### PR TITLE
[GSan] Support chaining releases with atomic rmw

### DIFF
--- a/python/test/gsan/test_gsan.py
+++ b/python/test/gsan/test_gsan.py
@@ -315,6 +315,93 @@ def test_atomic_release_acquire_transitively_synchronizes_cross_sm(with_gsan, ca
 
 
 @triton.jit
+def _release_rmw_chain_kernel(payload_ptr, counter_ptr, out_ptr, scope: tl.constexpr, NUM_WRITERS: tl.constexpr):
+    pid = tl.program_id(0)
+    if pid == NUM_WRITERS:
+        atomic_poll(counter_ptr, NUM_WRITERS, sem="acquire", scope=scope)
+        idx = tl.arange(0, triton.next_power_of_2(NUM_WRITERS))
+        value = tl.load(payload_ptr + idx, mask=idx < NUM_WRITERS)
+        tl.store(out_ptr + idx, value, mask=idx < NUM_WRITERS)
+    else:
+        tl.store(payload_ptr + pid, 1000 + pid)
+        tl.atomic_add(counter_ptr, 1, sem="release", scope=scope)
+
+
+@pytest.mark.skipif(not is_cuda(), reason="GSan requires CUDA")
+@pytest.mark.parametrize("scope, expected_scope", ATOMIC_SCOPE_CASES[1:])
+def test_atomic_release_rmw_chain_synchronizes_all_writers(with_gsan, capfd, scope, expected_scope):
+    num_writers = 3
+    payload = torch.zeros(num_writers, dtype=torch.int32, device="cuda")
+
+    counter = torch.zeros(1, dtype=torch.int32, device="cuda")
+    out = torch.full((num_writers, ), -1, dtype=torch.int32, device="cuda")
+    _release_rmw_chain_kernel[(num_writers + 1, )](
+        payload,
+        counter,
+        out,
+        scope=scope,
+        NUM_WRITERS=num_writers,
+        num_warps=1,
+    )
+    torch.cuda.synchronize()
+
+    expected = torch.arange(1000, 1000 + num_writers, dtype=torch.int32, device="cuda")
+    torch.testing.assert_close(out, expected)
+
+    writer_tids = set()
+    for index in range(num_writers):
+        payload_cell = shadow_cell_from_address(payload[index].data_ptr())
+        writer_tid = payload_cell.write_clock.thread_id
+        writer_epoch = payload_cell.write_clock.epoch
+        writer_tids.add(writer_tid)
+        consumer_tid = payload_cell.read_clocks[0].thread_id
+        consumer_state = thread_state_from_smid(consumer_tid)
+        assert consumer_state.vector_clock[writer_tid] >= writer_epoch
+    assert len(writer_tids) == num_writers
+
+    counter_cell = shadow_cell_from_address(counter.data_ptr())
+    assert counter_cell.write_clock.scope == expected_scope
+    assert counter_cell.write_clock.is_release
+
+    _assert_no_gsan_runtime_output(capfd)
+
+
+@triton.jit
+def _ordered_mixed_scope_release_rmw_kernel(payload_ptr, counter_ptr, ready_ptr):
+    pid = tl.program_id(0)
+    if pid == 0:
+        tl.store(payload_ptr, 1000)
+        tl.atomic_add(counter_ptr, 1, sem="release", scope="gpu")
+        tl.atomic_xchg(ready_ptr, 1, sem="relaxed", scope="gpu")
+    elif pid == 1:
+        atomic_poll(ready_ptr, 1)
+        tl.atomic_add(counter_ptr, 1, sem="acq_rel", scope="sys")
+
+
+@pytest.mark.skipif(not is_cuda(), reason="GSan requires CUDA")
+def test_ordered_mixed_scope_release_rmw_is_allowed(with_gsan, capfd):
+    payload = torch.zeros(1, dtype=torch.int32, device="cuda")
+    counter = torch.zeros(1, dtype=torch.int32, device="cuda")
+    ready = torch.zeros(1, dtype=torch.int32, device="cuda")
+    _ordered_mixed_scope_release_rmw_kernel[(2, )](payload, counter, ready, num_warps=1)
+    torch.cuda.synchronize()
+
+    assert counter.item() == 2
+
+    payload_cell = shadow_cell_from_address(payload.data_ptr())
+    counter_cell = shadow_cell_from_address(counter.data_ptr())
+    assert counter_cell.write_clock.scope == AtomicScope.SYSTEM
+    assert counter_cell.write_clock.is_release
+
+    counter_writer_state = thread_state_from_smid(counter_cell.write_clock.thread_id)
+    snapshot_idx = _clock_buffer_snapshot_idx(counter_cell.write_clock.epoch, counter_writer_state,
+                                              payload_cell.write_clock.thread_id)
+    assert counter_writer_state.clock_buffer[snapshot_idx] >= payload_cell.write_clock.epoch
+
+    _assert_no_gsan_runtime_output(capfd)
+
+
+@triton.jit
 def _write_blocks_kernel(ptr, n_elements, BLOCK_SIZE: tl.constexpr):
     pid = tl.program_id(0)
     offsets = pid * BLOCK_SIZE + tl.arange(0, BLOCK_SIZE)

--- a/python/test/gsan/test_gsan_failures.py
+++ b/python/test/gsan/test_gsan_failures.py
@@ -194,6 +194,17 @@ def _host_tma_atomic_flag_publish_kernel(payload_ptr, flag_ptr, flag_desc, count
         tl.store(scratch_ptr, result)
 
 
+@triton.jit
+def _mixed_scope_release_rmw_kernel(counter_ptr, ready_ptr):
+    pid = tl.program_id(0)
+    if pid == 0:
+        tl.atomic_add(counter_ptr, 1, sem="release", scope="gpu")
+        tl.atomic_xchg(ready_ptr, 1, sem="relaxed", scope="gpu")
+    elif pid == 1:
+        atomic_poll(ready_ptr, 1)
+        tl.atomic_add(counter_ptr, 1, sem="release", scope="sys")
+
+
 def _cuda_byte_allocator(size: int, _align: int, _stream):
     return torch.empty(size, dtype=torch.int8, device="cuda")
 
@@ -232,6 +243,13 @@ def _run_waw_case() -> None:
     scratch = torch.zeros(1, dtype=torch.int32, device="cuda")
     counter = torch.zeros(1, dtype=torch.int32, device="cuda")
     _waw_kernel[(2, )](target, scratch, counter, num_warps=1)
+
+
+@run_with_gsan
+def _run_mixed_scope_release_rmw_case() -> None:
+    counter = torch.zeros(1, dtype=torch.int32, device="cuda")
+    ready = torch.zeros(1, dtype=torch.int32, device="cuda")
+    _mixed_scope_release_rmw_kernel[(2, )](counter, ready, num_warps=1)
 
 
 @run_with_gsan
@@ -403,6 +421,16 @@ def test_write_after_read():
 def test_write_after_write():
     _run_failure_case("waw", runner=_run_waw_case, source_function=_waw_kernel.fn, marker="tl.store(ptr, 2)",
                       error="Write after write race detected")
+
+
+def test_mixed_scope_release_rmw_accumulation():
+    _run_failure_case(
+        "mixed_scope_release_rmw",
+        runner=_run_mixed_scope_release_rmw_case,
+        source_function=_mixed_scope_release_rmw_kernel.fn,
+        marker='tl.atomic_add(counter_ptr, 1, sem="release", scope="sys")',
+        error="GSan detected atomic release accumulation with mixed scopes, which is not supported.",
+    )
 
 
 def test_tma_read_after_write():

--- a/python/triton/experimental/gsan/src/GSanLibrary.cu
+++ b/python/triton/experimental/gsan/src/GSanLibrary.cu
@@ -229,6 +229,17 @@ GSAN_DEVICE bool areAtomicScopesCompatible(AtomicScope lhs, thread_id_t lhsTid,
          scopeCoversPair(rhs, lhsTid, rhsTid, globals);
 }
 
+GSAN_DEVICE bool canAccumulateReleaseRmw(ThreadState *state, AtomicScope scope,
+                                         const ScalarClock &previousWrite) {
+  // A propagated snapshot currently carries only one scope. Only combine
+  // concurrent releases when that scope remains unchanged.
+  if (!previousWrite.isRelease || scope != previousWrite.scope)
+    return false;
+  return areAtomicScopesCompatible(scope, state->threadId, previousWrite.scope,
+                                   previousWrite.threadId,
+                                   getGlobalState(state));
+}
+
 GSAN_DEVICE void initThread(GlobalState *globals, Location loc) {
   auto *state = getThreadState(globals);
 
@@ -310,6 +321,28 @@ GSAN_DEVICE const epoch_t *getSnapshotForWrite(ThreadState *state,
     return nullptr;
   auto *writerState = getThreadStateById(getGlobalState(state), write.threadId);
   return getClockBufferSlot(writerState, write.epoch, loc);
+}
+
+GSAN_DEVICE epoch_t publishCurrentVectorClockWithPriorRelease(
+    ThreadState *state, const ScalarClock &previousWrite, Location loc) {
+  const auto *previousSnapshot = getSnapshotForWrite(state, previousWrite, loc);
+  auto *globals = getGlobalState(state);
+  assert_msg(loc, globals->clockBufferSize != 0,
+             "GSan clock buffer size must be non-zero");
+  uint32_t nextHead = state->clockBufferHead + 1;
+  assert_msg(loc, nextHead <= kMaxEpoch, "GSan clock buffer token overflowed");
+  auto *slot = getClockBufferBase(state) +
+               (nextHead % globals->clockBufferSize) * globals->numThreads;
+  for (int i = 0; i < globals->numThreads; ++i) {
+    auto current = state->vectorClock[i];
+    auto previous = previousSnapshot[i];
+    slot[i] = current > previous ? current : previous;
+  }
+  state->clockBufferHead = nextHead;
+  // The joined snapshot extends the release sequence without acquiring the
+  // prior writer into this thread's vector clock.
+  state->clockBufferDirty = 1;
+  return static_cast<epoch_t>(nextHead);
 }
 
 GSAN_DEVICE epoch_t propagateClockBufferSnapshot(ThreadState *state,
@@ -604,12 +637,25 @@ GSAN_DEVICE void endAtomicAccess(AtomicEventState *event, bool pred,
                                 "Write after write race detected");
     }
 
+    auto previousWrite = event->cells[0]->writeClock;
     ScalarClock newWriteClock;
     if (hasRelease(sem)) {
-      auto token = publishCurrentVectorClock(state, loc);
+      epoch_t token;
+      if (canAccumulateReleaseRmw(state, scope, previousWrite))
+        token = publishCurrentVectorClockWithPriorRelease(state, previousWrite,
+                                                          loc);
+      else if (previousWrite.isRelease) {
+        const auto *previousSnapshot =
+            getSnapshotForWrite(state, previousWrite, loc);
+        assert_msg(loc, dominatesSnapshot(state, previousSnapshot),
+                   "GSan detected atomic release accumulation with mixed "
+                   "scopes, which is not supported.");
+        token = publishCurrentVectorClock(state, loc);
+      } else {
+        token = publishCurrentVectorClock(state, loc);
+      }
       newWriteClock = makePublishedClock(state, scope, token);
     } else {
-      auto previousWrite = event->cells[0]->writeClock;
       if (previousWrite.isRelease) {
         auto token = propagateClockBufferSnapshot(state, previousWrite, loc);
         newWriteClock = makePublishedClock(state, scope, token);


### PR DESCRIPTION
Currently an atomic release is modelled as over-writing the vector clock in the shadow memory, however this is not correct. You can actually accumulate multiple releases into the same memory location without the modifying thread doing an acquire in between. e.g.

```python
prev = tl.atomic_add(global_counter_ptr, 1, sem="release")
if prev = tl.num_programs(0) - 1:
    # Acquires all releases on the global counter
    tl.atomic_add(global_counter_ptr, 0, sem="acquire")
```

We model this by checking compatibility of the previous writer, and publishing the elementwise maximum of their vector clock and ours. But not updating our own clock.

There is an edge case here, that I'm punting on. What should happen if you have two writers on the same gpu, one writer uses `scope="gpu"` and the other uses `scope="sys"`? Perhaps the scope of the write should be the common denominator? I just ban this for now.