### PR TITLE
Canonicalize reshape(broadcast) -> broadcast(reshape)

### DIFF
--- a/lib/Dialect/Triton/IR/Ops.cpp
+++ b/lib/Dialect/Triton/IR/Ops.cpp
@@ -880,6 +880,70 @@ LogicalResult ReshapeOp::canonicalize(ReshapeOp op, PatternRewriter &rewriter) {
     return failure();
   }
 
+  // reshape(broadcast(x)) -> broadcast(reshape(x))
+  //
+  // On its own this doesn't do much, but consider
+  //    broadcast(reshape(broadcast))
+  // -> broadcast(broadcast(reshape))
+  // -> broadcast(reshape)
+  if (auto broadcast = dyn_cast<BroadcastOp>(definingOp)) {
+    auto removeUnitDims = [](ArrayRef<int64_t> shape) {
+      SmallVector<int64_t> result;
+      for (int64_t dim : shape)
+        if (dim != 1)
+          result.push_back(dim);
+      return result;
+    };
+    // We can only do this if the reshape only adds/removes unit dimensions.
+    auto broadcastShape = op.getSrc().getType().getShape();
+    auto dstShape = op.getType().getShape();
+    if (removeUnitDims(broadcastShape) == removeUnitDims(dstShape)) {
+      auto src = broadcast.getSrc();
+      auto srcType = src.getType();
+      auto broadcastSrcShape = srcType.getShape();
+      // Compute the result shape of the new reshape. It should be dstShape with
+      // some dims set to 1.
+      auto newShape = dstShape.vec();
+      unsigned broadcastDim = 0;
+      for (int64_t &dim : newShape) {
+        // We are only interested in the non-unit dims, since the reshape may
+        // add or remove any number of unit dims.
+        if (dim == 1)
+          continue;
+        while (broadcastShape[broadcastDim] == 1)
+          ++broadcastDim;
+        // For each non-unit result dim of the broadcast, set the reshape result
+        // to be the source dim size of the broadcast.
+        dim = broadcastSrcShape[broadcastDim++];
+      }
+
+      auto newType = op.getType().clone(newShape);
+      // Check that a reshape on the smaller shape can still go from the
+      // original broadcast src encoding to the original reshape dst encoding.
+      // This may not always be the case, for instance, dot operand encoding
+      // introduces broadcasting on smaller shapes.
+      if (auto srcEncoding = srcType.getEncoding()) {
+        auto interface =
+            cast<DialectInferLayoutInterface>(&srcEncoding.getDialect());
+        auto resultEncoding = newType.getEncoding();
+        Attribute inferredEncoding = resultEncoding;
+        if (failed(interface->inferReshapeOpEncoding(
+                srcType.getShape(), srcEncoding, newShape, inferredEncoding,
+                op.getAllowReorder(), /*loc=*/{})) ||
+            failed(interface->verifyLayoutsAreEqual(
+                newShape, inferredEncoding, resultEncoding, /*loc=*/{})))
+          return failure();
+      }
+      auto newReshape = ReshapeOp::create(rewriter, op.getLoc(), newType, src,
+                                          op.getAllowReorder(),
+                                          /*efficient_layout=*/false);
+      auto newBroadcast = BroadcastOp::create(rewriter, broadcast.getLoc(),
+                                              op.getType(), newReshape);
+      rewriter.replaceOp(op, newBroadcast);
+      return success();
+    }
+  }
+
   // reshape(reshape) -> reshape
   if (auto parentReshape = dyn_cast<ReshapeOp>(definingOp)) {
     // Allow reorder if either reshape allowed it

--- a/test/Triton/canonicalize.mlir
+++ b/test/Triton/canonicalize.mlir
@@ -69,6 +69,37 @@ tt.func @fn(%arg0: tensor<1xf32, #sliced0>) -> (tensor<32x1xf32, #blocked0>){
 
 // -----
 
+// CHECK-LABEL: @canonicalize_broadcast_reshape_chain
+tt.func @canonicalize_broadcast_reshape_chain(%arg0: tensor<8xf32>) -> tensor<2x4x4x8xf32> {
+  // CHECK-NEXT: %[[RESHAPE:.*]] = tt.reshape %arg0 : tensor<8xf32> -> tensor<1x1x1x8xf32>
+  // CHECK-NEXT: %[[BROADCAST:.*]] = tt.broadcast %[[RESHAPE]] : tensor<1x1x1x8xf32> -> tensor<2x4x4x8xf32>
+  // CHECK-NEXT: tt.return %[[BROADCAST]] : tensor<2x4x4x8xf32>
+  %0 = tt.reshape %arg0 : tensor<8xf32> -> tensor<1x8xf32>
+  %1 = tt.broadcast %0 : tensor<1x8xf32> -> tensor<4x8xf32>
+  %2 = tt.reshape %1 : tensor<4x8xf32> -> tensor<1x4x1x8xf32>
+  %3 = tt.broadcast %2 : tensor<1x4x1x8xf32> -> tensor<2x4x4x8xf32>
+  tt.return %3 : tensor<2x4x4x8xf32>
+}
+
+// -----
+
+#linear = #ttg.linear<{register = [[0, 0, 1], [8, 0, 0], [0, 0, 8], [0, 0, 16], [64, 0, 0]], lane = [[0, 0, 2], [0, 0, 4], [1, 0, 0], [2, 0, 0], [4, 0, 0]], warp = [[16, 0, 0], [32, 0, 0]], block = []}>
+#mma = #ttg.nvidia_mma<{versionMajor = 3, versionMinor = 0, warpsPerCTA = [4, 1], instrShape = [16, 16, 16]}>
+#dot = #ttg.dot_op<{opIdx = 0, parent = #mma, kWidth = 2}>
+module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.target = "cuda:90", "ttg.threads-per-warp" = 32 : i32} {
+  // CHECK-LABEL: @preserve_reshape_result_layout
+  tt.func @preserve_reshape_result_layout(%arg0: tensor<128x1x1xbf16, #linear>) -> tensor<128x32xbf16, #dot> {
+    // CHECK-NEXT: %[[BROADCAST:.*]] = tt.broadcast %arg0
+    // CHECK-NEXT: %[[RESHAPE:.*]] = tt.reshape %[[BROADCAST]]
+    // CHECK-NEXT: tt.return %[[RESHAPE]]
+    %0 = tt.broadcast %arg0 : tensor<128x1x1xbf16, #linear> -> tensor<128x1x32xbf16, #linear>
+    %1 = tt.reshape %0 : tensor<128x1x32xbf16, #linear> -> tensor<128x32xbf16, #dot>
+    tt.return %1 : tensor<128x32xbf16, #dot>
+  }
+}
+
+// -----
+
 #blocked = #ttg.blocked<{sizePerThread = [1, 4], threadsPerWarp = [8, 4], warpsPerCTA = [1, 1], order = [1, 0]}>
 module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 1 : i32} {
   tt.func @fp_to_fp_pos_zero_fold() -> tensor<32x128xf8E4M3FNUZ, #blocked> {


### PR DESCRIPTION

Implement the pattern we have for expand dims for reshape as well. This
is more generic than the expand dims one, since it allows the reshape to
add or remove an arbitrary number of unit dims, as long as the original
layouts can be maintained.

---
[//]: # (BEGIN SAPLING FOOTER)
* __->__ #10806
* #10421
* #10797
* #10799
* #10807
* #10796
* #10731