### PR TITLE
[AMD] Rewrite gluon partition layout derivation

### DIFF
--- a/lib/Analysis/Allocation.cpp
+++ b/lib/Analysis/Allocation.cpp
@@ -57,7 +57,7 @@ unsigned getNumScratchElemsSwizzledCvt(const LinearLayout &srcLayout,
   // The smem has the same cta layout as the srcLayout, so we use that instead
   // We remove the number of elements that are duplicated in the cta layout
   auto nBlocks = product(triton::gpu::getCTASplitNum(
-      gpu::LinearEncodingAttr::get(ctx, srcLayout)));
+      gpu::GenericLinearEncodingAttr::get(ctx, srcLayout)));
   return smem.getTotalOutDimSize() / (reps * nBlocks);
 }
 

--- a/python/src/gluon_ir.cc
+++ b/python/src/gluon_ir.cc
@@ -1365,7 +1365,12 @@ void init_gluon_ir(py::module_ &m) {
           auto ll = ttg::chooseScaledWmmaScaleLayout(
               &ctx, opIdx, shape, wmmaMDim, wmmaNDim, isTransposed, scaleFactor,
               ctaLayout, cgaLayout);
-          auto attr = ttg::LinearEncodingAttr::get(&ctx, ll);
+          // A swizzled (partition-aware) WMMA produces a non-permutation scale
+          // layout, which only GenericLinearEncodingAttr can represent.
+          Attribute attr =
+              ttg::isPermutationMatrixLayout(ll)
+                  ? Attribute(ttg::LinearEncodingAttr::get(&ctx, ll))
+                  : Attribute(ttg::GenericLinearEncodingAttr::get(&ctx, ll));
           return layoutToGluon(attr);
         });
 

--- a/python/test/gluon/test_frontend.py
+++ b/python/test/gluon/test_frontend.py
@@ -2206,15 +2206,21 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.targ
 
 @pytest.mark.parametrize("num_warps", [4, 8])
 @pytest.mark.parametrize("block_m,block_n", [(64, 64), (64, 128), (128, 128)])
+@pytest.mark.parametrize("subtiles_m,subtiles_n", [(1, 1), (1, 2), (2, 1), (2, 2)])
 @pytest.mark.parametrize("a_transposed", [False, True])
 @pytest.mark.parametrize("b_transposed", [False, True])
-def test_make_partitioned_dot_layouts(num_warps, block_m, block_n, a_transposed, b_transposed):
+def test_make_partitioned_dot_layouts(num_warps, block_m, block_n, subtiles_m, subtiles_n, a_transposed, b_transposed):
     block_k = 32
     INSTR_M, INSTR_N, INSTR_K = 16, 16, 32
-    # WARP_TILES_M=4 and WARP_TILES_N=2 for both 4- and 8-warp cases (different
-    # warp/reg base layouts but same per-warp tile extents).
-    warp_coverage_m = 4 * INSTR_M
-    warp_coverage_n = 2 * INSTR_N
+
+    # The WMMA layout is sized for the sliced compute extent (block / subtiles),
+    # while the shared layouts still partition the full block.
+    slice_m = block_m // subtiles_m
+    slice_n = block_n // subtiles_n
+    # A slice must cover at least NUM_PARTITIONS (=2) * tiles_per_partition
+    # instruction tiles (2 in M, 1 in N); skip configs that violate this.
+    if slice_m < 4 * INSTR_M or slice_n < 2 * INSTR_N:
+        pytest.skip(f"slice ({slice_m}, {slice_n}) below the minimum partition extent")
 
     a_shape = [block_k, block_m] if a_transposed else [block_m, block_k]
     b_shape = [block_n, block_k] if b_transposed else [block_k, block_n]
@@ -2222,30 +2228,31 @@ def test_make_partitioned_dot_layouts(num_warps, block_m, block_n, a_transposed,
     pb = ttgl.PaddedSharedLayout.with_identity_for([[b_shape[1], 8]], b_shape, [1, 0])
     sla, slb, wmma = make_partitioned_dot_layouts(block_m, block_n, pa, pb, num_warps=num_warps,
                                                   instr_shape=[INSTR_M, INSTR_N, INSTR_K], a_transposed=a_transposed,
-                                                  b_transposed=b_transposed)
+                                                  b_transposed=b_transposed, slice_m=slice_m, slice_n=slice_n)
 
-    a_num_groups = block_m // warp_coverage_m
-    b_num_groups = block_n // warp_coverage_n
     a_partition_dim = 1 if a_transposed else 0
     b_partition_dim = 0 if b_transposed else 1
