### PR TITLE
[TRITONGPU] Clone single-use load producer chains for CTA layouts

### DIFF
--- a/lib/Dialect/TritonNvidiaGPU/Transforms/AssignCTALayouts.cpp
+++ b/lib/Dialect/TritonNvidiaGPU/Transforms/AssignCTALayouts.cpp
@@ -3,9 +3,12 @@
 #include "mlir/IR/Builders.h"
 #include "mlir/IR/BuiltinOps.h"
 #include "mlir/IR/BuiltinTypes.h"
+#include "mlir/IR/IRMapping.h"
+#include "mlir/Interfaces/SideEffectInterfaces.h"
 #include "mlir/Support/LLVM.h"
 #include "triton/Dialect/Triton/IR/Dialect.h"
 #include "triton/Dialect/TritonGPU/IR/Dialect.h"
+#include "triton/Dialect/TritonGPU/Transforms/Utility.h"
 #include "triton/Dialect/TritonNvidiaGPU/IR/Dialect.h"
 #include "triton/Dialect/TritonNvidiaGPU/Transforms/Passes.h"
 #include "llvm/Support/ErrorHandling.h"
@@ -60,77 +63,122 @@ Value convertValueToLayout(OpBuilder &builder, Location loc, Value value,
   return ttg::ConvertLayoutOp::create(builder, loc, newTy, value);
 }
 
