### PR TITLE
[INTERPRETER] Support bfloat16 operations via ml_dtypes

### DIFF
--- a/docs/programming-guide/chapter-3/debugging.rst
+++ b/docs/programming-guide/chapter-3/debugging.rst
@@ -65,7 +65,6 @@ Limitations
 
 The interpreter has several known limitations:
 
-- It does not support operations on :code:`bfloat16` numeric types. To perform operations on :code:`bfloat16` tensors, use :code:`tl.cast(tensor)` to convert the tensor to :code:`float32`.
 - It does not support indirect memory access patterns such as:
 
   .. code-block:: python

--- a/python/test-requirements.txt
+++ b/python/test-requirements.txt
@@ -9,3 +9,4 @@ llnl-hatchet
 pandas<3.0
 expecttest
 msgpack
+ml_dtypes

--- a/python/test/unit/language/test_core.py
+++ b/python/test/unit/language/test_core.py
@@ -127,9 +127,6 @@ def check_type_supported(dtype, device):
             pytest.skip("bfloat16 is only supported on NVGPU with cc >= 80")
         if cc[0] < 9 and dtype in {tl.float8e4nv, "float8e4nv", "float8_e4m3fn"}:
             pytest.skip("float8e4nv is only supported on NVGPU with cc >= 90")
-    if is_interpreter():
-        if dtype in [tl.bfloat16, "bfloat16", torch.bfloat16]:
-            pytest.skip("bfloat16 is not supported in the interpreter")
 
 
 def get_src_element_ty_size(dtype_str):
@@ -1955,12 +1952,8 @@ def test_tensor_atomic_use_result(dtype_str, size, op, device):
 @pytest.mark.parametrize("num_ctas", num_ctas_list)
 def test_cast(dtype_x, dtype_z, bitcast, size, num_ctas, device):
     # CUDA: bfloat16 on cc < 80 will not be tested
-    # Interpreter: Only bfloat16 <-> float32 is supported
-    if not is_interpreter() or \
-        (is_interpreter() and not ((dtype_z == 'bfloat16' and dtype_x == 'float32')
-                                   or (dtype_z == 'float32' and dtype_x == 'bfloat16'))):
-        check_type_supported(dtype_x, device)
-        check_type_supported(dtype_z, device)
+    check_type_supported(dtype_x, device)
+    check_type_supported(dtype_z, device)
 
     if is_hip():
         if not is_hip_cdna3() and not is_hip_cdna4() and not is_hip_gfx1250() and (dtype_x == 'float8_e4m3fn'
@@ -3481,8 +3474,6 @@ def get_test_small_dots_cases():
 def test_dot(M, N, K, num_warps, col_a, col_b, epilogue, input_precision, in_dtype, out_dtype, kpack, mma_nonk_size,
              num_ctas, device):
     if is_interpreter():
-        if in_dtype == 'bfloat16':
-            pytest.skip("bfloat16 is not supported in the interpreter")
         if input_precision == "bf16x3" or input_precision == "bf16x6":
             pytest.skip(f"input_precision {input_precision} is not supported in the interpreter")
     else:
@@ -7035,9 +7026,6 @@ def test_tensor_member(device):
 @pytest.mark.parametrize("trans_a", [False, True])
 @pytest.mark.parametrize("trans_b", [False, True])
 def test_dot_multidim(rank, trans_a, trans_b, device):
-
-    if is_interpreter():
-        pytest.skip("bfloat16 is not supported in the interpreter")
 
     @triton.jit
     def kernel(X, Y, Z, RANK: tl.constexpr, TRANS_A: tl.constexpr, TRANS_B: tl.constexpr):

--- a/python/test/unit/language/test_core.py
+++ b/python/test/unit/language/test_core.py
@@ -1502,6 +1502,8 @@ def test_atomic_rmw_predicate(num_ctas, device):
                           for check_return_val in ([True, False] if is_hip() else [True])])
 def test_tensor_atomic_rmw(shape, axis, num_ctas, dtype_x_str, check_return_val, device):
     check_type_supported(dtype_x_str, device)
+    if is_interpreter() and dtype_x_str == 'bfloat16':
+        pytest.skip("atomic ops on bfloat16 are not supported in the interpreter")
     shape0, shape1 = shape
     # triton kernel
 
