### PR TITLE
[Gluon] Fix SharedLinearLayout.shape

### DIFF
--- a/python/test/gluon/test_layout.py
+++ b/python/test/gluon/test_layout.py
@@ -1,0 +1,7 @@
+from triton.experimental.gluon import language as ttgl
+
+
+def test_shared_linear_layout_shape():
+    assert ttgl.SharedLinearLayout([[0, 1], [0, 2]]).shape == [1, 4]
+    assert ttgl.SharedLinearLayout([[3, 1], [1, 0], [0, 1]]).shape == [4, 2]
+    assert ttgl.SharedLinearLayout([[4]]).shape == [8]

--- a/python/triton/experimental/gluon/language/_layouts.py
+++ b/python/triton/experimental/gluon/language/_layouts.py
@@ -659,11 +659,11 @@ class SharedLinearLayout(SharedLayout):
     @property
     def shape(self):
         rank = len(self.offset_bases[0])
-        max_stride = [1] * rank
+        max_stride = [0] * rank
         for b in itertools.chain(self.offset_bases, self.block_bases):
             for i, bi in enumerate(b):
                 max_stride[i] = max(max_stride[i], bi)
-        return [2 * s for s in max_stride]
+        return [1 << s.bit_length() for s in max_stride]
 
     def __hash__(self):
         return hash((


### PR DESCRIPTION
Correctly handle some more general cases:

* the size of one of the dimensions is 1
* the layout is swizzled

There's a design question here of whether the function should try to handle non-surjective layouts. One could go either way on this in theory, but a non-surjective layout just isn't very useful in practice.

<!---
The core Triton is a small number of people, and we receive many PRs (thank
you!).  To help us review your code more quickly, **if you are a new
contributor (less than 3 PRs merged) we ask that you complete the following
tasks and include the filled-out checklist in your PR description.**

Complete the following tasks before sending your PR, and replace `[ ]` with
`[x]` to indicate you have done them.
-->

# New contributor declaration
- [x] I am not making a trivial change, such as fixing a typo in a comment.

- [x] I have written a PR description following these
  [rules](https://cbea.ms/git-commit/#why-not-how).

- [x] I have run `pre-commit run --from-ref origin/main --to-ref HEAD`.

- Select one of the following.
  - [x] I have added tests: Python unit test in `python/test/gluon`

- Select one of the following.
  - [x] I have not added any `lit` tests.
