### PR TITLE
[AMD] Enable local prefetch schedule in pipeliner

### DIFF
--- a/test/TritonGPU/amd/amd-pipeline-tdm.mlir
+++ b/test/TritonGPU/amd/amd-pipeline-tdm.mlir
@@ -1,5 +1,9 @@
 // RUN: triton-opt %s -split-input-file -tritonamdgpu-optimize-descriptor-encoding  -tritonamdgpu-schedule-loops="num_stages=2" -tritonamdgpu-pipeline="use_async_copy=1" -canonicalize | FileCheck %s
 
+// Re-run with num_stages=3 to exercise the LDS-prefetch schedule (only enabled
+// on the TDM path when numStages >= 3).
+// RUN: triton-opt %s -split-input-file -tritonamdgpu-optimize-descriptor-encoding  -tritonamdgpu-schedule-loops="num_stages=3" -tritonamdgpu-pipeline="use_async_copy=1" -canonicalize | FileCheck %s --check-prefix=LDS_PREFETCH
+
 #blocked = #ttg.blocked<{sizePerThread = [1, 8], threadsPerWarp = [8, 4], warpsPerCTA = [8, 1], order = [1, 0]}>
 #blocked1 = #ttg.blocked<{sizePerThread = [1, 8], threadsPerWarp = [4, 8], warpsPerCTA = [8, 1], order = [1, 0]}>
 #mma = #ttg.amd_wmma<{version = 3, isTranspose = true, ctaLayout = {warp = [[1, 0], [2, 0], [4, 0]]}, instrShape = [16, 16, 32]}>
@@ -78,6 +82,26 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 8 : i32, ttg.targ
 // CHECK-NOT: amdg.async_tdm_wait
 // CHECK: tt.descriptor_store {{.*}} : !tt.tensordesc<512x64xf16, #[[$PADDED_C]]>
 
+// With num_stages=3 the TDM path uses the LDS-prefetch schedule: ttg.local_load
+// is hoisted one stage ahead of the tt.dot so the dot consumes operands that
+// were prefetched into registers the previous iteration. The loop body leads
+// with the dot, followed by the async_wait, the next-tile TDM copies, and the
+// local_loads that feed the next iteration (carried as iter_args).
+// LDS_PREFETCH-LABEL: tt.func @matmul_kernel_make_tensor_descriptor
+// Prologue: dot operands for the first iteration are pre-loaded from LDS.
+// LDS_PREFETCH: %[[PRO_A:.+]] = ttg.local_load {{.*}} -> tensor<512x32xf16, #ttg.dot_op<{opIdx = 0, parent = {{.*}}, kWidth = 8}>>
+// LDS_PREFETCH: %[[PRO_B:.+]] = ttg.local_load {{.*}} -> tensor<32x64xf16, #ttg.dot_op<{opIdx = 1, parent = {{.*}}, kWidth = 8}>>
+// LDS_PREFETCH: scf.for
+// LDS_PREFETCH-SAME: %[[OP_A:[^ ]+]] = %[[PRO_A]]
+// LDS_PREFETCH-SAME: %[[OP_B:[^ ]+]] = %[[PRO_B]]
+// LDS_PREFETCH: tt.dot %[[OP_A]], %[[OP_B]]
+// LDS_PREFETCH: amdg.async_tdm_wait {{.*}} {num = 0 : i32}
+// LDS_PREFETCH: amdg.async_tdm_copy_global_to_local {{.*}} -> !ttg.memdesc<512x32xf16
+// LDS_PREFETCH: amdg.async_tdm_copy_global_to_local {{.*}} -> !ttg.memdesc<32x64xf16
+// LDS_PREFETCH: %[[NXT_A:.+]] = ttg.local_load {{.*}} -> tensor<512x32xf16, #ttg.dot_op<{opIdx = 0, parent = {{.*}}, kWidth = 8}>>
+// LDS_PREFETCH: %[[NXT_B:.+]] = ttg.local_load {{.*}} -> tensor<32x64xf16, #ttg.dot_op<{opIdx = 1, parent = {{.*}}, kWidth = 8}>>
+// LDS_PREFETCH: scf.yield {{.*}}, %[[NXT_A]], %[[NXT_B]]
+
 // -----
 
 // Test TDM padding for fp8 (f8E5M2) matmul on gfx1250.
@@ -152,6 +176,22 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 8 : i32, ttg.targ
 // CHECK-NOT: ttg.async_commit_group
 // CHECK: }
 // CHECK: tt.descriptor_store {{.*}} : !tt.tensordesc<256x64xf16, #[[$PADDED_C]]>
