### PR TITLE
[triton_kernels] Preserve Gluon specialization dialect

### DIFF
--- a/python/triton_kernels/tests/test_specialize.py
+++ b/python/triton_kernels/tests/test_specialize.py
@@ -1,4 +1,5 @@
 import importlib
+import inspect
 import types
 
 import torch
@@ -101,11 +102,13 @@ def test_cacheable(device, fresh_triton_cache, monkeypatch):
 
     # check line info in ttir
     ttir = k.asm["ttir"]
+    source, start_line = inspect.getsourcelines(template_kernel.fn)
+    store_line = start_line + next(i for i, line in enumerate(source) if "tl.store" in line)
     loc = None
     for line in ttir.split("\n"):
         if loc and loc in line:
             assert "test_specialize.py" in line
-            assert ":18:5" in line
+            assert f":{store_line}:5" in line
         if "store" in line:
             loc = line.split("(", 1)[1].split(")", 1)[0]
     assert loc is not None, f"Expected to find a store instruction with location info, got: {ttir}"

--- a/python/triton_kernels/tests/test_specialize.py
+++ b/python/triton_kernels/tests/test_specialize.py
@@ -1,13 +1,22 @@
 import importlib
+import types
 
 import torch
-from triton_kernels.specialize import cacheable, specialize
 import triton
 import triton.language as tl
+from triton.experimental import gluon
+from triton.experimental.gluon import GluonJITFunction
+import triton.experimental.gluon.language as gl
+from triton_kernels.specialize import ClosureArg, FnSpecs, SpecializationModule, cacheable, specialize
 
 
 @triton.jit
 def identity(x):
+    return x
+
+
+@gluon.jit
+def gluon_identity(x):
     return x
 
 
@@ -16,6 +25,27 @@ def template_kernel(o, fn: tl.constexpr):
     cst = 1.0
     cst = fn(cst)
     tl.store(o, cst)
+
+
+@gluon.jit
+def gluon_template_kernel(o, fn: gl.constexpr, fn_args):
+    cst = fn(1.0, *fn_args)
+    gl.store(o, cst)
+
+
+def test_specialization_module_preserves_gluon_dialect():
+    specializations = SpecializationModule(
+        "specialized_gluon_kernel",
+        kernels=[("kernel", gluon_template_kernel)],
+        closure_args={"fn": ClosureArg("fn", "fn_args")},
+    )
+
+    module = specializations.get(fn=FnSpecs("identity", gluon_identity))
+
+    assert isinstance(module, types.ModuleType)
+    assert isinstance(module.kernel, GluonJITFunction)
+    assert module.kernel.is_gluon()
+    assert "fn: gl.constexpr = gluon_identity" in module.kernel.src
 
 
 def retrieve_fn(module, name):

--- a/python/triton_kernels/tests/test_specialize.py
+++ b/python/triton_kernels/tests/test_specialize.py
@@ -2,11 +2,11 @@ import importlib
 import inspect
 import types
 
+import pytest
 import torch
 import triton
 import triton.language as tl
 from triton.experimental import gluon
-from triton.experimental.gluon import GluonJITFunction
 import triton.experimental.gluon.language as gl
 from triton_kernels.specialize import ClosureArg, FnSpecs, SpecializationModule, cacheable, specialize
 
@@ -34,19 +34,33 @@ def gluon_template_kernel(o, fn: gl.constexpr, fn_args):
     gl.store(o, cst)
 
 
-def test_specialization_module_preserves_gluon_dialect():
+@triton.jit
+def triton_dialect_template_kernel(o, fn: tl.constexpr, fn_args):
+    cst = fn(1.0, *fn_args)
+    tl.store(o, cst)
+
+
+@pytest.mark.parametrize(
+    "template_fn,specialized_fn,lang_module",
+    [
+        (triton_dialect_template_kernel, identity, "tl"),
+        (gluon_template_kernel, gluon_identity, "gl"),
+    ],
+)
+def test_specialization_module_preserves_dialect(template_fn, specialized_fn, lang_module):
     specializations = SpecializationModule(
-        "specialized_gluon_kernel",
-        kernels=[("kernel", gluon_template_kernel)],
+        f"specialized_{lang_module}_kernel",
+        kernels=[("kernel", template_fn)],
         closure_args={"fn": ClosureArg("fn", "fn_args")},
     )
 
