### PR TITLE
[NVIDIA] Support local gather from multi-CTA subslices

### DIFF
--- a/include/triton/Conversion/TritonGPUToLLVM/Utility.h
+++ b/include/triton/Conversion/TritonGPUToLLVM/Utility.h
@@ -420,15 +420,21 @@ public:
   // The offsets are considered to be in the type of the memdesc.
   // For padded layouts, we return the offsets without padding.
   static uint64_t getMaskSpanOffsets(triton::gpu::MemDescType srcTy);
+  static std::pair<uint64_t, uint64_t>
+  getMaskSpanOffsetsAndBlocks(triton::gpu::MemDescType srcTy);
 
   // Returns whether the shared memory access had a memdesc_subslice
   // that is rank-preserving (soon to be called memdesc_slice)
   static bool isAffineSharedMemoryAccess(triton::gpu::MemDescType srcTy) {
-    return getMaskSpanOffsets(srcTy) != 0;
+    auto [offsetMask, blockMask] = getMaskSpanOffsetsAndBlocks(srcTy);
+    return offsetMask != 0 || blockMask != 0;
   }
 
   Value getShmemOffset(Location loc, RewriterBase &rewriter,
                        triton::gpu::MemDescType srcTy) const;
+  std::pair<Value, Value>
+  getShmemOffsetAndBlock(Location loc, RewriterBase &rewriter,
+                         triton::gpu::MemDescType srcTy) const;
   Value getShmemAffineBase(Location loc, RewriterBase &rewriter,
                            triton::gpu::MemDescType srcTy) const;
 
@@ -634,7 +640,7 @@ struct LocalAtomicScatterRMWInfo {
   Value threadPred;
   SmallVector<Value> values;
   SmallVector<Value> maskValues;
-  SmallVector<Value> ptrs;
+  SmallVector<LocalSharedMemoryAddress> addrs;
 };
 
 FailureOr<LocalAtomicScatterRMWInfo> prepareLocalAtomicScatterRMW(
@@ -666,6 +672,7 @@ lowerLdStShared(Location loc, MLIRContext *ctx, LinearLayout cvt,
                 Type llvmElemTy, ArrayRef<Value> smemBases,
                 ArrayRef<std::pair<unsigned, unsigned>> paddingShifts,
                 Value affineOffset, uint64_t maskSpanAffineOffset,
+                Value affineBlockOffset, uint64_t maskSpanAffineBlock,
                 RewriterBase &rewriter, const TargetInfoBase &targetInfo,
                 std::optional<int> maybeMaxVecElems = {},
                 Operation *localLoadOp = nullptr);
@@ -682,7 +689,8 @@ SmallVector<Value> lowerLdSt(
     ArrayRef<Value> valsArray, // Input for store, output for load
     Type llvmElemTy, ArrayRef<Value> smemBases,
     ArrayRef<std::pair<unsigned, unsigned>> paddingShifts, Value affineOffset,
-    uint64_t maskSpanAffineOffset, Value laneId, Value warpId,
+    uint64_t maskSpanAffineOffset, Value affineBlockOffset,
+    uint64_t maskSpanAffineBlock, Value laneId, Value warpId,
     RewriterBase &rewriter, const TargetInfoBase &targetInfo,
     std::optional<int> maybeMaxVecElems,
     std::function<SmallVector<Value>(RewriterBase &, Location, ArrayRef<Value>,

--- a/include/triton/Tools/LayoutUtils.h
+++ b/include/triton/Tools/LayoutUtils.h
@@ -125,7 +125,8 @@ ColumnAction actionRemoveBroadcastedRegs(const LinearLayout &layout);
 
 std::pair<int64_t, ColumnAction>
 actionAdditiveStrides(const LinearLayout &layout, const LinearLayout addrLayout,
-                      uint64_t maskSpanOffsets, int64_t regsPerInst);
+                      uint64_t maskSpanOffsets, uint64_t maskSpanBlocks,
+                      int64_t regsPerInst);
 
 // For a layout A with A.hasInDim(kReg), repeat the values so that they have
 // the same broadcasting as layout

--- a/lib/Conversion/TritonGPUToLLVM/ConvertLayoutOpToLLVM.cpp
+++ b/lib/Conversion/TritonGPUToLLVM/ConvertLayoutOpToLLVM.cpp
@@ -235,12 +235,14 @@ struct ConvertLayoutOpConversion
       // Store
       lowerLdStShared(loc, ctx, storeCvt, tileInVals, llvmElemTy, smemBase,
                       /*paddingShifts=*/{}, affineOffset, maskSpanAffineOffset,
-                      rewriter, targetInfo);
+                      /*affineBlockOffset=*/Value(),
+                      /*maskSpanAffineBlock=*/0, rewriter, targetInfo);
       emitBarrier();
       // Load
       auto tileOutVals = lowerLdStShared(
           loc, ctx, loadCvt, {}, llvmElemTy, smemBase, /*paddingShifts=*/{},
-          affineOffset, maskSpanAffineOffset, rewriter, targetInfo);
+          affineOffset, maskSpanAffineOffset, /*affineBlockOffset=*/Value(),
+          /*maskSpanAffineBlock=*/0, rewriter, targetInfo);
       llvm::append_range(outVals, tileOutVals);
     }
 

--- a/lib/Conversion/TritonGPUToLLVM/Utility.cpp
+++ b/lib/Conversion/TritonGPUToLLVM/Utility.cpp
@@ -861,13 +861,8 @@ SmallVector<Value> lowerLdSt(
                     {kWarp, reps.getBases().lookup(kWarp)},
                     {kBlock, reps.getBases().lookup(kBlock)}},
                    reps.getOutDims(), false);
