### PR TITLE
Guard cudagraph benchmarking during active capture

### DIFF
--- a/python/test/unit/runtime/test_testing.py
+++ b/python/test/unit/runtime/test_testing.py
@@ -1,0 +1,24 @@
+from unittest import mock
+
+import pytest
+import torch
+
+import triton
+
+
+@pytest.mark.parametrize(
+    "bench_name",
+    ["do_bench_cudagraph", "do_bench_cudagraph_proton"],
+)
+def test_cudagraph_bench_rejects_active_capture(bench_name):
+    bench = getattr(triton.testing, bench_name)
+
+    with (
+            mock.patch.object(torch.cuda, "is_available", return_value=True),
+            mock.patch.object(torch.cuda, "is_current_stream_capturing", return_value=True),
+            mock.patch.object(torch.cuda, "synchronize") as synchronize,
+    ):
+        with pytest.raises(RuntimeError, match="Warm up autotuned kernels"):
+            bench(lambda: None)
+
+    synchronize.assert_not_called()

--- a/python/test/unit/runtime/test_testing.py
+++ b/python/test/unit/runtime/test_testing.py
@@ -6,19 +6,13 @@ import torch
 import triton
 
 
-@pytest.mark.parametrize(
-    "bench_name",
-    ["do_bench_cudagraph", "do_bench_cudagraph_proton"],
-)
-def test_cudagraph_bench_rejects_active_capture(bench_name):
-    bench = getattr(triton.testing, bench_name)
-
+def test_do_bench_cudagraph_rejects_active_capture():
     with (
-            mock.patch.object(torch.cuda, "is_available", return_value=True),
-            mock.patch.object(torch.cuda, "is_current_stream_capturing", return_value=True),
-            mock.patch.object(torch.cuda, "synchronize") as synchronize,
+        mock.patch.object(torch.cuda, "is_available", return_value=True),
+        mock.patch.object(torch.cuda, "is_current_stream_capturing", return_value=True),
+        mock.patch.object(torch.cuda, "synchronize") as synchronize,
     ):
         with pytest.raises(RuntimeError, match="Warm up autotuned kernels"):
-            bench(lambda: None)
+            triton.testing.do_bench_cudagraph(lambda: None)
 
     synchronize.assert_not_called()

