### PR TITLE
[DNR][Do not merge] All FPSAN changes branch

### DIFF
--- a/include/triton/Analysis/Utility.h
+++ b/include/triton/Analysis/Utility.h
@@ -252,6 +252,8 @@ bool supportWMMA(triton::DotOp op);
 
 bool supportMMA(triton::DotOp op, int version);
 
+bool supportMMA(triton::DotOpInterface op, int version);
+
 bool supportMMA(Value value, int version);
 
 // Conversion from `srcTy` to `dstTy` involving the minimum amount of data

--- a/include/triton/Conversion/TritonGPUToLLVM/Utility.h
+++ b/include/triton/Conversion/TritonGPUToLLVM/Utility.h
@@ -613,12 +613,10 @@ struct LocalSharedMemoryAddress {
 // Compute per-element shared-memory addresses for a local atomic/ldst update by
 // replacing `coords[*][axis]` with `idxValues[*]` and mapping the resulting
 // logical coordinates back to shared-memory offsets and target CTAs.
-SmallVector<LocalSharedMemoryAddress>
-computeLocalAddrs(Location loc, triton::gpu::MemDescType memDescTy,
-                  SharedMemoryObject smemObj, Type llvmElemTy,
-                  ArrayRef<Value> idxValues,
-                  ArrayRef<SmallVector<Value>> coords, unsigned axis,
-                  RewriterBase &rewriter);
+SmallVector<LocalSharedMemoryAddress> computeLocalAddrs(
+    Location loc, triton::gpu::MemDescType memDescTy,
+    SharedMemoryObject smemObj, Type llvmElemTy, ArrayRef<Value> idxValues,
+    ArrayRef<SmallVector<Value>> coords, unsigned axis, RewriterBase &rewriter);
 
 SmallVector<Value> computeLocalPtrs(Location loc,
                                     triton::gpu::MemDescType memDescTy,

--- a/include/triton/Conversion/TritonGPUToLLVM/Utility.h
+++ b/include/triton/Conversion/TritonGPUToLLVM/Utility.h
@@ -616,14 +616,8 @@ struct LocalSharedMemoryAddress {
 SmallVector<LocalSharedMemoryAddress> computeLocalAddrs(
     Location loc, triton::gpu::MemDescType memDescTy,
     SharedMemoryObject smemObj, Type llvmElemTy, ArrayRef<Value> idxValues,
-    ArrayRef<SmallVector<Value>> coords, unsigned axis, RewriterBase &rewriter);
-
-SmallVector<LocalSharedMemoryAddress>
-computeLocalAddrs(Location loc, triton::gpu::MemDescType memDescTy,
-                  SharedMemoryObject smemObj, Type llvmElemTy,
-                  ArrayRef<Value> idxValues,
-                  ArrayRef<SmallVector<Value>> coords, unsigned axis,
-                  ArrayRef<Value> offsets, RewriterBase &rewriter);
+    ArrayRef<SmallVector<Value>> coords, unsigned axis, RewriterBase &rewriter,
+    ArrayRef<Value> offsets = {});
 
 SmallVector<Value> computeLocalPtrs(Location loc,
                                     triton::gpu::MemDescType memDescTy,

--- a/include/triton/Conversion/TritonGPUToLLVM/Utility.h
+++ b/include/triton/Conversion/TritonGPUToLLVM/Utility.h
@@ -605,9 +605,21 @@ emitIndices(Location loc, RewriterBase &rewriter, const TargetInfoBase &target,
             const LinearLayout &layout, RankedTensorType type,
             bool withCTAOffset);
 
-// Compute per-element shared-memory pointers for a local atomic/ldst update by
+struct LocalSharedMemoryAddress {
+  Value ptr;
+  std::optional<Value> ctaId;
+};
+
+// Compute per-element shared-memory addresses for a local atomic/ldst update by
 // replacing `coords[*][axis]` with `idxValues[*]` and mapping the resulting
-// logical coordinates back to shared-memory offsets.
+// logical coordinates back to shared-memory offsets and target CTAs.
+SmallVector<LocalSharedMemoryAddress>
+computeLocalAddrs(Location loc, triton::gpu::MemDescType memDescTy,
+                  SharedMemoryObject smemObj, Type llvmElemTy,
+                  ArrayRef<Value> idxValues,
+                  ArrayRef<SmallVector<Value>> coords, unsigned axis,
+                  RewriterBase &rewriter);
+
 SmallVector<Value> computeLocalPtrs(Location loc,
                                     triton::gpu::MemDescType memDescTy,
                                     SharedMemoryObject smemObj, Type llvmElemTy,

--- a/include/triton/Conversion/TritonGPUToLLVM/Utility.h
+++ b/include/triton/Conversion/TritonGPUToLLVM/Utility.h
@@ -613,11 +613,12 @@ struct LocalSharedMemoryAddress {
 // Compute per-element shared-memory addresses for a local atomic/ldst update by
 // replacing `coords[*][axis]` with `idxValues[*]` and mapping the resulting
 // logical coordinates back to shared-memory offsets and target CTAs.
-SmallVector<LocalSharedMemoryAddress> computeLocalAddrs(
-    Location loc, triton::gpu::MemDescType memDescTy,
-    SharedMemoryObject smemObj, Type llvmElemTy, ArrayRef<Value> idxValues,
-    ArrayRef<SmallVector<Value>> coords, unsigned axis, RewriterBase &rewriter,
-    ArrayRef<Value> offsets = {});
+SmallVector<LocalSharedMemoryAddress>
+computeLocalAddrs(Location loc, triton::gpu::MemDescType memDescTy,
+                  SharedMemoryObject smemObj, Type llvmElemTy,
+                  ArrayRef<Value> idxValues,
+                  ArrayRef<SmallVector<Value>> coords, unsigned axis,
+                  RewriterBase &rewriter, ArrayRef<Value> offsets = {});
 
 SmallVector<Value> computeLocalPtrs(Location loc,
                                     triton::gpu::MemDescType memDescTy,

--- a/include/triton/Conversion/TritonGPUToLLVM/Utility.h
+++ b/include/triton/Conversion/TritonGPUToLLVM/Utility.h
@@ -618,12 +618,24 @@ SmallVector<LocalSharedMemoryAddress> computeLocalAddrs(
     SharedMemoryObject smemObj, Type llvmElemTy, ArrayRef<Value> idxValues,
     ArrayRef<SmallVector<Value>> coords, unsigned axis, RewriterBase &rewriter);
 
+SmallVector<LocalSharedMemoryAddress>
+computeLocalAddrs(Location loc, triton::gpu::MemDescType memDescTy,
+                  SharedMemoryObject smemObj, Type llvmElemTy,
+                  ArrayRef<Value> idxValues,
+                  ArrayRef<SmallVector<Value>> coords, unsigned axis,
+                  ArrayRef<Value> offsets, RewriterBase &rewriter);
+
 SmallVector<Value> computeLocalPtrs(Location loc,
                                     triton::gpu::MemDescType memDescTy,
                                     SharedMemoryObject smemObj, Type llvmElemTy,
                                     ArrayRef<Value> idxValues,
                                     ArrayRef<SmallVector<Value>> coords,
                                     unsigned axis, RewriterBase &rewriter);
+
+SmallVector<Value> loadLocalAddrs(Location loc, Type llvmElemTy,
+                                  ArrayRef<LocalSharedMemoryAddress> addrs,
+                                  RewriterBase &rewriter,
+                                  const TargetInfoBase &targetInfo);
 
 // Backend-agnostic preparation for lowering LocalAtomicScatterRMWOp.
 struct LocalAtomicScatterRMWInfo {

--- a/include/triton/Dialect/Triton/IR/TritonOpInterfaces.td
+++ b/include/triton/Dialect/Triton/IR/TritonOpInterfaces.td
@@ -58,7 +58,13 @@ def DotOpInterface : OpInterface<"DotOpInterface"> {
       /*desc=*/"Verify the dimensions of the A and B DotOp operands.",
       /*retType=*/"bool",
       /*methodName=*/"verifyDims",
-      /*args=*/(ins)>,
+      /*args=*/(ins),
+      /*methodBody=*/[{}],
+      /*defaultImpl=*/ [{
+        auto aShape = cast<ShapedType>($_op.getA().getType()).getShape();
+        auto bShape = cast<ShapedType>($_op.getB().getType()).getShape();
+        return aShape.back() == bShape[bShape.size() - 2];
+      }]>,
   InterfaceMethod<
       /*desc=*/"Verify the dimensions of the DotOp output.",
       /*retType=*/"bool",

--- a/include/triton/Dialect/TritonGPU/IR/Dialect.h
+++ b/include/triton/Dialect/TritonGPU/IR/Dialect.h
@@ -278,6 +278,12 @@ SmallVector<int64_t> getAllocationShapePerCTA(Type type);
 
 unsigned getNumCTAs(Attribute layout);
 
+// Returns the MMAv2 warp distribution for a matrix tile. This does not apply
+// dot-chain policy and may oversubscribe tiles with fewer instruction
+// repetitions than warps.
+SmallVector<unsigned> getMmaV2WarpsPerCTA(ArrayRef<int64_t> shape,
+                                          int numWarps);
+
 // Return the order that represents that the batch is in row-major or
 // column-major order for a batch of matrices of shape [*, m, n] with
 // len(shape) == rank.

--- a/include/triton/Dialect/TritonInstrument/IR/TritonInstrumentOps.td
+++ b/include/triton/Dialect/TritonInstrument/IR/TritonInstrumentOps.td
@@ -5,6 +5,7 @@ include "triton/Dialect/TritonInstrument/IR/TritonInstrumentDialect.td"
 include "triton/Dialect/TritonGPU/IR/TritonGPUTypes.td"
 include "triton/Dialect/Triton/IR/TritonTypes.td"
 include "triton/Dialect/Triton/IR/TritonInterfaces.td"
+include "triton/Dialect/Triton/IR/TritonOpInterfaces.td"
 include "triton/Dialect/Triton/IR/TritonAttrDefs.td"
 include "mlir/IR/OpBase.td"
 include "mlir/Interfaces/SideEffectInterfaces.td"
@@ -209,6 +210,32 @@ def TTI_ExperimentalLockReleaseOp : TTI_Op<"experimental_lock_release", [MemoryE
 
 // ===== FPSan ops =====
 
+
+def TTI_DotI8Op : TTI_Op<"dot_i8", [
+  Pure,
+  DeclareOpInterfaceMethods<DotOpInterface>,
+  TypesMatchWith<"result's type matches accumulator's type",
+                 "d", "c", "$_self">
+]> {
+  let summary = "non-saturating NVIDIA MMAv2 i8 dot";
+  let description = [{
+    Performs a wrapping i8 matrix multiplication into an i32 accumulator using
+    NVIDIA MMAv2. The A and B operands have independent signedness.
+  }];
+  let arguments = (ins
+    RankedTensorOf<[I8]>:$a,
+    RankedTensorOf<[I8]>:$b,
+    RankedTensorOf<[I32]>:$c,
+    BoolAttr:$aSigned,
+    BoolAttr:$bSigned
+  );
+  let results = (outs RankedTensorOf<[I32]>:$d);
+  let assemblyFormat = [{
+    $a `,` $b `,` $c `,` `aSigned` `=` $aSigned `,` `bSigned` `=` $bSigned
+    attr-dict `:` type($a) `*` type($b) `->` type($d)
+  }];
+  let hasVerifier = 1;
+}
 
 def TTI_ExperimentalFPSanEmbedOp : TTI_Op<"experimental_fpsan_embed", [
   Pure,

--- a/include/triton/Dialect/TritonInstrument/IR/TritonInstrumentOps.td
+++ b/include/triton/Dialect/TritonInstrument/IR/TritonInstrumentOps.td
@@ -15,6 +15,7 @@ include "triton/Dialect/TritonInstrument/IR/TritonInstrumentAttrDefs.td"
 // Interfaces
 //
 def GlobalMemory : Resource<"::mlir::triton::GlobalMemory">;
+def SharedMemory : Resource<"::mlir::triton::gpu::SharedMemory">;
 
 //
 // Ops
@@ -76,6 +77,29 @@ def TTI_ExperimentalClusterCTAIdOp
     }]>
   ];
   let assemblyFormat = "attr-dict `:` type($result)";
+}
+
+def TTI_ExperimentalLocalGatherOp
+    : TTI_Op<"experimental_local_gather"> {
+  let summary = "Gather elements from shared memory with logical base offsets";
+  let description = [{
+    Gather elements from a shared memory descriptor using an index tensor along
+    one axis, after shifting the logical source coordinates by rank-sized scalar
+    offsets. This is intentionally private to instrumentation passes.
+  }];
+  let arguments = (ins
+    Arg<TTG_MemDescType, "", [MemRead<SharedMemory>]>:$src,
+    TT_IntTensor:$indices,
+    Variadic<I32>:$offsets,
+    I32Attr:$axis
+  );
+  let results = (outs TT_Tensor:$result);
+
+  let assemblyFormat = [{
+    $src `[` $indices `]` `offsets` `=` `[` $offsets `]`
+    attr-dict `:` qualified(type($src)) `,` type($indices) `->` type($result)
+  }];
+  let hasVerifier = 1;
 }
 
 def TTI_ExperimentalGSanInitOp

--- a/lib/Analysis/Utility.cpp
+++ b/lib/Analysis/Utility.cpp
@@ -1242,6 +1242,12 @@ bool supportMMA(triton::DotOp op, int version) {
   return supportMMA(op.getA(), version) && supportMMA(op.getB(), version);
 }
 
+bool supportMMA(triton::DotOpInterface op, int version) {
+  if (auto dotOp = dyn_cast<triton::DotOp>(op.getOperation()))
+    return supportMMA(dotOp, version);
+  return supportMMA(op.getA(), version) && supportMMA(op.getB(), version);
+}
+
 bool supportMMA(Value value, int version) {
   // Tell whether a DotOp support MMA by the operand type(either $a or $b).
   // We cannot get both the operand types(in TypeConverter), here we assume the

--- a/lib/Conversion/TritonGPUToLLVM/MemoryOpToLLVM.cpp
+++ b/lib/Conversion/TritonGPUToLLVM/MemoryOpToLLVM.cpp
@@ -18,7 +18,7 @@ using namespace mlir::triton::gpu;
 // For gather: storeVals is empty, returns loaded values.
 // For scatter: storeVals contains values to store, returns empty.
 SmallVector<Value>
-lowerLocalScGt(Location loc, MemDescType memDescTy,
+lowerLocalScGt(Location loc, MLIRContext *ctx, MemDescType memDescTy,
                SharedMemoryObject smemObj, Type llvmElemTy,
                ArrayRef<Value> idxValues, ArrayRef<SmallVector<Value>> coords,
                unsigned axis, ArrayRef<Value> storeVals, RewriterBase &rewriter,
@@ -27,15 +27,37 @@ lowerLocalScGt(Location loc, MemDescType memDescTy,
   bool isScatter = !storeVals.empty();
   SmallVector<LocalSharedMemoryAddress> addrs = computeLocalAddrs(
       loc, memDescTy, smemObj, llvmElemTy, idxValues, coords, axis, rewriter);
+  Value currentCtaId;
+  if (!addrs.empty() && addrs.front().ctaId)
+    currentCtaId = targetInfo.getClusterCTAId(rewriter, loc);
 
   SmallVector<Value> results;
+  if (!isScatter)
+    results.resize(coords.size());
+
   for (auto [i, addr] : llvm::enumerate(addrs)) {
     if (isScatter) {
-      targetInfo.storeDShared(rewriter, loc, addr.ptr, addr.ctaId, storeVals[i],
-                              b.true_val());
+      if (addr.ctaId) {
+        Value isLocal = b.icmp_eq(*addr.ctaId, currentCtaId);
+        Value isRemote = b.icmp_ne(*addr.ctaId, currentCtaId);
+        targetInfo.storeShared(rewriter, loc, addr.ptr, storeVals[i], isLocal);
+        targetInfo.storeDShared(rewriter, loc, addr.ptr, addr.ctaId,
+                                storeVals[i], isRemote);
+      } else {
+        targetInfo.storeShared(rewriter, loc, addr.ptr, storeVals[i],
+                               b.true_val());
+      }
+    } else if (addr.ctaId) {
+      Value isLocal = b.icmp_eq(*addr.ctaId, currentCtaId);
+      Value isRemote = b.icmp_ne(*addr.ctaId, currentCtaId);
+      Value local =
+          targetInfo.loadShared(rewriter, loc, addr.ptr, llvmElemTy, isLocal);
+      Value remote = targetInfo.loadDShared(rewriter, loc, addr.ptr, addr.ctaId,
+                                            llvmElemTy, isRemote);
+      results[i] = b.select(isLocal, local, remote);
     } else {
-      results.push_back(targetInfo.loadDShared(
-          rewriter, loc, addr.ptr, addr.ctaId, llvmElemTy, b.true_val()));
+      results[i] = targetInfo.loadShared(rewriter, loc, addr.ptr, llvmElemTy,
+                                         b.true_val());
     }
   }
 
@@ -263,6 +285,7 @@ public:
   matchAndRewrite(LocalGatherOp op, OpAdaptor adaptor,
                   ConversionPatternRewriter &rewriter) const override {
     auto loc = op.getLoc();
+    auto *ctx = op.getContext();
     auto memDescTy = cast<MemDescType>(op.getSrc().getType());
     auto regTy = cast<RankedTensorType>(op.getType());
     auto typeConverter = getTypeConverter();
@@ -277,7 +300,7 @@ public:
         emitIndices(loc, rewriter, targetInfo, regTy.getEncoding(), regTy,
                     /*withCTAOffset=*/true);
 
-    auto results = lowerLocalScGt(loc, memDescTy, smemObj, llvmElemTy,
+    auto results = lowerLocalScGt(loc, ctx, memDescTy, smemObj, llvmElemTy,
                                   idxValues, dstIndices, op.getAxis(),
                                   /*storeVals=*/{}, rewriter, targetInfo);
 
@@ -304,6 +327,7 @@ public:
   matchAndRewrite(LocalScatterOp op, OpAdaptor adaptor,
                   ConversionPatternRewriter &rewriter) const override {
     auto loc = op.getLoc();
+    auto *ctx = op.getContext();
     auto memDescTy = cast<MemDescType>(op.getDst().getType());
     auto valuesTy = cast<RankedTensorType>(op.getValues().getType());
     auto typeConverter = getTypeConverter();
@@ -320,7 +344,7 @@ public:
         emitIndices(loc, rewriter, targetInfo, valuesTy.getEncoding(), valuesTy,
                     /*withCTAOffset=*/true);
 
-    lowerLocalScGt(loc, memDescTy, smemObj, llvmElemTy, idxValues,
+    lowerLocalScGt(loc, ctx, memDescTy, smemObj, llvmElemTy, idxValues,
                    srcIndices, op.getAxis(), values, rewriter, targetInfo);
 
     rewriter.eraseOp(op);

--- a/lib/Conversion/TritonGPUToLLVM/MemoryOpToLLVM.cpp
+++ b/lib/Conversion/TritonGPUToLLVM/MemoryOpToLLVM.cpp
@@ -24,17 +24,16 @@ lowerLocalScGt(Location loc, MLIRContext *ctx, MemDescType memDescTy,
                unsigned axis, ArrayRef<Value> storeVals, RewriterBase &rewriter,
                const TargetInfoBase &targetInfo) {
   auto b = TritonLLVMOpBuilder(loc, rewriter);
-  bool isScatter = !storeVals.empty();
   SmallVector<LocalSharedMemoryAddress> addrs = computeLocalAddrs(
       loc, memDescTy, smemObj, llvmElemTy, idxValues, coords, axis, rewriter);
-
-  SmallVector<Value> results;
-  if (!isScatter)
+  if (storeVals.empty())
     return loadLocalAddrs(loc, llvmElemTy, addrs, rewriter, targetInfo);
 
   Value currentCtaId;
   if (!addrs.empty() && addrs.front().ctaId)
     currentCtaId = targetInfo.getClusterCTAId(rewriter, loc);
+
+  SmallVector<Value> results;
   for (auto [i, addr] : llvm::enumerate(addrs)) {
     if (addr.ctaId) {
       Value isLocal = b.icmp_eq(*addr.ctaId, currentCtaId);

--- a/lib/Conversion/TritonGPUToLLVM/MemoryOpToLLVM.cpp
+++ b/lib/Conversion/TritonGPUToLLVM/MemoryOpToLLVM.cpp
@@ -27,37 +27,24 @@ lowerLocalScGt(Location loc, MLIRContext *ctx, MemDescType memDescTy,
   bool isScatter = !storeVals.empty();
   SmallVector<LocalSharedMemoryAddress> addrs = computeLocalAddrs(
       loc, memDescTy, smemObj, llvmElemTy, idxValues, coords, axis, rewriter);
-  Value currentCtaId;
-  if (!addrs.empty() && addrs.front().ctaId)
-    currentCtaId = targetInfo.getClusterCTAId(rewriter, loc);
 
   SmallVector<Value> results;
   if (!isScatter)
-    results.resize(coords.size());
+    return loadLocalAddrs(loc, llvmElemTy, addrs, rewriter, targetInfo);
 
+  Value currentCtaId;
+  if (!addrs.empty() && addrs.front().ctaId)
+    currentCtaId = targetInfo.getClusterCTAId(rewriter, loc);
   for (auto [i, addr] : llvm::enumerate(addrs)) {
-    if (isScatter) {
-      if (addr.ctaId) {
-        Value isLocal = b.icmp_eq(*addr.ctaId, currentCtaId);
-        Value isRemote = b.icmp_ne(*addr.ctaId, currentCtaId);
-        targetInfo.storeShared(rewriter, loc, addr.ptr, storeVals[i], isLocal);
-        targetInfo.storeDShared(rewriter, loc, addr.ptr, addr.ctaId,
-                                storeVals[i], isRemote);
-      } else {
-        targetInfo.storeShared(rewriter, loc, addr.ptr, storeVals[i],
-                               b.true_val());
-      }
-    } else if (addr.ctaId) {
+    if (addr.ctaId) {
       Value isLocal = b.icmp_eq(*addr.ctaId, currentCtaId);
       Value isRemote = b.icmp_ne(*addr.ctaId, currentCtaId);
-      Value local =
-          targetInfo.loadShared(rewriter, loc, addr.ptr, llvmElemTy, isLocal);
-      Value remote = targetInfo.loadDShared(rewriter, loc, addr.ptr, addr.ctaId,
-                                            llvmElemTy, isRemote);
-      results[i] = b.select(isLocal, local, remote);
+      targetInfo.storeShared(rewriter, loc, addr.ptr, storeVals[i], isLocal);
+      targetInfo.storeDShared(rewriter, loc, addr.ptr, addr.ctaId, storeVals[i],
+                              isRemote);
     } else {
-      results[i] = targetInfo.loadShared(rewriter, loc, addr.ptr, llvmElemTy,
-                                         b.true_val());
+      targetInfo.storeShared(rewriter, loc, addr.ptr, storeVals[i],
+                             b.true_val());
     }
   }
 

--- a/lib/Conversion/TritonGPUToLLVM/MemoryOpToLLVM.cpp
+++ b/lib/Conversion/TritonGPUToLLVM/MemoryOpToLLVM.cpp
@@ -25,19 +25,41 @@ lowerLocalScGt(Location loc, MLIRContext *ctx, MemDescType memDescTy,
                const TargetInfoBase &targetInfo) {
   auto b = TritonLLVMOpBuilder(loc, rewriter);
   bool isScatter = !storeVals.empty();
-  SmallVector<Value> ptrs = computeLocalPtrs(
+  SmallVector<LocalSharedMemoryAddress> addrs = computeLocalAddrs(
       loc, memDescTy, smemObj, llvmElemTy, idxValues, coords, axis, rewriter);
+  Value currentCtaId;
+  if (llvm::any_of(addrs, [](const LocalSharedMemoryAddress &addr) {
+        return addr.ctaId.has_value();
+      }))
+    currentCtaId = targetInfo.getClusterCTAId(rewriter, loc);
 
   SmallVector<Value> results;
   if (!isScatter)
     results.resize(coords.size());
 
-  for (auto [i, ptr] : llvm::enumerate(ptrs)) {
+  for (auto [i, addr] : llvm::enumerate(addrs)) {
     if (isScatter) {
-      targetInfo.storeShared(rewriter, loc, ptr, storeVals[i], b.true_val());
+      if (addr.ctaId) {
+        Value isLocal = b.icmp_eq(*addr.ctaId, currentCtaId);
+        Value isRemote = b.icmp_ne(*addr.ctaId, currentCtaId);
+        targetInfo.storeShared(rewriter, loc, addr.ptr, storeVals[i], isLocal);
+        targetInfo.storeDShared(rewriter, loc, addr.ptr, addr.ctaId,
+                                storeVals[i], isRemote);
+      } else {
+        targetInfo.storeShared(rewriter, loc, addr.ptr, storeVals[i],
+                               b.true_val());
+      }
+    } else if (addr.ctaId) {
+      Value isLocal = b.icmp_eq(*addr.ctaId, currentCtaId);
+      Value isRemote = b.icmp_ne(*addr.ctaId, currentCtaId);
+      Value local =
+          targetInfo.loadShared(rewriter, loc, addr.ptr, llvmElemTy, isLocal);
+      Value remote = targetInfo.loadDShared(rewriter, loc, addr.ptr, addr.ctaId,
+                                            llvmElemTy, isRemote);
+      results[i] = b.select(isLocal, local, remote);
     } else {
-      results[i] =
-          targetInfo.loadShared(rewriter, loc, ptr, llvmElemTy, b.true_val());
+      results[i] = targetInfo.loadShared(rewriter, loc, addr.ptr, llvmElemTy,
+                                         b.true_val());
     }
   }
 
@@ -267,13 +289,6 @@ public:
     auto loc = op.getLoc();
     auto *ctx = op.getContext();
     auto memDescTy = cast<MemDescType>(op.getSrc().getType());
-    // TODO: PartitionedSharedEncoding lowering will be enabled in subsequent
-    // PRs.
-    if (isa<triton::gpu::PartitionedSharedEncodingAttr>(
-            memDescTy.getEncoding())) {
-      return rewriter.notifyMatchFailure(
-          op, "PartitionedSharedEncoding not yet supported in lowering");
-    }
     auto regTy = cast<RankedTensorType>(op.getType());
     auto typeConverter = getTypeConverter();
 
@@ -316,13 +331,6 @@ public:
     auto loc = op.getLoc();
     auto *ctx = op.getContext();
     auto memDescTy = cast<MemDescType>(op.getDst().getType());
-    // TODO: PartitionedSharedEncoding lowering will be enabled in subsequent
-    // PRs.
-    if (isa<triton::gpu::PartitionedSharedEncodingAttr>(
-            memDescTy.getEncoding())) {
-      return rewriter.notifyMatchFailure(
-          op, "PartitionedSharedEncoding not yet supported in lowering");
-    }
     auto valuesTy = cast<RankedTensorType>(op.getValues().getType());
     auto typeConverter = getTypeConverter();
 

--- a/lib/Conversion/TritonGPUToLLVM/MemoryOpToLLVM.cpp
+++ b/lib/Conversion/TritonGPUToLLVM/MemoryOpToLLVM.cpp
@@ -18,7 +18,7 @@ using namespace mlir::triton::gpu;
 // For gather: storeVals is empty, returns loaded values.
 // For scatter: storeVals contains values to store, returns empty.
 SmallVector<Value>
-lowerLocalScGt(Location loc, MLIRContext *ctx, MemDescType memDescTy,
+lowerLocalScGt(Location loc, MemDescType memDescTy,
                SharedMemoryObject smemObj, Type llvmElemTy,
                ArrayRef<Value> idxValues, ArrayRef<SmallVector<Value>> coords,
                unsigned axis, ArrayRef<Value> storeVals, RewriterBase &rewriter,
@@ -27,39 +27,15 @@ lowerLocalScGt(Location loc, MLIRContext *ctx, MemDescType memDescTy,
   bool isScatter = !storeVals.empty();
   SmallVector<LocalSharedMemoryAddress> addrs = computeLocalAddrs(
       loc, memDescTy, smemObj, llvmElemTy, idxValues, coords, axis, rewriter);
-  Value currentCtaId;
-  if (llvm::any_of(addrs, [](const LocalSharedMemoryAddress &addr) {
-        return addr.ctaId.has_value();
-      }))
-    currentCtaId = targetInfo.getClusterCTAId(rewriter, loc);
 
   SmallVector<Value> results;
-  if (!isScatter)
-    results.resize(coords.size());
-
   for (auto [i, addr] : llvm::enumerate(addrs)) {
     if (isScatter) {
-      if (addr.ctaId) {
-        Value isLocal = b.icmp_eq(*addr.ctaId, currentCtaId);
-        Value isRemote = b.icmp_ne(*addr.ctaId, currentCtaId);
-        targetInfo.storeShared(rewriter, loc, addr.ptr, storeVals[i], isLocal);
-        targetInfo.storeDShared(rewriter, loc, addr.ptr, addr.ctaId,
-                                storeVals[i], isRemote);
-      } else {
-        targetInfo.storeShared(rewriter, loc, addr.ptr, storeVals[i],
-                               b.true_val());
-      }
-    } else if (addr.ctaId) {
-      Value isLocal = b.icmp_eq(*addr.ctaId, currentCtaId);
-      Value isRemote = b.icmp_ne(*addr.ctaId, currentCtaId);
-      Value local =
-          targetInfo.loadShared(rewriter, loc, addr.ptr, llvmElemTy, isLocal);
-      Value remote = targetInfo.loadDShared(rewriter, loc, addr.ptr, addr.ctaId,
-                                            llvmElemTy, isRemote);
-      results[i] = b.select(isLocal, local, remote);
+      targetInfo.storeDShared(rewriter, loc, addr.ptr, addr.ctaId, storeVals[i],
+                              b.true_val());
     } else {
-      results[i] = targetInfo.loadShared(rewriter, loc, addr.ptr, llvmElemTy,
-                                         b.true_val());
+      results.push_back(targetInfo.loadDShared(
+          rewriter, loc, addr.ptr, addr.ctaId, llvmElemTy, b.true_val()));
     }
   }
 
@@ -287,7 +263,6 @@ public:
   matchAndRewrite(LocalGatherOp op, OpAdaptor adaptor,
                   ConversionPatternRewriter &rewriter) const override {
     auto loc = op.getLoc();
-    auto *ctx = op.getContext();
     auto memDescTy = cast<MemDescType>(op.getSrc().getType());
     auto regTy = cast<RankedTensorType>(op.getType());
     auto typeConverter = getTypeConverter();
@@ -302,7 +277,7 @@ public:
         emitIndices(loc, rewriter, targetInfo, regTy.getEncoding(), regTy,
                     /*withCTAOffset=*/true);
 
-    auto results = lowerLocalScGt(loc, ctx, memDescTy, smemObj, llvmElemTy,
+    auto results = lowerLocalScGt(loc, memDescTy, smemObj, llvmElemTy,
                                   idxValues, dstIndices, op.getAxis(),
                                   /*storeVals=*/{}, rewriter, targetInfo);
 
@@ -329,7 +304,6 @@ public:
   matchAndRewrite(LocalScatterOp op, OpAdaptor adaptor,
                   ConversionPatternRewriter &rewriter) const override {
     auto loc = op.getLoc();
-    auto *ctx = op.getContext();
     auto memDescTy = cast<MemDescType>(op.getDst().getType());
     auto valuesTy = cast<RankedTensorType>(op.getValues().getType());
     auto typeConverter = getTypeConverter();
@@ -346,7 +320,7 @@ public:
         emitIndices(loc, rewriter, targetInfo, valuesTy.getEncoding(), valuesTy,
                     /*withCTAOffset=*/true);
 
-    lowerLocalScGt(loc, ctx, memDescTy, smemObj, llvmElemTy, idxValues,
+    lowerLocalScGt(loc, memDescTy, smemObj, llvmElemTy, idxValues,
                    srcIndices, op.getAxis(), values, rewriter, targetInfo);
 
     rewriter.eraseOp(op);

--- a/lib/Conversion/TritonGPUToLLVM/Utility.cpp
+++ b/lib/Conversion/TritonGPUToLLVM/Utility.cpp
@@ -545,17 +545,7 @@ computeLocalAddrs(Location loc, triton::gpu::MemDescType memDescTy,
                   SharedMemoryObject smemObj, Type llvmElemTy,
                   ArrayRef<Value> idxValues,
                   ArrayRef<SmallVector<Value>> coords, unsigned axis,
-                  RewriterBase &rewriter) {
-  return computeLocalAddrs(loc, memDescTy, smemObj, llvmElemTy, idxValues,
-                           coords, axis, /*offsets=*/{}, rewriter);
-}
-
-SmallVector<LocalSharedMemoryAddress>
-computeLocalAddrs(Location loc, triton::gpu::MemDescType memDescTy,
-                  SharedMemoryObject smemObj, Type llvmElemTy,
-                  ArrayRef<Value> idxValues,
-                  ArrayRef<SmallVector<Value>> coords, unsigned axis,
-                  ArrayRef<Value> offsets, RewriterBase &rewriter) {
+                  RewriterBase &rewriter, ArrayRef<Value> offsets) {
   MLIRContext *ctx = memDescTy.getContext();
   auto b = TritonLLVMOpBuilder(loc, rewriter);
 
@@ -670,29 +660,22 @@ SmallVector<Value> loadLocalAddrs(Location loc, Type llvmElemTy,
                                   const TargetInfoBase &targetInfo) {
   auto b = TritonLLVMOpBuilder(loc, rewriter);
   Value currentCtaId;
-  if (llvm::any_of(addrs, [](const LocalSharedMemoryAddress &addr) {
-        return addr.ctaId.has_value();
-      }))
+  if (!addrs.empty() && addrs.front().ctaId)
     currentCtaId = targetInfo.getClusterCTAId(rewriter, loc);
 
-  SmallVector<Value> results;
-  results.reserve(addrs.size());
-  for (const LocalSharedMemoryAddress &addr : addrs) {
-    if (!addr.ctaId) {
-      results.push_back(targetInfo.loadShared(rewriter, loc, addr.ptr,
-                                              llvmElemTy, b.true_val()));
-      continue;
-    }
-
-    Value isLocal = b.icmp_eq(*addr.ctaId, currentCtaId);
-    Value isRemote = b.icmp_ne(*addr.ctaId, currentCtaId);
-    Value local =
-        targetInfo.loadShared(rewriter, loc, addr.ptr, llvmElemTy, isLocal);
-    Value remote = targetInfo.loadDShared(rewriter, loc, addr.ptr, addr.ctaId,
-                                          llvmElemTy, isRemote);
-    results.push_back(b.select(isLocal, local, remote));
-  }
-  return results;
+  return llvm::map_to_vector(
+      addrs, [&](const LocalSharedMemoryAddress &addr) -> Value {
+        if (!addr.ctaId)
+          return targetInfo.loadShared(rewriter, loc, addr.ptr, llvmElemTy,
+                                       b.true_val());
+        Value isLocal = b.icmp_eq(*addr.ctaId, currentCtaId);
+        Value local =
+            targetInfo.loadShared(rewriter, loc, addr.ptr, llvmElemTy, isLocal);
+        Value remote = targetInfo.loadDShared(
+            rewriter, loc, addr.ptr, addr.ctaId, llvmElemTy,
+            b.icmp_ne(*addr.ctaId, currentCtaId));
+        return b.select(isLocal, local, remote);
+      });
 }
 
 FailureOr<LocalAtomicScatterRMWInfo> prepareLocalAtomicScatterRMW(

--- a/lib/Conversion/TritonGPUToLLVM/Utility.cpp
+++ b/lib/Conversion/TritonGPUToLLVM/Utility.cpp
@@ -546,6 +546,16 @@ computeLocalAddrs(Location loc, triton::gpu::MemDescType memDescTy,
                   ArrayRef<Value> idxValues,
                   ArrayRef<SmallVector<Value>> coords, unsigned axis,
                   RewriterBase &rewriter) {
+  return computeLocalAddrs(loc, memDescTy, smemObj, llvmElemTy, idxValues,
+                           coords, axis, /*offsets=*/{}, rewriter);
+}
+
+SmallVector<LocalSharedMemoryAddress>
+computeLocalAddrs(Location loc, triton::gpu::MemDescType memDescTy,
+                  SharedMemoryObject smemObj, Type llvmElemTy,
+                  ArrayRef<Value> idxValues,
+                  ArrayRef<SmallVector<Value>> coords, unsigned axis,
+                  ArrayRef<Value> offsets, RewriterBase &rewriter) {
   MLIRContext *ctx = memDescTy.getContext();
   auto b = TritonLLVMOpBuilder(loc, rewriter);
 
@@ -581,9 +591,12 @@ computeLocalAddrs(Location loc, triton::gpu::MemDescType memDescTy,
       idx = b.zext(i32_ty, idx);
     }
 
-    // Copy coordinates and replace the axis coordinate with the index value
+    // Copy coordinates, replace the axis coordinate with the index value, and
+    // then shift all logical coordinates by the optional base offsets.
     SmallVector<Value> indices(coords[i]);
     indices[axis] = idx;
+    for (auto [dim, offset] : llvm::enumerate(offsets))
+      indices[dim] = b.add(indices[dim], offset);
 
     // Apply inverted shared layout to compute offset
     SmallVector<std::pair<StringAttr, Value>> inputs;
@@ -649,6 +662,37 @@ SmallVector<Value> computeLocalPtrs(Location loc,
       computeLocalAddrs(loc, memDescTy, smemObj, llvmElemTy, idxValues, coords,
                         axis, rewriter),
       [](const LocalSharedMemoryAddress &addr) { return addr.ptr; });
+}
+
+SmallVector<Value> loadLocalAddrs(Location loc, Type llvmElemTy,
+                                  ArrayRef<LocalSharedMemoryAddress> addrs,
+                                  RewriterBase &rewriter,
+                                  const TargetInfoBase &targetInfo) {
+  auto b = TritonLLVMOpBuilder(loc, rewriter);
+  Value currentCtaId;
+  if (llvm::any_of(addrs, [](const LocalSharedMemoryAddress &addr) {
+        return addr.ctaId.has_value();
+      }))
+    currentCtaId = targetInfo.getClusterCTAId(rewriter, loc);
+
+  SmallVector<Value> results;
+  results.reserve(addrs.size());
+  for (const LocalSharedMemoryAddress &addr : addrs) {
+    if (!addr.ctaId) {
+      results.push_back(targetInfo.loadShared(rewriter, loc, addr.ptr,
+                                              llvmElemTy, b.true_val()));
+      continue;
+    }
+
+    Value isLocal = b.icmp_eq(*addr.ctaId, currentCtaId);
+    Value isRemote = b.icmp_ne(*addr.ctaId, currentCtaId);
+    Value local =
+        targetInfo.loadShared(rewriter, loc, addr.ptr, llvmElemTy, isLocal);
+    Value remote = targetInfo.loadDShared(rewriter, loc, addr.ptr, addr.ctaId,
+                                          llvmElemTy, isRemote);
+    results.push_back(b.select(isLocal, local, remote));
+  }
+  return results;
 }
 
 FailureOr<LocalAtomicScatterRMWInfo> prepareLocalAtomicScatterRMW(

--- a/lib/Conversion/TritonGPUToLLVM/Utility.cpp
+++ b/lib/Conversion/TritonGPUToLLVM/Utility.cpp
@@ -540,12 +540,12 @@ emitIndices(Location loc, RewriterBase &rewriter, const TargetInfoBase &target,
   return emitIndices(loc, rewriter, target, ll, type, withCTAOffset);
 }
 
-SmallVector<Value> computeLocalPtrs(Location loc,
-                                    triton::gpu::MemDescType memDescTy,
-                                    SharedMemoryObject smemObj, Type llvmElemTy,
-                                    ArrayRef<Value> idxValues,
-                                    ArrayRef<SmallVector<Value>> coords,
-                                    unsigned axis, RewriterBase &rewriter) {
+SmallVector<LocalSharedMemoryAddress>
+computeLocalAddrs(Location loc, triton::gpu::MemDescType memDescTy,
+                  SharedMemoryObject smemObj, Type llvmElemTy,
+                  ArrayRef<Value> idxValues,
+                  ArrayRef<SmallVector<Value>> coords, unsigned axis,
+                  RewriterBase &rewriter) {
   MLIRContext *ctx = memDescTy.getContext();
   auto b = TritonLLVMOpBuilder(loc, rewriter);
 
@@ -561,12 +561,15 @@ SmallVector<Value> computeLocalPtrs(Location loc,
     allDims.push_back(str_attr("dim" + Twine(dim)));
 
   auto kOffset = str_attr("offset");
+  auto kBlock = str_attr("block");
+  bool useBlockId = invSharedLayout.hasOutDim(kBlock) &&
+                    invSharedLayout.getOutDimSize(kBlock) > 1;
   // Get the subslice affine offset (non-zero for memdesc subslices)
   Value affineOffset = smemObj.getShmemOffset(loc, rewriter, memDescTy);
   auto bitwidth = getIntOrFloatOrPtrBitWidth(llvmElemTy);
 
-  SmallVector<Value> ptrs;
-  ptrs.reserve(coords.size());
+  SmallVector<LocalSharedMemoryAddress> addrs;
+  addrs.reserve(coords.size());
 
   for (auto [i, idxVal] : llvm::enumerate(idxValues)) {
     Value idx = idxVal;
@@ -589,15 +592,18 @@ SmallVector<Value> computeLocalPtrs(Location loc,
 
     auto outputs = applyLinearLayout(loc, rewriter, invSharedLayout, inputs);
 
-    // Extract the offset value
+    // Extract the offset and target CTA.
     Value offset = nullptr;
+    Value blockId = nullptr;
     for (auto [name, value] : outputs) {
-      if (name == kOffset) {
+      if (name == kOffset)
         offset = value;
-        break;
-      }
+      else if (name == kBlock)
+        blockId = value;
     }
     assert(offset && "expected offset output from inverted shared layout");
+    assert((!useBlockId || blockId) &&
+           "expected block output from multi-CTA shared layout");
 
     // For subslices, the physical offset is computed as:
     //   physical_offset = L⁻¹(coords) ⊕ L⁻¹(subslice_logical_offset)
@@ -626,10 +632,23 @@ SmallVector<Value> computeLocalPtrs(Location loc,
       ptr = b.gep(smemObj.getBase().getType(), llvmElemTy, smemObj.getBase(),
                   offset);
     }
-    ptrs.push_back(ptr);
+    addrs.push_back(
+        {ptr, useBlockId ? std::optional<Value>(blockId) : std::nullopt});
   }
 
-  return ptrs;
+  return addrs;
+}
+
+SmallVector<Value> computeLocalPtrs(Location loc,
+                                    triton::gpu::MemDescType memDescTy,
+                                    SharedMemoryObject smemObj, Type llvmElemTy,
+                                    ArrayRef<Value> idxValues,
+                                    ArrayRef<SmallVector<Value>> coords,
+                                    unsigned axis, RewriterBase &rewriter) {
+  return llvm::map_to_vector(
+      computeLocalAddrs(loc, memDescTy, smemObj, llvmElemTy, idxValues, coords,
+                        axis, rewriter),
+      [](const LocalSharedMemoryAddress &addr) { return addr.ptr; });
 }
 
 FailureOr<LocalAtomicScatterRMWInfo> prepareLocalAtomicScatterRMW(

--- a/lib/Conversion/TritonInstrumentToLLVM/InstrumentationToLLVM.cpp
+++ b/lib/Conversion/TritonInstrumentToLLVM/InstrumentationToLLVM.cpp
@@ -375,7 +375,7 @@ struct LocalGatherOpConversion
 
     auto addrs =
         computeLocalAddrs(loc, memDescTy, smemObj, llvmElemTy, idxValues,
-                          dstIndices, op.getAxis(), offsets, rewriter);
+                          dstIndices, op.getAxis(), rewriter, offsets);
     auto results = loadLocalAddrs(loc, llvmElemTy, addrs, rewriter, targetInfo);
     Value result = packLLElements(loc, typeConverter, results, rewriter, regTy);
 

--- a/lib/Conversion/TritonInstrumentToLLVM/InstrumentationToLLVM.cpp
+++ b/lib/Conversion/TritonInstrumentToLLVM/InstrumentationToLLVM.cpp
@@ -347,6 +347,46 @@ private:
   const TargetInfoBase &targetInfo;
 };
 
+struct LocalGatherOpConversion
+    : public ConvertOpToLLVMPattern<tti::ExperimentalLocalGatherOp> {
+  LocalGatherOpConversion(const LLVMTypeConverter &converter,
+                          const TargetInfoBase &targetInfo,
+                          PatternBenefit benefit = 1)
+      : ConvertOpToLLVMPattern<tti::ExperimentalLocalGatherOp>(converter,
+                                                               benefit),
+        targetInfo(targetInfo) {}
+
+  LogicalResult
+  matchAndRewrite(tti::ExperimentalLocalGatherOp op, OpAdaptor adaptor,
+                  ConversionPatternRewriter &rewriter) const override {
+    auto loc = op.getLoc();
+    auto memDescTy = cast<ttg::MemDescType>(op.getSrc().getType());
+    auto regTy = cast<RankedTensorType>(op.getType());
+    auto typeConverter = getTypeConverter();
+
+    Type llvmElemTy = typeConverter->convertType(memDescTy.getElementType());
+    auto smemObj = LLVM::getSharedMemoryObjectFromStruct(loc, adaptor.getSrc(),
+                                                         llvmElemTy, rewriter);
+    auto idxValues = unpackLLElements(loc, adaptor.getIndices(), rewriter);
+    auto dstIndices =
+        emitIndices(loc, rewriter, targetInfo, regTy.getEncoding(), regTy,
+                    /*withCTAOffset=*/true);
+    SmallVector<Value> offsets(adaptor.getOffsets());
+
+    auto addrs =
+        computeLocalAddrs(loc, memDescTy, smemObj, llvmElemTy, idxValues,
+                          dstIndices, op.getAxis(), offsets, rewriter);
+    auto results = loadLocalAddrs(loc, llvmElemTy, addrs, rewriter, targetInfo);
+    Value result = packLLElements(loc, typeConverter, results, rewriter, regTy);
+
+    rewriter.replaceOp(op, result);
+    return success();
+  }
+
+private:
+  const TargetInfoBase &targetInfo;
+};
+
 } // namespace
 
 void mlir::triton::populateInstrumentationToLLVMPatterns(
@@ -358,4 +398,5 @@ void mlir::triton::populateInstrumentationToLLVMPatterns(
   patterns.add<LockReleaseOpConversion>(typeConverter, targetInfo);
   patterns.add<MemDescToI32OpConversion>(typeConverter);
   patterns.add<ClusterCTAIdOpConversion>(typeConverter, targetInfo);
+  patterns.add<LocalGatherOpConversion>(typeConverter, targetInfo);
 }

--- a/lib/Dialect/Triton/IR/Ops.cpp
+++ b/lib/Dialect/Triton/IR/Ops.cpp
@@ -283,13 +283,6 @@ LogicalResult DotOp::verify() {
                                                      bEncoding);
 }
 
-bool DotOp::verifyDims() {
-  auto aShape = this->getA().getType().getShape();
-  auto bShape = this->getB().getType().getShape();
-
-  return aShape[aShape.size() - 1] == bShape[aShape.size() - 2];
-}
-
 //-- DotScaledOp --
 bool DotScaledOp::verifyDims() {
   auto aShape = this->getA().getType().getShape();

--- a/lib/Dialect/TritonGPU/IR/Dialect.cpp
+++ b/lib/Dialect/TritonGPU/IR/Dialect.cpp
@@ -3174,8 +3174,8 @@ struct TritonGPUInferLayoutInterface
         dyn_cast_or_null<NvidiaMmaEncodingAttr>(aEncoding.getParent());
     auto mmaBEncoding =
         dyn_cast_or_null<NvidiaMmaEncodingAttr>(bEncoding.getParent());
-    auto dotOp = cast<DotOp>(op);
-    auto resEnc = dotOp.getResult().getType().getEncoding();
+    auto dotOp = cast<DotOpInterface>(op);
+    auto resEnc = cast<RankedTensorType>(dotOp.getD().getType()).getEncoding();
     auto mmaResEncoding = dyn_cast<NvidiaMmaEncodingAttr>(resEnc);
     if (mmaAEncoding || mmaBEncoding || mmaResEncoding) {
       // Check that they are all set and have the same version.

--- a/lib/Dialect/TritonGPU/IR/Dialect.cpp
+++ b/lib/Dialect/TritonGPU/IR/Dialect.cpp
@@ -472,6 +472,30 @@ SmallVector<int64_t> getAllocationShapePerCTA(Type type) {
                                   tensorType.getShape());
 }
 
+SmallVector<unsigned> getMmaV2WarpsPerCTA(ArrayRef<int64_t> shape,
+                                          int numWarps) {
+  if (shape.size() == 3)
+    return {static_cast<unsigned>(numWarps), 1, 1};
+
+  assert(shape.size() == 2);
+  SmallVector<int64_t> reps = {ceil(shape[0], int64_t{16}),
+                               ceil(shape[1], int64_t{8})};
+  SmallVector<unsigned> warps = {1, 1};
+  // Balance repetitions to reduce register pressure, breaking ties toward M
+  // because the lhs instruction tile uses more registers than the rhs.
+  while (product(warps) < numWarps) {
+    if (reps[0] >= reps[1]) {
+      warps[0] *= 2;
+      if (reps[0] != 1)
+        reps[0] /= 2;
+    } else {
+      warps[1] *= 2;
+      reps[1] /= 2;
+    }
+  }
+  return warps;
+}
+
 unsigned getNumCTAs(Attribute layout) {
   return product<unsigned>(getCTAsPerCGA(layout));
 }

--- a/lib/Dialect/TritonGPU/Transforms/AccelerateMatmul.cpp
+++ b/lib/Dialect/TritonGPU/Transforms/AccelerateMatmul.cpp
@@ -88,7 +88,7 @@ SmallVector<unsigned> warpsPerTileV2(DotOpInterface dotOp,
   auto rank = shape.size();
   // Early exit for batched matmul
   if (rank == 3)
-    return {(unsigned)numWarps, 1, 1};
+    return getMmaV2WarpsPerCTA(shape, numWarps);
 
   auto filter = [&dotOp](Operation *op) {
     return op->getParentRegion() == dotOp->getParentRegion() &&
@@ -117,33 +117,7 @@ SmallVector<unsigned> warpsPerTileV2(DotOpInterface dotOp,
     }
   }
 
-  assert(rank == 2);
-  SmallVector<int64_t> shapePerWarp = {16, 8};
-  SmallVector<int64_t> warps = {1, 1};
-  // Compute repM and repN
-  SmallVector<int64_t> reps = {ceil(shape[0], shapePerWarp[0]),
-                               ceil(shape[1], shapePerWarp[1])};
-  // The formula for the number of registers given the reps is
-  // repM * 4 * repK + repN * 2 * repK + regsC
-  // where regsC = repM * repN * 4, which does not depend on the warp shape
-  //
-  // As such, to minimize the register pressure, we need to balance
-  // repM and repN. We then untie towards M, as the lhs tile has 4 elements,
-  // and the rhs tile has just 2.
-  while (product(warps) < numWarps) {
-    if (reps[0] >= reps[1]) {
-      warps[0] *= 2;
-      // Too many warps for this mma (repM == repN == 1).
-      // We allocate the remaining warps to the left (arbitrary choice)
-      if (reps[0] != 1) {
-        reps[0] /= 2;
-      }
-    } else {
-      warps[1] *= 2;
-      reps[1] /= 2;
-    }
-  }
-  return {(unsigned)warps[0], (unsigned)warps[1]};
+  return getMmaV2WarpsPerCTA(shape, numWarps);
 }
 SmallVector<unsigned, 2>
 warpsPerTileV3(DotOpInterface dotOp, const ArrayRef<int64_t> shape,

--- a/lib/Dialect/TritonGPU/Transforms/RemoveLayoutConversions.cpp
+++ b/lib/Dialect/TritonGPU/Transforms/RemoveLayoutConversions.cpp
@@ -202,8 +202,8 @@ bool isLayoutAnchor(Operation *op) {
     return true;
   if (isa<LoadOp, StoreOp>(op))
     return isExpensiveLoadOrStore(op);
-  if (isa<DotOp, DotScaledOp, nvidia_gpu::WarpGroupDotOp, AtomicRMWOp,
-          AtomicCASOp, triton::nvidia_gpu::TMEMLoadOp>(op))
+  if (isa<DotOpInterface, AtomicRMWOp, AtomicCASOp,
+          triton::nvidia_gpu::TMEMLoadOp>(op))
     return true;
   if (auto gatherOp = dyn_cast<GatherOp>(op))
     return gatherOp.getEfficientLayout();
@@ -653,7 +653,7 @@ void LayoutPropagation::rewriteOp(Operation *op) {
 bool canBeRemat(Operation *op) {
   if (isa<LoadOp, StoreOp>(op))
     return !isExpensiveLoadOrStore(op);
-  if (isa<AtomicRMWOp, AtomicCASOp, DotOp>(op))
+  if (isa<AtomicRMWOp, AtomicCASOp, DotOpInterface>(op))
     return false;
   if (auto gather = dyn_cast<GatherOp>(op))
     return !gather.getEfficientLayout();

--- a/lib/Dialect/TritonInstrument/IR/Ops.cpp
+++ b/lib/Dialect/TritonInstrument/IR/Ops.cpp
@@ -40,6 +40,40 @@ LogicalResult DotI8Op::verify() {
                                                            bEnc);
 }
 
+LogicalResult ExperimentalLocalGatherOp::verify() {
+  auto srcTy = getSrc().getType();
+  auto indicesTy = cast<RankedTensorType>(getIndices().getType());
+  auto dstTy = cast<RankedTensorType>(getType());
+  unsigned axis = getAxis();
+
+  if (!isa<ttg::SharedEncodingTrait>(srcTy.getEncoding()))
+    return emitError("source must have shared memory encoding");
+
+  if (!indicesTy.getElementType().isInteger())
+    return emitError("indices must have integer element type");
+
+  if (dstTy.getShape() != indicesTy.getShape())
+    return emitError("result shape must match indices shape");
+
+  if (srcTy.getRank() != indicesTy.getRank())
+    return emitError("source and indices must have the same rank");
+
+  if (axis >= srcTy.getRank())
+    return emitError("axis ")
+           << axis << " is out of bounds for source rank " << srcTy.getRank();
+
+  if (srcTy.getElementType() != dstTy.getElementType())
+    return emitError("result element type must match source element type");
+
+  if (indicesTy.getEncoding() != dstTy.getEncoding())
+    return emitError("indices and result must have the same layout");
+
+  if (static_cast<int64_t>(getOffsets().size()) != srcTy.getRank())
+    return emitError("offset count must match source rank");
+
+  return success();
+}
+
 template <typename ViewOp, typename FPSanOp>
 struct PushFPSanThroughViewPattern : public OpRewritePattern<ViewOp> {
   using OpRewritePattern<ViewOp>::OpRewritePattern;

--- a/lib/Dialect/TritonInstrument/IR/Ops.cpp
+++ b/lib/Dialect/TritonInstrument/IR/Ops.cpp
@@ -16,12 +16,6 @@ namespace instrument {
 namespace tt = mlir::triton;
 namespace ttg = mlir::triton::gpu;
 
-bool DotI8Op::verifyDims() {
-  auto aShape = getA().getType().getShape();
-  auto bShape = getB().getType().getShape();
-  return aShape.back() == bShape[bShape.size() - 2];
-}
-
 LogicalResult DotI8Op::verify() {
   auto aEnc =
       dyn_cast<ttg::DotOperandEncodingAttr>(getA().getType().getEncoding());

--- a/lib/Dialect/TritonInstrument/IR/Ops.cpp
+++ b/lib/Dialect/TritonInstrument/IR/Ops.cpp
@@ -16,6 +16,36 @@ namespace instrument {
 namespace tt = mlir::triton;
 namespace ttg = mlir::triton::gpu;
 
+bool DotI8Op::verifyDims() {
+  auto aShape = getA().getType().getShape();
+  auto bShape = getB().getType().getShape();
+  return aShape.back() == bShape[bShape.size() - 2];
+}
+
+LogicalResult DotI8Op::verify() {
+  auto aEnc =
+      dyn_cast<ttg::DotOperandEncodingAttr>(getA().getType().getEncoding());
+  auto bEnc =
+      dyn_cast<ttg::DotOperandEncodingAttr>(getB().getType().getEncoding());
+  if (!aEnc || !bEnc)
+    return emitError("requires dot operand encodings for A and B");
+
+  auto aMma = dyn_cast<ttg::NvidiaMmaEncodingAttr>(aEnc.getParent());
+  auto bMma = dyn_cast<ttg::NvidiaMmaEncodingAttr>(bEnc.getParent());
+  auto dMma =
+      dyn_cast<ttg::NvidiaMmaEncodingAttr>(getD().getType().getEncoding());
+  if (!aMma || !bMma || !dMma || aMma.getVersionMajor() != 2 ||
+      bMma.getVersionMajor() != 2 || dMma.getVersionMajor() != 2)
+    return emitError("requires NVIDIA MMAv2 operand and result layouts");
+  if (aMma != bMma || aMma != dMma)
+    return emitError("requires matching NVIDIA MMAv2 layouts");
+
+  auto layoutInterface =
+      cast<tt::DialectInferLayoutInterface>(&dMma.getDialect());
+  return layoutInterface->verifyDotOpEncodingCompatibility(getOperation(), aEnc,
+                                                           bEnc);
+}
+
 template <typename ViewOp, typename FPSanOp>
 struct PushFPSanThroughViewPattern : public OpRewritePattern<ViewOp> {
   using OpRewritePattern<ViewOp>::OpRewritePattern;

--- a/lib/Dialect/TritonInstrument/Transforms/FpSanitizer.cpp
+++ b/lib/Dialect/TritonInstrument/Transforms/FpSanitizer.cpp
@@ -3,6 +3,7 @@
 #include "mlir/IR/Types.h"
 #include "mlir/Transforms/GreedyPatternRewriteDriver.h"
 #include "mlir/Transforms/RegionUtils.h"
+#include "triton/Analysis/Utility.h"
 #include "triton/Dialect/Triton/IR/Dialect.h"
 #include "triton/Dialect/TritonGPU/IR/Dialect.h"
 #include "triton/Dialect/TritonGPU/Transforms/Utility.h"
@@ -83,6 +84,21 @@ std::pair<int64_t, int64_t> getMmaEmulationTileShape(PatternRewriter &rewriter,
   return {std::min<int64_t>(kTileM, m), std::min<int64_t>(kTileN, n)};
 }
 
+std::pair<int64_t, int64_t>
+getDirectSharedMmaEmulationTileShape(PatternRewriter &rewriter, int64_t m,
+                                     int64_t n, int64_t k,
+                                     IntegerType accElem) {
+  auto [tileM, tileN] = getMmaEmulationTileShape(rewriter, m, n, k, accElem);
+  int64_t numWarps =
+      ttg::lookupNumWarps(rewriter.getInsertionBlock()->getParent());
+  int64_t widerN = std::min<int64_t>(16 * numWarps, n);
+  while (widerN > tileN && (n % widerN) != 0)
+    widerN /= 2;
+  if (widerN > tileN && getI8MmaWarpsPerCTA(tileM, widerN, numWarps))
+    tileN = widerN;
+  return {tileM, tileN};
+}
+
 Operation *createGlobalScratchBarrier(PatternRewriter &rewriter, Location loc,
                                       bool sharedClusterState = false) {
   Operation *barrier = ttg::BarrierOp::create(rewriter, loc,
@@ -150,6 +166,16 @@ ttg::BlockedEncodingAttr getOptimizedBlockedEncoding(PatternRewriter &rewriter,
 struct ScratchInfo {
   Value ptr;
   RankedTensorType tensorType;
+};
+
+struct MmaOperandSource {
+  Value scratchPtr;
+  Value sharedMemdesc;
+  RankedTensorType tileType;
+  int64_t rowStride;
+  int64_t stride;
+
+  bool isShared() const { return static_cast<bool>(sharedMemdesc); }
 };
 
 struct ScratchState {
@@ -885,31 +911,18 @@ Value fpsanVariadicExternTagged(PatternRewriter &rewriter, Location loc,
 }
 
 std::optional<ScratchInfo>
-createOperandScratch(PatternRewriter &rewriter, Location loc,
-                     TmemScratchManager &scratch, Value memdesc,
-                     ttg::MemDescType memTy, bool isTmem, Region *scope) {
+createTmemOperandScratch(PatternRewriter &rewriter, Location loc,
+                         TmemScratchManager &scratch, Value memdesc,
+                         ttg::MemDescType memTy, Region *scope) {
   auto layout = scratch.getScratchEncoding(rewriter, memdesc, memTy);
   auto tensorTy =
       RankedTensorType::get(memTy.getShape(), memTy.getElementType(), layout);
-  Value fullVal;
-  if (isTmem) {
-    auto info = scratch.getOrCreate(memdesc, rewriter, scope);
-    if (!info)
-      return std::nullopt;
-    fullVal = loadFpSanScratchMemory(rewriter, loc, info->ptr, tensorTy);
-    if (!fullVal)
-      return std::nullopt;
-  } else {
-    if (scratch.usesSharedClusterState()) {
-      // A two-CTA TMA barrier is waited on by the lead CTA. FPSAN executes the
-      // emulated MMA in both CTAs, so rendezvous before the partner snapshots
-      // the shared-memory operand.
-      ttng::ClusterBarrierOp::create(rewriter, loc);
-    }
-    fullVal =
-        ttg::LocalLoadOp::create(rewriter, loc, tensorTy, memdesc, Value())
-            .getResult();
-  }
+  auto info = scratch.getOrCreate(memdesc, rewriter, scope);
+  if (!info)
+    return std::nullopt;
+  Value fullVal = loadFpSanScratchMemory(rewriter, loc, info->ptr, tensorTy);
+  if (!fullVal)
+    return std::nullopt;
   int64_t elSize = memTy.getElementType().getIntOrFloatBitWidth() / 8;
   int64_t alignment = std::max<int64_t>(elSize, 16);
   int64_t sizeInBytes = product(memTy.getShape()) * elSize;
@@ -1023,6 +1036,75 @@ Value loadScratchStrided2D(PatternRewriter &rewriter, Location loc, Value base,
                            RankedTensorType tensorTy, int64_t stride1) {
   return loadScratchStrided2D(rewriter, loc, base, tensorTy, /*stride0=*/1,
                               stride1);
+}
+
+Value loadMmaOperand(PatternRewriter &rewriter, Location loc,
+                     const MmaOperandSource &source, RankedTensorType resultTy,
+                     bool isLhs, Value tileOffset, Value kOffset) {
+  if (!source.isShared()) {
+    Value rowOffset = isLhs ? tileOffset : kOffset;
+    Value colOffset = isLhs ? kOffset : tileOffset;
+    Value rowStride = arith::ConstantOp::create(
+        rewriter, loc, rewriter.getI32IntegerAttr(source.rowStride));
+    Value stride = arith::ConstantOp::create(
+        rewriter, loc, rewriter.getI32IntegerAttr(source.stride));
+    Value row = arith::MulIOp::create(rewriter, loc, rowOffset, rowStride);
+    Value col = arith::MulIOp::create(rewriter, loc, colOffset, stride);
+    Value offset = arith::AddIOp::create(rewriter, loc, row, col);
+    Value ptr = tt::AddPtrOp::create(rewriter, loc, source.scratchPtr.getType(),
+                                     source.scratchPtr, offset);
+    return loadScratchStrided2D(rewriter, loc, ptr, resultTy, source.rowStride,
+                                source.stride);
+  }
+
+  Value shared = source.sharedMemdesc;
+  auto sharedTy = cast<ttg::MemDescType>(shared.getType());
+  unsigned tileAxis = isLhs ? 0 : 1;
+  unsigned kAxis = 1 - tileAxis;
+  auto cgaLayout = ttg::getCGALayout(sharedTy.getEncoding());
+  auto replicatedCGA = ttg::CGAEncodingAttr::fromSplitParams(
+      rewriter.getContext(), cgaLayout.getCTAsPerCGA(),
+      SmallVector<unsigned>(2, 1), cgaLayout.getCTAOrder());
+  SmallVector<int64_t> loadShape(resultTy.getShape());
+  int numWarps = ttg::lookupNumWarps(rewriter.getInsertionBlock()->getParent());
+  int threadsPerWarp = ttg::lookupThreadsPerWarp(rewriter);
+  SmallVector<unsigned> threadsPerWarpShape(2, 1);
+  threadsPerWarpShape[tileAxis] =
+      std::min<int64_t>(loadShape[tileAxis], threadsPerWarp);
+  threadsPerWarpShape[kAxis] = threadsPerWarp / threadsPerWarpShape[tileAxis];
+  SmallVector<unsigned> warpsPerCTA(2, 1);
+  warpsPerCTA[kAxis] = numWarps;
+  SmallVector<unsigned> sizePerThread(2, 1);
+  sizePerThread[tileAxis] = loadShape[tileAxis] / threadsPerWarpShape[tileAxis];
+  auto loadLayout = ttg::BlockedEncodingAttr::get(
+      rewriter.getContext(), sizePerThread, threadsPerWarpShape, warpsPerCTA,
+      SmallVector<unsigned>{tileAxis, kAxis}, replicatedCGA);
+  auto loadTy =
+      RankedTensorType::get(loadShape, resultTy.getElementType(), loadLayout);
+  auto indicesTy =
+      RankedTensorType::get(loadShape, rewriter.getI32Type(), loadLayout);
+  auto kEncoding = getSingleDimSliceEncoding(loadLayout, kAxis);
+  auto kTy = RankedTensorType::get({loadShape[kAxis]}, rewriter.getI32Type(),
+                                   kEncoding);
+  Value indices =
+      tt::MakeRangeOp::create(rewriter, loc, kTy, 0, loadShape[kAxis]);
+  Value kSplat = tt::SplatOp::create(rewriter, loc, kTy, kOffset);
+  indices = arith::AddIOp::create(rewriter, loc, indices, kSplat);
+  indices = expandAllSlicedDims(rewriter, loc, indices);
+  if (cast<RankedTensorType>(indices.getType()).getShape() !=
+      ArrayRef(loadShape))
+    indices = tt::BroadcastOp::create(rewriter, loc, indicesTy, indices);
+  Value zero =
+      arith::ConstantOp::create(rewriter, loc, rewriter.getI32IntegerAttr(0));
+  SmallVector<Value> offsets(2, zero);
+  offsets[tileAxis] = tileOffset;
+  Value loaded = ExperimentalLocalGatherOp::create(
+                     rewriter, loc, loadTy, shared, indices, offsets,
+                     rewriter.getI32IntegerAttr(kAxis))
+                     .getResult();
+  if (loaded.getType() != resultTy)
+    loaded = ttg::ConvertLayoutOp::create(rewriter, loc, resultTy, loaded);
+  return loaded;
 }
 
 Operation *storeScratchStrided2D(PatternRewriter &rewriter, Location loc,
@@ -1266,17 +1348,17 @@ Value unpackPackedFp4Tensor(PatternRewriter &rewriter, Location loc,
 }
 
 Value loadOperandK32(PatternRewriter &rewriter, Location loc, bool isLhs,
-                     Value tilePtr, RankedTensorType fullTileTy, Value kI32,
-                     int64_t rowStride, int64_t stride,
+                     const MmaOperandSource &source, Value tileIdx, Value kI32,
                      int64_t packFactor = 1) {
-  SmallVector<int64_t> logicalShape{isLhs ? fullTileTy.getShape()[0] : kI8MmaK,
-                                    isLhs ? kI8MmaK : fullTileTy.getShape()[1]};
+  SmallVector<int64_t> logicalShape{
+      isLhs ? source.tileType.getShape()[0] : kI8MmaK,
+      isLhs ? kI8MmaK : source.tileType.getShape()[1]};
   SmallVector<int64_t> rawShape = logicalShape;
   rawShape[isLhs ? 1 : 0] /= packFactor;
-  auto rawLayout = getOptimizedBlockedEncoding(rewriter, rawShape,
-                                               fullTileTy.getElementType());
-  auto rawTy =
-      RankedTensorType::get(rawShape, fullTileTy.getElementType(), rawLayout);
+  auto rawLayout = getOptimizedBlockedEncoding(
+      rewriter, rawShape, source.tileType.getElementType());
+  auto rawTy = RankedTensorType::get(rawShape, source.tileType.getElementType(),
+                                     rawLayout);
 
   Value packedKIdx = kI32;
   if (packFactor != 1) {
@@ -1284,13 +1366,8 @@ Value loadOperandK32(PatternRewriter &rewriter, Location loc, bool isLhs,
         rewriter, loc, rewriter.getI32IntegerAttr(packFactor));
     packedKIdx = arith::DivUIOp::create(rewriter, loc, kI32, factor);
   }
-  Value kStride = arith::ConstantOp::create(
-      rewriter, loc, rewriter.getI32IntegerAttr(isLhs ? stride : rowStride));
-  Value offset = arith::MulIOp::create(rewriter, loc, packedKIdx, kStride);
-  Value chunkPtr =
-      tt::AddPtrOp::create(rewriter, loc, tilePtr.getType(), tilePtr, offset);
   Value chunk =
-      loadScratchStrided2D(rewriter, loc, chunkPtr, rawTy, rowStride, stride);
+      loadMmaOperand(rewriter, loc, source, rawTy, isLhs, tileIdx, packedKIdx);
 
   if (packFactor == 2) {
     auto logicalLayout = getOptimizedBlockedEncoding(rewriter, logicalShape,
@@ -1365,13 +1442,13 @@ Value loadScaledScaleK32(PatternRewriter &rewriter, Location loc, bool isLhs,
 }
 
 Value loadScaledOperandK32(PatternRewriter &rewriter, Location loc, bool isLhs,
-                           Value tilePtr, RankedTensorType fullTileTy,
+                           const MmaOperandSource &source,
                            const DotScaleConfig &scale, Value tileIdx,
-                           Value kI32, int64_t rowStride, int64_t stride) {
+                           Value kI32) {
   int64_t packFactor = isLhs ? scale.aKPackFactor : scale.bKPackFactor;
   tt::ScaleDotElemType elemType = isLhs ? scale.aElemType : scale.bElemType;
-  Value chunk = loadOperandK32(rewriter, loc, isLhs, tilePtr, fullTileTy, kI32,
-                               rowStride, stride, packFactor);
+  Value chunk =
+      loadOperandK32(rewriter, loc, isLhs, source, tileIdx, kI32, packFactor);
 
   Value payload = castDotScaledOperandToComputePayload(
       rewriter, loc, chunk, elemType, scale.computeElem);
@@ -1487,49 +1564,22 @@ Value tryEmitI8DotDecomposition(PatternRewriter &rewriter, Location loc,
   return ttg::ConvertLayoutOp::create(rewriter, loc, accTy, product);
 }
 
-std::optional<scf::ForOp> emitMmaEmulationLoops(
-    PatternRewriter &rewriter, Location loc, Value aPtr, Value bPtr, Value dPtr,
-    int64_t m, int64_t n, int64_t k, int64_t tileM, int64_t tileN,
-    RankedTensorType aTileTy, RankedTensorType bTileTy,
-    RankedTensorType accTileTy, ttg::DistributedEncodingTrait accLayout,
-    IntegerType accElem, Value useDInt, Value predInt, int64_t aStride,
-    int64_t bStride, int64_t dStride, const DotScaleConfig &scale = {},
-    int64_t aRowStride = 1, int64_t bRowStride = 1, int64_t dRowStride = 1) {
-  if ((m % tileM) != 0 || (n % tileN) != 0)
-    return std::nullopt;
-
-  OpBuilder::InsertionGuard guard(rewriter);
-  Value zero =
-      arith::ConstantOp::create(rewriter, loc, rewriter.getI32IntegerAttr(0));
-  Value mUpper =
-      arith::ConstantOp::create(rewriter, loc, rewriter.getI32IntegerAttr(m));
-  Value nUpper =
-      arith::ConstantOp::create(rewriter, loc, rewriter.getI32IntegerAttr(n));
-  Value mStep = arith::ConstantOp::create(rewriter, loc,
-                                          rewriter.getI32IntegerAttr(tileM));
-  Value nStep = arith::ConstantOp::create(rewriter, loc,
-                                          rewriter.getI32IntegerAttr(tileN));
-
-  auto mLoop = scf::ForOp::create(rewriter, loc, zero, mUpper, mStep);
-  rewriter.setInsertionPointToStart(mLoop.getBody());
-  Value mIdx = mLoop.getInductionVar();
-  auto nLoop = scf::ForOp::create(rewriter, loc, zero, nUpper, nStep);
-  rewriter.setInsertionPointToStart(nLoop.getBody());
-  Value nIdx = nLoop.getInductionVar();
+LogicalResult emitMmaEmulationTile(
+    PatternRewriter &rewriter, Location loc, const MmaOperandSource &aSource,
+    const MmaOperandSource &bSource, Value dPtr, int64_t k, int64_t tileM,
+    int64_t tileN, RankedTensorType accTileTy,
+    ttg::DistributedEncodingTrait accLayout, IntegerType accElem, Value useDInt,
+    Value predInt, Value mIdxI32, Value nIdxI32, int64_t dStride,
+    const DotScaleConfig &scale = {}, int64_t dRowStride = 1) {
+  bool hasSharedOperand = aSource.isShared() || bSource.isShared();
 
   auto i32Ty = rewriter.getI32Type();
-  Value mIdxI32 = arith::IndexCastOp::create(rewriter, loc, i32Ty, mIdx);
-  Value nIdxI32 = arith::IndexCastOp::create(rewriter, loc, i32Ty, nIdx);
+  Value zero =
+      arith::ConstantOp::create(rewriter, loc, rewriter.getI32IntegerAttr(0));
   Value dRowStrideConst = arith::ConstantOp::create(
       rewriter, loc, rewriter.getI32IntegerAttr(dRowStride));
   Value dStrideConst = arith::ConstantOp::create(
       rewriter, loc, rewriter.getI32IntegerAttr(dStride));
-  Value aRowStrideConst = arith::ConstantOp::create(
-      rewriter, loc, rewriter.getI32IntegerAttr(aRowStride));
-  Value bStrideConst = arith::ConstantOp::create(
-      rewriter, loc, rewriter.getI32IntegerAttr(bStride));
-  Value bRowStrideConst = arith::ConstantOp::create(
-      rewriter, loc, rewriter.getI32IntegerAttr(bRowStride));
 
   Value mDOffset =
       arith::MulIOp::create(rewriter, loc, mIdxI32, dRowStrideConst);
@@ -1540,14 +1590,6 @@ std::optional<scf::ForOp> emitMmaEmulationLoops(
   Value accTile = loadScratchStrided2D(rewriter, loc, dTilePtr, accTileTy,
                                        dRowStride, dStride);
   Value accTileI = embedToInt(rewriter, loc, accTile);
-
-  Value aMOffset =
-      arith::MulIOp::create(rewriter, loc, mIdxI32, aRowStrideConst);
-  Value aTilePtr =
-      tt::AddPtrOp::create(rewriter, loc, aPtr.getType(), aPtr, aMOffset);
-  Value bOffset = arith::MulIOp::create(rewriter, loc, nIdxI32, bStrideConst);
-  Value bTilePtr =
-      tt::AddPtrOp::create(rewriter, loc, bPtr.getType(), bPtr, bOffset);
 
   Value sum;
   int numWarps = ttg::lookupNumWarps(rewriter.getInsertionBlock()->getParent());
@@ -1561,11 +1603,11 @@ std::optional<scf::ForOp> emitMmaEmulationLoops(
       isScaleK32Aligned(scale.bScalePtr, scale.bScaleFactor) &&
       canUseI8MmaTile(tileM, tileN, numWarps);
   if (canUseI8Decomposition) {
-    if (!scale.computeElem && accElem.getWidth() <= 32) {
-      Value aTile = loadScratchStrided2D(rewriter, loc, aTilePtr, aTileTy,
-                                         aRowStride, aStride);
-      Value bTile = loadScratchStrided2D(rewriter, loc, bTilePtr, bTileTy,
-                                         bRowStride, bStride);
+    if (!hasSharedOperand && !scale.computeElem && accElem.getWidth() <= 32) {
+      Value aTile = loadMmaOperand(rewriter, loc, aSource, aSource.tileType,
+                                   /*isLhs=*/true, mIdxI32, zero);
+      Value bTile = loadMmaOperand(rewriter, loc, bSource, bSource.tileType,
+                                   /*isLhs=*/false, nIdxI32, zero);
       sum = tryEmitI8DotDecomposition(
           rewriter, loc, embedToInt(rewriter, loc, aTile),
           embedToInt(rewriter, loc, bTile), accLayout, accElem, numWarps);
@@ -1585,17 +1627,15 @@ std::optional<scf::ForOp> emitMmaEmulationLoops(
       Value aChunk;
       Value bChunk;
       if (scale.computeElem) {
-        aChunk = loadScaledOperandK32(rewriter, loc, /*isLhs=*/true, aTilePtr,
-                                      aTileTy, scale, mIdxI32, kI32, aRowStride,
-                                      aStride);
-        bChunk = loadScaledOperandK32(rewriter, loc, /*isLhs=*/false, bTilePtr,
-                                      bTileTy, scale, nIdxI32, kI32, bRowStride,
-                                      bStride);
+        aChunk = loadScaledOperandK32(rewriter, loc, /*isLhs=*/true, aSource,
+                                      scale, mIdxI32, kI32);
+        bChunk = loadScaledOperandK32(rewriter, loc, /*isLhs=*/false, bSource,
+                                      scale, nIdxI32, kI32);
       } else {
-        aChunk = loadOperandK32(rewriter, loc, /*isLhs=*/true, aTilePtr,
-                                aTileTy, kI32, aRowStride, aStride);
-        bChunk = loadOperandK32(rewriter, loc, /*isLhs=*/false, bTilePtr,
-                                bTileTy, kI32, bRowStride, bStride);
+        aChunk = loadOperandK32(rewriter, loc, /*isLhs=*/true, aSource, mIdxI32,
+                                kI32);
+        bChunk = loadOperandK32(rewriter, loc, /*isLhs=*/false, bSource,
+                                nIdxI32, kI32);
       }
       Value partial = tryEmitI8DotDecomposition(
           rewriter, loc, embedToInt(rewriter, loc, aChunk),
@@ -1612,13 +1652,10 @@ std::optional<scf::ForOp> emitMmaEmulationLoops(
   }
 
   if (!sum) {
-    auto aSliceTy =
-        RankedTensorType::get({tileM, 1}, aTileTy.getElementType(), accLayout);
-    auto bSliceTy =
-        RankedTensorType::get({1, tileN}, bTileTy.getElementType(), accLayout);
-    Value aStrideVal = arith::ConstantOp::create(
-        rewriter, loc, rewriter.getI32IntegerAttr(aStride));
-
+    auto aSliceTy = RankedTensorType::get(
+        {tileM, 1}, aSource.tileType.getElementType(), accLayout);
+    auto bSliceTy = RankedTensorType::get(
+        {1, tileN}, bSource.tileType.getElementType(), accLayout);
     Value zeroSum = getIntConstantLike(rewriter, loc, accTileI.getType(), 0);
     Value kUpper =
         arith::ConstantOp::create(rewriter, loc, rewriter.getI32IntegerAttr(k));
@@ -1641,18 +1678,10 @@ std::optional<scf::ForOp> emitMmaEmulationLoops(
           rewriter, loc, rewriter.getI32IntegerAttr(scale.bKPackFactor));
       bKIdx = arith::DivUIOp::create(rewriter, loc, kI32, bPackFactor);
     }
-    Value aOffset =
-        arith::MulIOp::create(rewriter, loc, i32Ty, aKIdx, aStrideVal);
-    Value aSlicePtr =
-        tt::AddPtrOp::create(rewriter, loc, aPtr.getType(), aTilePtr, aOffset);
-    Value aSlice = loadScratchStrided2D(rewriter, loc, aSlicePtr, aSliceTy,
-                                        aRowStride, aStride);
-    Value bKOffset =
-        arith::MulIOp::create(rewriter, loc, bKIdx, bRowStrideConst);
-    Value bSlicePtr =
-        tt::AddPtrOp::create(rewriter, loc, bPtr.getType(), bTilePtr, bKOffset);
-    Value bSlice = loadScratchStrided2D(rewriter, loc, bSlicePtr, bSliceTy,
-                                        bRowStride, bStride);
+    Value aSlice = loadMmaOperand(rewriter, loc, aSource, aSliceTy,
+                                  /*isLhs=*/true, mIdxI32, aKIdx);
+    Value bSlice = loadMmaOperand(rewriter, loc, bSource, bSliceTy,
+                                  /*isLhs=*/false, nIdxI32, bKIdx);
     if (scale.aKPackFactor == 2)
       aSlice = unpackPackedFp4Slice(rewriter, loc, aSlice, kI32);
     if (scale.bKPackFactor == 2)
@@ -1695,8 +1724,61 @@ std::optional<scf::ForOp> emitMmaEmulationLoops(
   createGlobalScratchBarrier(rewriter, loc);
   storeScratchStrided2D(rewriter, loc, dTilePtr, out, accTileTy, dRowStride,
                         dStride);
+  return success();
+}
 
+std::optional<scf::ForOp> emitMmaEmulationLoops(
+    PatternRewriter &rewriter, Location loc, const MmaOperandSource &aSource,
+    const MmaOperandSource &bSource, Value dPtr, int64_t m, int64_t n,
+    int64_t k, int64_t tileM, int64_t tileN, RankedTensorType accTileTy,
+    ttg::DistributedEncodingTrait accLayout, IntegerType accElem, Value useDInt,
+    Value predInt, int64_t dStride, const DotScaleConfig &scale = {},
+    int64_t dRowStride = 1) {
+  if ((m % tileM) != 0 || (n % tileN) != 0)
+    return std::nullopt;
+
+  OpBuilder::InsertionGuard guard(rewriter);
+  Value zero =
+      arith::ConstantOp::create(rewriter, loc, rewriter.getI32IntegerAttr(0));
+  Value mUpper =
+      arith::ConstantOp::create(rewriter, loc, rewriter.getI32IntegerAttr(m));
+  Value nUpper =
+      arith::ConstantOp::create(rewriter, loc, rewriter.getI32IntegerAttr(n));
+  Value mStep = arith::ConstantOp::create(rewriter, loc,
+                                          rewriter.getI32IntegerAttr(tileM));
+  Value nStep = arith::ConstantOp::create(rewriter, loc,
+                                          rewriter.getI32IntegerAttr(tileN));
+
+  auto mLoop = scf::ForOp::create(rewriter, loc, zero, mUpper, mStep);
+  rewriter.setInsertionPointToStart(mLoop.getBody());
+  Value mIdx = mLoop.getInductionVar();
+  auto nLoop = scf::ForOp::create(rewriter, loc, zero, nUpper, nStep);
+  rewriter.setInsertionPointToStart(nLoop.getBody());
+  auto i32Ty = rewriter.getI32Type();
+  Value mIdxI32 = arith::IndexCastOp::create(rewriter, loc, i32Ty, mIdx);
+  Value nIdxI32 =
+      arith::IndexCastOp::create(rewriter, loc, i32Ty, nLoop.getInductionVar());
+  if (failed(emitMmaEmulationTile(rewriter, loc, aSource, bSource, dPtr, k,
+                                  tileM, tileN, accTileTy, accLayout, accElem,
+                                  useDInt, predInt, mIdxI32, nIdxI32, dStride,
+                                  scale, dRowStride)))
+    return std::nullopt;
   return mLoop;
+}
+
+std::optional<scf::ForOp> emitMmaEmulationLoops(
+    PatternRewriter &rewriter, Location loc, Value aPtr, Value bPtr, Value dPtr,
+    int64_t m, int64_t n, int64_t k, int64_t tileM, int64_t tileN,
+    RankedTensorType aTileTy, RankedTensorType bTileTy,
+    RankedTensorType accTileTy, ttg::DistributedEncodingTrait accLayout,
+    IntegerType accElem, Value useDInt, Value predInt, int64_t aStride,
+    int64_t bStride, int64_t dStride, const DotScaleConfig &scale = {},
+    int64_t aRowStride = 1, int64_t bRowStride = 1, int64_t dRowStride = 1) {
+  MmaOperandSource aSource{aPtr, Value(), aTileTy, aRowStride, aStride};
+  MmaOperandSource bSource{bPtr, Value(), bTileTy, bRowStride, bStride};
+  return emitMmaEmulationLoops(rewriter, loc, aSource, bSource, dPtr, m, n, k,
+                               tileM, tileN, accTileTy, accLayout, accElem,
+                               useDInt, predInt, dStride, scale, dRowStride);
 }
 
 //----------------------------------------
@@ -2505,42 +2587,57 @@ struct TCGen5MMAPattern : public OpRewritePattern<ttng::TCGen5MMAOp> {
         arith::ExtUIOp::create(rewriter, loc, accElem, op.getPred());
 
     rewriter.setInsertionPoint(op);
-    auto aScratch = createOperandScratch(rewriter, loc, *scratch, op.getA(),
-                                         aMemTy, aIsTmem, scope);
-    if (!aScratch)
-      return emitFpSanCodegenError(op.getOperation());
-    auto bScratch = createOperandScratch(rewriter, loc, *scratch, op.getB(),
-                                         bMemTy, bIsTmem, scope);
-    if (!bScratch)
-      return emitFpSanCodegenError(op.getOperation());
-
-    // Each warp may only populate a subset of the operand scratch tiles, so
-    // synchronize before the emulation loops start reading them.
-    createGlobalScratchBarrier(rewriter, loc,
-                               scratch->usesSharedClusterState());
-
-    auto [tileM, tileN] = getMmaEmulationTileShape(rewriter, m, n, k, accElem);
+    auto [tileM, tileN] =
+        (!aIsTmem || !bIsTmem)
+            ? getDirectSharedMmaEmulationTileShape(rewriter, m, n, k, accElem)
+            : getMmaEmulationTileShape(rewriter, m, n, k, accElem);
     auto accTileLayout =
         getOptimizedBlockedEncoding(rewriter, {tileM, tileN}, accElem);
     auto accTileTy =
         RankedTensorType::get({tileM, tileN}, accElem, accTileLayout);
-    auto aTileLayout = getOptimizedBlockedEncoding(
-        rewriter, {tileM, k},
-        getScratchStorageElementType(aMemTy.getElementType()));
-    auto aTileTy = RankedTensorType::get(
-        {tileM, k}, getScratchStorageElementType(aMemTy.getElementType()),
-        aTileLayout);
-    auto bTileLayout = getOptimizedBlockedEncoding(
-        rewriter, {k, tileN},
-        getScratchStorageElementType(bMemTy.getElementType()));
-    auto bTileTy = RankedTensorType::get(
-        {k, tileN}, getScratchStorageElementType(bMemTy.getElementType()),
-        bTileLayout);
+    Type aTileElem = aIsTmem
+                         ? getScratchStorageElementType(aMemTy.getElementType())
+                         : aMemTy.getElementType();
+    auto aTileLayout =
+        getOptimizedBlockedEncoding(rewriter, {tileM, k}, aTileElem);
+    auto aTileTy = RankedTensorType::get({tileM, k}, aTileElem, aTileLayout);
+    Type bTileElem = bIsTmem
+                         ? getScratchStorageElementType(bMemTy.getElementType())
+                         : bMemTy.getElementType();
+    auto bTileLayout =
+        getOptimizedBlockedEncoding(rewriter, {k, tileN}, bTileElem);
+    auto bTileTy = RankedTensorType::get({k, tileN}, bTileElem, bTileLayout);
+
+    std::optional<ScratchInfo> aScratch;
+    if (aIsTmem) {
+      aScratch = createTmemOperandScratch(rewriter, loc, *scratch, op.getA(),
+                                          aMemTy, scope);
+      if (!aScratch)
+        return emitFpSanCodegenError(op.getOperation());
+    }
+    std::optional<ScratchInfo> bScratch;
+    if (bIsTmem) {
+      bScratch = createTmemOperandScratch(rewriter, loc, *scratch, op.getB(),
+                                          bMemTy, scope);
+      if (!bScratch)
+        return emitFpSanCodegenError(op.getOperation());
+    }
+    MmaOperandSource aSource{aIsTmem ? aScratch->ptr : Value(),
+                             aIsTmem ? Value() : op.getA(), aTileTy,
+                             /*rowStride=*/1, /*stride=*/m};
+    MmaOperandSource bSource{bIsTmem ? bScratch->ptr : Value(),
+                             bIsTmem ? Value() : op.getB(), bTileTy,
+                             /*rowStride=*/1, /*stride=*/k};
+
+    // TMEM and D scratch are written cooperatively. In two-CTA mode, the
+    // cluster barrier also makes both CTAs' shared operands visible before the
+    // first direct load.
+    createGlobalScratchBarrier(rewriter, loc,
+                               scratch->usesSharedClusterState());
 
     auto mLoop = emitMmaEmulationLoops(
-        rewriter, loc, aScratch->ptr, bScratch->ptr, dInfo->ptr, m, n, k, tileM,
-        tileN, aTileTy, bTileTy, accTileTy, accTileLayout, accElem, useDInt,
-        predInt, /*aStride=*/m, /*bStride=*/k, /*dStride=*/m);
+        rewriter, loc, aSource, bSource, dInfo->ptr, m, n, k, tileM, tileN,
+        accTileTy, accTileLayout, accElem, useDInt, predInt, /*dStride=*/m);
     if (!mLoop)
       return emitFpSanUnsupported(op.getOperation());
     rewriter.setInsertionPointAfter(*mLoop);
@@ -2661,24 +2758,19 @@ struct TCGen5MMAScaledPattern
         arith::ExtUIOp::create(rewriter, loc, accElem, op.getPred());
 
     rewriter.setInsertionPoint(op);
-    auto aScratch = createOperandScratch(rewriter, loc, *scratch, op.getA(),
-                                         aMemTy, aIsTmem, scope);
-    if (!aScratch)
-      return emitFpSanCodegenError(op.getOperation());
-    auto bScratch = createOperandScratch(rewriter, loc, *scratch, op.getB(),
-                                         bMemTy, bIsTmem, scope);
-    if (!bScratch)
-      return emitFpSanCodegenError(op.getOperation());
-    auto aScaleScratch = createOperandScratch(
-        rewriter, loc, *scratch, op.getAScale(), aScaleMemTy, true, scope);
+    auto aScaleScratch = createTmemOperandScratch(
+        rewriter, loc, *scratch, op.getAScale(), aScaleMemTy, scope);
     if (!aScaleScratch)
       return emitFpSanCodegenError(op.getOperation());
-    auto bScaleScratch = createOperandScratch(
-        rewriter, loc, *scratch, op.getBScale(), bScaleMemTy, true, scope);
+    auto bScaleScratch = createTmemOperandScratch(
+        rewriter, loc, *scratch, op.getBScale(), bScaleMemTy, scope);
     if (!bScaleScratch)
       return emitFpSanCodegenError(op.getOperation());
 
-    auto [tileM, tileN] = getMmaEmulationTileShape(rewriter, m, n, k, accElem);
+    auto [tileM, tileN] =
+        (!aIsTmem || !bIsTmem)
+            ? getDirectSharedMmaEmulationTileShape(rewriter, m, n, k, accElem)
+            : getMmaEmulationTileShape(rewriter, m, n, k, accElem);
 
     auto accTileLayout = getOptimizedBlockedEncoding(rewriter, {tileM, tileN},
                                                      dMemTy.getElementType());
@@ -2692,6 +2784,27 @@ struct TCGen5MMAScaledPattern
                                                    bMemTy.getElementType());
     auto bTileTy = RankedTensorType::get({bPackedK, tileN},
                                          bMemTy.getElementType(), bTileLayout);
+
+    std::optional<ScratchInfo> aScratch;
+    if (aIsTmem) {
+      aScratch = createTmemOperandScratch(rewriter, loc, *scratch, op.getA(),
+                                          aMemTy, scope);
+      if (!aScratch)
+        return emitFpSanCodegenError(op.getOperation());
+    }
+    std::optional<ScratchInfo> bScratch;
+    if (bIsTmem) {
+      bScratch = createTmemOperandScratch(rewriter, loc, *scratch, op.getB(),
+                                          bMemTy, scope);
+      if (!bScratch)
+        return emitFpSanCodegenError(op.getOperation());
+    }
+    MmaOperandSource aSource{aIsTmem ? aScratch->ptr : Value(),
+                             aIsTmem ? Value() : op.getA(), aTileTy,
+                             /*rowStride=*/1, /*stride=*/m};
+    MmaOperandSource bSource{bIsTmem ? bScratch->ptr : Value(),
+                             bIsTmem ? Value() : op.getB(), bTileTy,
+                             /*rowStride=*/1, /*stride=*/bPackedK};
 
     DotScaleConfig scale;
     scale.aElemType = op.getAType();
@@ -2711,15 +2824,15 @@ struct TCGen5MMAScaledPattern
     scale.aScaleFactor = *aScaleFactor;
     scale.bScaleFactor = *bScaleFactor;
 
-    // The operand and scale scratch buffers are written cooperatively, so all
-    // warps must finish those stores before the emulation loop reads them.
+    // TMEM scales and D scratch are written cooperatively. In two-CTA mode,
+    // rendezvous before either CTA directly reads the shared operands.
     createGlobalScratchBarrier(rewriter, loc,
                                scratch->usesSharedClusterState());
 
-    auto mLoop = emitMmaEmulationLoops(
-        rewriter, loc, aScratch->ptr, bScratch->ptr, dInfo->ptr, m, n, k, tileM,
-        tileN, aTileTy, bTileTy, accTileTy, accTileLayout, accElem, useDInt,
-        predInt, /*aStride=*/m, /*bStride=*/bPackedK, /*dStride=*/m, scale);
+    auto mLoop =
+        emitMmaEmulationLoops(rewriter, loc, aSource, bSource, dInfo->ptr, m, n,
+                              k, tileM, tileN, accTileTy, accTileLayout,
+                              accElem, useDInt, predInt, /*dStride=*/m, scale);
     if (!mLoop)
       return emitFpSanUnsupported(op.getOperation());
     rewriter.setInsertionPointAfter(*mLoop);

--- a/lib/Dialect/TritonInstrument/Transforms/FpSanitizer.cpp
+++ b/lib/Dialect/TritonInstrument/Transforms/FpSanitizer.cpp
@@ -84,8 +84,7 @@ getMmaEmulationTileShape(PatternRewriter &rewriter, int64_t m, int64_t n,
   }
   if (directShared) {
     int64_t widerN = std::min<int64_t>(16 * numWarps, n);
-    if (widerN > tile.second &&
-        canUseI8MmaTile(tile.first, widerN, numWarps))
+    if (widerN > tile.second && canUseI8MmaTile(tile.first, widerN, numWarps))
       tile.second = widerN;
   }
   return tile;

--- a/lib/Dialect/TritonInstrument/Transforms/FpSanitizer.cpp
+++ b/lib/Dialect/TritonInstrument/Transforms/FpSanitizer.cpp
@@ -68,13 +68,12 @@ bool canUseI8MmaTile(int64_t m, int64_t n, int numWarps) {
   return m >= 16 && n >= 8 && (m / 16) * (n / 8) >= numWarps;
 }
 
-std::pair<int64_t, int64_t> getMmaEmulationTileShape(PatternRewriter &rewriter,
-                                                     int64_t m, int64_t n,
-                                                     int64_t k,
-                                                     IntegerType accElem,
-                                                     bool directShared = false) {
-  std::pair<int64_t, int64_t> tile = {
-      std::min<int64_t>(kTileM, m), std::min<int64_t>(kTileN, n)};
+std::pair<int64_t, int64_t>
+getMmaEmulationTileShape(PatternRewriter &rewriter, int64_t m, int64_t n,
+                         int64_t k, IntegerType accElem,
+                         bool directShared = false) {
+  std::pair<int64_t, int64_t> tile = {std::min<int64_t>(kTileM, m),
+                                      std::min<int64_t>(kTileN, n)};
   int64_t numWarps =
       ttg::lookupNumWarps(rewriter.getInsertionBlock()->getParent());
   if (supportsI8DotDecomposition(rewriter, accElem) && (k % kI8MmaK) == 0) {
@@ -931,8 +930,8 @@ createTmemOperandScratch(PatternRewriter &rewriter, Location loc,
 
 std::optional<MmaOperandSource> createMmaOperandSource(
     PatternRewriter &rewriter, Location loc, TmemScratchManager &scratch,
-    Value memdesc, ttg::MemDescType memTy, bool isTmem,
-    RankedTensorType tileTy, Region *scope, int64_t rowStride, int64_t stride) {
+    Value memdesc, ttg::MemDescType memTy, bool isTmem, RankedTensorType tileTy,
+    Region *scope, int64_t rowStride, int64_t stride) {
   if (!isTmem)
     return MmaOperandSource{Value(), memdesc, tileTy, rowStride, stride};
   auto info =
@@ -1596,10 +1595,10 @@ std::optional<scf::ForOp> emitMmaEmulationLoops(
   rewriter.setInsertionPointToStart(mLoop.getBody());
   auto nLoop = scf::ForOp::create(rewriter, loc, zero, nUpper, nStep);
   rewriter.setInsertionPointToStart(nLoop.getBody());
-  Value mIdxI32 = arith::IndexCastOp::create(
-      rewriter, loc, i32Ty, mLoop.getInductionVar());
-  Value nIdxI32 = arith::IndexCastOp::create(
-      rewriter, loc, i32Ty, nLoop.getInductionVar());
+  Value mIdxI32 =
+      arith::IndexCastOp::create(rewriter, loc, i32Ty, mLoop.getInductionVar());
+  Value nIdxI32 =
+      arith::IndexCastOp::create(rewriter, loc, i32Ty, nLoop.getInductionVar());
 
   Value dRowStrideConst = arith::ConstantOp::create(
       rewriter, loc, rewriter.getI32IntegerAttr(dRowStride));
@@ -2759,9 +2758,9 @@ struct TCGen5MMAScaledPattern
     auto aSource = createMmaOperandSource(rewriter, loc, *scratch, op.getA(),
                                           aMemTy, aIsTmem, aTileTy, scope,
                                           /*rowStride=*/1, /*stride=*/m);
-    auto bSource = createMmaOperandSource(
-        rewriter, loc, *scratch, op.getB(), bMemTy, bIsTmem, bTileTy, scope,
-        /*rowStride=*/1, /*stride=*/bPackedK);
+    auto bSource = createMmaOperandSource(rewriter, loc, *scratch, op.getB(),
+                                          bMemTy, bIsTmem, bTileTy, scope,
+                                          /*rowStride=*/1, /*stride=*/bPackedK);
     if (!aSource || !bSource)
       return emitFpSanCodegenError(op.getOperation());
 

--- a/lib/Dialect/TritonInstrument/Transforms/FpSanitizer.cpp
+++ b/lib/Dialect/TritonInstrument/Transforms/FpSanitizer.cpp
@@ -57,32 +57,15 @@ constexpr int64_t kI8MmaK = 32;
 
 bool supportsI8DotDecomposition(PatternRewriter &rewriter,
                                 IntegerType accElem) {
-  auto module =
+  auto moduleOp =
       rewriter.getInsertionBlock()->getParentOp()->getParentOfType<ModuleOp>();
-  if (getAMDArch(module))
+  if (getAMDArch(moduleOp))
     return false;
   return llvm::is_contained({16, 32, 64}, accElem.getWidth());
 }
 
-std::optional<SmallVector<unsigned>> getI8MmaWarpsPerCTA(int64_t m, int64_t n,
-                                                         int numWarps) {
-  if (m < 16 || n < 8 || (m % 16) != 0 || (n % 8) != 0 || numWarps <= 0)
-    return std::nullopt;
-
-  SmallVector<unsigned> warpsPerCTA{1, 1};
-  SmallVector<int64_t> reps{m / 16, n / 8};
-  while (warpsPerCTA[0] * warpsPerCTA[1] < numWarps) {
-    unsigned axis = reps[0] >= reps[1] ? 0 : 1;
-    if (reps[axis] <= 1 || (reps[axis] % 2) != 0)
-      axis = 1 - axis;
-    if (reps[axis] <= 1 || (reps[axis] % 2) != 0)
-      return std::nullopt;
-    warpsPerCTA[axis] *= 2;
-    reps[axis] /= 2;
-  }
-  if (warpsPerCTA[0] * warpsPerCTA[1] != numWarps)
-    return std::nullopt;
-  return warpsPerCTA;
+bool canUseI8MmaTile(int64_t m, int64_t n, int numWarps) {
+  return m >= 16 && n >= 8 && (m / 16) * (n / 8) >= numWarps;
 }
 
 std::pair<int64_t, int64_t> getMmaEmulationTileShape(PatternRewriter &rewriter,
@@ -93,12 +76,8 @@ std::pair<int64_t, int64_t> getMmaEmulationTileShape(PatternRewriter &rewriter,
     int64_t numWarps =
         ttg::lookupNumWarps(rewriter.getInsertionBlock()->getParent());
     int64_t tileM = std::min<int64_t>(16 * numWarps, m);
-    while (tileM > 0 && (m % tileM) != 0)
-      tileM /= 2;
     int64_t tileN = std::min<int64_t>(8 * numWarps, n);
-    while (tileN > 0 && (n % tileN) != 0)
-      tileN /= 2;
-    if (getI8MmaWarpsPerCTA(tileM, tileN, numWarps))
+    if (canUseI8MmaTile(tileM, tileN, numWarps))
       return {tileM, tileN};
   }
   return {std::min<int64_t>(kTileM, m), std::min<int64_t>(kTileN, n)};
@@ -1418,9 +1397,9 @@ Value tryEmitI8DotDecomposition(PatternRewriter &rewriter, Location loc,
   if (bShape[0] != k || (k % kI8MmaK) != 0 ||
       !supportsI8DotDecomposition(rewriter, accElem))
     return Value();
-  auto warpsPerCTA = getI8MmaWarpsPerCTA(m, n, numWarps);
-  if (!warpsPerCTA)
+  if (!canUseI8MmaTile(m, n, numWarps))
     return Value();
+  auto warpsPerCTA = ttg::getMmaV2WarpsPerCTA({m, n}, numWarps);
 
   auto aElem = cast<IntegerType>(aPayloadTy.getElementType());
   auto bElem = cast<IntegerType>(bPayloadTy.getElementType());
@@ -1434,7 +1413,7 @@ Value tryEmitI8DotDecomposition(PatternRewriter &rewriter, Location loc,
   auto i8Ty = rewriter.getI8Type();
   auto i32Ty = rewriter.getI32Type();
   auto mmaLayout = ttg::NvidiaMmaEncodingAttr::get(
-      ctx, /*versionMajor=*/2, /*versionMinor=*/0, *warpsPerCTA,
+      ctx, /*versionMajor=*/2, /*versionMinor=*/0, warpsPerCTA,
       ttg::getCGALayout(accLayout), SmallVector<unsigned>{16, 8});
   auto aDotLayout = ttg::DotOperandEncodingAttr::get(ctx, 0, mmaLayout, i8Ty);
   auto bDotLayout = ttg::DotOperandEncodingAttr::get(ctx, 1, mmaLayout, i8Ty);
@@ -1580,7 +1559,7 @@ std::optional<scf::ForOp> emitMmaEmulationLoops(
       (k % kI8MmaK) == 0 && supportsI8DotDecomposition(rewriter, accElem) &&
       isScaleK32Aligned(scale.aScalePtr, scale.aScaleFactor) &&
       isScaleK32Aligned(scale.bScalePtr, scale.bScaleFactor) &&
-      getI8MmaWarpsPerCTA(tileM, tileN, numWarps).has_value();
+      canUseI8MmaTile(tileM, tileN, numWarps);
   if (canUseI8Decomposition) {
     if (!scale.computeElem && accElem.getWidth() <= 32) {
       Value aTile = loadScratchStrided2D(rewriter, loc, aTilePtr, aTileTy,

--- a/lib/Dialect/TritonInstrument/Transforms/FpSanitizer.cpp
+++ b/lib/Dialect/TritonInstrument/Transforms/FpSanitizer.cpp
@@ -3,7 +3,6 @@
 #include "mlir/IR/Types.h"
 #include "mlir/Transforms/GreedyPatternRewriteDriver.h"
 #include "mlir/Transforms/RegionUtils.h"
-#include "triton/Analysis/Utility.h"
 #include "triton/Dialect/Triton/IR/Dialect.h"
 #include "triton/Dialect/TritonGPU/IR/Dialect.h"
 #include "triton/Dialect/TritonGPU/Transforms/Utility.h"
@@ -72,31 +71,25 @@ bool canUseI8MmaTile(int64_t m, int64_t n, int numWarps) {
 std::pair<int64_t, int64_t> getMmaEmulationTileShape(PatternRewriter &rewriter,
                                                      int64_t m, int64_t n,
                                                      int64_t k,
-                                                     IntegerType accElem) {
+                                                     IntegerType accElem,
+                                                     bool directShared = false) {
+  std::pair<int64_t, int64_t> tile = {
+      std::min<int64_t>(kTileM, m), std::min<int64_t>(kTileN, n)};
+  int64_t numWarps =
+      ttg::lookupNumWarps(rewriter.getInsertionBlock()->getParent());
   if (supportsI8DotDecomposition(rewriter, accElem) && (k % kI8MmaK) == 0) {
-    int64_t numWarps =
-        ttg::lookupNumWarps(rewriter.getInsertionBlock()->getParent());
     int64_t tileM = std::min<int64_t>(16 * numWarps, m);
     int64_t tileN = std::min<int64_t>(8 * numWarps, n);
     if (canUseI8MmaTile(tileM, tileN, numWarps))
-      return {tileM, tileN};
+      tile = {tileM, tileN};
   }
-  return {std::min<int64_t>(kTileM, m), std::min<int64_t>(kTileN, n)};
-}
-
-std::pair<int64_t, int64_t>
-getDirectSharedMmaEmulationTileShape(PatternRewriter &rewriter, int64_t m,
-                                     int64_t n, int64_t k,
-                                     IntegerType accElem) {
-  auto [tileM, tileN] = getMmaEmulationTileShape(rewriter, m, n, k, accElem);
-  int64_t numWarps =
-      ttg::lookupNumWarps(rewriter.getInsertionBlock()->getParent());
-  int64_t widerN = std::min<int64_t>(16 * numWarps, n);
-  while (widerN > tileN && (n % widerN) != 0)
-    widerN /= 2;
-  if (widerN > tileN && getI8MmaWarpsPerCTA(tileM, widerN, numWarps))
-    tileN = widerN;
-  return {tileM, tileN};
+  if (directShared) {
+    int64_t widerN = std::min<int64_t>(16 * numWarps, n);
+    if (widerN > tile.second &&
+        canUseI8MmaTile(tile.first, widerN, numWarps))
+      tile.second = widerN;
+  }
+  return tile;
 }
 
 Operation *createGlobalScratchBarrier(PatternRewriter &rewriter, Location loc,
@@ -936,6 +929,19 @@ createTmemOperandScratch(PatternRewriter &rewriter, Location loc,
   return ScratchInfo{ptr, tensorTy};
 }
 
+std::optional<MmaOperandSource> createMmaOperandSource(
+    PatternRewriter &rewriter, Location loc, TmemScratchManager &scratch,
+    Value memdesc, ttg::MemDescType memTy, bool isTmem,
+    RankedTensorType tileTy, Region *scope, int64_t rowStride, int64_t stride) {
+  if (!isTmem)
+    return MmaOperandSource{Value(), memdesc, tileTy, rowStride, stride};
+  auto info =
+      createTmemOperandScratch(rewriter, loc, scratch, memdesc, memTy, scope);
+  if (!info)
+    return std::nullopt;
+  return MmaOperandSource{info->ptr, Value(), tileTy, rowStride, stride};
+}
+
 std::optional<ScratchInfo> createWGMMAScratch(PatternRewriter &rewriter,
                                               Location loc, Value operand) {
   if (auto memTy = dyn_cast<ttg::MemDescType>(operand.getType())) {
@@ -1564,18 +1570,37 @@ Value tryEmitI8DotDecomposition(PatternRewriter &rewriter, Location loc,
   return ttg::ConvertLayoutOp::create(rewriter, loc, accTy, product);
 }
 
-LogicalResult emitMmaEmulationTile(
+std::optional<scf::ForOp> emitMmaEmulationLoops(
     PatternRewriter &rewriter, Location loc, const MmaOperandSource &aSource,
-    const MmaOperandSource &bSource, Value dPtr, int64_t k, int64_t tileM,
-    int64_t tileN, RankedTensorType accTileTy,
+    const MmaOperandSource &bSource, Value dPtr, int64_t m, int64_t n,
+    int64_t k, int64_t tileM, int64_t tileN, RankedTensorType accTileTy,
     ttg::DistributedEncodingTrait accLayout, IntegerType accElem, Value useDInt,
-    Value predInt, Value mIdxI32, Value nIdxI32, int64_t dStride,
-    const DotScaleConfig &scale = {}, int64_t dRowStride = 1) {
-  bool hasSharedOperand = aSource.isShared() || bSource.isShared();
+    Value predInt, int64_t dStride, const DotScaleConfig &scale = {},
+    int64_t dRowStride = 1) {
+  if ((m % tileM) != 0 || (n % tileN) != 0)
+    return std::nullopt;
 
+  OpBuilder::InsertionGuard guard(rewriter);
   auto i32Ty = rewriter.getI32Type();
   Value zero =
       arith::ConstantOp::create(rewriter, loc, rewriter.getI32IntegerAttr(0));
+  Value mUpper =
+      arith::ConstantOp::create(rewriter, loc, rewriter.getI32IntegerAttr(m));
+  Value nUpper =
+      arith::ConstantOp::create(rewriter, loc, rewriter.getI32IntegerAttr(n));
+  Value mStep = arith::ConstantOp::create(rewriter, loc,
+                                          rewriter.getI32IntegerAttr(tileM));
+  Value nStep = arith::ConstantOp::create(rewriter, loc,
+                                          rewriter.getI32IntegerAttr(tileN));
+  auto mLoop = scf::ForOp::create(rewriter, loc, zero, mUpper, mStep);
+  rewriter.setInsertionPointToStart(mLoop.getBody());
+  auto nLoop = scf::ForOp::create(rewriter, loc, zero, nUpper, nStep);
+  rewriter.setInsertionPointToStart(nLoop.getBody());
+  Value mIdxI32 = arith::IndexCastOp::create(
+      rewriter, loc, i32Ty, mLoop.getInductionVar());
+  Value nIdxI32 = arith::IndexCastOp::create(
+      rewriter, loc, i32Ty, nLoop.getInductionVar());
+
   Value dRowStrideConst = arith::ConstantOp::create(
       rewriter, loc, rewriter.getI32IntegerAttr(dRowStride));
   Value dStrideConst = arith::ConstantOp::create(
@@ -1592,6 +1617,7 @@ LogicalResult emitMmaEmulationTile(
   Value accTileI = embedToInt(rewriter, loc, accTile);
 
   Value sum;
+  bool hasSharedOperand = aSource.isShared() || bSource.isShared();
   int numWarps = ttg::lookupNumWarps(rewriter.getInsertionBlock()->getParent());
   auto isScaleK32Aligned = [](Value scalePtr, int64_t scaleFactor) {
     return !scalePtr || (scaleFactor > 0 && ((kI8MmaK % scaleFactor) == 0 ||
@@ -1724,45 +1750,6 @@ LogicalResult emitMmaEmulationTile(
   createGlobalScratchBarrier(rewriter, loc);
   storeScratchStrided2D(rewriter, loc, dTilePtr, out, accTileTy, dRowStride,
                         dStride);
-  return success();
-}
-
-std::optional<scf::ForOp> emitMmaEmulationLoops(
-    PatternRewriter &rewriter, Location loc, const MmaOperandSource &aSource,
-    const MmaOperandSource &bSource, Value dPtr, int64_t m, int64_t n,
-    int64_t k, int64_t tileM, int64_t tileN, RankedTensorType accTileTy,
-    ttg::DistributedEncodingTrait accLayout, IntegerType accElem, Value useDInt,
-    Value predInt, int64_t dStride, const DotScaleConfig &scale = {},
-    int64_t dRowStride = 1) {
-  if ((m % tileM) != 0 || (n % tileN) != 0)
-    return std::nullopt;
-
-  OpBuilder::InsertionGuard guard(rewriter);
-  Value zero =
-      arith::ConstantOp::create(rewriter, loc, rewriter.getI32IntegerAttr(0));
-  Value mUpper =
-      arith::ConstantOp::create(rewriter, loc, rewriter.getI32IntegerAttr(m));
-  Value nUpper =
-      arith::ConstantOp::create(rewriter, loc, rewriter.getI32IntegerAttr(n));
-  Value mStep = arith::ConstantOp::create(rewriter, loc,
-                                          rewriter.getI32IntegerAttr(tileM));
-  Value nStep = arith::ConstantOp::create(rewriter, loc,
-                                          rewriter.getI32IntegerAttr(tileN));
-
-  auto mLoop = scf::ForOp::create(rewriter, loc, zero, mUpper, mStep);
-  rewriter.setInsertionPointToStart(mLoop.getBody());
-  Value mIdx = mLoop.getInductionVar();
-  auto nLoop = scf::ForOp::create(rewriter, loc, zero, nUpper, nStep);
-  rewriter.setInsertionPointToStart(nLoop.getBody());
-  auto i32Ty = rewriter.getI32Type();
-  Value mIdxI32 = arith::IndexCastOp::create(rewriter, loc, i32Ty, mIdx);
-  Value nIdxI32 =
-      arith::IndexCastOp::create(rewriter, loc, i32Ty, nLoop.getInductionVar());
-  if (failed(emitMmaEmulationTile(rewriter, loc, aSource, bSource, dPtr, k,
-                                  tileM, tileN, accTileTy, accLayout, accElem,
-                                  useDInt, predInt, mIdxI32, nIdxI32, dStride,
-                                  scale, dRowStride)))
-    return std::nullopt;
   return mLoop;
 }
 
@@ -2587,10 +2574,8 @@ struct TCGen5MMAPattern : public OpRewritePattern<ttng::TCGen5MMAOp> {
         arith::ExtUIOp::create(rewriter, loc, accElem, op.getPred());
 
     rewriter.setInsertionPoint(op);
-    auto [tileM, tileN] =
-        (!aIsTmem || !bIsTmem)
-            ? getDirectSharedMmaEmulationTileShape(rewriter, m, n, k, accElem)
-            : getMmaEmulationTileShape(rewriter, m, n, k, accElem);
+    auto [tileM, tileN] = getMmaEmulationTileShape(
+        rewriter, m, n, k, accElem, /*directShared=*/!aIsTmem || !bIsTmem);
     auto accTileLayout =
         getOptimizedBlockedEncoding(rewriter, {tileM, tileN}, accElem);
     auto accTileTy =
@@ -2608,26 +2593,14 @@ struct TCGen5MMAPattern : public OpRewritePattern<ttng::TCGen5MMAOp> {
         getOptimizedBlockedEncoding(rewriter, {k, tileN}, bTileElem);
     auto bTileTy = RankedTensorType::get({k, tileN}, bTileElem, bTileLayout);
 
-    std::optional<ScratchInfo> aScratch;
-    if (aIsTmem) {
-      aScratch = createTmemOperandScratch(rewriter, loc, *scratch, op.getA(),
-                                          aMemTy, scope);
-      if (!aScratch)
-        return emitFpSanCodegenError(op.getOperation());
-    }
-    std::optional<ScratchInfo> bScratch;
-    if (bIsTmem) {
-      bScratch = createTmemOperandScratch(rewriter, loc, *scratch, op.getB(),
-                                          bMemTy, scope);
-      if (!bScratch)
-        return emitFpSanCodegenError(op.getOperation());
-    }
-    MmaOperandSource aSource{aIsTmem ? aScratch->ptr : Value(),
-                             aIsTmem ? Value() : op.getA(), aTileTy,
-                             /*rowStride=*/1, /*stride=*/m};
-    MmaOperandSource bSource{bIsTmem ? bScratch->ptr : Value(),
-                             bIsTmem ? Value() : op.getB(), bTileTy,
-                             /*rowStride=*/1, /*stride=*/k};
+    auto aSource = createMmaOperandSource(rewriter, loc, *scratch, op.getA(),
+                                          aMemTy, aIsTmem, aTileTy, scope,
+                                          /*rowStride=*/1, /*stride=*/m);
+    auto bSource = createMmaOperandSource(rewriter, loc, *scratch, op.getB(),
+                                          bMemTy, bIsTmem, bTileTy, scope,
+                                          /*rowStride=*/1, /*stride=*/k);
+    if (!aSource || !bSource)
+      return emitFpSanCodegenError(op.getOperation());
 
     // TMEM and D scratch are written cooperatively. In two-CTA mode, the
     // cluster barrier also makes both CTAs' shared operands visible before the
@@ -2636,7 +2609,7 @@ struct TCGen5MMAPattern : public OpRewritePattern<ttng::TCGen5MMAOp> {
                                scratch->usesSharedClusterState());
 
     auto mLoop = emitMmaEmulationLoops(
-        rewriter, loc, aSource, bSource, dInfo->ptr, m, n, k, tileM, tileN,
+        rewriter, loc, *aSource, *bSource, dInfo->ptr, m, n, k, tileM, tileN,
         accTileTy, accTileLayout, accElem, useDInt, predInt, /*dStride=*/m);
     if (!mLoop)
       return emitFpSanUnsupported(op.getOperation());
@@ -2767,10 +2740,8 @@ struct TCGen5MMAScaledPattern
     if (!bScaleScratch)
       return emitFpSanCodegenError(op.getOperation());
 
-    auto [tileM, tileN] =
-        (!aIsTmem || !bIsTmem)
-            ? getDirectSharedMmaEmulationTileShape(rewriter, m, n, k, accElem)
-            : getMmaEmulationTileShape(rewriter, m, n, k, accElem);
+    auto [tileM, tileN] = getMmaEmulationTileShape(
+        rewriter, m, n, k, accElem, /*directShared=*/!aIsTmem || !bIsTmem);
 
     auto accTileLayout = getOptimizedBlockedEncoding(rewriter, {tileM, tileN},
                                                      dMemTy.getElementType());
@@ -2785,26 +2756,14 @@ struct TCGen5MMAScaledPattern
     auto bTileTy = RankedTensorType::get({bPackedK, tileN},
                                          bMemTy.getElementType(), bTileLayout);
 
-    std::optional<ScratchInfo> aScratch;
-    if (aIsTmem) {
-      aScratch = createTmemOperandScratch(rewriter, loc, *scratch, op.getA(),
-                                          aMemTy, scope);
-      if (!aScratch)
-        return emitFpSanCodegenError(op.getOperation());
-    }
-    std::optional<ScratchInfo> bScratch;
-    if (bIsTmem) {
-      bScratch = createTmemOperandScratch(rewriter, loc, *scratch, op.getB(),
-                                          bMemTy, scope);
-      if (!bScratch)
-        return emitFpSanCodegenError(op.getOperation());
-    }
-    MmaOperandSource aSource{aIsTmem ? aScratch->ptr : Value(),
-                             aIsTmem ? Value() : op.getA(), aTileTy,
-                             /*rowStride=*/1, /*stride=*/m};
-    MmaOperandSource bSource{bIsTmem ? bScratch->ptr : Value(),
-                             bIsTmem ? Value() : op.getB(), bTileTy,
-                             /*rowStride=*/1, /*stride=*/bPackedK};
+    auto aSource = createMmaOperandSource(rewriter, loc, *scratch, op.getA(),
+                                          aMemTy, aIsTmem, aTileTy, scope,
+                                          /*rowStride=*/1, /*stride=*/m);
+    auto bSource = createMmaOperandSource(
+        rewriter, loc, *scratch, op.getB(), bMemTy, bIsTmem, bTileTy, scope,
+        /*rowStride=*/1, /*stride=*/bPackedK);
+    if (!aSource || !bSource)
+      return emitFpSanCodegenError(op.getOperation());
 
     DotScaleConfig scale;
     scale.aElemType = op.getAType();
@@ -2830,8 +2789,8 @@ struct TCGen5MMAScaledPattern
                                scratch->usesSharedClusterState());
 
     auto mLoop =
-        emitMmaEmulationLoops(rewriter, loc, aSource, bSource, dInfo->ptr, m, n,
-                              k, tileM, tileN, accTileTy, accTileLayout,
+        emitMmaEmulationLoops(rewriter, loc, *aSource, *bSource, dInfo->ptr, m,
+                              n, k, tileM, tileN, accTileTy, accTileLayout,
                               accElem, useDInt, predInt, /*dStride=*/m, scale);
     if (!mLoop)
       return emitFpSanUnsupported(op.getOperation());

--- a/lib/Dialect/TritonInstrument/Transforms/FpSanitizer.cpp
+++ b/lib/Dialect/TritonInstrument/Transforms/FpSanitizer.cpp
@@ -53,6 +53,56 @@ static bool isValueAvailableInScope(Value value, Region *scope) {
 
 constexpr int64_t kTileM = 8;
 constexpr int64_t kTileN = 8;
+constexpr int64_t kI8MmaK = 32;
+
+bool supportsI8DotDecomposition(PatternRewriter &rewriter,
+                                IntegerType accElem) {
+  auto module =
+      rewriter.getInsertionBlock()->getParentOp()->getParentOfType<ModuleOp>();
+  if (getAMDArch(module))
+    return false;
+  return llvm::is_contained({16, 32, 64}, accElem.getWidth());
+}
+
+std::optional<SmallVector<unsigned>> getI8MmaWarpsPerCTA(int64_t m, int64_t n,
+                                                         int numWarps) {
+  if (m < 16 || n < 8 || (m % 16) != 0 || (n % 8) != 0 || numWarps <= 0)
+    return std::nullopt;
+
+  SmallVector<unsigned> warpsPerCTA{1, 1};
+  SmallVector<int64_t> reps{m / 16, n / 8};
+  while (warpsPerCTA[0] * warpsPerCTA[1] < numWarps) {
+    unsigned axis = reps[0] >= reps[1] ? 0 : 1;
+    if (reps[axis] <= 1 || (reps[axis] % 2) != 0)
+      axis = 1 - axis;
+    if (reps[axis] <= 1 || (reps[axis] % 2) != 0)
+      return std::nullopt;
+    warpsPerCTA[axis] *= 2;
+    reps[axis] /= 2;
+  }
+  if (warpsPerCTA[0] * warpsPerCTA[1] != numWarps)
+    return std::nullopt;
+  return warpsPerCTA;
+}
+
+std::pair<int64_t, int64_t> getMmaEmulationTileShape(PatternRewriter &rewriter,
+                                                     int64_t m, int64_t n,
+                                                     int64_t k,
+                                                     IntegerType accElem) {
+  if (supportsI8DotDecomposition(rewriter, accElem) && (k % kI8MmaK) == 0) {
+    int64_t numWarps =
+        ttg::lookupNumWarps(rewriter.getInsertionBlock()->getParent());
+    int64_t tileM = std::min<int64_t>(16 * numWarps, m);
+    while (tileM > 0 && (m % tileM) != 0)
+      tileM /= 2;
+    int64_t tileN = std::min<int64_t>(8 * numWarps, n);
+    while (tileN > 0 && (n % tileN) != 0)
+      tileN /= 2;
+    if (getI8MmaWarpsPerCTA(tileM, tileN, numWarps))
+      return {tileM, tileN};
+  }
+  return {std::min<int64_t>(kTileM, m), std::min<int64_t>(kTileN, n)};
+}
 
 Operation *createGlobalScratchBarrier(PatternRewriter &rewriter, Location loc,
                                       bool sharedClusterState = false) {
@@ -1206,6 +1256,258 @@ Value emulateDotStep(PatternRewriter &rewriter, Location loc, Value aSlice,
   return arith::MulIOp::create(rewriter, loc, aFull, bFull);
 }
 
+Value unpackPackedFp4Tensor(PatternRewriter &rewriter, Location loc,
+                            Value packed, int64_t axis,
+                            RankedTensorType logicalTy) {
+  Value packedI = embedToInt(rewriter, loc, packed);
+  auto packedTy = cast<RankedTensorType>(packedI.getType());
+  auto packedI8Ty = packedTy.clone(rewriter.getI8Type());
+  packedI = castSignedIntValueToType(rewriter, loc, packedI, packedI8Ty);
+
+  Value mask = getIntConstantLike(rewriter, loc, packedI8Ty, 0x0F);
+  Value four = getIntConstantLike(rewriter, loc, packedI8Ty, 4);
+  Value lo = arith::AndIOp::create(rewriter, loc, packedI, mask);
+  Value hi = arith::ShRUIOp::create(rewriter, loc, packedI, four);
+  auto halfTy = packedTy.clone(logicalTy.getElementType());
+  lo = castSignedIntValueToType(rewriter, loc, lo, halfTy);
+  hi = castSignedIntValueToType(rewriter, loc, hi, halfTy);
+  Value joined = tt::JoinOp::create(rewriter, loc, lo, hi);
+
+  int64_t rank = packedTy.getRank();
+  auto order = llvm::to_vector(llvm::seq<int32_t>(axis + 1));
+  order.push_back(rank);
+  llvm::append_range(order, llvm::seq<int32_t>(axis + 1, rank));
+  Value transposed = tt::TransOp::create(rewriter, loc, joined, order);
+
+  Value logical =
+      tt::ReshapeOp::create(rewriter, loc, logicalTy.getShape(), transposed);
+  if (logical.getType() != logicalTy)
+    logical = ttg::ConvertLayoutOp::create(rewriter, loc, logicalTy, logical);
+  return logical;
+}
+
+Value loadOperandK32(PatternRewriter &rewriter, Location loc, bool isLhs,
+                     Value tilePtr, RankedTensorType fullTileTy, Value kI32,
+                     int64_t rowStride, int64_t stride,
+                     int64_t packFactor = 1) {
+  SmallVector<int64_t> logicalShape{isLhs ? fullTileTy.getShape()[0] : kI8MmaK,
+                                    isLhs ? kI8MmaK : fullTileTy.getShape()[1]};
+  SmallVector<int64_t> rawShape = logicalShape;
+  rawShape[isLhs ? 1 : 0] /= packFactor;
+  auto rawLayout = getOptimizedBlockedEncoding(rewriter, rawShape,
+                                               fullTileTy.getElementType());
+  auto rawTy =
+      RankedTensorType::get(rawShape, fullTileTy.getElementType(), rawLayout);
+
+  Value packedKIdx = kI32;
+  if (packFactor != 1) {
+    Value factor = arith::ConstantOp::create(
+        rewriter, loc, rewriter.getI32IntegerAttr(packFactor));
+    packedKIdx = arith::DivUIOp::create(rewriter, loc, kI32, factor);
+  }
+  Value kStride = arith::ConstantOp::create(
+      rewriter, loc, rewriter.getI32IntegerAttr(isLhs ? stride : rowStride));
+  Value offset = arith::MulIOp::create(rewriter, loc, packedKIdx, kStride);
+  Value chunkPtr =
+      tt::AddPtrOp::create(rewriter, loc, tilePtr.getType(), tilePtr, offset);
+  Value chunk =
+      loadScratchStrided2D(rewriter, loc, chunkPtr, rawTy, rowStride, stride);
+
+  if (packFactor == 2) {
+    auto logicalLayout = getOptimizedBlockedEncoding(rewriter, logicalShape,
+                                                     rewriter.getI8Type());
+    auto logicalTy = RankedTensorType::get(logicalShape, rewriter.getI8Type(),
+                                           logicalLayout);
+    chunk = unpackPackedFp4Tensor(rewriter, loc, chunk,
+                                  /*axis=*/isLhs ? 1 : 0, logicalTy);
+  }
+  return chunk;
+}
+
+Value loadScaledScaleK32(PatternRewriter &rewriter, Location loc, bool isLhs,
+                         const DotScaleConfig &scale, Value tileIdx, Value kI32,
+                         RankedTensorType targetTy) {
+  Value ptr = isLhs ? scale.aScalePtr : scale.bScalePtr;
+  if (!ptr)
+    return Value();
+
+  int64_t scaleFactor = isLhs ? scale.aScaleFactor : scale.bScaleFactor;
+  int64_t scaleStride = isLhs ? scale.aScaleStride : scale.bScaleStride;
+  auto scaleTileTy = isLhs ? scale.aScaleTileTy : scale.bScaleTileTy;
+  int64_t groups = scaleFactor < kI8MmaK ? kI8MmaK / scaleFactor : 1;
+  int64_t repeat = kI8MmaK / groups;
+  SmallVector<int64_t> compactShape =
+      isLhs ? SmallVector<int64_t>{targetTy.getShape()[0], groups}
+            : SmallVector<int64_t>{groups, targetTy.getShape()[1]};
+  SmallVector<int64_t> broadcastShape =
+      isLhs ? SmallVector<int64_t>{targetTy.getShape()[0], groups, repeat}
+            : SmallVector<int64_t>{groups, repeat, targetTy.getShape()[1]};
+  int64_t expandAxis = isLhs ? 2 : 1;
+
+  auto broadcastLayout = getOptimizedBlockedEncoding(
+      rewriter, broadcastShape, scaleTileTy.getElementType());
+  auto compactSliceLayout = ttg::SliceEncodingAttr::get(
+      rewriter.getContext(), expandAxis, broadcastLayout);
+  auto compactLoadLayout = getOptimizedBlockedEncoding(
+      rewriter, compactShape, scaleTileTy.getElementType());
+  auto compactLoadTy = RankedTensorType::get(
+      compactShape, scaleTileTy.getElementType(), compactLoadLayout);
+
+  Value tilePtr =
+      tt::AddPtrOp::create(rewriter, loc, ptr.getType(), ptr, tileIdx);
+  Value factor = arith::ConstantOp::create(
+      rewriter, loc, rewriter.getI32IntegerAttr(scaleFactor));
+  Value groupIdx = arith::DivUIOp::create(rewriter, loc, kI32, factor);
+  Value stride = arith::ConstantOp::create(
+      rewriter, loc, rewriter.getI32IntegerAttr(scaleStride));
+  Value groupOffset = arith::MulIOp::create(rewriter, loc, groupIdx, stride);
+  Value groupPtr =
+      tt::AddPtrOp::create(rewriter, loc, ptr.getType(), tilePtr, groupOffset);
+  Value compact = loadScratchStrided2D(rewriter, loc, groupPtr, compactLoadTy,
+                                       /*stride0=*/isLhs ? 1 : scaleStride,
+                                       /*stride1=*/isLhs ? scaleStride : 1);
+  compact = castDotScaledScaleToComputePayload(rewriter, loc, compact,
+                                               scale.computeElem);
+  auto compactSliceTy = cast<RankedTensorType>(compact.getType())
+                            .cloneWithEncoding(compactSliceLayout);
+  compact =
+      ttg::ConvertLayoutOp::create(rewriter, loc, compactSliceTy, compact);
+
+  Value expanded = tt::ExpandDimsOp::create(rewriter, loc, compact, expandAxis);
+  auto broadcastTy =
+      cast<RankedTensorType>(expanded.getType()).clone(broadcastShape);
+  Value broadcast =
+      tt::BroadcastOp::create(rewriter, loc, broadcastTy, expanded);
+  Value reshaped =
+      tt::ReshapeOp::create(rewriter, loc, targetTy.getShape(), broadcast);
+  if (reshaped.getType() != targetTy)
+    reshaped = ttg::ConvertLayoutOp::create(rewriter, loc, targetTy, reshaped);
+  return reshaped;
+}
+
+Value loadScaledOperandK32(PatternRewriter &rewriter, Location loc, bool isLhs,
+                           Value tilePtr, RankedTensorType fullTileTy,
+                           const DotScaleConfig &scale, Value tileIdx,
+                           Value kI32, int64_t rowStride, int64_t stride) {
+  int64_t packFactor = isLhs ? scale.aKPackFactor : scale.bKPackFactor;
+  tt::ScaleDotElemType elemType = isLhs ? scale.aElemType : scale.bElemType;
+  Value chunk = loadOperandK32(rewriter, loc, isLhs, tilePtr, fullTileTy, kI32,
+                               rowStride, stride, packFactor);
+
+  Value payload = castDotScaledOperandToComputePayload(
+      rewriter, loc, chunk, elemType, scale.computeElem);
+  auto payloadTy = cast<RankedTensorType>(payload.getType());
+  Value scalePayload =
+      loadScaledScaleK32(rewriter, loc, isLhs, scale, tileIdx, kI32, payloadTy);
+  if (scalePayload)
+    payload = arith::MulIOp::create(rewriter, loc, payload, scalePayload);
+  return payload;
+}
+
+Value tryEmitI8DotDecomposition(PatternRewriter &rewriter, Location loc,
+                                Value aPayload, Value bPayload,
+                                Attribute accLayout, IntegerType accElem,
+                                int numWarps) {
+  auto aPayloadTy = cast<RankedTensorType>(aPayload.getType());
+  auto bPayloadTy = cast<RankedTensorType>(bPayload.getType());
+  auto aShape = aPayloadTy.getShape();
+  auto bShape = bPayloadTy.getShape();
+  int64_t m = aShape[0];
+  int64_t k = aShape[1];
+  int64_t n = bShape[1];
+  if (bShape[0] != k || (k % kI8MmaK) != 0 ||
+      !supportsI8DotDecomposition(rewriter, accElem))
+    return Value();
+  auto warpsPerCTA = getI8MmaWarpsPerCTA(m, n, numWarps);
+  if (!warpsPerCTA)
+    return Value();
+
+  auto aElem = cast<IntegerType>(aPayloadTy.getElementType());
+  auto bElem = cast<IntegerType>(bPayloadTy.getElementType());
+  assert((aElem.getWidth() % 8) == 0 && (bElem.getWidth() % 8) == 0);
+  int64_t aLimbs = aElem.getWidth() / 8;
+  int64_t bLimbs = bElem.getWidth() / 8;
+  int64_t accLimbs = accElem.getWidth() / 8;
+  int64_t highestDiagonal = std::min(accLimbs - 1, aLimbs + bLimbs - 2);
+
+  auto *ctx = rewriter.getContext();
+  auto i8Ty = rewriter.getI8Type();
+  auto i32Ty = rewriter.getI32Type();
+  auto mmaLayout = ttg::NvidiaMmaEncodingAttr::get(
+      ctx, /*versionMajor=*/2, /*versionMinor=*/0, *warpsPerCTA,
+      ttg::getCGALayout(accLayout), SmallVector<unsigned>{16, 8});
+  auto aDotLayout = ttg::DotOperandEncodingAttr::get(ctx, 0, mmaLayout, i8Ty);
+  auto bDotLayout = ttg::DotOperandEncodingAttr::get(ctx, 1, mmaLayout, i8Ty);
+  auto accMmaTy = RankedTensorType::get({m, n}, i32Ty, mmaLayout);
+
+  auto extractLimb = [&](Value payload, ttg::DotOperandEncodingAttr layout,
+                         int64_t limb) {
+    auto payloadTy = cast<RankedTensorType>(payload.getType());
+    auto blockedLimbTy = payloadTy.clone(i8Ty);
+    auto dotLimbTy = blockedLimbTy.cloneWithEncoding(layout);
+    Value shifted = payload;
+    if (limb != 0) {
+      Value shift = getIntConstantLike(rewriter, loc, payloadTy, 8 * limb);
+      shifted = arith::ShRUIOp::create(rewriter, loc, shifted, shift);
+    }
+    Value truncated =
+        arith::TruncIOp::create(rewriter, loc, blockedLimbTy, shifted);
+    return ttg::ConvertLayoutOp::create(rewriter, loc, dotLimbTy, truncated);
+  };
+
+  auto emitByteDiagonal = [&](Value sum, int64_t diagonal) {
+    int64_t firstALimb = std::max<int64_t>(0, diagonal - bLimbs + 1);
+    int64_t lastALimb = std::min(diagonal, aLimbs - 1);
+    for (int64_t aLimb = firstALimb; aLimb <= lastALimb; ++aLimb) {
+      int64_t bLimb = diagonal - aLimb;
+      Value a = extractLimb(aPayload, aDotLayout, aLimb);
+      Value b = extractLimb(bPayload, bDotLayout, bLimb);
+      auto dot = DotI8Op::create(rewriter, loc, accMmaTy, a, b, sum,
+                                 aLimb == aLimbs - 1, bLimb == bLimbs - 1);
+      sum = dot.getResult();
+    }
+    return sum;
+  };
+
+  if (accElem.getWidth() == 64) {
+    // Complete each K32 byte diagonal in i32 before widening it.  The largest
+    // diagonal is 8 * kI8MmaK * 255^2 < 2^24, so its i32 result is exact.
+    auto accTy = RankedTensorType::get({m, n}, accElem, accLayout);
+    Value product = getIntConstantLike(rewriter, loc, accTy, 0);
+    for (int64_t diagonal = highestDiagonal; diagonal >= 0; --diagonal) {
+      if (diagonal != highestDiagonal) {
+        Value shift = getIntConstantLike(rewriter, loc, accTy, 8);
+        product = arith::ShLIOp::create(rewriter, loc, product, shift);
+      }
+
+      Value diagonalSum = getIntConstantLike(rewriter, loc, accMmaTy, 0);
+      diagonalSum = emitByteDiagonal(diagonalSum, diagonal);
+      auto diagonalTy = RankedTensorType::get({m, n}, i32Ty, accLayout);
+      if (diagonalSum.getType() != diagonalTy) {
+        diagonalSum = ttg::ConvertLayoutOp::create(rewriter, loc, diagonalTy,
+                                                   diagonalSum);
+      }
+      Value diagonalWide =
+          arith::ExtSIOp::create(rewriter, loc, accTy, diagonalSum);
+      product = arith::AddIOp::create(rewriter, loc, product, diagonalWide);
+    }
+    return product;
+  }
+
+  Value product = getIntConstantLike(rewriter, loc, accMmaTy, 0);
+  for (int64_t diagonal = highestDiagonal; diagonal >= 0; --diagonal) {
+    if (diagonal != highestDiagonal) {
+      Value shift = getIntConstantLike(rewriter, loc, accMmaTy, 8);
+      product = arith::ShLIOp::create(rewriter, loc, product, shift);
+    }
+    product = emitByteDiagonal(product, diagonal);
+  }
+  auto accTy = RankedTensorType::get({m, n}, i32Ty, accLayout);
+  if (product.getType() == accTy)
+    return product;
+  return ttg::ConvertLayoutOp::create(rewriter, loc, accTy, product);
+}
+
 std::optional<scf::ForOp> emitMmaEmulationLoops(
     PatternRewriter &rewriter, Location loc, Value aPtr, Value bPtr, Value dPtr,
     int64_t m, int64_t n, int64_t k, int64_t tileM, int64_t tileN,
@@ -1268,67 +1570,133 @@ std::optional<scf::ForOp> emitMmaEmulationLoops(
   Value bTilePtr =
       tt::AddPtrOp::create(rewriter, loc, bPtr.getType(), bPtr, bOffset);
 
-  auto aSliceTy =
-      RankedTensorType::get({tileM, 1}, aTileTy.getElementType(), accLayout);
-  auto bSliceTy =
-      RankedTensorType::get({1, tileN}, bTileTy.getElementType(), accLayout);
-  Value aStrideVal = arith::ConstantOp::create(
-      rewriter, loc, rewriter.getI32IntegerAttr(aStride));
+  Value sum;
+  int numWarps = ttg::lookupNumWarps(rewriter.getInsertionBlock()->getParent());
+  auto isScaleK32Aligned = [](Value scalePtr, int64_t scaleFactor) {
+    return !scalePtr || (scaleFactor > 0 && ((kI8MmaK % scaleFactor) == 0 ||
+                                             (scaleFactor % kI8MmaK) == 0));
+  };
+  bool canUseI8Decomposition =
+      (k % kI8MmaK) == 0 && supportsI8DotDecomposition(rewriter, accElem) &&
+      isScaleK32Aligned(scale.aScalePtr, scale.aScaleFactor) &&
+      isScaleK32Aligned(scale.bScalePtr, scale.bScaleFactor) &&
+      getI8MmaWarpsPerCTA(tileM, tileN, numWarps).has_value();
+  if (canUseI8Decomposition) {
+    if (!scale.computeElem && accElem.getWidth() <= 32) {
+      Value aTile = loadScratchStrided2D(rewriter, loc, aTilePtr, aTileTy,
+                                         aRowStride, aStride);
+      Value bTile = loadScratchStrided2D(rewriter, loc, bTilePtr, bTileTy,
+                                         bRowStride, bStride);
+      sum = tryEmitI8DotDecomposition(
+          rewriter, loc, embedToInt(rewriter, loc, aTile),
+          embedToInt(rewriter, loc, bTile), accLayout, accElem, numWarps);
+      assert(sum && "i8 decomposition eligibility must match its emitter");
+      sum = castSignedIntValueToType(rewriter, loc, sum, accTileI.getType());
+    } else {
+      Value zeroSum = getIntConstantLike(rewriter, loc, accTileI.getType(), 0);
+      Value kUpper = arith::ConstantOp::create(rewriter, loc,
+                                               rewriter.getI32IntegerAttr(k));
+      Value kStep = arith::ConstantOp::create(
+          rewriter, loc, rewriter.getI32IntegerAttr(kI8MmaK));
+      auto kLoop =
+          scf::ForOp::create(rewriter, loc, zero, kUpper, kStep, zeroSum);
+      rewriter.setInsertionPointToStart(kLoop.getBody());
+      Value kIdx = kLoop.getInductionVar();
+      Value kI32 = arith::IndexCastOp::create(rewriter, loc, i32Ty, kIdx);
+      Value aChunk;
+      Value bChunk;
+      if (scale.computeElem) {
+        aChunk = loadScaledOperandK32(rewriter, loc, /*isLhs=*/true, aTilePtr,
+                                      aTileTy, scale, mIdxI32, kI32, aRowStride,
+                                      aStride);
+        bChunk = loadScaledOperandK32(rewriter, loc, /*isLhs=*/false, bTilePtr,
+                                      bTileTy, scale, nIdxI32, kI32, bRowStride,
+                                      bStride);
+      } else {
+        aChunk = loadOperandK32(rewriter, loc, /*isLhs=*/true, aTilePtr,
+                                aTileTy, kI32, aRowStride, aStride);
+        bChunk = loadOperandK32(rewriter, loc, /*isLhs=*/false, bTilePtr,
+                                bTileTy, kI32, bRowStride, bStride);
+      }
+      Value partial = tryEmitI8DotDecomposition(
+          rewriter, loc, embedToInt(rewriter, loc, aChunk),
+          embedToInt(rewriter, loc, bChunk), accLayout, accElem, numWarps);
+      assert(partial && "K32 decomposition must be eligible");
+      partial =
+          castSignedIntValueToType(rewriter, loc, partial, accTileI.getType());
+      Value next = arith::AddIOp::create(rewriter, loc,
+                                         kLoop.getRegionIterArgs()[0], partial);
+      scf::YieldOp::create(rewriter, loc, next);
+      rewriter.setInsertionPointAfter(kLoop);
+      sum = kLoop.getResult(0);
+    }
+  }
 
-  Value zeroSum = getIntConstantLike(rewriter, loc, accTileI.getType(), 0);
-  Value kUpper =
-      arith::ConstantOp::create(rewriter, loc, rewriter.getI32IntegerAttr(k));
-  Value kStep =
-      arith::ConstantOp::create(rewriter, loc, rewriter.getI32IntegerAttr(1));
-  auto kLoop = scf::ForOp::create(rewriter, loc, zero, kUpper, kStep, zeroSum);
-  rewriter.setInsertionPointToStart(kLoop.getBody());
-  Value kIdx = kLoop.getInductionVar();
-  Value kI32 = arith::IndexCastOp::create(rewriter, loc, i32Ty, kIdx);
-  Value aKIdx = kI32;
-  Value bKIdx = kI32;
-  if (scale.aKPackFactor == 2) {
-    Value aPackFactor = arith::ConstantOp::create(
-        rewriter, loc, rewriter.getI32IntegerAttr(scale.aKPackFactor));
-    aKIdx = arith::DivUIOp::create(rewriter, loc, kI32, aPackFactor);
-  }
-  if (scale.bKPackFactor == 2) {
-    Value bPackFactor = arith::ConstantOp::create(
-        rewriter, loc, rewriter.getI32IntegerAttr(scale.bKPackFactor));
-    bKIdx = arith::DivUIOp::create(rewriter, loc, kI32, bPackFactor);
-  }
-  Value aOffset =
-      arith::MulIOp::create(rewriter, loc, i32Ty, aKIdx, aStrideVal);
-  Value aSlicePtr =
-      tt::AddPtrOp::create(rewriter, loc, aPtr.getType(), aTilePtr, aOffset);
-  Value aSlice = loadScratchStrided2D(rewriter, loc, aSlicePtr, aSliceTy,
-                                      aRowStride, aStride);
-  Value bKOffset = arith::MulIOp::create(rewriter, loc, bKIdx, bRowStrideConst);
-  Value bSlicePtr =
-      tt::AddPtrOp::create(rewriter, loc, bPtr.getType(), bTilePtr, bKOffset);
-  Value bSlice = loadScratchStrided2D(rewriter, loc, bSlicePtr, bSliceTy,
-                                      bRowStride, bStride);
-  Value aScaleSlice;
-  if (scale.aScalePtr) {
+  if (!sum) {
+    auto aSliceTy =
+        RankedTensorType::get({tileM, 1}, aTileTy.getElementType(), accLayout);
+    auto bSliceTy =
+        RankedTensorType::get({1, tileN}, bTileTy.getElementType(), accLayout);
+    Value aStrideVal = arith::ConstantOp::create(
+        rewriter, loc, rewriter.getI32IntegerAttr(aStride));
+
+    Value zeroSum = getIntConstantLike(rewriter, loc, accTileI.getType(), 0);
+    Value kUpper =
+        arith::ConstantOp::create(rewriter, loc, rewriter.getI32IntegerAttr(k));
+    Value kStep =
+        arith::ConstantOp::create(rewriter, loc, rewriter.getI32IntegerAttr(1));
+    auto kLoop =
+        scf::ForOp::create(rewriter, loc, zero, kUpper, kStep, zeroSum);
+    rewriter.setInsertionPointToStart(kLoop.getBody());
+    Value kIdx = kLoop.getInductionVar();
+    Value kI32 = arith::IndexCastOp::create(rewriter, loc, i32Ty, kIdx);
+    Value aKIdx = kI32;
+    Value bKIdx = kI32;
+    if (scale.aKPackFactor == 2) {
+      Value aPackFactor = arith::ConstantOp::create(
+          rewriter, loc, rewriter.getI32IntegerAttr(scale.aKPackFactor));
+      aKIdx = arith::DivUIOp::create(rewriter, loc, kI32, aPackFactor);
+    }
+    if (scale.bKPackFactor == 2) {
+      Value bPackFactor = arith::ConstantOp::create(
+          rewriter, loc, rewriter.getI32IntegerAttr(scale.bKPackFactor));
+      bKIdx = arith::DivUIOp::create(rewriter, loc, kI32, bPackFactor);
+    }
+    Value aOffset =
+        arith::MulIOp::create(rewriter, loc, i32Ty, aKIdx, aStrideVal);
+    Value aSlicePtr =
+        tt::AddPtrOp::create(rewriter, loc, aPtr.getType(), aTilePtr, aOffset);
+    Value aSlice = loadScratchStrided2D(rewriter, loc, aSlicePtr, aSliceTy,
+                                        aRowStride, aStride);
+    Value bKOffset =
+        arith::MulIOp::create(rewriter, loc, bKIdx, bRowStrideConst);
+    Value bSlicePtr =
+        tt::AddPtrOp::create(rewriter, loc, bPtr.getType(), bTilePtr, bKOffset);
+    Value bSlice = loadScratchStrided2D(rewriter, loc, bSlicePtr, bSliceTy,
+                                        bRowStride, bStride);
     if (scale.aKPackFactor == 2)
       aSlice = unpackPackedFp4Slice(rewriter, loc, aSlice, kI32);
-    aScaleSlice =
-        loadScaleSlice(rewriter, loc, /*isLhs=*/true, scale, mIdxI32, kI32);
-  }
-  Value bScaleSlice;
-  if (scale.bScalePtr) {
     if (scale.bKPackFactor == 2)
       bSlice = unpackPackedFp4Slice(rewriter, loc, bSlice, kI32);
-    bScaleSlice =
-        loadScaleSlice(rewriter, loc, /*isLhs=*/false, scale, nIdxI32, kI32);
+    Value aScaleSlice;
+    if (scale.aScalePtr) {
+      aScaleSlice =
+          loadScaleSlice(rewriter, loc, /*isLhs=*/true, scale, mIdxI32, kI32);
+    }
+    Value bScaleSlice;
+    if (scale.bScalePtr) {
+      bScaleSlice =
+          loadScaleSlice(rewriter, loc, /*isLhs=*/false, scale, nIdxI32, kI32);
+    }
+    Value partial =
+        emulateDotStep(rewriter, loc, aSlice, bSlice, aScaleSlice, bScaleSlice,
+                       tileM, tileN, accLayout, accElem, scale);
+    Value acc = kLoop.getRegionIterArgs()[0];
+    Value next = arith::AddIOp::create(rewriter, loc, acc, partial);
+    scf::YieldOp::create(rewriter, loc, next);
+    rewriter.setInsertionPointAfter(kLoop);
+    sum = kLoop.getResult(0);
   }
-  Value partial =
-      emulateDotStep(rewriter, loc, aSlice, bSlice, aScaleSlice, bScaleSlice,
-                     tileM, tileN, accLayout, accElem, scale);
-  Value acc = kLoop.getRegionIterArgs()[0];
-  Value next = arith::AddIOp::create(rewriter, loc, acc, partial);
-  scf::YieldOp::create(rewriter, loc, next);
-  rewriter.setInsertionPointAfter(kLoop);
-  Value sum = kLoop.getResult(0);
 
   Value useDMask =
       tt::SplatOp::create(rewriter, loc, accTileI.getType(), useDInt);
@@ -1342,7 +1710,9 @@ std::optional<scf::ForOp> emitMmaEmulationLoops(
   Value outMasked = arith::MulIOp::create(rewriter, loc, outI, predMask);
   Value accMasked = arith::MulIOp::create(rewriter, loc, accTileI, predInv);
   Value outSelI = arith::AddIOp::create(rewriter, loc, outMasked, accMasked);
-  Value out = unembedToFloat(rewriter, loc, outSelI, accTileTy);
+  Value out = isFloatLike(accTileTy)
+                  ? unembedToFloat(rewriter, loc, outSelI, accTileTy)
+                  : outSelI;
   createGlobalScratchBarrier(rewriter, loc);
   storeScratchStrided2D(rewriter, loc, dTilePtr, out, accTileTy, dRowStride,
                         dStride);
@@ -1565,30 +1935,10 @@ struct Fp4ToFpPattern : public OpRewritePattern<ttg::Fp4ToFpOp> {
     if (!srcElemTy || srcElemTy.getWidth() != 8)
       return emitFpSanInvariantError(op.getOperation());
 
-    int64_t axis = op.getAxis();
-    int64_t rank = srcTy.getRank();
     auto dstIntTy = cast<RankedTensorType>(getIntTypeLike(dstTy));
-    auto halfIntTy = srcTy.clone(dstIntTy.getElementType());
-
     auto loc = op.getLoc();
-    auto mask = getIntConstantLike(rewriter, loc, srcTy, 0x0F);
-    auto four = getIntConstantLike(rewriter, loc, srcTy, 4);
-    Value lo = arith::AndIOp::create(rewriter, loc, op.getSrc(), mask);
-    Value hi = arith::ShRUIOp::create(rewriter, loc, op.getSrc(), four);
-    auto loI = castSignedIntValueToType(rewriter, loc, lo, halfIntTy);
-    auto hiI = castSignedIntValueToType(rewriter, loc, hi, halfIntTy);
-    Value joined = tt::JoinOp::create(rewriter, loc, loI, hiI);
-
-    auto order = llvm::to_vector(llvm::seq<int32_t>(axis + 1));
-    order.push_back(rank);
-    llvm::append_range(order, llvm::seq<int32_t>(axis + 1, rank));
-    auto transposed = tt::TransOp::create(rewriter, loc, joined, order);
-
-    Value result =
-        tt::ReshapeOp::create(rewriter, loc, dstTy.getShape(), transposed);
-    if (result.getType() != dstIntTy)
-      result = ttg::ConvertLayoutOp::create(rewriter, loc, dstIntTy, result);
-
+    Value result = unpackPackedFp4Tensor(rewriter, loc, op.getSrc(),
+                                         op.getAxis(), dstIntTy);
     rewriter.replaceOp(op, unembedToFloat(rewriter, loc, result, dstTy));
     return success();
   }
@@ -1668,13 +2018,11 @@ struct DotPattern : public OpRewritePattern<tt::DotOp> {
     Value predInt = arith::ConstantOp::create(
         rewriter, loc, rewriter.getIntegerAttr(accElem, 1));
 
-    int64_t tileM = std::min<int64_t>(kTileM, m);
-    int64_t tileN = std::min<int64_t>(kTileN, n);
+    auto [tileM, tileN] = getMmaEmulationTileShape(rewriter, m, n, k, accElem);
 
     // Use optimized blocked layouts for emulation tiles instead of the
     // original dot encodings.  Encodings like AMDWmmaEncodingAttr impose
-    // minimum shape requirements (e.g. >= 16x16) that the small emulation
-    // tiles (kTileM x kTileN = 8x8) cannot satisfy.
+    // minimum shape requirements that FMA fallback tiles cannot satisfy.
     auto accLayout = getOptimizedBlockedEncoding(rewriter, {tileM, tileN},
                                                  cTy.getElementType());
     auto aLayout =
@@ -1823,8 +2171,7 @@ struct DotScaledPattern : public OpRewritePattern<tt::DotScaledOp> {
     Value predInt = arith::ConstantOp::create(
         rewriter, loc, rewriter.getIntegerAttr(accElem, 1));
 
-    int64_t tileM = std::min<int64_t>(kTileM, m);
-    int64_t tileN = std::min<int64_t>(kTileN, n);
+    auto [tileM, tileN] = getMmaEmulationTileShape(rewriter, m, n, k, accElem);
 
     auto accLayout = getOptimizedBlockedEncoding(rewriter, {tileM, tileN},
                                                  cTy.getElementType());
@@ -2093,8 +2440,7 @@ struct WarpGroupDotPattern : public OpRewritePattern<ttng::WarpGroupDotOp> {
     if (!aScratch || !bScratch || !dPtr)
       return emitFpSanCodegenError(op.getOperation());
 
-    int64_t tileM = std::min<int64_t>(kTileM, m);
-    int64_t tileN = std::min<int64_t>(kTileN, n);
+    auto [tileM, tileN] = getMmaEmulationTileShape(rewriter, m, n, k, accElem);
 
     auto accTileLayout = getOptimizedBlockedEncoding(rewriter, {tileM, tileN},
                                                      cTy.getElementType());
@@ -2189,26 +2535,28 @@ struct TCGen5MMAPattern : public OpRewritePattern<ttng::TCGen5MMAOp> {
     if (!bScratch)
       return emitFpSanCodegenError(op.getOperation());
 
-    int64_t tileM = std::min<int64_t>(kTileM, m);
-    int64_t tileN = std::min<int64_t>(kTileN, n);
-
-    auto accTileLayout = getOptimizedBlockedEncoding(rewriter, {tileM, tileN},
-                                                     dMemTy.getElementType());
-    auto accTileTy = RankedTensorType::get(
-        {tileM, tileN}, dMemTy.getElementType(), accTileLayout);
-    auto aTileLayout = getOptimizedBlockedEncoding(rewriter, {tileM, k},
-                                                   aMemTy.getElementType());
-    auto aTileTy =
-        RankedTensorType::get({tileM, k}, aMemTy.getElementType(), aTileLayout);
-    auto bTileLayout = getOptimizedBlockedEncoding(rewriter, {k, tileN},
-                                                   bMemTy.getElementType());
-    auto bTileTy =
-        RankedTensorType::get({k, tileN}, bMemTy.getElementType(), bTileLayout);
-
     // Each warp may only populate a subset of the operand scratch tiles, so
     // synchronize before the emulation loops start reading them.
     createGlobalScratchBarrier(rewriter, loc,
                                scratch->usesSharedClusterState());
+
+    auto [tileM, tileN] = getMmaEmulationTileShape(rewriter, m, n, k, accElem);
+    auto accTileLayout =
+        getOptimizedBlockedEncoding(rewriter, {tileM, tileN}, accElem);
+    auto accTileTy =
+        RankedTensorType::get({tileM, tileN}, accElem, accTileLayout);
+    auto aTileLayout = getOptimizedBlockedEncoding(
+        rewriter, {tileM, k},
+        getScratchStorageElementType(aMemTy.getElementType()));
+    auto aTileTy = RankedTensorType::get(
+        {tileM, k}, getScratchStorageElementType(aMemTy.getElementType()),
+        aTileLayout);
+    auto bTileLayout = getOptimizedBlockedEncoding(
+        rewriter, {k, tileN},
+        getScratchStorageElementType(bMemTy.getElementType()));
+    auto bTileTy = RankedTensorType::get(
+        {k, tileN}, getScratchStorageElementType(bMemTy.getElementType()),
+        bTileLayout);
 
     auto mLoop = emitMmaEmulationLoops(
         rewriter, loc, aScratch->ptr, bScratch->ptr, dInfo->ptr, m, n, k, tileM,
@@ -2351,8 +2699,7 @@ struct TCGen5MMAScaledPattern
     if (!bScaleScratch)
       return emitFpSanCodegenError(op.getOperation());
 
-    int64_t tileM = std::min<int64_t>(kTileM, m);
-    int64_t tileN = std::min<int64_t>(kTileN, n);
+    auto [tileM, tileN] = getMmaEmulationTileShape(rewriter, m, n, k, accElem);
 
     auto accTileLayout = getOptimizedBlockedEncoding(rewriter, {tileM, tileN},
                                                      dMemTy.getElementType());

--- a/lib/Dialect/TritonNvidiaGPU/IR/Ops.cpp
+++ b/lib/Dialect/TritonNvidiaGPU/IR/Ops.cpp
@@ -149,13 +149,6 @@ bool WarpGroupDotOp::needsPartialAccumulator() {
   return isFP8 && accFP32 && maxNumImpreciseAcc <= aTensorTy.getShape()[1];
 }
 
-bool WarpGroupDotOp::verifyDims() {
-  auto aShape = this->getA().getType().getShape();
-  auto bShape = this->getB().getType().getShape();
-
-  return aShape[aShape.size() - 1] == bShape[aShape.size() - 2];
-}
-
 // -- WarpGroupDotWaitOp --
 LogicalResult WarpGroupDotWaitOp::inferReturnTypes(
     MLIRContext *context, std::optional<Location> location, ValueRange operands,
@@ -975,13 +968,6 @@ void TCGen5MMAOp::getEffects(
   for (auto &barrierMutable : getBarriersMutable())
     effects.emplace_back(MemoryEffects::Write::get(), &barrierMutable,
                          SharedMemory::get());
-}
-
-bool TCGen5MMAOp::verifyDims() {
-  auto aShape = this->getA().getType().getShape();
-  auto bShape = this->getB().getType().getShape();
-
-  return aShape[aShape.size() - 1] == bShape[aShape.size() - 2];
 }
 
 Value TCGen5MMAOp::useAccumulator() { return getUseD(); }

--- a/python/src/llvm.cc
+++ b/python/src/llvm.cc
@@ -4,6 +4,7 @@
 #include "triton/Tools/Sys/GetEnv.h"
 #include "llvm/ADT/SmallVector.h"
 #include "llvm/Analysis/ScopedNoAliasAA.h"
+#include "llvm/Analysis/TargetTransformInfo.h"
 #include "llvm/CodeGen/MIRParser/MIRParser.h"
 #include "llvm/CodeGen/MachineModuleInfo.h"
 #include "llvm/CodeGen/MachineRegisterInfo.h"
@@ -31,6 +32,7 @@
 #include "llvm/Transforms/InstCombine/InstCombine.h"
 #include "llvm/Transforms/Instrumentation/AddressSanitizer.h"
 #include "llvm/Transforms/Instrumentation/AddressSanitizerOptions.h"
+#include "llvm/Transforms/Scalar.h"
 #include <csignal>
 #include <cstdio>
 #include <memory>
@@ -325,12 +327,10 @@ translateLLVMIRToMIR(llvm::Module &module, const std::string &triple,
   return result;
 }
 
-std::string translateLLVMIRToASM(llvm::Module &module,
-                                 const std::string &triple,
-                                 const std::string &proc,
-                                 const std::string &features,
-                                 const std::vector<std::string> &flags,
-                                 bool enable_fp_fusion, bool isObject) {
+std::string translateLLVMIRToASM(
+    llvm::Module &module, const std::string &triple, const std::string &proc,
+    const std::string &features, const std::vector<std::string> &flags,
+    bool enable_fp_fusion, bool isObject, bool canonicalizeGEP) {
   using namespace mlir;
 
   // Apply flags
@@ -386,6 +386,16 @@ std::string translateLLVMIRToASM(llvm::Module &module,
   auto machine = createTargetMachine(&module, proc, enable_fp_fusion, features);
   // set data layout
   module.setDataLayout(machine->createDataLayout());
+  if (canonicalizeGEP && !disableLLVMOpt) {
+    // The NVPTX pipeline otherwise exposes many equivalent GEPs to SLSR
+    // without eliminating them first.
+    llvm::legacy::PassManager cleanup;
+    cleanup.add(llvm::createTargetTransformInfoWrapperPass(
+        machine->getTargetIRAnalysis()));
+    cleanup.add(llvm::createSeparateConstOffsetFromGEPPass());
+    cleanup.add(llvm::createEarlyCSEPass());
+    cleanup.run(module);
+  }
   // emit machine code
   std::string result;
   {
@@ -773,7 +783,8 @@ void init_triton_llvm(py::module &&m) {
       "translate_to_asm",
       [](std::string llvmIR, std::string triple, std::string proc,
          std::string features, std::vector<std::string> flags,
-         bool enable_fp_fusion, bool isObject) -> py::object {
+         bool enable_fp_fusion, bool isObject,
+         bool canonicalizeGEP) -> py::object {
         std::string obj;
         {
           // when allow_threads goes out of scope, gil will be released
@@ -790,8 +801,9 @@ void init_triton_llvm(py::module &&m) {
                 "failed to parse IR: " + error.getMessage() +
                 "lineno: " + std::to_string(error.getLineNo()));
           }
-          obj = translateLLVMIRToASM(*module, triple, proc, features, flags,
-                                     enable_fp_fusion, isObject);
+          obj =
+              translateLLVMIRToASM(*module, triple, proc, features, flags,
+                                   enable_fp_fusion, isObject, canonicalizeGEP);
         }
         if (isObject)
           return py::bytes(obj);

--- a/python/test/gluon/test_fpsan.py
+++ b/python/test/gluon/test_fpsan.py
@@ -1771,6 +1771,70 @@ def test_tcgen05_mma(device, use_acc, fresh_knobs):
 
 
 @pytest.mark.skipif(not is_blackwell(), reason="Requires Blackwell")
+@pytest.mark.parametrize("partition_warps", [4, 2, 1])
+def test_tcgen05_mma_warp_specialize_partition(device, partition_warps, fresh_knobs):
+    _require_cuda_backend(device)
+
+    M = gl.constexpr(64)
+    N = gl.constexpr(32)
+    K = gl.constexpr(32)
+    PARTITION_WARPS = gl.constexpr(partition_warps)
+    fresh_knobs.compilation.instrumentation_mode = "fpsan"
+
+    @gluon.jit
+    def default_partition():
+        pass
+
+    @gluon.jit
+    def mma_partition(smem_a, smem_b, acc_tmem, bar):
+        tcgen05_mma(smem_a, smem_b.permute((1, 0)), acc_tmem, use_acc=False, pred=True, mbarriers=[bar])
+
+    @gluon.jit
+    def kernel(a_ptr, b_ptr, out_ptr):
+        layout: gl.constexpr = gl.BlockedLayout([1, 1], [32, 1], [gl.num_warps(), 1], [1, 0])
+        offs_m = gl.arange(0, M, layout=gl.SliceLayout(1, layout))[:, None]
+        offs_n = gl.arange(0, N, layout=gl.SliceLayout(1, layout))[:, None]
+        offs_k = gl.arange(0, K, layout=gl.SliceLayout(0, layout))[None, :]
+        out_offs_n = gl.arange(0, N, layout=gl.SliceLayout(0, layout))[None, :]
+
+        a = gl.load(a_ptr + offs_m * K + offs_k)
+        b = gl.load(b_ptr + offs_n * K + offs_k)
+        smem_a = gl.allocate_shared_memory(gl.float32, [M, K], gl.NVMMASharedLayout.get_default_for([M, K], gl.float32),
+                                           a)
+        smem_b = gl.allocate_shared_memory(gl.float32, [N, K], gl.NVMMASharedLayout.get_default_for([N, K], gl.float32),
+                                           b)
+        acc_tmem = allocate_tensor_memory(gl.float32, [M, N], layout=TensorMemoryLayout((M, N), col_stride=1))
+        bar = mbarrier.allocate_mbarrier()
+        mbarrier.init(bar, count=1)
+
+        gl.warp_specialize([
+            (default_partition, ()),
+            (mma_partition, (smem_a, smem_b, acc_tmem, bar)),
+        ], [PARTITION_WARPS])
+
+        mbarrier.wait(bar, phase=0, deps=[smem_a, smem_b])
+        mbarrier.invalidate(bar)
+        out = gl.convert_layout(acc_tmem.load(), layout)
+        gl.store(out_ptr + offs_m * N + out_offs_n, out)
+
+    rs = np.random.RandomState(0)
+    a_bits = rs.randint(-(2**31), 2**31 - 1, size=(M.value, K.value), dtype=np.int32)
+    b_bits = rs.randint(-(2**31), 2**31 - 1, size=(N.value, K.value), dtype=np.int32)
+    exp_bits = _mm_payload_u32(a_bits, b_bits.T)
+    a = torch.tensor(a_bits, device=device, dtype=torch.int32)
+    b = torch.tensor(b_bits, device=device, dtype=torch.int32)
+    out = torch.empty((M.value, N.value), device=device, dtype=torch.int32)
+
+    kernel[(1, )](
+        triton.TensorWrapper(a, dtype=torch.float32),
+        triton.TensorWrapper(b, dtype=torch.float32),
+        triton.TensorWrapper(out, dtype=torch.float32),
+        num_warps=4,
+    )
+    _assert_payload_equal(out, exp_bits)
+
+
+@pytest.mark.skipif(not is_blackwell(), reason="Requires Blackwell")
 @pytest.mark.parametrize("use_acc", [False, True])
 def test_tcgen05_mma_two_ctas(device, use_acc, fresh_knobs):
     _require_cuda_backend(device)

--- a/python/test/unit/runtime/test_cache.py
+++ b/python/test/unit/runtime/test_cache.py
@@ -160,6 +160,68 @@ def test_nested2_change():
     assert baseline != updated
 
 
+ORDER_DEPENDENT_CONSTEXPR = tl.constexpr(42)
+
+
+@triton.jit
+def order_dependent_inner():
+    return ORDER_DEPENDENT_CONSTEXPR
+
+
+@triton.jit
+def order_dependent_outer():
+    order_dependent_inner()
+
+
+def test_cache_key_independent_of_dependency_hash_order():
+    functions = (order_dependent_inner, order_dependent_outer)
+
+    for function in functions:
+        function.hash = None
+        function.used_global_vals = {}
+    cold_key = order_dependent_outer.cache_key
+
+    for function in functions:
+        function.hash = None
+        function.used_global_vals = {}
+    order_dependent_inner.cache_key
+    prehashed_key = order_dependent_outer.cache_key
+
+    assert prehashed_key == cold_key
+
+
+def test_cache_key_independent_of_globals_dict_identity():
+
+    def make_child(value):
+        shared = tl.constexpr(value)
+
+        @triton.jit
+        def child():
+            return shared
+
+        return child
+
+    child_a = make_child(1)
+    child_b = make_child(2)
+
+    @triton.jit
+    def parent():
+        child_a()
+        child_b()
+
+    functions = (child_a, child_b, parent)
+
+    def key_after_prehashing(first, second):
+        for function in functions:
+            function.hash = None
+            function.used_global_vals = {}
+        first.cache_key
+        second.cache_key
+        return parent.cache_key
+
+    assert key_after_prehashing(child_a, child_b) == key_after_prehashing(child_b, child_a)
+
+
 def test_combine_fn_change():
     # Test that tl.reduce and associative_scan calls include
     # the combine_fn in the hash

--- a/python/test/unit/runtime/test_cache_determinism.py
+++ b/python/test/unit/runtime/test_cache_determinism.py
@@ -1,0 +1,127 @@
+import concurrent.futures
+import os
+import random
+import subprocess
+import sys
+
+import triton
+import triton.language as tl
+
+
+def make_child(value):
+    shared = tl.constexpr(value)
+
+    @triton.jit
+    def child():
+        return shared
+
+    return child
+
+
+identity_child_a = make_child(1)
+identity_child_b = make_child(2)
+
+
+@triton.jit
+def identity_parent():
+    identity_child_a()
+    identity_child_b()
+
+
+stress_children = [make_child(value) for value in range(16)]
+(
+    stress_child_00,
+    stress_child_01,
+    stress_child_02,
+    stress_child_03,
+    stress_child_04,
+    stress_child_05,
+    stress_child_06,
+    stress_child_07,
+    stress_child_08,
+    stress_child_09,
+    stress_child_10,
+    stress_child_11,
+    stress_child_12,
+    stress_child_13,
+    stress_child_14,
+    stress_child_15,
+) = stress_children
+
+
+@triton.jit
+def stress_parent():
+    stress_child_00()
+    stress_child_01()
+    stress_child_02()
+    stress_child_03()
+    stress_child_04()
+    stress_child_05()
+    stress_child_06()
+    stress_child_07()
+    stress_child_08()
+    stress_child_09()
+    stress_child_10()
+    stress_child_11()
+    stress_child_12()
+    stress_child_13()
+    stress_child_14()
+    stress_child_15()
+
+
+def _subprocess_key(mode, seed, order="forward"):
+    env = os.environ.copy()
+    env["PYTHONHASHSEED"] = str(seed)
+    env["TRITON_CACHE_KEY_TEST_ORDER"] = order
+    env["TRITON_CACHE_KEY_TEST_SEED"] = str(seed)
+    result = subprocess.run(
+        [sys.executable, __file__, mode],
+        check=True,
+        capture_output=True,
+        env=env,
+        text=True,
+        timeout=30,
+    )
+    return result.stdout.strip()
+
+
+def test_cache_key_deterministic_across_process_global_identities():
+    cases = [(seed, order) for seed in range(4) for order in ("forward", "reverse")]
+    with concurrent.futures.ThreadPoolExecutor(max_workers=len(cases)) as executor:
+        keys = list(executor.map(lambda case: _subprocess_key("identity", *case), cases))
+
+    assert len(set(keys)) == 1
+
+
+def test_cache_key_deterministic_under_concurrent_dependency_hashing():
+    with concurrent.futures.ThreadPoolExecutor(max_workers=8) as executor:
+        keys = list(executor.map(lambda seed: _subprocess_key("stress", seed), range(16)))
+
+    assert len(set(keys)) == 1
+
+
+def _run_identity_case():
+    children = [identity_child_a, identity_child_b]
+    if os.environ["TRITON_CACHE_KEY_TEST_ORDER"] == "reverse":
+        children.reverse()
+    for child in children:
+        child.cache_key
+    print(identity_parent.cache_key)
+
+
+def _run_stress_case():
+    functions = [stress_parent, *stress_children]
+    random.Random(int(os.environ["TRITON_CACHE_KEY_TEST_SEED"])).shuffle(functions)
+    with concurrent.futures.ThreadPoolExecutor(max_workers=8) as executor:
+        list(executor.map(lambda function: function.cache_key, functions))
+    print(stress_parent.cache_key)
+
+
+if __name__ == "__main__":
+    mode = sys.argv[1]
+    if mode == "identity":
+        _run_identity_case()
+    elif mode == "stress":
+        _run_stress_case()
+    else:
+        raise ValueError(f"unknown mode: {mode}")

--- a/python/triton/runtime/jit.py
+++ b/python/triton/runtime/jit.py
@@ -525,7 +525,8 @@ class JITCallable:
             self.used_global_vals = dict(sorted(dependencies_finder.used_global_vals.items()))
 
             from triton.language.core import constexpr
-            constexpr_globals = [(name, val) for (name, _), (val, _) in self.used_global_vals.items()
+            constexpr_globals = [(name, val)
+                                 for (name, _), (val, _) in self.used_global_vals.items()
                                  if isinstance(val, constexpr)]
             constexpr_globals.sort(key=lambda item: (item[0], repr(item[1])))
             self.hash += str(constexpr_globals)

--- a/python/triton/runtime/jit.py
+++ b/python/triton/runtime/jit.py
@@ -97,6 +97,7 @@ class DependenciesFinder(ast.NodeVisitor):
 
     def _update_hash(self, func):
         assert isinstance(func, JITCallable)
+        func_key = func.cache_key
         # Merge our used_global_vals with those of the called function,
         # after checking that all overlapping values are consistent.
         for k in self.used_global_vals.keys() & func.used_global_vals.keys():
@@ -109,7 +110,6 @@ class DependenciesFinder(ast.NodeVisitor):
                 )
         self.used_global_vals.update(func.used_global_vals)
         # update hash
-        func_key = func.cache_key
         func_key += str(getattr(func, "noinline", False))
         self.hasher.update(func_key.encode("utf-8"))
 
@@ -525,9 +525,10 @@ class JITCallable:
             self.used_global_vals = dict(sorted(dependencies_finder.used_global_vals.items()))
 
             from triton.language.core import constexpr
-            self.hash += str([(name, val)
-                              for (name, _), (val, _) in self.used_global_vals.items()
-                              if isinstance(val, constexpr)])
+            constexpr_globals = [(name, val) for (name, _), (val, _) in self.used_global_vals.items()
+                                 if isinstance(val, constexpr)]
+            constexpr_globals.sort(key=lambda item: (item[0], repr(item[1])))
+            self.hash += str(constexpr_globals)
             self.hash = hashlib.sha256(self.hash.encode("utf-8")).hexdigest()
         return self.hash
 

--- a/test/Conversion/tritongpu_to_llvm.mlir
+++ b/test/Conversion/tritongpu_to_llvm.mlir
@@ -1491,6 +1491,51 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32} {
 
 // -----
 
+#mma = #ttg.nvidia_mma<{versionMajor=2, warpsPerCTA=[1, 1], instrShape = [16, 8]}>
+#dot_operand_a = #ttg.dot_op<{opIdx=0, parent=#mma, kWidth=4}>
+#dot_operand_b = #ttg.dot_op<{opIdx=1, parent=#mma, kWidth=4}>
+module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 1 : i32} {
+  // CHECK-LABEL: matmul_signed_i8dot
+  tt.func @matmul_signed_i8dot(%a: tensor<16x32xi8, #dot_operand_a>,
+                               %b: tensor<32x8xi8, #dot_operand_b>,
+                               %c: tensor<16x8xi32, #mma>) {
+    // CHECK: llvm.inline_asm
+    // CHECK-SAME: mma.sync.aligned.m16n8k32.row.col.satfinite.s32.s8.s8.s32
+    %d = tt.dot %a, %b, %c : tensor<16x32xi8, #dot_operand_a> * tensor<32x8xi8, #dot_operand_b> -> tensor<16x8xi32, #mma>
+    tt.return
+  }
+}
+
+// -----
+
+#mma = #ttg.nvidia_mma<{versionMajor=2, warpsPerCTA=[1, 1], instrShape = [16, 8]}>
+#dot_operand_a = #ttg.dot_op<{opIdx=0, parent=#mma, kWidth=4}>
+#dot_operand_b = #ttg.dot_op<{opIdx=1, parent=#mma, kWidth=4}>
+module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 1 : i32} {
+  // CHECK-LABEL: matmul_mixed_signed_i8dot
+  tt.func @matmul_mixed_signed_i8dot(%a: tensor<16x32xi8, #dot_operand_a>,
+                                     %b: tensor<32x8xi8, #dot_operand_b>,
+                                     %c: tensor<16x8xi32, #mma>) {
+    // CHECK-NOT: satfinite
+    // CHECK: llvm.inline_asm
+    // CHECK-SAME: mma.sync.aligned.m16n8k32.row.col.s32.s8.s8.s32
+    // CHECK: llvm.inline_asm
+    // CHECK-SAME: mma.sync.aligned.m16n8k32.row.col.s32.s8.u8.s32
+    // CHECK: llvm.inline_asm
+    // CHECK-SAME: mma.sync.aligned.m16n8k32.row.col.s32.u8.s8.s32
+    // CHECK: llvm.inline_asm
+    // CHECK-SAME: mma.sync.aligned.m16n8k32.row.col.s32.u8.u8.s32
+    // CHECK-NOT: satfinite
+    %d0 = tti.dot_i8 %a, %b, %c, aSigned = true, bSigned = true : tensor<16x32xi8, #dot_operand_a> * tensor<32x8xi8, #dot_operand_b> -> tensor<16x8xi32, #mma>
+    %d1 = tti.dot_i8 %a, %b, %d0, aSigned = true, bSigned = false : tensor<16x32xi8, #dot_operand_a> * tensor<32x8xi8, #dot_operand_b> -> tensor<16x8xi32, #mma>
+    %d2 = tti.dot_i8 %a, %b, %d1, aSigned = false, bSigned = true : tensor<16x32xi8, #dot_operand_a> * tensor<32x8xi8, #dot_operand_b> -> tensor<16x8xi32, #mma>
+    %d3 = tti.dot_i8 %a, %b, %d2, aSigned = false, bSigned = false : tensor<16x32xi8, #dot_operand_a> * tensor<32x8xi8, #dot_operand_b> -> tensor<16x8xi32, #mma>
+    tt.return
+  }
+}
+
+// -----
+
 #blocked0 = #ttg.blocked<{sizePerThread = [1], threadsPerWarp = [32], warpsPerCTA = [4], order = [0]}>
 module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, "ttg.target" = "cuda:80"} {
   // CHECK-LABEL: atomic_add_f32

--- a/test/Conversion/tritoninstrument_to_llvm.mlir
+++ b/test/Conversion/tritoninstrument_to_llvm.mlir
@@ -137,3 +137,25 @@ tt.func private @experimental_fpsan_unembed(%arg0: i32) -> f32 {
   tt.return %0 : f32
 }
 }
+
+// -----
+
+#local_gather_blocked = #ttg.blocked<{sizePerThread = [1, 1], threadsPerWarp = [1, 32], warpsPerCTA = [1, 4], order = [1, 0], CGALayout = [[0, 1]]}>
+#local_gather_shared = #ttg.swizzled_shared<{vec = 1, perPhase = 1, maxPhase = 1, order = [1, 0], CGALayout = [[0, 1]]}>
+
+module attributes {"ttg.num-ctas" = 2 : i32, "ttg.num-warps" = 4 : i32, "ttg.threads-per-warp" = 32 : i32, ttg.target = "cuda:90"} {
+// CHECK-LABEL: @experimental_local_gather
+// CHECK: ld.shared::cluster
+tt.func private @experimental_local_gather(%out: !tt.ptr<i32>) {
+  %src = ttg.local_alloc {allocation.offset = [0 : i32, 256 : i32]} : () -> !ttg.memdesc<2x32xi32, #local_gather_shared, #ttg.shared_memory, mutable>
+  %idx = arith.constant dense<0> : tensor<2x32xi32, #local_gather_blocked>
+  %c0 = arith.constant 0 : i32
+  %c1 = arith.constant 1 : i32
+  %g = tti.experimental_local_gather %src[%idx] offsets = [%c1, %c0] {axis = 0 : i32} : !ttg.memdesc<2x32xi32, #local_gather_shared, #ttg.shared_memory, mutable>, tensor<2x32xi32, #local_gather_blocked> -> tensor<2x32xi32, #local_gather_blocked>
+  %ptrs = tt.splat %out : !tt.ptr<i32> -> tensor<2x32x!tt.ptr<i32>, #local_gather_blocked>
+  %offs = arith.constant dense<0> : tensor<2x32xi32, #local_gather_blocked>
+  %out_ptrs = tt.addptr %ptrs, %offs : tensor<2x32x!tt.ptr<i32>, #local_gather_blocked>, tensor<2x32xi32, #local_gather_blocked>
+  tt.store %out_ptrs, %g : tensor<2x32x!tt.ptr<i32>, #local_gather_blocked>
+  tt.return
+}
+}

--- a/test/Conversion/tritonnvidiagpu_to_llvm.mlir
+++ b/test/Conversion/tritonnvidiagpu_to_llvm.mlir
@@ -802,3 +802,26 @@ module attributes {"ttg.num-ctas" = 2 : i32, "ttg.num-warps" = 4 : i32, "ttg.tot
     llvm.return
   }
 }
+
+// -----
+
+#local_gather_scatter_blocked = #ttg.blocked<{sizePerThread = [1, 1], threadsPerWarp = [1, 32], warpsPerCTA = [1, 4], order = [1, 0], CGALayout = [[0, 1]]}>
+#local_gather_scatter_shared = #ttg.swizzled_shared<{vec = 1, perPhase = 1, maxPhase = 1, order = [1, 0], CGALayout = [[0, 1]]}>
+
+module attributes {"ttg.num-ctas" = 2 : i32, "ttg.num-warps" = 4 : i32, "ttg.threads-per-warp" = 32 : i32} {
+  // CHECK-LABEL: @local_gather_scatter_two_ctas
+  // CHECK: ld.shared::cluster
+  // CHECK: nvvm.barrier0
+  // CHECK: st.shared::cluster
+  tt.func @local_gather_scatter_two_ctas(%out: !tt.ptr<i32>, %vals: tensor<2x32xi32, #local_gather_scatter_blocked>) {
+    %src = ttg.local_alloc {allocation.offset = [0 : i32, 256 : i32]} : () -> !ttg.memdesc<2x32xi32, #local_gather_scatter_shared, #ttg.shared_memory, mutable>
+    %idx = arith.constant dense<0> : tensor<2x32xi32, #local_gather_scatter_blocked>
+    %g = ttg.local_gather %src[%idx] {axis = 0 : i32} : !ttg.memdesc<2x32xi32, #local_gather_scatter_shared, #ttg.shared_memory, mutable>, tensor<2x32xi32, #local_gather_scatter_blocked> -> tensor<2x32xi32, #local_gather_scatter_blocked>
+    ttg.local_scatter %src[%idx], %vals {axis = 0 : i32} : !ttg.memdesc<2x32xi32, #local_gather_scatter_shared, #ttg.shared_memory, mutable>, tensor<2x32xi32, #local_gather_scatter_blocked>, tensor<2x32xi32, #local_gather_scatter_blocked>
+    %ptrs = tt.splat %out : !tt.ptr<i32> -> tensor<2x32x!tt.ptr<i32>, #local_gather_scatter_blocked>
+    %offs = arith.constant dense<0> : tensor<2x32xi32, #local_gather_scatter_blocked>
+    %out_ptrs = tt.addptr %ptrs, %offs : tensor<2x32x!tt.ptr<i32>, #local_gather_scatter_blocked>, tensor<2x32xi32, #local_gather_scatter_blocked>
+    tt.store %out_ptrs, %g : tensor<2x32x!tt.ptr<i32>, #local_gather_scatter_blocked>
+    tt.return
+  }
+}

--- a/test/TritonGPU/fpsan.mlir
+++ b/test/TritonGPU/fpsan.mlir
@@ -25,6 +25,68 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, "ttg.thr
 
 // -----
 
+#blocked = #ttg.blocked<{sizePerThread = [1, 4], threadsPerWarp = [32, 1], warpsPerCTA = [4, 1], order = [1, 0]}>
+#dot_operand_a = #ttg.dot_op<{opIdx = 0, parent = #blocked}>
+#dot_operand_b = #ttg.dot_op<{opIdx = 1, parent = #blocked}>
+module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, "ttg.threads-per-warp" = 32 : i32} {
+  // CHECK-LABEL: @dot_i8_decomposition
+  tt.func public @dot_i8_decomposition() -> tensor<32x32xf32, #blocked> {
+    // CHECK: scf.for
+    // CHECK: tti.dot_i8 {{.*}} aSigned = true, bSigned = true
+    // CHECK: tti.dot_i8 {{.*}} aSigned = false, bSigned = true
+    // CHECK: tti.dot_i8 {{.*}} aSigned = true, bSigned = false
+    // CHECK: tti.dot_i8 {{.*}} aSigned = false, bSigned = false
+    // CHECK-NOT: tti.dot_i8
+    %one = arith.constant 1.000000e+00 : f16
+    %zero = arith.constant dense<0.000000e+00> : tensor<32x32xf32, #blocked>
+    %a = tt.splat %one : f16 -> tensor<32x32xf16, #dot_operand_a>
+    %b = tt.splat %one : f16 -> tensor<32x32xf16, #dot_operand_b>
+    %out = tt.dot %a, %b, %zero : tensor<32x32xf16, #dot_operand_a> * tensor<32x32xf16, #dot_operand_b> -> tensor<32x32xf32, #blocked>
+    tt.return %out : tensor<32x32xf32, #blocked>
+  }
+}
+
+// -----
+
+#blocked = #ttg.blocked<{sizePerThread = [1, 4], threadsPerWarp = [32, 1], warpsPerCTA = [4, 1], order = [1, 0]}>
+#dot_operand_a = #ttg.dot_op<{opIdx = 0, parent = #blocked}>
+#dot_operand_b = #ttg.dot_op<{opIdx = 1, parent = #blocked}>
+module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, "ttg.threads-per-warp" = 32 : i32} {
+  // CHECK-LABEL: @dot_f64_i8_decomposition
+  tt.func public @dot_f64_i8_decomposition() -> tensor<32x32xf64, #blocked> {
+    // CHECK-COUNT-36: tti.dot_i8
+    // CHECK-NOT: tti.dot_i8
+    // CHECK: arith.extsi {{.*}} : tensor<{{.*}}xi32, #{{.*}}> to tensor<{{.*}}xi64, #{{.*}}>
+    %one = arith.constant 1.000000e+00 : f64
+    %zero = arith.constant dense<0.000000e+00> : tensor<32x32xf64, #blocked>
+    %a = tt.splat %one : f64 -> tensor<32x32xf64, #dot_operand_a>
+    %b = tt.splat %one : f64 -> tensor<32x32xf64, #dot_operand_b>
+    %out = tt.dot %a, %b, %zero : tensor<32x32xf64, #dot_operand_a> * tensor<32x32xf64, #dot_operand_b> -> tensor<32x32xf64, #blocked>
+    tt.return %out : tensor<32x32xf64, #blocked>
+  }
+}
+
+// -----
+
+#blocked = #ttg.blocked<{sizePerThread = [1, 1], threadsPerWarp = [32, 1], warpsPerCTA = [4, 1], order = [1, 0]}>
+#dot_operand_a = #ttg.dot_op<{opIdx = 0, parent = #blocked}>
+#dot_operand_b = #ttg.dot_op<{opIdx = 1, parent = #blocked}>
+module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, "ttg.threads-per-warp" = 32 : i32} {
+  // CHECK-LABEL: @dot_f64_fma_fallback
+  tt.func public @dot_f64_fma_fallback() -> tensor<8x8xf64, #blocked> {
+    // CHECK: scf.for
+    // CHECK-NOT: tt.dot
+    %one = arith.constant 1.000000e+00 : f64
+    %zero = arith.constant dense<0.000000e+00> : tensor<8x8xf64, #blocked>
+    %a = tt.splat %one : f64 -> tensor<8x4xf64, #dot_operand_a>
+    %b = tt.splat %one : f64 -> tensor<4x8xf64, #dot_operand_b>
+    %out = tt.dot %a, %b, %zero : tensor<8x4xf64, #dot_operand_a> * tensor<4x8xf64, #dot_operand_b> -> tensor<8x8xf64, #blocked>
+    tt.return %out : tensor<8x8xf64, #blocked>
+  }
+}
+
+// -----
+
 #blocked = #ttg.blocked<{sizePerThread = [1, 1, 1], threadsPerWarp = [1, 32, 1], warpsPerCTA = [1, 4, 1], order = [2, 1, 0]}>
 #dot_operand_a = #ttg.dot_op<{opIdx = 0, parent = #blocked}>
 #dot_operand_b = #ttg.dot_op<{opIdx = 1, parent = #blocked}>
@@ -56,6 +118,7 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, "ttg.thr
     // CHECK: scf.for
     // CHECK: ttg.barrier global_read|global_write
     // CHECK-NOT: ttg.dot_scaled
+    // CHECK-NOT: tt.dot
     // CHECK-NOT: ttg.convert_layout
      %cst = arith.constant 1.000000e+00 : f16
      %zero = arith.constant dense<0.000000e+00> : tensor<16x16xf32, #blocked>
@@ -63,6 +126,30 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, "ttg.thr
      %b = tt.splat %cst : f16 -> tensor<16x16xf16, #dot_B>
      %out = tt.dot_scaled %a, %b, %zero lhs = fp16 rhs = fp16 {fastMath = false} : tensor<16x16xf16, #dot_A> * tensor<16x16xf16, #dot_B> -> tensor<16x16xf32, #blocked>
      tt.return %out : tensor<16x16xf32, #blocked>
+  }
+}
+
+// -----
+
+#blocked = #ttg.blocked<{sizePerThread = [1, 4], threadsPerWarp = [32, 1], warpsPerCTA = [4, 1], order = [1, 0]}>
+#dot_A = #ttg.dot_op<{opIdx = 0, parent = #blocked}>
+#dot_B = #ttg.dot_op<{opIdx = 1, parent = #blocked}>
+module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, "ttg.threads-per-warp" = 32 : i32} {
+  // CHECK-LABEL: @dot_scaled_i8_decomposition
+  tt.func public @dot_scaled_i8_decomposition() -> tensor<32x32xf32, #blocked> {
+    // CHECK: scf.for
+    // CHECK: tti.dot_i8 {{.*}} aSigned = true, bSigned = true
+    // CHECK: tti.dot_i8 {{.*}} aSigned = false, bSigned = true
+    // CHECK: tti.dot_i8 {{.*}} aSigned = true, bSigned = false
+    // CHECK: tti.dot_i8 {{.*}} aSigned = false, bSigned = false
+    // CHECK-NOT: tti.dot_i8
+    // CHECK-NOT: ttg.dot_scaled
+    %one = arith.constant 1.000000e+00 : f16
+    %zero = arith.constant dense<0.000000e+00> : tensor<32x32xf32, #blocked>
+    %a = tt.splat %one : f16 -> tensor<32x64xf16, #dot_A>
+    %b = tt.splat %one : f16 -> tensor<64x32xf16, #dot_B>
+    %out = tt.dot_scaled %a, %b, %zero lhs = fp16 rhs = fp16 {fastMath = false} : tensor<32x64xf16, #dot_A> * tensor<64x32xf16, #dot_B> -> tensor<32x32xf32, #blocked>
+    tt.return %out : tensor<32x32xf32, #blocked>
   }
 }
 
@@ -79,6 +166,8 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, "ttg.thr
     // CHECK: tt.store
     // CHECK: ttg.barrier global_read|global_write
     // CHECK: scf.for
+    // CHECK-COUNT-10: tti.dot_i8
+    // CHECK-NOT: tti.dot_i8
     // CHECK: ttg.barrier global_read|global_write
     // CHECK: %[[RAW:.*]] = tt.load
     // CHECK: %[[OUT:.*]] = tti.experimental_fpsan_unembed %[[RAW]]

--- a/test/TritonGPU/invalid.mlir
+++ b/test/TritonGPU/invalid.mlir
@@ -326,6 +326,46 @@ module attributes {"ttg.num-warps" = 1 : i32} {
 
 // -----
 
+#mma0 = #ttg.nvidia_mma<{versionMajor=2, warpsPerCTA=[1,1], instrShape = [16, 8]}>
+#dot_operand_a = #ttg.dot_op<{opIdx=0, parent=#mma0, kWidth=4}>
+#dot_operand_b = #ttg.dot_op<{opIdx=1, parent=#mma0, kWidth=4}>
+module attributes {"ttg.num-warps" = 1 : i32} {
+  tt.func @dot_i8_invalid_operand_type(%A: tensor<16x32xi16, #dot_operand_a>, %B: tensor<32x8xi8, #dot_operand_b>, %C: tensor<16x8xi32, #mma0>) {
+    // expected-error@+1 {{operand #0 must be ranked tensor of 8-bit signless integer values}}
+    %D = "tti.dot_i8"(%A, %B, %C) {aSigned = true, bSigned = true} : (tensor<16x32xi16, #dot_operand_a>, tensor<32x8xi8, #dot_operand_b>, tensor<16x8xi32, #mma0>) -> tensor<16x8xi32, #mma0>
+    tt.return
+  }
+}
+
+// -----
+
+#blocked = #ttg.blocked<{sizePerThread = [1, 1], threadsPerWarp = [32, 1], warpsPerCTA = [1, 1], order = [1, 0]}>
+#dot_operand_a = #ttg.dot_op<{opIdx=0, parent=#blocked}>
+#dot_operand_b = #ttg.dot_op<{opIdx=1, parent=#blocked}>
+module attributes {"ttg.num-warps" = 1 : i32} {
+  tt.func @dot_i8_non_mma_layout(%A: tensor<16x32xi8, #dot_operand_a>, %B: tensor<32x8xi8, #dot_operand_b>, %C: tensor<16x8xi32, #blocked>) {
+    // expected-error@+1 {{requires NVIDIA MMAv2 operand and result layouts}}
+    %D = tti.dot_i8 %A, %B, %C, aSigned = true, bSigned = true : tensor<16x32xi8, #dot_operand_a> * tensor<32x8xi8, #dot_operand_b> -> tensor<16x8xi32, #blocked>
+    tt.return
+  }
+}
+
+// -----
+
+#mma0 = #ttg.nvidia_mma<{versionMajor=2, warpsPerCTA=[1,1], instrShape = [16, 8]}>
+#mma1 = #ttg.nvidia_mma<{versionMajor=2, warpsPerCTA=[1,1], instrShape = [32, 8]}>
+#dot_operand_a = #ttg.dot_op<{opIdx=0, parent=#mma0, kWidth=4}>
+#dot_operand_b = #ttg.dot_op<{opIdx=1, parent=#mma1, kWidth=4}>
+module attributes {"ttg.num-warps" = 1 : i32} {
+  tt.func @dot_i8_mismatched_layout(%A: tensor<16x32xi8, #dot_operand_a>, %B: tensor<32x8xi8, #dot_operand_b>, %C: tensor<16x8xi32, #mma0>) {
+    // expected-error@+1 {{requires matching NVIDIA MMAv2 layouts}}
+    %D = tti.dot_i8 %A, %B, %C, aSigned = true, bSigned = true : tensor<16x32xi8, #dot_operand_a> * tensor<32x8xi8, #dot_operand_b> -> tensor<16x8xi32, #mma0>
+    tt.return
+  }
+}
+
+// -----
+
 tt.func @warp_specialize_no_holder() {
   // expected-error @below {{'ttg.warp_specialize' op expected to find only a `ttg.warp_specialize.partitions` op inside its second region}}
   "ttg.warp_specialize"() ({

--- a/test/TritonGPU/nvidia-fpsan.mlir
+++ b/test/TritonGPU/nvidia-fpsan.mlir
@@ -76,6 +76,8 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.shar
     // CHECK: ttg.global_scratch_alloc
     // CHECK: ttg.barrier global_read|global_write
     // CHECK-NEXT: scf.for
+    // CHECK: tti.experimental_local_gather
+    // CHECK: tti.experimental_local_gather
     // CHECK: tti.dot_i8 {{.*}} aSigned = true, bSigned = true
     // CHECK: tti.dot_i8 {{.*}} aSigned = false, bSigned = true
     // CHECK: tti.dot_i8 {{.*}} aSigned = true, bSigned = false
@@ -91,6 +93,32 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.shar
     %d = ttng.tmem_alloc {tensor_memory_col_offset = 0 : i32, tensor_memory_row_offset = 0 : i32} : () -> !ttg.memdesc<128x128xf32, #tmem, #ttng.tensor_memory, mutable>
     %bar = ttg.local_alloc {allocation.offset = 8192 : i32} : () -> !ttg.memdesc<1xi64, #shared1, #smem, mutable>
     ttng.tc_gen5_mma %a, %b, %d, %true, %true, %bar[%true] {is_async} : !ttg.memdesc<128x128xf16, #shared, #smem, mutable>, !ttg.memdesc<128x128xf16, #shared, #smem, mutable>, !ttg.memdesc<128x128xf32, #tmem, #ttng.tensor_memory, mutable>, !ttg.memdesc<1xi64, #shared1, #smem, mutable>
+    tt.return
+  }
+}
+
+// -----
+
+#shared = #ttg.nvmma_shared<{swizzlingByteWidth = 128, transposed = false, elementBitWidth = 16}>
+#shared1 = #ttg.swizzled_shared<{vec = 1, perPhase = 1, maxPhase = 1, order = [0]}>
+#smem = #ttg.shared_memory
+#tmem_a = #ttng.tensor_memory_encoding<blockM = 128, blockN = 128, colStride = 1>
+#tmem_d = #ttng.tensor_memory_encoding<blockM = 128, blockN = 128, colStride = 1>
+module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.shared = 65544 : i32, ttg.tensor_memory_size = 0 : i32, "ttg.total-num-warps" = 1 : i32} {
+  // CHECK-LABEL: @tcgen05_mma_tmem_a_shared_b
+  tt.func public @tcgen05_mma_tmem_a_shared_b() {
+    // CHECK: ttg.global_scratch_alloc
+    // CHECK: tt.store
+    // CHECK: ttg.barrier global_read|global_write
+    // CHECK: tti.experimental_local_gather
+    // CHECK: tti.dot_i8
+    // CHECK-NOT: ttng.tc_gen5_mma
+    %true = arith.constant true
+    %a = ttng.tmem_alloc {tensor_memory_col_offset = 0 : i32, tensor_memory_row_offset = 0 : i32} : () -> !ttg.memdesc<128x128xf16, #tmem_a, #ttng.tensor_memory, mutable>
+    %b = ttg.local_alloc {allocation.offset = 0 : i32} : () -> !ttg.memdesc<128x128xf16, #shared, #smem, mutable>
+    %d = ttng.tmem_alloc {tensor_memory_col_offset = 128 : i32, tensor_memory_row_offset = 0 : i32} : () -> !ttg.memdesc<128x128xf32, #tmem_d, #ttng.tensor_memory, mutable>
+    %bar = ttg.local_alloc {allocation.offset = 8192 : i32} : () -> !ttg.memdesc<1xi64, #shared1, #smem, mutable>
+    ttng.tc_gen5_mma %a, %b, %d, %true, %true, %bar[%true] {is_async} : !ttg.memdesc<128x128xf16, #tmem_a, #ttng.tensor_memory, mutable>, !ttg.memdesc<128x128xf16, #shared, #smem, mutable>, !ttg.memdesc<128x128xf32, #tmem_d, #ttng.tensor_memory, mutable>, !ttg.memdesc<1xi64, #shared1, #smem, mutable>
     tt.return
   }
 }
@@ -135,6 +163,8 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.shar
     // CHECK: ttg.global_scratch_alloc
     // CHECK: ttg.barrier global_read|global_write
     // CHECK-NEXT: scf.for
+    // CHECK: tti.experimental_local_gather
+    // CHECK: tti.experimental_local_gather
     // CHECK: tti.dot_i8 {{.*}} aSigned = true, bSigned = true
     // CHECK: tti.dot_i8 {{.*}} aSigned = false, bSigned = true
     // CHECK: tti.dot_i8 {{.*}} aSigned = true, bSigned = false
@@ -261,22 +291,19 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.shar
 #shared1 = #ttg.swizzled_shared<{vec = 1, perPhase = 1, maxPhase = 1, order = [0], CGALayout = [[1]]}>
 #smem = #ttg.shared_memory
 #tmem = #ttng.tensor_memory_encoding<blockM = 128, blockN = 128, colStride = 1, CGALayout = [[1, 0]], twoCTAs = true>
-// CHECK: #[[$SHARED_A_SCRATCH:[A-Za-z0-9_]+]] = #ttg.blocked<{sizePerThread = [1, 8], threadsPerWarp = [1, 32], warpsPerCTA = [1, 4], order = [1, 0], CGALayout = {{\[\[1, 0\]\]}}}>
 // CHECK: module attributes {{.*}}"ttng.two-ctas" = true
 module attributes {"ttg.num-ctas" = 2 : i32, "ttg.num-warps" = 4 : i32, ttg.shared = 65544 : i32, ttg.tensor_memory_size = 0 : i32, "ttg.total-num-warps" = 1 : i32} {
     // CHECK-LABEL: @tcgen05_mma_two_ctas
   tt.func public @tcgen05_mma_two_ctas() {
     // CHECK: ttg.global_scratch_alloc {{.*}}shared_cluster_state
     // CHECK: ttng.cluster_barrier
-    // CHECK-NEXT: {{.*}} = ttg.local_load {{.*}} -> tensor<256x128xf16, #[[$SHARED_A_SCRATCH]]>
+    // CHECK-NEXT: scf.for
+    // CHECK: tti.experimental_local_gather
+    // CHECK: tti.experimental_local_gather
     // CHECK: tt.store
     // CHECK: ttg.barrier global_read|global_write
     // CHECK-NEXT: ttng.cluster_barrier
-    // CHECK: scf.for
-    // CHECK: tt.store
-    // CHECK: ttg.barrier global_read|global_write
-    // CHECK-NEXT: ttng.cluster_barrier
-    // CHECK: ttng.arrive_barrier
+    // CHECK-NEXT: ttng.arrive_barrier
     // CHECK-NOT: ttng.tc_gen5_mma
     %true = arith.constant true
     %a = ttg.local_alloc {allocation.offset = 0 : i32} : () -> !ttg.memdesc<256x128xf16, #shared_a, #smem, mutable>
@@ -298,7 +325,6 @@ module attributes {"ttg.num-ctas" = 2 : i32, "ttg.num-warps" = 4 : i32, ttg.shar
 #blocked_multibuffer = #ttg.blocked<{sizePerThread = [1, 4], threadsPerWarp = [32, 1], warpsPerCTA = [4, 1], order = [0, 1], CGALayout = [[1, 0]]}>
 #tmem = #ttng.tensor_memory_encoding<blockM = 128, blockN = 128, colStride = 1, CGALayout = [[1, 0]], twoCTAs = true>
 #tmem_scales = #ttng.tensor_memory_scales_encoding<CGALayout = [[0, 0]]>
-// CHECK: #[[$TMEM_VIEW_SCRATCH:[A-Za-z0-9_]+]] = #ttg.blocked<{sizePerThread = [1, 4], threadsPerWarp = [32, 1], warpsPerCTA = [4, 1], order = [0, 1], CGALayout = {{\[\[1, 0\]\]}}}>
 module attributes {"ttg.num-ctas" = 2 : i32, "ttg.num-warps" = 4 : i32, ttg.shared = 65544 : i32, ttg.tensor_memory_size = 0 : i32, "ttg.total-num-warps" = 1 : i32} {
   tt.func public @enable_two_ctas() {
     %true = arith.constant true
@@ -312,7 +338,7 @@ module attributes {"ttg.num-ctas" = 2 : i32, "ttg.num-warps" = 4 : i32, ttg.shar
   // CHECK-LABEL: @tmem_multibuffer_two_ctas
   tt.func public @tmem_multibuffer_two_ctas(%idx: i32) {
     // CHECK: ttg.global_scratch_alloc {{.*}}shared_cluster_state
-    // CHECK: tt.store {{.*}} {ignore_cta} : tensor<256x128x!tt.ptr<i32>, #[[$TMEM_VIEW_SCRATCH]]>
+    // CHECK: tt.store {{.*}} {ignore_cta} : tensor<256x128x!tt.ptr<i32>
     // CHECK-NOT: ttng.tmem_load
     // CHECK-NOT: ttng.tmem_store
     // CHECK-NOT: ttg.memdesc_index
@@ -361,10 +387,13 @@ module attributes {"ttg.num-ctas" = 2 : i32, "ttg.num-warps" = 4 : i32, ttg.shar
   tt.func public @tcgen05_mma_scaled_two_ctas() {
     // CHECK: ttg.global_scratch_alloc {{.*}}shared_cluster_state
     // CHECK: ttng.cluster_barrier
-    // CHECK-NEXT: {{.*}} = ttg.local_load
+    // CHECK-NEXT: scf.for
+    // CHECK: tti.experimental_local_gather
+    // CHECK: tti.experimental_local_gather
+    // CHECK: tt.store
     // CHECK: ttg.barrier global_read|global_write
     // CHECK-NEXT: ttng.cluster_barrier
-    // CHECK: ttng.arrive_barrier
+    // CHECK-NEXT: ttng.arrive_barrier
     // CHECK-NOT: ttng.tc_gen5_mma_scaled
     %true = arith.constant true
     %a = ttg.local_alloc {allocation.offset = 0 : i32} : () -> !ttg.memdesc<256x256xi8, #shared_a, #smem, mutable>

--- a/test/TritonGPU/nvidia-fpsan.mlir
+++ b/test/TritonGPU/nvidia-fpsan.mlir
@@ -76,7 +76,11 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.shar
     // CHECK: ttg.global_scratch_alloc
     // CHECK: ttg.barrier global_read|global_write
     // CHECK-NEXT: scf.for
-    // CHECK: ttg.barrier global_read|global_write
+    // CHECK: tti.dot_i8 {{.*}} aSigned = true, bSigned = true
+    // CHECK: tti.dot_i8 {{.*}} aSigned = false, bSigned = true
+    // CHECK: tti.dot_i8 {{.*}} aSigned = true, bSigned = false
+    // CHECK: tti.dot_i8 {{.*}} aSigned = false, bSigned = false
+    // CHECK-NOT: tti.dot_i8
     // CHECK: tt.store
     // CHECK: ttg.barrier global_read|global_write
     // CHECK: ttng.arrive_barrier
@@ -103,7 +107,6 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.shar
     // CHECK: ttg.global_scratch_alloc
     // CHECK: ttg.barrier global_read|global_write
     // CHECK-NEXT: scf.for
-    // CHECK: ttg.barrier global_read|global_write
     // CHECK: tt.store
     // CHECK: ttg.barrier global_read|global_write
     // CHECK: ttng.arrive_barrier
@@ -132,6 +135,11 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.shar
     // CHECK: ttg.global_scratch_alloc
     // CHECK: ttg.barrier global_read|global_write
     // CHECK-NEXT: scf.for
+    // CHECK: tti.dot_i8 {{.*}} aSigned = true, bSigned = true
+    // CHECK: tti.dot_i8 {{.*}} aSigned = false, bSigned = true
+    // CHECK: tti.dot_i8 {{.*}} aSigned = true, bSigned = false
+    // CHECK: tti.dot_i8 {{.*}} aSigned = false, bSigned = false
+    // CHECK-NOT: tti.dot_i8
     // CHECK: ttg.barrier global_read|global_write
     // CHECK: tt.store
     // CHECK: ttg.barrier global_read|global_write

--- a/third_party/amd/backend/compiler.py
+++ b/third_party/amd/backend/compiler.py
@@ -560,7 +560,7 @@ class HIPBackend(BaseBackend):
                                                options.enable_fp_fusion, False, knobs.amd.swap_mir_enable_misched)
         else:
             amdgcn = llvm.translate_to_asm(src, amd.TARGET_TRIPLE, options.arch, features, flags,
-                                           options.enable_fp_fusion, False)
+                                           options.enable_fp_fusion, False, False)
         if knobs.amd.dump_amdgcn:
             print("// -----// AMDGCN Dump //----- //")
             print(amdgcn)

--- a/third_party/nvidia/backend/compiler.py
+++ b/third_party/nvidia/backend/compiler.py
@@ -470,7 +470,8 @@ class CUDABackend(BaseBackend):
         proc = sm_arch_from_capability(capability)
         features = get_features(opt, self.target.arch)
         flags = ["nvptx-mad-wide-opt"]
-        ret = llvm.translate_to_asm(src, triple, proc, features, flags, opt.enable_fp_fusion, False)
+        canonicalize_gep = "fpsan" in opt.instrumentation_mode
+        ret = llvm.translate_to_asm(src, triple, proc, features, flags, opt.enable_fp_fusion, False, canonicalize_gep)
         # Find kernel names (there should only be one)
         names = re.findall(r".visible .entry ([a-zA-Z_][a-zA-Z0-9_]*)", ret)
         assert len(names) == 1

--- a/third_party/nvidia/lib/TritonNVIDIAGPUToLLVM/CMakeLists.txt
+++ b/third_party/nvidia/lib/TritonNVIDIAGPUToLLVM/CMakeLists.txt
@@ -28,6 +28,7 @@ add_triton_library(TritonNVIDIAGPUToLLVM
     GluonTransforms
     TritonAnalysis
     TritonGPUToLLVM
+    TritonInstrumentIR
     TritonInstrumentToLLVM
     MLIRReconcileUnrealizedCasts
     NVGPUIR

--- a/third_party/nvidia/lib/TritonNVIDIAGPUToLLVM/DotOpToLLVM.cpp
+++ b/third_party/nvidia/lib/TritonNVIDIAGPUToLLVM/DotOpToLLVM.cpp
@@ -2,6 +2,7 @@
 #include "Utility.h"
 
 #include "triton/Conversion/TritonGPUToLLVM/PatternTritonGPUOpToLLVM.h"
+#include "triton/Dialect/TritonInstrument/IR/Dialect.h"
 
 using namespace mlir;
 using namespace mlir::triton;
@@ -12,6 +13,11 @@ using ::mlir::triton::gpu::NvidiaMmaEncodingAttr;
 using ::mlir::triton::gpu::toLinearLayout;
 
 LogicalResult convertMMA(triton::DotOp op, triton::DotOp::Adaptor adaptor,
+                         const LLVMTypeConverter *typeConverter,
+                         ConversionPatternRewriter &rewriter, bool isTuring);
+
+LogicalResult convertMMA(triton::instrument::DotI8Op op,
+                         triton::instrument::DotI8Op::Adaptor adaptor,
                          const LLVMTypeConverter *typeConverter,
                          ConversionPatternRewriter &rewriter, bool isTuring);
 
@@ -82,6 +88,34 @@ struct DotOpConversion : public ConvertOpToLLVMPattern<triton::DotOp> {
 
     llvm::report_fatal_error(
         "Unsupported DotOp found when converting TritonGPU to LLVM.");
+  }
+};
+
+struct DotI8OpConversion
+    : public ConvertOpToLLVMPattern<triton::instrument::DotI8Op> {
+  using ConvertOpToLLVMPattern<
+      triton::instrument::DotI8Op>::ConvertOpToLLVMPattern;
+
+  DotI8OpConversion(LLVMTypeConverter &converter, int, PatternBenefit benefit)
+      : ConvertOpToLLVMPattern<triton::instrument::DotI8Op>(converter,
+                                                            benefit) {}
+
+  LogicalResult
+  matchAndRewrite(triton::instrument::DotI8Op op, OpAdaptor adaptor,
+                  ConversionPatternRewriter &rewriter) const override {
+    auto dType = op.getD().getType();
+    auto dEncoding = dType.getEncoding();
+    if (!isPermutationMatrixLayout(toLinearLayout(dType.getShape(), dEncoding)))
+      return rewriter.notifyMatchFailure(
+          op, "DotI8Op result encoding must have a permutation-matrix linear "
+              "layout");
+
+    auto mmaLayout = dyn_cast<NvidiaMmaEncodingAttr>(dEncoding);
+    if (!mmaLayout || mmaLayout.getVersionMajor() != 2)
+      return rewriter.notifyMatchFailure(op,
+                                         "DotI8Op requires an MMAv2 layout");
+    return convertMMA(op, adaptor, getTypeConverter(), rewriter,
+                      mmaLayout.isTuring());
   }
 };
 
@@ -161,6 +195,7 @@ void mlir::triton::NVIDIA::populateDotOpToLLVMPatterns(
     LLVMTypeConverter &typeConverter, RewritePatternSet &patterns,
     int computeCapability, PatternBenefit benefit) {
   patterns.add<DotOpConversion>(typeConverter, computeCapability, benefit);
+  patterns.add<DotI8OpConversion>(typeConverter, computeCapability, benefit);
   patterns.add<WarpGroupDotOpConversion>(typeConverter, benefit);
   patterns.add<WarpGroupDotWaitOpConversion>(typeConverter, benefit);
   patterns.add<ScaledDotOpConversion>(typeConverter, computeCapability,

--- a/third_party/nvidia/lib/TritonNVIDIAGPUToLLVM/DotOpToLLVM/MMAv2.cpp
+++ b/third_party/nvidia/lib/TritonNVIDIAGPUToLLVM/DotOpToLLVM/MMAv2.cpp
@@ -4,6 +4,7 @@
 #include "triton/Conversion/TritonGPUToLLVM/Utility.h"
 #include "triton/Dialect/Triton/IR/Dialect.h"
 #include "triton/Dialect/TritonGPU/IR/Attributes.h"
+#include "triton/Dialect/TritonInstrument/IR/Dialect.h"
 #include "llvm/ADT/SmallVector.h"
 
 using namespace mlir;
@@ -715,13 +716,11 @@ using EmitMmaCallback = std::function<void(
     unsigned batchOffset, ValueTableV2 &ha, ValueTableV2 &hb,
     const SmallVector<Value> &fc, RankedTensorType dTensorTy, int repK)>;
 
-LogicalResult
-convertMMAImpl(DotOpInterface op, Value llvmA, Value llvmB, Value llvmC,
-               const LLVMTypeConverter *typeConverter,
-               ConversionPatternRewriter &rewriter, TensorCoreType mmaType,
-               const NumRegisters &numRegisters,
-               const std::map<TensorCoreType, std::string> &mmaInstructions,
-               const EmitMmaCallback &emitMma) {
+LogicalResult convertMMAImpl(
+    DotOpInterface op, Value llvmA, Value llvmB, Value llvmC,
+    const LLVMTypeConverter *typeConverter, ConversionPatternRewriter &rewriter,
+    TensorCoreType mmaType, const NumRegisters &numRegisters,
+    const std::string &mmaInstruction, const EmitMmaCallback &emitMma) {
   auto loc = op.getLoc();
   auto aType = cast<RankedTensorType>(op.getA().getType());
   auto bType = cast<RankedTensorType>(op.getB().getType());
@@ -787,7 +786,7 @@ convertMMAImpl(DotOpInterface op, Value llvmA, Value llvmB, Value llvmC,
       elemsPerThread[rank - 2] * elemsPerThread[rank - 1] / numCPackedElem;
   auto callMma = [&](unsigned b, unsigned m, unsigned n, unsigned k) {
     PTXBuilder builder;
-    auto &mma = *builder.create(mmaInstructions.at(mmaType));
+    auto &mma = *builder.create(mmaInstruction);
     // using =r for float32 works but leads to less readable ptx.
     unsigned colsPerThread = repN * 2;
     emitMma(builder, b, static_cast<int>(m), static_cast<int>(n),
@@ -834,21 +833,10 @@ convertMMAImpl(DotOpInterface op, Value llvmA, Value llvmB, Value llvmC,
   return success();
 }
 
-} // namespace
-
-LogicalResult convertMMA(triton::DotOp op, triton::DotOp::Adaptor adaptor,
-                         const LLVMTypeConverter *typeConverter,
-                         ConversionPatternRewriter &rewriter, bool isTuring) {
-  auto aTensorTy = op.getA().getType();
-  auto bTensorTy = op.getB().getType();
-  auto dTensorTy = op.getD().getType();
-
-  TensorCoreType mmaType = getMmaTypeDot(op, aTensorTy, bTensorTy, dTensorTy);
-  const auto &instrMap = isTuring ? mmaInstrPtxTuring : mmaInstrPtxAmpere;
-  if (instrMap.find(mmaType) == instrMap.end())
-    return op.emitError(
-        "unsupported MMA instruction for the given operand/result types");
-
+LogicalResult convertMMAWithInstruction(
+    DotOpInterface op, Value llvmA, Value llvmB, Value llvmC,
+    const LLVMTypeConverter *typeConverter, ConversionPatternRewriter &rewriter,
+    TensorCoreType mmaType, const std::string &mmaInstruction, bool isTuring) {
   NumRegisters numRegisters = (mmaType == TensorCoreType::FP64_FP64_FP64_FP64)
                                   ? NumRegisters{1, 1, 1}
                                   : NumRegisters{2, 1, 2};
@@ -885,9 +873,43 @@ LogicalResult convertMMA(triton::DotOp op, triton::DotOp::Adaptor adaptor,
     }
   };
 
-  return convertMMAImpl(op, adaptor.getA(), adaptor.getB(), adaptor.getC(),
-                        typeConverter, rewriter, mmaType, numRegisters,
-                        instrMap, emit);
+  return convertMMAImpl(op, llvmA, llvmB, llvmC, typeConverter, rewriter,
+                        mmaType, numRegisters, mmaInstruction, emit);
+}
+
+} // namespace
+
+LogicalResult convertMMA(triton::DotOp op, triton::DotOp::Adaptor adaptor,
+                         const LLVMTypeConverter *typeConverter,
+                         ConversionPatternRewriter &rewriter, bool isTuring) {
+  auto aTensorTy = op.getA().getType();
+  auto bTensorTy = op.getB().getType();
+  auto dTensorTy = op.getD().getType();
+
+  TensorCoreType mmaType = getMmaTypeDot(op, aTensorTy, bTensorTy, dTensorTy);
+  const auto &instrMap = isTuring ? mmaInstrPtxTuring : mmaInstrPtxAmpere;
+  if (instrMap.find(mmaType) == instrMap.end())
+    return op.emitError(
+        "unsupported MMA instruction for the given operand/result types");
+
+  return convertMMAWithInstruction(op, adaptor.getA(), adaptor.getB(),
+                                   adaptor.getC(), typeConverter, rewriter,
+                                   mmaType, instrMap.at(mmaType), isTuring);
+}
+
+LogicalResult convertMMA(triton::instrument::DotI8Op op,
+                         triton::instrument::DotI8Op::Adaptor adaptor,
+                         const LLVMTypeConverter *typeConverter,
+                         ConversionPatternRewriter &rewriter, bool isTuring) {
+  std::string mmaInstruction = isTuring
+                                   ? "mma.sync.aligned.m8n8k16.row.col.s32."
+                                   : "mma.sync.aligned.m16n8k32.row.col.s32.";
+  mmaInstruction += op.getASigned() ? "s8." : "u8.";
+  mmaInstruction += op.getBSigned() ? "s8.s32" : "u8.s32";
+  return convertMMAWithInstruction(op, adaptor.getA(), adaptor.getB(),
+                                   adaptor.getC(), typeConverter, rewriter,
+                                   TensorCoreType::INT32_INT8_INT8_INT32,
+                                   mmaInstruction, isTuring);
 }
 
 LogicalResult convertMMADotScaled(triton::DotScaledOp op,
@@ -955,5 +977,5 @@ LogicalResult convertMMADotScaled(triton::DotScaledOp op,
 
   return convertMMAImpl(op, adaptor.getA(), adaptor.getB(), adaptor.getC(),
                         typeConverter, rewriter, mmaType, numRegisters,
-                        mmaInstrPtxScaled, emit);
+                        mmaInstrPtxScaled.at(mmaType), emit);
 }


### PR DESCRIPTION
## Summary
Aggregate validation branch containing the complete FPSan stack:

- #10440: cluster barriers in warp-specialized regions
- #10461: FPSan two-CTA MMAv5 support
- #10466: mixed-signed i8 MMA decomposition
- https://github.com/triton-lang/triton/pull/10472: multi-CTA local gather and scatter
- https://github.com/triton-lang/triton/pull/10473: direct shared-memory TCGen operand loads
- Broadened FPSan MMA coverage from current main

## Validation
- GB300 compiler build and relevant lit tests passed.
- GB300 TCGen FPSan suite: 100 passed.
- Performance smoke: approximately 5.3x FP8 unscaled, 4.6x MXFP scaled, and 2.0x scaled two-CTA.
