### PR TITLE
[TRITONGPU] Optimize MMA layout to prefer 2cta and tma multicast

### DIFF
--- a/lib/Dialect/TritonNvidiaGPU/Transforms/AssignCTALayouts.cpp
+++ b/lib/Dialect/TritonNvidiaGPU/Transforms/AssignCTALayouts.cpp
@@ -210,6 +210,14 @@ bool allowTwoCTASplit(triton::DotOp dot, bool preferTwoCTA) {
   return true;
 }
 
+bool preferTwoCTA(ModuleOp mod) {
+  auto targetAttr = mod->getAttrOfType<StringAttr>(triton::gpu::AttrTargetName);
+  if (!targetAttr || !targetAttr.getValue().starts_with("cuda:"))
+    return false;
+  int computeCapability = getNVIDIAComputeCapability(mod);
+  return computeCapability >= 100 && computeCapability < 120;
+}
+
 void assignDotCTALayout(triton::DotOp dot, bool preferTwoCTA) {
   MLIRContext *ctx = dot.getContext();
 
@@ -332,18 +340,11 @@ struct AssignCTALayoutsPass
     if (numCTAs == 1)
       return;
 
-    auto preferTwoCTA = [&]() {
-      auto targetAttr =
-          mod->getAttrOfType<StringAttr>(triton::gpu::AttrTargetName);
-      if (!targetAttr || !targetAttr.getValue().starts_with("cuda:"))
-        return false;
-      int computeCapability = getNVIDIAComputeCapability(mod);
-      return computeCapability >= 100 && computeCapability < 120;
-    }();
+    bool useTwoCTA = preferTwoCTA(mod);
 
     mod.walk([&](Operation *op) {
       if (auto dot = dyn_cast<triton::DotOp>(op))
-        assignDotCTALayout(dot, preferTwoCTA);
+        assignDotCTALayout(dot, useTwoCTA);
       if (auto reduce = dyn_cast<triton::ReduceOp>(op))
         assignReduceCTALayout(reduce);
     });

--- a/lib/Dialect/TritonNvidiaGPU/Transforms/AssignCTALayouts.cpp
+++ b/lib/Dialect/TritonNvidiaGPU/Transforms/AssignCTALayouts.cpp
@@ -169,51 +169,11 @@ void convertOpResultsFromLayouts(Operation *op,
   }
 }
 
