### PR TITLE
Build LLVM from the repository pinned in cmake/llvm-build-info.json

### DIFF
--- a/.github/workflows/llvm-build.yml
+++ b/.github/workflows/llvm-build.yml
@@ -62,6 +62,10 @@ jobs:
         echo "Found LLVM commit hash: ${LLVM_COMMIT_HASH}"
         echo "llvm_commit_hash=${LLVM_COMMIT_HASH}" >> ${GITHUB_ENV}
 
+        LLVM_REPOSITORY="$(jq -r '.repository // "llvm/llvm-project"' llvm-build/cmake/llvm-build-info.json)"
+        echo "Found LLVM repository: ${LLVM_REPOSITORY}"
+        echo "llvm_repository=${LLVM_REPOSITORY}" >> ${GITHUB_ENV}
+
         LLVM_BUILD_NUMBER="$(jq -r '.build_number' llvm-build/cmake/llvm-build-info.json)"
         echo "Found LLVM build number: ${LLVM_BUILD_NUMBER}"
 
@@ -86,7 +90,7 @@ jobs:
     - name: Checkout LLVM
       uses: actions/checkout@v6
       with:
-        repository: llvm/llvm-project
+        repository: ${{ env.llvm_repository }}
         path: llvm-project
         ref: ${{ env.llvm_commit_hash }}
 

--- a/cmake/llvm-build-info.json
+++ b/cmake/llvm-build-info.json
@@ -1,4 +1,5 @@
 {
-  "llvm_hash": "9ce06fd29838777aaa89f133fe4b9f764be11d35",
+  "llvm_hash": "1f126a6dea50d185c0781743a667390037ae88bd",
+  "repository": "triton-lang/llvm-project",
   "build_number": 1
 }


### PR DESCRIPTION
## Summary

Add an optional `repository` field to `cmake/llvm-build-info.json` and have the `llvm-build` workflow read it (defaulting to `llvm/llvm-project` when absent), so the `Checkout LLVM` step builds from the pinned repository for **all** matrix entries.

This is the narrowest change (per @neildhar): the build pulls both the repo and the hash from `cmake/llvm-build-info.json`. A release branch sets `llvm_hash` + `repository` there and the normal build does the rest — no `workflow_dispatch` options, no separate metadata file, no extra matrix entries.

This branch points at the triton-release LLVM:
```json
{
  "llvm_hash": "1f126a6dea50d185c0781743a667390037ae88bd",
  "repository": "triton-lang/llvm-project",
  "build_number": 1
}
```

## Test is successful here
https://github.com/triton-lang/triton/pull/10624

Authored with assistance from an AI coding assistant.