-  // actionAdditiveStrides compares flattened output bases, so place the block
-  // mask above the offset bits before checking for overlap.
-  uint64_t maskSpanAffine =
-      maskSpanAffineOffset |
-      (maskSpanAffineBlock << reps.getOutDimSizeLog2(kOffset));
-  auto [nAdditive, permStrides] =
-      actionAdditiveStrides(reps, addrLayout, maskSpanAffine, elemsPerVec);
+  auto [nAdditive, permStrides] = actionAdditiveStrides(
+      reps, addrLayout, maskSpanAffineOffset, maskSpanAffineBlock, elemsPerVec);
   reps = permStrides.apply(reps);
 
   if (isPartitioned) {

--- a/lib/Conversion/TritonGPUToLLVM/Utility.cpp
+++ b/lib/Conversion/TritonGPUToLLVM/Utility.cpp
@@ -619,14 +619,19 @@ materializeLocalAddrs(Location loc, triton::gpu::MemDescType memDescTy,
                       RewriterBase &rewriter) {
   auto b = TritonLLVMOpBuilder(loc, rewriter);
 
-  // Get the subslice affine offset (non-zero for memdesc subslices)
-  Value affineOffset = smemObj.getShmemOffset(loc, rewriter, memDescTy);
+  // Get the subslice affine offset and target CTA.
+  auto [affineOffset, affineBlockOffset] =
+      smemObj.getShmemOffsetAndBlock(loc, rewriter, memDescTy);
+  bool hasAffineBlock =
+      SharedMemoryObject::getMaskSpanOffsetsAndBlocks(memDescTy).second != 0;
   auto bitwidth = getIntOrFloatOrPtrBitWidth(llvmElemTy);
   SmallVector<LocalSharedMemoryAddress> addrs;
   addrs.reserve(offsetAndBlock.size());
   for (auto [offset, blockId] : offsetAndBlock) {
-    // For subslices, the physical offset is computed as:
+    // For subslices, the physical offset and target CTA are computed as:
     //   physical_offset = L⁻¹(coords) ⊕ L⁻¹(subslice_logical_offset)
+    //   target_cta = block(L⁻¹(coords)) ⊕
+    //                block(L⁻¹(subslice_logical_offset))
     //
     // We use XOR for consistency with lowerLdSt. MemDescSubsliceOp::verify()
     // enforces:
@@ -636,6 +641,11 @@ materializeLocalAddrs(Location loc, triton::gpu::MemDescType memDescTy,
     // These constraints ensure the bit ranges of L⁻¹(coords) and
     // L⁻¹(subslice_offset) are disjoint, so XOR and addition are equivalent.
     offset = b.xor_(offset, affineOffset);
+    if (hasAffineBlock) {
+      if (!blockId)
+        blockId = b.i32_val(0);
+      blockId = b.xor_(blockId, affineBlockOffset);
+    }
 
     // Add padding offset for padded layouts (non-linear component)
     Value ptr;
@@ -694,14 +704,13 @@ FailureOr<LocalAtomicScatterRMWInfo> prepareLocalAtomicScatterRMW(
   auto offsetAndBlock =
       computeBlockLocalOffsets(loc, memDescTy, activeRegLayout, idxValues,
                                op.getAxis(), rewriter, targetInfo);
-  SmallVector<Value> ptrs = llvm::map_to_vector(
-      materializeLocalAddrs(loc, memDescTy, smemObj, llvmElemTy, offsetAndBlock,
-                            rewriter),
-      [](const LocalSharedMemoryAddress &addr) { return addr.ptr; });
+  SmallVector<LocalSharedMemoryAddress> addrs =
+      materializeLocalAddrs(loc, memDescTy, smemObj, llvmElemTy,
+                            offsetAndBlock, rewriter);
 
   return LocalAtomicScatterRMWInfo{valuesTy,        llvmElemTy, regLayout,
                                    removeBroadcast, threadPred, values,
-                                   maskValues,      ptrs};
+                                   maskValues,      addrs};
 }
 
 SmallVector<std::pair<unsigned, unsigned>>
@@ -754,6 +763,7 @@ lowerLdStShared(Location loc, MLIRContext *ctx, LinearLayout cvt,
                 Type llvmElemTy, ArrayRef<Value> smemBases,
                 ArrayRef<std::pair<unsigned, unsigned>> paddingShifts,
                 Value affineOffset, uint64_t maskSpanAffineOffset,
+                Value affineBlockOffset, uint64_t maskSpanAffineBlock,
                 RewriterBase &rewriter, const TargetInfoBase &targetInfo,
                 std::optional<int> maybeMaxVecElems, Operation *localLoadOp) {
 
@@ -780,8 +790,9 @@ lowerLdStShared(Location loc, MLIRContext *ctx, LinearLayout cvt,
   };
   auto [laneId, warpId] = getLaneAndWarpId(rewriter, loc);
   return lowerLdSt(loc, ctx, cvt, valsArray, llvmElemTy, smemBases,
-                   paddingShifts, affineOffset, maskSpanAffineOffset, laneId,
-                   warpId, rewriter, targetInfo, maybeMaxVecElems, emitLdSt);
+                   paddingShifts, affineOffset, maskSpanAffineOffset,
+                   affineBlockOffset, maskSpanAffineBlock, laneId, warpId,
+                   rewriter, targetInfo, maybeMaxVecElems, emitLdSt);
 }
 
 SmallVector<Value> lowerLdSt(
@@ -789,7 +800,8 @@ SmallVector<Value> lowerLdSt(
     ArrayRef<Value> valsArray, // Input for store, output for load
     Type llvmElemTy, ArrayRef<Value> smemBases,
     ArrayRef<std::pair<unsigned, unsigned>> paddingShifts, Value affineOffset,
-    uint64_t maskSpanAffineOffset, Value laneId, Value warpId,
+    uint64_t maskSpanAffineOffset, Value affineBlockOffset,
+    uint64_t maskSpanAffineBlock, Value laneId, Value warpId,
     RewriterBase &rewriter, const TargetInfoBase &targetInfo,
     std::optional<int> maybeMaxVecElems,
     std::function<SmallVector<Value>(RewriterBase &, Location, ArrayRef<Value>,
@@ -869,9 +881,10 @@ SmallVector<Value> lowerLdSt(
       LinearLayout::zeros1D(bitwidth / 8, kReg, kOffset, bitwidth / 8);
   auto i8AddrLayout = i8Tile * addrLayout;
 
+  bool layoutUsesBlockId = !reps.isTrivialOver({kBlock});
+  bool useBlockId = layoutUsesBlockId || maskSpanAffineBlock != 0;
   Value blockId = b.i32_val(0);
-  bool useBlockId = !reps.isTrivialOver({kBlock});
-  if (useBlockId) {
+  if (layoutUsesBlockId) {
     blockId = targetInfo.getClusterCTAId(rewriter, loc);
   }
 
@@ -884,6 +897,8 @@ SmallVector<Value> lowerLdSt(
   Value targetCtaId;
   if (crossCTA) {
     targetCtaId = baseI8AndCTA[1].second;
+    if (maskSpanAffineBlock != 0)
+      targetCtaId = b.xor_(targetCtaId, affineBlockOffset);
   }
 
   // It's fine that we don't compute the offset in bytes as affineOffset
@@ -986,8 +1001,10 @@ lowerLocalLdSt(Location loc, MLIRContext *ctx,
     }
     return outVals;
   }
-  auto affineOffset = smemObj.getShmemOffset(loc, rewriter, srcTy);
-  auto maskSpanAffineOffset = smemObj.getMaskSpanOffsets(srcTy);
+  auto [affineOffset, affineBlockOffset] =
+      smemObj.getShmemOffsetAndBlock(loc, rewriter, srcTy);
+  auto [maskSpanAffineOffset, maskSpanAffineBlock] =
+      smemObj.getMaskSpanOffsetsAndBlocks(srcTy);
 
   // Extract padding info from padded encoding (standalone or inside
   // partitioned)
@@ -1007,7 +1024,8 @@ lowerLocalLdSt(Location loc, MLIRContext *ctx,
                                smemObj.getBases().end());
   return lowerLdStShared(loc, ctx, cvt, valsArray, llvmElemTy, smemBases,
                          paddingShifts, affineOffset, maskSpanAffineOffset,
-                         rewriter, targetInfo, maybeMaxVecElems, localLoadOp);
+                         affineBlockOffset, maskSpanAffineBlock, rewriter,
+                         targetInfo, maybeMaxVecElems, localLoadOp);
 }
 
 SmallVector<Value> unpackLLElements(Location loc, Value llvmStruct,
@@ -1323,8 +1341,8 @@ SmallVector<Type> SharedMemoryObject::getTypes() const {
   return types;
 }
 
-uint64_t
-SharedMemoryObject::getMaskSpanOffsets(triton::gpu::MemDescType srcTy) {
+std::pair<uint64_t, uint64_t> SharedMemoryObject::getMaskSpanOffsetsAndBlocks(
+    triton::gpu::MemDescType srcTy) {
   auto ctx = srcTy.getContext();
   auto shape = srcTy.getShape();
   auto allocShape = srcTy.getAllocShape();
@@ -1334,44 +1352,50 @@ SharedMemoryObject::getMaskSpanOffsets(triton::gpu::MemDescType srcTy) {
 
   // Early exist when there is no subview
   if (allocShape == shape) {
-    return 0;
+    return {0, 0};
   }
   auto totalLl =
       triton::gpu::isPaddedEncoding(srcTy.getEncoding())
           ? triton::gpu::paddedLinearLayout(allocShape, srcTy.getEncoding())
           : triton::gpu::toLinearLayout(allocShape, srcTy.getEncoding());
-  auto dimNames = standardOutDimNames(ctx, shape.size());
   // Map from dimNames to offset, block
   auto invLl = totalLl.pseudoinvert();
   SmallVector<std::pair<StringAttr, int32_t>> logicalOffsets;
-  for (auto dim : standardOutDimNames(srcTy.getContext(), shape.size())) {
+  for (auto dim : standardOutDimNames(ctx, shape.size())) {
     logicalOffsets.push_back({dim, 0});
   }
 
-  auto ret = 0;
+  uint64_t offsetMask = 0;
+  uint64_t blockMask = 0;
   for (auto [dim, shapes] : llvm::enumerate(llvm::zip(shape, allocShape))) {
     auto [shape, allocShape] = shapes;
     for (int j = llvm::Log2_32(shape); j < llvm::Log2_32(allocShape); ++j) {
       logicalOffsets[dim].second = 1 << j;
       auto offsetAndBlock = invLl.apply(logicalOffsets);
-      ret |= offsetAndBlock[0].second;
-      assert(offsetAndBlock[1].second == 0);
+      offsetMask |= offsetAndBlock[0].second;
+      blockMask |= offsetAndBlock[1].second;
     }
     // Reset the offset for the next dimension
     logicalOffsets[dim].second = 0;
   }
-  return ret;
+  return {offsetMask, blockMask};
 }
 
-Value SharedMemoryObject::getShmemOffset(Location loc, RewriterBase &rewriter,
-                                         triton::gpu::MemDescType srcTy) const {
+uint64_t
+SharedMemoryObject::getMaskSpanOffsets(triton::gpu::MemDescType srcTy) {
+  return getMaskSpanOffsetsAndBlocks(srcTy).first;
+}
+
+std::pair<Value, Value> SharedMemoryObject::getShmemOffsetAndBlock(
+    Location loc, RewriterBase &rewriter,
+    triton::gpu::MemDescType srcTy) const {
   auto ctx = srcTy.getContext();
   auto b = TritonLLVMOpBuilder(loc, rewriter);
 
   // If it did not have a memdesc_subslice we don't need to compute the offset
   // as it is zero
   if (!isAffineSharedMemoryAccess(srcTy)) {
-    return b.i32_val(0);
+    return {b.i32_val(0), b.i32_val(0)};
   }
 
   // We return the offset without the padding. The padding will be added in the
@@ -1389,13 +1413,14 @@ Value SharedMemoryObject::getShmemOffset(Location loc, RewriterBase &rewriter,
     logicalOffsets.push_back({dim, offset});
   }
 
-  // We don't allow for non-trivial block dimensions in the shared memory
-  // layout. We have in practice that offsetAndBlock[1].second is zero, but we
-  // cannot assert that without constant propagation so we just discard it.
-  auto offset =
-      applyLinearLayout(loc, rewriter, ll.pseudoinvert(), logicalOffsets)[0]
-          .second;
-  return offset;
+  auto offsetAndBlock =
+      applyLinearLayout(loc, rewriter, ll.pseudoinvert(), logicalOffsets);
+  return {offsetAndBlock[0].second, offsetAndBlock[1].second};
+}
+
+Value SharedMemoryObject::getShmemOffset(Location loc, RewriterBase &rewriter,
+                                         triton::gpu::MemDescType srcTy) const {
+  return getShmemOffsetAndBlock(loc, rewriter, srcTy).first;
 }
 
 Value SharedMemoryObject::getShmemAffineBase(
@@ -2081,7 +2106,8 @@ void finalizeTensorAtomicResults(Operation *op, RankedTensorType tensorTy,
   SmallVector<Value> smemBases = {smemBase};
   lowerLdSt(loc, ctx, storeCvt, uniqueResultVals, valueElemTy, smemBases,
             /*paddingShifts=*/{}, /*affineOffset=*/b.i32_val(0),
-            /*maskSpanAffineOffset=*/0, laneId, warpId, rewriter, targetInfo,
+            /*maskSpanAffineOffset=*/0, /*affineBlockOffset=*/Value(),
+            /*maskSpanAffineBlock=*/0, laneId, warpId, rewriter, targetInfo,
             /*maybeMaxVecElems=*/{}, emitSt);
   if (crossCTA)
     targetInfo.clusterBarrier(loc, rewriter, op);
@@ -2091,8 +2117,9 @@ void finalizeTensorAtomicResults(Operation *op, RankedTensorType tensorTy,
   resultVals =
       lowerLdSt(loc, ctx, loadCvt, /*valsArray=*/{}, valueElemTy, smemBases,
                 /*paddingShifts=*/{}, /*affineOffset=*/b.i32_val(0),
-                /*maskSpanAffineOffset=*/0, laneId, warpId, rewriter,
-                targetInfo, /*maybeMaxVecElems=*/{}, emitLd);
+                /*maskSpanAffineOffset=*/0, /*affineBlockOffset=*/Value(),
+                /*maskSpanAffineBlock=*/0, laneId, warpId, rewriter, targetInfo,
+                /*maybeMaxVecElems=*/{}, emitLd);
   if (!removeRegBroadcast.isIdentity())
     resultVals = broadcastAs(resultVals, regLayout);
 

--- a/lib/Conversion/TritonGPUToLLVM/Utility.cpp
+++ b/lib/Conversion/TritonGPUToLLVM/Utility.cpp
@@ -704,9 +704,8 @@ FailureOr<LocalAtomicScatterRMWInfo> prepareLocalAtomicScatterRMW(
   auto offsetAndBlock =
       computeBlockLocalOffsets(loc, memDescTy, activeRegLayout, idxValues,
                                op.getAxis(), rewriter, targetInfo);
-  SmallVector<LocalSharedMemoryAddress> addrs =
-      materializeLocalAddrs(loc, memDescTy, smemObj, llvmElemTy,
-                            offsetAndBlock, rewriter);
+  SmallVector<LocalSharedMemoryAddress> addrs = materializeLocalAddrs(
+      loc, memDescTy, smemObj, llvmElemTy, offsetAndBlock, rewriter);
 
   return LocalAtomicScatterRMWInfo{valuesTy,        llvmElemTy, regLayout,
                                    removeBroadcast, threadPred, values,

--- a/lib/Conversion/TritonGPUToLLVM/Utility.cpp
+++ b/lib/Conversion/TritonGPUToLLVM/Utility.cpp
@@ -861,8 +861,13 @@ SmallVector<Value> lowerLdSt(
                     {kWarp, reps.getBases().lookup(kWarp)},
                     {kBlock, reps.getBases().lookup(kBlock)}},
                    reps.getOutDims(), false);
-  auto [nAdditive, permStrides] = actionAdditiveStrides(
-      reps, addrLayout, maskSpanAffineOffset, elemsPerVec);
+  // actionAdditiveStrides compares flattened output bases, so place the block
+  // mask above the offset bits before checking for overlap.
+  uint64_t maskSpanAffine =
+      maskSpanAffineOffset |
+      (maskSpanAffineBlock << reps.getOutDimSizeLog2(kOffset));
+  auto [nAdditive, permStrides] =
+      actionAdditiveStrides(reps, addrLayout, maskSpanAffine, elemsPerVec);
   reps = permStrides.apply(reps);
 
   if (isPartitioned) {

--- a/lib/Dialect/TritonGPU/IR/Ops.cpp
+++ b/lib/Dialect/TritonGPU/IR/Ops.cpp
@@ -1162,13 +1162,9 @@ LogicalResult MemDescSubsliceOp::verify() {
       namedOffsets[dim] = {kDim, dimSize};
       auto offsetAndBlock = llInv.apply(namedOffsets);
       auto offset = offsetAndBlock[0];
-      auto block = offsetAndBlock[1];
       if (!llvm::isPowerOf2_32(offset.second) && offset.second != 0) {
         return emitError(
             "We don't support splitting along the swizzling pattern");
-      }
-      if (block.second != 0) {
-        return emitError("We don't support splitting along CTA dimensions");
       }
     }
   }

--- a/lib/Tools/LayoutUtils.cpp
+++ b/lib/Tools/LayoutUtils.cpp
@@ -295,12 +295,13 @@ ColumnAction actionRemoveBroadcastedRegs(const LinearLayout &layout) {
 }
 std::pair<int64_t, ColumnAction>
 actionAdditiveStrides(const LinearLayout &layout, const LinearLayout addrLayout,
-                      uint64_t maskSpanOffsets, int64_t regsPerInst) {
+                      uint64_t maskSpanOffsets, uint64_t maskSpanBlocks,
+                      int64_t regsPerInst) {
   // General idea:
   // We want to swap an xor into an addition when computing the register
-  // offsets. We can do this if the output bits of this register are disjoint
-  // from those from lanes/warps/blocks or any affine offset (i.e.,
-  // maskSpanOffsets).
+  // offsets and blocks. We can do this if each output component of this
+  // register is disjoint from the corresponding components from
+  // lanes/warps/blocks and any affine offset.
   //
   // Additionally, the lowering only ever evaluates register offsets at indices
   // that are multiples of `regsPerInst` (the inner-loop stride, matching one
@@ -315,20 +316,28 @@ actionAdditiveStrides(const LinearLayout &layout, const LinearLayout addrLayout,
          "regsPerInst must be a power of two");
   auto kReg = *layout.getInDimNames().begin();
   assert(kReg.str() == "register");
+  assert(layout.getNumOutDims() >= 1 && layout.getNumOutDims() <= 2);
+  assert(layout.getOutDims() == addrLayout.getOutDims());
   const size_t regBasisPerVec = llvm::Log2_64(regsPerInst);
-  uint32_t bits = maskSpanOffsets;
-  auto addrNamedBases = addrLayout.flattenOuts().getBases();
+  uint64_t offsetBits = maskSpanOffsets;
+  uint64_t blockBits = maskSpanBlocks;
+  bool hasBlock = layout.getNumOutDims() == 2;
+  auto addrNamedBases = addrLayout.getBases();
   for (auto bases : llvm::make_second_range(addrNamedBases)) {
     for (auto basis : bases) {
-      bits |= basis[0];
+      offsetBits |= basis[0];
+      if (hasBlock)
+        blockBits |= basis[1];
     }
   }
   SmallVector<size_t> front, back;
-  auto layoutNamedBases = layout.flattenOuts().getBases();
+  auto layoutNamedBases = layout.getBases();
   assert(layoutNamedBases.lookup(kReg).size() >= regBasisPerVec &&
          "layout must have at least log2(regsPerInst) register bases");
   for (auto [idx, basis] : llvm::enumerate(layoutNamedBases.lookup(kReg))) {
-    if (idx < regBasisPerVec || (basis[0] & bits) == 0) {
+    bool isAdditive = (basis[0] & offsetBits) == 0 &&
+                      (!hasBlock || (basis[1] & blockBits) == 0);
+    if (idx < regBasisPerVec || isAdditive) {
       front.push_back(idx);
     } else {
       back.push_back(idx);

--- a/lib/Tools/LayoutUtils.cpp
+++ b/lib/Tools/LayoutUtils.cpp
@@ -316,18 +316,16 @@ actionAdditiveStrides(const LinearLayout &layout, const LinearLayout addrLayout,
          "regsPerInst must be a power of two");
   auto kReg = *layout.getInDimNames().begin();
   assert(kReg.str() == "register");
-  assert(layout.getNumOutDims() >= 1 && layout.getNumOutDims() <= 2);
+  assert(layout.getNumOutDims() == 2);
   assert(layout.getOutDims() == addrLayout.getOutDims());
   const size_t regBasisPerVec = llvm::Log2_64(regsPerInst);
   uint64_t offsetBits = maskSpanOffsets;
   uint64_t blockBits = maskSpanBlocks;
-  bool hasBlock = layout.getNumOutDims() == 2;
   auto addrNamedBases = addrLayout.getBases();
   for (auto bases : llvm::make_second_range(addrNamedBases)) {
     for (auto basis : bases) {
       offsetBits |= basis[0];
-      if (hasBlock)
-        blockBits |= basis[1];
+      blockBits |= basis[1];
     }
   }
   SmallVector<size_t> front, back;
@@ -335,8 +333,8 @@ actionAdditiveStrides(const LinearLayout &layout, const LinearLayout addrLayout,
   assert(layoutNamedBases.lookup(kReg).size() >= regBasisPerVec &&
          "layout must have at least log2(regsPerInst) register bases");
   for (auto [idx, basis] : llvm::enumerate(layoutNamedBases.lookup(kReg))) {
-    bool isAdditive = (basis[0] & offsetBits) == 0 &&
-                      (!hasBlock || (basis[1] & blockBits) == 0);
+    bool isAdditive =
+        (basis[0] & offsetBits) == 0 && (basis[1] & blockBits) == 0;
     if (idx < regBasisPerVec || isAdditive) {
       front.push_back(idx);
     } else {

--- a/python/test/gluon/test_core.py
+++ b/python/test/gluon/test_core.py
@@ -2997,6 +2997,101 @@ def test_shared_gather_cga(num_ctas, broadcast_mask):
 
 
 @gluon.jit
+def shared_subslice_two_ctas_kernel(
+    inp,
+    values,
+    result_out,
+    final_out,
+    OP: ttgl.constexpr,
+    alloc_layout: ttgl.constexpr,
+    tile_layout: ttgl.constexpr,
+):
+    shared_layout: ttgl.constexpr = ttgl.SwizzledSharedLayout(1, 1, 1, order=[1, 0], cga_layout=[[1, 0]])
+    alloc_rows = ttgl.arange(0, 4, layout=ttgl.SliceLayout(1, alloc_layout))
+    alloc_cols = ttgl.arange(0, 32, layout=ttgl.SliceLayout(0, alloc_layout))
+    alloc_offsets = alloc_rows[:, None] * 32 + alloc_cols[None, :]
+    initial = ttgl.load(inp + alloc_offsets)
+    smem = ttgl.allocate_shared_memory(ttgl.int32, [4, 32], shared_layout, value=initial)
+    ttgl.barrier(cluster=True)
+
+    tile = smem.slice(2, 2, dim=0)
+    tile_rows = ttgl.arange(0, 2, layout=ttgl.SliceLayout(1, tile_layout))
+    tile_cols = ttgl.arange(0, 32, layout=ttgl.SliceLayout(0, tile_layout))
+    tile_offsets = tile_rows[:, None] * 32 + tile_cols[None, :]
+
+    if OP == "load":
+        result = tile.load(tile_layout)
+        ttgl.store(result_out + tile_offsets, result)
+    elif OP == "gather":
+        peer_cols = (tile_cols ^ 1)[None, :] + tile_rows[:, None] * 0
+        result = tile.gather(peer_cols, axis=1)
+        ttgl.store(result_out + tile_offsets, result)
+    else:
+        update = ttgl.load(values + tile_offsets)
+        if OP == "store":
+            tile.store(update)
+        elif OP == "scatter":
+            peer_cols = (tile_cols ^ 1)[None, :] + tile_rows[:, None] * 0
+            tile.scatter(update, peer_cols, axis=1)
+        else:
+            indices = tile_cols[None, :] + tile_rows[:, None] * 0
+            old = tile.atomic_scatter_add(update, indices, axis=1)
+            ones = ttgl.full([2, 32], 1, ttgl.int32, tile_layout)
+            tile.atomic_scatter_add(ones, indices, axis=1)
+            ttgl.store(result_out + tile_offsets, old)
+        ttgl.barrier(cluster=True)
+        final = smem.load(alloc_layout)
+        ttgl.store(final_out + alloc_offsets, final)
+
+
+@pytest.mark.skipif(not is_hopper_or_newer(), reason="Requires Hopper")
+@pytest.mark.parametrize("op", ["load", "store", "gather", "scatter", "atomic"])
+def test_shared_subslice_two_ctas(op):
+    inp = torch.arange(4 * 32, dtype=torch.int32, device="cuda").reshape(4, 32)
+    values = torch.arange(2 * 32, dtype=torch.int32, device="cuda").reshape(2, 32) + 1000
+    if op == "atomic":
+        values.fill_(1)
+    result = torch.empty((2, 32), dtype=torch.int32, device="cuda")
+    final = torch.empty_like(inp)
+    alloc_layout = ttgl.BlockedLayout([1, 1], [1, 32], [1, 4], [1, 0], cga_layout=[[1, 0]])
+    tile_layout = ttgl.BlockedLayout([1, 1], [1, 32], [1, 4], [1, 0], cga_layout=[[0, 0]])
+
+    compiled = shared_subslice_two_ctas_kernel[(1, )](
+        inp,
+        values,
+        result,
+        final,
+        OP=op,
+        alloc_layout=alloc_layout,
+        tile_layout=tile_layout,
+        num_warps=4,
+        num_ctas=2,
+    )
+
+    ptx = compiled.asm["ptx"]
+    if op in ("load", "gather"):
+        assert "ld.shared::cluster" in ptx
+        expected = inp[2:4]
+        if op == "gather":
+            expected = expected.reshape(2, 16, 2).flip(-1).reshape(2, 32)
+        torch.testing.assert_close(result, expected, atol=0, rtol=0)
+    else:
+        expected = inp.clone()
+        if op == "store":
+            expected[2:4] = values
+            assert "st.shared::cluster" in ptx
+        elif op == "scatter":
+            expected[2:4] = values.reshape(2, 16, 2).flip(-1).reshape(2, 32)
+            assert "st.shared::cluster" in ptx
+        else:
+            expected[2:4] += values + 1
+            assert "atom.shared::cluster.cluster.relaxed.add.u32" in ptx
+            assert "red.shared::cluster.cluster.relaxed.inc.u32" in ptx
+            torch.testing.assert_close(result, inp[2:4], atol=0, rtol=0)
+        torch.testing.assert_close(final, expected, atol=0, rtol=0)
+
+
+@gluon.jit
 def shared_scatter_kernel(
     indices_ptr,
     values_ptr,

--- a/python/test/gluon/test_core.py
+++ b/python/test/gluon/test_core.py
@@ -3092,6 +3092,62 @@ def test_shared_subslice_two_ctas(op):
 
 
 @gluon.jit
+def shared_subslice_swizzled_register_block_kernel(inp, out, alloc_layout: ttgl.constexpr, tile_layout: ttgl.constexpr,
+                                                   shared_layout: ttgl.constexpr):
+    rows = ttgl.arange(0, 4, layout=ttgl.SliceLayout(1, alloc_layout))
+    cols = ttgl.arange(0, 32, layout=ttgl.SliceLayout(0, alloc_layout))
+    offsets = rows[:, None] * 32 + cols[None, :]
+    initial = ttgl.load(inp + offsets)
+    smem = ttgl.allocate_shared_memory(ttgl.int32, [4, 32], shared_layout, value=initial)
+    ttgl.barrier(cluster=True)
+
+    tile = smem.slice(2, 2, dim=0)
+    loaded = tile.load(tile_layout)
+    tile_rows = ttgl.arange(0, 2, layout=ttgl.SliceLayout(1, tile_layout))
+    tile_cols = ttgl.arange(0, 32, layout=ttgl.SliceLayout(0, tile_layout))
+    tile_offsets = tile_rows[:, None] * 32 + tile_cols[None, :]
+    ttgl.store(out + tile_offsets, loaded)
+
+
+@pytest.mark.skipif(not is_hopper_or_newer(), reason="Requires Hopper")
+def test_shared_subslice_swizzled_register_block():
+    # The shared layout maps logical row bit 0 to an offset bit and block bit 0,
+    # while logical row bit 1 maps to block bit 0. Slicing at row 2 therefore
+    # makes the affine block offset overlap the tile's register block basis.
+    shared_layout = ttgl.SharedLinearLayout(
+        offset_bases=[[0, 1], [0, 2], [0, 4], [0, 8], [0, 16], [3, 0]],
+        block_bases=[[2, 0]],
+    )
+    alloc_layout = ttgl.DistributedLinearLayout(
+        reg_bases=[],
+        lane_bases=[[0, 1], [0, 2], [0, 4], [0, 8], [0, 16]],
+        warp_bases=[[1, 0], [2, 0]],
+        block_bases=[[0, 0]],
+        shape=[4, 32],
+    )
+    tile_layout = ttgl.DistributedLinearLayout(
+        reg_bases=[[1, 0]],
+        lane_bases=[[0, 1], [0, 2], [0, 4], [0, 8], [0, 16]],
+        warp_bases=[[0, 0], [0, 0]],
+        block_bases=[[0, 0]],
+        shape=[2, 32],
+    )
+
+    inp = torch.arange(4 * 32, dtype=torch.int32, device="cuda").reshape(4, 32)
+    out = torch.empty((2, 32), dtype=torch.int32, device="cuda")
+    shared_subslice_swizzled_register_block_kernel[(1, )](
+        inp,
+        out,
+        alloc_layout=alloc_layout,
+        tile_layout=tile_layout,
+        shared_layout=shared_layout,
+        num_warps=4,
+        num_ctas=2,
+    )
+    torch.testing.assert_close(out, inp[2:4], atol=0, rtol=0)
+
+
+@gluon.jit
 def shared_scatter_kernel(
     indices_ptr,
     values_ptr,

--- a/python/test/gsan/test_gsan.py
+++ b/python/test/gsan/test_gsan.py
@@ -10,9 +10,8 @@ from triton.experimental.gluon.language.nvidia.ampere import async_copy
 from triton.tools.tensor_descriptor import TensorDescriptor
 
 from triton._internal_testing import is_blackwell, is_cuda, is_ampere_or_newer, is_hopper_or_newer
-from triton.experimental.gsan import create_mem_pool, warmup_gsan_kernels
+from triton.experimental.gsan import create_mem_pool
 from triton._C.libtriton.gsan_testing import AtomicScope, SHADOW_GRANULARITY_BYTES, ScalarClock
-from triton.experimental.gsan._stream_sync import _synchronize_vector_clocks_kernel
 from triton.experimental.gsan._testing_utils import (atomic_poll, load_one_i32, shadow_cell_from_address, store_one_i32,
                                                      thread_state_from_smid)
 
@@ -102,17 +101,6 @@ def _assert_cross_sm_sync(payload_ptr: torch.Tensor, flag_ptr: torch.Tensor, exp
 def _assert_no_gsan_runtime_output(capfd) -> None:
     captured = capfd.readouterr()
     assert "GSanLibrary.cu" not in captured.out + captured.err
-
-
-def test_stream_sync_layout_args_do_not_specialize():
-    params = {param.name: param for param in _synchronize_vector_clocks_kernel.params}
-    for name in ("stride_bytes", "num_sms", "num_threads", "header_bytes"):
-        assert params[name].do_not_specialize
-
-
-@pytest.mark.skipif(not is_cuda(), reason="GSan requires CUDA")
-def test_warmup_gsan_kernels():
-    assert warmup_gsan_kernels() is None
 
 
 @pytest.mark.skipif(not is_cuda(), reason="GSan requires CUDA")

--- a/python/test/gsan/test_gsan.py
+++ b/python/test/gsan/test_gsan.py
@@ -10,9 +10,8 @@ from triton.experimental.gluon.language.nvidia.ampere import async_copy
 from triton.tools.tensor_descriptor import TensorDescriptor
 
 from triton._internal_testing import is_blackwell, is_cuda, is_ampere_or_newer, is_hopper_or_newer
-from triton.experimental.gsan import create_mem_pool, prepare_launch_stream_sync
+from triton.experimental.gsan import create_mem_pool, warmup_gsan_kernels
 from triton._C.libtriton.gsan_testing import AtomicScope, SHADOW_GRANULARITY_BYTES, ScalarClock
-from triton.experimental.gsan._allocator import get_reserve_pointer, get_reserve_size
 from triton.experimental.gsan._stream_sync import _synchronize_vector_clocks_kernel
 from triton.experimental.gsan._testing_utils import (atomic_poll, load_one_i32, shadow_cell_from_address, store_one_i32,
                                                      thread_state_from_smid)
@@ -105,16 +104,15 @@ def _assert_no_gsan_runtime_output(capfd) -> None:
     assert "GSanLibrary.cu" not in captured.out + captured.err
 
 
-def test_stream_sync_layout_args_do_not_specialize_on_alignment():
+def test_stream_sync_layout_args_do_not_specialize():
     params = {param.name: param for param in _synchronize_vector_clocks_kernel.params}
     for name in ("stride_bytes", "num_sms", "num_threads", "header_bytes"):
-        assert params[name].do_not_specialize_on_alignment
+        assert params[name].do_not_specialize
 
 
 @pytest.mark.skipif(not is_cuda(), reason="GSan requires CUDA")
-def test_prepare_launch_stream_sync(with_gsan):
-    torch.empty(1, device="cuda")
-    assert prepare_launch_stream_sync(torch.cuda.current_device()) is not None
+def test_warmup_gsan_kernels():
+    assert warmup_gsan_kernels() is None
 
 
 @pytest.mark.skipif(not is_cuda(), reason="GSan requires CUDA")
@@ -143,24 +141,6 @@ def test_load_store_updates_shadow(with_gsan):
     assert cell1.read_clocks[0] == ScalarClock(epoch1, tid, AtomicScope.NON_ATOMIC)
     # Scalar accesses are instrumented once via the redundant-thread predicate.
     assert cell1.num_reads == 1
-
-
-@pytest.mark.skipif(not is_cuda(), reason="GSan requires CUDA")
-def test_unmanaged_read_managed_write(fresh_knobs):
-    source = torch.tensor([7], dtype=torch.int32, device="cuda")
-
-    triton.knobs.compilation.instrumentation_mode = "gsan"
-    pool = create_mem_pool()
-    with torch.cuda.use_mem_pool(pool):
-        out = torch.zeros(1, dtype=torch.int32, device="cuda")
-        load_one_i32[(1, )](source, out, num_warps=1)
-        torch.cuda.synchronize()
-
-    reserve = get_reserve_pointer()
-    reserve_size = get_reserve_size()
-    assert not reserve <= source.data_ptr() < reserve + reserve_size
-    assert reserve <= out.data_ptr() < reserve + reserve_size
-    assert out.item() == 7
 
 
 @gluon.jit

--- a/python/test/gsan/test_gsan.py
+++ b/python/test/gsan/test_gsan.py
@@ -113,6 +113,7 @@ def test_stream_sync_layout_args_do_not_specialize_on_alignment():
 
 @pytest.mark.skipif(not is_cuda(), reason="GSan requires CUDA")
 def test_prepare_launch_stream_sync(with_gsan):
+    torch.empty(1, device="cuda")
     assert prepare_launch_stream_sync(torch.cuda.current_device()) is not None
 
 

--- a/python/test/gsan/test_gsan.py
+++ b/python/test/gsan/test_gsan.py
@@ -10,8 +10,10 @@ from triton.experimental.gluon.language.nvidia.ampere import async_copy
 from triton.tools.tensor_descriptor import TensorDescriptor
 
 from triton._internal_testing import is_blackwell, is_cuda, is_ampere_or_newer, is_hopper_or_newer
-from triton.experimental.gsan import create_mem_pool
+from triton.experimental.gsan import create_mem_pool, prepare_launch_stream_sync
 from triton._C.libtriton.gsan_testing import AtomicScope, SHADOW_GRANULARITY_BYTES, ScalarClock
+from triton.experimental.gsan._allocator import get_reserve_pointer, get_reserve_size
+from triton.experimental.gsan._stream_sync import _synchronize_vector_clocks_kernel
 from triton.experimental.gsan._testing_utils import (atomic_poll, load_one_i32, shadow_cell_from_address, store_one_i32,
                                                      thread_state_from_smid)
 
@@ -103,6 +105,17 @@ def _assert_no_gsan_runtime_output(capfd) -> None:
     assert "GSanLibrary.cu" not in captured.out + captured.err
 
 
+def test_stream_sync_layout_args_do_not_specialize_on_alignment():
+    params = {param.name: param for param in _synchronize_vector_clocks_kernel.params}
+    for name in ("stride_bytes", "num_sms", "num_threads", "header_bytes"):
+        assert params[name].do_not_specialize_on_alignment
+
+
+@pytest.mark.skipif(not is_cuda(), reason="GSan requires CUDA")
+def test_prepare_launch_stream_sync(with_gsan):
+    assert prepare_launch_stream_sync(torch.cuda.current_device()) is not None
+
+
 @pytest.mark.skipif(not is_cuda(), reason="GSan requires CUDA")
 def test_load_store_updates_shadow(with_gsan):
     target = torch.zeros(1, dtype=torch.int32, device="cuda")
@@ -129,6 +142,24 @@ def test_load_store_updates_shadow(with_gsan):
     assert cell1.read_clocks[0] == ScalarClock(epoch1, tid, AtomicScope.NON_ATOMIC)
     # Scalar accesses are instrumented once via the redundant-thread predicate.
     assert cell1.num_reads == 1
+
+
+@pytest.mark.skipif(not is_cuda(), reason="GSan requires CUDA")
+def test_unmanaged_read_managed_write(fresh_knobs):
+    source = torch.tensor([7], dtype=torch.int32, device="cuda")
+
+    triton.knobs.compilation.instrumentation_mode = "gsan"
+    pool = create_mem_pool()
+    with torch.cuda.use_mem_pool(pool):
+        out = torch.zeros(1, dtype=torch.int32, device="cuda")
+        load_one_i32[(1, )](source, out, num_warps=1)
+        torch.cuda.synchronize()
+
+    reserve = get_reserve_pointer()
+    reserve_size = get_reserve_size()
+    assert not reserve <= source.data_ptr() < reserve + reserve_size
+    assert reserve <= out.data_ptr() < reserve + reserve_size
+    assert out.item() == 7
 
 
 @gluon.jit

--- a/python/triton/experimental/gsan/__init__.py
+++ b/python/triton/experimental/gsan/__init__.py
@@ -1,6 +1,14 @@
 from ._allocator import ShareableHandleType, configure, create_mem_pool, freeze_config, get_allocator
+from ._stream_sync import prepare_launch_stream_sync
 
-__all__ = ["ShareableHandleType", "configure", "create_mem_pool", "freeze_config", "get_allocator"]
+__all__ = [
+    "ShareableHandleType",
+    "configure",
+    "create_mem_pool",
+    "freeze_config",
+    "get_allocator",
+    "prepare_launch_stream_sync",
+]
 
 _LAZY_LOAD_MODULES = {"symmetric_memory"}
 

--- a/python/triton/experimental/gsan/__init__.py
+++ b/python/triton/experimental/gsan/__init__.py
@@ -1,5 +1,5 @@
 from ._allocator import ShareableHandleType, configure, create_mem_pool, freeze_config, get_allocator
-from ._stream_sync import prepare_launch_stream_sync
+from ._stream_sync import warmup_gsan_kernels
 
 __all__ = [
     "ShareableHandleType",
@@ -7,7 +7,7 @@ __all__ = [
     "create_mem_pool",
     "freeze_config",
     "get_allocator",
-    "prepare_launch_stream_sync",
+    "warmup_gsan_kernels",
 ]
 
 _LAZY_LOAD_MODULES = {"symmetric_memory"}

--- a/python/triton/experimental/gsan/_stream_sync.py
+++ b/python/triton/experimental/gsan/_stream_sync.py
@@ -43,23 +43,22 @@ def _compile_without_gsan():
         yield
 
 
-@functools.lru_cache()
-def _compiled_sync_kernel(device: int, stride_bytes: int, num_sms: int, num_threads: int, header_bytes: int,
-                          BLOCK_SIZE):
+def warmup_gsan_kernels() -> None:
+    """Compile GSan support kernels without initializing the GSan runtime."""
     with _compile_without_gsan():
-        return _synchronize_vector_clocks_kernel.warmup(
+        _synchronize_vector_clocks_kernel.warmup(
             triton.MockTensor(tl.uint8),
-            stride_bytes,
-            num_sms,
-            num_threads,
-            header_bytes,
-            BLOCK_SIZE=BLOCK_SIZE,
+            0,
+            0,
+            0,
+            0,
+            BLOCK_SIZE=_SYNC_BLOCK_SIZE,
             grid=(1, ),
             num_warps=1,
         )
 
 
-@triton.jit(do_not_specialize_on_alignment=["stride_bytes", "num_sms", "num_threads", "header_bytes"])
+@triton.jit(do_not_specialize=["stride_bytes", "num_sms", "num_threads", "header_bytes"])
 def _synchronize_vector_clocks_kernel(thread_state_region, stride_bytes, num_sms, num_threads, header_bytes,
                                       BLOCK_SIZE: tl.constexpr):
     pid = tl.program_id(axis=0)
@@ -106,19 +105,6 @@ def _synchronize_process_group_barrier_kernel(local_thread_state_region, peer_th
         tl.store(vector_clock_ptr + offsets, max_clocks, mask=mask)
 
 
-def prepare_launch_stream_sync(device: int):
-    """Precompile and cache the synchronization kernel used before launches."""
-    layout = _runtime_state_layout(get_device_rank(device), device)
-    return _compiled_sync_kernel(
-        device,
-        layout.thread_state_stride_bytes,
-        layout.num_sms,
-        layout.num_threads,
-        layout.thread_state_header_size_bytes,
-        _SYNC_BLOCK_SIZE,
-    )
-
-
 def synchronize_launch_stream(device: int) -> None:
     """This models the implicit synchronization between kernel launches.
 
@@ -128,15 +114,16 @@ def synchronize_launch_stream(device: int) -> None:
     """
     layout = _runtime_state_layout(get_device_rank(device), device)
     grid = (triton.cdiv(layout.num_threads, _SYNC_BLOCK_SIZE), 1, 1)
-    kernel = prepare_launch_stream_sync(device)
-    kernel[grid](
-        layout.thread_state_region,
-        layout.thread_state_stride_bytes,
-        layout.num_sms,
-        layout.num_threads,
-        layout.thread_state_header_size_bytes,
-        _SYNC_BLOCK_SIZE,
-    )
+    with _compile_without_gsan():
+        _synchronize_vector_clocks_kernel[grid](
+            layout.thread_state_region,
+            layout.thread_state_stride_bytes,
+            layout.num_sms,
+            layout.num_threads,
+            layout.thread_state_header_size_bytes,
+            BLOCK_SIZE=_SYNC_BLOCK_SIZE,
+            num_warps=1,
+        )
 
 
 def synchronize_process_group_barrier(device: int, peer_devices: tuple[int, ...]) -> None:

--- a/python/triton/experimental/gsan/_stream_sync.py
+++ b/python/triton/experimental/gsan/_stream_sync.py
@@ -10,6 +10,8 @@ import triton.language as tl
 from ._allocator import get_device_rank, get_runtime_state_layout
 from ._utils import uint8_cuda_tensor_from_ptr
 
+_SYNC_BLOCK_SIZE = 128
+
 
 @dataclass(frozen=True)
 class _RuntimeStateLayout:
@@ -57,7 +59,7 @@ def _compiled_sync_kernel(device: int, stride_bytes: int, num_sms: int, num_thre
         )
 
 
-@triton.jit
+@triton.jit(do_not_specialize_on_alignment=["stride_bytes", "num_sms", "num_threads", "header_bytes"])
 def _synchronize_vector_clocks_kernel(thread_state_region, stride_bytes, num_sms, num_threads, header_bytes,
                                       BLOCK_SIZE: tl.constexpr):
     pid = tl.program_id(axis=0)
@@ -104,6 +106,19 @@ def _synchronize_process_group_barrier_kernel(local_thread_state_region, peer_th
         tl.store(vector_clock_ptr + offsets, max_clocks, mask=mask)
 
 
+def prepare_launch_stream_sync(device: int):
+    """Precompile and cache the synchronization kernel used before launches."""
+    layout = _runtime_state_layout(get_device_rank(device), device)
+    return _compiled_sync_kernel(
+        device,
+        layout.thread_state_stride_bytes,
+        layout.num_sms,
+        layout.num_threads,
+        layout.thread_state_header_size_bytes,
+        _SYNC_BLOCK_SIZE,
+    )
+
+
 def synchronize_launch_stream(device: int) -> None:
     """This models the implicit synchronization between kernel launches.
 
@@ -112,23 +127,15 @@ def synchronize_launch_stream(device: int) -> None:
     This makes all reads and writes transitively visible to other threads.
     """
     layout = _runtime_state_layout(get_device_rank(device), device)
-    BLOCK_SIZE = 128
-    grid = (triton.cdiv(layout.num_threads, BLOCK_SIZE), 1, 1)
-    kernel = _compiled_sync_kernel(
-        device,
-        layout.thread_state_stride_bytes,
-        layout.num_sms,
-        layout.num_threads,
-        layout.thread_state_header_size_bytes,
-        BLOCK_SIZE,
-    )
+    grid = (triton.cdiv(layout.num_threads, _SYNC_BLOCK_SIZE), 1, 1)
+    kernel = prepare_launch_stream_sync(device)
     kernel[grid](
         layout.thread_state_region,
         layout.thread_state_stride_bytes,
         layout.num_sms,
         layout.num_threads,
         layout.thread_state_header_size_bytes,
-        BLOCK_SIZE,
+        _SYNC_BLOCK_SIZE,
     )
 
 

--- a/python/triton/experimental/gsan/_stream_sync.py
+++ b/python/triton/experimental/gsan/_stream_sync.py
@@ -10,8 +10,6 @@ import triton.language as tl
 from ._allocator import get_device_rank, get_runtime_state_layout
 from ._utils import uint8_cuda_tensor_from_ptr
 
-_SYNC_BLOCK_SIZE = 128
-
 
 @dataclass(frozen=True)
 class _RuntimeStateLayout:
@@ -52,7 +50,7 @@ def warmup_gsan_kernels() -> None:
             0,
             0,
             0,
-            BLOCK_SIZE=_SYNC_BLOCK_SIZE,
+            BLOCK_SIZE=128,
             grid=(1, ),
             num_warps=1,
         )
@@ -113,7 +111,7 @@ def synchronize_launch_stream(device: int) -> None:
     This makes all reads and writes transitively visible to other threads.
     """
     layout = _runtime_state_layout(get_device_rank(device), device)
-    grid = (triton.cdiv(layout.num_threads, _SYNC_BLOCK_SIZE), 1, 1)
+    grid = (triton.cdiv(layout.num_threads, 128), 1, 1)
     with _compile_without_gsan():
         _synchronize_vector_clocks_kernel[grid](
             layout.thread_state_region,
@@ -121,7 +119,7 @@ def synchronize_launch_stream(device: int) -> None:
             layout.num_sms,
             layout.num_threads,
             layout.thread_state_header_size_bytes,
-            BLOCK_SIZE=_SYNC_BLOCK_SIZE,
+            BLOCK_SIZE=128,
             num_warps=1,
         )
 

--- a/python/triton/experimental/gsan/src/GSan.h
+++ b/python/triton/experimental/gsan/src/GSan.h
@@ -19,7 +19,7 @@ using uint16_t = __UINT16_TYPE__;
 using uint32_t = __UINT32_TYPE__;
 using uintptr_t = __UINTPTR_TYPE__;
 
-// Reserve 1 PiB, should be big enough for a while :)
+// Reserve 1 TiB, should be big enough for a while :)
 static constexpr size_t kReserveSize = 1ull << 40;
 static constexpr int kShadowMemGranularityBytes = 4;
 static_assert((kReserveSize & (kReserveSize - 1)) == 0,

--- a/python/triton/experimental/gsan/src/GSan.h
+++ b/python/triton/experimental/gsan/src/GSan.h
@@ -19,7 +19,7 @@ using uint16_t = __UINT16_TYPE__;
 using uint32_t = __UINT32_TYPE__;
 using uintptr_t = __UINTPTR_TYPE__;
 
-// Reserve 1 TiB, should be big enough for a while :)
+// Reserve 1 PiB, should be big enough for a while :)
 static constexpr size_t kReserveSize = 1ull << 40;
 static constexpr int kShadowMemGranularityBytes = 4;
 static_assert((kReserveSize & (kReserveSize - 1)) == 0,

--- a/python/triton/experimental/gsan/src/GSanLibrary.cu
+++ b/python/triton/experimental/gsan/src/GSanLibrary.cu
@@ -477,6 +477,8 @@ GSAN_DEVICE void readRange(ThreadState *state, uintptr_t read_addr, int nBytes,
   auto range = roundRange(Range{read_addr, read_addr + nBytes});
 
   auto reserveBase = state->reserveBase;
+  if (range.start >= reserveBase + kReserveSize || reserveBase >= range.end)
+    return;
   rwLockAcquireRead(state->lock);
 
   for (uintptr_t addr = range.start; addr < range.end;

--- a/test/Conversion/tritonnvidiagpu_to_llvm.mlir
+++ b/test/Conversion/tritonnvidiagpu_to_llvm.mlir
@@ -614,6 +614,8 @@ module attributes {"ttg.num-ctas" = 2 : i32, "ttg.num-warps" = 4 : i32, "ttg.tot
 #local_gather_scatter_blocked = #ttg.blocked<{sizePerThread = [1, 1], threadsPerWarp = [1, 32], warpsPerCTA = [1, 4], order = [1, 0], CGALayout = [[0, 1]]}>
 #local_gather_scatter_shared_split = #ttg.swizzled_shared<{vec = 1, perPhase = 1, maxPhase = 1, order = [1, 0], CGALayout = [[0, 1]]}>
 #local_gather_scatter_shared_broadcast = #ttg.swizzled_shared<{vec = 1, perPhase = 1, maxPhase = 1, order = [1, 0], CGALayout = [[0, 0]]}>
+#local_subslice_blocked = #ttg.blocked<{sizePerThread = [1, 1], threadsPerWarp = [1, 32], warpsPerCTA = [1, 4], order = [1, 0], CGALayout = [[0, 0]]}>
+#local_subslice_shared = #ttg.swizzled_shared<{vec = 1, perPhase = 1, maxPhase = 1, order = [1, 0], CGALayout = [[1, 0]]}>
 
 module attributes {"ttg.num-ctas" = 2 : i32, "ttg.num-warps" = 4 : i32, "ttg.threads-per-warp" = 32 : i32} {
   // CHECK-LABEL: @local_gather_scatter_same_ownership
@@ -672,6 +674,96 @@ module attributes {"ttg.num-ctas" = 2 : i32, "ttg.num-warps" = 4 : i32, "ttg.thr
     %offs = arith.constant dense<0> : tensor<2x32xi32, #local_gather_scatter_blocked>
     %out_ptrs = tt.addptr %ptrs, %offs : tensor<2x32x!tt.ptr<i32>, #local_gather_scatter_blocked>, tensor<2x32xi32, #local_gather_scatter_blocked>
     tt.store %out_ptrs, %g : tensor<2x32x!tt.ptr<i32>, #local_gather_scatter_blocked>
+    tt.return
+  }
+}
+
+// -----
+
+module attributes {"ttg.num-ctas" = 2 : i32, "ttg.num-warps" = 4 : i32, "ttg.threads-per-warp" = 32 : i32} {
+  // CHECK-LABEL: @local_gather_subslice_other_cta
+  // CHECK: nvvm.mapa
+  // CHECK: llvm.load {{.*}} : !llvm.ptr<7> -> i32
+  // SUBSLICE-LABEL: @local_gather_subslice_other_cta
+  // SUBSLICE: %[[ONE:.*]] = llvm.mlir.constant(1 : i32) : i32
+  // SUBSLICE: %[[TWO:.*]] = llvm.mlir.constant(2 : i32) : i32
+  // SUBSLICE: %[[MASKED_BLOCK:.*]] = llvm.and %{{.*}}, %[[TWO]] : i32
+  // SUBSLICE-NEXT: %[[SHIFTED_BLOCK:.*]] = llvm.lshr %[[MASKED_BLOCK]], %[[ONE]] : i32
+  // SUBSLICE-NEXT: %[[BLOCK_OFFSET_BITS:.*]] = llvm.or disjoint %[[SHIFTED_BLOCK]], %{{.*}} : i32
+  // SUBSLICE-NEXT: %[[BLOCK_OFFSET:.*]] = llvm.xor %{{.*}}, %[[BLOCK_OFFSET_BITS]] : i32
+  // SUBSLICE: %[[TARGET_CTA:.*]] = llvm.xor %{{.*}}, %[[BLOCK_OFFSET]] : i32
+  // SUBSLICE: nvvm.mapa %{{.*}}, %[[TARGET_CTA]]
+  tt.func @local_gather_subslice_other_cta(%out: !tt.ptr<i32>) {
+    %src = ttg.local_alloc {allocation.offset = 0 : i32} : () -> !ttg.memdesc<4x32xi32, #local_subslice_shared, #ttg.shared_memory, mutable>
+    %tile = ttg.memdesc_subslice %src [2, 0] : !ttg.memdesc<4x32xi32, #local_subslice_shared, #ttg.shared_memory, mutable> -> !ttg.memdesc<2x32xi32, #local_subslice_shared, #ttg.shared_memory, mutable, 4x32>
+    %idx = arith.constant dense<0> : tensor<2x32xi32, #local_subslice_blocked>
+    %g = ttg.local_gather %tile[%idx] {axis = 1 : i32} : !ttg.memdesc<2x32xi32, #local_subslice_shared, #ttg.shared_memory, mutable, 4x32>, tensor<2x32xi32, #local_subslice_blocked> -> tensor<2x32xi32, #local_subslice_blocked>
+    %ptrs = tt.splat %out : !tt.ptr<i32> -> tensor<2x32x!tt.ptr<i32>, #local_subslice_blocked>
+    %offs = arith.constant dense<0> : tensor<2x32xi32, #local_subslice_blocked>
+    %out_ptrs = tt.addptr %ptrs, %offs : tensor<2x32x!tt.ptr<i32>, #local_subslice_blocked>, tensor<2x32xi32, #local_subslice_blocked>
+    tt.store %out_ptrs, %g : tensor<2x32x!tt.ptr<i32>, #local_subslice_blocked>
+    tt.return
+  }
+
+  // CHECK-LABEL: @local_load_subslice_other_cta
+  // CHECK: nvvm.mapa
+  // CHECK: llvm.load {{.*}} : !llvm.ptr<7>
+  tt.func @local_load_subslice_other_cta(%out: !tt.ptr<i32>) {
+    %src = ttg.local_alloc {allocation.offset = 0 : i32} : () -> !ttg.memdesc<4x32xi32, #local_subslice_shared, #ttg.shared_memory, mutable>
+    %tile = ttg.memdesc_subslice %src [2, 0] : !ttg.memdesc<4x32xi32, #local_subslice_shared, #ttg.shared_memory, mutable> -> !ttg.memdesc<2x32xi32, #local_subslice_shared, #ttg.shared_memory, mutable, 4x32>
+    %loaded = ttg.local_load %tile : !ttg.memdesc<2x32xi32, #local_subslice_shared, #ttg.shared_memory, mutable, 4x32> -> tensor<2x32xi32, #local_subslice_blocked>
+    %ptrs = tt.splat %out : !tt.ptr<i32> -> tensor<2x32x!tt.ptr<i32>, #local_subslice_blocked>
+    %offs = arith.constant dense<0> : tensor<2x32xi32, #local_subslice_blocked>
+    %out_ptrs = tt.addptr %ptrs, %offs : tensor<2x32x!tt.ptr<i32>, #local_subslice_blocked>, tensor<2x32xi32, #local_subslice_blocked>
+    tt.store %out_ptrs, %loaded : tensor<2x32x!tt.ptr<i32>, #local_subslice_blocked>
+    tt.return
+  }
+
+  // CHECK-LABEL: @local_store_subslice_other_cta
+  // CHECK: nvvm.mapa
+  // CHECK: llvm.store {{.*}} : vector<1xi32>, !llvm.ptr<7>
+  tt.func @local_store_subslice_other_cta(%vals: tensor<2x32xi32, #local_subslice_blocked>) {
+    %src = ttg.local_alloc {allocation.offset = 0 : i32} : () -> !ttg.memdesc<4x32xi32, #local_subslice_shared, #ttg.shared_memory, mutable>
+    %tile = ttg.memdesc_subslice %src [2, 0] : !ttg.memdesc<4x32xi32, #local_subslice_shared, #ttg.shared_memory, mutable> -> !ttg.memdesc<2x32xi32, #local_subslice_shared, #ttg.shared_memory, mutable, 4x32>
+    ttg.local_store %vals, %tile : tensor<2x32xi32, #local_subslice_blocked> -> !ttg.memdesc<2x32xi32, #local_subslice_shared, #ttg.shared_memory, mutable, 4x32>
+    tt.return
+  }
+
+  // CHECK-LABEL: @local_scatter_subslice_other_cta
+  // CHECK: nvvm.mapa
+  // CHECK: llvm.store {{.*}} : vector<1xi32>, !llvm.ptr<7>
+  tt.func @local_scatter_subslice_other_cta(%vals: tensor<2x32xi32, #local_subslice_blocked>) {
+    %src = ttg.local_alloc {allocation.offset = 0 : i32} : () -> !ttg.memdesc<4x32xi32, #local_subslice_shared, #ttg.shared_memory, mutable>
+    %tile = ttg.memdesc_subslice %src [2, 0] : !ttg.memdesc<4x32xi32, #local_subslice_shared, #ttg.shared_memory, mutable> -> !ttg.memdesc<2x32xi32, #local_subslice_shared, #ttg.shared_memory, mutable, 4x32>
+    %idx = arith.constant dense<0> : tensor<2x32xi32, #local_subslice_blocked>
+    ttg.local_scatter %tile[%idx], %vals {axis = 1 : i32} : !ttg.memdesc<2x32xi32, #local_subslice_shared, #ttg.shared_memory, mutable, 4x32>, tensor<2x32xi32, #local_subslice_blocked>, tensor<2x32xi32, #local_subslice_blocked>
+    tt.return
+  }
+
+  // CHECK-LABEL: @local_atomic_subslice_other_cta
+  // CHECK: mapa.shared::cluster.u32
+  // CHECK: atom.shared::cluster.cluster.relaxed.add.u32
+  tt.func @local_atomic_subslice_other_cta(%out: !tt.ptr<i32>, %vals: tensor<2x32xi32, #local_subslice_blocked>) {
+    %src = ttg.local_alloc {allocation.offset = 0 : i32} : () -> !ttg.memdesc<4x32xi32, #local_subslice_shared, #ttg.shared_memory, mutable>
+    %tile = ttg.memdesc_subslice %src [2, 0] : !ttg.memdesc<4x32xi32, #local_subslice_shared, #ttg.shared_memory, mutable> -> !ttg.memdesc<2x32xi32, #local_subslice_shared, #ttg.shared_memory, mutable, 4x32>
+    %idx = arith.constant dense<0> : tensor<2x32xi32, #local_subslice_blocked>
+    %old = ttg.local_atomic_scatter_rmw add, %tile[%idx], %vals {axis = 1 : i32} : (!ttg.memdesc<2x32xi32, #local_subslice_shared, #ttg.shared_memory, mutable, 4x32>, tensor<2x32xi32, #local_subslice_blocked>, tensor<2x32xi32, #local_subslice_blocked>) -> tensor<2x32xi32, #local_subslice_blocked>
+    %ptrs = tt.splat %out : !tt.ptr<i32> -> tensor<2x32x!tt.ptr<i32>, #local_subslice_blocked>
+    %offs = arith.constant dense<0> : tensor<2x32xi32, #local_subslice_blocked>
+    %out_ptrs = tt.addptr %ptrs, %offs : tensor<2x32x!tt.ptr<i32>, #local_subslice_blocked>, tensor<2x32xi32, #local_subslice_blocked>
+    tt.store %out_ptrs, %old : tensor<2x32x!tt.ptr<i32>, #local_subslice_blocked>
+    tt.return
+  }
+
+  // CHECK-LABEL: @local_atomic_inc_subslice_other_cta
+  // CHECK: mapa.shared::cluster.u32
+  // CHECK: red.shared::cluster.cluster.relaxed.inc.u32
+  tt.func @local_atomic_inc_subslice_other_cta() {
+    %src = ttg.local_alloc {allocation.offset = 0 : i32} : () -> !ttg.memdesc<4x32xi32, #local_subslice_shared, #ttg.shared_memory, mutable>
+    %tile = ttg.memdesc_subslice %src [2, 0] : !ttg.memdesc<4x32xi32, #local_subslice_shared, #ttg.shared_memory, mutable> -> !ttg.memdesc<2x32xi32, #local_subslice_shared, #ttg.shared_memory, mutable, 4x32>
+    %idx = arith.constant dense<0> : tensor<2x32xi32, #local_subslice_blocked>
+    %one = arith.constant dense<1> : tensor<2x32xi32, #local_subslice_blocked>
+    %unused = ttg.local_atomic_scatter_rmw add, %tile[%idx], %one {axis = 1 : i32} : (!ttg.memdesc<2x32xi32, #local_subslice_shared, #ttg.shared_memory, mutable, 4x32>, tensor<2x32xi32, #local_subslice_blocked>, tensor<2x32xi32, #local_subslice_blocked>) -> tensor<2x32xi32, #local_subslice_blocked>
     tt.return
   }
 }

--- a/test/Conversion/tritonnvidiagpu_to_llvm.mlir
+++ b/test/Conversion/tritonnvidiagpu_to_llvm.mlir
@@ -680,6 +680,9 @@ module attributes {"ttg.num-ctas" = 2 : i32, "ttg.num-warps" = 4 : i32, "ttg.thr
 
 // -----
 
+#local_subslice_blocked = #ttg.blocked<{sizePerThread = [1, 1], threadsPerWarp = [1, 32], warpsPerCTA = [1, 4], order = [1, 0], CGALayout = [[0, 0]]}>
+#local_subslice_shared = #ttg.swizzled_shared<{vec = 1, perPhase = 1, maxPhase = 1, order = [1, 0], CGALayout = [[1, 0]]}>
+
 module attributes {"ttg.num-ctas" = 2 : i32, "ttg.num-warps" = 4 : i32, "ttg.threads-per-warp" = 32 : i32} {
   // CHECK-LABEL: @local_gather_subslice_other_cta
   // CHECK: nvvm.mapa

--- a/test/TritonGPU/invalid.mlir
+++ b/test/TritonGPU/invalid.mlir
@@ -62,18 +62,6 @@ module {
 
 // -----
 
-#shared = #ttg.swizzled_shared<{vec = 1, perPhase = 1, maxPhase = 1, order = [1, 0], CGALayout = [[0, 1]]}>
-#smem = #ttg.shared_memory
-module attributes {"ttg.num-ctas" = 2 : i32} {
-  tt.func public @subslice_non_broadcast_cga_dim(%arg0: !ttg.memdesc<8x16xf32, #shared, #smem>) {
-      // expected-error @+1 {{CTA dimensions}}
-      %a = ttg.memdesc_subslice %arg0 [0, 0] : !ttg.memdesc<8x16xf32, #shared, #smem> -> !ttg.memdesc<8x8xf32, #shared, #smem>
-      tt.return
-  }
-}
-
-// -----
-
 #shared = #ttg.swizzled_shared<{vec = 8, perPhase = 1, maxPhase = 4, order = [0, 1]}>
 #smem = #ttg.shared_memory
 tt.func public @miss_encoding(%arg0: !ttg.memdesc<8x16xf32, #shared, #smem>) {

--- a/third_party/amd/lib/TritonAMDGPUToLLVM/LoadStoreOpToLLVM.cpp
+++ b/third_party/amd/lib/TritonAMDGPUToLLVM/LoadStoreOpToLLVM.cpp
@@ -506,8 +506,9 @@ struct DirectToLdsLoadConversionBase : public LoadStoreConversionBase {
     }
 
     lowerLdSt(loc, ctx, cvt, vals, resElemTy, smemObj.getBase(), paddingShifts,
-              affineOffset, maskSpanAffineOffset, laneId, warpId, rewriter,
-              targetInfo, vec, lowerInstForwardMulticastMask);
+              affineOffset, maskSpanAffineOffset, /*affineBlockOffset=*/Value(),
+              /*maskSpanAffineBlock=*/0, laneId, warpId, rewriter, targetInfo,
+              vec, lowerInstForwardMulticastMask);
     return success();
   }
 

--- a/third_party/amd/lib/TritonAMDGPUToLLVM/MemoryOpToLLVM.cpp
+++ b/third_party/amd/lib/TritonAMDGPUToLLVM/MemoryOpToLLVM.cpp
@@ -256,7 +256,8 @@ private:
     // Compute the bits that are moved by one instruction
     // Compute elements for which we can swap the xor by an add
     auto [nAdditive, permStrides] = actionAdditiveStrides(
-        reps, addrLayout, maskSpanAffineOffset, fullTile.getInDimSize(kReg));
+        reps, addrLayout, maskSpanAffineOffset, /*maskSpanBlocks=*/0,
+        fullTile.getInDimSize(kReg));
     reps = permStrides.apply(reps);
     if (isPartitioned) {
       partitionLayout = permStrides.apply(partitionLayout);

--- a/third_party/amd/lib/TritonAMDGPUToLLVM/MemoryOpToLLVM.cpp
+++ b/third_party/amd/lib/TritonAMDGPUToLLVM/MemoryOpToLLVM.cpp
@@ -130,6 +130,7 @@ private:
     auto kLane = S("lane");
     auto kWarp = S("warp");
     auto kOffset = S("offset");
+    auto kBlock = S("block");
     auto kAddr = S("addr");
     auto kPartition = S("partition");
     auto smemPtrTy = ptr_ty(ctx, 3);
@@ -252,6 +253,12 @@ private:
         LinearLayout({{kLane, addrToOffset.getBases().lookup(kAddr)},
                       {kWarp, reps.getBases().lookup(kWarp)}},
                      {{kOffset, reps.getOutDimSize(kOffset)}}, false);
+
+    // Matrix accesses are CTA-local. Model that with a trivial block output so
+    // additive stride analysis always compares (offset, block) components.
+    reps =
+        reps.reshapeOuts({{kOffset, reps.getOutDimSize(kOffset)}, {kBlock, 1}});
+    addrLayout = addrLayout.reshapeOuts(reps.getOutDims());
 
     // Compute the bits that are moved by one instruction
     // Compute elements for which we can swap the xor by an add

--- a/third_party/amd/lib/TritonAMDGPUToLLVM/MemoryOpToLLVM.cpp
+++ b/third_party/amd/lib/TritonAMDGPUToLLVM/MemoryOpToLLVM.cpp
@@ -59,6 +59,8 @@ public:
     auto ldsParamsVec = targetInfo.queryLDSTransLoadParams(bitWidth);
     if (ldsParamsVec.empty())
       return failure();
+    if (SharedMemoryObject::getMaskSpanOffsetsAndBlocks(srcTy).second != 0)
+      return failure();
 
     LinearLayout sharedLL;
     if (triton::gpu::isPaddedEncoding(srcTy.getEncoding())) {
@@ -539,6 +541,8 @@ private:
     auto kBlock = str_attr("block");
     auto dstTy = cast<RankedTensorType>(op.getType());
     auto srcTy = cast<MemDescType>(op.getSrc().getType());
+    if (SharedMemoryObject::getMaskSpanOffsetsAndBlocks(srcTy).second != 0)
+      return failure();
     auto llvmElemTy = typeConverter->convertType(dstTy.getElementType());
     auto bitWidth = llvmElemTy.getIntOrFloatBitWidth();
     auto smemObj = LLVM::getSharedMemoryObjectFromStruct(loc, adaptor.getSrc(),
@@ -611,7 +615,8 @@ private:
     SmallVector<Value> outVals = lowerLdSt(
         loc, rewriter.getContext(), cvt, {}, // Input for store, output for load
         llvmElemTy, smemObj.getBase(), paddingShifts, affineOffset,
-        maskSpanAffineOffset, laneId, warpId, rewriter, targetInfo,
+        maskSpanAffineOffset, /*affineBlockOffset=*/Value(),
+        /*maskSpanAffineBlock=*/0, laneId, warpId, rewriter, targetInfo,
         ldsTransLoadParams->tileSize, lowerInst);
     Value result = packLLElements(loc, typeConverter, outVals, rewriter, retTy);
     rewriter.replaceOp(op, result);
@@ -656,13 +661,20 @@ struct LocalAtomicScatterRMWOpConversion
 
     bool returnOld = !op.getResult().use_empty();
 
+    if (llvm::any_of(info.addrs, [](const LocalSharedMemoryAddress &addr) {
+          return bool(addr.ctaId);
+        })) {
+      return rewriter.notifyMatchFailure(
+          op, "cross-CTA shared atomics are not supported on AMDGPU");
+    }
+
     SmallVector<Value> results;
     if (returnOld)
-      results.reserve(info.ptrs.size());
+      results.reserve(info.addrs.size());
 
-    for (auto [i, ptrAndValue] :
-         llvm::enumerate(llvm::zip(info.ptrs, info.values))) {
-      auto [ptr, value] = ptrAndValue;
+    for (auto [i, addrAndValue] :
+         llvm::enumerate(llvm::zip(info.addrs, info.values))) {
+      auto [addr, value] = addrAndValue;
       Value rmwMask = triton::gpu::maybeAnd(
           rewriter, loc, info.threadPred,
           info.maskValues.empty() ? Value() : info.maskValues[i]);
@@ -670,7 +682,7 @@ struct LocalAtomicScatterRMWOpConversion
       if (!rmwMask)
         rmwMask = b.true_val();
 
-      Value old = emitter.emitAtomicRMW(rewriter, ptr, value, rmwMask,
+      Value old = emitter.emitAtomicRMW(rewriter, addr.ptr, value, rmwMask,
                                         /*sharedMemBase=*/std::nullopt,
                                         /*enableIntraWaveReduce=*/false);
       if (returnOld)

--- a/third_party/nvidia/include/TritonNVIDIAGPUToLLVM/AtomicPTXBuilder.h
+++ b/third_party/nvidia/include/TritonNVIDIAGPUToLLVM/AtomicPTXBuilder.h
@@ -16,7 +16,7 @@
 
 namespace mlir::triton::NVIDIA {
 
-enum class PtxAtomicAddrSpace { Global, Shared };
+enum class PtxAtomicAddrSpace { Global, Shared, SharedCluster };
 enum class PtxAtomicInstr { Atom, Red };
 
 inline std::string getPtxRegisterSizeCode(int size, bool isFloat) {
@@ -37,18 +37,18 @@ inline std::string getPtxRegisterSizeCode(int size, bool isFloat) {
 }
 
 inline FailureOr<Value>
-emitPtxAtomicRMW(ConversionPatternRewriter &rewriter, Location loc,
-                 Type valueElemTy, Value ptr, ArrayRef<Value> vals,
-                 RMWOp rmwOpAttr, MemSemantic sem, MemSyncScope scope,
-                 Value pred, unsigned vec = 1, unsigned packed = 1,
-                 PtxAtomicAddrSpace addrSpace = PtxAtomicAddrSpace::Global,
-                 PtxAtomicInstr instr = PtxAtomicInstr::Atom) {
+emitPtxAtomicRMWImpl(ConversionPatternRewriter &rewriter, Location loc,
+                     Type valueElemTy, Value ptr, ArrayRef<Value> vals,
+                     RMWOp rmwOpAttr, MemSemantic sem, std::string scope,
+                     Value pred, unsigned vec, unsigned packed,
+                     PtxAtomicAddrSpace addrSpace, PtxAtomicInstr instr) {
   assert((vec == 1 || packed == 1) && "packed or vec must be 1");
   assert(vals.size() == (vec > 1 ? vec : packed) &&
          "Expected atomic RMW operand count to match vectorization");
 
   bool isRed = instr == PtxAtomicInstr::Red;
   bool isGlobal = addrSpace == PtxAtomicAddrSpace::Global;
+  bool isSharedCluster = addrSpace == PtxAtomicAddrSpace::SharedCluster;
   assert((isGlobal || (vec == 1 && packed == 1)) &&
          "shared atomic RMW does not support vectorized lowering");
 
@@ -93,9 +93,11 @@ emitPtxAtomicRMW(ConversionPatternRewriter &rewriter, Location loc,
                                                         : std::string("atom"));
   if (isGlobal)
     atomicInstr.global();
+  else if (isSharedCluster)
+    atomicInstr.o("shared::cluster");
   else
     atomicInstr.shared();
-  atomicInstr.o(stringifyMemSyncScope(scope).str());
+  atomicInstr.o(scope);
 
   std::string rmwOp = stringifyRMWOp(rmwOpAttr).str();
   std::string suffix;
@@ -157,6 +159,30 @@ emitPtxAtomicRMW(ConversionPatternRewriter &rewriter, Location loc,
     retType = valueElemTy;
   }
   return ptxBuilderAtomicRMW.launch(rewriter, loc, retType);
+}
+
+inline FailureOr<Value>
+emitPtxAtomicRMW(ConversionPatternRewriter &rewriter, Location loc,
+                 Type valueElemTy, Value ptr, ArrayRef<Value> vals,
+                 RMWOp rmwOpAttr, MemSemantic sem, MemSyncScope scope,
+                 Value pred, unsigned vec = 1, unsigned packed = 1) {
+  return emitPtxAtomicRMWImpl(rewriter, loc, valueElemTy, ptr, vals, rmwOpAttr,
+                              sem, stringifyMemSyncScope(scope).str(), pred,
+                              vec, packed, PtxAtomicAddrSpace::Global,
+                              PtxAtomicInstr::Atom);
+}
+
+inline FailureOr<Value>
+emitPtxSharedAtomicRMW(ConversionPatternRewriter &rewriter, Location loc,
+                       Type valueElemTy, Value ptr, ArrayRef<Value> vals,
+                       RMWOp rmwOpAttr, Value pred, bool isCluster,
+                       PtxAtomicInstr instr) {
+  auto addrSpace = isCluster ? PtxAtomicAddrSpace::SharedCluster
+                             : PtxAtomicAddrSpace::Shared;
+  return emitPtxAtomicRMWImpl(rewriter, loc, valueElemTy, ptr, vals, rmwOpAttr,
+                              MemSemantic::RELAXED,
+                              isCluster ? "cluster" : "cta", pred, /*vec=*/1,
+                              /*packed=*/1, addrSpace, instr);
 }
 
 inline Value emitPtxAtomicCAS(ConversionPatternRewriter &rewriter, Location loc,

--- a/third_party/nvidia/lib/TritonNVIDIAGPUToLLVM/ConvertLayoutOpToLLVM.cpp
+++ b/third_party/nvidia/lib/TritonNVIDIAGPUToLLVM/ConvertLayoutOpToLLVM.cpp
@@ -198,7 +198,8 @@ struct ConvertLayoutOpSwizzlingConversion
       if (idxSrc == 0) {
         lowerLdStShared(loc, ctx, storeCvt, tileInVals, llvmElemTy, smemBase,
                         /*paddingShifts=*/{}, affineOffset,
-                        maskSpanAffineOffset, rewriter, targetInfo);
+                        maskSpanAffineOffset, /*affineBlockOffset=*/Value(),
+                        /*maskSpanAffineBlock=*/0, rewriter, targetInfo);
       } else {
         assert(idxSrc == 1 || idxSrc == 2);
         bool transpose = idxSrc == 2;
@@ -215,7 +216,8 @@ struct ConvertLayoutOpSwizzlingConversion
       if (idxDst == 0) {
         tileOutVals = lowerLdStShared(
             loc, ctx, loadCvt, {}, llvmElemTy, smemBase, /*paddingShifts=*/{},
-            affineOffset, maskSpanAffineOffset, rewriter, targetInfo);
+            affineOffset, maskSpanAffineOffset, /*affineBlockOffset=*/Value(),
+            /*maskSpanAffineBlock=*/0, rewriter, targetInfo);
       } else {
         assert(idxDst == 1 || idxDst == 2);
         bool transpose = idxDst == 2;

--- a/third_party/nvidia/lib/TritonNVIDIAGPUToLLVM/LoadStoreOpToLLVM.cpp
+++ b/third_party/nvidia/lib/TritonNVIDIAGPUToLLVM/LoadStoreOpToLLVM.cpp
@@ -1103,7 +1103,8 @@ struct AsyncCopyGlobalToLocalOpConversion
     auto maskSpanAffineOffset = SharedMemoryObject::getMaskSpanOffsets(dstTy);
     auto [laneId, warpId] = getLaneAndWarpId(rewriter, loc);
     lowerLdSt(loc, ctx, cvt, vals, resElemTy, smemObj.getBase(),
-              /*paddingShifts=*/{}, affineOffset, maskSpanAffineOffset, laneId,
+              /*paddingShifts=*/{}, affineOffset, maskSpanAffineOffset,
+              /*affineBlockOffset=*/Value(), /*maskSpanAffineBlock=*/0, laneId,
               warpId, rewriter, targetInfo, maxVec, emitCpAsync);
 
     // Drop the result token.

--- a/third_party/nvidia/lib/TritonNVIDIAGPUToLLVM/MemoryOpToLLVM.cpp
+++ b/third_party/nvidia/lib/TritonNVIDIAGPUToLLVM/MemoryOpToLLVM.cpp
@@ -31,45 +31,46 @@ bool isConstI32OneTensor(Value value) {
 }
 
 Value emitSharedInc(ConversionPatternRewriter &rewriter, Location loc,
-                    Value ptr, bool returnOld, Value pred = Value()) {
+                    Value ptr, bool returnOld, bool isCluster,
+                    Value pred = Value()) {
   PTXBuilder ptxBuilder;
   // PTX atom/red.inc resets to 0 only when the old value reaches the bound, so
   // using UINT32_MAX makes it equivalent to a wrapping increment-by-1.
   auto *boundOpr = ptxBuilder.newConstantOperand("0xffffffff");
+  auto &inc = *ptxBuilder.create(returnOld ? "atom" : "red");
+  if (isCluster)
+    inc.o("shared::cluster").o("cluster");
+  else
+    inc.shared().o("cta");
+  inc.o("relaxed").o("inc").o("u32");
+
   if (!returnOld) {
     auto *ptrOpr = ptxBuilder.newAddrOperand(ptr, "r");
-    auto &red = *ptxBuilder.create("red");
-    red.shared().o("cta").o("relaxed").o("inc").o("u32");
-    red(ptrOpr, boundOpr).maybePredicate(pred, "b");
+    inc(ptrOpr, boundOpr).maybePredicate(pred, "b");
     return ptxBuilder.launch(rewriter, loc, void_ty(rewriter.getContext()));
   }
 
   auto *dstOpr = ptxBuilder.newOperand("=r", /*init=*/true);
   auto *ptrOpr = ptxBuilder.newAddrOperand(ptr, "r");
-  auto &atom = *ptxBuilder.create("atom");
-  atom.shared().o("cta").o("relaxed").o("inc").o("u32");
-  atom(dstOpr, ptrOpr, boundOpr).maybePredicate(pred, "b");
+  inc(dstOpr, ptrOpr, boundOpr).maybePredicate(pred, "b");
   return ptxBuilder.launch(rewriter, loc, i32_ty);
 }
 
 FailureOr<Value> emitSharedAtomicRMW(ConversionPatternRewriter &rewriter,
                                      Location loc, Type valueElemTy, Value ptr,
                                      Value value, RMWOp rmwOp, bool returnOld,
-                                     Value pred) {
+                                     bool isCluster, Value pred) {
   SmallVector<Value> vals{value};
   if (!returnOld) {
-    auto result = emitPtxAtomicRMW(
-        rewriter, loc, valueElemTy, ptr, vals, rmwOp, MemSemantic::RELAXED,
-        MemSyncScope::CTA, pred, /*vec=*/1, /*packed=*/1,
-        PtxAtomicAddrSpace::Shared, PtxAtomicInstr::Red);
+    auto result =
+        emitPtxSharedAtomicRMW(rewriter, loc, valueElemTy, ptr, vals, rmwOp,
+                               pred, isCluster, PtxAtomicInstr::Red);
     if (succeeded(result))
       return result;
   }
 
-  return emitPtxAtomicRMW(rewriter, loc, valueElemTy, ptr, vals, rmwOp,
-                          MemSemantic::RELAXED, MemSyncScope::CTA, pred,
-                          /*vec=*/1, /*packed=*/1, PtxAtomicAddrSpace::Shared,
-                          PtxAtomicInstr::Atom);
+  return emitPtxSharedAtomicRMW(rewriter, loc, valueElemTy, ptr, vals, rmwOp,
+                                pred, isCluster, PtxAtomicInstr::Atom);
 }
 
 LogicalResult lowerLdStMatrix(
@@ -100,6 +101,10 @@ LogicalResult lowerLdStMatrix(
     }
   }
   if (isa<PaddedSharedEncodingAttr>(memDescType.getEncoding())) {
+    return failure();
+  }
+  if (SharedMemoryObject::getMaskSpanOffsetsAndBlocks(memDescType).second !=
+      0) {
     return failure();
   }
   auto memLayout = toLinearLayout(memDescType);
@@ -366,8 +371,10 @@ static void lowerAsyncSharedStore(Location loc, MLIRContext *ctx,
     return;
   }
 
-  auto affineOffset = dstMemObj.getShmemOffset(loc, rewriter, dstTy);
-  auto maskSpanAffineOffset = dstMemObj.getMaskSpanOffsets(dstTy);
+  auto [affineOffset, affineBlockOffset] =
+      dstMemObj.getShmemOffsetAndBlock(loc, rewriter, dstTy);
+  auto [maskSpanAffineOffset, maskSpanAffineBlock] =
+      dstMemObj.getMaskSpanOffsetsAndBlocks(dstTy);
   std::optional<int> maybeMaxVecElems;
   SmallVector<std::pair<unsigned, unsigned>> paddingShifts;
   if (triton::gpu::isPaddedEncoding(dstTy.getEncoding())) {
@@ -395,8 +402,9 @@ static void lowerAsyncSharedStore(Location loc, MLIRContext *ctx,
   };
   auto [laneId, warpId] = getLaneAndWarpId(rewriter, loc);
   lowerLdSt(loc, ctx, cvt, vals, llvmElemTy, smemBases, paddingShifts,
-            affineOffset, maskSpanAffineOffset, laneId, warpId, rewriter,
-            targetInfo, maybeMaxVecElems, emitSt);
+            affineOffset, maskSpanAffineOffset, affineBlockOffset,
+            maskSpanAffineBlock, laneId, warpId, rewriter, targetInfo,
+            maybeMaxVecElems, emitSt);
 }
 
 struct AsyncSharedStoreOpConversion
@@ -474,21 +482,25 @@ public:
 
     SmallVector<Value> results;
     if (returnOld)
-      results.reserve(info.ptrs.size());
-    for (auto [i, ptrAndValue] :
-         llvm::enumerate(llvm::zip(info.ptrs, info.values))) {
-      auto [ptr, value] = ptrAndValue;
+      results.reserve(info.addrs.size());
+    for (auto [i, addrAndValue] :
+         llvm::enumerate(llvm::zip(info.addrs, info.values))) {
+      auto [addr, value] = addrAndValue;
       Value pred =
           maybeAnd(rewriter, loc, info.threadPred,
                    info.maskValues.empty() ? Value() : info.maskValues[i]);
+      bool isCluster = bool(addr.ctaId);
+      Value ptr =
+          targetInfo.mapDShared(rewriter, loc, addr.ptr, addr.ctaId, pred);
       if (isI32Inc) {
-        Value result = emitSharedInc(rewriter, loc, ptr, returnOld, pred);
+        Value result =
+            emitSharedInc(rewriter, loc, ptr, returnOld, isCluster, pred);
         if (returnOld)
           results.push_back(result);
         continue;
       }
       auto old = emitSharedAtomicRMW(rewriter, loc, info.llvmElemTy, ptr, value,
-                                     rmwOp, returnOld, pred);
+                                     rmwOp, returnOld, isCluster, pred);
       if (failed(old))
         return failure();
       if (returnOld)

--- a/third_party/nvidia/lib/TritonNVIDIAGPUToLLVM/TargetInfo.cpp
+++ b/third_party/nvidia/lib/TritonNVIDIAGPUToLLVM/TargetInfo.cpp
@@ -192,6 +192,11 @@ static Value mapa(RewriterBase &rewriter, Location loc, Value ptr, Value ctaid,
   return builder.launch(rewriter, loc, clusterPtrTy, /*hasSideEffect=*/false);
 }
 
+Value TargetInfo::mapDShared(RewriterBase &rewriter, Location loc, Value ptr,
+                             Value ctaId, Value pred) const {
+  return ctaId ? mapa(rewriter, loc, ptr, ctaId, pred) : ptr;
+}
+
 static std::string getConstraintForBitwidth(unsigned bitwidth) {
   switch (bitwidth) {
   case 8:

--- a/third_party/nvidia/lib/TritonNVIDIAGPUToLLVM/TargetInfo.h
+++ b/third_party/nvidia/lib/TritonNVIDIAGPUToLLVM/TargetInfo.h
@@ -30,6 +30,8 @@ public:
   Value loadDShared(RewriterBase &rewriter, Location loc, Value ptr,
                     Value ctaId, Type elemTy, Value pred,
                     Operation *localLoadOp = nullptr) const override;
+  Value mapDShared(RewriterBase &rewriter, Location loc, Value ptr, Value ctaId,
+                   Value pred) const;
 
   bool supportLdMatrix() const override {
     return targetFeatures.supportLdMatrix();

--- a/third_party/nvidia/lib/TritonNVIDIAGPUToLLVM/Utility.cpp
+++ b/third_party/nvidia/lib/TritonNVIDIAGPUToLLVM/Utility.cpp
@@ -213,6 +213,7 @@ LogicalResult lowerLdStMatrix(
   auto kLane = S("lane");
   auto kWarp = S("warp");
   auto kOffset = S("offset");
+  auto kBlock = S("block");
   auto kAddr = S("addr");
   auto smemPtrTy = ptr_ty(ctx, 3);
   auto bitwidth = getIntOrFloatOrPtrBitWidth(llvmElemTy);
@@ -358,6 +359,12 @@ LogicalResult lowerLdStMatrix(
       LinearLayout({{kLane, addrToOffset.getBases().lookup(kAddr)},
                     {kWarp, reps.getBases().lookup(kWarp)}},
                    {{kOffset, reps.getOutDimSize(kOffset)}}, false);
+
+  // Matrix accesses are CTA-local. Model that with a trivial block output so
+  // additive stride analysis always compares (offset, block) components.
+  reps =
+      reps.reshapeOuts({{kOffset, reps.getOutDimSize(kOffset)}, {kBlock, 1}});
+  addrLayout = addrLayout.reshapeOuts(reps.getOutDims());
   // Compute the bits that are moved by one instruction
   // Compute elements for which we can swap the xor by an add
   auto [nAdditive, permStrides] = actionAdditiveStrides(

--- a/third_party/nvidia/lib/TritonNVIDIAGPUToLLVM/Utility.cpp
+++ b/third_party/nvidia/lib/TritonNVIDIAGPUToLLVM/Utility.cpp
@@ -361,7 +361,8 @@ LogicalResult lowerLdStMatrix(
   // Compute the bits that are moved by one instruction
   // Compute elements for which we can swap the xor by an add
   auto [nAdditive, permStrides] = actionAdditiveStrides(
-      reps, addrLayout, maskSpanAffineOffset, fullTileVec.getInDimSize(kReg));
+      reps, addrLayout, maskSpanAffineOffset, /*maskSpanBlocks=*/0,
+      fullTileVec.getInDimSize(kReg));
   reps = permStrides.apply(reps);
   if (isStore) {
     vals = permStrides.apply(vals);


### PR DESCRIPTION
PR description written by Codex

Allow `ttg.local_gather` to consume a `ttg.memdesc_subslice` whose affine offset changes the target CTA. Preserve the subslice block component during lowering, account for affine CTA bits when selecting additive register strides, and restrict CTA-splitting subslices to local-gather users.

## Stack
Merge bottom-up:
- [x] #10641
- [x] #10642
- [x] #10559 (this PR)
- [x] #10627
- [ ] #10656
- [ ] #10669
