### PR TITLE
fix: is_power_of_two returns True for 0

### DIFF
--- a/python/test/unit/test_utils.py
+++ b/python/test/unit/test_utils.py
@@ -1,0 +1,28 @@
+import pytest
+
+from triton._utils import is_power_of_two, validate_block_shape
+
+
+def test_is_power_of_two():
+    assert is_power_of_two(1)
+    assert is_power_of_two(2)
+    assert is_power_of_two(8)
+    assert is_power_of_two(1024)
+    # 0 is not a power of two; x & (x - 1) == 0 alone wrongly accepts it.
+    assert not is_power_of_two(0)
+    assert not is_power_of_two(3)
+    assert not is_power_of_two(6)
+    assert not is_power_of_two(-4)
+
+
+def test_validate_block_shape_rejects_zero():
+    # validate_block_shape promises every element is a power of 2, but a 0
+    # element used to slip through because is_power_of_two(0) returned True.
+    with pytest.raises(ValueError, match="must be a power of 2"):
+        validate_block_shape([0])
+    with pytest.raises(ValueError, match="must be a power of 2"):
+        validate_block_shape([8, 0])
+
+
+def test_validate_block_shape_accepts_powers_of_two():
+    assert validate_block_shape([8, 16]) == 128

--- a/python/triton/_utils.py
+++ b/python/triton/_utils.py
@@ -56,7 +56,8 @@ def find_paths_if(iterable: Union[IterableType, Any], pred: Callable[[ObjPath, A
 
 
 def is_power_of_two(x):
-    return (x & (x - 1)) == 0
+    # x & (x - 1) is also 0 for x == 0, but 0 is not a power of two, so guard it.
+    return x > 0 and (x & (x - 1)) == 0
 
 
 def validate_block_shape(shape: List[int]):


### PR DESCRIPTION
### Summary

`is_power_of_two` returns `True` for `0`:

```python
def is_power_of_two(x):
    return (x & (x - 1)) == 0
```

`0 & (0 - 1) == 0`, so the check passes even though 0 is not a power of two.

Its only caller is `validate_block_shape`, which loops over a shape and raises `"Shape element {i} must be a power of 2"` for any non-power-of-2 element. Because of this bug a `0` element slips through (and `numel` becomes 0) instead of producing that error — e.g. `validate_block_shape([0])` returns silently rather than rejecting the shape.

### Fix

Guard with `x > 0`, so 0 (and negatives) are correctly rejected.

### Tests

Added `python/test/unit/test_utils.py` covering `is_power_of_two` (including 0 and a negative) and `validate_block_shape` rejecting a `0` element while still accepting valid powers of two. It fails before this change and passes after.

I don't have a local Triton build, so I verified the logic standalone and rely on CI to run the test.
