### PR TITLE
[TritonGPU] Fix typos in op/pass descriptions and comments

### DIFF
--- a/include/triton/Dialect/Gluon/Transforms/Passes.td
+++ b/include/triton/Dialect/Gluon/Transforms/Passes.td
@@ -42,7 +42,7 @@ def GluonInline: Pass<"gluon-inline"> {
 }
 
 def GluonSimplifyControlFlow: Pass<"gluon-slimplify-control-flow"> {
-  let summary = "simplications for control flow ops";
+  let summary = "simplifications for control flow ops";
 
   let description = [{
     The `gluon-simplify-control-flow` pass applies a reduced set of

--- a/include/triton/Dialect/TritonGPU/IR/TritonGPUAttrDefs.td
+++ b/include/triton/Dialect/TritonGPU/IR/TritonGPUAttrDefs.td
@@ -511,7 +511,7 @@ current block number: 0, 1, 2.. maxPhase-1, 0, 1, 2 ...
 
 This layout is used to reduce bank conflicts in cases where shared memory writes
 and reads are performed on layouts with different order. It's meant for hardware
-without native shared memory tranpose support.
+without native shared memory transpose support.
 
 Swizzling pattern affects only 2 fastest dimensions of a tensor.
 In the following text these two dimensions are called row and column:
@@ -529,7 +529,7 @@ Swizzling pattern is following:
 
 Let's consider an element with logical coordinates = (inRowId, inColId).
 For simplicity, we do not vectorize memory in examples,
-i.e. vec == 1 and layout swizzles inidividual elements.
+i.e. vec == 1 and layout swizzles individual elements.
 For vec != 1 example, take a look at SwizzledSharedEncodingAttr documentation.
 
 Swizzled coordinates within memory object are (outRowId, outColId):
@@ -1169,7 +1169,7 @@ Row |
 Example 2:
 This example illustrates the purpose of the ctaLayout parameter.
 ctaLayout is a linear layout describing how warps are arranged across WMMA tiles.
-Previously, this information was encoded using warpsPerCTA and tilesPerWarp parametes.
+Previously, this information was encoded using warpsPerCTA and tilesPerWarp parameters.
 For instance, a configuration with 4 warps, represented as:
 
 warpsPerCTA = [2, 2], tilesPerWarp = [1, 1]
@@ -1225,7 +1225,7 @@ w2 w3
 w0 w1 <- first tile computed by w1
 w2 w3
 
-Note that ctaLayout naturally composes with layout definied on a single WMMA tile
+Note that ctaLayout naturally composes with layout defined on a single WMMA tile
 to form final WMMA layout.
 
 wmmaLayout = tileLayout * ctaLayout

--- a/include/triton/Dialect/TritonGPU/IR/TritonGPUOps.td
+++ b/include/triton/Dialect/TritonGPU/IR/TritonGPUOps.td
@@ -51,7 +51,7 @@ def TTG_AsyncWaitOp : TTG_Op<"async_wait", [MemWaitOpTrait]> {
     It takes zero or more `asyncToken` plus an integer `num` that specifies how many async copy groups can remain
     outstanding after the `async_wait` op is completed. `num = 0` waits until all groups of async copies are complete.
 
-    This operation does not provide any syncronisation in the CTA, if syncronisation is needed use `ttg.local_barrier`
+    This operation does not provide any synchronization in the CTA, if synchronization is needed use `ttg.local_barrier`
     in addition to this operation.
   }];
 
@@ -737,17 +737,17 @@ def TTG_BarrierOp : TTG_Op<"barrier"> {
     The `barrier` op synchronises the execution and all operations between the selected address spaces for all
     threads in the CTA. It is used to coordinate communication between threads in the CTA.
 
-    This operation waits until all threads in the CTA have reached a `barrier` (for syncronisation) and operations
+    This operation waits until all threads in the CTA have reached a `barrier` (for synchronization) and operations
     between the selected address spaces made by these threads prior to the op are visible to all threads in the CTA.
 
     Data hazards between threads accessing the same memory can be avoided by synchronising the
     specified scope in-between these accesses with a `barrier`.
 
-    A `barrier` operation only provides syncronisation and memory guarantees on the selected address spaces in the CTA.
+    A `barrier` operation only provides synchronization and memory guarantees on the selected address spaces in the CTA.
 
     The mandatory `addrspace` attribute is a bitmask describing which address spaces will be visible when the `barrier` completes:
 
-    * `none`         control-only syncronisation (no memory ordering).
+    * `none`         control-only synchronization (no memory ordering).
     * `local`        shared-memory operations are complete and visible CTA-wide.
     * `global_read`  global memory reads are complete and visible CTA-wide.
     * `global_write` global memory writes are complete and visible CTA-wide.

--- a/include/triton/Dialect/TritonGPU/Transforms/Passes.td
+++ b/include/triton/Dialect/TritonGPU/Transforms/Passes.td
@@ -228,7 +228,7 @@ def TritonGPUOptimizeDotOperands : Pass<"tritongpu-optimize-dot-operands", "mlir
   let options = [
     Option<"hoistLayoutConversion", "hoist-layout-conversion",
            "bool", /*default*/"true",
-           "whether to move conver to dot operand earlier pass elementwise ops">
+           "whether to move convert to dot operand earlier pass elementwise ops">
   ];
 }
 

--- a/include/triton/Dialect/TritonGPU/Transforms/PipeliningUtility.h
+++ b/include/triton/Dialect/TritonGPU/Transforms/PipeliningUtility.h
@@ -180,13 +180,13 @@ DenseSet<Operation *>
 getTopLevelUsersInLoop(Operation *op, scf::ForOp forOp,
                        std::function<bool(Operation *)> filter = nullptr);
 
-// Return the "first" op in terms of the stage and cluser ordering
+// Return the "first" op in terms of the stage and cluster ordering
 Operation *
 getFirstUseOfPipelinedOp(ArrayRef<Operation *> ops, scf::ForOp forOp,
                          CoarseSchedule &schedule,
                          std::function<bool(Operation *)> filterUse = nullptr);
 
-// Return the "last" op in terms of the stage and cluser ordering
+// Return the "last" op in terms of the stage and cluster ordering
 Operation *
 getLastUseOfPipelinedOp(ArrayRef<Operation *> ops, scf::ForOp forOp,
                         CoarseSchedule &schedule,


### PR DESCRIPTION
<!---
The core Triton is a small number of people, and we receive many PRs (thank
you!).  To help us review your code more quickly, **if you are a new
contributor (less than 3 PRs merged) we ask that you complete the following
tasks and include the filled-out checklist in your PR description.**

Complete the following tasks before sending your PR, and replace `[ ]` with
`[x]` to indicate you have done them.
-->

Fixes several spelling typos in developer-facing comments and MLIR op/pass
descriptions under `include/triton/Dialect/`. Comment/description-only — no
functional, IR, or API changes, and no code identifiers, op names, or pass
registration names were touched.

- TritonGPUAttrDefs.td: tranpose -> transpose, inidividual -> individual,
  parametes -> parameters, definied -> defined
- TritonGPUOps.td: syncronisation -> synchronization (x5)
- TritonGPU/Transforms/Passes.td: conver -> convert (hoist-layout-conversion help text)
- TritonGPU/Transforms/PipeliningUtility.h: cluser -> cluster (x2)
- Gluon/Transforms/Passes.td: simplications -> simplifications (pass summary)

# New contributor declaration
- [ ] I am not making a trivial change, such as fixing a typo in a comment.

- [x] I have written a PR description following these
  [rules](https://cbea.ms/git-commit/#why-not-how).

- [ ] I have run `pre-commit run --from-ref origin/main --to-ref HEAD`.

- Select one of the following.
  - [ ] I have added tests.
    - `/test` for `lit` tests
    - `/unittest` for C++ tests
    - `/python/test` for end-to-end tests
  - [x] This PR does not need a test because `FILL THIS IN`.

- Select one of the following.
  - [x] I have not added any `lit` tests.
  - [ ] The `lit` tests I have added follow these [best practices](https://mlir.llvm.org/getting_started/TestingGuide/#filecheck-best-practices),
    including the "tests should be minimal" section. (Usually running Python code
    and using the instructions it generates is not minimal.)