-bool comesFromDescriptorLoad(Value value) {
-  while (auto cvtOp = value.getDefiningOp<ttg::ConvertLayoutOp>())
-    value = cvtOp.getSrc();
-  return isa_and_nonnull<triton::DescriptorLoadLikeOpInterface>(
-      value.getDefiningOp());
-}
-
 DotCTALayout getDotCTALayout(int64_t m, int64_t n, unsigned numCTAs,
-                             bool preferTwoCTA, bool canMulticastA,
-                             bool canMulticastB, int64_t aTileBits,
-                             int64_t bTileBits) {
+                             bool preferTwoCTA) {
   constexpr unsigned kPreferredChunkSize = 128;
   constexpr unsigned kMinChunkSize = 64;
-  constexpr unsigned kMaxMMAv5TwoCTAsNPerCTA = 256;
   auto isLegalChunkSize = [](unsigned chunk) { return chunk >= kMinChunkSize; };
-  auto isLegalTwoCTASplit = [&](unsigned splitM, unsigned splitN) {
-    unsigned mPerCTA = m / splitM;
-    unsigned nPerCTA = n / splitN;
-    return isLegalChunkSize(mPerCTA) && isLegalChunkSize(nPerCTA) &&
-           nPerCTA <= kMaxMMAv5TwoCTAsNPerCTA;
-  };
-
-  if (preferTwoCTA) {
-    DotCTALayout bestLayout = {{0, 0}, {0, 1}};
-    int64_t bestScore = -1;
-    for (unsigned splitM = numCTAs; splitM > 1; splitM /= 2) {
-      if (numCTAs % splitM != 0)
-        continue;
-      unsigned splitN = numCTAs / splitM;
-      if (!isLegalTwoCTASplit(splitM, splitN))
-        continue;
-
-      int64_t score = 0;
-      if (canMulticastA)
-        score += static_cast<int64_t>(splitN - 1) * aTileBits;
-      if (canMulticastB)
-        score += static_cast<int64_t>(splitM - 1) * bTileBits;
-      if (score > bestScore) {
-        bestLayout = {{splitM, splitN}, {0, 1}};
-        bestScore = score;
-      }
-    }
-    if (bestScore >= 0)
-      return bestLayout;
-  }
 
   unsigned splitM = 1;
   unsigned splitN = numCTAs;
@@ -223,14 +183,13 @@ DotCTALayout getDotCTALayout(int64_t m, int64_t n, unsigned numCTAs,
   for (unsigned chunkM = kPreferredChunkSize; isLegalChunkSize(chunkM);
        chunkM /= 2) {
     splitM = std::clamp<unsigned>(m / chunkM, 1, numCTAs);
-    while (splitM > 1 && numCTAs % splitM != 0)
-      --splitM;
     splitN = numCTAs / splitM;
     if (isLegalChunkSize(n / splitN))
       break;
   }
 
-  return {{splitM, splitN}, {1, 0}};
+  return {{splitM, splitN}, preferTwoCTA ? std::array<unsigned, 2>{0, 1}
+                                         : std::array<unsigned, 2>{1, 0}};
 }
 
 bool preferTwoCTASplit(triton::DotOp dot, bool isBlackwell) {
@@ -256,10 +215,7 @@ void assignDotCTALayout(triton::DotOp dot, bool isBlackwell) {
 
   DotCTALayout layout = getDotCTALayout(
       dTy.getShape()[0], dTy.getShape()[1], ttg::getNumCTAs(dLayout),
-      preferTwoCTASplit(dot, isBlackwell), comesFromDescriptorLoad(dot.getA()),
-      comesFromDescriptorLoad(dot.getB()),
-      aTy.getNumElements() * aTy.getElementType().getIntOrFloatBitWidth(),
-      bTy.getNumElements() * bTy.getElementType().getIntOrFloatBitWidth());
+      preferTwoCTASplit(dot, isBlackwell));
 
   OpBuilder builder(dot);
   int threadsPerWarp = ttg::lookupThreadsPerWarp(builder);

--- a/lib/Dialect/TritonNvidiaGPU/Transforms/AssignCTALayouts.cpp
+++ b/lib/Dialect/TritonNvidiaGPU/Transforms/AssignCTALayouts.cpp
@@ -7,8 +7,8 @@
 #include "mlir/Support/LLVM.h"
 #include "triton/Dialect/Triton/IR/Dialect.h"
 #include "triton/Dialect/TritonGPU/IR/Dialect.h"
+#include "triton/Dialect/TritonGPU/Transforms/Utility.h"
 #include "triton/Dialect/TritonNvidiaGPU/IR/Dialect.h"
-#include "triton/Dialect/TritonNvidiaGPU/IR/TargetFeatures.h"
 #include "triton/Dialect/TritonNvidiaGPU/Transforms/Passes.h"
 #include "llvm/Support/ErrorHandling.h"
 
@@ -177,7 +177,7 @@ DotCTALayout getDotCTALayout(int64_t m, int64_t n, unsigned numCTAs,
   auto isLegalChunkSize = [](unsigned chunk) { return chunk >= kMinChunkSize; };
 
   if (preferTwoCTA) {
-    for (unsigned splitM = numCTAs; splitM > 1; --splitM) {
+    for (unsigned splitM = numCTAs; splitM > 1; splitM /= 2) {
       if (numCTAs % splitM != 0)
         continue;
       unsigned splitN = numCTAs / splitM;
@@ -207,13 +207,6 @@ DotCTALayout getDotCTALayout(int64_t m, int64_t n, unsigned numCTAs,
   return {{splitM, splitN}, {1, 0}};
 }
 
-bool hasDescriptorLoadLikeRoot(Value value) {
-  while (auto cvtOp = value.getDefiningOp<ttg::ConvertLayoutOp>())
-    value = cvtOp.getSrc();
-  return isa_and_nonnull<triton::DescriptorLoadLikeOpInterface>(
-      value.getDefiningOp());
-}
-
 bool preferTwoCTASplit(triton::DotOp dot, bool isBlackwell) {
   if (!isBlackwell || ttg::lookupNumCTAs(dot) < 2)
     return false;
@@ -222,7 +215,11 @@ bool preferTwoCTASplit(triton::DotOp dot, bool isBlackwell) {
   if (retTy.getRank() != 2)
     return false;
 
-  return hasDescriptorLoadLikeRoot(dot.getB());
+  Value b = dot.getB();
+  while (auto cvtOp = b.getDefiningOp<ttg::ConvertLayoutOp>())
+    b = cvtOp.getSrc();
+  return isa_and_nonnull<triton::DescriptorLoadLikeOpInterface>(
+      b.getDefiningOp());
 }
 
 void assignDotCTALayout(triton::DotOp dot, bool isBlackwell) {
@@ -351,8 +348,7 @@ struct AssignCTALayoutsPass
         mod->getAttrOfType<StringAttr>(triton::gpu::AttrTargetName);
     bool isBlackwell = false;
     if (targetAttr && targetAttr.getValue().starts_with("cuda:")) {
-      int computeCapability =
-          TargetFeatures::fromModuleOp(mod).getComputeCapability();
+      int computeCapability = getNVIDIAComputeCapability(mod);
       isBlackwell = computeCapability >= 100 && computeCapability < 120;
     }
 

--- a/lib/Dialect/TritonNvidiaGPU/Transforms/AssignCTALayouts.cpp
+++ b/lib/Dialect/TritonNvidiaGPU/Transforms/AssignCTALayouts.cpp
@@ -175,25 +175,32 @@ DotCTALayout getDotCTALayout(int64_t m, int64_t n, unsigned numCTAs,
   constexpr unsigned kMinChunkSize = 64;
   auto isLegalChunkSize = [](unsigned chunk) { return chunk >= kMinChunkSize; };
 
-  unsigned splitM = 1;
-  unsigned splitN = numCTAs;
-  // Prefer a larger M chunk, up to 128 elements, by assigning splitM first.
-  // splitN gets the remaining CTAs as long as each N chunk has at least 64
-  // elements.
-  for (unsigned chunkM = kPreferredChunkSize; isLegalChunkSize(chunkM);
-       chunkM /= 2) {
-    splitM = std::clamp<unsigned>(m / chunkM, 1, numCTAs);
-    splitN = numCTAs / splitM;
-    if (isLegalChunkSize(n / splitN))
+  unsigned splitM = numCTAs;
+  unsigned splitN = 1;
+  if (preferTwoCTA) {
+    unsigned mChunkSize = m / (numCTAs / 2);
+    unsigned nChunkSize = n / 2;
+    if (isLegalChunkSize(mChunkSize) && isLegalChunkSize(nChunkSize)) {
+      splitM = numCTAs / 2;
+      splitN = 2;
+    }
+  }
+
+  // Keep decreasing splitM until we reach kPreferredChunkSize
+  while (splitM > 1) {
+    unsigned mChunkSize = m / splitM;
+    if (mChunkSize <= kPreferredChunkSize)
       break;
+    splitM /= 2;
+    splitN = numCTAs / splitM;
   }
 
   return {{splitM, splitN}, preferTwoCTA ? std::array<unsigned, 2>{0, 1}
                                          : std::array<unsigned, 2>{1, 0}};
 }
 
-bool preferTwoCTASplit(triton::DotOp dot, bool isBlackwell) {
-  if (!isBlackwell || ttg::lookupNumCTAs(dot) < 2)
+bool allowTwoCTASplit(triton::DotOp dot, bool preferTwoCTA) {
+  if (!preferTwoCTA || ttg::lookupNumCTAs(dot) < 2)
     return false;
 
   auto retTy = cast<RankedTensorType>(dot.getType());
@@ -202,7 +209,7 @@ bool preferTwoCTASplit(triton::DotOp dot, bool isBlackwell) {
   return true;
 }
 
-void assignDotCTALayout(triton::DotOp dot, bool isBlackwell) {
+void assignDotCTALayout(triton::DotOp dot, bool preferTwoCTA) {
   MLIRContext *ctx = dot.getContext();
 
   auto aTy = cast<RankedTensorType>(dot.getA().getType());
@@ -215,7 +222,7 @@ void assignDotCTALayout(triton::DotOp dot, bool isBlackwell) {
 
   DotCTALayout layout = getDotCTALayout(
       dTy.getShape()[0], dTy.getShape()[1], ttg::getNumCTAs(dLayout),
-      preferTwoCTASplit(dot, isBlackwell));
+      allowTwoCTASplit(dot, preferTwoCTA));
 
   OpBuilder builder(dot);
   int threadsPerWarp = ttg::lookupThreadsPerWarp(builder);
@@ -326,15 +333,15 @@ struct AssignCTALayoutsPass
 
     auto targetAttr =
         mod->getAttrOfType<StringAttr>(triton::gpu::AttrTargetName);
-    bool isBlackwell = false;
+    bool preferTwoCTA = false;
     if (targetAttr && targetAttr.getValue().starts_with("cuda:")) {
       int computeCapability = getNVIDIAComputeCapability(mod);
-      isBlackwell = computeCapability >= 100 && computeCapability < 120;
+      preferTwoCTA = computeCapability >= 100 && computeCapability < 120;
     }
 
     mod.walk([&](Operation *op) {
       if (auto dot = dyn_cast<triton::DotOp>(op))
-        assignDotCTALayout(dot, isBlackwell);
+        assignDotCTALayout(dot, preferTwoCTA);
       if (auto reduce = dyn_cast<triton::ReduceOp>(op))
         assignReduceCTALayout(reduce);
     });

--- a/lib/Dialect/TritonNvidiaGPU/Transforms/AssignCTALayouts.cpp
+++ b/lib/Dialect/TritonNvidiaGPU/Transforms/AssignCTALayouts.cpp
@@ -169,24 +169,50 @@ void convertOpResultsFromLayouts(Operation *op,
   }
 }
 
+bool comesFromDescriptorLoad(Value value) {
+  while (auto cvtOp = value.getDefiningOp<ttg::ConvertLayoutOp>())
+    value = cvtOp.getSrc();
+  return isa_and_nonnull<triton::DescriptorLoadLikeOpInterface>(
+      value.getDefiningOp());
+}
+
 DotCTALayout getDotCTALayout(int64_t m, int64_t n, unsigned numCTAs,
-                             bool preferTwoCTA) {
+                             bool preferTwoCTA, bool canMulticastA,
+                             bool canMulticastB, int64_t aTileBits,
+                             int64_t bTileBits) {
   constexpr unsigned kPreferredChunkSize = 128;
   constexpr unsigned kMinChunkSize = 64;
   constexpr unsigned kMaxMMAv5TwoCTAsNPerCTA = 256;
   auto isLegalChunkSize = [](unsigned chunk) { return chunk >= kMinChunkSize; };
+  auto isLegalTwoCTASplit = [&](unsigned splitM, unsigned splitN) {
+    unsigned mPerCTA = m / splitM;
+    unsigned nPerCTA = n / splitN;
+    return isLegalChunkSize(mPerCTA) && isLegalChunkSize(nPerCTA) &&
+           nPerCTA <= kMaxMMAv5TwoCTAsNPerCTA;
+  };
 
   if (preferTwoCTA) {
+    DotCTALayout bestLayout = {{0, 0}, {0, 1}};
+    int64_t bestScore = -1;
     for (unsigned splitM = numCTAs; splitM > 1; splitM /= 2) {
       if (numCTAs % splitM != 0)
         continue;
       unsigned splitN = numCTAs / splitM;
-      unsigned mPerCTA = m / splitM;
-      unsigned nPerCTA = n / splitN;
-      if (isLegalChunkSize(mPerCTA) && isLegalChunkSize(nPerCTA) &&
-          nPerCTA <= kMaxMMAv5TwoCTAsNPerCTA)
-        return {{splitM, splitN}, {0, 1}};
+      if (!isLegalTwoCTASplit(splitM, splitN))
+        continue;
+
+      int64_t score = 0;
+      if (canMulticastA)
+        score += static_cast<int64_t>(splitN - 1) * aTileBits;
+      if (canMulticastB)
+        score += static_cast<int64_t>(splitM - 1) * bTileBits;
+      if (score > bestScore) {
+        bestLayout = {{splitM, splitN}, {0, 1}};
+        bestScore = score;
+      }
     }
+    if (bestScore >= 0)
+      return bestLayout;
   }
 
   unsigned splitM = 1;
@@ -214,12 +240,7 @@ bool preferTwoCTASplit(triton::DotOp dot, bool isBlackwell) {
   auto retTy = cast<RankedTensorType>(dot.getType());
   if (retTy.getRank() != 2)
     return false;
-
-  Value b = dot.getB();
-  while (auto cvtOp = b.getDefiningOp<ttg::ConvertLayoutOp>())
-    b = cvtOp.getSrc();
-  return isa_and_nonnull<triton::DescriptorLoadLikeOpInterface>(
-      b.getDefiningOp());
+  return true;
 }
 
 void assignDotCTALayout(triton::DotOp dot, bool isBlackwell) {
@@ -235,7 +256,10 @@ void assignDotCTALayout(triton::DotOp dot, bool isBlackwell) {
 
   DotCTALayout layout = getDotCTALayout(
       dTy.getShape()[0], dTy.getShape()[1], ttg::getNumCTAs(dLayout),
-      preferTwoCTASplit(dot, isBlackwell));
+      preferTwoCTASplit(dot, isBlackwell), comesFromDescriptorLoad(dot.getA()),
+      comesFromDescriptorLoad(dot.getB()),
+      aTy.getNumElements() * aTy.getElementType().getIntOrFloatBitWidth(),
+      bTy.getNumElements() * bTy.getElementType().getIntOrFloatBitWidth());
 
   OpBuilder builder(dot);
   int threadsPerWarp = ttg::lookupThreadsPerWarp(builder);

--- a/lib/Dialect/TritonNvidiaGPU/Transforms/AssignCTALayouts.cpp
+++ b/lib/Dialect/TritonNvidiaGPU/Transforms/AssignCTALayouts.cpp
@@ -1,4 +1,5 @@
 #include <algorithm>
+#include <array>
 
 #include "mlir/IR/Builders.h"
 #include "mlir/IR/BuiltinOps.h"
@@ -29,6 +30,11 @@ namespace {
 struct DotCTASplit {
   unsigned m;
   unsigned n;
+};
+
+struct DotCTALayout {
+  DotCTASplit split;
+  std::array<unsigned, 2> order;
 };
 
 ttg::DistributedEncodingTrait
@@ -163,14 +169,25 @@ void convertOpResultsFromLayouts(Operation *op,
   }
 }
 
-DotCTASplit getDotCTASplit(int64_t m, int64_t n, unsigned numCTAs,
-                           bool preferMOnly) {
+DotCTALayout getDotCTALayout(int64_t m, int64_t n, unsigned numCTAs,
+                             bool preferTwoCTA) {
   constexpr unsigned kPreferredChunkSize = 128;
   constexpr unsigned kMinChunkSize = 64;
+  constexpr unsigned kMaxMMAv5TwoCTAsNPerCTA = 256;
   auto isLegalChunkSize = [](unsigned chunk) { return chunk >= kMinChunkSize; };
 
-  if (preferMOnly && isLegalChunkSize(m / numCTAs))
-    return {numCTAs, 1};
+  if (preferTwoCTA) {
+    for (unsigned splitM = numCTAs; splitM > 1; --splitM) {
+      if (numCTAs % splitM != 0)
+        continue;
+      unsigned splitN = numCTAs / splitM;
+      unsigned mPerCTA = m / splitM;
+      unsigned nPerCTA = n / splitN;
+      if (isLegalChunkSize(mPerCTA) && isLegalChunkSize(nPerCTA) &&
+          nPerCTA <= kMaxMMAv5TwoCTAsNPerCTA)
+        return {{splitM, splitN}, {0, 1}};
+    }
+  }
 
   unsigned splitM = 1;
   unsigned splitN = numCTAs;
@@ -180,12 +197,14 @@ DotCTASplit getDotCTASplit(int64_t m, int64_t n, unsigned numCTAs,
   for (unsigned chunkM = kPreferredChunkSize; isLegalChunkSize(chunkM);
        chunkM /= 2) {
     splitM = std::clamp<unsigned>(m / chunkM, 1, numCTAs);
+    while (splitM > 1 && numCTAs % splitM != 0)
+      --splitM;
     splitN = numCTAs / splitM;
     if (isLegalChunkSize(n / splitN))
       break;
   }
 
-  return {splitM, splitN};
+  return {{splitM, splitN}, {1, 0}};
 }
 
 bool hasDescriptorLoadLikeRoot(Value value) {
@@ -195,12 +214,12 @@ bool hasDescriptorLoadLikeRoot(Value value) {
       value.getDefiningOp());
 }
 
-bool preferMOnlySplitForTwoCTAMMA(triton::DotOp dot, bool isBlackwell) {
-  if (!isBlackwell || ttg::lookupNumCTAs(dot) != 4)
+bool preferTwoCTASplit(triton::DotOp dot, bool isBlackwell) {
+  if (!isBlackwell || ttg::lookupNumCTAs(dot) < 2)
     return false;
 
   auto retTy = cast<RankedTensorType>(dot.getType());
-  if (retTy.getRank() != 2 || retTy.getDimSize(1) > 256)
+  if (retTy.getRank() != 2)
     return false;
 
   return hasDescriptorLoadLikeRoot(dot.getB());
@@ -217,16 +236,17 @@ void assignDotCTALayout(triton::DotOp dot, bool isBlackwell) {
   auto bLayout = cast<ttg::DotOperandEncodingAttr>(bTy.getEncoding());
   auto dLayout = cast<ttg::BlockedEncodingAttr>(dTy.getEncoding());
 
-  DotCTASplit split = getDotCTASplit(
+  DotCTALayout layout = getDotCTALayout(
       dTy.getShape()[0], dTy.getShape()[1], ttg::getNumCTAs(dLayout),
-      preferMOnlySplitForTwoCTAMMA(dot, isBlackwell));
+      preferTwoCTASplit(dot, isBlackwell));
 
   OpBuilder builder(dot);
   int threadsPerWarp = ttg::lookupThreadsPerWarp(builder);
   int numWarps = ttg::lookupNumWarps(dot);
 
   auto newCGALayout = ttg::CGAEncodingAttr::fromSplitParams(
-      ctx, {split.m, split.n}, {split.m, split.n}, {1, 0});
+      ctx, {layout.split.m, layout.split.n}, {layout.split.m, layout.split.n},
+      layout.order);
   auto newDLayout = ttg::BlockedEncodingAttr::get(
       ctx, dTy.getShape(), dLayout.getSizePerThread(), dLayout.getOrder(),
       numWarps, threadsPerWarp, newCGALayout);

--- a/lib/Dialect/TritonNvidiaGPU/Transforms/AssignCTALayouts.cpp
+++ b/lib/Dialect/TritonNvidiaGPU/Transforms/AssignCTALayouts.cpp
@@ -195,8 +195,9 @@ DotCTALayout getDotCTALayout(int64_t m, int64_t n, unsigned numCTAs,
     splitN = numCTAs / splitM;
   }
 
-  return {{splitM, splitN}, preferTwoCTA ? std::array<unsigned, 2>{0, 1}
-                                         : std::array<unsigned, 2>{1, 0}};
+  return {{splitM, splitN},
+          preferTwoCTA ? std::array<unsigned, 2>{0, 1}
+                       : std::array<unsigned, 2>{1, 0}};
 }
 
 bool allowTwoCTASplit(triton::DotOp dot, bool preferTwoCTA) {
@@ -220,9 +221,9 @@ void assignDotCTALayout(triton::DotOp dot, bool preferTwoCTA) {
   auto bLayout = cast<ttg::DotOperandEncodingAttr>(bTy.getEncoding());
   auto dLayout = cast<ttg::BlockedEncodingAttr>(dTy.getEncoding());
 
-  DotCTALayout layout = getDotCTALayout(
-      dTy.getShape()[0], dTy.getShape()[1], ttg::getNumCTAs(dLayout),
-      allowTwoCTASplit(dot, preferTwoCTA));
+  DotCTALayout layout = getDotCTALayout(dTy.getShape()[0], dTy.getShape()[1],
+                                        ttg::getNumCTAs(dLayout),
+                                        allowTwoCTASplit(dot, preferTwoCTA));
 
   OpBuilder builder(dot);
   int threadsPerWarp = ttg::lookupThreadsPerWarp(builder);

--- a/lib/Dialect/TritonNvidiaGPU/Transforms/AssignCTALayouts.cpp
+++ b/lib/Dialect/TritonNvidiaGPU/Transforms/AssignCTALayouts.cpp
@@ -7,6 +7,7 @@
 #include "triton/Dialect/Triton/IR/Dialect.h"
 #include "triton/Dialect/TritonGPU/IR/Dialect.h"
 #include "triton/Dialect/TritonNvidiaGPU/IR/Dialect.h"
+#include "triton/Dialect/TritonNvidiaGPU/IR/TargetFeatures.h"
 #include "triton/Dialect/TritonNvidiaGPU/Transforms/Passes.h"
 #include "llvm/Support/ErrorHandling.h"
 
@@ -162,10 +163,14 @@ void convertOpResultsFromLayouts(Operation *op,
   }
 }
 
-DotCTASplit getDotCTASplit(int64_t m, int64_t n, unsigned numCTAs) {
+DotCTASplit getDotCTASplit(int64_t m, int64_t n, unsigned numCTAs,
+                           bool preferMOnly) {
   constexpr unsigned kPreferredChunkSize = 128;
   constexpr unsigned kMinChunkSize = 64;
   auto isLegalChunkSize = [](unsigned chunk) { return chunk >= kMinChunkSize; };
+
+  if (preferMOnly && isLegalChunkSize(m / numCTAs))
+    return {numCTAs, 1};
 
   unsigned splitM = 1;
   unsigned splitN = numCTAs;
@@ -183,7 +188,25 @@ DotCTASplit getDotCTASplit(int64_t m, int64_t n, unsigned numCTAs) {
   return {splitM, splitN};
 }
 
-void assignDotCTALayout(triton::DotOp dot) {
+bool hasDescriptorLoadLikeRoot(Value value) {
+  while (auto cvtOp = value.getDefiningOp<ttg::ConvertLayoutOp>())
+    value = cvtOp.getSrc();
+  return isa_and_nonnull<triton::DescriptorLoadLikeOpInterface>(
+      value.getDefiningOp());
+}
+
+bool preferMOnlySplitForTwoCTAMMA(triton::DotOp dot, bool isBlackwell) {
+  if (!isBlackwell || ttg::lookupNumCTAs(dot) != 4)
+    return false;
+
+  auto retTy = cast<RankedTensorType>(dot.getType());
+  if (retTy.getRank() != 2 || retTy.getDimSize(1) > 256)
+    return false;
+
+  return hasDescriptorLoadLikeRoot(dot.getB());
+}
+
+void assignDotCTALayout(triton::DotOp dot, bool isBlackwell) {
   MLIRContext *ctx = dot.getContext();
 
   auto aTy = cast<RankedTensorType>(dot.getA().getType());
@@ -194,8 +217,9 @@ void assignDotCTALayout(triton::DotOp dot) {
   auto bLayout = cast<ttg::DotOperandEncodingAttr>(bTy.getEncoding());
   auto dLayout = cast<ttg::BlockedEncodingAttr>(dTy.getEncoding());
 
-  DotCTASplit split = getDotCTASplit(dTy.getShape()[0], dTy.getShape()[1],
-                                     ttg::getNumCTAs(dLayout));
+  DotCTASplit split = getDotCTASplit(
+      dTy.getShape()[0], dTy.getShape()[1], ttg::getNumCTAs(dLayout),
+      preferMOnlySplitForTwoCTAMMA(dot, isBlackwell));
 
   OpBuilder builder(dot);
   int threadsPerWarp = ttg::lookupThreadsPerWarp(builder);
@@ -303,9 +327,18 @@ struct AssignCTALayoutsPass
     if (numCTAs == 1)
       return;
 
+    auto targetAttr =
+        mod->getAttrOfType<StringAttr>(triton::gpu::AttrTargetName);
+    bool isBlackwell = false;
+    if (targetAttr && targetAttr.getValue().starts_with("cuda:")) {
+      int computeCapability =
+          TargetFeatures::fromModuleOp(mod).getComputeCapability();
+      isBlackwell = computeCapability >= 100 && computeCapability < 120;
+    }
+
     mod.walk([&](Operation *op) {
       if (auto dot = dyn_cast<triton::DotOp>(op))
-        assignDotCTALayout(dot);
+        assignDotCTALayout(dot, isBlackwell);
       if (auto reduce = dyn_cast<triton::ReduceOp>(op))
         assignReduceCTALayout(reduce);
     });

--- a/lib/Dialect/TritonNvidiaGPU/Transforms/AssignCTALayouts.cpp
+++ b/lib/Dialect/TritonNvidiaGPU/Transforms/AssignCTALayouts.cpp
@@ -332,13 +332,14 @@ struct AssignCTALayoutsPass
     if (numCTAs == 1)
       return;
 
-    auto targetAttr =
-        mod->getAttrOfType<StringAttr>(triton::gpu::AttrTargetName);
-    bool preferTwoCTA = false;
-    if (targetAttr && targetAttr.getValue().starts_with("cuda:")) {
+    auto preferTwoCTA = [&]() {
+      auto targetAttr =
+          mod->getAttrOfType<StringAttr>(triton::gpu::AttrTargetName);
+      if (!targetAttr || !targetAttr.getValue().starts_with("cuda:"))
+        return false;
       int computeCapability = getNVIDIAComputeCapability(mod);
-      preferTwoCTA = computeCapability >= 100 && computeCapability < 120;
-    }
+      return computeCapability >= 100 && computeCapability < 120;
+    }();
 
     mod.walk([&](Operation *op) {
       if (auto dot = dyn_cast<triton::DotOp>(op))

--- a/python/test/unit/language/test_tensor_descriptor.py
+++ b/python/test/unit/language/test_tensor_descriptor.py
@@ -672,8 +672,7 @@ def test_make_tensor_descriptor_matmul(num_stages, num_ctas, BLOCK_M, BLOCK_N, B
             "ptx"] or "stmatrix.sync.aligned.x4.m8n8.shared.b16" in kernel.asm["ptx"]
 
 
-@pytest.mark.skipif(not is_cuda() or torch.cuda.get_device_capability(0)[0] != 10,
-                    reason="Requires Blackwell MMAv5")
+@pytest.mark.skipif(not is_cuda() or torch.cuda.get_device_capability(0)[0] != 10, reason="Requires Blackwell MMAv5")
 @pytest.mark.parametrize("num_ctas, BLOCK_M, BLOCK_N", [(4, 256, 256), (8, 256, 512)])
 def test_make_tensor_descriptor_matmul_multi_cta_tma_multicast(num_ctas, BLOCK_M, BLOCK_N, device):
     M, N, K = 512, 512, 256

--- a/python/test/unit/language/test_tensor_descriptor.py
+++ b/python/test/unit/language/test_tensor_descriptor.py
@@ -672,6 +672,49 @@ def test_make_tensor_descriptor_matmul(num_stages, num_ctas, BLOCK_M, BLOCK_N, B
             "ptx"] or "stmatrix.sync.aligned.x4.m8n8.shared.b16" in kernel.asm["ptx"]
 
 
+@pytest.mark.skipif(not is_cuda() or torch.cuda.get_device_capability(0)[0] != 10,
+                    reason="Requires Blackwell MMAv5")
+@pytest.mark.parametrize("num_ctas, BLOCK_M, BLOCK_N", [(4, 256, 256), (8, 256, 512)])
+def test_make_tensor_descriptor_matmul_multi_cta_tma_multicast(num_ctas, BLOCK_M, BLOCK_N, device):
+    M, N, K = 512, 512, 256
+    BLOCK_K = 64
+    torch.manual_seed(42)
+    A = torch.randn((M, K), dtype=torch.float16, device=device)
+    B = torch.randn((K, N), dtype=torch.float16, device=device)
+    C = torch.empty((M, N), dtype=torch.float16, device=device)
+    grid = (triton.cdiv(M, BLOCK_M), triton.cdiv(N, BLOCK_N), 1)
+
+    def alloc_fn(size: int, align: int, stream: Optional[int]):
+        assert align == 128
+        assert stream == 0
+        return torch.empty(size, dtype=torch.int8, device=device)
+
+    triton.set_allocator(alloc_fn)
+
+    kernel = matmul_kernel_make_tensor_descriptor[grid](
+        A,
+        B,
+        C,
+        M,
+        N,
+        K,
+        BLOCK_M,
+        BLOCK_N,
+        BLOCK_K,
+        num_warps=4,
+        num_stages=3,
+        num_ctas=num_ctas,
+    )
+
+    ref_out = torch.matmul(A.to(torch.float32), B.to(torch.float32)).to(torch.float16)
+    torch.testing.assert_close(ref_out, C, rtol=1e-3, atol=1e-3)
+
+    mma_lines = [line for line in kernel.asm["ttgir"].splitlines() if "ttng.tc_gen5_mma" in line]
+    assert any("two_ctas" in line and "multicast" in line for line in mma_lines)
+    assert "cta_group::2" in kernel.asm["ptx"]
+    assert "multicast::cluster" in kernel.asm["ptx"]
+
+
 @triton.jit
 def kernel_make_tensor_descriptor_loop_carried(a_ptr, M, N, MBLOCK: tl.constexpr, NBLOCK: tl.constexpr):
     # Test that descriptors work with

--- a/test/TritonNvidiaGPU/assign_cta_layouts.mlir
+++ b/test/TritonNvidiaGPU/assign_cta_layouts.mlir
@@ -124,3 +124,33 @@ module attributes {"ttg.num-ctas" = 2 : i32, "ttg.num-warps" = 4 : i32, ttg.targ
     tt.return %a : tensor<128x32xf16, #desc_load_src>
   }
 }
+
+// -----
+
+#desc_load_4cta = #ttg.blocked<{sizePerThread = [1, 4], threadsPerWarp = [1, 32], warpsPerCTA = [4, 1], order = [1, 0], CGALayout = [[1, 0], [2, 0]]}>
+#dot_default_4cta = #ttg.blocked<{sizePerThread = [4, 4], threadsPerWarp = [1, 32], warpsPerCTA = [4, 1], order = [1, 0], CGALayout = [[0, 1], [0, 2]]}>
+#dot_a_4cta = #ttg.dot_op<{opIdx = 0, parent = #dot_default_4cta}>
+#dot_b_4cta = #ttg.dot_op<{opIdx = 1, parent = #dot_default_4cta}>
+
+// CHECK-DAG: #[[$DESC_4CTA_B_ORIG:.*]] = #ttg.blocked<{sizePerThread = [1, 4], threadsPerWarp = [1, 32], warpsPerCTA = [4, 1], order = [1, 0], CGALayout = {{\[\[1, 0\], \[2, 0\]\]}}}>
+// CHECK-DAG: #[[$DESC_4CTA_B_PLANNED:.*]] = #ttg.blocked<{sizePerThread = [1, 4], threadsPerWarp = [1, 32], warpsPerCTA = [2, 2], order = [1, 0], CGALayout = {{\[\[0, 0\], \[0, 0\]\]}}}>
+// CHECK-DAG: #[[$DOT_4CTA_M_ONLY:.*]] = #ttg.blocked<{sizePerThread = [4, 4], threadsPerWarp = [1, 32], warpsPerCTA = [2, 2], order = [1, 0], CGALayout = {{\[\[1, 0\], \[2, 0\]\]}}}>
+module attributes {"ttg.num-ctas" = 4 : i32, "ttg.num-warps" = 4 : i32, ttg.target = "cuda:100", "ttg.threads-per-warp" = 32 : i32} {
+  // CHECK-LABEL: tt.func @dot_prefers_m_only_for_4cta_descriptor_rhs
+  // CHECK: %[[B_DESC_LOAD:.*]] = tt.descriptor_load %{{.*}}[%{{.*}}, %{{.*}}] : !tt.tensordesc<64x256xf16> -> tensor<64x256xf16, #[[$DESC_4CTA_B_PLANNED]]>
+  // CHECK: ttg.convert_layout %{{.*}} : tensor<256x64xf16, #{{.*}}> -> tensor<256x64xf16, #ttg.dot_op<{opIdx = 0, parent = #[[$DOT_4CTA_M_ONLY]]}>>
+  // CHECK: ttg.convert_layout %[[B_DESC_LOAD]] : tensor<64x256xf16, #[[$DESC_4CTA_B_PLANNED]]> -> tensor<64x256xf16, #ttg.dot_op<{opIdx = 1, parent = #[[$DOT_4CTA_M_ONLY]]}>>
+  // CHECK: tt.dot %{{.*}}, %{{.*}}, %{{.*}} : tensor<256x64xf16, #ttg.dot_op<{opIdx = 0, parent = #[[$DOT_4CTA_M_ONLY]]}>> * tensor<64x256xf16, #ttg.dot_op<{opIdx = 1, parent = #[[$DOT_4CTA_M_ONLY]]}>> -> tensor<256x256xf32, #[[$DOT_4CTA_M_ONLY]]>
+  tt.func @dot_prefers_m_only_for_4cta_descriptor_rhs(
+    %a: tensor<256x64xf16, #desc_load_4cta>,
+    %b_desc: !tt.tensordesc<64x256xf16>,
+    %i: i32,
+    %j: i32,
+    %c: tensor<256x256xf32, #dot_default_4cta>) {
+    %b = tt.descriptor_load %b_desc[%i, %j] : !tt.tensordesc<64x256xf16> -> tensor<64x256xf16, #desc_load_4cta>
+    %ad = ttg.convert_layout %a : tensor<256x64xf16, #desc_load_4cta> -> tensor<256x64xf16, #dot_a_4cta>
+    %bd = ttg.convert_layout %b : tensor<64x256xf16, #desc_load_4cta> -> tensor<64x256xf16, #dot_b_4cta>
+    %dot = tt.dot %ad, %bd, %c : tensor<256x64xf16, #dot_a_4cta> * tensor<64x256xf16, #dot_b_4cta> -> tensor<256x256xf32, #dot_default_4cta>
+    tt.return
+  }
+}

--- a/test/TritonNvidiaGPU/assign_cta_layouts.mlir
+++ b/test/TritonNvidiaGPU/assign_cta_layouts.mlir
@@ -56,11 +56,11 @@ module attributes {"ttg.num-ctas" = 4 : i32, "ttg.num-warps" = 4 : i32, ttg.targ
 #dot_b_load = #ttg.dot_op<{opIdx = 1, parent = #dot_default_load}>
 
 // CHECK-DAG: #[[$LOAD_ORIG:.*]] = #ttg.blocked<{sizePerThread = [1, 4], threadsPerWarp = [8, 4], warpsPerCTA = [4, 1], order = [1, 0], CGALayout = {{\[\[1, 0\]\]}}}>
-// CHECK-DAG: #[[$LOAD_PLANNED:.*]] = #ttg.blocked<{sizePerThread = [1, 4], threadsPerWarp = [4, 8], warpsPerCTA = [4, 1], order = [1, 0], CGALayout = {{\[\[1, 0\]\]}}}>
+// CHECK-DAG: #[[$LOAD_PLANNED:.*]] = #ttg.blocked<{sizePerThread = [1, 4], threadsPerWarp = [4, 8], warpsPerCTA = [4, 1], order = [1, 0], CGALayout = {{\[\[0, 0\]\]}}}>
 // CHECK-DAG: #[[$LOAD_B_ORIG:.*]] = #ttg.blocked<{sizePerThread = [1, 4], threadsPerWarp = [1, 32], warpsPerCTA = [4, 1], order = [1, 0], CGALayout = {{\[\[1, 0\]\]}}}>
-// CHECK-DAG: #[[$LOAD_B_PLANNED:.*]] = #ttg.blocked<{sizePerThread = [1, 4], threadsPerWarp = [1, 32], warpsPerCTA = [4, 1], order = [1, 0], CGALayout = {{\[\[0, 0\]\]}}}>
+// CHECK-DAG: #[[$LOAD_B_PLANNED:.*]] = #ttg.blocked<{sizePerThread = [1, 4], threadsPerWarp = [2, 16], warpsPerCTA = [4, 1], order = [1, 0], CGALayout = {{\[\[0, 1\]\]}}}>
 // CHECK-DAG: #[[$DOT_DEFAULT_LOAD:.*]] = #ttg.blocked<{sizePerThread = [4, 4], threadsPerWarp = [1, 32], warpsPerCTA = [4, 1], order = [1, 0], CGALayout = {{\[\[0, 1\]\]}}}>
-// CHECK-DAG: #[[$DOT_OPT_LOAD:.*]] = #ttg.blocked<{sizePerThread = [4, 4], threadsPerWarp = [1, 32], warpsPerCTA = [4, 1], order = [1, 0], CGALayout = {{\[\[1, 0\]\]}}}>
+// CHECK-DAG: #[[$DOT_OPT_LOAD:.*]] = #ttg.blocked<{sizePerThread = [4, 4], threadsPerWarp = [2, 16], warpsPerCTA = [4, 1], order = [1, 0], CGALayout = {{\[\[0, 1\]\]}}}>
 module attributes {"ttg.num-ctas" = 2 : i32, "ttg.num-warps" = 4 : i32, ttg.target = "cuda:100", "ttg.threads-per-warp" = 32 : i32} {
   // CHECK-LABEL: tt.func @dot_clones_load_source
   // CHECK: %[[ORIG_LOAD:.*]] = tt.load %{{.*}} : tensor<128x32x!tt.ptr<f16>, #[[$LOAD_ORIG]]>
@@ -96,11 +96,11 @@ module attributes {"ttg.num-ctas" = 2 : i32, "ttg.num-warps" = 4 : i32, ttg.targ
 #dot_b_desc_load = #ttg.dot_op<{opIdx = 1, parent = #dot_default_desc_load}>
 
 // CHECK-DAG: #[[$DESC_LOAD_ORIG:.*]] = #ttg.blocked<{sizePerThread = [1, 4], threadsPerWarp = [8, 4], warpsPerCTA = [4, 1], order = [1, 0], CGALayout = {{\[\[1, 0\]\]}}}>
-// CHECK-DAG: #[[$DESC_LOAD_PLANNED:.*]] = #ttg.blocked<{sizePerThread = [1, 4], threadsPerWarp = [4, 8], warpsPerCTA = [4, 1], order = [1, 0], CGALayout = {{\[\[1, 0\]\]}}}>
+// CHECK-DAG: #[[$DESC_LOAD_PLANNED:.*]] = #ttg.blocked<{sizePerThread = [1, 4], threadsPerWarp = [4, 8], warpsPerCTA = [4, 1], order = [1, 0], CGALayout = {{\[\[0, 0\]\]}}}>
 // CHECK-DAG: #[[$DESC_LOAD_B_ORIG:.*]] = #ttg.blocked<{sizePerThread = [1, 4], threadsPerWarp = [1, 32], warpsPerCTA = [4, 1], order = [1, 0], CGALayout = {{\[\[1, 0\]\]}}}>
-// CHECK-DAG: #[[$DESC_LOAD_B_PLANNED:.*]] = #ttg.blocked<{sizePerThread = [1, 4], threadsPerWarp = [1, 32], warpsPerCTA = [4, 1], order = [1, 0], CGALayout = {{\[\[0, 0\]\]}}}>
+// CHECK-DAG: #[[$DESC_LOAD_B_PLANNED:.*]] = #ttg.blocked<{sizePerThread = [1, 4], threadsPerWarp = [2, 16], warpsPerCTA = [4, 1], order = [1, 0], CGALayout = {{\[\[0, 1\]\]}}}>
 // CHECK-DAG: #[[$DOT_DEFAULT_DESC_LOAD:.*]] = #ttg.blocked<{sizePerThread = [4, 4], threadsPerWarp = [1, 32], warpsPerCTA = [4, 1], order = [1, 0], CGALayout = {{\[\[0, 1\]\]}}}>
-// CHECK-DAG: #[[$DOT_OPT_DESC_LOAD:.*]] = #ttg.blocked<{sizePerThread = [4, 4], threadsPerWarp = [1, 32], warpsPerCTA = [4, 1], order = [1, 0], CGALayout = {{\[\[1, 0\]\]}}}>
+// CHECK-DAG: #[[$DOT_OPT_DESC_LOAD:.*]] = #ttg.blocked<{sizePerThread = [4, 4], threadsPerWarp = [2, 16], warpsPerCTA = [4, 1], order = [1, 0], CGALayout = {{\[\[0, 1\]\]}}}>
 module attributes {"ttg.num-ctas" = 2 : i32, "ttg.num-warps" = 4 : i32, ttg.target = "cuda:100", "ttg.threads-per-warp" = 32 : i32} {
   // CHECK-LABEL: tt.func @dot_clones_descriptor_load_source
   // CHECK: %[[ORIG_DESC_LOAD:.*]] = tt.descriptor_load %{{.*}}[%{{.*}}, %{{.*}}] : !tt.tensordesc<128x32xf16> -> tensor<128x32xf16, #[[$DESC_LOAD_ORIG]]>
@@ -132,8 +132,8 @@ module attributes {"ttg.num-ctas" = 2 : i32, "ttg.num-warps" = 4 : i32, ttg.targ
 #dot_a_8cta = #ttg.dot_op<{opIdx = 0, parent = #dot_default_8cta}>
 #dot_b_8cta = #ttg.dot_op<{opIdx = 1, parent = #dot_default_8cta}>
 
-// CHECK-DAG: #[[$DESC_8CTA_B_PLANNED:.*]] = #ttg.blocked<{sizePerThread = [1, 4], threadsPerWarp = [1, 32], warpsPerCTA = [2, 2], order = [1, 0], CGALayout = {{\[\[0, 0\], \[0, 0\], \[0, 1\]\]}}}>
-// CHECK-DAG: #[[$DOT_8CTA_M_FIRST:.*]] = #ttg.blocked<{sizePerThread = [4, 4], threadsPerWarp = [1, 32], warpsPerCTA = [2, 2], order = [1, 0], CGALayout = {{\[\[1, 0\], \[2, 0\], \[0, 1\]\]}}}>
+// CHECK-DAG: #[[$DESC_8CTA_B_PLANNED:.*]] = #ttg.blocked<{sizePerThread = [1, 4], threadsPerWarp = [1, 32], warpsPerCTA = [4, 1], order = [1, 0], CGALayout = {{\[\[0, 0\], \[0, 1\], \[0, 2\]\]}}}>
+// CHECK-DAG: #[[$DOT_8CTA_M_FIRST:.*]] = #ttg.blocked<{sizePerThread = [4, 4], threadsPerWarp = [1, 32], warpsPerCTA = [4, 1], order = [1, 0], CGALayout = {{\[\[1, 0\], \[0, 1\], \[0, 2\]\]}}}>
 module attributes {"ttg.num-ctas" = 8 : i32, "ttg.num-warps" = 4 : i32, ttg.target = "cuda:100", "ttg.threads-per-warp" = 32 : i32} {
   // CHECK-LABEL: tt.func @dot_prefers_m_first_for_8cta_descriptor_rhs
   // CHECK: %[[B_DESC_LOAD:.*]] = tt.descriptor_load %{{.*}}[%{{.*}}, %{{.*}}] : !tt.tensordesc<64x512xf16> -> tensor<64x512xf16, #[[$DESC_8CTA_B_PLANNED]]>
@@ -150,39 +150,6 @@ module attributes {"ttg.num-ctas" = 8 : i32, "ttg.num-warps" = 4 : i32, ttg.targ
     %ad = ttg.convert_layout %a : tensor<256x64xf16, #desc_load_8cta> -> tensor<256x64xf16, #dot_a_8cta>
     %bd = ttg.convert_layout %b : tensor<64x512xf16, #desc_load_8cta> -> tensor<64x512xf16, #dot_b_8cta>
     %dot = tt.dot %ad, %bd, %c : tensor<256x64xf16, #dot_a_8cta> * tensor<64x512xf16, #dot_b_8cta> -> tensor<256x512xf32, #dot_default_8cta>
-    tt.return
-  }
-}
-
-// -----
-
-#desc_load_a_reuse_4cta = #ttg.blocked<{sizePerThread = [1, 4], threadsPerWarp = [8, 4], warpsPerCTA = [4, 1], order = [1, 0], CGALayout = [[1, 0], [2, 0]]}>
-#desc_load_a_reuse_b_4cta = #ttg.blocked<{sizePerThread = [1, 4], threadsPerWarp = [1, 32], warpsPerCTA = [4, 1], order = [1, 0], CGALayout = [[1, 0], [2, 0]]}>
-#dot_default_a_reuse_4cta = #ttg.blocked<{sizePerThread = [4, 4], threadsPerWarp = [1, 32], warpsPerCTA = [4, 1], order = [1, 0], CGALayout = [[0, 1], [0, 2]]}>
-#dot_a_a_reuse_4cta = #ttg.dot_op<{opIdx = 0, parent = #dot_default_a_reuse_4cta}>
-#dot_b_a_reuse_4cta = #ttg.dot_op<{opIdx = 1, parent = #dot_default_a_reuse_4cta}>
-
-// CHECK-DAG: #[[$DESC_4CTA_A_REUSE_A_PLANNED:.*]] = #ttg.blocked<{sizePerThread = [1, 4], threadsPerWarp = [2, 16], warpsPerCTA = [4, 1], order = [1, 0], CGALayout = {{\[\[1, 0\], \[0, 0\]\]}}}>
-// CHECK-DAG: #[[$DESC_4CTA_A_REUSE_B_PLANNED:.*]] = #ttg.blocked<{sizePerThread = [1, 4], threadsPerWarp = [2, 16], warpsPerCTA = [4, 1], order = [1, 0], CGALayout = {{\[\[0, 0\], \[0, 1\]\]}}}>
-// CHECK-DAG: #[[$DOT_4CTA_A_REUSE:.*]] = #ttg.blocked<{sizePerThread = [4, 4], threadsPerWarp = [2, 16], warpsPerCTA = [4, 1], order = [1, 0], CGALayout = {{\[\[1, 0\], \[0, 1\]\]}}}>
-module attributes {"ttg.num-ctas" = 4 : i32, "ttg.num-warps" = 4 : i32, ttg.target = "cuda:100", "ttg.threads-per-warp" = 32 : i32} {
-  // CHECK-LABEL: tt.func @dot_prefers_a_reuse_for_larger_descriptor_lhs
-  // CHECK: %[[A_DESC_LOAD:.*]] = tt.descriptor_load %{{.*}}[%{{.*}}, %{{.*}}] : !tt.tensordesc<512x64xf16> -> tensor<512x64xf16, #[[$DESC_4CTA_A_REUSE_A_PLANNED]]>
-  // CHECK: %[[B_DESC_LOAD:.*]] = tt.descriptor_load %{{.*}}[%{{.*}}, %{{.*}}] : !tt.tensordesc<64x128xf16> -> tensor<64x128xf16, #[[$DESC_4CTA_A_REUSE_B_PLANNED]]>
-  // CHECK: ttg.convert_layout %[[A_DESC_LOAD]] : tensor<512x64xf16, #[[$DESC_4CTA_A_REUSE_A_PLANNED]]> -> tensor<512x64xf16, #ttg.dot_op<{opIdx = 0, parent = #[[$DOT_4CTA_A_REUSE]]}>>
-  // CHECK: ttg.convert_layout %[[B_DESC_LOAD]] : tensor<64x128xf16, #[[$DESC_4CTA_A_REUSE_B_PLANNED]]> -> tensor<64x128xf16, #ttg.dot_op<{opIdx = 1, parent = #[[$DOT_4CTA_A_REUSE]]}>>
-  // CHECK: tt.dot %{{.*}}, %{{.*}}, %{{.*}} : tensor<512x64xf16, #ttg.dot_op<{opIdx = 0, parent = #[[$DOT_4CTA_A_REUSE]]}>> * tensor<64x128xf16, #ttg.dot_op<{opIdx = 1, parent = #[[$DOT_4CTA_A_REUSE]]}>> -> tensor<512x128xf32, #[[$DOT_4CTA_A_REUSE]]>
-  tt.func @dot_prefers_a_reuse_for_larger_descriptor_lhs(
-    %a_desc: !tt.tensordesc<512x64xf16>,
-    %b_desc: !tt.tensordesc<64x128xf16>,
-    %i: i32,
-    %j: i32,
-    %c: tensor<512x128xf32, #dot_default_a_reuse_4cta>) {
-    %a = tt.descriptor_load %a_desc[%i, %j] : !tt.tensordesc<512x64xf16> -> tensor<512x64xf16, #desc_load_a_reuse_4cta>
-    %b = tt.descriptor_load %b_desc[%i, %j] : !tt.tensordesc<64x128xf16> -> tensor<64x128xf16, #desc_load_a_reuse_b_4cta>
-    %ad = ttg.convert_layout %a : tensor<512x64xf16, #desc_load_a_reuse_4cta> -> tensor<512x64xf16, #dot_a_a_reuse_4cta>
-    %bd = ttg.convert_layout %b : tensor<64x128xf16, #desc_load_a_reuse_b_4cta> -> tensor<64x128xf16, #dot_b_a_reuse_4cta>
-    %dot = tt.dot %ad, %bd, %c : tensor<512x64xf16, #dot_a_a_reuse_4cta> * tensor<64x128xf16, #dot_b_a_reuse_4cta> -> tensor<512x128xf32, #dot_default_a_reuse_4cta>
     tt.return
   }
 }

--- a/test/TritonNvidiaGPU/assign_cta_layouts.mlir
+++ b/test/TritonNvidiaGPU/assign_cta_layouts.mlir
@@ -28,7 +28,7 @@ module attributes {"ttg.num-ctas" = 4 : i32, "ttg.num-warps" = 4 : i32, ttg.targ
 #dot_b = #ttg.dot_op<{opIdx = 1, parent = #dot_default}>
 
 // CHECK-DAG: #[[$DOT_DEFAULT:.*]] = #ttg.blocked<{sizePerThread = [4, 4], threadsPerWarp = [1, 32], warpsPerCTA = [4, 1], order = [1, 0], CGALayout = {{\[\[0, 1\], \[0, 2\]\]}}}>
-// CHECK-DAG: #[[$DOT_OPT:.*]] = #ttg.blocked<{sizePerThread = [4, 4], threadsPerWarp = [2, 16], warpsPerCTA = [4, 1], order = [1, 0], CGALayout = {{\[\[0, 1\], \[1, 0\]\]}}}>
+// CHECK-DAG: #[[$DOT_OPT:.*]] = #ttg.blocked<{sizePerThread = [4, 4], threadsPerWarp = [2, 16], warpsPerCTA = [4, 1], order = [1, 0], CGALayout = {{\[\[1, 0\], \[0, 1\]\]}}}>
 module attributes {"ttg.num-ctas" = 4 : i32, "ttg.num-warps" = 4 : i32, ttg.target = "cuda:100", "ttg.threads-per-warp" = 32 : i32} {
   // CHECK-LABEL: tt.func @dot_split_mn
   // CHECK: ttg.convert_layout %{{.*}} : tensor<128x32xf16, #ttg.dot_op<{opIdx = 0, parent = #[[$DOT_DEFAULT]]}>> -> tensor<128x32xf16, #ttg.dot_op<{opIdx = 0, parent = #[[$DOT_OPT]]}>>
@@ -56,11 +56,11 @@ module attributes {"ttg.num-ctas" = 4 : i32, "ttg.num-warps" = 4 : i32, ttg.targ
 #dot_b_load = #ttg.dot_op<{opIdx = 1, parent = #dot_default_load}>
 
 // CHECK-DAG: #[[$LOAD_ORIG:.*]] = #ttg.blocked<{sizePerThread = [1, 4], threadsPerWarp = [8, 4], warpsPerCTA = [4, 1], order = [1, 0], CGALayout = {{\[\[1, 0\]\]}}}>
-// CHECK-DAG: #[[$LOAD_PLANNED:.*]] = #ttg.blocked<{sizePerThread = [1, 4], threadsPerWarp = [4, 8], warpsPerCTA = [4, 1], order = [1, 0], CGALayout = {{\[\[0, 0\]\]}}}>
+// CHECK-DAG: #[[$LOAD_PLANNED:.*]] = #ttg.blocked<{sizePerThread = [1, 4], threadsPerWarp = [4, 8], warpsPerCTA = [4, 1], order = [1, 0], CGALayout = {{\[\[1, 0\]\]}}}>
 // CHECK-DAG: #[[$LOAD_B_ORIG:.*]] = #ttg.blocked<{sizePerThread = [1, 4], threadsPerWarp = [1, 32], warpsPerCTA = [4, 1], order = [1, 0], CGALayout = {{\[\[1, 0\]\]}}}>
-// CHECK-DAG: #[[$LOAD_B_PLANNED:.*]] = #ttg.blocked<{sizePerThread = [1, 4], threadsPerWarp = [2, 16], warpsPerCTA = [4, 1], order = [1, 0], CGALayout = {{\[\[0, 1\]\]}}}>
+// CHECK-DAG: #[[$LOAD_B_PLANNED:.*]] = #ttg.blocked<{sizePerThread = [1, 4], threadsPerWarp = [1, 32], warpsPerCTA = [4, 1], order = [1, 0], CGALayout = {{\[\[0, 0\]\]}}}>
 // CHECK-DAG: #[[$DOT_DEFAULT_LOAD:.*]] = #ttg.blocked<{sizePerThread = [4, 4], threadsPerWarp = [1, 32], warpsPerCTA = [4, 1], order = [1, 0], CGALayout = {{\[\[0, 1\]\]}}}>
-// CHECK-DAG: #[[$DOT_OPT_LOAD:.*]] = #ttg.blocked<{sizePerThread = [4, 4], threadsPerWarp = [2, 16], warpsPerCTA = [4, 1], order = [1, 0], CGALayout = {{\[\[0, 1\]\]}}}>
+// CHECK-DAG: #[[$DOT_OPT_LOAD:.*]] = #ttg.blocked<{sizePerThread = [4, 4], threadsPerWarp = [1, 32], warpsPerCTA = [4, 1], order = [1, 0], CGALayout = {{\[\[1, 0\]\]}}}>
 module attributes {"ttg.num-ctas" = 2 : i32, "ttg.num-warps" = 4 : i32, ttg.target = "cuda:100", "ttg.threads-per-warp" = 32 : i32} {
   // CHECK-LABEL: tt.func @dot_clones_load_source
   // CHECK: %[[ORIG_LOAD:.*]] = tt.load %{{.*}} : tensor<128x32x!tt.ptr<f16>, #[[$LOAD_ORIG]]>
@@ -154,3 +154,35 @@ module attributes {"ttg.num-ctas" = 8 : i32, "ttg.num-warps" = 4 : i32, ttg.targ
   }
 }
 
+// -----
+
+#desc_load_a_reuse_4cta = #ttg.blocked<{sizePerThread = [1, 4], threadsPerWarp = [8, 4], warpsPerCTA = [4, 1], order = [1, 0], CGALayout = [[1, 0], [2, 0]]}>
+#desc_load_a_reuse_b_4cta = #ttg.blocked<{sizePerThread = [1, 4], threadsPerWarp = [1, 32], warpsPerCTA = [4, 1], order = [1, 0], CGALayout = [[1, 0], [2, 0]]}>
+#dot_default_a_reuse_4cta = #ttg.blocked<{sizePerThread = [4, 4], threadsPerWarp = [1, 32], warpsPerCTA = [4, 1], order = [1, 0], CGALayout = [[0, 1], [0, 2]]}>
+#dot_a_a_reuse_4cta = #ttg.dot_op<{opIdx = 0, parent = #dot_default_a_reuse_4cta}>
+#dot_b_a_reuse_4cta = #ttg.dot_op<{opIdx = 1, parent = #dot_default_a_reuse_4cta}>
+
+// CHECK-DAG: #[[$DESC_4CTA_A_REUSE_A_PLANNED:.*]] = #ttg.blocked<{sizePerThread = [1, 4], threadsPerWarp = [2, 16], warpsPerCTA = [4, 1], order = [1, 0], CGALayout = {{\[\[1, 0\], \[0, 0\]\]}}}>
+// CHECK-DAG: #[[$DESC_4CTA_A_REUSE_B_PLANNED:.*]] = #ttg.blocked<{sizePerThread = [1, 4], threadsPerWarp = [2, 16], warpsPerCTA = [4, 1], order = [1, 0], CGALayout = {{\[\[0, 0\], \[0, 1\]\]}}}>
+// CHECK-DAG: #[[$DOT_4CTA_A_REUSE:.*]] = #ttg.blocked<{sizePerThread = [4, 4], threadsPerWarp = [2, 16], warpsPerCTA = [4, 1], order = [1, 0], CGALayout = {{\[\[1, 0\], \[0, 1\]\]}}}>
+module attributes {"ttg.num-ctas" = 4 : i32, "ttg.num-warps" = 4 : i32, ttg.target = "cuda:100", "ttg.threads-per-warp" = 32 : i32} {
+  // CHECK-LABEL: tt.func @dot_prefers_a_reuse_for_larger_descriptor_lhs
+  // CHECK: %[[A_DESC_LOAD:.*]] = tt.descriptor_load %{{.*}}[%{{.*}}, %{{.*}}] : !tt.tensordesc<512x64xf16> -> tensor<512x64xf16, #[[$DESC_4CTA_A_REUSE_A_PLANNED]]>
+  // CHECK: %[[B_DESC_LOAD:.*]] = tt.descriptor_load %{{.*}}[%{{.*}}, %{{.*}}] : !tt.tensordesc<64x128xf16> -> tensor<64x128xf16, #[[$DESC_4CTA_A_REUSE_B_PLANNED]]>
+  // CHECK: ttg.convert_layout %[[A_DESC_LOAD]] : tensor<512x64xf16, #[[$DESC_4CTA_A_REUSE_A_PLANNED]]> -> tensor<512x64xf16, #ttg.dot_op<{opIdx = 0, parent = #[[$DOT_4CTA_A_REUSE]]}>>
+  // CHECK: ttg.convert_layout %[[B_DESC_LOAD]] : tensor<64x128xf16, #[[$DESC_4CTA_A_REUSE_B_PLANNED]]> -> tensor<64x128xf16, #ttg.dot_op<{opIdx = 1, parent = #[[$DOT_4CTA_A_REUSE]]}>>
+  // CHECK: tt.dot %{{.*}}, %{{.*}}, %{{.*}} : tensor<512x64xf16, #ttg.dot_op<{opIdx = 0, parent = #[[$DOT_4CTA_A_REUSE]]}>> * tensor<64x128xf16, #ttg.dot_op<{opIdx = 1, parent = #[[$DOT_4CTA_A_REUSE]]}>> -> tensor<512x128xf32, #[[$DOT_4CTA_A_REUSE]]>
+  tt.func @dot_prefers_a_reuse_for_larger_descriptor_lhs(
+    %a_desc: !tt.tensordesc<512x64xf16>,
+    %b_desc: !tt.tensordesc<64x128xf16>,
+    %i: i32,
+    %j: i32,
+    %c: tensor<512x128xf32, #dot_default_a_reuse_4cta>) {
+    %a = tt.descriptor_load %a_desc[%i, %j] : !tt.tensordesc<512x64xf16> -> tensor<512x64xf16, #desc_load_a_reuse_4cta>
+    %b = tt.descriptor_load %b_desc[%i, %j] : !tt.tensordesc<64x128xf16> -> tensor<64x128xf16, #desc_load_a_reuse_b_4cta>
+    %ad = ttg.convert_layout %a : tensor<512x64xf16, #desc_load_a_reuse_4cta> -> tensor<512x64xf16, #dot_a_a_reuse_4cta>
+    %bd = ttg.convert_layout %b : tensor<64x128xf16, #desc_load_a_reuse_b_4cta> -> tensor<64x128xf16, #dot_b_a_reuse_4cta>
+    %dot = tt.dot %ad, %bd, %c : tensor<512x64xf16, #dot_a_a_reuse_4cta> * tensor<64x128xf16, #dot_b_a_reuse_4cta> -> tensor<512x128xf32, #dot_default_a_reuse_4cta>
+    tt.return
+  }
+}

--- a/test/TritonNvidiaGPU/assign_cta_layouts.mlir
+++ b/test/TritonNvidiaGPU/assign_cta_layouts.mlir
@@ -96,11 +96,11 @@ module attributes {"ttg.num-ctas" = 2 : i32, "ttg.num-warps" = 4 : i32, ttg.targ
 #dot_b_desc_load = #ttg.dot_op<{opIdx = 1, parent = #dot_default_desc_load}>
 
 // CHECK-DAG: #[[$DESC_LOAD_ORIG:.*]] = #ttg.blocked<{sizePerThread = [1, 4], threadsPerWarp = [8, 4], warpsPerCTA = [4, 1], order = [1, 0], CGALayout = {{\[\[1, 0\]\]}}}>
-// CHECK-DAG: #[[$DESC_LOAD_PLANNED:.*]] = #ttg.blocked<{sizePerThread = [1, 4], threadsPerWarp = [4, 8], warpsPerCTA = [4, 1], order = [1, 0], CGALayout = {{\[\[0, 0\]\]}}}>
+// CHECK-DAG: #[[$DESC_LOAD_PLANNED:.*]] = #ttg.blocked<{sizePerThread = [1, 4], threadsPerWarp = [4, 8], warpsPerCTA = [4, 1], order = [1, 0], CGALayout = {{\[\[1, 0\]\]}}}>
 // CHECK-DAG: #[[$DESC_LOAD_B_ORIG:.*]] = #ttg.blocked<{sizePerThread = [1, 4], threadsPerWarp = [1, 32], warpsPerCTA = [4, 1], order = [1, 0], CGALayout = {{\[\[1, 0\]\]}}}>
-// CHECK-DAG: #[[$DESC_LOAD_B_PLANNED:.*]] = #ttg.blocked<{sizePerThread = [1, 4], threadsPerWarp = [2, 16], warpsPerCTA = [4, 1], order = [1, 0], CGALayout = {{\[\[0, 1\]\]}}}>
+// CHECK-DAG: #[[$DESC_LOAD_B_PLANNED:.*]] = #ttg.blocked<{sizePerThread = [1, 4], threadsPerWarp = [1, 32], warpsPerCTA = [4, 1], order = [1, 0], CGALayout = {{\[\[0, 0\]\]}}}>
 // CHECK-DAG: #[[$DOT_DEFAULT_DESC_LOAD:.*]] = #ttg.blocked<{sizePerThread = [4, 4], threadsPerWarp = [1, 32], warpsPerCTA = [4, 1], order = [1, 0], CGALayout = {{\[\[0, 1\]\]}}}>
-// CHECK-DAG: #[[$DOT_OPT_DESC_LOAD:.*]] = #ttg.blocked<{sizePerThread = [4, 4], threadsPerWarp = [2, 16], warpsPerCTA = [4, 1], order = [1, 0], CGALayout = {{\[\[0, 1\]\]}}}>
+// CHECK-DAG: #[[$DOT_OPT_DESC_LOAD:.*]] = #ttg.blocked<{sizePerThread = [4, 4], threadsPerWarp = [1, 32], warpsPerCTA = [4, 1], order = [1, 0], CGALayout = {{\[\[1, 0\]\]}}}>
 module attributes {"ttg.num-ctas" = 2 : i32, "ttg.num-warps" = 4 : i32, ttg.target = "cuda:100", "ttg.threads-per-warp" = 32 : i32} {
   // CHECK-LABEL: tt.func @dot_clones_descriptor_load_source
   // CHECK: %[[ORIG_DESC_LOAD:.*]] = tt.descriptor_load %{{.*}}[%{{.*}}, %{{.*}}] : !tt.tensordesc<128x32xf16> -> tensor<128x32xf16, #[[$DESC_LOAD_ORIG]]>
@@ -122,6 +122,35 @@ module attributes {"ttg.num-ctas" = 2 : i32, "ttg.num-warps" = 4 : i32, ttg.targ
     %bd = ttg.convert_layout %b : tensor<32x128xf16, #desc_load_src_b> -> tensor<32x128xf16, #dot_b_desc_load>
     %dot = tt.dot %ad, %bd, %c : tensor<128x32xf16, #dot_a_desc_load> * tensor<32x128xf16, #dot_b_desc_load> -> tensor<128x128xf32, #dot_default_desc_load>
     tt.return %a : tensor<128x32xf16, #desc_load_src>
+  }
+}
+
+// -----
+
+#desc_load_8cta = #ttg.blocked<{sizePerThread = [1, 4], threadsPerWarp = [1, 32], warpsPerCTA = [4, 1], order = [1, 0], CGALayout = [[1, 0], [2, 0], [4, 0]]}>
+#dot_default_8cta = #ttg.blocked<{sizePerThread = [4, 4], threadsPerWarp = [1, 32], warpsPerCTA = [4, 1], order = [1, 0], CGALayout = [[0, 1], [0, 2], [0, 4]]}>
+#dot_a_8cta = #ttg.dot_op<{opIdx = 0, parent = #dot_default_8cta}>
+#dot_b_8cta = #ttg.dot_op<{opIdx = 1, parent = #dot_default_8cta}>
+
+// CHECK-DAG: #[[$DESC_8CTA_B_PLANNED:.*]] = #ttg.blocked<{sizePerThread = [1, 4], threadsPerWarp = [1, 32], warpsPerCTA = [2, 2], order = [1, 0], CGALayout = {{\[\[0, 0\], \[0, 0\], \[0, 1\]\]}}}>
+// CHECK-DAG: #[[$DOT_8CTA_M_FIRST:.*]] = #ttg.blocked<{sizePerThread = [4, 4], threadsPerWarp = [1, 32], warpsPerCTA = [2, 2], order = [1, 0], CGALayout = {{\[\[1, 0\], \[2, 0\], \[0, 1\]\]}}}>
+module attributes {"ttg.num-ctas" = 8 : i32, "ttg.num-warps" = 4 : i32, ttg.target = "cuda:100", "ttg.threads-per-warp" = 32 : i32} {
+  // CHECK-LABEL: tt.func @dot_prefers_m_first_for_8cta_descriptor_rhs
+  // CHECK: %[[B_DESC_LOAD:.*]] = tt.descriptor_load %{{.*}}[%{{.*}}, %{{.*}}] : !tt.tensordesc<64x512xf16> -> tensor<64x512xf16, #[[$DESC_8CTA_B_PLANNED]]>
+  // CHECK: ttg.convert_layout %{{.*}} : tensor<256x64xf16, #{{.*}}> -> tensor<256x64xf16, #ttg.dot_op<{opIdx = 0, parent = #[[$DOT_8CTA_M_FIRST]]}>>
+  // CHECK: ttg.convert_layout %[[B_DESC_LOAD]] : tensor<64x512xf16, #[[$DESC_8CTA_B_PLANNED]]> -> tensor<64x512xf16, #ttg.dot_op<{opIdx = 1, parent = #[[$DOT_8CTA_M_FIRST]]}>>
+  // CHECK: tt.dot %{{.*}}, %{{.*}}, %{{.*}} : tensor<256x64xf16, #ttg.dot_op<{opIdx = 0, parent = #[[$DOT_8CTA_M_FIRST]]}>> * tensor<64x512xf16, #ttg.dot_op<{opIdx = 1, parent = #[[$DOT_8CTA_M_FIRST]]}>> -> tensor<256x512xf32, #[[$DOT_8CTA_M_FIRST]]>
+  tt.func @dot_prefers_m_first_for_8cta_descriptor_rhs(
+    %a: tensor<256x64xf16, #desc_load_8cta>,
+    %b_desc: !tt.tensordesc<64x512xf16>,
+    %i: i32,
+    %j: i32,
+    %c: tensor<256x512xf32, #dot_default_8cta>) {
+    %b = tt.descriptor_load %b_desc[%i, %j] : !tt.tensordesc<64x512xf16> -> tensor<64x512xf16, #desc_load_8cta>
+    %ad = ttg.convert_layout %a : tensor<256x64xf16, #desc_load_8cta> -> tensor<256x64xf16, #dot_a_8cta>
+    %bd = ttg.convert_layout %b : tensor<64x512xf16, #desc_load_8cta> -> tensor<64x512xf16, #dot_b_8cta>
+    %dot = tt.dot %ad, %bd, %c : tensor<256x64xf16, #dot_a_8cta> * tensor<64x512xf16, #dot_b_8cta> -> tensor<256x512xf32, #dot_default_8cta>
+    tt.return
   }
 }
 

--- a/test/TritonNvidiaGPU/assign_cta_layouts.mlir
+++ b/test/TritonNvidiaGPU/assign_cta_layouts.mlir
@@ -154,32 +154,3 @@ module attributes {"ttg.num-ctas" = 8 : i32, "ttg.num-warps" = 4 : i32, ttg.targ
   }
 }
 
-// -----
-
-#desc_load_4cta = #ttg.blocked<{sizePerThread = [1, 4], threadsPerWarp = [1, 32], warpsPerCTA = [4, 1], order = [1, 0], CGALayout = [[1, 0], [2, 0]]}>
-#dot_default_4cta = #ttg.blocked<{sizePerThread = [4, 4], threadsPerWarp = [1, 32], warpsPerCTA = [4, 1], order = [1, 0], CGALayout = [[0, 1], [0, 2]]}>
-#dot_a_4cta = #ttg.dot_op<{opIdx = 0, parent = #dot_default_4cta}>
-#dot_b_4cta = #ttg.dot_op<{opIdx = 1, parent = #dot_default_4cta}>
-
-// CHECK-DAG: #[[$DESC_4CTA_B_ORIG:.*]] = #ttg.blocked<{sizePerThread = [1, 4], threadsPerWarp = [1, 32], warpsPerCTA = [4, 1], order = [1, 0], CGALayout = {{\[\[1, 0\], \[2, 0\]\]}}}>
-// CHECK-DAG: #[[$DESC_4CTA_B_PLANNED:.*]] = #ttg.blocked<{sizePerThread = [1, 4], threadsPerWarp = [1, 32], warpsPerCTA = [2, 2], order = [1, 0], CGALayout = {{\[\[0, 0\], \[0, 0\]\]}}}>
-// CHECK-DAG: #[[$DOT_4CTA_M_ONLY:.*]] = #ttg.blocked<{sizePerThread = [4, 4], threadsPerWarp = [1, 32], warpsPerCTA = [2, 2], order = [1, 0], CGALayout = {{\[\[1, 0\], \[2, 0\]\]}}}>
-module attributes {"ttg.num-ctas" = 4 : i32, "ttg.num-warps" = 4 : i32, ttg.target = "cuda:100", "ttg.threads-per-warp" = 32 : i32} {
-  // CHECK-LABEL: tt.func @dot_prefers_m_only_for_4cta_descriptor_rhs
-  // CHECK: %[[B_DESC_LOAD:.*]] = tt.descriptor_load %{{.*}}[%{{.*}}, %{{.*}}] : !tt.tensordesc<64x256xf16> -> tensor<64x256xf16, #[[$DESC_4CTA_B_PLANNED]]>
-  // CHECK: ttg.convert_layout %{{.*}} : tensor<256x64xf16, #{{.*}}> -> tensor<256x64xf16, #ttg.dot_op<{opIdx = 0, parent = #[[$DOT_4CTA_M_ONLY]]}>>
-  // CHECK: ttg.convert_layout %[[B_DESC_LOAD]] : tensor<64x256xf16, #[[$DESC_4CTA_B_PLANNED]]> -> tensor<64x256xf16, #ttg.dot_op<{opIdx = 1, parent = #[[$DOT_4CTA_M_ONLY]]}>>
-  // CHECK: tt.dot %{{.*}}, %{{.*}}, %{{.*}} : tensor<256x64xf16, #ttg.dot_op<{opIdx = 0, parent = #[[$DOT_4CTA_M_ONLY]]}>> * tensor<64x256xf16, #ttg.dot_op<{opIdx = 1, parent = #[[$DOT_4CTA_M_ONLY]]}>> -> tensor<256x256xf32, #[[$DOT_4CTA_M_ONLY]]>
-  tt.func @dot_prefers_m_only_for_4cta_descriptor_rhs(
-    %a: tensor<256x64xf16, #desc_load_4cta>,
-    %b_desc: !tt.tensordesc<64x256xf16>,
-    %i: i32,
-    %j: i32,
-    %c: tensor<256x256xf32, #dot_default_4cta>) {
-    %b = tt.descriptor_load %b_desc[%i, %j] : !tt.tensordesc<64x256xf16> -> tensor<64x256xf16, #desc_load_4cta>
-    %ad = ttg.convert_layout %a : tensor<256x64xf16, #desc_load_4cta> -> tensor<256x64xf16, #dot_a_4cta>
-    %bd = ttg.convert_layout %b : tensor<64x256xf16, #desc_load_4cta> -> tensor<64x256xf16, #dot_b_4cta>
-    %dot = tt.dot %ad, %bd, %c : tensor<256x64xf16, #dot_a_4cta> * tensor<64x256xf16, #dot_b_4cta> -> tensor<256x256xf32, #dot_default_4cta>
-    tt.return
-  }
-}

--- a/test/TritonNvidiaGPU/assign_cta_layouts.mlir
+++ b/test/TritonNvidiaGPU/assign_cta_layouts.mlir
@@ -132,8 +132,8 @@ module attributes {"ttg.num-ctas" = 2 : i32, "ttg.num-warps" = 4 : i32, ttg.targ
 #dot_a_8cta = #ttg.dot_op<{opIdx = 0, parent = #dot_default_8cta}>
 #dot_b_8cta = #ttg.dot_op<{opIdx = 1, parent = #dot_default_8cta}>
 
-// CHECK-DAG: #[[$DESC_8CTA_B_PLANNED:.*]] = #ttg.blocked<{sizePerThread = [1, 4], threadsPerWarp = [1, 32], warpsPerCTA = [4, 1], order = [1, 0], CGALayout = {{\[\[0, 0\], \[0, 1\], \[0, 2\]\]}}}>
-// CHECK-DAG: #[[$DOT_8CTA_M_FIRST:.*]] = #ttg.blocked<{sizePerThread = [4, 4], threadsPerWarp = [1, 32], warpsPerCTA = [4, 1], order = [1, 0], CGALayout = {{\[\[1, 0\], \[0, 1\], \[0, 2\]\]}}}>
+// CHECK-DAG: #[[$DESC_8CTA_B_PLANNED:.*]] = #ttg.blocked<{sizePerThread = [1, 4], threadsPerWarp = [1, 32], warpsPerCTA = [2, 2], order = [1, 0], CGALayout = {{\[\[0, 0\], \[0, 0\], \[0, 1\]\]}}}>
+// CHECK-DAG: #[[$DOT_8CTA_M_FIRST:.*]] = #ttg.blocked<{sizePerThread = [4, 4], threadsPerWarp = [1, 32], warpsPerCTA = [2, 2], order = [1, 0], CGALayout = {{\[\[1, 0\], \[2, 0\], \[0, 1\]\]}}}>
 module attributes {"ttg.num-ctas" = 8 : i32, "ttg.num-warps" = 4 : i32, ttg.target = "cuda:100", "ttg.threads-per-warp" = 32 : i32} {
   // CHECK-LABEL: tt.func @dot_prefers_m_first_for_8cta_descriptor_rhs
   // CHECK: %[[B_DESC_LOAD:.*]] = tt.descriptor_load %{{.*}}[%{{.*}}, %{{.*}}] : !tt.tensordesc<64x512xf16> -> tensor<64x512xf16, #[[$DESC_8CTA_B_PLANNED]]>


### PR DESCRIPTION


<git-pr-chain>

#### Commits in this PR

1. Prefer two-CTA layouts for descriptor RHS dots
2. After that prefer splitting M until mChunkSize is not smaller than 128

M=N=K=4096 matmul.
4CTA speedup: 1.195x.
8CTA speedup: 1.110x.

#### PR chain
1. #10325
1. #10676
1. #10765
1. 👉 #10769 👈 **YOU ARE HERE**
1. #10781
1. #10812
1. #10817

⚠️⚠️ Please **do not click the green "merge" button** unless you know what you're doing. This PR is part of a chain of PRs, and clicking the merge button will not merge it into `main`. ⚠️⚠️

</git-pr-chain>