### PR TITLE
[libdevice] Add min/max libdevice builtins

### DIFF
--- a/python/test/unit/cuda/test_libdevice_cuda.py
+++ b/python/test/unit/cuda/test_libdevice_cuda.py
@@ -6,7 +6,7 @@ import torch
 import triton
 import triton.language as tl
 
-from triton._internal_testing import is_cuda
+from triton._internal_testing import is_cuda, numpy_random, to_numpy, to_triton
 from triton.language.extra import libdevice
 
 
@@ -261,3 +261,33 @@ def test_fpsan_distinguishes_approximate_libdevice(op, fresh_knobs):
     )
 
     assert not torch.equal(builtin, external)
+
+
+# Integer min/max are NVIDIA-only libdevice builtins (__nv_min/__nv_umin/__nv_llmin/...),
+# so they live here rather than in the cross-backend test_libdevice.py. Data is generated
+# via numpy_random/to_triton because torch lacks randint ranges and maximum/minimum for
+# the unsigned dtypes.
+@pytest.mark.parametrize("dtype_str", ["int32", "int64", "uint32", "uint64"])
+@pytest.mark.parametrize("fn", ["max", "min"])
+def test_int_max_min(fn, dtype_str, device):
+    if not is_cuda():
+        pytest.skip("integer max/min are NVIDIA-only libdevice builtins")
+
+    @triton.jit
+    def kernel(x_ptr, y_ptr, out_ptr, fn: tl.constexpr, SIZE: tl.constexpr):
+        off = tl.arange(0, SIZE)
+        x = tl.load(x_ptr + off)
+        y = tl.load(y_ptr + off)
+        tl.store(out_ptr + off, getattr(libdevice, fn)(x, y))
+
+    SIZE = 128
+    rs = np.random.RandomState(seed=0)
+    x = numpy_random(SIZE, dtype_str=dtype_str, rs=rs)
+    y = numpy_random(SIZE, dtype_str=dtype_str, rs=rs)
+    x_tri = to_triton(x, device=device, dst_type=dtype_str)
+    y_tri = to_triton(y, device=device, dst_type=dtype_str)
+    out_tri = to_triton(np.empty(SIZE, dtype=getattr(np, dtype_str)), device=device, dst_type=dtype_str)
+    kernel[(1, )](x_tri, y_tri, out_tri, fn=fn, SIZE=SIZE)
+
+    ref = np.maximum(x, y) if fn == "max" else np.minimum(x, y)
+    np.testing.assert_array_equal(to_numpy(out_tri), ref)

--- a/python/test/unit/language/test_libdevice.py
+++ b/python/test/unit/language/test_libdevice.py
@@ -113,3 +113,36 @@ def test_isinf(device, dtype_str):
     BLOCK_SIZE = 256
     triton_isinf[(triton.cdiv(numel, BLOCK_SIZE), )](x, y, numel, BLOCK_SIZE)
     assert torch.equal(y.cpu(), res)
+
+
+@pytest.mark.parametrize("dtype_str", ["float32", "float64"])
+@pytest.mark.parametrize("fn", ["fmax", "fmin"])
+def test_fmax_fmin(device, dtype_str, fn):
+
+    @triton.jit
+    def kernel(x_ptr, y_ptr, out_ptr, fn: tl.constexpr, SIZE: tl.constexpr):
+        off = tl.arange(0, SIZE)
+        x = tl.load(x_ptr + off)
+        y = tl.load(y_ptr + off)
+        tl.store(out_ptr + off, getattr(libdevice, fn)(x, y))
+
+    SIZE = 128
+    dtype = getattr(torch, dtype_str)
+    torch.manual_seed(0)
+    x = torch.randn((SIZE, ), dtype=dtype, device=device)
+    y = torch.randn((SIZE, ), dtype=dtype, device=device)
+    inf, nan = float("inf"), float("nan")
+    # IEEE edge cases: fmax/fmin return the non-NaN operand (NaN only when both
+    # are NaN) and treat +/-inf as ordinary large/small values -- unlike
+    # tl.maximum/tl.minimum, which propagate NaN.
+    edge_x = [nan, 1.0, nan, inf, -inf, 2.0, -inf]
+    edge_y = [3.0, nan, nan, 5.0, 4.0, -inf, inf]
+    for i, (xv, yv) in enumerate(zip(edge_x, edge_y)):
+        x[i], y[i] = xv, yv
+    out = torch.empty_like(x)
+    kernel[(1, )](x, y, out, fn=fn, SIZE=SIZE)
+
+    # Exact fmax/fmin: pick the non-NaN operand, otherwise the larger/smaller.
+    mm = torch.maximum if fn == "fmax" else torch.minimum
+    ref = torch.where(x.isnan(), y, torch.where(y.isnan(), x, mm(x, y)))
+    torch.testing.assert_close(out, ref, equal_nan=True)

--- a/python/triton/language/extra/libdevice.py
+++ b/python/triton/language/extra/libdevice.py
@@ -750,6 +750,22 @@ def fmod(arg0, arg1):
     ...
 
 
+def fmax(arg0, arg1):
+    ...
+
+
+def fmin(arg0, arg1):
+    ...
+
+
+def max(arg0, arg1):
+    ...
+
+
+def min(arg0, arg1):
+    ...
+
+
 def remainder(arg0, arg1):
     ...
 

--- a/third_party/amd/language/hip/libdevice.py
+++ b/third_party/amd/language/hip/libdevice.py
@@ -481,6 +481,24 @@ def fmod(arg0, arg1, _semantic=None):
 
 
 @core.extern
