### PR TITLE
[FPSAN] Optimize exp instrumentation

### DIFF
--- a/lib/Dialect/TritonInstrument/Transforms/FpSanitizer.cpp
+++ b/lib/Dialect/TritonInstrument/Transforms/FpSanitizer.cpp
@@ -739,7 +739,9 @@ Value fpsanSRem(PatternRewriter &rewriter, Location loc, Value num, Value den) {
 // k = ceil(N/4) and c = 1 + 2^k.  Then c^x mod 2^N has the exact closed form
 // below because all terms from the fourth binomial term onward vanish. This
 // preserves exp2(a + b) = exp2(a) * exp2(b) without a per-element
-// exponentiation loop.
+// exponentiation loop. If N <= 8, then this has the maximal possible period
+// of 2^(N-2); if N > 8, then this has a large but non-maximal period of
+// 2^(N-k) = 2^floor(3N/4) instead.
 Value fpsanExp2FromInt(PatternRewriter &rewriter, Location loc, Value xI,
                        Type floatTy) {
   unsigned bitWidth = getIntBitwidth(xI.getType());

--- a/lib/Dialect/TritonInstrument/Transforms/FpSanitizer.cpp
+++ b/lib/Dialect/TritonInstrument/Transforms/FpSanitizer.cpp
@@ -735,42 +735,51 @@ Value fpsanSRem(PatternRewriter &rewriter, Location loc, Value num, Value den) {
   return unembedToFloat(rewriter, loc, resI, num.getType());
 }
 
-// Modular exponentiation in payload space; this preserves
-// exp2(a + b) = exp2(a) * exp2(b) under the integer rewrite.
+// A fixed-base modular exponential in payload space.  For payload width N, set
+// k = ceil(N/4) and c = 1 + 2^k.  Then c^x mod 2^N has the exact closed form
+// below because all terms from the fourth binomial term onward vanish. This
+// preserves exp2(a + b) = exp2(a) * exp2(b) without a per-element
+// exponentiation loop.
 Value fpsanExp2FromInt(PatternRewriter &rewriter, Location loc, Value xI,
                        Type floatTy) {
   unsigned bitWidth = getIntBitwidth(xI.getType());
+  unsigned shift = (bitWidth + 3) / 4;
   auto one = getIntConstantLike(rewriter, loc, xI.getType(), 1);
-  auto zero = getIntConstantLike(rewriter, loc, xI.getType(), 0);
-  auto c = getIntConstantLike(rewriter, loc, xI.getType(), 0xa343836d);
+  auto shiftBase = getIntConstantLike(rewriter, loc, xI.getType(), shift);
+  auto shiftBase2 = getIntConstantLike(rewriter, loc, xI.getType(), 2 * shift);
 
-  auto lower =
-      arith::ConstantOp::create(rewriter, loc, rewriter.getI32IntegerAttr(0));
-  auto upper = arith::ConstantOp::create(rewriter, loc,
-                                         rewriter.getI32IntegerAttr(bitWidth));
-  auto step =
-      arith::ConstantOp::create(rewriter, loc, rewriter.getI32IntegerAttr(1));
-  auto topBit = arith::ConstantOp::create(
-      rewriter, loc, rewriter.getI32IntegerAttr(bitWidth - 1));
-  auto loop = scf::ForOp::create(rewriter, loc, lower, upper, step, one);
-  rewriter.setInsertionPointToStart(loop.getBody());
+  Value xMinusOne = arith::SubIOp::create(rewriter, loc, xI, one);
+  Value choose2Twice = arith::MulIOp::create(rewriter, loc, xI, xMinusOne);
+  Value choose2 = arith::ShRUIOp::create(rewriter, loc, choose2Twice, one);
 
-  Value i = loop.getInductionVar();
-  Value y = loop.getRegionIterArgs()[0];
-  y = arith::MulIOp::create(rewriter, loc, y, y);
-  Value bitIndex =
-      arith::SubIOp::create(rewriter, loc, rewriter.getI32Type(), topBit, i);
-  Value shift = castScalarIntToIntLike(rewriter, loc, bitIndex, xI.getType());
-  Value bit = arith::ShLIOp::create(rewriter, loc, one, shift);
-  auto masked = arith::AndIOp::create(rewriter, loc, xI, bit);
-  auto isZero = arith::CmpIOp::create(rewriter, loc, arith::CmpIPredicate::eq,
-                                      masked, zero);
-  auto factor = arith::SelectOp::create(rewriter, loc, isZero, one, c);
-  y = arith::MulIOp::create(rewriter, loc, y, factor);
-  scf::YieldOp::create(rewriter, loc, y);
-  rewriter.setInsertionPointAfter(loop);
+  Value term1 = arith::ShLIOp::create(rewriter, loc, xI, shiftBase);
+  Value term2 = arith::ShLIOp::create(rewriter, loc, choose2, shiftBase2);
+  Value result = arith::AddIOp::create(rewriter, loc, one, term1);
+  result = arith::AddIOp::create(rewriter, loc, result, term2);
 
-  return unembedToFloat(rewriter, loc, loop.getResult(0), floatTy);
+  unsigned choose3Bits = bitWidth - 3 * shift;
+  uint64_t choose3InputMask = (uint64_t{1} << (choose3Bits + 1)) - 1;
+  auto choose3Mask =
+      getIntConstantLike(rewriter, loc, xI.getType(), choose3InputMask);
+  auto two = getIntConstantLike(rewriter, loc, xI.getType(), 2);
+  auto six = getIntConstantLike(rewriter, loc, xI.getType(), 6);
+  auto shiftBase3 = getIntConstantLike(rewriter, loc, xI.getType(), 3 * shift);
+
+  // Only the low choose3Bits bits of C(x, 3) survive the final shift. C(x, 3)
+  // modulo 2^choose3Bits has period 2^(choose3Bits + 1), so reducing x first
+  // keeps the products small.
+  Value xLow = arith::AndIOp::create(rewriter, loc, xI, choose3Mask);
+  Value xLowMinusOne = arith::SubIOp::create(rewriter, loc, xLow, one);
+  Value xLowMinusTwo = arith::SubIOp::create(rewriter, loc, xLow, two);
+  Value choose3Numerator =
+      arith::MulIOp::create(rewriter, loc, xLow, xLowMinusOne);
+  choose3Numerator =
+      arith::MulIOp::create(rewriter, loc, choose3Numerator, xLowMinusTwo);
+  Value choose3 = arith::DivUIOp::create(rewriter, loc, choose3Numerator, six);
+
+  Value term3 = arith::ShLIOp::create(rewriter, loc, choose3, shiftBase3);
+  result = arith::AddIOp::create(rewriter, loc, result, term3);
+  return unembedToFloat(rewriter, loc, result, floatTy);
 }
 
 Value fpsanExp2(PatternRewriter &rewriter, Location loc, Value input) {

--- a/python/test/gluon/test_fpsan.py
+++ b/python/test/gluon/test_fpsan.py
@@ -300,15 +300,24 @@ def _expected_div_payload_i32(x_i32: np.ndarray, y_i32: np.ndarray) -> np.ndarra
 
 
 def _expected_exp2_i32(x_i32: np.ndarray) -> np.ndarray:
-    c = np.uint64(0xa343836d)
     mask = np.uint64(0xFFFFFFFF)
     x = _mix_f32_bits_to_payload_u32(x_i32).astype(np.uint64)
-    y = np.ones_like(x, dtype=np.uint64)
-    for i in range(32):
-        y = (y * y) & mask
-        factor = np.where((x & np.uint64(1 << (31 - i))) == 0, np.uint64(1), c)
-        y = (y * factor) & mask
+    x_minus_one = (x + mask) & mask
+    choose2 = ((x * x_minus_one) & mask) >> np.uint64(1)
+    x_low = (x & np.uint64(0x1FF)).astype(np.int64)
+    choose3 = (x_low * (x_low - 1) * (x_low - 2) // 6).astype(np.uint64)
+    y = (np.uint64(1) + (x << np.uint64(8)) + (choose2 << np.uint64(16)) + (choose3 << np.uint64(24))) & mask
     return _unmix_payload_u32_to_f32_bits_i32(y.astype(np.uint32))
+
+
+def _expected_exp2_i64(x_i64: np.ndarray) -> np.ndarray:
+    x = _mix_float_bits(x_i64, "f64")
+    with np.errstate(over="ignore"):
+        choose2 = (x * (x - np.uint64(1))) >> np.uint64(1)
+        x_low = (x & np.uint64(0x1FFFF)).astype(np.int64)
+        choose3 = (x_low * (x_low - 1) * (x_low - 2) // 6).astype(np.uint64)
+        y = (np.uint64(1) + (x << np.uint64(16)) + (choose2 << np.uint64(32)) + (choose3 << np.uint64(48)))
+    return _unmix_payload_to_float_bits(y, "f64")
 
 
 def _expected_exp_i32(x_i32: np.ndarray) -> np.ndarray:
@@ -864,6 +873,30 @@ def test_unary_math_identity(device, op, fresh_knobs):
     _assert_payload_equal(out, exp_bits)
 
 
+def test_exp2_payload_f64(device, fresh_knobs):
+    _require_cuda_backend(device)
+
+    fresh_knobs.compilation.instrumentation_mode = "fpsan"
+
+    n_elements = 256
+    block = 256
+    rs = np.random.RandomState(31)
+    x_bits = _random_float_bits(rs, (n_elements, ), "f64")
+    _, x = _as_float_bits_tensor(x_bits, "f64")
+    out = torch.empty((n_elements, ), dtype=torch.int64, device="cuda")
+
+    _unary_math_kernel[(1, )](
+        x,
+        triton.TensorWrapper(out, dtype=torch.float64),
+        n_elements,
+        OP="exp2",
+        BLOCK=block,
+        THREADS_PER_WARP=THREADS_PER_WARP,
+    )
+
+    _assert_payload_equal(out, _expected_exp2_i64(x_bits))
+
+
 def test_exp_add_mul_identity(device, fresh_knobs):
     _require_cuda_backend(device)
 
@@ -889,6 +922,44 @@ def test_exp_add_mul_identity(device, fresh_knobs):
                                       THREADS_PER_WARP=THREADS_PER_WARP)
     _exp_binary_identity_kernel[grid](xw, yw, out_mul_w, n_elements, MODE="exp_mul", BLOCK=BLOCK,
                                       THREADS_PER_WARP=THREADS_PER_WARP)
+
+    _assert_payload_equal(out_add, out_mul)
+
+
+def test_exp_add_mul_identity_f64(device, fresh_knobs):
+    _require_cuda_backend(device)
+
+    fresh_knobs.compilation.instrumentation_mode = "fpsan"
+
+    n_elements = 256
+    block = 256
+    rs = np.random.RandomState(29)
+    x_bits = _random_float_bits(rs, (n_elements, ), "f64")
+    y_bits = _random_float_bits(rs, (n_elements, ), "f64")
+    _, x = _as_float_bits_tensor(x_bits, "f64")
+    _, y = _as_float_bits_tensor(y_bits, "f64")
+    out_add = torch.empty((n_elements, ), dtype=torch.int64, device="cuda")
+    out_mul = torch.empty_like(out_add)
+
+    grid = (1, )
+    _exp_binary_identity_kernel[grid](
+        x,
+        y,
+        triton.TensorWrapper(out_add, dtype=torch.float64),
+        n_elements,
+        MODE="exp_add",
+        BLOCK=block,
+        THREADS_PER_WARP=THREADS_PER_WARP,
+    )
+    _exp_binary_identity_kernel[grid](
+        x,
+        y,
+        triton.TensorWrapper(out_mul, dtype=torch.float64),
+        n_elements,
+        MODE="exp_mul",
+        BLOCK=block,
+        THREADS_PER_WARP=THREADS_PER_WARP,
+    )
 
     _assert_payload_equal(out_add, out_mul)
 

--- a/test/TritonGPU/fpsan.mlir
+++ b/test/TritonGPU/fpsan.mlir
@@ -423,18 +423,31 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32} {
   tt.func public @exp_ops(%a: tensor<4xf32>) -> (tensor<4xf32>, tensor<4xf32>) {
     // CHECK-DAG: arith.constant dense<594471359>
     // CHECK-DAG: arith.constant dense<1>
-    // CHECK-DAG: arith.constant dense<0>
-    // CHECK-DAG: arith.constant dense<-1555856531>
     // CHECK: tti.experimental_fpsan_embed
     // CHECK: arith.muli
-    // CHECK: arith.andi
-    // CHECK: arith.cmpi
-    // CHECK: arith.select
+    // CHECK-NOT: scf.for
     // CHECK-NOT: math.exp
     // CHECK-NOT: math.exp2
     %0 = math.exp %a : tensor<4xf32>
     %1 = math.exp2 %a : tensor<4xf32>
     tt.return %0, %1 : tensor<4xf32>, tensor<4xf32>
+  }
+}
+
+// -----
+
+module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32} {
+  // CHECK-LABEL: @exp2_all_widths
+  tt.func public @exp2_all_widths(%a8: f8E4M3FN, %a16: f16, %ab16: bf16, %a32: f32, %a64: f64) -> (f8E4M3FN, f16, bf16, f32, f64) {
+    // CHECK-NOT: scf.for
+    // CHECK-NOT: math.exp2
+    %r8 = math.exp2 %a8 : f8E4M3FN
+    %r16 = math.exp2 %a16 : f16
+    %rb16 = math.exp2 %ab16 : bf16
+    %r32 = math.exp2 %a32 : f32
+    %r64 = math.exp2 %a64 : f64
+    // CHECK: tt.return
+    tt.return %r8, %r16, %rb16, %r32, %r64 : f8E4M3FN, f16, bf16, f32, f64
   }
 }
 


### PR DESCRIPTION
PR description written by Codex

Optimize f32 and f64 exponential instrumentation in FpSan. Use closed-form payload transforms to reduce compile time and generated runtime work while preserving the sanitizer identities covered by the accompanying tests.

## Stack
Merge bottom-up:
- [ ] #10561 (this PR)
- [ ] #10641
- [ ] #10642
- [ ] #10559
- [ ] #10627
