### PR TITLE
Parse ld.so.conf to find libcuda and libamdhip64

### DIFF
--- a/python/triton/_utils.py
+++ b/python/triton/_utils.py
@@ -1,6 +1,8 @@
 from __future__ import annotations
 
-from functools import reduce
+import glob
+import os
+from functools import lru_cache, reduce
 from typing import Any, Callable, TYPE_CHECKING, Union, List, Dict
 
 if TYPE_CHECKING:
@@ -155,3 +157,74 @@ def _tuple_create(arg, contents):
     # between them, but only NamedTuple has "_fields" and apparently this is how
     # everyone does the check.
     return type(arg)(*contents) if hasattr(arg, "_fields") else type(arg)(contents)
+
+
+def _parse_ld_so_conf(conf_path: str, depth: int = 0) -> list[str]:
+    """Parse an ld.so.conf file, resolving 'include' directives recursively.
+
+    Returns a list of library search directories, in the order they appear.
+    """
+    dirs: list[str] = []
+    if depth > 20:
+        return dirs
+
+    try:
+        with open(conf_path) as f:
+            for line in f:
+                line = line.strip()
+                # Skip empty lines and comments.
+                if not line or line.startswith("#"):
+                    continue
+                # Handle 'include <glob-pattern>' directives.
+                if line.startswith("include "):
+                    pattern = line.split(None, 1)[1]
+                    # Patterns may be relative to the directory containing the
+                    # conf file (typically /etc).
+                    if not os.path.isabs(pattern):
+                        pattern = os.path.join(os.path.dirname(conf_path), pattern)
+                    for included in sorted(glob.glob(pattern)):
+                        dirs.extend(_parse_ld_so_conf(included, depth + 1))
+                else:
+                    # The line is a directory path.
+                    if os.path.isdir(line):
+                        dirs.append(line)
+    except OSError:
+        pass
+    return dirs
+
+
+@lru_cache()
+def _ld_so_conf_library_dirs() -> tuple[str, ...]:
+    """Return the list of library directories from /etc/ld.so.conf plus defaults.
+
+    The dynamic linker always searches a set of default directories
+    (``/lib``, ``/usr/lib`` and their 64-bit variants) regardless of what is
+    listed in ``ld.so.conf``.
+    """
+    import struct
+
+    dirs = _parse_ld_so_conf("/etc/ld.so.conf")
+
+    # Default search paths that the dynamic linker uses unconditionally.
+    defaults = []
+    if struct.calcsize("P") == 8:
+        defaults.extend(["/lib64", "/usr/lib64"])
+    defaults.extend(["/lib", "/usr/lib"])
+    for d in defaults:
+        if os.path.isdir(d) and d not in dirs:
+            dirs.append(d)
+
+    return tuple(dirs)
+
+
+def find_library_dirs(lib_name: str) -> list[str]:
+    """Find directories containing *lib_name* using the ld.so.conf search paths."""
+    return [d for d in _ld_so_conf_library_dirs() if os.path.exists(os.path.join(d, lib_name))]
+
+
+def find_library(lib_name: str) -> list[str]:
+    """Find full paths to *lib_name* using the ld.so.conf search paths.
+
+    Returns a list of paths to matching library files.
+    """
+    return [os.path.join(d, lib_name) for d in find_library_dirs(lib_name)]

--- a/third_party/amd/backend/driver.py
+++ b/third_party/amd/backend/driver.py
@@ -4,6 +4,7 @@ import subprocess
 import triton
 from pathlib import Path
 from triton import knobs
+from triton._utils import find_library
 from triton.backends.compiler import GPUTarget
 from triton.backends.driver import GPUDriver, decompose_descriptor, expand_signature, wrap_handle_tensordesc_impl
 from triton.runtime import _allocation
@@ -142,12 +143,8 @@ def _get_path_to_hip_runtime_dylib():
             return rocm_lib_path
         paths.append(rocm_lib_path)
 
-    # Afterwards try to search the loader dynamic library resolution paths.
-    libs = subprocess.check_output(["/sbin/ldconfig", "-p"]).decode(errors="ignore")
-    # each line looks like the following:
-    # libamdhip64.so.6 (libc6,x86-64) => /opt/rocm-6.0.2/lib/libamdhip64.so.6
-    # libamdhip64.so (libc6,x86-64) => /opt/rocm-6.0.2/lib/libamdhip64.so
-    locs = [line.split()[-1] for line in libs.splitlines() if line.strip().endswith(lib_name)]
+    # Afterwards try to search the loader library resolution paths via ld.so.conf.
+    locs = find_library(lib_name)
     for loc in locs:
         if os.path.exists(loc):
             return loc

