### PR TITLE
[triton-ext] Prepend `create_` to custom operation builders

### DIFF
--- a/examples/plugins/DialectPlugins/DialectPlugin/lib/DialectPlugin/DialectPluginDialect.cpp
+++ b/examples/plugins/DialectPlugins/DialectPlugin/lib/DialectPlugin/DialectPluginDialect.cpp
@@ -68,7 +68,7 @@ TRITON_PLUGIN_API plugin::PluginInfo *tritonGetPluginInfo() {
   static plugin::DialectInfo dialect = {DIALECT_NAME, VERSION,
                                         registerTritonPluginDialect};
   static plugin::DialectInfo dialects[] = {dialect};
-  static plugin::OpInfo op = {"create_custom_op", addTritonPluginCustomOp};
+  static plugin::OpInfo op = {"custom_op", addTritonPluginCustomOp};
   static plugin::OpInfo ops[] = {op};
   static plugin::PluginInfo info = {TRITON_PLUGIN_API_VERSION,
                                     PLUGIN_NAME,

--- a/python/src/ir.cc
+++ b/python/src/ir.cc
@@ -1897,8 +1897,10 @@ void init_triton_ir(py::module_ &m) {
   // Add custom operations.
   for (const auto &plugin : mlir::triton::plugin::loadPlugins()) {
     for (const auto &op : plugin.listOps()) {
+      std::string wrapped = std::string("create_") + op.name;
       TritonOpBuilderBinding.def(
-          op.name, [op](TritonOpBuilder &self, std::vector<Value> args) {
+          wrapped.c_str(),
+          [op](TritonOpBuilder &self, std::vector<Value> args) {
             args.insert(args.begin(), Value());
             op.addOp(self, args);
             return args[0];


### PR DESCRIPTION
Like #10737, this change is a minor tweak to prepend `create_` to each custom operation in `libtriton.ir.builder.*`.
