### PR TITLE
[AMD] Warp-pipeline: keep each stage's memory ops in program order

### DIFF
--- a/test/TritonGPU/amd/amd-convert-warp-pipeline.mlir
+++ b/test/TritonGPU/amd/amd-convert-warp-pipeline.mlir
@@ -770,20 +770,21 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 8 : i32, ttg.targ
 // CHECK: tt.store
 //
 // Between stage 0 and 1: existing async_wait wrapped, no s_barrier.
-// The first barrier follows stage 0's memory op; the cluster barrier is next.
-// CHECK: rocdl.sched.barrier
-// CHECK-NEXT: rocdl.sched.barrier
+// The per-mem-op barrier (non_mem_non_sideeffect) follows stage 0's store; the
+// cluster barrier (none) is next.
+// CHECK: rocdl.sched.barrier non_mem_non_sideeffect
+// CHECK-NEXT: rocdl.sched.barrier none
 // CHECK-NEXT: amdg.async_wait
-// CHECK-NEXT: rocdl.sched.barrier
+// CHECK-NEXT: rocdl.sched.barrier none
 // CHECK-NOT: rocdl.s.barrier
 // Stage 1 ops.
 // CHECK: tt.store
 //
 // Between stage 1 and 2: no pre-existing barrier, so s_barrier inserted.
-// CHECK: rocdl.sched.barrier
-// CHECK-NEXT: rocdl.sched.barrier
+// CHECK: rocdl.sched.barrier non_mem_non_sideeffect
+// CHECK-NEXT: rocdl.sched.barrier none
 // CHECK-NEXT: rocdl.s.barrier
-// CHECK-NEXT: rocdl.sched.barrier
+// CHECK-NEXT: rocdl.sched.barrier none
 // Stage 2 ops.
 // CHECK: tt.store
 //
@@ -1075,29 +1076,30 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 8 : i32, ttg.targ
 // CHECK: ttg.local_store
 //
 // Barrier between stage0→stage1 is LOCAL (adjacent RAW: write→read).
-// The first barrier follows stage 0's memory op; the cluster barrier is next.
-// CHECK: rocdl.sched.barrier
-// CHECK-NEXT: rocdl.sched.barrier
+// The per-mem-op barrier (non_mem_non_sideeffect) follows stage 0's store; the
+// cluster barrier (none) is next.
+// CHECK: rocdl.sched.barrier non_mem_non_sideeffect
+// CHECK-NEXT: rocdl.sched.barrier none
 // CHECK-NEXT: ttg.barrier local
-// CHECK-NEXT: rocdl.sched.barrier
+// CHECK-NEXT: rocdl.sched.barrier none
 //
 // Stage 1 ops (local_load).
 // CHECK: ttg.local_load
 //
 // Barrier between stage1→stage2 is LOCAL (distance-2 WAR: a1 reads, a0 writes).
-// CHECK: rocdl.sched.barrier
-// CHECK-NEXT: rocdl.sched.barrier
+// CHECK: rocdl.sched.barrier non_mem_non_sideeffect
+// CHECK-NEXT: rocdl.sched.barrier none
 // CHECK-NEXT: ttg.barrier local
-// CHECK-NEXT: rocdl.sched.barrier
+// CHECK-NEXT: rocdl.sched.barrier none
 //
 // Stage 2 ops (global store).
 // CHECK: tt.store
 //
 // Wrap-around barrier is s_barrier only (a2 has no LDS, a0 writes — no dep).
-// CHECK: rocdl.sched.barrier
-// CHECK-NEXT: rocdl.sched.barrier
+// CHECK: rocdl.sched.barrier non_mem_non_sideeffect
+// CHECK-NEXT: rocdl.sched.barrier none
 // CHECK-NEXT: rocdl.s.barrier
-// CHECK-NEXT: rocdl.sched.barrier
+// CHECK-NEXT: rocdl.sched.barrier none
 //
 // CHECK: scf.yield
 
