### PR TITLE
[FRONTEND] Make JIT dependency cache keys deterministic

### DIFF
--- a/python/test/unit/runtime/test_cache.py
+++ b/python/test/unit/runtime/test_cache.py
@@ -160,6 +160,68 @@ def test_nested2_change():
     assert baseline != updated
 
 
+ORDER_DEPENDENT_CONSTEXPR = tl.constexpr(42)
+
+
+@triton.jit
+def order_dependent_inner():
+    return ORDER_DEPENDENT_CONSTEXPR
+
+
+@triton.jit
+def order_dependent_outer():
+    order_dependent_inner()
+
+
+def test_cache_key_independent_of_dependency_hash_order():
+    functions = (order_dependent_inner, order_dependent_outer)
+
+    for function in functions:
+        function.hash = None
+        function.used_global_vals = {}
+    cold_key = order_dependent_outer.cache_key
+
+    for function in functions:
+        function.hash = None
+        function.used_global_vals = {}
+    order_dependent_inner.cache_key
+    prehashed_key = order_dependent_outer.cache_key
+
+    assert prehashed_key == cold_key
+
+
+def test_cache_key_independent_of_globals_dict_identity():
+
+    def make_child(value):
+        shared = tl.constexpr(value)
+
+        @triton.jit
+        def child():
+            return shared
+
+        return child
+
+    child_a = make_child(1)
+    child_b = make_child(2)
+
+    @triton.jit
+    def parent():
+        child_a()
+        child_b()
+
+    functions = (child_a, child_b, parent)
+
+    def key_after_prehashing(first, second):
+        for function in functions:
+            function.hash = None
+            function.used_global_vals = {}
+        first.cache_key
+        second.cache_key
+        return parent.cache_key
+
+    assert key_after_prehashing(child_a, child_b) == key_after_prehashing(child_b, child_a)
+
+
 def test_combine_fn_change():
     # Test that tl.reduce and associative_scan calls include
     # the combine_fn in the hash

--- a/python/test/unit/runtime/test_cache_determinism.py
+++ b/python/test/unit/runtime/test_cache_determinism.py
@@ -1,0 +1,127 @@
+import concurrent.futures
+import os
+import random
+import subprocess
+import sys
+
+import triton
+import triton.language as tl
+
+
+def make_child(value):
+    shared = tl.constexpr(value)
+
+    @triton.jit
+    def child():
+        return shared
+
+    return child
+
+
+identity_child_a = make_child(1)
+identity_child_b = make_child(2)
+
+
+@triton.jit
+def identity_parent():
+    identity_child_a()
+    identity_child_b()
+
+
+stress_children = [make_child(value) for value in range(16)]
+(
+    stress_child_00,
+    stress_child_01,
+    stress_child_02,
+    stress_child_03,
+    stress_child_04,
+    stress_child_05,
+    stress_child_06,
+    stress_child_07,
+    stress_child_08,
+    stress_child_09,
+    stress_child_10,
+    stress_child_11,
+    stress_child_12,
+    stress_child_13,
+    stress_child_14,
+    stress_child_15,
+) = stress_children
+
+
+@triton.jit
+def stress_parent():
+    stress_child_00()
+    stress_child_01()
+    stress_child_02()
+    stress_child_03()
+    stress_child_04()
+    stress_child_05()
+    stress_child_06()
+    stress_child_07()
+    stress_child_08()
+    stress_child_09()
+    stress_child_10()
+    stress_child_11()
+    stress_child_12()
+    stress_child_13()
+    stress_child_14()
+    stress_child_15()
+
+
+def _subprocess_key(mode, seed, order="forward"):
+    env = os.environ.copy()
+    env["PYTHONHASHSEED"] = str(seed)
+    env["TRITON_CACHE_KEY_TEST_ORDER"] = order
+    env["TRITON_CACHE_KEY_TEST_SEED"] = str(seed)
+    result = subprocess.run(
+        [sys.executable, __file__, mode],
+        check=True,
+        capture_output=True,
+        env=env,
+        text=True,
+        timeout=30,
+    )
+    return result.stdout.strip()
+
+
+def test_cache_key_deterministic_across_process_global_identities():
+    cases = [(seed, order) for seed in range(4) for order in ("forward", "reverse")]
+    with concurrent.futures.ThreadPoolExecutor(max_workers=len(cases)) as executor:
+        keys = list(executor.map(lambda case: _subprocess_key("identity", *case), cases))
+
+    assert len(set(keys)) == 1
+
+
+def test_cache_key_deterministic_under_concurrent_dependency_hashing():
+    with concurrent.futures.ThreadPoolExecutor(max_workers=8) as executor:
+        keys = list(executor.map(lambda seed: _subprocess_key("stress", seed), range(16)))
+
+    assert len(set(keys)) == 1
+
+
+def _run_identity_case():
+    children = [identity_child_a, identity_child_b]
+    if os.environ["TRITON_CACHE_KEY_TEST_ORDER"] == "reverse":
+        children.reverse()
+    for child in children:
+        child.cache_key
+    print(identity_parent.cache_key)
+
+
+def _run_stress_case():
+    functions = [stress_parent, *stress_children]
+    random.Random(int(os.environ["TRITON_CACHE_KEY_TEST_SEED"])).shuffle(functions)
+    with concurrent.futures.ThreadPoolExecutor(max_workers=8) as executor:
+        list(executor.map(lambda function: function.cache_key, functions))
+    print(stress_parent.cache_key)
+
+
+if __name__ == "__main__":
+    mode = sys.argv[1]
+    if mode == "identity":
+        _run_identity_case()
+    elif mode == "stress":
+        _run_stress_case()
+    else:
+        raise ValueError(f"unknown mode: {mode}")

