### PR TITLE
[LANGUAGE] Keep fp16 minimum/maximum in fp16 for scalar literals

### DIFF
--- a/python/test/unit/language/test_core.py
+++ b/python/test/unit/language/test_core.py
@@ -6385,6 +6385,31 @@ def test_propagate_nan(dtype, propagate_nan, func, device):
             assert not torch.isnan(C[0])
 
 
+@pytest.mark.parametrize("func", ['minimum', 'maximum'])
+def test_fp16_scalar_literal_no_fp32_promotion(func, device):
+    # Regression test for #10730. minimum/maximum of an fp16 tensor and a
+    # Python float scalar literal must stay in fp16, like the other elementwise
+    # ops (e.g. `+`): a scalar of equal-or-lower kind does not participate in
+    # type promotion. Previously the operands were materialized with to_tensor()
+    # before binary_op_type_checking_impl ran, so 0.0 became a 0-d fp32 tensor
+    # and forced the result (and a loop-carried fp16 variable) to fp32.
+
+    @triton.jit
+    def kernel(X, Y, func: tl.constexpr):
+        offs = tl.arange(0, 16)
+        x = tl.load(X + offs)
+        y = getattr(tl, func)(x, 0.0)
+        tl.static_assert(y.dtype == tl.float16)
+        tl.store(Y + offs, y)
+
+    x = torch.randn((16, ), device=device, dtype=torch.float16)
+    y = torch.empty_like(x)
+    kernel[(1, )](x, y, func)
+    ref = torch.maximum(x, torch.zeros_like(x)) if func == 'maximum' else torch.minimum(x, torch.zeros_like(x))
+    assert y.dtype == torch.float16
+    torch.testing.assert_close(y, ref)
+
+
 # -----------------------
 # test clamp
 # -----------------------

--- a/python/triton/language/core.py
+++ b/python/triton/language/core.py
@@ -2999,10 +2999,6 @@ def minimum(x, y, propagate_nan: constexpr = PropagateNan.NONE, _semantic=None):
     """
     x = _unwrap_if_constexpr(x)
     y = _unwrap_if_constexpr(y)
-    if isinstance(x, tensor):
-        x = _promote_bfloat16_to_float32(x, _semantic=_semantic)
-    if isinstance(y, tensor):
-        y = _promote_bfloat16_to_float32(y, _semantic=_semantic)
     propagate_nan = _unwrap_if_constexpr(propagate_nan)
     return _semantic.minimum(x, y, propagate_nan)
 
@@ -3023,10 +3019,6 @@ def maximum(x, y, propagate_nan: constexpr = PropagateNan.NONE, _semantic=None):
     """
     x = _unwrap_if_constexpr(x)
     y = _unwrap_if_constexpr(y)
-    if isinstance(x, tensor):
-        x = _promote_bfloat16_to_float32(x, _semantic=_semantic)
-    if isinstance(y, tensor):
-        y = _promote_bfloat16_to_float32(y, _semantic=_semantic)
     propagate_nan = _unwrap_if_constexpr(propagate_nan)
     return _semantic.maximum(x, y, propagate_nan)
 

--- a/python/triton/language/core.py
+++ b/python/triton/language/core.py
@@ -2997,10 +2997,12 @@ def minimum(x, y, propagate_nan: constexpr = PropagateNan.NONE, _semantic=None):
 
     .. seealso:: :class:`tl.PropagateNan`
     """
-    x = _semantic.to_tensor(x)
-    y = _semantic.to_tensor(y)
-    x = _promote_bfloat16_to_float32(x, _semantic=_semantic)
-    y = _promote_bfloat16_to_float32(y, _semantic=_semantic)
+    x = _unwrap_if_constexpr(x)
+    y = _unwrap_if_constexpr(y)
+    if isinstance(x, tensor):
+        x = _promote_bfloat16_to_float32(x, _semantic=_semantic)
+    if isinstance(y, tensor):
+        y = _promote_bfloat16_to_float32(y, _semantic=_semantic)
     propagate_nan = _unwrap_if_constexpr(propagate_nan)
     return _semantic.minimum(x, y, propagate_nan)
 
@@ -3019,10 +3021,12 @@ def maximum(x, y, propagate_nan: constexpr = PropagateNan.NONE, _semantic=None):
 
     .. seealso:: :class:`tl.PropagateNan`
     """
