### PR TITLE
[Testing] Create benchmark save directory before running

### DIFF
--- a/python/triton/testing.py
+++ b/python/triton/testing.py
@@ -577,13 +577,14 @@ class Mark:
         has_single_bench = isinstance(self.benchmarks, Benchmark)
         benchmarks = [self.benchmarks] if has_single_bench else self.benchmarks
         result_dfs = []
+        if save_path:
+            # Create directory if it doesn't exist
+            os.makedirs(save_path, exist_ok=True)
         try:
             for bench in benchmarks:
                 result_dfs.append(self._run(bench, save_path, show_plots, print_data, **kwargs))
         finally:
             if save_path:
-                # Create directory if it doesn't exist
-                os.makedirs(save_path, exist_ok=True)
                 with open(os.path.join(save_path, "results.html"), "w") as html:
                     html.write("<html><body>\n")
                     for bench in benchmarks[:len(result_dfs)]:


### PR DESCRIPTION
Ensure benchmark result directories exist before individual runs write outputs, so saved artifacts can be produced reliably.

<!---
The core Triton is a small number of people, and we receive many PRs (thank
you!).  To help us review your code more quickly, **if you are a new
contributor (less than 3 PRs merged) we ask that you complete the following
tasks and include the filled-out checklist in your PR description.**

Complete the following tasks before sending your PR, and replace `[ ]` with
`[x]` to indicate you have done them.
-->

# New contributor declaration
- [x] I am not making a trivial change, such as fixing a typo in a comment.

- [x] I have written a PR description following these
  [rules](https://cbea.ms/git-commit/#why-not-how).

- [x] I have run `pre-commit run --from-ref origin/main --to-ref HEAD`.

- Select one of the following.
  - [ ] I have added tests.
    - `/test` for `lit` tests
    - `/unittest` for C++ tests
    - `/python/test` for end-to-end tests
  - [x] This PR does not need a test because `FILL THIS IN`.

- Select one of the following.
  - [x] I have not added any `lit` tests.
  - [ ] The `lit` tests I have added follow these [best practices](https://mlir.llvm.org/getting_started/TestingGuide/#filecheck-best-practices),
    including the "tests should be minimal" section. (Usually running Python code
    and using the instructions it generates is not minimal.)
