### PR TITLE
[AMD] Fix atomic_poll timeout crash on gfx11/gfx12

### DIFF
--- a/third_party/amd/lib/TritonAMDGPUToLLVM/TargetInfo.cpp
+++ b/third_party/amd/lib/TritonAMDGPUToLLVM/TargetInfo.cpp
@@ -167,9 +167,21 @@ Value TargetInfo::ballot(RewriterBase &rewriter, Location loc, Type type,
 
 Value TargetInfo::getGlobalTimer(RewriterBase &rewriter, Location loc) const {
   auto b = TritonLLVMOpBuilder(loc, rewriter);
-  Value timer = LLVM::createLLVMIntrinsicCallOp(
-                    rewriter, loc, "llvm.amdgcn.s.memrealtime", i64_ty, {})
-                    .getResult(0);
+  Value timer;
+  switch (getISAFamily()) {
+  case ISAFamily::RDNA3:
+  case ISAFamily::RDNA4:
+    timer = LLVM::createLLVMIntrinsicCallOp(rewriter, loc,
+                                            "llvm.amdgcn.s.sendmsg.rtn.i64",
+                                            i64_ty, {b.i32_val(131)})
+                .getResult(0);
+    break;
+  default:
+    timer = LLVM::createLLVMIntrinsicCallOp(
+                rewriter, loc, "llvm.amdgcn.s.memrealtime", i64_ty, {})
+                .getResult(0);
+    break;
+  }
   // The clock generator runs at 100 MHz, so each tick is 10 ns.
   return b.mul(timer, b.i64_val(10));
 }

--- a/third_party/amd/lib/TritonAMDGPUToLLVM/TargetInfo.cpp
+++ b/third_party/amd/lib/TritonAMDGPUToLLVM/TargetInfo.cpp
@@ -171,6 +171,7 @@ Value TargetInfo::getGlobalTimer(RewriterBase &rewriter, Location loc) const {
   switch (getISAFamily()) {
   case ISAFamily::RDNA3:
   case ISAFamily::RDNA4:
+  case ISAFamily::GFX1250:
     timer = LLVM::createLLVMIntrinsicCallOp(rewriter, loc,
                                             "llvm.amdgcn.s.sendmsg.rtn.i64",
                                             i64_ty, {b.i32_val(131)})

--- a/third_party/amd/lib/TritonAMDGPUToLLVM/TargetInfo.cpp
+++ b/third_party/amd/lib/TritonAMDGPUToLLVM/TargetInfo.cpp
@@ -171,12 +171,13 @@ Value TargetInfo::getGlobalTimer(RewriterBase &rewriter, Location loc) const {
   switch (getISAFamily()) {
   case ISAFamily::RDNA3:
   case ISAFamily::RDNA4:
-  case ISAFamily::GFX1250:
-    timer = LLVM::createLLVMIntrinsicCallOp(rewriter, loc,
-                                            "llvm.amdgcn.s.sendmsg.rtn.i64",
-                                            i64_ty, {b.i32_val(131)})
+  case ISAFamily::GFX1250: {
+    Value msg = b.i32_val(/*MSG_RTN_GET_REALTIME=*/131);
+    timer = LLVM::createLLVMIntrinsicCallOp(
+                rewriter, loc, "llvm.amdgcn.s.sendmsg.rtn.i64", i64_ty, {msg})
                 .getResult(0);
     break;
+  }
   default:
     timer = LLVM::createLLVMIntrinsicCallOp(
                 rewriter, loc, "llvm.amdgcn.s.memrealtime", i64_ty, {})


### PR DESCRIPTION
<!---
The core Triton is a small number of people, and we receive many PRs (thank
you!).  To help us review your code more quickly, **if you are a new
contributor (less than 3 PRs merged) we ask that you complete the following
tasks and include the filled-out checklist in your PR description.**

Complete the following tasks before sending your PR, and replace `[ ]` with
`[x]` to indicate you have done them.
-->

`tl.atomic_poll(..., timeout_ns=...)` aborts at compile time on RDNA3/RDNA4
  LLVM ERROR: Cannot select: intrinsic %llvm.amdgcn.s.memrealtime

  The implementation of `TargetInfo::getGlobalTimer` unconditionally emits the `llvm.amdgcn.s.memrealtime` intrinsic. The
  `s_memrealtime` instruction was **removed in RDNA 3/4**, so LLVM's AMDGPU instruction selector cannot lower it and calls `abort()`. 
  
  ## Fix
  
  Make `getGlobalTimer` arch-aware. On GFX11+ the realtime clock is read via
  `s_sendmsg_rtn_b64 ..., sendmsg(MSG_RTN_GET_REALTIME)`, exposed as `llvm.amdgcn.s.sendmsg.rtn.i64(131)`.

# New contributor declaration
- [x] I am not making a trivial change, such as fixing a typo in a comment.

- [x] I have written a PR description following these
  [rules](https://cbea.ms/git-commit/#why-not-how).

- [x] I have run `pre-commit run --from-ref origin/main --to-ref HEAD`.

- Select one of the following.
  - [ ] I have added tests.
    - `/test` for `lit` tests
    - `/unittest` for C++ tests
    - `/python/test` for end-to-end tests
  - [x] This PR does not need a test because `I fixed a test`.

- Select one of the following.
  - [ x] I have not added any `lit` tests.
  - [ ] The `lit` tests I have added follow these [best practices](https://mlir.llvm.org/getting_started/TestingGuide/#filecheck-best-practices),
    including the "tests should be minimal" section. (Usually running Python code
    and using the instructions it generates is not minimal.)
