### PR TITLE
[Tools] Fix stdlib detection for base site packages

### DIFF
--- a/python/test/unit/tools/test_slice_kernel.py
+++ b/python/test/unit/tools/test_slice_kernel.py
@@ -164,6 +164,54 @@ def kernel() -> int:
     assert_code_equal(output, expected)
 
 
+def test_slice_kernel_does_not_treat_base_python_site_packages_as_stdlib_in_venv(tmp_path, monkeypatch):
+    fake_base_stdlib = tmp_path / "base" / "lib" / "python3.12"
+    fake_base_site_packages = fake_base_stdlib / "site-packages"
+    fake_venv_site_packages = tmp_path / "venv" / "lib" / "python3.12" / "site-packages"
+    fake_base_site_packages.mkdir(parents=True)
+    fake_venv_site_packages.mkdir(parents=True)
+    pkg, mod = _make_package(
+        fake_base_site_packages,
+        {
+            "helpers.py":
+            """
+                def helper() -> int:
+                    return 7
+            """,
+            "kernel_mod.py":
+            """
+                from .helpers import helper
+
+                def kernel() -> int:
+                    return helper()
+            """,
+        },
+    )
+
+    original_get_paths = sysconfig.get_paths
+
+    def fake_get_paths():
+        paths = original_get_paths().copy()
+        paths["stdlib"] = str(fake_base_stdlib)
+        paths["platstdlib"] = str(fake_base_stdlib)
+        paths["purelib"] = str(fake_venv_site_packages)
+        paths["platlib"] = str(fake_venv_site_packages)
+        return paths
+
+    monkeypatch.setattr(sysconfig, "get_paths", fake_get_paths)
+
+    output = slice_kernel([f"{mod('kernel_mod')}:kernel"], ["triton", "torch"], target=TranslatorTarget.GENERIC)
+    expected = R"""
+def helper() -> int:
+    return 7
+
+
+def kernel() -> int:
+    return helper()
+    """
+    assert_code_equal(output, expected)
+
+
 def test_slice_kernel_supports_injected_decorator_matchers(tmp_path):
     pkg, mod = _make_package(
         tmp_path,

--- a/python/triton/tools/triton_to_gluon_translator/slice_kernel.py
+++ b/python/triton/tools/triton_to_gluon_translator/slice_kernel.py
@@ -628,6 +628,12 @@ def is_stdlib_module(module: ModuleType) -> bool:
         return True
 
     origin_path = Path(origin)
+    # A virtual environment can load packages from its base Python installation.
+    # Those packages live below the base stdlib path, but are not included in the
+    # active environment's purelib or platlib paths.
+    if any(part in {"site-packages", "dist-packages"} for part in origin_path.parts):
+        return False
+
     sys_paths = sysconfig.get_paths()
     site_package_paths = [Path(sys_paths[key]) for key in ("purelib", "platlib") if key in sys_paths]
     if any(origin_path.is_relative_to(site_path) for site_path in site_package_paths):


### PR DESCRIPTION
## Summary

- classify modules under `site-packages` and `dist-packages` as third-party before checking stdlib roots
- handle virtual environments that can import packages from the base Python installation
- add a regression test with distinct base-Python and virtualenv package paths

## Testing

- `python/test/unit/tools/test_slice_kernel.py` (19 passed, 2 xfailed)