### PR TITLE
[FPSAN] Fix FPSan sliced scratch layout expansion

### DIFF
--- a/include/triton/Dialect/TritonInstrument/IR/Utility.h
+++ b/include/triton/Dialect/TritonInstrument/IR/Utility.h
@@ -74,7 +74,10 @@ gpu::GlobalScratchAllocOp
 createThirdPartyScratchAlloc(OpBuilder &b, Location loc, Type ptrType,
                              int64_t sizeInBytes, int64_t alignment,
                              bool sharedClusterState = false);
-Value expandOuterSlicedDim(OpBuilder &b, Location loc, Value tensor);
+RankedTensorType getSlicedTensorType(RankedTensorType tensorType,
+                                     ArrayRef<int> keptDims, Type elementType);
+Value reshapeAndBroadcast(OpBuilder &b, Location loc, Value tensor,
+                          ArrayRef<int> keptDims, RankedTensorType dstType);
 RankedTensorType getIntTensorType(Region *region, ArrayRef<int64_t> shape,
                                   unsigned bitWidth);
 TypedValue<RankedTensorType> createConstIntTensor(OpBuilder &builder,
@@ -83,8 +86,6 @@ TypedValue<RankedTensorType> createConstIntTensor(OpBuilder &builder,
                                                   bool isSigned = false);
 uint32_t getMemDescLength(Value buf);
 FuncOp getEntryPoint(ModuleOp module);
-gpu::DistributedEncodingTrait
-getSingleDimSliceEncoding(gpu::DistributedEncodingTrait encoding, int dim);
 
 inline Value maybeAnd(ImplicitLocOpBuilder &b, Value lhs, Value rhs) {
   if (!lhs)

--- a/lib/Dialect/TritonInstrument/IR/FunctionBuilder.cpp
+++ b/lib/Dialect/TritonInstrument/IR/FunctionBuilder.cpp
@@ -268,27 +268,16 @@ Value createConvertLayout(ImplicitLocOpBuilder &b, Value tensor,
 
 Value convertAndBroadcast(ImplicitLocOpBuilder &b, Value tensor,
                           ArrayRef<int> keptDims, RankedTensorType dstType) {
-  auto loc = b.getLoc();
   auto tensorType = cast<RankedTensorType>(tensor.getType());
-  auto encoding = cast<ttg::DistributedEncodingTrait>(dstType.getEncoding());
   assert(static_cast<size_t>(tensorType.getRank()) == keptDims.size() &&
          "expected one kept dimension per source tensor rank");
-  llvm::SmallDenseSet<int> keptDimsSet(keptDims.begin(), keptDims.end());
-  Attribute sliceEncoding = encoding;
-  for (int dim = encoding.getRepOrder().size() - 1; dim >= 0; --dim) {
-    if (!keptDimsSet.contains(dim))
-      sliceEncoding = ttg::SliceEncodingAttr::get(
-          b.getContext(), dim,
-          cast<ttg::DistributedEncodingTrait>(sliceEncoding));
-  }
-  tensor = createConvertLayout(b, tensor, sliceEncoding);
-  while (cast<RankedTensorType>(tensor.getType()).getRank() < dstType.getRank())
-    tensor = tti::expandOuterSlicedDim(b, loc, tensor);
   auto resultType = RankedTensorType::get(
-      dstType.getShape(), tensorType.getElementType(), encoding);
-  if (cast<RankedTensorType>(tensor.getType()) == resultType)
-    return tensor;
-  return triton::BroadcastOp::create(b, resultType, tensor);
+      dstType.getShape(), tensorType.getElementType(), dstType.getEncoding());
+  auto sliceType = tti::getSlicedTensorType(resultType, keptDims,
+                                            tensorType.getElementType());
+  if (tensorType != sliceType)
+    tensor = ttg::ConvertLayoutOp::create(b, sliceType, tensor);
+  return tti::reshapeAndBroadcast(b, b.getLoc(), tensor, keptDims, resultType);
 }
 
 Value expandAliases(ImplicitLocOpBuilder &b, Value bufferMask,
@@ -316,17 +305,14 @@ Value adjustIntegerWidth(ImplicitLocOpBuilder &b, Value value,
 Value createThreadColumnMask(ImplicitLocOpBuilder &b, Value threadMask,
                              RankedTensorType tensorType, int columnDim) {
   auto loc = b.getLoc();
-  auto encoding = cast<ttg::DistributedEncodingTrait>(tensorType.getEncoding());
-  auto sliceEncoding = tti::getSingleDimSliceEncoding(encoding, columnDim);
   int columns = tensorType.getShape()[columnDim];
 
   RankedTensorType rangeType =
-      RankedTensorType::get({columns}, b.getI32Type(), sliceEncoding);
+      tti::getSlicedTensorType(tensorType, {columnDim}, b.getI32Type());
   Value range = triton::MakeRangeOp::create(b, rangeType, 0, columns);
 
   auto elemType = cast<IntegerType>(tensorType.getElementType());
-  RankedTensorType rangeElemType =
-      RankedTensorType::get({columns}, elemType, sliceEncoding);
+  RankedTensorType rangeElemType = rangeType.clone(elemType);
   Value rangeElem = range;
   if (elemType.getWidth() != 32)
     rangeElem = arith::ExtUIOp::create(b, rangeElemType, range);
@@ -346,10 +332,7 @@ Value createThreadColumnMask(ImplicitLocOpBuilder &b, Value threadMask,
 Value createDimMask(ImplicitLocOpBuilder &b, Value index,
                     RankedTensorType tensorType, int dim) {
   assert(dim >= 0 && dim < tensorType.getRank() && "invalid tensor dimension");
-  auto encoding = cast<ttg::DistributedEncodingTrait>(tensorType.getEncoding());
-  auto sliceEncoding = tti::getSingleDimSliceEncoding(encoding, dim);
-  auto indexType = RankedTensorType::get({tensorType.getShape()[dim]},
-                                         b.getI32Type(), sliceEncoding);
+  auto indexType = tti::getSlicedTensorType(tensorType, {dim}, b.getI32Type());
   Value range = triton::MakeRangeOp::create(b, indexType, /*start=*/0,
                                             /*end=*/tensorType.getShape()[dim]);
   Value indexTensor = triton::SplatOp::create(b, indexType, index);
@@ -363,10 +346,7 @@ Value createDimMask(ImplicitLocOpBuilder &b, Value index,
 Value createDimIndices(ImplicitLocOpBuilder &b, RankedTensorType tensorType,
                        int dim) {
   assert(dim >= 0 && dim < tensorType.getRank() && "invalid tensor dimension");
-  auto encoding = cast<ttg::DistributedEncodingTrait>(tensorType.getEncoding());
-  auto sliceEncoding = tti::getSingleDimSliceEncoding(encoding, dim);
-  auto indexType = RankedTensorType::get({tensorType.getShape()[dim]},
-                                         b.getI32Type(), sliceEncoding);
+  auto indexType = tti::getSlicedTensorType(tensorType, {dim}, b.getI32Type());
   Value range = triton::MakeRangeOp::create(b, indexType, /*start=*/0,
                                             /*end=*/tensorType.getShape()[dim]);
   auto fullIndexType = cast<RankedTensorType>(
@@ -388,10 +368,7 @@ Value createCTASetMask(ImplicitLocOpBuilder &b, RankedTensorType tensorType,
   // build a [0, numCTAs) row-index vector on `dim`, broadcast it to the state
   // tensor shape, and test one bit of `recipientCTAs` per row.
   auto loc = b.getLoc();
-  auto encoding = cast<ttg::DistributedEncodingTrait>(tensorType.getEncoding());
-  auto rowSliceEncoding = tti::getSingleDimSliceEncoding(encoding, dim);
-  auto rowType =
-      RankedTensorType::get({numCTAs}, b.getI32Type(), rowSliceEncoding);
+  auto rowType = tti::getSlicedTensorType(tensorType, {dim}, b.getI32Type());
   Value rowIdx = triton::MakeRangeOp::create(b, rowType, /*start=*/0,
                                              /*end=*/numCTAs);
   auto indexType = cast<RankedTensorType>(

--- a/lib/Dialect/TritonInstrument/IR/Utility.cpp
+++ b/lib/Dialect/TritonInstrument/IR/Utility.cpp
@@ -306,43 +306,75 @@ TypedValue<RankedTensorType> createConstIntTensor(OpBuilder &builder,
           .getResult());
 }
 
-DistributedEncodingTrait
-getSingleDimSliceEncoding(DistributedEncodingTrait encoding, int dim) {
-  int rank = encoding.getRepOrder().size();
+static DistributedEncodingTrait
+getSliceEncoding(DistributedEncodingTrait encoding, int rank,
+                 ArrayRef<int> keptDims) {
   MLIRContext *ctx = encoding.getContext();
-  assert(dim < rank && "Expected dim to be less than rank");
+  assert(llvm::is_sorted(keptDims) &&
+         "expected kept dimensions to preserve source dimension order");
+  llvm::SmallDenseSet<int> keptDimsSet(keptDims.begin(), keptDims.end());
+  assert(keptDimsSet.size() == keptDims.size() &&
+         "expected unique kept dimensions");
+  for (int dim : keptDims) {
+    assert(dim >= 0 && dim < rank &&
+           "expected kept dimension in destination rank");
+  }
   DistributedEncodingTrait sliceEncoding = encoding;
   for (int i = rank - 1; i >= 0; --i) {
-    if (i != dim) {
+    if (!keptDimsSet.contains(i)) {
       sliceEncoding = SliceEncodingAttr::get(ctx, i, sliceEncoding);
     }
   }
   return sliceEncoding;
 }
 
-Value expandOuterSlicedDim(OpBuilder &b, Location loc, Value tensor) {
-  auto type = cast<RankedTensorType>(tensor.getType());
-  auto sliceEncoding = dyn_cast<SliceEncodingAttr>(type.getEncoding());
-  if (sliceEncoding) {
-    int dim = sliceEncoding.getDim();
-    auto shape = type.getShape();
-    auto newShape = SmallVector<int64_t>(shape);
-    newShape.insert(newShape.begin() + dim, 1);
-    auto newType = RankedTensorType::get(newShape, type.getElementType(),
-                                         sliceEncoding.getParent());
-    tensor = ExpandDimsOp::create(b, loc, newType, tensor, dim);
+RankedTensorType getSlicedTensorType(RankedTensorType tensorType,
+                                     ArrayRef<int> keptDims, Type elementType) {
+  auto encoding = cast<DistributedEncodingTrait>(tensorType.getEncoding());
+  auto sliceEncoding =
+      getSliceEncoding(encoding, tensorType.getRank(), keptDims);
+  SmallVector<int64_t> shape;
+  shape.reserve(keptDims.size());
+  for (int dim : keptDims) {
+    assert(dim >= 0 && dim < tensorType.getRank() &&
+           "expected kept dimension in tensor rank");
+    shape.push_back(tensorType.getShape()[dim]);
   }
-  return tensor;
+  return RankedTensorType::get(shape, elementType, sliceEncoding);
 }
 
-static Value expandAllSlicedDims(OpBuilder &b, Location loc, Value tensor) {
-  auto type = cast<RankedTensorType>(tensor.getType());
-  auto sliceEncoding = dyn_cast<SliceEncodingAttr>(type.getEncoding());
-  while (sliceEncoding) {
-    tensor = expandOuterSlicedDim(b, loc, tensor);
-    type = cast<RankedTensorType>(tensor.getType());
-    sliceEncoding = dyn_cast<SliceEncodingAttr>(type.getEncoding());
+Value reshapeAndBroadcast(OpBuilder &b, Location loc, Value tensor,
+                          ArrayRef<int> keptDims, RankedTensorType dstType) {
+  auto tensorType = cast<RankedTensorType>(tensor.getType());
+  assert(static_cast<size_t>(tensorType.getRank()) == keptDims.size() &&
+         "expected one kept dimension per source tensor rank");
+  assert(llvm::is_sorted(keptDims) &&
+         "expected kept dimensions to preserve source dimension order");
+
+  SmallVector<int64_t> reshapeShape(dstType.getRank(), 1);
+  for (auto [srcDim, dstDim] : llvm::enumerate(keptDims)) {
+    assert(dstDim >= 0 && dstDim < dstType.getRank() &&
+           "expected kept dimension in destination rank");
+    assert(!llvm::is_contained(keptDims.take_front(srcDim), dstDim) &&
+           "expected unique kept dimensions");
+    assert(tensorType.getShape()[srcDim] == dstType.getShape()[dstDim] &&
+           "expected kept dimension to preserve size");
+    reshapeShape[dstDim] = tensorType.getShape()[srcDim];
   }
+
+  if (!llvm::equal(tensorType.getShape(), reshapeShape))
+    tensor = ReshapeOp::create(b, loc, reshapeShape, tensor);
+
+  tensorType = cast<RankedTensorType>(tensor.getType());
+  auto broadcastSrcType = RankedTensorType::get(
+      reshapeShape, tensorType.getElementType(), dstType.getEncoding());
+  if (tensor.getType() != broadcastSrcType) {
+    assert(cvtReordersRegisters(tensorType, broadcastSrcType) &&
+           "expected reshaped layout conversion to reorder registers only");
+    tensor = ConvertLayoutOp::create(b, loc, broadcastSrcType, tensor);
+  }
+  if (tensor.getType() != dstType)
+    tensor = BroadcastOp::create(b, loc, dstType, tensor);
   return tensor;
 }
 
@@ -361,19 +393,14 @@ static Value createPointerTensor(OpBuilder &b, Location loc, Value base,
     strides[i] = strides[i - 1] * tensorType.getShape()[i - 1];
   }
   for (int i = 0; i < tensorType.getRank(); ++i) {
-    auto partialEncoding = getSingleDimSliceEncoding(encoding, i);
-    auto arangeType = RankedTensorType::get({tensorType.getShape()[i]},
-                                            b.getI32Type(), partialEncoding);
+    auto arangeType = getSlicedTensorType(tensorType, {i}, b.getI32Type());
     auto arange =
         MakeRangeOp::create(b, loc, arangeType, 0, arangeType.getShape()[0]);
     auto cstStride = createConstIntTensor(b, loc, strides[i], arangeType);
     auto arangeTimesStride =
         arith::MulIOp::create(b, loc, arangeType, arange, cstStride);
-    auto expandDims = expandAllSlicedDims(b, loc, arangeTimesStride);
-    if (cast<RankedTensorType>(expandDims.getType()).getShape() !=
-        tensorType.getShape()) {
-      expandDims = BroadcastOp::create(b, loc, offsetsType, expandDims);
-    }
+    auto expandDims =
+        reshapeAndBroadcast(b, loc, arangeTimesStride, {i}, offsetsType);
     ptrTensor =
         AddPtrOp::create(b, loc, ptrTensor.getType(), ptrTensor, expandDims);
   }
@@ -384,9 +411,7 @@ static Value createCurrentCTAMask(OpBuilder &b, Location loc,
                                   RankedTensorType tensorType) {
   assert(tensorType.getRank() > 0 && "expected ranked tensor");
   auto encoding = cast<DistributedEncodingTrait>(tensorType.getEncoding());
-  auto sliceEncoding = getSingleDimSliceEncoding(encoding, /*dim=*/0);
-  auto indexType = RankedTensorType::get({tensorType.getShape()[0]},
-                                         b.getI32Type(), sliceEncoding);
+  auto indexType = getSlicedTensorType(tensorType, {0}, b.getI32Type());
   Value range = MakeRangeOp::create(b, loc, indexType, /*start=*/0,
                                     tensorType.getShape()[0]);
   Value ctaId = ExperimentalClusterCTAIdOp::create(b, loc);
@@ -395,11 +420,7 @@ static Value createCurrentCTAMask(OpBuilder &b, Location loc,
                                        ctaIdTensor);
   auto maskType =
       RankedTensorType::get(tensorType.getShape(), b.getI1Type(), encoding);
-  Value mask = expandAllSlicedDims(b, loc, mask1D);
-  if (cast<RankedTensorType>(mask.getType()).getShape() !=
-      tensorType.getShape())
-    mask = BroadcastOp::create(b, loc, maskType, mask);
-  return mask;
+  return reshapeAndBroadcast(b, loc, mask1D, {0}, maskType);
 }
 
 Operation *createStoreScratchMemory(OpBuilder &b, Location loc, Value alloc,

--- a/lib/Dialect/TritonInstrument/Transforms/FpSanitizer.cpp
+++ b/lib/Dialect/TritonInstrument/Transforms/FpSanitizer.cpp
@@ -953,18 +953,6 @@ Value createAsyncToken(PatternRewriter &rewriter, Location loc,
   return ttg::AsyncCommitGroupOp::create(rewriter, loc, deps).getResult();
 }
 
-Value expandAllSlicedDims(PatternRewriter &rewriter, Location loc,
-                          Value tensor) {
-  auto type = cast<RankedTensorType>(tensor.getType());
-  auto sliceEncoding = dyn_cast<ttg::SliceEncodingAttr>(type.getEncoding());
-  while (sliceEncoding) {
-    tensor = expandOuterSlicedDim(rewriter, loc, tensor);
-    type = cast<RankedTensorType>(tensor.getType());
-    sliceEncoding = dyn_cast<ttg::SliceEncodingAttr>(type.getEncoding());
-  }
-  return tensor;
-}
-
 Value createPointerTensorStrided2D(PatternRewriter &rewriter, Location loc,
                                    Value base, RankedTensorType resultTy,
                                    int64_t stride0, int64_t stride1) {
@@ -976,29 +964,21 @@ Value createPointerTensorStrided2D(PatternRewriter &rewriter, Location loc,
   auto i32Ty = rewriter.getI32Type();
   auto offsetsTy = RankedTensorType::get(shape, i32Ty, encoding);
 
-  auto dim0Enc = getSingleDimSliceEncoding(encoding, 0);
-  auto dim0Ty = RankedTensorType::get({shape[0]}, i32Ty, dim0Enc);
+  auto dim0Ty = getSlicedTensorType(offsetsTy, {0}, i32Ty);
   auto range0 = tt::MakeRangeOp::create(rewriter, loc, dim0Ty, 0, shape[0]);
   auto stride0Const = createConstIntTensor(rewriter, loc, stride0, dim0Ty);
   auto off0 =
       arith::MulIOp::create(rewriter, loc, dim0Ty, range0, stride0Const);
-  auto off0Exp = expandAllSlicedDims(rewriter, loc, off0);
-  if (cast<RankedTensorType>(off0Exp.getType()).getShape() != shape) {
-    off0Exp = tt::BroadcastOp::create(rewriter, loc, offsetsTy, off0Exp);
-  }
+  auto off0Exp = reshapeAndBroadcast(rewriter, loc, off0, {0}, offsetsTy);
   ptrTensor =
       tt::AddPtrOp::create(rewriter, loc, ptrTensorTy, ptrTensor, off0Exp);
 
-  auto dim1Enc = getSingleDimSliceEncoding(encoding, 1);
-  auto dim1Ty = RankedTensorType::get({shape[1]}, i32Ty, dim1Enc);
+  auto dim1Ty = getSlicedTensorType(offsetsTy, {1}, i32Ty);
   auto range1 = tt::MakeRangeOp::create(rewriter, loc, dim1Ty, 0, shape[1]);
   auto stride1Const = createConstIntTensor(rewriter, loc, stride1, dim1Ty);
   auto off1 =
       arith::MulIOp::create(rewriter, loc, dim1Ty, range1, stride1Const);
-  auto off1Exp = expandAllSlicedDims(rewriter, loc, off1);
-  if (cast<RankedTensorType>(off1Exp.getType()).getShape() != shape) {
-    off1Exp = tt::BroadcastOp::create(rewriter, loc, offsetsTy, off1Exp);
-  }
+  auto off1Exp = reshapeAndBroadcast(rewriter, loc, off1, {1}, offsetsTy);
   ptrTensor =
       tt::AddPtrOp::create(rewriter, loc, ptrTensorTy, ptrTensor, off1Exp);
 

--- a/lib/Dialect/TritonInstrument/Transforms/GlobalSanitizer.cpp
+++ b/lib/Dialect/TritonInstrument/Transforms/GlobalSanitizer.cpp
@@ -103,18 +103,6 @@ getInstrumentationEncoding(OpBuilder &builder, ArrayRef<int64_t> shape,
                                        order, base.getCGALayout());
 }
 
-static Value expandAllSlicedDims(OpBuilder &builder, Location loc,
-                                 Value tensor) {
-  auto type = cast<RankedTensorType>(tensor.getType());
-  auto sliceEncoding = dyn_cast<ttg::SliceEncodingAttr>(type.getEncoding());
-  while (sliceEncoding) {
-    tensor = expandOuterSlicedDim(builder, loc, tensor);
-    type = cast<RankedTensorType>(tensor.getType());
-    sliceEncoding = dyn_cast<ttg::SliceEncodingAttr>(type.getEncoding());
-  }
-  return tensor;
-}
-
 static DescriptorInfo getDescriptorInfo(Value desc, OpBuilder &builder) {
   if (!isa<tt::TensorDescType>(desc.getType())) {
     std::string msg;
@@ -147,15 +135,12 @@ static DescriptorInfo getDescriptorInfo(Value desc, OpBuilder &builder) {
 static Value createExpandedOffsetRange(OpBuilder &builder, Location loc,
                                        RankedTensorType fullI64Type,
                                        Value offset, unsigned dim) {
-  auto fullEncoding =
-      cast<ttg::DistributedEncodingTrait>(fullI64Type.getEncoding());
-  auto sliceEncoding = getSingleDimSliceEncoding(fullEncoding, dim);
   int64_t dimSize = fullI64Type.getShape()[dim];
 
-  auto sliceI32Type =
-      RankedTensorType::get({dimSize}, builder.getI32Type(), sliceEncoding);
-  auto sliceI64Type =
-      RankedTensorType::get({dimSize}, builder.getI64Type(), sliceEncoding);
+  auto sliceI32Type = getSlicedTensorType(fullI64Type, {static_cast<int>(dim)},
+                                          builder.getI32Type());
+  auto sliceI64Type = getSlicedTensorType(fullI64Type, {static_cast<int>(dim)},
+                                          builder.getI64Type());
 
   Value range = tt::MakeRangeOp::create(builder, loc, sliceI32Type, 0, dimSize);
   Value rangeI64 = arith::ExtSIOp::create(builder, loc, sliceI64Type, range);
@@ -164,26 +149,17 @@ static Value createExpandedOffsetRange(OpBuilder &builder, Location loc,
       tt::SplatOp::create(builder, loc, sliceI64Type, offsetI64);
   Value result =
       arith::AddIOp::create(builder, loc, sliceI64Type, offsetSplat, rangeI64);
-  result = expandAllSlicedDims(builder, loc, result);
-  if (cast<RankedTensorType>(result.getType()).getShape() !=
-      fullI64Type.getShape()) {
-    result = tt::BroadcastOp::create(builder, loc, fullI64Type, result);
-  }
-  return result;
+  return reshapeAndBroadcast(builder, loc, result, {static_cast<int>(dim)},
+                             fullI64Type);
 }
 
 static Value convertAndBroadcast(OpBuilder &builder, Location loc, Value tensor,
                                  int dim, RankedTensorType dstType) {
   auto tensorType = cast<RankedTensorType>(tensor.getType());
-  auto encoding = cast<ttg::DistributedEncodingTrait>(dstType.getEncoding());
-  auto sliceEncoding = getSingleDimSliceEncoding(encoding, dim);
-  auto sliceType = RankedTensorType::get(
-      tensorType.getShape(), tensorType.getElementType(), sliceEncoding);
+  auto sliceType =
+      getSlicedTensorType(dstType, {dim}, tensorType.getElementType());
   tensor = ttg::ConvertLayoutOp::create(builder, loc, sliceType, tensor);
-  tensor = expandAllSlicedDims(builder, loc, tensor);
-  if (cast<RankedTensorType>(tensor.getType()).getShape() != dstType.getShape())
-    tensor = tt::BroadcastOp::create(builder, loc, dstType, tensor);
-  return tensor;
+  return reshapeAndBroadcast(builder, loc, tensor, {dim}, dstType);
 }
 
 static Value createMaskFromRanges(OpBuilder &builder, Location loc,

--- a/test/TritonGPU/fpsan.mlir
+++ b/test/TritonGPU/fpsan.mlir
@@ -13,7 +13,7 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, "ttg.thr
   tt.func public @dot_emulation() -> tensor<16x16xf32, #blocked> {
     // CHECK: scf.for
     // CHECK-NOT: tt.dot
-    // CHECK-NOT: ttg.convert_layout
+    // CHECK: ttg.convert_layout
     %cst = arith.constant 1.000000e+00 : f16
     %zero = arith.constant dense<0.000000e+00> : tensor<16x16xf32, #blocked>
     %a = tt.splat %cst : f16 -> tensor<16x16xf16, #dot_operand_a>
@@ -96,7 +96,7 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, "ttg.thr
     // CHECK: scf.for
     // CHECK: scf.for
     // CHECK-NOT: tt.dot
-    // CHECK-NOT: ttg.convert_layout
+    // CHECK: ttg.convert_layout
     %one = arith.constant 1.000000e+00 : f16
     %zero = arith.constant dense<0.000000e+00> : tensor<2x16x16xf32, #blocked>
     %a = tt.splat %one : f16 -> tensor<2x16x16xf16, #dot_operand_a>
@@ -119,7 +119,7 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, "ttg.thr
     // CHECK: ttg.barrier global_read|global_write
     // CHECK-NOT: ttg.dot_scaled
     // CHECK-NOT: tt.dot
-    // CHECK-NOT: ttg.convert_layout
+    // CHECK: ttg.convert_layout
      %cst = arith.constant 1.000000e+00 : f16
      %zero = arith.constant dense<0.000000e+00> : tensor<16x16xf32, #blocked>
      %a = tt.splat %cst : f16 -> tensor<16x16xf16, #dot_A>
@@ -202,6 +202,24 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, "ttg.thr
     ttng.tmem_store %arg0, %tmem, %true : tensor<128x64xf32, #tmem_linear> -> !ttg.memdesc<128x64xf32, #tmem, #ttng.tensor_memory, mutable>
     %out = ttng.tmem_load %tmem : !ttg.memdesc<128x64xf32, #tmem, #ttng.tensor_memory, mutable> -> tensor<128x64xf32, #tmem_linear>
     tt.return %out : tensor<128x64xf32, #tmem_linear>
+  }
+}
+
+// -----
+
+#tmem_split_parent = #ttg.linear<{register = [[0, 1, 0], [0, 2, 0], [0, 4, 0], [0, 8, 0], [0, 16, 0], [0, 32, 0], [0, 0, 1]], lane = [[1, 0, 0], [2, 0, 0], [4, 0, 0], [8, 0, 0], [16, 0, 0]], warp = [[32, 0, 0], [64, 0, 0]], block = []}>
+#tmem_split = #ttg.slice<{dim = 2, parent = #tmem_split_parent}>
+#tmem_f8 = #ttng.tensor_memory_encoding<blockM = 128, blockN = 64, colStride = 1>
+module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, "ttg.threads-per-warp" = 32 : i32} {
+  // CHECK-LABEL: @tmem_scratch_sliced_payloads
+  tt.func public @tmem_scratch_sliced_payloads(%arg0: tensor<128x64xf32, #tmem_split>) {
+    // CHECK: tt.store
+    // CHECK-NOT: ttng.tmem_store
+    %true = arith.constant true
+    %tmem = ttng.tmem_alloc : () -> !ttg.memdesc<128x64xf8E4M3FN, #tmem_f8, #ttng.tensor_memory, mutable>
+    %fp8 = tt.fp_to_fp %arg0, rounding = rtne : tensor<128x64xf32, #tmem_split> -> tensor<128x64xf8E4M3FN, #tmem_split>
+    ttng.tmem_store %fp8, %tmem, %true : tensor<128x64xf8E4M3FN, #tmem_split> -> !ttg.memdesc<128x64xf8E4M3FN, #tmem_f8, #ttng.tensor_memory, mutable>
+    tt.return
   }
 }
 


### PR DESCRIPTION
the previous logic was relying on layout encoding and was wrong if the original layout was already a sliced layout. 
Simplify the whole logic by using reshape + broadcast 