### PR TITLE
[TRITON] Fold split(join(a,b)) -> (a,b) and join(split(x)) -> x

### DIFF
--- a/include/triton/Dialect/Triton/IR/TritonOps.td
+++ b/include/triton/Dialect/Triton/IR/TritonOps.td
@@ -545,6 +545,7 @@ def TT_JoinOp : TT_Op<"join", [
     let results = (outs TT_Tensor:$result);
     let assemblyFormat = "$lhs `,` $rhs attr-dict `:` type($lhs) `->` type($result)";
     let hasVerifier = 1;
+    let hasFolder = 1;
 }
 
 def TT_SplitOp : TT_Op<"split", [
@@ -565,6 +566,7 @@ def TT_SplitOp : TT_Op<"split", [
     let arguments = (ins TT_Tensor:$src);
     let results = (outs TT_Tensor:$outLHS, TT_Tensor:$outRHS);
     let assemblyFormat = "$src attr-dict `:` type($src) `->` type($outLHS)";
+    let hasFolder = 1;
 }
 
 def TT_TransOp : TT_Op<"trans", [Pure,

--- a/include/triton/Dialect/Triton/IR/TritonOps.td
+++ b/include/triton/Dialect/Triton/IR/TritonOps.td
@@ -549,6 +549,7 @@ def TT_JoinOp : TT_Op<"join", [
     let results = (outs TT_Tensor:$result);
     let assemblyFormat = "$lhs `,` $rhs attr-dict `:` type($lhs) `->` type($result)";
     let hasVerifier = 1;
+    let hasFolder = 1;
 }
 
 def TT_SplitOp : TT_Op<"split", [
@@ -569,6 +570,7 @@ def TT_SplitOp : TT_Op<"split", [
     let arguments = (ins TT_Tensor:$src);
     let results = (outs TT_Tensor:$outLHS, TT_Tensor:$outRHS);
     let assemblyFormat = "$src attr-dict `:` type($src) `->` type($outLHS)";
+    let hasFolder = 1;
 }
 
 def TT_TransOp : TT_Op<"trans", [Pure,

--- a/lib/Dialect/Triton/IR/Ops.cpp
+++ b/lib/Dialect/Triton/IR/Ops.cpp
@@ -1421,6 +1421,19 @@ LogicalResult JoinOp::verify() {
   return success();
 }
 
+OpFoldResult JoinOp::fold(FoldAdaptor adaptor) {
+  // join(split(x)[0], split(x)[1]) -> x
+  // Only fold when both operands are exactly the two results of a single split
+  // and the reconstructed type matches, so layout encodings are preserved.
+  auto lhsSplit = getLhs().getDefiningOp<SplitOp>();
+  auto rhsSplit = getRhs().getDefiningOp<SplitOp>();
+  if (lhsSplit && lhsSplit == rhsSplit && getLhs() == lhsSplit.getOutLHS() &&
+      getRhs() == lhsSplit.getOutRHS() &&
+      lhsSplit.getSrc().getType() == getType())
+    return lhsSplit.getSrc();
+  return {};
+}
+
 // -- SplitOp --
 LogicalResult SplitOp::inferReturnTypes(
     MLIRContext *context, std::optional<Location> location,
@@ -1447,6 +1460,21 @@ LogicalResult SplitOp::inferReturnTypes(
   inferredReturnTypes.push_back(retTy);
   inferredReturnTypes.push_back(retTy);
   return success();
+}
+
+LogicalResult SplitOp::fold(FoldAdaptor adaptor,
+                            SmallVectorImpl<OpFoldResult> &results) {
+  // split(join(a, b)) -> (a, b)
+  // Guard on exact type equality so we never silently drop a layout conversion.
+  if (auto join = getSrc().getDefiningOp<JoinOp>()) {
+    if (join.getLhs().getType() == getOutLHS().getType() &&
+        join.getRhs().getType() == getOutRHS().getType()) {
+      results.push_back(join.getLhs());
+      results.push_back(join.getRhs());
+      return success();
+    }
+  }
+  return failure();
 }
 
 // -- ElementwiseInlineAsmOp --

--- a/lib/Dialect/Triton/IR/Ops.cpp
+++ b/lib/Dialect/Triton/IR/Ops.cpp
@@ -1427,6 +1427,19 @@ LogicalResult JoinOp::verify() {
   return success();
 }
 
+OpFoldResult JoinOp::fold(FoldAdaptor adaptor) {
+  // join(split(x)[0], split(x)[1]) -> x
+  // Only fold when both operands are exactly the two results of a single split
+  // and the reconstructed type matches, so layout encodings are preserved.
+  auto lhsSplit = getLhs().getDefiningOp<SplitOp>();
+  auto rhsSplit = getRhs().getDefiningOp<SplitOp>();
+  if (lhsSplit && lhsSplit == rhsSplit && getLhs() == lhsSplit.getOutLHS() &&
+      getRhs() == lhsSplit.getOutRHS() &&
+      lhsSplit.getSrc().getType() == getType())
+    return lhsSplit.getSrc();
+  return {};
+}
+
 // -- SplitOp --
 bool SplitOp::isCompatibleReturnTypes(TypeRange lhs, TypeRange rhs) {
   for (auto [lhs, rhs] : llvm::zip_equal(lhs, rhs)) {
@@ -1477,6 +1490,21 @@ LogicalResult SplitOp::inferReturnTypes(
   inferredReturnTypes.push_back(retTy);
   inferredReturnTypes.push_back(retTy);
   return success();
+}
+
+LogicalResult SplitOp::fold(FoldAdaptor adaptor,
+                            SmallVectorImpl<OpFoldResult> &results) {
+  // split(join(a, b)) -> (a, b)
+  // Guard on exact type equality so we never silently drop a layout conversion.
+  if (auto join = getSrc().getDefiningOp<JoinOp>()) {
+    if (join.getLhs().getType() == getOutLHS().getType() &&
+        join.getRhs().getType() == getOutRHS().getType()) {
+      results.push_back(join.getLhs());
+      results.push_back(join.getRhs());
+      return success();
+    }
+  }
+  return failure();
 }
 
 // -- ElementwiseInlineAsmOp --

--- a/test/Hopper/WarpSpecialization/ws_data_partition.mlir
+++ b/test/Hopper/WarpSpecialization/ws_data_partition.mlir
@@ -129,11 +129,13 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.targ
     // CHECK: tt.reshape {{.*}} : tensor<64x64x1xf16,
     // CHECK: tt.reshape {{.*}} : tensor<64x64x1xf16,
     %r1 = tt.reshape %r0 allow_reorder {async_task_id = array<i32: 0, 1, 2>} : tensor<128x64x1xf16, #blocked2> -> tensor<128x64xf16, #blocked>
-    // CHECK: tt.join {{.*}} : tensor<64x64xf16,
-    // CHECK: tt.join {{.*}} : tensor<64x64xf16,
+    // The split(join(x, x)) round-trip is an identity: it canonicalizes away
+    // (its result is x), so the partitioned reshape flows straight to the
+    // consumers below. The task id on the erased ops is irrelevant once they
+    // are dead.
+    // CHECK-NOT: tt.join
+    // CHECK-NOT: tt.split
     %0 = tt.join %r1, %r1 {async_task_id = array<i32: 0, 1, 2>} : tensor<128x64xf16, #blocked> -> tensor<128x64x2xf16, #blocked2>
-    // CHECK: tt.split {{.*}} : tensor<64x64x2xf16,
-    // CHECK: tt.split {{.*}} : tensor<64x64x2xf16,
     %1:2 = tt.split %0 {async_task_id = array<i32: 0, 1, 2>} : tensor<128x64x2xf16, #blocked2> -> tensor<128x64xf16, #blocked>
     // CHECK: ttg.local_alloc {{.*}} : (tensor<64x64xf16,
     // CHECK: ttg.local_alloc {{.*}} : (tensor<64x64xf16,

--- a/test/Hopper/WarpSpecialization/ws_data_partition.mlir
+++ b/test/Hopper/WarpSpecialization/ws_data_partition.mlir
@@ -129,14 +129,15 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.targ
     // CHECK: tt.reshape {{.*}} : tensor<64x64x1xf16,
     // CHECK: tt.reshape {{.*}} : tensor<64x64x1xf16,
     %r1 = tt.reshape %r0 allow_reorder {async_task_id = array<i32: 0, 1, 2>} : tensor<128x64x1xf16, #blocked2> -> tensor<128x64xf16, #blocked>
-    // The split(join(x, x)) round-trip is an identity: it canonicalizes away
-    // (its result is x), so the partitioned reshape flows straight to the
-    // consumers below. The task id on the erased ops is irrelevant once they
-    // are dead.
-    // CHECK-NOT: tt.join
-    // CHECK-NOT: tt.split
+    // CHECK: tt.join {{.*}} : tensor<64x64xf16,
+    // CHECK: tt.join {{.*}} : tensor<64x64xf16,
     %0 = tt.join %r1, %r1 {async_task_id = array<i32: 0, 1, 2>} : tensor<128x64xf16, #blocked> -> tensor<128x64x2xf16, #blocked2>
-    %1:2 = tt.split %0 {async_task_id = array<i32: 0, 1, 2>} : tensor<128x64x2xf16, #blocked2> -> tensor<128x64xf16, #blocked>
+    // Keep the round-trip from folding away, so the partitioning of both ops
+    // stays under test.
+    %mid = arith.addf %0, %0 {async_task_id = array<i32: 0, 1, 2>} : tensor<128x64x2xf16, #blocked2>
+    // CHECK: tt.split {{.*}} : tensor<64x64x2xf16,
+    // CHECK: tt.split {{.*}} : tensor<64x64x2xf16,
+    %1:2 = tt.split %mid {async_task_id = array<i32: 0, 1, 2>} : tensor<128x64x2xf16, #blocked2> -> tensor<128x64xf16, #blocked>
     // CHECK: ttg.local_alloc {{.*}} : (tensor<64x64xf16,
     // CHECK: ttg.local_alloc {{.*}} : (tensor<64x64xf16,
     %2 = ttg.local_alloc %1#0 {async_task_id = array<i32: 1, 2>} : (tensor<128x64xf16, #blocked>) -> !ttg.memdesc<128x64xf16, #shared, #smem>

--- a/test/Triton/canonicalize.mlir
+++ b/test/Triton/canonicalize.mlir
@@ -260,3 +260,44 @@ tt.func @no_canonicalize_indivisible_offset(%base: tensor<128x!tt.ptr<f32>>) -> 
   %result = tt.int_to_ptr %offset_ptr_int : tensor<128xi64> -> tensor<128x!tt.ptr<f32>>
   tt.return %result : tensor<128x!tt.ptr<f32>>
 }
+
+// -----
+
+// CHECK-LABEL: split_join
+tt.func @split_join(%a: tensor<8x4xf32>, %b: tensor<8x4xf32>) -> (tensor<8x4xf32>, tensor<8x4xf32>) {
+  // split(join(a, b)) -> (a, b)
+  // CHECK-NOT: tt.join
+  // CHECK-NOT: tt.split
+  // CHECK: tt.return %arg0, %arg1
+  %j = tt.join %a, %b : tensor<8x4xf32> -> tensor<8x4x2xf32>
+  %o:2 = tt.split %j : tensor<8x4x2xf32> -> tensor<8x4xf32>
+  tt.return %o#0, %o#1 : tensor<8x4xf32>, tensor<8x4xf32>
+}
+
+// -----
+
+// CHECK-LABEL: join_split
+tt.func @join_split(%x: tensor<8x4x2xf32>) -> tensor<8x4x2xf32> {
+  // join(split(x)[0], split(x)[1]) -> x
+  // CHECK-NOT: tt.split
+  // CHECK-NOT: tt.join
+  // CHECK: tt.return %arg0
+  %s:2 = tt.split %x : tensor<8x4x2xf32> -> tensor<8x4xf32>
+  %j = tt.join %s#0, %s#1 : tensor<8x4xf32> -> tensor<8x4x2xf32>
+  tt.return %j : tensor<8x4x2xf32>
+}
+
+// -----
+
+// CHECK-LABEL: split_join_folds_through_discardable_attr
+tt.func @split_join_folds_through_discardable_attr(%a: tensor<8x4xf32>, %b: tensor<8x4xf32>) -> (tensor<8x4xf32>, tensor<8x4xf32>) {
+  // The fold is a pure algebraic identity and is intentionally agnostic to
+  // discardable attributes (e.g. a warp-specialization async_task_id): the
+  // round-trip is removed and the original operands flow through.
+  // CHECK-NOT: tt.join
+  // CHECK-NOT: tt.split
+  // CHECK: tt.return %arg0, %arg1
+  %j = tt.join %a, %b : tensor<8x4xf32> -> tensor<8x4x2xf32>
+  %o:2 = tt.split %j {async_task_id = array<i32: 0>} : tensor<8x4x2xf32> -> tensor<8x4xf32>
+  tt.return %o#0, %o#1 : tensor<8x4xf32>, tensor<8x4xf32>
+}


### PR DESCRIPTION
`tt.join` and `tt.split` are inverses, but neither had a folder, so a round-trip survived `-canonicalize`:

- `split(join(a, b)) -> (a, b)`
- `join(split(x)[0], split(x)[1]) -> x`

The join is a real use of both operands, so a surviving round-trip keeps the unused half's producer chain alive. On a kernel whose unused half is a `tl.dot`, folding takes shared memory from 16384 B to 0 and SASS from 224 to 72 instructions. `ptxas` deletes the dead HMMA itself, but not the shared-memory allocation, which Triton sizes before `ptxas` runs.

Both folds require exact type equality. Since #10749 a join/split pair may differ by register broadcast, and a folder cannot materialise a `ttg.convert_layout`, so it declines there, as `TransOp::fold` does.

Tests in `test/Triton/canonicalize.mlir`. `ws_data_partition.mlir` used the round-trip as a data-partition vehicle and is updated.
