### PR TITLE
[DOC] Fix heuristics function argument description

### DIFF
--- a/python/triton/runtime/autotuner.py
+++ b/python/triton/runtime/autotuner.py
@@ -497,7 +497,7 @@ def heuristics(values):
         def kernel(x_ptr, x_size, BLOCK_SIZE: tl.constexpr):
             ...
     :param values: a dictionary of meta-parameter names and functions that compute the value of the meta-parameter.
-                   each such function takes a list of positional arguments as input.
+                   each such function takes a dict of all the arguments passed to the kernel, keyed by argument name, as input.
     :type values: dict[str, Callable[[dict[str, Any]], Any]]
     """
 


### PR DESCRIPTION
## Summary

The `@triton.heuristics` docstring said each heuristic function "takes a list of positional arguments as input." That is wrong. The function is called with a dict of all the kernel arguments keyed by name, which is what the example (`args['x_size']`) and the type hint (`Callable[[dict[str, Any]], Any]`) already show.

Updates the description to match.

Closes #4753
