### PR TITLE
Disable GitHub cache for gfx90a CI

### DIFF
--- a/.github/workflows/integration-tests-amd.yml
+++ b/.github/workflows/integration-tests-amd.yml
@@ -75,6 +75,7 @@ jobs:
           echo "json=$(cat $json_file)" >> $GITHUB_OUTPUT
         shell: bash
       - name: Cache build dependencies
+        if: ${{ matrix.runner[0] != 'self-hosted' }}
         uses: actions/cache@v4
         with:
           # Note that we cannot use environment variables here given there is


### PR DESCRIPTION
Disable the GitHub dependency cache for the self-hosted gfx90a AMD integration job so its persistent host-local Triton cache is not uploaded into repository cache entries.