### PR TITLE
[GLUON] Add `ttgl.local_barrier` (shared-memory-scoped CTA barrier)

### DIFF
--- a/python/src/ir.cc
+++ b/python/src/ir.cc
@@ -1884,6 +1884,13 @@ void init_triton_ir(py::module_ &m) {
            [](TritonOpBuilder &self) {
              self.create<triton::gpu::BarrierOp>(triton::gpu::AddrSpace::All);
            })
+      // Shared-memory-only (local address space) CTA barrier. Orders local
+      // memory operations CTA-wide without the global/tensor memory ordering of
+      // the full `all` barrier.
+      .def("create_local_barrier",
+           [](TritonOpBuilder &self) {
+             self.create<triton::gpu::BarrierOp>(triton::gpu::AddrSpace::Local);
+           })
       // Make a tensor descriptor
       .def("create_make_tensor_descriptor",
            [](TritonOpBuilder &self, Value &base, std::vector<Value> &shape,

--- a/python/test/gluon/test_frontend.py
+++ b/python/test/gluon/test_frontend.py
@@ -1697,6 +1697,13 @@ def test_barrier():
 
 @filecheck_test
 @gluon.jit
+def test_local_barrier():
+    # CHECK: ttg.barrier local
+    ttgl.local_barrier()
+
+
+@filecheck_test
+@gluon.jit
 def test_fence_async_shared():
     # CHECK: ttng.fence_async_shared {bCluster = false}
     blackwell.fence_async_shared()

--- a/python/triton/experimental/gluon/language/__init__.py
+++ b/python/triton/experimental/gluon/language/__init__.py
@@ -85,6 +85,7 @@ from ._core import (
     store,
     sub,
     barrier,
+    local_barrier,
     to_linear_layout,
     to_tensor,
     expect_zero,

--- a/python/triton/experimental/gluon/language/_core.py
+++ b/python/triton/experimental/gluon/language/_core.py
@@ -716,6 +716,18 @@ def barrier(*, cluster: bool = False, _semantic=None):
 
 
 @builtin
+def local_barrier(_semantic=None):
+    """
+    Order shared memory operations across the CTA.
+
+    Lowers to ``ttg.barrier local``: makes prior shared memory writes visible
+    to subsequent shared memory reads across the CTA. Unlike :func:`barrier`
+    (``ttg.barrier all``), it does not order global or tensor memory.
+    """
+    _semantic.builder.create_local_barrier()
+
+
+@builtin
 def bank_conflicts(distr_ty, shared_ty, _semantic=None) -> int:
     """
     Count the bank conflicts per wavefront of each instruction generated when


### PR DESCRIPTION
## Summary
`ttgl.barrier()` lowers to `ttg.barrier all`, which orders **all** address
spaces. When a barrier only needs to guard shared-memory (LDS) read/write
hazards the global/tensor memory ordering is unnecessary. 
On AMD RDNA the full barrier additionally emits a
global cache invalidate (`buffer_gl0_inv`) after every `s_barrier`, which we can save
with local_barrier.

## Changes
- `create_local_barrier` builder binding (`AddrSpace::Local`) in `python/src/ir.cc`
- `ttgl.local_barrier()` Gluon builtin, in core `_core.py` next to `ttgl.barrier()`
- filecheck test asserting it lowers to `ttg.barrier local`

## Design notes
- The `ttg.barrier` op already carries an `addrspace` bitmask and the `local`
  scope is backend-supported; this change only exposes it to the Gluon frontend.

## Motivation / impact
On a gfx1151 (RDNA3.5) fp16 GEMM, replacing `ttgl.barrier()` with
`ttgl.local_barrier()` in the pipelined main loop removed a per-iteration
`buffer_gl0_inv` and improved that kernel's throughput by ~15%.

## Test
```
pytest python/test/gluon/test_frontend.py -k test_local_barrier
```
`test_local_barrier` compiles a Gluon kernel calling `ttgl.local_barrier()`
and checks the emitted IR contains `ttg.barrier local`.
