### PR TITLE
[BACKEND] Relayout local loads after partition warp changes

### DIFF
--- a/lib/Conversion/TritonToTritonGPU/RelayoutTritonGPU.cpp
+++ b/lib/Conversion/TritonToTritonGPU/RelayoutTritonGPU.cpp
@@ -26,6 +26,12 @@ RankedTensorType getTMEMTensorLayout(const TypeConverter *tc,
   return type.cloneWithEncoding(encoding);
 }
 
+bool isTMEMOperandDynamicallyLegal(Operation *op, RankedTensorType type,
+                                   MemDescType memdesc) {
+  return type.getEncoding() &&
+         ttng::isDistributedLayoutTMemCompatible(op, type, memdesc);
+}
+
 struct TMEMLoadOpPattern : public OpConversionPattern<ttng::TMEMLoadOp> {
   using OpConversionPattern::OpConversionPattern;
 
@@ -83,6 +89,19 @@ struct TMEMAllocOpPattern : public OpConversionPattern<ttng::TMEMAllocOp> {
   }
 };
 
+struct LocalLoadOpPattern : public OpConversionPattern<LocalLoadOp> {
+  using OpConversionPattern::OpConversionPattern;
+
+  LogicalResult
+  matchAndRewrite(LocalLoadOp op, OpAdaptor,
+                  ConversionPatternRewriter &rewriter) const override {
+    auto type =
+        cast<RankedTensorType>(getTypeConverter()->convertType(op.getType()));
+    rewriter.modifyOpInPlace(op, [&] { op.getResult().setType(type); });
+    return success();
+  }
+};
+
 class RelayoutTritonGPU
     : public triton::impl::RelayoutTritonGPUBase<RelayoutTritonGPU> {
 public:
@@ -105,7 +124,24 @@ public:
           return TritonGPUConversionTarget::isDynamicallyLegal(op,
                                                                typeConverter);
         });
-
+    target.addDynamicallyLegalOp<ttng::TMEMLoadOp>([&](ttng::TMEMLoadOp op) {
+      return TritonGPUConversionTarget::isDynamicallyLegal(op, typeConverter) &&
+             isTMEMOperandDynamicallyLegal(op, op.getType(),
+                                           op.getSrc().getType());
+    });
+    target.addDynamicallyLegalOp<ttng::TMEMStoreOp>([&](ttng::TMEMStoreOp op) {
+      return TritonGPUConversionTarget::isDynamicallyLegal(op, typeConverter) &&
+             isTMEMOperandDynamicallyLegal(op, op.getSrc().getType(),
+                                           op.getDst().getType());
+    });
+    target.addDynamicallyLegalOp<ttng::TMEMAllocOp>([&](ttng::TMEMAllocOp op) {
+      return TritonGPUConversionTarget::isDynamicallyLegal(op, typeConverter) &&
+             (!op.getSrc() || isTMEMOperandDynamicallyLegal(
+                                  op, op.getSrc().getType(), op.getType()));
+    });
+    target.addDynamicallyLegalOp<LocalLoadOp>([&](Operation *op) {
+      return TritonGPUConversionTarget::isDynamicallyLegal(op, typeConverter);
+    });
     // rewrite patterns
     RewritePatternSet patterns(context);
     // add rules
@@ -113,6 +149,7 @@ public:
         // clang-format off
         GatherScatterOpPattern<ttng::AsyncTMAGatherOp>,
         GatherScatterOpPattern<ttng::AsyncTMAScatterOp>,
+        LocalLoadOpPattern,
         TMEMLoadOpPattern,
         TMEMStoreOpPattern,
         TMEMAllocOpPattern

--- a/test/TritonGPU/optimize-partition-warps.mlir
+++ b/test/TritonGPU/optimize-partition-warps.mlir
@@ -9,6 +9,8 @@
 #blocked_tmem = #ttg.blocked<{sizePerThread = [1, 16], threadsPerWarp = [16, 2], warpsPerCTA = [4, 2], order = [0, 1]}>
 #shared_1d = #ttg.swizzled_shared<{vec = 1, perPhase = 1, maxPhase = 1, order = [0]}>
 #shared = #ttg.nvmma_shared<{swizzlingByteWidth = 32, transposed = false, elementBitWidth = 8}>
