### PR TITLE
[release/3.8.x] Revert the PR https://github.com/triton-lang/triton/pull/7067 for 3.8 release

### DIFF
--- a/test/Conversion/tritongpu_to_llvm.mlir
+++ b/test/Conversion/tritongpu_to_llvm.mlir
@@ -847,7 +847,7 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32} {
   // CHECK-LABEL: convert_layout_blocked_blocked
   tt.func @convert_layout_blocked_blocked(%arg0: tensor<32x32xf32, #blocked0>) {
     // CHECK: llvm.mlir.addressof @global_smem
-    // CHECK-COUNT-8: llvm.store
+    // CHECK-COUNT-8: llvm.inline_asm {{.*}} "st.shared::cta.b32
     // CHECK-: nvvm.barrier
     // CHECK-COUNT-8: llvm.load
     %0 = ttg.convert_layout %arg0 : tensor<32x32xf32, #blocked0> -> tensor<32x32xf32, #blocked1>
@@ -864,8 +864,8 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32} {
   // CHECK-LABEL: convert_layout_blocked_blocked_vec
   tt.func @convert_layout_blocked_blocked_vec(%arg0: tensor<32x32xf32, #blocked0>) {
     // CHECK: llvm.mlir.addressof @global_smem
-    // CHECK: llvm.store
-    // CHECK: llvm.store
+    // CHECK: llvm.inline_asm {{.*}} "st.shared::cta.v4.b32
+    // CHECK: llvm.inline_asm {{.*}} "st.shared::cta.v4.b32
     // CHECK: nvvm.barrier
     // CHECK: llvm.load
     // CHECK: llvm.load
@@ -900,11 +900,11 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 1 : i32} {
   // CHECK-LABEL: convert_layout_blocked_blocked_multi_rep
   tt.func @convert_layout_blocked_blocked_multi_rep(%arg0: tensor<32x32xf32, #blocked0>) {
     // CHECK: llvm.mlir.addressof @global_smem
-    // CHECK: llvm.store {{.*}} vector<4xi32>
+    // CHECK: llvm.inline_asm {{.*}} "st.shared::cta.v4.b32
     // CHECK: nvvm.bar.warp.sync
     // CHECK: nvvm.ldmatrix %{{.*}} : (!llvm.ptr<3>) -> !llvm.struct<(i32, i32, i32, i32)>
     // CHECK: nvvm.bar.warp.sync
-    // CHECK: llvm.store {{.*}} vector<4xi32>
+    // CHECK: llvm.inline_asm {{.*}} "st.shared::cta.v4.b32
     // CHECK: nvvm.bar.warp.sync
     // CHECK: nvvm.ldmatrix %{{.*}} : (!llvm.ptr<3>) -> !llvm.struct<(i32, i32, i32, i32)>
     %0 = ttg.convert_layout %arg0 : tensor<32x32xf32, #blocked0> -> tensor<32x32xf32, #blocked1>
@@ -932,10 +932,8 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 1 : i32} {
     %BB_DOT = ttg.local_load %BB : !ttg.memdesc<16x16xf16, #shared0, #smem> -> tensor<16x16xf16, #dot_operand_b>
     %cst0 = arith.constant dense<0.000000e+00> : tensor<16x16xf32, #mma0>
 
-    // CHECK: llvm.inline_asm
-    // CHECK-SAME: mma.sync.aligned.m16n8k16.row.col.f32.f16.f16.f32
-    // CHECK: llvm.inline_asm
-    // CHECK-SAME: mma.sync.aligned.m16n8k16.row.col.f32.f16.f16.f32
+    // CHECK: llvm.inline_asm {{.*}} "mma.sync.aligned.m16n8k16.row.col.f32.f16.f16.f32
+    // CHECK: llvm.inline_asm {{.*}} "mma.sync.aligned.m16n8k16.row.col.f32.f16.f16.f32
     %D = tt.dot %AA_DOT, %BB_DOT, %cst0 : tensor<16x16xf16, #dot_operand_a> * tensor<16x16xf16, #dot_operand_b> -> tensor<16x16xf32, #mma0>
 
     tt.return
@@ -962,10 +960,8 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 1 : i32} {
     %BB_DOT = ttg.local_load %BB : !ttg.memdesc<16x16xf16, #shared0, #smem> -> tensor<16x16xf16, #dot_operand_b>
     %cst0 = arith.constant dense<0.000000e+00> : tensor<16x16xf32, #mma0>
 
-    // CHECK: llvm.inline_asm
-    // CHECK-SAME: mma.sync.aligned.m16n8k16.row.col.f32.f16.f16.f32
-    // CHECK: llvm.inline_asm
-    // CHECK-SAME: mma.sync.aligned.m16n8k16.row.col.f32.f16.f16.f32
+    // CHECK: llvm.inline_asm {{.*}} "mma.sync.aligned.m16n8k16.row.col.f32.f16.f16.f32
+    // CHECK: llvm.inline_asm {{.*}} "mma.sync.aligned.m16n8k16.row.col.f32.f16.f16.f32
     %D = tt.dot %AA_DOT, %BB_DOT, %cst0 : tensor<16x16xf16, #dot_operand_a> * tensor<16x16xf16, #dot_operand_b> -> tensor<16x16xf32, #mma0>
 
     tt.return
@@ -990,10 +986,8 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 1 : i32} {
     %BB_DOT = ttg.local_load %BB : !ttg.memdesc<16x16xf16, #shared0, #smem> -> tensor<16x16xf16, #dot_operand_b>
     %cst0 = arith.constant dense<0.000000e+00> : tensor<16x16xf32, #mma0>
 
-    // CHECK: llvm.inline_asm
-    // CHECK-SAME: mma.sync.aligned.m16n8k16.row.col.f32.f16.f16.f32
-    // CHECK: llvm.inline_asm
-    // CHECK-SAME: mma.sync.aligned.m16n8k16.row.col.f32.f16.f16.f32
+    // CHECK: llvm.inline_asm {{.*}} "mma.sync.aligned.m16n8k16.row.col.f32.f16.f16.f32
+    // CHECK: llvm.inline_asm {{.*}} "mma.sync.aligned.m16n8k16.row.col.f32.f16.f16.f32
     %D = tt.dot %AA_DOT, %BB_DOT, %cst0 : tensor<16x16xf16, #dot_operand_a> * tensor<16x16xf16, #dot_operand_b> -> tensor<16x16xf32, #mma0>
 
     tt.return
@@ -1061,7 +1055,7 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32} {
   // CHECK: llvm.mlir.global external @global_smem
   // CHECK-LABEL: convert_layout_transpose
   tt.func @convert_layout_transpose(%arg0: tensor<128x128xf8E5M2, #blocked>) {
-    // CHECK-COUNT-128: llvm.store {{.*}} vector<1xi8>
+    // CHECK-COUNT-128: llvm.inline_asm {{.*}} "st.shared::cta.b8
     // CHECK: nvvm.barrier
     // CHECK-COUNT-32: llvm.load {{.*}} vector<4xi8>
     %0 = ttg.convert_layout %arg0 : tensor<128x128xf8E5M2, #blocked> -> tensor<128x128xf8E5M2, #blocked1>
@@ -1077,8 +1071,8 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32} {
   // CHECK: llvm.mlir.global external @global_smem
   // CHECK-LABEL: convert_layout_mmav2_block
   tt.func @convert_layout_mmav2_blocked(%arg0: tensor<32x16xf32, #mma>) {
-    // CHECK: llvm.store
-    // CHECK: llvm.store
+    // CHECK: llvm.inline_asm {{.*}} "st.shared::cta.v2.b32
+    // CHECK: llvm.inline_asm {{.*}} "st.shared::cta.v2.b32
     // CHECK: nvvm.barrier
     // CHECK: llvm.load
     %0 = ttg.convert_layout %arg0 : tensor<32x16xf32, #mma> -> tensor<32x16xf32, #blocked0>
@@ -1272,7 +1266,7 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 8 : i32} {
   // CHECK: llvm.mlir.global external @global_smem
   // CHECK-LABEL: convert_layout_mmav3_transpose
   tt.func @convert_layout_mmav3_transpose(%arg0: tensor<128x256xf8E5M2, #mma>) {
-    // CHECK-COUNT-8: llvm.store {{.*}} : vector<4xi32>
+    // CHECK-COUNT-8: llvm.inline_asm {{.*}} "st.shared::cta.v4.b32
     // CHECK: nvvm.barrier
     %0 = ttg.convert_layout %arg0 : tensor<128x256xf8E5M2, #mma> -> tensor<128x256xf8E5M2, #blocked>
     tt.return
@@ -1287,10 +1281,8 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 8 : i32} {
   // CHECK: llvm.mlir.global external @global_smem
   // CHECK-LABEL: convert_layout_blocked_shared
   tt.func @convert_layout_blocked_shared(%arg0: tensor<128x32xf32, #blocked0>) {
-    // CHECK: llvm.store
-    // CHECK-SAME: !llvm.ptr<3>
-    // CHECK: llvm.store
-    // CHECK-SAME: !llvm.ptr<3>
+    // CHECK: llvm.inline_asm {{.*}} "st.shared::cta.v4.b32
+    // CHECK: llvm.inline_asm {{.*}} "st.shared::cta.v4.b32
     %0 = ttg.local_alloc %arg0 : (tensor<128x32xf32, #blocked0>) -> !ttg.memdesc<128x32xf32, #shared0, #smem>
     tt.return
   }
@@ -1303,7 +1295,7 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 8 : i32} {
 module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 1 : i32} {
   // CHECK-LABEL: convert_blocked1d_to_slice0
   tt.func @convert_blocked1d_to_slice0(%src:tensor<32xi32, #blocked0>) {
-    // CHECK: llvm.store {{.*}} : vector<1xi32>
+    // CHECK: llvm.inline_asm {{.*}} "st.shared::cta.b32
     // CHECK: nvvm.bar.warp.sync
     // CHECK-COUNT-1: llvm.load {{.*}} -> vector<4xi32>
     %cvt = ttg.convert_layout %src : tensor<32xi32, #blocked0> -> tensor<32xi32, #ttg.slice<{dim = 0, parent = #blocked1}>>
@@ -1332,7 +1324,7 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 1 : i32} {
   // CHECK-LABEL: convert_blocked_to_blocked_ptr
   tt.func @convert_blocked_to_blocked_ptr(%src:tensor<32x!tt.ptr<f32>, #blocked0>) {
     // CHECK: llvm.ptrtoint
-    // CHECK: llvm.store
+    // CHECK: llvm.inline_asm {{.*}} "st.shared::cta.b64
     // CHECK: nvvm.bar.warp.sync
     // CHECK: llvm.inttoptr
     // CHECK-COUNT-4: llvm.insertvalue
@@ -1349,7 +1341,7 @@ module attributes {"ttg.num-ctas" = 2 : i32, "ttg.num-warps" = 1 : i32} {
   // Broadcast-only CGA bases should not force a cluster barrier.
   // CHECK-LABEL: convert_blocked_to_blocked_broadcast_cga
   tt.func @convert_blocked_to_blocked_broadcast_cga(%src: tensor<32xf32, #blocked0>) {
-    // CHECK: llvm.store
+    // CHECK: llvm.inline_asm {{.*}} "st.shared::cta.b32
     // CHECK: nvvm.bar.warp.sync
     // CHECK: llvm.load
     // CHECK-NOT: nvvm.cluster.arrive
@@ -1366,7 +1358,7 @@ module attributes {"ttg.num-ctas" = 2 : i32, "ttg.num-warps" = 1 : i32} {
 #dst = #ttg.linear<{register = [], lane = [[0], [0], [0], [0], [0]], warp = [], block = [[1]]}>
 module attributes {"ttg.num-ctas" = 2 : i32, "ttg.num-warps" = 1 : i32, ttg.target = "cuda:90", "ttg.threads-per-warp" = 32 : i32} {
   // CHECK-LABEL: convert_layout_loads_local_replica
-  // CHECK: llvm.store
+  // CHECK: llvm.inline_asm {{.*}} "st.shared::cta.v2.b32
   // CHECK: nvg.cluster_id
   // CHECK-NOT: nvvm.mapa
   // CHECK: llvm.load
@@ -1387,7 +1379,7 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 8 : i32} {
   // CHECK-LABEL: linear_layout_with_multiple_iterations
   tt.func @linear_layout_with_multiple_iterations(%src: tensor<8x4xbf16, #linear>) {
     %cvt = ttg.convert_layout %src : tensor<8x4xbf16, #linear> -> tensor<8x4xbf16, #linear1>
-    // CHECK-COUNT-1: llvm.store {{.*}} : vector<4xi16>
+    // CHECK-COUNT-1: llvm.inline_asm {{.*}} "st.shared::cta.v4.b16
     // CHECK: nvvm.barrier
     // CHECK-COUNT: llvm.load{{.*}}->vector<2xi16>
     tt.return
@@ -2030,7 +2022,7 @@ module attributes {"ttg.target" = "cuda:80", "ttg.num-ctas" = 1 : i32, "ttg.num-
 // -----
 
 //  CHECK-LABEL: reduce_md_slice
-//  CHECK: llvm.store {{.*}} vector<2xi32>
+//  CHECK: llvm.inline_asm {{.*}} "st.shared::cta.v2.b32
 //  CHECK: llvm.load {{.*}} vector<2xi32>
 #blocked = #ttg.blocked<{sizePerThread = [1, 1, 1], threadsPerWarp = [1, 1, 32], warpsPerCTA = [1, 2, 2], order = [2, 1, 0]}>
 #sliced = #ttg.slice<{dim = 2, parent = #blocked}>
@@ -2170,7 +2162,7 @@ module attributes {"ttg.target" = "cuda:90", "ttg.num-ctas" = 1 : i32, "ttg.num-
 #smem = #ttg.shared_memory
 module attributes {"ttg.target" = "cuda:90", "ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 8 : i32, "ttg.threads-per-warp" = 32 : i32} {
   // CHECK-LABEL: @vectorize_shmem_store
-  // CHECK-COUNT-4:  llvm.store {{.*}} {alignment = 16 : i64} : vector<4xi32>, !llvm.ptr<3>
+  // CHECK-COUNT-4: llvm.inline_asm {{.*}} "st.shared::cta.v4.b32
   tt.func public @vectorize_shmem_store(%block : tensor<64x64xi32, #blocked>) {
     %0 = ttg.local_alloc %block : (tensor<64x64xi32, #blocked>) -> !ttg.memdesc<64x64xi32, #shared, #smem>
     tt.return
@@ -2212,7 +2204,7 @@ module attributes {"ttg.target" = "cuda:80", "ttg.num-ctas" = 1 : i32, "ttg.num-
 #smem = #ttg.shared_memory
 module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.target = "cuda:90", "ttg.threads-per-warp" = 32 : i32} {
   // CHECK-LABEL: test_local_store
-  // CHECK: llvm.store
+  // CHECK: llvm.inline_asm {{.*}} "st.shared::cta.b32
   tt.func public @test_local_store(%arg0: tensor<1xf32, #blocked>) {
     %c0_i32 = arith.constant 0 : i32
     %0 = ttg.local_alloc {allocation.offset = 0 : i32} : () -> !ttg.memdesc<1xf32, #shared, #smem, mutable>
@@ -2246,7 +2238,7 @@ module attributes {"ttg.num-ctas" = 2 : i32, "ttg.num-warps" = 1 : i32, ttg.targ
   // CHECK-LABEL: local_store_uses_local_cta
   // CHECK: nvg.cluster_id
   // CHECK-NOT: nvvm.mapa
-  // CHECK: llvm.store
+  // CHECK: llvm.inline_asm {{.*}} "st.shared::cta.b32
   tt.func public @local_store_uses_local_cta(%arg0: tensor<2xf32, #reg>, %arg1: !ttg.memdesc<2xf32, #shared, #smem, mutable>) {
     ttg.local_store %arg0, %arg1 : tensor<2xf32, #reg> -> !ttg.memdesc<2xf32, #shared, #smem, mutable>
     tt.return
@@ -2260,7 +2252,7 @@ module attributes {"ttg.num-ctas" = 2 : i32, "ttg.num-warps" = 1 : i32, ttg.targ
 #smem = #ttg.shared_memory
 module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.target = "cuda:90", "ttg.threads-per-warp" = 32 : i32} {
   // CHECK-LABEL: test_local_store_subview
-  // CHECK: llvm.store
+  // CHECK: llvm.inline_asm {{.*}} "st.shared::cta.b32
   tt.func public @test_local_store_subview(%arg0: tensor<1xf32, #blocked>) {
     %c0_i32 = arith.constant 0 : i32
     %0 = ttg.local_alloc {allocation.offset = 0 : i32} : () -> !ttg.memdesc<1x1xf32, #shared, #smem, mutable>
@@ -2519,7 +2511,7 @@ tt.func @gather_in_shared(%arg0: tensor<16x4xi32, #blocked1>, %arg1: tensor<8x4x
   // CHECK-LABEL: gather_in_shared
   // CHECK: [[SMEM_BASE:%.*]] = llvm.mlir.addressof @global_smem
   // CHECK-NEXT: [[SMEM:%.*]] = llvm.getelementptr [[SMEM_BASE]]
-  // CHECK: store
+  // CHECK: llvm.inline_asm {{.*}} "st.shared::cta.b32
   // CHECK-NEXT: nvvm.barrier
 
   // CHECK: [[I0:%.*]] = llvm.extractvalue %arg0[0]

--- a/test/Conversion/tritongpu_to_llvm_hopper.mlir
+++ b/test/Conversion/tritongpu_to_llvm_hopper.mlir
@@ -301,11 +301,11 @@ module attributes {"ttg.target" = "cuda:90", "ttg.num-ctas" = 1 : i32, "ttg.num-
 // CHECK-LABEL: convert_mma_to_blocked
 module attributes {"ttg.target" = "cuda:90", "ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 8 : i32, "ttg.threads-per-warp" = 32 : i32} {
   tt.func @convert_mma_to_blocked(%a: tensor<128x256xf16, #mma>) {
-    // CHECK-COUNT-8: llvm.store
+    // CHECK-COUNT-8: llvm.inline_asm {{.*}} "st.shared::cta.v4.b32
     //          CHECK: nvvm.barrier
     // CHECK-COUNT-8: nvvm.ldmatrix
     //          CHECK: nvvm.barrier
-    // CHECK-COUNT-8: llvm.store
+    // CHECK-COUNT-8: llvm.inline_asm {{.*}} "st.shared::cta.v4.b32
     //          CHECK: nvvm.barrier
     // CHECK-COUNT-8: nvvm.ldmatrix
     %c = ttg.convert_layout %a : tensor<128x256xf16, #mma> -> tensor<128x256xf16, #blocked>
@@ -319,19 +319,19 @@ module attributes {"ttg.target" = "cuda:90", "ttg.num-ctas" = 1 : i32, "ttg.num-
 #linear = #ttg.linear<{register = [[0, 1], [0, 2], [0, 4], [0, 8], [0, 16]], lane = [[1, 0], [2, 0], [4, 0], [8, 0], [0, 32]], warp = [[32, 0], [64, 0], [16, 0]], block = []}>
 module attributes {"ttg.target" = "cuda:90", "ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 8 : i32, "ttg.threads-per-warp" = 32 : i32} {
   tt.func @convert_mma_to_blocked(%a: tensor<128x64xbf16, #linear>) {
-    // CHECK: llvm.store {{.*}} : vector<4xi32>
+    // CHECK: llvm.inline_asm {{.*}} "st.shared::cta.v4.b32
     // CHECK: nvvm.barrier
     // CHECK: llvm.load {{.*}} -> vector<4xi32>
     // CHECK: nvvm.barrier
-    // CHECK: llvm.store {{.*}} : vector<4xi32>
+    // CHECK: llvm.inline_asm {{.*}} "st.shared::cta.v4.b32
     // CHECK: nvvm.barrier
     // CHECK: llvm.load {{.*}} -> vector<4xi32>
     // CHECK: nvvm.barrier
-    // CHECK: llvm.store {{.*}} : vector<4xi32>
+    // CHECK: llvm.inline_asm {{.*}} "st.shared::cta.v4.b32
     // CHECK: nvvm.barrier
     // CHECK: llvm.load {{.*}} -> vector<4xi32>
     // CHECK: nvvm.barrier
-    // CHECK: llvm.store {{.*}} : vector<4xi32>
+    // CHECK: llvm.inline_asm {{.*}} "st.shared::cta.v4.b32
     // CHECK: nvvm.barrier
     // CHECK: llvm.load {{.*}} -> vector<4xi32>
     // CHECK-NOT: llvm.store
@@ -349,19 +349,19 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32} {
   // There are x4 the ldmatrix as there is broadcasting at a warp level
   // CHECK-LABEL: convert_blocked_to_dot_rhs
   tt.func @convert_blocked_to_dot_rhs(%a: tensor<64x64xf16, #blocked>) {
-    // CHECK-COUNT-1: llvm.store
+    // CHECK-COUNT-1: llvm.inline_asm {{.*}} "st.shared::cta.v4.b32
     //          CHECK: nvvm.barrier
     // CHECK-COUNT-4: nvvm.ldmatrix
     //          CHECK: nvvm.barrier
-    // CHECK-COUNT-1: llvm.store
+    // CHECK-COUNT-1: llvm.inline_asm {{.*}} "st.shared::cta.v4.b32
     //          CHECK: nvvm.barrier
     // CHECK-COUNT-4: nvvm.ldmatrix
     //          CHECK: nvvm.barrier
-    // CHECK-COUNT-1: llvm.store
+    // CHECK-COUNT-1: llvm.inline_asm {{.*}} "st.shared::cta.v4.b32
     //          CHECK: nvvm.barrier
     // CHECK-COUNT-4: nvvm.ldmatrix
     //          CHECK: nvvm.barrier
-    // CHECK-COUNT-1: llvm.store
+    // CHECK-COUNT-1: llvm.inline_asm {{.*}} "st.shared::cta.v4.b32
     //          CHECK: nvvm.barrier
     // CHECK-COUNT-4: nvvm.ldmatrix
     %b = ttg.convert_layout %a  : tensor<64x64xf16, #blocked> -> tensor<64x64xf16, #ttg.dot_op<{opIdx = 1, parent = #mma, kWidth = 2}>>

--- a/test/Conversion/tritonnvidiagpu_to_llvm.mlir
+++ b/test/Conversion/tritonnvidiagpu_to_llvm.mlir
@@ -621,7 +621,7 @@ module attributes {"ttg.num-ctas" = 2 : i32, "ttg.num-warps" = 4 : i32, "ttg.thr
   // CHECK: llvm.load {{.*}} : !llvm.ptr<3> -> i32
   // CHECK: nvvm.barrier
   // CHECK-NOT: nvvm.mapa
-  // CHECK: llvm.store {{.*}} : vector<1xi32>, !llvm.ptr<3>
+  // CHECK: llvm.inline_asm {{.*}} "st.shared::cta.b32
   // CHECK-NOT: nvvm.mapa
   // CHECK: llvm.return
   tt.func @local_gather_scatter_same_ownership(%out: !tt.ptr<i32>, %vals: tensor<2x32xi32, #local_gather_scatter_blocked>) {
@@ -642,7 +642,7 @@ module attributes {"ttg.num-ctas" = 2 : i32, "ttg.num-warps" = 4 : i32, "ttg.thr
   // CHECK: llvm.load {{.*}} : !llvm.ptr<3> -> i32
   // CHECK: nvvm.barrier
   // CHECK-NOT: nvvm.mapa
-  // CHECK: llvm.store {{.*}} : vector<1xi32>, !llvm.ptr<3>
+  // CHECK: llvm.inline_asm {{.*}} "st.shared::cta.b32
   // CHECK-NOT: nvvm.mapa
   // CHECK: llvm.return
   tt.func @local_gather_scatter_broadcast(%out: !tt.ptr<i32>, %vals: tensor<2x32xi32, #local_gather_scatter_blocked>) {
@@ -662,7 +662,7 @@ module attributes {"ttg.num-ctas" = 2 : i32, "ttg.num-warps" = 4 : i32, "ttg.thr
   // CHECK: llvm.load {{.*}} : !llvm.ptr<7> -> i32
   // CHECK: nvvm.barrier
   // CHECK: nvvm.mapa
-  // CHECK: llvm.store {{.*}} : vector<1xi32>, !llvm.ptr<7>
+  // CHECK: llvm.inline_asm {{.*}} "st.shared::cluster.b32
   tt.func @local_gather_scatter_cross_cta(%out: !tt.ptr<i32>, %vals: tensor<2x32xi32, #local_gather_scatter_blocked>) {
     %src = ttg.local_alloc {allocation.offset = [0 : i32, 256 : i32]} : () -> !ttg.memdesc<2x32xi32, #local_gather_scatter_shared_split, #ttg.shared_memory, mutable>
     %idx = arith.constant dense<0> : tensor<2x32xi32, #local_gather_scatter_blocked>

--- a/third_party/nvidia/lib/TritonNVIDIAGPUToLLVM/TargetInfo.cpp
+++ b/third_party/nvidia/lib/TritonNVIDIAGPUToLLVM/TargetInfo.cpp
@@ -307,23 +307,23 @@ void TargetInfo::storeDShared(RewriterBase &rewriter, Location loc, Value ptr,
                 .b(elemBitwidth);
   auto *ptrOpr = builder.newAddrOperand(ptr, "r");
 
-  if (isConstantTruePred(pred)) {
-    b.store(val, ptr, /*align=*/vec * elemBitwidth / 8);
-  } else {
-    PTXBuilder::Operand *valOpr;
-    std::string constraint = getConstraintForBitwidth(elemBitwidth);
-    if (vec > 1) {
-      SmallVector<std::pair<Value, std::string>> vecVals;
-      for (int i = 0; i < vec; i++) {
-        vecVals.push_back({b.extract_element(val, b.i32_val(i)), constraint});
-      }
-      valOpr = builder.newListOperand(vecVals);
-    } else {
-      valOpr = builder.newOperand(val, constraint);
+  PTXBuilder::Operand *valOpr;
+  std::string constraint = getConstraintForBitwidth(elemBitwidth);
+  if (vec > 1) {
+    SmallVector<std::pair<Value, std::string>> vecVals;
+    for (int i = 0; i < vec; i++) {
+      vecVals.push_back({b.extract_element(val, b.i32_val(i)), constraint});
     }
-    st(ptrOpr, valOpr).predicate(pred, "b");
-    builder.launch(rewriter, loc, void_ty(ctx));
+    valOpr = builder.newListOperand(vecVals);
+  } else {
+    valOpr = builder.newOperand(val, constraint);
   }
+  if (!isConstantTruePred(pred)) {
+    st(ptrOpr, valOpr).predicate(pred, "b");
+  } else {
+    st(ptrOpr, valOpr);
+  }
+  builder.launch(rewriter, loc, void_ty(ctx));
 }
 
 Value TargetInfo::loadDShared(RewriterBase &rewriter, Location loc, Value ptr,


### PR DESCRIPTION
## Summary
- Relanding the shared-store change from #9756 to `release/3.8.x`
- emit explicit `st.shared::cta` / `st.shared::cluster` PTX for unpredicated `storeDShared` paths instead of lowering them through `llvm.store`
- keep `loadDShared` and the remaining behavior from #7067/#7173 unchanged
- update conversion tests to expect inline-assembly shared stores

## Motivation
#9756 previously #7067 on `release/3.7.x` for an SM89 `ptxas` issue. For Triton 3.8 this is causing issue https://github.com/pytorch/pytorch/issues/188841 on H100: Triton 3.8 zeros part of `grad_weight` in an fp8 `_scaled_mm` backward pass.

We modify the expected PTX spelling because the 3.8 code explicitly distinguishes local CTA stores (`st.shared::cta`) from cluster stores (`st.shared::cluster`). Older `st.shared` syntax implied CTA-local shared memory.

## Test Plan
- `CUDA_VISIBLE_DEVICES=0 TORCHINDUCTOR_FORCE_DISABLE_CACHES=1 python fp8_repro.py`
  - `triton=3.8.0 compiled grad_weight zeros=0/512 max_abs_diff=0.0`
  - `OK`
- `lit -Dfilecheck=/home/warrdeng/.triton/llvm/llvm-46111560-ubuntu-x64-1/bin/FileCheck -v --filter='triton(nvidia)?gpu_to_llvm(_hopper)?\\.mlir' build/cmake.linux-x86_64-cpython-3.12/test`
  - `PASS: TRITON :: Conversion/tritonnvidiagpu_to_llvm.mlir`
  - `PASS: TRITON :: Conversion/amd/tritongpu_to_llvm.mlir`
  - `PASS: TRITON :: Conversion/tritongpu_to_llvm_hopper.mlir`
  - `PASS: TRITON :: Conversion/tritongpu_to_llvm.mlir`