### PR TITLE
Fix stale remat value reuse in RemoveLayoutConversions

### DIFF
--- a/lib/Dialect/TritonGPU/Transforms/RemoveLayoutConversions.cpp
+++ b/lib/Dialect/TritonGPU/Transforms/RemoveLayoutConversions.cpp
@@ -846,8 +846,10 @@ void LayoutRematerialization::rewriteSlice(
       addRematValue(old, it->second, newV);
     }
   }
-  // Check mapping and see if there are existing convertOps on the old Argument
-  convertOp.replaceAllUsesWith(mapping.lookup(convertOp.getSrc()));
+  // Add the rewritten convert to the replacements so it is removed from the
+  // remat maps and has its uses replaced like the other ops we delete.
+  replacements.emplace_back(convertOp.getResult(),
+                            mapping.lookup(convertOp.getSrc()));
 
   updateRematMapping(replacements);
   for (auto &kv : replacements) {

--- a/test/TritonGPU/remove-layout-conversions-backward-remat-reuse.mlir
+++ b/test/TritonGPU/remove-layout-conversions-backward-remat-reuse.mlir
@@ -1,0 +1,33 @@
+// RUN: triton-opt %s -tritongpu-remove-layout-conversions | FileCheck %s
+
+// CHECK-LABEL: @backward_remat_reuse
+// CHECK-COUNT-2: tt.broadcast
+// CHECK-COUNT-1: ttg.convert_layout
+// CHECK-NOT: ttg.convert_layout
+
+#blocked = #ttg.blocked<{sizePerThread = [1, 1], threadsPerWarp = [32, 1], warpsPerCTA = [4, 1], order = [0, 1]}>
+#blocked1 = #ttg.blocked<{sizePerThread = [4, 1], threadsPerWarp = [16, 2], warpsPerCTA = [1, 4], order = [0, 1]}>
+module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32} {
+  tt.func @backward_remat_reuse(%arg0: !tt.ptr<f32>, %arg1: i32, %arg2: i32) -> tensor<64x2xf32, #blocked> {
+    %cst_0 = arith.constant dense<1.000000e+00> : tensor<64x2xf32, #blocked>
+    %cst_1 = arith.constant dense<1> : tensor<64x2xi32, #blocked>
+    %0 = tt.splat %arg1 : i32 -> tensor<64x1xi32, #blocked1>
+    %1:2 = scf.for %arg3 = %arg2 to %arg1 step %arg1 iter_args(%arg4 = %cst_0, %arg5 = %cst_0) -> (tensor<64x2xf32, #blocked>, tensor<64x2xf32, #blocked>)  : i32 {
+      %2 = tt.broadcast %0 : tensor<64x1xi32, #blocked1> -> tensor<64x2xi32, #blocked1>
+      %3 = ttg.convert_layout %2 : tensor<64x2xi32, #blocked1> -> tensor<64x2xi32, #blocked>
+      %4 = arith.cmpi slt, %3, %cst_1 : tensor<64x2xi32, #blocked>
+      %5 = tt.broadcast %0 : tensor<64x1xi32, #blocked1> -> tensor<64x2xi32, #blocked1>
+      %6 = ttg.convert_layout %5 : tensor<64x2xi32, #blocked1> -> tensor<64x2xi32, #blocked>
+      %7 = tt.splat %arg0 : !tt.ptr<f32> -> tensor<64x2x!tt.ptr<f32>, #blocked>
+      %8 = tt.addptr %7, %6 : tensor<64x2x!tt.ptr<f32>, #blocked>, tensor<64x2xi32, #blocked>
+      %9 = ttg.convert_layout %8 : tensor<64x2x!tt.ptr<f32>, #blocked> -> tensor<64x2x!tt.ptr<f32>, #blocked1>
+      %10 = tt.load %9 : tensor<64x2x!tt.ptr<f32>, #blocked1>
+      %11 = ttg.convert_layout %10 : tensor<64x2xf32, #blocked1> -> tensor<64x2xf32, #blocked>
+      %12 = arith.select %4, %cst_0, %arg5 : tensor<64x2xi1, #blocked>, tensor<64x2xf32, #blocked>
+      %13 = arith.mulf %11, %arg5 : tensor<64x2xf32, #blocked>
+      %14 = arith.select %4, %13, %arg4 : tensor<64x2xi1, #blocked>, tensor<64x2xf32, #blocked>
+      scf.yield %14, %12 : tensor<64x2xf32, #blocked>, tensor<64x2xf32, #blocked>
+    }
+    tt.return %1#0 : tensor<64x2xf32, #blocked>
+  }
+}


