### PR TITLE
[SANITIZER] Avoid split rematerialization and handle exp

### DIFF
--- a/include/triton/Dialect/TritonGPU/Transforms/Passes.td
+++ b/include/triton/Dialect/TritonGPU/Transforms/Passes.td
@@ -262,9 +262,9 @@ def TritonGPURemoveLayoutConversions : Pass<"tritongpu-remove-layout-conversions
                            "mlir::triton::TritonDialect"];
 
   let options = [
-    Option<"disableRemat", "disable-remat",
+    Option<"disableRematSplitting", "disable-remat-splitting",
            "bool", /*default*/"false",
-           "prevent backward rematerialization from duplicating layout conversions">
+           "prevent backward rematerialization from duplicating operations">
   ];
 }
 

--- a/include/triton/Dialect/TritonGPU/Transforms/Passes.td
+++ b/include/triton/Dialect/TritonGPU/Transforms/Passes.td
@@ -261,6 +261,11 @@ def TritonGPURemoveLayoutConversions : Pass<"tritongpu-remove-layout-conversions
   let dependentDialects = ["mlir::triton::gpu::TritonGPUDialect",
                            "mlir::triton::TritonDialect"];
 
+  let options = [
+    Option<"disableRemat", "disable-remat",
+           "bool", /*default*/"false",
+           "prevent backward rematerialization from duplicating layout conversions">
+  ];
 }
 
 def TritonGPUOptimizeThreadLocality : Pass<"tritongpu-optimize-thread-locality", "mlir::ModuleOp"> {

--- a/lib/Dialect/TritonGPU/Transforms/RemoveLayoutConversions.cpp
+++ b/lib/Dialect/TritonGPU/Transforms/RemoveLayoutConversions.cpp
@@ -906,9 +906,8 @@ void LayoutRematerialization::rewriteSlice(
 
   convertOp->erase();
   for (Operation *op : llvm::reverse(rematerializedOps)) {
-    if (llvm::all_of(op->getResults(), [](Value result) {
-          return result.use_empty();
-        })) {
+    if (llvm::all_of(op->getResults(),
+                     [](Value result) { return result.use_empty(); })) {
       LDBG("  erase rematerialized op " << *op);
       for (Value result : op->getResults())
         removeRematValue(result);
@@ -1653,7 +1652,8 @@ class TritonGPURemoveLayoutConversionsPass
           TritonGPURemoveLayoutConversionsPass> {
 public:
   using impl::TritonGPURemoveLayoutConversionsBase<
-      TritonGPURemoveLayoutConversionsPass>::TritonGPURemoveLayoutConversionsBase;
+      TritonGPURemoveLayoutConversionsPass>::
+      TritonGPURemoveLayoutConversionsBase;
 
   // Cleanup convert ops.
   void cleanupConvertOps() {

--- a/lib/Dialect/TritonGPU/Transforms/RemoveLayoutConversions.cpp
+++ b/lib/Dialect/TritonGPU/Transforms/RemoveLayoutConversions.cpp
@@ -112,8 +112,7 @@ private:
 
 class LayoutRematerialization {
 public:
-  LayoutRematerialization(FuncOp F, bool disableRemat = false)
-      : funcOp(F), disableRemat(disableRemat) {}
+  LayoutRematerialization(FuncOp F) : funcOp(F) {}
   ~LayoutRematerialization();
 
   // Map the original value to the remat'ed one.
@@ -179,7 +178,6 @@ public:
 
 private:
   void updateRematMapping(SmallVector<std::tuple<Value, Value>> &values);
-  void removeRematValue(Value value);
   // Map values to their rematerializations for a given encoding. We have to be
   // careful about what we put in this map because updateRematMapping only
   // updates keys, and doesn't search for rematerialized values that may be
@@ -191,7 +189,6 @@ private:
   FuncOp funcOp;
   DominanceInfo domInfo;
   PostDominanceInfo postDomInfo;
-  bool disableRemat;
 };
 
 LayoutRematerialization::~LayoutRematerialization() {
@@ -713,19 +710,6 @@ void LayoutRematerialization::updateRematMapping(
   }
 }
 
-void LayoutRematerialization::removeRematValue(Value value) {
-  rematMapping.erase(value);
-  for (auto &[key, remats] : rematMapping) {
-    SmallVector<Attribute> encodingsToRemove;
-    for (auto [encoding, remat] : remats) {
-      if (remat == value)
-        encodingsToRemove.push_back(encoding);
-    }
-    for (Attribute encoding : encodingsToRemove)
-      remats.erase(encoding);
-  }
-}
-
 void LayoutRematerialization::rewriteSlice(
     SetVector<Value> &slice, DenseMap<Value, Attribute> &layout,
     const DenseMap<std::pair<Value, Attribute>, Value> &existingRemats,
@@ -771,19 +755,6 @@ void LayoutRematerialization::rewriteSlice(
   }
   slice.set_subtract(valuesWithExistingRemat);
   opsToRewrite = mlir::topologicalSort(opsToRewrite);
-
-  // Backward rematerialization clones the slice. When requested, track the
-  // original straight-line operations so a nested conversion is not left as a
-  // dead duplicate after its users have been rewritten.
-  SmallVector<Operation *> rematerializedOps;
-  if (disableRemat && llvm::any_of(slice, [](Value value) {
-        return value.getDefiningOp<ConvertLayoutOp>();
-      })) {
-    for (Operation *op : opsToRewrite) {
-      if (op->getNumResults() > 0 && op->getNumRegions() == 0)
-        rematerializedOps.push_back(op);
-    }
-  }
 
   // replaceAllUsesWith calls delayed until after initial rewrite.
   // This is required for slice.count(value) to work mid rewrite.
@@ -905,15 +876,6 @@ void LayoutRematerialization::rewriteSlice(
   }
 
   convertOp->erase();
-  for (Operation *op : llvm::reverse(rematerializedOps)) {
-    if (llvm::all_of(op->getResults(),
-                     [](Value result) { return result.use_empty(); })) {
-      LDBG("  erase rematerialized op " << *op);
-      for (Value result : op->getResults())
-        removeRematValue(result);
-      op->erase();
-    }
-  }
   for (Operation *op : deadOps)
     op->erase();
 }
@@ -1628,10 +1590,10 @@ bool LayoutRematerialization::hoistConvertIntoConditionals(
   return true;
 }
 
-bool backwardRematerialization(ModuleOp module, bool disableRemat) {
+bool backwardRematerialization(ModuleOp module) {
   bool changed = false;
   module.walk([&](FuncOp funcOp) {
-    LayoutRematerialization layoutRemat(funcOp, disableRemat);
+    LayoutRematerialization layoutRemat(funcOp);
     changed |= layoutRemat.backwardRematerialization();
   });
   return changed;
@@ -1691,29 +1653,29 @@ public:
 
     cleanupConvertOps();
 
-    bool changed = false;
-    do {
-      changed = false;
-      // 2. For remaining convert ops, try to rematerialize the slice of
-      // producer operation to avoid having to convert.
-      changed = backwardRematerialization(m, disableRemat);
+    if (!disableRemat) {
+      bool changed = false;
+      do {
+        changed = false;
+        // 2. For remaining convert ops, try to rematerialize the slice of
+        // producer operation to avoid having to convert.
+        changed = backwardRematerialization(m);
+        LLVM_DEBUG({
+          DBGS() << "Module after backward remat:\n";
+          m.dump();
+        });
+
+        // Cleanup dummy converts created during backward remat.
+        cleanupConvertOps();
+      } while (changed);
+      // 3. For remaining converts, try to hoist them above cast generating
+      // larger size types in order to reduce the cost of the convert op.
+      hoistConvert(m);
       LLVM_DEBUG({
-        DBGS() << "Module after backward remat:\n";
+        DBGS() << "Module after hoisting converts:\n";
         m.dump();
       });
-
-      // Cleanup dummy converts created during backward remat.
-      cleanupConvertOps();
-    } while (changed);
-    // 3. For remaining converts, try to hoist them above cast generating larger
-    // size types in order to reduce the cost of the convert op.
-    // Hoisting also rematerializes slices and can recreate the duplicate.
-    if (!disableRemat)
-      hoistConvert(m);
-    LLVM_DEBUG({
-      DBGS() << "Module after hoisting converts:\n";
-      m.dump();
-    });
+    }
 
     // 4. Prepare dead iter args to be cleaned up by dead code elimination in
     // the pattern rewriter below.

--- a/lib/Dialect/TritonGPU/Transforms/RemoveLayoutConversions.cpp
+++ b/lib/Dialect/TritonGPU/Transforms/RemoveLayoutConversions.cpp
@@ -112,7 +112,8 @@ private:
 
 class LayoutRematerialization {
 public:
-  LayoutRematerialization(FuncOp F) : funcOp(F) {}
+  LayoutRematerialization(FuncOp F, bool disableRemat = false)
+      : funcOp(F), disableRemat(disableRemat) {}
   ~LayoutRematerialization();
 
   // Map the original value to the remat'ed one.
@@ -178,6 +179,7 @@ public:
 
 private:
   void updateRematMapping(SmallVector<std::tuple<Value, Value>> &values);
+  void removeRematValue(Value value);
   // Map values to their rematerializations for a given encoding. We have to be
   // careful about what we put in this map because updateRematMapping only
   // updates keys, and doesn't search for rematerialized values that may be
@@ -189,6 +191,7 @@ private:
   FuncOp funcOp;
   DominanceInfo domInfo;
   PostDominanceInfo postDomInfo;
+  bool disableRemat;
 };
 
 LayoutRematerialization::~LayoutRematerialization() {
@@ -710,6 +713,19 @@ void LayoutRematerialization::updateRematMapping(
   }
 }
 
+void LayoutRematerialization::removeRematValue(Value value) {
+  rematMapping.erase(value);
+  for (auto &[key, remats] : rematMapping) {
+    SmallVector<Attribute> encodingsToRemove;
+    for (auto [encoding, remat] : remats) {
+      if (remat == value)
+        encodingsToRemove.push_back(encoding);
+    }
+    for (Attribute encoding : encodingsToRemove)
+      remats.erase(encoding);
+  }
+}
+
 void LayoutRematerialization::rewriteSlice(
     SetVector<Value> &slice, DenseMap<Value, Attribute> &layout,
     const DenseMap<std::pair<Value, Attribute>, Value> &existingRemats,
@@ -755,6 +771,19 @@ void LayoutRematerialization::rewriteSlice(
   }
   slice.set_subtract(valuesWithExistingRemat);
   opsToRewrite = mlir::topologicalSort(opsToRewrite);
+
+  // Backward rematerialization clones the slice. When requested, track the
+  // original straight-line operations so a nested conversion is not left as a
+  // dead duplicate after its users have been rewritten.
+  SmallVector<Operation *> rematerializedOps;
+  if (disableRemat && llvm::any_of(slice, [](Value value) {
+        return value.getDefiningOp<ConvertLayoutOp>();
+      })) {
+    for (Operation *op : opsToRewrite) {
+      if (op->getNumResults() > 0 && op->getNumRegions() == 0)
+        rematerializedOps.push_back(op);
+    }
+  }
 
   // replaceAllUsesWith calls delayed until after initial rewrite.
   // This is required for slice.count(value) to work mid rewrite.
@@ -876,6 +905,16 @@ void LayoutRematerialization::rewriteSlice(
   }
 
   convertOp->erase();
+  for (Operation *op : llvm::reverse(rematerializedOps)) {
+    if (llvm::all_of(op->getResults(), [](Value result) {
+          return result.use_empty();
+        })) {
+      LDBG("  erase rematerialized op " << *op);
+      for (Value result : op->getResults())
+        removeRematValue(result);
+      op->erase();
+    }
+  }
   for (Operation *op : deadOps)
     op->erase();
 }
@@ -1590,10 +1629,10 @@ bool LayoutRematerialization::hoistConvertIntoConditionals(
   return true;
 }
 
-bool backwardRematerialization(ModuleOp module) {
+bool backwardRematerialization(ModuleOp module, bool disableRemat) {
   bool changed = false;
   module.walk([&](FuncOp funcOp) {
-    LayoutRematerialization layoutRemat(funcOp);
+    LayoutRematerialization layoutRemat(funcOp, disableRemat);
     changed |= layoutRemat.backwardRematerialization();
   });
   return changed;
@@ -1613,6 +1652,9 @@ class TritonGPURemoveLayoutConversionsPass
     : public impl::TritonGPURemoveLayoutConversionsBase<
           TritonGPURemoveLayoutConversionsPass> {
 public:
+  using impl::TritonGPURemoveLayoutConversionsBase<
+      TritonGPURemoveLayoutConversionsPass>::TritonGPURemoveLayoutConversionsBase;
+
   // Cleanup convert ops.
   void cleanupConvertOps() {
     MLIRContext *context = &getContext();
@@ -1654,7 +1696,7 @@ public:
       changed = false;
       // 2. For remaining convert ops, try to rematerialize the slice of
       // producer operation to avoid having to convert.
-      changed = backwardRematerialization(m);
+      changed = backwardRematerialization(m, disableRemat);
       LLVM_DEBUG({
         DBGS() << "Module after backward remat:\n";
         m.dump();
@@ -1665,7 +1707,9 @@ public:
     } while (changed);
     // 3. For remaining converts, try to hoist them above cast generating larger
     // size types in order to reduce the cost of the convert op.
-    hoistConvert(m);
+    // Hoisting also rematerializes slices and can recreate the duplicate.
+    if (!disableRemat)
+      hoistConvert(m);
     LLVM_DEBUG({
       DBGS() << "Module after hoisting converts:\n";
       m.dump();

--- a/lib/Dialect/TritonGPU/Transforms/RemoveLayoutConversions.cpp
+++ b/lib/Dialect/TritonGPU/Transforms/RemoveLayoutConversions.cpp
@@ -123,12 +123,13 @@ public:
     return rematMapping.lookup(value).lookup(encoding);
   }
 
-  bool backwardRematerialization();
+  bool backwardRematerialization(bool disableRematSplitting);
 
   /// Rematerialize the backward slice leading up to \p convertOp to produce the
   /// result layout directly if it is possible and profitable to do so.
   /// \return true if \p convertOp was eliminated, false otherwise.
-  bool backwardRematerialization(ConvertLayoutOp convertOp);
+  bool backwardRematerialization(ConvertLayoutOp convertOp,
+                                 bool disableRematSplitting);
 
   // TODO: Merge the three hoistConvert*(); functions as they are duplicate code
   void hoistConvertDotOperand();
@@ -955,14 +956,15 @@ LogicalResult LayoutRematerialization::getRematerializableSlice(
   return success();
 }
 
-bool LayoutRematerialization::backwardRematerialization() {
+bool LayoutRematerialization::backwardRematerialization(
+    bool disableRematSplitting) {
   bool changed = false;
   // Go through each ConvertLayoutOp.
   SmallVector<ConvertLayoutOp> convertOps;
   funcOp.walk(
       [&](ConvertLayoutOp convertOp) { convertOps.push_back(convertOp); });
   for (ConvertLayoutOp convertOp : convertOps) {
-    if (!backwardRematerialization(convertOp)) {
+    if (!backwardRematerialization(convertOp, disableRematSplitting)) {
       // If the conversion didn't get removed, consider it for reuse in future
       // backward slices.
       addRematValue(convertOp.getSrc(), convertOp.getType().getEncoding(),
@@ -1072,7 +1074,7 @@ static unsigned getCostFactor(Value result, Attribute rematEncoding) {
 /// newCvtCost.
 bool isRematBeneficial(ConvertLayoutOp convertOp, const SetVector<Value> &slice,
                        const DenseMap<Value, Attribute> &layout,
-                       int64_t newCvtCost) {
+                       int64_t newCvtCost, bool disableRematSplitting) {
   // Identify all operations in the slice
   SetVector<Operation *> sliceOps;
   for (Value v : slice) {
@@ -1138,6 +1140,11 @@ bool isRematBeneficial(ConvertLayoutOp convertOp, const SetVector<Value> &slice,
     for (auto operand : op->getOperands())
       if (slice.contains(operand))
         nonSliceOnlyValues.insert(operand);
+  }
+
+  if (disableRematSplitting && !nonSliceOnlyValues.empty()) {
+    LDBG("  skipped rematerialization because it would split the slice");
+    return false;
   }
 
   int64_t convertLayoutCost =
@@ -1210,7 +1217,7 @@ bool isRematBeneficial(ConvertLayoutOp convertOp, const SetVector<Value> &slice,
 }
 
 bool LayoutRematerialization::backwardRematerialization(
-    ConvertLayoutOp convertOp) {
+    ConvertLayoutOp convertOp, bool disableRematSplitting) {
   // DotOperand is hoisted by hoistDotOperand
   RankedTensorType targetType = convertOp.getType();
   if (isa<DotOperandEncodingAttr>(targetType.getEncoding()))
@@ -1243,8 +1250,9 @@ bool LayoutRematerialization::backwardRematerialization(
   }
 
   // 2. Determine whether rematerialisation is beneficial.
-  if (!isRematBeneficial(convertOp, slice, layout, /*newCvtCost=*/0)) {
-    LDBG("  skipped rematerialization due to higher cost");
+  if (!isRematBeneficial(convertOp, slice, layout, /*newCvtCost=*/0,
+                         disableRematSplitting)) {
+    LDBG("  skipped rematerialization because it is not beneficial");
     return false;
   }
 
@@ -1450,7 +1458,8 @@ bool LayoutRematerialization::hoistConvertOnTopOfExtOrBroadcast(
     return false;
   int64_t newCvtCost =
       getConvertCost(extOrBroadcastOp->getOperand(0), srcEncoding);
-  if (!isRematBeneficial(convertOp, slice, layout, newCvtCost))
+  if (!isRematBeneficial(convertOp, slice, layout, newCvtCost,
+                         /*disableRematSplitting=*/false))
     return false;
   // Move the convert before the ext op and rewrite the slice.
   OpBuilder builder(extOrBroadcastOp);
@@ -1590,11 +1599,11 @@ bool LayoutRematerialization::hoistConvertIntoConditionals(
   return true;
 }
 
-bool backwardRematerialization(ModuleOp module) {
+bool backwardRematerialization(ModuleOp module, bool disableRematSplitting) {
   bool changed = false;
   module.walk([&](FuncOp funcOp) {
     LayoutRematerialization layoutRemat(funcOp);
-    changed |= layoutRemat.backwardRematerialization();
+    changed |= layoutRemat.backwardRematerialization(disableRematSplitting);
   });
   return changed;
 }
@@ -1653,21 +1662,22 @@ public:
 
     cleanupConvertOps();
 
-    if (!disableRemat) {
-      bool changed = false;
-      do {
-        changed = false;
-        // 2. For remaining convert ops, try to rematerialize the slice of
-        // producer operation to avoid having to convert.
-        changed = backwardRematerialization(m);
-        LLVM_DEBUG({
-          DBGS() << "Module after backward remat:\n";
-          m.dump();
-        });
+    bool changed = false;
+    do {
+      changed = false;
+      // 2. For remaining convert ops, try to rematerialize the slice of
+      // producer operation to avoid having to convert.
+      changed = backwardRematerialization(m, disableRematSplitting);
+      LLVM_DEBUG({
+        DBGS() << "Module after backward remat:\n";
+        m.dump();
+      });
 
-        // Cleanup dummy converts created during backward remat.
-        cleanupConvertOps();
-      } while (changed);
+      // Cleanup dummy converts created during backward remat.
+      cleanupConvertOps();
+    } while (changed);
+
+    if (!disableRematSplitting) {
       // 3. For remaining converts, try to hoist them above cast generating
       // larger size types in order to reduce the cost of the convert op.
       hoistConvert(m);

--- a/lib/Dialect/TritonInstrument/Transforms/FpSanitizer.cpp
+++ b/lib/Dialect/TritonInstrument/Transforms/FpSanitizer.cpp
@@ -3080,6 +3080,7 @@ makeTernaryExternTransform(TernaryExternTransform transform) {
 std::optional<KnownExternTransform> getKnownExtern(StringRef symbol) {
   return llvm::StringSwitch<std::optional<KnownExternTransform>>(symbol)
       .Case("__nv_fast_expf", makeUnaryExternTransform(fpsanExp))
+      .Case("__nv_expf", makeUnaryExternTransform(fpsanExp))
       .Case("__nv_exp2f", makeUnaryExternTransform(fpsanExp2))
       .Case("__nv_logf", makeTaggedUnaryExternTransform(UnaryOpId::Log))
       .Case("__nv_log2f", makeTaggedUnaryExternTransform(UnaryOpId::Log2))

--- a/python/src/passes.cc
+++ b/python/src/passes.cc
@@ -80,6 +80,8 @@ void init_triton_passes_ttgpuir(py::module_ &m) {
                             createTritonGPUOptimizeDotOperands, bool);
   ADD_PASS_WRAPPER_0("add_remove_layout_conversions",
                      createTritonGPURemoveLayoutConversions);
+  ADD_PASS_OPTION_WRAPPER_1("add_remove_layout_conversions",
+                            createTritonGPURemoveLayoutConversions, bool);
   ADD_PASS_WRAPPER_0("add_reduce_data_duplication",
                      createTritonGPUReduceDataDuplication);
   ADD_PASS_WRAPPER_0("add_allocate_warp_groups",

--- a/python/test/unit/cuda/test_libdevice_cuda.py
+++ b/python/test/unit/cuda/test_libdevice_cuda.py
@@ -71,6 +71,9 @@ def builtin_libdevice_unary_kernel(
 
     if OP == "exp":
         builtin = tl.exp(x)
+        external = libdevice.exp(x)
+    elif OP == "fast_exp":
+        builtin = tl.exp(x)
         external = libdevice.fast_expf(x)
     elif OP == "sqrt_rn":
         builtin = tl.sqrt_rn(x)
@@ -162,7 +165,7 @@ def _random_payloads(generator, n_elements):
 
 
 @pytest.mark.parametrize(
-    "op", ["exp", "exp2", "log", "log2", "sin", "cos", "sqrt_rn", "rsqrt", "erf", "floor", "ceil"]
+    "op", ["exp", "fast_exp", "exp2", "log", "log2", "sin", "cos", "sqrt_rn", "rsqrt", "erf", "floor", "ceil"]
 )
 def test_fpsan_libdevice_unary_equivalence(op, fresh_knobs):
     if not is_cuda() or not torch.cuda.is_available():

--- a/test/TritonGPU/fpsan.mlir
+++ b/test/TritonGPU/fpsan.mlir
@@ -564,6 +564,20 @@ tt.func public @extern_unary_fallback(%a: tensor<4xf32>) -> tensor<4xf32> {
 
 // -----
 
+// CHECK-LABEL: @extern_exp_known
+tt.func public @extern_exp_known(%a: tensor<4xf32>) -> tensor<4xf32> {
+  // CHECK-DAG: arith.constant dense<594471359>
+  // CHECK-DAG: arith.constant dense<1>
+  // CHECK: tti.experimental_fpsan_embed
+  // CHECK: arith.muli
+  // CHECK-NOT: scf.for
+  // CHECK-NOT: tt.extern_elementwise
+  %0 = tt.extern_elementwise %a {libname = "", libpath = "", pure = true, symbol = "__nv_expf"} : (tensor<4xf32>) -> tensor<4xf32>
+  tt.return %0 : tensor<4xf32>
+}
+
+// -----
+
 // CHECK-LABEL: @extern_unary_known
 tt.func public @extern_unary_known(%a: tensor<4xf32>) -> tensor<4xf32> {
   // CHECK: tti.experimental_fpsan_embed

--- a/test/TritonGPU/remove-layout-conversions-disable-remat.mlir
+++ b/test/TritonGPU/remove-layout-conversions-disable-remat.mlir
@@ -1,0 +1,26 @@
+// RUN: triton-opt %s -tritongpu-remove-layout-conversions | FileCheck %s --check-prefix=DEFAULT
+// RUN: triton-opt %s -tritongpu-remove-layout-conversions='disable-remat=true' | FileCheck %s --check-prefix=DISABLED
+
+// DEFAULT-LABEL: @nested_convert
+// DEFAULT-COUNT-1: ttg.convert_layout
+// DEFAULT-NOT: ttg.convert_layout
+
+// DISABLED-LABEL: @nested_convert
+// DISABLED-COUNT-1: ttg.convert_layout
+// DISABLED-NOT: ttg.convert_layout
+
+#blocked = #ttg.blocked<{sizePerThread = [1, 4], threadsPerWarp = [1, 32], warpsPerCTA = [4, 2], order = [1, 0], CGALayout = [[0, 1]]}>
+#src = #ttg.linear<{register = [[1, 0], [2, 0], [4, 0], [8, 0], [16, 0], [32, 0], [64, 0]], lane = [[0, 1], [0, 2], [0, 4], [0, 8], [0, 16]], warp = [[0, 32], [0, 64], [0, 128]], block = [[0, 256]]}>
+#packed = #ttg.linear<{register = [[0, 0, 1], [0, 1, 0], [4, 0, 0], [8, 0, 0], [16, 0, 0], [32, 0, 0], [64, 0, 0]], lane = [[0, 2, 0], [0, 4, 0], [0, 8, 0], [0, 16, 0], [0, 32, 0]], warp = [[0, 64, 0], [1, 0, 0], [2, 0, 0]], block = [[0, 128, 0]]}>
+#target = #ttg.linear<{register = [[0, 1]], lane = [[0, 2], [0, 4], [0, 8], [0, 16], [0, 32]], warp = [[0, 64], [0, 0], [0, 0]], block = [[0, 128]]}>
+
+module attributes {"ttg.num-ctas" = 2 : i32, "ttg.num-warps" = 8 : i32} {
+  tt.func @nested_convert(%arg0: tensor<128x512xf32, #src>) -> tensor<128x256xi64, #target> {
+    %0 = ttg.convert_layout %arg0 : tensor<128x512xf32, #src> -> tensor<128x512xf32, #blocked>
+    %1 = tt.reshape %0 : tensor<128x512xf32, #blocked> -> tensor<128x256x2xf32, #packed>
+    %outLHS, %outRHS = tt.split %1 : tensor<128x256x2xf32, #packed> -> tensor<128x256xf32, #ttg.slice<{dim = 2, parent = #packed}>>
+    %2 = tt.elementwise_inline_asm "mov.b64 $0, { $1, $2 };" {constraints = "=l,r,r", packed_element = 1 : i32, pure = true} %outLHS, %outRHS : tensor<128x256xf32, #ttg.slice<{dim = 2, parent = #packed}>>, tensor<128x256xf32, #ttg.slice<{dim = 2, parent = #packed}>> -> tensor<128x256xi64, #ttg.slice<{dim = 2, parent = #packed}>>
+    %3 = ttg.convert_layout %2 : tensor<128x256xi64, #ttg.slice<{dim = 2, parent = #packed}>> -> tensor<128x256xi64, #target>
+    tt.return %3 : tensor<128x256xi64, #target>
+  }
+}

--- a/test/TritonGPU/remove-layout-conversions-disable-remat.mlir
+++ b/test/TritonGPU/remove-layout-conversions-disable-remat.mlir
@@ -1,20 +1,35 @@
 // RUN: triton-opt %s -tritongpu-remove-layout-conversions | FileCheck %s --check-prefix=DEFAULT
-// RUN: triton-opt %s -tritongpu-remove-layout-conversions='disable-remat=true' | FileCheck %s --check-prefix=DISABLED
+// RUN: triton-opt %s -tritongpu-remove-layout-conversions='disable-remat-splitting=true' | FileCheck %s --check-prefix=NO-SPLIT
 
-// DEFAULT-LABEL: @nested_convert
+// DEFAULT-LABEL: @nested_convert_single_use
 // DEFAULT: %[[RESHAPE:.+]] = tt.reshape
 // DEFAULT-NEXT: %[[CONVERT:.+]] = ttg.convert_layout %[[RESHAPE]]
 // DEFAULT-NEXT: %[[LHS:.+]], %[[RHS:.+]] = tt.split %[[CONVERT]]
 // DEFAULT-NEXT: %[[ASM:.+]] = tt.elementwise_inline_asm {{.*}} %[[LHS]], %[[RHS]]
 // DEFAULT-NEXT: tt.return %[[ASM]]
 
-// DISABLED-LABEL: @nested_convert
-// DISABLED: %[[RESHAPE:.+]] = tt.reshape
-// DISABLED-NEXT: %[[INPUT_CONVERT:.+]] = ttg.convert_layout %[[RESHAPE]]
-// DISABLED-NEXT: %[[LHS:.+]], %[[RHS:.+]] = tt.split %[[INPUT_CONVERT]]
-// DISABLED-NEXT: %[[ASM:.+]] = tt.elementwise_inline_asm {{.*}} %[[LHS]], %[[RHS]]
-// DISABLED-NEXT: %[[OUTPUT_CONVERT:.+]] = ttg.convert_layout %[[ASM]]
-// DISABLED-NEXT: tt.return %[[OUTPUT_CONVERT]]
+// NO-SPLIT-LABEL: @nested_convert_single_use
+// NO-SPLIT: %[[RESHAPE:.+]] = tt.reshape
+// NO-SPLIT-NEXT: %[[INPUT_CONVERT:.+]] = ttg.convert_layout %[[RESHAPE]]
+// NO-SPLIT-NEXT: %[[LHS:.+]], %[[RHS:.+]] = tt.split %[[INPUT_CONVERT]]
+// NO-SPLIT-NEXT: %[[ASM:.+]] = tt.elementwise_inline_asm {{.*}} %[[LHS]], %[[RHS]]
+// NO-SPLIT-NEXT: tt.return %[[ASM]]
+
+// DEFAULT-LABEL: @nested_convert_multi_use
+// DEFAULT: %[[RESHAPE:.+]] = tt.reshape
+// DEFAULT-NEXT: %[[TARGET_INPUT:.+]] = ttg.convert_layout %[[RESHAPE]]
+// DEFAULT-NEXT: %[[ORIGINAL_INPUT:.+]] = ttg.convert_layout %[[RESHAPE]]
+// DEFAULT: %[[TARGET:.+]] = tt.elementwise_inline_asm
+// DEFAULT-NEXT: %[[ORIGINAL:.+]] = tt.elementwise_inline_asm
+// DEFAULT-NEXT: tt.return %[[TARGET]], %[[TARGET]], %[[ORIGINAL]]
+
+// NO-SPLIT-LABEL: @nested_convert_multi_use
+// NO-SPLIT: %[[RESHAPE:.+]] = tt.reshape
+// NO-SPLIT-NEXT: %[[INPUT_CONVERT:.+]] = ttg.convert_layout %[[RESHAPE]]
+// NO-SPLIT-NEXT: %[[LHS:.+]], %[[RHS:.+]] = tt.split %[[INPUT_CONVERT]]
+// NO-SPLIT-NEXT: %[[ASM:.+]] = tt.elementwise_inline_asm {{.*}} %[[LHS]], %[[RHS]]
+// NO-SPLIT-NEXT: %[[OUTPUT_CONVERT:.+]] = ttg.convert_layout %[[ASM]]
+// NO-SPLIT-NEXT: tt.return %[[OUTPUT_CONVERT]], %[[OUTPUT_CONVERT]], %[[ASM]]
 
 #blocked = #ttg.blocked<{sizePerThread = [1, 4], threadsPerWarp = [1, 32], warpsPerCTA = [4, 2], order = [1, 0], CGALayout = [[0, 1]]}>
 #src = #ttg.linear<{register = [[1, 0], [2, 0], [4, 0], [8, 0], [16, 0], [32, 0], [64, 0]], lane = [[0, 1], [0, 2], [0, 4], [0, 8], [0, 16]], warp = [[0, 32], [0, 64], [0, 128]], block = [[0, 256]]}>
@@ -22,12 +37,22 @@
 #target = #ttg.linear<{register = [[0, 1]], lane = [[0, 2], [0, 4], [0, 8], [0, 16], [0, 32]], warp = [[0, 64], [0, 0], [0, 0]], block = [[0, 128]]}>
 
 module attributes {"ttg.num-ctas" = 2 : i32, "ttg.num-warps" = 8 : i32} {
-  tt.func @nested_convert(%arg0: tensor<128x512xf32, #src>) -> tensor<128x256xi64, #target> {
+  tt.func @nested_convert_single_use(%arg0: tensor<128x512xf32, #src>) -> tensor<128x256xi64, #target> {
     %0 = ttg.convert_layout %arg0 : tensor<128x512xf32, #src> -> tensor<128x512xf32, #blocked>
     %1 = tt.reshape %0 : tensor<128x512xf32, #blocked> -> tensor<128x256x2xf32, #packed>
     %outLHS, %outRHS = tt.split %1 : tensor<128x256x2xf32, #packed> -> tensor<128x256xf32, #ttg.slice<{dim = 2, parent = #packed}>>
     %2 = tt.elementwise_inline_asm "mov.b64 $0, { $1, $2 };" {constraints = "=l,r,r", packed_element = 1 : i32, pure = true} %outLHS, %outRHS : tensor<128x256xf32, #ttg.slice<{dim = 2, parent = #packed}>>, tensor<128x256xf32, #ttg.slice<{dim = 2, parent = #packed}>> -> tensor<128x256xi64, #ttg.slice<{dim = 2, parent = #packed}>>
     %3 = ttg.convert_layout %2 : tensor<128x256xi64, #ttg.slice<{dim = 2, parent = #packed}>> -> tensor<128x256xi64, #target>
     tt.return %3 : tensor<128x256xi64, #target>
+  }
+
+  tt.func @nested_convert_multi_use(%arg0: tensor<128x512xf32, #src>) -> (tensor<128x256xi64, #target>, tensor<128x256xi64, #target>, tensor<128x256xi64, #ttg.slice<{dim = 2, parent = #packed}>>) {
+    %0 = ttg.convert_layout %arg0 : tensor<128x512xf32, #src> -> tensor<128x512xf32, #blocked>
+    %1 = tt.reshape %0 : tensor<128x512xf32, #blocked> -> tensor<128x256x2xf32, #packed>
+    %outLHS, %outRHS = tt.split %1 : tensor<128x256x2xf32, #packed> -> tensor<128x256xf32, #ttg.slice<{dim = 2, parent = #packed}>>
+    %2 = tt.elementwise_inline_asm "mov.b64 $0, { $1, $2 };" {constraints = "=l,r,r", packed_element = 1 : i32, pure = true} %outLHS, %outRHS : tensor<128x256xf32, #ttg.slice<{dim = 2, parent = #packed}>>, tensor<128x256xf32, #ttg.slice<{dim = 2, parent = #packed}>> -> tensor<128x256xi64, #ttg.slice<{dim = 2, parent = #packed}>>
+    %3 = ttg.convert_layout %2 : tensor<128x256xi64, #ttg.slice<{dim = 2, parent = #packed}>> -> tensor<128x256xi64, #target>
+    %4 = ttg.convert_layout %2 : tensor<128x256xi64, #ttg.slice<{dim = 2, parent = #packed}>> -> tensor<128x256xi64, #target>
+    tt.return %3, %4, %2 : tensor<128x256xi64, #target>, tensor<128x256xi64, #target>, tensor<128x256xi64, #ttg.slice<{dim = 2, parent = #packed}>>
   }
 }

--- a/test/TritonGPU/remove-layout-conversions-disable-remat.mlir
+++ b/test/TritonGPU/remove-layout-conversions-disable-remat.mlir
@@ -2,12 +2,19 @@
 // RUN: triton-opt %s -tritongpu-remove-layout-conversions='disable-remat=true' | FileCheck %s --check-prefix=DISABLED
 
 // DEFAULT-LABEL: @nested_convert
-// DEFAULT-COUNT-1: ttg.convert_layout
-// DEFAULT-NOT: ttg.convert_layout
+// DEFAULT: %[[RESHAPE:.+]] = tt.reshape
+// DEFAULT-NEXT: %[[CONVERT:.+]] = ttg.convert_layout %[[RESHAPE]]
+// DEFAULT-NEXT: %[[LHS:.+]], %[[RHS:.+]] = tt.split %[[CONVERT]]
+// DEFAULT-NEXT: %[[ASM:.+]] = tt.elementwise_inline_asm {{.*}} %[[LHS]], %[[RHS]]
+// DEFAULT-NEXT: tt.return %[[ASM]]
 
 // DISABLED-LABEL: @nested_convert
-// DISABLED-COUNT-1: ttg.convert_layout
-// DISABLED-NOT: ttg.convert_layout
+// DISABLED: %[[RESHAPE:.+]] = tt.reshape
+// DISABLED-NEXT: %[[INPUT_CONVERT:.+]] = ttg.convert_layout %[[RESHAPE]]
+// DISABLED-NEXT: %[[LHS:.+]], %[[RHS:.+]] = tt.split %[[INPUT_CONVERT]]
+// DISABLED-NEXT: %[[ASM:.+]] = tt.elementwise_inline_asm {{.*}} %[[LHS]], %[[RHS]]
+// DISABLED-NEXT: %[[OUTPUT_CONVERT:.+]] = ttg.convert_layout %[[ASM]]
+// DISABLED-NEXT: tt.return %[[OUTPUT_CONVERT]]
 
 #blocked = #ttg.blocked<{sizePerThread = [1, 4], threadsPerWarp = [1, 32], warpsPerCTA = [4, 2], order = [1, 0], CGALayout = [[0, 1]]}>
 #src = #ttg.linear<{register = [[1, 0], [2, 0], [4, 0], [8, 0], [16, 0], [32, 0], [64, 0]], lane = [[0, 1], [0, 2], [0, 4], [0, 8], [0, 16]], warp = [[0, 32], [0, 64], [0, 128]], block = [[0, 256]]}>

--- a/third_party/nvidia/backend/compiler.py
+++ b/third_party/nvidia/backend/compiler.py
@@ -330,7 +330,7 @@ class CUDABackend(BaseBackend):
         passes.common.add_canonicalizer(pm)
         if "fpsan" in opt.instrumentation_mode:
             passes.ttgpuir.add_fp_sanitizer(pm)
-            passes.ttgpuir.add_remove_layout_conversions(pm)
+            passes.ttgpuir.add_remove_layout_conversions(pm, True)
             passes.common.add_canonicalizer(pm)
             passes.common.add_cse(pm)
 
@@ -356,7 +356,7 @@ class CUDABackend(BaseBackend):
         if "fpsan" in options.instrumentation_mode:
             passes.ttgpuir.add_fp_sanitizer(pm)
         if any(mode in options.instrumentation_mode for mode in ["consan", "fpsan"]):
-            passes.ttgpuir.add_remove_layout_conversions(pm)
+            passes.ttgpuir.add_remove_layout_conversions(pm, True)
             passes.common.add_canonicalizer(pm)
             passes.common.add_cse(pm)
 


### PR DESCRIPTION
PR description written by Codex

Keep backward rematerialization enabled for FPSan and ConSan cleanup while preventing it from splitting a slice that has surviving values. Single-use rewrites and reuse of dominating rematerializations remain enabled; convert hoisting stays disabled in this mode.

Rename the pass option to `disable-remat-splitting` and recognize `__nv_expf` as the known FPSan exponential transform. Tests cover single-use and multi-use layout paths, rematerialization reuse, and libdevice exp payload equivalence.
