### PR TITLE
[TritonGPU] Enable reshape of memdesc subviews

### DIFF
--- a/lib/Conversion/TritonGPUToLLVM/Utility.cpp
+++ b/lib/Conversion/TritonGPUToLLVM/Utility.cpp
@@ -1316,9 +1316,10 @@ SharedMemoryObject::getMaskSpanOffsets(triton::gpu::MemDescType srcTy) {
       triton::gpu::isPaddedEncoding(srcTy.getEncoding())
           ? triton::gpu::paddedLinearLayout(allocShape, srcTy.getEncoding())
           : triton::gpu::toLinearLayout(allocShape, srcTy.getEncoding());
-  auto dimNames = standardOutDimNames(ctx, shape.size());
-  // Map from dimNames to offset, block
+  // Map logical coordinates to physical offset and block coordinates.
   auto invLl = totalLl.pseudoinvert();
+  auto offsetIdx = invLl.getOutDimIndex(StringAttr::get(ctx, "offset"));
+  auto blockIdx = invLl.getOutDimIndex(StringAttr::get(ctx, "block"));
   SmallVector<std::pair<StringAttr, int32_t>> logicalOffsets;
   for (auto dim : standardOutDimNames(srcTy.getContext(), shape.size())) {
     logicalOffsets.push_back({dim, 0});
@@ -1329,9 +1330,9 @@ SharedMemoryObject::getMaskSpanOffsets(triton::gpu::MemDescType srcTy) {
     auto [shape, allocShape] = shapes;
     for (int j = llvm::Log2_32(shape); j < llvm::Log2_32(allocShape); ++j) {
       logicalOffsets[dim].second = 1 << j;
-      auto offsetAndBlock = invLl.apply(logicalOffsets);
-      ret |= offsetAndBlock[0].second;
-      assert(offsetAndBlock[1].second == 0);
+      auto physicalOffsets = invLl.apply(logicalOffsets);
+      ret |= physicalOffsets[offsetIdx].second;
+      assert(physicalOffsets[blockIdx].second == 0);
     }
     // Reset the offset for the next dimension
     logicalOffsets[dim].second = 0;
@@ -1368,10 +1369,10 @@ Value SharedMemoryObject::getShmemOffset(Location loc, RewriterBase &rewriter,
   // We don't allow for non-trivial block dimensions in the shared memory
   // layout. We have in practice that offsetAndBlock[1].second is zero, but we
   // cannot assert that without constant propagation so we just discard it.
-  auto offset =
-      applyLinearLayout(loc, rewriter, ll.pseudoinvert(), logicalOffsets)[0]
-          .second;
-  return offset;
+  auto invLl = ll.pseudoinvert();
+  auto offsetIdx = invLl.getOutDimIndex(StringAttr::get(ctx, "offset"));
+  return applyLinearLayout(loc, rewriter, invLl, logicalOffsets)[offsetIdx]
+      .second;
 }
 
 Value SharedMemoryObject::getShmemAffineBase(

--- a/lib/Conversion/TritonGPUToLLVM/ViewOpToLLVM.cpp
+++ b/lib/Conversion/TritonGPUToLLVM/ViewOpToLLVM.cpp
@@ -381,21 +381,30 @@ struct MemDescReshapeOpConversion
     auto srcSmemObj = getSharedMemoryObjectFromStruct(loc, adaptor.getSrc(),
                                                       llvmElemTy, rewriter);
     SmallVector<Value> offsets = srcSmemObj.getOffsets();
-    // FIXME: This should be done by composing a linear layout with its
-    // reshaped counterpart.
-    SmallVector<unsigned> srcShape;
-    for (int64_t d : op.getSrc().getType().getShape())
-      srcShape.push_back(d);
-    SmallVector<unsigned> dstShape;
-    for (int64_t d : op.getType().getShape())
-      dstShape.push_back(d);
-    Value linearOffset = LLVM::linearize(rewriter, loc, offsets, srcShape);
-    SmallVector<Value> delinearizedOffset =
-        LLVM::delinearize(rewriter, loc, linearOffset, dstShape);
-    auto b = TritonLLVMOpBuilder(loc, rewriter);
+    auto srcTy = op.getSrc().getType();
+    bool isSubview = srcTy.getAllocShape().take_back(srcTy.getRank()) !=
+                     srcTy.getShape();
+    SmallVector<Value> reshapedOffsets;
+    if (isSubview) {
+      auto coordinateTransform = toLinearLayout(srcTy).pseudoinvert().compose(
+          toLinearLayout(op.getType()));
+      SmallVector<std::pair<StringAttr, Value>> namedOffsets;
+      for (auto [dim, offset] : llvm::zip(
+               standardOutDimNames(op.getContext(), srcTy.getRank()), offsets))
+        namedOffsets.push_back({dim, offset});
+      auto transformed = applyLinearLayout(
+          loc, rewriter, coordinateTransform, namedOffsets);
+      reshapedOffsets = llvm::to_vector(llvm::make_second_range(transformed));
+    } else {
+      auto srcShape = convertType<unsigned>(srcTy.getShape());
+      auto dstShape = convertType<unsigned>(op.getType().getShape());
+      Value linearOffset = LLVM::linearize(rewriter, loc, offsets, srcShape);
+      reshapedOffsets =
+          LLVM::delinearize(rewriter, loc, linearOffset, dstShape);
+    }
     auto dstSmemObj =
         SharedMemoryObject(srcSmemObj.getBases(), srcSmemObj.getBaseElemType(),
-                           delinearizedOffset);
+                           reshapedOffsets);
     auto retVal = getStructFromSharedMemoryObject(loc, dstSmemObj, rewriter);
     rewriter.replaceOp(op, retVal);
     return success();

--- a/lib/Conversion/TritonGPUToLLVM/ViewOpToLLVM.cpp
+++ b/lib/Conversion/TritonGPUToLLVM/ViewOpToLLVM.cpp
@@ -382,8 +382,8 @@ struct MemDescReshapeOpConversion
                                                       llvmElemTy, rewriter);
     SmallVector<Value> offsets = srcSmemObj.getOffsets();
     auto srcTy = op.getSrc().getType();
-    bool isSubview = srcTy.getAllocShape().take_back(srcTy.getRank()) !=
-                     srcTy.getShape();
+    bool isSubview =
+        srcTy.getAllocShape().take_back(srcTy.getRank()) != srcTy.getShape();
     SmallVector<Value> reshapedOffsets;
     if (isSubview) {
       auto coordinateTransform = toLinearLayout(srcTy).pseudoinvert().compose(
@@ -392,8 +392,8 @@ struct MemDescReshapeOpConversion
       for (auto [dim, offset] : llvm::zip(
                standardOutDimNames(op.getContext(), srcTy.getRank()), offsets))
         namedOffsets.push_back({dim, offset});
-      auto transformed = applyLinearLayout(
-          loc, rewriter, coordinateTransform, namedOffsets);
+      auto transformed =
+          applyLinearLayout(loc, rewriter, coordinateTransform, namedOffsets);
       reshapedOffsets = llvm::to_vector(llvm::make_second_range(transformed));
     } else {
       auto srcShape = convertType<unsigned>(srcTy.getShape());
@@ -402,9 +402,8 @@ struct MemDescReshapeOpConversion
       reshapedOffsets =
           LLVM::delinearize(rewriter, loc, linearOffset, dstShape);
     }
-    auto dstSmemObj =
-        SharedMemoryObject(srcSmemObj.getBases(), srcSmemObj.getBaseElemType(),
-                           reshapedOffsets);
+    auto dstSmemObj = SharedMemoryObject(
+        srcSmemObj.getBases(), srcSmemObj.getBaseElemType(), reshapedOffsets);
     auto retVal = getStructFromSharedMemoryObject(loc, dstSmemObj, rewriter);
     rewriter.replaceOp(op, retVal);
     return success();

--- a/lib/Dialect/TritonGPU/IR/Dialect.cpp
+++ b/lib/Dialect/TritonGPU/IR/Dialect.cpp
@@ -4399,14 +4399,12 @@ LinearLayout triton::gpu::inferReshapeLinearLayout(TensorOrMemDesc srcTy,
   auto src = toLinearLayout(srcTy);
   assert(product(srcTy.getShape()) == product(dstShape));
   auto memDesc = dyn_cast<MemDescType>(srcTy);
-  if (!memDesc ||
-      memDesc.getAllocShape().take_back(memDesc.getRank()) ==
-          memDesc.getShape())
+  if (!memDesc || memDesc.getAllocShape().take_back(memDesc.getRank()) ==
+                      memDesc.getShape())
     return reshapeLayout(ctx, src, dstShape);
 
   auto srcShape = memDesc.getShape();
-  auto srcAllocShape =
-      memDesc.getAllocShape().take_back(memDesc.getRank());
+  auto srcAllocShape = memDesc.getAllocShape().take_back(memDesc.getRank());
   auto srcDimNames = standardOutDimNames(ctx, memDesc.getRank());
   LinearLayout transform = LinearLayout::empty();
   for (auto [dim, size] : llvm::zip(srcDimNames, srcShape))
@@ -4415,8 +4413,8 @@ LinearLayout triton::gpu::inferReshapeLinearLayout(TensorOrMemDesc srcTy,
 
   auto dstDim0 = standardOutDimNames(ctx, dstShape.size()).front();
   for (int dim = memDesc.getRank() - 1; dim >= 0; --dim)
-    transform *= LinearLayout::identity1D(
-        srcAllocShape[dim] / srcShape[dim], srcDimNames[dim], dstDim0);
+    transform *= LinearLayout::identity1D(srcAllocShape[dim] / srcShape[dim],
+                                          srcDimNames[dim], dstDim0);
   return src.compose(transform);
 }
 

--- a/lib/Dialect/TritonGPU/IR/Dialect.cpp
+++ b/lib/Dialect/TritonGPU/IR/Dialect.cpp
@@ -4398,8 +4398,26 @@ LinearLayout triton::gpu::inferReshapeLinearLayout(TensorOrMemDesc srcTy,
   auto *ctx = srcTy.getContext();
   auto src = toLinearLayout(srcTy);
   assert(product(srcTy.getShape()) == product(dstShape));
-  auto dst = reshapeLayout(ctx, src, dstShape);
-  return dst;
+  auto memDesc = dyn_cast<MemDescType>(srcTy);
+  if (!memDesc ||
+      memDesc.getAllocShape().take_back(memDesc.getRank()) ==
+          memDesc.getShape())
+    return reshapeLayout(ctx, src, dstShape);
+
+  auto srcShape = memDesc.getShape();
+  auto srcAllocShape =
+      memDesc.getAllocShape().take_back(memDesc.getRank());
+  auto srcDimNames = standardOutDimNames(ctx, memDesc.getRank());
+  LinearLayout transform = LinearLayout::empty();
+  for (auto [dim, size] : llvm::zip(srcDimNames, srcShape))
+    transform *= LinearLayout::identity1D(size, dim, dim);
+  transform = reshapeLayout(ctx, transform, dstShape);
+
+  auto dstDim0 = standardOutDimNames(ctx, dstShape.size()).front();
+  for (int dim = memDesc.getRank() - 1; dim >= 0; --dim)
+    transform *= LinearLayout::identity1D(
+        srcAllocShape[dim] / srcShape[dim], srcDimNames[dim], dstDim0);
+  return src.compose(transform);
 }
 
 // Helper function for im2col mode block shape calculation.

--- a/lib/Dialect/TritonGPU/IR/Ops.cpp
+++ b/lib/Dialect/TritonGPU/IR/Ops.cpp
@@ -628,8 +628,8 @@ static LogicalResult inferMemDescSubviewReshapeOpEncoding(
 
   if (isa<NVMMASharedEncodingAttr>(srcEnc)) {
     Attribute candidate;
-    if (succeeded(inferMemDescReshapeOpEncoding(
-            srcTy.getShape(), srcEnc, dstShape, candidate)) &&
+    if (succeeded(inferMemDescReshapeOpEncoding(srcTy.getShape(), srcEnc,
+                                                dstShape, candidate)) &&
         isa<NVMMASharedEncodingAttr>(candidate) &&
         toLinearLayout(dstAllocShape, candidate) == dstLayout) {
       dstEnc = candidate;
@@ -642,14 +642,13 @@ static LogicalResult inferMemDescSubviewReshapeOpEncoding(
     auto kPartition = StringAttr::get(ctx, "partition");
     for (auto [partitionDim, outDim] :
          llvm::enumerate(standardOutDimNames(ctx, dstAllocShape.size()))) {
-      if (dstAllocShape[partitionDim] %
-          partitioned.getNumLogicalPieces())
+      if (dstAllocShape[partitionDim] % partitioned.getNumLogicalPieces())
         continue;
 
-      auto pieces = LinearLayout::identity1D(
-          partitioned.getNumPartitions(), kPartition, outDim);
-      pieces *= LinearLayout::identity1D(partitioned.getNumGroups(), kOffset,
-                                         outDim);
+      auto pieces = LinearLayout::identity1D(partitioned.getNumPartitions(),
+                                             kPartition, outDim);
+      pieces *=
+          LinearLayout::identity1D(partitioned.getNumGroups(), kOffset, outDim);
       auto inner =
           divideRight(dstLayout, pieces.transposeIns({kOffset, kPartition}));
       if (!inner || inner->getInDimSize(kPartition) != 1)
@@ -666,9 +665,9 @@ static LogicalResult inferMemDescSubviewReshapeOpEncoding(
         return success();
       }
     }
-    return emitOptionalError(
-        loc, "memdesc subview reshape is not representable by "
-             "PartitionedSharedEncodingAttr");
+    return emitOptionalError(loc,
+                             "memdesc subview reshape is not representable by "
+                             "PartitionedSharedEncodingAttr");
   }
 
   dstEnc = SharedLinearEncodingAttr::get(
@@ -711,12 +710,11 @@ LogicalResult MemDescReshapeOp::inferReturnTypes(
                "allocation, and destination shapes");
     auto dstLayout =
         inferReshapeLinearLayout(cast<TensorOrMemDesc>(srcTy), dstShape);
-    if (failed(inferMemDescSubviewReshapeOpEncoding(
-            srcTy, dstShape, dstLayout, dstEncoding, loc)))
+    if (failed(inferMemDescSubviewReshapeOpEncoding(srcTy, dstShape, dstLayout,
+                                                    dstEncoding, loc)))
       return failure();
-    llvm::append_range(
-        dstAllocShape,
-        convertType<int64_t>(llvm::to_vector(dstLayout.getOutDimSizes())));
+    llvm::append_range(dstAllocShape, convertType<int64_t>(llvm::to_vector(
+                                          dstLayout.getOutDimSizes())));
   } else {
     if (Attribute srcEnc = srcTy.getEncoding()) {
       if (failed(inferMemDescReshapeOpEncoding(srcShape, srcEnc, dstShape,

--- a/lib/Dialect/TritonGPU/IR/Ops.cpp
+++ b/lib/Dialect/TritonGPU/IR/Ops.cpp
@@ -591,8 +591,7 @@ static LogicalResult inferMemDescReshapeOpEncoding(ArrayRef<int64_t> srcShape,
         auto dstLL = nvmmaSharedToLinearLayout(
             dstShape, candidateEncoding, TMAMode::Tiled,
             /*disableSwizzle=*/false, /*emitErrors=*/false);
-        if (succeeded(dstLL) &&
-            reshapeLayout(ctx, srcLL, dstShape) == *dstLL) {
+        if (succeeded(dstLL) && reshapeLayout(ctx, srcLL, dstShape) == *dstLL) {
           dstEnc = candidateEncoding;
           return success();
         }

--- a/lib/Dialect/TritonGPU/IR/Ops.cpp
+++ b/lib/Dialect/TritonGPU/IR/Ops.cpp
@@ -559,11 +559,6 @@ LogicalResult MemDescReshapeOp::verify() {
   if (dstType.getElementType() != srcType.getElementType()) {
     return emitError("result element type must match src element type");
   }
-  auto srcShape = srcType.getShape();
-  if (srcType.getAllocShape().take_back(srcShape.size()) != srcShape) {
-    return emitError("NYI: memdesc_reshape of memdesc_subslice");
-  }
-
   MemDescType expectedTy;
   if (failed(inferReturnTypes(getContext(), getLoc(), srcType,
                               dstType.getShape(), expectedTy)))
@@ -622,6 +617,65 @@ static LogicalResult inferMemDescReshapeOpEncoding(ArrayRef<int64_t> srcShape,
   return success();
 }
 
+static LogicalResult inferMemDescSubviewReshapeOpEncoding(
+    MemDescType srcTy, ArrayRef<int64_t> dstShape,
+    const LinearLayout &dstLayout, Attribute &dstEnc,
+    std::optional<Location> loc) {
+  auto srcEnc = srcTy.getEncoding();
+  auto *ctx = srcTy.getContext();
+  auto dstAllocShape =
+      convertType<int64_t>(llvm::to_vector(dstLayout.getOutDimSizes()));
+
+  if (isa<NVMMASharedEncodingAttr>(srcEnc)) {
+    Attribute candidate;
+    if (succeeded(inferMemDescReshapeOpEncoding(
+            srcTy.getShape(), srcEnc, dstShape, candidate)) &&
+        isa<NVMMASharedEncodingAttr>(candidate) &&
+        toLinearLayout(dstAllocShape, candidate) == dstLayout) {
+      dstEnc = candidate;
+      return success();
+    }
+  }
+
+  if (auto partitioned = dyn_cast<PartitionedSharedEncodingAttr>(srcEnc)) {
+    auto kOffset = StringAttr::get(ctx, "offset");
+    auto kPartition = StringAttr::get(ctx, "partition");
+    for (auto [partitionDim, outDim] :
+         llvm::enumerate(standardOutDimNames(ctx, dstAllocShape.size()))) {
+      if (dstAllocShape[partitionDim] %
+          partitioned.getNumLogicalPieces())
+        continue;
+
+      auto pieces = LinearLayout::identity1D(
+          partitioned.getNumPartitions(), kPartition, outDim);
+      pieces *= LinearLayout::identity1D(partitioned.getNumGroups(), kOffset,
+                                         outDim);
+      auto inner =
+          divideRight(dstLayout, pieces.transposeIns({kOffset, kPartition}));
+      if (!inner || inner->getInDimSize(kPartition) != 1)
+        continue;
+
+      auto innerEnc = SharedLinearEncodingAttr::get(
+          ctx, inner->squeezeIns(kPartition),
+          partitioned.getPartitionLayout().getAlignment());
+      auto candidate = PartitionedSharedEncodingAttr::get(
+          ctx, partitioned.getNumPartitions(), partitioned.getNumGroups(),
+          partitionDim, innerEnc);
+      if (toLinearLayout(dstAllocShape, candidate) == dstLayout) {
+        dstEnc = candidate;
+        return success();
+      }
+    }
+    return emitOptionalError(
+        loc, "memdesc subview reshape is not representable by "
+             "PartitionedSharedEncodingAttr");
+  }
+
+  dstEnc = SharedLinearEncodingAttr::get(
+      ctx, dstLayout, cast<SharedEncodingTrait>(srcEnc).getAlignment());
+  return success();
+}
+
 LogicalResult MemDescReshapeOp::inferReturnTypes(
     MLIRContext *context, std::optional<Location> loc, MemDescType srcTy,
     ArrayRef<int64_t> dstShape, MemDescType &inferredReturnType) {
@@ -630,16 +684,47 @@ LogicalResult MemDescReshapeOp::inferReturnTypes(
         loc, "dst shape has different number of elements than src");
 
   Attribute dstEncoding;
-  if (Attribute srcEnc = srcTy.getEncoding()) {
-    if (failed(inferMemDescReshapeOpEncoding(srcTy.getShape(), srcEnc, dstShape,
-                                             dstEncoding)))
-      return failure();
-  }
-
+  auto srcShape = srcTy.getShape();
+  auto srcAllocShape = srcTy.getAllocShape().take_back(srcTy.getRank());
   SmallVector<int64_t> dstAllocShape =
-      to_vector(srcTy.getAllocShape().take_front(srcTy.getAllocShape().size() -
-                                                 srcTy.getShape().size()));
-  dstAllocShape.append(dstShape.begin(), dstShape.end());
+      to_vector(srcTy.getAllocShape().drop_back(srcTy.getRank()));
+  bool isSubview = srcAllocShape != srcShape;
+  if (isSubview) {
+    if (!isa_and_nonnull<SharedEncodingTrait>(srcTy.getEncoding()))
+      return emitOptionalError(
+          loc, "memdesc subview reshape requires a shared memory encoding");
+    if (isPaddedEncoding(srcTy.getEncoding()))
+      return emitOptionalError(
+          loc, "memdesc reshape of padded shared memory subviews is not "
+               "supported");
+    if (cast<LayoutEncodingTrait>(srcTy.getEncoding()).getRank() !=
+        srcTy.getRank())
+      return emitOptionalError(
+          loc, "memdesc subview reshape requires the layout rank to match "
+               "the memdesc rank");
+
+    if (!llvm::all_of(srcShape, llvm::isPowerOf2_64) ||
+        !llvm::all_of(srcAllocShape, llvm::isPowerOf2_64) ||
+        !llvm::all_of(dstShape, llvm::isPowerOf2_64))
+      return emitOptionalError(
+          loc, "memdesc subview reshape requires power-of-two source, "
+               "allocation, and destination shapes");
+    auto dstLayout =
+        inferReshapeLinearLayout(cast<TensorOrMemDesc>(srcTy), dstShape);
+    if (failed(inferMemDescSubviewReshapeOpEncoding(
+            srcTy, dstShape, dstLayout, dstEncoding, loc)))
+      return failure();
+    llvm::append_range(
+        dstAllocShape,
+        convertType<int64_t>(llvm::to_vector(dstLayout.getOutDimSizes())));
+  } else {
+    if (Attribute srcEnc = srcTy.getEncoding()) {
+      if (failed(inferMemDescReshapeOpEncoding(srcShape, srcEnc, dstShape,
+                                               dstEncoding)))
+        return failure();
+    }
+    llvm::append_range(dstAllocShape, dstShape);
+  }
 
   inferredReturnType = MemDescType::get(
       dstShape, srcTy.getElementType(), dstEncoding, srcTy.getMemorySpace(),

--- a/lib/Dialect/TritonGPU/IR/Ops.cpp
+++ b/lib/Dialect/TritonGPU/IR/Ops.cpp
@@ -625,59 +625,34 @@ LogicalResult MemDescReshapeOp::inferReturnTypes(
         loc, "dst shape has different number of elements than src");
 
   Attribute dstEncoding;
+  auto srcEnc = srcTy.getEncoding();
   auto srcShape = srcTy.getShape();
-  auto srcAllocShape = srcTy.getAllocShape().take_back(srcTy.getRank());
-  SmallVector<int64_t> dstAllocShape =
-      to_vector(srcTy.getAllocShape().drop_back(srcTy.getRank()));
-  bool isSubview = srcAllocShape != srcShape;
-  if (isSubview) {
-    auto srcEnc = srcTy.getEncoding();
-    if (!isa_and_nonnull<SharedEncodingTrait>(srcEnc))
-      return emitOptionalError(
-          loc, "memdesc subview reshape requires a shared memory encoding");
-    if (isa<PartitionedSharedEncodingAttr>(srcEnc))
-      return emitOptionalError(
-          loc, "memdesc reshape of partitioned shared memory subviews is not "
-               "supported");
-    if (isPaddedEncoding(srcEnc))
-      return emitOptionalError(
-          loc, "memdesc reshape of padded shared memory subviews is not "
-               "supported");
-    if (cast<LayoutEncodingTrait>(srcEnc).getRank() != srcTy.getRank())
-      return emitOptionalError(
-          loc, "memdesc subview reshape requires the layout rank to match "
-               "the memdesc rank");
+  bool isSubview = srcTy.getAllocShape().take_back(srcTy.getRank()) != srcShape;
+  if (isSubview &&
+      (!isa_and_nonnull<SharedEncodingTrait>(srcEnc) ||
+       isa<PartitionedSharedEncodingAttr, PaddedSharedEncodingAttr>(srcEnc) ||
+       cast<LayoutEncodingTrait>(srcEnc).getRank() != srcTy.getRank()))
+    return emitOptionalError(loc, "unsupported memdesc subview reshape");
+  if (srcEnc && (!isSubview || isa<NVMMASharedEncodingAttr>(srcEnc)) &&
+      failed(inferMemDescReshapeOpEncoding(srcShape, srcEnc, dstShape,
+                                           dstEncoding)))
+    return failure();
 
-    if (!llvm::all_of(srcShape, llvm::isPowerOf2_64) ||
-        !llvm::all_of(srcAllocShape, llvm::isPowerOf2_64) ||
-        !llvm::all_of(dstShape, llvm::isPowerOf2_64))
-      return emitOptionalError(
-          loc, "memdesc subview reshape requires power-of-two source, "
-               "allocation, and destination shapes");
+  auto dstAllocSuffix = to_vector(dstShape);
+  if (isSubview) {
     auto dstLayout =
         inferReshapeLinearLayout(cast<TensorOrMemDesc>(srcTy), dstShape);
-    auto dstLayoutShape =
+    dstAllocSuffix =
         convertType<int64_t>(llvm::to_vector(dstLayout.getOutDimSizes()));
-    if (isa<NVMMASharedEncodingAttr>(srcEnc)) {
-      Attribute candidate;
-      if (succeeded(inferMemDescReshapeOpEncoding(srcShape, srcEnc, dstShape,
-                                                  candidate)) &&
-          isa<NVMMASharedEncodingAttr>(candidate) &&
-          toLinearLayout(dstLayoutShape, candidate) == dstLayout)
-        dstEncoding = candidate;
-    }
-    if (!dstEncoding)
+    if (!isa_and_nonnull<NVMMASharedEncodingAttr>(dstEncoding) ||
+        toLinearLayout(dstAllocSuffix, dstEncoding) != dstLayout)
       dstEncoding = SharedLinearEncodingAttr::get(
           context, dstLayout, cast<SharedEncodingTrait>(srcEnc).getAlignment());
-    llvm::append_range(dstAllocShape, dstLayoutShape);
-  } else {
-    if (Attribute srcEnc = srcTy.getEncoding()) {
-      if (failed(inferMemDescReshapeOpEncoding(srcShape, srcEnc, dstShape,
-                                               dstEncoding)))
-        return failure();
-    }
-    llvm::append_range(dstAllocShape, dstShape);
   }
+
+  auto dstAllocShape =
+      to_vector(srcTy.getAllocShape().drop_back(srcTy.getRank()));
+  llvm::append_range(dstAllocShape, dstAllocSuffix);
 
   inferredReturnType = MemDescType::get(
       dstShape, srcTy.getElementType(), dstEncoding, srcTy.getMemorySpace(),

--- a/lib/Dialect/TritonGPU/IR/Ops.cpp
+++ b/lib/Dialect/TritonGPU/IR/Ops.cpp
@@ -588,8 +588,11 @@ static LogicalResult inferMemDescReshapeOpEncoding(ArrayRef<int64_t> srcShape,
             mmaEncoding.getTransposed(), mmaEncoding.getElementBitWidth(),
             mmaEncoding.getFp4Padded(), CGALayout);
         auto srcLL = toLinearLayout(srcShape, srcEnc);
-        auto dstLL = toLinearLayout(dstShape, candidateEncoding);
-        if (reshapeLayout(ctx, srcLL, dstShape) == dstLL) {
+        auto dstLL = nvmmaSharedToLinearLayout(
+            dstShape, candidateEncoding, TMAMode::Tiled,
+            /*disableSwizzle=*/false, /*emitErrors=*/false);
+        if (succeeded(dstLL) &&
+            reshapeLayout(ctx, srcLL, dstShape) == *dstLL) {
           dstEnc = candidateEncoding;
           return success();
         }

--- a/lib/Dialect/TritonGPU/IR/Ops.cpp
+++ b/lib/Dialect/TritonGPU/IR/Ops.cpp
@@ -617,64 +617,6 @@ static LogicalResult inferMemDescReshapeOpEncoding(ArrayRef<int64_t> srcShape,
   return success();
 }
 
-static LogicalResult inferMemDescSubviewReshapeOpEncoding(
-    MemDescType srcTy, ArrayRef<int64_t> dstShape,
-    const LinearLayout &dstLayout, Attribute &dstEnc,
-    std::optional<Location> loc) {
-  auto srcEnc = srcTy.getEncoding();
-  auto *ctx = srcTy.getContext();
-  auto dstAllocShape =
-      convertType<int64_t>(llvm::to_vector(dstLayout.getOutDimSizes()));
-
-  if (isa<NVMMASharedEncodingAttr>(srcEnc)) {
-    Attribute candidate;
-    if (succeeded(inferMemDescReshapeOpEncoding(srcTy.getShape(), srcEnc,
-                                                dstShape, candidate)) &&
-        isa<NVMMASharedEncodingAttr>(candidate) &&
-        toLinearLayout(dstAllocShape, candidate) == dstLayout) {
-      dstEnc = candidate;
-      return success();
-    }
-  }
-
-  if (auto partitioned = dyn_cast<PartitionedSharedEncodingAttr>(srcEnc)) {
-    auto kOffset = StringAttr::get(ctx, "offset");
-    auto kPartition = StringAttr::get(ctx, "partition");
-    for (auto [partitionDim, outDim] :
-         llvm::enumerate(standardOutDimNames(ctx, dstAllocShape.size()))) {
-      if (dstAllocShape[partitionDim] % partitioned.getNumLogicalPieces())
-        continue;
-
-      auto pieces = LinearLayout::identity1D(partitioned.getNumPartitions(),
-                                             kPartition, outDim);
-      pieces *=
-          LinearLayout::identity1D(partitioned.getNumGroups(), kOffset, outDim);
-      auto inner =
-          divideRight(dstLayout, pieces.transposeIns({kOffset, kPartition}));
-      if (!inner || inner->getInDimSize(kPartition) != 1)
-        continue;
-
-      auto innerEnc = SharedLinearEncodingAttr::get(
-          ctx, inner->squeezeIns(kPartition),
-          partitioned.getPartitionLayout().getAlignment());
-      auto candidate = PartitionedSharedEncodingAttr::get(
-          ctx, partitioned.getNumPartitions(), partitioned.getNumGroups(),
-          partitionDim, innerEnc);
-      if (toLinearLayout(dstAllocShape, candidate) == dstLayout) {
-        dstEnc = candidate;
-        return success();
-      }
-    }
-    return emitOptionalError(loc,
-                             "memdesc subview reshape is not representable by "
-                             "PartitionedSharedEncodingAttr");
-  }
-
-  dstEnc = SharedLinearEncodingAttr::get(
-      ctx, dstLayout, cast<SharedEncodingTrait>(srcEnc).getAlignment());
-  return success();
-}
-
 LogicalResult MemDescReshapeOp::inferReturnTypes(
     MLIRContext *context, std::optional<Location> loc, MemDescType srcTy,
     ArrayRef<int64_t> dstShape, MemDescType &inferredReturnType) {
@@ -689,15 +631,19 @@ LogicalResult MemDescReshapeOp::inferReturnTypes(
       to_vector(srcTy.getAllocShape().drop_back(srcTy.getRank()));
   bool isSubview = srcAllocShape != srcShape;
   if (isSubview) {
-    if (!isa_and_nonnull<SharedEncodingTrait>(srcTy.getEncoding()))
+    auto srcEnc = srcTy.getEncoding();
+    if (!isa_and_nonnull<SharedEncodingTrait>(srcEnc))
       return emitOptionalError(
           loc, "memdesc subview reshape requires a shared memory encoding");
-    if (isPaddedEncoding(srcTy.getEncoding()))
+    if (isa<PartitionedSharedEncodingAttr>(srcEnc))
+      return emitOptionalError(
+          loc, "memdesc reshape of partitioned shared memory subviews is not "
+               "supported");
+    if (isPaddedEncoding(srcEnc))
       return emitOptionalError(
           loc, "memdesc reshape of padded shared memory subviews is not "
                "supported");
-    if (cast<LayoutEncodingTrait>(srcTy.getEncoding()).getRank() !=
-        srcTy.getRank())
+    if (cast<LayoutEncodingTrait>(srcEnc).getRank() != srcTy.getRank())
       return emitOptionalError(
           loc, "memdesc subview reshape requires the layout rank to match "
                "the memdesc rank");
@@ -710,11 +656,20 @@ LogicalResult MemDescReshapeOp::inferReturnTypes(
                "allocation, and destination shapes");
     auto dstLayout =
         inferReshapeLinearLayout(cast<TensorOrMemDesc>(srcTy), dstShape);
-    if (failed(inferMemDescSubviewReshapeOpEncoding(srcTy, dstShape, dstLayout,
-                                                    dstEncoding, loc)))
-      return failure();
-    llvm::append_range(dstAllocShape, convertType<int64_t>(llvm::to_vector(
-                                          dstLayout.getOutDimSizes())));
+    auto dstLayoutShape =
+        convertType<int64_t>(llvm::to_vector(dstLayout.getOutDimSizes()));
+    if (isa<NVMMASharedEncodingAttr>(srcEnc)) {
+      Attribute candidate;
+      if (succeeded(inferMemDescReshapeOpEncoding(srcShape, srcEnc, dstShape,
+                                                  candidate)) &&
+          isa<NVMMASharedEncodingAttr>(candidate) &&
+          toLinearLayout(dstLayoutShape, candidate) == dstLayout)
+        dstEncoding = candidate;
+    }
+    if (!dstEncoding)
+      dstEncoding = SharedLinearEncodingAttr::get(
+          context, dstLayout, cast<SharedEncodingTrait>(srcEnc).getAlignment());
+    llvm::append_range(dstAllocShape, dstLayoutShape);
   } else {
     if (Attribute srcEnc = srcTy.getEncoding()) {
       if (failed(inferMemDescReshapeOpEncoding(srcShape, srcEnc, dstShape,

--- a/lib/Dialect/TritonGPU/IR/Traits.cpp
+++ b/lib/Dialect/TritonGPU/IR/Traits.cpp
@@ -34,9 +34,15 @@ LogicalResult OpTrait::impl::verifyEquivalentMemDescType(Type typeA,
   if (static_cast<bool>(encodingA) != static_cast<bool>(encodingB))
     return failure();
 
+  auto layoutA = cast<LayoutEncodingTrait>(encodingA);
+  auto layoutB = cast<LayoutEncodingTrait>(encodingB);
+  if (layoutA.getRank() != layoutB.getRank())
+    return failure();
+
   auto layoutInterface =
       cast<triton::DialectInferLayoutInterface>(&encodingA.getDialect());
-  return layoutInterface->verifyLayoutsAreEqual(memdescA.getShape(), encodingA,
+  auto layoutShape = memdescA.getAllocShape().take_back(layoutA.getRank());
+  return layoutInterface->verifyLayoutsAreEqual(layoutShape, encodingA,
                                                 encodingB, {});
 }
 

--- a/python/src/gluon_ir.cc
+++ b/python/src/gluon_ir.cc
@@ -607,8 +607,7 @@ void init_gluon_ir(py::module &&m) {
              return layoutToGluon(ty.getEncoding());
            })
       .def("get_alloc_shape_from_memdesc",
-           [](GluonOpBuilder &self,
-              Value memdesc) -> std::vector<int64_t> {
+           [](GluonOpBuilder &self, Value memdesc) -> std::vector<int64_t> {
              auto ty = cast<ttg::MemDescType>(memdesc.getType());
              return {ty.getAllocShape().begin(), ty.getAllocShape().end()};
            })

--- a/python/src/gluon_ir.cc
+++ b/python/src/gluon_ir.cc
@@ -606,6 +606,12 @@ void init_gluon_ir(py::module &&m) {
              check(ty.getEncoding(), "expected a memdesc with an encoding");
              return layoutToGluon(ty.getEncoding());
            })
+      .def("get_alloc_shape_from_memdesc",
+           [](GluonOpBuilder &self,
+              Value memdesc) -> std::vector<int64_t> {
+             auto ty = cast<ttg::MemDescType>(memdesc.getType());
+             return {ty.getAllocShape().begin(), ty.getAllocShape().end()};
+           })
       .def("get_tensor_descriptor_layout_type",
            [](GluonOpBuilder &self, Type blockType, bool isSigned,
               Attribute layout) -> Type {

--- a/python/test/gluon/test_core.py
+++ b/python/test/gluon/test_core.py
@@ -2159,6 +2159,167 @@ def test_padded_shared_layout_subslice(interval_pairs, shared_layout, slice_m_of
     assert (output == ref_output).all()
 
 
+@gluon.jit
+def _make_2d_offsets(rows: ttgl.constexpr, cols: ttgl.constexpr, stride: ttgl.constexpr,
+                     layout: ttgl.constexpr):
+    row = ttgl.arange(0, rows, ttgl.SliceLayout(1, layout))
+    col = ttgl.arange(0, cols, ttgl.SliceLayout(0, layout))
+    return row[:, None] * stride + col[None, :]
+
+
+def test_shared_memory_subview_reshape():
+    m = 8
+    n = 16
+    num_warps = 1
+    layout = ttgl.BlockedLayout([1, 1], [4, THREADS_PER_WARP // 4], [1, 1], [1, 0])
+    shared_layout = ttgl.SwizzledSharedLayout(1, 1, 1, [1, 0])
+
+    @gluon.jit
+    def kernel(in_ptr, out_ptr, M: ttgl.constexpr, N: ttgl.constexpr, layout: ttgl.constexpr,
+               shared_layout: ttgl.constexpr):
+        offsets = _make_2d_offsets(M, N, N, layout)
+
+        smem = ttgl.allocate_shared_memory(ttgl.int32, [M, N], shared_layout)
+        smem.store(ttgl.load(in_ptr + offsets))
+        reshaped = smem.slice(N // 2, N // 2, dim=1).reshape([M // 2, N])
+
+        out_offsets = _make_2d_offsets(M // 2, N, N, layout)
+        ttgl.store(out_ptr + out_offsets, reshaped.load(layout))
+
+    input = torch.arange(m * n, device="cuda", dtype=torch.int32).reshape(m, n)
+    output = torch.empty((m // 2, n), device="cuda", dtype=torch.int32)
+
+    kernel[(1, )](input, output, m, n, layout, shared_layout, num_warps=num_warps)
+
+    torch.testing.assert_close(output, input[:, n // 2:].reshape(m // 2, n))
+
+
+def test_shared_memory_subview_reshape_chained_gaps_linear_layout():
+    shape = (16, 32)
+    offsets = (8, 16)
+    slice_shape = (8, 16)
+    mid_shape = (4, 32)
+    dst_shape = (2, 64)
+    num_warps = 1
+    layout = ttgl.BlockedLayout([1, 1], [4, THREADS_PER_WARP // 4], [1, 1], [1, 0])
+    shared_layout = ttgl.SharedLinearLayout(
+        offset_bases=[[0, 1], [1, 0], [0, 2], [2, 0], [0, 4], [4, 0], [0, 8], [8, 0], [0, 16]])
+
+    @gluon.jit
+    def kernel(in_ptr, view_out_ptr, parent_out_ptr, M: ttgl.constexpr, N: ttgl.constexpr,
+               SLICE_M_OFFSET: ttgl.constexpr, SLICE_N_OFFSET: ttgl.constexpr, SLICE_M: ttgl.constexpr,
+               SLICE_N: ttgl.constexpr, MID_M: ttgl.constexpr, MID_N: ttgl.constexpr, DST_M: ttgl.constexpr,
+               DST_N: ttgl.constexpr, layout: ttgl.constexpr, shared_layout: ttgl.constexpr):
+        src_offsets = _make_2d_offsets(M, N, N, layout)
+
+        smem = ttgl.allocate_shared_memory(ttgl.int32, [M, N], shared_layout)
+        smem.store(ttgl.load(in_ptr + src_offsets))
+        view = smem.slice(SLICE_M_OFFSET, SLICE_M, dim=0).slice(SLICE_N_OFFSET, SLICE_N, dim=1)
+        reshaped = view.reshape([MID_M, MID_N]).reshape([DST_M, DST_N])
+        other = smem.slice(0, SLICE_M, dim=0).slice(0, SLICE_N, dim=1).reshape([DST_M, DST_N])
+
+        out_offsets = _make_2d_offsets(DST_M, DST_N, DST_N, layout)
+        ttgl.store(view_out_ptr + out_offsets, reshaped.load(layout))
+
+        replacement = _make_2d_offsets(DST_M, DST_N, 1000, layout)
+        reshaped.store(replacement)
+        other.store(-replacement - 1)
+        ttgl.store(parent_out_ptr + src_offsets, smem.load(layout))
+
+    input = torch.arange(math.prod(shape), device="cuda", dtype=torch.int32).reshape(shape)
+    view_output = torch.empty(dst_shape, device="cuda", dtype=torch.int32)
+    parent_output = torch.empty_like(input)
+
+    kernel[(1, )](input, view_output, parent_output, *shape, *offsets, *slice_shape, *mid_shape, *dst_shape, layout,
+                  shared_layout, num_warps=num_warps)
+
+    torch.testing.assert_close(
+        view_output,
+        input[offsets[0]:offsets[0] + slice_shape[0], offsets[1]:offsets[1] + slice_shape[1]].reshape(dst_shape),
+    )
+    replacement = (torch.arange(dst_shape[0], device="cuda", dtype=torch.int32)[:, None] * 1000 +
+                   torch.arange(dst_shape[1], device="cuda", dtype=torch.int32)[None, :])
+    expected_parent = input.clone()
+    expected_parent[:slice_shape[0], :slice_shape[1]] = (-replacement - 1).reshape(slice_shape)
+    expected_parent[offsets[0]:offsets[0] + slice_shape[0],
+                    offsets[1]:offsets[1] + slice_shape[1]] = replacement.reshape(slice_shape)
+    torch.testing.assert_close(parent_output, expected_parent)
+
+
+def test_shared_memory_subview_reshape_rank_change_with_3d_gaps():
+    src_shape = (8, 16, 32)
+    offsets = (4, 8, 16)
+    slice_shape = (4, 8, 16)
+    dst_shape = (16, 32)
+    num_warps = 4
+    src_layout = ttgl.BlockedLayout([1, 1, 4], [8, THREADS_PER_WARP // 8, 1], [2, 1, 2], [1, 2, 0])
+    dst_layout = ttgl.BlockedLayout([1, 1], [4, THREADS_PER_WARP // 4], [4, 1], [1, 0])
+    shared_layout = ttgl.SwizzledSharedLayout(vec=4, per_phase=2, max_phase=4, order=[1, 2, 0])
+
+    @gluon.jit
+    def kernel(in_ptr, out_ptr, D0: ttgl.constexpr, D1: ttgl.constexpr, D2: ttgl.constexpr,
+               OFFSET0: ttgl.constexpr, OFFSET1: ttgl.constexpr, OFFSET2: ttgl.constexpr, SLICE0: ttgl.constexpr,
+               SLICE1: ttgl.constexpr, SLICE2: ttgl.constexpr, DST0: ttgl.constexpr, DST1: ttgl.constexpr,
+               src_layout: ttgl.constexpr, dst_layout: ttgl.constexpr, shared_layout: ttgl.constexpr):
+        src_i = ttgl.arange(0, D0, ttgl.SliceLayout(1, ttgl.SliceLayout(2, src_layout)))
+        src_j = ttgl.arange(0, D1, ttgl.SliceLayout(0, ttgl.SliceLayout(2, src_layout)))
+        src_k = ttgl.arange(0, D2, ttgl.SliceLayout(0, ttgl.SliceLayout(1, src_layout)))
+        src_offsets = src_i[:, None, None] * D1 * D2 + src_j[None, :, None] * D2 + src_k[None, None, :]
+
+        smem = ttgl.allocate_shared_memory(ttgl.int32, [D0, D1, D2], shared_layout)
+        smem.store(ttgl.load(in_ptr + src_offsets))
+        view = smem.slice(OFFSET0, SLICE0, dim=0)
+        view = view.slice(OFFSET1, SLICE1, dim=1)
+        view = view.slice(OFFSET2, SLICE2, dim=2)
+        reshaped = view.reshape([1, SLICE0, SLICE1, SLICE2]).reshape([DST0, DST1])
+
+        dst_offsets = _make_2d_offsets(DST0, DST1, DST1, dst_layout)
+        ttgl.store(out_ptr + dst_offsets, reshaped.load(dst_layout))
+
+    input = torch.arange(math.prod(src_shape), device="cuda", dtype=torch.int32).reshape(src_shape)
+    output = torch.empty(dst_shape, device="cuda", dtype=torch.int32)
+
+    kernel[(1, )](input, output, *src_shape, *offsets, *slice_shape, *dst_shape, src_layout, dst_layout,
+                  shared_layout, num_warps=num_warps)
+
+    expected = input[offsets[0]:offsets[0] + slice_shape[0], offsets[1]:offsets[1] + slice_shape[1],
+                     offsets[2]:offsets[2] + slice_shape[2]].reshape(dst_shape)
+    torch.testing.assert_close(output, expected)
+
+
+def test_shared_memory_index_subview_repeated_reshape():
+    buffers = 2
+    m = 8
+    n = 16
+    index = 1
+    num_warps = 1
+    layout = ttgl.BlockedLayout([1, 1], [4, THREADS_PER_WARP // 4], [1, 1], [1, 0])
+    shared_layout = ttgl.SwizzledSharedLayout(vec=4, per_phase=2, max_phase=4, order=[1, 0])
+
+    @gluon.jit
+    def kernel(in_ptr, out_ptr, index, BUFFERS: ttgl.constexpr, M: ttgl.constexpr, N: ttgl.constexpr,
+               layout: ttgl.constexpr, shared_layout: ttgl.constexpr):
+        offsets = _make_2d_offsets(M, N, N, layout)
+
+        smem = ttgl.allocate_shared_memory(ttgl.int32, [BUFFERS, M, N], shared_layout)
+        for buffer in ttgl.static_range(BUFFERS):
+            values = ttgl.load(in_ptr + buffer * M * N + offsets)
+            smem.index(buffer).store(values)
+
+        view = smem.index(index).slice(N // 2, N // 2, dim=1)
+        reshaped = view.reshape([1, 2, 2, 16]).reshape([M // 2, N])
+
+        out_offsets = _make_2d_offsets(M // 2, N, N, layout)
+        ttgl.store(out_ptr + out_offsets, reshaped.load(layout))
+
+    input = torch.arange(buffers * m * n, device="cuda", dtype=torch.int32).reshape(buffers, m, n)
+    output = torch.empty((m // 2, n), device="cuda", dtype=torch.int32)
+
+    kernel[(1, )](input, output, index, buffers, m, n, layout, shared_layout, num_warps=num_warps)
+
+    torch.testing.assert_close(output, input[index, :, n // 2:].reshape(m // 2, n))
+
+
 @pytest.mark.skipif(not is_blackwell(), reason="Requires Blackwell")
 @pytest.mark.parametrize("op, tol", [("add", 0), ("sub", 0), ("mul", 0), ("fma", 1e-6)])
 def test_float2(op, tol):

--- a/python/test/gluon/test_core.py
+++ b/python/test/gluon/test_core.py
@@ -2160,8 +2160,7 @@ def test_padded_shared_layout_subslice(interval_pairs, shared_layout, slice_m_of
 
 
 @gluon.jit
-def _make_2d_offsets(rows: ttgl.constexpr, cols: ttgl.constexpr, stride: ttgl.constexpr,
-                     layout: ttgl.constexpr):
+def _make_2d_offsets(rows: ttgl.constexpr, cols: ttgl.constexpr, stride: ttgl.constexpr, layout: ttgl.constexpr):
     row = ttgl.arange(0, rows, ttgl.SliceLayout(1, layout))
     col = ttgl.arange(0, cols, ttgl.SliceLayout(0, layout))
     return row[:, None] * stride + col[None, :]
@@ -2257,10 +2256,10 @@ def test_shared_memory_subview_reshape_rank_change_with_3d_gaps():
     shared_layout = ttgl.SwizzledSharedLayout(vec=4, per_phase=2, max_phase=4, order=[1, 2, 0])
 
     @gluon.jit
-    def kernel(in_ptr, out_ptr, D0: ttgl.constexpr, D1: ttgl.constexpr, D2: ttgl.constexpr,
-               OFFSET0: ttgl.constexpr, OFFSET1: ttgl.constexpr, OFFSET2: ttgl.constexpr, SLICE0: ttgl.constexpr,
-               SLICE1: ttgl.constexpr, SLICE2: ttgl.constexpr, DST0: ttgl.constexpr, DST1: ttgl.constexpr,
-               src_layout: ttgl.constexpr, dst_layout: ttgl.constexpr, shared_layout: ttgl.constexpr):
+    def kernel(in_ptr, out_ptr, D0: ttgl.constexpr, D1: ttgl.constexpr, D2: ttgl.constexpr, OFFSET0: ttgl.constexpr,
+               OFFSET1: ttgl.constexpr, OFFSET2: ttgl.constexpr, SLICE0: ttgl.constexpr, SLICE1: ttgl.constexpr,
+               SLICE2: ttgl.constexpr, DST0: ttgl.constexpr, DST1: ttgl.constexpr, src_layout: ttgl.constexpr,
+               dst_layout: ttgl.constexpr, shared_layout: ttgl.constexpr):
         src_i = ttgl.arange(0, D0, ttgl.SliceLayout(1, ttgl.SliceLayout(2, src_layout)))
         src_j = ttgl.arange(0, D1, ttgl.SliceLayout(0, ttgl.SliceLayout(2, src_layout)))
         src_k = ttgl.arange(0, D2, ttgl.SliceLayout(0, ttgl.SliceLayout(1, src_layout)))
@@ -2279,8 +2278,8 @@ def test_shared_memory_subview_reshape_rank_change_with_3d_gaps():
     input = torch.arange(math.prod(src_shape), device="cuda", dtype=torch.int32).reshape(src_shape)
     output = torch.empty(dst_shape, device="cuda", dtype=torch.int32)
 
-    kernel[(1, )](input, output, *src_shape, *offsets, *slice_shape, *dst_shape, src_layout, dst_layout,
-                  shared_layout, num_warps=num_warps)
+    kernel[(1, )](input, output, *src_shape, *offsets, *slice_shape, *dst_shape, src_layout, dst_layout, shared_layout,
+                  num_warps=num_warps)
 
     expected = input[offsets[0]:offsets[0] + slice_shape[0], offsets[1]:offsets[1] + slice_shape[1],
                      offsets[2]:offsets[2] + slice_shape[2]].reshape(dst_shape)

--- a/python/test/gluon/test_frontend.py
+++ b/python/test/gluon/test_frontend.py
@@ -328,9 +328,9 @@ def shared_memory_subview_kernel(XBLOCK: ttgl.constexpr, layout: ttgl.constexpr,
     XHALF: ttgl.constexpr = XBLOCK // 2
     smem = ttgl.allocate_shared_memory(ttgl.int32, [XBLOCK, XBLOCK], smem_layout)
     view = smem.slice(XHALF, XHALF, dim=1)
-    value = view.load(layout)
+    value = view.reshape([XHALF, XBLOCK]).load(layout)
     view = smem.slice(XHALF, XHALF, dim=0)
-    view.store(value.trans())
+    view.store(value)
 
 
 @pytest.mark.parametrize("target", ALL_TARGETS)
@@ -345,17 +345,17 @@ def test_shared_memory_subview(target):
     expecttest.assert_expected_inline(
         anonymize_ir(mod.str_nodebug()), """\
 #blocked = #ttg.blocked<{sizePerThread = [1, 1], threadsPerWarp = [1, 32], warpsPerCTA = [4, 1], order = [1, 0]}>
-#blocked1 = #ttg.blocked<{sizePerThread = [1, 1], threadsPerWarp = [32, 1], warpsPerCTA = [1, 4], order = [0, 1]}>
 #shared = #ttg.swizzled_shared<{vec = 1, perPhase = 1, maxPhase = 1, order = [1, 0]}>
+#shared1 = #ttg.shared_linear<{offset = [[0, 1], [0, 2], [0, 4], [0, 8], [0, 16], [0, 32], [0, 64], [128, 0], [0, 128], [1, 0], [2, 0], [4, 0], [8, 0], [16, 0], [32, 0], [64, 0]]}, alignment = 16>
 #smem = #ttg.shared_memory
 module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.target = "...", "ttg.threads-per-warp" = 32 : i32} {
   tt.func public @shared_memory_subview_kernel() attributes {noinline = false} {
     %0 = ttg.local_alloc : () -> !ttg.memdesc<256x256xi32, #shared, #smem, mutable>
     %1 = ttg.memdesc_subslice %0[0, 128] : !ttg.memdesc<256x256xi32, #shared, #smem, mutable> -> !ttg.memdesc<256x128xi32, #shared, #smem, mutable, 256x256>
-    %2 = ttg.local_load %1 : !ttg.memdesc<256x128xi32, #shared, #smem, mutable, 256x256> -> tensor<256x128xi32, #blocked>
-    %3 = ttg.memdesc_subslice %0[128, 0] : !ttg.memdesc<256x256xi32, #shared, #smem, mutable> -> !ttg.memdesc<128x256xi32, #shared, #smem, mutable, 256x256>
-    %4 = tt.trans %2 {order = array<i32: 1, 0>} : tensor<256x128xi32, #blocked> -> tensor<128x256xi32, #blocked1>
-    ttg.local_store %4, %3 : tensor<128x256xi32, #blocked1> -> !ttg.memdesc<128x256xi32, #shared, #smem, mutable, 256x256>
+    %2 = ttg.memdesc_reshape %1 : !ttg.memdesc<256x128xi32, #shared, #smem, mutable, 256x256> -> !ttg.memdesc<128x256xi32, #shared1, #smem, mutable, 256x256>
+    %3 = ttg.local_load %2 : !ttg.memdesc<128x256xi32, #shared1, #smem, mutable, 256x256> -> tensor<128x256xi32, #blocked>
+    %4 = ttg.memdesc_subslice %0[128, 0] : !ttg.memdesc<256x256xi32, #shared, #smem, mutable> -> !ttg.memdesc<128x256xi32, #shared, #smem, mutable, 256x256>
+    ttg.local_store %3, %4 : tensor<128x256xi32, #blocked> -> !ttg.memdesc<128x256xi32, #shared, #smem, mutable, 256x256>
     tt.return
   }
 }

--- a/python/triton/experimental/gluon/language/_semantic.py
+++ b/python/triton/experimental/gluon/language/_semantic.py
@@ -459,9 +459,7 @@ class GluonSemantic(TritonSemantic[TensorTy]):
 
         handle = self.builder.create_memdesc_reshape(mem_desc.handle, shape)
         layout = self.builder.get_gluon_layout_from_memdesc(handle)
-        alloc_shape = mem_desc.type.alloc_shape
-        prefix_len = len(alloc_shape) - mem_desc.rank
-        new_alloc_shape = alloc_shape[:prefix_len] + list(shape)
+        new_alloc_shape = self.builder.get_alloc_shape_from_memdesc(handle)
 
         return ttgl.shared_memory_descriptor(
             handle,

--- a/test/Conversion/tritongpu_to_llvm.mlir
+++ b/test/Conversion/tritongpu_to_llvm.mlir
@@ -505,6 +505,174 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32} {
 
 // -----
 
+#src_2d = #ttg.shared_linear<{offset = [[0, 1], [0, 2], [0, 4], [0, 8], [1, 0], [2, 0], [4, 0]]}, alignment = 16>
+#dst_2d = #ttg.shared_linear<{offset = [[0, 1], [0, 2], [0, 4], [4, 0], [0, 8], [1, 0], [2, 0]]}, alignment = 16>
+#src_3d = #ttg.shared_linear<{offset = [[0, 0, 1], [0, 0, 2], [0, 0, 4], [0, 1, 0], [0, 2, 0], [1, 0, 0], [2, 0, 0]]}, alignment = 16>
+#dst_rank3 = #ttg.shared_linear<{offset = [[0, 1], [0, 2], [0, 4], [0, 8], [2, 0], [0, 16], [1, 0]]}, alignment = 16>
+#dst_indexed = #ttg.shared_linear<{offset = [[0, 1], [0, 2], [0, 4], [2, 0], [0, 8], [1, 0], [4, 0]]}, alignment = 16>
+#smem = #ttg.shared_memory
+module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 1 : i32} {
+  // CHECK-LABEL: llvm.func @reshape_subview_offsets
+  // CHECK: %[[BASE:.*]] = llvm.extractvalue %arg0[0]
+  // CHECK: %[[ROW:.*]] = llvm.extractvalue %arg0[1]
+  // CHECK: %[[COL:.*]] = llvm.extractvalue %arg0[2]
+  // CHECK: %[[ROW_SHIFTED:.*]] = llvm.shl %[[ROW]], %{{.*}}
+  // CHECK: %[[ROW_PART:.*]] = llvm.or %{{.*}}, %[[ROW_SHIFTED]]
+  // CHECK: %[[C3:.*]] = llvm.mlir.constant(3 : i32)
+  // CHECK: %[[COL_SHIFTED:.*]] = llvm.shl %[[COL]], %[[C3]]
+  // CHECK: %[[FLAT:.*]] = llvm.or %[[ROW_PART]], %[[COL_SHIFTED]]
+  // Destination row is ((flat & 6) >> 1) | ((flat & 64) >> 4).
+  // CHECK: %[[C6:.*]] = llvm.mlir.constant(6 : i32)
+  // CHECK: %[[ROW_LOW_MASK:.*]] = llvm.and %[[FLAT]], %[[C6]]
+  // CHECK: %[[C1:.*]] = llvm.mlir.constant(1 : i32)
+  // CHECK: %[[ROW_LOW:.*]] = llvm.lshr %[[ROW_LOW_MASK]], %[[C1]]
+  // CHECK: %[[C64:.*]] = llvm.mlir.constant(64 : i32)
+  // CHECK: %[[ROW_HIGH_MASK:.*]] = llvm.and %[[FLAT]], %[[C64]]
+  // CHECK: %[[C4:.*]] = llvm.mlir.constant(4 : i32)
+  // CHECK: %[[ROW_HIGH:.*]] = llvm.lshr %[[ROW_HIGH_MASK]], %[[C4]]
+  // CHECK: %[[ROW_BITS:.*]] = llvm.or disjoint %[[ROW_LOW]], %[[ROW_HIGH]]
+  // CHECK: %[[ROW_PAD:.*]] = llvm.or disjoint %[[ROW_BITS]], %{{.*}}
+  // CHECK: %[[OUT_ROW:.*]] = llvm.xor %{{.*}}, %[[ROW_PAD]]
+  // Destination column is ((flat & 56) >> 3) | ((flat & 1) << 3).
+  // CHECK: %[[C56:.*]] = llvm.mlir.constant(56 : i32)
+  // CHECK: %[[COL_LOW_MASK:.*]] = llvm.and %[[FLAT]], %[[C56]]
+  // CHECK: %[[C3B:.*]] = llvm.mlir.constant(3 : i32)
+  // CHECK: %[[COL_LOW:.*]] = llvm.lshr %[[COL_LOW_MASK]], %[[C3B]]
+  // CHECK: %[[C1B:.*]] = llvm.mlir.constant(1 : i32)
+  // CHECK: %[[COL_HIGH_MASK:.*]] = llvm.and %[[FLAT]], %[[C1B]]
+  // CHECK: %[[C3C:.*]] = llvm.mlir.constant(3 : i32)
+  // CHECK: %[[COL_HIGH:.*]] = llvm.shl %[[COL_HIGH_MASK]], %[[C3C]]
+  // CHECK: %[[COL_BITS:.*]] = llvm.or disjoint %[[COL_LOW]], %[[COL_HIGH]]
+  // CHECK: %[[COL_PAD:.*]] = llvm.or disjoint %[[COL_BITS]], %{{.*}}
+  // CHECK: %[[OUT_COL:.*]] = llvm.xor %{{.*}}, %[[COL_PAD]]
+  // CHECK: %[[WITH_BASE:.*]] = llvm.insertvalue %[[BASE]], %{{.*}}[0]
+  // CHECK: %[[WITH_ROW:.*]] = llvm.insertvalue %[[OUT_ROW]], %[[WITH_BASE]][1]
+  // CHECK: llvm.insertvalue %[[OUT_COL]], %[[WITH_ROW]][2]
+  tt.func @reshape_subview_offsets(%arg0 : !ttg.memdesc<8x8xf32, #src_2d, #smem, 8x16>) {
+    %0 = ttg.memdesc_reshape %arg0 : !ttg.memdesc<8x8xf32, #src_2d, #smem, 8x16> -> !ttg.memdesc<4x16xf32, #dst_2d, #smem, 8x16>
+    tt.return
+  }
+
+  // CHECK-LABEL: llvm.func @reshape_rank3_middle_gap
+  // CHECK: %[[BASE:.*]] = llvm.extractvalue %arg0[0]
+  // CHECK: %[[D0:.*]] = llvm.extractvalue %arg0[1]
+  // CHECK: %[[D1:.*]] = llvm.extractvalue %arg0[2]
+  // CHECK: %[[D2:.*]] = llvm.extractvalue %arg0[3]
+  // CHECK: %[[D0_SHIFTED:.*]] = llvm.shl %[[D0]], %{{.*}}
+  // CHECK: %[[D0_PART:.*]] = llvm.or %{{.*}}, %[[D0_SHIFTED]]
+  // CHECK: %[[C2:.*]] = llvm.mlir.constant(2 : i32)
+  // CHECK: %[[D1_SHIFTED:.*]] = llvm.shl %[[D1]], %[[C2]]
+  // CHECK: %[[D01:.*]] = llvm.or %[[D0_PART]], %[[D1_SHIFTED]]
+  // CHECK: %[[C4:.*]] = llvm.mlir.constant(4 : i32)
+  // CHECK: %[[D2_SHIFTED:.*]] = llvm.shl %[[D2]], %[[C4]]
+  // CHECK: %[[FLAT:.*]] = llvm.or %[[D01]], %[[D2_SHIFTED]]
+  // Destination row is ((flat & 2) >> 1) | ((flat & 8) >> 2).
+  // CHECK: %[[C2B:.*]] = llvm.mlir.constant(2 : i32)
+  // CHECK: %[[ROW_LOW_MASK:.*]] = llvm.and %[[FLAT]], %[[C2B]]
+  // CHECK: %[[C1:.*]] = llvm.mlir.constant(1 : i32)
+  // CHECK: %[[ROW_LOW:.*]] = llvm.lshr %[[ROW_LOW_MASK]], %[[C1]]
+  // CHECK: %[[C8:.*]] = llvm.mlir.constant(8 : i32)
+  // CHECK: %[[ROW_HIGH_MASK:.*]] = llvm.and %[[FLAT]], %[[C8]]
+  // CHECK: %[[C2C:.*]] = llvm.mlir.constant(2 : i32)
+  // CHECK: %[[ROW_HIGH:.*]] = llvm.lshr %[[ROW_HIGH_MASK]], %[[C2C]]
+  // CHECK: %[[ROW_BITS:.*]] = llvm.or disjoint %[[ROW_LOW]], %[[ROW_HIGH]]
+  // CHECK: %[[ROW_PAD:.*]] = llvm.or disjoint %[[ROW_BITS]], %{{.*}}
+  // CHECK: %[[OUT_ROW:.*]] = llvm.xor %{{.*}}, %[[ROW_PAD]]
+  // Destination column is ((flat & 112) >> 4) | ((flat & 1) << 4) | ((flat & 4) << 1).
+  // CHECK: %[[C112:.*]] = llvm.mlir.constant(112 : i32)
+  // CHECK: %[[COL_LOW_MASK:.*]] = llvm.and %[[FLAT]], %[[C112]]
+  // CHECK: %[[C4B:.*]] = llvm.mlir.constant(4 : i32)
+  // CHECK: %[[COL_LOW:.*]] = llvm.lshr %[[COL_LOW_MASK]], %[[C4B]]
+  // CHECK: %[[C1B:.*]] = llvm.mlir.constant(1 : i32)
+  // CHECK: %[[COL_MID_MASK:.*]] = llvm.and %[[FLAT]], %[[C1B]]
+  // CHECK: %[[C4C:.*]] = llvm.mlir.constant(4 : i32)
+  // CHECK: %[[COL_MID:.*]] = llvm.shl %[[COL_MID_MASK]], %[[C4C]]
+  // CHECK: %[[C4D:.*]] = llvm.mlir.constant(4 : i32)
+  // CHECK: %[[COL_HIGH_MASK:.*]] = llvm.and %[[FLAT]], %[[C4D]]
+  // CHECK: %[[C1C:.*]] = llvm.mlir.constant(1 : i32)
+  // CHECK: %[[COL_HIGH:.*]] = llvm.shl %[[COL_HIGH_MASK]], %[[C1C]]
+  // CHECK: %[[COL_LOW_MID:.*]] = llvm.or disjoint %[[COL_LOW]], %[[COL_MID]]
+  // CHECK: %[[COL_BITS:.*]] = llvm.or disjoint %[[COL_LOW_MID]], %[[COL_HIGH]]
+  // CHECK: %[[COL_PAD:.*]] = llvm.or disjoint %[[COL_BITS]], %{{.*}}
+  // CHECK: %[[OUT_COL:.*]] = llvm.xor %{{.*}}, %[[COL_PAD]]
+  // CHECK: %[[WITH_BASE:.*]] = llvm.insertvalue %[[BASE]], %{{.*}}[0]
+  // CHECK: %[[WITH_ROW:.*]] = llvm.insertvalue %[[OUT_ROW]], %[[WITH_BASE]][1]
+  // CHECK: llvm.insertvalue %[[OUT_COL]], %[[WITH_ROW]][2]
+  tt.func @reshape_rank3_middle_gap(%arg0 : !ttg.memdesc<4x2x8xf32, #src_3d, #smem, 4x4x8>) {
+    %0 = ttg.memdesc_reshape %arg0 : !ttg.memdesc<4x2x8xf32, #src_3d, #smem, 4x4x8> -> !ttg.memdesc<2x32xf32, #dst_rank3, #smem, 4x32>
+    tt.return
+  }
+
+  // CHECK-LABEL: llvm.func @reshape_indexed_subview
+  // Indexing selects a 128-element buffer and preserves that base through the
+  // following subslice and reshape.
+  // CHECK: %[[C128:.*]] = llvm.mlir.constant(128 : i32)
+  // CHECK: %[[BUFFER_OFFSET:.*]] = llvm.mul %arg1, %[[C128]]
+  // CHECK: %[[BASE:.*]] = llvm.extractvalue %arg0[0]
+  // CHECK: %[[ARG_ROW:.*]] = llvm.extractvalue %arg0[2]
+  // CHECK: %[[ARG_COL:.*]] = llvm.extractvalue %arg0[3]
+  // CHECK: %[[INDEXED_BASE:.*]] = llvm.getelementptr %[[BASE]][%[[BUFFER_OFFSET]]]
+  // CHECK: %[[INDEXED_DESC:.*]] = llvm.insertvalue %[[INDEXED_BASE]], %{{.*}}[0]
+  // CHECK: %[[INDEXED_DESC_ROW:.*]] = llvm.insertvalue %[[ARG_ROW]], %[[INDEXED_DESC]][1]
+  // CHECK: %[[INDEXED_DESC_FULL:.*]] = llvm.insertvalue %[[ARG_COL]], %[[INDEXED_DESC_ROW]][2]
+  // CHECK: %[[SUB_BASE:.*]] = llvm.extractvalue %[[INDEXED_DESC_FULL]][0]
+  // CHECK: %[[ROW:.*]] = llvm.extractvalue %[[INDEXED_DESC_FULL]][1]
+  // CHECK: %[[COL:.*]] = llvm.extractvalue %[[INDEXED_DESC_FULL]][2]
+  // CHECK: %[[C4:.*]] = llvm.mlir.constant(4 : i32)
+  // CHECK: %[[SUB_ROW:.*]] = llvm.add %[[ROW]], %[[C4]]
+  // CHECK: %[[C8:.*]] = llvm.mlir.constant(8 : i32)
+  // CHECK: %[[SUB_COL:.*]] = llvm.add %[[COL]], %[[C8]]
+  // CHECK: %[[SUB_DESC:.*]] = llvm.insertvalue %[[SUB_BASE]], %{{.*}}[0]
+  // CHECK: %[[SUB_DESC_ROW:.*]] = llvm.insertvalue %[[SUB_ROW]], %[[SUB_DESC]][1]
+  // CHECK: %[[SUB_DESC_FULL:.*]] = llvm.insertvalue %[[SUB_COL]], %[[SUB_DESC_ROW]][2]
+  // CHECK: %[[RESHAPE_BASE:.*]] = llvm.extractvalue %[[SUB_DESC_FULL]][0]
+  // CHECK: %[[RESHAPE_ROW:.*]] = llvm.extractvalue %[[SUB_DESC_FULL]][1]
+  // CHECK: %[[RESHAPE_COL:.*]] = llvm.extractvalue %[[SUB_DESC_FULL]][2]
+  // CHECK: %[[ROW_SHIFTED:.*]] = llvm.shl %[[RESHAPE_ROW]], %{{.*}}
+  // CHECK: %[[ROW_PART:.*]] = llvm.or %{{.*}}, %[[ROW_SHIFTED]]
+  // CHECK: %[[C3:.*]] = llvm.mlir.constant(3 : i32)
+  // CHECK: %[[COL_SHIFTED:.*]] = llvm.shl %[[RESHAPE_COL]], %[[C3]]
+  // CHECK: %[[FLAT:.*]] = llvm.or %[[ROW_PART]], %[[COL_SHIFTED]]
+  // Destination row is ((flat & 2) >> 1) | (flat & 4) | ((flat & 64) >> 5).
+  // CHECK: %[[C2:.*]] = llvm.mlir.constant(2 : i32)
+  // CHECK: %[[ROW_LOW_MASK:.*]] = llvm.and %[[FLAT]], %[[C2]]
+  // CHECK: %[[C1:.*]] = llvm.mlir.constant(1 : i32)
+  // CHECK: %[[ROW_LOW:.*]] = llvm.lshr %[[ROW_LOW_MASK]], %[[C1]]
+  // CHECK: %[[C4B:.*]] = llvm.mlir.constant(4 : i32)
+  // CHECK: %[[ROW_MID:.*]] = llvm.and %[[FLAT]], %[[C4B]]
+  // CHECK: %[[C64:.*]] = llvm.mlir.constant(64 : i32)
+  // CHECK: %[[ROW_HIGH_MASK:.*]] = llvm.and %[[FLAT]], %[[C64]]
+  // CHECK: %[[C5:.*]] = llvm.mlir.constant(5 : i32)
+  // CHECK: %[[ROW_HIGH:.*]] = llvm.lshr %[[ROW_HIGH_MASK]], %[[C5]]
+  // CHECK: %[[ROW_LOW_MID:.*]] = llvm.or disjoint %[[ROW_LOW]], %[[ROW_MID]]
+  // CHECK: %[[ROW_BITS:.*]] = llvm.or disjoint %[[ROW_LOW_MID]], %[[ROW_HIGH]]
+  // CHECK: %[[ROW_PAD:.*]] = llvm.or disjoint %[[ROW_BITS]], %{{.*}}
+  // CHECK: %[[OUT_ROW:.*]] = llvm.xor %{{.*}}, %[[ROW_PAD]]
+  // Destination column is ((flat & 56) >> 3) | ((flat & 1) << 3).
+  // CHECK: %[[C56:.*]] = llvm.mlir.constant(56 : i32)
+  // CHECK: %[[COL_LOW_MASK:.*]] = llvm.and %[[FLAT]], %[[C56]]
+  // CHECK: %[[C3B:.*]] = llvm.mlir.constant(3 : i32)
+  // CHECK: %[[COL_LOW:.*]] = llvm.lshr %[[COL_LOW_MASK]], %[[C3B]]
+  // CHECK: %[[C1B:.*]] = llvm.mlir.constant(1 : i32)
+  // CHECK: %[[COL_HIGH_MASK:.*]] = llvm.and %[[FLAT]], %[[C1B]]
+  // CHECK: %[[C3C:.*]] = llvm.mlir.constant(3 : i32)
+  // CHECK: %[[COL_HIGH:.*]] = llvm.shl %[[COL_HIGH_MASK]], %[[C3C]]
+  // CHECK: %[[COL_BITS:.*]] = llvm.or disjoint %[[COL_LOW]], %[[COL_HIGH]]
+  // CHECK: %[[COL_PAD:.*]] = llvm.or disjoint %[[COL_BITS]], %{{.*}}
+  // CHECK: %[[OUT_COL:.*]] = llvm.xor %{{.*}}, %[[COL_PAD]]
+  // CHECK: %[[WITH_BASE:.*]] = llvm.insertvalue %[[RESHAPE_BASE]], %{{.*}}[0]
+  // CHECK: %[[WITH_ROW:.*]] = llvm.insertvalue %[[OUT_ROW]], %[[WITH_BASE]][1]
+  // CHECK: llvm.insertvalue %[[OUT_COL]], %[[WITH_ROW]][2]
+  tt.func @reshape_indexed_subview(%arg0 : !ttg.memdesc<2x8x16xf32, #src_2d, #smem>, %index : i32) {
+    %0 = ttg.memdesc_index %arg0[%index] : !ttg.memdesc<2x8x16xf32, #src_2d, #smem> -> !ttg.memdesc<8x16xf32, #src_2d, #smem>
+    %1 = ttg.memdesc_subslice %0[4, 8] : !ttg.memdesc<8x16xf32, #src_2d, #smem> -> !ttg.memdesc<4x8xf32, #src_2d, #smem, 8x16>
+    %2 = ttg.memdesc_reshape %1 : !ttg.memdesc<4x8xf32, #src_2d, #smem, 8x16> -> !ttg.memdesc<2x16xf32, #dst_indexed, #smem, 8x16>
+    tt.return
+  }
+}
+
+// -----
+
 module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32} {
   // CHECK-LABEL: basic_program_id
   tt.func @basic_program_id() {

--- a/test/TritonGPU/invalid.mlir
+++ b/test/TritonGPU/invalid.mlir
@@ -180,6 +180,17 @@ tt.func public @reshape_padded_subview(%arg0: !ttg.memdesc<4x4xf32, #padded_src,
 
 // -----
 
+#shared = #ttg.swizzled_shared<{vec = 1, perPhase = 1, maxPhase = 1, order = [1, 0]}>
+#partitioned = #ttg.partitioned_shared<{numPartitions = 2, numGroups = 1, partitionDim = 0, partitionLayout = #shared}>
+#smem = #ttg.shared_memory
+tt.func public @reshape_partitioned_subview(%arg0: !ttg.memdesc<8x8xf16, #partitioned, #smem, 16x8>) {
+    // expected-error @+1 {{memdesc reshape of partitioned shared memory subviews is not supported}}
+    %0 = ttg.memdesc_reshape %arg0 : !ttg.memdesc<8x8xf16, #partitioned, #smem, 16x8> -> !ttg.memdesc<4x16xf16, #partitioned, #smem, 8x16>
+    tt.return
+}
+
+// -----
+
 #shared_rank2 = #ttg.swizzled_shared<{vec = 1, perPhase = 1, maxPhase = 1, order = [1, 0]}>
 #smem = #ttg.shared_memory
 tt.func public @reshape_subview_layout_rank_mismatch(%arg0 : !ttg.memdesc<2x4x8xf32, #shared_rank2, #smem, 2x8x8>) {

--- a/test/TritonGPU/invalid.mlir
+++ b/test/TritonGPU/invalid.mlir
@@ -173,19 +173,8 @@ tt.func public @subview_along_swizzling(%arg0: !ttg.memdesc<8x16xf32, #shared, #
 #padded_dst = #ttg.padded_shared<[4:+4] {order = [1, 0], shape = [2, 8]}>
 #smem = #ttg.shared_memory
 tt.func public @reshape_padded_subview(%arg0: !ttg.memdesc<4x4xf32, #padded_src, #smem, 8x4>) {
-    // expected-error @+1 {{memdesc reshape of padded shared memory subviews is not supported}}
+    // expected-error @+1 {{unsupported memdesc subview reshape}}
     %0 = ttg.memdesc_reshape %arg0 : !ttg.memdesc<4x4xf32, #padded_src, #smem, 8x4> -> !ttg.memdesc<2x8xf32, #padded_dst, #smem>
-    tt.return
-}
-
-// -----
-
-#shared = #ttg.swizzled_shared<{vec = 1, perPhase = 1, maxPhase = 1, order = [1, 0]}>
-#partitioned = #ttg.partitioned_shared<{numPartitions = 2, numGroups = 1, partitionDim = 0, partitionLayout = #shared}>
-#smem = #ttg.shared_memory
-tt.func public @reshape_partitioned_subview(%arg0: !ttg.memdesc<8x8xf16, #partitioned, #smem, 16x8>) {
-    // expected-error @+1 {{memdesc reshape of partitioned shared memory subviews is not supported}}
-    %0 = ttg.memdesc_reshape %arg0 : !ttg.memdesc<8x8xf16, #partitioned, #smem, 16x8> -> !ttg.memdesc<4x16xf16, #partitioned, #smem, 8x16>
     tt.return
 }
 
@@ -194,7 +183,7 @@ tt.func public @reshape_partitioned_subview(%arg0: !ttg.memdesc<8x8xf16, #partit
 #shared_rank2 = #ttg.swizzled_shared<{vec = 1, perPhase = 1, maxPhase = 1, order = [1, 0]}>
 #smem = #ttg.shared_memory
 tt.func public @reshape_subview_layout_rank_mismatch(%arg0 : !ttg.memdesc<2x4x8xf32, #shared_rank2, #smem, 2x8x8>) {
-  // expected-error @+1 {{memdesc subview reshape requires the layout rank to match the memdesc rank}}
+  // expected-error @+1 {{unsupported memdesc subview reshape}}
   %0 = ttg.memdesc_reshape %arg0 : !ttg.memdesc<2x4x8xf32, #shared_rank2, #smem, 2x8x8> -> !ttg.memdesc<4x16xf32, #shared_rank2, #smem, 8x16>
   tt.return
 }

--- a/test/TritonGPU/invalid.mlir
+++ b/test/TritonGPU/invalid.mlir
@@ -169,6 +169,27 @@ tt.func public @subview_along_swizzling(%arg0: !ttg.memdesc<8x16xf32, #shared, #
 
 // -----
 
+#padded_src = #ttg.padded_shared<[4:+4] {order = [1, 0], shape = [8, 4]}>
+#padded_dst = #ttg.padded_shared<[4:+4] {order = [1, 0], shape = [2, 8]}>
+#smem = #ttg.shared_memory
+tt.func public @reshape_padded_subview(%arg0: !ttg.memdesc<4x4xf32, #padded_src, #smem, 8x4>) {
+    // expected-error @+1 {{memdesc reshape of padded shared memory subviews is not supported}}
+    %0 = ttg.memdesc_reshape %arg0 : !ttg.memdesc<4x4xf32, #padded_src, #smem, 8x4> -> !ttg.memdesc<2x8xf32, #padded_dst, #smem>
+    tt.return
+}
+
+// -----
+
+#shared_rank2 = #ttg.swizzled_shared<{vec = 1, perPhase = 1, maxPhase = 1, order = [1, 0]}>
+#smem = #ttg.shared_memory
+tt.func public @reshape_subview_layout_rank_mismatch(%arg0 : !ttg.memdesc<2x4x8xf32, #shared_rank2, #smem, 2x8x8>) {
+  // expected-error @+1 {{memdesc subview reshape requires the layout rank to match the memdesc rank}}
+  %0 = ttg.memdesc_reshape %arg0 : !ttg.memdesc<2x4x8xf32, #shared_rank2, #smem, 2x8x8> -> !ttg.memdesc<4x16xf32, #shared_rank2, #smem, 8x16>
+  tt.return
+}
+
+// -----
+
 #linear = #ttg.linear<{register = [], lane = [[1], [2], [4], [8], [16]], warp = [], block = []}>
 #shared = #ttg.swizzled_shared<{vec = 1, perPhase = 1, maxPhase = 1, order = [0]}>
 #smem = #ttg.shared_memory

--- a/test/TritonGPU/ops.mlir
+++ b/test/TritonGPU/ops.mlir
@@ -143,9 +143,6 @@ module attributes {"ttg.target" = "gfx950", "ttg.num-ctas" = 1 : i32, "ttg.num-w
 #shared_linear_equiv = #ttg.shared_linear<{offset = [[0, 0, 1, 0], [0, 1, 0, 0], [0, 2, 0, 0], [0, 4, 0, 0], [0, 0, 0, 1], [0, 2, 0, 2], [0, 4, 0, 4], [0, 0, 0, 8]]}, alignment = 512>
 #subview_src = #ttg.swizzled_shared<{vec = 1, perPhase = 1, maxPhase = 1, order = [1, 0]}>
 #subview_dst = #ttg.shared_linear<{offset = [[0, 1], [0, 2], [0, 4], [4, 0], [0, 8], [1, 0], [2, 0]]}, alignment = 16>
-#partition_src = #ttg.partitioned_shared<{numPartitions = 2, numGroups = 1, partitionDim = 0, partitionLayout = #subview_src}>
-#partition_dst_inner = #ttg.shared_linear<{offset = [[0, 1], [0, 2], [0, 4], [0, 8], [1, 0], [2, 0]]}, alignment = 16>
-#partition_dst = #ttg.partitioned_shared<{numPartitions = 2, numGroups = 1, partitionDim = 0, partitionLayout = #partition_dst_inner}>
 #subview_src_3d = #ttg.shared_linear<{offset = [[0, 0, 1], [0, 0, 2], [0, 0, 4], [0, 1, 0], [0, 2, 0], [1, 0, 0], [2, 0, 0]]}, alignment = 16>
 #subview_dst_2d = #ttg.shared_linear<{offset = [[0, 1], [0, 2], [0, 4], [0, 8], [2, 0], [0, 16], [1, 0]]}, alignment = 16>
 #smem = #ttg.shared_memory
@@ -176,14 +173,6 @@ module attributes {"ttg.target" = "cuda:0", "ttg.num-ctas" = 1 : i32, "ttg.num-w
   tt.func @memdesc_reshape_subview(%arg0 : !ttg.memdesc<8x16xf32, #subview_src, #smem>) {
     %0 = ttg.memdesc_subslice %arg0[0, 8] : !ttg.memdesc<8x16xf32, #subview_src, #smem> -> !ttg.memdesc<8x8xf32, #subview_src, #smem, 8x16>
     %1 = ttg.memdesc_reshape %0 : !ttg.memdesc<8x8xf32, #subview_src, #smem, 8x16> -> !ttg.memdesc<4x16xf32, #subview_dst, #smem, 8x16>
-    tt.return
-  }
-
-  // CHECK-LABEL: memdesc_reshape_partitioned_subview
-  // CHECK: ttg.memdesc_reshape %{{.*}} : !ttg.memdesc<8x8xf16, #{{.*}}, #smem, 16x8> -> !ttg.memdesc<4x16xf16, #{{.*}}, #smem, 8x16>
-  tt.func @memdesc_reshape_partitioned_subview(%arg0 : !ttg.memdesc<16x8xf16, #partition_src, #smem>) {
-    %0 = ttg.memdesc_subslice %arg0[8, 0] : !ttg.memdesc<16x8xf16, #partition_src, #smem> -> !ttg.memdesc<8x8xf16, #partition_src, #smem, 16x8>
-    %1 = ttg.memdesc_reshape %0 : !ttg.memdesc<8x8xf16, #partition_src, #smem, 16x8> -> !ttg.memdesc<4x16xf16, #partition_dst, #smem, 8x16>
     tt.return
   }
 

--- a/test/TritonGPU/ops.mlir
+++ b/test/TritonGPU/ops.mlir
@@ -202,6 +202,24 @@ module attributes {"ttg.target" = "cuda:100", "ttg.num-ctas" = 1 : i32, "ttg.num
 
 // -----
 
+#src = #ttg.nvmma_shared<{swizzlingByteWidth = 32, transposed = true, elementBitWidth = 32}>
+#dst = #ttg.shared_linear<{offset = [[1, 0, 0], [2, 0, 0], [4, 0, 0], [0, 1, 0], [0, 2, 0], [4, 4, 0], [8, 0, 0]]}, alignment = 256>
+#smem = #ttg.shared_memory
+
+module {
+  // CHECK-LABEL: @reshape_nvmma_subview_fallback
+  // CHECK: ttg.memdesc_reshape
+  tt.func @reshape_nvmma_subview_fallback(
+      %arg0: !ttg.memdesc<8x8xi32, #src, #smem, 16x8>) {
+    %0 = ttg.memdesc_reshape %arg0
+        : !ttg.memdesc<8x8xi32, #src, #smem, 16x8>
+       -> !ttg.memdesc<8x8x1xi32, #dst, #smem, 16x8x1>
+    tt.return
+  }
+}
+
+// -----
+
 #shared1d = #ttg.swizzled_shared<{vec = 1, perPhase = 1, maxPhase = 1, order = [0]}>
 #shared2d = #ttg.swizzled_shared<{vec = 1, perPhase = 1, maxPhase = 1, order = [1, 0]}>
 #smem = #ttg.shared_memory

--- a/test/TritonGPU/ops.mlir
+++ b/test/TritonGPU/ops.mlir
@@ -141,6 +141,13 @@ module attributes {"ttg.target" = "gfx950", "ttg.num-ctas" = 1 : i32, "ttg.num-w
 #shared2 = #ttg.nvmma_shared<{swizzlingByteWidth = 64, transposed = true, elementBitWidth = 32}>
 #shared_linear_16 = #ttg.shared_linear<{offset = [[0, 1], [0, 2], [0, 4], [0, 8], [1, 0], [2, 4], [4, 8], [8, 0]]}, alignment = 512>
 #shared_linear_equiv = #ttg.shared_linear<{offset = [[0, 0, 1, 0], [0, 1, 0, 0], [0, 2, 0, 0], [0, 4, 0, 0], [0, 0, 0, 1], [0, 2, 0, 2], [0, 4, 0, 4], [0, 0, 0, 8]]}, alignment = 512>
+#subview_src = #ttg.swizzled_shared<{vec = 1, perPhase = 1, maxPhase = 1, order = [1, 0]}>
+#subview_dst = #ttg.shared_linear<{offset = [[0, 1], [0, 2], [0, 4], [4, 0], [0, 8], [1, 0], [2, 0]]}, alignment = 16>
+#partition_src = #ttg.partitioned_shared<{numPartitions = 2, numGroups = 1, partitionDim = 0, partitionLayout = #subview_src}>
+#partition_dst_inner = #ttg.shared_linear<{offset = [[0, 1], [0, 2], [0, 4], [0, 8], [1, 0], [2, 0]]}, alignment = 16>
+#partition_dst = #ttg.partitioned_shared<{numPartitions = 2, numGroups = 1, partitionDim = 0, partitionLayout = #partition_dst_inner}>
+#subview_src_3d = #ttg.shared_linear<{offset = [[0, 0, 1], [0, 0, 2], [0, 0, 4], [0, 1, 0], [0, 2, 0], [1, 0, 0], [2, 0, 0]]}, alignment = 16>
+#subview_dst_2d = #ttg.shared_linear<{offset = [[0, 1], [0, 2], [0, 4], [0, 8], [2, 0], [0, 16], [1, 0]]}, alignment = 16>
 #smem = #ttg.shared_memory
 module attributes {"ttg.target" = "cuda:0", "ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 1 : i32, "ttg.threads-per-warp" = 32 : i32} {
   // CHECK-LABEL: memdesc_reshape
@@ -161,6 +168,45 @@ module attributes {"ttg.target" = "cuda:0", "ttg.num-ctas" = 1 : i32, "ttg.num-w
   // CHECK: %[[T:.*]] = ttg.memdesc_trans %{{.*}} {order = array<i32: 1, 0>} : !ttg.memdesc<16x16xf32, #{{.*}}, #smem> -> !ttg.memdesc<16x16xf32, #{{.*}}, #smem>
   tt.func @memdesc_trans_equiv(%arg0 : !ttg.memdesc<16x16xf32, #shared_linear_16, #smem>) {
     %0 = ttg.memdesc_trans %arg0 {order = array<i32: 1, 0>} : !ttg.memdesc<16x16xf32, #shared_linear_16, #smem> -> !ttg.memdesc<16x16xf32, #shared2, #smem>
+    tt.return
+  }
+
+  // CHECK-LABEL: memdesc_reshape_subview
+  // CHECK: ttg.memdesc_reshape %{{.*}} : !ttg.memdesc<8x8xf32, #{{.*}}, #smem, 8x16> -> !ttg.memdesc<4x16xf32, #{{.*}}, #smem, 8x16>
+  tt.func @memdesc_reshape_subview(%arg0 : !ttg.memdesc<8x16xf32, #subview_src, #smem>) {
+    %0 = ttg.memdesc_subslice %arg0[0, 8] : !ttg.memdesc<8x16xf32, #subview_src, #smem> -> !ttg.memdesc<8x8xf32, #subview_src, #smem, 8x16>
+    %1 = ttg.memdesc_reshape %0 : !ttg.memdesc<8x8xf32, #subview_src, #smem, 8x16> -> !ttg.memdesc<4x16xf32, #subview_dst, #smem, 8x16>
+    tt.return
+  }
+
+  // CHECK-LABEL: memdesc_reshape_partitioned_subview
+  // CHECK: ttg.memdesc_reshape %{{.*}} : !ttg.memdesc<8x8xf16, #{{.*}}, #smem, 16x8> -> !ttg.memdesc<4x16xf16, #{{.*}}, #smem, 8x16>
+  tt.func @memdesc_reshape_partitioned_subview(%arg0 : !ttg.memdesc<16x8xf16, #partition_src, #smem>) {
+    %0 = ttg.memdesc_subslice %arg0[8, 0] : !ttg.memdesc<16x8xf16, #partition_src, #smem> -> !ttg.memdesc<8x8xf16, #partition_src, #smem, 16x8>
+    %1 = ttg.memdesc_reshape %0 : !ttg.memdesc<8x8xf16, #partition_src, #smem, 16x8> -> !ttg.memdesc<4x16xf16, #partition_dst, #smem, 8x16>
+    tt.return
+  }
+
+  // CHECK-LABEL: memdesc_reshape_rank3_middle_gap
+  // CHECK: ttg.memdesc_reshape %{{.*}} : !ttg.memdesc<4x2x8xf32, #{{.*}}, #smem, 4x4x8> -> !ttg.memdesc<2x32xf32, #{{.*}}, #smem, 4x32>
+  tt.func @memdesc_reshape_rank3_middle_gap(%arg0 : !ttg.memdesc<4x2x8xf32, #subview_src_3d, #smem, 4x4x8>) {
+    %0 = ttg.memdesc_reshape %arg0 : !ttg.memdesc<4x2x8xf32, #subview_src_3d, #smem, 4x4x8> -> !ttg.memdesc<2x32xf32, #subview_dst_2d, #smem, 4x32>
+    tt.return
+  }
+}
+
+// -----
+
+#nvmma_src = #ttg.nvmma_shared<{swizzlingByteWidth = 32, transposed = false, elementBitWidth = 16, rank = 2}>
+#nvmma_dst = #ttg.nvmma_shared<{swizzlingByteWidth = 32, transposed = false, elementBitWidth = 16, rank = 3}>
+#smem = #ttg.shared_memory
+module attributes {"ttg.target" = "cuda:100", "ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 1 : i32, "ttg.threads-per-warp" = 32 : i32} {
+  // CHECK: #{{.*}} = #ttg.nvmma_shared<{{.*}}rank = 3{{.*}}>
+  // CHECK-LABEL: memdesc_reshape_nvmma_subview
+  // CHECK: ttg.memdesc_reshape %{{.*}} : !ttg.memdesc<8x16xf16, #{{.*}}, #smem, 16x16> -> !ttg.memdesc<4x2x16xf16, #{{.*}}, #smem, 8x2x16>
+  tt.func @memdesc_reshape_nvmma_subview(%arg0 : !ttg.memdesc<16x16xf16, #nvmma_src, #smem>) {
+    %0 = ttg.memdesc_subslice %arg0[8, 0] : !ttg.memdesc<16x16xf16, #nvmma_src, #smem> -> !ttg.memdesc<8x16xf16, #nvmma_src, #smem, 16x16>
+    %1 = ttg.memdesc_reshape %0 : !ttg.memdesc<8x16xf16, #nvmma_src, #smem, 16x16> -> !ttg.memdesc<4x2x16xf16, #nvmma_dst, #smem, 8x2x16>
     tt.return
   }
 }


### PR DESCRIPTION
PR description written by Codex

Enable reshaping shared-memory subviews while preserving allocation holes through linear-layout composition. Preserve exact NVMMA layouts when representable and reject unsupported encodings.