@@ -1581,6 +1583,8 @@ def test_tensor_atomic_rmw(shape, axis, num_ctas, dtype_x_str, check_return_val,
                                                          for dtype_x_str in ['bfloat16', 'float16', 'float32']])
 def test_tensor_atomic_add_non_exclusive_offset(size, num_ctas, dtype_x_str, device):
     check_type_supported(dtype_x_str, device)
+    if is_interpreter() and dtype_x_str == 'bfloat16':
+        pytest.skip("atomic ops on bfloat16 are not supported in the interpreter")
 
     @triton.jit
     def kernel(X, val, NUM: tl.constexpr):
@@ -1605,6 +1609,8 @@ def test_tensor_atomic_add_non_exclusive_offset(size, num_ctas, dtype_x_str, dev
                                                          for dtype_x_str in ['bfloat16', 'float16', 'float32']])
 def test_tensor_atomic_add_shift_1(size, num_ctas, dtype_x_str, device):
     check_type_supported(dtype_x_str, device)
+    if is_interpreter() and dtype_x_str == 'bfloat16':
+        pytest.skip("atomic ops on bfloat16 are not supported in the interpreter")
 
     @triton.jit
     def kernel(X, val, NUM: tl.constexpr):

--- a/python/triton/runtime/interpreter.py
+++ b/python/triton/runtime/interpreter.py
@@ -486,6 +486,9 @@ class InterpreterBuilder:
     def get_fp16(self, value):
         return TensorHandle(np.array([value], dtype=np.float16), tl.float16)
 
+    def get_bf16(self, value):
+        return TensorHandle(np.array([value], dtype=_get_np_dtype(tl.bfloat16)), tl.bfloat16)
+
     def get_fp32(self, value):
         return TensorHandle(np.array([value], dtype=np.float32), tl.float32)
 

--- a/python/triton/runtime/interpreter.py
+++ b/python/triton/runtime/interpreter.py
@@ -159,8 +159,7 @@ def _get_np_dtype(tt_dtype):
         tl.uint32: np.dtype(np.uint32),
         tl.int64: np.dtype(np.int64),
         tl.uint64: np.dtype(np.uint64),
-        # bfloat16 is backed by ml_dtypes so that arithmetic, casts, and
-        # reductions behave like a real float (with round-to-nearest-even)
+        # bfloat16 is backed by ml_dtypes, not raw uint16 bits
         tl.bfloat16: np.dtype(ml_dtypes.bfloat16),
         # float8 types are stored as uint8
         tl.float8e5: np.dtype(np.uint8),

--- a/python/triton/runtime/interpreter.py
+++ b/python/triton/runtime/interpreter.py
@@ -6,6 +6,7 @@ from typing import Tuple, List, Dict, Callable, TypeVar, Optional
 
 import math
 import numpy as np
+import ml_dtypes
 
 import triton
 import triton.language as tl
@@ -158,8 +159,9 @@ def _get_np_dtype(tt_dtype):
         tl.uint32: np.dtype(np.uint32),
         tl.int64: np.dtype(np.int64),
         tl.uint64: np.dtype(np.uint64),
-        # bfloat16 types are stored as uint16
-        tl.bfloat16: np.dtype(np.uint16),
+        # bfloat16 is backed by ml_dtypes so that arithmetic, casts, and
+        # reductions behave like a real float (with round-to-nearest-even)
+        tl.bfloat16: np.dtype(ml_dtypes.bfloat16),
         # float8 types are stored as uint8
         tl.float8e5: np.dtype(np.uint8),
         tl.float8e5b16: np.dtype(np.uint8),
@@ -526,14 +528,7 @@ class InterpreterBuilder:
 
     # casting ops
     def cast_impl(self, src, dst_type):
-        src_element_type = src.dtype.scalar
-        dst_element_type = dst_type.scalar
-        if (src_element_type == tl.bfloat16 and dst_element_type == tl.float32) or \
-           (src_element_type == tl.float32 and dst_element_type == tl.bfloat16):
-            data = _convert_float(src.data, src_element_type, dst_element_type, None).view(_get_np_dtype(dst_type))
-            return TensorHandle(data, dst_type.scalar)
-        else:
-            return TensorHandle(src.data.astype(_get_np_dtype(dst_type)), dst_type.scalar)
+        return TensorHandle(src.data.astype(_get_np_dtype(dst_type)), dst_type.scalar)
 
     create_si_to_fp = lambda self, src, dst_type: self.cast_impl(src, dst_type)
     create_ui_to_fp = lambda self, src, dst_type: self.cast_impl(src, dst_type)

