### PR TITLE
Remove unused sphinx_rtd_theme import in docs/conf.py

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -31,7 +31,7 @@ from collections import defaultdict
 from itertools import count
 from pathlib import Path
 
-import sphinx_rtd_theme
+
 from myst_sphinx_gallery import GalleryConfig
 from sphinx_gallery.sorting import FileNameSortKey
 


### PR DESCRIPTION
## Problem Background
The `sphinx_rtd_theme` module is imported in `docs/conf.py` but is not used within the file. This unused import can trigger lint warnings (e.g., from flake8 or pylint), indicating dead code that should be cleaned up to maintain code quality and readability.

## Changes Made
- Removed the unused import statement `import sphinx_rtd_theme` from `docs/conf.py` to eliminate the lint warning and adhere to best practices for code cleanliness.

## Verification
- Run a linter (e.g., `flake8 docs/conf.py`) to confirm that the unused import warning is resolved.
- Ensure that the Sphinx documentation build (e.g., `make html` in the docs directory) completes successfully without errors, as the theme is likely configured elsewhere and not affected by this change.