### PR TITLE
[FPSAN] Support clamp payload semantics

### DIFF
--- a/docs/programming-guide/chapter-3/fpsan.rst
+++ b/docs/programming-guide/chapter-3/fpsan.rst
@@ -164,29 +164,33 @@ Important caveat:
 
 - This is ring arithmetic modulo ``2^w``, not IEEE arithmetic.
 
-Min and Max
-===========
+Min, Max, and Clamp
+===================
 
 Supported operations:
 
 - ``tl.minimum(x, y)``
 - ``tl.maximum(x, y)``
 - ``min(x, y)`` and ``max(x, y)`` in Triton code
+- ``tl.clamp(x, lo, hi)``
 
 Rewrite:
 
 - signed integer ``min`` or ``max`` on payloads
+- clamp becomes ``min(max(x, lo), hi)`` in the same signed payload order
 
 Exact preserved properties:
 
 - idempotence: ``min(x, x) = x`` and ``max(x, x) = x``
 - commutativity
 - associativity
+- ``clamp(x, lo, hi) = min(max(x, lo), hi)``
 
 Important caveats:
 
 - The order is the signed integer order of payloads, not IEEE float order.
 - NaN handling, and the exact signed-zero contract, are not modeled.
+- Both ``propagate_nan`` modes use the same payload semantics.
 
 Division
 ========

--- a/lib/Dialect/TritonInstrument/Transforms/FpSanitizer.cpp
+++ b/lib/Dialect/TritonInstrument/Transforms/FpSanitizer.cpp
@@ -1839,6 +1839,27 @@ struct BinaryFloatToIntPattern : public OpRewritePattern<OpF> {
   }
 };
 
