### PR TITLE
[testing] Fix stale do_bench docstring and add missing run docstring

### DIFF
--- a/python/triton/testing.py
+++ b/python/triton/testing.py
@@ -38,7 +38,7 @@ def _quantile(a, q):
         t = point - lower
         return (1 - t) * a[lower] + t * a[upper]
 
-    return [get_quantile(q) for q in q]
+    return [get_quantile(qi) for qi in q]
 
 
 def _summarize_statistics(times, quantiles, return_mode):
@@ -241,21 +241,28 @@ def do_bench_cudagraph_proton(fn, rep=20, grad_to_none=None, quantiles=None, ret
 
 def do_bench(fn, warmup=25, rep=100, grad_to_none=None, quantiles=None, return_mode="mean"):
     """
-    Benchmark the runtime of the provided function. By default, return the median runtime of :code:`fn` along with
-    the 20-th and 80-th performance percentile.
+    Benchmark the runtime of the provided function. By default, returns the mean runtime of :code:`fn` as a single float.
 
     :param fn: Function to benchmark
     :type fn: Callable
-    :param warmup: Warmup time (in ms)
+    :param warmup: Warmup time (in ms). Controls how long the function is run before timing begins.
     :type warmup: int
-    :param rep: Repetition time (in ms)
+    :param rep: Repetition time (in ms). Controls the total duration of the timed runs.
     :type rep: int
     :param grad_to_none: Reset the gradient of the provided tensor to None
     :type grad_to_none: torch.tensor, optional
-    :param quantiles: Performance percentile to return in addition to the median.
+    :param quantiles: If provided, return these quantiles of the runtime distribution instead
+        of a summary statistic. For example, ``[0.2, 0.5, 0.8]`` returns the 20th, 50th, and
+        80th percentile runtimes in ms. When set, ``return_mode`` is ignored.
     :type quantiles: list[float], optional
-    :param return_mode: The statistical measure to return. Options are "min", "max", "mean", "median", or "all". Default is "mean".
+    :param return_mode: The summary statistic to return when ``quantiles`` is not set.
+        ``"mean"`` and ``"median"`` return a single float. ``"min"`` and ``"max"`` return
+        the fastest and slowest run respectively. ``"all"`` returns the raw list of
+        per-run timings in ms. Default is ``"mean"``.
     :type return_mode: str
+    :return: A single float by default, a list of floats if ``quantiles`` is provided,
+        or a list of all per-run timings if ``return_mode="all"``.
+    :rtype: float | list[float]
     """
     assert return_mode in ["min", "max", "mean", "median", "all"]
 
@@ -505,7 +512,7 @@ class Mark:
         self.benchmarks = benchmarks
 
     def _run(self, bench: Benchmark, save_path: str, show_plots: bool, print_data: bool, diff_col=False,
-             save_precision=6, **kwrags):
+             save_precision=6, **kwargs):
         import os
 
         import matplotlib.pyplot as plt
@@ -526,7 +533,7 @@ class Mark:
 
             row_mean, row_min, row_max = [], [], []
             for y in bench.line_vals:
-                ret = self.fn(**x_args, **{bench.line_arg: y}, **bench.args, **kwrags)
+                ret = self.fn(**x_args, **{bench.line_arg: y}, **bench.args, **kwargs)
                 try:
                     y_mean, y_min, y_max = ret
                 except TypeError:
@@ -574,6 +581,26 @@ class Mark:
         return df
 
     def run(self, show_plots=False, print_data=False, save_path='', return_df=False, **kwargs):
+        """
+        Run all benchmarks and optionally display, print, or save the results.
+
+        :param show_plots: If ``True``, display the matplotlib plot interactively after each benchmark.
+        :type show_plots: bool
+        :param print_data: If ``True``, print the results dataframe to stdout after each benchmark.
+        :type print_data: bool
+        :param save_path: Directory path to save results. If provided, saves a ``.png`` plot,
+            a ``.csv`` of the mean values, and a ``results.html`` index for each benchmark.
+            The directory is created if it does not exist.
+        :type save_path: str
+        :param return_df: If ``True``, return the results as a :class:`pandas.DataFrame` (or a list
+            of DataFrames if multiple benchmarks were provided).
+        :type return_df: bool
+        :param kwargs: Additional keyword arguments forwarded to the benchmarked function.
+        :return: A :class:`pandas.DataFrame` if a single :class:`Benchmark` was provided and
+            ``return_df=True``. A list of :class:`pandas.DataFrame` if multiple benchmarks were
+            provided and ``return_df=True``. ``None`` otherwise.
+        :rtype: pandas.DataFrame | list[pandas.DataFrame] | None
+        """
         has_single_bench = isinstance(self.benchmarks, Benchmark)
         benchmarks = [self.benchmarks] if has_single_bench else self.benchmarks
         result_dfs = []

