### PR TITLE
[BACKEND] Remove host LLVM target dependencies

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -394,26 +394,6 @@ if(TRITON_BUILD_PYTHON_MODULE)
     Python3::Module
     nanobind-static
   )
-  if(CMAKE_SYSTEM_PROCESSOR MATCHES "aarch64" OR # Linux arm64
-     CMAKE_SYSTEM_PROCESSOR MATCHES "arm64" OR # macOS arm64
-     CMAKE_OSX_ARCHITECTURES MATCHES "arm64")  # also macOS arm64
-      list(APPEND TRITON_LIBRARIES
-          LLVMAArch64CodeGen
-          LLVMAArch64AsmParser
-      )
-  elseif(CMAKE_SYSTEM_PROCESSOR MATCHES "x86_64" OR CMAKE_SYSTEM_PROCESSOR MATCHES "AMD64")
-      list(APPEND TRITON_LIBRARIES
-          LLVMX86CodeGen
-          LLVMX86AsmParser
-      )
-  elseif(CMAKE_SYSTEM_PROCESSOR MATCHES "ppc64le")
-      list(APPEND TRITON_LIBRARIES
-        LLVMPowerPCAsmParser
-        LLVMPowerPCCodeGen
-      )
-  else()
-    message(FATAL_ERROR "LLVM codegen/ASM parser libs: This HW architecture (${CMAKE_SYSTEM_PROCESSOR}) is not configured in cmake lib dependencies.")
-  endif()
 
   # Define triton library
   string(JOIN "," TRITON_BACKENDS_TUPLE ${TRITON_CODEGEN_BACKENDS})

--- a/python/src/llvm.cc
+++ b/python/src/llvm.cc
@@ -902,11 +902,18 @@ void init_triton_llvm(py::module_ &m) {
   m.def("init_targets", []() {
     static std::once_flag init_flag;
     std::call_once(init_flag, []() {
-      llvm::InitializeAllTargetInfos();
-      llvm::InitializeAllTargets();
-      llvm::InitializeAllTargetMCs();
-      llvm::InitializeAllAsmParsers();
-      llvm::InitializeAllAsmPrinters();
+      // Initialize only the GPU targets Triton emits code for. Initializing all
+      // targets would also require linking LLVM's host target libraries.
+      LLVMInitializeNVPTXTargetInfo();
+      LLVMInitializeNVPTXTarget();
+      LLVMInitializeNVPTXTargetMC();
+      LLVMInitializeNVPTXAsmPrinter();
+
+      LLVMInitializeAMDGPUTargetInfo();
+      LLVMInitializeAMDGPUTarget();
+      LLVMInitializeAMDGPUTargetMC();
+      LLVMInitializeAMDGPUAsmParser();
+      LLVMInitializeAMDGPUAsmPrinter();
     });
     // Disable LLVM's internal parallelism. Triton kernels produce small LLVM
     // modules where pass-level parallelism is not beneficial, and LLVM's global


### PR DESCRIPTION
This removes the host-architecture LLVM target libraries from the Python extension's explicit link dependencies. Triton now initializes only the NVPTX and AMDGPU target components, which are the targets the compiler emits.

The previous `InitializeAllTargets` calls made target initialization depend on whichever host backend was configured into LLVM and required a hardcoded `CMAKE_SYSTEM_PROCESSOR` switch. This prevented builds on new CPU architectures despite Triton having no host codegen requirement.

Validated with a full `make` build, `pre-commit run -a`, and LLVM-to-assembly smoke tests for `nvptx64-nvidia-cuda` and `amdgcn-amd-amdhsa`.

Addresses https://github.com/triton-lang/triton/discussions/10728