+struct ClampFOpPattern : public OpRewritePattern<tt::ClampFOp> {
+  using OpRewritePattern::OpRewritePattern;
+
+  LogicalResult matchAndRewrite(tt::ClampFOp op,
+                                PatternRewriter &rewriter) const override {
+    auto loc = op.getLoc();
+    auto xI = embedToInt(rewriter, loc, op.getX());
+    auto minI = embedToInt(rewriter, loc, op.getMin());
+    auto maxI = embedToInt(rewriter, loc, op.getMax());
+
+    // Match the signed-payload semantics used by the FPSan min/max rewrites.
+    // Float bit patterns that encode IEEE NaNs are ordinary payloads here, so
+    // both PropagateNan modes intentionally have the same behavior.
+    auto lowerBoundedI = arith::MaxSIOp::create(rewriter, loc, xI, minI);
+    auto resultI = arith::MinSIOp::create(rewriter, loc, lowerBoundedI, maxI);
+    auto resultF = unembedToFloat(rewriter, loc, resultI, op.getType());
+    rewriter.replaceOp(op, resultF);
+    return success();
+  }
+};
+
 struct NegFOpPattern : public OpRewritePattern<arith::NegFOp> {
   using OpRewritePattern::OpRewritePattern;
 
@@ -3099,11 +3120,11 @@ public:
                  BinaryFloatToIntPattern<arith::MaximumFOp, arith::MaxSIOp>,
                  BinaryFloatToIntPattern<arith::MinNumFOp, arith::MinSIOp>,
                  BinaryFloatToIntPattern<arith::MaxNumFOp, arith::MaxSIOp>,
-                 NegFOpPattern, DivFOpPattern, PreciseDivFOpPattern,
-                 RemFOpPattern, FmaPattern, ExpOpPattern, Exp2OpPattern,
-                 CosOpPattern, SinOpPattern, ExtFOpPattern, TruncFOpPattern,
-                 FpToFpPattern, Fp4ToFpPattern, DotPattern, DotScaledPattern>(
-        &getContext());
+                 ClampFOpPattern, NegFOpPattern, DivFOpPattern,
+                 PreciseDivFOpPattern, RemFOpPattern, FmaPattern, ExpOpPattern,
+                 Exp2OpPattern, CosOpPattern, SinOpPattern, ExtFOpPattern,
+                 TruncFOpPattern, FpToFpPattern, Fp4ToFpPattern, DotPattern,
+                 DotScaledPattern>(&getContext());
     patterns.add<UnaryPattern<math::LogOp>>(&getContext(), UnaryOpId::Log);
     patterns.add<UnaryPattern<math::Log2Op>>(&getContext(), UnaryOpId::Log2);
     patterns.add<UnaryPattern<math::SqrtOp>>(&getContext(), UnaryOpId::Sqrt);

--- a/lib/Dialect/TritonInstrument/Transforms/FpSanitizer.cpp
+++ b/lib/Dialect/TritonInstrument/Transforms/FpSanitizer.cpp
@@ -1845,17 +1845,22 @@ struct ClampFOpPattern : public OpRewritePattern<tt::ClampFOp> {
   LogicalResult matchAndRewrite(tt::ClampFOp op,
                                 PatternRewriter &rewriter) const override {
     auto loc = op.getLoc();
-    auto xI = embedToInt(rewriter, loc, op.getX());
-    auto minI = embedToInt(rewriter, loc, op.getMin());
-    auto maxI = embedToInt(rewriter, loc, op.getMax());
-
-    // Match the signed-payload semantics used by the FPSan min/max rewrites.
-    // Float bit patterns that encode IEEE NaNs are ordinary payloads here, so
-    // both PropagateNan modes intentionally have the same behavior.
-    auto lowerBoundedI = arith::MaxSIOp::create(rewriter, loc, xI, minI);
-    auto resultI = arith::MinSIOp::create(rewriter, loc, lowerBoundedI, maxI);
-    auto resultF = unembedToFloat(rewriter, loc, resultI, op.getType());
-    rewriter.replaceOp(op, resultF);
+    Value result;
+    // Pre-lower to the matching float min/max pair so clamp inherits the
+    // payload semantics of the corresponding FPSan min/max patterns.
+    if (op.getPropagateNan() == tt::PropagateNan::ALL) {
+      auto lowerBounded =
+          arith::MaximumFOp::create(rewriter, loc, op.getX(), op.getMin());
+      result =
+          arith::MinimumFOp::create(rewriter, loc, lowerBounded, op.getMax());
+    } else {
+      assert(op.getPropagateNan() == tt::PropagateNan::NONE);
+      auto lowerBounded =
+          arith::MaxNumFOp::create(rewriter, loc, op.getX(), op.getMin());
+      result =
+          arith::MinNumFOp::create(rewriter, loc, lowerBounded, op.getMax());
+    }
+    rewriter.replaceOp(op, result);
     return success();
   }
 };

--- a/python/test/gluon/test_fpsan.py
+++ b/python/test/gluon/test_fpsan.py
@@ -231,6 +231,14 @@ def _expected_max_i32(x_i32: np.ndarray, y_i32: np.ndarray) -> np.ndarray:
     return _unmix_payload_u32_to_f32_bits_i32(np.maximum(x, y).astype(np.int32).view(np.uint32))
 
 
+def _expected_clamp_i32(x_i32: np.ndarray, lo_i32: np.ndarray, hi_i32: np.ndarray) -> np.ndarray:
+    x = _u32_to_i32(_mix_f32_bits_to_payload_u32(x_i32))
+    lo = _u32_to_i32(_mix_f32_bits_to_payload_u32(lo_i32))
+    hi = _u32_to_i32(_mix_f32_bits_to_payload_u32(hi_i32))
+    clamped = np.minimum(np.maximum(x, lo), hi)
+    return _unmix_payload_u32_to_f32_bits_i32(clamped.astype(np.int32).view(np.uint32))
+
+
 def _expected_srem_i32(x_i32: np.ndarray, y_i32: np.ndarray) -> np.ndarray:
     # Match LLVM srem semantics: remainder after trunc-toward-zero division.
     # NOTE: Python/NumPy '%' uses floor division for negatives, so we implement explicitly.
@@ -513,6 +521,20 @@ def _binop_kernel(x_ptr, y_ptr, out_ptr, n_elements, OP: gl.constexpr, BLOCK: gl
     gl.store(out_ptr + offs, z, mask=mask)
 
 
+@triton.jit
+def _clamp_kernel(x_ptr, lo_ptr, hi_ptr, out_ptr, n_elements, PROPAGATE_NAN: tl.constexpr, BLOCK: tl.constexpr):
+    offs = tl.program_id(0) * BLOCK + tl.arange(0, BLOCK)
+    mask = offs < n_elements
+    x = tl.load(x_ptr + offs, mask=mask, other=0.0)
+    lo = tl.load(lo_ptr + offs, mask=mask, other=0.0)
+    hi = tl.load(hi_ptr + offs, mask=mask, other=0.0)
+    if PROPAGATE_NAN:
+        out = tl.clamp(x, lo, hi, propagate_nan=tl.PropagateNan.ALL)
+    else:
+        out = tl.clamp(x, lo, hi, propagate_nan=tl.PropagateNan.NONE)
+    tl.store(out_ptr + offs, out, mask=mask)
+
+
 @gluon.jit
 def _constant_identity_kernel(x_ptr, out_ptr, n_elements, OP: gl.constexpr, BLOCK: gl.constexpr,
                               THREADS_PER_WARP: gl.constexpr):
@@ -668,6 +690,54 @@ def test_binops_payload_semantics(device, op, expected_fn, fresh_knobs):
 
     out_np = out.cpu().numpy().astype(np.int32, copy=False)
     exp_np = expected_fn(x.cpu().numpy().astype(np.int32, copy=False), y.cpu().numpy().astype(np.int32, copy=False))
+    _assert_payload_equal(out_np, exp_np)
+
+
+@pytest.mark.parametrize("propagate_nan", [False, True], ids=["none", "all"])
+def test_clamp_payload_semantics(device, propagate_nan, fresh_knobs):
+    _require_cuda_backend(device)
+
+    fresh_knobs.compilation.instrumentation_mode = "fpsan"
+
+    n_elements = 1024
+    BLOCK = 256
+
+    g = torch.Generator(device="cuda")
+    g.manual_seed(17)
+    x = torch.randint(-(2**31), 2**31 - 1, (n_elements, ), dtype=torch.int32, device="cuda", generator=g)
+    a = torch.randint(-(2**31), 2**31 - 1, (n_elements, ), dtype=torch.int32, device="cuda", generator=g)
+    b = torch.randint(-(2**31), 2**31 - 1, (n_elements, ), dtype=torch.int32, device="cuda", generator=g)
+
+    # Exercise payload carriers whose raw float representation is a NaN.
+    nan_bits = np.array([0x7FC00000, 0x7F800001, 0xFFC12345, 0xFF800001], dtype=np.uint32).view(np.int32)
+    x[:len(nan_bits)] = torch.from_numpy(nan_bits.copy()).to(device="cuda")
+
+    x_np = x.cpu().numpy().astype(np.int32, copy=False)
+    a_np = a.cpu().numpy().astype(np.int32, copy=False)
+    b_np = b.cpu().numpy().astype(np.int32, copy=False)
+    a_payload = _u32_to_i32(_mix_f32_bits_to_payload_u32(a_np))
+    b_payload = _u32_to_i32(_mix_f32_bits_to_payload_u32(b_np))
+    a_is_lower = a_payload <= b_payload
+    lo_np = np.where(a_is_lower, a_np, b_np).astype(np.int32)
+    hi_np = np.where(a_is_lower, b_np, a_np).astype(np.int32)
+
+    lo = torch.from_numpy(lo_np).to(device="cuda")
+    hi = torch.from_numpy(hi_np).to(device="cuda")
+    out = torch.empty((n_elements, ), dtype=torch.int32, device="cuda")
+
+    grid = (triton.cdiv(n_elements, BLOCK), )
+    _clamp_kernel[grid](
+        triton.TensorWrapper(x, dtype=torch.float32),
+        triton.TensorWrapper(lo, dtype=torch.float32),
+        triton.TensorWrapper(hi, dtype=torch.float32),
+        triton.TensorWrapper(out, dtype=torch.float32),
+        n_elements,
+        PROPAGATE_NAN=propagate_nan,
+        BLOCK=BLOCK,
+    )
+
+    out_np = out.cpu().numpy().astype(np.int32, copy=False)
+    exp_np = _expected_clamp_i32(x_np, lo_np, hi_np)
     _assert_payload_equal(out_np, exp_np)
 
 

--- a/test/TritonGPU/fpsan.mlir
+++ b/test/TritonGPU/fpsan.mlir
@@ -343,8 +343,8 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32} {
   tt.func public @clamp_none(%x: tensor<4xf32>, %lo: tensor<4xf32>, %hi: tensor<4xf32>) -> tensor<4xf32> {
     // CHECK: %[[X:.*]] = tti.experimental_fpsan_embed %arg0 : (tensor<4xf32>) -> tensor<4xi32>
     // CHECK: %[[LO:.*]] = tti.experimental_fpsan_embed %arg1 : (tensor<4xf32>) -> tensor<4xi32>
-    // CHECK: %[[HI:.*]] = tti.experimental_fpsan_embed %arg2 : (tensor<4xf32>) -> tensor<4xi32>
     // CHECK: %[[LOWER_BOUNDED:.*]] = arith.maxsi %[[X]], %[[LO]] : tensor<4xi32>
+    // CHECK: %[[HI:.*]] = tti.experimental_fpsan_embed %arg2 : (tensor<4xf32>) -> tensor<4xi32>
     // CHECK: %[[CLAMPED:.*]] = arith.minsi %[[LOWER_BOUNDED]], %[[HI]] : tensor<4xi32>
     // CHECK: %[[OUT:.*]] = tti.experimental_fpsan_unembed %[[CLAMPED]] : (tensor<4xi32>) -> tensor<4xf32>
     // CHECK-NOT: tt.clampf
@@ -361,8 +361,8 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32} {
   tt.func public @clamp_all(%x: tensor<4xf32>, %lo: tensor<4xf32>, %hi: tensor<4xf32>) -> tensor<4xf32> {
     // CHECK: %[[X:.*]] = tti.experimental_fpsan_embed %arg0 : (tensor<4xf32>) -> tensor<4xi32>
     // CHECK: %[[LO:.*]] = tti.experimental_fpsan_embed %arg1 : (tensor<4xf32>) -> tensor<4xi32>
-    // CHECK: %[[HI:.*]] = tti.experimental_fpsan_embed %arg2 : (tensor<4xf32>) -> tensor<4xi32>
     // CHECK: %[[LOWER_BOUNDED:.*]] = arith.maxsi %[[X]], %[[LO]] : tensor<4xi32>
+    // CHECK: %[[HI:.*]] = tti.experimental_fpsan_embed %arg2 : (tensor<4xf32>) -> tensor<4xi32>
     // CHECK: %[[CLAMPED:.*]] = arith.minsi %[[LOWER_BOUNDED]], %[[HI]] : tensor<4xi32>
     // CHECK: %[[OUT:.*]] = tti.experimental_fpsan_unembed %[[CLAMPED]] : (tensor<4xi32>) -> tensor<4xf32>
     // CHECK-NOT: tt.clampf

--- a/test/TritonGPU/fpsan.mlir
+++ b/test/TritonGPU/fpsan.mlir
@@ -339,6 +339,42 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32} {
 // -----
 
 module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32} {
+  // CHECK-LABEL: @clamp_none
+  tt.func public @clamp_none(%x: tensor<4xf32>, %lo: tensor<4xf32>, %hi: tensor<4xf32>) -> tensor<4xf32> {
+    // CHECK: %[[X:.*]] = tti.experimental_fpsan_embed %arg0 : (tensor<4xf32>) -> tensor<4xi32>
+    // CHECK: %[[LO:.*]] = tti.experimental_fpsan_embed %arg1 : (tensor<4xf32>) -> tensor<4xi32>
+    // CHECK: %[[HI:.*]] = tti.experimental_fpsan_embed %arg2 : (tensor<4xf32>) -> tensor<4xi32>
+    // CHECK: %[[LOWER_BOUNDED:.*]] = arith.maxsi %[[X]], %[[LO]] : tensor<4xi32>
+    // CHECK: %[[CLAMPED:.*]] = arith.minsi %[[LOWER_BOUNDED]], %[[HI]] : tensor<4xi32>
+    // CHECK: %[[OUT:.*]] = tti.experimental_fpsan_unembed %[[CLAMPED]] : (tensor<4xi32>) -> tensor<4xf32>
+    // CHECK-NOT: tt.clampf
+    // CHECK: tt.return %[[OUT]] : tensor<4xf32>
+    %out = tt.clampf %x, %lo, %hi, propagateNan = none : tensor<4xf32>
+    tt.return %out : tensor<4xf32>
+  }
+}
+
+// -----
+
+module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32} {
+  // CHECK-LABEL: @clamp_all
+  tt.func public @clamp_all(%x: tensor<4xf32>, %lo: tensor<4xf32>, %hi: tensor<4xf32>) -> tensor<4xf32> {
+    // CHECK: %[[X:.*]] = tti.experimental_fpsan_embed %arg0 : (tensor<4xf32>) -> tensor<4xi32>
+    // CHECK: %[[LO:.*]] = tti.experimental_fpsan_embed %arg1 : (tensor<4xf32>) -> tensor<4xi32>
+    // CHECK: %[[HI:.*]] = tti.experimental_fpsan_embed %arg2 : (tensor<4xf32>) -> tensor<4xi32>
+    // CHECK: %[[LOWER_BOUNDED:.*]] = arith.maxsi %[[X]], %[[LO]] : tensor<4xi32>
+    // CHECK: %[[CLAMPED:.*]] = arith.minsi %[[LOWER_BOUNDED]], %[[HI]] : tensor<4xi32>
+    // CHECK: %[[OUT:.*]] = tti.experimental_fpsan_unembed %[[CLAMPED]] : (tensor<4xi32>) -> tensor<4xf32>
+    // CHECK-NOT: tt.clampf
+    // CHECK: tt.return %[[OUT]] : tensor<4xf32>
+    %out = tt.clampf %x, %lo, %hi, propagateNan = all : tensor<4xf32>
+    tt.return %out : tensor<4xf32>
+  }
+}
+
+// -----
+
+module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32} {
   // CHECK-LABEL: @neg_op
   tt.func public @neg_op(%a: tensor<4xf32>) -> tensor<4xf32> {
     // CHECK-DAG: %[[A:.*]] = tti.experimental_fpsan_embed %arg0 : (tensor<4xf32>) -> tensor<4xi32>


### PR DESCRIPTION
<!-- PR title: [FPSAN] Support clamp payload semantics -->
`tl.clamp` lowers to `tt.clampf`, but FPSan did not rewrite that operation.
Backend-specific floating-point clamp lowering therefore interpreted FPSan
carrier bit patterns as IEEE floating-point values. Carrier patterns that
happen to encode NaNs could be propagated or canonicalized instead of being
handled as payloads.

Rewrite `tt.clampf` before target lowering as signed payload operations:

```text
minsi(maxsi(embed(x), embed(lo)), embed(hi))
```

This matches the semantics already used by FPSan for `minimum`, `maximum`,
`minnum`, and `maxnum`. Both `propagateNan` modes intentionally use the
same behavior because FPSan does not model IEEE NaN propagation or signed-zero
semantics; every floating-point bit pattern is an ordinary payload.

Doing the rewrite in the FPSan pass also makes clamp behavior independent of
later target selection, including NVIDIA min/max lowering, Hopper's symmetric
clamp intrinsic, and AMD `fmed3`.

The tests cover:

- both `propagateNan = none` and `propagateNan = all` at the IR level;
- end-to-end `tl.clamp` payload semantics;
- explicit quiet/signaling NaN carrier encodings;
- signed-payload-ordered lower and upper bounds.

The FPSan programming guide now documents clamp and its NaN-mode behavior.

## Testing

- `make`
- `test/TritonGPU/fpsan.mlir` — all three RUN pipelines passed directly with
  the rebuilt `triton-opt` and `FileCheck`
- `python3 -m pytest -s --tb=short python/test/gluon/test_fpsan.py::test_clamp_payload_semantics`
  — 2 passed
- `pre-commit run --from-ref origin/main --to-ref HEAD`

# New contributor declaration

- [x] I am not making a trivial change, such as fixing a typo in a comment.

- [x] I have written a PR description following these
  [rules](https://cbea.ms/git-commit/#why-not-how).

- [x] I have run `pre-commit run --from-ref origin/main --to-ref HEAD`.

- [x] I have added tests.
  - `/test` for `lit` tests
  - `/python/test` for end-to-end tests

- [ ] I have not added any `lit` tests.
- [x] The `lit` tests I have added follow these
  [best practices](https://mlir.llvm.org/getting_started/TestingGuide/#filecheck-best-practices),
  including the "tests should be minimal" section.
