### PR TITLE
[GSan] Support multi-node topologies

### DIFF
--- a/lib/Dialect/TritonInstrument/Transforms/GlobalSanitizer.cpp
+++ b/lib/Dialect/TritonInstrument/Transforms/GlobalSanitizer.cpp
@@ -269,20 +269,20 @@ static void instrumentAsyncTMALoad(ttng::AsyncTMACopyGlobalToLocalOp op) {
 
   OpBuilder builder(op);
   auto desc = getDescriptorInfo(op.getDesc(), builder);
+  auto blockShape = op.getDesc().getType().getShape();
 
   auto offsets = castToI64(builder, op.getLoc(), op.getCoord());
-  auto access = createTiledAccess(builder, op.getLoc(), desc,
-                                  op.getResult().getType().getShape(), offsets,
-                                  op.getPred());
+  auto access = createTiledAccess(builder, op.getLoc(), desc, blockShape,
+                                  offsets, op.getPred());
   ExperimentalGSanTensorAccessOp::create(builder, op.getLoc(), access.first,
                                          access.second, /*isStore=*/false);
 }
 
 static void instrumentAsyncTMAStore(Operation *op, Value descValue,
-                                    ArrayRef<int64_t> blockShape,
                                     ValueRange coords) {
   OpBuilder builder(op);
   auto desc = getDescriptorInfo(descValue, builder);
+  auto blockShape = cast<tt::TensorDescType>(descValue.getType()).getShape();
 
   auto offsets = castToI64(builder, op->getLoc(), coords);
   auto access = createTiledAccess(builder, op->getLoc(), desc, blockShape,
@@ -294,11 +294,11 @@ static void instrumentAsyncTMAStore(Operation *op, Value descValue,
 static void instrumentAsyncTMAReduce(ttng::AsyncTMAReduceOp op) {
   OpBuilder builder(op);
   auto desc = getDescriptorInfo(op.getDesc(), builder);
+  auto blockShape = op.getDesc().getType().getShape();
 
   auto offsets = castToI64(builder, op.getLoc(), op.getCoord());
-  auto access = createTiledAccess(builder, op.getLoc(), desc,
-                                  op.getSrc().getType().getShape(), offsets,
-                                  std::nullopt);
+  auto access = createTiledAccess(builder, op.getLoc(), desc, blockShape,
+                                  offsets, std::nullopt);
   ExperimentalGSanAtomicTensorAccessOp::create(
       builder, op.getLoc(), access.first, access.second, MemSemantic::RELAXED,
       MemSyncScope::GPU);
@@ -412,9 +412,7 @@ public:
           .Case(
               [&](ttng::AsyncTMAGatherOp op) { instrumentAsyncTMAGather(op); })
           .Case([&](ttng::AsyncTMACopyLocalToGlobalOp op) {
-            instrumentAsyncTMAStore(op, op.getDesc(),
-                                    op.getSrc().getType().getShape(),
-                                    op.getCoord());
+            instrumentAsyncTMAStore(op, op.getDesc(), op.getCoord());
           })
           .Case(
               [&](ttng::AsyncTMAReduceOp op) { instrumentAsyncTMAReduce(op); })

--- a/python/test/gsan/test_allocator.py
+++ b/python/test/gsan/test_allocator.py
@@ -5,16 +5,69 @@ import os
 import pytest
 import torch
 
-from triton._internal_testing import is_cuda
-from triton.experimental.gsan import create_mem_pool
-from triton.experimental.gsan._allocator import (export_allocation_handles, free_allocation, get_reserve_pointer,
-                                                 get_reserve_size, gsan_free, gsan_malloc, import_allocation_handles)
-from triton.experimental.gsan._testing_utils import shadow_tensor_for
+from triton._internal_testing import is_cuda, run_in_process
+from triton.experimental.gsan import configure, create_mem_pool, freeze_config
+from triton.experimental.gsan._allocator import (
+    export_allocation_handles,
+    free_allocation,
+    get_device_rank,
+    get_reserve_pointer,
+    get_reserve_size,
+    gsan_free,
+    gsan_malloc,
+    import_allocation_handles,
+)
+from triton.experimental.gsan._testing_utils import global_state, shadow_tensor_for
 from triton.experimental.gsan._utils import uint8_cuda_tensor_from_ptr
 
 # With 2 MiB pages, this rounds to a 6 MiB allocation inside an 8 MiB tree node.
 # This tests cases where AllocNode.size != AllocNode.allocSize
 _ODD_LARGE_ALLOCATION_SIZE = 4 * 1024 * 1024 + 1
+
+
+def _run_configure_check(device_ranks: dict[int, int], num_devices: int) -> None:
+    configure(device_ranks=device_ranks, num_devices=num_devices)
+    assert get_device_rank(0) == device_ranks[0]
+    assert get_device_rank(1) == device_ranks[1]
+
+
+def _run_configure_runtime_fields_check() -> None:
+    device = torch.cuda.current_device()
+    configure(rng_seed=12345, clock_buffer_size=17)
+
+    ptr = gsan_malloc(1, device, 0)
+    try:
+        state = global_state(device_index=device)
+        assert state.rng_seed == 12345
+        assert state.clock_buffer_size == 17
+    finally:
+        gsan_free(ptr, device, 0, 0)
+
+
+def _run_freeze_config_check() -> None:
+    configure(rng_seed=12345)
+    freeze_config()
+    try:
+        configure(rng_seed=12345)
+    except RuntimeError as exc:
+        assert "configuration is already frozen" in str(exc)
+    else:
+        raise AssertionError("expected freeze_config() to reject later config changes")
+
+
+def _run_allocator_freezes_config_check() -> None:
+    device = torch.cuda.current_device()
+    configure(rng_seed=12345)
+    ptr = gsan_malloc(1, device, 0)
+    try:
+        try:
+            configure(rng_seed=12345)
+        except RuntimeError as exc:
+            assert "configuration is already frozen" in str(exc)
+        else:
+            raise AssertionError("expected allocator initialization to freeze config")
+    finally:
+        gsan_free(ptr, device, 0, 0)
 
 
 @pytest.fixture
@@ -55,6 +108,44 @@ def test_malloc_edge_cases(_direct_allocator):
 
     # Null free is a no-op.
     free(0)
+
+
+@pytest.mark.skipif(not is_cuda() or torch.cuda.device_count() < 2, reason="requires at least two CUDA devices")
+def test_configure_supports_swapped_cuda_device_ids():
+    device_ranks = {0: 1, 1: 0}
+    result = run_in_process(_run_configure_check, args=(device_ranks, 2))
+    assert result.exc is None
+
+
+@pytest.mark.skipif(not is_cuda() or torch.cuda.device_count() < 2, reason="requires at least two CUDA devices")
+def test_configure_supports_sparse_global_device_ids():
+    device_ranks = {0: 2, 1: 3}
+    result = run_in_process(_run_configure_check, args=(device_ranks, 4))
+    assert result.exc is None
+
+
+@pytest.mark.skipif(not is_cuda(), reason="requires CUDA backend")
+def test_configure_exposes_runtime_fields():
+    result = run_in_process(_run_configure_runtime_fields_check)
+    assert result.exc is None
+
+
+@pytest.mark.skipif(not is_cuda(), reason="requires CUDA backend")
+def test_freeze_config_rejects_later_changes():
+    result = run_in_process(_run_freeze_config_check)
+    assert result.exc is None
+
+
+@pytest.mark.skipif(not is_cuda(), reason="requires CUDA backend")
+def test_allocator_initialization_rejects_later_config():
+    result = run_in_process(_run_allocator_freezes_config_check)
+    assert result.exc is None
+
+
+@pytest.mark.skipif(not is_cuda() or torch.cuda.device_count() < 2, reason="requires at least two CUDA devices")
+def test_default_topology_uses_cuda_device_indices():
+    assert get_device_rank(0) == 0
+    assert get_device_rank(1) == 1
 
 
 def test_malloc_free(_direct_allocator):

--- a/python/test/gsan/test_gsan.py
+++ b/python/test/gsan/test_gsan.py
@@ -400,10 +400,6 @@ def _host_tma_reduce_add_kernel(desc, src_ptr, src_stride_0, src_stride_1, BLOCK
     desc.atomic_add([0, 0], src)
 
 
-def _shadow_cell_state(cell) -> tuple[int, object, tuple[object, ...]]:
-    return (cell.num_reads, cell.write_clock, tuple(cell.read_clocks))
-
-
 def _shadow_cells_for_tensor(tensor: torch.Tensor):
     assert tensor.ndim >= 1
     if tensor.ndim > 1:
@@ -427,18 +423,16 @@ def _assert_shadow_mask(before, after, changed_mask: torch.Tensor, *, access_kin
         for col_idx in range(changed_mask.shape[1]):
             before_cell = before[row_idx][col_idx]
             after_cell = after[row_idx][col_idx]
-            before_state = _shadow_cell_state(before_cell)
-            after_state = _shadow_cell_state(after_cell)
 
             if changed_mask[row_idx, col_idx].item():
-                assert after_state != before_state
+                assert after_cell != before_cell
                 if access_kind == "read":
                     assert after_cell.write_clock == before_cell.write_clock
                 else:
                     assert after_cell.write_clock != before_cell.write_clock
                     assert after_cell.write_clock.epoch != 0
             else:
-                assert after_state == before_state
+                assert after_cell == before_cell
 
 
 def _masked_store_change_mask(storage: torch.Tensor, m_size: int, n_size: int, row_idx: int,

--- a/python/test/gsan/test_symmetric_memory.py
+++ b/python/test/gsan/test_symmetric_memory.py
@@ -13,7 +13,7 @@ import triton.language as tl
 from triton._internal_testing import is_cuda, run_in_process
 from triton.experimental.gsan import symmetric_memory
 from triton.experimental.gsan._allocator import get_runtime_state_layout
-from triton.experimental.gsan._testing_utils import atomic_poll, shadow_tensor_for
+from triton.experimental.gsan._testing_utils import atomic_poll, shadow_cell_from_address, shadow_tensor_for, SHADOW_GRANULARITY_BYTES
 from triton.experimental.gsan._utils import uint8_cuda_tensor_from_ptr
 
 
@@ -23,16 +23,20 @@ def _get_free_tcp_port() -> int:
         return int(sock.getsockname()[1])
 
 
-def _local_vector_clocks(device_index: int) -> tuple[torch.Tensor, dict[str, int]]:
-    layout = get_runtime_state_layout(device_index)
+def _vector_clocks(runtime_state_device: int, access_device: int) -> tuple[torch.Tensor, dict[str, int]]:
+    layout = get_runtime_state_layout(runtime_state_device)
     region_size = layout["thread_state_stride_bytes"] * layout["num_sms"]
-    region = uint8_cuda_tensor_from_ptr(layout["thread_state_base_ptr"], region_size, device_index)
+    region = uint8_cuda_tensor_from_ptr(layout["thread_state_base_ptr"], region_size, access_device)
     clocks = torch.as_strided(
         region.view(torch.uint16)[layout["thread_state_header_size_bytes"] // 2:],
         size=(layout["num_sms"], layout["num_threads"]),
         stride=(layout["thread_state_stride_bytes"] // 2, 1),
     )
     return clocks, layout
+
+
+def _local_vector_clocks(device_index: int) -> tuple[torch.Tensor, dict[str, int]]:
+    return _vector_clocks(device_index, device_index)
 
 
 @triton.jit
@@ -56,9 +60,15 @@ def _single_cta_no_atomic_sync_kernel(payload_ptr, peer_payload_ptr, seen_peer_p
     tl.store(seen_peer_ptr, seen_peer)
 
 
+@triton.jit
+def _store_scalar_kernel(peer_buf, byte_offset, value):
+    tl.store(peer_buf + byte_offset, value)
+
+
 def _run_symmetric_memory_checks(rank: int, world_size: int) -> None:
     dev = torch.device(f"cuda:{rank}")
     torch.cuda.set_device(dev)
+    symmetric_memory.configure(dist.group.WORLD)
 
     buf = symmetric_memory.empty((2048, ), dtype=torch.uint8, device=dev)
     buf.fill_(rank + 1)
@@ -141,6 +151,7 @@ def _run_subgroup_symmetric_memory_checks(rank: int) -> None:
             subgroup_rank = dist.get_rank(subgroup)
             subgroup_world_size = dist.get_world_size(subgroup)
             assert subgroup_world_size == 2
+            symmetric_memory.configure(subgroup)
 
             buf = symmetric_memory.empty((2048, ), dtype=torch.uint8, device=dev)
             buf.fill_(subgroup_rank + 7)
@@ -189,9 +200,73 @@ def _run_subgroup_symmetric_memory_checks(rank: int) -> None:
             dist.destroy_process_group(subgroup)
 
 
+def _run_multi_node_simulated_symmetric_memory_checks(rank: int, world_size: int, device_index: int) -> None:
+    triton.knobs.compilation.instrumentation_mode = "gsan"
+
+    dev = torch.device(f"cuda:{device_index}")
+    torch.cuda.set_device(dev)
+    symmetric_memory.configure(dist.group.WORLD)
+
+    buf = symmetric_memory.empty((2048, ), dtype=torch.uint8, device=dev)
+    buf.fill_(rank + 31)
+
+    hdl = symmetric_memory.rendezvous(buf, group=dist.group.WORLD)
+    assert hdl.rank == rank
+    assert hdl.world_size == world_size
+
+    peer = (rank + 1) % world_size
+    prev = (rank - 1) % world_size
+    hdl.barrier(channel=0)
+    peer_buf = hdl.get_buffer(peer, buf.shape, buf.dtype)
+    assert torch.all(peer_buf == (peer + 31)).item()
+
+    peer_buf.fill_(rank + 101)
+    hdl.barrier(channel=0)
+    assert torch.all(buf == (prev + 101)).item()
+
+    outgoing_shadow_offset = rank * SHADOW_GRANULARITY_BYTES
+    incoming_shadow_offset = prev * SHADOW_GRANULARITY_BYTES
+    untouched_shadow_offset = (world_size + rank) * SHADOW_GRANULARITY_BYTES
+    incoming_shadow_before = shadow_cell_from_address(buf.data_ptr() + incoming_shadow_offset,
+                                                      device_index=device_index)
+    untouched_shadow_before = shadow_cell_from_address(buf.data_ptr() + untouched_shadow_offset,
+                                                       device_index=device_index)
+
+    _store_scalar_kernel[(1, )](peer_buf, outgoing_shadow_offset, rank + 151, num_warps=1)
+    torch.cuda.synchronize()
+    hdl.barrier(channel=0)
+    dist.barrier()
+
+    incoming_shadow_after = shadow_cell_from_address(buf.data_ptr() + incoming_shadow_offset, device_index=device_index)
+    untouched_shadow_after = shadow_cell_from_address(buf.data_ptr() + untouched_shadow_offset,
+                                                      device_index=device_index)
+    assert int(buf[incoming_shadow_offset].item()) == prev + 151
+    assert incoming_shadow_after != incoming_shadow_before
+    assert incoming_shadow_after.write_clock != incoming_shadow_before.write_clock
+    assert incoming_shadow_after.write_clock.epoch != 0
+    assert untouched_shadow_after == untouched_shadow_before
+
+    local_clocks, layout = _vector_clocks(rank, device_index)
+    local_clocks.zero_()
+    local_tid = rank * layout["num_sms"]
+    local_clocks[0, local_tid] = rank + 211
+    hdl.barrier(channel=0)
+
+    synced_clocks, _ = _vector_clocks(rank, device_index)
+    for global_rank in range(world_size):
+        tid = global_rank * layout["num_sms"]
+        assert torch.all(synced_clocks[:, tid] == (global_rank + 211)).item()
+
+    del peer_buf
+    torch.cuda.synchronize()
+    dist.barrier()
+    hdl.close()
+
+
 def _run_single_cta_atomic_sync_check(rank: int, world_size: int) -> None:
     dev = torch.device(f"cuda:{rank}")
     torch.cuda.set_device(dev)
+    symmetric_memory.configure(dist.group.WORLD)
 
     peer = (rank + 1) % world_size
     state = symmetric_memory.empty((2, ), dtype=torch.int32, device=dev)
@@ -237,6 +312,7 @@ def _run_single_cta_no_atomic_sync_check(rank: int, world_size: int) -> None:
 
     dev = torch.device(f"cuda:{rank}")
     torch.cuda.set_device(dev)
+    symmetric_memory.configure(dist.group.WORLD)
 
     peer = (rank + 1) % world_size
     payload = symmetric_memory.empty((1, ), dtype=torch.int32, device=dev)
@@ -281,6 +357,20 @@ def _distributed_worker_single_cta_atomic_sync(rank: int, world_size: int, maste
     dist.init_process_group(backend="nccl", rank=rank, world_size=world_size, device_id=torch.device(dev))
     try:
         _run_single_cta_atomic_sync_check(rank, world_size)
+        dist.barrier()
+    finally:
+        dist.destroy_process_group()
+
+
+def _distributed_worker_multi_node_simulated(rank: int, world_size: int, master_port: int,
+                                             num_local_devices: int) -> None:
+    device_index = rank % num_local_devices
+    os.environ["WORLD_SIZE"] = str(world_size)
+    os.environ["MASTER_ADDR"] = "127.0.0.1"
+    os.environ["MASTER_PORT"] = str(master_port)
+    dist.init_process_group(backend="gloo", rank=rank, world_size=world_size)
+    try:
+        _run_multi_node_simulated_symmetric_memory_checks(rank, world_size, device_index)
         dist.barrier()
     finally:
         dist.destroy_process_group()
@@ -342,6 +432,21 @@ def test_gsan_symmetric_memory_rendezvous_subgroup_without_global_zero():
 
 
 @pytest.mark.skipif(not is_cuda(), reason="requires CUDA backend")
+def test_gsan_symmetric_memory_rendezvous_multi_node_simulated():
+    if torch.cuda.device_count() < 2:
+        pytest.skip("requires 2 CUDA devices")
+
+    world_size = 4
+    master_port = _get_free_tcp_port()
+    mp.spawn(
+        _distributed_worker_multi_node_simulated,
+        args=(world_size, master_port, 2),
+        nprocs=world_size,
+        join=True,
+    )
+
+
+@pytest.mark.skipif(not is_cuda(), reason="requires CUDA backend")
 def test_gsan_symmetric_memory_single_cta_atomic_sync():
     if torch.cuda.device_count() < 2:
         pytest.skip("requires 2 CUDA devices")
@@ -373,6 +478,7 @@ def _run_triton_kernels_convert_dp_to_ep_with_gsan_pool(rank: int, world_size: i
 
     dev = torch.device(f"cuda:{rank}")
     torch.cuda.set_device(dev)
+    symmetric_memory.configure(dist.group.WORLD)
 
     class _GSanSymmetricMemoryPool(SymmetricMemoryPool):
 

--- a/python/triton/experimental/gsan/__init__.py
+++ b/python/triton/experimental/gsan/__init__.py
@@ -1,6 +1,6 @@
-from ._allocator import create_mem_pool, get_allocator
+from ._allocator import configure, create_mem_pool, freeze_config, get_allocator
 
-__all__ = ["create_mem_pool", "get_allocator"]
+__all__ = ["configure", "create_mem_pool", "freeze_config", "get_allocator"]
 
 _LAZY_LOAD_MODULES = {"symmetric_memory"}
 

--- a/python/triton/experimental/gsan/_allocator.py
+++ b/python/triton/experimental/gsan/_allocator.py
@@ -40,6 +40,45 @@ def get_allocator():
     return CUDAPluggableAllocator(so_name, "gsanMalloc", "gsanFree")
 
 
+def configure(
+    *,
+    device_ranks: dict[int, int] | None = None,
+    num_devices: int | None = None,
+    rng_seed: int | None = None,
+    clock_buffer_size: int | None = None,
+) -> None:
+    """Configures the process-local GSan state.
+
+    GSan keeps one allocator configuration per process. Call this before the
+    allocator initializes runtime state, or before calling :func:`freeze_config`.
+    Once frozen, later calls to :func:`configure` raise ``RuntimeError``.
+
+    Args:
+        device_ranks (dict[int, int], optional): Mapping from local CUDA device index to the
+            logical GSan device id. This enables gsan to be used with multi-node nvlink domains,
+            or simply processes with different CUDA_VISIBLE_DEVICES settings. Each value must be
+            unique and in ``[0, num_devices)``. If None, defaults to a 1:1 mapping from device
+            index to device id.
+        num_devices (int, optional): Total number of logical GSan devices in the topology. If
+            None, defaults to the number of visible CUDA devices.
+        rng_seed (int, optional): Optional seed for GSan's stochastic read-clock sampling. Use this
+            to make sampling decisions reproducible across runs when debugging sanitizer behavior.
+            If omitted, GSan first checks ``TRITON_GSAN_SEED`` and otherwise generates a random
+            seed when the allocator runtime state is initialized.
+        clock_buffer_size (int, optional): When doing an atomic release operation, GSan uses a
+            circular buffer to record what memory accesses have been released. If the writing CTA
+            has done more release writes than there are circular buffer entries, then the atomic
+            flag cannot be read and you will need to increase the buffer size. If omitted, GSan
+            first checks ``TRITON_GSAN_CLOCK_BUFFER_SIZE`` and otherwise defaults to 1024.
+    """
+    _load_gsan_module().configure(device_ranks, num_devices, rng_seed, clock_buffer_size)
+
+
+def freeze_config() -> None:
+    """Prevents later `configure(...)` calls from changing allocator configuration."""
+    _load_gsan_module().freeze_config()
+
+
 def create_mem_pool():
     from torch.cuda.memory import MemPool
     return MemPool(get_allocator().allocator())
@@ -65,6 +104,10 @@ def get_reserve_size() -> int:
 
 def get_global_state_pointer() -> int:
     return _load_gsan_module().get_global_state_pointer()
+
+
+def get_device_rank(device: int) -> int:
+    return _load_gsan_module().get_device_rank(device)
 
 
 def get_runtime_state_layout(device: int) -> dict[str, int]:

--- a/python/triton/experimental/gsan/_stream_sync.py
+++ b/python/triton/experimental/gsan/_stream_sync.py
@@ -7,7 +7,7 @@ from dataclasses import dataclass
 import triton
 import triton.language as tl
 
-from ._allocator import get_runtime_state_layout
+from ._allocator import get_device_rank, get_runtime_state_layout
 from ._utils import uint8_cuda_tensor_from_ptr
 
 
@@ -111,7 +111,7 @@ def synchronize_launch_stream(device: int) -> None:
 
     This makes all reads and writes transitively visible to other threads.
     """
-    layout = _runtime_state_layout(device, device)
+    layout = _runtime_state_layout(get_device_rank(device), device)
     BLOCK_SIZE = 128
     grid = (triton.cdiv(layout.num_threads, BLOCK_SIZE), 1, 1)
     kernel = _compiled_sync_kernel(
@@ -142,7 +142,7 @@ def synchronize_process_group_barrier(device: int, peer_devices: tuple[int, ...]
     if not peer_devices:
         return
 
-    local_layout = _runtime_state_layout(device, device)
+    local_layout = _runtime_state_layout(get_device_rank(device), device)
     peer_regions = []
     for peer_device in peer_devices:
         peer_layout = _runtime_state_layout(peer_device, device)

--- a/python/triton/experimental/gsan/_utils.py
+++ b/python/triton/experimental/gsan/_utils.py
@@ -44,9 +44,13 @@ _DLManagedTensor._fields_ = [
     ("deleter", _DLManagedTensorDeleter),
 ]
 
-_PyCapsule_New = ctypes.pythonapi.PyCapsule_New
-_PyCapsule_New.restype = ctypes.py_object
-_PyCapsule_New.argtypes = [ctypes.c_void_p, ctypes.c_char_p, ctypes.c_void_p]
+_PyCapsuleNew = ctypes.PYFUNCTYPE(
+    ctypes.py_object,
+    ctypes.c_void_p,
+    ctypes.c_char_p,
+    ctypes.c_void_p,
+)
+_PyCapsule_New = _PyCapsuleNew(("PyCapsule_New", ctypes.pythonapi))
 
 # Keep the ctypes-owned metadata alive until PyTorch drops the imported tensor.
 _DLPACK_STATE: dict[int, object] = {}

--- a/python/triton/experimental/gsan/src/GSanAllocator.cc
+++ b/python/triton/experimental/gsan/src/GSanAllocator.cc
@@ -58,16 +58,20 @@ struct AllocNode {
 };
 
 struct GSanConfig {
-  int numGPUs;
-  int numSMs;
-  int numThreads;
-  int clockBufferSize;
-  uint32_t rngSeed;
+  int numGPUs = 1;
+  int numSMs = 0;
+  int numThreads = 0;
+  int clockBufferSize = 0;
+  uint32_t rngSeed = 0;
+  bool clockBufferSizeConfigured = false;
+  bool rngSeedConfigured = false;
+  int deviceRanks[gsan::kMaxGPUs] = {};
+  bool configuredDeviceRanks[gsan::kMaxGPUs] = {};
+  bool topologyConfigured = false;
+  bool topologyFrozen = false;
 };
 
 struct AllocatorState {
-  GSanConfig config;
-
   // User memory + shadow memory
   CUdeviceptr reserveBaseAddress = 0;
   AllocNode treeRoot;
@@ -85,7 +89,42 @@ void printCUDAError(CUresult err) {
 }
 
 static AllocatorState *alloc = nullptr;
+static GSanConfig config;
 static std::mutex mut;
+
+int getDeviceRankForCudaDevice(int device) {
+  if (!config.topologyConfigured)
+    return -1;
+  if (device < 0 || device >= static_cast<int>(gsan::kMaxGPUs))
+    return -1;
+  if (!config.configuredDeviceRanks[device])
+    return -1;
+  return config.deviceRanks[device];
+}
+
+CUresult ensureTopologyConfigured() {
+  if (config.topologyConfigured)
+    return CUDA_SUCCESS;
+
+  // Default topology assumes a single node with 1:1 mapping of device index to
+  // GSan device ID.
+  int cudaDeviceCount = 0;
+  CUresult err = cuDeviceGetCount(&cudaDeviceCount);
+  if (err != CUDA_SUCCESS)
+    return err;
+  if (cudaDeviceCount <= 0)
+    return CUDA_ERROR_NO_DEVICE;
+  if (cudaDeviceCount > static_cast<int>(gsan::kMaxGPUs))
+    return CUDA_ERROR_NOT_SUPPORTED;
+
+  config.numGPUs = cudaDeviceCount;
+  for (int cudaDevice = 0; cudaDevice < cudaDeviceCount; ++cudaDevice) {
+    config.deviceRanks[cudaDevice] = cudaDevice;
+    config.configuredDeviceRanks[cudaDevice] = true;
+  }
+  config.topologyConfigured = true;
+  return CUDA_SUCCESS;
+}
 
 size_t cdiv(size_t num, size_t den) { return (num + (den - 1)) / den; }
 
@@ -301,15 +340,13 @@ CUresult refreshConfigForDevice(int device) {
   if (alloc == nullptr)
     return CUDA_ERROR_NOT_INITIALIZED;
 
-  int numGPUs = 0;
-  CUresult err = cuDeviceGetCount(&numGPUs);
+  config.topologyFrozen = true;
+  CUresult err = ensureTopologyConfigured();
   if (err != CUDA_SUCCESS)
     return err;
-  if (numGPUs <= 0)
-    return CUDA_ERROR_NO_DEVICE;
-  if (numGPUs > static_cast<int>(gsan::kMaxGPUs))
-    return CUDA_ERROR_NOT_SUPPORTED;
-  if (device < 0 || device >= numGPUs)
+
+  int deviceRank = getDeviceRankForCudaDevice(device);
+  if (device < 0)
     return CUDA_ERROR_INVALID_DEVICE;
 
   CUdevice cuDevice = 0;
@@ -325,41 +362,51 @@ CUresult refreshConfigForDevice(int device) {
   if (numSMs <= 0)
     return CUDA_ERROR_INVALID_VALUE;
 
-  auto &config = alloc->config;
-  config.numGPUs = numGPUs;
   config.numSMs = numSMs;
   config.numThreads = config.numGPUs * config.numSMs;
+  if (config.numThreads > gsan::kMaxThreads)
+    return CUDA_ERROR_NOT_SUPPORTED;
 
-  // Seed rng for stochastic read clocks
-  auto userSeed = getenv("TRITON_GSAN_SEED");
-  if (userSeed) {
-    auto res =
-        std::from_chars(userSeed, userSeed + strlen(userSeed), config.rngSeed);
-    if (res.ec != std::errc()) {
-      auto errc = make_error_code(res.ec);
-      auto msg = errc.message();
-      fprintf(stderr, "Invalid TRITON_GSAN_SEED value: %s", msg.c_str());
-      return CUDA_ERROR_INVALID_VALUE;
+  // Seed rng for stochastic read clocks.
+  if (!config.rngSeedConfigured) {
+    auto userSeed = getenv("TRITON_GSAN_SEED");
+    if (userSeed) {
+      const char *userSeedEnd = userSeed + strlen(userSeed);
+      auto res = std::from_chars(userSeed, userSeedEnd, config.rngSeed);
+      if (res.ec != std::errc() || res.ptr != userSeedEnd) {
+        auto errc = make_error_code(res.ec);
+        auto msg = errc.message();
+        fprintf(stderr, "Invalid TRITON_GSAN_SEED value: %s", msg.c_str());
+        return CUDA_ERROR_INVALID_VALUE;
+      }
+    } else {
+      std::uniform_int_distribution<uint32_t> dist;
+      std::random_device rd{};
+      config.rngSeed = dist(rd);
     }
-  } else {
-    std::uniform_int_distribution<uint32_t> dist;
-    std::random_device rd{};
-    config.rngSeed = dist(rd);
+    config.rngSeedConfigured = true;
   }
 
-  auto userClockSize = getenv("TRITON_GSAN_CLOCK_BUFFER_SIZE");
-  if (userClockSize) {
-    auto res =
-        std::from_chars(userSeed, userSeed + strlen(userSeed), config.rngSeed);
-    if (res.ec != std::errc()) {
-      auto errc = make_error_code(res.ec);
-      auto msg = errc.message();
-      fprintf(stderr, "Invalid TRITON_CLOCK_BUFFER_SIZE value: %s",
-              msg.c_str());
-      return CUDA_ERROR_INVALID_VALUE;
+  if (!config.clockBufferSizeConfigured) {
+    auto userClockSize = getenv("TRITON_GSAN_CLOCK_BUFFER_SIZE");
+    if (userClockSize) {
+      int clockBufferSize = 0;
+      const char *userClockSizeEnd = userClockSize + strlen(userClockSize);
+      auto res =
+          std::from_chars(userClockSize, userClockSizeEnd, clockBufferSize);
+      if (res.ec != std::errc() || res.ptr != userClockSizeEnd ||
+          clockBufferSize <= 0) {
+        auto errc = make_error_code(res.ec);
+        auto msg = errc.message();
+        fprintf(stderr, "Invalid TRITON_GSAN_CLOCK_BUFFER_SIZE value: %s",
+                msg.c_str());
+        return CUDA_ERROR_INVALID_VALUE;
+      }
+      config.clockBufferSize = clockBufferSize;
+    } else {
+      config.clockBufferSize = 1024;
     }
-  } else {
-    config.clockBufferSize = 1024;
+    config.clockBufferSizeConfigured = true;
   }
   return CUDA_SUCCESS;
 }
@@ -370,8 +417,8 @@ CUresult ensureRuntimeStateMapped(int device) {
   CUresult err = refreshConfigForDevice(device);
   if (err != CUDA_SUCCESS)
     return err;
-  auto &config = alloc->config;
-  if (alloc->perDeviceHandles[device] != 0)
+  int deviceRank = getDeviceRankForCudaDevice(device);
+  if (alloc->perDeviceHandles[deviceRank] != 0)
     return CUDA_SUCCESS;
 
   CUmemAllocationProp prop = {};
@@ -409,7 +456,7 @@ CUresult ensureRuntimeStateMapped(int device) {
   CUmemAccessDesc accessDesc = {};
   gsan::GlobalState globals = {};
   CUdeviceptr deviceAddr =
-      alloc->globalStateAddress + device * gsan::kPerDeviceStateStride;
+      alloc->globalStateAddress + deviceRank * gsan::kPerDeviceStateStride;
 
   err = cuMemCreate(&allocHandle, allocSize, &prop, 0);
   if (err != CUDA_SUCCESS)
@@ -442,7 +489,7 @@ CUresult ensureRuntimeStateMapped(int device) {
   if (err != CUDA_SUCCESS)
     goto error;
 
-  alloc->perDeviceHandles[device] = allocHandle;
+  alloc->perDeviceHandles[deviceRank] = allocHandle;
   alloc->perDeviceStateSize = allocSize;
   return CUDA_SUCCESS;
 
@@ -714,7 +761,8 @@ int gsanExportRuntimeStateHandle(int device, int *fd, size_t *allocSize) {
     return -1;
   }
 
-  auto handle = alloc->perDeviceHandles[device];
+  int deviceRank = getDeviceRankForCudaDevice(device);
+  auto handle = alloc->perDeviceHandles[deviceRank];
   auto size = alloc->perDeviceStateSize;
   if (handle == 0 || size == 0)
     return -1;
@@ -805,7 +853,7 @@ int gsanImportRuntimeStateHandle(int fd, size_t allocSize, int peerDevice,
     return -1;
   }
 
-  if (device < 0 || device >= alloc->config.numGPUs)
+  if (peerDevice < 0 || peerDevice >= config.numGPUs)
     return -1;
   if (allocSize != alloc->perDeviceStateSize)
     return -1;
@@ -861,6 +909,19 @@ bool parseIntArg(PyObject *obj, const char *name, int *out) {
     return false;
   }
   *out = static_cast<int>(value);
+  return true;
+}
+
+bool parseUInt32Arg(PyObject *obj, const char *name, uint32_t *out) {
+  unsigned long long value = PyLong_AsUnsignedLongLong(obj);
+  if (value == std::numeric_limits<unsigned long long>::max() &&
+      PyErr_Occurred())
+    return false;
+  if (value > std::numeric_limits<uint32_t>::max()) {
+    PyErr_Format(PyExc_OverflowError, "%s is out of range for uint32", name);
+    return false;
+  }
+  *out = static_cast<uint32_t>(value);
   return true;
 }
 
@@ -926,6 +987,150 @@ PyObject *pyFree([[maybe_unused]] PyObject *self, PyObject *const *args,
   Py_RETURN_NONE;
 }
 
+PyObject *pyConfigure([[maybe_unused]] PyObject *self, PyObject *const *args,
+                      Py_ssize_t nargs) {
+  if (nargs != 4) {
+    PyErr_Format(PyExc_TypeError,
+                 "%s.configure expected 4 positional arguments, got %zd",
+                 kModuleName, nargs);
+    return nullptr;
+  }
+
+  PyObject *deviceRankMap = args[0];
+  PyObject *numDevicesArg = args[1];
+  const bool topologyRequested =
+      deviceRankMap != Py_None || numDevicesArg != Py_None;
+  if ((deviceRankMap == Py_None) != (numDevicesArg == Py_None)) {
+    PyErr_SetString(PyExc_ValueError,
+                    "device_ranks and num_devices must be configured "
+                    "together");
+    return nullptr;
+  }
+
+  int requestedNumDevices = 0;
+  int requestedDeviceRanks[gsan::kMaxGPUs] = {};
+  bool requestedConfiguredDeviceRanks[gsan::kMaxGPUs] = {};
+  if (topologyRequested) {
+    if (!PyDict_Check(deviceRankMap)) {
+      PyErr_SetString(PyExc_TypeError, "device_ranks must be a dict[int, int]");
+      return nullptr;
+    }
+    if (!parseIntArg(numDevicesArg, "num_devices", &requestedNumDevices))
+      return nullptr;
+    if (requestedNumDevices <= 0 ||
+        requestedNumDevices > static_cast<int>(gsan::kMaxGPUs)) {
+      PyErr_Format(PyExc_ValueError, "num_devices must be in [1, %zu], got %d",
+                   static_cast<size_t>(gsan::kMaxGPUs), requestedNumDevices);
+      return nullptr;
+    }
+    if (PyDict_Size(deviceRankMap) <= 0) {
+      PyErr_SetString(PyExc_ValueError, "device_ranks must not be empty");
+      return nullptr;
+    }
+
+    bool requestedGlobalDeviceIds[gsan::kMaxGPUs] = {};
+    Py_ssize_t pos = 0;
+    PyObject *key = nullptr;
+    PyObject *value = nullptr;
+    while (PyDict_Next(deviceRankMap, &pos, &key, &value)) {
+      int cudaDevice = 0;
+      int globalDeviceId = 0;
+      if (!parseIntArg(key, "cuda_device", &cudaDevice) ||
+          !parseIntArg(value, "global_device_id", &globalDeviceId)) {
+        return nullptr;
+      }
+      if (cudaDevice < 0 || cudaDevice >= static_cast<int>(gsan::kMaxGPUs)) {
+        PyErr_Format(PyExc_ValueError,
+                     "cuda_device must be in [0, %zu), got %d",
+                     static_cast<size_t>(gsan::kMaxGPUs), cudaDevice);
+        return nullptr;
+      }
+      if (globalDeviceId < 0 || globalDeviceId >= requestedNumDevices) {
+        PyErr_Format(PyExc_ValueError,
+                     "global_device_id must be in [0, %d), got %d",
+                     requestedNumDevices, globalDeviceId);
+        return nullptr;
+      }
+      if (requestedGlobalDeviceIds[globalDeviceId]) {
+        PyErr_Format(PyExc_ValueError,
+                     "global_device_id %d is assigned to more than one CUDA "
+                     "device",
+                     globalDeviceId);
+        return nullptr;
+      }
+      requestedDeviceRanks[cudaDevice] = globalDeviceId;
+      requestedConfiguredDeviceRanks[cudaDevice] = true;
+      requestedGlobalDeviceIds[globalDeviceId] = true;
+    }
+  }
+
+  const bool rngSeedRequested = args[2] != Py_None;
+  uint32_t requestedRngSeed = 0;
+  if (rngSeedRequested &&
+      !parseUInt32Arg(args[2], "rng_seed", &requestedRngSeed))
+    return nullptr;
+
+  const bool clockBufferSizeRequested = args[3] != Py_None;
+  int requestedClockBufferSize = 0;
+  if (clockBufferSizeRequested) {
+    if (!parseIntArg(args[3], "clock_buffer_size", &requestedClockBufferSize))
+      return nullptr;
+    if (requestedClockBufferSize <= 0) {
+      PyErr_Format(PyExc_ValueError,
+                   "clock_buffer_size must be positive, got %d",
+                   requestedClockBufferSize);
+      return nullptr;
+    }
+  }
+
+  std::lock_guard lg(mut);
+  if (config.topologyFrozen) {
+    PyErr_SetString(PyExc_RuntimeError,
+                    "GSan allocator configuration is already frozen and "
+                    "cannot be changed");
+    return nullptr;
+  }
+
+  if (topologyRequested) {
+    config.numGPUs = requestedNumDevices;
+    for (size_t i = 0; i < gsan::kMaxGPUs; ++i) {
+      config.deviceRanks[i] = requestedDeviceRanks[i];
+      config.configuredDeviceRanks[i] = requestedConfiguredDeviceRanks[i];
+    }
+    config.topologyConfigured = true;
+  }
+  if (rngSeedRequested) {
+    config.rngSeed = requestedRngSeed;
+    config.rngSeedConfigured = true;
+  }
+  if (clockBufferSizeRequested) {
+    config.clockBufferSize = requestedClockBufferSize;
+    config.clockBufferSizeConfigured = true;
+  }
+  Py_RETURN_NONE;
+}
+
+PyObject *pyFreezeConfig([[maybe_unused]] PyObject *self, PyObject *const *args,
+                         Py_ssize_t nargs) {
+  if (nargs != 0) {
+    PyErr_Format(PyExc_TypeError,
+                 "%s.freeze_config expected 0 positional arguments, got %zd",
+                 kModuleName, nargs);
+    return nullptr;
+  }
+
+  std::lock_guard lg(mut);
+  CUresult err = ensureTopologyConfigured();
+  if (err != CUDA_SUCCESS) {
+    printCUDAError(err);
+    PyErr_SetString(PyExc_RuntimeError,
+                    "failed to configure the default GSan topology");
+    return nullptr;
+  }
+  config.topologyFrozen = true;
+  Py_RETURN_NONE;
+}
+
 PyObject *pyGetReservePointer([[maybe_unused]] PyObject *self,
                               PyObject *const *args, Py_ssize_t nargs) {
   if (nargs != 0) {
@@ -956,6 +1161,37 @@ PyObject *pyGetGlobalStatePointer([[maybe_unused]] PyObject *self,
   return PyLong_FromUnsignedLongLong(alloc->globalStateAddress);
 }
 
+PyObject *pyGetDeviceRank([[maybe_unused]] PyObject *self,
+                          PyObject *const *args, Py_ssize_t nargs) {
+  if (nargs != 1) {
+    PyErr_Format(PyExc_TypeError,
+                 "%s.get_device_rank expected 1 positional argument, got %zd",
+                 kModuleName, nargs);
+    return nullptr;
+  }
+
+  int device = 0;
+  if (!parseIntArg(args[0], "device", &device))
+    return nullptr;
+
+  std::lock_guard lg(mut);
+  CUresult err = ensureTopologyConfigured();
+  if (err != CUDA_SUCCESS) {
+    printCUDAError(err);
+    PyErr_SetString(PyExc_RuntimeError,
+                    "failed to configure the default GSan topology");
+    return nullptr;
+  }
+
+  int deviceRank = getDeviceRankForCudaDevice(device);
+  if (deviceRank < 0) {
+    PyErr_Format(PyExc_ValueError,
+                 "no GSan device rank configured for CUDA device %d", device);
+    return nullptr;
+  }
+  return PyLong_FromLong(deviceRank);
+}
+
 PyObject *pyGetRuntimeStateLayout([[maybe_unused]] PyObject *self,
                                   PyObject *const *args, Py_ssize_t nargs) {
   if (nargs != 1) {
@@ -975,13 +1211,18 @@ PyObject *pyGetRuntimeStateLayout([[maybe_unused]] PyObject *self,
     PyErr_SetString(PyExc_RuntimeError, "failed to initialize gsan allocator");
     return nullptr;
   }
-  if (ensureRuntimeStateMapped(device) != CUDA_SUCCESS) {
-    PyErr_SetString(PyExc_RuntimeError,
-                    "failed to map runtime state for device");
+  if (device < 0 || device >= config.numGPUs) {
+    PyErr_Format(PyExc_ValueError, "device must be in [0, %d), got %d",
+                 config.numGPUs, device);
+    return nullptr;
+  }
+  if (alloc->perDeviceHandles[device] == 0) {
+    PyErr_Format(PyExc_RuntimeError,
+                 "GSan runtime state for device %d has not been mapped",
+                 device);
     return nullptr;
   }
 
-  const auto &config = alloc->config;
   uintptr_t globalStateAddress =
       alloc->globalStateAddress + device * gsan::kPerDeviceStateStride;
   uintptr_t threadStateBase =
@@ -1129,6 +1370,10 @@ PyMethodDef kGSanAllocatorMethods[] = {
      "Allocate GSan memory. Returns a CUDA pointer as an integer."},
     {"free", reinterpret_cast<PyCFunction>(pyFree), METH_FASTCALL,
      "Free GSan memory by pointer."},
+    {"configure", reinterpret_cast<PyCFunction>(pyConfigure), METH_FASTCALL,
+     "Configure GSan topology and runtime tuning fields."},
+    {"freeze_config", reinterpret_cast<PyCFunction>(pyFreezeConfig),
+     METH_FASTCALL, "Prevent later changes to the GSan allocator config."},
     {"get_reserve_pointer", reinterpret_cast<PyCFunction>(pyGetReservePointer),
      METH_FASTCALL, "Return the reserve base pointer as an integer."},
     {"get_reserve_size", reinterpret_cast<PyCFunction>(pyGetReserveSize),
@@ -1139,6 +1384,8 @@ PyMethodDef kGSanAllocatorMethods[] = {
     {"get_global_state_pointer",
      reinterpret_cast<PyCFunction>(pyGetGlobalStatePointer), METH_NOARGS,
      "Return the pointer to the GSan global state region."},
+    {"get_device_rank", reinterpret_cast<PyCFunction>(pyGetDeviceRank),
+     METH_FASTCALL, "Return the configured logical GSan device rank."},
     {"get_runtime_state_layout",
      reinterpret_cast<PyCFunction>(pyGetRuntimeStateLayout), METH_FASTCALL,
      "Return the per-device GSan runtime state layout."},

--- a/python/triton/experimental/gsan/src/GSanAllocator.cc
+++ b/python/triton/experimental/gsan/src/GSanAllocator.cc
@@ -93,15 +93,12 @@ size_t roundUp(size_t val, size_t alignment) {
   return cdiv(val, alignment) * alignment;
 }
 
-uint32_t roundDownToPowerOfTwo(uint32_t x) {
+size_t roundDownToPowerOfTwo(size_t x) {
   if (x == 0)
     return 0;
 
-  x |= x >> 1;
-  x |= x >> 2;
-  x |= x >> 4;
-  x |= x >> 8;
-  x |= x >> 16;
+  for (size_t shift = 1; shift < sizeof(x) * 8; shift <<= 1)
+    x |= x >> shift;
 
   return x - (x >> 1);
 }

--- a/python/triton/experimental/gsan/src/gsan_testing.cc
+++ b/python/triton/experimental/gsan/src/gsan_testing.cc
@@ -27,6 +27,23 @@ struct PyShadowCell {
   uint32_t numReads = 0;
 };
 
+bool scalarClockEquals(const PyScalarClock &lhs, const PyScalarClock &rhs) {
+  return lhs.epoch == rhs.epoch && lhs.threadId == rhs.threadId &&
+         lhs.scope == rhs.scope && lhs.isRelease == rhs.isRelease;
+}
+
+bool shadowCellEquals(const PyShadowCell &lhs, const PyShadowCell &rhs) {
+  if (lhs.numReads != rhs.numReads ||
+      !scalarClockEquals(lhs.writeClock, rhs.writeClock)) {
+    return false;
+  }
+  for (size_t i = 0; i < lhs.readClocks.size(); ++i) {
+    if (!scalarClockEquals(lhs.readClocks[i], rhs.readClocks[i]))
+      return false;
+  }
+  return true;
+}
+
 struct PyGlobalState {
   uintptr_t reserveBase = 0;
   uintptr_t globalsBase = 0;
@@ -273,8 +290,7 @@ void init_gsan_testing(py::module &&m) {
       .def(
           "__eq__",
           [](const PyScalarClock &lhs, const PyScalarClock &rhs) {
-            return lhs.epoch == rhs.epoch && lhs.threadId == rhs.threadId &&
-                   lhs.scope == rhs.scope && lhs.isRelease == rhs.isRelease;
+            return scalarClockEquals(lhs, rhs);
           },
           py::is_operator())
       .def("__str__", [](const PyScalarClock &c) { return scalarClockStr(c); })
@@ -292,6 +308,12 @@ void init_gsan_testing(py::module &&m) {
                              [](const PyShadowCell &cell) {
                                return static_cast<uint64_t>(cell.numReads);
                              })
+      .def(
+          "__eq__",
+          [](const PyShadowCell &lhs, const PyShadowCell &rhs) {
+            return shadowCellEquals(lhs, rhs);
+          },
+          py::is_operator())
       .def("__str__",
            [](const PyShadowCell &cell) { return shadowCellStr(cell); })
       .def("__repr__",

--- a/python/triton/experimental/gsan/symmetric_memory.py
+++ b/python/triton/experimental/gsan/symmetric_memory.py
@@ -22,8 +22,9 @@ import torch.distributed as dist
 import torch.distributed.distributed_c10d as c10d
 
 from . import _stream_sync
-from ._allocator import (create_mem_pool, export_allocation_handles, export_runtime_state_handle, free_allocation,
-                         import_allocation_handles, import_runtime_state_handle)
+from ._allocator import (configure as _configure, create_mem_pool, export_allocation_handles,
+                         export_runtime_state_handle, free_allocation, import_allocation_handles,
+                         import_runtime_state_handle)
 from ._utils import uint8_cuda_tensor_from_ptr
 
 _RendezvousCacheKey: TypeAlias = tuple[int, int, int]
@@ -40,8 +41,7 @@ def _normalize_size(size: tuple[object, ...]) -> tuple[int, ...]:
 
 
 @functools.lru_cache()
-def _get_mem_pool(device_index: int):
-    _ = device_index
+def _get_mem_pool():
     return create_mem_pool()
 
 
@@ -65,7 +65,7 @@ def empty(*size, dtype: torch.dtype | None = None, device: torch.device | str | 
     device_index = torch.cuda.current_device() if dev.index is None else dev.index
     dev = torch.device("cuda", device_index)
 
-    with torch.cuda.use_mem_pool(_get_mem_pool(device_index)):
+    with torch.cuda.use_mem_pool(_get_mem_pool()):
         return torch.empty(shape, dtype=dtype, device=dev)
 
 
@@ -75,6 +75,16 @@ def _resolve_group(group) -> tuple[dist.ProcessGroup, str]:
     if isinstance(group, str):
         return c10d._resolve_process_group(group), group
     raise TypeError(f"rendezvous: unsupported group type: {type(group)}")
+
+
+def configure(group, *, rng_seed: int | None = None, clock_buffer_size: int | None = None):
+    process_group, _ = _resolve_group(group)
+    _configure(
+        device_ranks={torch.cuda.current_device(): dist.get_rank(process_group)},
+        num_devices=dist.get_world_size(process_group),
+        rng_seed=rng_seed,
+        clock_buffer_size=clock_buffer_size,
+    )
 
 
 def _send_fds(
@@ -146,7 +156,7 @@ def _import_peer_ptrs(
                 import_runtime_state_handle(
                     peer_runtime_state_fd,
                     int(peer_runtime_state_alloc_size),
-                    int(metas[peer]["device_index"]),
+                    peer,
                     device_index,
                 )
     except Exception:
@@ -203,8 +213,10 @@ class GSanSymmetricMemoryHandle:
             raise NotImplementedError("Only channel=0 is supported in GSan symmetric memory.")
         _ = timeout_ms
         if self._world_size > 1:
+            torch.cuda.synchronize(self._device_index)
             dist.barrier(group=self._group)
             _stream_sync.synchronize_process_group_barrier(self._device_index, self._peer_device_indices)
+            torch.cuda.synchronize(self._device_index)
             dist.barrier(group=self._group)
 
     def get_buffer(
@@ -317,7 +329,7 @@ def rendezvous(tensor: torch.Tensor, group) -> GSanSymmetricMemoryHandle:
             device_index=device_index,
             buffer_size=buffer_size,
             peer_ptrs=(base_ptr, ),
-            peer_device_indices=(int(device_index), ),
+            peer_device_indices=(rank, ),
             cache_key=cache_key,
         )
         _RENDEZVOUS_CACHE[cache_key] = handle
@@ -357,7 +369,6 @@ def rendezvous(tensor: torch.Tensor, group) -> GSanSymmetricMemoryHandle:
         dist.all_gather_object(metas, local_meta, group=process_group)
 
         first = metas[0]
-        seen_device_indices: set[int] = set()
         for i, meta in enumerate(metas):
             if meta["hostname"] != first["hostname"]:
                 raise RuntimeError(
@@ -371,15 +382,10 @@ def rendezvous(tensor: torch.Tensor, group) -> GSanSymmetricMemoryHandle:
                 raise RuntimeError("rendezvous: all ranks must use tensors with identical byte size.")
             if meta["alloc_size"] != first["alloc_size"]:
                 raise RuntimeError("rendezvous: all ranks must use identical GSan allocation sizes.")
-            peer_device_index = int(meta["device_index"])
-            if peer_device_index in seen_device_indices:
-                raise RuntimeError(
-                    "rendezvous: all ranks must use unique CUDA device indices within the process group.")
-            seen_device_indices.add(peer_device_index)
             runtime_meta_size = meta["runtime_state_alloc_size"]
             if runtime_meta_size is not None and int(runtime_meta_size) <= 0:
                 raise RuntimeError("rendezvous: runtime_state_alloc_size must be > 0 when provided.")
-        peer_device_indices = tuple(int(meta["device_index"]) for meta in metas)
+        peer_device_indices = tuple(range(world_size))
 
         token_holder = [uuid.uuid4().hex if rank == 0 else None]
         dist.broadcast_object_list(token_holder, group=process_group, group_src=0)

--- a/test/TritonGPU/gsan.mlir
+++ b/test/TritonGPU/gsan.mlir
@@ -63,6 +63,29 @@ module attributes {"ttg.num-warps" = 1 : i32, "ttg.threads-per-warp" = 32 : i32}
 
 // -----
 
+#shared = #ttg.nvmma_shared<{swizzlingByteWidth = 128, transposed = false, elementBitWidth = 32}>
+#bar = #ttg.swizzled_shared<{vec = 1, perPhase = 1, maxPhase = 1, order = [0]}>
+#smem = #ttg.shared_memory
+
+module attributes {"ttg.num-warps" = 1 : i32, "ttg.threads-per-warp" = 32 : i32} {
+  // CHECK-LABEL: tt.func @instrumented_rank_reducing_tma_copy
+  tt.func @instrumented_rank_reducing_tma_copy(%desc: !tt.tensordesc<1x1x1x32x32xf32, #shared>) {
+    %true = arith.constant true
+    %c0_i32 = arith.constant 0 : i32
+    %buf = ttg.local_alloc {allocation.offset = 0 : i32} : () -> !ttg.memdesc<32x32xf32, #shared, #smem, mutable>
+    %barrier = ttg.local_alloc {allocation.offset = 4096 : i32} : () -> !ttg.memdesc<1xi64, #bar, #smem, mutable>
+    // CHECK: tti.experimental_gsan_tensor_access %{{.*}}, false, %{{.*}}
+    // CHECK-NEXT: ttng.async_tma_copy_global_to_local
+    ttng.async_tma_copy_global_to_local %desc[%c0_i32, %c0_i32, %c0_i32, %c0_i32, %c0_i32] %buf, %barrier, %true : !tt.tensordesc<1x1x1x32x32xf32, #shared>, !ttg.memdesc<1xi64, #bar, #smem, mutable> -> !ttg.memdesc<32x32xf32, #shared, #smem, mutable>
+    // CHECK: tti.experimental_gsan_tensor_access %{{.*}}, true, %{{.*}}
+    // CHECK-NEXT: ttng.async_tma_copy_local_to_global
+    ttng.async_tma_copy_local_to_global %desc[%c0_i32, %c0_i32, %c0_i32, %c0_i32, %c0_i32] %buf : !tt.tensordesc<1x1x1x32x32xf32, #shared>, !ttg.memdesc<32x32xf32, #shared, #smem, mutable>
+    tt.return
+  }
+}
+
+// -----
+
 #blocked_rows_parent = #ttg.blocked<{sizePerThread = [1, 4], threadsPerWarp = [32, 1], warpsPerCTA = [1, 1], order = [1, 0]}>
 #blocked_rows = #ttg.slice<{dim = 0, parent = #blocked_rows_parent}>
 #shared = #ttg.nvmma_shared<{swizzlingByteWidth = 128, transposed = false, elementBitWidth = 32}>

--- a/third_party/nvidia/backend/driver.py
+++ b/third_party/nvidia/backend/driver.py
@@ -324,7 +324,8 @@ class CudaLauncher(object):
         if self.gsan_enabled:
             import triton.experimental.gsan._allocator as gsan_allocator
             device = triton.runtime.driver.active.get_current_device()
-            gsan_state_ptr = gsan_allocator.get_global_state_pointer() + device * GSAN_PER_DEVICE_STATE_STRIDE
+            device_rank = gsan_allocator.get_device_rank(device)
+            gsan_state_ptr = gsan_allocator.get_global_state_pointer() + device_rank * GSAN_PER_DEVICE_STATE_STRIDE
             kernel_args = (*args, gsan_state_ptr)
 
         self.launch(gridX, gridY, gridZ, stream, function, self.launch_cooperative_grid, self.launch_pdl,


### PR DESCRIPTION
<git-pr-chain>


[GSan] Support multi-node topologies

This adds a `configure` function to gsan, which allows the user
to control some runtime config variables, and in particular the mapping
from device index to global device id. This enables gsan to work as part
of a multi-node nvlink domain.

Once either the user calls `gsan.freeze_config()` or an allocation
happens, the config is considered frozen and any future updates will
fail. This prevents the allocator from getting into an invalid state.

We can't actually test multi-node in CI, but I've added a test which
simulates it by running 2 process per gpu and mapping the same
GPU to different device ids in gsan.


#### [PR chain](https://github.com/jlebar/git-pr-chain)
1. #10576
1. 👉 #10577 👈 **YOU ARE HERE**
1. #10578
1. #10579

⚠️⚠️ Please **do not click the green "merge" button** unless you know what
you're doing.  This PR is part of a chain of PRs, and clicking the merge
button will not merge it into master. ⚠️⚠️ 
</git-pr-chain>




