### PR TITLE
Keep broadcasting in slice encoding

### DIFF
--- a/lib/Conversion/TritonGPUToLLVM/ReduceOpToLLVM.cpp
+++ b/lib/Conversion/TritonGPUToLLVM/ReduceOpToLLVM.cpp
@@ -42,7 +42,7 @@ public:
 
     // Remove block as we don't currently support it
     LinearLayout regLl = triton::gpu::toLinearLayout(helper.getSrcTy());
-    // Remove broadcasting in registers as SliceLayout removes them
+    // Canonicalize the reduction to unique register values.
     regLl = regLl.removeZeroBasesAlongDim(str_attr("register"));
 
     // First reduce all the values along axis within each thread.
@@ -92,6 +92,7 @@ public:
     if (auto resultTy =
             dyn_cast<RankedTensorType>(op.getResult()[0].getType())) {
       auto outputLayout = triton::gpu::toLinearLayout(resultTy);
+      outputLayout = outputLayout.removeZeroBasesAlongDim(str_attr("register"));
       if (regLl != outputLayout) {
         // Reuse the shmem
         sync(rewriter, loc, lastCvtCrossesCTAs, op);

--- a/lib/Conversion/TritonGPUToLLVM/ViewOpToLLVM.cpp
+++ b/lib/Conversion/TritonGPUToLLVM/ViewOpToLLVM.cpp
@@ -286,6 +286,7 @@ struct ExpandDimsOpConversion : public ConvertOpToLLVMPattern<ExpandDimsOp> {
   LogicalResult
   matchAndRewrite(ExpandDimsOp op, OpAdaptor adaptor,
                   ConversionPatternRewriter &rewriter) const override {
+    assert(!isExpensiveView(op.getSrc().getType(), op.getType()));
     rewriter.replaceOp(op, adaptor.getSrc());
     return success();
   }

--- a/lib/Dialect/TritonGPU/IR/LinearLayoutConversions.cpp
+++ b/lib/Dialect/TritonGPU/IR/LinearLayoutConversions.cpp
@@ -1139,27 +1139,12 @@ DotOperandEncodingAttr::toLinearLayout(ArrayRef<int64_t> shape) const {
 }
 
 LinearLayout SliceEncodingAttr::toLinearLayout(ArrayRef<int64_t> shape) const {
-  MLIRContext *ctx = getContext();
-
   // First compute the linear layout for this layout's parent.
   SmallVector<int64_t> parentShape(shape);
   parentShape.insert(parentShape.begin() + getDim(), 1);
   LinearLayout parentLL = triton::gpu::toLinearLayout(parentShape, getParent());
 
-  auto sliceLL = removeStandardDim(parentLL, getDim());
-
-  // Step 3: Along the "register" dim, remove any all-zero bases.
-  auto bases = sliceLL.getBases();
-  std::vector<std::vector<int>> newRegBases;
-  for (const auto &basis : bases[S("register")]) {
-    if (llvm::any_of(basis, [](int b) { return b != 0; })) {
-      newRegBases.push_back(basis);
-    }
-  }
-  bases[S("register")] = newRegBases;
-
-  return LinearLayout(std::move(bases),
-                      llvm::to_vector(sliceLL.getOutDimNames()));
+  return removeStandardDim(parentLL, getDim());
 }
 
 LinearLayout tensorMemoryToLinearLayout(ArrayRef<int64_t> shape,

--- a/unittest/Dialect/TritonGPU/LinearLayoutConversionsTest.cpp
+++ b/unittest/Dialect/TritonGPU/LinearLayoutConversionsTest.cpp
@@ -883,7 +883,7 @@ TEST_F(LinearLayoutConversionsTest, SliceDot) {
   EXPECT_EQ(toLinearLayout({16}, sliceV2),
             LinearLayout(
                 {
-                    {S("register"), {{8}}},
+                    {S("register"), {{0}, {0}, {0}, {8}, {0}}},
                     {S("lane"), {{0}, {0}, {1}, {2}, {4}}},
                     {S("warp"), {}},
                     {S("block"), {}},
@@ -898,7 +898,7 @@ TEST_F(LinearLayoutConversionsTest, SliceDot) {
   EXPECT_EQ(toLinearLayout({16}, sliceV3),
             LinearLayout(
                 {
-                    {S("register"), {{1}, {8}}},
+                    {S("register"), {{1}, {0}, {8}}},
                     {S("lane"), {{2}, {4}, {0}, {0}, {0}}},
                     {S("warp"), {{0}, {0}}},
                     {S("block"), {}},
@@ -2801,13 +2801,13 @@ TEST_F(LinearLayoutConversionsTest, WMMA_v3_2x4Warps_rhs) {
 TEST_F(LinearLayoutConversionsTest, SliceOfBlocked) {
   auto parent = blocked({2, 4}, {4, 2}, {2, 2}, {2, 2}, {2, 2}, {1, 0}, {1, 0});
   EXPECT_EQ(toLinearLayout({128}, slice(parent, 0)),
-            LinearLayout({{S("register"), {{1}, {2}, {16}, {32}}},
+            LinearLayout({{S("register"), {{1}, {2}, {0}, {16}, {32}}},
                           {S("lane"), {{4}, {0}, {0}}},
                           {S("warp"), {{8}, {0}}},
                           {S("block"), {{64}, {0}}}},
                          {S("dim0")}));
   EXPECT_EQ(toLinearLayout({128}, slice(parent, 1)),
-            LinearLayout({{S("register"), {{1}, {16}, {32}}},
+            LinearLayout({{S("register"), {{0}, {0}, {1}, {16}, {32}}},
                           {S("lane"), {{0}, {2}, {4}}},
                           {S("warp"), {{0}, {8}}},
                           {S("block"), {{0}, {64}}}},
@@ -2817,7 +2817,7 @@ TEST_F(LinearLayoutConversionsTest, SliceOfBlocked) {
 TEST_F(LinearLayoutConversionsTest, SliceWithShape1) {
   auto parent = blocked({1, 4}, {8, 4}, {2, 2}, {1, 1}, {1, 1}, {0, 1}, {1, 0});
   EXPECT_EQ(toLinearLayout({1}, slice(parent, 0)),
-            LinearLayout({{S("register"), {}},
+            LinearLayout({{S("register"), {{0}, {0}}},
                           {S("lane"), {{0}, {0}, {0}, {0}, {0}}},
                           {S("warp"), {{0}, {0}}},
                           {S("block"), {}}},
@@ -2830,7 +2830,7 @@ TEST_F(LinearLayoutConversionsTest, Slice4D) {
   EXPECT_EQ(toLinearLayout({2, 1, 1}, slice(parent, 3)),
             LinearLayout(
                 {
-                    {S("register"), {}},
+                    {S("register"), {{0, 0, 0}, {0, 0, 0}}},
                     {S("lane"),
                      {{0, 0, 0}, {0, 0, 0}, {0, 0, 0}, {0, 0, 0}, {1, 0, 0}}},
                     {S("warp"), {{0, 0, 0}, {0, 0, 0}, {0, 0, 0}}},
@@ -2842,25 +2842,25 @@ TEST_F(LinearLayoutConversionsTest, Slice4D) {
 TEST_F(LinearLayoutConversionsTest, SliceOfMmaV2) {
   auto parent = mma(2, 0, {16, 8}, {2, 2}, {1, 1}, {1, 1}, {0, 1});
   EXPECT_EQ(toLinearLayout({16}, slice(parent, 0)),
-            LinearLayout({{S("register"), {{1}}},
+            LinearLayout({{S("register"), {{1}, {0}}},
                           {S("lane"), {{2}, {4}, {0}, {0}, {0}}},
                           {S("warp"), {{8}, {0}}},
                           {S("block"), {}}},
                          {S("dim0")}));
   EXPECT_EQ(toLinearLayout({128}, slice(parent, 0)),
-            LinearLayout({{S("register"), {{1}, {16}, {32}, {64}}},
+            LinearLayout({{S("register"), {{1}, {0}, {16}, {32}, {64}}},
                           {S("lane"), {{2}, {4}, {0}, {0}, {0}}},
                           {S("warp"), {{8}, {0}}},
                           {S("block"), {}}},
                          {S("dim0")}));
   EXPECT_EQ(toLinearLayout({8}, slice(parent, 1)),
-            LinearLayout({{S("register"), {}},
+            LinearLayout({{S("register"), {{0}, {0}}},
                           {S("lane"), {{0}, {0}, {1}, {2}, {4}}},
                           {S("warp"), {{0}, {0}}},
                           {S("block"), {}}},
                          {S("dim0")}));
   EXPECT_EQ(toLinearLayout({128}, slice(parent, 1)),
-            LinearLayout({{S("register"), {{8}, {32}, {64}}},
+            LinearLayout({{S("register"), {{0}, {8}, {32}, {64}}},
                           {S("lane"), {{0}, {0}, {1}, {2}, {4}}},
                           {S("warp"), {{0}, {16}}},
                           {S("block"), {}}},


### PR DESCRIPTION

Slice encoding currently discards broadcasting, which makes expand dims
behave differently from other view ops. Preserve the zero register bases
when removing the sliced dimension so equivalent views retain the same
layout.

Lower reductions and expand dims using unique register values so the
broadcast bases do not inflate the LLVM struct.

---
[//]: # (BEGIN SAPLING FOOTER)
* #10806
* #10421
* #10797
* #10799
* #10807
* #10796
* __->__ #10731