### PR TITLE
Using`inspect.get_annotations()` to access annotations for PEP 649

### DIFF
--- a/python/triton/language/core.py
+++ b/python/triton/language/core.py
@@ -1609,7 +1609,6 @@ def _resolve_aggregate_fields(cls):
 
     # Add cls's own fields, resolving string annotations via typing.get_type_hints.
     own_names = inspect.get_annotations(cls)
-
     hints = typing.get_type_hints(cls)
     for name in own_names:
         all_annotations[name] = hints[name]

--- a/python/triton/language/core.py
+++ b/python/triton/language/core.py
@@ -1604,11 +1604,12 @@ def _resolve_aggregate_fields(cls):
             continue
         if not getattr(base, "__triton_aggregate__", False):
             raise TypeError(f"Aggregates can only inherit from other aggregates, but got non-aggregate base: {base}")
-        all_annotations.update(getattr(base, "__annotations__", {}))
+        all_annotations.update(inspect.get_annotations(base))
         all_defaults.update(getattr(base, "__aggregate_defaults__", {}))
 
     # Add cls's own fields, resolving string annotations via typing.get_type_hints.
-    own_names = cls.__dict__.get("__annotations__", {})
+    own_names = inspect.get_annotations(cls)
+
     hints = typing.get_type_hints(cls)
     for name in own_names:
         all_annotations[name] = hints[name]

--- a/python/triton/runtime/interpreter.py
+++ b/python/triton/runtime/interpreter.py
@@ -1311,7 +1311,7 @@ class GridExecutor:
         self.arg_names = arg_names
         self.grid = grid
         self.pre_run_hooks = pre_run_hooks
-        __annotations__ = {name: _normalize_ty(ty) for name, ty in fn.__annotations__.items()}
+        __annotations__ = {name: _normalize_ty(ty) for name, ty in inspect.get_annotations(fn).items()}
         self.constexprs = [name for name in arg_names if __annotations__.get(name) == "constexpr"]
 
     def _init_args_hst(self, args_dev, kwargs):


### PR DESCRIPTION
This fixes #10580 

Replaces outdated idioms for fetching annoatations with 
`inspect.get_annotations()`, primarily to fix `@aggregate`.

Previously, the frontend used idioms like 
`cls.__dict__.get("__annotations__", {})`, which meant that the 
lazification of pep-649 introduced in python 3.14 broke 
`@aggregate`, which reflected in test failures in 
`python/test/unit/language/test_frontend.py`.

The primary fix was to this line in `python/triton/language/core.py`:
```python
own_names = cls.__dict__.get("__annotations__", {})
````

This was changed to:
```python
own_names = inspect.get_annotations(cls)
```

This alone fixed the test failures in `test_frontend.py`, but I also 
grepped for other instanes of `__annotations__` being used and replaced 
them with `inspect.get_annotations()` since I'm not sure if these could
break in the future, and since using `inspect.get_annotations()` is 
mentioned in the python docs as a best practice.

# New contributor declaration
- [X] I am not making a trivial change, such as fixing a typo in a comment.

- [X] I have written a PR description following these
  [rules](https://cbea.ms/git-commit/#why-not-how).

- [X] I have run `pre-commit run --from-ref origin/main --to-ref HEAD`.

- Select one of the following.
  - [ ] I have added tests.
    - `/test` for `lit` tests
    - `/unittest` for C++ tests
    - `/python/test` for end-to-end tests
  - [X] This PR does not need a test because `test_frontend.py works as a nice test for this`.

- Select one of the following.
  - [X] I have not added any `lit` tests.
  - [ ] The `lit` tests I have added follow these [best practices](https://mlir.llvm.org/getting_started/TestingGuide/#filecheck-best-practices),
    including the "tests should be minimal" section. (Usually running Python code
    and using the instructions it generates is not minimal.)
