### PR TITLE
Build LLVM for the Triton 3.8 release branch (llvm-project#203770)

### DIFF
--- a/cmake/llvm-build-info.json
+++ b/cmake/llvm-build-info.json
@@ -1,5 +1,5 @@
 {
-  "llvm_hash": "1f126a6dea50d185c0781743a667390037ae88bd",
+  "llvm_hash": "4611156032e1ebac68b2b8f6107b1475a7c60800",
   "repository": "triton-lang/llvm-project",
-  "build_number": 2
+  "build_number": 1
 }


### PR DESCRIPTION
## Summary
Point `cmake/llvm-build-info.json` at `triton-lang/llvm-project@4611156` so the `llvm-build` workflow produces a prebuilt LLVM to unblock Triton 3.8 release branch. Following example https://github.com/triton-lang/triton/pull/10632

That branch contains the latest Triton LLVM pin (`62b7cf96`) + one cherry-pick: [llvm/llvm-project#203770](https://github.com/llvm/llvm-project/pull/203770) "[AMDGPU] Fix checkVALUHazardsHelper distance accounting on branchy CFG".

This fixes a gfx950/MI350 silent bf16 miscompile (NaN) under `torch.compile` that blocks the 3.8 pin bump in [pytorch/pytorch#185453](https://github.com/pytorch/pytorch/pull/185453). The bug is in LLVM #197267 (present in `62b7cf96`); #203770 is the upstream fix, validated on MI350 (deit/beit pass with it, fail without).

```json
{
  "llvm_hash": "4611156032e1ebac68b2b8f6107b1475a7c60800",
  "repository": "triton-lang/llvm-project",
  "build_number": 1
}
```

Only `build-info.json` changes — `cmake/llvm-info.json` (what `main` consumes) is untouched, so this just stages a new prebuilt and doesn't change main's LLVM.

Authored with Claude