### PR TITLE
[Gluon] Add static persistent scheduler for 2CTA block-scale MMA

### DIFF
--- a/python/examples/gluon/04-2cta-block-scale-matmul.py
+++ b/python/examples/gluon/04-2cta-block-scale-matmul.py
@@ -140,6 +140,9 @@ def swizzle_scales_packed_block(scales: torch.Tensor):
 # Autotuning configs and hook
 # ---------------------------------------------------------------------------
 
+SCHEDULER_CLC = gl.constexpr("cluster_launch_control")
+SCHEDULER_SPS = gl.constexpr("static_persistent")
+
 
 def mma_scaled_get_configs(pre_hook=None, cga_layouts=None):
     if cga_layouts is None:
@@ -156,6 +159,7 @@ def mma_scaled_get_configs(pre_hook=None, cga_layouts=None):
                 "GRID_MINOR_DIM": minor_dim,
                 "GRID_TILE_WIDTH": grid_tile_width,
                 "CGA_LAYOUT": cga_layout,
+                "scheduler": scheduler,
             },
             num_warps=4,
             num_ctas=2**len(cga_layout),
@@ -170,8 +174,9 @@ def mma_scaled_get_configs(pre_hook=None, cga_layouts=None):
         for stages in (3, 4, 5)
         for acc_buffers in (1, 2)
         for cga_layout in cga_layouts
+        for scheduler in (SCHEDULER_CLC, SCHEDULER_SPS)
         # tcgen05_mma_scaled requires BLOCK_M_PER_CTA == 128
-        if BM // (2**len(cga_layout)) == 128 if epilogue_n <= BN
+        if BM // (2**len(cga_layout)) == 128 and epilogue_n <= BN
     ]
 
 
@@ -438,6 +443,48 @@ class ClcTileSchedulerConsumer:
         )
 
 
+@gluon.aggregate
+class SpsTileScheduler:
+    has_work: gl.tensor
+    tile_id: gl.tensor
+    pid_m: gl.tensor
+    pid_n: gl.tensor
+    TILE_M: gl.constexpr
+    TILE_N: gl.constexpr
+    MINOR_DIM: gl.constexpr
+    GRID_TILE_WIDTH: gl.constexpr
+    NUM_PID_M: gl.tensor
+    NUM_PID_N: gl.tensor
+
+    @gluon.jit
+    def initialize(TILE_M: gl.constexpr, TILE_N: gl.constexpr, MINOR_DIM: gl.constexpr, GRID_TILE_WIDTH: gl.constexpr,
+                   NUM_PID_M, NUM_PID_N):
+        tile_id = gl.program_id(axis=0)
+        has_work = tile_id < NUM_PID_M * NUM_PID_N
+        pid_m = gl.to_tensor(0)
+        pid_n = gl.to_tensor(0)
+        if has_work:
+            pid_m, pid_n = _planar_snake(tile_id, NUM_PID_M, NUM_PID_N, MINOR_DIM, GRID_TILE_WIDTH)
+        return SpsTileScheduler(has_work, tile_id, pid_m, pid_n, TILE_M, TILE_N, MINOR_DIM, GRID_TILE_WIDTH, NUM_PID_M,
+                                NUM_PID_N)
+
+    @gluon.jit
+    def get_offsets(self):
+        return self.pid_m * self.TILE_M, self.pid_n * self.TILE_N
+
+    @gluon.jit
+    def step(self, iteration):
+        next_tile_id = self.tile_id + gl.num_programs(axis=0)
+        has_work = next_tile_id < self.NUM_PID_M * self.NUM_PID_N
+        pid_m = gl.to_tensor(0)
+        pid_n = gl.to_tensor(0)
+        if has_work:
+            pid_m, pid_n = _planar_snake(next_tile_id, self.NUM_PID_M, self.NUM_PID_N, self.MINOR_DIM,
+                                         self.GRID_TILE_WIDTH)
+        return SpsTileScheduler(has_work, next_tile_id, pid_m, pid_n, self.TILE_M, self.TILE_N, self.MINOR_DIM,
+                                self.GRID_TILE_WIDTH, self.NUM_PID_M, self.NUM_PID_N)
+
+
 # ---------------------------------------------------------------------------
 # Partitions
 # ---------------------------------------------------------------------------
@@ -466,6 +513,9 @@ class PartitionArgs:
     clc_consumed_bars: gl.shared_memory_descriptor
     MINOR_DIM: gl.constexpr
     GRID_TILE_WIDTH: gl.constexpr
