### PR TITLE
[Release-only] Bump version to 3.7.1 release, turn off publishing to pypi, and cherry-pick wheels.yml cibuildwheel fix (#10547)

### DIFF
--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -113,6 +113,7 @@ jobs:
           path: ./wheelhouse/*.whl
 
       - name: Upload wheels to PyPI
+        if: false
         run: |
           python3 -m pip install twine --upgrade --user
           python3 -m twine upload wheelhouse/* -u __token__ -p ${{ secrets.PYPY_API_TOKEN }}

--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -102,9 +102,8 @@ jobs:
             export CIBW_MANYLINUX_AARCH64_IMAGE="quay.io/pypa/manylinux_2_28_${{ matrix.config.arch }}:latest"
           fi
 
-          export CIBW_BUILD="cp3{10,11,12,13,13t,14,14t}-manylinux_${{ matrix.config.arch }}"
+          export CIBW_BUILD="cp3{10,11,12,13,14,14t}-manylinux_${{ matrix.config.arch }}"
           export CIBW_SKIP="cp{35,36,37,38,39}-*"
-          export CIBW_ENABLE=cpython-freethreading
           python3 -m cibuildwheel . --output-dir wheelhouse
 
       - uses: actions/upload-artifact@v4

--- a/python/triton/__init__.py
+++ b/python/triton/__init__.py
@@ -1,5 +1,5 @@
 """isort:skip_file"""
-__version__ = '3.7.0'
+__version__ = '3.7.1'
 
 # ---------------------------------------
 # Note: import order is significant here.

--- a/setup.py
+++ b/setup.py
@@ -813,7 +813,7 @@ def get_triton_version_suffix():
 
 
 # keep it separate for easy substitution
-TRITON_VERSION = "3.7.0" + get_triton_version_suffix()
+TRITON_VERSION = "3.7.1" + get_triton_version_suffix()
 
 # Dynamically define supported Python versions and classifiers
 MIN_PYTHON = (3, 10)


### PR DESCRIPTION
We would like to create Release 3.7.1 to fix following issue: https://github.com/pytorch/pytorch/issues/181248
Fix is: https://github.com/triton-lang/triton/pull/10537

- Bump version to 3.7.1.
- Disable publishing to pypi step, so that we don't release it until we are ready
- Includes cherry-pick of https://github.com/triton-lang/triton/pull/10547

Similar to https://github.com/triton-lang/triton/pull/8636

