### PR TITLE
[AMD] Pipeline TDM descriptor stores and scatters in loops

### DIFF
--- a/python/test/gluon/test_frontend.py
+++ b/python/test/gluon/test_frontend.py
@@ -3901,8 +3901,8 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.targ
     %c0_i32 = arith.constant 0 : i32
     %c2_i32 = arith.constant 2 : i32
     %2 = amdg.update_tensor_descriptor %0 add_offsets = [%c0_i32, %c2_i32] {clamp_bounds} : !tt.tensordesc<16x64xf16, #shared>
-    amdg.async_tdm_copy_local_to_global %2 from %1 : !ttg.memdesc<16x64xf16, #shared, #smem, mutable> -> !tt.tensordesc<16x64xf16, #shared>
-    %3 = amdg.async_tdm_wait  {num = 0 : i32}
+    %3 = amdg.async_tdm_copy_local_to_global %2 from %1 : !ttg.memdesc<16x64xf16, #shared, #smem, mutable> -> !tt.tensordesc<16x64xf16, #shared>
+    %4 = amdg.async_tdm_wait  {num = 0 : i32}
     tt.return
   }
 }

--- a/python/test/unit/language/test_pipeliner.py
+++ b/python/test/unit/language/test_pipeliner.py
@@ -5,7 +5,7 @@ import torch
 import triton
 import triton.language as tl
 
-from triton._internal_testing import is_cuda, is_hopper_or_newer, is_hip_cdna, is_hip_cdna2, is_hip
+from triton._internal_testing import is_cuda, is_hopper_or_newer, is_hip_cdna, is_hip_cdna2, is_hip, is_hip_gfx1250
 
 
 def check_capabilities():
