### PR TITLE
[AMD] Fix buffer-op offsets being marked split-safe when a negative leaf node is hidden behind a layout/shape op

### DIFF
--- a/test/TritonGPU/amd/amd-annotate-buffer-op-split-safety.mlir
+++ b/test/TritonGPU/amd/amd-annotate-buffer-op-split-safety.mlir
@@ -48,3 +48,60 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 1 : i32, "ttg.thr
         tt.return
     }
 }
+
+// -----
+
+#blocked0 = #ttg.blocked<{sizePerThread = [4], threadsPerWarp = [32], warpsPerCTA = [1], order = [0]}>
+#blocked1 = #ttg.blocked<{sizePerThread = [1], threadsPerWarp = [32], warpsPerCTA = [1], order = [0]}>
+module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 1 : i32, "ttg.threads-per-warp" = 32 : i32} {
+    // CHECK-LABEL: @no_split_convert_layout_negative_summand
+    // CHECK: amdg.buffer_load
+    // CHECK-NOT: amdgpu.split_soffset_safe
+    tt.func @no_split_convert_layout_negative_summand(%arg0: !tt.ptr<f32> {tt.divisibility = 16 : i32}) {
+        %cn64 = arith.constant -64 : i32
+        %neg = tt.splat %cn64 : i32 -> tensor<128xi32, #blocked1>
+        %range = tt.make_range {end = 192 : i32, start = 64 : i32} : tensor<128xi32, #blocked1>
+        %add = arith.addi %neg, %range : tensor<128xi32, #blocked1>
+        %offset = ttg.convert_layout %add : tensor<128xi32, #blocked1> -> tensor<128xi32, #blocked0>
+        %ret = amdg.buffer_load %arg0[%offset] : tensor<128xf32, #blocked0>
+        tt.return
+    }
+}
+
+// -----
+
+#blocked0 = #ttg.blocked<{sizePerThread = [4], threadsPerWarp = [32], warpsPerCTA = [1], order = [0]}>
+#blocked1 = #ttg.blocked<{sizePerThread = [1], threadsPerWarp = [32], warpsPerCTA = [1], order = [0]}>
+module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 1 : i32, "ttg.threads-per-warp" = 32 : i32} {
+    // CHECK-LABEL: @split_convert_layout_all_nonneg
+    // CHECK: amdg.buffer_load
+    // CHECK-SAME: amdgpu.split_soffset_safe
+    tt.func @split_convert_layout_all_nonneg(%arg0: !tt.ptr<f32> {tt.divisibility = 16 : i32}) {
+        %c5 = arith.constant 5 : i32
+        %base = tt.splat %c5 : i32 -> tensor<128xi32, #blocked1>
+        %range = tt.make_range {end = 128 : i32, start = 0 : i32} : tensor<128xi32, #blocked1>
+        %add = arith.addi %base, %range : tensor<128xi32, #blocked1>
+        %offset = ttg.convert_layout %add : tensor<128xi32, #blocked1> -> tensor<128xi32, #blocked0>
+        %ret = amdg.buffer_load %arg0[%offset] : tensor<128xf32, #blocked0>
+        tt.return
+    }
+}
+
+// -----
+
+#blocked0 = #ttg.blocked<{sizePerThread = [4], threadsPerWarp = [32], warpsPerCTA = [1], order = [0]}>
+#blocked2d = #ttg.blocked<{sizePerThread = [1, 4], threadsPerWarp = [1, 32], warpsPerCTA = [1, 1], order = [1, 0]}>
+module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 1 : i32, "ttg.threads-per-warp" = 32 : i32} {
+    // CHECK-LABEL: @no_split_reshape_negative_summand
+    // CHECK: amdg.buffer_load
+    // CHECK-NOT: amdgpu.split_soffset_safe
+    tt.func @no_split_reshape_negative_summand(%arg0: !tt.ptr<f32> {tt.divisibility = 16 : i32}) {
+        %cn64 = arith.constant -64 : i32
+        %neg = tt.splat %cn64 : i32 -> tensor<128xi32, #blocked0>
+        %range = tt.make_range {end = 192 : i32, start = 64 : i32} : tensor<128xi32, #blocked0>
+        %add = arith.addi %neg, %range : tensor<128xi32, #blocked0>
+        %offset = tt.reshape %add allow_reorder : tensor<128xi32, #blocked0> -> tensor<1x128xi32, #blocked2d>
+        %ret = amdg.buffer_load %arg0[%offset] : tensor<1x128xf32, #blocked2d>
+        tt.return
+    }
+}

