### PR TITLE
[AMD] Fix WMMA CGA-layout verify for batched dots

### DIFF
--- a/lib/Dialect/TritonGPU/IR/Dialect.cpp
+++ b/lib/Dialect/TritonGPU/IR/Dialect.cpp
@@ -3234,17 +3234,17 @@ struct TritonGPUInferLayoutInterface
 
       auto aLL = aEncoding.getCGALayout().getLinearLayout();
       auto bLL = bEncoding.getCGALayout().getLinearLayout();
-      // In multi-CTA, the CGA layout of operand 0 broadcasts across dim1 and
-      // operand 1 broadcasts across dim0.
+      // A broadcasts over N, B over M (the trailing two result dims). Batch
+      // dims (rank > 2) are shared across A/B/result, not broadcast.
       auto ctx = op->getContext();
-      auto dim0 = StringAttr::get(ctx, "dim0");
-      auto dim1 = StringAttr::get(ctx, "dim1");
-      // Resize to size 1 makes the dimension broadcast-only (all bases
-      // become 0).
-      if (aLL != resLL.resizeOutDim(dim1, 1))
+      int rank = cast<RankedTensorType>(dotOp.getD().getType()).getRank();
+      auto mDim = StringAttr::get(ctx, "dim" + std::to_string(rank - 2));
+      auto nDim = StringAttr::get(ctx, "dim" + std::to_string(rank - 1));
+      // resizeOutDim(d, 1) makes d broadcast-only.
+      if (aLL != resLL.resizeOutDim(nDim, 1))
         return op->emitError("Incompatible CGA layout for operand 0");
 
-      if (bLL != resLL.resizeOutDim(dim0, 1))
+      if (bLL != resLL.resizeOutDim(mDim, 1))
         return op->emitError("Incompatible CGA layout for operand 1");
     }
     return success();

--- a/third_party/amd/python/test/test_gluon_gfx1250.py
+++ b/third_party/amd/python/test/test_gluon_gfx1250.py
@@ -13,6 +13,7 @@ from triton.tools.mxfp import MXFP4Tensor, MXScaleTensor
 from triton.experimental import gluon
 import triton.experimental.gluon.language as ttgl
 from triton.experimental.gluon.language.amd.gfx1250 import get_wmma_scale_layout, PartitionedSharedLayout, _valid_dtype_combinations
+from triton._C.libtriton.gluon_ir import make_cga_layout
 
 
 @gluon.jit
@@ -4599,3 +4600,73 @@ def test_cache_modifier(loadCM, storeCM, test_kernel):
 
     assert load_found
     assert store_found
