### PR TITLE
Partially revert #10516

### DIFF
--- a/lib/Dialect/TritonGPU/Transforms/RemoveLayoutConversions.cpp
+++ b/lib/Dialect/TritonGPU/Transforms/RemoveLayoutConversions.cpp
@@ -1400,8 +1400,6 @@ bool LayoutRematerialization::hoistConvertOnTopOfExtOrBroadcast(
             ExpandDimsOp>(op)) {
       return true;
     }
-    if (auto reshapeOp = dyn_cast<ReshapeOp>(op))
-      return reshapeOp.getExpandDimsAxis().has_value();
     if (auto fpToFpOp = dyn_cast<FpToFpOp>(op)) {
       auto srcType = cast<RankedTensorType>(fpToFpOp.getOperand().getType());
       return getElementBitWidth(srcType) <

--- a/test/TritonGPU/combine.mlir
+++ b/test/TritonGPU/combine.mlir
@@ -175,17 +175,6 @@ tt.func @hoist_above_broadcast(%arg0: tensor<1024x1xf32, #layout2>, %arg1: f32) 
   tt.return %3 : tensor<1024x128xf32, #layout3>
 }
 
-// CHECK-LABEL: hoist_above_expand_dims_reshape
-tt.func @hoist_above_expand_dims_reshape(%arg0: tensor<1024xf32, #expand_layout0_slice>) -> tensor<1024x1xf32, #expand_layout1> {
-// CHECK: %[[CVT:.+]] = ttg.convert_layout %arg0 : tensor<1024xf32, #{{.*}}> -> tensor<1024xf32, #[[DST_LAYOUT:.*]]>
-// CHECK: tt.reshape %[[CVT]] : tensor<1024xf32, #[[DST_LAYOUT]]> -> tensor<1024x1xf32, #{{.*}}>
-// CHECK-NOT: ttg.convert_layout
-// CHECK: tt.return
-  %0 = tt.reshape %arg0 : tensor<1024xf32, #expand_layout0_slice> -> tensor<1024x1xf32, #expand_layout0>
-  %1 = ttg.convert_layout %0 : tensor<1024x1xf32, #expand_layout0> -> tensor<1024x1xf32, #expand_layout1>
-  tt.return %1 : tensor<1024x1xf32, #expand_layout1>
-}
-
 // CHECK-LABEL: if
 tt.func @if(%arg0: i32, %arg1: !tt.ptr<i32> {tt.divisibility = 16 : i32}) {
   // CHECK-NOT: ttg.convert_layout


### PR DESCRIPTION

Remove the new RemoveLayoutConversions heuristic due to internal
regressions. The cost heuristic likely needs some tweaking.