--- a/test/TritonGPU/amd/amd-annotate-buffer-op-split-safety.mlir
+++ b/test/TritonGPU/amd/amd-annotate-buffer-op-split-safety.mlir
@@ -105,3 +105,23 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 1 : i32, "ttg.thr
         tt.return
     }
 }
+
+// -----
+
+#blocked2d = #ttg.blocked<{sizePerThread = [1, 4], threadsPerWarp = [1, 32], warpsPerCTA = [1, 1], order = [1, 0]}>
+#slice2d0 = #ttg.slice<{dim = 0, parent = #blocked2d}>
+module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 1 : i32, "ttg.threads-per-warp" = 32 : i32} {
+    // CHECK-LABEL: @no_split_expand_dims_broadcast_negative_summand
+    // CHECK: amdg.buffer_load
+    // CHECK-NOT: amdgpu.split_soffset_safe
+    tt.func @no_split_expand_dims_broadcast_negative_summand(%arg0: !tt.ptr<f32> {tt.divisibility = 16 : i32}) {
+        %cn64 = arith.constant -64 : i32
+        %neg = tt.splat %cn64 : i32 -> tensor<128xi32, #slice2d0>
+        %range = tt.make_range {end = 192 : i32, start = 64 : i32} : tensor<128xi32, #slice2d0>
+        %add = arith.addi %neg, %range : tensor<128xi32, #slice2d0>
+        %expanded = tt.expand_dims %add {axis = 0 : i32} : tensor<128xi32, #slice2d0> -> tensor<1x128xi32, #blocked2d>
+        %offset = tt.broadcast %expanded : tensor<1x128xi32, #blocked2d> -> tensor<2x128xi32, #blocked2d>
+        %ret = amdg.buffer_load %arg0[%offset] : tensor<2x128xf32, #blocked2d>
+        tt.return
+    }
+}

--- a/third_party/amd/lib/TritonAMDGPUTransforms/AnnotateBufferOpSplitSafety.cpp
+++ b/third_party/amd/lib/TritonAMDGPUTransforms/AnnotateBufferOpSplitSafety.cpp
@@ -8,6 +8,7 @@
 #include "third_party/amd/include/Dialect/TritonAMDGPU/IR/Dialect.h"
 #include "triton/Analysis/Utility.h"
 #include "triton/Dialect/Triton/IR/Dialect.h"
