### PR TITLE
[FPSAN] Recognize equivalent CUDA libdevice operations

### DIFF
--- a/lib/Dialect/TritonInstrument/Transforms/FpSanitizer.cpp
+++ b/lib/Dialect/TritonInstrument/Transforms/FpSanitizer.cpp
@@ -13,7 +13,9 @@
 #include "triton/Tools/LayoutUtils.h"
 #include "llvm/ADT/DenseSet.h"
 #include "llvm/ADT/STLExtras.h"
+#include "llvm/ADT/StringSwitch.h"
 #include <cassert>
+#include <functional>
 
 namespace mlir {
 namespace triton {
@@ -678,6 +680,16 @@ Value fpsanFDiv(PatternRewriter &rewriter, Location loc, Value num, Value den) {
   auto inv = fpsanIntInv(rewriter, loc, denI);
   auto resI = arith::MulIOp::create(rewriter, loc, numI, inv);
   return unembedToFloat(rewriter, loc, resI, num.getType());
+}
+
+Value fpsanFma(PatternRewriter &rewriter, Location loc, Value a, Value b,
+               Value c) {
+  auto aI = embedToInt(rewriter, loc, a);
+  auto bI = embedToInt(rewriter, loc, b);
+  auto cI = embedToInt(rewriter, loc, c);
+  auto mul = arith::MulIOp::create(rewriter, loc, aI, bI);
+  auto sum = arith::AddIOp::create(rewriter, loc, mul, cI);
+  return unembedToFloat(rewriter, loc, sum, a.getType());
 }
 
 Value fpsanSRem(PatternRewriter &rewriter, Location loc, Value num, Value den) {
@@ -1760,14 +1772,8 @@ struct FmaPattern : public OpRewritePattern<math::FmaOp> {
                                 PatternRewriter &rewriter) const override {
     if (!isFloatLike(op.getType()))
       return failure();
-    auto loc = op.getLoc();
-    auto aI = embedToInt(rewriter, loc, op.getA());
-    auto bI = embedToInt(rewriter, loc, op.getB());
-    auto cI = embedToInt(rewriter, loc, op.getC());
-    auto mul = arith::MulIOp::create(rewriter, loc, aI, bI);
-    auto sum = arith::AddIOp::create(rewriter, loc, mul, cI);
-    auto resF = unembedToFloat(rewriter, loc, sum, op.getType());
-    rewriter.replaceOp(op, resF);
+    rewriter.replaceOp(
+        op, fpsanFma(rewriter, op.getLoc(), op.getA(), op.getB(), op.getC()));
     return success();
   }
 };
@@ -2754,6 +2760,78 @@ private:
   UnaryOpId unaryOpId;
 };
 
+bool hasFp32Signature(tt::ExternElementwiseOp op, unsigned arity) {
+  if (op.getNumOperands() != arity ||
+      !getElementTypeOrSelf(op.getType()).isF32())
+    return false;
+  return llvm::all_of(op.getOperandTypes(), [](Type type) {
+    return getElementTypeOrSelf(type).isF32();
+  });
+}
+
+using KnownExternTransform =
+    std::function<Value(PatternRewriter &, tt::ExternElementwiseOp)>;
+using UnaryExternTransform =
+    std::function<Value(PatternRewriter &, Location, Value)>;
+using BinaryExternTransform =
+    std::function<Value(PatternRewriter &, Location, Value, Value)>;
+using TernaryExternTransform =
+    std::function<Value(PatternRewriter &, Location, Value, Value, Value)>;
+
+KnownExternTransform makeUnaryExternTransform(UnaryExternTransform transform) {
+  return [transform](PatternRewriter &rewriter, tt::ExternElementwiseOp op) {
+    if (!hasFp32Signature(op, 1))
+      return Value();
+    return transform(rewriter, op.getLoc(), op.getOperand(0));
+  };
+}
+
+KnownExternTransform makeTaggedUnaryExternTransform(UnaryOpId opId) {
+  return [opId](PatternRewriter &rewriter, tt::ExternElementwiseOp op) {
+    if (!hasFp32Signature(op, 1))
+      return Value();
+    return fpsanUnaryTagged(rewriter, op.getLoc(), op.getOperand(0), opId);
+  };
+}
+
+KnownExternTransform
+makeBinaryExternTransform(BinaryExternTransform transform) {
+  return [transform](PatternRewriter &rewriter, tt::ExternElementwiseOp op) {
+    if (!hasFp32Signature(op, 2))
+      return Value();
+    return transform(rewriter, op.getLoc(), op.getOperand(0), op.getOperand(1));
+  };
+}
+
+KnownExternTransform
+makeTernaryExternTransform(TernaryExternTransform transform) {
+  return [transform](PatternRewriter &rewriter, tt::ExternElementwiseOp op) {
+    if (!hasFp32Signature(op, 3))
+      return Value();
+    return transform(rewriter, op.getLoc(), op.getOperand(0), op.getOperand(1),
+                     op.getOperand(2));
+  };
+}
+
+std::optional<KnownExternTransform> getKnownExtern(StringRef symbol) {
+  return llvm::StringSwitch<std::optional<KnownExternTransform>>(symbol)
+      .Case("__nv_fast_expf", makeUnaryExternTransform(fpsanExp))
+      .Case("__nv_exp2f", makeUnaryExternTransform(fpsanExp2))
+      .Case("__nv_logf", makeTaggedUnaryExternTransform(UnaryOpId::Log))
+      .Case("__nv_log2f", makeTaggedUnaryExternTransform(UnaryOpId::Log2))
+      .Case("__nv_cosf", makeUnaryExternTransform(fpsanCos))
+      .Case("__nv_sinf", makeUnaryExternTransform(fpsanSin))
+      .Case("__nv_rsqrtf", makeTaggedUnaryExternTransform(UnaryOpId::Rsqrt))
+      .Case("__nv_erff", makeTaggedUnaryExternTransform(UnaryOpId::Erf))
+      .Case("__nv_floorf", makeTaggedUnaryExternTransform(UnaryOpId::Floor))
+      .Case("__nv_ceilf", makeTaggedUnaryExternTransform(UnaryOpId::Ceil))
+      .Case("__nv_fsqrt_rn",
+            makeTaggedUnaryExternTransform(UnaryOpId::PreciseSqrt))
+      .Case("__nv_fdiv_rn", makeBinaryExternTransform(fpsanFDiv))
+      .Case("__nv_fmaf", makeTernaryExternTransform(fpsanFma))
+      .Default(std::nullopt);
+}
+
 struct ExternElementwisePattern
     : public OpRewritePattern<tt::ExternElementwiseOp> {
   using OpRewritePattern::OpRewritePattern;
@@ -2764,8 +2842,15 @@ struct ExternElementwisePattern
         op.getNumOperands() == 0 || !externHasNumericOperands(op))
       return failure();
 
-    uint64_t hash = stableStringHash(op.getSymbol());
-    Value result = fpsanVariadicExternTagged(rewriter, op.getLoc(), op, hash);
+    Value result;
+    // FPSan models the intended operation, so aliases may intentionally ignore
+    // backend details such as flushing subnormal inputs or outputs to zero.
+    if (auto transform = getKnownExtern(op.getSymbol()))
+      result = (*transform)(rewriter, op);
+    if (!result) {
+      uint64_t hash = stableStringHash(op.getSymbol());
+      result = fpsanVariadicExternTagged(rewriter, op.getLoc(), op, hash);
+    }
     if (!result)
       return emitFpSanCodegenError(op.getOperation());
     rewriter.replaceOp(op, result);

--- a/python/test/gluon/test_fpsan.py
+++ b/python/test/gluon/test_fpsan.py
@@ -1088,14 +1088,15 @@ def test_extern_ternary_payload_semantics(device, op, symbol, fresh_knobs):
     _extern_ternary_math_kernel[grid](xw, yw, zw, outw, n_elements, OP=op, BLOCK=BLOCK,
                                       THREADS_PER_WARP=THREADS_PER_WARP)
 
-    exp_bits = _expected_extern_variadic_tag_i32(
-        [
-            x.cpu().numpy().astype(np.int32, copy=False),
-            y.cpu().numpy().astype(np.int32, copy=False),
-            z.cpu().numpy().astype(np.int32, copy=False),
-        ],
-        symbol,
-    )
+    input_bits = [
+        x.cpu().numpy().astype(np.int32, copy=False),
+        y.cpu().numpy().astype(np.int32, copy=False),
+        z.cpu().numpy().astype(np.int32, copy=False),
+    ]
+    if symbol == "__nv_fmaf":
+        exp_bits = _expected_fma_i32(*input_bits)
+    else:
+        exp_bits = _expected_extern_variadic_tag_i32(input_bits, symbol)
     _assert_payload_equal(out, exp_bits)
 
 

--- a/python/test/unit/cuda/test_libdevice_cuda.py
+++ b/python/test/unit/cuda/test_libdevice_cuda.py
@@ -6,6 +6,7 @@ import torch
 import triton
 import triton.language as tl
 
+from triton._internal_testing import is_cuda
 from triton.language.extra import libdevice
 
 
@@ -53,3 +54,210 @@ def test_math_extern(dtype_str, direct_import):
 
     y_ref = torch.tanh(x)
     np.testing.assert_allclose(y_ref.cpu().numpy(), y_tri.cpu().numpy(), rtol=0, atol=1.0e-6)
+
+
+@triton.jit
+def builtin_libdevice_unary_kernel(
+    x_ptr,
+    builtin_ptr,
+    libdevice_ptr,
+    n_elements,
+    OP: tl.constexpr,
+    BLOCK_SIZE: tl.constexpr,
+):
+    offsets = tl.program_id(0) * BLOCK_SIZE + tl.arange(0, BLOCK_SIZE)
+    mask = offsets < n_elements
+    x = tl.load(x_ptr + offsets, mask=mask)
+
+    if OP == "exp":
+        builtin = tl.exp(x)
+        external = libdevice.fast_expf(x)
+    elif OP == "sqrt_rn":
+        builtin = tl.sqrt_rn(x)
+        external = libdevice.sqrt_rn(x)
+    elif OP == "exp2":
+        builtin = tl.exp2(x)
+        external = libdevice.exp2(x)
+    elif OP == "log":
+        builtin = tl.log(x)
+        external = libdevice.log(x)
+    elif OP == "log2":
+        builtin = tl.log2(x)
+        external = libdevice.log2(x)
+    elif OP == "sin":
+        builtin = tl.sin(x)
+        external = libdevice.sin(x)
+    elif OP == "cos":
+        builtin = tl.cos(x)
+        external = libdevice.cos(x)
+    elif OP == "rsqrt":
+        builtin = tl.rsqrt(x)
+        external = libdevice.rsqrt(x)
+    elif OP == "erf":
+        builtin = tl.erf(x)
+        external = libdevice.erf(x)
+    elif OP == "floor":
+        builtin = tl.floor(x)
+        external = libdevice.floor(x)
+    elif OP == "ceil":
+        builtin = tl.ceil(x)
+        external = libdevice.ceil(x)
+    elif OP == "fast_sin":
+        builtin = tl.sin(x)
+        external = libdevice.fast_sinf(x)
+    elif OP == "fast_cos":
+        builtin = tl.cos(x)
+        external = libdevice.fast_cosf(x)
+    elif OP == "fast_log":
+        builtin = tl.log(x)
+        external = libdevice.fast_logf(x)
+    elif OP == "fast_log2":
+        builtin = tl.log2(x)
+        external = libdevice.fast_log2f(x)
+
+    tl.store(builtin_ptr + offsets, builtin, mask=mask)
+    tl.store(libdevice_ptr + offsets, external, mask=mask)
+
+
+@triton.jit
+def builtin_libdevice_div_rn_kernel(
+    x_ptr,
+    y_ptr,
+    builtin_ptr,
+    libdevice_ptr,
+    n_elements,
+    BLOCK_SIZE: tl.constexpr,
+):
+    offsets = tl.program_id(0) * BLOCK_SIZE + tl.arange(0, BLOCK_SIZE)
+    mask = offsets < n_elements
+    x = tl.load(x_ptr + offsets, mask=mask)
+    y = tl.load(y_ptr + offsets, mask=mask)
+
+    tl.store(builtin_ptr + offsets, tl.div_rn(x, y), mask=mask)
+    tl.store(libdevice_ptr + offsets, libdevice.div_rn(x, y), mask=mask)
+
+
+@triton.jit
+def builtin_libdevice_fma_kernel(
+    x_ptr,
+    y_ptr,
+    z_ptr,
+    builtin_ptr,
+    libdevice_ptr,
+    n_elements,
+    BLOCK_SIZE: tl.constexpr,
+):
+    offsets = tl.program_id(0) * BLOCK_SIZE + tl.arange(0, BLOCK_SIZE)
+    mask = offsets < n_elements
+    x = tl.load(x_ptr + offsets, mask=mask)
+    y = tl.load(y_ptr + offsets, mask=mask)
+    z = tl.load(z_ptr + offsets, mask=mask)
+
+    tl.store(builtin_ptr + offsets, tl.fma(x, y, z), mask=mask)
+    tl.store(libdevice_ptr + offsets, libdevice.fma(x, y, z), mask=mask)
+
+
+def _random_payloads(generator, n_elements):
+    return torch.randint(-(2**31), 2**31 - 1, (n_elements,), dtype=torch.int32, device="cuda", generator=generator)
+
+
+@pytest.mark.parametrize(
+    "op", ["exp", "exp2", "log", "log2", "sin", "cos", "sqrt_rn", "rsqrt", "erf", "floor", "ceil"]
+)
+def test_fpsan_libdevice_unary_equivalence(op, fresh_knobs):
+    if not is_cuda() or not torch.cuda.is_available():
+        pytest.skip("test requires CUDA")
+
+    fresh_knobs.compilation.instrumentation_mode = "fpsan"
+    n_elements = 1024
+    block_size = 256
+    generator = torch.Generator(device="cuda")
+    generator.manual_seed(0)
+    x = _random_payloads(generator, n_elements)
+    builtin = torch.empty_like(x)
+    external = torch.empty_like(x)
+
+    builtin_libdevice_unary_kernel[(triton.cdiv(n_elements, block_size),)](
+        triton.TensorWrapper(x, dtype=torch.float32),
+        triton.TensorWrapper(builtin, dtype=torch.float32),
+        triton.TensorWrapper(external, dtype=torch.float32),
+        n_elements,
+        OP=op,
+        BLOCK_SIZE=block_size,
+    )
+
+    assert torch.equal(builtin, external)
+
+
+def test_fpsan_libdevice_div_rn_equivalence(fresh_knobs):
+    if not is_cuda() or not torch.cuda.is_available():
+        pytest.skip("test requires CUDA")
+
+    fresh_knobs.compilation.instrumentation_mode = "fpsan"
+    n_elements = 1024
+    block_size = 256
+    generator = torch.Generator(device="cuda")
+    generator.manual_seed(0)
+    inputs = [_random_payloads(generator, n_elements) for _ in range(2)]
+    builtin = torch.empty_like(inputs[0])
+    external = torch.empty_like(inputs[0])
+
+    builtin_libdevice_div_rn_kernel[(triton.cdiv(n_elements, block_size),)](
+        *(triton.TensorWrapper(value, dtype=torch.float32) for value in inputs),
+        triton.TensorWrapper(builtin, dtype=torch.float32),
+        triton.TensorWrapper(external, dtype=torch.float32),
+        n_elements,
+        BLOCK_SIZE=block_size,
+    )
+
+    assert torch.equal(builtin, external)
+
+
+def test_fpsan_libdevice_fma_equivalence(fresh_knobs):
+    if not is_cuda() or not torch.cuda.is_available():
+        pytest.skip("test requires CUDA")
+
+    fresh_knobs.compilation.instrumentation_mode = "fpsan"
+    n_elements = 1024
+    block_size = 256
+    generator = torch.Generator(device="cuda")
+    generator.manual_seed(0)
+    inputs = [_random_payloads(generator, n_elements) for _ in range(3)]
+    builtin = torch.empty_like(inputs[0])
+    external = torch.empty_like(inputs[0])
+
+    builtin_libdevice_fma_kernel[(triton.cdiv(n_elements, block_size),)](
+        *(triton.TensorWrapper(value, dtype=torch.float32) for value in inputs),
+        triton.TensorWrapper(builtin, dtype=torch.float32),
+        triton.TensorWrapper(external, dtype=torch.float32),
+        n_elements,
+        BLOCK_SIZE=block_size,
+    )
+
+    assert torch.equal(builtin, external)
+
+
+@pytest.mark.parametrize("op", ["fast_sin", "fast_cos", "fast_log", "fast_log2"])
+def test_fpsan_distinguishes_approximate_libdevice(op, fresh_knobs):
+    if not is_cuda() or not torch.cuda.is_available():
+        pytest.skip("test requires CUDA")
+
+    fresh_knobs.compilation.instrumentation_mode = "fpsan"
+    n_elements = 1024
+    block_size = 256
+    generator = torch.Generator(device="cuda")
+    generator.manual_seed(0)
+    x = _random_payloads(generator, n_elements)
+    builtin = torch.empty_like(x)
+    external = torch.empty_like(x)
+
+    builtin_libdevice_unary_kernel[(triton.cdiv(n_elements, block_size),)](
+        triton.TensorWrapper(x, dtype=torch.float32),
+        triton.TensorWrapper(builtin, dtype=torch.float32),
+        triton.TensorWrapper(external, dtype=torch.float32),
+        n_elements,
+        OP=op,
+        BLOCK_SIZE=block_size,
+    )
+
+    assert not torch.equal(builtin, external)

--- a/test/TritonGPU/fpsan.mlir
+++ b/test/TritonGPU/fpsan.mlir
@@ -404,8 +404,8 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, "ttg.thr
 
 // -----
 
-// CHECK-LABEL: @extern_unary
-tt.func public @extern_unary(%a: tensor<4xf32>) -> tensor<4xf32> {
+// CHECK-LABEL: @extern_unary_fallback
+tt.func public @extern_unary_fallback(%a: tensor<4xf32>) -> tensor<4xf32> {
   // CHECK: tti.experimental_fpsan_embed
   // CHECK: arith.xori
   // CHECK-NOT: tt.extern_elementwise
@@ -415,8 +415,21 @@ tt.func public @extern_unary(%a: tensor<4xf32>) -> tensor<4xf32> {
 
 // -----
 
-// CHECK-LABEL: @extern_binary
-tt.func public @extern_binary(%a: tensor<4xf32>, %b: tensor<4xf32>) -> tensor<4xf32> {
+// CHECK-LABEL: @extern_unary_known
+tt.func public @extern_unary_known(%a: tensor<4xf32>) -> tensor<4xf32> {
+  // CHECK: tti.experimental_fpsan_embed
+  // CHECK: arith.muli
+  // CHECK: arith.xori
+  // CHECK: arith.muli
+  // CHECK-NOT: tt.extern_elementwise
+  %0 = tt.extern_elementwise %a {libname = "", libpath = "", pure = true, symbol = "__nv_logf"} : (tensor<4xf32>) -> tensor<4xf32>
+  tt.return %0 : tensor<4xf32>
+}
+
+// -----
+
+// CHECK-LABEL: @extern_binary_fallback
+tt.func public @extern_binary_fallback(%a: tensor<4xf32>, %b: tensor<4xf32>) -> tensor<4xf32> {
   // CHECK: tti.experimental_fpsan_embed
   // CHECK: arith.addi
   // CHECK: arith.xori
@@ -427,13 +440,41 @@ tt.func public @extern_binary(%a: tensor<4xf32>, %b: tensor<4xf32>) -> tensor<4x
 
 // -----
 
-// CHECK-LABEL: @extern_ternary
-tt.func public @extern_ternary(%a: tensor<4xf32>, %b: tensor<4xf32>, %c: tensor<4xf32>) -> tensor<4xf32> {
+// CHECK-LABEL: @extern_binary_known
+tt.func public @extern_binary_known(%a: tensor<4xf32>, %b: tensor<4xf32>) -> tensor<4xf32> {
+  // CHECK: tti.experimental_fpsan_embed
+  // CHECK-NOT: arith.xori
+  // CHECK: tti.experimental_fpsan_unembed
+  // CHECK-NOT: tt.extern_elementwise
+  %0 = tt.extern_elementwise %a, %b {libname = "", libpath = "", pure = true, symbol = "__nv_fdiv_rn"} : (tensor<4xf32>, tensor<4xf32>) -> tensor<4xf32>
+  tt.return %0 : tensor<4xf32>
+}
+
+// -----
+
+// CHECK-LABEL: @extern_ternary_known
+tt.func public @extern_ternary_known(%a: tensor<4xf32>, %b: tensor<4xf32>, %c: tensor<4xf32>) -> tensor<4xf32> {
+  // CHECK: %[[A:.*]] = tti.experimental_fpsan_embed
+  // CHECK: %[[B:.*]] = tti.experimental_fpsan_embed
+  // CHECK: %[[C:.*]] = tti.experimental_fpsan_embed
+  // CHECK: %[[MUL:.*]] = arith.muli %[[A]], %[[B]]
+  // CHECK: %[[SUM:.*]] = arith.addi %[[MUL]], %[[C]]
+  // CHECK: tti.experimental_fpsan_unembed %[[SUM]]
+  // CHECK-NOT: arith.xori
+  // CHECK-NOT: tt.extern_elementwise
+  %0 = tt.extern_elementwise %a, %b, %c {libname = "", libpath = "", pure = true, symbol = "__nv_fmaf"} : (tensor<4xf32>, tensor<4xf32>, tensor<4xf32>) -> tensor<4xf32>
+  tt.return %0 : tensor<4xf32>
+}
+
+// -----
+
+// CHECK-LABEL: @extern_ternary_fallback
+tt.func public @extern_ternary_fallback(%a: tensor<4xf32>, %b: tensor<4xf32>, %c: tensor<4xf32>) -> tensor<4xf32> {
   // CHECK: tti.experimental_fpsan_embed
   // CHECK: arith.addi
   // CHECK: arith.xori
   // CHECK-NOT: tt.extern_elementwise
-  %0 = tt.extern_elementwise %a, %b, %c {libname = "", libpath = "", pure = true, symbol = "__nv_fmaf"} : (tensor<4xf32>, tensor<4xf32>, tensor<4xf32>) -> tensor<4xf32>
+  %0 = tt.extern_elementwise %a, %b, %c {libname = "", libpath = "", pure = true, symbol = "__nv_norm3df"} : (tensor<4xf32>, tensor<4xf32>, tensor<4xf32>) -> tensor<4xf32>
   tt.return %0 : tensor<4xf32>
 }
 


### PR DESCRIPTION
## Summary

This PR recognizes selected FP32 CUDA libdevice calls as semantic aliases of their Triton language operations under FPSan. Calls in each row below now produce the same FPSan payload:

| Triton operation | CUDA libdevice call | CUDA symbol |
| --- | --- | --- |
| `tl.exp` | `libdevice.fast_expf` | `__nv_fast_expf` |
| `tl.exp2` | `libdevice.exp2` | `__nv_exp2f` |
| `tl.log` | `libdevice.log` | `__nv_logf` |
| `tl.log2` | `libdevice.log2` | `__nv_log2f` |
| `tl.sin` | `libdevice.sin` | `__nv_sinf` |
| `tl.cos` | `libdevice.cos` | `__nv_cosf` |
| `tl.rsqrt` | `libdevice.rsqrt` | `__nv_rsqrtf` |
| `tl.erf` | `libdevice.erf` | `__nv_erff` |
| `tl.floor` | `libdevice.floor` | `__nv_floorf` |
| `tl.ceil` | `libdevice.ceil` | `__nv_ceilf` |
| `tl.sqrt_rn` | `libdevice.sqrt_rn` | `__nv_fsqrt_rn` |
| `tl.div_rn` | `libdevice.div_rn` | `__nv_fdiv_rn` |
| `tl.fma` | `libdevice.fma` | `__nv_fmaf` |

FPSan models the intended floating-point computation rather than backend details such as flush-to-zero behavior. These aliases may therefore share an FPSan payload even when their native results differ for subnormal inputs or outputs.

Known symbols map directly to their FPSan transforms through shared unary, binary, and ternary adapters. Unrecognized externs continue to use the existing variadic fallback, which combines all operand payloads with a stable hash of the external symbol.

## Deliberately distinct operations

The following approximate CUDA functions are **not** considered equivalent to their corresponding `tl.*` operations and continue to use symbol-derived fallback tagging:

- `libdevice.fast_sinf` versus `tl.sin`
- `libdevice.fast_cosf` versus `tl.cos`
- `libdevice.fast_logf` versus `tl.log`
- `libdevice.fast_log2f` versus `tl.log2`

`libdevice.fast_expf` is the exception: this PR intentionally treats it as the FPSan semantic equivalent of `tl.exp`.

## Scope

This PR is limited to the FP32 CUDA symbols listed above. CUDA libdevice exposes many additional operations that are not classified here; they retain the default external-symbol payload. FP64 symbols, alternative rounding-mode variants, and non-CUDA libraries such as AMD OCML are also out of scope.

## Testing

- `python/test/unit/cuda/test_libdevice_cuda.py` checks FPSan payload equality for every recognized `tl.*`/libdevice pair above and checks that the four approximate fast operations remain distinct.
- `test/TritonGPU/fpsan.mlir` checks both recognized dispatch and the default unknown-symbol fallback for unary, binary, and ternary externs, plus the mixed-type fallback.
- `python/test/gluon/test_fpsan.py` checks the semantic FMA payload for `__nv_fmaf` while retaining generic variadic-tag expectations for unrecognized externs.

# New contributor declaration

- [x] I am not making a trivial change, such as fixing a typo in a comment.
- [x] I have written a PR description following these rules.
- [x] I have run `pre-commit run --from-ref origin/main --to-ref HEAD`.
- [x] I have added tests under `/python/test` and updated `/test/TritonGPU/fpsan.mlir`.
- [x] The `lit` test update follows the FileCheck best practices, including keeping the check minimal.
