### PR TITLE
fix: use float zero for fp8 block pointer padded loads

### DIFF
--- a/python/triton/language/core.py
+++ b/python/triton/language/core.py
@@ -1924,7 +1924,10 @@ class _block_ptr:
         if padding_option == "":
             generated_other = None
         elif padding_option == "zero":
-            generated_other = 0
+            # Use a float zero for floating-point pointees: `other` is cast to the
+            # element type, and there is no int -> fp8 cast, so an int zero breaks
+            # padded loads of fp8 block pointers (see #10751).
+            generated_other = 0 if self.base.dtype.element_ty.is_int() else 0.0
         elif padding_option == "nan":
             if self.base.dtype.element_ty.is_int():
                 raise ValueError("Padding option `nan` is not supported for integer block pointers")


### PR DESCRIPTION
Fixes #10751

When padding_option="zero" on a block pointer load targeting an fp8 tensor, the integer 0 fails to cast to fp8e4nv because there is no int->fp8 cast path. Use float 0.0 for floating-point pointee types to route through the working float->fp8 conversion.

Tested on RTX 4070 Ti SUPER with Triton 3.8.0: before the fix, fp8 block-pointer loads with padding_option="zero" fail at compile time; after the fix they compile and run correctly. STORE path is unaffected.

Note: this is a one-line regression fix from PR #9668. Similar PR #10788 was closed citing block-pointer deprecation, but this bug affects users on current hardware today.