### PR TITLE
fix(autotuner): keep at least one config when a fractional top_k rounds to zero

### DIFF
--- a/python/test/unit/runtime/test_autotuner.py
+++ b/python/test/unit/runtime/test_autotuner.py
@@ -237,6 +237,32 @@ def test_prune_configs(with_perf_model: bool, device: str):
         assert records['capture_named_args']
 
 
+def test_prune_configs_fractional_top_k_keeps_one(device: str):
+    # A fractional top_k that rounds down to zero for a small config set must
+    # still keep one config instead of pruning them all and crashing the later
+    # min() on an empty set: here int(2 * 0.3) == 0.
+    N = 1024
+    src = torch.randn(N, device=device)
+    dst = torch.empty(N, device=device)
+
+    def perf_model(*args, **kwargs):
+        return kwargs['BLOCK_SIZE']
+
+    configs = [triton.Config(kwargs={'BLOCK_SIZE': 32}), triton.Config(kwargs={'BLOCK_SIZE': 128})]
+    prune_configs_by = {'perf_model': perf_model, 'top_k': 0.3}
+
+    @triton.autotune(configs=configs, key=['N'], prune_configs_by=prune_configs_by, do_bench=do_bench)
+    @triton.jit
+    def _kernel(dst, src, N, BLOCK_SIZE: tl.constexpr):
+        offsets = tl.program_id(0) * BLOCK_SIZE + tl.arange(0, BLOCK_SIZE)
+        x = tl.load(src + offsets, mask=offsets < N)
+        tl.store(dst + offsets, x, mask=offsets < N)
+
+    grid = lambda META: (triton.cdiv(N, META['BLOCK_SIZE']), )
+    _kernel[grid](dst, src, N=N)
+    torch.testing.assert_close(src, dst)
+
+
 @pytest.mark.parametrize("prune_kind", ["early_config_prune", "perf_model"])
 def test_pruned_single_config_skips_benchmark(prune_kind: str, device: str, fresh_knobs):
     N = 1024

--- a/python/triton/runtime/autotuner.py
+++ b/python/triton/runtime/autotuner.py
@@ -291,7 +291,11 @@ class Autotuner(KernelInterface):
         if self.perf_model:
             top_k = self.configs_top_k
             if isinstance(top_k, float) and top_k <= 1.0:
-                top_k = int(len(self.configs) * top_k)
+                # Keep at least one config: a small fraction over a small config
+                # set rounds down to zero, which would prune everything and crash
+                # the later min() on an empty set. early_config_prune already
+                # guarantees at least one config; mirror that here.
+                top_k = max(1, int(len(self.configs) * top_k))
             elif not isinstance(top_k, int):
                 # Slice index must be an integer
                 raise TypeError("Error while pruning configs, top_k must be either 1) a float <= 1.0 or 2) an int")


### PR DESCRIPTION
## Summary

`Autotuner.prune_configs` treats a float `top_k <= 1.0` as a fraction of the configs:

```python
if isinstance(top_k, float) and top_k <= 1.0:
    top_k = int(len(self.configs) * top_k)
```

For a small config set a small fraction rounds down to zero — e.g. `int(2 * 0.3) == 0`. The perf-model branch then slices `sorted(est_timing.keys(), ...)[:0]` and returns an **empty** config list. Back in `run()` the benchmark path builds an empty `timings` dict and `min(timings, key=timings.get)` raises `ValueError: min() arg is an empty sequence`.

`top_k` (including the fractional form, type-checked at the same spot) is a documented `prune_configs_by` field, and `early_config_prune` already guarantees "at least one config" — but the fractional `top_k` path doesn't.

## Fix

`max(1, int(len(self.configs) * top_k))` — always keep at least the single best config, matching the `early_config_prune` guarantee. Normal fractions and integer `top_k` are unaffected (`int(5 * 0.5) == 2`; an integer `top_k` skips this branch). When it resolves to a single config, the existing single-pruned-config fast path (#10413) takes over and skips benchmarking.

## Test

Added `test_prune_configs_fractional_top_k_keeps_one`, mirroring `test_prune_configs`: two configs + a perf model + `top_k=0.3` (which truncates to 0). Before the fix the autotuned launch raises the empty-`min()` `ValueError`; after it the best config is kept and the kernel runs.

## Verification

I verified the truncation logic and the `max(1, ...)` fix standalone in pure Python (`int(2 * 0.3) == 0` → empty slice → crash; `max(1, 0) == 1` → one config kept). I wasn't able to run the unit test locally — no GPU, and the Triton C extension isn't built on my machine — so the added test relies on CI. The change is `ruff` and `yapf` clean.
