### PR TITLE
[Backend] Recognise reversed operand-argument mapping in ReduceOp::getSingleCombiner for commutative combiners

### DIFF
--- a/lib/Dialect/Triton/IR/Ops.cpp
+++ b/lib/Dialect/Triton/IR/Ops.cpp
@@ -656,8 +656,13 @@ llvm::SmallVector<Type> ReduceOp::getElementTypes() {
   if (!reduceOp || reduceOp->getNumOperands() != 2 ||
       reduceOp->getNumResults() != 1)
     return nullptr;
-  if (reduceOp->getOperand(0) != block->getArgument(0) ||
-      reduceOp->getOperand(1) != block->getArgument(1))
+  Value arg0 = block->getArgument(0), arg1 = block->getArgument(1);
+  Value lhs = reduceOp->getOperand(0), rhs = reduceOp->getOperand(1);
+  // For commutative combiners, the reversed argument-operand mapping is
+  // equivalent.
+  bool reversedMapping = (lhs == arg1 && rhs == arg0) &&
+                         reduceOp->hasTrait<OpTrait::IsCommutative>();
+  if (!(lhs == arg0 && rhs == arg1) && !reversedMapping)
     return nullptr;
 
   return reduceOp;

--- a/test/Conversion/amd/tritongpu_to_llvm.mlir
+++ b/test/Conversion/amd/tritongpu_to_llvm.mlir
@@ -261,23 +261,31 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 1 : i32, "ttg.thr
 module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 1 : i32, "ttg.threads-per-warp" = 64 : i32} {
   // CHECK-LABEL: reduce_dpp_max_commuted
   tt.func @reduce_dpp_max_commuted(%arg0: tensor<64xf32, #blocked3>) {
-    // CHECK: rocdl.ds_bpermute
-    // CHECK: llvm.intr.maxnum
-    // CHECK: rocdl.ds_bpermute
-    // CHECK: llvm.intr.maxnum
     // CHECK: rocdl.update.dpp
-    // CHECK-SAME: with 296, 15, 15, true : i32
-    // CHECK: llvm.intr.maxnum
-    // CHECK: rocdl.update.dpp
-    // CHECK-SAME: with 321, 15, 15, true : i32
-    // CHECK: rocdl.update.dpp
-    // CHECK-SAME: with 27, 15, 15, true : i32
-    // CHECK: llvm.intr.maxnum
-    // CHECK: rocdl.update.dpp
-    // CHECK-SAME: with 78, 15, 15, true : i32
-    // CHECK: llvm.intr.maxnum
-    // CHECK: rocdl.update.dpp
-    // CHECK-SAME: with 177, 15, 15, true : i32
+    // CHECK-SAME: with 280, 15, 15, true : f32
+    // CHECK-NEXT: llvm.intr.maxnum
+
+    // CHECK-NEXT: rocdl.update.dpp
+    // CHECK-SAME: with 276, 15, 15, true : f32
+    // CHECK-NEXT: llvm.intr.maxnum
+
+    // CHECK-NEXT: rocdl.update.dpp
+    // CHECK-SAME: with 274, 15, 15, true : f32
+    // CHECK-NEXT: llvm.intr.maxnum
+
+    // CHECK-NEXT: rocdl.update.dpp
+    // CHECK-SAME: with 273, 15, 15, true : f32
+    // CHECK-NEXT: llvm.intr.maxnum
+
+    // CHECK-NEXT: rocdl.update.dpp
+    // CHECK-SAME: with 322, 10, 15, true : f32
+    // CHECK-NEXT: llvm.intr.maxnum
+
+    // CHECK-NEXT: rocdl.update.dpp
+    // CHECK-SAME: with 323, 15, 15, true : f32
+    // CHECK-NEXT: llvm.intr.maxnum
+
+    // CHECK: rocdl.readlane
     %0 = "tt.reduce"(%arg0) <{axis = 0 : i32}> ({
     ^bb0(%arg1: f32, %arg2: f32):
       %1 = arith.maxnumf %arg2, %arg1 : f32
@@ -761,11 +769,7 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, "ttg.thr
 
 // GFX950-LABEL: reduce_16x16_commuted
 // GFX950: llvm.call_intrinsic "llvm.amdgcn.permlane32.swap"
-// GFX950: llvm.icmp "eq"
-// GFX950: llvm.select
 // GFX950: llvm.call_intrinsic "llvm.amdgcn.permlane16.swap"
-// GFX950: llvm.icmp "eq"
-// GFX950: llvm.select
 module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, "ttg.threads-per-warp" = 64 : i32} {
   tt.func @reduce_16x16_commuted(%arg0: tensor<64x16xf32, #ttg.amd_mfma<{versionMajor = 4, versionMinor = 0, warpsPerCTA = [4, 1], instrShape = [16, 16, 16], isTransposed = true}>>){
 %1 = "tt.reduce"(%arg0) <{axis = 1 : i32}> ({

--- a/test/Conversion/amd/tritongpu_to_llvm.mlir
+++ b/test/Conversion/amd/tritongpu_to_llvm.mlir
@@ -257,6 +257,37 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 1 : i32, "ttg.thr
 }
 
 // -----
+#blocked3 = #ttg.blocked<{sizePerThread = [1], threadsPerWarp = [64], warpsPerCTA = [1], order = [0]}>
+module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 1 : i32, "ttg.threads-per-warp" = 64 : i32} {
+  // CHECK-LABEL: reduce_dpp_max_commuted
+  tt.func @reduce_dpp_max_commuted(%arg0: tensor<64xf32, #blocked3>) {
+    // CHECK: rocdl.ds_bpermute
+    // CHECK: llvm.intr.maxnum
+    // CHECK: rocdl.ds_bpermute
+    // CHECK: llvm.intr.maxnum
+    // CHECK: rocdl.update.dpp
+    // CHECK-SAME: with 296, 15, 15, true : i32
+    // CHECK: llvm.intr.maxnum
+    // CHECK: rocdl.update.dpp
+    // CHECK-SAME: with 321, 15, 15, true : i32
+    // CHECK: rocdl.update.dpp
+    // CHECK-SAME: with 27, 15, 15, true : i32
+    // CHECK: llvm.intr.maxnum
+    // CHECK: rocdl.update.dpp
+    // CHECK-SAME: with 78, 15, 15, true : i32
+    // CHECK: llvm.intr.maxnum
+    // CHECK: rocdl.update.dpp
+    // CHECK-SAME: with 177, 15, 15, true : i32
+    %0 = "tt.reduce"(%arg0) <{axis = 0 : i32}> ({
+    ^bb0(%arg1: f32, %arg2: f32):
+      %1 = arith.maxnumf %arg2, %arg1 : f32
+      tt.reduce.return %1 : f32
+    }) : (tensor<64xf32, #blocked3>) -> f32
+    tt.return
+  }
+}
+
+// -----
 
 #blocked4 = #ttg.blocked<{sizePerThread = [1], threadsPerWarp = [64], warpsPerCTA = [1], order = [0]}>
 module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 1 : i32, "ttg.threads-per-warp" = 64 : i32} {
@@ -720,6 +751,26 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, "ttg.thr
 %1 = "tt.reduce"(%arg0) <{axis = 1 : i32}> ({
 ^bb0(%arg24: f32, %arg25: f32):
   %3166 = "arith.maxnumf"(%arg24, %arg25) <{fastmath = #arith.fastmath<none>}> : (f32, f32) -> f32
+  "tt.reduce.return"(%3166) : (f32) -> ()
+}) : (tensor<64x16xf32, #ttg.amd_mfma<{versionMajor = 4, versionMinor = 0, warpsPerCTA = [4, 1], instrShape = [16, 16, 16], isTransposed = true}>>) -> tensor<64xf32, #ttg.slice<{dim = 1, parent = #ttg.amd_mfma<{versionMajor = 4, versionMinor = 0, warpsPerCTA = [4, 1], instrShape = [16, 16, 16], isTransposed = true}>}>>
+  tt.return
+  }
+}
+
+// -----
+
+// GFX950-LABEL: reduce_16x16_commuted
+// GFX950: llvm.call_intrinsic "llvm.amdgcn.permlane32.swap"
+// GFX950: llvm.icmp "eq"
+// GFX950: llvm.select
+// GFX950: llvm.call_intrinsic "llvm.amdgcn.permlane16.swap"
+// GFX950: llvm.icmp "eq"
+// GFX950: llvm.select
+module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, "ttg.threads-per-warp" = 64 : i32} {
+  tt.func @reduce_16x16_commuted(%arg0: tensor<64x16xf32, #ttg.amd_mfma<{versionMajor = 4, versionMinor = 0, warpsPerCTA = [4, 1], instrShape = [16, 16, 16], isTransposed = true}>>){
+%1 = "tt.reduce"(%arg0) <{axis = 1 : i32}> ({
+^bb0(%arg24: f32, %arg25: f32):
+  %3166 = "arith.maxnumf"(%arg25, %arg24) <{fastmath = #arith.fastmath<none>}> : (f32, f32) -> f32
   "tt.reduce.return"(%3166) : (f32) -> ()
 }) : (tensor<64x16xf32, #ttg.amd_mfma<{versionMajor = 4, versionMinor = 0, warpsPerCTA = [4, 1], instrShape = [16, 16, 16], isTransposed = true}>>) -> tensor<64xf32, #ttg.slice<{dim = 1, parent = #ttg.amd_mfma<{versionMajor = 4, versionMinor = 0, warpsPerCTA = [4, 1], instrShape = [16, 16, 16], isTransposed = true}>}>>
   tt.return

--- a/test/Conversion/tritongpu_to_llvm.mlir
+++ b/test/Conversion/tritongpu_to_llvm.mlir
@@ -1921,6 +1921,30 @@ module attributes {"ttg.target" = "cuda:80", "ttg.num-ctas" = 1 : i32, "ttg.num-
 }
 
 // -----
+
+// CHECK-LABEL: sum_reduction_commuted
+//   CHECK-NOT:   nvvm.redux.sync
+//       CHECK:   nvvm.shfl.sync bfly
+//       CHECK:   nvvm.shfl.sync bfly
+//       CHECK:   nvvm.shfl.sync bfly
+//       CHECK:   nvvm.shfl.sync bfly
+//       CHECK:   nvvm.shfl.sync bfly
+//       CHECK:   nvvm.barrier
+//       CHECK:   nvvm.shfl.sync bfly
+//       CHECK:   nvvm.shfl.sync bfly
+#blocked = #ttg.blocked<{sizePerThread = [1, 4], threadsPerWarp = [1, 32], warpsPerCTA = [1, 4], order = [1, 0]}>
+module attributes {"ttg.target" = "cuda:80", "ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, "ttg.threads-per-warp" = 32 : i32} {
+  tt.func public @sum_reduction_commuted(%arg0: tensor<1x1024xi32, #blocked>) {
+    %11 = "tt.reduce"(%arg0) <{axis = 1 : i32}> ({
+    ^bb0(%arg2: i32, %arg3: i32):
+      %15 = arith.addi %arg3, %arg2 : i32
+      tt.reduce.return %15 : i32
+    }) : (tensor<1x1024xi32, #blocked>) -> tensor<1xi32, #ttg.slice<{dim = 1, parent = #blocked}>>
+    tt.return
+  }
+}
+
+// -----
 // CHECK-LABEL: @reduce_vec8_axisonly
 // CHECK-COUNT-7: llvm.fadd {{.*}} : f16
 // CHECK-NOT: llvm.fadd {{.*}} : vector<2xf16>

--- a/test/Conversion/tritongpu_to_llvm.mlir
+++ b/test/Conversion/tritongpu_to_llvm.mlir
@@ -1923,12 +1923,8 @@ module attributes {"ttg.target" = "cuda:80", "ttg.num-ctas" = 1 : i32, "ttg.num-
 // -----
 
 // CHECK-LABEL: sum_reduction_commuted
-//   CHECK-NOT:   nvvm.redux.sync
-//       CHECK:   nvvm.shfl.sync bfly
-//       CHECK:   nvvm.shfl.sync bfly
-//       CHECK:   nvvm.shfl.sync bfly
-//       CHECK:   nvvm.shfl.sync bfly
-//       CHECK:   nvvm.shfl.sync bfly
+//       CHECK:  %[[M:.+]] = llvm.mlir.constant(-1 : i32) : i32
+//       CHECK:   nvvm.redux.sync  add %{{.*}}, %[[M]]
 //       CHECK:   nvvm.barrier
 //       CHECK:   nvvm.shfl.sync bfly
 //       CHECK:   nvvm.shfl.sync bfly


### PR DESCRIPTION
(Came across this while trying to understand the codebase for a PR for #10693, which is still under work.)

Consider the following handwritten add combiners for a reduction, which should be equivalent for all commutative combiners.

```python
@triton.jit
def fwd_add(a, b):
    return a + b

@triton.jit
def rev_add(a, b):
    return b + a

@triton.jit
def compare_reduce(X, O1, O2, BLOCK: tl.constexpr):
    x = tl.load(X + tl.arange(0, BLOCK))
    fwd_reduce = tl.reduce(x, 0, fwd_add)
    rev_reduce = tl.reduce(x, 0, rev_add)
    tl.store(O1, fwd_reduce)
    tl.store(O2, rev_reduce)
```

The `fwd_reduce` generate 1 x `redux` in ptx:

```python
mov.b32  %r29, -1 
redux.sync.add.s32  %r30, %r28, %r29
```

While `rev_reduce` generate the generic 5 x `shfl` algorithm:

```python
shfl.sync.bfly.b32 %r48, %r47, 16, 31, -1 ; add.s32 ; intra-warp tree, offset 16
shfl.sync.bfly.b32 %r50, %r49,  8, 31, -1 ; add.s32 ;                  offset 8
shfl.sync.bfly.b32 %r52, %r51,  4, 31, -1 ; add.s32 ;                  offset 4
shfl.sync.bfly.b32 %r54, %r53,  2, 31, -1 ; add.s32 ;                  offset 2
shfl.sync.bfly.b32 %r56, %r55,  1, 31, -1 ; add.s32 ;                  offset 1
```

This is due to `ReduceOp::getSingleCombiner()` currently only accept the case when the mapping between block arguments and the combiner operands is arg0 == lhs and arg1 == rhs, but not the reversed case, even if both forms are equivalent when the combiner is commutative.

Added 3 lit tests, 1 for each existing downstream consumer of `getSingleCombiner()` , showing both arg-operand mappings correctly generate the identical check lines.
<!---
The core Triton is a small number of people, and we receive many PRs (thank
you!).  To help us review your code more quickly, **if you are a new
contributor (less than 3 PRs merged) we ask that you complete the following
tasks and include the filled-out checklist in your PR description.**

Complete the following tasks before sending your PR, and replace `[ ]` with
`[x]` to indicate you have done them.
-->

# New contributor declaration
- [x] I am not making a trivial change, such as fixing a typo in a comment.

- [x] I have written a PR description following these
  [rules](https://cbea.ms/git-commit/#why-not-how).

- [x] I have run `pre-commit run --from-ref origin/main --to-ref HEAD`.

- Select one of the following.
  - [x] I have added tests.
    - `/test` for `lit` tests
    - `/unittest` for C++ tests
    - `/python/test` for end-to-end tests
  - [ ] This PR does not need a test because `FILL THIS IN`.

- Select one of the following.
  - [ ] I have not added any `lit` tests.
  - [x] The `lit` tests I have added follow these [best practices](https://mlir.llvm.org/getting_started/TestingGuide/#filecheck-best-practices),
    including the "tests should be minimal" section. (Usually running Python code
    and using the instructions it generates is not minimal.)
