### PR TITLE
[TRITONGPU] Cost descriptor layouts for partial reductions

### DIFF
--- a/lib/Dialect/TritonGPU/Transforms/OptimizeThreadLocality.cpp
+++ b/lib/Dialect/TritonGPU/Transforms/OptimizeThreadLocality.cpp
@@ -2,6 +2,7 @@
 #include <numeric>
 
 #include "mlir/IR/ImplicitLocOpBuilder.h"
+#include "mlir/Interfaces/SideEffectInterfaces.h"
 #include "mlir/Pass/Pass.h"
 #include "mlir/Pass/PassManager.h"
 #include "mlir/Support/LLVM.h"
@@ -13,6 +14,12 @@
 #include "triton/Dialect/TritonGPU/Transforms/Passes.h"
 #include "triton/Dialect/TritonGPU/Transforms/Utility.h"
 #include "triton/Tools/LayoutUtils.h"
+#include "llvm/Support/Debug.h"
+#include "llvm/Support/MathExtras.h"
+
+#define DEBUG_TYPE "tritongpu-optimize-thread-locality"
+#define DBGS() (llvm::dbgs() << "[" DEBUG_TYPE "]: ")
+#define LDBG(X) LLVM_DEBUG(DBGS() << X << "\n")
 
 namespace mlir {
 namespace triton {
@@ -236,6 +243,277 @@ struct OptimizeGatherLayoutPattern : public mlir::OpRewritePattern<GatherOp> {
 } // namespace
 
 namespace {
+
+struct DescriptorReductionLayoutCandidate {
+  int64_t saving;
+  SmallVector<std::pair<Operation *, Attribute>> descriptorLayouts;
+};
+
+// Estimate the number of shared-memory load instructions each thread needs to
+// consume a descriptor result. The global TMA transfer is identical for all
+// distributed layouts, so only the shared-to-register vector width matters.
+static int64_t getDescriptorLoadCost(RankedTensorType type) {
+  auto contigPerThread = getContigPerThread(type);
+  unsigned contiguousDim = getOrder(type).front();
+  unsigned maxVectorWidth = 128 / type.getElementTypeBitWidth();
+  unsigned vectorWidth =
+      std::max(1u, std::min(contigPerThread[contiguousDim], maxVectorWidth));
+  unsigned elemsPerThread = getTotalElemsPerThread(type);
+  return (elemsPerThread + vectorWidth - 1) / vectorWidth;
+}
+
+// Count the per-thread work performed by a reduction. Each communication stage
+// consists of a data movement and a combine instruction. This intentionally
+// uses structural instruction counts instead of target-specific latency
+// constants.
+static int64_t getReductionCost(RankedTensorType type, unsigned axis) {
+  auto elemsPerThread = getElemsPerThread(type);
+  unsigned axisElemsPerThread = elemsPerThread[axis];
+  unsigned totalElemsPerThread = getTotalElemsPerThread(type);
+  unsigned resultElemsPerThread = totalElemsPerThread / axisElemsPerThread;
+  auto threadsPerWarp = getThreadsPerWarp(type.getEncoding(), type.getShape());
+  auto warpsPerCTA = getWarpsPerCTA(type.getEncoding(), type.getShape());
+  unsigned communicationStages = llvm::Log2_64_Ceil(threadsPerWarp[axis]) +
+                                 llvm::Log2_64_Ceil(warpsPerCTA[axis]);
+  int64_t localCombines = resultElemsPerThread * (axisElemsPerThread - 1);
+  int64_t communication = 2 * resultElemsPerThread * communicationStages;
+  return localCombines + communication;
+}
+
+static int64_t getSliceWorkCost(const SetVector<Value> &slice,
+                                const DenseMap<Value, Attribute> &layouts,
+                                bool useCandidateLayouts) {
+  int64_t cost = 0;
+  for (Value value : slice) {
+    Operation *op = value.getDefiningOp();
+    if (!op || isa<DescriptorLoadOp, arith::ConstantOp>(op))
+      continue;
+    auto type = dyn_cast<RankedTensorType>(value.getType());
+    if (!type)
+      continue;
+    if (useCandidateLayouts)
+      type = type.cloneWithEncoding(layouts.lookup(value));
+    cost += getTotalElemsPerThread(type);
+  }
+  return cost;
+}
+
+static std::optional<DescriptorReductionLayoutCandidate>
+analyzeDescriptorReductionLayout(ReduceOp reduce,
+                                 BlockedEncodingAttr candidateEncoding) {
+  Operation *combiner = reduce.getSingleCombiner();
+  if (!combiner ||
+      !isa<arith::AddFOp, arith::MulFOp, arith::MaximumFOp, arith::MaxNumFOp,
+           arith::MinimumFOp, arith::MinNumFOp, arith::AddIOp, arith::MulIOp,
+           arith::MaxSIOp, arith::MinSIOp, arith::MaxUIOp, arith::MinUIOp>(
+          combiner))
+    return std::nullopt;
+  if (!ReduceOpHelper(reduce).isAssociative())
+    return std::nullopt;
+
+  SetVector<Value> slice;
+  DenseMap<Value, Attribute> layouts;
+  for (OpOperand &operand : reduce->getOpOperands()) {
+    auto stopAtDescriptor = [](Operation *op) {
+      return isa<DescriptorLoadOp>(op);
+    };
+    if (failed(getConvertBackwardSlice(operand, slice, candidateEncoding,
+                                       layouts, stopAtDescriptor))) {
+      LDBG("candidate backward slice failed");
+      return std::nullopt;
+    }
+  }
+
+  DenseSet<Operation *> sliceOps;
+  llvm::MapVector<Operation *, Value> descriptorResults;
+  for (Value value : slice) {
+    Operation *op = value.getDefiningOp();
+    if (!op) {
+      LDBG("candidate slice reached a block argument");
+      return std::nullopt;
+    }
+    sliceOps.insert(op);
+    if (isa<DescriptorLoadOp>(op)) {
+      if (op->getNumResults() != 1 || value != op->getResult(0)) {
+        LDBG("candidate found unsupported descriptor result");
+        return std::nullopt;
+      }
+      descriptorResults.try_emplace(op, value);
+      continue;
+    }
+    if (!isMemoryEffectFree(op)) {
+      LDBG("candidate found effectful interior op " << *op);
+      return std::nullopt;
+    }
+  }
+  if (descriptorResults.empty()) {
+    LDBG("candidate found no descriptor root");
+    return std::nullopt;
+  }
+
+  // Changing the layout of a descriptor result with an external user would
+  // leave a full-tensor conversion on that path. Defer those DAGs until the
+  // model can account for their conversion cost explicitly.
+  for (Value value : slice) {
+    for (Operation *user : value.getUsers()) {
+      if (user != reduce && !sliceOps.contains(user)) {
+        LDBG("candidate slice has external user " << *user);
+        return std::nullopt;
+      }
+    }
+  }
+
+  int64_t currentCost =
+      getSliceWorkCost(slice, layouts, /*useCandidateLayouts=*/false);
+  int64_t candidateCost =
+      getSliceWorkCost(slice, layouts, /*useCandidateLayouts=*/true);
+
+  for (Value operand : reduce->getOperands()) {
+    auto currentType = cast<RankedTensorType>(operand.getType());
+    currentCost += getReductionCost(currentType, reduce.getAxis());
+    candidateCost += getReductionCost(
+        currentType.cloneWithEncoding(candidateEncoding), reduce.getAxis());
+  }
+
+  Attribute candidateResultEncoding =
+      inferDstEncoding(reduce, candidateEncoding);
+  if (!candidateResultEncoding)
+    return std::nullopt;
+  for (Value result : reduce->getResults()) {
+    auto currentType = cast<RankedTensorType>(result.getType());
+    auto candidateType = currentType.cloneWithEncoding(candidateResultEncoding);
+    // Layouts may replicate values differently. Treat the conversion as free
+    // only when register reordering is sufficient in both directions; this
+    // conservatively accounts for communication needed to create or remove
+    // replicated values.
+    if (!cvtReordersRegisters(candidateType, currentType) ||
+        !cvtReordersRegisters(currentType, candidateType)) {
+      candidateCost += 2 * std::max(getTotalElemsPerThread(candidateType),
+                                    getTotalElemsPerThread(currentType));
+    }
+  }
+
+  SmallVector<std::pair<Operation *, Attribute>> descriptorLayouts;
+  for (auto [op, value] : descriptorResults) {
+    auto currentType = cast<RankedTensorType>(value.getType());
+    auto candidateType = currentType.cloneWithEncoding(layouts.lookup(value));
+    auto candidateBlocked =
+        dyn_cast<BlockedEncodingAttr>(candidateType.getEncoding());
+    if (!candidateBlocked)
+      return std::nullopt;
+    // Preserve at least one 32-bit shared-memory bank access. Sub-bank scalar
+    // accesses do not reduce shared-memory traffic and create long serial
+    // reduction chains for narrow element types.
+    if (candidateBlocked.getSizePerThread()[candidateBlocked.getOrder()[0]] *
+            candidateType.getElementTypeBitWidth() <
+        32)
+      return std::nullopt;
+    currentCost += getDescriptorLoadCost(currentType);
+    candidateCost += getDescriptorLoadCost(candidateType);
+    descriptorLayouts.emplace_back(op, candidateType.getEncoding());
+  }
+
+  LDBG("candidate " << candidateEncoding << " costs " << candidateCost
+                    << " vs current " << currentCost);
+  if (candidateCost >= currentCost)
+    return std::nullopt;
+  return DescriptorReductionLayoutCandidate{currentCost - candidateCost,
+                                            std::move(descriptorLayouts)};
+}
+
+static SmallVector<BlockedEncodingAttr>
+getDescriptorReductionLayoutCandidates(ReduceOp reduce) {
+  auto srcType = cast<RankedTensorType>(reduce.getOperand(0).getType());
+  auto current = dyn_cast<BlockedEncodingAttr>(srcType.getEncoding());
+  if (!current || !isa<RankedTensorType>(reduce->getResult(0).getType()) ||
+      srcType.getRank() < 2)
+    return {};
+
+  unsigned axis = reduce.getAxis();
+  if (getCTASplitNum(current)[axis] != 1)
+    return {};
+
+  auto order = llvm::to_vector(current.getOrder());
+  unsigned contiguousDim = order.front();
+  if (axis == contiguousDim)
+    return {};
+  llvm::erase(order, axis);
+  order.push_back(axis);
+
+  auto sizePerThread = llvm::to_vector(current.getSizePerThread());
+  for (unsigned dim = 0; dim < sizePerThread.size(); ++dim) {
+    if (dim != contiguousDim && sizePerThread[dim] != 1)
+      return {};
+  }
+
+  auto module = reduce->getParentOfType<ModuleOp>();
+  int numWarps = lookupNumWarps(reduce);
+  int threadsPerWarp = TritonGPUDialect::getThreadsPerWarp(module);
+  auto cgaLayout = getCGALayout(current);
+  unsigned maxVectorWidth = sizePerThread[contiguousDim];
+
+  llvm::SmallSetVector<Attribute, 8> uniqueCandidates;
+  for (unsigned vectorWidth = 1; vectorWidth <= maxVectorWidth;
+       vectorWidth *= 2) {
+    SmallVector<unsigned> candidateSizePerThread(srcType.getRank(), 1);
+    candidateSizePerThread[contiguousDim] = vectorWidth;
+    auto candidate = BlockedEncodingAttr::get(
+        srcType.getContext(), srcType.getShape(), candidateSizePerThread, order,
+        numWarps, threadsPerWarp, cgaLayout);
+    if (candidate != current)
+      uniqueCandidates.insert(candidate);
+  }
+
+  SmallVector<BlockedEncodingAttr> candidates;
+  for (Attribute candidate : uniqueCandidates)
+    candidates.push_back(cast<BlockedEncodingAttr>(candidate));
+  return candidates;
+}
+
+static void optimizeDescriptorReductionLayouts(ModuleOp module) {
+  auto target = module->getAttrOfType<StringAttr>(AttrTargetName);
+  if (!target || !target.getValue().starts_with("cuda:"))
+    return;
+
+  SmallVector<ReduceOp> reductions;
+  module.walk([&](ReduceOp reduce) { reductions.push_back(reduce); });
+
+  llvm::MapVector<Operation *, Attribute> selectedLayouts;
+  DenseSet<Operation *> conflicts;
+  for (ReduceOp reduce : reductions) {
+    std::optional<DescriptorReductionLayoutCandidate> best;
+    for (BlockedEncodingAttr candidate :
+         getDescriptorReductionLayoutCandidates(reduce)) {
+      LDBG("considering candidate " << candidate << " for " << reduce);
+      auto analyzed = analyzeDescriptorReductionLayout(reduce, candidate);
+      if (analyzed && (!best || analyzed->saving > best->saving))
+        best = std::move(analyzed);
+    }
+    if (!best)
+      continue;
+
+    // A descriptor can currently be selected by at most one reduction:
+    // analyzeDescriptorReductionLayout's external-user check bails whenever a
+    // descriptor result feeds anything other than the single reduction being
+    // analyzed, so two reductions can never both claim the same descriptor.
+    // The conflict tracking here is therefore defensive -- it keeps the rewrite
+    // correct if that guard is ever relaxed to allow shared descriptors.
+    for (auto [descriptor, encoding] : best->descriptorLayouts) {
+      auto [it, inserted] = selectedLayouts.try_emplace(descriptor, encoding);
+      if (!inserted && it->second != encoding)
+        conflicts.insert(descriptor);
+    }
+  }
+
+  for (auto [descriptor, encoding] : selectedLayouts) {
+    if (!conflicts.contains(descriptor)) {
+      LDBG("selecting descriptor layout " << encoding << " for "
+                                          << *descriptor);
+      convertDistributedOpEncoding(encoding, descriptor);
+    }
+  }
+}
+
 class TritonGPUOptimizeThreadLocalityPass
     : public impl::TritonGPUOptimizeThreadLocalityBase<
           TritonGPUOptimizeThreadLocalityPass> {
@@ -249,6 +527,11 @@ class TritonGPUOptimizeThreadLocalityPass
     if (mlir::applyPatternsGreedily(mod, std::move(layoutPatterns)).failed()) {
       signalPassFailure();
     }
+
+    // Rewrite only descriptor roots here. The following
+    // RemoveLayoutConversions pass propagates the selected layout through the
+    // consumer slice and removes the conversions introduced by the rewrite.
+    optimizeDescriptorReductionLayouts(mod);
 
     DenseSet<triton::ReduceOp> reduceOps;
     mod.walk([&](triton::ReduceOp reduce) -> void {

--- a/python/test/unit/language/test_tensor_descriptor.py
+++ b/python/test/unit/language/test_tensor_descriptor.py
@@ -56,6 +56,50 @@ def test_tensor_descriptor_load(dtype_str, num_ctas, M_BLOCK, N_BLOCK, device):
     torch.testing.assert_close(expect, unwrap_tensor(out))
 
 
+@pytest.mark.parametrize("dtype_str,M_BLOCK,N_BLOCK,REDUCE_AXIS", [
+    ("bfloat16", 32, 128, 1),
+    ("bfloat16", 64, 128, 1),
+    ("float32", 32, 64, 1),
+    ("bfloat16", 32, 128, 2),
+])
+def test_tensor_descriptor_load_partial_reduce(dtype_str, M_BLOCK, N_BLOCK, REDUCE_AXIS, device):
+
+    @triton.jit
+    def kernel(out_ptr, desc, M: tl.constexpr, N: tl.constexpr, M_BLOCK: tl.constexpr, N_BLOCK: tl.constexpr,
+               REDUCE_AXIS: tl.constexpr):
+        pid = tl.program_id(0)
+        num_n_blocks: tl.constexpr = N // N_BLOCK
+        pid_m = pid // num_n_blocks
+        pid_n = pid % num_n_blocks
+        offset_m = pid_m * M_BLOCK
+        offset_n = pid_n * N_BLOCK
+
+        block = desc.load([0, offset_m, offset_n]).to(tl.float32)
+        block_max = tl.max(block, axis=REDUCE_AXIS)
+        if REDUCE_AXIS == 1:
+            offsets_n = offset_n + tl.arange(0, N_BLOCK)
+            tl.store(out_ptr + pid_m * N + offsets_n, tl.reshape(block_max, [N_BLOCK]))
+        else:
+            offsets_m = tl.arange(0, M_BLOCK)
+            tl.store(out_ptr + pid * M_BLOCK + offsets_m, tl.reshape(block_max, [M_BLOCK]))
+
+    M, N = 2 * M_BLOCK, 2 * N_BLOCK
+    inp = torch.randn((1, M, N), dtype=getattr(torch, dtype_str), device=device)
+    desc = TensorDescriptor(inp, inp.shape, inp.stride(), [1, M_BLOCK, N_BLOCK])
+    grid = ((M // M_BLOCK) * (N // N_BLOCK), )
+    out_shape = (M // M_BLOCK, N) if REDUCE_AXIS == 1 else (grid[0], M_BLOCK)
+    out = torch.empty(out_shape, dtype=torch.float32, device=device)
+
+    kernel[grid](out, desc, M, N, M_BLOCK, N_BLOCK, REDUCE_AXIS, num_warps=4)
+
+    if REDUCE_AXIS == 1:
+        expect = inp.reshape(M // M_BLOCK, M_BLOCK, N).float().amax(dim=1)
+    else:
+        expect = inp.reshape(M // M_BLOCK, M_BLOCK, N // N_BLOCK, N_BLOCK)
+        expect = expect.float().amax(dim=3).permute(0, 2, 1).reshape(out_shape)
+    torch.testing.assert_close(expect, out, rtol=0, atol=0)
+
+
 @pytest.mark.interpreter
 @pytest.mark.parametrize("dtype_str", tma_dtypes)
 @pytest.mark.parametrize("num_ctas", [1, 2])

--- a/test/TritonGPU/optimize-locality.mlir
+++ b/test/TritonGPU/optimize-locality.mlir
@@ -1,4 +1,5 @@
 // RUN: triton-opt %s -split-input-file -tritongpu-optimize-thread-locality -canonicalize | FileCheck %s
+// RUN: triton-opt %s -split-input-file -tritongpu-optimize-thread-locality -tritongpu-remove-layout-conversions | FileCheck %s --check-prefix=DESC
 
 // CHECK-LABEL: negative_zero_accumulator
 // CHECK: %[[INIT_ARG:.*]] = arith.constant dense<0.000000e+00>
@@ -48,6 +49,139 @@ module attributes {"ttg.target" = "cuda:80", "ttg.num-ctas" = 1 : i32, "ttg.num-
     tt.store %25, %26 : tensor<32x!tt.ptr<f32>, #blocked1>
     tt.return
   }
+}
+
+// -----
+
+#descriptor_vec8 = #ttg.blocked<{sizePerThread = [1, 1, 8], threadsPerWarp = [1, 2, 16], warpsPerCTA = [1, 4, 1], order = [2, 1, 0]}>
+
+// DESC: #[[$REDUCE_FRIENDLY:.+]] = #ttg.blocked<{sizePerThread = [1, 1, 2], threadsPerWarp = [1, 1, 32], warpsPerCTA = [1, 2, 2], order = [2, 0, 1]}>
+
+module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.target = "cuda:100", "ttg.threads-per-warp" = 32 : i32} {
+
+// DESC-LABEL: descriptor_load_partial_reduce
+tt.func @descriptor_load_partial_reduce(%desc: !tt.tensordesc<1x32x128xbf16>, %idx: i32) -> tensor<1x128xf32, #ttg.slice<{dim = 1, parent = #descriptor_vec8}>> {
+  // DESC: %[[LOAD:.+]] = tt.descriptor_load {{.*}} -> tensor<1x32x128xbf16, #[[$REDUCE_FRIENDLY]]>
+  // DESC-NEXT: %[[EXT:.+]] = arith.extf %[[LOAD]] : tensor<1x32x128xbf16, #[[$REDUCE_FRIENDLY]]> to tensor<1x32x128xf32, #[[$REDUCE_FRIENDLY]]>
+  %0 = tt.descriptor_load %desc[%idx, %idx, %idx] : !tt.tensordesc<1x32x128xbf16> -> tensor<1x32x128xbf16, #descriptor_vec8>
+  %1 = arith.extf %0 : tensor<1x32x128xbf16, #descriptor_vec8> to tensor<1x32x128xf32, #descriptor_vec8>
+  // DESC-NEXT: %[[REDUCE:.+]] = "tt.reduce"(%[[EXT]]) <{axis = 1 : i32}>
+  %2 = "tt.reduce"(%1) <{axis = 1 : i32}> ({
+  ^bb0(%lhs: f32, %rhs: f32):
+    %max = arith.maximumf %lhs, %rhs : f32
+    tt.reduce.return %max : f32
+  }) : (tensor<1x32x128xf32, #descriptor_vec8>) -> tensor<1x128xf32, #ttg.slice<{dim = 1, parent = #descriptor_vec8}>>
+  // DESC: ttg.convert_layout %[[REDUCE]] : tensor<1x128xf32, #ttg.slice<{dim = 1, parent = #[[$REDUCE_FRIENDLY]]}>>
+  tt.return %2 : tensor<1x128xf32, #ttg.slice<{dim = 1, parent = #descriptor_vec8}>>
+}
+
+}
+
+// -----
+
+#descriptor_vec8 = #ttg.blocked<{sizePerThread = [1, 1, 8], threadsPerWarp = [1, 2, 16], warpsPerCTA = [1, 4, 1], order = [2, 1, 0]}>
+
+// DESC: #[[$LARGE_REDUCTION:.+]] = #ttg.blocked<{sizePerThread = [1, 1, 4], threadsPerWarp = [1, 1, 32], warpsPerCTA = [1, 4, 1], order = [2, 0, 1]}>
+
+module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.target = "cuda:100", "ttg.threads-per-warp" = 32 : i32} {
+
+// DESC-LABEL: descriptor_load_large_partial_reduce
+tt.func @descriptor_load_large_partial_reduce(%desc: !tt.tensordesc<1x64x128xbf16>, %idx: i32) -> tensor<1x128xf32, #ttg.slice<{dim = 1, parent = #descriptor_vec8}>> {
+  // DESC: %[[LOAD:.+]] = tt.descriptor_load {{.*}} -> tensor<1x64x128xbf16, #[[$LARGE_REDUCTION]]>
+  // DESC-NEXT: %[[EXT_LARGE:.+]] = arith.extf %[[LOAD]] : tensor<1x64x128xbf16, #[[$LARGE_REDUCTION]]> to tensor<1x64x128xf32, #[[$LARGE_REDUCTION]]>
+  %0 = tt.descriptor_load %desc[%idx, %idx, %idx] : !tt.tensordesc<1x64x128xbf16> -> tensor<1x64x128xbf16, #descriptor_vec8>
+  %1 = arith.extf %0 : tensor<1x64x128xbf16, #descriptor_vec8> to tensor<1x64x128xf32, #descriptor_vec8>
+  // DESC-NEXT: "tt.reduce"(%[[EXT_LARGE]]) <{axis = 1 : i32}>
+  %2 = "tt.reduce"(%1) <{axis = 1 : i32}> ({
+  ^bb0(%lhs: f32, %rhs: f32):
+    %max = arith.maximumf %lhs, %rhs : f32
+    tt.reduce.return %max : f32
+  }) : (tensor<1x64x128xf32, #descriptor_vec8>) -> tensor<1x128xf32, #ttg.slice<{dim = 1, parent = #descriptor_vec8}>>
+  tt.return %2 : tensor<1x128xf32, #ttg.slice<{dim = 1, parent = #descriptor_vec8}>>
+}
+
+}
+
+// -----
+
+#descriptor_vec8 = #ttg.blocked<{sizePerThread = [1, 1, 8], threadsPerWarp = [1, 2, 16], warpsPerCTA = [1, 4, 1], order = [2, 1, 0]}>
+
+// DESC: #[[$UNCHANGED:.+]] = #ttg.blocked<{sizePerThread = [1, 1, 8], threadsPerWarp = [1, 2, 16], warpsPerCTA = [1, 4, 1], order = [2, 1, 0]}>
+
+module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.target = "cuda:100", "ttg.threads-per-warp" = 32 : i32} {
+
+// DESC-LABEL: descriptor_load_multiple_users
+tt.func @descriptor_load_multiple_users(%desc: !tt.tensordesc<1x32x128xbf16>, %idx: i32) -> (tensor<1x128xf32, #ttg.slice<{dim = 1, parent = #descriptor_vec8}>>, tensor<1x32x128xf32, #descriptor_vec8>) {
+  // DESC: %[[LOAD:.+]] = tt.descriptor_load {{.*}} -> tensor<1x32x128xbf16, #[[$UNCHANGED]]>
+  // DESC-NEXT: %[[EXT_UNCHANGED:.+]] = arith.extf %[[LOAD]] : tensor<1x32x128xbf16, #[[$UNCHANGED]]> to tensor<1x32x128xf32, #[[$UNCHANGED]]>
+  %0 = tt.descriptor_load %desc[%idx, %idx, %idx] : !tt.tensordesc<1x32x128xbf16> -> tensor<1x32x128xbf16, #descriptor_vec8>
+  %1 = arith.extf %0 : tensor<1x32x128xbf16, #descriptor_vec8> to tensor<1x32x128xf32, #descriptor_vec8>
+  // DESC-NEXT: "tt.reduce"(%[[EXT_UNCHANGED]]) <{axis = 1 : i32}>
+  %2 = "tt.reduce"(%1) <{axis = 1 : i32}> ({
+  ^bb0(%lhs: f32, %rhs: f32):
+    %max = arith.maximumf %lhs, %rhs : f32
+    tt.reduce.return %max : f32
+  }) : (tensor<1x32x128xf32, #descriptor_vec8>) -> tensor<1x128xf32, #ttg.slice<{dim = 1, parent = #descriptor_vec8}>>
+  // DESC-NOT: ttg.convert_layout
+  // DESC: tt.return
+  tt.return %2, %1 : tensor<1x128xf32, #ttg.slice<{dim = 1, parent = #descriptor_vec8}>>, tensor<1x32x128xf32, #descriptor_vec8>
+}
+
+}
+
+// -----
+
+#descriptor_vec8 = #ttg.blocked<{sizePerThread = [1, 1, 8], threadsPerWarp = [1, 2, 16], warpsPerCTA = [1, 4, 1], order = [2, 1, 0]}>
+
+// DESC: #[[$MULTI_RESULT:.+]] = #ttg.blocked<{sizePerThread = [1, 1, 8], threadsPerWarp = [1, 2, 16], warpsPerCTA = [1, 4, 1], order = [2, 1, 0]}>
+
+module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.target = "cuda:100", "ttg.threads-per-warp" = 32 : i32} {
+
+// DESC-LABEL: descriptor_load_multi_result_reduce
+tt.func @descriptor_load_multi_result_reduce(%desc: !tt.tensordesc<1x32x128xbf16>, %idx: i32) -> (tensor<1x128xf32, #ttg.slice<{dim = 1, parent = #descriptor_vec8}>>, tensor<1x128xf32, #ttg.slice<{dim = 1, parent = #descriptor_vec8}>>) {
+  // DESC: %[[LOAD_MULTI:.+]] = tt.descriptor_load {{.*}} -> tensor<1x32x128xbf16, #[[$MULTI_RESULT]]>
+  // DESC-NEXT: %[[EXT_MULTI:.+]] = arith.extf %[[LOAD_MULTI]] : tensor<1x32x128xbf16, #[[$MULTI_RESULT]]> to tensor<1x32x128xf32, #[[$MULTI_RESULT]]>
+  %0 = tt.descriptor_load %desc[%idx, %idx, %idx] : !tt.tensordesc<1x32x128xbf16> -> tensor<1x32x128xbf16, #descriptor_vec8>
+  %1 = arith.extf %0 : tensor<1x32x128xbf16, #descriptor_vec8> to tensor<1x32x128xf32, #descriptor_vec8>
+  // DESC-NEXT: %{{.*}}:2 = "tt.reduce"(%[[EXT_MULTI]], %[[EXT_MULTI]]) <{axis = 1 : i32}>
+  %2:2 = "tt.reduce"(%1, %1) <{axis = 1 : i32}> ({
+  ^bb0(%lhs0: f32, %lhs1: f32, %rhs0: f32, %rhs1: f32):
+    %max0 = arith.maximumf %lhs0, %rhs0 : f32
+    %max1 = arith.maximumf %lhs1, %rhs1 : f32
+    tt.reduce.return %max0, %max1 : f32, f32
+  }) : (tensor<1x32x128xf32, #descriptor_vec8>, tensor<1x32x128xf32, #descriptor_vec8>) -> (tensor<1x128xf32, #ttg.slice<{dim = 1, parent = #descriptor_vec8}>>, tensor<1x128xf32, #ttg.slice<{dim = 1, parent = #descriptor_vec8}>>)
+  // DESC-NOT: ttg.convert_layout
+  // DESC: tt.return
+  tt.return %2#0, %2#1 : tensor<1x128xf32, #ttg.slice<{dim = 1, parent = #descriptor_vec8}>>, tensor<1x128xf32, #ttg.slice<{dim = 1, parent = #descriptor_vec8}>>
+}
+
+}
+
+// -----
+
+#descriptor_cross_cta = #ttg.blocked<{sizePerThread = [1, 1, 8], threadsPerWarp = [1, 2, 16], warpsPerCTA = [1, 4, 1], order = [2, 1, 0], CGALayout = [[0, 1, 0]]}>
+
+// DESC: #[[$CROSS_CTA:.+]] = #ttg.blocked<{sizePerThread = [1, 1, 8], threadsPerWarp = [1, 2, 16], warpsPerCTA = [1, 4, 1], order = [2, 1, 0], CGALayout = {{\[\[0, 1, 0\]\]}}}>
+
+module attributes {"ttg.num-ctas" = 2 : i32, "ttg.num-warps" = 4 : i32, ttg.target = "cuda:100", "ttg.threads-per-warp" = 32 : i32} {
+
+// DESC-LABEL: descriptor_load_cross_cta_reduce
+tt.func @descriptor_load_cross_cta_reduce(%desc: !tt.tensordesc<1x32x128xbf16>, %idx: i32) -> tensor<1x128xf32, #ttg.slice<{dim = 1, parent = #descriptor_cross_cta}>> {
+  // DESC: %[[LOAD:.+]] = tt.descriptor_load {{.*}} -> tensor<1x32x128xbf16, #[[$CROSS_CTA]]>
+  // DESC-NEXT: %[[EXT_CROSS:.+]] = arith.extf %[[LOAD]] : tensor<1x32x128xbf16, #[[$CROSS_CTA]]> to tensor<1x32x128xf32, #[[$CROSS_CTA]]>
+  %0 = tt.descriptor_load %desc[%idx, %idx, %idx] : !tt.tensordesc<1x32x128xbf16> -> tensor<1x32x128xbf16, #descriptor_cross_cta>
+  %1 = arith.extf %0 : tensor<1x32x128xbf16, #descriptor_cross_cta> to tensor<1x32x128xf32, #descriptor_cross_cta>
+  // DESC-NEXT: "tt.reduce"(%[[EXT_CROSS]]) <{axis = 1 : i32}>
+  %2 = "tt.reduce"(%1) <{axis = 1 : i32}> ({
+  ^bb0(%lhs: f32, %rhs: f32):
+    %max = arith.maximumf %lhs, %rhs : f32
+    tt.reduce.return %max : f32
+  }) : (tensor<1x32x128xf32, #descriptor_cross_cta>) -> tensor<1x128xf32, #ttg.slice<{dim = 1, parent = #descriptor_cross_cta}>>
+  // DESC-NOT: ttg.convert_layout
+  // DESC: tt.return
+  tt.return %2 : tensor<1x128xf32, #ttg.slice<{dim = 1, parent = #descriptor_cross_cta}>>
+}
+
 }
 
 // -----
@@ -784,6 +918,34 @@ tt.func @skip_optimize_on_1d_tensor(%arg0: tensor<256xf32, #blocked>, %arg1: ten
   // CHECK: tt.gather {{.*}} [[LAYOUT]]>
   %0 = tt.gather %arg0[%arg1] {axis = 0 : i32} : (tensor<256xf32, #blocked>, tensor<8xi32, #blocked>) -> tensor<8xf32, #blocked>
   tt.return %0 : tensor<8xf32, #blocked>
+}
+
+}
+
+// -----
+
+#descriptor_i32 = #ttg.blocked<{sizePerThread = [1, 1, 4], threadsPerWarp = [1, 2, 16], warpsPerCTA = [1, 4, 1], order = [2, 1, 0]}>
+
+// DESC: #[[$INT_REDUCTION:.+]] = #ttg.blocked<{sizePerThread = [1, 1, 1], threadsPerWarp = [1, 1, 32], warpsPerCTA = [1, 1, 4], order = [2, 0, 1]}>
+
+module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.target = "cuda:100", "ttg.threads-per-warp" = 32 : i32} {
+
+// Integer reductions exercise the integer combiner allowlist and the integer
+// inferDstEncoding path. A 32-bit element keeps a full shared-memory bank even
+// at vector width 1, so the descriptor is still moved to a reduction-friendly
+// layout.
+// DESC-LABEL: descriptor_load_integer_partial_reduce
+tt.func @descriptor_load_integer_partial_reduce(%desc: !tt.tensordesc<1x64x128xi32>, %idx: i32) -> tensor<1x128xi32, #ttg.slice<{dim = 1, parent = #descriptor_i32}>> {
+  // DESC: %[[LOAD:.+]] = tt.descriptor_load {{.*}} -> tensor<1x64x128xi32, #[[$INT_REDUCTION]]>
+  %0 = tt.descriptor_load %desc[%idx, %idx, %idx] : !tt.tensordesc<1x64x128xi32> -> tensor<1x64x128xi32, #descriptor_i32>
+  // DESC-NEXT: %[[REDUCE:.+]] = "tt.reduce"(%[[LOAD]]) <{axis = 1 : i32}>
+  %2 = "tt.reduce"(%0) <{axis = 1 : i32}> ({
+  ^bb0(%lhs: i32, %rhs: i32):
+    %max = arith.maxsi %lhs, %rhs : i32
+    tt.reduce.return %max : i32
+  }) : (tensor<1x64x128xi32, #descriptor_i32>) -> tensor<1x128xi32, #ttg.slice<{dim = 1, parent = #descriptor_i32}>>
+  // DESC: ttg.convert_layout %[[REDUCE]] : tensor<1x128xi32, #ttg.slice<{dim = 1, parent = #[[$INT_REDUCTION]]}>>
+  tt.return %2 : tensor<1x128xi32, #ttg.slice<{dim = 1, parent = #descriptor_i32}>>
 }
 
 }


### PR DESCRIPTION
## Summary

Add consumer-aware layout selection for CUDA descriptor loads feeding partial reductions. `OptimizeThreadLocality` evaluates partially vectorized blocked layouts using descriptor-load, elementwise, reduction, and output-conversion costs.

The initial scope is conservative: plain descriptor loads, blocked layouts, simple associative reductions, and single-consumer DAGs. Cross-CTA, contiguous-axis, and non-CUDA cases are skipped. `Coalesce` remains focused on memory access, while `RemoveLayoutConversions` propagates the selected layout.

## Performance

RTX 5090, bf16 input, fp32 max reduction, four warps, 100 CUDA graph repetitions:

| Shape / tile | main | this PR | change |
|---|---:|---:|---:|
| 8192x8192, BM32 BN128 | 0.083279 ms | 0.083189 ms | neutral |
| 2048x2048, BM32 BN128 | 0.002816 ms | 0.002379 ms | -15.5% |
| 1024x1024, BM32 BN128 | 0.001672 ms | 0.001486 ms | -11.1% |
| 2048x2048, BM32 BN64 | 0.003369 ms | 0.002435 ms | -27.7% |
| 2048x2048, BM16 BN128 | 0.003504 ms | 0.002280 ms | -34.9% |
| 2048x2048, BM64 BN128 | 0.002594 ms | 0.002432 ms | -6.2% |

For the issue configuration, the selected vec2 layout reduces PTX shuffle sites from 25 to 3 and barriers from 13 to 9. All outputs exactly matched `torch.amax`.

# New contributor declaration
- [x] I am not making a trivial change, such as fixing a typo in a comment.

- [x] I have written a PR description following these
  [rules](https://cbea.ms/git-commit/#why-not-how).

- [x] I have run `pre-commit run --from-ref origin/main --to-ref HEAD`.

- Select one of the following.
  - [x] I have added tests.
    - `/test` for `lit` tests
    - `/unittest` for C++ tests
    - `/python/test` for end-to-end tests
  - [ ] This PR does not need a test because `FILL THIS IN`.

- Select one of the following.
  - [ ] I have not added any `lit` tests.
  - [x] The `lit` tests I have added follow these [best practices](https://mlir.llvm.org/getting_started/TestingGuide/#filecheck-best-practices),
    including the "tests should be minimal" section. (Usually running Python code
    and using the instructions it generates is not minimal.)