### PR TITLE
Remove broadcasted registers in llvm struct

### DIFF
--- a/include/triton/Conversion/TritonGPUToLLVM/ElementwiseOpToLLVMBase.h
+++ b/include/triton/Conversion/TritonGPUToLLVM/ElementwiseOpToLLVMBase.h
@@ -83,6 +83,7 @@ public:
     // We zero out the bases that are constant
     auto kReg = StringAttr::get(ctx, "register");
     auto ll = toLinearLayout(rtType);
+    ll = ll.removeZeroBasesAlongDim(kReg);
     auto dims = to_vector(ll.getOutDimNames());
     auto llReg = ll.sublayout({kReg}, dims);
     auto inv = ll.pseudoinvert();
@@ -116,7 +117,7 @@ public:
     Type elemTy = this->getTypeConverter()->convertType(resultElementTy);
     SmallVector<SmallVector<Value>> allOperands;
     for (auto operand : adaptor.getOperands()) {
-      auto subOperands = unpackLLElements(loc, operand, rewriter);
+      auto subOperands = unpackUniqueTensorElements(loc, operand, rewriter);
       allOperands.resize(subOperands.size());
       for (auto v : llvm::enumerate(subOperands))
         allOperands[v.index()].push_back(v.value());
@@ -138,8 +139,8 @@ public:
       it += curr.size();
     }
     resultVals = maybeDeduplicate(op, resultVals);
-    Value view = packLLElements(loc, this->getTypeConverter(), resultVals,
-                                rewriter, resultTy);
+    Value view = packUniqueTensorElements(loc, this->getTypeConverter(),
+                                          resultVals, rewriter, resultTy);
     rewriter.replaceOp(op, view);
 
     return success();

--- a/include/triton/Conversion/TritonGPUToLLVM/Utility.h
+++ b/include/triton/Conversion/TritonGPUToLLVM/Utility.h
@@ -710,8 +710,28 @@ lowerLocalLdSt(Location loc, MLIRContext *ctx,
 SmallVector<Value> unpackLLElements(Location loc, Value llvmStruct,
                                     RewriterBase &rewriter);
 
+SmallVector<Value> unpackUniqueTensorElements(Location loc, Value llvmStruct,
+                                              RewriterBase &rewriter);
+
+/// Unpack the values in \p llvmStruct into a vector using the layout from
+/// \p originalType.
+SmallVector<Value> unpackTensorElements(Location loc, Value llvmStruct,
+                                        RewriterBase &rewriter,
+                                        Type originalType);
+
 Value packLLElements(Location loc, const LLVMTypeConverter *typeConverter,
                      ValueRange resultVals, RewriterBase &rewriter, Type type);
+
+Value packUniqueTensorElements(Location loc,
+                               const LLVMTypeConverter *typeConverter,
+                               ValueRange resultVals, RewriterBase &rewriter,
+                               Type type);
+
+/// Pack the values in \p resultVals into an llvm struct using the layout from
+/// \p type.
+Value packTensorElements(Location loc, const LLVMTypeConverter *typeConverter,
+                         ValueRange resultVals, RewriterBase &rewriter,
+                         Type type);
 
 SmallVector<Value> unpackLLVector(Location loc, Value llvmVec,
                                   RewriterBase &rewriter);

--- a/lib/Conversion/TritonGPUToLLVM/AssertOpToLLVM.cpp
+++ b/lib/Conversion/TritonGPUToLLVM/AssertOpToLLVM.cpp
@@ -19,7 +19,8 @@ struct AssertOpConversion : public ConvertOpToLLVMPattern<triton::AssertOp> {
                   ConversionPatternRewriter &rewriter) const override {
     auto loc = op.getLoc();
     auto b = TritonLLVMOpBuilder(loc, rewriter);
-    auto elems = unpackLLElements(loc, adaptor.getCondition(), rewriter);
+    auto elems =
+        unpackUniqueTensorElements(loc, adaptor.getCondition(), rewriter);
     auto elemTy = elems[0].getType();
     Value condition = b.int_val(elemTy.getIntOrFloatBitWidth(), 0);
     for (auto elem : elems) {

--- a/lib/Conversion/TritonGPUToLLVM/ConvertLayoutOpToLLVM.cpp
+++ b/lib/Conversion/TritonGPUToLLVM/ConvertLayoutOpToLLVM.cpp
@@ -95,14 +95,15 @@ struct ConvertLayoutOpConversion
     auto kRegister = str_attr("register");
     assert(!cvtNeedsSharedMemory(op.getSrc().getType(), op.getType()));
 
-    auto inVals = unpackLLElements(loc, adaptor.getSrc(), rewriter);
+    auto inVals = unpackTensorElements(loc, adaptor.getSrc(), rewriter,
+                                       op.getSrc().getType());
     SmallVector<Value> outVals(conversion.getInDimSize(kRegister));
     for (int i = 0; i < outVals.size(); i++) {
       auto srcIdx = conversion.apply({{kRegister, i}}).begin()->second;
       outVals[i] = inVals[srcIdx];
     }
-    Value result = packLLElements(loc, getTypeConverter(), outVals, rewriter,
-                                  op.getType());
+    Value result = packTensorElements(loc, getTypeConverter(), outVals,
+                                      rewriter, op.getType());
     rewriter.replaceOp(op, result);
     return success();
   }
@@ -145,26 +146,6 @@ struct ConvertLayoutOpConversion
         v = b.trunc(llvmElemTy, v);
       }
       return outVals;
-    }
-
-    // Remove broadcasting in src
-    auto removeBroadcastSrc = actionRemoveBroadcastedRegs(srcLayout);
-    if (!removeBroadcastSrc.isIdentity()) {
-      auto prmtSrc = removeBroadcastSrc.apply(srcLayout);
-      auto newInVals = removeBroadcastSrc.apply(inVals);
-      return transferSwizzlingLocalMemImpl(loc, rewriter, prmtSrc, dstLayout,
-                                           newInVals, llvmElemTy, smemBase,
-                                           sourceOp);
-    }
-
-    // Remove broadcasting in dst
-    auto removeBroadcastDst = actionRemoveBroadcastedRegs(dstLayout);
-    if (!removeBroadcastDst.isIdentity()) {
-      auto prmtDst = removeBroadcastDst.apply(dstLayout);
-      auto outVals =
-          transferSwizzlingLocalMemImpl(loc, rewriter, srcLayout, prmtDst,
-                                        inVals, llvmElemTy, smemBase, sourceOp);
-      return broadcastAs(outVals, dstLayout);
     }
 
     // At this point we have a type that's at least 8-bit
@@ -254,21 +235,24 @@ struct ConvertLayoutOpConversion
   void transferSwizzlingLocalMem(ConvertLayoutOp op, Value src,
                                  ConversionPatternRewriter &rewriter) const {
     auto loc = op.getLoc();
+    auto *ctx = op.getContext();
     auto srcTy = op.getSrc().getType();
     auto dstTy = op.getType();
 
     auto srcLayout = toLinearLayout(srcTy);
     auto dstLayout = toLinearLayout(dstTy);
+    srcLayout = srcLayout.removeZeroBasesAlongDim(str_attr("register"));
+    dstLayout = dstLayout.removeZeroBasesAlongDim(str_attr("register"));
 
     auto llvmElemTy = getTypeConverter()->convertType(srcTy.getElementType());
     auto smemBase =
         LLVM::getSharedMemoryBase(loc, rewriter, targetInfo, op.getOperation());
-    auto inVals = unpackLLElements(loc, src, rewriter);
+    auto inVals = unpackUniqueTensorElements(loc, src, rewriter);
     auto outVals = transferSwizzlingLocalMemImpl(
         loc, rewriter, srcLayout, dstLayout, inVals, llvmElemTy, smemBase, op);
 
-    Value result =
-        packLLElements(loc, getTypeConverter(), outVals, rewriter, dstTy);
+    Value result = packUniqueTensorElements(loc, getTypeConverter(), outVals,
+                                            rewriter, dstTy);
     rewriter.replaceOp(op, result);
   }
 
@@ -311,13 +295,7 @@ struct ConvertLayoutOpConversion
     // Here, R denotes the number of 32-bit registers in use after packing (or
     // splitting, if applied to 64-bit types or pointers), and in the `Swap`
     // method, `m` denotes the number of mixed transpositions passed in.
-    auto inVals = unpackLLElements(loc, adaptor.getSrc(), rewriter);
-
-    // To avoid unnecessary data movement, we remove any broadcasting in the
-    // register dimension from the `inVals`.
-    auto srcLayout = toLinearLayout(srcTy);
-    auto removeBroadcastSrc = actionRemoveBroadcastedRegs(srcLayout);
-    inVals = removeBroadcastSrc.apply(inVals);
+    auto inVals = unpackUniqueTensorElements(loc, adaptor.getSrc(), rewriter);
 
     // If the target layout has a larger register dimension than the source
     // layout, then we broadcast along the register dimension to match size. The
@@ -419,16 +397,11 @@ struct ConvertLayoutOpConversion
     // If `dstLayout` has a smaller `kReg` dimension than `srcLayout` after
     // broadcasting is removed, then drop the extra registers from `outVals`.
     auto dstLayout = toLinearLayout(dstTy);
-    auto removeBroadcastDst = actionRemoveBroadcastedRegs(dstLayout);
-    auto strippedDstLayout = removeBroadcastDst.apply(dstLayout);
+    auto strippedDstLayout = dstLayout.removeZeroBasesAlongDim(kReg);
     outVals.resize(strippedDstLayout.getInDimSize(kReg));
 
-    // Introduce broadcasting in registers if expected by `dstLayout`.
-    if (!removeBroadcastDst.isIdentity())
-      outVals = broadcastAs(outVals, dstLayout);
-
-    Value result = packLLElements(loc, getTypeConverter(), outVals, rewriter,
-                                  op.getType());
+    Value result = packUniqueTensorElements(loc, getTypeConverter(), outVals,
+                                            rewriter, dstTy);
     rewriter.replaceOp(op, result);
     return success();
   }

