### PR TITLE
[Test] Replace np.concat with np.concatenate in test_libdevice_rint

### DIFF
--- a/python/test/unit/language/test_core.py
+++ b/python/test/unit/language/test_core.py
@@ -7075,7 +7075,7 @@ def test_libdevice_rint(dtype_str, device):
     x0_np = np.random.uniform(iinfo32.min, iinfo32.max + 1, size)
     x1_np = np.random.uniform(iinfo64.min, iinfo64.max + 1, size)
     x2_np = np.array([-2.5, -1.5, -0.5, -0., 0., 0.5, 1.5, 2.5, float("inf"), -float("inf"), float("nan")])
-    x_np = np.concat((x0_np, x1_np, x2_np))
+    x_np = np.concatenate((x0_np, x1_np, x2_np))
     x_tri = to_triton(x_np, device=device, dst_type=dtype_str)
 
     @triton.jit


### PR DESCRIPTION
### Summary

Replace `np.concat` with `np.concatenate` in `test_libdevice_rint` to fix
test failures with NumPy < 2.0.

### Problem

`np.concat` was introduced in NumPy 2.0+. The project does not pin a minimum
NumPy version (only `numpy` is listed in `test-requirements.txt`), so it would
be better to be compatible with NumPy 1.x as well. Using `np.concat` causes an
`AttributeError` on environments with NumPy < 2.0:

```
FAILED language/test_core.py::test_libdevice_rint[float32] - AttributeError: module 'numpy' has no attribute 'concat'
FAILED language/test_core.py::test_libdevice_rint[float64] - AttributeError: module 'numpy' has no attribute 'concat'
```

### Fix

Use `np.concatenate`, which is available in all NumPy versions and is
functionally equivalent for this use case. This is also consistent with the
rest of the codebase, which also uses `np.concatenate`.

### Testing

- Verified `test_libdevice_rint[float32]` and `test_libdevice_rint[float64]`
  pass after the change.

<!---
The core Triton is a small number of people, and we receive many PRs (thank
you!).  To help us review your code more quickly, **if you are a new
contributor (less than 3 PRs merged) we ask that you complete the following
tasks and include the filled-out checklist in your PR description.**

Complete the following tasks before sending your PR, and replace `[ ]` with
`[x]` to indicate you have done them.
-->

# New contributor declaration
- [x] I am not making a trivial change, such as fixing a typo in a comment.

- [x] I have written a PR description following these
  [rules](https://cbea.ms/git-commit/#why-not-how).

- [ ] I have run `pre-commit run --from-ref origin/main --to-ref HEAD`.

- Select one of the following.
  - [ ] I have added tests.
    - `/test` for `lit` tests
    - `/unittest` for C++ tests
    - `/python/test` for end-to-end tests
  - [x] This PR does not need a test because `FILL THIS IN`.

- Select one of the following.
  - [x] I have not added any `lit` tests.
  - [ ] The `lit` tests I have added follow these [best practices](https://mlir.llvm.org/getting_started/TestingGuide/#filecheck-best-practices),
    including the "tests should be minimal" section. (Usually running Python code
    and using the instructions it generates is not minimal.)
