### PR TITLE
[NVIDIA] Enable mixed-precision FP8xFP4 block-scaled dot on sm120

### DIFF
--- a/lib/Dialect/TritonGPU/Transforms/AccelerateMatmul.cpp
+++ b/lib/Dialect/TritonGPU/Transforms/AccelerateMatmul.cpp
@@ -746,11 +746,17 @@ public:
       return elemType == ScaleDotElemType::E2M1;
     };
 
-    // TODO: Enable mixed-precision mxfp for sm120
-    if (!((isFP8(aElemType) && isFP8(bElemType)) ||
-          (isFP4(aElemType) && isFP4(bElemType)))) {
+    // sm120 lowers block-scaled dots through the kind::mxf8f6f4 (FP8 operands,
+    // k=32) and kind::mxf4nvf4 (FP4 operands, k=64) MMA instructions. Same-type
+    // FP8xFP8 and FP4xFP4 are handled directly; mixed FP8xFP4 is emitted
+    // through kind::mxf8f6f4 with the FP4 operand carried in the f8f6f4
+    // container.
+    auto isFP8OrFP4 = [&](ScaleDotElemType elemType) -> bool {
+      return isFP8(elemType) || isFP4(elemType);
+    };
+    if (!(isFP8OrFP4(aElemType) && isFP8OrFP4(bElemType))) {
       return rewriter.notifyMatchFailure(
-          dotOp, "only FP8xFP8 and FP4xFP4 are supported on sm120");
+          dotOp, "only FP8 and FP4 operands are supported on sm120");
     }
 
     auto scaleElemType = dotOp.getAScale().getType().getElementType();
@@ -765,6 +771,49 @@ public:
     // Operand processing
     Value a = dotOp.getA();
     Value b = dotOp.getB();
+
+    // Mixed FP8 x FP4: sm120's warp-level scaled MMA has no native mixed
+    // fragment, so widen the FP4 (e2m1) operand to e4m3 and run it through the
+    // same-type FP8 mxf8f6f4 path. e2m1's representable values are an exact
+    // subset of e4m3, so this is lossless; the FP4 operand is still loaded as 4
+    // bits and only widened in registers right before the MMA.
+    auto aElemTypeNew = aElemType;
+    auto bElemTypeNew = bElemType;
+    auto widenFp4ToE4M3 = [&](Value v, int opIdx) -> Value {
+      auto ty = cast<RankedTensorType>(v.getType());
+      int kAxis = (opIdx == 0) ? ty.getRank() - 1 : ty.getRank() - 2;
+      // Unpack e2m1 (i8, two values per byte) to f16, reusing the tested path;
+      // this doubles the K axis so it matches the FP8 operand.
+      auto vTyped = cast<TypedValue<RankedTensorType>>(v);
+      Value asF16 = triton::gpu::Fp4ToFpOp::create(
+          rewriter, dotOp.getLoc(), vTyped, rewriter.getF16Type(), kAxis);
+      auto f16Ty = cast<RankedTensorType>(asF16.getType());
+      auto f8Ty = RankedTensorType::get(
+          f16Ty.getShape(), Float8E4M3FNType::get(rewriter.getContext()),
+          f16Ty.getEncoding());
+      // e2m1's values are an exact subset of e4m3, so this cast is lossless
+      // (the rounding mode is required by the verifier but never rounds here).
+      auto rnd = triton::RoundingModeAttr::get(rewriter.getContext(),
+                                               triton::RoundingMode::RTNE);
+      return triton::FpToFpOp::create(rewriter, dotOp.getLoc(), f8Ty, asF16,
+                                      rnd);
+    };
+    // The widening unpacks the FP4 operand along K, so it only handles a
+    // K-packed FP4 operand; a non-K-packed one falls back to decomposition.
+    if (isFP4(aElemType) && isFP8(bElemType)) {
+      if (!dotOp.getLhsKPack())
+        return rewriter.notifyMatchFailure(
+            dotOp, "sm120 mixed FP8xFP4 requires a K-packed FP4 operand");
+      a = widenFp4ToE4M3(a, /*opIdx=*/0);
+      aElemTypeNew = ScaleDotElemType::E4M3;
+    } else if (isFP8(aElemType) && isFP4(bElemType)) {
+      if (!dotOp.getRhsKPack())
+        return rewriter.notifyMatchFailure(
+            dotOp, "sm120 mixed FP8xFP4 requires a K-packed FP4 operand");
+      b = widenFp4ToE4M3(b, /*opIdx=*/1);
+      bElemTypeNew = ScaleDotElemType::E4M3;
+    }
+
     auto oldAType = cast<RankedTensorType>(a.getType());
     auto oldBType = cast<RankedTensorType>(b.getType());
 