@@ -1375,15 +1377,18 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 8 : i32, ttg.targ
 // CHECK: scf.if
 // CHECK:   ttg.local_store
 // Cluster barrier between stage 0 and stage 1 is LOCAL (nested write seen).
-// CHECK: rocdl.sched.barrier
+// Stage 0's mem ops are nested in the scf.if (not top-level), so there is no
+// per-mem-op barrier here — just the cluster barrier (none).
+// CHECK: rocdl.sched.barrier none
 // CHECK-NEXT: ttg.barrier local
-// CHECK-NEXT: rocdl.sched.barrier
+// CHECK-NEXT: rocdl.sched.barrier none
 // Stage 1 reads LDS.
 // CHECK: ttg.local_load
 // Wrap-around barrier is also LOCAL (stage1 read vs stage0 write next iter).
-// The first barrier follows stage 1's memory op; the cluster barrier is next.
-// CHECK: rocdl.sched.barrier
-// CHECK-NEXT: rocdl.sched.barrier
+// The per-mem-op barrier (non_mem_non_sideeffect) follows stage 1's load; the
+// cluster barrier (none) is next.
+// CHECK: rocdl.sched.barrier non_mem_non_sideeffect
+// CHECK-NEXT: rocdl.sched.barrier none
 // CHECK-NEXT: ttg.barrier local
-// CHECK-NEXT: rocdl.sched.barrier
+// CHECK-NEXT: rocdl.sched.barrier none
 // CHECK: scf.yield

--- a/test/TritonGPU/amd/amd-convert-warp-pipeline.mlir
+++ b/test/TritonGPU/amd/amd-convert-warp-pipeline.mlir
@@ -770,7 +770,9 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 8 : i32, ttg.targ
 // CHECK: tt.store
 //
 // Between stage 0 and 1: existing async_wait wrapped, no s_barrier.
+// The first barrier follows stage 0's memory op; the cluster barrier is next.
 // CHECK: rocdl.sched.barrier
+// CHECK-NEXT: rocdl.sched.barrier
 // CHECK-NEXT: amdg.async_wait
 // CHECK-NEXT: rocdl.sched.barrier
 // CHECK-NOT: rocdl.s.barrier
@@ -779,6 +781,7 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 8 : i32, ttg.targ
 //
 // Between stage 1 and 2: no pre-existing barrier, so s_barrier inserted.
 // CHECK: rocdl.sched.barrier
+// CHECK-NEXT: rocdl.sched.barrier
 // CHECK-NEXT: rocdl.s.barrier
 // CHECK-NEXT: rocdl.sched.barrier
 // Stage 2 ops.
@@ -1072,7 +1075,9 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 8 : i32, ttg.targ
 // CHECK: ttg.local_store
 //
 // Barrier between stage0→stage1 is LOCAL (adjacent RAW: write→read).
+// The first barrier follows stage 0's memory op; the cluster barrier is next.
 // CHECK: rocdl.sched.barrier
+// CHECK-NEXT: rocdl.sched.barrier
 // CHECK-NEXT: ttg.barrier local
 // CHECK-NEXT: rocdl.sched.barrier
 //
@@ -1081,6 +1086,7 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 8 : i32, ttg.targ
 //
 // Barrier between stage1→stage2 is LOCAL (distance-2 WAR: a1 reads, a0 writes).
 // CHECK: rocdl.sched.barrier
+// CHECK-NEXT: rocdl.sched.barrier
 // CHECK-NEXT: ttg.barrier local
 // CHECK-NEXT: rocdl.sched.barrier
 //
@@ -1089,6 +1095,7 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 8 : i32, ttg.targ
 //
 // Wrap-around barrier is s_barrier only (a2 has no LDS, a0 writes — no dep).
 // CHECK: rocdl.sched.barrier
+// CHECK-NEXT: rocdl.sched.barrier
 // CHECK-NEXT: rocdl.s.barrier
 // CHECK-NEXT: rocdl.sched.barrier
 //
