### PR TITLE
[NVIDIA] Optimize atomic RMWs to use `red` when result is unused

### DIFF
--- a/python/test/unit/language/test_core.py
+++ b/python/test/unit/language/test_core.py
@@ -1420,11 +1420,12 @@ def test_atomic_rmw(op, dtype_x_str, mode, sem, device):
 
     # triton kernel
     @triton.jit
-    def kernel(X, Z):
+    def kernel(X, Z, Old):
         pid = tl.program_id(0)
         x = tl.load(X + pid)
         old = GENERATE_TEST_HERE
         tl.static_assert(old.dtype == x.dtype)
+        tl.store(Old + pid, old)
 
     sem_arg = sem if sem is None else f'"{sem}"'
     kernel = patch_kernel(kernel, {'GENERATE_TEST_HERE': f'tl.atomic_{op}(Z, x, sem={sem_arg})'})
@@ -1451,7 +1452,8 @@ def test_atomic_rmw(op, dtype_x_str, mode, sem, device):
     x_tri = to_triton(x, device=device, dst_type=dst_type)
 
     z_tri = to_triton(np.array([neutral], dtype=getattr(np, dtype_x_str)), device=device, dst_type=dst_type)
-    h = kernel[(n_programs, )](x_tri, z_tri)
+    old_tri = to_triton(np.empty_like(x), device=device, dst_type=dst_type)
+    h = kernel[(n_programs, )](x_tri, z_tri, old_tri)
     # torch result
     if dst_type == 'bfloat16':
         z_ref = numpy_op(x).astype(getattr(np, dtype_x_str))

--- a/test/Conversion/tritongpu_to_llvm.mlir
+++ b/test/Conversion/tritongpu_to_llvm.mlir
@@ -1563,6 +1563,7 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, "ttg.tar
     // CHECK: llvm.inline_asm has_side_effects asm_dialect = att operand_attrs = [] "mov.u32 $0, 0x0;
     // CHECK-SAME: @$3 atom.global.gpu.relaxed.add.f32
     %0 = tt.atomic_rmw fadd, relaxed, gpu, %arg0, %arg2, %arg1 : (tensor<256x!tt.ptr<f32>, #blocked0>, tensor<256xf32, #blocked0>, tensor<256xi1, #blocked0>) -> tensor<256xf32, #blocked0>
+    tt.store %arg0, %0 : tensor<256x!tt.ptr<f32>, #blocked0>
     tt.return
   }
 }
@@ -1576,6 +1577,7 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, "ttg.tar
     // CHECK: llvm.inline_asm
     // CHECK-SAME: @$3 atom.global.gpu.relaxed.add.f32
     %0 = tt.atomic_rmw fadd, relaxed, gpu, %arg0, %arg2, %arg1 : (!tt.ptr<f32>, f32, i1) -> f32
+    tt.store %arg0, %0 : !tt.ptr<f32>
     tt.return
   }
 }
@@ -1587,10 +1589,27 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, "ttg.tar
   // CHECK-LABEL: atomic_add_f32
   tt.func @atomic_add_f32_sys_scope(%arg0 : tensor<256x!tt.ptr<f32>, #blocked0>, %arg1 : tensor<256xi1, #blocked0>, %arg2 : tensor<256xf32, #blocked0>) {
     // CHECK: llvm.inline_asm
-    // CHECK-SAME: @$3 atom.global.sys.relaxed.add.f32
+    // CHECK-SAME: red.global.sys.relaxed.add.f32
     // CHECK: llvm.inline_asm
-    // CHECK-SAME: @$3 atom.global.sys.relaxed.add.f32
+    // CHECK-SAME: red.global.sys.relaxed.add.f32
     %0 = tt.atomic_rmw fadd, relaxed, sys, %arg0, %arg2, %arg1 : (tensor<256x!tt.ptr<f32>, #blocked0>, tensor<256xf32, #blocked0>, tensor<256xi1, #blocked0>) -> tensor<256xf32, #blocked0>
+    tt.return
+  }
+}
+
+// -----
+
+module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, "ttg.target" = "cuda:80"} {
+  // CHECK-LABEL: atomic_semantics_dead_result
+  tt.func @atomic_semantics_dead_result(%ptr : !tt.ptr<f32>, %mask : i1, %val : f32) {
+    // CHECK: red.global.gpu.relaxed.add.f32
+    %0 = tt.atomic_rmw fadd, relaxed, gpu, %ptr, %val, %mask : (!tt.ptr<f32>, f32, i1) -> f32
+    // CHECK: red.global.gpu.release.add.f32
+    %1 = tt.atomic_rmw fadd, release, gpu, %ptr, %val, %mask : (!tt.ptr<f32>, f32, i1) -> f32
+    // CHECK: atom.global.gpu.acquire.add.f32
+    %2 = tt.atomic_rmw fadd, acquire, gpu, %ptr, %val, %mask : (!tt.ptr<f32>, f32, i1) -> f32
+    // CHECK: atom.global.gpu.acq_rel.add.f32
+    %3 = tt.atomic_rmw fadd, acq_rel, gpu, %ptr, %val, %mask : (!tt.ptr<f32>, f32, i1) -> f32
     tt.return
   }
 }
