### PR TITLE
[TRITONGPU] Load two cta/tma multicast without pipelining

### DIFF
--- a/include/triton/Dialect/TritonGPU/Transforms/Utility.h
+++ b/include/triton/Dialect/TritonGPU/Transforms/Utility.h
@@ -302,6 +302,9 @@ bool comesFromLoadOrBlockArg(Value v);
 // `resultIdx`th result.
 SmallVector<Value> getTiedArgs(Operation *op, int resultIdx);
 
+bool valueFeedsMulticastMMA(Value value);
+bool valueFeedsTwoCTAMMA(Value value);
+
 // Verifies the provided memory descriptor type used for barrier allocation
 LogicalResult verifyBarrierType(Operation *op,
                                 mlir::triton::gpu::MemDescType barrierType);

--- a/lib/Dialect/TritonGPU/Transforms/AccelerateMatmul.cpp
+++ b/lib/Dialect/TritonGPU/Transforms/AccelerateMatmul.cpp
@@ -692,10 +692,12 @@ static bool canUseTwoCTAsInModule(ModuleOp module, int computeCapability) {
 
 static bool usesTMAMulticast(Value operand) {
   auto loadOp =
-      getDefiningOpSkippingConvertLayout<triton::DescriptorLoadOp>(operand);
+      getDefiningOpSkippingConvertLayout<triton::DescriptorLoadLikeOpInterface>(
+          operand);
   if (!loadOp)
     return false;
-  RankedTensorType loadTy = loadOp.getType();
+  RankedTensorType loadTy =
+      cast<RankedTensorType>(loadOp->getResult(0).getType());
   auto sharedEnc = NVMMASharedEncodingAttr::get(
       loadTy.getContext(), loadTy.getShape(), getOrderForMemory(loadTy),
       getCGALayout(loadTy.getEncoding()), loadTy.getElementType(),

--- a/lib/Dialect/TritonGPU/Transforms/Pipeliner/LowerLoops.cpp
+++ b/lib/Dialect/TritonGPU/Transforms/Pipeliner/LowerLoops.cpp
@@ -295,22 +295,6 @@ static bool loadFeedsTwoCTAMMA(Operation *loadOp) {
   return false;
 }
 
-static bool loadFeedsMulticastMMAv5MMA(Operation *loadOp) {
-  SetVector<Operation *> worklist;
-  worklist.insert(loadOp->user_begin(), loadOp->user_end());
-  for (unsigned i = 0; i < worklist.size(); ++i) {
-    Operation *op = worklist[i];
-    auto mma = dyn_cast<ttng::MMAv5OpInterface>(op);
-    if (mma) {
-      if (mma.getMulticast())
-        return true;
-      continue;
-    }
-    worklist.insert(op->user_begin(), op->user_end());
-  }
-  return false;
-}
-
 static bool loadUsesTMAMulticast(Operation *loadOp,
                                  SharedEncodingTrait sharedEncoding) {
   if (!isa<tt::DescriptorLoadOp>(loadOp))
@@ -545,8 +529,9 @@ scf::ForOp lowerLoads(scf::ForOp forOp, CoarseSchedule &schedule,
         asyncLoad.stageDiff = stageDiff;
         asyncLoad.contiguity = contiguity;
         asyncLoad.sharedEncoding = sharedEncoding;
-        asyncLoad.useMulticast = loadUsesTMAMulticast(&op, sharedEncoding) &&
-                                 loadFeedsMulticastMMAv5MMA(&op);
+        asyncLoad.useMulticast =
+            loadUsesTMAMulticast(&op, sharedEncoding) &&
+            triton::valueFeedsMulticastMMA(op.getResult(0));
       } else if (stageDiff > 1) {
         // Distance-1 loads can in most cases be pipelined in registers without
         // any performance degradation, as the schedule will usually reorder the

--- a/lib/Dialect/TritonGPU/Transforms/Utility.cpp
+++ b/lib/Dialect/TritonGPU/Transforms/Utility.cpp
@@ -1697,7 +1697,8 @@ static void addForwardedValuesThroughUse(OpOperand &use,
   worklist.insert(user->result_begin(), user->result_end());
 }
 
-bool valueFeedsMulticastMMA(Value value) {
+template <typename Predicate>
+static bool valueFeedsMMAv5MMA(Value value, Predicate predicate) {
   llvm::SetVector<Value> worklist;
   worklist.insert(value);
   for (unsigned i = 0; i < worklist.size(); ++i) {
@@ -1705,7 +1706,7 @@ bool valueFeedsMulticastMMA(Value value) {
     for (OpOperand &use : current.getUses()) {
       Operation *user = use.getOwner();
       if (auto mma = dyn_cast<ttng::MMAv5OpInterface>(user)) {
-        if (mma.getMulticast())
+        if (predicate(mma))
           return true;
         continue;
       }
@@ -1716,23 +1717,14 @@ bool valueFeedsMulticastMMA(Value value) {
   return false;
 }
 
-bool valueFeedsTwoCTAMMA(Value value) {
-  llvm::SetVector<Value> worklist;
-  worklist.insert(value);
-  for (unsigned i = 0; i < worklist.size(); ++i) {
-    Value current = worklist[i];
-    for (OpOperand &use : current.getUses()) {
-      Operation *user = use.getOwner();
-      if (auto mma = dyn_cast<ttng::MMAv5OpInterface>(user)) {
-        if (mma.getTwoCtas())
-          return true;
-        continue;
-      }
+bool valueFeedsMulticastMMA(Value value) {
+  return valueFeedsMMAv5MMA(
+      value, [](ttng::MMAv5OpInterface mma) { return mma.getMulticast(); });
+}
 
-      addForwardedValuesThroughUse(use, worklist);
-    }
-  }
-  return false;
+bool valueFeedsTwoCTAMMA(Value value) {
+  return valueFeedsMMAv5MMA(
+      value, [](ttng::MMAv5OpInterface mma) { return mma.getTwoCtas(); });
 }
 
 LogicalResult verifyBarrierType(Operation *op,

--- a/lib/Dialect/TritonGPU/Transforms/Utility.cpp
+++ b/lib/Dialect/TritonGPU/Transforms/Utility.cpp
@@ -1679,6 +1679,62 @@ SmallVector<Value> getTiedArgs(Operation *op, int resultIdx) {
   return {};
 }
 
+static void addForwardedValuesThroughUse(OpOperand &use,
+                                         llvm::SetVector<Value> &worklist) {
+  Operation *user = use.getOwner();
+  if (auto forOp = dyn_cast<scf::ForOp>(user)) {
+    unsigned operandIdx = use.getOperandNumber();
+    if (operandIdx >= forOp.getNumControlOperands()) {
+      unsigned iterArgIdx = operandIdx - forOp.getNumControlOperands();
+      worklist.insert(forOp.getRegionIterArg(iterArgIdx));
+      worklist.insert(forOp.getResult(iterArgIdx));
+    }
+  } else if (auto yieldOp = dyn_cast<scf::YieldOp>(user)) {
+    if (auto forOp = dyn_cast<scf::ForOp>(yieldOp->getParentOp()))
+      worklist.insert(forOp.getResult(use.getOperandNumber()));
+  }
+
+  worklist.insert(user->result_begin(), user->result_end());
+}
+
+bool valueFeedsMulticastMMA(Value value) {
+  llvm::SetVector<Value> worklist;
+  worklist.insert(value);
+  for (unsigned i = 0; i < worklist.size(); ++i) {
+    Value current = worklist[i];
+    for (OpOperand &use : current.getUses()) {
+      Operation *user = use.getOwner();
+      if (auto mma = dyn_cast<ttng::MMAv5OpInterface>(user)) {
+        if (mma.getMulticast())
+          return true;
+        continue;
+      }
+
+      addForwardedValuesThroughUse(use, worklist);
+    }
+  }
+  return false;
+}
+
+bool valueFeedsTwoCTAMMA(Value value) {
+  llvm::SetVector<Value> worklist;
+  worklist.insert(value);
+  for (unsigned i = 0; i < worklist.size(); ++i) {
+    Value current = worklist[i];
+    for (OpOperand &use : current.getUses()) {
+      Operation *user = use.getOwner();
+      if (auto mma = dyn_cast<ttng::MMAv5OpInterface>(user)) {
+        if (mma.getTwoCtas())
+          return true;
+        continue;
+      }
+
+      addForwardedValuesThroughUse(use, worklist);
+    }
+  }
+  return false;
+}
+
 LogicalResult verifyBarrierType(Operation *op,
                                 mlir::triton::gpu::MemDescType barrierType) {
   auto numCTAs = triton::gpu::lookupNumCTAs(op);

--- a/lib/Dialect/TritonNvidiaGPU/Transforms/ClusterBarrierInsertion.cpp
+++ b/lib/Dialect/TritonNvidiaGPU/Transforms/ClusterBarrierInsertion.cpp
@@ -140,37 +140,21 @@ static bool opUsesTrackedMBarrier(Operation *op,
 }
 
 static LogicalResult
-insertCrossCTAMBarrierInitSyncForFunction(FunctionOpInterface funcOp,
-                                          Allocation *allocation, int numCTAs,
-                                          OpBuilder &builder) {
-  if (!funcOp || funcOp->getNumRegions() != 1) {
-    return funcOp.emitOpError(
-        "cross-CTA mbarrier init sync insertion requires a single function "
-        "top-level region");
-  }
+insertCrossCTAMBarrierInitSyncForBarrier(FunctionOpInterface funcOp,
+                                         Allocation *allocation,
+                                         ttng::InitBarrierOp initBarrierOp,
+                                         OpBuilder &builder) {
   Region &topLevelRegion = funcOp->getRegion(0);
-  llvm::SetVector<Operation *> crossCTAInitAnchors;
-  Allocation::BufferIdSetT trackedBarrierBuffers;
+  Operation *crossCTAInitAnchor =
+      topLevelRegion.findAncestorOpInRegion(*initBarrierOp.getOperation());
+  assert(crossCTAInitAnchor && "init op must be inside the function region");
 
-  // Find all cross-CTA mbarrier.init ops and map each
-  // one to the containing top-level op that bounds the insertion window.
-  funcOp.walk([&](ttng::InitBarrierOp initBarrierOp) {
-    if (!requiresCrossCTAMBarrierInitSync(initBarrierOp, funcOp, allocation,
-                                          numCTAs))
-      return;
-    Operation *topLevelAnchor =
-        topLevelRegion.findAncestorOpInRegion(*initBarrierOp.getOperation());
-    assert(topLevelAnchor && "init op must be inside the function region");
-    crossCTAInitAnchors.insert(topLevelAnchor);
-    for (auto bufferId :
-         allocation->getAllBufferIdsWithAliases(initBarrierOp.getBarrier())) {
-      assert(bufferId != Allocation::InvalidBufferId);
-      trackedBarrierBuffers.insert(bufferId);
-    }
-  });
-  // Nothing to do
-  if (crossCTAInitAnchors.empty())
-    return success();
+  Allocation::BufferIdSetT trackedBarrierBuffers;
+  for (auto bufferId :
+       allocation->getAllBufferIdsWithAliases(initBarrierOp.getBarrier())) {
+    assert(bufferId != Allocation::InvalidBufferId);
+    trackedBarrierBuffers.insert(bufferId);
+  }
 
   llvm::SetVector<Operation *> trackedUseAnchors;
   for (Block &block : topLevelRegion) {
@@ -184,31 +168,8 @@ insertCrossCTAMBarrierInitSyncForFunction(FunctionOpInterface funcOp,
                               "not find any mbarrier use");
   }
 
-  // Find the earliest insertion point that postdominates every tracked init.
   PostDominanceInfo postDomInfo(funcOp);
-  llvm::SmallPtrSet<Block *, 8> initBlocks;
-  for (Operation *crossCTAInitAnchor : crossCTAInitAnchors)
-    initBlocks.insert(crossCTAInitAnchor->getBlock());
-  Block *firstInsertionBlock =
-      postDomInfo.findNearestCommonDominator(initBlocks);
-  if (!firstInsertionBlock) {
-    return funcOp.emitOpError(
-        "could not find a common post-dominating insertion block for "
-        "cross-CTA mbarrier.init");
-  }
-
-  Operation *lastInitInInsertionBlock = nullptr;
-  for (Operation *crossCTAInitAnchor : crossCTAInitAnchors) {
-    if (crossCTAInitAnchor->getBlock() != firstInsertionBlock)
-      continue;
-    if (!lastInitInInsertionBlock ||
-        lastInitInInsertionBlock->isBeforeInBlock(crossCTAInitAnchor)) {
-      lastInitInInsertionBlock = crossCTAInitAnchor;
-    }
-  }
-  Operation *firstInsertionAnchor =
-      lastInitInInsertionBlock ? lastInitInInsertionBlock->getNextNode()
-                               : &firstInsertionBlock->front();
+  Operation *firstInsertionAnchor = crossCTAInitAnchor->getNextNode();
 
   // Find the latest insertion point that still dominates every tracked use.
   DominanceInfo domInfo(funcOp);
@@ -235,7 +196,8 @@ insertCrossCTAMBarrierInitSyncForFunction(FunctionOpInterface funcOp,
                                        ? firstTrackedUseInInsertionBlock
                                        : lastInsertionBlock->getTerminator();
 
-  if (!domInfo.dominates(firstInsertionAnchor, lastInsertionAnchor)) {
+  if (!firstInsertionAnchor ||
+      !domInfo.dominates(firstInsertionAnchor, lastInsertionAnchor)) {
     return funcOp.emitOpError(
         "could not find an insertion point between cross-CTA mbarrier.init "
         "ops and tracked mbarrier uses");
@@ -269,12 +231,35 @@ insertCrossCTAMBarrierInitSyncForFunction(FunctionOpInterface funcOp,
           ? reusedClusterBarrier.getOperation()
           : lastInsertionAnchor;
   builder.setInsertionPoint(fenceInsertionPoint);
-  Location loc = lastInitInInsertionBlock
-                     ? lastInitInInsertionBlock->getLoc()
-                     : crossCTAInitAnchors.front()->getLoc();
+  Location loc = crossCTAInitAnchor->getLoc();
   ttng::FenceMBarrierInitReleaseClusterOp::create(builder, loc);
   if (!reusedClusterBarrier)
     ttng::ClusterBarrierOp::create(builder, loc, /*relaxed=*/true);
+  return success();
+}
+
+static LogicalResult
+insertCrossCTAMBarrierInitSyncForFunction(FunctionOpInterface funcOp,
+                                          Allocation *allocation, int numCTAs,
+                                          OpBuilder &builder) {
+  if (!funcOp || funcOp->getNumRegions() != 1) {
+    return funcOp.emitOpError(
+        "cross-CTA mbarrier init sync insertion requires a single function "
+        "top-level region");
+  }
+
+  SmallVector<ttng::InitBarrierOp> crossCTAInits;
+  funcOp.walk([&](ttng::InitBarrierOp initBarrierOp) {
+    if (requiresCrossCTAMBarrierInitSync(initBarrierOp, funcOp, allocation,
+                                         numCTAs))
+      crossCTAInits.push_back(initBarrierOp);
+  });
+
+  for (ttng::InitBarrierOp initBarrierOp : crossCTAInits)
+    if (failed(insertCrossCTAMBarrierInitSyncForBarrier(
+            funcOp, allocation, initBarrierOp, builder)))
+      return failure();
+
   return success();
 }
 

--- a/lib/Dialect/TritonNvidiaGPU/Transforms/ClusterBarrierInsertion.cpp
+++ b/lib/Dialect/TritonNvidiaGPU/Transforms/ClusterBarrierInsertion.cpp
@@ -140,21 +140,37 @@ static bool opUsesTrackedMBarrier(Operation *op,
 }
 
 static LogicalResult
-insertCrossCTAMBarrierInitSyncForBarrier(FunctionOpInterface funcOp,
-                                         Allocation *allocation,
-                                         ttng::InitBarrierOp initBarrierOp,
-                                         OpBuilder &builder) {
-  Region &topLevelRegion = funcOp->getRegion(0);
-  Operation *crossCTAInitAnchor =
-      topLevelRegion.findAncestorOpInRegion(*initBarrierOp.getOperation());
-  assert(crossCTAInitAnchor && "init op must be inside the function region");
-
-  Allocation::BufferIdSetT trackedBarrierBuffers;
-  for (auto bufferId :
-       allocation->getAllBufferIdsWithAliases(initBarrierOp.getBarrier())) {
-    assert(bufferId != Allocation::InvalidBufferId);
-    trackedBarrierBuffers.insert(bufferId);
+insertCrossCTAMBarrierInitSyncForFunction(FunctionOpInterface funcOp,
+                                          Allocation *allocation, int numCTAs,
+                                          OpBuilder &builder) {
+  if (!funcOp || funcOp->getNumRegions() != 1) {
+    return funcOp.emitOpError(
+        "cross-CTA mbarrier init sync insertion requires a single function "
+        "top-level region");
   }
+  Region &topLevelRegion = funcOp->getRegion(0);
+  llvm::SetVector<Operation *> crossCTAInitAnchors;
+  Allocation::BufferIdSetT trackedBarrierBuffers;
+
+  // Find all cross-CTA mbarrier.init ops and map each
+  // one to the containing top-level op that bounds the insertion window.
+  funcOp.walk([&](ttng::InitBarrierOp initBarrierOp) {
+    if (!requiresCrossCTAMBarrierInitSync(initBarrierOp, funcOp, allocation,
+                                          numCTAs))
+      return;
+    Operation *topLevelAnchor =
+        topLevelRegion.findAncestorOpInRegion(*initBarrierOp.getOperation());
+    assert(topLevelAnchor && "init op must be inside the function region");
+    crossCTAInitAnchors.insert(topLevelAnchor);
+    for (auto bufferId :
+         allocation->getAllBufferIdsWithAliases(initBarrierOp.getBarrier())) {
+      assert(bufferId != Allocation::InvalidBufferId);
+      trackedBarrierBuffers.insert(bufferId);
+    }
+  });
+  // Nothing to do
+  if (crossCTAInitAnchors.empty())
+    return success();
 
   llvm::SetVector<Operation *> trackedUseAnchors;
   for (Block &block : topLevelRegion) {
@@ -168,8 +184,31 @@ insertCrossCTAMBarrierInitSyncForBarrier(FunctionOpInterface funcOp,
                               "not find any mbarrier use");
   }
 
+  // Find the earliest insertion point that postdominates every tracked init.
   PostDominanceInfo postDomInfo(funcOp);
-  Operation *firstInsertionAnchor = crossCTAInitAnchor->getNextNode();
+  llvm::SmallPtrSet<Block *, 8> initBlocks;
+  for (Operation *crossCTAInitAnchor : crossCTAInitAnchors)
+    initBlocks.insert(crossCTAInitAnchor->getBlock());
+  Block *firstInsertionBlock =
+      postDomInfo.findNearestCommonDominator(initBlocks);
+  if (!firstInsertionBlock) {
+    return funcOp.emitOpError(
+        "could not find a common post-dominating insertion block for "
+        "cross-CTA mbarrier.init");
+  }
+
+  Operation *lastInitInInsertionBlock = nullptr;
+  for (Operation *crossCTAInitAnchor : crossCTAInitAnchors) {
+    if (crossCTAInitAnchor->getBlock() != firstInsertionBlock)
+      continue;
+    if (!lastInitInInsertionBlock ||
+        lastInitInInsertionBlock->isBeforeInBlock(crossCTAInitAnchor)) {
+      lastInitInInsertionBlock = crossCTAInitAnchor;
+    }
+  }
+  Operation *firstInsertionAnchor =
+      lastInitInInsertionBlock ? lastInitInInsertionBlock->getNextNode()
+                               : &firstInsertionBlock->front();
 
   // Find the latest insertion point that still dominates every tracked use.
   DominanceInfo domInfo(funcOp);
@@ -196,8 +235,7 @@ insertCrossCTAMBarrierInitSyncForBarrier(FunctionOpInterface funcOp,
                                        ? firstTrackedUseInInsertionBlock
                                        : lastInsertionBlock->getTerminator();
 
-  if (!firstInsertionAnchor ||
-      !domInfo.dominates(firstInsertionAnchor, lastInsertionAnchor)) {
+  if (!domInfo.dominates(firstInsertionAnchor, lastInsertionAnchor)) {
     return funcOp.emitOpError(
         "could not find an insertion point between cross-CTA mbarrier.init "
         "ops and tracked mbarrier uses");
@@ -231,35 +269,12 @@ insertCrossCTAMBarrierInitSyncForBarrier(FunctionOpInterface funcOp,
           ? reusedClusterBarrier.getOperation()
           : lastInsertionAnchor;
   builder.setInsertionPoint(fenceInsertionPoint);
-  Location loc = crossCTAInitAnchor->getLoc();
+  Location loc = lastInitInInsertionBlock
+                     ? lastInitInInsertionBlock->getLoc()
+                     : crossCTAInitAnchors.front()->getLoc();
   ttng::FenceMBarrierInitReleaseClusterOp::create(builder, loc);
   if (!reusedClusterBarrier)
     ttng::ClusterBarrierOp::create(builder, loc, /*relaxed=*/true);
-  return success();
-}
-
-static LogicalResult
-insertCrossCTAMBarrierInitSyncForFunction(FunctionOpInterface funcOp,
-                                          Allocation *allocation, int numCTAs,
-                                          OpBuilder &builder) {
-  if (!funcOp || funcOp->getNumRegions() != 1) {
-    return funcOp.emitOpError(
-        "cross-CTA mbarrier init sync insertion requires a single function "
-        "top-level region");
-  }
-
-  SmallVector<ttng::InitBarrierOp> crossCTAInits;
-  funcOp.walk([&](ttng::InitBarrierOp initBarrierOp) {
-    if (requiresCrossCTAMBarrierInitSync(initBarrierOp, funcOp, allocation,
-                                         numCTAs))
-      crossCTAInits.push_back(initBarrierOp);
-  });
-
-  for (ttng::InitBarrierOp initBarrierOp : crossCTAInits)
-    if (failed(insertCrossCTAMBarrierInitSyncForBarrier(
-            funcOp, allocation, initBarrierOp, builder)))
-      return failure();
-
   return success();
 }
 

--- a/lib/Dialect/TritonNvidiaGPU/Transforms/MBarrierUtilities.cpp
+++ b/lib/Dialect/TritonNvidiaGPU/Transforms/MBarrierUtilities.cpp
@@ -57,6 +57,8 @@ bool requiresCrossCTAMBarrierInitSync(
   if (isCrossCTAMBarrier(barrier, numCTAs))
     return true;
 
+  // Or if it's used by a multi-CTA consumer that broadcasts barrier state
+  // across CTAs even though the barrier allocation itself looks per-CTA.
   return funcOp
       ->walk<WalkOrder::PreOrder>([&](Operation *op) {
         if (isCrossCTAConsumer(op, aliasesBarrier))

--- a/lib/Dialect/TritonNvidiaGPU/Transforms/TMALowering.cpp
+++ b/lib/Dialect/TritonNvidiaGPU/Transforms/TMALowering.cpp
@@ -103,8 +103,8 @@ struct TMAGatherLowering : public OpRewritePattern<DescriptorGatherOp> {
     auto createLoad = [&](Value desc, Value barrierAlloc, Value alloc,
                           Value pred, bool useMulticast) {
       triton::nvidia_gpu::AsyncTMAGatherOp::create(
-          rewriter, op.getLoc(), desc, xOffsets, op.getYOffset(),
-          barrierAlloc, alloc, pred, useMulticast);
+          rewriter, op.getLoc(), desc, xOffsets, op.getYOffset(), barrierAlloc,
+          alloc, pred, useMulticast);
     };
     lowerTMALoad(op, op.getType(), op.getDesc(), createLoad, rewriter);
     return success();

--- a/lib/Dialect/TritonNvidiaGPU/Transforms/TMALowering.cpp
+++ b/lib/Dialect/TritonNvidiaGPU/Transforms/TMALowering.cpp
@@ -40,7 +40,7 @@ lowerTMALoad(Operation *op, RankedTensorType tensorType, Value desc,
   auto numCTAs = gpu::lookupNumCTAs(op);
   bool useTwoCTABarrier = triton::valueFeedsTwoCTAMMA(op->getResult(0));
   bool useMulticast =
-      isa<DescriptorLoadOp>(op) && hasCGABroadcast(memDescType) &&
+      isa<DescriptorLoadLikeOpInterface>(op) && hasCGABroadcast(memDescType) &&
       llvm::any_of(op->getResults(), triton::valueFeedsMulticastMMA);
   auto barrierCGALayout = [&]() -> gpu::CGAEncodingAttr {
     if (!useTwoCTABarrier)
@@ -103,10 +103,9 @@ struct TMAGatherLowering : public OpRewritePattern<DescriptorGatherOp> {
 
     auto createLoad = [&](Value desc, Value barrierAlloc, Value alloc,
                           Value pred, bool useMulticast) {
-      triton::nvidia_gpu::AsyncTMAGatherOp::create(rewriter, op.getLoc(), desc,
-                                                   xOffsets, op.getYOffset(),
-                                                   barrierAlloc, alloc, pred,
-                                                   useMulticast);
+      triton::nvidia_gpu::AsyncTMAGatherOp::create(
+          rewriter, op.getLoc(), desc, xOffsets, op.getYOffset(), barrierAlloc,
+          alloc, pred, useMulticast);
     };
     lowerTMALoad(op, op.getType(), op.getDesc(), createLoad, rewriter);
     return success();

--- a/lib/Dialect/TritonNvidiaGPU/Transforms/TMALowering.cpp
+++ b/lib/Dialect/TritonNvidiaGPU/Transforms/TMALowering.cpp
@@ -13,9 +13,6 @@
 #include "triton/Dialect/TritonNvidiaGPU/Transforms/Passes.h"
 #include "triton/Dialect/TritonNvidiaGPU/Transforms/TMAUtilities.h"
 #include "triton/Tools/LayoutUtils.h"
-#include "llvm/Support/ErrorHandling.h"
-
-#include <vector>
 
 namespace mlir {
 namespace triton {
@@ -25,69 +22,6 @@ namespace nvidia_gpu {
 #include "triton/Dialect/TritonNvidiaGPU/Transforms/Passes.h.inc"
 
 namespace {
-
-static gpu::DistributedEncodingTrait
-replaceCGALayout(gpu::DistributedEncodingTrait layout,
-                 const gpu::CGAEncodingAttr &newCGALayout) {
-  if (auto blockedLayout = mlir::dyn_cast<gpu::BlockedEncodingAttr>(layout)) {
-    return gpu::BlockedEncodingAttr::get(
-        layout.getContext(), blockedLayout.getSizePerThread(),
-        blockedLayout.getThreadsPerWarp(), blockedLayout.getWarpsPerCTA(),
-        blockedLayout.getOrder(), newCGALayout);
-  }
-  if (auto sliceLayout = mlir::dyn_cast<gpu::SliceEncodingAttr>(layout)) {
-    return gpu::SliceEncodingAttr::get(
-        layout.getContext(), sliceLayout.getDim(),
-        replaceCGALayout(sliceLayout.getParent(), newCGALayout));
-  }
-  llvm::report_fatal_error("replaceCGALayout not implemented for layout");
-}
-
-static Value convertGatherOffsetsToMemDescRowsCGALayout(
-    Value xOffsets, gpu::MemDescType memDescType, PatternRewriter &rewriter,
-    Location loc) {
-  auto xOffsetsType = cast<RankedTensorType>(xOffsets.getType());
-  if (!xOffsetsType.getEncoding())
-    return xOffsets;
-
-  MLIRContext *ctx = xOffsets.getContext();
-  auto kBlock = StringAttr::get(ctx, "block");
-  auto kDim0 = StringAttr::get(ctx, "dim0");
-  auto rowsCGALayout = gpu::getCGALayout(memDescType.getEncoding())
-                           .getLinearLayout()
-                           .sublayout({kBlock}, {kDim0});
-  auto xOffsetsCGALayout =
-      gpu::getCGALayout(xOffsetsType.getEncoding()).getLinearLayout();
-  if (rowsCGALayout == xOffsetsCGALayout)
-    return xOffsets;
-
-  auto xOffsetsEncoding =
-      cast<gpu::DistributedEncodingTrait>(xOffsetsType.getEncoding());
-  gpu::DistributedEncodingTrait newEncoding;
-  if (auto sliceEncoding = dyn_cast<gpu::SliceEncodingAttr>(xOffsetsEncoding)) {
-    unsigned parentRank = xOffsetsType.getRank() + 1;
-    unsigned keptDim = sliceEncoding.getDim() == 0 ? 1 : 0;
-    std::vector<std::vector<int32_t>> parentBases;
-    for (ArrayRef<int32_t> rowBasis :
-         rowsCGALayout.getBases().lookup(kBlock)) {
-      std::vector<int32_t> parentBasis(parentRank, 0);
-      parentBasis[keptDim] = rowBasis[0];
-      parentBases.push_back(std::move(parentBasis));
-    }
-    auto parentCGALayout = gpu::CGAEncodingAttr::get(
-        ctx, LinearLayout({{kBlock, std::move(parentBases)}},
-                          standardOutDimNames(ctx, parentRank)));
-    auto newParentEncoding =
-        replaceCGALayout(sliceEncoding.getParent(), parentCGALayout);
-    newEncoding = gpu::SliceEncodingAttr::get(ctx, sliceEncoding.getDim(),
-                                              newParentEncoding);
-  } else {
-    auto newCGAEncoding = gpu::CGAEncodingAttr::get(ctx, rowsCGALayout);
-    newEncoding = replaceCGALayout(xOffsetsEncoding, newCGAEncoding);
-  }
-  auto newType = xOffsetsType.cloneWithEncoding(newEncoding);
-  return gpu::ConvertLayoutOp::create(rewriter, loc, newType, xOffsets);
-}
 
 static void
 lowerTMALoad(Operation *op, RankedTensorType tensorType, Value desc,
@@ -168,11 +102,8 @@ struct TMAGatherLowering : public OpRewritePattern<DescriptorGatherOp> {
 
     auto createLoad = [&](Value desc, Value barrierAlloc, Value alloc,
                           Value pred, bool useMulticast) {
-      auto memDescType = cast<gpu::MemDescType>(alloc.getType());
-      Value gatherOffsets = convertGatherOffsetsToMemDescRowsCGALayout(
-          xOffsets, memDescType, rewriter, op.getLoc());
       triton::nvidia_gpu::AsyncTMAGatherOp::create(
-          rewriter, op.getLoc(), desc, gatherOffsets, op.getYOffset(),
+          rewriter, op.getLoc(), desc, xOffsets, op.getYOffset(),
           barrierAlloc, alloc, pred, useMulticast);
     };
     lowerTMALoad(op, op.getType(), op.getDesc(), createLoad, rewriter);

--- a/lib/Dialect/TritonNvidiaGPU/Transforms/TMALowering.cpp
+++ b/lib/Dialect/TritonNvidiaGPU/Transforms/TMALowering.cpp
@@ -12,7 +12,7 @@
 #include "triton/Dialect/TritonNvidiaGPU/IR/Dialect.h"
 #include "triton/Dialect/TritonNvidiaGPU/Transforms/Passes.h"
 #include "triton/Dialect/TritonNvidiaGPU/Transforms/TMAUtilities.h"
-#include "llvm/ADT/SetVector.h"
+#include "triton/Tools/LayoutUtils.h"
 #include "llvm/Support/ErrorHandling.h"
 
 namespace mlir {
@@ -23,22 +23,6 @@ namespace nvidia_gpu {
 #include "triton/Dialect/TritonNvidiaGPU/Transforms/Passes.h.inc"
 
 namespace {
-
-static bool loadFeedsMulticastMMAv5MMA(Operation *loadOp) {
-  llvm::SetVector<Operation *> worklist;
-  worklist.insert(loadOp->user_begin(), loadOp->user_end());
-  for (unsigned i = 0; i < worklist.size(); ++i) {
-    Operation *op = worklist[i];
-    auto mma = dyn_cast<MMAv5OpInterface>(op);
-    if (mma) {
-      if (mma.getMulticast())
-        return true;
-      continue;
-    }
-    worklist.insert(op->user_begin(), op->user_end());
-  }
-  return false;
-}
 
 static void
 lowerTMALoad(Operation *op, RankedTensorType tensorType, Value desc,
@@ -54,13 +38,27 @@ lowerTMALoad(Operation *op, RankedTensorType tensorType, Value desc,
   auto alloc =
       gpu::LocalAllocOp::create(rewriter, loc, memDescType).getResult();
   auto numCTAs = gpu::lookupNumCTAs(op);
-  auto barrierCGALayout =
-      gpu::CGAEncodingAttr::get1DLayout(tensorType.getContext(), numCTAs);
+  bool useTwoCTABarrier = triton::valueFeedsTwoCTAMMA(op->getResult(0));
+  bool useMulticast =
+      isa<DescriptorLoadOp>(op) && hasCGABroadcast(memDescType) &&
+      llvm::any_of(op->getResults(), triton::valueFeedsMulticastMMA);
+  auto barrierCGALayout = [&]() -> gpu::CGAEncodingAttr {
+    if (!useTwoCTABarrier)
+      return gpu::CGAEncodingAttr::get1DLayout(tensorType.getContext(),
+                                               numCTAs);
+    auto kBlock = StringAttr::get(ctx, "block");
+    auto dim = standardOutDimNames(ctx, /*rank=*/1)[0];
+    return gpu::CGAEncodingAttr::get(
+        ctx, LinearLayout::zeros1D(2, kBlock, dim) *
+                 LinearLayout::identity1D(numCTAs / 2, kBlock, dim));
+  }();
   auto barrierEncoding = gpu::SwizzledSharedEncodingAttr::get(
       tensorType.getContext(), 1, 1, 1, {0}, barrierCGALayout);
+  auto numBarrierSlots = useTwoCTABarrier ? numCTAs / 2 : numCTAs;
   gpu::MemDescType barrierMemDescType =
-      gpu::MemDescType::get({numCTAs}, rewriter.getI64Type(), barrierEncoding,
-                            sharedMemorySpace, /*mutableMemory=*/true);
+      gpu::MemDescType::get({numBarrierSlots}, rewriter.getI64Type(),
+                            barrierEncoding, sharedMemorySpace,
+                            /*mutableMemory=*/true);
   Value barrierAlloc =
       gpu::LocalAllocOp::create(rewriter, loc, barrierMemDescType);
   InitBarrierOp::create(rewriter, loc, barrierAlloc, 1);
@@ -70,9 +68,6 @@ lowerTMALoad(Operation *op, RankedTensorType tensorType, Value desc,
   Value pred = arith::ConstantIntOp::create(rewriter, loc, 1, 1);
   triton::nvidia_gpu::BarrierExpectOp::create(rewriter, loc, barrierAlloc,
                                               sizeInBytes, pred);
-  bool useMulticast = isa<DescriptorLoadOp>(op) &&
-                      hasCGABroadcast(memDescType) &&
-                      loadFeedsMulticastMMAv5MMA(op);
   createLoad(desc, barrierAlloc, alloc, pred, useMulticast);
   Value phase = arith::ConstantIntOp::create(rewriter, loc, 0, 32);
   WaitBarrierOp::create(rewriter, loc, barrierAlloc, phase);
@@ -107,10 +102,11 @@ struct TMAGatherLowering : public OpRewritePattern<DescriptorGatherOp> {
         sextI16ToI32Indices(op.getXOffsets(), rewriter, op.getLoc());
 
     auto createLoad = [&](Value desc, Value barrierAlloc, Value alloc,
-                          Value pred, bool /*useMulticast*/) {
+                          Value pred, bool useMulticast) {
       triton::nvidia_gpu::AsyncTMAGatherOp::create(rewriter, op.getLoc(), desc,
                                                    xOffsets, op.getYOffset(),
-                                                   barrierAlloc, alloc, pred);
+                                                   barrierAlloc, alloc, pred,
+                                                   useMulticast);
     };
     lowerTMALoad(op, op.getType(), op.getDesc(), createLoad, rewriter);
     return success();

--- a/lib/Dialect/TritonNvidiaGPU/Transforms/TMALowering.cpp
+++ b/lib/Dialect/TritonNvidiaGPU/Transforms/TMALowering.cpp
@@ -15,6 +15,8 @@
 #include "triton/Tools/LayoutUtils.h"
 #include "llvm/Support/ErrorHandling.h"
 
+#include <vector>
+
 namespace mlir {
 namespace triton {
 namespace nvidia_gpu {
@@ -23,6 +25,69 @@ namespace nvidia_gpu {
 #include "triton/Dialect/TritonNvidiaGPU/Transforms/Passes.h.inc"
 
 namespace {
+
+static gpu::DistributedEncodingTrait
+replaceCGALayout(gpu::DistributedEncodingTrait layout,
+                 const gpu::CGAEncodingAttr &newCGALayout) {
+  if (auto blockedLayout = mlir::dyn_cast<gpu::BlockedEncodingAttr>(layout)) {
+    return gpu::BlockedEncodingAttr::get(
+        layout.getContext(), blockedLayout.getSizePerThread(),
+        blockedLayout.getThreadsPerWarp(), blockedLayout.getWarpsPerCTA(),
+        blockedLayout.getOrder(), newCGALayout);
+  }
+  if (auto sliceLayout = mlir::dyn_cast<gpu::SliceEncodingAttr>(layout)) {
+    return gpu::SliceEncodingAttr::get(
+        layout.getContext(), sliceLayout.getDim(),
+        replaceCGALayout(sliceLayout.getParent(), newCGALayout));
+  }
+  llvm::report_fatal_error("replaceCGALayout not implemented for layout");
+}
+
+static Value convertGatherOffsetsToMemDescRowsCGALayout(
+    Value xOffsets, gpu::MemDescType memDescType, PatternRewriter &rewriter,
+    Location loc) {
+  auto xOffsetsType = cast<RankedTensorType>(xOffsets.getType());
+  if (!xOffsetsType.getEncoding())
+    return xOffsets;
+
+  MLIRContext *ctx = xOffsets.getContext();
+  auto kBlock = StringAttr::get(ctx, "block");
+  auto kDim0 = StringAttr::get(ctx, "dim0");
+  auto rowsCGALayout = gpu::getCGALayout(memDescType.getEncoding())
+                           .getLinearLayout()
+                           .sublayout({kBlock}, {kDim0});
+  auto xOffsetsCGALayout =
+      gpu::getCGALayout(xOffsetsType.getEncoding()).getLinearLayout();
+  if (rowsCGALayout == xOffsetsCGALayout)
+    return xOffsets;
+
+  auto xOffsetsEncoding =
+      cast<gpu::DistributedEncodingTrait>(xOffsetsType.getEncoding());
+  gpu::DistributedEncodingTrait newEncoding;
+  if (auto sliceEncoding = dyn_cast<gpu::SliceEncodingAttr>(xOffsetsEncoding)) {
+    unsigned parentRank = xOffsetsType.getRank() + 1;
+    unsigned keptDim = sliceEncoding.getDim() == 0 ? 1 : 0;
+    std::vector<std::vector<int32_t>> parentBases;
+    for (ArrayRef<int32_t> rowBasis :
+         rowsCGALayout.getBases().lookup(kBlock)) {
+      std::vector<int32_t> parentBasis(parentRank, 0);
+      parentBasis[keptDim] = rowBasis[0];
+      parentBases.push_back(std::move(parentBasis));
+    }
+    auto parentCGALayout = gpu::CGAEncodingAttr::get(
+        ctx, LinearLayout({{kBlock, std::move(parentBases)}},
+                          standardOutDimNames(ctx, parentRank)));
+    auto newParentEncoding =
+        replaceCGALayout(sliceEncoding.getParent(), parentCGALayout);
+    newEncoding = gpu::SliceEncodingAttr::get(ctx, sliceEncoding.getDim(),
+                                              newParentEncoding);
+  } else {
+    auto newCGAEncoding = gpu::CGAEncodingAttr::get(ctx, rowsCGALayout);
+    newEncoding = replaceCGALayout(xOffsetsEncoding, newCGAEncoding);
+  }
+  auto newType = xOffsetsType.cloneWithEncoding(newEncoding);
+  return gpu::ConvertLayoutOp::create(rewriter, loc, newType, xOffsets);
+}
 
 static void
 lowerTMALoad(Operation *op, RankedTensorType tensorType, Value desc,
@@ -103,9 +168,12 @@ struct TMAGatherLowering : public OpRewritePattern<DescriptorGatherOp> {
 
     auto createLoad = [&](Value desc, Value barrierAlloc, Value alloc,
                           Value pred, bool useMulticast) {
+      auto memDescType = cast<gpu::MemDescType>(alloc.getType());
+      Value gatherOffsets = convertGatherOffsetsToMemDescRowsCGALayout(
+          xOffsets, memDescType, rewriter, op.getLoc());
       triton::nvidia_gpu::AsyncTMAGatherOp::create(
-          rewriter, op.getLoc(), desc, xOffsets, op.getYOffset(), barrierAlloc,
-          alloc, pred, useMulticast);
+          rewriter, op.getLoc(), desc, gatherOffsets, op.getYOffset(),
+          barrierAlloc, alloc, pred, useMulticast);
     };
     lowerTMALoad(op, op.getType(), op.getDesc(), createLoad, rewriter);
     return success();

--- a/python/test/unit/language/test_tensor_descriptor.py
+++ b/python/test/unit/language/test_tensor_descriptor.py
@@ -728,7 +728,7 @@ def matmul_kernel_make_tensor_descriptor_no_loop(a_ptr, b_ptr, c_ptr, M: tl.cons
 
 
 @pytest.mark.skipif(not is_cuda() or torch.cuda.get_device_capability(0)[0] != 10, reason="Requires Blackwell MMAv5")
-def test_make_tensor_descriptor_no_loop_tma_load_multicast_two_cta(device, capfd):
+def test_make_tensor_descriptor_no_loop_tma_load_multicast_two_cta(device):
     M, N, K = 256, 256, 64
     BLOCK_M, BLOCK_N, BLOCK_K = M, N, K
     torch.manual_seed(42)
@@ -743,16 +743,17 @@ def test_make_tensor_descriptor_no_loop_tma_load_multicast_two_cta(device, capfd
 
     triton.set_allocator(alloc_fn)
 
-    with pytest.raises(RuntimeError, match="PassManager::run failed"):
-        matmul_kernel_make_tensor_descriptor_no_loop.warmup(A, B, C, M, N, K, BLOCK_M, BLOCK_N, BLOCK_K, grid=(1, ),
-                                                            num_warps=4, num_ctas=4)
-    stderr = capfd.readouterr().err
-    assert "scf.for" not in stderr
-    assert "ttng.async_tma_copy_global_to_local" in stderr
-    assert "!ttg.memdesc<2xi64" in stderr
-    assert "ttng.tc_gen5_mma" in stderr
-    assert "two_ctas" in stderr
-    assert "multicast" in stderr
+    kernel = matmul_kernel_make_tensor_descriptor_no_loop[(1, )](A, B, C, M, N, K, BLOCK_M, BLOCK_N, BLOCK_K,
+                                                                 num_warps=4, num_ctas=4)
+    ref_out = torch.matmul(A.to(torch.float32), B.to(torch.float32)).to(torch.float16)
+    torch.testing.assert_close(ref_out, C, rtol=1e-3, atol=1e-3)
+
+    assert "scf.for" not in kernel.asm["ttgir"]
+    assert "ttng.async_tma_copy_global_to_local" in kernel.asm["ttgir"]
+    mma_lines = [line for line in kernel.asm["ttgir"].splitlines() if "ttng.tc_gen5_mma" in line]
+    assert any("two_ctas" in line and "multicast" in line for line in mma_lines)
+    assert "cta_group::2" in kernel.asm["ptx"]
+    assert "multicast::cluster" in kernel.asm["ptx"]
 
 
 @triton.jit
@@ -770,7 +771,7 @@ def matmul_kernel_make_tensor_descriptor_gather_no_loop(a_ptr, b_ptr, c_ptr, M: 
 
 
 @pytest.mark.skipif(not is_cuda() or torch.cuda.get_device_capability(0)[0] != 10, reason="Requires Blackwell MMAv5")
-def test_make_tensor_descriptor_no_loop_tma_gather_multicast_two_cta_rejects_mismatched_offsets(device, capfd):
+def test_make_tensor_descriptor_no_loop_tma_gather_multicast_two_cta(device):
     M, N, K = 256, 256, 64
     BLOCK_M, BLOCK_N, BLOCK_K = M, N, K
     torch.manual_seed(42)
@@ -785,12 +786,17 @@ def test_make_tensor_descriptor_no_loop_tma_gather_multicast_two_cta_rejects_mis
 
     triton.set_allocator(alloc_fn)
 
-    with pytest.raises(RuntimeError, match="PassManager::run failed"):
-        matmul_kernel_make_tensor_descriptor_gather_no_loop.warmup(A, B, C, M, N, K, BLOCK_M, BLOCK_N, BLOCK_K,
-                                                                   grid=(1, ), num_warps=4, num_ctas=4)
-    stderr = capfd.readouterr().err
-    assert "ttng.async_tma_gather" in stderr
-    assert "x offsets must have the same row CGA layout as the memdesc" in stderr
+    kernel = matmul_kernel_make_tensor_descriptor_gather_no_loop[(1, )](A, B, C, M, N, K, BLOCK_M, BLOCK_N, BLOCK_K,
+                                                                        num_warps=4, num_ctas=4)
+    ref_out = torch.matmul(A.to(torch.float32), B.to(torch.float32)).to(torch.float16)
+    torch.testing.assert_close(ref_out, C, rtol=1e-3, atol=1e-3)
+
+    assert "scf.for" not in kernel.asm["ttgir"]
+    assert "ttng.async_tma_gather" in kernel.asm["ttgir"]
+    mma_lines = [line for line in kernel.asm["ttgir"].splitlines() if "ttng.tc_gen5_mma" in line]
+    assert any("two_ctas" in line and "multicast" in line for line in mma_lines)
+    assert "cta_group::2" in kernel.asm["ptx"]
+    assert "multicast::cluster" in kernel.asm["ptx"]
 
 
 @triton.jit

--- a/python/test/unit/language/test_tensor_descriptor.py
+++ b/python/test/unit/language/test_tensor_descriptor.py
@@ -757,49 +757,6 @@ def test_make_tensor_descriptor_no_loop_tma_load_multicast_two_cta(device):
 
 
 @triton.jit
-def matmul_kernel_make_tensor_descriptor_gather_no_loop(a_ptr, b_ptr, c_ptr, M: tl.constexpr, N: tl.constexpr,
-                                                        K: tl.constexpr, BLOCK_M: tl.constexpr, BLOCK_N: tl.constexpr,
-                                                        BLOCK_K: tl.constexpr):
-    a_desc = tl.make_tensor_descriptor(a_ptr, [M, K], [K, 1], [1, BLOCK_K])
-    b_desc = tl.make_tensor_descriptor(b_ptr, [K, N], [N, 1], [BLOCK_K, BLOCK_N])
-    c_desc = tl.make_tensor_descriptor(c_ptr, [M, N], [N, 1], [BLOCK_M, BLOCK_N])
-
-    a = a_desc.gather(tl.arange(0, BLOCK_M), 0)
-    b = b_desc.load([0, 0])
-    accumulator = tl.dot(a, b)
-    c_desc.store([0, 0], accumulator.to(a_desc.dtype))
-
-
-@pytest.mark.skipif(not is_cuda() or torch.cuda.get_device_capability(0)[0] != 10, reason="Requires Blackwell MMAv5")
-def test_make_tensor_descriptor_no_loop_tma_gather_multicast_two_cta(device):
-    M, N, K = 256, 256, 64
-    BLOCK_M, BLOCK_N, BLOCK_K = M, N, K
-    torch.manual_seed(42)
-    A = torch.randn((M, K), dtype=torch.float16, device=device)
-    B = torch.randn((K, N), dtype=torch.float16, device=device)
-    C = torch.empty((M, N), dtype=torch.float16, device=device)
-
-    def alloc_fn(size: int, align: int, stream: Optional[int]):
-        assert align == 128
-        assert stream == 0
-        return torch.empty(size, dtype=torch.int8, device=device)
-
-    triton.set_allocator(alloc_fn)
-
-    kernel = matmul_kernel_make_tensor_descriptor_gather_no_loop[(1, )](A, B, C, M, N, K, BLOCK_M, BLOCK_N, BLOCK_K,
-                                                                        num_warps=4, num_ctas=4)
-    ref_out = torch.matmul(A.to(torch.float32), B.to(torch.float32)).to(torch.float16)
-    torch.testing.assert_close(ref_out, C, rtol=1e-3, atol=1e-3)
-
-    assert "scf.for" not in kernel.asm["ttgir"]
-    assert "ttng.async_tma_gather" in kernel.asm["ttgir"]
-    mma_lines = [line for line in kernel.asm["ttgir"].splitlines() if "ttng.tc_gen5_mma" in line]
-    assert any("two_ctas" in line and "multicast" in line for line in mma_lines)
-    assert "cta_group::2" in kernel.asm["ptx"]
-    assert "multicast::cluster" in kernel.asm["ptx"]
-
-
-@triton.jit
 def kernel_make_tensor_descriptor_loop_carried(a_ptr, M, N, MBLOCK: tl.constexpr, NBLOCK: tl.constexpr):
     # Test that descriptors work with
     pid = tl.program_id(0)

--- a/python/test/unit/language/test_tensor_descriptor.py
+++ b/python/test/unit/language/test_tensor_descriptor.py
@@ -715,6 +715,85 @@ def test_make_tensor_descriptor_matmul_multi_cta_tma_multicast(num_ctas, BLOCK_M
 
 
 @triton.jit
+def matmul_kernel_make_tensor_descriptor_no_loop(a_ptr, b_ptr, c_ptr, M: tl.constexpr, N: tl.constexpr, K: tl.constexpr,
+                                                 BLOCK_M: tl.constexpr, BLOCK_N: tl.constexpr, BLOCK_K: tl.constexpr):
+    a_desc = tl.make_tensor_descriptor(a_ptr, [M, K], [K, 1], [BLOCK_M, BLOCK_K])
+    b_desc = tl.make_tensor_descriptor(b_ptr, [K, N], [N, 1], [BLOCK_K, BLOCK_N])
+    c_desc = tl.make_tensor_descriptor(c_ptr, [M, N], [N, 1], [BLOCK_M, BLOCK_N])
+
+    a = a_desc.load([0, 0])
+    b = b_desc.load([0, 0])
+    accumulator = tl.dot(a, b)
+    c_desc.store([0, 0], accumulator.to(a_desc.dtype))
+
+
+@pytest.mark.skipif(not is_cuda() or torch.cuda.get_device_capability(0)[0] != 10, reason="Requires Blackwell MMAv5")
+def test_make_tensor_descriptor_no_loop_tma_load_multicast_two_cta(device, capfd):
+    M, N, K = 256, 256, 64
+    BLOCK_M, BLOCK_N, BLOCK_K = M, N, K
+    torch.manual_seed(42)
+    A = torch.randn((M, K), dtype=torch.float16, device=device)
+    B = torch.randn((K, N), dtype=torch.float16, device=device)
+    C = torch.empty((M, N), dtype=torch.float16, device=device)
+
+    def alloc_fn(size: int, align: int, stream: Optional[int]):
+        assert align == 128
+        assert stream == 0
+        return torch.empty(size, dtype=torch.int8, device=device)
+
+    triton.set_allocator(alloc_fn)
+
+    with pytest.raises(RuntimeError, match="PassManager::run failed"):
+        matmul_kernel_make_tensor_descriptor_no_loop.warmup(A, B, C, M, N, K, BLOCK_M, BLOCK_N, BLOCK_K, grid=(1, ),
+                                                            num_warps=4, num_ctas=4)
+    stderr = capfd.readouterr().err
+    assert "scf.for" not in stderr
+    assert "ttng.async_tma_copy_global_to_local" in stderr
+    assert "!ttg.memdesc<2xi64" in stderr
+    assert "ttng.tc_gen5_mma" in stderr
+    assert "two_ctas" in stderr
+    assert "multicast" in stderr
+
+
+@triton.jit
+def matmul_kernel_make_tensor_descriptor_gather_no_loop(a_ptr, b_ptr, c_ptr, M: tl.constexpr, N: tl.constexpr,
+                                                        K: tl.constexpr, BLOCK_M: tl.constexpr, BLOCK_N: tl.constexpr,
+                                                        BLOCK_K: tl.constexpr):
+    a_desc = tl.make_tensor_descriptor(a_ptr, [M, K], [K, 1], [1, BLOCK_K])
+    b_desc = tl.make_tensor_descriptor(b_ptr, [K, N], [N, 1], [BLOCK_K, BLOCK_N])
+    c_desc = tl.make_tensor_descriptor(c_ptr, [M, N], [N, 1], [BLOCK_M, BLOCK_N])
+
+    a = a_desc.gather(tl.arange(0, BLOCK_M), 0)
+    b = b_desc.load([0, 0])
+    accumulator = tl.dot(a, b)
+    c_desc.store([0, 0], accumulator.to(a_desc.dtype))
+
+
+@pytest.mark.skipif(not is_cuda() or torch.cuda.get_device_capability(0)[0] != 10, reason="Requires Blackwell MMAv5")
+def test_make_tensor_descriptor_no_loop_tma_gather_multicast_two_cta_rejects_mismatched_offsets(device, capfd):
+    M, N, K = 256, 256, 64
+    BLOCK_M, BLOCK_N, BLOCK_K = M, N, K
+    torch.manual_seed(42)
+    A = torch.randn((M, K), dtype=torch.float16, device=device)
+    B = torch.randn((K, N), dtype=torch.float16, device=device)
+    C = torch.empty((M, N), dtype=torch.float16, device=device)
+
+    def alloc_fn(size: int, align: int, stream: Optional[int]):
+        assert align == 128
+        assert stream == 0
+        return torch.empty(size, dtype=torch.int8, device=device)
+
+    triton.set_allocator(alloc_fn)
+
+    with pytest.raises(RuntimeError, match="PassManager::run failed"):
+        matmul_kernel_make_tensor_descriptor_gather_no_loop.warmup(A, B, C, M, N, K, BLOCK_M, BLOCK_N, BLOCK_K,
+                                                                   grid=(1, ), num_warps=4, num_ctas=4)
+    stderr = capfd.readouterr().err
+    assert "ttng.async_tma_gather" in stderr
+    assert "x offsets must have the same row CGA layout as the memdesc" in stderr
+
+
+@triton.jit
 def kernel_make_tensor_descriptor_loop_carried(a_ptr, M, N, MBLOCK: tl.constexpr, NBLOCK: tl.constexpr):
     # Test that descriptors work with
     pid = tl.program_id(0)

--- a/test/TritonNvidiaGPU/tma_lowering.mlir
+++ b/test/TritonNvidiaGPU/tma_lowering.mlir
@@ -176,3 +176,44 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.targ
     tt.return %9 : tensor<64x32xf32, #mma1>
   }
 }
+
+
+// -----
+
+#blockedA_twocta = #ttg.blocked<{sizePerThread = [1, 8], threadsPerWarp = [2, 16], warpsPerCTA = [4, 1], order = [1, 0], CGALayout = [[1, 0], [2, 0]]}>
+#blockedB_twocta = #ttg.blocked<{sizePerThread = [1, 8], threadsPerWarp = [2, 16], warpsPerCTA = [4, 1], order = [1, 0], CGALayout = [[0, 1], [0, 0]]}>
+#sharedA_twocta = #ttg.nvmma_shared<{swizzlingByteWidth = 128, transposed = false, elementBitWidth = 16, CGALayout = [[1, 0], [2, 0]]}>
+#sharedB_twocta = #ttg.nvmma_shared<{swizzlingByteWidth = 128, transposed = false, elementBitWidth = 16, CGALayout = [[0, 1], [0, 0]]}>
+#mma_bar_twocta = #ttg.swizzled_shared<{vec = 1, perPhase = 1, maxPhase = 1, order = [0], CGALayout = [[1], [2]]}>
+#smem = #ttg.shared_memory
+#tmem_twocta = #ttng.tensor_memory_encoding<blockM = 128, blockN = 128, colStride = 1, CGALayout = [[1, 0], [2, 0]], twoCTAs = true>
+
+module attributes {"ttg.num-ctas" = 4 : i32, "ttg.num-warps" = 4 : i32, ttg.target = "cuda:100", "ttg.threads-per-warp" = 32 : i32} {
+  // CHECK-DAG: #[[$TMA_BAR:.*]] = #ttg.swizzled_shared<{{.*}}CGALayout = {{\[\[0\], \[1\]\]}}{{.*}}>
+  // CHECK-LABEL: @tma_load_feeds_two_cta_multicast_mmav5
+  // CHECK: ttng.tensormap_create
+  // CHECK: [[DESC:%.*]] = ttng.reinterpret_tensor_descriptor
+  // CHECK: ttg.local_alloc : () -> !ttg.memdesc<2xi64, #[[$TMA_BAR]]
+  // CHECK: ttng.async_tma_copy_global_to_local [[DESC]]{{.*}} {multicast} : {{.*}}!ttg.memdesc<2xi64, #[[$TMA_BAR]]
+  tt.func public @tma_load_feeds_two_cta_multicast_mmav5(
+      %ptr: !tt.ptr<f16> {tt.divisibility = 16 : i32},
+      %a: !ttg.memdesc<512x64xf16, #sharedA_twocta, #smem, mutable>,
+      %acc: !ttg.memdesc<512x128xf32, #tmem_twocta, #ttng.tensor_memory, mutable>,
+      %bar: !ttg.memdesc<4xi64, #mma_bar_twocta, #smem, mutable>) {
+    %true = arith.constant true
+    %c0_i32 = arith.constant 0 : i32
+    %c1_i64 = arith.constant 1 : i64
+    %c64_i32 = arith.constant 64 : i32
+    %c128_i32 = arith.constant 128 : i32
+    %c128_i64 = arith.constant 128 : i64
+    %desc = tt.make_tensor_descriptor %ptr, [%c64_i32, %c128_i32], [%c128_i64, %c1_i64] : !tt.ptr<f16>, !tt.tensordesc<64x128xf16, #sharedB_twocta>
+    %0 = tt.descriptor_load %desc[%c0_i32, %c0_i32] : !tt.tensordesc<64x128xf16, #sharedB_twocta> -> tensor<64x128xf16, #blockedB_twocta>
+    %1 = ttg.local_alloc %0 : (tensor<64x128xf16, #blockedB_twocta>) -> !ttg.memdesc<64x128xf16, #sharedB_twocta, #smem, mutable>
+    ttng.tc_gen5_mma %a, %1, %acc, %true, %true, %bar[%true] {is_async, multicast, two_ctas} :
+      !ttg.memdesc<512x64xf16, #sharedA_twocta, #smem, mutable>,
+      !ttg.memdesc<64x128xf16, #sharedB_twocta, #smem, mutable>,
+      !ttg.memdesc<512x128xf32, #tmem_twocta, #ttng.tensor_memory, mutable>,
+      !ttg.memdesc<4xi64, #mma_bar_twocta, #smem, mutable>
+    tt.return
+  }
+}

--- a/third_party/nvidia/backend/compiler.py
+++ b/third_party/nvidia/backend/compiler.py
@@ -324,7 +324,6 @@ class CUDABackend(BaseBackend):
         passes.ttgpuir.add_reorder_instructions(pm)
         passes.ttir.add_loop_aware_cse(pm)
         passes.common.add_symbol_dce(pm)
-        nvidia.passes.ttnvgpuir.add_hoist_mbarrier_lifecycle(pm, capability)
         nvidia.passes.ttnvgpuir.add_fence_insertion(pm, capability)
         nvidia.passes.ttnvgpuir.add_lower_mma(pm)
         passes.common.add_sccp(pm)
@@ -335,6 +334,7 @@ class CUDABackend(BaseBackend):
             passes.ttgpuir.add_remove_layout_conversions(pm)
             passes.common.add_canonicalizer(pm)
             passes.common.add_cse(pm)
+
         nvidia.passes.ttnvgpuir.add_hoist_mbarrier_lifecycle(pm, capability)
 
         pm.run(mod, 'make_ttgir')

--- a/third_party/nvidia/backend/compiler.py
+++ b/third_party/nvidia/backend/compiler.py
@@ -335,6 +335,7 @@ class CUDABackend(BaseBackend):
             passes.ttgpuir.add_remove_layout_conversions(pm)
             passes.common.add_canonicalizer(pm)
             passes.common.add_cse(pm)
+        nvidia.passes.ttnvgpuir.add_hoist_mbarrier_lifecycle(pm, capability)
 
         pm.run(mod, 'make_ttgir')
         metadata["tensordesc_meta"] = mod.get_tensordesc_metadata()

--- a/third_party/nvidia/backend/compiler.py
+++ b/third_party/nvidia/backend/compiler.py
@@ -394,7 +394,6 @@ class CUDABackend(BaseBackend):
             CUDABackend.instrumentation.patch("ttgpuir_to_llvmir", pm, mod.context)
         nvidia.passes.ttnvgpuir.add_proxy_fence_insertion(pm, capability)
         nvidia.passes.ttnvgpuir.add_tmem_barrier_insertion(pm)
-        nvidia.passes.ttnvgpuir.add_hoist_mbarrier_lifecycle(pm, capability)
         nvidia.passes.ttgpuir.add_to_llvmir(pm, capability, ptx_version, "consan" in options.instrumentation_mode)
         nvidia.passes.ttnvgpuir.add_initialize_ws_cluster_barriers(pm, capability, ptx_version)
         passes.ttgpuir.add_canonicalize_llvm_ir(pm)

--- a/third_party/nvidia/backend/compiler.py
+++ b/third_party/nvidia/backend/compiler.py
@@ -394,6 +394,7 @@ class CUDABackend(BaseBackend):
             CUDABackend.instrumentation.patch("ttgpuir_to_llvmir", pm, mod.context)
         nvidia.passes.ttnvgpuir.add_proxy_fence_insertion(pm, capability)
         nvidia.passes.ttnvgpuir.add_tmem_barrier_insertion(pm)
+        nvidia.passes.ttnvgpuir.add_hoist_mbarrier_lifecycle(pm, capability)
         nvidia.passes.ttgpuir.add_to_llvmir(pm, capability, ptx_version, "consan" in options.instrumentation_mode)
         nvidia.passes.ttnvgpuir.add_initialize_ws_cluster_barriers(pm, capability, ptx_version)
         passes.ttgpuir.add_canonicalize_llvm_ir(pm)


### PR DESCRIPTION
<git-pr-chain>

#### Commits in this PR
1. Fix TMA lowering for two-CTA MMAv5 users
1. Support multicast TMA gather for two-CTA MMA
1. Fix no-loop two-CTA tensor descriptor compilation
1. restore a comment
1. Hoist mbarrier lifecycle after TMEM barrier insertion
1. Remove gather offset layout conversion workaround
1. Remove late mbarrier lifecycle hoist from llir

#### PR chain
1. #10325
1. #10676
1. #10765
1. #10769
1. 👉 #10781 👈 **YOU ARE HERE**
1. #10812
1. #10817

⚠️⚠️ Please **do not click the green "merge" button** unless you know what you're doing. This PR is part of a chain of PRs, and clicking the merge button will not merge it into `main`. ⚠️⚠️

</git-pr-chain>