### PR TITLE
[Lang] Kernel composition with aggregate parameters

### DIFF
--- a/python/test/unit/language/test_frontend.py
+++ b/python/test/unit/language/test_frontend.py
@@ -245,6 +245,83 @@ def test_starred_varargs():
     consume_varargs(*dims)
 
 
+@triton.aggregate
+class _CopyDescPolicy:
+    src: tl.tensor_descriptor
+    dst: tl.tensor_descriptor
+    scale: tl.constexpr
+
+    @triton.constexpr_function
+    def __init__(self, src, dst, scale):
+        self.src = src
+        self.dst = dst
+        self.scale = tl.constexpr(scale)
+
+    @triton.jit
+    def run(self, off_m, off_n):
+        self.dst.store([off_m, off_n], self.src.load([off_m, off_n]) * self.scale)
+
+
+@triton.jit
+def _host_agg_kernel(policy: tl.constexpr, M_BLOCK: tl.constexpr, N_BLOCK: tl.constexpr):
+    policy.run(tl.program_id(0) * M_BLOCK, tl.program_id(1) * N_BLOCK)
+
+
+def _compile_host_agg_signature(policy, M_BLOCK, N_BLOCK):
+    """Drive the frontend (no GPU) to obtain the Triton signature for a kernel
+    taking a host-constructed aggregate, exercising the same constexpr-aggregate
+    lifting that ``JITFunction.run`` performs."""
+    from triton.compiler import make_backend
+    from triton._filecheck import stub_target
+    from triton.runtime.jit import create_function_from_signature
+
+    backend = make_backend(stub_target)
+    binder = create_function_from_signature(_host_agg_kernel.signature, _host_agg_kernel.params, backend)
+    kwargs = {"sanitize_overflow": False}
+    bound_args, specialization, options = binder(policy, M_BLOCK, N_BLOCK, **kwargs)
+    _host_agg_kernel._specialize_host_aggregates(backend, bound_args, specialization)
+    _, signature, _, _ = _host_agg_kernel._pack_args(backend, kwargs, bound_args, specialization, options)
+    return signature
+
+
+def test_host_aggregate_tensor_descriptor_members():
+    # A host-constructed aggregate with `tl.tensor_descriptor` data members passed
+    # as a `tl.constexpr` argument: its descriptor members are lifted to runtime
+    # kernel parameters (like host-lambda captures) while the constexpr member is
+    # baked in. This checks the generated kernel interface/signature only, so it
+    # needs no GPU -- the descriptors are built from CPU tensors.
+    torch = pytest.importorskip("torch")
+    from triton.tools.tensor_descriptor import TensorDescriptor
+
+    M, N = 32, 128
+    M_BLOCK, N_BLOCK = 8, 32
+    src = TensorDescriptor.from_tensor(torch.randn((M, N)), [M_BLOCK, N_BLOCK])
+    dst = TensorDescriptor.from_tensor(torch.zeros((M, N)), [M_BLOCK, N_BLOCK])
+    policy = _CopyDescPolicy(src, dst, 2.0)
+
+    # Signature: `policy` expands to a tuple whose leading element is the baked
+    # constexpr aggregate and whose remaining elements are the two lifted
+    # descriptor members; the constexpr `scale` does not appear, and the other
+    # constexpr block sizes stay baked.
+    signature = _compile_host_agg_signature(policy, M_BLOCK, N_BLOCK)
+    sig = signature["policy"]
+    assert sig[0] == "constexpr"
+    assert len(sig) == 3
+    assert all("tensordesc" in s for s in sig[1:])
+    assert signature["M_BLOCK"] == "constexpr"
+    assert signature["N_BLOCK"] == "constexpr"
+
+    # Interface: the generated kernel takes the two descriptors as runtime
+    # parameters, while the constexpr scale is baked in as a constant.
+    module = run_parser(_host_agg_kernel, args=(policy, M_BLOCK, N_BLOCK))
+    module_str = module.str_nodebug()
+    interface = next(line for line in module_str.splitlines() if "tt.func public @_host_agg_kernel" in line)
+    assert interface.count("!tt.tensordesc<8x32xf32>") == 2
+    # scale=2.0 was folded into the body, so it is not a kernel parameter.
+    assert " f32," not in interface and not interface.rstrip().endswith(" f32)")
+    assert "arith.constant 2.000000e+00 : f32" in module_str
+
+
 @triton.jit
 def accumulate(a, b):
     return a + b

--- a/python/test/unit/language/test_frontend.py
+++ b/python/test/unit/language/test_frontend.py
@@ -322,6 +322,110 @@ def test_host_aggregate_tensor_descriptor_members():
     assert "arith.constant 2.000000e+00 : f32" in module_str
 
 
