### PR TITLE
[FRONTEND] Fix INT_MIN signed overflow in uint_to_uniform_float

### DIFF
--- a/python/test/unit/language/test_random.py
+++ b/python/test/unit/language/test_random.py
@@ -247,14 +247,15 @@ def test_randn(size, seed, dtype, device, const_seed):
     assert abs(x.std() - 1) < 1e-2
 
 
-# tl.rand() should never produce >=1.0
+# tl.rand() should never produce >=1.0. With debug=True, this also guards the
+# int32 fold against the INT_MIN overflow that tripped the sanitizer (#10597).
 
 
 @pytest.mark.interpreter
 @pytest.mark.parametrize('dtype', ['int32', 'int64'])
 def test_rand_limits(dtype, device):
 
-    @triton.jit
+    @triton.jit(debug=True)
     def kernel(input, output, n: tl.constexpr):
         idx = tl.arange(0, n)
         x = tl.load(input + idx)

--- a/python/triton/language/random.py
+++ b/python/triton/language/random.py
@@ -139,7 +139,7 @@ def uint_to_uniform_float(x):
         tl.static_assert(tl.constexpr(x.dtype == tl.uint64) or tl.constexpr(x.dtype == tl.int64))
         x = x.to(tl.int64, bitcast=True)
         scale = 1.0842020432385337e-19
-    x = tl.where(x < 0, -x - 1, x)
+    x = tl.where(x < 0, ~x, x)
     return x * scale
 
 


### PR DESCRIPTION
`uint_to_uniform_float` folds negative integers to non-negative values with
`-x - 1`. Evaluating `-x` first computes `0 - x`, which signed-overflows when
`x == INT_MIN` (`-2**31` on the int32/uint32 path). Signed overflow is undefined
behavior, and Triton's overflow sanitizer flags it: a kernel compiled with
`debug=True` emits a device-side assertion (`int32 overflow detected for
operation sub`) that aborts whenever the PRNG produces the bit pattern that maps
to `INT_MIN`. This was reported in #10597.

`~x` is the bitwise complement, which equals `-x - 1` for every value in two's
complement. The random stream is therefore bit-for-bit identical, but the fold
is now a single `xor` that never overflows, so the spurious assertion is gone.

The existing `test_rand_limits` already feeds `INT_MIN`/`INT_MAX` through the
fold. Compiling its kernel with `@triton.jit(debug=True)` arms the overflow
sanitizer on that path, so the test now regresses if the fold reintroduces an
overflowing operation.

Fixes #10597.
