### PR TITLE
[AMD][gfx1250] TDM gather/scatter: reuse one descriptor across chunks to cut in-loop SALU

### DIFF
--- a/test/Conversion/amd/tritongpu_tdm_to_llvm.mlir
+++ b/test/Conversion/amd/tritongpu_tdm_to_llvm.mlir
@@ -403,3 +403,61 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.targ
     tt.return
   }
 }
+
+// -----
+
+// Multi-chunk gather: 16 row indices lower to two TDM instructions.  Chunk 1's
+// LDS address is chunk 0 + a compile-time-constant byte delta (8 rows * 64 cols
+// * 2 bytes = 1024), and both chunks insert it into the same chunk-invariant
+// base descriptor (group0).
+#blocked = #ttg.blocked<{sizePerThread = [16, 1], threadsPerWarp = [1, 32], warpsPerCTA = [1, 4], order = [1, 0]}>
+#slice = #ttg.slice<{dim = 1, parent = #blocked}>
+#shared = #ttg.swizzled_shared<{vec = 1, perPhase = 1, maxPhase = 1, order = [1, 0]}>
+#smem = #ttg.shared_memory
+module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.target = "hip:gfx1250", "ttg.threads-per-warp" = 32 : i32} {
+  // CHECK-LABEL: tdm_gather_multichunk
+  // CHECK-DAG: %[[DELTA:.*]] = llvm.mlir.constant(1024 : i32) : i32
+  // CHECK: %[[C0:.*]] = llvm.ptrtoint %{{.*}} : !llvm.ptr<3> to i32
+  // CHECK: llvm.insertelement %[[C0]], %[[G0:.*]][%{{.*}} : i32] : vector<4xi32>
+  // CHECK: "llvm.amdgcn.tensor.load.to.lds"
+  // CHECK: %[[C1:.*]] = llvm.add %[[C0]], %[[DELTA]] : i32
+  // CHECK: llvm.insertelement %[[C1]], %[[G0]][%{{.*}} : i32] : vector<4xi32>
+  // CHECK: "llvm.amdgcn.tensor.load.to.lds"
+  tt.func public @tdm_gather_multichunk(
+    %tensorDesc: !tt.tensordesc<16x64xf16, #shared>,
+    %memDesc: !ttg.memdesc<16x64xf16, #shared, #smem, mutable>,
+    %row_indices: tensor<16xi32, #slice>
+  ) {
+    amdg.async_tdm_gather %tensorDesc[%row_indices] to %memDesc : tensor<16xi32, #slice>, !ttg.memdesc<16x64xf16, #shared, #smem, mutable> -> !tt.tensordesc<16x64xf16, #shared>
+    tt.return
+  }
+}
+
+// -----
+
+// Padded multi-chunk gather: the chunk delta (8 rows) is a whole number of pad
+// intervals, so the byte delta carries the padding too --
+// (8*64 + (8*64/64)*4) * 2 bytes = 1088 -- and both chunks insert it into the
+// same chunk-invariant base descriptor (group0).
+#blocked = #ttg.blocked<{sizePerThread = [16, 1], threadsPerWarp = [1, 32], warpsPerCTA = [1, 4], order = [1, 0]}>
+#slice = #ttg.slice<{dim = 1, parent = #blocked}>
+#shared = #ttg.padded_shared<[64:+4] {order = [1, 0], shape = [16, 64]}>
+#smem = #ttg.shared_memory
+module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.target = "hip:gfx1250", "ttg.threads-per-warp" = 32 : i32} {
+  // CHECK-LABEL: tdm_gather_multichunk_padded
+  // CHECK-DAG: %[[DELTA:.*]] = llvm.mlir.constant(1088 : i32) : i32
+  // CHECK: %[[C0:.*]] = llvm.ptrtoint %{{.*}} : !llvm.ptr<3> to i32
+  // CHECK: llvm.insertelement %[[C0]], %[[G0:.*]][%{{.*}} : i32] : vector<4xi32>
+  // CHECK: "llvm.amdgcn.tensor.load.to.lds"
+  // CHECK: %[[C1:.*]] = llvm.add %[[C0]], %[[DELTA]] : i32
+  // CHECK: llvm.insertelement %[[C1]], %[[G0]][%{{.*}} : i32] : vector<4xi32>
+  // CHECK: "llvm.amdgcn.tensor.load.to.lds"
+  tt.func public @tdm_gather_multichunk_padded(
+    %tensorDesc: !tt.tensordesc<16x64xf16, #shared>,
+    %memDesc: !ttg.memdesc<16x64xf16, #shared, #smem, mutable>,
+    %row_indices: tensor<16xi32, #slice>
+  ) {
+    amdg.async_tdm_gather %tensorDesc[%row_indices] to %memDesc : tensor<16xi32, #slice>, !ttg.memdesc<16x64xf16, #shared, #smem, mutable> -> !tt.tensordesc<16x64xf16, #shared>
+    tt.return
+  }
+}

