### PR TITLE
[FRONTEND] Fix tl.flip crash on documented default dim=None

### DIFF
--- a/python/test/unit/language/test_standard.py
+++ b/python/test/unit/language/test_standard.py
@@ -67,7 +67,7 @@ def test_sort(M, N, k, descending, dtype_str, device):
 @pytest.mark.interpreter
 @pytest.mark.parametrize("M, N, K", [[1, 16, 64], [8, 2, 256], [32, 1, 2], [128, 8, 1]])
 @pytest.mark.parametrize("dtype_str", ['int32', 'float16', 'float32', 'bfloat16'])
-@pytest.mark.parametrize("dim", [0, 1, 2, -2])
+@pytest.mark.parametrize("dim", [0, 1, 2, -2, None])
 def test_flip(M, N, K, dtype_str, dim, device):
 
     @triton.jit
@@ -82,7 +82,7 @@ def test_flip(M, N, K, dtype_str, dim, device):
 
     x = numpy_random((M, N, K), dtype_str=dtype_str)
     x = torch.from_numpy(x).to(device)
-    y = torch.flip(x, (dim, ))
+    y = torch.flip(x, (dim if dim is not None else -1, ))
     z = torch.empty_like(x, device=device)
     flip_kernel[(1, )](x, z, M, N, K, dim, num_warps=8)
     assert (y == z).all(), (y, z)

--- a/python/triton/language/standard.py
+++ b/python/triton/language/standard.py
@@ -522,8 +522,8 @@ def flip(x, dim=None):
     :param dim: the dimension to flip along
     :type dim: int
     """
-    core.static_assert(-len(x.shape) <= dim and dim < len(x.shape))
     _dim: core.constexpr = _get_flip_dim(dim, x.shape)
+    core.static_assert(0 <= _dim and _dim < len(x.shape), "flip: dim must be None or in [-rank, rank)")
     core.static_assert(_is_power_of_two(x.shape[_dim]))
     steps: core.constexpr = _log2(x.shape[_dim])
 


### PR DESCRIPTION
`tl.flip(x)` with the documented default `dim=None` raises `TypeError: '<=' not supported between instances of 'int' and 'NoneType'` at compile time and under `TRITON_INTERPRET=1`.

The bounds-check `static_assert` in `flip()` runs before `_get_flip_dim()` resolves `dim=None` to the last axis, so the existing `None` handling is never reached for the default argument. This PR resolves `_dim` first and asserts on the normalized value. Negative dims are shifted by the rank before the check, so out-of-range dims (e.g. `dim=2` or `dim=-3` on a 2-D tensor) are still rejected at compile time, now with an error message.

Also adds `dim=None` to `test_flip`'s parametrization, which is the coverage gap that let this go uncaught.

Verified on CPU interpreter: the reproducer from the issue passes, explicit dims are unchanged, and `pytest python/test/unit/language/test_standard.py -k flip -m interpreter --device cpu` passes 81/81.

Fixes #10790.

# New contributor declaration
- [x] I am not making a trivial change, such as fixing a typo in a comment.

- [x] I have written a PR description following these
  [rules](https://cbea.ms/git-commit/#why-not-how).

- [ ] I have run `pre-commit run --from-ref origin/main --to-ref HEAD` (env still building locally; ruff, yapf, and check-ast pass on the changed files).

- Select one of the following.
  - [x] I have added tests.
    - `/test` for `lit` tests
    - `/unittest` for C++ tests
    - `/python/test` for end-to-end tests
  - [ ] This PR does not need a test because `FILL THIS IN`.

- Select one of the following.
  - [x] I have not added any `lit` tests.
  - [ ] The `lit` tests I have added follow these [best practices](https://github.com/triton-lang/triton/blob/main/docs/programming-guide/chapter-5/lit-testing.md), including the "tests should be minimal" section. (Usually running Python code and using the instructions it generates is not minimal.)