### PR TITLE
[TRITON_KERNELS] Prevent padded top-k experts under FPSan

### DIFF
--- a/python/triton_kernels/tests/test_topk.py
+++ b/python/triton_kernels/tests/test_topk.py
@@ -27,6 +27,28 @@ def test_topk(n_rows, n_cols, k, apply_softmax, dtype):
     assert sparse_x_tri.mask.storage.data.shape == sparse_x_ref.mask.storage.data.shape
 
 
+@pytest.mark.parametrize("n_experts", [13, 33])
+@pytest.mark.parametrize("apply_softmax", [False, True])
+@pytest.mark.parametrize("dtype,storage_dtype", [
+    (torch.float16, torch.int16),
+    (torch.bfloat16, torch.int16),
+    (torch.float32, torch.int32),
+])
+def test_topk_fpsan_masks_padded_experts(fresh_knobs, n_experts, apply_softmax, dtype, storage_dtype):
+    fresh_knobs.compilation.instrumentation_mode = "fpsan"
+
+    n_rows = 2
+    k = 8
+    # Negative NaNs sort below -inf as floating-point keys. Under FPSan these
+    # bit patterns are valid payload carriers, so -inf cannot mask padding.
+    logits = torch.full((n_rows, n_experts), -1, dtype=storage_dtype, device="cuda").view(dtype)
+
+    sparse_logits = topk(logits, k, apply_softmax=apply_softmax)
+
+    expected_indices = torch.arange(k, dtype=torch.int16, device="cuda").expand(n_rows, k)
+    assert_equal(sparse_logits.indx, expected_indices)
+
+
 def bench_topk(n_rows, n_cols, k, apply_softmax, all_gather=False):
     # setup distributed environment
     rank, world_size = 0, 1

--- a/python/triton_kernels/triton_kernels/topk_details/_topk_forward.py
+++ b/python/triton_kernels/triton_kernels/topk_details/_topk_forward.py
@@ -59,6 +59,10 @@ def streaming_topk(X, stride_xm, n_expts_tot, offs_m, mask_m, N_EXPTS_PAD: tl.co
     x = tl.load(X_ptrs, mask=(mask_m & mask_n), other=float("-inf"))
     x = fpval_to_key(x.to(x_utype, bitcast=True))
     x = (x.to(x_ultype) << 16) | indx_to_key(offs_x_n, N_EXPTS_PAD)[None, :]
+    # Valid packed keys are nonzero because their index key is nonzero. Mask
+    # padding to zero so it cannot be selected when FPSan payloads sort below
+    # the floating-point -inf sentinel.
+    x = tl.where(mask_n, x, 0)
     acc = tl.topk(x, N_EXPTS_ACT, dim=1)
 
     # subsequent iterations:


### PR DESCRIPTION
<!-- PR title: [TRITON_KERNELS] Prevent padded top-k experts under FPSan -->

## Description

Prevent `triton_kernels.topk` from selecting padded expert lanes when FPSan payload carriers do not follow IEEE floating-point ordering.

`streaming_topk` pads the final 32-lane expert block by loading `-inf`, converts each float bit pattern into a sortable unsigned key, and packs the expert-index tie-breaker into the low 16 bits. This assumes the `-inf` key is below every valid input key. FPSan can produce arbitrary float carrier bit patterns, so that assumption does not hold.

For example, for fp32, carrier bits `0xffffffff` map to key `0x00000000`, while the `-inf` bits `0xff800000` map to key `0x007fffff`. The padded lane can therefore rank above a valid expert and produce an index greater than or equal to `n_experts`.

Mask padded lanes to integer zero after constructing the packed key. Every valid packed key is strictly positive because its expert-index key, `N_EXPTS_PAD - index`, is nonzero. Zero is therefore a safe bottom sentinel independent of the FPSan carrier bit pattern.

The regression covers:

- `apply_softmax=False` and `apply_softmax=True`
- fp16, bf16, and fp32 carriers
- a single partial block with 13 experts
- a multi-block case with 33 experts, where the partial block has fewer than `k` valid lanes

## Validation

- `python/triton_kernels/tests/test_topk.py::test_topk_fpsan_masks_padded_experts`: 12 passed
- Existing `python/triton_kernels/tests/test_topk.py::test_topk`: 96 passed
- Additional adversarial matrix across 78 dtype, expert-count, and softmax cases: passed
- `pre-commit run --from-ref origin/main --to-ref HEAD`: passed

This change only touches Python and `python/triton_kernels`, so no native rebuild was required.
