### PR TITLE
[AMD] Fix conversion crash for scalar fp_to_fp

### DIFF
--- a/test/Conversion/amd/fp_to_fp.mlir
+++ b/test/Conversion/amd/fp_to_fp.mlir
@@ -239,3 +239,12 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, "ttg.thr
     tt.return
   }
 }
+
+// -----
+
+// COMMON-LABEL: test_scalar_conversion
+// COMMON: llvm.return
+tt.func @test_scalar_conversion(%arg0: f32) -> f8E4M3FN {
+  %0 = tt.fp_to_fp %arg0, rounding = rtne : f32 -> f8E4M3FN
+  tt.return %0 : f8E4M3FN
+}

--- a/third_party/amd/lib/TritonAMDGPUToLLVM/ConvertFpCastOpToLLVM.cpp
+++ b/third_party/amd/lib/TritonAMDGPUToLLVM/ConvertFpCastOpToLLVM.cpp
@@ -2485,7 +2485,10 @@ struct FpToFpOpConversion
   }
 
   std::optional<size_t> getNumContiguousElementsPerThread(Operation *op) const {
-    auto tensorTy = cast<RankedTensorType>(op->getOperand(0).getType());
+    auto tensorTy = dyn_cast<RankedTensorType>(op->getOperand(0).getType());
+    // Scalar operand: one element per thread.
+    if (!tensorTy)
+      return 1;
     auto layoutTy = mlir::dyn_cast<triton::gpu::DistributedEncodingTrait>(
         tensorTy.getEncoding());
     if (!layoutTy)
@@ -2504,7 +2507,6 @@ struct FpToFpOpConversion
     auto dstElementType = getElementTypeOrSelf(op.getResult());
 
     auto roundingMode = op.getRounding();
-    auto tensorTy = cast<RankedTensorType>(op.getOperand().getType());
 
     auto maybeMaxElementsPerThread = getNumContiguousElementsPerThread(op);
     if (!maybeMaxElementsPerThread) {


### PR DESCRIPTION
## Summary
Lowering a **scalar** `tt.fp_to_fp` (e.g. `f32 -> f8E4M3FN`) on the AMD backend crashes in `ConvertFpCastOpToLLVM`. `getNumContiguousElementsPerThread` unconditionally does `cast<RankedTensorType>(op->getOperand(0).getType())`, which asserts/aborts when the operand is a scalar (no ranked-tensor type, no layout).

This was introduced by the refactor in #10534 as verified through bisect.

## Fix
- Use `dyn_cast` and return one element per thread when the operand is not a tensor (a scalar carries a single element), so it lowers through the normal scalar path instead of crashing.
- Remove a now-dead `cast<RankedTensorType>` in `createDestOps`.

## Test
Adds a scalar `f32 -> f8E4M3FN` case to `test/Conversion/amd/fp_to_fp.mlir`; it crashes the pass before the fix and lowers cleanly after.

## Where this surfaced
Caught by the PyTorch Triton 3.8.0 pin bump:
- Pin PR: pytorch/pytorch#185453 (pins Triton `17736268609b`)
- CI failure tracker: pytorch/pytorch#187401
- Failing test: `test/inductor/test_fp8.py::TestFP8TypesCUDA::test_xblock_for_small_numel_float8_e4m3fn_cuda` (ROCm MI300/MI350). The `small_numel` case reduces to a single element, so Inductor emits a scalar `tt.fp_to_fp`.

## Verification (MI300X / gfx942)
- Failing PyTorch fp8 repro (small-numel `float8_e4m3fn`): crashes before, passes with correct output after.
- `small_numel`/`e4m3` regression sweep: 16 passed / 0 failed.
- Existing AMD `fp_to_fp` lit cases unaffected; new lit case passes for gfx942 and gfx950.