### PR TITLE
[FPSAN] Accelerate MMA emulation with mixed-signed i8 decomposition

### DIFF
--- a/include/triton/Analysis/Utility.h
+++ b/include/triton/Analysis/Utility.h
@@ -252,6 +252,8 @@ bool supportWMMA(triton::DotOp op);
 
 bool supportMMA(triton::DotOp op, int version);
 
+bool supportMMA(triton::DotOpInterface op, int version);
+
 bool supportMMA(Value value, int version);
 
 // Conversion from `srcTy` to `dstTy` involving the minimum amount of data

--- a/include/triton/Dialect/Triton/IR/TritonOpInterfaces.td
+++ b/include/triton/Dialect/Triton/IR/TritonOpInterfaces.td
@@ -58,7 +58,13 @@ def DotOpInterface : OpInterface<"DotOpInterface"> {
       /*desc=*/"Verify the dimensions of the A and B DotOp operands.",
       /*retType=*/"bool",
       /*methodName=*/"verifyDims",
-      /*args=*/(ins)>,
+      /*args=*/(ins),
+      /*methodBody=*/[{}],
+      /*defaultImpl=*/ [{
+        auto aShape = cast<ShapedType>($_op.getA().getType()).getShape();
+        auto bShape = cast<ShapedType>($_op.getB().getType()).getShape();
+        return aShape.back() == bShape[bShape.size() - 2];
+      }]>,
   InterfaceMethod<
       /*desc=*/"Verify the dimensions of the DotOp output.",
       /*retType=*/"bool",

--- a/include/triton/Dialect/TritonGPU/IR/Dialect.h
+++ b/include/triton/Dialect/TritonGPU/IR/Dialect.h
@@ -278,6 +278,12 @@ SmallVector<int64_t> getAllocationShapePerCTA(Type type);
 
 unsigned getNumCTAs(Attribute layout);
 
+// Returns the MMAv2 warp distribution for a matrix tile. This does not apply
+// dot-chain policy and may oversubscribe tiles with fewer instruction
+// repetitions than warps.
+SmallVector<unsigned> getMmaV2WarpsPerCTA(ArrayRef<int64_t> shape,
+                                          int numWarps);
+
 // Return the order that represents that the batch is in row-major or
 // column-major order for a batch of matrices of shape [*, m, n] with
 // len(shape) == rank.

--- a/include/triton/Dialect/TritonInstrument/IR/TritonInstrumentOps.td
+++ b/include/triton/Dialect/TritonInstrument/IR/TritonInstrumentOps.td
@@ -5,6 +5,7 @@ include "triton/Dialect/TritonInstrument/IR/TritonInstrumentDialect.td"
 include "triton/Dialect/TritonGPU/IR/TritonGPUTypes.td"
 include "triton/Dialect/Triton/IR/TritonTypes.td"
 include "triton/Dialect/Triton/IR/TritonInterfaces.td"
+include "triton/Dialect/Triton/IR/TritonOpInterfaces.td"
 include "triton/Dialect/Triton/IR/TritonAttrDefs.td"
 include "mlir/IR/OpBase.td"
 include "mlir/Interfaces/SideEffectInterfaces.td"
@@ -209,6 +210,32 @@ def TTI_ExperimentalLockReleaseOp : TTI_Op<"experimental_lock_release", [MemoryE
 
 // ===== FPSan ops =====
 
+
+def TTI_DotI8Op : TTI_Op<"dot_i8", [
+  Pure,
+  DeclareOpInterfaceMethods<DotOpInterface>,
+  TypesMatchWith<"result's type matches accumulator's type",
+                 "d", "c", "$_self">
+]> {
+  let summary = "non-saturating NVIDIA MMAv2 i8 dot";
+  let description = [{
+    Performs a wrapping i8 matrix multiplication into an i32 accumulator using
+    NVIDIA MMAv2. The A and B operands have independent signedness.
+  }];
+  let arguments = (ins
+    RankedTensorOf<[I8]>:$a,
+    RankedTensorOf<[I8]>:$b,
+    RankedTensorOf<[I32]>:$c,
+    BoolAttr:$aSigned,
+    BoolAttr:$bSigned
+  );
+  let results = (outs RankedTensorOf<[I32]>:$d);
+  let assemblyFormat = [{
+    $a `,` $b `,` $c `,` `aSigned` `=` $aSigned `,` `bSigned` `=` $bSigned
+    attr-dict `:` type($a) `*` type($b) `->` type($d)
+  }];
+  let hasVerifier = 1;
+}
 
 def TTI_ExperimentalFPSanEmbedOp : TTI_Op<"experimental_fpsan_embed", [
   Pure,

--- a/lib/Analysis/Utility.cpp
+++ b/lib/Analysis/Utility.cpp
@@ -1242,6 +1242,12 @@ bool supportMMA(triton::DotOp op, int version) {
   return supportMMA(op.getA(), version) && supportMMA(op.getB(), version);
 }
 
+bool supportMMA(triton::DotOpInterface op, int version) {
+  if (auto dotOp = dyn_cast<triton::DotOp>(op.getOperation()))
+    return supportMMA(dotOp, version);
+  return supportMMA(op.getA(), version) && supportMMA(op.getB(), version);
+}
+
 bool supportMMA(Value value, int version) {
   // Tell whether a DotOp support MMA by the operand type(either $a or $b).
   // We cannot get both the operand types(in TypeConverter), here we assume the

--- a/lib/Dialect/Triton/IR/Ops.cpp
+++ b/lib/Dialect/Triton/IR/Ops.cpp
@@ -283,13 +283,6 @@ LogicalResult DotOp::verify() {
                                                      bEncoding);
 }
 
-bool DotOp::verifyDims() {
-  auto aShape = this->getA().getType().getShape();
-  auto bShape = this->getB().getType().getShape();
-
-  return aShape[aShape.size() - 1] == bShape[aShape.size() - 2];
-}
-
 //-- DotScaledOp --
 bool DotScaledOp::verifyDims() {
   auto aShape = this->getA().getType().getShape();

--- a/lib/Dialect/TritonGPU/IR/Dialect.cpp
+++ b/lib/Dialect/TritonGPU/IR/Dialect.cpp
@@ -3174,8 +3174,8 @@ struct TritonGPUInferLayoutInterface
         dyn_cast_or_null<NvidiaMmaEncodingAttr>(aEncoding.getParent());
     auto mmaBEncoding =
         dyn_cast_or_null<NvidiaMmaEncodingAttr>(bEncoding.getParent());
-    auto dotOp = cast<DotOp>(op);
-    auto resEnc = dotOp.getResult().getType().getEncoding();
+    auto dotOp = cast<DotOpInterface>(op);
+    auto resEnc = cast<RankedTensorType>(dotOp.getD().getType()).getEncoding();
     auto mmaResEncoding = dyn_cast<NvidiaMmaEncodingAttr>(resEnc);
     if (mmaAEncoding || mmaBEncoding || mmaResEncoding) {
       // Check that they are all set and have the same version.

--- a/lib/Dialect/TritonGPU/IR/Dialect.cpp
+++ b/lib/Dialect/TritonGPU/IR/Dialect.cpp
@@ -472,6 +472,30 @@ SmallVector<int64_t> getAllocationShapePerCTA(Type type) {
                                   tensorType.getShape());
 }
 
+SmallVector<unsigned> getMmaV2WarpsPerCTA(ArrayRef<int64_t> shape,
+                                          int numWarps) {
+  if (shape.size() == 3)
+    return {static_cast<unsigned>(numWarps), 1, 1};
+
+  assert(shape.size() == 2);
+  SmallVector<int64_t> reps = {ceil(shape[0], int64_t{16}),
+                               ceil(shape[1], int64_t{8})};
+  SmallVector<unsigned> warps = {1, 1};
+  // Balance repetitions to reduce register pressure, breaking ties toward M
+  // because the lhs instruction tile uses more registers than the rhs.
+  while (product(warps) < numWarps) {
+    if (reps[0] >= reps[1]) {
+      warps[0] *= 2;
+      if (reps[0] != 1)
+        reps[0] /= 2;
+    } else {
+      warps[1] *= 2;
+      reps[1] /= 2;
+    }
+  }
+  return warps;
+}
+
 unsigned getNumCTAs(Attribute layout) {
   return product<unsigned>(getCTAsPerCGA(layout));
 }

--- a/lib/Dialect/TritonGPU/Transforms/AccelerateMatmul.cpp
+++ b/lib/Dialect/TritonGPU/Transforms/AccelerateMatmul.cpp
@@ -88,7 +88,7 @@ SmallVector<unsigned> warpsPerTileV2(DotOpInterface dotOp,
   auto rank = shape.size();
   // Early exit for batched matmul
   if (rank == 3)
-    return {(unsigned)numWarps, 1, 1};
+    return getMmaV2WarpsPerCTA(shape, numWarps);
 
   auto filter = [&dotOp](Operation *op) {
     return op->getParentRegion() == dotOp->getParentRegion() &&
@@ -117,33 +117,7 @@ SmallVector<unsigned> warpsPerTileV2(DotOpInterface dotOp,
     }
   }
 
-  assert(rank == 2);
-  SmallVector<int64_t> shapePerWarp = {16, 8};
-  SmallVector<int64_t> warps = {1, 1};
-  // Compute repM and repN
-  SmallVector<int64_t> reps = {ceil(shape[0], shapePerWarp[0]),
-                               ceil(shape[1], shapePerWarp[1])};
-  // The formula for the number of registers given the reps is
-  // repM * 4 * repK + repN * 2 * repK + regsC
-  // where regsC = repM * repN * 4, which does not depend on the warp shape
-  //
-  // As such, to minimize the register pressure, we need to balance
-  // repM and repN. We then untie towards M, as the lhs tile has 4 elements,
-  // and the rhs tile has just 2.
-  while (product(warps) < numWarps) {
-    if (reps[0] >= reps[1]) {
-      warps[0] *= 2;
-      // Too many warps for this mma (repM == repN == 1).
-      // We allocate the remaining warps to the left (arbitrary choice)
-      if (reps[0] != 1) {
-        reps[0] /= 2;
-      }
-    } else {
-      warps[1] *= 2;
-      reps[1] /= 2;
-    }
-  }
-  return {(unsigned)warps[0], (unsigned)warps[1]};
+  return getMmaV2WarpsPerCTA(shape, numWarps);
 }
 SmallVector<unsigned, 2>
 warpsPerTileV3(DotOpInterface dotOp, const ArrayRef<int64_t> shape,

--- a/lib/Dialect/TritonGPU/Transforms/RemoveLayoutConversions.cpp
+++ b/lib/Dialect/TritonGPU/Transforms/RemoveLayoutConversions.cpp
@@ -202,8 +202,8 @@ bool isLayoutAnchor(Operation *op) {
     return true;
   if (isa<LoadOp, StoreOp>(op))
     return isExpensiveLoadOrStore(op);
-  if (isa<DotOp, DotScaledOp, nvidia_gpu::WarpGroupDotOp, AtomicRMWOp,
-          AtomicCASOp, triton::nvidia_gpu::TMEMLoadOp>(op))
+  if (isa<DotOpInterface, AtomicRMWOp, AtomicCASOp,
+          triton::nvidia_gpu::TMEMLoadOp>(op))
     return true;
   if (auto gatherOp = dyn_cast<GatherOp>(op))
     return gatherOp.getEfficientLayout();
@@ -653,7 +653,7 @@ void LayoutPropagation::rewriteOp(Operation *op) {
 bool canBeRemat(Operation *op) {
   if (isa<LoadOp, StoreOp>(op))
     return !isExpensiveLoadOrStore(op);
-  if (isa<AtomicRMWOp, AtomicCASOp, DotOp>(op))
+  if (isa<AtomicRMWOp, AtomicCASOp, DotOpInterface>(op))
     return false;
   if (auto gather = dyn_cast<GatherOp>(op))
     return !gather.getEfficientLayout();

--- a/lib/Dialect/TritonInstrument/IR/Ops.cpp
+++ b/lib/Dialect/TritonInstrument/IR/Ops.cpp
@@ -16,12 +16,6 @@ namespace instrument {
 namespace tt = mlir::triton;
 namespace ttg = mlir::triton::gpu;
 
-bool DotI8Op::verifyDims() {
-  auto aShape = getA().getType().getShape();
-  auto bShape = getB().getType().getShape();
-  return aShape.back() == bShape[bShape.size() - 2];
-}
-
 LogicalResult DotI8Op::verify() {
   auto aEnc =
       dyn_cast<ttg::DotOperandEncodingAttr>(getA().getType().getEncoding());

--- a/lib/Dialect/TritonInstrument/IR/Ops.cpp
+++ b/lib/Dialect/TritonInstrument/IR/Ops.cpp
@@ -16,6 +16,36 @@ namespace instrument {
 namespace tt = mlir::triton;
 namespace ttg = mlir::triton::gpu;
 
+bool DotI8Op::verifyDims() {
+  auto aShape = getA().getType().getShape();
+  auto bShape = getB().getType().getShape();
+  return aShape.back() == bShape[bShape.size() - 2];
+}
+
+LogicalResult DotI8Op::verify() {
+  auto aEnc =
+      dyn_cast<ttg::DotOperandEncodingAttr>(getA().getType().getEncoding());
+  auto bEnc =
+      dyn_cast<ttg::DotOperandEncodingAttr>(getB().getType().getEncoding());
+  if (!aEnc || !bEnc)
+    return emitError("requires dot operand encodings for A and B");
+
+  auto aMma = dyn_cast<ttg::NvidiaMmaEncodingAttr>(aEnc.getParent());
+  auto bMma = dyn_cast<ttg::NvidiaMmaEncodingAttr>(bEnc.getParent());
+  auto dMma =
+      dyn_cast<ttg::NvidiaMmaEncodingAttr>(getD().getType().getEncoding());
+  if (!aMma || !bMma || !dMma || aMma.getVersionMajor() != 2 ||
+      bMma.getVersionMajor() != 2 || dMma.getVersionMajor() != 2)
+    return emitError("requires NVIDIA MMAv2 operand and result layouts");
+  if (aMma != bMma || aMma != dMma)
+    return emitError("requires matching NVIDIA MMAv2 layouts");
+
+  auto layoutInterface =
+      cast<tt::DialectInferLayoutInterface>(&dMma.getDialect());
+  return layoutInterface->verifyDotOpEncodingCompatibility(getOperation(), aEnc,
+                                                           bEnc);
+}
+
 template <typename ViewOp, typename FPSanOp>
 struct PushFPSanThroughViewPattern : public OpRewritePattern<ViewOp> {
   using OpRewritePattern<ViewOp>::OpRewritePattern;

--- a/lib/Dialect/TritonInstrument/Transforms/FpSanitizer.cpp
+++ b/lib/Dialect/TritonInstrument/Transforms/FpSanitizer.cpp
@@ -57,32 +57,15 @@ constexpr int64_t kI8MmaK = 32;
 
 bool supportsI8DotDecomposition(PatternRewriter &rewriter,
                                 IntegerType accElem) {
-  auto module =
+  auto moduleOp =
       rewriter.getInsertionBlock()->getParentOp()->getParentOfType<ModuleOp>();
-  if (getAMDArch(module))
+  if (getAMDArch(moduleOp))
     return false;
   return llvm::is_contained({16, 32, 64}, accElem.getWidth());
 }
 
-std::optional<SmallVector<unsigned>> getI8MmaWarpsPerCTA(int64_t m, int64_t n,
-                                                         int numWarps) {
-  if (m < 16 || n < 8 || (m % 16) != 0 || (n % 8) != 0 || numWarps <= 0)
-    return std::nullopt;
-
-  SmallVector<unsigned> warpsPerCTA{1, 1};
-  SmallVector<int64_t> reps{m / 16, n / 8};
-  while (warpsPerCTA[0] * warpsPerCTA[1] < numWarps) {
-    unsigned axis = reps[0] >= reps[1] ? 0 : 1;
-    if (reps[axis] <= 1 || (reps[axis] % 2) != 0)
-      axis = 1 - axis;
-    if (reps[axis] <= 1 || (reps[axis] % 2) != 0)
-      return std::nullopt;
-    warpsPerCTA[axis] *= 2;
-    reps[axis] /= 2;
-  }
-  if (warpsPerCTA[0] * warpsPerCTA[1] != numWarps)
-    return std::nullopt;
-  return warpsPerCTA;
+bool canUseI8MmaTile(int64_t m, int64_t n, int numWarps) {
+  return m >= 16 && n >= 8 && (m / 16) * (n / 8) >= numWarps;
 }
 
 std::pair<int64_t, int64_t> getMmaEmulationTileShape(PatternRewriter &rewriter,
@@ -93,12 +76,8 @@ std::pair<int64_t, int64_t> getMmaEmulationTileShape(PatternRewriter &rewriter,
     int64_t numWarps =
         ttg::lookupNumWarps(rewriter.getInsertionBlock()->getParent());
     int64_t tileM = std::min<int64_t>(16 * numWarps, m);
-    while (tileM > 0 && (m % tileM) != 0)
-      tileM /= 2;
     int64_t tileN = std::min<int64_t>(8 * numWarps, n);
-    while (tileN > 0 && (n % tileN) != 0)
-      tileN /= 2;
-    if (getI8MmaWarpsPerCTA(tileM, tileN, numWarps))
+    if (canUseI8MmaTile(tileM, tileN, numWarps))
       return {tileM, tileN};
   }
   return {std::min<int64_t>(kTileM, m), std::min<int64_t>(kTileN, n)};
@@ -1418,9 +1397,9 @@ Value tryEmitI8DotDecomposition(PatternRewriter &rewriter, Location loc,
   if (bShape[0] != k || (k % kI8MmaK) != 0 ||
       !supportsI8DotDecomposition(rewriter, accElem))
     return Value();
-  auto warpsPerCTA = getI8MmaWarpsPerCTA(m, n, numWarps);
-  if (!warpsPerCTA)
+  if (!canUseI8MmaTile(m, n, numWarps))
     return Value();
+  auto warpsPerCTA = ttg::getMmaV2WarpsPerCTA({m, n}, numWarps);
 
   auto aElem = cast<IntegerType>(aPayloadTy.getElementType());
   auto bElem = cast<IntegerType>(bPayloadTy.getElementType());
@@ -1434,7 +1413,7 @@ Value tryEmitI8DotDecomposition(PatternRewriter &rewriter, Location loc,
   auto i8Ty = rewriter.getI8Type();
   auto i32Ty = rewriter.getI32Type();
   auto mmaLayout = ttg::NvidiaMmaEncodingAttr::get(
-      ctx, /*versionMajor=*/2, /*versionMinor=*/0, *warpsPerCTA,
+      ctx, /*versionMajor=*/2, /*versionMinor=*/0, warpsPerCTA,
       ttg::getCGALayout(accLayout), SmallVector<unsigned>{16, 8});
   auto aDotLayout = ttg::DotOperandEncodingAttr::get(ctx, 0, mmaLayout, i8Ty);
   auto bDotLayout = ttg::DotOperandEncodingAttr::get(ctx, 1, mmaLayout, i8Ty);
@@ -1580,7 +1559,7 @@ std::optional<scf::ForOp> emitMmaEmulationLoops(
       (k % kI8MmaK) == 0 && supportsI8DotDecomposition(rewriter, accElem) &&
       isScaleK32Aligned(scale.aScalePtr, scale.aScaleFactor) &&
       isScaleK32Aligned(scale.bScalePtr, scale.bScaleFactor) &&
-      getI8MmaWarpsPerCTA(tileM, tileN, numWarps).has_value();
+      canUseI8MmaTile(tileM, tileN, numWarps);
   if (canUseI8Decomposition) {
     if (!scale.computeElem && accElem.getWidth() <= 32) {
       Value aTile = loadScratchStrided2D(rewriter, loc, aTilePtr, aTileTy,

--- a/lib/Dialect/TritonInstrument/Transforms/FpSanitizer.cpp
+++ b/lib/Dialect/TritonInstrument/Transforms/FpSanitizer.cpp
@@ -53,6 +53,56 @@ static bool isValueAvailableInScope(Value value, Region *scope) {
 
 constexpr int64_t kTileM = 8;
 constexpr int64_t kTileN = 8;
+constexpr int64_t kI8MmaK = 32;
+
+bool supportsI8DotDecomposition(PatternRewriter &rewriter,
+                                IntegerType accElem) {
+  auto module =
+      rewriter.getInsertionBlock()->getParentOp()->getParentOfType<ModuleOp>();
+  if (getAMDArch(module))
+    return false;
+  return llvm::is_contained({16, 32, 64}, accElem.getWidth());
+}
+
+std::optional<SmallVector<unsigned>> getI8MmaWarpsPerCTA(int64_t m, int64_t n,
+                                                         int numWarps) {
+  if (m < 16 || n < 8 || (m % 16) != 0 || (n % 8) != 0 || numWarps <= 0)
+    return std::nullopt;
+
+  SmallVector<unsigned> warpsPerCTA{1, 1};
+  SmallVector<int64_t> reps{m / 16, n / 8};
+  while (warpsPerCTA[0] * warpsPerCTA[1] < numWarps) {
+    unsigned axis = reps[0] >= reps[1] ? 0 : 1;
+    if (reps[axis] <= 1 || (reps[axis] % 2) != 0)
+      axis = 1 - axis;
+    if (reps[axis] <= 1 || (reps[axis] % 2) != 0)
+      return std::nullopt;
+    warpsPerCTA[axis] *= 2;
+    reps[axis] /= 2;
+  }
+  if (warpsPerCTA[0] * warpsPerCTA[1] != numWarps)
+    return std::nullopt;
+  return warpsPerCTA;
+}
+
+std::pair<int64_t, int64_t> getMmaEmulationTileShape(PatternRewriter &rewriter,
+                                                     int64_t m, int64_t n,
+                                                     int64_t k,
+                                                     IntegerType accElem) {
+  if (supportsI8DotDecomposition(rewriter, accElem) && (k % kI8MmaK) == 0) {
+    int64_t numWarps =
+        ttg::lookupNumWarps(rewriter.getInsertionBlock()->getParent());
+    int64_t tileM = std::min<int64_t>(16 * numWarps, m);
+    while (tileM > 0 && (m % tileM) != 0)
+      tileM /= 2;
+    int64_t tileN = std::min<int64_t>(8 * numWarps, n);
+    while (tileN > 0 && (n % tileN) != 0)
+      tileN /= 2;
+    if (getI8MmaWarpsPerCTA(tileM, tileN, numWarps))
+      return {tileM, tileN};
+  }
+  return {std::min<int64_t>(kTileM, m), std::min<int64_t>(kTileN, n)};
+}
 
 Operation *createGlobalScratchBarrier(PatternRewriter &rewriter, Location loc,
                                       bool sharedClusterState = false) {
@@ -1206,6 +1256,258 @@ Value emulateDotStep(PatternRewriter &rewriter, Location loc, Value aSlice,
   return arith::MulIOp::create(rewriter, loc, aFull, bFull);
 }
 
+Value unpackPackedFp4Tensor(PatternRewriter &rewriter, Location loc,
+                            Value packed, int64_t axis,
+                            RankedTensorType logicalTy) {
+  Value packedI = embedToInt(rewriter, loc, packed);
+  auto packedTy = cast<RankedTensorType>(packedI.getType());
+  auto packedI8Ty = packedTy.clone(rewriter.getI8Type());
+  packedI = castSignedIntValueToType(rewriter, loc, packedI, packedI8Ty);
+
+  Value mask = getIntConstantLike(rewriter, loc, packedI8Ty, 0x0F);
+  Value four = getIntConstantLike(rewriter, loc, packedI8Ty, 4);
+  Value lo = arith::AndIOp::create(rewriter, loc, packedI, mask);
+  Value hi = arith::ShRUIOp::create(rewriter, loc, packedI, four);
+  auto halfTy = packedTy.clone(logicalTy.getElementType());
+  lo = castSignedIntValueToType(rewriter, loc, lo, halfTy);
+  hi = castSignedIntValueToType(rewriter, loc, hi, halfTy);
+  Value joined = tt::JoinOp::create(rewriter, loc, lo, hi);
+
+  int64_t rank = packedTy.getRank();
+  auto order = llvm::to_vector(llvm::seq<int32_t>(axis + 1));
+  order.push_back(rank);
+  llvm::append_range(order, llvm::seq<int32_t>(axis + 1, rank));
+  Value transposed = tt::TransOp::create(rewriter, loc, joined, order);
+
+  Value logical =
+      tt::ReshapeOp::create(rewriter, loc, logicalTy.getShape(), transposed);
+  if (logical.getType() != logicalTy)
+    logical = ttg::ConvertLayoutOp::create(rewriter, loc, logicalTy, logical);
+  return logical;
+}
+
+Value loadOperandK32(PatternRewriter &rewriter, Location loc, bool isLhs,
+                     Value tilePtr, RankedTensorType fullTileTy, Value kI32,
+                     int64_t rowStride, int64_t stride,
+                     int64_t packFactor = 1) {
+  SmallVector<int64_t> logicalShape{isLhs ? fullTileTy.getShape()[0] : kI8MmaK,
+                                    isLhs ? kI8MmaK : fullTileTy.getShape()[1]};
+  SmallVector<int64_t> rawShape = logicalShape;
+  rawShape[isLhs ? 1 : 0] /= packFactor;
+  auto rawLayout = getOptimizedBlockedEncoding(rewriter, rawShape,
+                                               fullTileTy.getElementType());
+  auto rawTy =
+      RankedTensorType::get(rawShape, fullTileTy.getElementType(), rawLayout);
+
+  Value packedKIdx = kI32;
+  if (packFactor != 1) {
+    Value factor = arith::ConstantOp::create(
+        rewriter, loc, rewriter.getI32IntegerAttr(packFactor));
+    packedKIdx = arith::DivUIOp::create(rewriter, loc, kI32, factor);
+  }
+  Value kStride = arith::ConstantOp::create(
+      rewriter, loc, rewriter.getI32IntegerAttr(isLhs ? stride : rowStride));
+  Value offset = arith::MulIOp::create(rewriter, loc, packedKIdx, kStride);
+  Value chunkPtr =
+      tt::AddPtrOp::create(rewriter, loc, tilePtr.getType(), tilePtr, offset);
+  Value chunk =
+      loadScratchStrided2D(rewriter, loc, chunkPtr, rawTy, rowStride, stride);
+
+  if (packFactor == 2) {
+    auto logicalLayout = getOptimizedBlockedEncoding(rewriter, logicalShape,
+                                                     rewriter.getI8Type());
+    auto logicalTy = RankedTensorType::get(logicalShape, rewriter.getI8Type(),
+                                           logicalLayout);
+    chunk = unpackPackedFp4Tensor(rewriter, loc, chunk,
+                                  /*axis=*/isLhs ? 1 : 0, logicalTy);
+  }
+  return chunk;
+}
+
+Value loadScaledScaleK32(PatternRewriter &rewriter, Location loc, bool isLhs,
+                         const DotScaleConfig &scale, Value tileIdx, Value kI32,
+                         RankedTensorType targetTy) {
+  Value ptr = isLhs ? scale.aScalePtr : scale.bScalePtr;
+  if (!ptr)
+    return Value();
+
+  int64_t scaleFactor = isLhs ? scale.aScaleFactor : scale.bScaleFactor;
+  int64_t scaleStride = isLhs ? scale.aScaleStride : scale.bScaleStride;
+  auto scaleTileTy = isLhs ? scale.aScaleTileTy : scale.bScaleTileTy;
+  int64_t groups = scaleFactor < kI8MmaK ? kI8MmaK / scaleFactor : 1;
+  int64_t repeat = kI8MmaK / groups;
+  SmallVector<int64_t> compactShape =
+      isLhs ? SmallVector<int64_t>{targetTy.getShape()[0], groups}
+            : SmallVector<int64_t>{groups, targetTy.getShape()[1]};
+  SmallVector<int64_t> broadcastShape =
+      isLhs ? SmallVector<int64_t>{targetTy.getShape()[0], groups, repeat}
+            : SmallVector<int64_t>{groups, repeat, targetTy.getShape()[1]};
+  int64_t expandAxis = isLhs ? 2 : 1;
+
+  auto broadcastLayout = getOptimizedBlockedEncoding(
+      rewriter, broadcastShape, scaleTileTy.getElementType());
+  auto compactSliceLayout = ttg::SliceEncodingAttr::get(
+      rewriter.getContext(), expandAxis, broadcastLayout);
+  auto compactLoadLayout = getOptimizedBlockedEncoding(
+      rewriter, compactShape, scaleTileTy.getElementType());
+  auto compactLoadTy = RankedTensorType::get(
+      compactShape, scaleTileTy.getElementType(), compactLoadLayout);
+
+  Value tilePtr =
+      tt::AddPtrOp::create(rewriter, loc, ptr.getType(), ptr, tileIdx);
+  Value factor = arith::ConstantOp::create(
+      rewriter, loc, rewriter.getI32IntegerAttr(scaleFactor));
+  Value groupIdx = arith::DivUIOp::create(rewriter, loc, kI32, factor);
+  Value stride = arith::ConstantOp::create(
+      rewriter, loc, rewriter.getI32IntegerAttr(scaleStride));
+  Value groupOffset = arith::MulIOp::create(rewriter, loc, groupIdx, stride);
+  Value groupPtr =
+      tt::AddPtrOp::create(rewriter, loc, ptr.getType(), tilePtr, groupOffset);
+  Value compact = loadScratchStrided2D(rewriter, loc, groupPtr, compactLoadTy,
+                                       /*stride0=*/isLhs ? 1 : scaleStride,
+                                       /*stride1=*/isLhs ? scaleStride : 1);
+  compact = castDotScaledScaleToComputePayload(rewriter, loc, compact,
+                                               scale.computeElem);
+  auto compactSliceTy = cast<RankedTensorType>(compact.getType())
+                            .cloneWithEncoding(compactSliceLayout);
+  compact =
+      ttg::ConvertLayoutOp::create(rewriter, loc, compactSliceTy, compact);
+
+  Value expanded = tt::ExpandDimsOp::create(rewriter, loc, compact, expandAxis);
+  auto broadcastTy =
+      cast<RankedTensorType>(expanded.getType()).clone(broadcastShape);
+  Value broadcast =
+      tt::BroadcastOp::create(rewriter, loc, broadcastTy, expanded);
+  Value reshaped =
+      tt::ReshapeOp::create(rewriter, loc, targetTy.getShape(), broadcast);
+  if (reshaped.getType() != targetTy)
+    reshaped = ttg::ConvertLayoutOp::create(rewriter, loc, targetTy, reshaped);
+  return reshaped;
+}
+
+Value loadScaledOperandK32(PatternRewriter &rewriter, Location loc, bool isLhs,
+                           Value tilePtr, RankedTensorType fullTileTy,
+                           const DotScaleConfig &scale, Value tileIdx,
+                           Value kI32, int64_t rowStride, int64_t stride) {
+  int64_t packFactor = isLhs ? scale.aKPackFactor : scale.bKPackFactor;
+  tt::ScaleDotElemType elemType = isLhs ? scale.aElemType : scale.bElemType;
+  Value chunk = loadOperandK32(rewriter, loc, isLhs, tilePtr, fullTileTy, kI32,
+                               rowStride, stride, packFactor);
+
+  Value payload = castDotScaledOperandToComputePayload(
+      rewriter, loc, chunk, elemType, scale.computeElem);
+  auto payloadTy = cast<RankedTensorType>(payload.getType());
+  Value scalePayload =
+      loadScaledScaleK32(rewriter, loc, isLhs, scale, tileIdx, kI32, payloadTy);
+  if (scalePayload)
+    payload = arith::MulIOp::create(rewriter, loc, payload, scalePayload);
+  return payload;
+}
+
+Value tryEmitI8DotDecomposition(PatternRewriter &rewriter, Location loc,
+                                Value aPayload, Value bPayload,
+                                Attribute accLayout, IntegerType accElem,
+                                int numWarps) {
+  auto aPayloadTy = cast<RankedTensorType>(aPayload.getType());
+  auto bPayloadTy = cast<RankedTensorType>(bPayload.getType());
+  auto aShape = aPayloadTy.getShape();
+  auto bShape = bPayloadTy.getShape();
+  int64_t m = aShape[0];
+  int64_t k = aShape[1];
+  int64_t n = bShape[1];
+  if (bShape[0] != k || (k % kI8MmaK) != 0 ||
+      !supportsI8DotDecomposition(rewriter, accElem))
+    return Value();
+  auto warpsPerCTA = getI8MmaWarpsPerCTA(m, n, numWarps);
+  if (!warpsPerCTA)
+    return Value();
+
+  auto aElem = cast<IntegerType>(aPayloadTy.getElementType());
+  auto bElem = cast<IntegerType>(bPayloadTy.getElementType());
+  assert((aElem.getWidth() % 8) == 0 && (bElem.getWidth() % 8) == 0);
+  int64_t aLimbs = aElem.getWidth() / 8;
+  int64_t bLimbs = bElem.getWidth() / 8;
+  int64_t accLimbs = accElem.getWidth() / 8;
+  int64_t highestDiagonal = std::min(accLimbs - 1, aLimbs + bLimbs - 2);
+
+  auto *ctx = rewriter.getContext();
+  auto i8Ty = rewriter.getI8Type();
+  auto i32Ty = rewriter.getI32Type();
+  auto mmaLayout = ttg::NvidiaMmaEncodingAttr::get(
+      ctx, /*versionMajor=*/2, /*versionMinor=*/0, *warpsPerCTA,
+      ttg::getCGALayout(accLayout), SmallVector<unsigned>{16, 8});
+  auto aDotLayout = ttg::DotOperandEncodingAttr::get(ctx, 0, mmaLayout, i8Ty);
+  auto bDotLayout = ttg::DotOperandEncodingAttr::get(ctx, 1, mmaLayout, i8Ty);
+  auto accMmaTy = RankedTensorType::get({m, n}, i32Ty, mmaLayout);
+
+  auto extractLimb = [&](Value payload, ttg::DotOperandEncodingAttr layout,
+                         int64_t limb) {
+    auto payloadTy = cast<RankedTensorType>(payload.getType());
+    auto blockedLimbTy = payloadTy.clone(i8Ty);
+    auto dotLimbTy = blockedLimbTy.cloneWithEncoding(layout);
+    Value shifted = payload;
+    if (limb != 0) {
+      Value shift = getIntConstantLike(rewriter, loc, payloadTy, 8 * limb);
+      shifted = arith::ShRUIOp::create(rewriter, loc, shifted, shift);
+    }
+    Value truncated =
+        arith::TruncIOp::create(rewriter, loc, blockedLimbTy, shifted);
+    return ttg::ConvertLayoutOp::create(rewriter, loc, dotLimbTy, truncated);
+  };
+
+  auto emitByteDiagonal = [&](Value sum, int64_t diagonal) {
+    int64_t firstALimb = std::max<int64_t>(0, diagonal - bLimbs + 1);
+    int64_t lastALimb = std::min(diagonal, aLimbs - 1);
+    for (int64_t aLimb = firstALimb; aLimb <= lastALimb; ++aLimb) {
+      int64_t bLimb = diagonal - aLimb;
+      Value a = extractLimb(aPayload, aDotLayout, aLimb);
+      Value b = extractLimb(bPayload, bDotLayout, bLimb);
+      auto dot = DotI8Op::create(rewriter, loc, accMmaTy, a, b, sum,
+                                 aLimb == aLimbs - 1, bLimb == bLimbs - 1);
+      sum = dot.getResult();
+    }
+    return sum;
+  };
+
+  if (accElem.getWidth() == 64) {
+    // Complete each K32 byte diagonal in i32 before widening it.  The largest
+    // diagonal is 8 * kI8MmaK * 255^2 < 2^24, so its i32 result is exact.
+    auto accTy = RankedTensorType::get({m, n}, accElem, accLayout);
+    Value product = getIntConstantLike(rewriter, loc, accTy, 0);
+    for (int64_t diagonal = highestDiagonal; diagonal >= 0; --diagonal) {
+      if (diagonal != highestDiagonal) {
+        Value shift = getIntConstantLike(rewriter, loc, accTy, 8);
+        product = arith::ShLIOp::create(rewriter, loc, product, shift);
+      }
+
+      Value diagonalSum = getIntConstantLike(rewriter, loc, accMmaTy, 0);
+      diagonalSum = emitByteDiagonal(diagonalSum, diagonal);
+      auto diagonalTy = RankedTensorType::get({m, n}, i32Ty, accLayout);
+      if (diagonalSum.getType() != diagonalTy) {
+        diagonalSum = ttg::ConvertLayoutOp::create(rewriter, loc, diagonalTy,
+                                                   diagonalSum);
+      }
+      Value diagonalWide =
+          arith::ExtSIOp::create(rewriter, loc, accTy, diagonalSum);
+      product = arith::AddIOp::create(rewriter, loc, product, diagonalWide);
+    }
+    return product;
+  }
+
+  Value product = getIntConstantLike(rewriter, loc, accMmaTy, 0);
+  for (int64_t diagonal = highestDiagonal; diagonal >= 0; --diagonal) {
+    if (diagonal != highestDiagonal) {
+      Value shift = getIntConstantLike(rewriter, loc, accMmaTy, 8);
+      product = arith::ShLIOp::create(rewriter, loc, product, shift);
+    }
+    product = emitByteDiagonal(product, diagonal);
+  }
+  auto accTy = RankedTensorType::get({m, n}, i32Ty, accLayout);
+  if (product.getType() == accTy)
+    return product;
+  return ttg::ConvertLayoutOp::create(rewriter, loc, accTy, product);
+}
+
 std::optional<scf::ForOp> emitMmaEmulationLoops(
     PatternRewriter &rewriter, Location loc, Value aPtr, Value bPtr, Value dPtr,
     int64_t m, int64_t n, int64_t k, int64_t tileM, int64_t tileN,
@@ -1268,67 +1570,133 @@ std::optional<scf::ForOp> emitMmaEmulationLoops(
   Value bTilePtr =
       tt::AddPtrOp::create(rewriter, loc, bPtr.getType(), bPtr, bOffset);
 
-  auto aSliceTy =
-      RankedTensorType::get({tileM, 1}, aTileTy.getElementType(), accLayout);
-  auto bSliceTy =
-      RankedTensorType::get({1, tileN}, bTileTy.getElementType(), accLayout);
-  Value aStrideVal = arith::ConstantOp::create(
-      rewriter, loc, rewriter.getI32IntegerAttr(aStride));
+  Value sum;
+  int numWarps = ttg::lookupNumWarps(rewriter.getInsertionBlock()->getParent());
+  auto isScaleK32Aligned = [](Value scalePtr, int64_t scaleFactor) {
+    return !scalePtr || (scaleFactor > 0 && ((kI8MmaK % scaleFactor) == 0 ||
+                                             (scaleFactor % kI8MmaK) == 0));
+  };
+  bool canUseI8Decomposition =
+      (k % kI8MmaK) == 0 && supportsI8DotDecomposition(rewriter, accElem) &&
+      isScaleK32Aligned(scale.aScalePtr, scale.aScaleFactor) &&
+      isScaleK32Aligned(scale.bScalePtr, scale.bScaleFactor) &&
+      getI8MmaWarpsPerCTA(tileM, tileN, numWarps).has_value();
+  if (canUseI8Decomposition) {
+    if (!scale.computeElem && accElem.getWidth() <= 32) {
+      Value aTile = loadScratchStrided2D(rewriter, loc, aTilePtr, aTileTy,
+                                         aRowStride, aStride);
+      Value bTile = loadScratchStrided2D(rewriter, loc, bTilePtr, bTileTy,
+                                         bRowStride, bStride);
+      sum = tryEmitI8DotDecomposition(
+          rewriter, loc, embedToInt(rewriter, loc, aTile),
+          embedToInt(rewriter, loc, bTile), accLayout, accElem, numWarps);
+      assert(sum && "i8 decomposition eligibility must match its emitter");
+      sum = castSignedIntValueToType(rewriter, loc, sum, accTileI.getType());
+    } else {
+      Value zeroSum = getIntConstantLike(rewriter, loc, accTileI.getType(), 0);
+      Value kUpper = arith::ConstantOp::create(rewriter, loc,
+                                               rewriter.getI32IntegerAttr(k));
+      Value kStep = arith::ConstantOp::create(
+          rewriter, loc, rewriter.getI32IntegerAttr(kI8MmaK));
+      auto kLoop =
+          scf::ForOp::create(rewriter, loc, zero, kUpper, kStep, zeroSum);
+      rewriter.setInsertionPointToStart(kLoop.getBody());
+      Value kIdx = kLoop.getInductionVar();
+      Value kI32 = arith::IndexCastOp::create(rewriter, loc, i32Ty, kIdx);
+      Value aChunk;
+      Value bChunk;
+      if (scale.computeElem) {
+        aChunk = loadScaledOperandK32(rewriter, loc, /*isLhs=*/true, aTilePtr,
+                                      aTileTy, scale, mIdxI32, kI32, aRowStride,
+                                      aStride);
+        bChunk = loadScaledOperandK32(rewriter, loc, /*isLhs=*/false, bTilePtr,
+                                      bTileTy, scale, nIdxI32, kI32, bRowStride,
+                                      bStride);
+      } else {
+        aChunk = loadOperandK32(rewriter, loc, /*isLhs=*/true, aTilePtr,
+                                aTileTy, kI32, aRowStride, aStride);
+        bChunk = loadOperandK32(rewriter, loc, /*isLhs=*/false, bTilePtr,
+                                bTileTy, kI32, bRowStride, bStride);
+      }
+      Value partial = tryEmitI8DotDecomposition(
+          rewriter, loc, embedToInt(rewriter, loc, aChunk),
+          embedToInt(rewriter, loc, bChunk), accLayout, accElem, numWarps);
+      assert(partial && "K32 decomposition must be eligible");
+      partial =
+          castSignedIntValueToType(rewriter, loc, partial, accTileI.getType());
+      Value next = arith::AddIOp::create(rewriter, loc,
+                                         kLoop.getRegionIterArgs()[0], partial);
+      scf::YieldOp::create(rewriter, loc, next);
+      rewriter.setInsertionPointAfter(kLoop);
+      sum = kLoop.getResult(0);
+    }
+  }
 
-  Value zeroSum = getIntConstantLike(rewriter, loc, accTileI.getType(), 0);
-  Value kUpper =
-      arith::ConstantOp::create(rewriter, loc, rewriter.getI32IntegerAttr(k));
-  Value kStep =
-      arith::ConstantOp::create(rewriter, loc, rewriter.getI32IntegerAttr(1));
-  auto kLoop = scf::ForOp::create(rewriter, loc, zero, kUpper, kStep, zeroSum);
-  rewriter.setInsertionPointToStart(kLoop.getBody());
-  Value kIdx = kLoop.getInductionVar();
-  Value kI32 = arith::IndexCastOp::create(rewriter, loc, i32Ty, kIdx);
-  Value aKIdx = kI32;
-  Value bKIdx = kI32;
-  if (scale.aKPackFactor == 2) {
-    Value aPackFactor = arith::ConstantOp::create(
-        rewriter, loc, rewriter.getI32IntegerAttr(scale.aKPackFactor));
-    aKIdx = arith::DivUIOp::create(rewriter, loc, kI32, aPackFactor);
-  }
-  if (scale.bKPackFactor == 2) {
-    Value bPackFactor = arith::ConstantOp::create(
-        rewriter, loc, rewriter.getI32IntegerAttr(scale.bKPackFactor));
-    bKIdx = arith::DivUIOp::create(rewriter, loc, kI32, bPackFactor);
-  }
-  Value aOffset =
-      arith::MulIOp::create(rewriter, loc, i32Ty, aKIdx, aStrideVal);
-  Value aSlicePtr =
-      tt::AddPtrOp::create(rewriter, loc, aPtr.getType(), aTilePtr, aOffset);
-  Value aSlice = loadScratchStrided2D(rewriter, loc, aSlicePtr, aSliceTy,
-                                      aRowStride, aStride);
-  Value bKOffset = arith::MulIOp::create(rewriter, loc, bKIdx, bRowStrideConst);
-  Value bSlicePtr =
-      tt::AddPtrOp::create(rewriter, loc, bPtr.getType(), bTilePtr, bKOffset);
-  Value bSlice = loadScratchStrided2D(rewriter, loc, bSlicePtr, bSliceTy,
-                                      bRowStride, bStride);
-  Value aScaleSlice;
-  if (scale.aScalePtr) {
+  if (!sum) {
+    auto aSliceTy =
+        RankedTensorType::get({tileM, 1}, aTileTy.getElementType(), accLayout);
+    auto bSliceTy =
+        RankedTensorType::get({1, tileN}, bTileTy.getElementType(), accLayout);
+    Value aStrideVal = arith::ConstantOp::create(
+        rewriter, loc, rewriter.getI32IntegerAttr(aStride));
+
+    Value zeroSum = getIntConstantLike(rewriter, loc, accTileI.getType(), 0);
+    Value kUpper =
+        arith::ConstantOp::create(rewriter, loc, rewriter.getI32IntegerAttr(k));
+    Value kStep =
+        arith::ConstantOp::create(rewriter, loc, rewriter.getI32IntegerAttr(1));
+    auto kLoop =
+        scf::ForOp::create(rewriter, loc, zero, kUpper, kStep, zeroSum);
+    rewriter.setInsertionPointToStart(kLoop.getBody());
+    Value kIdx = kLoop.getInductionVar();
+    Value kI32 = arith::IndexCastOp::create(rewriter, loc, i32Ty, kIdx);
+    Value aKIdx = kI32;
+    Value bKIdx = kI32;
+    if (scale.aKPackFactor == 2) {
+      Value aPackFactor = arith::ConstantOp::create(
+          rewriter, loc, rewriter.getI32IntegerAttr(scale.aKPackFactor));
+      aKIdx = arith::DivUIOp::create(rewriter, loc, kI32, aPackFactor);
+    }
+    if (scale.bKPackFactor == 2) {
+      Value bPackFactor = arith::ConstantOp::create(
+          rewriter, loc, rewriter.getI32IntegerAttr(scale.bKPackFactor));
+      bKIdx = arith::DivUIOp::create(rewriter, loc, kI32, bPackFactor);
+    }
+    Value aOffset =
+        arith::MulIOp::create(rewriter, loc, i32Ty, aKIdx, aStrideVal);
+    Value aSlicePtr =
+        tt::AddPtrOp::create(rewriter, loc, aPtr.getType(), aTilePtr, aOffset);
+    Value aSlice = loadScratchStrided2D(rewriter, loc, aSlicePtr, aSliceTy,
+                                        aRowStride, aStride);
+    Value bKOffset =
+        arith::MulIOp::create(rewriter, loc, bKIdx, bRowStrideConst);
+    Value bSlicePtr =
+        tt::AddPtrOp::create(rewriter, loc, bPtr.getType(), bTilePtr, bKOffset);
+    Value bSlice = loadScratchStrided2D(rewriter, loc, bSlicePtr, bSliceTy,
+                                        bRowStride, bStride);
     if (scale.aKPackFactor == 2)
       aSlice = unpackPackedFp4Slice(rewriter, loc, aSlice, kI32);
-    aScaleSlice =
-        loadScaleSlice(rewriter, loc, /*isLhs=*/true, scale, mIdxI32, kI32);
-  }
-  Value bScaleSlice;
-  if (scale.bScalePtr) {
     if (scale.bKPackFactor == 2)
       bSlice = unpackPackedFp4Slice(rewriter, loc, bSlice, kI32);
-    bScaleSlice =
-        loadScaleSlice(rewriter, loc, /*isLhs=*/false, scale, nIdxI32, kI32);
+    Value aScaleSlice;
+    if (scale.aScalePtr) {
+      aScaleSlice =
+          loadScaleSlice(rewriter, loc, /*isLhs=*/true, scale, mIdxI32, kI32);
+    }
+    Value bScaleSlice;
+    if (scale.bScalePtr) {
+      bScaleSlice =
+          loadScaleSlice(rewriter, loc, /*isLhs=*/false, scale, nIdxI32, kI32);
+    }
+    Value partial =
+        emulateDotStep(rewriter, loc, aSlice, bSlice, aScaleSlice, bScaleSlice,
+                       tileM, tileN, accLayout, accElem, scale);
+    Value acc = kLoop.getRegionIterArgs()[0];
+    Value next = arith::AddIOp::create(rewriter, loc, acc, partial);
+    scf::YieldOp::create(rewriter, loc, next);
+    rewriter.setInsertionPointAfter(kLoop);
+    sum = kLoop.getResult(0);
   }
-  Value partial =
-      emulateDotStep(rewriter, loc, aSlice, bSlice, aScaleSlice, bScaleSlice,
-                     tileM, tileN, accLayout, accElem, scale);
-  Value acc = kLoop.getRegionIterArgs()[0];
-  Value next = arith::AddIOp::create(rewriter, loc, acc, partial);
-  scf::YieldOp::create(rewriter, loc, next);
-  rewriter.setInsertionPointAfter(kLoop);
-  Value sum = kLoop.getResult(0);
 
   Value useDMask =
       tt::SplatOp::create(rewriter, loc, accTileI.getType(), useDInt);
@@ -1342,7 +1710,9 @@ std::optional<scf::ForOp> emitMmaEmulationLoops(
   Value outMasked = arith::MulIOp::create(rewriter, loc, outI, predMask);
   Value accMasked = arith::MulIOp::create(rewriter, loc, accTileI, predInv);
   Value outSelI = arith::AddIOp::create(rewriter, loc, outMasked, accMasked);
-  Value out = unembedToFloat(rewriter, loc, outSelI, accTileTy);
+  Value out = isFloatLike(accTileTy)
+                  ? unembedToFloat(rewriter, loc, outSelI, accTileTy)
+                  : outSelI;
   createGlobalScratchBarrier(rewriter, loc);
   storeScratchStrided2D(rewriter, loc, dTilePtr, out, accTileTy, dRowStride,
                         dStride);
@@ -1565,30 +1935,10 @@ struct Fp4ToFpPattern : public OpRewritePattern<ttg::Fp4ToFpOp> {
     if (!srcElemTy || srcElemTy.getWidth() != 8)
       return emitFpSanInvariantError(op.getOperation());
 
-    int64_t axis = op.getAxis();
-    int64_t rank = srcTy.getRank();
     auto dstIntTy = cast<RankedTensorType>(getIntTypeLike(dstTy));
-    auto halfIntTy = srcTy.clone(dstIntTy.getElementType());
-
     auto loc = op.getLoc();
-    auto mask = getIntConstantLike(rewriter, loc, srcTy, 0x0F);
-    auto four = getIntConstantLike(rewriter, loc, srcTy, 4);
-    Value lo = arith::AndIOp::create(rewriter, loc, op.getSrc(), mask);
-    Value hi = arith::ShRUIOp::create(rewriter, loc, op.getSrc(), four);
-    auto loI = castSignedIntValueToType(rewriter, loc, lo, halfIntTy);
-    auto hiI = castSignedIntValueToType(rewriter, loc, hi, halfIntTy);
-    Value joined = tt::JoinOp::create(rewriter, loc, loI, hiI);
-
-    auto order = llvm::to_vector(llvm::seq<int32_t>(axis + 1));
-    order.push_back(rank);
-    llvm::append_range(order, llvm::seq<int32_t>(axis + 1, rank));
-    auto transposed = tt::TransOp::create(rewriter, loc, joined, order);
-
-    Value result =
-        tt::ReshapeOp::create(rewriter, loc, dstTy.getShape(), transposed);
-    if (result.getType() != dstIntTy)
-      result = ttg::ConvertLayoutOp::create(rewriter, loc, dstIntTy, result);
-
+    Value result = unpackPackedFp4Tensor(rewriter, loc, op.getSrc(),
+                                         op.getAxis(), dstIntTy);
     rewriter.replaceOp(op, unembedToFloat(rewriter, loc, result, dstTy));
     return success();
   }
@@ -1668,13 +2018,11 @@ struct DotPattern : public OpRewritePattern<tt::DotOp> {
     Value predInt = arith::ConstantOp::create(
         rewriter, loc, rewriter.getIntegerAttr(accElem, 1));
 
-    int64_t tileM = std::min<int64_t>(kTileM, m);
-    int64_t tileN = std::min<int64_t>(kTileN, n);
+    auto [tileM, tileN] = getMmaEmulationTileShape(rewriter, m, n, k, accElem);
 
     // Use optimized blocked layouts for emulation tiles instead of the
     // original dot encodings.  Encodings like AMDWmmaEncodingAttr impose
-    // minimum shape requirements (e.g. >= 16x16) that the small emulation
-    // tiles (kTileM x kTileN = 8x8) cannot satisfy.
+    // minimum shape requirements that FMA fallback tiles cannot satisfy.
     auto accLayout = getOptimizedBlockedEncoding(rewriter, {tileM, tileN},
                                                  cTy.getElementType());
     auto aLayout =
@@ -1823,8 +2171,7 @@ struct DotScaledPattern : public OpRewritePattern<tt::DotScaledOp> {
     Value predInt = arith::ConstantOp::create(
         rewriter, loc, rewriter.getIntegerAttr(accElem, 1));
 
-    int64_t tileM = std::min<int64_t>(kTileM, m);
-    int64_t tileN = std::min<int64_t>(kTileN, n);
+    auto [tileM, tileN] = getMmaEmulationTileShape(rewriter, m, n, k, accElem);
 
     auto accLayout = getOptimizedBlockedEncoding(rewriter, {tileM, tileN},
                                                  cTy.getElementType());
@@ -2093,8 +2440,7 @@ struct WarpGroupDotPattern : public OpRewritePattern<ttng::WarpGroupDotOp> {
     if (!aScratch || !bScratch || !dPtr)
       return emitFpSanCodegenError(op.getOperation());
 
-    int64_t tileM = std::min<int64_t>(kTileM, m);
-    int64_t tileN = std::min<int64_t>(kTileN, n);
+    auto [tileM, tileN] = getMmaEmulationTileShape(rewriter, m, n, k, accElem);
 
     auto accTileLayout = getOptimizedBlockedEncoding(rewriter, {tileM, tileN},
                                                      cTy.getElementType());
@@ -2189,26 +2535,28 @@ struct TCGen5MMAPattern : public OpRewritePattern<ttng::TCGen5MMAOp> {
     if (!bScratch)
       return emitFpSanCodegenError(op.getOperation());
 
-    int64_t tileM = std::min<int64_t>(kTileM, m);
-    int64_t tileN = std::min<int64_t>(kTileN, n);
-
-    auto accTileLayout = getOptimizedBlockedEncoding(rewriter, {tileM, tileN},
-                                                     dMemTy.getElementType());
-    auto accTileTy = RankedTensorType::get(
-        {tileM, tileN}, dMemTy.getElementType(), accTileLayout);
-    auto aTileLayout = getOptimizedBlockedEncoding(rewriter, {tileM, k},
-                                                   aMemTy.getElementType());
-    auto aTileTy =
-        RankedTensorType::get({tileM, k}, aMemTy.getElementType(), aTileLayout);
-    auto bTileLayout = getOptimizedBlockedEncoding(rewriter, {k, tileN},
-                                                   bMemTy.getElementType());
-    auto bTileTy =
-        RankedTensorType::get({k, tileN}, bMemTy.getElementType(), bTileLayout);
-
     // Each warp may only populate a subset of the operand scratch tiles, so
     // synchronize before the emulation loops start reading them.
     createGlobalScratchBarrier(rewriter, loc,
                                scratch->usesSharedClusterState());
+
+    auto [tileM, tileN] = getMmaEmulationTileShape(rewriter, m, n, k, accElem);
+    auto accTileLayout =
+        getOptimizedBlockedEncoding(rewriter, {tileM, tileN}, accElem);
+    auto accTileTy =
+        RankedTensorType::get({tileM, tileN}, accElem, accTileLayout);
+    auto aTileLayout = getOptimizedBlockedEncoding(
+        rewriter, {tileM, k},
+        getScratchStorageElementType(aMemTy.getElementType()));
+    auto aTileTy = RankedTensorType::get(
+        {tileM, k}, getScratchStorageElementType(aMemTy.getElementType()),
+        aTileLayout);
+    auto bTileLayout = getOptimizedBlockedEncoding(
+        rewriter, {k, tileN},
+        getScratchStorageElementType(bMemTy.getElementType()));
+    auto bTileTy = RankedTensorType::get(
+        {k, tileN}, getScratchStorageElementType(bMemTy.getElementType()),
+        bTileLayout);
 
     auto mLoop = emitMmaEmulationLoops(
         rewriter, loc, aScratch->ptr, bScratch->ptr, dInfo->ptr, m, n, k, tileM,
@@ -2351,8 +2699,7 @@ struct TCGen5MMAScaledPattern
     if (!bScaleScratch)
       return emitFpSanCodegenError(op.getOperation());
 
-    int64_t tileM = std::min<int64_t>(kTileM, m);
-    int64_t tileN = std::min<int64_t>(kTileN, n);
+    auto [tileM, tileN] = getMmaEmulationTileShape(rewriter, m, n, k, accElem);
 
     auto accTileLayout = getOptimizedBlockedEncoding(rewriter, {tileM, tileN},
                                                      dMemTy.getElementType());

--- a/lib/Dialect/TritonNvidiaGPU/IR/Ops.cpp
+++ b/lib/Dialect/TritonNvidiaGPU/IR/Ops.cpp
@@ -149,13 +149,6 @@ bool WarpGroupDotOp::needsPartialAccumulator() {
   return isFP8 && accFP32 && maxNumImpreciseAcc <= aTensorTy.getShape()[1];
 }
 
-bool WarpGroupDotOp::verifyDims() {
-  auto aShape = this->getA().getType().getShape();
-  auto bShape = this->getB().getType().getShape();
-
-  return aShape[aShape.size() - 1] == bShape[aShape.size() - 2];
-}
-
 // -- WarpGroupDotWaitOp --
 LogicalResult WarpGroupDotWaitOp::inferReturnTypes(
     MLIRContext *context, std::optional<Location> location, ValueRange operands,
@@ -975,13 +968,6 @@ void TCGen5MMAOp::getEffects(
   for (auto &barrierMutable : getBarriersMutable())
     effects.emplace_back(MemoryEffects::Write::get(), &barrierMutable,
                          SharedMemory::get());
-}
-
-bool TCGen5MMAOp::verifyDims() {
-  auto aShape = this->getA().getType().getShape();
-  auto bShape = this->getB().getType().getShape();
-
-  return aShape[aShape.size() - 1] == bShape[aShape.size() - 2];
 }
 
 Value TCGen5MMAOp::useAccumulator() { return getUseD(); }

--- a/python/test/gluon/test_fpsan.py
+++ b/python/test/gluon/test_fpsan.py
@@ -1771,6 +1771,70 @@ def test_tcgen05_mma(device, use_acc, fresh_knobs):
 
 
 @pytest.mark.skipif(not is_blackwell(), reason="Requires Blackwell")
+@pytest.mark.parametrize("partition_warps", [4, 2, 1])
+def test_tcgen05_mma_warp_specialize_partition(device, partition_warps, fresh_knobs):
+    _require_cuda_backend(device)
+
+    M = gl.constexpr(64)
+    N = gl.constexpr(32)
+    K = gl.constexpr(32)
+    PARTITION_WARPS = gl.constexpr(partition_warps)
+    fresh_knobs.compilation.instrumentation_mode = "fpsan"
+
+    @gluon.jit
+    def default_partition():
+        pass
+
+    @gluon.jit
+    def mma_partition(smem_a, smem_b, acc_tmem, bar):
+        tcgen05_mma(smem_a, smem_b.permute((1, 0)), acc_tmem, use_acc=False, pred=True, mbarriers=[bar])
+
+    @gluon.jit
+    def kernel(a_ptr, b_ptr, out_ptr):
+        layout: gl.constexpr = gl.BlockedLayout([1, 1], [32, 1], [gl.num_warps(), 1], [1, 0])
+        offs_m = gl.arange(0, M, layout=gl.SliceLayout(1, layout))[:, None]
+        offs_n = gl.arange(0, N, layout=gl.SliceLayout(1, layout))[:, None]
+        offs_k = gl.arange(0, K, layout=gl.SliceLayout(0, layout))[None, :]
+        out_offs_n = gl.arange(0, N, layout=gl.SliceLayout(0, layout))[None, :]
+
+        a = gl.load(a_ptr + offs_m * K + offs_k)
+        b = gl.load(b_ptr + offs_n * K + offs_k)
+        smem_a = gl.allocate_shared_memory(gl.float32, [M, K], gl.NVMMASharedLayout.get_default_for([M, K], gl.float32),
+                                           a)
+        smem_b = gl.allocate_shared_memory(gl.float32, [N, K], gl.NVMMASharedLayout.get_default_for([N, K], gl.float32),
+                                           b)
+        acc_tmem = allocate_tensor_memory(gl.float32, [M, N], layout=TensorMemoryLayout((M, N), col_stride=1))
+        bar = mbarrier.allocate_mbarrier()
+        mbarrier.init(bar, count=1)
+
+        gl.warp_specialize([
+            (default_partition, ()),
+            (mma_partition, (smem_a, smem_b, acc_tmem, bar)),
+        ], [PARTITION_WARPS])
+
+        mbarrier.wait(bar, phase=0, deps=[smem_a, smem_b])
+        mbarrier.invalidate(bar)
+        out = gl.convert_layout(acc_tmem.load(), layout)
+        gl.store(out_ptr + offs_m * N + out_offs_n, out)
+
+    rs = np.random.RandomState(0)
+    a_bits = rs.randint(-(2**31), 2**31 - 1, size=(M.value, K.value), dtype=np.int32)
+    b_bits = rs.randint(-(2**31), 2**31 - 1, size=(N.value, K.value), dtype=np.int32)
+    exp_bits = _mm_payload_u32(a_bits, b_bits.T)
+    a = torch.tensor(a_bits, device=device, dtype=torch.int32)
+    b = torch.tensor(b_bits, device=device, dtype=torch.int32)
+    out = torch.empty((M.value, N.value), device=device, dtype=torch.int32)
+
+    kernel[(1, )](
+        triton.TensorWrapper(a, dtype=torch.float32),
+        triton.TensorWrapper(b, dtype=torch.float32),
+        triton.TensorWrapper(out, dtype=torch.float32),
+        num_warps=4,
+    )
+    _assert_payload_equal(out, exp_bits)
+
+
+@pytest.mark.skipif(not is_blackwell(), reason="Requires Blackwell")
 @pytest.mark.parametrize("use_acc", [False, True])
 def test_tcgen05_mma_two_ctas(device, use_acc, fresh_knobs):
     _require_cuda_backend(device)

--- a/test/Conversion/tritongpu_to_llvm.mlir
+++ b/test/Conversion/tritongpu_to_llvm.mlir
@@ -1491,6 +1491,51 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32} {
 
 // -----
 
+#mma = #ttg.nvidia_mma<{versionMajor=2, warpsPerCTA=[1, 1], instrShape = [16, 8]}>
+#dot_operand_a = #ttg.dot_op<{opIdx=0, parent=#mma, kWidth=4}>
+#dot_operand_b = #ttg.dot_op<{opIdx=1, parent=#mma, kWidth=4}>
+module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 1 : i32} {
+  // CHECK-LABEL: matmul_signed_i8dot
+  tt.func @matmul_signed_i8dot(%a: tensor<16x32xi8, #dot_operand_a>,
+                               %b: tensor<32x8xi8, #dot_operand_b>,
+                               %c: tensor<16x8xi32, #mma>) {
+    // CHECK: llvm.inline_asm
+    // CHECK-SAME: mma.sync.aligned.m16n8k32.row.col.satfinite.s32.s8.s8.s32
+    %d = tt.dot %a, %b, %c : tensor<16x32xi8, #dot_operand_a> * tensor<32x8xi8, #dot_operand_b> -> tensor<16x8xi32, #mma>
+    tt.return
+  }
+}
+
+// -----
+
+#mma = #ttg.nvidia_mma<{versionMajor=2, warpsPerCTA=[1, 1], instrShape = [16, 8]}>
+#dot_operand_a = #ttg.dot_op<{opIdx=0, parent=#mma, kWidth=4}>
+#dot_operand_b = #ttg.dot_op<{opIdx=1, parent=#mma, kWidth=4}>
+module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 1 : i32} {
+  // CHECK-LABEL: matmul_mixed_signed_i8dot
+  tt.func @matmul_mixed_signed_i8dot(%a: tensor<16x32xi8, #dot_operand_a>,
+                                     %b: tensor<32x8xi8, #dot_operand_b>,
+                                     %c: tensor<16x8xi32, #mma>) {
+    // CHECK-NOT: satfinite
+    // CHECK: llvm.inline_asm
+    // CHECK-SAME: mma.sync.aligned.m16n8k32.row.col.s32.s8.s8.s32
+    // CHECK: llvm.inline_asm
+    // CHECK-SAME: mma.sync.aligned.m16n8k32.row.col.s32.s8.u8.s32
+    // CHECK: llvm.inline_asm
+    // CHECK-SAME: mma.sync.aligned.m16n8k32.row.col.s32.u8.s8.s32
+    // CHECK: llvm.inline_asm
+    // CHECK-SAME: mma.sync.aligned.m16n8k32.row.col.s32.u8.u8.s32
+    // CHECK-NOT: satfinite
+    %d0 = tti.dot_i8 %a, %b, %c, aSigned = true, bSigned = true : tensor<16x32xi8, #dot_operand_a> * tensor<32x8xi8, #dot_operand_b> -> tensor<16x8xi32, #mma>
+    %d1 = tti.dot_i8 %a, %b, %d0, aSigned = true, bSigned = false : tensor<16x32xi8, #dot_operand_a> * tensor<32x8xi8, #dot_operand_b> -> tensor<16x8xi32, #mma>
+    %d2 = tti.dot_i8 %a, %b, %d1, aSigned = false, bSigned = true : tensor<16x32xi8, #dot_operand_a> * tensor<32x8xi8, #dot_operand_b> -> tensor<16x8xi32, #mma>
+    %d3 = tti.dot_i8 %a, %b, %d2, aSigned = false, bSigned = false : tensor<16x32xi8, #dot_operand_a> * tensor<32x8xi8, #dot_operand_b> -> tensor<16x8xi32, #mma>
+    tt.return
+  }
+}
+
+// -----
+
 #blocked0 = #ttg.blocked<{sizePerThread = [1], threadsPerWarp = [32], warpsPerCTA = [4], order = [0]}>
 module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, "ttg.target" = "cuda:80"} {
   // CHECK-LABEL: atomic_add_f32

--- a/test/TritonGPU/fpsan.mlir
+++ b/test/TritonGPU/fpsan.mlir
@@ -25,6 +25,68 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, "ttg.thr
 
 // -----
 
+#blocked = #ttg.blocked<{sizePerThread = [1, 4], threadsPerWarp = [32, 1], warpsPerCTA = [4, 1], order = [1, 0]}>
+#dot_operand_a = #ttg.dot_op<{opIdx = 0, parent = #blocked}>
+#dot_operand_b = #ttg.dot_op<{opIdx = 1, parent = #blocked}>
+module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, "ttg.threads-per-warp" = 32 : i32} {
+  // CHECK-LABEL: @dot_i8_decomposition
+  tt.func public @dot_i8_decomposition() -> tensor<32x32xf32, #blocked> {
+    // CHECK: scf.for
+    // CHECK: tti.dot_i8 {{.*}} aSigned = true, bSigned = true
+    // CHECK: tti.dot_i8 {{.*}} aSigned = false, bSigned = true
+    // CHECK: tti.dot_i8 {{.*}} aSigned = true, bSigned = false
+    // CHECK: tti.dot_i8 {{.*}} aSigned = false, bSigned = false
+    // CHECK-NOT: tti.dot_i8
+    %one = arith.constant 1.000000e+00 : f16
+    %zero = arith.constant dense<0.000000e+00> : tensor<32x32xf32, #blocked>
+    %a = tt.splat %one : f16 -> tensor<32x32xf16, #dot_operand_a>
+    %b = tt.splat %one : f16 -> tensor<32x32xf16, #dot_operand_b>
+    %out = tt.dot %a, %b, %zero : tensor<32x32xf16, #dot_operand_a> * tensor<32x32xf16, #dot_operand_b> -> tensor<32x32xf32, #blocked>
+    tt.return %out : tensor<32x32xf32, #blocked>
+  }
+}
+
+// -----
+
+#blocked = #ttg.blocked<{sizePerThread = [1, 4], threadsPerWarp = [32, 1], warpsPerCTA = [4, 1], order = [1, 0]}>
+#dot_operand_a = #ttg.dot_op<{opIdx = 0, parent = #blocked}>
+#dot_operand_b = #ttg.dot_op<{opIdx = 1, parent = #blocked}>
+module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, "ttg.threads-per-warp" = 32 : i32} {
+  // CHECK-LABEL: @dot_f64_i8_decomposition
+  tt.func public @dot_f64_i8_decomposition() -> tensor<32x32xf64, #blocked> {
+    // CHECK-COUNT-36: tti.dot_i8
+    // CHECK-NOT: tti.dot_i8
+    // CHECK: arith.extsi {{.*}} : tensor<{{.*}}xi32, #{{.*}}> to tensor<{{.*}}xi64, #{{.*}}>
+    %one = arith.constant 1.000000e+00 : f64
+    %zero = arith.constant dense<0.000000e+00> : tensor<32x32xf64, #blocked>
+    %a = tt.splat %one : f64 -> tensor<32x32xf64, #dot_operand_a>
+    %b = tt.splat %one : f64 -> tensor<32x32xf64, #dot_operand_b>
+    %out = tt.dot %a, %b, %zero : tensor<32x32xf64, #dot_operand_a> * tensor<32x32xf64, #dot_operand_b> -> tensor<32x32xf64, #blocked>
+    tt.return %out : tensor<32x32xf64, #blocked>
+  }
+}
+
+// -----
+
+#blocked = #ttg.blocked<{sizePerThread = [1, 1], threadsPerWarp = [32, 1], warpsPerCTA = [4, 1], order = [1, 0]}>
+#dot_operand_a = #ttg.dot_op<{opIdx = 0, parent = #blocked}>
+#dot_operand_b = #ttg.dot_op<{opIdx = 1, parent = #blocked}>
+module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, "ttg.threads-per-warp" = 32 : i32} {
+  // CHECK-LABEL: @dot_f64_fma_fallback
+  tt.func public @dot_f64_fma_fallback() -> tensor<8x8xf64, #blocked> {
+    // CHECK: scf.for
+    // CHECK-NOT: tt.dot
+    %one = arith.constant 1.000000e+00 : f64
+    %zero = arith.constant dense<0.000000e+00> : tensor<8x8xf64, #blocked>
+    %a = tt.splat %one : f64 -> tensor<8x4xf64, #dot_operand_a>
+    %b = tt.splat %one : f64 -> tensor<4x8xf64, #dot_operand_b>
+    %out = tt.dot %a, %b, %zero : tensor<8x4xf64, #dot_operand_a> * tensor<4x8xf64, #dot_operand_b> -> tensor<8x8xf64, #blocked>
+    tt.return %out : tensor<8x8xf64, #blocked>
+  }
+}
+
+// -----
+
 #blocked = #ttg.blocked<{sizePerThread = [1, 1, 1], threadsPerWarp = [1, 32, 1], warpsPerCTA = [1, 4, 1], order = [2, 1, 0]}>
 #dot_operand_a = #ttg.dot_op<{opIdx = 0, parent = #blocked}>
 #dot_operand_b = #ttg.dot_op<{opIdx = 1, parent = #blocked}>
@@ -56,6 +118,7 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, "ttg.thr
     // CHECK: scf.for
     // CHECK: ttg.barrier global_read|global_write
     // CHECK-NOT: ttg.dot_scaled
+    // CHECK-NOT: tt.dot
     // CHECK-NOT: ttg.convert_layout
      %cst = arith.constant 1.000000e+00 : f16
      %zero = arith.constant dense<0.000000e+00> : tensor<16x16xf32, #blocked>
@@ -63,6 +126,30 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, "ttg.thr
      %b = tt.splat %cst : f16 -> tensor<16x16xf16, #dot_B>
      %out = tt.dot_scaled %a, %b, %zero lhs = fp16 rhs = fp16 {fastMath = false} : tensor<16x16xf16, #dot_A> * tensor<16x16xf16, #dot_B> -> tensor<16x16xf32, #blocked>
      tt.return %out : tensor<16x16xf32, #blocked>
+  }
+}
+
+// -----
+
+#blocked = #ttg.blocked<{sizePerThread = [1, 4], threadsPerWarp = [32, 1], warpsPerCTA = [4, 1], order = [1, 0]}>
+#dot_A = #ttg.dot_op<{opIdx = 0, parent = #blocked}>
+#dot_B = #ttg.dot_op<{opIdx = 1, parent = #blocked}>
+module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, "ttg.threads-per-warp" = 32 : i32} {
+  // CHECK-LABEL: @dot_scaled_i8_decomposition
+  tt.func public @dot_scaled_i8_decomposition() -> tensor<32x32xf32, #blocked> {
+    // CHECK: scf.for
+    // CHECK: tti.dot_i8 {{.*}} aSigned = true, bSigned = true
+    // CHECK: tti.dot_i8 {{.*}} aSigned = false, bSigned = true
+    // CHECK: tti.dot_i8 {{.*}} aSigned = true, bSigned = false
+    // CHECK: tti.dot_i8 {{.*}} aSigned = false, bSigned = false
+    // CHECK-NOT: tti.dot_i8
+    // CHECK-NOT: ttg.dot_scaled
+    %one = arith.constant 1.000000e+00 : f16
+    %zero = arith.constant dense<0.000000e+00> : tensor<32x32xf32, #blocked>
+    %a = tt.splat %one : f16 -> tensor<32x64xf16, #dot_A>
+    %b = tt.splat %one : f16 -> tensor<64x32xf16, #dot_B>
+    %out = tt.dot_scaled %a, %b, %zero lhs = fp16 rhs = fp16 {fastMath = false} : tensor<32x64xf16, #dot_A> * tensor<64x32xf16, #dot_B> -> tensor<32x32xf32, #blocked>
+    tt.return %out : tensor<32x32xf32, #blocked>
   }
 }
 
@@ -79,6 +166,8 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, "ttg.thr
     // CHECK: tt.store
     // CHECK: ttg.barrier global_read|global_write
     // CHECK: scf.for
+    // CHECK-COUNT-10: tti.dot_i8
+    // CHECK-NOT: tti.dot_i8
     // CHECK: ttg.barrier global_read|global_write
     // CHECK: %[[RAW:.*]] = tt.load
     // CHECK: %[[OUT:.*]] = tti.experimental_fpsan_unembed %[[RAW]]

--- a/test/TritonGPU/invalid.mlir
+++ b/test/TritonGPU/invalid.mlir
@@ -326,6 +326,46 @@ module attributes {"ttg.num-warps" = 1 : i32} {
 
 // -----
 
+#mma0 = #ttg.nvidia_mma<{versionMajor=2, warpsPerCTA=[1,1], instrShape = [16, 8]}>
+#dot_operand_a = #ttg.dot_op<{opIdx=0, parent=#mma0, kWidth=4}>
+#dot_operand_b = #ttg.dot_op<{opIdx=1, parent=#mma0, kWidth=4}>
+module attributes {"ttg.num-warps" = 1 : i32} {
+  tt.func @dot_i8_invalid_operand_type(%A: tensor<16x32xi16, #dot_operand_a>, %B: tensor<32x8xi8, #dot_operand_b>, %C: tensor<16x8xi32, #mma0>) {
+    // expected-error@+1 {{operand #0 must be ranked tensor of 8-bit signless integer values}}
+    %D = "tti.dot_i8"(%A, %B, %C) {aSigned = true, bSigned = true} : (tensor<16x32xi16, #dot_operand_a>, tensor<32x8xi8, #dot_operand_b>, tensor<16x8xi32, #mma0>) -> tensor<16x8xi32, #mma0>
+    tt.return
+  }
+}
+
+// -----
+
+#blocked = #ttg.blocked<{sizePerThread = [1, 1], threadsPerWarp = [32, 1], warpsPerCTA = [1, 1], order = [1, 0]}>
+#dot_operand_a = #ttg.dot_op<{opIdx=0, parent=#blocked}>
+#dot_operand_b = #ttg.dot_op<{opIdx=1, parent=#blocked}>
+module attributes {"ttg.num-warps" = 1 : i32} {
+  tt.func @dot_i8_non_mma_layout(%A: tensor<16x32xi8, #dot_operand_a>, %B: tensor<32x8xi8, #dot_operand_b>, %C: tensor<16x8xi32, #blocked>) {
+    // expected-error@+1 {{requires NVIDIA MMAv2 operand and result layouts}}
+    %D = tti.dot_i8 %A, %B, %C, aSigned = true, bSigned = true : tensor<16x32xi8, #dot_operand_a> * tensor<32x8xi8, #dot_operand_b> -> tensor<16x8xi32, #blocked>
+    tt.return
+  }
+}
+
+// -----
+
+#mma0 = #ttg.nvidia_mma<{versionMajor=2, warpsPerCTA=[1,1], instrShape = [16, 8]}>
+#mma1 = #ttg.nvidia_mma<{versionMajor=2, warpsPerCTA=[1,1], instrShape = [32, 8]}>
+#dot_operand_a = #ttg.dot_op<{opIdx=0, parent=#mma0, kWidth=4}>
+#dot_operand_b = #ttg.dot_op<{opIdx=1, parent=#mma1, kWidth=4}>
+module attributes {"ttg.num-warps" = 1 : i32} {
+  tt.func @dot_i8_mismatched_layout(%A: tensor<16x32xi8, #dot_operand_a>, %B: tensor<32x8xi8, #dot_operand_b>, %C: tensor<16x8xi32, #mma0>) {
+    // expected-error@+1 {{requires matching NVIDIA MMAv2 layouts}}
+    %D = tti.dot_i8 %A, %B, %C, aSigned = true, bSigned = true : tensor<16x32xi8, #dot_operand_a> * tensor<32x8xi8, #dot_operand_b> -> tensor<16x8xi32, #mma0>
+    tt.return
+  }
+}
+
+// -----
+
 tt.func @warp_specialize_no_holder() {
   // expected-error @below {{'ttg.warp_specialize' op expected to find only a `ttg.warp_specialize.partitions` op inside its second region}}
   "ttg.warp_specialize"() ({

--- a/test/TritonGPU/nvidia-fpsan.mlir
+++ b/test/TritonGPU/nvidia-fpsan.mlir
@@ -76,7 +76,11 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.shar
     // CHECK: ttg.global_scratch_alloc
     // CHECK: ttg.barrier global_read|global_write
     // CHECK-NEXT: scf.for
-    // CHECK: ttg.barrier global_read|global_write
+    // CHECK: tti.dot_i8 {{.*}} aSigned = true, bSigned = true
+    // CHECK: tti.dot_i8 {{.*}} aSigned = false, bSigned = true
+    // CHECK: tti.dot_i8 {{.*}} aSigned = true, bSigned = false
+    // CHECK: tti.dot_i8 {{.*}} aSigned = false, bSigned = false
+    // CHECK-NOT: tti.dot_i8
     // CHECK: tt.store
     // CHECK: ttg.barrier global_read|global_write
     // CHECK: ttng.arrive_barrier
@@ -103,7 +107,6 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.shar
     // CHECK: ttg.global_scratch_alloc
     // CHECK: ttg.barrier global_read|global_write
     // CHECK-NEXT: scf.for
-    // CHECK: ttg.barrier global_read|global_write
     // CHECK: tt.store
     // CHECK: ttg.barrier global_read|global_write
     // CHECK: ttng.arrive_barrier
@@ -132,6 +135,11 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.shar
     // CHECK: ttg.global_scratch_alloc
     // CHECK: ttg.barrier global_read|global_write
     // CHECK-NEXT: scf.for
+    // CHECK: tti.dot_i8 {{.*}} aSigned = true, bSigned = true
+    // CHECK: tti.dot_i8 {{.*}} aSigned = false, bSigned = true
+    // CHECK: tti.dot_i8 {{.*}} aSigned = true, bSigned = false
+    // CHECK: tti.dot_i8 {{.*}} aSigned = false, bSigned = false
+    // CHECK-NOT: tti.dot_i8
     // CHECK: ttg.barrier global_read|global_write
     // CHECK: tt.store
     // CHECK: ttg.barrier global_read|global_write

--- a/third_party/nvidia/lib/TritonNVIDIAGPUToLLVM/CMakeLists.txt
+++ b/third_party/nvidia/lib/TritonNVIDIAGPUToLLVM/CMakeLists.txt
@@ -28,6 +28,7 @@ add_triton_library(TritonNVIDIAGPUToLLVM
     GluonTransforms
     TritonAnalysis
     TritonGPUToLLVM
+    TritonInstrumentIR
     TritonInstrumentToLLVM
     MLIRReconcileUnrealizedCasts
     NVGPUIR

--- a/third_party/nvidia/lib/TritonNVIDIAGPUToLLVM/DotOpToLLVM.cpp
+++ b/third_party/nvidia/lib/TritonNVIDIAGPUToLLVM/DotOpToLLVM.cpp
@@ -2,6 +2,7 @@
 #include "Utility.h"
 
 #include "triton/Conversion/TritonGPUToLLVM/PatternTritonGPUOpToLLVM.h"
+#include "triton/Dialect/TritonInstrument/IR/Dialect.h"
 
 using namespace mlir;
 using namespace mlir::triton;
@@ -12,6 +13,11 @@ using ::mlir::triton::gpu::NvidiaMmaEncodingAttr;
 using ::mlir::triton::gpu::toLinearLayout;
 
 LogicalResult convertMMA(triton::DotOp op, triton::DotOp::Adaptor adaptor,
+                         const LLVMTypeConverter *typeConverter,
+                         ConversionPatternRewriter &rewriter, bool isTuring);
+
+LogicalResult convertMMA(triton::instrument::DotI8Op op,
+                         triton::instrument::DotI8Op::Adaptor adaptor,
                          const LLVMTypeConverter *typeConverter,
                          ConversionPatternRewriter &rewriter, bool isTuring);
 
@@ -82,6 +88,34 @@ struct DotOpConversion : public ConvertOpToLLVMPattern<triton::DotOp> {
 
     llvm::report_fatal_error(
         "Unsupported DotOp found when converting TritonGPU to LLVM.");
+  }
+};
+
+struct DotI8OpConversion
+    : public ConvertOpToLLVMPattern<triton::instrument::DotI8Op> {
+  using ConvertOpToLLVMPattern<
+      triton::instrument::DotI8Op>::ConvertOpToLLVMPattern;
+
+  DotI8OpConversion(LLVMTypeConverter &converter, int, PatternBenefit benefit)
+      : ConvertOpToLLVMPattern<triton::instrument::DotI8Op>(converter,
+                                                            benefit) {}
+
+  LogicalResult
+  matchAndRewrite(triton::instrument::DotI8Op op, OpAdaptor adaptor,
+                  ConversionPatternRewriter &rewriter) const override {
+    auto dType = op.getD().getType();
+    auto dEncoding = dType.getEncoding();
+    if (!isPermutationMatrixLayout(toLinearLayout(dType.getShape(), dEncoding)))
+      return rewriter.notifyMatchFailure(
+          op, "DotI8Op result encoding must have a permutation-matrix linear "
+              "layout");
+
+    auto mmaLayout = dyn_cast<NvidiaMmaEncodingAttr>(dEncoding);
+    if (!mmaLayout || mmaLayout.getVersionMajor() != 2)
+      return rewriter.notifyMatchFailure(op,
+                                         "DotI8Op requires an MMAv2 layout");
+    return convertMMA(op, adaptor, getTypeConverter(), rewriter,
+                      mmaLayout.isTuring());
   }
 };
 
@@ -161,6 +195,7 @@ void mlir::triton::NVIDIA::populateDotOpToLLVMPatterns(
     LLVMTypeConverter &typeConverter, RewritePatternSet &patterns,
     int computeCapability, PatternBenefit benefit) {
   patterns.add<DotOpConversion>(typeConverter, computeCapability, benefit);
+  patterns.add<DotI8OpConversion>(typeConverter, computeCapability, benefit);
   patterns.add<WarpGroupDotOpConversion>(typeConverter, benefit);
   patterns.add<WarpGroupDotWaitOpConversion>(typeConverter, benefit);
   patterns.add<ScaledDotOpConversion>(typeConverter, computeCapability,

--- a/third_party/nvidia/lib/TritonNVIDIAGPUToLLVM/DotOpToLLVM/MMAv2.cpp
+++ b/third_party/nvidia/lib/TritonNVIDIAGPUToLLVM/DotOpToLLVM/MMAv2.cpp
@@ -4,6 +4,7 @@
 #include "triton/Conversion/TritonGPUToLLVM/Utility.h"
 #include "triton/Dialect/Triton/IR/Dialect.h"
 #include "triton/Dialect/TritonGPU/IR/Attributes.h"
+#include "triton/Dialect/TritonInstrument/IR/Dialect.h"
 #include "llvm/ADT/SmallVector.h"
 
 using namespace mlir;
@@ -715,13 +716,11 @@ using EmitMmaCallback = std::function<void(
     unsigned batchOffset, ValueTableV2 &ha, ValueTableV2 &hb,
     const SmallVector<Value> &fc, RankedTensorType dTensorTy, int repK)>;
 
-LogicalResult
-convertMMAImpl(DotOpInterface op, Value llvmA, Value llvmB, Value llvmC,
-               const LLVMTypeConverter *typeConverter,
-               ConversionPatternRewriter &rewriter, TensorCoreType mmaType,
-               const NumRegisters &numRegisters,
-               const std::map<TensorCoreType, std::string> &mmaInstructions,
-               const EmitMmaCallback &emitMma) {
+LogicalResult convertMMAImpl(
+    DotOpInterface op, Value llvmA, Value llvmB, Value llvmC,
+    const LLVMTypeConverter *typeConverter, ConversionPatternRewriter &rewriter,
+    TensorCoreType mmaType, const NumRegisters &numRegisters,
+    const std::string &mmaInstruction, const EmitMmaCallback &emitMma) {
   auto loc = op.getLoc();
   auto aType = cast<RankedTensorType>(op.getA().getType());
   auto bType = cast<RankedTensorType>(op.getB().getType());
@@ -787,7 +786,7 @@ convertMMAImpl(DotOpInterface op, Value llvmA, Value llvmB, Value llvmC,
       elemsPerThread[rank - 2] * elemsPerThread[rank - 1] / numCPackedElem;
   auto callMma = [&](unsigned b, unsigned m, unsigned n, unsigned k) {
     PTXBuilder builder;
-    auto &mma = *builder.create(mmaInstructions.at(mmaType));
+    auto &mma = *builder.create(mmaInstruction);
     // using =r for float32 works but leads to less readable ptx.
     unsigned colsPerThread = repN * 2;
     emitMma(builder, b, static_cast<int>(m), static_cast<int>(n),
@@ -834,21 +833,10 @@ convertMMAImpl(DotOpInterface op, Value llvmA, Value llvmB, Value llvmC,
   return success();
 }
 
-} // namespace
-
-LogicalResult convertMMA(triton::DotOp op, triton::DotOp::Adaptor adaptor,
-                         const LLVMTypeConverter *typeConverter,
-                         ConversionPatternRewriter &rewriter, bool isTuring) {
-  auto aTensorTy = op.getA().getType();
-  auto bTensorTy = op.getB().getType();
-  auto dTensorTy = op.getD().getType();
-
-  TensorCoreType mmaType = getMmaTypeDot(op, aTensorTy, bTensorTy, dTensorTy);
-  const auto &instrMap = isTuring ? mmaInstrPtxTuring : mmaInstrPtxAmpere;
-  if (instrMap.find(mmaType) == instrMap.end())
-    return op.emitError(
-        "unsupported MMA instruction for the given operand/result types");
-
+LogicalResult convertMMAWithInstruction(
+    DotOpInterface op, Value llvmA, Value llvmB, Value llvmC,
+    const LLVMTypeConverter *typeConverter, ConversionPatternRewriter &rewriter,
+    TensorCoreType mmaType, const std::string &mmaInstruction, bool isTuring) {
   NumRegisters numRegisters = (mmaType == TensorCoreType::FP64_FP64_FP64_FP64)
                                   ? NumRegisters{1, 1, 1}
                                   : NumRegisters{2, 1, 2};
@@ -885,9 +873,43 @@ LogicalResult convertMMA(triton::DotOp op, triton::DotOp::Adaptor adaptor,
     }
   };
 
-  return convertMMAImpl(op, adaptor.getA(), adaptor.getB(), adaptor.getC(),
-                        typeConverter, rewriter, mmaType, numRegisters,
-                        instrMap, emit);
+  return convertMMAImpl(op, llvmA, llvmB, llvmC, typeConverter, rewriter,
+                        mmaType, numRegisters, mmaInstruction, emit);
+}
+
+} // namespace
+
+LogicalResult convertMMA(triton::DotOp op, triton::DotOp::Adaptor adaptor,
+                         const LLVMTypeConverter *typeConverter,
+                         ConversionPatternRewriter &rewriter, bool isTuring) {
+  auto aTensorTy = op.getA().getType();
+  auto bTensorTy = op.getB().getType();
+  auto dTensorTy = op.getD().getType();
+
+  TensorCoreType mmaType = getMmaTypeDot(op, aTensorTy, bTensorTy, dTensorTy);
+  const auto &instrMap = isTuring ? mmaInstrPtxTuring : mmaInstrPtxAmpere;
+  if (instrMap.find(mmaType) == instrMap.end())
+    return op.emitError(
+        "unsupported MMA instruction for the given operand/result types");
+
+  return convertMMAWithInstruction(op, adaptor.getA(), adaptor.getB(),
+                                   adaptor.getC(), typeConverter, rewriter,
+                                   mmaType, instrMap.at(mmaType), isTuring);
+}
+
+LogicalResult convertMMA(triton::instrument::DotI8Op op,
+                         triton::instrument::DotI8Op::Adaptor adaptor,
+                         const LLVMTypeConverter *typeConverter,
+                         ConversionPatternRewriter &rewriter, bool isTuring) {
+  std::string mmaInstruction = isTuring
+                                   ? "mma.sync.aligned.m8n8k16.row.col.s32."
+                                   : "mma.sync.aligned.m16n8k32.row.col.s32.";
+  mmaInstruction += op.getASigned() ? "s8." : "u8.";
+  mmaInstruction += op.getBSigned() ? "s8.s32" : "u8.s32";
+  return convertMMAWithInstruction(op, adaptor.getA(), adaptor.getB(),
+                                   adaptor.getC(), typeConverter, rewriter,
+                                   TensorCoreType::INT32_INT8_INT8_INT32,
+                                   mmaInstruction, isTuring);
 }
 
 LogicalResult convertMMADotScaled(triton::DotScaledOp op,
@@ -955,5 +977,5 @@ LogicalResult convertMMADotScaled(triton::DotScaledOp op,
 
   return convertMMAImpl(op, adaptor.getA(), adaptor.getB(), adaptor.getC(),
                         typeConverter, rewriter, mmaType, numRegisters,
-                        mmaInstrPtxScaled, emit);
+                        mmaInstrPtxScaled.at(mmaType), emit);
 }


### PR DESCRIPTION
Stack:
- #10440
- #10461
- This PR

## Summary
- Accelerate FPSan MMA emulation using mixed-signed i8 MMA decomposition.
- Introduce `tti.dot_i8` without changing ordinary `tt.dot`.
- Preserve scalar FMA fallback and disable the NVIDIA i8 path on AMD.
- Preserve two-CTA and warp-specialized partition behavior.

## Validation
- GB300 full `python/test/gluon/test_fpsan.py`: `221 passed, 89 skipped`
- Relevant lit tests: passed
- Pre-commit: passed
