### PR TITLE
[DOCS] Remove non-existent `padding_option` from `tl.store` docstring

### DIFF
--- a/python/triton/language/core.py
+++ b/python/triton/language/core.py
@@ -2563,7 +2563,7 @@ def store(pointer, value, mask=None, boundary_check=(), cache_modifier="", evict
             this case:
 
             - `mask` must also be scalar, and
-            - `boundary_check` and `padding_option` must be empty.
+            - `boundary_check` must be empty.
 
         (2) If `pointer` is an N-dimensional tensor of pointers, an
             N-dimensional block is stored.  In this case:


### PR DESCRIPTION
### Problem

`tl.store`'s docstring documents a parameter it doesn't have. The single-element-pointer case says:

> - `boundary_check` and `padding_option` must be empty.

But `store`'s signature is:

```python
def store(pointer, value, mask=None, boundary_check=(), cache_modifier="", eviction_policy="", _semantic=None):
```

There is no `padding_option` — padding is a **load-only** concept (`load` pads out-of-bound reads with `""`/`"zero"`/`"nan"`); there is nothing to pad on a store.

### Fix

Drop the bogus `padding_option` reference, leaving:

> - `boundary_check` must be empty.

This now matches the N-dimensional-tensor case immediately below, which already documents only `boundary_check`.

Docstring-only change — no behavior change.
