### PR TITLE
[BACKEND] Allow to split TMEM along M

### DIFF
--- a/include/triton/Dialect/TritonNvidiaGPU/IR/Dialect.h
+++ b/include/triton/Dialect/TritonNvidiaGPU/IR/Dialect.h
@@ -120,7 +120,8 @@ LinearLayout getTileLayout(MLIRContext *ctx, TMemAccessAtom atom, bool unpacked,
 
 TMemAllocation getTmemAllocSizes(gpu::MemDescType memDescType);
 
-uint32_t getTMemSubSliceOffset(gpu::MemDescType memDescType, int32_t nOffset);
+uint32_t getTMemSubSliceOffset(gpu::MemDescType memDescType, int32_t offset,
+                               int32_t dim);
 
 SmallVector<gpu::DistributedEncodingTrait>
 getTmemCompatibleLayouts(gpu::MemDescType memType, unsigned numWarps,

--- a/include/triton/Dialect/TritonNvidiaGPU/IR/TensorMemoryUtils.h
+++ b/include/triton/Dialect/TritonNvidiaGPU/IR/TensorMemoryUtils.h
@@ -21,7 +21,6 @@ struct TMemLdStEncodingInfo {
   ColumnAction perm;
   int numRegsPerMessage;
   std::optional<uint32_t> secondHalfOffset;
-  std::optional<ColumnAction> broadcast = std::nullopt;
   bool unpacked = false;
   unsigned vec = 1;
   bool padding = false;

--- a/include/triton/Dialect/TritonNvidiaGPU/IR/TritonNvidiaGPUOps.td
+++ b/include/triton/Dialect/TritonNvidiaGPU/IR/TritonNvidiaGPUOps.td
@@ -984,9 +984,8 @@ def TTNG_TMEMSubSliceOp : TTNG_Op<"tmem_subslice", [Pure,
   let description = [{
     This operation takes a subslice of a tensor memory allocation and returns a
     new descriptor containing the address and a view of the subslice.
-    This is similar to ttg.memdesc_subslice except we can only slice along the
-    inner dimension of a 2D memdesc, as this is the only supported slice for
-    TMEM.
+    This is similar to ttg.memdesc_subslice and can slice either dimension of a
+    2D tensor memory descriptor, including non-contiguous views within a CTA.
   }];
   let arguments = (ins TTG_MemDescType:$src, I32Attr:$offset,
                        DefaultValuedAttr<I32Attr, "1">:$dim);
@@ -1009,6 +1008,8 @@ def TTNG_TMEMCopyOp : TTNG_Op<"tmem_copy"> {
     2D blocks stored contiguously in SMEM are copied into TMEM as specified by the destination address.
     This op lowers to the PTX instruction tcgen05.cp. This supports writing to
     the scales TMEM layout as well as the default TMEM layout.
+    For the default layout, each contiguous TMEM row segment must contain at
+    least 128 bits, the minimum width supported by tcgen05.cp.
     Currently, the semantics are different when writing to the TMEM scale layout.
 
     In the case of the default layout, the copy doesn't change the logical

--- a/include/triton/Dialect/TritonNvidiaGPU/IR/TritonNvidiaGPUOps.td
+++ b/include/triton/Dialect/TritonNvidiaGPU/IR/TritonNvidiaGPUOps.td
@@ -988,14 +988,15 @@ def TTNG_TMEMSubSliceOp : TTNG_Op<"tmem_subslice", [Pure,
     inner dimension of a 2D memdesc, as this is the only supported slice for
     TMEM.
   }];
-  let arguments = (ins TTG_MemDescType:$src, I32Attr:$N);
+  let arguments = (ins TTG_MemDescType:$src, I32Attr:$offset,
+                       DefaultValuedAttr<I32Attr, "1">:$dim);
 
   let assemblyFormat = [{
     $src attr-dict `:` qualified(type($src)) `->` qualified(type($result))
   }];
 
   let builders = [
-      OpBuilder<(ins "Value":$alloc, "int":$offset, "int":$size)>,
+      OpBuilder<(ins "Value":$alloc, "int":$offset, "int":$size, "int":$dim)>,
     ];
   let results = (outs TTG_MemDescType:$result);
   let hasVerifier = 1;

--- a/lib/Analysis/BufferRegion.cpp
+++ b/lib/Analysis/BufferRegion.cpp
@@ -269,7 +269,7 @@ LogicalResult BufferRegionAnalysis::visitOperation(
     RegionInfo in = operands[0]->getValue();
     uint32_t subBufferSize = getMemDescSize(tmemSubsliceOp.getType());
     uint32_t relativeOffset = ttng::getTMemSubSliceOffset(
-        tmemSubsliceOp.getType(), tmemSubsliceOp.getN());
+        tmemSubsliceOp.getType(), tmemSubsliceOp.getOffset());
     for (auto &region : in.regions) {
       regionInfo.regions.insert(
           {region.baseOffset + relativeOffset, subBufferSize});

--- a/lib/Analysis/BufferRegion.cpp
+++ b/lib/Analysis/BufferRegion.cpp
@@ -269,7 +269,8 @@ LogicalResult BufferRegionAnalysis::visitOperation(
     RegionInfo in = operands[0]->getValue();
     uint32_t subBufferSize = getMemDescSize(tmemSubsliceOp.getType());
     uint32_t relativeOffset = ttng::getTMemSubSliceOffset(
-        tmemSubsliceOp.getType(), tmemSubsliceOp.getOffset());
+        tmemSubsliceOp.getSrc().getType(), tmemSubsliceOp.getOffset(),
+        tmemSubsliceOp.getDim());
     for (auto &region : in.regions) {
       regionInfo.regions.insert(
           {region.baseOffset + relativeOffset, subBufferSize});

--- a/lib/Dialect/TritonGPU/IR/LinearLayoutConversions.cpp
+++ b/lib/Dialect/TritonGPU/IR/LinearLayoutConversions.cpp
@@ -1374,10 +1374,29 @@ LinearLayout toLinearLayout(RankedTensorType type) {
 }
 
 LinearLayout toLinearLayout(MemDescType type) {
-  // Pass in the allocation shape. Then when using invertAndCompose it will
-  // trim the allocationShape to the shape if they are different.
-  // We also remove the first dimension of the allocationShape if there was a
-  // call to memdesc_index
+  // For TMEM we instantiate the subview directly. This is possible
+  // as TMEM has no swizzling.
+  if (isa<TensorMemoryEncodingAttr>(type.getEncoding())) {
+    auto shape = type.getShape().take_back(2);
+    auto allocShape = type.getAllocShape().take_back(2);
+    auto ll = toLinearLayout(allocShape, type.getEncoding());
+    // Trim the shape
+    for (auto [dim, size] : llvm::zip_equal(ll.getOutDimNames(), shape))
+      ll = ll.resizeOutDim(dim, size);
+
+    auto kCol = StringAttr::get(type.getContext(), "col");
+    int nColBases = ll.getInDimSizeLog2(kCol);
+    int bitwidth = type.getElementType().getIntOrFloatBitWidth();
+    int minColBases = llvm::Log2_32(32 / bitwidth);
+    while (nColBases > minColBases &&
+           llvm::all_of(ll.getBasis(kCol, nColBases - 1),
+                        [](int32_t v) { return v == 0; }))
+      --nColBases;
+    return ll.resizeInDim(kCol, 1u << nColBases);
+  }
+  // Shared memory needs the allocation shape so that invertAndCompose can trim
+  // subviews. We also remove the first dimension of the allocation shape if
+  // there was a call to memdesc_index.
   auto shape = type.getAllocShape().take_back(type.getRank());
   return toLinearLayout(shape, type.getEncoding());
 }

--- a/lib/Dialect/TritonGPU/IR/Types.cpp
+++ b/lib/Dialect/TritonGPU/IR/Types.cpp
@@ -122,6 +122,19 @@ LogicalResult MemDescType::verify(function_ref<InFlightDiagnostic()> emitError,
     if (shape.size() != 2 && shape.size() != 3) {
       return emitError() << "rank must be 2 or 3";
     }
+    auto isPowerOfTwo = [](int64_t dim) {
+      return llvm::isPowerOf2_64(dim) && dim > 0;
+    };
+    if (!llvm::all_of(shape.take_back(2), isPowerOfTwo)) {
+      return emitError()
+             << "shape must have power-of-2 and non-zero dimensions; got "
+             << shape;
+    }
+    if (!llvm::all_of(allocShape.take_back(2), isPowerOfTwo)) {
+      return emitError()
+             << "alloc shape must have power-of-2 and non-zero dimensions; got "
+             << allocShape;
+    }
     unsigned bitwidth = elementType.getIntOrFloatBitWidth();
     if (bitwidth * enc.getColStride() > 32) {
       return emitError()
@@ -133,11 +146,11 @@ LogicalResult MemDescType::verify(function_ref<InFlightDiagnostic()> emitError,
     allocShape = allocShape.take_back(2);
     auto ctaSplit = enc.getCGALayout().getCTASplitNum();
     auto blockN = std::min<int32_t>(enc.getBlockN(), shape.back());
-    if (allocShape[0] < enc.getBlockM() * ctaSplit[0] ||
-        allocShape[1] < blockN * ctaSplit[1]) {
-      return emitError() << "the allocation shape must be at least "
+    if (shape[shape.size() - 2] < enc.getBlockM() * ctaSplit[0] ||
+        shape[shape.size() - 1] < blockN * ctaSplit[1]) {
+      return emitError() << "the tensor shape must be at least "
                          << enc.getBlockM() * ctaSplit[0] << "x"
-                         << blockN * ctaSplit[1] << ". Got " << allocShape;
+                         << blockN * ctaSplit[1] << ". Got " << shape;
     }
     // Checks the layout of the allocation
     auto ll = toLinearLayout(allocShape, enc);

--- a/lib/Dialect/TritonInstrument/Transforms/FpSanitizer.cpp
+++ b/lib/Dialect/TritonInstrument/Transforms/FpSanitizer.cpp
@@ -366,7 +366,7 @@ public:
       int64_t stride = baseTy.getShape().front();
       if (baseTy.getRank() > 2)
         stride = product(baseTy.getShape().drop_front(1));
-      int64_t offset = subslice.getN();
+      int64_t offset = subslice.getOffset();
       auto offsetVal = arith::ConstantOp::create(
           rewriter, loc, rewriter.getI32IntegerAttr(offset));
       auto strideVal = arith::ConstantOp::create(

--- a/lib/Dialect/TritonInstrument/Transforms/FpSanitizer.cpp
+++ b/lib/Dialect/TritonInstrument/Transforms/FpSanitizer.cpp
@@ -357,15 +357,17 @@ public:
         return std::nullopt;
 
       auto baseTy = cast<ttg::MemDescType>(subslice.getSrc().getType());
-      if (baseTy.getRank() < 2 || memTy.getRank() != 2)
+      if (baseTy.getRank() != 2 || memTy.getRank() != 2 ||
+          baseInfo->tensorType.getRank() != 2)
         return std::nullopt;
 
       OpBuilder::InsertionGuard guard(rewriter);
       rewriter.setInsertionPoint(subslice);
       auto loc = subslice.getLoc();
-      int64_t stride = baseTy.getShape().front();
-      if (baseTy.getRank() > 2)
-        stride = product(baseTy.getShape().drop_front(1));
+      // Scratch tensors are column-major. Keep the parent shape so a row
+      // slice and any following column slices retain the original stride.
+      int64_t stride =
+          subslice.getDim() == 0 ? 1 : baseInfo->tensorType.getShape().front();
       int64_t offset = subslice.getOffset();
       auto offsetVal = arith::ConstantOp::create(
           rewriter, loc, rewriter.getI32IntegerAttr(offset));
@@ -376,11 +378,7 @@ public:
       Value ptr = tt::AddPtrOp::create(rewriter, loc, baseInfo->ptr.getType(),
                                        baseInfo->ptr, offsetEls);
       ptr = remapToScope(ptr, rewriter, scope, loc);
-      auto layout = getScratchEncoding(rewriter, memdesc, memTy);
-      auto tensorTy = RankedTensorType::get(memTy.getShape(),
-                                            memTy.getElementType(), layout);
-
-      ScratchInfo info{ptr, tensorTy};
+      ScratchInfo info{ptr, baseInfo->tensorType};
       return info;
     }
 
@@ -972,6 +970,76 @@ Value fpsanVariadicExternTagged(PatternRewriter &rewriter, Location loc,
   return unembedToFloat(rewriter, loc, outI, resultTy);
 }
 
+static Value createPointerTensorStrided2D(PatternRewriter &rewriter,
+                                          Location loc, Value base,
+                                          RankedTensorType resultTy,
+                                          int64_t stride0, int64_t stride1) {
+  auto shape = resultTy.getShape();
+  auto encoding = cast<ttg::DistributedEncodingTrait>(resultTy.getEncoding());
+  auto ptrTy = base.getType();
+  auto ptrTensorTy = RankedTensorType::get(shape, ptrTy, encoding);
+  Value ptrTensor = tt::SplatOp::create(rewriter, loc, ptrTensorTy, base);
+  auto i32Ty = rewriter.getI32Type();
+  auto offsetsTy = RankedTensorType::get(shape, i32Ty, encoding);
+
+  auto dim0Ty = getSlicedTensorType(offsetsTy, {0}, i32Ty);
+  auto range0 = tt::MakeRangeOp::create(rewriter, loc, dim0Ty, 0, shape[0]);
+  auto stride0Const = createConstIntTensor(rewriter, loc, stride0, dim0Ty);
+  auto off0 =
+      arith::MulIOp::create(rewriter, loc, dim0Ty, range0, stride0Const);
+  auto off0Exp = reshapeAndBroadcast(rewriter, loc, off0, {0}, offsetsTy);
+  ptrTensor =
+      tt::AddPtrOp::create(rewriter, loc, ptrTensorTy, ptrTensor, off0Exp);
+
+  auto dim1Ty = getSlicedTensorType(offsetsTy, {1}, i32Ty);
+  auto range1 = tt::MakeRangeOp::create(rewriter, loc, dim1Ty, 0, shape[1]);
+  auto stride1Const = createConstIntTensor(rewriter, loc, stride1, dim1Ty);
+  auto off1 =
+      arith::MulIOp::create(rewriter, loc, dim1Ty, range1, stride1Const);
+  auto off1Exp = reshapeAndBroadcast(rewriter, loc, off1, {1}, offsetsTy);
+  ptrTensor =
+      tt::AddPtrOp::create(rewriter, loc, ptrTensorTy, ptrTensor, off1Exp);
+
+  return ptrTensor;
+}
+
+static Value loadScratchStrided2D(PatternRewriter &rewriter, Location loc,
+                                  Value base, RankedTensorType tensorTy,
+                                  int64_t stride0, int64_t stride1) {
+  auto storageTy = getScratchStorageType(tensorTy);
+  auto ptrTensor = createPointerTensorStrided2D(rewriter, loc, base, storageTy,
+                                                stride0, stride1);
+  Value stored =
+      tt::LoadOp::create(rewriter, loc, ptrTensor, CacheModifier::NONE,
+                         EvictionPolicy::NORMAL, false);
+  if (isFloatLike(tensorTy))
+    return unembedToFloat(rewriter, loc, stored, tensorTy);
+  return stored;
+}
+
+static Value loadScratchStrided2D(PatternRewriter &rewriter, Location loc,
+                                  Value base, RankedTensorType tensorTy,
+                                  int64_t stride1) {
+  return loadScratchStrided2D(rewriter, loc, base, tensorTy, /*stride0=*/1,
+                              stride1);
+}
+
+static Operation *storeScratchStrided2D(PatternRewriter &rewriter, Location loc,
+                                        Value base, Value tensor,
+                                        RankedTensorType tensorTy,
+                                        int64_t stride0, int64_t stride1,
+                                        bool ignoreCTA = false) {
+  auto storageTy = getScratchStorageType(tensorTy);
+  auto ptrTensor = createPointerTensorStrided2D(rewriter, loc, base, storageTy,
+                                                stride0, stride1);
+  Value stored = tensor;
+  if (isFloatLike(tensorTy))
+    stored = embedToInt(rewriter, loc, tensor);
+  return tt::StoreOp::create(rewriter, loc, ptrTensor, stored, Value(),
+                             CacheModifier::NONE, EvictionPolicy::NORMAL,
+                             ignoreCTA);
+}
+
 std::optional<ScratchInfo>
 createTmemOperandScratch(PatternRewriter &rewriter, Location loc,
                          TmemScratchManager &scratch, Value memdesc,
@@ -982,7 +1050,8 @@ createTmemOperandScratch(PatternRewriter &rewriter, Location loc,
   auto info = scratch.getOrCreate(memdesc, rewriter, scope);
   if (!info || info->scaleSourceType)
     return std::nullopt;
-  Value fullVal = loadFpSanScratchMemory(rewriter, loc, info->ptr, tensorTy);
+  Value fullVal = loadScratchStrided2D(rewriter, loc, info->ptr, tensorTy,
+                                       info->tensorType.getShape().front());
   if (!fullVal)
     return std::nullopt;
   int64_t elSize = memTy.getElementType().getIntOrFloatBitWidth() / 8;
@@ -1041,58 +1110,6 @@ Value createAsyncToken(PatternRewriter &rewriter, Location loc,
   return ttg::AsyncCommitGroupOp::create(rewriter, loc, deps).getResult();
 }
 
-Value createPointerTensorStrided2D(PatternRewriter &rewriter, Location loc,
-                                   Value base, RankedTensorType resultTy,
-                                   int64_t stride0, int64_t stride1) {
-  auto shape = resultTy.getShape();
-  auto encoding = cast<ttg::DistributedEncodingTrait>(resultTy.getEncoding());
-  auto ptrTy = base.getType();
-  auto ptrTensorTy = RankedTensorType::get(shape, ptrTy, encoding);
-  Value ptrTensor = tt::SplatOp::create(rewriter, loc, ptrTensorTy, base);
-  auto i32Ty = rewriter.getI32Type();
-  auto offsetsTy = RankedTensorType::get(shape, i32Ty, encoding);
-
-  auto dim0Ty = getSlicedTensorType(offsetsTy, {0}, i32Ty);
-  auto range0 = tt::MakeRangeOp::create(rewriter, loc, dim0Ty, 0, shape[0]);
-  auto stride0Const = createConstIntTensor(rewriter, loc, stride0, dim0Ty);
-  auto off0 =
-      arith::MulIOp::create(rewriter, loc, dim0Ty, range0, stride0Const);
-  auto off0Exp = reshapeAndBroadcast(rewriter, loc, off0, {0}, offsetsTy);
-  ptrTensor =
-      tt::AddPtrOp::create(rewriter, loc, ptrTensorTy, ptrTensor, off0Exp);
-
-  auto dim1Ty = getSlicedTensorType(offsetsTy, {1}, i32Ty);
-  auto range1 = tt::MakeRangeOp::create(rewriter, loc, dim1Ty, 0, shape[1]);
-  auto stride1Const = createConstIntTensor(rewriter, loc, stride1, dim1Ty);
-  auto off1 =
-      arith::MulIOp::create(rewriter, loc, dim1Ty, range1, stride1Const);
-  auto off1Exp = reshapeAndBroadcast(rewriter, loc, off1, {1}, offsetsTy);
-  ptrTensor =
-      tt::AddPtrOp::create(rewriter, loc, ptrTensorTy, ptrTensor, off1Exp);
-
-  return ptrTensor;
-}
-
-Value loadScratchStrided2D(PatternRewriter &rewriter, Location loc, Value base,
-                           RankedTensorType tensorTy, int64_t stride0,
-                           int64_t stride1) {
-  auto storageTy = getScratchStorageType(tensorTy);
-  auto ptrTensor = createPointerTensorStrided2D(rewriter, loc, base, storageTy,
-                                                stride0, stride1);
-  Value stored =
-      tt::LoadOp::create(rewriter, loc, ptrTensor, CacheModifier::NONE,
-                         EvictionPolicy::NORMAL, false);
-  if (isFloatLike(tensorTy))
-    return unembedToFloat(rewriter, loc, stored, tensorTy);
-  return stored;
-}
-
-Value loadScratchStrided2D(PatternRewriter &rewriter, Location loc, Value base,
-                           RankedTensorType tensorTy, int64_t stride1) {
-  return loadScratchStrided2D(rewriter, loc, base, tensorTy, /*stride0=*/1,
-                              stride1);
-}
-
 Value loadMmaOperand(PatternRewriter &rewriter, Location loc,
                      const MmaOperandSource &source, RankedTensorType resultTy,
                      bool isLhs, Value tileOffset, Value kOffset) {
@@ -1132,20 +1149,6 @@ Value loadMmaOperand(PatternRewriter &rewriter, Location loc,
   return ExperimentalLocalGatherOp::create(rewriter, loc, resultTy, shared,
                                            indices, offsets,
                                            rewriter.getI32IntegerAttr(kAxis));
-}
-
-Operation *storeScratchStrided2D(PatternRewriter &rewriter, Location loc,
-                                 Value base, Value tensor,
-                                 RankedTensorType tensorTy, int64_t stride0,
-                                 int64_t stride1) {
-  auto storageTy = getScratchStorageType(tensorTy);
-  auto ptrTensor = createPointerTensorStrided2D(rewriter, loc, base, storageTy,
-                                                stride0, stride1);
-  Value stored = tensor;
-  if (isFloatLike(tensorTy))
-    stored = embedToInt(rewriter, loc, tensor);
-  return tt::StoreOp::create(rewriter, loc, ptrTensor, stored,
-                             CacheModifier::NONE, EvictionPolicy::NORMAL);
 }
 
 Value unpackPackedFp4Slice(PatternRewriter &rewriter, Location loc,
@@ -2446,7 +2449,8 @@ struct TMEMLoadPattern : public OpRewritePattern<ttng::TMEMLoadOp> {
       if (isFloatLike(resultTy))
         result = unembedToFloat(rewriter, loc, result, resultTy);
     } else {
-      result = loadFpSanScratchMemory(rewriter, loc, info->ptr, resultTy);
+      result = loadScratchStrided2D(rewriter, loc, info->ptr, resultTy,
+                                    info->tensorType.getShape().front());
     }
 
     if (!result)
@@ -2520,15 +2524,17 @@ struct TMEMStorePattern : public OpRewritePattern<ttng::TMEMStoreOp> {
     if (!srcTy.getEncoding())
       return emitFpSanUnsupported(op.getOperation());
     auto storageTy = getScratchStorageType(srcTy);
+    int64_t stride = info->tensorType.getShape().front();
     Value stored = embedToInt(rewriter, loc, op.getSrc());
     if (!matchPattern(op.getPred(), m_One())) {
       Value previous =
-          createLoadScratchMemory(rewriter, loc, info->ptr, storageTy);
+          loadScratchStrided2D(rewriter, loc, info->ptr, storageTy, stride);
       Value pred = castScalarIntToIntLike(
           rewriter, loc, op.getPred(), storageTy.clone(rewriter.getI1Type()));
       stored = arith::SelectOp::create(rewriter, loc, pred, stored, previous);
     }
-    if (!createStoreScratchMemory(rewriter, loc, info->ptr, stored, storageTy))
+    if (!storeScratchStrided2D(rewriter, loc, info->ptr, stored, storageTy,
+                               /*stride0=*/1, stride, /*ignoreCTA=*/true))
       return emitFpSanCodegenError(op.getOperation());
 
     createGlobalScratchBarrier(rewriter, loc,
@@ -2577,7 +2583,10 @@ struct TMEMCopyPattern : public OpRewritePattern<ttng::TMEMCopyOp> {
     Value srcReg =
         ttg::LocalLoadOp::create(rewriter, loc, srcRegTy, op.getSrc(), Value())
             .getResult();
-    if (!storeFpSanScratchMemory(rewriter, loc, info->ptr, srcReg, srcRegTy))
+    if (!storeScratchStrided2D(rewriter, loc, info->ptr, srcReg, srcRegTy,
+                               /*stride0=*/1,
+                               info->tensorType.getShape().front(),
+                               /*ignoreCTA=*/true))
       return emitFpSanCodegenError(op.getOperation());
 
     createGlobalScratchBarrier(rewriter, loc,
@@ -2791,7 +2800,8 @@ struct TCGen5MMAPattern : public OpRewritePattern<ttng::TCGen5MMAOp> {
 
     auto mLoop = emitMmaEmulationLoops(
         rewriter, loc, *aSource, *bSource, dInfo->ptr, m, n, k, tileM, tileN,
-        accTileTy, accTileLayout, accElem, useDInt, predInt, /*dStride=*/m);
+        accTileTy, accTileLayout, accElem, useDInt, predInt,
+        /*dStride=*/dInfo->tensorType.getShape().front());
     if (!mLoop)
       return emitFpSanUnsupported(op.getOperation());
     rewriter.setInsertionPointAfter(*mLoop);
@@ -2966,10 +2976,10 @@ struct TCGen5MMAScaledPattern
     createGlobalScratchBarrier(rewriter, loc,
                                scratch->usesSharedClusterState());
 
-    auto mLoop =
-        emitMmaEmulationLoops(rewriter, loc, *aSource, *bSource, dInfo->ptr, m,
-                              n, k, tileM, tileN, accTileTy, accTileLayout,
-                              accElem, useDInt, predInt, /*dStride=*/m, scale);
+    auto mLoop = emitMmaEmulationLoops(
+        rewriter, loc, *aSource, *bSource, dInfo->ptr, m, n, k, tileM, tileN,
+        accTileTy, accTileLayout, accElem, useDInt, predInt,
+        /*dStride=*/dInfo->tensorType.getShape().front(), scale);
     if (!mLoop)
       return emitFpSanUnsupported(op.getOperation());
     rewriter.setInsertionPointAfter(*mLoop);

--- a/lib/Dialect/TritonNvidiaGPU/IR/Dialect.cpp
+++ b/lib/Dialect/TritonNvidiaGPU/IR/Dialect.cpp
@@ -75,7 +75,7 @@ TMemAllocation getTmemAllocSizes(MemDescType memDescType) {
   auto ll = toLinearLayout(memDescType);
   auto bitwidth = memDescType.getElementTypeBitWidth();
   int nRow = ll.getInDimSize(kRow);
-  int nCol = ll.getInDimSize(kCol) / (32 / bitwidth);
+  int nCol = llvm::divideCeil(ll.getInDimSize(kCol) * bitwidth, 32);
   // If we have just one 16xcol block per warp, we don't allocate 128 rows
   // we use 64 rows instead.
   // We could generalise this to when we have more zeros in the layout, but

--- a/lib/Dialect/TritonNvidiaGPU/IR/Dialect.cpp
+++ b/lib/Dialect/TritonNvidiaGPU/IR/Dialect.cpp
@@ -71,9 +71,8 @@ TMemAllocation getTmemAllocSizes(MemDescType memDescType) {
   auto S = [&](StringRef str) { return StringAttr::get(ctx, str); };
   auto kRow = S("row");
   auto kCol = S("col");
-  // Remove multibuffering if present
-  auto shape = memDescType.getShape().take_back(2);
-  auto ll = toLinearLayout(shape, memDescType.getEncoding());
+  // Remove multibuffering if present and preserve any tensor-memory subview.
+  auto ll = toLinearLayout(memDescType);
   auto bitwidth = memDescType.getElementTypeBitWidth();
   int nRow = ll.getInDimSize(kRow);
   int nCol = ll.getInDimSize(kCol) / (32 / bitwidth);
@@ -92,14 +91,15 @@ TMemAllocation getTmemAllocSizes(MemDescType memDescType) {
   return {nRow, nCol};
 }
 
-uint32_t getTMemSubSliceOffset(MemDescType memDescType, int32_t nOffset) {
+uint32_t getTMemSubSliceOffset(MemDescType memDescType, int32_t offset,
+                               int32_t dim) {
   auto llInv = toLinearLayout(memDescType).pseudoinvert();
   auto dimNames = llvm::to_vector(llInv.getInDimNames());
   SmallVector<std::pair<StringAttr, int32_t>> logicalOffsets;
   logicalOffsets.reserve(dimNames.size());
   for (auto dim : dimNames)
     logicalOffsets.push_back({dim, 0});
-  logicalOffsets.back().second = nOffset;
+  logicalOffsets[dim].second = offset;
 
   auto rowCol = llInv.apply(logicalOffsets);
   uint32_t bitwidth = memDescType.getElementTypeBitWidth();
@@ -321,7 +321,7 @@ getDistributedLayoutForTmemLdSt(gpu::MemDescType memType, TMemAccessAtom atom,
          "numWarps must be a power of 2 and >= 4");
   assert(atom != TMemAccessAtom::I16x32bx2 &&
          "This layout is inferred sometimes for the 32x32b atom");
-  auto ll = toLinearLayout(memType.getShape(), memType.getEncoding());
+  auto ll = toLinearLayout(memType);
   auto bitwidth = memType.getElementTypeBitWidth();
   return getDistributedLayoutForTmemLdSt(ll, atom, numWarps, bitwidth);
 }

--- a/lib/Dialect/TritonNvidiaGPU/IR/Ops.cpp
+++ b/lib/Dialect/TritonNvidiaGPU/IR/Ops.cpp
@@ -1526,6 +1526,15 @@ LogicalResult TMEMCopyOp::verify() {
     if (srcTy.getElementType().getIntOrFloatBitWidth() != 32) {
       return emitOpError("Source element type should be 32-bit.");
     }
+    auto kCol = StringAttr::get(getContext(), "col");
+    auto colBases = tmemLl.getBases().lookup(kCol);
+    auto firstHole = llvm::find_if(colBases, [](ArrayRef<int32_t> basis) {
+      return llvm::all_of(basis,
+                          [](int32_t component) { return component == 0; });
+    });
+    if (std::distance(colBases.begin(), firstHole) < 2)
+      return emitOpError("The destination must have at least 128 contiguous "
+                         "bits per TMEM row.");
   }
   // Given that we want to support flexible input SMEM shapes, kinds of shape
   // checking we can do here are limited. For simplicity, shape checking is
@@ -1561,18 +1570,37 @@ LogicalResult TMEMSubSliceOp::verify() {
     return emitOpError("The result must be a 2D tensor memory buffer.");
   if (dstTy.getRank() != 2)
     return emitOpError("The result must be a 2D tensor memory buffer.");
-  if (getDim() != 1)
-    return emitOpError("Only slicing the inner dimension is supported.");
-  if (dstTy.getDimSize(0) != srcTy.getDimSize(0))
-    return emitOpError("The result must have the same number of rows as the "
-                       "source.");
+  auto dim = getDim();
+  if (dim > 1)
+    return emitOpError("The slice dimension must be 0 or 1.");
+  if (dstTy.getDimSize(1 - dim) != srcTy.getDimSize(1 - dim))
+    return emitOpError("The result must have the same size as the source in "
+                       "the dimension that is not being sliced.");
+  auto srcShape = srcTy.getShape();
+  auto dstShape = dstTy.getShape();
   auto offset = getOffset();
-  if (offset & (dstTy.getDimSize(1) - 1)) {
+  if (offset & (dstShape[dim] - 1)) {
     return emitError("The split offset may not touch the tile");
   }
-  if (offset >= srcTy.getDimSize(1)) {
+  if (offset + dstShape[dim] > srcShape[dim]) {
     return emitError("The split offset may not exceed the source shape");
   }
+  auto srcLL = toLinearLayout(srcTy);
+  auto isTrimmed = [&](ArrayRef<int32_t> basis) {
+    return basis[dim] >= dstShape[dim];
+  };
+  auto kBlock = StringAttr::get(getContext(), "block");
+  if (llvm::any_of(srcLL.getBases().lookup(kBlock), isTrimmed))
+    return emitOpError("The result may not be sliced across CTAs.");
+
+  auto dims = standardOutDimNames(getContext(), 2);
+  auto logical = static_cast<int32_t>(offset);
+  SmallVector<std::pair<StringAttr, int32_t>> logicalOffset = {
+      {dims[0], dim == 0 ? logical : 0}, {dims[1], dim == 1 ? logical : 0}};
+  auto rowCol = srcLL.pseudoinvert().apply(logicalOffset);
+  if (uint64_t(rowCol[1].second) * srcTy.getElementTypeBitWidth() % 32 != 0)
+    return emitOpError(
+        "The split offset must be 32-bit aligned in tensor memory.");
 
   return success();
 }

--- a/lib/Dialect/TritonNvidiaGPU/IR/Ops.cpp
+++ b/lib/Dialect/TritonNvidiaGPU/IR/Ops.cpp
@@ -1571,7 +1571,7 @@ LogicalResult TMEMSubSliceOp::verify() {
   if (dstTy.getRank() != 2)
     return emitOpError("The result must be a 2D tensor memory buffer.");
   auto dim = getDim();
-  if (dim > 1)
+  if (dim < 0 || dim > 1)
     return emitOpError("The slice dimension must be 0 or 1.");
   if (dstTy.getDimSize(1 - dim) != srcTy.getDimSize(1 - dim))
     return emitOpError("The result must have the same size as the source in "

--- a/lib/Dialect/TritonNvidiaGPU/IR/Ops.cpp
+++ b/lib/Dialect/TritonNvidiaGPU/IR/Ops.cpp
@@ -1561,10 +1561,12 @@ LogicalResult TMEMSubSliceOp::verify() {
     return emitOpError("The result must be a 2D tensor memory buffer.");
   if (dstTy.getRank() != 2)
     return emitOpError("The result must be a 2D tensor memory buffer.");
+  if (getDim() != 1)
+    return emitOpError("Only slicing the inner dimension is supported.");
   if (dstTy.getDimSize(0) != srcTy.getDimSize(0))
     return emitOpError("The result must have the same number of rows as the "
                        "source.");
-  auto offset = getN();
+  auto offset = getOffset();
   if (offset & (dstTy.getDimSize(1) - 1)) {
     return emitError("The split offset may not touch the tile");
   }
@@ -1576,12 +1578,12 @@ LogicalResult TMEMSubSliceOp::verify() {
 }
 
 void TMEMSubSliceOp::build(OpBuilder &builder, OperationState &state,
-                           Value alloc, int offset, int size) {
+                           Value alloc, int offset, int size, int dim) {
   auto allocTy = cast<triton::gpu::MemDescType>(alloc.getType());
   SmallVector<int64_t> shape(allocTy.getShape());
-  shape.back() = size;
+  shape[dim] = size;
   auto subsliceType = allocTy.cloneWith(shape, allocTy.getElementType());
-  build(builder, state, subsliceType, alloc, offset);
+  build(builder, state, subsliceType, alloc, offset, dim);
 }
 
 // -- TensormapCreateOp --

--- a/lib/Dialect/TritonNvidiaGPU/IR/TensorMemoryUtils.cpp
+++ b/lib/Dialect/TritonNvidiaGPU/IR/TensorMemoryUtils.cpp
@@ -124,14 +124,9 @@ lowerTMemLdSt(const LinearLayout &cvt, int maxnreg, int bitwidth,
 
   // Remove broadcasting in the registers
   auto removeBroadcastSrc = actionRemoveBroadcastedRegs(cvt);
-  if (!removeBroadcastSrc.isIdentity()) {
-    auto prmtCvt = removeBroadcastSrc.apply(cvt);
-    auto info = lowerTMemLdSt(prmtCvt, maxnreg, bitwidth, emitError, unpacked);
-    if (failed(info))
-      return failure();
-    info->broadcast = std::move(removeBroadcastSrc);
-    return info;
-  }
+  if (!removeBroadcastSrc.isIdentity())
+    return lowerTMemLdSt(removeBroadcastSrc.apply(cvt), maxnreg, bitwidth,
+                         emitError, unpacked);
   auto *ctx = cvt.getInDimNames().begin()->getContext();
   auto S = [ctx](StringRef str) { return StringAttr::get(ctx, str); };
   auto kReg = S("register");
@@ -170,7 +165,9 @@ lowerTMemLdSt(const LinearLayout &cvt, int maxnreg, int bitwidth,
       // to fill a full 32b register, e.g., colN = 1 and colStride != 1 or when
       // bitwidth == 8 (this happens with scales with K=1).
       // These two cases are mostly supported for testing purposes.
-      unpacked = bitwidth == 16;
+      // A padded TMEM value occupies one physical column, so an unpacked
+      // store would overwrite the adjacent column.
+      unpacked = false;
       quot = *maybeQuot;
       padding = true;
       newBitwidth = 32;

--- a/lib/Dialect/TritonNvidiaGPU/Transforms/InterleaveTMem.cpp
+++ b/lib/Dialect/TritonNvidiaGPU/Transforms/InterleaveTMem.cpp
@@ -150,17 +150,18 @@ std::pair<Value, AccessRange> findBufferAccess(Value a) {
     return findBufferAccessMemdescSubview(defOp);
   }
 
-  // Subslice is a subview only on the N dimension.
+  // Subslice is a subview on one tensor dimension.
   if (auto subslice = dyn_cast<TMEMSubSliceOp>(defOp)) {
     auto [alloc, parentAccess] = findBufferAccess(subslice.getSrc());
     if (!alloc)
       return {};
-    if (!parentAccess.ranges[1])
+    unsigned dim = subslice.getDim();
+    if (!parentAccess.ranges[dim])
       return {alloc, parentAccess};
-    uint64_t mStart = parentAccess.ranges[1]->start() + subslice.getOffset();
-    uint64_t mSize = subslice.getType().getShape()[1];
+    uint64_t start = parentAccess.ranges[dim]->start() + subslice.getOffset();
+    uint64_t size = subslice.getType().getShape()[dim];
     AccessRange childAccess = parentAccess;
-    childAccess.ranges[1] = {{mStart, mStart + mSize}};
+    childAccess.ranges[dim] = {{start, start + size}};
     return {alloc, std::move(childAccess)};
   }
 

--- a/lib/Dialect/TritonNvidiaGPU/Transforms/InterleaveTMem.cpp
+++ b/lib/Dialect/TritonNvidiaGPU/Transforms/InterleaveTMem.cpp
@@ -157,7 +157,7 @@ std::pair<Value, AccessRange> findBufferAccess(Value a) {
       return {};
     if (!parentAccess.ranges[1])
       return {alloc, parentAccess};
-    uint64_t mStart = parentAccess.ranges[1]->start() + subslice.getN();
+    uint64_t mStart = parentAccess.ranges[1]->start() + subslice.getOffset();
     uint64_t mSize = subslice.getType().getShape()[1];
     AccessRange childAccess = parentAccess;
     childAccess.ranges[1] = {{mStart, mStart + mSize}};

--- a/lib/Dialect/TritonNvidiaGPU/Transforms/OptimizeTMemLayouts.cpp
+++ b/lib/Dialect/TritonNvidiaGPU/Transforms/OptimizeTMemLayouts.cpp
@@ -31,9 +31,9 @@ namespace {
 //  %lhs, %rhs = tt.split %t
 //
 // becomes
-//  %o0   = ttng.tmem_subslice %o { N = 0   }
+//  %o0   = ttng.tmem_subslice %o { offset = 0 }
 //  %lhs  = ttng.tmem_load     %o0
-//  %o1   = ttng.tmem_subslice %o { N = 128 }
+//  %o1   = ttng.tmem_subslice %o { offset = 128 }
 //  %rhs  = ttng.tmem_load     %o1
 //
 // and if %lhs / %rhs are split again through the same reshape->trans->split
@@ -114,7 +114,7 @@ public:
         [&](int64_t nOffset) -> std::pair<TMEMLoadOp, ttg::ConvertLayoutOp> {
       // Generate the subslice op.
       Value subSlice = TMEMSubSliceOp::create(rewriter, tmemLoad.getLoc(), tmem,
-                                              nOffset, splitNSize);
+                                              nOffset, splitNSize, 1);
 
       // Choose a layout compatible with the slice size.
       gpu::MemDescType subSliceType =
@@ -183,7 +183,8 @@ public:
     Value truePred = arith::ConstantOp::create(b, loc, b.getBoolAttr(true));
 
     auto createSlice = [&](TypedValue<RankedTensorType> input, int offset) {
-      auto subSlice = TMEMSubSliceOp::create(b, loc, tmem, offset, splitNSize);
+      auto subSlice =
+          TMEMSubSliceOp::create(b, loc, tmem, offset, splitNSize, 1);
       auto distLayout =
           nvidia_gpu::getDefaultLayoutForTmemLdSt(subSlice.getType(), numWarps);
       auto newType = input.getType().cloneWithEncoding(distLayout);

--- a/lib/Dialect/TritonNvidiaGPU/Transforms/TensorMemoryAllocation.cpp
+++ b/lib/Dialect/TritonNvidiaGPU/Transforms/TensorMemoryAllocation.cpp
@@ -124,7 +124,7 @@ static Interval<int> getLiveIntervals(Value value, Liveness &liveness,
   SmallVector<Operation *> users(value.getUsers());
   while (!users.empty()) {
     Operation *user = users.pop_back_val();
-    if (!isa<ttg::MemDescIndexOp, ttg::MemDescReinterpretOp>(user))
+    if (!user->hasTrait<OpTrait::MemDescViewTrait>())
       continue;
     auto usersLivness = liveness.resolveLiveness(user->getResult(0));
     liveOperations.insert(liveOperations.end(), usersLivness.begin(),
@@ -244,8 +244,6 @@ static SmallVector<Operation *> getAlloc(Value value) {
       allocs.push_back(defOp);
     } else if (defOp->hasTrait<OpTrait::MemDescViewTrait>()) {
       worklist.push_back(defOp->getOperand(0));
-    } else if (auto sliceOp = dyn_cast<TMEMSubSliceOp>(defOp)) {
-      worklist.push_back(sliceOp.getSrc());
     } else if (auto selectOp = dyn_cast<arith::SelectOp>(defOp)) {
       worklist.push_back(selectOp.getTrueValue());
       worklist.push_back(selectOp.getFalseValue());

--- a/python/src/gluon_ir.cc
+++ b/python/src/gluon_ir.cc
@@ -893,9 +893,10 @@ void init_gluon_ir(py::module_ &m) {
              self.create<ttng::TMEMCopyOp>(src, dst);
            })
       .def("create_tmem_subslice",
-           [](GluonOpBuilder &self, Type resultTy, Value memDesc,
-              int N) -> Value {
-             return self.create<ttng::TMEMSubSliceOp>(resultTy, memDesc, N);
+           [](GluonOpBuilder &self, Type resultTy, Value memDesc, int offset,
+              int dim) -> Value {
+             return self.create<ttng::TMEMSubSliceOp>(resultTy, memDesc, offset,
+                                                      dim);
            })
       .def("create_mbarrier_init",
            [](GluonOpBuilder &self, Value memDesc, int count) {

--- a/python/test/gluon/test_core.py
+++ b/python/test/gluon/test_core.py
@@ -1772,6 +1772,131 @@ def test_tmem_copy_2d():
         torch.testing.assert_close(x_res, warp)
 
 
+@pytest.mark.parametrize("M, N, BLOCK_M, BLOCK_N", [(256, 128, 128, 128), (128, 256, 64, 128)])
+@pytest.mark.skipif(not is_blackwell(), reason="Requires Blackwell")
+def test_tmem_row_slice(M, N, BLOCK_M, BLOCK_N):
+
+    @gluon.jit
+    def _store_view(view, out):
+        values = view.load()
+        layout: ttgl.constexpr = ttgl.BlockedLayout(size_per_thread=[1, 1], threads_per_warp=[1, 32],
+                                                    warps_per_cta=[1, 4], order=[1, 0])
+        values = ttgl.convert_layout(values, layout)
+        rows = ttgl.arange(0, view.shape[0], layout=ttgl.SliceLayout(1, layout))
+        cols = ttgl.arange(0, view.shape[1], layout=ttgl.SliceLayout(0, layout))
+        ttgl.store(out + rows[:, None] * view.shape[1] + cols[None, :], values)
+
+    @gluon.jit
+    def tmem_row_slice_kernel(inp, out0, out1, out2, M: ttgl.constexpr, N: ttgl.constexpr, BLOCK_M: ttgl.constexpr,
+                              BLOCK_N: ttgl.constexpr):
+        parent = allocate_tensor_memory(ttgl.float32, [M, N], TensorMemoryLayout([BLOCK_M, BLOCK_N], col_stride=1))
+        layout: ttgl.constexpr = ttgl.BlockedLayout(size_per_thread=[1, 1], threads_per_warp=[1, 32],
+                                                    warps_per_cta=[1, 4], order=[1, 0])
+        rows = ttgl.arange(0, M, layout=ttgl.SliceLayout(1, layout))
+        cols = ttgl.arange(0, N, layout=ttgl.SliceLayout(0, layout))
+        values = ttgl.load(inp + rows[:, None] * N + cols[None, :])
+        parent.store(ttgl.convert_layout(values, parent.get_reg_layout()))
+
+        row_half0 = parent.slice(0, M // 2, dim=0)
+        row_half1 = parent.slice(M // 2, M // 2, dim=0)
+        _store_view(row_half0, out0)
+        _store_view(row_half1, out1)
+        _store_view(row_half1.slice(N // 2, N // 2), out2)
+
+    inp = torch.arange(M * N, device="cuda", dtype=torch.float32).reshape(M, N)
+    out0 = torch.empty((M // 2, N), device="cuda", dtype=torch.float32)
+    out1 = torch.empty_like(out0)
+    out2 = torch.empty((M // 2, N // 2), device="cuda", dtype=torch.float32)
+    tmem_row_slice_kernel[(1, )](inp, out0, out1, out2, M, N, BLOCK_M, BLOCK_N, num_warps=4)
+    torch.testing.assert_close(out0, inp[:M // 2], atol=0, rtol=0)
+    torch.testing.assert_close(out1, inp[M // 2:], atol=0, rtol=0)
+    torch.testing.assert_close(out2, inp[M // 2:, N // 2:], atol=0, rtol=0)
+
+
+@pytest.mark.parametrize("dtype", [torch.float16, torch.float32])
+@pytest.mark.parametrize("M, N, BLOCK_N, dim", [(256, 256, 64, 0), (256, 128, 128, 1)])
+@pytest.mark.skipif(not is_blackwell(), reason="Requires Blackwell")
+def test_tmem_noncontiguous_subslice_load_store(dtype, M, N, BLOCK_N, dim):
+
+    @gluon.jit
+    def kernel(inp, out, M: ttgl.constexpr, N: ttgl.constexpr, BLOCK_N: ttgl.constexpr, DIM: ttgl.constexpr):
+        parent = allocate_tensor_memory(
+            inp.dtype.element_ty, [M, N],
+            TensorMemoryLayout([128, BLOCK_N], col_stride=32 // inp.dtype.element_ty.primitive_bitwidth))
+        parent_layout: ttgl.constexpr = parent.get_reg_layout()
+        rows = ttgl.arange(0, M, layout=ttgl.SliceLayout(1, parent_layout))[:, None]
+        cols = ttgl.arange(0, N, layout=ttgl.SliceLayout(0, parent_layout))[None, :]
+        parent.store(ttgl.load(inp + rows * N + cols))
+
+        if DIM == 0:
+            view = parent.slice(M // 2, M // 2, dim=0)
+        else:
+            view = parent.slice(N // 2, N // 2, dim=1)
+        view.store(view.load() + 7.0)
+        ttgl.store(out + rows * N + cols, parent.load(parent_layout))
+
+    inp = torch.arange(M * N, device="cuda", dtype=torch.int32).remainder(64).to(dtype).reshape(M, N)
+    out = torch.empty_like(inp)
+    kernel[(1, )](inp, out, M, N, BLOCK_N, dim, num_warps=4)
+    ref = inp.clone()
+    if dim == 0:
+        ref[M // 2:] += 7
+    else:
+        ref[:, N // 2:] += 7
+    torch.testing.assert_close(out, ref, atol=0, rtol=0)
+
+
+@pytest.mark.skipif(not is_blackwell(), reason="Requires Blackwell")
+def test_tmem_noncontiguous_subslice_load_min():
+
+    @gluon.jit
+    def kernel(inp, out, reduced_out):
+        parent = allocate_tensor_memory(ttgl.float32, [256, 256], TensorMemoryLayout([128, 64], col_stride=1))
+        parent_layout: ttgl.constexpr = parent.get_reg_layout()
+        rows = ttgl.arange(0, 256, layout=ttgl.SliceLayout(1, parent_layout))[:, None]
+        cols = ttgl.arange(0, 256, layout=ttgl.SliceLayout(0, parent_layout))[None, :]
+        parent.store(ttgl.load(inp + rows * 256 + cols))
+
+        values, reduced = parent.slice(128, 128, dim=0).load_min()
+        layout: ttgl.constexpr = ttgl.BlockedLayout([1, 1], [1, 32], [4, 1], [1, 0])
+        view_rows = ttgl.arange(0, 128, layout=ttgl.SliceLayout(1, layout))[:, None]
+        view_cols = ttgl.arange(0, 256, layout=ttgl.SliceLayout(0, layout))[None, :]
+        ttgl.store(out + view_rows * 256 + view_cols, ttgl.convert_layout(values, layout))
+        red_layout: ttgl.constexpr = ttgl.SliceLayout(1, layout)
+        red_rows = ttgl.arange(0, 128, layout=red_layout)
+        ttgl.store(reduced_out + red_rows, ttgl.convert_layout(reduced, red_layout))
+
+    torch.manual_seed(0)
+    inp = torch.randn((256, 256), dtype=torch.float32, device="cuda")
+    out = torch.empty((128, 256), dtype=torch.float32, device="cuda")
+    reduced = torch.empty((128, ), dtype=torch.float32, device="cuda")
+    kernel[(1, )](inp, out, reduced, num_warps=4)
+    torch.testing.assert_close(out, inp[128:], atol=0, rtol=0)
+    torch.testing.assert_close(reduced, inp[128:].amin(dim=1), atol=0, rtol=0)
+
+
+@pytest.mark.skipif(not is_blackwell(), reason="Requires Blackwell")
+def test_tmem_subslice_unpacked_one_column():
+
+    @gluon.jit
+    def kernel(inp, out):
+        parent = allocate_tensor_memory(ttgl.float16, [128, 2], TensorMemoryLayout([128, 1], col_stride=2))
+        layout: ttgl.constexpr = parent.get_reg_layout()
+        rows = ttgl.arange(0, 128, layout=ttgl.SliceLayout(1, layout))
+        cols = ttgl.arange(0, 2, layout=ttgl.SliceLayout(0, layout))
+        parent.store(ttgl.load(inp + rows[:, None] * 2 + cols[None, :]))
+
+        view = parent.slice(0, 1)
+        view.store(ttgl.full([128, 1], 777, dtype=ttgl.float16, layout=view.get_reg_layout()))
+        ttgl.store(out + rows[:, None] * 2 + cols[None, :], parent.load())
+
+    inp = torch.arange(256, device="cuda", dtype=torch.float16).reshape(128, 2)
+    out = torch.empty_like(inp)
+    kernel[(1, )](inp, out, num_warps=4)
+    torch.testing.assert_close(out[:, 0], torch.full_like(out[:, 0], 777), atol=0, rtol=0)
+    torch.testing.assert_close(out[:, 1], inp[:, 1], atol=0, rtol=0)
+
+
 @pytest.mark.skipif(not is_blackwell(), reason="Requires Blackwell")
 def test_tmem_subslice_block_m_64():
 
@@ -2051,6 +2176,42 @@ def test_tmem_copy_no_scales(M, N, BLOCK_N, num_warps, swizzle):
 
     tmem_copy_no_scales[(1, )](input, output, M, N, BLOCK_N, swizzle, num_warps=num_warps)
     assert (output == input).all()
+
+
+@pytest.mark.parametrize("N, BLOCK_N", [(256, 64), (64, 8), (64, 4)])
+@pytest.mark.skipif(not is_blackwell(), reason="Requires Blackwell")
+def test_tmem_copy_noncontiguous_subslice(N, BLOCK_N):
+
+    @gluon.jit
+    def kernel(inp, out, N: ttgl.constexpr, BLOCK_N: ttgl.constexpr):
+        parent = allocate_tensor_memory(ttgl.int32, [256, N], TensorMemoryLayout([128, BLOCK_N], col_stride=1))
+        parent_layout: ttgl.constexpr = parent.get_reg_layout()
+        parent.store(ttgl.full([256, N], -7, dtype=ttgl.int32, layout=parent_layout))
+        view = parent.slice(128, 128, dim=0)
+
+        view_layout: ttgl.constexpr = view.get_reg_layout()
+        rows = ttgl.arange(0, 128, layout=ttgl.SliceLayout(1, view_layout))[:, None]
+        cols = ttgl.arange(0, N, layout=ttgl.SliceLayout(0, view_layout))[None, :]
+        values = ttgl.load(inp + rows * N + cols)
+        smem_layout: ttgl.constexpr = ttgl.NVMMASharedLayout(swizzle_byte_width=128, element_bitwidth=32, rank=2)
+        smem = ttgl.allocate_shared_memory(ttgl.int32, [128, N], layout=smem_layout)
+        smem.store(values)
+
+        bar = ttgl.allocate_shared_memory(ttgl.int64, [1], mbarrier.MBarrierLayout())
+        mbarrier.init(bar, count=1)
+        tcgen05_copy(smem, view)
+        tcgen05_commit(bar)
+        mbarrier.wait(bar, phase=0)
+
+        parent_rows = ttgl.arange(0, 256, layout=ttgl.SliceLayout(1, parent_layout))[:, None]
+        parent_cols = ttgl.arange(0, N, layout=ttgl.SliceLayout(0, parent_layout))[None, :]
+        ttgl.store(out + parent_rows * N + parent_cols, parent.load(parent_layout))
+
+    inp = torch.arange(128 * N, dtype=torch.int32, device="cuda").reshape(128, N)
+    out = torch.empty((256, N), dtype=torch.int32, device="cuda")
+    kernel[(1, )](inp, out, N, BLOCK_N, num_warps=4)
+    torch.testing.assert_close(out[:128], torch.full_like(out[:128], -7), atol=0, rtol=0)
+    torch.testing.assert_close(out[128:], inp, atol=0, rtol=0)
 
 
 @gluon.jit
@@ -2475,6 +2636,47 @@ def test_tcgen05_mma_scaled_minimal():
     torch.testing.assert_close(out, ref, atol=1e-6, rtol=1e-6)
     ttgir = compiled.asm["ttgir"]
     assert "ttng.tc_gen5_mma_scaled" in ttgir
+
+
+@pytest.mark.skipif(not is_blackwell(), reason="Requires Blackwell")
+def test_tcgen05_mma_scaled_noncontiguous_accumulator():
+
+    @gluon.jit
+    def kernel(a, b, out):
+        layout: ttgl.constexpr = ttgl.BlockedLayout([1, 1], [1, 32], [4, 1], [1, 0])
+        smem_layout: ttgl.constexpr = ttgl.NVMMASharedLayout(swizzle_byte_width=128, transposed=False,
+                                                             element_bitwidth=8, rank=2)
+        rows = ttgl.arange(0, 128, layout=ttgl.SliceLayout(1, layout))[:, None]
+        cols = ttgl.arange(0, 128, layout=ttgl.SliceLayout(0, layout))[None, :]
+        a_smem = ttgl.allocate_shared_memory(ttgl.float8e5, [128, 128], smem_layout, ttgl.load(a + rows * 128 + cols))
+        b_smem = ttgl.allocate_shared_memory(ttgl.float8e5, [128, 128], smem_layout, ttgl.load(b + rows * 128 + cols))
+
+        parent = allocate_tensor_memory(ttgl.float32, [256, 128], TensorMemoryLayout([128, 64], col_stride=1))
+        parent_layout: ttgl.constexpr = parent.get_reg_layout()
+        parent.store(ttgl.full([256, 128], -7.0, dtype=ttgl.float32, layout=parent_layout))
+        acc = parent.slice(128, 128, dim=0)
+
+        scale_layout: ttgl.constexpr = TensorMemoryScalesLayout()
+        a_scale = allocate_tensor_memory(ttgl.uint8, [128, 4], scale_layout)
+        b_scale = allocate_tensor_memory(ttgl.uint8, [128, 4], scale_layout)
+        a_scale.store(ttgl.full([128, 4], 127, dtype=ttgl.uint8, layout=a_scale.get_reg_layout()))
+        b_scale.store(ttgl.full([128, 4], 127, dtype=ttgl.uint8, layout=b_scale.get_reg_layout()))
+        bar = ttgl.allocate_shared_memory(ttgl.int64, [1], mbarrier.MBarrierLayout())
+        mbarrier.init(bar, count=1)
+        tcgen05_mma_scaled(a_smem, b_smem, acc, a_scale, b_scale, "e5m2", "e5m2", use_acc=False, mbarriers=[bar])
+        mbarrier.wait(bar, phase=0)
+
+        parent_rows = ttgl.arange(0, 256, layout=ttgl.SliceLayout(1, parent_layout))[:, None]
+        parent_cols = ttgl.arange(0, 128, layout=ttgl.SliceLayout(0, parent_layout))[None, :]
+        ttgl.store(out + parent_rows * 128 + parent_cols, parent.load(parent_layout))
+
+    torch.manual_seed(0)
+    a = torch.randint(20, 40, (128, 128), dtype=torch.uint8, device="cuda").view(torch.float8_e5m2)
+    b = torch.randint(20, 40, (128, 128), dtype=torch.uint8, device="cuda").view(torch.float8_e5m2)
+    out = torch.empty((256, 128), dtype=torch.float32, device="cuda")
+    kernel[(1, )](a, b, out, num_warps=4)
+    torch.testing.assert_close(out[:128], torch.full_like(out[:128], -7), atol=0, rtol=0)
+    torch.testing.assert_close(out[128:], a.float() @ b.float(), atol=1e-6, rtol=1e-6)
 
 
 @pytest.mark.parametrize(

--- a/python/test/gluon/test_core.py
+++ b/python/test/gluon/test_core.py
@@ -1846,7 +1846,7 @@ def test_tmem_noncontiguous_subslice_load_store(dtype, M, N, BLOCK_N, dim):
     torch.testing.assert_close(out, ref, atol=0, rtol=0)
 
 
-@pytest.mark.skipif(not is_blackwell(), reason="Requires Blackwell")
+@pytest.mark.skipif(not is_blackwell_ultra(), reason="Requires Blackwell Ultra")
 def test_tmem_noncontiguous_subslice_load_min():
 
     @gluon.jit

--- a/python/test/gluon/test_fpsan.py
+++ b/python/test/gluon/test_fpsan.py
@@ -2706,6 +2706,71 @@ def test_tmem_index_subslice(device, fresh_knobs):
     _assert_payload_equal(out, exp_bits)
 
 
+@pytest.mark.skipif(not is_blackwell(), reason="Requires Blackwell")
+@pytest.mark.parametrize("operation,pred", [("store", False), ("store", True), ("copy", True)])
+@pytest.mark.parametrize("column_slice", [False, True])
+def test_tmem_row_subslice(device, operation, pred, column_slice, fresh_knobs):
+    _require_cuda_backend(device)
+
+    m, n = 256, 128
+    view_m = m // 2
+    view_n = n // 2 if column_slice else n
+
+    fresh_knobs.compilation.instrumentation_mode = "fpsan"
+
+    @gluon.jit
+    def kernel(parent_ptr, value_ptr, view_out_ptr, parent_out_ptr, pred, OPERATION: gl.constexpr,
+               COLUMN_SLICE: gl.constexpr, VIEW_N: gl.constexpr):
+        parent = allocate_tensor_memory(gl.float32, [256, 128], TensorMemoryLayout([128, 64], col_stride=1))
+        parent_layout: gl.constexpr = parent.get_reg_layout()
+        parent_rows = gl.arange(0, 256, layout=gl.SliceLayout(1, parent_layout))[:, None]
+        parent_cols = gl.arange(0, 128, layout=gl.SliceLayout(0, parent_layout))[None, :]
+        parent.store(gl.load(parent_ptr + parent_rows * 128 + parent_cols))
+
+        view = parent.slice(128, 128, dim=0)
+        if COLUMN_SLICE:
+            view = view.slice(64, 64)
+        view_layout: gl.constexpr = view.get_reg_layout()
+        view_rows = gl.arange(0, 128, layout=gl.SliceLayout(1, view_layout))[:, None]
+        view_cols = gl.arange(0, VIEW_N, layout=gl.SliceLayout(0, view_layout))[None, :]
+        values = gl.load(value_ptr + view_rows * VIEW_N + view_cols)
+
+        if OPERATION == "copy":
+            smem_layout: gl.constexpr = gl.NVMMASharedLayout(swizzle_byte_width=128, element_bitwidth=32, rank=2)
+            smem = gl.allocate_shared_memory(gl.float32, [128, VIEW_N], layout=smem_layout)
+            smem.store(values)
+            bar = mbarrier.allocate_mbarrier()
+            mbarrier.init(bar, count=1)
+            tcgen05_copy(smem, view)
+            tcgen05_commit(bar)
+            mbarrier.wait(bar, phase=0)
+        else:
+            view.store(values, pred=pred != 0)
+
+        gl.store(view_out_ptr + view_rows * VIEW_N + view_cols, view.load(view_layout))
+        gl.store(parent_out_ptr + parent_rows * 128 + parent_cols, parent.load(parent_layout))
+
+    rs = np.random.RandomState(0)
+    parent_bits = rs.randint(-(2**31), 2**31 - 1, size=(m, n), dtype=np.int32)
+    value_bits = rs.randint(-(2**31), 2**31 - 1, size=(view_m, view_n), dtype=np.int32)
+    expected_parent = parent_bits.copy()
+    if pred:
+        expected_parent[view_m:, n - view_n:] = value_bits
+    expected_view = expected_parent[view_m:, n - view_n:]
+
+    parent = torch.tensor(parent_bits, device=device, dtype=torch.int32)
+    value = torch.tensor(value_bits, device=device, dtype=torch.int32)
+    view_out = torch.empty((view_m, view_n), device=device, dtype=torch.int32)
+    parent_out = torch.empty_like(parent)
+    kernel[(1, )](triton.TensorWrapper(parent, dtype=torch.float32), triton.TensorWrapper(value, dtype=torch.float32),
+                  triton.TensorWrapper(view_out, dtype=torch.float32),
+                  triton.TensorWrapper(parent_out, dtype=torch.float32), int(pred), operation, column_slice, view_n,
+                  num_warps=4)
+
+    _assert_payload_equal(view_out, expected_view)
+    _assert_payload_equal(parent_out, expected_parent)
+
+
 @pytest.mark.skipif(not is_blackwell_ultra(), reason="Requires Blackwell Ultra")
 @pytest.mark.parametrize("red_op,use_abs", [("min", False), ("max", True)])
 def test_tmem_load_reduce(device, red_op, use_abs, fresh_knobs):

--- a/python/test/gluon/test_frontend.py
+++ b/python/test/gluon/test_frontend.py
@@ -303,8 +303,8 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.targ
     %result_1 = ttng.tmem_load %result_0 : !ttg.memdesc<128x128xi32, #tmem, #ttng.tensor_memory, mutable> -> tensor<128x128xi32, #blocked>
     %true = arith.constant true
     ttng.tmem_store %cst, %result_0, %true : tensor<128x128xi32, #blocked> -> !ttg.memdesc<128x128xi32, #tmem, #ttng.tensor_memory, mutable>
-    %0 = ttng.tmem_subslice %result_0 {N = 0 : i32} : !ttg.memdesc<128x128xi32, #tmem, #ttng.tensor_memory, mutable> -> !ttg.memdesc<128x64xi32, #tmem, #ttng.tensor_memory, mutable, 128x128>
-    %1 = ttng.tmem_subslice %result_0 {N = 64 : i32} : !ttg.memdesc<128x128xi32, #tmem, #ttng.tensor_memory, mutable> -> !ttg.memdesc<128x64xi32, #tmem, #ttng.tensor_memory, mutable, 128x128>
+    %0 = ttng.tmem_subslice %result_0 {offset = 0 : i32} : !ttg.memdesc<128x128xi32, #tmem, #ttng.tensor_memory, mutable> -> !ttg.memdesc<128x64xi32, #tmem, #ttng.tensor_memory, mutable, 128x128>
+    %1 = ttng.tmem_subslice %result_0 {offset = 64 : i32} : !ttg.memdesc<128x128xi32, #tmem, #ttng.tensor_memory, mutable> -> !ttg.memdesc<128x64xi32, #tmem, #ttng.tensor_memory, mutable, 128x128>
     %result_2 = ttng.tmem_alloc : () -> !ttg.memdesc<2x128x128xf32, #tmem, #ttng.tensor_memory, mutable>
     %c0_i32_3 = arith.constant 0 : i32
     %c2_i32 = arith.constant 2 : i32
@@ -1077,7 +1077,7 @@ module attributes {"ttg.num-ctas" = 4 : i32, "ttg.num-warps" = 4 : i32, ttg.targ
     %result = ttng.tmem_alloc : () -> !ttg.memdesc<2x512x256xf32, #tmem, #ttng.tensor_memory, mutable>
     %c0_i32 = arith.constant 0 : i32
     %0 = ttg.memdesc_index %result[%c0_i32] : !ttg.memdesc<2x512x256xf32, #tmem, #ttng.tensor_memory, mutable> -> !ttg.memdesc<512x256xf32, #tmem, #ttng.tensor_memory, mutable>
-    %1 = ttng.tmem_subslice %0 {N = 0 : i32} : !ttg.memdesc<512x256xf32, #tmem, #ttng.tensor_memory, mutable> -> !ttg.memdesc<512x32xf32, #tmem, #ttng.tensor_memory, mutable, 512x256>
+    %1 = ttng.tmem_subslice %0 {offset = 0 : i32} : !ttg.memdesc<512x256xf32, #tmem, #ttng.tensor_memory, mutable> -> !ttg.memdesc<512x32xf32, #tmem, #ttng.tensor_memory, mutable, 512x256>
     %result_0 = ttng.tmem_load %1 : !ttg.memdesc<512x32xf32, #tmem, #ttng.tensor_memory, mutable, 512x256> -> tensor<512x32xf32, #linear>
     tt.return
   }

--- a/python/test/gluon/test_frontend.py
+++ b/python/test/gluon/test_frontend.py
@@ -1085,6 +1085,19 @@ module attributes {"ttg.num-ctas" = 4 : i32, "ttg.num-warps" = 4 : i32, ttg.targ
 """)
 
 
+@gluon.jit
+def tmem_subslice_noncontiguous_kernel():
+    layout: ttgl.constexpr = TensorMemoryLayout(block=[128, 128], col_stride=1)
+    tmem = ttgl.nvidia.blackwell.allocate_tensor_memory(ttgl.float32, [256, 256], layout)
+    tmem.slice(0, 128, dim=0)
+
+
+def test_tmem_subslice_noncontiguous():
+    ir = run_parser(tmem_subslice_noncontiguous_kernel, target=BLACKWELL_TARGET).str_nodebug()
+    assert "ttng.tmem_subslice" in ir
+    assert "!ttg.memdesc<128x256xf32" in ir
+
+
 @filecheck_test
 @gluon.jit
 def test_tmem_reduction_default_layout_constexpr():

--- a/python/triton/experimental/gluon/language/nvidia/blackwell/__init__.py
+++ b/python/triton/experimental/gluon/language/nvidia/blackwell/__init__.py
@@ -364,26 +364,30 @@ class tensor_memory_descriptor(base_value):
         _semantic.builder.create_tmem_store(self.handle, value.handle, pred.handle)
 
     @builtin
-    def slice(self, start, length, _semantic: GluonSemantic = None) -> None:
+    def slice(self, start, length, dim=1, _semantic: GluonSemantic = None) -> None:
         """
         Create a slice of the tensor memory descriptor along the last dimension.
 
         Args:
             start (int): The starting index for subslice.
             length (int): The length of the subslice.
+            dim (int): The dimension to slice (default: 1).
 
         Returns:
             tensor_memory_descriptor: Descriptor for the subslice.
         """
         start = _unwrap_if_constexpr(start)
         length = _unwrap_if_constexpr(length)
+        dim = _unwrap_if_constexpr(dim)
         _check(isinstance(start, int), lambda: "start must be a constant int")
         _check(isinstance(length, int), lambda: "length must be a constant int")
-        shape = self.shape[:-1] + [length]
+        _check(isinstance(dim, int) and dim == 1, lambda: "only dim=1 is supported")
+        shape = list(self.shape)
+        shape[dim] = length
         layout = self.type.layout
         ret = tensor_memory_descriptor(None, self.dtype, shape, layout, self.type.alloc_shape)
         builder = _semantic.builder
-        ret.handle = builder.create_tmem_subslice(ret.type.to_ir(builder), self.handle, start)
+        ret.handle = builder.create_tmem_subslice(ret.type.to_ir(builder), self.handle, start, dim)
         return ret
 
     @builtin

--- a/python/triton/experimental/gluon/language/nvidia/blackwell/__init__.py
+++ b/python/triton/experimental/gluon/language/nvidia/blackwell/__init__.py
@@ -366,7 +366,7 @@ class tensor_memory_descriptor(base_value):
     @builtin
     def slice(self, start, length, dim=1, _semantic: GluonSemantic = None) -> None:
         """
-        Create a slice of the tensor memory descriptor along the last dimension.
+        Create a slice of the tensor memory descriptor along a given dimension.
 
         Args:
             start (int): The starting index for subslice.
@@ -381,7 +381,7 @@ class tensor_memory_descriptor(base_value):
         dim = _unwrap_if_constexpr(dim)
         _check(isinstance(start, int), lambda: "start must be a constant int")
         _check(isinstance(length, int), lambda: "length must be a constant int")
-        _check(isinstance(dim, int) and dim == 1, lambda: "only dim=1 is supported")
+        _check(isinstance(dim, int) and dim in (0, 1), lambda: "dim must be 0 or 1")
         shape = list(self.shape)
         shape[dim] = length
         layout = self.type.layout

--- a/test/Analysis/test-buffer-region.mlir
+++ b/test/Analysis/test-buffer-region.mlir
@@ -135,7 +135,7 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 1 : i32, ttg.shar
 module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 1 : i32, ttg.shared = 65544 : i32, ttg.target = "cuda:100", ttg.tensor_memory_size = 0 : i32, "ttg.threads-per-warp" = 32 : i32, "ttg.total-num-warps" = 1 : i32} {
   tt.func public @tensor_memory_subslice_interleaved() {
     %tm = ttng.tmem_alloc {tensor_memory_col_offset = 0 : i32, tensor_memory_row_offset = 0 : i32} : () -> !ttg.memdesc<64x128xf32, #tmem, #ttng.tensor_memory, mutable>
-    %sub = ttng.tmem_subslice %tm {N = 32 : i32} : !ttg.memdesc<64x128xf32, #tmem, #ttng.tensor_memory, mutable> -> !ttg.memdesc<64x32xf32, #tmem, #ttng.tensor_memory, mutable, 64x128>
+    %sub = ttng.tmem_subslice %tm {offset = 32 : i32} : !ttg.memdesc<64x128xf32, #tmem, #ttng.tensor_memory, mutable> -> !ttg.memdesc<64x32xf32, #tmem, #ttng.tensor_memory, mutable, 64x128>
     // expected-remark @below {{Buffers: [1048576, 32]}}
     ttng.tmem_load %sub : !ttg.memdesc<64x32xf32, #tmem, #ttng.tensor_memory, mutable, 64x128> -> tensor<64x32xf32>
     tt.return

--- a/test/Analysis/test-buffer-region.mlir
+++ b/test/Analysis/test-buffer-region.mlir
@@ -145,6 +145,45 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 1 : i32, ttg.shar
   tt.func private @print_all_regions() attributes {test.print_all_used_regions} {
     tt.return
   }
+
+}
+
+// -----
+
+#tmem = #ttng.tensor_memory_encoding<blockM = 128, blockN = 128, colStride = 1>
+
+module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 1 : i32, ttg.shared = 65544 : i32, ttg.target = "cuda:100", ttg.tensor_memory_size = 0 : i32, "ttg.threads-per-warp" = 32 : i32, "ttg.total-num-warps" = 1 : i32} {
+  tt.func public @tensor_memory_row_subslice() {
+    %tm = ttng.tmem_alloc {tensor_memory_col_offset = 0 : i32, tensor_memory_row_offset = 0 : i32} : () -> !ttg.memdesc<256x128xf32, #tmem, #ttng.tensor_memory, mutable>
+    %sub = ttng.tmem_subslice %tm {offset = 128 : i32, dim = 0 : i32} : !ttg.memdesc<256x128xf32, #tmem, #ttng.tensor_memory, mutable> -> !ttg.memdesc<128x128xf32, #tmem, #ttng.tensor_memory, mutable, 256x128>
+    // expected-remark @below {{Buffers: [128, 128]}}
+    ttng.tmem_load %sub : !ttg.memdesc<128x128xf32, #tmem, #ttng.tensor_memory, mutable, 256x128> -> tensor<128x128xf32>
+    tt.return
+  }
+
+  // expected-remark @below {{All Tensor Regions: [128, 128]}}
+  tt.func private @print_all_regions() attributes {test.print_all_used_regions} {
+    tt.return
+  }
+}
+
+// -----
+
+#tmem = #ttng.tensor_memory_encoding<blockM = 64, blockN = 128, colStride = 1>
+
+module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 1 : i32, ttg.shared = 65544 : i32, ttg.target = "cuda:100", ttg.tensor_memory_size = 0 : i32, "ttg.threads-per-warp" = 32 : i32, "ttg.total-num-warps" = 1 : i32} {
+  tt.func public @tensor_memory_row_subslice_interleaved() {
+    %tm = ttng.tmem_alloc {tensor_memory_col_offset = 0 : i32, tensor_memory_row_offset = 0 : i32} : () -> !ttg.memdesc<128x256xf32, #tmem, #ttng.tensor_memory, mutable>
+    %sub = ttng.tmem_subslice %tm {offset = 64 : i32, dim = 0 : i32} : !ttg.memdesc<128x256xf32, #tmem, #ttng.tensor_memory, mutable> -> !ttg.memdesc<64x256xf32, #tmem, #ttng.tensor_memory, mutable, 128x256>
+    // expected-remark @below {{Buffers: [1048576, 256]}}
+    ttng.tmem_load %sub : !ttg.memdesc<64x256xf32, #tmem, #ttng.tensor_memory, mutable, 128x256> -> tensor<64x256xf32>
+    tt.return
+  }
+
+  // expected-remark @below {{All Tensor Regions: [1048576, 256]}}
+  tt.func private @print_all_regions() attributes {test.print_all_used_regions} {
+    tt.return
+  }
 }
 
 // -----

--- a/test/Conversion/tritongpu_to_llvm_blackwell.mlir
+++ b/test/Conversion/tritongpu_to_llvm_blackwell.mlir
@@ -876,6 +876,20 @@ tt.func private @subslice_packed(%arg0: !ttg.memdesc<128x128xf16, #tmem, #ttng.t
   tt.return %0 : !ttg.memdesc<128x64xf16, #tmem, #ttng.tensor_memory, 128x128>
 }
 
+// CHECK-LABEL: @subslice_row_then_column
+tt.func private @subslice_row_then_column(%arg0: !ttg.memdesc<256x128xf32, #tmem, #ttng.tensor_memory>) -> !ttg.memdesc<128x64xf32, #tmem, #ttng.tensor_memory, 256x128> {
+  // CHECK: [[ROW_OFFSET:%.*]] = llvm.mlir.constant(128 : i32)
+  // CHECK: [[PTR:%.*]] = llvm.ptrtoint
+  // CHECK: [[ROW:%.*]] = llvm.add [[PTR]], [[ROW_OFFSET]] : i32
+  // CHECK: [[ROW_PTR:%.*]] = llvm.inttoptr [[ROW]] : i32 to !llvm.ptr<3>
+  // CHECK: [[COL_OFFSET:%.*]] = llvm.mlir.constant(64 : i32)
+  // CHECK: [[ROW_BASE:%.*]] = llvm.ptrtoint [[ROW_PTR]] : !llvm.ptr<3> to i32
+  // CHECK: llvm.add [[ROW_BASE]], [[COL_OFFSET]] : i32
+  %0 = ttng.tmem_subslice %arg0 {offset = 128 : i32, dim = 0 : i32} : !ttg.memdesc<256x128xf32, #tmem, #ttng.tensor_memory> -> !ttg.memdesc<128x128xf32, #tmem, #ttng.tensor_memory, 256x128>
+  %1 = ttng.tmem_subslice %0 {offset = 64 : i32} : !ttg.memdesc<128x128xf32, #tmem, #ttng.tensor_memory, 256x128> -> !ttg.memdesc<128x64xf32, #tmem, #ttng.tensor_memory, 256x128>
+  tt.return %1 : !ttg.memdesc<128x64xf32, #tmem, #ttng.tensor_memory, 256x128>
+}
+
 // CHECK-LABEL: @load_store_x1
 tt.func @load_store_x1(%arg0: !ttg.memdesc<128x2xf16, #tmem_x1, #ttng.tensor_memory, mutable>) {
   %true = arith.constant true
@@ -1008,6 +1022,15 @@ tt.func private @subslice_16x32bx2_packed(%arg0: !ttg.memdesc<64x128xf16, #bm64_
   tt.return %0 : !ttg.memdesc<64x64xf16, #bm64_bn128, #tmem, 64x128>
 }
 
+// CHECK-LABEL: @subslice_16x32bx2_row
+tt.func private @subslice_16x32bx2_row(%arg0: !ttg.memdesc<256x128xf32, #bm64_bn128, #tmem>) -> !ttg.memdesc<128x128xf32, #bm64_bn128, #tmem, 256x128> {
+  // CHECK: [[OFFSET:%.*]] = llvm.mlir.constant(128 : i32)
+  // CHECK: [[PTR:%.*]] = llvm.ptrtoint
+  // CHECK: llvm.add [[PTR]], [[OFFSET]] : i32
+  %0 = ttng.tmem_subslice %arg0 {offset = 128 : i32, dim = 0 : i32} : !ttg.memdesc<256x128xf32, #bm64_bn128, #tmem> -> !ttg.memdesc<128x128xf32, #bm64_bn128, #tmem, 256x128>
+  tt.return %0 : !ttg.memdesc<128x128xf32, #bm64_bn128, #tmem, 256x128>
+}
+
 // CHECK-LABEL: @subslice_16x32bx2_interleaved_block1
 tt.func private @subslice_16x32bx2_interleaved_block1(%arg0: !ttg.memdesc<64x128xf32, #bm64_bn32, #tmem>) -> !ttg.memdesc<64x32xf32, #bm64_bn32, #tmem, 64x128> {
   // 16 << 16 => 1048576
@@ -1091,7 +1114,7 @@ module attributes {"ttg.num-warps" = 4 : i32} {
 // CHECK-LABEL: @load_store_16x2_scales_uses_zero_second_half
 tt.func private @load_store_16x2_scales_uses_zero_second_half(%arg0: !ttg.memdesc<16x2xi8, #tmem_scales, #ttng.tensor_memory, mutable>, %arg1: tensor<16x2xi8, #linear>) {
   %true = arith.constant true
-  // CHECK: @$0 tcgen05.st.sync.aligned.16x32bx2.x1.unpack::16b.b32 [$1 + 0], 0, {$2}
+  // CHECK: @$0 tcgen05.st.sync.aligned.16x32bx2.x1.b32 [$1 + 0], 0, {$2}
   // CHECK: llvm.return
   ttng.tmem_store %arg1, %arg0, %true : tensor<16x2xi8, #linear> -> !ttg.memdesc<16x2xi8, #tmem_scales, #ttng.tensor_memory, mutable>
   tt.return

--- a/test/Conversion/tritongpu_to_llvm_blackwell.mlir
+++ b/test/Conversion/tritongpu_to_llvm_blackwell.mlir
@@ -195,7 +195,7 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32} {
                                     %c: !ttg.memdesc<256x128xf32, #tmem, #ttng.tensor_memory, mutable>) {
     %false = arith.constant false
     %true = arith.constant true
-    %sub = ttng.tmem_subslice %c {N = 64 : i32} : !ttg.memdesc<256x128xf32, #tmem, #ttng.tensor_memory, mutable> -> !ttg.memdesc<256x64xf32, #tmem, #ttng.tensor_memory, mutable, 256x128>
+    %sub = ttng.tmem_subslice %c {offset = 64 : i32} : !ttg.memdesc<256x128xf32, #tmem, #ttng.tensor_memory, mutable> -> !ttg.memdesc<256x64xf32, #tmem, #ttng.tensor_memory, mutable, 256x128>
     ttng.tc_gen5_mma %a, %b, %sub, %false, %true :
        !ttg.memdesc<256x64xf16, #shared, #ttg.shared_memory>,
        !ttg.memdesc<64x64xf16, #shared1, #ttg.shared_memory>,
@@ -862,7 +862,7 @@ tt.func private @subslice_unpacked(%arg0: !ttg.memdesc<128x128xf16, #tmem_unpack
   // CHECK: [[OFFSET:%.*]] = llvm.mlir.constant(64 : i32)
   // CHECK: [[PTR:%.*]] = llvm.ptrtoint
   // CHECK: llvm.add [[PTR]], [[OFFSET]] : i32
-  %0 = ttng.tmem_subslice %arg0 {N = 64 : i32} : !ttg.memdesc<128x128xf16, #tmem_unpacked, #ttng.tensor_memory> -> !ttg.memdesc<128x64xf16, #tmem_unpacked, #ttng.tensor_memory, 128x128>
+  %0 = ttng.tmem_subslice %arg0 {offset = 64 : i32} : !ttg.memdesc<128x128xf16, #tmem_unpacked, #ttng.tensor_memory> -> !ttg.memdesc<128x64xf16, #tmem_unpacked, #ttng.tensor_memory, 128x128>
   tt.return %0 : !ttg.memdesc<128x64xf16, #tmem_unpacked, #ttng.tensor_memory, 128x128>
 }
 
@@ -872,7 +872,7 @@ tt.func private @subslice_packed(%arg0: !ttg.memdesc<128x128xf16, #tmem, #ttng.t
   // CHECK: [[OFFSET:%.*]] = llvm.mlir.constant(32 : i32)
   // CHECK: [[PTR:%.*]] = llvm.ptrtoint
   // CHECK: llvm.add [[PTR]], [[OFFSET]] : i32
-  %0 = ttng.tmem_subslice %arg0 {N = 64 : i32} : !ttg.memdesc<128x128xf16, #tmem, #ttng.tensor_memory> -> !ttg.memdesc<128x64xf16, #tmem, #ttng.tensor_memory, 128x128>
+  %0 = ttng.tmem_subslice %arg0 {offset = 64 : i32} : !ttg.memdesc<128x128xf16, #tmem, #ttng.tensor_memory> -> !ttg.memdesc<128x64xf16, #tmem, #ttng.tensor_memory, 128x128>
   tt.return %0 : !ttg.memdesc<128x64xf16, #tmem, #ttng.tensor_memory, 128x128>
 }
 
@@ -995,7 +995,7 @@ tt.func private @subslice_16x32bx2(%arg0: !ttg.memdesc<64x128xf32, #bm64_bn128, 
   // CHECK: [[OFFSET:%.*]] = llvm.mlir.constant(64 : i32)
   // CHECK: [[PTR:%.*]] = llvm.ptrtoint
   // CHECK: llvm.add [[PTR]], [[OFFSET]] : i32
-  %0 = ttng.tmem_subslice %arg0 {N = 64 : i32} : !ttg.memdesc<64x128xf32, #bm64_bn128, #tmem> -> !ttg.memdesc<64x64xf32, #bm64_bn128, #tmem, 64x128>
+  %0 = ttng.tmem_subslice %arg0 {offset = 64 : i32} : !ttg.memdesc<64x128xf32, #bm64_bn128, #tmem> -> !ttg.memdesc<64x64xf32, #bm64_bn128, #tmem, 64x128>
   tt.return %0 : !ttg.memdesc<64x64xf32, #bm64_bn128, #tmem, 64x128>
 }
 
@@ -1004,7 +1004,7 @@ tt.func private @subslice_16x32bx2_packed(%arg0: !ttg.memdesc<64x128xf16, #bm64_
   // CHECK: [[OFFSET:%.*]] = llvm.mlir.constant(32 : i32)
   // CHECK: [[PTR:%.*]] = llvm.ptrtoint
   // CHECK: llvm.add [[PTR]], [[OFFSET]] : i32
-  %0 = ttng.tmem_subslice %arg0 {N = 64 : i32} : !ttg.memdesc<64x128xf16, #bm64_bn128, #tmem> -> !ttg.memdesc<64x64xf16, #bm64_bn128, #tmem, 64x128>
+  %0 = ttng.tmem_subslice %arg0 {offset = 64 : i32} : !ttg.memdesc<64x128xf16, #bm64_bn128, #tmem> -> !ttg.memdesc<64x64xf16, #bm64_bn128, #tmem, 64x128>
   tt.return %0 : !ttg.memdesc<64x64xf16, #bm64_bn128, #tmem, 64x128>
 }
 
@@ -1014,7 +1014,7 @@ tt.func private @subslice_16x32bx2_interleaved_block1(%arg0: !ttg.memdesc<64x128
   // CHECK: [[OFFSET:%.*]] = llvm.mlir.constant(1048576 : i32)
   // CHECK: [[PTR:%.*]] = llvm.ptrtoint
   // CHECK: llvm.add [[PTR]], [[OFFSET]] : i32
-  %0 = ttng.tmem_subslice %arg0 {N = 32 : i32} : !ttg.memdesc<64x128xf32, #bm64_bn32, #tmem> -> !ttg.memdesc<64x32xf32, #bm64_bn32, #tmem, 64x128>
+  %0 = ttng.tmem_subslice %arg0 {offset = 32 : i32} : !ttg.memdesc<64x128xf32, #bm64_bn32, #tmem> -> !ttg.memdesc<64x32xf32, #bm64_bn32, #tmem, 64x128>
   tt.return %0 : !ttg.memdesc<64x32xf32, #bm64_bn32, #tmem, 64x128>
 }
 
@@ -1023,7 +1023,7 @@ tt.func private @subslice_16x32bx2_interleaved_block0(%arg0: !ttg.memdesc<64x128
   // CHECK: [[OFFSET:%.*]] = llvm.mlir.constant(16 : i32)
   // CHECK: [[PTR:%.*]] = llvm.ptrtoint
   // CHECK: llvm.add [[PTR]], [[OFFSET]] : i32
-  %0 = ttng.tmem_subslice %arg0 {N = 16 : i32} : !ttg.memdesc<64x128xf32, #bm64_bn32, #tmem> -> !ttg.memdesc<64x16xf32, #bm64_bn32, #tmem, 64x128>
+  %0 = ttng.tmem_subslice %arg0 {offset = 16 : i32} : !ttg.memdesc<64x128xf32, #bm64_bn32, #tmem> -> !ttg.memdesc<64x16xf32, #bm64_bn32, #tmem, 64x128>
   tt.return %0 : !ttg.memdesc<64x16xf32, #bm64_bn32, #tmem, 64x128>
 }
 
@@ -1033,7 +1033,7 @@ tt.func private @subslice_16x32bx2_interleaved_block0_offset(%arg0: !ttg.memdesc
   // CHECK: [[OFFSET:%.*]] = llvm.mlir.constant(1048592 : i32)
   // CHECK: [[PTR:%.*]] = llvm.ptrtoint
   // CHECK: llvm.add [[PTR]], [[OFFSET]] : i32
-  %0 = ttng.tmem_subslice %arg0 {N = 48 : i32} : !ttg.memdesc<64x128xf32, #bm64_bn32, #tmem> -> !ttg.memdesc<64x16xf32, #bm64_bn32, #tmem, 64x128>
+  %0 = ttng.tmem_subslice %arg0 {offset = 48 : i32} : !ttg.memdesc<64x128xf32, #bm64_bn32, #tmem> -> !ttg.memdesc<64x16xf32, #bm64_bn32, #tmem, 64x128>
   tt.return %0 : !ttg.memdesc<64x16xf32, #bm64_bn32, #tmem, 64x128>
 }
 
@@ -1042,7 +1042,7 @@ tt.func private @subslice_16x32bx2_interleaved_block4_offset(%arg0: !ttg.memdesc
   // CHECK: [[OFFSET:%.*]] = llvm.mlir.constant(48 : i32)
   // CHECK: [[PTR:%.*]] = llvm.ptrtoint
   // CHECK: llvm.add [[PTR]], [[OFFSET]] : i32
-  %0 = ttng.tmem_subslice %arg0 {N = 80 : i32} : !ttg.memdesc<64x128xf32, #bm64_bn32, #tmem> -> !ttg.memdesc<64x16xf32, #bm64_bn32, #tmem, 64x128>
+  %0 = ttng.tmem_subslice %arg0 {offset = 80 : i32} : !ttg.memdesc<64x128xf32, #bm64_bn32, #tmem> -> !ttg.memdesc<64x16xf32, #bm64_bn32, #tmem, 64x128>
   tt.return %0 : !ttg.memdesc<64x16xf32, #bm64_bn32, #tmem, 64x128>
 }
 
@@ -1060,7 +1060,7 @@ tt.func private @subslice_cga_allocshape_preserved(%arg0: !ttg.memdesc<512x256xf
   // CHECK: [[OFFSET:%.*]] = llvm.mlir.constant(32 : i32)
   // CHECK: [[PTR:%.*]] = llvm.ptrtoint
   // CHECK: llvm.add [[PTR]], [[OFFSET]] : i32
-  %0 = ttng.tmem_subslice %arg0 {N = 32 : i32} : !ttg.memdesc<512x256xf32, #bm128_bn256_cga, #tmem> -> !ttg.memdesc<512x32xf32, #bm128_bn256_cga, #tmem, 512x256>
+  %0 = ttng.tmem_subslice %arg0 {offset = 32 : i32} : !ttg.memdesc<512x256xf32, #bm128_bn256_cga, #tmem> -> !ttg.memdesc<512x32xf32, #bm128_bn256_cga, #tmem, 512x256>
   tt.return %0 : !ttg.memdesc<512x32xf32, #bm128_bn256_cga, #tmem, 512x256>
 }
 

--- a/test/NVWS/invalid.mlir
+++ b/test/NVWS/invalid.mlir
@@ -1,4 +1,4 @@
-// RUN: triton-opt --split-input-file %s --verify-diagnostics
+// RUN: triton-opt --split-input-file %s --nvws-insert-tmem-aref --verify-diagnostics
 
 #shared0 = #ttg.nvmma_shared<{swizzlingByteWidth = 32, transposed = false, elementBitWidth = 16}>
 #smem = #ttg.shared_memory
@@ -7,6 +7,27 @@ module attributes {"ttg.target" = "cuda:0", "ttg.num-ctas" = 1 : i32, "ttg.num-w
     %c0_i32 = arith.constant 0 : i32
     // expected-error @below {{Leading dims of sliced aref inputs don't match}}
     %0 = nvws.aref.create %d, %e : !nvws.aref<[!ttg.memdesc<1x64x16xf16, #shared0, #smem>, !ttg.memdesc<2x16x32xf16, #shared0, #smem>]>
+    tt.return
+  }
+}
+
+// -----
+
+#blocked = #ttg.blocked<{sizePerThread = [1, 128], threadsPerWarp = [32, 1], warpsPerCTA = [4, 1], order = [0, 1]}>
+#tmem = #ttng.tensor_memory_encoding<blockM = 128, blockN = 128, colStride = 1>
+module attributes {"ttg.target" = "cuda:100", "ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, "ttg.threads-per-warp" = 32 : i32} {
+  tt.func @tmem_subview() {
+    %c0 = arith.constant 0 : index
+    %c1 = arith.constant 1 : index
+    %true = arith.constant true
+    %zero = arith.constant dense<0.0> : tensor<128x128xf32, #blocked>
+    %parent = ttng.tmem_alloc : () -> !ttg.memdesc<256x128xf32, #tmem, #ttng.tensor_memory, mutable>
+    %view = ttng.tmem_subslice %parent {offset = 128 : i32, dim = 0 : i32} : !ttg.memdesc<256x128xf32, #tmem, #ttng.tensor_memory, mutable> -> !ttg.memdesc<128x128xf32, #tmem, #ttng.tensor_memory, mutable, 256x128>
+    // expected-error @+1 {{TMEM subviews NYI in the pipeliner}}
+    ttng.tmem_store %zero, %view, %true : tensor<128x128xf32, #blocked> -> !ttg.memdesc<128x128xf32, #tmem, #ttng.tensor_memory, mutable, 256x128>
+    scf.for %i = %c0 to %c1 step %c1 {
+      scf.yield
+    } {tt.warp_specialize}
     tt.return
   }
 }

--- a/test/TritonGPU/consan.mlir
+++ b/test/TritonGPU/consan.mlir
@@ -1699,7 +1699,7 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 1 : i32, ttg.shar
     // CHECK-DAG: arith.constant dense<{{\[\[true, true, false, false\], \[true, true, false, false\], \[false, false, true, false\], \[false, false, false, false\]\]}}> : tensor<4x4xi1
     %buf0 = ttng.tmem_alloc {tensor_memory_col_offset = 0 : i32, tensor_memory_row_offset = 0 : i32} : () -> !ttg.memdesc<64x64xf32, #tmem, #ttng.tensor_memory, mutable>
     %buf1 = ttng.tmem_alloc {tensor_memory_col_offset = 64 : i32, tensor_memory_row_offset = 0 : i32} : () -> !ttg.memdesc<64x64xf32, #tmem, #ttng.tensor_memory, mutable>
-    %buf3 = ttng.tmem_subslice %buf0 {N = 32 : i32} : !ttg.memdesc<64x64xf32, #tmem, #ttng.tensor_memory, mutable> -> !ttg.memdesc<64x32xf32, #tmem, #ttng.tensor_memory, mutable, 64x64>
+    %buf3 = ttng.tmem_subslice %buf0 {offset = 32 : i32} : !ttg.memdesc<64x64xf32, #tmem, #ttng.tensor_memory, mutable> -> !ttg.memdesc<64x32xf32, #tmem, #ttng.tensor_memory, mutable, 64x64>
     ttng.tmem_load %buf0 : !ttg.memdesc<64x64xf32, #tmem, #ttng.tensor_memory, mutable> -> tensor<64x64xf32>
     ttng.tmem_load %buf1 : !ttg.memdesc<64x64xf32, #tmem, #ttng.tensor_memory, mutable> -> tensor<64x64xf32>
     ttng.tmem_load %buf3 : !ttg.memdesc<64x32xf32, #tmem, #ttng.tensor_memory, mutable, 64x64> -> tensor<64x32xf32>

--- a/test/TritonGPU/nvidia-fpsan.mlir
+++ b/test/TritonGPU/nvidia-fpsan.mlir
@@ -72,7 +72,7 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.shar
     // CHECK-NOT: ttng.tmem_subslice
     %src = ttg.local_alloc {allocation.offset = 0 : i32} : () -> !ttg.memdesc<128x128xf32, #shared, #smem, mutable>
     %dst = ttng.tmem_alloc {tensor_memory_col_offset = 0 : i32, tensor_memory_row_offset = 0 : i32} : () -> !ttg.memdesc<128x128xf32, #tmem, #ttng.tensor_memory, mutable>
-    %sub = ttng.tmem_subslice %dst {N = 0 : i32} : !ttg.memdesc<128x128xf32, #tmem, #ttng.tensor_memory, mutable> -> !ttg.memdesc<128x128xf32, #tmem, #ttng.tensor_memory, mutable>
+    %sub = ttng.tmem_subslice %dst {offset = 0 : i32} : !ttg.memdesc<128x128xf32, #tmem, #ttng.tensor_memory, mutable> -> !ttg.memdesc<128x128xf32, #tmem, #ttng.tensor_memory, mutable>
     ttng.tmem_copy %src, %sub : !ttg.memdesc<128x128xf32, #shared, #smem, mutable>, !ttg.memdesc<128x128xf32, #tmem, #ttng.tensor_memory, mutable>
     tt.return
   }
@@ -92,7 +92,7 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.shar
     %true = arith.constant true
     %zero = arith.constant dense<0.0> : tensor<128x128xf32, #blocked>
     %buf = ttng.tmem_alloc {tensor_memory_col_offset = 0 : i32, tensor_memory_row_offset = 0 : i32} : () -> !ttg.memdesc<128x256xf32, #tmem, #ttng.tensor_memory, mutable>
-    %sub = ttng.tmem_subslice %buf {N = 128 : i32} : !ttg.memdesc<128x256xf32, #tmem, #ttng.tensor_memory, mutable> -> !ttg.memdesc<128x128xf32, #tmem, #ttng.tensor_memory, mutable, 128x256>
+    %sub = ttng.tmem_subslice %buf {offset = 128 : i32} : !ttg.memdesc<128x256xf32, #tmem, #ttng.tensor_memory, mutable> -> !ttg.memdesc<128x128xf32, #tmem, #ttng.tensor_memory, mutable, 128x256>
     ttng.tmem_store %zero, %sub, %true : tensor<128x128xf32, #blocked> -> !ttg.memdesc<128x128xf32, #tmem, #ttng.tensor_memory, mutable, 128x256>
     %val = ttng.tmem_load %sub : !ttg.memdesc<128x128xf32, #tmem, #ttng.tensor_memory, mutable, 128x256> -> tensor<128x128xf32, #blocked>
     tt.return

--- a/test/TritonNvidiaGPU/interleave_tmem.mlir
+++ b/test/TritonNvidiaGPU/interleave_tmem.mlir
@@ -20,10 +20,10 @@ tt.func public @sink_load(%arg0: !ttg.memdesc<128x128xf32, #tmem, #ttng.tensor_m
   // CHECK: ttng.tmem_load
   // CHECK: ttg.convert_layout
   // CHECK: arith.truncf
-  %subslice0 = ttng.tmem_subslice %arg0 {N = 0 : i32} : !ttg.memdesc<128x128xf32, #tmem, #ttng.tensor_memory, mutable> -> !ttg.memdesc<128x64xf32, #tmem, #ttng.tensor_memory, mutable, 128x128>
+  %subslice0 = ttng.tmem_subslice %arg0 {offset = 0 : i32} : !ttg.memdesc<128x128xf32, #tmem, #ttng.tensor_memory, mutable> -> !ttg.memdesc<128x64xf32, #tmem, #ttng.tensor_memory, mutable, 128x128>
   %subtile0 = ttng.tmem_load %subslice0 : !ttg.memdesc<128x64xf32, #tmem, #ttng.tensor_memory, mutable, 128x128> -> tensor<128x64xf32, #linear64>
   %outLHS = ttg.convert_layout %subtile0 : tensor<128x64xf32, #linear64> -> tensor<128x64xf32, #blocked>
-  %subslice1 = ttng.tmem_subslice %arg0 {N = 64 : i32} : !ttg.memdesc<128x128xf32, #tmem, #ttng.tensor_memory, mutable> -> !ttg.memdesc<128x64xf32, #tmem, #ttng.tensor_memory, mutable, 128x128>
+  %subslice1 = ttng.tmem_subslice %arg0 {offset = 64 : i32} : !ttg.memdesc<128x128xf32, #tmem, #ttng.tensor_memory, mutable> -> !ttg.memdesc<128x64xf32, #tmem, #ttng.tensor_memory, mutable, 128x128>
   %subtile1 = ttng.tmem_load %subslice1 : !ttg.memdesc<128x64xf32, #tmem, #ttng.tensor_memory, mutable, 128x128> -> tensor<128x64xf32, #linear64>
   %outRHS = ttg.convert_layout %subtile1 : tensor<128x64xf32, #linear64> -> tensor<128x64xf32, #blocked>
 
@@ -72,20 +72,20 @@ tt.func @interleave_load_store_ws() {
       // CHECK: memdesc_index
       %cur_acc = ttg.memdesc_index %arg0[%i] : !ttg.memdesc<2x128x128xf32, #tmem, #ttng.tensor_memory, mutable> -> !ttg.memdesc<128x128xf32, #tmem, #ttng.tensor_memory, mutable>
 
-      // CHECK-NEXT: [[S0:%.+]] = ttng.tmem_subslice %{{.+}} {N = 0 : i32}
-      // CHECK-NEXT: [[S1:%.+]] = ttng.tmem_subslice %{{.+}} {N = 64 : i32}
+      // CHECK-NEXT: [[S0:%.+]] = ttng.tmem_subslice %{{.+}} {offset = 0 : i32}
+      // CHECK-NEXT: [[S1:%.+]] = ttng.tmem_subslice %{{.+}} {offset = 64 : i32}
 
       // CHECK-NEXT: [[L0:%.+]] = ttng.tmem_load [[S0]]
       // CHECK-NEXT: [[M0:%.+]] = arith.mulf [[L0]]
       // CHECK-NEXT: ttng.tmem_store [[M0]], [[S0]]
-      %slice0 = ttng.tmem_subslice %cur_acc {N = 0 : i32} : !ttg.memdesc<128x128xf32, #tmem, #ttng.tensor_memory, mutable> -> !ttg.memdesc<128x64xf32, #tmem, #ttng.tensor_memory, mutable, 128x128>
+      %slice0 = ttng.tmem_subslice %cur_acc {offset = 0 : i32} : !ttg.memdesc<128x128xf32, #tmem, #ttng.tensor_memory, mutable> -> !ttg.memdesc<128x64xf32, #tmem, #ttng.tensor_memory, mutable, 128x128>
       %val0 = ttng.tmem_load %slice0 : !ttg.memdesc<128x64xf32, #tmem, #ttng.tensor_memory, mutable, 128x128> -> tensor<128x64xf32, #linear64>
       %mul0 = arith.mulf %val0, %alpha : tensor<128x64xf32, #linear64>
 
       // CHECK-NEXT: [[L1:%.+]] = ttng.tmem_load [[S1]]
       // CHECK-NEXT: [[M1:%.+]] = arith.mulf [[L1]]
       // CHECK-NEXT: ttng.tmem_store [[M1]], [[S1]]
-      %slice1 = ttng.tmem_subslice %cur_acc {N = 64 : i32} : !ttg.memdesc<128x128xf32, #tmem, #ttng.tensor_memory, mutable> -> !ttg.memdesc<128x64xf32, #tmem, #ttng.tensor_memory, mutable, 128x128>
+      %slice1 = ttng.tmem_subslice %cur_acc {offset = 64 : i32} : !ttg.memdesc<128x128xf32, #tmem, #ttng.tensor_memory, mutable> -> !ttg.memdesc<128x64xf32, #tmem, #ttng.tensor_memory, mutable, 128x128>
       %val1 = ttng.tmem_load %slice1 : !ttg.memdesc<128x64xf32, #tmem, #ttng.tensor_memory, mutable, 128x128> -> tensor<128x64xf32, #linear64>
       %mul1 = arith.mulf %val1, %alpha : tensor<128x64xf32, #linear64>
 

--- a/test/TritonNvidiaGPU/invalid.mlir
+++ b/test/TritonNvidiaGPU/invalid.mlir
@@ -863,7 +863,7 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32} {
   tt.func public @tmem_subslice_non_tmem_source() {
     %md = ttg.local_alloc : () -> !ttg.memdesc<128x128xi32, #shared1, #ttg.shared_memory, mutable>
     // expected-error @+1 {{The source must be a tensor memory buffer.}}
-    %sub = ttng.tmem_subslice %md {N = 0 : i32} : !ttg.memdesc<128x128xi32, #shared1, #ttg.shared_memory, mutable> -> !ttg.memdesc<128x128xi32, #shared1, #ttg.shared_memory, mutable>
+    %sub = ttng.tmem_subslice %md {offset = 0 : i32} : !ttg.memdesc<128x128xi32, #shared1, #ttg.shared_memory, mutable> -> !ttg.memdesc<128x128xi32, #shared1, #ttg.shared_memory, mutable>
     tt.return
   }
 }
@@ -875,7 +875,7 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32} {
   tt.func public @tmem_subslice_rank_not_2() {
     %md = ttng.tmem_alloc : () -> !ttg.memdesc<2x128x128xf32, #tmem, #ttng.tensor_memory, mutable>
     // expected-error @+1 {{The result must be a 2D tensor memory buffer.}}
-    %sub = ttng.tmem_subslice %md {N = 0 : i32} : !ttg.memdesc<2x128x128xf32, #tmem, #ttng.tensor_memory, mutable> -> !ttg.memdesc<2x128x128xf32, #tmem, #ttng.tensor_memory, mutable>
+    %sub = ttng.tmem_subslice %md {offset = 0 : i32} : !ttg.memdesc<2x128x128xf32, #tmem, #ttng.tensor_memory, mutable> -> !ttg.memdesc<2x128x128xf32, #tmem, #ttng.tensor_memory, mutable>
     tt.return
   }
 }
@@ -887,7 +887,7 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32} {
   tt.func public @tmem_subslice_rows_mismatch() {
     %md = ttng.tmem_alloc : () -> !ttg.memdesc<128x128xf32, #tmem, #ttng.tensor_memory, mutable>
     // expected-error @+1 {{The result must have the same number of rows as the source.}}
-    %sub = ttng.tmem_subslice %md {N = 0 : i32} : !ttg.memdesc<128x128xf32, #tmem, #ttng.tensor_memory, mutable> -> !ttg.memdesc<64x128xf32, #tmem, #ttng.tensor_memory, mutable, 128x128>
+    %sub = ttng.tmem_subslice %md {offset = 0 : i32} : !ttg.memdesc<128x128xf32, #tmem, #ttng.tensor_memory, mutable> -> !ttg.memdesc<64x128xf32, #tmem, #ttng.tensor_memory, mutable, 128x128>
     tt.return
   }
 }
@@ -899,7 +899,7 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32} {
   tt.func public @tmem_subslice_element_type_mismatch() {
     %md = ttng.tmem_alloc : () -> !ttg.memdesc<128x128xi32, #tmem, #ttng.tensor_memory, mutable>
     // expected-error @+1 {{The source and result must have the same element type.}}
-    %sub = ttng.tmem_subslice %md {N = 0 : i32} : !ttg.memdesc<128x128xi32, #tmem, #ttng.tensor_memory, mutable> -> !ttg.memdesc<128x128xf16, #tmem, #ttng.tensor_memory, mutable, 128x128>
+    %sub = ttng.tmem_subslice %md {offset = 0 : i32} : !ttg.memdesc<128x128xi32, #tmem, #ttng.tensor_memory, mutable> -> !ttg.memdesc<128x128xf16, #tmem, #ttng.tensor_memory, mutable, 128x128>
     tt.return
   }
 }
@@ -911,7 +911,7 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32} {
   tt.func public @tmem_subslice_alloc_shape_mismatch() {
     %md = ttng.tmem_alloc : () -> !ttg.memdesc<128x128xf32, #tmem, #ttng.tensor_memory, mutable>
     // expected-error @+1 {{The source and result must have the same alloc shape.}}
-    %sub = ttng.tmem_subslice %md {N = 0 : i32} : !ttg.memdesc<128x128xf32, #tmem, #ttng.tensor_memory, mutable> -> !ttg.memdesc<128x64xf32, #tmem, #ttng.tensor_memory, mutable, 2x128x128>
+    %sub = ttng.tmem_subslice %md {offset = 0 : i32} : !ttg.memdesc<128x128xf32, #tmem, #ttng.tensor_memory, mutable> -> !ttg.memdesc<128x64xf32, #tmem, #ttng.tensor_memory, mutable, 2x128x128>
     tt.return
   }
 }
@@ -923,7 +923,7 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32} {
   tt.func public @tmem_subslice_offset_alignment_invalid() {
     %md = ttng.tmem_alloc : () -> !ttg.memdesc<128x256xf32, #tmem, #ttng.tensor_memory, mutable>
     // expected-error @+1 {{The split offset may not touch the tile}}
-    %sub = ttng.tmem_subslice %md {N = 32 : i32} : !ttg.memdesc<128x256xf32, #tmem, #ttng.tensor_memory, mutable> -> !ttg.memdesc<128x64xf32, #tmem, #ttng.tensor_memory, mutable, 128x256>
+    %sub = ttng.tmem_subslice %md {offset = 32 : i32} : !ttg.memdesc<128x256xf32, #tmem, #ttng.tensor_memory, mutable> -> !ttg.memdesc<128x64xf32, #tmem, #ttng.tensor_memory, mutable, 128x256>
     tt.return
   }
 }
@@ -935,7 +935,7 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32} {
   tt.func public @tmem_subslice_offset_exceed() {
     %md = ttng.tmem_alloc : () -> !ttg.memdesc<128x128xf32, #tmem, #ttng.tensor_memory, mutable>
     // expected-error @+1 {{The split offset may not exceed the source shape}}
-    %sub = ttng.tmem_subslice %md {N = 128 : i32} : !ttg.memdesc<128x128xf32, #tmem, #ttng.tensor_memory, mutable> -> !ttg.memdesc<128x64xf32, #tmem, #ttng.tensor_memory, mutable, 128x128>
+    %sub = ttng.tmem_subslice %md {offset = 128 : i32} : !ttg.memdesc<128x128xf32, #tmem, #ttng.tensor_memory, mutable> -> !ttg.memdesc<128x64xf32, #tmem, #ttng.tensor_memory, mutable, 128x128>
     tt.return
   }
 }

--- a/test/TritonNvidiaGPU/invalid.mlir
+++ b/test/TritonNvidiaGPU/invalid.mlir
@@ -885,9 +885,9 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32} {
 #tmem = #ttng.tensor_memory_encoding<blockM = 128, blockN = 128, colStride = 1>
 module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32} {
   tt.func public @tmem_subslice_rows_mismatch() {
-    %md = ttng.tmem_alloc : () -> !ttg.memdesc<128x128xf32, #tmem, #ttng.tensor_memory, mutable>
-    // expected-error @+1 {{The result must have the same number of rows as the source.}}
-    %sub = ttng.tmem_subslice %md {offset = 0 : i32} : !ttg.memdesc<128x128xf32, #tmem, #ttng.tensor_memory, mutable> -> !ttg.memdesc<64x128xf32, #tmem, #ttng.tensor_memory, mutable, 128x128>
+    %md = ttng.tmem_alloc : () -> !ttg.memdesc<256x128xf32, #tmem, #ttng.tensor_memory, mutable>
+    // expected-error @+1 {{The result must have the same size as the source in the dimension that is not being sliced.}}
+    %sub = ttng.tmem_subslice %md {offset = 0 : i32} : !ttg.memdesc<256x128xf32, #tmem, #ttng.tensor_memory, mutable> -> !ttg.memdesc<128x128xf32, #tmem, #ttng.tensor_memory, mutable, 256x128>
     tt.return
   }
 }
@@ -936,6 +936,109 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32} {
     %md = ttng.tmem_alloc : () -> !ttg.memdesc<128x128xf32, #tmem, #ttng.tensor_memory, mutable>
     // expected-error @+1 {{The split offset may not exceed the source shape}}
     %sub = ttng.tmem_subslice %md {offset = 128 : i32} : !ttg.memdesc<128x128xf32, #tmem, #ttng.tensor_memory, mutable> -> !ttg.memdesc<128x64xf32, #tmem, #ttng.tensor_memory, mutable, 128x128>
+    tt.return
+  }
+}
+
+// -----
+
+#tmem = #ttng.tensor_memory_encoding<blockM = 128, blockN = 1, colStride = 1>
+module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32} {
+  tt.func public @tmem_subslice_subword_offset() {
+    %md = ttng.tmem_alloc : () -> !ttg.memdesc<128x2xf16, #tmem, #ttng.tensor_memory, mutable>
+    // expected-error @+1 {{The split offset must be 32-bit aligned in tensor memory.}}
+    %sub = ttng.tmem_subslice %md {offset = 1 : i32} : !ttg.memdesc<128x2xf16, #tmem, #ttng.tensor_memory, mutable> -> !ttg.memdesc<128x1xf16, #tmem, #ttng.tensor_memory, mutable, 128x2>
+    tt.return
+  }
+}
+
+// -----
+
+#shared = #ttg.nvmma_shared<{swizzlingByteWidth = 128, transposed = false, elementBitWidth = 32}>
+#tmem = #ttng.tensor_memory_encoding<blockM = 128, blockN = 2, colStride = 1>
+module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32} {
+  tt.func public @tmem_copy_noncontiguous_too_narrow(%src: !ttg.memdesc<128x64xi32, #shared, #ttg.shared_memory>) {
+    %md = ttng.tmem_alloc : () -> !ttg.memdesc<256x64xi32, #tmem, #ttng.tensor_memory, mutable>
+    %sub = ttng.tmem_subslice %md {offset = 128 : i32, dim = 0 : i32} : !ttg.memdesc<256x64xi32, #tmem, #ttng.tensor_memory, mutable> -> !ttg.memdesc<128x64xi32, #tmem, #ttng.tensor_memory, mutable, 256x64>
+    // expected-error @+1 {{at least 128 contiguous bits}}
+    ttng.tmem_copy %src, %sub : !ttg.memdesc<128x64xi32, #shared, #ttg.shared_memory>, !ttg.memdesc<128x64xi32, #tmem, #ttng.tensor_memory, mutable, 256x64>
+    tt.return
+  }
+}
+
+// -----
+
+#tmem = #ttng.tensor_memory_encoding<blockM = 128, blockN = 128, colStride = 1, CGALayout = [[1, 0]]>
+module attributes {"ttg.num-ctas" = 2 : i32, "ttg.num-warps" = 4 : i32} {
+  tt.func public @tmem_subslice_row_across_ctas() {
+    %md = ttng.tmem_alloc : () -> !ttg.memdesc<512x128xf32, #tmem, #ttng.tensor_memory, mutable>
+    // expected-error @+1 {{The result may not be sliced across CTAs.}}
+    %sub = ttng.tmem_subslice %md {offset = 256 : i32, dim = 0 : i32} : !ttg.memdesc<512x128xf32, #tmem, #ttng.tensor_memory, mutable> -> !ttg.memdesc<256x128xf32, #tmem, #ttng.tensor_memory, mutable, 512x128>
+    tt.return
+  }
+}
+
+// -----
+
+#tmem = #ttng.tensor_memory_encoding<blockM = 128, blockN = 128, colStride = 1>
+module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32} {
+  tt.func public @tmem_subslice_row_too_small() {
+    %md = ttng.tmem_alloc : () -> !ttg.memdesc<256x128xf32, #tmem, #ttng.tensor_memory, mutable>
+    // expected-error @+1 {{the tensor shape must be at least 128x128. Got 64, 128}}
+    %sub = ttng.tmem_subslice %md {offset = 0 : i32, dim = 0 : i32} : !ttg.memdesc<256x128xf32, #tmem, #ttng.tensor_memory, mutable> -> !ttg.memdesc<64x128xf32, #tmem, #ttng.tensor_memory, mutable, 256x128>
+    tt.return
+  }
+}
+
+// -----
+
+#tmem = #ttng.tensor_memory_encoding<blockM = 128, blockN = 128, colStride = 1>
+module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32} {
+  tt.func public @tmem_subslice_row_offset_exceed(%md: !ttg.memdesc<256x128xf32, #tmem, #ttng.tensor_memory, mutable>) {
+    // expected-error @+1 {{The split offset may not exceed the source shape}}
+    %sub = ttng.tmem_subslice %md {offset = 256 : i32, dim = 0 : i32} : !ttg.memdesc<256x128xf32, #tmem, #ttng.tensor_memory, mutable> -> !ttg.memdesc<128x128xf32, #tmem, #ttng.tensor_memory, mutable, 256x128>
+    tt.return
+  }
+}
+
+// -----
+
+#tmem = #ttng.tensor_memory_encoding<blockM = 128, blockN = 128, colStride = 1>
+module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32} {
+  // expected-error @+1 {{shape must have power-of-2 and non-zero dimensions; got 192, 128}}
+  tt.func public @tmem_memdesc_row_non_power_of_two(%md: !ttg.memdesc<192x128xf32, #tmem, #ttng.tensor_memory, mutable, 256x128>) {
+    tt.return
+  }
+}
+
+// -----
+
+#tmem = #ttng.tensor_memory_encoding<blockM = 128, blockN = 128, colStride = 1>
+module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32} {
+  // expected-error @+1 {{shape must have power-of-2 and non-zero dimensions; got 2, 192, 128}}
+  tt.func public @tmem_memdesc_multibuffer_row_non_power_of_two(%md: !ttg.memdesc<2x192x128xf32, #tmem, #ttng.tensor_memory, mutable, 2x256x128>) {
+    tt.return
+  }
+}
+
+// -----
+
+#tmem = #ttng.tensor_memory_encoding<blockM = 128, blockN = 128, colStride = 1>
+module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32} {
+  // expected-error @+1 {{alloc shape must have power-of-2 and non-zero dimensions; got 192, 128}}
+  tt.func public @tmem_memdesc_alloc_row_non_power_of_two(%md: !ttg.memdesc<128x128xf32, #tmem, #ttng.tensor_memory, mutable, 192x128>) {
+    tt.return
+  }
+}
+
+// -----
+
+#tmem = #ttng.tensor_memory_encoding<blockM = 128, blockN = 128, colStride = 1>
+module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32} {
+  tt.func public @tmem_subslice_invalid_dim() {
+    %md = ttng.tmem_alloc : () -> !ttg.memdesc<256x128xf32, #tmem, #ttng.tensor_memory, mutable>
+    // expected-error @+1 {{The slice dimension must be 0 or 1.}}
+    %sub = ttng.tmem_subslice %md {offset = 0 : i32, dim = 2 : i32} : !ttg.memdesc<256x128xf32, #tmem, #ttng.tensor_memory, mutable> -> !ttg.memdesc<256x64xf32, #tmem, #ttng.tensor_memory, mutable, 256x128>
     tt.return
   }
 }

--- a/test/TritonNvidiaGPU/invalid.mlir
+++ b/test/TritonNvidiaGPU/invalid.mlir
@@ -1045,6 +1045,18 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32} {
 
 // -----
 
+#tmem = #ttng.tensor_memory_encoding<blockM = 128, blockN = 128, colStride = 1>
+module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32} {
+  tt.func public @tmem_subslice_negative_dim() {
+    %md = ttng.tmem_alloc : () -> !ttg.memdesc<256x128xf32, #tmem, #ttng.tensor_memory, mutable>
+    // expected-error @+1 {{The slice dimension must be 0 or 1.}}
+    %sub = ttng.tmem_subslice %md {offset = 0 : i32, dim = -1 : i32} : !ttg.memdesc<256x128xf32, #tmem, #ttng.tensor_memory, mutable> -> !ttg.memdesc<256x64xf32, #tmem, #ttng.tensor_memory, mutable, 256x128>
+    tt.return
+  }
+}
+
+// -----
+
 #shared = #ttg.nvmma_shared<{swizzlingByteWidth = 128, transposed = false, elementBitWidth = 32}>
 #smem = #ttg.shared_memory
 module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.target = "cuda:90", "ttg.threads-per-warp" = 32 : i32} {

--- a/test/TritonNvidiaGPU/test_tensor_memory_allocation.mlir
+++ b/test/TritonNvidiaGPU/test_tensor_memory_allocation.mlir
@@ -62,6 +62,44 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.shar
 // -----
 
 #blocked = #ttg.blocked<{sizePerThread = [1, 128], threadsPerWarp = [32, 1], warpsPerCTA = [4, 1], order = [0, 1]}>
+#tmem = #ttng.tensor_memory_encoding<blockM = 128, blockN = 128, colStride = 1>
+
+module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.target = "cuda:100"} {
+  // CHECK: ttg.tensor_memory_size = 512
+  // CHECK-LABEL: @tmem_subslice_extends_liveness
+  tt.func @tmem_subslice_extends_liveness() {
+    %true = arith.constant true
+    %zero = arith.constant dense<0.0> : tensor<128x128xf32, #blocked>
+    // CHECK: ttng.tmem_alloc {tensor_memory_col_offset = 0 : i32, tensor_memory_row_offset = 0 : i32}
+    %parent = ttng.tmem_alloc : () -> !ttg.memdesc<256x128xf32, #tmem, #ttng.tensor_memory, mutable>
+    %view = ttng.tmem_subslice %parent {offset = 128 : i32, dim = 0 : i32} : !ttg.memdesc<256x128xf32, #tmem, #ttng.tensor_memory, mutable> -> !ttg.memdesc<128x128xf32, #tmem, #ttng.tensor_memory, mutable, 256x128>
+    // CHECK: ttng.tmem_alloc {tensor_memory_col_offset = 256 : i32, tensor_memory_row_offset = 0 : i32}
+    %other = ttng.tmem_alloc : () -> !ttg.memdesc<128x128xf32, #tmem, #ttng.tensor_memory, mutable>
+    ttng.tmem_store %zero, %other, %true : tensor<128x128xf32, #blocked> -> !ttg.memdesc<128x128xf32, #tmem, #ttng.tensor_memory, mutable>
+    ttng.tmem_store %zero, %view, %true : tensor<128x128xf32, #blocked> -> !ttg.memdesc<128x128xf32, #tmem, #ttng.tensor_memory, mutable, 256x128>
+    tt.return
+  }
+}
+
+// -----
+
+#tmem_n1 = #ttng.tensor_memory_encoding<blockM = 128, blockN = 1, colStride = 1>
+#tmem = #ttng.tensor_memory
+
+module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.target = "cuda:100"} {
+  // CHECK: ttg.tensor_memory_size = 32
+  // CHECK-LABEL: @tmem_f16_one_column
+  tt.func public @tmem_f16_one_column() {
+    // CHECK: ttng.tmem_alloc {tensor_memory_col_offset = 0 : i32, tensor_memory_row_offset = 0 : i32}
+    %a = ttng.tmem_alloc : () -> !ttg.memdesc<128x1xf16, #tmem_n1, #tmem, mutable>
+    "use"(%a) : (!ttg.memdesc<128x1xf16, #tmem_n1, #tmem, mutable>) -> ()
+    tt.return
+  }
+}
+
+// -----
+
+#blocked = #ttg.blocked<{sizePerThread = [1, 128], threadsPerWarp = [32, 1], warpsPerCTA = [4, 1], order = [0, 1]}>
 #blocked1 = #ttg.blocked<{sizePerThread = [1, 64], threadsPerWarp = [32, 1], warpsPerCTA = [4, 1], order = [0, 1]}>
 #tmem = #ttng.tensor_memory_encoding<blockM = 128, blockN = 128, colStride = 1>
 #tmem1 = #ttng.tensor_memory_encoding<blockM = 128, blockN = 64, colStride = 1>

--- a/test/TritonNvidiaGPU/tmem_layouts.mlir
+++ b/test/TritonNvidiaGPU/tmem_layouts.mlir
@@ -10,10 +10,10 @@
 module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 8 : i32, ttg.target = "cuda:100"} {
   // CHECK-LABEL: @subtile_tmem_load
   tt.func public @subtile_tmem_load(%arg0: !ttg.memdesc<128x128xf32, #tmem, #ttng.tensor_memory, mutable>) -> (tensor<128x64xf32, #blocked>, tensor<128x64xf32, #blocked>) {
-    // CHECK: %[[S0:.+]] = ttng.tmem_subslice %{{.+}} {N = 0 : i32}
+    // CHECK: %[[S0:.+]] = ttng.tmem_subslice %{{.+}} {offset = 0 : i32}
     // CHECK: %[[L0:.+]] = ttng.tmem_load %[[S0]] : !ttg.memdesc<128x64xf32
     // CHECK: %[[C0:.+]] = ttg.convert_layout %[[L0]]
-    // CHECK: %[[S1:.+]] = ttng.tmem_subslice %{{.+}} {N = 64 : i32}
+    // CHECK: %[[S1:.+]] = ttng.tmem_subslice %{{.+}} {offset = 64 : i32}
     // CHECK: %[[L1:.+]] = ttng.tmem_load %[[S1]] : !ttg.memdesc<128x64xf32
     // CHECK: %[[C1:.+]] = ttg.convert_layout %[[L1]]
     // CHECK: tt.return %[[C0]], %[[C1]]
@@ -40,18 +40,18 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 8 : i32, ttg.targ
 module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 8 : i32, ttg.target = "cuda:100"} {
   // CHECK-LABEL: @subtile4_tmem_load
   tt.func public @subtile4_tmem_load(%arg0: !ttg.memdesc<128x256xf32, #tmem, #ttng.tensor_memory, mutable>) -> (tensor<128x64xf32, #blocked>, tensor<128x64xf32, #blocked>, tensor<128x64xf32, #blocked>, tensor<128x64xf32, #blocked>) {
-    // CHECK: %[[S0:.+]] = ttng.tmem_subslice %{{.+}} {N = 0 : i32}
-    // CHECK: %[[S1:.+]] = ttng.tmem_subslice %[[S0]] {N = 0 : i32}
+    // CHECK: %[[S0:.+]] = ttng.tmem_subslice %{{.+}} {offset = 0 : i32}
+    // CHECK: %[[S1:.+]] = ttng.tmem_subslice %[[S0]] {offset = 0 : i32}
     // CHECK: %[[L1:.+]] = ttng.tmem_load %[[S1]] : !ttg.memdesc<128x64xf32
     // CHECK: %[[C1:.+]] = ttg.convert_layout %[[L1]]
-    // CHECK: %[[S2:.+]] = ttng.tmem_subslice %[[S0]] {N = 64 : i32}
+    // CHECK: %[[S2:.+]] = ttng.tmem_subslice %[[S0]] {offset = 64 : i32}
     // CHECK: %[[L2:.+]] = ttng.tmem_load %[[S2]] : !ttg.memdesc<128x64xf32
     // CHECK: %[[C2:.+]] = ttg.convert_layout %[[L2]]
-    // CHECK: %[[S3:.+]] = ttng.tmem_subslice %{{.+}} {N = 128 : i32}
-    // CHECK: %[[S4:.+]] = ttng.tmem_subslice %[[S3]] {N = 0 : i32}
+    // CHECK: %[[S3:.+]] = ttng.tmem_subslice %{{.+}} {offset = 128 : i32}
+    // CHECK: %[[S4:.+]] = ttng.tmem_subslice %[[S3]] {offset = 0 : i32}
     // CHECK: %[[L4:.+]] = ttng.tmem_load %[[S4]] : !ttg.memdesc<128x64xf32
     // CHECK: %[[C4:.+]] = ttg.convert_layout %[[L4]]
-    // CHECK: %[[S5:.+]] = ttng.tmem_subslice %[[S3]] {N = 64 : i32}
+    // CHECK: %[[S5:.+]] = ttng.tmem_subslice %[[S3]] {offset = 64 : i32}
     // CHECK: %[[L5:.+]] = ttng.tmem_load %[[S5]] : !ttg.memdesc<128x64xf32
     // CHECK: %[[C5:.+]] = ttg.convert_layout %[[L5]]
     // CHECK: tt.return %[[C1]], %[[C2]], %[[C4]], %[[C5]]
@@ -88,10 +88,10 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.targ
     %arg1: tensor<128x64xf32, #blocked5>,
     %arg2: tensor<128x64xf32, #blocked5>
   ) {
-    // CHECK: [[S0:%.+]] = ttng.tmem_subslice %arg0 {N = 0 : i32}
+    // CHECK: [[S0:%.+]] = ttng.tmem_subslice %arg0 {offset = 0 : i32}
     // CHECK: [[V0:%.+]] = ttg.convert_layout %arg1
     // CHECK: ttng.tmem_store [[V0]], [[S0]]
-    // CHECK: [[S1:%.+]] = ttng.tmem_subslice %arg0 {N = 64 : i32}
+    // CHECK: [[S1:%.+]] = ttng.tmem_subslice %arg0 {offset = 64 : i32}
     // CHECK: [[V1:%.+]] = ttg.convert_layout %arg2
     // CHECK: ttng.tmem_store [[V1]], [[S1]]
     %true = arith.constant true

--- a/third_party/nvidia/lib/Dialect/NVWS/Transforms/InsertTmemAref.cpp
+++ b/third_party/nvidia/lib/Dialect/NVWS/Transforms/InsertTmemAref.cpp
@@ -531,14 +531,6 @@ insertTmemArefImpl(TmemAccessDag::Node *node,
     state.asyncOp[node->partitionId] = AsyncOp::NONE;
   }
 
-  for (Value operand : node->op->getOperands()) {
-    auto type = dyn_cast<MemDescType>(operand.getType());
-    if (type && isa<TensorMemoryEncodingAttr>(type.getEncoding()))
-      assert(type.getShape().take_back(2) ==
-                 type.getAllocShape().take_back(2) &&
-             "NVWS does not support TMEM subviews");
-  }
-
   OpBuilder b(node->op);
   if (auto tmemLoadOp = dyn_cast<TMEMLoadOp>(node->op)) {
     if (auto id = node->partitionId)
@@ -902,6 +894,20 @@ LogicalResult runOnFunction(triton::FuncOp funcOp) {
   if (!walkResult.wasInterrupted())
     return success();
 
+  walkResult = funcOp.walk([&](Operation *op) {
+    for (Value operand : op->getOperands()) {
+      auto type = dyn_cast<MemDescType>(operand.getType());
+      if (type && isa<TensorMemoryEncodingAttr>(type.getEncoding()) &&
+          type.getShape().take_back(2) != type.getAllocShape().take_back(2)) {
+        op->emitError("TMEM subviews NYI in the pipeliner");
+        return WalkResult::interrupt();
+      }
+    }
+    return WalkResult::advance();
+  });
+  if (walkResult.wasInterrupted())
+    return failure();
+
   SmallVector<TmemAccessDag> tmemDags;
   funcOp.walk([&](TMEMAllocOp allocOp) {
     tmemDags.push_back(TmemAccessDag::build(allocOp));
@@ -929,11 +935,13 @@ class NVWSTmemArefInsertion
     : public triton::impl::NVWSInsertTmemArefBase<NVWSTmemArefInsertion> {
 public:
   void runOnOperation() override {
-    getOperation().walk([&](triton::FuncOp funcOp) {
+    auto walkResult = getOperation().walk([&](triton::FuncOp funcOp) {
       if (failed(runOnFunction(funcOp)))
         return WalkResult::interrupt();
       return WalkResult::advance();
     });
+    if (walkResult.wasInterrupted())
+      signalPassFailure();
   }
 };
 

--- a/third_party/nvidia/lib/Dialect/NVWS/Transforms/InsertTmemAref.cpp
+++ b/third_party/nvidia/lib/Dialect/NVWS/Transforms/InsertTmemAref.cpp
@@ -531,6 +531,14 @@ insertTmemArefImpl(TmemAccessDag::Node *node,
     state.asyncOp[node->partitionId] = AsyncOp::NONE;
   }
 
+  for (Value operand : node->op->getOperands()) {
+    auto type = dyn_cast<MemDescType>(operand.getType());
+    if (type && isa<TensorMemoryEncodingAttr>(type.getEncoding()))
+      assert(type.getShape().take_back(2) ==
+                 type.getAllocShape().take_back(2) &&
+             "NVWS does not support TMEM subviews");
+  }
+
   OpBuilder b(node->op);
   if (auto tmemLoadOp = dyn_cast<TMEMLoadOp>(node->op)) {
     if (auto id = node->partitionId)

--- a/third_party/nvidia/lib/TritonNVIDIAGPUToLLVM/DotOpToLLVM/MMAv5.cpp
+++ b/third_party/nvidia/lib/TritonNVIDIAGPUToLLVM/DotOpToLLVM/MMAv5.cpp
@@ -659,21 +659,18 @@ LogicalResult convertScaledDot(const LLVMTypeConverter &typeConverter,
   dot.numBitsPerElementB = getFormatBitSize(op.getBType());
 
   TritonLLVMOpBuilder tb(loc, rewriter);
-  Value baseD = tb.ptrtoint(i32_ty, adaptor.getD());
+  DotOpMmaV5TmemLoader dLoader =
+      DotOpMmaV5TmemLoader::build(loc, rewriter, dTensorTy, adaptor.getD(),
+                                  dTensorTy.getElementTypeBitWidth());
   Value baseScaleA = tb.ptrtoint(i32_ty, adaptor.getAScale());
   Value baseScaleB = tb.ptrtoint(i32_ty, adaptor.getBScale());
   bool twoCTAs = ttng::getModuleTwoCTAs(op);
   SmallVector<Value> commitDescs = op.getCompletionDescs();
 
-  int numRows = 128;
-  int colSizeInBits = 32;
   dot.getAccAddress = [&](ConversionPatternRewriter &rewriter, Location loc,
                           int m, int n, const DotConversion::InstDesc &desc) {
-    int numColPerBlock = ceil<int>(desc.mmaSizeM * desc.mmaSizeN *
-                                       dTensorTy.getElementTypeBitWidth(),
-                                   numRows * colSizeInBits);
-    int blockId = m + n * desc.repShape.numRepM;
-    return MemDescOperand{baseD, numColPerBlock * blockId};
+    return dLoader.tmemLoad(m * desc.mmaSizeM, n * desc.mmaSizeN, rewriter,
+                            loc);
   };
 
   dot.createMMAInst = [&](ConversionPatternRewriter &rewriter, Location loc,

--- a/third_party/nvidia/lib/TritonNVIDIAGPUToLLVM/TensorMemoryToLLVM.cpp
+++ b/third_party/nvidia/lib/TritonNVIDIAGPUToLLVM/TensorMemoryToLLVM.cpp
@@ -13,7 +13,9 @@
 #include "triton/Dialect/TritonNvidiaGPU/IR/TensorMemoryUtils.h"
 #include "triton/Tools/LayoutUtils.h"
 #include "llvm/ADT/SmallVector.h"
+#include "llvm/Support/MathExtras.h"
 #include "llvm/Support/raw_ostream.h"
+#include <algorithm>
 
 using namespace mlir;
 using namespace mlir::triton;
@@ -416,22 +418,6 @@ lowerTMemLdStFromInfo(Location loc, ConversionPatternRewriter &rewriter,
                       std::optional<TMEMLoadReduceModifier> redOp, bool useAbs,
                       bool useNaN) {
   bool isStore = !vals.empty();
-  if (info.broadcast) {
-    auto removeBroadcast = std::move(info.broadcast.value());
-    info.broadcast = std::nullopt;
-
-    auto inVals = to_vector(vals);
-    if (isStore) {
-      inVals = removeBroadcast.apply(inVals);
-    }
-    auto [outVals, redvalVals] =
-        lowerTMemLdStFromInfo(loc, rewriter, info, pred, llvmElemTy, inVals,
-                              tmemBase, redOp, useAbs, useNaN);
-    if (!isStore) {
-      outVals = broadcastAs(outVals, info.reps);
-    }
-    return {outVals, redvalVals};
-  }
   if (llvmElemTy.getIntOrFloatBitWidth() < 32) {
     unsigned bitwidth = llvmElemTy.getIntOrFloatBitWidth();
     bool padding = false;
@@ -547,8 +533,8 @@ struct TensorMemoryLoadOpConversion
         loc, rewriter, regTy, memTy, tmemBase, maxnreg, b.i1_val(true),
         llvmElemTy, {}, redOp, useAbs, useNaN);
 
-    Value resultStruct = packTensorElements(loc, getTypeConverter(), resultVals,
-                                            rewriter, op.getType());
+    Value resultStruct = packUniqueTensorElements(
+        loc, getTypeConverter(), resultVals, rewriter, op.getType());
     // Wait insertion could be moved to the TTGIR level if needed.
     NVVM::Tcgen05WaitOp::create(rewriter, loc, NVVM::Tcgen05WaitKind::LOAD);
 
@@ -560,8 +546,8 @@ struct TensorMemoryLoadOpConversion
     SmallVector<Value> results = {resultStruct};
     if (redOp) {
       // Pack redval values into the red tensor result
-      Value redStruct = packTensorElements(loc, getTypeConverter(), redvalVals,
-                                           rewriter, op.getRed().getType());
+      Value redStruct = packUniqueTensorElements(
+          loc, getTypeConverter(), redvalVals, rewriter, op.getRed().getType());
       results.push_back(redStruct);
     }
 
@@ -587,7 +573,7 @@ struct TensorMemoryStoreOpConversion
     auto regTy = cast<RankedTensorType>(op.getSrc().getType());
 
     SmallVector<Value> srcValues =
-        unpackTensorElements(loc, adaptor.getSrc(), rewriter, regTy);
+        unpackUniqueTensorElements(loc, adaptor.getSrc(), rewriter);
     auto maxnreg = getContextualMaxNReg(op);
     lowerTMemLdStFromTypes(loc, rewriter, regTy, memTy, tmemBase, maxnreg, pred,
                            llvmElemTy, srcValues);
@@ -626,7 +612,7 @@ struct TensorMemoryAllocOpConversion
       auto llvmElemTy = getTypeConverter()->convertType(regTy.getElementType());
       auto maxnreg = getContextualMaxNReg(op);
       SmallVector<Value> srcValues =
-          unpackTensorElements(loc, adaptor.getSrc(), rewriter, regTy);
+          unpackUniqueTensorElements(loc, adaptor.getSrc(), rewriter);
       Value ptr = b.inttoptr(base.getType(), allocAddress);
       lowerTMemLdStFromTypes(loc, rewriter, regTy, memTy, ptr, maxnreg,
                              b.i1_val(true), llvmElemTy, srcValues);
@@ -684,7 +670,23 @@ static LogicalResult copySharedToTmem(ConversionPatternRewriter &rewriter,
   auto cvt = tmemLl.invertAndCompose(shmemLl);
 
   auto bitwidth = srcTy.getElementType().getIntOrFloatBitWidth();
-  auto atom = getTMemCopyAtom(cvt, bitwidth);
+  uint32_t holeMask = 0;
+  // Zero col bases are physical holes. Compact them for the SMEM descriptor,
+  // then skip the corresponding physical TMEM ranges when issuing copies.
+  if (isa<TensorMemoryEncodingAttr>(dstTy.getEncoding())) {
+    for (auto [i, basis] : llvm::enumerate(tmemLl.getBases().lookup(kCol))) {
+      if (llvm::all_of(basis, [](int32_t component) { return component == 0; }))
+        holeMask |= uint32_t{1} << i;
+    }
+  }
+  auto compact = holeMask ? cvt.removeZeroBasesAlongDim(kCol) : cvt;
+  unsigned contiguousCols = holeMask
+                                ? uint32_t{1} << llvm::countr_zero(holeMask)
+                                : compact.getInDimSize(kCol);
+  auto atom = getTMemCopyAtom(
+      compact.resizeInDim(
+          kCol, std::min<unsigned>(contiguousCols, compact.getInDimSize(kCol))),
+      bitwidth);
   // Get shmem ptr
   Type elemTy = typeConverter->convertType(srcTy.getElementType());
   auto smemObj =
@@ -695,10 +697,11 @@ static LogicalResult copySharedToTmem(ConversionPatternRewriter &rewriter,
   // once we have access to the lbo/sbo
   const SmallVector<unsigned> instrShape = {32, atom.bCol / bitwidth};
   auto kWarp = str_attr("warp");
-  auto cvtWarp = cvt.reshapeIns({{kRow, 32},
-                                 {kWarp, 4},
-                                 {kCol, cvt.getInDimSize(kCol)},
-                                 {kBlock, cvt.getInDimSize(kBlock)}})
+  auto cvtWarp = compact
+                     .reshapeIns({{kRow, 32},
+                                  {kWarp, 4},
+                                  {kCol, compact.getInDimSize(kCol)},
+                                  {kBlock, compact.getInDimSize(kBlock)}})
                      .sublayout({kRow, kCol}, to_vector(cvt.getOutDimNames()));
 
   auto loader = DotOpMmaSmemLoader::build(loc, rewriter, cvtWarp, bitwidth,
@@ -723,11 +726,15 @@ static LogicalResult copySharedToTmem(ConversionPatternRewriter &rewriter,
            strideRow * (64 / 8));
   }
 
+  int logicalCol = 0;
   for (int col = 0; col < cvt.getInDimSize(kCol); col += instrShape[1]) {
-    auto desc = loader->smemLoad(0, col, rewriter, loc);
+    if (col & holeMask)
+      continue;
+    auto desc = loader->smemLoad(0, logicalCol, rewriter, loc);
     auto tmemAddr =
         b.add(b.ptrtoint(i32_ty, baseDst), b.i32_val(col * bitwidth / 32));
     createTcgen05Cp(rewriter, loc, tmemAddr, desc, pred, atom, twoCTAs);
+    logicalCol += instrShape[1];
   }
   return success();
 }
@@ -821,8 +828,8 @@ struct TMEMSubSliceOpConversion
                   ConversionPatternRewriter &rewriter) const override {
     Location loc = op->getLoc();
     auto b = TritonLLVMOpBuilder(loc, rewriter);
-    auto dstTy = cast<MemDescType>(op.getResult().getType());
-    uint32_t offset = getTMemSubSliceOffset(dstTy, op.getOffset());
+    auto srcTy = cast<MemDescType>(op.getSrc().getType());
+    uint32_t offset = getTMemSubSliceOffset(srcTy, op.getOffset(), op.getDim());
 
     Value tmemBase = adaptor.getSrc();
     Value offsetVal = b.i32_val(offset);

--- a/third_party/nvidia/lib/TritonNVIDIAGPUToLLVM/TensorMemoryToLLVM.cpp
+++ b/third_party/nvidia/lib/TritonNVIDIAGPUToLLVM/TensorMemoryToLLVM.cpp
@@ -822,7 +822,7 @@ struct TMEMSubSliceOpConversion
     Location loc = op->getLoc();
     auto b = TritonLLVMOpBuilder(loc, rewriter);
     auto dstTy = cast<MemDescType>(op.getResult().getType());
-    uint32_t offset = getTMemSubSliceOffset(dstTy, op.getN());
+    uint32_t offset = getTMemSubSliceOffset(dstTy, op.getOffset());
 
     Value tmemBase = adaptor.getSrc();
     Value offsetVal = b.i32_val(offset);

--- a/unittest/Dialect/TritonGPU/LinearLayoutConversionsTest.cpp
+++ b/unittest/Dialect/TritonGPU/LinearLayoutConversionsTest.cpp
@@ -3340,6 +3340,64 @@ TEST_F(LinearLayoutConversionsTest, TensorMemory_blockM_128) {
                 LinearLayout::identity1D(2, kCol, d1));
 }
 
+TEST_F(LinearLayoutConversionsTest, TensorMemory_subview) {
+  auto d0 = S("dim0");
+  auto d1 = S("dim1");
+  auto kRow = S("row");
+  auto kCol = S("col");
+  auto kBlock = S("block");
+  auto tmemSpace = TensorMemorySpaceAttr::get(&ctx);
+  auto f32 = Float32Type::get(&ctx);
+  auto f16 = Float16Type::get(&ctx);
+  auto i8 = IntegerType::get(&ctx, 8);
+
+  auto interleaved = MemDescType::get({64, 2}, f32, tmem(64, 2), tmemSpace,
+                                      /*mutableMemory=*/true, {64, 128});
+  LinearLayout expectedInterleaved(
+      {{kRow, {{1, 0}, {2, 0}, {4, 0}, {8, 0}, {0, 0}, {16, 0}, {32, 0}}},
+       {kCol, {{0, 1}}},
+       {kBlock, {}}},
+      {d0, d1});
+  EXPECT_EQ(toLinearLayout(interleaved), expectedInterleaved);
+
+  auto withHole = MemDescType::get({128, 256}, f32, tmem(128, 64), tmemSpace,
+                                   /*mutableMemory=*/true, {256, 256});
+  LinearLayout expectedWithHole(
+      {{kRow, {{1, 0}, {2, 0}, {4, 0}, {8, 0}, {16, 0}, {32, 0}, {64, 0}}},
+       {kCol,
+        {{0, 1},
+         {0, 2},
+         {0, 4},
+         {0, 8},
+         {0, 16},
+         {0, 32},
+         {0, 0},
+         {0, 64},
+         {0, 128}}},
+       {kBlock, {}}},
+      {d0, d1});
+  EXPECT_EQ(toLinearLayout(withHole), expectedWithHole);
+
+  auto stridedEnc = TensorMemoryEncodingAttr::get(
+      &ctx, 128, 1, 2, CGAEncodingAttr::get1CTALayout(&ctx, 2));
+  auto stridedSubview = MemDescType::get({128, 1}, f16, stridedEnc, tmemSpace,
+                                         /*mutableMemory=*/true, {256, 1});
+  LinearLayout expectedStrided = LinearLayout::identity1D(128, kRow, d0) *
+                                 LinearLayout::zeros1D(2, kCol, d1) *
+                                 LinearLayout::identity1D(1, kBlock, d0);
+  EXPECT_EQ(toLinearLayout(stridedSubview), expectedStrided);
+
+  auto fp4Enc = TensorMemoryEncodingAttr::get(
+      &ctx, 128, 1, 1, CGAEncodingAttr::get1CTALayout(&ctx, 2),
+      /*twoCTAs=*/false, /*fp4Padded=*/true);
+  auto fp4Subview = MemDescType::get({128, 1}, i8, fp4Enc, tmemSpace,
+                                     /*mutableMemory=*/true, {256, 1});
+  LinearLayout expectedFp4 = LinearLayout::identity1D(128, kRow, d0) *
+                             LinearLayout::zeros1D(4, kCol, d1) *
+                             LinearLayout::identity1D(1, kBlock, d0);
+  EXPECT_EQ(toLinearLayout(fp4Subview), expectedFp4);
+}
+
 TEST_F(LinearLayoutConversionsTest, TensorMemory_fp4Padded) {
   auto enc = TensorMemoryEncodingAttr::get(
       &ctx, 128, 64, 1, CGAEncodingAttr::get1CTALayout(&ctx, 2),


### PR DESCRIPTION
We also allow to having non-contiguous slices.

The semantics here are:
- it zeros out the relevant bases that you slice
- it trims columns that are zero
- In the limit, it leaves enough zeros as to have at least one 32b column

We also revamp how TMEM subslices are handled and improve their support
all across. In particular, we have `toLinearLayout` already return the
sliced layout (which we can do here and not in SMEM because TMEM does not
have swizzling).



We also fix a few lowerings here and there on some edge cases.

GPT added a ton of tests, most of the LOCs are tests...