### PR TITLE
[BACKEND] Fix bankconflicts for MMAv2 with bitwidth=64

### DIFF
--- a/include/triton/Dialect/TritonGPU/IR/TritonGPUAttrDefs.td
+++ b/include/triton/Dialect/TritonGPU/IR/TritonGPUAttrDefs.td
@@ -162,7 +162,9 @@ When vec=2, elements are swizzled in pairs of 2.  In other words, the element at
         // This packs a few rows together for small K
         int perPhase = std::max<int>(1024 / (bitwidth * K), 1);
 
-        int mmaStride = 8;
+        // FP64 MMAv2 uses an m8n8k4 tile rather than the m16n8 tile used by
+        // the other MMAv2 variants.
+        int mmaStride = bitwidth == 64 ? 4 : 8;
         int vec = 4 * kWidth;
         // needsTrans is equiv. to flipping the opIdx
         if (needTrans)

--- a/unittest/Dialect/TritonGPU/SwizzleTest.cpp
+++ b/unittest/Dialect/TritonGPU/SwizzleTest.cpp
@@ -345,6 +345,36 @@ TEST_F(SwizzleTest, Test16x16Bf16BlockedMma) {
   EXPECT_EQ(w, 0);
 }
 
+TEST_F(BankConflictTest, F64MmaV2BSharedLayout) {
+  using mlir::triton::gpu::DotOperandEncodingAttr;
+  using mlir::triton::gpu::SwizzledSharedEncodingAttr;
+
+  SmallVector<int64_t> shape = {4, 16};
+  auto src = blocked(/*spt=*/{1, 1}, /*tpw=*/{2, 16}, /*wpcta=*/{4, 1},
+                     /*order=*/{1, 0});
+  auto mmaV2 = mma({2, 0}, {4, 1}, {8, 8});
+  auto dst = DotOperandEncodingAttr::get(&ctx, /*opIdx=*/1, mmaV2,
+                                         /*kWidth=*/1);
+  auto cta = mlir::triton::gpu::CGAEncodingAttr::get1CTALayout(&ctx, 2);
+  auto shared = SwizzledSharedEncodingAttr::get(
+      &ctx, dst, shape, /*order=*/{1, 0}, cta, /*typeWidthInBit=*/64);
+  EXPECT_EQ(shared.getVec(), 4);
+  EXPECT_EQ(shared.getPerPhase(), 1);
+  EXPECT_EQ(shared.getMaxPhase(), 4);
+  EXPECT_EQ(computeConflicts(shape, src, shared, /*bitwidth=*/64), 0);
+  EXPECT_EQ(computeConflicts(shape, dst, shared, /*bitwidth=*/64), 0);
+
+  auto srcLL =
+      actionRemoveBroadcastedRegs(toLL(shape, src)).apply(toLL(shape, src));
+  auto dstLL =
+      actionRemoveBroadcastedRegs(toLL(shape, dst)).apply(toLL(shape, dst));
+  auto optimal = optimalSwizzlingLdSt(srcLL, dstLL, /*bitwidth=*/64);
+  auto [readConflicts, writeConflicts] =
+      bankConflictsLdSt(srcLL, dstLL, optimal, /*bitwidth=*/64);
+  EXPECT_EQ(readConflicts, 0);
+  EXPECT_EQ(writeConflicts, 0);
+}
+
 TEST_F(SwizzleTest, Test16x256U4Mma) {
   // 16×256 u4 MMA
   LinearLayout blocked(


### PR DESCRIPTION
We use a different tile in this case, so we were creating intermediate
shared memory layouts with bank conflicts in the reduce-data-duplication
pass.

To be completly honest, I think we should see if we can just kill the
`reduce-data-duplication` pass as it predates the point when we had nice
bankconflict-free `convert_layout`s.
