### PR TITLE
[TritonGPU] Fail cleanly when lowering global_scratch_alloc without an offset

### DIFF
--- a/lib/Conversion/TritonGPUToLLVM/MemoryOpToLLVM.cpp
+++ b/lib/Conversion/TritonGPUToLLVM/MemoryOpToLLVM.cpp
@@ -86,7 +86,14 @@ struct GlobalScratchAllocOpConversion
 
     auto opOffsetAttr = op->getAttrOfType<mlir::IntegerAttr>(
         "ttg.global_scratch_memory_offset");
-    assert(opOffsetAttr);
+    if (!opOffsetAttr) {
+      // The offset is assigned by -tritongpu-global-scratch-memory-allocation.
+      // If that pass has not run (e.g. it is currently absent from the AMD
+      // pipeline), report a clean legalization failure instead of aborting.
+      return rewriter.notifyMatchFailure(
+          op, "missing 'ttg.global_scratch_memory_offset'; run "
+              "-tritongpu-global-scratch-memory-allocation before lowering");
+    }
     auto opOffset = opOffsetAttr.getValue().getZExtValue();
 
     auto funcOp = op->getParentOfType<LLVM::LLVMFuncOp>();

--- a/test/Conversion/amd/global_scratch_alloc_missing_offset.mlir
+++ b/test/Conversion/amd/global_scratch_alloc_missing_offset.mlir
@@ -1,0 +1,15 @@
+// RUN: triton-opt %s -split-input-file -allow-unregistered-dialect --allocate-shared-memory --convert-triton-amdgpu-to-llvm=gfx-arch=gfx942 --verify-diagnostics
+
+// The lowering of `ttg.global_scratch_alloc` reads the offset assigned by the
+// `-tritongpu-global-scratch-memory-allocation` pass. That pass is not part of
+// the AMD pipeline (the op is only produced by NVIDIA device-side TMA), so when
+// such an op reaches lowering its offset attribute is absent. The conversion
+// must fail to legalize cleanly rather than abort on an assertion. See #9078.
+module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.target = "hip:gfx942", "ttg.threads-per-warp" = 64 : i32} {
+  tt.func public @global_scratch_alloc_missing_offset() {
+    // expected-error@+1 {{failed to legalize operation 'ttg.global_scratch_alloc' that was explicitly marked illegal}}
+    %0 = ttg.global_scratch_alloc {alignment = 8 : i32, nbytes = 100 : i32} : !tt.ptr<i8>
+    "use"(%0) : (!tt.ptr<i8>) -> ()
+    tt.return
+  }
+}


### PR DESCRIPTION
Fixes #9078.

`GlobalScratchAllocOpConversion` reads the `ttg.global_scratch_memory_offset` attribute (assigned by `-tritongpu-global-scratch-memory-allocation`) behind a bare `assert()`. When a `ttg.global_scratch_alloc` reaches lowering without that pass having run, the assert aborts the compiler (`SmallVector`/`opOffsetAttr` assertion → `abort`) instead of reporting an error.

As @peterbell10 noted on the issue, the allocation pass isn't in the AMD pipeline because `ttg.global_scratch_alloc` is only produced by NVIDIA device-side TMA. But an internal op reaching lowering without a required attribute should degrade to a clean diagnostic, not an ICE.

This returns a `notifyMatchFailure` (mirroring the existing `!funcOp` early-out a few lines down in the same pattern), so the op fails to legalize with a diagnostic instead of crashing.

**Before** (`triton-opt repro.mlir --convert-triton-amdgpu-to-llvm=gfx-arch=gfx950`):
```
triton-opt: .../MemoryOpToLLVM.cpp:89: ... Assertion `opOffsetAttr' failed.
```
**After:**
```
error: failed to legalize operation 'ttg.global_scratch_alloc' that was explicitly marked illegal
```

## Testing
- New `test/Conversion/amd/global_scratch_alloc_missing_offset.mlir` (`-verify-diagnostics`): the op fails to legalize cleanly, no crash.
- Full `test/` lit suite green; the existing `global_scratch_to_llvm.mlir` positive test (which runs the allocation pass, so the offset is present) is unaffected.