--- a/test/TritonGPU/amd/invalid.mlir
+++ b/test/TritonGPU/amd/invalid.mlir
@@ -294,6 +294,65 @@ module attributes {"ttg.num-ctas" = 4 : i32, "ttg.num-warps" = 1 : i32, ttg.targ
 
 // -----
 
+// Gather padding interval (128) does not divide the innermost block dimension
+// (64), so the chunk-relative lds_addr padding would not distribute.
+#blocked = #ttg.blocked<{sizePerThread = [16, 1], threadsPerWarp = [1, 32], warpsPerCTA = [1, 4], order = [1, 0]}>
+#slice = #ttg.slice<{dim = 1, parent = #blocked}>
+#shared = #ttg.padded_shared<[128:+4] {order = [1, 0], shape = [16, 64]}>
+#smem = #ttg.shared_memory
+module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.target = "hip:gfx1250", "ttg.threads-per-warp" = 32 : i32} {
+  tt.func @tdm_gather_invalid_padding_interval(
+    %tensorDesc: !tt.tensordesc<16x64xf16, #shared>,
+    %memDesc: !ttg.memdesc<16x64xf16, #shared, #smem, mutable>,
+    %row_indices: tensor<16xi32, #slice>
+  ) {
+    // expected-error @+1 {{TDM gather padding interval must divide the innermost block dimension}}
+    %token = amdg.async_tdm_gather %tensorDesc[%row_indices] to %memDesc : tensor<16xi32, #slice>, !ttg.memdesc<16x64xf16, #shared, #smem, mutable> -> !tt.tensordesc<16x64xf16, #shared>
+    tt.return
+  }
+}
+
+// -----
+
+// Gather of a sub-byte element type: the lds_addr byte-delta scaling truncates
+// to zero for <8-bit elements.
+#blocked = #ttg.blocked<{sizePerThread = [16, 1], threadsPerWarp = [1, 32], warpsPerCTA = [1, 4], order = [1, 0]}>
+#slice = #ttg.slice<{dim = 1, parent = #blocked}>
+#shared = #ttg.swizzled_shared<{vec = 1, perPhase = 1, maxPhase = 1, order = [1, 0]}>
+#smem = #ttg.shared_memory
+module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.target = "hip:gfx1250", "ttg.threads-per-warp" = 32 : i32} {
+  tt.func @tdm_gather_invalid_subbyte_element(
+    %tensorDesc: !tt.tensordesc<16x64xi4, #shared>,
+    %memDesc: !ttg.memdesc<16x64xi4, #shared, #smem, mutable>,
+    %row_indices: tensor<16xi32, #slice>
+  ) {
+    // expected-error @+1 {{TDM gather requires element types of at least 8 bits}}
+    %token = amdg.async_tdm_gather %tensorDesc[%row_indices] to %memDesc : tensor<16xi32, #slice>, !ttg.memdesc<16x64xi4, #shared, #smem, mutable> -> !tt.tensordesc<16x64xi4, #shared>
+    tt.return
+  }
+}
+
+// -----
+
+// Scatter of a sub-byte element type: same lds_addr byte-delta truncation.
+#blocked = #ttg.blocked<{sizePerThread = [16, 1], threadsPerWarp = [1, 32], warpsPerCTA = [1, 4], order = [1, 0]}>
+#slice = #ttg.slice<{dim = 1, parent = #blocked}>
+#shared = #ttg.swizzled_shared<{vec = 1, perPhase = 1, maxPhase = 1, order = [1, 0]}>
+#smem = #ttg.shared_memory
+module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.target = "hip:gfx1250", "ttg.threads-per-warp" = 32 : i32} {
+  tt.func @tdm_scatter_invalid_subbyte_element(
+    %tensorDesc: !tt.tensordesc<16x64xi4, #shared>,
+    %memDesc: !ttg.memdesc<16x64xi4, #shared, #smem, mutable>,
+    %row_indices: tensor<16xi32, #slice>
+  ) {
+    // expected-error @+1 {{TDM scatter requires element types of at least 8 bits}}
+    %token = amdg.async_tdm_scatter %tensorDesc[%row_indices] from %memDesc : tensor<16xi32, #slice>, !ttg.memdesc<16x64xi4, #shared, #smem, mutable> -> !tt.tensordesc<16x64xi4, #shared>
+    tt.return
+  }
+}
+
+// -----
+
 #blocked1 = #ttg.blocked<{sizePerThread = [16, 1], threadsPerWarp = [1, 32], warpsPerCTA = [1, 1], order = [1, 0], CGALayout = [[0, 0], [0, 0]]}>
 #slice1 = #ttg.slice<{dim = 1, parent = #blocked1}>
 #shared1 = #ttg.swizzled_shared<{vec = 1, perPhase = 1, maxPhase = 1, order = [1, 0], CGALayout = [[1, 0], [2, 0]]}>

--- a/third_party/amd/lib/Dialect/TritonAMDGPU/IR/Dialect.cpp
+++ b/third_party/amd/lib/Dialect/TritonAMDGPU/IR/Dialect.cpp
@@ -816,6 +816,9 @@ LogicalResult AsyncTDMScatterOp::verify() {
       !llvm::isa<gpu::SwizzledSharedEncodingAttr>(enc))
     return emitOpError("Invalid shared memory layout for TDM");
 
+  if (smemTy.getElementType().getIntOrFloatBitWidth() < 8)
+    return emitOpError("TDM scatter requires element types of at least 8 bits");
+
   auto dstRowIndicesType = cast<RankedTensorType>(getDstRowIndices().getType());
   if (dstRowIndicesType.getRank() != 1)
     return emitOpError("dst_row_indices must be a 1D tensor");
@@ -864,6 +867,9 @@ LogicalResult AsyncTDMGatherOp::verify() {
       !llvm::isa<gpu::SwizzledSharedEncodingAttr>(enc))
     return emitOpError("Invalid shared memory layout for TDM");
 
+  if (smemTy.getElementType().getIntOrFloatBitWidth() < 8)
+    return emitOpError("TDM gather requires element types of at least 8 bits");
+
   auto srcRowIndicesType = cast<RankedTensorType>(getSrcRowIndices().getType());
   if (srcRowIndicesType.getRank() != 1)
     return emitOpError("src_row_indices must be a 1D tensor");
