### PR TITLE
Fix AOT linker algo ID bounds check

### DIFF
--- a/python/test/unit/tools/test_aot.py
+++ b/python/test/unit/tools/test_aot.py
@@ -388,6 +388,71 @@ def check_hasco_binary_str(tmp_dir: str, dtype: str):
         assert int(matches[0]) > 16, "Expected valid HSACO object binary string"
 
 
+def test_linker_rejects_invalid_algo_id():
+    from triton.tools.link import (
+        KernelLinkerMeta,
+        make_func_pointers,
+        make_get_num_algos_def,
+        make_kernel_meta_const_dispatcher,
+    )
+
+    meta = KernelLinkerMeta(
+        orig_kernel_name="kernel",
+        arg_names=["x"],
+        arg_ctypes=["int"],
+        sizes=[None],
+        sig_hash="abcdef12",
+        triton_suffix="",
+        suffix="",
+        num_specs=0,
+    )
+
+    with tempfile.TemporaryDirectory() as tmp_dir:
+        c_path = os.path.join(tmp_dir, "test_linker_algo_id_bounds.c")
+        exe_path = os.path.join(tmp_dir, "test_linker_algo_id_bounds")
+        with open(c_path, "w") as fp:
+            fp.write(f"""
+#include <stdio.h>
+
+typedef void *TT_StreamTy;
+typedef int TT_ResultTy;
+
+#define TT_ERROR_INVALID_VALUE 777
+#define CHECK_EQ(actual, expected) \\
+  do {{ \\
+    TT_ResultTy got = (actual); \\
+    if (got != (expected)) {{ \\
+      fprintf(stderr, "%s:%d: got %d, expected %d\\n", __FILE__, __LINE__, got, (expected)); \\
+      return 1; \\
+    }} \\
+  }} while (0)
+
+TT_ResultTy kernel_algo0(TT_StreamTy stream, int x) {{
+  return x + 10;
+}}
+
+TT_ResultTy kernel_algo1(TT_StreamTy stream, int x) {{
+  return x + 20;
+}}
+
+{make_func_pointers(["kernel_algo0", "kernel_algo1"], meta)}
+{make_get_num_algos_def(meta)}
+{make_kernel_meta_const_dispatcher(meta)}
+
+int main(void) {{
+  CHECK_EQ(kernel_get_num_algos(), 2);
+  CHECK_EQ(kernel(0, 5, 0), 15);
+  CHECK_EQ(kernel(0, 5, 1), 25);
+  CHECK_EQ(kernel(0, 5, -1), TT_ERROR_INVALID_VALUE);
+  CHECK_EQ(kernel(0, 5, 2), TT_ERROR_INVALID_VALUE);
+  return 0;
+}}
+""")
+
+        subprocess.run(["gcc", "-std=c99", "-DNDEBUG", c_path, "-o", exe_path], check=True)
+        subprocess.run([exe_path], check=True)
+
+
 # Test edge case where the provided kernel signature has no specializations
 def test_compile_link_matmul_no_specialization():
     np.random.seed(3)

--- a/python/triton/tools/link.py
+++ b/python/triton/tools/link.py
@@ -214,7 +214,9 @@ def make_kernel_hints_dispatcher(name: str, metas: Sequence[KernelLinkerMeta]) -
 # generate dispatcher function for kernels with different meta-parameter and constant values
 def make_kernel_meta_const_dispatcher(meta: KernelLinkerMeta) -> str:
     src = f"TT_ResultTy {meta.orig_kernel_name}(TT_StreamTy stream, {gen_signature_with_full_args(meta)}, int algo_id){{\n"
-    src += f"  assert (algo_id < (int)sizeof({meta.orig_kernel_name}_kernels));\n"
+    src += f"  int num_algos = (int)(sizeof({meta.orig_kernel_name}_kernels) / sizeof({meta.orig_kernel_name}_kernels[0]));\n"
+    src += "  if (algo_id < 0 || algo_id >= num_algos)\n"
+    src += "    return TT_ERROR_INVALID_VALUE;\n"
     src += f"  return {meta.orig_kernel_name}_kernels[algo_id](stream, {', '.join(meta.arg_names)});\n"
     src += "}\n"
     return src
@@ -319,7 +321,6 @@ if __name__ == "__main__":
     with args.out.with_suffix(".c").open("w") as fp:
         out = backend_prelude
         out += "#include <stdint.h>\n"
-        out += "#include <assert.h>\n"
         out += "\n"
         out += "\n".join(defs)
         out += "\n"


### PR DESCRIPTION
## Summary
- Check AOT linker `algo_id` values against the actual function-pointer array length before indexing.
- Reject negative and out-of-range IDs with `TT_ERROR_INVALID_VALUE` instead of relying on `assert`.
- Add a small generated-C regression that runs with `-DNDEBUG` and covers valid IDs plus `-1` and `2` for a two-algo table.

## Root cause
The generated dispatcher compared `algo_id` with `sizeof(kernel_array)`, which is a byte count, and the guard disappeared in release builds. The existing `*_get_num_algos()` helper already used the element-count expression, so the dispatcher now follows that pattern.

## Testing
- `python3 -m py_compile python/triton/tools/link.py python/test/unit/tools/test_aot.py`
- `git diff --check -- python/triton/tools/link.py python/test/unit/tools/test_aot.py`
- Standalone generated-C validation compiled and run with `gcc -std=c99 -DNDEBUG`

Not run locally: `PYTHONPATH=python pytest -s --tb=short python/test/unit/tools/test_aot.py::test_linker_rejects_invalid_algo_id` because this checkout does not have `pytest` installed, and the local Triton package import also needs a built `triton._C` extension.