### PR TITLE
[Backend] Add ballot + popcount fast path for boolean warpscan

### DIFF
--- a/include/triton/Analysis/Utility.h
+++ b/include/triton/Analysis/Utility.h
@@ -116,6 +116,10 @@ public:
   explicit ScanLoweringHelper(triton::ScanOp op);
   // Return true if the lowering of the scan op is supported.
   bool isSupported();
+  // Return true iff the scan has a single integer operand known to take
+  // value in {0, 1}, and the combine region is an integer add of the two
+  // block arguments.
+  bool isSingleBooleanAddScan();
   // Return the number of elements per thread along axis dim.
   unsigned getAxisNumElementsPerThread();
   // Return the number of elements per thread along non-axis dims.

--- a/include/triton/Conversion/TritonGPUToLLVM/TargetInfoBase.h
+++ b/include/triton/Conversion/TritonGPUToLLVM/TargetInfoBase.h
@@ -77,6 +77,9 @@ public:
                           SmallVector<Value> &acc, triton::ReduceOp op,
                           unsigned reduceLaneIdMask) const = 0;
 
+  virtual Value warpPrefixPopcount(RewriterBase &rewriter, Location loc,
+                                   Value pred) const = 0;
+
   virtual std::string getMulhiFuncName(Type resultElementTy) const = 0;
   // Emits LLVM code with |rewriter| to print a message following the given
   // format from the device. |formatStrStart| is the pointer to the start of

--- a/lib/Analysis/Utility.cpp
+++ b/lib/Analysis/Utility.cpp
@@ -8,6 +8,7 @@
 #include "mlir/Dialect/LLVMIR/LLVMDialect.h"
 #include "mlir/IR/Dialect.h"
 #include "mlir/IR/Matchers.h"
+#include "mlir/IR/TypeUtilities.h"
 #include "mlir/Support/LLVM.h"
 #include "triton/Analysis/Allocation.h"
 #include "triton/Conversion/MLIRTypes.h"
@@ -19,6 +20,7 @@
 #include "triton/Tools/LinearLayout.h"
 #include "triton/Tools/Sys/GetEnv.h"
 #include "llvm/ADT/SmallSet.h"
