### PR TITLE
Fix zero-grid reduce launches for empty shapes

### DIFF
--- a/python/triton_kernels/tests/test_reduce.py
+++ b/python/triton_kernels/tests/test_reduce.py
@@ -120,6 +120,39 @@ def test_op(B, M, N, dtype_str, dim, mask_mode, postprocess_fn):
         assert torch.allclose(x_tri.grad.float(), x_ref.grad.float(), atol=1e-3, rtol=1e-3)
 
 
+@pytest.mark.parametrize("B, M, N", [
+    (5, 2, 0),
+    (0, 2, 5),
+])
+@pytest.mark.parametrize("dtype", [
+    torch.float16,
+    torch.float32,
+])
+@pytest.mark.parametrize("mask_mode", [
+    "none",
+    "full",
+    "broadcast_b",
+    "broadcast_m",
+    "broadcast_n",
+])
+def test_op_empty_forward_backward(B, M, N, dtype, mask_mode):
+    torch.manual_seed(0)
+    device = "cuda"
+    x = torch.randn((B, M, N), device=device, dtype=dtype, requires_grad=True)
+    mask = init_mask(mask_mode, B, M, N, device)
+    x_tri = x.clone().detach().requires_grad_(True)
+    x_ref = x.clone().detach().requires_grad_(True)
+
+    y_tri, _ = reduce(x_tri, dim=1, mask=mask)
+    y_ref, _ = reduce_torch(x_ref, dim=1, mask=mask, x_flex=None, y_flex=None)
+    assert torch.allclose(y_tri.float(), y_ref.float(), atol=1e-3, rtol=1e-3)
+
+    dy = torch.randn_like(y_tri)
+    y_tri.backward(dy)
+    y_ref.backward(dy)
+    assert torch.allclose(x_tri.grad.float(), x_ref.grad.float(), atol=1e-3, rtol=1e-3)
+
+
 def test_unpadded_batch_size_rowidxs_subtile():
     if not torch.cuda.is_available() or not is_cuda():
         pytest.skip("rowidxs path requires CUDA")

--- a/python/triton_kernels/triton_kernels/reduce.py
+++ b/python/triton_kernels/triton_kernels/reduce.py
@@ -736,6 +736,8 @@ def reduce_forward(
     y_mxscale = None
     if y_has_mx:
         y_mxscale = torch.empty((S0, triton.cdiv(Y_S1, y_microblock_size)), device=x.device, dtype=y_mx_scale_dtype)
+    if S0 == 0 or Y_S1 == 0:
+        return y, y_mxscale
     # Strides for X along reduced and non-reduced dims
     stride_xr = x.stride(dim)
     stride_x0 = x.stride(nonred[0])
@@ -978,6 +980,8 @@ def reduce_backward(
     reduction_n = (postprocess_fn1.specs.reduction_n if postprocess_fn1 is not None else FnSpecs.default().reduction_n)
     Y_S1 = X_S1 // reduction_n
     assert dy.shape == (S0, Y_S1), f"dY shape {dy.shape} mismatch with (S0={S0}, Y_S1={Y_S1})"
+    if S0 == 0 or X_S1 == 0:
+        return
 
     # Strides for dX must match the element size of the tensor passed to the kernel.
     # If we reinterpret the dtype (e.g., flex/float8), use the reinterpreted view's strides.


### PR DESCRIPTION
## Summary
- Return allocated empty reduce outputs before launching when the forward grid is empty.
- Return from reduce backward before launching zero-grid kernels for empty non-reduced axes.
- Add empty forward/backward coverage for (5, 2, 0) and (0, 2, 5) with mask broadcasting.

## Test
- H100: PYTHONPATH=python/triton_kernels pytest -s --tb=short python/triton_kernels/tests/test_reduce.py::test_op_empty_forward_backward