### PR TITLE
[CI] Limit default pytest discovery surface

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -52,8 +52,8 @@ test-plugins: all
 
 .PHONY: test-gluon
 test-gluon: all
-	$(PYTEST) -n $(NUM_PROCS) python/test/gluon/ python/tutorials/gluon/
-	PYTHONPATH="$(TRITON_KERNELS_PATH)" $(PYTEST) -n 2 python/examples/gluon/
+	$(PYTEST) -n $(NUM_PROCS) python/test/gluon/ python/tutorials/gluon/[0-9][0-9]-*.py
+	PYTHONPATH="$(TRITON_KERNELS_PATH)" $(PYTEST) -n 2 python/examples/gluon/[0-9][0-9]-*.py
 
 .PHONY: test-gsan
 test-gsan: all

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,4 +1,4 @@
 [pytest]
 addopts = --tb=short
 markers = interpreter: indicate whether interpreter supports the test
-python_files = test_*.py *_test.py tutorials/*.py examples/*.py
+python_files = test_*.py *_test.py


### PR DESCRIPTION
[CI] Limit default pytest discovery surface

Failure mechanism

pytest.ini currently sets:

python_files = test_*.py *_test.py tutorials/*.py examples/*.py

That makes repo-wide collection under python/ treat tutorials and examples as part of the default pytest surface. In a pytest-only environment, collection imports tutorial and example modules and fails on optional imports such as torch, tabulate, and triton before any explicit test selection.

Semantic change

Narrow the root python_files patterns back to:

- test_*.py
- *_test.py

Then keep the Gluon tutorial and example coverage by making test-gluon pass explicit file globs instead of directory paths:

- python/tutorials/gluon/[0-9][0-9]-*.py
- python/examples/gluon/[0-9][0-9]-*.py

Preserved invariant

This keeps Gluon tutorial and example coverage in CI without leaving those directories on the repo-wide default discovery path.

It also preserves the explicit tutorial and example entrypoints that #10565 intended to keep working.

Validation

- make -n test-gluon now expands to explicit tutorial and example file paths instead of directory collection
- a minimal pytest-only reproduction with python_files = test_*.py *_test.py still collects explicit tutorial and example files when they are passed by path
- the original repo-wide collection reproducer no longer relies on tutorial or example imports to discover tests

Closes #10612