### PR TITLE
[BACKEND] Fix device_print(..., hex=True) for floating-point values

### DIFF
--- a/lib/Conversion/TritonGPUToLLVM/PrintOpToLLVM.cpp
+++ b/lib/Conversion/TritonGPUToLLVM/PrintOpToLLVM.cpp
@@ -180,8 +180,13 @@ struct PrintOpConversion : public ConvertOpToLLVMPattern<triton::PrintOp> {
     if (isa<LLVM::LLVMPointerType>(type)) {
       return "%p";
     }
+    // Use hexadecimal floating-point notation for floats. The printf ABI
+    // promotes them to f64 before formatting.
+    if (hex && isa<FloatType>(type)) {
+      return "%a";
+    }
     // Hex is "0x%0nx" or "0x%0nllx", where n is the number of hex digits in the
-    // type (so 4 for fp16, 8 for int32, 16 for int64).
+    // integer type (so 4 for int16, 8 for int32, 16 for int64).
     if (hex) {
       // Ignore `width` for `hex` values, pad to typeWidth.
       std::string ret =

--- a/python/test/unit/language/print_helper.py
+++ b/python/test/unit/language/print_helper.py
@@ -142,6 +142,12 @@ def test_print(func: str, data_type: str, device: str):
         kernel_print_no_arg[(1, )](num_warps=num_warps)
     elif func == "device_print_hex":
         kernel_device_print_hex[(1, )](x, y, num_warps=num_warps, BLOCK=N)
+    elif func == "device_print_hex_fp32_canonical":
+        canonical = torch.tensor(
+            [1.0, 1.5, 0.1, -1.5, -0.0, float("inf"), float("-inf"), 6.0], dtype=torch.float32, device=device)
+        x = canonical.repeat(N // canonical.numel())
+        y = torch.zeros_like(x)
+        kernel_device_print_hex[(1, )](x, y, num_warps=num_warps, BLOCK=N)
     elif func == "device_print_pointer":
         kernel_print_pointer[(1, )](x, y, num_warps=num_warps, BLOCK=N)
     elif func == "device_print_2d_tensor":

--- a/python/test/unit/language/test_subprocess.py
+++ b/python/test/unit/language/test_subprocess.py
@@ -1,8 +1,11 @@
 import itertools
 import os
+import re
 import subprocess
 import sys
 from collections import Counter
+
+import numpy as np
 
 import triton
 from triton._internal_testing import is_interpreter
@@ -12,6 +15,23 @@ import pytest
 dir_path = os.path.dirname(os.path.realpath(__file__))
 print_path = os.path.join(dir_path, "print_helper.py")
 torch_types = ["int8", "uint8", "int16", "int32", "long", "float16", "float32", "float64"]
+FP32_HEX_CANONICAL = (
+    "0x1p+0",
+    "0x1.8p+0",
+    "0x1.99999ap-4",
+    "-0x1.8p+0",
+    "-0x0p+0",
+    "inf",
+    "-inf",
+    "0x1.8p+2",
+)
+HEX_FLOAT_RE = re.compile(r"-?0x[0-9a-f]+(?:\.[0-9a-f]*)?p[+-]?\d+|-?inf|-?nan", re.IGNORECASE)
+
+
+def _hex_float_values(output: bytes) -> Counter:
+    # Device printf delegates formatting to the host C library, so normalize
+    # equivalent %a spellings (for example, optional trailing zeroes).
+    return Counter(float.fromhex(value).hex() for value in HEX_FLOAT_RE.findall(output.decode("UTF-8")))
 
 
 @pytest.mark.interpreter
@@ -28,6 +48,10 @@ torch_types = ["int8", "uint8", "int16", "int32", "long", "float16", "float32", 
                                                       ("device_print_hex", "int16"),
                                                       ("device_print_hex", "int32"),
                                                       ("device_print_hex", "int64"),
+                                                      ("device_print_hex", "float16"),
+                                                      ("device_print_hex", "float32"),
+                                                      ("device_print_hex", "float64"),
+                                                      ("device_print_hex_fp32_canonical", "float32"),
                                                       ("device_print_pointer", "int32"),
                                                       ("device_print_negative", "int32"),
                                                       ("device_print_uint", "uint32"),
@@ -41,15 +65,28 @@ def test_print(func_type: str, data_type: str, device: str):
     )
     assert proc.returncode == 0
 
-    if is_interpreter() and func_type != "static_assert":
-        # Interpreter uses a different format for device_print
-        # Only check if there's no error
+    # The total number of elements in the 1-D tensor to print.
+    N = 128
+
+    if is_interpreter():
         assert proc.stderr == b''
+
+    if func_type == "device_print_hex" and data_type.startswith("float"):
+        float_type = getattr(np, data_type)
+        expected = Counter(float(float_type(i)).hex() for i in range(N))
+        assert _hex_float_values(proc.stdout) == expected
+        return
+    if func_type == "device_print_hex_fp32_canonical":
+        expected = Counter(float.fromhex(value).hex() for value in FP32_HEX_CANONICAL)
+        expected = Counter({value: count * (N // len(FP32_HEX_CANONICAL)) for value, count in expected.items()})
+        assert _hex_float_values(proc.stdout) == expected
+        return
+
+    if is_interpreter():
+        # Interpreter uses a different format for device_print.
         return
 
     outs = [line for line in proc.stdout.decode("UTF-8").splitlines() if line]
-    # The total number of elements in the 1-D tensor to print.
-    N = 128
 
     # Constant for testing the printing of scalar values
     SCALAR_VAL = 42

--- a/python/triton/language/core.py
+++ b/python/triton/language/core.py
@@ -3536,7 +3536,7 @@ def device_print(prefix, *args, hex=False, _semantic=None):
 
     :param prefix: a prefix to print before the values. This is required to be a string literal.
     :param args: the values to print. They can be any tensor or scalar.
-    :param hex: print all values as hex instead of decimal
+    :param hex: print integers in hexadecimal and floating-point values in hexadecimal floating-point notation
     '''
     import string
     prefix = _unwrap_if_constexpr(prefix)

--- a/python/triton/runtime/interpreter.py
+++ b/python/triton/runtime/interpreter.py
@@ -811,7 +811,14 @@ class InterpreterBuilder:
         if prefix:
             msg += f" {prefix}"
         if hex:
-            np.set_printoptions(formatter={'all': lambda x: f"0x{x:02x}"})
+
+            def _to_hex(x):
+                if isinstance(x, np.floating):
+                    return float(x).hex()
+                width = x.dtype.itemsize * 2
+                return f"0x{int(x):0{width}x}"
+
+            np.set_printoptions(formatter={'all': _to_hex})
         for value in values:
             print(msg + f" {value.data}")
         if hex:


### PR DESCRIPTION
In hex mode, bitcast floating-point operands to same-width integers before printf promotion so their raw IEEE-754 bits live on NVIDIA and AMD backends.

Format interpreter hex output using the operand dtype width and view floating-point values as unsigned integers. Extend device_print hex coverage to float16, float32, and float64, verify exact interpreter bit patterns, and check hard-coded fp32 canonical values for 1.0, negative zero, and positive and negative infinity.

Tested with make and the full test_print matrix: 35 GPU tests and 35 interpreter tests pass.

<!---
The core Triton is a small number of people, and we receive many PRs (thank
you!).  To help us review your code more quickly, **if you are a new
contributor (less than 3 PRs merged) we ask that you complete the following
tasks and include the filled-out checklist in your PR description.**

Complete the following tasks before sending your PR, and replace `[ ]` with
`[x]` to indicate you have done them.
-->

# New contributor declaration
- [x] I am not making a trivial change, such as fixing a typo in a comment.

- [x] I have written a PR description following these
  [rules](https://cbea.ms/git-commit/#why-not-how).

- [x] I have run `pre-commit run --from-ref origin/main --to-ref HEAD`.

- Select one of the following.
  - [x] I have added tests.
    - `/test` for `lit` tests
    - `/unittest` for C++ tests
    - `/python/test` for end-to-end tests
  - [ ] This PR does not need a test because `FILL THIS IN`.

- Select one of the following.
  - [x] I have not added any `lit` tests.
  - [ ] The `lit` tests I have added follow these [best practices](https://mlir.llvm.org/getting_started/TestingGuide/#filecheck-best-practices),
    including the "tests should be minimal" section. (Usually running Python code
    and using the instructions it generates is not minimal.)