@@ -515,12 +515,18 @@ def matmul_kernel_persistent_scatter(a_ptr, b_ptr, c_ptr,  #
         c_desc.scatter(c, offs_am + tl.arange(0, BLOCK_SIZE_M), offs_bn)
 
 
-@pytest.mark.skipif(torch.cuda.get_device_capability()[0] != 10,
-                    reason="TMA Scatter only works on cloud Blackwell Chips")
+def _supports_descriptor_scatter():
+    if is_cuda():
+        return torch.cuda.get_device_capability()[0] == 10
+    return is_hip_gfx1250()
+
+
+@pytest.mark.skipif(not _supports_descriptor_scatter(),
+                    reason="TMA/TDM Scatter only works on cloud Blackwell Chips or AMD gfx1250")
 def test_scatter_pipeline(device):
 
     def alloc_fn(size, alignment, stream):
-        return torch.empty(size, device="cuda", dtype=torch.int8)
+        return torch.empty(size, device=device, dtype=torch.int8)
 
     triton.set_allocator(alloc_fn)
 
@@ -528,7 +534,7 @@ def test_scatter_pipeline(device):
     BLOCK_M, BLOCK_N, BLOCK_K = 64, 64, 32
     GROUP_SIZE_M = 4
 
-    NUM_SMS = torch.cuda.get_device_properties("cuda").multi_processor_count
+    NUM_SMS = torch.cuda.get_device_properties(device).multi_processor_count
     grid_x = min(NUM_SMS, triton.cdiv(M, BLOCK_M) * triton.cdiv(N, BLOCK_N))
 
     a = torch.randn(M, K, device=device, dtype=torch.float16)
@@ -541,7 +547,16 @@ def test_scatter_pipeline(device):
     ref = torch.matmul(a, b.T)
     torch.testing.assert_close(c, ref)
 
-    assert kernel.asm["ttgir"].count("tma_store_wait") == 2, "expected pipelined TMA scatter"
+    if is_cuda():
+        # NVIDIA: pipelineTMAStores hoists the wait, leaving one wait inside
+        # the persistent loop and one drain wait after the loop.
+        assert kernel.asm["ttgir"].count("tma_store_wait") == 2, "expected pipelined TMA scatter"
+    else:
+        # AMD: 5 async_tdm_wait ops total:
+        #   2 from load pipeline (1 inside inner K-loop + 1 in epilogue)
+        #   3 from store pipeline (1 seed before loop + 1 inside outer
+        #     loop consuming previous iteration's token + 1 drain after loop)
+        assert kernel.asm["ttgir"].count("async_tdm_wait") == 5, "expected pipelined TDM scatter"
 
 
 @pytest.mark.parametrize("num_stages", [1, 2, 3])

--- a/test/TritonGPU/amd/amd-pipeline-tdm.mlir
+++ b/test/TritonGPU/amd/amd-pipeline-tdm.mlir
@@ -431,3 +431,147 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 8 : i32, ttg.targ
 // CHECK: scf.if %{{[0-9]+}} {
 // CHECK-NEXT: tt.descriptor_store
 // CHECK-NEXT: }
+
+// -----
+
+// Two descriptor stores in the same loop iteration with identical source
+// shape/type share a single LDS allocation. The pipeliner must serialize
+// them so that the second `local_store` does not overwrite the buffer while
+// the first TDM store is still consuming it.
+#blocked = #ttg.blocked<{sizePerThread = [1, 8], threadsPerWarp = [4, 8], warpsPerCTA = [8, 1], order = [1, 0]}>
+module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 8 : i32, ttg.target = "hip:gfx1250", "ttg.threads-per-warp" = 32 : i32} {
+  tt.func @tdm_two_same_shape_stores_share_alloc(
+      %x_ptr: !tt.ptr<f16> {tt.divisibility = 16 : i32},
+      %y_ptr: !tt.ptr<f16> {tt.divisibility = 16 : i32},
+      %src: tensor<32x64xf16, #blocked>,
+      %M: i32 {tt.divisibility = 16 : i32},
+      %N: i32 {tt.divisibility = 16 : i32},
+      %ub: i32) {
+    %c0_i32 = arith.constant 0 : i32
+    %c1_i32 = arith.constant 1 : i32
+    %c32_i32 = arith.constant 32 : i32
+    %c1_i64 = arith.constant 1 : i64
+    %n_stride = arith.extsi %N : i32 to i64
+    %x_desc = tt.make_tensor_descriptor %x_ptr, [%M, %N], [%n_stride, %c1_i64] : <f16>, <32x64xf16>
+    %y_desc = tt.make_tensor_descriptor %y_ptr, [%M, %N], [%n_stride, %c1_i64] : <f16>, <32x64xf16>
+    scf.for %iv = %c0_i32 to %ub step %c1_i32 iter_args(%off = %c0_i32) -> (i32) : i32 {
+      tt.descriptor_store %x_desc[%off, %c0_i32], %src : !tt.tensordesc<32x64xf16>, tensor<32x64xf16, #blocked>
+      tt.descriptor_store %y_desc[%off, %c0_i32], %src : !tt.tensordesc<32x64xf16>, tensor<32x64xf16, #blocked>
+      %next = arith.addi %off, %c32_i32 : i32
+      scf.yield %next : i32
+    }
+    tt.return
+  }
+}
+
+// CHECK-LABEL: tt.func @tdm_two_same_shape_stores_share_alloc
+// One shared LDS allocation hoisted out of the loop.
+// CHECK: %[[ALLOC:.+]] = ttg.local_alloc :
+// CHECK-NOT: ttg.local_alloc
+// One seed wait before the loop.
+// CHECK: %[[SEED:.+]] = amdg.async_tdm_wait  {num = 0 : i32}
+// CHECK-NOT: amdg.async_tdm_wait{{.*}}{num = 0
+// Loop carries one async token iter_arg.
+// CHECK: scf.for {{.*}} iter_args({{.*}}, %[[ITER_TOK:[^ )]+]] = %[[SEED]])
+// CHECK-SAME: -> (i32, !ttg.async.token)
+// First store: wait on previous iteration's tail token, then write LDS.
+// CHECK: amdg.async_tdm_wait %[[ITER_TOK]] {num = 0 : i32}
+// CHECK: ttg.local_store {{.*}}, %[[ALLOC]]
+// CHECK: %[[TOK1:.+]] = amdg.async_tdm_copy_local_to_global {{.*}} from %[[ALLOC]]
+// Second store: wait on first store's token to prevent overwriting LDS while the first TDM store is still consuming it.
+// CHECK: amdg.async_tdm_wait %[[TOK1]] {num = 0 : i32}
+// CHECK: ttg.local_store {{.*}}, %[[ALLOC]]
+// CHECK: %[[TOK2:.+]] = amdg.async_tdm_copy_local_to_global {{.*}} from %[[ALLOC]]
+// Yield the second store's token
+// CHECK: scf.yield {{.*}}, %[[TOK2]] : i32, !ttg.async.token
+// CHECK: }
+// Drain the in-flight TDM store and deallocate the shared buffer
+// CHECK: amdg.async_tdm_wait %{{[^,]+}} {num = 0 : i32}
+// CHECK: ttg.local_dealloc %[[ALLOC]]
+// CHECK-NOT: ttg.local_dealloc
+
+// -----
+
+// Two descriptor stores with different source element types have to use separate allocations.
+#blocked_mix = #ttg.blocked<{sizePerThread = [1, 8], threadsPerWarp = [4, 8], warpsPerCTA = [8, 1], order = [1, 0]}>
+module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 8 : i32, ttg.target = "hip:gfx1250", "ttg.threads-per-warp" = 32 : i32} {
+  tt.func @tdm_two_stores_diff_elem_type(
+      %x_ptr: !tt.ptr<f16> {tt.divisibility = 16 : i32},
+      %y_ptr: !tt.ptr<bf16> {tt.divisibility = 16 : i32},
+      %src_a: tensor<32x64xf16, #blocked_mix>,
+      %src_b: tensor<32x64xbf16, #blocked_mix>,
+      %M: i32 {tt.divisibility = 16 : i32},
+      %N: i32 {tt.divisibility = 16 : i32},
+      %ub: i32) {
+    %c0_i32 = arith.constant 0 : i32
+    %c1_i32 = arith.constant 1 : i32
+    %c32_i32 = arith.constant 32 : i32
+    %c1_i64 = arith.constant 1 : i64
+    %n_stride = arith.extsi %N : i32 to i64
+    %x_desc = tt.make_tensor_descriptor %x_ptr, [%M, %N], [%n_stride, %c1_i64] : <f16>, <32x64xf16>
+    %y_desc = tt.make_tensor_descriptor %y_ptr, [%M, %N], [%n_stride, %c1_i64] : <bf16>, <32x64xbf16>
+    scf.for %iv = %c0_i32 to %ub step %c1_i32 iter_args(%off = %c0_i32) -> (i32) : i32 {
+      tt.descriptor_store %x_desc[%off, %c0_i32], %src_a : !tt.tensordesc<32x64xf16>, tensor<32x64xf16, #blocked_mix>
+      tt.descriptor_store %y_desc[%off, %c0_i32], %src_b : !tt.tensordesc<32x64xbf16>, tensor<32x64xbf16, #blocked_mix>
+      %next = arith.addi %off, %c32_i32 : i32
+      scf.yield %next : i32
+    }
+    tt.return
+  }
+}
+
+// CHECK-LABEL: tt.func @tdm_two_stores_diff_elem_type
+// CHECK-DAG: %[[AF16:.+]] = ttg.local_alloc : () -> !ttg.memdesc<32x64xf16, {{.+}}, #smem, mutable>
+// CHECK-DAG: %[[ABF16:.+]] = ttg.local_alloc : () -> !ttg.memdesc<32x64xbf16, {{.+}}, #smem, mutable>
+// CHECK-NOT: ttg.local_alloc
+// CHECK: scf.for
+// CHECK-SAME: -> (i32, !ttg.async.token, !ttg.async.token)
+// CHECK: ttg.local_store {{.*}}, %[[AF16]]
+// CHECK: amdg.async_tdm_copy_local_to_global {{.*}} from %[[AF16]]
+// CHECK: ttg.local_store {{.*}}, %[[ABF16]]
+// CHECK: amdg.async_tdm_copy_local_to_global {{.*}} from %[[ABF16]]
+// CHECK: ttg.local_dealloc %[[AF16]]
+// CHECK: ttg.local_dealloc %[[ABF16]]
+
+// -----
+
+// Same element type but different tile size
+#blocked_mix2 = #ttg.blocked<{sizePerThread = [1, 8], threadsPerWarp = [4, 8], warpsPerCTA = [8, 1], order = [1, 0]}>
+module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 8 : i32, ttg.target = "hip:gfx1250", "ttg.threads-per-warp" = 32 : i32} {
+  tt.func @tdm_two_stores_diff_tensor_shape(
+      %x_ptr: !tt.ptr<f16> {tt.divisibility = 16 : i32},
+      %y_ptr: !tt.ptr<f16> {tt.divisibility = 16 : i32},
+      %src_a: tensor<32x64xf16, #blocked_mix2>,
+      %src_b: tensor<32x32xf16, #blocked_mix2>,
+      %M: i32 {tt.divisibility = 16 : i32},
+      %N: i32 {tt.divisibility = 16 : i32},
+      %ub: i32) {
+    %c0_i32 = arith.constant 0 : i32
+    %c1_i32 = arith.constant 1 : i32
+    %c32_i32 = arith.constant 32 : i32
+    %c1_i64 = arith.constant 1 : i64
+    %n_stride = arith.extsi %N : i32 to i64
+    %x_desc = tt.make_tensor_descriptor %x_ptr, [%M, %N], [%n_stride, %c1_i64] : <f16>, <32x64xf16>
+    %y_desc = tt.make_tensor_descriptor %y_ptr, [%M, %c32_i32], [%n_stride, %c1_i64] : <f16>, <32x32xf16>
+    scf.for %iv = %c0_i32 to %ub step %c1_i32 iter_args(%off = %c0_i32) -> (i32) : i32 {
+      tt.descriptor_store %x_desc[%off, %c0_i32], %src_a : !tt.tensordesc<32x64xf16>, tensor<32x64xf16, #blocked_mix2>
+      tt.descriptor_store %y_desc[%off, %c0_i32], %src_b : !tt.tensordesc<32x32xf16>, tensor<32x32xf16, #blocked_mix2>
+      %next = arith.addi %off, %c32_i32 : i32
+      scf.yield %next : i32
+    }
+    tt.return
+  }
+}
+
+// CHECK-LABEL: tt.func @tdm_two_stores_diff_tensor_shape
+// CHECK-DAG: %[[A64:.+]] = ttg.local_alloc : () -> !ttg.memdesc<32x64xf16, {{.+}}, #smem, mutable>
+// CHECK-DAG: %[[A32:.+]] = ttg.local_alloc : () -> !ttg.memdesc<32x32xf16, {{.+}}, #smem, mutable>
+// CHECK-NOT: ttg.local_alloc
+// CHECK: scf.for
+// CHECK-SAME: -> (i32, !ttg.async.token, !ttg.async.token)
+// CHECK: ttg.local_store {{.*}}, %[[A64]]
+// CHECK: amdg.async_tdm_copy_local_to_global {{.*}} from %[[A64]]
+// CHECK: ttg.local_store {{.*}}, %[[A32]]
+// CHECK: amdg.async_tdm_copy_local_to_global {{.*}} from %[[A32]]
+// CHECK: ttg.local_dealloc %[[A64]]
+// CHECK: ttg.local_dealloc %[[A32]]

