### PR TITLE
[AMD] Rebalance FMA blocked layout on RDNA3/4

### DIFF
--- a/test/TritonGPU/amd/accelerate-amd-matmul-fma-rdna.mlir
+++ b/test/TritonGPU/amd/accelerate-amd-matmul-fma-rdna.mlir
@@ -1,0 +1,125 @@
+// RUN: triton-opt %s -split-input-file --tritonamdgpu-accelerate-matmul="gfx-arch=gfx1100 matrix-instruction-size=0" --verify-diagnostics | FileCheck %s
+
+// An f32 dot is not supported by WMMA, so it stays blocked and is lowered via
+// the FMA path. RebalanceBlockedFMA rewrites the layout
+// (here threadsPerWarp = [32, 1], i.e. all 32 lanes along M) into a balanced
+// one (threadsPerWarp = [2, 16]) to reduce the LDS read volume.
+
+// CHECK-DAG: #[[ORIG1:.+]] = #ttg.blocked<{sizePerThread = [1, 1], threadsPerWarp = [32, 1], warpsPerCTA = [4, 1], order = [1, 0]}>
+// CHECK-DAG: #[[BAL1:.+]] = #ttg.blocked<{sizePerThread = [1, 1], threadsPerWarp = [2, 16], warpsPerCTA = [4, 1], order = [1, 0]}>
+#blocked = #ttg.blocked<{sizePerThread = [1, 1], threadsPerWarp = [32, 1], warpsPerCTA = [4, 1], order = [1, 0]}>
+module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, "ttg.threads-per-warp" = 32 : i32} {
+  // CHECK: rebalance_layout_fma_dot_f32(
+  tt.func public @rebalance_layout_fma_dot_f32(
+      %arg0: tensor<128x64xf32, #ttg.dot_op<{opIdx = 0, parent = #blocked}>>,
+      %arg1: tensor<64x128xf32, #ttg.dot_op<{opIdx = 1, parent = #blocked}>>,
+      %arg2: tensor<128x128x!tt.ptr<f32>, #blocked>) {
+    %cst = arith.constant dense<0.000000e+00> : tensor<128x128xf32, #blocked>
+    // CHECK-DAG: %[[A:.+]] = ttg.convert_layout {{.*}} -> tensor<128x64xf32, #ttg.dot_op<{opIdx = 0, parent = #[[BAL1]]}>>
+    // CHECK-DAG: %[[B:.+]] = ttg.convert_layout {{.*}} -> tensor<64x128xf32, #ttg.dot_op<{opIdx = 1, parent = #[[BAL1]]}>>
+    // CHECK-DAG: %[[C:.+]] = ttg.convert_layout {{.*}} -> tensor<128x128xf32, #[[BAL1]]>
+    // CHECK: %[[D:.+]] = tt.dot %[[A]], %[[B]], %[[C]]{{.*}} -> tensor<128x128xf32, #[[BAL1]]>
+    // expected-remark @+1 {{Attempting to map dot operation to FMA intrinsic.}}
+    %0 = tt.dot %arg0, %arg1, %cst : tensor<128x64xf32, #ttg.dot_op<{opIdx = 0, parent = #blocked}>> * tensor<64x128xf32, #ttg.dot_op<{opIdx = 1, parent = #blocked}>> -> tensor<128x128xf32, #blocked>
+    // CHECK: ttg.convert_layout %[[D]]{{.*}} -> tensor<128x128xf32, #[[ORIG1]]>
+    tt.store %arg2, %0 : tensor<128x128x!tt.ptr<f32>, #blocked>
+    tt.return
+  }
+}
+
+// -----
+
+// CHECK-DAG: #[[BAL2:.+]] = #ttg.blocked<{sizePerThread = [1, 1], threadsPerWarp = [2, 16], warpsPerCTA = [4, 1], order = [1, 0]}>
+#blocked = #ttg.blocked<{sizePerThread = [1, 1], threadsPerWarp = [2, 16], warpsPerCTA = [4, 1], order = [1, 0]}>
+module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, "ttg.threads-per-warp" = 32 : i32} {
+  // CHECK: already_balanced_layout_fma_dot_f32(
+  tt.func public @already_balanced_layout_fma_dot_f32(
+      %arg0: tensor<128x64xf32, #ttg.dot_op<{opIdx = 0, parent = #blocked}>>,
+      %arg1: tensor<64x128xf32, #ttg.dot_op<{opIdx = 1, parent = #blocked}>>,
+      %arg2: tensor<128x128x!tt.ptr<f32>, #blocked>) {
+    %cst = arith.constant dense<0.000000e+00> : tensor<128x128xf32, #blocked>
+    // CHECK-NOT: ttg.convert_layout
+    // CHECK: %{{.*}} = tt.dot {{.*}} -> tensor<128x128xf32, #[[BAL2]]>
+    // expected-remark @+1 {{Attempting to map dot operation to FMA intrinsic.}}
+    %0 = tt.dot %arg0, %arg1, %cst : tensor<128x64xf32, #ttg.dot_op<{opIdx = 0, parent = #blocked}>> * tensor<64x128xf32, #ttg.dot_op<{opIdx = 1, parent = #blocked}>> -> tensor<128x128xf32, #blocked>
+    // CHECK-NOT: ttg.convert_layout
+    tt.store %arg2, %0 : tensor<128x128x!tt.ptr<f32>, #blocked>
+    tt.return
+  }
+}
+
+// -----
+
+// CHECK-DAG: #[[ORIG3:.+]] = #ttg.blocked<{sizePerThread = [1, 1], threadsPerWarp = [16, 2], warpsPerCTA = [4, 1], order = [1, 0]}>
+// CHECK-DAG: #[[BAL3:.+]] = #ttg.blocked<{sizePerThread = [1, 1], threadsPerWarp = [1, 32], warpsPerCTA = [4, 1], order = [1, 0]}>
+#blocked = #ttg.blocked<{sizePerThread = [1, 1], threadsPerWarp = [16, 2], warpsPerCTA = [4, 1], order = [1, 0]}>
+module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, "ttg.threads-per-warp" = 32 : i32} {
+  // CHECK: rebalance_layout_fma_dot_f32_non_square(
+  tt.func public @rebalance_layout_fma_dot_f32_non_square(
+      %arg0: tensor<64x64xf32, #ttg.dot_op<{opIdx = 0, parent = #blocked}>>,
+      %arg1: tensor<64x256xf32, #ttg.dot_op<{opIdx = 1, parent = #blocked}>>,
+      %arg2: tensor<64x256x!tt.ptr<f32>, #blocked>) {
+    %cst = arith.constant dense<0.000000e+00> : tensor<64x256xf32, #blocked>
+    // CHECK-DAG: %[[A:.+]] = ttg.convert_layout {{.*}} -> tensor<64x64xf32, #ttg.dot_op<{opIdx = 0, parent = #[[BAL3]]}>>
+    // CHECK-DAG: %[[B:.+]] = ttg.convert_layout {{.*}} -> tensor<64x256xf32, #ttg.dot_op<{opIdx = 1, parent = #[[BAL3]]}>>
+    // CHECK-DAG: %[[C:.+]] = ttg.convert_layout {{.*}} -> tensor<64x256xf32, #[[BAL3]]>
+    // CHECK: %[[D:.+]] = tt.dot %[[A]], %[[B]], %[[C]]{{.*}} -> tensor<64x256xf32, #[[BAL3]]>
+    // expected-remark @+1 {{Attempting to map dot operation to FMA intrinsic.}}
+    %0 = tt.dot %arg0, %arg1, %cst : tensor<64x64xf32, #ttg.dot_op<{opIdx = 0, parent = #blocked}>> * tensor<64x256xf32, #ttg.dot_op<{opIdx = 1, parent = #blocked}>> -> tensor<64x256xf32, #blocked>
+    // CHECK: ttg.convert_layout %[[D]]{{.*}} -> tensor<64x256xf32, #[[ORIG3]]>
+    tt.store %arg2, %0 : tensor<64x256x!tt.ptr<f32>, #blocked>
+    tt.return
+  }
+}
+
+// -----
+
+// CHECK-DAG: #[[ORIG4:.+]] = #ttg.blocked<{sizePerThread = [4, 4], threadsPerWarp = [4, 8], warpsPerCTA = [4, 1], order = [1, 0]}>
+// CHECK-DAG: #[[BAL4:.+]] = #ttg.blocked<{sizePerThread = [4, 4], threadsPerWarp = [2, 16], warpsPerCTA = [4, 1], order = [1, 0]}>
+#blocked = #ttg.blocked<{sizePerThread = [4, 4], threadsPerWarp = [4, 8], warpsPerCTA = [4, 1], order = [1, 0]}>
+module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, "ttg.threads-per-warp" = 32 : i32} {
+  // CHECK: rebalance_layout_fma_dot_f32_size_per_thread(
+  tt.func public @rebalance_layout_fma_dot_f32_size_per_thread(
+      %arg0: tensor<128x64xf32, #ttg.dot_op<{opIdx = 0, parent = #blocked}>>,
+      %arg1: tensor<64x128xf32, #ttg.dot_op<{opIdx = 1, parent = #blocked}>>,
+      %arg2: tensor<128x128x!tt.ptr<f32>, #blocked>) {
+    %cst = arith.constant dense<0.000000e+00> : tensor<128x128xf32, #blocked>
+    // CHECK-DAG: %[[A:.+]] = ttg.convert_layout {{.*}} -> tensor<128x64xf32, #ttg.dot_op<{opIdx = 0, parent = #[[BAL4]]}>>
+    // CHECK-DAG: %[[B:.+]] = ttg.convert_layout {{.*}} -> tensor<64x128xf32, #ttg.dot_op<{opIdx = 1, parent = #[[BAL4]]}>>
+    // CHECK-DAG: %[[C:.+]] = ttg.convert_layout {{.*}} -> tensor<128x128xf32, #[[BAL4]]>
+    // CHECK: %[[D:.+]] = tt.dot %[[A]], %[[B]], %[[C]]{{.*}} -> tensor<128x128xf32, #[[BAL4]]>
+    // expected-remark @+1 {{Attempting to map dot operation to FMA intrinsic.}}
+    %0 = tt.dot %arg0, %arg1, %cst : tensor<128x64xf32, #ttg.dot_op<{opIdx = 0, parent = #blocked}>> * tensor<64x128xf32, #ttg.dot_op<{opIdx = 1, parent = #blocked}>> -> tensor<128x128xf32, #blocked>
+    // CHECK: ttg.convert_layout %[[D]]{{.*}} -> tensor<128x128xf32, #[[ORIG4]]>
+    tt.store %arg2, %0 : tensor<128x128x!tt.ptr<f32>, #blocked>
+    tt.return
+  }
+}
+
+// -----
+
+// Same layout as the first test, but with order = [0, 1] instead of
+// [1, 0]. Here M (dim 0) is the contiguous/fastest dimension, so the heuristic
+// must take that into account and produce the exact transpose of the order = [1, 0].
+
+// CHECK-DAG: #[[ORIG5:.+]] = #ttg.blocked<{sizePerThread = [1, 1], threadsPerWarp = [32, 1], warpsPerCTA = [4, 1], order = [0, 1]}>
+// CHECK-DAG: #[[BAL5:.+]] = #ttg.blocked<{sizePerThread = [1, 1], threadsPerWarp = [16, 2], warpsPerCTA = [1, 4], order = [0, 1]}>
+#blocked = #ttg.blocked<{sizePerThread = [1, 1], threadsPerWarp = [32, 1], warpsPerCTA = [4, 1], order = [0, 1]}>
+module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, "ttg.threads-per-warp" = 32 : i32} {
+  // CHECK: rebalance_layout_fma_dot_f32_transposed_order(
+  tt.func public @rebalance_layout_fma_dot_f32_transposed_order(
+      %arg0: tensor<128x64xf32, #ttg.dot_op<{opIdx = 0, parent = #blocked}>>,
+      %arg1: tensor<64x128xf32, #ttg.dot_op<{opIdx = 1, parent = #blocked}>>,
+      %arg2: tensor<128x128x!tt.ptr<f32>, #blocked>) {
+    %cst = arith.constant dense<0.000000e+00> : tensor<128x128xf32, #blocked>
+    // CHECK-DAG: %[[A:.+]] = ttg.convert_layout {{.*}} -> tensor<128x64xf32, #ttg.dot_op<{opIdx = 0, parent = #[[BAL5]]}>>
+    // CHECK-DAG: %[[B:.+]] = ttg.convert_layout {{.*}} -> tensor<64x128xf32, #ttg.dot_op<{opIdx = 1, parent = #[[BAL5]]}>>
+    // CHECK-DAG: %[[C:.+]] = ttg.convert_layout {{.*}} -> tensor<128x128xf32, #[[BAL5]]>
+    // CHECK: %[[D:.+]] = tt.dot %[[A]], %[[B]], %[[C]]{{.*}} -> tensor<128x128xf32, #[[BAL5]]>
+    // expected-remark @+1 {{Attempting to map dot operation to FMA intrinsic.}}
+    %0 = tt.dot %arg0, %arg1, %cst : tensor<128x64xf32, #ttg.dot_op<{opIdx = 0, parent = #blocked}>> * tensor<64x128xf32, #ttg.dot_op<{opIdx = 1, parent = #blocked}>> -> tensor<128x128xf32, #blocked>
+    // CHECK: ttg.convert_layout %[[D]]{{.*}} -> tensor<128x128xf32, #[[ORIG5]]>
+    tt.store %arg2, %0 : tensor<128x128x!tt.ptr<f32>, #blocked>
+    tt.return
+  }
+}

