### PR TITLE
[interpreter] fix NaN handling in argmin/argmax with tie_break_left=False

### DIFF
--- a/python/test/unit/language/test_core.py
+++ b/python/test/unit/language/test_core.py
@@ -2489,6 +2489,65 @@ def test_argmax_argmin_with_nan(device):
     assert idx.item() == 1, f"expected 1, got {idx.item()}"
 
 
+@pytest.mark.interpreter
+def test_argmax_argmin_tie_break_fast_with_nan(device):
+    # tl.argmax/argmin with tie_break_left=False should also ignore NaN,
+    # consistent with the tie_break_left=True behaviour and JIT hardware
+    # semantics (fmaxf/fminf treat NaN as missing values).
+    # Regression test for: https://github.com/triton-lang/triton/issues/10697
+    @triton.jit
+    def argmax_fast_kernel(x_ptr, val_ptr, idx_ptr, N: tl.constexpr, BLOCK: tl.constexpr):
+        offsets = tl.arange(0, BLOCK)
+        mask = offsets < N
+        x = tl.load(x_ptr + offsets, mask=mask, other=-float("inf"))
+        val = tl.max(x, axis=0)
+        idx = tl.argmax(x, axis=0, tie_break_left=False)
+        tl.store(val_ptr, val)
+        tl.store(idx_ptr, idx)
+
+    @triton.jit
+    def argmin_fast_kernel(x_ptr, val_ptr, idx_ptr, N: tl.constexpr, BLOCK: tl.constexpr):
+        offsets = tl.arange(0, BLOCK)
+        mask = offsets < N
+        x = tl.load(x_ptr + offsets, mask=mask, other=float("inf"))
+        val = tl.min(x, axis=0)
+        idx = tl.argmin(x, axis=0, tie_break_left=False)
+        tl.store(val_ptr, val)
+        tl.store(idx_ptr, idx)
+
+    val = torch.empty((), dtype=torch.float32, device=device)
+    idx = torch.empty((), dtype=torch.int32, device=device)
+
+    # argmax: [nan, 6, 8] -> max=8.0, argmax=2
+    x = torch.tensor([float("nan"), 6.0, 8.0], dtype=torch.float32, device=device)
+    argmax_fast_kernel[(1, )](x, val, idx, N=3, BLOCK=4)
+    assert val.item() == 8.0, f"expected 8.0, got {val.item()}"
+    assert idx.item() == 2, f"expected 2, got {idx.item()}"
+
+    # argmin: [nan, 6, 8] -> min=6.0, argmin=1
+    val.zero_()
+    idx.zero_()
+    argmin_fast_kernel[(1, )](x, val, idx, N=3, BLOCK=4)
+    assert val.item() == 6.0, f"expected 6.0, got {val.item()}"
+    assert idx.item() == 1, f"expected 1, got {idx.item()}"
+
+    # argmax: NaN at end [3, 5, nan] -> max=5.0, argmax=1
+    x_nan_end = torch.tensor([3.0, 5.0, float("nan")], dtype=torch.float32, device=device)
+    val.zero_()
+    idx.zero_()
+    argmax_fast_kernel[(1, )](x_nan_end, val, idx, N=3, BLOCK=4)
+    assert val.item() == 5.0, f"expected 5.0, got {val.item()}"
+    assert idx.item() == 1, f"expected 1, got {idx.item()}"
+
+    # argmin: NaN in middle [3, nan, 1] -> min=1.0, argmin=2
+    x_nan_mid = torch.tensor([3.0, float("nan"), 1.0], dtype=torch.float32, device=device)
+    val.zero_()
+    idx.zero_()
+    argmin_fast_kernel[(1, )](x_nan_mid, val, idx, N=3, BLOCK=4)
+    assert val.item() == 1.0, f"expected 1.0, got {val.item()}"
+    assert idx.item() == 2, f"expected 2, got {idx.item()}"
+
+
 def get_reduced_dtype(dtype_str, op):
     if op in ('argmin', 'argmax'):
         return 'int32'

--- a/python/triton/runtime/interpreter.py
+++ b/python/triton/runtime/interpreter.py
@@ -1062,25 +1062,26 @@ class ReduceOps(ReduceScanOpInterface):
     def sum(self, input):
         return self.to_tensor(np.sum(input.handle.data, axis=self.axis, keepdims=self.keep_dims), input.dtype)
 
