### PR TITLE
[Backend] Recognise reversed mul operands in CombineBroadcastMulReducePattern

### DIFF
--- a/lib/Dialect/Triton/Transforms/Combine.cpp
+++ b/lib/Dialect/Triton/Transforms/Combine.cpp
@@ -153,25 +153,36 @@ public:
     auto mulOp = reduceOp.getOperand(0).getDefiningOp<arith::MulFOp>();
     if (!mulOp)
       return failure();
-    // mul operand has to be broadcast
-    auto broadcastLhsOp = mulOp.getOperand(0).getDefiningOp<BroadcastOp>();
-    if (!broadcastLhsOp)
+    // mul operands have to be broadcasts. Since multiplication is
+    // commutative, identify the dot operands from their broadcast axes instead
+    // of from the mul operand order.
+    auto broadcast0Op = mulOp.getOperand(0).getDefiningOp<BroadcastOp>();
+    if (!broadcast0Op)
       return failure();
-    auto broadcastRhsOp = mulOp.getOperand(1).getDefiningOp<BroadcastOp>();
-    if (!broadcastRhsOp)
+    auto broadcast1Op = mulOp.getOperand(1).getDefiningOp<BroadcastOp>();
+    if (!broadcast1Op)
       return failure();
     // broadcast operand is expand dims
-    auto expandLhsOp = broadcastLhsOp.getSrc().getDefiningOp<ExpandDimsOp>();
-    if (!expandLhsOp)
+    auto expand0Op = broadcast0Op.getSrc().getDefiningOp<ExpandDimsOp>();
+    if (!expand0Op)
       return failure();
-    auto expandRhsOp = broadcastRhsOp.getSrc().getDefiningOp<ExpandDimsOp>();
-    if (!expandRhsOp)
+    auto expand1Op = broadcast1Op.getSrc().getDefiningOp<ExpandDimsOp>();
+    if (!expand1Op)
       return failure();
-    // get not-broadcast dimensions
-    int expandLhsAxis = expandLhsOp.getAxis();
-    int expandRhsAxis = expandRhsOp.getAxis();
-    if (expandLhsAxis != 2 || expandRhsAxis != 0)
+
+    auto broadcastLhsOp = broadcast0Op;
+    auto broadcastRhsOp = broadcast1Op;
+    auto expandLhsOp = expand0Op;
+    auto expandRhsOp = expand1Op;
+    if (expand0Op.getAxis() == 0 && expand1Op.getAxis() == 2) {
+      broadcastLhsOp = broadcast1Op;
+      broadcastRhsOp = broadcast0Op;
+      expandLhsOp = expand1Op;
+      expandRhsOp = expand0Op;
+    } else if (expand0Op.getAxis() != 2 || expand1Op.getAxis() != 0) {
       return failure();
+    }
+
     // The first operand must be broadcasted from (M, K, 1) to (M, K, N), and
     // the second operand must go from (1, K, N) to (M, K, N).
     if (!isBroadcastAlongAxis(broadcastLhsOp, 2) ||

--- a/test/Triton/combine.mlir
+++ b/test/Triton/combine.mlir
@@ -492,6 +492,27 @@ tt.func @test_combine_broadcast_mul_reduce(%arg0: tensor<32x16xf32>, %arg1: tens
     tt.return %5 : tensor<32x32xf32>
 }
 
+// CHECK-LABEL: @test_combine_broadcast_mul_reduce_swapped
+// CHECK-SAME: (%[[A:[a-zA-Z0-9_]+]]: tensor<32x16xf32>, %[[B:[a-zA-Z0-9_]+]]: tensor<16x32xf32>)
+tt.func @test_combine_broadcast_mul_reduce_swapped(%arg0: tensor<32x16xf32>, %arg1: tensor<16x32xf32>) -> tensor<32x32xf32> {
+    // CHECK: %[[CST:.*]] = arith.constant dense<0.000000e+00> : tensor<32x32xf32>
+    // CHECK-NOT: tt.reduce
+    // CHECK: %[[RES:.*]] = tt.dot %[[A]], %[[B]], %[[CST]] : tensor<32x16xf32> * tensor<16x32xf32> -> tensor<32x32xf32>
+    // CHECK-NOT: tt.reduce
+    // CHECK: tt.return %[[RES]] : tensor<32x32xf32>
+    %0 = tt.expand_dims %arg0 {axis = 2 : i32} : tensor<32x16xf32> -> tensor<32x16x1xf32>
+    %1 = tt.broadcast %0 : tensor<32x16x1xf32> -> tensor<32x16x32xf32>
+    %2 = tt.expand_dims %arg1 {axis = 0 : i32} : tensor<16x32xf32> -> tensor<1x16x32xf32>
+    %3 = tt.broadcast %2 : tensor<1x16x32xf32> -> tensor<32x16x32xf32>
+    %4 = arith.mulf %3, %1 : tensor<32x16x32xf32>
+    %5 = "tt.reduce"(%4) <{axis = 1 : i32}> ({
+    ^bb0(%arg2: f32, %arg3: f32):
+        %6 = arith.addf %arg2, %arg3 : f32
+        tt.reduce.return %6 : f32
+    }) : (tensor<32x16x32xf32>) -> tensor<32x32xf32>
+    tt.return %5 : tensor<32x32xf32>
+}
+
 // CHECK-LABEL: @test_combine_broadcast_mul_reduce_extra_broadcast
 tt.func @test_combine_broadcast_mul_reduce_extra_broadcast(%arg0: tensor<32x1xf32>, %arg1: tensor<1x32xf32>) -> tensor<32x32xf32> {
     // CHECK-NOT: tt.dot


### PR DESCRIPTION
Consider this broadcast-and-reduce spelling of a dot product:

```python
x_broadcast = tl.expand_dims(x, 2)  # [M, K] -> [M, K, 1]
y_broadcast = tl.expand_dims(y, 0)  # [K, N] -> [1, K, N]
z = tl.sum(x_broadcast * y_broadcast, axis=1)
```

This computes `acc[m, n] = sum_k x[m, k] * y[k, n]`. The same dot product can also be written with multiplication in the other order:

```python
z = tl.sum(y_broadcast * x_broadcast, axis=1)
```

The second spelling preserves the Python operand order when lowered, producing an `arith.mulf` with the axis-0 broadcast as operand 0 and the axis-2 broadcast as operand 1. The current matcher assumes the opposite order, so it returns failure and leaves the expression as `arith.mulf + tt.reduce` instead of folding it to `tt.dot`.

This patch identifies the dot operands from their `expand_dims` axes rather than from the `arith.mulf` operand order. The axis-2 source is still used as the `tt.dot` lhs and the axis-0 source as rhs, so both multiplication orders produce the same `tt.dot`.

This is similar to #10734 in that it removes an unnecessary ordering assumption when matching operands of a commutative operation.

Added 1 lit test in `test/Triton/combine.mlir`, showing both `mul` operand orders generate `tt.dot` with the same lhs/rhs order.