@@ -798,9 +847,8 @@ public:
 
     newDot = triton::DotScaledOp::create(
         rewriter, dotOp.getLoc(), mmaResult.newRetType, newA, newB,
-        mmaResult.newAcc, aScale, bScale, dotOp.getAElemType(),
-        dotOp.getBElemType(), dotOp.getFastMath(), dotOp.getLhsKPack(),
-        dotOp.getRhsKPack());
+        mmaResult.newAcc, aScale, bScale, aElemTypeNew, bElemTypeNew,
+        dotOp.getFastMath(), dotOp.getLhsKPack(), dotOp.getRhsKPack());
     rewriter.replaceOpWithNewOp<ConvertLayoutOp>(dotOp, dotOp.getType(),
                                                  newDot->getResult(0));
     return success();

--- a/python/test/unit/language/test_matmul.py
+++ b/python/test/unit/language/test_matmul.py
@@ -1198,12 +1198,21 @@ def mxfp8_mxfp4_matmul(  #
 def test_mxfp8_mxfp4_matmul(M, N, K, BLOCK_M, BLOCK_N, BLOCK_K, NUM_STAGES, B_TRANS, PACK_B_ALONG_K, CONST_SCALE,
                             A_DATA_TYPE, B_DATA_TYPE, WITH_A_SCALE, WITH_B_SCALE, nonKDim, device):
     if is_cuda():
-        if torch.cuda.get_device_capability()[0] != 10:
-            pytest.skip("Requires compute capability == 10")
+        cc = torch.cuda.get_device_capability()[0]
+        if cc not in (10, 12):
+            pytest.skip("Requires compute capability 10 or 12")
         if not (WITH_A_SCALE and WITH_B_SCALE):
             pytest.skip("None scale has not been tested on NV backend")
-        if not (A_DATA_TYPE == "float8e5" and B_DATA_TYPE == "float4"):
-            pytest.skip(f"(A: {A_DATA_TYPE}, B: {B_DATA_TYPE}) has not been tested on NV backend")
+        if cc == 10:
+            if not (A_DATA_TYPE == "float8e5" and B_DATA_TYPE == "float4"):
+                pytest.skip(f"(A: {A_DATA_TYPE}, B: {B_DATA_TYPE}) has not been tested on NV backend")
+        else:
+            # sm120 lowers mixed FP8 x FP4 through the kind::mxf8f6f4 MMA by
+            # widening the FP4 operand to e4m3, so exactly one operand is FP4.
+            if (A_DATA_TYPE == "float4") == (B_DATA_TYPE == "float4"):
+                pytest.skip("sm120 mixed path requires exactly one FP4 operand")
+            if not PACK_B_ALONG_K:
+                pytest.skip("Packing FP4 along M/N is not supported on sm120")
     elif is_hip():
         if not (is_hip_cdna4() or is_hip_gfx1250()):
             pytest.skip("Scaled mxfp4 & mxfp8 matmul is only natively supported on CDNA4 and above")
@@ -1289,8 +1298,11 @@ def test_mxfp8_mxfp4_matmul(M, N, K, BLOCK_M, BLOCK_N, BLOCK_K, NUM_STAGES, B_TR
                                    dtype_converter[A_DATA_TYPE], dtype_converter[B_DATA_TYPE], BLOCK_M, BLOCK_N,
                                    BLOCK_K, PACK_B_ALONG_K=PACK_B_ALONG_K, NUM_STAGES=NUM_STAGES, **kernel_kwargs)
     if is_cuda():
-        ttgir = out.asm["ttgir"]
-        assert "fp4Padded = true" in ttgir
+        if torch.cuda.get_device_capability()[0] == 12:
+            # sm120 widens the FP4 operand to e4m3 and uses the FP8 mxf8f6f4 MMA.
+            assert ("mma.sync.aligned.m16n8k32.row.col.kind::mxf8f6f4.block_scale.scale_vec::1X" in out.asm["ptx"])
+        else:
+            assert "fp4Padded = true" in out.asm["ttgir"]
 
     torch.testing.assert_close(ref_out, output, atol=1e-3, rtol=1e-3)
 

--- a/test/Conversion/tritongpu_to_llvm_sm120.mlir
+++ b/test/Conversion/tritongpu_to_llvm_sm120.mlir
@@ -28,3 +28,33 @@ module attributes {"ttg.target" = "cuda:120", "ttg.num-ctas" = 1 : i32, "ttg.num
     tt.return
   }
 }
