### PR TITLE
Fix pytest collection warning in gluon frontend test

### DIFF
--- a/python/test/gluon/test_frontend.py
+++ b/python/test/gluon/test_frontend.py
@@ -3412,7 +3412,7 @@ def infer_layout_for_padded_shared_kernel():
 
 
 @gluon.jit
-def test_convert_padded_shared_with_multicta_kernel():
+def convert_padded_shared_with_multicta_kernel():
     shape: ttgl.constexpr = [512, 128]
     initial_order: ttgl.constexpr = [0, 1]
     layout: ttgl.constexpr = ttgl.PaddedSharedLayout.with_identity_for(interval_padding_pairs=[[256, 16]],
@@ -3447,7 +3447,7 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.targ
 def test_convert_padded_shared_with_multicta(target):
     # It is to make sure layoutToGluon() handle CGA layout correctly when
     # converting a PaddedSharedEncodingAttr to a PaddedSharedLayout object.
-    run_parser(test_convert_padded_shared_with_multicta_kernel, *make_args(num_ctas=2), target=target)
+    run_parser(convert_padded_shared_with_multicta_kernel, *make_args(num_ctas=2), target=target)
 
 
 @filecheck_test


### PR DESCRIPTION
This renames a @gluon.jit helper in python/test/gluon/test_frontend.py so pytest stops trying to collect it as a standalone test.

Failure mechanism

The helper was named test_convert_padded_shared_with_multicta_kernel, so pytest treated it as a test candidate during collection. Because @gluon.jit wraps it as a JITFunction, pytest emitted:

PytestCollectionWarning: cannot collect 'test_convert_padded_shared_with_multicta_kernel' because it is not a function.

Semantic change

Rename the helper to convert_padded_shared_with_multicta_kernel and update the single run_parser(...) call site.

This keeps the parser coverage the same and only removes the accidental test-style name.

Validation

pytest -q python/test/gluon/test_frontend.py -q

pytest -q python/test/gluon/test_frontend.py -q -W error::pytest.PytestCollectionWarning

Both pass locally after the rename.

Closes #10608
