### PR TITLE
Support expand-dims reshapes in Triton passes

### DIFF
--- a/include/triton/Dialect/TritonGPU/Transforms/PartitionSchedulingUtility.h
+++ b/include/triton/Dialect/TritonGPU/Transforms/PartitionSchedulingUtility.h
@@ -37,7 +37,8 @@ Flags getNodeFlags(Node *node);
 size_t computeCost(Operation *op);
 
 inline bool isViewOp(Operation *op) {
-  return isa<tt::BroadcastOp, tt::ExpandDimsOp, ttg::ConvertLayoutOp>(op) ||
+  return isa<tt::BroadcastOp, tt::ExpandDimsOp, tt::ReshapeOp,
+             ttg::ConvertLayoutOp>(op) ||
          op->hasTrait<OpTrait::MemDescViewTrait>();
 }
 

--- a/include/triton/Dialect/TritonGPU/Transforms/PartitionSchedulingUtility.h
+++ b/include/triton/Dialect/TritonGPU/Transforms/PartitionSchedulingUtility.h
@@ -38,7 +38,8 @@ Flags getNodeFlags(Node *node);
 size_t computeCost(Operation *op);
 
 inline bool isViewOp(Operation *op) {
-  return isa<tt::BroadcastOp, tt::ExpandDimsOp, ttg::ConvertLayoutOp>(op) ||
+  return isa<tt::BroadcastOp, tt::ExpandDimsOp, tt::ReshapeOp,
+             ttg::ConvertLayoutOp>(op) ||
          op->hasTrait<OpTrait::MemDescViewTrait>();
 }
 

--- a/lib/Conversion/TritonToTritonGPU/TritonToTritonGPUPass.cpp
+++ b/lib/Conversion/TritonToTritonGPU/TritonToTritonGPUPass.cpp
@@ -189,6 +189,32 @@ struct TritonExpandDimsPattern
   }
 };
 
+struct TritonReshapePattern : public OpConversionPattern<triton::ReshapeOp> {
+  using OpConversionPattern::OpConversionPattern;
+
+  LogicalResult
+  matchAndRewrite(triton::ReshapeOp op, OpAdaptor adaptor,
+                  ConversionPatternRewriter &rewriter) const override {
+    auto resultType = cast<RankedTensorType>(
+        this->getTypeConverter()->convertType(op.getType()));
+    Value src = adaptor.getSrc();
+    if (auto axis = op.getExpandDimsAxis(); axis && !op.getAllowReorder()) {
+      auto resultEncoding =
+          cast<DistributedEncodingTrait>(resultType.getEncoding());
+      auto srcType = cast<RankedTensorType>(src.getType());
+      auto slicedEncoding =
+          SliceEncodingAttr::get(getContext(), *axis, resultEncoding);
+      auto slicedSrcType = srcType.cloneWithEncoding(slicedEncoding);
+      src = ConvertLayoutOp::create(rewriter, op.getLoc(), slicedSrcType, src);
+    }
+
+    auto newOp = rewriter.replaceOpWithNewOp<triton::ReshapeOp>(
+        op, resultType, src, op.getAllowReorder(), op.getEfficientLayout());
+    addNamedAttrs(newOp, adaptor.getAttributes());
+    return success();
+  }
+};
+
 struct TritonDotPattern : public OpConversionPattern<triton::DotOp> {
   using OpConversionPattern::OpConversionPattern;
 
@@ -487,7 +513,7 @@ void populateTritonPatterns(TritonGPUTypeConverter &typeConverter,
   patterns.insert< // TODO: view should have custom pattern that views the
                    // layout
       // clang-format off
-      GenericOpPattern<triton::ReshapeOp>,
+      TritonReshapePattern,
       GenericOpPattern<triton::BitcastOp>,
       GenericOpPattern<triton::FpToFpOp>,
       GenericOpPattern<triton::IntToPtrOp>,

--- a/lib/Conversion/TritonToTritonGPU/TritonToTritonGPUPass.cpp
+++ b/lib/Conversion/TritonToTritonGPU/TritonToTritonGPUPass.cpp
@@ -189,6 +189,32 @@ struct TritonExpandDimsPattern
   }
 };
 
