### PR TITLE
[*SAN] Avoid reading instrumentation_mode from knobs in the compiler

### DIFF
--- a/third_party/nvidia/backend/compiler.py
+++ b/third_party/nvidia/backend/compiler.py
@@ -522,7 +522,7 @@ class CUDABackend(BaseBackend):
             # -Ofc mid miscompiles some large ConSan kernels into invalid global
             # accesses; -O1 keeps compile time reasonable without that ptxas bug.
             if (not knobs.nvidia.disable_ptxas_opt
-                    and any(mode in knobs.compilation.instrumentation_mode for mode in ["consan", "fpsan"])):
+                    and any(mode in opt.instrumentation_mode for mode in ["consan", "fpsan"])):
                 ptx_extra_options += ["--opt-level", "1"]
 
             # Add --regAllocOptLevel=2 to work around ptxas 13.x bug


### PR DESCRIPTION
For reading `instrumentation_mode` in the compiler we should use the value passed as the triton function argument, instead of reading it from knobs. If the client is using triton.compile instead of jitfunction.run this might have led to inconsistencies, as the former does not update function kwargs.