### PR TITLE
[AMD] Skip redundant CTA barrier between two async LDS copies

### DIFF
--- a/test/Conversion/amd/amdgpu_membar.mlir
+++ b/test/Conversion/amd/amdgpu_membar.mlir
@@ -278,4 +278,21 @@ tt.func @missing_barrier_reused_allocation(%A: !tt.ptr<f16>, %B: !tt.ptr<f16>) {
   tt.return
 }
 
+// Two async copies into the same buffer need no CTA barrier between them: async DMA
+// copies into LDS are ordered by the async queue + commit/wait tokens, not by a
+// workgroup barrier, so the barrier the stock analysis inserts between them is
+// redundant. The read side is unaffected (a consumer is still ordered by its
+// async_wait).
+// CHECK-LABEL: async_copy_to_async_copy_no_barrier
+tt.func @async_copy_to_async_copy_no_barrier(%A: !tt.ptr<f16>) {
+  %a_ptr = tt.splat %A : !tt.ptr<f16> -> tensor<16x16x!tt.ptr<f16>, #AL>
+  %alloc = ttg.local_alloc : () -> !ttg.memdesc<16x16xf16, #A_SHARED, #ttg.shared_memory, mutable>
+  %1 = ttg.async_copy_global_to_local %a_ptr, %alloc : tensor<16x16x!tt.ptr<f16>, #AL> -> !ttg.memdesc<16x16xf16, #A_SHARED, #ttg.shared_memory, mutable>
+  // CHECK: ttg.async_copy_global_to_local
+  // CHECK-NOT: ttg.barrier local
+  // CHECK: ttg.async_copy_global_to_local
+  %2 = ttg.async_copy_global_to_local %a_ptr, %alloc : tensor<16x16x!tt.ptr<f16>, #AL> -> !ttg.memdesc<16x16xf16, #A_SHARED, #ttg.shared_memory, mutable>
+  tt.return
+}
+
 }

--- a/third_party/amd/lib/TritonAMDGPUToLLVM/MembarUtility.cpp
+++ b/third_party/amd/lib/TritonAMDGPUToLLVM/MembarUtility.cpp
@@ -52,6 +52,23 @@ bool filterAsyncLocalLoadsDependencies(Operation *op1, Operation *op2,
          isLocalLoadWithAsyncWaitToken(op2);
 }
 
+// Returns true if both operations are async copies into LDS (cp.async /
+// buffer_load_to_lds / async TDM copy). Such DMA copies are ordered by the
+// async queue and the commit/wait tokens, not by a CTA barrier, so a barrier
+// inserted purely between two of them is redundant: the stock analysis
+// conservatively emits one because it treats them as ordinary shared-memory
+// writes. The read side is unaffected -- a consumer LocalLoad is still ordered
+// by its async-wait (handled by filterAsyncLocalLoadsDependencies) and the
+// barrier the analysis emits after the AsyncWait.
+bool filterAsyncVsAsyncDependencies(Operation *op1, Operation *op2) {
+  auto isAsyncLoad = [](Operation *op) {
+    return llvm::isa<triton::gpu::AsyncCopyGlobalToLocalOp,
+                     triton::amdgpu::BufferLoadToLocalOp,
+                     triton::amdgpu::AsyncTDMCopyLocalToGlobalOp>(op);
+  };
+  return isAsyncLoad(op1) && isAsyncLoad(op2);
+}
+
 bool filterLDSMemoryBarriersDependencies(Operation *op1, Operation *op2) {
   auto isLDSMemoryBarrierOp = [](Operation *op) {
     return llvm::isa<triton::amdgpu::InitBarrierOp,
@@ -67,6 +84,7 @@ bool filterLDSMemoryBarriersDependencies(Operation *op1, Operation *op2) {
 bool membarFilter(Operation *op1, Operation *op2, bool /*op1IsRead*/,
                   bool /*op2IsRead*/, Allocation *allocation) {
   return (filterAsyncLocalLoadsDependencies(op1, op2, allocation) ||
+          filterAsyncVsAsyncDependencies(op1, op2) ||
           filterLDSMemoryBarriersDependencies(op1, op2));
 }
 } // namespace mlir::triton::AMD


### PR DESCRIPTION
## Summary

The AMD `membar` analysis treats async copies into LDS (`cp.async` / `buffer_load_to_lds` / async TDM copy) like ordinary shared-memory writes, so it inserts a workgroup `s_barrier` between two consecutive ones. That barrier is redundant: async DMA copies into LDS are ordered by the async queue and the `commit`/`wait` tokens, not by a CTA barrier. This teaches `membarFilter` to skip the barrier when both operands are async LDS copies.

## Why

Hand-written, explicitly multi-buffered kernels (e.g. Gluon attention with a double-buffered K/V prefetch) issue async load *groups* whose writes the analysis separates with a full `s_barrier`. The software pipeliner-generated code does not carry this extra barrier, so explicit kernels pay one redundant CTA sync per loop iteration. Removing it brings the loop's barrier count in line with the pipeliner's. Measured on gfx950: **+1.8% on a head-dim-192 (GQA) attention forward**, scaling with the number of async load groups (≈+8% on head-dim-512, which splits D into four slabs).

## Correctness

- The skipped barrier sits purely between two async writes; it never provided their ordering — the async queue + `commit`/`wait` do. Disjoint buffers have no hazard; same-buffer (WAW) writes are issue-ordered by the queue, and any later reader still waits via its `async_wait`.
- The read side is unaffected: a consumer `local_load` is still ordered by its async-wait token (existing `filterAsyncLocalLoadsDependencies`) and the barrier emitted right after the `AsyncWait`.
- Existing membar lit tests — including `missing_barrier_reused_allocation` (an async write overlapping an in-flight `local_load`, where a barrier **is** required) — still pass: that hazard is read↔write, which this filter does not touch.

## Scope

Architecture-independent at the membar level — applies to all AMD async-to-LDS targets (CDNA3/CDNA4 `buffer_load_to_lds`, gfx1250 TDM). Runtime-validated on gfx950; a CDNA3/gfx1250 sanity check would be appreciated. Orthogonal to the asyncmark migration (#9883, #10081) and `load_shared_relaxed` removal (#10599): those operate on the LLVM-IR wait-count model, while this barrier is inserted by the TTGIR-level `membar` analysis (validated on current `main`).

## Test

`test/Conversion/amd/amdgpu_membar.mlir`: two `async_copy_global_to_local` into the same buffer → assert no `ttg.barrier local` between them.

---

# New contributor declaration
- [x] I am not making a trivial change, such as fixing a typo in a comment.
- [x] I have written a PR description following [these rules](https://cbea.ms/git-commit/#why-not-how).
- [] I have run `pre-commit run --from-ref origin/main --to-ref HEAD`.
- [x] I have added tests. (`/test` lit test in `amdgpu_membar.mlir`)
- [x] The `lit` tests I have added follow these [best practices](https://mlir.llvm.org/getting_started/TestingGuide/#filecheck-best-practices), including the "tests should be minimal" section.