### PR TITLE
[AMD] Fix scaled-dot lowering for the asymmetric packing case on gfx1250

### DIFF
--- a/test/TritonGPU/amd/accelerate-amd-matmul-wmma-gfx1250.mlir
+++ b/test/TritonGPU/amd/accelerate-amd-matmul-wmma-gfx1250.mlir
@@ -473,7 +473,7 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.targ
 #blocked1 = #ttg.blocked<{sizePerThread = [1, 16], threadsPerWarp = [16, 2], warpsPerCTA = [4, 1], order = [1, 0]}>
 #blocked3 = #ttg.blocked<{sizePerThread = [1, 1], threadsPerWarp = [1, 32], warpsPerCTA = [4, 1], order = [1, 0]}>
 module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.target = "hip:gfx1250", "ttg.threads-per-warp" = 32 : i32} {
-  tt.func public @wmma_dot_scaled_mxfp4_mxfp4_n_packed(
+  tt.func public @wmma_dot_scaled_mxfp4_mxfp4_asymmetric_packing(
       %arg0: tensor<64x32xi8, #blocked>,
       %arg1: tensor<64x64xi8, #blocked1>,
       %arg2: tensor<64x128x!tt.ptr<f32>, #blocked3>

--- a/test/TritonGPU/amd/accelerate-amd-matmul-wmma-gfx1250.mlir
+++ b/test/TritonGPU/amd/accelerate-amd-matmul-wmma-gfx1250.mlir
@@ -466,3 +466,28 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.targ
     tt.return
   }
 }
+
+// -----
+
+#blocked = #ttg.blocked<{sizePerThread = [1, 16], threadsPerWarp = [8, 4], warpsPerCTA = [4, 1], order = [1, 0]}>
+#blocked1 = #ttg.blocked<{sizePerThread = [1, 16], threadsPerWarp = [16, 2], warpsPerCTA = [4, 1], order = [1, 0]}>
+#blocked3 = #ttg.blocked<{sizePerThread = [1, 1], threadsPerWarp = [1, 32], warpsPerCTA = [4, 1], order = [1, 0]}>
+module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.target = "hip:gfx1250", "ttg.threads-per-warp" = 32 : i32} {
+  tt.func public @wmma_dot_scaled_mxfp4_mxfp4_n_packed(
+      %arg0: tensor<64x32xi8, #blocked>,
+      %arg1: tensor<64x64xi8, #blocked1>,
+      %arg2: tensor<64x128x!tt.ptr<f32>, #blocked3>
+      ) {
+    // CHECK-DAG: %[[ASCALE:.+]] = arith.constant dense<127> : tensor<64x2xi8, {{.*}}>
+    // CHECK-DAG: %[[BSCALE:.+]] = arith.constant dense<127> : tensor<128x2xi8, {{.*}}>
+    // CHECK: %[[C:.+]] = ttg.convert_layout {{.*}} : tensor<64x128xf32, {{.*}}> -> tensor<64x128xf32, #mma>
+    // CHECK: %[[A:.+]] = ttg.convert_layout {{.*}} : tensor<64x32xi8, {{.*}}> -> tensor<64x32xi8, #ttg.dot_op<{opIdx = 0, parent = #mma1, kWidth = 16}>>
+    // CHECK: %[[B:.+]] = ttg.convert_layout {{.*}} : tensor<64x64xi8, {{.*}}> -> tensor<64x64xi8, #ttg.dot_op<{opIdx = 1, parent = #mma1, kWidth = 16}>>
+    // CHECK: tt.dot_scaled %[[A]] scale {{.*}}, %[[B]] scale {{.*}}, %[[C]] lhs = e2m1 rhs = e2m1
+    // CHECK-SAME: tensor<64x32xi8, {{.*}}>, tensor<64x2xi8, {{.*}}> * tensor<64x64xi8, {{.*}}>, tensor<128x2xi8, {{.*}}> -> tensor<64x128xf32, #mma>
+    %cst = arith.constant dense<0.000000e+00> : tensor<64x128xf32, #blocked3>
+    %1 = tt.dot_scaled %arg0, %arg1, %cst lhs = e2m1 rhs = e2m1 {fastMath = false, lhs_k_pack = true, rhs_k_pack = false} : tensor<64x32xi8, #blocked> * tensor<64x64xi8, #blocked1> -> tensor<64x128xf32, #blocked3>
+    tt.store %arg2, %1 : tensor<64x128x!tt.ptr<f32>, #blocked3>
+    tt.return
+  }
+}

--- a/third_party/amd/lib/TritonAMDGPUTransforms/AccelerateAMDMatmul.cpp
+++ b/third_party/amd/lib/TritonAMDGPUTransforms/AccelerateAMDMatmul.cpp
@@ -1268,8 +1268,13 @@ public:
         int64_t nonKDim = idx == 0 ? valShape[0] : valShape[1];
         int64_t k = idx == 0 ? valShape[1] : valShape[0];
         ScaleDotElemType &elemType = idx == 0 ? aElemType : bElemType;
+        bool kPack = idx == 0 ? dotOp.getLhsKPack() : dotOp.getRhsKPack();
         int packSize = elemType == ScaleDotElemType::E2M1 ? 2 : 1;
-        shape = {nonKDim, k * packSize / scaleFactor};
+        if (kPack)
+          k *= packSize;
+        else
+          nonKDim *= packSize;
+        shape = {nonKDim, k / scaleFactor};
         std::tie(scaleType, scaleValue) = getDefaultScaleTypeValue(idx);
       } else {
         scaleType = scale.getType().getElementType();

--- a/third_party/amd/lib/TritonAMDGPUTransforms/AccelerateAMDMatmul.cpp
+++ b/third_party/amd/lib/TritonAMDGPUTransforms/AccelerateAMDMatmul.cpp
@@ -1268,12 +1268,13 @@ public:
         int64_t nonKDim = idx == 0 ? valShape[0] : valShape[1];
         int64_t k = idx == 0 ? valShape[1] : valShape[0];
         ScaleDotElemType &elemType = idx == 0 ? aElemType : bElemType;
-        bool kPack = idx == 0 ? dotOp.getLhsKPack() : dotOp.getRhsKPack();
         int packSize = elemType == ScaleDotElemType::E2M1 ? 2 : 1;
-        if (kPack)
+        bool kPack = idx == 0 ? dotOp.getLhsKPack() : dotOp.getRhsKPack();
+        if (kPack) {
           k *= packSize;
-        else
+        } else {
           nonKDim *= packSize;
+        }
         shape = {nonKDim, k / scaleFactor};
         std::tie(scaleType, scaleValue) = getDefaultScaleTypeValue(idx);
       } else {


### PR DESCRIPTION
In `ScaledBlockedToScaledWMMAF8F6F4`, the WMMA scaled-dot lowering always assumes that the packing happens on the K dimension (this assumption happens only when a scale is absent), regardless of which dimension the operand is actually packed. For an fp4 operand packed on N (`rhs_k_pack = false`), `valShape` carries the pack factor on N, not K. Applying the fp4 pack factor to K therefore over-counts K and under-counts N, producing a scale of the wrong shape.

The fix checks where the packing actually happens: if the operand is packed on K,  we size the scale as before; if it is packed on the non-K dimension we instead apply the pack factor on that dimension.

This PR also provides a simple testcase to exercise the asymmetric packing case, demonstrating the fix