+def fmax(arg0, arg1, _semantic=None):
+    return core.extern_elementwise(
+        "", "", [arg0, arg1], {
+            (core.dtype("fp32"), core.dtype("fp32")): ("__ocml_fmax_f32", core.dtype("fp32")),
+            (core.dtype("fp64"), core.dtype("fp64")): ("__ocml_fmax_f64", core.dtype("fp64")),
+        }, is_pure=True, _semantic=_semantic)
+
+
+@core.extern
+def fmin(arg0, arg1, _semantic=None):
+    return core.extern_elementwise(
+        "", "", [arg0, arg1], {
+            (core.dtype("fp32"), core.dtype("fp32")): ("__ocml_fmin_f32", core.dtype("fp32")),
+            (core.dtype("fp64"), core.dtype("fp64")): ("__ocml_fmin_f64", core.dtype("fp64")),
+        }, is_pure=True, _semantic=_semantic)
+
+
+@core.extern
 def fma(arg0, arg1, arg2, _semantic=None):
     return core.extern_elementwise(
         "", "", [arg0, arg1, arg2], {

--- a/third_party/nvidia/language/cuda/libdevice.py
+++ b/third_party/nvidia/language/cuda/libdevice.py
@@ -1540,6 +1540,46 @@ def fmod(arg0, arg1, _semantic=None):
 
 
 @core.extern
+def fmax(arg0, arg1, _semantic=None):
+    return core.extern_elementwise(
+        "", "", [arg0, arg1], {
+            (core.dtype("fp32"), core.dtype("fp32")): ("__nv_fmaxf", core.dtype("fp32")),
+            (core.dtype("fp64"), core.dtype("fp64")): ("__nv_fmax", core.dtype("fp64")),
+        }, is_pure=True, _semantic=_semantic)
+
+
+@core.extern
+def fmin(arg0, arg1, _semantic=None):
+    return core.extern_elementwise(
+        "", "", [arg0, arg1], {
+            (core.dtype("fp32"), core.dtype("fp32")): ("__nv_fminf", core.dtype("fp32")),
+            (core.dtype("fp64"), core.dtype("fp64")): ("__nv_fmin", core.dtype("fp64")),
+        }, is_pure=True, _semantic=_semantic)
+
+
+@core.extern
+def max(arg0, arg1, _semantic=None):
+    return core.extern_elementwise(
+        "", "", [arg0, arg1], {
+            (core.dtype("int32"), core.dtype("int32")): ("__nv_max", core.dtype("int32")),
+            (core.dtype("uint32"), core.dtype("uint32")): ("__nv_umax", core.dtype("uint32")),
+            (core.dtype("int64"), core.dtype("int64")): ("__nv_llmax", core.dtype("int64")),
+            (core.dtype("uint64"), core.dtype("uint64")): ("__nv_ullmax", core.dtype("uint64")),
+        }, is_pure=True, _semantic=_semantic)
+
+
+@core.extern
+def min(arg0, arg1, _semantic=None):
+    return core.extern_elementwise(
+        "", "", [arg0, arg1], {
+            (core.dtype("int32"), core.dtype("int32")): ("__nv_min", core.dtype("int32")),
+            (core.dtype("uint32"), core.dtype("uint32")): ("__nv_umin", core.dtype("uint32")),
+            (core.dtype("int64"), core.dtype("int64")): ("__nv_llmin", core.dtype("int64")),
+            (core.dtype("uint64"), core.dtype("uint64")): ("__nv_ullmin", core.dtype("uint64")),
+        }, is_pure=True, _semantic=_semantic)
+
+
+@core.extern
 def remainder(arg0, arg1, _semantic=None):
     return core.extern_elementwise(
         "", "", [arg0, arg1], {


### PR DESCRIPTION
tl.extra.libdevice exposes most of CUDA's libdevice surface, but the min/max family was missing fall back to tl.minimum / tl.maximum

Expose:
  - fmax/fmin for fp32 and fp64 on both backends (NVIDIA __nv_fmax{f}/ __nv_fmin{f}, AMD __ocml_fmax_f{32,64}/__ocml_fmin_f{32,64})
  - integer max/min for {,u}int{32,64} on NVIDIA only (__nv_{,u,ll,ull}{max,min}); OCML has no integer equivalents


<!---
The core Triton is a small number of people, and we receive many PRs (thank
you!).  To help us review your code more quickly, **if you are a new
contributor (less than 3 PRs merged) we ask that you complete the following
tasks and include the filled-out checklist in your PR description.**

Complete the following tasks before sending your PR, and replace `[ ]` with
`[x]` to indicate you have done them.
-->

# New contributor declaration
- [x] I am not making a trivial change, such as fixing a typo in a comment.

- [x] I have written a PR description following these
  [rules](https://cbea.ms/git-commit/#why-not-how).

- [x] I have run `pre-commit run --from-ref origin/main --to-ref HEAD`.

- Select one of the following.
  - [x] I have added tests.
    - `/test` for `lit` tests
    - `/unittest` for C++ tests
    - `/python/test` for end-to-end tests
  - [ ] This PR does not need a test because `FILL THIS IN`.

- Select one of the following.
  - [x] I have not added any `lit` tests.
  - [ ] The `lit` tests I have added follow these [best practices](https://mlir.llvm.org/getting_started/TestingGuide/#filecheck-best-practices),
    including the "tests should be minimal" section. (Usually running Python code
    and using the instructions it generates is not minimal.)