+struct TritonReshapePattern : public OpConversionPattern<triton::ReshapeOp> {
+  using OpConversionPattern::OpConversionPattern;
+
+  LogicalResult
+  matchAndRewrite(triton::ReshapeOp op, OpAdaptor adaptor,
+                  ConversionPatternRewriter &rewriter) const override {
+    auto resultType = cast<RankedTensorType>(
+        this->getTypeConverter()->convertType(op.getType()));
+    Value src = adaptor.getSrc();
+    if (auto axis = op.getExpandDimsAxis(); axis && !op.getAllowReorder()) {
+      auto resultEncoding =
+          cast<DistributedEncodingTrait>(resultType.getEncoding());
+      auto srcType = cast<RankedTensorType>(src.getType());
+      auto slicedEncoding =
+          SliceEncodingAttr::get(getContext(), *axis, resultEncoding);
+      auto slicedSrcType = srcType.cloneWithEncoding(slicedEncoding);
+      src = ConvertLayoutOp::create(rewriter, op.getLoc(), slicedSrcType, src);
+    }
+
+    auto newOp = rewriter.replaceOpWithNewOp<triton::ReshapeOp>(
+        op, resultType, src, op.getAllowReorder(), op.getEfficientLayout());
+    addNamedAttrs(newOp, adaptor.getAttributes());
+    return success();
+  }
+};
+
 struct TritonDotPattern : public OpConversionPattern<triton::DotOp> {
   using OpConversionPattern::OpConversionPattern;
 
@@ -443,7 +469,7 @@ void populateTritonPatterns(TritonGPUTypeConverter &typeConverter,
   patterns.insert< // TODO: view should have custom pattern that views the
                    // layout
       // clang-format off
-      GenericOpPattern<triton::ReshapeOp>,
+      TritonReshapePattern,
       GenericOpPattern<triton::BitcastOp>,
       GenericOpPattern<triton::FpToFpOp>,
       GenericOpPattern<triton::IntToPtrOp>,

--- a/lib/Dialect/TritonGPU/Transforms/RemoveLayoutConversions.cpp
+++ b/lib/Dialect/TritonGPU/Transforms/RemoveLayoutConversions.cpp
@@ -263,6 +263,15 @@ void LayoutPropagation::initAnchorLayout() {
 void LayoutPropagation::setEncoding(ValueRange values, LayoutInfo &info,
                                     SmallVector<Value> &changed,
                                     Operation *op) {
+  std::optional<unsigned> requiredSliceDim;
+  if (auto reshape = dyn_cast<ReshapeOp>(op);
+      reshape && !reshape.getAllowReorder()) {
+    auto srcType = reshape.getSrc().getType();
+    if (auto slice = dyn_cast<SliceEncodingAttr>(srcType.getEncoding());
+        slice &&
+        slice.paddedShape(srcType.getShape()) == reshape.getType().getShape())
+      requiredSliceDim = slice.getDim();
+  }
   for (Value value : values) {
     if (!isa<RankedTensorType>(value.getType()))
       continue;
@@ -274,6 +283,11 @@ void LayoutPropagation::setEncoding(ValueRange values, LayoutInfo &info,
         // encoding.
         dstEncoding = encoding;
       } else {
+        if (requiredSliceDim && !isa<MmaEncodingTrait>(encoding)) {
+          auto slice = dyn_cast<SliceEncodingAttr>(encoding);
+          if (!slice || slice.getDim() != *requiredSliceDim)
+            continue;
+        }
         dstEncoding = inferDstEncoding(op, encoding);
       }
       if (dstEncoding)

--- a/test/TritonGPU/combine.mlir
+++ b/test/TritonGPU/combine.mlir
@@ -2230,6 +2230,29 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 1 : i32, "ttg.thr
 
 // -----
 
+#mma = #ttg.nvidia_mma<{versionMajor = 3, versionMinor = 0, warpsPerCTA = [8, 1], instrShape = [16, 256, 16]}>
+#blocked1 = #ttg.blocked<{sizePerThread = [1, 1, 8], threadsPerWarp = [1, 1, 32], warpsPerCTA = [1, 8, 1], order = [2, 1, 0]}>
+#shared = #ttg.nvmma_shared<{swizzlingByteWidth = 128, transposed = false, elementBitWidth = 16, rank = 3}>
+#smem = #ttg.shared_memory
+
+module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 8 : i32, "ttg.threads-per-warp" = 32 : i32} {
+  // CHECK-LABEL: @expand_dims_reshape_mma_forward_propagate
+  // CHECK-NOT: ttg.convert_layout
+  // CHECK: tt.reshape %arg0
+  // CHECK-NOT: ttg.convert_layout
+  // CHECK: tt.return
+  tt.func public @expand_dims_reshape_mma_forward_propagate(
+      %arg0: tensor<128x256xf16, #mma>) {
+    %0 = ttg.convert_layout %arg0 : tensor<128x256xf16, #mma> -> tensor<128x256xf16, #ttg.slice<{dim = 0, parent = #blocked1}>>
+    %1 = tt.reshape %0 : tensor<128x256xf16, #ttg.slice<{dim = 0, parent = #blocked1}>> -> tensor<1x128x256xf16, #blocked1>
+    %2 = ttg.local_alloc : () -> !ttg.memdesc<1x128x256xf16, #shared, #smem, mutable>
+    ttg.local_store %1, %2 : tensor<1x128x256xf16, #blocked1> -> !ttg.memdesc<1x128x256xf16, #shared, #smem, mutable>
+    tt.return
+  }
+}
+
+// -----
+
 #blocked = #ttg.blocked<{sizePerThread = [1,2], threadsPerWarp = [32,1], warpsPerCTA = [1,1], order = [1,0]}>
 #blocked1 = #ttg.blocked<{sizePerThread = [1,1], threadsPerWarp = [16,2], warpsPerCTA = [1,1], order = [1,0]}>
 #blocked2 = #ttg.blocked<{sizePerThread = [1], threadsPerWarp = [32], warpsPerCTA = [1], order = [0]}>

--- a/test/TritonGPU/combine.mlir
+++ b/test/TritonGPU/combine.mlir
@@ -2278,6 +2278,29 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 1 : i32, "ttg.thr
 
 // -----
 
+#mma = #ttg.nvidia_mma<{versionMajor = 3, versionMinor = 0, warpsPerCTA = [8, 1], instrShape = [16, 256, 16]}>
+#blocked1 = #ttg.blocked<{sizePerThread = [1, 1, 8], threadsPerWarp = [1, 1, 32], warpsPerCTA = [1, 8, 1], order = [2, 1, 0]}>
+#shared = #ttg.nvmma_shared<{swizzlingByteWidth = 128, transposed = false, elementBitWidth = 16, rank = 3}>
+#smem = #ttg.shared_memory
+
+module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 8 : i32, "ttg.threads-per-warp" = 32 : i32} {
+  // CHECK-LABEL: @expand_dims_reshape_mma_forward_propagate
+  // CHECK-NOT: ttg.convert_layout
+  // CHECK: tt.reshape %arg0
+  // CHECK-NOT: ttg.convert_layout
+  // CHECK: tt.return
+  tt.func public @expand_dims_reshape_mma_forward_propagate(
+      %arg0: tensor<128x256xf16, #mma>) {
+    %0 = ttg.convert_layout %arg0 : tensor<128x256xf16, #mma> -> tensor<128x256xf16, #ttg.slice<{dim = 0, parent = #blocked1}>>
+    %1 = tt.reshape %0 : tensor<128x256xf16, #ttg.slice<{dim = 0, parent = #blocked1}>> -> tensor<1x128x256xf16, #blocked1>
+    %2 = ttg.local_alloc : () -> !ttg.memdesc<1x128x256xf16, #shared, #smem, mutable>
+    ttg.local_store %1, %2 : tensor<1x128x256xf16, #blocked1> -> !ttg.memdesc<1x128x256xf16, #shared, #smem, mutable>
+    tt.return
+  }
+}
+
+// -----
+
 #blocked = #ttg.blocked<{sizePerThread = [1,2], threadsPerWarp = [32,1], warpsPerCTA = [1,1], order = [1,0]}>
 #blocked1 = #ttg.blocked<{sizePerThread = [1,1], threadsPerWarp = [16,2], warpsPerCTA = [1,1], order = [1,0]}>
 #blocked2 = #ttg.blocked<{sizePerThread = [1], threadsPerWarp = [32], warpsPerCTA = [1], order = [0]}>

--- a/test/TritonGPU/partition-scheduling.mlir
+++ b/test/TritonGPU/partition-scheduling.mlir
@@ -165,9 +165,9 @@ tt.func @optimize_broadcast(%arg0: i32, %arg1: !tt.tensordesc<128x128xf32, #shar
     // CHECK: [[X:%.*]] = "producer"{{.*}}partition = array<i32: 0>
     %x = "producer"() {ttg.partition = array<i32: 0>, data} : () -> tensor<128xf32>
 
-    // CHECK-DAG: [[X0_P0:%.*]] = tt.expand_dims [[X]] {{.*}}partition = array<i32: 0>
-    // CHECK-DAG: [[X0_P1:%.*]] = tt.expand_dims [[X]] {{.*}}partition = array<i32: 1>
-    %x0 = tt.expand_dims %x {axis = 0 : i32} : tensor<128xf32> -> tensor<1x128xf32>
+    // CHECK-DAG: [[X0_P0:%.*]] = tt.reshape [[X]] {{.*}}partition = array<i32: 0>
+    // CHECK-DAG: [[X0_P1:%.*]] = tt.reshape [[X]] {{.*}}partition = array<i32: 1>
+    %x0 = tt.reshape %x : tensor<128xf32> -> tensor<1x128xf32>
     // CHECK-DAG: [[X1_P0:%.*]] = tt.broadcast [[X0_P0]] {{.*}}partition = array<i32: 0>
     // CHECK-DAG: [[X1_P1:%.*]] = tt.broadcast [[X0_P1]] {{.*}}partition = array<i32: 1>
     %x1 = tt.broadcast %x0 : tensor<1x128xf32> -> tensor<128x128xf32>

--- a/third_party/nvidia/hopper/lib/Transforms/WarpSpecialization/WSDataPartition.cpp
+++ b/third_party/nvidia/hopper/lib/Transforms/WarpSpecialization/WSDataPartition.cpp
@@ -273,6 +273,16 @@ static bool getBackwardSliceToPartition(Value v,
         currentDim--;
     }
 
+    if (auto reshapeOp = dyn_cast<ReshapeOp>(op)) {
+      if (auto axis = reshapeOp.getExpandDimsAxis();
+          axis && !reshapeOp.getAllowReorder()) {
+        // currentDim is the dim after expansion.
+        assert(*axis != currentDim && "expanded dim always has shape 1");
+        if (*axis < currentDim)
+          currentDim--;
+      }
+    }
+
     // Recusively process operands backwards.
     if (op->hasTrait<OpTrait::Elementwise>() ||
         isa<arith::ConstantOp, arith::ExtSIOp, arith::ExtUIOp, arith::ExtFOp,


### PR DESCRIPTION
Handle unit-dimension reshapes when converting Triton to TritonGPU and
tracking warp-specialization partitions. Treat reshapes as views during
partition scheduling.
