### PR TITLE
[DOCS] Document top-level triton.* API symbols

### DIFF
--- a/docs/python-api/triton.rst
+++ b/docs/python-api/triton.rst
@@ -3,11 +3,79 @@ triton
 
 .. currentmodule:: triton
 
+Compilation
+-----------
+
+.. autosummary::
+    :toctree: generated
+    :nosignatures:
+
+    compile
+
+
+JIT
+---
+
 .. autosummary::
     :toctree: generated
     :nosignatures:
 
     jit
+    JITFunction
+
+
+Autotuning
+----------
+
+.. autosummary::
+    :toctree: generated
+    :nosignatures:
+
     autotune
     heuristics
     Config
+
+
+Tensor Reinterpretation
+-----------------------
+
+.. autosummary::
+    :toctree: generated
+    :nosignatures:
+
+    reinterpret
+    TensorWrapper
+
+
+Memory
+------
+
+.. autosummary::
+    :toctree: generated
+    :nosignatures:
+
+    set_allocator
+
+
+Utilities
+---------
+
+.. autosummary::
+    :toctree: generated
+    :nosignatures:
+
+    cdiv
+    next_power_of_2
+
+
+Exceptions
+----------
+
+.. autosummary::
+    :toctree: generated
+    :nosignatures:
+
+    TritonError
+    CompilationError
+    OutOfResources
+    InterpreterError

--- a/python/triton/__init__.py
+++ b/python/triton/__init__.py
@@ -67,6 +67,16 @@ __all__ = [
 
 @constexpr_function
 def cdiv(x: int, y: int):
+    """
+    Returns the ceiling division of :code:`x` by :code:`y` (that is, :code:`x / y`
+    rounded up to the nearest integer).
+
+    Commonly used on the host to size a launch grid, e.g.
+    ``grid = (triton.cdiv(n_elements, BLOCK_SIZE), )``.
+
+    :param x: the dividend.
+    :param y: the divisor.
+    """
     return (x + y - 1) // y
 
 

--- a/python/triton/compiler/compiler.py
+++ b/python/triton/compiler/compiler.py
@@ -224,6 +224,21 @@ class CompileTimer:
 
 
 def compile(src, target=None, options=None, _env_vars=None):
+    """
+    Compiles a kernel to a device binary.
+
+    This is the lowering entry point used by :func:`triton.jit`; it can also be
+    called directly for ahead-of-time compilation.
+
+    :param src: the kernel to compile, given either as an :code:`ASTSource`
+        (a ``@triton.jit`` function together with its signature) or as a path or
+        string pointing at a textual IR module.
+    :param target: the :code:`GPUTarget` to compile for; defaults to the target of
+        the currently active device.
+    :param options: backend-specific compilation options (e.g. :code:`num_warps`,
+        :code:`num_stages`) layered over the backend defaults.
+    :returns: a compiled kernel that can be launched on the device.
+    """
     compilation_listener = knobs.compilation.listener
     if compilation_listener:
         timer = CompileTimer()

--- a/python/triton/runtime/errors.py
+++ b/python/triton/runtime/errors.py
@@ -3,6 +3,7 @@ from typing import Optional
 
 
 class InterpreterError(TritonError):
+    """Raised when an error occurs while executing a kernel in the interpreter (:code:`TRITON_INTERPRET=1`)."""
 
     def __init__(self, error_message: Optional[str] = None):
         self.error_message = error_message
@@ -12,6 +13,14 @@ class InterpreterError(TritonError):
 
 
 class OutOfResources(TritonError):
+    """
+    Raised when a kernel needs more of a hardware resource than is available,
+    for example more shared memory or registers than the device provides.
+
+    Reducing block sizes or :code:`num_stages` often resolves it. The resource is
+    named by :attr:`name`, with the requested and available amounts in
+    :attr:`required` and :attr:`limit`.
+    """
 
     def __init__(self, required, limit, name):
         self.required = required

--- a/python/triton/runtime/jit.py
+++ b/python/triton/runtime/jit.py
@@ -626,6 +626,15 @@ def convert_to_tuple_if_list(item):
 
 
 class JITFunction(JITCallable, KernelInterface[T]):
+    """
+    A just-in-time compiled Triton kernel.
+
+    Instances are produced by applying the :func:`triton.jit` decorator to a Python
+    function and are rarely constructed directly. A kernel is launched with the
+    ``kernel[grid](*args, **kwargs)`` syntax: on the first launch for a given set of
+    argument types the kernel is specialized and compiled, and the result is cached
+    for subsequent launches.
+    """
 
     def is_gluon(self):
         return False
@@ -1044,6 +1053,14 @@ class MockTensor:
 
 
 class TensorWrapper:
+    """
+    Presents a tensor under a different element type.
+
+    Returned by :func:`triton.reinterpret`. The wrapper forwards the storage,
+    shape, strides, and device of the wrapped tensor while reporting :attr:`dtype`
+    as the new type, so a kernel reads the same bytes under a different
+    interpretation.
+    """
 
     def __init__(self, base, dtype):
         self.dtype = dtype
@@ -1081,6 +1098,18 @@ class TensorWrapper:
 
 
 def reinterpret(tensor, dtype):
+    """
+    Reinterprets a tensor's data as a different element type, without copying.
+
+    This is a bitcast-like view: the underlying bytes are unchanged and only their
+    interpretation differs. Useful for element types that have no native framework
+    dtype (for example the 8-bit floating-point formats).
+
+    :param tensor: the tensor whose data should be reinterpreted.
+    :param dtype: the Triton dtype to interpret the data as.
+    :returns: a :class:`TensorWrapper` viewing :code:`tensor` as :code:`dtype` (or
+        the original tensor when the reinterpretation is a no-op).
+    """
     if isinstance(tensor, TensorWrapper):
         if dtype == tensor.base.dtype:
             # Reinterpreting to the original interpretation; return the base.


### PR DESCRIPTION
## Summary

The top-level `triton.*` API reference (`docs/python-api/triton.rst`) listed only 4 of the ~25 public symbols in `triton.__all__`. This PR organizes the page into sections and documents the missing user-facing ones. Documentation only — no behavior is changed.

## What changed

`docs/python-api/triton.rst` is reorganized into sections (Compilation / JIT / Autotuning / Tensor Reinterpretation / Memory / Utilities / Exceptions), and the following public symbols are added:

- **Compilation**: `compile`
- **JIT**: `JITFunction`
- **Tensor reinterpretation**: `reinterpret`, `TensorWrapper`
- **Memory**: `set_allocator`
- **Utilities**: `cdiv`, `next_power_of_2`
- **Exceptions**: `TritonError`, `CompilationError`, `OutOfResources`, `InterpreterError`

Symbols that already had a docstring (`next_power_of_2`, `set_allocator`, `CompilationError`) are simply listed; the others receive a short docstring at the source (`TritonError` is listed as-is). Documentation only — no behavior is changed.

## Preview

Rendered with the official `sphinx_rtd_theme`: https://bowencui123.github.io/triton-doc-preview/pr10742-full/python-api/triton.html

Signed-off-by: Bowen Cui <bcui2@gmu.edu>
