### PR TITLE
[AMD][gfx1250] TDM: make async_tdm_gather/scatter pure

### DIFF
--- a/python/src/gluon_ir.cc
+++ b/python/src/gluon_ir.cc
@@ -1126,15 +1126,15 @@ void init_gluon_ir(py::module &&m) {
            })
       .def("create_async_tdm_scatter",
            [](GluonOpBuilder &self, Value descPtr, Value dstRowIndices,
-              Value dstColOffset, Value src, Value barrier) {
-             self.create<ttag::AsyncTDMScatterOp>(descPtr, dstRowIndices,
-                                                  dstColOffset, src, barrier);
+              Value src, Value barrier) {
+             self.create<ttag::AsyncTDMScatterOp>(descPtr, dstRowIndices, src,
+                                                  barrier);
            })
       .def("create_async_tdm_gather",
            [](GluonOpBuilder &self, Value descPtr, Value srcRowIndices,
-              Value srcColOffset, Value dst, Value pred, Value barrier) {
-             self.create<ttag::AsyncTDMGatherOp>(
-                 descPtr, srcRowIndices, srcColOffset, dst, pred, barrier);
+              Value dst, Value barrier) {
+             self.create<ttag::AsyncTDMGatherOp>(descPtr, srcRowIndices, dst,
+                                                 barrier);
            })
       .def("create_tdm_prefetch",
            [](GluonOpBuilder &self, Value descPtr, std::vector<Value> &indices,

--- a/python/test/gluon/test_frontend.py
+++ b/python/test/gluon/test_frontend.py
@@ -3902,7 +3902,7 @@ def amd_tdm_gather_kernel(ptr):
 
     row_indices = ttgl.arange(0, NUM_INDICES, layout=ROW_IDX_LAYOUT)
     buffer = ttgl.allocate_shared_memory(desc.dtype, shape=desc.block_shape, layout=desc.layout)
-    ttgl.amd.gfx1250.tdm.async_gather(desc, src_row_indices=row_indices, src_col_offset=0, dst=buffer)
+    ttgl.amd.gfx1250.tdm.async_gather(desc, src_row_indices=row_indices, dst=buffer)
 
     ttgl.amd.gfx1250.tdm.async_wait(0)
     buffer.load(layout=BLOCKED_LAYOUT)
@@ -3927,9 +3927,7 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.targ
     %0 = tt.make_tensor_descriptor %arg0, [%c32_i32, %c128_i32], [%c128_i64, %c1_i64] : <f16>, <16x64xf16, #shared>
     %1 = tt.make_range {end = 16 : i32, start = 0 : i32} : tensor<16xi32, #ttg.slice<{dim = 1, parent = #blocked}>>
     %2 = ttg.local_alloc : () -> !ttg.memdesc<16x64xf16, #shared, #smem, mutable>
-    %c0_i32 = arith.constant 0 : i32
-    %c1_i32 = arith.constant 1 : i32
-    %3 = amdg.async_tdm_gather %0[%1, %c0_i32] to %2, pred = %c1_i32 : tensor<16xi32, #ttg.slice<{dim = 1, parent = #blocked}>>, !ttg.memdesc<16x64xf16, #shared, #smem, mutable> -> !tt.tensordesc<16x64xf16, #shared>
+    %3 = amdg.async_tdm_gather %0[%1] to %2 : tensor<16xi32, #ttg.slice<{dim = 1, parent = #blocked}>>, !ttg.memdesc<16x64xf16, #shared, #smem, mutable> -> !tt.tensordesc<16x64xf16, #shared>
     %4 = amdg.async_tdm_wait  {num = 0 : i32}
     %5 = ttg.local_load %2 : !ttg.memdesc<16x64xf16, #shared, #smem, mutable> -> tensor<16x64xf16, #blocked>
     tt.return
@@ -3953,7 +3951,7 @@ def amd_tdm_scatter_kernel(ptr):
     buffer = ttgl.allocate_shared_memory(desc.dtype, desc.block_shape, desc.layout, value)
 
     row_indices = ttgl.arange(0, NUM_INDICES, layout=ROW_IDX_LAYOUT)
-    ttgl.amd.gfx1250.tdm.async_scatter(desc, dst_row_indices=row_indices, dst_col_offset=0, src=buffer)
+    ttgl.amd.gfx1250.tdm.async_scatter(desc, dst_row_indices=row_indices, src=buffer)
     ttgl.amd.gfx1250.tdm.async_wait(0)
 
 
@@ -3978,8 +3976,7 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.targ
     %cst_0 = arith.constant dense<1.000000e+00> : tensor<16x64xf16, #blocked>
     %1 = ttg.local_alloc %cst_0 : (tensor<16x64xf16, #blocked>) -> !ttg.memdesc<16x64xf16, #shared, #smem, mutable>
     %2 = tt.make_range {end = 16 : i32, start = 0 : i32} : tensor<16xi32, #ttg.slice<{dim = 1, parent = #blocked}>>
-    %c0_i32 = arith.constant 0 : i32
-    %3 = amdg.async_tdm_scatter %0[%2, %c0_i32] from %1 : tensor<16xi32, #ttg.slice<{dim = 1, parent = #blocked}>>, !ttg.memdesc<16x64xf16, #shared, #smem, mutable> -> !tt.tensordesc<16x64xf16, #shared>
+    %3 = amdg.async_tdm_scatter %0[%2] from %1 : tensor<16xi32, #ttg.slice<{dim = 1, parent = #blocked}>>, !ttg.memdesc<16x64xf16, #shared, #smem, mutable> -> !tt.tensordesc<16x64xf16, #shared>
     %4 = amdg.async_tdm_wait  {num = 0 : i32}
     tt.return
   }

--- a/python/triton/experimental/gluon/language/amd/gfx1250/tdm.py
+++ b/python/triton/experimental/gluon/language/amd/gfx1250/tdm.py
@@ -328,7 +328,7 @@ def async_wait(num_outstanding=0, _semantic=None) -> None:
 
 
 @builtin
-def async_scatter(desc: tensor_descriptor, dst_row_indices: ttgl.tensor, dst_col_offset, src: shared_memory_descriptor,
+def async_scatter(desc: tensor_descriptor, dst_row_indices: ttgl.tensor, src: shared_memory_descriptor,
                   mbarrier: shared_memory_descriptor = None, _semantic=None) -> None:
     """Scatter data from shared memory to non-contiguous rows in global memory asynchronously.
 
@@ -341,11 +341,13 @@ def async_scatter(desc: tensor_descriptor, dst_row_indices: ttgl.tensor, dst_col
     - int32: up to 8 rows can be scattered per TDM instruction
     If more rows are needed, multiple TDM instructions will be automatically issued.
 
+    The column offset is carried by the descriptor: position it beforehand with
+    ``update_tensor_descriptor(desc, add_offsets=[0, col])``.
+
     Args:
-        desc (tensor_descriptor): the destination tensor descriptor. Must be 2D.
+        desc (tensor_descriptor): the destination tensor descriptor. Must be 2D and positioned
+                                  (column via update_tensor_descriptor).
         dst_row_indices (tensor): 1D tensor of row indices (int16 or int32) in the destination tensor.
-        dst_col_offset (int or tensor): the starting column offset in the destination tensor
-                                        for all scattered rows.
         src (shared_memory_descriptor): the shared memory source containing data to scatter. Must be 2D.
         mbarrier (shared_memory_descriptor, optional): The barrier object to signal "arrive" on.
     """
@@ -355,19 +357,15 @@ def async_scatter(desc: tensor_descriptor, dst_row_indices: ttgl.tensor, dst_col
     src_ndim = len(src.shape)
     assert src_ndim == 2, f"TDM scatter src must be 2D, got {src_ndim}D"
 
-    # Convert dst_col_offset to i32
-    dst_col_offset_handle = _semantic._convert_to_ir_values([dst_col_offset], require_i64=False)[0]
-
     mbarrier = _unwrap_if_constexpr(mbarrier)
     mbarrier_handle = mbarrier.handle if mbarrier is not None else ttgl.ir.value()
 
-    _semantic.builder.create_async_tdm_scatter(desc.handle, dst_row_indices.handle, dst_col_offset_handle, src.handle,
-                                               mbarrier_handle)
+    _semantic.builder.create_async_tdm_scatter(desc.handle, dst_row_indices.handle, src.handle, mbarrier_handle)
 
 
 @builtin
-def async_gather(desc: tensor_descriptor, src_row_indices: ttgl.tensor, src_col_offset, dst: shared_memory_descriptor,
-                 pred=True, mbarrier: shared_memory_descriptor = None, _semantic=None) -> None:
+def async_gather(desc: tensor_descriptor, src_row_indices: ttgl.tensor, dst: shared_memory_descriptor,
+                 mbarrier: shared_memory_descriptor = None, _semantic=None) -> None:
     """Gather data from non-contiguous rows in global memory to shared memory asynchronously.
 
     This operation uses TDM gather mode to read data from non-contiguous rows in global memory.
@@ -379,13 +377,14 @@ def async_gather(desc: tensor_descriptor, src_row_indices: ttgl.tensor, src_col_
     - int32: up to 8 rows can be gathered per TDM instruction
     If more rows are needed, multiple TDM instructions will be automatically issued.
 
+    The column offset and predicate are carried by the descriptor: position it
+    beforehand with ``update_tensor_descriptor(desc, add_offsets=[0, col], pred=p)``.
+
     Args:
-        desc (tensor_descriptor): the source tensor descriptor. Must be 2D.
+        desc (tensor_descriptor): the source tensor descriptor. Must be 2D and positioned
+                                  (column / pred via update_tensor_descriptor).
         src_row_indices (tensor): 1D tensor of row indices (int16 or int32) in the source tensor.
-        src_col_offset (int or tensor): the starting column offset in the source tensor
-                                        for all gathered rows.
         dst (shared_memory_descriptor): the shared memory destination to store gathered data. Must be 2D.
-        pred (bool, optional): Predicate to enable or disable the gather. Defaults to True.
         mbarrier (shared_memory_descriptor, optional): The barrier object to signal "arrive" on.
     """
     ndim = len(desc.block_shape)
@@ -394,16 +393,10 @@ def async_gather(desc: tensor_descriptor, src_row_indices: ttgl.tensor, src_col_
     dst_ndim = len(dst.shape)
     assert dst_ndim == 2, f"TDM gather dst must be 2D, got {dst_ndim}D"
 
-    # Convert src_col_offset to i32
-    src_col_offset_handle = _semantic._convert_to_ir_values([src_col_offset], require_i64=False)[0]
-
-    pred = _handle_i32_pred(pred, _semantic)
-
     mbarrier = _unwrap_if_constexpr(mbarrier)
     mbarrier_handle = mbarrier.handle if mbarrier is not None else ttgl.ir.value()
 
-    _semantic.builder.create_async_tdm_gather(desc.handle, src_row_indices.handle, src_col_offset_handle, dst.handle,
-                                              pred.handle, mbarrier_handle)
+    _semantic.builder.create_async_tdm_gather(desc.handle, src_row_indices.handle, dst.handle, mbarrier_handle)
 
 
 @builtin

--- a/python/triton/tools/triton_to_gluon_translator/amd_helpers.py
+++ b/python/triton/tools/triton_to_gluon_translator/amd_helpers.py
@@ -294,7 +294,8 @@ def tl_obj_gather_amd(desc_args, x_offsets, y_offset):
     x_offsets = ttgl.convert_layout(x_offsets, idx_layout)
     alloc = ttgl.allocate_shared_memory(desc_args.desc.dtype, list(gather_shape), smem_layout)
     y_off = ttgl.to_tensor(y_offset)
-    amd_tdm.async_gather(gather_desc, x_offsets, y_off, alloc)
+    gather_desc = amd_tdm.update_tensor_descriptor(gather_desc, add_offsets=[0, y_off], clamp_bounds=True)
+    amd_tdm.async_gather(gather_desc, x_offsets, alloc)
     amd_tdm.async_wait(0)
     ret_layout: ttgl.constexpr = default_blocked_layout(list(gather_shape), num_warps, current_target())
     out = alloc.load(ret_layout)
@@ -318,7 +319,8 @@ def tl_obj_scatter_amd(desc_args, value, x_offsets, y_offset):
     x_offsets = ttgl.convert_layout(x_offsets, idx_layout)
     alloc = ttgl.allocate_shared_memory(desc_args.desc.dtype, list(scatter_shape), smem_layout, value)
     y_off = ttgl.to_tensor(y_offset)
-    amd_tdm.async_scatter(scatter_desc, x_offsets, y_off, alloc)
+    scatter_desc = amd_tdm.update_tensor_descriptor(scatter_desc, add_offsets=[0, y_off], clamp_bounds=True)
+    amd_tdm.async_scatter(scatter_desc, x_offsets, alloc)
     amd_tdm.async_wait(0)
 
 

--- a/test/Conversion/amd/tritongpu_tdm_to_llvm.mlir
+++ b/test/Conversion/amd/tritongpu_tdm_to_llvm.mlir
@@ -179,7 +179,7 @@ module attributes {"ttg.num-ctas" = 16 : i32, "ttg.num-warps" = 4 : i32, ttg.tar
     // CHECK: %[[G1_0_WITH_MASK:.*]] = llvm.or %{{.*}}, %[[CTA_MASK]]
     // CHECK: %[[G1_0_MASKED:.*]] = llvm.and %[[G1_0_WITH_MASK]]
     // CHECK: llvm.insertelement %[[G1_0_MASKED]]
-    amdg.async_tdm_gather %tensorDesc[%row_indices, %c0_i32] to %memDesc, pred = %pred : tensor<8xi32, #slice1>, !ttg.memdesc<8x64xf16, #shared1, #smem, mutable> -> !tt.tensordesc<8x64xf16, #shared1>
+    amdg.async_tdm_gather %tensorDesc[%row_indices] to %memDesc : tensor<8xi32, #slice1>, !ttg.memdesc<8x64xf16, #shared1, #smem, mutable> -> !tt.tensordesc<8x64xf16, #shared1>
     // CHECK: "llvm.amdgcn.tensor.load.to.lds"({{.+}}) : (vector<4xi32>, vector<8xi32>, vector<4xi32>, vector<4xi32>, vector<8xi32>, i32) -> ()
     tt.return
   }
@@ -267,8 +267,7 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.targ
     %memDesc: !ttg.memdesc<8x64xf16, #shared_scatter_pad, #smem_scatter_pad, mutable>,
     %row_indices: tensor<8xi32, #idx_layout>
   ) {
-    %c0_i32 = arith.constant 0 : i32
-    amdg.async_tdm_scatter %tensorDesc[%row_indices, %c0_i32] from %memDesc : tensor<8xi32, #idx_layout>, !ttg.memdesc<8x64xf16, #shared_scatter_pad, #smem_scatter_pad, mutable> -> !tt.tensordesc<8x64xf16>
+    amdg.async_tdm_scatter %tensorDesc[%row_indices] from %memDesc : tensor<8xi32, #idx_layout>, !ttg.memdesc<8x64xf16, #shared_scatter_pad, #smem_scatter_pad, mutable> -> !tt.tensordesc<8x64xf16>
     // CHECK: "llvm.amdgcn.tensor.store.from.lds"({{.+}}) : (vector<4xi32>, vector<8xi32>, vector<4xi32>, vector<4xi32>, vector<8xi32>, i32) -> ()
     tt.return
   }

--- a/test/TritonGPU/amd/amd-convert-tensor-ops.mlir
+++ b/test/TritonGPU/amd/amd-convert-tensor-ops.mlir
@@ -13,7 +13,8 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.targ
 // CHECK-LABEL: @test_gather_i32
 // CHECK: ttg.convert_layout %{{.*}} -> tensor<32xi32, #ttg.slice<{dim = 0, parent = #[[$AMD_IDX_I32]]}>>
 // CHECK: ttg.local_alloc
-// CHECK: amdg.async_tdm_gather {{.*}} pred = %{{.*}} : tensor<32xi32, #ttg.slice<{dim = 0, parent = #[[$AMD_IDX_I32]]
+// CHECK: amdg.update_tensor_descriptor %{{.*}} add_offsets = [%c0_i32, %{{.*}}] pred = %{{.*}} {clamp_bounds}
+// CHECK: amdg.async_tdm_gather %{{.*}}[%{{.*}}] to %{{.*}} : tensor<32xi32, #ttg.slice<{dim = 0, parent = #[[$AMD_IDX_I32]]
 // CHECK: amdg.async_tdm_wait {num = 0 : i32}
 // CHECK: ttg.local_load
 tt.func public @test_gather_i32(%desc: !tt.tensordesc<1x32xi8, #padded_desc>,
@@ -38,7 +39,8 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.targ
 // CHECK-LABEL: @test_gather_i16
 // CHECK: ttg.convert_layout %{{.*}} -> tensor<32xi16, #ttg.slice<{dim = 0, parent = #[[$AMD_IDX_I16]]}>>
 // CHECK: ttg.local_alloc
-// CHECK: amdg.async_tdm_gather {{.*}} pred = %{{.*}} : tensor<32xi16, #ttg.slice<{dim = 0, parent = #[[$AMD_IDX_I16]]
+// CHECK: amdg.update_tensor_descriptor %{{.*}} add_offsets = [%c0_i32, %{{.*}}] pred = %{{.*}} {clamp_bounds}
+// CHECK: amdg.async_tdm_gather %{{.*}}[%{{.*}}] to %{{.*}} : tensor<32xi16, #ttg.slice<{dim = 0, parent = #[[$AMD_IDX_I16]]
 // CHECK: amdg.async_tdm_wait {num = 0 : i32}
 // CHECK: ttg.local_load
 tt.func public @test_gather_i16(%desc: !tt.tensordesc<1x32xi8, #padded_desc16>,
@@ -64,7 +66,8 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.targ
 // CHECK-LABEL: @test_scatter_i32
 // CHECK: ttg.convert_layout %{{.*}} -> tensor<32xi32, #ttg.slice<{dim = 0, parent = #[[$AMD_IDX_S_I32]]}>>
 // CHECK: ttg.local_alloc {{.*}} : (tensor<32x32xi8
-// CHECK: amdg.async_tdm_scatter {{.*}} from {{.*}} : tensor<32xi32, #ttg.slice<{dim = 0, parent = #[[$AMD_IDX_S_I32]]
+// CHECK: amdg.update_tensor_descriptor %{{.*}} add_offsets = [%c0_i32, %{{.*}}] {clamp_bounds}
+// CHECK: amdg.async_tdm_scatter %{{.*}}[%{{.*}}] from %{{.*}} : tensor<32xi32, #ttg.slice<{dim = 0, parent = #[[$AMD_IDX_S_I32]]
 // CHECK: amdg.async_tdm_wait {num = 0 : i32}
 // CHECK-NOT: ttg.local_load
 tt.func public @test_scatter_i32(%desc: !tt.tensordesc<1x32xi8, #padded_desc_s>,
@@ -90,7 +93,8 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.targ
 // CHECK-LABEL: @test_scatter_i16
 // CHECK: ttg.convert_layout %{{.*}} -> tensor<32xi16, #ttg.slice<{dim = 0, parent = #[[$AMD_IDX_S_I16]]}>>
 // CHECK: ttg.local_alloc {{.*}} : (tensor<32x32xi8
-// CHECK: amdg.async_tdm_scatter {{.*}} from {{.*}} : tensor<32xi16, #ttg.slice<{dim = 0, parent = #[[$AMD_IDX_S_I16]]
+// CHECK: amdg.update_tensor_descriptor %{{.*}} add_offsets = [%c0_i32, %{{.*}}] {clamp_bounds}
+// CHECK: amdg.async_tdm_scatter %{{.*}}[%{{.*}}] from %{{.*}} : tensor<32xi16, #ttg.slice<{dim = 0, parent = #[[$AMD_IDX_S_I16]]
 // CHECK: amdg.async_tdm_wait {num = 0 : i32}
 // CHECK-NOT: ttg.local_load
 tt.func public @test_scatter_i16(%desc: !tt.tensordesc<1x32xi8, #padded_desc_s16>,

--- a/test/TritonGPU/amd/amd-update-async-wait-count-without-token.mlir
+++ b/test/TritonGPU/amd/amd-update-async-wait-count-without-token.mlir
@@ -583,13 +583,13 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.targ
     %c0_i32 = arith.constant 0 : i32
 
     // Gather with i32 indices: sizePerThread=16, 4 warps, maxPerInstr=8 => 2 instructions
-    amdg.async_tdm_gather %tensorDesc[%row_indices_i32, %c0_i32] to %memDesc, pred = %pred : tensor<64xi32, #ttg.slice<{dim = 0, parent = #idx_i32_parent}>>, !ttg.memdesc<256x128xf16, #shared, #smem, mutable> -> !tt.tensordesc<64x128xf16>
+    amdg.async_tdm_gather %tensorDesc[%row_indices_i32] to %memDesc : tensor<64xi32, #ttg.slice<{dim = 0, parent = #idx_i32_parent}>>, !ttg.memdesc<256x128xf16, #shared, #smem, mutable> -> !tt.tensordesc<64x128xf16>
     // Scatter with i32 indices: 2 instructions
-    amdg.async_tdm_scatter %tensorDesc[%row_indices_i32, %c0_i32] from %memDesc : tensor<64xi32, #ttg.slice<{dim = 0, parent = #idx_i32_parent}>>, !ttg.memdesc<256x128xf16, #shared, #smem, mutable> -> !tt.tensordesc<64x128xf16>
+    amdg.async_tdm_scatter %tensorDesc[%row_indices_i32] from %memDesc : tensor<64xi32, #ttg.slice<{dim = 0, parent = #idx_i32_parent}>>, !ttg.memdesc<256x128xf16, #shared, #smem, mutable> -> !tt.tensordesc<64x128xf16>
     // Gather with i16 indices: sizePerThread=64, 4 warps, maxPerInstr=16 => 4 instructions
-    amdg.async_tdm_gather %tensorDesc[%row_indices_i16, %c0_i32] to %memDesc, pred = %pred : tensor<256xi16, #ttg.slice<{dim = 0, parent = #idx_i16_parent}>>, !ttg.memdesc<256x128xf16, #shared, #smem, mutable> -> !tt.tensordesc<64x128xf16>
+    amdg.async_tdm_gather %tensorDesc[%row_indices_i16] to %memDesc : tensor<256xi16, #ttg.slice<{dim = 0, parent = #idx_i16_parent}>>, !ttg.memdesc<256x128xf16, #shared, #smem, mutable> -> !tt.tensordesc<64x128xf16>
     // Scatter with i16 indices: 4 instructions
-    amdg.async_tdm_scatter %tensorDesc[%row_indices_i16, %c0_i32] from %memDesc : tensor<256xi16, #ttg.slice<{dim = 0, parent = #idx_i16_parent}>>, !ttg.memdesc<256x128xf16, #shared, #smem, mutable> -> !tt.tensordesc<64x128xf16>
+    amdg.async_tdm_scatter %tensorDesc[%row_indices_i16] from %memDesc : tensor<256xi16, #ttg.slice<{dim = 0, parent = #idx_i16_parent}>>, !ttg.memdesc<256x128xf16, #shared, #smem, mutable> -> !tt.tensordesc<64x128xf16>
 
     // i32 ops emit 2 instructions each, i16 ops emit 4 each => total 12 instructions
     // CHECK: amdg.async_tdm_intrinsic_wait {count = 0

--- a/test/TritonGPU/amd/amd-update-async-wait-count.mlir
+++ b/test/TritonGPU/amd/amd-update-async-wait-count.mlir
@@ -618,13 +618,13 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.targ
     %c0_i32 = arith.constant 0 : i32
 
     // Gather with i32 indices: sizePerThread=16, 4 warps, maxPerInstr=8 => 2 instructions
-    %token1 = amdg.async_tdm_gather %tensorDesc[%row_indices_i32, %c0_i32] to %memDesc, pred = %pred : tensor<64xi32, #ttg.slice<{dim = 0, parent = #idx_i32_parent}>>, !ttg.memdesc<256x128xf16, #shared, #smem, mutable> -> !tt.tensordesc<64x128xf16>
+    %token1 = amdg.async_tdm_gather %tensorDesc[%row_indices_i32] to %memDesc : tensor<64xi32, #ttg.slice<{dim = 0, parent = #idx_i32_parent}>>, !ttg.memdesc<256x128xf16, #shared, #smem, mutable> -> !tt.tensordesc<64x128xf16>
     // Scatter with i32 indices: 2 instructions
-    %token2 = amdg.async_tdm_scatter %tensorDesc[%row_indices_i32, %c0_i32] from %memDesc : tensor<64xi32, #ttg.slice<{dim = 0, parent = #idx_i32_parent}>>, !ttg.memdesc<256x128xf16, #shared, #smem, mutable> -> !tt.tensordesc<64x128xf16>
+    %token2 = amdg.async_tdm_scatter %tensorDesc[%row_indices_i32] from %memDesc : tensor<64xi32, #ttg.slice<{dim = 0, parent = #idx_i32_parent}>>, !ttg.memdesc<256x128xf16, #shared, #smem, mutable> -> !tt.tensordesc<64x128xf16>
     // Gather with i16 indices: sizePerThread=64, 4 warps, maxPerInstr=16 => 4 instructions
-    %token3 = amdg.async_tdm_gather %tensorDesc[%row_indices_i16, %c0_i32] to %memDesc, pred = %pred : tensor<256xi16, #ttg.slice<{dim = 0, parent = #idx_i16_parent}>>, !ttg.memdesc<256x128xf16, #shared, #smem, mutable> -> !tt.tensordesc<64x128xf16>
+    %token3 = amdg.async_tdm_gather %tensorDesc[%row_indices_i16] to %memDesc : tensor<256xi16, #ttg.slice<{dim = 0, parent = #idx_i16_parent}>>, !ttg.memdesc<256x128xf16, #shared, #smem, mutable> -> !tt.tensordesc<64x128xf16>
     // Scatter with i16 indices: 4 instructions
-    %token4 = amdg.async_tdm_scatter %tensorDesc[%row_indices_i16, %c0_i32] from %memDesc : tensor<256xi16, #ttg.slice<{dim = 0, parent = #idx_i16_parent}>>, !ttg.memdesc<256x128xf16, #shared, #smem, mutable> -> !tt.tensordesc<64x128xf16>
+    %token4 = amdg.async_tdm_scatter %tensorDesc[%row_indices_i16] from %memDesc : tensor<256xi16, #ttg.slice<{dim = 0, parent = #idx_i16_parent}>>, !ttg.memdesc<256x128xf16, #shared, #smem, mutable> -> !tt.tensordesc<64x128xf16>
 
     // CHECK: amdg.async_tdm_intrinsic_wait {{.*}} {count = 0
     %w1 = amdg.async_tdm_wait %token4 {num = 0 : i32}

--- a/test/TritonGPU/amd/invalid.mlir
+++ b/test/TritonGPU/amd/invalid.mlir
@@ -247,7 +247,7 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 1 : i32, ttg.targ
   ) {
     %c0_i32 = arith.constant 0 : i32
     // expected-error @+1 {{index layout distributes values across lanes}}
-    %token = amdg.async_tdm_gather %tensorDesc[%row_indices, %c0_i32] to %memDesc, pred = %pred : tensor<32xi32, #slice_lane_dist>, !ttg.memdesc<32x128xf16, #shared_gather, #smem_gather, mutable> -> !tt.tensordesc<32x128xf16>
+    %token = amdg.async_tdm_gather %tensorDesc[%row_indices] to %memDesc : tensor<32xi32, #slice_lane_dist>, !ttg.memdesc<32x128xf16, #shared_gather, #smem_gather, mutable> -> !tt.tensordesc<32x128xf16>
     tt.return
   }
 }
@@ -267,7 +267,7 @@ module attributes {"ttg.num-ctas" = 4 : i32, "ttg.num-warps" = 1 : i32, ttg.targ
   ) {
     %c0_i32 = arith.constant 0 : i32
     // expected-error @+1 {{TDM gather index and destination layout must both have a block basis or neither have a block basis}}
-    %token = amdg.async_tdm_gather %tensorDesc[%row_indices, %c0_i32] to %memDesc, pred = %pred : tensor<16xi32, #slice1>, !ttg.memdesc<16x64xf16, #shared1, #smem, mutable> -> !tt.tensordesc<16x64xf16>
+    %token = amdg.async_tdm_gather %tensorDesc[%row_indices] to %memDesc : tensor<16xi32, #slice1>, !ttg.memdesc<16x64xf16, #shared1, #smem, mutable> -> !tt.tensordesc<16x64xf16>
     tt.return
   }
 }
@@ -287,7 +287,7 @@ module attributes {"ttg.num-ctas" = 4 : i32, "ttg.num-warps" = 1 : i32, ttg.targ
   ) {
     %c0_i32 = arith.constant 0 : i32
     // expected-error @+1 {{TDM gather index and shared encoding must have the same block basis for the row dimension}}
-    %token = amdg.async_tdm_gather %tensorDesc[%row_indices, %c0_i32] to %memDesc, pred = %pred : tensor<32xi32, #slice1>, !ttg.memdesc<32x64xf16, #shared1, #smem, mutable> -> !tt.tensordesc<32x64xf16>
+    %token = amdg.async_tdm_gather %tensorDesc[%row_indices] to %memDesc : tensor<32xi32, #slice1>, !ttg.memdesc<32x64xf16, #shared1, #smem, mutable> -> !tt.tensordesc<32x64xf16>
     tt.return
   }
 }
@@ -307,7 +307,7 @@ module attributes {"ttg.num-ctas" = 4 : i32, "ttg.num-warps" = 1 : i32, ttg.targ
   ) {
     %c0_i32 = arith.constant 0 : i32
     // expected-error @+1 {{TDM gather index and shared encoding must have the same block basis for the row dimension}}
-    %token = amdg.async_tdm_gather %tensorDesc[%row_indices, %c0_i32] to %memDesc, pred = %pred : tensor<16xi32, #slice1>, !ttg.memdesc<16x64xf16, #shared1, #smem, mutable> -> !tt.tensordesc<16x64xf16>
+    %token = amdg.async_tdm_gather %tensorDesc[%row_indices] to %memDesc : tensor<16xi32, #slice1>, !ttg.memdesc<16x64xf16, #shared1, #smem, mutable> -> !tt.tensordesc<16x64xf16>
     tt.return
   }
 }
@@ -327,7 +327,7 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.targ
   ) {
     %c0_i32 = arith.constant 0 : i32
     // expected-error @+1 {{TDM scatter padding is only supported when padding interval equals the innermost block dimension}}
-    amdg.async_tdm_scatter %tensorDesc[%row_indices, %c0_i32] from %memDesc : tensor<8xi32>, !ttg.memdesc<8x64xf16, #shared_scatter_32, #smem_scatter, mutable> -> !tt.tensordesc<8x64xf16>
+    amdg.async_tdm_scatter %tensorDesc[%row_indices] from %memDesc : tensor<8xi32>, !ttg.memdesc<8x64xf16, #shared_scatter_32, #smem_scatter, mutable> -> !tt.tensordesc<8x64xf16>
     tt.return
   }
 
@@ -338,7 +338,7 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.targ
   ) {
     %c0_i32 = arith.constant 0 : i32
     // expected-error @+1 {{TDM scatter only supports single interval paddings}}
-    amdg.async_tdm_scatter %tensorDesc[%row_indices, %c0_i32] from %memDesc : tensor<8xi32>, !ttg.memdesc<8x64xf16, #shared_scatter_2_intervals, #smem_scatter, mutable> -> !tt.tensordesc<8x64xf16>
+    amdg.async_tdm_scatter %tensorDesc[%row_indices] from %memDesc : tensor<8xi32>, !ttg.memdesc<8x64xf16, #shared_scatter_2_intervals, #smem_scatter, mutable> -> !tt.tensordesc<8x64xf16>
     tt.return
   }
 }
