### PR TITLE
Support local gather and scatter in ConSan

### DIFF
--- a/include/triton/Dialect/TritonInstrument/IR/TritonInstrument.md
+++ b/include/triton/Dialect/TritonInstrument/IR/TritonInstrument.md
@@ -202,6 +202,15 @@ two-CTA Tensor Core operation is issued by the even CTA in the pair, but its
 memory effects cover both CTA rows in that pair. CLC try-cancel is issued once
 for the cluster and touches all CTA rows.
 
+For `ttg.local_gather` and `ttg.local_scatter` on direct memdescs, runtime
+indices can select shared memory owned by a peer CTA. ConSan derives the
+possible recipient CTA rows from the same block-local layout conversion used
+by lowering. The issuing CTA is fixed while register, lane, warp, and runtime
+index bases are spanned, producing a static conservative recipient set for the
+full buffer without defaulting every access to the whole cluster. Cross-CTA
+affine subslices remain unsupported by BufferRegion analysis, as for other
+local memdesc accesses.
+
 ## Barrier Synchronization
 
 ConSan separates barrier tracking from visibility transfer. Ordinary mbarrier
@@ -283,12 +292,16 @@ The common hook implementation covers these TritonGPU operations:
 - `ttg.async_commit_group`: commits staged `AsyncCp` accesses.
 - `ttg.async_wait`: clears `AsyncCp` entries beyond the pending-count threshold
   and transfers write visibility.
-- `ttg.local_load`: barrier-tracked shared-memory read.
-- `ttg.local_store`: barrier-tracked shared-memory write.
+- `ttg.local_load` and `ttg.local_gather`: barrier-tracked shared-memory
+  reads. A gather conservatively covers its full source descriptor because its
+  indices are runtime values.
+- `ttg.local_store` and `ttg.local_scatter`: barrier-tracked shared-memory
+  writes. A scatter conservatively covers its full destination descriptor
+  because its indices are runtime values.
 - `ttg.local_alloc` with a source: barrier-tracked shared-memory write.
 
-All three ordinary shared-memory effects above are generic-proxy accesses for
-the proxy-ordering model.
+These shared-memory effects are generic-proxy accesses for the proxy-ordering
+model.
 
 NVIDIA hooks additionally cover:
 

--- a/include/triton/Dialect/TritonInstrument/IR/TritonInstrument.md
+++ b/include/triton/Dialect/TritonInstrument/IR/TritonInstrument.md
@@ -202,14 +202,15 @@ two-CTA Tensor Core operation is issued by the even CTA in the pair, but its
 memory effects cover both CTA rows in that pair. CLC try-cancel is issued once
 for the cluster and touches all CTA rows.
 
-For `ttg.local_gather` and `ttg.local_scatter` on direct memdescs, runtime
-indices can select shared memory owned by a peer CTA. ConSan derives the
-possible recipient CTA rows from the same block-local layout conversion used
-by lowering. The issuing CTA is fixed while register, lane, warp, and runtime
-index bases are spanned, producing a static conservative recipient set for the
+For direct memdesc accesses, ConSan derives the possible recipient CTA rows
+from the same block-local register-to-shared layout conversion used by
+lowering. This covers `ttg.local_load`, `ttg.local_store`, and source-backed
+`ttg.local_alloc`. For `ttg.local_gather` and `ttg.local_scatter`, the runtime
+index replaces one logical coordinate, so ConSan additionally spans that
+index's layout bases. In each case the issuing CTA is fixed while the other
+input bases are spanned, producing a static conservative recipient set for the
 full buffer without defaulting every access to the whole cluster. Cross-CTA
-affine subslices remain unsupported by BufferRegion analysis, as for other
-local memdesc accesses.
+affine subslices are rejected as unsupported by BufferRegion analysis.
 
 ## Barrier Synchronization
 

--- a/include/triton/Dialect/TritonInstrument/IR/Utility.h
+++ b/include/triton/Dialect/TritonInstrument/IR/Utility.h
@@ -268,7 +268,7 @@ struct AuxDataMap {
                                                 const ConSanTargetHooks *hooks);
 
 private:
-  void getBuffersAndBarriers(
+  LogicalResult getBuffersAndBarriers(
       ModuleOp module,
       SmallVector<SmallVector<triton::BufferRegion>, 2> &bufRegions,
       SmallVector<triton::BufferRegion> &barrierRegions);

--- a/include/triton/Dialect/TritonInstrument/Transforms/ConSanTargetHooks.h
+++ b/include/triton/Dialect/TritonInstrument/Transforms/ConSanTargetHooks.h
@@ -142,11 +142,23 @@ public:
       info->operandEffects.emplace_back(MemEffectsOpInfo::Effects::Read,
                                         loadOp.getSrc());
     }