@@ -877,10 +883,19 @@ LogicalResult AsyncTDMGatherOp::verify() {
            << numIndices;
 
   auto paddedEnc = llvm::dyn_cast<gpu::PaddedSharedEncodingAttr>(enc);
-  if (paddedEnc && !(paddedEnc.getIntervals().size() == 1 &&
-                     paddedEnc.getPaddings().size() == 1))
-    return emitOpError(
-        "TDM gather does not support multiple interval-padding pairs");
+  if (paddedEnc) {
+    if (!(paddedEnc.getIntervals().size() == 1 &&
+          paddedEnc.getPaddings().size() == 1))
+      return emitOpError(
+          "TDM gather does not support multiple interval-padding pairs");
+
+    if (blockShape.back() % paddedEnc.getIntervals()[0] != 0)
+      return emitOpError(
+                 "TDM gather padding interval must divide the innermost "
+                 "block dimension (got padInterval=")
+             << paddedEnc.getIntervals()[0]
+             << ", innermost dimension=" << blockShape.back() << ")";
+  }
 
   auto shapePerCTA = triton::gpu::getShapePerCTA(smemTy);
   auto sharedOrder = triton::gpu::getOrder(

--- a/third_party/amd/lib/TritonAMDGPUToLLVM/TDMUtility.cpp
+++ b/third_party/amd/lib/TritonAMDGPUToLLVM/TDMUtility.cpp
@@ -1478,9 +1478,11 @@ emitTDMGatherScatter(RewriterBase &rewriter, Location loc,
     } else {
       // chunk i's register-offset delta from chunk 0, evaluated at warp 0.
       // applyLinearLayout is linear in `register`, so the per-warp term cancels
-      // (LL(register=0) == 0) and the delta is a compile-time constant.  It
-      // must be addition-separable from the warp term, which holds for the
-      // row-strip-per-warp layouts gather/scatter emit.
+      // (LL(register=0) == 0) and the delta is a compile-time constant.  Adding
+      // it to chunk0's address (rather than XOR-ing, as applyLinearLayout
+      // would) is exact because the index layout is a permutation matrix
+      // (distributed / LinearEncodingAttr invariant): register and warp own
+      // disjoint output bits, so XOR == integer add for these layouts.
       int64_t rowDelta = indexLL
                              .apply({{kRegister, (int32_t)startIdx},
                                      {kLane, 0},

--- a/third_party/amd/lib/TritonAMDGPUToLLVM/TDMUtility.cpp
+++ b/third_party/amd/lib/TritonAMDGPUToLLVM/TDMUtility.cpp
@@ -1002,18 +1002,8 @@ void fillTDMDescriptor(RewriterBase &rewriter, Location loc,
   }
 }
 
-// Fill TDM descriptor for gather/scatter operations (2D only).
-// Gather reads from non-contiguous rows in global memory to LDS.
-// Scatter writes from LDS to non-contiguous rows in global memory.
-// Build the chunk-invariant part of a gather/scatter descriptor: group0[0]
-// (pred|mode), group0[2:3] (global address) and the whole of group1 (tensor
-// shape, barrier, tile dims).  All TDM instructions emitted for one
-// async_gather/async_scatter share these; only group0[1] (lds_addr) and
-// group2/group3 (row indices) vary per chunk and are filled afterwards by
-// fillGatherScatterChunk.  Computing the shared part once -- and letting the
-// per-chunk filler touch only group0[1] -- keeps the chunk descriptors
-// differing in a single dword, so the backend re-stamps just the lds_addr lane
-// instead of rebuilding the whole 4-dword group0 per chunk.
+// Build the chunk-invariant part of a gather/scatter descriptor once, so the
+// per-chunk loop only re-stamps lds_addr instead of rebuilding group0.
 static void prepareGatherScatterDescriptorBase(
     RewriterBase &rewriter, Location loc, Type elementType,
     SmallVector<int64_t> blockShape, unsigned padInterval, unsigned padAmount,
@@ -1065,8 +1055,6 @@ static void prepareGatherScatterDescriptorBase(
     predWithGatherScatter = b.or_(predWithGatherScatter, b.i32_val(1 << 30));
   }
 
-  // group0[0],[2],[3] are chunk-invariant.  group0[1] (lds_addr) is set per
-  // chunk by fillGatherScatterChunk so the chunks differ in only that lane.
   group0 = vecSet(b, group0, 0, predWithGatherScatter);
   group0 = vecSet(b, group0, 2, b.trunc(i32_ty, globalAddr));
 
@@ -1101,9 +1089,6 @@ static void prepareGatherScatterDescriptorBase(
   group1 = vecSet(b, group1, 0, g1_0);
   group1 = vecSet(b, group1, 1, g1_1);
 
-  // tile_dim1 (number of valid indices, group1[4]) is per-chunk and is set in
-  // fillGatherScatterChunk.
-
   // Encode tile_dim0 for gather/scatter as the full undivided column width:
   // gather/scatter is row-indexed across all warps, so each TDM instruction
   // covers the full row.  createTDMDescriptor leaves the upper 16 bits of
@@ -1122,11 +1107,7 @@ static void prepareGatherScatterDescriptorBase(
   }
 }
 
-// Fill the per-chunk parts of a gather/scatter descriptor on top of the base
-// from prepareGatherScatterDescriptorBase: group0[1] (lds_addr), group1[4]
-// (number of valid indices / tile_dim1) and group2/group3 (the row indices).
-// group0[1] is the only group0 lane that varies between chunks, so the chunk
-// descriptors differ in exactly one dword.
+// Fill the per-chunk parts of a gather/scatter descriptor on top of the base.
 static void fillGatherScatterChunk(RewriterBase &rewriter, Location loc,
                                    Value &group0, Value &group1, Value &group2,
                                    Value &group3, Value ldsAddr,
@@ -1135,11 +1116,10 @@ static void fillGatherScatterChunk(RewriterBase &rewriter, Location loc,
   assert(!rowIndices.empty() && "Gather/scatter requires row indices.");
   auto b = TritonLLVMOpBuilder(loc, rewriter);
 
-  // group0[1]: lds_addr -- the only per-chunk group0 lane.
+  // group0[1]: lds_addr
   group0 = vecSet(b, group0, 1, ldsAddr);
 
-  // tile_dim1 (group1[4] lower 16 bits): number of valid indices for this
-  // chunk.
+  // tile_dim1 (group1[4] lower 16 bits): number of valid indices
   size_t numIndices = rowIndices.size();
   Value g1_4 = b.and_(vecGet(b, group1, 4), b.i32_val(0xFFFF0000));
   g1_4 = b.or_(g1_4, b.i32_val(numIndices & 0xFFFF));
@@ -1426,20 +1406,15 @@ emitTDMGatherScatter(RewriterBase &rewriter, Location loc,
     pred = b.select(inRange, pred, b.i32_val(0));
   }
 
-  // Precompute LDS row offset for each instruction batch via
-  // applyLinearLayout with the actual register index and warp ID.
-  SmallVector<Value> batchLdsOffsets;
+  // chunk 0's LDS row offset (per warp); chunks 1..N-1 derive theirs as a
+  // compile-time-constant delta off chunk 0 below.
   auto kBlock = rewriter.getStringAttr("block");
-  for (size_t startIdx = 0; startIdx < effectiveRowIndices.size();
-       startIdx += maxIndicesPerInstr) {
-    auto offsets = applyLinearLayout(loc, rewriter, indexLL,
-                                     {{kRegister, b.i32_val(startIdx)},
-                                      {kLane, b.i32_val(0)},
-                                      {kWarp, warpId},
-                                      {kBlock, b.i32_val(0)}});
-    batchLdsOffsets.push_back(offsets[0].second);
-  }
-  assert(batchLdsOffsets.size() == analysis.numInstructions);
+  Value chunk0RowOffset = applyLinearLayout(loc, rewriter, indexLL,
+                                            {{kRegister, b.i32_val(0)},
+                                             {kLane, b.i32_val(0)},
+                                             {kWarp, warpId},
+                                             {kBlock, b.i32_val(0)}})[0]
+                              .second;
 
   size_t numIndicesPerWarp = effectiveRowIndices.size();
 
@@ -1453,15 +1428,16 @@ emitTDMGatherScatter(RewriterBase &rewriter, Location loc,
   Value group2Zero = LLVM::ZeroOp::create(rewriter, loc, v4i32Ty);
   Value group3Zero = LLVM::ZeroOp::create(rewriter, loc, v4i32Ty);
 
-  // chunk 0's lds_addr; chunks 1..N-1 derive theirs as chunk0 + const delta.
   Type sharedPtrTy = ptr_ty(rewriter.getContext(), 3);
   Value chunk0LdsAddr;
 
-  // Build the chunk-invariant descriptor base once.  All chunks share group0[0]
-  // (pred|mode), group0[2:3] (global addr) and group1; only group0[1]
-  // (lds_addr) and group2/group3 (indices) vary per chunk, so the backend
-  // re-stamps just the lds_addr lane between chunks instead of rebuilding all
-  // of group0.
+  // The lds-trick scales each chunk's element-offset delta to bytes; the
+  // gather/scatter verifier guarantees >=1-byte elements, so this never
+  // truncates to 0.
+  unsigned elemBytes = elementType.getIntOrFloatBitWidth() / 8;
+
+  // Build the chunk-invariant base once; the loop below only re-stamps the
+  // per-chunk lds_addr and indices.
   Value baseGroup0 = group0In;
   Value baseGroup1 = group1In;
   prepareGatherScatterDescriptorBase(
@@ -1478,22 +1454,18 @@ emitTDMGatherScatter(RewriterBase &rewriter, Location loc,
     SmallVector<Value> batchIndices(effectiveRowIndices.begin() + startIdx,
                                     effectiveRowIndices.begin() + endIdx);
 
-    // Start from the shared base; only group0[1] (lds_addr) and the per-chunk
-    // indices (group2/group3) differ.
     Value g0 = baseGroup0;
     Value g1 = baseGroup1;
     Value g2 = group2Zero;
     Value g3 = group3Zero;
 
-    // Per-chunk lds_addr (g0[1]): chunk 0 = full per-warp computation; chunks
-    // 1..N-1 = chunk0_addr + a compile-time-constant byte delta.  Because
-    // applyLinearLayout is affine in `register`, the (chunkI - chunk0) offset
-    // with warp pinned to 0 folds to a constant, so LLVM emits
-    // `s_add_co_i32 sX, chunk0_addr, <imm>` per chunk instead of feeding a
-    // per-chunk loop-invariant SGPR.
+    // Per-chunk lds_addr (g0[1]): chunk 0 does the full per-warp computation;
+    // chunks 1..N-1 are chunk0_addr + a compile-time-constant byte delta, so
+    // the backend emits `s_add_co_i32 sX, chunk0_addr, <imm>` per chunk instead
+    // of a separate per-chunk LDS-address SGPR.
     Value ldsAddr;
     if (instrIdx == 0) {
-      Value ldsOffset = b.mul(batchLdsOffsets[0], b.i32_val(blockShape[1]));
+      Value ldsOffset = b.mul(chunk0RowOffset, b.i32_val(blockShape[1]));
       if (padInterval > 0 && padAmount > 0) {
         Value iVal = b.i32_val(log2(padInterval));
         Value pVal = b.i32_val(log2(padAmount));
@@ -1504,34 +1476,25 @@ emitTDMGatherScatter(RewriterBase &rewriter, Location loc,
                            b.gep(sharedPtrTy, elementType, ldsPtr, ldsOffset));
       chunk0LdsAddr = ldsAddr;
     } else {
-      // byte delta = (LL(register=startIdx, warp=0) - LL(register=0, warp=0))
-      //              * blockShape[1] + pad(delta).  pad(a+b)=pad(a)+pad(b)
-      //              holds because chunk byte deltas are multiples of
-      //              padInterval for all TDM gather patterns we emit.
-      auto chunkIOffsets = applyLinearLayout(loc, rewriter, indexLL,
-                                             {{kRegister, b.i32_val(startIdx)},
-                                              {kLane, b.i32_val(0)},
-                                              {kWarp, b.i32_val(0)},
-                                              {kBlock, b.i32_val(0)}});
-      auto chunk0Offsets = applyLinearLayout(loc, rewriter, indexLL,
-                                             {{kRegister, b.i32_val(0)},
-                                              {kLane, b.i32_val(0)},
-                                              {kWarp, b.i32_val(0)},
-                                              {kBlock, b.i32_val(0)}});
-      Value rowDelta = b.sub(chunkIOffsets[0].second, chunk0Offsets[0].second);
-      Value elemDelta = b.mul(rowDelta, b.i32_val(blockShape[1]));
+      // chunk i's register-offset delta from chunk 0, evaluated at warp 0.
+      // applyLinearLayout is linear in `register`, so the per-warp term cancels
+      // (LL(register=0) == 0) and the delta is a compile-time constant.  It
+      // must be addition-separable from the warp term, which holds for the
+      // row-strip-per-warp layouts gather/scatter emit.
+      int64_t rowDelta = indexLL
+                             .apply({{kRegister, (int32_t)startIdx},
+                                     {kLane, 0},
+                                     {kWarp, 0},
+                                     {kBlock, 0}})[0]
+                             .second;
+      int64_t elemDelta = rowDelta * blockShape[1];
       if (padInterval > 0 && padAmount > 0) {
-        Value iVal = b.i32_val(log2(padInterval));
-        Value pVal = b.i32_val(log2(padAmount));
-        Value padDelta = b.shl(i32_ty, b.ashr(elemDelta, iVal), pVal);
-        elemDelta = b.add(elemDelta, padDelta);
+        // padInterval divides the innermost block dim (enforced by the
+        // verifier) and elemDelta is a multiple of it, so pad() distributes:
+        // pad(a+delta) == pad(a) + pad(delta).
+        elemDelta += (elemDelta / padInterval) * padAmount;
       }
-      // chunk0LdsAddr is a byte address (chunk 0's gep scaled by elementType),
-      // so scale the element-offset delta to bytes explicitly; required for
-      // >1-byte element types (e.g. fp16).
-      unsigned elemBytes = elementType.getIntOrFloatBitWidth() / 8;
-      Value byteDelta = b.mul(elemDelta, b.i32_val(elemBytes));
-      ldsAddr = b.add(chunk0LdsAddr, byteDelta);
+      ldsAddr = b.add(chunk0LdsAddr, b.i32_val(elemDelta * (int64_t)elemBytes));
     }
 
     fillGatherScatterChunk(rewriter, loc, g0, g1, g2, g3, ldsAddr, batchIndices,

--- a/third_party/amd/lib/TritonAMDGPUToLLVM/TDMUtility.cpp
+++ b/third_party/amd/lib/TritonAMDGPUToLLVM/TDMUtility.cpp
@@ -1009,7 +1009,7 @@ void fillTDMDescriptorForGatherScatter(
     const LLVMTypeConverter *typeConverter, Type elementType,
     SmallVector<int64_t> blockShape, unsigned padInterval, unsigned padAmount,
     Value &group0, Value &group1, Value &group2, Value &group3,
-    Value ldsRowOffset, Value ldsPtr, Value pred, Value multicastMask,
+    Value ldsAddr, Value pred, Value multicastMask,
     Value barrierPtr, const triton::LinearLayout &cgaLayout, Value ctaId,
     ArrayRef<Value> rowIndices, bool use32BitIndices, bool isGather) {
   assert(!rowIndices.empty() && "Gather/scatter requires row indices.");
@@ -1018,7 +1018,6 @@ void fillTDMDescriptorForGatherScatter(
   auto b = TritonLLVMOpBuilder(loc, rewriter);
 
   Type globalPtrTy = ptr_ty(ctx, 1);
-  Type sharedPtrTy = ptr_ty(ctx, 3);
 
   // Decode descriptor to get tensor info (only group0/1 used for 2D).
   Value descGroups[2] = {group0, group1};
@@ -1036,17 +1035,6 @@ void fillTDMDescriptorForGatherScatter(
   Value cgaColOffset = b.mul(b.zext(i64_ty, cgaColOffsetElem), tensorStride[1]);
   globalPtr = b.gep(globalPtrTy, elementType, globalPtr, cgaColOffset);
 
-  // Calculate LDS offset based on row offset only (column always starts at 0)
-  Value ldsOffset = b.mul(ldsRowOffset, b.i32_val(blockShape[1]));
-
-  // Apply padding if needed
-  if (padInterval > 0 && padAmount > 0) {
-    Value iVal = b.i32_val(log2(padInterval));
-    Value pVal = b.i32_val(log2(padAmount));
-    Value padOffset = b.shl(i32_ty, b.ashr(ldsOffset, iVal), pVal);
-    ldsOffset = b.add(ldsOffset, padOffset);
-  }
-  ldsPtr = b.gep(sharedPtrTy, elementType, ldsPtr, ldsOffset);
 
   // tensorShape[1] is the OOB extent carried by the descriptor (set once via
   // update_tensor_descriptor set_bounds / clamp_bounds, like the contiguous
@@ -1065,7 +1053,6 @@ void fillTDMDescriptorForGatherScatter(
 
   // Update group0 with addresses and enable gather/scatter mode
   Value globalAddr = b.ptrtoint(i64_ty, globalPtr);
-  Value ldsAddr = b.ptrtoint(i32_ty, ldsPtr);
 
   // Set gather/scatter bits: bit 31 = enable, bit 30 = 32-bit indices
   Value predWithGatherScatter = b.or_(pred, b.i32_val(1 << 31));
@@ -1439,6 +1426,10 @@ emitTDMGatherScatter(RewriterBase &rewriter, Location loc,
   Value group2Zero = LLVM::ZeroOp::create(rewriter, loc, v4i32Ty);
   Value group3Zero = LLVM::ZeroOp::create(rewriter, loc, v4i32Ty);
 
+  // chunk 0's lds_addr; chunks 1..N-1 derive theirs as chunk0 + const delta.
+  Type sharedPtrTy = ptr_ty(rewriter.getContext(), 3);
+  Value chunk0LdsAddr;
+
   // Issue multiple TDM instructions if needed
   for (size_t instrIdx = 0; instrIdx < analysis.numInstructions; ++instrIdx) {
     size_t startIdx = instrIdx * maxIndicesPerInstr;
@@ -1454,13 +1445,57 @@ emitTDMGatherScatter(RewriterBase &rewriter, Location loc,
     Value g2 = group2Zero;
     Value g3 = group3Zero;
 
-    Value ldsRowOffset = batchLdsOffsets[instrIdx];
+    // Per-chunk lds_addr (g0[1]): chunk 0 = full per-warp computation; chunks
+    // 1..N-1 = chunk0_addr + a compile-time-constant byte delta.  Because
+    // applyLinearLayout is affine in `register`, the (chunkI - chunk0) offset
+    // with warp pinned to 0 folds to a constant, so LLVM emits
+    // `s_add_co_i32 sX, chunk0_addr, <imm>` per chunk instead of feeding a
+    // per-chunk loop-invariant SGPR.
+    Value ldsAddr;
+    if (instrIdx == 0) {
+      Value ldsOffset = b.mul(batchLdsOffsets[0], b.i32_val(blockShape[1]));
+      if (padInterval > 0 && padAmount > 0) {
+        Value iVal = b.i32_val(log2(padInterval));
+        Value pVal = b.i32_val(log2(padAmount));
+        Value padOffset = b.shl(i32_ty, b.ashr(ldsOffset, iVal), pVal);
+        ldsOffset = b.add(ldsOffset, padOffset);
+      }
+      ldsAddr =
+          b.ptrtoint(i32_ty, b.gep(sharedPtrTy, elementType, ldsPtr, ldsOffset));
+      chunk0LdsAddr = ldsAddr;
+    } else {
+      // byte delta = (LL(register=startIdx, warp=0) - LL(register=0, warp=0))
+      //              * blockShape[1] + pad(delta).  pad(a+b)=pad(a)+pad(b) holds
+      //              because chunk byte deltas are multiples of padInterval for
+      //              all TDM gather patterns we emit.
+      auto chunkIOffsets = applyLinearLayout(
+          loc, rewriter, indexLL,
+          {{kRegister, b.i32_val(startIdx)}, {kLane, b.i32_val(0)},
+           {kWarp, b.i32_val(0)}, {kBlock, b.i32_val(0)}});
+      auto chunk0Offsets = applyLinearLayout(
+          loc, rewriter, indexLL,
+          {{kRegister, b.i32_val(0)}, {kLane, b.i32_val(0)},
+           {kWarp, b.i32_val(0)}, {kBlock, b.i32_val(0)}});
+      Value rowDelta = b.sub(chunkIOffsets[0].second, chunk0Offsets[0].second);
+      Value elemDelta = b.mul(rowDelta, b.i32_val(blockShape[1]));
+      if (padInterval > 0 && padAmount > 0) {
+        Value iVal = b.i32_val(log2(padInterval));
+        Value pVal = b.i32_val(log2(padAmount));
+        Value padDelta = b.shl(i32_ty, b.ashr(elemDelta, iVal), pVal);
+        elemDelta = b.add(elemDelta, padDelta);
+      }
+      // chunk0LdsAddr is a byte address (chunk 0's gep scaled by elementType),
+      // so scale the element-offset delta to bytes explicitly; required for
+      // >1-byte element types (e.g. fp16).
+      unsigned elemBytes = elementType.getIntOrFloatBitWidth() / 8;
+      Value byteDelta = b.mul(elemDelta, b.i32_val(elemBytes));
+      ldsAddr = b.add(chunk0LdsAddr, byteDelta);
+    }
 
     fillTDMDescriptorForGatherScatter(
         rewriter, loc, typeConverter, elementType, to_vector(blockShape),
-        padInterval, padAmount, g0, g1, g2, g3, ldsRowOffset, ldsPtr, pred,
-        multicastMask, barrierPtr, cgaLayout, ctaId, batchIndices,
-        use32BitIndices, isGather);
+        padInterval, padAmount, g0, g1, g2, g3, ldsAddr, pred, multicastMask,
+        barrierPtr, cgaLayout, ctaId, batchIndices, use32BitIndices, isGather);
 
     auto v8i32Ty = VectorType::get(8, rewriter.getI32Type());
     Value group4Zero = LLVM::ZeroOp::create(rewriter, loc, v8i32Ty);

--- a/third_party/amd/lib/TritonAMDGPUToLLVM/TDMUtility.cpp
+++ b/third_party/amd/lib/TritonAMDGPUToLLVM/TDMUtility.cpp
@@ -231,9 +231,10 @@ SmallVector<Value> scalarizeTDMDescriptor(RewriterBase &rewriter, Location loc,
 
 // Shrink a tensor_dim by a signed offset, clamping a backward/over-advance to
 // 0:  result = (off < 0) ? 0 : max(0, cur - off).  A negative offset yields a
-// zero extent.  Shared by fillTDMDescriptor / fillTDMDescriptorForGatherScatter
-// (implicit per-tile bounds) and updateTensorDescriptor's clamp_bounds so all
-// paths derive the OOB extent identically.
+// zero extent.  Shared by fillTDMDescriptor /
+// prepareGatherScatterDescriptorBase (implicit per-tile bounds) and
+// updateTensorDescriptor's clamp_bounds so all paths derive the OOB extent
+// identically.
 //
 // Written in this specific shape (smax + sign select) to avoid suboptimal
 // codegen: LLVM InstCombine can otherwise fold the clamp into VALU-only
@@ -508,7 +509,7 @@ SmallVector<Value> createTDMDescriptor(RewriterBase &rewriter, Location loc,
 
   // This base descriptor records only tensor metadata.  Per-op hardware fields
   // (pred, LDS address, barrier, tile_dim*) are materialized by
-  // fillTDMDescriptor / fillTDMDescriptorForGatherScatter, where the
+  // fillTDMDescriptor / prepareGatherScatterDescriptorBase, where the
   // destination, predicate, and warp distribution are known.
 
   // group0 (128 bits / 4 dwords) effective bit encoding:
@@ -1004,16 +1005,21 @@ void fillTDMDescriptor(RewriterBase &rewriter, Location loc,
 // Fill TDM descriptor for gather/scatter operations (2D only).
 // Gather reads from non-contiguous rows in global memory to LDS.
 // Scatter writes from LDS to non-contiguous rows in global memory.
-void fillTDMDescriptorForGatherScatter(
-    RewriterBase &rewriter, Location loc,
-    const LLVMTypeConverter *typeConverter, Type elementType,
+// Build the chunk-invariant part of a gather/scatter descriptor: group0[0]
+// (pred|mode), group0[2:3] (global address) and the whole of group1 (tensor
+// shape, barrier, tile dims).  All TDM instructions emitted for one
+// async_gather/async_scatter share these; only group0[1] (lds_addr) and
+// group2/group3 (row indices) vary per chunk and are filled afterwards by
+// fillGatherScatterChunk.  Computing the shared part once -- and letting the
+// per-chunk filler touch only group0[1] -- keeps the chunk descriptors
+// differing in a single dword, so the backend re-stamps just the lds_addr lane
+// instead of rebuilding the whole 4-dword group0 per chunk.
+static void prepareGatherScatterDescriptorBase(
+    RewriterBase &rewriter, Location loc, Type elementType,
     SmallVector<int64_t> blockShape, unsigned padInterval, unsigned padAmount,
-    Value &group0, Value &group1, Value &group2, Value &group3,
-    Value ldsAddr, Value pred, Value multicastMask,
+    Value &group0, Value &group1, Value pred, Value multicastMask,
     Value barrierPtr, const triton::LinearLayout &cgaLayout, Value ctaId,
-    ArrayRef<Value> rowIndices, bool use32BitIndices, bool isGather) {
-  assert(!rowIndices.empty() && "Gather/scatter requires row indices.");
-
+    bool use32BitIndices, bool isGather) {
   auto ctx = rewriter.getContext();
   auto b = TritonLLVMOpBuilder(loc, rewriter);
 
@@ -1034,7 +1040,6 @@ void fillTDMDescriptorForGatherScatter(
   Value cgaColOffsetElem = cgaOffsets[1].second;
   Value cgaColOffset = b.mul(b.zext(i64_ty, cgaColOffsetElem), tensorStride[1]);
   globalPtr = b.gep(globalPtrTy, elementType, globalPtr, cgaColOffset);
-
 
   // tensorShape[1] is the OOB extent carried by the descriptor (set once via
   // update_tensor_descriptor set_bounds / clamp_bounds, like the contiguous
@@ -1060,8 +1065,9 @@ void fillTDMDescriptorForGatherScatter(
     predWithGatherScatter = b.or_(predWithGatherScatter, b.i32_val(1 << 30));
   }
 
+  // group0[0],[2],[3] are chunk-invariant.  group0[1] (lds_addr) is set per
+  // chunk by fillGatherScatterChunk so the chunks differ in only that lane.
   group0 = vecSet(b, group0, 0, predWithGatherScatter);
-  group0 = vecSet(b, group0, 1, ldsAddr);
   group0 = vecSet(b, group0, 2, b.trunc(i32_ty, globalAddr));
 
   // group0[3]: preserve type bits, set global_addr upper 25 bits
@@ -1095,11 +1101,8 @@ void fillTDMDescriptorForGatherScatter(
   group1 = vecSet(b, group1, 0, g1_0);
   group1 = vecSet(b, group1, 1, g1_1);
 
-  // Set tile_dim1 (number of valid indices) in lower 16 bits of group1[4]
-  size_t numIndices = rowIndices.size();
-  Value g1_4 = b.and_(vecGet(b, group1, 4), b.i32_val(0xFFFF0000));
-  g1_4 = b.or_(g1_4, b.i32_val(numIndices & 0xFFFF));
-  group1 = vecSet(b, group1, 4, g1_4);
+  // tile_dim1 (number of valid indices, group1[4]) is per-chunk and is set in
+  // fillGatherScatterChunk.
 
   // Encode tile_dim0 for gather/scatter as the full undivided column width:
   // gather/scatter is row-indexed across all warps, so each TDM instruction
@@ -1117,6 +1120,30 @@ void fillTDMDescriptorForGatherScatter(
     g1_3_gs = b.or_(g1_3_gs, b.i32_val(tileDim0 << 16));
     group1 = vecSet(b, group1, 3, g1_3_gs);
   }
+}
+
+// Fill the per-chunk parts of a gather/scatter descriptor on top of the base
+// from prepareGatherScatterDescriptorBase: group0[1] (lds_addr), group1[4]
+// (number of valid indices / tile_dim1) and group2/group3 (the row indices).
+// group0[1] is the only group0 lane that varies between chunks, so the chunk
+// descriptors differ in exactly one dword.
+static void fillGatherScatterChunk(RewriterBase &rewriter, Location loc,
+                                   Value &group0, Value &group1, Value &group2,
+                                   Value &group3, Value ldsAddr,
+                                   ArrayRef<Value> rowIndices,
+                                   bool use32BitIndices) {
+  assert(!rowIndices.empty() && "Gather/scatter requires row indices.");
+  auto b = TritonLLVMOpBuilder(loc, rewriter);
+
+  // group0[1]: lds_addr -- the only per-chunk group0 lane.
+  group0 = vecSet(b, group0, 1, ldsAddr);
+
+  // tile_dim1 (group1[4] lower 16 bits): number of valid indices for this
+  // chunk.
+  size_t numIndices = rowIndices.size();
+  Value g1_4 = b.and_(vecGet(b, group1, 4), b.i32_val(0xFFFF0000));
+  g1_4 = b.or_(g1_4, b.i32_val(numIndices & 0xFFFF));
+  group1 = vecSet(b, group1, 4, g1_4);
 
   // Fill group2 and group3 with row indices
   if (use32BitIndices) {
@@ -1430,6 +1457,18 @@ emitTDMGatherScatter(RewriterBase &rewriter, Location loc,
   Type sharedPtrTy = ptr_ty(rewriter.getContext(), 3);
   Value chunk0LdsAddr;
 
+  // Build the chunk-invariant descriptor base once.  All chunks share group0[0]
+  // (pred|mode), group0[2:3] (global addr) and group1; only group0[1]
+  // (lds_addr) and group2/group3 (indices) vary per chunk, so the backend
+  // re-stamps just the lds_addr lane between chunks instead of rebuilding all
+  // of group0.
+  Value baseGroup0 = group0In;
+  Value baseGroup1 = group1In;
+  prepareGatherScatterDescriptorBase(
+      rewriter, loc, elementType, to_vector(blockShape), padInterval, padAmount,
+      baseGroup0, baseGroup1, pred, multicastMask, barrierPtr, cgaLayout, ctaId,
+      use32BitIndices, isGather);
+
   // Issue multiple TDM instructions if needed
   for (size_t instrIdx = 0; instrIdx < analysis.numInstructions; ++instrIdx) {
     size_t startIdx = instrIdx * maxIndicesPerInstr;
@@ -1439,9 +1478,10 @@ emitTDMGatherScatter(RewriterBase &rewriter, Location loc,
     SmallVector<Value> batchIndices(effectiveRowIndices.begin() + startIdx,
                                     effectiveRowIndices.begin() + endIdx);
 
-    // Make copies of the descriptor groups for this iteration
-    Value g0 = group0In;
-    Value g1 = group1In;
+    // Start from the shared base; only group0[1] (lds_addr) and the per-chunk
+    // indices (group2/group3) differ.
+    Value g0 = baseGroup0;
+    Value g1 = baseGroup1;
     Value g2 = group2Zero;
     Value g3 = group3Zero;
 
@@ -1460,22 +1500,24 @@ emitTDMGatherScatter(RewriterBase &rewriter, Location loc,
         Value padOffset = b.shl(i32_ty, b.ashr(ldsOffset, iVal), pVal);
         ldsOffset = b.add(ldsOffset, padOffset);
       }
-      ldsAddr =
-          b.ptrtoint(i32_ty, b.gep(sharedPtrTy, elementType, ldsPtr, ldsOffset));
+      ldsAddr = b.ptrtoint(i32_ty,
+                           b.gep(sharedPtrTy, elementType, ldsPtr, ldsOffset));
       chunk0LdsAddr = ldsAddr;
     } else {
       // byte delta = (LL(register=startIdx, warp=0) - LL(register=0, warp=0))
-      //              * blockShape[1] + pad(delta).  pad(a+b)=pad(a)+pad(b) holds
-      //              because chunk byte deltas are multiples of padInterval for
-      //              all TDM gather patterns we emit.
-      auto chunkIOffsets = applyLinearLayout(
-          loc, rewriter, indexLL,
-          {{kRegister, b.i32_val(startIdx)}, {kLane, b.i32_val(0)},
-           {kWarp, b.i32_val(0)}, {kBlock, b.i32_val(0)}});
-      auto chunk0Offsets = applyLinearLayout(
-          loc, rewriter, indexLL,
-          {{kRegister, b.i32_val(0)}, {kLane, b.i32_val(0)},
-           {kWarp, b.i32_val(0)}, {kBlock, b.i32_val(0)}});
+      //              * blockShape[1] + pad(delta).  pad(a+b)=pad(a)+pad(b)
+      //              holds because chunk byte deltas are multiples of
+      //              padInterval for all TDM gather patterns we emit.
+      auto chunkIOffsets = applyLinearLayout(loc, rewriter, indexLL,
+                                             {{kRegister, b.i32_val(startIdx)},
+                                              {kLane, b.i32_val(0)},
+                                              {kWarp, b.i32_val(0)},
+                                              {kBlock, b.i32_val(0)}});
+      auto chunk0Offsets = applyLinearLayout(loc, rewriter, indexLL,
+                                             {{kRegister, b.i32_val(0)},
+                                              {kLane, b.i32_val(0)},
+                                              {kWarp, b.i32_val(0)},
+                                              {kBlock, b.i32_val(0)}});
       Value rowDelta = b.sub(chunkIOffsets[0].second, chunk0Offsets[0].second);
       Value elemDelta = b.mul(rowDelta, b.i32_val(blockShape[1]));
       if (padInterval > 0 && padAmount > 0) {
@@ -1492,10 +1534,8 @@ emitTDMGatherScatter(RewriterBase &rewriter, Location loc,
       ldsAddr = b.add(chunk0LdsAddr, byteDelta);
     }
 
-    fillTDMDescriptorForGatherScatter(
-        rewriter, loc, typeConverter, elementType, to_vector(blockShape),
-        padInterval, padAmount, g0, g1, g2, g3, ldsAddr, pred, multicastMask,
-        barrierPtr, cgaLayout, ctaId, batchIndices, use32BitIndices, isGather);
+    fillGatherScatterChunk(rewriter, loc, g0, g1, g2, g3, ldsAddr, batchIndices,
+                           use32BitIndices);
 
     auto v8i32Ty = VectorType::get(8, rewriter.getI32Type());
     Value group4Zero = LLVM::ZeroOp::create(rewriter, loc, v8i32Ty);

--- a/third_party/amd/lib/TritonAMDGPUToLLVM/TDMUtility.h
+++ b/third_party/amd/lib/TritonAMDGPUToLLVM/TDMUtility.h
@@ -86,22 +86,6 @@ void fillTDMDescriptor(RewriterBase &rewriter, Location loc,
                        std::optional<uint32_t> warpUsedHint = std::nullopt,
                        bool isPureForm = false);
 
-// Fill TDM descriptor for gather/scatter operations (2D only).
-// Gather reads from non-contiguous rows in global memory to LDS.
-// Scatter writes from LDS to non-contiguous rows in global memory.
-// - rowIndices: which global rows to read from (gather) or write to (scatter)
-// - ldsRowOffset: starting row within shared memory
-// - use32BitIndices: true for 32-bit indices (max 8 rows), false for 16-bit
-// (max 16 rows)
-void fillTDMDescriptorForGatherScatter(
-    RewriterBase &rewriter, Location loc,
-    const LLVMTypeConverter *typeConverter, Type elementType,
-    SmallVector<int64_t> blockShape, unsigned padInterval, unsigned padAmount,
-    Value &group0, Value &group1, Value &group2, Value &group3,
-    Value ldsRowOffset, Value ldsPtr, Value pred, Value multicastMask,
-    Value barrierPtr, const triton::LinearLayout &cgaLayout, Value ctaId,
-    ArrayRef<Value> rowIndices, bool use32BitIndices, bool isGather);
-
 // Emit a TDM load/store for regular contiguous transfers (1D-5D).
 // PartitionedSharedEncoding aligns warps to LDS partitions; without a hint
 // the op auto-splits into multiple instructions when warps don't cover all

--- a/third_party/amd/python/test/test_tdm_copy.py
+++ b/third_party/amd/python/test/test_tdm_copy.py
@@ -269,6 +269,69 @@ def test_compile_tdm_clamp_no_readfirstlane():
     assert "v_readfirstlane" not in amdgcn, f"TDM tensor_dim clamp regressed to VALU (v_readfirstlane emitted)\n{amdgcn}"
 
 
+@gluon.jit
+def tdm_gather_loop_kernel(ptr, optr, M, N, K, BLOCK_N: ttgl.constexpr, NUM_INDICES: ttgl.constexpr):
+    """Gather NUM_INDICES rows into shared memory each iteration via TDM, advancing
+    the descriptor column per iteration (the v3_tdm/MoE pattern)."""
+    num_warps: ttgl.constexpr = ttgl.num_warps()
+    SHARED_LAYOUT: ttgl.constexpr = ttgl.PaddedSharedLayout.with_identity_for([[32, 4]], [NUM_INDICES, BLOCK_N], [1, 0])
+    BLOCKED_LAYOUT: ttgl.constexpr = ttgl.BlockedLayout([NUM_INDICES, 1], [1, 32], [1, num_warps], [1, 0])
+    ROW_IDX_LAYOUT: ttgl.constexpr = ttgl.SliceLayout(1, BLOCKED_LAYOUT)
+
+    desc = ttgl.amd.gfx1250.tdm.make_tensor_descriptor(base=ptr, shape=(M, N), strides=(N, 1),
+                                                       block_shape=(NUM_INDICES, BLOCK_N), layout=SHARED_LAYOUT)
+    row_indices = ttgl.arange(0, NUM_INDICES, layout=ROW_IDX_LAYOUT)
+    buf = ttgl.allocate_shared_memory(desc.dtype, desc.block_shape, desc.layout)
+    acc = ttgl.zeros([NUM_INDICES, BLOCK_N], ttgl.float32, layout=BLOCKED_LAYOUT)
+    for _ in range(0, K, BLOCK_N):
+        desc = ttgl.amd.gfx1250.tdm.update_tensor_descriptor(desc, add_offsets=[0, BLOCK_N])
+        ttgl.amd.gfx1250.tdm.async_gather(desc, src_row_indices=row_indices, dst=buf)
+        ttgl.amd.gfx1250.tdm.async_wait(0)
+        acc += buf.load(layout=BLOCKED_LAYOUT).to(ttgl.float32)
+
+    offs_m = ttgl.arange(0, NUM_INDICES, layout=ttgl.SliceLayout(1, BLOCKED_LAYOUT))
+    offs_n = ttgl.arange(0, BLOCK_N, layout=ttgl.SliceLayout(0, BLOCKED_LAYOUT))
+    ttgl.store(optr + offs_m[:, None] * N + offs_n[None, :], acc.to(ttgl.float16))
+
+
+def test_compile_tdm_gather_shared_descriptor_sgprs():
+    """The base-hoist makes a multi-chunk gather reuse one descriptor across chunks.
+
+    The gather is placed in a loop with the descriptor advancing per iteration, so
+    the descriptor is not a compile-time constant (the v3_tdm/MoE pattern).  32 row
+    indices lower to four ``tensor_load_to_lds`` per iteration; the base-hoist makes
+    all four reuse one group0 SGPR tuple (only the per-chunk lds_addr lane and index
+    operands change).  Without it each chunk rebuilds group0 into its own SGPR
+    window, giving one distinct group0 per chunk -- this is the part of PR2 that a
+    straight-line gather cannot exercise, because there LLVM CSE folds the per-chunk
+    rebuilds back together regardless.
+    """
+    signature = {
+        "ptr": "*fp16", "optr": "*fp16", "M": "i32", "N": "i32", "K": "i32", "BLOCK_N": "constexpr", "NUM_INDICES":
+        "constexpr"
+    }
+    k = triton.compile(
+        gluon._runtime.GluonASTSource(
+            fn=tdm_gather_loop_kernel,
+            signature=signature,
+            constexprs={"BLOCK_N": 64, "NUM_INDICES": 32},
+        ),
+        target=GPUTarget("hip", "gfx1250", 32),
+        options={"num_warps": 4},
+    )
+    amdgcn = k.asm["amdgcn"]
+
+    loads = [ln.split() for ln in amdgcn.splitlines() if ln.strip().startswith("tensor_load_to_lds")]
+    assert len(loads) >= 4, f"expected a 4-chunk gather, got {len(loads)} TDM instruction(s)\n{amdgcn}"
+
+    # operand 1 = group0 (4 SGPRs).  The base-hoist makes every chunk of the
+    # in-loop gather reuse one group0 tuple; without it each chunk rebuilds group0
+    # into its own SGPR window (one distinct group0 per chunk).
+    group0 = {toks[1].rstrip(",") for toks in loads}
+    assert len(group0) == 1, (f"chunks must share one group0 SGPR tuple (base-hoist); got {len(group0)} distinct "
+                              f"group0 tuples for {len(loads)} loads: {sorted(group0)}\n{amdgcn}")
+
+
 _RUNTIME_BLOCK_SHAPES = [(64, 64), (128, 64)]
 
 


### PR DESCRIPTION
## Summary

A multi-row `async_tdm_gather`/`async_tdm_scatter` lowers to N `tensor_load_to_lds`/`tensor_store_from_lds` instructions ("chunks", one per row-index batch). Previously every chunk rebuilt the full TDM descriptor and recomputed its LDS address from scratch. This PR makes the chunks share one descriptor and derive their LDS address from chunk 0, cutting the in-loop SALU that dominates pipelined gather/scatter kernels. No functional change.

Builds on #10685 (the pure `async_tdm_gather/scatter` op surface).

## Changes

**Constant per-chunk `lds_addr`.** Chunk 0 does the full per-warp LDS-address computation; chunks 1..N-1 are `chunk0_addr + a compile-time-constant byte delta`. The index `LinearLayout` is linear in `register`, so the per-warp term cancels and the delta folds to a constant — the backend emits `s_add_co_i32 sX, chunk0_addr, <imm>` per chunk instead of materializing a separate per-chunk LDS-address SGPR.

**Hoist the chunk-invariant descriptor.** `prepareGatherScatterDescriptorBase` builds the chunk-invariant fields once (group0[0] pred/mode, group0[2:3] global address, group1[0..3] tensor shape/barrier/tile_dim0); `fillGatherScatterChunk` re-stamps only the per-chunk lanes (group0[1] lds_addr, group1[4] index count, group2/3 indices). All chunks share one SGPR descriptor tuple; the backend bumps only the lds_addr lane between chunks instead of rebuilding group0.

**Verifier preconditions.** The two preconditions the optimization relies on are enforced at op construction (user diagnostic) rather than a release-stripped lowering assert:
- elements must be >=1 byte — the per-chunk byte-delta scaling truncates to 0 for sub-byte types (gather and scatter);
- for a padded gather, the padding interval must divide the innermost block dimension, so each chunk's row delta spans a whole number of intervals (scatter already enforces the stricter `interval == innermost` rule).

## Result

Gather correctness unchanged. For a 4-chunk gather in a loop, in-loop SALU drops 35 → 27 and the four `tensor_load_to_lds` go from 4 distinct group0 SGPR tuples to 1 shared tuple.
