### PR TITLE
Add direct layout storage shape queries

### DIFF
--- a/python/triton_kernels/tests/test_tensor.py
+++ b/python/triton_kernels/tests/test_tensor.py
@@ -3,6 +3,7 @@ import torch
 from triton_kernels.tensor_details.dtype import BIT, FP4, UINT8
 from triton_kernels.tensor import (
     convert_layout,
+    empty,
     make_ragged_tensor_metadata,
     make_ragged_tensor_metadata_torch,
     remap_ragged_tensor_metadata,
@@ -23,6 +24,49 @@ from triton_kernels.tensor_details.layout import (
     HopperMXValueLayout,
     StridedLayout,
 )
+
+
+@pytest.mark.parametrize(
+    ("logical_shape", "is_fp4", "layout", "storage_shape"),
+    [
+        ((3, 258, 514), True, StridedLayout(-2), [3, 129, 514]),
+        ((0, 64), True, StridedLayout(-2), [0, 64]),
+        ((3, 258, 514), True, HopperMXValueLayout(-2, 3), [3, 768, 192]),
+        ((3, 258, 514), True, HopperMXValueLayout(-1, 3), [3, 128, 1280]),
+        ((0, 64), True, HopperMXValueLayout(-2, 3), [0, 64]),
+        ((3, 70, 65), False, HopperMXScaleLayout(-2, 4), [3, 2240, 4]),
+        ((3, 70, 65), False, HopperMXScaleLayout(-1, 4), [3, 4, 2112]),
+        ((0, 64), False, HopperMXScaleLayout(-2, 4), [0, 4]),
+        ((3, 258, 514), True, BlackwellMXValueLayout(), [3, 256, 514]),
+        ((0, 64), True, BlackwellMXValueLayout(), [0, 64]),
+        ((3, 258, 514), True, BlackwellMX4ValueShuffledLayout(), [3, 4, 3, 256, 64]),
+        ((0, 64), True, BlackwellMX4ValueShuffledLayout(), [1, 0, 1, 256, 64]),
+        ((3, 254, 60), False, BlackwellMXScaleLayout(), [1, 3, 64, 2, 256]),
+        ((0, 64), False, BlackwellMXScaleLayout(), [1, 1, 0, 2, 256]),
+        ((130, 65), False, BlackwellActMXScaleLayout(None), [1, 2, 18, 2, 256]),
+        ((3, 130, 65), False, BlackwellActMXScaleLayout(None), [1, 6, 18, 2, 256]),
+        ((0, 64), False, BlackwellActMXScaleLayout(None), [1, 0, 16, 2, 256]),
+        ((3, 254, 60), False, CDNA4MXScaleLayout(), [3, 8192, 2]),
+        ((0, 64), False, CDNA4MXScaleLayout(), [1, 0, 2]),
+        ((3, 254, 60), False, GFX1250MXScaleLayout(), [3, 32768, 1]),
+        ((0, 64), False, GFX1250MXScaleLayout(), [1, 0, 1]),
+    ],
+)
+def test_layout_storage_shape_matches_conversion(logical_shape, is_fp4, layout, storage_shape):
+    dtype = FP4 if is_fp4 else UINT8
+    tensor = empty(logical_shape, dtype=dtype, device="meta")
+
+    converted = convert_layout(tensor, layout)
+
+    assert layout.storage_shape(list(logical_shape), is_fp4) == storage_shape
+    assert list(converted.storage.data.shape) == storage_shape
+
+
+def test_ragged_layout_storage_shape():
+    slice_sizes = torch.tensor([17, 0, 33, 5], dtype=torch.int32)
+    metadata = make_ragged_tensor_metadata_torch(slice_sizes, 100)
+
+    assert BlackwellActMXScaleLayout(metadata).storage_shape([100, 94], False) == [1, 4, 24, 2, 256]
 
 
 @pytest.mark.parametrize(

--- a/python/triton_kernels/tests/test_tensor_details/test_layout_hopper.py
+++ b/python/triton_kernels/tests/test_tensor_details/test_layout_hopper.py
@@ -37,11 +37,12 @@ def test_mxfp4_value_roundtrip(shape, trans, mx_axis, mma_version):
 
 def test_mxfp4_value_swizzle_uses_data_shape():
     x = torch.randint(0, 256, (64, 128), dtype=torch.uint8)
-    transformation = HopperMXValueLayout(-1, 3).make_transformation([64, 256], is_fp4=False)
+    transformation = HopperMXValueLayout(-1, 3).make_transformation([64, 256], is_fp4=True)
 
     swizzled = transformation.swizzle_data(x)
 
     assert swizzled.shape == (64, 512)
+    assert transformation.storage_shape == list(swizzled.shape)
     assert torch.equal(transformation.unswizzle_data(swizzled), x)
 
 

--- a/python/triton_kernels/tests/test_tensor_details/test_layout_hopper.py
+++ b/python/triton_kernels/tests/test_tensor_details/test_layout_hopper.py
@@ -28,14 +28,16 @@ def test_mxfp4_value_roundtrip(shape, trans, mx_axis, mma_version):
     if x.shape[1 - mx_axis] < 32:
         pytest.skip("Not enough elements along non-mx axis")
     layout = HopperMXValueLayout(mx_axis - 2, mma_version)
-    shape = list(x.shape)
-    shape[-1] *= 2
-    transformation = layout.make_transformation(shape, is_fp4=False)
-    res = transformation.unswizzle_data(transformation.swizzle_data(x))
+    logical_shape = list(x.shape)
+    logical_shape[-1] *= 2
+    transformation = layout.make_transformation(logical_shape, is_fp4=True)
+    swizzled = transformation.swizzle_data(x)
+    assert list(swizzled.shape) == transformation.storage_shape
+    res = transformation.unswizzle_data(swizzled)
     assert (res == x).all()
 
 
-def test_mxfp4_value_swizzle_uses_data_shape():
+def test_mxfp4_value_storage_shape_matches_swizzle():
     x = torch.randint(0, 256, (64, 128), dtype=torch.uint8)
     transformation = HopperMXValueLayout(-1, 3).make_transformation([64, 256], is_fp4=True)
 

--- a/python/triton_kernels/tests/test_tensor_details/test_layout_hopper.py
+++ b/python/triton_kernels/tests/test_tensor_details/test_layout_hopper.py
@@ -35,6 +35,16 @@ def test_mxfp4_value_roundtrip(shape, trans, mx_axis, mma_version):
     assert (res == x).all()
 
 
+def test_mxfp4_value_swizzle_uses_data_shape():
+    x = torch.randint(0, 256, (64, 128), dtype=torch.uint8)
+    transformation = HopperMXValueLayout(-1, 3).make_transformation([64, 256], is_fp4=False)
+
+    swizzled = transformation.swizzle_data(x)
+
+    assert swizzled.shape == (64, 512)
+    assert torch.equal(transformation.unswizzle_data(swizzled), x)
+
+
 @pytest.mark.parametrize("shape", ZERO_SIZED_SHAPES)
 @pytest.mark.parametrize("mx_axis", [-2, -1])
 @pytest.mark.parametrize("mma_version", [2, 3])

--- a/python/triton_kernels/triton_kernels/tensor.py
+++ b/python/triton_kernels/triton_kernels/tensor.py
@@ -299,13 +299,10 @@ def torch_dtype_to_dtype(dtype: torch.dtype) -> DataType:
 
 def empty(shape: tuple[int], dtype: DataType, device: torch.device, layout=None,
           allow_implicit_conversion: bool = False):
-    storage_shape = list(shape)
     storage_dtype = torch.uint8 if dtype == FP4 else dtype_to_torch_dtype(dtype)
     initial_layout = layout if isinstance(layout, StridedLayout) else StridedLayout()
-    # pack sub-byte datatype along last dimension
-    order = initial_layout.order(len(storage_shape))
-    dim = order[0]
-    storage_shape[dim] = storage_shape[dim] // (storage_dtype.itemsize * 8 // dtype.bitwidth)
+    storage_shape = initial_layout.storage_shape(list(shape), dtype == FP4)
+    order = initial_layout.order(len(shape))
     # storage strides
     strides = [0] * len(storage_shape)
     running = 1

--- a/python/triton_kernels/triton_kernels/tensor_details/layout_details/base.py
+++ b/python/triton_kernels/triton_kernels/tensor_details/layout_details/base.py
@@ -13,6 +13,10 @@ class LayoutTransformation(ABC):
         """Physical storage shape produced by this transformation."""
         raise NotImplementedError
 
+    def _validate_storage_shape(self, data):
+        assert list(data.shape) == self.storage_shape
+        return data
+
     @abstractmethod
     def swizzle_data(self, data):
         pass

--- a/python/triton_kernels/triton_kernels/tensor_details/layout_details/base.py
+++ b/python/triton_kernels/triton_kernels/tensor_details/layout_details/base.py
@@ -5,7 +5,7 @@ from dataclasses import dataclass
 @dataclass(frozen=True)
 class LayoutTransformation(ABC):
 
-    shape: list[int]  # Logical element shape, before FP4 byte packing.
+    shape: list[int]
     is_fp4: bool
 
     @property

--- a/python/triton_kernels/triton_kernels/tensor_details/layout_details/base.py
+++ b/python/triton_kernels/triton_kernels/tensor_details/layout_details/base.py
@@ -5,7 +5,7 @@ from dataclasses import dataclass
 @dataclass(frozen=True)
 class LayoutTransformation(ABC):
 
-    shape: list[int]
+    shape: list[int]  # Logical element shape, before FP4 byte packing.
     is_fp4: bool
 
     @property

--- a/python/triton_kernels/triton_kernels/tensor_details/layout_details/base.py
+++ b/python/triton_kernels/triton_kernels/tensor_details/layout_details/base.py
@@ -8,6 +8,11 @@ class LayoutTransformation(ABC):
     shape: list[int]
     is_fp4: bool
 
+    @property
+    def storage_shape(self) -> list[int]:
+        """Physical storage shape produced by this transformation."""
+        raise NotImplementedError
+
     @abstractmethod
     def swizzle_data(self, data):
         pass
@@ -24,8 +29,12 @@ class Layout(ABC):
         """Whether existing storage is already valid for `other`."""
         return self == other
 
+    def storage_shape(self, shape: list[int], is_fp4: bool) -> list[int]:
+        """Return the physical storage shape for a logical tensor shape."""
+        return self.make_transformation(shape, is_fp4).storage_shape
+
     @abstractmethod
-    def make_transformation(self, shape: list[int]) -> LayoutTransformation:
+    def make_transformation(self, shape: list[int], is_fp4: bool) -> LayoutTransformation:
         pass
 
     @abstractmethod

--- a/python/triton_kernels/triton_kernels/tensor_details/layout_details/blackwell_scale.py
+++ b/python/triton_kernels/triton_kernels/tensor_details/layout_details/blackwell_scale.py
@@ -118,7 +118,7 @@ class BlackwellActMXScaleLayoutTransformation(LayoutTransformation):
 
         data = data.reshape(self.B, self.M_pad // 128, 4, 32, self.K_pad // 4, 4)
         data = data.transpose(2, 4).contiguous()  # [1, M//128, K//4, 32, 4, 4]
-        data = data.view(*self.storage_shape)
+        data = data.view(1, self.B * self.M_pad // 128, self.K_pad // 4, 2, 256)
         return data
 
     def unswizzle_data(self, data):
@@ -181,7 +181,7 @@ class BlackwellMXScaleLayoutTransformation(LayoutTransformation):
             data = data.reshape(self.B, self.N_pad // self.ALIGN_N, self.ALIGN_N // 32, 32,
                                 self.K_pad // self.SWIZZLE_K, self.SWIZZLE_K)
             data = data.transpose(2, 4).contiguous()
-            data = data.view(*self.storage_shape)
+            data = data.view(1, self.B * self.N_pad // 128, self.K_pad // self.SWIZZLE_K, 2, 256)
             return data
 
         # The following code is equivalent to the above, but faster for GPU tensors.
@@ -190,7 +190,11 @@ class BlackwellMXScaleLayoutTransformation(LayoutTransformation):
         assert tuple(data.shape) == tuple(self.shape)
         data = data.reshape((self.B, self.K, self.N))
 
-        out = torch.empty(self.storage_shape, dtype=torch.uint8, device=data.device)
+        out = torch.empty(
+            (1, self.B * self.N_pad // self.ALIGN_N, self.K_pad // self.SWIZZLE_K, 2, 256),
+            dtype=torch.uint8,
+            device=data.device,
+        )
         if not out.numel():
             return out
 

--- a/python/triton_kernels/triton_kernels/tensor_details/layout_details/blackwell_scale.py
+++ b/python/triton_kernels/triton_kernels/tensor_details/layout_details/blackwell_scale.py
@@ -118,7 +118,7 @@ class BlackwellActMXScaleLayoutTransformation(LayoutTransformation):
 
         data = data.reshape(self.B, self.M_pad // 128, 4, 32, self.K_pad // 4, 4)
         data = data.transpose(2, 4).contiguous()  # [1, M//128, K//4, 32, 4, 4]
-        data = data.view(1, self.B * self.M_pad // 128, self.K_pad // 4, 2, 256)
+        data = data.view(*self.storage_shape)
         return data
 
     def unswizzle_data(self, data):
@@ -181,7 +181,7 @@ class BlackwellMXScaleLayoutTransformation(LayoutTransformation):
             data = data.reshape(self.B, self.N_pad // self.ALIGN_N, self.ALIGN_N // 32, 32,
                                 self.K_pad // self.SWIZZLE_K, self.SWIZZLE_K)
             data = data.transpose(2, 4).contiguous()
-            data = data.view(1, self.B * self.N_pad // 128, self.K_pad // self.SWIZZLE_K, 2, 256)
+            data = data.view(*self.storage_shape)
             return data
 
         # The following code is equivalent to the above, but faster for GPU tensors.
@@ -190,11 +190,7 @@ class BlackwellMXScaleLayoutTransformation(LayoutTransformation):
         assert tuple(data.shape) == tuple(self.shape)
         data = data.reshape((self.B, self.K, self.N))
 
-        out = torch.empty(
-            (1, self.B * self.N_pad // self.ALIGN_N, self.K_pad // self.SWIZZLE_K, 2, 256),
-            dtype=torch.uint8,
-            device=data.device,
-        )
+        out = torch.empty(self.storage_shape, dtype=torch.uint8, device=data.device)
         if not out.numel():
             return out
 

--- a/python/triton_kernels/triton_kernels/tensor_details/layout_details/blackwell_scale.py
+++ b/python/triton_kernels/triton_kernels/tensor_details/layout_details/blackwell_scale.py
@@ -165,7 +165,7 @@ class BlackwellMXScaleLayoutTransformation(LayoutTransformation):
 
     @property
     def storage_shape(self) -> list[int]:
-        return [1, self.B * self.N_pad // 128, self.K_pad // self.SWIZZLE_K, 2, 256]
+        return [1, self.B * self.N_pad // self.ALIGN_N, self.K_pad // self.SWIZZLE_K, 2, 256]
 
     def swizzle_data(self, data):
         need_torch = data.device.type in ["cpu", "meta"] or data.dtype.itemsize != 1 or is_fake(data)

--- a/python/triton_kernels/triton_kernels/tensor_details/layout_details/blackwell_scale.py
+++ b/python/triton_kernels/triton_kernels/tensor_details/layout_details/blackwell_scale.py
@@ -96,6 +96,10 @@ class BlackwellActMXScaleLayoutTransformation(LayoutTransformation):
         object.__setattr__(self, "mode", mode)
         object.__setattr__(self, "added_leading_batch_dim", added_leading_batch_dim)
 
+    @property
+    def storage_shape(self) -> list[int]:
+        return [1, self.B * self.M_pad // 128, self.K_pad // 4, 2, 256]
+
     def swizzle_data(self, data):
         if data.numel():
             if self.mode == "batched":
@@ -114,7 +118,7 @@ class BlackwellActMXScaleLayoutTransformation(LayoutTransformation):
 
         data = data.reshape(self.B, self.M_pad // 128, 4, 32, self.K_pad // 4, 4)
         data = data.transpose(2, 4).contiguous()  # [1, M//128, K//4, 32, 4, 4]
-        data = data.view(1, self.B * self.M_pad // 128, self.K_pad // 4, 2, 256)
+        data = data.view(*self.storage_shape)
         return data
 
     def unswizzle_data(self, data):
@@ -158,6 +162,10 @@ class BlackwellMXScaleLayoutTransformation(LayoutTransformation):
         object.__setattr__(self, "K_pad", (K + self.ALIGN_K - 1) // self.ALIGN_K * self.ALIGN_K)
         object.__setattr__(self, "N_pad", (N + self.ALIGN_N - 1) // self.ALIGN_N * self.ALIGN_N)
 
+    @property
+    def storage_shape(self) -> list[int]:
+        return [1, self.B * self.N_pad // 128, self.K_pad // self.SWIZZLE_K, 2, 256]
+
     def swizzle_data(self, data):
         need_torch = data.device.type in ["cpu", "meta"] or data.dtype.itemsize != 1
         try:
@@ -173,7 +181,7 @@ class BlackwellMXScaleLayoutTransformation(LayoutTransformation):
             data = data.reshape(self.B, self.N_pad // self.ALIGN_N, self.ALIGN_N // 32, 32,
                                 self.K_pad // self.SWIZZLE_K, self.SWIZZLE_K)
             data = data.transpose(2, 4).contiguous()
-            data = data.view(1, self.B * self.N_pad // 128, self.K_pad // self.SWIZZLE_K, 2, 256)
+            data = data.view(*self.storage_shape)
             return data
 
         # The following code is equivalent to the above, but faster for GPU tensors.
@@ -182,11 +190,7 @@ class BlackwellMXScaleLayoutTransformation(LayoutTransformation):
         assert tuple(data.shape) == tuple(self.shape)
         data = data.reshape((self.B, self.K, self.N))
 
-        out = torch.empty(
-            (1, self.B * self.N_pad // self.ALIGN_N, self.K_pad // self.SWIZZLE_K, 2, 256),
-            dtype=torch.uint8,
-            device=data.device,
-        )
+        out = torch.empty(self.storage_shape, dtype=torch.uint8, device=data.device)
         if not out.numel():
             return out
 

--- a/python/triton_kernels/triton_kernels/tensor_details/layout_details/blackwell_scale.py
+++ b/python/triton_kernels/triton_kernels/tensor_details/layout_details/blackwell_scale.py
@@ -2,6 +2,7 @@ import math
 from dataclasses import dataclass
 
 import torch
+from torch._subclasses.fake_tensor import is_fake
 import triton
 import triton.language as tl
 
@@ -167,12 +168,7 @@ class BlackwellMXScaleLayoutTransformation(LayoutTransformation):
         return [1, self.B * self.N_pad // 128, self.K_pad // self.SWIZZLE_K, 2, 256]
 
     def swizzle_data(self, data):
-        need_torch = data.device.type in ["cpu", "meta"] or data.dtype.itemsize != 1
-        try:
-            from torch._subclasses.fake_tensor import is_fake
-            need_torch = need_torch or is_fake(data)
-        except ImportError:
-            pass
+        need_torch = data.device.type in ["cpu", "meta"] or data.dtype.itemsize != 1 or is_fake(data)
 
         if need_torch:
             if data.numel():

--- a/python/triton_kernels/triton_kernels/tensor_details/layout_details/blackwell_scale.py
+++ b/python/triton_kernels/triton_kernels/tensor_details/layout_details/blackwell_scale.py
@@ -120,7 +120,7 @@ class BlackwellActMXScaleLayoutTransformation(LayoutTransformation):
         data = data.reshape(self.B, self.M_pad // 128, 4, 32, self.K_pad // 4, 4)
         data = data.transpose(2, 4).contiguous()  # [1, M//128, K//4, 32, 4, 4]
         data = data.view(*self.storage_shape)
-        return data
+        return self._validate_storage_shape(data)
 
     def unswizzle_data(self, data):
         data = data.reshape(self.B, self.M_pad // 128, self.K_pad // 4, 32, 4, 4)
@@ -178,7 +178,7 @@ class BlackwellMXScaleLayoutTransformation(LayoutTransformation):
                                 self.K_pad // self.SWIZZLE_K, self.SWIZZLE_K)
             data = data.transpose(2, 4).contiguous()
             data = data.view(*self.storage_shape)
-            return data
+            return self._validate_storage_shape(data)
 
         # The following code is equivalent to the above, but faster for GPU tensors.
 
@@ -188,7 +188,7 @@ class BlackwellMXScaleLayoutTransformation(LayoutTransformation):
 
         out = torch.empty(self.storage_shape, dtype=torch.uint8, device=data.device)
         if not out.numel():
-            return out
+            return self._validate_storage_shape(out)
 
         block_k = 64
         grid = (self.B * triton.cdiv(self.N_pad, self.ALIGN_N) * triton.cdiv(self.K_pad, block_k), )
@@ -203,7 +203,7 @@ class BlackwellMXScaleLayoutTransformation(LayoutTransformation):
             BLOCK_K=block_k,
             num_warps=4,
         )
-        return out.view(data.dtype)
+        return self._validate_storage_shape(out.view(data.dtype))
 
     def unswizzle_data(self, data):
         data = data.reshape(self.B, self.N_pad // self.ALIGN_N, self.K_pad // self.SWIZZLE_K, 32, self.ALIGN_N // 32,

--- a/python/triton_kernels/triton_kernels/tensor_details/layout_details/blackwell_scale.py
+++ b/python/triton_kernels/triton_kernels/tensor_details/layout_details/blackwell_scale.py
@@ -165,7 +165,7 @@ class BlackwellMXScaleLayoutTransformation(LayoutTransformation):
 
     @property
     def storage_shape(self) -> list[int]:
-        return [1, self.B * self.N_pad // self.ALIGN_N, self.K_pad // self.SWIZZLE_K, 2, 256]
+        return [1, self.B * self.N_pad // 128, self.K_pad // self.SWIZZLE_K, 2, 256]
 
     def swizzle_data(self, data):
         need_torch = data.device.type in ["cpu", "meta"] or data.dtype.itemsize != 1 or is_fake(data)

--- a/python/triton_kernels/triton_kernels/tensor_details/layout_details/blackwell_value.py
+++ b/python/triton_kernels/triton_kernels/tensor_details/layout_details/blackwell_value.py
@@ -47,25 +47,25 @@ class BlackwellMXValueLayoutTransformation(LayoutTransformation):
 
     def swizzle_data(self, data):
         assert data.stride(-1) == 1
-        # Move FP4 packing to the second-to-last axis.
-        storage = torch.empty_strided(self.storage_shape, strides_major_dim_m2(self.storage_shape), device=data.device,
-                                      dtype=data.dtype)
+        # re-pack as column-major
+        ret = torch.empty_strided(self.storage_shape, strides_major_dim_m2(self.storage_shape), device=data.device,
+                                  dtype=data.dtype)
         repacked_shape = list(data.shape)
         repacked_shape[-1] *= 2
         repacked_shape[-2] //= 2
-        repack(data, -1, -2, self.is_fp4, out=storage[..., :repacked_shape[-2], :])
-        return storage
+        repack(data, -1, -2, self.is_fp4, out=ret[..., :repacked_shape[-2], :])
+        return ret
 
     def unswizzle_data(self, data: torch.Tensor):
         assert data.stride(-2) == 1
         # unpad
-        repacked_shape = [self.shape[i] for i in range(data.ndim)]
-        repacked_shape[-2] //= 2
-        data = data[tuple(slice(0, size) for size in repacked_shape)]
+        sizes = [self.shape[i] for i in range(data.ndim)]
+        sizes[-2] //= 2
+        data = data[tuple(slice(0, s) for s in sizes)]
         # repack
-        canonical_shape = list(self.shape)
-        canonical_shape[-1] //= 2
-        canonical = torch.empty(canonical_shape, device=data.device, dtype=data.dtype)
-        repack(data, -2, -1, self.is_fp4, out=canonical)
-        assert canonical.stride(-1) == 1
-        return canonical
+        out_shape = list(self.shape)
+        out_shape[-1] //= 2
+        out = torch.empty(out_shape, device=data.device, dtype=data.dtype)
+        repack(data, -2, -1, self.is_fp4, out=out)
+        assert out.stride(-1) == 1
+        return out

--- a/python/triton_kernels/triton_kernels/tensor_details/layout_details/blackwell_value.py
+++ b/python/triton_kernels/triton_kernels/tensor_details/layout_details/blackwell_value.py
@@ -48,12 +48,11 @@ class BlackwellMXValueLayoutTransformation(LayoutTransformation):
     def swizzle_data(self, data):
         assert data.stride(-1) == 1
         # Move FP4 packing to the second-to-last axis.
+        storage = torch.empty_strided(self.storage_shape, strides_major_dim_m2(self.storage_shape), device=data.device,
+                                      dtype=data.dtype)
         repacked_shape = list(data.shape)
         repacked_shape[-1] *= 2
         repacked_shape[-2] //= 2
-        storage_shape = self.storage_shape
-        storage = torch.empty_strided(storage_shape, strides_major_dim_m2(storage_shape), device=data.device,
-                                      dtype=data.dtype)
         repack(data, -1, -2, self.is_fp4, out=storage[..., :repacked_shape[-2], :])
         return storage
 

--- a/python/triton_kernels/triton_kernels/tensor_details/layout_details/blackwell_value.py
+++ b/python/triton_kernels/triton_kernels/tensor_details/layout_details/blackwell_value.py
@@ -47,26 +47,26 @@ class BlackwellMXValueLayoutTransformation(LayoutTransformation):
 
     def swizzle_data(self, data):
         assert data.stride(-1) == 1
-        # re-pack as column-major
-        out_shape = list(data.shape)
-        out_shape[-1] *= 2
-        out_shape[-2] //= 2
-        padded_shape = self.storage_shape
-        ret = torch.empty_strided(padded_shape, strides_major_dim_m2(padded_shape), device=data.device,
-                                  dtype=data.dtype)
-        repack(data, -1, -2, self.is_fp4, out=ret[..., :out_shape[-2], :])
-        return ret
+        # Move FP4 packing to the second-to-last axis.
+        repacked_shape = list(data.shape)
+        repacked_shape[-1] *= 2
+        repacked_shape[-2] //= 2
+        storage_shape = self.storage_shape
+        storage = torch.empty_strided(storage_shape, strides_major_dim_m2(storage_shape), device=data.device,
+                                      dtype=data.dtype)
+        repack(data, -1, -2, self.is_fp4, out=storage[..., :repacked_shape[-2], :])
+        return storage
 
     def unswizzle_data(self, data: torch.Tensor):
         assert data.stride(-2) == 1
         # unpad
-        sizes = [self.shape[i] for i in range(data.ndim)]
-        sizes[-2] //= 2
-        data = data[tuple(slice(0, s) for s in sizes)]
+        repacked_shape = [self.shape[i] for i in range(data.ndim)]
+        repacked_shape[-2] //= 2
+        data = data[tuple(slice(0, size) for size in repacked_shape)]
         # repack
-        out_shape = list(self.shape)
-        out_shape[-1] //= 2
-        out = torch.empty(out_shape, device=data.device, dtype=data.dtype)
-        repack(data, -2, -1, self.is_fp4, out=out)
-        assert out.stride(-1) == 1
-        return out
+        canonical_shape = list(self.shape)
+        canonical_shape[-1] //= 2
+        canonical = torch.empty(canonical_shape, device=data.device, dtype=data.dtype)
+        repack(data, -2, -1, self.is_fp4, out=canonical)
+        assert canonical.stride(-1) == 1
+        return canonical

--- a/python/triton_kernels/triton_kernels/tensor_details/layout_details/blackwell_value.py
+++ b/python/triton_kernels/triton_kernels/tensor_details/layout_details/blackwell_value.py
@@ -54,7 +54,7 @@ class BlackwellMXValueLayoutTransformation(LayoutTransformation):
         repacked_shape[-1] *= 2
         repacked_shape[-2] //= 2
         repack(data, -1, -2, self.is_fp4, out=ret[..., :repacked_shape[-2], :])
-        return ret
+        return self._validate_storage_shape(ret)
 
     def unswizzle_data(self, data: torch.Tensor):
         assert data.stride(-2) == 1

--- a/python/triton_kernels/triton_kernels/tensor_details/layout_details/blackwell_value.py
+++ b/python/triton_kernels/triton_kernels/tensor_details/layout_details/blackwell_value.py
@@ -51,7 +51,8 @@ class BlackwellMXValueLayoutTransformation(LayoutTransformation):
         out_shape = list(data.shape)
         out_shape[-1] *= 2
         out_shape[-2] //= 2
-        padded_shape = self.storage_shape
+        padded_shape = list(out_shape)
+        padded_shape[-2] += (-out_shape[-2]) % 128
         ret = torch.empty_strided(padded_shape, strides_major_dim_m2(padded_shape), device=data.device,
                                   dtype=data.dtype)
         repack(data, -1, -2, self.is_fp4, out=ret[..., :out_shape[-2], :])

--- a/python/triton_kernels/triton_kernels/tensor_details/layout_details/blackwell_value.py
+++ b/python/triton_kernels/triton_kernels/tensor_details/layout_details/blackwell_value.py
@@ -37,13 +37,13 @@ class BlackwellMXValueLayoutTransformation(LayoutTransformation):
 
     @property
     def storage_shape(self) -> list[int]:
-        shape = list(self.shape)
+        *leading_shape, M, K = self.shape
         if self.is_fp4:
-            shape[-1] //= 2
-        shape[-1] *= 2
-        shape[-2] //= 2
-        shape[-2] += -shape[-2] % 128
-        return shape
+            K //= 2
+        K *= 2
+        M //= 2
+        M += -M % 128
+        return [*leading_shape, M, K]
 
     def swizzle_data(self, data):
         assert data.stride(-1) == 1

--- a/python/triton_kernels/triton_kernels/tensor_details/layout_details/blackwell_value.py
+++ b/python/triton_kernels/triton_kernels/tensor_details/layout_details/blackwell_value.py
@@ -35,14 +35,23 @@ def strides_major_dim_m2(shape):
 @dataclass(frozen=True)
 class BlackwellMXValueLayoutTransformation(LayoutTransformation):
 
+    @property
+    def storage_shape(self) -> list[int]:
+        shape = list(self.shape)
+        if self.is_fp4:
+            shape[-1] //= 2
+        shape[-1] *= 2
+        shape[-2] //= 2
+        shape[-2] += -shape[-2] % 128
+        return shape
+
     def swizzle_data(self, data):
         assert data.stride(-1) == 1
         # re-pack as column-major
         out_shape = list(data.shape)
         out_shape[-1] *= 2
         out_shape[-2] //= 2
-        padded_shape = list(out_shape)
-        padded_shape[-2] += (-out_shape[-2]) % 128
+        padded_shape = self.storage_shape
         ret = torch.empty_strided(padded_shape, strides_major_dim_m2(padded_shape), device=data.device,
                                   dtype=data.dtype)
         repack(data, -1, -2, self.is_fp4, out=ret[..., :out_shape[-2], :])

--- a/python/triton_kernels/triton_kernels/tensor_details/layout_details/blackwell_value.py
+++ b/python/triton_kernels/triton_kernels/tensor_details/layout_details/blackwell_value.py
@@ -51,8 +51,7 @@ class BlackwellMXValueLayoutTransformation(LayoutTransformation):
         out_shape = list(data.shape)
         out_shape[-1] *= 2
         out_shape[-2] //= 2
-        padded_shape = list(out_shape)
-        padded_shape[-2] += (-out_shape[-2]) % 128
+        padded_shape = self.storage_shape
         ret = torch.empty_strided(padded_shape, strides_major_dim_m2(padded_shape), device=data.device,
                                   dtype=data.dtype)
         repack(data, -1, -2, self.is_fp4, out=ret[..., :out_shape[-2], :])

--- a/python/triton_kernels/triton_kernels/tensor_details/layout_details/blackwell_value_shuffled.py
+++ b/python/triton_kernels/triton_kernels/tensor_details/layout_details/blackwell_value_shuffled.py
@@ -115,12 +115,11 @@ class BlackwellMX4ValueShuffledTransformation(LayoutTransformation):
         This matches the baseline TMA block shape [block_n, packed_block_k] after swapping.
         """
         data = self._canonical_to_physical(data)
-        leading_shape = data.shape[:-2]
-        E = math.prod(leading_shape)
+        E, num_tiles_k, num_tiles_n, tile_n, tile_k_packed = self.storage_shape
         K_packed, N = data.shape[-2:]
         data = data.reshape(E, K_packed, N)
-        tile_k_packed, tile_n, padded_K_packed, padded_N, num_tiles_k, num_tiles_n = \
-            self._compute_params(E, K_packed, N)
+        padded_K_packed = num_tiles_k * tile_k_packed
+        padded_N = num_tiles_n * tile_n
 
         # Pad to tile boundaries if needed (in original [E, K_packed, N] space)
         if K_packed != padded_K_packed or N != padded_N:

--- a/python/triton_kernels/triton_kernels/tensor_details/layout_details/blackwell_value_shuffled.py
+++ b/python/triton_kernels/triton_kernels/tensor_details/layout_details/blackwell_value_shuffled.py
@@ -11,8 +11,8 @@ class BlackwellMX4ValueShuffledLayout(Layout):
     """
     Shuffled weight layout for MX4 matmul on Blackwell GPUs.
 
-    Physical packed storage for mxfp4 is column-major with shape [E, K_packed, N],
-    where K_packed = K // 2 (two FP4 values per byte).
+    The transformation first repacks canonical FP4 storage into an intermediate
+    K-packed shape [E, K_packed, N], where K_packed = K // 2.
 
     Baseline TMA loads operate on the swapped view [E, N, K_packed] with block
     shape [block_n, packed_block_k], then the kernel transposes to
@@ -72,7 +72,7 @@ class BlackwellMX4ValueShuffledTransformation(LayoutTransformation):
         return [E, num_tiles_k, num_tiles_n, tile_n, tile_k_packed]
 
     def _compute_params(self, E, K_packed, N):
-        """Compute tiling parameters from the physical shape."""
+        """Compute tiling parameters from the K-packed shape."""
         packed_block_k = self.block_k // 2
         tile_k_packed = packed_block_k
         tile_n = self.block_n
@@ -86,26 +86,26 @@ class BlackwellMX4ValueShuffledTransformation(LayoutTransformation):
 
         return tile_k_packed, tile_n, padded_K_packed, padded_N, num_tiles_k, num_tiles_n
 
-    def _canonical_to_physical(self, data: torch.Tensor) -> torch.Tensor:
-        """Repack canonical [..., K, N_packed] storage to physical [E, K_packed, N]."""
+    def _canonical_to_k_packed(self, data: torch.Tensor) -> torch.Tensor:
+        """Move FP4 packing from N to K."""
         if not self.is_fp4:
             raise ValueError("BlackwellMX4ValueShuffledLayout only supports fp4 values")
         assert data.stride(-1) == 1
-        out_shape = list(data.shape)
-        out_shape[-1] *= 2
-        out_shape[-2] //= 2
-        out = torch.empty(out_shape, dtype=data.dtype, device=data.device)
-        return repack(data, -1, -2, self.is_fp4, out=out)
+        k_packed_shape = list(data.shape)
+        k_packed_shape[-1] *= 2
+        k_packed_shape[-2] //= 2
+        k_packed = torch.empty(k_packed_shape, dtype=data.dtype, device=data.device)
+        return repack(data, -1, -2, self.is_fp4, out=k_packed)
 
-    def _physical_to_canonical(self, data: torch.Tensor) -> torch.Tensor:
-        """Repack physical [E, K_packed, N] storage to canonical [..., K, N_packed]."""
+    def _k_packed_to_canonical(self, data: torch.Tensor) -> torch.Tensor:
+        """Move FP4 packing from K back to N."""
         if not self.is_fp4:
             raise ValueError("BlackwellMX4ValueShuffledLayout only supports fp4 values")
-        out_shape = list(data.shape)
-        out_shape[-2] *= 2
-        out_shape[-1] //= 2
-        out = torch.empty(out_shape, dtype=data.dtype, device=data.device)
-        return repack(data, -2, -1, self.is_fp4, out=out)
+        canonical_shape = list(data.shape)
+        canonical_shape[-2] *= 2
+        canonical_shape[-1] //= 2
+        canonical = torch.empty(canonical_shape, dtype=data.dtype, device=data.device)
+        return repack(data, -2, -1, self.is_fp4, out=canonical)
 
     def swizzle_data(self, data: torch.Tensor) -> torch.Tensor:
         """
@@ -114,7 +114,7 @@ class BlackwellMX4ValueShuffledTransformation(LayoutTransformation):
         Target layout: [E, num_tiles_k, num_tiles_n, tile_n, tile_k_packed]
         This matches the baseline TMA block shape [block_n, packed_block_k] after swapping.
         """
-        data = self._canonical_to_physical(data)
+        data = self._canonical_to_k_packed(data)
         leading_shape = data.shape[:-2]
         E = math.prod(leading_shape)
         K_packed, N = data.shape[-2:]
@@ -122,7 +122,7 @@ class BlackwellMX4ValueShuffledTransformation(LayoutTransformation):
         tile_k_packed, tile_n, padded_K_packed, padded_N, num_tiles_k, num_tiles_n = \
             self._compute_params(E, K_packed, N)
 
-        # Pad to tile boundaries if needed (in original [E, K_packed, N] space)
+        # Pad to tile boundaries in K-packed [E, K_packed, N] space.
         if K_packed != padded_K_packed or N != padded_N:
             padded = torch.zeros((E, padded_K_packed, padded_N), dtype=data.dtype, device=data.device)
             padded[:, :K_packed, :N] = data
@@ -162,12 +162,12 @@ class BlackwellMX4ValueShuffledTransformation(LayoutTransformation):
         # Back to swapped view [E, padded_N, padded_K_packed]
         data = data.view(E, padded_N, padded_K_packed)
 
-        # Transpose back to physical [E, padded_K_packed, padded_N]
+        # Transpose back to K-packed [E, padded_K_packed, padded_N].
         data = data.transpose(1, 2).contiguous()
 
         # Trim padding back to original shape
         data = data[:, :orig_K_packed, :orig_N].contiguous()
-        data = self._physical_to_canonical(data)
+        data = self._k_packed_to_canonical(data)
         if not leading_shape:
             return data.squeeze(0)
         return data.reshape(*leading_shape, data.shape[-2], data.shape[-1])

--- a/python/triton_kernels/triton_kernels/tensor_details/layout_details/blackwell_value_shuffled.py
+++ b/python/triton_kernels/triton_kernels/tensor_details/layout_details/blackwell_value_shuffled.py
@@ -11,8 +11,8 @@ class BlackwellMX4ValueShuffledLayout(Layout):
     """
     Shuffled weight layout for MX4 matmul on Blackwell GPUs.
 
-    The transformation first repacks canonical FP4 storage into an intermediate
-    K-packed shape [E, K_packed, N], where K_packed = K // 2.
+    Physical packed storage for mxfp4 is column-major with shape [E, K_packed, N],
+    where K_packed = K // 2 (two FP4 values per byte).
 
     Baseline TMA loads operate on the swapped view [E, N, K_packed] with block
     shape [block_n, packed_block_k], then the kernel transposes to
@@ -72,7 +72,7 @@ class BlackwellMX4ValueShuffledTransformation(LayoutTransformation):
         return [E, num_tiles_k, num_tiles_n, tile_n, tile_k_packed]
 
     def _compute_params(self, E, K_packed, N):
-        """Compute tiling parameters from the K-packed shape."""
+        """Compute tiling parameters from the physical shape."""
         packed_block_k = self.block_k // 2
         tile_k_packed = packed_block_k
         tile_n = self.block_n
@@ -86,26 +86,26 @@ class BlackwellMX4ValueShuffledTransformation(LayoutTransformation):
 
         return tile_k_packed, tile_n, padded_K_packed, padded_N, num_tiles_k, num_tiles_n
 
-    def _canonical_to_k_packed(self, data: torch.Tensor) -> torch.Tensor:
-        """Move FP4 packing from N to K."""
+    def _canonical_to_physical(self, data: torch.Tensor) -> torch.Tensor:
+        """Repack canonical [..., K, N_packed] storage to physical [E, K_packed, N]."""
         if not self.is_fp4:
             raise ValueError("BlackwellMX4ValueShuffledLayout only supports fp4 values")
         assert data.stride(-1) == 1
-        k_packed_shape = list(data.shape)
-        k_packed_shape[-1] *= 2
-        k_packed_shape[-2] //= 2
-        k_packed = torch.empty(k_packed_shape, dtype=data.dtype, device=data.device)
-        return repack(data, -1, -2, self.is_fp4, out=k_packed)
+        out_shape = list(data.shape)
+        out_shape[-1] *= 2
+        out_shape[-2] //= 2
+        out = torch.empty(out_shape, dtype=data.dtype, device=data.device)
+        return repack(data, -1, -2, self.is_fp4, out=out)
 
-    def _k_packed_to_canonical(self, data: torch.Tensor) -> torch.Tensor:
-        """Move FP4 packing from K back to N."""
+    def _physical_to_canonical(self, data: torch.Tensor) -> torch.Tensor:
+        """Repack physical [E, K_packed, N] storage to canonical [..., K, N_packed]."""
         if not self.is_fp4:
             raise ValueError("BlackwellMX4ValueShuffledLayout only supports fp4 values")
-        canonical_shape = list(data.shape)
-        canonical_shape[-2] *= 2
-        canonical_shape[-1] //= 2
-        canonical = torch.empty(canonical_shape, dtype=data.dtype, device=data.device)
-        return repack(data, -2, -1, self.is_fp4, out=canonical)
+        out_shape = list(data.shape)
+        out_shape[-2] *= 2
+        out_shape[-1] //= 2
+        out = torch.empty(out_shape, dtype=data.dtype, device=data.device)
+        return repack(data, -2, -1, self.is_fp4, out=out)
 
     def swizzle_data(self, data: torch.Tensor) -> torch.Tensor:
         """
@@ -114,7 +114,7 @@ class BlackwellMX4ValueShuffledTransformation(LayoutTransformation):
         Target layout: [E, num_tiles_k, num_tiles_n, tile_n, tile_k_packed]
         This matches the baseline TMA block shape [block_n, packed_block_k] after swapping.
         """
-        data = self._canonical_to_k_packed(data)
+        data = self._canonical_to_physical(data)
         leading_shape = data.shape[:-2]
         E = math.prod(leading_shape)
         K_packed, N = data.shape[-2:]
@@ -122,7 +122,7 @@ class BlackwellMX4ValueShuffledTransformation(LayoutTransformation):
         tile_k_packed, tile_n, padded_K_packed, padded_N, num_tiles_k, num_tiles_n = \
             self._compute_params(E, K_packed, N)
 
-        # Pad to tile boundaries in K-packed [E, K_packed, N] space.
+        # Pad to tile boundaries if needed (in original [E, K_packed, N] space)
         if K_packed != padded_K_packed or N != padded_N:
             padded = torch.zeros((E, padded_K_packed, padded_N), dtype=data.dtype, device=data.device)
             padded[:, :K_packed, :N] = data
@@ -162,12 +162,12 @@ class BlackwellMX4ValueShuffledTransformation(LayoutTransformation):
         # Back to swapped view [E, padded_N, padded_K_packed]
         data = data.view(E, padded_N, padded_K_packed)
 
-        # Transpose back to K-packed [E, padded_K_packed, padded_N].
+        # Transpose back to physical [E, padded_K_packed, padded_N]
         data = data.transpose(1, 2).contiguous()
 
         # Trim padding back to original shape
         data = data[:, :orig_K_packed, :orig_N].contiguous()
-        data = self._k_packed_to_canonical(data)
+        data = self._physical_to_canonical(data)
         if not leading_shape:
             return data.squeeze(0)
         return data.reshape(*leading_shape, data.shape[-2], data.shape[-1])

--- a/python/triton_kernels/triton_kernels/tensor_details/layout_details/blackwell_value_shuffled.py
+++ b/python/triton_kernels/triton_kernels/tensor_details/layout_details/blackwell_value_shuffled.py
@@ -137,7 +137,7 @@ class BlackwellMX4ValueShuffledTransformation(LayoutTransformation):
         # This puts K tiles first (for inner loop locality) and arranges
         # inner dims as [tile_n, tile_k_packed] to match baseline TMA block.
         data = data.permute(0, 3, 1, 2, 4).contiguous()
-        return data
+        return self._validate_storage_shape(data)
 
     def unswizzle_data(self, data: torch.Tensor) -> torch.Tensor:
         """

--- a/python/triton_kernels/triton_kernels/tensor_details/layout_details/blackwell_value_shuffled.py
+++ b/python/triton_kernels/triton_kernels/tensor_details/layout_details/blackwell_value_shuffled.py
@@ -61,6 +61,16 @@ class BlackwellMX4ValueShuffledTransformation(LayoutTransformation):
     block_k: int = 128
     block_n: int = 256
 
+    @property
+    def storage_shape(self) -> list[int]:
+        if not self.is_fp4:
+            raise ValueError("BlackwellMX4ValueShuffledLayout only supports fp4 values")
+        E = math.prod(self.shape[:-2])
+        K_packed = self.shape[-2] // 2
+        N = self.shape[-1]
+        tile_k_packed, tile_n, _, _, num_tiles_k, num_tiles_n = self._compute_params(E, K_packed, N)
+        return [E, num_tiles_k, num_tiles_n, tile_n, tile_k_packed]
+
     def _compute_params(self, E, K_packed, N):
         """Compute tiling parameters from the physical shape."""
         packed_block_k = self.block_k // 2

--- a/python/triton_kernels/triton_kernels/tensor_details/layout_details/cdna4_scale.py
+++ b/python/triton_kernels/triton_kernels/tensor_details/layout_details/cdna4_scale.py
@@ -65,7 +65,7 @@ class CDNA4MXScaleLayoutTransformation(LayoutTransformation):
         data = data.reshape(self.B, self.storage_shape[2], self.storage_shape[1])
         data = data.transpose(-1, -2)
         assert data.stride(-2) == 1
-        return data
+        return self._validate_storage_shape(data)
 
     def unswizzle_data(self, data):
         data = data.transpose(-1, -2)

--- a/python/triton_kernels/triton_kernels/tensor_details/layout_details/cdna4_scale.py
+++ b/python/triton_kernels/triton_kernels/tensor_details/layout_details/cdna4_scale.py
@@ -62,8 +62,7 @@ class CDNA4MXScaleLayoutTransformation(LayoutTransformation):
         data = data.transpose(-1, -2)
         data = data.view(self.B, self.N_pad // NON_K_PRESHUFFLE_BLOCK_SIZE, 2, 16, self.K_SCALE_pad // 8, 2, 4, 1)
         data = data.permute(0, 1, 4, 6, 3, 5, 2, 7).contiguous()
-        storage_shape = self.storage_shape
-        data = data.reshape(storage_shape[0], storage_shape[2], storage_shape[1])
+        data = data.reshape(self.B, *reversed(self.storage_shape[1:]))
         data = data.transpose(-1, -2)
         assert data.stride(-2) == 1
         return data

--- a/python/triton_kernels/triton_kernels/tensor_details/layout_details/cdna4_scale.py
+++ b/python/triton_kernels/triton_kernels/tensor_details/layout_details/cdna4_scale.py
@@ -48,6 +48,10 @@ class CDNA4MXScaleLayoutTransformation(LayoutTransformation):
         object.__setattr__(self, "K_SCALE", K_SCALE)
         object.__setattr__(self, "N", N)
 
+    @property
+    def storage_shape(self) -> list[int]:
+        return [self.B, self.K_SCALE_pad * NON_K_PRESHUFFLE_BLOCK_SIZE, self.N_pad // NON_K_PRESHUFFLE_BLOCK_SIZE]
+
     def swizzle_data(self, data):
         assert data.numel() == 0 or data.stride(-1) == 1
         # re-pack as column-major

--- a/python/triton_kernels/triton_kernels/tensor_details/layout_details/cdna4_scale.py
+++ b/python/triton_kernels/triton_kernels/tensor_details/layout_details/cdna4_scale.py
@@ -62,7 +62,7 @@ class CDNA4MXScaleLayoutTransformation(LayoutTransformation):
         data = data.transpose(-1, -2)
         data = data.view(self.B, self.N_pad // NON_K_PRESHUFFLE_BLOCK_SIZE, 2, 16, self.K_SCALE_pad // 8, 2, 4, 1)
         data = data.permute(0, 1, 4, 6, 3, 5, 2, 7).contiguous()
-        data = data.reshape(self.B, *reversed(self.storage_shape[1:]))
+        data = data.reshape(self.B, self.storage_shape[2], self.storage_shape[1])
         data = data.transpose(-1, -2)
         assert data.stride(-2) == 1
         return data

--- a/python/triton_kernels/triton_kernels/tensor_details/layout_details/cdna4_scale.py
+++ b/python/triton_kernels/triton_kernels/tensor_details/layout_details/cdna4_scale.py
@@ -62,7 +62,8 @@ class CDNA4MXScaleLayoutTransformation(LayoutTransformation):
         data = data.transpose(-1, -2)
         data = data.view(self.B, self.N_pad // NON_K_PRESHUFFLE_BLOCK_SIZE, 2, 16, self.K_SCALE_pad // 8, 2, 4, 1)
         data = data.permute(0, 1, 4, 6, 3, 5, 2, 7).contiguous()
-        data = data.reshape(self.B, self.N_pad // 32, self.K_SCALE_pad * 32)
+        storage_shape = self.storage_shape
+        data = data.reshape(storage_shape[0], storage_shape[2], storage_shape[1])
         data = data.transpose(-1, -2)
         assert data.stride(-2) == 1
         return data

--- a/python/triton_kernels/triton_kernels/tensor_details/layout_details/gfx1250_scale.py
+++ b/python/triton_kernels/triton_kernels/tensor_details/layout_details/gfx1250_scale.py
@@ -54,7 +54,7 @@ class GFX1250MXScaleLayoutTransformation(LayoutTransformation):
         data = data.view(self.B, self.N_pad // self.ALIGN_N, 4, self.ALIGN_N // 4,
                          self.K_SCALE_pad // self.ALIGN_K_SCALE, self.ALIGN_K_SCALE)
         data = data.permute(0, 1, 4, 3, 2, 5).contiguous()
-        data = data.reshape(self.B, *reversed(self.storage_shape[1:]))
+        data = data.reshape(self.B, self.storage_shape[2], self.storage_shape[1])
         return data.transpose(-1, -2)
 
     def unswizzle_data(self, data):

--- a/python/triton_kernels/triton_kernels/tensor_details/layout_details/gfx1250_scale.py
+++ b/python/triton_kernels/triton_kernels/tensor_details/layout_details/gfx1250_scale.py
@@ -54,7 +54,8 @@ class GFX1250MXScaleLayoutTransformation(LayoutTransformation):
         data = data.view(self.B, self.N_pad // self.ALIGN_N, 4, self.ALIGN_N // 4,
                          self.K_SCALE_pad // self.ALIGN_K_SCALE, self.ALIGN_K_SCALE)
         data = data.permute(0, 1, 4, 3, 2, 5).contiguous()
-        data = data.reshape(self.B, self.N_pad // self.ALIGN_N, self.K_SCALE_pad * self.ALIGN_N)
+        storage_shape = self.storage_shape
+        data = data.reshape(storage_shape[0], storage_shape[2], storage_shape[1])
         return data.transpose(-1, -2)
 
     def unswizzle_data(self, data):

--- a/python/triton_kernels/triton_kernels/tensor_details/layout_details/gfx1250_scale.py
+++ b/python/triton_kernels/triton_kernels/tensor_details/layout_details/gfx1250_scale.py
@@ -54,8 +54,7 @@ class GFX1250MXScaleLayoutTransformation(LayoutTransformation):
         data = data.view(self.B, self.N_pad // self.ALIGN_N, 4, self.ALIGN_N // 4,
                          self.K_SCALE_pad // self.ALIGN_K_SCALE, self.ALIGN_K_SCALE)
         data = data.permute(0, 1, 4, 3, 2, 5).contiguous()
-        storage_shape = self.storage_shape
-        data = data.reshape(storage_shape[0], storage_shape[2], storage_shape[1])
+        data = data.reshape(self.B, *reversed(self.storage_shape[1:]))
         return data.transpose(-1, -2)
 
     def unswizzle_data(self, data):

--- a/python/triton_kernels/triton_kernels/tensor_details/layout_details/gfx1250_scale.py
+++ b/python/triton_kernels/triton_kernels/tensor_details/layout_details/gfx1250_scale.py
@@ -55,7 +55,7 @@ class GFX1250MXScaleLayoutTransformation(LayoutTransformation):
                          self.K_SCALE_pad // self.ALIGN_K_SCALE, self.ALIGN_K_SCALE)
         data = data.permute(0, 1, 4, 3, 2, 5).contiguous()
         data = data.reshape(self.B, self.storage_shape[2], self.storage_shape[1])
-        return data.transpose(-1, -2)
+        return self._validate_storage_shape(data.transpose(-1, -2))
 
     def unswizzle_data(self, data):
         data = data.transpose(-1, -2)

--- a/python/triton_kernels/triton_kernels/tensor_details/layout_details/gfx1250_scale.py
+++ b/python/triton_kernels/triton_kernels/tensor_details/layout_details/gfx1250_scale.py
@@ -43,6 +43,10 @@ class GFX1250MXScaleLayoutTransformation(LayoutTransformation):
         object.__setattr__(self, "K_SCALE", K_SCALE)
         object.__setattr__(self, "N", N)
 
+    @property
+    def storage_shape(self) -> list[int]:
+        return [self.B, self.K_SCALE_pad * self.ALIGN_N, self.N_pad // self.ALIGN_N]
+
     def swizzle_data(self, data):
         if data.numel():
             data = torch.nn.functional.pad(data, (0, self.N_pad - self.N, 0, self.K_SCALE_pad - self.K_SCALE))

--- a/python/triton_kernels/triton_kernels/tensor_details/layout_details/hopper_scale.py
+++ b/python/triton_kernels/triton_kernels/tensor_details/layout_details/hopper_scale.py
@@ -52,7 +52,7 @@ class HopperMXScaleLayoutTransformation(LayoutTransformation):
         object.__setattr__(self, "K", K)
 
     @property
-    def _padded_swizzle_input_shape(self) -> list[int]:
+    def _padded_shape(self) -> list[int]:
         *leading_shape, M, K = self.shape
         if self.mx_axis == len(leading_shape):
             M, K = K, M
@@ -63,10 +63,10 @@ class HopperMXScaleLayoutTransformation(LayoutTransformation):
 
     @property
     def storage_shape(self) -> list[int]:
-        *leading_shape, M_pad, K_pad = self._padded_swizzle_input_shape
+        *leading_shape, M, K = self._padded_shape
         if self.mx_axis == len(leading_shape):
-            return [*leading_shape, K_pad * 32, M_pad // 32]
-        return [*leading_shape, M_pad // 32, K_pad * 32]
+            return [*leading_shape, K * 32, M // 32]
+        return [*leading_shape, M // 32, K * 32]
 
     def _maybe_mT(self, data):
         if self.mx_axis == len(self.leading_shape):
@@ -77,7 +77,7 @@ class HopperMXScaleLayoutTransformation(LayoutTransformation):
         assert data.shape == (*self.leading_shape, self.M, self.K)
         data = self._maybe_mT(data).contiguous()
         *batch, M_in, K_in = data.shape
-        *_, M, K = self._padded_swizzle_input_shape
+        *_, M, K = self._padded_shape
         pad_m = M - M_in
         pad_k = K - K_in
         if data.numel():

--- a/python/triton_kernels/triton_kernels/tensor_details/layout_details/hopper_scale.py
+++ b/python/triton_kernels/triton_kernels/tensor_details/layout_details/hopper_scale.py
@@ -53,14 +53,13 @@ class HopperMXScaleLayoutTransformation(LayoutTransformation):
 
     @property
     def _padded_shape(self) -> list[int]:
-        shape = list(self.shape)
-        if self.mx_axis == len(self.leading_shape):
-            shape[-2], shape[-1] = shape[-1], shape[-2]
-        M, K = shape[-2:]
+        *leading_shape, M, K = self.shape
+        if self.mx_axis == len(leading_shape):
+            M, K = K, M
         align_m = 32 * self.num_warps
-        shape[-2] = (M + align_m - 1) // align_m * align_m
-        shape[-1] = (K + 1) // 2 * 2
-        return shape
+        M = (M + align_m - 1) // align_m * align_m
+        K = (K + 1) // 2 * 2
+        return [*leading_shape, M, K]
 
     @property
     def storage_shape(self) -> list[int]:
@@ -84,8 +83,11 @@ class HopperMXScaleLayoutTransformation(LayoutTransformation):
         if data.numel():
             data = torch.nn.functional.pad(data, (0, pad_k, 0, pad_m))
         assert data.is_contiguous()
+        assert M % (
+            2 * self.num_warps * 2 *
+            8) == 0 and K % 2 == 0, f"Input tensor must have a subtile of shape (..., {2 * self.num_warps * 2 * 8}, 2)"
         b = len(batch)
-        data = data.reshape(*batch, M // (32 * self.num_warps), 2, self.num_warps, 2, 8, K // 2, 2)
+        data = data.reshape(*batch, M // (2 * self.num_warps * 2 * 8), 2, self.num_warps, 2, 8, K // 2, 2)
         perm = [0, 2, 5, 1, 4, 6, 3]
         perm = list(range(b)) + [b + p for p in perm]
         data = data.permute(*perm)

--- a/python/triton_kernels/triton_kernels/tensor_details/layout_details/hopper_scale.py
+++ b/python/triton_kernels/triton_kernels/tensor_details/layout_details/hopper_scale.py
@@ -52,7 +52,7 @@ class HopperMXScaleLayoutTransformation(LayoutTransformation):
         object.__setattr__(self, "K", K)
 
     @property
-    def _padded_shape(self) -> list[int]:
+    def storage_shape(self) -> list[int]:
         shape = list(self.shape)
         if self.mx_axis == len(self.leading_shape):
             shape[-2], shape[-1] = shape[-1], shape[-2]
@@ -60,11 +60,7 @@ class HopperMXScaleLayoutTransformation(LayoutTransformation):
         align_m = 32 * self.num_warps
         shape[-2] = (M + align_m - 1) // align_m * align_m
         shape[-1] = (K + 1) // 2 * 2
-        return shape
-
-    @property
-    def storage_shape(self) -> list[int]:
-        *leading_shape, M, K = self._padded_shape
+        *leading_shape, M, K = shape
         if self.mx_axis == len(leading_shape):
             return [*leading_shape, K * 32, M // 32]
         return [*leading_shape, M // 32, K * 32]
@@ -77,15 +73,21 @@ class HopperMXScaleLayoutTransformation(LayoutTransformation):
     def swizzle_data(self, data):
         assert data.shape == (*self.leading_shape, self.M, self.K)
         data = self._maybe_mT(data).contiguous()
-        *batch, M_in, K_in = data.shape
-        *_, M, K = self._padded_shape
-        pad_m = M - M_in
-        pad_k = K - K_in
+        *batch, M, K = data.shape
+        SWIZZLE_ALIGN_M = 2 * self.num_warps * 2 * 8
+        SWIZZLE_ALIGN_K = 2
+        pad_m = (SWIZZLE_ALIGN_M - (M % SWIZZLE_ALIGN_M)) % SWIZZLE_ALIGN_M
+        pad_k = (SWIZZLE_ALIGN_K - (K % SWIZZLE_ALIGN_K)) % SWIZZLE_ALIGN_K
         if data.numel():
             data = torch.nn.functional.pad(data, (0, pad_k, 0, pad_m))
+        M += pad_m
+        K += pad_k
         assert data.is_contiguous()
+        assert M % (
+            2 * self.num_warps * 2 *
+            8) == 0 and K % 2 == 0, f"Input tensor must have a subtile of shape (..., {2 * self.num_warps * 2 * 8}, 2)"
         b = len(batch)
-        data = data.reshape(*batch, M // (32 * self.num_warps), 2, self.num_warps, 2, 8, K // 2, 2)
+        data = data.reshape(*batch, M // (2 * self.num_warps * 2 * 8), 2, self.num_warps, 2, 8, K // 2, 2)
         perm = [0, 2, 5, 1, 4, 6, 3]
         perm = list(range(b)) + [b + p for p in perm]
         data = data.permute(*perm)

--- a/python/triton_kernels/triton_kernels/tensor_details/layout_details/hopper_scale.py
+++ b/python/triton_kernels/triton_kernels/tensor_details/layout_details/hopper_scale.py
@@ -52,7 +52,7 @@ class HopperMXScaleLayoutTransformation(LayoutTransformation):
         object.__setattr__(self, "K", K)
 
     @property
-    def _padded_shape(self) -> list[int]:
+    def _padded_swizzle_input_shape(self) -> list[int]:
         *leading_shape, M, K = self.shape
         if self.mx_axis == len(leading_shape):
             M, K = K, M
@@ -63,10 +63,10 @@ class HopperMXScaleLayoutTransformation(LayoutTransformation):
 
     @property
     def storage_shape(self) -> list[int]:
-        *leading_shape, M, K = self._padded_shape
+        *leading_shape, M_pad, K_pad = self._padded_swizzle_input_shape
         if self.mx_axis == len(leading_shape):
-            return [*leading_shape, K * 32, M // 32]
-        return [*leading_shape, M // 32, K * 32]
+            return [*leading_shape, K_pad * 32, M_pad // 32]
+        return [*leading_shape, M_pad // 32, K_pad * 32]
 
     def _maybe_mT(self, data):
         if self.mx_axis == len(self.leading_shape):
@@ -77,7 +77,7 @@ class HopperMXScaleLayoutTransformation(LayoutTransformation):
         assert data.shape == (*self.leading_shape, self.M, self.K)
         data = self._maybe_mT(data).contiguous()
         *batch, M_in, K_in = data.shape
-        *_, M, K = self._padded_shape
+        *_, M, K = self._padded_swizzle_input_shape
         pad_m = M - M_in
         pad_k = K - K_in
         if data.numel():

--- a/python/triton_kernels/triton_kernels/tensor_details/layout_details/hopper_scale.py
+++ b/python/triton_kernels/triton_kernels/tensor_details/layout_details/hopper_scale.py
@@ -96,7 +96,7 @@ class HopperMXScaleLayoutTransformation(LayoutTransformation):
         assert data.shape[-2] == M // 32
         assert data.shape[-1] == K * 32
         data = self._maybe_mT(data)
-        return data
+        return self._validate_storage_shape(data)
 
     def unswizzle_data(self, data):
         data = self._maybe_mT(data)

--- a/python/triton_kernels/triton_kernels/tensor_details/layout_details/hopper_scale.py
+++ b/python/triton_kernels/triton_kernels/tensor_details/layout_details/hopper_scale.py
@@ -51,6 +51,24 @@ class HopperMXScaleLayoutTransformation(LayoutTransformation):
         object.__setattr__(self, "M", M)
         object.__setattr__(self, "K", K)
 
+    @property
+    def _padded_shape(self) -> list[int]:
+        shape = list(self.shape)
+        if self.mx_axis == len(self.leading_shape):
+            shape[-2], shape[-1] = shape[-1], shape[-2]
+        M, K = shape[-2:]
+        align_m = 32 * self.num_warps
+        shape[-2] = (M + align_m - 1) // align_m * align_m
+        shape[-1] = (K + 1) // 2 * 2
+        return shape
+
+    @property
+    def storage_shape(self) -> list[int]:
+        *leading_shape, M, K = self._padded_shape
+        if self.mx_axis == len(leading_shape):
+            return [*leading_shape, K * 32, M // 32]
+        return [*leading_shape, M // 32, K * 32]
+
     def _maybe_mT(self, data):
         if self.mx_axis == len(self.leading_shape):
             return data.contiguous().mT
@@ -59,21 +77,15 @@ class HopperMXScaleLayoutTransformation(LayoutTransformation):
     def swizzle_data(self, data):
         assert data.shape == (*self.leading_shape, self.M, self.K)
         data = self._maybe_mT(data).contiguous()
-        *batch, M, K = data.shape
-        SWIZZLE_ALIGN_M = 2 * self.num_warps * 2 * 8
-        SWIZZLE_ALIGN_K = 2
-        pad_m = (SWIZZLE_ALIGN_M - (M % SWIZZLE_ALIGN_M)) % SWIZZLE_ALIGN_M
-        pad_k = (SWIZZLE_ALIGN_K - (K % SWIZZLE_ALIGN_K)) % SWIZZLE_ALIGN_K
+        *batch, M_in, K_in = data.shape
+        *_, M, K = self._padded_shape
+        pad_m = M - M_in
+        pad_k = K - K_in
         if data.numel():
             data = torch.nn.functional.pad(data, (0, pad_k, 0, pad_m))
-        M += pad_m
-        K += pad_k
         assert data.is_contiguous()
-        assert M % (
-            2 * self.num_warps * 2 *
-            8) == 0 and K % 2 == 0, f"Input tensor must have a subtile of shape (..., {2 * self.num_warps * 2 * 8}, 2)"
         b = len(batch)
-        data = data.reshape(*batch, M // (2 * self.num_warps * 2 * 8), 2, self.num_warps, 2, 8, K // 2, 2)
+        data = data.reshape(*batch, M // (32 * self.num_warps), 2, self.num_warps, 2, 8, K // 2, 2)
         perm = [0, 2, 5, 1, 4, 6, 3]
         perm = list(range(b)) + [b + p for p in perm]
         data = data.permute(*perm)

--- a/python/triton_kernels/triton_kernels/tensor_details/layout_details/hopper_scale.py
+++ b/python/triton_kernels/triton_kernels/tensor_details/layout_details/hopper_scale.py
@@ -52,7 +52,7 @@ class HopperMXScaleLayoutTransformation(LayoutTransformation):
         object.__setattr__(self, "K", K)
 
     @property
-    def storage_shape(self) -> list[int]:
+    def _padded_shape(self) -> list[int]:
         shape = list(self.shape)
         if self.mx_axis == len(self.leading_shape):
             shape[-2], shape[-1] = shape[-1], shape[-2]
@@ -60,7 +60,11 @@ class HopperMXScaleLayoutTransformation(LayoutTransformation):
         align_m = 32 * self.num_warps
         shape[-2] = (M + align_m - 1) // align_m * align_m
         shape[-1] = (K + 1) // 2 * 2
-        *leading_shape, M, K = shape
+        return shape
+
+    @property
+    def storage_shape(self) -> list[int]:
+        *leading_shape, M, K = self._padded_shape
         if self.mx_axis == len(leading_shape):
             return [*leading_shape, K * 32, M // 32]
         return [*leading_shape, M // 32, K * 32]
@@ -73,21 +77,15 @@ class HopperMXScaleLayoutTransformation(LayoutTransformation):
     def swizzle_data(self, data):
         assert data.shape == (*self.leading_shape, self.M, self.K)
         data = self._maybe_mT(data).contiguous()
-        *batch, M, K = data.shape
-        SWIZZLE_ALIGN_M = 2 * self.num_warps * 2 * 8
-        SWIZZLE_ALIGN_K = 2
-        pad_m = (SWIZZLE_ALIGN_M - (M % SWIZZLE_ALIGN_M)) % SWIZZLE_ALIGN_M
-        pad_k = (SWIZZLE_ALIGN_K - (K % SWIZZLE_ALIGN_K)) % SWIZZLE_ALIGN_K
+        *batch, M_in, K_in = data.shape
+        *_, M, K = self._padded_shape
+        pad_m = M - M_in
+        pad_k = K - K_in
         if data.numel():
             data = torch.nn.functional.pad(data, (0, pad_k, 0, pad_m))
-        M += pad_m
-        K += pad_k
         assert data.is_contiguous()
-        assert M % (
-            2 * self.num_warps * 2 *
-            8) == 0 and K % 2 == 0, f"Input tensor must have a subtile of shape (..., {2 * self.num_warps * 2 * 8}, 2)"
         b = len(batch)
-        data = data.reshape(*batch, M // (2 * self.num_warps * 2 * 8), 2, self.num_warps, 2, 8, K // 2, 2)
+        data = data.reshape(*batch, M // (32 * self.num_warps), 2, self.num_warps, 2, 8, K // 2, 2)
         perm = [0, 2, 5, 1, 4, 6, 3]
         perm = list(range(b)) + [b + p for p in perm]
         data = data.permute(*perm)

--- a/python/triton_kernels/triton_kernels/tensor_details/layout_details/hopper_value.py
+++ b/python/triton_kernels/triton_kernels/tensor_details/layout_details/hopper_value.py
@@ -53,6 +53,30 @@ class HopperMXValueLayoutTransformation(LayoutTransformation):
         object.__setattr__(self, "K", K)
         object.__setattr__(self, "N", N)
 
+    def _padded_shape(self, shape) -> list[int]:
+        shape = list(shape)
+        *leading_shape, M, K = shape
+        if self.mx_axis == len(leading_shape):
+            align_m, align_k = 64, 256
+        else:
+            align_m, align_k = 256, 64
+        shape[-2] = (M + align_m - 1) // align_m * align_m
+        shape[-1] = (K + align_k - 1) // align_k * align_k
+        return shape
+
+    @property
+    def storage_shape(self) -> list[int]:
+        shape = list(self.shape)
+        if self.is_fp4:
+            shape[-1] //= 2
+            if self.mx_axis != len(shape) - 1:
+                shape[-1] *= 2
+                shape[self.mx_axis] //= 2
+        *leading_shape, M, K = self._padded_shape(shape)
+        if self.mx_axis == len(leading_shape):
+            return [*leading_shape, M * 4, K // 4]
+        return [*leading_shape, M // 4, K * 4]
+
     def _maybe_mT(self, data):
         if self.mx_axis == len(self.leading_shape):
             return data.mT
@@ -85,10 +109,9 @@ class HopperMXValueLayoutTransformation(LayoutTransformation):
         assert self.mma_version in (2, 3)
         # Align the dimension packed by four to a 64-byte load extent.
         *_, M_in, K_in = data.shape
-        SWIZZLE_ALIGN_M = 64 if self.mx_axis == batch else 256
-        SWIZZLE_ALIGN_K = 256 if self.mx_axis == batch else 64
-        pad_m = (SWIZZLE_ALIGN_M - (M_in % SWIZZLE_ALIGN_M)) % SWIZZLE_ALIGN_M
-        pad_k = (SWIZZLE_ALIGN_K - (K_in % SWIZZLE_ALIGN_K)) % SWIZZLE_ALIGN_K
+        *_, M, K = self._padded_shape(data.shape)
+        pad_m = M - M_in
+        pad_k = K - K_in
         if data.numel():
             data = torch.nn.functional.pad(data, (0, pad_k, 0, pad_m))
         else:

--- a/python/triton_kernels/triton_kernels/tensor_details/layout_details/hopper_value.py
+++ b/python/triton_kernels/triton_kernels/tensor_details/layout_details/hopper_value.py
@@ -54,25 +54,24 @@ class HopperMXValueLayoutTransformation(LayoutTransformation):
         object.__setattr__(self, "N", N)
 
     def _padded_shape(self, shape) -> list[int]:
-        shape = list(shape)
         *leading_shape, M, K = shape
         if self.mx_axis == len(leading_shape):
             align_m, align_k = 64, 256
         else:
             align_m, align_k = 256, 64
-        shape[-2] = (M + align_m - 1) // align_m * align_m
-        shape[-1] = (K + align_k - 1) // align_k * align_k
-        return shape
+        M = (M + align_m - 1) // align_m * align_m
+        K = (K + align_k - 1) // align_k * align_k
+        return [*leading_shape, M, K]
 
     @property
     def storage_shape(self) -> list[int]:
-        shape = list(self.shape)
+        *leading_shape, M, K = self.shape
         if self.is_fp4:
-            shape[-1] //= 2
-            if self.mx_axis != len(shape) - 1:
-                shape[-1] *= 2
-                shape[self.mx_axis] //= 2
-        *leading_shape, M, K = self._padded_shape(shape)
+            K //= 2
+            if self.mx_axis == len(leading_shape):
+                M //= 2
+                K *= 2
+        *leading_shape, M, K = self._padded_shape((*leading_shape, M, K))
         if self.mx_axis == len(leading_shape):
             return [*leading_shape, M * 4, K // 4]
         return [*leading_shape, M // 4, K * 4]

--- a/python/triton_kernels/triton_kernels/tensor_details/layout_details/hopper_value.py
+++ b/python/triton_kernels/triton_kernels/tensor_details/layout_details/hopper_value.py
@@ -164,8 +164,7 @@ class HopperMXValueLayoutTransformation(LayoutTransformation):
         # twiddle the bits
         data = _pack_bits(data, self.mx_axis)
         data = self._maybe_mT(data)
-        assert list(data.shape) == self.storage_shape
-        return data
+        return self._validate_storage_shape(data)
 
     def unswizzle_data(self, data):
         data = self._maybe_mT(data)

--- a/python/triton_kernels/triton_kernels/tensor_details/layout_details/hopper_value.py
+++ b/python/triton_kernels/triton_kernels/tensor_details/layout_details/hopper_value.py
@@ -164,6 +164,7 @@ class HopperMXValueLayoutTransformation(LayoutTransformation):
         # twiddle the bits
         data = _pack_bits(data, self.mx_axis)
         data = self._maybe_mT(data)
+        assert list(data.shape) == self.storage_shape
         return data
 
     def unswizzle_data(self, data):

--- a/python/triton_kernels/triton_kernels/tensor_details/layout_details/hopper_value.py
+++ b/python/triton_kernels/triton_kernels/tensor_details/layout_details/hopper_value.py
@@ -53,7 +53,7 @@ class HopperMXValueLayoutTransformation(LayoutTransformation):
         object.__setattr__(self, "K", K)
         object.__setattr__(self, "N", N)
 
-    def _padded_repacked_shape(self, shape) -> list[int]:
+    def _padded_shape(self, shape) -> list[int]:
         *leading_shape, M, K = shape
         if self.mx_axis == len(leading_shape):
             align_m, align_k = 64, 256
@@ -71,10 +71,10 @@ class HopperMXValueLayoutTransformation(LayoutTransformation):
             if self.mx_axis == len(leading_shape):
                 M //= 2
                 K *= 2
-        *leading_shape, M_pad, K_pad = self._padded_repacked_shape((*leading_shape, M, K))
+        *leading_shape, M, K = self._padded_shape((*leading_shape, M, K))
         if self.mx_axis == len(leading_shape):
-            return [*leading_shape, M_pad * 4, K_pad // 4]
-        return [*leading_shape, M_pad // 4, K_pad * 4]
+            return [*leading_shape, M * 4, K // 4]
+        return [*leading_shape, M // 4, K * 4]
 
     def _maybe_mT(self, data):
         if self.mx_axis == len(self.leading_shape):
@@ -107,17 +107,17 @@ class HopperMXValueLayoutTransformation(LayoutTransformation):
         assert batch >= 0
         assert self.mma_version in (2, 3)
         # Align the dimension packed by four to a 64-byte load extent.
-        *_, M, K = data.shape
-        *_, M_pad, K_pad = self._padded_repacked_shape(data.shape)
-        pad_m = M_pad - M
-        pad_k = K_pad - K
+        *_, M_in, K_in = data.shape
+        *_, M, K = self._padded_shape(data.shape)
+        pad_m = M - M_in
+        pad_k = K - K_in
         if data.numel():
             data = torch.nn.functional.pad(data, (0, pad_k, 0, pad_m))
         else:
-            data = data.reshape(*data.shape[:-2], M_pad, K_pad)
+            data = data.reshape(*data.shape[:-2], M_in + pad_m, K_in + pad_k)
 
         data = self._maybe_mT(data)
-        swizzle_input_shape = data.shape
+        init_shape = data.shape
 
         # We are loading 8 bf16 elements per thread to use ld.global.v4
         # Every u8 represents 2 mxfp4 elements
@@ -159,8 +159,8 @@ class HopperMXValueLayoutTransformation(LayoutTransformation):
         data = data.flatten(-10, -1)
         data = data.flatten(-3, -2)
         assert data.is_contiguous()
-        assert data.shape[-2] == swizzle_input_shape[-2] // 4
-        assert data.shape[-1] == swizzle_input_shape[-1] * 4
+        assert data.shape[-2] == init_shape[-2] // 4
+        assert data.shape[-1] == init_shape[-1] * 4
         # twiddle the bits
         data = _pack_bits(data, self.mx_axis)
         data = self._maybe_mT(data)

--- a/python/triton_kernels/triton_kernels/tensor_details/layout_details/hopper_value.py
+++ b/python/triton_kernels/triton_kernels/tensor_details/layout_details/hopper_value.py
@@ -53,6 +53,17 @@ class HopperMXValueLayoutTransformation(LayoutTransformation):
         object.__setattr__(self, "K", K)
         object.__setattr__(self, "N", N)
 
+    def _padded_shape(self, shape) -> list[int]:
+        shape = list(shape)
+        *leading_shape, M, K = shape
+        if self.mx_axis == len(leading_shape):
+            align_m, align_k = 64, 256
+        else:
+            align_m, align_k = 256, 64
+        shape[-2] = (M + align_m - 1) // align_m * align_m
+        shape[-1] = (K + align_k - 1) // align_k * align_k
+        return shape
+
     @property
     def storage_shape(self) -> list[int]:
         shape = list(self.shape)
@@ -61,13 +72,9 @@ class HopperMXValueLayoutTransformation(LayoutTransformation):
             if self.mx_axis != len(shape) - 1:
                 shape[-1] *= 2
                 shape[self.mx_axis] //= 2
-        *leading_shape, M, K = shape
+        *leading_shape, M, K = self._padded_shape(shape)
         if self.mx_axis == len(leading_shape):
-            M += -M % 64
-            K += -K % 256
             return [*leading_shape, M * 4, K // 4]
-        M += -M % 256
-        K += -K % 64
         return [*leading_shape, M // 4, K * 4]
 
     def _maybe_mT(self, data):
@@ -102,10 +109,9 @@ class HopperMXValueLayoutTransformation(LayoutTransformation):
         assert self.mma_version in (2, 3)
         # Align the dimension packed by four to a 64-byte load extent.
         *_, M_in, K_in = data.shape
-        SWIZZLE_ALIGN_M = 64 if self.mx_axis == batch else 256
-        SWIZZLE_ALIGN_K = 256 if self.mx_axis == batch else 64
-        pad_m = (SWIZZLE_ALIGN_M - (M_in % SWIZZLE_ALIGN_M)) % SWIZZLE_ALIGN_M
-        pad_k = (SWIZZLE_ALIGN_K - (K_in % SWIZZLE_ALIGN_K)) % SWIZZLE_ALIGN_K
+        *_, M, K = self._padded_shape(data.shape)
+        pad_m = M - M_in
+        pad_k = K - K_in
         if data.numel():
             data = torch.nn.functional.pad(data, (0, pad_k, 0, pad_m))
         else:

--- a/python/triton_kernels/triton_kernels/tensor_details/layout_details/hopper_value.py
+++ b/python/triton_kernels/triton_kernels/tensor_details/layout_details/hopper_value.py
@@ -53,7 +53,7 @@ class HopperMXValueLayoutTransformation(LayoutTransformation):
         object.__setattr__(self, "K", K)
         object.__setattr__(self, "N", N)
 
-    def _padded_shape(self, shape) -> list[int]:
+    def _padded_repacked_shape(self, shape) -> list[int]:
         *leading_shape, M, K = shape
         if self.mx_axis == len(leading_shape):
             align_m, align_k = 64, 256
@@ -71,10 +71,10 @@ class HopperMXValueLayoutTransformation(LayoutTransformation):
             if self.mx_axis == len(leading_shape):
                 M //= 2
                 K *= 2
-        *leading_shape, M, K = self._padded_shape((*leading_shape, M, K))
+        *leading_shape, M_pad, K_pad = self._padded_repacked_shape((*leading_shape, M, K))
         if self.mx_axis == len(leading_shape):
-            return [*leading_shape, M * 4, K // 4]
-        return [*leading_shape, M // 4, K * 4]
+            return [*leading_shape, M_pad * 4, K_pad // 4]
+        return [*leading_shape, M_pad // 4, K_pad * 4]
 
     def _maybe_mT(self, data):
         if self.mx_axis == len(self.leading_shape):
@@ -107,17 +107,17 @@ class HopperMXValueLayoutTransformation(LayoutTransformation):
         assert batch >= 0
         assert self.mma_version in (2, 3)
         # Align the dimension packed by four to a 64-byte load extent.
-        *_, M_in, K_in = data.shape
-        *_, M, K = self._padded_shape(data.shape)
-        pad_m = M - M_in
-        pad_k = K - K_in
+        *_, M, K = data.shape
+        *_, M_pad, K_pad = self._padded_repacked_shape(data.shape)
+        pad_m = M_pad - M
+        pad_k = K_pad - K
         if data.numel():
             data = torch.nn.functional.pad(data, (0, pad_k, 0, pad_m))
         else:
-            data = data.reshape(*data.shape[:-2], M_in + pad_m, K_in + pad_k)
+            data = data.reshape(*data.shape[:-2], M_pad, K_pad)
 
         data = self._maybe_mT(data)
-        init_shape = data.shape
+        swizzle_input_shape = data.shape
 
         # We are loading 8 bf16 elements per thread to use ld.global.v4
         # Every u8 represents 2 mxfp4 elements
@@ -159,8 +159,8 @@ class HopperMXValueLayoutTransformation(LayoutTransformation):
         data = data.flatten(-10, -1)
         data = data.flatten(-3, -2)
         assert data.is_contiguous()
-        assert data.shape[-2] == init_shape[-2] // 4
-        assert data.shape[-1] == init_shape[-1] * 4
+        assert data.shape[-2] == swizzle_input_shape[-2] // 4
+        assert data.shape[-1] == swizzle_input_shape[-1] * 4
         # twiddle the bits
         data = _pack_bits(data, self.mx_axis)
         data = self._maybe_mT(data)

--- a/python/triton_kernels/triton_kernels/tensor_details/layout_details/hopper_value.py
+++ b/python/triton_kernels/triton_kernels/tensor_details/layout_details/hopper_value.py
@@ -53,17 +53,6 @@ class HopperMXValueLayoutTransformation(LayoutTransformation):
         object.__setattr__(self, "K", K)
         object.__setattr__(self, "N", N)
 
-    def _padded_shape(self, shape) -> list[int]:
-        shape = list(shape)
-        *leading_shape, M, K = shape
-        if self.mx_axis == len(leading_shape):
-            align_m, align_k = 64, 256
-        else:
-            align_m, align_k = 256, 64
-        shape[-2] = (M + align_m - 1) // align_m * align_m
-        shape[-1] = (K + align_k - 1) // align_k * align_k
-        return shape
-
     @property
     def storage_shape(self) -> list[int]:
         shape = list(self.shape)
@@ -72,9 +61,13 @@ class HopperMXValueLayoutTransformation(LayoutTransformation):
             if self.mx_axis != len(shape) - 1:
                 shape[-1] *= 2
                 shape[self.mx_axis] //= 2
-        *leading_shape, M, K = self._padded_shape(shape)
+        *leading_shape, M, K = shape
         if self.mx_axis == len(leading_shape):
+            M += -M % 64
+            K += -K % 256
             return [*leading_shape, M * 4, K // 4]
+        M += -M % 256
+        K += -K % 64
         return [*leading_shape, M // 4, K * 4]
 
     def _maybe_mT(self, data):
@@ -109,9 +102,10 @@ class HopperMXValueLayoutTransformation(LayoutTransformation):
         assert self.mma_version in (2, 3)
         # Align the dimension packed by four to a 64-byte load extent.
         *_, M_in, K_in = data.shape
-        *_, M, K = self._padded_shape(data.shape)
-        pad_m = M - M_in
-        pad_k = K - K_in
+        SWIZZLE_ALIGN_M = 64 if self.mx_axis == batch else 256
+        SWIZZLE_ALIGN_K = 256 if self.mx_axis == batch else 64
+        pad_m = (SWIZZLE_ALIGN_M - (M_in % SWIZZLE_ALIGN_M)) % SWIZZLE_ALIGN_M
+        pad_k = (SWIZZLE_ALIGN_K - (K_in % SWIZZLE_ALIGN_K)) % SWIZZLE_ALIGN_K
         if data.numel():
             data = torch.nn.functional.pad(data, (0, pad_k, 0, pad_m))
         else:

--- a/python/triton_kernels/triton_kernels/tensor_details/layout_details/strided.py
+++ b/python/triton_kernels/triton_kernels/tensor_details/layout_details/strided.py
@@ -75,21 +75,21 @@ class StridedLayoutTransformation(LayoutTransformation):
         if r == 0:
             return data
         pd = self.order[0]  # packed/contiguous dim in output
-        out_shape = self.storage_shape
+        storage_shape = self.storage_shape
         # dense strides in minor->major `self.order`
         stride, s = [0] * r, 1
         for d in self.order:
-            stride[d], s = s, s * out_shape[d]
-        out = torch.empty_strided(out_shape, stride, dtype=data.dtype, device=data.device)
-        repack(data, -1, pd, self.is_fp4, out=out)
-        return out
+            stride[d], s = s, s * storage_shape[d]
+        storage = torch.empty_strided(storage_shape, stride, dtype=data.dtype, device=data.device)
+        repack(data, -1, pd, self.is_fp4, out=storage)
+        return storage
 
     def unswizzle_data(self, data):
         assert data.stride(self.order[0]) == 1
-        out_shape = list(self.shape)
+        canonical_shape = list(self.shape)
         if self.is_fp4:
-            out_shape[-1] //= 2
-        ret = torch.empty(out_shape, dtype=data.dtype, device=data.device)
-        repack(data, self.order[0], -1, self.is_fp4, out=ret)
-        assert ret.stride(-1) == 1
-        return ret
+            canonical_shape[-1] //= 2
+        canonical = torch.empty(canonical_shape, dtype=data.dtype, device=data.device)
+        repack(data, self.order[0], -1, self.is_fp4, out=canonical)
+        assert canonical.stride(-1) == 1
+        return canonical

--- a/python/triton_kernels/triton_kernels/tensor_details/layout_details/strided.py
+++ b/python/triton_kernels/triton_kernels/tensor_details/layout_details/strided.py
@@ -75,9 +75,7 @@ class StridedLayoutTransformation(LayoutTransformation):
         if r == 0:
             return data
         pd = self.order[0]  # packed/contiguous dim in output
-        out_shape = list(self.shape)
-        if self.is_fp4:
-            out_shape[pd] //= 2
+        out_shape = self.storage_shape
         # dense strides in minor->major `self.order`
         stride, s = [0] * r, 1
         for d in self.order:

--- a/python/triton_kernels/triton_kernels/tensor_details/layout_details/strided.py
+++ b/python/triton_kernels/triton_kernels/tensor_details/layout_details/strided.py
@@ -75,7 +75,9 @@ class StridedLayoutTransformation(LayoutTransformation):
         if r == 0:
             return data
         pd = self.order[0]  # packed/contiguous dim in output
-        out_shape = self.storage_shape
+        out_shape = list(self.shape)
+        if self.is_fp4:
+            out_shape[pd] //= 2
         # dense strides in minor->major `self.order`
         stride, s = [0] * r, 1
         for d in self.order:

--- a/python/triton_kernels/triton_kernels/tensor_details/layout_details/strided.py
+++ b/python/triton_kernels/triton_kernels/tensor_details/layout_details/strided.py
@@ -73,7 +73,7 @@ class StridedLayoutTransformation(LayoutTransformation):
         assert data.numel() == 0 or data.stride(-1) == 1
         r = len(self.shape)
         if r == 0:
-            return data
+            return self._validate_storage_shape(data)
         pd = self.order[0]  # packed/contiguous dim in output
         out_shape = self.storage_shape
         # dense strides in minor->major `self.order`
@@ -82,7 +82,7 @@ class StridedLayoutTransformation(LayoutTransformation):
             stride[d], s = s, s * out_shape[d]
         out = torch.empty_strided(out_shape, stride, dtype=data.dtype, device=data.device)
         repack(data, -1, pd, self.is_fp4, out=out)
-        return out
+        return self._validate_storage_shape(out)
 
     def unswizzle_data(self, data):
         assert data.stride(self.order[0]) == 1

--- a/python/triton_kernels/triton_kernels/tensor_details/layout_details/strided.py
+++ b/python/triton_kernels/triton_kernels/tensor_details/layout_details/strided.py
@@ -75,12 +75,12 @@ class StridedLayoutTransformation(LayoutTransformation):
         if r == 0:
             return data
         pd = self.order[0]  # packed/contiguous dim in output
-        storage_shape = self.storage_shape
+        sizes = self.storage_shape
         # dense strides in minor->major `self.order`
         stride, s = [0] * r, 1
         for d in self.order:
-            stride[d], s = s, s * storage_shape[d]
-        storage = torch.empty_strided(storage_shape, stride, dtype=data.dtype, device=data.device)
+            stride[d], s = s, s * sizes[d]
+        storage = torch.empty_strided(sizes, stride, dtype=data.dtype, device=data.device)
         repack(data, -1, pd, self.is_fp4, out=storage)
         return storage
 

--- a/python/triton_kernels/triton_kernels/tensor_details/layout_details/strided.py
+++ b/python/triton_kernels/triton_kernels/tensor_details/layout_details/strided.py
@@ -62,15 +62,20 @@ class StridedLayoutTransformation(LayoutTransformation):
 
     order: list[int]
 
+    @property
+    def storage_shape(self) -> list[int]:
+        shape = list(self.shape)
+        if self.is_fp4:
+            shape[self.order[0]] //= 2
+        return shape
+
     def swizzle_data(self, data):
         assert data.numel() == 0 or data.stride(-1) == 1
         r = len(self.shape)
         if r == 0:
             return data
         pd = self.order[0]  # packed/contiguous dim in output
-        out_shape = list(self.shape)
-        if self.is_fp4:
-            out_shape[pd] //= 2
+        out_shape = self.storage_shape
         # dense strides in minor->major `self.order`
         stride, s = [0] * r, 1
         for d in self.order:

--- a/python/triton_kernels/triton_kernels/tensor_details/layout_details/strided.py
+++ b/python/triton_kernels/triton_kernels/tensor_details/layout_details/strided.py
@@ -75,21 +75,21 @@ class StridedLayoutTransformation(LayoutTransformation):
         if r == 0:
             return data
         pd = self.order[0]  # packed/contiguous dim in output
-        sizes = self.storage_shape
+        out_shape = self.storage_shape
         # dense strides in minor->major `self.order`
         stride, s = [0] * r, 1
         for d in self.order:
-            stride[d], s = s, s * sizes[d]
-        storage = torch.empty_strided(sizes, stride, dtype=data.dtype, device=data.device)
-        repack(data, -1, pd, self.is_fp4, out=storage)
-        return storage
+            stride[d], s = s, s * out_shape[d]
+        out = torch.empty_strided(out_shape, stride, dtype=data.dtype, device=data.device)
+        repack(data, -1, pd, self.is_fp4, out=out)
+        return out
 
     def unswizzle_data(self, data):
         assert data.stride(self.order[0]) == 1
-        canonical_shape = list(self.shape)
+        out_shape = list(self.shape)
         if self.is_fp4:
-            canonical_shape[-1] //= 2
-        canonical = torch.empty(canonical_shape, dtype=data.dtype, device=data.device)
-        repack(data, self.order[0], -1, self.is_fp4, out=canonical)
-        assert canonical.stride(-1) == 1
-        return canonical
+            out_shape[-1] //= 2
+        ret = torch.empty(out_shape, dtype=data.dtype, device=data.device)
+        repack(data, self.order[0], -1, self.is_fp4, out=ret)
+        assert ret.stride(-1) == 1
+        return ret


### PR DESCRIPTION
## Summary

- add `Layout.storage_shape(logical_shape, is_fp4)` for direct physical-shape queries
- implement integer shape propagation for every built-in layout
- reuse the query in strided allocation and final layout output sizing
- test FP4 packing, padding, rank-changing, ragged, and zero-sized layouts against actual conversion

## Motivation

Some callers need the swizzled storage shape for planning or allocation without materializing a tensor or running the layout conversion. Conversion already computes or shares the same shape arithmetic for padding, views, and allocations, so exposing it through `Layout.storage_shape` makes that existing logic available as cheap metadata while keeping it consistent with the actual conversion.

## Performance

Median CPU time after warmup; the baseline constructs a meta tensor, wraps it, converts the layout, and reads the resulting shape.

| Layout | Meta conversion | `storage_shape` | Speedup |
| --- | ---: | ---: | ---: |
| Strided | 105.25 us | 0.54 us | 195x |
| Hopper value | 1064.55 us | 0.98 us | 1092x |
| Hopper scale | 16.53 us | 0.83 us | 20x |
| Blackwell value | 114.32 us | 0.38 us | 303x |
| Blackwell shuffled | 122.12 us | 0.63 us | 195x |
| Blackwell scale | 12.95 us | 0.77 us | 17x |
| Blackwell act scale | 10.43 us | 0.91 us | 11x |
| CDNA4 scale | 14.37 us | 0.75 us | 19x |
| GFX1250 scale | 11.81 us | 0.80 us | 15x |

For Hopper value layout, FakeTensorMode took 2.33 ms versus 0.98 us for the direct query.

## Test plan

- pre-commit hooks
- focused layout tests (`169 passed`)
- randomized meta conversion cross-checks (`384 passed`)
