### PR TITLE
Fix invalid kWidth widening heuristic for JoinOp

### DIFF
--- a/lib/Dialect/TritonGPU/Transforms/AccelerateMatmul.cpp
+++ b/lib/Dialect/TritonGPU/Transforms/AccelerateMatmul.cpp
@@ -242,6 +242,32 @@ static bool bwdFilter(Operation *op) {
              ConvertLayoutOp>(op);
 }
 
+static bool joinPacksLastDim(JoinOp join) {
+  auto type = cast<RankedTensorType>(join.getResult().getType());
+  unsigned rank = type.getRank();
+  if (rank < 2)
+    return false;
+
+  auto enc = cast<BlockedEncodingAttr>(type.getEncoding());
+  ArrayRef<unsigned> order = enc.getOrder();
+  // Check that the appended join axis
+  // and the previous last axis are the two fastest-changing axes, so the join
+  // packs the last dimension contiguously.
+  return order.size() == rank && order[0] == rank - 1 && order[1] == rank - 2;
+}
+
+static bool canWidenKWidthForJoin(int loadBitWidth,
+                                  const SetVector<Operation *> &slice) {
+  return llvm::any_of(slice, [loadBitWidth](Operation *op) {
+    auto join = dyn_cast<JoinOp>(op);
+        if (!join)
+          return false;
+        auto type = cast<RankedTensorType>(join.getResult().getType());
+        return type.getElementTypeBitWidth() == loadBitWidth * 2 &&
+               joinPacksLastDim(join);
+      });
+}
+
 // Finds the bitwidth with which the value x is loaded
 static int computeOrigBitWidth(Value x) {
   SetVector<Operation *> slice;
@@ -277,7 +303,12 @@ static int computeOrigBitWidth(Value x) {
   // In the future we might want to do something like trying a large kWidth,
   // run layout backpropagation and see what's the contiguity that you
   // get at the loads that feed into it.
-  if (llvm::any_of(slice, [](Operation *op) { return isa<JoinOp>(op); }))
+  //
+  // This heuristic is intended for packed-K values of shape [..., K / 2]
+  // joined into [..., K / 2, 2]. We also check that the bitwidth of the joined
+  // value is twice the original bitwidth, meaning "one loaded storage element
+  // contributes two logical K values after unpack/join".
+  if (canWidenKWidthForJoin(origBitWidth, slice))
     origBitWidth /= 2;
 
   return origBitWidth;

--- a/lib/Dialect/TritonGPU/Transforms/AccelerateMatmul.cpp
+++ b/lib/Dialect/TritonGPU/Transforms/AccelerateMatmul.cpp
@@ -250,9 +250,8 @@ static bool joinPacksLastDim(JoinOp join) {
 
   auto enc = cast<BlockedEncodingAttr>(type.getEncoding());
   ArrayRef<unsigned> order = enc.getOrder();
-  // Check that the appended join axis
-  // and the previous last axis are the two fastest-changing axes, so the join
-  // packs the last dimension contiguously.
+  // Check that the appended join axis and the previous last axis are the two
+  // fastest-changing axes, so the join packs the last dimension contiguously.
   return order.size() == rank && order[0] == rank - 1 && order[1] == rank - 2;
 }
 
@@ -260,12 +259,12 @@ static bool canWidenKWidthForJoin(int loadBitWidth,
                                   const SetVector<Operation *> &slice) {
   return llvm::any_of(slice, [loadBitWidth](Operation *op) {
     auto join = dyn_cast<JoinOp>(op);
-        if (!join)
-          return false;
-        auto type = cast<RankedTensorType>(join.getResult().getType());
-        return type.getElementTypeBitWidth() == loadBitWidth * 2 &&
-               joinPacksLastDim(join);
-      });
+    if (!join)
+      return false;
+    auto type = cast<RankedTensorType>(join.getResult().getType());
+    return type.getElementTypeBitWidth() == loadBitWidth * 2 &&
+           joinPacksLastDim(join);
+  });
 }
 
 // Finds the bitwidth with which the value x is loaded

