### PR TITLE
[AMD][BACKEND] Revert enabling SGPR preload on gfx1250

### DIFF
--- a/third_party/amd/backend/compiler.py
+++ b/third_party/amd/backend/compiler.py
@@ -481,7 +481,7 @@ class HIPBackend(BaseBackend):
         #
         # TODO(tyb0807): Disabled when using MIR swap/dump because the value is
         # not serializable to/from MIR YAML
-        if not (knobs.amd.swap_mir or knobs.amd.dump_mir):
+        if options.arch != "gfx1250" and not (knobs.amd.swap_mir or knobs.amd.dump_mir):
             amd.set_all_fn_arg_inreg(kernel_fn)
 
         if knobs.compilation.enable_asan:


### PR DESCRIPTION
Partial revert of https://github.com/triton-lang/triton/pull/10543 due to a functional regression with SGPR preload.