### PR TITLE
[FRONTEND] Fix fp8 block-pointer load with padding_option="zero"

### DIFF
--- a/python/test/unit/language/test_block_pointer.py
+++ b/python/test/unit/language/test_block_pointer.py
@@ -65,6 +65,27 @@ def test_block_copy(dtypes_str, n, padding_option, boundary_check, device):
             assert torch.all(torch.isnan(b[n // 2:n]))
 
 
+@pytest.mark.parametrize("padding_option", ["zero", "nan"])
+def test_block_copy_fp8_padding(padding_option, device):
+    # Regression test for #10751: a padded block-pointer load of an fp8 tensor
+    # used to fail to compile ("cannot cast int32 ... to fp8e4nv") because the
+    # "zero" padding value was an int and there is no int -> fp8 cast.
+    check_type_supported(torch.float8_e4m3fn, device)
+    n = 256
+    a = torch.randn((n, ), device=device, dtype=torch.float32).to(torch.float8_e4m3fn)
+    b = torch.zeros((n, ), device=device, dtype=torch.float8_e4m3fn)
+    grid = lambda meta: (triton.cdiv(n, meta["BLOCK_SIZE"]), )
+    block_copy_kernel[grid](a_ptr=a, b_ptr=b, N=n, BLOCK_SIZE=64, PADDING_OPTION=padding_option, TEST_LOWER_BOUND=False,
+                            TEST_UPPER_BOUND=False)
+    # In-bounds half is copied exactly; the padded upper half takes the pad value.
+    assert torch.all(a[0:n // 2] == b[0:n // 2])
+    bf = b[n // 2:n].to(torch.float32)
+    if padding_option == "zero":
+        assert torch.all(bf == 0)
+    else:
+        assert torch.all(torch.isnan(bf))
+
+
 @triton.jit
 def matmul_no_scf_with_advance_kernel(  #
         a_ptr, b_ptr, c_ptr,  #

--- a/python/triton/language/core.py
+++ b/python/triton/language/core.py
@@ -1924,7 +1924,10 @@ class _block_ptr:
         if padding_option == "":
             generated_other = None
         elif padding_option == "zero":
-            generated_other = 0
+            # Use a float zero for floating-point pointees so the cast to the
+            # element type takes the supported float path; an int zero would try
+            # int -> fp8, which has no cast (see #10751).
+            generated_other = 0 if self.base.dtype.element_ty.is_int() else 0.0
         elif padding_option == "nan":
             if self.base.dtype.element_ty.is_int():
                 raise ValueError("Padding option `nan` is not supported for integer block pointers")


### PR DESCRIPTION
Fixes #10751.

After #9668 (python-only block pointers), a padded block-pointer load builds the padding value in Python. For `padding_option="zero"` the value was the int `0`, which `TritonSemantic.load` then casts to the pointee element type. There is no `int -> fp8` cast, so an fp8 block-pointer load with `padding_option="zero"` fails to compile:

```
cannot cast int32[constexpr[128], constexpr[128]] to <['128', '128'], fp8e4nv>
```

This is a regression: it worked on 3.7 (the padding was applied in C++ without an int cast), and `nan` padding + storing to fp8 both still work.

**Fix:** use a float zero for floating-point pointees so the cast takes the supported float path, mirroring the `padding_option="nan"` branch right below (which already special-cases integer vs. floating types). Integer pointees keep the int zero.

```python
elif padding_option == "zero":
    generated_other = 0 if self.base.dtype.element_ty.is_int() else 0.0
```

## Testing
- New `test_block_copy_fp8_padding[zero|nan]` in `test/unit/language/test_block_pointer.py` (the existing `test_block_copy` parametrization doesn't cover fp8, which is why this slipped through).
- Verified out-of-band that the padded region is **exactly zero** and the in-bounds region round-trips for `fp8e4nv / fp16 / bf16 / fp32 / int8 / int32` — the fix restores fp8 without changing any other dtype.
- Full `test_block_pointer.py` green (235 passed, 45 skipped).
