### PR TITLE
[TRITONGPU] Preserve explicit num_stages when flattening loops

### DIFF
--- a/lib/Dialect/TritonGPU/Transforms/FuseNestedLoops.cpp
+++ b/lib/Dialect/TritonGPU/Transforms/FuseNestedLoops.cpp
@@ -1008,17 +1008,22 @@ static void fuseOneLevel(LoopNestNode *parent, mlir::DominanceInfo &domInfo) {
   // Update the parent's loop to the fused loop. Set the new stage count to the
   // max stage count of the inner loops.
   int numStages = 1;
-  if (auto stageAttr = outer->getAttrOfType<IntegerAttr>(kNumStagesAttrName))
+  bool hasNumStages = false;
+  if (auto stageAttr = outer->getAttrOfType<IntegerAttr>(kNumStagesAttrName)) {
+    hasNumStages = true;
     numStages = stageAttr.getInt();
+  }
   for (InnerLoop &loop : innerLoops) {
     if (auto stageAttr =
-            loop.op->getAttrOfType<IntegerAttr>(kNumStagesAttrName))
+            loop.op->getAttrOfType<IntegerAttr>(kNumStagesAttrName)) {
+      hasNumStages = true;
       numStages = std::max<int>(numStages, stageAttr.getInt());
+    }
     loop.op.erase();
   }
   outer.erase();
   parent->loop = fused;
-  if (numStages > 1)
+  if (hasNumStages)
     fused->setAttr(kNumStagesAttrName, b.getI32IntegerAttr(numStages));
 }
 

--- a/test/TritonGPU/fuse-nested-loops.mlir
+++ b/test/TritonGPU/fuse-nested-loops.mlir
@@ -471,6 +471,22 @@ tt.func @preserve_stage_count(%lb: i32, %ub: i32) {
   tt.return
 }
 
+// CHECK-LABEL: @preserve_explicit_stage_one
+tt.func @preserve_explicit_stage_one(%lb: i32, %ub: i32) {
+  %c1_i32 = arith.constant 1 : i32
+
+  // CHECK-COUNT-1: scf.for
+  scf.for %i = %lb to %ub step %c1_i32 : i32 {
+    scf.for %j = %lb to %ub step %c1_i32 : i32 {
+      "body"(%j) : (i32) -> ()
+      scf.yield
+    }
+  } {"ttg.always-fuse", tt.num_stages = 1 : i32}
+  // CHECK: tt.num_stages = 1 : i32
+  // CHECK-NOT: scf.for
+  tt.return
+}
+
 // CHECK-LABEL: @fuse_attr_speculate
 // CHECK-SAME: [[LB:%.*]]: i32, [[UB:%.*]]: i32
 tt.func @fuse_attr_speculate(%lb: i32, %ub: i32) {


### PR DESCRIPTION
Preserve explicit `tt.num_stages` annotations when nested loops are flattened, including the explicit `tt.num_stages = 1` case.

<git-pr-chain>

#### PR chain
1. 👉 [#10744](https://github.com/triton-lang/triton/pull/10744) 👈 **YOU ARE HERE**
1. [#10782](https://github.com/triton-lang/triton/pull/10782)

</git-pr-chain>