+
+// -----
+
+#blocked = #ttg.blocked<{sizePerThread = [1, 1], threadsPerWarp = [1, 32], warpsPerCTA = [1, 4], order = [1, 0]}>
+#blocked_k = #ttg.blocked<{sizePerThread = [1, 1], threadsPerWarp = [1, 32], warpsPerCTA = [4, 1], order = [0, 1]}>
+
+module attributes {"ttg.target" = "cuda:120", "ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, "ttg.threads-per-warp" = 32 : i32} {
+  // CHECK-LABEL: @sm120_mmav2_dot_scaled_mixed
+  // The FP4 (e2m1) operand is widened to e4m3 and routed through the FP8
+  // mxf8f6f4 MMA, so both operands report e4m3 in the PTX type string.
+  // CHECK: mma.sync.aligned.m16n8k32.row.col.kind::mxf8f6f4.block_scale.scale_vec::1X.f32.e4m3.e4m3
+  tt.func public @sm120_mmav2_dot_scaled_mixed(
+    %a: tensor<128x64xf8E4M3FN, #blocked_k>,
+    %scale_a: tensor<128x2xi8, #blocked>,
+    %b: tensor<32x128xi8, #blocked>,
+    %scale_b: tensor<128x2xi8, #blocked>,
+    %out: !tt.ptr<f32>
+  ){
+    %cst = arith.constant dense<0.000000e+00> : tensor<128x128xf32, #blocked>
+    %d = tt.dot_scaled %a scale %scale_a, %b scale %scale_b, %cst lhs = e4m3 rhs = e2m1 {fastMath = false}
+      : tensor<128x64xf8E4M3FN, #blocked_k>, tensor<128x2xi8, #blocked>
+        * tensor<32x128xi8, #blocked>, tensor<128x2xi8, #blocked>
+        -> tensor<128x128xf32, #blocked>
+    %out_splat = tt.splat %out : !tt.ptr<f32> -> tensor<128x1x!tt.ptr<f32>, #blocked>
+    %out_ptrs = tt.broadcast %out_splat : tensor<128x1x!tt.ptr<f32>, #blocked> -> tensor<128x128x!tt.ptr<f32>, #blocked>
+    %zero = arith.constant dense<0> : tensor<128x128xi1, #blocked>
+    tt.store %out_ptrs, %d, %zero : tensor<128x128x!tt.ptr<f32>, #blocked>
+    tt.return
+  }
+}

