### PR TITLE
[PROTON] Fix parallel-build race on MLIR TableGen headers in ProtonIR

### DIFF
--- a/third_party/proton/Dialect/lib/Dialect/Proton/IR/CMakeLists.txt
+++ b/third_party/proton/Dialect/lib/Dialect/Proton/IR/CMakeLists.txt
@@ -5,4 +5,10 @@ add_triton_library(ProtonIR
   DEPENDS
   ProtonTableGen
   ProtonAttrDefsIncGen
+
+  LINK_LIBS PUBLIC
+  MLIRIR
+  MLIRLLVMDialect
+  MLIRFunctionInterfaces
+  MLIRTransformUtils
 )


### PR DESCRIPTION
## Summary
`ProtonIR` compiles `Dialect.cpp` / `Ops.cpp`, which include MLIR core
headers (`mlir/IR/BuiltinOps.h`, `mlir/IR/Dialect.h`,
`mlir/IR/BuiltinAttributes.h`, `mlir/Dialect/LLVMIR/LLVMDialect.h`,
`mlir/Interfaces/FunctionInterfaces.h`, `mlir/Transforms/InliningUtils.h`, …).
These transitively pull in TableGen-generated headers such as
`BuiltinLocationAttributes.h.inc`.
However, `ProtonIR` declares **no `LINK_LIBS`** — it is the only MLIR-dialect
object library in the tree that links no other library at all. As a result,
its object compiles inherit no ordering against the MLIR generated headers,
unlike every other dialect (e.g. `TritonIR` links `MLIRIR …`). When MLIR is
built in-tree alongside Triton and a high parallelism level is used (`-j`),
CMake may schedule `Dialect.cpp` before the MLIR headers are generated:

`fatal error: '.../mlir/IR/BuiltinLocationAttributes.h.inc' file not found`

The failure is probabilistic and depends on task-scheduling order; low
parallelism usually hides it because TableGen happens to finish first.
## Fix
Give `ProtonIR` the MLIR usage requirements it actually needs, matching its
includes and mirroring the other dialect libraries:
- `MLIRIR` — `mlir/IR/*`
- `MLIRLLVMDialect` — `mlir/Dialect/LLVMIR/LLVMDialect.h`
- `MLIRFunctionInterfaces` — `mlir/Interfaces/Function{Implementation,Interfaces}.h`
- `MLIRTransformUtils` — `mlir/Transforms/InliningUtils.h`
Each of these is built via `add_mlir_library` (which depends on
`mlir-generic-headers`) and carries its own TableGen `IncGen`, so `ProtonIR`'s
compiles are now correctly ordered after the generated headers it consumes.
Using real `MLIR*` link libraries (rather than a direct dependency on
`mlir-generic-headers`) keeps this working for both in-tree and prebuilt-LLVM
builds, since those targets are imported from the installed LLVM/MLIR.
## How to reproduce
1. Configure an in-tree LLVM + Triton build (so MLIR headers are generated as
   part of the build rather than provided prebuilt).
2. Clean build (`rm -rf build`).
3. Build with high parallelism (`-j32` or higher).
4. The `BuiltinLocationAttributes.h.inc: No such file or directory` error
   appears intermittently while compiling `ProtonIR`.
With this change the race no longer occurs.

## Notes
This is the same class of build race previously fixed narrowly in #9708
(TritonPlugin) and #10077 (NVHopperTransforms); `ProtonIR` is the remaining
target that was missing its MLIR link dependencies.

<!---
The core Triton is a small number of people, and we receive many PRs (thank
you!).  To help us review your code more quickly, **if you are a new
contributor (less than 3 PRs merged) we ask that you complete the following
tasks and include the filled-out checklist in your PR description.**

Complete the following tasks before sending your PR, and replace `[ ]` with
`[x]` to indicate you have done them.
-->

# New contributor declaration
- [x] I am not making a trivial change, such as fixing a typo in a comment.

- [x] I have written a PR description following these
  [rules](https://cbea.ms/git-commit/#why-not-how).

- [ ] I have run `pre-commit run --from-ref origin/main --to-ref HEAD`.

- Select one of the following.
  - [ ] I have added tests.
    - `/test` for `lit` tests
    - `/unittest` for C++ tests
    - `/python/test` for end-to-end tests
  - [x] This PR does not need a test because `FILL THIS IN`.

- Select one of the following.
  - [x] I have not added any `lit` tests.
  - [ ] The `lit` tests I have added follow these [best practices](https://mlir.llvm.org/getting_started/TestingGuide/#filecheck-best-practices),
    including the "tests should be minimal" section. (Usually running Python code
    and using the instructions it generates is not minimal.)


CC: @antiagainst  @zhanglx13 
