### PR TITLE
Remove 3.13t builds from wheels.yml

### DIFF
--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -104,7 +104,6 @@ jobs:
 
           export CIBW_BUILD="cp3{10,11,12,13,14,14t}-manylinux_${{ matrix.config.arch }}"
           export CIBW_SKIP="cp{35,36,37,38,39}-*"
-          export CIBW_ENABLE=cpython-freethreading
           python3 -m cibuildwheel . --output-dir wheelhouse
 
       - uses: actions/upload-artifact@v7

--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -102,7 +102,7 @@ jobs:
             export CIBW_MANYLINUX_AARCH64_IMAGE="quay.io/pypa/manylinux_2_28_${{ matrix.config.arch }}:latest"
           fi
 
-          export CIBW_BUILD="cp3{10,11,12,13,13t,14,14t}-manylinux_${{ matrix.config.arch }}"
+          export CIBW_BUILD="cp3{10,11,12,13,14,14t}-manylinux_${{ matrix.config.arch }}"
           export CIBW_SKIP="cp{35,36,37,38,39}-*"
           export CIBW_ENABLE=cpython-freethreading
           python3 -m cibuildwheel . --output-dir wheelhouse


### PR DESCRIPTION
Same as: https://github.com/pytorch/pytorch/pull/182951

pypa/manylinux upstream removed CPython 3.13t (free-threaded) on 2026-05-07 (https://github.com/pypa/manylinux/pull/1884, commit [638a3185](https://github.com/pypa/manylinux/commit/638a318520a8a152b61d92fbec5dfe182acf3081)) on the schedule announced months in advance in https://github.com/pypa/manylinux/issues/1882. 

CPython 3.13t was experimental and has become less relevant now that CPython 3.14t is available and no longer experimental. Free-threading fixes are not always backported in CPython 3.13 given its experimental status.

The current quay.io/pypa/manylinux_2_28_x86_64:latest image no longer ships /opt/python/cp313-cp313t/, so any fresh Docker rebuild that references it fails. Cached image layers on main have been hiding this; the first PR to trigger a fresh rebuild after the upstream push tripped on it.

This PR drops 3.13t from the binary build matrix end-to-end, mirroring upstream.