### PR TITLE
[AMD][TRITON_KERNELS] Improve MXFP4 matmul_ogs config on RDNA

### DIFF
--- a/python/triton_kernels/triton_kernels/matmul_details/opt_flags.py
+++ b/python/triton_kernels/triton_kernels/matmul_details/opt_flags.py
@@ -134,20 +134,37 @@ def make_default_opt_flags_amd(
     if get_cdna_version() == 3 and rhs_dtype.bitwidth == 8 and precision_config.b_mx_scale is not None:
         num_stages = 1
 
-    # specific configs for F16 x MXFP4 on CDNA4
-    if is_cdna4 and lhs_dtype.bitwidth == 16 and rhs_dtype.bitwidth == 4 and precision_config.b_mx_scale is not None:
-        split_k = 1
-        if m <= 1024:
-            target_kernel_kwargs["waves_per_eu"] = 3
-            block_n = 128
-            block_k = 128
-            num_warps = 4
-        else:
+    if lhs_dtype.bitwidth == 16 and rhs_dtype.bitwidth == 4 and precision_config.b_mx_scale is not None:
+        # specific configs for F16 x MXFP4 on CDNA4
+        if is_cdna4:
+            split_k = 1
+            if m <= 1024:
+                target_kernel_kwargs["waves_per_eu"] = 3
+                block_n = 128
+                block_k = 128
+                num_warps = 4
+            else:
+                target_kernel_kwargs["waves_per_eu"] = 0
+                block_m = 64
+                block_n = 512
+                block_k = 256
+                num_warps = 8
+
+        # Specific configs for F16 x MXFP4 on RDNA.
+        if get_rdna_version() in (3, 4):
+            split_k = 1
             target_kernel_kwargs["waves_per_eu"] = 0
-            block_m = 64
-            block_n = 512
-            block_k = 256
-            num_warps = 8
+            num_stages = 1
+            if m <= 512:
+                block_m = 16
+                block_n = 64
+                block_k = 512
+                num_warps = 4
+            else:
+                block_m = 64
+                block_n = 128
+                block_k = 128
+                num_warps = 4
 
     def replace_with_valid_constraint(k: str, v):
         if constraints.get(k, None) is not None:


### PR DESCRIPTION
Add RDNA-specific MXFP4 matmul_ogs configs for GPT-OSS MoE shapes.

The configs were selected from an exhaustive search on both RDNA3 and RDNA4. Following the existing CDNA4-specific path, add tuned configs for RDNA by choosing different tile shapes for small and large M.

Benchmark: GPT-OSS MoE M sweep using the existing `run_mlp` in `triton_kernels/bench/bench_mlp.py`. The sweep keeps the GPT-OSS dimensions fixed and varies the effective routed M seen by the expert `matmul_ogs` kernels.

gfx1201

<table>
    <thead>
      <tr>
        <th align="right">M (batch x topk)</th>
        <th align="right">Baseline ms</th>
        <th align="right">TunedConfig ms</th>
        <th align="right">Speedup</th>
      </tr>
    </thead>
    <tbody>
      <tr><td align="right">16</td><td align="right">2.954</td><td align="right">0.398</td><td align="right">7.413x</td></tr>
      <tr><td align="right">32</td><td align="right">0.631</td><td align="right">0.547</td><td align="right">1.154x</td></tr>
      <tr><td align="right">64</td><td align="right">0.806</td><td align="right">0.696</td><td align="right">1.159x</td></tr>
      <tr><td align="right">128</td><td align="right">0.961</td><td align="right">0.854</td><td align="right">1.126x</td></tr>
      <tr><td align="right">256</td><td align="right">0.979</td><td align="right">0.872</td><td align="right">1.122x</td></tr>
      <tr><td align="right">512</td><td align="right">1.598</td><td align="right">1.048</td><td align="right">1.525x</td></tr>
      <tr><td align="right">1024</td><td align="right">1.701</td><td align="right">1.336</td><td align="right">1.273x</td></tr>
      <tr><td align="right">2048</td><td align="right">1.916</td><td align="right">1.836</td><td align="right">1.044x</td></tr>
      <tr><td align="right">4096</td><td align="right">3.205</td><td align="right">3.166</td><td align="right">1.013x</td></tr>
      <tr><td align="right">8192</td><td align="right">6.105</td><td align="right">6.097</td><td align="right">1.001x</td></tr>
      <tr><td align="right">16384</td><td align="right">22.645</td><td align="right">11.875</td><td align="right">1.907x</td></tr>
    </tbody>
  </table>

gfx1100

 <table>
    <thead>
      <tr>
        <th align="right">M (batch x topk)</th>
        <th align="right">Baseline ms</th>
        <th align="right">TunedConfig ms</th>
        <th align="right">Speedup</th>
      </tr>
    </thead>
    <tbody>
      <tr><td align="right">16</td><td align="right">3.029</td><td align="right">0.526</td><td align="right">5.75x</td></tr>
      <tr><td align="right">32</td><td align="right">1.367</td><td align="right">0.721</td><td align="right">1.90x</td></tr>
      <tr><td align="right">64</td><td align="right">1.623</td><td align="right">1.022</td><td align="right">1.59x</td></tr>
      <tr><td align="right">128</td><td align="right">1.686</td><td align="right">1.123</td><td align="right">1.50x</td></tr>
      <tr><td align="right">256</td><td align="right">1.726</td><td align="right">1.163</td><td align="right">1.48x</td></tr>
      <tr><td align="right">512</td><td align="right">2.583</td><td align="right">1.453</td><td align="right">1.78x</td></tr>
      <tr><td align="right">1024</td><td align="right">2.724</td><td align="right">1.969</td><td align="right">1.38x</td></tr>
      <tr><td align="right">2048</td><td align="right">3.198</td><td align="right">2.747</td><td align="right">1.16x</td></tr>
      <tr><td align="right">4096</td><td align="right">4.937</td><td align="right">4.863</td><td align="right">1.02x</td></tr>
      <tr><td align="right">8192</td><td align="right">9.407</td><td align="right">9.430</td><td align="right">1.00x</td></tr>
      <tr><td align="right">16384</td><td align="right">21.435</td><td align="right">18.775</td><td align="right">1.14x</td></tr>
    </tbody>
  </table>

gfx1151

 <table>
    <thead>
      <tr>
        <th align="right">M (batch x topk)</th>
        <th align="right">Baseline ms</th>
        <th align="right">TunedConfig ms</th>
        <th align="right">Speedup</th>
      </tr>
    </thead>
    <tbody>
      <tr><td align="right">16</td><td align="right">8.115</td><td align="right">1.405</td><td align="right">5.77x</td></tr>
      <tr><td align="right">32</td><td align="right">2.451</td><td align="right">1.880</td><td align="right">1.30x</td></tr>
      <tr><td align="right">64</td><td align="right">2.831</td><td align="right">2.205</td><td align="right">1.28x</td></tr>
      <tr><td align="right">128</td><td align="right">3.422</td><td align="right">2.813</td><td align="right">1.22x</td></tr>
      <tr><td align="right">256</td><td align="right">3.488</td><td align="right">2.908</td><td align="right">1.20x</td></tr>
      <tr><td align="right">512</td><td align="right">5.591</td><td align="right">3.727</td><td align="right">1.50x</td></tr>
      <tr><td align="right">1024</td><td align="right">6.195</td><td align="right">4.436</td><td align="right">1.40x</td></tr>
      <tr><td align="right">2048</td><td align="right">8.559</td><td align="right">6.179</td><td align="right">1.39x</td></tr>
      <tr><td align="right">4096</td><td align="right">14.556</td><td align="right">10.917</td><td align="right">1.33x</td></tr>
      <tr><td align="right">8192</td><td align="right">24.162</td><td align="right">20.451</td><td align="right">1.18x</td></tr>
      <tr><td align="right">16384</td><td align="right">52.857</td><td align="right">41.330</td><td align="right">1.28x</td></tr>
    </tbody>
  </table>