### PR TITLE
[FPSAN] Support inline assembly

### DIFF
--- a/docs/programming-guide/chapter-3/fpsan.rst
+++ b/docs/programming-guide/chapter-3/fpsan.rst
@@ -406,16 +406,17 @@ Important caveat:
 - The same raw-payload interpretation is reused by scaled-dot paths for
   ``e2m1``.
 
-----------------------------
-Pure Extern Elementwise Ops
-----------------------------
+------------------------------------------
+Pure Extern and Inline-Asm Elementwise Ops
+------------------------------------------
 
 Supported operation:
 
-- ``tl.extern_elementwise`` when all of the following hold:
+- ``tl.extern_elementwise`` and ``tl.inline_asm_elementwise`` when all of the
+  following hold:
 
   - the op is ``pure``
-  - the result type is float-like
+  - every result type is float-like
   - there is at least one operand
   - every operand is numeric
 
@@ -423,19 +424,22 @@ Rewrite:
 
 - rotate each operand payload by its argument index
 - sum the rotated payloads
-- xor the result with a stable hash of the symbol name
+- xor the result with a stable hash of the symbol name or inline-asm string;
+  inline-asm result indices are also included for multi-result operations
 - unembed
 
 Exact preserved properties:
 
 - deterministic dependence on all operands and on operand order
-- deterministic distinction between different external symbols
+- deterministic distinction between different external symbols, inline-asm
+  strings, and inline-asm result indices
 - mixed float and integer operands are supported; float operands are embedded,
   integer operands are used directly after signed casting to the result width
 
 Important caveat:
 
-- This is a structural tag, not a numeric model of the external function.
+- This is a structural tag, not a numeric model of the external function or
+  inline assembly.
 
 ---------------------------
 Gluon MMA and Tensor Memory

--- a/lib/Dialect/TritonInstrument/Transforms/FpSanitizer.cpp
+++ b/lib/Dialect/TritonInstrument/Transforms/FpSanitizer.cpp
@@ -914,14 +914,13 @@ Value fpsanSin(PatternRewriter &rewriter, Location loc, Value input) {
   return unembedToFloat(rewriter, loc, cosSin.sin, input.getType());
 }
 
