### PR TITLE
Support expand-dims reshapes

### DIFF
--- a/include/triton/Dialect/Triton/IR/TritonOps.td
+++ b/include/triton/Dialect/Triton/IR/TritonOps.td
@@ -488,6 +488,9 @@ def TT_ReshapeOp : TT_Op<"reshape", [Pure,
     let hasCanonicalizeMethod = 1;
     let hasFolder = 1;
     let hasVerifier = 1;
+    let extraClassDeclaration = [{
+      std::optional<unsigned> getExpandDimsAxis();
+    }];
 }
 
 def TT_BroadcastOp : TT_Op<"broadcast", [Pure,

--- a/lib/Dialect/Gluon/Transforms/Canonicalize.cpp
+++ b/lib/Dialect/Gluon/Transforms/Canonicalize.cpp
@@ -57,6 +57,7 @@ void Canonicalize::runOnOperation() {
   StoreOp::getCanonicalizationPatterns(patterns, ctx);
   BroadcastOp::getCanonicalizationPatterns(patterns, ctx);
   ExpandDimsOp::getCanonicalizationPatterns(patterns, ctx);
+  ReshapeOp::getCanonicalizationPatterns(patterns, ctx);
   IntToPtrOp::getCanonicalizationPatterns(patterns, ctx);
   ttg::WarpSpecializeOp::getCanonicalizationPatterns(patterns, ctx);
   ttg::WarpSpecializePartitionsOp::getCanonicalizationPatterns(patterns, ctx);

--- a/lib/Dialect/Triton/IR/Ops.cpp
+++ b/lib/Dialect/Triton/IR/Ops.cpp
@@ -920,6 +920,22 @@ LogicalResult CatOp::verify() {
 
 //-- ReshapeOp --
 
+std::optional<unsigned> ReshapeOp::getExpandDimsAxis() {
+  auto srcTy = getSrc().getType();
+  auto dstTy = getType();
+  if (srcTy.getRank() + 1 != dstTy.getRank())
+    return std::nullopt;
+  auto srcShape = srcTy.getShape();
+  auto dstShape = dstTy.getShape();
+  for (unsigned axis = 0; axis < dstShape.size(); ++axis) {
+    if (dstShape[axis] == 1 &&
+        srcShape.take_front(axis) == dstShape.take_front(axis) &&
+        srcShape.drop_front(axis) == dstShape.drop_front(axis + 1))
+      return axis;
+  }
+  return std::nullopt;
+}
+
 void ReshapeOp::build(OpBuilder &builder, OperationState &state,
                       ArrayRef<int64_t> shape, Value src, bool allowReorder) {
   auto srcTy = cast<RankedTensorType>(src.getType());

--- a/lib/Dialect/Triton/Transforms/ReorderBroadcast.cpp
+++ b/lib/Dialect/Triton/Transforms/ReorderBroadcast.cpp
@@ -217,6 +217,7 @@ public:
 
     BroadcastOp::getCanonicalizationPatterns(patterns, context);
     ExpandDimsOp::getCanonicalizationPatterns(patterns, context);
+    ReshapeOp::getCanonicalizationPatterns(patterns, context);
     // elementwise(broadcast(a)) => broadcast(elementwise(a))
     patterns.add<MoveBroadcastAfterElementwisePattern>(context);
     // elementwise(splat(a), splat(b), ...) => splat(elementwise(a, b, ...))

--- a/lib/Dialect/TritonGPU/Transforms/RemoveLayoutConversions.cpp
+++ b/lib/Dialect/TritonGPU/Transforms/RemoveLayoutConversions.cpp
@@ -1397,6 +1397,8 @@ bool LayoutRematerialization::hoistConvertOnTopOfExtOrBroadcast(
             ExpandDimsOp>(op)) {
       return true;
     }
+    if (auto reshapeOp = dyn_cast<ReshapeOp>(op))
+      return reshapeOp.getExpandDimsAxis().has_value();
     if (auto fpToFpOp = dyn_cast<FpToFpOp>(op)) {
       auto srcType = cast<RankedTensorType>(fpToFpOp.getOperand().getType());
       return getElementBitWidth(srcType) <

--- a/lib/Dialect/TritonNvidiaGPU/Transforms/PlanCTA.cpp
+++ b/lib/Dialect/TritonNvidiaGPU/Transforms/PlanCTA.cpp
@@ -26,6 +26,7 @@
 #include "mlir/Support/LLVM.h"
 #include "triton/Dialect/Triton/IR/Dialect.h"
 #include "triton/Dialect/TritonGPU/IR/Dialect.h"
+#include "triton/Dialect/TritonGPU/Transforms/Utility.h"
 #include "triton/Dialect/TritonNvidiaGPU/IR/Dialect.h"
 #include "triton/Dialect/TritonNvidiaGPU/Transforms/Passes.h"
 #include "llvm/ADT/STLExtras.h"
@@ -123,6 +124,8 @@ private:
   bool processBroadcast(triton::BroadcastOp broadcast, Attribute layout);
   bool processExpandDimsBackward(triton::ExpandDimsOp expandDims,
                                  ttg::DistributedEncodingTrait newResultLayout);
+  bool processReshapeBackward(triton::ReshapeOp reshape,
+                              Attribute newResultLayout);
 
   bool processConvertLayoutBackward(ttg::ConvertLayoutOp convertLayout,
                                     CastOp cast);
@@ -419,6 +422,8 @@ bool CTAPlanner::propagateBackward(CastOp cast) {
       processBroadcast(broadcast, layout);
     } else if (auto expandDims = llvm::dyn_cast<triton::ExpandDimsOp>(op)) {
       processExpandDimsBackward(expandDims, layout);
+    } else if (auto reshape = llvm::dyn_cast<triton::ReshapeOp>(op)) {
+      processReshapeBackward(reshape, layout);
     } else if (auto ifOp = llvm::dyn_cast<scf::IfOp>(op)) {
       processIfOpBackward(ifOp, cast);
     } else if (auto forOp = llvm::dyn_cast<scf::ForOp>(op)) {
@@ -697,6 +702,13 @@ bool CTAPlanner::processExpandDimsBackward(
   auto newSrcLayout = ttg::SliceEncodingAttr::get(
       newResultLayout.getContext(), expandDims.getAxis(), newResultLayout);
   insertCasts(expandDims.getOperation(), {newSrcLayout}, {newResultLayout});
+  return true;
+}
+
+bool CTAPlanner::processReshapeBackward(triton::ReshapeOp reshape,
+                                        Attribute newResultLayout) {
+  auto newSrcLayout = inferSrcEncoding(reshape, newResultLayout);
+  insertCasts(reshape.getOperation(), {newSrcLayout}, {newResultLayout});
   return true;
 }
 

--- a/test/TritonGPU/amd/amd-canonicalize-pointers.mlir
+++ b/test/TritonGPU/amd/amd-canonicalize-pointers.mlir
@@ -587,6 +587,58 @@ module attributes {"ttg.num-warps" = 4 : i32} {
 
 // -----
 
+module attributes {"ttg.num-warps" = 4 : i32} {
+  tt.func @reshape_offset(%arg0: !tt.ptr<f16>, %arg1: i32) -> tensor<4x4xf16> {
+    %0 = tt.make_range {end = 16 : i32, start = 0 : i32} : tensor<16xi32>
+    %1 = tt.splat %arg1 : i32 -> tensor<16xi32>
+    %2 = arith.addi %1, %0 : tensor<16xi32>
+    %3 = tt.reshape %2 : tensor<16xi32> -> tensor<4x4xi32>
+    %4 = tt.splat %arg0 : !tt.ptr<f16> -> tensor<4x4x!tt.ptr<f16>>
+    %5 = tt.addptr %4, %3 : tensor<4x4x!tt.ptr<f16>>, tensor<4x4xi32>
+    %6 = tt.load %5 : tensor<4x4x!tt.ptr<f16>>
+    tt.return %6 : tensor<4x4xf16>
+  }
+}
+
+// CHECK-LABEL:   tt.func @reshape_offset(
+// CHECK-SAME:                            %[[VAL_0:.*]]: !tt.ptr<f16>,
+// CHECK-SAME:                            %[[VAL_1:.*]]: i32) -> tensor<4x4xf16> {
+// CHECK:           %[[VAL_2:.*]] = tt.make_range {end = 16 : i32, start = 0 : i32} : tensor<16xi32>
+// CHECK:           %[[VAL_3:.*]] = tt.reshape %[[VAL_2]] : tensor<16xi32> -> tensor<4x4xi32>
+// CHECK:           %[[VAL_4:.*]] = tt.addptr %[[VAL_0]], %[[VAL_1]] : !tt.ptr<f16>, i32
+// CHECK:           %[[VAL_5:.*]] = tt.splat %[[VAL_4]] : !tt.ptr<f16> -> tensor<4x4x!tt.ptr<f16>>
+// CHECK:           %[[VAL_6:.*]] = tt.addptr %[[VAL_5]], %[[VAL_3]] : tensor<4x4x!tt.ptr<f16>>, tensor<4x4xi32>
+// CHECK:           %[[VAL_7:.*]] = tt.load %[[VAL_6]] : tensor<4x4x!tt.ptr<f16>>
+// CHECK:           tt.return %[[VAL_7]] : tensor<4x4xf16>
+// CHECK:         }
+
+// -----
+
+module attributes {"ttg.num-warps" = 4 : i32} {
+  tt.func @reshape_pointer(%arg0: !tt.ptr<f16>) -> tensor<4x4xf16> {
+    %0 = tt.make_range {end = 16 : i32, start = 0 : i32} : tensor<16xi32>
+    %1 = tt.splat %arg0 : !tt.ptr<f16> -> tensor<16x!tt.ptr<f16>>
+    %2 = tt.addptr %1, %0 : tensor<16x!tt.ptr<f16>>, tensor<16xi32>
+    %3 = tt.reshape %2 : tensor<16x!tt.ptr<f16>> -> tensor<4x4x!tt.ptr<f16>>
+    %4 = tt.load %3 : tensor<4x4x!tt.ptr<f16>>
+    tt.return %4 : tensor<4x4xf16>
+  }
+}
+
+// CHECK-LABEL:   tt.func @reshape_pointer(
+// CHECK-SAME:                             %[[VAL_0:.*]]: !tt.ptr<f16>) -> tensor<4x4xf16> {
+// CHECK:           %[[VAL_1:.*]] = tt.make_range {end = 16 : i32, start = 0 : i32} : tensor<16xi32>
+// CHECK:           %[[VAL_2:.*]] = arith.extsi %[[VAL_1]] : tensor<16xi32> to tensor<16xi64>
+// CHECK:           %[[VAL_3:.*]] = tt.reshape %[[VAL_2]] : tensor<16xi64> -> tensor<4x4xi64>
+// CHECK:           %[[VAL_4:.*]] = arith.trunci %[[VAL_3]] : tensor<4x4xi64> to tensor<4x4xi32>
+// CHECK:           %[[VAL_5:.*]] = tt.splat %[[VAL_0]] : !tt.ptr<f16> -> tensor<4x4x!tt.ptr<f16>>
+// CHECK:           %[[VAL_6:.*]] = tt.addptr %[[VAL_5]], %[[VAL_4]] : tensor<4x4x!tt.ptr<f16>>, tensor<4x4xi32>
+// CHECK:           %[[VAL_7:.*]] = tt.load %[[VAL_6]] : tensor<4x4x!tt.ptr<f16>>
+// CHECK:           tt.return %[[VAL_7]] : tensor<4x4xf16>
+// CHECK:         }
+
+// -----
+
 
 // The following is a more complex case where also a multiplication is involved. It's useful to walk through the case.
 // We have that the offset to the pointer is the following:

--- a/test/TritonGPU/combine.mlir
+++ b/test/TritonGPU/combine.mlir
@@ -6,6 +6,11 @@
 #layout2 = #ttg.blocked<{sizePerThread = [1, 4], threadsPerWarp = [2, 16], warpsPerCTA = [4, 1], order = [1, 0]}>
 #layout3 = #ttg.blocked<{sizePerThread = [1, 4], threadsPerWarp = [2, 16], warpsPerCTA = [1, 4], order = [1, 0]}>
 
+#expand_layout0 = #ttg.blocked<{sizePerThread = [1, 1], threadsPerWarp = [32, 1], warpsPerCTA = [4, 1], order = [1, 0]}>
+#expand_layout1 = #ttg.blocked<{sizePerThread = [4, 1], threadsPerWarp = [32, 1], warpsPerCTA = [4, 1], order = [1, 0]}>
+#expand_layout0_slice = #ttg.slice<{dim = 1, parent = #expand_layout0}>
+#expand_layout1_slice = #ttg.slice<{dim = 1, parent = #expand_layout1}>
+
 #layout4 = #ttg.blocked<{sizePerThread = [1, 1], threadsPerWarp = [32, 1], warpsPerCTA = [2, 2], order = [0, 1]}>
 #layout5 = #ttg.blocked<{sizePerThread = [1, 2], threadsPerWarp = [32, 1], warpsPerCTA = [2, 2], order = [0, 1]}>
 #linear = #ttg.linear<{register = [[0, 1], [0, 2], [0, 4], [0, 8], [0, 16]], lane = [[1, 0], [2, 0], [4, 0], [8, 0], [0, 32]], warp = [[16, 0], [32, 0]], block = []}>
@@ -170,6 +175,16 @@ tt.func @hoist_above_broadcast(%arg0: tensor<1024x1xf32, #layout2>, %arg1: f32) 
   tt.return %3 : tensor<1024x128xf32, #layout3>
 }
 
+// CHECK-LABEL: hoist_above_expand_dims_reshape
+tt.func @hoist_above_expand_dims_reshape(%arg0: tensor<1024xf32, #expand_layout0_slice>) -> tensor<1024x1xf32, #expand_layout1> {
+// CHECK: %[[CVT:.+]] = ttg.convert_layout %arg0 : tensor<1024xf32, #{{.*}}> -> tensor<1024xf32, #[[DST_LAYOUT:.*]]>
+// CHECK: tt.reshape %[[CVT]] : tensor<1024xf32, #[[DST_LAYOUT]]> -> tensor<1024x1xf32, #{{.*}}>
+// CHECK-NOT: ttg.convert_layout
+// CHECK: tt.return
+  %0 = tt.reshape %arg0 : tensor<1024xf32, #expand_layout0_slice> -> tensor<1024x1xf32, #expand_layout0>
+  %1 = ttg.convert_layout %0 : tensor<1024x1xf32, #expand_layout0> -> tensor<1024x1xf32, #expand_layout1>
+  tt.return %1 : tensor<1024x1xf32, #expand_layout1>
+}
 
 // CHECK-LABEL: if
 tt.func @if(%arg0: i32, %arg1: !tt.ptr<i32> {tt.divisibility = 16 : i32}) {

--- a/test/TritonNvidiaGPU/plan_cta.mlir
+++ b/test/TritonNvidiaGPU/plan_cta.mlir
@@ -1,8 +1,12 @@
 // RUN: triton-opt %s -triton-nvidia-gpu-plan-cta | FileCheck %s
 
 #blocked = #ttg.blocked<{sizePerThread = [4], threadsPerWarp = [32], warpsPerCTA = [4], order = [0], CGALayout = [[0], [0]]}>
+#blocked_2d = #ttg.blocked<{sizePerThread = [4, 1], threadsPerWarp = [32, 1], warpsPerCTA = [4, 1], order = [0, 1], CGALayout = [[0, 0], [0, 0]]}>
+#slice = #ttg.slice<{dim = 1, parent = #blocked_2d}>
 
   // CHECK: #blocked = #ttg.blocked<{sizePerThread = [4], threadsPerWarp = [32], warpsPerCTA = [4], order = [0], CGALayout = {{\[\[1\], \[2\]\]}}}>
+  // CHECK-DAG: #[[$RESHAPE_DST:.+]] = #ttg.blocked<{{.*}}CGALayout = {{\[\[1, 0\], \[2, 0\]\]}}}>
+  // CHECK-DAG: #[[$RESHAPE_SRC:.+]] = #ttg.linear
 module attributes {"ttg.num-ctas" = 4 : i32, "ttg.num-warps" = 4 : i32, ttg.target = "cuda:100", "ttg.threads-per-warp" = 32 : i32} {
   // CHECK-LABEL: tt.func @reduce_1d_split_ctas
   // CHECK: "tt.reduce"(%{{.*}}) <{axis = 0 : i32}>
@@ -16,5 +20,20 @@ module attributes {"ttg.num-ctas" = 4 : i32, "ttg.num-warps" = 4 : i32, ttg.targ
       tt.reduce.return %sum : f32
     }) : (tensor<65536xf32, #blocked>) -> f32
     tt.return %red : f32
+  }
+
+  // CHECK-LABEL: tt.func @reduce_reshape
+  // CHECK: %[[CST:.*]] = arith.constant dense<0.000000e+00> : tensor<65536xf32, #[[$RESHAPE_SRC]]>
+  // CHECK-NEXT: %[[RESHAPE:.*]] = tt.reshape %[[CST]] : tensor<65536xf32, #[[$RESHAPE_SRC]]> -> tensor<65536x1xf32, #[[$RESHAPE_DST]]>
+  // CHECK-NEXT: %[[RED:.*]] = "tt.reduce"(%[[RESHAPE]]) <{axis = 1 : i32}>
+  tt.func @reduce_reshape() -> tensor<65536xf32, #slice> {
+    %cst = arith.constant dense<0.000000e+00> : tensor<65536xf32, #slice>
+    %expanded = tt.reshape %cst : tensor<65536xf32, #slice> -> tensor<65536x1xf32, #blocked_2d>
+    %red = "tt.reduce"(%expanded) <{axis = 1 : i32}> ({
+    ^bb0(%lhs: f32, %rhs: f32):
+      %sum = arith.addf %lhs, %rhs : f32
+      tt.reduce.return %sum : f32
+    }) : (tensor<65536x1xf32, #blocked_2d>) -> tensor<65536xf32, #slice>
+    tt.return %red : tensor<65536xf32, #slice>
   }
 }

--- a/third_party/amd/lib/TritonAMDGPUTransforms/CanonicalizePointers.cpp
+++ b/third_party/amd/lib/TritonAMDGPUTransforms/CanonicalizePointers.cpp
@@ -417,6 +417,14 @@ createDecomposeOffsetFromExpr(RewriterBase &rewriter, Location loc, Value expr,
                 rewriter, loc, nonUniform, expandOp.getAxis());
             return std::make_pair(uniform, expandNonUniform);
           })
+          .Case<tt::ReshapeOp>([&](auto reshapeOp) {
+            auto [uniform, nonUniform] = createDecomposeOffsetFromExpr(
+                rewriter, loc, reshapeOp.getSrc(), bitness, scalarToSplatMap);
+            Value reshapeNonUniform = tt::ReshapeOp::create(
+                rewriter, loc, reshapeOp.getType(), nonUniform,
+                reshapeOp.getAllowReorder(), reshapeOp.getEfficientLayout());
+            return std::make_pair(uniform, reshapeNonUniform);
+          })
           .Case<arith::AddIOp>([&](Operation *op) {
             return createDecomposeOffsetFromAdd(rewriter, loc, expr, bitness,
                                                 scalarToSplatMap);
@@ -1587,6 +1595,42 @@ public:
   }
 };
 
+/// Rewrite reshape(base, offset) -> base, reshape(offset).
+class ConvertReshape : public PointerCanonicalizationPattern<tt::ReshapeOp> {
+public:
+  using PointerCanonicalizationPattern::PointerCanonicalizationPattern;
+  LogicalResult
+  matchAndRewrite_(tt::ReshapeOp reshapeOp, OneToNOpAdaptor adaptor,
+                   ConversionPatternRewriter &rewriter) const override {
+    ValueRange remappedOperands = adaptor.getSrc();
+    if (remappedOperands.size() != 2)
+      return success();
+    Value fatPtrBase = remappedOperands[0];
+    if (!llvm::isa<tt::PointerType>(fatPtrBase.getType()))
+      return rewriter.notifyMatchFailure(
+          reshapeOp, "only scalar base currently supported");
+    Value fatPtrOffset = remappedOperands[1];
+
+    RankedTensorType result =
+        llvm::cast<RankedTensorType>(reshapeOp->getResultTypes().front());
+    if (!llvm::isa<tt::PointerType>(result.getElementType()))
+      return rewriter.notifyMatchFailure(
+          reshapeOp, "expected reshape result to be tensor of tt.ptr");
+
+    RankedTensorType newResult = RankedTensorType::get(
+        result.getShape(),
+        llvm::cast<RankedTensorType>(fatPtrOffset.getType()).getElementType(),
+        result.getEncoding());
+    auto newOffset = tt::ReshapeOp::create(
+        rewriter, reshapeOp.getLoc(), newResult, fatPtrOffset,
+        reshapeOp.getAllowReorder(), reshapeOp.getEfficientLayout());
+    rewriter.replaceOpWithMultiple(reshapeOp, {{fatPtrBase, newOffset}});
+    fatPtrs[{fatPtrBase, newOffset}] = fatPtrs.at({fatPtrBase, fatPtrOffset});
+
+    return success();
+  }
+};
+
 /// convert integer offset, keep base
 class ConvertConvertLayoutOp
     : public PointerCanonicalizationPattern<tt::gpu::ConvertLayoutOp> {
@@ -2053,7 +2097,7 @@ void TritonAMDGPUCanonicalizePointersPass::runOnOperation() {
       MaterializeFatPointerVariadic<tt::ExternElementwiseOp>,
       MaterializeFatPointerVariadic<tt::ElementwiseInlineAsmOp>,
       MaterializeFatPointerVariadic<tt::PrintOp>, ConvertSCFForOp,
-      ConvertExpandDims, ConvertSCFYieldOp, ConvertSCFIfOp,
+      ConvertExpandDims, ConvertReshape, ConvertSCFYieldOp, ConvertSCFIfOp,
       ConvertSCFConditionOp, ConvertSCFWhileOp, ConvertCFCondBranch,
       ConvertCFBranch, ConvertArithSelectOp, ConvertReturnOp>(
       patterns.getContext(), opsToRewrite, fatPrs, convertedBlocks);


### PR DESCRIPTION

Introduce the notion of an "expand-dims" reshape, which is just a
reshape that introduces a new size 1 axis.

Handle this in some existing passes, and run the reshape canonicalizer
in all the same places as the expand dims canonicalizer. This gets us
closer to being able to replace expand dims with reshape.

---
[//]: # (BEGIN SAPLING FOOTER)
* #10421
* #10555
* #10593
* #10545
* __->__ #10516