### PR TITLE
Restore heuristic to hoist above reshape

### DIFF
--- a/lib/Dialect/TritonGPU/Transforms/RemoveLayoutConversions.cpp
+++ b/lib/Dialect/TritonGPU/Transforms/RemoveLayoutConversions.cpp
@@ -1400,6 +1400,8 @@ bool LayoutRematerialization::hoistConvertOnTopOfExtOrBroadcast(
             ExpandDimsOp>(op)) {
       return true;
     }
+    if (auto reshapeOp = dyn_cast<ReshapeOp>(op))
+      return reshapeOp.getExpandDimsAxis().has_value();
     if (auto fpToFpOp = dyn_cast<FpToFpOp>(op)) {
       auto srcType = cast<RankedTensorType>(fpToFpOp.getOperand().getType());
       return getElementBitWidth(srcType) <
@@ -1450,6 +1452,15 @@ bool LayoutRematerialization::hoistConvertOnTopOfExtOrBroadcast(
     return false;
   int64_t newCvtCost =
       getConvertCost(extOrBroadcastOp->getOperand(0), srcEncoding);
+  // getConvertCost treats all <=32 bit types as equivalent. However, we
+  // shouldn't hoist to a wider type if everything else remains equal. To
+  // address this, increase the weight of the new convert if it is on a wider
+  // element type.
+  Type oldElemTy = getElementTypeOrSelf(convertOp.getSrc());
+  Type newElemTy = getElementTypeOrSelf(extOrBroadcastOp->getOperand(0));
+  if (oldElemTy.isIntOrFloat() && newElemTy.isIntOrFloat())
+    if (oldElemTy.getIntOrFloatBitWidth() < newElemTy.getIntOrFloatBitWidth())
+      newCvtCost *= 2;
   if (!isRematBeneficial(convertOp, slice, layout, newCvtCost))
     return false;
   // Move the convert before the ext op and rewrite the slice.

--- a/test/TritonGPU/combine.mlir
+++ b/test/TritonGPU/combine.mlir
@@ -175,6 +175,33 @@ tt.func @hoist_above_broadcast(%arg0: tensor<1024x1xf32, #layout2>, %arg1: f32) 
   tt.return %3 : tensor<1024x128xf32, #layout3>
 }
 
+// CHECK-LABEL: hoist_above_expand_dims_reshape
+tt.func @hoist_above_expand_dims_reshape(%arg0: tensor<1024xf32, #expand_layout0_slice>) -> tensor<1024x1xf32, #expand_layout1> {
+// CHECK: %[[CVT:.+]] = ttg.convert_layout %arg0 : tensor<1024xf32, #{{.*}}> -> tensor<1024xf32, #[[DST_LAYOUT:.*]]>
+// CHECK: tt.reshape %[[CVT]] : tensor<1024xf32, #[[DST_LAYOUT]]> -> tensor<1024x1xf32, #{{.*}}>
+// CHECK-NOT: ttg.convert_layout
+// CHECK: tt.return
+  %0 = tt.reshape %arg0 : tensor<1024xf32, #expand_layout0_slice> -> tensor<1024x1xf32, #expand_layout0>
+  %1 = ttg.convert_layout %0 : tensor<1024x1xf32, #expand_layout0> -> tensor<1024x1xf32, #expand_layout1>
+  tt.return %1 : tensor<1024x1xf32, #expand_layout1>
+}
+
+// CHECK-LABEL: dont_hoist_to_wider_type
+tt.func @dont_hoist_to_wider_type(%arg0: tensor<1024xi16, #layout0>) -> tensor<1024xi8, #layout1> {
+// CHECK: %[[EXT:.+]] = arith.extsi %arg0
+// CHECK: %[[ADD:.+]] = arith.addi %[[EXT]]
+// CHECK: %[[TRUNC:.+]] = arith.trunci %[[ADD]]
+// CHECK: ttg.convert_layout %[[TRUNC]]
+// CHECK: tt.return
+  %0 = arith.extsi %arg0 : tensor<1024xi16, #layout0> to tensor<1024xi32, #layout0>
+  %cst = arith.constant dense<1> : tensor<1024xi32, #layout0>
+  %1 = arith.addi %0, %cst : tensor<1024xi32, #layout0>
+  %2 = arith.trunci %1 : tensor<1024xi32, #layout0> to tensor<1024xi8, #layout0>
+  %3 = ttg.convert_layout %2 : tensor<1024xi8, #layout0> -> tensor<1024xi8, #layout1>
+  tt.return %3 : tensor<1024xi8, #layout1>
+}
+
+
 // CHECK-LABEL: if
 tt.func @if(%arg0: i32, %arg1: !tt.ptr<i32> {tt.divisibility = 16 : i32}) {
   // CHECK-NOT: ttg.convert_layout


### PR DESCRIPTION

Reintroduce the heuristic reverted in #10815. Address the previous
regression by blocking hoisting when it creates a more expensive
layout conversion.
