### PR TITLE
[CI] Fix gluon tutorials not being run in CI

### DIFF
--- a/pytest.ini
+++ b/pytest.ini
@@ -1,3 +1,4 @@
 [pytest]
 addopts = --tb=short
 markers = interpreter: indicate whether interpreter supports the test
+python_files = test_*.py *_test.py tutorials/*.py examples/*.py

--- a/python/examples/pytest.ini
+++ b/python/examples/pytest.ini
@@ -1,2 +1,0 @@
-[pytest]
-python_files = *.py

--- a/python/tutorials/gluon/06-tcgen05.py
+++ b/python/tutorials/gluon/06-tcgen05.py
@@ -179,7 +179,7 @@ def small_mma_kernel(a_desc, b_desc, c_desc, d_desc, tmem_block: gl.constexpr,  
     # Copy operands into TMEM.
     # TODO: Use `tcgen05.cp` when it is exposed in Gluon.
     acc_tmem_layout: gl.constexpr = TensorMemoryLayout(
-        tmem_block.value,
+        tmem_block,
         col_stride=32 // d_desc.dtype.primitive_bitwidth,
     )
     acc_tmem = allocate_tensor_memory(d_desc.dtype, [M, N], acc_tmem_layout)
@@ -190,7 +190,7 @@ def small_mma_kernel(a_desc, b_desc, c_desc, d_desc, tmem_block: gl.constexpr,  
     if LHS_IN_TMEM:
         # When the LHS operand is fp16 or fp8, it is packed in TMEM.
         lhs_tmem_layout: gl.constexpr = TensorMemoryLayout(
-            tmem_block.value,
+            tmem_block,
             col_stride=1,
         )
         lhs_tmem = allocate_tensor_memory(a_desc.dtype, [M, K], lhs_tmem_layout)

--- a/python/tutorials/gluon/14-multicta.py
+++ b/python/tutorials/gluon/14-multicta.py
@@ -191,9 +191,6 @@ def test_multicta_softmax_f32(M, N):
 
 
 def benchmark_multicta_softmax_f32():
-    if not is_hopper_or_newer():
-        raise RuntimeError("softmax benchmark requires Hopper or newer")
-
     SOFTMAX_BENCH_SHAPES = [
         (2**15, 2**8),
         (2**15, 2**9),
@@ -219,7 +216,8 @@ def benchmark_multicta_softmax_f32():
         print(f"{M:>6} x {N:<6}  {cfg['num_ctas']:>4}  {cfg['num_warps']:>5}  {ms:>9.3f}  {gbps(ms, num_bytes):>16.2f}")
 
 
-benchmark_multicta_softmax_f32()
+if __name__ == "__main__" and is_hopper_or_newer():
+    benchmark_multicta_softmax_f32()
 
 # %%
 # Softmax benchmark results

--- a/python/tutorials/gluon/pytest.ini
+++ b/python/tutorials/gluon/pytest.ini
@@ -1,2 +1,0 @@
-[pytest]
-python_files = *.py

--- a/python/tutorials/pytest.ini
+++ b/python/tutorials/pytest.ini
@@ -1,2 +1,0 @@
-[pytest]
-python_files = *.py


### PR DESCRIPTION
Fixes https://github.com/triton-lang/triton/pull/10451#issuecomment-4670002065, and the reason the test didn't run in CI.

Apparently only one pytest.ini file can take effect, so if you pass in multiple folders to a pytest command it will look for a common ancestor ini file. The fix is to merge all of our ini files into one.