### PR TITLE
[DOCS] Document that `tl.load(other=...)` requires `mask`

### DIFF
--- a/python/triton/language/core.py
+++ b/python/triton/language/core.py
@@ -2504,7 +2504,7 @@ def load(pointer, mask=None, other=None, boundary_check=(), padding_option="", c
     :param mask: if `mask[idx]` is false, do not load the data at address `pointer[idx]`
         (must be `None` with block pointers)
     :type mask: Block of `triton.int1`, optional
-    :param other: if `mask[idx]` is false, return `other[idx]`. If `other` is `None`, the masked-out value is undefined.
+    :param other: if `mask[idx]` is false, return `other[idx]`. If `other` is `None`, the masked-out value is undefined. `other` may only be specified together with `mask`; providing `other` without `mask` raises a `ValueError`.
     :type other: Block, optional
     :param boundary_check: tuple of integers, indicating the dimensions which should do the boundary check
     :type boundary_check: tuple of ints, optional


### PR DESCRIPTION
### Problem (#1137)

`semantic.py` rejects `tl.load` when `other` is supplied without `mask`:

```python
raise ValueError("`other` cannot be provided without `mask`")
```

…but `load`'s docstring never documents this restriction — the `:param other:` entry only describes what `other` does when `mask` is false. A user passing `other=` without `mask=` hits the error with no hint from the docs, which is the confusion reported in #1137.

### Fix

Add the requirement to the `other` parameter docs:

> `other` may only be specified together with `mask`; providing `other` without `mask` raises a `ValueError`.

Docstring-only change — no behavior change. In the same spirit as prior `load`-semantics doc clarifications.

Refs #1137
