### PR TITLE
[AMD] Add support for InThreadTranspose for the FMA path

### DIFF
--- a/test/TritonGPU/amd/in-thread-transpose.mlir
+++ b/test/TritonGPU/amd/in-thread-transpose.mlir
@@ -569,3 +569,125 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 2 : i32, ttg.targ
     tt.return
   }
 }
+
+// -----
+// FMA path (f32 on gfx1201). The dot operand's parent encoding is #ttg.blocked
+// (FMA outer-product), not AMDMfma/AMDWmma. 
+// CHECK-DAG: [[$DOT:#.*]] = #ttg.blocked<{sizePerThread = [4, 4], threadsPerWarp = [4, 8], warpsPerCTA = [2, 1], order = [1, 0]}>
+// CHECK-DAG: [[$SHAREDA:#.*]] = #ttg.swizzled_shared<{vec = 1, perPhase = 1, maxPhase = 1, order = [0, 1]}>
+// CHECK-DAG: [[$SHAREDB:#.*]] = #ttg.swizzled_shared<{vec = 1, perPhase = 1, maxPhase = 1, order = [1, 0]}>
+// CHECK-NOT: #ttg.amd_rotating_shared
+// CHECK-LABEL: inThreadTranspose_simple_fma_transposed_b
+// CHECK: [[TA:%.*]] = amdg.in_thread_transpose {{.*}} -> tensor<32x8xf32, [[$LINEARA:#.*]]>
+// CHECK: [[ALLOCA:%.*]] = ttg.local_alloc [[TA]] : (tensor<32x8xf32, [[$LINEARA]]>) -> !ttg.memdesc<32x8xf32, [[$SHAREDA]], #smem>
+// CHECK: ttg.local_load [[ALLOCA]] : !ttg.memdesc<32x8xf32, [[$SHAREDA]], #smem> -> tensor<32x8xf32, #ttg.dot_op<{opIdx = 0, parent = [[$DOT]]}>>
+// CHECK: [[TB:%.*]] = amdg.in_thread_transpose {{.*}} -> tensor<8x32xf32, [[$LINEARB:#.*]]>
+// CHECK: [[ALLOCB:%.*]] = ttg.local_alloc [[TB]] : (tensor<8x32xf32, [[$LINEARB]]>) -> !ttg.memdesc<8x32xf32, [[$SHAREDB]], #smem>
+// CHECK: ttg.local_load [[ALLOCB]] : !ttg.memdesc<8x32xf32, [[$SHAREDB]], #smem> -> tensor<8x32xf32, #ttg.dot_op<{opIdx = 1, parent = [[$DOT]]}>>
+// CHECK: tt.dot
+
+#dot = #ttg.blocked<{sizePerThread = [4, 4], threadsPerWarp = [4, 8], warpsPerCTA = [2, 1], order = [1, 0]}>
+#blockedA = #ttg.blocked<{sizePerThread = [1, 4], threadsPerWarp = [16, 2], warpsPerCTA = [2, 1], order = [1, 0]}>
+#blockedB = #ttg.blocked<{sizePerThread = [4, 1], threadsPerWarp = [2, 16], warpsPerCTA = [1, 2], order = [0, 1]}>
+#sharedA = #ttg.swizzled_shared<{vec = 1, perPhase = 1, maxPhase = 1, order = [1, 0]}>
+#sharedB = #ttg.swizzled_shared<{vec = 1, perPhase = 1, maxPhase = 1, order = [0, 1]}>
+#smem = #ttg.shared_memory
+module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 2 : i32, ttg.target = "hip:gfx1201", "ttg.threads-per-warp" = 32 : i32} {
+  tt.func public @inThreadTranspose_simple_fma_transposed_b(%argA: !tt.ptr<f32> {tt.divisibility = 16 : i32, tt.pointer_range = 32 : i32}, %argB: !tt.ptr<f32> {tt.divisibility = 16 : i32, tt.pointer_range = 32 : i32}) {
+    %cst = arith.constant dense<0.000000e+00> : tensor<32x32xf32, #dot>
+    %0 = tt.splat %argA : !tt.ptr<f32> -> tensor<32x8x!tt.ptr<f32>, #blockedA>
+    %1 = tt.splat %argB : !tt.ptr<f32> -> tensor<8x32x!tt.ptr<f32>, #blockedB>
+    %2 = tt.load %0 : tensor<32x8x!tt.ptr<f32>, #blockedA>
+    %3 = tt.load %1 : tensor<8x32x!tt.ptr<f32>, #blockedB>
+
+    %4 = ttg.local_alloc %2 : (tensor<32x8xf32, #blockedA>) -> !ttg.memdesc<32x8xf32, #sharedA, #smem>
+    %5 = ttg.local_load %4 : !ttg.memdesc<32x8xf32, #sharedA, #smem> -> tensor<32x8xf32, #ttg.dot_op<{opIdx = 0, parent = #dot}>>
+
+    %6 = ttg.local_alloc %3 : (tensor<8x32xf32, #blockedB>) -> !ttg.memdesc<8x32xf32, #sharedB, #smem>
+    %7 = ttg.local_load %6 : !ttg.memdesc<8x32xf32, #sharedB, #smem> -> tensor<8x32xf32, #ttg.dot_op<{opIdx = 1, parent = #dot}>>
+
+    %8 = tt.dot %5, %7, %cst : tensor<32x8xf32, #ttg.dot_op<{opIdx = 0, parent = #dot}>> * tensor<8x32xf32, #ttg.dot_op<{opIdx = 1, parent = #dot}>> -> tensor<32x32xf32, #dot>
+    tt.return
+  }
+}
+
+// -----
+// FMA path negative: the global loads are already operand-major (A is M-contiguous,
+// B is N-contiguous), exactly the orientation the FMA dot wants in LDS. There
+// is nothing to transpose, so InThreadTranspose must bail. This is the FMA
+// mirror of inThreadTranspose_k_fast_neg.
+// CHECK-NOT: #ttg.amd_rotating_shared
+// CHECK-NOT: #ttg.linear
+// CHECK-DAG: [[$OM_A:#.*]] = #ttg.blocked<{sizePerThread = [4, 1], threadsPerWarp = [8, 4], warpsPerCTA = [1, 2], order = [0, 1]}>
+// CHECK-DAG: [[$OM_B:#.*]] = #ttg.blocked<{sizePerThread = [1, 4], threadsPerWarp = [8, 4], warpsPerCTA = [1, 2], order = [1, 0]}>
+// CHECK-NOT: #ttg.amd_rotating_shared
+// CHECK-NOT: #ttg.linear
+// CHECK-LABEL: inThreadTranspose_fma_operand_major_neg
+// CHECK-DAG: tt.load {{.*}} : tensor<32x8x!tt.ptr<f32>, [[$OM_A]]>
+// CHECK-DAG: tt.load {{.*}} : tensor<8x32x!tt.ptr<f32>, [[$OM_B]]>
+// CHECK-NOT: amdg.in_thread_transpose
+
+#dot = #ttg.blocked<{sizePerThread = [4, 4], threadsPerWarp = [4, 8], warpsPerCTA = [2, 1], order = [1, 0]}>
+#blockedA = #ttg.blocked<{sizePerThread = [4, 1], threadsPerWarp = [8, 4], warpsPerCTA = [1, 2], order = [0, 1]}>
+#blockedB = #ttg.blocked<{sizePerThread = [1, 4], threadsPerWarp = [8, 4], warpsPerCTA = [1, 2], order = [1, 0]}>
+#sharedA = #ttg.swizzled_shared<{vec = 1, perPhase = 1, maxPhase = 1, order = [0, 1]}>
+#sharedB = #ttg.swizzled_shared<{vec = 1, perPhase = 1, maxPhase = 1, order = [1, 0]}>
+#smem = #ttg.shared_memory
+module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 2 : i32, ttg.target = "hip:gfx1201", "ttg.threads-per-warp" = 32 : i32} {
+  tt.func public @inThreadTranspose_fma_operand_major_neg(%argA: !tt.ptr<f32> {tt.divisibility = 16 : i32, tt.pointer_range = 32 : i32}, %argB: !tt.ptr<f32> {tt.divisibility = 16 : i32, tt.pointer_range = 32 : i32}) {
+    %cst = arith.constant dense<0.000000e+00> : tensor<32x32xf32, #dot>
+    %0 = tt.splat %argA : !tt.ptr<f32> -> tensor<32x8x!tt.ptr<f32>, #blockedA>
+    %1 = tt.splat %argB : !tt.ptr<f32> -> tensor<8x32x!tt.ptr<f32>, #blockedB>
+    %2 = tt.load %0 : tensor<32x8x!tt.ptr<f32>, #blockedA>
+    %3 = tt.load %1 : tensor<8x32x!tt.ptr<f32>, #blockedB>
+
+    %4 = ttg.local_alloc %2 : (tensor<32x8xf32, #blockedA>) -> !ttg.memdesc<32x8xf32, #sharedA, #smem>
+    %5 = ttg.local_load %4 : !ttg.memdesc<32x8xf32, #sharedA, #smem> -> tensor<32x8xf32, #ttg.dot_op<{opIdx = 0, parent = #dot}>>
+
+    %6 = ttg.local_alloc %3 : (tensor<8x32xf32, #blockedB>) -> !ttg.memdesc<8x32xf32, #sharedB, #smem>
+    %7 = ttg.local_load %6 : !ttg.memdesc<8x32xf32, #sharedB, #smem> -> tensor<8x32xf32, #ttg.dot_op<{opIdx = 1, parent = #dot}>>
+
+    %8 = tt.dot %5, %7, %cst : tensor<32x8xf32, #ttg.dot_op<{opIdx = 0, parent = #dot}>> * tensor<8x32xf32, #ttg.dot_op<{opIdx = 1, parent = #dot}>> -> tensor<32x32xf32, #dot>
+    tt.return
+  }
+}
+
+// -----
+// FMA path negative: the loads are K-contiguous (the orientation FMA can transpose),
+// but the K dim has only one element per thread, so there is no room to widen
+// the store. InThreadTranspose must bail out.
+// CHECK-NOT: #ttg.amd_rotating_shared
+// CHECK-NOT: #ttg.linear
+// CHECK-DAG: [[$SK_A:#.*]] = #ttg.blocked<{sizePerThread = [4, 1], threadsPerWarp = [4, 8], warpsPerCTA = [2, 1], order = [1, 0]}>
+// CHECK-DAG: [[$SK_B:#.*]] = #ttg.blocked<{sizePerThread = [1, 4], threadsPerWarp = [8, 4], warpsPerCTA = [1, 2], order = [0, 1]}>
+// CHECK-NOT: #ttg.amd_rotating_shared
+// CHECK-NOT: #ttg.linear
+// CHECK-LABEL: inThreadTranspose_fma_small_k_neg
+// CHECK-DAG: tt.load {{.*}} : tensor<32x8x!tt.ptr<f32>, [[$SK_A]]>
+// CHECK-DAG: tt.load {{.*}} : tensor<8x32x!tt.ptr<f32>, [[$SK_B]]>
+// CHECK-NOT: amdg.in_thread_transpose
+
+#dot = #ttg.blocked<{sizePerThread = [4, 4], threadsPerWarp = [4, 8], warpsPerCTA = [2, 1], order = [1, 0]}>
+#blockedA = #ttg.blocked<{sizePerThread = [4, 1], threadsPerWarp = [4, 8], warpsPerCTA = [2, 1], order = [1, 0]}>
+#blockedB = #ttg.blocked<{sizePerThread = [1, 4], threadsPerWarp = [8, 4], warpsPerCTA = [1, 2], order = [0, 1]}>
+#sharedA = #ttg.swizzled_shared<{vec = 1, perPhase = 1, maxPhase = 1, order = [1, 0]}>
+#sharedB = #ttg.swizzled_shared<{vec = 1, perPhase = 1, maxPhase = 1, order = [0, 1]}>
+#smem = #ttg.shared_memory
+module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 2 : i32, ttg.target = "hip:gfx1201", "ttg.threads-per-warp" = 32 : i32} {
+  tt.func public @inThreadTranspose_fma_small_k_neg(%argA: !tt.ptr<f32> {tt.divisibility = 16 : i32, tt.pointer_range = 32 : i32}, %argB: !tt.ptr<f32> {tt.divisibility = 16 : i32, tt.pointer_range = 32 : i32}) {
+    %cst = arith.constant dense<0.000000e+00> : tensor<32x32xf32, #dot>
+    %0 = tt.splat %argA : !tt.ptr<f32> -> tensor<32x8x!tt.ptr<f32>, #blockedA>
+    %1 = tt.splat %argB : !tt.ptr<f32> -> tensor<8x32x!tt.ptr<f32>, #blockedB>
+    %2 = tt.load %0 : tensor<32x8x!tt.ptr<f32>, #blockedA>
+    %3 = tt.load %1 : tensor<8x32x!tt.ptr<f32>, #blockedB>
+
+    %4 = ttg.local_alloc %2 : (tensor<32x8xf32, #blockedA>) -> !ttg.memdesc<32x8xf32, #sharedA, #smem>
+    %5 = ttg.local_load %4 : !ttg.memdesc<32x8xf32, #sharedA, #smem> -> tensor<32x8xf32, #ttg.dot_op<{opIdx = 0, parent = #dot}>>
+
+    %6 = ttg.local_alloc %3 : (tensor<8x32xf32, #blockedB>) -> !ttg.memdesc<8x32xf32, #sharedB, #smem>
+    %7 = ttg.local_load %6 : !ttg.memdesc<8x32xf32, #sharedB, #smem> -> tensor<8x32xf32, #ttg.dot_op<{opIdx = 1, parent = #dot}>>
+
+    %8 = tt.dot %5, %7, %cst : tensor<32x8xf32, #ttg.dot_op<{opIdx = 0, parent = #dot}>> * tensor<8x32xf32, #ttg.dot_op<{opIdx = 1, parent = #dot}>> -> tensor<32x32xf32, #dot>
+    tt.return
+  }
+}

--- a/test/TritonGPU/amd/in-thread-transpose.mlir
+++ b/test/TritonGPU/amd/in-thread-transpose.mlir
@@ -571,7 +571,7 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 2 : i32, ttg.targ
 }
 
 // -----
-// FMA path (f32 on gfx1201). The dot operand's parent encoding is #ttg.blocked
+// FMA path. The dot operand's parent encoding is #ttg.blocked
 // (FMA outer-product), not AMDMfma/AMDWmma. 
 // CHECK-DAG: [[$DOT:#.*]] = #ttg.blocked<{sizePerThread = [4, 4], threadsPerWarp = [4, 8], warpsPerCTA = [2, 1], order = [1, 0]}>
 // CHECK-DAG: [[$SHAREDA:#.*]] = #ttg.swizzled_shared<{vec = 1, perPhase = 1, maxPhase = 1, order = [0, 1]}>

--- a/third_party/amd/lib/TritonAMDGPUTransforms/InThreadTranspose.cpp
+++ b/third_party/amd/lib/TritonAMDGPUTransforms/InThreadTranspose.cpp
@@ -35,9 +35,6 @@ static Type replaceEncoding(Type type, Attribute encoding) {
                                tensorType.getElementType(), encoding);
 }
 
-// In the AMD backend, the only dot operand whose parent is a plain blocked
-// encoding is the FMA (outer-product) lowering; MFMA/WMMA use dedicated
-// encodings. So a blocked parent identifies the FMA path.
 static bool isFmaDotOperand(ttg::DotOperandEncodingAttr dotOperandEnc) {
   return isa<ttg::BlockedEncodingAttr>(dotOperandEnc.getParent());
 }

--- a/third_party/amd/lib/TritonAMDGPUTransforms/InThreadTranspose.cpp
+++ b/third_party/amd/lib/TritonAMDGPUTransforms/InThreadTranspose.cpp
@@ -35,6 +35,13 @@ static Type replaceEncoding(Type type, Attribute encoding) {
                                tensorType.getElementType(), encoding);
 }
 
+// In the AMD backend, the only dot operand whose parent is a plain blocked
+// encoding is the FMA (outer-product) lowering; MFMA/WMMA use dedicated
+// encodings. So a blocked parent identifies the FMA path.
+static bool isFmaDotOperand(ttg::DotOperandEncodingAttr dotOperandEnc) {
+  return isa<ttg::BlockedEncodingAttr>(dotOperandEnc.getParent());
+}
+
 /// Replace load encoding with given one.
 ///
 /// This functions converts load inputs to given one
@@ -110,15 +117,24 @@ Attribute createNewSharedEncoding(RankedTensorType operandType) {
   auto ctx = operandType.getContext();
   auto dotOperandEnc =
       cast<ttg::DotOperandEncodingAttr>(operandType.getEncoding());
+  bool isFMA = isFmaDotOperand(dotOperandEnc);
   auto cgaLayout = ttg::getCGALayout(dotOperandEnc);
   auto bitWidth = operandType.getElementTypeBitWidth();
   SmallVector<unsigned> order{1, 0};
   if (dotOperandEnc.getOpIdx() == 1)
     std::swap(order[0], order[1]);
+  // The order computed above is the matrix-core orientation (K-dim contiguous).
+  // FMA wants the operand-major dim (M for A, N for B) contiguous in LDS, which
+  // is the opposite orientation.
+  if (isFMA)
+    std::swap(order[0], order[1]);
 
   auto tempAttr = ttg::SwizzledSharedEncodingAttr::get(
       ctx, dotOperandEnc, operandType.getShape(), order, cgaLayout, bitWidth,
       /*needTrans=*/false);
+
+  if (isFMA)
+    return tempAttr;
 
   auto sharedVec = tempAttr.getVec();
   auto perPhase = tempAttr.getPerPhase();
@@ -590,10 +606,9 @@ matchInThreadTransposePattern(ttg::LocalLoadOp lLoad) {
     return failure();
 
   int kDimNum = opDotOpEnc.getOpIdx() == 0 ? 1 : 0;
-  // TODO: support wmma
-  if (!isa<ttg::AMDMfmaEncodingAttr, ttg::AMDWmmaEncodingAttr>(
-          opDotOpEnc.getParent())) {
-    LDBG("Operand's parent encoding is not MFMA");
+  if (!isa<ttg::AMDMfmaEncodingAttr, ttg::AMDWmmaEncodingAttr,
+           ttg::BlockedEncodingAttr>(opDotOpEnc.getParent())) {
+    LDBG("Operand's parent encoding is not MFMA/WMMA/Blocked");
     return failure();
   }
 
@@ -623,7 +638,14 @@ matchInThreadTransposePattern(ttg::LocalLoadOp lLoad) {
     if (!blockedEnc)
       return failure();
     auto order = blockedEnc.getOrder();
-    if (order[0] == kDimNum) {
+    bool isFMA = isFmaDotOperand(opDotOpEnc);
+    bool loadIsKContiguous = (order[0] == kDimNum);
+    // MFMA/WMMA need an operand-major global load to transpose into a
+    // K-contiguous LDS tile, so they bail when the load is already
+    // K-contiguous. FMA is the opposite: it needs a K-contiguous global load to
+    // transpose into an operand-major (M/N-contiguous) LDS tile, so it bails
+    // when the load is already operand-major.
+    if (isFMA ? !loadIsKContiguous : loadIsKContiguous) {
       return failure();
     }
     auto globalLoadSearch = findAllDefiningOps<tt::LoadOp>(loadCandidate);


### PR DESCRIPTION
InThreadTranspose only triggers if the kernel contains WMMA/MFMA instructions. But actually, InThreadTranspose can be very beneficial for kernels with no WMMA/MFMA too. On RDNA4 specifically I tested a few matmuls with f32 datatype (so FMA path is exercised):

| dtype | trA | trB | G | M | K | N | Speedup |
|---|---|---|---|---|---|---|---|
|     f32     |     F        |     T        |     2    |     64     |     400    |     400     |        2.1x     |
|     f32     |     F        |     T        |     1    |     100    |     100    |     19200  |        1.1x     |
|     f32     |     F        |     T        |     12  |     384    |     64     |     384     |        1.1x     |
|     f32     |     F        |     T        |     64  |     768    |     64     |     64      |        1.3x     |
|     f32     |     F        |     T        |     1    |     128    |     2048  |     1000    |        1.2x     |
|     f32     |     F        |     T        |     32  |     256    |     128    |     256     |        1.1x     |
|     f32     |     F        |     T        |     1    |     16     |     2048  |     1000    |        1.5x     |
|     f32     |     F        |     T        |     14  |     4200  |     64     |     14      |        1.2x     |
|     f32     |     F        |     T        |     1    |     64     |     2048  |     1000    |        1.5x     |
|     f32     |     F        |     T        |     1    |     32     |     2048  |     1000    |        1.2x     |

Speedup column represents the speed of this PR with respect to main branch, with an average speedup of 33%.

InThreadTranspose is quite generic already, and the implementation is very simple, we just need to tweak a few things:
1. Allow a `#blocked` dot operand in `matchInThreadTransposePattern`, which previously only accepted a parent op with WMMA/MFMA semantics
2. Matrix cores want a K contiguous LDS tile, so they bail when the global load is already K contiguous. But FMA is the exact opposite: it wants a M/N-contiguous tile from a K-contiguous load, so we add a check to identify it.
3. In `createNewSharedEncoding`, for FMA the LDS tile is operand-major (M-contiguous for A, N-contiguous for B), the opposite of the matrix-core K-contiguous order, so we swap the memory orientation.

The PR also 3 new cases to the existing `in-thread-transpose.mlir`