### PR TITLE
Fix CLC scheduler slot reuse in multi-CTA Gluon matmuls

### DIFF
--- a/python/examples/gluon/03-matmul-multicta.py
+++ b/python/examples/gluon/03-matmul-multicta.py
@@ -339,8 +339,12 @@ def matmul_clc_partition(p):
     ACC_STAGES: gl.constexpr = p.clc_barriers.shape[0]
     i = 0
     while has_work:
-        # Reuse the slot only after all consumer partitions signaled consumed.
+        # Reuse the CTA-local planar slot only after its consumer partitions
+        # have finished reading it. Then rendezvous the CLC partitions across
+        # the cluster before reusing the multicast CLC result slot.
         mbarrier.wait(p.clc_consumed_bars.index(consumed_state.index), consumed_state.phase, pred=(i >= ACC_STAGES))
+        if gl.num_ctas() > 1:
+            gl.barrier(cluster=True)
         barrier = p.clc_barriers.index(state.index)
         result = p.clc_result_buffers.index(state.index)
         # 16: clc.try_cancel has a `.b128` modifier
@@ -512,7 +516,7 @@ def _matmul_kernel(
 
     clc_barriers = mbarrier.allocate_mbarrier(batch=ACC_STAGES)
     clc_planar_ready_bars = mbarrier.allocate_mbarrier(batch=ACC_STAGES)
-    clc_consumed_bars = mbarrier.allocate_mbarrier(batch=ACC_STAGES, two_ctas=TWO_CTAS)
+    clc_consumed_bars = mbarrier.allocate_mbarrier(batch=ACC_STAGES)
     for i in gl.static_range(ACC_STAGES):
         mbarrier.init(clc_barriers.index(i), count=1)
         mbarrier.init(clc_planar_ready_bars.index(i), count=1)

--- a/python/examples/gluon/04-2cta-block-scale-matmul.py
+++ b/python/examples/gluon/04-2cta-block-scale-matmul.py
@@ -639,8 +639,12 @@ def mma_scaled_clc_partition(p):
     ACC_STAGES: gl.constexpr = p.clc_barriers.shape[0]
     i = 0
     while has_work:
-        # Reuse the slot only after all consumer partitions signaled consumed.
+        # Reuse the CTA-local planar slot only after its consumer partitions
+        # have finished reading it. Then rendezvous the CLC partitions across
+        # the cluster before reusing the multicast CLC result slot.
         mbarrier.wait(p.clc_consumed_bars.index(consumed_state.index), consumed_state.phase, pred=(i >= ACC_STAGES))
+        if gl.num_ctas() > 1:
+            gl.barrier(cluster=True)
         barrier = p.clc_barriers.index(state.index)
         result = p.clc_result_buffers.index(state.index)
         # 16: clc.try_cancel has a `.b128` modifier
@@ -712,7 +716,7 @@ def mma_scaled_warp_specialized_kernel(a_desc, b_desc, c_desc, a_scale_desc, b_s
 
     clc_barriers = mbarrier.allocate_mbarrier(batch=num_acc_buffers)
     clc_planar_ready_bars = mbarrier.allocate_mbarrier(batch=num_acc_buffers)
-    clc_consumed_bars = mbarrier.allocate_mbarrier(batch=num_acc_buffers, two_ctas=TWO_CTAS)
+    clc_consumed_bars = mbarrier.allocate_mbarrier(batch=num_acc_buffers)
     if scheduler == SCHEDULER_CLC:
         for i in gl.static_range(num_acc_buffers):
             mbarrier.init(clc_barriers.index(i), count=1)

--- a/python/test/gluon/test_consan.py
+++ b/python/test/gluon/test_consan.py
@@ -477,6 +477,123 @@ def test_clc_result_reuse_after_cluster_barrier(device, run_wrapper, monkeypatch
     kernel[(1, )](output, num_warps=4, num_ctas=2)
 
 
+@pytest.mark.skipif(not is_cuda() or torch.cuda.get_device_capability()[0] < 10, reason="Requires blackwell")
+@pytest.mark.parametrize("num_ctas", [2, 4], ids=lambda n: f"{n}ctas")
+@pytest.mark.parametrize("TWO_CTAS", [True, False], ids=["paired-barrier", "cta-local-barrier"])
+def test_planar_slot_reuse_requires_cta_local_barrier(TWO_CTAS, num_ctas, device, run_wrapper, monkeypatch):
+    if run_wrapper:
+        result = run_in_process(test_planar_slot_reuse_requires_cta_local_barrier,
+                                (TWO_CTAS, num_ctas, device, False, monkeypatch))
+        if TWO_CTAS:
+            assert_expected_cuda_failure(result.exc)
+            assert "Buffer being accessed has outstanding" in result.driver_stderr_output
+        else:
+            assert result.exc is None
+            assert result.driver_stderr_output == ""
+        return
+
+    monkeypatch.setenv("TRITON_INSTRUMENTATION_MODE", "consan")
+    monkeypatch.setenv("CUDA_LAUNCH_BLOCKING", "1")
+    knobs.refresh_knobs()
+
+    @gluon.jit
+    def consumer(slot, ready, consumed, cga_layout: ttgl.constexpr):
+        layout: ttgl.constexpr = ttgl.BlockedLayout([1], [32], [ttgl.num_warps()], [0], cga_layout=cga_layout)
+        mbarrier.wait(ready, phase=0)
+        value = slot.load(layout).reshape([])
+        mbarrier.arrive(consumed, pred=(value != 0))
+
+    @gluon.jit
+    def initializer(slot, ready, cga_layout: ttgl.constexpr):
+        layout: ttgl.constexpr = ttgl.BlockedLayout([1], [32], [ttgl.num_warps()], [0], cga_layout=cga_layout)
+        slot.store(ttgl.full([1], 1, ttgl.int64, layout))
+        mbarrier.arrive(ready)
+
+    @gluon.jit
+    def reuser(slot, consumed, cga_layout: ttgl.constexpr):
+        layout: ttgl.constexpr = ttgl.BlockedLayout([1], [32], [ttgl.num_warps()], [0], cga_layout=cga_layout)
+        mbarrier.wait(consumed, phase=0)
+        slot.store(ttgl.full([1], 2, ttgl.int64, layout))
+
+    @gluon.jit
+    def kernel(TWO_CTAS: ttgl.constexpr):
+        cga_layout: ttgl.constexpr = multicast_cga_layout(ttgl.num_ctas(), 1)
+        shared_layout: ttgl.constexpr = ttgl.SwizzledSharedLayout(1, 1, 1, order=[0], cga_layout=cga_layout)
+        slot = ttgl.allocate_shared_memory(ttgl.int64, [1], shared_layout)
+        ready = mbarrier.allocate_mbarrier()
+        consumed = mbarrier.allocate_mbarrier(two_ctas=TWO_CTAS)
+        mbarrier.init(ready, count=1)
+        mbarrier.init(consumed, count=1)
+
+        ttgl.warp_specialize([
+            (consumer, (slot, ready, consumed, cga_layout)),
+            (initializer, (slot, ready, cga_layout)),
+            (reuser, (slot, consumed, cga_layout)),
+        ], [1, 1], [24, 24])
+
+    kernel[(1, )](TWO_CTAS, num_warps=4, num_ctas=num_ctas)
+
+
+@pytest.mark.skipif(not is_cuda() or torch.cuda.get_device_capability()[0] < 10, reason="Requires blackwell")
+@pytest.mark.parametrize("num_ctas", [2, 4], ids=lambda n: f"{n}ctas")
+@pytest.mark.parametrize("SYNC", [False, True], ids=["missing-cluster-barrier", "cluster-barrier"])
+def test_clc_result_reuse_in_warp_specialize(SYNC, num_ctas, device, run_wrapper, monkeypatch):
+    if run_wrapper:
+        result = run_in_process(test_clc_result_reuse_in_warp_specialize, (SYNC, num_ctas, device, False, monkeypatch))
+        if SYNC:
+            assert result.exc is None
+            assert result.driver_stderr_output == ""
+        else:
+            assert_expected_cuda_failure(result.exc)
+            assert "Buffer being accessed has outstanding" in result.driver_stderr_output
+        return
+
+    monkeypatch.setenv("TRITON_INSTRUMENTATION_MODE", "consan")
+    monkeypatch.setenv("CUDA_LAUNCH_BLOCKING", "1")
+    knobs.refresh_knobs()
+
+    @gluon.jit
+    def idle_partition():
+        pass
+
+    @gluon.jit
+    def clc_partition(out, result, bar, SYNC: ttgl.constexpr):
+        mbarrier.expect(bar, 16)
+        clc.try_cancel(result, bar)
+        mbarrier.wait(bar, 0)
+        first = clc.load_result(result)
+
+        if SYNC:
+            ttgl.barrier(cluster=True)
+
+        # Keep proxy ordering explicit so this test isolates whether the
+        # partition-scoped cluster rendezvous publishes every CTA's read.
+        hopper.fence_async_shared(cluster=True)
+
+        mbarrier.expect(bar, 16)
+        clc.try_cancel(result, bar)
+        mbarrier.wait(bar, 1)
+        second = clc.load_result(result)
+
+        ttgl.atomic_or(out, (first.is_canceled() | second.is_canceled()).to(ttgl.int32))
+
+    @gluon.jit
+    def kernel(out, SYNC: ttgl.constexpr):
+        cga_layout: ttgl.constexpr = multicast_cga_layout(ttgl.num_ctas(), 1)
+        layout: ttgl.constexpr = ttgl.SwizzledSharedLayout(1, 1, 1, order=[0], cga_layout=cga_layout)
+        result = ttgl.allocate_shared_memory(ttgl.int64, [2], layout)
+        bar = mbarrier.allocate_mbarrier()
+        mbarrier.init(bar, count=1)
+
+        ttgl.warp_specialize([
+            (idle_partition, ()),
+            (clc_partition, (out, result, bar, SYNC)),
+        ], [1], [24])
+
+    output = torch.zeros((1, ), device=device, dtype=torch.int32)
+    kernel[(1, )](output, SYNC=SYNC, num_warps=4, num_ctas=num_ctas)
+
+
 @pytest.mark.skipif(not is_cuda() or torch.cuda.get_device_capability()[0] < 9, reason="Requires hopper or newer")
 def test_async_tma_multicast_kernel_reuse(device, run_wrapper, monkeypatch, num_ctas):
     if num_ctas == 1:

--- a/python/tutorials/gluon/14-multicta.py
+++ b/python/tutorials/gluon/14-multicta.py
@@ -303,13 +303,16 @@ if __name__ == "__main__" and is_hopper_or_newer():
 # both to barriers that are themselves cross-CTA and to per-CTA barriers consumed
 # by multicast or 2CTA ops. The compiler inserts the required
 # `fence.mbarrier_init.release.cluster` plus a relaxed cluster barrier after the
-# top-level init sequence and before the first use. Since cluster barriers must
-# execute outside `warp_specialize`, initialize these barriers in the top-level
-# part of the kernel before entering warp specialization.
+# top-level init sequence and before the first use. Keep these initializations
+# in the top-level part of the kernel so that synchronization completes before
+# any warp-specialized partition can use the barriers.
 #
 # Final note on synchronization.
-# cluster.arrive / cluster.wait (i.e., CGA barriers, the cluster equivalent of bar.sync for CTAs) must be
-# executed by all threads in the kernel. As a result, they cannot be used inside a warp_specialize block.
+# A complete `gl.barrier(cluster=True)` can be used inside a warp-specialized
+# partition. The compiler lowers it to a partition-scoped cluster mbarrier, so
+# the corresponding partition in every CTA participates. Split cluster.arrive
+# / cluster.wait operations must still be executed by all threads in the kernel
+# and cannot be used inside a warp_specialize block.
 #
 # Moreover, operations such as convert_layout, reduce, sum, max, etc., emit CGA barriers when they cross CTAs.
 # Therefore, these operations are also not allowed inside a warp_specialize block whenever they may span multiple
@@ -843,7 +846,12 @@ def matmul_clc_partition(p):
     acc_stages: gl.constexpr = p.clc_barriers.shape[0]
     i = 0
     while has_work:
+        # Reuse the CTA-local planar slot only after its consumer partitions
+        # have finished reading it. Then rendezvous the CLC partitions across
+        # the cluster before reusing the multicast CLC result slot.
         mbarrier.wait(p.clc_consumed_bars.index(consumed_state.index), consumed_state.phase, pred=(i >= acc_stages))
+        if gl.num_ctas() > 1:
+            gl.barrier(cluster=True)
         barrier = p.clc_barriers.index(state.index)
         result = p.clc_result_buffers.index(state.index)
         mbarrier.expect(barrier, 16)
@@ -1019,7 +1027,7 @@ def matmul_multicta_kernel(
 
     clc_barriers = mbarrier.allocate_mbarrier(batch=ACC_STAGES)
     clc_planar_ready_bars = mbarrier.allocate_mbarrier(batch=ACC_STAGES)
-    clc_consumed_bars = mbarrier.allocate_mbarrier(batch=ACC_STAGES, two_ctas=two_ctas)
+    clc_consumed_bars = mbarrier.allocate_mbarrier(batch=ACC_STAGES)
     for i in gl.static_range(ACC_STAGES):
         mbarrier.init(clc_barriers.index(i), count=1)
         mbarrier.init(clc_planar_ready_bars.index(i), count=1)


### PR DESCRIPTION
## Summary

- use CTA-local consumed barriers so every CLC partition waits for its CTA's planar-slot readers before reusing the slot
- rendezvous corresponding CLC partitions across the cluster before the next multicast CLC request; proxy-fence insertion then emits the cluster-scoped async-proxy fence
- apply the protocol to both CLC matmul examples and the multi-CTA tutorial, and clarify warp-specialized cluster-barrier support
- add ConSan regressions for both planar-slot and CLC-result reuse with 2-CTA and 4-CTA clusters

## Why

The scheduler reuses two shared-memory resources with different lifetimes. The planar PID slot is CTA-local, while the CLC result is written to every CTA through cluster multicast. A paired consumed barrier cannot protect both: inside warp specialization only the leader CTA waits on that barrier, so a follower CTA can overwrite its local planar slot while consumer partitions still read it.

A CTA-local consumed barrier protects each planar slot independently. After those local drains, a partition-scoped cluster rendezvous ensures every CTA has consumed its multicast result before the next `clc.try_cancel` reuses the result slot.

## Validation

- `pytest -s --tb=short python/test/gluon/test_consan.py -k 'test_planar_slot_reuse_requires_cta_local_barrier or test_clc_result_reuse_in_warp_specialize'` on `codex-gb200-f33`: 8 passed, 421 deselected
- reduced `03-matmul-multicta.py` correctness runs at M=N=4096, K=512 with 2 and 4 CTAs: passed
- generated PTX checked for CTA-local wait, cluster release/acquire rendezvous, `fence.proxy.async.shared::cluster`, then multicast CLC request
- repository pre-commit hooks: passed