--- a/python/triton/testing.py
+++ b/python/triton/testing.py
@@ -249,8 +249,9 @@ def do_bench(fn, warmup=25, rep=100, grad_to_none=None, quantiles=None, return_m
     :type warmup: int
     :param rep: Repetition time (in ms). Controls the total duration of the timed runs.
     :type rep: int
-    :param grad_to_none: Reset the gradient of the provided tensor to None
-    :type grad_to_none: torch.tensor, optional
+    :param grad_to_none: Reset the gradient of the provided tensors to None before each run,
+        to avoid gradient accumulation affecting timing.
+    :type grad_to_none: list[torch.Tensor], optional
     :param quantiles: If provided, return these quantiles of the runtime distribution instead
         of a summary statistic. For example, ``[0.2, 0.5, 0.8]`` returns the 20th, 50th, and
         80th percentile runtimes in ms. When set, ``return_mode`` is ignored.

--- a/python/triton/testing.py
+++ b/python/triton/testing.py
@@ -582,26 +582,6 @@ class Mark:
         return df
 
     def run(self, show_plots=False, print_data=False, save_path='', return_df=False, **kwargs):
-        """
-        Run all benchmarks and optionally display, print, or save the results.
-
-        :param show_plots: If ``True``, display the matplotlib plot interactively after each benchmark.
-        :type show_plots: bool
-        :param print_data: If ``True``, print the results dataframe to stdout after each benchmark.
-        :type print_data: bool
-        :param save_path: Directory path to save results. If provided, saves a ``.png`` plot,
-            a ``.csv`` of the mean values, and a ``results.html`` index for each benchmark.
-            The directory is created if it does not exist.
-        :type save_path: str
-        :param return_df: If ``True``, return the results as a :class:`pandas.DataFrame` (or a list
-            of DataFrames if multiple benchmarks were provided).
-        :type return_df: bool
-        :param kwargs: Additional keyword arguments forwarded to the benchmarked function.
-        :return: A :class:`pandas.DataFrame` if a single :class:`Benchmark` was provided and
-            ``return_df=True``. A list of :class:`pandas.DataFrame` if multiple benchmarks were
-            provided and ``return_df=True``. ``None`` otherwise.
-        :rtype: pandas.DataFrame | list[pandas.DataFrame] | None
-        """
         has_single_bench = isinstance(self.benchmarks, Benchmark)
         benchmarks = [self.benchmarks] if has_single_bench else self.benchmarks
         result_dfs = []


### PR DESCRIPTION
<!---
The core Triton is a small number of people, and we receive many PRs (thank
you!).  To help us review your code more quickly, **if you are a new
contributor (less than 3 PRs merged) we ask that you complete the following
tasks and include the filled-out checklist in your PR description.**

Complete the following tasks before sending your PR, and replace `[ ]` with
`[x]` to indicate you have done them.
-->

# New contributor declaration
- [ ] I am not making a trivial change, such as fixing a typo in a comment.

- [X] I have written a PR description following these
  [rules](https://cbea.ms/git-commit/#why-not-how).

- [X] I have run `pre-commit run --from-ref origin/main --to-ref HEAD`.

- Select one of the following.
  - [ ] I have added tests.
    - `/test` for `lit` tests
    - `/unittest` for C++ tests
    - `/python/test` for end-to-end tests
  - [X] This PR does not need a test because `because it contains no behavior changes,
    only docstring corrections and a variable rename.`

- Select one of the following.
  - [X] I have not added any `lit` tests.
  - [ ] The `lit` tests I have added follow these [best practices](https://mlir.llvm.org/getting_started/TestingGuide/#filecheck-best-practices),
    including the "tests should be minimal" section. (Usually running Python code
    and using the instructions it generates is not minimal.)

## Why

`do_bench` docstring states the default behavior returns the median runtime
along with the 20th and 80th percentile. This described an older API where
`quantiles=(0.2, 0.5, 0.8)` was the default. The current default is
`return_mode="mean"`, which returns a single float. A user reading the
docstring would expect a 3-tuple by default and be confused when they get
a scalar.

<!--- The `run` method on `Mark` had no docstring at all despite being the primary
public interface users call after `@perf_report`. --->

## What changed

- Rewrote `do_bench` docstring to reflect current behavior. Clarified that
  `quantiles` and `return_mode` are mutually exclusive, if `quantiles` is
  set, `return_mode` is ignored entirely (visible in `_summarize_statistics`),
  which was undocumented. Fixed `grad_to_none` type annotation from
  `torch.tensor` to `list[torch.Tensor]` since the implementation iterates
  over it. Added missing `:return:` and `:rtype:` fields.
<!--- - Added docstring for `Mark.run` covering all parameters and the three-case
  return type depending on `return_df` and whether a single or multiple
  `Benchmark` objects were provided. --->
- `**kwrags` → `**kwargs` in `Mark._run` (typo).
- `for q in q` → `for qi in q` in `_quantile` (variable shadowing).

## Testing

- This PR does not need a test because it contains no behavior changes,
  only docstring corrections and a variable rename.
- `pre-commit run --from-ref origin/main --to-ref HEAD`