### PR TITLE
[AMD] Don't split soffset for masked buffer ops

### DIFF
--- a/test/TritonGPU/amd/amd-annotate-buffer-op-split-safety.mlir
+++ b/test/TritonGPU/amd/amd-annotate-buffer-op-split-safety.mlir
@@ -18,6 +18,8 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 1 : i32, "ttg.thr
 // -----
 
 #blocked0 = #ttg.blocked<{sizePerThread = [4], threadsPerWarp = [32], warpsPerCTA = [1], order = [0]}>
+#shared0 = #ttg.swizzled_shared<{vec = 1, perPhase = 1, maxPhase = 1, order = [0]}>
+#smem = #ttg.shared_memory
 module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 1 : i32, "ttg.threads-per-warp" = 32 : i32} {
     // CHECK-LABEL: @split_all_nonneg
     // CHECK: amdg.buffer_load
@@ -28,6 +30,22 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 1 : i32, "ttg.thr
         %range = tt.make_range {end = 128 : i32, start = 0 : i32} : tensor<128xi32, #blocked0>
         %offset = arith.addi %base, %range : tensor<128xi32, #blocked0>
         %ret = amdg.buffer_load %arg0[%offset] : tensor<128xf32, #blocked0>
+        tt.return
+    }
+    // CHECK-LABEL: @no_split_masked_buffer_ops
+    // CHECK: amdg.buffer_load
+    // CHECK-NOT: amdgpu.split_soffset_safe
+    // CHECK: amdg.buffer_store
+    // CHECK-NOT: amdgpu.split_soffset_safe
+    // CHECK: amdg.buffer_load_to_local
+    // CHECK-NOT: amdgpu.split_soffset_safe
+    tt.func @no_split_masked_buffer_ops(%arg0: !tt.ptr<f32>, %value: tensor<128xf32, #blocked0>,
+                                        %dst: !ttg.memdesc<128xf32, #shared0, #smem, mutable>,
+                                        %mask: tensor<128xi1, #blocked0>) {
+        %range = tt.make_range {end = 128 : i32, start = 0 : i32} : tensor<128xi32, #blocked0>
+        %0 = amdg.buffer_load %arg0[%range], %mask : tensor<128xf32, #blocked0>
+        amdg.buffer_store %value, %arg0[%range], %mask : tensor<128xf32, #blocked0>
+        %1 = amdg.buffer_load_to_local %arg0[%range] mask = %mask into %dst : <f32>[tensor<128xi32, #blocked0>] -> <128xf32, #shared0, #smem, mutable>
         tt.return
     }
 }

--- a/third_party/amd/lib/TritonAMDGPUTransforms/AnnotateBufferOpSplitSafety.cpp
+++ b/third_party/amd/lib/TritonAMDGPUTransforms/AnnotateBufferOpSplitSafety.cpp
@@ -125,18 +125,24 @@ struct AnnotateBufferOpSplitSafetyPass
       return signalPassFailure();
 
     UnitAttr unit = UnitAttr::get(&getContext());
-    auto annotateIfSafe = [&](Operation *op, Value offsets) {
+    auto annotateIfSafe = [&](Operation *op, Value offsets, Value mask) {
+      // Don't split a masked op: #10362 lifts the offset's uniform part into
+      // soffset, which is added unconditionally and bypasses the voffset
+      // out-of-bounds masking, so masked-off lanes would still access memory.
+      // (All-true masks are nulled earlier, so any mask here is real.)
+      if (mask)
+        return;
       if (isNonNegative(offsets, *solver))
         op->setAttr(kSplitSafeAttrName, unit);
     };
 
     mod.walk([&](Operation *op) {
       if (auto load = dyn_cast<tta::BufferLoadOp>(op))
-        annotateIfSafe(op, load.getOffsets());
+        annotateIfSafe(op, load.getOffsets(), load.getMask());
       else if (auto store = dyn_cast<tta::BufferStoreOp>(op))
-        annotateIfSafe(op, store.getOffsets());
+        annotateIfSafe(op, store.getOffsets(), store.getMask());
       else if (auto loadLds = dyn_cast<tta::BufferLoadToLocalOp>(op))
-        annotateIfSafe(op, loadLds.getOffsets());
+        annotateIfSafe(op, loadLds.getOffsets(), loadLds.getMask());
     });
   }
 };


### PR DESCRIPTION
## Summary
Authored with Claude

#10362 splits a uniform component of a buffer op's offset into the scalar `soffset` during AMD lowering. This silently miscompiles masked buffer loads on AMD GPUs, producing wrong numerical results with no error or crash to flag it. For a **masked** buffer op this is unsound: the LLVM emitter drops masked-off lanes by forcing their per-lane `voffset` to an out-of-bounds sentinel (`BufferOpsEmitter`: `select(pred, voffset, OOB)`), but any uniform component lifted into `soffset` is added **unconditionally** and is not covered by that sentinel. With a non-zero `soffset` the masked-off address can re-enter bounds, so the op reads real data instead of returning `other`, a silent numerical miscompile.

The hoisted `soffset` is genuinely wave-uniform, so this is **not** a uniformity-analysis misclassification; the split itself is unsafe under masking.

We first came across this issue when upgrading the Triton pin for Pytorch and observing the `test_dont_inplace_disjoint_accesses` PyTorch Inductor test on MI300x fail. This produced ~30 abs error once the reduction loop is software-pipelined (`num_stages=2` gives the offset a uniform component to lift). AMD-only, because Inductor enables this pipelining for HIP. We bisected Triton and found #10362 is the root cause. We verified with the changes in this PR, the error is gone.

## Fix

In `AnnotateBufferOpSplitSafety`, only annotate `amdgpu.split_soffset_safe` for unmasked ops; any op carrying a mask is left un-split, keeping the whole offset in the bounds-checked `voffset` (pre-#10362 behavior) so masked lanes are correctly dropped. `ConvertToBufferOps` already drops all-true masks to null before this pass, so a present mask always predicates. Unmasked ops (the common path and #10362's perf target) are unaffected.

Covers all three buffer op types: `BufferLoadOp`, `BufferStoreOp`, `BufferLoadToLocalOp`.

## Testing

* Hardware (MI300X, gfx942, ROCm 6.4.2): the failing kernel goes from `max_abs_err ~30` to `~0.06` with software pipelining ON, matching the no-pipelining baseline.
* Lit: adds `amd-annotate-buffer-op-split-safety.mlir` coverage. Masked load/store/load_to_local stay un-split (`CHECK-NOT: amdgpu.split_soffset_safe`); unmasked ops still split.
