### PR TITLE
Fix random uniform conversion overflow

### DIFF
--- a/python/test/unit/language/test_random.py
+++ b/python/test/unit/language/test_random.py
@@ -5,6 +5,7 @@ import torch
 
 import triton
 import triton.language as tl
+from triton._internal_testing import run_in_process
 
 #####################################
 # Reference Philox Implementation
@@ -250,9 +251,7 @@ def test_randn(size, seed, dtype, device, const_seed):
 # tl.rand() should never produce >=1.0
 
 
-@pytest.mark.interpreter
-@pytest.mark.parametrize('dtype', ['int32', 'int64'])
-def test_rand_limits(dtype, device):
+def _run_rand_limits(dtype, device):
 
     @triton.jit
     def kernel(input, output, n: tl.constexpr):
@@ -271,3 +270,14 @@ def test_rand_limits(dtype, device):
 
     assert output[0] == output[1]
     assert 1.0 - torch.finfo(torch.float32).eps <= output[0].item() < 1.0
+
+
+@pytest.mark.interpreter
+@pytest.mark.parametrize('dtype', ['int32', 'int64'])
+@pytest.mark.parametrize('debug', [False, True])
+def test_rand_limits(dtype, debug, device):
+    if debug:
+        result = run_in_process(_run_rand_limits, (dtype, device), env={"TRITON_DEBUG": "1"})
+        assert result.exc is None, result.exc
+    else:
+        _run_rand_limits(dtype, device)

--- a/python/triton/language/random.py
+++ b/python/triton/language/random.py
@@ -139,7 +139,7 @@ def uint_to_uniform_float(x):
         tl.static_assert(tl.constexpr(x.dtype == tl.uint64) or tl.constexpr(x.dtype == tl.int64))
         x = x.to(tl.int64, bitcast=True)
         scale = 1.0842020432385337e-19
-    x = tl.where(x < 0, -x - 1, x)
+    x = tl.where(x < 0, x ^ -1, x)
     return x * scale
 
 


### PR DESCRIPTION
# New contributor declaration
- [x] I am not making a trivial change, such as fixing a typo in a comment.

- [x] I have written a PR description following these rules.

- [x] I have run `pre-commit run --from-ref upstream/main --to-ref HEAD`.
  - Local note: in this checkout `origin` is my fork and `upstream` is `triton-lang/triton`, so `upstream/main` is the base branch equivalent of the template's `origin/main`.

- Select one of the following.
  - [x] I have added tests.
    - `/python/test` for end-to-end tests
  - [ ] This PR does not need a test because `FILL THIS IN`.

- Select one of the following.
  - [x] I have not added any `lit` tests.
  - [ ] The `lit` tests I have added follow these best practices, including the "tests should be minimal" section.

## Summary

`tl.random.uint_to_uniform_float()` maps the signed view of random integers into a non-negative magnitude before scaling into `[0, 1)`. The negative branch currently uses `-x - 1`, which is equivalent to a bitwise complement for normal values but overflows for the signed minimum value under overflow sanitization.

This changes that branch to `x ^ -1`, which is the same two's-complement mapping without doing a signed negation. The existing min/max boundary test now also runs under `TRITON_DEBUG=1`, so the sanitizer path covers this edge case.

Fixes #10597.

## Verification

Passed:
- `python -m py_compile python\triton\language\random.py python\test\unit\language\test_random.py`
- `pre-commit run --files python\triton\language\random.py python\test\unit\language\test_random.py`
- `pre-commit run --from-ref upstream/main --to-ref HEAD`
- `git diff --check`

Not run locally:
- `PYTHONPATH=python python -m pytest python\test\unit\language\test_random.py -q -k rand_limits`

That pytest command failed during collection in this Windows checkout because the compiled local extension is not built: `ImportError: cannot import name 'getenv' from 'triton._C.libtriton'`.