-    # The non-partitioned axis of each piece is block_k, the partitioned axis is
-    # divided down to (block / num_partitions / num_groups).
-    a_inner = [block_m / 2 / a_num_groups, block_k]
-    b_inner = [block_n / 2 / b_num_groups, block_k] if b_transposed else [block_k, block_n / 2 / b_num_groups]
-    for layout, num_groups, partition_dim, inner_shape in [
-        (sla, a_num_groups, a_partition_dim, a_inner),
-        (slb, b_num_groups, b_partition_dim, b_inner),
-    ]:
+    a_pieces = 2 * subtiles_m
+    b_pieces = 2 * subtiles_n
+    a_inner = [block_k, block_m // a_pieces] if a_transposed else [block_m // a_pieces, block_k]
+    b_inner = [block_n // b_pieces, block_k] if b_transposed else [block_k, block_n // b_pieces]
+    for layout, partition_dim, num_groups, inner_shape in [(sla, a_partition_dim, subtiles_m, a_inner),
+                                                           (slb, b_partition_dim, subtiles_n, b_inner)]:
         assert isinstance(layout, PartitionedSharedLayout)
         assert layout.num_partitions == 2
         assert layout.num_groups == num_groups
         assert layout.partition_dim == partition_dim
         assert layout.partition_layout.shape == inner_shape
 
-    if num_warps == 4:
-        expected_warp_bases, expected_reg_bases = [[2, 1], [1, 0]], [[2, 0]]
-    else:
-        expected_warp_bases, expected_reg_bases = [[2, 1], [1, 0], [2, 0]], []
+    STM, STN = slice_m // INSTR_M, slice_n // INSTR_N
+    piece_m, piece_n = STM // 4, STN // 2
+    expected_warp_bases = [[STM // 2, piece_n], [piece_m, 0]]
+    m_group = [piece_m * 2]
+    if num_warps == 8:
+        expected_warp_bases.append([m_group.pop(), 0])
+    expected_reg_bases = [[0, 1 << i] for i in range(piece_n.bit_length() - 1)]
+    expected_reg_bases += [[1 << i, 0] for i in range(piece_m.bit_length() - 1)]
+    expected_reg_bases += [[w, 0] for w in m_group]
     assert isinstance(wmma, amd_layouts.AMDWMMALayout)
     assert wmma.warp_bases == expected_warp_bases
     assert wmma.reg_bases == expected_reg_bases

--- a/python/triton/experimental/gluon/language/amd/gfx1250/_layouts.py
+++ b/python/triton/experimental/gluon/language/amd/gfx1250/_layouts.py
@@ -72,24 +72,24 @@ class PartitionedSharedLayout(SharedLayout):
 
 
 @constexpr_function
-def _make_partitioned_dot_operand_layout(sublayout, partition_dim, num_partitions, block_mn_size, warp_coverage, order):
+def _make_partitioned_dot_operand_layout(sublayout, partition_dim, num_partitions, num_groups, order):
     """Build a ``PartitionedSharedLayout`` for one GEMM operand.
 
     The operand tile (``sublayout``) is split along ``partition_dim`` into
-    ``num_partitions * num_groups`` logical pieces, where
-    ``num_groups = block_mn_size // warp_coverage``.  Each piece carries an
-    inner ``PaddedSharedLayout`` rebuilt with an identity mapping using the
-    original sublayout's ``interval_padding_pairs`` and ``cga_layout``.
+    ``num_partitions * num_groups`` logical pieces. Each
+    piece carries an inner ``PaddedSharedLayout`` rebuilt with an identity
+    mapping using the original sublayout's parameters.
     """
     is_power_of_2 = lambda n: n > 0 and n & (n - 1) == 0
-    num_groups = block_mn_size // warp_coverage
-    assert num_groups >= 1, f"block dim ({block_mn_size}) must be >= {warp_coverage}"
+    assert num_groups >= 1, f"num_groups ({num_groups}) must be >= 1"
     assert is_power_of_2(num_groups), \
-        f"block_dim / warp_coverage = {num_groups} must be a power of 2"
+        f"num_groups = {num_groups} must be a power of 2"
 
     num_logical_pieces = num_partitions * num_groups
     inner_shape = list(sublayout.shape)
-    assert inner_shape[partition_dim] % num_logical_pieces == 0
+    assert inner_shape[partition_dim] % num_logical_pieces == 0, \
+        f"partitioned dim ({inner_shape[partition_dim]}) must be divisible by " \
+        f"num_partitions * num_groups = {num_logical_pieces}"
     inner_shape[partition_dim] //= num_logical_pieces
 
     # TODO: when the partitioned dimension is the contiguous (fastest-varying)
@@ -102,17 +102,17 @@ def _make_partitioned_dot_operand_layout(sublayout, partition_dim, num_partition
 
 @constexpr_function
 def make_partitioned_dot_layouts(block_m, block_n, original_layout_a, original_layout_b, num_warps, instr_shape,
-                                 a_transposed=False, b_transposed=False):
+                                 a_transposed=False, b_transposed=False, slice_m=None, slice_n=None):
     """Create partitioned shared memory layouts and WMMA layout for a GFX1250 GEMM
        in order to avoid LDS partition conflicts.
 
     Args:
-        block_m: M dimension tile size.  Must be at least
-            ``WARP_TILES_M * instr_shape[0]`` (the per-CTA M extent covered by
-            one partition group), and a power-of-2 multiple thereof.
-        block_n: N dimension tile size.  Must be at least
-            ``WARP_TILES_N * instr_shape[1]``, and a power-of-2 multiple
-            thereof.
+        block_m: M dimension tile size of the *shared* operand buffer.  Must be
+            at least ``4 * instr_shape[0]`` because one partition in M dimension
+            must be at least 2 tiles wide.
+        block_n: N dimension tile size of the *shared* operand buffer.  Must be
+            at least ``2 * instr_shape[1]`` since one partition in N dimension
+            must be at least 1 tile wide.
         original_layout_a: ``PaddedSharedLayout`` for operand A.  Shape is
             ``[block_m, block_k]`` when not transposed (K contiguous) and
             ``[block_k, block_m]`` when transposed (M contiguous).
@@ -125,9 +125,13 @@ def make_partitioned_dot_layouts(block_m, block_n, original_layout_a, original_l
             the contiguous axis instead of K.
         b_transposed: Whether B is transposed in shared memory, i.e. K is
             the contiguous axis instead of N.
+        slice_m: M dimension of a dot operation after slicing. Defaults to ``block_m`` (unsliced).
+        slice_n: N dimension of a dot operation after slicing. Defaults to ``block_n`` (unsliced).
 
     Returns:
-        A tuple ``(shared_layout_a, shared_layout_b, wmma_layout)``.
+        A tuple ``(shared_layout_a, shared_layout_b, wmma_layout)``.  The
+        ``wmma_layout`` is sized for ``slice_m x slice_n``; the two shared
+        layouts partition the full ``block_m`` / ``block_n``.
     """
     from triton.experimental.gluon.language.amd._layouts import AMDWMMALayout
 
@@ -147,6 +151,31 @@ def make_partitioned_dot_layouts(block_m, block_n, original_layout_a, original_l
     # transposition. TDM additionally requires order [rank-1, ..., 0].
     order = [1, 0]
 
+    INSTR_M = INSTR_SHAPE[0]
+    INSTR_N = INSTR_SHAPE[1]
+
+    is_power_of_2 = lambda n: n > 0 and (n & (n - 1)) == 0
+
+    # The sliced dot compute extent defaults to the full block (unsliced).
+    slice_m = block_m if slice_m is None else slice_m
+    slice_n = block_n if slice_n is None else slice_n
+
+    assert is_power_of_2(INSTR_M) and is_power_of_2(INSTR_N), \
+        f"instr_shape M/N must be powers of 2, got {INSTR_SHAPE}"
+    assert block_m % INSTR_M == 0 and block_n % INSTR_N == 0, \
+        f"block ({block_m}, {block_n}) must be a multiple of instr_shape ({INSTR_M}, {INSTR_N})"
+    assert is_power_of_2(slice_m) and is_power_of_2(slice_n), \
+        f"slice_m / slice_n must be powers of 2, got ({slice_m}, {slice_n})"
+    assert block_m % slice_m == 0 and block_n % slice_n == 0, \
+        f"slice ({slice_m}, {slice_n}) must divide block ({block_m}, {block_n})"
+    assert slice_m % INSTR_M == 0 and slice_n % INSTR_N == 0, \
+        f"slice ({slice_m}, {slice_n}) must be a multiple of instr_shape ({INSTR_M}, {INSTR_N})"
+
+    def _log2(n):
+        return n.bit_length() - 1
+
+    # --- Derived layout rule -------------------------------------------------
+    #
     # WMMA CTA layout: Below, M runs vertically (rows) and N
     # horizontally (cols); each cell is one INSTR_SHAPE-sized instruction tile,
     # labelled with the warp that computes it.  ``warp_bases`` map warp-id bits
@@ -163,32 +192,80 @@ def make_partitioned_dot_layouts(block_m, block_n, original_layout_a, original_l
     # Such layout allows w0 and w1 as well as w2 and w3 to read different A/B
     # operand data blocks in a single instruction, which is necessary precondition
     # for avoiding LDS partition conflicts.
-    if num_warps == 4:
-        warp_bases = [[2, 1], [1, 0]]
-        reg_bases = [[2, 0]]
-    else:  # num_warps == 8
-        # Same idea as the 4-warp case, but the third warp bit replaces the
-        # register bit. This means there's no need to define repetition registers,
-        # single instruction CTA layout is enough to describe the layout we need.
-        # Each warp now owns a single instruction tile and the extra warp dimension
-        # is folded into the M-axis of the warp grid.
-        warp_bases = [[2, 1], [1, 0], [2, 0]]
-        reg_bases = []
+    #
+    # The above defined CTALayout tile will then be repeated across the full block (block_m x block_n).
+    # However, this is not always the optimal way to partition the full block.
+    # For example, if the block 64x128, the block would look like this:
+    #
+    #   M=0:  w0 w1 w0 w1 w0 w1 w0 w1
+    #   M=1:  w2 w3 w2 w3 w2 w3 w2 w3
+    #   M=2:  w0 w1 w0 w1 w0 w1 w0 w1
+    #   M=3:  w2 w3 w2 w3 w2 w3 w2 w3
+    #
+    # From the TDM perspective, wave can only transfer one strided logical piece at a time.
+    # Since we have 8 logical pieces for B tensor above, and only 4 warps, TDM transaction will be split
+    # into 2 instructions, which is not efficient.
+    #
+    # to avoid this, we can increase number of consecutive tiles the wave computes.
+    # In the above example, we could create following CTA layout:
+    #
+    #   M=0:  w0 w0 w0 w0 w1 w1 w1 w1
+    #   M=1:  w2 w2 w2 w2 w3 w3 w3 w3
+    #   M=2:  w0 w0 w0 w0 w1 w1 w1 w1
+    #   M=3:  w2 w2 w2 w2 w3 w3 w3 w3
+    #
+    # This way, each warp can read 2 larger strided logical pieces at a time, which will produce 1 TDM transaction.
+    # In addition to having less transaction, this can also help with global bandwidth, because in N contiguous
+    # tensors, it's better if the cache line is not split across multiple waves. This way we can read the whole
+    # cache line with a single wave.
 
-    # The tile extent along each dimension is 2^m, where m is the largest
-    # basis component in that dimension across both warp and register bases.
-    def _tile_extent(dim):
-        m = max((b[dim] for b in warp_bases + reg_bases), default=0)
-        return 1 << m
+    tiles_per_slice_m = slice_m // INSTR_M
+    tiles_per_slice_n = slice_n // INSTR_N
+    tiles_per_partition_m = 2
+    tiles_per_partition_n = 1
 
-    WARP_TILES_M = _tile_extent(0)
-    WARP_TILES_N = _tile_extent(1)
+    # Each slice must cover at least one instruction tile per partition piece,
+    # otherwise piece_m / piece_n would round down to 0 and produce a degenerate
+    # (non-surjective) WMMA layout with zero warp/register bases.
+    assert tiles_per_slice_m >= NUM_PARTITIONS * tiles_per_partition_m, \
+        f"slice_m ({slice_m}) must be at least " \
+        f"{NUM_PARTITIONS * tiles_per_partition_m} * instr_shape[0] ({INSTR_M})"
+    assert tiles_per_slice_n >= NUM_PARTITIONS * tiles_per_partition_n, \
+        f"slice_n ({slice_n}) must be at least " \
+        f"{NUM_PARTITIONS * tiles_per_partition_n} * instr_shape[1] ({INSTR_N})"
+
+    piece_m = tiles_per_slice_m // (NUM_PARTITIONS * tiles_per_partition_m)
+    piece_n = tiles_per_slice_n // (NUM_PARTITIONS * tiles_per_partition_n)
+
+    # Registers that walk the contiguous tiles inside one piece.
+    m_within = [1 << i for i in range(_log2(piece_m))]
+    n_within = [1 << i for i in range(_log2(piece_n))]
+    # Register that jump between same-partition pieces of A inside one slice
+    # (within-slice group repeats).
+    m_group = [piece_m * 2]
+
+    warp_bases = [[tiles_per_slice_m // 2, piece_n], [piece_m, 0]]
+    reg_bases = []
+
+    if num_warps == 8:
+        # In 8 warp case, instead of repetition of warp0, we use that tile for warp4.
+        warp_bases.append([m_group[-1], 0])
+        m_group = m_group[:-1]
+
+    # Register bases, ordered N-within, M-within, M-group.
+    for w in n_within:
+        reg_bases.append([0, w])
+    for w in m_within:
+        reg_bases.append([w, 0])
+    for w in m_group:
+        reg_bases.append([w, 0])
 
     wmma_layout = AMDWMMALayout(3, True, warp_bases, reg_bases, INSTR_SHAPE)
 
-    # Per-CTA extent that one warp+register cycle covers in each dimension.
-    warp_coverage_m = WARP_TILES_M * INSTR_SHAPE[0]
-    warp_coverage_n = WARP_TILES_N * INSTR_SHAPE[1]
+    # Full-block partitioning (PartitionedSharedLayout): num_groups counts how
+    # many times the [P0, P1] cycle repeats across the full block = block / slice.
+    num_groups_m = block_m // slice_m
+    num_groups_n = block_n // slice_n
 
     # Partition A along its M axis and B along its N axis.  These dims live
     # at different positions in the tile depending on transposition (the
@@ -197,10 +274,10 @@ def make_partitioned_dot_layouts(block_m, block_n, original_layout_a, original_l
     b_partition_dim = 0 if b_transposed else 1
 
     shared_layout_a = _make_partitioned_dot_operand_layout(original_layout_a, partition_dim=a_partition_dim,
-                                                           num_partitions=NUM_PARTITIONS, block_mn_size=block_m,
-                                                           warp_coverage=warp_coverage_m, order=order)
+                                                           num_partitions=NUM_PARTITIONS, num_groups=num_groups_m,
+                                                           order=order)
     shared_layout_b = _make_partitioned_dot_operand_layout(original_layout_b, partition_dim=b_partition_dim,
-                                                           num_partitions=NUM_PARTITIONS, block_mn_size=block_n,
-                                                           warp_coverage=warp_coverage_n, order=order)
+                                                           num_partitions=NUM_PARTITIONS, num_groups=num_groups_n,
+                                                           order=order)
 
     return shared_layout_a, shared_layout_b, wmma_layout

--- a/python/triton/experimental/gluon/language/amd/gfx1250/_layouts.py
+++ b/python/triton/experimental/gluon/language/amd/gfx1250/_layouts.py
@@ -108,11 +108,11 @@ def make_partitioned_dot_layouts(block_m, block_n, original_layout_a, original_l
 
     Args:
         block_m: M dimension tile size of the *shared* operand buffer.  Must be
-            at least ``4 * instr_shape[0]`` because one partition in M dimension
-            must be at least 2 tiles wide.
+            at least ``4 * instr_shape[0]`` because the M dimension is split into
+            2 partitions and each partition must be at least 2 instructions wide.
         block_n: N dimension tile size of the *shared* operand buffer.  Must be
-            at least ``2 * instr_shape[1]`` since one partition in N dimension
-            must be at least 1 tile wide.
+            at least ``2 * instr_shape[1]`` because the N dimension is split into
+            2 partitions and each partition must be at least 1 instruction wide.
         original_layout_a: ``PaddedSharedLayout`` for operand A.  Shape is
             ``[block_m, block_k]`` when not transposed (K contiguous) and
             ``[block_k, block_m]`` when transposed (M contiguous).
@@ -125,8 +125,10 @@ def make_partitioned_dot_layouts(block_m, block_n, original_layout_a, original_l
             the contiguous axis instead of K.
         b_transposed: Whether B is transposed in shared memory, i.e. K is
             the contiguous axis instead of N.
-        slice_m: M dimension of a dot operation after slicing. Defaults to ``block_m`` (unsliced).
-        slice_n: N dimension of a dot operation after slicing. Defaults to ``block_n`` (unsliced).
+        slice_m: M dimension of a dot operation after slicing.  Defaults to
+            ``block_m`` (unsliced).
+        slice_n: N dimension of a dot operation after slicing.  Defaults to
+            ``block_n`` (unsliced).
 
     Returns:
         A tuple ``(shared_layout_a, shared_layout_b, wmma_layout)``.  The
@@ -193,8 +195,9 @@ def make_partitioned_dot_layouts(block_m, block_n, original_layout_a, original_l
     # operand data blocks in a single instruction, which is necessary precondition
     # for avoiding LDS partition conflicts.
     #
-    # The above defined CTALayout tile will then be repeated across the full block (block_m x block_n).
-    # However, this is not always the optimal way to partition the full block.
+    # The above defined CTALayout tile will then be repeated across the full
+    # block (block_m x block_n).  However, this is not always the optimal way to
+    # partition the full block.
     # For example, if the block 64x128, the block would look like this:
     #
     #   M=0:  w0 w1 w0 w1 w0 w1 w0 w1
@@ -202,40 +205,43 @@ def make_partitioned_dot_layouts(block_m, block_n, original_layout_a, original_l
     #   M=2:  w0 w1 w0 w1 w0 w1 w0 w1
     #   M=3:  w2 w3 w2 w3 w2 w3 w2 w3
     #
-    # From the TDM perspective, wave can only transfer one strided logical piece at a time.
-    # Since we have 8 logical pieces for B tensor above, and only 4 warps, TDM transaction will be split
-    # into 2 instructions, which is not efficient.
+    # From the TDM perspective, wave can only transfer one strided logical piece
+    # at a time.  Since we have 8 logical pieces for B tensor above, and only 4
+    # warps, TDM transaction will be split into 2 instructions, which is not
+    # efficient.
     #
-    # to avoid this, we can increase number of consecutive tiles the wave computes.
-    # In the above example, we could create following CTA layout:
+    # to avoid this, we can increase number of consecutive instructions the wave
+    # computes.  In the above example, we could create following CTA layout:
     #
     #   M=0:  w0 w0 w0 w0 w1 w1 w1 w1
     #   M=1:  w2 w2 w2 w2 w3 w3 w3 w3
     #   M=2:  w0 w0 w0 w0 w1 w1 w1 w1
     #   M=3:  w2 w2 w2 w2 w3 w3 w3 w3
     #
-    # This way, each warp can read 2 larger strided logical pieces at a time, which will produce 1 TDM transaction.
-    # In addition to having less transaction, this can also help with global bandwidth, because in N contiguous
-    # tensors, it's better if the cache line is not split across multiple waves. This way we can read the whole
-    # cache line with a single wave.
+    # This way, each warp can read 2 larger strided logical pieces at a time,
+    # which will produce 1 TDM transaction.
+    # In addition to having less transaction, this can also help with global
+    # bandwidth, because in N contiguous tensors, it's better if the cache line
+    # is not split across multiple waves. This way we can read the whole cache
+    # line with a single wave.
 
-    tiles_per_slice_m = slice_m // INSTR_M
-    tiles_per_slice_n = slice_n // INSTR_N
-    tiles_per_partition_m = 2
-    tiles_per_partition_n = 1
+    instr_per_slice_m = slice_m // INSTR_M
+    instr_per_slice_n = slice_n // INSTR_N
+    instr_per_partition_m = 2
+    instr_per_partition_n = 1
 
     # Each slice must cover at least one instruction tile per partition piece,
     # otherwise piece_m / piece_n would round down to 0 and produce a degenerate
     # (non-surjective) WMMA layout with zero warp/register bases.
-    assert tiles_per_slice_m >= NUM_PARTITIONS * tiles_per_partition_m, \
+    assert instr_per_slice_m >= NUM_PARTITIONS * instr_per_partition_m, \
         f"slice_m ({slice_m}) must be at least " \
-        f"{NUM_PARTITIONS * tiles_per_partition_m} * instr_shape[0] ({INSTR_M})"
-    assert tiles_per_slice_n >= NUM_PARTITIONS * tiles_per_partition_n, \
+        f"{NUM_PARTITIONS * instr_per_partition_m} * instr_shape[0] ({INSTR_M})"
+    assert instr_per_slice_n >= NUM_PARTITIONS * instr_per_partition_n, \
         f"slice_n ({slice_n}) must be at least " \
-        f"{NUM_PARTITIONS * tiles_per_partition_n} * instr_shape[1] ({INSTR_N})"
+        f"{NUM_PARTITIONS * instr_per_partition_n} * instr_shape[1] ({INSTR_N})"
 
-    piece_m = tiles_per_slice_m // (NUM_PARTITIONS * tiles_per_partition_m)
-    piece_n = tiles_per_slice_n // (NUM_PARTITIONS * tiles_per_partition_n)
+    piece_m = instr_per_slice_m // (NUM_PARTITIONS * instr_per_partition_m)
+    piece_n = instr_per_slice_n // (NUM_PARTITIONS * instr_per_partition_n)
 
     # Registers that walk the contiguous tiles inside one piece.
     m_within = [1 << i for i in range(_log2(piece_m))]
@@ -244,7 +250,7 @@ def make_partitioned_dot_layouts(block_m, block_n, original_layout_a, original_l
     # (within-slice group repeats).
     m_group = [piece_m * 2]
 
-    warp_bases = [[tiles_per_slice_m // 2, piece_n], [piece_m, 0]]
+    warp_bases = [[instr_per_slice_m // 2, piece_n], [piece_m, 0]]
     reg_bases = []
 
     if num_warps == 8:

--- a/third_party/amd/lib/TritonAMDGPUToLLVM/DotOpToLLVM/WMMA.cpp
+++ b/third_party/amd/lib/TritonAMDGPUToLLVM/DotOpToLLVM/WMMA.cpp
@@ -808,9 +808,11 @@ LogicalResult convertScaledWMMA(triton::DotScaledOp op,
                                 triton::DotScaledOp::Adaptor adaptor,
                                 const LLVMTypeConverter *typeConverter,
                                 ConversionPatternRewriter &rewriter) {
-  assert(isa<LinearEncodingAttr>(op.getAScale().getType().getEncoding()) &&
-         isa<LinearEncodingAttr>(op.getBScale().getType().getEncoding()) &&
-         "Both LhsScale and RhsScale should be linear layout.");
+  assert(isa<mlir::triton::gpu::LinearEncodingTrait>(
+             op.getAScale().getType().getEncoding()) &&
+         isa<mlir::triton::gpu::LinearEncodingTrait>(
+             op.getBScale().getType().getEncoding()) &&
+         "Both LhsScale and RhsScale should be a LinearEncodingTrait.");
 
   auto cTensorTy = op.getC().getType();
   auto dTensorTy = op.getD().getType();

--- a/third_party/amd/lib/TritonAMDGPUToLLVM/Utility.cpp
+++ b/third_party/amd/lib/TritonAMDGPUToLLVM/Utility.cpp
@@ -733,11 +733,8 @@ unsigned getContiguity(Value ptr, Value offset,
   // FIXME (Alex): this should not be needed anymore because it's done inside
   // getContiguity, but we have an order issues with LL, so we keep this
   // until the LL order issue is fixed
-  auto linearLayout = triton::gpu::toLinearLayout(tensorTy);
-  auto llAttr = triton::gpu::LinearEncodingAttr::get(tensorTy.getContext(),
-                                                     std::move(linearLayout));
   auto order = triton::gpu::getOrder(tensorTy);
-  auto contigPerThread = llAttr.getContigPerThread();
+  auto contigPerThread = triton::gpu::getContigPerThread(tensorTy);
   assert(order[0] < contigPerThread.size() &&
          "Unexpected contigPerThread size");
   contiguity = std::min(contiguity, contigPerThread[order[0]]);

--- a/third_party/amd/python/examples/gluon/mxfp_gemm_gfx1250.py
+++ b/third_party/amd/python/examples/gluon/mxfp_gemm_gfx1250.py
@@ -96,10 +96,14 @@ class MXFPGEMMConfig:
     # the packed (doubled) compute-path width. The store reduces it by 2.
     ACTIVATION: gl.constexpr
 
+    # When set, build partitioned shared layouts and a partition-aware WMMA
+    # layout (via make_partitioned_dot_layouts) to avoid LDS partition conflicts.
+    RESOLVE_PARTITION_CONFLICTS: gl.constexpr
+
     @gluon.constexpr_function
     def __init__(self, BLOCK_M, BLOCK_N, BLOCK_K, DTYPE_A, DTYPE_B, SCALE_BLOCK, NUM_BUFFERS, TRANSPOSE_B, WITH_A_SCALE,
                  SCALE_PRESHUFFLE, NUM_WARPS, ASYNC_COPY_SCALE=False, NUM_SUBTILES=(1, 1, 1), L2_PREFETCH_DISTANCE=0,
-                 ACTIVATION=""):
+                 ACTIVATION="", RESOLVE_PARTITION_CONFLICTS=False):
         self.BLOCK_M = gl.constexpr(BLOCK_M)
         self.BLOCK_N = gl.constexpr(BLOCK_N)
         self.BLOCK_K = gl.constexpr(BLOCK_K)
@@ -118,6 +122,7 @@ class MXFPGEMMConfig:
         self.NUM_SUBTILES = gl.constexpr(NUM_SUBTILES)
         self.L2_PREFETCH_DISTANCE = gl.constexpr(L2_PREFETCH_DISTANCE)
         self.ACTIVATION = gl.constexpr(ACTIVATION)
+        self.RESOLVE_PARTITION_CONFLICTS = gl.constexpr(RESOLVE_PARTITION_CONFLICTS)
         if ACTIVATION == "swiglu":
             assert (BLOCK_N // NUM_SUBTILES[1]) % 2 == 0, \
             "SwiGLU requires (BLOCK_N // NUM_SUBTILES[1]) % 2 == 0"
@@ -135,8 +140,37 @@ class MXFPGEMMConfig:
         self.BLOCK_K_SCALE_PRESHUFFLED = gl.constexpr(BLOCK_K_SCALE * self.PRESHUFFLE_FACTOR)
 
         INSTR_M: gl.constexpr = 32 if (DTYPE_A == "e2m1" and DTYPE_B == "e2m1") else 16
-        WMMA_LAYOUT: gl.constexpr = get_wmma_layout(NUM_WARPS, False, SCALE_PRESHUFFLE, INSTR_M)
-        WMMA_LAYOUT_PACKED: gl.constexpr = get_wmma_layout(NUM_WARPS, True, SCALE_PRESHUFFLE, INSTR_M)
+
+        BLOCK_K_PACKED_A = BLOCK_K // self.DIV_FACTOR_A
+        BLOCK_K_PACKED_B = BLOCK_K // self.DIV_FACTOR_B
+        PAD_INTERVAL_A = 256 if BLOCK_K_PACKED_A <= 256 else BLOCK_K_PACKED_A
+        PAD_INTERVAL_B = 256 if BLOCK_K_PACKED_B <= 256 else BLOCK_K_PACKED_B
+
+        padded_a = gl.PaddedSharedLayout.with_identity_for([[PAD_INTERVAL_A, 16]], [BLOCK_M, BLOCK_K_PACKED_A], [1, 0])
+        if TRANSPOSE_B:
+            padded_b = gl.PaddedSharedLayout.with_identity_for([[PAD_INTERVAL_B, 16]], [BLOCK_N, BLOCK_K_PACKED_B],
+                                                               [1, 0])
+        else:
+            padded_b = gl.PaddedSharedLayout.with_identity_for([[BLOCK_N, 16]], [BLOCK_K_PACKED_B, BLOCK_N], [1, 0])
+
+        if RESOLVE_PARTITION_CONFLICTS:
+            # Split each operand tile along its M (A) / N (B) axis into partitioned
+            # pieces and build a partition-aware WMMA layout to avoid LDS partition
+            # conflicts.
+            shared_a, shared_b, WMMA_LAYOUT = gl.amd.gfx1250.make_partitioned_dot_layouts(
+                BLOCK_M, BLOCK_N, padded_a, padded_b, NUM_WARPS, [INSTR_M, 16, 128], a_transposed=False,
+                b_transposed=TRANSPOSE_B, slice_m=BLOCK_M // NUM_SUBTILES_M, slice_n=BLOCK_N // NUM_SUBTILES_N)
+            # The packed (fp4) WMMA layout shares the partition-aware warp/register
+            # bases but halves the K instruction extent.
+            WMMA_LAYOUT_PACKED = gl.amd.AMDWMMALayout(3, True, WMMA_LAYOUT.warp_bases, WMMA_LAYOUT.reg_bases,
+                                                      [INSTR_M, 16, 64])
+            self.shared_layout_a = gl.constexpr(shared_a)
+            self.shared_layout_b = gl.constexpr(shared_b)
+        else:
+            WMMA_LAYOUT = get_wmma_layout(NUM_WARPS, False, SCALE_PRESHUFFLE, INSTR_M)
+            WMMA_LAYOUT_PACKED = get_wmma_layout(NUM_WARPS, True, SCALE_PRESHUFFLE, INSTR_M)
+            self.shared_layout_a = gl.constexpr(padded_a)
+            self.shared_layout_b = gl.constexpr(padded_b)
 
         self.dot_layout_a = gl.constexpr(
             gl.DotOperandLayout(operand_index=0, parent=WMMA_LAYOUT_PACKED if DTYPE_A == "e2m1" else WMMA_LAYOUT,
@@ -151,20 +185,6 @@ class MXFPGEMMConfig:
             gl.amd.gfx1250.get_wmma_scale_layout(self.dot_layout_b,
                                                  [BLOCK_N // NUM_SUBTILES_N, BLOCK_K_SCALE // NUM_SUBTILES_K]))
         self.acc_layout = gl.constexpr(WMMA_LAYOUT)
-
-        BLOCK_K_PACKED_A = BLOCK_K // self.DIV_FACTOR_A
-        BLOCK_K_PACKED_B = BLOCK_K // self.DIV_FACTOR_B
-        PAD_INTERVAL_A = 256 if BLOCK_K_PACKED_A <= 256 else BLOCK_K_PACKED_A
-        PAD_INTERVAL_B = 256 if BLOCK_K_PACKED_B <= 256 else BLOCK_K_PACKED_B
-
-        self.shared_layout_a = gl.constexpr(
-            gl.PaddedSharedLayout.with_identity_for([[PAD_INTERVAL_A, 16]], [BLOCK_M, BLOCK_K_PACKED_A], [1, 0]))
-        if TRANSPOSE_B:
-            self.shared_layout_b = gl.constexpr(
-                gl.PaddedSharedLayout.with_identity_for([[PAD_INTERVAL_B, 16]], [BLOCK_N, BLOCK_K_PACKED_B], [1, 0]))
-        else:
-            self.shared_layout_b = gl.constexpr(
-                gl.PaddedSharedLayout.with_identity_for([[BLOCK_N, 16]], [BLOCK_K_PACKED_B, BLOCK_N], [1, 0]))
 
         self.shared_layout_a_scale = gl.constexpr(
             gl.PaddedSharedLayout.with_identity_for([[256, 8]],
@@ -1401,7 +1421,7 @@ def mxgemm_tdm_pipelined_kernel(a_ptr, b_ptr, c_ptr, a_scale, b_scale, M, N, K, 
                                 TRANSPOSE_B: gl.constexpr, NUM_BUFFERS: gl.constexpr, SCALE_PRESHUFFLE: gl.constexpr,
                                 ASYNC_COPY_SCALE: gl.constexpr, WITH_A_SCALE: gl.constexpr, SCHEDULE: gl.constexpr,
                                 NUM_WARPS: gl.constexpr, PINGPONG: gl.constexpr, L2_PREFETCH_DISTANCE: gl.constexpr = 0,
-                                ACTIVATION: gl.constexpr = ""):
+                                ACTIVATION: gl.constexpr = "", RESOLVE_PARTITION_CONFLICTS: gl.constexpr = False):
 
     if PINGPONG:
         gl.static_assert(NUM_WARPS == 8 and (SCHEDULE == 'baseline' or SCHEDULE == 'sliceK'))
@@ -1424,7 +1444,7 @@ def mxgemm_tdm_pipelined_kernel(a_ptr, b_ptr, c_ptr, a_scale, b_scale, M, N, K, 
 
     cfg = MXFPGEMMConfig(BLOCK_M, BLOCK_N_PACKED, BLOCK_K, DTYPE_A, DTYPE_B, SCALE_BLOCK, NUM_BUFFERS, TRANSPOSE_B,
                          WITH_A_SCALE, SCALE_PRESHUFFLE, NUM_WARPS, ASYNC_COPY_SCALE, NUM_SUBTILES,
-                         L2_PREFETCH_DISTANCE, ACTIVATION)
+                         L2_PREFETCH_DISTANCE, ACTIVATION, RESOLVE_PARTITION_CONFLICTS)
 
     pid = gl.program_id(axis=0)
     num_pid_m = gl.cdiv(M, BLOCK_M)
@@ -1547,7 +1567,8 @@ def interleave_b_scale_rows(s_gate, s_up):
 @pytest.mark.parametrize("L2_PREFETCH_DISTANCE", [-1, 0, 2])
 def test_runtime_mxgemm_tdm_8warps_pipeline(DTYPE_A, DTYPE_B, M, N, K, BLOCK_M, BLOCK_N, BLOCK_K, TRANSPOSE_B,
                                             NUM_BUFFERS, SCALE_PRESHUFFLE, WITH_A_SCALE, SCHEDULE, ASYNC_COPY_SCALE,
-                                            GROUP_SIZE_M, PINGPONG, L2_PREFETCH_DISTANCE):
+                                            GROUP_SIZE_M, PINGPONG, L2_PREFETCH_DISTANCE,
+                                            RESOLVE_PARTITION_CONFLICTS=False):
     SCALE_BLOCK = 32
     numWarps = 8
     numCtas = 1
@@ -1621,13 +1642,12 @@ def test_runtime_mxgemm_tdm_8warps_pipeline(DTYPE_A, DTYPE_B, M, N, K, BLOCK_M, 
 
     dtype_converter = {'float8_e5m2': "e5m2", "float8_e4m3": "e4m3", "float4": "e2m1"}
 
-    k = mxgemm_tdm_pipelined_kernel[grid](a_d, b_d, c_d, a_scale_d, b_scale_d, M, N, K, stride_am, stride_ak, stride_bk,
-                                          stride_bn, stride_cm, stride_cn, stride_scale, dtype_converter[DTYPE_A],
-                                          dtype_converter[DTYPE_B], SCALE_BLOCK, BLOCK_M, BLOCK_N, BLOCK_K,
-                                          GROUP_SIZE_M, TRANSPOSE_B, NUM_BUFFERS, SCALE_PRESHUFFLE, ASYNC_COPY_SCALE,
-                                          WITH_A_SCALE, SCHEDULE, numWarps, PINGPONG,
-                                          L2_PREFETCH_DISTANCE=L2_PREFETCH_DISTANCE, num_warps=numWarps,
-                                          num_ctas=numCtas, waves_per_eu=(numWarps // 4))
+    k = mxgemm_tdm_pipelined_kernel[grid](
+        a_d, b_d, c_d, a_scale_d, b_scale_d, M, N, K, stride_am, stride_ak, stride_bk, stride_bn, stride_cm, stride_cn,
+        stride_scale, dtype_converter[DTYPE_A], dtype_converter[DTYPE_B], SCALE_BLOCK, BLOCK_M, BLOCK_N, BLOCK_K,
+        GROUP_SIZE_M, TRANSPOSE_B, NUM_BUFFERS, SCALE_PRESHUFFLE, ASYNC_COPY_SCALE, WITH_A_SCALE, SCHEDULE, numWarps,
+        PINGPONG, L2_PREFETCH_DISTANCE=L2_PREFETCH_DISTANCE, RESOLVE_PARTITION_CONFLICTS=RESOLVE_PARTITION_CONFLICTS,
+        num_warps=numWarps, num_ctas=numCtas, waves_per_eu=(numWarps // 4))
     static_profile(k)
 
     if TRANSPOSE_B:
@@ -1665,7 +1685,7 @@ def test_runtime_mxgemm_tdm_8warps_pipeline(DTYPE_A, DTYPE_B, M, N, K, BLOCK_M, 
 @pytest.mark.parametrize("ACTIVATION", ['', 'swiglu'])
 def test_runtime_mxgemm_tdm_pipelined(DTYPE_A, DTYPE_B, M, N, K, BLOCK_M, BLOCK_N, BLOCK_K, TRANSPOSE_B, NUM_BUFFERS,
                                       SCALE_PRESHUFFLE, WITH_A_SCALE, SCHEDULE, ASYNC_COPY_SCALE, GROUP_SIZE_M,
-                                      L2_PREFETCH_DISTANCE, ACTIVATION):
+                                      L2_PREFETCH_DISTANCE, ACTIVATION, RESOLVE_PARTITION_CONFLICTS=False):
     """
     Pipelined mxfp GEMM with optional fused SwiGLU epilogue.
 
@@ -1790,7 +1810,8 @@ def test_runtime_mxgemm_tdm_pipelined(DTYPE_A, DTYPE_B, M, N, K, BLOCK_M, BLOCK_
                                           GROUP_SIZE_M, TRANSPOSE_B, NUM_BUFFERS, SCALE_PRESHUFFLE, ASYNC_COPY_SCALE,
                                           WITH_A_SCALE, SCHEDULE, NUM_WARPS=numWarps, PINGPONG=False,
                                           L2_PREFETCH_DISTANCE=L2_PREFETCH_DISTANCE, ACTIVATION=ACTIVATION,
-                                          num_warps=numWarps, num_ctas=numCtas, waves_per_eu=numWarps // 4)
+                                          RESOLVE_PARTITION_CONFLICTS=RESOLVE_PARTITION_CONFLICTS, num_warps=numWarps,
+                                          num_ctas=numCtas, waves_per_eu=numWarps // 4)
     static_profile(k)
 
     if TRANSPOSE_B:
@@ -1847,6 +1868,10 @@ if __name__ == '__main__':
                         help='Prefetch distance (in iterations) for operands into L2. -1 disables L2 prefetch.')
     parser.add_argument('--activation', type=str, default='', choices=['', 'swiglu'],
                         help='Optional fused activation epilogue')
+    parser.add_argument(
+        '--resolve_partition_conflicts', action='store_true',
+        help='Use partitioned shared layouts and a partition-aware WMMA layout to avoid LDS '
+        'partition conflicts')
 
     args = parser.parse_args()
 
@@ -1866,7 +1891,8 @@ if __name__ == '__main__':
                                                 ASYNC_COPY_SCALE=False,  #
                                                 GROUP_SIZE_M=args.group_size_m,  #
                                                 PINGPONG=args.pingpong,  #
-                                                L2_PREFETCH_DISTANCE=args.l2_prefetch_distance)
+                                                L2_PREFETCH_DISTANCE=args.l2_prefetch_distance,  #
+                                                RESOLVE_PARTITION_CONFLICTS=args.resolve_partition_conflicts)
     else:
         assert (args.num_buffers in (2, 3, 4))
         test_runtime_mxgemm_tdm_pipelined(args.dtype_a, args.dtype_b,  #
@@ -1880,4 +1906,5 @@ if __name__ == '__main__':
                                           ASYNC_COPY_SCALE=args.async_copy_scale,  #
                                           GROUP_SIZE_M=args.group_size_m,  #
                                           L2_PREFETCH_DISTANCE=args.l2_prefetch_distance,  #
-                                          ACTIVATION=args.activation)
+                                          ACTIVATION=args.activation,  #
+                                          RESOLVE_PARTITION_CONFLICTS=args.resolve_partition_conflicts)

--- a/third_party/amd/python/examples/gluon/mxfp_gemm_gfx1250.py
+++ b/third_party/amd/python/examples/gluon/mxfp_gemm_gfx1250.py
@@ -96,10 +96,6 @@ class MXFPGEMMConfig:
     # the packed (doubled) compute-path width. The store reduces it by 2.
     ACTIVATION: gl.constexpr
 
-    # When set, build partitioned shared layouts and a partition-aware WMMA
-    # layout (via make_partitioned_dot_layouts) to avoid LDS partition conflicts.
-    RESOLVE_PARTITION_CONFLICTS: gl.constexpr
-
     @gluon.constexpr_function
     def __init__(self, BLOCK_M, BLOCK_N, BLOCK_K, DTYPE_A, DTYPE_B, SCALE_BLOCK, NUM_BUFFERS, TRANSPOSE_B, WITH_A_SCALE,
                  SCALE_PRESHUFFLE, NUM_WARPS, ASYNC_COPY_SCALE=False, NUM_SUBTILES=(1, 1, 1), L2_PREFETCH_DISTANCE=0,
@@ -122,7 +118,6 @@ class MXFPGEMMConfig:
         self.NUM_SUBTILES = gl.constexpr(NUM_SUBTILES)
         self.L2_PREFETCH_DISTANCE = gl.constexpr(L2_PREFETCH_DISTANCE)
         self.ACTIVATION = gl.constexpr(ACTIVATION)
-        self.RESOLVE_PARTITION_CONFLICTS = gl.constexpr(RESOLVE_PARTITION_CONFLICTS)
         if ACTIVATION == "swiglu":
             assert (BLOCK_N // NUM_SUBTILES[1]) % 2 == 0, \
             "SwiGLU requires (BLOCK_N // NUM_SUBTILES[1]) % 2 == 0"


### PR DESCRIPTION
This PR reworks the GFX1250 partitioned-dot WMMA layout derivation so it can produce a WMMA layout 
sized for a sliced dot compute extent while the shared-memory operand buffers still partition the full block. 
It also adapts several call sites to the new LinearEncodingTrait / GenericLinearEncodingAttr split so that 
swizzled (partition-aware) layouts are represented correctly.

Changes:

- make_partitioned_dot_layouts gains slice_m / slice_n params (default to block_m / block_n, i.e. unsliced). The returned wmma_layout is now sized for slice_m x slice_n, while the two shared layouts continue to partition the full block_m / block_n.
- WMMA warp/register bases are derived from the per-slice instruction-tile counts and a fixed within-partition grouping (2 tiles in M, 1 in N), which increases the number of consecutive tiles a wave computes to reduce TDM transaction splitting and improve cache-line locality on N-contiguous operands.
- Added a RESOLVE_PARTITION_CONFLICTS flag (kernel arg, test param, and --resolve_partition_conflicts CLI option) that switches between the partition-aware layouts (calling make_partitioned_dot_layouts with slice_m/slice_n = BLOCK / NUM_SUBTILES) and the original padded-shared / get_wmma_layout path.
