### PR TITLE
[BACKEND] Fall back to shared-memory gather when no warp-local layout exists

### DIFF
--- a/include/triton/Analysis/Utility.h
+++ b/include/triton/Analysis/Utility.h
@@ -164,6 +164,12 @@ private:
   SmallVector<unsigned> order;
 };
 
+// Determine if a gather with the given source and index tensor types along
+// `axis` can be performed completely within a warp, i.e. each gather column in
+// both tensors is wholly owned by the same warp.
+bool isWarpLocalGather(RankedTensorType srcType, RankedTensorType idxType,
+                       unsigned axis);
+
 // Helper class for lowering `tt.gather` operations. This class shares lowering
 // logic between shared memory allocation and LLVM codegen.
 class GatherLoweringHelper {

--- a/lib/Analysis/Utility.cpp
+++ b/lib/Analysis/Utility.cpp
@@ -1094,19 +1094,22 @@ unsigned GatherLoweringHelper::getScratchSizeInBytes() {
 }
 
 bool GatherLoweringHelper::isWarpLocal() {
+  return isWarpLocalGather(gatherOp.getSrc().getType(),
+                           gatherOp.getIndices().getType(), gatherOp.getAxis());
+}
+
+bool isWarpLocalGather(RankedTensorType srcType, RankedTensorType idxType,
+                       unsigned axis) {
   // The gather is warp-local if for each column along the gather axis in the
   // source and index tensors, all the elements are owned by the same warp.
-  RankedTensorType srcType = gatherOp.getSrc().getType();
-  RankedTensorType idxType = gatherOp.getIndices().getType();
   LinearLayout srcLayout = toLinearLayout(srcType);
   LinearLayout idxLayout = toLinearLayout(idxType);
 
-  Builder b(gatherOp.getContext());
+  Builder b(srcType.getContext());
   StringAttr kBlock = b.getStringAttr("block");
   StringAttr kWarp = b.getStringAttr("warp");
   StringAttr kLane = b.getStringAttr("lane");
-  StringAttr kGatherDim =
-      b.getStringAttr("dim" + std::to_string(gatherOp.getAxis()));
+  StringAttr kGatherDim = b.getStringAttr("dim" + std::to_string(axis));
 
   // The tensor layouts must be distributed layouts, where the basis matrix is a
   // subpermutation matrix (permutation matrix plus zeros for broadcasting).
@@ -1131,7 +1134,7 @@ bool GatherLoweringHelper::isWarpLocal() {
 
   SmallVector<StringAttr> otherDims;
   for (unsigned dim = 0, rank = srcType.getRank(); dim < rank; ++dim) {
-    if (dim != gatherOp.getAxis()) {
+    if (dim != axis) {
       otherDims.push_back(b.getStringAttr("dim" + Twine(dim)));
     }
   }

--- a/lib/Dialect/TritonGPU/Transforms/OptimizeThreadLocality.cpp
+++ b/lib/Dialect/TritonGPU/Transforms/OptimizeThreadLocality.cpp
@@ -196,6 +196,18 @@ static LogicalResult setOptimizedGatherLayout(GatherOp op, RewriterBase &b) {
   auto newLayout = BlockedEncodingAttr::get(ctx, sizePerThread, threadsPerWarp,
                                             warpsPerCTA, order, cgaLayout);
 
+  // The overflow threads and warps placed along the gather axis broadcast over
+  // the source tensor, whose extent along the axis is always covered by
+  // `sizePerThread[axis] * threadsPerWarp[axis]`. The same is not necessarily
+  // true for the index tensor: if its extent along the gather axis is larger,
+  // overflow warps map to distinct rows of the index tensor, splitting gather
+  // columns across warps (e.g. source 4x4 and index 4096x4 along axis 0 with 4
+  // warps). The layout is not warp-local in that case, so leave the layout
+  // unchanged and let the gather lower through shared memory instead.
+  if (!isWarpLocalGather(srcType.cloneWithEncoding(newLayout),
+                         idxType.cloneWithEncoding(newLayout), axis))
+    return failure();
+
   // Update the layout on the gather op and insert conversions.
   auto cvtSrc = ConvertLayoutOp::create(
       b, op.getLoc(), srcType.cloneWithEncoding(newLayout), op.getSrc());

--- a/python/test/unit/language/test_core.py
+++ b/python/test/unit/language/test_core.py
@@ -6887,7 +6887,17 @@ def gather_test_kernel_1d(src_ptr, idx_ptr, out_ptr, axis: tl.constexpr, src_dim
 @pytest.mark.interpreter
 @pytest.mark.parametrize("src_shape, indices_shape, axis", [
     ([32], [64], 0),
+    ([4], [4096], 0),
     ([4, 4], [8, 4], 0),
+    # Sources too small to absorb all warps in the non-gather dimensions, with
+    # indices longer than the source tile along the gather axis. No warp-local
+    # layout is assigned; these lower through shared memory (issue #5836).
+    ([4, 4], [16, 4], 0),
+    ([4, 4], [4096, 4], 0),
+    ([4, 4], [4, 4096], 1),
+    ([16, 4], [4096, 4], 0),
+    # Large enough along the gather axis for a warp-local layout again.
+    ([64, 4], [4096, 4], 0),
     ([128, 64], [256, 64], 0),
     ([128, 64], [128, 128], 1),
 ])

--- a/test/TritonGPU/optimize-locality.mlir
+++ b/test/TritonGPU/optimize-locality.mlir
@@ -787,3 +787,69 @@ tt.func @skip_optimize_on_1d_tensor(%arg0: tensor<256xf32, #blocked>, %arg1: ten
 }
 
 }
+
+// -----
+
+// The source tensor is too small along the non-gather dimension to absorb all
+// the warps, and the index tensor is longer along the gather axis than the
+// source tile, so no warp-local layout is assigned: the overflow warps would
+// split index columns across warps. Check that the gather keeps its original
+// layout and lowers through shared memory (no efficient_layout).
+
+#blocked = #ttg.blocked<{sizePerThread = [1, 1], threadsPerWarp = [32, 1], warpsPerCTA = [4, 1], order = [1, 0]}>
+
+// CHECK: [[LAYOUT:#.*]] = #ttg.blocked<{sizePerThread = [1, 1], threadsPerWarp = [32, 1], warpsPerCTA = [4, 1], order = [1, 0]}>
+
+module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32} {
+
+// CHECK: skip_optimize_small_source_large_index_axis_0
+tt.func @skip_optimize_small_source_large_index_axis_0(%arg0: tensor<4x4xf32, #blocked>, %arg1: tensor<4096x4xi32, #blocked>) -> tensor<4096x4xf32, #blocked> {
+  // CHECK-NOT: ttg.convert_layout
+  // CHECK: tt.gather {{.*}} {axis = 0 : i32} : (tensor<4x4xf32, [[LAYOUT]]>, tensor<4096x4xi32, [[LAYOUT]]>) -> tensor<4096x4xf32, [[LAYOUT]]>
+  %0 = tt.gather %arg0[%arg1] {axis = 0 : i32} : (tensor<4x4xf32, #blocked>, tensor<4096x4xi32, #blocked>) -> tensor<4096x4xf32, #blocked>
+  tt.return %0 : tensor<4096x4xf32, #blocked>
+}
+
+}
+
+// -----
+
+// Same as above along axis 1.
+
+#blocked = #ttg.blocked<{sizePerThread = [1, 1], threadsPerWarp = [1, 32], warpsPerCTA = [1, 4], order = [0, 1]}>
+
+// CHECK: [[LAYOUT:#.*]] = #ttg.blocked<{sizePerThread = [1, 1], threadsPerWarp = [1, 32], warpsPerCTA = [1, 4], order = [0, 1]}>
+
+module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32} {
+
+// CHECK: skip_optimize_small_source_large_index_axis_1
+tt.func @skip_optimize_small_source_large_index_axis_1(%arg0: tensor<4x4xf32, #blocked>, %arg1: tensor<4x4096xi32, #blocked>) -> tensor<4x4096xf32, #blocked> {
+  // CHECK-NOT: ttg.convert_layout
+  // CHECK: tt.gather {{.*}} {axis = 1 : i32} : (tensor<4x4xf32, [[LAYOUT]]>, tensor<4x4096xi32, [[LAYOUT]]>) -> tensor<4x4096xf32, [[LAYOUT]]>
+  %0 = tt.gather %arg0[%arg1] {axis = 1 : i32} : (tensor<4x4xf32, #blocked>, tensor<4x4096xi32, #blocked>) -> tensor<4x4096xf32, #blocked>
+  tt.return %0 : tensor<4x4096xf32, #blocked>
+}
+
+}
+
+// -----
+
+// Boundary case: the warps still overflow onto the gather axis, but the index
+// tensor's gather-axis extent (8) does not exceed the source tile
+// (sizePerThread[0] * threadsPerWarp[0] = 8), so the overflow warps broadcast
+// over both tensors and the warp-local layout is still valid.
+
+#blocked = #ttg.blocked<{sizePerThread = [1, 1], threadsPerWarp = [32, 1], warpsPerCTA = [4, 1], order = [1, 0]}>
+
+// CHECK: [[LAYOUT:#.*]] = #ttg.blocked<{sizePerThread = [1, 1], threadsPerWarp = [8, 4], warpsPerCTA = [4, 1], order = [0, 1]}>
+
+module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32} {
+
+// CHECK: set_warp_shuffle_layout_small_source_boundary_index
+tt.func @set_warp_shuffle_layout_small_source_boundary_index(%arg0: tensor<4x4xf32, #blocked>, %arg1: tensor<8x4xi32, #blocked>) -> tensor<8x4xf32, #blocked> {
+  // CHECK: tt.gather {{.*}} {axis = 0 : i32, efficient_layout} : (tensor<4x4xf32, [[LAYOUT]]>, tensor<8x4xi32, [[LAYOUT]]>) -> tensor<8x4xf32, [[LAYOUT]]>
+  %0 = tt.gather %arg0[%arg1] {axis = 0 : i32} : (tensor<4x4xf32, #blocked>, tensor<8x4xi32, #blocked>) -> tensor<8x4xf32, #blocked>
+  tt.return %0 : tensor<8x4xf32, #blocked>
+}
+
+}


### PR DESCRIPTION
Fixes #5836.

`tl.gather` aborts the compiler when the index tensor is much longer than the source tensor along
the gather axis, e.g. `src = (4, 4)`, `idx = (4096, 4)`, `axis = 0` with 4 warps:

```
OptimizeThreadLocality.cpp:220: ... setOptimizedGatherLayout(...):
Assertion `GatherLoweringHelper(op).isWarpLocal()' failed.
```

`setOptimizedGatherLayout` sizes `threadsPerWarp`/`warpsPerCTA` from the source shape and places
the leftover threads and warps along the gather axis, relying on them broadcasting. That is always
true for the source tensor, whose gather-axis extent is covered by
`sizePerThread[axis] * threadsPerWarp[axis]`, but not for an index tensor that is longer than that
tile along the gather axis: the leftover warps then map to distinct rows of the index tensor
(for the repro, warp bases `(8, 0), (16, 0)` into `dim0`), splitting gather columns across warps,
so the layout the pass just installed is not warp-local and the assert fires.

This PR validates the candidate layout against the same warp-locality predicate the lowering uses
(`GatherLoweringHelper::isWarpLocal`, refactored into a free function `isWarpLocalGather` shared by
both callers) *before* rewriting any IR, and returns `failure()` when the layout is infeasible. The
gather then keeps its default layout and lowers through the existing shared-memory path, exactly as
rank-1 gathers already do. Shapes that compiled before are unaffected: the check is the same
predicate the assert evaluated, so every previously-passing layout still passes. The assert is
retained.

Verified on an sm89 GPU (source build with assertions): the repro from the issue (1-D) and the 2-D
variants compile and produce exact matches against `torch.gather`; full lit suite and C++ unit
tests pass; the new lit tests pin the pass behavior on both sides of the feasibility boundary
((4,4)/(8,4) still gets the optimized warp-shuffle layout, (4,4)/(4096,4) is left alone).

# New contributor declaration
- [x] I am not making a trivial change, such as fixing a typo in a comment.

- [x] I have written a PR description following these
  [rules](https://cbea.ms/git-commit/#why-not-how).

- [x] I have run `pre-commit run --from-ref origin/main --to-ref HEAD`.

- Select one of the following.
  - [x] I have added tests.
    - `/test` for `lit` tests
    - `/unittest` for C++ tests
    - `/python/test` for end-to-end tests
  - [ ] This PR does not need a test because `FILL THIS IN`.

- Select one of the following.
  - [ ] I have not added any `lit` tests.
  - [x] The `lit` tests I have added follow these [best practices](https://mlir.llvm.org/getting_started/TestingGuide/#filecheck-best-practices),
    including the "tests should be minimal" section. (Usually running Python code
    and using the instructions it generates is not minimal.)
