### PR TITLE
[Allocator] Partition-aware allocation in calculateStarts

### DIFF
--- a/lib/Analysis/Allocation.cpp
+++ b/lib/Analysis/Allocation.cpp
@@ -517,6 +517,137 @@ private:
     LLVM_DEBUG(dumpAllocationSize());
   }
 
+  /// Partition eligibility check: returns true if placing
+  /// `buffer` at `proposedOffset` keeps it in different physical partition(s)
+  /// than all of its already-placed partition neighbors.
+  bool isPartitionEligible(BufferT *buffer, size_t proposedOffset,
+                           const DenseSet<BufferT *> &placed) {
+    if (partitionSize == 0 || buffer->neighbors.empty())
+      return true;
+
+    // Footprints are compared as inclusive partition-index ranges, so a buffer
+    // that straddles a partition boundary (placed at a non-partition-aligned
+    // offset, even if it is smaller than a partition) is handled correctly.
+    size_t aLo = getPartitionIndex(proposedOffset, partitionSize);
+    size_t aHi =
+        getPartitionIndex(proposedOffset + buffer->size - 1, partitionSize);
+    for (auto *neighbor : buffer->neighbors) {
+      if (!placed.contains(neighbor))
+        continue;
+      size_t bLo = getPartitionIndex(neighbor->offset, partitionSize);
+      size_t bHi = getPartitionIndex(neighbor->offset + neighbor->size - 1,
+                                     partitionSize);
+      // Inclusive partition ranges overlap -> shares a physical partition.
+      if (aLo <= bHi && bLo <= aHi)
+        return false;
+    }
+    return true;
+  }
+
+  /// First offset strictly above every physical partition `buf` occupies (the
+  /// start of the partition after the one holding its last byte).
+  size_t offsetPastPartitionOf(BufferT *buf) const {
+    return (getPartitionIndex(buf->offset + buf->size - 1, partitionSize) + 1) *
+           partitionSize;
+  }
+
+  /// Smallest offset at which `buf` lands in a partition free of all its
+  /// already-placed neighbors, i.e. the lowest offset where it is partition-
+  /// eligible. Returns 0 if it has no placed neighbors.
+  size_t partitionSafeOffset(BufferT *buf,
+                             const DenseSet<BufferT *> &placed) const {
+    size_t clearOffset = 0;
+    for (BufferT *neighbor : buf->neighbors)
+      if (placed.contains(neighbor))
+        clearOffset = std::max(clearOffset, offsetPastPartitionOf(neighbor));
+    return clearOffset;
+  }
+
+  // A slot of free shared memory: an offset and the liveness interval for
+  // which that offset is available. Keyed by offset so `begin()` is the lowest.
+  using TripleMapT = std::multimap<size_t, Interval<size_t>>;
+
+  /// Buffers whose whole liveness fits this slot's lifetime (`range`) and no
+  /// *other* open slot.
+  SmallVector<BufferT *> findTimeEligibleBuffers(ArrayRef<BufferT *> candidates,
+                                                 Interval<size_t> range,
+                                                 const TripleMapT &tripleMap) {
+    SmallVector<BufferT *> timeEligible;
+    for (auto *buffer : candidates) {
+      Interval<size_t> live = bufferRange.lookup(buffer);
+      if (!live.intersects(range))
+        continue;
+      if (llvm::none_of(tripleMap, [&](const auto &slot) {
+            return slot.second.intersects(live);
+          }))
+        timeEligible.push_back(buffer);
+    }
+    return timeEligible;
+  }
+
+  /// First time-eligible buffer that is also partition-eligible at this slot
+  /// (clear of its already-placed neighbors' partitions), or null if none. For
+  /// non-partitioned buffers this is simply the first candidate.
+  BufferT *firstPlaceable(ArrayRef<BufferT *> timeEligible, size_t offset,
+                          const DenseSet<BufferT *> &placed) {
+    for (auto *buffer : timeEligible) {
+      size_t alignedOffset = llvm::alignTo(offset, buffer->alignment);
+      if (isPartitionEligible(buffer, alignedOffset, placed))
+        return buffer;
+    }
+    return nullptr;
+  }
+
+  /// Give `buffer` this slot's offset and split the slot's remaining free space
+  /// around the buffer's liveness.
+  void placeBufferAndSplitSlot(BufferT *buffer, size_t offset,
+                               Interval<size_t> range, TripleMapT &tripleMap,
+                               DenseSet<BufferT *> &placed) {
+    // TODO(Keren): A buffer's size shouldn't be determined here, have to clean
+    // it up.
+    size_t alignOffset = buffer->setOffsetAligned(offset);
+    placed.insert(buffer);
+    Interval<size_t> live = bufferRange.lookup(buffer);
+    tripleMap.insert({alignOffset + buffer->size,
+                      Interval{std::max(range.start(), live.start()),
+                               std::min(range.end(), live.end())}});
+    // We could insert (range.start, live.start) or (range.start, live.end):
+    // both are correct, and the graph coloring pass resolves any overlap.
+    if (range.start() < live.start())
+      tripleMap.insert({offset, Interval{range.start(), live.end()}});
+    if (live.end() < range.end())
+      tripleMap.insert({offset, Interval{live.start(), range.end()}});
+  }
+
+  /// No candidate is partition-eligible in this slot; reopen it as a slot at
+  /// the smallest offset that clears some blocked buffer's neighbors, so that
+  /// buffer becomes eligible next iteration. This only ever raises the offset,
+  /// so the placement loop keeps making progress.
+  ///
+  ///     offset      shared memory     physical partition
+  ///
+  ///               +-----------------+
+  ///               |  requeued slot  |   part 1  -> re-added to tripleMap;
+  ///               |                 |              P1 placed here next iter
+  ///       65536   +=================+   <- first boundary past P0's end
+  ///               |  picked slot    |   part 0  -> P1 is time-eligible but
+  ///               |  (P1 blocked)   |              blocked by P0, so skipped
+  ///       40000   +-----------------+
+  ///               |  P0 (placed)    |   part 0  (P1's neighbor)
+  ///           0   +-----------------+
+  void reopenSlotPastBlocker(ArrayRef<BufferT *> timeEligible, size_t offset,
+                             Interval<size_t> range, TripleMapT &tripleMap,
+                             const DenseSet<BufferT *> &placed) {
+    assert(partitionSize > 0 &&
+           "candidates can only be blocked when partitioning is active");
+    size_t newSlotOffset = std::numeric_limits<size_t>::max();
+    for (BufferT *buffer : timeEligible)
+      newSlotOffset =
+          std::min(newSlotOffset, partitionSafeOffset(buffer, placed));
+    assert(newSlotOffset > offset && "reopened slot must make progress");
+    tripleMap.insert({newSlotOffset, range});
+  }
+
   /// Computes the initial shared memory offsets.
   void calculateStarts(const SmallVector<BufferT *> &buffers) {
     //  v = values in shared memory
@@ -536,43 +667,32 @@ private:
     // If the available triple's range is less than a given buffer range,
     // we won't know if there has been an overlap without using graph coloring.
     // Start -> Liveness Range
-    using TripleMapT = std::multimap<size_t, Interval<size_t>>;
     TripleMapT tripleMap;
     tripleMap.insert(std::make_pair(0, Interval<size_t>()));
     SmallVector<BufferT *> xBuffers = buffers;
+    DenseSet<BufferT *> placed;
     while (!xBuffers.empty()) {
+      // 1) Pick the lowest-offset available slot.
       auto tripleIt = tripleMap.begin();
-      auto offset = tripleIt->first;
-      auto range = tripleIt->second;
+      size_t offset = tripleIt->first;
+      Interval<size_t> range = tripleIt->second;
       tripleMap.erase(tripleIt);
-      auto bufferIt =
-          std::find_if(xBuffers.begin(), xBuffers.end(), [&](auto *buffer) {
-            auto xRange = bufferRange[buffer];
-            bool res = xRange.intersects(range);
-            for (const auto &val : tripleMap)
-              res = res &&
-                    !val.second.intersects(xRange); // only one buffer intersect
-            return res;
-          });
-      if (bufferIt != xBuffers.end()) {
-        auto buffer = *bufferIt;
-        auto xSize = buffer->size;
-        auto xRange = bufferRange.lookup(buffer);
-        // TODO(Keren): A buffer's size shouldn't be determined here, have to
-        // clean it up
-        size_t alignOffset = buffer->setOffsetAligned(offset);
-        tripleMap.insert({alignOffset + xSize,
-                          Interval{std::max(range.start(), xRange.start()),
-                                   std::min(range.end(), xRange.end())}});
-        // We could either insert (range.start, xRange.start) or (range.start,
-        // xRange.end), both are correct and determine the potential buffer
-        // offset, and the graph coloring algorithm will solve the interference,
-        // if any
-        if (range.start() < xRange.start())
-          tripleMap.insert({offset, Interval{range.start(), xRange.end()}});
-        if (xRange.end() < range.end())
-          tripleMap.insert({offset, Interval{xRange.start(), range.end()}});
-        xBuffers.erase(bufferIt);
+
+      // 2) Buffers that can occupy this slot for their whole lifetime.
+      SmallVector<BufferT *> timeEligible =
+          findTimeEligibleBuffers(xBuffers, range, tripleMap);
+
+      // 3) The first that is also clear of its placed neighbors' partitions.
+      BufferT *chosen = firstPlaceable(timeEligible, offset, placed);
+
+      // 4) Place it (splitting the slot); otherwise reopen a slot past a
+      // blocker so a buffer becomes eligible next iteration. If nothing was
+      // even time-eligible, the slot is simply dropped.
+      if (chosen) {
+        placeBufferAndSplitSlot(chosen, offset, range, tripleMap, placed);
+        xBuffers.erase(std::find(xBuffers.begin(), xBuffers.end(), chosen));
+      } else if (!timeEligible.empty()) {
+        reopenSlotPastBlocker(timeEligible, offset, range, tripleMap, placed);
       }
     }
     LLVM_DEBUG(dumpBuffers());
@@ -622,11 +742,14 @@ private:
       // same partitioned tensor are placed in different physical partitions.
       // Only check this when partitioning is enabled (partitionSize > 0).
       if (partitionSize > 0) {
+        size_t xLo = getPartitionIndex(x->offset, partitionSize);
+        size_t xHi = getPartitionIndex(x->offset + x->size - 1, partitionSize);
         for (auto *neighbor : x->neighbors) {
-          if (getPartitionIndex(x->offset, partitionSize) ==
-              getPartitionIndex(neighbor->offset, partitionSize)) {
+          size_t nLo = getPartitionIndex(neighbor->offset, partitionSize);
+          size_t nHi = getPartitionIndex(neighbor->offset + neighbor->size - 1,
+                                         partitionSize);
+          if (xLo <= nHi && nLo <= xHi)
             interference[x].insert(neighbor);
-          }
         }
       }
     }
@@ -679,11 +802,9 @@ private:
             std::find(x->neighbors.begin(), x->neighbors.end(), y) !=
             x->neighbors.end();
         if (isPartitionNeighbor && partitionSize > 0) {
-          // For partition neighbors, bump to the next partition
-          // boundary to ensure they are in different physical partitions
-          size_t nextPartitionStart =
-              (getPartitionIndex(y->offset, partitionSize) + 1) * partitionSize;
-          newOffset = std::max(newOffset, nextPartitionStart);
+          // For partition neighbors, bump past the neighbor's partition(s) so
+          // they end up in different physical partitions.
+          newOffset = std::max(newOffset, offsetPastPartitionOf(y));
         } else {
           // Regular interference - just move past the interfering buffer
           newOffset = std::max(newOffset, y->offset + y->size);

--- a/lib/Analysis/Allocation.cpp
+++ b/lib/Analysis/Allocation.cpp
@@ -526,8 +526,7 @@ private:
       return true;
 
     // Footprints are compared as inclusive partition-index ranges, so a buffer
-    // that straddles a partition boundary (placed at a non-partition-aligned
-    // offset, even if it is smaller than a partition) is handled correctly.
+    // that straddles a partition boundary is handled correctly.
     size_t aLo = getPartitionIndex(proposedOffset, partitionSize);
     size_t aHi =
         getPartitionIndex(proposedOffset + buffer->size - 1, partitionSize);
@@ -542,110 +541,6 @@ private:
         return false;
     }
     return true;
-  }
-
-  /// First offset strictly above every physical partition `buf` occupies (the
-  /// start of the partition after the one holding its last byte).
-  size_t offsetPastPartitionOf(BufferT *buf) const {
-    return (getPartitionIndex(buf->offset + buf->size - 1, partitionSize) + 1) *
-           partitionSize;
-  }
-
-  /// Smallest offset at which `buf` lands in a partition free of all its
-  /// already-placed neighbors, i.e. the lowest offset where it is partition-
-  /// eligible. Returns 0 if it has no placed neighbors.
-  size_t partitionSafeOffset(BufferT *buf,
-                             const DenseSet<BufferT *> &placed) const {
-    size_t clearOffset = 0;
-    for (BufferT *neighbor : buf->neighbors)
-      if (placed.contains(neighbor))
-        clearOffset = std::max(clearOffset, offsetPastPartitionOf(neighbor));
-    return clearOffset;
-  }
-
-  // A slot of free shared memory: an offset and the liveness interval for
-  // which that offset is available. Keyed by offset so `begin()` is the lowest.
-  using TripleMapT = std::multimap<size_t, Interval<size_t>>;
-
-  /// Buffers whose whole liveness fits this slot's lifetime (`range`) and no
-  /// *other* open slot.
-  SmallVector<BufferT *> findTimeEligibleBuffers(ArrayRef<BufferT *> candidates,
-                                                 Interval<size_t> range,
-                                                 const TripleMapT &tripleMap) {
-    SmallVector<BufferT *> timeEligible;
-    for (auto *buffer : candidates) {
-      Interval<size_t> live = bufferRange.lookup(buffer);
-      if (!live.intersects(range))
-        continue;
-      if (llvm::none_of(tripleMap, [&](const auto &slot) {
-            return slot.second.intersects(live);
-          }))
-        timeEligible.push_back(buffer);
-    }
-    return timeEligible;
-  }
-
-  /// First time-eligible buffer that is also partition-eligible at this slot
-  /// (clear of its already-placed neighbors' partitions), or null if none. For
-  /// non-partitioned buffers this is simply the first candidate.
-  BufferT *firstPlaceable(ArrayRef<BufferT *> timeEligible, size_t offset,
-                          const DenseSet<BufferT *> &placed) {
-    for (auto *buffer : timeEligible) {
-      size_t alignedOffset = llvm::alignTo(offset, buffer->alignment);
-      if (isPartitionEligible(buffer, alignedOffset, placed))
-        return buffer;
-    }
-    return nullptr;
-  }
-
-  /// Give `buffer` this slot's offset and split the slot's remaining free space
-  /// around the buffer's liveness.
-  void placeBufferAndSplitSlot(BufferT *buffer, size_t offset,
-                               Interval<size_t> range, TripleMapT &tripleMap,
-                               DenseSet<BufferT *> &placed) {
-    // TODO(Keren): A buffer's size shouldn't be determined here, have to clean
-    // it up.
-    size_t alignOffset = buffer->setOffsetAligned(offset);
-    placed.insert(buffer);
-    Interval<size_t> live = bufferRange.lookup(buffer);
-    tripleMap.insert({alignOffset + buffer->size,
-                      Interval{std::max(range.start(), live.start()),
-                               std::min(range.end(), live.end())}});
-    // We could insert (range.start, live.start) or (range.start, live.end):
-    // both are correct, and the graph coloring pass resolves any overlap.
-    if (range.start() < live.start())
-      tripleMap.insert({offset, Interval{range.start(), live.end()}});
-    if (live.end() < range.end())
-      tripleMap.insert({offset, Interval{live.start(), range.end()}});
-  }
-
-  /// No candidate is partition-eligible in this slot; reopen it as a slot at
-  /// the smallest offset that clears some blocked buffer's neighbors, so that
-  /// buffer becomes eligible next iteration. This only ever raises the offset,
-  /// so the placement loop keeps making progress.
-  ///
-  ///     offset      shared memory     physical partition
-  ///
-  ///               +-----------------+
-  ///               |  requeued slot  |   part 1  -> re-added to tripleMap;
-  ///               |                 |              P1 placed here next iter
-  ///       65536   +=================+   <- first boundary past P0's end
-  ///               |  picked slot    |   part 0  -> P1 is time-eligible but
-  ///               |  (P1 blocked)   |              blocked by P0, so skipped
-  ///       40000   +-----------------+
-  ///               |  P0 (placed)    |   part 0  (P1's neighbor)
-  ///           0   +-----------------+
-  void reopenSlotPastBlocker(ArrayRef<BufferT *> timeEligible, size_t offset,
-                             Interval<size_t> range, TripleMapT &tripleMap,
-                             const DenseSet<BufferT *> &placed) {
-    assert(partitionSize > 0 &&
-           "candidates can only be blocked when partitioning is active");
-    size_t newSlotOffset = std::numeric_limits<size_t>::max();
-    for (BufferT *buffer : timeEligible)
-      newSlotOffset =
-          std::min(newSlotOffset, partitionSafeOffset(buffer, placed));
-    assert(newSlotOffset > offset && "reopened slot must make progress");
-    tripleMap.insert({newSlotOffset, range});
   }
 
   /// Computes the initial shared memory offsets.
