### PR TITLE
[Backend] Recognise reversed mul operands in CombineBroadcastMulReducePattern

### DIFF
--- a/lib/Dialect/Triton/Transforms/Combine.cpp
+++ b/lib/Dialect/Triton/Transforms/Combine.cpp
@@ -153,18 +153,28 @@ public:
     auto mulOp = reduceOp.getOperand(0).getDefiningOp<arith::MulFOp>();
     if (!mulOp)
       return failure();
-    // mul operand has to be broadcast
-    auto broadcastLhsOp = mulOp.getOperand(0).getDefiningOp<BroadcastOp>();
-    if (!broadcastLhsOp)
+    // mul operands have to be broadcasts. Since multiplication is
+    // commutative, identify the dot operands from their broadcast axes instead
+    // of from the mul operand order.
+    auto broadcast0Op = mulOp.getOperand(0).getDefiningOp<BroadcastOp>();
+    if (!broadcast0Op)
       return failure();
-    auto broadcastRhsOp = mulOp.getOperand(1).getDefiningOp<BroadcastOp>();
-    if (!broadcastRhsOp)
+    auto broadcast1Op = mulOp.getOperand(1).getDefiningOp<BroadcastOp>();
+    if (!broadcast1Op)
       return failure();
-    // The first operand must be broadcasted from (M, K, 1) to (M, K, N), and
-    // the second operand must go from (1, K, N) to (M, K, N).
-    if (!isBroadcastAlongAxis(broadcastLhsOp, 2) ||
-        !isBroadcastAlongAxis(broadcastRhsOp, 0))
+    // axis=2 maps to dot lhs; axis=0 maps to dot rhs.
+    auto broadcastLhsOp = broadcast0Op;
+    auto broadcastRhsOp = broadcast1Op;
+    if (isBroadcastAlongAxis(broadcast0Op, 0) &&
+        isBroadcastAlongAxis(broadcast1Op, 2)) {
+      broadcastLhsOp = broadcast1Op;
+      broadcastRhsOp = broadcast0Op;
+    } else if (!isBroadcastAlongAxis(broadcast0Op, 2) ||
+               !isBroadcastAlongAxis(broadcast1Op, 0)) {
       return failure();
+    }
+    // broadcastLhsOp must go from (M, K, 1) to (M, K, N), and
+    // broadcastRhsOp must go from (1, K, N) to (M, K, N).
     auto broadcastLhsShape =
         cast<ShapedType>(broadcastLhsOp.getType()).getShape();
     auto broadcastRhsShape =

--- a/test/Triton/combine.mlir
+++ b/test/Triton/combine.mlir
@@ -518,6 +518,24 @@ tt.func @test_combine_broadcast_mul_reduce_reshape(%arg0: tensor<32x16x1xf32>, %
     tt.return %3 : tensor<32x32xf32>
 }
 
+// CHECK-LABEL: @test_combine_broadcast_mul_reduce_reshape_swapped
+tt.func @test_combine_broadcast_mul_reduce_reshape_swapped(%arg0: tensor<32x16x1xf32>, %arg1: tensor<1x16x32xf32>) -> tensor<32x32xf32> {
+    // CHECK: %[[CST:.*]] = arith.constant dense<0.000000e+00> : tensor<32x32xf32>
+    // CHECK: %[[LHS:.*]] = tt.reshape %arg0 : tensor<32x16x1xf32> -> tensor<32x16xf32>
+    // CHECK: %[[RHS:.*]] = tt.reshape %arg1 : tensor<1x16x32xf32> -> tensor<16x32xf32>
+    // CHECK: %[[RES:.*]] = tt.dot %[[LHS]], %[[RHS]], %[[CST]] : tensor<32x16xf32> * tensor<16x32xf32> -> tensor<32x32xf32>
+    // CHECK: tt.return %[[RES]] : tensor<32x32xf32>
+    %0 = tt.broadcast %arg0 : tensor<32x16x1xf32> -> tensor<32x16x32xf32>
+    %1 = tt.broadcast %arg1 : tensor<1x16x32xf32> -> tensor<32x16x32xf32>
+    %2 = arith.mulf %1, %0 : tensor<32x16x32xf32>  // operands swapped
+    %3 = "tt.reduce"(%2) <{axis = 1 : i32}> ({
+    ^bb0(%arg2: f32, %arg3: f32):
+        %4 = arith.addf %arg2, %arg3 : f32
+        tt.reduce.return %4 : f32
+    }) : (tensor<32x16x32xf32>) -> tensor<32x32xf32>
+    tt.return %3 : tensor<32x32xf32>
+}
+
 // CHECK-LABEL: @test_combine_broadcast_mul_reduce_extra_broadcast
 tt.func @test_combine_broadcast_mul_reduce_extra_broadcast(%arg0: tensor<32x1xf32>, %arg1: tensor<1x32xf32>) -> tensor<32x32xf32> {
     // CHECK-NOT: tt.dot


### PR DESCRIPTION
CombineBroadcastMulReducePattern folds a broadcast-mul-reduce form into `tt.dot`. After #10545 generalized this combine, the pattern no longer requires explicit `tt.expand_dims` ops: it identifies dot-like operands from broadcasted shapes such as `(M, K, 1) -> (M, K, N)` and `(1, K, N) -> (M, K, N)`.

Since `arith.mulf` is commutative, the two broadcast operands may appear in either order. However, the matcher still assumed that mul operand 0 was the axis-2 broadcast and mul operand 1 was the axis-0 broadcast.

For example, this order is matched:

```mlir
%lhs_b = tt.broadcast %lhs : tensor<32x16x1xf32> -> tensor<32x16x32xf32>
%rhs_b = tt.broadcast %rhs : tensor<1x16x32xf32> -> tensor<32x16x32xf32>
%mul = arith.mulf %lhs_b, %rhs_b : tensor<32x16x32xf32>
%out = "tt.reduce"(%mul) <{axis = 1 : i32}> ...
```

But the equivalent reversed order is missed:

```mlir
%mul = arith.mulf %rhs_b, %lhs_b : tensor<32x16x32xf32>
```

This patch identifies the dot operands from the broadcast axes instead of from the `arith.mulf` operand order. The axis-2 source is still used as the `tt.dot` lhs and the axis-0 source as rhs, so both multiplication orders produce the same `tt.dot`.

This is similar to #10734 in that it removes an unnecessary ordering assumption when matching operands of a commutative operation.

Added 1 lit test in `test/Triton/combine.mlir`, covering the swapped `arith.mulf` operand order in the generalized broadcast-reduce dot combine pattern.