-Value cloneLoadWithLayout(OpBuilder &builder, Location loc, Value value,
-                          Attribute layout, int numWarps, int threadsPerWarp) {
-  Value loadValue = value;
-  // If the operand is already a convert-layout chain rooted at a load:
-  //
-  //   %old_load = tt.load %old_ptr : ... #blocked_old
-  //   %old_dot_operand = ttg.convert_layout %old_load : #blocked_old ->
-  //   #dot_old
-  //
-  // create a sibling load using the planned CTA layout:
-  //
-  //   %new_ptr = ttg.convert_layout %old_ptr : #blocked_old -> #blocked_new
-  //   %new_load = tt.load %new_ptr : ... #blocked_new
-  //   %new_dot_operand = ttg.convert_layout %new_load : #blocked_new ->
-  //   #dot_new
-  //
-  // This avoids inserting a cross-CTA conversion on the loaded value and leaves
-  // the original load available for any other users if any.
-  // TODO: Match more flexible producer patterns between the load and consumer.
-  while (auto cvtOp = loadValue.getDefiningOp<ttg::ConvertLayoutOp>())
-    loadValue = cvtOp.getSrc();
+Attribute getLayoutInCGA(Value value, Attribute preferredLayout, int numWarps,
+                         int threadsPerWarp) {
+  auto type = dyn_cast<RankedTensorType>(value.getType());
+  if (!type)
+    return {};
 
-  Operation *loadOp = loadValue.getDefiningOp();
-  if (!isa_and_nonnull<triton::LoadOp, triton::DescriptorLoadLikeOpInterface>(
-          loadOp))
-    return value;
+  auto currentDot = dyn_cast<ttg::DotOperandEncodingAttr>(type.getEncoding());
+  auto preferredDot = dyn_cast<ttg::DotOperandEncodingAttr>(preferredLayout);
+  if (currentDot && preferredDot &&
+      currentDot.getOpIdx() == preferredDot.getOpIdx() &&
+      currentDot.getKWidth() == preferredDot.getKWidth())
+    return preferredLayout;
 
-  auto oldTy = cast<RankedTensorType>(loadValue.getType());
-  auto oldLayout = cast<ttg::DistributedEncodingTrait>(oldTy.getEncoding());
+  auto currentLayout =
+      dyn_cast<ttg::DistributedEncodingTrait>(type.getEncoding());
+  if (!currentLayout ||
+      !isa<ttg::BlockedEncodingAttr, ttg::SliceEncodingAttr>(currentLayout))
+    return {};
 
-  auto cgaLayout = ttg::getCGALayout(layout);
-  auto newLoadLayout = cloneWithCGALayout(oldLayout, oldTy.getShape(), numWarps,
-                                          threadsPerWarp, cgaLayout);
-  if (oldLayout == newLoadLayout)
-    return value;
+  return cloneWithCGALayout(currentLayout, type.getShape(), numWarps,
+                            threadsPerWarp, ttg::getCGALayout(preferredLayout));
+}
 
-  auto newTy = oldTy.cloneWithEncoding(newLoadLayout);
-
-  OpBuilder loadBuilder(loadOp);
-  loadBuilder.setInsertionPointAfter(loadOp);
-
-  auto convertLoadOperand = [&](Value operand) -> Value {
-    if (!operand)
+Value getSingleTensorOperand(Operation *op) {
+  Value source;
+  for (Value operand : op->getOperands()) {
+    if (!isa<RankedTensorType>(operand.getType()))
+      continue;
+    if (source)
       return {};
-    return convertValueToLayout(loadBuilder, loadOp->getLoc(), operand,
-                                newLoadLayout);
-  };
-  auto convertLoadedValue = [&](Value loaded) {
-    return convertValueToLayout(builder, loc, loaded, layout);
-  };
+    source = operand;
+  }
+  return source;
+}
 
-  if (auto scalarLoad = dyn_cast<triton::LoadOp>(loadOp)) {
-    Value newPtr = convertLoadOperand(scalarLoad.getPtr());
-    Value newMask = convertLoadOperand(scalarLoad.getMask());
-    Value newOther = convertLoadOperand(scalarLoad.getOther());
-    Operation *newLoad = triton::LoadOp::create(
-                             loadBuilder, scalarLoad.getLoc(), newTy, newPtr,
-                             newMask, newOther, scalarLoad.getCache(),
-                             scalarLoad.getEvict(), scalarLoad.getIsVolatile())
-                             .getOperation();
-    newLoad->setAttrs(loadOp->getAttrs());
-    return convertLoadedValue(newLoad->getResult(0));
+// Clone a load and a single-use chain of side-effect-free operations in the
+// planned CTA layout. Restricting each operation to one tensor operand keeps
+// this a simple def-use chain; inferSrcEncoding handles tt.trans.
+Value cloneProducerWithLayout(OpBuilder &builder, Value value, Attribute layout,
+                              int numWarps, int threadsPerWarp) {
+  Operation *op = value.getDefiningOp();
+  if (isa_and_nonnull<triton::LoadOp, triton::DescriptorLoadLikeOpInterface>(
+          op)) {
+    if (auto load = dyn_cast<triton::LoadOp>(op); load && load.getIsVolatile())
+      return {};
+
+    auto oldType = cast<RankedTensorType>(value.getType());
+    if (oldType.getEncoding() == layout)
+      return {};
+    auto newType = oldType.cloneWithEncoding(layout);
+    OpBuilder loadBuilder(op);
+    loadBuilder.setInsertionPointAfter(op);
+
+    if (auto load = dyn_cast<triton::LoadOp>(op)) {
+      auto convertOperand = [&](Value operand) -> Value {
+        if (!operand)
+          return {};
+        return convertValueToLayout(loadBuilder, op->getLoc(), operand, layout);
+      };
+      Operation *newLoad =
+          triton::LoadOp::create(
+              loadBuilder, load.getLoc(), newType,
+              convertOperand(load.getPtr()), convertOperand(load.getMask()),
+              convertOperand(load.getOther()), load.getCache(), load.getEvict(),
+              load.getIsVolatile())
+              .getOperation();
+      newLoad->setAttrs(op->getAttrs());
+      return newLoad->getResult(0);
+    }
+
+    Operation *newLoad = loadBuilder.clone(*op);
+    newLoad->getResult(0).setType(newType);
+    return newLoad->getResult(0);
   }
 
-  if (isa<triton::DescriptorLoadLikeOpInterface>(loadOp)) {
-    Operation *newLoad = loadBuilder.clone(*loadOp);
-    newLoad->getResult(0).setType(newTy);
-    return convertLoadedValue(newLoad->getResult(0));
-  }
+  if (!op || !value.hasOneUse() || op->getNumResults() != 1 ||
+      !op->getRegions().empty() || !isMemoryEffectFree(op))
+    return {};
 
-  llvm_unreachable("expected scalar or descriptor load");
+  Value source = getSingleTensorOperand(op);
+  if (!source)
+    return {};
+
+  bool isConvert = isa<ttg::ConvertLayoutOp>(op);
+  Attribute sourceLayout =
+      isConvert ? getLayoutInCGA(source, layout, numWarps, threadsPerWarp)
+                : inferSrcEncoding(op, layout);
+  if (!sourceLayout)
+    return {};
+
+  Value newSource = cloneProducerWithLayout(builder, source, sourceLayout,
+                                            numWarps, threadsPerWarp);
+  if (!newSource)
+    return {};
+  if (isConvert)
+    return newSource;
+
+  IRMapping mapping;
+  mapping.map(source, newSource);
+  Operation *newOp = builder.clone(*op, mapping);
+  auto oldType = cast<RankedTensorType>(op->getResult(0).getType());
+  newOp->getResult(0).setType(oldType.cloneWithEncoding(layout));
+  return newOp->getResult(0);
+}
+
+Value cloneLoadWithLayout(OpBuilder &builder, Value value,
+                          Attribute preferredLayout, int numWarps,
+                          int threadsPerWarp) {
+  Attribute layout =
+      getLayoutInCGA(value, preferredLayout, numWarps, threadsPerWarp);
+  if (!layout)
+    return value;
+  if (Value cloned = cloneProducerWithLayout(builder, value, layout, numWarps,
+                                             threadsPerWarp))
+    return cloned;
+  return value;
 }
 
 void convertOpOperandsToLayouts(Operation *op,
@@ -140,8 +188,8 @@ void convertOpOperandsToLayouts(Operation *op,
   Location loc = op->getLoc();
   for (auto [operand, layout] :
        llvm::zip(op->getOpOperands(), operandLayouts)) {
-    Value value = cloneLoadWithLayout(builder, loc, operand.get(), layout,
-                                      numWarps, threadsPerWarp);
+    Value value = cloneLoadWithLayout(builder, operand.get(), layout, numWarps,
+                                      threadsPerWarp);
     operand.set(convertValueToLayout(builder, loc, value, layout));
   }
 }

--- a/test/TritonNvidiaGPU/assign_cta_layouts.mlir
+++ b/test/TritonNvidiaGPU/assign_cta_layouts.mlir
@@ -75,7 +75,7 @@ module attributes {"ttg.num-ctas" = 2 : i32, "ttg.num-warps" = 4 : i32, ttg.targ
     %ptrs: tensor<128x32x!tt.ptr<f16>, #load_src>,
     %out: tensor<128x32x!tt.ptr<f16>, #load_src>,
     %b_ptrs: tensor<32x128x!tt.ptr<f16>, #load_src_b>,
-    %c: tensor<128x128xf32, #dot_default_load>) {
+    %c: tensor<128x128xf32, #dot_default_load>) -> tensor<128x128xf32, #dot_default_load> {
     %a = tt.load %ptrs : tensor<128x32x!tt.ptr<f16>, #load_src>
     %b = tt.load %b_ptrs : tensor<32x128x!tt.ptr<f16>, #load_src_b>
     tt.store %out, %a : tensor<128x32x!tt.ptr<f16>, #load_src>
@@ -83,7 +83,7 @@ module attributes {"ttg.num-ctas" = 2 : i32, "ttg.num-warps" = 4 : i32, ttg.targ
     %ad = ttg.convert_layout %a_blocked : tensor<128x32xf16, #dot_default_load> -> tensor<128x32xf16, #dot_a_load>
     %bd = ttg.convert_layout %b : tensor<32x128xf16, #load_src_b> -> tensor<32x128xf16, #dot_b_load>
     %dot = tt.dot %ad, %bd, %c : tensor<128x32xf16, #dot_a_load> * tensor<32x128xf16, #dot_b_load> -> tensor<128x128xf32, #dot_default_load>
-    tt.return
+    tt.return %dot : tensor<128x128xf32, #dot_default_load>
   }
 }
 
@@ -108,19 +108,56 @@ module attributes {"ttg.num-ctas" = 2 : i32, "ttg.num-warps" = 4 : i32, ttg.targ
   // CHECK: %[[B_DESC_LOAD:.*]] = tt.descriptor_load %{{.*}}[%{{.*}}, %{{.*}}] : !tt.tensordesc<32x128xf16> -> tensor<32x128xf16, #[[$DESC_LOAD_B_PLANNED]]>
   // CHECK: ttg.convert_layout %[[DESC_LOAD]] : tensor<128x32xf16, #[[$DESC_LOAD_PLANNED]]> -> tensor<128x32xf16, #ttg.dot_op<{opIdx = 0, parent = #[[$DOT_OPT_DESC_LOAD]]}>>
   // CHECK: ttg.convert_layout %[[B_DESC_LOAD]] : tensor<32x128xf16, #[[$DESC_LOAD_B_PLANNED]]> -> tensor<32x128xf16, #ttg.dot_op<{opIdx = 1, parent = #[[$DOT_OPT_DESC_LOAD]]}>>
-  // CHECK: tt.return %[[ORIG_DESC_LOAD]] : tensor<128x32xf16, #[[$DESC_LOAD_ORIG]]>
+  // CHECK: tt.return %[[ORIG_DESC_LOAD]], %{{.*}} : tensor<128x32xf16, #[[$DESC_LOAD_ORIG]]>,
   tt.func @dot_clones_descriptor_load_source(
     %a_desc: !tt.tensordesc<128x32xf16>,
     %b_desc: !tt.tensordesc<32x128xf16>,
     %i: i32,
     %j: i32,
-    %c: tensor<128x128xf32, #dot_default_desc_load>) -> tensor<128x32xf16, #desc_load_src> {
+    %c: tensor<128x128xf32, #dot_default_desc_load>) -> (tensor<128x32xf16, #desc_load_src>, tensor<128x128xf32, #dot_default_desc_load>) {
     %a = tt.descriptor_load %a_desc[%i, %j] : !tt.tensordesc<128x32xf16> -> tensor<128x32xf16, #desc_load_src>
     %b = tt.descriptor_load %b_desc[%i, %j] : !tt.tensordesc<32x128xf16> -> tensor<32x128xf16, #desc_load_src_b>
     %a_blocked = ttg.convert_layout %a : tensor<128x32xf16, #desc_load_src> -> tensor<128x32xf16, #dot_default_desc_load>
     %ad = ttg.convert_layout %a_blocked : tensor<128x32xf16, #dot_default_desc_load> -> tensor<128x32xf16, #dot_a_desc_load>
     %bd = ttg.convert_layout %b : tensor<32x128xf16, #desc_load_src_b> -> tensor<32x128xf16, #dot_b_desc_load>
     %dot = tt.dot %ad, %bd, %c : tensor<128x32xf16, #dot_a_desc_load> * tensor<32x128xf16, #dot_b_desc_load> -> tensor<128x128xf32, #dot_default_desc_load>
-    tt.return %a : tensor<128x32xf16, #desc_load_src>
+    tt.return %a, %dot : tensor<128x32xf16, #desc_load_src>, tensor<128x128xf32, #dot_default_desc_load>
+  }
+}
+
+// -----
+
+#chain_load = #ttg.blocked<{sizePerThread = [4, 1], threadsPerWarp = [4, 8], warpsPerCTA = [1, 4], order = [0, 1], CGALayout = [[0, 1]]}>
+#chain_trans = #ttg.blocked<{sizePerThread = [1, 4], threadsPerWarp = [8, 4], warpsPerCTA = [4, 1], order = [1, 0], CGALayout = [[1, 0]]}>
+#chain_dot_default = #ttg.blocked<{sizePerThread = [4, 4], threadsPerWarp = [1, 32], warpsPerCTA = [4, 1], order = [1, 0], CGALayout = [[0, 1]]}>
+#chain_dot_a = #ttg.dot_op<{opIdx = 0, parent = #chain_dot_default}>
+#chain_dot_b = #ttg.dot_op<{opIdx = 1, parent = #chain_dot_default}>
+
+// CHECK-DAG: #[[$CHAIN_DOT_DEFAULT:.*]] = #ttg.blocked<{sizePerThread = [4, 4], threadsPerWarp = [1, 32], warpsPerCTA = [4, 1], order = [1, 0], CGALayout = {{\[\[0, 1\]\]}}}>
+// CHECK-DAG: #[[$CHAIN_DOT_PLANNED:.*]] = #ttg.blocked<{sizePerThread = [4, 4], threadsPerWarp = [2, 16], warpsPerCTA = [4, 1], order = [1, 0], CGALayout = {{\[\[0, 1\]\]}}}>
+module attributes {"ttg.num-ctas" = 2 : i32, "ttg.num-warps" = 4 : i32, ttg.target = "cuda:100", "ttg.threads-per-warp" = 32 : i32} {
+  // CHECK-LABEL: tt.func @dot_clones_single_user_producer_chain
+  // CHECK: %[[CHAIN_OLD_LOAD:.*]] = tt.load %{{.*}} : tensor<32x128x!tt.ptr<f16>, #[[$CHAIN_LOAD_ORIG:.*]]>
+  // CHECK: %[[CHAIN_PTRS:.*]] = ttg.convert_layout %{{.*}} : tensor<32x128x!tt.ptr<f16>, #[[$CHAIN_LOAD_ORIG]]> -> tensor<32x128x!tt.ptr<f16>, #[[$CHAIN_LOAD_PLANNED:.*]]>
+  // CHECK: %[[CHAIN_NEW_LOAD:.*]] = tt.load %[[CHAIN_PTRS]] : tensor<32x128x!tt.ptr<f16>, #[[$CHAIN_LOAD_PLANNED]]>
+  // CHECK: tt.store %{{.*}}, %[[CHAIN_OLD_LOAD]] : tensor<32x128x!tt.ptr<f16>, #[[$CHAIN_LOAD_ORIG]]>
+  // CHECK: %[[CHAIN_WIDE:.*]] = arith.extf %[[CHAIN_NEW_LOAD]] : tensor<32x128xf16, #[[$CHAIN_LOAD_PLANNED]]> to tensor<32x128xf32, #[[$CHAIN_LOAD_PLANNED]]>
+  // CHECK: %[[CHAIN_NARROW:.*]] = arith.truncf %[[CHAIN_WIDE]] : tensor<32x128xf32, #[[$CHAIN_LOAD_PLANNED]]> to tensor<32x128xf16, #[[$CHAIN_LOAD_PLANNED]]>
+  // CHECK: %[[CHAIN_TRANS:.*]] = tt.trans %[[CHAIN_NARROW]] {order = array<i32: 1, 0>} : tensor<32x128xf16, #[[$CHAIN_LOAD_PLANNED]]> -> tensor<128x32xf16, #[[$CHAIN_TRANS_PLANNED:.*]]>
+  // CHECK: %[[CHAIN_AD:.*]] = ttg.convert_layout %[[CHAIN_TRANS]] : tensor<128x32xf16, #[[$CHAIN_TRANS_PLANNED]]> -> tensor<128x32xf16, #ttg.dot_op<{opIdx = 0, parent = #[[$CHAIN_DOT_PLANNED]]}>>
+  // CHECK: tt.dot %[[CHAIN_AD]], %{{.*}}, %{{.*}} : tensor<128x32xf16, #ttg.dot_op<{opIdx = 0, parent = #[[$CHAIN_DOT_PLANNED]]}>> * tensor<32x128xf16, #ttg.dot_op<{opIdx = 1, parent = #[[$CHAIN_DOT_PLANNED]]}>> -> tensor<128x128xf32, #[[$CHAIN_DOT_PLANNED]]>
+  tt.func @dot_clones_single_user_producer_chain(
+      %ptrs: tensor<32x128x!tt.ptr<f16>, #chain_load>,
+      %old_out: tensor<32x128x!tt.ptr<f16>, #chain_load>,
+      %b: tensor<32x128xf16, #chain_dot_b>,
+      %c: tensor<128x128xf32, #chain_dot_default>) -> tensor<128x128xf32, #chain_dot_default> {
+    %value = tt.load %ptrs : tensor<32x128x!tt.ptr<f16>, #chain_load>
+    tt.store %old_out, %value : tensor<32x128x!tt.ptr<f16>, #chain_load>
+    %wide = arith.extf %value : tensor<32x128xf16, #chain_load> to tensor<32x128xf32, #chain_load>
+    %narrow = arith.truncf %wide : tensor<32x128xf32, #chain_load> to tensor<32x128xf16, #chain_load>
+    %trans = tt.trans %narrow {order = array<i32: 1, 0>} : tensor<32x128xf16, #chain_load> -> tensor<128x32xf16, #chain_trans>
+    %ad = ttg.convert_layout %trans : tensor<128x32xf16, #chain_trans> -> tensor<128x32xf16, #chain_dot_a>
+    %dot = tt.dot %ad, %b, %c : tensor<128x32xf16, #chain_dot_a> * tensor<32x128xf16, #chain_dot_b> -> tensor<128x128xf32, #chain_dot_default>
+    tt.return %dot : tensor<128x128xf32, #chain_dot_default>
   }
 }


### PR DESCRIPTION
## What changed

- Extend `AssignCTALayouts` load cloning through a single-use producer chain.
- Replay side-effect-free, single-result operations with one tensor operand in the planned CTA layout.
- Infer source layouts through `tt.trans` and treat `ttg.convert_layout` as transparent.
- Keep ordinary and descriptor load cloning, while rejecting volatile loads and unsupported producer graphs.

## Why

The direct `load -> convert_layout` matcher was too restrictive when layout-polymorphic operations such as casts or transpose occur between the load and the dot operand. Cloning the narrow def-use chain lets the load adopt the assigned CTA layout without relying on forced rematerialization in `RemoveLayoutConversions`.

## Impact

This remains intentionally conservative: intermediate values must have exactly one use, and operations with multiple tensor operands, regions, side effects, or multiple results fall back to the existing layout conversion path.

## Validation

- `make`
- `ninja triton-opt`
- `lit -v test/TritonNvidiaGPU/assign_cta_layouts.mlir test/TritonNvidiaGPU/optimize_cta_locality.mlir`