### PR TITLE
Optimize TMA descriptor layouts for partial reductions

### DIFF
--- a/lib/Dialect/TritonGPU/Transforms/Coalesce.cpp
+++ b/lib/Dialect/TritonGPU/Transforms/Coalesce.cpp
@@ -27,8 +27,29 @@ namespace gpu {
 // destination layout will affect the shared memory load/store generated. So we
 // still want to allow vectorization for the src/destination layout up to
 // 16bytes.
+static std::optional<unsigned> getReductionAxis(Operation *op) {
+  while (op->getNumResults() == 1 && op->getResult(0).hasOneUse()) {
+    Operation *user = *op->getResult(0).getUsers().begin();
+    if (auto reduce = dyn_cast<ReduceOp>(user)) {
+      if (reduce.getNumOperands() == 1)
+        return reduce.getAxis();
+      return std::nullopt;
+    }
+    if (!user->hasTrait<OpTrait::Elementwise>() || user->getNumResults() != 1)
+      return std::nullopt;
+    auto inputType = dyn_cast<RankedTensorType>(op->getResult(0).getType());
+    auto outputType = dyn_cast<RankedTensorType>(user->getResult(0).getType());
+    if (!inputType || !outputType ||
+        inputType.getShape() != outputType.getShape())
+      return std::nullopt;
+    op = user;
+  }
+  return std::nullopt;
+}
+
 static Attribute pickDescriptorLoadStoreLayout(int numWarps, int threadsPerWarp,
-                                               RankedTensorType type) {
+                                               RankedTensorType type,
+                                               Operation *op) {
   auto shapePerCTA = triton::gpu::getShapePerCTA(type);
   int numElems = product<int64_t>(shapePerCTA);
   int numThreads = numWarps * threadsPerWarp;
@@ -38,10 +59,22 @@ static Attribute pickDescriptorLoadStoreLayout(int numWarps, int threadsPerWarp,
 
   int vectorSize = std::min(numElemsPerThread, maxVectorSize);
   SmallVector<unsigned> sizePerThread(type.getRank(), 1);
-  sizePerThread.back() = vectorSize;
 
   SmallVector<unsigned> order =
       getMatrixOrder(type.getRank(), /*rowMajor*/ true);
+  if (auto reductionAxis = getReductionAxis(op)) {
+    int64_t nonReductionElems = numElems / shapePerCTA[*reductionAxis];
+    if (nonReductionElems >= numThreads) {
+      // Prefer a thread-local reduction when the other dimensions can occupy
+      // the whole CTA. Vectorizing the descriptor load in this case can spread
+      // the reduction axis across lanes and warps, making the reduction much
+      // more expensive than the wider shared-memory load is worth.
+      vectorSize = 1;
+      order.erase(llvm::find(order, *reductionAxis));
+      order.push_back(*reductionAxis);
+    }
+  }
+  sizePerThread.back() = vectorSize;
   auto cgaLayout = triton::gpu::getCGALayout(type.getEncoding());
 
   Attribute layout = triton::gpu::BlockedEncodingAttr::get(
@@ -59,11 +92,11 @@ static void pickDescriptorLoadStoreLayout(
       if (load->getNumResults() == 1)
         layoutMap[op] = pickDescriptorLoadStoreLayout(
             numWarps, threadsPerWarp,
-            cast<RankedTensorType>(load->getResult(0).getType()));
+            cast<RankedTensorType>(load->getResult(0).getType()), op);
     }
     if (auto store = dyn_cast<DescriptorStoreLikeOpInterface>(op)) {
-      layoutMap[op] = pickDescriptorLoadStoreLayout(numWarps, threadsPerWarp,
-                                                    store.getSrc().getType());
+      layoutMap[op] = pickDescriptorLoadStoreLayout(
+          numWarps, threadsPerWarp, store.getSrc().getType(), op);
     }
   });
 }