+#shared_bf16 = #ttg.nvmma_shared<{swizzlingByteWidth = 32, transposed = false, elementBitWidth = 16}>
+#shared_f32 = #ttg.nvmma_shared<{swizzlingByteWidth = 32, transposed = false, elementBitWidth = 32}>
 #bar_layout = #ttg.swizzled_shared<{vec = 1, perPhase = 1, maxPhase = 1, order = [0]}>
 #tmem = #ttng.tensor_memory_encoding<blockM = 64, blockN = 64, colStride = 1>
 #tmem1 = #ttng.tensor_memory_encoding<blockM = 128, blockN = 64, colStride = 1>
@@ -74,6 +76,40 @@ tt.func @large_tensor_computation(%arg0: i32) {
     ttg.local_store %3, %arg2 : tensor<128x256xf16, #blocked2d_8> -> !ttg.memdesc<128x256xf16, #shared, #smem, mutable>
     ttg.warp_return
   } : (i32, !ttg.memdesc<128x256xf16, #shared, #smem, mutable>) -> ()
+  tt.return
+}
+
+// CHECK-LABEL: @local_load_store
+tt.func @local_load_store(%arg0: i32) {
+  %alloc = ttg.local_alloc : () -> !ttg.memdesc<16x128xbf16, #shared_bf16, #smem, mutable>
+  ttg.warp_specialize(%arg0, %alloc)
+  default {
+    ttg.warp_yield
+  }
+  // CHECK: partition0({{.*}}) num_warps(1)
+  partition0(%arg1: i32, %arg2: !ttg.memdesc<16x128xbf16, #shared_bf16, #smem, mutable>) num_warps(4) {
+    // CHECK: ttg.local_load {{.*}} -> tensor<16x128xbf16, #{{.*}}>
+    %0 = ttg.local_load %arg2 : !ttg.memdesc<16x128xbf16, #shared_bf16, #smem, mutable> -> tensor<16x128xbf16, #blocked2d_4>
+    ttg.local_store %0, %arg2 : tensor<16x128xbf16, #blocked2d_4> -> !ttg.memdesc<16x128xbf16, #shared_bf16, #smem, mutable>
+    ttg.warp_return
+  } : (i32, !ttg.memdesc<16x128xbf16, #shared_bf16, #smem, mutable>) -> ()
+  tt.return
+}
+
+// CHECK-LABEL: @local_load_tmem_alloc
+tt.func @local_load_tmem_alloc(%arg0: i32) {
+  %alloc = ttg.local_alloc : () -> !ttg.memdesc<64x64xf32, #shared_f32, #smem, mutable>
+  ttg.warp_specialize(%arg0, %alloc)
+  default {
+    ttg.warp_yield
+  }
+  // CHECK: partition0({{.*}}) num_warps(4)
+  partition0(%arg1: i32, %arg2: !ttg.memdesc<64x64xf32, #shared_f32, #smem, mutable>) num_warps(8) {
+    %0 = ttg.local_load %arg2 : !ttg.memdesc<64x64xf32, #shared_f32, #smem, mutable> -> tensor<64x64xf32, #blocked_tmem>
+    %1 = ttng.tmem_alloc %0 : (tensor<64x64xf32, #blocked_tmem>) -> !ttg.memdesc<64x64xf32, #tmem, #ttng.tensor_memory>
+    "use"(%1) : (!ttg.memdesc<64x64xf32, #tmem, #ttng.tensor_memory>) -> ()
+    ttg.warp_return
+  } : (i32, !ttg.memdesc<64x64xf32, #shared_f32, #smem, mutable>) -> ()
   tt.return
 }
 


### PR DESCRIPTION
Relayout local_load results when partition warp relayout clears tensor encodings. Add a regression for a local_load/local_store handoff that shrinks to one warp.
