### PR TITLE
[AMD][gfx1250] TDM: add regression test for the uniform tensor_dim clamp

### DIFF
--- a/third_party/amd/python/test/test_tdm_copy.py
+++ b/third_party/amd/python/test/test_tdm_copy.py
@@ -248,16 +248,12 @@ def tdm_clamp_kernel(a_ptr, M, N, BLOCK_M: ttgl.constexpr, BLOCK_N: ttgl.constex
 
 
 def test_compile_tdm_clamp_no_readfirstlane():
-    """Regression guard for the TDM tensor_dim clamp staying uniform (SGPR), #10517.
+    """The TDM tensor_dim clamp must stay uniform (SGPR).
 
-    The pre-#10517 clamp shape ``select(icmp_ule(dim - off, dim), dim - off, 0)``
-    is not recognized as uniform by LLVM's AMDGPU uniformity passes, so it is
-    demoted to VALU; the TDM lowering then has to recover the descriptor offset
-    with ``v_readfirstlane_b32`` next to each ``tensor_load_to_lds`` inside the
-    loop (which mismatched the VGPR MSB and produced wrong offsets / NaNs).  The
-    fixed shape ``select(off < 0, 0, smax(dim - off, 0))`` stays in SGPRs, so a
-    TDM load whose offsets exercise the clamp must lower with no
-    ``v_readfirstlane_b32``.
+    A non-uniform clamp is demoted to VALU and has to be read back into an SGPR
+    with ``v_readfirstlane`` next to each ``tensor_load_to_lds``, adding latency
+    to every TDM load.  A TDM load whose offsets exercise the clamp must lower
+    with none.
     """
     signature = {"a_ptr": "*fp16", "M": "i32", "N": "i32", "BLOCK_M": "constexpr", "BLOCK_N": "constexpr"}
     k = triton.compile(
@@ -270,10 +266,7 @@ def test_compile_tdm_clamp_no_readfirstlane():
         options={"num_warps": 4},
     )
     amdgcn = k.asm["amdgcn"]
-    assert "tensor_load_to_lds" in amdgcn, amdgcn
-    n_readfirstlane = len(re.findall(r"v_readfirstlane_b32", amdgcn))
-    assert n_readfirstlane == 0, (f"TDM tensor_dim clamp regressed to VALU: {n_readfirstlane} "
-                                  f"v_readfirstlane_b32 in the lowered kernel\n{amdgcn}")
+    assert "v_readfirstlane" not in amdgcn, f"TDM tensor_dim clamp regressed to VALU (v_readfirstlane emitted)\n{amdgcn}"
 
 
 _RUNTIME_BLOCK_SHAPES = [(64, 64), (128, 64)]

--- a/third_party/amd/python/test/test_tdm_copy.py
+++ b/third_party/amd/python/test/test_tdm_copy.py
@@ -231,6 +231,51 @@ def test_compile_vector_add_tdm(BLOCK_M, BLOCK_N, HINT_A, HINT_B):
                         f"HINT_B=0b{HINT_B:08b}, got {n_tdm}\n{amdgcn}")
 
 
+@gluon.jit
+def tdm_clamp_kernel(a_ptr, M, N, BLOCK_M: ttgl.constexpr, BLOCK_N: ttgl.constexpr):
+    """Single TDM load whose offsets exercise the tensor_dim OOB clamp."""
+    SHARED_LAYOUT: ttgl.constexpr = ttgl.PaddedSharedLayout.with_identity_for([[32, 4]], [BLOCK_M, BLOCK_N], [1, 0])
+    BLOCKED_LAYOUT: ttgl.constexpr = ttgl.BlockedLayout([1, 8], [4, 8], [4, 1], [1, 0])
+
+    off_m = ttgl.program_id(axis=0) * BLOCK_M
+    off_n = ttgl.program_id(axis=1) * BLOCK_N
+    desc = ttgl.amd.gfx1250.tdm.make_tensor_descriptor(base=a_ptr, shape=(M, N), strides=(N, 1),
+                                                       block_shape=(BLOCK_M, BLOCK_N), layout=SHARED_LAYOUT)
+    buf = ttgl.allocate_shared_memory(desc.dtype, desc.block_shape, desc.layout)
+    ttgl.amd.gfx1250.tdm.async_load(desc, [off_m, off_n], buf)
+    ttgl.amd.gfx1250.tdm.async_wait(0)
+    buf.load(layout=BLOCKED_LAYOUT)
+
+
+def test_compile_tdm_clamp_no_readfirstlane():
+    """Regression guard for the TDM tensor_dim clamp staying uniform (SGPR), #10517.
+
+    The pre-#10517 clamp shape ``select(icmp_ule(dim - off, dim), dim - off, 0)``
+    is not recognized as uniform by LLVM's AMDGPU uniformity passes, so it is
+    demoted to VALU; the TDM lowering then has to recover the descriptor offset
+    with ``v_readfirstlane_b32`` next to each ``tensor_load_to_lds`` inside the
+    loop (which mismatched the VGPR MSB and produced wrong offsets / NaNs).  The
+    fixed shape ``select(off < 0, 0, smax(dim - off, 0))`` stays in SGPRs, so a
+    TDM load whose offsets exercise the clamp must lower with no
+    ``v_readfirstlane_b32``.
+    """
+    signature = {"a_ptr": "*fp16", "M": "i32", "N": "i32", "BLOCK_M": "constexpr", "BLOCK_N": "constexpr"}
+    k = triton.compile(
+        gluon._runtime.GluonASTSource(
+            fn=tdm_clamp_kernel,
+            signature=signature,
+            constexprs={"BLOCK_M": 64, "BLOCK_N": 64},
+        ),
+        target=GPUTarget("hip", "gfx1250", 32),
+        options={"num_warps": 4},
+    )
+    amdgcn = k.asm["amdgcn"]
+    assert "tensor_load_to_lds" in amdgcn, amdgcn
+    n_readfirstlane = len(re.findall(r"v_readfirstlane_b32", amdgcn))
+    assert n_readfirstlane == 0, (f"TDM tensor_dim clamp regressed to VALU: {n_readfirstlane} "
+                                  f"v_readfirstlane_b32 in the lowered kernel\n{amdgcn}")
+
+
 _RUNTIME_BLOCK_SHAPES = [(64, 64), (128, 64)]
 
 


### PR DESCRIPTION
#10517 rephrased the TDM tensor_dim clamp so it stays uniform (SGPR), avoiding a VALU demotion that forced a v_readfirstlane_b32 next to each tensor_load_to_lds inside the loop (mismatched VGPR MSB -> wrong descriptor offset -> NaNs), but it did not add a test.  Add a compile-only guard: a TDM load whose offsets exercise the tensor_dim clamp must lower with zero v_readfirstlane_b32.

Verified sensitive: reverting the clamp to the pre-#10517 icmp_ule shape makes this kernel emit 5 v_readfirstlane_b32.