+
+
+# Multi-CTA batched matmul: each CTA in the cluster computes one batch of A @ B.
+@gluon.jit
+def gemm_3d_cga_split_kernel(a_ptr, b_ptr, c_ptr, M, N, K,  #
+                             BLOCK_M: ttgl.constexpr, BLOCK_N: ttgl.constexpr, BLOCK_K: ttgl.constexpr,
+                             NUM_CTAS: ttgl.constexpr, K_WIDTH: ttgl.constexpr, load_layout: ttgl.constexpr,
+                             wmma_layout: ttgl.constexpr):
+    load_dim0_layout: ttgl.constexpr = ttgl.SliceLayout(1, ttgl.SliceLayout(2, load_layout))
+    load_dim1_layout: ttgl.constexpr = ttgl.SliceLayout(0, ttgl.SliceLayout(2, load_layout))
+    load_dim2_layout: ttgl.constexpr = ttgl.SliceLayout(0, ttgl.SliceLayout(1, load_layout))
+    wmma_dim0_layout: ttgl.constexpr = ttgl.SliceLayout(1, ttgl.SliceLayout(2, wmma_layout))
+    wmma_dim1_layout: ttgl.constexpr = ttgl.SliceLayout(0, ttgl.SliceLayout(2, wmma_layout))
+    wmma_dim2_layout: ttgl.constexpr = ttgl.SliceLayout(0, ttgl.SliceLayout(1, wmma_layout))
+
+    ob = ttgl.arange(0, NUM_CTAS, layout=load_dim0_layout)
+    om = ttgl.arange(0, BLOCK_M, layout=load_dim1_layout)
+    ok = ttgl.arange(0, BLOCK_K, layout=load_dim2_layout)
+    okb = ttgl.arange(0, BLOCK_K, layout=load_dim1_layout)
+    on = ttgl.arange(0, BLOCK_N, layout=load_dim2_layout)
+
+    offs_a = ob[:, None, None] * (M * K) + om[None, :, None] * K + ok[None, None, :]
+    a = ttgl.load(a_ptr + offs_a)
+    offs_b = ob[:, None, None] * (K * N) + okb[None, :, None] * N + on[None, None, :]
+    b = ttgl.load(b_ptr + offs_b)
+
+    a = ttgl.convert_layout(a, ttgl.DotOperandLayout(0, wmma_layout, K_WIDTH))
+    b = ttgl.convert_layout(b, ttgl.DotOperandLayout(1, wmma_layout, K_WIDTH))
+    acc = ttgl.zeros((NUM_CTAS, BLOCK_M, BLOCK_N), dtype=ttgl.float32, layout=wmma_layout)
+    acc = ttgl.amd.gfx1250.wmma(a, b, acc)
+
+    sb = ttgl.arange(0, NUM_CTAS, layout=wmma_dim0_layout)
+    sm = ttgl.arange(0, BLOCK_M, layout=wmma_dim1_layout)
+    sn = ttgl.arange(0, BLOCK_N, layout=wmma_dim2_layout)
+    offs_c = sb[:, None, None] * (BLOCK_M * BLOCK_N) + sm[None, :, None] * BLOCK_N + sn[None, None, :]
+    ttgl.store(c_ptr + offs_c, acc)
+
+
+@pytest.mark.skipif(not is_hip_gfx1250(), reason="Requires GFX1250")
+@pytest.mark.parametrize("num_ctas", [2, 4])
+def test_runtime_gemm_3d_multi_cta(num_ctas):
+    BLOCK_M = BLOCK_N = 32
+    BLOCK_K = 64
+    num_warps = 4
+    M, N, K = BLOCK_M, BLOCK_N, BLOCK_K
+
+    cga = make_cga_layout([num_ctas, 1, 1], [num_ctas, 1, 1], [2, 1, 0])
+    n_warps = 2
+    m_warps = num_warps // n_warps
+    sM = BLOCK_M // (m_warps * 8)
+    sN = BLOCK_N // (n_warps * 4)
+    load_layout = ttgl.BlockedLayout([1, sM, sN], [1, 8, 4], [1, m_warps, n_warps], [2, 1, 0], cga)
+    warp_bases = [[0, 0, 1]]
+    for i in range(int(math.log2(num_warps // 2))):
+        warp_bases.append([0, 1 << i, 0])
+    wmma_layout = ttgl.amd.AMDWMMALayout(version=3, transposed=True, warp_bases=warp_bases, reg_bases=[],
+                                         instr_shape=[16, 16, 32], cga_layout=cga, rank=3)
+
+    torch.manual_seed(0)
+    a = torch.randn((num_ctas, M, K), dtype=torch.float16)
+    b = torch.randn((num_ctas, K, N), dtype=torch.float16)
+    c = torch.zeros((num_ctas, M, N), dtype=torch.float32)
+    a_device, b_device, c_device = a.cuda(), b.cuda(), c.cuda()
+
+    # Launching with num_ctas > 1 runs the multi-CTA CGA-layout verifier on the rank-3 dot.
+    gemm_3d_cga_split_kernel[(1, )](a_device, b_device, c_device, M, N, K, BLOCK_M=BLOCK_M, BLOCK_N=BLOCK_N,
+                                    BLOCK_K=BLOCK_K, NUM_CTAS=num_ctas, K_WIDTH=8, load_layout=load_layout,
+                                    wmma_layout=wmma_layout, num_warps=num_warps, num_ctas=num_ctas)
+
+    torch.testing.assert_close(c_device.cpu(), torch.bmm(a.float(), b.float()), rtol=2e-2, atol=2e-2)


### PR DESCRIPTION
The dot CGA-layout compatibility check (verifyDotOpEncodingCompatibility) used dim0/dim1 for M/N.  That is correct for a 2-D dot (result [M, N] => M=dim0, N=dim1), but for a batched (rank-3) dot the result is [BATCH, M, N], so M/N shift to dim1/dim2. The hard-coded dim0/dim1 then compared the wrong axes and rejected valid layouts with "Incompatible CGA layout for operand 0/1".

- Fix: derive M/N from the trailing two result dims (dim{rank-2}/dim{rank-1}). For rank-2 this is exactly dim0/dim1, so 2-D behavior is unchanged; rank-3+ now selects the right axes.