### PR TITLE
Support local atomic scatter RMW in ConSan

### DIFF
--- a/include/triton/Dialect/TritonInstrument/IR/TritonInstrument.md
+++ b/include/triton/Dialect/TritonInstrument/IR/TritonInstrument.md
@@ -205,12 +205,13 @@ for the cluster and touches all CTA rows.
 For direct memdesc accesses, ConSan derives the possible recipient CTA rows
 from the same block-local register-to-shared layout conversion used by
 lowering. This covers `ttg.local_load`, `ttg.local_store`, and source-backed
-`ttg.local_alloc`. For `ttg.local_gather` and `ttg.local_scatter`, the runtime
-index replaces one logical coordinate, so ConSan additionally spans that
-index's layout bases. In each case the issuing CTA is fixed while the other
-input bases are spanned, producing a static conservative recipient set for the
-full buffer without defaulting every access to the whole cluster. Cross-CTA
-affine subslices are rejected as unsupported by BufferRegion analysis.
+`ttg.local_alloc`. For `ttg.local_gather`, `ttg.local_scatter`, and
+`ttg.local_atomic_scatter_rmw`, the runtime index replaces one logical
+coordinate, so ConSan additionally spans that index's layout bases. In each
+case the issuing CTA is fixed while the other input bases are spanned,
+producing a static conservative recipient set for the full buffer without
+defaulting every access to the whole cluster. Cross-CTA affine subslices are
+rejected as unsupported by BufferRegion analysis.
 
 ## Barrier Synchronization
 
@@ -296,9 +297,10 @@ The common hook implementation covers these TritonGPU operations:
 - `ttg.local_load` and `ttg.local_gather`: barrier-tracked shared-memory
   reads. A gather conservatively covers its full source descriptor because its
   indices are runtime values.
-- `ttg.local_store` and `ttg.local_scatter`: barrier-tracked shared-memory
-  writes. A scatter conservatively covers its full destination descriptor
-  because its indices are runtime values.
+- `ttg.local_store`, `ttg.local_scatter`, and
+  `ttg.local_atomic_scatter_rmw`: barrier-tracked shared-memory writes. Scatter
+  and atomic scatter RMW conservatively cover their full destination
+  descriptors because their indices are runtime values.
 - `ttg.local_alloc` with a source: barrier-tracked shared-memory write.
 
 These shared-memory effects are generic-proxy accesses for the proxy-ordering

--- a/include/triton/Dialect/TritonInstrument/Transforms/ConSanTargetHooks.h
+++ b/include/triton/Dialect/TritonInstrument/Transforms/ConSanTargetHooks.h
@@ -160,6 +160,12 @@ public:
       info->operandEffects.emplace_back(MemEffectsOpInfo::Effects::Write,
                                         scatterOp.getDst());
     }
