### PR TITLE
[CI] Parallelize GB200 Triton and Gluon tests

### DIFF
--- a/.github/workflows/integration-tests-nvidia.yml
+++ b/.github/workflows/integration-tests-nvidia.yml
@@ -88,69 +88,54 @@ jobs:
       - name: Run lit tests
         run: make test-lit
       - name: Run triton tests
-        if: ${{ matrix.config.runner_type != 'nvidia-gb200' }}
-        run: make NUM_PROCS=24 test-unit
-      - name: Run triton tests on GB200
-        if: ${{ matrix.config.runner_type == 'nvidia-gb200' }}
-        shell: bash
         run: |
+          if [[ "${{ matrix.config.runner_type }}" != "nvidia-gb200" ]]; then
+            exec make NUM_PROCS=24 test-unit
+          fi
           set -euo pipefail
           test "$(nvidia-smi -L | wc -l)" -ge 4
-
           pids=()
           CUDA_VISIBLE_DEVICES=0 python3 -m pytest -s --tb=short -n 24 \
-            --ignore-glob='plugins/*' python/test/unit &
-          pids+=("$!")
+            --ignore-glob='plugins/*' python/test/unit & pids+=("$!")
           for group in 1 2 3 4; do
             gpu=$((group - 1))
             CUDA_VISIBLE_DEVICES="$gpu" python3 -m pytest -s --tb=short -n 3 \
               --splits 4 --group "$group" --splitting-algorithm=least_duration \
-              python/triton_kernels/tests/ &
-            pids+=("$!")
+              python/triton_kernels/tests/ & pids+=("$!")
           done
           CUDA_VISIBLE_DEVICES=0 python3 -m pytest -s --tb=short \
-            python/tutorials/06-fused-attention.py &
-          pids+=("$!")
+            python/tutorials/06-fused-attention.py & pids+=("$!")
           CUDA_VISIBLE_DEVICES=0 \
             TRITON_ALWAYS_COMPILE=1 \
             TRITON_DISABLE_LINE_INFO=0 \
             LLVM_PASS_PLUGIN_PATH=python/triton/instrumentation/libGPUInstrumentationTestLib.so \
             python3 -m pytest -s --tb=short --capture=tee-sys -rfs -vvv \
-              python/test/unit/instrumentation/test_gpuhello.py &
-          pids+=("$!")
-
+              python/test/unit/instrumentation/test_gpuhello.py & pids+=("$!")
           status=0
           for pid in "${pids[@]}"; do
             wait "$pid" || status=1
           done
           exit "$status"
       - name: Run gluon tests
-        if: ${{ matrix.config.runner_type != 'nvidia-gb200' }}
-        run: make NUM_PROCS=24 test-gluon
-      - name: Run gluon tests on GB200
-        if: ${{ matrix.config.runner_type == 'nvidia-gb200' }}
-        shell: bash
         run: |
+          if [[ "${{ matrix.config.runner_type }}" != "nvidia-gb200" ]]; then
+            exec make NUM_PROCS=24 test-gluon
+          fi
           set -euo pipefail
           test "$(nvidia-smi -L | wc -l)" -ge 4
-
           pids=()
           for group in 1 2 3; do
             gpu=$((group - 1))
             CUDA_VISIBLE_DEVICES="$gpu" python3 -m pytest -s --tb=short -n 8 \
               --splits 3 --group "$group" --splitting-algorithm=least_duration \
               --ignore=python/test/gluon/test_fpsan.py \
-              python/test/gluon/ python/tutorials/gluon/ &
-            pids+=("$!")
+              python/test/gluon/ python/tutorials/gluon/ & pids+=("$!")
           done
           CUDA_VISIBLE_DEVICES=2 python3 -m pytest -s --tb=short -n 12 --maxschedchunk=1 \
-            python/test/gluon/test_fpsan.py &
-          pids+=("$!")
+            python/test/gluon/test_fpsan.py & pids+=("$!")
           CUDA_VISIBLE_DEVICES=3 \
             PYTHONPATH="$PWD/python/triton_kernels${PYTHONPATH:+:$PYTHONPATH}" \