--- a/test/TritonGPU/coalesce.mlir
+++ b/test/TritonGPU/coalesce.mlir
@@ -1,4 +1,5 @@
 // RUN: triton-opt %s -split-input-file -tritongpu-coalesce | FileCheck %s
+// RUN: triton-opt %s -split-input-file -tritongpu-coalesce -tritongpu-remove-layout-conversions | FileCheck %s --check-prefix=RLC
 
 #blocked0 = #ttg.blocked<{sizePerThread = [1], threadsPerWarp = [32], warpsPerCTA = [4], order = [0]}>
 #blocked1 = #ttg.blocked<{sizePerThread = [1, 1], threadsPerWarp = [32, 1], warpsPerCTA = [4, 1], order = [0, 1]}>
@@ -294,6 +295,52 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.targ
     // CHECK:  tt.load %1 : tensor<32x4x4x!tt.ptr<i8>, #blocked>
     %108 = tt.load %50 : tensor<32x4x4x!tt.ptr<i8>, #blocked>
     tt.return
+  }
+}
+
+// -----
+
+#blocked = #ttg.blocked<{sizePerThread = [1, 1, 1], threadsPerWarp = [1, 2, 16], warpsPerCTA = [1, 4, 1], order = [2, 1, 0]}>
+module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.target = "cuda:100", "ttg.threads-per-warp" = 32 : i32} {
+  // CHECK: #[[$REDUCE_LOCAL:.*]] = #ttg.blocked<{sizePerThread = [1, 1, 1], threadsPerWarp = [1, 1, 32], warpsPerCTA = [1, 1, 4], order = [2, 0, 1]}>
+  // CHECK-LABEL: @descriptor_load_partial_reduce
+  // RLC: #[[$RLC_REDUCE_LOCAL:.*]] = #ttg.blocked<{sizePerThread = [1, 1, 1], threadsPerWarp = [1, 1, 32], warpsPerCTA = [1, 1, 4], order = [2, 0, 1]}>
+  // RLC-LABEL: @descriptor_load_partial_reduce
+  tt.func public @descriptor_load_partial_reduce(%arg0: !tt.tensordesc<1x32x128xbf16>) -> tensor<1x128xf32, #ttg.slice<{dim = 1, parent = #blocked}>> {
+    %c0_i32 = arith.constant 0 : i32
+    // CHECK: %[[LOAD:.+]] = tt.descriptor_load {{.*}} -> tensor<1x32x128xbf16, #[[$REDUCE_LOCAL]]>
+    // RLC: %[[RLC_LOAD:.+]] = tt.descriptor_load {{.*}} -> tensor<1x32x128xbf16, #[[$RLC_REDUCE_LOCAL]]>
+    // RLC: %[[RLC_EXT:.+]] = arith.extf %[[RLC_LOAD]] : tensor<1x32x128xbf16, #[[$RLC_REDUCE_LOCAL]]> to tensor<1x32x128xf32, #[[$RLC_REDUCE_LOCAL]]>
+    // RLC: %[[RLC_REDUCE:.+]] = "tt.reduce"(%[[RLC_EXT]])
+    // RLC: ttg.convert_layout %[[RLC_REDUCE]] : tensor<1x128xf32, #ttg.slice<{dim = 1, parent = #[[$RLC_REDUCE_LOCAL]]}>> -> tensor<1x128xf32
+    %0 = tt.descriptor_load %arg0[%c0_i32, %c0_i32, %c0_i32] : !tt.tensordesc<1x32x128xbf16> -> tensor<1x32x128xbf16, #blocked>
+    %1 = arith.extf %0 : tensor<1x32x128xbf16, #blocked> to tensor<1x32x128xf32, #blocked>
+    %2 = "tt.reduce"(%1) <{axis = 1 : i32}> ({
+    ^bb0(%lhs: f32, %rhs: f32):
+      %max = arith.maximumf %lhs, %rhs : f32
+      tt.reduce.return %max : f32
+    }) : (tensor<1x32x128xf32, #blocked>) -> tensor<1x128xf32, #ttg.slice<{dim = 1, parent = #blocked}>>
+    tt.return %2 : tensor<1x128xf32, #ttg.slice<{dim = 1, parent = #blocked}>>
+  }
+}
+
+// -----
+
+#blocked = #ttg.blocked<{sizePerThread = [1, 1, 1], threadsPerWarp = [1, 2, 16], warpsPerCTA = [1, 4, 1], order = [2, 1, 0]}>
+module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.target = "cuda:100", "ttg.threads-per-warp" = 32 : i32} {
+  // CHECK: #[[$VECTORIZED:.*]] = #ttg.blocked<{sizePerThread = [1, 1, 4], threadsPerWarp = [1, 8, 4], warpsPerCTA = [1, 4, 1], order = [2, 1, 0]}>
+  // CHECK-LABEL: @descriptor_load_small_partial_reduce
+  tt.func public @descriptor_load_small_partial_reduce(%arg0: !tt.tensordesc<1x32x16xbf16>) -> tensor<1x16xf32, #ttg.slice<{dim = 1, parent = #blocked}>> {
+    %c0_i32 = arith.constant 0 : i32
+    // CHECK: tt.descriptor_load {{.*}} -> tensor<1x32x16xbf16, #[[$VECTORIZED]]>
+    %0 = tt.descriptor_load %arg0[%c0_i32, %c0_i32, %c0_i32] : !tt.tensordesc<1x32x16xbf16> -> tensor<1x32x16xbf16, #blocked>
+    %1 = arith.extf %0 : tensor<1x32x16xbf16, #blocked> to tensor<1x32x16xf32, #blocked>
+    %2 = "tt.reduce"(%1) <{axis = 1 : i32}> ({
+    ^bb0(%lhs: f32, %rhs: f32):
+      %max = arith.maximumf %lhs, %rhs : f32
+      tt.reduce.return %max : f32
+    }) : (tensor<1x32x16xf32, #blocked>) -> tensor<1x16xf32, #ttg.slice<{dim = 1, parent = #blocked}>>
+    tt.return %2 : tensor<1x16xf32, #ttg.slice<{dim = 1, parent = #blocked}>>
   }
 }
 