-    module = specializations.get(fn=FnSpecs("identity", gluon_identity))
+    module = specializations.get(fn=FnSpecs("identity", specialized_fn))
 
     assert isinstance(module, types.ModuleType)
-    assert isinstance(module.kernel, GluonJITFunction)
-    assert module.kernel.is_gluon()
-    assert "fn: gl.constexpr = gluon_identity" in module.kernel.src
+    # GluonJITFunction subclasses JITFunction, so exact class equality is required here.
+    assert module.kernel.__class__ is template_fn.__class__
+    assert module.kernel.is_gluon() == template_fn.is_gluon()
+    assert f"fn: {lang_module}.constexpr = {specialized_fn.__name__}" in module.kernel.src
 
 
 def retrieve_fn(module, name):

--- a/python/triton_kernels/triton_kernels/specialize.py
+++ b/python/triton_kernels/triton_kernels/specialize.py
@@ -29,7 +29,7 @@ def cacheable(f):
     return g
 
 
-def define_kernel(src, module, attrs=None, **extra_globals):
+def define_kernel(src, module, attrs=None, jit_function_cls=triton.JITFunction, **extra_globals):
     """
     Dynamically create a Triton function or kernel from a src string,
     linking any symbols in the kernel to objects specified by extra_globals.
@@ -60,7 +60,7 @@ def define_kernel(src, module, attrs=None, **extra_globals):
 
     if attrs is None:
         attrs = dict()
-    f = triton.JITFunction(f, **attrs)
+    f = jit_function_cls(f, **attrs)
     f._unsafe_update_src(src)
     return f
 
@@ -118,8 +118,10 @@ def specialize(fn, module, constants, tuples, name=None, do_not_specialize=tuple
     globals = spec_fns | fn.get_capture_scope()
     # build new source code and define kernel dynamically
     new_signature = f"def {name}({', '.join(non_specialized_args)}):"
+    lang_module = "gl" if fn.is_gluon() else "tl"
     constexpr_lines = [
-        f"    {key}: tl.constexpr = {value.__name__ if callable(value) else value}" for key, value in constants.items()
+        f"    {key}: {lang_module}.constexpr = {value.__name__ if callable(value) else value}"
+        for key, value in constants.items()
     ]
     tuple_lines = [
         f"    {key} = {'(' + ','.join(value) + (',' if len(value)>=1 else '') + ')'}" for key, value in tuples.items()
@@ -153,7 +155,7 @@ def specialize(fn, module, constants, tuples, name=None, do_not_specialize=tuple
 
     if do_not_specialize:
         attrs["do_not_specialize"] = do_not_specialize
-    ret = define_kernel(new_src, module, attrs, **globals)
+    ret = define_kernel(new_src, module, attrs, jit_function_cls=type(fn), **globals)
 
     # Reuse the original kernel's metadata so that stack traces and other
     # source-based tooling report the correct file and line numbers.


### PR DESCRIPTION
## Summary

- preserve the template JIT function class when dynamically specializing kernels
- emit the matching `gl.constexpr` or `tl.constexpr` namespace
- add a regression test covering Gluon kernels returned by `SpecializationModule.get()`

## Testing

- `python -m pytest -s --tb=short python/triton_kernels/tests/test_specialize.py::test_specialization_module_preserves_gluon_dialect`
- `python -m ruff check python/triton_kernels/triton_kernels/specialize.py python/triton_kernels/tests/test_specialize.py`
- `python3 -m py_compile python/triton_kernels/triton_kernels/specialize.py python/triton_kernels/tests/test_specialize.py`