-            python3 -m pytest -s --tb=short -n 2 python/examples/gluon/ &
-          pids+=("$!")
-
+            python3 -m pytest -s --tb=short -n 2 python/examples/gluon/ & pids+=("$!")
           status=0
           for pid in "${pids[@]}"; do
             wait "$pid" || status=1

--- a/.github/workflows/integration-tests-nvidia.yml
+++ b/.github/workflows/integration-tests-nvidia.yml
@@ -86,6 +86,7 @@ jobs:
       - name: CCache Stats
         run: ccache --print-stats
       - name: Run lit tests
+        if: ${{ matrix.config.runner_type != 'nvidia-gb200' || matrix.config.shard == 1 }}
         run: make test-lit
       - name: Run triton tests
         run: |
@@ -93,24 +94,22 @@ jobs:
             exec make NUM_PROCS=24 test-unit
           fi
           set -euo pipefail
-          test "$(nvidia-smi -L | wc -l)" -ge 4
+          shard=${{ matrix.config.shard }}
           pids=()
-          CUDA_VISIBLE_DEVICES=0 python3 -m pytest -s --tb=short -n 24 \
-            --ignore-glob='plugins/*' python/test/unit & pids+=("$!")
-          for group in 1 2 3 4; do
-            gpu=$((group - 1))
-            CUDA_VISIBLE_DEVICES="$gpu" python3 -m pytest -s --tb=short -n 3 \
-              --splits 4 --group "$group" --splitting-algorithm=least_duration \
-              python/triton_kernels/tests/ & pids+=("$!")
-          done
-          CUDA_VISIBLE_DEVICES=0 python3 -m pytest -s --tb=short \
-            python/tutorials/06-fused-attention.py & pids+=("$!")
-          CUDA_VISIBLE_DEVICES=0 \
+          python3 -m pytest -s --tb=short -n 3 \
+            --splits 4 --group "$shard" --splitting-algorithm=least_duration \
+            python/triton_kernels/tests/ & pids+=("$!")
+          if ((shard == 1)); then
+            python3 -m pytest -s --tb=short -n 24 \
+              --ignore-glob='plugins/*' python/test/unit & pids+=("$!")
+            python3 -m pytest -s --tb=short \
+              python/tutorials/06-fused-attention.py & pids+=("$!")
             TRITON_ALWAYS_COMPILE=1 \
-            TRITON_DISABLE_LINE_INFO=0 \
-            LLVM_PASS_PLUGIN_PATH=python/triton/instrumentation/libGPUInstrumentationTestLib.so \
-            python3 -m pytest -s --tb=short --capture=tee-sys -rfs -vvv \
-              python/test/unit/instrumentation/test_gpuhello.py & pids+=("$!")
+              TRITON_DISABLE_LINE_INFO=0 \
+              LLVM_PASS_PLUGIN_PATH=python/triton/instrumentation/libGPUInstrumentationTestLib.so \
+              python3 -m pytest -s --tb=short --capture=tee-sys -rfs -vvv \
+                python/test/unit/instrumentation/test_gpuhello.py & pids+=("$!")
+          fi
           status=0
           for pid in "${pids[@]}"; do
             wait "$pid" || status=1
@@ -121,39 +120,37 @@ jobs:
           if [[ "${{ matrix.config.runner_type }}" != "nvidia-gb200" ]]; then
             exec make NUM_PROCS=24 test-gluon
           fi
-          set -euo pipefail
-          test "$(nvidia-smi -L | wc -l)" -ge 4
-          pids=()
-          for group in 1 2 3; do
-            gpu=$((group - 1))
-            CUDA_VISIBLE_DEVICES="$gpu" python3 -m pytest -s --tb=short -n 8 \
-              --splits 3 --group "$group" --splitting-algorithm=least_duration \
+          shard=${{ matrix.config.shard }}
+          if ((shard <= 2)); then
+            python3 -m pytest -s --tb=short -n 12 \
+              --splits 2 --group "$shard" --splitting-algorithm=least_duration \
               --ignore=python/test/gluon/test_fpsan.py \
