### PR TITLE
Make applyLinearLayout generate cleaner code

### DIFF
--- a/include/triton/Tools/LinearLayout.h
+++ b/include/triton/Tools/LinearLayout.h
@@ -432,6 +432,11 @@ public:
     return isSurjective() && getTotalInDimSize() == getTotalOutDimSize();
   }
 
+  // Given a linear map L: V -> W.
+  // If L(v) = 0 for every vector v in V, where 0 is the zero vector in W,
+  // then L is the zero linear map.
+  bool isZero() const;
+
   // Remove a dimension of size 1 from the layout.
   [[nodiscard]] LinearLayout squeezeIns(StringAttr dim) const;
   [[nodiscard]] LinearLayout squeezeOuts(StringAttr dim) const;

--- a/lib/Conversion/TritonGPUToLLVM/Utility.cpp
+++ b/lib/Conversion/TritonGPUToLLVM/Utility.cpp
@@ -353,6 +353,13 @@ applyLinearLayout(Location loc, RewriterBase &rewriter,
   for (auto &[outDimName, outIdx] : outIndices) {
     // Apply flattened sublayout for this output
     auto matrix = layout.sublayout(inDimNames, outDimName).flattenIns();
+
+    // If `matrix` is a zero layout, then `matrix(x) = 0`.
+    // Since `outIdx ⊕ 0 = outIdx`, we can safely skip the computation below.
+    if (matrix.isZero()) {
+      continue;
+    }
+
     auto out = triton::gpu::matrixVectorProd(b, matrix, x);
     outIdx = b.xor_(outIdx, out);
   }

--- a/lib/Tools/LinearLayout.cpp
+++ b/lib/Tools/LinearLayout.cpp
@@ -763,6 +763,18 @@ LinearLayout operator*(LinearLayout inner, LinearLayout outer) {
                       inner.isSurjective() && outer.isSurjective());
 }
 
+bool LinearLayout::isZero() const {
+  for (const auto& [inDimName, basisImages] : bases) {
+    for (const auto& basisImage : basisImages) {
+      for (const auto& coord : basisImage) {
+        if (coord > 0) return false;
+      }
+    }
+  }
+
+  return true;
+}
+
 bool LinearLayout::isTrivialOver(ArrayRef<StringAttr> dimNames) const {
   for (StringAttr dim : dimNames) {
     if (!hasInDim(dim) || !hasOutDim(dim)) {


### PR DESCRIPTION
Inside `applyLinearLayout` in `lib/Conversion/TritonGPUToLLVM/Utility.cpp`, there is a for loop:
```cpp
for (auto &[outDimName, outIdx] : outIndices) {
  // Apply flattened sublayout for this output
  auto matrix = layout.sublayout(inDimNames, outDimName).flattenIns();
  auto out = triton::gpu::matrixVectorProd(b, matrix, x);
  outIdx = b.xor_(outIdx, out);
}
```

When `matrix` is the zero linear map, for example:
```
matrix:
 - msg=1 -> (0)
   msg=2 -> (0)
   msg=4 -> (0)
   msg=8 -> (0)
   msg=16 -> (0)
where out dims are: [block (size 1)]
```

`triton::gpu::matrixVectorProd(b, matrix, x)` still produces an unnecessary MLIR Value. As a result, `applyLinearLayout` also generates an unnecessary LLVM `xor` instruction:
```
BEFORE outIdx: %144 = llvm.mlir.constant(0 : i32) : i32
matrixVectorProd out: %160 = llvm.or disjoint %158, %159 : i32
AFTERR outIdx: %161 = llvm.xor %144, %160 : i32
```

This MR skips generating unnecessary MLIR operations, making the generated code cleaner.

<!---
The core Triton is a small number of people, and we receive many PRs (thank
you!).  To help us review your code more quickly, **if you are a new
contributor (less than 3 PRs merged) we ask that you complete the following
tasks and include the filled-out checklist in your PR description.**

Complete the following tasks before sending your PR, and replace `[ ]` with
`[x]` to indicate you have done them.
-->

# New contributor declaration
- [x] I am not making a trivial change, such as fixing a typo in a comment.

- [x] I have written a PR description following these
  [rules](https://cbea.ms/git-commit/#why-not-how).

- [x] I have run `pre-commit run --from-ref origin/main --to-ref HEAD`.

- Select one of the following.
  - [ ] I have added tests.
    - `/test` for `lit` tests
    - `/unittest` for C++ tests
    - `/python/test` for end-to-end tests
  - [x] This PR does not need a test because `./test/Conversion/tritonnvidiagpu_to_llvm.mlir` has already included several test cases for `ttng.async_tma_copy_global_to_local` which can cover my changes.

- Select one of the following.
  - [x] I have not added any `lit` tests.
  - [ ] The `lit` tests I have added follow these [best practices](https://mlir.llvm.org/getting_started/TestingGuide/#filecheck-best-practices),
    including the "tests should be minimal" section. (Usually running Python code
    and using the instructions it generates is not minimal.)
