### PR TITLE
[Gluon] Initialize CLC barriers only for CLC scheduler

### DIFF
--- a/python/examples/gluon/04-2cta-block-scale-matmul.py
+++ b/python/examples/gluon/04-2cta-block-scale-matmul.py
@@ -713,10 +713,11 @@ def mma_scaled_warp_specialized_kernel(a_desc, b_desc, c_desc, a_scale_desc, b_s
     clc_barriers = mbarrier.allocate_mbarrier(batch=num_acc_buffers)
     clc_planar_ready_bars = mbarrier.allocate_mbarrier(batch=num_acc_buffers)
     clc_consumed_bars = mbarrier.allocate_mbarrier(batch=num_acc_buffers, two_ctas=TWO_CTAS)
-    for i in gl.static_range(num_acc_buffers):
-        mbarrier.init(clc_barriers.index(i), count=1)
-        mbarrier.init(clc_planar_ready_bars.index(i), count=1)
-        mbarrier.init(clc_consumed_bars.index(i), count=N_PARTITIONS - 1)
+    if scheduler == SCHEDULER_CLC:
+        for i in gl.static_range(num_acc_buffers):
+            mbarrier.init(clc_barriers.index(i), count=1)
+            mbarrier.init(clc_planar_ready_bars.index(i), count=1)
+            mbarrier.init(clc_consumed_bars.index(i), count=N_PARTITIONS - 1)
 
     cga_layout_clc: gl.constexpr = [[0]] * (gl.num_ctas().bit_length() - 1)
     clc_layout: gl.constexpr = gl.SwizzledSharedLayout(1, 1, 1, [0], cga_layout=cga_layout_clc)


### PR DESCRIPTION
PR description written by Codex

Only initialize CLC-specific mbarriers for the CLC scheduler. SPS reuses the same shared-memory storage in the epilogue, and PTX requires valid mbarriers to be invalidated before their storage is repurposed.

Tested with the complete 1,500-case warp-specialized matrix on GB300.

## Stack
Merge bottom-up:
- [ ] #10657 (this PR)
