### PR TITLE
[BACKEND][MEMBAR] Avoid redundant CTA barriers for back-to-back memory waits

### DIFF
--- a/lib/Analysis/Membar.cpp
+++ b/lib/Analysis/Membar.cpp
@@ -288,7 +288,8 @@ void MembarAnalysis::update(Operation *op, BlockInfo *blockInfo,
 
   if (op->hasTrait<mlir::OpTrait::MemWaitOpTrait>()) {
     // If the current op is an async wait and there is no later sync point
-    // before memory is accessed, insert a barrier op and sync.
+    // before memory is accessed, insert a barrier op and sync. This avoids
+    // redundant barriers by deffering the barrier to the later sync point.
     if (hasSyncPointBeforeMemoryEffect(op))
       return;
 

--- a/lib/Analysis/Membar.cpp
+++ b/lib/Analysis/Membar.cpp
@@ -264,6 +264,20 @@ bool containsLocalBarrier(Operation *op) {
   return false;
 }
 
+// Returns true if the same block has a later wait or local barrier before any
+// memory effect or nested control flow.
+static bool hasSyncPointBeforeMemoryEffect(Operation *op) {
+  for (Operation *next = op->getNextNode(); next; next = next->getNextNode()) {
+    if (containsLocalBarrier(next) ||
+        next->hasTrait<mlir::OpTrait::MemWaitOpTrait>())
+      return true;
+
+    if (isa<RegionBranchOpInterface>(next) || !isMemoryEffectFree(next))
+      return false;
+  }
+  return false;
+}
+
 void MembarAnalysis::update(Operation *op, BlockInfo *blockInfo,
                             FuncBlockInfoMapT *funcBlockInfoMap,
                             OpBuilder *builder) {
@@ -272,10 +286,12 @@ void MembarAnalysis::update(Operation *op, BlockInfo *blockInfo,
     blockInfo->sync();
   }
 
-  if (op->hasTrait<mlir::OpTrait::MemWaitOpTrait>() &&
-      !containsLocalBarrier(op->getNextNode())) {
-    // If the current op is an async wait and the next op is not a barrier we
-    // insert a barrier op and sync
+  if (op->hasTrait<mlir::OpTrait::MemWaitOpTrait>()) {
+    // If the current op is an async wait and there is no later sync point
+    // before memory is accessed, insert a barrier op and sync.
+    if (hasSyncPointBeforeMemoryEffect(op))
+      return;
+
     builder->setInsertionPointAfter(op);
     insertBarrier(op, builder);
     blockInfo->sync();

--- a/lib/Analysis/Membar.cpp
+++ b/lib/Analysis/Membar.cpp
@@ -286,13 +286,11 @@ void MembarAnalysis::update(Operation *op, BlockInfo *blockInfo,
     blockInfo->sync();
   }
 
-  if (op->hasTrait<mlir::OpTrait::MemWaitOpTrait>()) {
-    // If the current op is an async wait and there is no later sync point
-    // before memory is accessed, insert a barrier op and sync. This avoids
-    // redundant barriers by deffering the barrier to the later sync point.
-    if (hasSyncPointBeforeMemoryEffect(op))
-      return;
-
+  // If the current op is an (async) memory wait and there is no later sync
+  // point before memory is accessed, insert a barrier op and sync. This avoids
+  // redundant barriers by deferring the barrier to the later sync point.
+  if (op->hasTrait<mlir::OpTrait::MemWaitOpTrait>() &&
+      !hasSyncPointBeforeMemoryEffect(op)) {
     builder->setInsertionPointAfter(op);
     insertBarrier(op, builder);
     blockInfo->sync();

--- a/test/Analysis/test-membar.mlir
+++ b/test/Analysis/test-membar.mlir
@@ -115,6 +115,102 @@ tt.func @async_wait(%arg: tensor<32x16xf16, #AL>) {
   tt.return
 }
 
+// CHECK-LABEL: async_wait_back_to_back
+tt.func @async_wait_back_to_back(%arg: tensor<32x16xf16, #AL>) {
+  %cst0 = ttg.local_alloc %arg : (tensor<32x16xf16, #AL>) -> !ttg.memdesc<32x16xf16, #A_SHARED, #ttg.shared_memory>
+  // CHECK: ttg.async_wait
+  // CHECK-NEXT: ttg.async_wait
+  // CHECK-NEXT: ttg.barrier local
+  // CHECK-NEXT: ttg.local_load
+  ttg.async_wait {num = 4 : i32}
+  ttg.async_wait {num = 0 : i32}
+  %1 = ttg.local_load %cst0 : !ttg.memdesc<32x16xf16, #A_SHARED, #ttg.shared_memory> -> tensor<32x16xf16, #AL>
+  tt.return
+}
+
+// CHECK-LABEL: async_wait_pure_op_between_waits
+tt.func @async_wait_pure_op_between_waits(%arg: tensor<32x16xf16, #AL>) {
+  %c1_i32 = arith.constant 1 : i32
+  %cst0 = ttg.local_alloc %arg : (tensor<32x16xf16, #AL>) -> !ttg.memdesc<32x16xf16, #A_SHARED, #ttg.shared_memory>
+  // CHECK: ttg.async_wait
+  // CHECK-NEXT: arith.addi
+  // CHECK-NEXT: ttg.async_wait
+  // CHECK-NEXT: ttg.barrier local
+  // CHECK-NEXT: ttg.local_load
+  ttg.async_wait {num = 4 : i32}
+  %pure = arith.addi %c1_i32, %c1_i32 : i32
+  ttg.async_wait {num = 0 : i32}
+  %1 = ttg.local_load %cst0 : !ttg.memdesc<32x16xf16, #A_SHARED, #ttg.shared_memory> -> tensor<32x16xf16, #AL>
+  tt.return
+}
+
+// CHECK-LABEL: async_wait_existing_barrier
+tt.func @async_wait_existing_barrier(%arg: tensor<32x16xf16, #AL>) {
+  %cst0 = ttg.local_alloc %arg : (tensor<32x16xf16, #AL>) -> !ttg.memdesc<32x16xf16, #A_SHARED, #ttg.shared_memory>
+  // CHECK: ttg.async_wait
+  // CHECK-NEXT: ttg.barrier local
+  // CHECK-NEXT: ttg.local_load
+  ttg.async_wait {num = 4 : i32}
+  ttg.barrier local
+  %1 = ttg.local_load %cst0 : !ttg.memdesc<32x16xf16, #A_SHARED, #ttg.shared_memory> -> tensor<32x16xf16, #AL>
+  tt.return
+}
+
+// CHECK-LABEL: async_wait_scan_stops_at_memory_effect
+tt.func @async_wait_scan_stops_at_memory_effect(%arg: tensor<32x16xf16, #AL>) {
+  %cst0 = ttg.local_alloc %arg : (tensor<32x16xf16, #AL>) -> !ttg.memdesc<32x16xf16, #A_SHARED, #ttg.shared_memory>
+  // CHECK: ttg.async_wait
+  // CHECK-NEXT: ttg.barrier local
+  // CHECK-NEXT: ttg.local_load
+  ttg.async_wait {num = 4 : i32}
+  %1 = ttg.local_load %cst0 : !ttg.memdesc<32x16xf16, #A_SHARED, #ttg.shared_memory> -> tensor<32x16xf16, #AL>
+  // CHECK: ttg.async_wait
+  // CHECK-NEXT: ttg.barrier local
+  // CHECK-NEXT: ttg.local_load
+  ttg.async_wait {num = 0 : i32}
+  %2 = ttg.local_load %cst0 : !ttg.memdesc<32x16xf16, #A_SHARED, #ttg.shared_memory> -> tensor<32x16xf16, #AL>
+  tt.return
+}
+
+// CHECK-LABEL: async_wait_scan_stops_at_control_flow
+tt.func @async_wait_scan_stops_at_control_flow(%arg: tensor<32x16xf16, #AL>, %cond: i1) {
+  %cst0 = ttg.local_alloc %arg : (tensor<32x16xf16, #AL>) -> !ttg.memdesc<32x16xf16, #A_SHARED, #ttg.shared_memory>
+  // CHECK: ttg.async_wait
+  // CHECK-NEXT: ttg.barrier local
+  // CHECK-NEXT: scf.if
+  ttg.async_wait {num = 4 : i32}
+  scf.if %cond {
+    scf.yield
+  } else {
+    scf.yield
+  }
+  // CHECK: ttg.async_wait
+  // CHECK-NEXT: ttg.barrier local
+  // CHECK-NEXT: ttg.local_load
+  ttg.async_wait {num = 0 : i32}
+  %1 = ttg.local_load %cst0 : !ttg.memdesc<32x16xf16, #A_SHARED, #ttg.shared_memory> -> tensor<32x16xf16, #AL>
+  tt.return
+}
+
+// CHECK-LABEL: async_wait_scan_reaches_block_end
+tt.func @async_wait_scan_reaches_block_end(%arg: tensor<32x16xf16, #AL>, %cond: i1) {
+  %cst0 = ttg.local_alloc %arg : (tensor<32x16xf16, #AL>) -> !ttg.memdesc<32x16xf16, #A_SHARED, #ttg.shared_memory>
+  scf.if %cond {
+    // CHECK: ttg.async_wait
+    // CHECK-NEXT: ttg.barrier local
+    // CHECK-NEXT: } else {
+    ttg.async_wait {num = 4 : i32}
+    scf.yield
+  } else {
+    scf.yield
+  }
+  // CHECK: ttg.async_wait
+  // CHECK-NEXT: ttg.barrier local
+  ttg.async_wait {num = 0 : i32}
+  tt.return
+}
+
+
 // CHECK-LABEL: subview
 tt.func @subview() {
   %cst0 = arith.constant dense<0.000000e+00> : tensor<32x16xf16, #AL>


### PR DESCRIPTION
The goal is to avoid redundant local barriers for back-to-back waits. In general, we do not expect to see back-to-back waits since the pipeliner folds them. However, if we mix `AsyncCopy` and `DescriptorLoads` on AMD (`gfx1250`), we get two different wait ops that may be scheduled back to back or just be separated by non memory operations. In those cases, this avoids the redundant barrier between them and enables much better LLVM codegen.

This will help with mxfp kernels where we might load scales via `AsyncCopy` and operands via `TDM` or persistent kernels where we mix `TDM loads` with `AsyncStores`.