### PR TITLE
[Consan] Fix flaky multi-CTA CLC test

### DIFF
--- a/python/test/gluon/test_consan.py
+++ b/python/test/gluon/test_consan.py
@@ -373,7 +373,10 @@ def test_clc_result_visibility(FAILURE, device, run_wrapper, monkeypatch, num_ct
         result = run_in_process(test_clc_result_visibility, (FAILURE, device, False, monkeypatch, num_ctas))
         if FAILURE:
             assert_expected_cuda_failure(result.exc)
-            assert "Buffer being accessed has outstanding writes" in result.driver_stderr_output
+            assert any(msg in result.driver_stderr_output for msg in [
+                "Buffer being accessed has outstanding writes",
+                "Buffer being accessed has outstanding reads",
+            ])
         else:
             assert result.exc is None
             assert result.driver_stderr_output == ""


### PR DESCRIPTION
Close https://github.com/triton-lang/triton/issues/10584

The flaky failure has been observed for `num_ctas=4` and `FAILURE=True`. With `FAILURE=True`, the kernel does

```
clc.try_cancel(clc_result, clc_bar)
mbarrier.expect(clc_bar, 16)
mbarrier.wait(clc_bar, 0, pred=False) # wait is nop
response = clc.load_result(clc_result) # CLC write can still be in flight
```

So the test makes sure that Consan detects a premature load before the CLC write by the leader CTA completes. This is the meaning of the expected error msg `"Buffer being accessed has outstanding writes"`.

But occasionally, it can happen that a non-leader CTA  can issue CLC load before the leader CTA issues CLC write. When that happens, Consan emits a diagnostic `"Buffer being accessed has outstanding reads"`. Since this is different from the expected error msg, the test fails.

It seems this failure doesn't happen in practice with `num_ctas = 2`. But with `num_ctas = 4`, I can consistently reproduce this in my environment.