+    if (auto gatherOp = dyn_cast<ttg::LocalGatherOp>(op)) {
+      info.emplace();
+      info->trackingKind = MemEffectsOpInfo::TrackingKind::Barrier;
+      info->operandEffects.emplace_back(MemEffectsOpInfo::Effects::Read,
+                                        gatherOp.getSrc());
+    }
     if (auto storeOp = dyn_cast<ttg::LocalStoreOp>(op)) {
       info.emplace();
       info->trackingKind = MemEffectsOpInfo::TrackingKind::Barrier;
       info->operandEffects.emplace_back(MemEffectsOpInfo::Effects::Write,
                                         storeOp.getDst());
+    }
+    if (auto scatterOp = dyn_cast<ttg::LocalScatterOp>(op)) {
+      info.emplace();
+      info->trackingKind = MemEffectsOpInfo::TrackingKind::Barrier;
+      info->operandEffects.emplace_back(MemEffectsOpInfo::Effects::Write,
+                                        scatterOp.getDst());
     }
     if (auto allocOp = dyn_cast<ttg::LocalAllocOp>(op)) {
       if (allocOp.getSrc()) {

--- a/lib/Analysis/BufferRegion.cpp
+++ b/lib/Analysis/BufferRegion.cpp
@@ -90,7 +90,7 @@ bool isUsedAsTensorMemory(Value v) {
          isa_and_nonnull<ttng::TensorMemorySpaceAttr>(type.getMemorySpace());
 }
 
-uint32_t getMemDescSubsliceByteOffset(ttg::MemDescSubsliceOp op) {
+FailureOr<uint32_t> getMemDescSubsliceByteOffset(ttg::MemDescSubsliceOp op) {
   auto srcTy = op.getSrc().getType();
   auto offsets = op.getOffsets();
   if (offsets.empty())
@@ -117,9 +117,17 @@ uint32_t getMemDescSubsliceByteOffset(ttg::MemDescSubsliceOp op) {
   StringAttr blockDim = StringAttr::get(ctx, "block");
   mlir::triton::LinearLayout inverse = layout.invert();
   auto mapped = inverse.apply(logicalOffsets);
-  assert(mapped.size() == 2 && mapped[0].first == offsetDim &&
-         mapped[1].first == blockDim && mapped[1].second == 0 &&
-         "expected offset and zero block dimensions after inversion");
+  if (mapped.size() != 2 || mapped[0].first != offsetDim ||
+      mapped[1].first != blockDim) {
+    op.emitError("unsupported memdesc subslice layout in buffer region "
+                 "analysis");
+    return failure();
+  }
+  if (mapped[1].second != 0) {
+    op.emitError("memdesc subslices with cross-CTA affine offsets are "
+                 "unsupported by buffer region analysis");
+    return failure();
+  }
   uint64_t elementOffset = static_cast<uint32_t>(mapped[0].second);
 
   uint64_t elementSizeBytes =
@@ -244,10 +252,13 @@ LogicalResult BufferRegionAnalysis::visitOperation(
   if (auto memdescSubsliceOp = dyn_cast<ttg::MemDescSubsliceOp>(op)) {
     RegionInfo in = operands[0]->getValue();
     uint32_t subBufferSize = getMemDescSize(memdescSubsliceOp.getType());
-    uint32_t relativeOffset = getMemDescSubsliceByteOffset(memdescSubsliceOp);
+    FailureOr<uint32_t> relativeOffset =
+        getMemDescSubsliceByteOffset(memdescSubsliceOp);
+    if (failed(relativeOffset))
+      return failure();
     for (auto &region : in.regions) {
       regionInfo.regions.insert(
-          {region.baseOffset + relativeOffset, subBufferSize});
+          {region.baseOffset + *relativeOffset, subBufferSize});
     }
     for (auto *r : results) {
       propagateIfChanged(r, r->join(regionInfo));

--- a/lib/Analysis/BufferRegion.cpp
+++ b/lib/Analysis/BufferRegion.cpp
@@ -321,9 +321,10 @@ void BufferRegionAnalysis::calculateUsedBufferRegions(Operation *op) {
 }
 
 bool BufferRegionAnalysis::isMemoryAccessOperation(Operation *op) {
-  if (isa<ttg::LocalLoadOp, ttg::LocalStoreOp, ttng::TMEMLoadOp,
-          ttng::TMEMStoreOp, ttng::TMEMCopyOp, ttg::AsyncCopyGlobalToLocalOp,
-          ttng::TMAOpInterface, ttng::CLCLoadResultOp>(op)) {
+  if (isa<ttg::LocalLoadOp, ttg::LocalStoreOp, ttg::LocalGatherOp,
+          ttg::LocalScatterOp, ttng::TMEMLoadOp, ttng::TMEMStoreOp,
+          ttng::TMEMCopyOp, ttg::AsyncCopyGlobalToLocalOp, ttng::TMAOpInterface,
+          ttng::CLCLoadResultOp>(op)) {
     return true;
   }
   if (isa<ttg::MBarrierOpInterface>(op)) {

--- a/lib/Dialect/TritonInstrument/IR/Utility.cpp
+++ b/lib/Dialect/TritonInstrument/IR/Utility.cpp
@@ -532,7 +532,8 @@ LogicalResult AuxDataMap::populateAndPassToWarpSpecialize(
     ModuleOp module, FunctionBuilder &fb, const ConSanTargetHooks *hooks) {
   SmallVector<SmallVector<BufferRegion>, numMemTypes> bufRegions(numMemTypes);
   SmallVector<BufferRegion> barrierRegions;
-  getBuffersAndBarriers(module, bufRegions, barrierRegions);
+  if (failed(getBuffersAndBarriers(module, bufRegions, barrierRegions)))
+    return failure();
   int numCTAs = lookupNumCTAs(module);
   threadLayout = getThreadLayout(module, hooks);
   hasAsyncProxyFenceTracking = hooks &&
@@ -737,7 +738,7 @@ LogicalResult AuxDataMap::populateAndPassToWarpSpecialize(
   return success();
 }
 
-void AuxDataMap::getBuffersAndBarriers(
+LogicalResult AuxDataMap::getBuffersAndBarriers(
     ModuleOp module, SmallVector<SmallVector<BufferRegion>, 2> &bufRegions,
     SmallVector<BufferRegion> &barrierRegions) {
   // Collect shared memory buffers allocated in the module
@@ -745,7 +746,7 @@ void AuxDataMap::getBuffersAndBarriers(
   triton::BufferRegionAnalysis *analysis =
       solver->load<triton::BufferRegionAnalysis>();
   if (failed(solver->initializeAndRun(module)))
-    return;
+    return failure();
 
   analysis->calculateUsedBufferRegions(module);
   bufRegions[(int)MemType::SHARED_MEM] = analysis->getAllUsedBufferRegions(
@@ -769,6 +770,7 @@ void AuxDataMap::getBuffersAndBarriers(
         llvm::NextPowerOf2(bufRegions[iMemType].size() - 1),
         BufferRegion{0, 0});
   }
+  return success();
 }
 
 void AuxDataMap::passToWarpSpecialize(FuncOp func, ValueType valueType,

--- a/lib/Dialect/TritonInstrument/Transforms/ConcurrencySanitizer.cpp
+++ b/lib/Dialect/TritonInstrument/Transforms/ConcurrencySanitizer.cpp
@@ -3,11 +3,13 @@
 #include "mlir/Transforms/Passes.h"
 #include "triton/Dialect/Triton/IR/Utility.h"
 #include "triton/Dialect/TritonGPU/IR/Dialect.h"
+#include "triton/Dialect/TritonGPU/IR/LinearLayoutConversions.h"
 #include "triton/Dialect/TritonInstrument/IR/Dialect.h"
 #include "triton/Dialect/TritonInstrument/IR/FunctionBuilder.h"
 #include "triton/Dialect/TritonInstrument/IR/Utility.h"
 #include "triton/Dialect/TritonInstrument/Transforms/ConSanTargetHooks.h"
 #include "triton/Dialect/TritonNvidiaGPU/IR/Dialect.h"
+#include "triton/Tools/LayoutUtils.h"
 #include "triton/Tools/Sys/GetEnv.h"
 
 namespace mlir {
@@ -367,7 +369,114 @@ SmallVector<uint16_t> getTensorCoreBarrierBroadcastMasks(Operation *op) {
   return ttng::getCTABroadcastMasks(twoCTAs, commitDescs);
 }
 
+void extendXorSpan(uint32_t &span, uint32_t basis, int numCTAs) {
+  uint32_t oldSpan = span;
+  for (int value = 0; value < numCTAs; ++value) {
+    if (!(oldSpan & (1u << value)))
+      continue;
+    uint32_t extended = value ^ basis;
+    assert(extended < static_cast<uint32_t>(numCTAs) &&
+           "CTA basis exceeds the cluster size");
+    span |= 1u << extended;
+  }
+}
+
+Value getLocalGatherScatterRecipientCTAs(ImplicitLocOpBuilder &b,
+                                         ttg::MemDescType memDescTy,
+                                         RankedTensorType regTy,
+                                         unsigned axis) {
+  MLIRContext *ctx = b.getContext();
+  LinearLayout sharedLayout = ttg::isPaddedEncoding(memDescTy.getEncoding())
+                                  ? ttg::paddedLinearLayout(memDescTy)
+                                  : ttg::toLinearLayout(memDescTy);
+  SmallVector<StringAttr> allDims =
+      standardOutDimNames(ctx, memDescTy.getRank());
+  StringAttr axisDim = allDims[axis];
+  LinearLayout regLayout = ttg::toLinearLayout(regTy).transposeOuts(allDims);
+  SmallVector<StringAttr> nonIndexedDims = allDims;
+  nonIndexedDims.erase(nonIndexedDims.begin() + axis);
+  LinearLayout indexedLayout =
+      regLayout.sublayout(llvm::to_vector(regLayout.getInDimNames()),
+                          nonIndexedDims) *
+      LinearLayout::identity1D(sharedLayout.getOutDimSize(axisDim), axisDim,
+                               axisDim);
+  indexedLayout = indexedLayout.transposeOuts(allDims);
+  LinearLayout conversion =
+      invertAndComposeBlockLocal(sharedLayout, indexedLayout);
+
+  StringAttr kBlock = StringAttr::get(ctx, "block");
+  int numCTAs = ttg::lookupNumCTAs(b);
+  // Runtime indices are unavailable to this pass. Span all block-output bases
+  // that lowering can derive from register, lane, warp, and index inputs. This
+  // is a conservative recipient set for the full BufferRegion effect.
+  uint32_t targetSpan = 1;
+  int blockOutIdx = conversion.getOutDimIndex(kBlock);
+  for (const auto &[inDim, bases] : conversion.getBases()) {
+    if (inDim == kBlock)
+      continue;
+    for (const auto &basis : bases)
+      extendXorSpan(targetSpan, basis[blockOutIdx], numCTAs);
+  }
+
+  SmallVector<uint32_t> recipientMasks;
+  recipientMasks.reserve(numCTAs);
+  for (int issuer = 0; issuer < numCTAs; ++issuer) {
+    SmallVector<std::pair<StringAttr, int32_t>> inputs;
+    for (StringAttr inDim : conversion.getInDimNames())
+      inputs.push_back({inDim, inDim == kBlock ? issuer : 0});
+    auto outputs = conversion.apply(inputs);
+    auto block = llvm::find_if(
+        outputs, [&](const auto &entry) { return entry.first == kBlock; });
+    assert(block != outputs.end() && "expected block output dimension");
+
+    uint32_t mask = 0;
+    for (int delta = 0; delta < numCTAs; ++delta) {
+      if (!(targetSpan & (1u << delta)))
+        continue;
+      uint32_t target = block->second ^ delta;
+      assert(target < static_cast<uint32_t>(numCTAs) &&
+             "target CTA exceeds the cluster size");
+      mask |= 1u << target;
+    }
+    recipientMasks.push_back(mask);
+  }
+
+  bool currentCTAOnly =
+      llvm::all_of(llvm::enumerate(recipientMasks), [](auto entry) {
+        return entry.value() == (1u << entry.index());
+      });
+  if (currentCTAOnly)
+    return currentCTAMask(b);
+  if (llvm::all_of(recipientMasks, [&](uint32_t mask) {
+        return mask == recipientMasks.front();
+      }))
+    return arith::ConstantIntOp::create(b, recipientMasks.front(), 32);
+
+  Value ctaId = tti::ExperimentalClusterCTAIdOp::create(b, b.getLoc());
+  Value recipients =
+      arith::ConstantIntOp::create(b, recipientMasks.front(), 32);
+  for (int issuer = 1; issuer < numCTAs; ++issuer) {
+    Value isIssuer =
+        arith::CmpIOp::create(b, arith::CmpIPredicate::eq, ctaId,
+                              arith::ConstantIntOp::create(b, issuer, 32));
+    recipients = arith::SelectOp::create(
+        b, isIssuer,
+        arith::ConstantIntOp::create(b, recipientMasks[issuer], 32),
+        recipients);
+  }
+  return recipients;
+}
+
 Value getMemEffectCTAs(ImplicitLocOpBuilder &b, Operation *op) {
+  if (auto gather = dyn_cast<ttg::LocalGatherOp>(op)) {
+    return getLocalGatherScatterRecipientCTAs(
+        b, gather.getSrc().getType(), gather.getType(), gather.getAxis());
+  }
+  if (auto scatter = dyn_cast<ttg::LocalScatterOp>(op)) {
+    return getLocalGatherScatterRecipientCTAs(b, scatter.getDst().getType(),
+                                              scatter.getValues().getType(),
+                                              scatter.getAxis());
+  }
   if (auto tmaLoad = dyn_cast<ttng::TMALoadLikeOpInterface>(op)) {
     if (tmaLoad.getMulticast())
       return getMulticastRecipientCTAs(b, tmaLoad.getResult());

--- a/lib/Dialect/TritonInstrument/Transforms/ConcurrencySanitizer.cpp
+++ b/lib/Dialect/TritonInstrument/Transforms/ConcurrencySanitizer.cpp
@@ -381,14 +381,23 @@ void extendXorSpan(uint32_t &span, uint32_t basis, int numCTAs) {
   }
 }
 
-Value getLocalGatherScatterRecipientCTAs(ImplicitLocOpBuilder &b,
-                                         ttg::MemDescType memDescTy,
-                                         RankedTensorType regTy,
-                                         unsigned axis) {
-  MLIRContext *ctx = b.getContext();
-  LinearLayout sharedLayout = ttg::isPaddedEncoding(memDescTy.getEncoding())
-                                  ? ttg::paddedLinearLayout(memDescTy)
-                                  : ttg::toLinearLayout(memDescTy);
+LinearLayout getSharedLayout(ttg::MemDescType memDescTy) {
+  return ttg::isPaddedEncoding(memDescTy.getEncoding())
+             ? ttg::paddedLinearLayout(memDescTy)
+             : ttg::toLinearLayout(memDescTy);
+}
+
+LinearLayout getLocalLoadStoreConversion(ttg::MemDescType memDescTy,
+                                         RankedTensorType regTy) {
+  return invertAndComposeBlockLocal(getSharedLayout(memDescTy),
+                                    ttg::toLinearLayout(regTy));
+}
+
+LinearLayout getLocalGatherScatterConversion(ttg::MemDescType memDescTy,
+                                             RankedTensorType regTy,
+                                             unsigned axis) {
+  MLIRContext *ctx = memDescTy.getContext();
+  LinearLayout sharedLayout = getSharedLayout(memDescTy);
   SmallVector<StringAttr> allDims =
       standardOutDimNames(ctx, memDescTy.getRank());
   StringAttr axisDim = allDims[axis];
@@ -401,44 +410,64 @@ Value getLocalGatherScatterRecipientCTAs(ImplicitLocOpBuilder &b,
       LinearLayout::identity1D(sharedLayout.getOutDimSize(axisDim), axisDim,
                                axisDim);
   indexedLayout = indexedLayout.transposeOuts(allDims);
-  LinearLayout conversion =
-      invertAndComposeBlockLocal(sharedLayout, indexedLayout);
+  return invertAndComposeBlockLocal(sharedLayout, indexedLayout);
+}
+
+uint32_t getXorImageMask(const LinearLayout &layout, StringAttr outDim,
+                         int numCTAs) {
+  uint32_t image = 1;
+  for (StringAttr inDim : layout.getInDimNames()) {
+    for (int bit = 0; bit < layout.getInDimSizeLog2(inDim); ++bit)
+      extendXorSpan(image, layout.getBasis(inDim, bit, outDim), numCTAs);
+  }
+  return image;
+}
+
+uint32_t translateXorMask(uint32_t mask, uint32_t translation, int numCTAs) {
+  uint32_t translated = 0;
+  for (int value = 0; value < numCTAs; ++value) {
+    if (!(mask & (1u << value)))
+      continue;
+    uint32_t target = value ^ translation;
+    assert(target < static_cast<uint32_t>(numCTAs) &&
+           "target CTA exceeds the cluster size");
+    translated |= 1u << target;
+  }
+  return translated;
+}
+
+Value getLocalMemoryRecipientCTAs(ImplicitLocOpBuilder &b,
+                                  const LinearLayout &conversion) {
+  MLIRContext *ctx = b.getContext();
 
   StringAttr kBlock = StringAttr::get(ctx, "block");
   int numCTAs = ttg::lookupNumCTAs(b);
-  // Runtime indices are unavailable to this pass. Span all block-output bases
-  // that lowering can derive from register, lane, warp, and index inputs. This
-  // is a conservative recipient set for the full BufferRegion effect.
-  uint32_t targetSpan = 1;
-  int blockOutIdx = conversion.getOutDimIndex(kBlock);
-  for (const auto &[inDim, bases] : conversion.getBases()) {
-    if (inDim == kBlock)
-      continue;
-    for (const auto &basis : bases)
-      extendXorSpan(targetSpan, basis[blockOutIdx], numCTAs);
-  }
+  assert(conversion.hasInDim(kBlock) && conversion.hasOutDim(kBlock) &&
+         conversion.getInDimSize(kBlock) == numCTAs &&
+         conversion.getOutDimSize(kBlock) == numCTAs &&
+         "expected conversion to preserve the cluster dimensions");
+
+  // Span every non-issuer input basis that lowering can map into the block
+  // output. For gather/scatter this includes the independent runtime-index
+  // input, whose value is unavailable to this pass. The resulting image is a
+  // conservative recipient set for the full BufferRegion effect.
+  SmallVector<StringAttr> varyingInputs =
+      llvm::to_vector(conversion.getInDimNames());
+  llvm::erase(varyingInputs, kBlock);
+  LinearLayout varyingInputsToTarget =
+      conversion.sublayout(varyingInputs, {kBlock});
+  uint32_t targetSpan = getXorImageMask(varyingInputsToTarget, kBlock, numCTAs);
+
+  LinearLayout issuerToTarget = conversion.sublayout({kBlock}, {kBlock});
 
   SmallVector<uint32_t> recipientMasks;
   recipientMasks.reserve(numCTAs);
   for (int issuer = 0; issuer < numCTAs; ++issuer) {
-    SmallVector<std::pair<StringAttr, int32_t>> inputs;
-    for (StringAttr inDim : conversion.getInDimNames())
-      inputs.push_back({inDim, inDim == kBlock ? issuer : 0});
-    auto outputs = conversion.apply(inputs);
-    auto block = llvm::find_if(
-        outputs, [&](const auto &entry) { return entry.first == kBlock; });
-    assert(block != outputs.end() && "expected block output dimension");
-
-    uint32_t mask = 0;
-    for (int delta = 0; delta < numCTAs; ++delta) {
-      if (!(targetSpan & (1u << delta)))
-        continue;
-      uint32_t target = block->second ^ delta;
-      assert(target < static_cast<uint32_t>(numCTAs) &&
-             "target CTA exceeds the cluster size");
-      mask |= 1u << target;
-    }
-    recipientMasks.push_back(mask);
+    auto outputs = issuerToTarget.apply({{kBlock, issuer}});
+    assert(outputs.size() == 1 && outputs.front().first == kBlock &&
+           "expected block output dimension");
+    recipientMasks.push_back(
+        translateXorMask(targetSpan, outputs.front().second, numCTAs));
   }
 
   bool currentCTAOnly =
@@ -467,15 +496,40 @@ Value getLocalGatherScatterRecipientCTAs(ImplicitLocOpBuilder &b,
   return recipients;
 }
 
+Value getLocalLoadStoreRecipientCTAs(ImplicitLocOpBuilder &b,
+                                     ttg::MemDescType memDescTy,
+                                     RankedTensorType regTy) {
+  // Layout-less tensors can appear in intermediate/test IR but cannot encode a
+  // cross-CTA ownership mapping. Preserve the existing current-CTA behavior.
+  if (!regTy.getEncoding())
+    return currentCTAMask(b);
+  return getLocalMemoryRecipientCTAs(
+      b, getLocalLoadStoreConversion(memDescTy, regTy));
+}
+
 Value getMemEffectCTAs(ImplicitLocOpBuilder &b, Operation *op) {
+  if (auto load = dyn_cast<ttg::LocalLoadOp>(op)) {
+    return getLocalLoadStoreRecipientCTAs(b, load.getSrc().getType(),
+                                          load.getType());
+  }
+  if (auto store = dyn_cast<ttg::LocalStoreOp>(op)) {
+    return getLocalLoadStoreRecipientCTAs(b, store.getDst().getType(),
+                                          store.getSrc().getType());
+  }
+  if (auto alloc = dyn_cast<ttg::LocalAllocOp>(op); alloc && alloc.getSrc()) {
+    return getLocalLoadStoreRecipientCTAs(b, alloc.getType(),
+                                          alloc.getSrc().getType());
+  }
   if (auto gather = dyn_cast<ttg::LocalGatherOp>(op)) {
-    return getLocalGatherScatterRecipientCTAs(
-        b, gather.getSrc().getType(), gather.getType(), gather.getAxis());
+    return getLocalMemoryRecipientCTAs(
+        b, getLocalGatherScatterConversion(gather.getSrc().getType(),
+                                           gather.getType(), gather.getAxis()));
   }
   if (auto scatter = dyn_cast<ttg::LocalScatterOp>(op)) {
-    return getLocalGatherScatterRecipientCTAs(b, scatter.getDst().getType(),
-                                              scatter.getValues().getType(),
-                                              scatter.getAxis());
+    return getLocalMemoryRecipientCTAs(
+        b, getLocalGatherScatterConversion(scatter.getDst().getType(),
+                                           scatter.getValues().getType(),
+                                           scatter.getAxis()));
   }
   if (auto tmaLoad = dyn_cast<ttng::TMALoadLikeOpInterface>(op)) {
     if (tmaLoad.getMulticast())

--- a/python/test/gluon/test_consan.py
+++ b/python/test/gluon/test_consan.py
@@ -602,6 +602,60 @@ def test_cluster_barrier_does_not_publish_later_read(device, run_wrapper, monkey
 
 
 @pytest.mark.skipif(not is_cuda() or torch.cuda.get_device_capability()[0] < 9, reason="Requires hopper or newer")
+@pytest.mark.parametrize(
+    "GATHER,FAILURE",
+    [
+        pytest.param(True, True, id="gather-missing-barrier"),
+        pytest.param(True, False, id="gather-synchronized"),
+        pytest.param(False, False, id="scatter-synchronized"),
+    ],
+)
+def test_local_gather_scatter_cross_cta_visibility(GATHER, FAILURE, device, run_wrapper, monkeypatch):
+    if run_wrapper:
+        result = run_in_process(test_local_gather_scatter_cross_cta_visibility,
+                                (GATHER, FAILURE, device, False, monkeypatch))
+        if FAILURE:
+            assert_expected_cuda_failure(result.exc)
+            assert "Buffer being accessed has outstanding" in result.driver_stderr_output
+        else:
+            assert result.exc is None
+            assert result.driver_stderr_output == ""
+        return
+
+    monkeypatch.setenv("TRITON_INSTRUMENTATION_MODE", "consan")
+    monkeypatch.setenv("CUDA_LAUNCH_BLOCKING", "1")
+    knobs.refresh_knobs()
+
+    @gluon.jit
+    def kernel(inp, out, layout: ttgl.constexpr, GATHER: ttgl.constexpr, FAILURE: ttgl.constexpr):
+        shared_layout: ttgl.constexpr = ttgl.SwizzledSharedLayout(1, 1, 1, order=[1, 0], cga_layout=[[0, 1]])
+        rows = ttgl.arange(0, 2, layout=ttgl.SliceLayout(1, layout))
+        cols = ttgl.arange(0, 32, layout=ttgl.SliceLayout(0, layout))
+        offsets = rows[:, None] * 32 + cols[None, :]
+        values = ttgl.load(inp + offsets)
+        smem = ttgl.allocate_shared_memory(ttgl.int32, [2, 32], shared_layout, value=values)
+        if not FAILURE:
+            ttgl.barrier(cluster=True)
+
+        peer_cols = (cols ^ 1)[None, :] + rows[:, None] * 0
+        if GATHER:
+            result = smem.gather(peer_cols, axis=1)
+        else:
+            smem.scatter(values, peer_cols, axis=1)
+            ttgl.barrier(cluster=True)
+            result = smem.load(layout)
+        ttgl.store(out + offsets, result)
+
+    inp = torch.arange(64, dtype=torch.int32, device=device).reshape(2, 32)
+    out = torch.empty_like(inp)
+    layout = ttgl.BlockedLayout([1, 1], [1, 32], [1, 4], [1, 0], cga_layout=[[0, 1]])
+    kernel[(1, )](inp, out, layout, GATHER=GATHER, FAILURE=FAILURE, num_warps=4, num_ctas=2)
+    if not FAILURE:
+        expected = inp.reshape(2, 16, 2).flip(-1).reshape(2, 32)
+        torch.testing.assert_close(out, expected)
+
+
+@pytest.mark.skipif(not is_cuda() or torch.cuda.get_device_capability()[0] < 9, reason="Requires hopper or newer")
 @pytest.mark.parametrize("FAILURE", [True, False])
 def test_async_tma_kernel_2bufs_1bar(FAILURE, device, run_wrapper, monkeypatch, num_ctas):
     if run_wrapper:

--- a/python/test/gluon/test_consan.py
+++ b/python/test/gluon/test_consan.py
@@ -603,20 +603,20 @@ def test_cluster_barrier_does_not_publish_later_read(device, run_wrapper, monkey
 
 @pytest.mark.skipif(not is_cuda() or torch.cuda.get_device_capability()[0] < 9, reason="Requires hopper or newer")
 @pytest.mark.parametrize(
-    "GATHER,FAILURE",
+    "OP,FAILURE",
     [
-        pytest.param(True, True, id="gather-missing-barrier"),
-        pytest.param(True, False, id="gather-synchronized"),
-        pytest.param(False, False, id="scatter-synchronized"),
+        pytest.param("gather", True, id="gather-missing-barrier"),
+        pytest.param("gather", False, id="gather-synchronized"),
+        pytest.param("scatter", False, id="scatter-synchronized"),
     ],
 )
-def test_local_gather_scatter_cross_cta_visibility(GATHER, FAILURE, device, run_wrapper, monkeypatch):
+def test_local_gather_scatter_cross_cta_visibility(OP, FAILURE, device, run_wrapper, monkeypatch):
     if run_wrapper:
         result = run_in_process(test_local_gather_scatter_cross_cta_visibility,
-                                (GATHER, FAILURE, device, False, monkeypatch))
+                                (OP, FAILURE, device, False, monkeypatch))
         if FAILURE:
             assert_expected_cuda_failure(result.exc)
-            assert "Buffer being accessed has outstanding" in result.driver_stderr_output
+            assert "Buffer being accessed has outstanding reads" in result.driver_stderr_output
         else:
             assert result.exc is None
             assert result.driver_stderr_output == ""
@@ -627,31 +627,42 @@ def test_local_gather_scatter_cross_cta_visibility(GATHER, FAILURE, device, run_
     knobs.refresh_knobs()
 
     @gluon.jit
-    def kernel(inp, out, layout: ttgl.constexpr, GATHER: ttgl.constexpr, FAILURE: ttgl.constexpr):
+    def kernel(inp, out, layout: ttgl.constexpr, OP: ttgl.constexpr, FAILURE: ttgl.constexpr):
         shared_layout: ttgl.constexpr = ttgl.SwizzledSharedLayout(1, 1, 1, order=[1, 0], cga_layout=[[0, 1]])
         rows = ttgl.arange(0, 2, layout=ttgl.SliceLayout(1, layout))
         cols = ttgl.arange(0, 32, layout=ttgl.SliceLayout(0, layout))
         offsets = rows[:, None] * 32 + cols[None, :]
         values = ttgl.load(inp + offsets)
-        smem = ttgl.allocate_shared_memory(ttgl.int32, [2, 32], shared_layout, value=values)
-        if not FAILURE:
-            ttgl.barrier(cluster=True)
+        smem = ttgl.allocate_shared_memory(ttgl.int32, [2, 32], shared_layout)
+        peer_cols = (cols ^ 16)[None, :] + rows[:, None] * 0
+        # Finish ConSan's untracked poison initialization before peer DSM access.
+        ttgl.barrier(cluster=True)
 
-        peer_cols = (cols ^ 1)[None, :] + rows[:, None] * 0
-        if GATHER:
+        if FAILURE:
             result = smem.gather(peer_cols, axis=1)
+            ttgl.store(out + offsets, result)
+            # Order every peer read before the stores without publishing it.
+            hopper.cluster.barrier(relaxed=True)
+            smem.store(values)
         else:
-            smem.scatter(values, peer_cols, axis=1)
+            smem.store(values)
             ttgl.barrier(cluster=True)
-            result = smem.load(layout)
-        ttgl.store(out + offsets, result)
+            if OP == "gather":
+                result = smem.gather(peer_cols, axis=1)
+                # Order peer DSM reads and keep allocations alive until they finish.
+                ttgl.barrier(cluster=True)
+            else:
+                smem.scatter(values, peer_cols, axis=1)
+                ttgl.barrier(cluster=True)
+                result = smem.load(layout)
+            ttgl.store(out + offsets, result)
 
     inp = torch.arange(64, dtype=torch.int32, device=device).reshape(2, 32)
     out = torch.empty_like(inp)
     layout = ttgl.BlockedLayout([1, 1], [1, 32], [1, 4], [1, 0], cga_layout=[[0, 1]])
-    kernel[(1, )](inp, out, layout, GATHER=GATHER, FAILURE=FAILURE, num_warps=4, num_ctas=2)
+    kernel[(1, )](inp, out, layout, OP=OP, FAILURE=FAILURE, num_warps=4, num_ctas=2)
     if not FAILURE:
-        expected = inp.reshape(2, 16, 2).flip(-1).reshape(2, 32)
+        expected = inp.reshape(2, 2, 16).flip(1).reshape(2, 32)
         torch.testing.assert_close(out, expected)
 
 

--- a/test/TritonGPU/consan-capture-reservation.mlir
+++ b/test/TritonGPU/consan-capture-reservation.mlir
@@ -1,6 +1,7 @@
 // RUN: split-file %s %t
 // RUN: not triton-opt %t/missing.mlir -allow-unregistered-dialect -tritoninstrument-concurrency-sanitizer 2>&1 | FileCheck %t/missing.mlir --check-prefix=MISSING
 // RUN: not triton-opt %t/too-small.mlir -allow-unregistered-dialect -tritoninstrument-concurrency-sanitizer 2>&1 | FileCheck %t/too-small.mlir --check-prefix=SMALL
+// RUN: not triton-opt %t/cross-cta-affine.mlir -allow-unregistered-dialect -tritoninstrument-concurrency-sanitizer 2>&1 | FileCheck %t/cross-cta-affine.mlir --check-prefix=AFFINE
 
 //--- missing.mlir
 
@@ -14,6 +15,23 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, "ttg.thr
     partition0() num_warps(4) {
       ttg.warp_return
     } : () -> ()
+    tt.return
+  }
+}
+
+//--- cross-cta-affine.mlir
+
+#shared = #ttg.swizzled_shared<{vec = 1, perPhase = 1, maxPhase = 1, order = [1, 0], CGALayout = [[1, 0]]}>
+#smem = #ttg.shared_memory
+#blocked = #ttg.blocked<{sizePerThread = [1, 1], threadsPerWarp = [1, 32], warpsPerCTA = [1, 4], order = [1, 0], CGALayout = [[0, 0]]}>
+
+module attributes {"ttg.num-ctas" = 2 : i32, "ttg.num-warps" = 4 : i32, "ttg.threads-per-warp" = 32 : i32, "ttg.total-num-warps" = 4 : i32, ttg.shared = 512 : i32, ttg.target = "cuda:90", ttg.tensor_memory_size = 0 : i32} {
+  tt.func public @cross_cta_affine_subslice() {
+    %src = ttg.local_alloc {allocation.offset = 0 : i32} : () -> !ttg.memdesc<4x32xi32, #shared, #smem, mutable>
+    // AFFINE: error: memdesc subslices with cross-CTA affine offsets are unsupported by buffer region analysis
+    %tile = ttg.memdesc_subslice %src [2, 0] : !ttg.memdesc<4x32xi32, #shared, #smem, mutable> -> !ttg.memdesc<2x32xi32, #shared, #smem, mutable, 4x32>
+    %indices = arith.constant dense<0> : tensor<2x32xi32, #blocked>
+    %gathered = ttg.local_gather %tile[%indices] {axis = 1 : i32} : !ttg.memdesc<2x32xi32, #shared, #smem, mutable, 4x32>, tensor<2x32xi32, #blocked> -> tensor<2x32xi32, #blocked>
     tt.return
   }
 }

--- a/test/TritonGPU/consan.mlir
+++ b/test/TritonGPU/consan.mlir
@@ -114,6 +114,49 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.shar
 
 // -----
 
+#local_gather_scatter_shared = #ttg.nvmma_shared<{swizzlingByteWidth = 64, transposed = false, elementBitWidth = 32, CGALayout = [[0, 1]]}>
+#local_gather_scatter_smem = #ttg.shared_memory
+#local_gather_scatter_blocked = #ttg.blocked<{sizePerThread = [1, 1], threadsPerWarp = [1, 32], warpsPerCTA = [1, 4], order = [1, 0], CGALayout = [[0, 1]]}>
+module attributes {"ttg.num-ctas" = 2 : i32, "ttg.num-warps" = 4 : i32, ttg.shared = 528 : i32, ttg.target = "cuda:90", ttg.tensor_memory_size = 0 : i32, "ttg.threads-per-warp" = 32 : i32, "ttg.total-num-warps" = 4 : i32} {
+  // CHECK-LABEL: @local_gather_scatter_effects
+  tt.func public @local_gather_scatter_effects(%out: !tt.tensordesc<8x32xi32, #local_gather_scatter_shared>) {
+    // CHECK-DAG: tti.experimental_buffer_descriptors [0, 16], [512, 512], shared_mem : tensor<2xi64
+    // CHECK-DAG: arith.constant dense<true> : tensor<2x2xi1
+    %c0 = arith.constant 0 : i32
+    %indices = arith.constant dense<0> : tensor<8x32xi32, #local_gather_scatter_blocked>
+    %values = arith.constant dense<1> : tensor<8x32xi32, #local_gather_scatter_blocked>
+    %src = ttg.local_alloc {allocation.offset = 0 : i32} : () -> !ttg.memdesc<8x32xi32, #local_gather_scatter_shared, #local_gather_scatter_smem, mutable>
+    %dst = ttg.local_alloc {allocation.offset = 16 : i32} : () -> !ttg.memdesc<8x32xi32, #local_gather_scatter_shared, #local_gather_scatter_smem, mutable>
+
+    // Indexing the unsharded axis leaves the gather local to the issuing CTA.
+    // CHECK: %[[GATHER_CTAS:.*]] = arith.shli {{.*}} : i32
+    // CHECK: tt.call @__triton_consan_set_proxy_access{{.*}}({{.*}}%[[GATHER_CTAS]]{{.*}})
+    // CHECK: tt.call @__triton_consan_verify_write_visibility{{.*}}({{.*}}%[[GATHER_CTAS]]{{.*}})
+    // CHECK: tt.call @__triton_consan_set_read_visibility{{.*}}({{.*}}%[[GATHER_CTAS]]{{.*}})
+    // CHECK: ttg.local_gather
+    %gathered = ttg.local_gather %src[%indices] {axis = 0 : i32} : !ttg.memdesc<8x32xi32, #local_gather_scatter_shared, #local_gather_scatter_smem, mutable>, tensor<8x32xi32, #local_gather_scatter_blocked> -> tensor<8x32xi32, #local_gather_scatter_blocked>
+
+    // Indexing the sharded axis can target either CTA row.
+    // CHECK: %[[SCATTER_CTAS:.*]] = arith.constant 3 : i32
+    // CHECK: tt.call @__triton_consan_set_proxy_access{{.*}}({{.*}}%[[SCATTER_CTAS]]{{.*}})
+    // CHECK: tt.call @__triton_consan_verify_write_visibility{{.*}}({{.*}}%[[SCATTER_CTAS]]{{.*}})
+    // CHECK: tt.call @__triton_consan_verify_read_visibility{{.*}}({{.*}}%[[SCATTER_CTAS]]{{.*}})
+    // CHECK: tt.call @__triton_consan_set_write_visibility{{.*}}({{.*}}%[[SCATTER_CTAS]]{{.*}})
+    // CHECK: tt.call @__triton_consan_clear_read_visibility{{.*}}({{.*}}%[[SCATTER_CTAS]]{{.*}})
+    // CHECK: ttg.local_scatter
+    ttg.local_scatter %dst[%indices], %values {axis = 1 : i32} : !ttg.memdesc<8x32xi32, #local_gather_scatter_shared, #local_gather_scatter_smem, mutable>, tensor<8x32xi32, #local_gather_scatter_blocked>, tensor<8x32xi32, #local_gather_scatter_blocked>
+
+    // An async-proxy consumer makes the generic-proxy classification above
+    // observable in ConSan's output.
+    // CHECK: tt.call @__triton_consan_verify_proxy_access
+    // CHECK: ttng.async_tma_copy_local_to_global
+    ttng.async_tma_copy_local_to_global %out[%c0, %c0] %dst : !tt.tensordesc<8x32xi32, #local_gather_scatter_shared>, !ttg.memdesc<8x32xi32, #local_gather_scatter_shared, #local_gather_scatter_smem, mutable>
+    tt.return
+  }
+}
+
+// -----
+
 #shared = #ttg.nvmma_shared<{swizzlingByteWidth = 128, transposed = false, elementBitWidth = 32}>
 #shared1 = #ttg.swizzled_shared<{vec = 1, perPhase = 1, maxPhase = 1, order = [0]}>
 #smem = #ttg.shared_memory

--- a/test/TritonGPU/consan.mlir
+++ b/test/TritonGPU/consan.mlir
@@ -115,6 +115,7 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.shar
 // -----
 
 #local_gather_scatter_shared = #ttg.nvmma_shared<{swizzlingByteWidth = 64, transposed = false, elementBitWidth = 32, CGALayout = [[0, 1]]}>
+#local_gather_shared = #ttg.swizzled_shared<{vec = 1, perPhase = 1, maxPhase = 1, order = [1, 0], CGALayout = [[0, 1]]}>
 #local_gather_scatter_smem = #ttg.shared_memory
 #local_gather_scatter_blocked = #ttg.blocked<{sizePerThread = [1, 1], threadsPerWarp = [1, 32], warpsPerCTA = [1, 4], order = [1, 0], CGALayout = [[0, 1]]}>
 module attributes {"ttg.num-ctas" = 2 : i32, "ttg.num-warps" = 4 : i32, ttg.shared = 528 : i32, ttg.target = "cuda:90", ttg.tensor_memory_size = 0 : i32, "ttg.threads-per-warp" = 32 : i32, "ttg.total-num-warps" = 4 : i32} {
@@ -125,26 +126,26 @@ module attributes {"ttg.num-ctas" = 2 : i32, "ttg.num-warps" = 4 : i32, ttg.shar
     %c0 = arith.constant 0 : i32
     %indices = arith.constant dense<0> : tensor<8x32xi32, #local_gather_scatter_blocked>
     %values = arith.constant dense<1> : tensor<8x32xi32, #local_gather_scatter_blocked>
-    %src = ttg.local_alloc {allocation.offset = 0 : i32} : () -> !ttg.memdesc<8x32xi32, #local_gather_scatter_shared, #local_gather_scatter_smem, mutable>
+    %src = ttg.local_alloc {allocation.offset = 0 : i32} : () -> !ttg.memdesc<8x32xi32, #local_gather_shared, #local_gather_scatter_smem, mutable>
     %dst = ttg.local_alloc {allocation.offset = 16 : i32} : () -> !ttg.memdesc<8x32xi32, #local_gather_scatter_shared, #local_gather_scatter_smem, mutable>
 
-    // Indexing the unsharded axis leaves the gather local to the issuing CTA.
-    // CHECK: %[[GATHER_CTAS:.*]] = arith.shli {{.*}} : i32
+    // Indexing the sharded axis can target either CTA row.
+    // CHECK: %[[GATHER_CTAS:.*]] = arith.constant 3 : i32
     // CHECK: tt.call @__triton_consan_set_proxy_access{{.*}}({{.*}}%[[GATHER_CTAS]]{{.*}})
     // CHECK: tt.call @__triton_consan_verify_write_visibility{{.*}}({{.*}}%[[GATHER_CTAS]]{{.*}})
     // CHECK: tt.call @__triton_consan_set_read_visibility{{.*}}({{.*}}%[[GATHER_CTAS]]{{.*}})
     // CHECK: ttg.local_gather
-    %gathered = ttg.local_gather %src[%indices] {axis = 0 : i32} : !ttg.memdesc<8x32xi32, #local_gather_scatter_shared, #local_gather_scatter_smem, mutable>, tensor<8x32xi32, #local_gather_scatter_blocked> -> tensor<8x32xi32, #local_gather_scatter_blocked>
+    %gathered = ttg.local_gather %src[%indices] {axis = 1 : i32} : !ttg.memdesc<8x32xi32, #local_gather_shared, #local_gather_scatter_smem, mutable>, tensor<8x32xi32, #local_gather_scatter_blocked> -> tensor<8x32xi32, #local_gather_scatter_blocked>
 
-    // Indexing the sharded axis can target either CTA row.
-    // CHECK: %[[SCATTER_CTAS:.*]] = arith.constant 3 : i32
+    // Indexing the unsharded axis leaves the scatter local to the issuing CTA.
+    // CHECK: %[[SCATTER_CTAS:.*]] = arith.shli {{.*}} : i32
     // CHECK: tt.call @__triton_consan_set_proxy_access{{.*}}({{.*}}%[[SCATTER_CTAS]]{{.*}})
     // CHECK: tt.call @__triton_consan_verify_write_visibility{{.*}}({{.*}}%[[SCATTER_CTAS]]{{.*}})
     // CHECK: tt.call @__triton_consan_verify_read_visibility{{.*}}({{.*}}%[[SCATTER_CTAS]]{{.*}})
     // CHECK: tt.call @__triton_consan_set_write_visibility{{.*}}({{.*}}%[[SCATTER_CTAS]]{{.*}})
     // CHECK: tt.call @__triton_consan_clear_read_visibility{{.*}}({{.*}}%[[SCATTER_CTAS]]{{.*}})
     // CHECK: ttg.local_scatter
-    ttg.local_scatter %dst[%indices], %values {axis = 1 : i32} : !ttg.memdesc<8x32xi32, #local_gather_scatter_shared, #local_gather_scatter_smem, mutable>, tensor<8x32xi32, #local_gather_scatter_blocked>, tensor<8x32xi32, #local_gather_scatter_blocked>
+    ttg.local_scatter %dst[%indices], %values {axis = 0 : i32} : !ttg.memdesc<8x32xi32, #local_gather_scatter_shared, #local_gather_scatter_smem, mutable>, tensor<8x32xi32, #local_gather_scatter_blocked>, tensor<8x32xi32, #local_gather_scatter_blocked>
 
     // An async-proxy consumer makes the generic-proxy classification above
     // observable in ConSan's output.

--- a/test/TritonGPU/consan.mlir
+++ b/test/TritonGPU/consan.mlir
@@ -51,6 +51,10 @@ module attributes {"ttg.num-ctas" = 2 : i32, "ttg.num-warps" = 1 : i32, ttg.shar
     // CHECK: call {{.*}}fill_global_tensor{{.*}}(%[[WRITE_TRACKING_GLOB]], %c0_i8
     // CHECK: %[[READ_TRACKING_GLOB:.*]] = ttg.global_scratch_alloc {alignment = 16 : i32, nbytes = 64 : i32, shared_cluster_state, third_party_allocation, tt.divisibility = 16 : i64} : !tt.ptr<i64>
     // CHECK: call {{.*}}fill_global_tensor{{.*}}(%[[READ_TRACKING_GLOB]], %c0_i64
+    // Matching register and shared ownership keeps an ordinary load local.
+    // CHECK: ttng.init_barrier
+    // CHECK: %[[LOCAL_CTAS:.*]] = arith.shli {{.*}} : i32
+    // CHECK: tt.call @__triton_consan_verify_write_visibility{{.*}}({{.*}}%[[LOCAL_CTAS]]{{.*}})
     // CHECK-NOT: publish_cluster_visibility
     // CHECK: tt.return
     %0 = ttg.local_alloc {allocation.offset = 0 : i32} : () -> !ttg.memdesc<32x32xf32, #shared, #smem, mutable>
@@ -152,6 +156,40 @@ module attributes {"ttg.num-ctas" = 2 : i32, "ttg.num-warps" = 4 : i32, ttg.shar
     // CHECK: tt.call @__triton_consan_verify_proxy_access
     // CHECK: ttng.async_tma_copy_local_to_global
     ttng.async_tma_copy_local_to_global %out[%c0, %c0] %dst : !tt.tensordesc<8x32xi32, #local_gather_scatter_shared>, !ttg.memdesc<8x32xi32, #local_gather_scatter_shared, #local_gather_scatter_smem, mutable>
+    tt.return
+  }
+}
+
+// -----
+
+#local_access_shared = #ttg.swizzled_shared<{vec = 1, perPhase = 1, maxPhase = 1, order = [1, 0], CGALayout = [[0, 1]]}>
+#local_access_smem = #ttg.shared_memory
+#local_access_blocked = #ttg.blocked<{sizePerThread = [1, 1], threadsPerWarp = [1, 32], warpsPerCTA = [1, 4], order = [1, 0], CGALayout = [[1, 0]]}>
+module attributes {"ttg.num-ctas" = 2 : i32, "ttg.num-warps" = 4 : i32, ttg.shared = 512 : i32, ttg.target = "cuda:90", ttg.tensor_memory_size = 0 : i32, "ttg.threads-per-warp" = 32 : i32, "ttg.total-num-warps" = 4 : i32} {
+  // CHECK-LABEL: @local_load_store_cross_cta_effects
+  tt.func public @local_load_store_cross_cta_effects() {
+    %values = arith.constant dense<1> : tensor<8x32xi32, #local_access_blocked>
+
+    // A source-backed allocation lowers through the local-store path.
+    // CHECK: ttg.local_alloc %{{.*}}
+    // CHECK: %[[ALLOC_CTAS:.*]] = arith.constant 3 : i32
+    // CHECK: tt.call @__triton_consan_set_write_visibility{{.*}}({{.*}}%[[ALLOC_CTAS]]{{.*}})
+    %buf = ttg.local_alloc %values {allocation.offset = 0 : i32} : (tensor<8x32xi32, #local_access_blocked>) -> !ttg.memdesc<8x32xi32, #local_access_shared, #local_access_smem, mutable>
+
+    // The register and shared layouts shard different logical axes, so every
+    // issuer reads from both CTA rows.
+    // CHECK: %[[LOAD_CTAS:.*]] = arith.constant 3 : i32
+    // CHECK: tt.call @__triton_consan_verify_write_visibility{{.*}}({{.*}}%[[LOAD_CTAS]]{{.*}})
+    // CHECK: ttg.local_load
+    %loaded = ttg.local_load %buf : !ttg.memdesc<8x32xi32, #local_access_shared, #local_access_smem, mutable> -> tensor<8x32xi32, #local_access_blocked>
+
+    // The corresponding store writes both CTA rows.
+    // CHECK: %[[STORE_CTAS:.*]] = arith.constant 3 : i32
+    // CHECK: tt.call @__triton_consan_verify_read_visibility{{.*}}({{.*}}%[[STORE_CTAS]]{{.*}})
+    // CHECK: ttg.local_store
+    ttg.local_store %loaded, %buf : tensor<8x32xi32, #local_access_blocked> -> !ttg.memdesc<8x32xi32, #local_access_shared, #local_access_smem, mutable>
+    // Keep the target dialect loaded in this standalone split module.
+    ttng.cluster_barrier {relaxed = true}
     tt.return
   }
 }


### PR DESCRIPTION
## Summary

- Model `ttg.local_gather` as a shared-memory read and `ttg.local_scatter` as a shared-memory write in ConSan.
- Track their alias and proxy operands through `BufferRegionAnalysis` and the ConSan target hook.
- Derive recipient CTA sets from the same block-local `LinearLayout` conversions used by lowering for gather/scatter, ordinary `ttg.local_load` and `ttg.local_store`, and source-backed `ttg.local_alloc`.
- Reject cross-CTA affine `ttg.memdesc_subslice` offsets explicitly and propagate that analysis failure through ConSan instead of silently instrumenting the wrong CTA row.
- Document the final contract and add focused, non-redundant regression coverage.

## Scope

Cross-CTA accesses expressed by supported register/shared layouts are modeled directly. Gather/scatter additionally span the static XOR image of their runtime index bases.

Cross-CTA affine memdesc-subslice offsets remain unsupported and now produce a precise diagnostic. Supporting them requires carrying the SSA value's affine block offset through the recipient-mask calculation.

## Validation

Local compiler validation:

- `TRITON_BUILD_WITH_CLANG_LLD=1 TRITON_BUILD_WITH_CCACHE=1 pip install . --no-build-isolation` — passed
- `make` — passed (`16/16` incremental targets)
- `lit -v test/TritonGPU/consan.mlir test/TritonGPU/consan-capture-reservation.mlir test/Analysis/test-buffer-region.mlir` — `3/3` passed
- Repository pre-commit hooks on all changed files and `git diff --check` — passed

GB200 validation on exact head `99d7299f697ad25e0e271bcc4b79d73d51a3f956`:

- cleared `/tmp/triton`, then `make` — passed (`28/28` targets)
- the same focused lit set — `3/3` passed
- `pytest -s --tb=short python/test/gluon/test_consan.py::test_local_gather_scatter_cross_cta_visibility` — `3 passed in 9.26s`

The GB200 validation worktree remained clean after testing.