### PR TITLE
[FPSAN] Fix TMEM emulation correctness

### DIFF
--- a/lib/Dialect/TritonInstrument/Transforms/FpSanitizer.cpp
+++ b/lib/Dialect/TritonInstrument/Transforms/FpSanitizer.cpp
@@ -11,7 +11,6 @@
 #include "triton/Dialect/TritonInstrument/Transforms/Passes.h"
 #include "triton/Dialect/TritonNvidiaGPU/IR/Dialect.h"
 #include "triton/Tools/LayoutUtils.h"
-#include "llvm/ADT/DenseSet.h"
 #include "llvm/ADT/STLExtras.h"
 #include <cassert>
 
@@ -165,6 +164,7 @@ ttg::BlockedEncodingAttr getOptimizedBlockedEncoding(PatternRewriter &rewriter,
 struct ScratchInfo {
   Value ptr;
   RankedTensorType tensorType;
+  ttg::MemDescType scaleSourceType;
 };
 
 struct MmaOperandSource {
@@ -338,8 +338,7 @@ public:
         auto initTy = cast<RankedTensorType>(init.getType());
         if (!storeFpSanScratchMemory(rewriter, loc, ptr, init, initTy))
           return std::nullopt;
-        if (sharedClusterState)
-          createGlobalScratchBarrier(rewriter, loc, sharedClusterState);
+        createGlobalScratchBarrier(rewriter, loc, sharedClusterState);
       }
 
       state.canonical = ScratchInfo{ptr, tensorTy};
@@ -352,7 +351,7 @@ public:
 
     if (auto subslice = memdesc.getDefiningOp<ttng::TMEMSubSliceOp>()) {
       auto baseInfo = getOrCreate(subslice.getSrc(), rewriter, scope);
-      if (!baseInfo)
+      if (!baseInfo || baseInfo->scaleSourceType)
         return std::nullopt;
 
       auto baseTy = cast<ttg::MemDescType>(subslice.getSrc().getType());
@@ -385,7 +384,7 @@ public:
 
     if (auto view = memdesc.getDefiningOp<ttg::MemDescIndexOp>()) {
       auto baseInfo = getOrCreate(view.getSrc(), rewriter, scope);
-      if (!baseInfo)
+      if (!baseInfo || baseInfo->scaleSourceType)
         return std::nullopt;
 
       auto baseTy = cast<ttg::MemDescType>(view.getSrc().getType());
@@ -417,6 +416,16 @@ public:
       auto baseInfo = getOrCreate(view.getSrc(), rewriter, scope);
       if (!baseInfo)
         return std::nullopt;
+
+      auto baseTy = cast<ttg::MemDescType>(view.getSrc().getType());
+      if (isa<ttng::TensorMemoryScalesEncodingAttr>(baseTy.getEncoding()) &&
+          !isa<ttng::TensorMemoryScalesEncodingAttr>(memTy.getEncoding()))
+        return ScratchInfo{baseInfo->ptr, baseInfo->tensorType, baseTy};
+      if (baseInfo->scaleSourceType) {
+        if (isa<ttng::TensorMemoryScalesEncodingAttr>(memTy.getEncoding()))
+          return std::nullopt;
+        return baseInfo;
+      }
 
       OpBuilder::InsertionGuard guard(rewriter);
       rewriter.setInsertionPoint(view);
@@ -917,7 +926,7 @@ createTmemOperandScratch(PatternRewriter &rewriter, Location loc,
   auto tensorTy =
       RankedTensorType::get(memTy.getShape(), memTy.getElementType(), layout);
   auto info = scratch.getOrCreate(memdesc, rewriter, scope);
-  if (!info)
+  if (!info || info->scaleSourceType)
     return std::nullopt;
   Value fullVal = loadFpSanScratchMemory(rewriter, loc, info->ptr, tensorTy);
   if (!fullVal)
@@ -2328,22 +2337,96 @@ struct TMEMLoadPattern : public OpRewritePattern<ttng::TMEMLoadOp> {
     auto resultTy = cast<RankedTensorType>(op.getResult().getType());
     if (!resultTy.getEncoding())
       return emitFpSanUnsupported(op.getOperation());
-    Value result = loadFpSanScratchMemory(rewriter, loc, info->ptr, resultTy);
+
+    Value result;
+    if (info->scaleSourceType) {
+      auto scaleMemTy = info->scaleSourceType;
+      auto physicalMemTy = cast<ttg::MemDescType>(op.getSrc().getType());
+      auto scaleShape = scaleMemTy.getShape();
+
+      constexpr int64_t physicalRows = 128;
+      auto physicalEncoding =
+          cast<ttng::TensorMemoryEncodingAttr>(physicalMemTy.getEncoding());
+      int64_t rows = scaleShape[0];
+      int64_t cols = scaleShape[1];
+      SmallVector<int64_t> physicalShape = {physicalRows, rows * cols / 32};
+      if (rows % 32 != 0 || cols % 4 != 0 ||
+          ttng::getTmemAllocSizes(scaleMemTy).numRows != physicalRows ||
+          physicalMemTy.getElementType().getIntOrFloatBitWidth() != 8 ||
+          physicalMemTy.getShape() != ArrayRef<int64_t>(physicalShape) ||
+          physicalEncoding.getBlockM() != physicalRows ||
+          physicalEncoding.getColStride() != 1)
+        return emitFpSanUnsupported(op.getOperation());
+
+      // Reconstruct the scale-copy hardware representation from the latest
+      // compact shadow at the point where the raw TMEM alias is consumed.
+      result = createLoadScratchMemory(rewriter, loc, info->ptr,
+                                       getScratchStorageType(info->tensorType));
+      SmallVector<int64_t> shape = {rows / 32, 32, cols / 4, 4};
+      result = tt::ReshapeOp::create(rewriter, loc, shape, result);
+      result = tt::TransOp::create(rewriter, loc, result, {1, 2, 0, 3});
+      shape = {32, physicalShape[1]};
+      result = tt::ReshapeOp::create(rewriter, loc, shape, result);
+      shape = {1, 32, physicalShape[1]};
+      result = tt::ReshapeOp::create(rewriter, loc, shape, result);
+      shape[0] = 4;
+      auto repeatedTy = cast<RankedTensorType>(result.getType()).clone(shape);
+      result = tt::BroadcastOp::create(rewriter, loc, repeatedTy, result);
+      result = tt::ReshapeOp::create(rewriter, loc, physicalShape, result);
+      result = ttg::ConvertLayoutOp::create(
+          rewriter, loc, getScratchStorageType(resultTy), result);
+      if (isFloatLike(resultTy))
+        result = unembedToFloat(rewriter, loc, result, resultTy);
+    } else {
+      result = loadFpSanScratchMemory(rewriter, loc, info->ptr, resultTy);
+    }
+
     if (!result)
       return emitFpSanCodegenError(op.getOperation());
+
+    Value reduced;
+    if (op.getRed()) {
+      Value reductionInput = result;
+      if (op.getAbs().value_or(false))
+        reductionInput =
+            math::AbsFOp::create(rewriter, loc, reductionInput).getResult();
+      reductionInput = embedToInt(rewriter, loc, reductionInput);
+
+      auto reduce =
+          tt::ReduceOp::create(rewriter, loc, ValueRange{reductionInput}, 1);
+      Block &block = reduce.getCombineOp().emplaceBlock();
+      Type elemTy = getElementTypeOrSelf(reductionInput.getType());
+      block.addArguments({elemTy, elemTy}, {loc, loc});
+
+      {
+        OpBuilder::InsertionGuard guard(rewriter);
+        rewriter.setInsertionPointToStart(&block);
+        Value lhs = block.getArgument(0);
+        Value rhs = block.getArgument(1);
+        // FPSAN gives both NaN modes the same signed-payload semantics.
+        Value combined =
+            *op.getRedOp() == ttng::TMEMLoadReduceModifier::MIN
+                ? arith::MinSIOp::create(rewriter, loc, lhs, rhs).getResult()
+                : arith::MaxSIOp::create(rewriter, loc, lhs, rhs).getResult();
+        tt::ReduceReturnOp::create(rewriter, loc, ValueRange{combined});
+      }
+      reduced = unembedToFloat(rewriter, loc, reduce.getResult().front(),
+                               op.getRed().getType());
+    }
 
     createGlobalScratchBarrier(rewriter, loc,
                                scratch->usesSharedClusterState());
 
-    if (op.getNumResults() == 1) {
-      rewriter.replaceOp(op, result);
-      return success();
+    SmallVector<Value> replacements{result};
+    if (op.getToken()) {
+      SmallVector<Value> deps;
+      if (op.getDep())
+        deps.push_back(op.getDep());
+      replacements.push_back(createAsyncToken(rewriter, loc, deps));
     }
-    SmallVector<Value> deps;
-    if (op.getDep())
-      deps.push_back(op.getDep());
-    Value token = createAsyncToken(rewriter, loc, deps);
-    rewriter.replaceOp(op, {result, token});
+    if (reduced)
+      replacements.push_back(reduced);
+    rewriter.replaceOp(op, replacements);
     return success();
   }
 
@@ -2361,12 +2444,23 @@ struct TMEMStorePattern : public OpRewritePattern<ttng::TMEMStoreOp> {
     auto info = scratch->getOrCreate(op.getDst(), rewriter, scope);
     if (!info)
       return emitFpSanCodegenError(op.getOperation());
+    if (info->scaleSourceType)
+      return emitFpSanUnsupported(op.getOperation());
 
     auto loc = op.getLoc();
     auto srcTy = cast<RankedTensorType>(op.getSrc().getType());
     if (!srcTy.getEncoding())
       return emitFpSanUnsupported(op.getOperation());
-    if (!storeFpSanScratchMemory(rewriter, loc, info->ptr, op.getSrc(), srcTy))
+    auto storageTy = getScratchStorageType(srcTy);
+    Value stored = embedToInt(rewriter, loc, op.getSrc());
+    if (!matchPattern(op.getPred(), m_One())) {
+      Value previous =
+          createLoadScratchMemory(rewriter, loc, info->ptr, storageTy);
+      Value pred = castScalarIntToIntLike(
+          rewriter, loc, op.getPred(), storageTy.clone(rewriter.getI1Type()));
+      stored = arith::SelectOp::create(rewriter, loc, pred, stored, previous);
+    }
+    if (!createStoreScratchMemory(rewriter, loc, info->ptr, stored, storageTy))
       return emitFpSanCodegenError(op.getOperation());
 
     createGlobalScratchBarrier(rewriter, loc,
@@ -2398,6 +2492,8 @@ struct TMEMCopyPattern : public OpRewritePattern<ttng::TMEMCopyOp> {
     auto info = scratch->getOrCreate(op.getDst(), rewriter, scope);
     if (!info)
       return emitFpSanCodegenError(op.getOperation());
+    if (info->scaleSourceType)
+      return emitFpSanUnsupported(op.getOperation());
 
     auto loc = op.getLoc();
     auto srcMemTy = cast<ttg::MemDescType>(op.getSrc().getType());
@@ -2561,7 +2657,7 @@ struct TCGen5MMAPattern : public OpRewritePattern<ttng::TCGen5MMAOp> {
 
     auto scope = getScratchScopeRegion(op);
     auto dInfo = scratch->getOrCreate(op.getD(), rewriter, scope);
-    if (!dInfo)
+    if (!dInfo || dInfo->scaleSourceType)
       return emitFpSanCodegenError(op.getOperation());
 
     auto loc = op.getLoc();
@@ -2735,7 +2831,7 @@ struct TCGen5MMAScaledPattern
 
     auto scope = getScratchScopeRegion(op);
     auto dInfo = scratch->getOrCreate(op.getD(), rewriter, scope);
-    if (!dInfo)
+    if (!dInfo || dInfo->scaleSourceType)
       return emitFpSanCodegenError(op.getOperation());
 
     auto loc = op.getLoc();

--- a/python/test/gluon/test_fpsan.py
+++ b/python/test/gluon/test_fpsan.py
@@ -9,6 +9,7 @@ from triton.experimental import gluon
 from triton.experimental.gluon import language as gl
 from triton import language as tl
 from triton._internal_testing import is_blackwell, is_cuda, is_hip, is_hip_cdna3, is_hip_cdna4, is_hip_gfx1250, is_hopper, is_interpreter
+from triton._internal_testing import is_blackwell_ultra
 from triton.experimental.gluon.language.nvidia.ampere import mma_v2
 from triton.experimental.gluon.language.nvidia import hopper
 from triton.experimental.gluon.language.nvidia.blackwell import (
@@ -2301,8 +2302,33 @@ def test_tcgen05_mma_scaled_two_ctas(device, fresh_knobs):
         b_scale_offs_k = gl.arange(0, SCALE_K, layout=gl.SliceLayout(0, b_scale_reg_layout))[None, :]
         scale_offs_m = gl.arange(0, BLOCK_M, layout=gl.SliceLayout(1, a_scale_reg_layout))[:, None]
         scale_offs_n = gl.arange(0, BLOCK_N, layout=gl.SliceLayout(1, b_scale_reg_layout))[:, None]
-        a_scale.store(gl.load(a_scale_ptr + scale_offs_m * SCALE_K + a_scale_offs_k))
-        b_scale.store(gl.load(b_scale_ptr + scale_offs_n * SCALE_K + b_scale_offs_k))
+        a_scale_values = gl.load(a_scale_ptr + scale_offs_m * SCALE_K + a_scale_offs_k)
+        b_scale_values = gl.load(b_scale_ptr + scale_offs_n * SCALE_K + b_scale_offs_k)
+        scale_smem_offset_bases: gl.constexpr = [
+            [0, 1],
+            [0, 2],
+            [32, 0],
+            [64, 0],
+            [1, 0],
+            [2, 0],
+            [4, 0],
+            [8, 0],
+            [16, 0],
+        ]
+        a_scale_smem_layout: gl.constexpr = gl.SharedLinearLayout(
+            offset_bases=scale_smem_offset_bases,
+            block_bases=((128, 0), ),
+        )
+        b_scale_smem_layout: gl.constexpr = gl.SharedLinearLayout(
+            offset_bases=scale_smem_offset_bases,
+            block_bases=((0, 0), ),
+        )
+        a_scale_smem = gl.allocate_shared_memory(gl.int8, [BLOCK_M, SCALE_K], a_scale_smem_layout)
+        b_scale_smem = gl.allocate_shared_memory(gl.int8, [BLOCK_N, SCALE_K], b_scale_smem_layout)
+        a_scale_smem.store(a_scale_values)
+        b_scale_smem.store(b_scale_values)
+        tcgen05_copy(a_scale_smem, a_scale)
+        tcgen05_copy(b_scale_smem, b_scale)
 
         bar = mbarrier.allocate_mbarrier()
         mbarrier.init(bar, count=1)
@@ -2392,15 +2418,72 @@ def test_tmem_index_subslice(device, fresh_knobs):
     _assert_payload_equal(out, exp_bits)
 
 
-@pytest.mark.skipif(not is_blackwell(), reason="Requires Blackwell")
-@pytest.mark.parametrize("two_ctas", [False, True])
-def test_tmem_copy_scales_in_warp_specialize_partition(device, two_ctas, fresh_knobs):
+@pytest.mark.skipif(not is_blackwell_ultra(), reason="Requires Blackwell Ultra")
+@pytest.mark.parametrize("red_op,use_abs", [("min", False), ("max", True)])
+def test_tmem_load_reduce(device, red_op, use_abs, fresh_knobs):
     _require_cuda_backend(device)
 
-    smem_h = 64
-    smem_w = 16
+    m = 128
+    n = 128
+    M = gl.constexpr(m)
+    N = gl.constexpr(n)
+
+    fresh_knobs.compilation.instrumentation_mode = "fpsan"
+
+    @gluon.jit
+    def kernel(x_ptr, out_ptr, RED_OP: gl.constexpr, USE_ABS: gl.constexpr):
+        layout: gl.constexpr = gl.BlockedLayout([1, 1], [32, 1], [gl.num_warps(), 1], [1, 0])
+        red_layout: gl.constexpr = gl.SliceLayout(1, layout)
+        offs_m = gl.arange(0, M, layout=red_layout)
+        offs_n = gl.arange(0, N, layout=gl.SliceLayout(0, layout))
+        offs = offs_m[:, None] * N + offs_n[None, :]
+
+        value = gl.load(x_ptr + offs)
+        tmem_layout: gl.constexpr = TensorMemoryLayout((M, N), col_stride=1)
+        tmem = allocate_tensor_memory(gl.float32, [M, N], layout=tmem_layout)
+        tmem.store(gl.convert_layout(value, tmem.get_reg_layout()))
+
+        if RED_OP == "min":
+            _, reduced = tmem.load_min(abs=USE_ABS)
+        else:
+            _, reduced = tmem.load_max(abs=USE_ABS)
+        gl.store(out_ptr + offs_m, gl.convert_layout(reduced, red_layout))
+
+    rs = np.random.RandomState(0)
+    x_bits = rs.uniform(-100.0, 100.0, size=(m, n)).astype(np.float32).view(np.int32)
+    reduction_bits = x_bits
+    if use_abs:
+        reduction_bits = _u32_to_i32(_as_u32(x_bits) & np.uint32(0x7FFFFFFF))
+    payload = _u32_to_i32(_mix_f32_bits_to_payload_u32(reduction_bits))
+    reduced_payload = (payload.min(axis=1) if red_op == "min" else payload.max(axis=1)).astype(np.int32)
+    exp_bits = _unmix_payload_u32_to_f32_bits_i32(reduced_payload.view(np.uint32))
+
+    x = torch.tensor(x_bits, device=device, dtype=torch.int32)
+    out = torch.empty((m, ), device=device, dtype=torch.int32)
+    kernel[(1, )](
+        triton.TensorWrapper(x, dtype=torch.float32),
+        triton.TensorWrapper(out, dtype=torch.float32),
+        RED_OP=red_op,
+        USE_ABS=use_abs,
+        num_warps=4,
+    )
+
+    _assert_payload_equal(out, exp_bits)
+
+
+@pytest.mark.skipif(not is_blackwell(), reason="Requires Blackwell")
+@pytest.mark.parametrize("scale_shape", [(64, 16), (256, 4)])
+@pytest.mark.parametrize("two_ctas", [False, True])
+def test_tmem_copy_scales_in_warp_specialize_partition(device, scale_shape, two_ctas, fresh_knobs):
+    _require_cuda_backend(device)
+
+    smem_h, smem_w = scale_shape
     SMEM_H = gl.constexpr(smem_h)
     SMEM_W = gl.constexpr(smem_w)
+    tmem_rows = 128
+    tmem_cols = 32
+    TMEM_ROWS = gl.constexpr(tmem_rows)
+    TMEM_COLS = gl.constexpr(tmem_cols)
 
     fresh_knobs.compilation.instrumentation_mode = "fpsan"
 
@@ -2408,6 +2491,15 @@ def test_tmem_copy_scales_in_warp_specialize_partition(device, two_ctas, fresh_k
     def copy_partition(smem, tmem, bar):
         tcgen05_copy(smem, tmem)
         tcgen05_commit(bar)
+
+    @gluon.jit
+    def load_partition(physical, bar, out_ptr):
+        mbarrier.wait(bar, phase=0)
+        mbarrier.invalidate(bar)
+        physical_reg_layout: gl.constexpr = physical.get_reg_layout()
+        copied = physical.load(physical_reg_layout)
+        out_ptrs = out_ptr + gl.arange(0, TMEM_ROWS)[:, None] * TMEM_COLS + gl.arange(0, TMEM_COLS)[None, :]
+        gl.store(gl.set_auto_layout(out_ptrs, physical_reg_layout), copied)
 
     @gluon.jit
     def default_partition():
@@ -2432,8 +2524,8 @@ def test_tmem_copy_scales_in_warp_specialize_partition(device, two_ctas, fresh_k
         in_ptrs = (in_ptr + gl.arange(0, SMEM_H)[:, None] * SMEM_W + gl.arange(0, SMEM_W)[None, :])
         value = gl.load(gl.set_auto_layout(in_ptrs, blocked))
 
-        smem_layout: gl.constexpr = gl.SharedLinearLayout(
-            offset_bases=[
+        if SMEM_H == 64:
+            smem_offset_bases: gl.constexpr = [
                 [0, 1],
                 [0, 2],
                 [32, 0],
@@ -2444,7 +2536,22 @@ def test_tmem_copy_scales_in_warp_specialize_partition(device, two_ctas, fresh_k
                 [8, 0],
                 [16, 0],
                 [0, 8],
-            ],
+            ]
+        else:
+            smem_offset_bases: gl.constexpr = [
+                [0, 1],
+                [0, 2],
+                [32, 0],
+                [64, 0],
+                [1, 0],
+                [2, 0],
+                [4, 0],
+                [8, 0],
+                [16, 0],
+                [128, 0],
+            ]
+        smem_layout: gl.constexpr = gl.SharedLinearLayout(
+            offset_bases=smem_offset_bases,
             block_bases=cga_layout,
         )
         smem = gl.allocate_shared_memory(gl.int8, (SMEM_H, SMEM_W), layout=smem_layout)
@@ -2454,24 +2561,28 @@ def test_tmem_copy_scales_in_warp_specialize_partition(device, two_ctas, fresh_k
         tmem = allocate_tensor_memory(gl.int8, (SMEM_H, SMEM_W), layout=tmem_layout)
         bar = mbarrier.allocate_mbarrier()
         mbarrier.init(bar, count=1)
+        physical_layout: gl.constexpr = TensorMemoryLayout((TMEM_ROWS, TMEM_COLS), col_stride=1, cga_layout=cga_layout)
+        physical = tmem._reinterpret(shape=(TMEM_ROWS, TMEM_COLS), layout=physical_layout)
 
         gl.warp_specialize(
             [
                 (default_partition, ()),
                 (copy_partition, (smem, tmem, bar)),
+                (load_partition, (physical, bar, out_ptr)),
             ],
-            [1],
-            [32],
+            [1, 4],
+            [32, 32],
         )
 
-        mbarrier.wait(bar, phase=0)
-        mbarrier.invalidate(bar)
-        gl.store(out_ptr, 1)
+    rs = np.random.RandomState(0)
+    x_np = rs.randint(-100, 100, size=(smem_h, smem_w), dtype=np.int8)
+    warp_tile = x_np.reshape(smem_h // 32, 32, smem_w // 4, 4).transpose(1, 2, 0, 3).reshape(32, -1)
+    expected = np.tile(warp_tile, (4, 1))
 
-    x = torch.randint(size=(smem_h, smem_w), low=-100, high=100, dtype=torch.int8, device=device)
-    out = torch.empty((), device=device, dtype=torch.int32)
+    x = torch.tensor(x_np, device=device, dtype=torch.int8)
+    out = torch.empty((tmem_rows, tmem_cols), device=device, dtype=torch.int8)
     kernel[(1, )](x, out, TWO_CTAS=two_ctas, num_warps=4, num_ctas=2 if two_ctas else 1)
-    torch.testing.assert_close(out, torch.ones_like(out))
+    torch.testing.assert_close(out, torch.tensor(expected, device=device))
 
 
 @pytest.mark.skipif(not is_blackwell(), reason="Requires Blackwell")

--- a/test/TritonGPU/nvidia-fpsan.mlir
+++ b/test/TritonGPU/nvidia-fpsan.mlir
@@ -4,22 +4,57 @@
 //--- success.mlir
 
 #blocked = #ttg.blocked<{sizePerThread = [1, 64], threadsPerWarp = [32, 1], warpsPerCTA = [4, 1], order = [0, 1]}>
+#blocked_reduce = #ttg.blocked<{sizePerThread = [1, 128], threadsPerWarp = [32, 1], warpsPerCTA = [4, 1], order = [0, 1]}>
+#red = #ttg.slice<{dim = 1, parent = #blocked_reduce}>
 #tmem = #ttng.tensor_memory_encoding<blockM = 128, blockN = 128, colStride = 1>
 module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.shared = 65544 : i32, ttg.tensor_memory_size = 0 : i32, "ttg.total-num-warps" = 1 : i32} {
   // CHECK-LABEL: @tmem_load_store
   tt.func public @tmem_load_store() {
     // CHECK: ttg.global_scratch_alloc
     // CHECK: tt.store
+    // CHECK-NEXT: ttg.barrier global_read|global_write
     // CHECK: tt.load
     // CHECK-NOT: ttng.tmem_load
     // CHECK-NOT: ttng.tmem_store
     %true = arith.constant true
     %zero = arith.constant dense<0.0> : tensor<128x128xf32, #blocked>
-    %buf = ttng.tmem_alloc {tensor_memory_col_offset = 0 : i32, tensor_memory_row_offset = 0 : i32} : () -> !ttg.memdesc<128x128xf32, #tmem, #ttng.tensor_memory, mutable>
-    ttng.tmem_store %zero, %buf, %true : tensor<128x128xf32, #blocked> -> !ttg.memdesc<128x128xf32, #tmem, #ttng.tensor_memory, mutable>
+    %buf = ttng.tmem_alloc %zero {tensor_memory_col_offset = 0 : i32, tensor_memory_row_offset = 0 : i32} : (tensor<128x128xf32, #blocked>) -> !ttg.memdesc<128x128xf32, #tmem, #ttng.tensor_memory, mutable>
     %val = ttng.tmem_load %buf : !ttg.memdesc<128x128xf32, #tmem, #ttng.tensor_memory, mutable> -> tensor<128x128xf32, #blocked>
     ttng.tmem_store %val, %buf, %true : tensor<128x128xf32, #blocked> -> !ttg.memdesc<128x128xf32, #tmem, #ttng.tensor_memory, mutable>
     tt.return
+  }
+
+  // CHECK-LABEL: @tmem_store_predicate(
+  // CHECK-SAME: %[[PRED_ARG:.*]]: i1
+  tt.func public @tmem_store_predicate(%pred: i1) {
+    // CHECK: %[[OLD:.*]] = tt.load
+    // CHECK: %[[PRED:.*]] = tt.splat %[[PRED_ARG]]
+    // CHECK: %[[SELECTED:.*]] = arith.select %[[PRED]], %{{.*}}, %[[OLD]]
+    // CHECK: tt.store {{.*}}, %[[SELECTED]]
+    // CHECK-NOT: ttng.tmem_store
+    %zero = arith.constant dense<0.0> : tensor<128x128xf32, #blocked>
+    %one = arith.constant dense<1.0> : tensor<128x128xf32, #blocked>
+    %buf = ttng.tmem_alloc %zero {tensor_memory_col_offset = 0 : i32, tensor_memory_row_offset = 0 : i32} : (tensor<128x128xf32, #blocked>) -> !ttg.memdesc<128x128xf32, #tmem, #ttng.tensor_memory, mutable>
+    ttng.tmem_store %one, %buf, %pred : tensor<128x128xf32, #blocked> -> !ttg.memdesc<128x128xf32, #tmem, #ttng.tensor_memory, mutable>
+    tt.return
+  }
+
+  // CHECK-LABEL: @tmem_load_reduce
+  tt.func public @tmem_load_reduce() -> tensor<128xf32, #red> {
+    // CHECK: %[[LOADED:.*]] = tt.load
+    // CHECK: %[[VALUE:.*]] = tti.experimental_fpsan_unembed %[[LOADED]]
+    // CHECK: %[[ABS:.*]] = math.absf %[[VALUE]]
+    // CHECK: %[[PAYLOAD:.*]] = tti.experimental_fpsan_embed %[[ABS]]
+    // CHECK: %[[REDUCED:.*]] = "tt.reduce"(%[[PAYLOAD]]) <{axis = 1 : i32}>
+    // CHECK: arith.maxsi
+    // CHECK: tt.reduce.return
+    // CHECK: %[[RED_VALUE:.*]] = tti.experimental_fpsan_unembed %[[REDUCED]]
+    // CHECK: tt.return %[[RED_VALUE]]
+    // CHECK-NOT: ttng.tmem_load
+    %zero = arith.constant dense<0.0> : tensor<128x128xf32, #blocked_reduce>
+    %buf = ttng.tmem_alloc %zero {tensor_memory_col_offset = 0 : i32, tensor_memory_row_offset = 0 : i32} : (tensor<128x128xf32, #blocked_reduce>) -> !ttg.memdesc<128x128xf32, #tmem, #ttng.tensor_memory, mutable>
+    %result, %red = ttng.tmem_load %buf {redOp = #ttng.redOp<max>, abs = true, NaN = true} : !ttg.memdesc<128x128xf32, #tmem, #ttng.tensor_memory, mutable> -> tensor<128x128xf32, #blocked_reduce>, tensor<128xf32, #red>
+    tt.return %red : tensor<128xf32, #red>
   }
 }
 
@@ -318,7 +353,9 @@ module attributes {"ttg.num-ctas" = 2 : i32, "ttg.num-warps" = 4 : i32, ttg.shar
 #shared1 = #ttg.swizzled_shared<{vec = 1, perPhase = 1, maxPhase = 1, order = [0], CGALayout = [[1]]}>
 #smem = #ttg.shared_memory
 #blocked_multibuffer = #ttg.blocked<{sizePerThread = [1, 4], threadsPerWarp = [32, 1], warpsPerCTA = [4, 1], order = [0, 1], CGALayout = [[1, 0]]}>
+#blocked_copy = #ttg.blocked<{sizePerThread = [1, 4], threadsPerWarp = [32, 1], warpsPerCTA = [4, 1], order = [0, 1], CGALayout = [[0, 0]]}>
 #tmem = #ttng.tensor_memory_encoding<blockM = 128, blockN = 128, colStride = 1, CGALayout = [[1, 0]], twoCTAs = true>
+#tmem_copy_alias = #ttng.tensor_memory_encoding<blockM = 128, blockN = 128, colStride = 1, CGALayout = [[0, 0]]>
 #tmem_scales = #ttng.tensor_memory_scales_encoding<CGALayout = [[0, 0]]>
 module attributes {"ttg.num-ctas" = 2 : i32, "ttg.num-warps" = 4 : i32, ttg.shared = 65544 : i32, ttg.tensor_memory_size = 0 : i32, "ttg.total-num-warps" = 1 : i32} {
   tt.func public @enable_two_ctas() {
@@ -347,24 +384,34 @@ module attributes {"ttg.num-ctas" = 2 : i32, "ttg.num-warps" = 4 : i32, ttg.shar
   }
 
   // CHECK-LABEL: @tmem_copy_commit_two_ctas
-  tt.func public @tmem_copy_commit_two_ctas() {
-    // CHECK: ttg.global_scratch_alloc {{.*}}shared_cluster_state
+  tt.func public @tmem_copy_commit_two_ctas() -> tensor<128x128xi8, #blocked_copy> {
+    // CHECK: ttg.global_scratch_alloc {{.*}}nbytes = 4096{{.*}}shared_cluster_state
     // CHECK-NOT: ttng.tmem_copy
     // CHECK: ttng.cluster_barrier
     // CHECK-NEXT: {{.*}} = ttg.local_load
+    // CHECK: tt.store
     // CHECK: ttg.barrier global_read|global_write
     // CHECK-NEXT: ttng.cluster_barrier
     // CHECK: ttg.barrier global_read|global_write
     // CHECK-NEXT: ttng.cluster_barrier
     // CHECK: ttng.arrive_barrier
+    // CHECK: tt.load
+    // CHECK: tt.trans
+    // CHECK: tt.broadcast
+    // CHECK: ttg.convert_layout
+    // CHECK-NOT: ttng.tmem_load
     // CHECK-NOT: ttng.tc_gen5_commit
+    // CHECK-NOT: ttg.global_scratch_alloc
+    // CHECK-NOT: tt.store
     %true = arith.constant true
     %src = ttg.local_alloc {allocation.offset = 0 : i32} : () -> !ttg.memdesc<128x32xi8, #shared_copy, #smem, mutable>
     %dst = ttng.tmem_alloc : () -> !ttg.memdesc<128x32xi8, #tmem_scales, #ttng.tensor_memory, mutable>
     %bar = ttg.local_alloc {allocation.offset = 8192 : i32} : () -> !ttg.memdesc<1xi64, #shared1, #smem, mutable>
+    %alias = ttg.memdesc_reinterpret %dst : !ttg.memdesc<128x32xi8, #tmem_scales, #ttng.tensor_memory, mutable> -> !ttg.memdesc<128x128xi8, #tmem_copy_alias, #ttng.tensor_memory, mutable>
     ttng.tmem_copy %src, %dst : !ttg.memdesc<128x32xi8, #shared_copy, #smem, mutable>, !ttg.memdesc<128x32xi8, #tmem_scales, #ttng.tensor_memory, mutable>
     ttng.tc_gen5_commit %bar, %true : !ttg.memdesc<1xi64, #shared1, #smem, mutable>
-    tt.return
+    %val = ttng.tmem_load %alias : !ttg.memdesc<128x128xi8, #tmem_copy_alias, #ttng.tensor_memory, mutable> -> tensor<128x128xi8, #blocked_copy>
+    tt.return %val : tensor<128x128xi8, #blocked_copy>
   }
 }
 


### PR DESCRIPTION
PR description written by Codex

Fix FPSAN TMEM emulation for initialized scratch synchronization, predicated stores, reduction loads, and scale-copy reinterpret views.

## Stack
Merge bottom-up:
- [x] #10472
- [x] #10473
- [x] #10527
- [x] #10532
- [x] #10533
- [ ] #10542 (this PR)
- [ ] #10548
- [ ] #10561
- [ ] #10559