@@ -667,6 +562,7 @@ private:
     // If the available triple's range is less than a given buffer range,
     // we won't know if there has been an overlap without using graph coloring.
     // Start -> Liveness Range
+    using TripleMapT = std::multimap<size_t, Interval<size_t>>;
     TripleMapT tripleMap;
     tripleMap.insert(std::make_pair(0, Interval<size_t>()));
     SmallVector<BufferT *> xBuffers = buffers;
@@ -678,21 +574,91 @@ private:
       Interval<size_t> range = tripleIt->second;
       tripleMap.erase(tripleIt);
 
-      // 2) Buffers that can occupy this slot for their whole lifetime.
-      SmallVector<BufferT *> timeEligible =
-          findTimeEligibleBuffers(xBuffers, range, tripleMap);
+      // 2) Buffers whose whole liveness fits this slot's liveness range
+      // and no other open slot.
+      SmallVector<BufferT *> livenessEligible;
+      for (auto *buffer : xBuffers) {
+        Interval<size_t> live = bufferRange.lookup(buffer);
+        if (!live.intersects(range))
+          continue;
+        if (llvm::none_of(tripleMap, [&](const auto &slot) {
+              return slot.second.intersects(live);
+            }))
+          livenessEligible.push_back(buffer);
+      }
 
