### PR TITLE
[release/3.7.x][CUDA][PTXAS][WAR] Downgrade ptxas-blackwell from v13.1.80 to v13.0.88

### DIFF
--- a/cmake/nvidia-toolchain-version.json
+++ b/cmake/nvidia-toolchain-version.json
@@ -1,5 +1,5 @@
 {
-  "ptxas-blackwell": "13.1.80",
+  "ptxas-blackwell": "13.0.88",
   "ptxas": "12.8.93",
   "cuobjdump": "13.1.80",
   "nvdisasm": "13.1.80",


### PR DESCRIPTION
Downgrade ptxas-blackwell to last known good ptxas version (v13.0.88) that does not reproduce the mini-repro of https://github.com/pytorch/pytorch/issues/181248 
The intention is to workaround this issue, and does not regress THOR by using ptxas v13+ (since ptxas v12.9.86 cannot recognize sm_110a). 

Inspired by https://github.com/triton-lang/triton/pull/10462 and implementing https://github.com/triton-lang/triton/pull/10462#discussion_r3352889394 

Test plan: 
Test the mini repro across SM100, SM110, SM120, and SM121 devices. 
If possible, test the original vLLM reproducer in https://github.com/pytorch/pytorch/issues/181248

The part that I'm unsure: 
How does v13.0.88 compare to v12.9.86 in terms of end-to-end performance on B200/GB200.  

cc @atalman @malfet @ptrblck @eqy @masahi 
