### PR TITLE
Scope ConSan cluster visibility to warp partitions

### DIFF
--- a/include/triton/Dialect/TritonInstrument/IR/FunctionBuilder.h
+++ b/include/triton/Dialect/TritonInstrument/IR/FunctionBuilder.h
@@ -104,6 +104,8 @@ public:
   // reported.
   void createClusterBarrierRendezvousCall(ImplicitLocOpBuilder &b,
                                           int barrierIdx, int thread,
+                                          uint64_t threadPeersMask,
+                                          bool partitionScoped,
                                           bool publishVisibility,
                                           Operation *insertPoint);
   // checkAllActiveWaiting: return whether unfinished threads across the
@@ -235,10 +237,13 @@ public:
   void createCopyReadVisibilityCall(ImplicitLocOpBuilder &b, int sourceThread,
                                     uint64_t destMask, Value pred,
                                     MemType memType, Operation *insertPoint);
-  // publishClusterVisibility: after a non-relaxed cluster barrier, make
-  // synchronous facts visible to every CTA in the cluster.
+  // publishClusterVisibility: after a non-relaxed cluster barrier, make the
+  // participating threads' synchronous facts visible across the cluster. A
+  // top-level barrier includes every thread; a warp-specialized barrier is
+  // scoped to its partition and peer thread classes.
   void createPublishClusterVisibilityCall(ImplicitLocOpBuilder &b, Value pred,
-                                          MemType memType,
+                                          int thread, uint64_t threadPeersMask,
+                                          bool partitionScoped, MemType memType,
                                           Operation *insertPoint);
   // setProxyAccess: record a generic-proxy access by the current base thread
   // and invalidate prior proxy-fence coverage for that source thread.
@@ -278,9 +283,11 @@ public:
                                    uint64_t destMask, Value pred,
                                    Operation *insertPoint);
   // publishClusterProxyAccesses: publish packed generic access and fence facts
-  // to every base thread after a non-relaxed cluster barrier.
+  // across the cluster. A warp-specialized barrier only updates the
+  // participating base-thread column.
   void createPublishClusterProxyAccessesCall(ImplicitLocOpBuilder &b,
-                                             Value pred,
+                                             Value pred, int thread,
+                                             bool partitionScoped,
                                              Operation *insertPoint);
   // stageAccessForCommit: mark the buffer as staged (value -1) in the
   // outstanding commit table for this thread.

--- a/include/triton/Dialect/TritonInstrument/IR/TritonInstrument.md
+++ b/include/triton/Dialect/TritonInstrument/IR/TritonInstrument.md
@@ -156,8 +156,10 @@ places that ordinary read visibility is transported:
   base thread's row. A fence before the wait cannot cover accesses learned only
   by that wait; a fence after the wait can.
 - Barrier invalidation clears the barrier's proxy tracking row.
-- A non-relaxed publishing cluster barrier publishes the proxy frontier across
-  CTA and base-thread rows.
+- A non-relaxed publishing cluster barrier transports the proxy frontier across
+  CTAs. At top level it publishes to every base-thread row; inside warp
+  specialization it publishes only from and to the participating partition's
+  base-thread row.
 - Warp specialization copies the parent's proxy frontier into the new
   partition base-thread rows.
 
@@ -248,11 +250,16 @@ TMA-style and CLC cross-CTA writes become visible in the CTA rows reached by the
 memory effect. Read transfers update the current CTA row.
 
 A non-relaxed cluster barrier is different from an mbarrier wait: its virtual
-rendezvous publishes synchronous work from base threads to all CTA rows at the
-phase-completing arrival. This includes both ordinary read/write visibility and
-the generic-access/proxy-fence frontier. Publishing while the rendezvous lock is
-held makes the shadow state visible before any participant can continue, so no
-second cluster barrier is needed for the ConSan protocol.
+rendezvous publishes synchronous work across CTA rows at the phase-completing
+arrival. A top-level barrier represents all synchronous threads. A barrier
+inside warp specialization represents only the corresponding partition in each
+CTA, so it publishes frontiers visible to that base thread and merges them only
+into the same partition's peer thread classes. It does not make work observed
+only by another partition visible; that still requires an explicit handoff such
+as an mbarrier arrive/wait. Publication includes both ordinary read/write
+visibility and the generic-access/proxy-fence frontier. Publishing while the
+rendezvous lock is held makes the shadow state visible before any participant
+can continue, so no second cluster barrier is needed for the ConSan protocol.
 
 ## Barrier Lifecycle and Deadlock Checks
 

