### PR TITLE
[AMD] CanonicalizePointers: Handle select of pointers under tensor condition

### DIFF
--- a/test/TritonGPU/amd/amd-canonicalize-pointers-different-bases.mlir
+++ b/test/TritonGPU/amd/amd-canonicalize-pointers-different-bases.mlir
@@ -43,3 +43,55 @@ module attributes {"ttg.num-warps" = 4 : i32} {
     tt.return %5 : f32
   }
 }
+
+// -----
+
+// A select between two different base pointers under a tensor (per-element)
+// condition cannot use a uniform scalar base, so both arms are materialized
+// into tensor pointers before the select.
+// CHECK-LABEL: tt.func @select_tensor_cond_different_bases
+// CHECK: [[TRUE:%.*]] = tt.addptr {{.*}} : tensor<1024x!tt.ptr<f32>>, tensor<1024xi32>
+// CHECK: [[FALSE:%.*]] = tt.splat %arg1 : !tt.ptr<f32> -> tensor<1024x!tt.ptr<f32>>
+// CHECK: [[SEL:%.*]] = arith.select {{.*}}, [[TRUE]], [[FALSE]] : tensor<1024xi1>, tensor<1024x!tt.ptr<f32>>
+// CHECK: tt.load [[SEL]]
+module attributes {"ttg.num-warps" = 4 : i32} {
+  tt.func @select_tensor_cond_different_bases(%arg0: !tt.ptr<f32> {tt.divisibility = 16 : i32, tt.pointer_range = 32 : i32},
+                                              %arg1: !tt.ptr<f32> {tt.divisibility = 16 : i32, tt.pointer_range = 32 : i32},
+                                              %arg2: i32) -> tensor<1024xf32> {
+    %0 = tt.make_range {end = 1024 : i32, start = 0 : i32} : tensor<1024xi32>
+    %1 = tt.splat %arg2 : i32 -> tensor<1024xi32>
+    %2 = arith.cmpi eq, %0, %1 : tensor<1024xi32>
+    %3 = tt.splat %arg0 : !tt.ptr<f32> -> tensor<1024x!tt.ptr<f32>>
+    %4 = tt.addptr %3, %0 : tensor<1024x!tt.ptr<f32>>, tensor<1024xi32>
+    %5 = tt.splat %arg1 : !tt.ptr<f32> -> tensor<1024x!tt.ptr<f32>>
+    %6 = arith.select %2, %4, %5 : tensor<1024xi1>, tensor<1024x!tt.ptr<f32>>
+    %7 = tt.load %6 : tensor<1024x!tt.ptr<f32>>
+    tt.return %7 : tensor<1024xf32>
+  }
+}
+
+// -----
+
+// A tensor-condition select sharing the same base keeps the uniform base and
+// only selects the offsets (no pointer select).
+// CHECK-LABEL: tt.func @select_tensor_cond_same_base
+// CHECK: [[OFF:%.*]] = arith.select {{.*}} : tensor<1024xi1>, tensor<1024xi32>
+// CHECK: [[BASE:%.*]] = tt.splat %arg0 : !tt.ptr<f32> -> tensor<1024x!tt.ptr<f32>>
+// CHECK: [[PTR:%.*]] = tt.addptr [[BASE]], [[OFF]]
+// CHECK: tt.load [[PTR]]
+module attributes {"ttg.num-warps" = 4 : i32} {
+  tt.func @select_tensor_cond_same_base(%arg0: !tt.ptr<f32> {tt.divisibility = 16 : i32, tt.pointer_range = 32 : i32},
+                                        %arg1: i32) -> tensor<1024xf32> {
+    %c16_i32 = arith.constant 16 : i32
+    %0 = tt.make_range {end = 1024 : i32, start = 0 : i32} : tensor<1024xi32>
+    %1 = tt.splat %arg1 : i32 -> tensor<1024xi32>
+    %2 = arith.cmpi eq, %0, %1 : tensor<1024xi32>
+    %3 = tt.splat %arg0 : !tt.ptr<f32> -> tensor<1024x!tt.ptr<f32>>
+    %4 = tt.addptr %3, %0 : tensor<1024x!tt.ptr<f32>>, tensor<1024xi32>
+    %5 = tt.splat %c16_i32 : i32 -> tensor<1024xi32>
+    %6 = tt.addptr %3, %5 : tensor<1024x!tt.ptr<f32>>, tensor<1024xi32>
+    %7 = arith.select %2, %4, %6 : tensor<1024xi1>, tensor<1024x!tt.ptr<f32>>
+    %8 = tt.load %7 : tensor<1024x!tt.ptr<f32>>
+    tt.return %8 : tensor<1024xf32>
+  }
+}