@@ -1374,7 +1381,9 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 8 : i32, ttg.targ
 // Stage 1 reads LDS.
 // CHECK: ttg.local_load
 // Wrap-around barrier is also LOCAL (stage1 read vs stage0 write next iter).
+// The first barrier follows stage 1's memory op; the cluster barrier is next.
 // CHECK: rocdl.sched.barrier
+// CHECK-NEXT: rocdl.sched.barrier
 // CHECK-NEXT: ttg.barrier local
 // CHECK-NEXT: rocdl.sched.barrier
 // CHECK: scf.yield

--- a/third_party/amd/lib/TritonAMDGPUToLLVM/ConvertWarpPipeline.cpp
+++ b/third_party/amd/lib/TritonAMDGPUToLLVM/ConvertWarpPipeline.cpp
@@ -480,17 +480,12 @@ public:
 
     // Emit a scheduling barrier after every memory op in the stage so the
     // backend scheduler keeps them in program order.
-    {
-      SmallVector<Operation *> memOps;
-      for (Operation &op : *block)
-        if (readsOrWritesMemory(&op))
-          memOps.push_back(&op);
-      for (Operation *op : memOps) {
-        rewriter.setInsertionPointAfter(op);
-        ROCDL::SchedBarrier::create(rewriter, op->getLoc(),
+    for (Operation &op : *block)
+      if (readsOrWritesMemory(&op)) {
+        rewriter.setInsertionPointAfter(&op);
+        ROCDL::SchedBarrier::create(rewriter, op.getLoc(),
                                     ROCDL::SchedGroupMask::non_mem_non_sideeffect);
       }
-    }
 
     Operation *terminator = block->getTerminator();
     ValueRange results = terminator->getOperands();

--- a/third_party/amd/lib/TritonAMDGPUToLLVM/ConvertWarpPipeline.cpp
+++ b/third_party/amd/lib/TritonAMDGPUToLLVM/ConvertWarpPipeline.cpp
@@ -96,14 +96,8 @@ static bool isWarpPipelineIgnorableBarrier(Operation *op) {
 // True if `op` reads or writes memory (a load / store / async-copy).
 static bool readsOrWritesMemory(Operation *op) {
   auto mei = dyn_cast<MemoryEffectOpInterface>(op);
-  if (!mei)
-    return false;
-  SmallVector<SideEffects::EffectInstance<MemoryEffects::Effect>> effs;
-  mei.getEffects(effs);
-  for (auto &eff : effs)
-    if (isa<MemoryEffects::Read, MemoryEffects::Write>(eff.getEffect()))
-      return true;
-  return false;
+  return mei && (mei.hasEffect<MemoryEffects::Read>() ||
+                 mei.hasEffect<MemoryEffects::Write>());
 }
 
 // True if `exec` is a stage created by the warp-pipeline frontend.
@@ -494,7 +488,7 @@ public:
       for (Operation *op : memOps) {
         rewriter.setInsertionPointAfter(op);
         ROCDL::SchedBarrier::create(rewriter, op->getLoc(),
-                                    ROCDL::SchedGroupMask::none);
+                                    ROCDL::SchedGroupMask::non_mem_non_sideeffect);
       }
     }
 

--- a/third_party/amd/lib/TritonAMDGPUToLLVM/ConvertWarpPipeline.cpp
+++ b/third_party/amd/lib/TritonAMDGPUToLLVM/ConvertWarpPipeline.cpp
@@ -93,6 +93,19 @@ static bool isWarpPipelineIgnorableBarrier(Operation *op) {
              triton::amdgpu::AsyncTDMIntrinsicWait>(op);
 }
 
+// True if `op` reads or writes memory (a load / store / async-copy).
+static bool readsOrWritesMemory(Operation *op) {
+  auto mei = dyn_cast<MemoryEffectOpInterface>(op);
+  if (!mei)
+    return false;
+  SmallVector<SideEffects::EffectInstance<MemoryEffects::Effect>> effs;
+  mei.getEffects(effs);
+  for (auto &eff : effs)
+    if (isa<MemoryEffects::Read, MemoryEffects::Write>(eff.getEffect()))
+      return true;
+  return false;
+}
+
 // True if `exec` is a stage created by the warp-pipeline frontend.
 static bool isPipelineStage(scf::ExecuteRegionOp exec) {
   return exec && exec->hasAttr("triton.warp_pipeline.stage");
@@ -470,6 +483,21 @@ public:
 
     // Inline region.
     Block *block = &reg.front();
+
+    // Emit a scheduling barrier after every memory op in the stage so the
+    // backend scheduler keeps them in program order.
+    {
+      SmallVector<Operation *> memOps;
+      for (Operation &op : *block)
+        if (readsOrWritesMemory(&op))
+          memOps.push_back(&op);
+      for (Operation *op : memOps) {
+        rewriter.setInsertionPointAfter(op);
+        ROCDL::SchedBarrier::create(rewriter, op->getLoc(),
+                                    ROCDL::SchedGroupMask::none);
+      }
+    }
+
     Operation *terminator = block->getTerminator();
     ValueRange results = terminator->getOperands();
     rewriter.inlineBlockBefore(block, exec, {});

--- a/third_party/amd/lib/TritonAMDGPUToLLVM/ConvertWarpPipeline.cpp
+++ b/third_party/amd/lib/TritonAMDGPUToLLVM/ConvertWarpPipeline.cpp
@@ -483,8 +483,9 @@ public:
     for (Operation &op : *block)
       if (readsOrWritesMemory(&op)) {
         rewriter.setInsertionPointAfter(&op);
-        ROCDL::SchedBarrier::create(rewriter, op.getLoc(),
-                                    ROCDL::SchedGroupMask::non_mem_non_sideeffect);
+        ROCDL::SchedBarrier::create(
+            rewriter, op.getLoc(),
+            ROCDL::SchedGroupMask::non_mem_non_sideeffect);
       }
 
     Operation *terminator = block->getTerminator();

--- a/third_party/amd/lib/TritonAMDGPUToLLVM/ConvertWarpPipeline.cpp
+++ b/third_party/amd/lib/TritonAMDGPUToLLVM/ConvertWarpPipeline.cpp
@@ -480,7 +480,7 @@ public:
 
     // Emit a scheduling barrier after every memory op in the stage so the
     // backend scheduler keeps them in program order.
-    for (Operation &op : *block)
+    for (Operation &op : llvm::make_early_inc_range(*block))
       if (readsOrWritesMemory(&op)) {
         rewriter.setInsertionPointAfter(&op);
         ROCDL::SchedBarrier::create(


### PR DESCRIPTION
When lowering a warp-pipeline stage (`ConvertWarpPipeline`), emit a scheduling barrier (`sched.barrier`) after every top-level memory op in the stage, so the backend scheduler keeps the stage's memory ops in program order. 

## Motivation

In a warp-pipelined GEMM, a stage's `local_load`s (`ds_read`) feed an imminent MFMA, while the same stage also issues the next tile's global→LDS prefetch. The backend scheduler is free to reorder that memory traffic — e.g. hoist the global→LDS copies ahead of the LDS reads the MFMA depends on — which delays those reads. On gfx950 MXFP4 GEMMs this shows up as `ds_read` stalls in the ATT trace.

## Change

In `InlineWarpPipelineExecuteRegionPattern`, after each op in a stage that reads or writes memory (detected via `MemoryEffectOpInterface`), insert a `sched.barrier` with `SchedGroupMask::non_mem_non_sideeffect`. That mask blocks memory ops from being scheduled across the barrier — so the prefetch can't hoist ahead of the `ds_read` a following MFMA depends on — while still letting compute (MFMA/ALU) schedule freely. It is a scheduling constraint only, not a memory fence, and applies to every stage unconditionally.

## Test

`test/TritonGPU/amd/amd-convert-warp-pipeline.mlir` checks that a `sched.barrier` with the expected mask (`non_mem_non_sideeffect` for the per-mem-op barriers, `none` for the cluster barriers) follows each stage's top-level memory ops.
