### PR TITLE
[AMD] Prevent unsafe buffer soffset splits

### DIFF
--- a/test/TritonGPU/amd/amd-annotate-buffer-op-split-safety.mlir
+++ b/test/TritonGPU/amd/amd-annotate-buffer-op-split-safety.mlir
@@ -125,3 +125,84 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 1 : i32, "ttg.thr
         tt.return
     }
 }
+
+// -----
+
+#blocked0 = #ttg.blocked<{sizePerThread = [4], threadsPerWarp = [32], warpsPerCTA = [1], order = [0]}>
+module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 1 : i32, "ttg.threads-per-warp" = 32 : i32} {
+    // CHECK-LABEL: @no_split_overflowing_add
+    // CHECK: amdg.buffer_load
+    // CHECK-NOT: amdgpu.split_soffset_safe
+    tt.func @no_split_overflowing_add(%arg0: !tt.ptr<f32> {tt.divisibility = 16 : i32}) {
+        %range = tt.make_range {end = 1073741826 : i32, start = 1073741824 : i32} : tensor<2xi32, #blocked0>
+        %offset = arith.addi %range, %range : tensor<2xi32, #blocked0>
+        %ret = amdg.buffer_load %arg0[%offset] : tensor<2xf32, #blocked0>
+        tt.return
+    }
+}
+
+// -----
+
+#blocked0 = #ttg.blocked<{sizePerThread = [4], threadsPerWarp = [32], warpsPerCTA = [1], order = [0]}>
+module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 1 : i32, "ttg.threads-per-warp" = 32 : i32} {
+    // CHECK-LABEL: @no_split_overflowing_mul
+    // CHECK: amdg.buffer_load
+    // CHECK-NOT: amdgpu.split_soffset_safe
+    tt.func @no_split_overflowing_mul(%arg0: !tt.ptr<f32> {tt.divisibility = 16 : i32}) {
+        %big = arith.constant dense<1073741824> : tensor<1xi32, #blocked0>
+        %range = tt.make_range {end = 4 : i32, start = 3 : i32} : tensor<1xi32, #blocked0>
+        %offset = arith.muli %range, %big : tensor<1xi32, #blocked0>
+        %ret = amdg.buffer_load %arg0[%offset] : tensor<1xf32, #blocked0>
+        tt.return
+    }
+}
+
+// -----
+
+#blocked0 = #ttg.blocked<{sizePerThread = [4], threadsPerWarp = [32], warpsPerCTA = [1], order = [0]}>
+module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 1 : i32, "ttg.threads-per-warp" = 32 : i32} {
+    // CHECK-LABEL: @no_split_overflowing_shl
+    // CHECK: amdg.buffer_load
+    // CHECK-NOT: amdgpu.split_soffset_safe
+    tt.func @no_split_overflowing_shl(%arg0: !tt.ptr<f32> {tt.divisibility = 16 : i32}) {
+        %sh = arith.constant dense<30> : tensor<1xi32, #blocked0>
+        %range = tt.make_range {end = 4 : i32, start = 3 : i32} : tensor<1xi32, #blocked0>
+        %offset = arith.shli %range, %sh : tensor<1xi32, #blocked0>
+        %ret = amdg.buffer_load %arg0[%offset] : tensor<1xf32, #blocked0>
+        tt.return
+    }
+}
+
+// -----
+
+#blocked0 = #ttg.blocked<{sizePerThread = [4], threadsPerWarp = [32], warpsPerCTA = [1], order = [0]}>
+module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 1 : i32, "ttg.threads-per-warp" = 32 : i32} {
+    // CHECK-LABEL: @no_split_shrui_by_zero
+    // CHECK: amdg.buffer_load
+    // CHECK-NOT: amdgpu.split_soffset_safe
+    tt.func @no_split_shrui_by_zero(%arg0: !tt.ptr<f32> {tt.divisibility = 16 : i32}) {
+        %neg = arith.constant dense<-1> : tensor<1xi32, #blocked0>
+        %zero = arith.constant dense<0> : tensor<1xi32, #blocked0>
+        %offset = arith.shrui %neg, %zero : tensor<1xi32, #blocked0>
+        %ret = amdg.buffer_load %arg0[%offset] : tensor<1xf32, #blocked0>
+        tt.return
+    }
+}
+
+// -----
+
+#blocked0 = #ttg.blocked<{sizePerThread = [4], threadsPerWarp = [32], warpsPerCTA = [1], order = [0]}>
+module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 1 : i32, "ttg.threads-per-warp" = 32 : i32} {
+    // CHECK-LABEL: @no_split_cat_hides_negative_leaf
+    // CHECK: amdg.buffer_load
+    // CHECK-NOT: amdgpu.split_soffset_safe
+    tt.func @no_split_cat_hides_negative_leaf(%arg0: !tt.ptr<f32> {tt.divisibility = 16 : i32}) {
+        %two = arith.constant dense<2> : tensor<2xi32, #blocked0>
+        %range = tt.make_range {end = 2 : i32, start = 0 : i32} : tensor<2xi32, #blocked0>
+        %leaf = arith.subi %range, %two : tensor<2xi32, #blocked0>
+        %offset = arith.addi %leaf, %two : tensor<2xi32, #blocked0>
+        %cat = tt.cat %offset, %offset : tensor<2xi32, #blocked0> -> tensor<4xi32, #blocked0>
+        %ret = amdg.buffer_load %arg0[%cat] : tensor<4xf32, #blocked0>
+        tt.return
+    }
+}

