### PR TITLE
[AMD] Work around gfx94x/gfx950 LLVM accuracy regressions

### DIFF
--- a/python/src/llvm.cc
+++ b/python/src/llvm.cc
@@ -40,6 +40,7 @@
 #include <pybind11/pybind11.h>
 #include <pybind11/stl.h>
 #include <stdexcept>
+#include <vector>
 
 namespace py = pybind11;
 
@@ -128,6 +129,15 @@ public:
   ScopedLLVMOption &operator=(const ScopedLLVMOption &) = delete;
 };
 
+std::vector<std::unique_ptr<ScopedLLVMOption<bool>>>
+setScopedLLVMOptions(const std::vector<std::string> &names) {
+  std::vector<std::unique_ptr<ScopedLLVMOption<bool>>> guards;
+  guards.reserve(names.size());
+  for (const std::string &name : names)
+    guards.push_back(std::make_unique<ScopedLLVMOption<bool>>(name, true));
+  return guards;
+}
+
 std::unique_ptr<TargetMachine>
 createTargetMachine(llvm::Module *module, std::string proc,
                     bool enable_fp_fusion, const std::string &features) {
@@ -162,10 +172,7 @@ void dumpSchedulingDAG(llvm::Module &module, const std::string &triple,
     return;
   }
 
-  // Apply flags
-  for (const std::string &flag : flags) {
-    setLLVMOption<bool>(flag, true);
-  }
+  [[maybe_unused]] auto flagGuards = setScopedLLVMOptions(flags);
 
   bool disableLLVMOpt = triton::tools::getBoolEnv("DISABLE_LLVM_OPT");
   if (!disableLLVMOpt) {
@@ -254,10 +261,7 @@ translateLLVMIRToMIR(llvm::Module &module, const std::string &triple,
 
   llvm::StripDebugInfo(module);
 
-  // Apply flags
-  for (const std::string &flag : flags) {
-    setLLVMOption<bool>(flag, true);
-  }
+  [[maybe_unused]] auto flagGuards = setScopedLLVMOptions(flags);
 
   bool disableLLVMOpt = triton::tools::getBoolEnv("DISABLE_LLVM_OPT");
   if (!disableLLVMOpt) {
@@ -333,10 +337,7 @@ std::string translateLLVMIRToASM(
     bool enable_fp_fusion, bool isObject, bool canonicalizeGEP) {
   using namespace mlir;
 
-  // Apply flags
-  for (const std::string &flag : flags) {
-    setLLVMOption<bool>(flag, true);
-  }
+  [[maybe_unused]] auto flagGuards = setScopedLLVMOptions(flags);
 
   if (triton::tools::getBoolEnv("LLVM_IR_ENABLE_DUMP")) {
     setLLVMOption<bool>("print-after-all", true);
@@ -439,10 +440,7 @@ translateMIRToASM(const std::string &mirPath, const std::string &triple,
     setLLVMOption<bool>("print-after-all", true);
   }
 
-  // Apply other flags
-  for (const std::string &flag : flags) {
-    setLLVMOption<bool>(flag, true);
-  }
+  [[maybe_unused]] auto flagGuards = setScopedLLVMOptions(flags);
 
   // Parse MIR into LLVM Module
   llvm::LLVMContext context;

--- a/python/test/unit/language/test_compile_only.py
+++ b/python/test/unit/language/test_compile_only.py
@@ -242,6 +242,32 @@ def test_signature_ordering():
     triton.compile(src=src, target=target)
 
 
+def test_ast_source_filters_divisibility_for_gfx94x_gfx950():
+    @triton.jit
+    def kernel(a, b):
+        idx = tl.arange(0, 16)
+        tl.store(b + idx, tl.load(a + idx))
+
+    attrs = {
+        (0,): [["tt.divisibility", 16], ["tt.pointer_range", 32]],
+        (1,): [["tt.divisibility", 16]],
+    }
+    src = ASTSource(fn=kernel, signature={"a": "*fp32", "b": "*fp32"}, attrs=attrs)
+
+    assert src._attrs_for_target(GPUTarget("hip", "gfx942", 64)) == {
+        (0,): [["tt.pointer_range", 32]],
+    }
+    assert src._attrs_for_target(GPUTarget("hip", "gfx950", 64)) == {
+        (0,): [["tt.pointer_range", 32]],
+    }
+    assert src._attrs_for_target(GPUTarget("hip", "gfx950:xnack-", 64)) == {
+        (0,): [["tt.pointer_range", 32]],
+    }
+    assert src._attrs_for_target(GPUTarget("hip", "gfx1030", 64)) == attrs
+    assert src._attrs_for_target(GPUTarget("hip", "gfx951", 64)) == attrs
+    assert src._attrs_for_target(GPUTarget("cuda", 90, 32)) == attrs
+
+
 def test_fp8_compiles_for_multiple_architectures_hip():
     """
     Validate FP8 compilation succeeds for architectures with different

--- a/python/triton/compiler/compiler.py
+++ b/python/triton/compiler/compiler.py
@@ -75,10 +75,31 @@ class ASTSource:
         key = f"{self.fn.cache_key}-{str(self.attrs)}-{sorted_sig}-{constants_key}"
         return hashlib.sha256(key.encode("utf-8")).hexdigest()
 
+    def _attrs_for_target(self, target):
+        arch = str(target.arch).split(":", 1)[0]
+        if target.backend != "hip" or not (arch.startswith("gfx94") or arch == "gfx950"):
+            return self.attrs
+
+        # LLVM 62b7cf regresses ROCm Inductor accuracy on gfx94x/gfx950 when
+        # kernels carry divisibility hints. Keep other hints intact.
+        attrs = {
+            key: [attr for attr in attr_specs if attr[0] != "tt.divisibility"]
+            for key, attr_specs in self.attrs.items()
+        }
+        return {key: attr_specs for key, attr_specs in attrs.items() if attr_specs}
+
     def make_ir(self, target: GPUTarget, options, codegen_fns, module_map, context):
         from .code_generator import ast_to_ttir
-        return ast_to_ttir(self.fn, self, context=context, options=options, codegen_fns=codegen_fns,
-                           module_map=module_map)
+        src = copy.copy(self)
+        src.attrs = self._attrs_for_target(target)
+        return ast_to_ttir(
+            self.fn,
+            src,
+            context=context,
+            options=options,
+            codegen_fns=codegen_fns,
+            module_map=module_map,
+        )
 
     def parse_options(self):
         return dict()

--- a/third_party/amd/backend/compiler.py
+++ b/third_party/amd/backend/compiler.py
@@ -49,6 +49,11 @@ def is_fpsan_supported(arch):
     return arch in ["gfx942", "gfx950", "gfx1250"]
 
 
+def needs_gfx94x_gfx950_llvm_workarounds(arch):
+    arch = str(arch).split(":", 1)[0]
+    return arch.startswith("gfx94") or arch == "gfx950"
+
+
 def is_consan_supported(arch):
     return arch in ["gfx1250"]
 
@@ -507,8 +512,12 @@ class HIPBackend(BaseBackend):
             if len(paths) > 0:
                 llvm.link_extern_libs(llvm_mod, paths)
 
+        # FIXME: LLVM 62b7cf regresses ROCm Inductor accuracy on gfx94x/gfx950
+        # through SLP vectorization. Keep the workaround scoped to the affected
+        # CDNA targets while the LLVM-side issue is fixed.
+        disable_slp_vectorizer = needs_gfx94x_gfx950_llvm_workarounds(options.arch)
         llvm.optimize_module(llvm_mod, llvm.OPTIMIZE_O3, options.arch, '', [], options.enable_fp_fusion,
-                             disable_vector_combine=True)
+                             disable_slp_vectorizer=disable_slp_vectorizer, disable_vector_combine=True)
 
         # Architectures with architected SGPRs store the workgroup id in ttmp9 (X) and ttmp7 (Y[15:0], Z[31:16]).
         # These attributes are used to determine if Z should be masked out when loading Y. They are inferred during
@@ -548,6 +557,10 @@ class HIPBackend(BaseBackend):
         flags = []
         if is_expert_scheduling_enabled(options.arch):
             flags.append("amdgpu-expert-scheduling-mode")
+        # FIXME: LLVM 62b7cf's AMDGPU post-RA scheduler miscompiles a gfx94x
+        # Inductor TIMM kernel. Disable it only for the affected CDNA targets.
+        if needs_gfx94x_gfx950_llvm_workarounds(options.arch):
+            flags.append("disable-post-ra")
         features = disable_real_true16_feature(options.arch)
         ir_hash = hashlib.sha256(src.encode("utf-8")).hexdigest()
         dump_file_id = names[0] + '_' + ir_hash


### PR DESCRIPTION
Fixes ROCm Inductor accuracy regressions seen while updating the PyTorch Triton pin.

The failures bisected to the LLVM roll in Triton #10503 / LLVM 62b7cf9623fc310525f39ed69aaecc318a909731 on MI300X/gfx950. The affected workloads were:

- `timm/beit_base_patch16_224`
- `timm/deit_base_distilled_patch16_224`
- `timm/vit_base_patch16_siglip_256`
- `torchbench/nanogpt`

This change keeps the mitigations scoped to HIP `gfx94x`/`gfx950`:

- filter `tt.divisibility` argument attrs before TTIR generation while preserving other attrs such as `tt.pointer_range`
- disable LLVM SLP vectorization for these targets
- pass `disable-post-ra` for these targets
- scope LLVM command-line option mutations with RAII guards so backend flags do not leak into later compilations

This does not disable masked buffer ops or masked buffer soffset splitting. In local testing, `vit_base_patch16_siglip_256` passes with masked buffer splitting enabled once `tt.divisibility` is filtered.

Local verification on MI300X/gfx950:

- `python/test/unit/language/test_compile_only.py::test_ast_source_filters_divisibility_for_gfx94x_gfx950` passed
- `timm/vit_base_patch16_siglip_256` passed
- `timm/deit_base_distilled_patch16_224` passed
- `timm/beit_base_patch16_224` passed
- `torchbench/nanogpt` passed