### PR TITLE
Fix matmul launch_metadata for RAGGED_DIMENSION="K".

### DIFF
--- a/python/triton_kernels/triton_kernels/matmul_details/_common.py
+++ b/python/triton_kernels/triton_kernels/matmul_details/_common.py
@@ -378,7 +378,7 @@ def matmul_launch_metadata(grid, kernel, args):
     K_repr = K
     if args["RAGGED_DIMENSION"] == "K":
         K = None if n_tokens is None else n_tokens
-        K_repr = K if allow_sync else None
+        K_repr = None
 
     repr = lambda s, x: f"{s} = {x}" if x is not None else f"E_{len(slice_sizes)}({s}) = {n_rows}"
     nbits = X.dtype.itemsize * 8


### PR DESCRIPTION
This makes the metadata consistent with other ragged cases.  In particular, we now use X_EXPECTED_SLICE_SIZE if it is supplied.  Previously we used the actual number of active rows, which is correct but extremely noisy on large profiles.