--- a/third_party/amd/lib/TritonAMDGPUTransforms/AnnotateBufferOpSplitSafety.cpp
+++ b/third_party/amd/lib/TritonAMDGPUTransforms/AnnotateBufferOpSplitSafety.cpp
@@ -28,7 +28,8 @@ constexpr llvm::StringLiteral kSplitSafeAttrName = "amdgpu.split_soffset_safe";
 static bool isTransparentWrapper(Operation *op) {
   bool isWrapper =
       isa<triton::SplatOp, triton::BroadcastOp, triton::ExpandDimsOp,
-          triton::ReshapeOp, ttg::ConvertLayoutOp>(op);
+          triton::ReshapeOp, triton::SplitOp, triton::TransOp,
+          tta::ExtractSliceOp, ttg::ConvertLayoutOp>(op);
   assert((!isWrapper || op->getNumOperands() == 1) &&
          "transparent wrapper must have a single SSA operand.");
   return isWrapper;
@@ -44,6 +45,15 @@ static Value peelTransparentWrappers(Value v) {
   return v;
 }
 
+// True when the integer-range lattice proves `v` non-negative. The lattice
+// models i32 wrap, so it rejects values that overflow into the sign bit.
+static bool hasNonNegativeRange(Value v, DataFlowSolver &solver) {
+  const auto *range = solver.lookupState<dataflow::IntegerValueRangeLattice>(v);
+  return range && !range->getValue().isUninitialized() &&
+         !AMD::isEmptyInitializedRange(range->getValue().getValue()) &&
+         succeeded(dataflow::staticallyNonNegative(solver, v));
+}
+
 // Conservatively accept an offset only when every leaf in its
 // additive/shape expression proves non-negative. This may miss safe splits,
 // but never annotates an offset with a possibly-negative voffset.
@@ -51,15 +61,11 @@ static bool isLeafNonNegative(Value v, DataFlowSolver &solver) {
   // An `add` is never a leaf to the soffset splitter. It peels the summands
   // apart and lifts the uniform ones into the unsigned soffset. So a sum whose
   // range is non-negative can still hide a negative summand.
-  if (peelTransparentWrappers(v).getDefiningOp<arith::AddIOp>())
+  Value peeled = peelTransparentWrappers(v);
+  Operation *def = peeled.getDefiningOp();
+  if (def && isa<arith::AddIOp, triton::CatOp, triton::JoinOp>(def))
     return false;
-
-  const auto *range = solver.lookupState<dataflow::IntegerValueRangeLattice>(v);
-  if (!range || range->getValue().isUninitialized())
-    return false;
-  if (AMD::isEmptyInitializedRange(range->getValue().getValue()))
-    return false;
-  return succeeded(dataflow::staticallyNonNegative(solver, v));
+  return hasNonNegativeRange(v, solver);
 }
 
 static bool isNonNegative(Value v, DataFlowSolver &solver) {
@@ -75,12 +81,33 @@ static bool isNonNegative(Value v, DataFlowSolver &solver) {
   if (!def)
     return false;
 
+  // The splitter re-sums the per-lane leaves into a single i32 voffset, so a
+  // sum of non-negative leaves can still overflow and wrap negative. Require
+  // the sum's range to be non-negative in addition to every operand.
+  if (isa<arith::AddIOp>(def)) {
+    if (!hasNonNegativeRange(v, solver))
+      return false;
+    for (Value operand : def->getOperands())
+      if (!isNonNegative(operand, solver))
+        return false;
+    return true;
+  }
+
+  if (isa<triton::CatOp, triton::JoinOp>(def)) {
+    for (Value operand : def->getOperands())
+      if (!isNonNegative(operand, solver))
+        return false;
+    return true;
+  }
+
   // Recurse through ops where "all operands non-negative -> result
-  // non-negative" (with the same < 2GB wrap caveat the rest of the
-  // buffer-op path already accepts on add/mul).
-  if (isa<arith::AddIOp, arith::MulIOp, arith::OrIOp, arith::XOrIOp,
-          arith::DivSIOp, arith::DivUIOp, arith::MinSIOp, arith::MinUIOp,
-          arith::MaxSIOp, arith::MaxUIOp, arith::ExtSIOp>(def)) {
+  // non-negative". `mul` and `shl` are excluded: they scale magnitude, so a
+  // product or shift of non-negative values can overflow i32 and wrap negative.
+  // They are trusted only when the lattice check above already proved them
+  // non-negative.
+  if (isa<arith::OrIOp, arith::XOrIOp, arith::DivSIOp, arith::DivUIOp,
+          arith::MinSIOp, arith::MinUIOp, arith::MaxSIOp, arith::MaxUIOp,
+          arith::ExtSIOp>(def)) {
     for (Value operand : def->getOperands())
       if (!isNonNegative(operand, solver))
         return false;
@@ -88,11 +115,11 @@ static bool isNonNegative(Value v, DataFlowSolver &solver) {
   }
 
   // First operand only (sign carries from operand 0).
-  if (isa<arith::ShLIOp, arith::ShRSIOp, arith::RemSIOp, arith::RemUIOp>(def))
+  if (isa<arith::ShRSIOp, arith::RemSIOp, arith::RemUIOp>(def))
     return isNonNegative(def->getOperand(0), solver);
 
   // Always non-negative regardless of operands.
-  if (isa<arith::ShRUIOp, arith::ExtUIOp>(def))
+  if (isa<arith::ExtUIOp>(def))
     return true;
 
   // Triton shape/control ops that are non-negative or preserve sign.


### PR DESCRIPTION
## Summary

#10362 splits a uniform component of an AMD buffer op offset into scalar `soffset`. That is only safe when the remaining per-lane `voffset` is safe by itself, because AMD raw buffer ops perform bounds/OOB handling on `voffset` before adding `soffset`.

The PyTorch Inductor repro generates offsets shaped like:

```text
offset = x0 + x1 * 67108864 + uniform_chunk_offset
```

`x1 * 67108864` can wrap negative in i32. The uniform chunk can make the final combined offset valid, but if #10362 lifts that chunk into `soffset`, the wrapped value is left in `voffset` and the active lane is treated as OOB.

We initially observed Pytorch Inductor `test_int64_index_intermediate` failing on MI300x (https://hud.pytorch.org/pr/pytorch/pytorch/185453#82449648818). We bisected to #10362 as the root cause and this PR will fix the issue.

## Fix

Tighten `AnnotateBufferOpSplitSafety` so `amdgpu.split_soffset_safe` is only added when values that can remain in `voffset` are independently non-negative:

* `arith.addi` now requires both the add result and all split leaves to prove non-negative.
* `arith.muli`, `arith.shli`, and unsafe `arith.shrui` cases are not accepted by structural reasoning that can miss i32 wrap/sign-bit behavior.
* value-forwarding ops are checked through instead of relying only on an aggregate result range, so `cat`/`join` and transparent shape/layout wrappers cannot hide an unsafe leaf.

Without the attribute, the emitter keeps the whole offset in `voffset` (pre-#10362 behavior), preserving correctness. Offsets whose leaves are provably safe can still split.

## Testing

* Hardware (MI300X, gfx942): PyTorch `CudaReproTests.test_int64_index_intermediate` passes.
* Hardware (MI300X, gfx942): PyTorch `CudaReproTests.test_dont_inplace_disjoint_accesses` still passes, preserving #10673.
* Focused lit: `amd-annotate-buffer-op-split-safety.mlir` covers overflowing `add`/`mul`/`shl`, `shrui` by zero, and a `cat`-wrapped hidden negative leaf.
* `pre-commit run --from-ref origin/main --to-ref HEAD`.
* `clang-format --dry-run --Werror` and `git diff --check`.

Tracks pytorch/pytorch#187401.

Authored with Claude