-
-def apply_impl(self, input):
-    # Note: np.nanargmin/np.nanargmax always return the leftmost index
-    # for equal values, whereas tie_break_fast on hardware returns an
-    # arbitrary index. This is a known remaining divergence between the
-    # interpreter and JIT for inputs with equal non-NaN elements.
-    if self.combine_fn in (tl.standard._argmin_combine_tie_break_left, tl.standard._argmin_combine_tie_break_fast):
-        return self.min_max(input[0], val_reduce_op=np.nanmin, idx_reduce_op=np.nanargmin)
-    elif self.combine_fn in (tl.standard._argmax_combine_tie_break_left, tl.standard._argmax_combine_tie_break_fast):
-        return self.min_max(input[0], val_reduce_op=np.nanmax, idx_reduce_op=np.nanargmax)
-    elif self.combine_fn == tl.standard._elementwise_max:
-        return self.min_max(input[0], val_reduce_op=np.nanmax, idx_reduce_op=None)
-    elif self.combine_fn == tl.standard._elementwise_min:
-        return self.min_max(input[0], val_reduce_op=np.nanmin, idx_reduce_op=None)
-    elif self.combine_fn == tl.standard._sum_combine:
-        return self.sum(input[0])
-    else:
-        # Fall back to the slow mode
-        return self.generic_reduce(input)
+    def apply_impl(self, input):
+        # Note: np.nanargmin/np.nanargmax always return the leftmost index
+        # for equal values, whereas tie_break_fast on hardware returns an
+        # arbitrary index. This is a known remaining divergence between the
+        # interpreter and JIT for inputs with equal non-NaN elements.
+        if (self.combine_fn is tl.standard._argmin_combine_tie_break_left
+                or self.combine_fn is tl.standard._argmin_combine_tie_break_fast):
+            return self.min_max(input[0], val_reduce_op=np.nanmin, idx_reduce_op=np.nanargmin)
+        elif (self.combine_fn is tl.standard._argmax_combine_tie_break_left
+              or self.combine_fn is tl.standard._argmax_combine_tie_break_fast):
+            return self.min_max(input[0], val_reduce_op=np.nanmax, idx_reduce_op=np.nanargmax)
+        elif self.combine_fn is tl.standard._elementwise_max:
+            return self.min_max(input[0], val_reduce_op=np.nanmax, idx_reduce_op=None)
+        elif self.combine_fn is tl.standard._elementwise_min:
+            return self.min_max(input[0], val_reduce_op=np.nanmin, idx_reduce_op=None)
+        elif self.combine_fn is tl.standard._sum_combine:
+            return self.sum(input[0])
+        else:
+            # Fall back to the slow mode
+            return self.generic_reduce(input)
 
 
 class ScanOps(ReduceScanOpInterface):

--- a/python/triton/runtime/interpreter.py
+++ b/python/triton/runtime/interpreter.py
@@ -1064,6 +1064,10 @@ class ReduceOps(ReduceScanOpInterface):
 
 
 def apply_impl(self, input):
+    # Note: np.nanargmin/np.nanargmax always return the leftmost index
+    # for equal values, whereas tie_break_fast on hardware returns an
+    # arbitrary index. This is a known remaining divergence between the
+    # interpreter and JIT for inputs with equal non-NaN elements.
     if self.combine_fn in (tl.standard._argmin_combine_tie_break_left, tl.standard._argmin_combine_tie_break_fast):
         return self.min_max(input[0], val_reduce_op=np.nanmin, idx_reduce_op=np.nanargmin)
     elif self.combine_fn in (tl.standard._argmax_combine_tie_break_left, tl.standard._argmax_combine_tie_break_fast):

--- a/python/triton/runtime/interpreter.py
+++ b/python/triton/runtime/interpreter.py
@@ -1064,13 +1064,9 @@ class ReduceOps(ReduceScanOpInterface):
 
 
 def apply_impl(self, input):
-    if self.combine_fn == tl.standard._argmin_combine_tie_break_left:
+    if self.combine_fn in (tl.standard._argmin_combine_tie_break_left, tl.standard._argmin_combine_tie_break_fast):
         return self.min_max(input[0], val_reduce_op=np.nanmin, idx_reduce_op=np.nanargmin)
-    elif self.combine_fn == tl.standard._argmax_combine_tie_break_left:
-        return self.min_max(input[0], val_reduce_op=np.nanmax, idx_reduce_op=np.nanargmax)
-    elif self.combine_fn == tl.standard._argmin_combine_tie_break_fast:
-        return self.min_max(input[0], val_reduce_op=np.nanmin, idx_reduce_op=np.nanargmin)
-    elif self.combine_fn == tl.standard._argmax_combine_tie_break_fast:
+    elif self.combine_fn in (tl.standard._argmax_combine_tie_break_left, tl.standard._argmax_combine_tie_break_fast):
         return self.min_max(input[0], val_reduce_op=np.nanmax, idx_reduce_op=np.nanargmax)
     elif self.combine_fn == tl.standard._elementwise_max:
         return self.min_max(input[0], val_reduce_op=np.nanmax, idx_reduce_op=None)

