### PR TITLE
[NVIDIA] Use cluster proxy fence for multi-CTA CLC

### DIFF
--- a/lib/Dialect/TritonNvidiaGPU/Transforms/ProxyFenceInsertion.cpp
+++ b/lib/Dialect/TritonNvidiaGPU/Transforms/ProxyFenceInsertion.cpp
@@ -86,9 +86,20 @@ bool filterFn(Operation *op, Operation *other, bool /*opIsRead*/,
   return ignoreOpForProxyFence(other);
 }
 
+enum class ProxyFenceScope { CTA, Cluster };
+
+ProxyFenceScope getProxyFenceScope(Operation *op) {
+  // Multi-CTA CLC multicasts its result to every CTA in the cluster.
+  if (isa<triton::nvidia_gpu::CLCTryCancelOp>(op) &&
+      triton::gpu::lookupNumCTAs(op) > 1)
+    return ProxyFenceScope::Cluster;
+  return ProxyFenceScope::CTA;
+}
+
 //===----------------------------------------------------------------------===//
 // Proxy Fence Analysis
 //===----------------------------------------------------------------------===//
+template <ProxyFenceScope scope>
 class ProxyFenceAnalysis : public MembarOrFenceAnalysis {
 
 public:
@@ -104,25 +115,28 @@ private:
   void insertFence(Operation *operation, OpBuilder *builder);
 };
 