-      // 3) The first that is also clear of its placed neighbors' partitions.
-      BufferT *chosen = firstPlaceable(timeEligible, offset, placed);
+      // 3) The first that is also clear of its placed neighbors' partitions
+      // (for non-partitioned buffers, simply the first candidate).
+      BufferT *chosen = nullptr;
+      for (auto *buffer : livenessEligible) {
+        size_t alignedOffset = llvm::alignTo(offset, buffer->alignment);
+        if (isPartitionEligible(buffer, alignedOffset, placed)) {
+          chosen = buffer;
+          break;
+        }
+      }
 
-      // 4) Place it (splitting the slot); otherwise reopen a slot past a
-      // blocker so a buffer becomes eligible next iteration. If nothing was
-      // even time-eligible, the slot is simply dropped.
+      // 4) Give `chosen` this slot's offset and split the slot's remaining free
+      // space around its liveness. If nothing was partition-eligible, reopen
+      // the slot at the smallest offset that clears some conflicting buffer's
+      // neighbors so that buffer becomes eligible next iteration; this only
+      // ever raises the offset, so the loop keeps making progress. If nothing
+      // was even liveness-eligible, the slot is simply dropped.
+      //
+      //     offset      shared memory     physical partition
+      //
+      //               +-----------------+
+      //               |  requeued slot  |   part 1  -> re-added to tripleMap;
+      //               |                 |              P1 placed here next iter
+      //       65536   +=================+   <- first boundary past P0's end
+      //               |  picked slot    |   part 0  -> P1 is liveness-eligible
+      //               |  (P1 blocked)   |              but blocked by P0,
+      //               |                 |              so skipped.
+      //       40000   +-----------------+
+      //               |  P0 (placed)    |   part 0  (P1's neighbor)
+      //           0   +-----------------+
       if (chosen) {
-        placeBufferAndSplitSlot(chosen, offset, range, tripleMap, placed);
+        // TODO(Keren): A buffer's size shouldn't be determined here, have to
+        // clean it up
+        size_t alignOffset = chosen->setOffsetAligned(offset);
+        placed.insert(chosen);
+        Interval<size_t> xRange = bufferRange.lookup(chosen);
+        tripleMap.insert({alignOffset + chosen->size,
+                          Interval{std::max(range.start(), xRange.start()),
+                                   std::min(range.end(), xRange.end())}});
+        // We could either insert (range.start, xRange.start) or (range.start,
+        // xRange.end), both are correct and determine the potential buffer
+        // offset, and the graph coloring algorithm will solve the interference,
+        // if any
+        if (range.start() < xRange.start())
+          tripleMap.insert({offset, Interval{range.start(), xRange.end()}});
+        if (xRange.end() < range.end())
+          tripleMap.insert({offset, Interval{xRange.start(), range.end()}});
         xBuffers.erase(std::find(xBuffers.begin(), xBuffers.end(), chosen));
-      } else if (!timeEligible.empty()) {
-        reopenSlotPastBlocker(timeEligible, offset, range, tripleMap, placed);
+      } else if (!livenessEligible.empty()) {
+        assert(partitionSize > 0 &&
+               "candidates can only be blocked when partitioning is active");
+        size_t newSlotOffset = std::numeric_limits<size_t>::max();
+        for (BufferT *buffer : livenessEligible) {
+          // Smallest offset at which `buffer` lands in a partition free of all
+          // its already-placed neighbors. Stays 0 if it has no placed
+          // neighbors.
+          size_t clearOffset = 0;
+          for (BufferT *neighbor : buffer->neighbors)
+            if (placed.contains(neighbor)) {
+              // First offset strictly above every physical partition `neighbor`
+              // occupies.
+              size_t pastNeighbor =
+                  (getPartitionIndex(neighbor->offset + neighbor->size - 1,
+                                     partitionSize) +
+                   1) *
+                  partitionSize;
+              clearOffset = std::max(clearOffset, pastNeighbor);
+            }
+          newSlotOffset = std::min(newSlotOffset, clearOffset);
+        }
+        assert(newSlotOffset > offset && "reopened slot must make progress");
+        tripleMap.insert({newSlotOffset, range});
       }
     }
     LLVM_DEBUG(dumpBuffers());