--- a/python/triton/testing.py
+++ b/python/triton/testing.py
@@ -116,8 +116,9 @@ def do_bench_cudagraph(fn, rep=20, grad_to_none=None, quantiles=None, return_mod
     import torch
     assert return_mode in ["min", "max", "mean", "median", "all"]
     if _is_current_cuda_stream_capturing(torch):
-        raise RuntimeError("do_bench_cudagraph cannot benchmark while the current CUDA stream is being captured. "
-                           "Warm up autotuned kernels before entering torch.cuda.graph(...).")
+        raise RuntimeError(
+            "do_bench_cudagraph cannot benchmark while the current CUDA stream is being captured. "
+            "Warm up autotuned kernels before entering torch.cuda.graph(...).")
 
     with torch.cuda.stream(torch.cuda.Stream()):
         # warmup
@@ -192,10 +193,6 @@ def do_bench_cudagraph_proton(fn, rep=20, grad_to_none=None, quantiles=None, ret
     assert return_mode in ["min", "max", "mean", "median", "all"]
 
     import torch
-    if _is_current_cuda_stream_capturing(torch):
-        raise RuntimeError(
-            "do_bench_cudagraph_proton cannot benchmark while the current CUDA stream is being captured. "
-            "Warm up autotuned kernels before entering torch.cuda.graph(...).")
 
     target = runtime.driver.active.get_current_target()
     if target.backend != "cuda":

--- a/python/triton/testing.py
+++ b/python/triton/testing.py
@@ -96,6 +96,10 @@ def _collect_proton_scope_times(database, prefix):
     return [time for _, time in sorted(scope_times)]
 
 
+def _is_current_cuda_stream_capturing(torch):
+    return torch.cuda.is_available() and torch.cuda.is_current_stream_capturing()
+
+
 def do_bench_cudagraph(fn, rep=20, grad_to_none=None, quantiles=None, return_mode="mean"):
     """
     Benchmark the runtime of the provided function.
@@ -111,6 +115,9 @@ def do_bench_cudagraph(fn, rep=20, grad_to_none=None, quantiles=None, return_mod
     """
     import torch
     assert return_mode in ["min", "max", "mean", "median", "all"]
+    if _is_current_cuda_stream_capturing(torch):
+        raise RuntimeError("do_bench_cudagraph cannot benchmark while the current CUDA stream is being captured. "
+                           "Warm up autotuned kernels before entering torch.cuda.graph(...).")
 
     with torch.cuda.stream(torch.cuda.Stream()):
         # warmup
@@ -184,12 +191,16 @@ def do_bench_cudagraph_proton(fn, rep=20, grad_to_none=None, quantiles=None, ret
     """
     assert return_mode in ["min", "max", "mean", "median", "all"]
 
+    import torch
+    if _is_current_cuda_stream_capturing(torch):
+        raise RuntimeError(
+            "do_bench_cudagraph_proton cannot benchmark while the current CUDA stream is being captured. "
+            "Warm up autotuned kernels before entering torch.cuda.graph(...).")
+
     target = runtime.driver.active.get_current_target()
     if target.backend != "cuda":
         raise RuntimeError("do_bench_cudagraph_proton requires the NVIDIA backend because Proton does not reliably "
                            "attribute CUDA graph replay launches to scopes on HIP.")
-
-    import torch
 
     with torch.cuda.stream(torch.cuda.Stream()):
         fn()


### PR DESCRIPTION
Fixes #10596.

`do_bench_cudagraph` calls `torch.cuda.synchronize()` while estimating and replaying the graph. If autotuning reaches it from inside an already-active CUDA graph capture, that synchronize call is not just unsupported; it invalidates the capture stream and the user gets a lower-level `cudaErrorStreamCaptureInvalidated` after the fact.

This keeps the existing expectation that autotuned kernels should be warmed before entering `torch.cuda.graph(...)`, but makes the failure mode explicit and non-destructive:

- detect an active CUDA stream capture before creating benchmark streams/events
- raise a clear `RuntimeError` that tells users to warm up autotuned kernels first
- apply the same guard to the Proton CUDA-graph benchmark variant
- cover the guard with a CPU-safe unit test using mocked CUDA capture state

# New contributor declaration
- [x] I am not making a trivial change, such as fixing a typo in a comment.

- [x] I have written a PR description following these
  [rules](https://cbea.ms/git-commit/#why-not-how).

- [x] I have run `pre-commit run --from-ref upstream/main --to-ref HEAD`.

- Select one of the following.
  - [x] I have added tests.
    - `/test` for `lit` tests
    - `/unittest` for C++ tests
    - `/python/test` for end-to-end tests
  - [ ] This PR does not need a test because `FILL THIS IN`.

- Select one of the following.
  - [x] I have not added any `lit` tests.
  - [ ] The `lit` tests I have added follow these [best practices](https://mlir.llvm.org/getting_started/TestingGuide/#filecheck-best-practices),
    including the "tests should be minimal" section. (Usually running Python code
    and using the instructions it generates is not minimal.)

Validation:
- `python -m py_compile python/triton/testing.py python/test/unit/runtime/test_testing.py`
- `python -m ruff check python/triton/testing.py python/test/unit/runtime/test_testing.py`
- `git diff --check`
- `pre-commit run --from-ref upstream/main --to-ref HEAD`
- stubbed guard smoke test that imports `python/triton/testing.py` with lightweight module stubs and verifies both cudagraph benchmark helpers reject active capture before `torch.cuda.synchronize()`

I could not run `python -m pytest python/test/unit/runtime/test_testing.py -q` in this Windows checkout because the local Triton C extension is not built (`ImportError: cannot import name 'getenv' from 'triton._C.libtriton'`).