+@triton.aggregate
+class _BiasAdd:
+    # Runtime member (lifted to a kernel param) + compile-time member (baked in).
+    bias: tl.tensor
+    n_cols: tl.constexpr
+
+    @triton.constexpr_function
+    def __init__(self, bias, n_cols):
+        self.bias = bias
+        self.n_cols = tl.constexpr(n_cols)
+
+    @triton.jit
+    def apply(self, acc, offs_n):
+        b = tl.load(self.bias + offs_n, mask=offs_n < self.n_cols, other=0.0)
+        return acc + b[None, :]
+
+
+@triton.aggregate
+class _BiasAddScale(_BiasAdd):
+    # A derived aggregate adding *both* kinds of data member on top of the
+    # inherited ones: a runtime `tl.tensor` scale and a compile-time `tl.constexpr`
+    # output scale. Inheritance keeps the parent fields first, so the field order
+    # is (bias, n_cols, scale, out_scale).
+    scale: tl.tensor
+    out_scale: tl.constexpr
+
+    @triton.constexpr_function
+    def __init__(self, bias, n_cols, scale, out_scale):
+        self.bias = bias
+        self.n_cols = tl.constexpr(n_cols)
+        self.scale = scale
+        self.out_scale = tl.constexpr(out_scale)
+
+    @triton.jit
+    def apply(self, acc, offs_n):
+        # Reuse the base epilogue, then apply the runtime and compile-time scales.
+        return _BiasAdd.apply(self, acc, offs_n) * self.scale * self.out_scale
+
+
+@triton.jit
+def _host_bias_kernel(out_ptr, epilogue: tl.constexpr, BLOCK_M: tl.constexpr, BLOCK_N: tl.constexpr):
+    offs_m = tl.arange(0, BLOCK_M)
+    offs_n = tl.arange(0, BLOCK_N)
+    acc = tl.zeros((BLOCK_M, BLOCK_N), tl.float32)
+    acc = epilogue.apply(acc, offs_n)
+    tl.store(out_ptr + offs_m[:, None] * BLOCK_N + offs_n[None, :], acc)
+
+
+def _frontend_signature(kernel, args):
+    """Drive the frontend (no GPU) to obtain the Triton signature for a kernel
+    taking a host-constructed aggregate, exercising the constexpr-aggregate
+    lifting that ``JITFunction.run`` performs."""
+    from triton.compiler import make_backend
+    from triton._filecheck import stub_target
+    from triton.runtime.jit import create_function_from_signature
+
+    backend = make_backend(stub_target)
+    binder = create_function_from_signature(kernel.signature, kernel.params, backend)
+    kwargs = {"sanitize_overflow": False}
+    bound_args, specialization, options = binder(*args, **kwargs)
+    kernel._specialize_host_aggregates(backend, bound_args, specialization)
+    _, signature, _, _ = kernel._pack_args(backend, kwargs, bound_args, specialization, options)
+    return signature
+
+
+def test_host_aggregate_derived_tensor_and_constexpr_members():
+    # A host-constructed *derived* aggregate mixing runtime (`tl.tensor`) and
+    # compile-time (`tl.constexpr`) data members, passed as a `tl.constexpr`
+    # argument. Its runtime members (a bias pointer and a scalar scale) are lifted
+    # to runtime kernel parameters, while its constexpr members (n_cols, out_scale)
+    # are baked in. This checks the generated kernel interface/signature only, so
+    # it needs no GPU.
+    torch = pytest.importorskip("torch")
+
+    N = 128
+    BLOCK_M, BLOCK_N = 16, N
+    bias = torch.randn((N, ))
+    epilogue = _BiasAddScale(bias, N, 0.5, 2.0)
+
+    # Signature: `epilogue` expands to a tuple whose leading element is the baked
+    # constexpr aggregate and whose remaining elements are the two lifted runtime
+    # members (bias pointer + scalar scale), in field order. The constexpr members
+    # (n_cols, out_scale) do not appear, and the block sizes stay baked.
+    signature = _frontend_signature(_host_bias_kernel, (bias, epilogue, BLOCK_M, BLOCK_N))
+    sig = signature["epilogue"]
+    assert sig[0] == "constexpr"
+    assert len(sig) == 3
+    assert sig[1] == "*fp32"  # the runtime `bias` pointer member
+    assert sig[2] == "fp32"  # the runtime scalar `scale` member
+    assert signature["BLOCK_M"] == "constexpr"
+    assert signature["BLOCK_N"] == "constexpr"
+
+    # Interface: the generated kernel takes the bias pointer and the scalar scale
+    # as runtime parameters, while the constexpr scales are folded into the body.
+    module = run_parser(_host_bias_kernel, args=(bias, epilogue, BLOCK_M, BLOCK_N))
+    module_str = module.str_nodebug()
+    interface = next(line for line in module_str.splitlines() if "tt.func public @_host_bias_kernel" in line)
+    # out_ptr + bias pointer = two pointer params; the scalar scale is an f32 param.
+    assert interface.count("!tt.ptr<f32>") == 2
+    assert " f32" in interface
+    # out_scale=2.0 was folded into the body, so it is a constant, not a parameter.
+    assert "arith.constant 2.000000e+00 : f32" in module_str
+
+
 @triton.jit
 def accumulate(a, b):
     return a + b