@@ -566,7 +566,7 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.targ
   ) {
     %c0_i32 = arith.constant 0 : i32
     // expected-error @+1 {{is inconsistent with the shared memory allocation layout}}
-    amdg.async_tdm_scatter %tensorDesc[%row_indices, %c0_i32] from %memDesc : tensor<8xi32>, !ttg.memdesc<8x64xf16, #scatter_alloc, #smem, mutable> -> !tt.tensordesc<8x64xf16, #scatter_desc>
+    amdg.async_tdm_scatter %tensorDesc[%row_indices] from %memDesc : tensor<8xi32>, !ttg.memdesc<8x64xf16, #scatter_alloc, #smem, mutable> -> !tt.tensordesc<8x64xf16, #scatter_desc>
     tt.return
   }
 }
@@ -587,7 +587,7 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.targ
   ) {
     %c0_i32 = arith.constant 0 : i32
     // expected-error @+1 {{is inconsistent with the shared memory allocation layout}}
-    %token = amdg.async_tdm_gather %tensorDesc[%row_indices, %c0_i32] to %memDesc, pred = %pred : tensor<8xi32>, !ttg.memdesc<8x64xf16, #gather_alloc, #smem, mutable> -> !tt.tensordesc<8x64xf16, #gather_desc>
+    %token = amdg.async_tdm_gather %tensorDesc[%row_indices] to %memDesc : tensor<8xi32>, !ttg.memdesc<8x64xf16, #gather_alloc, #smem, mutable> -> !tt.tensordesc<8x64xf16, #gather_desc>
     tt.return
   }
 }