--- a/python/triton/runtime/jit.py
+++ b/python/triton/runtime/jit.py
@@ -525,7 +525,8 @@ class JITCallable:
             self.used_global_vals = dict(sorted(dependencies_finder.used_global_vals.items()))
 
             from triton.language.core import constexpr
-            constexpr_globals = [(name, val) for (name, _), (val, _) in self.used_global_vals.items()
+            constexpr_globals = [(name, val)
+                                 for (name, _), (val, _) in self.used_global_vals.items()
                                  if isinstance(val, constexpr)]
             constexpr_globals.sort(key=lambda item: (item[0], repr(item[1])))
             self.hash += str(constexpr_globals)

--- a/python/triton/runtime/jit.py
+++ b/python/triton/runtime/jit.py
@@ -97,6 +97,7 @@ class DependenciesFinder(ast.NodeVisitor):
 
     def _update_hash(self, func):
         assert isinstance(func, JITCallable)
+        func_key = func.cache_key
         # Merge our used_global_vals with those of the called function,
         # after checking that all overlapping values are consistent.
         for k in self.used_global_vals.keys() & func.used_global_vals.keys():
@@ -109,7 +110,6 @@ class DependenciesFinder(ast.NodeVisitor):
                 )
         self.used_global_vals.update(func.used_global_vals)
         # update hash
-        func_key = func.cache_key
         func_key += str(getattr(func, "noinline", False))
         self.hasher.update(func_key.encode("utf-8"))
 
@@ -525,9 +525,10 @@ class JITCallable:
             self.used_global_vals = dict(sorted(dependencies_finder.used_global_vals.items()))
 
             from triton.language.core import constexpr
-            self.hash += str([(name, val)
-                              for (name, _), (val, _) in self.used_global_vals.items()
-                              if isinstance(val, constexpr)])
+            constexpr_globals = [(name, val) for (name, _), (val, _) in self.used_global_vals.items()
+                                 if isinstance(val, constexpr)]
+            constexpr_globals.sort(key=lambda item: (item[0], repr(item[1])))
+            self.hash += str(constexpr_globals)
             self.hash = hashlib.sha256(self.hash.encode("utf-8")).hexdigest()
         return self.hash
 


### PR DESCRIPTION
PR description written by Codex

Make transitive JIT dependency hashing independent of prehash order and process-local globals dictionary identities.

Add CPU-only subprocess regressions for cross-process and concurrent dependency hashing.