### PR TITLE
[FRONTEND] Fix atomic_min float result type (pointer -> value), matching atomic_max

### DIFF
--- a/python/triton/language/semantic.py
+++ b/python/triton/language/semantic.py
@@ -1368,7 +1368,7 @@ class TritonSemantic(Generic[TensorTy]):
                                            self.and_(mask, pos).handle, sem, scope), i_val.type)
         neg_ret = self.tensor(
             self.builder.create_atomic_rmw(ir.ATOMIC_OP.UMAX, ui_ptr.handle, ui_val.handle,
-                                           self.and_(mask, neg).handle, sem, scope), ui_ptr.type)
+                                           self.and_(mask, neg).handle, sem, scope), ui_val.type)
         ret = self.where(pos, pos_ret, neg_ret)
         return self.bitcast(ret, sca_ty)
 


### PR DESCRIPTION
### Problem

In `Semantic.atomic_min`, the float path splits into a signed-`MIN` branch for non-negative values and an unsigned-`UMAX` branch for negative values (the standard bit-trick for float atomics). The negative branch annotates the atomic-RMW result with **`ui_ptr.type`** — a *pointer* type:

```python
neg_ret = self.tensor(
    self.builder.create_atomic_rmw(ir.ATOMIC_OP.UMAX, ui_ptr.handle, ui_val.handle,
                                   self.and_(mask, neg).handle, sem, scope), ui_ptr.type)  # <- pointer type
```

But `create_atomic_rmw` returns the old **value**, not a pointer. The parallel code in `atomic_max` correctly uses the value type (`ui_val.type`):

```python
neg_ret = self.tensor(
    self.builder.create_atomic_rmw(ir.ATOMIC_OP.UMIN, ui_ptr.handle, ui_val.handle,
                                   self.and_(mask, neg).handle, sem, scope), ui_val.type)  # <- value type
```

So `atomic_min`'s `neg_ret` carries an inconsistent (pointer) type into the following `self.where(pos, pos_ret, neg_ret)` / `self.bitcast(ret, sca_ty)`, where `pos_ret` is value-typed.

### Fix

Use `ui_val.type` in `atomic_min`, matching `atomic_max`. One-line change; makes the two reductions consistent and gives `where()`/`bitcast` a correct value type.