--- a/lib/Dialect/TritonInstrument/IR/FunctionBuilder.cpp
+++ b/lib/Dialect/TritonInstrument/IR/FunctionBuilder.cpp
@@ -871,7 +871,8 @@ Value FunctionBuilder::createCheckAllActiveWaitingCall(ImplicitLocOpBuilder &b,
 }
 
 void FunctionBuilder::createClusterBarrierRendezvousCall(
-    ImplicitLocOpBuilder &b, int barrierIdx, int thread, bool publishVisibility,
+    ImplicitLocOpBuilder &b, int barrierIdx, int thread,
+    uint64_t threadPeersMask, bool partitionScoped, bool publishVisibility,
     Operation *insertPoint) {
   assert(!auxData.waiting.empty() && !auxData.barrierStates.empty() &&
          !auxData.activeMasks.empty() &&
@@ -923,8 +924,10 @@ void FunctionBuilder::createClusterBarrierRendezvousCall(
       arriveVirtualBarrier(b, statesPtr, statesType, barrierIdxVal, numCTAs);
   if (publishVisibility) {
     for (MemType memType : {MemType::SHARED_MEM, MemType::TENSOR_MEM})
-      createPublishClusterVisibilityCall(b, completed, memType, insertPoint);
-    createPublishClusterProxyAccessesCall(b, completed, insertPoint);
+      createPublishClusterVisibilityCall(b, completed, thread, threadPeersMask,
+                                         partitionScoped, memType, insertPoint);
+    createPublishClusterProxyAccessesCall(b, completed, thread, partitionScoped,
+                                          insertPoint);
   }
   Value ok = createCheckAllActiveWaitingCall(b, vTrue, insertPoint);
   tti::ExperimentalLockReleaseOp::create(b, lock, vTrue);
@@ -2727,8 +2730,8 @@ void FunctionBuilder::createCopyReadVisibilityCall(ImplicitLocOpBuilder &b,
 }
 
 void FunctionBuilder::createPublishClusterVisibilityCall(
-    ImplicitLocOpBuilder &b, Value pred, MemType memType,
-    Operation *insertPoint) {
+    ImplicitLocOpBuilder &b, Value pred, int thread, uint64_t threadPeersMask,
+    bool partitionScoped, MemType memType, Operation *insertPoint) {
   if (auxData.writeVisibility[(int)memType].empty() ||
       auxData.readVisibility[(int)memType].empty()) {
     return;
@@ -2739,17 +2742,24 @@ void FunctionBuilder::createPublishClusterVisibilityCall(
   auto readVis = auxData.readVisibility[(int)memType].at(insertPoint);
   auto writeVisibilityType = cast<RankedTensorType>(writeVis.type);
   auto readVisibilityType = cast<RankedTensorType>(readVis.type);
-  SmallVector<Value> args = {pred, writeVis.value, readVis.value};
+  Value threadVal = arith::ConstantIntOp::create(b, thread, 32);
+  Value threadPeersMaskVal =
+      arith::ConstantIntOp::create(b, threadPeersMask, 64);
+  SmallVector<Value> args = {pred, threadVal, threadPeersMaskVal,
+                             writeVis.value, readVis.value};
   createCallToCachedFunction(
       b, "publish_cluster_visibility", args,
       /*assertInfo=*/std::nullopt,
-      {writeVisibilityType, readVisibilityType, (uint64_t)memType},
+      {writeVisibilityType, readVisibilityType, (uint64_t)memType,
+       (uint64_t)partitionScoped},
       [writeVisibilityType, readVisibilityType,
-       numBaseThreads = auxData.threadLayout.numBaseThreads](
-          ImplicitLocOpBuilder &fb, Block *entryBlock) {
+       numBaseThreads = auxData.threadLayout.numBaseThreads,
+       partitionScoped](ImplicitLocOpBuilder &fb, Block *entryBlock) {
         Value pred = entryBlock->getArgument(0);
-        Value writeVisibilityPtr = entryBlock->getArgument(1);
-        Value readVisibilityPtr = entryBlock->getArgument(2);
+        Value threadVal = entryBlock->getArgument(1);
+        Value threadPeersMaskVal = entryBlock->getArgument(2);
+        Value writeVisibilityPtr = entryBlock->getArgument(3);
+        Value readVisibilityPtr = entryBlock->getArgument(4);
 
         auto [prevBlock, ifBlock, thenBlock] = createIfBlock(fb, pred);
         fb.setInsertionPointToStart(ifBlock);
@@ -2759,19 +2769,41 @@ void FunctionBuilder::createPublishClusterVisibilityCall(
         Value readVisibility = tti::createLoadScratchMemory(
             fb, fb.getLoc(), readVisibilityPtr, readVisibilityType);
 
-        // Cluster barriers publish generic-proxy synchronous work. Base-thread
-        // visibility distinguishes those facts from async-only TMA/TC/CLC
-        // effects, which are published by their own completion path.
-        uint64_t baseThreadMask = (1ULL << numBaseThreads) - 1;
-        Value baseMask = tti::createConstIntTensor(
-            fb, fb.getLoc(), baseThreadMask, writeVisibilityType);
         Value zeroWrites =
             tti::createConstIntTensor(fb, fb.getLoc(), 0, writeVisibilityType);
-        Value hasBaseWrite = arith::CmpIOp::create(
-            fb, arith::CmpIPredicate::ne,
-            arith::AndIOp::create(fb, writeVisibility, baseMask), zeroWrites);
-        Value syncWrites = arith::SelectOp::create(fb, hasBaseWrite,
-                                                   writeVisibility, zeroWrites);
+        Value syncWrites;
+        if (partitionScoped) {
+          auto elemType =
+              cast<IntegerType>(writeVisibilityType.getElementType());
+          Value threadI64 =
+              arith::ExtUIOp::create(fb, fb.getI64Type(), threadVal);
+          Value threadBitScalar = arith::ShLIOp::create(
+              fb, arith::ConstantIntOp::create(fb, 1, 64), threadI64);
+          Value threadBit = triton::SplatOp::create(
+              fb, writeVisibilityType,
+              adjustIntegerWidth(fb, threadBitScalar, elemType));
+          Value peersMask = triton::SplatOp::create(
+              fb, writeVisibilityType,
+              adjustIntegerWidth(fb, threadPeersMaskVal, elemType));
+          Value hasThreadWrite = arith::CmpIOp::create(
+              fb, arith::CmpIPredicate::ne,
+              arith::AndIOp::create(fb, writeVisibility, threadBit),
+              zeroWrites);
+          syncWrites = arith::SelectOp::create(fb, hasThreadWrite, peersMask,
+                                               zeroWrites);
+        } else {
+          // Top-level cluster barriers represent all synchronous threads. A
+          // base-thread bit distinguishes synchronous work from async-only
+          // TMA/TC/CLC effects, which use their own completion path.
+          uint64_t baseThreadMask = (1ULL << numBaseThreads) - 1;
+          Value baseMask = tti::createConstIntTensor(
+              fb, fb.getLoc(), baseThreadMask, writeVisibilityType);
+          Value hasBaseWrite = arith::CmpIOp::create(
+              fb, arith::CmpIPredicate::ne,
+              arith::AndIOp::create(fb, writeVisibility, baseMask), zeroWrites);
+          syncWrites = arith::SelectOp::create(fb, hasBaseWrite,
+                                               writeVisibility, zeroWrites);
+        }
         Value writesForCluster = reduce<arith::OrIOp>(fb, syncWrites, {2});
         writesForCluster = convertAndBroadcast(fb, writesForCluster, {0, 1},
                                                writeVisibilityType);
@@ -2781,18 +2813,35 @@ void FunctionBuilder::createPublishClusterVisibilityCall(
                                       newWriteVisibility, writeVisibilityType,
                                       /*currentCTAOnly=*/false);
 
-        Value readBaseMask = tti::createConstIntTensor(
-            fb, fb.getLoc(), baseThreadMask, readVisibilityType);
         Value zeroReads =
             tti::createConstIntTensor(fb, fb.getLoc(), 0, readVisibilityType);
-        Value hasBaseRead = arith::CmpIOp::create(
-            fb, arith::CmpIPredicate::ne,
-            arith::AndIOp::create(fb, readVisibility, readBaseMask), zeroReads);
-        Value syncReads =
-            arith::SelectOp::create(fb, hasBaseRead, readVisibility, zeroReads);
-        Value readsForCluster = reduce<arith::OrIOp>(fb, syncReads, {2, 3, 4});
-        readsForCluster = convertAndBroadcast(fb, readsForCluster, {0, 1},
-                                              readVisibilityType);
+        Value readsForCluster;
+        if (partitionScoped) {
+          Value sourceColumn = arith::SelectOp::create(
+              fb, createDimMask(fb, threadVal, readVisibilityType, /*dim=*/3),
+              readVisibility, zeroReads);
+          Value readsForThread =
+              reduce<arith::OrIOp>(fb, sourceColumn, {2, 3, 4});
+          readsForThread = convertAndBroadcast(fb, readsForThread, {0, 1},
+                                               readVisibilityType);
+          Value peerColumns = createThreadColumnMask(
+              fb, threadPeersMaskVal, readVisibilityType, /*columnDim=*/3);
+          readsForCluster = arith::SelectOp::create(fb, peerColumns,
+                                                    readsForThread, zeroReads);
+        } else {
+          uint64_t baseThreadMask = (1ULL << numBaseThreads) - 1;
+          Value readBaseMask = tti::createConstIntTensor(
+              fb, fb.getLoc(), baseThreadMask, readVisibilityType);
+          Value hasBaseRead = arith::CmpIOp::create(
+              fb, arith::CmpIPredicate::ne,
+              arith::AndIOp::create(fb, readVisibility, readBaseMask),
+              zeroReads);
+          Value syncReads = arith::SelectOp::create(fb, hasBaseRead,
+                                                    readVisibility, zeroReads);
+          readsForCluster = reduce<arith::OrIOp>(fb, syncReads, {2, 3, 4});
+          readsForCluster = convertAndBroadcast(fb, readsForCluster, {0, 1},
+                                                readVisibilityType);
+        }
         Value newReadVisibility =
             arith::OrIOp::create(fb, readVisibility, readsForCluster);
         tti::createStoreScratchMemory(fb, fb.getLoc(), readVisibilityPtr,
@@ -3339,27 +3388,45 @@ void FunctionBuilder::createCopyProxyAccessesCall(ImplicitLocOpBuilder &b,
 }
 
 void FunctionBuilder::createPublishClusterProxyAccessesCall(
-    ImplicitLocOpBuilder &b, Value pred, Operation *insertPoint) {
+    ImplicitLocOpBuilder &b, Value pred, int thread, bool partitionScoped,
+    Operation *insertPoint) {
   if (auxData.proxyAccessVisibility.empty())
     return;
   if (!pred)
     pred = arith::ConstantIntOp::create(b, 1, 1);
   ValueType visibility = auxData.proxyAccessVisibility.at(insertPoint);
   auto visibilityType = cast<RankedTensorType>(visibility.type);
-  SmallVector<Value> args = {pred, visibility.value};
+  SmallVector<Value> args = {pred, arith::ConstantIntOp::create(b, thread, 32),
+                             visibility.value};
   createCallToCachedFunction(
       b, "publish_cluster_proxy_accesses", args,
-      /*assertInfo=*/std::nullopt, {visibilityType},
-      [visibilityType](ImplicitLocOpBuilder &fb, Block *entryBlock) {
+      /*assertInfo=*/std::nullopt, {visibilityType, (uint64_t)partitionScoped},
+      [visibilityType, partitionScoped](ImplicitLocOpBuilder &fb,
+                                        Block *entryBlock) {
         Value pred = entryBlock->getArgument(0);
-        Value visibilityPtr = entryBlock->getArgument(1);
+        Value threadVal = entryBlock->getArgument(1);
+        Value visibilityPtr = entryBlock->getArgument(2);
 
         auto [prevBlock, ifBlock, thenBlock] = createIfBlock(fb, pred);
         fb.setInsertionPointToStart(ifBlock);
         Value visibility = tti::createLoadScratchMemory(
             fb, fb.getLoc(), visibilityPtr, visibilityType);
-        Value frontier = reduce<arith::OrIOp>(fb, visibility, {2, 3});
+        Value source = visibility;
+        Value zero =
+            tti::createConstIntTensor(fb, fb.getLoc(), 0, visibilityType);
+        if (partitionScoped) {
+          Value sourceColumn =
+              createDimMask(fb, threadVal, visibilityType, /*dim=*/3);
+          source = arith::SelectOp::create(fb, sourceColumn, visibility, zero);
+        }
+        Value frontier = reduce<arith::OrIOp>(fb, source, {2, 3});
         frontier = convertAndBroadcast(fb, frontier, {0, 1, 4}, visibilityType);
+        if (partitionScoped) {
+          Value destinationColumn =
+              createDimMask(fb, threadVal, visibilityType, /*dim=*/3);
+          frontier =
+              arith::SelectOp::create(fb, destinationColumn, frontier, zero);
+        }
         Value updated = arith::OrIOp::create(fb, visibility, frontier);
         tti::createStoreScratchMemory(fb, fb.getLoc(), visibilityPtr, updated,
                                       visibilityType,

--- a/lib/Dialect/TritonInstrument/Transforms/ConcurrencySanitizer.cpp
+++ b/lib/Dialect/TritonInstrument/Transforms/ConcurrencySanitizer.cpp
@@ -79,13 +79,12 @@ bool isTensorCoreOp(Operation *op) {
 }
 
 std::optional<int> maybeGetPartitionIdx(Operation *op) {
-  if (auto wsOp = op->getParentOfType<ttg::WarpSpecializePartitionsOp>()) {
+  Operation *parent = op->getParentOp();
+  if (!parent)
+    return std::nullopt;
+  if (isa<ttg::WarpSpecializePartitionsOp>(parent))
     return op->getParentRegion()->getRegionNumber();
-  }
-  if (Operation *parent = op->getParentOp()) {
-    return maybeGetPartitionIdx(parent);
-  }
-  return std::nullopt;
+  return maybeGetPartitionIdx(parent);
 }
 
 int getCurrentThread(Operation *op, const ConSanTargetHooks *hooks,
@@ -792,10 +791,13 @@ private:
       Operation *op = clusterBarrier.getOperation();
       int thread = getCurrentThread(op, hooks, auxData.threadLayout);
       int baseThread = getBaseThread(thread, auxData.threadLayout);
+      bool partitionScoped =
+          static_cast<bool>(op->getParentOfType<ttg::WarpSpecializeOp>());
       b.setLoc(op->getLoc());
       b.setInsertionPoint(op);
       funcBuilder.createClusterBarrierRendezvousCall(
           b, auxData.getClusterBarrierSlot(op), baseThread,
+          getThreadPeersMask(baseThread, auxData.threadLayout), partitionScoped,
           /*publishVisibility=*/!clusterBarrier.getRelaxed(), op);
     }
   }

--- a/python/test/gluon/test_consan.py
+++ b/python/test/gluon/test_consan.py
@@ -1835,12 +1835,16 @@ def test_ws_store_wait_load(FAILURE, device, run_wrapper, monkeypatch, num_ctas)
 
 
 @pytest.mark.skipif(not is_cuda() or torch.cuda.get_device_capability()[0] < 9, reason="Requires hopper")
-@pytest.mark.parametrize("FENCE_LOCATION", ["none", "producer_after_arrive", "producer", "consumer"])
+@pytest.mark.parametrize(
+    "FENCE_LOCATION",
+    ["none", "producer_after_arrive", "producer_after_arrive_cluster_barrier", "producer", "consumer"])
 def test_fence_async_shared_across_warp_specialize(FENCE_LOCATION, device, run_wrapper, monkeypatch, num_ctas):
+    if FENCE_LOCATION == "producer_after_arrive_cluster_barrier" and num_ctas == 1:
+        pytest.skip("Need multiple CTAs for a cluster barrier")
     if run_wrapper:
         result = run_in_process(test_fence_async_shared_across_warp_specialize,
                                 (FENCE_LOCATION, device, False, monkeypatch, num_ctas))
-        if FENCE_LOCATION in ("none", "producer_after_arrive"):
+        if FENCE_LOCATION in ("none", "producer_after_arrive", "producer_after_arrive_cluster_barrier"):
             assert_expected_cuda_failure(result.exc)
             assert "Async shared-memory access is missing fence_async_shared" in result.driver_stderr_output
         else:
@@ -1853,7 +1857,8 @@ def test_fence_async_shared_across_warp_specialize(FENCE_LOCATION, device, run_w
     knobs.refresh_knobs()
 
     @gluon.jit
-    def producer(smem: ttgl.constexpr, bar: ttgl.constexpr, FENCE_LOCATION: ttgl.constexpr, layout: ttgl.constexpr):
+    def producer(smem: ttgl.constexpr, bar: ttgl.constexpr, ready, FENCE_LOCATION: ttgl.constexpr,
+                 layout: ttgl.constexpr):
         block_m: ttgl.constexpr = XBLOCK * ttgl.num_ctas()
         smem.store(ttgl.full([block_m, XBLOCK], 42.0, ttgl.float16, layout))
         if FENCE_LOCATION == "producer":
@@ -1861,17 +1866,30 @@ def test_fence_async_shared_across_warp_specialize(FENCE_LOCATION, device, run_w
         mbarrier.arrive(bar, count=1)
         if FENCE_LOCATION == "producer_after_arrive":
             hopper.fence_async_shared()
+        if FENCE_LOCATION == "producer_after_arrive_cluster_barrier":
+            hopper.fence_async_shared()
+            # Order every producer fence before publishing a control-only
+            # global signal. The relaxed barrier does not publish ConSan state.
+            hopper.cluster.barrier(relaxed=True)
+            row_layout: ttgl.constexpr = ttgl.SliceLayout(1, layout)
+            rows = ttgl.arange(0, block_m, row_layout)
+            ttgl.store(ready + rows, 1, mask=rows == 0, cache_modifier=".wt")
 
     @gluon.jit
-    def consumer(output_desc, smem: ttgl.constexpr, bar: ttgl.constexpr, FENCE_LOCATION: ttgl.constexpr):
+    def consumer(output_desc, smem: ttgl.constexpr, bar: ttgl.constexpr, ready, FENCE_LOCATION: ttgl.constexpr):
         mbarrier.wait(bar, phase=0)
+        if FENCE_LOCATION == "producer_after_arrive_cluster_barrier":
+            flag = ttgl.load(ready, volatile=True)
+            while flag == 0:
+                flag = ttgl.load(ready, volatile=True)
+            ttgl.barrier(cluster=True)
         if FENCE_LOCATION == "consumer":
             hopper.fence_async_shared()
         tma.async_copy_shared_to_global(output_desc, [0, 0], smem)
         tma.store_wait(0)
 
     @gluon.jit
-    def kernel(output_desc, FENCE_LOCATION: ttgl.constexpr):
+    def kernel(output_desc, ready, FENCE_LOCATION: ttgl.constexpr):
         block_m: ttgl.constexpr = XBLOCK * ttgl.num_ctas()
         cga_layout: ttgl.constexpr = default_cga_layout(ttgl.num_ctas(), 2)
         smem_layout: ttgl.constexpr = ttgl.NVMMASharedLayout(swizzle_byte_width=128, element_bitwidth=16, rank=2,
@@ -1882,8 +1900,8 @@ def test_fence_async_shared_across_warp_specialize(FENCE_LOCATION, device, run_w
         bar = mbarrier.allocate_mbarrier()
         mbarrier.init(bar, count=1)
         ttgl.warp_specialize([
-            (producer, (smem, bar, FENCE_LOCATION, blocked_layout)),
-            (consumer, (output_desc, smem, bar, FENCE_LOCATION)),
+            (producer, (smem, bar, ready, FENCE_LOCATION, blocked_layout)),
+            (consumer, (output_desc, smem, bar, ready, FENCE_LOCATION)),
         ], [4], [32])
 
     block_m = XBLOCK.value * num_ctas
@@ -1891,7 +1909,8 @@ def test_fence_async_shared_across_warp_specialize(FENCE_LOCATION, device, run_w
     shared_layout = ttgl.NVMMASharedLayout(swizzle_byte_width=128, element_bitwidth=16, rank=2,
                                            cga_layout=default_cga_layout(num_ctas, 2))
     output_desc = gluon.nvidia.hopper.TensorDescriptor.from_tensor(output, [block_m, XBLOCK.value], shared_layout)
-    kernel[(1, )](output_desc, FENCE_LOCATION=FENCE_LOCATION, num_warps=4, num_ctas=num_ctas)
+    ready = torch.zeros((1, ), device=device, dtype=torch.int32)
+    kernel[(1, )](output_desc, ready, FENCE_LOCATION=FENCE_LOCATION, num_warps=4, num_ctas=num_ctas)
     torch.testing.assert_close(output, torch.full_like(output, 42.0))
 
 
@@ -1947,6 +1966,70 @@ def test_ws_load_wait_store(FAILURE, device, run_wrapper, monkeypatch, num_ctas)
 
     output = torch.empty((XBLOCK.value * num_ctas, ), device=device, dtype=torch.float16)
     ws_kernel[(1, )](output, FAILURE=FAILURE, num_warps=4, num_ctas=num_ctas)
+
+
+@pytest.mark.skipif(not is_cuda() or torch.cuda.get_device_capability()[0] < 9, reason="Requires hopper")
+@pytest.mark.parametrize("SYNCHRONIZED", [False, True], ids=["missing-local-handoff", "local-handoff"])
+def test_ws_cluster_barrier_does_not_replace_local_handoff(SYNCHRONIZED, device, run_wrapper, monkeypatch, num_ctas):
+    if num_ctas == 1:
+        pytest.skip("Need multiple CTAs for a cluster barrier")
+    if run_wrapper:
+        result = run_in_process(test_ws_cluster_barrier_does_not_replace_local_handoff,
+                                (SYNCHRONIZED, device, False, monkeypatch, num_ctas))
+        if SYNCHRONIZED:
+            assert result.exc is None
+            assert result.driver_stderr_output == ""
+        else:
+            assert_expected_cuda_failure(result.exc)
+            assert "Buffer being accessed has outstanding reads" in result.driver_stderr_output
+        return
+    monkeypatch.setenv("TRITON_INSTRUMENTATION_MODE", "consan")
+    monkeypatch.setenv("CUDA_LAUNCH_BLOCKING", "1")
+    knobs.refresh_knobs()
+
+    @gluon.jit
+    def consumer(smem, consumed, ready, output, layout: ttgl.constexpr):
+        block_x: ttgl.constexpr = XBLOCK * ttgl.num_ctas()
+        offsets = ttgl.arange(0, block_x, layout)
+        val = smem.load(layout)
+        ttgl.store(output + offsets, val)
+        # Order every consumer load before publishing a control-only global
+        # signal. The relaxed barrier does not publish ConSan state.
+        hopper.cluster.barrier(relaxed=True)
+        ttgl.store(ready + offsets, 1, mask=offsets == 0, cache_modifier=".wt")
+        mbarrier.arrive(consumed, count=1)
+
+    @gluon.jit
+    def producer(smem, consumed, ready, SYNCHRONIZED: ttgl.constexpr, layout: ttgl.constexpr):
+        block_x: ttgl.constexpr = XBLOCK * ttgl.num_ctas()
+        flag = ttgl.load(ready, volatile=True)
+        while flag == 0:
+            flag = ttgl.load(ready, volatile=True)
+        if SYNCHRONIZED:
+            mbarrier.wait(consumed, phase=0, deps=[smem])
+        ttgl.barrier(cluster=True)
+        smem.store(ttgl.full([block_x], 2, ttgl.float32, layout))
+
+    @gluon.jit
+    def kernel(output, ready, SYNCHRONIZED: ttgl.constexpr):
+        block_x: ttgl.constexpr = XBLOCK * ttgl.num_ctas()
+        cga_layout: ttgl.constexpr = default_cga_layout(ttgl.num_ctas(), 1)
+        smem_layout: ttgl.constexpr = ttgl.SwizzledSharedLayout(vec=1, per_phase=1, max_phase=1, order=[0],
+                                                                cga_layout=cga_layout)
+        blocked_layout: ttgl.constexpr = ttgl.BlockedLayout(size_per_thread=[1], threads_per_warp=[32],
+                                                            warps_per_cta=[4], order=[0], cga_layout=cga_layout)
+        smem = ttgl.allocate_shared_memory(ttgl.float32, [block_x], smem_layout)
+        consumed = mbarrier.allocate_mbarrier()
+        mbarrier.init(consumed, count=1)
+        smem.store(ttgl.full([block_x], 1, ttgl.float32, blocked_layout))
+        ttgl.warp_specialize([
+            (consumer, (smem, consumed, ready, output, blocked_layout)),
+            (producer, (smem, consumed, ready, SYNCHRONIZED, blocked_layout)),
+        ], [4], [32])
+
+    output = torch.empty((XBLOCK.value * num_ctas, ), device=device, dtype=torch.float32)
+    ready = torch.zeros((1, ), device=device, dtype=torch.int32)
+    kernel[(1, )](output, ready, SYNCHRONIZED=SYNCHRONIZED, num_warps=4, num_ctas=num_ctas)
 
 
 @pytest.mark.skipif(not is_cuda() or torch.cuda.get_device_capability()[0] < 9, reason="Requires hopper")

--- a/test/TritonGPU/consan.mlir
+++ b/test/TritonGPU/consan.mlir
@@ -67,6 +67,48 @@ module attributes {"ttg.num-ctas" = 2 : i32, "ttg.num-warps" = 1 : i32, ttg.shar
 
 // -----
 
+#shared_cluster_ws = #ttg.swizzled_shared<{vec = 1, perPhase = 1, maxPhase = 1, order = [1, 0], CGALayout = [[1, 0]]}>
+#smem_cluster_ws = #ttg.shared_memory
+#blocked_cluster_ws = #ttg.blocked<{sizePerThread = [1, 32], threadsPerWarp = [32, 1], warpsPerCTA = [4, 1], order = [0, 1], CGALayout = [[1, 0]]}>
+module attributes {"ttg.num-ctas" = 2 : i32, "ttg.num-warps" = 4 : i32, ttg.shared = 4104 : i32, ttg.target = "cuda:90", ttg.tensor_memory_size = 0 : i32, "ttg.threads-per-warp" = 32 : i32, "ttg.total-num-warps" = 6 : i32} {
+  // CHECK-LABEL: @cluster_barrier_partition_scopes
+  tt.func public @cluster_barrier_partition_scopes() {
+    %buf = ttg.local_alloc {allocation.offset = 0 : i32} : () -> !ttg.memdesc<32x32xf32, #shared_cluster_ws, #smem_cluster_ws, mutable>
+    %value = ttg.local_load %buf : !ttg.memdesc<32x32xf32, #shared_cluster_ws, #smem_cluster_ws, mutable> -> tensor<32x32xf32, #blocked_cluster_ws>
+
+    // A top-level barrier keeps the all-partition publisher.
+    // CHECK: tt.call @__triton_consan_publish_cluster_visibility{{.*}}_I0
+    ttng.cluster_barrier
+
+    ttg.warp_specialize(%buf) attributes {actualRegisters = array<i32: 32, 32, 32>, allocation.offset = 4096 : i32, requestedRegisters = array<i32: 32, 32>, warpGroupStartIds = array<i32: 4, 5>}
+    default {
+      // The default region is thread 0, but its cluster barrier is still
+      // partition-scoped.
+      // CHECK: default
+      // CHECK: tt.call @__triton_consan_publish_cluster_visibility{{.*}}_I1({{.*}}, %c0_i32_{{[0-9]+}}, %c1_i64_{{[0-9]+}},
+      ttng.cluster_barrier
+      ttg.warp_yield
+    }
+    partition0(%arg0: !ttg.memdesc<32x32xf32, #shared_cluster_ws, #smem_cluster_ws, mutable>) num_warps(1) {
+      ttg.warp_return
+    }
+    partition1(%arg1: !ttg.memdesc<32x32xf32, #shared_cluster_ws, #smem_cluster_ws, mutable>) num_warps(1) {
+      // Nested operations must retain partition1's thread identity.
+      // CHECK: partition1
+      // CHECK: scf.execute_region
+      // CHECK: tt.call @__triton_consan_publish_cluster_visibility{{.*}}_I1({{.*}}, %c2_i32_{{[0-9]+}}, %c4_i64_{{[0-9]+}},
+      scf.execute_region {
+        ttng.cluster_barrier
+        scf.yield
+      }
+      ttg.warp_return
+    } : (!ttg.memdesc<32x32xf32, #shared_cluster_ws, #smem_cluster_ws, mutable>) -> ()
+    tt.return
+  }
+}
+
+// -----
+
 #proxy_shared = #ttg.nvmma_shared<{swizzlingByteWidth = 128, transposed = false, elementBitWidth = 32}>
 #proxy_bar_shared = #ttg.swizzled_shared<{vec = 1, perPhase = 1, maxPhase = 1, order = [0]}>
 #proxy_smem = #ttg.shared_memory


### PR DESCRIPTION
## Summary

- scope ConSan cluster-barrier visibility publication to the participating warp-specialized partition while preserving top-level barrier behavior
- publish shared/tensor read-write and async-proxy frontiers only to the participant's peer classes
- preserve nested worker-partition identity and document the synchronization model
- add lit and GPU regressions for shared-read and proxy-fence overpublication

## Why

Hardware cluster barriers inside warp specialization synchronize the matching partition across CTAs, not every logical partition in the kernel. ConSan's virtual rendezvous already modeled those participants for deadlock detection, but its visibility publisher reduced and broadcast every partition column. That could make a worker barrier appear to import another partition's reads or proxy-fence state, hiding missing local handoffs.

## Testing

- `make` (with workspace ccache)
- `lit -v TritonGPU/consan.mlir TritonGPU/consan-capture-reservation.mlir Conversion/tritoninstrument_to_llvm.mlir TritonGPU/amd/amd-consan.mlir` (4 passed)
- GB208 new/extended GPU matrix (18 passed, 3 skipped)
- GB208 adjacent ConSan/CLC/deadlock set (17 passed, 4 skipped)
- GB208 repeated missing-handoff negatives across 2- and 4-CTA configurations (10 passed)
- red/green check: broad publication loses all four expected assertions; partition-scoped publication restores them (4 passed)