--- a/python/triton/_filecheck.py
+++ b/python/triton/_filecheck.py
@@ -63,6 +63,9 @@ def run_parser(kernel_fn, args=(), kwargs={}, target=stub_target):
     )
 
     bound_args, specialization, options = binder(*args, **kwargs)
+    # Reproduce run()'s frontend lifting of host-constructed aggregates whose
+    # runtime members become kernel parameters (a no-op for other kernels).
+    kernel_fn._specialize_host_aggregates(backend, bound_args, specialization)
     options, signature, constexprs, attrs = kernel_fn._pack_args(backend, kwargs, bound_args, specialization, options)
     source_cls = GluonASTSource if kernel_fn.is_gluon() else ASTSource
     src = source_cls(kernel_fn, signature, constexprs, attrs)

--- a/python/triton/compiler/code_generator.py
+++ b/python/triton/compiler/code_generator.py
@@ -14,9 +14,10 @@ from typing import Any, Callable, Dict, Optional, Tuple, Type, Union, Iterable, 
 from .. import knobs, language
 from .._C.libtriton import ir, gluon_ir
 from ..language import constexpr, str_to_ty, tensor, tuple as tl_tuple
-from ..language.core import _unwrap_if_constexpr, base_value, base_type
+from ..language.core import _unwrap_if_constexpr, base_value, base_type, _aggregate_type
 # ideally we wouldn't need any runtime component
-from ..runtime.jit import get_full_name, JITCallable, BoundConstexprFunction, ConstexprFunction, JITFunction
+from ..runtime.jit import (get_full_name, JITCallable, BoundConstexprFunction, ConstexprFunction, JITFunction,
+                           HostConstexprAggregate)
 from .._utils import apply_with_path, set_iterable_path, is_namedtuple
 
 from .errors import (CompilationError, CompileTimeAssertionFailure, UnsupportedLanguageConstruct)
@@ -273,6 +274,13 @@ class ASTFunction:
 
         def build_value(path, ty):
             nonlocal cursor, handles
+            # Types whose runtime pieces carry argument attributes at nested paths
+            # (e.g. host-constructed aggregates) apply them as they go.
+            unflatten_with_attrs = getattr(ty, "_unflatten_ir_with_attrs", None)
+            if unflatten_with_attrs is not None:
+                val, cursor = unflatten_with_attrs(handles, cursor, fn, self.attrs, path)
+                set_iterable_path(vals, path, val)
+                return
             # > set attributes
             attr_specs = self.attrs.get(path, [])
             for attr_name, attr_val in attr_specs:
@@ -1698,6 +1706,34 @@ class CodeGenerator(ast.NodeVisitor):
     }
 
 
+class host_aggregate_type(_aggregate_type):
+    """The argument type for a host-constructed ``@triton.aggregate`` passed as a
+    ``constexpr`` kernel argument.  Its ``tl.constexpr`` members are baked in (as
+    ``constexpr_type`` fields, which flatten to no IR), while its runtime data
+    members are threaded through the kernel interface like any other IR value."""
+
+    def __init__(self, base_cls, fields, runtime_names):
+        # `_aggregate_type` is a frozen dataclass, so bypass its __setattr__.
+        object.__setattr__(self, "base_cls", base_cls)
+        object.__setattr__(self, "fields", list(fields))
+        object.__setattr__(self, "runtime_names", list(runtime_names))
+
+    def _unflatten_ir_with_attrs(self, handles: List[ir.value], cursor: int, fn, attrs, path) -> Tuple[base_value, int]:
+        """Like ``_unflatten_ir`` but also applies the argument attributes
+        (divisibility, ...) of each runtime data member.  Element 0 of the lifted
+        parameter tuple is the aggregate wrapper, so the ``k``-th runtime member's
+        attributes live at path ``(*path, k + 1)`` (see ``JITFunction.run``)."""
+        rt_index = {name: k for k, name in enumerate(self.runtime_names)}
+        instance = self.base_cls._get_instance()
+        for name, ty in self.fields:
+            if name in rt_index:
+                for attr_name, attr_val in attrs.get((*path, rt_index[name] + 1), []):
+                    fn.set_arg_attr(cursor, attr_name, attr_val)
+            value, cursor = ty._unflatten_ir(handles, cursor)
+            setattr(instance, name, value)
+        return instance, cursor
+
+
 def ast_to_ttir(fn, src, context, options, codegen_fns, module_map, module=None):
     arg_types = [None] * len(fn.arg_names)
 
@@ -1723,6 +1759,23 @@ def ast_to_ttir(fn, src, context, options, codegen_fns, module_map, module=None)
 
     for path, value in src.constants.items():
         apply_constexpr_types(arg_types, list(path)[::-1], value)
