### PR TITLE
[Blackwell] Decide TMEMCopy compatibility for block scales early 

### DIFF
--- a/include/triton/Dialect/TritonGPU/IR/LinearLayoutConversions.h
+++ b/include/triton/Dialect/TritonGPU/IR/LinearLayoutConversions.h
@@ -169,8 +169,8 @@ LinearLayout getCoreMatrixLinearLayout(NVMMASharedEncodingAttr shared,
 // Create the canonical 2D SMEM linear layout for scales.
 // This is the shared-memory layout for the 32x4x4 TMEM scale-tile convention
 // recognized between the user kernel and the compiler.
-LinearLayout getCanonicalScaleSmemLinearLayout(MLIRContext *ctx,
-                                               ArrayRef<int64_t> shape);
+LinearLayout getScaleSmemLayoutForTMEMCopy(MLIRContext *ctx,
+                                           ArrayRef<int64_t> shape);
 
 // Create a TDM (Tensor DMA) LinearLayout: (message, warp, block) ->
 // (dim0, dim1, ...).  TDM is warp-granular.  The "warp" sublayout is an

--- a/include/triton/Dialect/TritonGPU/IR/LinearLayoutConversions.h
+++ b/include/triton/Dialect/TritonGPU/IR/LinearLayoutConversions.h
@@ -166,6 +166,12 @@ std::optional<LinearLayout> chooseMfmaLikeStoreLayout(RankedTensorType valType);
 LinearLayout getCoreMatrixLinearLayout(NVMMASharedEncodingAttr shared,
                                        bool disableSwizzle);
 
+// Create the canonical 2D SMEM linear layout for scales.
+// This is the shared-memory layout for the 32x4x4 TMEM scale-tile convention
+// recognized between the user kernel and the compiler.
+LinearLayout getCanonicalScaleSmemLinearLayout(MLIRContext *ctx,
+                                               ArrayRef<int64_t> shape);
+
 // Create a TDM (Tensor DMA) LinearLayout: (message, warp, block) ->
 // (dim0, dim1, ...).  TDM is warp-granular.  The "warp" sublayout is an
 // identity over `warpsPerCTA`, zero-padded up to log2(numWarps) so the

--- a/include/triton/Dialect/TritonGPU/IR/LinearLayoutConversions.h
+++ b/include/triton/Dialect/TritonGPU/IR/LinearLayoutConversions.h
@@ -170,7 +170,8 @@ LinearLayout getCoreMatrixLinearLayout(NVMMASharedEncodingAttr shared,
 // This is the shared-memory layout for the 32x4x4 TMEM scale-tile convention
 // recognized between the user kernel and the compiler.
 LinearLayout getScaleSmemLayoutForTMEMCopy(MLIRContext *ctx,
-                                           ArrayRef<int64_t> shape);
+                                           ArrayRef<int64_t> shape,
+                                           CGAEncodingAttr cgaLayout);
 
 // Create a TDM (Tensor DMA) LinearLayout: (message, warp, block) ->
 // (dim0, dim1, ...).  TDM is warp-granular.  The "warp" sublayout is an

--- a/lib/Dialect/TritonGPU/IR/LinearLayoutConversions.cpp
+++ b/lib/Dialect/TritonGPU/IR/LinearLayoutConversions.cpp
@@ -194,7 +194,8 @@ LinearLayout getCoreMatrixLinearLayout(NVMMASharedEncodingAttr shared,
 }
 
 LinearLayout getScaleSmemLayoutForTMEMCopy(MLIRContext *ctx,
-                                           ArrayRef<int64_t> shape) {
+                                           ArrayRef<int64_t> shape,
+                                           CGAEncodingAttr cgaLayout) {
   assert(shape.size() == 2 && "scale layout expects rank-2");
   assert(shape[0] % 128 == 0 && "scale rows must be a multiple of 128");
   assert(shape[1] % 4 == 0 && "scale columns must be a multiple of 4");
@@ -258,7 +259,9 @@ LinearLayout getScaleSmemLayoutForTMEMCopy(MLIRContext *ctx,
       LinearLayout::identity1D(4, kColLo, outDims[1]) *
       LinearLayout::identity1D(outerCols, kOuterCol, outDims[1]);
 
-  return offsetToChunked.compose(chunkedToLogical).transposeOuts(outDims);
+  return combineCtaCgaWithShape(
+      offsetToChunked.compose(chunkedToLogical).transposeOuts(outDims),
+      cgaLayout, shape);
 }
 
 static FailureOr<LinearLayout> buildNvmmaSharedLinearLayout(

--- a/lib/Dialect/TritonGPU/IR/LinearLayoutConversions.cpp
+++ b/lib/Dialect/TritonGPU/IR/LinearLayoutConversions.cpp
@@ -193,8 +193,8 @@ LinearLayout getCoreMatrixLinearLayout(NVMMASharedEncodingAttr shared,
   return LinearLayout({{S("offset"), bases2D}}, outDimNames);
 }
 
-LinearLayout getCanonicalScaleSmemLinearLayout(MLIRContext *ctx,
-                                               ArrayRef<int64_t> shape) {
+LinearLayout getScaleSmemLayoutForTMEMCopy(MLIRContext *ctx,
+                                           ArrayRef<int64_t> shape) {
   assert(shape.size() == 2 && "scale layout expects rank-2");
   assert(shape[0] % 128 == 0 && "scale rows must be a multiple of 128");
   assert(shape[1] % 4 == 0 && "scale columns must be a multiple of 4");

--- a/lib/Dialect/TritonGPU/IR/LinearLayoutConversions.cpp
+++ b/lib/Dialect/TritonGPU/IR/LinearLayoutConversions.cpp
@@ -194,7 +194,7 @@ LinearLayout getCoreMatrixLinearLayout(NVMMASharedEncodingAttr shared,
 }
 
 LinearLayout getCanonicalScaleSmemLinearLayout(MLIRContext *ctx,
-                                             ArrayRef<int64_t> shape) {
+                                               ArrayRef<int64_t> shape) {
   assert(shape.size() == 2 && "scale layout expects rank-2");
   assert(shape[0] % 128 == 0 && "scale rows must be a multiple of 128");
   assert(shape[1] % 4 == 0 && "scale columns must be a multiple of 4");
@@ -213,9 +213,17 @@ LinearLayout getCanonicalScaleSmemLinearLayout(MLIRContext *ctx,
   int32_t outerRows = rows / (32 * 4);
   int32_t outerCols = cols / 4;
 
-  // Reinterpret a flat row-major SMEM byte layout through the semantic
-  // pre-transpose scale tile [outerRow, outerCol, rowLo=32, rowMid=4, colLo=4],
-  // then map those chunked dimensions back to the final logical 2D tensor.
+  // Build the semantic pre-transpose chunked view that the user/kernel
+  // convention exposes before flattening back to 2D.
+  //
+  // Scale example:
+  //   shape         = [256, 16]
+  //   innerColSize  = 4
+  //   rowMidSize    = 4
+  //   rowLoSize     = 32
+  //
+  // The logical 2D scale tensor is interpreted as:
+  //   [outerRow=2, outerCol=4, rowLo=32, rowMid=4, colLo=4]
   auto offsetToChunked = LinearLayout::identity1D(rows * cols, kOffset, kFlat)
                              .reshapeOuts({{kColLo, 4},
                                            {kRowMid, 4},
@@ -223,6 +231,23 @@ LinearLayout getCanonicalScaleSmemLinearLayout(MLIRContext *ctx,
                                            {kOuterCol, outerCols},
                                            {kOuterRow, outerRows}});
 
+  // Start from a flat row-major SMEM layout over `rows * cols` bytes and
+  // reinterpret it as the chunked view above.
+  //
+  // Scale example:
+  //   offset -> flat[4096]
+  //          -> [colLo=4, rowMid=4, rowLo=32, outerCol=4, outerRow=2]
+
+  // Map each chunked dimension back to the final logical 2D tensor:
+  //   - colLo and outerCol both contribute to dim1
+  //   - rowLo, rowMid, and outerRow all contribute to dim0
+  //
+  // Scale example:
+  //   colLo    = 4      -> dim1 low bits
+  //   rowLo    = 32     -> dim0 low bits
+  //   rowMid   = 4      -> dim0 middle bits
+  //   outerCol = 4      -> dim1 high bits
+  //   outerRow = 2      -> dim0 high bits
   LinearLayout chunkedToLogical =
       LinearLayout::identity1D(32, kRowLo, outDims[0]) *
       LinearLayout::identity1D(4, kRowMid, outDims[0]) *

--- a/lib/Dialect/TritonGPU/IR/LinearLayoutConversions.cpp
+++ b/lib/Dialect/TritonGPU/IR/LinearLayoutConversions.cpp
@@ -193,6 +193,46 @@ LinearLayout getCoreMatrixLinearLayout(NVMMASharedEncodingAttr shared,
   return LinearLayout({{S("offset"), bases2D}}, outDimNames);
 }
 
+LinearLayout getCanonicalScaleSmemLinearLayout(MLIRContext *ctx,
+                                             ArrayRef<int64_t> shape) {
+  assert(shape.size() == 2 && "scale layout expects rank-2");
+  assert(shape[0] % 128 == 0 && "scale rows must be a multiple of 128");
+  assert(shape[1] % 4 == 0 && "scale columns must be a multiple of 4");
+
+  auto rows = shape[0];
+  auto cols = shape[1];
+  auto kOffset = S("offset");
+  auto kFlat = S("flat");
+  auto kColLo = S("colLo");
+  auto kRowMid = S("rowMid");
+  auto kRowLo = S("rowLo");
+  auto kOuterCol = S("outerCol");
+  auto kOuterRow = S("outerRow");
+  auto outDims = standardOutDimNames(ctx, 2);
+
+  int32_t outerRows = rows / (32 * 4);
+  int32_t outerCols = cols / 4;
+
+  // Reinterpret a flat row-major SMEM byte layout through the semantic
+  // pre-transpose scale tile [outerRow, outerCol, rowLo=32, rowMid=4, colLo=4],
+  // then map those chunked dimensions back to the final logical 2D tensor.
+  auto offsetToChunked = LinearLayout::identity1D(rows * cols, kOffset, kFlat)
+                             .reshapeOuts({{kColLo, 4},
+                                           {kRowMid, 4},
+                                           {kRowLo, 32},
+                                           {kOuterCol, outerCols},
+                                           {kOuterRow, outerRows}});
+
+  LinearLayout chunkedToLogical =
+      LinearLayout::identity1D(32, kRowLo, outDims[0]) *
+      LinearLayout::identity1D(4, kRowMid, outDims[0]) *
+      LinearLayout::identity1D(outerRows, kOuterRow, outDims[0]) *
+      LinearLayout::identity1D(4, kColLo, outDims[1]) *
+      LinearLayout::identity1D(outerCols, kOuterCol, outDims[1]);
+
+  return offsetToChunked.compose(chunkedToLogical).transposeOuts(outDims);
+}
+
 static FailureOr<LinearLayout> buildNvmmaSharedLinearLayout(
     ArrayRef<int64_t> shape, NVMMASharedEncodingAttr shared,
     ArrayRef<int64_t> tmaShape, bool disableSwizzle, bool emitErrors) {

--- a/lib/Dialect/TritonGPU/IR/LinearLayoutConversions.cpp
+++ b/lib/Dialect/TritonGPU/IR/LinearLayoutConversions.cpp
@@ -224,12 +224,13 @@ LinearLayout getCanonicalScaleSmemLinearLayout(MLIRContext *ctx,
   //
   // The logical 2D scale tensor is interpreted as:
   //   [outerRow=2, outerCol=4, rowLo=32, rowMid=4, colLo=4]
-  auto offsetToChunked = LinearLayout::identity1D(rows * cols, kOffset, kFlat)
-                             .reshapeOuts({{kColLo, 4},
-                                           {kRowMid, 4},
-                                           {kRowLo, 32},
-                                           {kOuterCol, outerCols},
-                                           {kOuterRow, outerRows}});
+  SmallVector<std::pair<StringAttr, int32_t>> chunkedDims = {
+      {kColLo, 4},
+      {kRowMid, 4},
+      {kRowLo, 32},
+      {kOuterCol, outerCols},
+      {kOuterRow, outerRows},
+  };
 
   // Start from a flat row-major SMEM layout over `rows * cols` bytes and
   // reinterpret it as the chunked view above.
@@ -237,6 +238,8 @@ LinearLayout getCanonicalScaleSmemLinearLayout(MLIRContext *ctx,
   // Scale example:
   //   offset -> flat[4096]
   //          -> [colLo=4, rowMid=4, rowLo=32, outerCol=4, outerRow=2]
+  auto offsetToChunked = LinearLayout::identity1D(rows * cols, kOffset, kFlat)
+                             .reshapeOuts(chunkedDims);
 
   // Map each chunked dimension back to the final logical 2D tensor:
   //   - colLo and outerCol both contribute to dim1

--- a/lib/Dialect/TritonGPU/Transforms/AccelerateMatmul.cpp
+++ b/lib/Dialect/TritonGPU/Transforms/AccelerateMatmul.cpp
@@ -198,21 +198,6 @@ getSharedMemoryMMAOperand(Value v, mlir::PatternRewriter &rewriter, int opIdx,
   return LocalAllocOp::create(rewriter, arg.getLoc(), newType, arg);
 }
 
-static MemDescType getCanonicalScaleMemDescType(RankedTensorType type) {
-  auto sharedMemory = SharedMemorySpaceAttr::get(type.getContext());
-  auto sinkLayout =
-      getCanonicalScaleSmemLinearLayout(type.getContext(), type.getShape());
-  auto bases = sinkLayout.getBases();
-  bases[StringAttr::get(type.getContext(), "block")] = {};
-  sinkLayout = LinearLayout(std::move(bases), sinkLayout.getOutDims(),
-                            /*requireSurjective=*/sinkLayout.isSurjective());
-  auto layout =
-      SharedLinearEncodingAttr::get(type.getContext(), std::move(sinkLayout),
-                                    /*alignment=*/128);
-  return MemDescType::get(type.getShape(), type.getElementType(), layout,
-                          sharedMemory, /*mutableMemory=*/false);
-}
-
 static bool isTmemCopyCompatibleScale(RankedTensorType argType,
                                       bool usesTMAload) {
   assert(argType.getEncoding() && "unexpected tensor type");
@@ -319,11 +304,22 @@ tryCreateTmemCopyCompatibleScaleOperand(Value scale,
   if (!isTmemCopyCompatibleScale(packedScaleType, usesTMAload))
     return Value();
 
-  Value logicalScale = reshape2D.getResult();
-  auto sinkType = getCanonicalScaleMemDescType(scaleType);
-  rewriter.setInsertionPointAfterValue(logicalScale);
+  auto sharedMemory = SharedMemorySpaceAttr::get(scaleType.getContext());
+  auto sinkLayout = getScaleSmemLayoutForTMEMCopy(scaleType.getContext(),
+                                                  scaleType.getShape());
+  auto bases = sinkLayout.getBases();
+  bases[StringAttr::get(scaleType.getContext(), "block")] = {};
+  sinkLayout = LinearLayout(std::move(bases), sinkLayout.getOutDims(),
+                            /*requireSurjective=*/sinkLayout.isSurjective());
+  auto layout = SharedLinearEncodingAttr::get(scaleType.getContext(),
+                                              std::move(sinkLayout),
+                                              /*alignment=*/128);
+  auto sinkType =
+      MemDescType::get(scaleType.getShape(), scaleType.getElementType(), layout,
+                       sharedMemory, /*mutableMemory=*/false);
+  rewriter.setInsertionPointAfterValue(reshape2D.getResult());
   return LocalAllocOp::create(rewriter, reshape2D.getLoc(), sinkType,
-                              logicalScale);
+                              reshape2D.getResult());
 }
 
 static Value createTmemScaleOperand(Value tensor, Attribute tmemEncoding,

--- a/lib/Dialect/TritonGPU/Transforms/AccelerateMatmul.cpp
+++ b/lib/Dialect/TritonGPU/Transforms/AccelerateMatmul.cpp
@@ -198,7 +198,6 @@ getSharedMemoryMMAOperand(Value v, mlir::PatternRewriter &rewriter, int opIdx,
   return LocalAllocOp::create(rewriter, arg.getLoc(), newType, arg);
 }
 
-
 static MemDescType getCanonicalScaleMemDescType(RankedTensorType type) {
   auto sharedMemory = SharedMemorySpaceAttr::get(type.getContext());
   auto sinkLayout =
@@ -214,29 +213,34 @@ static MemDescType getCanonicalScaleMemDescType(RankedTensorType type) {
                           sharedMemory, /*mutableMemory=*/false);
 }
 
-static bool isTmemCopyCompatibleScale(RankedTensorType packedScaleType,
+static bool isTmemCopyCompatibleScale(RankedTensorType argType,
                                       bool usesTMAload) {
-  auto sharedMemory = SharedMemorySpaceAttr::get(packedScaleType.getContext());
-  auto cgaLayout = getCGALayout(packedScaleType.getEncoding());
-  auto sharedLayout = NVMMASharedEncodingAttr::get(
-      packedScaleType.getContext(), /*swizzlingByteWidth=*/0,
-      /*transposed=*/false, /*elementBitWidth=*/8,
-      /*fp4Padded=*/false, cgaLayout);
-  auto sharedType = MemDescType::get(packedScaleType.getShape(),
-                                     packedScaleType.getElementType(),
-                                     sharedLayout, sharedMemory,
-                                     /*mutableMemory=*/false);
-  if (!isInnermostContiguous(sharedType, 512))
-    return false;
+  assert(argType.getEncoding() && "unexpected tensor type");
+  {
+    auto shmemLayout = NVMMASharedEncodingAttr::get(
+        argType.getContext(), /*swizzlingByteWidth=*/0,
+        /*transposed=*/false,
+        /*elementBitWidth=*/8,
+        /*fp4Padded=*/false, getCGALayout(argType.getEncoding()));
+    auto type = MemDescType::get(
+        argType.getShape(), argType.getElementType(), shmemLayout,
+        SharedMemorySpaceAttr::get(argType.getContext()));
+    if (!isInnermostContiguous(type, 512)) {
+      // TMEM copy expects metadata "chunks" in SMEM to be stored contiguously
+      // in the innermost axes.
+      return false;
+    }
+  }
 
   if (usesTMAload)
     return true;
 
-  if (packedScaleType.getRank() != 2)
+  if (argType.getRank() != 2) {
+    // TODO: Add support for higher rank when 5D coalesced load is fixed.
     return false;
+  }
 
-  auto innermostBits =
-      packedScaleType.getDimSize(packedScaleType.getRank() - 1) * 8;
+  auto innermostBits = argType.getDimSize(argType.getRank() - 1) * 8;
   return innermostBits % (32 * 128) == 0;
 }
 
@@ -253,8 +257,9 @@ static Value stripConvertLayout(Value value) {
   return value;
 }
 
-static Value tryCreateTmemCopyCompatibleScaleOperand(
-    Value scale, mlir::PatternRewriter &rewriter) {
+static Value
+tryCreateTmemCopyCompatibleScaleOperand(Value scale,
+                                        mlir::PatternRewriter &rewriter) {
   OpBuilder::InsertionGuard g(rewriter);
   // The final reshape to conform to the logical shape requirement of
   // dot_scaled.
@@ -273,7 +278,8 @@ static Value tryCreateTmemCopyCompatibleScaleOperand(
     return Value();
 
   // Permute to expose the 32x4x4 interleaving used by scale blocks in TMEM.
-  auto transOp = getDefiningOpSkippingConvertLayout<TransOp>(reshape2D.getSrc());
+  auto transOp =
+      getDefiningOpSkippingConvertLayout<TransOp>(reshape2D.getSrc());
   if (!transOp || transOp.getOrder() != ArrayRef<int32_t>({0, 3, 2, 1, 4}))
     return Value();
 
@@ -322,15 +328,13 @@ static Value tryCreateTmemCopyCompatibleScaleOperand(
 
 static Value createTmemScaleOperand(Value tensor, Attribute tmemEncoding,
                                     Attribute tensorMemorySpace, int numWarps,
-                                    Location loc,
-                                    PatternRewriter &rewriter) {
+                                    Location loc, PatternRewriter &rewriter) {
   auto tensorType = cast<RankedTensorType>(tensor.getType());
-  auto tmemType = MemDescType::get(tensorType.getShape(),
-                                   tensorType.getElementType(), tmemEncoding,
-                                   tensorMemorySpace,
-                                   /*mutableMemory=*/false);
-  auto tmemLayout =
-      nvidia_gpu::getDefaultLayoutForTmemLdSt(tmemType, numWarps);
+  auto tmemType =
+      MemDescType::get(tensorType.getShape(), tensorType.getElementType(),
+                       tmemEncoding, tensorMemorySpace,
+                       /*mutableMemory=*/false);
+  auto tmemLayout = nvidia_gpu::getDefaultLayoutForTmemLdSt(tmemType, numWarps);
   auto stagedType = tensorType.cloneWithEncoding(tmemLayout);
   Value converted = ConvertLayoutOp::create(rewriter, loc, stagedType, tensor);
   return triton::nvidia_gpu::TMEMAllocOp::create(rewriter, loc, tmemType,
@@ -679,7 +683,6 @@ public:
   }
 };
 
-
 class ScaledBlockedToMMA : public mlir::OpRewritePattern<triton::DotScaledOp> {
   int computeCapability;
 
@@ -878,23 +881,22 @@ public:
     Value scaleA =
         tryCreateTmemCopyCompatibleScaleOperand(dotOp.getAScale(), rewriter);
     if (!scaleA) {
-      scaleA = createTmemScaleOperand(dotOp.getAScale(), scaleEncoding,
-                                      tensorMemorySpace, numWarps, loc,
-                                      rewriter);
+      scaleA =
+          createTmemScaleOperand(dotOp.getAScale(), scaleEncoding,
+                                 tensorMemorySpace, numWarps, loc, rewriter);
     }
     Value scaleB =
         tryCreateTmemCopyCompatibleScaleOperand(dotOp.getBScale(), rewriter);
     if (!scaleB) {
-      scaleB = createTmemScaleOperand(dotOp.getBScale(), scaleEncoding,
-                                      tensorMemorySpace, numWarps, loc,
-                                      rewriter);
+      scaleB =
+          createTmemScaleOperand(dotOp.getBScale(), scaleEncoding,
+                                 tensorMemorySpace, numWarps, loc, rewriter);
     }
 
     auto vTrue = arith::ConstantIntOp::create(rewriter, dotOp.getLoc(), 1, 1);
     auto mmaOp = triton::nvidia_gpu::TCGen5MMAScaledOp::create(
-        rewriter, loc, tokType, a, b, acc.getResult(), acc.getToken(),
-        scaleA, scaleB, dotOp.getAElemType(),
-        dotOp.getBElemType(),
+        rewriter, loc, tokType, a, b, acc.getResult(), acc.getToken(), scaleA,
+        scaleB, dotOp.getAElemType(), dotOp.getBElemType(),
         /*useD=*/vTrue, /*pred=*/vTrue);
 
     auto ld = triton::nvidia_gpu::TMEMLoadOp::create(

--- a/lib/Dialect/TritonGPU/Transforms/AccelerateMatmul.cpp
+++ b/lib/Dialect/TritonGPU/Transforms/AccelerateMatmul.cpp
@@ -198,26 +198,143 @@ getSharedMemoryMMAOperand(Value v, mlir::PatternRewriter &rewriter, int opIdx,
   return LocalAllocOp::create(rewriter, arg.getLoc(), newType, arg);
 }
 
-static LocalAllocOp
-getSharedMemoryScale(Value arg, mlir::PatternRewriter &rewriter, Location loc) {
-  OpBuilder::InsertionGuard g(rewriter);
-  auto argType = cast<RankedTensorType>(arg.getType());
-  assert(argType.getEncoding() && "unexpected tensor type");
-  auto newOrder = getOrderForMemory(argType);
 
-  Attribute SharedMemorySpace =
-      SharedMemorySpaceAttr::get(argType.getContext());
-  auto CGALayout = getCGALayout(argType.getEncoding());
-  // No swizzling for scale for now
-  auto newLayout = NVMMASharedEncodingAttr::get(
-      argType.getContext(), /*swizzlingByteWidth=*/0,
-      /*transposed=*/false,
-      /*elementBitWidth=*/argType.getElementType().getIntOrFloatBitWidth(),
-      /*fp4Padded=*/false, CGALayout);
-  auto newType = MemDescType::get(argType.getShape(), argType.getElementType(),
-                                  newLayout, SharedMemorySpace);
-  rewriter.setInsertionPointAfterValue(arg);
-  return LocalAllocOp::create(rewriter, loc, newType, arg);
+static MemDescType getCanonicalScaleMemDescType(RankedTensorType type) {
+  auto sharedMemory = SharedMemorySpaceAttr::get(type.getContext());
+  auto sinkLayout =
+      getCanonicalScaleSmemLinearLayout(type.getContext(), type.getShape());
+  auto bases = sinkLayout.getBases();
+  bases[StringAttr::get(type.getContext(), "block")] = {};
+  sinkLayout = LinearLayout(std::move(bases), sinkLayout.getOutDims(),
+                            /*requireSurjective=*/sinkLayout.isSurjective());
+  auto layout =
+      SharedLinearEncodingAttr::get(type.getContext(), std::move(sinkLayout),
+                                    /*alignment=*/128);
+  return MemDescType::get(type.getShape(), type.getElementType(), layout,
+                          sharedMemory, /*mutableMemory=*/false);
+}
+
+static bool isTmemCopyCompatibleScale(RankedTensorType packedScaleType,
+                                      bool usesTMAload) {
+  auto sharedMemory = SharedMemorySpaceAttr::get(packedScaleType.getContext());
+  auto cgaLayout = getCGALayout(packedScaleType.getEncoding());
+  auto sharedLayout = NVMMASharedEncodingAttr::get(
+      packedScaleType.getContext(), /*swizzlingByteWidth=*/0,
+      /*transposed=*/false, /*elementBitWidth=*/8,
+      /*fp4Padded=*/false, cgaLayout);
+  auto sharedType = MemDescType::get(packedScaleType.getShape(),
+                                     packedScaleType.getElementType(),
+                                     sharedLayout, sharedMemory,
+                                     /*mutableMemory=*/false);
+  if (!isInnermostContiguous(sharedType, 512))
+    return false;
+
+  if (usesTMAload)
+    return true;
+
+  if (packedScaleType.getRank() != 2)
+    return false;
+
+  auto innermostBits =
+      packedScaleType.getDimSize(packedScaleType.getRank() - 1) * 8;
+  return innermostBits % (32 * 128) == 0;
+}
+
+template <typename OpTy>
+static OpTy getDefiningOpSkippingConvertLayout(Value value) {
+  while (auto cvtOp = value.getDefiningOp<ConvertLayoutOp>())
+    value = cvtOp.getSrc();
+  return value.getDefiningOp<OpTy>();
+}
+
+static Value stripConvertLayout(Value value) {
+  while (auto cvtOp = value.getDefiningOp<ConvertLayoutOp>())
+    value = cvtOp.getSrc();
+  return value;
+}
+
+static Value tryCreateTmemCopyCompatibleScaleOperand(
+    Value scale, mlir::PatternRewriter &rewriter) {
+  OpBuilder::InsertionGuard g(rewriter);
+  // The final reshape to conform to the logical shape requirement of
+  // dot_scaled.
+  auto reshape2D = getDefiningOpSkippingConvertLayout<ReshapeOp>(scale);
+  if (!reshape2D)
+    return Value();
+
+  auto scaleType = dyn_cast<RankedTensorType>(reshape2D.getResult().getType());
+  if (!scaleType || scaleType.getShape().size() != 2)
+    return Value();
+
+  auto scale2DShape = scaleType.getShape();
+  auto blockMN = scale2DShape[0];
+  auto numScales = scale2DShape[1];
+  if (blockMN % 128 != 0 || numScales % 4 != 0)
+    return Value();
+
+  // Permute to expose the 32x4x4 interleaving used by scale blocks in TMEM.
+  auto transOp = getDefiningOpSkippingConvertLayout<TransOp>(reshape2D.getSrc());
+  if (!transOp || transOp.getOrder() != ArrayRef<int32_t>({0, 3, 2, 1, 4}))
+    return Value();
+
+  // A logical scale tensor has shape [block_mn, num_scales]. The tensor view
+  // chain in a user kernel signals TMEMCopy compatibility by exposing the
+  // underlying 128x4 scale block as
+  //     --reshape
+  //   [mn_copy_tiles, k_copy_tiles, 32, 4, 4]
+  //     --trans {0, 3, 2, 1, 4}-->
+  //   [mn_copy_tiles, 4, 32, k_copy_tiles, 4]
+  //     --flatten-->
+  //   [block_mn, num_scales]
+  //
+  // The block shape with which the scale tensor is loaded is flexible:
+  // For example, [.., 2, 256], [.., 512], and [.., 32, 4, 4] are all acceptable
+  // as long as a reshape exposes the same 32x4x4 blocks before the transpose.
+  auto mnCopyTiles = blockMN / 128;
+  auto kCopyTiles = numScales / 4;
+  SmallVector<int64_t> tiledScaleShape = {mnCopyTiles, kCopyTiles, 32, 4, 4};
+
+  Value tiledScale = stripConvertLayout(transOp.getSrc());
+  auto reshapeTiled = tiledScale.getDefiningOp<ReshapeOp>();
+  if (!reshapeTiled ||
+      reshapeTiled.getType().getShape() != ArrayRef<int64_t>(tiledScaleShape))
+    return Value();
+
+  Value packedScale = stripConvertLayout(reshapeTiled.getSrc());
+  auto packedScaleType = dyn_cast<RankedTensorType>(packedScale.getType());
+  if (!packedScaleType)
+    return Value();
+
+  auto *loadOp = packedScale.getDefiningOp();
+  if (!isa_and_nonnull<LoadOp, DescriptorLoadLikeOpInterface>(loadOp))
+    return Value();
+
+  bool usesTMAload = isa<DescriptorLoadLikeOpInterface>(loadOp);
+  if (!isTmemCopyCompatibleScale(packedScaleType, usesTMAload))
+    return Value();
+
+  Value logicalScale = reshape2D.getResult();
+  auto sinkType = getCanonicalScaleMemDescType(scaleType);
+  rewriter.setInsertionPointAfterValue(logicalScale);
+  return LocalAllocOp::create(rewriter, reshape2D.getLoc(), sinkType,
+                              logicalScale);
+}
+
+static Value createTmemScaleOperand(Value tensor, Attribute tmemEncoding,
+                                    Attribute tensorMemorySpace, int numWarps,
+                                    Location loc,
+                                    PatternRewriter &rewriter) {
+  auto tensorType = cast<RankedTensorType>(tensor.getType());
+  auto tmemType = MemDescType::get(tensorType.getShape(),
+                                   tensorType.getElementType(), tmemEncoding,
+                                   tensorMemorySpace,
+                                   /*mutableMemory=*/false);
+  auto tmemLayout =
+      nvidia_gpu::getDefaultLayoutForTmemLdSt(tmemType, numWarps);
+  auto stagedType = tensorType.cloneWithEncoding(tmemLayout);
+  Value converted = ConvertLayoutOp::create(rewriter, loc, stagedType, tensor);
+  return triton::nvidia_gpu::TMEMAllocOp::create(rewriter, loc, tmemType,
+                                                 /*token=*/Type(), converted);
 }
 
 SmallVector<unsigned, 3>
@@ -562,59 +679,6 @@ public:
   }
 };
 
-Value addSmemStageToScaleLoad(Value scale, mlir::PatternRewriter &rewriter) {
-  /*
-    Rewrite load(scale) -> local_load(local_alloc(load(scale))).
-    This function does not add anything to the final IR when num_stages > 1,
-    but it makes it easy to apply TMEM copy rewriting later.
-
-    Since scales are stored in TMEM for MMAv5 scaled dot, loading of scales do
-    not needs to be put into SMEM. But in practice, the software pipeliner puts
-    loading of scales into multi-buffered SMEM. At that point, the SMEM
-    allocation created here is eliminated.
-   */
-  OpBuilder::InsertionGuard g(rewriter);
-  auto op = scale.getDefiningOp();
-  Operation *loadConsumer = nullptr;
-
-  if (!op)
-    return scale;
-
-  while (!isa<LoadOp, DescriptorLoadLikeOpInterface>(op)) {
-    if (auto reshape = dyn_cast<ReshapeOp>(op)) {
-      op = reshape.getSrc().getDefiningOp();
-      loadConsumer = reshape;
-    } else if (auto trans = dyn_cast<TransOp>(op)) {
-      op = trans.getSrc().getDefiningOp();
-      loadConsumer = trans;
-    } else if (auto cvt = dyn_cast<ConvertLayoutOp>(op)) {
-      op = cvt.getSrc().getDefiningOp();
-      loadConsumer = cvt;
-    } else {
-      // Unrecognized pattern, bail out. In practice, this implies that MMA
-      // pipelining will not apply to the scaled dot op, since scales will not
-      // be in passed through SMEM to tc_gen5_mma_scaled.
-      return scale;
-    }
-  }
-
-  auto scaleAfterLoad = op->getResult(0);
-  auto scaleSmemAlloc =
-      getSharedMemoryScale(scaleAfterLoad, rewriter, op->getLoc());
-
-  rewriter.setInsertionPointAfterValue(scaleSmemAlloc);
-  auto localLoad = LocalLoadOp::create(
-      rewriter, op->getLoc(), scaleAfterLoad.getType(), scaleSmemAlloc);
-
-  rewriter.replaceAllUsesExcept(scaleAfterLoad, localLoad.getResult(),
-                                scaleSmemAlloc);
-
-  if (loadConsumer) {
-    return scale;
-  } else {
-    return localLoad;
-  }
-}
 
 class ScaledBlockedToMMA : public mlir::OpRewritePattern<triton::DotScaledOp> {
   int computeCapability;
@@ -811,42 +875,25 @@ public:
     Attribute scaleEncoding =
         triton::nvidia_gpu::TensorMemoryScalesEncodingAttr::get(context,
                                                                 CGALayout);
-    MemDescType scaleAType = triton::gpu::MemDescType::get(
-        oldScaleAType.getShape(), oldScaleAType.getElementType(), scaleEncoding,
-        tensorMemorySpace,
-        /*mutableMemory=*/false);
-    MemDescType scaleBType = triton::gpu::MemDescType::get(
-        oldScaleBType.getShape(), oldScaleBType.getElementType(), scaleEncoding,
-        tensorMemorySpace,
-        /*mutableMemory=*/false);
-    Attribute scaleALayout =
-        nvidia_gpu::getDefaultLayoutForTmemLdSt(scaleAType, numWarps);
-    Attribute scaleBLayout =
-        nvidia_gpu::getDefaultLayoutForTmemLdSt(scaleBType, numWarps);
-    RankedTensorType newScaleAType =
-        oldScaleAType.cloneWithEncoding(scaleALayout);
-    RankedTensorType newScaleBType =
-        oldScaleBType.cloneWithEncoding(scaleBLayout);
-
-    auto lhsScale = addSmemStageToScaleLoad(dotOp.getAScale(), rewriter);
-    auto rhsScale = addSmemStageToScaleLoad(dotOp.getBScale(), rewriter);
-
-    Value newScaleA =
-        ConvertLayoutOp::create(rewriter, loc, newScaleAType, lhsScale);
-    Value newScaleB =
-        ConvertLayoutOp::create(rewriter, loc, newScaleBType, rhsScale);
-
-    // We don't need to track memory dependencies for the scale operands since
-    // they are not pipelined.
-    auto scaleA = triton::nvidia_gpu::TMEMAllocOp::create(
-        rewriter, loc, scaleAType, /*token=*/Type(), newScaleA);
-    auto scaleB = triton::nvidia_gpu::TMEMAllocOp::create(
-        rewriter, loc, scaleBType, /*token=*/Type(), newScaleB);
+    Value scaleA =
+        tryCreateTmemCopyCompatibleScaleOperand(dotOp.getAScale(), rewriter);
+    if (!scaleA) {
+      scaleA = createTmemScaleOperand(dotOp.getAScale(), scaleEncoding,
+                                      tensorMemorySpace, numWarps, loc,
+                                      rewriter);
+    }
+    Value scaleB =
+        tryCreateTmemCopyCompatibleScaleOperand(dotOp.getBScale(), rewriter);
+    if (!scaleB) {
+      scaleB = createTmemScaleOperand(dotOp.getBScale(), scaleEncoding,
+                                      tensorMemorySpace, numWarps, loc,
+                                      rewriter);
+    }
 
     auto vTrue = arith::ConstantIntOp::create(rewriter, dotOp.getLoc(), 1, 1);
     auto mmaOp = triton::nvidia_gpu::TCGen5MMAScaledOp::create(
         rewriter, loc, tokType, a, b, acc.getResult(), acc.getToken(),
-        scaleA.getResult(), scaleB.getResult(), dotOp.getAElemType(),
+        scaleA, scaleB, dotOp.getAElemType(),
         dotOp.getBElemType(),
         /*useD=*/vTrue, /*pred=*/vTrue);
 

--- a/lib/Dialect/TritonGPU/Transforms/AccelerateMatmul.cpp
+++ b/lib/Dialect/TritonGPU/Transforms/AccelerateMatmul.cpp
@@ -305,12 +305,9 @@ tryCreateTmemCopyCompatibleScaleOperand(Value scale,
     return Value();
 
   auto sharedMemory = SharedMemorySpaceAttr::get(scaleType.getContext());
-  auto sinkLayout = getScaleSmemLayoutForTMEMCopy(scaleType.getContext(),
-                                                  scaleType.getShape());
-  auto bases = sinkLayout.getBases();
-  bases[StringAttr::get(scaleType.getContext(), "block")] = {};
-  sinkLayout = LinearLayout(std::move(bases), sinkLayout.getOutDims(),
-                            /*requireSurjective=*/sinkLayout.isSurjective());
+  auto sinkLayout = getScaleSmemLayoutForTMEMCopy(
+      scaleType.getContext(), scaleType.getShape(),
+      getCGALayout(scaleType.getEncoding()));
   auto layout = SharedLinearEncodingAttr::get(scaleType.getContext(),
                                               std::move(sinkLayout),
                                               /*alignment=*/128);

--- a/lib/Dialect/TritonGPU/Transforms/OptimizeDotOperands.cpp
+++ b/lib/Dialect/TritonGPU/Transforms/OptimizeDotOperands.cpp
@@ -209,6 +209,14 @@ public:
     if (rewriteOperand(dotOp.getB(), rewriter).succeeded())
       changed = true;
 
+    if (auto mmaScaledOp = dyn_cast<triton::nvidia_gpu::TCGen5MMAScaledOp>(
+            dotOp.getOperation())) {
+      if (rewriteOperand(mmaScaledOp.getAScale(), rewriter).succeeded())
+        changed = true;
+      if (rewriteOperand(mmaScaledOp.getBScale(), rewriter).succeeded())
+        changed = true;
+    }
+
     return success(changed);
   }
 
@@ -292,143 +300,6 @@ private:
   }
 };
 
-// Inject TMEM copy instructions into IR to efficiently load blocked scales for
-// scaled dot
-class UseShmemForScales
-    : public OpRewritePattern<triton::nvidia_gpu::TCGen5MMAScaledOp> {
-public:
-  using OpRewritePattern<
-      triton::nvidia_gpu::TCGen5MMAScaledOp>::OpRewritePattern;
-
-  LogicalResult matchAndRewrite(triton::nvidia_gpu::TCGen5MMAScaledOp mmaOp,
-                                PatternRewriter &rewriter) const override {
-    auto aScale = mmaOp.getAScale();
-    auto bScale = mmaOp.getBScale();
-    LogicalResult ret = failure();
-    if (aScale && isa<triton::nvidia_gpu::TensorMemoryScalesEncodingAttr>(
-                      aScale.getType().getEncoding())) {
-      if (rewriteOperand(mmaOp.getAScaleMutable(), rewriter).succeeded())
-        ret = success();
-    }
-    if (bScale && isa<triton::nvidia_gpu::TensorMemoryScalesEncodingAttr>(
-                      bScale.getType().getEncoding())) {
-      if (rewriteOperand(mmaOp.getBScaleMutable(), rewriter).succeeded())
-        ret = success();
-    }
-    return ret;
-  }
-
-private:
-  LogicalResult rewriteOperand(OpOperand &opOperand,
-                               PatternRewriter &rewriter) const {
-    auto src = cast<TypedValue<MemDescType>>(opOperand.get());
-    auto tmemAlloc = src.getDefiningOp<triton::nvidia_gpu::TMEMAllocOp>();
-    if (!tmemAlloc) {
-      return failure();
-    }
-    auto dstType = tmemAlloc.getResult().getType();
-
-    if (!tmemAlloc.getSrc()) {
-      return failure();
-    }
-
-    // Look for a sequence
-    //    local_load
-    // -> reshape(..., (BLOCK_MN / 128, BLOCK_K / scale_vec_size / 4, 32, 4,
-    // 4)
-    // -> transpose(..., (0, 3, 2, 1, 4))
-    // -> reshape(..., (BLOCK_MN, BLOCK_K / scale_vec_size)
-    // -> tmem_alloc
-    // -> tc_gen_mma_scaled
-    // and replace it with local_alloc -> tc_gen_mma_scaled
-    auto scale2DShape = dstType.getShape();
-    auto blockMN = scale2DShape[0];
-    auto numScales = scale2DShape[1];
-    const SmallVector<int> transposeOrder{0, 3, 2, 1, 4};
-    const SmallVector<int64_t> reshape5DShape{blockMN / 128, numScales / 4, 32,
-                                              4, 4};
-
-    auto reshapeOp2D = getNextOp<triton::ReshapeOp>(tmemAlloc.getSrc());
-    if (!reshapeOp2D ||
-        reshapeOp2D.getResult().getType().getShape() != scale2DShape) {
-      return failure();
-    }
-
-    auto transOp = getNextOp<triton::TransOp>(reshapeOp2D.getSrc());
-    if (!transOp || transOp.getOrder() != ArrayRef<int>(transposeOrder)) {
-      return failure();
-    }
-
-    auto reshapeOp5D = getNextOp<triton::ReshapeOp>(transOp.getSrc());
-    if (!reshapeOp5D || reshapeOp5D.getResult().getType().getShape() !=
-                            ArrayRef<int64_t>(reshape5DShape)) {
-      return failure();
-    }
-
-    auto localLoad = getNextOp<triton::gpu::LocalLoadOp>(reshapeOp5D.getSrc());
-    if (!localLoad) {
-      return failure();
-    }
-    auto localAlloc = getNextOp<LocalAllocOp>(localLoad.getSrc());
-    bool usesTMAload =
-        localAlloc && localAlloc.getSrc() &&
-        getNextOp<DescriptorLoadLikeOpInterface>(localAlloc.getSrc());
-    if (!isTmemCopyCompatible(localLoad.getSrc().getType(), usesTMAload))
-      return failure();
-
-    PatternRewriter::InsertionGuard guard(rewriter);
-    rewriter.setInsertionPoint(tmemAlloc);
-
-    Value shared = localLoad.getSrc();
-
-    Value reshaped5D = MemDescReshapeOp::create(rewriter, reshapeOp5D.getLoc(),
-                                                shared, reshape5DShape);
-    SmallVector<int32_t> transposeOrder32(transposeOrder.begin(),
-                                          transposeOrder.end());
-    Value transposed = MemDescTransOp::create(rewriter, transOp.getLoc(),
-                                              reshaped5D, transposeOrder32);
-    SmallVector<int64_t> scale2DShapeVec(scale2DShape.begin(),
-                                         scale2DShape.end());
-    Value reshaped2D = MemDescReshapeOp::create(rewriter, reshapeOp2D.getLoc(),
-                                                transposed, scale2DShapeVec);
-
-    opOperand.assign(reshaped2D);
-    rewriter.eraseOp(tmemAlloc);
-    return success();
-  }
-
-  template <typename Op> Op getNextOp(Value op) const {
-    while (auto cvtOp = op.getDefiningOp<ConvertLayoutOp>()) {
-      op = cvtOp.getSrc();
-    }
-    return op.getDefiningOp<Op>();
-  }
-
-  bool isTmemCopyCompatible(triton::gpu::MemDescType scaleType,
-                            bool usesTMAload) const {
-    // TMEM copy expects that blocked scale "chunks" in SMEM are stored in
-    // innermost axes contiguously.
-    if (!isInnermostContiguous(scaleType, 512))
-      return false;
-
-    if (usesTMAload) {
-      return true;
-    }
-
-    if (scaleType.getRank() != 2) {
-      // TODO: Add support for higher rank when 5D coalesced load is fixed
-      return false;
-    }
-
-    auto elemBits = scaleType.getElementType().getIntOrFloatBitWidth();
-
-    // We assume that 32x128b chunks are flattened into the inner most axis.
-    auto innerMostBits =
-        scaleType.getDimSize(scaleType.getRank() - 1) * elemBits;
-    return innerMostBits % (32 * 128) == 0;
-  }
-};
-
 } // namespace
 
 #define GEN_PASS_DEF_TRITONGPUOPTIMIZEDOTOPERANDS
@@ -454,7 +325,6 @@ public:
     patterns.add<SwizzleShmemConvert>(context);
     patterns.add<FuseTransMMAV3Plus, ReshapeMemDesc>(context);
     patterns.add<RewriteMmaOperandViewsToMemDescForDotOp>(context);
-    patterns.add<UseShmemForScales>(context);
     ConvertLayoutOp::getCanonicalizationPatterns(patterns, context);
     if (failed(applyPatternsGreedily(m, std::move(patterns))))
       signalPassFailure();

--- a/test/TritonGPU/accelerate-matmul.mlir
+++ b/test/TritonGPU/accelerate-matmul.mlir
@@ -325,6 +325,99 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.targ
 #blocked = #ttg.blocked<{sizePerThread = [1, 1], threadsPerWarp = [1, 32], warpsPerCTA = [1, 4], order = [1, 0]}>
 #blocked1 = #ttg.blocked<{sizePerThread = [1, 1], threadsPerWarp = [16, 2], warpsPerCTA = [4, 1], order = [1, 0]}>
 #blocked2 = #ttg.blocked<{sizePerThread = [1, 1], threadsPerWarp = [2, 16], warpsPerCTA = [4, 1], order = [1, 0]}>
+#blocked3 = #ttg.blocked<{sizePerThread = [1, 1, 1, 1, 4], threadsPerWarp = [1, 1, 1, 8, 4], warpsPerCTA = [1, 1, 1, 4, 1], order = [4, 3, 2, 1, 0]}>
+#blocked4 = #ttg.blocked<{sizePerThread = [1, 1, 1, 1, 4], threadsPerWarp = [1, 1, 8, 4, 1], warpsPerCTA = [1, 1, 4, 1, 1], order = [4, 3, 2, 1, 0]}>
+#blocked5 = #ttg.blocked<{sizePerThread = [1, 1, 1, 1, 4], threadsPerWarp = [1, 4, 8, 1, 1], warpsPerCTA = [1, 1, 4, 1, 1], order = [4, 1, 2, 3, 0]}>
+#linear = #ttg.linear<{register = [[0, 1], [0, 2]], lane = [[32, 0], [64, 0], [1, 0], [2, 0], [4, 0]], warp = [[8, 0], [16, 0]], block = []}>
+
+// CHECK-LABEL: {{#shared2 = #ttg\.shared_linear<\{offset = \[\[0, 1\], \[0, 2\], \[32, 0\], \[64, 0\], \[1, 0\], \[2, 0\], \[4, 0\], \[8, 0\], \[16, 0\]\]\}, alignment = 128>}}
+module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.target = "cuda:100", "ttg.threads-per-warp" = 32 : i32} {
+  // CHECK-LABEL: @mmav5_scale_desc_tma
+  // CHECK-DAG: %[[A_SMEM:.+]] = ttg.local_alloc %arg0 : (tensor<128x128xi8, #{{.*}}>) -> !ttg.memdesc<128x128xi8, #{{.*}}, #smem>
+  // CHECK-DAG: %[[B_SMEM:.+]] = ttg.local_alloc %arg1 : (tensor<64x128xi8, #{{.*}}>) -> !ttg.memdesc<64x128xi8, #{{.*}}, #smem>
+  // CHECK: %[[SCALE_A_LOAD:.+]] = tt.descriptor_load %arg2[%{{.*}}, %{{.*}}, %{{.*}}, %{{.*}}, %{{.*}}] : !tt.tensordesc<1x1x1x32x16xi8> -> tensor<1x1x1x32x16xi8, #{{.*}}>
+  // CHECK: %[[SCALE_A_RS0:.+]] = tt.reshape %[[SCALE_A_LOAD]] : tensor<1x1x1x32x16xi8, #{{.*}}> -> tensor<1x1x32x4x4xi8, #{{.*}}>
+  // CHECK: %[[SCALE_A_TR0:.+]] = tt.trans %[[SCALE_A_RS0]] {order = array<i32: 0, 3, 2, 1, 4>} : tensor<1x1x32x4x4xi8, #{{.*}}> -> tensor<1x4x32x1x4xi8, #{{.*}}>
+  // CHECK: %[[SCALE_A_FINAL:.+]] = tt.reshape %[[SCALE_A_TR0]] : tensor<1x4x32x1x4xi8, #{{.*}}> -> tensor<128x4xi8, #{{.*}}>
+  // CHECK: %[[SCALE_A_SMEM:.+]] = ttg.local_alloc %[[SCALE_A_FINAL]] : (tensor<128x4xi8, #{{.*}}>) -> !ttg.memdesc<128x4xi8, #shared2, #smem>
+  // CHECK: %[[SCALE_B_LOAD:.+]] = tt.descriptor_load %arg3[%{{.*}}, %{{.*}}, %{{.*}}, %{{.*}}, %{{.*}}] : !tt.tensordesc<1x1x1x32x16xi8> -> tensor<1x1x1x32x16xi8, #{{.*}}>
+  // CHECK: %[[SCALE_B_RS0:.+]] = tt.reshape %[[SCALE_B_LOAD]] : tensor<1x1x1x32x16xi8, #{{.*}}> -> tensor<1x1x32x4x4xi8, #{{.*}}>
+  // CHECK: %[[SCALE_B_TR0:.+]] = tt.trans %[[SCALE_B_RS0]] {order = array<i32: 0, 3, 2, 1, 4>} : tensor<1x1x32x4x4xi8, #{{.*}}> -> tensor<1x4x32x1x4xi8, #{{.*}}>
+  // CHECK: %[[SCALE_B_FINAL:.+]] = tt.reshape %[[SCALE_B_TR0]] : tensor<1x4x32x1x4xi8, #{{.*}}> -> tensor<128x4xi8, #{{.*}}>
+  // CHECK: %[[SCALE_B_SMEM:.+]] = ttg.local_alloc %[[SCALE_B_FINAL]] : (tensor<128x4xi8, #{{.*}}>) -> !ttg.memdesc<128x4xi8, #shared2, #smem>
+  // CHECK-NOT: ttng.tmem_alloc %{{.*}} : (tensor<128x4xi8
+  // CHECK: ttng.tc_gen5_mma_scaled %[[A_SMEM]], %[[B_SMEM]], %{{.*}}, %[[SCALE_A_SMEM]], %[[SCALE_B_SMEM]], %{{.*}}, %{{.*}} lhs = e4m3 rhs = e2m1
+  tt.func public @mmav5_scale_desc_tma(
+      %a: tensor<128x128xi8, #blocked2>,
+      %b: tensor<64x128xi8, #blocked>,
+      %scale_a_desc: !tt.tensordesc<1x1x1x32x16xi8>,
+      %scale_b_desc: !tt.tensordesc<1x1x1x32x16xi8>,
+      %c: tensor<128x128xf32, #blocked>) -> tensor<128x128xf32, #blocked> {
+    %c0_i32 = arith.constant 0 : i32
+    %scale_a0 = tt.descriptor_load %scale_a_desc[%c0_i32, %c0_i32, %c0_i32, %c0_i32, %c0_i32] : !tt.tensordesc<1x1x1x32x16xi8> -> tensor<1x1x1x32x16xi8, #blocked3>
+    %scale_a1 = tt.reshape %scale_a0 : tensor<1x1x1x32x16xi8, #blocked3> -> tensor<1x1x32x4x4xi8, #blocked4>
+    %scale_a2 = tt.trans %scale_a1 {order = array<i32: 0, 3, 2, 1, 4>} : tensor<1x1x32x4x4xi8, #blocked4> -> tensor<1x4x32x1x4xi8, #blocked5>
+    %scale_a3 = tt.reshape %scale_a2 : tensor<1x4x32x1x4xi8, #blocked5> -> tensor<128x4xi8, #linear>
+    %scale_a4 = ttg.convert_layout %scale_a3 : tensor<128x4xi8, #linear> -> tensor<128x4xi8, #blocked1>
+    %scale_b0 = tt.descriptor_load %scale_b_desc[%c0_i32, %c0_i32, %c0_i32, %c0_i32, %c0_i32] : !tt.tensordesc<1x1x1x32x16xi8> -> tensor<1x1x1x32x16xi8, #blocked3>
+    %scale_b1 = tt.reshape %scale_b0 : tensor<1x1x1x32x16xi8, #blocked3> -> tensor<1x1x32x4x4xi8, #blocked4>
+    %scale_b2 = tt.trans %scale_b1 {order = array<i32: 0, 3, 2, 1, 4>} : tensor<1x1x32x4x4xi8, #blocked4> -> tensor<1x4x32x1x4xi8, #blocked5>
+    %scale_b3 = tt.reshape %scale_b2 : tensor<1x4x32x1x4xi8, #blocked5> -> tensor<128x4xi8, #linear>
+    %scale_b4 = ttg.convert_layout %scale_b3 : tensor<128x4xi8, #linear> -> tensor<128x4xi8, #blocked1>
+    %d = tt.dot_scaled %a scale %scale_a4, %b scale %scale_b4, %c lhs = e4m3 rhs = e2m1 {fastMath = false} : tensor<128x128xi8, #blocked2>, tensor<128x4xi8, #blocked1> * tensor<64x128xi8, #blocked>, tensor<128x4xi8, #blocked1> -> tensor<128x128xf32, #blocked>
+    tt.return %d : tensor<128x128xf32, #blocked>
+  }
+}
+
+// -----
+
+#blocked = #ttg.blocked<{sizePerThread = [1, 1], threadsPerWarp = [1, 32], warpsPerCTA = [1, 4], order = [1, 0]}>
+#blocked1 = #ttg.blocked<{sizePerThread = [1, 1], threadsPerWarp = [16, 2], warpsPerCTA = [4, 1], order = [1, 0]}>
+#blocked2 = #ttg.blocked<{sizePerThread = [1, 1], threadsPerWarp = [2, 16], warpsPerCTA = [4, 1], order = [1, 0]}>
+#blocked3 = #ttg.blocked<{sizePerThread = [1, 4], threadsPerWarp = [1, 32], warpsPerCTA = [1, 4], order = [1, 0]}>
+#blocked4 = #ttg.blocked<{sizePerThread = [1, 1, 1, 1, 4], threadsPerWarp = [1, 1, 8, 4, 1], warpsPerCTA = [1, 1, 4, 1, 1], order = [4, 3, 2, 1, 0]}>
+#blocked5 = #ttg.blocked<{sizePerThread = [1, 1, 1, 1, 4], threadsPerWarp = [1, 4, 8, 1, 1], warpsPerCTA = [1, 1, 4, 1, 1], order = [4, 1, 2, 3, 0]}>
+#linear = #ttg.linear<{register = [[0, 1], [0, 2]], lane = [[32, 0], [64, 0], [1, 0], [2, 0], [4, 0]], warp = [[8, 0], [16, 0]], block = []}>
+module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.target = "cuda:100", "ttg.threads-per-warp" = 32 : i32} {
+  // CHECK-LABEL: @mmav5_scale_load_2d_tmem_copy
+  // CHECK-DAG: %[[A_SMEM:.+]] = ttg.local_alloc %arg0 : (tensor<128x128xi8, #{{.*}}>) -> !ttg.memdesc<128x128xi8, #{{.*}}, #smem>
+  // CHECK-DAG: %[[B_SMEM:.+]] = ttg.local_alloc %arg1 : (tensor<64x128xi8, #{{.*}}>) -> !ttg.memdesc<64x128xi8, #{{.*}}, #smem>
+  // CHECK: %[[SCALE_A_LOAD:.+]] = tt.load %arg2 : tensor<1x512x!tt.ptr<i8>, #{{.*}}>
+  // CHECK: %[[SCALE_A_RS0:.+]] = tt.reshape %[[SCALE_A_LOAD]] : tensor<1x512xi8, #{{.*}}> -> tensor<1x1x32x4x4xi8, #{{.*}}>
+  // CHECK: %[[SCALE_A_TR0:.+]] = tt.trans %[[SCALE_A_RS0]] {order = array<i32: 0, 3, 2, 1, 4>} : tensor<1x1x32x4x4xi8, #{{.*}}> -> tensor<1x4x32x1x4xi8, #{{.*}}>
+  // CHECK: %[[SCALE_A_FINAL:.+]] = tt.reshape %[[SCALE_A_TR0]] : tensor<1x4x32x1x4xi8, #{{.*}}> -> tensor<128x4xi8, #{{.*}}>
+  // CHECK: %[[SCALE_A_SMEM:.+]] = ttg.local_alloc %[[SCALE_A_FINAL]] : (tensor<128x4xi8, #{{.*}}>) -> !ttg.memdesc<128x4xi8, #{{.*}}, #smem>
+  // CHECK: %[[SCALE_B_LOAD:.+]] = tt.load %arg3 : tensor<1x512x!tt.ptr<i8>, #{{.*}}>
+  // CHECK: %[[SCALE_B_RS0:.+]] = tt.reshape %[[SCALE_B_LOAD]] : tensor<1x512xi8, #{{.*}}> -> tensor<1x1x32x4x4xi8, #{{.*}}>
+  // CHECK: %[[SCALE_B_TR0:.+]] = tt.trans %[[SCALE_B_RS0]] {order = array<i32: 0, 3, 2, 1, 4>} : tensor<1x1x32x4x4xi8, #{{.*}}> -> tensor<1x4x32x1x4xi8, #{{.*}}>
+  // CHECK: %[[SCALE_B_FINAL:.+]] = tt.reshape %[[SCALE_B_TR0]] : tensor<1x4x32x1x4xi8, #{{.*}}> -> tensor<128x4xi8, #{{.*}}>
+  // CHECK: %[[SCALE_B_SMEM:.+]] = ttg.local_alloc %[[SCALE_B_FINAL]] : (tensor<128x4xi8, #{{.*}}>) -> !ttg.memdesc<128x4xi8, #{{.*}}, #smem>
+  // CHECK-NOT: ttng.tmem_alloc %{{.*}} : (tensor<128x4xi8
+  // CHECK: ttng.tc_gen5_mma_scaled %[[A_SMEM]], %[[B_SMEM]], %{{.*}}, %[[SCALE_A_SMEM]], %[[SCALE_B_SMEM]], %{{.*}}, %{{.*}} lhs = e4m3 rhs = e2m1
+  tt.func public @mmav5_scale_load_2d_tmem_copy(
+      %a: tensor<128x128xi8, #blocked2>,
+      %b: tensor<64x128xi8, #blocked>,
+      %scale_a_ptr: tensor<1x512x!tt.ptr<i8>, #blocked3>,
+      %scale_b_ptr: tensor<1x512x!tt.ptr<i8>, #blocked3>,
+      %c: tensor<128x128xf32, #blocked>) -> tensor<128x128xf32, #blocked> {
+    %scale_a0 = tt.load %scale_a_ptr : tensor<1x512x!tt.ptr<i8>, #blocked3>
+    %scale_a1 = tt.reshape %scale_a0 : tensor<1x512xi8, #blocked3> -> tensor<1x1x32x4x4xi8, #blocked4>
+    %scale_a2 = tt.trans %scale_a1 {order = array<i32: 0, 3, 2, 1, 4>} : tensor<1x1x32x4x4xi8, #blocked4> -> tensor<1x4x32x1x4xi8, #blocked5>
+    %scale_a3 = tt.reshape %scale_a2 : tensor<1x4x32x1x4xi8, #blocked5> -> tensor<128x4xi8, #linear>
+    %scale_b0 = tt.load %scale_b_ptr : tensor<1x512x!tt.ptr<i8>, #blocked3>
+    %scale_b1 = tt.reshape %scale_b0 : tensor<1x512xi8, #blocked3> -> tensor<1x1x32x4x4xi8, #blocked4>
+    %scale_b2 = tt.trans %scale_b1 {order = array<i32: 0, 3, 2, 1, 4>} : tensor<1x1x32x4x4xi8, #blocked4> -> tensor<1x4x32x1x4xi8, #blocked5>
+    %scale_b3 = tt.reshape %scale_b2 : tensor<1x4x32x1x4xi8, #blocked5> -> tensor<128x4xi8, #linear>
+    %d = tt.dot_scaled %a scale %scale_a3, %b scale %scale_b3, %c lhs = e4m3 rhs = e2m1 {fastMath = false} : tensor<128x128xi8, #blocked2>, tensor<128x4xi8, #linear> * tensor<64x128xi8, #blocked>, tensor<128x4xi8, #linear> -> tensor<128x128xf32, #blocked>
+    tt.return %d : tensor<128x128xf32, #blocked>
+  }
+}
+
+// -----
+
+#blocked = #ttg.blocked<{sizePerThread = [1, 1], threadsPerWarp = [1, 32], warpsPerCTA = [1, 4], order = [1, 0]}>
+#blocked1 = #ttg.blocked<{sizePerThread = [1, 1], threadsPerWarp = [16, 2], warpsPerCTA = [4, 1], order = [1, 0]}>
+#blocked2 = #ttg.blocked<{sizePerThread = [1, 1], threadsPerWarp = [2, 16], warpsPerCTA = [4, 1], order = [1, 0]}>
 module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.target = "cuda:100", "ttg.threads-per-warp" = 32 : i32} {
   // CHECK-DAG: #[[$TMEM:.+]] = #ttng.tensor_memory_encoding<blockM = 128, blockN = 128, colStride = 1>
   // CHECK-DAG: #[[$TMEM1:.+]] = #ttng.tensor_memory_scales_encoding
@@ -332,10 +425,6 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.targ
   //   CHECK-DAG:   %[[TRUE:.+]] = arith.constant true
   //   CHECK-DAG:   %[[A:.+]] = ttg.local_alloc %{{.*}} : (tensor<128x64xi8, #{{.*}}>) -> !ttg.memdesc<128x64xi8, #{{.*}}, #smem
   //   CHECK-DAG:   %[[B:.+]] = ttg.local_alloc %{{.*}} : (tensor<64x128xi8, #{{.*}}>) -> !ttg.memdesc<64x128xi8, #{{.*}}, #smem
-  //   CHECK-DAG:   %[[SCALEA_LOCAL:.+]] = ttg.local_alloc %{{.*}} : (tensor<128x2xi8, #{{.*}}>) -> !ttg.memdesc<128x2xi8, #{{.*}}, #smem>
-  //   CHECK:       ttg.local_load %[[SCALEA_LOCAL]] : !ttg.memdesc<128x2xi8, #{{.*}}, #smem> -> tensor<128x2xi8, #{{.*}}>
-  //   CHECK-DAG:   %[[SCALEB_LOCAL:.+]] = ttg.local_alloc %{{.*}} : (tensor<128x2xi8, #{{.*}}>) -> !ttg.memdesc<128x2xi8, #{{.*}}, #smem>
-  //   CHECK:       ttg.local_load %[[SCALEB_LOCAL]] : !ttg.memdesc<128x2xi8, #{{.*}}, #smem> -> tensor<128x2xi8, #{{.*}}>
   //   CHECK-DAG:   %[[ACC:.+]], %[[ACC_TOK:.+]] = ttng.tmem_alloc %{{.*}} : (tensor<128x128xf32, #{{.*}}>) -> (!ttg.memdesc<128x128xf32, #{{.*}}, #ttng.tensor_memory, mutable>, !ttg.async.token)
   //       CHECK:   %[[SCALEA:.+]] = ttng.tmem_alloc %{{.*}} : (tensor<128x2xi8, #{{.*}}>) -> !ttg.memdesc<128x2xi8, #[[$TMEM1]], #ttng.tensor_memory>
   //       CHECK:   %[[SCALEB:.+]] = ttng.tmem_alloc %{{.*}} : (tensor<128x2xi8, #{{.*}}>) -> !ttg.memdesc<128x2xi8, #[[$TMEM1]], #ttng.tensor_memory>
@@ -482,14 +571,8 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.targ
   //   CHECK-DAG:   %[[TRUE:.+]] = arith.constant true
   //   CHECK-DAG:   %[[B:.+]] = ttg.local_alloc %{{.*}} : (tensor<128x128xi8, #{{.*}}>) -> !ttg.memdesc<128x128xi8, #{{.*}}, #smem
   //   CHECK-DAG:   %[[A:.+]] = ttg.local_alloc %{{.*}} : (tensor<128x128xi8, #{{.*}}>) -> !ttg.memdesc<128x128xi8, #{{.*}}, #smem
-  //   CHECK-DAG:   %[[SCALEA_LOCAL:.+]] = ttg.local_alloc
-  //   CHECK:       ttg.local_load %[[SCALEA_LOCAL]]
-  //   CHECK-DAG:   %[[SCALEB_LOCAL:.+]] = ttg.local_alloc
-  //   CHECK:       ttg.local_load %[[SCALEB_LOCAL]]
   //   CHECK-DAG:   %[[ACC:.+]], %[[ACC_TOK:.+]] = ttng.tmem_alloc %{{.*}} : (tensor<128x128xf32, #{{.*}}>) -> (!ttg.memdesc<128x128xf32, #{{.*}}, #ttng.tensor_memory, mutable>, !ttg.async.token)
-  //       CHECK:   %[[SCALEA:.+]] = ttng.tmem_alloc %{{.*}} : (tensor<128x4xi8, #{{.*}}>) -> !ttg.memdesc<128x4xi8, #[[$TMEM1]], #ttng.tensor_memory>
-  //       CHECK:   %[[SCALEB:.+]] = ttng.tmem_alloc %{{.*}} : (tensor<128x4xi8, #{{.*}}>) -> !ttg.memdesc<128x4xi8, #[[$TMEM1]], #ttng.tensor_memory>
-  //       CHECK:   ttng.tc_gen5_mma_scaled %[[A]], %[[B]], %[[ACC]][%[[ACC_TOK]]], %[[SCALEA]], %[[SCALEB]], %[[TRUE]], %[[TRUE]] lhs = e4m3 rhs = e4m3
+  //       CHECK:   ttng.tc_gen5_mma_scaled %[[A]], %[[B]], %[[ACC]][%[[ACC_TOK]]], %{{.*}}, %{{.*}}, %[[TRUE]], %[[TRUE]] lhs = e4m3 rhs = e4m3
   tt.func public @mmav5_block_scaled_5d_scale(%a: tensor<128x128xi8, #blocked2>, %scale_a_ptr: tensor<1x1x32x4x4x!tt.ptr<i8>, #blocked3>, %b: tensor<128x128xi8, #blocked>, %scale_b_ptr: tensor<1x1x32x4x4x!tt.ptr<i8>, #blocked3>) -> tensor<128x128xf32, #blocked> {
     %cst = arith.constant dense<0.000000e+00> : tensor<128x128xf32, #blocked>
     %scale_a_5d = tt.load %scale_a_ptr: tensor<1x1x32x4x4x!tt.ptr<i8>, #blocked3>

--- a/test/TritonGPU/dot-operands.mlir
+++ b/test/TritonGPU/dot-operands.mlir
@@ -124,21 +124,21 @@ module attributes {"ttg.target" = "cuda:90", "ttg.num-ctas" = 1 : i32, "ttg.num-
 
 #shared = #ttg.nvmma_shared<{swizzlingByteWidth = 128, transposed = false, elementBitWidth = 16}>
 #shared1 = #ttg.swizzled_shared<{vec = 1, perPhase = 1, maxPhase = 1, order = [1, 0]}>
+#shared_scale_final = #ttg.shared_linear<{offset = [[0, 1], [0, 2], [32, 0], [64, 0], [1, 0], [2, 0], [4, 0], [8, 0], [16, 0], [128, 0]]}, alignment = 128>
 #smem = #ttg.shared_memory
 #blocked4 = #ttg.blocked<{sizePerThread = [1, 8], threadsPerWarp = [1, 32], warpsPerCTA = [2, 2], order = [1, 0]}>
 #blocked8 = #ttg.blocked<{sizePerThread = [1, 1, 1, 2, 4], threadsPerWarp = [1, 1, 16, 2, 1], warpsPerCTA = [2, 1, 2, 1, 1], order = [4, 3, 2, 1, 0]}>
 #blocked9 = #ttg.blocked<{sizePerThread = [1, 2, 1, 1, 4], threadsPerWarp = [1, 2, 16, 1, 1], warpsPerCTA = [2, 1, 2, 1, 1], order = [4, 1, 2, 3, 0]}>
-#blocked10 = #ttg.blocked<{sizePerThread = [1, 1, 1, 1, 4], threadsPerWarp = [1, 1, 32, 1, 1], warpsPerCTA = [1, 1, 1, 1, 4], order = [4, 3, 2, 1, 0]}>
-#blocked11 = #ttg.blocked<{sizePerThread = [1, 4], threadsPerWarp = [32, 1], warpsPerCTA = [1, 4], order = [1, 0]}>
+#linear_scale = #ttg.linear<{register = [[0, 1], [0, 2], [32, 0]], lane = [[64, 0], [1, 0], [2, 0], [4, 0], [8, 0]], warp = [[16, 0], [128, 0]], block = []}>
 #tmem = #ttng.tensor_memory_encoding<blockM = 128, blockN = 128, colStride = 1>
 #tmem_scales = #ttng.tensor_memory_scales_encoding<>
 module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.target = "cuda:100", "ttg.threads-per-warp" = 32 : i32} {
   // CHECK-LABEL: @scales_in_shmem
   // CHECK: %[[A_LA:.*]] = ttg.local_alloc
-  // CHECK: %[[B_LA:.*]] = ttg.local_alloc
   // CHECK: %[[A_RS:.*]] = ttg.memdesc_reshape %[[A_LA]]
   // CHECK: %[[A_TR:.*]] = ttg.memdesc_trans %[[A_RS]]
   // CHECK: %[[A_FINAL:.*]] = ttg.memdesc_reshape %[[A_TR]]
+  // CHECK: %[[B_LA:.*]] = ttg.local_alloc
   // CHECK: %[[B_RS:.*]] = ttg.memdesc_reshape %[[B_LA]]
   // CHECK: %[[B_TR:.*]] = ttg.memdesc_trans %[[B_RS]]
   // CHECK: %[[B_FINAL:.*]] = ttg.memdesc_reshape %[[B_TR]]
@@ -146,27 +146,21 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.targ
   // CHECK: ttng.tc_gen5_mma_scaled {{.*}}, %[[A_FINAL]], %[[B_FINAL]],
 
   tt.func public @scales_in_shmem(
-    %scale: tensor<2x512x!tt.ptr<i8>, #blocked4> {tt.contiguity = 16 : i32, tt.divisibility = 16 : i32},
+    %scale: tensor<2x512xi8, #blocked4>,
     %A_sh: !ttg.memdesc<128x128xf8E5M2, #shared, #ttg.shared_memory>,
     %B_sh: !ttg.memdesc<128x128xf8E5M2, #shared, #ttg.shared_memory>,
     %acc_tm: !ttg.memdesc<128x128xf32, #tmem, #ttng.tensor_memory>
     ) {
       %true = arith.constant true
-      %A_la = ttg.local_alloc : () -> !ttg.memdesc<2x512xi8, #shared1, #smem, mutable>
-      %B_la = ttg.local_alloc : () -> !ttg.memdesc<2x512xi8, #shared1, #smem, mutable>
-      %A_ll = ttg.local_load %A_la : !ttg.memdesc<2x512xi8, #shared1, #smem, mutable> -> tensor<2x512xi8, #blocked4>
-      %B_ll = ttg.local_load %B_la : !ttg.memdesc<2x512xi8, #shared1, #smem, mutable> -> tensor<2x512xi8, #blocked4>
-      %A_r = tt.reshape %A_ll : tensor<2x512xi8, #blocked4> -> tensor<2x1x32x4x4xi8, #blocked8>
-      %B_r = tt.reshape %B_ll : tensor<2x512xi8, #blocked4> -> tensor<2x1x32x4x4xi8, #blocked8>
+      %A_r = tt.reshape %scale : tensor<2x512xi8, #blocked4> -> tensor<2x1x32x4x4xi8, #blocked8>
+      %B_r = tt.reshape %scale : tensor<2x512xi8, #blocked4> -> tensor<2x1x32x4x4xi8, #blocked8>
       %A_tr = tt.trans %A_r {order = array<i32: 0, 3, 2, 1, 4>} : tensor<2x1x32x4x4xi8, #blocked8> -> tensor<2x4x32x1x4xi8, #blocked9>
       %B_tr = tt.trans %B_r {order = array<i32: 0, 3, 2, 1, 4>} : tensor<2x1x32x4x4xi8, #blocked8> -> tensor<2x4x32x1x4xi8, #blocked9>
-      %A_cv = ttg.convert_layout %A_tr : tensor<2x4x32x1x4xi8, #blocked9> -> tensor<2x4x32x1x4xi8, #blocked10>
-      %B_cv = ttg.convert_layout %B_tr : tensor<2x4x32x1x4xi8, #blocked9> -> tensor<2x4x32x1x4xi8, #blocked10>
-      %A_r2 = tt.reshape %A_cv : tensor<2x4x32x1x4xi8, #blocked10> -> tensor<256x4xi8, #blocked11>
-      %B_r2 = tt.reshape %B_cv : tensor<2x4x32x1x4xi8, #blocked10> -> tensor<256x4xi8, #blocked11>
-      %A_tm = ttng.tmem_alloc %A_r2 : (tensor<256x4xi8, #blocked11>) -> !ttg.memdesc<256x4xi8, #tmem_scales, #ttng.tensor_memory>
-      %B_tm = ttng.tmem_alloc %B_r2 : (tensor<256x4xi8, #blocked11>) -> !ttg.memdesc<256x4xi8, #tmem_scales, #ttng.tensor_memory>
-      ttng.tc_gen5_mma_scaled %A_sh, %B_sh, %acc_tm, %A_tm, %B_tm, %true, %true lhs = e5m2 rhs = e5m2 {loop.cluster = 0 : i32, loop.stage = 2 : i32} : !ttg.memdesc<128x128xf8E5M2, #shared, #ttg.shared_memory>, !ttg.memdesc<128x128xf8E5M2, #shared, #ttg.shared_memory>, !ttg.memdesc<128x128xf32, #tmem, #ttng.tensor_memory>, !ttg.memdesc<256x4xi8, #tmem_scales, #ttng.tensor_memory>, !ttg.memdesc<256x4xi8, #tmem_scales, #ttng.tensor_memory>
+      %A_r2 = tt.reshape %A_tr : tensor<2x4x32x1x4xi8, #blocked9> -> tensor<256x4xi8, #linear_scale>
+      %B_r2 = tt.reshape %B_tr : tensor<2x4x32x1x4xi8, #blocked9> -> tensor<256x4xi8, #linear_scale>
+      %A_s = ttg.local_alloc %A_r2 : (tensor<256x4xi8, #linear_scale>) -> !ttg.memdesc<256x4xi8, #shared_scale_final, #smem>
+      %B_s = ttg.local_alloc %B_r2 : (tensor<256x4xi8, #linear_scale>) -> !ttg.memdesc<256x4xi8, #shared_scale_final, #smem>
+      ttng.tc_gen5_mma_scaled %A_sh, %B_sh, %acc_tm, %A_s, %B_s, %true, %true lhs = e5m2 rhs = e5m2 {loop.cluster = 0 : i32, loop.stage = 2 : i32} : !ttg.memdesc<128x128xf8E5M2, #shared, #ttg.shared_memory>, !ttg.memdesc<128x128xf8E5M2, #shared, #ttg.shared_memory>, !ttg.memdesc<128x128xf32, #tmem, #ttng.tensor_memory>, !ttg.memdesc<256x4xi8, #shared_scale_final, #smem>, !ttg.memdesc<256x4xi8, #shared_scale_final, #smem>
       tt.return
 }
 }
@@ -208,12 +202,10 @@ module attributes {"ttg.target" = "cuda:100", "ttg.num-ctas" = 2 : i32, "ttg.num
 #linear2 = #ttg.linear<{register = [[0, 0, 0, 0, 1], [0, 0, 0, 0, 2], [0, 0, 0, 1, 0], [0, 0, 0, 2, 0]], lane = [[0, 0, 1, 0, 0], [0, 0, 2, 0, 0], [0, 0, 4, 0, 0], [0, 0, 8, 0, 0], [0, 0, 16, 0, 0]], warp = [[0, 0, 0, 0, 0], [0, 0, 0, 0, 0], [1, 0, 0, 0, 0]], block = []}>
 #linear3 = #ttg.linear<{register = [[0, 0, 0, 0, 1], [0, 0, 0, 0, 2], [0, 1, 0, 0, 0], [0, 2, 0, 0, 0]], lane = [[0, 0, 1, 0, 0], [0, 0, 2, 0, 0], [0, 0, 4, 0, 0], [0, 0, 8, 0, 0], [0, 0, 16, 0, 0]], warp = [[0, 0, 0, 0, 0], [0, 0, 0, 0, 0], [1, 0, 0, 0, 0]], block = []}>
 #linear4 = #ttg.linear<{register = [[0, 1], [0, 2], [32, 0], [64, 0]], lane = [[1, 0], [2, 0], [4, 0], [8, 0], [16, 0]], warp = [[0, 0], [0, 0], [128, 0]], block = []}>
+#shared_scale_final = #ttg.shared_linear<{offset = [[0, 1], [0, 2], [32, 0], [64, 0], [1, 0], [2, 0], [4, 0], [8, 0], [16, 0], [128, 0]]}, alignment = 128>
 #tmem = #ttng.tensor_memory_encoding<blockM = 128, blockN = 256, colStride = 1>
 #tmem_scales = #ttng.tensor_memory_scales_encoding<>
 module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 8 : i32, ttg.target = "cuda:100", "ttg.threads-per-warp" = 32 : i32} {
-  // CHECK-DAG: #[[BLOCKED5:.*]] = #ttg.blocked<{sizePerThread = [1, 1, 1, 1, 1], threadsPerWarp = [1, 1, 1, 2, 16], warpsPerCTA = [1, 1, 1, 8, 1], order = [4, 3, 2, 1, 0]}>
-  // CHECK-DAG: #[[SHARED2:.*]] = #ttg.nvmma_shared<{swizzlingByteWidth = 0, transposed = false, elementBitWidth = 8, rank = 5}>
-  // CHECK-DAG: #[[SMEM:.*]] = #ttg.shared_memory
   tt.func public @descriptor_load_scales_in_shmem(
       %scale_desc_ptr: !tt.ptr<i8>,
       %shmemA: !ttg.memdesc<128x128xf8E4M3FN, #shared, #smem>,
@@ -233,64 +225,22 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 8 : i32, ttg.targ
     %true = arith.constant true
 
     %desc = tt.make_tensor_descriptor %scale_desc_ptr, [%c1_i32, %c2_i32, %c1_i32, %c32_i32, %c16_i32], [%c1024_i64, %c512_i64, %c512_i64, %c16_i64, %c1_i64] : !tt.ptr<i8>, <1x2x1x32x16xi8>
-    // CHECK: %[[DESC_LOAD:.*]] = tt.descriptor_load {{.*}} !tt.tensordesc<1x2x1x32x16xi8> -> tensor<1x2x1x32x16xi8, #[[BLOCKED5]]>
-    %83 = tt.descriptor_load %desc[%c0_i32, %c0_i32, %c0_i32, %c0_i32, %c0_i32] : !tt.tensordesc<1x2x1x32x16xi8> -> tensor<1x2x1x32x16xi8, #blocked5>
-    // CHECK: %[[DESC_LA:.*]] = ttg.local_alloc %[[DESC_LOAD]] : (tensor<1x2x1x32x16xi8, #[[BLOCKED5]]>) -> !ttg.memdesc<1x2x1x32x16xi8, #[[SHARED2]], #[[SMEM]]>
-    %84 = ttg.local_alloc %83 : (tensor<1x2x1x32x16xi8, #blocked5>) -> !ttg.memdesc<1x2x1x32x16xi8, #shared2, #smem>
-    // CHECK-NOT: ttg.local_load
-    %85 = ttg.local_load %84 : !ttg.memdesc<1x2x1x32x16xi8, #shared2, #smem> -> tensor<1x2x1x32x16xi8, #linear1>
-    // CHECK-NOT: tt.reshape
-    %86 = tt.reshape %85 : tensor<1x2x1x32x16xi8, #linear1> -> tensor<2x1x32x4x4xi8, #linear2>
-    // CHECK-NOT: tt.trans
+    // CHECK: %[[DESC_LOAD:.*]] = tt.descriptor_load {{.*}} !tt.tensordesc<1x2x1x32x16xi8> -> tensor<1x2x1x32x16xi8
+    %83 = tt.descriptor_load %desc[%c0_i32, %c0_i32, %c0_i32, %c0_i32, %c0_i32] : !tt.tensordesc<1x2x1x32x16xi8> -> tensor<1x2x1x32x16xi8, #linear1>
+    %86 = tt.reshape %83 : tensor<1x2x1x32x16xi8, #linear1> -> tensor<2x1x32x4x4xi8, #linear2>
     %87 = tt.trans %86 {order = array<i32: 0, 3, 2, 1, 4>} : tensor<2x1x32x4x4xi8, #linear2> -> tensor<2x4x32x1x4xi8, #linear3>
-    // CHECK-NOT: tt.reshape
     %88 = tt.reshape %87 : tensor<2x4x32x1x4xi8, #linear3> -> tensor<256x4xi8, #linear4>
-    %89 = ttng.tmem_alloc %acc : (tensor<128x256xf32, #blocked1>) -> !ttg.memdesc<128x256xf32, #tmem, #ttng.tensor_memory, mutable>
-    %90 = ttng.tmem_alloc %cst_scales : (tensor<128x4xi8, #linear>) -> !ttg.memdesc<128x4xi8, #tmem_scales, #ttng.tensor_memory>
-    %91 = ttng.tmem_alloc %88 : (tensor<256x4xi8, #linear4>) -> !ttg.memdesc<256x4xi8, #tmem_scales, #ttng.tensor_memory>
-    // CHECK: %[[DESC_RS:.*]] = ttg.memdesc_reshape %[[DESC_LA]] : !ttg.memdesc<1x2x1x32x16xi8, #[[SHARED2]], #[[SMEM]]> -> !ttg.memdesc<2x1x32x4x4xi8, {{.*}}, #smem>
+    %89 = ttg.local_alloc %88 : (tensor<256x4xi8, #linear4>) -> !ttg.memdesc<256x4xi8, #shared_scale_final, #smem>
+    %90 = ttng.tmem_alloc %acc : (tensor<128x256xf32, #blocked1>) -> !ttg.memdesc<128x256xf32, #tmem, #ttng.tensor_memory, mutable>
+    %91 = ttng.tmem_alloc %cst_scales : (tensor<128x4xi8, #linear>) -> !ttg.memdesc<128x4xi8, #tmem_scales, #ttng.tensor_memory>
+    // CHECK: %[[DESC_LA:.*]] = ttg.local_alloc %[[DESC_LOAD]] : (tensor<1x2x1x32x16xi8, #{{.*}}>) -> !ttg.memdesc<1x2x1x32x16xi8, #{{.*}}, #smem
+    // CHECK-NOT: ttg.local_load
+    // CHECK: %[[DESC_RS:.*]] = ttg.memdesc_reshape %[[DESC_LA]]
     // CHECK: %[[DESC_TR:.*]] = ttg.memdesc_trans %[[DESC_RS]]
-    // CHECK: %[[SCALE_ALLOC:.*]] = ttg.memdesc_reshape %[[DESC_TR]] : !ttg.memdesc<2x4x32x1x4xi8, {{.*}}, #smem> -> !ttg.memdesc<256x4xi8, {{.*}}, #smem>
+    // CHECK: %[[SCALE_ALLOC:.*]] = ttg.memdesc_reshape %[[DESC_TR]]
     // CHECK: ttng.tc_gen5_mma_scaled {{.*}}, {{.*}}, {{.*}}, {{.*}}, %[[SCALE_ALLOC]], {{.*}}
-    ttng.tc_gen5_mma_scaled %shmemA, %shmemB, %89, %90, %91, %true, %true lhs = e4m3 rhs = e2m1 : !ttg.memdesc<128x128xf8E4M3FN, #shared, #smem>, !ttg.memdesc<64x256xi8, #shared1, #smem>, !ttg.memdesc<128x256xf32, #tmem, #ttng.tensor_memory, mutable>, !ttg.memdesc<128x4xi8, #tmem_scales, #ttng.tensor_memory>, !ttg.memdesc<256x4xi8, #tmem_scales, #ttng.tensor_memory>
+    ttng.tc_gen5_mma_scaled %shmemA, %shmemB, %90, %91, %89, %true, %true lhs = e4m3 rhs = e2m1 : !ttg.memdesc<128x128xf8E4M3FN, #shared, #smem>, !ttg.memdesc<64x256xi8, #shared1, #smem>, !ttg.memdesc<128x256xf32, #tmem, #ttng.tensor_memory, mutable>, !ttg.memdesc<128x4xi8, #tmem_scales, #ttng.tensor_memory>, !ttg.memdesc<256x4xi8, #shared_scale_final, #smem>
     tt.return
-  }
-}
-
-// -----
-
-#blocked = #ttg.blocked<{sizePerThread = [1, 1, 1, 1], threadsPerWarp = [1, 1, 1, 32], warpsPerCTA = [1, 1, 4, 1], order = [3, 2, 1, 0]}>
-#blocked1 = #ttg.blocked<{sizePerThread = [1, 1], threadsPerWarp = [1, 32], warpsPerCTA = [4, 1], order = [1, 0]}>
-#shared = #ttg.nvmma_shared<{swizzlingByteWidth = 64, transposed = false, elementBitWidth = 16}>
-#smem = #ttg.shared_memory
-// CHECK-DAG: #[[$SHARED:.+]] = #ttg.nvmma_shared<{swizzlingByteWidth = 64, transposed = false, elementBitWidth = 16}>
-// CHECK-DAG: #[[$SHARED1:.+]] = #ttg.nvmma_shared<{swizzlingByteWidth = 64, transposed = false, elementBitWidth = 16, rank = 4}>
-module attributes {"ttg.target" = "cuda:100", "ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, "ttg.threads-per-warp" = 32 : i32} {
-  // CHECK-LABEL: @reshape_memedesc
-  tt.func @reshape_memedesc(%arg: tensor<32x1x4x64xf16, #blocked>) -> !ttg.memdesc<128x64xf16, #shared, #smem> {
-    // CHECK: [[A:.+]] = ttg.local_alloc %{{.+}} : (tensor<32x1x4x64xf16, #{{.*}}>) -> !ttg.memdesc<32x1x4x64xf16, #[[$SHARED1]], #smem>
-    %r = tt.reshape %arg : tensor<32x1x4x64xf16, #blocked> -> tensor<128x64xf16, #blocked1>
-    // CHECK: %[[R:.+]] = ttg.memdesc_reshape %[[A:.+]] : !ttg.memdesc<32x1x4x64xf16, #[[$SHARED1]], #smem> -> !ttg.memdesc<128x64xf16, #[[$SHARED]], #smem>
-    %a = ttg.local_alloc %r : (tensor<128x64xf16, #blocked1>) -> !ttg.memdesc<128x64xf16, #shared, #smem>
-    // CHECK: tt.return %[[R]]
-    tt.return %a: !ttg.memdesc<128x64xf16, #shared, #smem>
-  }
-}
-
-// -----
-
-#blocked = #ttg.blocked<{sizePerThread = [1, 1, 1, 1], threadsPerWarp = [1, 1, 1, 32], warpsPerCTA = [1, 2, 2, 1], order = [3, 2, 1, 0]}>
-#blocked1 = #ttg.blocked<{sizePerThread = [1, 1], threadsPerWarp = [1, 32], warpsPerCTA = [4, 1], order = [1, 0]}>
-#shared = #ttg.nvmma_shared<{swizzlingByteWidth = 128, transposed = true, elementBitWidth = 32}>
-#smem = #ttg.shared_memory
-module attributes {"ttg.target" = "cuda:100", "ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, "ttg.threads-per-warp" = 32 : i32} {
-  // CHECK-LABEL: @reshape_memedesc_negative
-  tt.func @reshape_memedesc_negative(%arg: tensor<1x32x2x64xf32, #blocked>) -> !ttg.memdesc<64x64xf32, #shared, #smem> {
-    %r = tt.reshape %arg : tensor<1x32x2x64xf32, #blocked> -> tensor<64x64xf32, #blocked1>
-    // CHECK-NOT: ttg.memdesc_reshape
-    %a = ttg.local_alloc %r : (tensor<64x64xf32, #blocked1>) -> !ttg.memdesc<64x64xf32, #shared, #smem>
-    // CHECK: tt.return
-    tt.return %a: !ttg.memdesc<64x64xf32, #shared, #smem>
   }
 }
 

--- a/test/TritonNvidiaGPU/optimize_descriptor_encoding.mlir
+++ b/test/TritonNvidiaGPU/optimize_descriptor_encoding.mlir
@@ -187,3 +187,34 @@ tt.func public @descriptor_arg_from_4d_shared_linear_use(%arg0: !tt.tensordesc<1
   tt.return
 }
 }
+
+// -----
+
+#shared_linear_scale_base = #ttg.shared_linear<{offset = [[0, 0, 0, 0, 1], [0, 0, 0, 0, 2], [0, 0, 0, 0, 4], [0, 0, 0, 0, 8], [0, 0, 0, 1, 0], [0, 0, 0, 2, 0], [0, 0, 0, 4, 0], [0, 0, 0, 8, 0], [0, 0, 0, 16, 0], [0, 1, 0, 0, 0]]}, alignment = 128>
+#shared_linear_scale_rs = #ttg.shared_linear<{offset = [[0, 0, 0, 0, 1], [0, 0, 0, 0, 2], [0, 0, 0, 1, 0], [0, 0, 0, 2, 0], [0, 0, 1, 0, 0], [0, 0, 2, 0, 0], [0, 0, 4, 0, 0], [0, 0, 8, 0, 0], [0, 0, 16, 0, 0], [1, 0, 0, 0, 0]]}, alignment = 128>
+#shared_linear_scale_tr = #ttg.shared_linear<{offset = [[0, 0, 0, 0, 1], [0, 0, 0, 0, 2], [0, 1, 0, 0, 0], [0, 2, 0, 0, 0], [0, 0, 1, 0, 0], [0, 0, 2, 0, 0], [0, 0, 4, 0, 0], [0, 0, 8, 0, 0], [0, 0, 16, 0, 0], [1, 0, 0, 0, 0]]}, alignment = 128>
+#shared_linear_scale_final = #ttg.shared_linear<{offset = [[0, 1], [0, 2], [32, 0], [64, 0], [1, 0], [2, 0], [4, 0], [8, 0], [16, 0], [128, 0]]}, alignment = 128>
+#smem = #ttg.shared_memory
+
+module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 8 : i32, ttg.target = "cuda:100", "ttg.threads-per-warp" = 32 : i32} {
+// CHECK-DAG: #[[NVMMA_0_5D:.*]] = #ttg.nvmma_shared<{swizzlingByteWidth = 0, transposed = false, elementBitWidth = 8, rank = 5}>
+// CHECK-DAG: #[[SL_SCALE_BASE:.*]] = #ttg.shared_linear<{{.*}}alignment = 128>
+// CHECK-DAG: #[[SL_SCALE_RS:.*]] = #ttg.shared_linear<{{.*}}alignment = 128>
+// CHECK-DAG: #[[SL_SCALE_TR:.*]] = #ttg.shared_linear<{{.*}}alignment = 128>
+// CHECK-DAG: #[[SL_SCALE_FINAL:.*]] = #ttg.shared_linear<{{.*}}alignment = 128>
+tt.func public @scale_descriptor_arg_from_shared_linear_use(%arg0: !tt.tensordesc<1x2x1x32x16xi8>) {
+  // CHECK: %arg0: !tt.tensordesc<1x2x1x32x16xi8, #[[NVMMA_0_5D]]>
+  // CHECK: %[[LOAD:.*]] = tt.descriptor_load %arg0[%{{.*}}] : !tt.tensordesc<1x2x1x32x16xi8, #[[NVMMA_0_5D]]> -> tensor<1x2x1x32x16xi8>
+  // CHECK: %[[SCALE_LA:.*]] = ttg.local_alloc %[[LOAD]] : (tensor<1x2x1x32x16xi8>) -> !ttg.memdesc<1x2x1x32x16xi8, #[[SL_SCALE_BASE]], #smem, mutable>
+  // CHECK: %[[SCALE_RS:.*]] = ttg.memdesc_reshape %[[SCALE_LA]] : !ttg.memdesc<1x2x1x32x16xi8, #[[SL_SCALE_BASE]], #smem, mutable> -> !ttg.memdesc<2x1x32x4x4xi8, #[[SL_SCALE_RS]], #smem, mutable>
+  // CHECK: %[[SCALE_TR:.*]] = ttg.memdesc_trans %[[SCALE_RS]] {order = array<i32: 0, 3, 2, 1, 4>} : !ttg.memdesc<2x1x32x4x4xi8, #[[SL_SCALE_RS]], #smem, mutable> -> !ttg.memdesc<2x4x32x1x4xi8, #[[SL_SCALE_TR]], #smem, mutable>
+  // CHECK: ttg.memdesc_reshape %[[SCALE_TR]] : !ttg.memdesc<2x4x32x1x4xi8, #[[SL_SCALE_TR]], #smem, mutable> -> !ttg.memdesc<256x4xi8, #[[SL_SCALE_FINAL]], #smem, mutable>
+  %c0_i32 = arith.constant 0 : i32
+  %0 = tt.descriptor_load %arg0[%c0_i32, %c0_i32, %c0_i32, %c0_i32, %c0_i32] : !tt.tensordesc<1x2x1x32x16xi8> -> tensor<1x2x1x32x16xi8>
+  %1 = ttg.local_alloc %0 : (tensor<1x2x1x32x16xi8>) -> !ttg.memdesc<1x2x1x32x16xi8, #shared_linear_scale_base, #smem, mutable>
+  %2 = ttg.memdesc_reshape %1 : !ttg.memdesc<1x2x1x32x16xi8, #shared_linear_scale_base, #smem, mutable> -> !ttg.memdesc<2x1x32x4x4xi8, #shared_linear_scale_rs, #smem, mutable>
+  %3 = ttg.memdesc_trans %2 {order = array<i32: 0, 3, 2, 1, 4>} : !ttg.memdesc<2x1x32x4x4xi8, #shared_linear_scale_rs, #smem, mutable> -> !ttg.memdesc<2x4x32x1x4xi8, #shared_linear_scale_tr, #smem, mutable>
+  %4 = ttg.memdesc_reshape %3 : !ttg.memdesc<2x4x32x1x4xi8, #shared_linear_scale_tr, #smem, mutable> -> !ttg.memdesc<256x4xi8, #shared_linear_scale_final, #smem, mutable>
+  tt.return
+}
+}

--- a/unittest/Dialect/TritonGPU/LinearLayoutConversionsTest.cpp
+++ b/unittest/Dialect/TritonGPU/LinearLayoutConversionsTest.cpp
@@ -219,7 +219,7 @@ TEST_F(LinearLayoutConversionsTest, ShapeLargerThanLayout2DDegenerate) {
 
 TEST_F(LinearLayoutConversionsTest, CanonicalScaleSmemLayout) {
   LinearLayout layout =
-      getCanonicalScaleSmemLinearLayout(&ctx, /*shape=*/{256, 16});
+      getScaleSmemLayoutForTMEMCopy(&ctx, /*shape=*/{256, 16});
   LinearLayout expected = LinearLayout({{S("offset"),
                                          {{0, 1},
                                           {0, 2},

--- a/unittest/Dialect/TritonGPU/LinearLayoutConversionsTest.cpp
+++ b/unittest/Dialect/TritonGPU/LinearLayoutConversionsTest.cpp
@@ -217,6 +217,27 @@ TEST_F(LinearLayoutConversionsTest, ShapeLargerThanLayout2DDegenerate) {
                         {S("dim0"), S("dim1")}));
 }
 
+TEST_F(LinearLayoutConversionsTest, CanonicalScaleSmemLayout) {
+  LinearLayout layout =
+      getCanonicalScaleSmemLinearLayout(&ctx, /*shape=*/{256, 16});
+  LinearLayout expected = LinearLayout({{S("offset"),
+                                         {{0, 1},
+                                          {0, 2},
+                                          {32, 0},
+                                          {64, 0},
+                                          {1, 0},
+                                          {2, 0},
+                                          {4, 0},
+                                          {8, 0},
+                                          {16, 0},
+                                          {0, 4},
+                                          {0, 8},
+                                          {128, 0}}}},
+                                       {{S("dim0"), 256}, {S("dim1"), 16}},
+                                       /*requireSurjective=*/true);
+  EXPECT_EQ(layout, expected);
+}
+
 TEST_F(LinearLayoutConversionsTest, ShapeSmallerThanLayout) {
   // The shape is 8 elements, but the layout is 4*4*4 = 64 elems.  Therefore the
   // log2(64/8) = 3 most major bases are 0.

--- a/unittest/Dialect/TritonGPU/LinearLayoutConversionsTest.cpp
+++ b/unittest/Dialect/TritonGPU/LinearLayoutConversionsTest.cpp
@@ -218,8 +218,8 @@ TEST_F(LinearLayoutConversionsTest, ShapeLargerThanLayout2DDegenerate) {
 }
 
 TEST_F(LinearLayoutConversionsTest, CanonicalScaleSmemLayout) {
-  LinearLayout layout =
-      getScaleSmemLayoutForTMEMCopy(&ctx, /*shape=*/{256, 16});
+  LinearLayout layout = getScaleSmemLayoutForTMEMCopy(
+      &ctx, /*shape=*/{256, 16}, CGAEncodingAttr::get1CTALayout(&ctx, 2));
   LinearLayout expected = LinearLayout({{S("offset"),
                                          {{0, 1},
                                           {0, 2},
@@ -232,7 +232,8 @@ TEST_F(LinearLayoutConversionsTest, CanonicalScaleSmemLayout) {
                                           {16, 0},
                                           {0, 4},
                                           {0, 8},
-                                          {128, 0}}}},
+                                          {128, 0}}},
+                                        {S("block"), {}}},
                                        {{S("dim0"), 256}, {S("dim1"), 16}},
                                        /*requireSurjective=*/true);
   EXPECT_EQ(layout, expected);


### PR DESCRIPTION
## TLDR 

  - This PR elevates the already-existing blocked-scale unswizzle convention into:
      * an early decision in AccelerateMatmul
      * a canonical SMEM layout seeded there
      * a backprop/equivalence flow reused from #9931
   - It does not invent a new user convention for scales. No user code change is needed.

## Details 

The goal of this work is to make the TMEMCopy lowering flow for block scales have the same structure as what's done for swizzle-0 MMA operands in https://github.com/triton-lang/triton/pull/9931 - start with a legal `#shared_linear` layout in `AccelerateMatmul`, back propagate that layout through memdesc reshape / trans ops in `OptimizeDotOperand` (ODO), and select the equivalent `nvmma_shared` layout for TMA in `OptimizeDescriptorEncoding`.

Today the flow is opposite. ODO tries to decide if the scale tensor is compatible with TMEMCopy by pattern matching against the trans / reshape convention ("unswizzle") in the IR. We forward propagate the layout from the loaded tile through memdesc ops, and opportunistically create `#shared_linear` scale operands. The legality of this layout for TMEMCopy is supported only by the "convention" - in practice we know it works, but the entire process is admittedly ad hoc. 

Adopting the approach of https://github.com/triton-lang/triton/pull/9931 for blocked scales is not straightforward for the following reasons:
* Unlike the swizzle-0 MMA operand layout, there is no clear standard notion of "TMEMCopy-compatible scale layout in SMEM". So we need to come up with a definition of a canonical, TMEMCopy-induced SMEM layout for scales that we can seed in `AccelerateMatmul`.
* TMEMCopy is strictly an optional optimization. `AccelerateMatmul` needs to decide if the scale operand is supposed to be copied via TMEMCopy.

I addressed the first point by piggy-backing on the existing unswizzle convention as checked by `UseShmemForScales`. We are detecting hardcoded reshape / trans patterns in the IR, and the rewritten sequence of memdesc ops essentially determines the canonical SMEM layout for scales that is already assumed by Triton. This PR makes such a programmatically created layout more official by treating it as "the" canonical layout. 

For the second point on deciding the TMEMCopy compatibility -  I ported the unswizzle pattern detector from ODO to `AccelerateMatmul`, and assign SMEM operands to `TcGen05MMAScaled` if scales are decided to be TMEMCopy compatible. The upshot is that the MMA op starts with SMEM scale operands from the start, in contrast to the old convention where scale operands always start in TMEM.   