### PR TITLE
[FPSan] Canonicalize GEPs before NVPTX codegen

### DIFF
--- a/python/src/llvm.cc
+++ b/python/src/llvm.cc
@@ -4,6 +4,7 @@
 #include "triton/Tools/Sys/GetEnv.h"
 #include "llvm/ADT/SmallVector.h"
 #include "llvm/Analysis/ScopedNoAliasAA.h"
+#include "llvm/Analysis/TargetTransformInfo.h"
 #include "llvm/CodeGen/MIRParser/MIRParser.h"
 #include "llvm/CodeGen/MachineModuleInfo.h"
 #include "llvm/CodeGen/MachineRegisterInfo.h"
@@ -31,6 +32,7 @@
 #include "llvm/Transforms/InstCombine/InstCombine.h"
 #include "llvm/Transforms/Instrumentation/AddressSanitizer.h"
 #include "llvm/Transforms/Instrumentation/AddressSanitizerOptions.h"
+#include "llvm/Transforms/Scalar.h"
 #include <csignal>
 #include <cstdio>
 #include <memory>
@@ -325,12 +327,10 @@ translateLLVMIRToMIR(llvm::Module &module, const std::string &triple,
   return result;
 }
 
-std::string translateLLVMIRToASM(llvm::Module &module,
-                                 const std::string &triple,
-                                 const std::string &proc,
-                                 const std::string &features,
-                                 const std::vector<std::string> &flags,
-                                 bool enable_fp_fusion, bool isObject) {
+std::string translateLLVMIRToASM(
+    llvm::Module &module, const std::string &triple, const std::string &proc,
+    const std::string &features, const std::vector<std::string> &flags,
+    bool enable_fp_fusion, bool isObject, bool canonicalizeGEP) {
   using namespace mlir;
 
   // Apply flags
@@ -386,6 +386,16 @@ std::string translateLLVMIRToASM(llvm::Module &module,
   auto machine = createTargetMachine(&module, proc, enable_fp_fusion, features);
   // set data layout
   module.setDataLayout(machine->createDataLayout());
+  if (canonicalizeGEP && !disableLLVMOpt) {
+    // The NVPTX pipeline otherwise exposes many equivalent GEPs to SLSR
+    // without eliminating them first.
+    llvm::legacy::PassManager cleanup;
+    cleanup.add(llvm::createTargetTransformInfoWrapperPass(
+        machine->getTargetIRAnalysis()));
+    cleanup.add(llvm::createSeparateConstOffsetFromGEPPass());
+    cleanup.add(llvm::createEarlyCSEPass());
+    cleanup.run(module);
+  }
   // emit machine code
   std::string result;
   {
@@ -773,7 +783,8 @@ void init_triton_llvm(py::module &&m) {
       "translate_to_asm",
       [](std::string llvmIR, std::string triple, std::string proc,
          std::string features, std::vector<std::string> flags,
-         bool enable_fp_fusion, bool isObject) -> py::object {
+         bool enable_fp_fusion, bool isObject,
+         bool canonicalizeGEP) -> py::object {
         std::string obj;
         {
           // when allow_threads goes out of scope, gil will be released
@@ -790,8 +801,9 @@ void init_triton_llvm(py::module &&m) {
                 "failed to parse IR: " + error.getMessage() +
                 "lineno: " + std::to_string(error.getLineNo()));
           }
-          obj = translateLLVMIRToASM(*module, triple, proc, features, flags,
-                                     enable_fp_fusion, isObject);
+          obj =
+              translateLLVMIRToASM(*module, triple, proc, features, flags,
+                                   enable_fp_fusion, isObject, canonicalizeGEP);
         }
         if (isObject)
           return py::bytes(obj);

--- a/third_party/amd/backend/compiler.py
+++ b/third_party/amd/backend/compiler.py
@@ -560,7 +560,7 @@ class HIPBackend(BaseBackend):
                                                options.enable_fp_fusion, False, knobs.amd.swap_mir_enable_misched)
         else:
             amdgcn = llvm.translate_to_asm(src, amd.TARGET_TRIPLE, options.arch, features, flags,
-                                           options.enable_fp_fusion, False)
+                                           options.enable_fp_fusion, False, False)
         if knobs.amd.dump_amdgcn:
             print("// -----// AMDGCN Dump //----- //")
             print(amdgcn)

--- a/third_party/nvidia/backend/compiler.py
+++ b/third_party/nvidia/backend/compiler.py
@@ -470,7 +470,8 @@ class CUDABackend(BaseBackend):
         proc = sm_arch_from_capability(capability)
         features = get_features(opt, self.target.arch)
         flags = ["nvptx-mad-wide-opt"]
-        ret = llvm.translate_to_asm(src, triple, proc, features, flags, opt.enable_fp_fusion, False)
+        canonicalize_gep = "fpsan" in opt.instrumentation_mode
+        ret = llvm.translate_to_asm(src, triple, proc, features, flags, opt.enable_fp_fusion, False, canonicalize_gep)
         # Find kernel names (there should only be one)
         names = re.findall(r".visible .entry ([a-zA-Z_][a-zA-Z0-9_]*)", ret)
         assert len(names) == 1


### PR DESCRIPTION
NVPTX backend is blowing up for some FPSAN code. The address arithmetic for global scratch loads and stores is causing SLSR which tries to simplify address arithmetic to blow. The pass doesn't actually do much simplification but the analysis is blowing up. Run GEP canonicalizer before to reduce IR size. I didn't enable this broadly because it wasn't a compile time win (probably most code does not have as much address arithmetic).

In particular, this speeds up compiling `01-attention-forward.py` under FPSAN from 200 seconds to 11 seconds