### PR TITLE
[AMD] Preserve NaN when upcasting FNUZ fp8 (0x80)

### DIFF
--- a/python/test/unit/language/test_conversions.py
+++ b/python/test/unit/language/test_conversions.py
@@ -311,6 +311,45 @@ def test_typeconvert_upcast(src_dtype, dst_dtype, device):
 
     upcast_test(getattr(tl, src_dtype), getattr(tl, dst_dtype), *stuff, device=device)
 
+
+@pytest.mark.parametrize("src_dtype, dst_dtype", [
+    ('float8e4b8', 'float16'),
+    ('float8e4b8', 'bfloat16'),
+    ('float8e4b8', 'float32'),
+    ('float8e5b16', 'float16'),
+    ('float8e5b16', 'bfloat16'),
+    ('float8e5b16', 'float32'),
+])
+def test_typeconvert_upcast_fnuz_nan(src_dtype, dst_dtype, device):
+    # 0x80 is the only NaN encoding in the FNUZ fp8 formats (float8e4b8 == e4m3fnuz,
+    # float8e5b16 == e5m2fnuz): the -0 slot is repurposed as the single NaN, so
+    # upcasting 0x80 must produce a NaN, not a finite -0.0. On AMD targets without
+    # native FNUZ-fp8 conversion (everything except CDNA3) the upcast is emulated in
+    # software and used to drop the NaN. See triton-lang/triton#10745.
+    if is_cuda():
+        pytest.skip("FNUZ fp8 upcast is an AMD-backend software path")
+    if is_hip():
+        if is_hip_rdna3():
+            pytest.skip(f"{src_dtype} is not supported on AMDGPU RDNA3")
+        if is_hip_cdna2():
+            pytest.skip(f"{src_dtype} is not supported on current AMD GPU")
+
+    @triton.jit
+    def upcast_nan_kernel(src_ptr, dst_ptr, N: tl.constexpr):
+        idxs = tl.arange(0, N)
+        x = tl.load(src_ptr + idxs)
+        tl.store(dst_ptr + idxs, x.to(dst_ptr.dtype.element_ty))
+
+    N = 4
+    src_int = torch.full((N, ), 0x80, dtype=torch.uint8, device=device)
+    src = triton.reinterpret(src_int, getattr(tl, src_dtype))
+    dst = torch.empty((N, ), dtype=getattr(torch, dst_dtype), device=device)
+    upcast_nan_kernel[(1, )](src, dst, N)
+
+    assert torch.isnan(dst).all(), \
+        f"{src_dtype}->{dst_dtype}: upcast of 0x80 gave {dst.tolist()}, expected NaN"
+
+
 @pytest.mark.parametrize("src_dtype, dst_dtype, rounding, max_repr", [
     ('float32', 'float16', 'rtne', 0x477fe000),
     ('float32', 'float16', 'rtz', 0x477fe000),

--- a/third_party/amd/lib/TritonAMDGPUToLLVM/ConvertFpCastOpToLLVM.cpp
+++ b/third_party/amd/lib/TritonAMDGPUToLLVM/ConvertFpCastOpToLLVM.cpp
@@ -968,11 +968,6 @@ public:
 
     Value v8 = b.bitcast(v, i8_ty);
     Value vAbs = b.and_(v8, b.i8_val(0x7F));
-    // Check NaN (1.0000.000 in E4M3FNUZ)
-    // Pick an arbitrary number which represents NaN in fp16 (exp=11111 and mant
-    // != 0)
-    a = b.select(b.icmp_eq(v8, b.i8_val(0x80)), b.i16_val(0x7E00), a);
-
     // Check denorms and zero
     // Here we use a LUT to map S.0000.000 ~ S.0000.111 to its corresponding
     // fp16 value Minimum subnormal value in E4M3FNUZ is 2^-10
@@ -993,6 +988,12 @@ public:
 
     // Set sign
     a = b.or_(a, sign);
+
+    // NaN: 0x80 is the only NaN encoding in E4M3FNUZ. Apply the guard as the
+    // final write -- the denorm/zero LUT above matches vAbs==0 (0x80 & 0x7F) and
+    // would otherwise overwrite the NaN with 0x0000, then the sign re-apply
+    // would yield -0.0. Writing NaN last gives 0x7E00 exactly.
+    a = b.select(b.icmp_eq(v8, b.i8_val(0x80)), b.i16_val(0x7E00), a);
     a = b.bitcast(a, f16_ty);
 
     return a;
@@ -1154,6 +1155,11 @@ public:
     auto o12 = b.select(e_is_one, o2, o1);
     auto o = b.select(e_is_zero, o0, o12);
 
+    // NaN: 0x80 is the only NaN encoding in E5M2FNUZ; there was no guard, so the
+    // e_is_zero branch produced sign|(m>>1) = -0.0. Guard it as the final write.
+    Value v8 = b.bitcast(v, i8_ty);
+    o = b.select(b.icmp_eq(v8, b.i8_val(0x80)), b.int_val(16, 0x7E00), o);
+
     return b.bitcast(o, f16_ty);
   }
 
@@ -1302,8 +1308,15 @@ public:
     // Unpack the 2 bfloat16 values and return them
     auto bf16x2VecTy = vec_ty(bf16_ty, 2);
     out0 = b.bitcast(out0, bf16x2VecTy);
-    return {b.extract_element(bf16_ty, out0, b.i32_val(0)),
-            b.extract_element(bf16_ty, out0, b.i32_val(1))};
+    Value r0 = b.extract_element(bf16_ty, out0, b.i32_val(0));
+    Value r1 = b.extract_element(bf16_ty, out0, b.i32_val(1));
+    // NaN: 0x80 is the only NaN encoding in E4M3FNUZ. The abs-mask zeros the
+    // magnitude and the sign is OR'd back, giving -0.0; guard each lane to the
+    // bf16 NaN 0x7FC0.
+    Value nanBf16 = b.bitcast(b.i16_val(0x7FC0), bf16_ty);
+    r0 = b.select(b.icmp_eq(v[0], b.i8_val(0x80)), nanBf16, r0);
+    r1 = b.select(b.icmp_eq(v[1], b.i8_val(0x80)), nanBf16, r1);
+    return {r0, r1};
   }
 
 private:


