### PR TITLE
Infer NVMMA SMEM attributes from linear layouts

### DIFF
--- a/include/triton/Dialect/TritonNvidiaGPU/IR/NvmmaSmemAttrs.h
+++ b/include/triton/Dialect/TritonNvidiaGPU/IR/NvmmaSmemAttrs.h
@@ -1,0 +1,24 @@
+#pragma once
+
+#include <optional>
+#include <utility>
+
+#include "triton/Dialect/TritonGPU/IR/Dialect.h"
+#include "triton/Tools/LinearLayout.h"
+
+namespace mlir::triton::nvidia_gpu {
+
+struct NvmmaSmemAttrs {
+  unsigned swizzlingByteWidth = 0;
+  bool transposed = false;
+  bool fp4Padded = false;
+};
+
+// Internal helper for creating SMEM descriptors for MMA instructions. The
+// nvmmaSmemLL input must map two logical dims to offset/block outputs.
+std::optional<std::pair<NvmmaSmemAttrs, LinearLayout>>
+getNvmmaSmemAttrs(const LinearLayout &nvmmaSmemLL, unsigned bitwidth);
+
+std::optional<NvmmaSmemAttrs> getNvmmaSmemAttrs(gpu::MemDescType memTy);
+
+} // namespace mlir::triton::nvidia_gpu