--- a/third_party/amd/include/Dialect/TritonAMDGPU/IR/TritonAMDGPUOps.td
+++ b/third_party/amd/include/Dialect/TritonAMDGPU/IR/TritonAMDGPUOps.td
@@ -831,6 +831,8 @@ def AsyncTDMCopyLocalToGlobalOp : TT_AMDGPU_Op<"async_tdm_copy_local_to_global",
     DefaultValuedAttr<TT_CacheModifierAttr, "triton::CacheModifier::NONE">:$cache
   );
 
+  let results = (outs TTG_AsyncToken:$token);
+
   let assemblyFormat = [{
     $desc `from` $src (`,` `barrier` `=` $barrier^)?
     attr-dict `:` qualified(type($src)) (`,` qualified(type($barrier))^)? `->` qualified(type($desc))

--- a/third_party/amd/lib/TritonAMDGPUTransforms/CMakeLists.txt
+++ b/third_party/amd/lib/TritonAMDGPUTransforms/CMakeLists.txt
@@ -17,6 +17,7 @@ add_triton_library(TritonAMDGPUTransforms
   Pipeline.cpp
   ScheduleLoops.cpp
   LowerLoops.cpp
+  TDMStoresPipeline.cpp
   MfmaGroup.cpp
   WmmaGroup.cpp
   InThreadTranspose.cpp

--- a/third_party/amd/lib/TritonAMDGPUTransforms/Pipeline.cpp
+++ b/third_party/amd/lib/TritonAMDGPUTransforms/Pipeline.cpp
@@ -207,6 +207,17 @@ struct PipelinePass : impl::TritonAMDGPUPipelineBase<PipelinePass> {
     }
     combineWaitOps(moduleOp, useAsyncCopy);
 
+    // Pipeline TDM stores / scatters that survive in loop bodies: lift the
+    // LDS allocation out of the loop and hoist the wait so the outgoing
+    // async store overlaps the next iteration's compute.  The transformation
+    // is correct regardless of the loop's pipeline-stage count, so we apply
+    // it to every loop unconditionally; it is a no-op when no descriptor
+    // stores or scatters are present.
+    SmallVector<scf::ForOp> loops;
+    moduleOp->walk([&](scf::ForOp forOp) { loops.push_back(forOp); });
+    for (scf::ForOp forOp : loops)
+      pipelineTDMStores(forOp);
+
     tt::removePipeliningAttributes(moduleOp);
   }
 };

--- a/third_party/amd/lib/TritonAMDGPUTransforms/PipelineUtility.h
+++ b/third_party/amd/lib/TritonAMDGPUTransforms/PipelineUtility.h
@@ -21,6 +21,9 @@ constexpr char AttrBypassLDS[] = "amdg.bypass_lds_load";
 // - serialize schedule to IR for the next expandLoops function.
 void lowerLoops(ModuleOp moduleOp, bool useAsyncCopy, bool usePingpong);
 
+// Pipeline the TDM stores and scatter in the loop.
+bool pipelineTDMStores(scf::ForOp forOp);
+
 // LoadInfo encapsulates a load's key aspects wrt scheduling. The `distToUse`
 // and `use` fields grab values from getIndirectLevel() which is a thin wrapper
 // of triton::gpu::loadOpsToIndirectionLevel(). Consider the DU chain,

--- a/third_party/amd/lib/TritonAMDGPUTransforms/TDMStoresPipeline.cpp
+++ b/third_party/amd/lib/TritonAMDGPUTransforms/TDMStoresPipeline.cpp
@@ -2,6 +2,7 @@
 
 #include "amd/include/Dialect/TritonAMDGPU/IR/Dialect.h"
 #include "amd/lib/TritonAMDGPUTransforms/Utility.h"
+#include "mlir/Dialect/Arith/IR/Arith.h"
 #include "mlir/Dialect/SCF/IR/SCF.h"
 #include "mlir/IR/Builders.h"
 #include "triton/Dialect/Triton/IR/Dialect.h"
@@ -25,21 +26,12 @@ struct TDMStore {
 
 static SmallVector<TDMStore> getTDMStores(scf::ForOp forOp) {
   SmallVector<TDMStore> stores;
-  Block *loopBody = forOp.getBody();
-  forOp.getBody()->walk<mlir::WalkOrder::PreOrder>([&](Operation *op) {
-    if (auto storeOp = dyn_cast<tt::DescriptorStoreLikeOpInterface>(op)) {
-      // Only pipeline stores directly in the loop body.  Stores inside
-      // nested regions (e.g. scf.if from loop flattening) can't have
-      // their tokens yielded at the loop level; leave them for
-      // ConvertToTensorOps.
-      if (op->getBlock() == loopBody)
-        stores.push_back({storeOp, storeOp.getDesc(), storeOp.getSrc()});
-    } else if (isa<scf::ForOp>(op)) {
-      // Don't recurse into nested loops; they'd be handled separately.
-      return WalkResult::skip();
-    }
-    return WalkResult::advance();
-  });
+  // Only stores directly in the loop body can yield their tokens at the loop
+  // level; those in nested regions (e.g. scf.if) are left to
+  // ConvertToTensorOps.
+  for (auto storeOp :
+       forOp.getBody()->getOps<tt::DescriptorStoreLikeOpInterface>())
+    stores.push_back({storeOp, storeOp.getDesc(), storeOp.getSrc()});
   return stores;
 }
 
@@ -94,9 +86,11 @@ static Value createTDMAsyncCopy(scf::ForOp forOp, const TDMStore &store,
           indicesType.getShape(), indicesType.getElementType(), idxEnc);
       indices = ttg::ConvertLayoutOp::create(builder, loc, newIdxType, indices);
     }
+    Value zero = arith::ConstantIntOp::create(builder, loc, 0, 32);
+    Value scatterDesc = createUpdateTDMDescriptorOp(
+        builder, loc, desc, {zero, scatterOp.getYOffset()}, /*pred=*/Value{});
     auto scatterTDMOp = ttag::AsyncTDMScatterOp::create(
-        builder, loc, desc, indices, scatterOp.getYOffset(), alloc,
-        /*barrier=*/Value{});
+        builder, loc, scatterDesc, indices, alloc, /*barrier=*/Value{});
     token = scatterTDMOp.getRetToken();
   }
 