--- a/python/triton/runtime/interpreter.py
+++ b/python/triton/runtime/interpreter.py
@@ -1062,20 +1062,25 @@ class ReduceOps(ReduceScanOpInterface):
     def sum(self, input):
         return self.to_tensor(np.sum(input.handle.data, axis=self.axis, keepdims=self.keep_dims), input.dtype)
 
-    def apply_impl(self, input):
-        if self.combine_fn == tl.standard._argmin_combine_tie_break_left:
-            return self.min_max(input[0], val_reduce_op=np.nanmin, idx_reduce_op=np.nanargmin)
-        elif self.combine_fn == tl.standard._argmax_combine_tie_break_left:
-            return self.min_max(input[0], val_reduce_op=np.nanmax, idx_reduce_op=np.nanargmax)
-        elif self.combine_fn == tl.standard._elementwise_max:
-            return self.min_max(input[0], val_reduce_op=np.nanmax, idx_reduce_op=None)
-        elif self.combine_fn == tl.standard._elementwise_min:
-            return self.min_max(input[0], val_reduce_op=np.nanmin, idx_reduce_op=None)
-        elif self.combine_fn == tl.standard._sum_combine:
-            return self.sum(input[0])
-        else:
-            # Fall back to the slow mode
-            return self.generic_reduce(input)
+
+def apply_impl(self, input):
+    if self.combine_fn == tl.standard._argmin_combine_tie_break_left:
+        return self.min_max(input[0], val_reduce_op=np.nanmin, idx_reduce_op=np.nanargmin)
+    elif self.combine_fn == tl.standard._argmax_combine_tie_break_left:
+        return self.min_max(input[0], val_reduce_op=np.nanmax, idx_reduce_op=np.nanargmax)
+    elif self.combine_fn == tl.standard._argmin_combine_tie_break_fast:
+        return self.min_max(input[0], val_reduce_op=np.nanmin, idx_reduce_op=np.nanargmin)
+    elif self.combine_fn == tl.standard._argmax_combine_tie_break_fast:
+        return self.min_max(input[0], val_reduce_op=np.nanmax, idx_reduce_op=np.nanargmax)
+    elif self.combine_fn == tl.standard._elementwise_max:
+        return self.min_max(input[0], val_reduce_op=np.nanmax, idx_reduce_op=None)
+    elif self.combine_fn == tl.standard._elementwise_min:
+        return self.min_max(input[0], val_reduce_op=np.nanmin, idx_reduce_op=None)
+    elif self.combine_fn == tl.standard._sum_combine:
+        return self.sum(input[0])
+    else:
+        # Fall back to the slow mode
+        return self.generic_reduce(input)
 
 
 class ScanOps(ReduceScanOpInterface):


### PR DESCRIPTION
# New contributor declaration
- [x] I am not making a trivial change, such as fixing a typo in a comment.
- [x] I have written a PR description following these
  [rules](https://cbea.ms/git-commit/#why-not-how).
- [x] I have run `pre-commit run --from-ref origin/main --to-ref HEAD`.
- [x] I have added tests.
  - `/python/test` for end-to-end tests
- [x] I have not added any `lit` tests.

---

## What

`tl.argmin` and `tl.argmax` with `tie_break_left=False` produced
incorrect results in interpreter mode when the input contained NaN
values: NaN propagated as the reduction winner instead of being
skipped, causing the interpreter to diverge from JIT.

## Why

`ReduceOps.apply_impl` in `python/triton/runtime/interpreter.py`
fast-dispatched the `tie_break_left=True` variants
(`_argmin_combine_tie_break_left`, `_argmax_combine_tie_break_left`)
to `np.nanmin`/`np.nanmax`, which correctly ignore NaN. However, the
`tie_break_left=False` variants (`_argmin_combine_tie_break_fast`,
`_argmax_combine_tie_break_fast`) had no corresponding branch and fell
through to `generic_reduce`.

`generic_reduce` applies the Python combine function element-by-element.
Inside `_argmax_combine`, the comparison `value1 > value2` returns
`False` when either operand is NaN, so NaN silently wins the reduction
instead of being skipped. JIT mode compiles to hardware `fmaxf`/`fminf`,
which conform to IEEE 754 `minNum`/`maxNum` and return the non-NaN
operand — producing a different result than the interpreter.

## How

Add two `elif` branches in `ReduceOps.apply_impl` for the fast variants,
routing them to the same `np.nanmin`/`np.nanmax` path already used by
the `tie_break_left` variants. The NaN-ignoring behaviour is identical
for both variants; the tie-breaking difference (left-most vs arbitrary
index for equal non-NaN values) does not affect NaN handling.

Add `test_argmax_argmin_tie_break_fast_with_nan` in
`python/test/unit/language/test_core.py` as a regression guard, marked
`@pytest.mark.interpreter` since it targets interpreter-mode correctness.

Fixes #10697.