### PR TITLE
[PartitionScheduling] Fix WarpSpecialization heuristic bug and modernize idioms

### DIFF
--- a/lib/Dialect/TritonGPU/Transforms/WarpSpecialization/PartitionScheduling.cpp
+++ b/lib/Dialect/TritonGPU/Transforms/WarpSpecialization/PartitionScheduling.cpp
@@ -228,7 +228,7 @@ std::unique_ptr<Graph> buildGraph(Operation *region) {
     for (auto &use : value.getUses()) {
       auto op = use.getOwner();
       auto key = std::make_pair(op, use.getOperandNumber());
-      if (operands.find(key) != operands.end()) {
+      if (operands.contains(key)) {
         auto inputPort = operands[key];
         Node::addEdge(outputPort, inputPort);
       }
@@ -279,7 +279,7 @@ void propagateDataValues(const SmallVector<OutputPort> &values) {
 
   auto add = [&](OutputPort value) {
     value.getNode()->setDataValue(value.getIdx());
-    if (seen.find(value) == seen.end()) {
+    if (!seen.contains(value)) {
       stack.push_back(value);
       seen.insert(value);
     }
@@ -331,7 +331,7 @@ SmallVector<Edge> getOutCrossingEdges(Partition *partition) {
 }
 
 void deserializeManualPartitions(Operation *region, Graph *graph) {
-  std::map<int, Partition *> manual_partitions;
+  DenseMap<int, Partition *> manual_partitions;
   graph->walk([&](Node *node) {
     if (node->isOp()) {
       auto op = node->getOp();
@@ -340,7 +340,7 @@ void deserializeManualPartitions(Operation *region, Graph *graph) {
             cast<DenseI32ArrayAttr>(op->getAttr(kPartitionAttrName))
                 .asArrayRef();
         for (auto id : partitionIds) {
-          if (manual_partitions.find(id) == manual_partitions.end()) {
+          if (!manual_partitions.contains(id)) {
             auto partition = graph->addPartition();
             partition->addFlag(Flags::MANUAL);
             manual_partitions[id] = partition;
@@ -576,6 +576,7 @@ SmallVector<std::pair<std::string, std::function<bool(Edge)>>> heuristics = {
        auto to = edge.getToNode();
        if (!isMMA(from)) {
          // skip if not from an MMA
+         return false;
        }
        if (!isIfResult(to))
          // skip if not to an if op result
@@ -849,7 +850,7 @@ void mergePartitions(Graph *graph, std::string funcName,
                    << crossingEdges.size() << " crossing edges remaining\n";
     });
 
-    for (auto [name, apply] : heuristics) {
+    for (const auto &[name, apply] : heuristics) {
       for (auto it = crossingEdges.begin(); it != crossingEdges.end();) {
         auto edge = *it;
 
@@ -862,7 +863,7 @@ void mergePartitions(Graph *graph, std::string funcName,
         if (apply(edge)) {
           // check if applying the heuristic will satisfy the constraints
           bool ok = true;
-          for (auto [name, constraint] : constraints) {
+          for (const auto &[name, constraint] : constraints) {
             if (!constraint(edge)) {
               ok = false;
               break;
@@ -915,7 +916,7 @@ void mergePartitions(Graph *graph, std::string funcName,
       SmallVector<Partition *> all_partitions;
       for (auto partition : graph->getPartitions())
         all_partitions.push_back(partition);
-      for (auto [name, apply] : partition_heuristics) {
+      for (const auto &[name, apply] : partition_heuristics) {
         for (auto partitionA : all_partitions) {
           for (auto partitionB : all_partitions) {
             if (partitionA == partitionB)
@@ -1026,7 +1027,7 @@ void propagatePartitions(Graph *graph, std::string funcName,
             node->addPartitions(partitions);
             auto numPartitionsAfter = node->getPartitions().size();
             changed |= (numPartitionsBefore != numPartitionsAfter);
-            if (seen.count(node) == 0) {
+            if (!seen.contains(node)) {
               stack.push_back(node);
               seen.insert(node);
             }
@@ -1148,7 +1149,7 @@ void propagatePartitions(Graph *graph, std::string funcName,
           continue;
         fromNode->addPartitions(partitions);
 
-        if (seen.count(edge.getFromNode()) == 0) {
+        if (!seen.contains(edge.getFromNode())) {
           stack.push_back(fromNode);
           seen.insert(fromNode);
         }
@@ -1191,7 +1192,7 @@ void duplicateCheapOps(Graph *graph, std::string funcName,
         continue;
 
       auto update = [&]() {
-        std::map<Node *, Node *> parentMap;
+        DenseMap<Node *, Node *> parentMap;
 
         SmallVector<Node *> stack;
         stack.push_back(start);
@@ -1208,12 +1209,12 @@ void duplicateCheapOps(Graph *graph, std::string funcName,
                 if (child->getPartitions().size() != 1 || !isCandidate(child)) {
                   // do nothing
                 } else if (child->getPartition() == partition) {
-                  parentMap.emplace(child, node);
+                  parentMap.try_emplace(child, node);
                   stack.push_back(child);
                 } else if (child->getPartition() == startPartition) {
                   // found a path, set all nodes on the path to the partition
                   node->addPartition(startPartition);
-                  while (parentMap.find(node) != parentMap.end()) {
+                  while (parentMap.contains(node)) {
                     node = parentMap[node];
                     node->addPartition(startPartition);
                   }

--- a/test/TritonGPU/partition-scheduling.mlir
+++ b/test/TritonGPU/partition-scheduling.mlir
@@ -807,3 +807,46 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.targ
     tt.return
   }
 }
+
+// -----
+
+// The if_op_result_token heuristic should only place an scf.if result token in
+// the same partition as its producer when that producer is an MMA op. Here the
+// token is produced by a non-MMA op, so the if result must NOT be pulled into
+// the producer's partition; it stays with its consumer instead.
+#shared = #ttg.nvmma_shared<{swizzlingByteWidth = 128, transposed = false, elementBitWidth = 16}>
+#load_blocked = #ttg.blocked<{sizePerThread = [1, 1], threadsPerWarp = [1, 32], warpsPerCTA = [2, 2], order = [1, 0]}>
+module attributes {"ttg.num-warps" = 4 : i32, ttg.target = "cuda:100"} {
+
+// CHECK-LABEL: @if_result_token_non_mma_producer
+tt.func @if_result_token_non_mma_producer(%desc: !tt.tensordesc<64x128xf16, #shared>) {
+  %c0_i32 = arith.constant 0 : i32
+  %c1_i32 = arith.constant 1 : i32
+  %true = arith.constant true
+  %false = arith.constant false
+  %c32_i32 = arith.constant 32 : i32
+  scf.for %i = %c0_i32 to %c32_i32 step %c1_i32 : i32 {
+    %off:3 = "get_offsets"(%i) : (i32) -> (i32, i32, i32)
+    %ld = tt.descriptor_load %desc[%off#1, %off#2] : !tt.tensordesc<64x128xf16, #shared> -> tensor<64x128xf16, #load_blocked>
+    "sink"(%ld) : (tensor<64x128xf16, #load_blocked>) -> ()
+    // Non-MMA token producer, pinned to its own partition.
+    // CHECK: "make_token"() {{.*}}ttg.partition = array<i32: [[PROD:[0-9]+]]>
+    %tok = "make_token"() {data, ttg.partition = array<i32: 3>} : () -> !ttg.async.token
+    %cond = arith.cmpi eq, %i, %c0_i32 : i32
+    // The scf.if result token must land in the consumer's partition, NOT the
+    // producer's. With the buggy heuristic (missing return false) the if result
+    // was instead merged into [[PROD]].
+    // CHECK: scf.if
+    // CHECK: ttg.partition.outputs = [array<i32: [[CONS:[0-9]+]]>]
+    // CHECK-NOT: ttg.partition.outputs = {{\[}}array<i32: [[PROD]]>]
+    %r = scf.if %cond -> (!ttg.async.token) {
+      scf.yield %tok : !ttg.async.token
+    } else {
+      scf.yield %tok : !ttg.async.token
+    }
+    // CHECK: "consume"({{.*}}) {{.*}}ttg.partition = array<i32: [[CONS]]>
+    "consume"(%r) {data, ttg.partition = array<i32: 5>} : (!ttg.async.token) -> ()
+  } {tt.disallow_acc_multi_buffer, tt.num_stages = 2 : i32, tt.warp_specialize}
+  tt.return
+}
+}


### PR DESCRIPTION
Fixes #9853. Picks up the stalled draft #10278 (thanks @kimjune01) and completes it.

- Bug fix: missing `return false` in the `if_op_result_token` heuristic — the `!isMMA(from)` guard body was empty, so non-MMA producers weren't skipped. Every sibling heuristic uses the early-`return false` pattern.
- Idioms: `std::map`→`DenseMap` (×2), `.find()!=.end()`, `.count()==0` → `.contains()` (5 total, incl. two the original issue missed).
- Efficiency: take heuristic-list entries by `const auto &` to avoid per-iteration `std::function` copies in the merge loop.

Test plan: Lit test exercising the `if_op_result_token` MMA guard 

cc: @peterbell10 