+    if (auto atomicOp = dyn_cast<ttg::LocalAtomicScatterRMWOp>(op)) {
+      info.emplace();
+      info->trackingKind = MemEffectsOpInfo::TrackingKind::Barrier;
+      info->operandEffects.emplace_back(MemEffectsOpInfo::Effects::Write,
+                                        atomicOp.getDst());
+    }
     if (auto allocOp = dyn_cast<ttg::LocalAllocOp>(op)) {
       if (allocOp.getSrc()) {
         info.emplace();

--- a/lib/Analysis/BufferRegion.cpp
+++ b/lib/Analysis/BufferRegion.cpp
@@ -333,9 +333,9 @@ void BufferRegionAnalysis::calculateUsedBufferRegions(Operation *op) {
 
 bool BufferRegionAnalysis::isMemoryAccessOperation(Operation *op) {
   if (isa<ttg::LocalLoadOp, ttg::LocalStoreOp, ttg::LocalGatherOp,
-          ttg::LocalScatterOp, ttng::TMEMLoadOp, ttng::TMEMStoreOp,
-          ttng::TMEMCopyOp, ttg::AsyncCopyGlobalToLocalOp, ttng::TMAOpInterface,
-          ttng::CLCLoadResultOp>(op)) {
+          ttg::LocalScatterOp, ttg::LocalAtomicScatterRMWOp, ttng::TMEMLoadOp,
+          ttng::TMEMStoreOp, ttng::TMEMCopyOp, ttg::AsyncCopyGlobalToLocalOp,
+          ttng::TMAOpInterface, ttng::CLCLoadResultOp>(op)) {
     return true;
   }
   if (isa<ttg::MBarrierOpInterface>(op)) {

--- a/lib/Dialect/TritonInstrument/Transforms/ConcurrencySanitizer.cpp
+++ b/lib/Dialect/TritonInstrument/Transforms/ConcurrencySanitizer.cpp
@@ -531,6 +531,12 @@ Value getMemEffectCTAs(ImplicitLocOpBuilder &b, Operation *op) {
                                            scatter.getValues().getType(),
                                            scatter.getAxis()));
   }
+  if (auto atomic = dyn_cast<ttg::LocalAtomicScatterRMWOp>(op)) {
+    return getLocalMemoryRecipientCTAs(
+        b, getLocalGatherScatterConversion(atomic.getDst().getType(),
+                                           atomic.getValues().getType(),
+                                           atomic.getAxis()));
+  }
   if (auto tmaLoad = dyn_cast<ttng::TMALoadLikeOpInterface>(op)) {
     if (tmaLoad.getMulticast())
       return getMulticastRecipientCTAs(b, tmaLoad.getResult());

--- a/python/test/gluon/test_consan.py
+++ b/python/test/gluon/test_consan.py
@@ -608,12 +608,12 @@ def test_cluster_barrier_does_not_publish_later_read(device, run_wrapper, monkey
         pytest.param("gather", True, id="gather-missing-barrier"),
         pytest.param("gather", False, id="gather-synchronized"),
         pytest.param("scatter", False, id="scatter-synchronized"),
+        pytest.param("atomic", False, id="atomic-synchronized"),
     ],
 )
-def test_local_gather_scatter_cross_cta_visibility(OP, FAILURE, device, run_wrapper, monkeypatch):
+def test_local_indexed_cross_cta_visibility(OP, FAILURE, device, run_wrapper, monkeypatch):
     if run_wrapper:
-        result = run_in_process(test_local_gather_scatter_cross_cta_visibility,
-                                (OP, FAILURE, device, False, monkeypatch))
+        result = run_in_process(test_local_indexed_cross_cta_visibility, (OP, FAILURE, device, False, monkeypatch))
         if FAILURE:
             assert_expected_cuda_failure(result.exc)
             assert "Buffer being accessed has outstanding reads" in result.driver_stderr_output
@@ -651,8 +651,12 @@ def test_local_gather_scatter_cross_cta_visibility(OP, FAILURE, device, run_wrap
                 result = smem.gather(peer_cols, axis=1)
                 # Order peer DSM reads and keep allocations alive until they finish.
                 ttgl.barrier(cluster=True)
-            else:
+            elif OP == "scatter":
                 smem.scatter(values, peer_cols, axis=1)
+                ttgl.barrier(cluster=True)
+                result = smem.load(layout)
+            else:
+                smem.atomic_scatter_add(values, peer_cols, axis=1)
                 ttgl.barrier(cluster=True)
                 result = smem.load(layout)
             ttgl.store(out + offsets, result)
@@ -662,7 +666,8 @@ def test_local_gather_scatter_cross_cta_visibility(OP, FAILURE, device, run_wrap
     layout = ttgl.BlockedLayout([1, 1], [1, 32], [1, 4], [1, 0], cga_layout=[[0, 1]])
     kernel[(1, )](inp, out, layout, OP=OP, FAILURE=FAILURE, num_warps=4, num_ctas=2)
     if not FAILURE:
-        expected = inp.reshape(2, 2, 16).flip(1).reshape(2, 32)
+        peer = inp.reshape(2, 2, 16).flip(1).reshape(2, 32)
+        expected = inp + peer if OP == "atomic" else peer
         torch.testing.assert_close(out, expected)
 
 

--- a/test/TritonGPU/consan.mlir
+++ b/test/TritonGPU/consan.mlir
@@ -162,6 +162,42 @@ module attributes {"ttg.num-ctas" = 2 : i32, "ttg.num-warps" = 4 : i32, ttg.shar
 
 // -----
 
+#local_atomic_shared = #ttg.swizzled_shared<{vec = 1, perPhase = 1, maxPhase = 1, order = [1, 0], CGALayout = [[0, 1]]}>
+#local_atomic_tma_shared = #ttg.nvmma_shared<{swizzlingByteWidth = 64, transposed = false, elementBitWidth = 32, CGALayout = [[0, 1]]}>
+#local_atomic_smem = #ttg.shared_memory
+#local_atomic_blocked = #ttg.blocked<{sizePerThread = [1, 1], threadsPerWarp = [1, 32], warpsPerCTA = [1, 4], order = [1, 0], CGALayout = [[0, 1]]}>
+module attributes {"ttg.num-ctas" = 2 : i32, "ttg.num-warps" = 4 : i32, ttg.shared = 1024 : i32, ttg.target = "cuda:90", ttg.tensor_memory_size = 0 : i32, "ttg.threads-per-warp" = 32 : i32, "ttg.total-num-warps" = 4 : i32} {
+  // CHECK-LABEL: @local_atomic_scatter_rmw_effects
+  tt.func public @local_atomic_scatter_rmw_effects(%out: !tt.tensordesc<8x32xi32, #local_atomic_tma_shared>) {
+    // The atomic is the allocation's only user, so this descriptor proves
+    // BufferRegion discovers its full destination.
+    // CHECK-DAG: tti.experimental_buffer_descriptors [0, 512], [512, 512], shared_mem : tensor<2xi64
+    %c0 = arith.constant 0 : i32
+    %indices = arith.constant dense<0> : tensor<8x32xi32, #local_atomic_blocked>
+    %values = arith.constant dense<1> : tensor<8x32xi32, #local_atomic_blocked>
+    // CHECK: %[[ATOMIC_DST:.*]] = ttg.local_alloc {allocation.offset = 0 : i32}
+    %dst = ttg.local_alloc {allocation.offset = 0 : i32} : () -> !ttg.memdesc<8x32xi32, #local_atomic_shared, #local_atomic_smem, mutable>
+    %proxy = ttg.local_alloc {allocation.offset = 512 : i32} : () -> !ttg.memdesc<8x32xi32, #local_atomic_tma_shared, #local_atomic_smem, mutable>
+
+    // Runtime indices along the sharded axis can target either CTA row.
+    // CHECK: %[[ATOMIC_CTAS:.*]] = arith.constant 3 : i32
+    // CHECK: %[[ATOMIC_BUF:.*]] = tti.experimental_memdesc_to_i32 %[[ATOMIC_DST]]
+    // CHECK: %[[ATOMIC_BYTES:.*]] = arith.constant 512 : i32
+    // CHECK: tt.call @__triton_consan_set_proxy_access{{.*}}(%[[ATOMIC_BUF]], %[[ATOMIC_BYTES]], {{.*}}%[[ATOMIC_CTAS]])
+    // CHECK: tt.call @__triton_consan_verify_write_visibility{{.*}}({{.*}}%[[ATOMIC_CTAS]]{{.*}})
+    // CHECK: tt.call @__triton_consan_verify_read_visibility{{.*}}({{.*}}%[[ATOMIC_CTAS]]{{.*}})
+    // CHECK: tt.call @__triton_consan_set_write_visibility{{.*}}({{.*}}%[[ATOMIC_CTAS]]{{.*}})
+    // CHECK: tt.call @__triton_consan_clear_read_visibility{{.*}}({{.*}}%[[ATOMIC_CTAS]]{{.*}})
+    // CHECK: ttg.local_atomic_scatter_rmw
+    %old = ttg.local_atomic_scatter_rmw add, %dst[%indices], %values {axis = 1 : i32} : (!ttg.memdesc<8x32xi32, #local_atomic_shared, #local_atomic_smem, mutable>, tensor<8x32xi32, #local_atomic_blocked>, tensor<8x32xi32, #local_atomic_blocked>) -> tensor<8x32xi32, #local_atomic_blocked>
+    // Enable proxy tracking without giving the atomic destination another user.
+    ttng.async_tma_copy_local_to_global %out[%c0, %c0] %proxy : !tt.tensordesc<8x32xi32, #local_atomic_tma_shared>, !ttg.memdesc<8x32xi32, #local_atomic_tma_shared, #local_atomic_smem, mutable>
+    tt.return
+  }
+}
+
+// -----
+
 #local_access_shared = #ttg.swizzled_shared<{vec = 1, perPhase = 1, maxPhase = 1, order = [1, 0], CGALayout = [[0, 1]]}>
 #local_access_smem = #ttg.shared_memory
 #local_access_blocked = #ttg.blocked<{sizePerThread = [1, 1], threadsPerWarp = [1, 32], warpsPerCTA = [1, 4], order = [1, 0], CGALayout = [[1, 0]]}>


### PR DESCRIPTION
Model `ttg.local_atomic_scatter_rmw` in ConSan as a barrier-tracked, generic-proxy write on the full destination buffer.