+
+        # Host-constructed aggregates passed as constexpr kernel arguments: their
+        # runtime data members were lifted to runtime kernel parameters (the signature
+        # is a tuple ``("constexpr", *member_types)``).  Rebuild the aggregate type
+        # with constexpr members baked in and runtime members typed from the tuple.
+        if not isinstance(value, HostConstexprAggregate):
+            continue
+        idx = path[0]
+        tup_ty = arg_types[idx]
+        runtime_types = iter(list(tup_ty.types[1:]) if hasattr(tup_ty, "types") else [])
+        fields = []
+        for fname in value.field_order:
+            if fname in value.const_bindings:
+                fields.append((fname, constexpr(value.const_bindings[fname]).type))
+            else:
+                fields.append((fname, next(runtime_types)))
+        arg_types[idx] = host_aggregate_type(value.base_cls, fields, value.runtime_names)
 
     prototype = ASTFunction([], arg_types, src.attrs)
     # query function representation

--- a/python/triton/language/core.py
+++ b/python/triton/language/core.py
@@ -1709,8 +1709,16 @@ def _aggregate(cls):
         def __setattr__(self, name, value):
             if name not in all_annotations:
                 raise AttributeError(f"{cls.__name__} has no attribute '{name}'")
-            if not isinstance(value, all_annotations[name]):
-                raise TypeError(f"Expected {all_annotations[name]} for attribute '{name}', got {type(value)}")
+            ann = all_annotations[name]
+            if not isinstance(value, ann):
+                # Permit raw host values (e.g. torch.Tensor, host TensorDescriptor,
+                # python scalars) for runtime (non-constexpr) fields when an
+                # aggregate is constructed on the host to be passed as a
+                # `tl.constexpr` kernel argument; such members are lifted to runtime
+                # kernel parameters at launch. Triton values of the wrong type, and
+                # any value for a `tl.constexpr` field, are still rejected.
+                if ann is constexpr or isinstance(value, base_value):
+                    raise TypeError(f"Expected {ann} for attribute '{name}', got {type(value)}")
             if getattr(self, "_aggregate_init_complete", False):
                 raise AttributeError(f"cannot assign to field '{name}' on immutable aggregate {cls.__name__}; "
                                      f"use aggregate_replace() to construct a modified copy")

--- a/python/triton/runtime/jit.py
+++ b/python/triton/runtime/jit.py
@@ -376,12 +376,19 @@ class KernelInterface(Generic[T]):
 
 
 def serialize_specialization_data(name, signature, constants, attrs, options, key, target):
