### PR TITLE
[BACKEND] Fix multibuffer descriptor subslices

### DIFF
--- a/include/triton/Dialect/TritonGPU/IR/Dialect.h
+++ b/include/triton/Dialect/TritonGPU/IR/Dialect.h
@@ -269,6 +269,12 @@ SmallVector<int64_t> getShapePerCTA(ArrayRef<unsigned> CTASplitNum,
 SmallVector<int64_t> getShapePerCTA(Attribute layout, ArrayRef<int64_t> shape);
 SmallVector<int64_t> getShapePerCTA(Type type);
 
+// Returns the layout-ranked suffix, dropping a leading pipelining dimension.
+template <typename T>
+ArrayRef<T> dropPipeliningDim(ArrayRef<T> shape, Attribute layout) {
+  return shape.take_back(cast<LayoutEncodingTrait>(layout).getRank());
+}
+
 // Returns the shape per CTA, which is "physically" allocated.
 // Such shapes may be bigger than the logical one due to, for example, padding
 // in shared memory.

--- a/lib/Analysis/BufferRegion.cpp
+++ b/lib/Analysis/BufferRegion.cpp
@@ -97,6 +97,8 @@ FailureOr<uint32_t> getMemDescSubsliceByteOffset(ttg::MemDescSubsliceOp op) {
     return 0;
 
   Attribute encoding = srcTy.getEncoding();
+  auto layoutOffsets = ttg::dropPipeliningDim(offsets, encoding);
+  auto layoutRank = layoutOffsets.size();
   mlir::triton::LinearLayout layout;
   if (auto padded = dyn_cast<ttg::PaddedSharedEncodingAttr>(encoding)) {
     layout = padded.getLinearComponent();
@@ -106,10 +108,10 @@ FailureOr<uint32_t> getMemDescSubsliceByteOffset(ttg::MemDescSubsliceOp op) {
 
   MLIRContext *ctx = op->getContext();
   SmallVector<StringAttr> dimNames =
-      mlir::triton::standardOutDimNames(ctx, srcTy.getRank());
+      mlir::triton::standardOutDimNames(ctx, layoutRank);
   SmallVector<std::pair<StringAttr, int32_t>> logicalOffsets;
-  logicalOffsets.reserve(offsets.size());
-  for (auto &&[dimName, offset] : llvm::zip_equal(dimNames, offsets)) {
+  logicalOffsets.reserve(layoutRank);
+  for (auto &&[dimName, offset] : llvm::zip_equal(dimNames, layoutOffsets)) {
     logicalOffsets.push_back({dimName, static_cast<int32_t>(offset)});
   }
 
@@ -129,6 +131,11 @@ FailureOr<uint32_t> getMemDescSubsliceByteOffset(ttg::MemDescSubsliceOp op) {
     return failure();
   }
   uint64_t elementOffset = static_cast<uint32_t>(mapped[0].second);
+  if (offsets.size() != layoutRank) {
+    uint64_t stride = product(ttg::getAllocationShapePerCTA(
+        encoding, ttg::dropPipeliningDim(srcTy.getAllocShape(), encoding)));
+    elementOffset += static_cast<uint64_t>(offsets.front()) * stride;
+  }
 
   uint64_t elementSizeBytes =
       srcTy.getElementType().getIntOrFloatBitWidth() / 8;

--- a/lib/Conversion/TritonGPUToLLVM/Utility.cpp
+++ b/lib/Conversion/TritonGPUToLLVM/Utility.cpp
@@ -1440,11 +1440,10 @@ SmallVector<Type> SharedMemoryObject::getTypes() const {
 std::pair<uint64_t, uint64_t> SharedMemoryObject::getMaskSpanOffsetsAndBlocks(
     triton::gpu::MemDescType srcTy) {
   auto ctx = srcTy.getContext();
-  auto shape = srcTy.getShape();
-  auto allocShape = srcTy.getAllocShape();
-  assert(allocShape.size() >= shape.size());
-  assert(allocShape.size() - shape.size() <= 1);
-  allocShape = allocShape.take_back(shape.size());
+  auto encoding = srcTy.getEncoding();
+  auto shape = triton::gpu::dropPipeliningDim(srcTy.getShape(), encoding);
+  auto allocShape =
+      triton::gpu::dropPipeliningDim(srcTy.getAllocShape(), encoding);
 
   // Early exist when there is no subview
   if (allocShape == shape) {
@@ -1503,9 +1502,11 @@ std::pair<Value, Value> SharedMemoryObject::getShmemOffsetAndBlock(
     ll = triton::gpu::toLinearLayout(srcTy);
   }
 
-  auto dimNames = standardOutDimNames(ctx, offsets.size());
+  auto layoutOffsets =
+      triton::gpu::dropPipeliningDim(ArrayRef(offsets), srcTy.getEncoding());
+  auto dimNames = standardOutDimNames(ctx, layoutOffsets.size());
   SmallVector<std::pair<StringAttr, Value>> logicalOffsets;
-  for (auto [dim, offset] : llvm::zip(dimNames, offsets)) {
+  for (auto [dim, offset] : llvm::zip(dimNames, layoutOffsets)) {
     logicalOffsets.push_back({dim, offset});
   }
 

--- a/lib/Conversion/TritonGPUToLLVM/ViewOpToLLVM.cpp
+++ b/lib/Conversion/TritonGPUToLLVM/ViewOpToLLVM.cpp
@@ -2,6 +2,7 @@
 #include "triton/Conversion/TritonGPUToLLVM/PatternTritonGPUOpToLLVM.h"
 #include "triton/Conversion/TritonGPUToLLVM/Utility.h"
 #include "triton/Dialect/TritonGPU/IR/Attributes.h"
+#include "triton/Dialect/TritonGPU/IR/Dialect.h"
 #include "triton/Dialect/TritonGPU/IR/LinearLayoutConversions.h"
 #include "triton/Dialect/TritonGPU/IR/Types.h"
 #include "triton/Dialect/TritonNvidiaGPU/IR/Dialect.h"
@@ -489,6 +490,20 @@ struct MemDescSubsliceOpConversion
     auto smemObj = getSharedMemoryObjectFromStruct(loc, adaptor.getSrc(),
                                                    llvmElemTy, rewriter);
     auto opOffsetVals = op.getOffsets();
+    auto encoding = srcTy.getEncoding();
+    auto layoutOffsets = dropPipeliningDim(opOffsetVals, encoding);
+    SmallVector<Value> newBases = llvm::to_vector(smemObj.getBases());
+
+    if (layoutOffsets.size() != opOffsetVals.size() &&
+        opOffsetVals.front() != 0) {
+      int64_t stride = product(getAllocationShapePerCTA(
+          encoding, dropPipeliningDim(srcTy.getAllocShape(), encoding)));
+      if (auto partEnc = dyn_cast<PartitionedSharedEncodingAttr>(encoding))
+        stride /= partEnc.getNumPartitions();
+      Value offset = b.i32_val(opOffsetVals.front() * stride);
+      for (Value &base : newBases)
+        base = b.gep(base.getType(), llvmElemTy, base, offset);
+    }
 
     // Accumulate the logical offsets
     SmallVector<Value> offsetVals;
@@ -518,7 +533,6 @@ struct MemDescSubsliceOpConversion
     //
     // The offset component of (3) is already XORed in by getShmemOffset at
     // load time; only the partition component needs this fix.
-    SmallVector<Value> newBases = llvm::to_vector(smemObj.getBases());
     if (newBases.size() > 1) {
       LinearLayout ll = triton::gpu::isPaddedEncoding(srcTy.getEncoding())
                             ? triton::gpu::paddedLinearLayout(srcTy)
@@ -526,9 +540,9 @@ struct MemDescSubsliceOpConversion
       auto kPartition = StringAttr::get(ctx, "partition");
       assert(ll.hasInDim(kPartition) &&
              "multiple bases require a partition input dim");
-      auto dimNames = standardOutDimNames(ctx, opOffsetVals.size());
+      auto dimNames = standardOutDimNames(ctx, layoutOffsets.size());
       SmallVector<std::pair<StringAttr, int32_t>> namedOffsets;
-      for (auto [dim, off] : llvm::zip(dimNames, opOffsetVals))
+      for (auto [dim, off] : llvm::zip(dimNames, layoutOffsets))
         namedOffsets.push_back({dim, off});
       auto partitionLayout = ll.invert().sublayout(dimNames, {kPartition});
       int32_t partitionShift = partitionLayout.apply(namedOffsets)[0].second;

--- a/lib/Dialect/TritonGPU/IR/Dialect.cpp
+++ b/lib/Dialect/TritonGPU/IR/Dialect.cpp
@@ -3891,8 +3891,7 @@ struct TritonGPUVerifyTensorLayoutInterface
       return failure();
 
     if (auto sharedLinearEnc = dyn_cast<SharedLinearEncodingAttr>(layout)) {
-      auto rank = cast<LayoutEncodingTrait>(layout).getRank();
-      auto shape = memDescTy.getAllocShape().take_back(rank);
+      auto shape = dropPipeliningDim(memDescTy.getAllocShape(), layout);
       auto layoutShape = sharedLinearEnc.getLinearLayout().getOutDimSizes();
       if (!llvm::equal(shape, layoutShape)) {
         return makeErr() << layout << ".\nLayout has shape " << layoutShape

--- a/lib/Dialect/TritonGPU/IR/LinearLayoutConversions.cpp
+++ b/lib/Dialect/TritonGPU/IR/LinearLayoutConversions.cpp
@@ -1371,8 +1371,9 @@ LinearLayout toLinearLayout(MemDescType type) {
   // For TMEM we instantiate the subview directly. This is possible
   // as TMEM has no swizzling.
   if (isa<nvidia_gpu::TensorMemorySpaceAttr>(type.getMemorySpace())) {
-    auto shape = type.getShape().take_back(2);
-    auto allocShape = type.getAllocShape().take_back(2);
+    auto shape = dropPipeliningDim(type.getShape(), type.getEncoding());
+    auto allocShape =
+        dropPipeliningDim(type.getAllocShape(), type.getEncoding());
     auto ll = toLinearLayout(allocShape, type.getEncoding());
     auto outDims = llvm::to_vector(ll.getOutDimNames());
     // Trim the shape
@@ -1390,8 +1391,9 @@ LinearLayout toLinearLayout(MemDescType type) {
   // Shared memory needs the allocation shape so that invertAndCompose can trim
   // subviews. We also remove the first dimension of the allocation shape if
   // there was a call to memdesc_index.
-  auto shape = type.getAllocShape().take_back(type.getRank());
-  return toLinearLayout(shape, type.getEncoding());
+  return toLinearLayout(
+      dropPipeliningDim(type.getAllocShape(), type.getEncoding()),
+      type.getEncoding());
 }
 
 LinearLayout toLinearLayout(TensorOrMemDesc type) {
@@ -1425,8 +1427,9 @@ LinearLayout paddedLinearLayout(ArrayRef<int64_t> shape, Attribute encoding) {
 }
 
 LinearLayout paddedLinearLayout(MemDescType type) {
-  auto shape = type.getAllocShape().take_back(type.getRank());
-  return paddedLinearLayout(shape, type.getEncoding());
+  return paddedLinearLayout(
+      dropPipeliningDim(type.getAllocShape(), type.getEncoding()),
+      type.getEncoding());
 }
 
 LinearLayout getLayoutWithinBlock(const LinearLayout &layout) {

--- a/lib/Dialect/TritonGPU/IR/Ops.cpp
+++ b/lib/Dialect/TritonGPU/IR/Ops.cpp
@@ -690,14 +690,10 @@ LogicalResult MemDescReinterpretOp::verify() {
     return emitError("source and result must have the same memory space");
   if (srcTy.getMutableMemory() != dstTy.getMutableMemory())
     return emitError("source and result must have the same mutability");
-  auto isSubview = [](MemDescType ty) {
-    auto rank = cast<LayoutEncodingTrait>(ty.getEncoding()).getRank();
-    return ty.getShape().take_back(rank) != ty.getAllocShape().take_back(rank);
-  };
-  bool srcIsSubview = isSubview(srcTy);
+  bool srcIsSubview = srcTy.getShape() != srcTy.getAllocShape();
   bool srcIsTmem =
       isa<nvidia_gpu::TensorMemorySpaceAttr>(srcTy.getMemorySpace());
-  if (isSubview(dstTy) || (srcIsSubview && !srcIsTmem))
+  if (dstTy.getShape() != dstTy.getAllocShape() || (srcIsSubview && !srcIsTmem))
     return emitError("source and result must not be subviews; reinterpret the "
                      "parent descriptor and then take a subview");
   if (srcIsSubview) {
@@ -733,14 +729,13 @@ LogicalResult MemDescReinterpretOp::verify() {
     return success();
   }
   auto getViewNumBits = [](MemDescType ty) {
-    auto rank = cast<LayoutEncodingTrait>(ty.getEncoding()).getRank();
-    auto shape = ty.getAllocShape().take_back(rank);
     auto encoding = ty.getEncoding();
+    auto shape = dropPipeliningDim(ty.getAllocShape(), encoding);
     LinearLayout layout = isPaddedEncoding(encoding)
                               ? paddedLinearLayout(shape, encoding)
                               : toLinearLayout(shape, encoding);
     int64_t numLayoutCopies = 1;
-    for (int64_t dim : ty.getAllocShape().drop_back(rank))
+    for (int64_t dim : ty.getAllocShape().drop_back(shape.size()))
       numLayoutCopies *= dim;
     // Shared memory is allocated by offset; prefix dimensions outside the
     // layout-ranked suffix represent separate copies of that allocation.
@@ -1056,14 +1051,15 @@ LogicalResult MemDescIndexOp::verify() {
     return emitError("We don't allow taking memdesc_index of a memdesc_index");
   }
 
-  if (ArrayRef(srcTy.getShape()).take_back(dstTy.getRank()) !=
-      dstTy.getShape()) {
+  auto layoutShape = dropPipeliningDim(srcTy.getShape(), srcTy.getEncoding());
+  if (layoutShape != dstTy.getShape()) {
     return emitError("result shape must equal to srcShape[1:]");
   }
 
-  bool isSubview = srcTy.getAllocShape() != srcTy.getShape();
-  if (isSubview) {
-    return emitError("We don't support memdesc_index of a subview");
+  if (dropPipeliningDim(srcTy.getAllocShape(), srcTy.getEncoding()) !=
+      layoutShape) {
+    return emitError(
+        "We only support memdesc_index of a multibuffer-prefix subview");
   }
 
   auto srcEnc = srcTy.getEncoding();
@@ -1076,9 +1072,8 @@ LogicalResult MemDescIndexOp::verify() {
     return emitError("src and dst must have the same type of encoding");
   }
 
-  if (dstTy.getAllocShape() != dstTy.getShape() ||
-      srcTy.getAllocShape() != srcTy.getShape()) {
-    return emitError("alloc shape must match shape for both result and src");
+  if (dstTy.getAllocShape() != dstTy.getShape()) {
+    return emitError("alloc shape must match shape for the result");
   }
 
   if (isa<triton::nvidia_gpu::TensorMemoryEncodingAttr>(srcEnc)) {
@@ -1139,6 +1134,8 @@ LogicalResult MemDescSubsliceOp::verify() {
   if (!isa<SharedEncodingTrait>(srcEnc) || !isa<SharedEncodingTrait>(dstEnc)) {
     return emitError("src and dst must both be of shared memory encoding");
   }
+  auto layoutRank = dropPipeliningDim(getOffsets(), srcEnc).size();
+  auto prefixRank = getOffsets().size() - layoutRank;
 
   SetVector<int> splitDims{};
   for (int i = 0; i < srcTy.getRank(); i++) {
@@ -1147,11 +1144,6 @@ LogicalResult MemDescSubsliceOp::verify() {
     }
   }
   SmallVector<int64_t> offsets(getOffsets().begin(), getOffsets().end());
-  // Identity subview
-  if (splitDims.empty()) {
-    return success();
-  }
-
   for (auto [dim, offset] : llvm::enumerate(offsets)) {
     if (!splitDims.contains(dim)) {
       if (offset != 0) {
@@ -1159,14 +1151,18 @@ LogicalResult MemDescSubsliceOp::verify() {
                          "not being split");
       }
     } else {
-      if (offset & (dstTy.getDimSize(dim) - 1)) {
-        return emitError("The split offset may not touch the tile");
-      }
-      if (offset >= srcTy.getDimSize(dim)) {
+      if (offset < 0 ||
+          offset > srcTy.getDimSize(dim) - dstTy.getDimSize(dim)) {
         return emitError("The split offset may not exceed the source shape");
+      }
+      if (dim >= prefixRank && (offset & (dstTy.getDimSize(dim) - 1))) {
+        return emitError("The split offset may not touch the tile");
       }
     }
   }
+  // Identity subview
+  if (splitDims.empty())
+    return success();
 
   auto ctx = getContext();
   LinearLayout ll;
@@ -1182,14 +1178,16 @@ LogicalResult MemDescSubsliceOp::verify() {
 
   auto llInv = ll.pseudoinvert();
   for (auto dim : splitDims) {
-    auto kDim = mlir::StringAttr::get(ctx, "dim" + llvm::Twine(dim));
+    if (dim < prefixRank)
+      continue;
+    auto layoutDim = dim - prefixRank;
     llvm::SmallVector<std::pair<mlir::StringAttr, int32_t>> namedOffsets;
-    for (auto d : standardOutDimNames(ctx, srcTy.getRank())) {
+    for (auto d : standardOutDimNames(ctx, layoutRank)) {
       namedOffsets.push_back({d, 0});
     }
     for (int dimSize = dstTy.getDimSize(dim); dimSize < srcTy.getDimSize(dim);
          dimSize *= 2) {
-      namedOffsets[dim] = {kDim, dimSize};
+      namedOffsets[layoutDim].second = dimSize;
       auto offsetAndBlock = llInv.apply(namedOffsets);
       auto offset = offsetAndBlock[0];
       if (!llvm::isPowerOf2_32(offset.second) && offset.second != 0) {

--- a/lib/Dialect/TritonGPU/IR/Ops.cpp
+++ b/lib/Dialect/TritonGPU/IR/Ops.cpp
@@ -690,13 +690,18 @@ LogicalResult MemDescReinterpretOp::verify() {
     return emitError("source and result must have the same memory space");
   if (srcTy.getMutableMemory() != dstTy.getMutableMemory())
     return emitError("source and result must have the same mutability");
-  bool srcIsSubview = srcTy.getShape() != srcTy.getAllocShape();
+  auto isLayoutSubview = [](MemDescType ty) {
+    auto encoding = ty.getEncoding();
+    return dropPipeliningDim(ty.getShape(), encoding) !=
+           dropPipeliningDim(ty.getAllocShape(), encoding);
+  };
+  bool srcIsLayoutSubview = isLayoutSubview(srcTy);
   bool srcIsTmem =
       isa<nvidia_gpu::TensorMemorySpaceAttr>(srcTy.getMemorySpace());
-  if (dstTy.getShape() != dstTy.getAllocShape() || (srcIsSubview && !srcIsTmem))
+  if (isLayoutSubview(dstTy) || (srcIsLayoutSubview && !srcIsTmem))
     return emitError("source and result must not be subviews; reinterpret the "
                      "parent descriptor and then take a subview");
-  if (srcIsSubview) {
+  if (srcIsLayoutSubview) {
     auto rank = cast<LayoutEncodingTrait>(srcEnc).getRank();
     auto allocLayout =
         toLinearLayout(srcTy.getAllocShape().take_back(rank), srcEnc);
@@ -735,7 +740,7 @@ LogicalResult MemDescReinterpretOp::verify() {
                               ? paddedLinearLayout(shape, encoding)
                               : toLinearLayout(shape, encoding);
     int64_t numLayoutCopies = 1;
-    for (int64_t dim : ty.getAllocShape().drop_back(shape.size()))
+    for (int64_t dim : ty.getShape().drop_back(shape.size()))
       numLayoutCopies *= dim;
     // Shared memory is allocated by offset; prefix dimensions outside the
     // layout-ranked suffix represent separate copies of that allocation.

--- a/lib/Dialect/TritonGPU/IR/Types.cpp
+++ b/lib/Dialect/TritonGPU/IR/Types.cpp
@@ -143,7 +143,7 @@ LogicalResult MemDescType::verify(function_ref<InFlightDiagnostic()> emitError,
     }
     // Takes subslices into account and figures out whether we can construct
     // the linear layout at all
-    allocShape = allocShape.take_back(2);
+    allocShape = dropPipeliningDim(allocShape, enc);
     auto ctaSplit = enc.getCGALayout().getCTASplitNum();
     auto blockN = std::min<int32_t>(enc.getBlockN(), shape.back());
     if (shape[shape.size() - 2] < enc.getBlockM() * ctaSplit[0] ||
@@ -198,9 +198,7 @@ LogicalResult MemDescType::verify(function_ref<InFlightDiagnostic()> emitError,
     // pipelining dimension
     auto outDims = standardOutDimNames(ctx, rank);
     const auto &ll = enc.getLinearComponent();
-    auto expectedShape = allocShape;
-    if (rank == allocShape.size() - 1)
-      expectedShape = expectedShape.drop_front(1);
+    auto expectedShape = dropPipeliningDim(allocShape, enc);
 
     for (auto d = 0; d < rank; d++) {
       if (ll.getOutDimSize(outDims[d]) != expectedShape[d]) {
@@ -211,14 +209,14 @@ LogicalResult MemDescType::verify(function_ref<InFlightDiagnostic()> emitError,
     }
   } else if (auto enc = dyn_cast<NVMMASharedEncodingAttr>(encoding)) {
     SmallVector<int64_t> shapePerCTA(getShapePerCTA(enc, allocShape));
-    auto blockShape = ArrayRef(shapePerCTA).take_back(enc.getRank());
+    auto blockShape = dropPipeliningDim(ArrayRef(shapePerCTA), enc);
     if (failed(getTMABlockShape(blockShape, enc.getElementBitWidth(),
                                 enc.getSwizzlingByteWidth(), enc.getFp4Padded(),
                                 enc.getTransposed(), /*packedSize=*/false,
                                 emitError, TMAMode::Tiled)))
       return failure();
   } else if (auto enc = dyn_cast<SharedLinearEncodingAttr>(encoding)) {
-    auto blockShape = ArrayRef(allocShape).take_back(enc.getRank());
+    auto blockShape = dropPipeliningDim(allocShape, enc);
     const LinearLayout &ll = enc.getLinearLayout();
     for (auto [dim, size, llSize] :
          llvm::enumerate(blockShape, ll.getOutDimSizes())) {

--- a/python/test/gluon/test_core.py
+++ b/python/test/gluon/test_core.py
@@ -2166,6 +2166,33 @@ def test_block_m_64_mma():
     torch.testing.assert_close(d_ref, d_tri, rtol=0.08, atol=0)
 
 
+@pytest.mark.skipif(not is_hopper_or_newer(), reason="Requires Hopper")
+def test_multibuffer_prefix_subslice():
+
+    @gluon.jit
+    def kernel(out0, out3):
+        layout: ttgl.constexpr = ttgl.BlockedLayout([1, 1], [1, 32], [4, 1], [1, 0])
+        shared_layout: ttgl.constexpr = ttgl.NVMMASharedLayout(128, 32, rank=2)
+        parent = ttgl.allocate_shared_memory(ttgl.float32, [7, 32, 32], shared_layout)
+        stage0 = parent.index(0)
+        stage3 = parent.slice(3, 3, dim=0).index(0)
+        stage0.store(ttgl.full([32, 32], 1.0, ttgl.float32, layout))
+        stage3.store(ttgl.full([32, 32], 3.0, ttgl.float32, layout))
+        ttgl.barrier()
+
+        rows = ttgl.arange(0, 32, layout=ttgl.SliceLayout(1, layout))[:, None]
+        cols = ttgl.arange(0, 32, layout=ttgl.SliceLayout(0, layout))[None, :]
+        offsets = rows * 32 + cols
+        ttgl.store(out0 + offsets, stage0.load(layout))
+        ttgl.store(out3 + offsets, stage3.load(layout))
+
+    out0 = torch.empty((32, 32), device="cuda", dtype=torch.float32)
+    out3 = torch.empty_like(out0)
+    kernel[(1, )](out0, out3, num_warps=4)
+    torch.testing.assert_close(out0, torch.ones_like(out0), atol=0, rtol=0)
+    torch.testing.assert_close(out3, torch.full_like(out3, 3), atol=0, rtol=0)
+
+
 def test_slice_reinterpret():
     BLOCK = ttgl.constexpr(2048)
     SPLIT_BLOCK = ttgl.constexpr(BLOCK // 2)

--- a/python/test/gluon/test_frontend.py
+++ b/python/test/gluon/test_frontend.py
@@ -516,6 +516,25 @@ def anchor_noinline(x):
 
 @filecheck_test
 @gluon.jit
+def test_reinterpret_parent_then_multibuffer_subslice():
+    # CHECK-LABEL: test_reinterpret_parent_then_multibuffer_subslice
+    a_layout: ttgl.constexpr = ttgl.NVMMASharedLayout(64, 16, rank=2)
+    b_layout: ttgl.constexpr = ttgl.NVMMASharedLayout(32, 16, rank=2)
+    arena = ttgl.allocate_shared_memory(ttgl.float16, [7, 8, 32], a_layout)
+    # CHECK: [[B_PARENT:%.*]] = ttg.memdesc_reinterpret {{.*}} -> !ttg.memdesc<14x8x16xf16
+    b_parent = arena._reinterpret(ttgl.float16, [14, 8, 16], b_layout)
+    # CHECK: [[A_SUB:%.*]] = ttg.memdesc_subslice {{.*}}[0, 0, 0]
+    a_stages = arena.slice(0, 3, dim=0)
+    # CHECK: [[B_SUB:%.*]] = ttg.memdesc_subslice [[B_PARENT]][6, 0, 0] {{.*}} -> !ttg.memdesc<4x8x16xf16
+    b_stages = b_parent.slice(6, 4, dim=0)
+    # CHECK: ttg.memdesc_index [[A_SUB]]
+    anchor_noinline(a_stages.index(0))
+    # CHECK: ttg.memdesc_index [[B_SUB]]
+    anchor_noinline(b_stages.index(0))
+
+
+@filecheck_test
+@gluon.jit
 def test_warp_specialize():
     # CHECK:       [[BLOCKED:#.*]] = #ttg.blocked<{sizePerThread = [1], threadsPerWarp = [32], warpsPerCTA = [4], order = [0]}>
     # CHECK-LABEL: test_warp_specialize

--- a/test/Analysis/test-buffer-region.mlir
+++ b/test/Analysis/test-buffer-region.mlir
@@ -49,14 +49,15 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 1 : i32, ttg.shar
 
 module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 1 : i32, ttg.shared = 65544 : i32, ttg.target = "cuda:90", ttg.tensor_memory_size = 0 : i32, "ttg.threads-per-warp" = 32 : i32, "ttg.total-num-warps" = 1 : i32} {
   tt.func public @memdesc_index_multiple_access(%idx: i32) {
-    %0 = ttg.local_alloc {allocation.offset = 0 : i32} : () -> !ttg.memdesc<2x32x32xf32, #shared, #smem, mutable>
-    %view = ttg.memdesc_index %0[%idx] : !ttg.memdesc<2x32x32xf32, #shared, #smem, mutable> -> !ttg.memdesc<32x32xf32, #shared, #smem, mutable>
-    // expected-remark @below {{Buffers: [0, 4096], [4096, 4096]}}
+    %0 = ttg.local_alloc {allocation.offset = 0 : i32} : () -> !ttg.memdesc<8x32x32xf32, #shared, #smem, mutable>
+    %sub = ttg.memdesc_subslice %0 [3, 0, 0] : !ttg.memdesc<8x32x32xf32, #shared, #smem, mutable> -> !ttg.memdesc<3x32x32xf32, #shared, #smem, mutable, 8x32x32>
+    %view = ttg.memdesc_index %sub[%idx] : !ttg.memdesc<3x32x32xf32, #shared, #smem, mutable, 8x32x32> -> !ttg.memdesc<32x32xf32, #shared, #smem, mutable>
+    // expected-remark @below {{Buffers: [12288, 4096], [16384, 4096], [20480, 4096]}}
     ttg.local_load %view : !ttg.memdesc<32x32xf32, #shared, #smem, mutable> -> tensor<32x32xf32, #blocked>
     tt.return
   }
 
-  // expected-remark @below {{All Shared Regions: [0, 4096], [4096, 4096]}}
+  // expected-remark @below {{All Shared Regions: [12288, 4096], [16384, 4096], [20480, 4096]}}
   tt.func private @print_all_regions() attributes {test.print_all_used_regions} {
     tt.return
   }

--- a/test/Conversion/amd/tritongpu_to_llvm_gfx1250.mlir
+++ b/test/Conversion/amd/tritongpu_to_llvm_gfx1250.mlir
@@ -48,6 +48,27 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 2 : i32, "ttg.thr
 // -----
 
 #blocked = #ttg.blocked<{sizePerThread = [1, 1], threadsPerWarp = [8, 4], warpsPerCTA = [2, 1], order = [1, 0]}>
+#inner_shared = #ttg.swizzled_shared<{vec = 1, perPhase = 1, maxPhase = 1, order = [1, 0]}>
+#partitioned = #ttg.partitioned_shared<{numPartitions = 2, numGroups = 2, partitionDim = 0, partitionLayout = #inner_shared}>
+#smem = #ttg.shared_memory
+module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 2 : i32, "ttg.threads-per-warp" = 32 : i32} {
+  // GFX1250-LABEL: partitioned_shared_multibuffer_subslice
+  tt.func @partitioned_shared_multibuffer_subslice() -> tensor<16x16xf16, #blocked> {
+    %c0 = arith.constant 0 : i32
+    %0 = ttg.local_alloc : () -> !ttg.memdesc<5x16x16xf16, #partitioned, #smem, mutable>
+    // GFX1250: [[STAGE_OFFSET:%.*]] = llvm.mlir.constant(256 : i32)
+    // GFX1250-COUNT-2: llvm.getelementptr {{.*}}[[STAGE_OFFSET]]
+    %1 = ttg.memdesc_subslice %0 [2, 0, 0] : !ttg.memdesc<5x16x16xf16, #partitioned, #smem, mutable> -> !ttg.memdesc<3x16x16xf16, #partitioned, #smem, mutable, 5x16x16>
+    %2 = ttg.memdesc_index %1[%c0] : !ttg.memdesc<3x16x16xf16, #partitioned, #smem, mutable, 5x16x16> -> !ttg.memdesc<16x16xf16, #partitioned, #smem, mutable>
+    // GFX1250: llvm.load
+    %3 = ttg.local_load %2 : !ttg.memdesc<16x16xf16, #partitioned, #smem, mutable> -> tensor<16x16xf16, #blocked>
+    tt.return %3 : tensor<16x16xf16, #blocked>
+  }
+}
+
+// -----
+
+#blocked = #ttg.blocked<{sizePerThread = [1, 1], threadsPerWarp = [8, 4], warpsPerCTA = [2, 1], order = [1, 0]}>
 #inner_padded = #ttg.padded_shared<[128:+4] {order = [1, 0], shape = [16, 16]}>
 #partitioned = #ttg.partitioned_shared<{numPartitions = 2, numGroups = 2, partitionDim = 0, partitionLayout = #inner_padded}>
 #smem = #ttg.shared_memory

--- a/test/Conversion/tritongpu_to_llvm.mlir
+++ b/test/Conversion/tritongpu_to_llvm.mlir
@@ -550,6 +550,8 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32} {
   // CHECK-LABEL: rank_reducing_subview
   tt.func @rank_reducing_subview() {
     // CHECK: llvm.mlir.addressof @global_smem
+    // CHECK: llvm.mlir.constant(1536 : i32) : i32
+    // CHECK-NEXT: llvm.getelementptr
     // CHECK: llvm.mlir.constant(512 : i32) : i32
     // CHECK-NEXT: llvm.mul
     // CHECK-NEXT: llvm.extractvalue
@@ -558,9 +560,9 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32} {
     // CHECK-NEXT: llvm.extractvalue
     // CHECK-NEXT: llvm.getelementptr
     %index = arith.constant 1 : i32
-    %zero = arith.constant 0 : i32
     %0 = ttg.local_alloc : () -> !ttg.memdesc<128x16x32xf32, #shared0, #smem, mutable>
-    %1 = ttg.memdesc_index %0[%index] : !ttg.memdesc<128x16x32xf32, #shared0, #smem, mutable> -> !ttg.memdesc<16x32xf32, #shared0, #smem, mutable>
+    %sub = ttg.memdesc_subslice %0 [3, 0, 0] : !ttg.memdesc<128x16x32xf32, #shared0, #smem, mutable> -> !ttg.memdesc<3x16x32xf32, #shared0, #smem, mutable, 128x16x32>
+    %1 = ttg.memdesc_index %sub[%index] : !ttg.memdesc<3x16x32xf32, #shared0, #smem, mutable, 128x16x32> -> !ttg.memdesc<16x32xf32, #shared0, #smem, mutable>
     tt.return
   }
 }

--- a/test/TritonGPU/invalid.mlir
+++ b/test/TritonGPU/invalid.mlir
@@ -131,10 +131,21 @@ tt.func public @result_rank_too_large(%arg0: !ttg.memdesc<3x8x16xf32, #shared, #
 #smem = #ttg.shared_memory
 tt.func public @memdesc_index_result_alloc_shape_mismatch(%arg0: !ttg.memdesc<3x8x16xf32, #shared, #smem>) {
     %zero = arith.constant 0 : i32
-    // expected-error @+1 {{alloc shape must match shape for both result and src}}
+    // expected-error @+1 {{alloc shape must match shape for the result}}
     %a = ttg.memdesc_index %arg0[%zero] : !ttg.memdesc<3x8x16xf32, #shared, #smem> -> !ttg.memdesc<8x16xf32, #shared, #smem, 3x8x16>
     tt.return
 }
+// -----
+
+#shared = #ttg.swizzled_shared<{vec = 1, perPhase = 1, maxPhase = 1, order = [1, 0]}>
+#smem = #ttg.shared_memory
+tt.func public @memdesc_index_inner_subview(%arg0: !ttg.memdesc<3x8x8xf32, #shared, #smem, 3x8x16>) {
+    %zero = arith.constant 0 : i32
+    // expected-error @+1 {{We only support memdesc_index of a multibuffer-prefix subview}}
+    %a = ttg.memdesc_index %arg0[%zero] : !ttg.memdesc<3x8x8xf32, #shared, #smem, 3x8x16> -> !ttg.memdesc<8x8xf32, #shared, #smem>
+    tt.return
+}
+
 // -----
 
 #shared = #ttg.swizzled_shared<{vec = 8, perPhase = 1, maxPhase = 4, order = [0]}>
@@ -164,6 +175,36 @@ tt.func public @subview_along_swizzling_pattern(%arg0: !ttg.memdesc<8x16xf32, #s
 tt.func public @subview_along_swizzling(%arg0: !ttg.memdesc<8x16xf32, #shared, #smem>, %index: i32) {
     // expected-error @+1 {{tile}}
     %a = ttg.memdesc_subslice %arg0 [2, 0] : !ttg.memdesc<8x16xf32, #shared, #smem> -> !ttg.memdesc<4x16xf32, #shared, #smem>
+    tt.return
+}
+
+// -----
+
+#shared = #ttg.nvmma_shared<{swizzlingByteWidth = 64, transposed = false, elementBitWidth = 16}>
+#smem = #ttg.shared_memory
+tt.func public @multibuffer_subview_exceeds_source(%arg0: !ttg.memdesc<8x8x32xf16, #shared, #smem>) {
+    // expected-error @+1 {{The split offset may not exceed the source shape}}
+    %a = ttg.memdesc_subslice %arg0 [6, 0, 0] : !ttg.memdesc<8x8x32xf16, #shared, #smem> -> !ttg.memdesc<3x8x32xf16, #shared, #smem, 8x8x32>
+    tt.return
+}
+
+// -----
+
+#shared = #ttg.swizzled_shared<{vec = 1, perPhase = 1, maxPhase = 1, order = [1, 0]}>
+#smem = #ttg.shared_memory
+tt.func public @multibuffer_subview_unaligned_non_pipeline_offset(%arg0: !ttg.memdesc<5x8x16xf32, #shared, #smem>) {
+    // expected-error @+1 {{The split offset may not touch the tile}}
+    %a = ttg.memdesc_subslice %arg0 [2, 2, 0] : !ttg.memdesc<5x8x16xf32, #shared, #smem> -> !ttg.memdesc<3x4x16xf32, #shared, #smem, 5x8x16>
+    tt.return
+}
+
+// -----
+
+#shared = #ttg.nvmma_shared<{swizzlingByteWidth = 64, transposed = false, elementBitWidth = 16}>
+#smem = #ttg.shared_memory
+tt.func public @multibuffer_subview_nonzero_identity_offset(%arg0: !ttg.memdesc<8x8x32xf16, #shared, #smem>) {
+    // expected-error @+1 {{A non zero offset found in a dimension that is not being split}}
+    %a = ttg.memdesc_subslice %arg0 [3, 0, 0] : !ttg.memdesc<8x8x32xf16, #shared, #smem> -> !ttg.memdesc<8x8x32xf16, #shared, #smem>
     tt.return
 }
 
@@ -243,6 +284,17 @@ tt.func public @memdesc_reinterpret_changed_mutability(%arg0: !ttg.memdesc<8x16x
 tt.func public @memdesc_reinterpret_subview(%arg0: !ttg.memdesc<8x16xf16, #shared, #smem, 16x16>) {
     // expected-error @+1 {{source and result must not be subviews}}
     %a = ttg.memdesc_reinterpret %arg0 : !ttg.memdesc<8x16xf16, #shared, #smem, 16x16> -> !ttg.memdesc<8x16xf16, #shared, #smem>
+    tt.return
+}
+
+// -----
+
+#shared_a = #ttg.nvmma_shared<{swizzlingByteWidth = 64, transposed = false, elementBitWidth = 16}>
+#shared_b = #ttg.nvmma_shared<{swizzlingByteWidth = 32, transposed = false, elementBitWidth = 16}>
+#smem = #ttg.shared_memory
+tt.func public @memdesc_reinterpret_multibuffer_subview(%arg0: !ttg.memdesc<3x8x32xf16, #shared_a, #smem, 8x8x32>) {
+    // expected-error @+1 {{source and result must not be subviews}}
+    %a = ttg.memdesc_reinterpret %arg0 : !ttg.memdesc<3x8x32xf16, #shared_a, #smem, 8x8x32> -> !ttg.memdesc<16x8x16xf16, #shared_b, #smem>
     tt.return
 }
 

--- a/test/TritonGPU/invalid.mlir
+++ b/test/TritonGPU/invalid.mlir
@@ -292,9 +292,20 @@ tt.func public @memdesc_reinterpret_subview(%arg0: !ttg.memdesc<8x16xf16, #share
 #shared_a = #ttg.nvmma_shared<{swizzlingByteWidth = 64, transposed = false, elementBitWidth = 16}>
 #shared_b = #ttg.nvmma_shared<{swizzlingByteWidth = 32, transposed = false, elementBitWidth = 16}>
 #smem = #ttg.shared_memory
-tt.func public @memdesc_reinterpret_multibuffer_subview(%arg0: !ttg.memdesc<3x8x32xf16, #shared_a, #smem, 8x8x32>) {
-    // expected-error @+1 {{source and result must not be subviews}}
+tt.func public @memdesc_reinterpret_multibuffer_subview_expands(%arg0: !ttg.memdesc<3x8x32xf16, #shared_a, #smem, 8x8x32>) {
+    // expected-error @+1 {{result logical storage size must not exceed source logical storage size}}
     %a = ttg.memdesc_reinterpret %arg0 : !ttg.memdesc<3x8x32xf16, #shared_a, #smem, 8x8x32> -> !ttg.memdesc<16x8x16xf16, #shared_b, #smem>
+    tt.return
+}
+
+// -----
+
+#shared_a = #ttg.nvmma_shared<{swizzlingByteWidth = 64, transposed = false, elementBitWidth = 16}>
+#shared_b = #ttg.nvmma_shared<{swizzlingByteWidth = 32, transposed = false, elementBitWidth = 16}>
+#smem = #ttg.shared_memory
+tt.func public @memdesc_reinterpret_multibuffer_layout_subview(%arg0: !ttg.memdesc<3x4x32xf16, #shared_a, #smem, 8x8x32>) {
+    // expected-error @+1 {{source and result must not be subviews}}
+    %a = ttg.memdesc_reinterpret %arg0 : !ttg.memdesc<3x4x32xf16, #shared_a, #smem, 8x8x32> -> !ttg.memdesc<16x8x16xf16, #shared_b, #smem>
     tt.return
 }
 

--- a/test/TritonGPU/ops.mlir
+++ b/test/TritonGPU/ops.mlir
@@ -96,6 +96,20 @@ module attributes {"ttg.target" = "cuda:0", "ttg.num-ctas" = 1 : i32, "ttg.num-w
 
 // -----
 
+#shared_a = #ttg.nvmma_shared<{swizzlingByteWidth = 64, transposed = false, elementBitWidth = 16}>
+#shared_b = #ttg.nvmma_shared<{swizzlingByteWidth = 32, transposed = false, elementBitWidth = 16}>
+#smem = #ttg.shared_memory
+module attributes {"ttg.target" = "cuda:0", "ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 1 : i32, "ttg.threads-per-warp" = 32 : i32} {
+  // CHECK-LABEL: @memdesc_reinterpret_multibuffer_prefix_subview
+  tt.func @memdesc_reinterpret_multibuffer_prefix_subview(%arg0: !ttg.memdesc<3x8x32xf16, #shared_a, #smem, 8x8x32>) {
+    // CHECK: ttg.memdesc_reinterpret
+    %0 = ttg.memdesc_reinterpret %arg0 : !ttg.memdesc<3x8x32xf16, #shared_a, #smem, 8x8x32> -> !ttg.memdesc<6x8x16xf16, #shared_b, #smem>
+    tt.return
+  }
+}
+
+// -----
+
 #shared_cga_01 = #ttg.swizzled_shared<{vec = 1, perPhase = 1, maxPhase = 1, order = [1, 0], CGALayout = [[0, 1]]}>
 #shared_cga_10 = #ttg.swizzled_shared<{vec = 1, perPhase = 1, maxPhase = 1, order = [1, 0], CGALayout = [[1, 0]]}>
 #shared_cga_00 = #ttg.swizzled_shared<{vec = 1, perPhase = 1, maxPhase = 1, order = [1, 0], CGALayout = [[0, 0]]}>

--- a/test/TritonGPU/ops.mlir
+++ b/test/TritonGPU/ops.mlir
@@ -83,6 +83,19 @@ module attributes {"ttg.target" = "cuda:0", "ttg.num-ctas" = 1 : i32, "ttg.num-w
 
 // -----
 
+#shared = #ttg.nvmma_shared<{swizzlingByteWidth = 64, transposed = false, elementBitWidth = 16}>
+#smem = #ttg.shared_memory
+module attributes {"ttg.target" = "cuda:0", "ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 1 : i32, "ttg.threads-per-warp" = 32 : i32} {
+  // CHECK-LABEL: @multibuffer_subview_unaligned_pipeline_offset
+  tt.func @multibuffer_subview_unaligned_pipeline_offset(%arg0: !ttg.memdesc<5x8x32xf16, #shared, #smem>) {
+    // CHECK: ttg.memdesc_subslice %{{.*}}[2, 0, 0]
+    %0 = ttg.memdesc_subslice %arg0 [2, 0, 0] : !ttg.memdesc<5x8x32xf16, #shared, #smem> -> !ttg.memdesc<3x8x32xf16, #shared, #smem, 5x8x32>
+    tt.return
+  }
+}
+
+// -----
+
 #shared_cga_01 = #ttg.swizzled_shared<{vec = 1, perPhase = 1, maxPhase = 1, order = [1, 0], CGALayout = [[0, 1]]}>
 #shared_cga_10 = #ttg.swizzled_shared<{vec = 1, perPhase = 1, maxPhase = 1, order = [1, 0], CGALayout = [[1, 0]]}>
 #shared_cga_00 = #ttg.swizzled_shared<{vec = 1, perPhase = 1, maxPhase = 1, order = [1, 0], CGALayout = [[0, 0]]}>


### PR DESCRIPTION
PR description written by Codex

Fix multibuffer shared-memory subslices when the leading pipelining dimension is outside the layout rank, including physical offsets and buffer-region analysis. Allow tensor-memory scale subviews, centralize pipelining-dimension handling, and preserve the existing reinterpret and subview restrictions.

Validated with the focused lit, C++ layout, Gluon GPU, and ConSan suites on GB300.

## Stack
Merge bottom-up:
- [ ] #10856 (this PR)
