### PR TITLE
Add packed f32x2 arithmetic builtins

### DIFF
--- a/python/test/unit/language/test_f32x2.py
+++ b/python/test/unit/language/test_f32x2.py
@@ -1,0 +1,41 @@
+import pytest
+import torch
+
+import triton
+import triton.language as tl
+
+
+def _is_blackwell():
+    if not torch.cuda.is_available():
+        return False
+    return torch.cuda.get_device_capability()[0] >= 10
+
+
+@triton.jit
+def _f32x2_kernel(a_ptr, b_ptr, c_ptr, out_mul, out_add, out_sub, out_fma, N: tl.constexpr):
+    offs = tl.arange(0, N)
+    a = tl.load(a_ptr + offs)
+    b = tl.load(b_ptr + offs)
+    c = tl.load(c_ptr + offs)
+    tl.store(out_mul + offs, tl.math.mul_f32x2(a, b))
+    tl.store(out_add + offs, tl.math.add_f32x2(a, b))
+    tl.store(out_sub + offs, tl.math.sub_f32x2(a, b))
+    tl.store(out_fma + offs, tl.math.fma_f32x2(a, b, c))
+
+
+@pytest.mark.skipif(not _is_blackwell(), reason="f32x2 requires Blackwell sm_100")
+def test_f32x2():
+    N = 256
+    torch.manual_seed(0)
+    a = torch.randn(N, device="cuda", dtype=torch.float32)
+    b = torch.randn(N, device="cuda", dtype=torch.float32)
+    c = torch.randn(N, device="cuda", dtype=torch.float32)
+    out_mul = torch.empty_like(a)
+    out_add = torch.empty_like(a)
+    out_sub = torch.empty_like(a)
+    out_fma = torch.empty_like(a)
+    _f32x2_kernel[(1, )](a, b, c, out_mul, out_add, out_sub, out_fma, N)
+    torch.testing.assert_close(out_mul, a * b)
+    torch.testing.assert_close(out_add, a + b)
+    torch.testing.assert_close(out_sub, a - b)
+    torch.testing.assert_close(out_fma, a * b + c)

--- a/python/triton/language/__init__.py
+++ b/python/triton/language/__init__.py
@@ -124,8 +124,8 @@ from .core import (
     void,
     where,
 )
-from .math import (umulhi, exp, exp2, fma, log, log2, cos, rsqrt, sin, sqrt, sqrt_rn, abs, fdiv, div_rn, erf, floor,
-                   ceil)
+from .math import (umulhi, mul_f32x2, add_f32x2, sub_f32x2, fma_f32x2, exp, exp2, fma, log, log2, cos, rsqrt, sin,
+                   sqrt, sqrt_rn, abs, fdiv, div_rn, erf, floor, ceil)
 from .random import (
     pair_uniform_to_normal,
     philox,

--- a/python/triton/language/math.py
+++ b/python/triton/language/math.py
@@ -92,6 +92,91 @@ def umulhi(x, y, _semantic=None):
 
 
 @core.builtin
+def mul_f32x2(a, b, _semantic=None):
+    return core.inline_asm_elementwise(
+        """
+        {
+            .reg .b64 ra, rb, rc;
+            mov.b64 ra, { $2, $3 };
+            mov.b64 rb, { $4, $5 };
+            mul.f32x2 rc, ra, rb;
+            mov.b64 { $0, $1 }, rc;
+        }
+        """,
+        "=r,=r,r,r,r,r",
+        [a, b],
+        dtype=core.float32,
+        is_pure=True,
+        pack=2,
+        _semantic=_semantic,
+    )
+
+
+@core.builtin
+def add_f32x2(a, b, _semantic=None):
+    return core.inline_asm_elementwise(
+        """
+        {
+            .reg .b64 ra, rb, rc;
+            mov.b64 ra, { $2, $3 };
+            mov.b64 rb, { $4, $5 };
+            add.f32x2 rc, ra, rb;
+            mov.b64 { $0, $1 }, rc;
+        }
+        """,
+        "=r,=r,r,r,r,r",
+        [a, b],
+        dtype=core.float32,
+        is_pure=True,
+        pack=2,
+        _semantic=_semantic,
+    )
+
+
+@core.builtin
+def sub_f32x2(a, b, _semantic=None):
+    return core.inline_asm_elementwise(
+        """
+        {
+            .reg .b64 ra, rb, rc;
+            mov.b64 ra, { $2, $3 };
+            mov.b64 rb, { $4, $5 };
+            sub.f32x2 rc, ra, rb;
+            mov.b64 { $0, $1 }, rc;
+        }
+        """,
+        "=r,=r,r,r,r,r",
+        [a, b],
+        dtype=core.float32,
+        is_pure=True,
+        pack=2,
+        _semantic=_semantic,
+    )
+
+
+@core.builtin
+def fma_f32x2(a, b, c, _semantic=None):
+    return core.inline_asm_elementwise(
+        """
+        {
+            .reg .b64 ra, rb, rc, rd;
+            mov.b64 ra, { $2, $3 };
+            mov.b64 rb, { $4, $5 };
+            mov.b64 rc, { $6, $7 };
+            fma.rn.f32x2 rd, ra, rb, rc;
+            mov.b64 { $0, $1 }, rd;
+        }
+        """,
+        "=r,=r,r,r,r,r,r,r",
+        [a, b, c],
+        dtype=core.float32,
+        is_pure=True,
+        pack=2,
+        _semantic=_semantic,
+    )
+
+
+@core.builtin
 @_check_dtype(dtypes=["fp32", "fp64"])
 @_add_math_1arg_docstr("exponential")
 @core._tensor_member_fn


### PR DESCRIPTION
Expose tl.math.{mul,add,sub,fma}_f32x2 wrapping the Blackwell packed-FP32x2 PTX (mul/add/sub/fma.rn.f32x2; 2x FP32 throughput, bit-identical numerics) so kernels stop hand-writing tl.inline_asm_elementwise for it.



# New contributor declaration
- [x] I am not making a trivial change, such as fixing a typo in a comment.

- [x] I have written a PR description following these
  [rules](https://cbea.ms/git-commit/#why-not-how).

- [X] I have run `pre-commit run --from-ref origin/main --to-ref HEAD`.

- Select one of the following.
  - [ ] I have added tests.
    - `/test` for `lit` tests
    - `/unittest` for C++ tests
    - `/python/test` for end-to-end tests
  - [x] This PR does not need a test because `small function exposure`.

- Select one of the following.
  - [x] I have not added any `lit` tests.
  - [ ] The `lit` tests I have added follow these [best practices](https://mlir.llvm.org/getting_started/TestingGuide/#filecheck-best-practices),
    including the "tests should be minimal" section. (Usually running Python code
    and using the instructions it generates is not minimal.)