@@ -804,7 +770,10 @@ private:
         if (isPartitionNeighbor && partitionSize > 0) {
           // For partition neighbors, bump past the neighbor's partition(s) so
           // they end up in different physical partitions.
-          newOffset = std::max(newOffset, offsetPastPartitionOf(y));
+          size_t offsetPastY =
+              (getPartitionIndex(y->offset + y->size - 1, partitionSize) + 1) *
+              partitionSize;
+          newOffset = std::max(newOffset, offsetPastY);
         } else {
           // Regular interference - just move past the interfering buffer
           newOffset = std::max(newOffset, y->offset + y->size);

--- a/test/Analysis/test-allocation-partitioned.mlir
+++ b/test/Analysis/test-allocation-partitioned.mlir
@@ -22,6 +22,11 @@
 // 64x32xf16 = 4096 bytes total, 8 pieces = 512 bytes each, partition buffer = 512 * 2 = 1024 bytes
 #PARTITIONED_4P_2G = #ttg.partitioned_shared<{numPartitions = 4, numGroups = 2, partitionDim = 0, partitionLayout = #A_SHARED}>
 
+// Swizzled (unpadded) 2/4 partitions, 1 group. Piece size depends purely on the
+// tensor shape, which the tests below use to land on / straddle 64KB boundaries.
+#PARTITIONED_2P_1G_SW = #ttg.partitioned_shared<{numPartitions = 2, numGroups = 1, partitionDim = 0, partitionLayout = #A_SHARED}>
+#PARTITIONED_4P_1G_SW = #ttg.partitioned_shared<{numPartitions = 4, numGroups = 1, partitionDim = 0, partitionLayout = #A_SHARED}>
+
 #smem = #ttg.shared_memory
 
 module attributes {"ttg.num-warps" = 4 : i32, "ttg.num-ctas" = 1 : i32} {
@@ -83,8 +88,9 @@ tt.func @partitioned_4p_2g() {
 // expected-remark @below {{partitioned_with_regular}}
 // expected-remark @below {{size = 67640}}
 tt.func @partitioned_with_regular() {
-  // Non-partitioned allocation: 1024 bytes (placed after the partitioned buffer in partition 0)
-  // expected-remark @below {{offset = 4224, size = 1024}}
+  // Non-partitioned allocation: 1024 bytes, packed into partition 0 right after
+  // the partitioned buffer's first piece.
+  // expected-remark @below {{offset = 2112, size = 1024}}
   %regular = ttg.local_alloc : () -> !ttg.memdesc<32x16xf16, #A_SHARED, #ttg.shared_memory, mutable>
   // Partitioned allocation: 2 partition buffers of 2104 bytes each
   // expected-remark @below {{offset = 0, size = 2104}}
@@ -104,9 +110,10 @@ tt.func @multiple_partitioned() {
   // expected-remark @below {{offset = 0, size = 2104}}
   // expected-remark @below {{offset = 65536, size = 2104}}
   %alloc1 = ttg.local_alloc : () -> !ttg.memdesc<64x32xf16, #PARTITIONED_2P_2G, #ttg.shared_memory, mutable>
-  // Second partitioned allocation: 2 partition buffers of 2048 bytes each
-  // Both allocations are live, so they must be at different offsets within each physical partition
-  // expected-remark @below {{offset = 4224, size = 2048}}
+  // Second partitioned allocation: 2 partition buffers of 2048 bytes each.
+  // Co-locates alloc2's pieces in the same partitions as alloc1's pieces
+  // (alloc2 piece 0 packed right after alloc1 piece 0 in partition 0, etc).
+  // expected-remark @below {{offset = 2112, size = 2048}}
   // expected-remark @below {{offset = 67648, size = 2048}}
   %alloc2 = ttg.local_alloc : () -> !ttg.memdesc<64x32xf16, #PARTITIONED_2P_4G, #ttg.shared_memory, mutable>
   // Use both allocations so they overlap in liveness
@@ -128,6 +135,91 @@ tt.func @partitioned_reuse() {
   // expected-remark @below {{offset = 0, size = 2048}}
   // expected-remark @below {{offset = 65536, size = 2048}}
   %alloc2 = ttg.local_alloc : () -> !ttg.memdesc<64x32xf16, #PARTITIONED_2P_4G, #ttg.shared_memory, mutable>
+  tt.return
+}
+
+// Degeneration: with partition-size set but no partitioned tensors the analysis
+// must behave exactly like the classic first-fit allocator (no partition holes).
+// expected-remark @below {{regular_only}}
+// expected-remark @below {{size = 2048}}
+tt.func @regular_only() {
+  // Two live 1024-byte buffers packed back-to-back.
+  // expected-remark @below {{offset = 0, size = 1024}}
+  %a = ttg.local_alloc : () -> !ttg.memdesc<32x16xf16, #A_SHARED, #ttg.shared_memory, mutable>
+  // expected-remark @below {{offset = 1024, size = 1024}}
+  %b = ttg.local_alloc : () -> !ttg.memdesc<32x16xf16, #A_SHARED, #ttg.shared_memory, mutable>
+  "use"(%a) : (!ttg.memdesc<32x16xf16, #A_SHARED, #ttg.shared_memory, mutable>) -> ()
+  "use"(%b) : (!ttg.memdesc<32x16xf16, #A_SHARED, #ttg.shared_memory, mutable>) -> ()
+  tt.return
+}
+
+// Three 2-partition tensors (2048-byte pieces), all live.
+// The partitioned first stage packs every tensor's piece 0 into partition 0 and
+// every piece 1 into partition 1, so the whole thing fits in 2 physical
+// (71680 bytes).
+// expected-remark @below {{three_tensor_colocation}}
+// expected-remark @below {{size = 71680}}
+tt.func @three_tensor_colocation() {
+  // partition 0: pieces at 0, 2048, 4096 ; partition 1: at 65536, 67584, 69632.
+  // expected-remark @below {{offset = 0, size = 2048}}
+  // expected-remark @below {{offset = 65536, size = 2048}}
+  %a = ttg.local_alloc : () -> !ttg.memdesc<64x32xf16, #PARTITIONED_2P_1G_SW, #ttg.shared_memory, mutable>
+  // expected-remark @below {{offset = 2048, size = 2048}}
+  // expected-remark @below {{offset = 67584, size = 2048}}
+  %b = ttg.local_alloc : () -> !ttg.memdesc<64x32xf16, #PARTITIONED_2P_1G_SW, #ttg.shared_memory, mutable>
+  // expected-remark @below {{offset = 4096, size = 2048}}
+  // expected-remark @below {{offset = 69632, size = 2048}}
+  %c = ttg.local_alloc : () -> !ttg.memdesc<64x32xf16, #PARTITIONED_2P_1G_SW, #ttg.shared_memory, mutable>
+  "use"(%a) : (!ttg.memdesc<64x32xf16, #PARTITIONED_2P_1G_SW, #ttg.shared_memory, mutable>) -> ()
+  "use"(%b) : (!ttg.memdesc<64x32xf16, #PARTITIONED_2P_1G_SW, #ttg.shared_memory, mutable>) -> ()
+  "use"(%c) : (!ttg.memdesc<64x32xf16, #PARTITIONED_2P_1G_SW, #ttg.shared_memory, mutable>) -> ()
+  tt.return
+}
+
+// Piece size exactly one physical partition (2048x32xf16 = 131072 bytes total,
+// 65536 per partition buffer): the two neighbors land on partition boundaries
+// 0 and 65536 with no straddle and no wasted space.
+// expected-remark @below {{partition_exact_boundary}}
+// expected-remark @below {{size = 131072}}
+tt.func @partition_exact_boundary() {
+  // expected-remark @below {{offset = 0, size = 65536}}
+  // expected-remark @below {{offset = 65536, size = 65536}}
+  %a = ttg.local_alloc : () -> !ttg.memdesc<2048x32xf16, #PARTITIONED_2P_1G_SW, #ttg.shared_memory, mutable>
+  "use"(%a) : (!ttg.memdesc<2048x32xf16, #PARTITIONED_2P_1G_SW, #ttg.shared_memory, mutable>) -> ()
+  tt.return
+}
+
+// Partition pieces that straddle a physical-partition boundary must
+// still be separated correctly and packed tightly. %a's two pieces (40000 bytes)
+// go to partitions 0 and 1; %b's four pieces fill the gaps, with piece 0
+// straddling partitions 0/1 (allowed: %b is not a neighbor of %a).
+// expected-remark @below {{partitioned_straddle}}
+// expected-remark @below {{size = 302144}}
+tt.func @partitioned_straddle() {
+  // expected-remark @below {{offset = 0, size = 40000}}
+  // expected-remark @below {{offset = 80000, size = 40000}}
+  %a = ttg.local_alloc : () -> !ttg.memdesc<1250x32xf16, #PARTITIONED_2P_1G_SW, #ttg.shared_memory, mutable>
+  // expected-remark @below {{offset = 40000, size = 40000}}
+  // expected-remark @below {{offset = 131072, size = 40000}}
+  // expected-remark @below {{offset = 196608, size = 40000}}
+  // expected-remark @below {{offset = 262144, size = 40000}}
+  %b = ttg.local_alloc : () -> !ttg.memdesc<2500x32xf16, #PARTITIONED_4P_1G_SW, #ttg.shared_memory, mutable>
+  "use"(%a) : (!ttg.memdesc<1250x32xf16, #PARTITIONED_2P_1G_SW, #ttg.shared_memory, mutable>) -> ()
+  "use"(%b) : (!ttg.memdesc<2500x32xf16, #PARTITIONED_4P_1G_SW, #ttg.shared_memory, mutable>) -> ()
+  tt.return
+}
+
+// Two neighbors each larger than one physical partition (96000 bytes
+// -> each spans ~1.5 partitions). Comparing only start partitions would leave
+// them sharing a partition; the footprint-based conflict check separates them
+// (partitions 0-1 and 2-3).
+// expected-remark @below {{two_big_neighbors}}
+// expected-remark @below {{size = 227072}}
+tt.func @two_big_neighbors() {
+  // expected-remark @below {{offset = 0, size = 96000}}
+  // expected-remark @below {{offset = 131072, size = 96000}}
+  %a = ttg.local_alloc : () -> !ttg.memdesc<3000x32xf16, #PARTITIONED_2P_1G_SW, #ttg.shared_memory, mutable>
+  "use"(%a) : (!ttg.memdesc<3000x32xf16, #PARTITIONED_2P_1G_SW, #ttg.shared_memory, mutable>) -> ()
   tt.return
 }
 }


### PR DESCRIPTION
This PR implements following:

- The allocator’s initial placement phase (calculateStarts) was refactored to be partition-aware. It now tracks already  placed buffers, checks whether a candidate partition buffer would overlap any placed partition neighbors’ physical partition range, and reopens blocked slots at the next offset that clears the neighbor’s occupied partition footprint.
- Refactored calculateStarts into named helpers. The previously monolithic placement loop is now broken into focused methods.
The main loop is now a clean 4-step: pick lowest slot → find time-eligible → find first placeable → place-or-reopen.
- Buffers of the same partitioned tensor are now compared by their full inclusive partition-index range [Lo, Hi] (from offset through offset + size - 1) instead of just the starting partition
- Added appropriate lit tests in test/Analysis/test-allocation-partitioned.mlir.