### PR TITLE
test: add tie_break_left=False coverage to test_reduce1d

### DIFF
--- a/python/test/unit/language/test_core.py
+++ b/python/test/unit/language/test_core.py
@@ -2655,6 +2655,8 @@ def get_reduce_input(dtype_str, shape):
     'max-with-indices',
     'argmin-tie-break-left',
     'argmax-tie-break-left',
+    'argmin-tie-break-fast',
+    'argmax-tie-break-fast',
     'sum',
 ] for dtype in dtypes_with_bfloat16 for shape in [32, 64, 128, 512]])
 @pytest.mark.parametrize("num_ctas", num_ctas_list)
@@ -2686,14 +2688,16 @@ def test_reduce1d(op, dtype_str, shape, num_ctas, device):
         'min-with-indices': np.min,
         'argmin-tie-break-left': np.argmin,
         'argmax-tie-break-left': np.argmax,
+        'argmin-tie-break-fast': np.argmin,
+        'argmax-tie-break-fast': np.argmax,
     }[op]
-    if 'tie-break-left' in op:
+    if 'arg' in op:
         x[3:10] = x[numpy_op(x)]
     x_tri = to_triton(x, device=device)
     # numpy result
-    z_dtype_str = 'int32' if 'tie-break-left' in op else dtype_str
+    z_dtype_str = 'int32' if 'arg' in op else dtype_str
     z_tri_dtype_str = z_dtype_str
-    if 'tie-break-left' not in op and dtype_str == 'bfloat16':
+    if 'arg' not in op and dtype_str == 'bfloat16':
         z_dtype_str = 'float32'
         z_ref = numpy_op(x).astype(getattr(np, z_dtype_str))
         # trunc mantissa for a fair comparison of accuracy
@@ -2709,7 +2713,7 @@ def test_reduce1d(op, dtype_str, shape, num_ctas, device):
     if op == 'sum':
         np.testing.assert_allclose(z_ref, z_tri, rtol=0.01)
     else:
-        if 'tie-break-left' in op:
+        if 'arg' in op:
             # argmin and argmax can have multiple valid indices.
             # so instead we compare the values pointed by indices
             np.testing.assert_equal(x[z_ref], x[z_tri])


### PR DESCRIPTION
## Why

`test_reduce1d` covered `tl.argmin` and `tl.argmax` with `tie_break_left=True`
but had zero parametrized coverage for `tie_break_left=False`. The only existing
test for the fast path was `test_argmax_argmin_tie_break_fast_with_nan` (added in
#10699), limited to three specific NaN inputs on float32. A regression in
`_argmin_combine_tie_break_fast` or `_argmax_combine_tie_break_fast` on normal
non-NaN inputs would go undetected across all dtypes and block sizes.

## What

Add `'argmin-tie-break-fast'` and `'argmax-tie-break-fast'` to `test_reduce1d` and
update four guards from `'tie-break-left' in op` to `'arg' in op`:

| Guard | Before | After | Reason |
|---|---|---|---|
| `numpy_op` dict | KeyError for fast ops | entries added | obvious |
| duplicate injection | only left path | both arg paths | test tie resolution, not just correctness |
| `z_dtype_str` | `dtype_str` for fast path | `int32` for all arg ops | argmin/argmax always returns index |
| bfloat16 branch + comparison | excluded left only | excludes all arg ops | fast path is int32 too; compare values not indices |

No production code is changed.

## Testing

The two new op strings run through the same kernel patch and comparison logic as
the existing left tie-break variants. Duplicate values are injected so tie-breaking
behavior is exercised, and the assertion compares `x[z_ref] == x[z_tri]` (value at
the returned index) rather than the raw index, which is correct since multiple
indices are valid when values are equal.

Covers both `@pytest.mark.interpreter` and JIT modes across all dtypes in
`dtypes_with_bfloat16` and shapes `[32, 64, 128, 512]`.

## Checklist

- [x] I am not making a trivial change, such as fixing a typo in a comment.
- [x] I have written a PR description following these [rules](https://cbea.ms/git-commit/#why-not-how).
- [x] I have run `pre-commit run --from-ref origin/main --to-ref HEAD`.
- [x] I have added tests.
  - `/python/test` for end-to-end tests
- [x] I have not added any `lit` tests.

Fixes #10760