--- a/lib/Dialect/TritonGPU/Transforms/AccelerateMatmul.cpp
+++ b/lib/Dialect/TritonGPU/Transforms/AccelerateMatmul.cpp
@@ -248,11 +248,10 @@ static bool joinPacksLastDim(JoinOp join) {
   if (rank < 2)
     return false;
 
-  auto enc = cast<BlockedEncodingAttr>(type.getEncoding());
-  ArrayRef<unsigned> order = enc.getOrder();
+  auto order = getOrder(type);
   // Check that the appended join axis and the previous last axis are the two
   // fastest-changing axes, so the join packs the last dimension contiguously.
-  return order.size() == rank && order[0] == rank - 1 && order[1] == rank - 2;
+  return order[0] == rank - 1 && order[1] == rank - 2;
 }
 
 static bool canWidenKWidthForJoin(int loadBitWidth,

--- a/python/test/unit/language/test_matmul.py
+++ b/python/test/unit/language/test_matmul.py
@@ -75,6 +75,32 @@ def matmul_kernel(  #
         tl.store(output_ptrs, accumulator)
 
 
+@triton.jit
+def matmul_i4_m_minor_kernel(w4_ptr, rhs_ptr, output_ptr, BLOCK_M: tl.constexpr, BLOCK_N: tl.constexpr,
+                             BLOCK_K: tl.constexpr):
+    offs_pm = tl.arange(0, BLOCK_M // 2)
+    offs_m = tl.arange(0, BLOCK_M)
+    offs_n = tl.arange(0, BLOCK_N)
+    offs_k = tl.arange(0, BLOCK_K)
+
+    packed = tl.load(w4_ptr + offs_k[None, :] * (BLOCK_M // 2) + offs_pm[:, None])
+    low = (packed << 4) >> 4
+    high = packed >> 4
+    joined = tl.join(low, high)
+    lhs_i8 = tl.reshape(tl.trans(joined, 0, 2, 1), (BLOCK_M, BLOCK_K))
+    lhs = lhs_i8.to(tl.bfloat16)
+
+    rhs = tl.load(rhs_ptr + offs_k[:, None] * BLOCK_N + offs_n[None, :])
+    acc = tl.dot(lhs, rhs, input_precision="tf32")
+    tl.store(output_ptr + offs_m[:, None] * BLOCK_N + offs_n[None, :], acc)
+
+
+def pack_i4_m_minor(x):
+    x = x.T.contiguous().to(torch.int16) & 0xF
+    packed = x[:, 0::2] | (x[:, 1::2] << 4)
+    return packed.to(torch.uint8).view(torch.int8).contiguous()
+
+
 def get_src_element_ty_size(dtype_str):
     if dtype_str == "float8e5":
         return 1
@@ -177,6 +203,27 @@ def test_simple_matmul(dtype_src_str, dtype_dst_str, BLOCK_M, BLOCK_N, BLOCK_K, 
             if "32x32b" not in ptx and "16x32b" not in ptx:
                 print(ptx)
             assert ("32x32b" in ptx) or ("16x32b" in ptx), "PTX does not contain 32x32b or 16x32b"
+
+
+def test_i4_m_minor_join_bk16_matmul(device):
+    if not is_cuda():
+        pytest.skip("i4 M-minor join regression is CUDA-specific")
+    if torch.cuda.get_device_capability()[0] < 8:
+        pytest.skip("bf16 dot requires NVIDIA compute capability >= 8")
+
+    M, N, K = 64, 64, 16
+    torch.manual_seed(6120775)
+
+    w_i4 = torch.randint(-8, 8, (M, K), device=device, dtype=torch.int8)
+    w4 = pack_i4_m_minor(w_i4)
+    rhs = torch.randn((K, N), device=device, dtype=torch.float32).bfloat16()
+    output = torch.empty((M, N), device=device, dtype=torch.float32)
+
+    matmul_i4_m_minor_kernel[(1,)](w4, rhs, output, BLOCK_M=M, BLOCK_N=N, BLOCK_K=K, num_warps=2, num_stages=1)
+
+    ref_lhs = w_i4.float().bfloat16()
+    ref = torch.matmul(ref_lhs.float(), rhs.float())
+    torch.testing.assert_close(output, ref, atol=1e-3, rtol=1e-3)
 
 
 # persistent matmul with fused loops

--- a/python/test/unit/language/test_matmul.py
+++ b/python/test/unit/language/test_matmul.py
@@ -219,7 +219,7 @@ def test_i4_m_minor_join_bk16_matmul(device):
     rhs = torch.randn((K, N), device=device, dtype=torch.float32).bfloat16()
     output = torch.empty((M, N), device=device, dtype=torch.float32)
 
-    matmul_i4_m_minor_kernel[(1,)](w4, rhs, output, BLOCK_M=M, BLOCK_N=N, BLOCK_K=K, num_warps=2, num_stages=1)
+    matmul_i4_m_minor_kernel[(1, )](w4, rhs, output, BLOCK_M=M, BLOCK_N=N, BLOCK_K=K, num_warps=2, num_stages=1)
 
     ref_lhs = w_i4.float().bfloat16()
     ref = torch.matmul(ref_lhs.float(), rhs.float())

--- a/test/TritonGPU/accelerate-matmul.mlir
+++ b/test/TritonGPU/accelerate-matmul.mlir
@@ -185,6 +185,35 @@ module attributes {"ttg.target" = "cuda:80", "ttg.num-ctas" = 1 : i32, "ttg.num-
 
 // -----
 
+// CHECK-LABEL: join_unpacked_i8_dot
+// CHECK: tt.dot {{.*}} : tensor<64x16xbf16, #ttg.dot_op<{opIdx = 0, parent = #{{[a-zA-Z0-9_]+}}, kWidth = 4}>> * tensor<16x64xbf16, #ttg.dot_op<{opIdx = 1, parent = #{{[a-zA-Z0-9_]+}}, kWidth = 4}>>
+#blocked_acc = #ttg.blocked<{sizePerThread = [1, 4], threadsPerWarp = [2, 16], warpsPerCTA = [2, 1], order = [1, 0]}>
+#blocked_rhs = #ttg.blocked<{sizePerThread = [1, 8], threadsPerWarp = [4, 8], warpsPerCTA = [2, 1], order = [1, 0]}>
+#blocked_pair = #ttg.blocked<{sizePerThread = [8, 1], threadsPerWarp = [4, 8], warpsPerCTA = [1, 2], order = [0, 1]}>
+#blocked_lhs = #ttg.blocked<{sizePerThread = [16, 1], threadsPerWarp = [4, 8], warpsPerCTA = [1, 2], order = [0, 1]}>
+#blocked_join = #ttg.blocked<{sizePerThread = [8, 1, 2], threadsPerWarp = [4, 8, 1], warpsPerCTA = [1, 2, 1], order = [2, 0, 1]}>
+#blocked_trans = #ttg.blocked<{sizePerThread = [8, 2, 1], threadsPerWarp = [4, 1, 8], warpsPerCTA = [1, 1, 2], order = [1, 0, 2]}>
+module attributes {"ttg.target" = "cuda:80", "ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 2 : i32, "ttg.threads-per-warp" = 32 : i32} {
+  tt.func @join_unpacked_i8_dot(
+      %pa: tensor<32x16x!tt.ptr<i8>, #blocked_pair>,
+      %pb: tensor<16x64x!tt.ptr<bf16>, #blocked_rhs>)
+      -> tensor<64x64xf32, #blocked_acc> {
+    %acc = arith.constant dense<0.000000e+00> : tensor<64x64xf32, #blocked_acc>
+    %a_i8 = tt.load %pa : tensor<32x16x!tt.ptr<i8>, #blocked_pair>
+    %a_bf16 = arith.sitofp %a_i8 : tensor<32x16xi8, #blocked_pair> to tensor<32x16xbf16, #blocked_pair>
+    %joined = tt.join %a_bf16, %a_bf16 : tensor<32x16xbf16, #blocked_pair> -> tensor<32x16x2xbf16, #blocked_join>
+    %trans = tt.trans %joined {order = array<i32: 0, 2, 1>} : tensor<32x16x2xbf16, #blocked_join> -> tensor<32x2x16xbf16, #blocked_trans>
+    %lhs = tt.reshape %trans : tensor<32x2x16xbf16, #blocked_trans> -> tensor<64x16xbf16, #blocked_lhs>
+    %rhs = tt.load %pb : tensor<16x64x!tt.ptr<bf16>, #blocked_rhs>
+    %lhs_dot = ttg.convert_layout %lhs : tensor<64x16xbf16, #blocked_lhs> -> tensor<64x16xbf16, #ttg.dot_op<{opIdx = 0, parent = #blocked_acc}>>
+    %rhs_dot = ttg.convert_layout %rhs : tensor<16x64xbf16, #blocked_rhs> -> tensor<16x64xbf16, #ttg.dot_op<{opIdx = 1, parent = #blocked_acc}>>
+    %result = tt.dot %lhs_dot, %rhs_dot, %acc, inputPrecision = tf32 : tensor<64x16xbf16, #ttg.dot_op<{opIdx = 0, parent = #blocked_acc}>> * tensor<16x64xbf16, #ttg.dot_op<{opIdx = 1, parent = #blocked_acc}>> -> tensor<64x64xf32, #blocked_acc>
+    tt.return %result : tensor<64x64xf32, #blocked_acc>
+  }
+}
+
+// -----
+
 // CHECK: #mma = #ttg.nvidia_mma<{versionMajor = 3, {{.*}}, instrShape = [16, 32, 16]}>
 #blocked = #ttg.blocked<{sizePerThread = [4, 4], threadsPerWarp = [1, 32], warpsPerCTA = [32, 1], order = [1, 0]}>
 module attributes {"ttg.target" = "cuda:90", "ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 32 : i32, "ttg.threads-per-warp" = 32 : i32} {


### PR DESCRIPTION
The heuristic added in https://github.com/triton-lang/triton/pull/5924,
https://github.com/triton-lang/triton/blob/a8419b6502ffb41ac51918bcbf3074fced5fcfd5/lib/Dialect/TritonGPU/Transforms/AccelerateMatmul.cpp#L280-L281

is invalid when the join operates on a non-K axis, since it is intended to increase the dot operand kWidth to preserve load width for packed-K unpack patterns. When this heuristic is incorrectly applied to an MN-major tensor and `BLOCK_K` is small, it can result in a correctness error since the doubled `kWidth` in the layout suggests that there are more distinct K elements in the input than there are for a small `BLOCK_K`. 

The bug manifests in PTX as multiple `ld.shared` loading from the same location when they should get distinct values (unintended broadcasting from `ensureLayoutNotLargerThan`).