### PR TITLE
Fix GSan reserve size comment

### DIFF
--- a/python/triton/experimental/gsan/src/GSan.h
+++ b/python/triton/experimental/gsan/src/GSan.h
@@ -19,7 +19,7 @@ using uint16_t = __UINT16_TYPE__;
 using uint32_t = __UINT32_TYPE__;
 using uintptr_t = __UINTPTR_TYPE__;
 
-// Reserve 1 PiB, should be big enough for a while :)
+// Reserve 1 TiB, should be big enough for a while :)
 static constexpr size_t kReserveSize = 1ull << 40;
 static constexpr int kShadowMemGranularityBytes = 4;
 static_assert((kReserveSize & (kReserveSize - 1)) == 0,


### PR DESCRIPTION
## Summary
- Update the GSan reserve size comment from 1 PiB to 1 TiB to match `1ull << 40`.

Fixes #10079.

## Testing
- `git diff --check`

This is a comment-only documentation correction.