--- a/python/triton/runtime/interpreter.py
+++ b/python/triton/runtime/interpreter.py
@@ -6,7 +6,6 @@ from typing import Tuple, List, Dict, Callable, TypeVar, Optional
 
 import math
 import numpy as np
-import ml_dtypes
 
 import triton
 import triton.language as tl
@@ -143,6 +142,18 @@ def _get_signed_np_dtype(dtype):
     return dtype
 
 
+def _get_bf16_np_dtype():
+    # numpy has no native bfloat16, so the interpreter backs it with the optional
+    # ml_dtypes package. It is imported lazily (only when a bf16 tensor is actually
+    # used) so it is not a hard dependency of every Triton install.
+    try:
+        import ml_dtypes  # type: ignore
+    except ImportError as e:
+        raise ImportError("Using bfloat16 tensors in the Triton interpreter requires the optional "
+                          "'ml_dtypes' package. Install it with `pip install ml_dtypes`.") from e
+    return np.dtype(ml_dtypes.bfloat16)
+
+
 def _get_np_dtype(tt_dtype):
     if isinstance(tt_dtype, tl.pointer_type):
         return np.dtype(np.uint64)
@@ -159,8 +170,6 @@ def _get_np_dtype(tt_dtype):
         tl.uint32: np.dtype(np.uint32),
         tl.int64: np.dtype(np.int64),
         tl.uint64: np.dtype(np.uint64),
-        # bfloat16 is backed by ml_dtypes, not raw uint16 bits
-        tl.bfloat16: np.dtype(ml_dtypes.bfloat16),
         # float8 types are stored as uint8
         tl.float8e5: np.dtype(np.uint8),
         tl.float8e5b16: np.dtype(np.uint8),
@@ -171,7 +180,9 @@ def _get_np_dtype(tt_dtype):
     if isinstance(tt_dtype, tl.block_type):
         if isinstance(tt_dtype.element_ty, tl.pointer_type):
             return np.dtype(np.uint64)
-        return np_types[tt_dtype.element_ty]
+        return _get_np_dtype(tt_dtype.element_ty)
+    if tt_dtype == tl.bfloat16:
+        return _get_bf16_np_dtype()
     return np_types[tt_dtype]
 
 

--- a/setup.py
+++ b/setup.py
@@ -589,9 +589,6 @@ setup(
     license="MIT",
     install_requires=[
         "importlib-metadata; python_version < '3.10'",
-        # Used by the interpreter to back bfloat16 tensors with a real numpy
-        # float dtype (numpy itself has no native bfloat16).
-        "ml_dtypes",
     ],
     packages=list(get_packages()),
     package_dir=dict(get_package_dirs()),

--- a/setup.py
+++ b/setup.py
@@ -589,6 +589,9 @@ setup(
     license="MIT",
     install_requires=[
         "importlib-metadata; python_version < '3.10'",
+        # Used by the interpreter to back bfloat16 tensors with a real numpy
+        # float dtype (numpy itself has no native bfloat16).
+        "ml_dtypes",
     ],
     packages=list(get_packages()),
     package_dir=dict(get_package_dirs()),


### PR DESCRIPTION
The interpreter could not perform operations on `bfloat16` tensors. NumPy has no native `bfloat16`, so the interpreter stored `bf16` as `uint16` bit patterns.

This PR backs `bfloat16` with [`ml_dtypes`](https://github.com/jax-ml/ml_dtypes) (`ml_dtypes.bfloat16`), a NumPy-compatible bfloat16 dtype, and enables arithmetic, casts, reductions, etc.

# New contributor declaration
- [x] I am not making a trivial change, such as fixing a typo in a comment.

- [x] I have written a PR description following these
  [rules](https://cbea.ms/git-commit/#why-not-how).

- [x] I have run `pre-commit run --from-ref origin/main --to-ref HEAD`.

- Select one of the following.
  - [x] I have added tests.
    - `/python/test` for end-to-end tests

- Select one of the following.
  - [x] I have not added any `lit` tests.