### PR TITLE
[AMD] BuiltinFuncToLLVM: use Normal region simplification level

### DIFF
--- a/third_party/amd/lib/TritonAMDGPUToLLVM/BuiltinFuncToLLVM.cpp
+++ b/third_party/amd/lib/TritonAMDGPUToLLVM/BuiltinFuncToLLVM.cpp
@@ -203,7 +203,7 @@ struct ConvertBuiltinFuncToLLVM
     ModuleOp mod = getOperation();
 
     GreedyRewriteConfig config;
-    config.setRegionSimplificationLevel(GreedySimplifyRegionLevel::Aggressive);
+    config.setRegionSimplificationLevel(GreedySimplifyRegionLevel::Normal);
 
     AMD::TargetInfo targetInfo(this->gfxArch.getValue());
     RewritePatternSet patterns(context);


### PR DESCRIPTION
## Motivation

Fix compile-time regression (>8 minutes for a small triton kernel), #10465.

## Summary

`BuiltinFuncToLLVM` runs `applyPatternsGreedily` with
`GreedySimplifyRegionLevel::Aggressive`, which calls
`simplifyRegions(mergeBlocks=true)` after every rewrite iteration.

With the LLVM bump in #9746, `mergeBlocks` 
- produces basic blocks with 32,000 block arguments
- does not converge and thus runs 10 iterations (its limit)
leading to >8 minutes compile-time for a small kernel.


**Fix:** downgrade to `Normal`, which runs dead-argument elimination but
not block merging.
This was previously set to `Aggressive` by #4631, after it was initially set to
`Normal` in #4176 to avoid a compile-time regression. fyi @joviliast @giuseros 
https://github.com/ROCm/triton-internal/issues/179#issuecomment-2315597200 has more history.

## Testing

Reproducer: See #10465

| build | `make_llir` |
|-------|-------------|
| `upstream/main` unpatched | **>120s (timeout)** |
| this PR | **0.13s** |
