### PR TITLE
[DOC] Document variable scoping across control flow

### DIFF
--- a/docs/python-api/triton-semantics.rst
+++ b/docs/python-api/triton-semantics.rst
@@ -43,3 +43,26 @@ Differences with NumPy
 **C rounding in integer division** Operators in Triton follow C semantics rather than Python semantics for efficiency. As such, ``int // int`` implements `rounding towards zero as in C <https://en.wikipedia.org/wiki/Modulo#In_programming_languages>`_ for integers of mixed signs, rather than rounding towards minus infinity as in Python. For the same reason, the modulus operator ``int % int`` (which is defined as ``a % b = a - b * (a // b)``) also follows C semantics rather than Python semantics.
 
 Perhaps confusingly, integer division and modulus follow Python semantics for computations where all the inputs are scalars.
+
+**Variable scoping** A variable used after a ``for`` loop or an ``if`` statement must be assigned on *every* path through that block, unlike Python where a variable assigned inside a block remains visible afterwards. Triton does not model variables as being dynamically defined or undefined depending on control flow, so a variable that is only assigned inside the block is not considered defined once the block exits. This holds even when the block is guaranteed to execute, such as a ``range(0, 1)`` loop.
+
+For example, the following raises ``NameError: 'value' is not defined`` because ``value`` is only bound inside the loop body:
+
+.. code-block:: python
+
+    @triton.jit
+    def kernel(out_ptr):
+        for _ in range(0, 1):
+            value = 1.0
+        tl.store(out_ptr, value)  # `value` is not defined here
+
+Assign the variable before the block so that it is defined on all paths:
+
+.. code-block:: python
+
+    @triton.jit
+    def kernel(out_ptr):
+        value = 0.0
+        for _ in range(0, 1):
+            value = 1.0
+        tl.store(out_ptr, value)


### PR DESCRIPTION
## Summary

Documents that a variable used after a `for`/`if` block must be assigned on every path through it — unlike Python, Triton does not treat variables as dynamically defined/undefined based on control flow.

This is the documentation improvement requested in #10672, where a variable assigned only inside a `range(0, 1)` loop raised `NameError: 'value' is not defined`. As noted there, the behavior is intentional; the rule was just undocumented.

Adds a "Variable scoping" entry to the Triton Semantics page with the failing example and the fix (assign the variable before the block).

Closes #10672
