### PR TITLE
[AMD] Reconcile unrealized casts unconditionally before make_llir

### DIFF
--- a/python/src/passes.cc
+++ b/python/src/passes.cc
@@ -133,6 +133,8 @@ void init_triton_passes_convert(py::module &&m) {
   ADD_PASS_WRAPPER_0("add_index_to_llvmir", createConvertIndexToLLVMPass);
   ADD_PASS_WRAPPER_0("add_arith_to_llvmir", createArithToLLVMConversionPass);
   ADD_PASS_WRAPPER_0("add_nvvm_to_llvm", createConvertNVVMToLLVMPass);
+  ADD_PASS_WRAPPER_0("add_reconcile_unrealized_casts",
+                     createReconcileUnrealizedCastsPass);
 }
 
 void init_triton_passes_llvmir(py::module &&m) {

--- a/test/Conversion/amd/reconcile_unrealized_casts.mlir
+++ b/test/Conversion/amd/reconcile_unrealized_casts.mlir
@@ -1,12 +1,12 @@
-// RUN: triton-opt %s -split-input-file --triton-amdgpu-convert-warp-specialize-to-llvm=gfx-arch=gfx950 | FileCheck %s
+// RUN: triton-opt %s --reconcile-unrealized-casts | FileCheck %s
 
-// TritonAMDGPUConvertWarpSpecializeToLLVM reconciles leftover
-// unrealized_conversion_casts across the whole module, even for kernels that
-// contain no warp specialization. A no-op convert_layout (e.g. between two MFMA
-// layouts that are physically identical at a given shape) can survive
-// ConvertTritonGPUToLLVM as a `struct -> tensorA -> tensorB -> struct` cast chain
-// that transitively converts a value back to its original type. Reconciliation
-// must erase it, otherwise it reaches and fails MLIR->LLVM translation.
+// AMD's make_llir runs reconcile-unrealized-casts right after
+// ConvertTritonGPUToLLVM. A no-op convert_layout on a loop-carried value (e.g.
+// between two MFMA layouts that are physically identical at a given shape) can
+// survive that partial conversion as a `struct -> tensorA -> tensorB -> struct`
+// cast chain that transitively converts a value back to its original type. The
+// reconcile pass must eliminate such a chain; otherwise it reaches, and fails,
+// MLIR->LLVM translation.
 
 #mma = #ttg.amd_mfma<{version = 4, warpsPerCTA = [2, 1], instrShape = [16, 16, 32], isTransposed = true}>
 #mma1 = #ttg.amd_mfma<{version = 4, warpsPerCTA = [1, 2], instrShape = [16, 16, 32], isTransposed = true}>

--- a/test/Conversion/amd/reconcile_unrealized_casts.mlir
+++ b/test/Conversion/amd/reconcile_unrealized_casts.mlir
@@ -1,0 +1,24 @@
+// RUN: triton-opt %s -split-input-file --triton-amdgpu-convert-warp-specialize-to-llvm=gfx-arch=gfx950 | FileCheck %s
+
+// TritonAMDGPUConvertWarpSpecializeToLLVM reconciles leftover
+// unrealized_conversion_casts across the whole module, even for kernels that
+// contain no warp specialization. A no-op convert_layout (e.g. between two MFMA
+// layouts that are physically identical at a given shape) can survive
+// ConvertTritonGPUToLLVM as a `struct -> tensorA -> tensorB -> struct` cast chain
+// that transitively converts a value back to its original type. Reconciliation
+// must erase it, otherwise it reaches and fails MLIR->LLVM translation.
+
+#mma = #ttg.amd_mfma<{version = 4, warpsPerCTA = [2, 1], instrShape = [16, 16, 32], isTransposed = true}>
+#mma1 = #ttg.amd_mfma<{version = 4, warpsPerCTA = [1, 2], instrShape = [16, 16, 32], isTransposed = true}>
+module attributes {"ttg.num-warps" = 2 : i32, "ttg.threads-per-warp" = 64 : i32, "ttg.num-ctas" = 1 : i32} {
+  // CHECK-LABEL: @reconcile_roundtrip_cast_chain
+  // CHECK-NOT: unrealized_conversion_cast
+  // CHECK: llvm.return %arg0
+  llvm.func @reconcile_roundtrip_cast_chain(
+      %arg0: !llvm.struct<(f32, f32, f32, f32)>) -> !llvm.struct<(f32, f32, f32, f32)> {
+    %0 = builtin.unrealized_conversion_cast %arg0 : !llvm.struct<(f32, f32, f32, f32)> to tensor<16x16xf32, #mma>
+    %1 = builtin.unrealized_conversion_cast %0 : tensor<16x16xf32, #mma> to tensor<16x16xf32, #mma1>
+    %2 = builtin.unrealized_conversion_cast %1 : tensor<16x16xf32, #mma1> to !llvm.struct<(f32, f32, f32, f32)>
+    llvm.return %2 : !llvm.struct<(f32, f32, f32, f32)>
+  }
+}

--- a/third_party/amd/backend/compiler.py
+++ b/third_party/amd/backend/compiler.py
@@ -402,6 +402,8 @@ class HIPBackend(BaseBackend):
             passes.llvmir.add_di_scope(pm)
 
         amd.passes.ttgpuir.add_builtin_func_to_llvmir(pm, options.arch, __HIP_FTZ)
+        # Cleanup leave unrealized_conversion_casts before converted to LLVM.
+        passes.convert.add_reconcile_unrealized_casts(pm)
         pm.run(mod, 'make_llir')
 
         if knobs.compilation.dump_ir_extract_di_local_variables:

--- a/third_party/amd/backend/compiler.py
+++ b/third_party/amd/backend/compiler.py
@@ -402,7 +402,7 @@ class HIPBackend(BaseBackend):
             passes.llvmir.add_di_scope(pm)
 
         amd.passes.ttgpuir.add_builtin_func_to_llvmir(pm, options.arch, __HIP_FTZ)
-        # Cleanup leave unrealized_conversion_casts before converted to LLVM.
+        # Cleanup leftover unrealized_conversion_casts before converted to LLVM.
         passes.convert.add_reconcile_unrealized_casts(pm)
         pm.run(mod, 'make_llir')
 

--- a/third_party/amd/lib/TritonAMDGPUToLLVM/ConvertWarpSpecializeToLLVM.cpp
+++ b/third_party/amd/lib/TritonAMDGPUToLLVM/ConvertWarpSpecializeToLLVM.cpp
@@ -190,6 +190,16 @@ struct TritonAMDGPUConvertWarpSpecializeToLLVM
   void runOnOperation() override {
     ModuleOp mod = getOperation();
 
+    SmallVector<Operation *> wsOps;
+    mod.walk([&](Operation *op) {
+      if (isa<WarpSpecializeOp, WarpSpecializePartitionsOp, WarpYieldOp>(op))
+        wsOps.push_back(op);
+    });
+
+    // If no warp specialization ops, this pass is a no-op
+    if (wsOps.empty())
+      return;
+
     // Use the arch parameter if provided, otherwise get from module
     std::string archStr = this->gfxArch;
     if (archStr.empty()) {
@@ -201,20 +211,22 @@ struct TritonAMDGPUConvertWarpSpecializeToLLVM
       }
       archStr = arch->str();
     }
+
     AMD::TargetInfo targetInfo(archStr.c_str());
+    if (targetInfo.getISAFamily() != triton::amdgpu::ISAFamily::GFX1250) {
+      mod.emitError("Warp specialization is only supported on gfx1250, got ")
+          << archStr;
+      return signalPassFailure();
+    }
 
     // Convert types and cleanup unrealized conversions.
     mlir::LowerToLLVMOptions option(&getContext());
     option.overrideIndexBitwidth(32);
     TritonAMDGPUToLLVMTypeConverter typeConverter(&getContext(), option,
                                                   targetInfo);
-    mod.walk([&](Operation *op) {
-      if (isa<WarpSpecializeOp, WarpSpecializePartitionsOp, WarpYieldOp>(op))
-        convertOpTypes(op, typeConverter);
-    });
-
-    // Reconcile unrealized_conversion_casts across the whole module
-    // unconditionally.
+    for (Operation *op : wsOps) {
+      convertOpTypes(op, typeConverter);
+    }
     OpPassManager pm;
     pm.addPass(createReconcileUnrealizedCastsPass());
     if (failed(runPipeline(pm, mod)))

--- a/third_party/amd/lib/TritonAMDGPUToLLVM/ConvertWarpSpecializeToLLVM.cpp
+++ b/third_party/amd/lib/TritonAMDGPUToLLVM/ConvertWarpSpecializeToLLVM.cpp
@@ -190,16 +190,6 @@ struct TritonAMDGPUConvertWarpSpecializeToLLVM
   void runOnOperation() override {
     ModuleOp mod = getOperation();
 
-    SmallVector<Operation *> wsOps;
-    mod.walk([&](Operation *op) {
-      if (isa<WarpSpecializeOp, WarpSpecializePartitionsOp, WarpYieldOp>(op))
-        wsOps.push_back(op);
-    });
-
-    // If no warp specialization ops, this pass is a no-op
-    if (wsOps.empty())
-      return;
-
     // Use the arch parameter if provided, otherwise get from module
     std::string archStr = this->gfxArch;
     if (archStr.empty()) {
@@ -211,22 +201,20 @@ struct TritonAMDGPUConvertWarpSpecializeToLLVM
       }
       archStr = arch->str();
     }
-
     AMD::TargetInfo targetInfo(archStr.c_str());
-    if (targetInfo.getISAFamily() != triton::amdgpu::ISAFamily::GFX1250) {
-      mod.emitError("Warp specialization is only supported on gfx1250, got ")
-          << archStr;
-      return signalPassFailure();
-    }
 
     // Convert types and cleanup unrealized conversions.
     mlir::LowerToLLVMOptions option(&getContext());
     option.overrideIndexBitwidth(32);
     TritonAMDGPUToLLVMTypeConverter typeConverter(&getContext(), option,
                                                   targetInfo);
-    for (Operation *op : wsOps) {
-      convertOpTypes(op, typeConverter);
-    }
+    mod.walk([&](Operation *op) {
+      if (isa<WarpSpecializeOp, WarpSpecializePartitionsOp, WarpYieldOp>(op))
+        convertOpTypes(op, typeConverter);
+    });
+
+    // Reconcile unrealized_conversion_casts across the whole module
+    // unconditionally.
     OpPassManager pm;
     pm.addPass(createReconcileUnrealizedCastsPass());
     if (failed(runPipeline(pm, mod)))


### PR DESCRIPTION
This fix a crash where compiling the AOTriton flash-attention split-backward kernel for gfx950 crashes in make_llir with LLVM Translation failed for operation: `builtin.unrealized_conversion_cast`, after https://github.com/triton-lang/triton/pull/9953

Original behavior: AMD's `ConvertWarpSpecializeToLLVM` early-returned `if (wsOps.empty()) return;` whenever a module had no warp-specialize ops, which skipped its reconcile-unrealized-casts. That reconcile is the module-wide cleanup of casts left by the partial `ConvertTritonGPUToLLVM` conversion. So ordinary (non-ws) kernels never got it, and a leftover no-op convert_layout (lowered to a `struct→#mma→#mma1→struct` cast chain) survived to translation and eventually crash.

Reconcile now happens in compiler.py instead of having warp specialize pass to be load bearing point. 

Potential follow-ups:
 - We should never materialize the situation that has equivalent layout but different encodings on a block argument. But removing it from the `RemoveLayoutConversions` side has to be extremely targeted at the situation where it is exposed that make it overfitting to the consumer code.