### PR TITLE
Fix FP8 block-pointer zero padding: use float zero for float element types

### DIFF
--- a/python/triton/language/core.py
+++ b/python/triton/language/core.py
@@ -1924,7 +1924,10 @@ class _block_ptr:
         if padding_option == "":
             generated_other = None
         elif padding_option == "zero":
-            generated_other = 0
+            # Use a float zero for floating-point pointees: `other` is cast to the
+            # element type, and there is no int -> fp8 cast, so an int zero breaks
+            # padded loads of fp8 block pointers (see #10751).
+            generated_other = 0 if self.base.dtype.element_ty.is_int() else 0.0
         elif padding_option == "nan":
             if self.base.dtype.element_ty.is_int():
                 raise ValueError("Padding option `nan` is not supported for integer block pointers")


### PR DESCRIPTION
Fixes #10751.

Padding with int(0) produces int32 which has no conversion path to FP8 types. Use 0.0 for floating-point element types so the cast goes through the float-to-fp8 path.