-              python/test/gluon/ python/tutorials/gluon/ & pids+=("$!")
-          done
-          CUDA_VISIBLE_DEVICES=2 python3 -m pytest -s --tb=short -n 12 --maxschedchunk=1 \
-            python/test/gluon/test_fpsan.py & pids+=("$!")
-          CUDA_VISIBLE_DEVICES=3 \
+              python/test/gluon/ python/tutorials/gluon/
+          elif ((shard == 3)); then
+            python3 -m pytest -s --tb=short -n 12 --maxschedchunk=1 \
+              python/test/gluon/test_fpsan.py
+          else
             PYTHONPATH="$PWD/python/triton_kernels${PYTHONPATH:+:$PYTHONPATH}" \
-            python3 -m pytest -s --tb=short -n 2 python/examples/gluon/ & pids+=("$!")
-          status=0
-          for pid in "${pids[@]}"; do
-            wait "$pid" || status=1
-          done
-          exit "$status"
+              python3 -m pytest -s --tb=short -n 2 python/examples/gluon/
+          fi
       - name: Run gsan tests
+        if: ${{ matrix.config.runner_type != 'nvidia-gb200' || matrix.config.shard == 1 }}
         run: make NUM_PROCS=24 test-gsan
       - name: Run interpreter tests
         if: ${{ matrix.config.runner_type == 'nvidia-h100' }}
         run: make test-interpret
       - name: Run regression tests
+        if: ${{ matrix.config.runner_type != 'nvidia-gb200' || matrix.config.shard == 1 }}
         run: make test-regression
       - name: Run microbenchmark tests
+        if: ${{ matrix.config.runner_type != 'nvidia-gb200' || matrix.config.shard == 1 }}
         # Microbenchmark never fail but running them gives us an easy way to track performance changes.
         run: make test-microbenchmark
       - name: Run C++ unittests
+        if: ${{ matrix.config.runner_type != 'nvidia-gb200' || matrix.config.shard == 1 }}
         run: make test-cpp
       - name: Run Proton tests
+        if: ${{ matrix.config.runner_type != 'nvidia-gb200' || matrix.config.shard == 1 }}
         run: make test-proton
       - name: Inspect cache directories
         run: |

--- a/.github/workflows/integration-tests-nvidia.yml
+++ b/.github/workflows/integration-tests-nvidia.yml
@@ -88,9 +88,74 @@ jobs:
       - name: Run lit tests
         run: make test-lit
       - name: Run triton tests
+        if: ${{ matrix.config.runner_type != 'nvidia-gb200' }}
         run: make NUM_PROCS=24 test-unit