--- a/third_party/amd/lib/TritonAMDGPUTransforms/CanonicalizePointers.cpp
+++ b/third_party/amd/lib/TritonAMDGPUTransforms/CanonicalizePointers.cpp
@@ -1394,19 +1394,38 @@ public:
 
     // If both have been traversed, then we can rewrite select of pointers as a
     // select of base and offset
+    Value cond = selectOp.getCondition();
+    Value baseTrue = fatPtrTrue[0], offsetTrue = fatPtrTrue[1];
+    Value baseFalse = fatPtrFalse[0], offsetFalse = fatPtrFalse[1];
 
-    // Rewrite to select(fatBaseT, fatBaseF) and select(fatOffsetT, fatOffsetF)
-    auto newBase = arith::SelectOp::create(rewriter, selectOp.getLoc(),
-                                           selectOp.getCondition(),
-                                           fatPtrTrue[0], fatPtrFalse[0]);
-    auto newOffset = arith::SelectOp::create(rewriter, selectOp.getLoc(),
-                                             selectOp.getCondition(),
-                                             fatPtrTrue[1], fatPtrFalse[1]);
+    // A tensor condition can't select between differing scalar bases, so
+    // materialize both arms and select the full tensor pointers instead.
+    if (isa<RankedTensorType>(cond.getType()) && baseTrue != baseFalse) {
+      Value truePtr =
+          createTensorPointer(rewriter, baseTrue, offsetTrue, selectOp.getLoc(),
+                              fatPtrs.at({baseTrue, offsetTrue}));
+      Value falsePtr = createTensorPointer(
+          rewriter, baseFalse, offsetFalse, selectOp.getLoc(),
+          fatPtrs.at({baseFalse, offsetFalse}));
+      rewriter.replaceOp(selectOp,
+                         arith::SelectOp::create(rewriter, selectOp.getLoc(),
+                                                 cond, truePtr, falsePtr));
+      return success();
+    }
+
+    // Select base and offset separately. Reuse the base when both arms share
+    // it, so only the offset needs a select.
+    Value newBase = baseTrue;
+    if (baseTrue != baseFalse)
+      newBase = arith::SelectOp::create(rewriter, selectOp.getLoc(), cond,
+                                        baseTrue, baseFalse);
+    Value newOffset = arith::SelectOp::create(rewriter, selectOp.getLoc(), cond,
+                                              offsetTrue, offsetFalse);
 
     rewriter.replaceOpWithMultiple(selectOp, {{newBase, newOffset}});
     fatPtrs[{newBase, newOffset}] = FatPointers::FatPtrAttrs::intersect(
-        fatPtrs.at({fatPtrTrue[0], fatPtrTrue[1]}),
-        fatPtrs.at({fatPtrFalse[0], fatPtrFalse[1]}));
+        fatPtrs.at({baseTrue, offsetTrue}),
+        fatPtrs.at({baseFalse, offsetFalse}));
 
     return success();
   }


### PR DESCRIPTION
A select between two different base pointers under a tensor (per-element) condition emitted an invalid select pairing a tensor condition with scalar pointer operands. Materialize both arms into tensor pointers before the select, and skip the base select when both arms share the same base.

Fixes https://github.com/triton-lang/triton/issues/10381