+#include "triton/Dialect/TritonGPU/IR/Dialect.h"
 
 namespace mlir {
 
@@ -18,8 +19,30 @@ namespace {
 
 namespace AMD = mlir::triton::AMD;
 namespace tta = mlir::triton::amdgpu;
+namespace ttg = mlir::triton::gpu;
 
 constexpr llvm::StringLiteral kSplitSafeAttrName = "amdgpu.split_soffset_safe";
+
+// Shape/layout ops that forward their operand's values unchanged, and with them
+// the operand's sign and its integer-range lattice state.
+static bool isTransparentWrapper(Operation *op) {
+  bool isWrapper = isa<triton::SplatOp, triton::BroadcastOp,
+                       triton::ExpandDimsOp, triton::ReshapeOp,
+                       ttg::ConvertLayoutOp>(op);
+  assert((!isWrapper || op->getNumOperands() == 1) &&
+         "transparent wrapper must have a single SSA operand.");
+  return isWrapper;
+}
+
+// Peel transparent wrappers to expose the real defining op underneath.
+static Value peelTransparentWrappers(Value v) {
+  while (Operation *def = v.getDefiningOp()) {
+    if (!isTransparentWrapper(def))
+      break;
+    v = def->getOperand(0);
+  }
+  return v;
+}
 
 // Conservatively accept an offset only when every leaf in its
 // additive/shape expression proves non-negative. This may miss safe splits,
@@ -28,7 +51,7 @@ static bool isLeafNonNegative(Value v, DataFlowSolver &solver) {
   // An `add` is never a leaf to the soffset splitter. It peels the summands
   // apart and lifts the uniform ones into the unsigned soffset. So a sum whose
   // range is non-negative can still hide a negative summand.
-  if (v.getDefiningOp<arith::AddIOp>())
+  if (peelTransparentWrappers(v).getDefiningOp<arith::AddIOp>())
     return false;
 
   const auto *range = solver.lookupState<dataflow::IntegerValueRangeLattice>(v);
@@ -77,8 +100,7 @@ static bool isNonNegative(Value v, DataFlowSolver &solver) {
     return mr.getStartAttr().getInt() >= 0;
   if (isa<triton::GetProgramIdOp, triton::GetNumProgramsOp>(def))
     return true;
-  if (isa<triton::SplatOp, triton::BroadcastOp, triton::ExpandDimsOp,
-          triton::ReshapeOp>(def))
+  if (isTransparentWrapper(def))
     return isNonNegative(def->getOperand(0), solver);
 
   return false;

--- a/third_party/amd/lib/TritonAMDGPUTransforms/AnnotateBufferOpSplitSafety.cpp
+++ b/third_party/amd/lib/TritonAMDGPUTransforms/AnnotateBufferOpSplitSafety.cpp
@@ -26,9 +26,9 @@ constexpr llvm::StringLiteral kSplitSafeAttrName = "amdgpu.split_soffset_safe";
 // Shape/layout ops that forward their operand's values unchanged, and with them
 // the operand's sign and its integer-range lattice state.
 static bool isTransparentWrapper(Operation *op) {
-  bool isWrapper = isa<triton::SplatOp, triton::BroadcastOp,
-                       triton::ExpandDimsOp, triton::ReshapeOp,
-                       ttg::ConvertLayoutOp>(op);
+  bool isWrapper =
+      isa<triton::SplatOp, triton::BroadcastOp, triton::ExpandDimsOp,
+          triton::ReshapeOp, ttg::ConvertLayoutOp>(op);
   assert((!isWrapper || op->getNumOperands() == 1) &&
          "transparent wrapper must have a single SSA operand.");
   return isWrapper;


### PR DESCRIPTION
An offset is only marked split-safe when it can never feed a negative value into the unsigned scalar soffset. The pass was honoring that contract for a bare arith.addi (a sum can have a non-negative range while still containing a negative term), but the safety check only reasoned about the offset's outermost op. In some kernels the relevant add is routinely wrapped in shape/layout plumbing  (`tt.reshape`, `tt.broadcast`, `ttg.convert_layout`, etc.). When that happened, the check no longer saw the add, fell back to the aggregate range, and concluded "non-negative, safe." That is exactly the case the pass is meant to reject, so it was silently producing incorrect addresses.

Note: This is an extension of the bug fix here: https://github.com/triton-lang/triton/pull/10450

<!---
The core Triton is a small number of people, and we receive many PRs (thank
you!).  To help us review your code more quickly, **if you are a new
contributor (less than 3 PRs merged) we ask that you complete the following
tasks and include the filled-out checklist in your PR description.**

Complete the following tasks before sending your PR, and replace `[ ]` with
`[x]` to indicate you have done them.
-->

# New contributor declaration
- [X] I am not making a trivial change, such as fixing a typo in a comment.

- [X] I have written a PR description following these
  [rules](https://cbea.ms/git-commit/#why-not-how).

- [X] I have run `pre-commit run --from-ref origin/main --to-ref HEAD`.

- Select one of the following.
  - [X] I have added tests.
    - `/test` for `lit` tests
    - `/unittest` for C++ tests
    - `/python/test` for end-to-end tests
  - [ ] This PR does not need a test because `FILL THIS IN`.

- Select one of the following.
  - [ ] I have not added any `lit` tests.
  - [X] The `lit` tests I have added follow these [best practices](https://mlir.llvm.org/getting_started/TestingGuide/#filecheck-best-practices),
    including the "tests should be minimal" section. (Usually running Python code
    and using the instructions it generates is not minimal.)
