### PR TITLE
[docs] Add system prerequisites to install-from-source section

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,22 @@ Binary wheels are available for CPython 3.10-3.14.
 
 # Install from source
 
+## Prerequisites
+
+Install system-level build dependencies before building Triton from source.
+
+**Ubuntu/Debian:**
+
+```shell
+sudo apt install zlib1g-dev libxml2-dev build-essential
+```
+
+**CentOS/RHEL:**
+
+```shell
+sudo yum install zlib-devel libxml2-devel gcc gcc-c++
+```
+
 ```shell
 git clone https://github.com/triton-lang/triton.git
 cd triton


### PR DESCRIPTION
Fixes #7910

A fresh install on a minimal Ubuntu system fails without these packages. Adds a Prerequisites section listing the required system-level build dependencies for Ubuntu/Debian and CentOS/RHEL.