### PR TITLE
docs: add Blackwell sm_121 bring-up recipe to installation

### DIFF
--- a/docs/getting-started/installation.rst
+++ b/docs/getting-started/installation.rst
@@ -50,3 +50,36 @@ You can then test your installation by running the tests:
 
       # Or, to run tests without a GPU
       make test-nogpu
+
+--------------------------
+Hardware-specific notes
+--------------------------
+
+NVIDIA Blackwell sm\_121 (GB10 / DGX Spark)
+++++++++++++++++++++++++++++++++++++++++++++
+
+PyTorch 2.9 advertises maximum compute capability ``sm_120``, but Blackwell consumer parts
+identify as ``sm_121``. Triton-compiled kernels fail with:
+
+  ``RuntimeError: Triton Error [CUDA]: no kernel image is available for execution on the device``
+
+To run Triton on ``sm_121``, point Triton at a system ``ptxas`` that understands the target
+(CUDA 13.0 or later) and set the CUDA arch list to include native ``sm_121`` with a PTX
+fallback:
+
+.. code-block:: bash
+
+      export TRITON_PTXAS_PATH=/usr/local/cuda/bin/ptxas
+      export TORCH_CUDA_ARCH_LIST="12.1+PTX"
+      unset TRITON_OVERRIDE_ARCH
+
+The PyTorch-bundled ``ptxas`` predates ``sm_121``. Switching to the system ``ptxas`` via
+``TRITON_PTXAS_PATH`` is the whole fix — every other Triton internal is unchanged.
+
+.. warning::
+
+   Setting ``TRITON_OVERRIDE_ARCH=sm90`` (or any non-Blackwell arch) will produce kernels
+   that the Blackwell driver rejects. This is the most common misconfiguration.
+
+Verified on: NVIDIA GB10 (DGX Spark), PyTorch 2.9.0+cu130, Triton 3.5, CUDA 13.0,
+Ubuntu 24.04.


### PR DESCRIPTION
Fixes #10331

Adds a Hardware-specific notes section to the installation docs covering NVIDIA Blackwell sm_121 (GB10 / DGX Spark). The recipe and failure-mode analysis are from @eniktab's investigation in the linked issue.

The fix is two env vars: TRITON_PTXAS_PATH pointing at a CUDA 13.0+ system ptxas, and TORCH_CUDA_ARCH_LIST="12.1+PTX", with TRITON_OVERRIDE_ARCH explicitly unset.