### PR TITLE
[FPSAN] Prevent payload canonicalization during embedding

### DIFF
--- a/lib/Conversion/TritonInstrumentToLLVM/FpSanToLLVM.cpp
+++ b/lib/Conversion/TritonInstrumentToLLVM/FpSanToLLVM.cpp
@@ -123,10 +123,12 @@ Value mixFloatToInt(ConversionPatternRewriter &rewriter, Location loc, Value u,
   PayloadMixConfig cfg = getPayloadMixConfig(floatTy);
   Value signFlip =
       selectUIntConstantOnSign(rewriter, loc, u, cfg.signMask, 0, cfg.signMask);
-  Value x = b.xor_(u, signFlip);
   Value mulA = createUIntConstant(rewriter, loc, u.getType(), cfg.mulA);
   Value magMask = createUIntConstant(rewriter, loc, u.getType(), cfg.magMask);
-  Value yMul = b.mul(x, mulA);
+  // The sign-bit contribution to the product is discarded by magMask. Using
+  // the raw bits also prevents LLVM from folding the sign clear into fabs,
+  // which would canonicalize NaN-shaped FPSan payloads.
+  Value yMul = b.mul(u, mulA);
   Value y = b.and_(yMul, magMask);
   Value z = xorShiftRight(rewriter, loc, y, cfg.shift);
   Value mulB = selectUIntConstantOnSign(rewriter, loc, u, cfg.signMask,

--- a/python/test/gluon/test_fpsan.py
+++ b/python/test/gluon/test_fpsan.py
@@ -2359,6 +2359,55 @@ def test_reduction_matches_loop(device, fresh_knobs):
     _assert_payload_equal(reduce_out, loop_out)
 
 
+def test_dot_loop_accumulator_add_zero_preserves_payload(device, fresh_knobs):
+    _require_cuda_backend(device)
+
+    def allocator(size: int, alignment: int, stream):
+        return torch.empty(size, device="cuda", dtype=torch.int8)
+
+    triton.set_allocator(allocator)
+    fresh_knobs.compilation.instrumentation_mode = "fpsan"
+
+    @triton.jit(do_not_specialize=["k_size"])
+    def kernel(a_ptr, b_ptr, out_ptr, out_plus_zero_ptr, k_size):
+        rows = tl.arange(0, 16)
+        cols = tl.arange(0, 16)
+        inner = tl.arange(0, 16)
+        acc = tl.zeros((16, 16), tl.float32)
+        for tile in range(0, tl.cdiv(k_size, 16)):
+            k = tile * 16 + inner
+            a = tl.load(a_ptr + rows[:, None] * k_size + k[None, :], mask=k[None, :] < k_size)
+            b = tl.load(b_ptr + k[:, None] * 16 + cols[None, :], mask=k[:, None] < k_size)
+            acc = tl.dot(a, b, acc, allow_tf32=False)
+        offsets = rows[:, None] * 16 + cols[None, :]
+        tl.store(out_ptr + offsets, acc)
+        tl.store(out_plus_zero_ptr + offsets, acc + 0.0)
+
+    a_bits = np.zeros((16, 16), dtype=np.int32)
+    a_bits[:4, 0] = np.array([0x7FC00001, 0x7F800001, 0xFFC00001, 0xFF800001], dtype=np.uint32).view(np.int32)
+    b_bits = np.zeros((16, 16), dtype=np.int32)
+    b_bits[0, 0] = 0x3F800000
+    expected = np.zeros((16, 16), dtype=np.int32)
+    expected[:4, 0] = a_bits[:4, 0]
+
+    a = torch.tensor(a_bits, device="cuda")
+    b = torch.tensor(b_bits, device="cuda")
+    out = torch.empty((16, 16), device="cuda", dtype=torch.int32)
+    out_plus_zero = torch.empty_like(out)
+    kernel[(1, )](
+        triton.TensorWrapper(a, dtype=torch.float32),
+        triton.TensorWrapper(b, dtype=torch.float32),
+        triton.TensorWrapper(out, dtype=torch.float32),
+        triton.TensorWrapper(out_plus_zero, dtype=torch.float32),
+        16,
+        num_warps=1,
+        num_stages=1,
+    )
+
+    _assert_payload_equal(out, expected)
+    _assert_payload_equal(out_plus_zero, expected)
+
+
 @pytest.mark.skipif(not (is_hip_cdna3() or is_hip_cdna4()), reason="Requires CDNA3 or CDNA4")
 def test_mfma_dot(device, fresh_knobs):
     _require_cuda_backend(device)

--- a/test/Conversion/tritoninstrument_to_llvm.mlir
+++ b/test/Conversion/tritoninstrument_to_llvm.mlir
@@ -115,8 +115,8 @@ tt.func private @experimental_gsan_tensordesc_info(
 module attributes {"ttg.num-warps" = 4 : i32, ttg.target = "cuda:90"} {
 // CHECK-LABEL: @experimental_fpsan_embed
 // CHECK-NOT: tti.experimental_fpsan_embed
-// CHECK: llvm.bitcast %arg0 : f32 to i32
-// CHECK: llvm.mul
+// CHECK: %[[RAW:.*]] = llvm.bitcast %arg0 : f32 to i32
+// CHECK: llvm.mul %[[RAW]], %{{.*}} : i32
 // CHECK: llvm.xor
 tt.func private @experimental_fpsan_embed(%arg0: f32) -> i32 {
   %0 = tti.experimental_fpsan_embed %arg0 : (f32) -> i32


### PR DESCRIPTION
## Summary

Prevent LLVM from canonicalizing NaN-shaped FPSan payloads when an unembedded
floating-point value is embedded again.

This occurred with loop-carried `tl.dot` results followed by otherwise
identity-preserving operations such as `x + 0.0`.

## Problem

FPSan represents floating-point values as opaque integer payloads. In [FpSanToLLVM.cpp](https://github.com/triton-lang/triton/pull/10569/changes#diff-00f904d5453d72e6db6fadcd02da63d4ea7627d899a6801151e28b67535f1e11) During
embedding, `mixFloatToInt()` previously cleared the sign bit before applying
the first integer mixing multiplication:

```cpp
Value x = b.xor_(u, signFlip);
Value yMul = b.mul(x, mulA);
Value y = b.and_(yMul, magMask);
```

LLVM recognized the sign-clearing pattern as floating-point absolute value and
lowered it to `abs.f32` on NVIDIA GPUs. Although valid for ordinary
floating-point values, this is not valid for opaque FPSan payloads: payload bit
patterns that resemble NaNs were canonicalized.

For example, a loop-carried `tl.dot` followed by `acc + 0.0` produced changes
such as:

```text
0x7fc00001 -> 0x7fffffff
0x7f800001 -> 0x7fffffff
0xffc00001 -> 0xffffffff
0xff800001 -> 0xffffffff
```

As a result, `x + 0.0` did not preserve the FPSan payload.

## Fix

Multiply the raw bits and let the existing magnitude mask discard the sign-bit
contribution:

```cpp
Value yMul = b.mul(u, mulA);
Value y = b.and_(yMul, magMask);
```

This avoids producing the sign-clearing pattern that LLVM folds into `fabs`,
while preserving the existing payload mapping.

The existing sign-dependent second multiplier and final sign restoration are
unchanged.

## Tests

Added:

- A minimal MLIR lowering check requiring the raw bitcast value to feed the
  first mixing multiplication.
- An end-to-end GPU regression using a dynamically loop-carried `tl.dot`,
  followed by `acc + 0.0`, with positive and negative NaN-shaped payloads.
- The regression fails on unpatched `main` and passes with this change.

Local validation:

- `pre-commit run --from-ref origin/main --to-ref HEAD`
- Full lit suite: 276 passed, 2 unsupported
- Full `python/test/gluon/test_fpsan.py`: 69 passed, 17 skipped
- Exhaustive equivalence check for all 8-bit and 16-bit inputs
- Additional ad hoc local verification: exhaustive equivalence checking for 8- and 16-bit inputs, plus one million randomized 32- and 64-bit inputs.

# New contributor declaration

- [x] I am not making a trivial change, such as fixing a typo in a comment.

- [x] I have written a PR description following these
  [rules](https://cbea.ms/git-commit/#why-not-how).

- [x] I have run `pre-commit run --from-ref origin/main --to-ref HEAD`.

- [x] I have added tests.
  - `/test` for `lit` tests
  - `/python/test` for end-to-end tests

- [x] The `lit` tests I have added follow these
  [best practices](https://mlir.llvm.org/getting_started/TestingGuide/#filecheck-best-practices),
  including the "tests should be minimal" section.