--- a/lib/Dialect/TritonNvidiaGPU/IR/CMakeLists.txt
+++ b/lib/Dialect/TritonNvidiaGPU/IR/CMakeLists.txt
@@ -1,6 +1,7 @@
 add_triton_library(TritonNvidiaGPUIR
   Dialect.cpp
   TensorMemoryUtils.cpp
+  NvmmaSmemAttrs.cpp
   Ops.cpp
 
   DEPENDS

--- a/lib/Dialect/TritonNvidiaGPU/IR/NvmmaSmemAttrs.cpp
+++ b/lib/Dialect/TritonNvidiaGPU/IR/NvmmaSmemAttrs.cpp
@@ -1,0 +1,71 @@
+#include "triton/Dialect/TritonNvidiaGPU/IR/NvmmaSmemAttrs.h"
+#include "triton/Dialect/TritonGPU/IR/LinearLayoutConversions.h"
+#include "triton/Tools/LayoutUtils.h"
+
+#include <cassert>
+
+namespace ttg = mlir::triton::gpu;
+
+namespace mlir::triton::nvidia_gpu {
+
+std::optional<std::pair<NvmmaSmemAttrs, LinearLayout>>
+getNvmmaSmemAttrs(const LinearLayout &nvmmaSmemLL, unsigned bitwidth) {
+  assert(nvmmaSmemLL.getNumInDims() == 2);
+  assert(nvmmaSmemLL.getNumOutDims() == 2);
+
+  auto dims = llvm::to_vector<2>(nvmmaSmemLL.getInDimNames());
+  auto *ctx = dims[0].getContext();
+  auto offset = StringAttr::get(ctx, "offset");
+  auto block = StringAttr::get(ctx, "block");
+  assert(nvmmaSmemLL.hasOutDim(offset) && nvmmaSmemLL.hasOutDim(block));
+
+  // TODO: sw=0 is only matched for the MMA "core-matrices" operand form. The
+  // other sw=0 interpretation (nvmma_shared<sw=0> as a flat TMA destination) is
+  // not supported here.
+  for (bool fp4Padded : {false, true}) {
+    for (unsigned swizzling : {0u, 32u, 64u, 128u}) {
+      for (bool transposed : {false, true}) {
+        auto enc = ttg::NVMMASharedEncodingAttr::get(
+            ctx, swizzling, transposed, std::max(8u, bitwidth), fp4Padded,
+            ttg::CGAEncodingAttr::get1CTALayout(ctx, /*rank=*/2));
+        auto coreMatrixLL =
+            ttg::getCoreMatrixLinearLayout(enc, /*disableSwizzle=*/false);
+        auto outDims = llvm::to_vector(coreMatrixLL.getOutDims());
+        outDims[0].first = dims[0];
+        outDims[1].first = dims[1];
+        coreMatrixLL = LinearLayout(coreMatrixLL.getBases(), outDims,
+                                    /*requireSurjective=*/false);
+        if (bitwidth == 4)
+          coreMatrixLL =
+              LinearLayout::identity1D(2, offset, dims[1]) * coreMatrixLL;
+        if (transposed)
+          coreMatrixLL = transposeLinearLayout(coreMatrixLL, {1, 0});
+        auto candidateLL = coreMatrixLL.pseudoinvert();
+        // Add a trivial block dimension as getReps expects both layouts to
+        // have the same outdims
+        auto matchLL =
+            candidateLL * LinearLayout::identity1D(1, dims[0], block);
+        if (getReps(nvmmaSmemLL, matchLL).has_value())
+          return std::make_pair(
+              NvmmaSmemAttrs{swizzling, transposed, fp4Padded},
+              std::move(candidateLL));
+      }
+    }
+  }
+  return std::nullopt;
+}
+
+std::optional<NvmmaSmemAttrs> getNvmmaSmemAttrs(ttg::MemDescType memTy) {
+  if (auto nvmma = dyn_cast<ttg::NVMMASharedEncodingAttr>(memTy.getEncoding()))
+    return NvmmaSmemAttrs{nvmma.getSwizzlingByteWidth(), nvmma.getTransposed(),
+                          nvmma.getFp4Padded()};
+
+  auto ll = ttg::toLinearLayout(memTy).pseudoinvert();
+  unsigned bitwidth = memTy.getElementType().getIntOrFloatBitWidth();
+  auto attrsAndCandidate = getNvmmaSmemAttrs(ll, bitwidth);
+  if (!attrsAndCandidate)
+    return std::nullopt;
+  return attrsAndCandidate->first;
+}
+
+} // namespace mlir::triton::nvidia_gpu

--- a/test/Conversion/tritongpu_to_llvm_blackwell.mlir
+++ b/test/Conversion/tritongpu_to_llvm_blackwell.mlir
@@ -296,6 +296,34 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.shar
 // -----
 
 #shared = #ttg.nvmma_shared<{swizzlingByteWidth = 64, transposed = false, elementBitWidth = 8}>
+#tmem = #ttng.tensor_memory_encoding<blockM = 128, blockN = 64, colStride = 1>
+#tmem_scales = #ttng.tensor_memory_scales_encoding<>
+module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32} {
+  // CHECK-LABEL: @tc_gen5_mma_scaled_a_tmem
+  // CHECK: %[[TMEM_BASE:.+]] = llvm.ptrtoint %arg2 : !llvm.ptr<3> to i32
+  // CHECK: %[[A_BASE:.+]] = llvm.ptrtoint %arg0 : !llvm.ptr<3> to i32
+  // CHECK: @$7 tcgen05.mma.cta_group::1.kind::mxf8f6f4.block_scale.scale_vec::1X [ $0 + 0 ], [ $1 + 0 ], $2, $3, [ $4 + 0 ], [ $5 + 0 ], $6;", "r,r,l,r,r,r,b,b" %[[TMEM_BASE]], %[[A_BASE]]
+  tt.func @tc_gen5_mma_scaled_a_tmem(
+      %a: !ttg.memdesc<128x256xf8E5M2, #tmem, #ttng.tensor_memory>,
+      %b: !ttg.memdesc<256x64xf8E5M2, #shared, #ttg.shared_memory>,
+      %c: !ttg.memdesc<128x64xf32, #tmem, #ttng.tensor_memory, mutable>,
+      %scale_a: !ttg.memdesc<128x8xi8, #tmem_scales, #ttng.tensor_memory>,
+      %scale_b: !ttg.memdesc<64x8xi8, #tmem_scales, #ttng.tensor_memory>,
+      %useAcc: i1,
+      %pred: i1) {
+    ttng.tc_gen5_mma_scaled %a, %b, %c, %scale_a, %scale_b, %useAcc, %pred lhs = e5m2 rhs = e5m2 :
+      !ttg.memdesc<128x256xf8E5M2, #tmem, #ttng.tensor_memory>,
+      !ttg.memdesc<256x64xf8E5M2, #shared, #ttg.shared_memory>,
+      !ttg.memdesc<128x64xf32, #tmem, #ttng.tensor_memory, mutable>,
+      !ttg.memdesc<128x8xi8, #tmem_scales, #ttng.tensor_memory>,
+      !ttg.memdesc<64x8xi8, #tmem_scales, #ttng.tensor_memory>
+    tt.return
+  }
+}
+
+// -----
+
+#shared = #ttg.nvmma_shared<{swizzlingByteWidth = 64, transposed = false, elementBitWidth = 8}>
 #shared1 = #ttg.nvmma_shared<{swizzlingByteWidth = 32, transposed = true, elementBitWidth = 8}>
 #shared2 = #ttg.swizzled_shared<{vec = 1, perPhase = 1, maxPhase = 1, order = [0]}>
 #tmem = #ttng.tensor_memory_encoding<blockM = 128, blockN = 128, colStride = 1>

