### PR TITLE
[kernels] Fix integer overflow in stride calculations

### DIFF
--- a/python/triton_kernels/tests/test_distributed.py
+++ b/python/triton_kernels/tests/test_distributed.py
@@ -6,7 +6,16 @@ import torch
 import torch.distributed as dist
 import torch.multiprocessing as mp
 import triton
-from triton_kernels.distributed import convert_dp_to_ep, convert_ep_to_dp, make_expt_dict_uniform, make_expt_dict_random, make_expt_assignment, SymmetricMemoryPool
+from triton_kernels.distributed import (
+    _convert_dp_to_ep,
+    _convert_ep_to_dp,
+    convert_dp_to_ep,
+    convert_ep_to_dp,
+    make_expt_dict_uniform,
+    make_expt_dict_random,
+    make_expt_assignment,
+    SymmetricMemoryPool,
+)
 from triton_kernels.distributed_details.mesh import Mesh
 from triton_kernels.reduce import reduce
 from triton_kernels.topk import topk
@@ -89,6 +98,76 @@ def distributed_launcher(request):
 
     launch.world_size = n_gpus
     return launch
+
+
+# ------------------------------------------------------------
+# conversion kernels
+# ------------------------------------------------------------
+
+
+@pytest.mark.parametrize("kernel", [_convert_dp_to_ep, _convert_ep_to_dp], ids=["dp_to_ep", "ep_to_dp"])
+@pytest.mark.parametrize("large_operand", ["src", "dst"])
+def test_convert_large_strides(kernel, large_operand, device):
+    n_rows = 5
+    # The final row is 2**32 elements from the base, which overflows an int32 offset calculation.
+    overflow_stride = 1 << 30
+    values = torch.arange(1, n_rows + 1, dtype=torch.uint8, device=device).reshape(n_rows, 1)
+    small = torch.empty_strided(values.shape, (2, 1), dtype=values.dtype, device=device)
+    small.copy_(values)
+
+    storage = torch.empty((n_rows - 1) * overflow_stride + 1, dtype=torch.uint8, device=device)
+    large = torch.as_strided(storage, values.shape, (overflow_stride, 1))
+    large.zero_()
+    if large_operand == "src":
+        large.copy_(values)
+        src = large
+        dst = torch.empty_strided(values.shape, (2, 1), dtype=values.dtype, device=device)
+    else:
+        src, dst = small, large
+
+    expt_filter = torch.ones((1, 1), dtype=torch.int32, device=device)
+    expt_indx = torch.zeros((n_rows, 1), dtype=torch.int32, device=device)
+    row_indx = torch.arange(n_rows, dtype=torch.int32, device=device).reshape(n_rows, 1)
+
+    if kernel is _convert_dp_to_ep:
+        kernel[(n_rows, )](
+            (dst, ),
+            dst.stride(0),
+            src,
+            src.stride(0),
+            src.shape[1],
+            expt_filter,
+            expt_filter.stride(0),
+            expt_indx,
+            expt_indx.stride(0),
+            row_indx,
+            row_indx.stride(0),
+            n_rows,
+            SRC_RANK=0,
+            N_EXPT_ACT=1,
+            N_RANKS=1,
+            BLOCK=1,
+            num_warps=1,
+        )
+    else:
+        kernel[(n_rows, )](
+            (dst, ),
+            dst.stride(0),
+            src,
+            src.stride(0),
+            src.shape[1],
+            expt_filter,
+            expt_filter.stride(0),
+            expt_indx,
+            row_indx,
+            n_rows,
+            BLOCK=1,
+            SRC_RANK=0,
+            N_RANKS=1,
+            num_warps=1,
+        )
+
+    assert torch.equal(dst, values)
 
 
 # ------------------------------------------------------------

--- a/python/triton_kernels/triton_kernels/distributed.py
+++ b/python/triton_kernels/triton_kernels/distributed.py
@@ -162,9 +162,9 @@ def _convert_dp_to_ep(
         dst_row_ptrs = tl.where(dst_rank == expt_ranks, peer_dst_ptr, dst_row_ptrs)
     dst_row_ptrs = dst_row_ptrs.to(src_ptr.dtype, bitcast=True)
     dst_row_ptrs = tl.multiple_of(dst_row_ptrs, 16)
-    dst_row_ptrs = dst_row_ptrs + dst_row_indx * dst_stride_m
+    dst_row_ptrs = dst_row_ptrs + dst_row_indx * dst_stride_m.to(tl.int64)
     dst_ptrs = dst_row_ptrs[:, None] + offs_n[None, :]
-    src_ptrs = src_ptr + off_m_local * src_stride_m + offs_n
+    src_ptrs = src_ptr + off_m_local * src_stride_m.to(tl.int64) + offs_n
     for start_n in range(0, src_shape_n, BLOCK):
         mask_n = start_n + offs_n < src_shape_n
         src = tl.load(src_ptrs, mask=mask_n, other=0.0)
@@ -241,10 +241,10 @@ def _convert_ep_to_dp(
     has_dst_expt = (tl.load(expt_filter_ptr + dst_expt_indx // 32) >> (dst_expt_indx % 32)) & 1
     if not has_dst_expt.to(tl.int1):
         return
-    dst_indx_local = dst_indx_global - dst_rank * n_tokens_local
+    dst_indx_local = dst_indx_global - dst_rank * n_tokens_local.to(tl.int64)
     offs_n = tl.arange(0, BLOCK)
-    dst_ptrs = dst_ptr + dst_indx_local * dst_stride_m + offs_n
-    src_ptrs = src_ptr + pid_m * src_stride_m + offs_n
+    dst_ptrs = dst_ptr + dst_indx_local * dst_stride_m.to(tl.int64) + offs_n
+    src_ptrs = src_ptr + pid_m * src_stride_m.to(tl.int64) + offs_n
     for start_n in range(0, src_shape_n, BLOCK):
         mask_n = start_n + offs_n < src_shape_n
         src = tl.load(src_ptrs, mask=mask_n, other=0.0)


### PR DESCRIPTION
I've found that the dp <-> ep conversion kernels can overflow for large inputs.