--- a/third_party/nvidia/backend/driver.py
+++ b/third_party/nvidia/backend/driver.py
@@ -1,10 +1,10 @@
 import functools
 import os
-import subprocess
 import triton
 import ctypes
 import sys
 from triton import knobs
+from triton._utils import find_library_dirs
 from triton.runtime.build import compile_module_from_file
 from triton.runtime import _allocation
 from triton.backends.compiler import GPUTarget
@@ -27,21 +27,17 @@ def libcuda_dirs():
     if env_libcuda_path := knobs.nvidia.libcuda_path:
         return [env_libcuda_path]
 
-    libs = subprocess.check_output(["/sbin/ldconfig", "-p"]).decode(errors="ignore")
-    # each line looks like the following:
-    # libcuda.so.1 (libc6,x86-64) => /lib/x86_64-linux-gnu/libcuda.so.1
-    locs = [line.split()[-1] for line in libs.splitlines() if "libcuda.so.1" in line]
-    dirs = [os.path.dirname(loc) for loc in locs]
+    dirs = find_library_dirs("libcuda.so.1")
     env_ld_library_path = os.getenv("LD_LIBRARY_PATH")
     if env_ld_library_path and not dirs:
         dirs = [dir for dir in env_ld_library_path.split(":") if os.path.exists(os.path.join(dir, "libcuda.so.1"))]
     msg = 'libcuda.so cannot found!\n'
-    if locs:
-        msg += 'Possible files are located at %s.' % str(locs)
-        msg += 'Please create a symlink of libcuda.so to any of the files.'
+    if dirs:
+        msg += 'libcuda.so.1 was found in directories: %s.' % str(dirs)
+        msg += 'Please create a libcuda.so symlink in one of the directories.'
     else:
-        msg += 'Please make sure GPU is set up and then run "/sbin/ldconfig"'
-        msg += ' (requires sudo) to refresh the linker cache.'
+        msg += 'Please make sure GPU is set up and the linker search paths'
+        msg += ' in /etc/ld.so.conf are up to date.'
     assert any(os.path.exists(os.path.join(path, 'libcuda.so.1')) for path in dirs), msg
     return dirs
 


### PR DESCRIPTION
I'm trying to use triton with free-threaded Python, and that's running into issues when triton calls `subprocess.run(["/sbin/ldconfig", "-p"])` to find libcuda.  This triggers a fork(), which is not safe to do when there are multiple threads in the process.  With regular Python, it ends up being fine because the GIL protects the interpreter's state, but it can cause crashes with free-threaded Python.

Switch this logic to parse the dynamic loader's config instead to find where libcuda is stored.  This is more agreeable with multithreaded usage. Update the logic for the AMD backend as well to be consistent.

<!---
The core Triton is a small number of people, and we receive many PRs (thank
you!).  To help us review your code more quickly, **if you are a new
contributor (less than 3 PRs merged) we ask that you complete the following
tasks and include the filled-out checklist in your PR description.**

Complete the following tasks before sending your PR, and replace `[ ]` with
`[x]` to indicate you have done them.
-->

# New contributor declaration
- [x] I am not making a trivial change, such as fixing a typo in a comment.

- [x] I have written a PR description following these
  [rules](https://cbea.ms/git-commit/#why-not-how).

- [x] I have run `pre-commit run --from-ref origin/main --to-ref HEAD`.

- Select one of the following.
  - [ ] I have added tests.
    - `/test` for `lit` tests
    - `/unittest` for C++ tests
    - `/python/test` for end-to-end tests
  - [x] This PR does not need a test because any existing AMD and NVIDIA tests should already exercise this code path.

- Select one of the following.
  - [x] I have not added any `lit` tests.
  - [ ] The `lit` tests I have added follow these [best practices](https://mlir.llvm.org/getting_started/TestingGuide/#filecheck-best-practices),
    including the "tests should be minimal" section. (Usually running Python code
    and using the instructions it generates is not minimal.)