@@ -1616,6 +1635,7 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, "ttg.tar
 module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, "ttg.target" = "cuda:80"} {
   // CHECK-LABEL: atomic_add_use_result_no_broadcasting
   tt.func @atomic_add_use_result_no_broadcasting(%arg0 : tensor<128x!tt.ptr<f32>, #blocked0>, %arg1 : tensor<128xi1, #blocked0>, %arg2 : tensor<128xf32, #blocked0>) {
+    // CHECK: atom.global.sys.relaxed.add.f32
     %0 = tt.atomic_rmw fadd, relaxed, sys, %arg0, %arg2, %arg1 : (tensor<128x!tt.ptr<f32>, #blocked0>, tensor<128xf32, #blocked0>, tensor<128xi1, #blocked0>) -> tensor<128xf32, #blocked0>
     // CHECK-NOT: st.shared
     // CHECK-NOT: nvvm.barrier

--- a/third_party/nvidia/lib/TritonNVIDIAGPUToLLVM/LoadStoreOpToLLVM.cpp
+++ b/third_party/nvidia/lib/TritonNVIDIAGPUToLLVM/LoadStoreOpToLLVM.cpp
@@ -916,12 +916,12 @@ public:
       rmwVals.reserve(vec > 1 ? vec : packed);
       for (unsigned ii = 0; ii < (vec > 1 ? vec : packed); ++ii)
         rmwVals.push_back(valElements[i + ii]);
-      auto old = NVIDIA::emitPtxAtomicRMW(rewriter, loc, valueElemTy, rmwPtr,
-                                          rmwVals, atomicRmwAttr, op.getSem(),
-                                          op.getScope(), pred, vec, packed,
-                                          NVIDIA::PtxAtomicAddrSpace::Global,
-                                          useRed ? NVIDIA::PtxAtomicInstr::Red
-                                                 : NVIDIA::PtxAtomicInstr::Atom);
+      auto old = NVIDIA::emitPtxAtomicRMWImpl(
+          rewriter, loc, valueElemTy, rmwPtr, rmwVals, atomicRmwAttr,
+          op.getSem(), stringifyMemSyncScope(op.getScope()).str(), pred, vec,
+          packed, NVIDIA::PtxAtomicAddrSpace::Global,
+          useRed ? NVIDIA::PtxAtomicInstr::Red
+                 : NVIDIA::PtxAtomicInstr::Atom);
       if (failed(old))
         return failure();
       if (useRed)

--- a/third_party/nvidia/lib/TritonNVIDIAGPUToLLVM/LoadStoreOpToLLVM.cpp
+++ b/third_party/nvidia/lib/TritonNVIDIAGPUToLLVM/LoadStoreOpToLLVM.cpp
@@ -700,6 +700,10 @@ public:
     int numCTAs = triton::gpu::TritonGPUDialect::getNumCTAs(moduleOp);
 
     auto atomicRmwAttr = op.getAtomicRmwOp();
+    const bool useRed =
+        op.getResult().use_empty() && atomicRmwAttr != RMWOp::XCHG &&
+        (op.getSem() == MemSemantic::RELAXED ||
+         op.getSem() == MemSemantic::RELEASE);
 
     Value val = op.getVal();
     Value ptr = op.getPtr();
@@ -767,8 +771,9 @@ public:
             {triton::MemSyncScope::GPU, triton::nvgpu::MemSyncScope::GPU},
             {triton::MemSyncScope::SYSTEM,
              triton::nvgpu::MemSyncScope::SYSTEM}};
-    const bool doPTXLDPromotion = isPromotableToNVPTXLD(op) && vec == 1 &&
-                                  packed == 1 && ScopeMap.count(op.getScope());
+    const bool doPTXLDPromotion =
+        !useRed && isPromotableToNVPTXLD(op) && vec == 1 && packed == 1 &&
+        ScopeMap.count(op.getScope());
 
     for (size_t i = 0; i < elemsPerThread; i += vec * packed) {
       if (auto canonicalStart = getCanonicalIndex(i, regMask);
@@ -913,9 +918,14 @@ public:
         rmwVals.push_back(valElements[i + ii]);
       auto old = NVIDIA::emitPtxAtomicRMW(rewriter, loc, valueElemTy, rmwPtr,
                                           rmwVals, atomicRmwAttr, op.getSem(),
-                                          op.getScope(), pred, vec, packed);
+                                          op.getScope(), pred, vec, packed,
+                                          NVIDIA::PtxAtomicAddrSpace::Global,
+                                          useRed ? NVIDIA::PtxAtomicInstr::Red
+                                                 : NVIDIA::PtxAtomicInstr::Atom);
       if (failed(old))
         return failure();
+      if (useRed)
+        continue;
       if (tensorTy) {
         Value ret = *old;
         if (vec > 1) {
@@ -946,6 +956,10 @@ public:
         rewriter.replaceOp(op, {ret});
         return success();
       }
+    }
+    if (useRed) {
+      rewriter.eraseOp(op);
+      return success();
     }
     finalizeTensorAtomicResults(op, tensorTy, rewriter, resultVals, valueElemTy,
                                 b, threadPred, targetInfo, getTypeConverter());

--- a/third_party/nvidia/lib/TritonNVIDIAGPUToLLVM/LoadStoreOpToLLVM.cpp
+++ b/third_party/nvidia/lib/TritonNVIDIAGPUToLLVM/LoadStoreOpToLLVM.cpp
@@ -700,10 +700,10 @@ public:
     int numCTAs = triton::gpu::TritonGPUDialect::getNumCTAs(moduleOp);
 
     auto atomicRmwAttr = op.getAtomicRmwOp();
-    const bool useRed =
-        op.getResult().use_empty() && atomicRmwAttr != RMWOp::XCHG &&
-        (op.getSem() == MemSemantic::RELAXED ||
-         op.getSem() == MemSemantic::RELEASE);
+    const bool useRed = op.getResult().use_empty() &&
+                        atomicRmwAttr != RMWOp::XCHG &&
+                        (op.getSem() == MemSemantic::RELAXED ||
+                         op.getSem() == MemSemantic::RELEASE);
 
     Value val = op.getVal();
     Value ptr = op.getPtr();
@@ -771,9 +771,9 @@ public:
             {triton::MemSyncScope::GPU, triton::nvgpu::MemSyncScope::GPU},
             {triton::MemSyncScope::SYSTEM,
              triton::nvgpu::MemSyncScope::SYSTEM}};
-    const bool doPTXLDPromotion =
-        !useRed && isPromotableToNVPTXLD(op) && vec == 1 && packed == 1 &&
-        ScopeMap.count(op.getScope());
+    const bool doPTXLDPromotion = !useRed && isPromotableToNVPTXLD(op) &&
+                                  vec == 1 && packed == 1 &&
+                                  ScopeMap.count(op.getScope());
 
     for (size_t i = 0; i < elemsPerThread; i += vec * packed) {
       if (auto canonicalStart = getCanonicalIndex(i, regMask);
@@ -920,8 +920,7 @@ public:
           rewriter, loc, valueElemTy, rmwPtr, rmwVals, atomicRmwAttr,
           op.getSem(), stringifyMemSyncScope(op.getScope()).str(), pred, vec,
           packed, NVIDIA::PtxAtomicAddrSpace::Global,
-          useRed ? NVIDIA::PtxAtomicInstr::Red
-                 : NVIDIA::PtxAtomicInstr::Atom);
+          useRed ? NVIDIA::PtxAtomicInstr::Red : NVIDIA::PtxAtomicInstr::Atom);
       if (failed(old))
         return failure();
       if (useRed)


### PR DESCRIPTION
The ptx `atom` instruction has additional latency due to the read-back of the old value. If this isn't used, we can emit a `red` instead.

Note: There is a slight caveat that this is not equivalent if you use an acquire fence after a relaxed/release write, but since we don't officially have fences I think this is okay.