### PR TITLE
[triton-ext] Prepend `add_` to pass functions

### DIFF
--- a/examples/plugins/TritonPlugin.cpp
+++ b/examples/plugins/TritonPlugin.cpp
@@ -58,7 +58,7 @@ static void registerTritonPluginPass() {
 }
 
 static const char *PLUGIN_NAME = "TritonPlugin";
-static const char *PASS_NAME = "add_plugin";
+static const char *PASS_NAME = "plugin";
 static const char *VERSION = "0.1.0";
 
 using namespace mlir::triton;

--- a/python/src/passes.cc
+++ b/python/src/passes.cc
@@ -117,8 +117,9 @@ void init_triton_passes_ttgpuir(py::module_ &m) {
 void init_plugin_passes(py::module_ &m) {
   for (const auto &plugin : mlir::triton::plugin::loadPlugins()) {
     for (const auto &pass : plugin.listPasses()) {
+      std::string wrapped = std::string("add_") + pass.name;
       m.def(
-          pass.name,
+          wrapped.c_str(),
           [pass](mlir::PassManager &pm, std::vector<std::string> args) {
             pass.addPass(&pm, args);
           },

--- a/python/test/unit/plugins/custom_stages.py
+++ b/python/test/unit/plugins/custom_stages.py
@@ -34,7 +34,7 @@ def inspect_stages_hook(self=None, stages=None, options=None, language=None, cap
         pm = ir.pass_manager(mod.context)
         pm.enable_debug()
         if num_warps != 4:
-            passes.plugin.add_plugin(pm, {str(num_warps)})
+            passes.plugin.add_plugin(pm, [str(num_warps)])
         else:
             passes.plugin.add_plugin(pm)
         pm.run(mod, 'make_ttir_plugin')
@@ -55,7 +55,7 @@ def inspect_stages_hook_dialect(self=None, stages=None, options=None, language=N
         mod = self.make_ttgir(mod, metadata, opt, capability)
         pm = ir.pass_manager(mod.context)
         pm.enable_debug()
-        passes.plugin.plugingpu_conversion(pm)
+        passes.plugin.add_plugingpu_conversion(pm)
         pm.run(mod, 'make_ttgir_plugin')
         return mod
 


### PR DESCRIPTION
This is a nitpick fix to always prepend `add_` on the front of the pass name before creating the `libtriton.passes.*` pass function. This allows the plugin's `PassInfo` to contain the true pass name.