### PR DESCRIPTION
## Description

The FNUZ fp8 formats (`float8_e4m3fnuz` / `float8_e5m2fnuz`) have a **single** NaN encoding, `0x80` — the `-0` slot is repurposed as NaN and there is no Inf. On AMD targets without native FNUZ-fp8 hardware conversion (everything except CDNA3 — CDNA1/gfx908, CDNA2/gfx90a, CDNA4/gfx950, and RDNA) the upcast to fp16/bf16/fp32 is emulated in software, and the software decoders in `ConvertFpCastOpToLLVM.cpp` turned `0x80` into a finite `-0.0`, silently dropping the NaN (#10745).

Three decoders were affected:

- **`Fp8E4M3fnuzToFp16OneValue`** — the `0x80 → 0x7E00` NaN guard ran *before* the denorm/zero LUT. For `0x80`, `vAbs = 0x80 & 0x7F == 0` matched `LUT[0] = 0x0000`, overwriting the NaN, and the trailing sign re-apply produced `0x8000`. Moved the guard to be the **final write** so it yields `0x7E00`.
- **`Fp8E5M2fnuzToFp16OneValue`** — no NaN guard existed; with `exp == 0` the `e_is_zero` branch produced `sign | (m >> 1) = 0x8000`. Added the `0x80 → 0x7E00` guard as the final write.
- **`Fp8E4M3fnuzToBf16SW`** — no NaN guard; the abs-mask zeroed the magnitude and the sign was OR'd back, giving bf16 `0x8000`. Guard each unpacked lane to the bf16 NaN `0x7FC0`.

The other fnuz upcasts (`e5m2fnuz → bf16`, and both `→ fp32`) route through the decoders above, so all six `{e4m3fnuz, e5m2fnuz} × {fp16, bf16, fp32}` upcasts are fixed.

## Validation

Built current `main` from source and ran a byte-exhaustive check on **RDNA4 (gfx1201, RX 9070)** comparing every fp8 code against the `torch.float8_e{4m3,5m2}fnuz .to(dtype)` reference:

- **before:** all six combos diverge from the reference at exactly one code, `0x80` (upcast to a finite `-0.0` instead of NaN); the other 255 codes match.
- **after:** all 256 codes match the reference for all six combos; `0x80` now upcasts to NaN (`0x7E00` fp16/fp32, `0x7FC0` bf16).

Adds `test_typeconvert_upcast_fnuz_nan` (the existing exhaustive upcast test explicitly excludes `0x80`, which is why this slipped through). It passes on the patched build for all six combos.

## New contributor declaration

- [x] I am not making a trivial change, such as fixing a typo in a comment.
- [x] I have written a PR description following the guidelines above.
- [x] I have added tests relevant to the changes.
- [x] I have run pre-commit locally on my changes.
- AI usage: an AI coding assistant helped with the investigation, the hardware reproduction/validation, and drafting this description; I reviewed the change and can explain every line.

Fixes #10745