--- a/third_party/amd/lib/TritonAMDGPUTransforms/TDMStoresPipeline.cpp
+++ b/third_party/amd/lib/TritonAMDGPUTransforms/TDMStoresPipeline.cpp
@@ -1,0 +1,174 @@
+#include "amd/lib/TritonAMDGPUTransforms/PipelineUtility.h"
+
+#include "amd/include/Dialect/TritonAMDGPU/IR/Dialect.h"
+#include "amd/lib/TritonAMDGPUTransforms/Utility.h"
+#include "mlir/Dialect/SCF/IR/SCF.h"
+#include "mlir/IR/Builders.h"
+#include "triton/Dialect/Triton/IR/Dialect.h"
+#include "triton/Dialect/TritonGPU/IR/Dialect.h"
+#include "triton/Dialect/TritonGPU/Transforms/Utility.h"
+
+using namespace mlir;
+
+namespace tt = mlir::triton;
+namespace ttg = mlir::triton::gpu;
+namespace ttag = mlir::triton::amdgpu;
+
+namespace {
+
+// Bookkeeping for one descriptor store / scatter we want to pipeline.
+struct TDMStore {
+  Operation *op;
+  mlir::TypedValue<tt::TensorDescType> desc;
+  mlir::TypedValue<RankedTensorType> src;
+};
+
+static SmallVector<TDMStore> getTDMStores(scf::ForOp forOp) {
+  SmallVector<TDMStore> stores;
+  Block *loopBody = forOp.getBody();
+  forOp.getBody()->walk<mlir::WalkOrder::PreOrder>([&](Operation *op) {
+    if (auto storeOp = dyn_cast<tt::DescriptorStoreLikeOpInterface>(op)) {
+      // Only pipeline stores directly in the loop body.  Stores inside
+      // nested regions (e.g. scf.if from loop flattening) can't have
+      // their tokens yielded at the loop level; leave them for
+      // ConvertToTensorOps.
+      if (op->getBlock() == loopBody)
+        stores.push_back({storeOp, storeOp.getDesc(), storeOp.getSrc()});
+    } else if (isa<scf::ForOp>(op)) {
+      // Don't recurse into nested loops; they'd be handled separately.
+      return WalkResult::skip();
+    }
+    return WalkResult::advance();
+  });
+  return stores;
+}
+
+// Lift a single LDS allocation outside the loop, sized like store.src.
+static Value createAlloc(scf::ForOp &forOp, const TDMStore &store) {
+  OpBuilder builder(forOp);
+  RankedTensorType ty = store.src.getType();
+  auto encoding = getEncodingFromDescriptor(store.op, ty, store.desc);
+  Attribute sharedMemorySpace =
+      ttg::SharedMemorySpaceAttr::get(ty.getContext());
+  Type memdescType =
+      ttg::MemDescType::get(ty.getShape(), ty.getElementType(), encoding,
+                            sharedMemorySpace, /*mutableMemory=*/true);
+  return ttg::LocalAllocOp::create(builder, store.op->getLoc(), memdescType);
+}
+
+// Replace one descriptor_{store,scatter} with the pipelined async TDM
+// sequence:
+//
+//   amdg.async_tdm_wait <prevToken>    (wait for previous iter's TDM write
+//                                       to release the LDS buffer)
+//   ttg.local_store src, alloc         (write current iter's data into LDS)
+//   amdg.async_tdm_copy_local_to_global  OR  amdg.async_tdm_scatter
+//
+// `prevToken` is a loop-carried token from the previous iteration's TDM op.
+// Returns the token produced by the new TDM op for loop-carried threading.
+static Value createTDMAsyncCopy(scf::ForOp forOp, const TDMStore &store,
+                                Value alloc, Value prevToken) {
+  OpBuilder builder(store.op);
+  Location loc = store.op->getLoc();
+
+  ttag::AsyncTDMWait::create(builder, loc, prevToken, 0);
+  ttg::LocalStoreOp::create(builder, loc, store.src, alloc);
+
+  Value token;
+  Value desc = store.desc;
+  if (auto storeOp = dyn_cast<tt::DescriptorStoreOp>(store.op)) {
+    auto copyOp = ttag::AsyncTDMCopyLocalToGlobalOp::create(
+        builder, loc, desc, storeOp.getIndices(), alloc,
+        /*barrier=*/Value{});
+    token = copyOp.getToken();
+  } else {
+    auto scatterOp = cast<tt::DescriptorScatterOp>(store.op);
+    // Mirror TensorScatterLowering: re-layout them to AMD's TDM
+    // gather/scatter index encoding before issuing the async op.
+    auto indices = scatterOp.getXOffsets();
+    auto indicesType = cast<RankedTensorType>(indices.getType());
+    auto idxEnc = getTDMGatherScatterIndexEncoding(scatterOp, indicesType);
+    if (indicesType.getEncoding() != idxEnc) {
+      auto newIdxType = RankedTensorType::get(
+          indicesType.getShape(), indicesType.getElementType(), idxEnc);
+      indices = ttg::ConvertLayoutOp::create(builder, loc, newIdxType, indices);
+    }
+    auto scatterTDMOp = ttag::AsyncTDMScatterOp::create(
+        builder, loc, desc, indices, scatterOp.getYOffset(), alloc,
+        /*barrier=*/Value{});
+    token = scatterTDMOp.getRetToken();
+  }
+
+  store.op->erase();
+  return token;
+}
+
+} // namespace
+
+bool mlir::pipelineTDMStores(scf::ForOp forOp) {
+  SmallVector<TDMStore> stores = getTDMStores(forOp);
+  if (stores.empty())
+    return false;
+
+  // Reuse a single allocation across stores with the same src shape/type.
+  // This allows saving shared memory usage. This is safe because every
+  // iteration starts with `wait num=0` before the local_store. We could
+  // pipeline more aggressively if we didn't reuse but there is a tradeoff
+  // with shared memory usage.
+  DenseMap<Operation *, Value> storeToAlloc;
+  DenseMap<std::pair<ArrayRef<int64_t>, Type>, Value> allocs;
+  for (const TDMStore &store : stores) {
+    RankedTensorType srcTy = store.src.getType();
+    auto key = std::make_pair(srcTy.getShape(), srcTy.getElementType());
+    Value &alloc = allocs[key];
+    if (!alloc)
+      alloc = createAlloc(forOp, store);
+    storeToAlloc[store.op] = alloc;
+  }
+
+  // Create initial "empty" tokens before the loop (one per store).  These
+  // seed the loop-carried token chain; the first iteration's wait will see
+  // num=0 and be a no-op since nothing is in flight yet.
+  OpBuilder preBuilder(forOp);
+  auto tokenTy = ttg::AsyncTokenType::get(forOp.getContext());
+  SmallVector<Value> initTokens;
+  for (size_t i = 0; i < stores.size(); ++i) {
+    auto seedWait = ttag::AsyncTDMWait::create(preBuilder, forOp->getLoc(),
+                                               ArrayRef<Value>{}, 0);
+    initTokens.push_back(seedWait.getRetToken());
+  }
+
+  // Add one loop-carried token per store.  addIterArgsToLoop splices the
+  // loop body (no clone), so the Operation* pointers in `stores` and
+  // `storeToAlloc` remain valid.
+  unsigned firstNewArg = forOp.getBody()->getNumArguments();
+  forOp = addIterArgsToLoop(preBuilder, forOp, initTokens);
+
+  // Replace each store with the async TDM sequence, threading the token from
+  // the previous iteration's block arg into the wait and yielding the new
+  // token.
+  SmallVector<Value> newTokens;
+  for (auto [i, store] : llvm::enumerate(stores)) {
+    Value prevToken = forOp.getBody()->getArgument(firstNewArg + i);
+    Value newToken =
+        createTDMAsyncCopy(forOp, store, storeToAlloc[store.op], prevToken);
+    newTokens.push_back(newToken);
+  }
+
+  // Yield the new tokens so they become the next iteration's block args.
+  appendToForOpYield(forOp, newTokens);
+
+  // After the loop: drain the last in-flight TDM writes using the final
+  // tokens, then free the allocation(s).
+  OpBuilder builder(forOp);
+  builder.setInsertionPointAfter(forOp);
+  unsigned numOrigResults = forOp.getNumResults() - stores.size();
+  SmallVector<Value> finalTokens;
+  for (size_t i = 0; i < stores.size(); ++i)
+    finalTokens.push_back(forOp.getResult(numOrigResults + i));
+  ttag::AsyncTDMWait::create(builder, forOp->getLoc(), finalTokens, 0);
+  for (auto it : storeToAlloc)
+    ttg::LocalDeallocOp::create(builder, forOp->getLoc(), it.second);
+
+  return true;
+}

