### PR TITLE
Add cluster sync before 2CTA TMEM allocation

### DIFF
--- a/test/Conversion/lower_tensor_memory_to_llvm.mlir
+++ b/test/Conversion/lower_tensor_memory_to_llvm.mlir
@@ -4,7 +4,9 @@ module attributes {"ttg.num-warps" = 4 : i32, "ttg.total-num-warps" = 8 : i32, t
   llvm.mlir.global external @global_smem() {addr_space = 3 : i32, alignment = 16 : i64} : !llvm.array<0 x i8>
 
   // CHECK-LABEL: @automatic_tmem_lifecycle
-  // CHECK: tcgen05.alloc.cta_group::2.sync.aligned.shared::cta.b32
+  // CHECK: nvvm.cluster.arrive
+  // CHECK-NEXT: nvvm.cluster.wait
+  // CHECK-NEXT: {{.*}}tcgen05.alloc.cta_group::2.sync.aligned.shared::cta.b32
   // CHECK: tcgen05.relinquish_alloc_permit.cta_group::2.sync.aligned
   // CHECK: nvvm.cluster.arrive
   // CHECK-NEXT: nvvm.cluster.wait

--- a/third_party/nvidia/lib/NVGPUToLLVM/NVGPUToLLVMPass.cpp
+++ b/third_party/nvidia/lib/NVGPUToLLVM/NVGPUToLLVMPass.cpp
@@ -523,6 +523,11 @@ static Value createTMAlloc(IRRewriter &rewriter, LLVM::LLVMFuncOp func,
   Location loc = func.getLoc();
   auto b = TritonLLVMOpBuilder(loc, rewriter);
   Value sharedMem = mlir::LLVM::getStackPointer(rewriter, func);
+  if (twoCTAs) {
+    auto ctx = func->getContext();
+    NVVM::ClusterArriveOp::create(rewriter, loc, UnitAttr::get(ctx));
+    NVVM::ClusterWaitOp::create(rewriter, loc, UnitAttr::get(ctx));
+  }
   std::string ptxString =
       "@$0 tcgen05.alloc.cta_group::" + std::to_string(twoCTAs ? 2 : 1) +
       ".sync.aligned.shared::cta.b32 [$1], " + std::to_string(size) + ";";


### PR DESCRIPTION
Insert a cluster barrier before we try to allocate tmem in 2CTA mode