### PR TITLE
[BUILD] Tweak download names to avoid repeated downloads of nvcc and cupti.

### DIFF
--- a/python/build_helpers.py
+++ b/python/build_helpers.py
@@ -499,7 +499,7 @@ def download_and_copy_dependencies(helper_args: BuildHelperArgs):
 
     # We download a separate ptxas for blackwell, since there are some bugs when using it for hopper
     download_and_copy(
-        name="nvcc",
+        name="nvcc-blackwell",
         src_func=lambda system, arch, version: f"cuda_nvcc-{system}-{arch}-{version}-archive/bin/ptxas{exe_extension}",
         dst_path="bin/ptxas-blackwell",
         override_path=helper_args.ptxas_blackwell_path,
@@ -532,7 +532,7 @@ def download_and_copy_dependencies(helper_args: BuildHelperArgs):
     )
     crt = "crt" if int(nvidia_toolchain_version["cudacrt"].split(".")[0]) >= 13 else "nvcc"
     download_and_copy(
-        name="nvcc",
+        name="nvcc-crt",
         src_func=lambda system, arch, version: f"cuda_{crt}-{system}-{arch}-{version}-archive/include",
         dst_path="include",
         override_path=helper_args.cudacrt_path,
@@ -572,7 +572,7 @@ def download_and_copy_dependencies(helper_args: BuildHelperArgs):
         helper_args=helper_args,
     )
     download_and_copy(
-        name="cupti",
+        name="cupti-blackwell",
         src_func=lambda system, arch, version: f"cuda_cupti-{system}-{arch}-{version}-archive/lib",
         dst_path="lib/cupti-blackwell",
         override_path=helper_args.cupti_lib_blackwell_path,


### PR DESCRIPTION
<!---
The core Triton is a small number of people, and we receive many PRs (thank
you!).  To help us review your code more quickly, **if you are a new
contributor (less than 3 PRs merged) we ask that you complete the following
tasks and include the filled-out checklist in your PR description.**

Complete the following tasks before sending your PR, and replace `[ ]` with
`[x]` to indicate you have done them.
-->

# New contributor declaration
- [ ] I am not making a trivial change, such as fixing a typo in a comment.

- [x] I have written a PR description following these
  [rules](https://cbea.ms/git-commit/#why-not-how).

- [x] I have run `pre-commit run --from-ref origin/main --to-ref HEAD`.

- Select one of the following.
  - [ ] I have added tests.
    - `/test` for `lit` tests
    - `/unittest` for C++ tests
    - `/python/test` for end-to-end tests
  - [x] This PR does not need a test because `NFC Build tweak`.

- Select one of the following.
  - [x] I have not added any `lit` tests.
  - [ ] The `lit` tests I have added follow these [best practices](https://mlir.llvm.org/getting_started/TestingGuide/#filecheck-best-practices),
    including the "tests should be minimal" section. (Usually running Python code
    and using the instructions it generates is not minimal.)

---

## Summary

The Triton build can redownload the same nvidia nvcc/cupti artifacts every time it's invoked.  This happens because several dependencies share the same cache `tmp_path` and on the first cache miss that `tmp_path` is removed, so fresh builds will remove previous dependencies that share the same name. This change tweaks `tmp_path` so each dependency is given its own name and stored separately, so a cache miss doesn't delete a separate dependency.