### PR TITLE
[Hopper] Fix if-result data partition slicing

### DIFF
--- a/test/Hopper/WarpSpecialization/ws_data_partition.mlir
+++ b/test/Hopper/WarpSpecialization/ws_data_partition.mlir
@@ -151,3 +151,37 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.targ
     tt.return
   }
 }
+
+// -----
+
+// CHECK-LABEL: @if_result_backward_slice
+#blocked = #ttg.blocked<{sizePerThread = [1, 1], threadsPerWarp = [1, 32], warpsPerCTA = [2, 2], order = [1, 0]}>
+#blocked1 = #ttg.blocked<{sizePerThread = [1, 1], threadsPerWarp = [1, 32], warpsPerCTA = [1, 4], order = [1, 0]}>
+#mma = #ttg.nvidia_mma<{versionMajor = 3, versionMinor = 0, warpsPerCTA = [4, 1], instrShape = [16, 256, 16]}>
+#shared = #ttg.nvmma_shared<{swizzlingByteWidth = 128, transposed = false, elementBitWidth = 16}>
+#smem = #ttg.shared_memory
+module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.target = "cuda:90", "ttg.threads-per-warp" = 32 : i32} {
+  tt.func public @if_result_backward_slice(%arg0: !tt.ptr<f16>, %arg1: tensor<64x256xf16, #blocked1>) {
+    %true = arith.constant true
+    %cst = arith.constant {async_task_id = array<i32: 1, 2>} dense<0.000000e+00> : tensor<128x256xf32, #mma>
+    %ptr = tt.splat %arg0 {async_task_id = array<i32: 0>} : !tt.ptr<f16> -> tensor<128x64x!tt.ptr<f16>, #blocked>
+    // CHECK: %[[#LOAD1:]] = tt.load {{.*}} : tensor<64x64x!tt.ptr<f16>
+    // CHECK: %[[#LOAD2:]] = tt.load {{.*}} : tensor<64x64x!tt.ptr<f16>
+    %load = tt.load %ptr {async_task_id = array<i32: 0>} : tensor<128x64x!tt.ptr<f16>, #blocked>
+    // CHECK: %[[#ALLOC1:]] = ttg.local_alloc %[[#LOAD1]]
+    // CHECK: %[[#ALLOC2:]] = ttg.local_alloc %[[#LOAD2]]
+    %alloc = ttg.local_alloc %load {async_task_id = array<i32: 1, 2>} : (tensor<128x64xf16, #blocked>) -> !ttg.memdesc<128x64xf16, #shared, #smem>
+    // CHECK: scf.if {{.*}} -> (!ttg.memdesc<64x64xf16
+    // CHECK: scf.if {{.*}} -> (!ttg.memdesc<64x64xf16
+    %maybe_alloc = scf.if %true -> (!ttg.memdesc<128x64xf16, #shared, #smem>) {
+      scf.yield {async_task_id = array<i32: 1, 2>} %alloc : !ttg.memdesc<128x64xf16, #shared, #smem>
+    } else {
+      scf.yield {async_task_id = array<i32: 1, 2>} %alloc : !ttg.memdesc<128x64xf16, #shared, #smem>
+    }
+    %rhs = ttg.local_alloc %arg1 {async_task_id = array<i32: 1, 2>} : (tensor<64x256xf16, #blocked1>) -> !ttg.memdesc<64x256xf16, #shared, #smem>
+    // CHECK: ttng.warp_group_dot {{.*}} : !ttg.memdesc<64x64xf16, #shared, #smem> * !ttg.memdesc<64x256xf16, #shared, #smem> -> tensor<64x256xf32, #mma>
+    // CHECK: ttng.warp_group_dot {{.*}} : !ttg.memdesc<64x64xf16, #shared, #smem> * !ttg.memdesc<64x256xf16, #shared, #smem> -> tensor<64x256xf32, #mma>
+    %dot = ttng.warp_group_dot %maybe_alloc, %rhs, %cst {async_task_id = array<i32: 1, 2>, inputPrecision = 0 : i32} : !ttg.memdesc<128x64xf16, #shared, #smem> * !ttg.memdesc<64x256xf16, #shared, #smem> -> tensor<128x256xf32, #mma>
+    tt.return
+  }
+}

--- a/third_party/nvidia/hopper/lib/Transforms/WarpSpecialization/WSDataPartition.cpp
+++ b/third_party/nvidia/hopper/lib/Transforms/WarpSpecialization/WSDataPartition.cpp
@@ -320,8 +320,8 @@ static bool getBackwardSliceToPartition(Value v,
       partitionScheme.opPartitionDims[ifOp.elseYield()] = currentDim;
       auto thenYieldArg = ifOp.thenYield().getOperand(resultIndex);
       auto elseYieldArg = ifOp.elseYield().getOperand(resultIndex);
-      if (getBackwardSliceToPartition(thenYieldArg, partitionScheme,
-                                      currentDim))
+      if (!getBackwardSliceToPartition(thenYieldArg, partitionScheme,
+                                       currentDim))
         return false;
       if (!getBackwardSliceToPartition(elseYieldArg, partitionScheme,
                                        currentDim))


### PR DESCRIPTION
# New contributor declaration
- [x] I am not making a trivial change, such as fixing a typo in a comment.

- [x] I have written a PR description following these
  [rules](https://cbea.ms/git-commit/#why-not-how).

- [x] I have run `pre-commit run --from-ref origin/main --to-ref HEAD`.

- Select one of the following.
  - [x] I have added tests.
    - `/test` for `lit` tests
    - `/unittest` for C++ tests
    - `/python/test` for end-to-end tests
  - [ ] This PR does not need a test because `FILL THIS IN`.

- Select one of the following.
  - [ ] I have not added any `lit` tests.
  - [x] The `lit` tests I have added follow these [best practices](https://mlir.llvm.org/getting_started/TestingGuide/#filecheck-best-practices),
    including the "tests should be minimal" section. (Usually running Python code
    and using the instructions it generates is not minimal.)

## Why

Fixes #9559.

`getBackwardSliceToPartition` returns `true` when a value can be sliced and `false` when partitioning should fail. The `scf.if` result path handled the else yield with `if (!getBackwardSliceToPartition(...)) return false;`, but the then yield used the opposite polarity. That made a successful then-yield backward slice abort the whole data partition.

This matters when a warp-specialized value flows through an `scf.if` before reaching a partitioned consumer such as `ttng.warp_group_dot`: the then and else yield operands both have to be followed backward before the result can be sliced.

## What changed

- Make the then-yield recursive check use the same success polarity as the else-yield path.
- Add a `ws_data_partition.mlir` regression where a `ttg.local_alloc` result is yielded through both arms of an `scf.if` and then consumed by `ttng.warp_group_dot`.

There was an earlier closed PR for the one-line code change (#9794). This version adds a focused lit regression and avoids carrying unrelated metadata.

## Testing

- `pre-commit run --from-ref upstream/main --to-ref HEAD`
- `pre-commit run --files third_party/nvidia/hopper/lib/Transforms/WarpSpecialization/WSDataPartition.cpp test/Hopper/WarpSpecialization/ws_data_partition.mlir`
- `git diff --check upstream/main..HEAD`

I could not run the lit invocation locally because this Windows checkout does not have `triton-opt` / `FileCheck` binaries available. The added test is intended for the existing CI command:

```bash
triton-opt test/Hopper/WarpSpecialization/ws_data_partition.mlir -split-input-file --nvgpu-test-ws-data-partition=num-warp-groups=3 | FileCheck test/Hopper/WarpSpecialization/ws_data_partition.mlir
```
