### PR TITLE
[JIT] Restore constexpr specialization for Python int annotations

### DIFF
--- a/python/test/unit/language/test_annotations.py
+++ b/python/test/unit/language/test_annotations.py
@@ -37,6 +37,33 @@ def test_int_annotation(signed, width, device):
     assert f'arith.{pfx}tofp' in h.asm["ttir"]
 
 
+def test_annotated_int_preserves_constexpr_specialization(device):
+
+    @triton.jit
+    def _kernel(X, stride: int, BLOCK: tl.constexpr):
+        offsets = tl.arange(0, BLOCK)
+        tl.store(X + offsets * stride, offsets)
+
+    @triton.jit
+    def _typed_kernel(X, stride: tl.int32, BLOCK: tl.constexpr):
+        offsets = tl.arange(0, BLOCK)
+        tl.store(X + offsets * stride, offsets)
+
+    def func_signature(ttir):
+        return next(line for line in ttir.splitlines() if "tt.func public" in line).split(" attributes ")[0]
+
+    x = torch.empty(16, dtype=torch.int32, device=device)
+
+    h = _kernel.warmup(x, 1, BLOCK=16, grid=(1, ))
+    assert "stride" not in func_signature(h.asm["ttir"])
+
+    h = _kernel.warmup(x, 2, BLOCK=16, grid=(1, ))
+    assert "%stride: i32" in func_signature(h.asm["ttir"])
+
+    h = _typed_kernel.warmup(x, 1, BLOCK=16, grid=(1, ))
+    assert "%stride: i32" in func_signature(h.asm["ttir"])
+
+
 # Test that unknown annotations do not emit an error
 def test_unknown_annotation(device):
 

--- a/python/triton/runtime/jit.py
+++ b/python/triton/runtime/jit.py
@@ -322,6 +322,8 @@ class KernelParam:
 
     @cached_property
     def annotation_type(self) -> str:
+        if self._param.annotation is int or self._param.annotation == "int":
+            return ""
         a = self.annotation
         if a.startswith("*k"):
             a = a[2:]


### PR DESCRIPTION
## Summary
This fixes #9834.

This restores the pre-#6152 specialization behavior for bare Python `int` annotations.

After #6152, `int` started normalizing to `i32`, which made `KernelParam.annotation_type` non-empty. As a result, arguments like `stride: int` with value
  `1` no longer went through the constexpr specialization path, changing the generated code for cases such as the FP8 transpose store pattern in #9834.

This patch keeps the change narrow:
  - bare Python `int` / `"int"` does not force an `annotation_type`
  - explicit Triton integer types such as `tl.int32` still produce typed runtime arguments
  - the regression test checks both constexpr specialization and the typed `i32` case

  Validation:
  - `python/test/unit/language/test_annotations.py::test_annotated_int_preserves_constexpr_specialization`
  - `python/test/unit/language/test_annotations.py::test_int_annotation`
  - `python/test/unit/language/test_annotations.py::test_unknown_annotation`
  - `python/test/unit/runtime/test_specialize.py::test_specialize_impl`

  Manual AMD validation on MI300X / gfx942:
  - #9834 reproducer variants `int`, `nohint`, and `constexpr` all avoid `buffer_store_byte`
  - generated code uses vectorized dword stores

<!---
The core Triton is a small number of people, and we receive many PRs (thank
you!).  To help us review your code more quickly, **if you are a new
contributor (less than 3 PRs merged) we ask that you complete the following
tasks and include the filled-out checklist in your PR description.**

Complete the following tasks before sending your PR, and replace `[ ]` with
`[x]` to indicate you have done them.
-->

# New contributor declaration
- [x] I am not making a trivial change, such as fixing a typo in a comment.

- [x] I have written a PR description following these
  [rules](https://cbea.ms/git-commit/#why-not-how).

- [ ] I have run `pre-commit run --from-ref origin/main --to-ref HEAD`.

- Select one of the following.
  - [x] I have added tests.
    - `/test` for `lit` tests
    - `/unittest` for C++ tests
    - `/python/test` for end-to-end tests
  - [ ] This PR does not need a test because `FILL THIS IN`.

- Select one of the following.
  - [ ] I have not added any `lit` tests.
  - [ ] The `lit` tests I have added follow these [best practices](https://mlir.llvm.org/getting_started/TestingGuide/#filecheck-best-practices),
    including the "tests should be minimal" section. (Usually running Python code
    and using the instructions it generates is not minimal.)
