### PR TITLE
[AMD]Rephrase TDM tensor_dim Clamping to Avoid Suboptimal Codegen

### DIFF
--- a/third_party/amd/lib/TritonAMDGPUToLLVM/TDMUtility.cpp
+++ b/third_party/amd/lib/TritonAMDGPUToLLVM/TDMUtility.cpp
@@ -787,10 +787,12 @@ void fillTDMDescriptor(RewriterBase &rewriter, Location loc,
   dstPtr = b.gep(sharedPtrTy, elementType, dstPtr, dstOffset);
 
   // Update tensor shapes based on offset
+  Value zero = b.i32_val(0);
   for (size_t i = 0; i < numDims; ++i) {
-    auto diff = b.sub(tensorShape[i], offset[i]);
-    Value inBounds = b.icmp_ule(diff, tensorShape[i]);
-    tensorShape[i] = b.select(inBounds, diff, b.i32_val(0));
+    Value diff = b.sub(tensorShape[i], offset[i]);
+    Value clamped = b.smax(diff, zero);
+    Value isNeg = b.icmp_slt(offset[i], zero);
+    tensorShape[i] = b.select(isNeg, zero, clamped);
   }
 
   // TDM store does not support padding in general. However, if the padding
@@ -964,7 +966,13 @@ void fillTDMDescriptorForGatherScatter(
 
   // Adjust column tensor shape for OOB handling - subtract column offset to
   // get remaining elements.
-  tensorShape[1] = b.smax(b.i32_val(0), b.sub(tensorShape[1], globalColOffset));
+  {
+    Value zero = b.i32_val(0);
+    Value diff = b.sub(tensorShape[1], globalColOffset);
+    Value clamped = b.smax(diff, zero);
+    Value isNeg = b.icmp_slt(globalColOffset, zero);
+    tensorShape[1] = b.select(isNeg, zero, clamped);
+  }
 
   // For scatter with padding (store-from-LDS): clamp tensor_dim0 to the
   // original column width so OOB checking drops padding elements before they

--- a/third_party/amd/lib/TritonAMDGPUToLLVM/TDMUtility.cpp
+++ b/third_party/amd/lib/TritonAMDGPUToLLVM/TDMUtility.cpp
@@ -687,7 +687,6 @@ void fillTDMDescriptor(RewriterBase &rewriter, Location loc,
 
   auto ctx = rewriter.getContext();
   auto b = TritonLLVMOpBuilder(loc, rewriter);
-  Value zero = b.i32_val(0);
 
   Type globalPtrTy = ptr_ty(ctx, 1);
   Type sharedPtrTy = ptr_ty(ctx, 3);
@@ -788,6 +787,7 @@ void fillTDMDescriptor(RewriterBase &rewriter, Location loc,
   dstPtr = b.gep(sharedPtrTy, elementType, dstPtr, dstOffset);
 
   // Update tensor shapes based on offset
+  Value zero = b.i32_val(0);
   for (size_t i = 0; i < numDims; ++i) {
     // Clamp in this specific way to avoid suboptimal codegen by LLVM.
     // In some cases, LLVM InstCombine match and fold patterns into instructions
@@ -977,6 +977,7 @@ void fillTDMDescriptorForGatherScatter(
     // that only have VALU target instructions. Thus extra v_readfirstlane_b32
     // instructions are emitted to copy the value to sgpr after VALU
     // instructions.
+    Value zero = b.i32_val(0);
     Value diff = b.sub(tensorShape[1], globalColOffset);
     Value clamped = b.smax(diff, zero);
     Value isNeg = b.icmp_slt(globalColOffset, zero);

--- a/third_party/amd/lib/TritonAMDGPUToLLVM/TDMUtility.cpp
+++ b/third_party/amd/lib/TritonAMDGPUToLLVM/TDMUtility.cpp
@@ -687,6 +687,7 @@ void fillTDMDescriptor(RewriterBase &rewriter, Location loc,
 
   auto ctx = rewriter.getContext();
   auto b = TritonLLVMOpBuilder(loc, rewriter);
+  Value zero = b.i32_val(0);
 
   Type globalPtrTy = ptr_ty(ctx, 1);
   Type sharedPtrTy = ptr_ty(ctx, 3);
@@ -787,8 +788,12 @@ void fillTDMDescriptor(RewriterBase &rewriter, Location loc,
   dstPtr = b.gep(sharedPtrTy, elementType, dstPtr, dstOffset);
 
   // Update tensor shapes based on offset
-  Value zero = b.i32_val(0);
   for (size_t i = 0; i < numDims; ++i) {
+    // Clamp in this specific way to avoid suboptimal codegen by LLVM.
+    // In some cases, LLVM InstCombine match and fold patterns into instructions
+    // that only have VALU target instructions. Thus extra v_readfirstlane_b32
+    // instructions are emitted to copy the value to sgpr after VALU
+    // instructions.
     Value diff = b.sub(tensorShape[i], offset[i]);
     Value clamped = b.smax(diff, zero);
     Value isNeg = b.icmp_slt(offset[i], zero);
@@ -967,7 +972,11 @@ void fillTDMDescriptorForGatherScatter(
   // Adjust column tensor shape for OOB handling - subtract column offset to
   // get remaining elements.
   {
-    Value zero = b.i32_val(0);
+    // Clamp in this specific way to avoid suboptimal codegen by LLVM.
+    // In some cases, LLVM InstCombine match and fold patterns into instructions
+    // that only have VALU target instructions. Thus extra v_readfirstlane_b32
+    // instructions are emitted to copy the value to sgpr after VALU
+    // instructions.
     Value diff = b.sub(tensorShape[1], globalColOffset);
     Value clamped = b.smax(diff, zero);
     Value isNeg = b.icmp_slt(globalColOffset, zero);


### PR DESCRIPTION
Previous instructions sequence to clamp tensor shapes in TDM, i.e. `select(icmp_ule(sub(a,b), a), sub(a, b), 0)`, accidentally hit a pattern in LLVM's `InstCombine` pass, generating an operation that can only be lowered to VALU in AMDGPU backend. As a result, extra `v_readfirstlane_b32 ` instructions are generated to copy data back to sgpr after VALU computation. To avoid that, we need to use a specific way to do the clamping.