### PR TITLE
Pin Windows runner at 2022 in `llvm-build.yml`

### DIFF
--- a/.github/workflows/llvm-build.yml
+++ b/.github/workflows/llvm-build.yml
@@ -37,7 +37,7 @@ jobs:
         - {runner: 'AlmaLinux 8 ARM64', runs_on: 'ubuntu-22.04-arm', target-os: 'almalinux', arch: 'arm64', container: 'almalinux:8.10-20250411'}
         - {runner: 'MacOS X64', runs_on: 'macos-15-intel', target-os: 'macos', arch: 'x64'}
         - {runner: 'MacOS ARM64', runs_on: 'macos-15', target-os: 'macos', arch: 'arm64'}
-        - {runner: 'Windows Latest', runs_on: 'windows-latest', target-os: 'windows', arch: 'x64'}
+        - {runner: 'Windows 2022', runs_on: 'windows-2022', target-os: 'windows', arch: 'x64'}
 
     steps:
 

--- a/cmake/llvm-build-info.json
+++ b/cmake/llvm-build-info.json
@@ -1,5 +1,5 @@
 {
   "llvm_hash": "1f126a6dea50d185c0781743a667390037ae88bd",
   "repository": "triton-lang/llvm-project",
-  "build_number": 1
+  "build_number": 2
 }


### PR DESCRIPTION
Resolves #10659 .

How should we trigger a rebuild of LLVM? Preferably it should overwrite https://oaitriton.blob.core.windows.net/public/llvm-builds/llvm-1f126a6d-windows-x64-1.tar.gz , given that the LLVM commit is unchanged, and the `release/3.7.x` branch does not yet use `llvm-info.json` for a hash on each platform.

If the uploaded blob is immutable, maybe we can bump `build_number` from 1 to 2, then I can do some special handling to download it in `setup.py` in the triton-windows repo.

cc @antiagainst 