### PR TITLE
[CONSAN] Implementing fence-async-proxy modeling

### DIFF
--- a/include/triton/Dialect/TritonInstrument/IR/FunctionBuilder.h
+++ b/include/triton/Dialect/TritonInstrument/IR/FunctionBuilder.h
@@ -231,6 +231,48 @@ public:
   void createPublishClusterVisibilityCall(ImplicitLocOpBuilder &b, Value pred,
                                           MemType memType,
                                           Operation *insertPoint);
+  // setProxyAccess: record a generic-proxy access by the current base thread
+  // and invalidate prior proxy-fence coverage for that source thread.
+  void createSetProxyAccessCall(ImplicitLocOpBuilder &b, Value buf,
+                                uint32_t length, int thread, Value pred,
+                                Operation *insertPoint, Value effectCTAs);
+  // fenceProxyAccesses: mark all generic accesses visible to the current base
+  // thread as covered by fence.proxy.async. A CTA fence covers the current
+  // buffer row; a cluster fence covers every cluster buffer row.
+  void createFenceProxyAccessesCall(ImplicitLocOpBuilder &b, int thread,
+                                    bool cluster, Value pred,
+                                    Operation *insertPoint);
+  // trackProxyAccesses: snapshot the current base thread's packed generic
+  // access/fence frontier into a barrier tracking row.
+  void createTrackProxyAccessesCall(ImplicitLocOpBuilder &b, Value mbar,
+                                    int thread, Value pred,
+                                    Operation *insertPoint, Value barrierCTAs);
+  // transferProxyAccesses: merge a barrier's packed proxy frontier into the
+  // waiting base thread.
+  void createTransferProxyAccessesCall(ImplicitLocOpBuilder &b, Value mbar,
+                                       int thread, Value pred,
+                                       Operation *insertPoint);
+  // clearBarrierProxyAccessTracking: clear packed proxy state associated with
+  // an invalidated barrier.
+  void createClearBarrierProxyAccessTrackingCall(ImplicitLocOpBuilder &b,
+                                                 Value mbar, Value pred,
+                                                 Operation *insertPoint);
+  // verifyProxyAccess: assert that every generic-proxy access visible to the
+  // issuing base thread has crossed fence.proxy.async.
+  void createVerifyProxyAccessCall(ImplicitLocOpBuilder &b, Value buf,
+                                   uint32_t length, int thread,
+                                   StringRef operandName, Value pred,
+                                   Operation *insertPoint, Value effectCTAs);
+  // copyProxyAccesses: copy a parent base thread's packed proxy frontier to
+  // warp-specialization partition threads.
+  void createCopyProxyAccessesCall(ImplicitLocOpBuilder &b, int sourceThread,
+                                   uint64_t destMask, Value pred,
+                                   Operation *insertPoint);
+  // publishClusterProxyAccesses: publish packed generic access and fence facts
+  // to every base thread after a non-relaxed cluster barrier.
+  void createPublishClusterProxyAccessesCall(ImplicitLocOpBuilder &b,
+                                             Value pred,
+                                             Operation *insertPoint);
   // stageAccessForCommit: mark the buffer as staged (value -1) in the
   // outstanding commit table for this thread.
   void createStageAccessForCommitCall(ImplicitLocOpBuilder &b, Value buf,

--- a/include/triton/Dialect/TritonInstrument/IR/TritonInstrument.md
+++ b/include/triton/Dialect/TritonInstrument/IR/TritonInstrument.md
@@ -57,6 +57,8 @@ counters are involved.
 At a `ttg.warp_specialize`, the pass copies the default thread's read and write
 visibility to the destination partition peer masks so partition-local execution
 starts with the visibility frontier that existed before specialization.
+The generic-to-async proxy frontier is copied separately to the destination
+base-thread rows; it does not use the TMA, Tensor Core, or CLC peer slots.
 
 ## CTA Model
 
@@ -87,6 +89,7 @@ At a high level, the pass maintains:
 
 - Buffer and barrier descriptors discovered by BufferRegion analysis.
 - Read and write visibility frontiers for each tracked buffer.
+- Optional generic-to-async proxy-fence frontiers for shared-memory buffers.
 - Barrier lifecycle, waiting, and barrier-to-buffer tracking state.
 - Outstanding commit counters for commit-count-ordered asynchronous flows.
 - Optional alias metadata when tracked buffer regions overlap.
@@ -123,6 +126,64 @@ state that the write supersedes.
 All normal instrumentation emitted around one IR operation is wrapped in the
 ConSan lock. Barrier waits are split into a locked pre-wait section and a locked
 post-wait section.
+
+## Generic-to-Async Proxy Ordering
+
+On NVIDIA targets, some instructions access shared memory through the generic
+proxy and others through an async proxy. ConSan requires every generic-proxy
+access that precedes an async-proxy access to cross
+`ttng.fence_async_shared` before the async access is issued. This rule applies
+to both reads and writes. In particular, ConSan intentionally requires a fence
+for a generic read followed by an async read even though that pair alone is not
+a data hazard. This is the conservative rule exposed at the Gluon level.
+
+The proxy state is maintained per buffer, CTA, and base thread. Each frontier
+records which source base threads have made generic accesses visible and which
+of those source accesses have been covered by a proxy fence. A new generic
+access marks its source as seen and invalidates older fence coverage for that
+source and buffer. `ttng.fence_async_shared` covers the generic accesses
+currently visible to the issuing base thread; it does not fence another logical
+thread. A CTA-scoped fence covers current-CTA buffer rows, while a
+cluster-scoped fence covers buffer rows across the cluster.
+
+Synchronization transports the packed access-and-fence frontier in the same
+places that ordinary read visibility is transported:
+
+- A frontier-tracked mbarrier arrive copies the issuing base thread's current
+  proxy frontier into the barrier tracking row. The local copy remains live, so
+  an arrive does not make a later async access by the arriving thread legal.
+- A successful mbarrier wait merges the selected barrier row into the waiting
+  base thread's row. A fence before the wait cannot cover accesses learned only
+  by that wait; a fence after the wait can.
+- Barrier invalidation clears the barrier's proxy tracking row.
+- A non-relaxed publishing cluster barrier publishes the proxy frontier across
+  CTA and base-thread rows.
+- Warp specialization copies the parent's proxy frontier into the new
+  partition base-thread rows.
+
+Before an async-proxy shared-memory effect, ConSan checks only the issuing base
+thread's row, restricted to the effect-recipient CTA rows and expanded through
+the shared-memory alias matrix. The access is legal when every visible generic
+source bit has corresponding fence coverage. This current-thread check is what
+allows a producer to fence before publishing through an mbarrier, or a consumer
+to wait and then fence, without treating a fence in an unrelated thread as
+sufficient.
+
+When ConSan initializes an otherwise uninitialized shared allocation with a
+poison pattern, it emits a CTA-scoped async-shared fence after the poison store
+and its CTA barrier. The poison operations are added after ordinary ConSan
+instrumentation, so this fence prevents the sanitizer's own generic stores from
+introducing an unmodeled proxy hazard.
+
+ConSan does not add a symmetric proxy check for async-to-generic accesses.
+PTX completion mechanisms for the modeled async operations provide the
+async-to-generic proxy ordering, and ConSan already requires the corresponding
+explicit completion wait before a later conflicting generic access is legal.
+For example, a TMA-load mbarrier wait or an async commit-count wait transfers
+ordinary visibility to the waiting thread. By contrast, `cp.async` completion
+followed by a TCGen or WGMMA shared-memory access still needs
+`fence_async_shared`: `cp.async` is recorded as a generic-side access for this
+check, and its wait does not clear the generic-to-async proxy frontier.
 
 ## CTA Issuers, Effects, and Recipients
 
@@ -167,15 +228,17 @@ On a barrier wait, ConSan:
 6. Re-acquires the lock after the wait.
 7. Transfers tracked write and read visibility from the barrier to the current
    thread's peer mask for shared memory and tensor memory.
-8. Clears the current base thread's waiting bits.
+8. Transfers the tracked generic-to-async proxy frontier to the current base
+   thread.
+9. Clears the current base thread's waiting bits.
 
 Write transfers also consult the recorded effect-recipient CTA rows, which lets
 TMA-style and CLC cross-CTA writes become visible in the CTA rows reached by the
 memory effect. Read transfers update the current CTA row.
 
 A non-relaxed cluster barrier is different from an mbarrier wait: it publishes
-synchronous work from base threads to all CTA rows directly (i.e., just the generic
-proxy).
+synchronous work from base threads to all CTA rows directly. This includes both
+ordinary read/write visibility and the generic-access/proxy-fence frontier.
 
 ## Barrier Lifecycle and Deadlock Checks
 
@@ -187,7 +250,7 @@ without invalidation. Arrivals are checked for count underflow and tx-count
 range violations before the shadow barrier state is updated. When both the
 current arrival count and tx-count reach zero, the shadow state flips phase and
 reloads the current count from the initial count. Invalidation clears the
-barrier lifecycle, waiting, and read/write tracking state.
+barrier lifecycle, waiting, read/write tracking, and proxy-fence tracking state.
 
 Deadlock detection records the phase each base thread is waiting on. The check
 aligns those stored phases with each barrier's current phase, filters to active
@@ -216,13 +279,16 @@ same-partition ordering while still checking cross-partition races.
 The common hook implementation covers these TritonGPU operations:
 
 - `ttg.async_copy_global_to_local`: shared-memory write tracked with
-  `AsyncCp` commit counts.
+  `AsyncCp` commit counts and recorded as a generic-side proxy access.
 - `ttg.async_commit_group`: commits staged `AsyncCp` accesses.
 - `ttg.async_wait`: clears `AsyncCp` entries beyond the pending-count threshold
   and transfers write visibility.
 - `ttg.local_load`: barrier-tracked shared-memory read.
 - `ttg.local_store`: barrier-tracked shared-memory write.
 - `ttg.local_alloc` with a source: barrier-tracked shared-memory write.
+
+All three ordinary shared-memory effects above are generic-proxy accesses for
+the proxy-ordering model.
 
 NVIDIA hooks additionally cover:
 
@@ -232,16 +298,22 @@ NVIDIA hooks additionally cover:
   arrive path for multicast barriers.
 - `ttng.arrive_barrier`.
 - TMA loads as barrier-tracked writes with tx-count decrement and precise
-  effect-write tracking.
+  effect-write tracking. Their shared-memory destinations are async-proxy
+  effects.
 - TMA stores as `TmaStore` commit-count reads, with `ttng.tma_store_wait`
-  transferring read visibility.
+  transferring read visibility. Their shared-memory sources are async-proxy
+  effects.
 - TMEM load, store, alloc-with-source, and copy operations.
 - TCGen5 MMA, scaled MMA, commit, and TMEM copy operations as Tensor Core peer
-  thread effects.
+  thread effects. Shared A/B/scale operands and the shared source of TMEM copy
+  are async-proxy effects.
 - CLC try-cancel as a CLC peer-thread write with EffectWrites barrier tracking,
-  and CLC load-result as a barrier-tracked read.
-- Async WGMMA operands in shared memory as `Wgmma` commit-count reads, with
-  `ttng.warp_group_dot_wait` transferring read visibility.
+  and CLC load-result as a barrier-tracked read. The try-cancel result write is
+  an async-proxy effect.
+- WGMMA operands in shared memory as async-proxy effects. Async WGMMA also uses
+  `Wgmma` commit-count reads, with `ttng.warp_group_dot_wait` transferring read
+  visibility.
+- `ttng.async_shared_store` as a generic-side shared-memory access.
 
 AMD hooks additionally cover:
 

--- a/include/triton/Dialect/TritonInstrument/IR/Utility.h
+++ b/include/triton/Dialect/TritonInstrument/IR/Utility.h
@@ -35,6 +35,10 @@ enum Kind { None = -1, AsyncCp = 0, Wgmma, TmaStore, NumCommitKinds };
 // writeVisibility + readVisibility per active memory type.
 constexpr int kCapturesPerMemType = 2;
 
+// proxyAccessVisibility, plus proxyAccessTracking when barriers are present.
+constexpr int kProxyFenceBaseCaptures = 1;
+constexpr int kProxyFenceBarrierCaptures = 1;
+
 // barrierStates + waiting + activeMasks (only when barriers exist).
 constexpr int kBarrierBaseCaptures = 3;
 
@@ -54,13 +58,20 @@ constexpr int kCaptureSizeBytes = 8;
 /// \p hasBarriers        Whether barriers exist in the module.
 /// \p numCommitKinds     Number of distinct commit kinds required.
 inline int estimateConSanCaptureCount(int numActiveMemTypes, bool hasBarriers,
-                                      int numCommitKinds) {
+                                      int numCommitKinds,
+                                      bool hasAsyncProxyFenceTracking) {
   int perMemType = kCapturesPerMemType * numActiveMemTypes;
   int barrierCaptures =
       hasBarriers ? kBarrierBaseCaptures +
                         kBarrierTrackingCapturesPerMemType * numActiveMemTypes
                   : 0;
-  return perMemType + barrierCaptures + kFixedCaptures + numCommitKinds;
+  int proxyFenceCaptures =
+      hasAsyncProxyFenceTracking
+          ? kProxyFenceBaseCaptures +
+                (hasBarriers ? kProxyFenceBarrierCaptures : 0)
+          : 0;
+  return perMemType + barrierCaptures + proxyFenceCaptures + kFixedCaptures +
+         numCommitKinds;
 }
 
 void createAssertInThread(ImplicitLocOpBuilder &b, Value condition,
@@ -155,7 +166,8 @@ struct AuxDataMap {
   //   K = tracked mbarriers, power-of-two padded.
   //   T = logical ConSan thread bit slots used by this module, power-of-two
   //       padded for the distributed layout.
-  //   P = base-thread commit columns used by this module, power-of-two padded.
+  //   P = base-thread columns used by commit and proxy state, power-of-two
+  //       padded.
   //
   // Storage notation:
   //   tensor  = distributed tensor value.
@@ -195,6 +207,17 @@ struct AuxDataMap {
   // Per-memory-type buffer/barrier map for read visibility masks that a barrier
   // tracks.
   RegionToValueMap readTracking[numMemTypes];
+
+  // scratch, <Cbuf x B x Cthr x P x Cmask x i64>
+  // Generic-proxy shared-memory accesses visible to each base thread. The low
+  // 16 bits contain source base-thread ids that have accessed the buffer; bits
+  // [16..31] contain the subset covered by fence.proxy.async on the path to
+  // that consumer. CTA dimensions distinguish source and consumer CTAs.
+  RegionToValueMap proxyAccessVisibility;
+
+  // scratch, <Cbuf x B x Cbar x K x Cmask x i64>
+  // Barrier publication table for packed proxyAccessVisibility state.
+  RegionToValueMap proxyAccessTracking;
 
   // scratch, <C x B x P x i8>
   // Per-commit-kind outstanding commit counters for shared-memory buffers.
@@ -237,6 +260,8 @@ struct AuxDataMap {
   // Dense logical-thread numbering for this module. Base threads are always
   // present; TMA/TC/CLC peer ranges are added only when the module uses them.
   ThreadLayout threadLayout;
+
+  bool hasAsyncProxyFenceTracking = false;
 
   LogicalResult populateAndPassToWarpSpecialize(ModuleOp module,
                                                 FunctionBuilder &funcBuilder,

--- a/include/triton/Dialect/TritonInstrument/Transforms/ConSanTargetHooks.h
+++ b/include/triton/Dialect/TritonInstrument/Transforms/ConSanTargetHooks.h
@@ -31,12 +31,14 @@ struct MemEffectsOpInfo {
   };
   struct Effects {
     enum RW { Read, Write } rw;
+    enum class Proxy { Generic, Async } proxy;
     Value buf;
     std::string operandName = "";
     uint32_t length = 0;
 
-    Effects(RW rw, Value buf, std::string operandName = "")
-        : rw(rw), buf(buf), operandName(operandName),
+    Effects(RW rw, Value buf, std::string operandName = "",
+            Proxy proxy = Proxy::Generic)
+        : rw(rw), proxy(proxy), buf(buf), operandName(operandName),
           length(getMemDescLength(buf)) {}
   };
   struct BarrierInfo {
@@ -83,6 +85,10 @@ struct WaitOpInfo {
   bool transferReads;
 };
 
+struct AsyncProxyFenceInfo {
+  bool cluster;
+};
+
 struct CommitKindDesc {
   CommitKind::Kind kind;
   std::string operationDesc;
@@ -106,6 +112,15 @@ public:
   getBarrierInvalidateInfo(Operation *op) const = 0;
 
   virtual std::optional<WaitOpInfo> getWaitOpInfo(Operation *op) const = 0;
+
+  virtual std::optional<AsyncProxyFenceInfo>
+  getAsyncProxyFenceInfo(Operation *op) const {
+    return std::nullopt;
+  }
+
+  virtual bool needsAsyncProxyFenceTracking(ModuleOp module) const {
+    return false;
+  }
 
   virtual Value getIssuerCTAPred(ImplicitLocOpBuilder &b,
                                  Operation *op) const = 0;

--- a/lib/Dialect/TritonInstrument/IR/FunctionBuilder.cpp
+++ b/lib/Dialect/TritonInstrument/IR/FunctionBuilder.cpp
@@ -70,6 +70,11 @@ uint32_t makeInterleavedMask(unsigned bit, unsigned numBaseThreads) {
 }
 } // namespace WaitingBits
 
+namespace ProxyAccessBits {
+constexpr unsigned fencedOffset = MAX_NUM_BASE_THREADS;
+constexpr uint64_t seenMask = (1ull << MAX_NUM_BASE_THREADS) - 1;
+} // namespace ProxyAccessBits
+
 // Information about the optional assert message and tensor type to check.
 struct AssertInfo {
   StringRef message;
@@ -2640,6 +2645,572 @@ void FunctionBuilder::createPublishClusterVisibilityCall(
             arith::OrIOp::create(fb, readVisibility, readsForCluster);
         tti::createStoreScratchMemory(fb, fb.getLoc(), readVisibilityPtr,
                                       newReadVisibility, readVisibilityType,
+                                      /*currentCTAOnly=*/false);
+
+        fb.setInsertionPointToEnd(thenBlock);
+        triton::ReturnOp::create(fb);
+      });
+}
+
+void FunctionBuilder::createSetProxyAccessCall(ImplicitLocOpBuilder &b,
+                                               Value buf, uint32_t length,
+                                               int thread, Value pred,
+                                               Operation *insertPoint,
+                                               Value effectCTAs) {
+  auto &buffersMap = auxData.buffers[(int)MemType::SHARED_MEM];
+  if (buffersMap.empty() || auxData.proxyAccessVisibility.empty())
+    return;
+  if (!pred)
+    pred = arith::ConstantIntOp::create(b, 1, 1);
+
+  ValueType buffers = buffersMap.at(insertPoint);
+  ValueType visibility = auxData.proxyAccessVisibility.at(insertPoint);
+  auto buffersType = cast<RankedTensorType>(buffers.type);
+  auto visibilityType = cast<RankedTensorType>(visibility.type);
+  bool hasTracking = !auxData.proxyAccessTracking.empty();
+  RankedTensorType trackingType;
+  SmallVector<Value> args = {tti::ExperimentalMemDescToI32Op::create(b, buf),
+                             arith::ConstantIntOp::create(b, length, 32),
+                             pred,
+                             arith::ConstantIntOp::create(b, thread, 32),
+                             buffers.value,
+                             visibility.value,
+                             effectCTAs};
+  ManglingArgs specializationArgs{buffersType, visibilityType,
+                                  (uint64_t)hasTracking};
+  if (hasTracking) {
+    ValueType tracking = auxData.proxyAccessTracking.at(insertPoint);
+    trackingType = cast<RankedTensorType>(tracking.type);
+    args.push_back(tracking.value);
+    specializationArgs.append(trackingType);
+  }
+
+  createCallToCachedFunction(
+      b, "set_proxy_access", args, /*assertInfo=*/std::nullopt,
+      specializationArgs,
+      [visibilityType, trackingType, hasTracking](ImplicitLocOpBuilder &fb,
+                                                  Block *entryBlock) {
+        Value bufOffset = entryBlock->getArgument(0);
+        Value lengthVal = entryBlock->getArgument(1);
+        Value pred = entryBlock->getArgument(2);
+        Value threadVal = entryBlock->getArgument(3);
+        Value buffers = entryBlock->getArgument(4);
+        Value visibilityPtr = entryBlock->getArgument(5);
+        Value effectCTAs = entryBlock->getArgument(6);
+        Value trackingPtr = hasTracking ? entryBlock->getArgument(7) : Value();
+
+        auto [prevBlock, ifBlock, thenBlock] = createIfBlock(fb, pred);
+        fb.setInsertionPointToStart(ifBlock);
+
+        Value visibility = tti::createLoadScratchMemory(
+            fb, fb.getLoc(), visibilityPtr, visibilityType);
+        Value descriptor = createBufferDescriptor(fb, bufOffset, lengthVal);
+        Value buffersEqBuf = createCmpIntTensorScalar(fb, buffers, descriptor);
+        Value bufferVector = buffersEqBuf;
+        buffersEqBuf =
+            convertAndBroadcast(fb, buffersEqBuf, {1}, visibilityType);
+        Value bufferCTAMask =
+            createCTASetMask(fb, visibilityType, /*dim=*/0, effectCTAs);
+        Value currentCTA = createCurrentCTAMask(fb);
+        Value originCTAMask =
+            createCTASetMask(fb, visibilityType, /*dim=*/4, currentCTA);
+        Value selectedBuffers =
+            arith::AndIOp::create(fb, buffersEqBuf, bufferCTAMask);
+        selectedBuffers =
+            arith::AndIOp::create(fb, selectedBuffers, originCTAMask);
+
+        Value threadI64 =
+            arith::ExtUIOp::create(fb, fb.getI64Type(), threadVal);
+        Value one64 = arith::ConstantIntOp::create(fb, 1, 64);
+        Value seenBitScalar = arith::ShLIOp::create(fb, one64, threadI64);
+        Value fencedShift =
+            arith::AddIOp::create(fb, threadI64,
+                                  arith::ConstantIntOp::create(
+                                      fb, ProxyAccessBits::fencedOffset, 64));
+        Value fencedBitScalar = arith::ShLIOp::create(fb, one64, fencedShift);
+        Value allOnes = arith::ConstantIntOp::create(fb, -1, 64);
+        Value clearFencedScalar =
+            arith::XOrIOp::create(fb, fencedBitScalar, allOnes);
+        Value clearFenced =
+            triton::SplatOp::create(fb, visibilityType, clearFencedScalar);
+        Value clearedVisibility =
+            arith::AndIOp::create(fb, visibility, clearFenced);
+        clearedVisibility = arith::SelectOp::create(
+            fb, selectedBuffers, clearedVisibility, visibility);
+
+        Value consumerCTAMask =
+            createCTASetMask(fb, visibilityType, /*dim=*/2, currentCTA);
+        Value threadColumnMask =
+            createDimMask(fb, threadVal, visibilityType, /*dim=*/3);
+        Value ownerMask =
+            arith::AndIOp::create(fb, selectedBuffers, consumerCTAMask);
+        ownerMask = arith::AndIOp::create(fb, ownerMask, threadColumnMask);
+        Value seenBit =
+            triton::SplatOp::create(fb, visibilityType, seenBitScalar);
+        Value withSeen = arith::OrIOp::create(fb, clearedVisibility, seenBit);
+        Value updatedVisibility =
+            arith::SelectOp::create(fb, ownerMask, withSeen, clearedVisibility);
+        createMaskedStoreScratchMemory(fb, fb.getLoc(), visibilityPtr,
+                                       updatedVisibility, visibilityType,
+                                       selectedBuffers);
+
+        // A new generic access supersedes fence coverage for an older access
+        // from the same source. Clear that source's fence bit in outstanding
+        // barrier snapshots as well, so an old publication cannot mask it.
+        if (hasTracking) {
+          Value tracking = tti::createLoadScratchMemory(
+              fb, fb.getLoc(), trackingPtr, trackingType);
+          Value trackingBuffers =
+              convertAndBroadcast(fb, bufferVector, {1}, trackingType);
+          Value trackingBufferCTAMask =
+              createCTASetMask(fb, trackingType, /*dim=*/0, effectCTAs);
+          Value trackingOriginCTAMask =
+              createCTASetMask(fb, trackingType, /*dim=*/4, currentCTA);
+          Value trackingMask =
+              arith::AndIOp::create(fb, trackingBuffers, trackingBufferCTAMask);
+          trackingMask =
+              arith::AndIOp::create(fb, trackingMask, trackingOriginCTAMask);
+          Value trackingClear =
+              triton::SplatOp::create(fb, trackingType, clearFencedScalar);
+          Value clearedTracking =
+              arith::AndIOp::create(fb, tracking, trackingClear);
+          Value updatedTracking = arith::SelectOp::create(
+              fb, trackingMask, clearedTracking, tracking);
+          createMaskedStoreScratchMemory(fb, fb.getLoc(), trackingPtr,
+                                         updatedTracking, trackingType,
+                                         trackingMask);
+        }
+
+        fb.setInsertionPointToEnd(thenBlock);
+        triton::ReturnOp::create(fb);
+      });
+}
+
+void FunctionBuilder::createFenceProxyAccessesCall(ImplicitLocOpBuilder &b,
+                                                   int thread, bool cluster,
+                                                   Value pred,
+                                                   Operation *insertPoint) {
+  if (auxData.proxyAccessVisibility.empty())
+    return;
+  if (!pred)
+    pred = arith::ConstantIntOp::create(b, 1, 1);
+  ValueType visibility = auxData.proxyAccessVisibility.at(insertPoint);
+  auto visibilityType = cast<RankedTensorType>(visibility.type);
+  SmallVector<Value> args = {arith::ConstantIntOp::create(b, thread, 32), pred,
+                             visibility.value};
+  createCallToCachedFunction(
+      b, "fence_proxy_accesses", args, /*assertInfo=*/std::nullopt,
+      {visibilityType, (uint64_t)cluster},
+      [visibilityType, cluster](ImplicitLocOpBuilder &fb, Block *entryBlock) {
+        Value threadVal = entryBlock->getArgument(0);
+        Value pred = entryBlock->getArgument(1);
+        Value visibilityPtr = entryBlock->getArgument(2);
+
+        auto [prevBlock, ifBlock, thenBlock] = createIfBlock(fb, pred);
+        fb.setInsertionPointToStart(ifBlock);
+        Value visibility = tti::createLoadScratchMemory(
+            fb, fb.getLoc(), visibilityPtr, visibilityType);
+        Value currentCTA = createCurrentCTAMask(fb);
+        Value mask =
+            createCTASetMask(fb, visibilityType, /*dim=*/2, currentCTA);
+        mask = arith::AndIOp::create(
+            fb, mask, createDimMask(fb, threadVal, visibilityType, /*dim=*/3));
+        if (!cluster) {
+          mask = arith::AndIOp::create(
+              fb, mask,
+              createCTASetMask(fb, visibilityType, /*dim=*/0, currentCTA));
+        }
+        Value seenMask = tti::createConstIntTensor(
+            fb, fb.getLoc(), ProxyAccessBits::seenMask, visibilityType);
+        Value seen = arith::AndIOp::create(fb, visibility, seenMask);
+        Value shift = tti::createConstIntTensor(
+            fb, fb.getLoc(), ProxyAccessBits::fencedOffset, visibilityType);
+        Value fenced = arith::ShLIOp::create(fb, seen, shift);
+        Value covered = arith::OrIOp::create(fb, visibility, fenced);
+        Value updated = arith::SelectOp::create(fb, mask, covered, visibility);
+        createMaskedStoreScratchMemory(fb, fb.getLoc(), visibilityPtr, updated,
+                                       visibilityType, mask);
+
+        fb.setInsertionPointToEnd(thenBlock);
+        triton::ReturnOp::create(fb);
+      });
+}
+
+void FunctionBuilder::createTrackProxyAccessesCall(ImplicitLocOpBuilder &b,
+                                                   Value mbar, int thread,
+                                                   Value pred,
+                                                   Operation *insertPoint,
+                                                   Value barrierCTAs) {
+  if (auxData.barriers.empty() || auxData.proxyAccessVisibility.empty() ||
+      auxData.proxyAccessTracking.empty())
+    return;
+  if (!pred)
+    pred = arith::ConstantIntOp::create(b, 1, 1);
+  ValueType barriers = auxData.barriers.at(insertPoint);
+  ValueType visibility = auxData.proxyAccessVisibility.at(insertPoint);
+  ValueType tracking = auxData.proxyAccessTracking.at(insertPoint);
+  auto barriersType = cast<RankedTensorType>(barriers.type);
+  auto visibilityType = cast<RankedTensorType>(visibility.type);
+  auto trackingType = cast<RankedTensorType>(tracking.type);
+  SmallVector<Value> args = {
+      tti::ExperimentalMemDescToI32Op::create(b, mbar),
+      arith::ConstantIntOp::create(b, getMemDescLength(mbar), 32),
+      pred,
+      arith::ConstantIntOp::create(b, thread, 32),
+      barriers.value,
+      visibility.value,
+      tracking.value,
+      barrierCTAs};
+  createCallToCachedFunction(
+      b, "track_proxy_accesses", args, /*assertInfo=*/std::nullopt,
+      {barriersType, visibilityType, trackingType},
+      [visibilityType, trackingType](ImplicitLocOpBuilder &fb,
+                                     Block *entryBlock) {
+        Value mbarOffset = entryBlock->getArgument(0);
+        Value lengthVal = entryBlock->getArgument(1);
+        Value pred = entryBlock->getArgument(2);
+        Value threadVal = entryBlock->getArgument(3);
+        Value barriers = entryBlock->getArgument(4);
+        Value visibilityPtr = entryBlock->getArgument(5);
+        Value trackingPtr = entryBlock->getArgument(6);
+        Value barrierCTAs = entryBlock->getArgument(7);
+
+        auto [prevBlock, ifBlock, thenBlock] = createIfBlock(fb, pred);
+        fb.setInsertionPointToStart(ifBlock);
+        Value visibility = tti::createLoadScratchMemory(
+            fb, fb.getLoc(), visibilityPtr, visibilityType);
+        Value tracking = tti::createLoadScratchMemory(
+            fb, fb.getLoc(), trackingPtr, trackingType);
+        Value currentCTA = createCurrentCTAMask(fb);
+        Value sourceMask =
+            createCTASetMask(fb, visibilityType, /*dim=*/2, currentCTA);
+        sourceMask = arith::AndIOp::create(
+            fb, sourceMask,
+            createDimMask(fb, threadVal, visibilityType, /*dim=*/3));
+        Value zeroVisibility =
+            tti::createConstIntTensor(fb, fb.getLoc(), 0, visibilityType);
+        Value source =
+            arith::SelectOp::create(fb, sourceMask, visibility, zeroVisibility);
+        source = reduce<arith::OrIOp>(fb, source, {2, 3});
+        source = convertAndBroadcast(fb, source, {0, 1, 4}, trackingType);
+
+        Value descriptor = createBufferDescriptor(fb, mbarOffset, lengthVal);
+        Value barriersEqBar =
+            createCmpIntTensorScalar(fb, barriers, descriptor);
+        barriersEqBar =
+            convertAndBroadcast(fb, barriersEqBar, {3}, trackingType);
+        Value barrierCTAMask =
+            createCTASetMask(fb, trackingType, /*dim=*/2, barrierCTAs);
+        Value trackMask =
+            arith::AndIOp::create(fb, barriersEqBar, barrierCTAMask);
+        Value withSource = arith::OrIOp::create(fb, tracking, source);
+        Value updated =
+            arith::SelectOp::create(fb, trackMask, withSource, tracking);
+        createMaskedStoreScratchMemory(fb, fb.getLoc(), trackingPtr, updated,
+                                       trackingType, barrierCTAMask);
+
+        fb.setInsertionPointToEnd(thenBlock);
+        triton::ReturnOp::create(fb);
+      });
+}
+
+void FunctionBuilder::createTransferProxyAccessesCall(ImplicitLocOpBuilder &b,
+                                                      Value mbar, int thread,
+                                                      Value pred,
+                                                      Operation *insertPoint) {
+  if (auxData.barriers.empty() || auxData.proxyAccessVisibility.empty() ||
+      auxData.proxyAccessTracking.empty())
+    return;
+  if (!pred)
+    pred = arith::ConstantIntOp::create(b, 1, 1);
+  ValueType barriers = auxData.barriers.at(insertPoint);
+  ValueType visibility = auxData.proxyAccessVisibility.at(insertPoint);
+  ValueType tracking = auxData.proxyAccessTracking.at(insertPoint);
+  auto barriersType = cast<RankedTensorType>(barriers.type);
+  auto visibilityType = cast<RankedTensorType>(visibility.type);
+  auto trackingType = cast<RankedTensorType>(tracking.type);
+  SmallVector<Value> args = {
+      tti::ExperimentalMemDescToI32Op::create(b, mbar),
+      arith::ConstantIntOp::create(b, getMemDescLength(mbar), 32),
+      pred,
+      arith::ConstantIntOp::create(b, thread, 32),
+      barriers.value,
+      visibility.value,
+      tracking.value};
+  createCallToCachedFunction(
+      b, "transfer_proxy_accesses", args, /*assertInfo=*/std::nullopt,
+      {barriersType, visibilityType, trackingType},
+      [visibilityType, trackingType](ImplicitLocOpBuilder &fb,
+                                     Block *entryBlock) {
+        Value mbarOffset = entryBlock->getArgument(0);
+        Value lengthVal = entryBlock->getArgument(1);
+        Value pred = entryBlock->getArgument(2);
+        Value threadVal = entryBlock->getArgument(3);
+        Value barriers = entryBlock->getArgument(4);
+        Value visibilityPtr = entryBlock->getArgument(5);
+        Value trackingPtr = entryBlock->getArgument(6);
+
+        auto [prevBlock, ifBlock, thenBlock] = createIfBlock(fb, pred);
+        fb.setInsertionPointToStart(ifBlock);
+        Value visibility = tti::createLoadScratchMemory(
+            fb, fb.getLoc(), visibilityPtr, visibilityType);
+        Value tracking = tti::createLoadScratchMemory(
+            fb, fb.getLoc(), trackingPtr, trackingType);
+        Value descriptor = createBufferDescriptor(fb, mbarOffset, lengthVal);
+        Value barriersEqBar =
+            createCmpIntTensorScalar(fb, barriers, descriptor);
+        barriersEqBar =
+            convertAndBroadcast(fb, barriersEqBar, {3}, trackingType);
+        Value currentCTA = createCurrentCTAMask(fb);
+        Value barrierCTAMask =
+            createCTASetMask(fb, trackingType, /*dim=*/2, currentCTA);
+        Value selected =
+            arith::AndIOp::create(fb, barriersEqBar, barrierCTAMask);
+        Value zeroTracking =
+            tti::createConstIntTensor(fb, fb.getLoc(), 0, trackingType);
+        Value frontier =
+            arith::SelectOp::create(fb, selected, tracking, zeroTracking);
+        frontier = reduce<arith::OrIOp>(fb, frontier, {2, 3});
+        frontier = convertAndBroadcast(fb, frontier, {0, 1, 4}, visibilityType);
+
+        Value targetMask =
+            createCTASetMask(fb, visibilityType, /*dim=*/2, currentCTA);
+        targetMask = arith::AndIOp::create(
+            fb, targetMask,
+            createDimMask(fb, threadVal, visibilityType, /*dim=*/3));
+        Value withFrontier = arith::OrIOp::create(fb, visibility, frontier);
+        Value updated =
+            arith::SelectOp::create(fb, targetMask, withFrontier, visibility);
+        createMaskedStoreScratchMemory(fb, fb.getLoc(), visibilityPtr, updated,
+                                       visibilityType, targetMask);
+
+        fb.setInsertionPointToEnd(thenBlock);
+        triton::ReturnOp::create(fb);
+      });
+}
+
+void FunctionBuilder::createClearBarrierProxyAccessTrackingCall(
+    ImplicitLocOpBuilder &b, Value mbar, Value pred, Operation *insertPoint) {
+  if (auxData.proxyAccessTracking.empty())
+    return;
+  assert(!auxData.barriers.empty() &&
+         "barrier descriptors must exist when clearing proxy tracking");
+  if (!pred)
+    pred = arith::ConstantIntOp::create(b, 1, 1);
+  ValueType barriers = auxData.barriers.at(insertPoint);
+  ValueType tracking = auxData.proxyAccessTracking.at(insertPoint);
+  auto barriersType = cast<RankedTensorType>(barriers.type);
+  auto trackingType = cast<RankedTensorType>(tracking.type);
+  SmallVector<Value> args = {
+      tti::ExperimentalMemDescToI32Op::create(b, mbar),
+      arith::ConstantIntOp::create(b, getMemDescLength(mbar), 32), pred,
+      barriers.value, tracking.value};
+  createCallToCachedFunction(
+      b, "clear_barrier_proxy_tracking", args,
+      /*assertInfo=*/std::nullopt, {barriersType, trackingType},
+      [trackingType](ImplicitLocOpBuilder &fb, Block *entryBlock) {
+        Value mbarOffset = entryBlock->getArgument(0);
+        Value lengthVal = entryBlock->getArgument(1);
+        Value pred = entryBlock->getArgument(2);
+        Value barriers = entryBlock->getArgument(3);
+        Value trackingPtr = entryBlock->getArgument(4);
+
+        auto [prevBlock, ifBlock, thenBlock] = createIfBlock(fb, pred);
+        fb.setInsertionPointToStart(ifBlock);
+        Value tracking = tti::createLoadScratchMemory(
+            fb, fb.getLoc(), trackingPtr, trackingType);
+        Value descriptor = createBufferDescriptor(fb, mbarOffset, lengthVal);
+        Value barriersEqBar =
+            createCmpIntTensorScalar(fb, barriers, descriptor);
+        barriersEqBar =
+            convertAndBroadcast(fb, barriersEqBar, {3}, trackingType);
+        Value currentCTAMask = createCTASetMask(fb, trackingType, /*dim=*/2,
+                                                createCurrentCTAMask(fb));
+        Value clearMask =
+            arith::AndIOp::create(fb, barriersEqBar, currentCTAMask);
+        Value zero =
+            tti::createConstIntTensor(fb, fb.getLoc(), 0, trackingType);
+        Value updated = arith::SelectOp::create(fb, clearMask, zero, tracking);
+        createMaskedStoreScratchMemory(fb, fb.getLoc(), trackingPtr, updated,
+                                       trackingType, currentCTAMask);
+
+        fb.setInsertionPointToEnd(thenBlock);
+        triton::ReturnOp::create(fb);
+      });
+}
+
+void FunctionBuilder::createVerifyProxyAccessCall(
+    ImplicitLocOpBuilder &b, Value buf, uint32_t length, int thread,
+    StringRef operandName, Value pred, Operation *insertPoint,
+    Value effectCTAs) {
+  auto &buffersMap = auxData.buffers[(int)MemType::SHARED_MEM];
+  auto &aliasesMap = auxData.aliasMatrices[(int)MemType::SHARED_MEM];
+  bool hasAliases = auxData.hasNonTrivialAliasing[(int)MemType::SHARED_MEM];
+  if (buffersMap.empty() || auxData.proxyAccessVisibility.empty() ||
+      (hasAliases && aliasesMap.empty()))
+    return;
+  if (!pred)
+    pred = arith::ConstantIntOp::create(b, 1, 1);
+  ValueType buffers = buffersMap.at(insertPoint);
+  ValueType visibility = auxData.proxyAccessVisibility.at(insertPoint);
+  auto buffersType = cast<RankedTensorType>(buffers.type);
+  auto visibilityType = cast<RankedTensorType>(visibility.type);
+  Value bufOffset = tti::ExperimentalMemDescToI32Op::create(b, buf);
+  Value lengthVal = arith::ConstantIntOp::create(b, length, 32);
+  Value threadVal = arith::ConstantIntOp::create(b, thread, 32);
+  std::string message =
+      "Async shared-memory access is missing fence_async_shared";
+  if (!operandName.empty())
+    message += ". Operand: " + operandName.str();
+  AssertInfo assertInfo{message, b.getI1Type()};
+  Type aliasMatrixTypeBase;
+  auto buildBody = [&visibilityType, &aliasMatrixTypeBase](bool useAliases) {
+    return [=](ImplicitLocOpBuilder &fb, Block *entryBlock) {
+      Value bufOffset = entryBlock->getArgument(0);
+      Value lengthVal = entryBlock->getArgument(1);
+      Value pred = entryBlock->getArgument(2);
+      Value threadVal = entryBlock->getArgument(3);
+      Value buffers = entryBlock->getArgument(4);
+      Value visibilityPtr = entryBlock->getArgument(5);
+      Value effectCTAs = entryBlock->getArgument(6);
+      Value aliasMatrix = useAliases ? entryBlock->getArgument(7) : Value();
+
+      Value visibility = tti::createLoadScratchMemory(
+          fb, fb.getLoc(), visibilityPtr, visibilityType);
+      Value descriptor = createBufferDescriptor(fb, bufOffset, lengthVal);
+      Value buffersEqBuf = createCmpIntTensorScalar(fb, buffers, descriptor);
+      if (useAliases) {
+        buffersEqBuf =
+            expandAliases(fb, buffersEqBuf, aliasMatrix,
+                          cast<RankedTensorType>(aliasMatrixTypeBase));
+      }
+      buffersEqBuf = convertAndBroadcast(fb, buffersEqBuf, {1}, visibilityType);
+      Value mask = arith::AndIOp::create(
+          fb, buffersEqBuf,
+          createCTASetMask(fb, visibilityType, /*dim=*/0, effectCTAs));
+      Value currentCTA = createCurrentCTAMask(fb);
+      mask = arith::AndIOp::create(
+          fb, mask,
+          createCTASetMask(fb, visibilityType, /*dim=*/2, currentCTA));
+      mask = arith::AndIOp::create(
+          fb, mask, createDimMask(fb, threadVal, visibilityType, /*dim=*/3));
+      Value zero =
+          tti::createConstIntTensor(fb, fb.getLoc(), 0, visibilityType);
+      Value selected = arith::SelectOp::create(fb, mask, visibility, zero);
+      Value seenMask = tti::createConstIntTensor(
+          fb, fb.getLoc(), ProxyAccessBits::seenMask, visibilityType);
+      Value seen = arith::AndIOp::create(fb, selected, seenMask);
+      Value shift = tti::createConstIntTensor(
+          fb, fb.getLoc(), ProxyAccessBits::fencedOffset, visibilityType);
+      Value fenced = arith::ShRUIOp::create(fb, selected, shift);
+      fenced = arith::AndIOp::create(fb, fenced, seenMask);
+      Value notFenced = arith::XOrIOp::create(fb, fenced, seenMask);
+      Value missing = arith::AndIOp::create(fb, seen, notFenced);
+      Value missingAny = reduceAll<arith::OrIOp>(fb, missing);
+      Value zeroScalar = arith::ConstantOp::create(
+          fb, missingAny.getType(), fb.getIntegerAttr(missingAny.getType(), 0));
+      Value ok = arith::CmpIOp::create(fb, arith::CmpIPredicate::eq, missingAny,
+                                       zeroScalar);
+      Value vTrue = arith::ConstantOp::create(
+          fb, ok.getType(), fb.getIntegerAttr(fb.getI1Type(), 1));
+      Value predicatedOk = arith::SelectOp::create(fb, pred, ok, vTrue);
+      triton::ReturnOp::create(fb, predicatedOk);
+    };
+  };
+
+  SmallVector<Value> args = {bufOffset, lengthVal,     pred,
+                             threadVal, buffers.value, visibility.value,
+                             effectCTAs};
+  if (hasAliases) {
+    ValueType aliases = aliasesMap.at(insertPoint);
+    aliasMatrixTypeBase = aliases.type;
+    auto aliasMatrixType = cast<RankedTensorType>(aliases.type);
+    args.push_back(aliases.value);
+    createCallToCachedFunction(b, "verify_proxy_access", args, assertInfo,
+                               {buffersType, visibilityType, aliasMatrixType},
+                               buildBody(true));
+  } else {
+    createCallToCachedFunction(b, "verify_proxy_access_noalias", args,
+                               assertInfo, {buffersType, visibilityType},
+                               buildBody(false));
+  }
+}
+
+void FunctionBuilder::createCopyProxyAccessesCall(ImplicitLocOpBuilder &b,
+                                                  int sourceThread,
+                                                  uint64_t destMask, Value pred,
+                                                  Operation *insertPoint) {
+  if (auxData.proxyAccessVisibility.empty())
+    return;
+  if (!pred)
+    pred = arith::ConstantIntOp::create(b, 1, 1);
+  ValueType visibility = auxData.proxyAccessVisibility.at(insertPoint);
+  auto visibilityType = cast<RankedTensorType>(visibility.type);
+  SmallVector<Value> args = {arith::ConstantIntOp::create(b, sourceThread, 32),
+                             pred, visibility.value};
+  createCallToCachedFunction(
+      b, "copy_proxy_accesses", args, /*assertInfo=*/std::nullopt,
+      {visibilityType, destMask},
+      [visibilityType, destMask](ImplicitLocOpBuilder &fb, Block *entryBlock) {
+        Value sourceThread = entryBlock->getArgument(0);
+        Value pred = entryBlock->getArgument(1);
+        Value visibilityPtr = entryBlock->getArgument(2);
+
+        auto [prevBlock, ifBlock, thenBlock] = createIfBlock(fb, pred);
+        fb.setInsertionPointToStart(ifBlock);
+        Value visibility = tti::createLoadScratchMemory(
+            fb, fb.getLoc(), visibilityPtr, visibilityType);
+        Value zero =
+            tti::createConstIntTensor(fb, fb.getLoc(), 0, visibilityType);
+        Value destColumns = createThreadColumnMask(
+            fb, arith::ConstantIntOp::create(fb, destMask, 64), visibilityType,
+            /*columnDim=*/3);
+        Value cleared =
+            arith::SelectOp::create(fb, destColumns, zero, visibility);
+        Value sourceColumn = arith::SelectOp::create(
+            fb, createDimMask(fb, sourceThread, visibilityType, /*dim=*/3),
+            visibility, zero);
+        sourceColumn = reduce<arith::OrIOp>(fb, sourceColumn, {3});
+        sourceColumn =
+            convertAndBroadcast(fb, sourceColumn, {0, 1, 2, 4}, visibilityType);
+        Value replicated =
+            arith::SelectOp::create(fb, destColumns, sourceColumn, zero);
+        Value updated = arith::OrIOp::create(fb, cleared, replicated);
+        Value currentCTAMask = createCTASetMask(fb, visibilityType, /*dim=*/2,
+                                                createCurrentCTAMask(fb));
+        createMaskedStoreScratchMemory(fb, fb.getLoc(), visibilityPtr, updated,
+                                       visibilityType, currentCTAMask);
+
+        fb.setInsertionPointToEnd(thenBlock);
+        triton::ReturnOp::create(fb);
+      });
+}
+
+void FunctionBuilder::createPublishClusterProxyAccessesCall(
+    ImplicitLocOpBuilder &b, Value pred, Operation *insertPoint) {
+  if (auxData.proxyAccessVisibility.empty())
+    return;
+  if (!pred)
+    pred = arith::ConstantIntOp::create(b, 1, 1);
+  ValueType visibility = auxData.proxyAccessVisibility.at(insertPoint);
+  auto visibilityType = cast<RankedTensorType>(visibility.type);
+  SmallVector<Value> args = {pred, visibility.value};
+  createCallToCachedFunction(
+      b, "publish_cluster_proxy_accesses", args,
+      /*assertInfo=*/std::nullopt, {visibilityType},
+      [visibilityType](ImplicitLocOpBuilder &fb, Block *entryBlock) {
+        Value pred = entryBlock->getArgument(0);
+        Value visibilityPtr = entryBlock->getArgument(1);
+
+        auto [prevBlock, ifBlock, thenBlock] = createIfBlock(fb, pred);
+        fb.setInsertionPointToStart(ifBlock);
+        Value visibility = tti::createLoadScratchMemory(
+            fb, fb.getLoc(), visibilityPtr, visibilityType);
+        Value frontier = reduce<arith::OrIOp>(fb, visibility, {2, 3});
+        frontier = convertAndBroadcast(fb, frontier, {0, 1, 4}, visibilityType);
+        Value updated = arith::OrIOp::create(fb, visibility, frontier);
+        tti::createStoreScratchMemory(fb, fb.getLoc(), visibilityPtr, updated,
+                                      visibilityType,
                                       /*currentCTAOnly=*/false);
 
         fb.setInsertionPointToEnd(thenBlock);

--- a/lib/Dialect/TritonInstrument/IR/Utility.cpp
+++ b/lib/Dialect/TritonInstrument/IR/Utility.cpp
@@ -535,6 +535,9 @@ LogicalResult AuxDataMap::populateAndPassToWarpSpecialize(
   getBuffersAndBarriers(module, bufRegions, barrierRegions);
   int numCTAs = lookupNumCTAs(module);
   threadLayout = getThreadLayout(module, hooks);
+  hasAsyncProxyFenceTracking = hooks &&
+                               hooks->needsAsyncProxyFenceTracking(module) &&
+                               !bufRegions[(int)MemType::SHARED_MEM].empty();
   int captureCounter = 0;
   int64_t captureBytes = 0;
 
@@ -600,6 +603,17 @@ LogicalResult AuxDataMap::populateAndPassToWarpSpecialize(
             64, fb));
     passValueToWarpSpecialize(readVisibility[iMemType].at(entryRegion),
                               readVisibility[iMemType]);
+
+    if (memType == MemType::SHARED_MEM && hasAsyncProxyFenceTracking) {
+      proxyAccessVisibility.insert(
+          entryRegion,
+          createZeroInitStateTensor(b,
+                                    {numCTAs, numBufs, numCTAs,
+                                     threadLayout.numBaseThreadSlots, numCTAs},
+                                    64, fb));
+      passValueToWarpSpecialize(proxyAccessVisibility.at(entryRegion),
+                                proxyAccessVisibility);
+    }
   }
 
   if (!barrierRegions.empty()) {
@@ -646,6 +660,16 @@ LogicalResult AuxDataMap::populateAndPassToWarpSpecialize(
         passValueToWarpSpecialize(readTracking[iMemType].at(entryRegion),
                                   readTracking[iMemType]);
       }
+    }
+    if (hasAsyncProxyFenceTracking &&
+        !bufRegions[(int)MemType::SHARED_MEM].empty()) {
+      int numBufs = bufRegions[(int)MemType::SHARED_MEM].size();
+      proxyAccessTracking.insert(
+          entryRegion,
+          createZeroInitStateTensor(
+              b, {numCTAs, numBufs, numCTAs, numBarriers, numCTAs}, 64, fb));
+      passValueToWarpSpecialize(proxyAccessTracking.at(entryRegion),
+                                proxyAccessTracking);
     }
   }
 
@@ -700,8 +724,9 @@ LogicalResult AuxDataMap::populateAndPassToWarpSpecialize(
     int numCommitKinds = 0;
     for (int i = 0; i < CommitKind::NumCommitKinds; ++i)
       numCommitKinds += !commits[i].empty();
-    int expected = estimateConSanCaptureCount(
-        numActiveMemTypes, !barrierRegions.empty(), numCommitKinds);
+    int expected =
+        estimateConSanCaptureCount(numActiveMemTypes, !barrierRegions.empty(),
+                                   numCommitKinds, hasAsyncProxyFenceTracking);
     assert(captureCounter == expected &&
            "capture count changed -- update estimateConSanCaptureCount if this "
            "is expected!");

--- a/lib/Dialect/TritonInstrument/Transforms/ConcurrencySanitizer.cpp
+++ b/lib/Dialect/TritonInstrument/Transforms/ConcurrencySanitizer.cpp
@@ -444,8 +444,14 @@ private:
       ImplicitLocOpBuilder b(op->getLoc(), op);
       b.setInsertionPointAfter(op);
       Value alloc = op->getResult(0);
-      if (canInitializeAllocation(alloc))
+      if (canInitializeAllocation(alloc)) {
         initializeAllocation(b, alloc);
+        auto allocType = cast<ttg::MemDescType>(alloc.getType());
+        bool isShared =
+            isa<ttg::SharedMemorySpaceAttr>(allocType.getMemorySpace());
+        if (isShared && auxData.hasAsyncProxyFenceTracking)
+          ttng::FenceAsyncSharedOp::create(b, /*bCluster=*/false);
+      }
     }
   }
 
@@ -479,14 +485,21 @@ private:
 
       instrumentMemEffects(b, op, thread, funcBuilder);
       b.setLoc(op->getLoc());
+      if (auto info = hooks->getAsyncProxyFenceInfo(op)) {
+        funcBuilder.createFenceProxyAccessesCall(
+            b, baseThread, info->cluster, hooks->getIssuerCTAPred(b, op), op);
+      }
       if (auto wsOp = dyn_cast<ttg::WarpSpecializeOp>(op)) {
         funcBuilder.createSetActiveMaskCall(b, getActiveMask(wsOp), op);
         auto partitionRegions = wsOp.getNonEmptyPartitionRegions();
         if (!partitionRegions.empty()) {
           uint64_t destMask = 0;
+          uint64_t baseDestMask = 0;
           for (Region *region : partitionRegions)
             destMask |= getThreadPeersMask(region->getRegionNumber() + 1,
                                            auxData.threadLayout);
+          for (Region *region : partitionRegions)
+            baseDestMask |= 1ULL << (region->getRegionNumber() + 1);
           if (destMask) {
             for (MemType memType : {MemType::SHARED_MEM, MemType::TENSOR_MEM}) {
               funcBuilder.createCopyWriteVisibilityCall(b, thread, destMask,
@@ -495,6 +508,9 @@ private:
                                                        nullptr, memType, op);
             }
           }
+          if (baseDestMask)
+            funcBuilder.createCopyProxyAccessesCall(b, baseThread, baseDestMask,
+                                                    nullptr, op);
         }
       }
       if (auto info = hooks->getBarrierInitInfo(op)) {
@@ -516,6 +532,8 @@ private:
           funcBuilder.createClearBarrierReadTrackingCall(b, barrier, pred,
                                                          memType, op);
         }
+        funcBuilder.createClearBarrierProxyAccessTrackingCall(b, barrier, pred,
+                                                              op);
       }
       if (auto asyncCommitGroupOp = dyn_cast<ttg::AsyncCommitGroupOp>(op)) {
         if (!auxData.commits[CommitKind::AsyncCp].empty())
@@ -568,6 +586,7 @@ private:
           for (MemType memType : {MemType::SHARED_MEM, MemType::TENSOR_MEM})
             funcBuilder.createPublishClusterVisibilityCall(b, isCTA0, memType,
                                                            op);
+          funcBuilder.createPublishClusterProxyAccessesCall(b, isCTA0, op);
           tti::ExperimentalLockReleaseOp::create(b, lock, isCTA0);
           auto publishBarrier = ttng::ClusterBarrierOp::create(b, b.getLoc());
           auxData.nonPublishingClusterBarriers.push_back(
@@ -627,6 +646,8 @@ private:
           wb, alloc, getThreadPeersMask(thread, auxData.threadLayout), pred,
           memType, op);
     }
+    funcBuilder.createTransferProxyAccessesCall(wb, alloc, baseThread, pred,
+                                                op);
     funcBuilder.createClearWaitingCall(wb, alloc, baseThread, pred, op);
     tti::ExperimentalLockReleaseOp::create(wb, lock, pred);
   }
@@ -648,6 +669,16 @@ private:
       MemType memType = MemType::TENSOR_MEM;
       if (isa<ttg::SharedEncodingTrait>(bufType.getEncoding())) {
         memType = MemType::SHARED_MEM;
+      }
+      if (memType == MemType::SHARED_MEM) {
+        if (effect.proxy == MemEffectsOpInfo::Effects::Proxy::Async) {
+          funcBuilder.createVerifyProxyAccessCall(
+              b, buf, effect.length, baseThread, effect.operandName, pred, op,
+              effectCTAs);
+        } else {
+          funcBuilder.createSetProxyAccessCall(
+              b, buf, effect.length, baseThread, pred, op, effectCTAs);
+        }
       }
       if (effect.rw == MemEffectsOpInfo::Effects::Read) {
         // For op that is reading, we only need to check if anything else
@@ -715,6 +746,8 @@ private:
           funcBuilder.createTrackVisibleReadsCall(
               b, barrier, thread, combinedPred, memType, op, recipientCTAs);
         }
+        funcBuilder.createTrackProxyAccessesCall(
+            b, barrier, baseThread, combinedPred, op, recipientCTAs);
       } else if (barrierInfo.trackingMode ==
                  MemEffectsOpInfo::BarrierTrackingMode::EffectWrites) {
         for (const auto &effect : opInfo->operandEffects) {

--- a/lib/Dialect/TritonInstrument/Transforms/PrepareConSanCaptures.cpp
+++ b/lib/Dialect/TritonInstrument/Transforms/PrepareConSanCaptures.cpp
@@ -96,9 +96,11 @@ public:
 
     int numActiveMemTypes = (hasSharedMemoryBuffers(mod) ? 1 : 0) +
                             (hasTensorMemoryBuffers(mod) ? 1 : 0);
-    int totalCaptures =
-        tti::estimateConSanCaptureCount(numActiveMemTypes, hasBarriers(mod),
-                                        getNumCommitKinds(mod, hooks.get()));
+    int totalCaptures = tti::estimateConSanCaptureCount(
+        numActiveMemTypes, hasBarriers(mod),
+        getNumCommitKinds(mod, hooks.get()),
+        hasSharedMemoryBuffers(mod) &&
+            hooks->needsAsyncProxyFenceTracking(mod));
     int extraBytes = totalCaptures * tti::kCaptureSizeBytes;
 
     auto i32Ty = IntegerType::get(mod.getContext(), 32);

--- a/lib/Dialect/TritonNvidiaGPU/Transforms/ConSanNVIDIA.cpp
+++ b/lib/Dialect/TritonNvidiaGPU/Transforms/ConSanNVIDIA.cpp
@@ -7,6 +7,7 @@ namespace ttg = mlir::triton::gpu;
 namespace ttng = mlir::triton::nvidia_gpu;
 namespace tti = mlir::triton::instrument;
 
+using tti::AsyncProxyFenceInfo;
 using tti::BarrierInitInfo;
 using tti::BarrierInvalidateInfo;
 using tti::BarrierWaitInfo;
@@ -80,6 +81,23 @@ public:
                         static_cast<int>(tmaStoreWaitOp.getPendings()),
                         /*transferWrites=*/false, /*transferReads=*/true};
     return std::nullopt;
+  }
+
+  std::optional<AsyncProxyFenceInfo>
+  getAsyncProxyFenceInfo(Operation *op) const override {
+    if (auto fence = dyn_cast<ttng::FenceAsyncSharedOp>(op))
+      return AsyncProxyFenceInfo{fence.getBCluster()};
+    return std::nullopt;
+  }
+
+  bool needsAsyncProxyFenceTracking(ModuleOp module) const override {
+    bool needed = false;
+    module.walk([&](Operation *op) {
+      needed |= isa<ttng::TMALoadLikeOpInterface, ttng::CLCTryCancelOp,
+                    ttng::WarpGroupDotOp, ttng::MMAv5OpInterface,
+                    ttng::TMEMCopyOp, ttng::TMAStoreLikeOpInterface>(op);
+    });
+    return needed;
   }
 
   Value getIssuerCTAPred(ImplicitLocOpBuilder &b,
@@ -157,8 +175,9 @@ public:
     if (auto copyOp = dyn_cast<ttng::TMEMCopyOp>(op)) {
       info.emplace();
       info->trackingKind = MemEffectsOpInfo::TrackingKind::Barrier;
-      info->operandEffects.emplace_back(MemEffectsOpInfo::Effects::Read,
-                                        copyOp.getSrc(), "Src");
+      info->operandEffects.emplace_back(
+          MemEffectsOpInfo::Effects::Read, copyOp.getSrc(), "Src",
+          MemEffectsOpInfo::Effects::Proxy::Async);
       info->operandEffects.emplace_back(MemEffectsOpInfo::Effects::Write,
                                         copyOp.getDst(), "Dst");
     }
@@ -171,17 +190,21 @@ public:
                      mmav5Op.getCompletionBarrierPreds())) {
         info->barriers.push_back({barrier, barrierPred, 1});
       }
-      info->operandEffects.emplace_back(MemEffectsOpInfo::Effects::Read,
-                                        mmav5Op.getA(), "A");
-      info->operandEffects.emplace_back(MemEffectsOpInfo::Effects::Read,
-                                        mmav5Op.getB(), "B");
+      info->operandEffects.emplace_back(
+          MemEffectsOpInfo::Effects::Read, mmav5Op.getA(), "A",
+          MemEffectsOpInfo::Effects::Proxy::Async);
+      info->operandEffects.emplace_back(
+          MemEffectsOpInfo::Effects::Read, mmav5Op.getB(), "B",
+          MemEffectsOpInfo::Effects::Proxy::Async);
       info->operandEffects.emplace_back(MemEffectsOpInfo::Effects::Write,
                                         mmav5Op.getAccumulator(), "Acc");
       if (auto mmaScaledOp = dyn_cast<ttng::TCGen5MMAScaledOp>(op)) {
-        info->operandEffects.emplace_back(MemEffectsOpInfo::Effects::Read,
-                                          mmaScaledOp.getAScale(), "AScale");
-        info->operandEffects.emplace_back(MemEffectsOpInfo::Effects::Read,
-                                          mmaScaledOp.getBScale(), "BScale");
+        info->operandEffects.emplace_back(
+            MemEffectsOpInfo::Effects::Read, mmaScaledOp.getAScale(), "AScale",
+            MemEffectsOpInfo::Effects::Proxy::Async);
+        info->operandEffects.emplace_back(
+            MemEffectsOpInfo::Effects::Read, mmaScaledOp.getBScale(), "BScale",
+            MemEffectsOpInfo::Effects::Proxy::Async);
       }
     }
     if (auto commitOp = dyn_cast<ttng::TCGen5CommitOp>(op)) {
@@ -191,22 +214,24 @@ public:
       info->barriers.push_back({commitOp.getBarrier(), nullptr, 1});
     }
     if (auto wgmmaOp = dyn_cast<ttng::WarpGroupDotOp>(op)) {
+      info.emplace();
       if (wgmmaOp.getIsAsync() == true) {
-        info.emplace();
         info->trackingKind = MemEffectsOpInfo::TrackingKind::CommitCount;
         info->commitKind = tti::CommitKind::Wgmma;
         info->implicitCommit = true;
         info->barriers = {};
-        if (isa<ttg::SharedEncodingTrait>(
-                wgmmaOp.getA().getType().getEncoding())) {
-          info->operandEffects.emplace_back(MemEffectsOpInfo::Effects::Read,
-                                            wgmmaOp.getA(), "A");
-        }
-        if (isa<ttg::SharedEncodingTrait>(
-                wgmmaOp.getB().getType().getEncoding())) {
-          info->operandEffects.emplace_back(MemEffectsOpInfo::Effects::Read,
-                                            wgmmaOp.getB(), "B");
-        }
+      }
+      if (isa<ttg::SharedEncodingTrait>(
+              wgmmaOp.getA().getType().getEncoding())) {
+        info->operandEffects.emplace_back(
+            MemEffectsOpInfo::Effects::Read, wgmmaOp.getA(), "A",
+            MemEffectsOpInfo::Effects::Proxy::Async);
+      }
+      if (isa<ttg::SharedEncodingTrait>(
+              wgmmaOp.getB().getType().getEncoding())) {
+        info->operandEffects.emplace_back(
+            MemEffectsOpInfo::Effects::Read, wgmmaOp.getB(), "B",
+            MemEffectsOpInfo::Effects::Proxy::Async);
       }
     }
     if (auto loadOp = dyn_cast<ttng::TMALoadLikeOpInterface>(op)) {
@@ -227,8 +252,9 @@ public:
           {loadOp.getBarrier(), nullptr, /*count=*/0,
            MemEffectsOpInfo::BarrierTrackingMode::EffectWrites,
            /*txCount=*/-txCount});
-      info->operandEffects.emplace_back(MemEffectsOpInfo::Effects::Write,
-                                        loadOp.getResult());
+      info->operandEffects.emplace_back(
+          MemEffectsOpInfo::Effects::Write, loadOp.getResult(), "",
+          MemEffectsOpInfo::Effects::Proxy::Async);
     }
     if (auto storeOp = dyn_cast<ttng::AsyncSharedStoreOp>(op)) {
       info.emplace();
@@ -249,8 +275,9 @@ public:
            MemEffectsOpInfo::BarrierTrackingMode::EffectWrites,
            /*txCount=*/
            -static_cast<int>(tti::getMemDescLength(tryCancelOp.getResult()))});
