### PR TITLE
[DOC] Specify that do_bench* return values are in milliseconds

### DIFF
--- a/python/triton/testing.py
+++ b/python/triton/testing.py
@@ -128,7 +128,8 @@ def do_bench_cudagraph(fn, rep=20, grad_to_none=None, quantiles=None, return_mod
     :type grad_to_none: torch.tensor, optional
     :param return_mode: The statistical measure to return. Options are "min", "max", "mean", "median", or "all". Default is "mean".
     :type return_mode: str
-    :return: The runtime(s) in milliseconds, as a single float or, if ``quantiles`` is set, a list of floats.
+    :return: The runtime(s) in milliseconds: a single float for a scalar ``return_mode``, or a list of floats if ``quantiles`` is set or ``return_mode="all"``.
+    :rtype: float | list[float]
     """
     import torch
 
@@ -203,7 +204,8 @@ def do_bench_cudagraph_proton(fn, rep=20, grad_to_none=None, quantiles=None, ret
     :type grad_to_none: torch.tensor, optional
     :param return_mode: The statistical measure to return. Options are "min", "max", "mean", "median", or "all". Default is "mean".
     :type return_mode: str
-    :return: The runtime(s) in milliseconds, as a single float or, if ``quantiles`` is set, a list of floats.
+    :return: The runtime(s) in milliseconds: a single float for a scalar ``return_mode``, or a list of floats if ``quantiles`` is set or ``return_mode="all"``.
+    :rtype: float | list[float]
     """
     assert return_mode in ["min", "max", "mean", "median", "all"]
 
@@ -284,8 +286,7 @@ def do_bench(fn, warmup=25, rep=100, grad_to_none=None, quantiles=None, return_m
         the fastest and slowest run respectively. ``"all"`` returns the raw list of
         per-run timings in ms. Default is ``"mean"``.
     :type return_mode: str
-    :return: Runtimes in milliseconds: a single float by default, a list of floats if ``quantiles`` is provided,
-        or a list of all per-run timings if ``return_mode="all"``.
+    :return: The runtime(s) in milliseconds: a single float for a scalar ``return_mode``, or a list of floats if ``quantiles`` is set or ``return_mode="all"``.
     :rtype: float | list[float]
     """
     assert return_mode in ["min", "max", "mean", "median", "all"]
@@ -357,7 +358,8 @@ def do_bench_proton(fn, warmup=25, rep=100, grad_to_none=None, quantiles=None, r
     :type quantiles: list[float], optional
     :param return_mode: The statistical measure to return. Options are "min", "max", "mean", "median", or "all". Default is "mean".
     :type return_mode: str
-    :return: The runtime(s) in milliseconds, as a single float or, if ``quantiles`` is set, a list of floats.
+    :return: The runtime(s) in milliseconds: a single float for a scalar ``return_mode``, or a list of floats if ``quantiles`` is set or ``return_mode="all"``.
+    :rtype: float | list[float]
     """
     assert return_mode in ["min", "max", "mean", "median", "all"]
 

--- a/python/triton/testing.py
+++ b/python/triton/testing.py
@@ -128,6 +128,7 @@ def do_bench_cudagraph(fn, rep=20, grad_to_none=None, quantiles=None, return_mod
     :type grad_to_none: torch.tensor, optional
     :param return_mode: The statistical measure to return. Options are "min", "max", "mean", "median", or "all". Default is "mean".
     :type return_mode: str
+    :return: The runtime(s) in milliseconds, as a single float or, if ``quantiles`` is set, a list of floats.
     """
     import torch
 
@@ -202,6 +203,7 @@ def do_bench_cudagraph_proton(fn, rep=20, grad_to_none=None, quantiles=None, ret
     :type grad_to_none: torch.tensor, optional
     :param return_mode: The statistical measure to return. Options are "min", "max", "mean", "median", or "all". Default is "mean".
     :type return_mode: str
+    :return: The runtime(s) in milliseconds, as a single float or, if ``quantiles`` is set, a list of floats.
     """
     assert return_mode in ["min", "max", "mean", "median", "all"]
 
@@ -262,7 +264,7 @@ def do_bench_cudagraph_proton(fn, rep=20, grad_to_none=None, quantiles=None, ret
 
 def do_bench(fn, warmup=25, rep=100, grad_to_none=None, quantiles=None, return_mode="mean"):
     """
-    Benchmark the runtime of the provided function. By default, returns the mean runtime of :code:`fn` as a single float.
+    Benchmark the runtime of the provided function. By default, returns the mean runtime (in milliseconds) of :code:`fn` as a single float.
 
     :param fn: Function to benchmark
     :type fn: Callable
@@ -282,7 +284,7 @@ def do_bench(fn, warmup=25, rep=100, grad_to_none=None, quantiles=None, return_m
         the fastest and slowest run respectively. ``"all"`` returns the raw list of
         per-run timings in ms. Default is ``"mean"``.
     :type return_mode: str
-    :return: A single float by default, a list of floats if ``quantiles`` is provided,
+    :return: Runtimes in milliseconds: a single float by default, a list of floats if ``quantiles`` is provided,
         or a list of all per-run timings if ``return_mode="all"``.
     :rtype: float | list[float]
     """
@@ -355,6 +357,7 @@ def do_bench_proton(fn, warmup=25, rep=100, grad_to_none=None, quantiles=None, r
     :type quantiles: list[float], optional
     :param return_mode: The statistical measure to return. Options are "min", "max", "mean", "median", or "all". Default is "mean".
     :type return_mode: str
+    :return: The runtime(s) in milliseconds, as a single float or, if ``quantiles`` is set, a list of floats.
     """
     assert return_mode in ["min", "max", "mean", "median", "all"]
 


### PR DESCRIPTION
## Summary

The `do_bench*` benchmarking functions return timings in milliseconds, but the docstrings did not say so. For example `do_bench` said "returns the mean runtime of `fn` as a single float" without the unit (#10700).

This adds the unit (milliseconds) to the return description of `do_bench`, `do_bench_cudagraph`, `do_bench_cudagraph_proton`, and `do_bench_proton`. The values are already in ms in all paths (CUDA event `elapsed_time` returns ms, and the Proton path divides ns by 1e6).

No behavior change.

Closes #10700
