### PR TITLE
[triton-ext] Add Triton headers/definitions to wheel

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -469,6 +469,28 @@ if(TRITON_BUILD_PYTHON_MODULE)
     "${TRITON_WHEEL_DIR}/FileCheck"
     COPYONLY)
 
+  # Install Triton headers and TableGen definitions into the wheel staging
+  # directory so that downstream projects can use Triton as a C++ library
+  # without a separate cmake --install step.
+  set(_TRITON_WHEEL_INCLUDE "${TRITON_WHEEL_DIR}/include")
+  install(DIRECTORY ${PROJECT_SOURCE_DIR}/include/
+    COMPONENT wheel_headers
+    DESTINATION "${_TRITON_WHEEL_INCLUDE}"
+    FILES_MATCHING PATTERN "*.h")
+  install(DIRECTORY ${PROJECT_BINARY_DIR}/include/
+    COMPONENT wheel_headers
+    DESTINATION "${_TRITON_WHEEL_INCLUDE}"
+    FILES_MATCHING PATTERN "*.h" PATTERN "*.h.inc")
+  install(DIRECTORY ${PROJECT_SOURCE_DIR}/include/
+    COMPONENT wheel_headers
+    DESTINATION "${_TRITON_WHEEL_INCLUDE}"
+    FILES_MATCHING PATTERN "*.td")
+  install(DIRECTORY ${PROJECT_SOURCE_DIR}/python/
+    COMPONENT wheel_headers
+    DESTINATION "${_TRITON_WHEEL_INCLUDE}/python"
+    FILES_MATCHING PATTERN "*.h"
+    PATTERN "triton" EXCLUDE)
+
   # Build plugins when building libtriton since they depend on libtriton.
   if(TRITON_EXT_ENABLED)
     add_subdirectory(examples/plugins)

--- a/setup.py
+++ b/setup.py
@@ -373,6 +373,12 @@ class CMakeBuild(build_ext):
         update_symlink(Path(self.base_dir) / "compile_commands.json", cmake_dir / "compile_commands.json")
         subprocess.check_call(["cmake", "--build", "."] + build_args, cwd=cmake_dir)
         subprocess.check_call(["cmake", "--build", ".", "--target", "mlir-doc"], cwd=cmake_dir)
+        # Install Triton headers and TableGen definitions (*.h, *.h.inc, *.td)
+        # into the wheel staging directory so they are bundled in the wheel.
+        # This must run after the full build so that all TableGen-generated
+        # *.h.inc files exist in the CMake binary directory.
+        subprocess.check_call(["cmake", "--install", ".", "--component", "wheel_headers", "--prefix", wheeldir],
+                              cwd=cmake_dir)
 
 
 backends = [*BackendInstaller.copy(["nvidia", "amd"]), *BackendInstaller.copy_externals()]
@@ -594,6 +600,16 @@ setup(
         "__pycache__/*",
         "*.py[cod]",
     ]},
+    package_data={
+        # Headers and TableGen definitions copied into the wheel staging dir by
+        # the wheel_headers CMake install component.  Paths are relative to the
+        # triton package root (<build_lib>/triton/).
+        "triton": [
+            "include/**/*.h",
+            "include/**/*.h.inc",
+            "include/**/*.td",
+        ],
+    },
     ext_modules=[CMakeExtension("triton", "triton/_C/")],
     cmdclass={
         "bdist_wheel": plugin_bdist_wheel,

--- a/setup.py
+++ b/setup.py
@@ -373,12 +373,13 @@ class CMakeBuild(build_ext):
         update_symlink(Path(self.base_dir) / "compile_commands.json", cmake_dir / "compile_commands.json")
         subprocess.check_call(["cmake", "--build", "."] + build_args, cwd=cmake_dir)
         subprocess.check_call(["cmake", "--build", ".", "--target", "mlir-doc"], cwd=cmake_dir)
-        # Install Triton headers and TableGen definitions (*.h, *.h.inc, *.td)
-        # into the wheel staging directory so they are bundled in the wheel.
-        # This must run after the full build so that all TableGen-generated
-        # *.h.inc files exist in the CMake binary directory.
-        subprocess.check_call(["cmake", "--install", ".", "--component", "wheel_headers", "--prefix", wheeldir],
-                              cwd=cmake_dir)
+        if check_env_flag("TRITON_EXT_ENABLED"):
+            # Install Triton headers and TableGen definitions (*.h, *.h.inc, *.td)
+            # into the wheel staging directory so they are bundled in the wheel.
+            # This must run after the full build so that all TableGen-generated
+            # *.h.inc files exist in the CMake binary directory.
+            subprocess.check_call(["cmake", "--install", ".", "--component", "wheel_headers", "--prefix", wheeldir],
+                                  cwd=cmake_dir)
 
 
 backends = [*BackendInstaller.copy(["nvidia", "amd"]), *BackendInstaller.copy_externals()]


### PR DESCRIPTION
Building Triton extensions requires several things from Triton:
a. the Triton shared library
b. the Triton C++ headers
c. the Triton TableGen definitions
d. the Triton Python package

Both (a) and (d) are present in the `triton` wheel, but (b) and (c) are not. This change adds the files from (b) and (c) when `TRITON_EXT_ENABLED=1` in the build.