### PR TITLE
Use InferTypeOpInterface for JoinOp

### DIFF
--- a/include/triton/Dialect/Triton/IR/TritonOps.td
+++ b/include/triton/Dialect/Triton/IR/TritonOps.td
@@ -528,7 +528,10 @@ def TT_CatOp : TT_Op<"cat", [NoMemoryEffect,
 }
 
 def TT_JoinOp : TT_Op<"join", [
-    Pure, SameTypeOperands]> {
+  Pure,
+  SameTypeOperands,
+  InferTypeOpAdaptorWithIsCompatible,
+]> {
     let summary = "join two tensors along a new, minor dimension";
     let description = [{
         For example, if the two input tensors are 4x8xf32, returns a tensor of
@@ -538,13 +541,9 @@ def TT_JoinOp : TT_Op<"join", [
         the two input tensors must have the same shape.
     }];
 
-    let builders = [
-      OpBuilder<(ins "Value":$lhs, "Value":$rhs)>
-    ];
     let arguments = (ins TT_Tensor:$lhs, TT_Tensor:$rhs);
     let results = (outs TT_Tensor:$result);
     let assemblyFormat = "$lhs `,` $rhs attr-dict `:` type($lhs) `->` type($result)";
-    let hasVerifier = 1;
 }
 
 def TT_SplitOp : TT_Op<"split", [

--- a/lib/Dialect/Triton/IR/Ops.cpp
+++ b/lib/Dialect/Triton/IR/Ops.cpp
@@ -1367,9 +1367,42 @@ LogicalResult ReturnOp::verify() {
 
 // -- JoinOp --
 
-void JoinOp::build(OpBuilder &builder, OperationState &state, Value lhs,
-                   Value rhs) {
-  auto lhsTy = cast<RankedTensorType>(lhs.getType());
+bool JoinOp::isCompatibleReturnTypes(TypeRange lhs, TypeRange rhs) {
+  auto lhsTy = cast<RankedTensorType>(lhs.front());
+  auto rhsTy = cast<RankedTensorType>(rhs.front());
+  if (lhsTy.getShape() != rhsTy.getShape() ||
+      lhsTy.getElementType() != rhsTy.getElementType())
+    return false;
+
+  auto lhsEnc = lhsTy.getEncoding();
+  auto rhsEnc = rhsTy.getEncoding();
+  if (!lhsEnc || !rhsEnc)
+    return !lhsEnc && !rhsEnc;
+
+  // There are multiple correct destination layout for a given source layout but
+  // there is only one correct source layout (modulo broadcasting) for a given
+  // destination layout. So we verify that the source layout match the
+  // destination layout.
+  auto interface = cast<DialectInferLayoutInterface>(&lhsEnc.getDialect());
+  Attribute lhsSrcEnc;
+  Attribute rhsSrcEnc;
+  if (failed(interface->inferSplitOpEncoding(lhsEnc, lhsSrcEnc,
+                                             lhsTy.getShape(), {})) ||
+      failed(interface->inferSplitOpEncoding(rhsEnc, rhsSrcEnc,
+                                             lhsTy.getShape(), {})))
+    return false;
+
+  auto srcShape = lhsTy.getShape().drop_back();
+  return succeeded(
+      interface->verifyLayoutsAreEqual(srcShape, lhsSrcEnc, rhsSrcEnc, {},
+                                       /*ignoreRegBroadcast=*/true));
+}
+
+LogicalResult
+JoinOp::inferReturnTypes(MLIRContext *context, std::optional<Location> location,
+                         JoinOp::Adaptor adaptor,
+                         SmallVectorImpl<Type> &inferredReturnTypes) {
+  auto lhsTy = cast<RankedTensorType>(adaptor.getLhs().getType());
   SmallVector<int64_t> retShape(lhsTy.getShape());
   retShape.push_back(2);
 
@@ -1377,53 +1410,13 @@ void JoinOp::build(OpBuilder &builder, OperationState &state, Value lhs,
   Attribute retEnc;
   if (srcEnc) {
     if (failed(cast<DialectInferLayoutInterface>(&srcEnc.getDialect())
-                   ->inferDefaultJoinOpEncoding(
-                       srcEnc, retEnc, lhsTy.getShape(), state.location))) {
+                   ->inferDefaultJoinOpEncoding(srcEnc, retEnc,
+                                                lhsTy.getShape(), location))) {
       llvm_unreachable("failed to infer join encoding");
     }
   }
   auto retTy = RankedTensorType::get(retShape, lhsTy.getElementType(), retEnc);
-  JoinOp::build(builder, state, retTy, lhs, rhs);
-}
-
-LogicalResult JoinOp::verify() {
-  RankedTensorType srcTy = getLhs().getType();
-  SmallVector<int64_t> retShape(srcTy.getShape());
-  retShape.push_back(2);
-
-  RankedTensorType retTy = getType();
-  if (SmallVector<int64_t>(retTy.getShape()) != retShape) {
-    return emitOpError("result shape must be (")
-           << retShape << "), but got " << retTy.getShape();
-  }
-  if (retTy.getElementType() != srcTy.getElementType()) {
-    return emitOpError("result element type must match the input element type");
-  }
-  Attribute retEnc = retTy.getEncoding();
-  if (!retEnc) {
-    if (srcTy.getEncoding()) {
-      return emitOpError("result encoding must be specified");
-    }
-    return success();
-  }
-  // There are multiple correct destination layout for a given source layout but
-  // there is only one correct source layout (modulo broadcasting) for a given
-  // destination layout. So we verify that the source layout match the
-  // destination layout.
-  Attribute srcEnc;
-  Location location = getLoc();
-  if (cast<DialectInferLayoutInterface>(&retEnc.getDialect())
-          ->inferSplitOpEncoding(retEnc, srcEnc, retShape, location)
-          .failed()) {
-    return failure();
-  }
-
-  if (cast<triton::DialectInferLayoutInterface>(&srcEnc.getDialect())
-          ->verifyLayoutsAreEqual(srcTy.getShape(), srcEnc, srcTy.getEncoding(),
-                                  {}, /*ignoreRegBroadcast=*/true)
-          .failed()) {
-    return emitOpError("incompatible join layout");
-  }
+  inferredReturnTypes.push_back(retTy);
   return success();
 }
 

--- a/test/Triton/invalid.mlir
+++ b/test/Triton/invalid.mlir
@@ -79,7 +79,8 @@ tt.func public @fn(%arg0: tensor<32x32xf32>, %arg1: tensor<32x32xf16>) {
 // -----
 
 tt.func public @fn(%arg0: tensor<32xf32>, %arg1: tensor<32xf32>) {
-    // expected-error @+1 {{op result shape must be (32, 2), but got 64}}
+    // expected-error @+2 {{op inferred type}}
+    // expected-error @+1 {{op failed to infer returned types}}
     %a = tt.join %arg0, %arg1 : tensor<32xf32> -> tensor<64xf32>
     tt.return
 }
@@ -87,7 +88,8 @@ tt.func public @fn(%arg0: tensor<32xf32>, %arg1: tensor<32xf32>) {
 // -----
 
 tt.func public @fn(%arg0: tensor<32x32xf32>, %arg1: tensor<32x32xf32>) {
-    // expected-error @+1 {{result shape must be (32, 32, 2), but got 32, 64}}
+    // expected-error @+2 {{op inferred type}}
+    // expected-error @+1 {{op failed to infer returned types}}
     %a = tt.join %arg0, %arg1 : tensor<32x32xf32> -> tensor<32x64xf32>
     tt.return
 }
@@ -186,7 +188,8 @@ tt.func public @fn(%v1: tensor<4x128xf32>, %v2: tensor<4x128xi64>) {
 #blocked = #ttg.blocked<{sizePerThread = [1], threadsPerWarp = [32], warpsPerCTA = [1], order = [0]}>
 module attributes {"ttg.target" = "cuda:80", "ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 1 : i32, "ttg.threads-per-warp" = 32 : i32} {
 tt.func public @fn(%arg0: tensor<32xf32, #blocked>) {
-    // expected-error @+1 {{op result encoding must be specified}}
+    // expected-error @+2 {{op inferred type}}
+    // expected-error @+1 {{op failed to infer returned types}}
     %a = tt.join %arg0, %arg0 : tensor<32xf32, #blocked> -> tensor<32x2xf32>
     tt.return
 }
@@ -199,7 +202,8 @@ tt.func public @fn(%arg0: tensor<32xf32, #blocked>) {
 #blocked1 = #ttg.blocked<{sizePerThread = [1,2], threadsPerWarp = [32,1], warpsPerCTA = [1,1], order = [0,1]}>
 module attributes {"ttg.target" = "cuda:80", "ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 1 : i32, "ttg.threads-per-warp" = 32 : i32} {
 tt.func public @fn(%arg0: tensor<32xf32, #blocked>) {
-    // expected-error @+1 {{op incompatible join layout}}
+    // expected-error @+2 {{op inferred type}}
+    // expected-error @+1 {{op failed to infer returned types}}
     %a = tt.join %arg0, %arg0 : tensor<32xf32, #blocked> -> tensor<32x2xf32, #blocked1>
     tt.return
 }


### PR DESCRIPTION

This makes it consistent with `SplitOp`, and saves us needing to add a
custom builder and verifier.

---
[//]: # (BEGIN SAPLING FOOTER)
* __->__ #10748
* #10731
* #10749