### PR TITLE
[AxisAnalysis] Use global divisibility in AxisAnalysis

### DIFF
--- a/include/triton/Analysis/AxisInfo.h
+++ b/include/triton/Analysis/AxisInfo.h
@@ -7,6 +7,7 @@
 #include "mlir/Support/LLVM.h"
 #include "triton/Analysis/Utility.h"
 
+#include <algorithm>
 #include <optional>
 
 namespace mlir::triton {
@@ -33,6 +34,9 @@ public:
         constancy(constancy), constantValue(constantValue) {
     assert(divisibility.size() == contiguity.size());
     assert(constancy.size() == contiguity.size());
+    int64_t globalDivisibility = getGlobalDivisibility();
+    for (int64_t &dimDivisibility : this->divisibility)
+      dimDivisibility = std::max(dimDivisibility, globalDivisibility);
   }
 
   // contiguity[d] is the length of the shortest sequence of contiguous integers
@@ -84,6 +88,16 @@ public:
   // has divisibility 1 because its contiguity is 1.
   int64_t getDivisibility(size_t dim) const { return divisibility[dim]; }
   const DimVectorT &getDivisibility() const { return divisibility; }
+
+  // Unit contiguity makes every element a group base, so divisibility from
+  // such a dimension applies globally.
+  int64_t getGlobalDivisibility() const {
+    int64_t globalDivisibility = 1;
+    for (int dim = 0; dim < getRank(); ++dim)
+      if (getContiguity(dim) == 1)
+        globalDivisibility = std::max(globalDivisibility, getDivisibility(dim));
+    return globalDivisibility;
+  }
 
   // constancy[d] is the length of the shortest sequence of repeating integers
   // along dimension d.

--- a/lib/Analysis/AxisInfo.cpp
+++ b/lib/Analysis/AxisInfo.cpp
@@ -705,12 +705,10 @@ public:
     auto dstSuffixProducts = getSuffixProducts(dstShape);
 
     // Unit contiguity makes every element a group base, so divisibility from
-    // such a dimension applies globally.
-    int64_t globalDivisibility = 1;
-    for (int dim = 0; dim < srcTy.getRank(); ++dim)
-      if (srcInfo.getContiguity(dim) == 1)
-        globalDivisibility =
-            std::max(globalDivisibility, srcInfo.getDivisibility(dim));
+    // such a dimension applies globally. AxisInfo normalization propagates
+    // this fact within one value, but reshape can lose the source axis that
+    // carries it, so seed every destination axis before refining it below.
+    int64_t globalDivisibility = srcInfo.getGlobalDivisibility();
 
     AxisInfo::DimVectorT contiguity(dstTy.getRank(), 1);
     AxisInfo::DimVectorT divisibility(dstTy.getRank(), globalDivisibility);

--- a/lib/Analysis/AxisInfo.cpp
+++ b/lib/Analysis/AxisInfo.cpp
@@ -704,8 +704,16 @@ public:
     auto srcSuffixProducts = getSuffixProducts(srcShape);
     auto dstSuffixProducts = getSuffixProducts(dstShape);
 
+    // Unit contiguity makes every element a group base, so divisibility from
+    // such a dimension applies globally.
+    int64_t globalDivisibility = 1;
+    for (int dim = 0; dim < srcTy.getRank(); ++dim)
+      if (srcInfo.getContiguity(dim) == 1)
+        globalDivisibility =
+            std::max(globalDivisibility, srcInfo.getDivisibility(dim));
+
     AxisInfo::DimVectorT contiguity(dstTy.getRank(), 1);
-    AxisInfo::DimVectorT divisibility(dstTy.getRank(), 1);
+    AxisInfo::DimVectorT divisibility(dstTy.getRank(), globalDivisibility);
     AxisInfo::DimVectorT constancy(dstTy.getRank(), 1);
 
     for (int dstDim = 0; dstDim < dstTy.getRank(); ++dstDim) {
@@ -747,9 +755,11 @@ public:
           // unchanged. When the run is truncated, later group bases can start
           // inside the original run, so divisibility must be clamped
           // accordingly.
-          divisibility[dstDim] = dstContiguity == srcContiguity
-                                     ? srcDivisibility
-                                     : std::min(srcDivisibility, dstContiguity);
+          int64_t dstDivisibility =
+              dstContiguity == srcContiguity
+                  ? srcDivisibility
+                  : std::min(srcDivisibility, dstContiguity);
+          divisibility[dstDim] = std::max(globalDivisibility, dstDivisibility);
         }
         continue;
       }