+
+// The LDS-prefetch schedule applies to any non-scaled dot on the TDM path, so
+// fp8 operands feeding a plain tt.dot get the prefetch schedule too.
+// LDS_PREFETCH-LABEL: tt.func @tdm_padding_fp8
+// LDS_PREFETCH: %[[PRO_A:.+]] = ttg.local_load {{.*}} -> tensor<256x64xf8E5M2, #ttg.dot_op<{opIdx = 0, parent = {{.*}}, kWidth = 8}>>
+// LDS_PREFETCH: %[[PRO_B:.+]] = ttg.local_load {{.*}} -> tensor<64x64xf8E5M2, #ttg.dot_op<{opIdx = 1, parent = {{.*}}, kWidth = 8}>>
+// LDS_PREFETCH: scf.for
+// LDS_PREFETCH-SAME: %[[OP_A:[^ ]+]] = %[[PRO_A]]
+// LDS_PREFETCH-SAME: %[[OP_B:[^ ]+]] = %[[PRO_B]]
+// LDS_PREFETCH: tt.dot %[[OP_A]], %[[OP_B]]
+// LDS_PREFETCH: amdg.async_tdm_wait {{.*}} {num = 0 : i32}
+// LDS_PREFETCH: amdg.async_tdm_copy_global_to_local {{.*}} -> !ttg.memdesc<256x64xf8E5M2
+// LDS_PREFETCH: amdg.async_tdm_copy_global_to_local {{.*}} -> !ttg.memdesc<64x64xf8E5M2
+// LDS_PREFETCH: %[[NXT_A:.+]] = ttg.local_load {{.*}} -> tensor<256x64xf8E5M2, #ttg.dot_op<{opIdx = 0, parent = {{.*}}, kWidth = 8}>>
+// LDS_PREFETCH: %[[NXT_B:.+]] = ttg.local_load {{.*}} -> tensor<64x64xf8E5M2, #ttg.dot_op<{opIdx = 1, parent = {{.*}}, kWidth = 8}>>
+// LDS_PREFETCH: scf.yield {{.*}}, %[[NXT_A]], %[[NXT_B]]
 
 // -----
 

--- a/third_party/amd/lib/TritonAMDGPUTransforms/LowerLoops.cpp
+++ b/third_party/amd/lib/TritonAMDGPUTransforms/LowerLoops.cpp
@@ -511,14 +511,30 @@ void remapClusters(tt::CoarseSchedule &schedule, ClusterMap clusterMap,
 //            can cause invalid schedules to be produced.
 LogicalResult initSchedule(int maxDist, Stages &stages, int numStages,
                            int &numBuffers, bool useAsyncCopy, bool hasTDMLoad,
-                           bool waitAtTail, Clusters &clusters,
-                           tt::CoarseSchedule &schedule) {
+                           bool hasScaledDot, bool waitAtTail,
+                           Clusters &clusters, tt::CoarseSchedule &schedule) {
   LDBG("Init SingleDotSchedule");
   int lastStage = numStages - 1;
   stages[SCHED_GLOBAL_LOAD] = 0;
   stages[SCHED_LOCAL_STORE] = 0;
   stages[SCHED_LOCAL_LOAD] = lastStage;
   stages[SCHED_COMPUTE] = lastStage;
+
+  // LDS prefetch of dot operands: schedule ttg.local_load one stage before
+  // the tt.dot that consumes it, so the LDS read of the next K-tile overlaps
+  // the current tile's matrix op. for num_stages<3 there is no room to separate
+  // them.
+  // We take a conservative route and only enable LDS prefetch when the dot is
+  // not scaled until more testing is done.
+  // waitAtTail (pingpong) requires very specific scheduling, which is
+  // incompatible with the prefetch cluster ordering below, so disable prefetch
+  // in that case.
+  bool ldsPrefetch =
+      hasTDMLoad && !hasScaledDot && numStages >= 3 && !waitAtTail;
+  if (ldsPrefetch) {
+    stages[SCHED_LOCAL_LOAD] = lastStage - 1;
+  }
+
   stages[SCHED_ASYNC_WAIT] = stages[SCHED_LOCAL_LOAD];
 
   bool pairedGlobalLoadLocalStore = stages[SCHED_LOCAL_STORE] == 0;
@@ -589,6 +605,18 @@ LogicalResult initSchedule(int maxDist, Stages &stages, int numStages,
   int computeCluster = 2;
   if (stages[SCHED_LOCAL_LOAD] == stages[SCHED_COMPUTE]) {
     computeCluster = localLoadCluster;
+  }
+
+  // ldsPrefetch ordering: lead the loop body with the tt.dot (it consumes
+  // operands pre-loaded into registers the previous iteration, so it has no
+  // intra-iteration dependency), then the async_wait, the next-tile TDM copy,
+  // and finally the ttg.local_load that feeds the next iteration.
+  if (ldsPrefetch) {
+    computeCluster = 0;
+    asyncWaitCluster = 1;
+    globalLoadCluster = 2;
+    localLoadCluster = 3;
+    localStoreCluster = 4;
   }
 
   // Create a hash map to associate cluster hash in old schedule with its
@@ -713,10 +741,13 @@ void updateSchedule(scf::ForOp &forOp, const LoadToInfoMap &loadToInfo,
     maxDist = std::max(maxDist, info.distToUse);
   }
 
+  bool hasScaledDot = false;
+  forOp.walk([&](tt::DotScaledOp) { hasScaledDot = true; });
+
   int numBuffers = 1;
   if (failed(initSchedule(maxDist, stages, schedule.getNumStages(), numBuffers,
-                          useAsyncCopy, hasTDMLoad, waitAtTail, clusters,
-                          schedule)))
+                          useAsyncCopy, hasTDMLoad, hasScaledDot, waitAtTail,
+                          clusters, schedule)))
     return;
 
   // Convert the loads into shared memory allocations and loads from them.


### PR DESCRIPTION
Adds an LDS-prefetch schedule to the AMD TDM pipeliner: ttg.local_load of the dot operands is hoisted
one stage ahead of the tt.dot, so the next K-tile's LDS read overlaps the current tile's matrix op.
The loop now leads with the dot (consuming operands carried as iter_args) and ends with the local_loads
for the next iteration. This mirrors the hand-written gluon fp16 GEMM kernel.
Gated on hasTDMLoad && !hasScaledDot && num_stages >= 3. Scaled dots are excluded for now (conservative, pending more testing).
Appropriate testing is added to amd-pipeline-tdm.mlir.