### PR DESCRIPTION
## Summary

- make descriptor-load coalescing recognize a single-use elementwise chain ending in a single-input partial reduction
- prefer a reduction-local blocked layout when non-reduction dimensions can occupy the full CTA
- retain the existing vectorized descriptor layout when the non-reduction dimensions do not provide enough parallelism

## Root cause

Descriptor loads currently always prioritize up to 16-byte vectorization. For the reproducer in #9703, that distributes the 32-element reduction axis across lanes and warps, turning a thread-local reduction into a cross-warp reduction.

The new heuristic only changes the layout when all of these hold:

- the descriptor result has a single-use, shape-preserving elementwise chain
- the chain ends in a single-input reduction
- the non-reduction dimensions contain at least one element per CTA thread

In that case the reduction axis is placed last in the blocked-layout order and descriptor vectorization is disabled. After `RemoveLayoutConversions`, the load and elementwise conversion stay in that layout, the reduction is thread-local, and any required conversion is deferred until after the tensor has been reduced.

## Tests

- built `triton-opt` locally with `-Werror`
- `lit -v .../test/TritonGPU/coalesce.mlir`
- `lit -v .../test/TritonGPU/coalesce-async-copy.mlir`
- `lit -v .../test/TritonGPU/amd/amd-coalesce-async-copy.mlir`

The regression test covers the `1x32x128` shape from #9703 and checks the full `coalesce + remove-layout-conversions` pipeline. A negative test verifies that a smaller `1x32x16` output dimension retains the vectorized descriptor layout.

## Performance validation

I do not have access to the GB300 system from the report, so this is a draft pending a rerun of the original benchmark on that hardware. The generated TTGIR now keeps the reduction axis thread-local and moves the remaining layout conversion after the reduction.

Fixes #9703.