--- a/third_party/amd/lib/TritonAMDGPUTransforms/AccelerateAMDMatmul.cpp
+++ b/third_party/amd/lib/TritonAMDGPUTransforms/AccelerateAMDMatmul.cpp
@@ -15,6 +15,8 @@
 #include "triton/Tools/LayoutUtils.h"
 #include "triton/Tools/LinearLayout.h"
 #include "llvm/ADT/TypeSwitch.h"
+#include "llvm/Support/MathExtras.h"
+#include <numeric>
 
 namespace tt = mlir::triton;
 namespace ttg = mlir::triton::gpu;
@@ -1564,6 +1566,165 @@ public:
   }
 };
 
+// Non-WMMA/Non-MFMA fallback: rebalance the per-thread tile of an FMA (blocked)
+// dot.
+//
+// This heuristic tries to find the blocked encoding such that the LDS reads
+// are minimized.
+//
+// The idea is to compute the "perimeter" which is M_pt + N_pt (where M_pt
+// and N_pt are the number of elements per thread in the M and N dimensions
+// respectively), and find the minimum perimeter (which esentially minimizes
+// the LDS reads). Let aM/aN be the number of threads along M/N, so that
+// M_pt = M/aM and N_pt = N/aN. The search respects the constraints:
+// - aM and aN are powers of two with aM * aN == warpSize * numWarps (every
+//   thread is used)
+// - M_pt and N_pt must be divisible by the size per thread (the tile divides
+//   the output exactly)
+// - aM factors into threadsPerWarp_M * warpsPerCTA_M, and aN likewise, such
+//   that threadsPerWarp_M * threadsPerWarp_N == warpSize and
+//   warpsPerCTA_M * warpsPerCTA_N == numWarps
+class RebalanceBlockedFMA : public OpRewritePattern<tt::DotOp> {
+public:
+  using OpRewritePattern<tt::DotOp>::OpRewritePattern;
+
+  LogicalResult matchAndRewrite(tt::DotOp dotOp,
+                                PatternRewriter &rewriter) const override {
+    auto ctx = dotOp.getContext();
+    auto oldRetType = cast<RankedTensorType>(dotOp.getResult().getType());
+    auto blocked =
+        dyn_cast_or_null<ttg::BlockedEncodingAttr>(oldRetType.getEncoding());
+    if (!blocked)
+      return rewriter.notifyMatchFailure(
+          dotOp, "result not blocked (handled by MFMA/WMMA)");
+    if (oldRetType.getRank() != 2)
+      return rewriter.notifyMatchFailure(dotOp, "only rank-2 supported");
+
+    SmallVector<unsigned> sizePerThread =
+        llvm::to_vector(blocked.getSizePerThread());
+    SmallVector<unsigned> curTPW = llvm::to_vector(blocked.getThreadsPerWarp());
+    SmallVector<unsigned> curWPC = llvm::to_vector(blocked.getWarpsPerCTA());
+
+    int64_t M = oldRetType.getShape()[0];
+    int64_t N = oldRetType.getShape()[1];
+    unsigned warpSize = curTPW[0] * curTPW[1];
+    unsigned numWarps = curWPC[0] * curWPC[1];
+    unsigned T = warpSize * numWarps;
+
+    if (!llvm::isPowerOf2_32(warpSize) || !llvm::isPowerOf2_32(numWarps))
+      return rewriter.notifyMatchFailure(dotOp, "non-pow2 warp/lane counts");
+
+    // order[0] is the fastest-varying (contiguous) dimension; the whole layout
+    // decision is oriented around it so that lanes and per-thread runs land on
+    // the contiguous dimension for coalesced/vectorized LDS reads.
+    auto order = blocked.getOrder();
+    bool contiguousIsN = order[0] == 1;
+
+    // The actual layout decision.
+    // Pick threads-along-M (aM) and threads-along-N (aN=T/aM) that make the
+    // per-thread tile (M/aM x N/aN) as square as possible. Seed with the
+    // current split so we only switch to a strictly more balanced one.
+    //
+    // Lambda to compute the imbalance metric; how imbalanced the per-thread
+    // tile is. The lower the imbalance, the better.
+    //
+    // The tie-break (the +1 term) only matters when |mpt - npt| is equal for
+    // two splits. We then prefer the per-thread tile to be larger along the
+    // contiguous dimension, since extending the per-thread run along the
+    // fastest-varying dim helps vectorization:
+    // - For order=[1,0] (N contiguous) we prefer mpt >= npt;
+    // - For order=[0,1] (M contiguous) we prefer npt >= mpt.
+    auto imbalance = [&](unsigned aM) -> long {
+      unsigned aN = T / aM;
+      long mpt = M / aM, npt = N / aN;
+      long tieBreak = contiguousIsN ? (npt > mpt ? 1 : 0) : (mpt > npt ? 1 : 0);
+      return std::abs(mpt - npt) * 2 + tieBreak;
+    };
+    unsigned bestAM = curTPW[0] * curWPC[0];
+    long bestImb = imbalance(bestAM);
+    for (unsigned aM = 1; aM <= T; aM <<= 1) {
+      unsigned aN = T / aM;
+      unsigned tileM = sizePerThread[0] * aM;
+      unsigned tileN = sizePerThread[1] * aN;
+      if (tileM == 0 || tileN == 0)
+        continue;
+      if (M % tileM != 0 || N % tileN != 0)
+        continue; // require exact tiling
+      long imb = imbalance(aM);
+      if (imb < bestImb) {
+        bestImb = imb;
+        bestAM = aM;
+      }
+    }
+
+    // We have found the aM/aN that minimizes the imbalance metric. Now split
+    // it into warpsPerCTA_M * threadsPerWarp_M, preferring warps on M. This
+    // maximizes the number of lanes on N which, being the contiguous (fastest)
+    // dimension per order=[1,0], improves read coalescing. Empirically this
+    // matches the best-performing layout for FMA-based dot operations.
+    unsigned aM = bestAM, aN = T / bestAM;
+
+    unsigned wpcM, wpcN, tpwM, tpwN;
+    if (contiguousIsN) {
+      // Lanes on N: maximize warps on M. The largest wpcM that divides both
+      // numWarps (so wpcN is whole) and aM (so tpwM is whole) is their gcd.
+      wpcM = std::gcd(numWarps, aM);
+      wpcN = numWarps / wpcM;
+      tpwM = aM / wpcM;
+      tpwN = warpSize / tpwM;
+    } else {
+      // Lanes on M: same idea, but maximize warps on N instead.
+      wpcN = std::gcd(numWarps, aN);
+      wpcM = numWarps / wpcN;
+      tpwN = aN / wpcN;
+      tpwM = warpSize / tpwN;
+    }
+    if (tpwM * tpwN != warpSize || wpcM * wpcN != numWarps ||
+        tpwM * wpcM != aM || tpwN * wpcN != aN)
+      return rewriter.notifyMatchFailure(dotOp, "factorization mismatch");
+
+    SmallVector<unsigned> newTPW{tpwM, tpwN};
+    SmallVector<unsigned> newWPC{wpcM, wpcN};
+    if (newTPW == curTPW && newWPC == curWPC)
+      return rewriter.notifyMatchFailure(dotOp, "already balanced");
+
+    // We have computed the threads per warp (newTPW) and warps per CTA (newWPC)
+    // that we want to use, now rewrite the dot op to use the new
+    // blocked encoding.
+    auto newBlocked = ttg::BlockedEncodingAttr::get(ctx, sizePerThread, newTPW,
+                                                    newWPC, blocked.getOrder(),
+                                                    blocked.getCGALayout());
+
+    Value a = dotOp.getA(), b = dotOp.getB(), c = dotOp.getC();
+    auto aTy = cast<RankedTensorType>(a.getType());
+    auto bTy = cast<RankedTensorType>(b.getType());
+    auto cTy = cast<RankedTensorType>(c.getType());
+    auto aEnc = cast<ttg::DotOperandEncodingAttr>(aTy.getEncoding());
+    auto bEnc = cast<ttg::DotOperandEncodingAttr>(bTy.getEncoding());
+    auto newAEnc = ttg::DotOperandEncodingAttr::get(
+        ctx, aEnc.getOpIdx(), newBlocked, aEnc.getKWidth());
+    auto newBEnc = ttg::DotOperandEncodingAttr::get(
+        ctx, bEnc.getOpIdx(), newBlocked, bEnc.getKWidth());
+
+    Value newA =
+        convertAndCastTensor(rewriter, a, newAEnc, aTy.getElementType());
+    Value newB =
+        convertAndCastTensor(rewriter, b, newBEnc, bTy.getElementType());
+    Value newC =
+        convertAndCastTensor(rewriter, c, newBlocked, cTy.getElementType());
+
+    auto newRetType = RankedTensorType::get(
+        oldRetType.getShape(), oldRetType.getElementType(), newBlocked);
+    auto newDot = tt::DotOp::create(rewriter, dotOp.getLoc(), newRetType, newA,
+                                    newB, newC, dotOp.getInputPrecision(),
+                                    dotOp.getMaxNumImpreciseAcc());
+    Value res = convertAndCastTensor(rewriter, newDot, oldRetType.getEncoding(),
+                                     oldRetType.getElementType());
+    rewriter.replaceOp(dotOp, res);
+    return success();
+  }
+};
+
 class AccelerateBlocked : public OpRewritePattern<DotOp> {
   TargetFeatures targetFeatures;
 
@@ -1789,6 +1950,7 @@ struct TritonAMDGPUAccelerateMatmulPass
       mfmaPatterns.add<::BlockedToWMMA>(context, wmmaVersion,
                                         matrixInstructionSize,
                                         /*benefit=*/2);
+      mfmaPatterns.add<::RebalanceBlockedFMA>(context, /*benefit=*/1);
       break;
     default:
       break;


### PR DESCRIPTION
Triton has a mechanism to decide the layout (`sizePerThread`, `threadsPerWarp`, `warpsPerCTA` and `order`) for MFMA and WMMA based dot ops (in `BlockedToMFMA` and `BlockedToWMMA` respectively). This has significant performance advantage. 

However, it's missing one for the FMA path, so it will always fall back to a default layout regardless of the problem shape. This PR proposes a new mechanism for the FMA path, which has proven to give significant performance boost in several cases. On RDNA4 specifically I tested a few matmuls with f32 datatype (so FMA path is exercised):

| dtype   | trA | trB | G  | M      | K     | N     | Speedup  |
|---------|-----|-----|----|--------|-------|-------|----------|
| f32     | F   | F   | 1  | 14400  | 512   | 512   | 26.7%    |
| f32     | F   | F   | 1  | 4096   | 768   | 2304  | 18.9%    |
| f32     | F   | F   | 1  | 9216   | 320   | 2560  | 35.6%    |
| f32     | F   | F   | 1  | 4096   | 3072  | 768   | 10.3%    |

Speedup column represents the speed of this PR with respect to main branch, with an average speedup of 22.8%.

The PR adds RebalanceBlockedFMA (scoped to RDNA3/RDNA4) which recomputes `threadsPerWarp` and `warpsPerCTA` in order to minimize LDS reads and keep those reads coalesced/vectorized:

### Stage 1
RebalanceBlockedFMA aims to find the blocked encoding such that the LDS reads are minimized, by minimizing M_pt + N_pt (both representing the elements per thread for M and N respectively) while respecting some constraints (so that the IR is actually legal). To be more explicit, this mechanism computes M_pt and N_pt as follows:

```
M_pt = M / (threadsPerWarp_M × warpsPerCTA_M)
N_pt = N / (threadsPerWarp_N × warpsPerCTA_N)
```

When two splits are equally balanced (|M_pt − N_pt| ties), the tie-break prefers the per-thread tile to extend along the contiguous dimension (by checking order[0]).

### Stage 2
Stage 1 fixes how many threads cover M vs N. Then, stage 2 splits each into `warpsPerCTA` and `threadsPerWarp`. To coalesce/vectorize the LDS reads we pack as many lanes as possible into the contiguous dimension, which means spending as many warps as possible on the other dimension (done via gcd). 

The contiguous dimension is determined by `order[0]`:
- `order = [1, 0]` (N contiguous): warps on M, lanes on N.
- `order = [0, 1]` (M contiguous): the exact mirror, warps on N, lanes on M.

### Testing
The PR adds `test/TritonGPU/amd/accelerate-amd-matmul-fma-rdna.mlir` covering unbalanced case, already balanced case (negative test) and also tests `order = [0, 1]` and `order = [1, 0]` variants.

