### PR TITLE
Avoid output TMA for Blackwell matmul accumulation

### DIFF
--- a/python/triton_kernels/triton_kernels/matmul.py
+++ b/python/triton_kernels/triton_kernels/matmul.py
@@ -539,7 +539,14 @@ def matmul(a, b, bias,
     c_has_tma = (
         opt_flags.is_persistent and (scatter_indx is None or has_scatter_tma)
         and is_tma_compliant(c)
-        and (c_acc_in is None or c_acc_is_c)
+        and (
+            # On Blackwell, c_acc_in makes the persistent kernel issue one
+            # output descriptor load per epilogue subtile before the descriptor
+            # store. For large dW accumulation this serializes the epilogue; the
+            # pointer load/store path is faster while retaining TMA for A/B.
+            c_acc_in is None
+            or (c_acc_is_c and not target_info.cuda_capability_geq(10, 0))
+        )
         and fused_comm is None
         and (
             precision_config.c_value_pack_factor == 1


### PR DESCRIPTION
When c_acc_in is present, the persistent Blackwell matmul path reloads the accumulator through the output TMA descriptor once per epilogue subtile. For large dW accumulation this adds serialized TMA loads and barrier waits, making fused accumulation ~50% slower for some shapes.

This PR fixes it by using the existing pointer output path for c_acc_in while keeping TMA for A/B and the persistent MMA path.