### PR TITLE
[BACKEND] Avoid crossing CTAs in local_{load,store,gather,scatter}s and convert_layouts in the presence of broadcasting

### DIFF
--- a/include/triton/Conversion/TritonGPUToLLVM/Utility.h
+++ b/include/triton/Conversion/TritonGPUToLLVM/Utility.h
@@ -610,15 +610,20 @@ struct LocalSharedMemoryAddress {
   Value ctaId;
 };
 
-// Compute per-element shared-memory addresses for a local atomic/ldst update by
-// replacing `coords[*][axis]` with `idxValues[*]` and mapping the resulting
-// logical coordinates back to shared-memory offsets and target CTAs.
+// Compute per-element shared-memory offsets and target CTAs for a local
+// gather/scatter. The index replaces the logical coordinate along `axis`; all
+// other coordinates come from `regLayout`. The target CTA is null for local
+// accesses.
+SmallVector<std::pair<Value, Value>> computeBlockLocalOffsets(
+    Location loc, triton::gpu::MemDescType memDescTy,
+    const LinearLayout &regLayout, ArrayRef<Value> idxValues, unsigned axis,
+    RewriterBase &rewriter, const TargetInfoBase &targetInfo);
+
 SmallVector<LocalSharedMemoryAddress>
-computeLocalAddrs(Location loc, triton::gpu::MemDescType memDescTy,
-                  SharedMemoryObject smemObj, Type llvmElemTy,
-                  ArrayRef<Value> idxValues,
-                  ArrayRef<SmallVector<Value>> coords, unsigned axis,
-                  RewriterBase &rewriter, ArrayRef<Value> offsets = {});
+materializeLocalAddrs(Location loc, triton::gpu::MemDescType memDescTy,
+                      SharedMemoryObject smemObj, Type llvmElemTy,
+                      ArrayRef<std::pair<Value, Value>> offsetAndBlock,
+                      RewriterBase &rewriter);
 
 // Backend-agnostic preparation for lowering LocalAtomicScatterRMWOp.
 struct LocalAtomicScatterRMWInfo {

--- a/include/triton/Tools/LayoutUtils.h
+++ b/include/triton/Tools/LayoutUtils.h
@@ -10,6 +10,12 @@ namespace mlir::triton {
 bool squareSublayoutIsIdentity(const LinearLayout &ll,
                                ArrayRef<StringAttr> dimNames);
 
+// Compute B.invertAndCompose(A), mapping block bits broadcast by A to the
+// corresponding input block bits instead of block zero. This keeps replicated
+// memory accesses local without changing the composition.
+[[nodiscard]] LinearLayout invertAndComposeBlockLocal(const LinearLayout &A,
+                                                      const LinearLayout &B);
+
 // For each output dimension d, ensure that the layout's output size (i.e., its
 // codomain) does not exceed shape[d]. Do this without changing the size of the
 // layout's inputs (i.e., leave its domain unchanged).

--- a/include/triton/Tools/LinearLayout.h
+++ b/include/triton/Tools/LinearLayout.h
@@ -677,6 +677,15 @@ public:
   // does not map other dimensions onto those or these onto other dimensions.
   bool isTrivialOver(ArrayRef<StringAttr> dimNames) const;
 
+  // Returns true if the output dimension `dim` is equal to the input dimension
+  // `dim`. Other input dimensions must not affect this output dimension, but
+  // `dim` is allowed to affect other output dimensions.
+  //
+  // For example, a layout mapping block -> (offset, block) as (1, 1) is the
+  // identity on the block output dimension, even though it is not trivial over
+  // block because block also affects offset.
+  bool isIdentityOnOutDim(StringAttr dim) const;
+
   // For an endomorphism on dimNames (linear map that maps dimNames to dimNames)
   // checks whether it is the identity map on these dimensions (i.e
   // LinearLayouts::isTrivialOver) and if so, returns the sublayout of the

--- a/lib/Analysis/Utility.cpp
+++ b/lib/Analysis/Utility.cpp
@@ -1335,15 +1335,15 @@ std::unique_ptr<DataFlowSolver> createDataFlowSolver() {
 
 bool isCvtDimSync(const triton::LinearLayout &srcLayout,
                   const triton::LinearLayout &dstLayout, StringAttr dim) {
-  // We can use a dimension-level sync when the conversion is trivial over that
-  // dimension and there is no broadcasting over it.
+  // We can use a dimension-level sync when the conversion can be realized
+  // without moving values across that dimension.
   auto *ctx = srcLayout.getInDimNames().begin()->getContext();
   auto kWarp = StringAttr::get(ctx, "warp");
   auto kBlock = StringAttr::get(ctx, "block");
   assert(srcLayout.hasInDim(dim) && dstLayout.hasInDim(dim) &&
          "expected dim to be present in both layouts");
-  auto comp = dstLayout.invertAndCompose(srcLayout);
   if (dim == kWarp) {
+    auto comp = dstLayout.invertAndCompose(srcLayout);
     // We check that it's trivial over block and warps and that
     // there is no broadcasting over warp, as if there is, we'll
     // deduplicate the writes and the reads will read from data
@@ -1354,7 +1354,8 @@ bool isCvtDimSync(const triton::LinearLayout &srcLayout,
            dstLayout.getFreeVariableMasks()[dim] == 0;
   } else {
     assert(dim == kBlock);
-    return comp.isTrivialOver(dim);
+    return invertAndComposeBlockLocal(srcLayout, dstLayout)
+        .isIdentityOnOutDim(dim);
   }
 }
 } // namespace mlir

--- a/lib/Conversion/TritonGPUToLLVM/ConvertLayoutOpToLLVM.cpp
+++ b/lib/Conversion/TritonGPUToLLVM/ConvertLayoutOpToLLVM.cpp
@@ -186,7 +186,7 @@ struct ConvertLayoutOpConversion
     auto reps = LinearLayout::identity1D(nReps, kReg, kReps);
 
     auto totalStoreCvt = srcLayout.invertAndCompose(smem);
-    auto totalLoadCvt = dstLayout.invertAndCompose(smem);
+    auto totalLoadCvt = invertAndComposeBlockLocal(smem, dstLayout);
 
     // The permutation exists by construction of the reps dimension in
     // optimalSwizzling

--- a/lib/Conversion/TritonGPUToLLVM/MemoryOpToLLVM.cpp
+++ b/lib/Conversion/TritonGPUToLLVM/MemoryOpToLLVM.cpp
@@ -17,20 +17,23 @@ using namespace mlir::triton::gpu;
 // Helper for LocalGather/ScatterOpConversion.
 // For gather: storeVals is empty, returns loaded values.
 // For scatter: storeVals contains values to store, returns empty.
-SmallVector<Value>
-lowerLocalScGt(Location loc, MLIRContext *ctx, MemDescType memDescTy,
-               SharedMemoryObject smemObj, Type llvmElemTy,
-               ArrayRef<Value> idxValues, ArrayRef<SmallVector<Value>> coords,
-               unsigned axis, ArrayRef<Value> storeVals, RewriterBase &rewriter,
-               const TargetInfoBase &targetInfo) {
+SmallVector<Value> lowerLocalScGt(Location loc, MemDescType memDescTy,
+                                  SharedMemoryObject smemObj, Type llvmElemTy,
+                                  const LinearLayout &regLayout,
+                                  ArrayRef<Value> idxValues, unsigned axis,
+                                  ArrayRef<Value> storeVals,
+                                  RewriterBase &rewriter,
+                                  const TargetInfoBase &targetInfo) {
   auto b = TritonLLVMOpBuilder(loc, rewriter);
   bool isScatter = !storeVals.empty();
-  SmallVector<LocalSharedMemoryAddress> addrs = computeLocalAddrs(
-      loc, memDescTy, smemObj, llvmElemTy, idxValues, coords, axis, rewriter);
+  auto offsetAndBlock = computeBlockLocalOffsets(
+      loc, memDescTy, regLayout, idxValues, axis, rewriter, targetInfo);
+  SmallVector<LocalSharedMemoryAddress> addrs = materializeLocalAddrs(
+      loc, memDescTy, smemObj, llvmElemTy, offsetAndBlock, rewriter);
 
   SmallVector<Value> results;
   if (!isScatter)
-    results.resize(coords.size());
+    results.resize(idxValues.size());
 
   for (auto [i, addr] : llvm::enumerate(addrs)) {
     if (isScatter) {
@@ -266,7 +269,6 @@ public:
   matchAndRewrite(LocalGatherOp op, OpAdaptor adaptor,
                   ConversionPatternRewriter &rewriter) const override {
     auto loc = op.getLoc();
-    auto *ctx = op.getContext();
     auto memDescTy = cast<MemDescType>(op.getSrc().getType());
     // TODO: PartitionedSharedEncoding lowering will be enabled in subsequent
     // PRs.
@@ -284,12 +286,10 @@ public:
 
     SmallVector<Value> idxValues =
         unpackLLElements(loc, adaptor.getIndices(), rewriter);
-    SmallVector<SmallVector<Value>> dstIndices =
-        emitIndices(loc, rewriter, targetInfo, regTy.getEncoding(), regTy,
-                    /*withCTAOffset=*/true);
+    auto regLayout = toLinearLayout(regTy);
 
-    auto results = lowerLocalScGt(loc, ctx, memDescTy, smemObj, llvmElemTy,
-                                  idxValues, dstIndices, op.getAxis(),
+    auto results = lowerLocalScGt(loc, memDescTy, smemObj, llvmElemTy,
+                                  regLayout, idxValues, op.getAxis(),
                                   /*storeVals=*/{}, rewriter, targetInfo);
 
     Value result = packLLElements(loc, typeConverter, results, rewriter, regTy);
@@ -315,7 +315,6 @@ public:
   matchAndRewrite(LocalScatterOp op, OpAdaptor adaptor,
                   ConversionPatternRewriter &rewriter) const override {
     auto loc = op.getLoc();
-    auto *ctx = op.getContext();
     auto memDescTy = cast<MemDescType>(op.getDst().getType());
     // TODO: PartitionedSharedEncoding lowering will be enabled in subsequent
     // PRs.
@@ -335,12 +334,10 @@ public:
         unpackLLElements(loc, adaptor.getValues(), rewriter);
     SmallVector<Value> idxValues =
         unpackLLElements(loc, adaptor.getIndices(), rewriter);
-    SmallVector<SmallVector<Value>> srcIndices =
-        emitIndices(loc, rewriter, targetInfo, valuesTy.getEncoding(), valuesTy,
-                    /*withCTAOffset=*/true);
+    auto regLayout = toLinearLayout(valuesTy);
 
-    lowerLocalScGt(loc, ctx, memDescTy, smemObj, llvmElemTy, idxValues,
-                   srcIndices, op.getAxis(), values, rewriter, targetInfo);
+    lowerLocalScGt(loc, memDescTy, smemObj, llvmElemTy, regLayout, idxValues,
+                   op.getAxis(), values, rewriter, targetInfo);
 
     rewriter.eraseOp(op);
     return success();

--- a/lib/Conversion/TritonGPUToLLVM/MemoryOpToLLVM.cpp
+++ b/lib/Conversion/TritonGPUToLLVM/MemoryOpToLLVM.cpp
@@ -58,7 +58,7 @@ LogicalResult lowerLocalStore(Location loc, MLIRContext *ctx, Value regVal,
   auto sharedLayout = isPaddedEncoding(memDescTy.getEncoding())
                           ? paddedLinearLayout(memDescTy)
                           : toLinearLayout(memDescTy);
-  auto cvt = regLayout.invertAndCompose(sharedLayout);
+  auto cvt = invertAndComposeBlockLocal(sharedLayout, regLayout);
 
   lowerLocalLdSt(loc, ctx, cvt, inVals, llvmElemTy, memDescTy, smemObj,
                  rewriter, targetInfo);
@@ -185,7 +185,7 @@ public:
     auto sharedLayout = isPaddedEncoding(memDescTy.getEncoding())
                             ? paddedLinearLayout(memDescTy)
                             : toLinearLayout(memDescTy);
-    auto cvt = regLayout.invertAndCompose(sharedLayout);
+    auto cvt = invertAndComposeBlockLocal(sharedLayout, regLayout);
 
     auto outVals = lowerLocalLdSt(loc, ctx, cvt, {}, llvmElemTy, memDescTy,
                                   smemObj, rewriter, targetInfo, op);

--- a/lib/Conversion/TritonGPUToLLVM/Utility.cpp
+++ b/lib/Conversion/TritonGPUToLLVM/Utility.cpp
@@ -540,64 +540,91 @@ emitIndices(Location loc, RewriterBase &rewriter, const TargetInfoBase &target,
   return emitIndices(loc, rewriter, target, ll, type, withCTAOffset);
 }
 
-SmallVector<LocalSharedMemoryAddress>
-computeLocalAddrs(Location loc, triton::gpu::MemDescType memDescTy,
-                  SharedMemoryObject smemObj, Type llvmElemTy,
-                  ArrayRef<Value> idxValues,
-                  ArrayRef<SmallVector<Value>> coords, unsigned axis,
-                  RewriterBase &rewriter, ArrayRef<Value> offsets) {
+SmallVector<std::pair<Value, Value>> computeBlockLocalOffsets(
+    Location loc, triton::gpu::MemDescType memDescTy,
+    const LinearLayout &regLayout, ArrayRef<Value> idxValues, unsigned axis,
+    RewriterBase &rewriter, const TargetInfoBase &targetInfo) {
   MLIRContext *ctx = memDescTy.getContext();
   auto b = TritonLLVMOpBuilder(loc, rewriter);
-
-  // Get the shared memory layout (linear component for padded layouts)
   auto sharedLayout = triton::gpu::isPaddedEncoding(memDescTy.getEncoding())
                           ? paddedLinearLayout(memDescTy)
                           : toLinearLayout(memDescTy);
-  LinearLayout invSharedLayout = sharedLayout.pseudoinvert();
-
-  // Get layout dimension names for all dims
-  SmallVector<StringAttr> allDims;
-  for (unsigned dim = 0, rank = memDescTy.getRank(); dim < rank; ++dim)
-    allDims.push_back(str_attr("dim" + Twine(dim)));
-
+  auto allDims = standardOutDimNames(ctx, memDescTy.getRank());
+  auto kRegister = str_attr("register");
+  auto kLane = str_attr("lane");
+  auto kWarp = str_attr("warp");
   auto kOffset = str_attr("offset");
   auto kBlock = str_attr("block");
-  bool isMultiCTA = invSharedLayout.getOutDimSize(kBlock) > 1;
+  StringAttr axisDim = allDims[axis];
+  LinearLayout orderedRegLayout = regLayout.transposeOuts(allDims);
+  assert(idxValues.size() == regLayout.getInDimSize(kRegister));
+
+  auto toI32 = [&](Value idx) -> Value {
+    unsigned idxWidth = idx.getType().getIntOrFloatBitWidth();
+    if (idxWidth > 32)
+      return b.trunc(i32_ty, idx);
+    if (idxWidth < 32)
+      return b.zext(i32_ty, idx);
+    return idx;
+  };
+
+  SmallVector<std::pair<Value, Value>> offsetAndBlock;
+  offsetAndBlock.reserve(idxValues.size());
+
+  auto [laneId, warpId] = getLaneAndWarpId(rewriter, loc);
+  SmallVector<uint32_t> registerIndices;
+  for (uint32_t i = 0; i < idxValues.size(); ++i)
+    registerIndices.push_back(i);
+  // Replace the statically-known coordinate along axis with an independent
+  // input carrying the runtime index.
+  SmallVector<StringAttr> nonIndexedDims = allDims;
+  nonIndexedDims.erase(nonIndexedDims.begin() + axis);
+  assert(!orderedRegLayout.hasInDim(axisDim));
+  LinearLayout indexedLayout =
+      orderedRegLayout.sublayout(
+          llvm::to_vector(orderedRegLayout.getInDimNames()), nonIndexedDims) *
+      LinearLayout::identity1D(sharedLayout.getOutDimSize(axisDim), axisDim,
+                               axisDim);
+  indexedLayout = indexedLayout.transposeOuts(allDims);
+  LinearLayout cvt = invertAndComposeBlockLocal(sharedLayout, indexedLayout);
+  bool crossCTA = !cvt.isIdentityOnOutDim(kBlock);
+  bool blockAffectsOffset = !cvt.sublayoutIsZero({kBlock}, {kOffset});
+
+  Value blockId = b.i32_val(0);
+  if (crossCTA || blockAffectsOffset)
+    blockId = targetInfo.getClusterCTAId(rewriter, loc);
+
+  auto bases = applyLinearLayoutVec(loc, rewriter, cvt,
+                                    {{kRegister, b.i32_val(0)},
+                                     {kLane, laneId},
+                                     {kWarp, warpId},
+                                     {kBlock, blockId},
+                                     {axisDim, b.i32_val(0)}},
+                                    registerIndices);
+  LinearLayout indexCvt = cvt.sublayout({axisDim}, {kOffset, kBlock});
+  for (auto [base, idxVal] : llvm::zip(bases, idxValues)) {
+    auto index =
+        applyLinearLayout(loc, rewriter, indexCvt, {{axisDim, toI32(idxVal)}});
+    Value offset = b.xor_(base[0].second, index[0].second);
+    Value block = b.xor_(base[1].second, index[1].second);
+    offsetAndBlock.push_back({offset, crossCTA ? block : Value()});
+  }
+  return offsetAndBlock;
+}
+
+SmallVector<LocalSharedMemoryAddress>
+materializeLocalAddrs(Location loc, triton::gpu::MemDescType memDescTy,
+                      SharedMemoryObject smemObj, Type llvmElemTy,
+                      ArrayRef<std::pair<Value, Value>> offsetAndBlock,
+                      RewriterBase &rewriter) {
+  auto b = TritonLLVMOpBuilder(loc, rewriter);
+
   // Get the subslice affine offset (non-zero for memdesc subslices)
   Value affineOffset = smemObj.getShmemOffset(loc, rewriter, memDescTy);
   auto bitwidth = getIntOrFloatOrPtrBitWidth(llvmElemTy);
-
   SmallVector<LocalSharedMemoryAddress> addrs;
-  addrs.reserve(coords.size());
-
-  for (auto [i, idxVal] : llvm::enumerate(idxValues)) {
-    Value idx = idxVal;
-    unsigned idxWidth = idx.getType().getIntOrFloatBitWidth();
-    // Convert index to i32 if needed
-    if (idxWidth > 32) {
-      idx = b.trunc(i32_ty, idx);
-    } else if (idxWidth < 32) {
-      idx = b.zext(i32_ty, idx);
-    }
-
-    // Copy coordinates, replace the axis coordinate with the index value, and
-    // then shift all logical coordinates by the optional base offsets.
-    SmallVector<Value> indices(coords[i]);
-    indices[axis] = idx;
-    for (auto [dim, offset] : llvm::enumerate(offsets))
-      indices[dim] = b.add(indices[dim], offset);
-
-    // Apply inverted shared layout to compute offset
-    SmallVector<std::pair<StringAttr, Value>> inputs;
-    for (unsigned dim = 0; dim < indices.size(); ++dim)
-      inputs.push_back({allDims[dim], indices[dim]});
-
-    auto outputs = applyLinearLayout(loc, rewriter, invSharedLayout, inputs);
-    assert(outputs.size() == 2);
-    auto [offsetName, offset] = outputs[0];
-    auto [blockName, blockId] = outputs[1];
-    assert(offsetName == kOffset && blockName == kBlock);
-
+  addrs.reserve(offsetAndBlock.size());
+  for (auto [offset, blockId] : offsetAndBlock) {
     // For subslices, the physical offset is computed as:
     //   physical_offset = L⁻¹(coords) ⊕ L⁻¹(subslice_logical_offset)
     //
@@ -625,9 +652,8 @@ computeLocalAddrs(Location loc, triton::gpu::MemDescType memDescTy,
       ptr = b.gep(smemObj.getBase().getType(), llvmElemTy, smemObj.getBase(),
                   offset);
     }
-    addrs.push_back({ptr, isMultiCTA ? blockId : Value()});
+    addrs.push_back({ptr, blockId});
   }
-
   return addrs;
 }
 
@@ -665,13 +691,12 @@ FailureOr<LocalAtomicScatterRMWInfo> prepareLocalAtomicScatterRMW(
     if (!maskValues.empty())
       maskValues = removeBroadcast.apply(maskValues);
   }
-  SmallVector<SmallVector<Value>> srcIndices =
-      emitIndices(loc, rewriter, targetInfo, activeRegLayout, valuesTy,
-                  /*withCTAOffset=*/true);
-
+  auto offsetAndBlock =
+      computeBlockLocalOffsets(loc, memDescTy, activeRegLayout, idxValues,
+                               op.getAxis(), rewriter, targetInfo);
   SmallVector<Value> ptrs = llvm::map_to_vector(
-      computeLocalAddrs(loc, memDescTy, smemObj, llvmElemTy, idxValues,
-                        srcIndices, op.getAxis(), rewriter),
+      materializeLocalAddrs(loc, memDescTy, smemObj, llvmElemTy, offsetAndBlock,
+                            rewriter),
       [](const LocalSharedMemoryAddress &addr) { return addr.ptr; });
 
   return LocalAtomicScatterRMWInfo{valuesTy,        llvmElemTy, regLayout,

--- a/lib/Conversion/TritonGPUToLLVM/Utility.cpp
+++ b/lib/Conversion/TritonGPUToLLVM/Utility.cpp
@@ -782,6 +782,7 @@ SmallVector<Value> lowerLdSt(
   auto kOffset = str_attr("offset");
   auto kPartition = str_attr("partition");
   auto bitwidth = getIntOrFloatOrPtrBitWidth(llvmElemTy);
+  bool crossCTA = !cvt.isIdentityOnOutDim(kBlock);
 
   // Either we have multiple bases with a matching partition dimension,
   // or we have a single base.
@@ -856,7 +857,7 @@ SmallVector<Value> lowerLdSt(
                                          {kBlock, blockId}});
   auto regBaseI8 = baseI8AndCTA[0].second;
   Value targetCtaId;
-  if (useBlockId) {
+  if (crossCTA) {
     targetCtaId = baseI8AndCTA[1].second;
   }
 
@@ -889,7 +890,7 @@ SmallVector<Value> lowerLdSt(
         offset = b.add(offset, paddedAffineOffsetI8);
     }
     Value ctaOffset = b.i32_val(0);
-    if (useBlockId) {
+    if (crossCTA) {
       ctaOffset = b.xor_(targetCtaId, b.i32_val(idxAndBlock[1].second));
     }
     for (int j = 0; j < nAdditive; j += elemsPerVec) {
@@ -916,7 +917,7 @@ SmallVector<Value> lowerLdSt(
       }
 
       Value innerCtaOffset;
-      if (useBlockId) {
+      if (crossCTA) {
         innerCtaOffset = b.add(ctaOffset, b.i32_val(idxAndBlockAdd[1].second));
       }
       auto vecAddr = b.gep(smemPtrTy, i8_ty, smemBase, innerOffset,

--- a/lib/Conversion/TritonInstrumentToLLVM/InstrumentationToLLVM.cpp
+++ b/lib/Conversion/TritonInstrumentToLLVM/InstrumentationToLLVM.cpp
@@ -12,6 +12,7 @@
 #include "triton/Dialect/TritonInstrument/IR/Dialect.h"
 #include "triton/Dialect/TritonInstrument/IR/Utility.h"
 #include "triton/Dialect/TritonNvidiaGPU/IR/Dialect.h"
+#include "triton/Tools/LayoutUtils.h"
 #include <limits>
 
 namespace {
@@ -347,6 +348,55 @@ private:
   const TargetInfoBase &targetInfo;
 };
 
+static SmallVector<std::pair<Value, Value>>
+computeLocalOffsetsWithLogicalOffsets(Location loc, ttg::MemDescType memDescTy,
+                                      RankedTensorType regTy,
+                                      ArrayRef<Value> idxValues, unsigned axis,
+                                      ArrayRef<Value> offsets,
+                                      RewriterBase &rewriter,
+                                      const TargetInfoBase &targetInfo) {
+  MLIRContext *ctx = memDescTy.getContext();
+  auto b = TritonLLVMOpBuilder(loc, rewriter);
+  auto sharedLayout = ttg::isPaddedEncoding(memDescTy.getEncoding())
+                          ? ttg::paddedLinearLayout(memDescTy)
+                          : ttg::toLinearLayout(memDescTy);
+  LinearLayout invSharedLayout = sharedLayout.pseudoinvert();
+  auto allDims = tt::standardOutDimNames(ctx, memDescTy.getRank());
+  auto kOffset = str_attr("offset");
+  auto kBlock = str_attr("block");
+  bool crossCTA = invSharedLayout.getOutDimSize(kBlock) > 1;
+  assert(offsets.size() == allDims.size());
+
+  auto regLayout = ttg::toLinearLayout(regTy);
+  auto coords = emitIndices(loc, rewriter, targetInfo, regLayout, regTy,
+                            /*withCTAOffset=*/true);
+  SmallVector<std::pair<Value, Value>> offsetAndBlock;
+  offsetAndBlock.reserve(idxValues.size());
+  for (auto [coords, idxVal] : llvm::zip(coords, idxValues)) {
+    Value idx = idxVal;
+    unsigned idxWidth = idx.getType().getIntOrFloatBitWidth();
+    if (idxWidth > 32)
+      idx = b.trunc(i32_ty, idx);
+    else if (idxWidth < 32)
+      idx = b.zext(i32_ty, idx);
+
+    SmallVector<Value> indices(coords);
+    indices[axis] = idx;
+    for (auto [dim, offset] : llvm::enumerate(offsets))
+      indices[dim] = b.add(indices[dim], offset);
+
+    SmallVector<std::pair<StringAttr, Value>> inputs;
+    for (auto [dim, index] : llvm::zip(allDims, indices))
+      inputs.push_back({dim, index});
+    auto outputs = applyLinearLayout(loc, rewriter, invSharedLayout, inputs);
+    assert(outputs.size() == 2);
+    assert(outputs[0].first == kOffset && outputs[1].first == kBlock);
+    offsetAndBlock.push_back(
+        {outputs[0].second, crossCTA ? outputs[1].second : Value()});
+  }
+  return offsetAndBlock;
+}
+
 struct LocalGatherOpConversion
     : public ConvertOpToLLVMPattern<tti::ExperimentalLocalGatherOp> {
   LocalGatherOpConversion(const LLVMTypeConverter &converter,
@@ -368,14 +418,13 @@ struct LocalGatherOpConversion
     auto smemObj = LLVM::getSharedMemoryObjectFromStruct(loc, adaptor.getSrc(),
                                                          llvmElemTy, rewriter);
     auto idxValues = unpackLLElements(loc, adaptor.getIndices(), rewriter);
-    auto dstIndices =
-        emitIndices(loc, rewriter, targetInfo, regTy.getEncoding(), regTy,
-                    /*withCTAOffset=*/true);
     SmallVector<Value> offsets(adaptor.getOffsets());
 
-    auto addrs =
-        computeLocalAddrs(loc, memDescTy, smemObj, llvmElemTy, idxValues,
-                          dstIndices, op.getAxis(), rewriter, offsets);
+    auto offsetAndBlock = computeLocalOffsetsWithLogicalOffsets(
+        loc, memDescTy, regTy, idxValues, op.getAxis(), offsets, rewriter,
+        targetInfo);
+    auto addrs = materializeLocalAddrs(loc, memDescTy, smemObj, llvmElemTy,
+                                       offsetAndBlock, rewriter);
     auto b = TritonLLVMOpBuilder(loc, rewriter);
     SmallVector<Value> results =
         llvm::map_to_vector(addrs, [&](const LocalSharedMemoryAddress &addr) {

--- a/lib/Dialect/TritonNvidiaGPU/Transforms/ClusterBarrierInsertion.cpp
+++ b/lib/Dialect/TritonNvidiaGPU/Transforms/ClusterBarrierInsertion.cpp
@@ -31,8 +31,8 @@ static bool isDistributedMultiCTAOp(Operation *op, bool isRead) {
     auto srcTy = cvt.getSrc().getType();
     auto dstTy = cvt.getType();
     auto kBlock = StringAttr::get(op->getContext(), "block");
-    auto conversion = minimalCvtLayout(srcTy, dstTy);
-    return conversion.hasInDim(kBlock);
+    return !isCvtDimSync(ttg::toLinearLayout(srcTy), ttg::toLinearLayout(dstTy),
+                         kBlock);
   }
   if (auto reduce = dyn_cast<triton::ReduceOp>(op)) {
     if (!isRead)

--- a/lib/Tools/LayoutUtils.cpp
+++ b/lib/Tools/LayoutUtils.cpp
@@ -35,6 +35,33 @@ bool squareSublayoutIsIdentity(const LinearLayout &ll,
       ll, dimNames, [](int b, int32_t basis) { return basis == (1 << b); });
 }
 
+LinearLayout invertAndComposeBlockLocal(const LinearLayout &A,
+                                        const LinearLayout &B) {
+  auto cvt = B.invertAndCompose(A);
+  assert(!cvt.getInDimNames().empty());
+  auto kBlock =
+      StringAttr::get(cvt.getInDimNames().begin()->getContext(), "block");
+  assert(A.hasInDim(kBlock) && B.hasInDim(kBlock));
+  assert(A.getInDimSize(kBlock) == B.getInDimSize(kBlock));
+
+  // A zero block basis does not affect A's outputs, so force that output
+  // coordinate to equal the corresponding input block bit. This does not
+  // change the composition.
+  auto bases = cvt.getBases();
+  int blockOutIdx = cvt.getOutDimIndex(kBlock);
+  for (auto [i, aBlockBasis] : llvm::enumerate(A.getBases().at(kBlock))) {
+    if (!llvm::all_of(aBlockBasis, [](int32_t basis) { return basis == 0; }))
+      continue;
+    int blockBit = 1 << i;
+    for (auto &inDimBases : llvm::make_second_range(bases))
+      for (auto &basis : inDimBases)
+        basis[blockOutIdx] &= ~blockBit;
+    bases[kBlock][i][blockOutIdx] |= blockBit;
+  }
+  return LinearLayout(std::move(bases), cvt.getOutDims(),
+                      /*requireSurjective=*/false);
+}
+
 LinearLayout
 ensureLayoutNotLargerThan(const LinearLayout &layout,
                           const llvm::SmallDenseMap<StringAttr, int64_t> &shape,

--- a/lib/Tools/LinearLayout.cpp
+++ b/lib/Tools/LinearLayout.cpp
@@ -797,6 +797,18 @@ bool LinearLayout::isTrivialOver(ArrayRef<StringAttr> dimNames) const {
          sublayoutIsZero(dimNames, remainingOutDimNames);
 }
 
+bool LinearLayout::isIdentityOnOutDim(StringAttr dim) const {
+  if (!hasInDim(dim) || !hasOutDim(dim))
+    return false;
+  SmallVector<StringAttr> otherInDims;
+  for (StringAttr inDim : getInDimNames()) {
+    if (inDim != dim)
+      otherInDims.push_back(inDim);
+  }
+  return squareSublayoutIsIdentity(*this, {dim}) &&
+         sublayoutIsZero(otherInDims, {dim});
+}
+
 std::optional<LinearLayout>
 LinearLayout::quotient(ArrayRef<StringAttr> dimNames) const {
   if (llvm::any_of(dimNames,

--- a/python/test/gluon/test_core.py
+++ b/python/test/gluon/test_core.py
@@ -2901,6 +2901,101 @@ def test_shared_gather_scatter_two_ctas(gather):
     torch.testing.assert_close(out, inp.reshape(2, 16, 2).flip(-1).reshape(2, 32))
 
 
+def _shared_gather_cga_cases():
+    cases = [pytest.param(1, 0, id="1-cta-local")]
+    for num_ctas in (2, 4, 8, 16):
+        cases.append(pytest.param(num_ctas, 0, id=f"{num_ctas}-cta-sharded"))
+        if num_ctas >= 4:
+            # Keep bit 0 sharded for a remote read and replicate alternating
+            # higher bits, including the noncontiguous mask 0b1010 at 16 CTAs.
+            broadcast_mask = sum(1 << bit for bit in range(1, num_ctas.bit_length() - 1, 2))
+            cases.append(pytest.param(num_ctas, broadcast_mask, id=f"{num_ctas}-cta-partial"))
+        cases.append(pytest.param(num_ctas, num_ctas - 1, id=f"{num_ctas}-cta-broadcast"))
+    return cases
+
+
+def _shared_gather_layouts(num_ctas, broadcast_mask):
+    num_cta_bits = num_ctas.bit_length() - 1
+    full_cga = tuple((1 << bit, ) for bit in range(num_cta_bits))
+    shared_cga = []
+    shard_bit = 0
+    for bit in range(num_cta_bits):
+        if broadcast_mask & (1 << bit):
+            shared_cga.append((0, ))
+        else:
+            shared_cga.append((1 << shard_bit, ))
+            shard_bit += 1
+    value_layout = ttgl.BlockedLayout([1], [32], [1], [0], cga_layout=full_cga)
+    seed_layout = ttgl.SwizzledSharedLayout(1, 1, 1, order=[0], cga_layout=full_cga)
+    shared_layout = ttgl.SwizzledSharedLayout(1, 1, 1, order=[0], cga_layout=shared_cga)
+    return value_layout, seed_layout, shared_layout, shard_bit
+
+
+@gluon.jit
+def shared_gather_cga_kernel(
+    out,
+    value_layout: ttgl.constexpr,
+    seed_layout: ttgl.constexpr,
+    shared_layout: ttgl.constexpr,
+    BROADCAST_MASK: ttgl.constexpr,
+    NUM_SHARD_BITS: ttgl.constexpr,
+    CTA_TILE: ttgl.constexpr,
+):
+    num_ctas: ttgl.constexpr = ttgl.num_ctas()
+    num_cta_bits: ttgl.constexpr = num_ctas.bit_length() - 1
+    block: ttgl.constexpr = CTA_TILE * num_ctas
+    offsets = ttgl.arange(0, block, layout=value_layout)
+    # Seed each physical CTA with distinct layout-derived values, then view the
+    # same allocation through the CGA layout under test.
+    seed = ttgl.allocate_shared_memory(ttgl.int32, [block], seed_layout, value=offsets)
+    smem = seed._reinterpret(shape=[CTA_TILE << NUM_SHARD_BITS], layout=shared_layout)
+    ttgl.barrier(cluster=True)
+
+    cta = offsets // CTA_TILE
+    local = offsets & (CTA_TILE - 1)
+    # Compress the non-broadcast CTA bits into a shard ID. Flipping its low bit
+    # forces a remote read while leaving the replica bits unchanged.
+    shard = local * 0
+    shard_bit = 0
+    for bit in range(num_cta_bits):
+        if (BROADCAST_MASK & (1 << bit)) == 0:
+            shard |= ((cta >> bit) & 1) << shard_bit
+            shard_bit += 1
+    if NUM_SHARD_BITS:
+        indices = (shard ^ 1) * CTA_TILE + local
+    else:
+        indices = local ^ 1
+    result = smem.gather(indices, axis=0)
+    ttgl.store(out + offsets, result)
+
+
+@pytest.mark.skipif(not is_hopper_or_newer(), reason="Requires Hopper")
+@pytest.mark.parametrize("num_ctas,broadcast_mask", _shared_gather_cga_cases())
+def test_shared_gather_cga(num_ctas, broadcast_mask):
+    cta_tile = 32
+    out = torch.empty(cta_tile * num_ctas, dtype=torch.int32, device="cuda")
+    value_layout, seed_layout, shared_layout, num_shard_bits = _shared_gather_layouts(num_ctas, broadcast_mask)
+
+    shared_gather_cga_kernel[(1, )](
+        out,
+        value_layout,
+        seed_layout,
+        shared_layout,
+        BROADCAST_MASK=broadcast_mask,
+        NUM_SHARD_BITS=num_shard_bits,
+        CTA_TILE=cta_tile,
+        num_warps=1,
+        num_ctas=num_ctas,
+    )
+
+    offsets = torch.arange(out.numel(), dtype=torch.int32, device="cuda")
+    if broadcast_mask == num_ctas - 1:
+        expected = (offsets // cta_tile) * cta_tile + ((offsets % cta_tile) ^ 1)
+    else:
+        expected = ((offsets // cta_tile) ^ 1) * cta_tile + offsets % cta_tile
+    torch.testing.assert_close(out, expected)
+
+
 @gluon.jit
 def shared_scatter_kernel(
     indices_ptr,

--- a/python/test/gluon/test_lowerings.py
+++ b/python/test/gluon/test_lowerings.py
@@ -1149,7 +1149,7 @@ def test_convert2d_layouts(M, N, src_ctas_per_cga, dst_ctas_per_cga, interm_layo
 
     torch.testing.assert_close(y, x, rtol=0, atol=0)
     if src_ctas_per_cga != dst_ctas_per_cga:
-        assert "ld.shared::cluster" in compiled.asm["ptx"]
+        # Replicated values may be loaded from the local CTA.
         assert "st.shared::cluster" not in compiled.asm["ptx"]
 
 

--- a/test/Conversion/tritongpu_to_llvm.mlir
+++ b/test/Conversion/tritongpu_to_llvm.mlir
@@ -1362,6 +1362,24 @@ module attributes {"ttg.num-ctas" = 2 : i32, "ttg.num-warps" = 1 : i32} {
 
 // -----
 
+#src = #ttg.linear<{register = [[1]], lane = [[0], [0], [0], [0], [0]], warp = [], block = [[0]]}>
+#dst = #ttg.linear<{register = [], lane = [[0], [0], [0], [0], [0]], warp = [], block = [[1]]}>
+module attributes {"ttg.num-ctas" = 2 : i32, "ttg.num-warps" = 1 : i32, ttg.target = "cuda:90", "ttg.threads-per-warp" = 32 : i32} {
+  // CHECK-LABEL: convert_layout_loads_local_replica
+  // CHECK: llvm.store
+  // CHECK: nvg.cluster_id
+  // CHECK-NOT: nvvm.mapa
+  // CHECK: llvm.load
+  // CHECK-NOT: nvvm.cluster.arrive
+  // CHECK-NOT: nvvm.cluster.wait
+  tt.func @convert_layout_loads_local_replica(%arg0: tensor<2xf32, #src>) {
+    %0 = ttg.convert_layout %arg0 : tensor<2xf32, #src> -> tensor<2xf32, #dst>
+    tt.return
+  }
+}
+
+// -----
+
 // Regression test for https://github.com/triton-lang/triton/issues/5745
 #linear = #ttg.linear<{register = [[0, 1], [0, 2]], lane = [[0, 0], [0, 0], [0, 0], [0, 0], [0, 0]], warp = [[1, 0], [2, 0], [4, 0]], block = []}>
 #linear1 = #ttg.linear<{register = [[0, 2]], lane = [[0, 0], [0, 0], [0, 0], [0, 0], [1, 0]], warp = [[2, 0], [4, 0], [0, 1]], block = []}>
@@ -2199,6 +2217,38 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.targ
     %c0_i32 = arith.constant 0 : i32
     %0 = ttg.local_alloc {allocation.offset = 0 : i32} : () -> !ttg.memdesc<1xf32, #shared, #smem, mutable>
     ttg.local_store %arg0, %0 : tensor<1xf32, #blocked> -> !ttg.memdesc<1xf32, #shared, #smem, mutable>
+    tt.return
+  }
+}
+
+// -----
+
+#reg = #ttg.linear<{register = [], lane = [[0], [0], [0], [0], [0]], warp = [], block = [[1]]}>
+#shared = #ttg.shared_linear<{offset = [[1]], block = [[0]]}, alignment = 4>
+#smem = #ttg.shared_memory
+module attributes {"ttg.num-ctas" = 2 : i32, "ttg.num-warps" = 1 : i32, ttg.target = "cuda:90", "ttg.threads-per-warp" = 32 : i32} {
+  // CHECK-LABEL: local_load_uses_local_cta
+  // CHECK: nvg.cluster_id
+  // CHECK-NOT: nvvm.mapa
+  // CHECK: llvm.load
+  tt.func public @local_load_uses_local_cta(%arg0: !ttg.memdesc<2xf32, #shared, #smem>) {
+    %0 = ttg.local_load %arg0 : !ttg.memdesc<2xf32, #shared, #smem> -> tensor<2xf32, #reg>
+    tt.return
+  }
+}
+
+// -----
+
+#reg = #ttg.linear<{register = [], lane = [[0], [0], [0], [0], [0]], warp = [], block = [[1]]}>
+#shared = #ttg.shared_linear<{offset = [[1]], block = [[0]]}, alignment = 4>
+#smem = #ttg.shared_memory
+module attributes {"ttg.num-ctas" = 2 : i32, "ttg.num-warps" = 1 : i32, ttg.target = "cuda:90", "ttg.threads-per-warp" = 32 : i32} {
+  // CHECK-LABEL: local_store_uses_local_cta
+  // CHECK: nvg.cluster_id
+  // CHECK-NOT: nvvm.mapa
+  // CHECK: llvm.store
+  tt.func public @local_store_uses_local_cta(%arg0: tensor<2xf32, #reg>, %arg1: !ttg.memdesc<2xf32, #shared, #smem, mutable>) {
+    ttg.local_store %arg0, %arg1 : tensor<2xf32, #reg> -> !ttg.memdesc<2xf32, #shared, #smem, mutable>
     tt.return
   }
 }

--- a/test/Conversion/tritonnvidiagpu_to_llvm.mlir
+++ b/test/Conversion/tritonnvidiagpu_to_llvm.mlir
@@ -678,6 +678,60 @@ module attributes {"ttg.num-ctas" = 2 : i32, "ttg.num-warps" = 4 : i32, "ttg.thr
 
 // -----
 
+#local_gather_cga16_blocked = #ttg.blocked<{sizePerThread = [1, 1], threadsPerWarp = [8, 4], warpsPerCTA = [1, 1], order = [1, 0], CGALayout = [[0, 1], [1, 0], [0, 2], [2, 0]]}>
+#local_gather_cga16_sharded = #ttg.swizzled_shared<{vec = 4, perPhase = 2, maxPhase = 4, order = [1, 0], CGALayout = [[0, 1], [1, 0], [0, 2], [2, 0]]}>
+#local_gather_cga16_partial = #ttg.swizzled_shared<{vec = 4, perPhase = 2, maxPhase = 4, order = [1, 0], CGALayout = [[0, 1], [0, 0], [1, 0], [0, 0]]}>
+#local_gather_cga16_broadcast = #ttg.swizzled_shared<{vec = 4, perPhase = 2, maxPhase = 4, order = [1, 0], CGALayout = [[0, 0], [0, 0], [0, 0], [0, 0]]}>
+
+module attributes {"ttg.num-ctas" = 16 : i32, "ttg.num-warps" = 1 : i32, "ttg.threads-per-warp" = 32 : i32} {
+  // CHECK-LABEL: @local_gather_sharded_16_ctas
+  // CHECK: nvvm.mapa
+  // CHECK: llvm.load {{.*}} : !llvm.ptr<7> -> i32
+  // CHECK: llvm.return
+  tt.func private @local_gather_sharded_16_ctas() -> tensor<32x32xi32, #local_gather_cga16_blocked> {
+    %src = ttg.local_alloc {allocation.offset = [0 : i32]} : () -> !ttg.memdesc<32x32xi32, #local_gather_cga16_sharded, #ttg.shared_memory, mutable>
+    %idx = arith.constant dense<0> : tensor<32x32xi32, #local_gather_cga16_blocked>
+    %g = ttg.local_gather %src[%idx] {axis = 1 : i32} : !ttg.memdesc<32x32xi32, #local_gather_cga16_sharded, #ttg.shared_memory, mutable>, tensor<32x32xi32, #local_gather_cga16_blocked> -> tensor<32x32xi32, #local_gather_cga16_blocked>
+    tt.return %g : tensor<32x32xi32, #local_gather_cga16_blocked>
+  }
+
+  // CHECK-LABEL: @local_gather_partial_broadcast_16_ctas
+  // CHECK: %[[CTA:.*]] = nvg.cluster_id
+  // CHECK: %[[CTA_SHIFTED:.*]] = llvm.shl %[[CTA]], %{{.*}} : i32
+  // CHECK: %[[PACKED:.*]] = llvm.or %{{.*}}, %[[CTA_SHIFTED]] : i32
+  // CHECK: %[[LO_SHIFT:.*]] = llvm.mlir.constant(5 : i32)
+  // CHECK: %[[REPLICA_LO:.*]] = llvm.lshr %{{.*}}, %[[LO_SHIFT]] : i32
+  // CHECK: %[[BIT_MASK:.*]] = llvm.mlir.constant(256 : i32)
+  // CHECK: %[[BROADCAST_BIT:.*]] = llvm.and %[[PACKED]], %[[BIT_MASK]] : i32
+  // CHECK: %[[IS_ZERO:.*]] = llvm.icmp "eq" %[[BROADCAST_BIT]], %{{.*}} : i32
+  // CHECK: %[[REPLICA_HI:.*]] = llvm.mlir.constant(12 : i32)
+  // CHECK: %[[REPLICA:.*]] = llvm.select %[[IS_ZERO]], %{{.*}}, %[[REPLICA_HI]] : i1, i32
+  // CHECK: llvm.or disjoint %[[REPLICA_LO]], %[[REPLICA]] : i32
+  // CHECK: nvvm.mapa
+  // CHECK: llvm.load {{.*}} : !llvm.ptr<7> -> i32
+  // CHECK: llvm.return
+  tt.func private @local_gather_partial_broadcast_16_ctas() -> tensor<32x32xi32, #local_gather_cga16_blocked> {
+    %src = ttg.local_alloc {allocation.offset = [0 : i32]} : () -> !ttg.memdesc<32x32xi32, #local_gather_cga16_partial, #ttg.shared_memory, mutable>
+    %idx = arith.constant dense<0> : tensor<32x32xi32, #local_gather_cga16_blocked>
+    %g = ttg.local_gather %src[%idx] {axis = 1 : i32} : !ttg.memdesc<32x32xi32, #local_gather_cga16_partial, #ttg.shared_memory, mutable>, tensor<32x32xi32, #local_gather_cga16_blocked> -> tensor<32x32xi32, #local_gather_cga16_blocked>
+    tt.return %g : tensor<32x32xi32, #local_gather_cga16_blocked>
+  }
+
+  // CHECK-LABEL: @local_gather_full_broadcast_16_ctas
+  // CHECK-NOT: nvvm.mapa
+  // CHECK: llvm.load {{.*}} : !llvm.ptr<3> -> i32
+  // CHECK-NOT: nvvm.mapa
+  // CHECK: llvm.return
+  tt.func private @local_gather_full_broadcast_16_ctas() -> tensor<32x32xi32, #local_gather_cga16_blocked> {
+    %src = ttg.local_alloc {allocation.offset = [0 : i32]} : () -> !ttg.memdesc<32x32xi32, #local_gather_cga16_broadcast, #ttg.shared_memory, mutable>
+    %idx = arith.constant dense<0> : tensor<32x32xi32, #local_gather_cga16_blocked>
+    %g = ttg.local_gather %src[%idx] {axis = 1 : i32} : !ttg.memdesc<32x32xi32, #local_gather_cga16_broadcast, #ttg.shared_memory, mutable>, tensor<32x32xi32, #local_gather_cga16_blocked> -> tensor<32x32xi32, #local_gather_cga16_blocked>
+    tt.return %g : tensor<32x32xi32, #local_gather_cga16_blocked>
+  }
+}
+
+// -----
+
 module attributes {"ttg.num-ctas" = 2 : i32, "ttg.num-warps" = 4 : i32, ttg.shared = 5 : i32, "ttg.threads-per-warp" = 32 : i32} {
   // CHECK: module attributes {
   // CHECK-DAG: ttg.shared = 24 : i32

--- a/test/Conversion/tritonnvidiagpu_to_llvm.mlir
+++ b/test/Conversion/tritonnvidiagpu_to_llvm.mlir
@@ -612,20 +612,62 @@ module attributes {"ttg.num-ctas" = 2 : i32, "ttg.num-warps" = 4 : i32, "ttg.tot
 // -----
 
 #local_gather_scatter_blocked = #ttg.blocked<{sizePerThread = [1, 1], threadsPerWarp = [1, 32], warpsPerCTA = [1, 4], order = [1, 0], CGALayout = [[0, 1]]}>
-#local_gather_scatter_shared = #ttg.swizzled_shared<{vec = 1, perPhase = 1, maxPhase = 1, order = [1, 0], CGALayout = [[0, 1]]}>
+#local_gather_scatter_shared_split = #ttg.swizzled_shared<{vec = 1, perPhase = 1, maxPhase = 1, order = [1, 0], CGALayout = [[0, 1]]}>
+#local_gather_scatter_shared_broadcast = #ttg.swizzled_shared<{vec = 1, perPhase = 1, maxPhase = 1, order = [1, 0], CGALayout = [[0, 0]]}>
 
 module attributes {"ttg.num-ctas" = 2 : i32, "ttg.num-warps" = 4 : i32, "ttg.threads-per-warp" = 32 : i32} {
-  // CHECK-LABEL: @local_gather_scatter_two_ctas
+  // CHECK-LABEL: @local_gather_scatter_same_ownership
+  // CHECK-NOT: nvvm.mapa
+  // CHECK: llvm.load {{.*}} : !llvm.ptr<3> -> i32
+  // CHECK: nvvm.barrier
+  // CHECK-NOT: nvvm.mapa
+  // CHECK: llvm.store {{.*}} : vector<1xi32>, !llvm.ptr<3>
+  // CHECK-NOT: nvvm.mapa
+  // CHECK: llvm.return
+  tt.func @local_gather_scatter_same_ownership(%out: !tt.ptr<i32>, %vals: tensor<2x32xi32, #local_gather_scatter_blocked>) {
+    %src = ttg.local_alloc {allocation.offset = [0 : i32, 256 : i32]} : () -> !ttg.memdesc<2x32xi32, #local_gather_scatter_shared_split, #ttg.shared_memory, mutable>
+    %idx = arith.constant dense<0> : tensor<2x32xi32, #local_gather_scatter_blocked>
+    %g = ttg.local_gather %src[%idx] {axis = 0 : i32} : !ttg.memdesc<2x32xi32, #local_gather_scatter_shared_split, #ttg.shared_memory, mutable>, tensor<2x32xi32, #local_gather_scatter_blocked> -> tensor<2x32xi32, #local_gather_scatter_blocked>
+    ttg.local_scatter %src[%idx], %vals {axis = 0 : i32} : !ttg.memdesc<2x32xi32, #local_gather_scatter_shared_split, #ttg.shared_memory, mutable>, tensor<2x32xi32, #local_gather_scatter_blocked>, tensor<2x32xi32, #local_gather_scatter_blocked>
+    %ptrs = tt.splat %out : !tt.ptr<i32> -> tensor<2x32x!tt.ptr<i32>, #local_gather_scatter_blocked>
+    %offs = arith.constant dense<0> : tensor<2x32xi32, #local_gather_scatter_blocked>
+    %out_ptrs = tt.addptr %ptrs, %offs : tensor<2x32x!tt.ptr<i32>, #local_gather_scatter_blocked>, tensor<2x32xi32, #local_gather_scatter_blocked>
+    tt.store %out_ptrs, %g : tensor<2x32x!tt.ptr<i32>, #local_gather_scatter_blocked>
+    tt.return
+  }
+
+  // CHECK-LABEL: @local_gather_scatter_broadcast
+  // CHECK: nvg.cluster_id
+  // CHECK-NOT: nvvm.mapa
+  // CHECK: llvm.load {{.*}} : !llvm.ptr<3> -> i32
+  // CHECK: nvvm.barrier
+  // CHECK-NOT: nvvm.mapa
+  // CHECK: llvm.store {{.*}} : vector<1xi32>, !llvm.ptr<3>
+  // CHECK-NOT: nvvm.mapa
+  // CHECK: llvm.return
+  tt.func @local_gather_scatter_broadcast(%out: !tt.ptr<i32>, %vals: tensor<2x32xi32, #local_gather_scatter_blocked>) {
+    %src = ttg.local_alloc {allocation.offset = [0 : i32, 256 : i32]} : () -> !ttg.memdesc<2x32xi32, #local_gather_scatter_shared_broadcast, #ttg.shared_memory, mutable>
+    %idx = arith.constant dense<0> : tensor<2x32xi32, #local_gather_scatter_blocked>
+    %g = ttg.local_gather %src[%idx] {axis = 0 : i32} : !ttg.memdesc<2x32xi32, #local_gather_scatter_shared_broadcast, #ttg.shared_memory, mutable>, tensor<2x32xi32, #local_gather_scatter_blocked> -> tensor<2x32xi32, #local_gather_scatter_blocked>
+    ttg.local_scatter %src[%idx], %vals {axis = 0 : i32} : !ttg.memdesc<2x32xi32, #local_gather_scatter_shared_broadcast, #ttg.shared_memory, mutable>, tensor<2x32xi32, #local_gather_scatter_blocked>, tensor<2x32xi32, #local_gather_scatter_blocked>
+    %ptrs = tt.splat %out : !tt.ptr<i32> -> tensor<2x32x!tt.ptr<i32>, #local_gather_scatter_blocked>
+    %offs = arith.constant dense<0> : tensor<2x32xi32, #local_gather_scatter_blocked>
+    %out_ptrs = tt.addptr %ptrs, %offs : tensor<2x32x!tt.ptr<i32>, #local_gather_scatter_blocked>, tensor<2x32xi32, #local_gather_scatter_blocked>
+    tt.store %out_ptrs, %g : tensor<2x32x!tt.ptr<i32>, #local_gather_scatter_blocked>
+    tt.return
+  }
+
+  // CHECK-LABEL: @local_gather_scatter_cross_cta
   // CHECK: nvvm.mapa
   // CHECK: llvm.load {{.*}} : !llvm.ptr<7> -> i32
   // CHECK: nvvm.barrier
   // CHECK: nvvm.mapa
   // CHECK: llvm.store {{.*}} : vector<1xi32>, !llvm.ptr<7>
-  tt.func @local_gather_scatter_two_ctas(%out: !tt.ptr<i32>, %vals: tensor<2x32xi32, #local_gather_scatter_blocked>) {
-    %src = ttg.local_alloc {allocation.offset = [0 : i32, 256 : i32]} : () -> !ttg.memdesc<2x32xi32, #local_gather_scatter_shared, #ttg.shared_memory, mutable>
+  tt.func @local_gather_scatter_cross_cta(%out: !tt.ptr<i32>, %vals: tensor<2x32xi32, #local_gather_scatter_blocked>) {
+    %src = ttg.local_alloc {allocation.offset = [0 : i32, 256 : i32]} : () -> !ttg.memdesc<2x32xi32, #local_gather_scatter_shared_split, #ttg.shared_memory, mutable>
     %idx = arith.constant dense<0> : tensor<2x32xi32, #local_gather_scatter_blocked>
-    %g = ttg.local_gather %src[%idx] {axis = 0 : i32} : !ttg.memdesc<2x32xi32, #local_gather_scatter_shared, #ttg.shared_memory, mutable>, tensor<2x32xi32, #local_gather_scatter_blocked> -> tensor<2x32xi32, #local_gather_scatter_blocked>
-    ttg.local_scatter %src[%idx], %vals {axis = 0 : i32} : !ttg.memdesc<2x32xi32, #local_gather_scatter_shared, #ttg.shared_memory, mutable>, tensor<2x32xi32, #local_gather_scatter_blocked>, tensor<2x32xi32, #local_gather_scatter_blocked>
+    %g = ttg.local_gather %src[%idx] {axis = 1 : i32} : !ttg.memdesc<2x32xi32, #local_gather_scatter_shared_split, #ttg.shared_memory, mutable>, tensor<2x32xi32, #local_gather_scatter_blocked> -> tensor<2x32xi32, #local_gather_scatter_blocked>
+    ttg.local_scatter %src[%idx], %vals {axis = 1 : i32} : !ttg.memdesc<2x32xi32, #local_gather_scatter_shared_split, #ttg.shared_memory, mutable>, tensor<2x32xi32, #local_gather_scatter_blocked>, tensor<2x32xi32, #local_gather_scatter_blocked>
     %ptrs = tt.splat %out : !tt.ptr<i32> -> tensor<2x32x!tt.ptr<i32>, #local_gather_scatter_blocked>
     %offs = arith.constant dense<0> : tensor<2x32xi32, #local_gather_scatter_blocked>
     %out_ptrs = tt.addptr %ptrs, %offs : tensor<2x32x!tt.ptr<i32>, #local_gather_scatter_blocked>, tensor<2x32xi32, #local_gather_scatter_blocked>

--- a/third_party/nvidia/lib/TritonNVIDIAGPUToLLVM/ConvertLayoutOpToLLVM.cpp
+++ b/third_party/nvidia/lib/TritonNVIDIAGPUToLLVM/ConvertLayoutOpToLLVM.cpp
@@ -139,7 +139,7 @@ struct ConvertLayoutOpSwizzlingConversion
     auto reps = LinearLayout::identity1D(nReps, kReg, kReps);
 
     auto totalStoreCvt = srcLayout.invertAndCompose(smem);
-    auto totalLoadCvt = dstLayout.invertAndCompose(smem);
+    auto totalLoadCvt = invertAndComposeBlockLocal(smem, dstLayout);
 
     // The permutation exists by construction of the reps dimension in
     // optimalSwizzling

--- a/unittest/Tools/LinearLayoutTest.cpp
+++ b/unittest/Tools/LinearLayoutTest.cpp
@@ -550,6 +550,65 @@ TEST_F(LinearLayoutTest, InvertAndCompose_BroadcastedDims2) {
   EXPECT_EQ(c.compose(b), a.transposeOuts(llvm::to_vector(b.getOutDimNames())));
 }
 
+TEST_F(LinearLayoutTest, InvertAndComposeBlockLocal) {
+  auto memLayout =
+      LinearLayout({{S("offset"), {{1}}}, {S("block"), {{0}}}}, {S("dim")});
+  auto regLayout = LinearLayout({{S("register"), {}},
+                                 {S("lane"), {{0}, {0}, {0}, {0}, {0}}},
+                                 {S("warp"), {}},
+                                 {S("block"), {{1}}}},
+                                {S("dim")});
+
+  EXPECT_FALSE(
+      regLayout.invertAndCompose(memLayout).isIdentityOnOutDim(S("block")));
+  auto local = invertAndComposeBlockLocal(memLayout, regLayout);
+  auto expected =
+      LinearLayout({{S("register"), {}},
+                    {S("lane"), {{0, 0}, {0, 0}, {0, 0}, {0, 0}, {0, 0}}},
+                    {S("warp"), {}},
+                    {S("block"), {{1, 1}}}},
+                   {{S("offset"), 2}, {S("block"), 2}},
+                   /*requireSurjective=*/false);
+  EXPECT_EQ(local, expected);
+  EXPECT_TRUE(local.isIdentityOnOutDim(S("block")));
+  EXPECT_FALSE(local.isTrivialOver(S("block")));
+  EXPECT_EQ(local.compose(memLayout), regLayout);
+
+  auto partiallyBroadcastMem = LinearLayout(
+      {{S("offset"), {{2}}}, {S("block"), {{1}, {0}}}}, {S("dim")});
+  auto partiallyDistributedReg =
+      LinearLayout({{S("register"), {}},
+                    {S("lane"), {{0}, {0}, {0}, {0}, {0}}},
+                    {S("warp"), {}},
+                    {S("block"), {{1}, {2}}}},
+                   {S("dim")});
+  EXPECT_FALSE(partiallyDistributedReg.invertAndCompose(partiallyBroadcastMem)
+                   .isIdentityOnOutDim(S("block")));
+  auto partiallyLocal = invertAndComposeBlockLocal(partiallyBroadcastMem,
+                                                   partiallyDistributedReg);
+  auto partiallyExpected =
+      LinearLayout({{S("register"), {}},
+                    {S("lane"), {{0, 0}, {0, 0}, {0, 0}, {0, 0}, {0, 0}}},
+                    {S("warp"), {}},
+                    {S("block"), {{0, 1}, {1, 2}}}},
+                   {{S("offset"), 2}, {S("block"), 4}},
+                   /*requireSurjective=*/false);
+  EXPECT_EQ(partiallyLocal, partiallyExpected);
+  EXPECT_TRUE(partiallyLocal.isIdentityOnOutDim(S("block")));
+  EXPECT_EQ(partiallyLocal.compose(partiallyBroadcastMem),
+            partiallyDistributedReg);
+
+  auto partitionedMem =
+      LinearLayout({{S("offset"), {{1}}}, {S("block"), {{2}}}}, {S("dim")});
+  auto transposedReg = LinearLayout({{S("register"), {{2}}},
+                                     {S("lane"), {{0}, {0}, {0}, {0}, {0}}},
+                                     {S("warp"), {}},
+                                     {S("block"), {{1}}}},
+                                    {S("dim")});
+  EXPECT_EQ(invertAndComposeBlockLocal(partitionedMem, transposedReg),
+            transposedReg.invertAndCompose(partitionedMem));
+}
+
 TEST_F(LinearLayoutTest, InvertAndCompose_IdentityInDim) {
   SmallVector<StringAttr> outDims = {S("dim0"), S("dim1"), S("dim2"),
                                      S("dim3"), S("dim4"), S("dim5"),


### PR DESCRIPTION
The problem. Consider a load (or a store) with layouts
```
A = {offset = [[1]], block = [[0]]}
B = {reg=[], lane = [[0], [0], [0], [0], [0]], warp = [], block = [[1]]}
```
the composition we previously chose was
```
A^{-1}B = {reg=[], lane = [[0, 0], [0, 0], [0, 0], [0, 0], [0, 0]]], warp = [], block = [[1, 0]]
```
where `A^{-1}B` maps into `(offset, block)`
this meant that both CTA0 and CTA1 were reading from CTA0's offsets and
crossing CTAs. We now choose
```
A^{-1}B = {reg=[], lane = [[0, 0], [0, 0], [0, 0], [0, 0], [0, 0]]], warp = [], block = [[1, 1]]
```
which means that CTA0 reads its offset0 and CTA1 reads its offset1,
making the load (or store) CTA-local.

The mathematical idea here is that we are solving `AX = B`. If a column of `A` is
zero, then we can set the associated row of `X` to whatever we want. We
may use this to avoid crossing CTAs whenever possible.

We don't do this for all `invertAndCompose`s as it would create LLs in
that are mappings from `(reg, lane, warp, block)` into itself that are
not permutations and that would break a few invariants of our lowering,
but we do use this in the `local_load`-like part of `convert_layout`s to
avoid crossing CTAs there as well.
