### PR TITLE
[plugin] add push-based registration: registerInfo + refresh_plugin_p…

### DIFF
--- a/include/triton/Tools/PluginUtils.h
+++ b/include/triton/Tools/PluginUtils.h
@@ -157,6 +157,12 @@ public:
   /// with an LLVM usage error if the plugin provides invalid \c PluginInfo.
   const std::vector<Op> listOps() const;
 
+  /// Register a plugin's PluginInfo directly, without dlopen. For plugins
+  /// loaded via Python import (pybind PYBIND11_MODULE) where the .so is
+  /// already loaded by Python. The info must outlive the program (return a
+  /// pointer to a static struct, as with tritonGetPluginInfo).
+  static void registerInfo(PluginInfo *info);
+
 private:
   TritonPlugin(const std::string &filename,
                const llvm::sys::DynamicLibrary &library)

--- a/lib/Tools/PluginUtils.cpp
+++ b/lib/Tools/PluginUtils.cpp
@@ -189,4 +189,24 @@ const std::vector<TritonPlugin> &mlir::triton::plugin::loadPlugins() {
   return plugins;
 }
 
+void TritonPlugin::registerInfo(PluginInfo *info) {
+  if (!info)
+    return;
+  if (info->apiVersion != TRITON_PLUGIN_API_VERSION)
+    llvm::reportFatalUsageError(llvm::createStringError(
+        llvm::Twine("Wrong API version on plugin '") + info->pluginName +
+        "'. Got version " + Twine(info->apiVersion) + ", supported version is " +
+        Twine(TRITON_PLUGIN_API_VERSION) + "."));
+  if (!isTritonAndPluginsVersionsMatch(info->tritonVersion))
+    llvm::reportFatalUsageError(llvm::createStringError(
+        llvm::Twine("Wrong TRITON version on plugin '") + info->pluginName +
+        "'. Got version " + Twine(info->tritonVersion) +
+        ", supported version is " + Twine(TRITON_VERSION) + "."));
+  // The .so is already loaded by Python import; no dlopen needed. An empty
+  // DynamicLibrary is fine — registerDialects/listPasses only use info.
+  TritonPlugin plugin{"", llvm::sys::DynamicLibrary()};
+  plugin.info = info;
+  plugins.push_back(std::move(plugin));
+}
+
 #undef DEBUG_TYPE

--- a/python/src/passes.cc
+++ b/python/src/passes.cc
@@ -118,6 +118,8 @@ void init_plugin_passes(py::module_ &m) {
   for (const auto &plugin : mlir::triton::plugin::loadPlugins()) {
     for (const auto &pass : plugin.listPasses()) {
       std::string wrapped = std::string("add_") + pass.name;
+      if (py::hasattr(m, wrapped.c_str()))  // already registered (refresh)
+        continue;
       m.def(
           wrapped.c_str(),
           [pass](mlir::PassManager &pm, std::vector<std::string> args) {
@@ -175,4 +177,11 @@ void init_triton_passes(py::module_ &m) {
   init_gluon_passes(gluon_m);
   auto plugin_m = m.def_submodule("plugin");
   init_plugin_passes(plugin_m);
+  // Python-facing refresh: re-run init_plugin_passes for plugins injected
+  // after import triton (e.g. via TritonPlugin::registerInfo from a pybind
+  // PYBIND11_MODULE). Safe to call multiple times: init_plugin_passes skips
+  // already-registered passes via py::hasattr.
+  m.def("refresh_plugin_passes", [](py::module_ pm) {
+    init_plugin_passes(pm);
+  }, py::arg("plugin_m"));
 }


### PR DESCRIPTION
## Why

Triton's plugin system only supports plugins loaded via `TRITON_PLUGIN_PATHS` (dlopen at `loadPlugins()` time). Extensions loaded via Python `import` (pybind `PYBIND11_MODULE`) — e.g. a package shipping its own MLIR dialect/passes — cannot register into libtriton.so without setting `TRITON_PLUGIN_PATHS` to point at their installed .so.

This is awkward because:
     - The extension is already loaded by Python `import`; requiring a separate env var duplicates the loading.
     - `init_plugin_passes`/`init_triton_ir` run at `import triton` time, before the extension is imported, so the pull-based `loadPlugins()` loop misses the extension.

## What 

Add support for plugins loaded via Python import (pybind PYBIND11_MODULE) to register into libtriton.so without dlopen, complementing the existing TRITON_PLUGIN_PATHS pull model.

- PluginUtils.h/cpp: TritonPlugin::registerInfo(PluginInfo*) injects a plugin's info directly into the static plugins list (no dlopen — the .so is already loaded by Python). Validates API/triton version like TritonPlugin::load. An empty DynamicLibrary is fine since registerDialects/listPasses only use info.

- passes.cc: expose m.def("refresh_plugin_passes", [](py::module_ pm) { init_plugin_passes(pm); }) so a plugin imported after `import triton` can trigger re-registration of passes. init_plugin_passes is made idempotent via py::hasattr check — already-registered passes are skipped, so refresh only registers newly injected plugins.

Dialects need no refresh: load_dialects runs at compile time (after the plugin injects), so loadPlugins() returns the injected plugin.

This enables pybind-based extensions to register passes/dialects without setting TRITON_PLUGIN_PATHS.

<!---
The core Triton is a small number of people, and we receive many PRs (thank
you!).  To help us review your code more quickly, **if you are a new
contributor (less than 3 PRs merged) we ask that you complete the following
tasks and include the filled-out checklist in your PR description.**

Complete the following tasks before sending your PR, and replace `[ ]` with
`[x]` to indicate you have done them.
-->

# New contributor declaration
- [x] I am not making a trivial change, such as fixing a typo in a comment.

- [x] I have written a PR description following these
  [rules](https://cbea.ms/git-commit/#why-not-how).

- [ ] I have run `pre-commit run --from-ref origin/main --to-ref HEAD`.

- Select one of the following.
  - [ ] I have added tests.
    - `/test` for `lit` tests
    - `/unittest` for C++ tests
    - `/python/test` for end-to-end tests
  - [ ] This PR does not need a test because `FILL THIS IN`.

- Select one of the following.
  - [x] I have not added any `lit` tests.
  - [ ] The `lit` tests I have added follow these [best practices](https://mlir.llvm.org/getting_started/TestingGuide/#filecheck-best-practices),
    including the "tests should be minimal" section. (Usually running Python code
    and using the instructions it generates is not minimal.)