--- a/lib/Conversion/TritonGPUToLLVM/DotOpToLLVM/FMADotUtility.cpp
+++ b/lib/Conversion/TritonGPUToLLVM/DotOpToLLVM/FMADotUtility.cpp
@@ -44,11 +44,12 @@ namespace {
 using ValueTableFMA = std::unordered_map<OperandValueKey, Value>;
 
 ValueTableFMA getValueTableFromStructFMA(
-    Value val, ArrayRef<unsigned> perRepShape, ArrayRef<unsigned> repetitions,
-    unsigned kDim, unsigned nonKDim, ConversionPatternRewriter &rewriter,
-    Location loc, ArrayRef<unsigned> inRepOrder, ArrayRef<unsigned> repOrder) {
+    Value val, RankedTensorType tensorTy, ArrayRef<unsigned> perRepShape,
+    ArrayRef<unsigned> repetitions, unsigned kDim, unsigned nonKDim,
+    ConversionPatternRewriter &rewriter, Location loc,
+    ArrayRef<unsigned> inRepOrder, ArrayRef<unsigned> repOrder) {
   ValueTableFMA res;
-  auto elems = unpackLLElements(loc, val, rewriter);
+  auto elems = unpackTensorElements(loc, val, rewriter, tensorTy);
   assert(perRepShape.size() == 3);
   auto numElemsRep = product(perRepShape);
   assert(elems.size() == numElemsRep * product(repetitions));
@@ -81,9 +82,11 @@ LogicalResult parametricConvertFMADot(DotOp op, DotOp::Adaptor adaptor,
   auto loc = op.getLoc();
 
   auto A = op.getA();
+  auto B = op.getB();
   auto D = op.getResult();
 
   auto aTensorTy = cast<RankedTensorType>(A.getType());
+  auto bTensorTy = cast<RankedTensorType>(B.getType());
   auto dTensorTy = cast<RankedTensorType>(D.getType());
 
   SmallVector<int64_t> aShapePerCTA =
@@ -96,7 +99,7 @@ LogicalResult parametricConvertFMADot(DotOp op, DotOp::Adaptor adaptor,
   // TODO process A and B operand separately
   auto inRepOrder = expandMatrixOrderWithBatch(dLayout.getOrder());
   auto repOrder = expandMatrixOrderWithBatch(dLayout.getRepOrder());
-  auto cc = unpackLLElements(loc, adaptor.getC(), rewriter);
+  auto cc = unpackTensorElements(loc, adaptor.getC(), rewriter, dTensorTy);
 
   Value llA = adaptor.getA();
   Value llB = adaptor.getB();
@@ -121,11 +124,11 @@ LogicalResult parametricConvertFMADot(DotOp op, DotOp::Adaptor adaptor,
   }
 
   auto has = getValueTableFromStructFMA(
-      llA, {sizePerThread[0], sizePerThread[1], K},
+      llA, aTensorTy, {sizePerThread[0], sizePerThread[1], K},
       {repetitions[0], repetitions[1], 1},
       /*kDim*/ 2, /*nonKDim*/ 1, rewriter, loc, inRepOrder, repOrder);
   auto hbs = getValueTableFromStructFMA(
-      llB, {sizePerThread[0], K, sizePerThread[2]},
+      llB, bTensorTy, {sizePerThread[0], K, sizePerThread[2]},
       {repetitions[0], 1, repetitions[2]},
       /*kDim*/ 1, /*nonKDim*/ 2, rewriter, loc, inRepOrder, repOrder);
 
@@ -158,7 +161,7 @@ LogicalResult parametricConvertFMADot(DotOp op, DotOp::Adaptor adaptor,
                   aOpVector, bOpVector, acc[linearAccumIdx]);
             }
 
-  auto res = packLLElements(loc, typeConverter, acc, rewriter, dTensorTy);
+  auto res = packTensorElements(loc, typeConverter, acc, rewriter, dTensorTy);
   rewriter.replaceOp(op, res);
 
   return success();

--- a/lib/Conversion/TritonGPUToLLVM/ElementwiseOpToLLVM.cpp
+++ b/lib/Conversion/TritonGPUToLLVM/ElementwiseOpToLLVM.cpp
@@ -11,18 +11,6 @@ using namespace mlir::triton::gpu;
 
 namespace {
 
-int getNumElementsPerThreads(Type type,
-                             const LLVMTypeConverter *typeConverter) {
-  int numElemsPerThread = 1;
-  if (auto tensorTy = dyn_cast<RankedTensorType>(type)) {
-    auto structType =
-        dyn_cast<LLVM::LLVMStructType>(typeConverter->convertType(type));
-    if (structType)
-      numElemsPerThread = structType.getBody().size();
-  }
-  return numElemsPerThread;
-}
-
 struct AddPtrOpConversion : public ConvertOpToLLVMPattern<AddPtrOp> {
   using ConvertOpToLLVMPattern<AddPtrOp>::ConvertOpToLLVMPattern;
 
@@ -35,18 +23,19 @@ struct AddPtrOpConversion : public ConvertOpToLLVMPattern<AddPtrOp> {
     auto typeConverter = getTypeConverter();
     auto resultTensorTy = dyn_cast<RankedTensorType>(resultTy);
     if (resultTensorTy) {
-      unsigned elems = getTotalElemsPerThread(resultTy);
+      unsigned elems = getUniqueElemsPerThread(resultTy);
       Type elemTy = typeConverter->convertType(
           cast<PointerType>(resultTensorTy.getElementType()).getPointeeType());
       Type ptrTy = typeConverter->convertType(resultTensorTy.getElementType());
-      auto ptrs = unpackLLElements(loc, adaptor.getPtr(), rewriter);
-      auto offsets = unpackLLElements(loc, adaptor.getOffset(), rewriter);
+      auto ptrs = unpackUniqueTensorElements(loc, adaptor.getPtr(), rewriter);
+      auto offsets =
+          unpackUniqueTensorElements(loc, adaptor.getOffset(), rewriter);
       SmallVector<Value> resultVals(elems);
       for (unsigned i = 0; i < elems; ++i) {
         resultVals[i] = b.gep(ptrTy, elemTy, ptrs[i], offsets[i]);
       }
-      Value view =
-          packLLElements(loc, typeConverter, resultVals, rewriter, resultTy);
+      Value view = packUniqueTensorElements(loc, typeConverter, resultVals,
+                                            rewriter, resultTy);
       rewriter.replaceOp(op, view);
     } else {
       assert(isa<PointerType>(resultTy));
@@ -327,12 +316,13 @@ struct ElementwiseInlineAsmOpConversion
     // Layout is unpackedOperands[operand][elem].
     SmallVector<SmallVector<Value>> unpackedOperands;
     for (auto operand : adaptor.getOperands()) {
-      auto subOperands = unpackLLElements(loc, operand, rewriter);
+      auto subOperands = unpackUniqueTensorElements(loc, operand, rewriter);
       unpackedOperands.push_back(subOperands);
     }
 
-    int numElemsPerThread = getNumElementsPerThreads(op->getResult(0).getType(),
-                                                     getTypeConverter());
+    auto resultTy = op->getResult(0).getType();
+    int numElemsPerThread =
+        isa<RankedTensorType>(resultTy) ? getUniqueElemsPerThread(resultTy) : 1;
 
     // These are checked by the verifier, so we don't need to raise a nice
     // error.
@@ -381,8 +371,9 @@ struct ElementwiseInlineAsmOpConversion
     // Reorder and pack the results.
     SmallVector<Value> outs;
     for (int i = 0; i < unpackedResults.size(); i++) {
-      outs.push_back(packLLElements(loc, getTypeConverter(), unpackedResults[i],
-                                    rewriter, op->getResult(i).getType()));
+      outs.push_back(packUniqueTensorElements(loc, getTypeConverter(),
+                                              unpackedResults[i], rewriter,
+                                              op->getResult(i).getType()));
     }
 
     rewriter.replaceOp(op, outs);
@@ -572,8 +563,7 @@ struct MapElementwiseOpConversion
 
     auto operands = adaptor.getOperands();
     const auto nOperands = operands.size();
-    const auto nElems =
-        cast<LLVM::LLVMStructType>(operands[0].getType()).getBody().size();
+    const auto nElems = getUniqueElemsPerThread(op->getOperand(0).getType());
     const auto nElemsPerPack = op.getPack();
     if (nElems % nElemsPerPack != 0)
       return op->emitError()
@@ -586,7 +576,7 @@ struct MapElementwiseOpConversion
 
     SmallVector<Value> scalarOperands(nOperands * nElems);
     for (auto iOp : llvm::seq(nOperands)) {
-      auto elems = unpackLLElements(loc, operands[iOp], rewriter);
+      auto elems = unpackUniqueTensorElements(loc, operands[iOp], rewriter);
       assert(elems.size() == nElems);
       for (auto iPack : llvm::seq(nPacks)) {
         auto *packOperands =
@@ -620,8 +610,8 @@ struct MapElementwiseOpConversion
     SmallVector<Value> packedOutputs(nOutputs);
     for (auto iOut : llvm::seq(nOutputs)) {
       ArrayRef<Value> vals(&scalarOutputs[iOut * nElems], nElems);
-      packedOutputs[iOut] =
-          packLLElements(loc, typeConverter, vals, rewriter, op.getType(iOut));
+      packedOutputs[iOut] = packUniqueTensorElements(
+          loc, typeConverter, vals, rewriter, op.getType(iOut));
     }
     rewriter.replaceOp(op, packedOutputs);
     return success();

--- a/lib/Conversion/TritonGPUToLLVM/Fp4ToFpOpToLLVMBase.cpp
+++ b/lib/Conversion/TritonGPUToLLVM/Fp4ToFpOpToLLVMBase.cpp
@@ -16,7 +16,7 @@ LogicalResult Fp4ToFpOpConversionBase::matchAndRewrite(
   auto elemType = resTy.getElementType();
   assert(elemType == f16_ty || elemType == bf16_ty);
 
-  auto xVals = unpackLLElements(loc, adaptor.getSrc(), rewriter);
+  auto xVals = unpackUniqueTensorElements(loc, adaptor.getSrc(), rewriter);
 
   SmallVector<Value> results;
   results.reserve(xVals.size() * 2);
@@ -30,8 +30,8 @@ LogicalResult Fp4ToFpOpConversionBase::matchAndRewrite(
     results.append(upcast.begin(), upcast.end());
   }
 
-  Value result =
-      packLLElements(loc, getTypeConverter(), results, rewriter, resTy);
+  Value result = packUniqueTensorElements(loc, getTypeConverter(), results,
+                                          rewriter, resTy);
   rewriter.replaceOp(op, result);
   return success();
 }

--- a/lib/Conversion/TritonGPUToLLVM/GatherOpToLLVM.cpp
+++ b/lib/Conversion/TritonGPUToLLVM/GatherOpToLLVM.cpp
@@ -74,8 +74,8 @@ void GatherOpConversion::emitGatherInShared(
       convertType<unsigned>(triton::gpu::getShapePerCTA(srcType));
 
   // Grab the src values in this thread.
-  SmallVector<Value> srcValues =
-      unpackLLElements(loc, adaptor.getSrc(), rewriter);
+  SmallVector<Value> srcValues = unpackTensorElements(
+      loc, adaptor.getSrc(), rewriter, op.getSrc().getType());
 
   // Emit the indices of the src values owned by this thread.
   SmallVector<SmallVector<Value>> srcIndices =
@@ -105,8 +105,8 @@ void GatherOpConversion::emitGatherInShared(
   b.barrier(triton::gpu::AddrSpace::Local);
 
   // Grab the index values owned by this thread.
-  SmallVector<Value> idxValues =
-      unpackLLElements(loc, adaptor.getIndices(), rewriter);
+  SmallVector<Value> idxValues = unpackTensorElements(
+      loc, adaptor.getIndices(), rewriter, op.getIndices().getType());
 
   // Apply the layout of the destination tensor to obtain the indices of the
   // column to gather along, then for each column, replace the index along the
@@ -132,7 +132,7 @@ void GatherOpConversion::emitGatherInShared(
   }
 
   Value packed =
-      packLLElements(loc, getTypeConverter(), results, rewriter, dstType);
+      packTensorElements(loc, getTypeConverter(), results, rewriter, dstType);
   rewriter.replaceOp(op, packed);
 }
 
@@ -256,10 +256,10 @@ void GatherOpConversion::emitWarpLocalGather(
   LinearLayout idxColLayout =
       idxLayout.sublayout({kBlock, kWarp, kLane, kRegister}, otherDims);
 
-  SmallVector<Value> srcValues =
-      unpackLLElements(loc, adaptor.getSrc(), rewriter);
-  SmallVector<Value> idxValues =
-      unpackLLElements(loc, adaptor.getIndices(), rewriter);
+  SmallVector<Value> srcValues = unpackTensorElements(
+      loc, adaptor.getSrc(), rewriter, op.getSrc().getType());
+  SmallVector<Value> idxValues = unpackTensorElements(
+      loc, adaptor.getIndices(), rewriter, op.getIndices().getType());
 
   auto [laneId, warpId] = getLaneAndWarpId(rewriter, loc);
   Value blockId = targetInfo.getClusterCTAId(rewriter, loc);
@@ -336,8 +336,8 @@ void GatherOpConversion::emitWarpLocalGather(
     results.push_back(result);
   }
 
-  rewriter.replaceOp(op, packLLElements(loc, getTypeConverter(), results,
-                                        rewriter, op.getType()));
+  rewriter.replaceOp(op, packTensorElements(loc, getTypeConverter(), results,
+                                            rewriter, op.getType()));
 }
 
 } // namespace

--- a/lib/Conversion/TritonGPUToLLVM/HistogramOpToLLVM.cpp
+++ b/lib/Conversion/TritonGPUToLLVM/HistogramOpToLLVM.cpp
@@ -82,12 +82,13 @@ public:
     Location loc = op.getLoc();
     Value input = adaptor.getSrc();
     auto typeConverter = getTypeConverter();
-    SmallVector<Value> srcValues = unpackLLElements(loc, input, rewriter);
+    SmallVector<Value> srcValues =
+        unpackUniqueTensorElements(loc, input, rewriter);
 
     Value llMask = adaptor.getMask();
     SmallVector<Value> maskValues;
     if (llMask)
-      maskValues = unpackLLElements(loc, llMask, rewriter);
+      maskValues = unpackUniqueTensorElements(loc, llMask, rewriter);
 
     int numBins = op.getType().getDimSize(0);
     auto mod = op->getParentOfType<ModuleOp>();
@@ -132,8 +133,8 @@ public:
           b.sdiv(histogramValue[i], b.i32_val(replicationFactor));
     }
 
-    Value results = packLLElements(loc, typeConverter, histogramValue, rewriter,
-                                   op.getType());
+    Value results = packTensorElements(loc, typeConverter, histogramValue,
+                                       rewriter, op.getType());
     rewriter.replaceOp(op, results);
     return success();
   }

--- a/lib/Conversion/TritonGPUToLLVM/MakeRangeOpToLLVM.cpp
+++ b/lib/Conversion/TritonGPUToLLVM/MakeRangeOpToLLVM.cpp
@@ -39,7 +39,8 @@ struct MakeRangeOpConversion
       retVals[multiDim.index()] = b.add(multiDim.value()[0], start);
     }
     auto typeConverter = getTypeConverter();
-    Value result = packLLElements(loc, typeConverter, retVals, rewriter, ty);
+    Value result =
+        packTensorElements(loc, typeConverter, retVals, rewriter, ty);
     rewriter.replaceOp(op, result);
     return success();
   }
@@ -103,7 +104,7 @@ public:
     }
 
     Value result =
-        packLLElements(loc, getTypeConverter(), llValues, b, tensorTy);
+        packTensorElements(loc, getTypeConverter(), llValues, b, tensorTy);
     b.replaceOp(op, result);
     return success();
   }

--- a/lib/Conversion/TritonGPUToLLVM/MemoryOpToLLVM.cpp
+++ b/lib/Conversion/TritonGPUToLLVM/MemoryOpToLLVM.cpp
@@ -132,7 +132,8 @@ struct LocalAllocOpConversion
     // If there is an initial tensor, store it into the shared memory.
     if (op.getSrc()) {
       auto *ctx = op.getContext();
-      auto inVals = unpackLLElements(loc, adaptor.getSrc(), rewriter);
+      auto inVals = unpackTensorElements(loc, adaptor.getSrc(), rewriter,
+                                         op.getSrc().getType());
       if (failed(lowerLocalStore(loc, ctx, op.getSrc(), memDescTy, smemObj,
                                  inVals, typeConverter, rewriter,
                                  targetInfo))) {
@@ -193,7 +194,8 @@ public:
     auto outVals = lowerLocalLdSt(loc, ctx, cvt, {}, llvmElemTy, memDescTy,
                                   smemObj, rewriter, targetInfo, op);
 
-    Value result = packLLElements(loc, typeConverter, outVals, rewriter, regTy);
+    Value result =
+        packTensorElements(loc, typeConverter, outVals, rewriter, regTy);
     rewriter.replaceOp(op, result);
 
     return success();
@@ -227,7 +229,8 @@ public:
     auto llvmElemTy = typeConverter->convertType(memDescTy.getElementType());
     auto smemObj = LLVM::getSharedMemoryObjectFromStruct(loc, adaptor.getDst(),
                                                          llvmElemTy, rewriter);
-    auto inVals = unpackLLElements(loc, adaptor.getSrc(), rewriter);
+    auto inVals = unpackTensorElements(loc, adaptor.getSrc(), rewriter,
+                                       op.getSrc().getType());
     if (failed(lowerLocalStore(loc, ctx, regVal, memDescTy, smemObj, inVals,
                                typeConverter, rewriter, targetInfo))) {
       return failure();
@@ -284,15 +287,16 @@ public:
     auto smemObj = LLVM::getSharedMemoryObjectFromStruct(loc, adaptor.getSrc(),
                                                          llvmElemTy, rewriter);
 
-    SmallVector<Value> idxValues =
-        unpackLLElements(loc, adaptor.getIndices(), rewriter);
+    SmallVector<Value> idxValues = unpackTensorElements(
+        loc, adaptor.getIndices(), rewriter, op.getIndices().getType());
     auto regLayout = toLinearLayout(regTy);
 
     auto results = lowerLocalScGt(loc, memDescTy, smemObj, llvmElemTy,
                                   regLayout, idxValues, op.getAxis(),
                                   /*storeVals=*/{}, rewriter, targetInfo);
 
-    Value result = packLLElements(loc, typeConverter, results, rewriter, regTy);
+    Value result =
+        packTensorElements(loc, typeConverter, results, rewriter, regTy);
     rewriter.replaceOp(op, result);
 
     return success();
@@ -330,10 +334,10 @@ public:
     auto smemObj = LLVM::getSharedMemoryObjectFromStruct(loc, adaptor.getDst(),
                                                          llvmElemTy, rewriter);
 
-    SmallVector<Value> values =
-        unpackLLElements(loc, adaptor.getValues(), rewriter);
-    SmallVector<Value> idxValues =
-        unpackLLElements(loc, adaptor.getIndices(), rewriter);
+    SmallVector<Value> values = unpackTensorElements(
+        loc, adaptor.getValues(), rewriter, op.getValues().getType());
+    SmallVector<Value> idxValues = unpackTensorElements(
+        loc, adaptor.getIndices(), rewriter, op.getIndices().getType());
     auto regLayout = toLinearLayout(valuesTy);
 
     lowerLocalScGt(loc, memDescTy, smemObj, llvmElemTy, regLayout, idxValues,

--- a/lib/Conversion/TritonGPUToLLVM/PrintOpToLLVM.cpp
+++ b/lib/Conversion/TritonGPUToLLVM/PrintOpToLLVM.cpp
@@ -48,7 +48,8 @@ struct PrintOpConversion : public ConvertOpToLLVMPattern<triton::PrintOp> {
     for (size_t i = 0; i < op.getNumOperands(); i++) {
       bool isSigned = op.getIsSigned()[i] > 0;
       // Elements of the tensor that are resident in this GPU thread.
-      auto elems = unpackLLElements(loc, adaptor.getOperands()[i], rewriter);
+      auto elems = unpackTensorElements(loc, adaptor.getOperands()[i], rewriter,
+                                        op->getOperand(i).getType());
 
       // Get the indices of `elems` within the tensor.  Note that if `elems`
       // has an "interesting" layout, then these will not be in any

--- a/lib/Conversion/TritonGPUToLLVM/ReduceOpToLLVM.cpp
+++ b/lib/Conversion/TritonGPUToLLVM/ReduceOpToLLVM.cpp
@@ -43,13 +43,7 @@ public:
     // Remove block as we don't currently support it
     LinearLayout regLl = triton::gpu::toLinearLayout(helper.getSrcTy());
     // Remove broadcasting in registers as SliceLayout removes them
-    auto removeBroadcast = actionRemoveBroadcastedRegs(regLl);
-    if (!removeBroadcast.isIdentity()) {
-      regLl = removeBroadcast.apply(regLl);
-      for (auto &vals : accs) {
-        vals = removeBroadcast.apply(vals);
-      }
-    }
+    regLl = regLl.removeZeroBasesAlongDim(str_attr("register"));
 
     // First reduce all the values along axis within each thread.
     std::tie(regLl, accs) =
@@ -159,7 +153,7 @@ private:
     auto operands = adaptor.getOperands();
     SmallVector<SmallVector<Value>> srcValues(op.getNumOperands());
     for (unsigned i = 0; i < op.getNumOperands(); ++i) {
-      srcValues[i] = unpackLLElements(loc, operands[i], rewriter);
+      srcValues[i] = unpackUniqueTensorElements(loc, operands[i], rewriter);
     }
     return srcValues;
   }
@@ -318,7 +312,7 @@ private:
 
     // Update layout killing the axis bases along registers
     layout = ReduceOpHelper::zeroBasesAlongDimAndReorder(layout, axis, kReg);
-    layout = actionRemoveBroadcastedRegs(layout).apply(layout);
+    layout = layout.removeZeroBasesAlongDim(kReg);
     return {std::move(layout), std::move(accs)};
   }
 
@@ -394,13 +388,9 @@ private:
     Location loc = op.getLoc();
     SmallVector<Value> results(op.getNumOperands());
     for (unsigned i = 0; i < op.getNumOperands(); ++i) {
-      if (auto resultTy =
-              dyn_cast<RankedTensorType>(op.getResult()[i].getType())) {
-        results[i] = packLLElements(loc, getTypeConverter(), accs[i], rewriter,
-                                    resultTy);
-      } else {
-        results[i] = accs[i].front();
-      }
+      results[i] =
+          packUniqueTensorElements(loc, getTypeConverter(), accs[i], rewriter,
+                                   op.getResult()[i].getType());
     }
     rewriter.replaceOp(op, results);
   }
@@ -427,8 +417,8 @@ private:
       auto elemTy = op.getElementTypes()[i];
       auto srcTy = RankedTensorType::get(shape, elemTy, srcEnc);
       auto dstTy = RankedTensorType::get(shape, elemTy, dstEnc);
-      Value packed =
-          packLLElements(loc, getTypeConverter(), inVals[i], rewriter, srcTy);
+      Value packed = packUniqueTensorElements(loc, getTypeConverter(),
+                                              inVals[i], rewriter, srcTy);
       auto srcTensor =
           UnrealizedConversionCastOp::create(rewriter, loc, srcTy, packed)
               .getResult(0);
@@ -441,7 +431,7 @@ private:
       auto packedDst = UnrealizedConversionCastOp::create(
                            rewriter, loc, packedDstTy, cvt.getResult())
                            .getResult(0);
-      outVals[i] = unpackLLElements(loc, packedDst, rewriter);
+      outVals[i] = unpackUniqueTensorElements(loc, packedDst, rewriter);
     }
     return outVals;
   }

--- a/lib/Conversion/TritonGPUToLLVM/ScanOpToLLVM.cpp
+++ b/lib/Conversion/TritonGPUToLLVM/ScanOpToLLVM.cpp
@@ -420,15 +420,11 @@ ScanOpConversion::getDelinearizedIds(ConversionPatternRewriter &rewriter,
 
 SmallVector<SmallVector<Value>>
 unpackInputs(Location loc, triton::ScanOp op, triton::ScanOpAdaptor adaptor,
-             ConversionPatternRewriter &rewriter, unsigned nElems,
-             const ColumnAction &removeBroadcastRegs) {
+             ConversionPatternRewriter &rewriter, unsigned nElems) {
   auto operands = adaptor.getOperands();
   SmallVector<SmallVector<Value>> srcValues(nElems);
   for (unsigned i = 0; i < op.getNumOperands(); ++i) {
-    auto values = unpackLLElements(loc, operands[i], rewriter);
-    if (!removeBroadcastRegs.isIdentity()) {
-      values = removeBroadcastRegs.apply(values);
-    }
+    auto values = unpackUniqueTensorElements(loc, operands[i], rewriter);
 
     assert(values.size() == srcValues.size());
     for (unsigned j = 0; j < srcValues.size(); ++j) {
@@ -465,9 +461,6 @@ ScanOpConversion::emitFastScan(triton::ScanOp op, triton::ScanOpAdaptor adaptor,
                                ConversionPatternRewriter &rewriter,
                                const TargetInfoBase &targetInfo) const {
   ScanLoweringHelper helper(op);
-  auto origLayout = triton::gpu::toLinearLayout(
-      cast<RankedTensorType>(op.getOperands()[0].getType()));
-  auto removeBroadcastRegs = actionRemoveBroadcastedRegs(origLayout);
   auto loc = helper.getLoc();
   auto b = TritonLLVMOpBuilder(loc, rewriter);
   if (!helper.isSupported())
@@ -483,10 +476,9 @@ ScanOpConversion::emitFastScan(triton::ScanOp op, triton::ScanOpAdaptor adaptor,
   auto [laneIdAxis, warpIdAxis, flatIdParallel, isRepresentative] =
       getDelinearizedIds(rewriter, helper, laneId, warpId);
   auto axisNumWarps = helper.getAxisNumWarpsWithUniqueData();
-  unsigned nElems =
-      helper.getEncoding().getTotalElemsPerThread(helper.getShape());
-  auto srcValues =
-      unpackInputs(loc, op, adaptor, rewriter, nElems, removeBroadcastRegs);
+  unsigned nElems = triton::gpu::getUniqueElemsPerThread(
+      cast<RankedTensorType>(op.getOperands()[0].getType()));
+  auto srcValues = unpackInputs(loc, op, adaptor, rewriter, nElems);
 
   // For the reverse option we apply flip(scan(flip()) in
   // order to avoid having a separate code path in the reverse direction.
@@ -562,15 +554,10 @@ ScanOpConversion::emitFastScan(triton::ScanOp op, triton::ScanOpAdaptor adaptor,
   }
 
   auto valuesTransposed = transpose(srcValues);
-  if (!removeBroadcastRegs.isIdentity()) {
-    for (auto &values : valuesTransposed) {
-      values = broadcastAs(values, origLayout);
-    }
-  }
   for (unsigned i = 0; i < op.getNumOperands(); ++i) {
-    auto resultTy = dyn_cast<RankedTensorType>(op.getResult()[i].getType());
-    results[i] = packLLElements(loc, getTypeConverter(), valuesTransposed[i],
-                                rewriter, resultTy);
+    results[i] =
+        packUniqueTensorElements(loc, getTypeConverter(), valuesTransposed[i],
+                                 rewriter, op.getResult()[i].getType());
   }
   rewriter.replaceOp(op, results);
   return success();

--- a/lib/Conversion/TritonGPUToLLVM/TypeConverter.cpp
+++ b/lib/Conversion/TritonGPUToLLVM/TypeConverter.cpp
@@ -7,7 +7,7 @@
 using namespace mlir;
 using namespace mlir::triton;
 
-using ::mlir::triton::gpu::getTotalElemsPerThread;
+using ::mlir::triton::gpu::getUniqueElemsPerThread;
 using ::mlir::triton::gpu::MemDescType;
 
 TritonGPUToLLVMTypeConverter::TritonGPUToLLVMTypeConverter(
@@ -48,7 +48,7 @@ Type TritonGPUToLLVMTypeConverter::convertTritonTensorType(
     RankedTensorType type, const TargetInfoBase &targetInfo) {
   auto ctx = type.getContext();
   Type eltType = convertType(type.getElementType());
-  unsigned numElementsPerThread = getTotalElemsPerThread(type);
+  unsigned numElementsPerThread = getUniqueElemsPerThread(type);
   SmallVector<Type, 4> types(numElementsPerThread, eltType);
   return LLVM::LLVMStructType::getLiteral(ctx, types);
 }

--- a/lib/Conversion/TritonGPUToLLVM/Utility.cpp
+++ b/lib/Conversion/TritonGPUToLLVM/Utility.cpp
@@ -672,6 +672,7 @@ FailureOr<LocalAtomicScatterRMWInfo> prepareLocalAtomicScatterRMW(
     Value inputValues, Value mask, ConversionPatternRewriter &rewriter,
     const TargetInfoBase &targetInfo, const LLVMTypeConverter *typeConverter) {
   auto loc = op.getLoc();
+  auto *ctx = op.getContext();
   auto valuesTy = cast<RankedTensorType>(op.getValues().getType());
   auto memDescTy = cast<triton::gpu::MemDescType>(op.getDst().getType());
   if (isa<triton::gpu::PartitionedSharedEncodingAttr>(
@@ -682,25 +683,21 @@ FailureOr<LocalAtomicScatterRMWInfo> prepareLocalAtomicScatterRMW(
   auto llvmElemTy = typeConverter->convertType(memDescTy.getElementType());
   auto smemObj =
       LLVM::getSharedMemoryObjectFromStruct(loc, dst, llvmElemTy, rewriter);
-  SmallVector<Value> idxValues = unpackLLElements(loc, indices, rewriter);
-  SmallVector<Value> values = unpackLLElements(loc, inputValues, rewriter);
+  SmallVector<Value> idxValues =
+      unpackUniqueTensorElements(loc, indices, rewriter);
+  SmallVector<Value> values =
+      unpackUniqueTensorElements(loc, inputValues, rewriter);
   SmallVector<Value> maskValues;
   if (mask)
-    maskValues = unpackLLElements(loc, mask, rewriter);
+    maskValues = unpackUniqueTensorElements(loc, mask, rewriter);
 
   LinearLayout regLayout = triton::gpu::toLinearLayout(valuesTy);
   auto freeVarMasks = regLayout.getFreeVariableMasks();
   auto removeBroadcast = actionRemoveBroadcastedRegs(regLayout);
   Value threadPred = triton::gpu::emitRedundantThreadPredicate(
       freeVarMasks, rewriter, loc, targetInfo);
-  LinearLayout activeRegLayout = regLayout;
-  if (!removeBroadcast.isIdentity()) {
-    activeRegLayout = removeBroadcast.apply(regLayout);
-    values = removeBroadcast.apply(values);
-    idxValues = removeBroadcast.apply(idxValues);
-    if (!maskValues.empty())
-      maskValues = removeBroadcast.apply(maskValues);
-  }
+  LinearLayout activeRegLayout =
+      regLayout.removeZeroBasesAlongDim(str_attr("register"));
   auto offsetAndBlock =
       computeBlockLocalOffsets(loc, memDescTy, activeRegLayout, idxValues,
                                op.getAxis(), rewriter, targetInfo);
@@ -1045,6 +1042,20 @@ SmallVector<Value> unpackLLElements(Location loc, Value llvmStruct,
   return results;
 }
 
+SmallVector<Value> unpackUniqueTensorElements(Location loc, Value llvmStruct,
+                                              RewriterBase &rewriter) {
+  return unpackLLElements(loc, llvmStruct, rewriter);
+}
+
+SmallVector<Value> unpackTensorElements(Location loc, Value llvmStruct,
+                                        RewriterBase &rewriter,
+                                        Type originalType) {
+  if (auto tensorTy = dyn_cast<RankedTensorType>(originalType))
+    return broadcastAs(unpackUniqueTensorElements(loc, llvmStruct, rewriter),
+                       triton::gpu::toLinearLayout(tensorTy));
+  return unpackLLElements(loc, llvmStruct, rewriter);
+}
+
 Value packLLElements(Location loc, const LLVMTypeConverter *typeConverter,
                      ValueRange resultVals, RewriterBase &rewriter, Type type) {
   auto structType =
@@ -1077,6 +1088,26 @@ Value packLLElements(Location loc, const LLVMTypeConverter *typeConverter,
     llvmStruct = b.insert_val(structType, llvmStruct, value, i);
   }
   return llvmStruct;
+}
+
+Value packUniqueTensorElements(Location loc,
+                               const LLVMTypeConverter *typeConverter,
+                               ValueRange resultVals, RewriterBase &rewriter,
+                               Type type) {
+  return packLLElements(loc, typeConverter, resultVals, rewriter, type);
+}
+
+Value packTensorElements(Location loc, const LLVMTypeConverter *typeConverter,
+                         ValueRange resultVals, RewriterBase &rewriter,
+                         Type type) {
+  if (auto tensorTy = dyn_cast<RankedTensorType>(type)) {
+    auto uniqueResultVals =
+        actionRemoveBroadcastedRegs(triton::gpu::toLinearLayout(tensorTy))
+            .apply(resultVals);
+    return packUniqueTensorElements(loc, typeConverter, uniqueResultVals,
+                                    rewriter, type);
+  }
+  return packLLElements(loc, typeConverter, resultVals, rewriter, type);
 }
 
 SmallVector<Value> unpackLLVector(Location loc, Value llvmVec,
@@ -2043,11 +2074,10 @@ void finalizeTensorAtomicResults(Operation *op, RankedTensorType tensorTy,
                                  const LLVMTypeConverter *typeConverter) {
   auto *ctx = rewriter.getContext();
   auto loc = op->getLoc();
-  Type structTy = typeConverter->convertType(tensorTy);
   if (!op->hasAttr("allocation.offset")) {
     // No broadcasting, just pack the values into a struct
     Value resultStruct =
-        packLLElements(loc, typeConverter, resultVals, rewriter, structTy);
+        packTensorElements(loc, typeConverter, resultVals, rewriter, tensorTy);
     rewriter.replaceOp(op, {resultStruct});
     return;
   }
@@ -2119,12 +2149,9 @@ void finalizeTensorAtomicResults(Operation *op, RankedTensorType tensorTy,
                 /*maskSpanAffineOffset=*/0, /*affineBlockOffset=*/Value(),
                 /*maskSpanAffineBlock=*/0, laneId, warpId, rewriter, targetInfo,
                 /*maybeMaxVecElems=*/{}, emitLd);
-  if (!removeRegBroadcast.isIdentity())
-    resultVals = broadcastAs(resultVals, regLayout);
-
   // Create the result struct and replace the operation
-  Value resultStruct =
-      packLLElements(loc, typeConverter, resultVals, rewriter, structTy);
+  Value resultStruct = packUniqueTensorElements(loc, typeConverter, resultVals,
+                                                rewriter, tensorTy);
   rewriter.replaceOp(op, {resultStruct});
 }
 

--- a/lib/Conversion/TritonGPUToLLVM/ViewOpToLLVM.cpp
+++ b/lib/Conversion/TritonGPUToLLVM/ViewOpToLLVM.cpp
@@ -57,9 +57,10 @@ struct SplatOpConversion : public ConvertOpToLLVMPattern<triton::SplatOp> {
       constVal = vec;
     }
     Value llSrc = bitOrPtrCast(constVal, srcType, b);
-    size_t elemsPerThread = getTotalElemsPerThread(tensorTy);
+    size_t elemsPerThread = getUniqueElemsPerThread(tensorTy);
     llvm::SmallVector<Value> elems(elemsPerThread, llSrc);
-    return packLLElements(loc, typeConverter, elems, rewriter, resType);
+    return packUniqueTensorElements(loc, typeConverter, elems, rewriter,
+                                    resType);
   }
   LogicalResult matchAndRewrite(triton::SplatOp op, OpAdaptor adaptor,
                                 ConversionPatternRewriter &rewriter) const {
@@ -78,7 +79,7 @@ struct UnsplatOpConversion : public ConvertOpToLLVMPattern<triton::UnsplatOp> {
   LogicalResult matchAndRewrite(triton::UnsplatOp op, OpAdaptor adaptor,
                                 ConversionPatternRewriter &rewriter) const {
     auto loc = op->getLoc();
-    auto scrVals = unpackLLElements(loc, adaptor.getSrc(), rewriter);
+    auto scrVals = unpackUniqueTensorElements(loc, adaptor.getSrc(), rewriter);
     rewriter.replaceOp(op, scrVals[0]);
     return success();
   }
@@ -133,35 +134,9 @@ struct CatOpConversion : public ConvertOpToLLVMPattern<CatOp> {
                   ConversionPatternRewriter &rewriter) const override {
     Location loc = op->getLoc();
     auto resultTy = cast<RankedTensorType>(op.getType());
-    auto typeConverter = getTypeConverter();
-
-    // Note: We must explicitly handle broadcasted registers. The LLVM lowering
-    // generally represents broadcasted register bits by *duplicating* elements
-    // in the LLVM struct. Many conversions operate on a "stripped" (no-bcast)
-    // view and then re-introduce broadcasting at the end (see
-    // ConvertLayoutOpConversion).
-    StringAttr kReg = StringAttr::get(rewriter.getContext(), "register");
-
     // Unpack input values.
-    auto lhsVals = unpackLLElements(loc, adaptor.getLhs(), rewriter);
-    auto rhsVals = unpackLLElements(loc, adaptor.getRhs(), rewriter);
-
-    // Strip broadcasted registers from inputs.
-    auto lhsTy = cast<RankedTensorType>(op.getLhs().getType());
-    auto rhsTy = cast<RankedTensorType>(op.getRhs().getType());
-    auto lhsLayout = toLinearLayout(lhsTy);
-    auto rhsLayout = toLinearLayout(rhsTy);
-    auto removeBroadcastLhs = actionRemoveBroadcastedRegs(lhsLayout);
-    auto removeBroadcastRhs = actionRemoveBroadcastedRegs(rhsLayout);
-    if (!removeBroadcastLhs.isIdentity())
-      lhsVals = removeBroadcastLhs.apply(lhsVals);
-    if (!removeBroadcastRhs.isIdentity())
-      rhsVals = removeBroadcastRhs.apply(rhsVals);
-
-    // Compute the expected non-broadcast register count for the result.
-    auto dstLayout = toLinearLayout(resultTy);
-    auto removeBroadcastDst = actionRemoveBroadcastedRegs(dstLayout);
-    auto strippedDstLayout = removeBroadcastDst.apply(dstLayout);
+    auto lhsVals = unpackUniqueTensorElements(loc, adaptor.getLhs(), rewriter);
+    auto rhsVals = unpackUniqueTensorElements(loc, adaptor.getRhs(), rewriter);
 
     // concatenate (and potentially reorder) values
     SmallVector<Value> retVals;
@@ -170,14 +145,11 @@ struct CatOpConversion : public ConvertOpToLLVMPattern<CatOp> {
     for (Value v : rhsVals)
       retVals.push_back(v);
 
-    assert(retVals.size() == strippedDstLayout.getInDimSize(kReg));
-
-    // Re-introduce broadcasting if the destination expects it.
-    if (!removeBroadcastDst.isIdentity())
-      retVals = broadcastAs(retVals, dstLayout);
+    assert(retVals.size() == getUniqueElemsPerThread(resultTy));
 
     // pack and replace
-    Value ret = packLLElements(loc, typeConverter, retVals, rewriter, resultTy);
+    Value ret = packUniqueTensorElements(loc, getTypeConverter(), retVals,
+                                         rewriter, resultTy);
     rewriter.replaceOp(op, ret);
     return success();
   }
@@ -206,6 +178,7 @@ struct JoinOpConversion : public ConvertOpToLLVMPattern<JoinOp> {
     auto ll = toLinearLayout(dstTy);
     int splitDim = dstTy.getRank() - 1;
     auto kReg = mlir::StringAttr::get(dstTy.getContext(), "register");
+    ll = ll.removeZeroBasesAlongDim(kReg);
     const auto &bases = ll.getBases();
     const auto &regs = bases.find(kReg)->second;
     int numContiguousValues = 1;
@@ -219,9 +192,9 @@ struct JoinOpConversion : public ConvertOpToLLVMPattern<JoinOp> {
     }
     assert(found && "Join dimension is not distributed along registers.");
     SmallVector<Value> lhsVals =
-        unpackLLElements(loc, adaptor.getLhs(), rewriter);
+        unpackUniqueTensorElements(loc, adaptor.getLhs(), rewriter);
     SmallVector<Value> rhsVals =
-        unpackLLElements(loc, adaptor.getRhs(), rewriter);
+        unpackUniqueTensorElements(loc, adaptor.getRhs(), rewriter);
     assert(lhsVals.size() == rhsVals.size());
     SmallVector<Value> joinedVals;
     joinedVals.resize(lhsVals.size() * 2);
@@ -231,8 +204,8 @@ struct JoinOpConversion : public ConvertOpToLLVMPattern<JoinOp> {
         joinedVals[2 * i + numContiguousValues + j] = rhsVals[i + j];
       }
     }
-    auto typeConverter = getTypeConverter();
-    Value ret = packLLElements(loc, typeConverter, joinedVals, rewriter, dstTy);
+    Value ret = packUniqueTensorElements(loc, getTypeConverter(), joinedVals,
+                                         rewriter, dstTy);
     rewriter.replaceOp(op, ret);
     return success();
   }
@@ -257,6 +230,7 @@ struct SplitOpConversion : public ConvertOpToLLVMPattern<SplitOp> {
     auto ll = toLinearLayout(srcTy);
     int splitDim = srcTy.getRank() - 1;
     auto kReg = mlir::StringAttr::get(srcTy.getContext(), "register");
+    ll = ll.removeZeroBasesAlongDim(kReg);
     const auto &bases = ll.getBases();
     const auto &regs = bases.find(kReg)->second;
     int numContiguousValues = 1;
@@ -270,9 +244,8 @@ struct SplitOpConversion : public ConvertOpToLLVMPattern<SplitOp> {
     }
     assert(found && "Split dimension is not distributed along registers.");
     Location loc = op->getLoc();
-    auto typeConverter = getTypeConverter();
     SmallVector<Value> srcVals =
-        unpackLLElements(loc, adaptor.getSrc(), rewriter);
+        unpackUniqueTensorElements(loc, adaptor.getSrc(), rewriter);
     assert(srcVals.size() % 2 == 0);
     SmallVector<Value> outLhsVals;
     SmallVector<Value> outRhsVals;
@@ -282,11 +255,11 @@ struct SplitOpConversion : public ConvertOpToLLVMPattern<SplitOp> {
         outRhsVals.push_back(srcVals[i + numContiguousValues + j]);
       }
     }
-    auto resultTy = cast<RankedTensorType>(op.getResult(0).getType());
-    Value retLhs =
-        packLLElements(loc, typeConverter, outLhsVals, rewriter, resultTy);
-    Value retRhs =
-        packLLElements(loc, typeConverter, outRhsVals, rewriter, resultTy);
+    auto resultTy = op.getResult(0).getType();
+    Value retLhs = packUniqueTensorElements(loc, getTypeConverter(), outLhsVals,
+                                            rewriter, resultTy);
+    Value retRhs = packUniqueTensorElements(loc, getTypeConverter(), outRhsVals,
+                                            rewriter, resultTy);
     rewriter.replaceOp(op, {retLhs, retRhs});
     return success();
   }
@@ -299,13 +272,8 @@ struct ReshapeOpConversion : public ConvertOpToLLVMPattern<ReshapeOp> {
   LogicalResult
   matchAndRewrite(ReshapeOp op, OpAdaptor adaptor,
                   ConversionPatternRewriter &rewriter) const override {
-    Location loc = op->getLoc();
     assert(!isExpensiveView(op.getSrc().getType(), op.getType()));
-    auto resultTy = cast<RankedTensorType>(op.getType());
-    auto typeConverter = getTypeConverter();
-    auto vals = unpackLLElements(loc, adaptor.getSrc(), rewriter);
-    Value ret = packLLElements(loc, typeConverter, vals, rewriter, resultTy);
-    rewriter.replaceOp(op, ret);
+    rewriter.replaceOp(op, adaptor.getSrc());
     return success();
   }
 };
@@ -320,7 +288,8 @@ struct ExpandDimsOpConversion : public ConvertOpToLLVMPattern<ExpandDimsOp> {
                   ConversionPatternRewriter &rewriter) const override {
     Location loc = op->getLoc();
     auto typeConverter = getTypeConverter();
-    auto srcVals = unpackLLElements(loc, adaptor.getSrc(), rewriter);
+    auto srcVals = unpackTensorElements(loc, adaptor.getSrc(), rewriter,
+                                        op.getSrc().getType());
     auto srcTy = cast<RankedTensorType>(op.getSrc().getType());
     auto resultTy = cast<RankedTensorType>(op.getType());
     auto srcLayout = dyn_cast<SliceEncodingAttr>(srcTy.getEncoding());
@@ -342,7 +311,7 @@ struct ExpandDimsOpConversion : public ConvertOpToLLVMPattern<ExpandDimsOp> {
       resultVals.push_back(srcValues.at(offset));
     }
     Value ret =
-        packLLElements(loc, typeConverter, resultVals, rewriter, resultTy);
+        packTensorElements(loc, typeConverter, resultVals, rewriter, resultTy);
     rewriter.replaceOp(op, ret);
     return success();
   }
@@ -446,7 +415,8 @@ struct BroadcastOpConversion
     assert(rank == resultTy.getRank());
     auto srcOffsets = emitOffsetForLayout(srcLayout, srcTy);
     auto resultOffsets = emitOffsetForLayout(resultLayout, resultTy);
-    SmallVector<Value> srcVals = unpackLLElements(loc, src, rewriter);
+    SmallVector<Value> srcVals =
+        unpackTensorElements(loc, src, rewriter, srcTy);
     std::map<SmallVector<unsigned>, Value> srcValues;
     for (size_t i = 0; i < srcOffsets.size(); i++) {
       srcValues[srcOffsets[i]] = srcVals[i];
@@ -460,7 +430,7 @@ struct BroadcastOpConversion
       resultVals.push_back(srcValues.at(offset));
     }
     Value resultStruct =
-        packLLElements(loc, typeConverter, resultVals, rewriter, resultTy);
+        packTensorElements(loc, typeConverter, resultVals, rewriter, resultTy);
     rewriter.replaceOp(op, {resultStruct});
     return success();
   }

--- a/lib/Conversion/TritonInstrumentToLLVM/FpSanToLLVM.cpp
+++ b/lib/Conversion/TritonInstrumentToLLVM/FpSanToLLVM.cpp
@@ -178,13 +178,14 @@ struct ExperimentalFPSanEmbedOpConversion
     Type intTy = rewriter.getIntegerType(floatTy.getWidth());
 
     SmallVector<Value> resultVals;
-    for (Value elem : unpackLLElements(loc, adaptor.getVal(), rewriter)) {
+    for (Value elem :
+         unpackUniqueTensorElements(loc, adaptor.getVal(), rewriter)) {
       Value raw = bitcastIfNeeded(rewriter, loc, elem, intTy);
       resultVals.push_back(mixFloatToInt(rewriter, loc, raw, floatTy));
     }
 
-    Value result = packLLElements(loc, getTypeConverter(), resultVals, rewriter,
-                                  op.getType());
+    Value result = packUniqueTensorElements(loc, getTypeConverter(), resultVals,
+                                            rewriter, op.getType());
     rewriter.replaceOp(op, result);
     return success();
   }
@@ -202,13 +203,14 @@ struct ExperimentalFPSanUnembedOpConversion
     Type resultElemTy = getTypeConverter()->convertType(floatTy);
 
     SmallVector<Value> resultVals;
-    for (Value elem : unpackLLElements(loc, adaptor.getVal(), rewriter)) {
+    for (Value elem :
+         unpackUniqueTensorElements(loc, adaptor.getVal(), rewriter)) {
       Value raw = unmixIntToFloat(rewriter, loc, elem, floatTy);
       resultVals.push_back(bitcastIfNeeded(rewriter, loc, raw, resultElemTy));
     }
 
-    Value result = packLLElements(loc, getTypeConverter(), resultVals, rewriter,
-                                  op.getType());
+    Value result = packUniqueTensorElements(loc, getTypeConverter(), resultVals,
+                                            rewriter, op.getType());
     rewriter.replaceOp(op, result);
     return success();
   }

--- a/lib/Conversion/TritonInstrumentToLLVM/GSanToLLVM.cpp
+++ b/lib/Conversion/TritonInstrumentToLLVM/GSanToLLVM.cpp
@@ -426,10 +426,12 @@ public:
     Location loc = op.getLoc();
     auto ptrTy = op.getPtr().getType();
     int32_t bytesPerElem = tt::getPointeeBitWidth(ptrTy) / 8;
-    auto ptrElems = unpackLLElements(loc, adaptor.getPtr(), rewriter);
+    auto ptrElems =
+        unpackTensorElements(loc, adaptor.getPtr(), rewriter, ptrTy);
     SmallVector<Value> maskElems;
     if (Value llMask = adaptor.getMask()) {
-      maskElems = unpackLLElements(loc, llMask, rewriter);
+      maskElems =
+          unpackTensorElements(loc, llMask, rewriter, op.getMask().getType());
     }
 
     unsigned mergeVec = getVecSize(op);
@@ -484,10 +486,12 @@ public:
                   ConversionPatternRewriter &rewriter) const override {
     Location loc = op.getLoc();
     auto ptrTy = op.getPtr().getType();
-    auto ptrElems = unpackLLElements(loc, adaptor.getPtr(), rewriter);
+    auto ptrElems =
+        unpackTensorElements(loc, adaptor.getPtr(), rewriter, ptrTy);
     SmallVector<Value> maskElems;
     if (Value llMask = adaptor.getMask()) {
-      maskElems = unpackLLElements(loc, llMask, rewriter);
+      maskElems =
+          unpackTensorElements(loc, llMask, rewriter, op.getMask().getType());
     }
 
     int32_t bytesPerElem = std::max(1u, tt::getPointeeBitWidth(ptrTy) / 8);
@@ -548,11 +552,14 @@ public:
     Value llVal = adaptor.getVal();
     Value llMask = adaptor.getMask();
 
-    auto ptrElements = unpackLLElements(loc, llPtr, rewriter);
-    auto valElements = unpackLLElements(loc, llVal, rewriter);
+    auto ptrElements =
+        unpackTensorElements(loc, llPtr, rewriter, op.getPtr().getType());
+    auto valElements =
+        unpackTensorElements(loc, llVal, rewriter, op.getVal().getType());
     SmallVector<Value> maskElements;
     if (llMask)
-      maskElements = unpackLLElements(loc, llMask, rewriter);
+      maskElements =
+          unpackTensorElements(loc, llMask, rewriter, op.getMask().getType());
 
     auto valueTy = op.getType();
     auto tensorTy = dyn_cast<RankedTensorType>(valueTy);
@@ -652,9 +659,12 @@ public:
     Value llCmp = adaptor.getCmp();
     Value llVal = adaptor.getVal();
 
-    auto ptrElements = unpackLLElements(loc, llPtr, rewriter);
-    auto cmpElements = unpackLLElements(loc, llCmp, rewriter);
-    auto valElements = unpackLLElements(loc, llVal, rewriter);
+    auto ptrElements =
+        unpackTensorElements(loc, llPtr, rewriter, op.getPtr().getType());
+    auto cmpElements =
+        unpackTensorElements(loc, llCmp, rewriter, op.getCmp().getType());
+    auto valElements =
+        unpackTensorElements(loc, llVal, rewriter, op.getVal().getType());
 
     auto valueTy = op.getType();
     auto tensorTy = dyn_cast<RankedTensorType>(valueTy);

--- a/lib/Conversion/TritonInstrumentToLLVM/InstrumentationToLLVM.cpp
+++ b/lib/Conversion/TritonInstrumentToLLVM/InstrumentationToLLVM.cpp
@@ -417,7 +417,8 @@ struct LocalGatherOpConversion
     Type llvmElemTy = typeConverter->convertType(memDescTy.getElementType());
     auto smemObj = LLVM::getSharedMemoryObjectFromStruct(loc, adaptor.getSrc(),
                                                          llvmElemTy, rewriter);
-    auto idxValues = unpackLLElements(loc, adaptor.getIndices(), rewriter);
+    auto idxValues = unpackTensorElements(loc, adaptor.getIndices(), rewriter,
+                                          op.getIndices().getType());
     SmallVector<Value> offsets(adaptor.getOffsets());
 
     auto offsetAndBlock = computeLocalOffsetsWithLogicalOffsets(
@@ -431,7 +432,8 @@ struct LocalGatherOpConversion
           return targetInfo.loadDShared(rewriter, loc, addr.ptr, addr.ctaId,
                                         llvmElemTy, b.true_val());
         });
-    Value result = packLLElements(loc, typeConverter, results, rewriter, regTy);
+    Value result =
+        packTensorElements(loc, typeConverter, results, rewriter, regTy);
 
     rewriter.replaceOp(op, result);
     return success();

--- a/test/Conversion/amd/tritongpu_wmma_dot_scaled_to_llvm.mlir
+++ b/test/Conversion/amd/tritongpu_wmma_dot_scaled_to_llvm.mlir
@@ -129,21 +129,21 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.targ
     // Matrix C
     // CHECK-COUNT-8:  llvm.insertelement {{.*}} : vector<8xf32>
     // Matrix A
-    // CHECK-COUNT-32: llvm.extractvalue {{.*}} : !llvm.struct<(i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8,  i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8)>
+    // CHECK-COUNT-32: llvm.extractvalue {{.*}} : !llvm.struct<(i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8)>
     // CHECK-COUNT-32: llvm.insertelement {{.*}} : vector<64xi8>
     // CHECK-COUNT-32: llvm.insertelement %[[ZERO]], {{.*}} : vector<64xi8>
     // CHECK: llvm.bitcast {{.*}} : vector<64xi8> to vector<16xi32>
     // Matrix B
-    // CHECK-COUNT-32: llvm.extractvalue {{.*}} : !llvm.struct<(i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8,  i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8)>
+    // CHECK-COUNT-32: llvm.extractvalue {{.*}} : !llvm.struct<(i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8)>
     // CHECK-COUNT-32: llvm.insertelement {{.*}} : vector<64xi8>
     // CHECK-COUNT-32: llvm.insertelement %[[ZERO]], {{.*}} : vector<64xi8>
     // CHECK: llvm.bitcast {{.*}} : vector<64xi8> to vector<16xi32>
     // Scale A
-    // CHECK-COUNT-4: llvm.extractvalue {{.*}} : !llvm.struct<(i8, i8, i8, i8)>
+    // CHECK-COUNT-2: llvm.extractvalue {{.*}} : !llvm.struct<(i8, i8)>
     // CHECK-COUNT-4: llvm.insertelement {{.*}} : vector<4xi8>
     // CHECK: llvm.bitcast {{.*}} : vector<4xi8> to i32
     // Scale B
-    // CHECK-COUNT-4: llvm.extractvalue {{.*}} : !llvm.struct<(i8, i8, i8, i8)>
+    // CHECK-COUNT-2: llvm.extractvalue {{.*}} : !llvm.struct<(i8, i8)>
     // CHECK-COUNT-4: llvm.insertelement {{.*}} : vector<4xi8>
     // CHECK: llvm.bitcast {{.*}} : vector<4xi8> to i32
     // CHECK: llvm.call_intrinsic "llvm.amdgcn.wmma.scale.f32.16x16x128.f8f6f4"{{.*}} : (i32, vector<16xi32>, i32, vector<16xi32>, i16, vector<8xf32>, i32, i32, i32, i32, i32, i32, i1, i1) -> vector<8xf32>

--- a/test/Conversion/tritongpu_to_llvm.mlir
+++ b/test/Conversion/tritongpu_to_llvm.mlir
@@ -426,7 +426,6 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 2 : i32} {
 module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32} {
   // CHECK-LABEL: basic_view_broadcast
   tt.func @basic_view_broadcast(%arg : tensor<256xf32,#blocked0>) {
-    // CHECK: llvm.mlir.undef
     // CHECK: %[[T0:.*]] = llvm.extractvalue
     // CHECK: %[[T1:.*]] = llvm.extractvalue
     %0 = tt.reshape %arg allow_reorder : tensor<256xf32, #blocked0> -> tensor<256x1xf32,#blocked2>
@@ -2643,15 +2642,15 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 8 : i32, ttg.targ
 tt.func private @expand_dims_linear_layout() -> tensor<1x4xi32, #linear> {
   %0 = tt.make_range {end = 4 : i32, start = 0 : i32} : tensor<4xi32, #ttg.slice<{dim = 0, parent = #linear}>>
   %1 = tt.expand_dims %0 {axis = 0 : i32} : tensor<4xi32, #ttg.slice<{dim = 0, parent = #linear}>> -> tensor<1x4xi32, #linear>
-  // CHECK: return %{{.*}} : !llvm.struct<(i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32)>
+  // CHECK: return %{{.*}} : !llvm.struct<(i32)>
   tt.return %1 : tensor<1x4xi32, #linear>
 }
 
-// CHECK-LABEL: reshape_linear_layout_broadcasting
+// CHECK-LABEL: llvm.func internal @reshape_linear_layout_broadcasting
+// CHECK-SAME: (%[[ARG0:.*]]: !llvm.struct<(bf16)>
 tt.func private @reshape_linear_layout_broadcasting(%arg0: tensor<32x4xbf16, #linear>) -> tensor<32x4x1xbf16, #blocked> {
-  // CHECK-COUNT-16: extractvalue
-  // CHECK-COUNT-16: insertvalue
   %0 = tt.reshape %arg0 : tensor<32x4xbf16, #linear> -> tensor<32x4x1xbf16, #blocked>
+  // CHECK: llvm.return %[[ARG0]] : !llvm.struct<(bf16)>
   tt.return %0 : tensor<32x4x1xbf16, #blocked>
 }
 

--- a/test/TritonGPU/amd/amd-concat-op.mlir
+++ b/test/TritonGPU/amd/amd-concat-op.mlir
@@ -106,16 +106,16 @@ module attributes {"ttg.compute-capability" = 0 : i32, "ttg.num-ctas" = 1 : i32,
 
 // -----
 
-// Each input tensor broadcasts 4 registers along dimension 1, resulting in total 16 values per input.
-// Output tensor do not have redundancy in registers and holds 8 values.
+// Each input tensor broadcasts 4 registers along dimension 1, resulting in 4
+// unique values per input. The output tensor has 8 unique values.
 // Check that concat copies only 4 values from each input tensor, 8 in total.
 #src_layout = #ttg.linear<{register=[[0, 0], [0, 0], [1, 0], [2, 0]], lane=[[0, 0], [0, 0], [0, 0], [4, 0], [8, 0], [16, 0]], warp=[[0, 0], [32, 0], [64, 0]], block=[]}>
 #dst_layout = #ttg.linear<{register=[                [1, 0], [2, 0]], lane=[[0, 0], [0, 0], [0, 0], [4, 0], [8, 0], [16, 0]], warp=[[0, 0], [32, 0], [64, 0]], block=[]}>
 module attributes {"ttg.compute-capability" = 0 : i32, "ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 8 : i32, "ttg.threads-per-warp" = 64 : i32} {
   tt.func @concat_from_broadcasted_tensor(%arg0: tensor<128x1xi32, #src_layout>, %arg1: tensor<128x1xi32, #src_layout> {tt.divisibility = 16 : i32}) {
     // CHECK-LABEL: llvm.func @concat_from_broadcasted_tensor
-    // CHECK-COUNT-16: %{{.*}} = llvm.extractvalue %arg0[{{.*}}] : !llvm.struct
-    // CHECK-COUNT-16: %{{.*}} = llvm.extractvalue %arg1[{{.*}}] : !llvm.struct
+    // CHECK-COUNT-4: %{{.*}} = llvm.extractvalue %arg0[{{.*}}] : !llvm.struct
+    // CHECK-COUNT-4: %{{.*}} = llvm.extractvalue %arg1[{{.*}}] : !llvm.struct
     // CHECK-COUNT-8: %{{.*}} = llvm.insertvalue %{{.*}} : !llvm.struct
     %1 = amdg.concat %arg0, %arg1: tensor<128x1xi32, #src_layout>, tensor<128x1xi32, #src_layout> -> tensor<256x1xi32, #dst_layout>
     tt.return
@@ -125,8 +125,8 @@ module attributes {"ttg.compute-capability" = 0 : i32, "ttg.num-ctas" = 1 : i32,
 // -----
 
 // Input tensors do not have redundancy in register and hold 4 values each.
-// Output tensor broadcasts 4 registers along dimension 1, resulting in total 32 values.
-// Check that concat duplicates 4 values from each input 4 times, resulting in total 32 values.
+// The output tensor broadcasts 4 registers along dimension 1 but keeps only 8
+// unique values in its LLVM struct.
 #src_layout = #ttg.linear<{register=[                [1, 0], [2, 0]], lane=[[0, 0], [0, 0], [0, 0], [4, 0], [8, 0], [16, 0]], warp=[[0, 0], [32, 0], [64, 0]], block=[]}>
 #dst_layout = #ttg.linear<{register=[[0, 0], [0, 0], [1, 0], [2, 0]], lane=[[0, 0], [0, 0], [0, 0], [4, 0], [8, 0], [16, 0]], warp=[[0, 0], [32, 0], [64, 0]], block=[]}>
 module attributes {"ttg.compute-capability" = 0 : i32, "ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 8 : i32, "ttg.threads-per-warp" = 64 : i32} {
@@ -134,7 +134,7 @@ module attributes {"ttg.compute-capability" = 0 : i32, "ttg.num-ctas" = 1 : i32,
     // CHECK-LABEL: llvm.func @concat_to_broadcasted_tensor
     // CHECK-COUNT-4: %{{.*}} = llvm.extractvalue %arg0[{{.*}}] : !llvm.struct
     // CHECK-COUNT-4: %{{.*}} = llvm.extractvalue %arg1[{{.*}}] : !llvm.struct
-    // CHECK-COUNT-32: %{{.*}} = llvm.insertvalue %{{.*}} : !llvm.struct
+    // CHECK-COUNT-8: %{{.*}} = llvm.insertvalue %{{.*}} : !llvm.struct
     %1 = amdg.concat %arg0, %arg1: tensor<128x1xi32, #src_layout>, tensor<128x1xi32, #src_layout> -> tensor<256x1xi32, #dst_layout>
     tt.return
   }

--- a/test/TritonGPU/amd/amd-extractslice-op.mlir
+++ b/test/TritonGPU/amd/amd-extractslice-op.mlir
@@ -58,15 +58,15 @@ module attributes {"ttg.compute-capability" = 0 : i32, "ttg.num-ctas" = 1 : i32,
 
 // -----
 
-// Input tensor broadcasts 4 registers along dimension 1, resulting in total 32 values in tensor and 16 values per [128x1] tile.
-// Output tensor do not have redundancy in register and holds 4 values.
+// Input tensor broadcasts 4 registers along dimension 1, resulting in 8 unique
+// values. The output tensor has 4 unique values.
 // Test checks that extract slice copies only 4 values from input to output.
 #blocked1 = #ttg.linear<{register=[[0, 0], [0, 0], [1, 0], [2, 0], [128, 0]], lane=[[0, 0], [0, 0], [0, 0], [4, 0], [8, 0], [16, 0]], warp=[[0, 0], [32, 0], [64, 0]], block=[]}>
 #blocked2 = #ttg.linear<{register=[                [1, 0], [2, 0]],           lane=[[0, 0], [0, 0], [0, 0], [4, 0], [8, 0], [16, 0]], warp=[[0, 0], [32, 0], [64, 0]], block=[]}>
 module attributes {"ttg.compute-capability" = 0 : i32, "ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 8 : i32, "ttg.threads-per-warp" = 64 : i32} {
   tt.func @extract_from_broadcasted_tensor(%arg0: tensor<256x1xi32, #blocked1> {tt.divisibility = 16 : i32}) {
     // CHECK-LABEL: llvm.func @extract_from_broadcasted_tensor
-    // CHECK-COUNT-32: %{{.*}} = llvm.extractvalue  %{{.*}} : !llvm.struct
+    // CHECK-COUNT-8: %{{.*}} = llvm.extractvalue  %{{.*}} : !llvm.struct
     // CHECK-COUNT-4:  %{{.*}} = llvm.insertvalue %{{.*}} : !llvm.struct
     %0 = amdg.extract_slice %arg0 [0,0] : tensor<256x1xi32, #blocked1> to tensor<128x1xi32, #blocked2>
     tt.return
@@ -75,16 +75,16 @@ module attributes {"ttg.compute-capability" = 0 : i32, "ttg.num-ctas" = 1 : i32,
 
 // -----
 
-// Input tensor do not have broadcasted registers, resulting in total 8 values in tensor and 4 values per [128x1] tile.
-// Output tensor broadcasts 4 registers along dimension 1 and total 16 values.
-// Test checks that extract slice duplicates 4 values from input in 16 output values.
+// The input tensor does not have broadcasted registers and holds 8 values. The
+// output tensor broadcasts 4 registers along dimension 1 but keeps only 4
+// unique values in its LLVM struct.
 #blocked1 = #ttg.linear<{register=[                [1, 0], [2, 0], [128, 0]], lane=[[0, 0], [0, 0], [0, 0], [4, 0], [8, 0], [16, 0]], warp=[[0, 0], [32, 0], [64, 0]], block=[]}>
 #blocked2 = #ttg.linear<{register=[[0, 0], [0, 0], [1, 0], [2, 0]],           lane=[[0, 0], [0, 0], [0, 0], [4, 0], [8, 0], [16, 0]], warp=[[0, 0], [32, 0], [64, 0]], block=[]}>
 module attributes {"ttg.compute-capability" = 0 : i32, "ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 8 : i32, "ttg.threads-per-warp" = 64 : i32} {
   tt.func @extract_to_broadcasted_tensor(%arg0: tensor<256x1xi32, #blocked1> {tt.divisibility = 16 : i32}) {
     // CHECK-LABEL: llvm.func @extract_to_broadcasted_tensor
     // CHECK-COUNT-8: %{{.*}} = llvm.extractvalue  %{{.*}} : !llvm.struct
-    // CHECK-COUNT-16:  %{{.*}} = llvm.insertvalue %{{.*}} : !llvm.struct
+    // CHECK-COUNT-4:  %{{.*}} = llvm.insertvalue %{{.*}} : !llvm.struct
     %72 = amdg.extract_slice %arg0 [0,0] : tensor<256x1xi32, #blocked1> to tensor<128x1xi32, #blocked2>
     tt.return
   }

--- a/third_party/amd/lib/TritonAMDGPUDialectToLLVM/ConcatOpToLLVM.cpp
+++ b/third_party/amd/lib/TritonAMDGPUDialectToLLVM/ConcatOpToLLVM.cpp
@@ -50,7 +50,8 @@ struct ConcatOpConversion : public ConvertOpToLLVMPattern<amdgpu::ConcatOp> {
 
     for (size_t i = 0; i < sources.size(); i++) {
       Value currSrc = sources[i];
-      unpackedSources.push_back(unpackLLElements(loc, currSrc, rewriter));
+      unpackedSources.push_back(unpackTensorElements(
+          loc, currSrc, rewriter, op.getSources()[i].getType()));
     }
 
     // Algorithm:
@@ -100,8 +101,8 @@ struct ConcatOpConversion : public ConvertOpToLLVMPattern<amdgpu::ConcatOp> {
       resultVals.push_back(unpackedSources[linearOperandIdx][srcReg.value()]);
     }
 
-    Value packedResult = packLLElements(loc, this->getTypeConverter(),
-                                        resultVals, rewriter, resultType);
+    Value packedResult = packTensorElements(loc, this->getTypeConverter(),
+                                            resultVals, rewriter, resultType);
 
     rewriter.replaceOp(op, packedResult);
     return success();

--- a/third_party/amd/lib/TritonAMDGPUDialectToLLVM/ExtractSliceOpToLLVM.cpp
+++ b/third_party/amd/lib/TritonAMDGPUDialectToLLVM/ExtractSliceOpToLLVM.cpp
@@ -28,7 +28,7 @@ struct ExtractSliceOpConversion
     Location loc = op->getLoc();
     auto srcTy = cast<RankedTensorType>(op.getSource().getType());
     auto dstTy = cast<RankedTensorType>(op.getType());
-    auto vals = unpackLLElements(loc, adaptor.getSource(), rewriter);
+    auto vals = unpackTensorElements(loc, adaptor.getSource(), rewriter, srcTy);
     auto offsets = op.getStaticOffsets();
 
     auto linearLayoutSrc = triton::gpu::toLinearLayout(srcTy);
@@ -71,8 +71,8 @@ struct ExtractSliceOpConversion
       resultVals.push_back(vals[srcReg.value()]);
     }
 
-    Value ret = packLLElements(loc, this->getTypeConverter(), resultVals,
-                               rewriter, dstTy);
+    Value ret = packTensorElements(loc, this->getTypeConverter(), resultVals,
+                                   rewriter, dstTy);
 
     rewriter.replaceOp(op, ret);
     return success();

--- a/third_party/amd/lib/TritonAMDGPUDialectToLLVM/ScaledUpcastToLLVM.cpp
+++ b/third_party/amd/lib/TritonAMDGPUDialectToLLVM/ScaledUpcastToLLVM.cpp
@@ -30,8 +30,10 @@ struct ScaledUpcastFp4OpPattern
     auto loc = upcastOp.getLoc();
     auto elemType = upcastOp.getType().getElementType();
 
-    auto inputVals = unpackLLElements(loc, adaptor.getInput(), rewriter);
-    auto scaleVals = unpackLLElements(loc, adaptor.getScale(), rewriter);
+    auto inputVals =
+        unpackUniqueTensorElements(loc, adaptor.getInput(), rewriter);
+    auto scaleVals =
+        unpackUniqueTensorElements(loc, adaptor.getScale(), rewriter);
 
     assert(inputVals.size() % 4 == 0);
     SmallVector<Value> results;
@@ -109,8 +111,8 @@ struct ScaledUpcastFp4OpPattern
       }
     }
 
-    Value result = packLLElements(loc, getTypeConverter(), results, rewriter,
-                                  upcastOp.getType());
+    Value result = packUniqueTensorElements(loc, getTypeConverter(), results,
+                                            rewriter, upcastOp.getType());
     rewriter.replaceOp(upcastOp, result);
     return success();
   }
@@ -133,8 +135,10 @@ struct ScaledUpcastFp8OpPattern
     auto elemType = upcastOp.getType().getElementType();
     auto fp8ElemType = upcastOp.getInput().getType().getElementType();
 
-    auto inputVals = unpackLLElements(loc, adaptor.getInput(), rewriter);
-    auto scaleVals = unpackLLElements(loc, adaptor.getScale(), rewriter);
+    auto inputVals =
+        unpackUniqueTensorElements(loc, adaptor.getInput(), rewriter);
+    auto scaleVals =
+        unpackUniqueTensorElements(loc, adaptor.getScale(), rewriter);
 
     assert(inputVals.size() % 4 == 0);
     assert(inputVals.size() == scaleVals.size());
@@ -210,8 +214,8 @@ struct ScaledUpcastFp8OpPattern
       }
     }
 
-    Value result = packLLElements(loc, getTypeConverter(), results, rewriter,
-                                  upcastOp.getType());
+    Value result = packUniqueTensorElements(loc, getTypeConverter(), results,
+                                            rewriter, upcastOp.getType());
     rewriter.replaceOp(upcastOp, result);
     return success();
   }

--- a/third_party/amd/lib/TritonAMDGPUToLLVM/ConvertLayoutOpToLLVM.cpp
+++ b/third_party/amd/lib/TritonAMDGPUToLLVM/ConvertLayoutOpToLLVM.cpp
@@ -104,12 +104,7 @@ public:
       return ret;
     };
 
-    auto inVals = unpackLLElements(loc, adaptor.getSrc(), rewriter);
-
-    // Handle broadcasting in registers.
-    auto srcLL = triton::gpu::toLinearLayout(srcTy);
-    auto rmSrc = actionRemoveBroadcastedRegs(srcLL);
-    inVals = rmSrc.apply(inVals);
+    auto inVals = unpackUniqueTensorElements(loc, adaptor.getSrc(), rewriter);
     // The input values may require broadcasting so that the conversion can be
     // described as a permutation. This does not cost anything for simple cases.
     int regDim = inVals.size();
@@ -245,19 +240,12 @@ public:
     }
 
     // Handle broadcasting in registers.
-    // The `factors` produce output values which may contain broadcasting.
-    // This needs to be removed before using `broadcastAs` to get the correct
-    // broadcasting as expected by the original destination layout.
     auto dstLL = triton::gpu::toLinearLayout(dstTy);
-    auto rmDst = actionRemoveBroadcastedRegs(dstLL);
-    auto strippedDst = rmDst.apply(dstLL);
+    auto strippedDst = dstLL.removeZeroBasesAlongDim(kReg);
     outVals.resize(strippedDst.getInDimSize(kReg));
 
-    if (!rmDst.isIdentity())
-      outVals = broadcastAs(outVals, dstLL);
-
-    Value result = packLLElements(loc, getTypeConverter(), outVals, rewriter,
-                                  op.getType());
+    Value result = packUniqueTensorElements(loc, getTypeConverter(), outVals,
+                                            rewriter, dstTy);
     rewriter.replaceOp(op, result);
     return success();
   }
@@ -361,9 +349,9 @@ public:
   // Unpacks input values and packs them in int32 values, like they will be
   // stored in actual registers
   static std::vector<Value>
-  repackInputToRegisters(Location loc, OpAdaptor adaptor,
+  repackInputToRegisters(Location loc, OpAdaptor adaptor, Type srcTy,
                          ConversionPatternRewriter &rewriter) {
-    auto inVals = unpackLLElements(loc, adaptor.getSrc(), rewriter);
+    auto inVals = unpackTensorElements(loc, adaptor.getSrc(), rewriter, srcTy);
     auto numRegs = inVals.size() / regBytes;
     auto b = TritonLLVMOpBuilder(loc, rewriter);
     std::vector<Value> srcRegs(numRegs);
@@ -675,8 +663,8 @@ public:
         outVals[regIdx * regBytes + elem] = unpacked[elem];
       }
     }
-    return packLLElements(loc, getTypeConverter(), outVals, rewriter,
-                          op.getType());
+    return packTensorElements(loc, getTypeConverter(), outVals, rewriter,
+                              op.getType());
   }
 
   void transferWithVPerm(ConvertLayoutOp op, const LinearLayout &conversion,
@@ -687,7 +675,8 @@ public:
     auto fullLayout = getFullLayout(conversion, ctx);
     // Mapping for dst register bytes to source bytes
     auto dstRegContents = generateDstRegContents(fullLayout);
-    std::vector<Value> srcRegs = repackInputToRegisters(loc, adaptor, rewriter);
+    std::vector<Value> srcRegs =
+        repackInputToRegisters(loc, adaptor, op.getSrc().getType(), rewriter);
     TritonLLVMOpBuilder b(loc, rewriter);
 
     auto numDstValues = fullLayout.size();

--- a/third_party/amd/lib/TritonAMDGPUToLLVM/DotOpToLLVM/MFMA.cpp
+++ b/third_party/amd/lib/TritonAMDGPUToLLVM/DotOpToLLVM/MFMA.cpp
@@ -224,9 +224,8 @@ struct DotOpMFMAConversionHelper {
                             const FailureOr<MfmaIntrinsic> &maybeMfmaIntrinsic,
                             Type dstElemTy, Type elemtTy,
                             size_t mmaCount) const {
-    Type structTy = LLVM::LLVMStructType::getLiteral(
-        ctx, SmallVector<Type>(fc.size(), dstElemTy));
-    Value res = packLLElements(loc, typeConverter, fc, rewriter, structTy);
+    Value res =
+        packTensorElements(loc, typeConverter, fc, rewriter, op.getType());
 
     rewriter.replaceOp(op, res);
   }
@@ -322,10 +321,10 @@ struct DotOpMFMAConversionHelper {
 
     bool preserveBF16 = intrinsicName.contains(".bf16") && mfmaVersion >= 4;
     auto operandA = getValuesFromDotOperandLayoutStruct(
-        loadedA, numRepB, numRepM, numRepKA, kWidth, kBase,
+        loadedA, numRepB, numRepM, numRepKA, kWidth, kBase, aTensorTy,
         aTensorTy.getElementType(), allowXF32, preserveBF16);
     auto operandB = getValuesFromDotOperandLayoutStruct(
-        loadedB, numRepB, numRepN, numRepKB, kWidth, kBase,
+        loadedB, numRepB, numRepN, numRepKB, kWidth, kBase, bTensorTy,
         bTensorTy.getElementType(), allowXF32, preserveBF16);
 
     int warpSize = triton::gpu::lookupThreadsPerWarp(rewriter);
@@ -333,7 +332,7 @@ struct DotOpMFMAConversionHelper {
     int numVecInKBase = numRepK * kWidth / kBase;
 
     auto dstElemTy = dTensorTy.getElementType();
-    auto fc = unpackLLElements(loc, loadedC, rewriter);
+    auto fc = unpackTensorElements(loc, loadedC, rewriter, op.getC().getType());
     SmallVector<int64_t> fcStrides =
         computeStrides({numRepB, numRepM, numRepN, elemsPerVec});
 
@@ -462,10 +461,10 @@ struct DotOpMFMAConversionHelper {
   /// appropriate for mfma instructions
   virtual ValueTable getValuesFromDotOperandLayoutStruct(
       Value value, int batch, int nonKRep, int kRepInKWidth, int kWidth,
-      int kBase, Type type, bool allowXF32, bool preserveBF16,
-      bool isConstantScale = false) const {
+      int kBase, RankedTensorType tensorType, Type type, bool allowXF32,
+      bool preserveBF16, bool isConstantScale = false) const {
     auto tb = TritonLLVMOpBuilder(loc, rewriter);
-    auto elems = unpackLLElements(loc, value, rewriter);
+    auto elems = unpackTensorElements(loc, value, rewriter, tensorType);
     // number of kBase-element vectors
     int numVecInKBase = kRepInKWidth * kWidth / kBase;
     if (numVecInKBase == 0) {
@@ -686,11 +685,13 @@ struct ScaledDotOpMFMAConversionHelper : DotOpMFMAConversionHelper {
     int bNonKPackedVals = scaleBKBase / bkPackedVals;
 
     auto operandA = getValuesFromDotOperandLayoutStruct(
-        loadedA, numRepB, numRepM, numRepK, aKWidth, aKBase,
-        aTensorTy.getElementType(), allowXF32, /*preserveBF16=*/false);
+        loadedA, numRepB, numRepM, numRepK, aKWidth, aKBase, aTensorTy,
+        aTensorTy.getElementType(), allowXF32,
+        /*preserveBF16=*/false);
     auto operandB = getValuesFromDotOperandLayoutStruct(
-        loadedB, numRepB, numRepN, numRepK, bKWidth, bKBase,
-        bTensorTy.getElementType(), allowXF32, /*preserveBF16=*/false);
+        loadedB, numRepB, numRepN, numRepK, bKWidth, bKBase, bTensorTy,
+        bTensorTy.getElementType(), allowXF32,
+        /*preserveBF16=*/false);
 
     // Scales have the same replica distributions as their corresponding
     // operands.
@@ -700,18 +701,18 @@ struct ScaledDotOpMFMAConversionHelper : DotOpMFMAConversionHelper {
       auto aScaleTensorTy = cast<RankedTensorType>(aScale.getType());
       operandAScale = getValuesFromDotOperandLayoutStruct(
           loadedAScale, numRepB, numRepM, numRepK, scaleKWidth, scaleAKBase,
-          aScaleTensorTy.getElementType(), allowXF32, /*preserveBF16=*/false,
-          isAScaleConstant);
+          aScaleTensorTy, aScaleTensorTy.getElementType(), allowXF32,
+          /*preserveBF16=*/false, isAScaleConstant);
 
       auto bScaleTensorTy = cast<RankedTensorType>(bScale.getType());
       operandBScale = getValuesFromDotOperandLayoutStruct(
           loadedBScale, numRepB, numRepN, numRepK, scaleKWidth, scaleBKBase,
-          bScaleTensorTy.getElementType(), allowXF32, /*preserveBF16=*/false,
-          isBScaleConstant);
+          bScaleTensorTy, bScaleTensorTy.getElementType(), allowXF32,
+          /*preserveBF16=*/false, isBScaleConstant);
     }
 
     auto dstElemTy = dTensorTy.getElementType();
-    auto fc = unpackLLElements(loc, loadedC, rewriter);
+    auto fc = unpackTensorElements(loc, loadedC, rewriter, op.getC().getType());
 
     unsigned warpSize = triton::gpu::lookupThreadsPerWarp(rewriter);
     // compute number of output elements that each thread holds for one MFMA

--- a/third_party/amd/lib/TritonAMDGPUToLLVM/DotOpToLLVM/WMMA.cpp
+++ b/third_party/amd/lib/TritonAMDGPUToLLVM/DotOpToLLVM/WMMA.cpp
@@ -148,8 +148,8 @@ Value getOperandVals(ConversionPatternRewriter &rewriter,
                      LinearLayout dotLayout, Value value, int opIdx, int rank,
                      int batch, int nonK, int kIdx, int kInstrSize, int kBase,
                      int64_t kDimTensor, DotOperandEncodingAttr dotEnc,
-                     unsigned warpSize, int *opSel, Type type, Location loc,
-                     bool isScale = false) {
+                     unsigned warpSize, int *opSel, RankedTensorType tensorType,
+                     Type type, Location loc, bool isScale = false) {
   auto ctx = dotLayout.getOutDimNames().begin()->getContext();
 
   const StringAttr dim0 = StringAttr::get(ctx, "dim0");
@@ -158,7 +158,7 @@ Value getOperandVals(ConversionPatternRewriter &rewriter,
 
   TritonLLVMOpBuilder tb(loc, rewriter);
 
-  auto elems = unpackLLElements(loc, value, rewriter);
+  auto elems = unpackTensorElements(loc, value, rewriter, tensorType);
 
   Type elemTy = typeConverter->convertType(type);
   Type vecTy = vec_ty(elemTy, kBase);
@@ -463,7 +463,7 @@ LogicalResult convertDot(DotOp op, DotOpAdaptor adaptor,
   auto kDimTensorB = bTensorTy.getShape()[rank - 2];
 
   auto dstElemTy = dTensorTy.getElementType();
-  auto fc = unpackLLElements(loc, loadedC, rewriter);
+  auto fc = unpackTensorElements(loc, loadedC, rewriter, dTensorTy);
 
   unsigned warpSize = gpu::lookupThreadsPerWarp(rewriter);
   constexpr unsigned vgprElemBitWidth = 32;
@@ -518,28 +518,31 @@ LogicalResult convertDot(DotOp op, DotOpAdaptor adaptor,
       }
     }
     for (size_t k = 0; k < numRepK; ++k) {
-      auto ha = getOperandVals(
-          rewriter, typeConverter, aLayout, loadedA,
-          /*opIdx*/ 0, rank, batchIdx, m, k, kInstrSize, kBase, kDimTensorA,
-          aEnc, warpSize, /*opScale*/ nullptr, aTensorTy.getElementType(), loc);
+      auto ha =
+          getOperandVals(rewriter, typeConverter, aLayout, loadedA,
+                         /*opIdx*/ 0, rank, batchIdx, m, k, kInstrSize, kBase,
+                         kDimTensorA, aEnc, warpSize, /*opScale*/ nullptr,
+                         aTensorTy, aTensorTy.getElementType(), loc);
       ha = prepareOperands(rewriter, ha, aTensorTy.getElementType(), wmmaVer,
                            kBase, loc);
       ha = maskRepeatedKLanes(rewriter, loc, aLayout, aEnc, ha, warpSize);
 
-      auto hb = getOperandVals(
-          rewriter, typeConverter, bLayout, loadedB,
-          /*opIdx*/ 1, rank, batchIdx, n, k, kInstrSize, kBase, kDimTensorB,
-          bEnc, warpSize, /*opScale*/ nullptr, bTensorTy.getElementType(), loc);
+      auto hb =
+          getOperandVals(rewriter, typeConverter, bLayout, loadedB,
+                         /*opIdx*/ 1, rank, batchIdx, n, k, kInstrSize, kBase,
+                         kDimTensorB, bEnc, warpSize, /*opScale*/ nullptr,
+                         bTensorTy, bTensorTy.getElementType(), loc);
       hb = prepareOperands(rewriter, hb, bTensorTy.getElementType(), wmmaVer,
                            kBase, loc);
       hb = maskRepeatedKLanes(rewriter, loc, bLayout, bEnc, hb, warpSize);
 
       Value haNext;
       if (tiedGroup == 2) {
-        haNext = getOperandVals(rewriter, typeConverter, aLayout, loadedA,
-                                /*opIdx*/ 0, rank, batchIdx, nextM.value(), k,
-                                kInstrSize, kBase, kDimTensorA, aEnc, warpSize,
-                                nullptr, aTensorTy.getElementType(), loc);
+        haNext =
+            getOperandVals(rewriter, typeConverter, aLayout, loadedA,
+                           /*opIdx*/ 0, rank, batchIdx, nextM.value(), k,
+                           kInstrSize, kBase, kDimTensorA, aEnc, warpSize,
+                           nullptr, aTensorTy, aTensorTy.getElementType(), loc);
 
         haNext = prepareOperands(rewriter, haNext, aTensorTy.getElementType(),
                                  wmmaVer, kBase, loc);
@@ -571,9 +574,7 @@ LogicalResult convertDot(DotOp op, DotOpAdaptor adaptor,
   }
 
   // replace with new packed result
-  Type structTy = LLVM::LLVMStructType::getLiteral(
-      wmmaLayout.getContext(), SmallVector<Type>(fc.size(), dstElemTy));
-  Value res = packLLElements(loc, typeConverter, fc, rewriter, structTy);
+  Value res = packTensorElements(loc, typeConverter, fc, rewriter, dTensorTy);
 
   rewriter.replaceOp(op, res);
   return success();
@@ -686,7 +687,7 @@ LogicalResult convertScaledDot(triton::DotScaledOp op,
   auto bScaleLayout = triton::gpu::toLinearLayout(bScaleTensorTy);
 
   auto dstElemTy = dTensorTy.getElementType();
-  auto fc = unpackLLElements(loc, loadedC, rewriter);
+  auto fc = unpackTensorElements(loc, loadedC, rewriter, dTensorTy);
 
   unsigned warpSize = gpu::lookupThreadsPerWarp(rewriter);
 
@@ -722,14 +723,14 @@ LogicalResult convertScaledDot(triton::DotScaledOp op,
       auto ha = getOperandVals(rewriter, typeConverter, aLayout, loadedA,
                                /*opIdx*/ 0, rank, batchIdx, m, k, kDimA, kBaseA,
                                kDimTensorA, aEnc, warpSize, /*opSel*/ nullptr,
-                               aTensorTy.getElementType(), loc);
+                               aTensorTy, aTensorTy.getElementType(), loc);
       ha = prepareOperands(rewriter, ha, aTensorTy.getElementType(), wmmaVer,
                            kBaseA, loc);
 
       auto hb = getOperandVals(rewriter, typeConverter, bLayout, loadedB,
                                /*opIdx*/ 1, rank, batchIdx, n, k, kDimB, kBaseB,
                                kDimTensorB, bEnc, warpSize, /*opSel*/ nullptr,
-                               bTensorTy.getElementType(), loc);
+                               bTensorTy, bTensorTy.getElementType(), loc);
       hb = prepareOperands(rewriter, hb, bTensorTy.getElementType(), wmmaVer,
                            kBaseB, loc);
 
@@ -740,7 +741,7 @@ LogicalResult convertScaledDot(triton::DotScaledOp op,
           rewriter, typeConverter, aScaleLayout, loadedAScale,
           /*opIdx*/ 0, rank, batchIdx, m, k, kDimScale, KBaseScale,
           /*kDimTensor*/ kDimScale, aEnc, warpSize, &scaleOpSelA,
-          aScaleTensorTy.getElementType(), loc,
+          aScaleTensorTy, aScaleTensorTy.getElementType(), loc,
           /*isScale*/ true);
       sa = prepareOperands(rewriter, sa, aScaleTensorTy.getElementType(),
                            wmmaVer, KBaseScale, loc, /*isScale=*/true);
@@ -749,7 +750,7 @@ LogicalResult convertScaledDot(triton::DotScaledOp op,
           rewriter, typeConverter, bScaleLayout, loadedBScale,
           /*opIdx*/ 0, rank, batchIdx, n, k, kDimScale, KBaseScale,
           /*kDimTensor*/ kDimScale, bEnc, warpSize, &scaleOpSelB,
-          bScaleTensorTy.getElementType(), loc,
+          bScaleTensorTy, bScaleTensorTy.getElementType(), loc,
           /*isScale*/ true);
       sb = prepareOperands(rewriter, sb, bScaleTensorTy.getElementType(),
                            wmmaVer, KBaseScale, loc, /*isScale=*/true);
@@ -772,9 +773,7 @@ LogicalResult convertScaledDot(triton::DotScaledOp op,
     }
   }
 
-  Type structTy = LLVM::LLVMStructType::getLiteral(
-      wmmaLayout.getContext(), SmallVector<Type>(fc.size(), dstElemTy));
-  Value res = packLLElements(loc, typeConverter, fc, rewriter, structTy);
+  Value res = packTensorElements(loc, typeConverter, fc, rewriter, dTensorTy);
 
   rewriter.replaceOp(op, res);
   return success();

--- a/third_party/amd/lib/TritonAMDGPUToLLVM/HistogramOpToLLVM.cpp
+++ b/third_party/amd/lib/TritonAMDGPUToLLVM/HistogramOpToLLVM.cpp
@@ -147,12 +147,13 @@ public:
     Location loc = op.getLoc();
     Value input = adaptor.getSrc();
     auto typeConverter = getTypeConverter();
-    SmallVector<Value> srcValues = unpackLLElements(loc, input, rewriter);
+    SmallVector<Value> srcValues =
+        unpackUniqueTensorElements(loc, input, rewriter);
 
     Value llMask = adaptor.getMask();
     SmallVector<Value> maskValues;
     if (llMask)
-      maskValues = unpackLLElements(loc, llMask, rewriter);
+      maskValues = unpackUniqueTensorElements(loc, llMask, rewriter);
 
     int numBins = op.getType().getDimSize(0);
     auto mod = op->getParentOfType<ModuleOp>();
@@ -207,8 +208,8 @@ public:
           b.sdiv(histogramValue[i], b.i32_val(replicationFactor));
     }
 
-    Value results = packLLElements(loc, typeConverter, histogramValue, rewriter,
-                                   op.getType());
+    Value results = packTensorElements(loc, typeConverter, histogramValue,
+                                       rewriter, op.getType());
     rewriter.replaceOp(op, results);
     return success();
   }

--- a/third_party/amd/lib/TritonAMDGPUToLLVM/LoadStoreOpToLLVM.cpp
+++ b/third_party/amd/lib/TritonAMDGPUToLLVM/LoadStoreOpToLLVM.cpp
@@ -265,7 +265,7 @@ struct LoadStoreConversionBase {
     SmallVector<Value> maskElems;
     if (llMask) {
       vec = std::min<size_t>(vec, getMaskAlignment(mask));
-      maskElems = unpackLLElements(loc, llMask, rewriter);
+      maskElems = unpackTensorElements(loc, llMask, rewriter, mask.getType());
     }
     return maskElems;
   }
@@ -572,7 +572,7 @@ struct LoadOpConversion : public ConvertOpToLLVMPattern<triton::LoadOp>,
     unsigned numElems = getTotalElemsPerThread(ptr.getType());
 
     // Get the LLVM values for pointers
-    auto ptrElems = unpackLLElements(loc, llPtr, rewriter);
+    auto ptrElems = unpackTensorElements(loc, llPtr, rewriter, ptr.getType());
     assert(ptrElems.size() == numElems);
 
     // Get the LLVM values for mask
@@ -581,7 +581,8 @@ struct LoadOpConversion : public ConvertOpToLLVMPattern<triton::LoadOp>,
 
     SmallVector<Value> otherElems;
     if (other)
-      otherElems = unpackLLElements(loc, llOther, rewriter);
+      otherElems =
+          unpackTensorElements(loc, llOther, rewriter, other.getType());
 
     Value multicastMask;
     if (targetInfo.supportsMultiCTALaunch()) {
@@ -629,9 +630,8 @@ struct LoadOpConversion : public ConvertOpToLLVMPattern<triton::LoadOp>,
       }
     } // end vec
 
-    Type llvmResultStructTy = getTypeConverter()->convertType(valueTy);
-    Value resultStruct = packLLElements(loc, getTypeConverter(), loadedVals,
-                                        rewriter, llvmResultStructTy);
+    Value resultStruct = packTensorElements(loc, getTypeConverter(), loadedVals,
+                                            rewriter, valueTy);
 
     rewriter.replaceOp(op, {resultStruct});
     return success();
@@ -679,7 +679,8 @@ struct BufferLoadOpConversion
     vec = std::max(vec, op.getContiguity());
 
     // Get the offset
-    SmallVector<Value> offsetElems = unpackLLElements(loc, llOffset, rewriter);
+    SmallVector<Value> offsetElems =
+        unpackTensorElements(loc, llOffset, rewriter, offset.getType());
     assert(offsetElems.size() == numElems);
 
     // Get the mask
@@ -689,7 +690,8 @@ struct BufferLoadOpConversion
     // Get the `other` value (if any)
     SmallVector<Value> otherElems;
     if (llOther)
-      otherElems = unpackLLElements(loc, llOther, rewriter);
+      otherElems =
+          unpackTensorElements(loc, llOther, rewriter, op.getOther().getType());
 
     // Create the resource descriptor and then emit the buffer_load intrinsic(s)
     Value rsrcDesc = bufferEmitter.createResourceDescriptor(llPtr, llStride);
@@ -712,9 +714,8 @@ struct BufferLoadOpConversion
       }
     } // end vec
 
-    Type llvmResultStructTy = getTypeConverter()->convertType(valueTy);
-    Value resultStruct = packLLElements(loc, getTypeConverter(), loadedVals,
-                                        rewriter, llvmResultStructTy);
+    Value resultStruct = packTensorElements(loc, getTypeConverter(), loadedVals,
+                                            rewriter, valueTy);
 
     rewriter.replaceOp(op, {resultStruct});
     return success();
@@ -764,10 +765,12 @@ struct BufferLoadToLocalOpConversion
     SmallVector<Value> maskElems =
         getMaskElemsAndUpdateVeclen(rewriter, loc, llMask, mask, vec);
 
-    SmallVector<Value> offsetElems = unpackLLElements(loc, llOffset, rewriter);
+    SmallVector<Value> offsetElems =
+        unpackTensorElements(loc, llOffset, rewriter, offset.getType());
     SmallVector<Value> otherElems;
     if (llOther)
-      otherElems = unpackLLElements(loc, llOther, rewriter);
+      otherElems =
+          unpackTensorElements(loc, llOther, rewriter, op.getOther().getType());
 
     auto dstTy = op.getDest().getType();
     auto resElemTy = getTypeConverter()->convertType(dstTy.getElementType());
@@ -926,10 +929,12 @@ struct AsyncCopyGlobalToLocalOpConversion
     auto maskElements = getMaskElemsAndUpdateVeclen(
         rewriter, loc, adaptor.getMask(), op.getMask(), vec);
 
-    auto srcElems = unpackLLElements(loc, adaptor.getSrc(), rewriter);
+    auto srcElems = unpackTensorElements(loc, adaptor.getSrc(), rewriter,
+                                         op.getSrc().getType());
     SmallVector<Value> otherElems;
     if (op.getOther())
-      otherElems = unpackLLElements(loc, adaptor.getOther(), rewriter);
+      otherElems = unpackTensorElements(loc, adaptor.getOther(), rewriter,
+                                        op.getOther().getType());
 
     // If the op has a contiguity hint use it to increase the vector size.
     vec = std::max(vec, op.getContiguity());
@@ -1132,7 +1137,8 @@ struct AsyncCopyLocalToGlobalOpConversion
     auto maskElements = getMaskElemsAndUpdateVeclen(
         rewriter, loc, adaptor.getMask(), op.getMask(), vec);
 
-    auto dstElems = unpackLLElements(loc, adaptor.getDst(), rewriter);
+    auto dstElems = unpackTensorElements(loc, adaptor.getDst(), rewriter,
+                                         op.getDst().getType());
 
     // If the op has a contiguity hint use it to increase the vector size.
     vec = std::max(vec, op.getContiguity());
@@ -1462,7 +1468,8 @@ struct AsyncTDMScatterOpConversion
 
     // Get the destination row indices for scatter
     SmallVector<Value> dstRowIndices =
-        unpackLLElements(loc, adaptor.getDstRowIndices(), rewriter);
+        unpackTensorElements(loc, adaptor.getDstRowIndices(), rewriter,
+                             op.getDstRowIndices().getType());
 
     auto shapePerCTA = triton::gpu::getShapePerCTA(smemTy);
 
@@ -1553,7 +1560,8 @@ struct AsyncTDMGatherOpConversion
 
     // Get the source row indices for gather
     SmallVector<Value> srcRowIndices =
-        unpackLLElements(loc, adaptor.getSrcRowIndices(), rewriter);
+        unpackTensorElements(loc, adaptor.getSrcRowIndices(), rewriter,
+                             op.getSrcRowIndices().getType());
 
     auto shapePerCTA = triton::gpu::getShapePerCTA(smemTy);
 
@@ -1632,8 +1640,9 @@ struct StoreOpConversion : public ConvertOpToLLVMPattern<triton::StoreOp>,
     unsigned vec = getVectorSize(ptr, axisAnalysisPass);
     unsigned elemsPerThread = getTotalElemsPerThread(ptr.getType());
 
-    auto ptrElems = unpackLLElements(loc, llPtr, rewriter);
-    auto valueElems = unpackLLElements(loc, llValue, rewriter);
+    auto ptrElems = unpackTensorElements(loc, llPtr, rewriter, ptr.getType());
+    auto valueElems =
+        unpackTensorElements(loc, llValue, rewriter, op.getValue().getType());
     assert(ptrElems.size() == valueElems.size());
 
     SmallVector<Value> maskElems =
@@ -1734,8 +1743,10 @@ struct BufferAtomicRMWOpConversion
     }
 
     // Get the offsets and value
-    SmallVector<Value> offsetElems = unpackLLElements(loc, llOffset, rewriter);
-    SmallVector<Value> valueElems = unpackLLElements(loc, llData, rewriter);
+    SmallVector<Value> offsetElems = unpackTensorElements(
+        loc, llOffset, rewriter, op.getOffsets().getType());
+    SmallVector<Value> valueElems =
+        unpackTensorElements(loc, llData, rewriter, data.getType());
 
     // Get the mask
     SmallVector<Value> maskElems =
@@ -1853,9 +1864,12 @@ struct BufferAtomicCASOpConversion
     unsigned vec = 1u;
 
     // Get the offsets, val, and cmp
-    SmallVector<Value> offsetElems = unpackLLElements(loc, llOffset, rewriter);
-    SmallVector<Value> valElems = unpackLLElements(loc, llVal, rewriter);
-    SmallVector<Value> cmpElems = unpackLLElements(loc, llCmp, rewriter);
+    SmallVector<Value> offsetElems = unpackTensorElements(
+        loc, llOffset, rewriter, op.getOffsets().getType());
+    SmallVector<Value> valElems =
+        unpackTensorElements(loc, llVal, rewriter, op.getVal().getType());
+    SmallVector<Value> cmpElems =
+        unpackTensorElements(loc, llCmp, rewriter, op.getCmp().getType());
 
     Value rsrcDesc = bufferEmitter.createResourceDescriptor(llPtr, llStride);
     SmallVector<Value> loadedVals;
@@ -1960,8 +1974,10 @@ struct BufferStoreOpConversion
     vec = std::max(vec, op.getContiguity());
 
     // Get the offsets and value
-    SmallVector<Value> offsetElems = unpackLLElements(loc, llOffset, rewriter);
-    SmallVector<Value> valueElems = unpackLLElements(loc, llData, rewriter);
+    SmallVector<Value> offsetElems = unpackTensorElements(
+        loc, llOffset, rewriter, op.getOffsets().getType());
+    SmallVector<Value> valueElems =
+        unpackTensorElements(loc, llData, rewriter, data.getType());
 
     // Get the mask
     SmallVector<Value> maskElems =
@@ -2019,9 +2035,12 @@ struct AtomicCASOpConversion
     Value llVal = adaptor.getVal();
 
     // prep data by unpacking to get data ready
-    auto ptrElements = unpackLLElements(loc, llPtr, rewriter);
-    auto cmpElements = unpackLLElements(loc, llCmp, rewriter);
-    auto valElements = unpackLLElements(loc, llVal, rewriter);
+    auto ptrElements =
+        unpackTensorElements(loc, llPtr, rewriter, op.getPtr().getType());
+    auto cmpElements =
+        unpackTensorElements(loc, llCmp, rewriter, op.getCmp().getType());
+    auto valElements =
+        unpackTensorElements(loc, llVal, rewriter, op.getVal().getType());
 
     auto memOrdering = op.getSem();
     auto atomicMemOrdering = getMemoryOrdering(memOrdering);
@@ -2212,11 +2231,14 @@ struct AtomicRMWOpConversion
     Value llVal = adaptor.getVal();
     Value llMask = adaptor.getMask();
 
-    auto valElements = unpackLLElements(loc, llVal, rewriter);
-    auto ptrElements = unpackLLElements(loc, llPtr, rewriter);
+    auto valElements =
+        unpackTensorElements(loc, llVal, rewriter, op.getVal().getType());
+    auto ptrElements =
+        unpackTensorElements(loc, llPtr, rewriter, op.getPtr().getType());
     SmallVector<Value> maskElements;
     if (llMask)
-      maskElements = unpackLLElements(loc, llMask, rewriter);
+      maskElements =
+          unpackTensorElements(loc, llMask, rewriter, op.getMask().getType());
 
     auto tensorTy = dyn_cast<RankedTensorType>(opResult.getType());
     Type valueElemTy =
@@ -2577,9 +2599,8 @@ struct TDMPrefetchConversion
     }
 
     // Return offsets
-    Type llvmResultStructTy = getTypeConverter()->convertType(op.getType(0));
-    Value resultStruct = packLLElements(loc, getTypeConverter(), offsets,
-                                        rewriter, llvmResultStructTy);
+    Value resultStruct = packTensorElements(loc, getTypeConverter(), offsets,
+                                            rewriter, op.getType(0));
     rewriter.replaceOp(op, {resultStruct});
     return success();
   }

--- a/third_party/amd/lib/TritonAMDGPUToLLVM/MemoryOpToLLVM.cpp
+++ b/third_party/amd/lib/TritonAMDGPUToLLVM/MemoryOpToLLVM.cpp
@@ -100,10 +100,8 @@ public:
       if (failed(result))
         continue;
 
-      auto structTy = LLVM::LLVMStructType::getLiteral(
-          ctx, SmallVector<Type>(values.size(), llvmElemTy));
       auto value =
-          packLLElements(loc, typeConverter, values, rewriter, structTy);
+          packTensorElements(loc, typeConverter, values, rewriter, dstTy);
 
       rewriter.replaceOp(op, value);
       return success();
@@ -626,7 +624,8 @@ private:
         maskSpanAffineOffset, /*affineBlockOffset=*/Value(),
         /*maskSpanAffineBlock=*/0, laneId, warpId, rewriter, targetInfo,
         ldsTransLoadParams->tileSize, lowerInst);
-    Value result = packLLElements(loc, typeConverter, outVals, rewriter, retTy);
+    Value result =
+        packTensorElements(loc, typeConverter, outVals, rewriter, retTy);
     rewriter.replaceOp(op, result);
     return success();
   }

--- a/third_party/nvidia/lib/TritonNVIDIAGPUToLLVM/ConvertLayoutOpToLLVM.cpp
+++ b/third_party/nvidia/lib/TritonNVIDIAGPUToLLVM/ConvertLayoutOpToLLVM.cpp
@@ -33,10 +33,13 @@ struct ConvertLayoutOpSwizzlingConversion
                   ConversionPatternRewriter &rewriter) const override {
     auto srcTy = op.getSrc().getType();
     auto dstTy = op.getType();
+    auto *ctx = op.getContext();
 
     LinearLayout conversion = minimalCvtLayout(srcTy, dstTy);
     LinearLayout srcLayout = toLinearLayout(srcTy);
     LinearLayout dstLayout = toLinearLayout(dstTy);
+    srcLayout = srcLayout.removeZeroBasesAlongDim(str_attr("register"));
+    dstLayout = dstLayout.removeZeroBasesAlongDim(str_attr("register"));
 
     assert(to_vector(conversion.getInDimNames()) ==
            to_vector(conversion.getOutDimNames()));
@@ -46,13 +49,13 @@ struct ConvertLayoutOpSwizzlingConversion
       auto llvmElemTy = getTypeConverter()->convertType(srcTy.getElementType());
       auto smemBase = LLVM::getSharedMemoryBase(loc, rewriter, targetInfo,
                                                 op.getOperation());
-      auto inVals = unpackLLElements(loc, adaptor.getSrc(), rewriter);
+      auto inVals = unpackUniqueTensorElements(loc, adaptor.getSrc(), rewriter);
       auto outVals =
           transferWithinBlockSwizzling(loc, rewriter, srcLayout, dstLayout,
                                        inVals, llvmElemTy, smemBase, op);
 
-      Value result =
-          packLLElements(loc, getTypeConverter(), outVals, rewriter, dstTy);
+      Value result = packUniqueTensorElements(loc, getTypeConverter(), outVals,
+                                              rewriter, dstTy);
       rewriter.replaceOp(op, result);
       return success();
     }
@@ -97,26 +100,6 @@ struct ConvertLayoutOpSwizzlingConversion
         v = b.trunc(llvmElemTy, v);
       }
       return outVals;
-    }
-
-    // Remove broadcasting in src
-    auto removeBroadcastSrc = actionRemoveBroadcastedRegs(srcLayout);
-    if (!removeBroadcastSrc.isIdentity()) {
-      auto prmtSrc = removeBroadcastSrc.apply(srcLayout);
-      auto newInVals = removeBroadcastSrc.apply(inVals);
-      return transferWithinBlockSwizzling(loc, rewriter, prmtSrc, dstLayout,
-                                          newInVals, llvmElemTy, smemBase,
-                                          sourceOp);
-    }
-
-    // Remove broadcasting in dst
-    auto removeBroadcastDst = actionRemoveBroadcastedRegs(dstLayout);
-    if (!removeBroadcastDst.isIdentity()) {
-      auto prmtDst = removeBroadcastDst.apply(dstLayout);
-      auto outVals =
-          transferWithinBlockSwizzling(loc, rewriter, srcLayout, prmtDst,
-                                       inVals, llvmElemTy, smemBase, sourceOp);
-      return broadcastAs(outVals, dstLayout);
     }
 
     // At this point we have a type that's at least 8-bit

--- a/third_party/nvidia/lib/TritonNVIDIAGPUToLLVM/DotOpToLLVM/MMAv2.cpp
+++ b/third_party/nvidia/lib/TritonNVIDIAGPUToLLVM/DotOpToLLVM/MMAv2.cpp
@@ -18,27 +18,21 @@ namespace {
 
 using ValueTableV2 = std::map<std::array<int, 3>, Value>;
 
-Value loadC(Value tensor, Value llTensor,
-            const LLVMTypeConverter *typeConverter, Location loc,
-            ConversionPatternRewriter &rewriter) {
+SmallVector<Value> loadC(Value tensor, Value llTensor, Location loc,
+                         ConversionPatternRewriter &rewriter) {
   auto b = TritonLLVMOpBuilder(loc, rewriter);
-  MLIRContext *ctx = tensor.getContext();
   auto tensorTy = cast<RankedTensorType>(tensor.getType());
   size_t fcSize = triton::gpu::getTotalElemsPerThread(tensor.getType());
 
   assert(isa<NvidiaMmaEncodingAttr>(tensorTy.getEncoding()) &&
          "Currently, we only support $c with a mma layout.");
-  // Load a normal C tensor with mma layout, that should be a
-  // LLVM::struct with fcSize elements.
-  auto structTy = cast<LLVM::LLVMStructType>(llTensor.getType());
-  assert(structTy.getBody().size() == fcSize &&
-         "DotOp's $c operand should pass the same number of values as $d in "
-         "mma layout.");
+  auto elems = unpackTensorElements(loc, llTensor, rewriter, tensorTy);
+  assert(elems.size() == fcSize);
 
   auto numMmaRets = tensorTy.getElementType().getIntOrFloatBitWidth() / 8;
   assert(numMmaRets == 8 || numMmaRets == 4 || numMmaRets == 2);
   if (numMmaRets == 8 || numMmaRets == 4) {
-    return llTensor;
+    return elems;
   } else if (numMmaRets == 2) {
     auto cPack = SmallVector<Value>();
     auto cElemTy = tensorTy.getElementType();
@@ -47,21 +41,15 @@ Value loadC(Value tensor, Value llTensor,
     for (int i = 0; i < fcSize; i += numCPackedElem) {
       Value pack = LLVM::UndefOp::create(rewriter, loc, cPackTy);
       for (int j = 0; j < numCPackedElem; ++j) {
-        pack = b.insert_element(cPackTy, pack,
-                                b.extract_val(cElemTy, llTensor, i + j),
-                                b.i32_val(j));
+        pack = b.insert_element(cPackTy, pack, elems[i + j], b.i32_val(j));
       }
       cPack.push_back(pack);
     }
 
-    Type structTy = LLVM::LLVMStructType::getLiteral(
-        ctx, SmallVector<Type>(cPack.size(), cPackTy));
-    Value result =
-        packLLElements(loc, typeConverter, cPack, rewriter, structTy);
-    return result;
+    return cPack;
   }
 
-  return llTensor;
+  return elems;
 }
 
 // The number of i32 registers owned by each thread along m, n, k dimensions.
@@ -87,7 +75,7 @@ ValueTableV2 getValuesFromDotOperandLayoutStruct(
     ConversionPatternRewriter &rewriter, Value value, int batch, int repOuter,
     int repK, RankedTensorType type, const NumRegisters &numRegisters) {
   auto b = TritonLLVMOpBuilder(loc, rewriter);
-  auto elems = unpackLLElements(loc, value, rewriter);
+  auto elems = unpackTensorElements(loc, value, rewriter, type);
   auto eltTy = typeConverter->convertType(type.getElementType());
   int offset{};
   ValueTableV2 vals;
@@ -729,11 +717,9 @@ LogicalResult convertMMAImpl(
          "Both $a and %b should be DotOperand layout.");
 
   Value cOperand = op->getOperand(2);
-  Value loadedC = loadC(cOperand, llvmC, typeConverter, loc, rewriter);
+  auto fc = loadC(cOperand, llvmC, loc, rewriter);
 
   auto tb = TritonLLVMOpBuilder(loc, rewriter);
-  MLIRContext *ctx = op->getContext();
-
   auto aTensorTy = cast<RankedTensorType>(op.getA().getType());
   auto bTensorTy = cast<RankedTensorType>(op.getB().getType());
   auto dTensorTy = cast<RankedTensorType>(op.getD().getType());
@@ -774,8 +760,6 @@ LogicalResult convertMMAImpl(
                                                 llvmB, repBatch, repN, repK,
                                                 bTensorTy, numRegisters);
 
-  auto fc = unpackLLElements(loc, loadedC, rewriter);
-
   int bitwidthRet = dTensorTy.getElementType().getIntOrFloatBitWidth();
   auto numMmaRets = bitwidthRet == 64 ? 2 : bitwidthRet / 8;
   int numCPackedElem = bitwidthRet == 64 ? 1 : 4 / numMmaRets;
@@ -815,8 +799,6 @@ LogicalResult convertMMAImpl(
   Type resElemTy = dTensorTy.getElementType();
 
   // replace with new packed result
-  Type structTy = LLVM::LLVMStructType::getLiteral(
-      ctx, SmallVector<Type>(fc.size() * numCPackedElem, resElemTy));
   SmallVector<Value> results(fc.size() * numCPackedElem);
   for (int i = 0; i < fc.size(); ++i) {
     for (int j = 0; j < numCPackedElem; ++j) {
@@ -826,7 +808,8 @@ LogicalResult convertMMAImpl(
               : tb.bitcast(fc[i], resElemTy);
     }
   }
-  Value res = packLLElements(loc, typeConverter, results, rewriter, structTy);
+  Value res =
+      packTensorElements(loc, typeConverter, results, rewriter, dTensorTy);
 
   rewriter.replaceOp(op, res);
 
@@ -926,10 +909,10 @@ LogicalResult convertMMADotScaled(triton::DotScaledOp op,
     return op.emitError(
         "unsupported MMA instruction for the given operand/result types");
 
-  SmallVector<Value> unpackedAScale =
-      unpackLLElements(op.getLoc(), adaptor.getAScale(), rewriter);
-  SmallVector<Value> unpackedBScale =
-      unpackLLElements(op.getLoc(), adaptor.getBScale(), rewriter);
+  SmallVector<Value> unpackedAScale = unpackTensorElements(
+      op.getLoc(), adaptor.getAScale(), rewriter, op.getAScale().getType());
+  SmallVector<Value> unpackedBScale = unpackTensorElements(
+      op.getLoc(), adaptor.getBScale(), rewriter, op.getBScale().getType());
 
   NumRegisters numRegisters = {2, 1, 2};
   EmitMmaCallback emit = [&](PTXBuilder &builder, int b, int m, int n, int k,

--- a/third_party/nvidia/lib/TritonNVIDIAGPUToLLVM/DotOpToLLVM/WGMMA.cpp
+++ b/third_party/nvidia/lib/TritonNVIDIAGPUToLLVM/DotOpToLLVM/WGMMA.cpp
@@ -235,7 +235,7 @@ LogicalResult convertDot(const LLVMTypeConverter *typeConverter,
     aLoader = std::move(*loader);
     transA = aLoader.getDescriptor().transposed;
   } else {
-    structA = unpackLLElements(loc, loadedA, rewriter);
+    structA = unpackTensorElements(loc, loadedA, rewriter, aTensorTy);
   }
   auto bLoader = DotOpMmaSmemLoader::build(loc, rewriter, bTensorTy, baseB,
                                            {K, N}, 1, 3, false, dTensorTy);
@@ -247,7 +247,7 @@ LogicalResult convertDot(const LLVMTypeConverter *typeConverter,
   }
   bool transB = !bLoader->getDescriptor().transposed;
 
-  auto fc = unpackLLElements(loc, loadedC, rewriter);
+  auto fc = unpackTensorElements(loc, loadedC, rewriter, dTensorTy);
 
   triton::nvgpu::WGMMAEltType eltTypeC = getMmaRetType(d);
   triton::nvgpu::WGMMAEltType eltTypeA = getMmaOperandType(a, allowTF32);
@@ -366,10 +366,8 @@ LogicalResult convertDot(const LLVMTypeConverter *typeConverter,
       unpackAccumulator(rewriter, loc, mmaResults, dTensorTy);
 
   // replace with new packed result
-  Type structTy = LLVM::LLVMStructType::getLiteral(
-      mmaEncoding.getContext(),
-      SmallVector<Type>(results.size(), dTensorTy.getElementType()));
-  auto res = packLLElements(loc, typeConverter, results, rewriter, structTy);
+  auto res =
+      packTensorElements(loc, typeConverter, results, rewriter, dTensorTy);
   rewriter.replaceOp(op, res);
   return success();
 }

--- a/third_party/nvidia/lib/TritonNVIDIAGPUToLLVM/LoadStoreOpToLLVM.cpp
+++ b/third_party/nvidia/lib/TritonNVIDIAGPUToLLVM/LoadStoreOpToLLVM.cpp
@@ -162,13 +162,14 @@ struct LoadOpConversion : public ConvertOpToLLVMPattern<triton::LoadOp>,
                        << "\n";
     }
     // Get the LLVM values for pointers
-    auto ptrElems = unpackLLElements(loc, llPtr, rewriter);
+    auto ptrElems = unpackTensorElements(loc, llPtr, rewriter, ptr.getType());
     assert(ptrElems.size() == numElems);
 
     // Get the LLVM values for mask
     SmallVector<Value> maskElems;
     if (llMask) {
-      maskElems = unpackLLElements(loc, llMask, rewriter);
+      maskElems =
+          unpackTensorElements(loc, llMask, rewriter, op.getMask().getType());
       assert(maskElems.size() == numElems);
     }
 
@@ -186,7 +187,8 @@ struct LoadOpConversion : public ConvertOpToLLVMPattern<triton::LoadOp>,
     }
     SmallVector<Value> otherElems;
     if (other) {
-      otherElems = unpackLLElements(loc, llOther, rewriter);
+      otherElems =
+          unpackTensorElements(loc, llOther, rewriter, other.getType());
     }
 
     // vectorized iteration through all the pointer/mask/other elements
@@ -337,9 +339,8 @@ struct LoadOpConversion : public ConvertOpToLLVMPattern<triton::LoadOp>,
       }
     } // end vec
 
-    Type llvmResultStructTy = typeConverter->convertType(op.getType());
-    Value resultStruct = packLLElements(loc, typeConverter, loadedVals,
-                                        rewriter, llvmResultStructTy);
+    Value resultStruct = packTensorElements(loc, typeConverter, loadedVals,
+                                            rewriter, op.getType());
     rewriter.replaceOp(op, {resultStruct});
     return success();
   }
@@ -378,8 +379,9 @@ struct StoreOpConversion : public ConvertOpToLLVMPattern<triton::StoreOp>,
     unsigned vec = getVectorSize(ptr);
     unsigned elemsPerThread = getTotalElemsPerThread(ptr.getType());
 
-    auto ptrElems = unpackLLElements(loc, llPtr, rewriter);
-    auto valueElems = unpackLLElements(loc, llValue, rewriter);
+    auto ptrElems = unpackTensorElements(loc, llPtr, rewriter, ptr.getType());
+    auto valueElems =
+        unpackTensorElements(loc, llValue, rewriter, op.getValue().getType());
     assert(ptrElems.size() == valueElems.size());
 
     // Determine the vectorization size
@@ -387,7 +389,8 @@ struct StoreOpConversion : public ConvertOpToLLVMPattern<triton::StoreOp>,
     SmallVector<Value> maskElems;
     if (llMask) {
       Value mask = op.getMask();
-      maskElems = unpackLLElements(loc, llMask, rewriter);
+      maskElems =
+          unpackTensorElements(loc, llMask, rewriter, op.getMask().getType());
       assert(valueElems.size() == maskElems.size());
 
       unsigned maskAlign = getMaskAlignment(mask);
@@ -554,9 +557,12 @@ struct AtomicCASOpConversion
     Value llCmp = adaptor.getCmp();
     Value llVal = adaptor.getVal();
 
-    auto ptrElements = unpackLLElements(loc, llPtr, rewriter);
-    auto cmpElements = unpackLLElements(loc, llCmp, rewriter);
-    auto valElements = unpackLLElements(loc, llVal, rewriter);
+    auto ptrElements =
+        unpackTensorElements(loc, llPtr, rewriter, op.getPtr().getType());
+    auto cmpElements =
+        unpackTensorElements(loc, llCmp, rewriter, op.getCmp().getType());
+    auto valElements =
+        unpackTensorElements(loc, llVal, rewriter, op.getVal().getType());
 
     auto valueTy = op.getType();
     auto tensorTy = dyn_cast<RankedTensorType>(valueTy);
@@ -708,11 +714,14 @@ public:
     Value llVal = adaptor.getVal();
     Value llMask = adaptor.getMask();
 
-    auto valElements = unpackLLElements(loc, llVal, rewriter);
-    auto ptrElements = unpackLLElements(loc, llPtr, rewriter);
+    auto valElements =
+        unpackTensorElements(loc, llVal, rewriter, op.getVal().getType());
+    auto ptrElements =
+        unpackTensorElements(loc, llPtr, rewriter, op.getPtr().getType());
     SmallVector<Value> maskElements;
     if (llMask)
-      maskElements = unpackLLElements(loc, llMask, rewriter);
+      maskElements =
+          unpackTensorElements(loc, llMask, rewriter, op.getMask().getType());
 
     auto valueTy = op.getType();
     auto tensorTy = dyn_cast<RankedTensorType>(valueTy);
@@ -980,12 +989,12 @@ struct AsyncCopyGlobalToLocalOpConversion
     Value llMask = adaptor.getMask();
 
     // %src
-    auto srcElems = unpackLLElements(loc, llSrc, rewriter);
+    auto srcElems = unpackUniqueTensorElements(loc, llSrc, rewriter);
 
     // %mask
     SmallVector<Value> maskElems;
     if (llMask) {
-      maskElems = unpackLLElements(loc, llMask, rewriter);
+      maskElems = unpackUniqueTensorElements(loc, llMask, rewriter);
       assert(srcElems.size() == maskElems.size());
     }
 
@@ -993,7 +1002,7 @@ struct AsyncCopyGlobalToLocalOpConversion
     // %other
     // SmallVector<Value> otherElems;
     // if (llOther) {
-    //   otherElems = unpackLLElements(loc, llOther, rewriter);
+    //   otherElems = unpackTensorElements(loc, llOther, rewriter);
     //   assert(srcElems.size() == otherElems.size());
     // }
 
@@ -1012,9 +1021,7 @@ struct AsyncCopyGlobalToLocalOpConversion
 
     // Remove broadcasted registers
     auto srcLayout = ttg::toLinearLayout(srcTy);
-    auto removeBroadcastSrc = actionRemoveBroadcastedRegs(srcLayout);
-    srcLayout = removeBroadcastSrc.apply(srcLayout);
-    vals = removeBroadcastSrc.apply(vals);
+    srcLayout = srcLayout.removeZeroBasesAlongDim(str_attr("register"));
 
     // We can load N elements at a time if:
     //  1. Every group of N source pointers are contiguous.  For example, if
@@ -1587,7 +1594,8 @@ static LogicalResult iterateGatherScatterIndices(
   // Select one thread in each warp to issue the gather4 messages.
   pred = b.and_(pred, LLVM::NVIDIA::createElectPredicate(loc, rewriter));
 
-  SmallVector<Value> xOffsets = unpackLLElements(loc, xOffsetsValue, rewriter);
+  SmallVector<Value> xOffsets =
+      unpackTensorElements(loc, xOffsetsValue, rewriter, xCoords.getType());
   // Lane ID doesn't matter.
   Value laneId = b.i32_val(0);
   for (auto regId : seq<unsigned>(0, xOffsets.size(), 4)) {

--- a/third_party/nvidia/lib/TritonNVIDIAGPUToLLVM/MemoryOpToLLVM.cpp
+++ b/third_party/nvidia/lib/TritonNVIDIAGPUToLLVM/MemoryOpToLLVM.cpp
@@ -160,10 +160,8 @@ public:
     if (failed(result)) {
       return failure();
     }
-    auto structTy = LLVM::LLVMStructType::getLiteral(
-        op.getLoc().getContext(), SmallVector<Type>(values.size(), llvmElemTy));
     auto value =
-        packLLElements(op.getLoc(), typeConverter, values, rewriter, structTy);
+        packTensorElements(op.getLoc(), typeConverter, values, rewriter, dstTy);
     rewriter.replaceOp(op, value);
     return success();
   }
@@ -194,7 +192,8 @@ struct LocalAllocOpConversion
         smemBase, llvmElemTy, memDescType.getRank(), op.getLoc(), rewriter);
 
     auto regLayout = toLinearLayout(regTy);
-    auto values = unpackLLElements(op.getLoc(), adaptor.getSrc(), rewriter);
+    auto values =
+        unpackTensorElements(op.getLoc(), adaptor.getSrc(), rewriter, regTy);
     auto result =
         lowerLdStMatrix(op.getLoc(), regLayout, memDescType, values, smemObj,
                         rewriter, targetInfo, getTypeConverter());
@@ -230,7 +229,8 @@ struct LocalStoreOpConversion
         op.getLoc(), adaptor.getDst(), llvmElemTy, rewriter);
 
     auto regLayout = toLinearLayout(srcTy);
-    auto values = unpackLLElements(op.getLoc(), adaptor.getSrc(), rewriter);
+    auto values =
+        unpackTensorElements(op.getLoc(), adaptor.getSrc(), rewriter, srcTy);
     auto result =
         lowerLdStMatrix(op.getLoc(), regLayout, memDescType, values, smemObj,
                         rewriter, targetInfo, getTypeConverter());
@@ -439,7 +439,8 @@ struct AsyncSharedStoreOpConversion
                             ? paddedLinearLayout(dstTy)
                             : toLinearLayout(dstTy);
     auto cvt = regLayout.invertAndCompose(sharedLayout);
-    auto values = unpackLLElements(loc, adaptor.getSrc(), rewriter);
+    auto values = unpackTensorElements(loc, adaptor.getSrc(), rewriter,
+                                       op.getSrc().getType());
     lowerAsyncSharedStore(loc, op.getContext(), cvt, values, llvmElemTy, dstTy,
                           dstMemObj, mbarrierMemObj.getBase(), mbarrierTy,
                           rewriter, targetInfo);

--- a/third_party/nvidia/lib/TritonNVIDIAGPUToLLVM/TensorMemoryToLLVM.cpp
+++ b/third_party/nvidia/lib/TritonNVIDIAGPUToLLVM/TensorMemoryToLLVM.cpp
@@ -547,9 +547,8 @@ struct TensorMemoryLoadOpConversion
         loc, rewriter, regTy, memTy, tmemBase, maxnreg, b.i1_val(true),
         llvmElemTy, {}, redOp, useAbs, useNaN);
 
-    Type structTy = getTypeConverter()->convertType(op.getType());
-    Value resultStruct =
-        packLLElements(loc, getTypeConverter(), resultVals, rewriter, structTy);
+    Value resultStruct = packTensorElements(loc, getTypeConverter(), resultVals,
+                                            rewriter, op.getType());
     // Wait insertion could be moved to the TTGIR level if needed.
     NVVM::Tcgen05WaitOp::create(rewriter, loc, NVVM::Tcgen05WaitKind::LOAD);
 
@@ -561,9 +560,8 @@ struct TensorMemoryLoadOpConversion
     SmallVector<Value> results = {resultStruct};
     if (redOp) {
       // Pack redval values into the red tensor result
-      Type redStructTy = getTypeConverter()->convertType(op.getRed().getType());
-      Value redStruct = packLLElements(loc, getTypeConverter(), redvalVals,
-                                       rewriter, redStructTy);
+      Value redStruct = packTensorElements(loc, getTypeConverter(), redvalVals,
+                                           rewriter, op.getRed().getType());
       results.push_back(redStruct);
     }
 
@@ -589,7 +587,7 @@ struct TensorMemoryStoreOpConversion
     auto regTy = cast<RankedTensorType>(op.getSrc().getType());
 
     SmallVector<Value> srcValues =
-        unpackLLElements(loc, adaptor.getSrc(), rewriter);
+        unpackTensorElements(loc, adaptor.getSrc(), rewriter, regTy);
     auto maxnreg = getContextualMaxNReg(op);
     lowerTMemLdStFromTypes(loc, rewriter, regTy, memTy, tmemBase, maxnreg, pred,
                            llvmElemTy, srcValues);
@@ -628,7 +626,7 @@ struct TensorMemoryAllocOpConversion
       auto llvmElemTy = getTypeConverter()->convertType(regTy.getElementType());
       auto maxnreg = getContextualMaxNReg(op);
       SmallVector<Value> srcValues =
-          unpackLLElements(loc, adaptor.getSrc(), rewriter);
+          unpackTensorElements(loc, adaptor.getSrc(), rewriter, regTy);
       Value ptr = b.inttoptr(base.getType(), allocAddress);
       lowerTMemLdStFromTypes(loc, rewriter, regTy, memTy, ptr, maxnreg,
                              b.i1_val(true), llvmElemTy, srcValues);


### PR DESCRIPTION

Instead of carrying duplicate values around, just generate them on
demand in each pattern. This will generate less pack/unpack IR, and
makes DCE easier for LLVM, since duplicated values are never packed into
the struct.

Add new helpers to either get the uniqued or broadcasted values from the
struct. Use the uniqued version in places where it is simple to. We can
migrate additional places to use the uniqued version over time.

---
[//]: # (BEGIN SAPLING FOOTER)
* #10731
* __->__ #10722