-      info->operandEffects.emplace_back(MemEffectsOpInfo::Effects::Write,
-                                        tryCancelOp.getResult());
+      info->operandEffects.emplace_back(
+          MemEffectsOpInfo::Effects::Write, tryCancelOp.getResult(), "",
+          MemEffectsOpInfo::Effects::Proxy::Async);
     }
     if (auto loadResultOp = dyn_cast<ttng::CLCLoadResultOp>(op)) {
       info.emplace();
@@ -263,8 +290,9 @@ public:
       info->trackingKind = MemEffectsOpInfo::TrackingKind::CommitCount;
       info->commitKind = tti::CommitKind::TmaStore;
       info->implicitCommit = true;
-      info->operandEffects.emplace_back(MemEffectsOpInfo::Effects::Read,
-                                        storeOp.getSrc());
+      info->operandEffects.emplace_back(
+          MemEffectsOpInfo::Effects::Read, storeOp.getSrc(), "",
+          MemEffectsOpInfo::Effects::Proxy::Async);
     }
     if (auto arriveOp = dyn_cast<ttng::ArriveBarrierOp>(op)) {
       info.emplace();

--- a/python/test/gluon/test_consan.py
+++ b/python/test/gluon/test_consan.py
@@ -741,6 +741,7 @@ def test_tma_interleave_kernel(FAILURE, device, run_wrapper, monkeypatch, num_ct
         mbarrier.invalidate(bar.index(0))
         mbarrier.invalidate(bar.index(1))
 
+        hopper.fence_async_shared()
         tma.async_copy_shared_to_global(input_desc, [0, 0], smem.index(0))
         tma.store_wait(0)
 

--- a/python/test/gluon/test_consan.py
+++ b/python/test/gluon/test_consan.py
@@ -461,6 +461,7 @@ def test_clc_result_reuse_after_cluster_barrier(device, run_wrapper, monkeypatch
         mbarrier.wait(clc_bar, 0)
         first = clc.load_result(clc_result)
         ttgl.barrier(cluster=True)
+        hopper.fence_async_shared(cluster=True)
 
         mbarrier.expect(clc_bar, 16)
         clc.try_cancel(clc_result, clc_bar)
@@ -1751,6 +1752,67 @@ def test_ws_store_wait_load(FAILURE, device, run_wrapper, monkeypatch, num_ctas)
 
     output = torch.empty((XBLOCK.value * num_ctas, ), device=device, dtype=torch.float16)
     ws_kernel[(1, )](output, FAILURE=FAILURE, num_warps=4, num_ctas=num_ctas)
+
+
+@pytest.mark.skipif(not is_cuda() or torch.cuda.get_device_capability()[0] < 9, reason="Requires hopper")
+@pytest.mark.parametrize("FENCE_LOCATION", ["none", "producer_after_arrive", "producer", "consumer"])
+def test_fence_async_shared_across_warp_specialize(FENCE_LOCATION, device, run_wrapper, monkeypatch, num_ctas):
+    if run_wrapper:
+        result = run_in_process(test_fence_async_shared_across_warp_specialize,
+                                (FENCE_LOCATION, device, False, monkeypatch, num_ctas))
+        if FENCE_LOCATION in ("none", "producer_after_arrive"):
+            assert_expected_cuda_failure(result.exc)
+            assert "Async shared-memory access is missing fence_async_shared" in result.driver_stderr_output
+        else:
+            assert result.exc is None
+            assert result.driver_stderr_output == ""
+        return
+
+    monkeypatch.setenv("TRITON_INSTRUMENTATION_MODE", "consan")
+    monkeypatch.setenv("CUDA_LAUNCH_BLOCKING", "1")
+    knobs.refresh_knobs()
+
+    @gluon.jit
+    def producer(smem: ttgl.constexpr, bar: ttgl.constexpr, FENCE_LOCATION: ttgl.constexpr, layout: ttgl.constexpr):
+        block_m: ttgl.constexpr = XBLOCK * ttgl.num_ctas()
+        smem.store(ttgl.full([block_m, XBLOCK], 42.0, ttgl.float16, layout))
+        if FENCE_LOCATION == "producer":
+            hopper.fence_async_shared()
+        mbarrier.arrive(bar, count=1)
+        if FENCE_LOCATION == "producer_after_arrive":
+            hopper.fence_async_shared()
+
+    @gluon.jit
+    def consumer(output_desc, smem: ttgl.constexpr, bar: ttgl.constexpr, FENCE_LOCATION: ttgl.constexpr):
+        mbarrier.wait(bar, phase=0)
+        if FENCE_LOCATION == "consumer":
+            hopper.fence_async_shared()
+        tma.async_copy_shared_to_global(output_desc, [0, 0], smem)
+        tma.store_wait(0)
+
+    @gluon.jit
+    def kernel(output_desc, FENCE_LOCATION: ttgl.constexpr):
+        block_m: ttgl.constexpr = XBLOCK * ttgl.num_ctas()
+        cga_layout: ttgl.constexpr = default_cga_layout(ttgl.num_ctas(), 2)
+        smem_layout: ttgl.constexpr = ttgl.NVMMASharedLayout(swizzle_byte_width=128, element_bitwidth=16, rank=2,
+                                                             cga_layout=cga_layout)
+        blocked_layout: ttgl.constexpr = ttgl.BlockedLayout(size_per_thread=[1, XBLOCK], threads_per_warp=[32, 1],
+                                                            warps_per_cta=[4, 1], order=[0, 1], cga_layout=cga_layout)
+        smem = ttgl.allocate_shared_memory(ttgl.float16, [block_m, XBLOCK], smem_layout)
+        bar = mbarrier.allocate_mbarrier()
+        mbarrier.init(bar, count=1)
+        ttgl.warp_specialize([
+            (producer, (smem, bar, FENCE_LOCATION, blocked_layout)),
+            (consumer, (output_desc, smem, bar, FENCE_LOCATION)),
+        ], [4], [32])
+
+    block_m = XBLOCK.value * num_ctas
+    output = torch.empty((block_m, XBLOCK.value), device=device, dtype=torch.float16)
+    shared_layout = ttgl.NVMMASharedLayout(swizzle_byte_width=128, element_bitwidth=16, rank=2,
+                                           cga_layout=default_cga_layout(num_ctas, 2))
+    output_desc = gluon.nvidia.hopper.TensorDescriptor.from_tensor(output, [block_m, XBLOCK.value], shared_layout)
+    kernel[(1, )](output_desc, FENCE_LOCATION=FENCE_LOCATION, num_warps=4, num_ctas=num_ctas)
+    torch.testing.assert_close(output, torch.full_like(output, 42.0))
 
 
 @pytest.mark.skipif(not is_cuda() or torch.cuda.get_device_capability()[0] < 9, reason="Requires hopper")

--- a/test/TritonGPU/consan.mlir
+++ b/test/TritonGPU/consan.mlir
@@ -63,6 +63,57 @@ module attributes {"ttg.num-ctas" = 2 : i32, "ttg.num-warps" = 1 : i32, ttg.shar
 
 // -----
 
+#proxy_shared = #ttg.nvmma_shared<{swizzlingByteWidth = 128, transposed = false, elementBitWidth = 32}>
+#proxy_bar_shared = #ttg.swizzled_shared<{vec = 1, perPhase = 1, maxPhase = 1, order = [0]}>
+#proxy_smem = #ttg.shared_memory
+#proxy_blocked = #ttg.blocked<{sizePerThread = [1, 32], threadsPerWarp = [32, 1], warpsPerCTA = [1, 1], order = [0, 1]}>
+module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 1 : i32, ttg.shared = 4104 : i32, ttg.target = "cuda:90", ttg.tensor_memory_size = 0 : i32, "ttg.threads-per-warp" = 32 : i32, "ttg.total-num-warps" = 1 : i32} {
+  // CHECK-LABEL: @proxy_fence_state_transitions
+  tt.func public @proxy_fence_state_transitions(%out: !tt.tensordesc<32x32xf32, #proxy_shared>) {
+    %c0 = arith.constant 0 : i32
+    %true = arith.constant true
+    %buf = ttg.local_alloc {allocation.offset = 0 : i32} : () -> !ttg.memdesc<32x32xf32, #proxy_shared, #proxy_smem, mutable>
+    %bar = ttg.local_alloc {allocation.offset = 4096 : i32} : () -> !ttg.memdesc<1xi64, #proxy_bar_shared, #proxy_smem, mutable>
+    ttng.init_barrier %bar, 1 : !ttg.memdesc<1xi64, #proxy_bar_shared, #proxy_smem, mutable>
+
+    // CHECK: tt.call @__triton_consan_set_proxy_access
+    %value = ttg.local_load %buf : !ttg.memdesc<32x32xf32, #proxy_shared, #proxy_smem, mutable> -> tensor<32x32xf32, #proxy_blocked>
+    // CHECK: tt.call @__triton_consan_track_proxy_accesses
+    ttng.arrive_barrier %bar, 1, %true : !ttg.memdesc<1xi64, #proxy_bar_shared, #proxy_smem, mutable>
+    // CHECK: ttng.wait_barrier
+    // CHECK: tt.call @__triton_consan_transfer_proxy_accesses
+    ttng.wait_barrier %bar, %c0, %true : !ttg.memdesc<1xi64, #proxy_bar_shared, #proxy_smem, mutable>
+    // CHECK: tt.call @__triton_consan_fence_proxy_accesses
+    ttng.fence_async_shared {bCluster = false}
+    // CHECK: tt.call @__triton_consan_verify_proxy_access
+    ttng.async_tma_copy_local_to_global %out[%c0, %c0] %buf : !tt.tensordesc<32x32xf32, #proxy_shared>, !ttg.memdesc<32x32xf32, #proxy_shared, #proxy_smem, mutable>
+    tt.return
+  }
+}
+
+// -----
+
+#proxy_cp_shared = #ttg.nvmma_shared<{swizzlingByteWidth = 128, transposed = false, elementBitWidth = 32}>
+#proxy_cp_smem = #ttg.shared_memory
+#proxy_cp_blocked = #ttg.blocked<{sizePerThread = [1, 128], threadsPerWarp = [32, 1], warpsPerCTA = [1, 4], order = [0, 1]}>
+#proxy_cp_mma = #ttg.nvidia_mma<{versionMajor = 3, versionMinor = 0, warpsPerCTA = [4, 1], instrShape = [16, 32, 16]}>
+module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.shared = 65536 : i32, ttg.target = "cuda:90", ttg.tensor_memory_size = 0 : i32, "ttg.threads-per-warp" = 32 : i32, "ttg.total-num-warps" = 4 : i32} {
+  // CHECK-LABEL: @proxy_fence_tracks_cp_async_and_wgmma
+  tt.func public @proxy_fence_tracks_cp_async_and_wgmma(%ptr: tensor<128x128x!tt.ptr<f16>, #proxy_cp_blocked>, %acc: tensor<128x128xf16, #proxy_cp_mma>) {
+    %buf = ttg.local_alloc {allocation.offset = 0 : i32} : () -> !ttg.memdesc<128x128xf16, #proxy_cp_shared, #proxy_cp_smem, mutable>
+    // CHECK: tt.call @__triton_consan_set_proxy_access
+    ttg.async_copy_global_to_local %ptr, %buf : tensor<128x128x!tt.ptr<f16>, #proxy_cp_blocked> -> <128x128xf16, #proxy_cp_shared, #proxy_cp_smem, mutable>
+    ttg.async_commit_group
+    ttg.async_wait {num = 0 : i32}
+    // CHECK: tt.call @__triton_consan_verify_proxy_access
+    // CHECK: tt.call @__triton_consan_verify_proxy_access
+    ttng.warp_group_dot %buf, %buf, %acc : !ttg.memdesc<128x128xf16, #proxy_cp_shared, #proxy_cp_smem, mutable> * !ttg.memdesc<128x128xf16, #proxy_cp_shared, #proxy_cp_smem, mutable> -> tensor<128x128xf16, #proxy_cp_mma>
+    tt.return
+  }
+}
+
+// -----
+
 #shared = #ttg.nvmma_shared<{swizzlingByteWidth = 128, transposed = false, elementBitWidth = 32}>
 #shared1 = #ttg.swizzled_shared<{vec = 1, perPhase = 1, maxPhase = 1, order = [0]}>
 #smem = #ttg.shared_memory
@@ -728,7 +779,7 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 1 : i32, ttg.shar
     // CHECK-DAG: %[[SM_READ_VISIBILITY_GLOB:.*]] = ttg.global_scratch_alloc {alignment = 16 : i32, nbytes = 32 : i32, shared_cluster_state, third_party_allocation, tt.divisibility = 16 : i64} : !tt.ptr<i64>
     // CHECK-DAG: %[[TM_BUFS:.*]] = tti.experimental_buffer_descriptors [0], [{{.*}}], tensor_mem : tensor<1xi64
     // CHECK-DAG: %[[TM_WRITE_VISIBILITY_GLOB:.*]] = ttg.global_scratch_alloc {alignment = 16 : i32, nbytes = 8 : i32, shared_cluster_state, third_party_allocation, tt.divisibility = 16 : i64} : !tt.ptr<i64>
-    // CHECK-DAG: %[[TM_READ_VISIBILITY_GLOB:.*]] = ttg.global_scratch_alloc {alignment = 16 : i32, nbytes = 16 : i32, shared_cluster_state, third_party_allocation, tt.divisibility = 16 : i64} : !tt.ptr<i64>
+    // CHECK-DAG: tt.call @__triton_consan_fill_global_tensor{{.*}}T1x1x1x2x1xI64(%[[TM_READ_VISIBILITY_GLOB:[^,]+]],
     // CHECK-DAG: %[[BARRIERS:.*]] = tti.experimental_buffer_descriptors [65536], [{{.*}}], shared_mem : tensor<1xi64
 
     // CHECK-DAG: %[[SM_WRITE_TRACKING_GLOB:.*]] = ttg.global_scratch_alloc {alignment = 16 : i32, nbytes = 2 : i32, shared_cluster_state, third_party_allocation, tt.divisibility = 16 : i64} : !tt.ptr<i8>


### PR DESCRIPTION
Model the synchronization between shared memory proxies by introducing 2-bit per-buffer accounting: 1 bit for `accessed` and 1 bit for `fenced`. Frontier state is being tracked by the barriers the same way the read/write visibility is tracked in consan, allowing us to determine if async access is legal even across the warp specialized partitions.
The model purposefully require any async-proxy access following a generic-proxy access to be fenced, even if both accesses are reads. This is overly conservative and may require over-synchronization on the kernel level, but allows us to keep the implementation leaner.
The opposite direction - access via async-proxy followed by generic-proxy is not being checked, as using async-proxy results require explicit wait, and for all relevant accesses ptx spec claims that after such wait no fence is required. Missing wait will be caught by existing consan instrumentation.