### PR TITLE
[AMD] Use operand-major LDS layout for FMA dot operands

### DIFF
--- a/test/TritonGPU/amd/amd-pipeline-fma-shared-layout.mlir
+++ b/test/TritonGPU/amd/amd-pipeline-fma-shared-layout.mlir
@@ -1,0 +1,105 @@
+// RUN: triton-opt %s -split-input-file -tritonamdgpu-schedule-loops="num_stages=2" -tritonamdgpu-pipeline | FileCheck %s
+
+// Positive case: FMA dot, B operand (opIdx = 1) whose
+// global load is K-contiguous (order = [0, 1]). The dot reads from LDS strided
+// in this orientation, so the shared buffer must be flipped to operand-major
+// (N-contiguous, order = [1, 0]).
+
+#blocked = #ttg.blocked<{sizePerThread = [1, 1], threadsPerWarp = [2, 16], warpsPerCTA = [1, 1], order = [0, 1]}>
+#fma = #ttg.blocked<{sizePerThread = [1, 1], threadsPerWarp = [2, 16], warpsPerCTA = [1, 1], order = [1, 0]}>
+// CHECK: #shared = {{.*}}order = [1, 0]
+module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 1 : i32, ttg.target = "hip:gfx1100", "ttg.threads-per-warp" = 32 : i32} {
+  // CHECK-LABEL: fma_operand_b_kcontig_is_flipped
+  tt.func @fma_operand_b_kcontig_is_flipped(
+                %argB: tensor<32x32x!tt.ptr<f32>, #blocked>,
+                %argA: tensor<32x32xf32, #ttg.dot_op<{opIdx = 0, parent = #fma}>>,
+                %lb: i32, %ub: i32, %step: i32) -> tensor<32x32xf32, #fma> {
+    // CHECK: ttg.local_alloc {{.*}} #shared
+    %cst_acc = arith.constant dense<0.000000e+00> : tensor<32x32xf32, #fma>
+    %result = scf.for %iv = %lb to %ub step %step iter_args(%acc = %cst_acc) -> (tensor<32x32xf32, #fma>) : i32 {
+      %b = tt.load %argB : tensor<32x32x!tt.ptr<f32>, #blocked>
+      %b_dot = ttg.convert_layout %b : tensor<32x32xf32, #blocked> -> tensor<32x32xf32, #ttg.dot_op<{opIdx = 1, parent = #fma}>>
+      %c = tt.dot %argA, %b_dot, %acc : tensor<32x32xf32, #ttg.dot_op<{opIdx = 0, parent = #fma}>> * tensor<32x32xf32, #ttg.dot_op<{opIdx = 1, parent = #fma}>> -> tensor<32x32xf32, #fma>
+      scf.yield %c : tensor<32x32xf32, #fma>
+    }
+    tt.return %result : tensor<32x32xf32, #fma>
+  }
+}
+
+// -----
+
+// Positive case: FMA dot, A operand (opIdx = 0) whose global load is
+// K-contiguous (order = [1, 0]). Flip to operand-major (M-contiguous,
+// order = [0, 1]).
+
+#blocked = #ttg.blocked<{sizePerThread = [1, 1], threadsPerWarp = [16, 2], warpsPerCTA = [1, 1], order = [1, 0]}>
+#fma = #ttg.blocked<{sizePerThread = [1, 1], threadsPerWarp = [16, 2], warpsPerCTA = [1, 1], order = [1, 0]}>
+// CHECK: #shared = {{.*}}order = [0, 1]
+module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 1 : i32, ttg.target = "hip:gfx1100", "ttg.threads-per-warp" = 32 : i32} {
+  // CHECK-LABEL: fma_operand_a_kcontig_is_flipped
+  tt.func @fma_operand_a_kcontig_is_flipped(
+                %argA: tensor<32x32x!tt.ptr<f32>, #blocked>,
+                %argB: tensor<32x32xf32, #ttg.dot_op<{opIdx = 1, parent = #fma}>>,
+                %lb: i32, %ub: i32, %step: i32) -> tensor<32x32xf32, #fma> {
+    // CHECK: ttg.local_alloc {{.*}} #shared
+    %cst_acc = arith.constant dense<0.000000e+00> : tensor<32x32xf32, #fma>
+    %result = scf.for %iv = %lb to %ub step %step iter_args(%acc = %cst_acc) -> (tensor<32x32xf32, #fma>) : i32 {
+      %a = tt.load %argA : tensor<32x32x!tt.ptr<f32>, #blocked>
+      %a_dot = ttg.convert_layout %a : tensor<32x32xf32, #blocked> -> tensor<32x32xf32, #ttg.dot_op<{opIdx = 0, parent = #fma}>>
+      %c = tt.dot %a_dot, %argB, %acc : tensor<32x32xf32, #ttg.dot_op<{opIdx = 0, parent = #fma}>> * tensor<32x32xf32, #ttg.dot_op<{opIdx = 1, parent = #fma}>> -> tensor<32x32xf32, #fma>
+      scf.yield %c : tensor<32x32xf32, #fma>
+    }
+    tt.return %result : tensor<32x32xf32, #fma>
+  }
+}
+
+// -----
+
+// Negative case: MFMA dot, the layout must be left untouched.
+
+#blocked = #ttg.blocked<{sizePerThread = [1, 1], threadsPerWarp = [16, 4], warpsPerCTA = [1, 1], order = [0, 1]}>
+#mma = #ttg.amd_mfma<{version = 4, warpsPerCTA = [1, 1], instrShape = [16, 16, 4], isTransposed = true}>
+// CHECK: #shared = {{.*}}order = [0, 1]
+module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 1 : i32, ttg.target = "hip:gfx950", "ttg.threads-per-warp" = 64 : i32} {
+  // CHECK-LABEL: mfma_operand_b_kcontig_is_not_flipped
+  tt.func @mfma_operand_b_kcontig_is_not_flipped(
+                %argB: tensor<32x32x!tt.ptr<f32>, #blocked>,
+                %argA: tensor<16x32xf32, #ttg.dot_op<{opIdx = 0, parent = #mma, kWidth = 1}>>,
+                %lb: i32, %ub: i32, %step: i32) -> tensor<16x32xf32, #mma> {
+    // CHECK: ttg.local_alloc {{.*}} #shared
+    %cst_acc = arith.constant dense<0.000000e+00> : tensor<16x32xf32, #mma>
+    %result = scf.for %iv = %lb to %ub step %step iter_args(%acc = %cst_acc) -> (tensor<16x32xf32, #mma>) : i32 {
+      %b = tt.load %argB : tensor<32x32x!tt.ptr<f32>, #blocked>
+      %b_dot = ttg.convert_layout %b : tensor<32x32xf32, #blocked> -> tensor<32x32xf32, #ttg.dot_op<{opIdx = 1, parent = #mma, kWidth = 1}>>
+      %c = tt.dot %argA, %b_dot, %acc : tensor<16x32xf32, #ttg.dot_op<{opIdx = 0, parent = #mma, kWidth = 1}>> * tensor<32x32xf32, #ttg.dot_op<{opIdx = 1, parent = #mma, kWidth = 1}>> -> tensor<16x32xf32, #mma>
+      scf.yield %c : tensor<16x32xf32, #mma>
+    }
+    tt.return %result : tensor<16x32xf32, #mma>
+  }
+}
+
+// -----
+
+// No-op case: FMA dot, B operand (opIdx = 1) whose global load is already
+// operand-major (N-contiguous, order = [1, 0]).
+
+#blocked = #ttg.blocked<{sizePerThread = [1, 1], threadsPerWarp = [2, 16], warpsPerCTA = [1, 1], order = [1, 0]}>
+#fma = #ttg.blocked<{sizePerThread = [1, 1], threadsPerWarp = [2, 16], warpsPerCTA = [1, 1], order = [1, 0]}>
+// CHECK: #shared = {{.*}}order = [1, 0]
+module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 1 : i32, ttg.target = "hip:gfx1100", "ttg.threads-per-warp" = 32 : i32} {
+  // CHECK-LABEL: fma_operand_b_already_operand_major
+  tt.func @fma_operand_b_already_operand_major(
+                %argB: tensor<32x32x!tt.ptr<f32>, #blocked>,
+                %argA: tensor<32x32xf32, #ttg.dot_op<{opIdx = 0, parent = #fma}>>,
+                %lb: i32, %ub: i32, %step: i32) -> tensor<32x32xf32, #fma> {
+    // CHECK: ttg.local_alloc {{.*}} #shared
+    %cst_acc = arith.constant dense<0.000000e+00> : tensor<32x32xf32, #fma>
+    %result = scf.for %iv = %lb to %ub step %step iter_args(%acc = %cst_acc) -> (tensor<32x32xf32, #fma>) : i32 {
+      %b = tt.load %argB : tensor<32x32x!tt.ptr<f32>, #blocked>
+      %b_dot = ttg.convert_layout %b : tensor<32x32xf32, #blocked> -> tensor<32x32xf32, #ttg.dot_op<{opIdx = 1, parent = #fma}>>
+      %c = tt.dot %argA, %b_dot, %acc : tensor<32x32xf32, #ttg.dot_op<{opIdx = 0, parent = #fma}>> * tensor<32x32xf32, #ttg.dot_op<{opIdx = 1, parent = #fma}>> -> tensor<32x32xf32, #fma>
+      scf.yield %c : tensor<32x32xf32, #fma>
+    }
+    tt.return %result : tensor<32x32xf32, #fma>
+  }
+}

