### PR TITLE
[release/3.7.x] Add separate ptxas-thor for sm_110

### DIFF
--- a/cmake/nvidia-toolchain-version.json
+++ b/cmake/nvidia-toolchain-version.json
@@ -1,5 +1,6 @@
 {
-  "ptxas-blackwell": "13.1.80",
+  "ptxas-blackwell": "12.9.86",
+  "ptxas-thor": "13.1.80",
   "ptxas": "12.8.93",
   "cuobjdump": "13.1.80",
   "nvdisasm": "13.1.80",

--- a/python/triton/knobs.py
+++ b/python/triton/knobs.py
@@ -490,6 +490,7 @@ class nvidia_knobs(base_knobs):
     nvdisasm: env_nvidia_tool = env_nvidia_tool("nvdisasm")
     ptxas: env_nvidia_tool = env_nvidia_tool("ptxas")
     ptxas_blackwell: env_nvidia_tool = env_nvidia_tool("ptxas-blackwell")
+    ptxas_thor: env_nvidia_tool = env_nvidia_tool("ptxas-thor")
 
     dump_nvptx: env_bool = env_bool("NVPTX_ENABLE_DUMP")
     disable_ptxas_opt: env_bool = env_bool("DISABLE_PTXAS_OPT")

--- a/setup.py
+++ b/setup.py
@@ -570,6 +570,17 @@ def download_and_copy_dependencies():
         url_func=lambda system, arch, version:
         f"https://developer.download.nvidia.com/compute/cuda/redist/cuda_nvcc/{system}-{arch}/cuda_nvcc-{system}-{arch}-{version}-archive.tar.xz",
     )
+
+    # Thor (sm_110) needs a newer ptxas than the one bundled for blackwell.
+    download_and_copy(
+        name="nvcc",
+        src_func=lambda system, arch, version: f"cuda_nvcc-{system}-{arch}-{version}-archive/bin/ptxas{exe_extension}",
+        dst_path="bin/ptxas-thor",
+        variable="TRITON_PTXAS_THOR_PATH",
+        version=NVIDIA_TOOLCHAIN_VERSION["ptxas-thor"],
+        url_func=lambda system, arch, version:
+        f"https://developer.download.nvidia.com/compute/cuda/redist/cuda_nvcc/{system}-{arch}/cuda_nvcc-{system}-{arch}-{version}-archive.tar.xz",
+    )
     download_and_copy(
         name="cuobjdump",
         src_func=lambda system, arch, version:

--- a/third_party/nvidia/backend/compiler.py
+++ b/third_party/nvidia/backend/compiler.py
@@ -32,6 +32,10 @@ def min_dot_size(target: GPUTarget):
 
 
 def get_ptxas(arch: int) -> knobs.NvidiaTool:
+    # Thor (sm_110) needs its own ptxas; other blackwell archs (sm_100, sm_120)
+    # use ptxas-blackwell, and pre-blackwell archs use the default ptxas.
+    if arch == 110:
+        return knobs.nvidia.ptxas_thor
     return knobs.nvidia.ptxas_blackwell if arch >= 100 else knobs.nvidia.ptxas
 
 


### PR DESCRIPTION
### Summary

Fixes: https://github.com/https://github.com/pytorch/pytorch/issues/181248

On `release/3.7.x` the bundled `ptxas-blackwell` is currently `13.1.80` (CUDA 13.1) and is used for every `sm >= 100`. Thor (`sm_110`) needs the CUDA 13.1 ptxas, but the other blackwell archs (`sm_100`, `sm_120`) should stay on the CUDA 12.9 ptxas. This splits the two so Thor gets a working assembler without regressing blackwell.

### Changes

- **`cmake/nvidia-toolchain-version.json`**: pin `ptxas-blackwell` back to `12.9.86` and add `ptxas-thor` at `13.1.80`.
- **`setup.py`**: download/bundle `bin/ptxas-thor` (env `TRITON_PTXAS_THOR_PATH`), mirroring the existing `ptxas-blackwell` download.
- **`python/triton/knobs.py`**: expose `nvidia.ptxas_thor` (env `TRITON_PTXAS_THOR_PATH`).
- **`third_party/nvidia/backend/compiler.py`**: `get_ptxas()` returns `ptxas-thor` for `arch == 110`, `ptxas-blackwell` for the remaining `arch >= 100`, else the default `ptxas`.

```python
def get_ptxas(arch: int) -> knobs.NvidiaTool:
    if arch == 110:
        return knobs.nvidia.ptxas_thor
    return knobs.nvidia.ptxas_blackwell if arch >= 100 else knobs.nvidia.ptxas
```

### Test Plan

- `python setup.py` downloads `cuda_nvcc` `12.9.86` (-> `bin/ptxas-blackwell`) and `13.1.80` (-> `bin/ptxas-thor`) alongside the default `ptxas`.
- `get_ptxas(110)` selects `ptxas-thor`; `get_ptxas(100)` / `get_ptxas(120)` select `ptxas-blackwell`; `get_ptxas(90)` selects the default `ptxas`.

Authored with assistance from Claude.