### PR DESCRIPTION
## Summary

#9511 made `LayoutRematerialization` erase ops eagerly mid-walk. One of those eager erases is the rewritten `ConvertLayoutOp` in `rewriteSlice`. It is erased while the pass's remat state can still hand its result back to later conversions in the same walk, which produces a wrong-layout rematerialization. This silently miscompiles a **load address**, which we observed as NaN in PyTorch Inductor's timm training-accuracy benchmark.

The failure requires this sequence:

  1. A `ttg.convert_layout` is eliminated by backward rematerialization.
  2. `rewriteSlice` replaces its uses, but #9511 erases the convert immediately.
  3. The erased convert's result is still reachable through `rematMapping` and `mappedValues` as the same rematerialization walk continues.
  4. A later `ttg.convert_layout` asks for the same value and layout.
  5. The pass reuses the stale remat entry instead of rebuilding the correct value.
  6. In the repro this drops the `row % 192` term from the load address and reuses the `(row / 192) * 128`-derived term instead.

This PR removes the convert from the remat state before erasing it, leaving the rest of #9511 intact, and adds a lit regression test.

## Root cause

`LayoutRematerialization` walks every `ConvertLayoutOp` and rematerializes its backward slice. It keeps remat state across the walk: `rematMapping` caches the rematerialized `Value` for each old value and encoding, and `mappedValues` records which values have already been rematerialized. Together they let *later* conversions in the same walk reuse earlier results. Pre-#9511, ops produced during the walk were collected in `SetVector<Operation*> opToDelete` and erased together at the end by `cleanup()`, so a rewritten convert was never erased while the walk was still running.

#9511 dropped `opToDelete` and `cleanup()` and erased eagerly. The rewritten convert in `rewriteSlice` is still reachable through this remat state when it is erased, so a later conversion's `getRematValue` can return an entry that leads back to the erased convert. It then rematerializes against the wrong value and gets the wrong layout.

## Fix

`rewriteSlice` already keeps the remat state consistent when it deletes ops, by adding them to a `replacements` list that `updateRematMapping` processes. Give the rewritten convert the same treatment: add `(convertOp.getResult(), mapping.lookup(convertOp.getSrc()))` to `replacements`. `updateRematMapping` then rewrites the remat state so it no longer refers to the convert, and the shared replacement loop replaces the convert's IR uses with its rematerialized source. With nothing left pointing at the convert, the existing eager erase is safe and the rest of #9511 is untouched.

## Regression test

`test/TritonGPU/remove-layout-conversions-backward-remat-reuse.mlir`, reduced from the failing inductor_timm welford kernel. On the unfixed pass, `-tritongpu-remove-layout-conversions` drops the rematerialization of the per-row load-address base `row % 192` (an `arith.remsi` producing `tensor<64x1xi32>`) and reuses the divsi-derived `(row / 192) * 128` term in its place. The result is valid IR with a silently wrong load address. The test pins the full data-flow chain: it captures the rematerialized `row % 192`, its `tt.broadcast` to the loop's `64x8` shape, the `arith.addi` that folds it into the address, and requires the `tt.addptr` to consume that exact `arith.addi` result. This proves `row % 192` reaches the load address, not merely that an `arith.remsi` survives somewhere. The unfixed output omits the `tensor<64x1xi32>` remat entirely, so the first CHECK already fails.

## Test plan

- The lit test above fails on the unfixed pass and passes with the fix.
- The existing remove-layout-conversions lit tests still pass (`combine`, `remove-layout-conversions-scf-cleanup`, `matmul`, `pipeline-loop-nest`).
- End-to-end on H100 (PyTorch Inductor `inductor_timm --accuracy --training --amp`, source PyTorch and Triton trunk): correcting this load address flips the affected models from `fail_accuracy` to `pass` (`inception_v3`, `adv_inception_v3`, `ghostnet_100`, `repvgg_a2`, `tf_efficientnet_b0`, `mobilenetv2_100`, `mobilenetv3_large_100`).
