### PR TITLE
[FPSAN] Model Float2 inline assembly

### DIFF
--- a/lib/Dialect/TritonInstrument/Transforms/FpSanitizer.cpp
+++ b/lib/Dialect/TritonInstrument/Transforms/FpSanitizer.cpp
@@ -12,8 +12,10 @@
 #include "triton/Dialect/TritonNvidiaGPU/IR/Dialect.h"
 #include "triton/Tools/LayoutUtils.h"
 #include "llvm/ADT/STLExtras.h"
+#include "llvm/ADT/SmallString.h"
 #include "llvm/ADT/StringSwitch.h"
 #include <cassert>
+#include <cctype>
 #include <functional>
 
 namespace mlir {
@@ -1848,6 +1850,165 @@ std::optional<scf::ForOp> emitMmaEmulationLoops(
 // Patterns
 //----------------------------------------
 
+enum class Float2AsmKind { Pack, Unpack, Add, Sub, Mul, Fma };
+
+std::optional<Float2AsmKind> getFloat2AsmKind(tt::ElementwiseInlineAsmOp op) {
+  if (!op.getPure() || op.getPackedElement() != 1)
+    return std::nullopt;
+
+  llvm::SmallString<64> asmString;
+  for (char c : op.getAsmString()) {
+    if (!std::isspace(static_cast<unsigned char>(c)))
+      asmString.push_back(c);
+  }
+
+  return llvm::StringSwitch<std::optional<Float2AsmKind>>(asmString)
+      .Case("mov.b64$0,{$1,$2};", op.getConstraints() == "=l,r,r"
+                                      ? std::optional(Float2AsmKind::Pack)
+                                      : std::nullopt)
+      .Case("mov.b64{$0,$1},$2;", op.getConstraints() == "=r,=r,l"
+                                      ? std::optional(Float2AsmKind::Unpack)
+                                      : std::nullopt)
+      .Case("add.f32x2$0,$1,$2;", op.getConstraints() == "=l,l,l"
+                                      ? std::optional(Float2AsmKind::Add)
+                                      : std::nullopt)
+      .Case("sub.f32x2$0,$1,$2;", op.getConstraints() == "=l,l,l"
+                                      ? std::optional(Float2AsmKind::Sub)
+                                      : std::nullopt)
+      .Case("mul.f32x2$0,$1,$2;", op.getConstraints() == "=l,l,l"
+                                      ? std::optional(Float2AsmKind::Mul)
+                                      : std::nullopt)
+      .Case("fma.rn.f32x2$0,$1,$2,$3;", op.getConstraints() == "=l,l,l,l"
+                                            ? std::optional(Float2AsmKind::Fma)
+                                            : std::nullopt)
+      .Default(std::nullopt);
+}
+
+bool hasElementType(Type type, RankedTensorType shape, Type elementType) {
+  return type == shape.clone(elementType);
+}
+
+Type getTypeWithElementOrSelf(Type type, Type elementType) {
+  if (auto tensorType = dyn_cast<RankedTensorType>(type))
+    return tensorType.clone(elementType);
+  return elementType;
+}
+
+Value packFloat2Payloads(PatternRewriter &rewriter, Location loc, Value low,
+                         Value high, Type packedType) {
+  Value low64 = arith::ExtUIOp::create(rewriter, loc, packedType, low);
+  Value high64 = arith::ExtUIOp::create(rewriter, loc, packedType, high);
+  Value shift = getIntConstantLike(rewriter, loc, packedType, 32);
+  high64 = arith::ShLIOp::create(rewriter, loc, high64, shift);
+  return arith::OrIOp::create(rewriter, loc, low64, high64);
+}
+
+std::pair<Value, Value> unpackFloat2Payloads(PatternRewriter &rewriter,
+                                             Location loc, Value packed,
+                                             Type payloadType) {
+  Value low = arith::TruncIOp::create(rewriter, loc, payloadType, packed);
+  Value shift = getIntConstantLike(rewriter, loc, packed.getType(), 32);
+  Value high = arith::ShRUIOp::create(rewriter, loc, packed, shift);
+  high = arith::TruncIOp::create(rewriter, loc, payloadType, high);
+  return {low, high};
+}
+
+struct Float2InlineAsmPattern
+    : public OpRewritePattern<tt::ElementwiseInlineAsmOp> {
+  using OpRewritePattern::OpRewritePattern;
+
+  LogicalResult matchAndRewrite(tt::ElementwiseInlineAsmOp op,
+                                PatternRewriter &rewriter) const override {
+    std::optional<Float2AsmKind> kind = getFloat2AsmKind(op);
+    if (!kind)
+      return failure();
+
+    auto i32 = rewriter.getI32Type();
+    auto i64 = rewriter.getI64Type();
+    auto f32 = rewriter.getF32Type();
+    auto loc = op.getLoc();
+
+    if (*kind == Float2AsmKind::Pack) {
+      if (op.getNumOperands() != 2 || op.getNumResults() != 1)
+        return failure();
+      auto packedType = dyn_cast<RankedTensorType>(op->getResult(0).getType());
+      if (!packedType || packedType.getElementType() != i64 ||
+          !hasElementType(op.getOperand(0).getType(), packedType, f32) ||
+          !hasElementType(op.getOperand(1).getType(), packedType, f32))
+        return failure();
+
+      Value low = embedToInt(rewriter, loc, op.getOperand(0));
+      Value high = embedToInt(rewriter, loc, op.getOperand(1));
+      rewriter.replaceOp(
+          op, packFloat2Payloads(rewriter, loc, low, high, packedType));
+      return success();
+    }
+
+    if (*kind == Float2AsmKind::Unpack) {
+      if (op.getNumOperands() != 1 || op.getNumResults() != 2)
+        return failure();
+      auto packedType = dyn_cast<RankedTensorType>(op.getOperand(0).getType());
+      if (!packedType || packedType.getElementType() != i64 ||
+          !hasElementType(op->getResult(0).getType(), packedType, f32) ||
+          !hasElementType(op->getResult(1).getType(), packedType, f32))
+        return failure();
+
+      auto payloadType = packedType.clone(i32);
+      auto [low, high] =
+          unpackFloat2Payloads(rewriter, loc, op.getOperand(0), payloadType);
+      SmallVector<Value> results = {
+          unembedToFloat(rewriter, loc, low, op->getResult(0).getType()),
+          unembedToFloat(rewriter, loc, high, op->getResult(1).getType())};
+      rewriter.replaceOp(op, results);
+      return success();
+    }
+
+    unsigned arity = *kind == Float2AsmKind::Fma ? 3 : 2;
+    if (op.getNumOperands() != arity || op.getNumResults() != 1)
+      return failure();
+    Type packedType = op->getResult(0).getType();
+    if ((!isa<IntegerType>(packedType) && !isa<RankedTensorType>(packedType)) ||
+        getElementTypeOrSelf(packedType) != i64 ||
+        !llvm::all_of(op.getOperandTypes(),
+                      [&](Type type) { return type == packedType; }))
+      return failure();
+
+    Type payloadType = getTypeWithElementOrSelf(packedType, i32);
+    SmallVector<std::pair<Value, Value>> lanes;
+    for (Value operand : op.getOperands())
+      lanes.push_back(
+          unpackFloat2Payloads(rewriter, loc, operand, payloadType));
+
+    auto applyLane = [&](unsigned lane) -> Value {
+      Value a = lane == 0 ? lanes[0].first : lanes[0].second;
+      Value b = lane == 0 ? lanes[1].first : lanes[1].second;
+      switch (*kind) {
+      case Float2AsmKind::Add:
+        return arith::AddIOp::create(rewriter, loc, a, b);
+      case Float2AsmKind::Sub:
+        return arith::SubIOp::create(rewriter, loc, a, b);
+      case Float2AsmKind::Mul:
+        return arith::MulIOp::create(rewriter, loc, a, b);
+      case Float2AsmKind::Fma: {
+        Value c = lane == 0 ? lanes[2].first : lanes[2].second;
+        Value product = arith::MulIOp::create(rewriter, loc, a, b);
+        return arith::AddIOp::create(rewriter, loc, product, c);
+      }
+      case Float2AsmKind::Pack:
+      case Float2AsmKind::Unpack:
+        llvm_unreachable("handled above");
+      }
+      llvm_unreachable("unknown Float2 inline assembly");
+    };
+
+    Value low = applyLane(0);
+    Value high = applyLane(1);
+    rewriter.replaceOp(
+        op, packFloat2Payloads(rewriter, loc, low, high, packedType));
+    return success();
+  }
+};
+
 template <typename OpF, typename OpI>
 struct BinaryFloatToIntPattern : public OpRewritePattern<OpF> {
   using OpRewritePattern<OpF>::OpRewritePattern;
@@ -3188,7 +3349,7 @@ public:
                  PreciseDivFOpPattern, RemFOpPattern, FmaPattern, ExpOpPattern,
                  Exp2OpPattern, CosOpPattern, SinOpPattern, ExtFOpPattern,
                  TruncFOpPattern, FpToFpPattern, Fp4ToFpPattern, DotPattern,
-                 DotScaledPattern>(&getContext());
+                 DotScaledPattern, Float2InlineAsmPattern>(&getContext());
     patterns.add<UnaryPattern<math::LogOp>>(&getContext(), UnaryOpId::Log);
     patterns.add<UnaryPattern<math::Log2Op>>(&getContext(), UnaryOpId::Log2);
     patterns.add<UnaryPattern<math::SqrtOp>>(&getContext(), UnaryOpId::Sqrt);

--- a/python/test/gluon/test_fpsan.py
+++ b/python/test/gluon/test_fpsan.py
@@ -16,6 +16,7 @@ from triton.experimental.gluon.language.nvidia.blackwell import (
     TensorMemoryLayout,
     TensorMemoryScalesLayout,
     allocate_tensor_memory,
+    float2,
     mbarrier,
     tcgen05_commit,
     tcgen05_copy,
@@ -569,6 +570,49 @@ def _binop_kernel(x_ptr, y_ptr, out_ptr, n_elements, OP: gl.constexpr, BLOCK: gl
     gl.store(out_ptr + offs, z, mask=mask)
 
 
+@gluon.jit
+def _float2_kernel(x_ptr, y_ptr, z_ptr, out_ptr, n_elements, OP: gl.constexpr, BLOCK: gl.constexpr,
+                   THREADS_PER_WARP: gl.constexpr):
+    layout: gl.constexpr = gl.BlockedLayout(size_per_thread=[2], threads_per_warp=[THREADS_PER_WARP], warps_per_cta=[4],
+                                            order=[0])
+    offs = gl.arange(0, BLOCK, layout=layout)
+    mask = offs < n_elements
+
+    x = float2.pack2(
+        gl.load(x_ptr + offs, mask=mask, other=0.0),
+        gl.load(x_ptr + n_elements + offs, mask=mask, other=0.0),
+    )
+    y = float2.pack2(
+        gl.load(y_ptr + offs, mask=mask, other=0.0),
+        gl.load(y_ptr + n_elements + offs, mask=mask, other=0.0),
+    )
+    z = float2.pack2(
+        gl.load(z_ptr + offs, mask=mask, other=0.0),
+        gl.load(z_ptr + n_elements + offs, mask=mask, other=0.0),
+    )
+
+    if OP == "identity":
+        result = x
+    elif OP == "add":
+        result = x + y
+    elif OP == "sub":
+        result = x - y
+    elif OP == "mul":
+        result = x * y
+    elif OP == "fma":
+        result = float2.fma(x, y, z)
+    elif OP == "reduce_add":
+        result = float2.Float2Tensor(gl.join(x.value, y.value)).sum(axis=1)
+    else:
+        gl.static_assert(False, "unsupported Float2 OP")
+
+    low, high = float2.unpack2(result)
+    low = gl.convert_layout(low, layout)
+    high = gl.convert_layout(high, layout)
+    gl.store(out_ptr + offs, low, mask=mask)
+    gl.store(out_ptr + n_elements + offs, high, mask=mask)
+
+
 @triton.jit
 def _clamp_kernel(x_ptr, lo_ptr, hi_ptr, out_ptr, n_elements, PROPAGATE_NAN: tl.constexpr, BLOCK: tl.constexpr):
     offs = tl.program_id(0) * BLOCK + tl.arange(0, BLOCK)
@@ -739,6 +783,45 @@ def test_binops_payload_semantics(device, op, expected_fn, fresh_knobs):
     out_np = out.cpu().numpy().astype(np.int32, copy=False)
     exp_np = expected_fn(x.cpu().numpy().astype(np.int32, copy=False), y.cpu().numpy().astype(np.int32, copy=False))
     _assert_payload_equal(out_np, exp_np)
+
+
+@pytest.mark.skipif(not is_blackwell(), reason="Requires Blackwell")
+@pytest.mark.parametrize("op", ["identity", "add", "sub", "mul", "fma", "reduce_add"])
+def test_float2_payload_semantics(device, op, fresh_knobs):
+    _require_cuda_backend(device)
+    fresh_knobs.compilation.instrumentation_mode = "fpsan"
+
+    n_elements = 256
+    g = torch.Generator(device="cuda")
+    g.manual_seed(37)
+    inputs = [
+        torch.randint(-(2**31), 2**31 - 1, (2, n_elements), dtype=torch.int32, device="cuda", generator=g)
+        for _ in range(3)
+    ]
+    out = torch.empty((2, n_elements), dtype=torch.int32, device="cuda")
+    wrapped = [triton.TensorWrapper(value, dtype=torch.float32) for value in inputs]
+
+    _float2_kernel[(1, )](
+        *wrapped,
+        triton.TensorWrapper(out, dtype=torch.float32),
+        n_elements,
+        OP=op,
+        BLOCK=n_elements,
+        THREADS_PER_WARP=THREADS_PER_WARP,
+    )
+
+    input_bits = [value.cpu().numpy().astype(np.int32, copy=False) for value in inputs]
+    if op == "identity":
+        expected = input_bits[0]
+    elif op in ("add", "reduce_add"):
+        expected = _expected_add_i32(input_bits[0], input_bits[1])
+    elif op == "sub":
+        expected = _expected_sub_i32(input_bits[0], input_bits[1])
+    elif op == "mul":
+        expected = _expected_mul_i32(input_bits[0], input_bits[1])
+    elif op == "fma":
+        expected = _expected_fma_i32(input_bits[0], input_bits[1], input_bits[2])
+    _assert_payload_equal(out, expected)
 
 
 @pytest.mark.parametrize("propagate_nan", [False, True], ids=["none", "all"])

--- a/test/TritonGPU/fpsan.mlir
+++ b/test/TritonGPU/fpsan.mlir
@@ -564,6 +564,67 @@ tt.func public @extern_unary_fallback(%a: tensor<4xf32>) -> tensor<4xf32> {
 
 // -----
 
+// CHECK-LABEL: @float2_pack_unpack
+tt.func public @float2_pack_unpack(%a: tensor<4xf32>, %b: tensor<4xf32>) -> (tensor<4xf32>, tensor<4xf32>) {
+  // CHECK-DAG: %[[A:.*]] = tti.experimental_fpsan_embed
+  // CHECK-DAG: %[[B:.*]] = tti.experimental_fpsan_embed
+  // CHECK-DAG: %[[A64:.*]] = arith.extui %[[A]]
+  // CHECK-DAG: %[[B64:.*]] = arith.extui %[[B]]
+  // CHECK: %[[SHIFTED:.*]] = arith.shli %[[B64]]
+  // CHECK: %[[PACKED:.*]] = arith.ori %[[A64]], %[[SHIFTED]]
+  // CHECK: %[[LOW:.*]] = arith.trunci %[[PACKED]]
+  // CHECK: %[[HIGH64:.*]] = arith.shrui %[[PACKED]]
+  // CHECK: %[[HIGH:.*]] = arith.trunci %[[HIGH64]]
+  // CHECK: %[[LOW_FLOAT:.*]] = tti.experimental_fpsan_unembed %[[LOW]]
+  // CHECK: %[[HIGH_FLOAT:.*]] = tti.experimental_fpsan_unembed %[[HIGH]]
+  // CHECK-NOT: tt.elementwise_inline_asm
+  // CHECK: tt.return %[[LOW_FLOAT]], %[[HIGH_FLOAT]]
+  %packed = tt.elementwise_inline_asm "mov.b64 $0, { $1, $2 };" {constraints = "=l,r,r", packed_element = 1 : i32, pure = true} %a, %b : tensor<4xf32>, tensor<4xf32> -> tensor<4xi64>
+  %low, %high = tt.elementwise_inline_asm "mov.b64 { $0, $1 }, $2;" {constraints = "=r,=r,l", packed_element = 1 : i32, pure = true} %packed : tensor<4xi64> -> tensor<4xf32>, tensor<4xf32>
+  tt.return %low, %high : tensor<4xf32>, tensor<4xf32>
+}
+
+// -----
+
+// CHECK-LABEL: @float2_arithmetic
+tt.func public @float2_arithmetic(%a: tensor<4xi64>, %b: tensor<4xi64>, %c: tensor<4xi64>) -> (tensor<4xi64>, tensor<4xi64>, tensor<4xi64>, tensor<4xi64>) {
+  // CHECK: arith.addi
+  // CHECK: arith.subi
+  // CHECK: arith.muli
+  // CHECK: arith.muli
+  // CHECK: arith.addi
+  // CHECK-NOT: tt.elementwise_inline_asm
+  %add = tt.elementwise_inline_asm "add.f32x2 $0, $1, $2;" {constraints = "=l,l,l", packed_element = 1 : i32, pure = true} %a, %b : tensor<4xi64>, tensor<4xi64> -> tensor<4xi64>
+  %sub = tt.elementwise_inline_asm "sub.f32x2 $0, $1, $2;" {constraints = "=l,l,l", packed_element = 1 : i32, pure = true} %a, %b : tensor<4xi64>, tensor<4xi64> -> tensor<4xi64>
+  %mul = tt.elementwise_inline_asm "mul.f32x2 $0, $1, $2;" {constraints = "=l,l,l", packed_element = 1 : i32, pure = true} %a, %b : tensor<4xi64>, tensor<4xi64> -> tensor<4xi64>
+  %fma = tt.elementwise_inline_asm "fma.rn.f32x2 $0, $1, $2, $3;" {constraints = "=l,l,l,l", packed_element = 1 : i32, pure = true} %a, %b, %c : tensor<4xi64>, tensor<4xi64>, tensor<4xi64> -> tensor<4xi64>
+  tt.return %add, %sub, %mul, %fma : tensor<4xi64>, tensor<4xi64>, tensor<4xi64>, tensor<4xi64>
+}
+
+// -----
+
+// CHECK-LABEL: @float2_scalar_add
+tt.func public @float2_scalar_add(%a: i64, %b: i64) -> i64 {
+  // CHECK: arith.trunci
+  // CHECK: arith.shrui
+  // CHECK: arith.addi
+  // CHECK-NOT: tt.elementwise_inline_asm
+  %add = tt.elementwise_inline_asm "add.f32x2 $0, $1, $2;" {constraints = "=l,l,l", packed_element = 1 : i32, pure = true} %a, %b : i64, i64 -> i64
+  tt.return %add : i64
+}
+
+// -----
+
+// CHECK-LABEL: @float2_near_matches_unchanged
+tt.func public @float2_near_matches_unchanged(%a: tensor<4xi64>, %b: tensor<4xi64>) -> (tensor<4xi64>, tensor<4xi64>) {
+  // CHECK-COUNT-2: tt.elementwise_inline_asm
+  %wrong_constraints = tt.elementwise_inline_asm "add.f32x2 $0, $1, $2;" {constraints = "=l,l,r", packed_element = 1 : i32, pure = true} %a, %b : tensor<4xi64>, tensor<4xi64> -> tensor<4xi64>
+  %wrong_asm = tt.elementwise_inline_asm "add.rn.f32x2 $0, $1, $2;" {constraints = "=l,l,l", packed_element = 1 : i32, pure = true} %a, %b : tensor<4xi64>, tensor<4xi64> -> tensor<4xi64>
+  tt.return %wrong_constraints, %wrong_asm : tensor<4xi64>, tensor<4xi64>
+}
+
+// -----
+
 // CHECK-LABEL: @extern_unary_known
 tt.func public @extern_unary_known(%a: tensor<4xf32>) -> tensor<4xf32> {
   // CHECK: tti.experimental_fpsan_embed


### PR DESCRIPTION
PR description written by Codex

Model the exact inline assembly emitted by Float2Tensor in FPSan payload space, including scalar reduction combiners, so optimized Float2 epilogues match scalar FPSan semantics.

Tests cover exact and near-match assembly forms plus Float2 pack, unpack, arithmetic, FMA, and reduction payload equivalence.
