### PR TITLE
[AMD] Add clz and popc to HIP libdevice

### DIFF
--- a/python/test/unit/language/test_libdevice.py
+++ b/python/test/unit/language/test_libdevice.py
@@ -58,6 +58,36 @@ def test_libdevice_rename(device):
     triton_copy[(1, )](inp, out, BLOCK_SIZE)
 
 
+def test_clz(device):
+
+    @triton.jit
+    def triton_clz(in_ptr, out_ptr, SIZE: tl.constexpr):
+        offsets = tl.arange(0, SIZE)
+        tl.store(out_ptr + offsets, libdevice.clz(tl.load(in_ptr + offsets)))
+
+    x = torch.tensor([1, 2, 3, 4, 5, 8, 9, 16], dtype=torch.int32, device=device)
+    y = torch.empty_like(x)
+
+    triton_clz[(1, )](x, y, SIZE=x.numel())
+
+    assert torch.equal(y.cpu(), torch.tensor([31, 30, 30, 29, 29, 28, 28, 27], dtype=torch.int32))
+
+
+def test_popc(device):
+
+    @triton.jit
+    def triton_popc(in_ptr, out_ptr, SIZE: tl.constexpr):
+        offsets = tl.arange(0, SIZE)
+        tl.store(out_ptr + offsets, libdevice.popc(tl.load(in_ptr + offsets)))
+
+    x = torch.tensor([0, 1, 2, 3, 4, 7, 8, 15], dtype=torch.int32, device=device)
+    y = torch.empty_like(x)
+
+    triton_popc[(1, )](x, y, SIZE=x.numel())
+
+    assert torch.equal(y.cpu(), torch.tensor([0, 1, 1, 2, 1, 3, 1, 4], dtype=torch.int32))
+
+
 @pytest.mark.parametrize("dtype_str", ["float32", "float64"])
 def test_isinf(device, dtype_str):
 

--- a/third_party/amd/language/hip/libdevice.py
+++ b/third_party/amd/language/hip/libdevice.py
@@ -2,6 +2,24 @@ from triton.language import core
 
 
 @core.extern
+def clz(arg0, _semantic=None):
+    return core.extern_elementwise(
+        "", "", [arg0], {
+            (core.dtype("int32"), ): ("__ockl_clz_u32", core.dtype("int32")),
+            (core.dtype("int64"), ): ("__ockl_clz_u64", core.dtype("int64")),
+        }, is_pure=True, _semantic=_semantic).to(core.int32, _semantic=_semantic)
+
+
+@core.extern
+def popc(arg0, _semantic=None):
+    return core.extern_elementwise(
+        "", "", [arg0], {
+            (core.dtype("int32"), ): ("__ockl_popcount_u32", core.dtype("int32")),
+            (core.dtype("int64"), ): ("__ockl_popcount_u64", core.dtype("int32")),
+        }, is_pure=True, _semantic=_semantic)
+
+
+@core.extern
 def abs(arg0, _semantic=None):
     return core.extern_elementwise(
         "", "", [arg0], {


### PR DESCRIPTION
## Summary

Add `clz` and `popc` to the HIP `triton.language.extra.libdevice`
surface.

CUDA already exposes `libdevice.clz` and `libdevice.popc`, and ROCm/HIP
provides the underlying integer device support. Triton's HIP backend already
links OCKL, which contains `__ockl_clz_u32`, `__ockl_clz_u64`,
`__ockl_popcount_u32`, and `__ockl_popcount_u64`; HIP `libdevice.py` just was
not wiring those symbols into the frontend.

This adds the HIP wrapper and covers it with:

- runtime `libdevice.clz` and `libdevice.popc` tests on the active device

## Validation

Ran:

```bash
TRITON_PTXAS_PATH=/usr/local/cuda/bin/ptxas \
TRITON_PTXAS_BLACKWELL_PATH=/usr/local/cuda/bin/ptxas \
TRITON_CUOBJDUMP_PATH=/usr/local/cuda/bin/cuobjdump \
TRITON_NVDISASM_PATH=/usr/local/cuda/bin/nvdisasm \
TRITON_CUDACRT_PATH=/root/code/humm-fpsan/.venv/lib/python3.12/site-packages/triton/backends/nvidia/include \
TRITON_CUDART_PATH=/root/code/humm-fpsan/.venv/lib/python3.12/site-packages/triton/backends/nvidia/include \
python3 -m pytest python/test/unit/language/test_libdevice.py::test_clz \
  python/test/unit/language/test_libdevice.py::test_popc -q
```

Result: `2 passed`.
