### PR TITLE
[NVIDIA] Enable batched TMA GEMM tests on sm120

### DIFF
--- a/python/test/unit/language/test_tensor_descriptor.py
+++ b/python/test/unit/language/test_tensor_descriptor.py
@@ -815,8 +815,8 @@ def batched_gemm_2d_tma_kernel(a_ptr, b_ptr, c_ptr,  #
 def test_tensor_descriptor_batched_gemm_2d_tma(device):
     BLOCK_M, BLOCK_N, BLOCK_K = 128, 256, 64
 
-    if is_hip():
-        # Insufficient share memory for the larger block size
+    if is_hip() or is_sm12x():
+        # Insufficient shared memory for the larger block size on HIP and sm120
         BLOCK_M, BLOCK_N, BLOCK_K = 128, 128, 64
 
     if is_interpreter():
@@ -836,7 +836,9 @@ def test_tensor_descriptor_batched_gemm_2d_tma(device):
 
     def alloc_fn(size: int, align: int, stream: Optional[int]):
         # TODO: should only need num_stages * 3 descriptors per SM
-        assert size == 128 * 3 * (num_stages + 1) * grid[0]
+        # sm12x has no async dot, so its pipeline is one stage shorter -> one fewer buffer.
+        num_desc_buffers = num_stages if is_sm12x() else num_stages + 1
+        assert size == 128 * 3 * num_desc_buffers * grid[0]
         assert align == 128
         assert stream == 0
         return torch.empty(size, dtype=torch.int8, device=device)
@@ -919,8 +921,8 @@ def batched_gemm_3d_tma_kernel(a_ptr, b_ptr, c_ptr,  #
 def test_tensor_descriptor_batched_gemm_3d_tma(device):
     BLOCK_M, BLOCK_N, BLOCK_K = 128, 256, 64
 
-    if is_hip():
-        # Insufficient share memory for the larger block size
+    if is_hip() or is_sm12x():
+        # Insufficient shared memory for the larger block size on HIP and sm120
         BLOCK_M, BLOCK_N, BLOCK_K = 64, 64, 64
 
     if is_interpreter():


### PR DESCRIPTION
test_tensor_descriptor_batched_gemm_{2d,3d}_tma failed on sm120 (consumer Blackwell, e.g. RTX 5090) with OutOfResources: the default 128x256x64 block needs ~163KB of shared memory, exceeding the ~99KB available. Reduce the block on sm120 to the 64x64x64 (3d) / 128x128x64 (2d) values already used for HIP -- no new constants -- gated by is_sm12x() so cc9/cc10 datacenter behavior is unchanged.


Tested on an RTX 5090 (cc 12.0): both tests pass end-to-end, including the torch.bmm numerics check, exercising the real TMA + mma.sync path.

<!---
The core Triton is a small number of people, and we receive many PRs (thank
you!).  To help us review your code more quickly, **if you are a new
contributor (less than 3 PRs merged) we ask that you complete the following
tasks and include the filled-out checklist in your PR description.**

Complete the following tasks before sending your PR, and replace `[ ]` with
`[x]` to indicate you have done them.
-->

# New contributor declaration
- [ ] I am not making a trivial change, such as fixing a typo in a comment.

- [x] I have written a PR description following these
  [rules](https://cbea.ms/git-commit/#why-not-how).

- [x] I have run `pre-commit run --from-ref origin/main --to-ref HEAD`.

- Select one of the following.
  - [x] I have added tests.
    - `/test` for `lit` tests
    - `/unittest` for C++ tests
    - `/python/test` for end-to-end tests
  - [ ] This PR does not need a test because `FILL THIS IN`.

- Select one of the following.
  - [x] I have not added any `lit` tests.
  - [ ] The `lit` tests I have added follow these [best practices](https://mlir.llvm.org/getting_started/TestingGuide/#filecheck-best-practices),
    including the "tests should be minimal" section. (Usually running Python code
    and using the instructions it generates is not minimal.)