-void ProxyFenceAnalysis::insertFence(Operation *op, OpBuilder *builder) {
+template <ProxyFenceScope scope>
+void ProxyFenceAnalysis<scope>::insertFence(Operation *op, OpBuilder *builder) {
   OpBuilder::InsertionGuard g(*builder);
-  // Multi-CTA CLC multicasts its result to every CTA in the cluster.
-  bool cluster = isa<triton::nvidia_gpu::CLCTryCancelOp>(op) &&
-                 triton::gpu::lookupNumCTAs(op) > 1;
-  triton::nvidia_gpu::FenceAsyncSharedOp::create(*builder, op->getLoc(),
-                                                 cluster);
+  triton::nvidia_gpu::FenceAsyncSharedOp::create(
+      *builder, op->getLoc(), scope == ProxyFenceScope::Cluster);
 }
 
-void ProxyFenceAnalysis::update(Operation *op, BlockInfo *blockInfo,
-                                FuncBlockInfoMapT *funcBlockInfoMap,
-                                OpBuilder *builder) {
-  if (isa<triton::nvidia_gpu::FenceAsyncSharedOp>(op)) {
-    // If the current op is a fence, we clear previous reads and writes
-    blockInfo->sync();
+template <ProxyFenceScope scope>
+void ProxyFenceAnalysis<scope>::update(Operation *op, BlockInfo *blockInfo,
+                                       FuncBlockInfoMapT *funcBlockInfoMap,
+                                       OpBuilder *builder) {
+  if (auto fence = dyn_cast<triton::nvidia_gpu::FenceAsyncSharedOp>(op)) {
+    // A cluster fence covers both frontiers, while a CTA fence only covers the
+    // CTA frontier.
+    if (scope == ProxyFenceScope::CTA || fence.getBCluster())
+      blockInfo->sync();
     return;
   }
   BlockInfo curBlockInfo;
   BlockInfo proxyBlockInfo;
+  bool isProxyOp = (isAsyncProxyWrite(op) || isAsyncProxyRead(op)) &&
+                   getProxyFenceScope(op) == scope;
 
   auto scratchBufferId = Allocation::InvalidBufferId;
   if (isa<triton::CallOp>(op)) {
@@ -146,12 +160,14 @@ void ProxyFenceAnalysis::update(Operation *op, BlockInfo *blockInfo,
               auto slice = AllocationSlice(value, interval, bufferId);
 
               if (isAsyncProxyWrite(op) && value == getSmemDest(op)) {
-                proxyBlockInfo.syncWriteSlices[slice].insert(op);
+                if (isProxyOp)
+                  proxyBlockInfo.syncWriteSlices[slice].insert(op);
               } else if (isAsyncProxyRead(op) &&
                          isAsyncProxyReadSource(op, value)) {
                 // Safe fallback for async-proxy reads from shared memory when
                 // the earlier FenceInsertionPass did not place a fence.
-                proxyBlockInfo.syncReadSlices[slice].insert(op);
+                if (isProxyOp)
+                  proxyBlockInfo.syncReadSlices[slice].insert(op);
               } else if (isa<MemoryEffects::Write>(
                              effectInstance.getEffect())) {
                 curBlockInfo.syncWriteSlices[slice].insert(op);
@@ -174,7 +190,7 @@ void ProxyFenceAnalysis::update(Operation *op, BlockInfo *blockInfo,
     auto scratchSlice = AllocationSlice(interval);
     curBlockInfo.syncReadSlices[scratchSlice].insert(op);
   }
-  if (isAsyncProxyWrite(op) || isAsyncProxyRead(op)) {
+  if (isProxyOp) {
     if (proxyBlockInfo.isIntersected(*blockInfo, filter, allocation)) {
       builder->setInsertionPoint(op);
       insertFence(op, builder);
@@ -202,9 +218,15 @@ public:
     // This pass does not depend on the amount of shared memory allocated
     // so we can use the default allocation analysis scratch size function
     ModuleAllocation allocation(mod);
-    ModuleMembarOrFenceAnalysis<ProxyFenceAnalysis> analysis(&allocation,
-                                                             filterFn);
-    analysis.run();
+    // Keep independent frontiers for cluster- and CTA-scoped fences. Run the
+    // cluster analysis first so the CTA analysis can observe any cluster
+    // fences it inserts.
+    ModuleMembarOrFenceAnalysis<ProxyFenceAnalysis<ProxyFenceScope::Cluster>>
+        clusterAnalysis(&allocation, filterFn);
+    clusterAnalysis.run();
+    ModuleMembarOrFenceAnalysis<ProxyFenceAnalysis<ProxyFenceScope::CTA>>
+        ctaAnalysis(&allocation, filterFn);
+    ctaAnalysis.run();
   }
 };
 

--- a/lib/Dialect/TritonNvidiaGPU/Transforms/ProxyFenceInsertion.cpp
+++ b/lib/Dialect/TritonNvidiaGPU/Transforms/ProxyFenceInsertion.cpp
@@ -106,7 +106,11 @@ private:
 
 void ProxyFenceAnalysis::insertFence(Operation *op, OpBuilder *builder) {
   OpBuilder::InsertionGuard g(*builder);
-  triton::nvidia_gpu::FenceAsyncSharedOp::create(*builder, op->getLoc(), false);
+  // Multi-CTA CLC multicasts its result to every CTA in the cluster.
+  bool cluster = isa<triton::nvidia_gpu::CLCTryCancelOp>(op) &&
+                 triton::gpu::lookupNumCTAs(op) > 1;
+  triton::nvidia_gpu::FenceAsyncSharedOp::create(*builder, op->getLoc(),
+                                                 cluster);
 }
 
 void ProxyFenceAnalysis::update(Operation *op, BlockInfo *blockInfo,

--- a/lib/Dialect/TritonNvidiaGPU/Transforms/ProxyFenceInsertion.cpp
+++ b/lib/Dialect/TritonNvidiaGPU/Transforms/ProxyFenceInsertion.cpp
@@ -89,7 +89,19 @@ bool filterFn(Operation *op, Operation *other, bool /*opIsRead*/,
 enum class ProxyFenceScope { CTA, Cluster };
 
 ProxyFenceScope getProxyFenceScope(Operation *op) {
-  // Multi-CTA CLC multicasts its result to every CTA in the cluster.
+  // Multicast TMA and two-CTA tensor-core operations access peer-CTA shared
+  // memory. Multi-CTA CLC multicasts its result to every CTA in the cluster.
+  if (auto tma = dyn_cast<triton::nvidia_gpu::TMALoadLikeOpInterface>(op)) {
+    if (tma.getMulticast())
+      return ProxyFenceScope::Cluster;
+  }
+  if (auto mma = dyn_cast<triton::nvidia_gpu::MMAv5OpInterface>(op)) {
+    if (mma.getTwoCtas())
+      return ProxyFenceScope::Cluster;
+  }
+  if (isa<triton::nvidia_gpu::TMEMCopyOp>(op) &&
+      triton::nvidia_gpu::getModuleTwoCTAs(op))
+    return ProxyFenceScope::Cluster;
   if (isa<triton::nvidia_gpu::CLCTryCancelOp>(op) &&
       triton::gpu::lookupNumCTAs(op) > 1)
     return ProxyFenceScope::Cluster;
@@ -221,9 +233,18 @@ public:
     // Keep independent frontiers for cluster- and CTA-scoped fences. Run the
     // cluster analysis first so the CTA analysis can observe any cluster
     // fences it inserts.
-    ModuleMembarOrFenceAnalysis<ProxyFenceAnalysis<ProxyFenceScope::Cluster>>
-        clusterAnalysis(&allocation, filterFn);
-    clusterAnalysis.run();
+    bool hasClusterProxyOp =
+        mod.walk([](Operation *op) {
+             return getProxyFenceScope(op) == ProxyFenceScope::Cluster
+                        ? WalkResult::interrupt()
+                        : WalkResult::advance();
+           })
+            .wasInterrupted();
+    if (hasClusterProxyOp) {
+      ModuleMembarOrFenceAnalysis<ProxyFenceAnalysis<ProxyFenceScope::Cluster>>
+          clusterAnalysis(&allocation, filterFn);
+      clusterAnalysis.run();
+    }
     ModuleMembarOrFenceAnalysis<ProxyFenceAnalysis<ProxyFenceScope::CTA>>
         ctaAnalysis(&allocation, filterFn);
     ctaAnalysis.run();

--- a/python/test/gluon/test_consan.py
+++ b/python/test/gluon/test_consan.py
@@ -465,7 +465,6 @@ def test_clc_result_reuse_after_cluster_barrier(device, run_wrapper, monkeypatch
         mbarrier.wait(clc_bar, 0)
         first = clc.load_result(clc_result)
         ttgl.barrier(cluster=True)
-        hopper.fence_async_shared(cluster=True)
 
         mbarrier.expect(clc_bar, 16)
         clc.try_cancel(clc_result, clc_bar)

--- a/python/test/gluon/test_consan.py
+++ b/python/test/gluon/test_consan.py
@@ -465,6 +465,9 @@ def test_clc_result_reuse_after_cluster_barrier(device, run_wrapper, monkeypatch
         mbarrier.wait(clc_bar, 0)
         first = clc.load_result(clc_result)
         ttgl.barrier(cluster=True)
+        # A CTA fence must not hide the need for a cluster fence before the
+        # next multi-CTA CLC request.
+        hopper.fence_async_shared()
 
         mbarrier.expect(clc_bar, 16)
         clc.try_cancel(clc_result, clc_bar)

--- a/python/test/gluon/test_consan.py
+++ b/python/test/gluon/test_consan.py
@@ -501,13 +501,16 @@ def test_async_tma_multicast_kernel_reuse(device, run_wrapper, monkeypatch, num_
         smem = ttgl.allocate_shared_memory(ttgl.float16, [XBLOCK, XBLOCK], input_desc.layout)
         bar = mbarrier.allocate_mbarrier()
         mbarrier.init(bar, count=1)
+        val = ttgl.full([XBLOCK, XBLOCK], 0, ttgl.float16, blocked_layout)
         for phase in ttgl.static_range(2):
             mbarrier.expect(bar, input_desc.nbytes_per_cta)
             ttgl.barrier(cluster=True)
+            # A CTA fence after the cluster handoff cannot cover peer-CTA reads.
+            hopper.fence_async_shared()
             tma.async_load(input_desc, [0, 0], bar, smem, multicast=True)
             mbarrier.wait(bar, phase % 2, deps=[smem])
+            val += smem.load(blocked_layout)
             ttgl.barrier(cluster=True)
-        val = smem.load(blocked_layout)
         mbarrier.invalidate(bar)
 
         out_m = ttgl.arange(0, XBLOCK, ttgl.SliceLayout(1, blocked_layout))[:, None]

--- a/test/TritonGPU/proxy_fence_insertion.mlir
+++ b/test/TritonGPU/proxy_fence_insertion.mlir
@@ -103,7 +103,7 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32} {
   tt.func @missing_proxy_fence_local_store_before_tmem_copy(%arg0: tensor<128x4xi8, #blocked>,
       %arg1: !ttg.memdesc<128x4xi8, #tmem, #ttng.tensor_memory, mutable>) {
     // CHECK: ttg.local_store
-    // CHECK-NEXT: ttng.fence_async_shared
+    // CHECK-NEXT: ttng.fence_async_shared {bCluster = false}
     // CHECK-NEXT: ttng.tmem_copy
     %0 = ttg.local_alloc {allocation.offset = 16 : i32} : () -> !ttg.memdesc<128x4xi8, #shared1, #smem, mutable>
     ttg.local_store %arg0, %0 : tensor<128x4xi8, #blocked> -> !ttg.memdesc<128x4xi8, #shared1, #smem, mutable>
@@ -133,7 +133,7 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32} {
     // CHECK-NEXT: ttg.async_copy_global_to_local
     // CHECK-NEXT: ttg.async_commit_group
     // CHECK-NEXT: ttg.async_wait
-    // CHECK-NEXT: ttng.fence_async_shared
+    // CHECK-NEXT: ttng.fence_async_shared {bCluster = false}
     // CHECK-NEXT: ttng.tc_gen5_mma
     %0 = ttg.local_alloc {allocation.offset = 16 : i32} : () -> !ttg.memdesc<64x32xf8E4M3FN, #mma_a, #smem, mutable>
     %1 = ttg.local_alloc {allocation.offset = 32 : i32} : () -> !ttg.memdesc<32x64xf8E4M3FN, #mma_b, #smem, mutable>
@@ -234,6 +234,146 @@ module attributes {"ttg.num-ctas" = 2 : i32, "ttg.num-warps" = 1 : i32, ttg.targ
     ttng.clc_try_cancel %result, %barrier :
       !ttg.memdesc<2xi64, #shared_clc, #smem, mutable>,
       !ttg.memdesc<1xi64, #barrier, #smem, mutable>
+    tt.return
+  }
+}
+
+// -----
+
+#nvmma = #ttg.nvmma_shared<{swizzlingByteWidth = 128, transposed = false, elementBitWidth = 16, CGALayout = [[0, 0]]}>
+#barrier = #ttg.swizzled_shared<{vec = 1, perPhase = 1, maxPhase = 1, order = [0], CGALayout = [[0]]}>
+#blocked = #ttg.blocked<{sizePerThread = [1, 4], threadsPerWarp = [8, 4], warpsPerCTA = [4, 1], order = [0, 1], CGALayout = [[1, 0]]}>
+#smem = #ttg.shared_memory
+module attributes {"ttg.num-ctas" = 2 : i32, "ttg.num-warps" = 4 : i32, ttg.target = "cuda:90", "ttg.threads-per-warp" = 32 : i32} {
+  // CHECK-LABEL: multicast_tma_after_cluster_barrier_and_cta_fence
+  tt.func @multicast_tma_after_cluster_barrier_and_cta_fence(%desc: !tt.tensordesc<64x128xf16, #nvmma>) {
+    %c0 = arith.constant 0 : i32
+    %true = arith.constant true
+    %result = ttg.local_alloc {allocation.offset = 0 : i32} : () -> !ttg.memdesc<64x128xf16, #nvmma, #smem, mutable>
+    %barrier = ttg.local_alloc {allocation.offset = 16384 : i32} : () -> !ttg.memdesc<2xi64, #barrier, #smem, mutable>
+    %value = ttg.local_load %result : !ttg.memdesc<64x128xf16, #nvmma, #smem, mutable> -> tensor<64x128xf16, #blocked>
+    "test.keep"(%value) : (tensor<64x128xf16, #blocked>) -> ()
+    // CHECK: ttg.local_load
+    // CHECK: ttng.cluster_barrier
+    // CHECK-NEXT: ttng.fence_async_shared {bCluster = false}
+    // CHECK-NEXT: ttng.fence_async_shared {bCluster = true}
+    // CHECK-NEXT: ttng.async_tma_copy_global_to_local
+    ttng.cluster_barrier
+    ttng.fence_async_shared {bCluster = false}
+    ttng.async_tma_copy_global_to_local %desc[%c0, %c0] %result, %barrier, %true {multicast} :
+      !tt.tensordesc<64x128xf16, #nvmma>, !ttg.memdesc<2xi64, #barrier, #smem, mutable> -> !ttg.memdesc<64x128xf16, #nvmma, #smem, mutable>
+    tt.return
+  }
+}
+
+// -----
+
+#nvmma = #ttg.nvmma_shared<{swizzlingByteWidth = 128, transposed = false, elementBitWidth = 16, CGALayout = [[0, 0]]}>
+#barrier = #ttg.swizzled_shared<{vec = 1, perPhase = 1, maxPhase = 1, order = [0], CGALayout = [[0]]}>
+#blocked = #ttg.blocked<{sizePerThread = [1, 4], threadsPerWarp = [8, 4], warpsPerCTA = [4, 1], order = [0, 1], CGALayout = [[1, 0]]}>
+#smem = #ttg.shared_memory
+module attributes {"ttg.num-ctas" = 2 : i32, "ttg.num-warps" = 4 : i32, ttg.target = "cuda:90", "ttg.threads-per-warp" = 32 : i32} {
+  // CHECK-LABEL: non_multicast_tma_after_cluster_barrier_and_cta_fence
+  tt.func @non_multicast_tma_after_cluster_barrier_and_cta_fence(%desc: !tt.tensordesc<64x128xf16, #nvmma>) {
+    %c0 = arith.constant 0 : i32
+    %true = arith.constant true
+    %result = ttg.local_alloc {allocation.offset = 0 : i32} : () -> !ttg.memdesc<64x128xf16, #nvmma, #smem, mutable>
+    %barrier = ttg.local_alloc {allocation.offset = 16384 : i32} : () -> !ttg.memdesc<2xi64, #barrier, #smem, mutable>
+    %value = ttg.local_load %result : !ttg.memdesc<64x128xf16, #nvmma, #smem, mutable> -> tensor<64x128xf16, #blocked>
+    "test.keep"(%value) : (tensor<64x128xf16, #blocked>) -> ()
+    // CHECK: ttg.local_load
+    // CHECK: ttng.cluster_barrier
+    // CHECK-NEXT: ttng.fence_async_shared {bCluster = false}
+    // CHECK-NOT: ttng.fence_async_shared {bCluster = true}
+    // CHECK: ttng.async_tma_copy_global_to_local
+    ttng.cluster_barrier
+    ttng.fence_async_shared {bCluster = false}
+    ttng.async_tma_copy_global_to_local %desc[%c0, %c0] %result, %barrier, %true :
+      !tt.tensordesc<64x128xf16, #nvmma>, !ttg.memdesc<2xi64, #barrier, #smem, mutable> -> !ttg.memdesc<64x128xf16, #nvmma, #smem, mutable>
+    tt.return
+  }
+}
+
+// -----
+
+#shared = #ttg.nvmma_shared<{swizzlingByteWidth = 128, transposed = false, elementBitWidth = 32, CGALayout = [[0, 0]]}>
+#barrier = #ttg.swizzled_shared<{vec = 1, perPhase = 1, maxPhase = 1, order = [0], CGALayout = [[0]]}>
+#blocked = #ttg.blocked<{sizePerThread = [1, 4], threadsPerWarp = [32, 1], warpsPerCTA = [1, 1], order = [1, 0], CGALayout = [[0, 0]]}>
+#offsets = #ttg.slice<{dim = 0, parent = #blocked}>
+#smem = #ttg.shared_memory
+module attributes {"ttg.num-ctas" = 2 : i32, "ttg.num-warps" = 1 : i32, ttg.target = "cuda:100", "ttg.threads-per-warp" = 32 : i32} {
+  // CHECK-LABEL: multicast_tma_gather_after_cluster_barrier_and_cta_fence
+  tt.func @multicast_tma_gather_after_cluster_barrier_and_cta_fence(%desc: !tt.tensordesc<1x32xf32, #shared>) {
+    %c0 = arith.constant 0 : i32
+    %true = arith.constant true
+    %offsets = arith.constant dense<0> : tensor<32xi32, #offsets>
+    %result = ttg.local_alloc {allocation.offset = 0 : i32} : () -> !ttg.memdesc<32x32xf32, #shared, #smem, mutable>
+    %barrier = ttg.local_alloc {allocation.offset = 4096 : i32} : () -> !ttg.memdesc<1xi64, #barrier, #smem, mutable>
+    %value = ttg.local_load %result : !ttg.memdesc<32x32xf32, #shared, #smem, mutable> -> tensor<32x32xf32, #blocked>
+    "test.keep"(%value) : (tensor<32x32xf32, #blocked>) -> ()
+    // CHECK: ttg.local_load
+    // CHECK: ttng.cluster_barrier
+    // CHECK-NEXT: ttng.fence_async_shared {bCluster = false}
+    // CHECK-NEXT: ttng.fence_async_shared {bCluster = true}
+    // CHECK-NEXT: ttng.async_tma_gather
+    ttng.cluster_barrier
+    ttng.fence_async_shared {bCluster = false}
+    ttng.async_tma_gather %desc[%offsets, %c0] %result, %barrier, %true {multicast} :
+      !tt.tensordesc<1x32xf32, #shared>, tensor<32xi32, #offsets>, i32, !ttg.memdesc<1xi64, #barrier, #smem, mutable>, !ttg.memdesc<32x32xf32, #shared, #smem, mutable>, i1
+    tt.return
+  }
+}
+
+// -----
+
+#sharedA = #ttg.nvmma_shared<{swizzlingByteWidth = 64, transposed = false, elementBitWidth = 16, CGALayout = [[1, 0]]}>
+#sharedB = #ttg.nvmma_shared<{swizzlingByteWidth = 64, transposed = false, elementBitWidth = 16, CGALayout = [[0, 1]]}>
+#barrier = #ttg.swizzled_shared<{vec = 1, perPhase = 1, maxPhase = 1, order = [0], CGALayout = [[1]]}>
+#blocked = #ttg.blocked<{sizePerThread = [1, 1], threadsPerWarp = [16, 2], warpsPerCTA = [4, 2], order = [0, 1], CGALayout = [[1, 0]]}>
+#tmem = #ttng.tensor_memory_encoding<blockM = 128, blockN = 128, colStride = 1, CGALayout = [[1, 0]], twoCTAs = true>
+#smem = #ttg.shared_memory
+module attributes {"ttg.num-ctas" = 2 : i32, "ttg.num-warps" = 8 : i32, "ttng.two-ctas" = true, ttg.target = "cuda:100", "ttg.threads-per-warp" = 32 : i32} {
+  // CHECK-LABEL: two_cta_mma_after_cluster_barrier_and_cta_fence
+  tt.func @two_cta_mma_after_cluster_barrier_and_cta_fence(%value: tensor<256x32xf16, #blocked>) {
+    %true = arith.constant true
+    %a = ttg.local_alloc {allocation.offset = 0 : i32} : () -> !ttg.memdesc<256x32xf16, #sharedA, #smem, mutable>
+    %b = ttg.local_alloc {allocation.offset = 16384 : i32} : () -> !ttg.memdesc<32x128xf16, #sharedB, #smem, mutable>
+    %acc = ttng.tmem_alloc : () -> !ttg.memdesc<256x128xf32, #tmem, #ttng.tensor_memory, mutable>
+    %barrier = ttg.local_alloc {allocation.offset = 24576 : i32} : () -> !ttg.memdesc<2xi64, #barrier, #smem, mutable>
+    ttg.local_store %value, %a : tensor<256x32xf16, #blocked> -> !ttg.memdesc<256x32xf16, #sharedA, #smem, mutable>
+    // CHECK: ttg.local_store
+    // CHECK: ttng.cluster_barrier
+    // CHECK-NEXT: ttng.fence_async_shared {bCluster = false}
+    // CHECK-NEXT: ttng.fence_async_shared {bCluster = true}
+    // CHECK-NEXT: ttng.tc_gen5_mma
+    ttng.cluster_barrier
+    ttng.fence_async_shared {bCluster = false}
+    ttng.tc_gen5_mma %a, %b, %acc, %true, %true, %barrier[%true] {is_async, two_ctas} :
+      !ttg.memdesc<256x32xf16, #sharedA, #smem, mutable>, !ttg.memdesc<32x128xf16, #sharedB, #smem, mutable>, !ttg.memdesc<256x128xf32, #tmem, #ttng.tensor_memory, mutable>, !ttg.memdesc<2xi64, #barrier, #smem, mutable>
+    tt.return
+  }
+}
+
+// -----
+
+#shared = #ttg.nvmma_shared<{swizzlingByteWidth = 128, transposed = false, elementBitWidth = 32, CGALayout = [[0, 0]]}>
+#blocked = #ttg.blocked<{sizePerThread = [1, 4], threadsPerWarp = [8, 4], warpsPerCTA = [4, 1], order = [0, 1], CGALayout = [[1, 0]]}>
+#tmem = #ttng.tensor_memory_encoding<blockM = 128, blockN = 128, colStride = 1, CGALayout = [[0, 0]]>
+#smem = #ttg.shared_memory
+module attributes {"ttg.num-ctas" = 2 : i32, "ttg.num-warps" = 4 : i32, "ttng.two-ctas" = true, ttg.target = "cuda:100", "ttg.threads-per-warp" = 32 : i32} {
+  // CHECK-LABEL: two_cta_tmem_copy_after_cluster_barrier_and_cta_fence
+  tt.func @two_cta_tmem_copy_after_cluster_barrier_and_cta_fence(%value: tensor<128x128xf32, #blocked>) {
+    %src = ttg.local_alloc {allocation.offset = 0 : i32} : () -> !ttg.memdesc<128x128xf32, #shared, #smem, mutable>
+    %dst = ttng.tmem_alloc : () -> !ttg.memdesc<128x128xf32, #tmem, #ttng.tensor_memory, mutable>
+    ttg.local_store %value, %src : tensor<128x128xf32, #blocked> -> !ttg.memdesc<128x128xf32, #shared, #smem, mutable>
+    // CHECK: ttg.local_store
+    // CHECK: ttng.cluster_barrier
+    // CHECK-NEXT: ttng.fence_async_shared {bCluster = false}
+    // CHECK-NEXT: ttng.fence_async_shared {bCluster = true}
+    // CHECK-NEXT: ttng.tmem_copy
+    ttng.cluster_barrier
+    ttng.fence_async_shared {bCluster = false}
+    ttng.tmem_copy %src, %dst : !ttg.memdesc<128x128xf32, #shared, #smem, mutable>, !ttg.memdesc<128x128xf32, #tmem, #ttng.tensor_memory, mutable>
     tt.return
   }
 }

--- a/test/TritonGPU/proxy_fence_insertion.mlir
+++ b/test/TritonGPU/proxy_fence_insertion.mlir
@@ -8,7 +8,7 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32} {
   // CHECK-LABEL: fence_write_after_read
   tt.func @fence_write_after_read(%arg0: !tt.tensordesc<64x64xf32, #shared>, %arg1: !ttg.memdesc<1xi64, #shared1, #smem, mutable>) {
     // CHECK: ttg.local_load
-    // CHECK: ttng.fence_async_shared
+    // CHECK: ttng.fence_async_shared {bCluster = false}
     // CHECK: ttng.async_tma_copy_global_to_local
     %c0_i32 = arith.constant 0 : i32
     %true = arith.constant true
@@ -165,6 +165,22 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 1 : i32, ttg.targ
       !ttg.memdesc<1xi64, #shared_clc, #smem, mutable>
     tt.return
   }
+
+  // CHECK-LABEL: clc_try_cancel_single_cta_after_cluster_fence
+  tt.func @clc_try_cancel_single_cta_after_cluster_fence() {
+    %result = ttg.local_alloc {allocation.offset = 0 : i32} : () -> !ttg.memdesc<2xi64, #shared_clc, #smem, mutable>
+    %barrier = ttg.local_alloc {allocation.offset = 16 : i32} : () -> !ttg.memdesc<1xi64, #shared_clc, #smem, mutable>
+    %response = ttng.clc_load_result %result : !ttg.memdesc<2xi64, #shared_clc, #smem, mutable> -> i128
+    "test.keep"(%response) : (i128) -> ()
+    // CHECK: ttng.clc_load_result
+    // CHECK: ttng.fence_async_shared {bCluster = true}
+    // CHECK-NEXT: ttng.clc_try_cancel
+    ttng.fence_async_shared {bCluster = true}
+    ttng.clc_try_cancel %result, %barrier :
+      !ttg.memdesc<2xi64, #shared_clc, #smem, mutable>,
+      !ttg.memdesc<1xi64, #shared_clc, #smem, mutable>
+    tt.return
+  }
 }
 
 // -----
@@ -182,6 +198,39 @@ module attributes {"ttg.num-ctas" = 2 : i32, "ttg.num-warps" = 1 : i32, ttg.targ
     // CHECK: ttng.clc_load_result
     // CHECK: ttng.fence_async_shared {bCluster = true}
     // CHECK-NEXT: ttng.clc_try_cancel
+    ttng.clc_try_cancel %result, %barrier :
+      !ttg.memdesc<2xi64, #shared_clc, #smem, mutable>,
+      !ttg.memdesc<1xi64, #barrier, #smem, mutable>
+    tt.return
+  }
+
+  // CHECK-LABEL: clc_try_cancel_multi_cta_after_cta_fence
+  tt.func @clc_try_cancel_multi_cta_after_cta_fence() {
+    %result = ttg.local_alloc {allocation.offset = 0 : i32} : () -> !ttg.memdesc<2xi64, #shared_clc, #smem, mutable>
+    %barrier = ttg.local_alloc {allocation.offset = 16 : i32} : () -> !ttg.memdesc<1xi64, #barrier, #smem, mutable>
+    %response = ttng.clc_load_result %result : !ttg.memdesc<2xi64, #shared_clc, #smem, mutable> -> i128
+    "test.keep"(%response) : (i128) -> ()
+    // CHECK: ttng.clc_load_result
+    // CHECK: ttng.fence_async_shared {bCluster = false}
+    // CHECK-NEXT: ttng.fence_async_shared {bCluster = true}
+    // CHECK-NEXT: ttng.clc_try_cancel
+    ttng.fence_async_shared {bCluster = false}
+    ttng.clc_try_cancel %result, %barrier :
+      !ttg.memdesc<2xi64, #shared_clc, #smem, mutable>,
+      !ttg.memdesc<1xi64, #barrier, #smem, mutable>
+    tt.return
+  }
+
+  // CHECK-LABEL: clc_try_cancel_multi_cta_after_cluster_fence
+  tt.func @clc_try_cancel_multi_cta_after_cluster_fence() {
+    %result = ttg.local_alloc {allocation.offset = 0 : i32} : () -> !ttg.memdesc<2xi64, #shared_clc, #smem, mutable>
+    %barrier = ttg.local_alloc {allocation.offset = 16 : i32} : () -> !ttg.memdesc<1xi64, #barrier, #smem, mutable>
+    %response = ttng.clc_load_result %result : !ttg.memdesc<2xi64, #shared_clc, #smem, mutable> -> i128
+    "test.keep"(%response) : (i128) -> ()
+    // CHECK: ttng.clc_load_result
+    // CHECK: ttng.fence_async_shared {bCluster = true}
+    // CHECK-NEXT: ttng.clc_try_cancel
+    ttng.fence_async_shared {bCluster = true}
     ttng.clc_try_cancel %result, %barrier :
       !ttg.memdesc<2xi64, #shared_clc, #smem, mutable>,
       !ttg.memdesc<1xi64, #barrier, #smem, mutable>

--- a/test/TritonGPU/proxy_fence_insertion.mlir
+++ b/test/TritonGPU/proxy_fence_insertion.mlir
@@ -145,3 +145,46 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32} {
     tt.return
   }
 }
+
+// -----
+
+#shared_clc = #ttg.swizzled_shared<{vec = 1, perPhase = 1, maxPhase = 1, order = [0]}>
+#smem = #ttg.shared_memory
+module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 1 : i32, ttg.target = "cuda:100", "ttg.threads-per-warp" = 32 : i32} {
+  // CHECK-LABEL: clc_try_cancel_single_cta_fence
+  tt.func @clc_try_cancel_single_cta_fence() {
+    %result = ttg.local_alloc {allocation.offset = 0 : i32} : () -> !ttg.memdesc<2xi64, #shared_clc, #smem, mutable>
+    %barrier = ttg.local_alloc {allocation.offset = 16 : i32} : () -> !ttg.memdesc<1xi64, #shared_clc, #smem, mutable>
+    %response = ttng.clc_load_result %result : !ttg.memdesc<2xi64, #shared_clc, #smem, mutable> -> i128
+    "test.keep"(%response) : (i128) -> ()
+    // CHECK: ttng.clc_load_result
+    // CHECK: ttng.fence_async_shared {bCluster = false}
+    // CHECK-NEXT: ttng.clc_try_cancel
+    ttng.clc_try_cancel %result, %barrier :
+      !ttg.memdesc<2xi64, #shared_clc, #smem, mutable>,
+      !ttg.memdesc<1xi64, #shared_clc, #smem, mutable>
+    tt.return
+  }
+}
+
+// -----
+
+#shared_clc = #ttg.swizzled_shared<{vec = 1, perPhase = 1, maxPhase = 1, order = [0], CGALayout = [[0]]}>
+#barrier = #ttg.swizzled_shared<{vec = 1, perPhase = 1, maxPhase = 1, order = [0], CGALayout = [[1]]}>
+#smem = #ttg.shared_memory
+module attributes {"ttg.num-ctas" = 2 : i32, "ttg.num-warps" = 1 : i32, ttg.target = "cuda:100", "ttg.threads-per-warp" = 32 : i32} {
+  // CHECK-LABEL: clc_try_cancel_multi_cta_fence
+  tt.func @clc_try_cancel_multi_cta_fence() {
+    %result = ttg.local_alloc {allocation.offset = 0 : i32} : () -> !ttg.memdesc<2xi64, #shared_clc, #smem, mutable>
+    %barrier = ttg.local_alloc {allocation.offset = 16 : i32} : () -> !ttg.memdesc<1xi64, #barrier, #smem, mutable>
+    %response = ttng.clc_load_result %result : !ttg.memdesc<2xi64, #shared_clc, #smem, mutable> -> i128
+    "test.keep"(%response) : (i128) -> ()
+    // CHECK: ttng.clc_load_result
+    // CHECK: ttng.fence_async_shared {bCluster = true}
+    // CHECK-NEXT: ttng.clc_try_cancel
+    ttng.clc_try_cancel %result, %barrier :
+      !ttg.memdesc<2xi64, #shared_clc, #smem, mutable>,
+      !ttg.memdesc<1xi64, #barrier, #smem, mutable>
+    tt.return
+  }
+}


### PR DESCRIPTION
## Summary

Track generic-to-async shared-memory proxy dependencies independently at CTA and cluster scope, and insert the fence required by each async operation.

Async operations that access peer-CTA shared memory require cluster-scoped ordering. This includes multi-CTA CLC, multicast TMA loads and gathers, two-CTA MMAv5 operations, and two-CTA TMEM copies. Other async shared-memory operations remain CTA-scoped.

`ProxyFenceInsertion` runs independent cluster and CTA dataflow analyses over the existing CFG and call-summary machinery. A CTA fence clears only the CTA frontier, while a cluster fence clears both. The cluster analysis runs first, when the module contains a cluster-scoped proxy operation, so its inserted fences are visible to the CTA analysis.

## Testing

- `lit -v TritonGPU/proxy_fence_insertion.mlir`
- `pytest -s --tb=short python/test/gluon/test_consan.py::test_async_tma_multicast_kernel_reuse`
- `pytest -s --tb=short python/test/gluon/test_consan.py::test_clc_result_reuse_after_cluster_barrier`

Validated on `codex-gb200-f33`.