+      - name: Run triton tests on GB200
+        if: ${{ matrix.config.runner_type == 'nvidia-gb200' }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          test "$(nvidia-smi -L | wc -l)" -ge 4
+
+          pids=()
+          CUDA_VISIBLE_DEVICES=0 python3 -m pytest -s --tb=short -n 24 \
+            --ignore-glob='plugins/*' python/test/unit &
+          pids+=("$!")
+          for group in 1 2 3 4; do
+            gpu=$((group - 1))
+            CUDA_VISIBLE_DEVICES="$gpu" python3 -m pytest -s --tb=short -n 3 \
+              --splits 4 --group "$group" --splitting-algorithm=least_duration \
+              python/triton_kernels/tests/ &
+            pids+=("$!")
+          done
+          CUDA_VISIBLE_DEVICES=0 python3 -m pytest -s --tb=short \
+            python/tutorials/06-fused-attention.py &
+          pids+=("$!")
+          CUDA_VISIBLE_DEVICES=0 \
+            TRITON_ALWAYS_COMPILE=1 \
+            TRITON_DISABLE_LINE_INFO=0 \
+            LLVM_PASS_PLUGIN_PATH=python/triton/instrumentation/libGPUInstrumentationTestLib.so \
+            python3 -m pytest -s --tb=short --capture=tee-sys -rfs -vvv \
+              python/test/unit/instrumentation/test_gpuhello.py &
+          pids+=("$!")
+
+          status=0
+          for pid in "${pids[@]}"; do
+            wait "$pid" || status=1
+          done
+          exit "$status"
       - name: Run gluon tests
+        if: ${{ matrix.config.runner_type != 'nvidia-gb200' }}
         run: make NUM_PROCS=24 test-gluon
+      - name: Run gluon tests on GB200
+        if: ${{ matrix.config.runner_type == 'nvidia-gb200' }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          test "$(nvidia-smi -L | wc -l)" -ge 4
+
+          pids=()
+          for group in 1 2 3; do
+            gpu=$((group - 1))
+            CUDA_VISIBLE_DEVICES="$gpu" python3 -m pytest -s --tb=short -n 8 \
+              --splits 3 --group "$group" --splitting-algorithm=least_duration \
+              --ignore=python/test/gluon/test_fpsan.py \
+              python/test/gluon/ python/tutorials/gluon/ &
+            pids+=("$!")
+          done
+          CUDA_VISIBLE_DEVICES=2 python3 -m pytest -s --tb=short -n 12 --maxschedchunk=1 \
+            python/test/gluon/test_fpsan.py &
+          pids+=("$!")
+          CUDA_VISIBLE_DEVICES=3 \
+            PYTHONPATH="$PWD/python/triton_kernels${PYTHONPATH:+:$PYTHONPATH}" \
+            python3 -m pytest -s --tb=short -n 2 python/examples/gluon/ &
+          pids+=("$!")
+
+          status=0
+          for pid in "${pids[@]}"; do
+            wait "$pid" || status=1
+          done
+          exit "$status"
       - name: Run gsan tests
         run: make NUM_PROCS=24 test-gsan
       - name: Run interpreter tests

--- a/.github/workflows/runner-preparation.yml
+++ b/.github/workflows/runner-preparation.yml
@@ -95,7 +95,7 @@ jobs:
         if: env.enable_integration == 'true'
         run: |
           if [ x"${{ github.repository }}" == x"triton-lang/triton" ]; then
-            echo '::set-output name=matrix-NVIDIA::[{"name":"nvidia-a100","runner_type":"nvidia-a100","runs_on":["nvidia-a100"]},{"name":"nvidia-h100","runner_type":"nvidia-h100","runs_on":["nvidia-h100"]},{"name":"nvidia-gb200","runner_type":"nvidia-gb200","runs_on":{"group":"gb200-runner-set"}}]'
+            echo '::set-output name=matrix-NVIDIA::[{"name":"nvidia-a100","runner_type":"nvidia-a100","runs_on":["nvidia-a100"]},{"name":"nvidia-h100","runner_type":"nvidia-h100","runs_on":["nvidia-h100"]},{"name":"nvidia-gb200-1","runner_type":"nvidia-gb200","runs_on":{"group":"gb200-runner-set"},"shard":1},{"name":"nvidia-gb200-2","runner_type":"nvidia-gb200","runs_on":{"group":"gb200-runner-set"},"shard":2},{"name":"nvidia-gb200-3","runner_type":"nvidia-gb200","runs_on":{"group":"gb200-runner-set"},"shard":3},{"name":"nvidia-gb200-4","runner_type":"nvidia-gb200","runs_on":{"group":"gb200-runner-set"},"shard":4}]'
             echo '::set-output name=matrix-AMD::[["self-hosted", "gfx90a"], ["amd-gfx942"], ["amd-gfx950"]]'
             echo '::set-output name=matrix-MACOS::[["macos-latest"]]'
           else

--- a/python/test-requirements.txt
+++ b/python/test-requirements.txt
@@ -3,6 +3,7 @@ isort
 numpy
 pytest
 pytest-instafail
+pytest-split
 pytest-xdist
 scipy>=1.7.1
 llnl-hatchet


### PR DESCRIPTION
Parallelize Triton and Gluon tests across all four GB200 GPUs without reducing coverage.

Measured cold-cache runtimes:
- Triton: 9m23s
- Gluon: 7m34s