-    x = _semantic.to_tensor(x)
-    y = _semantic.to_tensor(y)
-    x = _promote_bfloat16_to_float32(x, _semantic=_semantic)
-    y = _promote_bfloat16_to_float32(y, _semantic=_semantic)
+    x = _unwrap_if_constexpr(x)
+    y = _unwrap_if_constexpr(y)
+    if isinstance(x, tensor):
+        x = _promote_bfloat16_to_float32(x, _semantic=_semantic)
+    if isinstance(y, tensor):
+        y = _promote_bfloat16_to_float32(y, _semantic=_semantic)
     propagate_nan = _unwrap_if_constexpr(propagate_nan)
     return _semantic.maximum(x, y, propagate_nan)
 

--- a/python/triton/language/semantic.py
+++ b/python/triton/language/semantic.py
@@ -363,8 +363,12 @@ class TritonSemantic(Generic[TensorTy]):
 # other arithmetic ops
 ##############
 
-    def minimum(self, x: TensorTy, y: TensorTy, propagate_nan: tl.PropagateNan):
+    def minimum(self, x: TensorTy | numbers.Number, y: TensorTy | numbers.Number, propagate_nan: tl.PropagateNan):
         x, y = self.binary_op_type_checking_impl(x, y)
+        # hardware doesn't support FMAX, FMIN, CMP for bfloat16
+        if x.type.scalar is tl.bfloat16:
+            x = self.cast(x, tl.float32)
+            y = self.cast(y, tl.float32)
         dtype = x.dtype
         if dtype.is_floating():
             if propagate_nan == tl.PropagateNan.ALL:
@@ -380,8 +384,12 @@ class TritonSemantic(Generic[TensorTy]):
         else:
             raise TypeError(f"Unexpected dtype {dtype}")
 
-    def maximum(self, x: TensorTy, y: TensorTy, propagate_nan: tl.PropagateNan):
+    def maximum(self, x: TensorTy | numbers.Number, y: TensorTy | numbers.Number, propagate_nan: tl.PropagateNan):
         x, y = self.binary_op_type_checking_impl(x, y)
+        # hardware doesn't support FMAX, FMIN, CMP for bfloat16
+        if x.type.scalar is tl.bfloat16:
+            x = self.cast(x, tl.float32)
+            y = self.cast(y, tl.float32)
         dtype = x.dtype
         if dtype.is_floating():
             if propagate_nan == tl.PropagateNan.ALL:


### PR DESCRIPTION
## Summary

`tl.minimum` / `tl.maximum` of an fp16 tensor and a Python float scalar literal
promote the result through fp32, unlike the other elementwise ops. On an fp16
tensor `x`, `tl.maximum(x, 0.0)` comes out fp32, and a loop-carried fp16 variable
updated with `tl.minimum(tl.maximum(v, 0.0), 6.0)` fails to compile:

```
Loop-carried variable v has initial type fp16 but is re-assigned to fp32
```

Meanwhile `tl.maximum(x, 0)` (int literal) and `x + 1.0` correctly stay fp16.
Reported in #10730, reproduces on `main`.

## Cause

`minimum` / `maximum` call `_semantic.to_tensor()` on both operands before
`binary_op_type_checking_impl` runs. That turns `0.0` into a 0-d fp32 tensor, so
the "a scalar of equal-or-lower kind does not participate in promotion" rule in
`computation_type_impl` never sees it as a scalar, and the result is promoted to
fp32. The other elementwise ops (`add`, `sub`, `mul`, ...) instead
`_unwrap_if_constexpr` their operands and let the scalar reach
`binary_op_type_checking_impl` as a plain number — which is why `x + 1.0` is fine.

## Fix

Unwrap the operands the same way, and apply the bf16->fp32 promotion (which exists
because the hardware has no bf16 FMAX/FMIN/CMP) only to real tensors, so scalar
literals are passed through as numbers. bf16 tensor operands still promote to fp32.

## Test

`test_fp16_scalar_literal_no_fp32_promotion` checks that `minimum` / `maximum` of
an fp16 tensor and `0.0` stays fp16.

Verified locally on triton 3.7.1 by applying this change (frontend AST->TTIR
compile, no GPU): before it, `tl.maximum(fp16, 0.0)` / `tl.minimum(fp16, 6.0)` and
the loop kernel fail the dtype / loop-carried check; after it they pass, while
`tl.maximum(fp16, 0)`, `x + 1.0`, and bf16 (both scalar and tensor operands ->
fp32) are unchanged.

Fixes #10730.