--- a/third_party/amd/include/Dialect/TritonAMDGPU/IR/TritonAMDGPUOps.td
+++ b/third_party/amd/include/Dialect/TritonAMDGPU/IR/TritonAMDGPUOps.td
@@ -860,21 +860,21 @@ def AsyncTDMScatterOp : TT_AMDGPU_Op<"async_tdm_scatter", [
     - I32: 32-bit indices, up to 8 rows per instruction
     If more rows are needed, multiple TDM instructions will be issued.
 
-    The dst_col_offset specifies the starting column in the destination tensor for
-    all scattered rows.
+    The descriptor must be positioned beforehand by amdg.update_tensor_descriptor
+    (global offset / column via add_offsets, bounds); this op only supplies the
+    per-instruction row slices (dst_row_indices) and the LDS source.
   }];
 
   let arguments = (ins
     Arg<TT_TensorDescType, "", [MemWrite<GlobalMemory>]>:$desc,
     TensorOf<[I16, I32]>:$dst_row_indices,
-    I32:$dst_col_offset,
     Arg<TTG_MemDescType, "", [MemRead<SharedMemory>]>:$src,
     Arg<Optional<TTG_MemDescType>, "", [MemWrite<SharedMemory>]>:$barrier
   );
   let results = (outs TTG_AsyncToken:$retToken);
 
   let assemblyFormat = [{
-    $desc `[` $dst_row_indices `,` $dst_col_offset `]` `from` $src (`,` `barrier` `=` $barrier^)?
+    $desc `[` $dst_row_indices `]` `from` $src (`,` `barrier` `=` $barrier^)?
     attr-dict `:` qualified(type($dst_row_indices)) `,` qualified(type($src)) (`,` qualified(type($barrier))^)? `->` qualified(type($desc))
   }];
 