--- a/test/TritonGPU/accelerate-matmul.mlir
+++ b/test/TritonGPU/accelerate-matmul.mlir
@@ -841,6 +841,37 @@ module attributes {"ttg.target" = "cuda:120", "ttg.num-ctas" = 1 : i32, "ttg.num
 
 // -----
 
+// Verify that for SM_120 with mixed FP8 x FP4 inputs the FP4 (e2m1) operand is
+// unpacked (ttg.fp4_to_fp, K doubled) and widened to f8E4M3FN (lossless) via
+// tt.fp_to_fp, so the rewritten dot is e4m3 x e4m3 routed through the
+// kind::mxf8f6f4 MMAv2 path with linear-layout scales.
+
+#blocked = #ttg.blocked<{sizePerThread = [1, 1], threadsPerWarp = [1, 32], warpsPerCTA = [1, 4], order = [1, 0]}>
+#blocked_k = #ttg.blocked<{sizePerThread = [1, 1], threadsPerWarp = [1, 32], warpsPerCTA = [4, 1], order = [0, 1]}>
+
+module attributes {"ttg.target" = "cuda:120", "ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, "ttg.threads-per-warp" = 32 : i32} {
+  // CHECK-LABEL: @sm120_dot_scaled_mixed_fp8_fp4
+  // CHECK: ttg.fp4_to_fp %{{.*}} {axis = 0 : i32} : {{.*}} -> tensor<64x128xf16
+  // CHECK: tt.fp_to_fp %{{.*}} rounding = rtne : {{.*}} -> tensor<64x128xf8E4M3FN
+  // CHECK: tt.dot_scaled {{.*}} lhs = e4m3 rhs = e4m3
+  // CHECK-NOT: ttng.tc_gen5_mma_scaled
+  tt.func public @sm120_dot_scaled_mixed_fp8_fp4(
+    %a: tensor<128x64xi8, #blocked_k>,
+    %scale_a: tensor<128x2xi8, #blocked>,
+    %b: tensor<32x128xi8, #blocked>,
+    %scale_b: tensor<128x2xi8, #blocked>
+  ) -> tensor<128x128xf32, #blocked> {
+    %cst = arith.constant dense<0.000000e+00> : tensor<128x128xf32, #blocked>
+    %d = tt.dot_scaled %a scale %scale_a, %b scale %scale_b, %cst lhs = e4m3 rhs = e2m1 {fastMath = false}
+      : tensor<128x64xi8, #blocked_k>, tensor<128x2xi8, #blocked>
+        * tensor<32x128xi8, #blocked>, tensor<128x2xi8, #blocked>
+        -> tensor<128x128xf32, #blocked>
+    tt.return %d : tensor<128x128xf32, #blocked>
+  }
+}
+
+// -----
+
 // Verify that for SM_120 with mixed fp16/fp8 inputs, tt.dot_scaled falls back
 // to decomposition instead of native dot_scaled MMAv2 lowering.
 


### PR DESCRIPTION
sm120 lowers block-scaled tt.dot_scaled through the kind::mxf8f6f4 (FP8, k=32) and kind::mxf4nvf4 (FP4, k=64) tensor-core instructions, but ScaledBlockedToMMA only accepted same-type FP8xFP8 / FP4xFP4. A mixed dot_scaled (e.g. mxfp4 x mxfp8) therefore fell back to upcast+emulation instead of using the tensor core.

Enable the mixed case by widening the FP4 (e2m1) operand to e4m3 and running it through the existing same-type FP8 mxf8f6f4 path. e2m1's representable values are an exact subset of e4m3, so the widening is lossless; the FP4 operand is still loaded as 4 bits and only widened in registers right before the MMA, so the load-bandwidth saving is preserved while the fp8 tensor core and hardware block-scaling are used. The widening unpacks the FP4 operand along K, so a non-K-packed FP4 operand is left to the decomposition fallback.

Validated on an RTX 5090 (sm120): both operand orderings emit mma.sync...kind::mxf8f6f4...e4m3.e4m3...ue8m0 and match an fp32 reference exactly. Tests: a lit test in accelerate-matmul.mlir asserting the FP4->e4m3 widening, a conversion test in tritongpu_to_llvm_sm120.mlir locking the emitted mxf8f6f4 PTX, and test_mxfp8_mxfp4_matmul enabled on sm120 (192 mixed cases pass, asserting both the reference match and the mxf8f6f4 PTX).

<!---
The core Triton is a small number of people, and we receive many PRs (thank
you!).  To help us review your code more quickly, **if you are a new
contributor (less than 3 PRs merged) we ask that you complete the following
tasks and include the filled-out checklist in your PR description.**

Complete the following tasks before sending your PR, and replace `[ ]` with
`[x]` to indicate you have done them.
-->

# New contributor declaration
- [x] I am not making a trivial change, such as fixing a typo in a comment.

- [x] I have written a PR description following these
  [rules](https://cbea.ms/git-commit/#why-not-how).

- [x] I have run `pre-commit run --from-ref origin/main --to-ref HEAD`.

- Select one of the following.
  - [x] I have added tests.
    - `/test` for `lit` tests
    - `/unittest` for C++ tests
    - `/python/test` for end-to-end tests
  - [ ] This PR does not need a test because `FILL THIS IN`.

- Select one of the following.
  - [ ] I have not added any `lit` tests.
  - [x] The `lit` tests I have added follow these [best practices](https://mlir.llvm.org/getting_started/TestingGuide/#filecheck-best-practices),
    including the "tests should be minimal" section. (Usually running Python code
    and using the instructions it generates is not minimal.)
