### PR TITLE
[IR/Transforms] Propagate cacheModifier/evictionPolicy from Descripto…

### DIFF
--- a/include/triton/Dialect/Triton/IR/TritonOps.td
+++ b/include/triton/Dialect/Triton/IR/TritonOps.td
@@ -1261,11 +1261,17 @@ def TT_DescriptorStoreOp : TT_Op<"descriptor_store", [TT_DescriptorStoreLikeOpIn
   let arguments = (ins
     Arg<TT_TensorDescType, "", [MemRead<GlobalMemory>, MemWrite<GlobalMemory>]>:$desc,
     TT_Tensor:$src,
-    Variadic<I32>:$indices
+    Variadic<I32>:$indices,
+    DefaultValuedAttr<TT_CacheModifierAttr, "::mlir::triton::CacheModifier::NONE">:$cache,
+    DefaultValuedAttr<TT_EvictionPolicyAttr, "::mlir::triton::EvictionPolicy::NORMAL">:$evict
   );
 
   let assemblyFormat = [{
     $desc `[` $indices `]` `,` $src
+    oilist(
+      `cacheModifier` `=` $cache |
+      `evictionPolicy` `=` $evict
+    )
     attr-dict `:` qualified(type($desc)) `,` type($src)
   }];
   let hasVerifier = 1;
@@ -1306,12 +1312,18 @@ def TT_DescriptorGatherOp : TT_Op<"descriptor_gather", [TT_DescriptorLoadLikeOpI
   let arguments = (ins
     Arg<TT_TensorDescType, "", [MemRead<GlobalMemory>]>:$desc,
     RankedTensorOf<[I16, I32]>:$x_offsets,
-    I32:$y_offset
+    I32:$y_offset,
+    DefaultValuedAttr<TT_CacheModifierAttr, "::mlir::triton::CacheModifier::NONE">:$cache,
+    DefaultValuedAttr<TT_EvictionPolicyAttr, "::mlir::triton::EvictionPolicy::NORMAL">:$evict
   );
   let results = (outs TT_Tensor:$result);
 
   let assemblyFormat = [{
     $desc `[` $x_offsets `,` $y_offset `]`
+    oilist(
+      `cacheModifier` `=` $cache |
+      `evictionPolicy` `=` $evict
+    )
     attr-dict `:` functional-type(operands, results)
   }];
 
@@ -1333,11 +1345,17 @@ def TT_DescriptorScatterOp : TT_Op<"descriptor_scatter", [TT_DescriptorStoreLike
     Arg<TT_TensorDescType, "", [MemRead<GlobalMemory>, MemWrite<GlobalMemory>]>:$desc,
     RankedTensorOf<[I16, I32]>:$x_offsets,
     I32:$y_offset,
-    TT_Tensor:$src
+    TT_Tensor:$src,
+    DefaultValuedAttr<TT_CacheModifierAttr, "::mlir::triton::CacheModifier::NONE">:$cache,
+    DefaultValuedAttr<TT_EvictionPolicyAttr, "::mlir::triton::EvictionPolicy::NORMAL">:$evict
   );
 
   let assemblyFormat = [{
     $desc `[` $x_offsets `,` $y_offset `]` `,` $src
+    oilist(
+      `cacheModifier` `=` $cache |
+      `evictionPolicy` `=` $evict
+    )
     attr-dict `:` type(operands)
   }];
 

--- a/lib/Dialect/Triton/Transforms/RewriteTensorDescriptorToPointer.cpp
+++ b/lib/Dialect/Triton/Transforms/RewriteTensorDescriptorToPointer.cpp
@@ -336,7 +336,7 @@ struct RewriteLoadPattern : OpConversionPattern<triton::DescriptorLoadOp> {
     auto newLoad = triton::LoadOp::create(
         rewriter, loc, generatePtr(rewriter, loc, blockShape, desc, offsets),
         generateMask(rewriter, loc, blockShape, desc, offsets), other,
-        triton::CacheModifier::NONE, triton::EvictionPolicy::NORMAL, false);
+        op.getCache(), op.getEvict(), false);
     newLoad->setAttrs(filterSegmentSizes(op->getAttrs()));
 
     Value result = newLoad.getResult();
@@ -373,8 +373,8 @@ struct RewriteStorePattern : OpConversionPattern<triton::DescriptorStoreOp> {
 
     auto newStore = rewriter.replaceOpWithNewOp<triton::StoreOp>(
         op, generatePtr(rewriter, loc, blockShape, desc, offsets), op.getSrc(),
-        generateMask(rewriter, loc, blockShape, desc, offsets),
-        triton::CacheModifier::NONE, triton::EvictionPolicy::NORMAL);
+        generateMask(rewriter, loc, blockShape, desc, offsets), op.getCache(),
+        op.getEvict());
     newStore->setAttrs(filterSegmentSizes(op->getAttrs()));
 
     return llvm::success();
@@ -417,9 +417,8 @@ struct RewriteGatherPattern : OpConversionPattern<triton::DescriptorGatherOp> {
     auto other = generateOther(rewriter, loc,
                                descTy.getSignlessBlockType().getElementType(),
                                blockShape, desc.paddingOption);
-    auto newLoad = triton::LoadOp::create(
-        rewriter, loc, ptr, mask, other, triton::CacheModifier::NONE,
-        triton::EvictionPolicy::NORMAL, false);
+    auto newLoad = triton::LoadOp::create(rewriter, loc, ptr, mask, other,
+                                          op.getCache(), op.getEvict(), false);
     newLoad->setAttrs(filterSegmentSizes(op->getAttrs()));
 
     Value result = newLoad.getResult();
@@ -448,8 +447,7 @@ struct RewriteScatterPattern
     auto [ptr, mask] = generateGatherScatterPtrMask(
         rewriter, loc, blockShape, desc, op.getXOffsets(), op.getYOffset());
     auto newStore = rewriter.replaceOpWithNewOp<triton::StoreOp>(
-        op, ptr, op.getSrc(), mask, triton::CacheModifier::NONE,
-        triton::EvictionPolicy::NORMAL);
+        op, ptr, op.getSrc(), mask, op.getCache(), op.getEvict());
     newStore->setAttrs(filterSegmentSizes(op->getAttrs()));
 
     return llvm::success();

--- a/python/src/ir.cc
+++ b/python/src/ir.cc
@@ -1555,14 +1555,17 @@ void init_triton_ir(py::module &&m) {
            })
       .def("create_descriptor_gather",
            [](TritonOpBuilder &self, Value desc, Value x_indices, Value y_index,
-              Type type) -> Value {
-             return self.create<DescriptorGatherOp>(type, desc, x_indices,
-                                                    y_index);
+              Type type, CacheModifier cacheModifier,
+              EvictionPolicy evictionPolicy) -> Value {
+             return self.create<DescriptorGatherOp>(
+                 type, desc, x_indices, y_index, cacheModifier, evictionPolicy);
            })
       .def("create_descriptor_store",
            [](TritonOpBuilder &self, Value desc, Value value,
-              std::vector<Value> &indices) -> void {
-             self.create<DescriptorStoreOp>(desc, value, indices);
+              std::vector<Value> &indices, CacheModifier cacheModifier,
+              EvictionPolicy evictionPolicy) -> void {
+             self.create<DescriptorStoreOp>(desc, value, indices, cacheModifier,
+                                            evictionPolicy);
            })
       .def("create_descriptor_reduce",
            [](TritonOpBuilder &self, DescriptorReduceKind kind, Value desc,
@@ -1571,8 +1574,10 @@ void init_triton_ir(py::module &&m) {
            })
       .def("create_descriptor_scatter",
            [](TritonOpBuilder &self, Value desc, Value value, Value x_indices,
-              Value y_index) -> void {
-             self.create<DescriptorScatterOp>(desc, x_indices, y_index, value);
+              Value y_index, CacheModifier cacheModifier,
+              EvictionPolicy evictionPolicy) -> void {
+             self.create<DescriptorScatterOp>(desc, x_indices, y_index, value,
+                                              cacheModifier, evictionPolicy);
            })
       .def("create_reshape",
            [](TritonOpBuilder &self, Value &arg, std::vector<int64_t> &shape,

--- a/python/test/unit/language/test_tensor_descriptor.py
+++ b/python/test/unit/language/test_tensor_descriptor.py
@@ -1812,3 +1812,57 @@ def test_tensor_descriptor_store_downcast(dtype_str, device):
     kernel[(grid_m, grid_n)](desc, M, N, M_BLOCK=M_BLOCK, N_BLOCK=N_BLOCK)
     ref = torch.arange(M * N, dtype=torch.float32, device=device).reshape(M, N).to(torch_dtype)
     torch.testing.assert_close(out, ref)
+
+
+@pytest.mark.parametrize("cache", ["", ".ca", ".cg"])
+def test_tensor_descriptor_load_cache_modifier(cache, device):
+    if not is_cuda():
+        pytest.skip("Cache modifier test only supports CUDA")
+
+    src = torch.empty(128, device=device)
+    dst = torch.empty(128, device=device)
+
+    @triton.jit
+    def kernel(dst, src, CACHE: tl.constexpr):
+        desc = tl.make_tensor_descriptor(src, shape=[128], strides=[1], block_shape=[128])
+        x = desc.load([0], cache_modifier=CACHE)
+        tl.store(dst + tl.arange(0, 128), x)
+
+    pgm = kernel[(1, )](dst, src, CACHE=cache)
+
+    ptx = pgm.asm['ptx']
+    all_modifiers = ['.ca', '.cg', '.cs', '.cv']
+    for modifier in all_modifiers:
+        if modifier == cache:
+            assert f'ld.global{modifier}' in ptx, \
+                f"Expected ld.global{modifier} in PTX but not found"
+        else:
+            assert f'ld.global{modifier}' not in ptx, \
+                f"Unexpected ld.global{modifier} found in PTX"
+
+
+@pytest.mark.parametrize("cache", ["", ".wb", ".cg", ".cs", ".wt"])
+def test_tensor_descriptor_store_cache_modifier(cache, device):
+    if not is_cuda():
+        pytest.skip("Cache modifier test only supports CUDA")
+
+    src = torch.empty(128, device=device)
+    dst = torch.empty(128, device=device)
+
+    @triton.jit
+    def kernel(dst, src, CACHE: tl.constexpr):
+        desc = tl.make_tensor_descriptor(dst, shape=[128], strides=[1], block_shape=[128])
+        x = tl.load(src + tl.arange(0, 128))
+        desc.store([0], x, cache_modifier=CACHE)
+
+    pgm = kernel[(1, )](dst, src, CACHE=cache)
+
+    ptx = pgm.asm['ptx']
+    all_modifiers = ['.wb', '.cg', '.cs', '.wt']
+    for modifier in all_modifiers:
+        if modifier == cache:
+            assert f'st.global{modifier}' in ptx, \
+                f"Expected st.global{modifier} in PTX but not found"
+        else:
+            assert f'st.global{modifier}' not in ptx, \
+                f"Unexpected st.global{modifier} found in PTX"

--- a/python/triton/language/core.py
+++ b/python/triton/language/core.py
@@ -1422,24 +1422,30 @@ class tensor_descriptor_base(base_value):
         return str(self.type)
 
     @builtin
-    def load(self, offsets: Sequence[constexpr | tensor], _semantic=None) -> tensor:
+    def load(self, offsets: Sequence[constexpr | tensor], cache_modifier: str = "", eviction_policy: str = "",
+             _semantic=None) -> tensor:
         """Load a block from the descriptor starting at the given element offsets.
 
         Values outside of the tensor bounds will be filled with zeros.
 
+        :param cache_modifier: Cache modifier for the load operation, e.g. ".ca", ".cg"
+        :param eviction_policy: Eviction policy for the load operation, e.g. "evict_last", "evict_first"
         :note: Offset must be a multiple of 16-bytes
         """
-        return _semantic.descriptor_load(self, offsets, "", "")
+        return _semantic.descriptor_load(self, offsets, cache_modifier, eviction_policy)
 
     @builtin
-    def store(self, offsets: Sequence[constexpr | tensor], value: tensor, _semantic=None) -> tensor:
+    def store(self, offsets: Sequence[constexpr | tensor], value: tensor, cache_modifier: str = "",
+              eviction_policy: str = "", _semantic=None) -> tensor:
         """Store a block from the descriptor starting at the given element offsets.
 
         Values outside of the tensor bounds will be ignored.
 
+        :param cache_modifier: Cache modifier for the store operation, e.g. ".wb", ".cg"
+        :param eviction_policy: Eviction policy for the store operation, e.g. "evict_last", "evict_first"
         :note: Offset must be a multiple of 16-bytes
         """
-        return _semantic.descriptor_store(self, value, offsets)
+        return _semantic.descriptor_store(self, value, offsets, cache_modifier, eviction_policy)
 
     @builtin
     def atomic_add(self, offsets: Sequence[constexpr | tensor], value: tensor, _semantic=None) -> tensor:
@@ -1466,20 +1472,20 @@ class tensor_descriptor_base(base_value):
         return _semantic.descriptor_atomic_xor(self, value, offsets)
 
     @builtin
-    def gather(self, *args, _semantic=None) -> tensor:
+    def gather(self, *args, _semantic=None, cache_modifier: str = "", eviction_policy: str = "") -> tensor:
         """Gather multiple descriptors worth of data"""
         assert len(args) == 2, f"descriptor gather only supports 2D indexing, but got {len(args)}"
         x_offsets = args[0]
         y_offset = args[1]
-        return _semantic.descriptor_gather(self, x_offsets, y_offset, "", "")
+        return _semantic.descriptor_gather(self, x_offsets, y_offset, cache_modifier, eviction_policy)
 
     @builtin
-    def scatter(self, value, *args, _semantic=None) -> tensor:
+    def scatter(self, value, *args, _semantic=None, cache_modifier: str = "", eviction_policy: str = "") -> tensor:
         """Scatter multiple descriptors worth of data"""
         assert len(args) == 2, f"descriptor scatter only supports 2D indexing, but got {len(args)}"
         x_offsets = args[0]
         y_offset = args[1]
-        return _semantic.descriptor_scatter(self, value, x_offsets, y_offset)
+        return _semantic.descriptor_scatter(self, value, x_offsets, y_offset, cache_modifier, eviction_policy)
 
 
 class tensor_descriptor_type(tensor_descriptor_base_type):
@@ -2541,16 +2547,17 @@ def load(pointer, mask=None, other=None, boundary_check=(), padding_option="", c
 
 @builtin
 def load_tensor_descriptor(desc: tensor_descriptor_base, offsets: Sequence[constexpr | tensor],
-                           _semantic=None) -> tensor:
+                           cache_modifier: str = "", eviction_policy: str = "", _semantic=None) -> tensor:
     """Load a block of data from a tensor descriptor."""
-    return desc.load(offsets, _semantic=_semantic)
+    return desc.load(offsets, cache_modifier=cache_modifier, eviction_policy=eviction_policy, _semantic=_semantic)
 
 
 @builtin
 def store_tensor_descriptor(desc: tensor_descriptor_base, offsets: Sequence[constexpr | tensor], value: tensor,
-                            _semantic=None) -> tensor:
+                            cache_modifier: str = "", eviction_policy: str = "", _semantic=None) -> tensor:
     """Store a block of data to a tensor descriptor."""
-    return desc.store(offsets, value, _semantic=_semantic)
+    return desc.store(offsets, value, cache_modifier=cache_modifier, eviction_policy=eviction_policy,
+                      _semantic=_semantic)
 
 
 @_tensor_member_fn

--- a/python/triton/language/semantic.py
+++ b/python/triton/language/semantic.py
@@ -1082,12 +1082,16 @@ class TritonSemantic(Generic[TensorTy]):
         assert value.shape == desc.block_shape, \
             f"expected value shape {desc.block_shape}, got {value.shape}"
 
-    def descriptor_store(self, desc: tl.tensor_descriptor_base, value: TensorTy, offsets) -> TensorTy:
+    def descriptor_store(self, desc: tl.tensor_descriptor_base, value: TensorTy, offsets, cache_modifier: str = "",
+                         eviction_policy: str = "") -> TensorTy:
         self.validate_store_like(desc, value, offsets)
         # implicitly cast to the descriptor's type
         value = self.cast(value, desc.dtype)
         offsets = self._convert_to_ir_values(offsets, require_i64=False)
-        return self.tensor(self.builder.create_descriptor_store(desc.handle, value.handle, offsets), tl.void)
+        return self.tensor(
+            self.builder.create_descriptor_store(desc.handle, value.handle, offsets,
+                                                 self._str_to_store_cache_modifier(cache_modifier),
+                                                 self._str_to_eviction_policy(eviction_policy)), tl.void)
 
     def descriptor_atomic_add(self, desc: tl.tensor_descriptor_base, value: TensorTy, offsets) -> TensorTy:
         self.validate_store_like(desc, value, offsets)
@@ -1143,8 +1147,6 @@ class TritonSemantic(Generic[TensorTy]):
     def descriptor_gather(self, desc, x_offsets, y_offset, cache_modifier: str, eviction_policy: str) -> TensorTy:
         assert isinstance(desc, tl.tensor_descriptor_base), \
             f"expected a tensor descriptor, got {desc.__class__.__name__}"
-        assert cache_modifier == "", "cache modifier is not supported yet"
-        assert eviction_policy == "", "eviction policy is not supported yet"
 
         # Validate descriptor.
         assert len(desc.block_shape) == 2, f"descriptor must be 2D, but got {desc.block_shape}"
@@ -1164,10 +1166,13 @@ class TritonSemantic(Generic[TensorTy]):
 
         type = tl.block_type(desc.dtype, [x_offsets.shape[0], desc.block_shape[1]])
         y_offset = self._convert_to_ir_values((y_offset, ), require_i64=False)[0]
-        x = self.builder.create_descriptor_gather(desc.handle, x_offsets.handle, y_offset, type.to_ir(self.builder))
+        x = self.builder.create_descriptor_gather(desc.handle, x_offsets.handle, y_offset, type.to_ir(self.builder),
+                                                  self._str_to_load_cache_modifier(cache_modifier),
+                                                  self._str_to_eviction_policy(eviction_policy))
         return self.tensor(x, type)
 
-    def descriptor_scatter(self, desc, value: TensorTy, x_offsets, y_offset) -> TensorTy:
+    def descriptor_scatter(self, desc, value: TensorTy, x_offsets, y_offset, cache_modifier: str = "",
+                           eviction_policy: str = "") -> TensorTy:
         assert isinstance(desc, tl.tensor_descriptor_base), \
             f"expected a tensor descriptor, got {type(desc).__name__}"
 
@@ -1188,7 +1193,9 @@ class TritonSemantic(Generic[TensorTy]):
             1] >= min_cols, f"descriptor scatter of {dtype} must have at least {min_cols} columns, but got {desc.block_shape[1]}"
 
         y_offset = self._convert_to_ir_values((y_offset, ), require_i64=False)[0]
-        self.builder.create_descriptor_scatter(desc.handle, value.handle, x_offsets.handle, y_offset)
+        self.builder.create_descriptor_scatter(desc.handle, value.handle, x_offsets.handle, y_offset,
+                                               self._str_to_store_cache_modifier(cache_modifier),
+                                               self._str_to_eviction_policy(eviction_policy))
         return self.tensor(None, tl.void)
 
     def _broadcast_ptr_val_mask(self, ptr, val, mask):

--- a/python/triton/runtime/interpreter.py
+++ b/python/triton/runtime/interpreter.py
@@ -838,27 +838,27 @@ class InterpreterBuilder:
         return self.create_masked_load(ptrs, mask, other, cache_modifier=cache_modifier,
                                        eviction_policy=eviction_policy, is_volatile=False)
 
-    def create_descriptor_store(self, desc: TensorDescHandle, value: TensorHandle, indices: List[TensorHandle]):
+    def create_descriptor_store(self, desc: TensorDescHandle, value: TensorHandle, indices: List[TensorHandle],
+                                cache_modifier=None, eviction_policy=None):
         ptrs, mask = desc.materialize_pointers(indices)
-        return self.create_masked_store(ptrs, value, mask, None, None)
+        return self.create_masked_store(ptrs, value, mask, cache_modifier, eviction_policy)
 
-    def create_descriptor_gather(self, desc: TensorDescHandle, x_offsets: TensorHandle, y_offset: TensorHandle, type):
+    def create_descriptor_gather(self, desc: TensorDescHandle, x_offsets: TensorHandle, y_offset: TensorHandle, type,
+                                 cache_modifier=None, eviction_policy=None):
         dtype = desc.base.dtype.element_ty
         np_dtype = _get_np_dtype(dtype)
         result = np.zeros([x_offsets.data.shape[0], desc.block_shape[-1]], dtype=np_dtype)
-        cache_modifier = None
-        eviction_policy = None
         for i, x_offset in enumerate(x_offsets.data):
             indices = [TensorHandle(x_offset, tl.int32), y_offset]
             result[i, :] = self.create_descriptor_load(desc, indices, cache_modifier, eviction_policy).data
         return TensorHandle(result, dtype)
 
     def create_descriptor_scatter(self, desc: TensorDescHandle, value: TensorHandle, x_offsets: TensorHandle,
-                                  y_offset: TensorHandle):
+                                  y_offset: TensorHandle, cache_modifier=None, eviction_policy=None):
         for i, x_offset in enumerate(x_offsets.data):
             slice = TensorHandle(value.data[i], value.dtype)
             indices = [TensorHandle(x_offset, tl.int32), y_offset]
-            self.create_descriptor_store(desc, slice, indices)
+            self.create_descriptor_store(desc, slice, indices, cache_modifier, eviction_policy)
 
     def get_all_ones_value(self, type):
         np_type = _get_np_dtype(type)

--- a/test/Triton/rewrite-tensor-descriptor-to-pointer.mlir
+++ b/test/Triton/rewrite-tensor-descriptor-to-pointer.mlir
@@ -159,3 +159,69 @@ module {
 
 // CHECK-LABEL: @arg_attr
 // CHECK-SAME: %arg7: i32 {tt.divisibility = 16 : i32} loc({{.*}})) {
+
+// -----
+
+module {
+  tt.func public @load_cache_modifier(%arg0: !tt.ptr<f32> {tt.divisibility = 16 : i32}) -> (tensor<128xf32>) {
+    %c1_i64 = arith.constant 1 : i64
+    %c128_i32 = arith.constant 128 : i32
+    %c0_i32 = arith.constant 0 : i32
+    %0 = tt.make_tensor_descriptor %arg0, [%c128_i32], [%c1_i64] {order = array<i32: 0>} : <f32>, <128xf32>
+    %3 = tt.descriptor_load %0[%c0_i32] cacheModifier = ca evictionPolicy = evict_first : !tt.tensordesc<128xf32> -> tensor<128xf32>
+    tt.return %3 : tensor<128xf32>
+  }
+}
+
+// CHECK-LABEL: @load_cache_modifier
+// CHECK: tt.load {{.*}} cacheModifier = ca evictionPolicy = evict_first
+
+// -----
+
+module {
+  tt.func public @store_cache_modifier(%arg0: !tt.ptr<f32> {tt.divisibility = 16 : i32}, %arg1: tensor<128xf32>) {
+    %c1_i64 = arith.constant 1 : i64
+    %c128_i32 = arith.constant 128 : i32
+    %c0_i32 = arith.constant 0 : i32
+    %0 = tt.make_tensor_descriptor %arg0, [%c128_i32], [%c1_i64] {order = array<i32: 0>} : <f32>, <128xf32>
+    tt.descriptor_store %0[%c0_i32], %arg1 cacheModifier = wb evictionPolicy = evict_last : !tt.tensordesc<128xf32>, tensor<128xf32>
+    tt.return
+  }
+}
+
+// CHECK-LABEL: @store_cache_modifier
+// CHECK: tt.store {{.*}} cacheModifier = wb evictionPolicy = evict_last
+
+// -----
+
+module {
+  tt.func public @gather_cache_modifier(%arg0: !tt.ptr<bf16> {tt.divisibility = 16 : i32}, %arg1: tensor<8xi32>) -> (tensor<8x128xbf16>) {
+    %c1_i64 = arith.constant 1 : i64
+    %c128_i64 = arith.constant 128 : i64
+    %c128_i32 = arith.constant 128 : i32
+    %c0_i32 = arith.constant 0 : i32
+    %0 = tt.make_tensor_descriptor %arg0, [%c128_i32, %c128_i32], [%c128_i64, %c1_i64] {order = array<i32: 0, 1>} : <bf16>, <1x128xbf16>
+    %3 = tt.descriptor_gather %0[%arg1, %c0_i32] cacheModifier = ca evictionPolicy = evict_first : (!tt.tensordesc<1x128xbf16>, tensor<8xi32>, i32) -> tensor<8x128xbf16>
+    tt.return %3 : tensor<8x128xbf16>
+  }
+}
+
+// CHECK-LABEL: @gather_cache_modifier
+// CHECK: tt.load {{.*}} cacheModifier = ca evictionPolicy = evict_first
+
+// -----
+
+module {
+  tt.func public @scatter_cache_modifier(%arg0: !tt.ptr<bf16> {tt.divisibility = 16 : i32}, %arg1: tensor<8xi32>, %arg2: tensor<8x128xbf16>) {
+    %c1_i64 = arith.constant 1 : i64
+    %c128_i64 = arith.constant 128 : i64
+    %c128_i32 = arith.constant 128 : i32
+    %c0_i32 = arith.constant 0 : i32
+    %0 = tt.make_tensor_descriptor %arg0, [%c128_i32, %c128_i32], [%c128_i64, %c1_i64] {order = array<i32: 0, 1>} : <bf16>, <1x128xbf16>
+    tt.descriptor_scatter %0[%arg1, %c0_i32], %arg2 cacheModifier = wb evictionPolicy = evict_last : !tt.tensordesc<1x128xbf16>, tensor<8xi32>, i32, tensor<8x128xbf16>
+    tt.return
+  }
+}
+
+// CHECK-LABEL: @scatter_cache_modifier
+// CHECK: tt.store {{.*}} cacheModifier = wb evictionPolicy = evict_last


### PR DESCRIPTION
## Summary

Fixes #10457
- Add `cacheModifier`/`evictionPolicy` attributes to `DescriptorStoreOp`, `DescriptorGatherOp`, and `DescriptorScatterOp` in `TritonOps.td`, matching the existing pattern on `DescriptorLoadOp`
- Update `RewriteTensorDescriptorToPointer` to propagate `op.getCache()`/`op.getEvict()` instead of hardcoding `CacheModifier::NONE`/`EvictionPolicy::NORMAL` across all four descriptor ops (load, store, gather, scatter)
- Update C++ Python bindings (`ir.cc`) for `create_descriptor_gather`/`create_descriptor_store`/`create_descriptor_scatter` to accept and forward the new attributes
- Expose `cache_modifier` and `eviction_policy` parameters in `tensor_descriptor_base.load`/`store`/`gather`/`scatter` in the Python API
- Remove the `assert cache_modifier == ""` guards that blocked `descriptor_gather` from using cache hints

## Root cause

`DescriptorLoadOp` already carried `cacheModifier` and `evictionPolicy` attributes in its IR definition and the Python semantic layer correctly passed them through, but the `RewriteTensorDescriptorToPointer` pass hardcoded `CacheModifier::NONE`/`EvictionPolicy::NORMAL` when lowering to regular `LoadOp`/`StoreOp`, silently discarding user-specified cache hints. Separately, `DescriptorStoreOp`, `DescriptorGatherOp`, and `DescriptorScatterOp` lacked these attributes entirely.

In kernels like flash attention, Q tiles (loaded once, reused across K/V loops) benefit from `.ca` (cache all), while K/V tiles (streaming access) benefit from `.cg` (cache global). Dropping these hints causes ~20% bf16 regression on Blackwell GPUs.

## Testing

```
# LIT: verify cache modifier propagation through the rewrite pass (4 new test cases)
triton-opt --triton-rewrite-tensor-descriptor-to-pointer --canonicalize --cse \
  --split-input-file test/Triton/rewrite-tensor-descriptor-to-pointer.mlir

# Python: full tensor descriptor test suite including new cache modifier tests
pytest python/test/unit/language/test_tensor_descriptor.py -v
# 1534 passed, 1332 skipped, 0 failures
```

New tests:
- `test_tensor_descriptor_load_cache_modifier` — parametrized over `""`, `".ca"`, `".cg"`, verifies `ld.global.<mod>` in PTX
- `test_tensor_descriptor_store_cache_modifier` — parametrized over `""`, `".wb"`, `".cg"`, `".cs"`, `".wt"`, verifies `st.global.<mod>` in PTX

## Notes

- `DescriptorReduceOp` is intentionally excluded because its lowering target `AtomicRMWOp` does not support cache modifiers at the hardware level (atomics bypass L1 cache)
- All new parameters have sensible defaults (`""` at Python level, `NONE`/`NORMAL` at IR level), fully backward compatible


# New contributor declaration
- [x] I am not making a trivial change, such as fixing a typo in a comment.

- [x] I have written a PR description following these
  [rules](https://cbea.ms/git-commit/#why-not-how).

- [x] I have run `pre-commit run --from-ref origin/main --to-ref HEAD`.

- Select one of the following.
  - [x] I have added tests.
    - `/test` for `lit` tests
    - `/python/test` for end-to-end tests
  - [ ] This PR does not need a test because `FILL THIS IN`.

- Select one of the following.
  - [ ] I have not added any `lit` tests.
  - [x] The `lit` tests I have added follow these [best practices](https://mlir.llvm.org/getting_started/TestingGuide/#filecheck-best-practices),
    including the "tests should be minimal" section. (Usually running Python code
    and using the instructions it generates is not minimal.)

