### PR TITLE
[TESTING] Use context manager to disable GC during CUDA graph capture

### DIFF
--- a/python/triton/testing.py
+++ b/python/triton/testing.py
@@ -1,4 +1,5 @@
 import functools
+import gc
 import math
 import os
 import statistics
@@ -60,6 +61,25 @@ def _summarize_statistics(times, quantiles, return_mode):
 
 
 @contextmanager
+def cuda_graph_without_gc(*args, **kwargs):
+    # A loaded Triton CompiledKernel may be finalized by Python's cyclic GC.
+    # Its destructor unloads the CUDA module, which is illegal during CUDA
+    # stream capture and invalidates the graph. Keep GC disabled only for the
+    # capture window and restore the caller's previous GC state afterwards.
+    import torch
+
+    gc_was_enabled = gc.isenabled()
+    if gc_was_enabled:
+        gc.disable()
+    try:
+        with torch.cuda.graph(*args, **kwargs) as graph:
+            yield graph
+    finally:
+        if gc_was_enabled:
+            gc.enable()
+
+
+@contextmanager
 def _proton_bench_session():
     import triton.profiler as proton
 
@@ -110,6 +130,7 @@ def do_bench_cudagraph(fn, rep=20, grad_to_none=None, quantiles=None, return_mod
     :type return_mode: str
     """
     import torch
+
     assert return_mode in ["min", "max", "mean", "median", "all"]
 
     with torch.cuda.stream(torch.cuda.Stream()):
@@ -142,7 +163,7 @@ def do_bench_cudagraph(fn, rep=20, grad_to_none=None, quantiles=None, return_mod
         # step 2 - construct a cuda graph with `n_repeat` unrolled function calls to minimize
         # host overhead
         g = torch.cuda.CUDAGraph()
-        with torch.cuda.graph(g):
+        with cuda_graph_without_gc(g):
             for _ in range(n_repeat):
                 if grad_to_none is not None:
                     for x in grad_to_none:
@@ -217,7 +238,7 @@ def do_bench_cudagraph_proton(fn, rep=20, grad_to_none=None, quantiles=None, ret
             cache = runtime.driver.active.get_empty_cache_for_benchmark()
             g = torch.cuda.CUDAGraph()
             scope_prefix = f"proton.{uuid.uuid4().hex}."
-            with torch.cuda.graph(g):
+            with cuda_graph_without_gc(g):
                 for i in range(n_repeat):
                     if grad_to_none is not None:
                         for x in grad_to_none:

--- a/python/triton_kernels/tests/test_distributed.py
+++ b/python/triton_kernels/tests/test_distributed.py
@@ -6,6 +6,7 @@ import torch
 import torch.distributed as dist
 import torch.multiprocessing as mp
 import triton
+from triton.testing import cuda_graph_without_gc
 from triton_kernels.distributed import (
     _convert_dp_to_ep,
     _convert_ep_to_dp,
@@ -311,7 +312,7 @@ def _run_expert_sharding(rank, world_size, *, n_tokens, d_model, n_expts_tot, n_
     g = torch.cuda.CUDAGraph()
     stream = torch.cuda.Stream()
     with torch.cuda.stream(stream):
-        with torch.cuda.graph(g):
+        with cuda_graph_without_gc(g):
             y_dp_local_tri_graph = run_moe()
 
     g.replay()

--- a/python/triton_kernels/tests/test_topk.py
+++ b/python/triton_kernels/tests/test_topk.py
@@ -1,6 +1,7 @@
 import pytest
 import torch
 import triton.profiler as proton
+from triton.testing import cuda_graph_without_gc
 from triton_kernels.topk import topk, topk_torch
 from triton_kernels.testing import assert_equal, assert_close
 from triton_kernels.distributed import SymmetricMemoryPool
@@ -47,7 +48,7 @@ def bench_topk(n_rows, n_cols, k, apply_softmax, all_gather=False):
     g = torch.cuda.CUDAGraph()
     stream = torch.cuda.Stream()
     with torch.cuda.stream(stream):
-        with torch.cuda.graph(g):
+        with cuda_graph_without_gc(g):
             _ = topk(x, k, apply_softmax=apply_softmax, all_gather=all_gather, symm_mem_pool=symm_mem_pool)
     torch.cuda.synchronize()
     proton.activate()

--- a/third_party/proton/test/reproducers/cupti_graph_replay_heap_growth.py
+++ b/third_party/proton/test/reproducers/cupti_graph_replay_heap_growth.py
@@ -697,6 +697,7 @@ def _run_single(args: argparse.Namespace) -> int:
     import triton
     import triton.language as tl
     import triton.profiler as proton
+    from triton.testing import cuda_graph_without_gc
 
     torch.cuda.set_device(args.device)
     device = torch.device(f"cuda:{args.device}")
@@ -732,7 +733,7 @@ def _run_single(args: argparse.Namespace) -> int:
 
     g = torch.cuda.CUDAGraph()
     if args.capture_before_start:
-        with torch.cuda.graph(g, stream=stream):
+        with cuda_graph_without_gc(g, stream=stream):
             direct_iteration()
         torch.cuda.synchronize()
 
@@ -808,7 +809,7 @@ def _run_single(args: argparse.Namespace) -> int:
     run_metadata["loaded_libcupti_objects_after_start"] = _read_loaded_shared_objects("libcupti")
 
     if not args.capture_before_start:
-        with torch.cuda.graph(g, stream=stream):
+        with cuda_graph_without_gc(g, stream=stream):
             direct_iteration()
         torch.cuda.synchronize()
         samples.append(_collect_sample("post_graph_capture", 0.0, 0, profile_base))

--- a/third_party/proton/test/test_profile.py
+++ b/third_party/proton/test/test_profile.py
@@ -7,18 +7,17 @@ import torch
 import triton
 import triton.profiler as proton
 import json
-import gc
 import pytest
 from typing import NamedTuple
 import pathlib
 import threading
-from contextlib import contextmanager
 
 import triton.language as tl
 import triton.profiler.hooks.launch as proton_launch
 from triton.profiler.state import COMPUTE_METADATA_SCOPE_NAME
 import triton.profiler.viewer as viewer
 from triton._internal_testing import is_hip, is_cuda, is_blackwell
+from triton.testing import cuda_graph_without_gc
 
 
 def _find_frame_by_name(frame, name):
@@ -29,23 +28,6 @@ def _find_frame_by_name(frame, name):
             return current
         queue.extend(current["children"])
     return None
-
-
-@contextmanager
-def cuda_graph_without_gc(*args, **kwargs):
-    # A loaded Triton CompiledKernel may be finalized by Python's cyclic GC.
-    # Its destructor unloads the CUDA module, which is illegal during CUDA
-    # stream capture and invalidates the graph. Keep GC disabled only for the
-    # capture window and restore the caller's previous GC state afterwards.
-    gc_was_enabled = gc.isenabled()
-    if gc_was_enabled:
-        gc.disable()
-    try:
-        with torch.cuda.graph(*args, **kwargs) as graph:
-            yield graph
-    finally:
-        if gc_was_enabled:
-            gc.enable()
 
 
 @pytest.mark.parametrize("context", ["shadow", "python"])
@@ -1585,7 +1567,7 @@ def test_tensor_metrics_cudagraph_hook(tmp_path: pathlib.Path, device: str):
     metric_value.zero_()
 
     graph = torch.cuda.CUDAGraph()
-    with torch.cuda.graph(graph):
+    with cuda_graph_without_gc(graph):
         metadata_owner_kernel[(1, )](x, y, metric_value, bytes_value, num_warps=1)
 
     with proton.scope("replay"):


### PR DESCRIPTION
- Introduced `cuda_graph_without_gc` to prevent Python's cyclic GC from finalizing loaded Triton CompiledKernel during CUDA stream capture.
- Updated relevant benchmarks and tests to utilize the new context manager for safer CUDA graph operations.