### PR TITLE
Replace compiler internal expand dims with reshape

### DIFF
--- a/include/triton/Dialect/Triton/IR/TritonOps.td
+++ b/include/triton/Dialect/Triton/IR/TritonOps.td
@@ -488,6 +488,9 @@ def TT_ReshapeOp : TT_Op<"reshape", [Pure,
     let hasCanonicalizeMethod = 1;
     let hasFolder = 1;
     let hasVerifier = 1;
+    let extraClassDeclaration = [{
+      std::optional<unsigned> getExpandDimsAxis();
+    }];
 }
 
 def TT_BroadcastOp : TT_Op<"broadcast", [Pure,

--- a/include/triton/Dialect/TritonGPU/Transforms/DecomposeScaledBlocked.h
+++ b/include/triton/Dialect/TritonGPU/Transforms/DecomposeScaledBlocked.h
@@ -19,8 +19,8 @@ protected:
                                          FloatType computeType) const;
   TypedValue<RankedTensorType>
   broadcastScale(PatternRewriter &rewriter, DotScaledOp scaledDotOp,
-                 ModuleOp mod, TypedValue<RankedTensorType> scale,
-                 int dim) const;
+                 TypedValue<RankedTensorType> scale, int dim,
+                 Attribute dstEncoding) const;
   TypedValue<RankedTensorType> maskNan(PatternRewriter &rewriter,
                                        DotScaledOp scaledDotOp,
                                        TypedValue<RankedTensorType> mxfp,

--- a/lib/Dialect/Gluon/Transforms/Canonicalize.cpp
+++ b/lib/Dialect/Gluon/Transforms/Canonicalize.cpp
@@ -57,6 +57,7 @@ void Canonicalize::runOnOperation() {
   StoreOp::getCanonicalizationPatterns(patterns, ctx);
   BroadcastOp::getCanonicalizationPatterns(patterns, ctx);
   ExpandDimsOp::getCanonicalizationPatterns(patterns, ctx);
+  ReshapeOp::getCanonicalizationPatterns(patterns, ctx);
   IntToPtrOp::getCanonicalizationPatterns(patterns, ctx);
   ttg::WarpSpecializeOp::getCanonicalizationPatterns(patterns, ctx);
   ttg::WarpSpecializePartitionsOp::getCanonicalizationPatterns(patterns, ctx);

--- a/lib/Dialect/Triton/IR/Ops.cpp
+++ b/lib/Dialect/Triton/IR/Ops.cpp
@@ -920,6 +920,22 @@ LogicalResult CatOp::verify() {
 
 //-- ReshapeOp --
 
+std::optional<unsigned> ReshapeOp::getExpandDimsAxis() {
+  auto srcTy = getSrc().getType();
+  auto dstTy = getType();
+  if (srcTy.getRank() + 1 != dstTy.getRank())
+    return std::nullopt;
+  auto srcShape = srcTy.getShape();
+  auto dstShape = dstTy.getShape();
+  for (unsigned axis = 0; axis < dstShape.size(); ++axis) {
+    if (dstShape[axis] == 1 &&
+        srcShape.take_front(axis) == dstShape.take_front(axis) &&
+        srcShape.drop_front(axis) == dstShape.drop_front(axis + 1))
+      return axis;
+  }
+  return std::nullopt;
+}
+
 void ReshapeOp::build(OpBuilder &builder, OperationState &state,
                       ArrayRef<int64_t> shape, Value src, bool allowReorder) {
   auto srcTy = cast<RankedTensorType>(src.getType());

--- a/lib/Dialect/Triton/IR/Ops.cpp
+++ b/lib/Dialect/Triton/IR/Ops.cpp
@@ -961,6 +961,15 @@ LogicalResult ReshapeOp::canonicalize(ReshapeOp op, PatternRewriter &rewriter) {
     return failure();
   }
 
+  // reshape(expand_dims(x)) -> x
+  if (auto expandDims = dyn_cast<ExpandDimsOp>(definingOp)) {
+    if (!op.getAllowReorder() &&
+        op.getType() == expandDims.getSrc().getType()) {
+      rewriter.replaceOp(op, expandDims.getSrc());
+      return success();
+    }
+  }
+
   // reshape(reshape) -> reshape
   if (auto parentReshape = dyn_cast<ReshapeOp>(definingOp)) {
     // Allow reorder if either reshape allowed it

--- a/lib/Dialect/Triton/Transforms/Combine.cpp
+++ b/lib/Dialect/Triton/Transforms/Combine.cpp
@@ -160,18 +160,6 @@ public:
     auto broadcastRhsOp = mulOp.getOperand(1).getDefiningOp<BroadcastOp>();
     if (!broadcastRhsOp)
       return failure();
-    // broadcast operand is expand dims
-    auto expandLhsOp = broadcastLhsOp.getSrc().getDefiningOp<ExpandDimsOp>();
-    if (!expandLhsOp)
-      return failure();
-    auto expandRhsOp = broadcastRhsOp.getSrc().getDefiningOp<ExpandDimsOp>();
-    if (!expandRhsOp)
-      return failure();
-    // get not-broadcast dimensions
-    int expandLhsAxis = expandLhsOp.getAxis();
-    int expandRhsAxis = expandRhsOp.getAxis();
-    if (expandLhsAxis != 2 || expandRhsAxis != 0)
-      return failure();
     // The first operand must be broadcasted from (M, K, 1) to (M, K, N), and
     // the second operand must go from (1, K, N) to (M, K, N).
     if (!isBroadcastAlongAxis(broadcastLhsOp, 2) ||
@@ -187,12 +175,19 @@ public:
         {broadcastLhsShape[0], broadcastRhsShape[2]},
         cast<ShapedType>(broadcastLhsOp.getSrc().getType()).getElementType());
     rewriter.setInsertionPoint(op);
+    Value lhs = ReshapeOp::create(
+        rewriter, op->getLoc(),
+        broadcastLhsOp.getSrc().getType().getShape().drop_back(),
+        broadcastLhsOp.getSrc());
+    Value rhs = ReshapeOp::create(
+        rewriter, op->getLoc(),
+        broadcastRhsOp.getSrc().getType().getShape().drop_front(),
+        broadcastRhsOp.getSrc());
     auto newAcc =
         SplatOp::create(rewriter, op->getLoc(), newAccType,
                         arith::ConstantOp::create(rewriter, op->getLoc(),
                                                   rewriter.getF32FloatAttr(0)));
-    rewriter.replaceOpWithNewOp<DotOp>(op, expandLhsOp.getSrc(),
-                                       expandRhsOp.getSrc(), newAcc,
+    rewriter.replaceOpWithNewOp<DotOp>(op, lhs, rhs, newAcc,
                                        InputPrecision::IEEE, 0);
     return success();
   }

--- a/lib/Dialect/Triton/Transforms/ReorderBroadcast.cpp
+++ b/lib/Dialect/Triton/Transforms/ReorderBroadcast.cpp
@@ -217,6 +217,7 @@ public:
 
     BroadcastOp::getCanonicalizationPatterns(patterns, context);
     ExpandDimsOp::getCanonicalizationPatterns(patterns, context);
+    ReshapeOp::getCanonicalizationPatterns(patterns, context);
     // elementwise(broadcast(a)) => broadcast(elementwise(a))
     patterns.add<MoveBroadcastAfterElementwisePattern>(context);
     // elementwise(splat(a), splat(b), ...) => splat(elementwise(a, b, ...))

--- a/lib/Dialect/Triton/Transforms/RewriteTensorDescriptorToPointer.cpp
+++ b/lib/Dialect/Triton/Transforms/RewriteTensorDescriptorToPointer.cpp
@@ -82,16 +82,9 @@ Descriptor unpackDescriptor(TensorDescType type, ValueRange pack) {
 
 Value expandOffsets(OpBuilder &builder, Location loc,
                     ArrayRef<int64_t> blockShape, Value offsets, unsigned dim) {
-  Value expandedResult = offsets;
-  for (size_t j = 0; j < blockShape.size(); ++j) {
-    if (j == dim) {
-      continue;
-    }
-    expandedResult =
-        triton::ExpandDimsOp::create(builder, loc, expandedResult, j);
-  }
-
-  return expandedResult;
+  SmallVector<int64_t> shape(blockShape.size(), 1);
+  shape[dim] = blockShape[dim];
+  return triton::ReshapeOp::create(builder, loc, shape, offsets);
 }
 
 Value getExpandedOffsetWithRange(OpBuilder &builder, const Location &loc,

--- a/lib/Dialect/TritonGPU/Transforms/DecomposeScaledBlocked.cpp
+++ b/lib/Dialect/TritonGPU/Transforms/DecomposeScaledBlocked.cpp
@@ -97,45 +97,63 @@ DecomposeScaledBlocked::scaleTo16(PatternRewriter &rewriter,
 }
 
 TypedValue<RankedTensorType> DecomposeScaledBlocked::broadcastScale(
-    PatternRewriter &rewriter, DotScaledOp scaledDotOp, ModuleOp mod,
-    TypedValue<RankedTensorType> scale, int dim) const {
-  auto *ctx = rewriter.getContext();
+    PatternRewriter &rewriter, DotScaledOp scaledDotOp,
+    TypedValue<RankedTensorType> scale, int dim, Attribute dstEncoding) const {
   auto loc = scale.getLoc();
   auto scaleTy = scale.getType();
-  auto rank = scaleTy.getRank();
-  // 2.1) Expand dims along the last dimension
-  {
-    // 2.1.1) Find default encoding for ExpandDims
-    auto shape = to_vector(scaleTy.getShape());
-    shape.insert(shape.end(), 1);
-    auto nWarps = lookupNumWarps(scaledDotOp);
-    auto threadsPerWarp = TritonGPUDialect::getThreadsPerWarp(mod);
-    auto numCTAs = TritonGPUDialect::getNumCTAs(mod);
-    auto blockedEnc =
-        getDefaultBlockedEncoding(ctx, shape, nWarps, threadsPerWarp, numCTAs);
-    // 2.1.2) Cast scale16 to SliceEncoding
-    auto sliceEnc = SliceEncodingAttr::get(ctx, rank, blockedEnc);
-    auto sliceType = scaleTy.cloneWithEncoding(sliceEnc);
-    scale = ConvertLayoutOp::create(rewriter, loc, sliceType, scale);
-  }
-  auto expandScale = ExpandDimsOp::create(rewriter, loc, scale, rank);
   int32_t scaleFactor = scaledDotOp.deduceScaleFactor();
-  // 2.2) Broadcast the dimension to the microscaling factor.
-  auto scaleShape = to_vector(scaleTy.getShape());
-  scaleShape.push_back(scaleFactor);
-  auto broadcastScale = BroadcastOp::create(
-      rewriter, loc, expandScale.getType().clone(scaleShape), expandScale);
-  // 2.3) Transpose the dimension to the scaled dimension
-  auto transposeOrder = llvm::to_vector(llvm::seq<int32_t>(rank));
-  transposeOrder.insert(transposeOrder.begin() + dim + 1, rank);
-  auto transposedScale =
-      TransOp::create(rewriter, loc, broadcastScale, transposeOrder);
-  // 2.4) Reshape to the shape of v
-  scaleShape.pop_back();
-  scaleShape[dim] *= scaleFactor;
-  auto reshapeScale =
-      ReshapeOp::create(rewriter, loc, scaleShape, transposedScale);
-  return reshapeScale;
+
+  // We want to broadcast the scales along dim. To do this:
+  //   1. Introduce a size 1 dimension right after dim
+  //   2. Broadcast the new dim to the scale factor
+  //   3. Reshape it to get the result shape.
+
+  // Compute the shape after each step.
+  auto expandedShape = to_vector(scaleTy.getShape());
+  expandedShape.insert(expandedShape.begin() + dim + 1, 1);
+  auto broadcastShape = expandedShape;
+  broadcastShape[dim + 1] = scaleFactor;
+  auto resultShape = to_vector(scaleTy.getShape());
+  resultShape[dim] *= scaleFactor;
+
+  // It is more efficient to perform a layout conversion before broadcasting,
+  // since there are fewer elements. Infer the source encoding that will produce
+  // dstEncoding after the broadcast and reshape.
+  auto interface = cast<DialectInferLayoutInterface>(&dstEncoding.getDialect());
+  Attribute broadcastEncoding;
+  auto result = interface->inferReshapeOpEncoding(
+      resultShape, dstEncoding, broadcastShape, broadcastEncoding,
+      /*allowReorder=*/false, loc);
+  assert(succeeded(result));
+  Attribute srcEncoding;
+  result = interface->inferReshapeOpEncoding(expandedShape, broadcastEncoding,
+                                             scaleTy.getShape(), srcEncoding,
+                                             /*allowReorder=*/false, loc);
+  assert(succeeded(result));
+
+  auto srcType = scaleTy.cloneWithEncoding(srcEncoding);
+
+  // Convert the scales to the desired type.
+  scale = ConvertLayoutOp::create(rewriter, loc, srcType, scale);
+
+  // Introduce the new dimension.
+  auto expandType = RankedTensorType::get(
+      expandedShape, scaleTy.getElementType(), broadcastEncoding);
+  // We know this layout avoids having any layout conversions after we expand
+  // the scales, so mark the layout as efficient. Otherwise, forward layout
+  // propagation may try to sink the convert layout.
+  auto expandScale = ReshapeOp::create(
+      rewriter, loc, expandType, scale,
+      /*allow_reorder=*/nullptr, /*efficient_layout=*/rewriter.getUnitAttr());
+  // Broadcast the dimension to the microscaling factor.
+  auto broadcastType = RankedTensorType::get(
+      broadcastShape, scaleTy.getElementType(), broadcastEncoding);
+  auto broadcastScale =
+      BroadcastOp::create(rewriter, loc, broadcastType, expandScale);
+  auto resultType =
+      RankedTensorType::get(resultShape, scaleTy.getElementType(), dstEncoding);
+  // Reshape to fold in the broadcasted dimension and get the final result.
+  return ReshapeOp::create(rewriter, loc, resultType, broadcastScale);
 }
 
 TypedValue<RankedTensorType> DecomposeScaledBlocked::maskNan(
@@ -148,7 +166,6 @@ TypedValue<RankedTensorType> DecomposeScaledBlocked::maskNan(
 
   // Implement tl.where(scale == 0xFF, float("nan"), mxfp)
   auto loc = scale.getLoc();
-  auto mod = scaledDotOp->getParentOfType<ModuleOp>();
 
   // Scale is NaN
   auto scaleTy = scale.getType();
@@ -170,11 +187,8 @@ TypedValue<RankedTensorType> DecomposeScaledBlocked::maskNan(
                               constFF)
             .getResult());
   }
-  auto cond = broadcastScale(rewriter, scaledDotOp, mod, scaleIsNan, dim);
-  // Make scale is NaN compatible with mxfp
-  auto condTy = cond.getType();
-  condTy = condTy.cloneWithEncoding(mxfp.getType().getEncoding());
-  cond = ConvertLayoutOp::create(rewriter, loc, condTy, cond);
+  auto cond = broadcastScale(rewriter, scaledDotOp, scaleIsNan, dim,
+                             mxfp.getType().getEncoding());
 
   // Create NaN
   auto mxfpTy = mxfp.getType();
@@ -232,7 +246,6 @@ TypedValue<RankedTensorType> DecomposeScaledBlocked::extendAndBroadcastScale(
     TypedValue<RankedTensorType> &scale, FloatType computeType,
     RankedTensorType dstType, int opIdx) const {
   auto loc = scale.getLoc();
-  auto mod = scaledDotOp->getParentOfType<ModuleOp>();
   auto v = opIdx == 0 ? scaledDotOp.getA() : scaledDotOp.getB();
   auto rank = v.getType().getRank();
   auto kDim = opIdx == 0 ? rank - 1 : rank - 2;
@@ -251,8 +264,8 @@ TypedValue<RankedTensorType> DecomposeScaledBlocked::extendAndBroadcastScale(
   auto scale16 = scaleTo16(rewriter, scale, computeType);
 
   // 2) Broadcast scale to the same shape as v and convert the layout
-  auto reshapeScale = broadcastScale(rewriter, scaledDotOp, mod, scale16, kDim);
-  return ConvertLayoutOp::create(rewriter, loc, dstType, reshapeScale);
+  return broadcastScale(rewriter, scaledDotOp, scale16, kDim,
+                        dstType.getEncoding());
 }
 
 TypedValue<RankedTensorType>

--- a/lib/Dialect/TritonGPU/Transforms/RemoveLayoutConversions.cpp
+++ b/lib/Dialect/TritonGPU/Transforms/RemoveLayoutConversions.cpp
@@ -339,6 +339,9 @@ SmallVector<Value> LayoutPropagation::propagateToUsers(Value value,
         continue;
       }
     }
+    if (auto reshapeOp = dyn_cast<ReshapeOp>(user);
+        reshapeOp && reshapeOp.getEfficientLayout())
+      continue;
     if (user->hasTrait<OpTrait::SameOperandsAndResultEncoding>() ||
         user->hasTrait<OpTrait::Elementwise>() ||
         isa<ReduceOp, ExpandDimsOp, ReshapeOp, TransOp, JoinOp, SplitOp,

--- a/lib/Dialect/TritonGPU/Transforms/RemoveLayoutConversions.cpp
+++ b/lib/Dialect/TritonGPU/Transforms/RemoveLayoutConversions.cpp
@@ -1397,6 +1397,8 @@ bool LayoutRematerialization::hoistConvertOnTopOfExtOrBroadcast(
             ExpandDimsOp>(op)) {
       return true;
     }
+    if (auto reshapeOp = dyn_cast<ReshapeOp>(op))
+      return reshapeOp.getExpandDimsAxis().has_value();
     if (auto fpToFpOp = dyn_cast<FpToFpOp>(op)) {
       auto srcType = cast<RankedTensorType>(fpToFpOp.getOperand().getType());
       return getElementBitWidth(srcType) <

--- a/lib/Dialect/TritonInstrument/Transforms/FpSanitizer.cpp
+++ b/lib/Dialect/TritonInstrument/Transforms/FpSanitizer.cpp
@@ -1427,10 +1427,6 @@ Value loadScaledScaleK32(PatternRewriter &rewriter, Location loc, bool isLhs,
             : SmallVector<int64_t>{groups, repeat, targetTy.getShape()[1]};
   int64_t expandAxis = isLhs ? 2 : 1;
 
-  auto broadcastLayout = getOptimizedBlockedEncoding(
-      rewriter, broadcastShape, scaleTileTy.getElementType());
-  auto compactSliceLayout = ttg::SliceEncodingAttr::get(
-      rewriter.getContext(), expandAxis, broadcastLayout);
   auto compactLoadLayout = getOptimizedBlockedEncoding(
       rewriter, compactShape, scaleTileTy.getElementType());
   auto compactLoadTy = RankedTensorType::get(
@@ -1451,12 +1447,10 @@ Value loadScaledScaleK32(PatternRewriter &rewriter, Location loc, bool isLhs,
                                        /*stride1=*/isLhs ? scaleStride : 1);
   compact = castDotScaledScaleToComputePayload(rewriter, loc, compact,
                                                scale.computeElem);
-  auto compactSliceTy = cast<RankedTensorType>(compact.getType())
-                            .cloneWithEncoding(compactSliceLayout);
-  compact =
-      ttg::ConvertLayoutOp::create(rewriter, loc, compactSliceTy, compact);
 
-  Value expanded = tt::ExpandDimsOp::create(rewriter, loc, compact, expandAxis);
+  auto expandedShape = compactShape;
+  expandedShape.insert(expandedShape.begin() + expandAxis, 1);
+  Value expanded = tt::ReshapeOp::create(rewriter, loc, expandedShape, compact);
   auto broadcastTy =
       cast<RankedTensorType>(expanded.getType()).clone(broadcastShape);
   Value broadcast =

--- a/lib/Dialect/TritonNvidiaGPU/Transforms/PlanCTA.cpp
+++ b/lib/Dialect/TritonNvidiaGPU/Transforms/PlanCTA.cpp
@@ -26,6 +26,7 @@
 #include "mlir/Support/LLVM.h"
 #include "triton/Dialect/Triton/IR/Dialect.h"
 #include "triton/Dialect/TritonGPU/IR/Dialect.h"
+#include "triton/Dialect/TritonGPU/Transforms/Utility.h"
 #include "triton/Dialect/TritonNvidiaGPU/IR/Dialect.h"
 #include "triton/Dialect/TritonNvidiaGPU/Transforms/Passes.h"
 #include "llvm/ADT/STLExtras.h"
@@ -123,6 +124,8 @@ private:
   bool processBroadcast(triton::BroadcastOp broadcast, Attribute layout);
   bool processExpandDimsBackward(triton::ExpandDimsOp expandDims,
                                  ttg::DistributedEncodingTrait newResultLayout);
+  bool processReshapeBackward(triton::ReshapeOp reshape,
+                              Attribute newResultLayout);
 
   bool processConvertLayoutBackward(ttg::ConvertLayoutOp convertLayout,
                                     CastOp cast);
@@ -419,6 +422,8 @@ bool CTAPlanner::propagateBackward(CastOp cast) {
       processBroadcast(broadcast, layout);
     } else if (auto expandDims = llvm::dyn_cast<triton::ExpandDimsOp>(op)) {
       processExpandDimsBackward(expandDims, layout);
+    } else if (auto reshape = llvm::dyn_cast<triton::ReshapeOp>(op)) {
+      processReshapeBackward(reshape, layout);
     } else if (auto ifOp = llvm::dyn_cast<scf::IfOp>(op)) {
       processIfOpBackward(ifOp, cast);
     } else if (auto forOp = llvm::dyn_cast<scf::ForOp>(op)) {
@@ -697,6 +702,13 @@ bool CTAPlanner::processExpandDimsBackward(
   auto newSrcLayout = ttg::SliceEncodingAttr::get(
       newResultLayout.getContext(), expandDims.getAxis(), newResultLayout);
   insertCasts(expandDims.getOperation(), {newSrcLayout}, {newResultLayout});
+  return true;
+}
+
+bool CTAPlanner::processReshapeBackward(triton::ReshapeOp reshape,
+                                        Attribute newResultLayout) {
+  auto newSrcLayout = inferSrcEncoding(reshape, newResultLayout);
+  insertCasts(reshape.getOperation(), {newSrcLayout}, {newResultLayout});
   return true;
 }
 

--- a/test/Triton/combine.mlir
+++ b/test/Triton/combine.mlir
@@ -366,6 +366,14 @@ tt.func @test_canonicalize_reshape(%arg0: tensor<8xf32>, %arg1: tensor<f32>) -> 
     tt.return %reshape1, %reshape2, %add, %view : tensor<4x2xf32>, tensor<2x2x2xf32>, tensor<8xf32>, tensor<2x2x2xf32>
 }
 
+// CHECK-LABEL: @test_canonicalize_reshape_expand_dims
+tt.func @test_canonicalize_reshape_expand_dims(%arg0: tensor<8xf32>) -> tensor<8xf32> {
+    // CHECK-NEXT: tt.return %arg0 : tensor<8xf32>
+    %0 = tt.expand_dims %arg0 {axis = 0 : i32} : tensor<8xf32> -> tensor<1x8xf32>
+    %1 = tt.reshape %0 : tensor<1x8xf32> -> tensor<8xf32>
+    tt.return %1 : tensor<8xf32>
+}
+
 // CHECK-LABEL: @test_canonicalize_broadcast
 tt.func @test_canonicalize_broadcast(%arg0: tensor<1x1x8xf32>, %arg1: tensor<f32>) -> (tensor<4x2x8xf32>, tensor<8x8xf32>, tensor<1x1x8xf32>) {
     %broadcast0 = tt.broadcast %arg0 : tensor<1x1x8xf32> -> tensor<1x2x8xf32>
@@ -490,6 +498,24 @@ tt.func @test_combine_broadcast_mul_reduce(%arg0: tensor<32x16xf32>, %arg1: tens
         tt.reduce.return %6 : f32
     }) : (tensor<32x16x32xf32>) -> tensor<32x32xf32>
     tt.return %5 : tensor<32x32xf32>
+}
+
+// CHECK-LABEL: @test_combine_broadcast_mul_reduce_reshape
+tt.func @test_combine_broadcast_mul_reduce_reshape(%arg0: tensor<32x16x1xf32>, %arg1: tensor<1x16x32xf32>) -> tensor<32x32xf32> {
+    // CHECK: %[[CST:.*]] = arith.constant dense<0.000000e+00> : tensor<32x32xf32>
+    // CHECK: %[[LHS:.*]] = tt.reshape %arg0 : tensor<32x16x1xf32> -> tensor<32x16xf32>
+    // CHECK: %[[RHS:.*]] = tt.reshape %arg1 : tensor<1x16x32xf32> -> tensor<16x32xf32>
+    // CHECK: %[[RES:.*]] = tt.dot %[[LHS]], %[[RHS]], %[[CST]] : tensor<32x16xf32> * tensor<16x32xf32> -> tensor<32x32xf32>
+    // CHECK: tt.return %[[RES]] : tensor<32x32xf32>
+    %0 = tt.broadcast %arg0 : tensor<32x16x1xf32> -> tensor<32x16x32xf32>
+    %1 = tt.broadcast %arg1 : tensor<1x16x32xf32> -> tensor<32x16x32xf32>
+    %2 = arith.mulf %0, %1 : tensor<32x16x32xf32>
+    %3 = "tt.reduce"(%2) <{axis = 1 : i32}> ({
+    ^bb0(%arg2: f32, %arg3: f32):
+        %4 = arith.addf %arg2, %arg3 : f32
+        tt.reduce.return %4 : f32
+    }) : (tensor<32x16x32xf32>) -> tensor<32x32xf32>
+    tt.return %3 : tensor<32x32xf32>
 }
 
 // CHECK-LABEL: @test_combine_broadcast_mul_reduce_extra_broadcast

--- a/test/Triton/rewrite-tensor-descriptor-to-pointer.mlir
+++ b/test/Triton/rewrite-tensor-descriptor-to-pointer.mlir
@@ -30,12 +30,12 @@ module {
 // CHECK-DAG: %[[VAL4:.*]] = tt.make_range {end = 128 : i32, start = 0 : i32}
 // CHECK-DAG: %[[VAL5:.*]] = arith.extsi %[[VAL4]] :
 // CHECK-DAG: %[[VAL6:.*]] = arith.addi %[[VAL3]], %[[VAL5]] :
-// CHECK-DAG: %[[VAL7:.*]] = tt.expand_dims %[[VAL6]] {axis = 1 : i32}
+// CHECK-DAG: %[[VAL7:.*]] = tt.reshape %[[VAL6]]
 // CHECK-DAG: %[[VAL8:.*]] = tt.broadcast %[[VAL7]] : tensor<128x1xi64> -> tensor<128x128xi64>
 // CHECK-DAG: %[[VAL9:.*]] = tt.addptr %[[VAL2]], %[[VAL8]] :
 // CHECK-DAG: %[[VAL10:.*]] = tt.splat %[[VAL1]] :
 // CHECK-DAG: %[[VAL11:.*]] = arith.addi %[[VAL10]], %[[VAL5]] :
-// CHECK-DAG: %[[VAL12:.*]] = tt.expand_dims %[[VAL11]] {axis = 0 : i32}
+// CHECK-DAG: %[[VAL12:.*]] = tt.reshape %[[VAL11]]
 // CHECK-DAG: %[[VAL13:.*]] = arith.muli %[[VAL12]], %[[CST3]] :
 // CHECK-DAG: %[[VAL14:.*]] = tt.broadcast %[[VAL13]] : tensor<1x128xi64> -> tensor<128x128xi64>
 // CHECK-DAG: %[[VAL15:.*]] = tt.addptr %[[VAL9]], %[[VAL14]] :
@@ -85,12 +85,12 @@ module {
 // CHECK-DAG: %[[VAL4:.*]] = tt.make_range {end = 128 : i32, start = 0 : i32}
 // CHECK-DAG: %[[VAL5:.*]] = arith.extsi %[[VAL4]] :
 // CHECK-DAG: %[[VAL6:.*]] = arith.addi %[[VAL3]], %[[VAL5]] :
-// CHECK-DAG: %[[VAL7:.*]] = tt.expand_dims %[[VAL6]] {axis = 1 : i32}
+// CHECK-DAG: %[[VAL7:.*]] = tt.reshape %[[VAL6]]
 // CHECK-DAG: %[[VAL8:.*]] = tt.broadcast %[[VAL7]] : tensor<128x1xi64> -> tensor<128x128xi64>
 // CHECK-DAG: %[[VAL9:.*]] = tt.addptr %[[VAL2]], %[[VAL8]] :
 // CHECK-DAG: %[[VAL10:.*]] = tt.splat %[[VAL1]] :
 // CHECK-DAG: %[[VAL11:.*]] = arith.addi %[[VAL10]], %[[VAL5]] :
-// CHECK-DAG: %[[VAL12:.*]] = tt.expand_dims %[[VAL11]] {axis = 0 : i32}
+// CHECK-DAG: %[[VAL12:.*]] = tt.reshape %[[VAL11]]
 // CHECK-DAG: %[[VAL13:.*]] = arith.muli %[[VAL12]], %[[CST2]] :
 // CHECK-DAG: %[[VAL14:.*]] = tt.broadcast %[[VAL13]] : tensor<1x128xi64> -> tensor<128x128xi64>
 // CHECK-DAG: %[[VAL15:.*]] = tt.addptr %[[VAL9]], %[[VAL14]] :

--- a/test/TritonGPU/amd/accelerate-amd-matmul-mfma-decompose-scaled-dot.mlir
+++ b/test/TritonGPU/amd/accelerate-amd-matmul-mfma-decompose-scaled-dot.mlir
@@ -11,17 +11,16 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.targ
       %arg2: tensor<32x2x!tt.ptr<i8>, #blocked1>,
       %arg3: tensor<32x32x!tt.ptr<f32>, #blocked>
     ) {
-    // CHECK: %[[CST:.*]] = arith.constant dense<7> : tensor<2x32xi16, #ttg.slice<{dim = 2, parent = #linear{{.*}}}>>
+    // CHECK: %[[CST:.*]] = arith.constant dense<7> : tensor<2x32xi16, #linear{{.*}}>
     // CHECK: %[[B:.*]] = ttg.convert_layout %{{.*}} : tensor<64x32xf8E4M3FN, #blocked{{.*}}> -> tensor<64x32xf8E4M3FN, #ttg.dot_op<{opIdx = 1, parent = #mma, kWidth = 8}>>
     // CHECK: %[[S:.*]] = ttg.convert_layout %{{.*}} : tensor<32x2xi8, #blocked{{.*}}> -> tensor<32x2xi8, #linear{{.*}}>
     // CHECK: %[[TS:.*]] = tt.trans %[[S]] {order = array<i32: 1, 0>}
     // CHECK: %[[ES:.*]] = arith.extui %[[TS]]
     // CHECK: %[[SHS:.*]] = arith.shli %[[ES]], %[[CST]]
-    // CHECK: %[[BS:.*]] = tt.bitcast %[[SHS]] : tensor<2x32xi16, #ttg.slice<{dim = 2, parent = #linear{{.*}}}>> -> tensor<2x32xbf16, #ttg.slice<{dim = 2, parent = #linear{{.*}}}>>
-    // CHECK: %[[EPS:.*]] = tt.expand_dims %[[BS]] {axis = 2 : i32} : tensor<2x32xbf16, #ttg.slice<{dim = 2, parent = #linear{{.*}}}>> -> tensor<2x32x1xbf16, #linear{{.*}}>
-    // CHECK: %[[BCS:.*]] = tt.broadcast %[[EPS]] : tensor<2x32x1xbf16, #linear{{.*}}> -> tensor<2x32x32xbf16, #linear{{.*}}>
-    // CHECK: %[[TBCS:.*]] = tt.trans %[[BCS]] {order = array<i32: 0, 2, 1>} : tensor<2x32x32xbf16, #linear{{.*}}> -> tensor<2x32x32xbf16, #linear{{.*}}>
-    // CHECK: %[[RTBCS:.*]] = tt.reshape %[[TBCS]] : tensor<2x32x32xbf16, #linear{{.*}}> -> tensor<64x32xbf16, #ttg.dot_op<{opIdx = 1, parent = #mma, kWidth = 8}>>
+    // CHECK: %[[BS:.*]] = tt.bitcast %[[SHS]] : tensor<2x32xi16, #linear{{.*}}> -> tensor<2x32xbf16, #linear{{.*}}>
+    // CHECK: %[[EPS:.*]] = tt.reshape %[[BS]] efficient_layout : tensor<2x32xbf16, #linear{{.*}}> -> tensor<2x1x32xbf16, #linear{{.*}}>
+    // CHECK: %[[BCS:.*]] = tt.broadcast %[[EPS]] : tensor<2x1x32xbf16, #linear{{.*}}> -> tensor<2x32x32xbf16, #linear{{.*}}>
+    // CHECK: %[[RTBCS:.*]] = tt.reshape %[[BCS]] : tensor<2x32x32xbf16, #linear{{.*}}> -> tensor<64x32xbf16, #ttg.dot_op<{opIdx = 1, parent = #mma, kWidth = 8}>>
     // CHECK: %[[UB:.*]] = amdg.scaled_upcast_fp8 %[[B]] scale %[[RTBCS]] : tensor<64x32xf8E4M3FN, #ttg.dot_op<{opIdx = 1, parent = #mma, kWidth = 8}>>, tensor<64x32xbf16, #ttg.dot_op<{opIdx = 1, parent = #mma, kWidth = 8}>> -> tensor<64x32xbf16, #ttg.dot_op<{opIdx = 1, parent = #mma, kWidth = 8}>>
     // CHECK: %[[SELECTEDB:.*]] = arith.select %{{.*}}, %{{.*}}, %[[UB]] : tensor<64x32xi1, #ttg.dot_op<{opIdx = 1, parent = #mma, kWidth = 8}>>, tensor<64x32xbf16, #ttg.dot_op<{opIdx = 1, parent = #mma, kWidth = 8}>>
     // CHECK: %[[A:.*]] = ttg.convert_layout %{{.*}} : tensor<32x64xbf16, #blocked{{.*}}> -> tensor<32x64xbf16, #ttg.dot_op<{opIdx = 0, parent = #mma, kWidth = 8}>>
@@ -74,17 +73,16 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.targ
       %arg2: tensor<32x2x!tt.ptr<i8>, #blocked1>,
       %arg3: tensor<32x32x!tt.ptr<f32>, #blocked>
     ) {
-    // CHECK: %[[CST:.*]] = arith.constant dense<7> : tensor<2x32xi16, #ttg.slice<{dim = 2, parent = #linear{{.*}}}>>
+    // CHECK: %[[CST:.*]] = arith.constant dense<7> : tensor<2x32xi16, #linear{{.*}}>
     // CHECK: %[[B:.*]] = ttg.convert_layout %{{.*}} : tensor<32x32xi8, #blocked{{.*}}> -> tensor<32x32xi8, #ttg.dot_op<{opIdx = 1, parent = #mma, kWidth = 4}>>
     // CHECK: %[[S:.*]] = ttg.convert_layout %{{.*}} : tensor<32x2xi8, #blocked{{.*}}> -> tensor<32x2xi8, #linear{{.*}}>
     // CHECK: %[[TS:.*]] = tt.trans %[[S]] {order = array<i32: 1, 0>}
     // CHECK: %[[ES:.*]] = arith.extui %[[TS]]
     // CHECK: %[[SHS:.*]] = arith.shli %[[ES]], %[[CST]]
-    // CHECK: %[[BS:.*]] = tt.bitcast %[[SHS]] : tensor<2x32xi16, #ttg.slice<{dim = 2, parent = #linear{{.*}}}>> -> tensor<2x32xbf16, #ttg.slice<{dim = 2, parent = #linear{{.*}}}>>
-    // CHECK: %[[EPS:.*]] = tt.expand_dims %[[BS]] {axis = 2 : i32} : tensor<2x32xbf16, #ttg.slice<{dim = 2, parent = #linear{{.*}}}>> -> tensor<2x32x1xbf16, #linear{{.*}}>
-    // CHECK: %[[BCS:.*]] = tt.broadcast %[[EPS]] : tensor<2x32x1xbf16, #linear{{.*}}> -> tensor<2x32x32xbf16, #linear{{.*}}>
-    // CHECK: %[[TBCS:.*]] = tt.trans %[[BCS]] {order = array<i32: 0, 2, 1>} : tensor<2x32x32xbf16, #linear{{.*}}> -> tensor<2x32x32xbf16, #linear{{.*}}>
-    // CHECK: %[[RTBCS:.*]] = tt.reshape %[[TBCS]] : tensor<2x32x32xbf16, #linear{{.*}}> -> tensor<64x32xbf16, #ttg.dot_op<{opIdx = 1, parent = #mma, kWidth = 8}>>
+    // CHECK: %[[BS:.*]] = tt.bitcast %[[SHS]] : tensor<2x32xi16, #linear{{.*}}> -> tensor<2x32xbf16, #linear{{.*}}>
+    // CHECK: %[[EPS:.*]] = tt.reshape %[[BS]] efficient_layout : tensor<2x32xbf16, #linear{{.*}}> -> tensor<2x1x32xbf16, #linear{{.*}}>
+    // CHECK: %[[BCS:.*]] = tt.broadcast %[[EPS]] : tensor<2x1x32xbf16, #linear{{.*}}> -> tensor<2x32x32xbf16, #linear{{.*}}>
+    // CHECK: %[[RTBCS:.*]] = tt.reshape %[[BCS]] : tensor<2x32x32xbf16, #linear{{.*}}> -> tensor<64x32xbf16, #ttg.dot_op<{opIdx = 1, parent = #mma, kWidth = 8}>>
     // CHECK: %[[UB:.*]] = amdg.scaled_upcast_fp4 %[[B]] scale %[[RTBCS]] {axis = 0 : i32} : tensor<32x32xi8, #ttg.dot_op<{opIdx = 1, parent = #mma, kWidth = 4}>>, tensor<64x32xbf16, #ttg.dot_op<{opIdx = 1, parent = #mma, kWidth = 8}>> -> tensor<64x32xbf16, #ttg.dot_op<{opIdx = 1, parent = #mma, kWidth = 8}>>
     // CHECK: %[[A:.*]] = ttg.convert_layout %{{.*}} : tensor<32x64xbf16, #blocked{{.*}}> -> tensor<32x64xbf16, #ttg.dot_op<{opIdx = 0, parent = #mma, kWidth = 8}>>
     // CHECK: %{{.*}} = tt.dot %[[A]], %[[UB]], %{{.*}} : tensor<32x64xbf16, #ttg.dot_op<{opIdx = 0, parent = #mma, kWidth = 8}>> * tensor<64x32xbf16, #ttg.dot_op<{opIdx = 1, parent = #mma, kWidth = 8}>> -> tensor<32x32xf32, #mma>

--- a/test/TritonGPU/amd/accelerate-amd-matmul-wmma-gfx1250.mlir
+++ b/test/TritonGPU/amd/accelerate-amd-matmul-wmma-gfx1250.mlir
@@ -200,7 +200,7 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.targ
 #blocked = #ttg.blocked<{sizePerThread = [1, 1], threadsPerWarp = [1, 32], warpsPerCTA = [4, 1], order = [1, 0]}>
 #blocked2 = #ttg.blocked<{sizePerThread = [1, 1], threadsPerWarp = [8, 4], warpsPerCTA = [4, 1], order = [1, 0]}>
 #blocked4 = #ttg.blocked<{sizePerThread = [1, 1], threadsPerWarp = [1, 32], warpsPerCTA = [1, 4], order = [1, 0]}>
-// CHECK{LITERAL}: #linear = #ttg.linear<{register = [[0, 1], [0, 2], [0, 4], [0, 8], [0, 16]], lane = [[0, 32], [0, 64], [1, 0], [2, 0], [4, 0]], warp = [[8, 0], [16, 0]], block = []}>
+// CHECK{LITERAL}: #linear = #ttg.linear<{register = [[1, 0], [2, 0], [4, 0], [8, 0], [16, 0]], lane = [[0, 0], [0, 0], [0, 0], [0, 0], [0, 0]], warp = [[0, 1], [0, 2]], block = []}>
 // CHECK-LABEL: wmma_dot_scaled_mxfp8_bf16
 module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.target = "hip:gfx1250", "ttg.threads-per-warp" = 32 : i32} {
   tt.func public @wmma_dot_scaled_mxfp8_bf16(
@@ -210,9 +210,9 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.targ
       %output: tensor<32x32x!tt.ptr<f32>, #blocked>
       ) {
     // CHECK: tt.load %arg1 {amdg.decomposed_dot_scaled_source = true} : tensor<32x4x!tt.ptr<i8>, #blocked1>
-    // CHECK: %[[SCALE:.*]] = tt.reshape {{.*}} : tensor<32x4x32xi8, #blocked3> -> tensor<32x128xi8, #linear>
-    // CHECK: %[[CVT0:.*]]  = ttg.convert_layout %[[SCALE]] : tensor<32x128xi8, #linear> -> tensor<32x128xi8, #blocked>
-    // CHECK: %[[UPCASTED:.*]] = amdg.scaled_upcast_fp8 {{.*}} scale %[[CVT0]] : tensor<32x128xf8E4M3FN, #blocked>, tensor<32x128xi8, #blocked> -> tensor<32x128xbf16, #blocked>
+    // CHECK: %[[SCALE_CVT:.*]] = ttg.convert_layout {{.*}} : tensor<32x4xi8, #blocked1> -> tensor<32x4xi8, #linear>
+    // CHECK: %[[SCALE:.*]] = tt.reshape {{.*}} : tensor<32x4x32xi8, #blocked3> -> tensor<32x128xi8, #blocked>
+    // CHECK: %[[UPCASTED:.*]] = amdg.scaled_upcast_fp8 {{.*}} scale %[[SCALE]] : tensor<32x128xf8E4M3FN, #blocked>, tensor<32x128xi8, #blocked> -> tensor<32x128xbf16, #blocked>
     // CHECK: %[[SEL:.*]] = arith.select {{.*}}, {{.*}}, %[[UPCASTED]]
     // CHECK: %[[CVT1:.*]] = ttg.convert_layout %[[SEL]] : tensor<32x128xbf16, #blocked> -> tensor<32x128xbf16, #ttg.dot_op<{opIdx = 0, parent = #blocked2}>>
     // CHECK: %[[OPND0:.*]] = ttg.convert_layout %[[CVT1]] : tensor<32x128xbf16, #ttg.dot_op<{opIdx = 0, parent = #blocked2}>> -> tensor<32x128xbf16, #ttg.dot_op<{opIdx = 0, parent = #mma, kWidth = 8}>>
@@ -233,7 +233,7 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.targ
 #blocked = #ttg.blocked<{sizePerThread = [1, 1], threadsPerWarp = [1, 32], warpsPerCTA = [4, 1], order = [1, 0]}>
 #blocked2 = #ttg.blocked<{sizePerThread = [1, 1], threadsPerWarp = [8, 4], warpsPerCTA = [4, 1], order = [1, 0]}>
 #blocked4 = #ttg.blocked<{sizePerThread = [1, 1], threadsPerWarp = [1, 32], warpsPerCTA = [1, 4], order = [1, 0]}>
-// CHECK{LITERAL}: #linear = #ttg.linear<{register = [[1, 0], [2, 0], [4, 0], [8, 0], [16, 0]], lane = [[0, 1], [0, 2], [0, 4], [0, 8], [0, 16]], warp = [[32, 0], [64, 0]], block = []}>
+// CHECK{LITERAL}: #linear = #ttg.linear<{register = [[1, 0], [2, 0]], lane = [[0, 1], [0, 2], [0, 4], [0, 8], [0, 16]], warp = [[0, 0], [0, 0]], block = []}>
 // CHECK-LABEL: wmma_dot_scaled_f16_mxfp8
 module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.target = "hip:gfx1250", "ttg.threads-per-warp" = 32 : i32} {
   tt.func public @wmma_dot_scaled_f16_mxfp8(
@@ -242,10 +242,9 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.targ
       %arg2: tensor<128x32x!tt.ptr<f8E5M2>, #blocked>,
       %output: tensor<32x32x!tt.ptr<f32>, #blocked>
       ) {
-    // CHECK: %[[TRANS:.*]] = tt.trans {{.*}} {order = array<i32: 0, 2, 1>} : tensor<4x32x32xi8, #blocked4> -> tensor<4x32x32xi8, #blocked5>
-    // CHECK: %[[SCALE:.*]] = tt.reshape %[[TRANS]] : tensor<4x32x32xi8, #blocked5> -> tensor<128x32xi8, #linear>
-    // CHECK: %[[CVT0:.*]] = ttg.convert_layout %[[SCALE]] : tensor<128x32xi8, #linear> -> tensor<128x32xi8, #blocked2>
-    // CHECK: %[[UPCASTED:.*]] = amdg.scaled_upcast_fp8 {{.*}} scale %[[CVT0]] : tensor<128x32xf8E5M2, #blocked2>, tensor<128x32xi8, #blocked2> -> tensor<128x32xf16, #blocked2>
+    // CHECK: %[[SCALE_CVT:.*]] = ttg.convert_layout {{.*}} : tensor<4x32xi8, #blocked3> -> tensor<4x32xi8, #linear>
+    // CHECK: %[[SCALE:.*]] = tt.reshape {{.*}} : tensor<4x32x32xi8, #blocked4> -> tensor<128x32xi8, #blocked2>
+    // CHECK: %[[UPCASTED:.*]] = amdg.scaled_upcast_fp8 {{.*}} scale %[[SCALE]] : tensor<128x32xf8E5M2, #blocked2>, tensor<128x32xi8, #blocked2> -> tensor<128x32xf16, #blocked2>
     // CHECK: %[[SEL:.*]] = arith.select {{.*}}, %cst, %[[UPCASTED]] : tensor<128x32xi1, #blocked2>, tensor<128x32xf16, #blocked2>
     // CHECK: %[[CVT1:.*]] = ttg.convert_layout %[[SEL]] : tensor<128x32xf16, #blocked2> -> tensor<128x32xf16, #ttg.dot_op<{opIdx = 1, parent = #blocked2}>>
     // CHECK: %[[OPND1:.*]] = ttg.convert_layout %[[CVT1]] : tensor<128x32xf16, #ttg.dot_op<{opIdx = 1, parent = #blocked2}>> -> tensor<128x32xf16, #ttg.dot_op<{opIdx = 1, parent = #mma, kWidth = 8}>>
@@ -267,7 +266,7 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.targ
 #blocked1 = #ttg.blocked<{sizePerThread = [1, 2], threadsPerWarp = [4, 8], warpsPerCTA = [4, 1], order = [1, 0]}>
 #blocked2 = #ttg.blocked<{sizePerThread = [1, 1], threadsPerWarp = [16, 2], warpsPerCTA = [4, 1], order = [1, 0]}>
 #blocked5 = #ttg.blocked<{sizePerThread = [1, 1], threadsPerWarp = [1, 32], warpsPerCTA = [4, 1], order = [1, 0]}>
-// CHECK{LITERAL}: #linear = #ttg.linear<{register = [[0, 1], [0, 2], [0, 4], [0, 8], [0, 16]], lane = [[0, 32], [1, 0], [2, 0], [4, 0], [8, 0]], warp = [[0, 0], [0, 0]], block = []}>
+// CHECK{LITERAL}: #linear = #ttg.linear<{register = [[0, 0], [4, 0], [8, 0]], lane = [[0, 0], [0, 0], [0, 0], [0, 0], [0, 1]], warp = [[1, 0], [2, 0]], block = []}>
 // CHECK-LABEL: wmma_dot_scaled_mxfp4_bf16
 module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.target = "hip:gfx1250", "ttg.threads-per-warp" = 32 : i32} {
   tt.func public @wmma_dot_scaled_mxfp4_bf16(
@@ -277,9 +276,9 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.targ
       %output: tensor<16x16x!tt.ptr<f32>, #blocked>
       ) {
     // CHECK: tt.load %arg1 {amdg.decomposed_dot_scaled_source = true} : tensor<16x2x!tt.ptr<i8>, #blocked1>
-    // CHECK: %[[SCALE:.*]] = tt.reshape {{.*}} : tensor<16x2x32xi8, #[[RESHAPE_LAYOUT:.+]]> -> tensor<16x64xi8, #linear>
-    // CHECK: %[[CVT0:.*]] = ttg.convert_layout %[[SCALE]] : tensor<16x64xi8, #linear> -> tensor<16x64xi8, #[[UPCAST_LAYOUT:.+]]>
-    // CHECK: %[[UPCASTED:.*]] = amdg.scaled_upcast_fp4 {{.+}} scale %[[CVT0]] {axis = 1 : i32} : tensor<16x32xi8, #blocked>, tensor<16x64xi8, #[[UPCAST_LAYOUT]]> -> tensor<16x64xbf16, #[[UPCAST_LAYOUT]]>
+    // CHECK: %[[SCALE_CVT:.*]] = ttg.convert_layout {{.*}} : tensor<16x2xi8, #blocked1> -> tensor<16x2xi8, #linear>
+    // CHECK: %[[SCALE:.*]] = tt.reshape {{.*}} : tensor<16x2x32xi8, #[[RESHAPE_LAYOUT:.+]]> -> tensor<16x64xi8, #[[UPCAST_LAYOUT:.+]]>
+    // CHECK: %[[UPCASTED:.*]] = amdg.scaled_upcast_fp4 {{.+}} scale %[[SCALE]] {axis = 1 : i32} : tensor<16x32xi8, #blocked>, tensor<16x64xi8, #[[UPCAST_LAYOUT]]> -> tensor<16x64xbf16, #[[UPCAST_LAYOUT]]>
     // CHECK: %[[SEL:.*]] = arith.select {{.*}}, %{{.*}}, %[[UPCASTED]] : tensor<16x64xi1, #[[UPCAST_LAYOUT]]>, tensor<16x64xbf16, #[[UPCAST_LAYOUT]]>
     // CHECK: %[[CVT1:.*]] = ttg.convert_layout %[[SEL]] : tensor<16x64xbf16, #[[UPCAST_LAYOUT]]> -> tensor<16x64xbf16, #ttg.dot_op<{opIdx = 0, parent = #blocked2}>>
     // CHECK: %[[OPND0:.*]] = ttg.convert_layout %[[CVT1]] : tensor<16x64xbf16, #ttg.dot_op<{opIdx = 0, parent = #blocked2}>> -> tensor<16x64xbf16, #ttg.dot_op<{opIdx = 0, parent = #mma, kWidth = 8}>>
@@ -300,7 +299,7 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.targ
 #blocked = #ttg.blocked<{sizePerThread = [1, 1], threadsPerWarp = [2, 16], warpsPerCTA = [4, 1], order = [1, 0]}>
 #blocked2 = #ttg.blocked<{sizePerThread = [1, 1], threadsPerWarp = [16, 2], warpsPerCTA = [4, 1], order = [1, 0]}>
 #blocked5 = #ttg.blocked<{sizePerThread = [1, 1], threadsPerWarp = [1, 32], warpsPerCTA = [4, 1], order = [1, 0]}>
-// CHECK{LITERAL}: #linear = #ttg.linear<{register = [[1, 0], [2, 0], [4, 0], [8, 0], [16, 0]], lane = [[0, 1], [0, 2], [0, 4], [0, 8], [32, 0]], warp = [[0, 0], [0, 0]], block = []}>
+// CHECK{LITERAL}: #linear = #ttg.linear<{register = [[0, 0], [1, 0]], lane = [[0, 1], [0, 2], [0, 4], [0, 8], [0, 0]], warp = [[0, 0], [0, 0]], block = []}>
 // CHECK-LABEL: wmma_dot_scaled_fp16_mxfp4
 module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.target = "hip:gfx1250", "ttg.threads-per-warp" = 32 : i32} {
   tt.func public @wmma_dot_scaled_fp16_mxfp4(
@@ -310,9 +309,9 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.targ
       %output: tensor<16x16x!tt.ptr<f32>, #blocked>
       ) {
     // CHECK: tt.load %arg1 {amdg.decomposed_dot_scaled_source = true} : tensor<16x2x!tt.ptr<i8>, #[[LOAD_LAYOUT:.+]]>
-    // CHECK: %[[SCALE:.*]] = tt.reshape {{.*}} : tensor<2x32x16xi8, #[[RESHAPE_LAYOUT:.+]]> -> tensor<64x16xi8, #linear>
-    // CHECK: %[[CVT0:.*]] = ttg.convert_layout %[[SCALE]] : tensor<64x16xi8, #linear> -> tensor<64x16xi8, #[[UPCAST_LAYOUT:.+]]>
-    // CHECK: %[[UPCASTED:.*]] = amdg.scaled_upcast_fp4 {{.+}} scale %[[CVT0]] {axis = 0 : i32} : tensor<32x16xi8, #blocked2>, tensor<64x16xi8, #[[UPCAST_LAYOUT]]> -> tensor<64x16xf16, #[[UPCAST_LAYOUT]]>
+    // CHECK: %[[SCALE_CVT:.*]] = ttg.convert_layout {{.*}} : tensor<2x16xi8, #[[SCALE_SRC_LAYOUT:.+]]> -> tensor<2x16xi8, #linear>
+    // CHECK: %[[SCALE:.*]] = tt.reshape {{.*}} : tensor<2x32x16xi8, #[[RESHAPE_LAYOUT:.+]]> -> tensor<64x16xi8, #[[UPCAST_LAYOUT:.+]]>
+    // CHECK: %[[UPCASTED:.*]] = amdg.scaled_upcast_fp4 {{.+}} scale %[[SCALE]] {axis = 0 : i32} : tensor<32x16xi8, #blocked2>, tensor<64x16xi8, #[[UPCAST_LAYOUT]]> -> tensor<64x16xf16, #[[UPCAST_LAYOUT]]>
     // CHECK: %[[SEL:.*]] = arith.select {{.*}}, %cst, %[[UPCASTED]] : tensor<64x16xi1, #[[UPCAST_LAYOUT]]>, tensor<64x16xf16, #[[UPCAST_LAYOUT]]>
     // CHECK: %[[CVT1:.*]] = ttg.convert_layout %[[SEL]] : tensor<64x16xf16, #[[UPCAST_LAYOUT]]> -> tensor<64x16xf16, #ttg.dot_op<{opIdx = 1, parent = #blocked2}>>
     // CHECK: %[[OPND1:.*]] = ttg.convert_layout %[[CVT1]] : tensor<64x16xf16, #ttg.dot_op<{opIdx = 1, parent = #blocked2}>> -> tensor<64x16xf16, #ttg.dot_op<{opIdx = 1, parent = #mma, kWidth = 8}>>

--- a/test/TritonGPU/amd/amd-canonicalize-pointers.mlir
+++ b/test/TritonGPU/amd/amd-canonicalize-pointers.mlir
@@ -587,6 +587,58 @@ module attributes {"ttg.num-warps" = 4 : i32} {
 
 // -----
 
+module attributes {"ttg.num-warps" = 4 : i32} {
+  tt.func @reshape_offset(%arg0: !tt.ptr<f16>, %arg1: i32) -> tensor<4x4xf16> {
+    %0 = tt.make_range {end = 16 : i32, start = 0 : i32} : tensor<16xi32>
+    %1 = tt.splat %arg1 : i32 -> tensor<16xi32>
+    %2 = arith.addi %1, %0 : tensor<16xi32>
+    %3 = tt.reshape %2 : tensor<16xi32> -> tensor<4x4xi32>
+    %4 = tt.splat %arg0 : !tt.ptr<f16> -> tensor<4x4x!tt.ptr<f16>>
+    %5 = tt.addptr %4, %3 : tensor<4x4x!tt.ptr<f16>>, tensor<4x4xi32>
+    %6 = tt.load %5 : tensor<4x4x!tt.ptr<f16>>
+    tt.return %6 : tensor<4x4xf16>
+  }
+}
+
+// CHECK-LABEL:   tt.func @reshape_offset(
+// CHECK-SAME:                            %[[VAL_0:.*]]: !tt.ptr<f16>,
+// CHECK-SAME:                            %[[VAL_1:.*]]: i32) -> tensor<4x4xf16> {
+// CHECK:           %[[VAL_2:.*]] = tt.make_range {end = 16 : i32, start = 0 : i32} : tensor<16xi32>
+// CHECK:           %[[VAL_3:.*]] = tt.reshape %[[VAL_2]] : tensor<16xi32> -> tensor<4x4xi32>
+// CHECK:           %[[VAL_4:.*]] = tt.addptr %[[VAL_0]], %[[VAL_1]] : !tt.ptr<f16>, i32
+// CHECK:           %[[VAL_5:.*]] = tt.splat %[[VAL_4]] : !tt.ptr<f16> -> tensor<4x4x!tt.ptr<f16>>
+// CHECK:           %[[VAL_6:.*]] = tt.addptr %[[VAL_5]], %[[VAL_3]] : tensor<4x4x!tt.ptr<f16>>, tensor<4x4xi32>
+// CHECK:           %[[VAL_7:.*]] = tt.load %[[VAL_6]] : tensor<4x4x!tt.ptr<f16>>
+// CHECK:           tt.return %[[VAL_7]] : tensor<4x4xf16>
+// CHECK:         }
+
+// -----
+
+module attributes {"ttg.num-warps" = 4 : i32} {
+  tt.func @reshape_pointer(%arg0: !tt.ptr<f16>) -> tensor<4x4xf16> {
+    %0 = tt.make_range {end = 16 : i32, start = 0 : i32} : tensor<16xi32>
+    %1 = tt.splat %arg0 : !tt.ptr<f16> -> tensor<16x!tt.ptr<f16>>
+    %2 = tt.addptr %1, %0 : tensor<16x!tt.ptr<f16>>, tensor<16xi32>
+    %3 = tt.reshape %2 : tensor<16x!tt.ptr<f16>> -> tensor<4x4x!tt.ptr<f16>>
+    %4 = tt.load %3 : tensor<4x4x!tt.ptr<f16>>
+    tt.return %4 : tensor<4x4xf16>
+  }
+}
+
+// CHECK-LABEL:   tt.func @reshape_pointer(
+// CHECK-SAME:                             %[[VAL_0:.*]]: !tt.ptr<f16>) -> tensor<4x4xf16> {
+// CHECK:           %[[VAL_1:.*]] = tt.make_range {end = 16 : i32, start = 0 : i32} : tensor<16xi32>
+// CHECK:           %[[VAL_2:.*]] = arith.extsi %[[VAL_1]] : tensor<16xi32> to tensor<16xi64>
+// CHECK:           %[[VAL_3:.*]] = tt.reshape %[[VAL_2]] : tensor<16xi64> -> tensor<4x4xi64>
+// CHECK:           %[[VAL_4:.*]] = arith.trunci %[[VAL_3]] : tensor<4x4xi64> to tensor<4x4xi32>
+// CHECK:           %[[VAL_5:.*]] = tt.splat %[[VAL_0]] : !tt.ptr<f16> -> tensor<4x4x!tt.ptr<f16>>
+// CHECK:           %[[VAL_6:.*]] = tt.addptr %[[VAL_5]], %[[VAL_4]] : tensor<4x4x!tt.ptr<f16>>, tensor<4x4xi32>
+// CHECK:           %[[VAL_7:.*]] = tt.load %[[VAL_6]] : tensor<4x4x!tt.ptr<f16>>
+// CHECK:           tt.return %[[VAL_7]] : tensor<4x4xf16>
+// CHECK:         }
+
+// -----
+
 
 // The following is a more complex case where also a multiplication is involved. It's useful to walk through the case.
 // We have that the offset to the pointer is the following:

--- a/test/TritonGPU/combine.mlir
+++ b/test/TritonGPU/combine.mlir
@@ -6,6 +6,11 @@
 #layout2 = #ttg.blocked<{sizePerThread = [1, 4], threadsPerWarp = [2, 16], warpsPerCTA = [4, 1], order = [1, 0]}>
 #layout3 = #ttg.blocked<{sizePerThread = [1, 4], threadsPerWarp = [2, 16], warpsPerCTA = [1, 4], order = [1, 0]}>
 
+#expand_layout0 = #ttg.blocked<{sizePerThread = [1, 1], threadsPerWarp = [32, 1], warpsPerCTA = [4, 1], order = [1, 0]}>
+#expand_layout1 = #ttg.blocked<{sizePerThread = [4, 1], threadsPerWarp = [32, 1], warpsPerCTA = [4, 1], order = [1, 0]}>
+#expand_layout0_slice = #ttg.slice<{dim = 1, parent = #expand_layout0}>
+#expand_layout1_slice = #ttg.slice<{dim = 1, parent = #expand_layout1}>
+
 #layout4 = #ttg.blocked<{sizePerThread = [1, 1], threadsPerWarp = [32, 1], warpsPerCTA = [2, 2], order = [0, 1]}>
 #layout5 = #ttg.blocked<{sizePerThread = [1, 2], threadsPerWarp = [32, 1], warpsPerCTA = [2, 2], order = [0, 1]}>
 #linear = #ttg.linear<{register = [[0, 1], [0, 2], [0, 4], [0, 8], [0, 16]], lane = [[1, 0], [2, 0], [4, 0], [8, 0], [0, 32]], warp = [[16, 0], [32, 0]], block = []}>
@@ -170,6 +175,16 @@ tt.func @hoist_above_broadcast(%arg0: tensor<1024x1xf32, #layout2>, %arg1: f32) 
   tt.return %3 : tensor<1024x128xf32, #layout3>
 }
 
+// CHECK-LABEL: hoist_above_expand_dims_reshape
+tt.func @hoist_above_expand_dims_reshape(%arg0: tensor<1024xf32, #expand_layout0_slice>) -> tensor<1024x1xf32, #expand_layout1> {
+// CHECK: %[[CVT:.+]] = ttg.convert_layout %arg0 : tensor<1024xf32, #{{.*}}> -> tensor<1024xf32, #[[DST_LAYOUT:.*]]>
+// CHECK: tt.reshape %[[CVT]] : tensor<1024xf32, #[[DST_LAYOUT]]> -> tensor<1024x1xf32, #{{.*}}>
+// CHECK-NOT: ttg.convert_layout
+// CHECK: tt.return
+  %0 = tt.reshape %arg0 : tensor<1024xf32, #expand_layout0_slice> -> tensor<1024x1xf32, #expand_layout0>
+  %1 = ttg.convert_layout %0 : tensor<1024x1xf32, #expand_layout0> -> tensor<1024x1xf32, #expand_layout1>
+  tt.return %1 : tensor<1024x1xf32, #expand_layout1>
+}
 
 // CHECK-LABEL: if
 tt.func @if(%arg0: i32, %arg1: !tt.ptr<i32> {tt.divisibility = 16 : i32}) {

--- a/test/TritonGPU/combine.mlir
+++ b/test/TritonGPU/combine.mlir
@@ -2209,6 +2209,27 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 1 : i32, "ttg.thr
 
 // -----
 
+#src = #ttg.blocked<{sizePerThread = [1, 1], threadsPerWarp = [32, 1], warpsPerCTA = [1, 1], order = [1, 0]}>
+#dst = #ttg.blocked<{sizePerThread = [1, 1], threadsPerWarp = [1, 32], warpsPerCTA = [1, 1], order = [1, 0]}>
+#src_slice = #ttg.slice<{dim = 1, parent = #src}>
+#dst_slice = #ttg.slice<{dim = 1, parent = #dst}>
+
+module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 1 : i32, "ttg.threads-per-warp" = 32 : i32} {
+  // CHECK-LABEL: @efficient_reshape_no_forward_propagate
+  // CHECK: %[[CVT:.+]] = ttg.convert_layout
+  // CHECK: tt.reshape %[[CVT]] efficient_layout
+  tt.func public @efficient_reshape_no_forward_propagate(
+      %arg0: tensor<32xf32, #src_slice>) -> tensor<32x1024xf32, #dst> {
+    // Keep this conversion before the reshape and the 1024x broadcast.
+    %0 = ttg.convert_layout %arg0 : tensor<32xf32, #src_slice> -> tensor<32xf32, #dst_slice>
+    %1 = tt.reshape %0 efficient_layout : tensor<32xf32, #dst_slice> -> tensor<32x1xf32, #dst>
+    %2 = tt.broadcast %1 : tensor<32x1xf32, #dst> -> tensor<32x1024xf32, #dst>
+    tt.return %2 : tensor<32x1024xf32, #dst>
+  }
+}
+
+// -----
+
 #blocked = #ttg.blocked<{sizePerThread = [1,2], threadsPerWarp = [32,1], warpsPerCTA = [1,1], order = [1,0]}>
 #blocked1 = #ttg.blocked<{sizePerThread = [1,1], threadsPerWarp = [16,2], warpsPerCTA = [1,1], order = [1,0]}>
 #blocked2 = #ttg.blocked<{sizePerThread = [1], threadsPerWarp = [32], warpsPerCTA = [1], order = [0]}>

--- a/test/TritonNvidiaGPU/plan_cta.mlir
+++ b/test/TritonNvidiaGPU/plan_cta.mlir
@@ -1,8 +1,12 @@
 // RUN: triton-opt %s -triton-nvidia-gpu-plan-cta | FileCheck %s
 
 #blocked = #ttg.blocked<{sizePerThread = [4], threadsPerWarp = [32], warpsPerCTA = [4], order = [0], CGALayout = [[0], [0]]}>
+#blocked_2d = #ttg.blocked<{sizePerThread = [4, 1], threadsPerWarp = [32, 1], warpsPerCTA = [4, 1], order = [0, 1], CGALayout = [[0, 0], [0, 0]]}>
+#slice = #ttg.slice<{dim = 1, parent = #blocked_2d}>
 
   // CHECK: #blocked = #ttg.blocked<{sizePerThread = [4], threadsPerWarp = [32], warpsPerCTA = [4], order = [0], CGALayout = {{\[\[1\], \[2\]\]}}}>
+  // CHECK-DAG: #[[$RESHAPE_DST:.+]] = #ttg.blocked<{{.*}}CGALayout = {{\[\[1, 0\], \[2, 0\]\]}}}>
+  // CHECK-DAG: #[[$RESHAPE_SRC:.+]] = #ttg.linear
 module attributes {"ttg.num-ctas" = 4 : i32, "ttg.num-warps" = 4 : i32, ttg.target = "cuda:100", "ttg.threads-per-warp" = 32 : i32} {
   // CHECK-LABEL: tt.func @reduce_1d_split_ctas
   // CHECK: "tt.reduce"(%{{.*}}) <{axis = 0 : i32}>
@@ -16,5 +20,20 @@ module attributes {"ttg.num-ctas" = 4 : i32, "ttg.num-warps" = 4 : i32, ttg.targ
       tt.reduce.return %sum : f32
     }) : (tensor<65536xf32, #blocked>) -> f32
     tt.return %red : f32
+  }
+
+  // CHECK-LABEL: tt.func @reduce_reshape
+  // CHECK: %[[CST:.*]] = arith.constant dense<0.000000e+00> : tensor<65536xf32, #[[$RESHAPE_SRC]]>
+  // CHECK-NEXT: %[[RESHAPE:.*]] = tt.reshape %[[CST]] : tensor<65536xf32, #[[$RESHAPE_SRC]]> -> tensor<65536x1xf32, #[[$RESHAPE_DST]]>
+  // CHECK-NEXT: %[[RED:.*]] = "tt.reduce"(%[[RESHAPE]]) <{axis = 1 : i32}>
+  tt.func @reduce_reshape() -> tensor<65536xf32, #slice> {
+    %cst = arith.constant dense<0.000000e+00> : tensor<65536xf32, #slice>
+    %expanded = tt.reshape %cst : tensor<65536xf32, #slice> -> tensor<65536x1xf32, #blocked_2d>
+    %red = "tt.reduce"(%expanded) <{axis = 1 : i32}> ({
+    ^bb0(%lhs: f32, %rhs: f32):
+      %sum = arith.addf %lhs, %rhs : f32
+      tt.reduce.return %sum : f32
+    }) : (tensor<65536x1xf32, #blocked_2d>) -> tensor<65536xf32, #slice>
+    tt.return %red : tensor<65536xf32, #slice>
   }
 }

--- a/third_party/amd/lib/TritonAMDGPUTransforms/AccelerateAMDMatmul.cpp
+++ b/third_party/amd/lib/TritonAMDGPUTransforms/AccelerateAMDMatmul.cpp
@@ -877,12 +877,9 @@ public:
         scale = TransOp::create(rewriter, loc, scale, order);
       }
 
-      reshapeScale = broadcastScale(
-          rewriter, dotOp, dotOp->getParentOfType<ModuleOp>(), scale, kDim);
-
       auto newScaleType = resultType.clone(scale.getType().getElementType());
-      reshapeScale = mlir::triton::gpu::ConvertLayoutOp::create(
-          rewriter, loc, newScaleType, reshapeScale);
+      reshapeScale = broadcastScale(rewriter, dotOp, scale, kDim,
+                                    newScaleType.getEncoding());
     } else {
       // Cast scale to bf16, broadcast it and convert the layout
       FloatType bf16Type = rewriter.getBF16Type();

--- a/third_party/amd/lib/TritonAMDGPUTransforms/CanonicalizePointers.cpp
+++ b/third_party/amd/lib/TritonAMDGPUTransforms/CanonicalizePointers.cpp
@@ -417,6 +417,14 @@ createDecomposeOffsetFromExpr(RewriterBase &rewriter, Location loc, Value expr,
                 rewriter, loc, nonUniform, expandOp.getAxis());
             return std::make_pair(uniform, expandNonUniform);
           })
+          .Case<tt::ReshapeOp>([&](auto reshapeOp) {
+            auto [uniform, nonUniform] = createDecomposeOffsetFromExpr(
+                rewriter, loc, reshapeOp.getSrc(), bitness, scalarToSplatMap);
+            Value reshapeNonUniform = tt::ReshapeOp::create(
+                rewriter, loc, reshapeOp.getType(), nonUniform,
+                reshapeOp.getAllowReorder(), reshapeOp.getEfficientLayout());
+            return std::make_pair(uniform, reshapeNonUniform);
+          })
           .Case<arith::AddIOp>([&](Operation *op) {
             return createDecomposeOffsetFromAdd(rewriter, loc, expr, bitness,
                                                 scalarToSplatMap);
@@ -1587,6 +1595,42 @@ public:
   }
 };
 
+/// Rewrite reshape(base, offset) -> base, reshape(offset).
+class ConvertReshape : public PointerCanonicalizationPattern<tt::ReshapeOp> {
+public:
+  using PointerCanonicalizationPattern::PointerCanonicalizationPattern;
+  LogicalResult
+  matchAndRewrite_(tt::ReshapeOp reshapeOp, OneToNOpAdaptor adaptor,
+                   ConversionPatternRewriter &rewriter) const override {
+    ValueRange remappedOperands = adaptor.getSrc();
+    if (remappedOperands.size() != 2)
+      return success();
+    Value fatPtrBase = remappedOperands[0];
+    if (!llvm::isa<tt::PointerType>(fatPtrBase.getType()))
+      return rewriter.notifyMatchFailure(
+          reshapeOp, "only scalar base currently supported");
+    Value fatPtrOffset = remappedOperands[1];
+
+    RankedTensorType result =
+        llvm::cast<RankedTensorType>(reshapeOp->getResultTypes().front());
+    if (!llvm::isa<tt::PointerType>(result.getElementType()))
+      return rewriter.notifyMatchFailure(
+          reshapeOp, "expected reshape result to be tensor of tt.ptr");
+
+    RankedTensorType newResult = RankedTensorType::get(
+        result.getShape(),
+        llvm::cast<RankedTensorType>(fatPtrOffset.getType()).getElementType(),
+        result.getEncoding());
+    auto newOffset = tt::ReshapeOp::create(
+        rewriter, reshapeOp.getLoc(), newResult, fatPtrOffset,
+        reshapeOp.getAllowReorder(), reshapeOp.getEfficientLayout());
+    rewriter.replaceOpWithMultiple(reshapeOp, {{fatPtrBase, newOffset}});
+    fatPtrs[{fatPtrBase, newOffset}] = fatPtrs.at({fatPtrBase, fatPtrOffset});
+
+    return success();
+  }
+};
+
 /// convert integer offset, keep base
 class ConvertConvertLayoutOp
     : public PointerCanonicalizationPattern<tt::gpu::ConvertLayoutOp> {
@@ -2053,7 +2097,7 @@ void TritonAMDGPUCanonicalizePointersPass::runOnOperation() {
       MaterializeFatPointerVariadic<tt::ExternElementwiseOp>,
       MaterializeFatPointerVariadic<tt::ElementwiseInlineAsmOp>,
       MaterializeFatPointerVariadic<tt::PrintOp>, ConvertSCFForOp,
-      ConvertExpandDims, ConvertSCFYieldOp, ConvertSCFIfOp,
+      ConvertExpandDims, ConvertReshape, ConvertSCFYieldOp, ConvertSCFIfOp,
       ConvertSCFConditionOp, ConvertSCFWhileOp, ConvertCFCondBranch,
       ConvertCFBranch, ConvertArithSelectOp, ConvertReturnOp>(
       patterns.getContext(), opsToRewrite, fatPrs, convertedBlocks);


### PR DESCRIPTION

Rewrite internal creation of `ExpandDimsOp` to instead use reshape.

---
[//]: # (BEGIN SAPLING FOOTER)
* #10421
* __->__ #10555
* #10593
* #10545
* #10516