### PR TITLE
[NVIDIA] Fix is_active() reporting no driver in forked torch compile workers

### DIFF
--- a/third_party/nvidia/backend/driver.py
+++ b/third_party/nvidia/backend/driver.py
@@ -380,6 +380,15 @@ class CudaDriver(GPUDriver):
 
     @staticmethod
     def is_active():
+        # cuInit(0) is not fork-safe (returns CUDA_ERROR_NOT_INITIALIZED in a
+        # process forked after CUDA init), so prefer torch's cached availability
+        # check when torch is already loaded; torch-free usage uses the native probe.
+        torch = sys.modules.get("torch")
+        if torch is not None:
+            try:
+                return torch.cuda.is_available() and torch.version.hip is None
+            except Exception:
+                pass
         return _cuda_driver_is_active()
 
     def map_python_to_cpp_type(self, ty: str) -> str:


### PR DESCRIPTION
## Problem
Fixes PyTorch Inductor issue pytorch/pytorch#184643. 
Specifically `CudaDriver.is_active()` can report that no CUDA driver is active in a process forked
after CUDA init, breaking PyTorch Inductor's compile workers (which fork post-init) with
`RuntimeError: 0 active drivers ([]). There should only be one.`.

#9578 rewrote `is_active()` to probe natively via `cuInit(0)`. `cuInit(0)` is not
fork-safe: in a process forked after CUDA init it returns `CUDA_ERROR_NOT_INITIALIZED`,
so `_cuda_driver_is_active()` returns `False` and Triton sees zero active drivers. The
pre-#9578 path (`torch.cuda.is_available()`) did not have this problem, since it does not
re-probe the driver with `cuInit` in the forked child.

## Fix

When torch is already imported, prefer its availability check; otherwise fall back to the
native probe. We make sure not to add new torch dependency; instead we use `sys.modules.get("torch")` which never imports torch, so
torch-free processes fall through to the native probe. This is also the same convention as
`CudaDriver.__init__` from #9833

## Test plan (verified on H100)

- Minimal repro from pytorch/pytorch#184643 goes from `0 active drivers` failure to passing.
- `test_nvidia_kernel_dispatch_without_torch`
  (`python/test/unit/runtime/test_no_torch_dispatch.py`, the torch-free path) still passes.