+    NUM_PID_M: gl.tensor
+    NUM_PID_N: gl.tensor
+    scheduler: gl.constexpr
 
     @gluon.jit
     def get_clc_consumer(self):
@@ -483,6 +533,17 @@ class PartitionArgs:
             self.clc_consumed_bars,
         )
 
+    @gluon.jit
+    def get_sps_scheduler(self):
+        return SpsTileScheduler.initialize(
+            self.a_desc.block_shape[0],
+            self.b_desc.block_shape[0],
+            self.MINOR_DIM,
+            self.GRID_TILE_WIDTH,
+            self.NUM_PID_M,
+            self.NUM_PID_N,
+        )
+
 
 @gluon.jit
 def mma_scaled_load_partition(p):
@@ -490,7 +551,10 @@ def mma_scaled_load_partition(p):
     BLOCK_K: gl.constexpr = p.a_desc.block_shape[1] * A_ELEM_PER_BYTE
     K = p.a_desc.shape[1] * A_ELEM_PER_BYTE
     state = Counter.create(1, p.load_empty_bars.shape[0])
-    scheduler = p.get_clc_consumer()
+    if p.scheduler == SCHEDULER_CLC:
+        scheduler = p.get_clc_consumer()
+    else:
+        scheduler = p.get_sps_scheduler()
     i = 0
     while scheduler.has_work:
         for k in range(0, K, BLOCK_K):
@@ -509,7 +573,10 @@ def mma_scaled_mma_partition(p):
     K = p.a_desc.shape[1] * A_ELEM_PER_BYTE
     load_state = Counter.create(0, p.load_empty_bars.shape[0])
     acc_state = Counter.create(1, p.acc_empty_bars.shape[0])
-    scheduler = p.get_clc_consumer()
+    if p.scheduler == SCHEDULER_CLC:
+        scheduler = p.get_clc_consumer()
+    else:
+        scheduler = p.get_sps_scheduler()
     i = 0
     while scheduler.has_work:
         mbarrier.wait(p.acc_empty_bars.index(acc_state.index), acc_state.phase)
@@ -535,7 +602,10 @@ def mma_scaled_epilogue_partition(p):
     acc_state = Counter.create(0, p.acc_empty_bars.shape[0])
     acc_smems = gl.allocate_shared_memory(p.c_desc.dtype, [subtile_stages, tile_m, EPILOGUE_BLOCK_N], p.c_desc.layout)
     sub_acc_state = Counter.create(0, subtile_stages)
-    scheduler = p.get_clc_consumer()
+    if p.scheduler == SCHEDULER_CLC:
+        scheduler = p.get_clc_consumer()
+    else:
+        scheduler = p.get_sps_scheduler()
     i = 0
     while scheduler.has_work:
         off_m, off_n = scheduler.get_offsets()
@@ -605,12 +675,13 @@ def mma_scaled_warp_specialized_kernel(a_desc, b_desc, c_desc, a_scale_desc, b_s
                                        num_buffers: gl.constexpr, BLOCK_M: gl.constexpr, BLOCK_N: gl.constexpr,
                                        BLOCK_K: gl.constexpr, EPILOGUE_BLOCK_N: gl.constexpr,
                                        num_acc_buffers: gl.constexpr, GRID_MINOR_DIM: gl.constexpr,
-                                       GRID_TILE_WIDTH: gl.constexpr, CGA_LAYOUT: gl.constexpr):
+                                       GRID_TILE_WIDTH: gl.constexpr, CGA_LAYOUT: gl.constexpr,
+                                       scheduler: gl.constexpr):
     NUM_CTAS: gl.constexpr = gl.num_ctas()
     TWO_CTAS: gl.constexpr = NUM_CTAS > 1
     BLOCK_M_PER_CTA: gl.constexpr = BLOCK_M // NUM_CTAS
     gl.static_assert(BLOCK_M_PER_CTA == 64 or BLOCK_M_PER_CTA == 128)
-    N_PARTITIONS: gl.constexpr = 4
+    N_PARTITIONS: gl.constexpr = 4 if scheduler == SCHEDULER_CLC else 3
 
     a_bufs = gl.allocate_shared_memory(a_desc.dtype, [num_buffers] + a_desc.block_shape, a_desc.layout)
     b_bufs = gl.allocate_shared_memory(b_desc.dtype, [num_buffers] + b_desc.block_shape, b_desc.layout)