--- a/third_party/amd/lib/TritonAMDGPUTransforms/TDMStoresPipeline.cpp
+++ b/third_party/amd/lib/TritonAMDGPUTransforms/TDMStoresPipeline.cpp
@@ -110,65 +110,80 @@ bool mlir::pipelineTDMStores(scf::ForOp forOp) {
   if (stores.empty())
     return false;
 
-  // Reuse a single allocation across stores with the same src shape/type.
-  // This allows saving shared memory usage. This is safe because every
-  // iteration starts with `wait num=0` before the local_store. We could
-  // pipeline more aggressively if we didn't reuse but there is a tradeoff
-  // with shared memory usage.
-  DenseMap<Operation *, Value> storeToAlloc;
-  DenseMap<std::pair<ArrayRef<int64_t>, Type>, Value> allocs;
+  // Reuse a single allocation across stores with the same src shape/type to
+  // save shared memory. Stores that share an allocation form one "alloc
+  // group". Within an iteration, an alloc group's stores must execute
+  // sequentially with respect to the LDS buffer: each `local_store` must
+  // wait for the previous in-iteration TDM op on the same allocation to
+  // finish reading the buffer before overwriting it.
+  //
+  // To get correct ordering, we maintain exactly one loop-carried token per
+  // allocation that represents the *last* TDM op of the previous iteration for
+  // that allocation. Inside the iteration we thread the token forward through
+  // each store in the group: store 0 waits on the loop-carried token,
+  // store 1 waits on store 0's token... The token of the group's last store is
+  // yielded as the next iteration's loop-carried token. This ensures the last
+  // TDM store of each allocation can overlap with the TDM loads inside the
+  // loop.
+  SmallVector<Value> uniqueAllocs;
+  DenseMap<Operation *, unsigned> storeToAllocIdx;
+  DenseMap<std::pair<ArrayRef<int64_t>, Type>, unsigned> allocKeyToIdx;
   for (const TDMStore &store : stores) {
     RankedTensorType srcTy = store.src.getType();
     auto key = std::make_pair(srcTy.getShape(), srcTy.getElementType());
-    Value &alloc = allocs[key];
-    if (!alloc)
-      alloc = createAlloc(forOp, store);
-    storeToAlloc[store.op] = alloc;
+    // Check if a key already exists, if not create a new allocation
+    auto [it, inserted] = allocKeyToIdx.try_emplace(key, uniqueAllocs.size());
+    if (inserted)
+      uniqueAllocs.push_back(createAlloc(forOp, store));
+    storeToAllocIdx[store.op] = it->second;
   }
 
-  // Create initial "empty" tokens before the loop (one per store).  These
-  // seed the loop-carried token chain; the first iteration's wait will see
-  // num=0 and be a no-op since nothing is in flight yet.
+  // Seed one "empty" loop-carried token per allocation; this is slightly
+  // conservative but the best we can do as we do not have an unitialized token
+  // state.
   OpBuilder preBuilder(forOp);
-  auto tokenTy = ttg::AsyncTokenType::get(forOp.getContext());
   SmallVector<Value> initTokens;
-  for (size_t i = 0; i < stores.size(); ++i) {
+  initTokens.reserve(uniqueAllocs.size());
+  for (size_t i = 0; i < uniqueAllocs.size(); ++i) {
     auto seedWait = ttag::AsyncTDMWait::create(preBuilder, forOp->getLoc(),
                                                ArrayRef<Value>{}, 0);
     initTokens.push_back(seedWait.getRetToken());
   }
 
   // Add one loop-carried token per store.  addIterArgsToLoop splices the
-  // loop body (no clone), so the Operation* pointers in `stores` and
-  // `storeToAlloc` remain valid.
+  // loop body (no clone), so the Operation* pointers in `storeToAllocIdx`
+  // remain valid.
   unsigned firstNewArg = forOp.getBody()->getNumArguments();
   forOp = addIterArgsToLoop(preBuilder, forOp, initTokens);
 
-  // Replace each store with the async TDM sequence, threading the token from
-  // the previous iteration's block arg into the wait and yielding the new
-  // token.
-  SmallVector<Value> newTokens;
-  for (auto [i, store] : llvm::enumerate(stores)) {
-    Value prevToken = forOp.getBody()->getArgument(firstNewArg + i);
-    Value newToken =
-        createTDMAsyncCopy(forOp, store, storeToAlloc[store.op], prevToken);
-    newTokens.push_back(newToken);
+  // `curTokens[i]` is the current in-flight token for `uniqueAllocs[i]`.
+  // It starts at the loop-carried token and advances after each store.
+  SmallVector<Value> curTokens(uniqueAllocs.size());
+  for (size_t i = 0; i < uniqueAllocs.size(); ++i)
+    curTokens[i] = forOp.getBody()->getArgument(firstNewArg + i);
+
+  for (const TDMStore &store : stores) {
+    unsigned aIdx = storeToAllocIdx[store.op];
+    curTokens[aIdx] =
+        createTDMAsyncCopy(forOp, store, uniqueAllocs[aIdx], curTokens[aIdx]);
   }
 
-  // Yield the new tokens so they become the next iteration's block args.
-  appendToForOpYield(forOp, newTokens);
+  // Yield the per-allocation tail tokens so they become the next
+  // iteration's loop-carried tokens.
+  appendToForOpYield(forOp, curTokens);
 
   // After the loop: drain the last in-flight TDM writes using the final
   // tokens, then free the allocation(s).
   OpBuilder builder(forOp);
   builder.setInsertionPointAfter(forOp);
-  unsigned numOrigResults = forOp.getNumResults() - stores.size();
+  unsigned numOrigResults = forOp.getNumResults() - uniqueAllocs.size();
   SmallVector<Value> finalTokens;
-  for (size_t i = 0; i < stores.size(); ++i)
+  finalTokens.reserve(uniqueAllocs.size());
+  for (size_t i = 0; i < uniqueAllocs.size(); ++i)
     finalTokens.push_back(forOp.getResult(numOrigResults + i));
   ttag::AsyncTDMWait::create(builder, forOp->getLoc(), finalTokens, 0);
-  for (auto it : storeToAlloc)
-    ttg::LocalDeallocOp::create(builder, forOp->getLoc(), it.second);
+  for (Value alloc : uniqueAllocs)
+    ttg::LocalDeallocOp::create(builder, forOp->getLoc(), alloc);
 
   return true;
 }

--- a/third_party/amd/lib/TritonAMDGPUTransforms/TDMStoresPipeline.cpp
+++ b/third_party/amd/lib/TritonAMDGPUTransforms/TDMStoresPipeline.cpp
@@ -77,9 +77,10 @@ static Value createTDMAsyncCopy(scf::ForOp forOp, const TDMStore &store,
   Value token;
   Value desc = store.desc;
   if (auto storeOp = dyn_cast<tt::DescriptorStoreOp>(store.op)) {
+    Value copyDesc = createUpdateTDMDescriptorOp(
+        builder, loc, desc, storeOp.getIndices(), /*pred=*/Value{});
     auto copyOp = ttag::AsyncTDMCopyLocalToGlobalOp::create(
-        builder, loc, desc, storeOp.getIndices(), alloc,
-        /*barrier=*/Value{});
+        builder, loc, copyDesc, alloc, /*barrier=*/Value{});
     token = copyOp.getToken();
   } else {
     auto scatterOp = cast<tt::DescriptorScatterOp>(store.op);


### PR DESCRIPTION
This brings AMD TDM descriptor store/scatter pipelining to parity with the NVIDIA side. It mirrors `pipelineTMAStores` (`lib/Dialect/TritonGPU/Transforms/Pipeliner/TMAStoresPipeline.cpp`). The gist of change is instead of lowering each in-loop descriptor store/scatter to a blocking `local_store -> async TDM write -> wait(num=0)` sequence, the LDS buffer is software-pipelined across iterations so the outgoing async write can overlap the next iteration's compute.

  ### Main changes

  - Token-carrying TDM ops. The async TDM write ops now produce an async token, and async_tdm_wait consumes tokens
  - New pipelineTDMStores pass. For each descriptor store/scatter surviving in a loop body:
    - Hoist the LDS allocation out of the loop (one alloc per distinct src shape/dtype).
    - Thread a loop-carried token per store: each iteration waits on the previous iteration's token before reusing the LDS buffer
    - Seed initial tokens before the loop and emit a drain wait after the loop to retire the final in-flight writes

The pass runs unconditionally over every loop and is a no-op when no descriptor stores/scatters are present, so it is independent of the loop's pipeline-stage count.

  ### Caveat

This restructures the IR for pipelining, but it does not yet yield true store/compute overlap on current hardware. TDM loads and stores share a single hardware counter: `s_wait_tensorcnt`, and same-warp TDM ops complete in issue order. Because store and load completion cannot be distinguished on that one counter.

The PR is still worthwhile as a baseline: it establishes the token-threaded pipeline structure and brings the pass to parity with the NVIDIA flow. Making TDM stores truly overlap is a follow-up work.

CC: @antiagainst @AlexAUT, already passed review in a downstream fork