### PR TITLE
[TEST] Preserve existing LD_LIBRARY_PATH in AOT tests

### DIFF
--- a/python/test/unit/tools/test_aot.py
+++ b/python/test/unit/tools/test_aot.py
@@ -413,7 +413,8 @@ def test_compile_link_matmul_no_specialization():
 
         # run test case
         env = os.environ.copy()
-        env["LD_LIBRARY_PATH"] = tmp_dir
+        existing = env.get("LD_LIBRARY_PATH")
+        env["LD_LIBRARY_PATH"] = f"{tmp_dir}:{existing}" if existing else tmp_dir
         subprocess.run(["./test", a_path, b_path, c_path], env=env, check=True, cwd=tmp_dir)
 
         # read data and compare against reference
@@ -446,7 +447,8 @@ def test_compile_link_matmul():
 
         # run test case
         env = os.environ.copy()
-        env["LD_LIBRARY_PATH"] = tmp_dir
+        existing = env.get("LD_LIBRARY_PATH")
+        env["LD_LIBRARY_PATH"] = f"{tmp_dir}:{existing}" if existing else tmp_dir
         subprocess.run(["./test", a_path, b_path, c_path], env=env, check=True, cwd=tmp_dir)
 
         # read data and compare against reference
@@ -480,7 +482,8 @@ def test_launcher_has_no_available_kernel():
 
         # run test case
         env = os.environ.copy()
-        env["LD_LIBRARY_PATH"] = tmp_dir
+        existing = env.get("LD_LIBRARY_PATH")
+        env["LD_LIBRARY_PATH"] = f"{tmp_dir}:{existing}" if existing else tmp_dir
         result = subprocess.run(
             ["./test", a_path, b_path, c_path],
             env=env,
@@ -528,7 +531,8 @@ def test_compile_link_autotune_matmul():
             gen_test_bin(tmp_dir, M, N, K, exe=test_name, algo_id=algo_id)
 
             env = os.environ.copy()
-            env["LD_LIBRARY_PATH"] = tmp_dir
+            existing = env.get("LD_LIBRARY_PATH")
+            env["LD_LIBRARY_PATH"] = f"{tmp_dir}:{existing}" if existing else tmp_dir
             subprocess.run(
                 [f"./{test_name}", a_path, b_path, c_path],
                 check=True,


### PR DESCRIPTION
Prepend tmp_dir to LD_LIBRARY_PATH instead of overwriting it to avoid breaking test execution in environments where LD_LIBRARY_PATH is already configured.

Our test containers use `$LD_LIBRARY_PATH` to locate `libcuda.so.1`. Overwriting `$LD_LIBRARY_PATH` - vs appending to it - makes this test fail.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

# New contributor declaration
- [x] I am not making a trivial change, such as fixing a typo in a comment.

- [x] I have written a PR description following these
  [rules](https://cbea.ms/git-commit/#why-not-how).

- [x] I have run `pre-commit run --from-ref origin/main --to-ref HEAD`.

- Select one of the following.
  - [ ] I have added tests.
    - `/test` for `lit` tests
    - `/unittest` for C++ tests
    - `/python/test` for end-to-end tests
  - [x] This PR does not need a test because I'm fixing a test.

- Select one of the following.
  - [x] I have not added any `lit` tests.
  - [ ] The `lit` tests I have added follow these [best practices](https://mlir.llvm.org/getting_started/TestingGuide/#filecheck-best-practices),
    including the "tests should be minimal" section. (Usually running Python code
    and using the instructions it generates is not minimal.)