--- a/third_party/nvidia/lib/TritonNVIDIAGPUToLLVM/DotOpToLLVM/MMAHelpers.h
+++ b/third_party/nvidia/lib/TritonNVIDIAGPUToLLVM/DotOpToLLVM/MMAHelpers.h
@@ -1,5 +1,6 @@
 #include "Utility.h"
 #include "mlir/Support/LLVM.h"
+#include "triton/Dialect/TritonNvidiaGPU/IR/NvmmaSmemAttrs.h"
 #include "triton/Tools/LayoutUtils.h"
 
 namespace mlir {
@@ -200,132 +201,91 @@ private:
     auto dims = to_vector(ll.getInDimNames());
     auto ctx = dims[0].getContext();
     auto kOffset = str_attr("offset");
+    auto attrsAndCandidate = nvidia_gpu::getNvmmaSmemAttrs(ll, bitwidth);
+    if (!attrsAndCandidate)
+      return failure();
 
-    // Any CGALayout, it's not really used within getCoreMatrixLinearLayout
-    auto CGALayout = triton::gpu::CGAEncodingAttr::get1CTALayout(ctx, 2);
+    auto [attrs, shmemTileInv] = std::move(*attrsAndCandidate);
+    int swizzling = attrs.swizzlingByteWidth;
+    bool transposed = attrs.transposed;
+    bool fp4Padded = attrs.fp4Padded;
 
-    for (bool fp4Padded : (bitwidth == 4 ? SmallVector<bool>({false, true})
-                                         : SmallVector<bool>({false}))) {
-      for (auto transposed : {false, true}) {
-        for (int swizzling : {0, 32, 64, 128}) {
-          // FIXME: getCoreMatrixLinearLayout does not accept bitwidth < 8
-          auto shmemEnc = triton::gpu::NVMMASharedEncodingAttr::get(
-              ctx, swizzling, transposed, std::max(8, bitwidth), fp4Padded,
-              CGALayout);
-          auto shmemTile =
-              getCoreMatrixLinearLayout(shmemEnc, /*disableSwizzle=*/false);
-          // Rename out dims to match the original layout (in case the dims were
-          // (row, col))
-          auto outDims = to_vector(shmemTile.getOutDims());
-          outDims[0].first = dims[0];
-          outDims[1].first = dims[1];
-          shmemTile = LinearLayout(shmemTile.getBases(), outDims,
-                                   /*requireSurjective=*/false);
-          // unpack the fp4 layout
-          if (bitwidth == 4) {
-            shmemTile =
-                LinearLayout::identity1D(2, kOffset, dims[1]) * shmemTile;
-          }
+    // The PTX docs are wrong in subtle ways:
+    // 1) LBO can be specified for kContig && swizzled != 0
+    //    PTX says it's assumed to be 1, but  we can in fact use it
+    // 2) The Cute layouts for kContig && swizzled != 0 are wrong
+    int lbo = 0, sbo = 0;
+    int leadingDim = transposed ? 0 : 1;
+    int stridedDim = transposed ? 1 : 0;
+    // The lbo / sbo is swapped for swizzling == 0 and MNContig lol
+    bool MNContig = (MNdim == 0) == transposed;
+    if (swizzling == 0 && MNContig) {
+      std::swap(leadingDim, stridedDim);
+    }
+    auto log2RowsTile = shmemTileInv.getInDimSizeLog2(dims[leadingDim]);
+    if (llvm::Log2_32(instrShape[leadingDim]) > log2RowsTile) {
+      lbo = ll.getBasis(dims[leadingDim], log2RowsTile, kOffset);
+    }
 
-          // getCoreMatrixLinearLayout gives the k-contiguous tile
-          // shmemTile is a layout onto a matrix with shape
-          // If swizzling != 0: 8 x (8 * swizzling / bitwidth)
-          // If swizzling == 0: 8 x (8 * 16 / bitwidth)
-          assert(shmemTile.getOutDimSize(dims[0]) == 8);
-          // Multiply by 2 if fp4Padded as the matrix has half the core
-          // matrix has half the number of elements
-          assert(shmemTile.getOutDimSize(dims[1]) * (fp4Padded ? 2 : 1) ==
-                 8 * std::max(16, swizzling) / bitwidth);
+    auto log2ColsTile = shmemTileInv.getInDimSizeLog2(dims[stridedDim]);
+    if (llvm::Log2_32(instrShape[stridedDim]) > log2ColsTile) {
+      sbo = ll.getBasis(dims[stridedDim], log2ColsTile, kOffset);
+    }
 
-          if (transposed) {
-            shmemTile = transposeLinearLayout(shmemTile, {1, 0});
-          }
-          // Pseudoinvert as fp4 may have padding
-          auto shmemTileInv = shmemTile.pseudoinvert();
-
-          // The PTX docs are wrong in subtle ways:
-          // 1) LBO can be specified for kContig && swizzled != 0
-          //    PTX says it's assumed to be 1, but  we can in fact use it
-          // 2) The Cute layouts for kContig && swizzled != 0 are wrong
-          int lbo = 0, sbo = 0;
-          int leadingDim = transposed ? 0 : 1;
-          int stridedDim = transposed ? 1 : 0;
-          // The lbo / sbo is swapped for swizzling == 0 and MNContig lol
-          bool MNContig = (MNdim == 0) == transposed;
-          if (swizzling == 0 && MNContig) {
-            std::swap(leadingDim, stridedDim);
-          }
-          auto log2RowsTile = shmemTileInv.getInDimSizeLog2(dims[leadingDim]);
-          if (llvm::Log2_32(instrShape[leadingDim]) > log2RowsTile) {
-            lbo = ll.getBasis(dims[leadingDim], log2RowsTile, kOffset);
-          }
-
-          auto log2ColsTile = shmemTileInv.getInDimSizeLog2(dims[stridedDim]);
-          if (llvm::Log2_32(instrShape[stridedDim]) > log2ColsTile) {
-            sbo = ll.getBasis(dims[stridedDim], log2ColsTile, kOffset);
-          }
-
-          // Pad the tile up to the full instruction shape with the relevant
-          // stride if the instruction shape is larger than the tile
-          auto bases = shmemTileInv.getBases();
-          for (int d : {0, 1}) {
-            // 'tile' with the atom tile according to the lbo/sbo rules
-            for (int i = 1;
-                 i < instrShape[d] / shmemTileInv.getInDimSize(dims[d]);
-                 i *= 2) {
-              auto stride = ll.getBasis(
-                  dims[d], shmemTileInv.getInDimSizeLog2(dims[d]), kOffset);
-              bases[dims[d]].push_back({stride * i});
-            }
-          }
-          auto maxBasis = 0;
-          for (auto dimBases : llvm::make_second_range(bases)) {
-            for (auto basis : dimBases) {
-              maxBasis = std::max(maxBasis, basis[0]);
-            }
-          }
-          // Multiply by 2 or round up to the next power of 2
-          shmemTileInv = LinearLayout(std::move(bases),
-                                      {{kOffset, llvm::NextPowerOf2(maxBasis)}},
-                                      /*requireSurjective=*/false);
-          // Add a trivial block dimension as getReps expects both layouts to
-          // have the same outdims
-          shmemTileInv *=
-              LinearLayout::identity1D(1, dims[0], str_attr("block"));
-
-          auto reps = getReps(ll, shmemTileInv);
-          if (reps.has_value()) {
-            SMEMDescriptor desc;
-            desc.descriptor = mmaVersion == 5 ? 1ULL << 46 : 0ULL;
-            // The lbo / sbo is defined wrt. the 128b elements
-            desc.leadDimensionBaseOffset = (lbo * bitwidth / 8) >> 4;
-            desc.strideDimensionBaseOffset = (sbo * bitwidth / 8) >> 4;
-            switch (swizzling) {
-            case 0:
-              desc.swizzlingMode = 0;
-              break;
-            case 32:
-              desc.swizzlingMode = 3;
-              break;
-            case 64:
-              desc.swizzlingMode = 2;
-              break;
-            case 128:
-              desc.swizzlingMode = 1;
-              break;
-            default:
-              llvm_unreachable("Unsupported swizzling size.");
-            }
-            return MMASMEMDescriptor{/* .descriptor = */ desc,
-                                     /* .swizzlingByteWidth = */ swizzling,
-                                     /* .bitwidth = */ bitwidth,
-                                     /* .transposed = */ transposed,
-                                     /* .fp4Padded = */ fp4Padded};
-          }
-        }
+    // Pad the tile up to the full instruction shape with the relevant
+    // stride if the instruction shape is larger than the tile
+    auto bases = shmemTileInv.getBases();
+    for (int d : {0, 1}) {
+      // 'tile' with the atom tile according to the lbo/sbo rules
+      for (int i = 1; i < instrShape[d] / shmemTileInv.getInDimSize(dims[d]);
+           i *= 2) {
+        auto stride = ll.getBasis(
+            dims[d], shmemTileInv.getInDimSizeLog2(dims[d]), kOffset);
+        bases[dims[d]].push_back({stride * i});
       }
     }
-    return failure();
+    auto maxBasis = 0;
+    for (auto dimBases : llvm::make_second_range(bases)) {
+      for (auto basis : dimBases) {
+        maxBasis = std::max(maxBasis, basis[0]);
+      }
+    }
+    // Multiply by 2 or round up to the next power of 2
+    shmemTileInv = LinearLayout(std::move(bases),
+                                {{kOffset, llvm::NextPowerOf2(maxBasis)}},
+                                /*requireSurjective=*/false);
+    // Add a trivial block dimension as getReps expects both layouts to
+    // have the same outdims
+    shmemTileInv *= LinearLayout::identity1D(1, dims[0], str_attr("block"));
+
+    assert(getReps(ll, shmemTileInv).has_value());
+
+    SMEMDescriptor desc;
+    desc.descriptor = mmaVersion == 5 ? 1ULL << 46 : 0ULL;
+    // The lbo / sbo is defined wrt. the 128b elements
+    desc.leadDimensionBaseOffset = (lbo * bitwidth / 8) >> 4;
+    desc.strideDimensionBaseOffset = (sbo * bitwidth / 8) >> 4;
+    switch (swizzling) {
+    case 0:
+      desc.swizzlingMode = 0;
+      break;
+    case 32:
+      desc.swizzlingMode = 3;
+      break;
+    case 64:
+      desc.swizzlingMode = 2;
+      break;
+    case 128:
+      desc.swizzlingMode = 1;
+      break;
+    default:
+      llvm_unreachable("Unsupported swizzling size.");
+    }
+    return MMASMEMDescriptor{/* .descriptor = */ desc,
+                             /* .swizzlingByteWidth = */ swizzling,
+                             /* .bitwidth = */ bitwidth,
+                             /* .transposed = */ transposed,
+                             /* .fp4Padded = */ fp4Padded};
   }
 };
 

--- a/third_party/nvidia/lib/TritonNVIDIAGPUToLLVM/DotOpToLLVM/MMAv5.cpp
+++ b/third_party/nvidia/lib/TritonNVIDIAGPUToLLVM/DotOpToLLVM/MMAv5.cpp
@@ -4,15 +4,13 @@
 #include "Utility.h"
 #include "mlir/Support/LLVM.h"
 #include "triton/Conversion/TritonGPUToLLVM/PatternTritonGPUOpToLLVM.h"
+#include "triton/Dialect/TritonNvidiaGPU/IR/NvmmaSmemAttrs.h"
 
 using namespace mlir;
 using namespace mlir::triton;
 using namespace mlir::triton::gpu;
 using namespace mlir::triton::NVIDIA;
 namespace ttng = mlir::triton::nvidia_gpu;
-
-using ::mlir::triton::gpu::NVMMASharedEncodingAttr;
-using ::mlir::triton::gpu::SharedLinearEncodingAttr;
 
 namespace {
 
@@ -80,20 +78,12 @@ enum class mxfpKind { mxf8f6f4 = 0, mxf4 = 1, mxf4nvf4 = 2 };
 
 bool isTransposed(Value operand) {
   auto tensorTy = cast<MemDescType>(operand.getType());
-  auto enc = tensorTy.getEncoding();
-  if (auto shared = dyn_cast<NVMMASharedEncodingAttr>(enc))
-    return shared.getTransposed();
-  if (auto tensor = dyn_cast<ttng::TensorMemoryEncodingAttr>(enc))
+  if (isa<ttng::TensorMemoryEncodingAttr>(tensorTy.getEncoding()))
     return false;
-  if (auto sharedLinear = dyn_cast<SharedLinearEncodingAttr>(enc)) {
-    // Hack. We should refactor the lowering to be able to use the
-    // result from the memory descriptor
-    auto *ctx = sharedLinear.getContext();
-    auto kOffset = StringAttr::get(ctx, "offset");
-    auto dim0 = StringAttr::get(ctx, "dim0");
-    return sharedLinear.getLinearLayout().getBasis(kOffset, 0, dim0) != 0;
-  }
-  return false;
+
+  auto attrs = ttng::getNvmmaSmemAttrs(tensorTy);
+  assert(attrs && "expected MMAv5 shared operand to have NVMMA SMEM attrs");
+  return attrs->transposed;
 }
 
 inline mxfpKind getMXFPKind(ScaleDotElemType typeA, ScaleDotElemType typeB,

--- a/unittest/Dialect/CMakeLists.txt
+++ b/unittest/Dialect/CMakeLists.txt
@@ -1,1 +1,2 @@
 add_subdirectory(TritonGPU)
+add_subdirectory(TritonNvidiaGPU)

--- a/unittest/Dialect/TritonNvidiaGPU/CMakeLists.txt
+++ b/unittest/Dialect/TritonNvidiaGPU/CMakeLists.txt
@@ -1,0 +1,10 @@
+add_triton_ut(
+  NAME NvmmaSmemAttrsTest
+  SRCS NvmmaSmemAttrsTest.cpp
+  LIBS
+    TritonAnalysis
+    TritonGPUIR
+    TritonNvidiaGPUIR
+    TritonGPUTransforms
+    TritonNvidiaGPUTransforms
+)

--- a/unittest/Dialect/TritonNvidiaGPU/NvmmaSmemAttrsTest.cpp
+++ b/unittest/Dialect/TritonNvidiaGPU/NvmmaSmemAttrsTest.cpp
@@ -1,0 +1,230 @@
+#include "triton/Dialect/TritonNvidiaGPU/IR/NvmmaSmemAttrs.h"
+
+#include "mlir/IR/MLIRContext.h"
+#include "triton/Dialect/TritonGPU/IR/Attributes.h"
+#include "triton/Dialect/TritonGPU/IR/Dialect.h"
+#include "triton/Dialect/TritonGPU/IR/LinearLayoutConversions.h"
+#include "triton/Dialect/TritonNvidiaGPU/IR/Dialect.h"
+#include "triton/Tools/LayoutUtils.h"
+#include "llvm/ADT/ArrayRef.h"
+#include <gtest/gtest.h>
+
+using namespace mlir::triton::nvidia_gpu;
+
+namespace mlir::triton::gpu {
+namespace {
+
+LinearLayout getSwizzle0CoreMatrixLinearLayout(MLIRContext *ctx,
+                                               ArrayRef<int64_t> shape,
+                                               unsigned elementBitWidth,
+                                               bool transposed,
+                                               bool fp4Padded) {
+  SmallVector<int64_t> tiledShape(shape);
+  if (transposed)
+    std::swap(tiledShape[0], tiledShape[1]);
+  auto enc = NVMMASharedEncodingAttr::get(
+      ctx, /*swizzlingByteWidth=*/0, /*transposed=*/false, elementBitWidth,
+      fp4Padded, CGAEncodingAttr::get1CTALayout(ctx, /*rank=*/2));
+  auto layout = ensureLayoutNotSmallerThan(
+      getCoreMatrixLinearLayout(enc, /*disableSwizzle=*/false),
+      standardOutDimNames(ctx, shape.size()), tiledShape);
+  if (transposed)
+    layout = transposeLinearLayout(layout, {1, 0});
+  return layout;
+}
+
+class NvmmaSmemAttrsTest : public ::testing::Test {
+public:
+  void SetUp() override {
+    ctx.getOrLoadDialect<TritonGPUDialect>();
+    ctx.getOrLoadDialect<TritonNvidiaGPUDialect>();
+  }
+
+  NVMMASharedEncodingAttr
+  nvmmaShared(unsigned swizzleSizeInBytes, bool transposed,
+              unsigned elementBitWidth, ArrayRef<unsigned> cpg,
+              ArrayRef<unsigned> cSplit, ArrayRef<unsigned> ord,
+              ArrayRef<unsigned> cOrd, bool fp4Padded = false) {
+    return NVMMASharedEncodingAttr::get(
+        &ctx, swizzleSizeInBytes, transposed, elementBitWidth, fp4Padded,
+        CGAEncodingAttr::fromSplitParams(&ctx, cpg, cSplit, cOrd));
+  }
+
+  StringAttr S(StringRef str) { return StringAttr::get(&ctx, str); }
+
+protected:
+  MLIRContext ctx;
+};
+
+TEST_F(NvmmaSmemAttrsTest, InferNvmmaSmemAttrsSharedLinear) {
+  auto i8Ty = IntegerType::get(&ctx, 8);
+  auto smem = SharedMemorySpaceAttr::get(&ctx);
+
+  struct ExpectedLayout {
+    unsigned swizzlingByteWidth = 0;
+    bool transposed = false;
+    bool fp4Padded = false;
+  };
+
+  auto checkLayout = [&](SmallVector<int64_t> shape, Type elemTy,
+                         NVMMASharedEncodingAttr nvmma,
+                         ExpectedLayout expected) {
+    auto ll = toLinearLayout(shape, nvmma);
+    auto sharedLinear = SharedLinearEncodingAttr::get(&ctx, std::move(ll),
+                                                      /*layoutAlignment=*/1024);
+    auto memTy = MemDescType::get(shape, elemTy, sharedLinear, smem);
+
+    auto inferred = getNvmmaSmemAttrs(memTy);
+    ASSERT_TRUE(inferred) << "sw=" << expected.swizzlingByteWidth
+                          << " transposed=" << expected.transposed
+                          << " fp4Padded=" << expected.fp4Padded;
+    EXPECT_EQ(inferred->swizzlingByteWidth, expected.swizzlingByteWidth);
+    EXPECT_EQ(inferred->transposed, expected.transposed);
+    EXPECT_EQ(inferred->fp4Padded, expected.fp4Padded);
+  };
+
+  for (unsigned sw : {32u, 64u, 128u}) {
+    for (bool transposed : {false, true}) {
+      for (bool fp4Padded : {false, true}) {
+        checkLayout({128, 128}, i8Ty,
+                    nvmmaShared(sw, transposed, /*elementBitWidth=*/8, {1, 1},
+                                {1, 1}, {1, 0}, {1, 0}, fp4Padded),
+                    ExpectedLayout{sw, transposed, fp4Padded});
+      }
+    }
+  }
+
+  SmallVector<int64_t> sw0Shape = {128, 256};
+  for (bool transposed : {false, true}) {
+    for (bool fp4Padded : {false, true}) {
+      auto sw0CoreMatrixTiled =
+          getSwizzle0CoreMatrixLinearLayout(&ctx, sw0Shape,
+                                            /*elementBitWidth=*/8, transposed,
+                                            fp4Padded) *
+          LinearLayout::identity1D(1, S("block"), S("dim0"));
+      auto sw0SharedLinear = SharedLinearEncodingAttr::get(
+          &ctx, std::move(sw0CoreMatrixTiled), /*layoutAlignment=*/1024);
+      auto sw0MemTy = MemDescType::get(sw0Shape, i8Ty, sw0SharedLinear, smem);
+      auto sw0Inferred = getNvmmaSmemAttrs(sw0MemTy);
+      ASSERT_TRUE(sw0Inferred)
+          << "transposed=" << transposed << " fp4Padded=" << fp4Padded;
+      EXPECT_EQ(sw0Inferred->swizzlingByteWidth, 0u);
+      EXPECT_EQ(sw0Inferred->transposed, transposed);
+      EXPECT_EQ(sw0Inferred->fp4Padded, fp4Padded);
+    }
+  }
+
+  struct Case {
+    unsigned bitwidth;
+    unsigned sw;
+    bool transposed;
+  };
+  for (Case testCase :
+       {Case{8, 32, true}, Case{16, 64, false}, Case{32, 128, true}}) {
+    checkLayout({128, 128}, IntegerType::get(&ctx, testCase.bitwidth),
+                nvmmaShared(testCase.sw, testCase.transposed, testCase.bitwidth,
+                            {1, 1}, {1, 1}, {1, 0}, {1, 0}),
+                ExpectedLayout{testCase.sw, testCase.transposed,
+                               /*fp4Padded=*/false});
+  }
+}
+
+TEST_F(NvmmaSmemAttrsTest, Fp4PaddedRequiresI8Storage) {
+  auto checkLayout = [&](const LinearLayout &ll) {
+    bool sawFp4Padded = false;
+    for (unsigned bitwidth : {8u, 16u, 32u, 64u}) {
+      auto attrsAndCandidate = getNvmmaSmemAttrs(ll, bitwidth);
+      if (!attrsAndCandidate)
+        continue;
+      auto attrs = attrsAndCandidate->first;
+      sawFp4Padded |= attrs.fp4Padded;
+      EXPECT_TRUE(!attrs.fp4Padded || bitwidth == 8)
+          << "fp4Padded with bitwidth=" << bitwidth;
+    }
+    return sawFp4Padded;
+  };
+
+  auto fp4 = nvmmaShared(/*swizzleSizeInBytes=*/128, /*transposed=*/false,
+                         /*elementBitWidth=*/8, {1, 1}, {1, 1}, {1, 0}, {1, 0},
+                         /*fp4Padded=*/true);
+  // Positive control: matcher must produce fp4Padded for i8 storage.
+  EXPECT_TRUE(checkLayout(toLinearLayout({128, 128}, fp4).pseudoinvert()));
+
+  struct Case {
+    unsigned bitwidth;
+    unsigned sw;
+    bool transposed;
+  };
+  for (Case testCase : {Case{8, 32, true}, Case{16, 64, false},
+                        Case{32, 128, true}, Case{64, 128, false}}) {
+    auto nvmma = nvmmaShared(testCase.sw, testCase.transposed,
+                             testCase.bitwidth, {1, 1}, {1, 1}, {1, 0}, {1, 0});
+    checkLayout(toLinearLayout({128, 128}, nvmma).pseudoinvert());
+  }
+}
+
+TEST_F(NvmmaSmemAttrsTest, InferNvmmaSmemAttrsRejectsNearMisses) {
+  auto i4Ty = IntegerType::get(&ctx, 4);
+  auto smem = SharedMemorySpaceAttr::get(&ctx);
+  auto inferSharedLinearInfo = [&](LinearLayout layout) {
+    SmallVector<int64_t> shape;
+    for (int32_t size : layout.getOutDimSizes())
+      shape.push_back(size);
+    auto sharedLinear = SharedLinearEncodingAttr::get(&ctx, std::move(layout),
+                                                      /*layoutAlignment=*/1024);
+    auto memTy = MemDescType::get(shape, i4Ty, sharedLinear, smem);
+    return getNvmmaSmemAttrs(memTy);
+  };
+  auto nonPaddedPrefix = LinearLayout({{S("offset"),
+                                        {{0, 1},
+                                         {0, 2},
+                                         {0, 4},
+                                         {0, 8},
+                                         {0, 16},
+                                         {0, 32},
+                                         {1, 8},
+                                         {2, 16},
+                                         {4, 32}}},
+                                       {S("block"), {}}},
+                                      {S("dim0"), S("dim1")});
+  EXPECT_FALSE(inferSharedLinearInfo(std::move(nonPaddedPrefix)));
+
+  auto shiftedZero = LinearLayout({{S("offset"),
+                                    {{0, 1},
+                                     {0, 2},
+                                     {0, 4},
+                                     {0, 8},
+                                     {0, 0},
+                                     {0, 16},
+                                     {0, 32},
+                                     {1, 8},
+                                     {2, 16},
+                                     {4, 32},
+                                     {8, 0},
+                                     {16, 0}}},
+                                   {S("block"), {}}},
+                                  {S("dim0"), S("dim1")});
+  EXPECT_FALSE(inferSharedLinearInfo(std::move(shiftedZero)));
+
+  // A valid fp4 prefix is not enough; the remaining bases must match.
+  auto earlyRowInterleave = LinearLayout({{S("offset"),
+                                           {{0, 1},
+                                            {0, 2},
+                                            {0, 4},
+                                            {0, 0},
+                                            {1, 8},
+                                            {2, 16},
+                                            {4, 32},
+                                            {0, 8},
+                                            {0, 16},
+                                            {0, 32},
+                                            {8, 0},
+                                            {16, 0}}},
+                                          {S("block"), {}}},
+                                         {{S("dim0"), 32}, {S("dim1"), 64}},
+                                         /*requireSurjective=*/true);
+  EXPECT_FALSE(inferSharedLinearInfo(std::move(earlyRowInterleave)));
+}
+
+} // namespace
+} // namespace mlir::triton::gpu


### PR DESCRIPTION
Add an MMA-focused utility to classify NVMMA SMEM attributes (swizzling, transposed, fp4Padded) from MemDescType or LinearLayout.
    
Use the inferred attributes in MMA SMEM descriptor construction and MMAv5 transpose queries, including operands rewritten to SharedLinear layouts. TMA use cases are left for future work.
    
 Add unit coverage for inference, fp4-padded matching, sw=0 MMA layouts, and near-miss rejection.