--- a/third_party/amd/lib/TritonAMDGPUTransforms/LowerLoops.cpp
+++ b/third_party/amd/lib/TritonAMDGPUTransforms/LowerLoops.cpp
@@ -272,6 +272,24 @@ std::optional<ttg::SharedEncodingTrait> getSharedEncIfAllUsersAreDotEnc(
 
       auto userResEnc = cast<ttg::TensorOrMemDesc>(userResType).getEncoding();
       if (auto dotOpEnc = dyn_cast<ttg::DotOperandEncodingAttr>(userResEnc)) {
+        // FMA LDS layout flip (read-side coalescing).
+        // sharedOrder is otherwise inherited from the global-load contiguity.
+        // When an FMA dot operand arrives K-contiguous in global memory (e.g.
+        // A or B is transposed), the dot reads from LDS strided, serializing
+        // the loads. Re-orient the shared buffer to operand-major so those
+        // reads are coalesced.
+        if (rank == 2 && isa<ttg::BlockedEncodingAttr>(dotOpEnc.getParent())) {
+          SmallVector<unsigned> operandMajorOrder = ttg::getOrderForDotOperand(
+              dotOpEnc.getOpIdx(), /*rank=*/2, /*kContig=*/false);
+          if (sharedOrder != operandMajorOrder) {
+            LDBG("FMA LDS layout flip: sharedOrder ["
+                 << sharedOrder[0] << "," << sharedOrder[1]
+                 << "] -> operand-major [" << operandMajorOrder[0] << ","
+                 << operandMajorOrder[1]
+                 << "] for opIdx=" << dotOpEnc.getOpIdx());
+            sharedOrder = std::move(operandMajorOrder);
+          }
+        }
         // Determine if we can use padded layouts and fallback to swizzled
         // layouts if not
         bool canUseAsyncCopy = false;


### PR DESCRIPTION
## Motivation
For dot ops that go through the FMA path, the LDS layout is inherited from the operand's global-load contiguity. When an operand arrives K-contiguous in global memory (for example, if B is trasnposed), the dot ends up reading it from LDS strided, which serializes the ds_loads. FMA dot operands actually want the operand-major dimension (M for A, N for B) contiguous in LDS so those reads coalesce. 

On RDNA4 specifically I tested a few matmuls (with B transposed) in f32 (so FMA path is exercised):

| dtype | trA | trB | G | M | K | N | Speedup |
|---|---|---|---|---|---|---|---|
|     f32     |     F        |     T        |     2    |     64     |     400    |     400     |        2.1x     |
|     f32     |     F        |     T        |     1    |     100    |     100    |     19200  |        1.1x     |
|     f32     |     F        |     T        |     12  |     384    |     64     |     384     |        1.1x     |
|     f32     |     F        |     T        |     64  |     768    |     64     |     64      |        1.3x     |
|     f32     |     F        |     T        |     1    |     128    |     2048  |     1000    |        1.2x     |
|     f32     |     F        |     T        |     32  |     256    |     128    |     256     |        1.1x     |
|     f32     |     F        |     T        |     1    |     16     |     2048  |     1000    |        1.5x     |
|     f32     |     F        |     T        |     14  |     4200  |     64     |     14      |        1.2x     |
|     f32     |     F        |     T        |     1    |     64     |     2048  |     1000    |        1.5x     |
|     f32     |     F        |     T        |     1    |     32     |     2048  |     1000    |        1.2x     |

Speedup column represents the speed of this PR with respect to main branch, with an average speedup of 33%.

## Implementation
In `getSharedEncIfAllUsersAreDotEnc`, the shared encoding is selected. When the dot operand's parent layout is #blocked (i.e. the FMA path), we override the inherited sharedOrder with the operand-major order before building the shared encoding. MFMA/WMMA operands are untouched, and the flip is only applied for 2D operands.