@@ -777,9 +787,6 @@ public:
         }
         constancy[dstDim] = dstConstancy;
       }
-      // Divisibility stays the same when the constant block is split
-      // even for constancy == 1.
-      divisibility[dstDim] = srcDivisibility;
     }
 
     return AxisInfo(contiguity, divisibility, constancy,

--- a/test/Analysis/test-alignment.mlir
+++ b/test/Analysis/test-alignment.mlir
@@ -341,7 +341,8 @@ tt.func @reshape_global_divisibility(
     %arg0: tensor<2x2xi32> {tt.contiguity = dense<[1, 1]> : tensor<2xi32>, tt.divisibility = dense<[8, 2]> : tensor<2xi32>, tt.constancy = dense<[1, 1]> : tensor<2xi32>},
     %arg1: tensor<2x2xi32> {tt.contiguity = dense<[1, 1]> : tensor<2xi32>, tt.divisibility = dense<[2, 8]> : tensor<2xi32>, tt.constancy = dense<[1, 1]> : tensor<2xi32>},
     %arg2: tensor<2x1x2xi32> {tt.contiguity = dense<[1, 1, 1]> : tensor<3xi32>, tt.divisibility = dense<[2, 32, 4]> : tensor<3xi32>, tt.constancy = dense<[1, 1, 1]> : tensor<3xi32>},
-    %arg3: tensor<4x4xi32> {tt.contiguity = dense<[1, 1]> : tensor<2xi32>, tt.divisibility = dense<[8, 2]> : tensor<2xi32>, tt.constancy = dense<[2, 4]> : tensor<2xi32>}) {
+    %arg3: tensor<4x4xi32> {tt.contiguity = dense<[1, 1]> : tensor<2xi32>, tt.divisibility = dense<[8, 2]> : tensor<2xi32>, tt.constancy = dense<[2, 4]> : tensor<2xi32>},
+    %arg4: tensor<2x2x!tt.ptr<i32>> {tt.contiguity = dense<[1, 2]> : tensor<2xi32>, tt.divisibility = dense<[4, 8]> : tensor<2xi32>, tt.constancy = dense<[1, 1]> : tensor<2xi32>}) {
   // Divisibility from a unit-contiguity source axis applies to every output
   // axis, including axes whose flat-index bits do not overlap the source axis.
   // expected-remark @below {{contiguity = [1, 1, 1], divisibility = [8, 8, 8], constancy = [1, 1, 1], constant_value = <none>}}
@@ -354,6 +355,38 @@ tt.func @reshape_global_divisibility(
   // Global divisibility is independent of merging constant source factors.
   // expected-remark @below {{contiguity = [1], divisibility = [8], constancy = [8], constant_value = <none>}}
   %3 = tt.reshape %arg3 : tensor<4x4xi32> -> tensor<16xi32>
+  // Pointer contiguity is measured in elements while divisibility is measured
+  // in bytes, so global divisibility can coexist with contiguity greater than
+  // one. Reshape must preserve the global divisor even when splitting that
+  // contiguous axis.
+  // expected-remark @below {{contiguity = [2, 1], divisibility = [8, 4], constancy = [1, 1], constant_value = <none>}}
+  %4 = tt.reshape %arg4 : tensor<2x2x!tt.ptr<i32>> -> tensor<4x1x!tt.ptr<i32>>
+  tt.return
+}
+
+// -----
+
+tt.func @global_divisibility_is_axis_independent(
+    %arg0: tensor<2x2xi32> {tt.contiguity = dense<[1, 1]> : tensor<2xi32>, tt.divisibility = dense<[8, 2]> : tensor<2xi32>, tt.constancy = dense<[1, 1]> : tensor<2xi32>},
+    %arg1: tensor<2x2xi32> {tt.contiguity = dense<[1, 1]> : tensor<2xi32>, tt.divisibility = dense<[2, 8]> : tensor<2xi32>, tt.constancy = dense<[1, 1]> : tensor<2xi32>},
+    %cond: i1) {
+  // Unit contiguity makes every element a group base, so the strongest such
+  // divisibility applies to every axis through shape and arithmetic ops.
+  // expected-remark @below {{contiguity = [1, 1, 1], divisibility = [8, 8, 8], constancy = [1, 1, 1], constant_value = <none>}}
+  %0 = tt.expand_dims %arg0 {axis = 0 : i32} : tensor<2x2xi32> -> tensor<1x2x2xi32>
+  // expected-remark @below {{contiguity = [1, 1], divisibility = [8, 8], constancy = [1, 1], constant_value = <none>}}
+  %1 = tt.trans %arg0 {order = array<i32: 1, 0>} : tensor<2x2xi32> -> tensor<2x2xi32>
+  // expected-remark @below {{contiguity = [1, 1, 1], divisibility = [8, 8, 8], constancy = [4, 1, 1], constant_value = <none>}}
+  %2 = tt.broadcast %0 : tensor<1x2x2xi32> -> tensor<4x2x2xi32>
+  %zero = arith.constant dense<0> : tensor<2x2xi32>
+  // expected-remark @below {{contiguity = [1, 1], divisibility = [8, 8], constancy = [1, 1], constant_value = <none>}}
+  %3 = arith.addi %arg0, %zero : tensor<2x2xi32>
+  // expected-remark @below {{contiguity = [1, 1], divisibility = [8, 8], constancy = [1, 1], constant_value = <none>}}
+  %4 = scf.if %cond -> tensor<2x2xi32> {
+    scf.yield %arg0 : tensor<2x2xi32>
+  } else {
+    scf.yield %arg1 : tensor<2x2xi32>
+  }
   tt.return
 }
 

--- a/test/Analysis/test-alignment.mlir
+++ b/test/Analysis/test-alignment.mlir
@@ -337,6 +337,28 @@ tt.func @reshape_refined_piece_merge(
 
 // -----
 
+tt.func @reshape_global_divisibility(
+    %arg0: tensor<2x2xi32> {tt.contiguity = dense<[1, 1]> : tensor<2xi32>, tt.divisibility = dense<[8, 2]> : tensor<2xi32>, tt.constancy = dense<[1, 1]> : tensor<2xi32>},
+    %arg1: tensor<2x2xi32> {tt.contiguity = dense<[1, 1]> : tensor<2xi32>, tt.divisibility = dense<[2, 8]> : tensor<2xi32>, tt.constancy = dense<[1, 1]> : tensor<2xi32>},
+    %arg2: tensor<2x1x2xi32> {tt.contiguity = dense<[1, 1, 1]> : tensor<3xi32>, tt.divisibility = dense<[2, 32, 4]> : tensor<3xi32>, tt.constancy = dense<[1, 1, 1]> : tensor<3xi32>},
+    %arg3: tensor<4x4xi32> {tt.contiguity = dense<[1, 1]> : tensor<2xi32>, tt.divisibility = dense<[8, 2]> : tensor<2xi32>, tt.constancy = dense<[2, 4]> : tensor<2xi32>}) {
+  // Divisibility from a unit-contiguity source axis applies to every output
+  // axis, including axes whose flat-index bits do not overlap the source axis.
+  // expected-remark @below {{contiguity = [1, 1, 1], divisibility = [8, 8, 8], constancy = [1, 1, 1], constant_value = <none>}}
+  %0 = tt.reshape %arg0 : tensor<2x2xi32> -> tensor<1x2x2xi32>
+  // expected-remark @below {{contiguity = [1, 1, 1], divisibility = [8, 8, 8], constancy = [1, 1, 1], constant_value = <none>}}
+  %1 = tt.reshape %arg1 : tensor<2x2xi32> -> tensor<1x2x2xi32>
+  // The strongest global divisor may come from a singleton source axis.
+  // expected-remark @below {{contiguity = [1], divisibility = [32], constancy = [1], constant_value = <none>}}
+  %2 = tt.reshape %arg2 : tensor<2x1x2xi32> -> tensor<4xi32>
+  // Global divisibility is independent of merging constant source factors.
+  // expected-remark @below {{contiguity = [1], divisibility = [8], constancy = [8], constant_value = <none>}}
+  %3 = tt.reshape %arg3 : tensor<4x4xi32> -> tensor<16xi32>
+  tt.return
+}
+
+// -----
+
 tt.func @broadcast() {
   // expected-remark @below {{contiguity = [1], divisibility = [64], constancy = [128], constant_value = 64}}
   %0 = arith.constant dense<64> : tensor<128xi32>


### PR DESCRIPTION
Playing around with codex I found this missing case.

The idea here is that if contiguity == 1, then the divisibility applies to every element of the tensor.
The idea is that a divisibility of `d` says that that the every element of the slice `t[0]` (where `0` is in the given dimension) is divisible by `d`. Even more, if `contig=1` it also says that every slice `t[1], t[2], ...` in that dimension is divisible by `d`. In other words, every element in the tensor is divisible by `d`.

This is generic, so a tensor with `div=[2, 8], contig=[1, 1]` can be upgraded to `div=[8, 8]`.