### PR TITLE
Fix make dev-install-llvm on macOS without lld

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -118,8 +118,7 @@ dev-install: dev-install-requires dev-install-triton
 .NOPARALLEL: dev-install-llvm
 dev-install-llvm:
 	LLVM_BUILD_PATH=$(LLVM_BUILD_PATH) scripts/build-llvm-project.sh
-	TRITON_BUILD_WITH_CLANG_LLD=1 TRITON_BUILD_WITH_CCACHE=0 \
-		LLVM_INCLUDE_DIRS=$(LLVM_BUILD_PATH)/include \
+	LLVM_INCLUDE_DIRS=$(LLVM_BUILD_PATH)/include \
 		LLVM_LIBRARY_DIR=$(LLVM_BUILD_PATH)/lib \
 		LLVM_SYSPATH=$(LLVM_BUILD_PATH) \
 	$(MAKE) dev-install

--- a/scripts/build-llvm-project.sh
+++ b/scripts/build-llvm-project.sh
@@ -12,6 +12,20 @@ LLVM_BUILD_PATH=${LLVM_BUILD_PATH:-"$LLVM_PROJECT_PATH/build"}
 LLVM_INSTALL_PATH=${LLVM_INSTALL_PATH:-"$LLVM_PROJECT_PATH/install"}
 LLVM_PROJECT_URL=${LLVM_PROJECT_URL:-"https://github.com/llvm/llvm-project"}
 
+# Build+link with clang+lld only when explicitly requested (the macOS toolchain
+# does not ship lld). Otherwise fall back to the default compiler and linker.
+CLANG_LLD_ARGS=()
+case "$(printf '%s' "$TRITON_BUILD_WITH_CLANG_LLD" | tr '[:upper:]' '[:lower:]')" in
+    1 | on | true) TRITON_BUILD_WITH_CLANG_LLD=1 ;;
+esac
+if [ "$TRITON_BUILD_WITH_CLANG_LLD" = "1" ]; then
+    CLANG_LLD_ARGS=(
+        -DCMAKE_C_COMPILER=clang
+        -DCMAKE_CXX_COMPILER=clang++
+        -DLLVM_ENABLE_LLD=ON
+    )
+fi
+
 if [ -z "$CMAKE_ARGS" ]; then
     if [ "$#" -eq 0 ]; then
         CMAKE_ARGS=(
@@ -19,9 +33,7 @@ if [ -z "$CMAKE_ARGS" ]; then
               -DCMAKE_BUILD_TYPE="$LLVM_BUILD_TYPE"
               -DLLVM_CCACHE_BUILD=OFF
               -DLLVM_ENABLE_ASSERTIONS=ON
-              -DCMAKE_C_COMPILER=clang
-              -DCMAKE_CXX_COMPILER=clang++
-              -DLLVM_ENABLE_LLD=ON
+              "${CLANG_LLD_ARGS[@]}"
               -DLLVM_OPTIMIZED_TABLEGEN=ON
               -DMLIR_ENABLE_BINDINGS_PYTHON=OFF
               -DLLVM_ENABLE_ZSTD=OFF


### PR DESCRIPTION
macOS' system toolchain does not ship lld, so `make dev-install-llvm` fails to build on a default setup because it force sets TRITON_BUILD_WITH_CLANG_LLD=1.

The macOS CI runner avoids by both installing lld with brew and by avoiding even using `make dev-install-llvm`

After some discussion, it seems pretty odd for `make dev-install-llvm` to hard set these build env vars.

So to address it, this patch alters these files in the following ways:

- Makefile: Drop setting TRITON_BUILD_WITH_CLANG_LLD=1 and TRITON_BUILD_WITH_CCACHE in the Makefile, avoiding the incorrect behavior in setup.py

- build-llvm-project.sh: Have the llvm-project build script honor TRITON_BUILD_WITH_CLANG_LLD by setting LLVM_ENABLE_LLD=ON and CMAKE_C(XX)_COMPILER=clang(++) when invoking LLVM's CMake only when TRITON_BUILD_WITH_CLANG_LLD=1/true/ON is set

This allows macOS builds to work with or without LLD installed (using the system's ld64/ldprime) and removes hard fixed defaults that don't make sense in the Makefile.