-bool externHasNumericOperands(tt::ExternElementwiseOp op) {
-  return llvm::all_of(op.getOperands(), [](Value operand) {
-    return isNumericLike(operand.getType());
-  });
+bool hasNumericOperands(ValueRange operands) {
+  return llvm::all_of(
+      operands, [](Value operand) { return isNumericLike(operand.getType()); });
 }
 
-Value castExternOperandToResultInt(PatternRewriter &rewriter, Location loc,
-                                   Value operand, Type resultIntTy) {
+Value castOperandToResultInt(PatternRewriter &rewriter, Location loc,
+                             Value operand, Type resultIntTy) {
   if (isFloatLike(operand.getType())) {
     return castSignedIntValueToType(
         rewriter, loc, embedToInt(rewriter, loc, operand), resultIntTy);
@@ -950,15 +949,14 @@ Value rotateLeftIntByAmount(PatternRewriter &rewriter, Location loc,
   return arith::OrIOp::create(rewriter, loc, left, right);
 }
 
-Value fpsanVariadicExternTagged(PatternRewriter &rewriter, Location loc,
-                                tt::ExternElementwiseOp op, uint64_t hash) {
-  Type resultTy = op.getType();
+Value fpsanVariadicTagged(PatternRewriter &rewriter, Location loc,
+                          ValueRange operands, Type resultTy, uint64_t hash) {
   Type resultIntTy = getIntTypeLike(resultTy);
 
   Value sumI = getIntConstantLike(rewriter, loc, resultIntTy, 0);
-  for (auto [argIdx, operand] : llvm::enumerate(op.getOperands())) {
+  for (auto [argIdx, operand] : llvm::enumerate(operands)) {
     Value operandI =
-        castExternOperandToResultInt(rewriter, loc, operand, resultIntTy);
+        castOperandToResultInt(rewriter, loc, operand, resultIntTy);
     if (!operandI)
       return Value();
     Value rotated = rotateLeftIntByAmount(rewriter, loc, operandI,
@@ -3103,7 +3101,7 @@ struct ExternElementwisePattern
   LogicalResult matchAndRewrite(tt::ExternElementwiseOp op,
                                 PatternRewriter &rewriter) const override {
     if (!op.getPure() || !isFloatLike(op.getType()) ||
-        op.getNumOperands() == 0 || !externHasNumericOperands(op))
+        op.getNumOperands() == 0 || !hasNumericOperands(op.getOperands()))
       return failure();
 
     Value result;
@@ -3113,11 +3111,37 @@ struct ExternElementwisePattern
       result = (*transform)(rewriter, op);
     if (!result) {
       uint64_t hash = stableStringHash(op.getSymbol());
-      result = fpsanVariadicExternTagged(rewriter, op.getLoc(), op, hash);
+      result = fpsanVariadicTagged(rewriter, op.getLoc(), op.getOperands(),
+                                   op.getType(), hash);
     }
     if (!result)
       return emitFpSanCodegenError(op.getOperation());
     rewriter.replaceOp(op, result);
+    return success();
+  }
+};
+
+struct ElementwiseInlineAsmPattern
+    : public OpRewritePattern<tt::ElementwiseInlineAsmOp> {
+  using OpRewritePattern::OpRewritePattern;
+
+  LogicalResult matchAndRewrite(tt::ElementwiseInlineAsmOp op,
+                                PatternRewriter &rewriter) const override {
+    if (!op.getPure() || op.getNumOperands() == 0 || op.getNumResults() == 0 ||
+        !hasNumericOperands(op.getOperands()) ||
+        !llvm::all_of(op.getResultTypes(), isFloatLike))
+      return failure();
+
+    uint64_t hash = stableStringHash(op.getAsmString());
+    SmallVector<Value> results;
+    for (auto [resultIdx, resultTy] : llvm::enumerate(op.getResultTypes())) {
+      Value result = fpsanVariadicTagged(
+          rewriter, op.getLoc(), op.getOperands(), resultTy, hash ^ resultIdx);
+      if (!result)
+        return emitFpSanCodegenError(op.getOperation());
+      results.push_back(result);
+    }
+    rewriter.replaceOp(op, results);
     return success();
   }
 };
@@ -3164,7 +3188,8 @@ public:
     patterns.add<UnaryPattern<math::CeilOp>>(&getContext(), UnaryOpId::Ceil);
     patterns.add<UnaryPattern<tt::PreciseSqrtOp>>(&getContext(),
                                                   UnaryOpId::PreciseSqrt);
-    patterns.add<ExternElementwisePattern>(&getContext());
+    patterns.add<ExternElementwisePattern, ElementwiseInlineAsmPattern>(
+        &getContext());
     patterns.add<TMEMLoadPattern, TMEMStorePattern, TMEMCopyPattern,
                  TCGen5MMAPattern, TCGen5MMAScaledPattern>(&getContext(),
                                                            &scratch);

--- a/python/test/gluon/test_fpsan.py
+++ b/python/test/gluon/test_fpsan.py
@@ -1426,6 +1426,39 @@ def test_inline_asm_payload_semantics(device, asm, fresh_knobs):
     _assert_payload_equal(out, exp_bits)
 
 
+@gluon.jit
+def _swiglu_tanh_kernel(gate_ptr, linear_ptr, out_ptr, BLOCK: gl.constexpr, THREADS_PER_WARP: gl.constexpr):
+    layout: gl.constexpr = gl.BlockedLayout(size_per_thread=[2], threads_per_warp=[THREADS_PER_WARP], warps_per_cta=[4],
+                                            order=[0])
+    offs = gl.arange(0, BLOCK, layout=layout)
+    gate = gl.load(gate_ptr + offs)
+    linear = gl.load(linear_ptr + offs)
+    tanh = gl.inline_asm_elementwise("tanh.approx.f32 $0, $1;", "=f,f", [0.851 * gate], dtype=gl.float32, is_pure=True,
+                                     pack=1)
+    sig = gate * gl.fma(tanh, 0.5, 0.5)
+    gl.store(out_ptr + offs, gl.fma(sig, linear, sig))
+
+
+def test_swiglu_tanh_payload_semantics(device, fresh_knobs):
+    _require_cuda_backend(device)
+    fresh_knobs.compilation.instrumentation_mode = "fpsan"
+    g = torch.Generator(device="cuda")
+    g.manual_seed(44)
+    gate = torch.randint(-(2**31), 2**31 - 1, (128, ), dtype=torch.int32, device="cuda", generator=g)
+    linear = torch.randint(-(2**31), 2**31 - 1, (128, ), dtype=torch.int32, device="cuda", generator=g)
+    out = torch.empty_like(gate)
+    _swiglu_tanh_kernel[(1, )](triton.TensorWrapper(gate, dtype=torch.float32),
+                               triton.TensorWrapper(linear, dtype=torch.float32),
+                               triton.TensorWrapper(out, dtype=torch.float32), BLOCK=128,
+                               THREADS_PER_WARP=THREADS_PER_WARP)
+    gate_bits = gate.cpu().numpy()
+    half = np.full_like(gate_bits, np.float32(0.5).view(np.int32))
+    arg = _expected_mul_i32(gate_bits, np.full_like(gate_bits, np.float32(0.851).view(np.int32)))
+    tanh = _expected_extern_unary_tag_i32(arg, "tanh.approx.f32 $0, $1;")
+    sig = _expected_mul_i32(gate_bits, _expected_fma_i32(tanh, half, half))
+    _assert_payload_equal(out, _expected_fma_i32(sig, linear.cpu().numpy(), sig))
+
+
 def _expected_fma_i32(x_i32: np.ndarray, y_i32: np.ndarray, z_i32: np.ndarray) -> np.ndarray:
     return _expected_add_i32(_expected_mul_i32(x_i32, y_i32), z_i32)
 

--- a/python/test/gluon/test_fpsan.py
+++ b/python/test/gluon/test_fpsan.py
@@ -1381,6 +1381,51 @@ def test_extern_mixed_payload_semantics(device, op, symbol, fresh_knobs):
     _assert_payload_equal(out, exp_bits)
 
 
+@gluon.jit
+def _inline_asm_math_kernel(x_ptr, y_ptr, out_ptr, n_elements, ASM: gl.constexpr, BLOCK: gl.constexpr,
+                            THREADS_PER_WARP: gl.constexpr):
+    pid = gl.program_id(0)
+    layout: gl.constexpr = gl.BlockedLayout(size_per_thread=[2], threads_per_warp=[THREADS_PER_WARP], warps_per_cta=[4],
+                                            order=[0])
+    offs = pid * BLOCK + gl.arange(0, BLOCK, layout=layout)
+    mask = offs < n_elements
+    x = gl.load(x_ptr + offs, mask=mask, other=0.0)
+    y = gl.load(y_ptr + offs, mask=mask, other=0.0)
+    out = gl.inline_asm_elementwise(ASM, "=r,r,r", [x, y], dtype=gl.float32, is_pure=True, pack=1)
+    gl.store(out_ptr + offs, out, mask=mask)
+
+
+@pytest.mark.parametrize("asm", ["add.f32 $0, $1, $2;", "sub.f32 $0, $1, $2;"])
+def test_inline_asm_payload_semantics(device, asm, fresh_knobs):
+    _require_cuda_backend(device)
+
+    fresh_knobs.compilation.instrumentation_mode = "fpsan"
+
+    n_elements = 1024
+    BLOCK = 256
+    g = torch.Generator(device="cuda")
+    g.manual_seed(43)
+    x = torch.randint(-(2**31), 2**31 - 1, (n_elements, ), dtype=torch.int32, device="cuda", generator=g)
+    y = torch.randint(-(2**31), 2**31 - 1, (n_elements, ), dtype=torch.int32, device="cuda", generator=g)
+    out = torch.empty((n_elements, ), dtype=torch.int32, device="cuda")
+
+    grid = (triton.cdiv(n_elements, BLOCK), )
+    _inline_asm_math_kernel[grid](
+        triton.TensorWrapper(x, dtype=torch.float32),
+        triton.TensorWrapper(y, dtype=torch.float32),
+        triton.TensorWrapper(out, dtype=torch.float32),
+        n_elements,
+        ASM=asm,
+        BLOCK=BLOCK,
+        THREADS_PER_WARP=THREADS_PER_WARP,
+    )
+
+    exp_bits = _expected_extern_variadic_tag_i32(
+        [x.cpu().numpy().astype(np.int32, copy=False),
+         y.cpu().numpy().astype(np.int32, copy=False)], asm)
+    _assert_payload_equal(out, exp_bits)
+
+
 def _expected_fma_i32(x_i32: np.ndarray, y_i32: np.ndarray, z_i32: np.ndarray) -> np.ndarray:
     return _expected_add_i32(_expected_mul_i32(x_i32, y_i32), z_i32)
 

--- a/test/TritonGPU/fpsan.mlir
+++ b/test/TritonGPU/fpsan.mlir
@@ -639,6 +639,69 @@ tt.func public @extern_mixed(%a: tensor<4xf32>, %b: tensor<4xi32>) -> tensor<4xf
   tt.return %0 : tensor<4xf32>
 }
 
+// -----
+
+// CHECK-LABEL: @inline_asm_unary
+tt.func public @inline_asm_unary(%a: tensor<4xf32>) -> tensor<4xf32> {
+  // CHECK: arith.constant dense<-2010648817> : tensor<4xi32>
+  // CHECK: tti.experimental_fpsan_embed
+  // CHECK: arith.xori
+  // CHECK-NOT: tt.elementwise_inline_asm
+  %0 = tt.elementwise_inline_asm "ex2.approx.ftz.f32 $0, $1;" {constraints = "=r,r", packed_element = 1 : i32, pure = true} %a : tensor<4xf32> -> tensor<4xf32>
+  tt.return %0 : tensor<4xf32>
+}
+
+// -----
+
+// CHECK-LABEL: @inline_asm_unary_different_asm
+tt.func public @inline_asm_unary_different_asm(%a: tensor<4xf32>) -> tensor<4xf32> {
+  // CHECK: arith.constant dense<-88535098> : tensor<4xi32>
+  // CHECK: tti.experimental_fpsan_embed
+  // CHECK: arith.xori
+  // CHECK-NOT: tt.elementwise_inline_asm
+  %0 = tt.elementwise_inline_asm "cvt.rn.tf32.f32 $0, $1;" {constraints = "=r,r", packed_element = 1 : i32, pure = true} %a : tensor<4xf32> -> tensor<4xf32>
+  tt.return %0 : tensor<4xf32>
+}
+
+// -----
+
+// CHECK-LABEL: @inline_asm_binary
+tt.func public @inline_asm_binary(%a: tensor<4xf32>, %b: tensor<4xf32>) -> tensor<4xf32> {
+  // CHECK: arith.constant dense<1604722435> : tensor<4xi32>
+  // CHECK: tti.experimental_fpsan_embed
+  // CHECK: arith.addi
+  // CHECK: arith.xori
+  // CHECK-NOT: tt.elementwise_inline_asm
+  %0 = tt.elementwise_inline_asm "add.f32 $0, $1, $2;" {constraints = "=r,r,r", packed_element = 1 : i32, pure = true} %a, %b : tensor<4xf32>, tensor<4xf32> -> tensor<4xf32>
+  tt.return %0 : tensor<4xf32>
+}
+
+// -----
+
+// CHECK-LABEL: @inline_asm_mixed
+tt.func public @inline_asm_mixed(%a: tensor<4xf32>, %b: tensor<4xi32>) -> tensor<4xf32> {
+  // CHECK: arith.constant dense<1352527917> : tensor<4xi32>
+  // CHECK: tti.experimental_fpsan_embed
+  // CHECK: arith.addi
+  // CHECK: arith.xori
+  // CHECK-NOT: tt.elementwise_inline_asm
+  %0 = tt.elementwise_inline_asm "shf.l.wrap.b32 $0, $1, $2, $2;" {constraints = "=r,r,r", packed_element = 1 : i32, pure = true} %a, %b : tensor<4xf32>, tensor<4xi32> -> tensor<4xf32>
+  tt.return %0 : tensor<4xf32>
+}
+
+// -----
+
+// CHECK-LABEL: @inline_asm_multi_result
+tt.func public @inline_asm_multi_result(%a: tensor<4xi64>) -> (tensor<4xf32>, tensor<4xf32>) {
+  // CHECK-DAG: arith.constant dense<2041845833> : tensor<4xi32>
+  // CHECK-DAG: arith.constant dense<2041845832> : tensor<4xi32>
+  // CHECK: arith.xori
+  // CHECK: arith.xori
+  // CHECK-NOT: tt.elementwise_inline_asm
+  %0:2 = tt.elementwise_inline_asm "mov.b64 { $0, $1 }, $2;" {constraints = "=r,=r,l", packed_element = 1 : i32, pure = true} %a : tensor<4xi64> -> tensor<4xf32>, tensor<4xf32>
+  tt.return %0#0, %0#1 : tensor<4xf32>, tensor<4xf32>
+}
+
 //--- canonicalize.mlir
 
 module {


### PR DESCRIPTION
PR description written by Codex

Use the extern-style structural tag for pure inline assembly, hashing the asm string and distinguishing multi-result outputs. Add lit and CUDA payload coverage, including the Swiglu tanh substitution regression, and update the FPSan documentation.

Validated with all three FPSan lit suites and the Gluon FPSan suite (199 passed, 114 skipped), plus the focused extern/inline-asm/Swiglu regression suite (13 passed).

## Stack
Merge bottom-up:
- [ ] #10857 (this PR)