@@ -655,14 +726,21 @@ def mma_scaled_warp_specialized_kernel(a_desc, b_desc, c_desc, a_scale_desc, b_s
     p = PartitionArgs(a_desc, b_desc, c_desc, a_scale_desc, b_scale_desc, a_bufs, b_bufs, a_scale_bufs, b_scale_bufs,
                       load_empty_bars, load_ready_bars, acc_bufs, acc_empty_bars, acc_ready_bars, clc_result_buffers,
                       clc_barriers, clc_planar_pid_buffers, clc_planar_ready_bars, clc_consumed_bars, GRID_MINOR_DIM,
-                      GRID_TILE_WIDTH)
+                      GRID_TILE_WIDTH, gl.cdiv(M, BLOCK_M), gl.cdiv(N, BLOCK_N), scheduler)
 
-    gl.warp_specialize([
-        (mma_scaled_epilogue_partition, (p, )),
-        (mma_scaled_mma_partition, (p, )),
-        (mma_scaled_load_partition, (p, )),
-        (mma_scaled_clc_partition, (p, )),
-    ], [1, 1, 1], [24, 24, 24])
+    if scheduler == SCHEDULER_CLC:
+        gl.warp_specialize([
+            (mma_scaled_epilogue_partition, (p, )),
+            (mma_scaled_mma_partition, (p, )),
+            (mma_scaled_load_partition, (p, )),
+            (mma_scaled_clc_partition, (p, )),
+        ], [1, 1, 1], [24, 24, 24])
+    else:
+        gl.warp_specialize([
+            (mma_scaled_epilogue_partition, (p, )),
+            (mma_scaled_mma_partition, (p, )),
+            (mma_scaled_load_partition, (p, )),
+        ], [1, 1], [24, 24])
 
 
 mma_scaled_kernel = triton.autotune(
@@ -707,7 +785,15 @@ def make_dummy_descriptors(A, B, A_scale, B_scale, out_dtype, M, N):
     return a_desc, b_desc, c_desc, a_scale_desc, b_scale_desc
 
 
-def mma_scaled_warp_specialized(A, B, A_scale, B_scale, VEC_SIZE, GRID_MINOR_DIM=0, GRID_TILE_WIDTH=4,
+def mma_scaled_warp_specialized_grid(M, N, BLOCK_M, BLOCK_N, num_ctas, scheduler, device):
+    num_pid = triton.cdiv(M, BLOCK_M) * triton.cdiv(N, BLOCK_N)
+    if scheduler == SCHEDULER_CLC:
+        return (num_pid, )
+    sm_count = torch.cuda.get_device_properties(device).multi_processor_count
+    return (max(1, min(num_pid, sm_count // num_ctas)), )
+
+
+def mma_scaled_warp_specialized(A, B, A_scale, B_scale, VEC_SIZE, scheduler, GRID_MINOR_DIM=0, GRID_TILE_WIDTH=4,
                                 out_dtype=torch.float16, BLOCK_M=128, BLOCK_N=256, BLOCK_K=None, EPILOGUE_BLOCK_N=None,
                                 num_buffers=3, acc_buffers=None, num_ctas=1):
     """Warp-specialized block-scale MMA (supports 1CTA and 2CTA)."""
@@ -738,8 +824,7 @@ def mma_scaled_warp_specialized(A, B, A_scale, B_scale, VEC_SIZE, GRID_MINOR_DIM
         "CGA_LAYOUT": cga_layout,
     })
 
-    num_pid = triton.cdiv(M, BLOCK_M) * triton.cdiv(N, BLOCK_N)
-    grid = (num_pid, )
+    grid = mma_scaled_warp_specialized_grid(M, N, BLOCK_M, BLOCK_N, num_ctas, scheduler, A.device)
     A_ELEM_PER_BYTE = 2 if IS_FP4_A else 1
     mma_scaled_warp_specialized_kernel[grid](
         A_desc,
@@ -760,6 +845,7 @@ def mma_scaled_warp_specialized(A, B, A_scale, B_scale, VEC_SIZE, GRID_MINOR_DIM
         GRID_MINOR_DIM,
         GRID_TILE_WIDTH,
         cga_layout,
+        scheduler=scheduler,
         num_ctas=num_ctas,
     )
     return C_desc.base
@@ -781,8 +867,8 @@ def mma_scaled_matmul(A, B, A_scale, B_scale, VEC_SIZE, out_dtype=torch.float16,
     a_desc, b_desc, c_desc, a_scale_desc, b_scale_desc = make_dummy_descriptors(A, B, A_scale, B_scale, out_dtype, M, N)
 
     def grid(meta):
-        num_tiles = triton.cdiv(M, meta["BLOCK_M"]) * triton.cdiv(N, meta["BLOCK_N"])
-        return (num_tiles, )
+        return mma_scaled_warp_specialized_grid(M, N, meta["BLOCK_M"], meta["BLOCK_N"], 2**len(meta["CGA_LAYOUT"]),
+                                                meta["scheduler"], A.device)
 
     kernel = {None: mma_scaled_kernel, 1: mma_scaled_1cta_kernel, 2: mma_scaled_2cta_kernel}[num_ctas]
     kernel[grid](a_desc, b_desc, c_desc, a_scale_desc, b_scale_desc, M, N, K, A_ELEM_PER_BYTE)
@@ -806,8 +892,10 @@ def mma_scaled_matmul(A, B, A_scale, B_scale, VEC_SIZE, out_dtype=torch.float16,
     (1, 256, 64, 3),
     (1, 128, 64, 5),
 ])
+@pytest.mark.parametrize("scheduler", [SCHEDULER_CLC, SCHEDULER_SPS])
 @pytest.mark.skipif(not is_blackwell(), reason="Requires Blackwell")
-def test_mma_scaled_warp_specialized(M, N, K, a_format, b_format, num_ctas, BLOCK_N, EPILOGUE_BLOCK_N, num_buffers):
+def test_mma_scaled_warp_specialized(M, N, K, a_format, b_format, num_ctas, BLOCK_N, EPILOGUE_BLOCK_N, num_buffers,
+                                     scheduler):
     if a_format != b_format and K % 128 != 0:
         pytest.skip("fp4 packed tensor descriptor requires K to be a multiple of 128")
     BLOCK_M = 256 if num_ctas > 1 else 128
@@ -818,8 +906,9 @@ def test_mma_scaled_warp_specialized(M, N, K, a_format, b_format, num_ctas, BLOC
     A_scale = swizzle_scales_packed_block(A_scale)
     B_scale = swizzle_scales_packed_block(B_scale)
     C_ref = A_ref @ B_ref.T
-    C = mma_scaled_warp_specialized(A, B, A_scale, B_scale, VEC_SIZE, BLOCK_M=BLOCK_M, BLOCK_N=BLOCK_N,
-                                    EPILOGUE_BLOCK_N=EPILOGUE_BLOCK_N, num_buffers=num_buffers, num_ctas=num_ctas)
+    C = mma_scaled_warp_specialized(A, B, A_scale, B_scale, VEC_SIZE, scheduler=scheduler, BLOCK_M=BLOCK_M,
+                                    BLOCK_N=BLOCK_N, EPILOGUE_BLOCK_N=EPILOGUE_BLOCK_N, num_buffers=num_buffers,
+                                    num_ctas=num_ctas)
     torch.testing.assert_close(C_ref, C.to(torch.float32), atol=1e-3, rtol=1e-3)
 
 
@@ -859,16 +948,28 @@ BEST_2CTA_CONFIG = dict(BLOCK_M=256, BLOCK_N=256, EPILOGUE_BLOCK_N=64, num_buffe
                         GRID_TILE_WIDTH=8)
 
 
-def make_fn(variant, A, B, A_scale, B_scale, VEC_SIZE, a_format, use_autotuned=False):
+def scheduler_for_k(K):
+    return SCHEDULER_SPS if K <= 8192 else SCHEDULER_CLC
+
+
+def fixed_config_for_mnk(config, MNK):
+    config = dict(config)
+    config["scheduler"] = scheduler_for_k(MNK)
+    return config
+
+
+def make_fn(variant, A, B, A_scale, B_scale, VEC_SIZE, a_format, MNK, use_autotuned=False):
     """Build the callable for a given variant (1cta, 2cta, or cublas)."""
     if variant == "2cta":
         if use_autotuned:
             return lambda: mma_scaled_matmul(A, B, A_scale, B_scale, VEC_SIZE, num_ctas=2)
-        return lambda: mma_scaled_warp_specialized(A, B, A_scale, B_scale, VEC_SIZE, **BEST_2CTA_CONFIG)
+        return lambda: mma_scaled_warp_specialized(A, B, A_scale, B_scale, VEC_SIZE,
+                                                   **fixed_config_for_mnk(BEST_2CTA_CONFIG, MNK))
     elif variant == "1cta":
         if use_autotuned:
             return lambda: mma_scaled_matmul(A, B, A_scale, B_scale, VEC_SIZE, num_ctas=1)
-        return lambda: mma_scaled_warp_specialized(A, B, A_scale, B_scale, VEC_SIZE, **BEST_1CTA_CONFIG)
+        return lambda: mma_scaled_warp_specialized(A, B, A_scale, B_scale, VEC_SIZE,
+                                                   **fixed_config_for_mnk(BEST_1CTA_CONFIG, MNK))
     elif variant == "cublas":
         A_scale_flat = A_scale.contiguous().flatten()
         B_scale_flat = B_scale.contiguous().flatten()
@@ -937,7 +1038,7 @@ def format_config(cfg):
     parts = [
         f"BM={kw['BLOCK_M']}", f"BN={kw['BLOCK_N']}", f"BK={kw['BLOCK_K']}", f"epilogue_N={kw['EPILOGUE_BLOCK_N']}",
         f"bufs={kw['num_buffers']}", f"acc_bufs={kw['num_acc_buffers']}", f"minor={kw['GRID_MINOR_DIM']}",
-        f"tile_w={kw['GRID_TILE_WIDTH']}", f"cga={kw['CGA_LAYOUT']}"
+        f"tile_w={kw['GRID_TILE_WIDTH']}", f"scheduler={kw['scheduler']}", f"cga={kw['CGA_LAYOUT']}"
     ]
     return ", ".join(parts)
 
@@ -953,7 +1054,7 @@ def run_benchmark(use_autotuned=False):
             for variant in variants:
                 if use_autotuned:
                     print(f"  {label} {variant} MNK={MNK}: ...", end="", flush=True)
-                fn = make_fn(variant, A, B, A_scale, B_scale, VEC_SIZE, a_format, use_autotuned=use_autotuned)
+                fn = make_fn(variant, A, B, A_scale, B_scale, VEC_SIZE, a_format, MNK, use_autotuned=use_autotuned)
                 ms = triton.testing.do_bench(fn)
                 tflops = 2.0 * MNK**3 * 1e-12 / (ms * 1e-3)
                 results[(label, variant, MNK)] = tflops


### PR DESCRIPTION
This PR adds static persistent scheduling as an explicit scheduler option for example 04 2CTA block-scale MMA. The existing CLC scheduler remains available and is still selected for the larger-K range where it is competitive or best. The fixed configs choose between CLC and static persistent scheduling by K.

```
  format CTA       K   CLC TFLOPs    SPS TFLOPs   SPS/CLC
  mxfp8  1CTA    256        831.6        1191.2     1.433
  mxfp8  1CTA    512       1321.0        1686.4     1.277
  mxfp8  1CTA   1024       1873.4        2219.6     1.185
  mxfp8  1CTA   2048       2369.6        2647.8     1.117
  mxfp8  1CTA   4096       2686.5        2888.0     1.075
  mxfp8  1CTA   8192       2815.3        2915.6     1.036
  mxfp8  1CTA  16384       2776.4        2820.2     1.016
  mxfp8  2CTA    256        808.8        1184.9     1.465
  mxfp8  2CTA    512       1312.0        1840.8     1.403
  mxfp8  2CTA   1024       1976.0        2486.7     1.258
  mxfp8  2CTA   2048       2638.7        3060.6     1.160
  mxfp8  2CTA   4096       3193.2        3361.0     1.053
  mxfp8  2CTA   8192       3432.4        3478.7     1.013
  mxfp8  2CTA  16384       3415.7        3411.9     0.999
  nvfp4  1CTA    256        916.6        1361.9     1.486
  nvfp4  1CTA    512       1620.5        2285.5     1.410
  nvfp4  1CTA   1024       2547.7        3260.7     1.280
  nvfp4  1CTA   2048       3565.5        4283.8     1.202
  nvfp4  1CTA   4096       4537.5        5083.1     1.120
  nvfp4  1CTA   8192       5147.4        5466.3     1.062
  nvfp4  1CTA  16384       5377.1        5572.6     1.036
  nvfp4  2CTA    256        913.2        1350.3     1.479
  nvfp4  2CTA    512       1578.6        2332.2     1.477
  nvfp4  2CTA   1024       2601.4        3633.0     1.397
  nvfp4  2CTA   2048       3866.6        4927.1     1.274
  nvfp4  2CTA   4096       5231.4        6088.3     1.164
  nvfp4  2CTA   8192       6384.0        6765.3     1.060
  nvfp4  2CTA  16384       6862.8        6937.7     1.011
```