### PR TITLE
Infer slice encodings for reshapes

### DIFF
--- a/lib/Dialect/TritonGPU/IR/Dialect.cpp
+++ b/lib/Dialect/TritonGPU/IR/Dialect.cpp
@@ -3546,6 +3546,50 @@ struct TritonGPUInferLayoutInterface
     if (allowReorder && dstEnc)
       if (!isExpensiveView(srcShape, srcEnc, dstShape, dstEnc))
         return success();
+
+    Attribute inferredDstEnc;
+    if (failed(inferReshapeOpEncodingImpl(srcShape, srcEnc, dstShape,
+                                          inferredDstEnc, loc)))
+      return failure();
+    // If the inferred encoding is equivalent to the encoding hint in dstEnc,
+    // prefer the hint. Otherwise, set dstEnc to the inferred encoding.
+    if (!isa_and_nonnull<DistributedEncodingTrait>(dstEnc) ||
+        failed(verifyLayoutsAreEqual(dstShape, inferredDstEnc, dstEnc,
+                                     /*loc=*/{},
+                                     /*ignoreRegBroadcast=*/false)))
+      dstEnc = inferredDstEnc;
+    return success();
+  }
+
+  LogicalResult inferReshapeOpEncodingImpl(ArrayRef<int64_t> srcShape,
+                                           Attribute srcEnc,
+                                           ArrayRef<int64_t> dstShape,
+                                           Attribute &dstEnc,
+                                           std::optional<Location> loc) const {
+    // If this reshape just introduces a new size 1 dimension, and the source is
+    // a slice along that dimension, use the slice parent as the result
+    // encoding.
+    if (auto sliceEnc = dyn_cast<SliceEncodingAttr>(srcEnc)) {
+      if (sliceEnc.paddedShape(srcShape) == dstShape) {
+        dstEnc = sliceEnc.getParent();
+        return success();
+      }
+    }
+    // Inverse of the above. If the reshape removes a size 1 dimension, the
+    // destination can just be a slice of the source.
+    // TODO: Consider extending this and the case above to support chained
+    // slices for cases where multiple size 1 dimensions are removed or added.
+    if (srcShape.size() == dstShape.size() + 1) {
+      for (unsigned dim = 0; dim < srcShape.size(); ++dim) {
+        if (srcShape[dim] == 1 &&
+            srcShape.take_front(dim) == dstShape.take_front(dim) &&
+            srcShape.drop_front(dim + 1) == dstShape.drop_front(dim)) {
+          dstEnc = SliceEncodingAttr::get(
+              srcEnc.getContext(), dim, cast<DistributedEncodingTrait>(srcEnc));
+          return success();
+        }
+      }
+    }
     auto result =
         inferReshapeOpLegacyEncoding(srcShape, srcEnc, dstShape, dstEnc);
     if (succeeded(result)) {

--- a/lib/Dialect/TritonGPU/IR/Dialect.cpp
+++ b/lib/Dialect/TritonGPU/IR/Dialect.cpp
@@ -3630,6 +3630,53 @@ struct TritonGPUInferLayoutInterface
     if (allowReorder && dstEnc)
       if (!isExpensiveView(srcShape, srcEnc, dstShape, dstEnc))
         return success();
+
+    Attribute inferredDstEnc;
+    if (failed(inferReshapeOpEncodingImpl(srcShape, srcEnc, dstShape,
+                                          inferredDstEnc, loc)))
+      return failure();
+    // If the inferred encoding is equivalent to the encoding hint in dstEnc,
+    // prefer the hint. Otherwise, set dstEnc to the inferred encoding.
+    if (!isa_and_nonnull<DistributedEncodingTrait>(dstEnc) ||
+        failed(verifyLayoutsAreEqual(dstShape, inferredDstEnc, dstEnc,
+                                     /*loc=*/{},
+                                     /*ignoreRegBroadcast=*/false)))
+      dstEnc = inferredDstEnc;
+    return success();
+  }
+
+  LogicalResult inferReshapeOpEncodingImpl(ArrayRef<int64_t> srcShape,
+                                           Attribute srcEnc,
+                                           ArrayRef<int64_t> dstShape,
+                                           Attribute &dstEnc,
+                                           std::optional<Location> loc) const {
+    // If this reshape just introduces a new size 1 dimension, and the source is
+    // a slice along that dimension, use the slice parent as the result
+    // encoding.
+    if (auto sliceEnc = dyn_cast<SliceEncodingAttr>(srcEnc)) {
+      if (sliceEnc.paddedShape(srcShape) == dstShape &&
+          !isExpensiveView(srcShape, srcEnc, dstShape, sliceEnc.getParent())) {
+        dstEnc = sliceEnc.getParent();
+        return success();
+      }
+    }
+    // Inverse of the above. If the reshape removes a size 1 dimension, the
+    // destination can just be a slice of the source.
+    // TODO: Consider extending this and the case above to support chained
+    // slices for cases where multiple size 1 dimensions are removed or added.
+    if (isa<DistributedEncodingTrait>(srcEnc) &&
+        srcShape.size() == dstShape.size() + 1) {
+      for (unsigned dim = 0; dim < srcShape.size(); ++dim) {
+        if (srcShape[dim] == 1 &&
+            srcShape.take_front(dim) == dstShape.take_front(dim) &&
+            srcShape.drop_front(dim + 1) == dstShape.drop_front(dim)) {
+          dstEnc = SliceEncodingAttr::get(
+              srcEnc.getContext(), dim, cast<DistributedEncodingTrait>(srcEnc));
+          if (!isExpensiveView(srcShape, srcEnc, dstShape, dstEnc))
+            return success();
+        }
+      }
+    }
     auto result =
         inferReshapeOpLegacyEncoding(srcShape, srcEnc, dstShape, dstEnc);
     if (succeeded(result)) {

--- a/python/test/gluon/test_frontend.py
+++ b/python/test/gluon/test_frontend.py
@@ -1559,8 +1559,8 @@ def test_reshape_linear_layout():
     # CHECK: [[LINEAR:#.*]] = #ttg.linear
     layout: ttgl.constexpr = ttgl.BlockedLayout([1, 1], [32, 1], [4, 1], [0, 1])
     x = ttgl.full([128, 1], 1, ttgl.int32, layout=layout)
-    # CHECK: tt.reshape %{{.*}} : tensor<128x1xi32, [[BLOCKED]]> -> tensor<128xi32, [[LINEAR]]>
-    x.reshape([128])
+    # CHECK: tt.reshape %{{.*}} : tensor<128x1xi32, [[BLOCKED]]> -> tensor<64x2xi32, [[LINEAR]]>
+    x.reshape([64, 2])
 
 
 @filecheck_test

--- a/python/test/gluon/test_frontend.py
+++ b/python/test/gluon/test_frontend.py
@@ -2381,8 +2381,8 @@ def test_reshape_linear_layout():
     # CHECK: [[LINEAR:#.*]] = #ttg.linear
     layout: ttgl.constexpr = ttgl.BlockedLayout([1, 1], [32, 1], [4, 1], [0, 1])
     x = ttgl.full([128, 1], 1, ttgl.int32, layout=layout)
-    # CHECK: tt.reshape %{{.*}} : tensor<128x1xi32, [[BLOCKED]]> -> tensor<128xi32, [[LINEAR]]>
-    x.reshape([128])
+    # CHECK: tt.reshape %{{.*}} : tensor<128x1xi32, [[BLOCKED]]> -> tensor<64x2xi32, [[LINEAR]]>
+    x.reshape([64, 2])
 
 
 @filecheck_test

--- a/test/TritonGPU/amd/accelerate-amd-matmul-mfma-decompose-scaled-dot.mlir
+++ b/test/TritonGPU/amd/accelerate-amd-matmul-mfma-decompose-scaled-dot.mlir
@@ -11,14 +11,14 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.targ
       %arg2: tensor<32x2x!tt.ptr<i8>, #blocked1>,
       %arg3: tensor<32x32x!tt.ptr<f32>, #blocked>
     ) {
-    // CHECK: %[[CST:.*]] = arith.constant dense<7> : tensor<2x32xi16, #linear{{.*}}>
+    // CHECK: %[[CST:.*]] = arith.constant dense<7> : tensor<2x32xi16, #ttg.slice<{dim = 1, parent = #blocked{{.*}}}>>
     // CHECK: %[[B:.*]] = ttg.convert_layout %{{.*}} : tensor<64x32xf8E4M3FN, #blocked{{.*}}> -> tensor<64x32xf8E4M3FN, #ttg.dot_op<{opIdx = 1, parent = #mma, kWidth = 8}>>
     // CHECK: %[[S:.*]] = ttg.convert_layout %{{.*}} : tensor<32x2xi8, #blocked{{.*}}> -> tensor<32x2xi8, #linear{{.*}}>
     // CHECK: %[[TS:.*]] = tt.trans %[[S]] {order = array<i32: 1, 0>}
     // CHECK: %[[ES:.*]] = arith.extui %[[TS]]
     // CHECK: %[[SHS:.*]] = arith.shli %[[ES]], %[[CST]]
-    // CHECK: %[[BS:.*]] = tt.bitcast %[[SHS]] : tensor<2x32xi16, #linear{{.*}}> -> tensor<2x32xbf16, #linear{{.*}}>
-    // CHECK: %[[EPS:.*]] = tt.reshape %[[BS]] efficient_layout : tensor<2x32xbf16, #linear{{.*}}> -> tensor<2x1x32xbf16, #linear{{.*}}>
+    // CHECK: %[[BS:.*]] = tt.bitcast %[[SHS]] : tensor<2x32xi16, #ttg.slice<{dim = 1, parent = #blocked{{.*}}}>> -> tensor<2x32xbf16, #ttg.slice<{dim = 1, parent = #blocked{{.*}}}>>
+    // CHECK: %[[EPS:.*]] = tt.reshape %[[BS]] efficient_layout : tensor<2x32xbf16, #ttg.slice<{dim = 1, parent = #blocked{{.*}}}>> -> tensor<2x1x32xbf16, #linear{{.*}}>
     // CHECK: %[[BCS:.*]] = tt.broadcast %[[EPS]] : tensor<2x1x32xbf16, #linear{{.*}}> -> tensor<2x32x32xbf16, #linear{{.*}}>
     // CHECK: %[[RTBCS:.*]] = tt.reshape %[[BCS]] : tensor<2x32x32xbf16, #linear{{.*}}> -> tensor<64x32xbf16, #ttg.dot_op<{opIdx = 1, parent = #mma, kWidth = 8}>>
     // CHECK: %[[UB:.*]] = amdg.scaled_upcast_fp8 %[[B]] scale %[[RTBCS]] : tensor<64x32xf8E4M3FN, #ttg.dot_op<{opIdx = 1, parent = #mma, kWidth = 8}>>, tensor<64x32xbf16, #ttg.dot_op<{opIdx = 1, parent = #mma, kWidth = 8}>> -> tensor<64x32xbf16, #ttg.dot_op<{opIdx = 1, parent = #mma, kWidth = 8}>>
@@ -73,14 +73,14 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.targ
       %arg2: tensor<32x2x!tt.ptr<i8>, #blocked1>,
       %arg3: tensor<32x32x!tt.ptr<f32>, #blocked>
     ) {
-    // CHECK: %[[CST:.*]] = arith.constant dense<7> : tensor<2x32xi16, #linear{{.*}}>
+    // CHECK: %[[CST:.*]] = arith.constant dense<7> : tensor<2x32xi16, #ttg.slice<{dim = 1, parent = #linear{{.*}}}>>
     // CHECK: %[[B:.*]] = ttg.convert_layout %{{.*}} : tensor<32x32xi8, #blocked{{.*}}> -> tensor<32x32xi8, #ttg.dot_op<{opIdx = 1, parent = #mma, kWidth = 4}>>
     // CHECK: %[[S:.*]] = ttg.convert_layout %{{.*}} : tensor<32x2xi8, #blocked{{.*}}> -> tensor<32x2xi8, #linear{{.*}}>
     // CHECK: %[[TS:.*]] = tt.trans %[[S]] {order = array<i32: 1, 0>}
     // CHECK: %[[ES:.*]] = arith.extui %[[TS]]
     // CHECK: %[[SHS:.*]] = arith.shli %[[ES]], %[[CST]]
-    // CHECK: %[[BS:.*]] = tt.bitcast %[[SHS]] : tensor<2x32xi16, #linear{{.*}}> -> tensor<2x32xbf16, #linear{{.*}}>
-    // CHECK: %[[EPS:.*]] = tt.reshape %[[BS]] efficient_layout : tensor<2x32xbf16, #linear{{.*}}> -> tensor<2x1x32xbf16, #linear{{.*}}>
+    // CHECK: %[[BS:.*]] = tt.bitcast %[[SHS]] : tensor<2x32xi16, #ttg.slice<{dim = 1, parent = #linear{{.*}}}>> -> tensor<2x32xbf16, #ttg.slice<{dim = 1, parent = #linear{{.*}}}>>
+    // CHECK: %[[EPS:.*]] = tt.reshape %[[BS]] efficient_layout : tensor<2x32xbf16, #ttg.slice<{dim = 1, parent = #linear{{.*}}}>> -> tensor<2x1x32xbf16, #linear{{.*}}>
     // CHECK: %[[BCS:.*]] = tt.broadcast %[[EPS]] : tensor<2x1x32xbf16, #linear{{.*}}> -> tensor<2x32x32xbf16, #linear{{.*}}>
     // CHECK: %[[RTBCS:.*]] = tt.reshape %[[BCS]] : tensor<2x32x32xbf16, #linear{{.*}}> -> tensor<64x32xbf16, #ttg.dot_op<{opIdx = 1, parent = #mma, kWidth = 8}>>
     // CHECK: %[[UB:.*]] = amdg.scaled_upcast_fp4 %[[B]] scale %[[RTBCS]] {axis = 0 : i32} : tensor<32x32xi8, #ttg.dot_op<{opIdx = 1, parent = #mma, kWidth = 4}>>, tensor<64x32xbf16, #ttg.dot_op<{opIdx = 1, parent = #mma, kWidth = 8}>> -> tensor<64x32xbf16, #ttg.dot_op<{opIdx = 1, parent = #mma, kWidth = 8}>>

--- a/test/TritonGPU/amd/accelerate-amd-matmul-mfma-decompose-scaled-dot.mlir
+++ b/test/TritonGPU/amd/accelerate-amd-matmul-mfma-decompose-scaled-dot.mlir
@@ -11,14 +11,14 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.targ
       %arg2: tensor<32x2x!tt.ptr<i8>, #blocked1>,
       %arg3: tensor<32x32x!tt.ptr<f32>, #blocked>
     ) {
-    // CHECK: %[[CST:.*]] = arith.constant dense<7> : tensor<2x32xi16, #linear{{.*}}>
+    // CHECK: %[[CST:.*]] = arith.constant dense<7> : tensor<2x32xi16, #ttg.slice<{dim = 1, parent = #blocked{{.*}}}>>
     // CHECK: %[[B:.*]] = ttg.convert_layout %{{.*}} : tensor<64x32xf8E4M3FN, #blocked{{.*}}> -> tensor<64x32xf8E4M3FN, #ttg.dot_op<{opIdx = 1, parent = #mma, kWidth = 8}>>
     // CHECK: %[[S:.*]] = ttg.convert_layout %{{.*}} : tensor<32x2xi8, #blocked{{.*}}> -> tensor<32x2xi8, #linear{{.*}}>
     // CHECK: %[[TS:.*]] = tt.trans %[[S]] {order = array<i32: 1, 0>}
     // CHECK: %[[ES:.*]] = arith.extui %[[TS]]
     // CHECK: %[[SHS:.*]] = arith.shli %[[ES]], %[[CST]]
-    // CHECK: %[[BS:.*]] = tt.bitcast %[[SHS]] : tensor<2x32xi16, #linear{{.*}}> -> tensor<2x32xbf16, #linear{{.*}}>
-    // CHECK: %[[EPS:.*]] = tt.reshape %[[BS]] efficient_layout : tensor<2x32xbf16, #linear{{.*}}> -> tensor<2x1x32xbf16, #linear{{.*}}>
+    // CHECK: %[[BS:.*]] = tt.bitcast %[[SHS]] : tensor<2x32xi16, #ttg.slice<{dim = 1, parent = #blocked{{.*}}}>> -> tensor<2x32xbf16, #ttg.slice<{dim = 1, parent = #blocked{{.*}}}>>
+    // CHECK: %[[EPS:.*]] = tt.reshape %[[BS]] efficient_layout : tensor<2x32xbf16, #ttg.slice<{dim = 1, parent = #blocked{{.*}}}>> -> tensor<2x1x32xbf16, #linear{{.*}}>
     // CHECK: %[[BCS:.*]] = tt.broadcast %[[EPS]] : tensor<2x1x32xbf16, #linear{{.*}}> -> tensor<2x32x32xbf16, #linear{{.*}}>
     // CHECK: %[[RTBCS:.*]] = tt.reshape %[[BCS]] : tensor<2x32x32xbf16, #linear{{.*}}> -> tensor<64x32xbf16, #ttg.dot_op<{opIdx = 1, parent = #mma, kWidth = 8}>>
     // CHECK: %[[UB:.*]] = amdg.scaled_upcast_fp8 %[[B]] scale %[[RTBCS]] : tensor<64x32xf8E4M3FN, #ttg.dot_op<{opIdx = 1, parent = #mma, kWidth = 8}>>, tensor<64x32xbf16, #ttg.dot_op<{opIdx = 1, parent = #mma, kWidth = 8}>> -> tensor<64x32xbf16, #ttg.dot_op<{opIdx = 1, parent = #mma, kWidth = 8}>>
@@ -73,14 +73,14 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.targ
       %arg2: tensor<32x2x!tt.ptr<i8>, #blocked1>,
       %arg3: tensor<32x32x!tt.ptr<f32>, #blocked>
     ) {
-    // CHECK: %[[CST:.*]] = arith.constant dense<7> : tensor<2x32xi16, #linear{{.*}}>
+    // CHECK: %[[CST:.*]] = arith.constant dense<7> : tensor<2x32xi16, #ttg.slice<{dim = 1, parent = #blocked{{.*}}}>>
     // CHECK: %[[B:.*]] = ttg.convert_layout %{{.*}} : tensor<32x32xi8, #blocked{{.*}}> -> tensor<32x32xi8, #ttg.dot_op<{opIdx = 1, parent = #mma, kWidth = 4}>>
     // CHECK: %[[S:.*]] = ttg.convert_layout %{{.*}} : tensor<32x2xi8, #blocked{{.*}}> -> tensor<32x2xi8, #linear{{.*}}>
     // CHECK: %[[TS:.*]] = tt.trans %[[S]] {order = array<i32: 1, 0>}
     // CHECK: %[[ES:.*]] = arith.extui %[[TS]]
     // CHECK: %[[SHS:.*]] = arith.shli %[[ES]], %[[CST]]
-    // CHECK: %[[BS:.*]] = tt.bitcast %[[SHS]] : tensor<2x32xi16, #linear{{.*}}> -> tensor<2x32xbf16, #linear{{.*}}>
-    // CHECK: %[[EPS:.*]] = tt.reshape %[[BS]] efficient_layout : tensor<2x32xbf16, #linear{{.*}}> -> tensor<2x1x32xbf16, #linear{{.*}}>
+    // CHECK: %[[BS:.*]] = tt.bitcast %[[SHS]] : tensor<2x32xi16, #ttg.slice<{dim = 1, parent = #blocked{{.*}}}>> -> tensor<2x32xbf16, #ttg.slice<{dim = 1, parent = #blocked{{.*}}}>>
+    // CHECK: %[[EPS:.*]] = tt.reshape %[[BS]] efficient_layout : tensor<2x32xbf16, #ttg.slice<{dim = 1, parent = #blocked{{.*}}}>> -> tensor<2x1x32xbf16, #linear{{.*}}>
     // CHECK: %[[BCS:.*]] = tt.broadcast %[[EPS]] : tensor<2x1x32xbf16, #linear{{.*}}> -> tensor<2x32x32xbf16, #linear{{.*}}>
     // CHECK: %[[RTBCS:.*]] = tt.reshape %[[BCS]] : tensor<2x32x32xbf16, #linear{{.*}}> -> tensor<64x32xbf16, #ttg.dot_op<{opIdx = 1, parent = #mma, kWidth = 8}>>
     // CHECK: %[[UB:.*]] = amdg.scaled_upcast_fp4 %[[B]] scale %[[RTBCS]] {axis = 0 : i32} : tensor<32x32xi8, #ttg.dot_op<{opIdx = 1, parent = #mma, kWidth = 4}>>, tensor<64x32xbf16, #ttg.dot_op<{opIdx = 1, parent = #mma, kWidth = 8}>> -> tensor<64x32xbf16, #ttg.dot_op<{opIdx = 1, parent = #mma, kWidth = 8}>>

--- a/test/TritonGPU/amd/accelerate-amd-matmul-wmma-gfx1250.mlir
+++ b/test/TritonGPU/amd/accelerate-amd-matmul-wmma-gfx1250.mlir
@@ -200,7 +200,6 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.targ
 #blocked = #ttg.blocked<{sizePerThread = [1, 1], threadsPerWarp = [1, 32], warpsPerCTA = [4, 1], order = [1, 0]}>
 #blocked2 = #ttg.blocked<{sizePerThread = [1, 1], threadsPerWarp = [8, 4], warpsPerCTA = [4, 1], order = [1, 0]}>
 #blocked4 = #ttg.blocked<{sizePerThread = [1, 1], threadsPerWarp = [1, 32], warpsPerCTA = [1, 4], order = [1, 0]}>
-// CHECK{LITERAL}: #linear = #ttg.linear<{register = [[1, 0], [2, 0], [4, 0], [8, 0], [16, 0]], lane = [[0, 0], [0, 0], [0, 0], [0, 0], [0, 0]], warp = [[0, 1], [0, 2]], block = []}>
 // CHECK-LABEL: wmma_dot_scaled_mxfp8_bf16
 module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.target = "hip:gfx1250", "ttg.threads-per-warp" = 32 : i32} {
   tt.func public @wmma_dot_scaled_mxfp8_bf16(
@@ -210,7 +209,7 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.targ
       %output: tensor<32x32x!tt.ptr<f32>, #blocked>
       ) {
     // CHECK: tt.load %arg1 {amdg.decomposed_dot_scaled_source = true} : tensor<32x4x!tt.ptr<i8>, #blocked1>
-    // CHECK: %[[SCALE_CVT:.*]] = ttg.convert_layout {{.*}} : tensor<32x4xi8, #blocked1> -> tensor<32x4xi8, #linear>
+    // CHECK: %[[SCALE_CVT:.*]] = ttg.convert_layout {{.*}} : tensor<32x4xi8, #blocked1> -> tensor<32x4xi8, #ttg.slice<{dim = 2, parent = #blocked3}>>
     // CHECK: %[[SCALE:.*]] = tt.reshape {{.*}} : tensor<32x4x32xi8, #blocked3> -> tensor<32x128xi8, #blocked>
     // CHECK: %[[UPCASTED:.*]] = amdg.scaled_upcast_fp8 {{.*}} scale %[[SCALE]] : tensor<32x128xf8E4M3FN, #blocked>, tensor<32x128xi8, #blocked> -> tensor<32x128xbf16, #blocked>
     // CHECK: %[[SEL:.*]] = arith.select {{.*}}, {{.*}}, %[[UPCASTED]]
@@ -233,7 +232,6 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.targ
 #blocked = #ttg.blocked<{sizePerThread = [1, 1], threadsPerWarp = [1, 32], warpsPerCTA = [4, 1], order = [1, 0]}>
 #blocked2 = #ttg.blocked<{sizePerThread = [1, 1], threadsPerWarp = [8, 4], warpsPerCTA = [4, 1], order = [1, 0]}>
 #blocked4 = #ttg.blocked<{sizePerThread = [1, 1], threadsPerWarp = [1, 32], warpsPerCTA = [1, 4], order = [1, 0]}>
-// CHECK{LITERAL}: #linear = #ttg.linear<{register = [[1, 0], [2, 0]], lane = [[0, 1], [0, 2], [0, 4], [0, 8], [0, 16]], warp = [[0, 0], [0, 0]], block = []}>
 // CHECK-LABEL: wmma_dot_scaled_f16_mxfp8
 module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.target = "hip:gfx1250", "ttg.threads-per-warp" = 32 : i32} {
   tt.func public @wmma_dot_scaled_f16_mxfp8(
@@ -242,7 +240,7 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.targ
       %arg2: tensor<128x32x!tt.ptr<f8E5M2>, #blocked>,
       %output: tensor<32x32x!tt.ptr<f32>, #blocked>
       ) {
-    // CHECK: %[[SCALE_CVT:.*]] = ttg.convert_layout {{.*}} : tensor<4x32xi8, #blocked3> -> tensor<4x32xi8, #linear>
+    // CHECK: %[[SCALE_CVT:.*]] = ttg.convert_layout {{.*}} : tensor<4x32xi8, #blocked3> -> tensor<4x32xi8, #ttg.slice<{dim = 1, parent = #blocked4}>>
     // CHECK: %[[SCALE:.*]] = tt.reshape {{.*}} : tensor<4x32x32xi8, #blocked4> -> tensor<128x32xi8, #blocked2>
     // CHECK: %[[UPCASTED:.*]] = amdg.scaled_upcast_fp8 {{.*}} scale %[[SCALE]] : tensor<128x32xf8E5M2, #blocked2>, tensor<128x32xi8, #blocked2> -> tensor<128x32xf16, #blocked2>
     // CHECK: %[[SEL:.*]] = arith.select {{.*}}, %cst, %[[UPCASTED]] : tensor<128x32xi1, #blocked2>, tensor<128x32xf16, #blocked2>
@@ -266,7 +264,6 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.targ
 #blocked1 = #ttg.blocked<{sizePerThread = [1, 2], threadsPerWarp = [4, 8], warpsPerCTA = [4, 1], order = [1, 0]}>
 #blocked2 = #ttg.blocked<{sizePerThread = [1, 1], threadsPerWarp = [16, 2], warpsPerCTA = [4, 1], order = [1, 0]}>
 #blocked5 = #ttg.blocked<{sizePerThread = [1, 1], threadsPerWarp = [1, 32], warpsPerCTA = [4, 1], order = [1, 0]}>
-// CHECK{LITERAL}: #linear = #ttg.linear<{register = [[0, 0], [4, 0], [8, 0]], lane = [[0, 0], [0, 0], [0, 0], [0, 0], [0, 1]], warp = [[1, 0], [2, 0]], block = []}>
 // CHECK-LABEL: wmma_dot_scaled_mxfp4_bf16
 module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.target = "hip:gfx1250", "ttg.threads-per-warp" = 32 : i32} {
   tt.func public @wmma_dot_scaled_mxfp4_bf16(
@@ -276,7 +273,7 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.targ
       %output: tensor<16x16x!tt.ptr<f32>, #blocked>
       ) {
     // CHECK: tt.load %arg1 {amdg.decomposed_dot_scaled_source = true} : tensor<16x2x!tt.ptr<i8>, #blocked1>
-    // CHECK: %[[SCALE_CVT:.*]] = ttg.convert_layout {{.*}} : tensor<16x2xi8, #blocked1> -> tensor<16x2xi8, #linear>
+    // CHECK: %[[SCALE_CVT:.*]] = ttg.convert_layout {{.*}} : tensor<16x2xi8, #blocked1> -> tensor<16x2xi8, #ttg.slice<{dim = 2, parent = #blocked4}>>
     // CHECK: %[[SCALE:.*]] = tt.reshape {{.*}} : tensor<16x2x32xi8, #[[RESHAPE_LAYOUT:.+]]> -> tensor<16x64xi8, #[[UPCAST_LAYOUT:.+]]>
     // CHECK: %[[UPCASTED:.*]] = amdg.scaled_upcast_fp4 {{.+}} scale %[[SCALE]] {axis = 1 : i32} : tensor<16x32xi8, #blocked>, tensor<16x64xi8, #[[UPCAST_LAYOUT]]> -> tensor<16x64xbf16, #[[UPCAST_LAYOUT]]>
     // CHECK: %[[SEL:.*]] = arith.select {{.*}}, %{{.*}}, %[[UPCASTED]] : tensor<16x64xi1, #[[UPCAST_LAYOUT]]>, tensor<16x64xbf16, #[[UPCAST_LAYOUT]]>
@@ -299,7 +296,6 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.targ
 #blocked = #ttg.blocked<{sizePerThread = [1, 1], threadsPerWarp = [2, 16], warpsPerCTA = [4, 1], order = [1, 0]}>
 #blocked2 = #ttg.blocked<{sizePerThread = [1, 1], threadsPerWarp = [16, 2], warpsPerCTA = [4, 1], order = [1, 0]}>
 #blocked5 = #ttg.blocked<{sizePerThread = [1, 1], threadsPerWarp = [1, 32], warpsPerCTA = [4, 1], order = [1, 0]}>
-// CHECK{LITERAL}: #linear = #ttg.linear<{register = [[0, 0], [1, 0]], lane = [[0, 1], [0, 2], [0, 4], [0, 8], [0, 0]], warp = [[0, 0], [0, 0]], block = []}>
 // CHECK-LABEL: wmma_dot_scaled_fp16_mxfp4
 module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.target = "hip:gfx1250", "ttg.threads-per-warp" = 32 : i32} {
   tt.func public @wmma_dot_scaled_fp16_mxfp4(
@@ -309,7 +305,7 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.targ
       %output: tensor<16x16x!tt.ptr<f32>, #blocked>
       ) {
     // CHECK: tt.load %arg1 {amdg.decomposed_dot_scaled_source = true} : tensor<16x2x!tt.ptr<i8>, #[[LOAD_LAYOUT:.+]]>
-    // CHECK: %[[SCALE_CVT:.*]] = ttg.convert_layout {{.*}} : tensor<2x16xi8, #[[SCALE_SRC_LAYOUT:.+]]> -> tensor<2x16xi8, #linear>
+    // CHECK: %[[SCALE_CVT:.*]] = ttg.convert_layout {{.*}} : tensor<2x16xi8, #[[SCALE_SRC_LAYOUT:.+]]> -> tensor<2x16xi8, #ttg.slice<{dim = 1, parent = #blocked5}>>
     // CHECK: %[[SCALE:.*]] = tt.reshape {{.*}} : tensor<2x32x16xi8, #[[RESHAPE_LAYOUT:.+]]> -> tensor<64x16xi8, #[[UPCAST_LAYOUT:.+]]>
     // CHECK: %[[UPCASTED:.*]] = amdg.scaled_upcast_fp4 {{.+}} scale %[[SCALE]] {axis = 0 : i32} : tensor<32x16xi8, #blocked2>, tensor<64x16xi8, #[[UPCAST_LAYOUT]]> -> tensor<64x16xf16, #[[UPCAST_LAYOUT]]>
     // CHECK: %[[SEL:.*]] = arith.select {{.*}}, %cst, %[[UPCASTED]] : tensor<64x16xi1, #[[UPCAST_LAYOUT]]>, tensor<64x16xf16, #[[UPCAST_LAYOUT]]>

--- a/test/TritonGPU/amd/accelerate-amd-matmul-wmma-gfx1250.mlir
+++ b/test/TritonGPU/amd/accelerate-amd-matmul-wmma-gfx1250.mlir
@@ -226,7 +226,6 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.targ
 #blocked = #ttg.blocked<{sizePerThread = [1, 1], threadsPerWarp = [1, 32], warpsPerCTA = [4, 1], order = [1, 0]}>
 #blocked2 = #ttg.blocked<{sizePerThread = [1, 1], threadsPerWarp = [8, 4], warpsPerCTA = [4, 1], order = [1, 0]}>
 #blocked4 = #ttg.blocked<{sizePerThread = [1, 1], threadsPerWarp = [1, 32], warpsPerCTA = [1, 4], order = [1, 0]}>
-// CHECK{LITERAL}: #linear = #ttg.linear<{register = [[1, 0], [2, 0], [4, 0], [8, 0], [16, 0]], lane = [[0, 0], [0, 0], [0, 0], [0, 0], [0, 0]], warp = [[0, 1], [0, 2]], block = []}>
 // CHECK-LABEL: wmma_dot_scaled_mxfp8_bf16
 module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.target = "hip:gfx1250", "ttg.threads-per-warp" = 32 : i32} {
   tt.func public @wmma_dot_scaled_mxfp8_bf16(
@@ -236,7 +235,7 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.targ
       %output: tensor<32x32x!tt.ptr<f32>, #blocked>
       ) {
     // CHECK: tt.load %arg1 {amdg.decomposed_dot_scaled_source = true} : tensor<32x4x!tt.ptr<i8>, #blocked1>
-    // CHECK: %[[SCALE_CVT:.*]] = ttg.convert_layout {{.*}} : tensor<32x4xi8, #blocked1> -> tensor<32x4xi8, #linear>
+    // CHECK: %[[SCALE_CVT:.*]] = ttg.convert_layout {{.*}} : tensor<32x4xi8, #blocked1> -> tensor<32x4xi8, #ttg.slice<{dim = 2, parent = #blocked3}>>
     // CHECK: %[[SCALE:.*]] = tt.reshape {{.*}} : tensor<32x4x32xi8, #blocked3> -> tensor<32x128xi8, #blocked>
     // CHECK: %[[UPCASTED:.*]] = amdg.scaled_upcast_fp8 {{.*}} scale %[[SCALE]] : tensor<32x128xf8E4M3FN, #blocked>, tensor<32x128xi8, #blocked> -> tensor<32x128xbf16, #blocked>
     // CHECK: %[[SEL:.*]] = arith.select {{.*}}, {{.*}}, %[[UPCASTED]]
@@ -259,7 +258,6 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.targ
 #blocked = #ttg.blocked<{sizePerThread = [1, 1], threadsPerWarp = [1, 32], warpsPerCTA = [4, 1], order = [1, 0]}>
 #blocked2 = #ttg.blocked<{sizePerThread = [1, 1], threadsPerWarp = [8, 4], warpsPerCTA = [4, 1], order = [1, 0]}>
 #blocked4 = #ttg.blocked<{sizePerThread = [1, 1], threadsPerWarp = [1, 32], warpsPerCTA = [1, 4], order = [1, 0]}>
-// CHECK{LITERAL}: #linear = #ttg.linear<{register = [[1, 0], [2, 0]], lane = [[0, 1], [0, 2], [0, 4], [0, 8], [0, 16]], warp = [[0, 0], [0, 0]], block = []}>
 // CHECK-LABEL: wmma_dot_scaled_f16_mxfp8
 module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.target = "hip:gfx1250", "ttg.threads-per-warp" = 32 : i32} {
   tt.func public @wmma_dot_scaled_f16_mxfp8(
@@ -268,7 +266,7 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.targ
       %arg2: tensor<128x32x!tt.ptr<f8E5M2>, #blocked>,
       %output: tensor<32x32x!tt.ptr<f32>, #blocked>
       ) {
-    // CHECK: %[[SCALE_CVT:.*]] = ttg.convert_layout {{.*}} : tensor<4x32xi8, #blocked3> -> tensor<4x32xi8, #linear>
+    // CHECK: %[[SCALE_CVT:.*]] = ttg.convert_layout {{.*}} : tensor<4x32xi8, #blocked3> -> tensor<4x32xi8, #ttg.slice<{dim = 1, parent = #blocked4}>>
     // CHECK: %[[SCALE:.*]] = tt.reshape {{.*}} : tensor<4x32x32xi8, #blocked4> -> tensor<128x32xi8, #blocked2>
     // CHECK: %[[UPCASTED:.*]] = amdg.scaled_upcast_fp8 {{.*}} scale %[[SCALE]] : tensor<128x32xf8E5M2, #blocked2>, tensor<128x32xi8, #blocked2> -> tensor<128x32xf16, #blocked2>
     // CHECK: %[[SEL:.*]] = arith.select {{.*}}, %cst, %[[UPCASTED]] : tensor<128x32xi1, #blocked2>, tensor<128x32xf16, #blocked2>
@@ -292,7 +290,6 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.targ
 #blocked1 = #ttg.blocked<{sizePerThread = [1, 2], threadsPerWarp = [4, 8], warpsPerCTA = [4, 1], order = [1, 0]}>
 #blocked2 = #ttg.blocked<{sizePerThread = [1, 1], threadsPerWarp = [16, 2], warpsPerCTA = [4, 1], order = [1, 0]}>
 #blocked5 = #ttg.blocked<{sizePerThread = [1, 1], threadsPerWarp = [1, 32], warpsPerCTA = [4, 1], order = [1, 0]}>
-// CHECK{LITERAL}: #linear = #ttg.linear<{register = [[4, 0], [8, 0]], lane = [[0, 0], [0, 0], [0, 0], [0, 0], [0, 1]], warp = [[1, 0], [2, 0]], block = []}>
 // CHECK-LABEL: wmma_dot_scaled_mxfp4_bf16
 module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.target = "hip:gfx1250", "ttg.threads-per-warp" = 32 : i32} {
   tt.func public @wmma_dot_scaled_mxfp4_bf16(
@@ -302,7 +299,7 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.targ
       %output: tensor<16x16x!tt.ptr<f32>, #blocked>
       ) {
     // CHECK: tt.load %arg1 {amdg.decomposed_dot_scaled_source = true} : tensor<16x2x!tt.ptr<i8>, #blocked1>
-    // CHECK: %[[SCALE_CVT:.*]] = ttg.convert_layout {{.*}} : tensor<16x2xi8, #blocked1> -> tensor<16x2xi8, #linear>
+    // CHECK: %[[SCALE_CVT:.*]] = ttg.convert_layout {{.*}} : tensor<16x2xi8, #blocked1> -> tensor<16x2xi8, #ttg.slice<{dim = 2, parent = #blocked4}>>
     // CHECK: %[[SCALE:.*]] = tt.reshape {{.*}} : tensor<16x2x32xi8, #[[RESHAPE_LAYOUT:.+]]> -> tensor<16x64xi8, #[[UPCAST_LAYOUT:.+]]>
     // CHECK: %[[UPCASTED:.*]] = amdg.scaled_upcast_fp4 {{.+}} scale %[[SCALE]] {axis = 1 : i32} : tensor<16x32xi8, #blocked>, tensor<16x64xi8, #[[UPCAST_LAYOUT]]> -> tensor<16x64xbf16, #[[UPCAST_LAYOUT]]>
     // CHECK: %[[SEL:.*]] = arith.select {{.*}}, %{{.*}}, %[[UPCASTED]] : tensor<16x64xi1, #[[UPCAST_LAYOUT]]>, tensor<16x64xbf16, #[[UPCAST_LAYOUT]]>
@@ -325,7 +322,6 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.targ
 #blocked = #ttg.blocked<{sizePerThread = [1, 1], threadsPerWarp = [2, 16], warpsPerCTA = [4, 1], order = [1, 0]}>
 #blocked2 = #ttg.blocked<{sizePerThread = [1, 1], threadsPerWarp = [16, 2], warpsPerCTA = [4, 1], order = [1, 0]}>
 #blocked5 = #ttg.blocked<{sizePerThread = [1, 1], threadsPerWarp = [1, 32], warpsPerCTA = [4, 1], order = [1, 0]}>
-// CHECK{LITERAL}: #linear = #ttg.linear<{register = [[1, 0]], lane = [[0, 1], [0, 2], [0, 4], [0, 8], [0, 0]], warp = [[0, 0], [0, 0]], block = []}>
 // CHECK-LABEL: wmma_dot_scaled_fp16_mxfp4
 module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.target = "hip:gfx1250", "ttg.threads-per-warp" = 32 : i32} {
   tt.func public @wmma_dot_scaled_fp16_mxfp4(
@@ -335,7 +331,7 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.targ
       %output: tensor<16x16x!tt.ptr<f32>, #blocked>
       ) {
     // CHECK: tt.load %arg1 {amdg.decomposed_dot_scaled_source = true} : tensor<16x2x!tt.ptr<i8>, #[[LOAD_LAYOUT:.+]]>
-    // CHECK: %[[SCALE_CVT:.*]] = ttg.convert_layout {{.*}} : tensor<2x16xi8, #[[SCALE_SRC_LAYOUT:.+]]> -> tensor<2x16xi8, #linear>
+    // CHECK: %[[SCALE_CVT:.*]] = ttg.convert_layout {{.*}} : tensor<2x16xi8, #[[SCALE_SRC_LAYOUT:.+]]> -> tensor<2x16xi8, #ttg.slice<{dim = 1, parent = #blocked5}>>
     // CHECK: %[[SCALE:.*]] = tt.reshape {{.*}} : tensor<2x32x16xi8, #[[RESHAPE_LAYOUT:.+]]> -> tensor<64x16xi8, #[[UPCAST_LAYOUT:.+]]>
     // CHECK: %[[UPCASTED:.*]] = amdg.scaled_upcast_fp4 {{.+}} scale %[[SCALE]] {axis = 0 : i32} : tensor<32x16xi8, #blocked2>, tensor<64x16xi8, #[[UPCAST_LAYOUT]]> -> tensor<64x16xf16, #[[UPCAST_LAYOUT]]>
     // CHECK: %[[SEL:.*]] = arith.select {{.*}}, %cst, %[[UPCASTED]] : tensor<64x16xi1, #[[UPCAST_LAYOUT]]>, tensor<64x16xf16, #[[UPCAST_LAYOUT]]>

--- a/test/TritonGPU/combine.mlir
+++ b/test/TritonGPU/combine.mlir
@@ -4063,7 +4063,8 @@ module attributes {"ttg.num-warps" = 4 : i32, ttg.target = "hip:gfx950", "ttg.th
 #blocked = #ttg.blocked<{sizePerThread = [1, 4], threadsPerWarp = [32, 1], warpsPerCTA = [4, 1], order = [1, 0]}>
 #blocked1 = #ttg.blocked<{sizePerThread = [1, 1], threadsPerWarp = [32, 1], warpsPerCTA = [4, 1], order = [1, 0]}>
 module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.target = "cuda:90", "ttg.threads-per-warp" = 32 : i32} {
-  tt.func public @hoist_into_cond_layout_conflict(%arg0: !tt.ptr<i32> {tt.divisibility = 16 : i32}, %arg1: !tt.ptr<i32> {tt.divisibility = 16 : i32}, %arg2: i1) -> tensor<4x1xi64, #blocked> {
+  // CHECK-LABEL: @hoist_into_cond_layout_conflict
+  tt.func public @hoist_into_cond_layout_conflict(%arg0: !tt.ptr<i32> {tt.divisibility = 16 : i32}, %arg1: !tt.ptr<i32> {tt.divisibility = 16 : i32}, %arg2: i1) -> tensor<4x2xi64, #blocked> {
     %c1_i32 = arith.constant 1 : i32
     %c4_i32 = arith.constant 4 : i32
     %c0_i32 = arith.constant 0 : i32
@@ -4071,44 +4072,48 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.targ
     %1 = arith.extsi %0 : tensor<4xi32, #ttg.slice<{dim = 1, parent = #blocked1}>> to tensor<4xi64, #ttg.slice<{dim = 1, parent = #blocked1}>>
     %2 = tt.splat %arg0 : !tt.ptr<i32> -> tensor<4x!tt.ptr<i32>, #ttg.slice<{dim = 1, parent = #blocked1}>>
     %3 = tt.expand_dims %1 {axis = 1 : i32} : tensor<4xi64, #ttg.slice<{dim = 1, parent = #blocked1}>> -> tensor<4x1xi64, #blocked1>
+    %expanded = tt.broadcast %3 : tensor<4x1xi64, #blocked1> -> tensor<4x2xi64, #blocked1>
     %4 = tt.addptr %2, %1 : tensor<4x!tt.ptr<i32>, #ttg.slice<{dim = 1, parent = #blocked1}>>, tensor<4xi64, #ttg.slice<{dim = 1, parent = #blocked1}>>
     %5 = tt.load %4 : tensor<4x!tt.ptr<i32>, #ttg.slice<{dim = 1, parent = #blocked1}>>
-    %6 = tt.reshape %5 : tensor<4xi32, #ttg.slice<{dim = 1, parent = #blocked1}>> -> tensor<4x1xi32, #blocked1>
-    %7 = arith.extsi %6 : tensor<4x1xi32, #blocked1> to tensor<4x1xi64, #blocked1>
-    %cst = arith.constant dense<0> : tensor<4x1xi64, #blocked>
-    %8 = scf.if %arg2 -> (tensor<4x1xi64, #blocked1>) {
+    // CHECK: tt.join
+    %6 = tt.join %5, %5 : tensor<4xi32, #ttg.slice<{dim = 1, parent = #blocked1}>> -> tensor<4x2xi32, #blocked1>
+    %7 = arith.extsi %6 : tensor<4x2xi32, #blocked1> to tensor<4x2xi64, #blocked1>
+    %cst = arith.constant dense<0> : tensor<4x2xi64, #blocked>
+    %8 = scf.if %arg2 -> (tensor<4x2xi64, #blocked1>) {
       // The backward slice from this extsi will produce a non-sliced layout for
       // %1.
-      scf.yield %7 : tensor<4x1xi64, #blocked1>
+      scf.yield %7 : tensor<4x2xi64, #blocked1>
     } else {
-      // The backward slice from this add will produce a sliced layout for %1.
-      scf.yield %3 : tensor<4x1xi64, #blocked1>
+      // The backward slice through expand and broadcast will produce a sliced
+      // layout for %1.
+      scf.yield %expanded : tensor<4x2xi64, #blocked1>
     }
     // CHECK: scf.for
     // CHECK-NEXT: scf.if
     // CHECK-NOT: ttg.convert_layout
     // CHECK: } else {
     // CHECK: ttg.convert_layout
-    // CHECK-NOT: ttg.convert-layout
-    %9 = scf.for %arg3 = %c0_i32 to %c4_i32 step %c1_i32 iter_args(%arg4 = %cst) -> (tensor<4x1xi64, #blocked>)  : i32 {
-      %10 = scf.if %arg2 -> (tensor<4x1xi64, #blocked1>) {
+    // CHECK-NOT: ttg.convert_layout
+    // CHECK: tt.return
+    %9 = scf.for %arg3 = %c0_i32 to %c4_i32 step %c1_i32 iter_args(%arg4 = %cst) -> (tensor<4x2xi64, #blocked>)  : i32 {
+      %10 = scf.if %arg2 -> (tensor<4x2xi64, #blocked1>) {
         // The backward slice from this extsi will produce a non-sliced layout
         // for %1 when it is rematerialized conflicting with the sliced layout
         // produced by %3 in the else arm of the other if.
-        %14 = arith.extsi %6 : tensor<4x1xi32, #blocked1> to tensor<4x1xi64, #blocked1>
-        scf.yield %14 : tensor<4x1xi64, #blocked1>
+        %14 = arith.extsi %6 : tensor<4x2xi32, #blocked1> to tensor<4x2xi64, #blocked1>
+        scf.yield %14 : tensor<4x2xi64, #blocked1>
       } else {
         // The backward slice from this add will produce conflicting layouts for
         // %1, so we try to hoist the convert into this arm.
-        %14 = arith.addi %7, %3 : tensor<4x1xi64, #blocked1>
-        scf.yield %14 : tensor<4x1xi64, #blocked1>
+        %14 = arith.addi %7, %expanded : tensor<4x2xi64, #blocked1>
+        scf.yield %14 : tensor<4x2xi64, #blocked1>
       }
-      %11 = arith.addi %8, %10 : tensor<4x1xi64, #blocked1>
-      %12 = ttg.convert_layout %11 : tensor<4x1xi64, #blocked1> -> tensor<4x1xi64, #blocked>
-      %13 = arith.addi %arg4, %12 : tensor<4x1xi64, #blocked>
-      scf.yield %13 : tensor<4x1xi64, #blocked>
+      %11 = arith.addi %8, %10 : tensor<4x2xi64, #blocked1>
+      %12 = ttg.convert_layout %11 : tensor<4x2xi64, #blocked1> -> tensor<4x2xi64, #blocked>
+      %13 = arith.addi %arg4, %12 : tensor<4x2xi64, #blocked>
+      scf.yield %13 : tensor<4x2xi64, #blocked>
     }
-    tt.return %9 : tensor<4x1xi64, #blocked>
+    tt.return %9 : tensor<4x2xi64, #blocked>
   }
 }
 

--- a/test/TritonGPU/combine.mlir
+++ b/test/TritonGPU/combine.mlir
@@ -4111,7 +4111,8 @@ module attributes {"ttg.num-warps" = 4 : i32, ttg.target = "hip:gfx950", "ttg.th
 #blocked = #ttg.blocked<{sizePerThread = [1, 4], threadsPerWarp = [32, 1], warpsPerCTA = [4, 1], order = [1, 0]}>
 #blocked1 = #ttg.blocked<{sizePerThread = [1, 1], threadsPerWarp = [32, 1], warpsPerCTA = [4, 1], order = [1, 0]}>
 module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.target = "cuda:90", "ttg.threads-per-warp" = 32 : i32} {
-  tt.func public @hoist_into_cond_layout_conflict(%arg0: !tt.ptr<i32> {tt.divisibility = 16 : i32}, %arg1: !tt.ptr<i32> {tt.divisibility = 16 : i32}, %arg2: i1) -> tensor<4x1xi64, #blocked> {
+  // CHECK-LABEL: @hoist_into_cond_layout_conflict
+  tt.func public @hoist_into_cond_layout_conflict(%arg0: !tt.ptr<i32> {tt.divisibility = 16 : i32}, %arg1: !tt.ptr<i32> {tt.divisibility = 16 : i32}, %arg2: i1) -> tensor<4x2xi64, #blocked> {
     %c1_i32 = arith.constant 1 : i32
     %c4_i32 = arith.constant 4 : i32
     %c0_i32 = arith.constant 0 : i32
@@ -4119,44 +4120,48 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.targ
     %1 = arith.extsi %0 : tensor<4xi32, #ttg.slice<{dim = 1, parent = #blocked1}>> to tensor<4xi64, #ttg.slice<{dim = 1, parent = #blocked1}>>
     %2 = tt.splat %arg0 : !tt.ptr<i32> -> tensor<4x!tt.ptr<i32>, #ttg.slice<{dim = 1, parent = #blocked1}>>
     %3 = tt.expand_dims %1 {axis = 1 : i32} : tensor<4xi64, #ttg.slice<{dim = 1, parent = #blocked1}>> -> tensor<4x1xi64, #blocked1>
+    %expanded = tt.broadcast %3 : tensor<4x1xi64, #blocked1> -> tensor<4x2xi64, #blocked1>
     %4 = tt.addptr %2, %1 : tensor<4x!tt.ptr<i32>, #ttg.slice<{dim = 1, parent = #blocked1}>>, tensor<4xi64, #ttg.slice<{dim = 1, parent = #blocked1}>>
     %5 = tt.load %4 : tensor<4x!tt.ptr<i32>, #ttg.slice<{dim = 1, parent = #blocked1}>>
-    %6 = tt.reshape %5 : tensor<4xi32, #ttg.slice<{dim = 1, parent = #blocked1}>> -> tensor<4x1xi32, #blocked1>
-    %7 = arith.extsi %6 : tensor<4x1xi32, #blocked1> to tensor<4x1xi64, #blocked1>
-    %cst = arith.constant dense<0> : tensor<4x1xi64, #blocked>
-    %8 = scf.if %arg2 -> (tensor<4x1xi64, #blocked1>) {
+    // CHECK: tt.join
+    %6 = tt.join %5, %5 : tensor<4xi32, #ttg.slice<{dim = 1, parent = #blocked1}>> -> tensor<4x2xi32, #blocked1>
+    %7 = arith.extsi %6 : tensor<4x2xi32, #blocked1> to tensor<4x2xi64, #blocked1>
+    %cst = arith.constant dense<0> : tensor<4x2xi64, #blocked>
+    %8 = scf.if %arg2 -> (tensor<4x2xi64, #blocked1>) {
       // The backward slice from this extsi will produce a non-sliced layout for
       // %1.
-      scf.yield %7 : tensor<4x1xi64, #blocked1>
+      scf.yield %7 : tensor<4x2xi64, #blocked1>
     } else {
-      // The backward slice from this add will produce a sliced layout for %1.
-      scf.yield %3 : tensor<4x1xi64, #blocked1>
+      // The backward slice through expand and broadcast will produce a sliced
+      // layout for %1.
+      scf.yield %expanded : tensor<4x2xi64, #blocked1>
     }
     // CHECK: scf.for
     // CHECK-NEXT: scf.if
     // CHECK-NOT: ttg.convert_layout
     // CHECK: } else {
     // CHECK: ttg.convert_layout
-    // CHECK-NOT: ttg.convert-layout
-    %9 = scf.for %arg3 = %c0_i32 to %c4_i32 step %c1_i32 iter_args(%arg4 = %cst) -> (tensor<4x1xi64, #blocked>)  : i32 {
-      %10 = scf.if %arg2 -> (tensor<4x1xi64, #blocked1>) {
+    // CHECK-NOT: ttg.convert_layout
+    // CHECK: tt.return
+    %9 = scf.for %arg3 = %c0_i32 to %c4_i32 step %c1_i32 iter_args(%arg4 = %cst) -> (tensor<4x2xi64, #blocked>)  : i32 {
+      %10 = scf.if %arg2 -> (tensor<4x2xi64, #blocked1>) {
         // The backward slice from this extsi will produce a non-sliced layout
         // for %1 when it is rematerialized conflicting with the sliced layout
         // produced by %3 in the else arm of the other if.
-        %14 = arith.extsi %6 : tensor<4x1xi32, #blocked1> to tensor<4x1xi64, #blocked1>
-        scf.yield %14 : tensor<4x1xi64, #blocked1>
+        %14 = arith.extsi %6 : tensor<4x2xi32, #blocked1> to tensor<4x2xi64, #blocked1>
+        scf.yield %14 : tensor<4x2xi64, #blocked1>
       } else {
         // The backward slice from this add will produce conflicting layouts for
         // %1, so we try to hoist the convert into this arm.
-        %14 = arith.addi %7, %3 : tensor<4x1xi64, #blocked1>
-        scf.yield %14 : tensor<4x1xi64, #blocked1>
+        %14 = arith.addi %7, %expanded : tensor<4x2xi64, #blocked1>
+        scf.yield %14 : tensor<4x2xi64, #blocked1>
       }
-      %11 = arith.addi %8, %10 : tensor<4x1xi64, #blocked1>
-      %12 = ttg.convert_layout %11 : tensor<4x1xi64, #blocked1> -> tensor<4x1xi64, #blocked>
-      %13 = arith.addi %arg4, %12 : tensor<4x1xi64, #blocked>
-      scf.yield %13 : tensor<4x1xi64, #blocked>
+      %11 = arith.addi %8, %10 : tensor<4x2xi64, #blocked1>
+      %12 = ttg.convert_layout %11 : tensor<4x2xi64, #blocked1> -> tensor<4x2xi64, #blocked>
+      %13 = arith.addi %arg4, %12 : tensor<4x2xi64, #blocked>
+      scf.yield %13 : tensor<4x2xi64, #blocked>
     }
-    tt.return %9 : tensor<4x1xi64, #blocked>
+    tt.return %9 : tensor<4x2xi64, #blocked>
   }
 }
 
@@ -4290,8 +4295,8 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, "ttg.thr
 
 // -----
 
-#src = #ttg.blocked<{sizePerThread = [1, 2], threadsPerWarp = [1, 1], warpsPerCTA = [1, 1], order = [0, 1]}>
 #dst = #ttg.blocked<{sizePerThread = [1, 2, 2], threadsPerWarp = [1, 1, 1], warpsPerCTA = [1, 1, 1], order = [0, 1, 2]}>
+#src = #ttg.slice<{dim = 2, parent = #dst}>
 #lin = #ttg.linear<{register = [[0, 1, 0]], lane = [], warp = [], block = []}>
 module attributes {"ttg.num-warps" = 1 : i32, "ttg.threads-per-warp" = 1 : i32} {
   // CHECK-LABEL: @test_existing_layout_conflict

--- a/test/TritonGPU/fpsan.mlir
+++ b/test/TritonGPU/fpsan.mlir
@@ -13,7 +13,8 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, "ttg.thr
   tt.func public @dot_emulation() -> tensor<16x16xf32, #blocked> {
     // CHECK: scf.for
     // CHECK-NOT: tt.dot
-    // CHECK: ttg.convert_layout
+    // CHECK-NOT: ttg.convert_layout
+    // CHECK: tt.return
     %cst = arith.constant 1.000000e+00 : f16
     %zero = arith.constant dense<0.000000e+00> : tensor<16x16xf32, #blocked>
     %a = tt.splat %cst : f16 -> tensor<16x16xf16, #dot_operand_a>
@@ -214,7 +215,8 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, "ttg.thr
     // CHECK: ttg.barrier global_read|global_write
     // CHECK-NOT: ttg.dot_scaled
     // CHECK-NOT: tt.dot
-    // CHECK: ttg.convert_layout
+    // CHECK-NOT: ttg.convert_layout
+    // CHECK: tt.return
      %cst = arith.constant 1.000000e+00 : f16
      %zero = arith.constant dense<0.000000e+00> : tensor<16x16xf32, #blocked>
      %a = tt.splat %cst : f16 -> tensor<16x16xf16, #dot_A>

--- a/test/TritonGPU/fpsan.mlir
+++ b/test/TritonGPU/fpsan.mlir
@@ -33,7 +33,8 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, "ttg.thr
   tt.func public @dot_emulation() -> tensor<16x16xf32, #blocked> {
     // CHECK: scf.for
     // CHECK-NOT: tt.dot
-    // CHECK: ttg.convert_layout
+    // CHECK-NOT: ttg.convert_layout
+    // CHECK: tt.return
     %cst = arith.constant 1.000000e+00 : f16
     %zero = arith.constant dense<0.000000e+00> : tensor<16x16xf32, #blocked>
     %a = tt.splat %cst : f16 -> tensor<16x16xf16, #dot_operand_a>
@@ -336,7 +337,8 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, "ttg.thr
     // CHECK: ttg.barrier global_read|global_write
     // CHECK-NOT: ttg.dot_scaled
     // CHECK-NOT: tt.dot
-    // CHECK: ttg.convert_layout
+    // CHECK-NOT: ttg.convert_layout
+    // CHECK: tt.return
      %cst = arith.constant 1.000000e+00 : f16
      %zero = arith.constant dense<0.000000e+00> : tensor<16x16xf32, #blocked>
      %a = tt.splat %cst : f16 -> tensor<16x16xf16, #dot_A>

--- a/test/TritonNvidiaGPU/plan_cta.mlir
+++ b/test/TritonNvidiaGPU/plan_cta.mlir
@@ -6,7 +6,6 @@
 
   // CHECK: #blocked = #ttg.blocked<{sizePerThread = [4], threadsPerWarp = [32], warpsPerCTA = [4], order = [0], CGALayout = {{\[\[1\], \[2\]\]}}}>
   // CHECK-DAG: #[[$RESHAPE_DST:.+]] = #ttg.blocked<{{.*}}CGALayout = {{\[\[1, 0\], \[2, 0\]\]}}}>
-  // CHECK-DAG: #[[$RESHAPE_SRC:.+]] = #ttg.linear
 module attributes {"ttg.num-ctas" = 4 : i32, "ttg.num-warps" = 4 : i32, ttg.target = "cuda:100", "ttg.threads-per-warp" = 32 : i32} {
   // CHECK-LABEL: tt.func @reduce_1d_split_ctas
   // CHECK: "tt.reduce"(%{{.*}}) <{axis = 0 : i32}>
@@ -23,8 +22,8 @@ module attributes {"ttg.num-ctas" = 4 : i32, "ttg.num-warps" = 4 : i32, ttg.targ
   }
 
   // CHECK-LABEL: tt.func @reduce_reshape
-  // CHECK: %[[CST:.*]] = arith.constant dense<0.000000e+00> : tensor<65536xf32, #[[$RESHAPE_SRC]]>
-  // CHECK-NEXT: %[[RESHAPE:.*]] = tt.reshape %[[CST]] : tensor<65536xf32, #[[$RESHAPE_SRC]]> -> tensor<65536x1xf32, #[[$RESHAPE_DST]]>
+  // CHECK: %[[CST:.*]] = arith.constant dense<0.000000e+00> : tensor<65536xf32, #ttg.slice<{dim = 1, parent = #[[$RESHAPE_DST]]}>>
+  // CHECK-NEXT: %[[RESHAPE:.*]] = tt.reshape %[[CST]] : tensor<65536xf32, #ttg.slice<{dim = 1, parent = #[[$RESHAPE_DST]]}>> -> tensor<65536x1xf32, #[[$RESHAPE_DST]]>
   // CHECK-NEXT: %[[RED:.*]] = "tt.reduce"(%[[RESHAPE]]) <{axis = 1 : i32}>
   tt.func @reduce_reshape() -> tensor<65536xf32, #slice> {
     %cst = arith.constant dense<0.000000e+00> : tensor<65536xf32, #slice>

--- a/unittest/Dialect/TritonGPU/DialectTest.cpp
+++ b/unittest/Dialect/TritonGPU/DialectTest.cpp
@@ -120,7 +120,6 @@ protected:
 /*static*/ MLIRContext InferLayoutTest::ctx;
 
 void testReshape(RankedTensorType srcTy, RankedTensorType dstTy,
-                 std::optional<BlockedEncodingAttr> expectedDstEnc,
                  DialectInferLayoutInterface *inferLayout,
                  bool longErrors = true) {
 
@@ -210,13 +209,8 @@ TEST_P(InferReshapeOpEncodingTest, DoIt) {
   if (!dst)
     FAIL() << "Could not parse destination type: " << dstTyStr;
 
-  std::optional<BlockedEncodingAttr> expectedDstEnc;
-  if (auto dstEnc = cast<RankedTensorType>(dst).getEncoding()) {
-    expectedDstEnc = cast<BlockedEncodingAttr>(dstEnc);
-  }
-
   testReshape(cast<RankedTensorType>(src), cast<RankedTensorType>(dst),
-              expectedDstEnc, inferLayout, /*longErrors=*/true);
+              inferLayout, /*longErrors=*/true);
 }
 
 // A testcase of {a, b, c} means:
@@ -290,7 +284,7 @@ INSTANTIATE_TEST_SUITE_P(
          R"(T<16x2xf32, #B<{spt=[1,2], tpw=[32,1], wpc=[2,1], ord=[1,0]}>>)"},
 
         {R"(T<2x1x2xf32, #B<{spt=[2,1,1], tpw=[2,1,2], wpc=[4,1,8], ord=[2,1,0]}>>)",
-         R"(T<2x2xf32,   #B<{spt=[2,1],   tpw=[2,2],   wpc=[4,8],   ord=[1,0]}>>)"},
+         R"(T<2x2xf32, #ttg.slice<{dim = 1, parent = #B<{spt=[2,1,1], tpw=[2,1,2], wpc=[4,1,8], ord=[2,1,0]}>}>>)"},
     })));
 
 class Fp4ToFpOpTest : public ::testing::Test {


### PR DESCRIPTION
Preserve slice encodings when a reshape adds or removes a unit dimension.
Keep an equivalent destination encoding hint when one is supplied.

Only use the slice or its parent when it preserves register broadcasting
and the number of elements per thread. Otherwise, use the existing
reshape inference path.