-    constants = {
-        key: str(value) if value.__class__.__name__ == "dtype" else {"constexpr": value.value}
-        if value.__class__.__name__ == "constexpr" else {"jit_function": f"{value.module}:{value.fn.__qualname__}"}
-        if value.__class__.__name__ == "JITFunction" else value
-        for key, value in constants.items()
-    }
+
+    def serialize_constant(value):
+        if value.__class__.__name__ == "dtype":
+            return str(value)
+        if value.__class__.__name__ == "constexpr":
+            return {"constexpr": value.value}
+        if value.__class__.__name__ == "JITFunction":
+            return {"jit_function": f"{value.module}:{value.fn.__qualname__}"}
+        if isinstance(value, HostConstexprAggregate):
+            return {"constexpr_aggregate": value.cache_key}
+        return value
+
+    constants = {key: serialize_constant(value) for key, value in constants.items()}
 
     import json
     obj = {
@@ -589,6 +596,66 @@ class JitFunctionInfo:
     jit_function: JITFunction
 
 
+def _capture_repr(value: Any) -> str:
+    """A stable, value-based representation of a runtime/compile-time member, used
+    to key the compilation cache (so the same aggregate configured with the same
+    compile-time members reuses a compiled kernel)."""
+    if isinstance(value, JITCallable):
+        return value.cache_key
+    # Avoid hashing tensor contents; capture only the structural identity.
+    if hasattr(value, "shape") and hasattr(value, "dtype") and hasattr(value, "data_ptr"):
+        return f"tensor({tuple(value.shape)},{value.dtype})"
+    return repr(value)
+
+
+def aggregate_cache_key(base_cls, const_bindings, runtime_names) -> str:
+    parts = [f"{base_cls.__module__}.{base_cls.__qualname__}"]
+    # Only compile-time (constexpr) members and the runtime member *layout* affect
+    # the cache key; runtime member values are passed as kernel parameters.
+    for name in sorted(const_bindings):
+        parts.append(f"{name}={_capture_repr(const_bindings[name])}")
+    parts.append("rt=" + ",".join(runtime_names))
+    return "aggregate:" + "|".join(parts)
+
+
+class HostConstexprAggregate:
+    """Stable wrapper for a host-constructed ``@triton.aggregate`` passed as a
+    ``constexpr`` kernel argument.
+
+    The aggregate's runtime (non-constexpr) data members -- e.g. ``tl.tensor`` or
+    ``tl.tensor_descriptor`` fields -- are lifted to runtime kernel parameters
+    (``runtime_names``/``runtime_values``), while its ``tl.constexpr`` members are
+    baked into the kernel (``const_bindings``).  Changing a runtime member's value
+    therefore reuses the same compiled kernel.
+    """
+
+    def __init__(self, value):
+        from triton.language.core import constexpr
+        self.base_cls = type(value)
+        self.field_order = list(getattr(value, "__aggregate_fields__"))
+        annotations = type(value).__annotations__
+        self.runtime_names = []
+        self.runtime_values = []
+        self.const_bindings = {}
+        for name in self.field_order:
+            member = getattr(value, name)
+            if annotations.get(name) is constexpr:
+                self.const_bindings[name] = member.value if isinstance(member, constexpr) else member
+            else:
+                self.runtime_names.append(name)
+                self.runtime_values.append(member)
+        self.cache_key = aggregate_cache_key(self.base_cls, self.const_bindings, self.runtime_names)
+
+    def __repr__(self) -> str:
+        return self.cache_key
+
+    def __hash__(self) -> int:
+        return hash(self.cache_key)
+
+    def __eq__(self, other) -> bool:
+        return isinstance(other, HostConstexprAggregate) and self.cache_key == other.cache_key
+
+
 def compute_cache_key(kernel_key_cache, specialization, options):
     key = (tuple(specialization), str(options))
     cache_key = kernel_key_cache.get(key, None)
@@ -723,6 +790,38 @@ class JITFunction(JITCallable, KernelInterface[T]):
 
         return options, signature, constexprs, attrs
 
+    def _specialize_host_aggregates(self, backend, bound_args, specialization):
+        """Lift the runtime data members of any host-constructed ``@triton.aggregate``
+        passed as a ``constexpr`` argument to runtime kernel parameters, mutating
+        ``bound_args`` and ``specialization`` in place.
+
+        Such an aggregate may carry runtime data members (tl.tensor /
+        tl.tensor_descriptor). Those members are appended to the argument as a tuple
+        ``(aggregate, *members)`` so they flow through the existing tuple-argument
+        machinery (signature, launcher, IR), while the kernel reconstructs the
+        aggregate against them. Only the aggregate's compile-time (tl.constexpr)
+        members specialize the kernel.
+        """
+        for i in self.constexprs:
+            name = self.arg_names[i]
+            val = bound_args.get(name)
+            if not getattr(val, "__triton_aggregate__", False):
+                continue
+            wrapper = HostConstexprAggregate(val)
+            if not wrapper.runtime_values:
+                # A pure compile-time aggregate already works as a baked constant.
+                continue
+            cap_types = []
+            cap_attrs = []
+            for cap in wrapper.runtime_values:
+                ty, attr = native_specialize_impl(backend, cap, False, True, True)
+                cap_types.append(ty)
+                cap_attrs.append(attr)
+            bound_args[name] = (wrapper, *wrapper.runtime_values)
+            # The wrapper sits in the (otherwise attribute) slot of the constexpr
+            # element so its identity participates in the cache key.
+            specialization[i] = (("constexpr", *cap_types), (wrapper, *cap_attrs))
+
     def run(self, *args, grid, warmup, **kwargs):
         kwargs["debug"] = kwargs.get("debug", self.debug) or knobs.runtime.debug
         kwargs["instrumentation_mode"] = knobs.compilation.instrumentation_mode
@@ -740,6 +839,8 @@ class JITFunction(JITCallable, KernelInterface[T]):
         # specialization is list[tuple[str, Any]], where first element of tuple is
         # the type and the second parameter is the 'specialization' value.
         bound_args, specialization, options = binder(*args, **kwargs)
+
+        self._specialize_host_aggregates(backend, bound_args, specialization)
 
         # add a cache field to the kernel specializations for kernel specific
         # pass pipelines

--- a/python/tutorials/12-composable-kernel.py
+++ b/python/tutorials/12-composable-kernel.py
@@ -1,0 +1,278 @@
+"""
+Composable Kernels: Host-Built Aggregates as Epilogues
+======================================================
+
+In this tutorial you will write a *single* ``matmul_kernel`` and customize its
+**epilogue** with a host-constructed ``@triton.aggregate`` passed as one
+``tl.constexpr`` argument. Two different launch functions build two different
+epilogue objects -- a base ``BiasAdd`` and a derived ``BiasAddScale`` -- and hand
+them to the same kernel.
+
+In doing so, you will learn about:
+
+* Writing a ``@triton.aggregate`` that mixes a **runtime data member** (a
+  ``tl.tensor`` -- here a bias pointer) with **compile-time data members**
+  (``tl.constexpr`` shape / scale).
+
+* **Inheriting** one aggregate from another: ``BiasAddScale(BiasAdd)`` adds a
+  ``scale`` field and overrides the ``@triton.jit`` ``apply`` epilogue method.
+
+* Constructing the object on the **host** and passing it as a single
+  ``tl.constexpr`` kernel argument. Its runtime members are *lifted to runtime
+  kernel parameters*, while its ``tl.constexpr`` members are baked in -- so
+  changing the bias tensor reuses the same compiled kernel.
+
+* Using the aggregate's type to drive **compile-time polymorphism**: the kernel
+  calls ``epilogue.apply(...)`` and the concrete aggregate type selects which IR
+  is emitted, with no runtime branching.
+
+"""
+
+# %%
+# Motivation
+# ----------
+#
+# A matmul is rarely the whole story: we usually fuse an *epilogue* onto the
+# accumulator -- add a bias, scale the result, apply an activation. We would like
+# to write the matmul body **once** and swap epilogues without rewriting the
+# kernel or threading an ever-growing list of optional pointers and flags through
+# its signature.
+#
+# A ``@triton.aggregate`` is the natural container for an epilogue: it bundles the
+# epilogue's *operands* (a bias tensor) with its *configuration* (output width, a
+# scale) and exposes the fused math as a ``@triton.jit`` method. Because the
+# object is passed as a single ``tl.constexpr`` argument, its runtime members are
+# lifted to kernel parameters automatically and its compile-time members
+# specialize the kernel.
+
+import torch
+
+import triton
+import triton.language as tl
+
+DEVICE = triton.runtime.driver.active.get_active_torch_device()
+
+
+# %%
+# A small validation helper
+# -------------------------
+#
+# Each example checks its Triton result against the equivalent PyTorch expression
+# and prints a checkmark with the max absolute difference.
+
+
+def run_test(expect, fn, label, atol=5e-2):
+    print(f"  {label}: ...", end="")
+    actual = fn().to(expect.dtype)
+    max_diff = torch.max(torch.abs(actual - expect)).item()
+    icon = "✅" if torch.allclose(actual, expect, atol=atol) else "❌"
+    print(f"\r  {label}: {icon}  (max abs diff {max_diff:.2e})")
+
+
+# %%
+# The base epilogue: ``BiasAdd``
+# ------------------------------
+#
+# ``BiasAdd`` carries one **runtime** data member -- a ``bias`` pointer
+# (``tl.tensor``) to a length-``N`` vector -- and one **compile-time** member,
+# ``n_cols`` (used to mask the bias load). Its ``@triton.jit`` ``apply`` method is
+# the fused epilogue: it adds the per-column bias to the matmul accumulator.
+#
+# The constructor is a ``@triton.constexpr_function`` so the object can be built
+# on the host (we pass a raw ``torch.Tensor`` for the runtime ``bias`` field) and
+# referenced by name inside a kernel.
+
+
+@triton.aggregate
+class BiasAdd:
+    # Runtime data member: lifted to a runtime kernel parameter at launch.
+    bias: tl.tensor
+    # Compile-time data member: baked into the kernel.
+    n_cols: tl.constexpr
+
+    @triton.constexpr_function
+    def __init__(self, bias, n_cols):
+        self.bias = bias
+        self.n_cols = tl.constexpr(n_cols)
+
+    @triton.jit
+    def apply(self, acc, offs_n):
+        # The runtime `bias` member drives the load; the compile-time `n_cols`
+        # member masks the tail.
+        bias = tl.load(self.bias + offs_n, mask=offs_n < self.n_cols, other=0.0)
+        return acc + bias[None, :]
+
+
+# %%
+# The derived epilogue: ``BiasAddScale``
+# --------------------------------------
+#
+# ``BiasAddScale`` *inherits* from ``BiasAdd`` -- it reuses the ``bias`` and
+# ``n_cols`` fields and adds a **runtime** ``scale``. Like ``bias``, the
+# ``scale`` is a ``tl.tensor`` data member, so it is lifted to a runtime kernel
+# parameter rather than baked in: changing it reuses the same compiled kernel. It
+# overrides ``apply`` to scale the biased accumulator. Aggregate inheritance
+# collects the parent fields first, then the child's, so the field order is
+# ``(bias, n_cols, scale)``.
+
+
+@triton.aggregate
+class BiasAddScale(BiasAdd):
+    # An additional runtime data member on top of the inherited fields: lifted to
+    # a runtime kernel parameter, not baked in.
+    scale: tl.tensor
+
+    @triton.constexpr_function
+    def __init__(self, bias, n_cols, scale):
+        self.bias = bias
+        self.n_cols = tl.constexpr(n_cols)
+        self.scale = scale
+
+    @triton.jit
+    def apply(self, acc, offs_n):
+        # Reuse the base epilogue (bias add), then apply the runtime scale. The
+        # base method is called explicitly with `self`, which is a `BiasAddScale`.
+        return BiasAdd.apply(self, acc, offs_n) * self.scale
+
+
+# %%
+# One kernel, any epilogue
+# ------------------------
+#
+# ``matmul_kernel`` computes ``C = A @ B`` and then calls ``epilogue.apply(...)``.
+# The ``epilogue`` parameter is a single ``tl.constexpr``: its concrete aggregate
+# type (``BiasAdd`` or ``BiasAddScale``) is known at compile time, so the call is
+# resolved with **no runtime branching**, and its runtime ``bias`` member was
+# lifted to a runtime kernel parameter behind the scenes.
+
+
+@triton.jit
+def matmul_kernel(
+    a_ptr, b_ptr, c_ptr,  #
+    M, N, K,  #
+    stride_am, stride_ak,  #
+    stride_bk, stride_bn,  #
+    stride_cm, stride_cn,  #
+    epilogue: tl.constexpr,  # a host-built BiasAdd / BiasAddScale aggregate
+    BLOCK_SIZE_M: tl.constexpr, BLOCK_SIZE_N: tl.constexpr, BLOCK_SIZE_K: tl.constexpr,  #
+):
+    pid_m = tl.program_id(axis=0)
+    pid_n = tl.program_id(axis=1)
+
+    offs_am = (pid_m * BLOCK_SIZE_M + tl.arange(0, BLOCK_SIZE_M)) % M
+    offs_bn = (pid_n * BLOCK_SIZE_N + tl.arange(0, BLOCK_SIZE_N)) % N
+    offs_k = tl.arange(0, BLOCK_SIZE_K)
+    a_ptrs = a_ptr + (offs_am[:, None] * stride_am + offs_k[None, :] * stride_ak)
+    b_ptrs = b_ptr + (offs_k[:, None] * stride_bk + offs_bn[None, :] * stride_bn)
+
+    acc = tl.zeros((BLOCK_SIZE_M, BLOCK_SIZE_N), dtype=tl.float32)
+    for k in range(0, tl.cdiv(K, BLOCK_SIZE_K)):
+        k_mask = offs_k[None, :] < K - k * BLOCK_SIZE_K
+        a = tl.load(a_ptrs, mask=k_mask, other=0.0)
+        b = tl.load(b_ptrs, mask=offs_k[:, None] < K - k * BLOCK_SIZE_K, other=0.0)
+        acc = tl.dot(a, b, acc)
+        a_ptrs += BLOCK_SIZE_K * stride_ak
+        b_ptrs += BLOCK_SIZE_K * stride_bk
+
+    # The fused epilogue. `epilogue` is a compile-time constant whose type selects
+    # which `apply` (BiasAdd's or BiasAddScale's) is emitted here.
+    offs_cn = pid_n * BLOCK_SIZE_N + tl.arange(0, BLOCK_SIZE_N)
+    acc = epilogue.apply(acc, offs_cn)
+    c = acc.to(c_ptr.dtype.element_ty)
+
+    offs_cm = pid_m * BLOCK_SIZE_M + tl.arange(0, BLOCK_SIZE_M)
+    c_ptrs = c_ptr + stride_cm * offs_cm[:, None] + stride_cn * offs_cn[None, :]
+    c_mask = (offs_cm[:, None] < M) & (offs_cn[None, :] < N)
+    tl.store(c_ptrs, c, mask=c_mask)
+
+
+# %%
+# Two launch functions, two epilogues, one kernel
+# -----------------------------------------------
+#
+# Each launch function builds its epilogue object on the host -- passing the
+# ``bias`` tensor as the runtime member -- and hands it to the *same*
+# ``matmul_kernel``. ``matmul_bias_add`` builds a ``BiasAdd``;
+# ``matmul_bias_add_scale`` builds a ``BiasAddScale``.
+
+BLOCK_SIZE_M, BLOCK_SIZE_N, BLOCK_SIZE_K = 64, 64, 32
+
+
+def _launch(a, b, epilogue):
+    M, K = a.shape
+    _, N = b.shape
+    c = torch.empty((M, N), device=a.device, dtype=torch.float16)
+    grid = (triton.cdiv(M, BLOCK_SIZE_M), triton.cdiv(N, BLOCK_SIZE_N))
+    matmul_kernel[grid](
+        a, b, c,  #
+        M, N, K,  #
+        a.stride(0), a.stride(1),  #
+        b.stride(0), b.stride(1),  #
+        c.stride(0), c.stride(1),  #
+        epilogue,  #
+        BLOCK_SIZE_M, BLOCK_SIZE_N, BLOCK_SIZE_K,  #
+    )
+    return c
+
+
+def matmul_bias_add(a, b, bias):
+    N = b.shape[1]
+    # The base epilogue: built on the host with a runtime `bias` tensor.
+    return _launch(a, b, BiasAdd(bias, N))
+
+
+def matmul_bias_add_scale(a, b, bias, scale):
+    N = b.shape[1]
+    # The derived epilogue: same runtime `bias`, plus a runtime `scale`.
+    return _launch(a, b, BiasAddScale(bias, N, scale))
+
+
+# %%
+# Let's check both against PyTorch.
+
+torch.manual_seed(0)
+M, N, K = 512, 256, 128
+a = torch.randn((M, K), device=DEVICE, dtype=torch.float16)
+b = torch.randn((K, N), device=DEVICE, dtype=torch.float16)
+bias = torch.randn((N, ), device=DEVICE, dtype=torch.float32)
+scale = 0.5
+
+ref = (a.float() @ b.float())
+run_test(ref + bias, lambda: matmul_bias_add(a, b, bias), "BiasAdd epilogue")
+run_test((ref + bias) * scale, lambda: matmul_bias_add_scale(a, b, bias, scale), "BiasAddScale epilogue (derived)")
+
+# %%
+# Reusing the compiled kernel across runtime members
+# --------------------------------------------------
+#
+# Because both ``bias`` and ``scale`` are *runtime* members, calling either launch
+# function again with a **different bias tensor or scale** -- but the same
+# compile-time members (``n_cols``) -- reuses the already-compiled kernel. Only
+# changing a ``tl.constexpr`` member (e.g. a block size or ``n_cols``) would
+# specialize a new one.
+
+bias2 = torch.randn((N, ), device=DEVICE, dtype=torch.float32)
+run_test(ref + bias2, lambda: matmul_bias_add(a, b, bias2), "BiasAdd epilogue (new bias, same kernel)")
+run_test((ref + bias2) * 0.25, lambda: matmul_bias_add_scale(a, b, bias2, 0.25),
+         "BiasAddScale epilogue (new bias & scale, same kernel)")
+
+# %%
+# Takeaways
+# ---------
+#
+# * An epilogue is naturally a ``@triton.aggregate``: it bundles runtime operands
+#   (a ``tl.tensor`` bias, a ``tl.tensor`` scale) with compile-time configuration
+#   (``n_cols``) and exposes the fused math as a ``@triton.jit`` method.
+#
+# * Aggregates **inherit**: ``BiasAddScale(BiasAdd)`` reuses the parent's fields,
+#   adds its own runtime ``scale`` member, and overrides ``apply`` to extend the
+#   epilogue.
+#
+# * Building the object on the **host** and passing it as one ``tl.constexpr``
+#   argument lifts its runtime members to kernel parameters while baking in its
+#   constexpr members -- so a single kernel signature stays clean no matter how
+#   rich the epilogue is, and changing a runtime member reuses the compiled kernel.
+#
+# * The aggregate's *type* drives compile-time polymorphism: ``matmul_kernel``
+#   calls ``epilogue.apply(...)`` once, and the concrete type selects the emitted
+#   IR -- two epilogues, two launch functions, one kernel.

--- a/python/tutorials/12-composable-kernel.py
+++ b/python/tutorials/12-composable-kernel.py
@@ -177,7 +177,8 @@ def matmul_kernel(
     # The fused epilogue. `epilogue` is a compile-time constant whose type selects
     # which `apply` (BiasAdd's or BiasAddScale's) is emitted here.
     offs_cn = pid_n * BLOCK_SIZE_N + tl.arange(0, BLOCK_SIZE_N)
-    acc = epilogue.apply(acc, offs_cn)
+    if not epilogue is None:
+        acc = epilogue.apply(acc, offs_cn)
     c = acc.to(c_ptr.dtype.element_ty)
 
     offs_cm = pid_m * BLOCK_SIZE_M + tl.arange(0, BLOCK_SIZE_M)
@@ -215,6 +216,9 @@ def _launch(a, b, epilogue):
     return c
 
 
+def matmul(a, b):
+    return _launch(a, b, None)
+
 def matmul_bias_add(a, b, bias):
     N = b.shape[1]
     # The base epilogue: built on the host with a runtime `bias` tensor.
@@ -238,6 +242,7 @@ bias = torch.randn((N, ), device=DEVICE, dtype=torch.float32)
 scale = 0.5
 
 ref = (a.float() @ b.float())
+run_test(ref, lambda: matmul(a, b), "None epilogue")
 run_test(ref + bias, lambda: matmul_bias_add(a, b, bias), "BiasAdd epilogue")
 run_test((ref + bias) * scale, lambda: matmul_bias_add_scale(a, b, bias, scale), "BiasAddScale epilogue (derived)")
 


### PR DESCRIPTION
Allow a `@triton.aggregate` to be built on the host and passed as a `tl.constexpr` kernel argument. Its runtime data members (e.g. `tl.tensor` and `tl.tensor_descriptor`) are lifted to runtime kernel parameters, while its `tl.constexpr` members are baked in, so changing a runtime member reuses the same compiled kernel while constexpr members specialize.

- core: permit raw host values for runtime aggregate fields during host construction.
- jit: add HostConstexprAggregate wrapper (stable cache key, runtime/constexpr member classification) and a reusable `_specialize_host_aggregates` step that lifts runtime members to kernel params in run(), plus specialization-cache serialization.
- code_generator: add host_aggregate_type, rebuild the aggregate arg type in ast_to_ttir from the lifted tuple signature, and propagate argument attributes (e.g. divisibility) to runtime member params.
- _filecheck: reproduce run()'s host-aggregate lifting so parser/filecheck tests exercise the same path.
- test + tutorial 12 (composable-kernel) demonstrating host-built aggregate epilogues: a BiasAdd base and derived BiasAddScale passed to one matmul kernel from two launch functions, with runtime bias/scale members.