+#include "llvm/ADT/TypeSwitch.h"
 
 namespace mlir {
 
@@ -475,6 +477,48 @@ unsigned ScanLoweringHelper::getNonAxisNumElementsPerThread() {
 }
 
 Region &ScanLoweringHelper::getCombineOp() { return scanOp.getCombineOp(); }
+
+// Depth-bounded recursive proof that `value` is in {0, 1}, walking up its
+// producer chain. Covers the common boolean mask creation and manipulation
+// patterns that reach scan lowering.
+static bool isKnownZeroOrOne(Value value, unsigned depth = 6) {
+  auto elemTy = getElementTypeOrSelf(value);
+  Operation *def = value.getDefiningOp();
+  if (elemTy.isInteger(1) ||
+      (def && (matchPattern(def, m_Zero()) || matchPattern(def, m_One()))))
+    return true;
+  if (!elemTy.isInteger() || depth == 0 || !def)
+    return false;
+  auto rec = [&](Value v) { return isKnownZeroOrOne(v, depth - 1); };
+  return llvm::TypeSwitch<Operation *, bool>(def)
+      .Case<arith::ExtUIOp, arith::TruncIOp>(
+          [&](auto cast) { return rec(cast.getIn()); })
+      .Case([&](arith::AndIOp andOp) {
+        return rec(andOp.getLhs()) || rec(andOp.getRhs());
+      })
+      .Case([&](arith::SelectOp sel) {
+        return rec(sel.getTrueValue()) && rec(sel.getFalseValue());
+      })
+      // Unary shape/layout manipulations that preserve values.
+      .Case<triton::SplatOp, triton::BroadcastOp, triton::ExpandDimsOp,
+            triton::ReshapeOp, triton::TransOp, triton::gpu::ConvertLayoutOp>(
+          [&](auto view) { return rec(view.getSrc()); })
+      .Default(false);
+}
+
+bool ScanLoweringHelper::isSingleBooleanAddScan() {
+  if (getNumOperands() != 1)
+    return false;
+  Block &block = getCombineOp().front();
+  if (block.getOperations().size() != 2)
+    return false;
+  Value arg0 = block.getArgument(0), arg1 = block.getArgument(1);
+  Value ret = block.getTerminator()->getOperand(0);
+  auto add = ret.getDefiningOp<arith::AddIOp>();
+  bool isSimpleAdd = add && ((add.getLhs() == arg0 && add.getRhs() == arg1) ||
+                             (add.getLhs() == arg1 && add.getRhs() == arg0));
+  return isSimpleAdd && isKnownZeroOrOne(scanOp->getOperand(0));
+}
 
 unsigned ScanLoweringHelper::getAxisNumThreadsPerWarpWithUniqueData() {
   return getEncoding().getThreadsPerWarp()[getAxis()];

--- a/lib/Conversion/TritonGPUToLLVM/ScanOpToLLVM.cpp
+++ b/lib/Conversion/TritonGPUToLLVM/ScanOpToLLVM.cpp
@@ -53,13 +53,39 @@ scanThreadContiguousElements(SmallVector<SmallVector<Value>> &srcValues,
 static void warpScan(SmallVector<SmallVector<Value>> &srcValues,
                      ConversionPatternRewriter &rewriter,
                      const TargetInfoBase &targetInfo,
-                     ScanLoweringHelper &helper, Value laneIdAxis) {
+                     ScanLoweringHelper &helper, Value laneIdAxis,
+                     unsigned iWarpSize) {
   Location loc = helper.getLoc();
   auto b = TritonLLVMOpBuilder(loc, rewriter);
   unsigned scanElementsPerThreads = helper.getAxisNumElementsPerThread();
   unsigned elementStride = helper.getAxisElementStride();
   unsigned threadStride = helper.getAxisThreadStride();
   unsigned scanDim = helper.getAxisNumThreadsPerWarpWithUniqueData();
+
+  if (scanElementsPerThreads == 1 && threadStride == 1 &&
+      scanDim == iWarpSize && (iWarpSize == 32 || iWarpSize == 64) &&
+      helper.isSingleBooleanAddScan()) {
+    // Fast path for boolean add scan, assuming full warp participation
+    // and 1 contiguous element per thread.
+    // Example (warpsize = 4):
+    //    starting bit:   [1],   [0],    [1],    [1]
+    //    ballot:         [1***],[10**], [101*], [1011]
+    //    popcnt:         [1],   [1],    [2],    [3]
+    auto elemTy = cast<IntegerType>(helper.getElementTypes()[0]);
+    unsigned width = elemTy.getWidth();
+    for (SmallVector<Value> &elem : srcValues) {
+      Value bit = b.icmp_ne(elem.front(), b.int_val(width, 0));
+      // NVIDIA: lane-masked ballot + popc, AMD: ballot + mbcnt
+      Value cnt = targetInfo.warpPrefixPopcount(rewriter, loc, bit);
+      if (width < 32)
+        cnt = b.trunc(elemTy, cnt);
+      else if (width > 32)
+        cnt = b.zext(elemTy, cnt);
+      elem.front() = cnt;
+    }
+    return;
+  }
+
   for (unsigned srcIndex = 0; srcIndex < srcValues.size(); srcIndex++) {
     unsigned elementIdx = (srcIndex / elementStride) % scanElementsPerThreads;
     // Only consider the last element of each contiguous chunk of elements.
@@ -496,8 +522,9 @@ ScanOpConversion::emitFastScan(triton::ScanOp op, triton::ScanOpAdaptor adaptor,
   // Scan contiguous elements in a thread and update `srcValues`.
   scanThreadContiguousElements(srcValues, rewriter, helper);
   // Apply warp level scan to the last element of each chunk of contiguous
-  // elements.
-  warpScan(srcValues, rewriter, targetInfo, helper, laneIdAxis);
+  // elements (ballot + popcount fast path for boolean add-scans, else the
+  // generic shuffle tree).
+  warpScan(srcValues, rewriter, targetInfo, helper, laneIdAxis, iWarpSize);
 
   if (axisNumWarps > 1) {
     // Slow path for the case where there are multiple warps with unique data on

--- a/test/Conversion/amd/scan_ballot_to_llvm.mlir
+++ b/test/Conversion/amd/scan_ballot_to_llvm.mlir
@@ -1,0 +1,45 @@
+// RUN: triton-opt %s -split-input-file --allocate-shared-memory --convert-triton-amdgpu-to-llvm=gfx-arch=gfx1030 --convert-builtin-func-to-llvm 2>&1 | FileCheck %s --check-prefix=WAVE32
+// RUN: triton-opt %s -split-input-file --allocate-shared-memory --convert-triton-amdgpu-to-llvm=gfx-arch=gfx942 --convert-builtin-func-to-llvm 2>&1 | FileCheck %s --check-prefix=WAVE64
+
+#l32 = #ttg.blocked<{sizePerThread = [1], threadsPerWarp = [32], warpsPerCTA = [1], order = [0]}>
+
+module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 1 : i32, ttg.target = "hip:gfx1030", "ttg.threads-per-warp" = 32 : i32} {
+
+// WAVE32-LABEL: @bool_extui_w32
+// WAVE32: rocdl.ballot
+// WAVE32: rocdl.mbcnt.lo
+// WAVE32-NOT: rocdl.mbcnt.hi
+tt.func private @bool_extui_w32(%arg0: tensor<32xi1, #l32>) -> tensor<32xi32, #l32> {
+  %b = arith.extui %arg0 : tensor<32xi1, #l32> to tensor<32xi32, #l32>
+  %0 = "tt.scan"(%b) <{axis = 0 : i32, reverse = false}> ({
+  ^bb0(%a: i32, %c: i32):
+    %1 = arith.addi %a, %c : i32
+    tt.scan.return %1 : i32
+  }) : (tensor<32xi32, #l32>) -> tensor<32xi32, #l32>
+  tt.return %0 : tensor<32xi32, #l32>
+}
+
+}
+
+// -----
+
+#l64 = #ttg.blocked<{sizePerThread = [1], threadsPerWarp = [64], warpsPerCTA = [1], order = [0]}>
+
+module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 1 : i32, ttg.target = "hip:gfx942", "ttg.threads-per-warp" = 64 : i32} {
+
+// WAVE32-LABEL: @bool_extui_w64
+// WAVE64-LABEL: @bool_extui_w64
+// WAVE64: rocdl.ballot
+// WAVE64: rocdl.mbcnt.lo
+// WAVE64: rocdl.mbcnt.hi
+tt.func private @bool_extui_w64(%arg0: tensor<64xi1, #l64>) -> tensor<64xi32, #l64> {
+  %b = arith.extui %arg0 : tensor<64xi1, #l64> to tensor<64xi32, #l64>
+  %0 = "tt.scan"(%b) <{axis = 0 : i32, reverse = false}> ({
+  ^bb0(%a: i32, %c: i32):
+    %1 = arith.addi %a, %c : i32
+    tt.scan.return %1 : i32
+  }) : (tensor<64xi32, #l64>) -> tensor<64xi32, #l64>
+  tt.return %0 : tensor<64xi32, #l64>
+}
+
+}

--- a/test/Conversion/scan_ballot_to_llvm.mlir
+++ b/test/Conversion/scan_ballot_to_llvm.mlir
@@ -1,0 +1,94 @@
+// RUN: triton-opt %s --allocate-shared-memory --convert-triton-gpu-to-llvm 2>&1 | FileCheck %s
+
+#l32    = #ttg.blocked<{sizePerThread = [1], threadsPerWarp = [32], warpsPerCTA = [1], order = [0]}>
+#l32x2  = #ttg.blocked<{sizePerThread = [1, 2], threadsPerWarp = [32, 1], warpsPerCTA = [1, 1], order = [0, 1]}>
+#l32x2t = #ttg.blocked<{sizePerThread = [1, 2], threadsPerWarp = [32, 1], warpsPerCTA = [1, 1], order = [1, 0]}>
+#l64x2  = #ttg.blocked<{sizePerThread = [2], threadsPerWarp = [32], warpsPerCTA = [1], order = [0]}>
+
+module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 1 : i32, ttg.target = "cuda:90", "ttg.threads-per-warp" = 32 : i32} {
+
+// CHECK-LABEL: @bool_extui
+// CHECK: %[[BALLOT:.*]] = nvvm.vote.sync ballot
+// CHECK: %[[MASKED:.*]] = llvm.and %[[BALLOT]],
+// CHECK: llvm.intr.ctpop(%[[MASKED]])
+tt.func private @bool_extui(%arg0: tensor<32xi1, #l32>) -> tensor<32xi32, #l32> {
+  %b = arith.extui %arg0 : tensor<32xi1, #l32> to tensor<32xi32, #l32>
+  %0 = "tt.scan"(%b) <{axis = 0 : i32, reverse = false}> ({
+  ^bb0(%a: i32, %c: i32):
+    %1 = arith.addi %a, %c : i32
+    tt.scan.return %1 : i32
+  }) : (tensor<32xi32, #l32>) -> tensor<32xi32, #l32>
+  tt.return %0 : tensor<32xi32, #l32>
+}
+
+// CHECK-LABEL: @bool_select_and
+// CHECK: llvm.intr.ctpop
+tt.func private @bool_select_and(%mask: tensor<32xi1, #l32>, %x: tensor<32xi32, #l32>) -> tensor<32xi32, #l32> {
+  %c0 = arith.constant dense<0> : tensor<32xi32, #l32>
+  %c1 = arith.constant dense<1> : tensor<32xi32, #l32>
+  %t = arith.andi %x, %c1 : tensor<32xi32, #l32>
+  %b = arith.select %mask, %t, %c0 : tensor<32xi1, #l32>, tensor<32xi32, #l32>
+  %0 = "tt.scan"(%b) <{axis = 0 : i32, reverse = false}> ({
+  ^bb0(%a: i32, %c: i32):
+    %1 = arith.addi %a, %c : i32
+    tt.scan.return %1 : i32
+  }) : (tensor<32xi32, #l32>) -> tensor<32xi32, #l32>
+  tt.return %0 : tensor<32xi32, #l32>
+}
+
+// width < 32: the i32 popcount is truncated to the scan's element type.
+// CHECK-LABEL: @bool_i1
+// CHECK: %[[CNT:.*]] = llvm.intr.ctpop
+// CHECK: llvm.trunc %[[CNT]] : i32 to i1
+tt.func private @bool_i1(%arg0: tensor<32xi1, #l32>) -> tensor<32xi1, #l32> {
+  %0 = "tt.scan"(%arg0) <{axis = 0 : i32, reverse = false}> ({
+  ^bb0(%a: i1, %c: i1):
+    %1 = arith.addi %a, %c : i1
+    tt.scan.return %1 : i1
+  }) : (tensor<32xi1, #l32>) -> tensor<32xi1, #l32>
+  tt.return %0 : tensor<32xi1, #l32>
+}
+
+// width > 32: the i32 popcount is zero-extended to the scan's element type.
+// CHECK-LABEL: @bool_extui_i64
+// CHECK: %[[CNT:.*]] = llvm.intr.ctpop
+// CHECK: llvm.zext %[[CNT]] : i32 to i64
+tt.func private @bool_extui_i64(%arg0: tensor<32xi1, #l32>) -> tensor<32xi64, #l32> {
+  %b = arith.extui %arg0 : tensor<32xi1, #l32> to tensor<32xi64, #l32>
+  %0 = "tt.scan"(%b) <{axis = 0 : i32, reverse = false}> ({
+  ^bb0(%a: i64, %c: i64):
+    %1 = arith.addi %a, %c : i64
+    tt.scan.return %1 : i64
+  }) : (tensor<32xi64, #l32>) -> tensor<32xi64, #l32>
+  tt.return %0 : tensor<32xi64, #l32>
+}
+
+// 2d scan with parallel elements per threads. The {0, 1} prover sees through convert_layout.
+// CHECK-LABEL: @convert_layout_2d
+// CHECK: llvm.intr.ctpop
+// CHECK: llvm.intr.ctpop
+tt.func private @convert_layout_2d(%arg0: tensor<32x2xi1, #l32x2t>) -> tensor<32x2xi32, #l32x2> {
+  %e = arith.extui %arg0 : tensor<32x2xi1, #l32x2t> to tensor<32x2xi32, #l32x2t>
+  %cl = ttg.convert_layout %e : tensor<32x2xi32, #l32x2t> -> tensor<32x2xi32, #l32x2>
+  %0 = "tt.scan"(%cl) <{axis = 0 : i32, reverse = false}> ({
+  ^bb0(%a: i32, %c: i32):
+    %1 = arith.addi %a, %c : i32
+    tt.scan.return %1 : i32
+  }) : (tensor<32x2xi32, #l32x2>) -> tensor<32x2xi32, #l32x2>
+  tt.return %0 : tensor<32x2xi32, #l32x2>
+}
+
+// The fast path should not fire with more than 1 contiguous element per thread.
+// CHECK-LABEL: @not_gate_layout
+// CHECK-NOT: llvm.intr.ctpop
+tt.func private @not_gate_layout(%arg0: tensor<64xi1, #l64x2>) -> tensor<64xi32, #l64x2> {
+  %b = arith.extui %arg0 : tensor<64xi1, #l64x2> to tensor<64xi32, #l64x2>
+  %0 = "tt.scan"(%b) <{axis = 0 : i32, reverse = false}> ({
+  ^bb0(%a: i32, %c: i32):
+    %1 = arith.addi %a, %c : i32
+    tt.scan.return %1 : i32
+  }) : (tensor<64xi32, #l64x2>) -> tensor<64xi32, #l64x2>
+  tt.return %0 : tensor<64xi32, #l64x2>
+}
+
+}

--- a/third_party/amd/lib/TritonAMDGPUToLLVM/TargetInfo.cpp
+++ b/third_party/amd/lib/TritonAMDGPUToLLVM/TargetInfo.cpp
@@ -186,6 +186,32 @@ StringRef TargetInfo::getAtomicSyncScope(MemSyncScope scope) const {
   llvm_unreachable("unknown memory synchronization scope");
 }
 
+Value TargetInfo::warpPrefixPopcount(RewriterBase &rewriter, Location loc,
+                                     Value pred) const {
+  auto b = TritonLLVMOpBuilder(loc, rewriter);
+  // Compute an inclusive prefix popcount by computing an exclusive prefix
+  // popcount with mbcnt, then adding back the lane's own predicate bit.
+  Value excl;
+  if (getWarpSize() == 32) {
+    Value mask = ballot(rewriter, loc, i32_ty, pred);
+    excl = ROCDL::MbcntLoOp::create(rewriter, loc, i32_ty, mask, b.i32_val(0),
+                                    /*arg_attrs=*/{}, /*res_attrs=*/{});
+  } else if (getWarpSize() == 64) {
+    // mbcnt_lo over the low 32 lanes, chained into mbcnt_hi for the high 32.
+    Value mask = ballot(rewriter, loc, i64_ty, pred);
+    Value maskLo = b.trunc(i32_ty, mask);
+    Value maskHi = b.trunc(i32_ty, b.lshr(mask, b.i64_val(32)));
+    Value lo = ROCDL::MbcntLoOp::create(rewriter, loc, i32_ty, maskLo,
+                                        b.i32_val(0), /*arg_attrs=*/{},
+                                        /*res_attrs=*/{});
+    excl = ROCDL::MbcntHiOp::create(rewriter, loc, i32_ty, maskHi, lo,
+                                    /*arg_attrs=*/{}, /*res_attrs=*/{});
+  } else {
+    llvm_unreachable("AMD warp size must be 32 or 64");
+  }
+  return b.add(excl, b.zext(i32_ty, pred));
+}
+
 void TargetInfo::barrier(Location loc, RewriterBase &rewriter,
                          triton::gpu::AddrSpace targets) const {
   auto b = TritonLLVMOpBuilder(loc, rewriter);

--- a/third_party/amd/lib/TritonAMDGPUToLLVM/TargetInfo.h
+++ b/third_party/amd/lib/TritonAMDGPUToLLVM/TargetInfo.h
@@ -82,6 +82,9 @@ public:
                   triton::ReduceOp op,
                   unsigned reduceLaneIdMask) const override;
 
+  Value warpPrefixPopcount(RewriterBase &rewriter, Location loc,
+                           Value pred) const override;
+
   std::string getMulhiFuncName(Type resultElementTy) const override;
 
   void printf(RewriterBase &rewriter, Value formatStrStart,

--- a/third_party/nvidia/lib/TritonNVIDIAGPUToLLVM/TargetInfo.cpp
+++ b/third_party/nvidia/lib/TritonNVIDIAGPUToLLVM/TargetInfo.cpp
@@ -165,6 +165,17 @@ StringRef TargetInfo::getAtomicSyncScope(MemSyncScope scope) const {
   llvm_unreachable("unknown memory synchronization scope");
 }
 
+Value TargetInfo::warpPrefixPopcount(RewriterBase &rewriter, Location loc,
+                                     Value pred) const {
+  auto b = TritonLLVMOpBuilder(loc, rewriter);
+  // Inclusive lane mask selecting lanes [0, laneId]: (-1) >> (31 - laneId).
+  Value laneId = getLaneId(rewriter, loc);
+  Value laneMask = b.lshr(b.i32_val(-1), b.sub(b.i32_val(31), laneId));
+  Value warpBits = ballot(rewriter, loc, i32_ty, pred);
+  return LLVM::CtPopOp::create(rewriter, loc, i32_ty,
+                               b.and_(warpBits, laneMask));
+}
+
 void TargetInfo::barrier(Location loc, RewriterBase &rewriter,
                          triton::gpu::AddrSpace targets) const {
   auto b = TritonLLVMOpBuilder(loc, rewriter);

--- a/third_party/nvidia/lib/TritonNVIDIAGPUToLLVM/TargetInfo.h
+++ b/third_party/nvidia/lib/TritonNVIDIAGPUToLLVM/TargetInfo.h
@@ -72,6 +72,9 @@ public:
                   triton::ReduceOp op,
                   unsigned reduceLaneIdMask) const override;
 
+  Value warpPrefixPopcount(RewriterBase &rewriter, Location loc,
+                           Value pred) const override;
+
   std::string getMulhiFuncName(Type resultElementTy) const override;
 
   void printf(RewriterBase &rewriter, Value formatStrStart,


### PR DESCRIPTION
Fixes #10693.

This patch adds a fast path to a warp-level scan when the combiner is a simple add (i.e. a cumsum) and the input can be proven to be in {0, 1}. The immediate motivation is the in-tree index compaction kernel (`python/triton_kernels/triton_kernels/compaction_details/_masked_compaction.py`), but in general cumsum on booleans is just counting and could come up anywhere.

This is implemented as a `TargetInfo` hook `warpPrefixPopcount` , triggered from the existing `warpScan` helper in `ScanOpToLLVM.cpp`. The NVIDIA backend lowers to a lane-masked `ballot` that gathers one bit from each participating thread into one word, keeping only the bits up to current thread, then `popc` to count the number of 1 bits in the word. The AMD backend have the `mbcnt` instruction that fuse the lane mask & popcount into one. 

The optimised version significantly improves on the generic 5 x (`shfl` + `icmp` + `add`) (10 × for i64 inputs) algorithm on a 32-thread warp scan. For 64 wide AMD wavefront that is 6 x `shfl` for i32 and 12 x for i64.

Benchmark Results

1. Single-warp `tl.cumsum` in a tight loop of 1024 reps

| GPU | i64 | i32 |
| --- | --- | --- |
| RTX 4090 | 7.17× | 4.27× |
| A100-80GB | 4.40× | 2.81× |
| H100 | 3.32× | 3.06× |
| B200 | 3.16× | 3.06× |
| MI300X (64wide) | 11.96× | 8.46× |

2. Compaction kernel, default config (`num_warps = 4`), 

(each entry shows speedup for dtype = i64 / i32)

| GPU | K=32 | K=64 | K=128 |
| --- | --- | --- | --- |
| RTX 4090 | 1.02× / 1.01× | 1.01× / 1.00× | 1.00× / 1.01× |
| A100-80GB | 1.09× / 1.06× | 1.11× / 1.10× | 1.02× / 1.05× |
| H100 | 1.00× / 1.00× | 1.04× / 1.05× | 1.00× / 1.00× |
| B200 | 1.04× / 1.02× | 1.04× / 1.10× | 1.02× / 1.00× |
| MI300X | — | 1.15× / 1.15× | 1.08× / 1.12× |

(Both benchmarks are run with grid size large enough to saturate the GPU.)

Limitations

This optimisation is gated at full warp scan, where each thread has exactly one contiguous element(more than 1 parallel element per thread is fine). Currently, 1D scan of size 256 or higher lowers to 4 contiguous element per thread, which may worth revisiting if this patch lands.

It is also possible to extend to sub-warp scans. I expect this to be profitable at least for the size 32 scans on AMD wave64, but for simplicity kept out from this PR.
<!---
The core Triton is a small number of people, and we receive many PRs (thank
you!).  To help us review your code more quickly, **if you are a new
contributor (less than 3 PRs merged) we ask that you complete the following
tasks and include the filled-out checklist in your PR description.**

Complete the following tasks before sending your PR, and replace `[ ]` with
`[x]` to indicate you have done them.
-->

# New contributor declaration
- [x] I am not making a trivial change, such as fixing a typo in a comment.

- [x] I have written a PR description following these
  [rules](https://cbea.ms/git-commit/#why-not-how).

- [x] I have run `pre-commit run --from-ref origin/main --to-ref HEAD`.

- Select one of the following.
  - [x] I have added tests.
    - `/test` for `lit` tests
    - `/unittest` for C++ tests
    - `/python/test` for end-to-end tests
  - [ ] This PR does not need a test because `FILL THIS IN`.

- Select one of the following.
  - [ ] I have not added any `lit` tests.
  - [x] The `lit` tests I have added follow these [best practices](https://mlir.llvm.org/getting_started/TestingGuide/#filecheck-best-practices),
    including the "tests should be minimal" section. (Usually running Python code
    and using the instructions it generates is not minimal.)
