### PR TITLE
[AMD] Compensate split soffset in masked buffer OOB sentinel

### DIFF
--- a/test/Conversion/amd/buffer_load_store.mlir
+++ b/test/Conversion/amd/buffer_load_store.mlir
@@ -48,9 +48,13 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 1 : i32} {
         %n = tt.splat %N: i32 -> tensor<128xi32, #blocked0>
         %mask = arith.cmpi slt, %range, %n: tensor<128xi32, #blocked0>
         // CHECK: %[[oob:.*]] = llvm.mlir.constant({{-?2147483648}} : i32) : i32
-        // CHECK: %[[soffset:.*]] = llvm.mul
-        // CHECK-NOT: llvm.sub {{.*}}, %[[soffset]] : i32
-        // CHECK: %[[masked_offset:.*]] = llvm.select {{.*}}, {{.*}}, %[[oob]] : i1, i32
+        // CHECK: %[[split_soffset:.*]] = llvm.mul
+        // CHECK: %[[nonneg_soffset:.*]] = llvm.icmp "sge" %[[split_soffset]], {{.*}} : i32
+        // CHECK: %[[soffset:.*]] = llvm.select %[[nonneg_soffset]], %[[split_soffset]], {{.*}} : i1, i32
+        // CHECK: %[[high_oob:.*]] = llvm.mlir.constant(-1 : i32) : i32
+        // CHECK: %[[split_masked_oob:.*]] = llvm.sub %[[high_oob]], %[[split_soffset]] : i32
+        // CHECK: %[[masked_oob:.*]] = llvm.select %[[nonneg_soffset]], %[[split_masked_oob]], %[[oob]] : i1, i32
+        // CHECK: %[[masked_offset:.*]] = llvm.select {{.*}}, {{.*}}, %[[masked_oob]] : i1, i32
         // CHECK: rocdl.raw.ptr.buffer.load {{.*}}, %[[masked_offset]], %[[soffset]]
         %ret = amdg.buffer_load %arg0[%offset], %mask {amdgpu.split_soffset_safe} : tensor<128xf32, #blocked0>
         tt.return
@@ -131,9 +135,13 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 1 : i32} {
         %n = tt.splat %N: i32 -> tensor<128xi32, #blocked0>
         %mask = arith.cmpi slt, %range, %n: tensor<128xi32, #blocked0>
         // CHECK: %[[oob:.*]] = llvm.mlir.constant({{-?2147483648}} : i32) : i32
-        // CHECK: %[[soffset:.*]] = llvm.mul
-        // CHECK-NOT: llvm.sub {{.*}}, %[[soffset]] : i32
-        // CHECK: %[[masked_offset:.*]] = llvm.select {{.*}}, {{.*}}, %[[oob]] : i1, i32
+        // CHECK: %[[split_soffset:.*]] = llvm.mul
+        // CHECK: %[[nonneg_soffset:.*]] = llvm.icmp "sge" %[[split_soffset]], {{.*}} : i32
+        // CHECK: %[[soffset:.*]] = llvm.select %[[nonneg_soffset]], %[[split_soffset]], {{.*}} : i1, i32
+        // CHECK: %[[high_oob:.*]] = llvm.mlir.constant(-1 : i32) : i32
+        // CHECK: %[[split_masked_oob:.*]] = llvm.sub %[[high_oob]], %[[split_soffset]] : i32
+        // CHECK: %[[masked_oob:.*]] = llvm.select %[[nonneg_soffset]], %[[split_masked_oob]], %[[oob]] : i1, i32
+        // CHECK: %[[masked_offset:.*]] = llvm.select {{.*}}, {{.*}}, %[[masked_oob]] : i1, i32
         // CHECK: rocdl.raw.ptr.buffer.store {{.*}}, {{.*}}, %[[masked_offset]], %[[soffset]]
         amdg.buffer_store %value, %arg0[%offset], %mask {amdgpu.split_soffset_safe} : tensor<128xf32, #blocked0>
         tt.return

--- a/third_party/amd/lib/TritonAMDGPUToLLVM/BufferOpsEmitter.cpp
+++ b/third_party/amd/lib/TritonAMDGPUToLLVM/BufferOpsEmitter.cpp
@@ -301,6 +301,7 @@ void BufferEmitter::fillCommonArgs(Type type, Value rsrcDesc,
   Value elemByteWidthVal = b.int_val(32, elementByteWidth);
   Value vOffsetElemsForIntrinsic = vOffsetElems;
   Value sgprOffsetBytes = b.int_val(32, 0);
+  Value maskedOutOfBoundsBytes = vOffsetOutOfBounds;
   // Gate the split on the TTGIR-level safety annotation. Without it, AMD
   // raw buffer ops would OOB-drop any lane whose voffset (sans soffset)
   // wraps negative.
@@ -308,14 +309,25 @@ void BufferEmitter::fillCommonArgs(Type type, Value rsrcDesc,
     auto [uniformOffsetElems, perLaneOffsetElems] =
         splitUniformAdditive(vOffsetElems, rewriter, loc, uniformitySolver);
     if (uniformOffsetElems) {
-      sgprOffsetBytes = b.mul(elemByteWidthVal, uniformOffsetElems);
-      vOffsetElemsForIntrinsic = perLaneOffsetElems;
+      Value splitSgprOffsetBytes = b.mul(elemByteWidthVal, uniformOffsetElems);
+      Value nonNegSoffset = b.icmp_sge(splitSgprOffsetBytes, b.i32_val(0));
+      sgprOffsetBytes = b.select(nonNegSoffset, splitSgprOffsetBytes,
+                                 b.i32_val(0));
+      vOffsetElemsForIntrinsic = b.select(nonNegSoffset, perLaneOffsetElems,
+                                          vOffsetElems);
+      // AMD raw buffer ops bounds-check voffset only, then add soffset.
+      // For non-negative split-safe soffsets, choose a high OOB voffset that
+      // remains OOB after subtraction. Negative soffsets fall back to no split.
+      Value splitMaskedOutOfBoundsBytes =
+          b.sub(b.i32_val(-1), splitSgprOffsetBytes);
+      maskedOutOfBoundsBytes = b.select(
+          nonNegSoffset, splitMaskedOutOfBoundsBytes, vOffsetOutOfBounds);
     }
   }
   Value vOffsetBytes = b.mul(elemByteWidthVal, vOffsetElemsForIntrinsic);
 
-  // Masked lanes use OOB voffset; AMD buffer bounds checks ignore soffset.
-  Value maskedOffsetBytes = b.select(pred, vOffsetBytes, vOffsetOutOfBounds);
+  // Masked lanes use an OOB voffset adjusted for any lifted non-negative soffset.
+  Value maskedOffsetBytes = b.select(pred, vOffsetBytes, maskedOutOfBoundsBytes);
 
   int32_t aux =
       getCtrlBitsForCacheModifierOnTarget(cm, isBufferLoad, targetInfo);

--- a/third_party/amd/lib/TritonAMDGPUToLLVM/BufferOpsEmitter.cpp
+++ b/third_party/amd/lib/TritonAMDGPUToLLVM/BufferOpsEmitter.cpp
@@ -311,10 +311,10 @@ void BufferEmitter::fillCommonArgs(Type type, Value rsrcDesc,
     if (uniformOffsetElems) {
       Value splitSgprOffsetBytes = b.mul(elemByteWidthVal, uniformOffsetElems);
       Value nonNegSoffset = b.icmp_sge(splitSgprOffsetBytes, b.i32_val(0));
-      sgprOffsetBytes = b.select(nonNegSoffset, splitSgprOffsetBytes,
-                                 b.i32_val(0));
-      vOffsetElemsForIntrinsic = b.select(nonNegSoffset, perLaneOffsetElems,
-                                          vOffsetElems);
+      sgprOffsetBytes =
+          b.select(nonNegSoffset, splitSgprOffsetBytes, b.i32_val(0));
+      vOffsetElemsForIntrinsic =
+          b.select(nonNegSoffset, perLaneOffsetElems, vOffsetElems);
       // AMD raw buffer ops bounds-check voffset only, then add soffset.
       // For non-negative split-safe soffsets, choose a high OOB voffset that
       // remains OOB after subtraction. Negative soffsets fall back to no split.
@@ -326,8 +326,10 @@ void BufferEmitter::fillCommonArgs(Type type, Value rsrcDesc,
   }
   Value vOffsetBytes = b.mul(elemByteWidthVal, vOffsetElemsForIntrinsic);
 
-  // Masked lanes use an OOB voffset adjusted for any lifted non-negative soffset.
-  Value maskedOffsetBytes = b.select(pred, vOffsetBytes, maskedOutOfBoundsBytes);
+  // Masked lanes use an OOB voffset adjusted for any lifted non-negative
+  // soffset.
+  Value maskedOffsetBytes =
+      b.select(pred, vOffsetBytes, maskedOutOfBoundsBytes);
 
   int32_t aux =
       getCtrlBitsForCacheModifierOnTarget(cm, isBufferLoad, targetInfo);


### PR DESCRIPTION
#10362 lifts a uniform offset into scalar `soffset`. For masked buffer ops this miscompiles: masked lanes are dropped via an OOB `voffset` sentinel, but the unconditional `soffset` can carry the address back in range (32-bit wrap), so the lane reads real data instead of `other`. This issue was brought up in #10654 .

Fix: for a non-negative split `soffset`, set the masked sentinel to `-1 - soffset` so the combined offset pins to `0xFFFFFFFF` and stays OOB. Negative `soffset` falls back to no split; unmasked ops are unaffected.

Tested on gfx942: `test_dont_inplace_disjoint_accesses` goes from ~9.5% mismatch to passing. Lit updated for the masked sentinel.

<!---
The core Triton is a small number of people, and we receive many PRs (thank
you!).  To help us review your code more quickly, **if you are a new
contributor (less than 3 PRs merged) we ask that you complete the following
tasks and include the filled-out checklist in your PR description.**

Complete the following tasks before sending your PR, and replace `[ ]` with
`[x]` to indicate you have done them.
-->

# New contributor declaration
- [x] I am not making a trivial change, such as fixing a typo in a comment.

- [x] I have written a PR description following these
  [rules](https://cbea.ms/git-commit/#why-not-how).

- [x] I have run `pre-commit run --from-ref origin/main --to-ref HEAD`.

- Select one of the following.
  - [x] I have added tests.
    - `/test` for `lit` tests
    - `/unittest` for C++ tests
    - `/python/test` for end-to-end tests
  - [ ] This PR does not need a test because `FILL THIS IN`.

- Select one of the following.
  - [ ] I have not added any `lit` tests.
  - [x] The `lit` tests I have added follow these [best practices](https://mlir.llvm.org/getting_started/TestingGuide/#filecheck-best-practices),
    including the "tests should be minimal" section. (Usually running Python code
    and using the instructions it generates is not minimal.)