@@ -887,7 +887,6 @@ def AsyncTDMScatterOp : TT_AMDGPU_Op<"async_tdm_scatter", [
 
 def AsyncTDMGatherOp : TT_AMDGPU_Op<"async_tdm_gather", [
     DeclareOpInterfaceMethods<MBarrierOpInterface>,
-    DeclareOpInterfaceMethods<PredicatedOpInterface>,
     DeclareOpInterfaceMethods<TDMOpInterface>]> {
   let summary = "Gather data from non-contiguous global memory rows to local memory asynchronously";
 
@@ -903,28 +902,28 @@ def AsyncTDMGatherOp : TT_AMDGPU_Op<"async_tdm_gather", [
     - I32: 32-bit indices, up to 8 rows per instruction
     If more rows are needed, multiple TDM instructions will be issued.
 
-    The src_col_offset specifies the starting column in the source tensor for
-    all gathered rows.
+    The descriptor must be positioned beforehand by amdg.update_tensor_descriptor
+    (global offset / column via add_offsets, bounds, pred); this op only supplies the
+    per-instruction row slices (src_row_indices) and the LDS destination, and inherits
+    `pred` from the descriptor.
   }];
 
   let arguments = (ins
     Arg<TT_TensorDescType, "", [MemRead<GlobalMemory>]>:$desc,
     TensorOf<[I16, I32]>:$src_row_indices,
-    I32:$src_col_offset,
     Arg<TTG_MemDescType, "", [MemWrite<SharedMemory>]>:$dst,
-    I32:$pred,
     Arg<Optional<TTG_MemDescType>, "", [MemWrite<SharedMemory>]>:$barrier
   );
   let results = (outs TTG_AsyncToken:$token);
 
   let builders = [
-    OpBuilder<(ins "Value":$desc, "Value":$src_row_indices, "Value":$src_col_offset, "Value":$dst, "Value":$pred), [{
-      return build($_builder, $_state, desc, src_row_indices, src_col_offset, dst, pred, /*barrier=*/static_cast<mlir::Value>(nullptr));
+    OpBuilder<(ins "Value":$desc, "Value":$src_row_indices, "Value":$dst), [{
+      return build($_builder, $_state, desc, src_row_indices, dst, /*barrier=*/static_cast<mlir::Value>(nullptr));
     }]>
   ];
 
   let assemblyFormat = [{
-    $desc `[` $src_row_indices `,` $src_col_offset `]` `to` $dst `,` `pred` `=` $pred (`,` `barrier` `=` $barrier^)?
+    $desc `[` $src_row_indices `]` `to` $dst (`,` `barrier` `=` $barrier^)?
     attr-dict `:` qualified(type($src_row_indices)) `,` qualified(type($dst)) (`,` qualified(type($barrier))^)? `->` qualified(type($desc))
   }];
 

--- a/third_party/amd/lib/Dialect/TritonAMDGPU/IR/Dialect.cpp
+++ b/third_party/amd/lib/Dialect/TritonAMDGPU/IR/Dialect.cpp
@@ -1130,14 +1130,6 @@ Type AsyncCopyLocalToGlobalOp::getPredicateOperandTypeLike() {
   return getDst().getType();
 }
 
-Value AsyncTDMGatherOp::getPredicateOperand() { return getPred(); }
-void AsyncTDMGatherOp::setPredicateOperand(Value pred) {
-  getPredMutable().assign(pred);
-}
-Type AsyncTDMGatherOp::getPredicateOperandTypeLike() {
-  return getPred().getType();
-}
-
 Value TDMPrefetchOp::getPredicateOperand() { return getPred(); }
 void TDMPrefetchOp::setPredicateOperand(Value pred) {
   getPredMutable().assign(pred);

--- a/third_party/amd/lib/TritonAMDGPUToLLVM/LoadStoreOpToLLVM.cpp
+++ b/third_party/amd/lib/TritonAMDGPUToLLVM/LoadStoreOpToLLVM.cpp
@@ -1489,9 +1489,6 @@ struct AsyncTDMScatterOpConversion
 
     auto shapePerCTA = triton::gpu::getShapePerCTA(smemTy);
 
-    // Get the destination column offset
-    Value dstColOffset = adaptor.getDstColOffset();
-
     auto dstRowIndicesType =
         cast<RankedTensorType>(op.getDstRowIndices().getType());
 
@@ -1520,13 +1517,12 @@ struct AsyncTDMScatterOpConversion
     auto ctaId = targetInfo.getClusterCTAId(rewriter, loc);
     int numWarps = triton::gpu::lookupNumWarps(op);
 
-    // Predicate must be i32 (not i1) to match other elements in group0
-    Value pred = arith::ConstantIntOp::create(rewriter, loc, 1, 32);
-    mlir::LLVM::AMD::emitTDMGatherScatter(
-        rewriter, loc, getTypeConverter(), desc, shapePerCTA, padInterval,
-        padAmount, srcPtr, pred, /*multicastMask=*/{}, elementType, barrierPtr,
-        cgaLayout, ctaId, dstRowIndices, dstColOffset,
-        /*isGather=*/false, numWarps, dstRowIndicesType);
+    if (failed(mlir::LLVM::AMD::emitTDMGatherScatter(
+            rewriter, loc, getTypeConverter(), desc, shapePerCTA, padInterval,
+            padAmount, srcPtr, /*multicastMask=*/{}, elementType, barrierPtr,
+            cgaLayout, ctaId, dstRowIndices,
+            /*isGather=*/false, numWarps, dstRowIndicesType)))
+      return failure();
 
     rewriter.eraseOp(op);
     return success();
@@ -1586,9 +1582,6 @@ struct AsyncTDMGatherOpConversion
 
     auto shapePerCTA = triton::gpu::getShapePerCTA(smemTy);
 
-    // Get the source column offset
-    Value srcColOffset = adaptor.getSrcColOffset();
-
     auto srcRowIndicesType =
         cast<RankedTensorType>(op.getSrcRowIndices().getType());
 
@@ -1620,11 +1613,12 @@ struct AsyncTDMGatherOpConversion
           LLVM::AMD::emitCtaMulticastMask(rewriter, loc, ctaId, sharedLayout);
     }
 
-    mlir::LLVM::AMD::emitTDMGatherScatter(
-        rewriter, loc, getTypeConverter(), desc, shapePerCTA, padInterval,
-        padAmount, dstPtr, op.getPred(), multicastMask, elementType, barrierPtr,
-        cgaLayout, ctaId, srcRowIndices, srcColOffset,
-        /*isGather=*/true, numWarps, srcRowIndicesType);
+    if (failed(mlir::LLVM::AMD::emitTDMGatherScatter(
+            rewriter, loc, getTypeConverter(), desc, shapePerCTA, padInterval,
+            padAmount, dstPtr, multicastMask, elementType, barrierPtr,
+            cgaLayout, ctaId, srcRowIndices,
+            /*isGather=*/true, numWarps, srcRowIndicesType)))
+      return failure();
 
     rewriter.eraseOp(op);
     return success();

--- a/third_party/amd/lib/TritonAMDGPUToLLVM/TDMUtility.cpp
+++ b/third_party/amd/lib/TritonAMDGPUToLLVM/TDMUtility.cpp
@@ -1009,9 +1009,8 @@ void fillTDMDescriptorForGatherScatter(
     const LLVMTypeConverter *typeConverter, Type elementType,
     SmallVector<int64_t> blockShape, unsigned padInterval, unsigned padAmount,
     Value &group0, Value &group1, Value &group2, Value &group3,
-    Value ldsRowOffset, Value globalColOffset, Value ldsPtr, Value pred,
-    Value multicastMask, Value barrierPtr,
-    const triton::LinearLayout &cgaLayout, Value ctaId,
+    Value ldsRowOffset, Value ldsPtr, Value pred, Value multicastMask,
+    Value barrierPtr, const triton::LinearLayout &cgaLayout, Value ctaId,
     ArrayRef<Value> rowIndices, bool use32BitIndices, bool isGather) {
   assert(!rowIndices.empty() && "Gather/scatter requires row indices.");
 
@@ -1037,11 +1036,6 @@ void fillTDMDescriptorForGatherScatter(
   Value cgaColOffset = b.mul(b.zext(i64_ty, cgaColOffsetElem), tensorStride[1]);
   globalPtr = b.gep(globalPtrTy, elementType, globalPtr, cgaColOffset);
 
-  // For scatter, only apply column offset to global address
-  // Row positions are specified by rowIndices
-  Value colOffset = b.mul(b.zext(i64_ty, globalColOffset), tensorStride[1]);
-  globalPtr = b.gep(globalPtrTy, elementType, globalPtr, colOffset);
-
   // Calculate LDS offset based on row offset only (column always starts at 0)
   Value ldsOffset = b.mul(ldsRowOffset, b.i32_val(blockShape[1]));
 
@@ -1054,10 +1048,9 @@ void fillTDMDescriptorForGatherScatter(
   }
   ldsPtr = b.gep(sharedPtrTy, elementType, ldsPtr, ldsOffset);
 
-  // Adjust column tensor shape for OOB handling - subtract the full column
-  // offset so each CTA slice gets the correct remaining extent.
-  Value totalColOffset = b.add(cgaColOffsetElem, globalColOffset);
-  tensorShape[1] = clampTensorDimByOffset(b, tensorShape[1], totalColOffset);
+  // tensorShape[1] is the OOB extent carried by the descriptor (set once via
+  // update_tensor_descriptor set_bounds / clamp_bounds, like the contiguous
+  // copy).  No per-call column clamp here.
 
   // For scatter with padding (store-from-LDS): clamp tensor_dim0 to the
   // original column width so OOB checking drops padding elements before they
@@ -1366,20 +1359,20 @@ size_t getTDMGatherScatterInstrinsicCount(RankedTensorType indicesType) {
   return analyzeGatherScatterLayout(indicesType).numInstructions;
 }
 
-void emitTDMGatherScatter(RewriterBase &rewriter, Location loc,
-                          const LLVMTypeConverter *typeConverter,
-                          ArrayRef<Value> desc, ArrayRef<int64_t> blockShape,
-                          unsigned padInterval, unsigned padAmount,
-                          Value ldsPtr, Value pred, Value multicastMask,
-                          Type elementType, Value barrierPtr,
-                          const triton::LinearLayout &cgaLayout, Value ctaId,
-                          ArrayRef<Value> rowIndices, Value colOffset,
-                          bool isGather, int numWarps,
-                          RankedTensorType indicesType) {
+LogicalResult
+emitTDMGatherScatter(RewriterBase &rewriter, Location loc,
+                     const LLVMTypeConverter *typeConverter,
+                     ArrayRef<Value> desc, ArrayRef<int64_t> blockShape,
+                     unsigned padInterval, unsigned padAmount, Value ldsPtr,
+                     Value multicastMask, Type elementType, Value barrierPtr,
+                     const triton::LinearLayout &cgaLayout, Value ctaId,
+                     ArrayRef<Value> rowIndices, bool isGather, int numWarps,
+                     RankedTensorType indicesType) {
   auto b = TritonLLVMOpBuilder(loc, rewriter);
 
   assert(!rowIndices.empty() && "Gather/scatter requires row indices");
-  assert(colOffset && "Gather/scatter requires column offset");
+
+  Value pred = vecGet(b, desc[0], 0);
 
   bool use32BitIndices =
       indicesType.getElementType().getIntOrFloatBitWidth() == 32;
@@ -1465,8 +1458,8 @@ void emitTDMGatherScatter(RewriterBase &rewriter, Location loc,
 
     fillTDMDescriptorForGatherScatter(
         rewriter, loc, typeConverter, elementType, to_vector(blockShape),
-        padInterval, padAmount, g0, g1, g2, g3, ldsRowOffset, colOffset, ldsPtr,
-        pred, multicastMask, barrierPtr, cgaLayout, ctaId, batchIndices,
+        padInterval, padAmount, g0, g1, g2, g3, ldsRowOffset, ldsPtr, pred,
+        multicastMask, barrierPtr, cgaLayout, ctaId, batchIndices,
         use32BitIndices, isGather);
 
     auto v8i32Ty = VectorType::get(8, rewriter.getI32Type());
@@ -1477,6 +1470,7 @@ void emitTDMGatherScatter(RewriterBase &rewriter, Location loc,
     LLVM::createLLVMIntrinsicCallOp(rewriter, loc, intrinsicName, {},
                                     {g0, g1, g2, g3, group4Zero, b.i32_val(0)});
   }
+  return success();
 }
 
 SmallVector<Value> emitTDMPrefetch(RewriterBase &rewriter, Location loc,

--- a/third_party/amd/lib/TritonAMDGPUToLLVM/TDMUtility.h
+++ b/third_party/amd/lib/TritonAMDGPUToLLVM/TDMUtility.h
@@ -91,7 +91,6 @@ void fillTDMDescriptor(RewriterBase &rewriter, Location loc,
 // Scatter writes from LDS to non-contiguous rows in global memory.
 // - rowIndices: which global rows to read from (gather) or write to (scatter)
 // - ldsRowOffset: starting row within shared memory
-// - globalColOffset: starting column in global memory
 // - use32BitIndices: true for 32-bit indices (max 8 rows), false for 16-bit
 // (max 16 rows)
 void fillTDMDescriptorForGatherScatter(
@@ -99,9 +98,8 @@ void fillTDMDescriptorForGatherScatter(
     const LLVMTypeConverter *typeConverter, Type elementType,
     SmallVector<int64_t> blockShape, unsigned padInterval, unsigned padAmount,
     Value &group0, Value &group1, Value &group2, Value &group3,
-    Value ldsRowOffset, Value globalColOffset, Value ldsPtr, Value pred,
-    Value multicastMask, Value barrierPtr,
-    const triton::LinearLayout &cgaLayout, Value ctaId,
+    Value ldsRowOffset, Value ldsPtr, Value pred, Value multicastMask,
+    Value barrierPtr, const triton::LinearLayout &cgaLayout, Value ctaId,
     ArrayRef<Value> rowIndices, bool use32BitIndices, bool isGather);
 
 // Emit a TDM load/store for regular contiguous transfers (1D-5D).
@@ -147,16 +145,15 @@ size_t getTDMGatherScatterInstrinsicCount(RankedTensorType indicesType);
 //   whether indices are 32-bit or 16-bit, detect redundant warps (via
 //   getFreeVariableMasks), and compute per-warp LDS offsets.
 // Multiple TDM instructions are issued automatically if more rows are needed.
-void emitTDMGatherScatter(RewriterBase &rewriter, Location loc,
-                          const LLVMTypeConverter *typeConverter,
-                          ArrayRef<Value> desc, ArrayRef<int64_t> blockShape,
-                          unsigned padInterval, unsigned padAmount,
-                          Value ldsPtr, Value pred, Value multicastMask,
-                          Type elementType, Value barrierPtr,
-                          const triton::LinearLayout &cgaLayout, Value ctaId,
-                          ArrayRef<Value> rowIndices, Value colOffset,
-                          bool isGather, int numWarps,
-                          RankedTensorType indicesType);
+LogicalResult
+emitTDMGatherScatter(RewriterBase &rewriter, Location loc,
+                     const LLVMTypeConverter *typeConverter,
+                     ArrayRef<Value> desc, ArrayRef<int64_t> blockShape,
+                     unsigned padInterval, unsigned padAmount, Value ldsPtr,
+                     Value multicastMask, Type elementType, Value barrierPtr,
+                     const triton::LinearLayout &cgaLayout, Value ctaId,
+                     ArrayRef<Value> rowIndices, bool isGather, int numWarps,
+                     RankedTensorType indicesType);
 
 // Emit prefetches for a TDM tile to make it available for an actual load in
 // the future. Data is prefetched cooperatively across all CTAs, warps, and

--- a/third_party/amd/lib/TritonAMDGPUTransforms/ConvertToTensorOps.cpp
+++ b/third_party/amd/lib/TritonAMDGPUTransforms/ConvertToTensorOps.cpp
@@ -90,9 +90,11 @@ struct TensorGatherLowering : public OpRewritePattern<DescriptorGatherOp> {
                          encoding, sharedMemorySpace, /*mutableMemory=*/true);
     Value alloc = LocalAllocOp::create(rewriter, loc, memDescType);
     Value pred = arith::ConstantIntOp::create(rewriter, loc, 1, 32);
+    Value zero = arith::ConstantIntOp::create(rewriter, loc, 0, 32);
 
-    amdgpu::AsyncTDMGatherOp::create(rewriter, loc, op.getDesc(), indices,
-                                     op.getYOffset(), alloc, pred);
+    Value gatherDesc = createUpdateTDMDescriptorOp(
+        rewriter, loc, op.getDesc(), {zero, op.getYOffset()}, pred);
+    amdgpu::AsyncTDMGatherOp::create(rewriter, loc, gatherDesc, indices, alloc);
     amdgpu::AsyncTDMWait::create(rewriter, loc, ArrayRef<Value>{}, 0);
     rewriter.replaceOpWithNewOp<LocalLoadOp>(op, op.getType(), alloc);
     return success();
@@ -167,8 +169,12 @@ struct TensorScatterLowering : public OpRewritePattern<DescriptorScatterOp> {
         MemDescType::get(tensorType.getShape(), tensorType.getElementType(),
                          encoding, sharedMemorySpace, /*mutableMemory=*/true);
     Value alloc = LocalAllocOp::create(rewriter, loc, memDescType, src);
-    amdgpu::AsyncTDMScatterOp::create(rewriter, loc, op.getDesc(), indices,
-                                      op.getYOffset(), alloc,
+    Value zero = arith::ConstantIntOp::create(rewriter, loc, 0, 32);
+
+    Value scatterDesc = createUpdateTDMDescriptorOp(
+        rewriter, loc, op.getDesc(), {zero, op.getYOffset()}, /*pred=*/Value{});
+    amdgpu::AsyncTDMScatterOp::create(rewriter, loc, scatterDesc, indices,
+                                      alloc,
                                       /*barrier=*/Value{});
     amdgpu::AsyncTDMWait::create(rewriter, loc, ArrayRef<Value>{}, 0);
     rewriter.eraseOp(op);

--- a/third_party/amd/lib/TritonAMDGPUTransforms/LowerLoops.cpp
+++ b/third_party/amd/lib/TritonAMDGPUTransforms/LowerLoops.cpp
@@ -109,9 +109,12 @@ TDMChainOps createTDMAsyncGather(tt::DescriptorGatherOp gatherOp, Value alloc,
           indices =
               ttg::ConvertLayoutOp::create(builder, loc, newIdxType, indices);
         }
-        return triton::amdgpu::AsyncTDMGatherOp::create(
-            builder, loc, gatherOp.getDesc(), indices, gatherOp.getYOffset(),
-            view, pred);
+        Value zero = arith::ConstantIntOp::create(builder, loc, 0, 32);
+        Value desc = createUpdateTDMDescriptorOp(
+            builder, loc, gatherOp.getDesc(), {zero, gatherOp.getYOffset()},
+            /*pred=*/pred);
+        return triton::amdgpu::AsyncTDMGatherOp::create(builder, loc, desc,
+                                                        indices, view);
       });
 }
 

--- a/third_party/amd/lib/TritonAMDGPUTransforms/Pipeline.cpp
+++ b/third_party/amd/lib/TritonAMDGPUTransforms/Pipeline.cpp
@@ -65,15 +65,18 @@ Operation *streamPredication(RewriterBase &rewriter, Operation *op,
     copyOp.getDescMutable().assign(updated.getResult());
     return op;
   }
+  // Pure gather inherits pred from its descriptor; gate it the same way as the
+  // copy by chaining a pred-only update_tensor_descriptor onto its descriptor.
   if (auto gatherOp = dyn_cast<triton::amdgpu::AsyncTDMGatherOp>(op)) {
-    auto predicatedOp = cast<tt::PredicatedOpInterface>(op);
     rewriter.setInsertionPoint(op);
-    auto predI32 = arith::ExtUIOp::create(
-        rewriter, op->getLoc(), predicatedOp.getPredicateOperand().getType(),
-        pred);
-    Value mask = arith::AndIOp::create(
-        rewriter, op->getLoc(), predicatedOp.getPredicateOperand(), predI32);
-    predicatedOp.setPredicateOperand(mask);
+    auto predI32 = arith::ExtUIOp::create(rewriter, op->getLoc(),
+                                          rewriter.getI32Type(), pred);
+    auto updated = triton::amdgpu::UpdateTensorDescriptorOp::create(
+        rewriter, op->getLoc(), gatherOp.getDesc().getType(),
+        gatherOp.getDesc(),
+        /*add_offsets=*/ValueRange{}, /*set_bounds=*/ValueRange{},
+        /*pred=*/predI32);
+    gatherOp.getDescMutable().assign(updated.getResult());
     return op;
   }
   if (isa<triton::amdgpu::AsyncTDMWait>(op))

--- a/third_party/amd/python/examples/gluon/moe_gfx1250.py
+++ b/third_party/amd/python/examples/gluon/moe_gfx1250.py
@@ -342,8 +342,9 @@ class MoEProgramBase:
 
         if cfg.USE_GATHER:
             col_offset_x = self.off_k_x + load_idx * BLOCK_K_PACKED_X
-            tdm.async_gather(self.x_desc, self.gathered_m, col_offset_x,
-                             self.x_buffer.index(load_idx % cfg.NUM_BUFFERS), pred=pred)
+            x_desc_k = tdm.update_tensor_descriptor(self.x_desc, add_offsets=[0, col_offset_x], pred=pred,
+                                                    clamp_bounds=True)
+            tdm.async_gather(x_desc_k, self.gathered_m, self.x_buffer.index(load_idx % cfg.NUM_BUFFERS))
         else:
             tdm.async_load(self.x_desc, [0, load_idx * BLOCK_K_PACKED_X],
                            self.x_buffer.index(load_idx % cfg.NUM_BUFFERS), pred=pred)
@@ -358,8 +359,9 @@ class MoEProgramBase:
         if cfg.WITH_X_MX_SCALE:
             if cfg.USE_GATHER:
                 col_offset_x_scale = self.off_k_x * cfg.DIV_FACTOR_X // cfg.SCALE_BLOCK + load_idx * BLOCK_K_SCALE
-                tdm.async_gather(self.x_scale_desc, self.gathered_m, col_offset_x_scale,
-                                 self.x_scale_buffer.index(load_idx % cfg.NUM_BUFFERS), pred=pred)
+                x_scale_desc_k = tdm.update_tensor_descriptor(self.x_scale_desc, add_offsets=[0, col_offset_x_scale],
+                                                              pred=pred, clamp_bounds=True)
+                tdm.async_gather(x_scale_desc_k, self.gathered_m, self.x_scale_buffer.index(load_idx % cfg.NUM_BUFFERS))
             else:
                 tdm.async_load(self.x_scale_desc, [0, load_idx * cfg.BLOCK_K_SCALE_PRESHUFFLED],
                                self.x_scale_buffer.index(load_idx % cfg.NUM_BUFFERS), pred=pred)
@@ -822,8 +824,9 @@ class MoESliceNKProgram:
 
         if cfg.USE_GATHER:
             col_offset_x = self.off_k_x + load_idx * BLOCK_K_PACKED_X
-            tdm.async_gather(self.x_desc, self.gathered_m, col_offset_x,
-                             self.x_buffer.index(load_idx % cfg.NUM_BUFFERS), pred=pred)
+            x_desc_k = tdm.update_tensor_descriptor(self.x_desc, add_offsets=[0, col_offset_x], pred=pred,
+                                                    clamp_bounds=True)
+            tdm.async_gather(x_desc_k, self.gathered_m, self.x_buffer.index(load_idx % cfg.NUM_BUFFERS))
         else:
             tdm.async_load(self.x_desc, [0, load_idx * BLOCK_K_PACKED_X],
                            self.x_buffer.index(load_idx % cfg.NUM_BUFFERS), pred=pred)
@@ -831,8 +834,9 @@ class MoESliceNKProgram:
         if cfg.WITH_X_MX_SCALE:
             if cfg.USE_GATHER:
                 col_offset_x_scale = self.off_k_x * cfg.DIV_FACTOR_X // cfg.SCALE_BLOCK + load_idx * BLOCK_K_SCALE
-                tdm.async_gather(self.x_scale_desc, self.gathered_m, col_offset_x_scale,
-                                 self.x_scale_buffer.index(load_idx % cfg.NUM_BUFFERS), pred=pred)
+                x_scale_desc_k = tdm.update_tensor_descriptor(self.x_scale_desc, add_offsets=[0, col_offset_x_scale],
+                                                              pred=pred, clamp_bounds=True)
+                tdm.async_gather(x_scale_desc_k, self.gathered_m, self.x_scale_buffer.index(load_idx % cfg.NUM_BUFFERS))
             else:
                 tdm.async_load(self.x_scale_desc, [0, load_idx * cfg.BLOCK_K_SCALE_PRESHUFFLED],
                                self.x_scale_buffer.index(load_idx % cfg.NUM_BUFFERS), pred=pred)
@@ -1170,7 +1174,8 @@ def _matmul(Y, stride_y_k, stride_y_z, stride_y_m, stride_y_n, X, stride_x_z, st
                                             block_shape=(BLOCK_M, OUT_BLOCK_N), layout=SCATTER_SHARED_LAYOUT)
 
         col_offset = (OUT_BLOCK_N * pid_n).to(cfg.index_type)
-        tdm.async_scatter(y_desc, dst_row_indices, col_offset, out_smem)
+        y_desc = tdm.update_tensor_descriptor(y_desc, add_offsets=[0, col_offset], clamp_bounds=True)
+        tdm.async_scatter(y_desc, dst_row_indices, out_smem)
         tdm.async_wait(0)
     else:
         offs_y_m = off_m + gl.arange(0, BLOCK_M, gl.SliceLayout(1, BLOCKED_LAYOUT_Y))

--- a/third_party/amd/python/test/test_gluon_gfx1250.py
+++ b/third_party/amd/python/test/test_gluon_gfx1250.py
@@ -3648,7 +3648,9 @@ def tdm_scatter_kernel(inp_ptr, out_ptr, dst_row_indices_ptr, M_out, N_out, stri
     dst_row_indices = ttgl.load(dst_row_indices_ptr + idx_offs)
 
     # Scatter the data to non-contiguous rows starting at DST_COL_OFFSET
-    ttgl.amd.gfx1250.tdm.async_scatter(out_desc, dst_row_indices, DST_COL_OFFSET, smem)
+    out_desc = ttgl.amd.gfx1250.tdm.update_tensor_descriptor(out_desc, add_offsets=[0, DST_COL_OFFSET],
+                                                             clamp_bounds=True)
+    ttgl.amd.gfx1250.tdm.async_scatter(out_desc, dst_row_indices, smem)
     ttgl.amd.gfx1250.tdm.async_wait(0)
 
 
@@ -3893,7 +3895,8 @@ def tdm_scatter_multi_col_kernel(inp_ptr, out_ptr, dst_row_indices_ptr, M, N, st
     dst_row_indices = ttgl.load(dst_row_indices_ptr + pid_m * BLOCK_M + idx_offs, mask=idx_mask, other=M)
 
     col_offset = pid_n * BLOCK_N
-    ttgl.amd.gfx1250.tdm.async_scatter(out_desc, dst_row_indices, col_offset, smem)
+    out_desc = ttgl.amd.gfx1250.tdm.update_tensor_descriptor(out_desc, add_offsets=[0, col_offset], clamp_bounds=True)
+    ttgl.amd.gfx1250.tdm.async_scatter(out_desc, dst_row_indices, smem)
     ttgl.amd.gfx1250.tdm.async_wait(0)
 
 
@@ -3953,7 +3956,9 @@ def _tdm_scatter_padded_kernel(inp_ptr, out_ptr, dst_row_indices_ptr, M_out, N_o
     idx_offs = ttgl.arange(0, NUM_INDICES, layout=IDX_LAYOUT)
     dst_row_indices = ttgl.load(dst_row_indices_ptr + idx_offs)
 
-    ttgl.amd.gfx1250.tdm.async_scatter(out_desc, dst_row_indices, DST_COL_OFFSET, smem)
+    out_desc = ttgl.amd.gfx1250.tdm.update_tensor_descriptor(out_desc, add_offsets=[0, DST_COL_OFFSET],
+                                                             clamp_bounds=True)
+    ttgl.amd.gfx1250.tdm.async_scatter(out_desc, dst_row_indices, smem)
     ttgl.amd.gfx1250.tdm.async_wait(0)
 
 
@@ -4027,8 +4032,9 @@ def tdm_gather_kernel(inp_ptr, out_ptr, src_row_indices_ptr, M_inp, N_inp, strid
     idx_offs = ttgl.arange(0, NUM_INDICES, layout=IDX_LAYOUT)
     src_row_indices = ttgl.load(src_row_indices_ptr + idx_offs)
 
-    # Gather data from non-contiguous rows starting at SRC_COL_OFFSET
-    ttgl.amd.gfx1250.tdm.async_gather(inp_desc, src_row_indices, SRC_COL_OFFSET, smem)
+    inp_desc = ttgl.amd.gfx1250.tdm.update_tensor_descriptor(inp_desc, add_offsets=[0, SRC_COL_OFFSET],
+                                                             clamp_bounds=True)
+    ttgl.amd.gfx1250.tdm.async_gather(inp_desc, src_row_indices, smem)
     ttgl.amd.gfx1250.tdm.async_wait(0)
 
     # Store gathered data to output using TDM
@@ -4051,7 +4057,7 @@ def tdm_gather_multi_cta_kernel(inp_ptr, out_ptr, src_row_indices_ptr, M_inp, N_
     idx_offs = ttgl.arange(0, BLOCK_M, layout=IDX_LAYOUT)
     src_row_indices = ttgl.load(src_row_indices_ptr + idx_offs)
 
-    ttgl.amd.gfx1250.tdm.async_gather(inp_desc, src_row_indices, SRC_COL_OFFSET, smem)
+    ttgl.amd.gfx1250.tdm.async_gather(inp_desc, src_row_indices, smem)
     ttgl.amd.gfx1250.tdm.async_wait(0)
 
     gathered = smem.load(layout=BLOCK_LAYOUT)
@@ -4396,7 +4402,8 @@ def tdm_gather_multi_col_kernel(inp_ptr, out_ptr, src_row_indices_ptr, M, N, str
     src_row_indices = ttgl.load(src_row_indices_ptr + pid_m * BLOCK_M + idx_offs, mask=idx_mask, other=M)
 
     col_offset = pid_n * BLOCK_N
-    ttgl.amd.gfx1250.tdm.async_gather(inp_desc, src_row_indices, col_offset, smem)
+    inp_desc = ttgl.amd.gfx1250.tdm.update_tensor_descriptor(inp_desc, add_offsets=[0, col_offset], clamp_bounds=True)
+    ttgl.amd.gfx1250.tdm.async_gather(inp_desc, src_row_indices, smem)
     ttgl.amd.gfx1250.tdm.async_wait(0)
 
     out_desc = ttgl.amd.gfx1250.tdm.make_tensor_descriptor(base=out_ptr, shape=(M, N), strides=(stride_m, 1),
@@ -4425,7 +4432,9 @@ def _tdm_gather_layout_kernel(inp_ptr, out_ptr, src_row_indices_ptr, M_inp, N_in
     idx_offs = ttgl.arange(0, NUM_INDICES, layout=IDX_LAYOUT)
     src_row_indices = ttgl.load(src_row_indices_ptr + idx_offs)
 
-    ttgl.amd.gfx1250.tdm.async_gather(inp_desc, src_row_indices, SRC_COL_OFFSET, smem)
+    inp_desc = ttgl.amd.gfx1250.tdm.update_tensor_descriptor(inp_desc, add_offsets=[0, SRC_COL_OFFSET],
+                                                             clamp_bounds=True)
+    ttgl.amd.gfx1250.tdm.async_gather(inp_desc, src_row_indices, smem)
     ttgl.amd.gfx1250.tdm.async_wait(0)
 
     out_desc = ttgl.amd.gfx1250.tdm.make_tensor_descriptor(base=out_ptr, shape=(BLOCK_M, BLOCK_N), strides=(BLOCK_N, 1),
@@ -4547,7 +4556,9 @@ def _tdm_scatter_layout_kernel(inp_ptr, out_ptr, dst_row_indices_ptr, M_out, N_o
     idx_offs = ttgl.arange(0, NUM_INDICES, layout=IDX_LAYOUT)
     dst_row_indices = ttgl.load(dst_row_indices_ptr + idx_offs)
 
-    ttgl.amd.gfx1250.tdm.async_scatter(out_desc, dst_row_indices, DST_COL_OFFSET, smem)
+    out_desc = ttgl.amd.gfx1250.tdm.update_tensor_descriptor(out_desc, add_offsets=[0, DST_COL_OFFSET],
+                                                             clamp_bounds=True)
+    ttgl.amd.gfx1250.tdm.async_scatter(out_desc, dst_row_indices, smem)
     ttgl.amd.gfx1250.tdm.async_wait(0)
 
 


### PR DESCRIPTION
Mirror the pure async_tdm_copy pattern for gather/scatter: the data-movement op keeps only what is sliced/distributed across the lowered TDM intrinsics (row_indices + dst/src LDS); the uniform tensor-level state moves onto the descriptor via update_tensor_descriptor.

- async_tdm_gather: drop src_col_offset + pred (+ PredicatedOpInterface)
- async_tdm_scatter: drop dst_col_offset
- column now comes from the descriptor global_addr (add_offsets), pred from group0[0]; gather/scatter lowering reads them off the positioned descriptor
- desugar + pipeliners (ConvertToTensorOps, LowerLoops, Pipeline) position the descriptor with update_tensor_descriptor (clamp_bounds) and emit the pure op
- multicast is preserved: emitTDMGatherScatter keeps the multicastMask path and its LogicalResult contract; purification is orthogonal
- Gluon async_gather(desc, rows, dst) / async_scatter(desc, rows, src)
- migrate in-tree callers + tests (gfx1250 gather/scatter, multi-CTA, the frontend golden IR, the MoE example, and the triton->gluon translator)
