### PR TITLE
Catch LLVM diagnostic and raise Python exception

### DIFF
--- a/python/src/llvm.cc
+++ b/python/src/llvm.cc
@@ -9,6 +9,8 @@
 #include "llvm/CodeGen/MachineModuleInfo.h"
 #include "llvm/CodeGen/MachineRegisterInfo.h"
 #include "llvm/IR/DebugInfo.h"
+#include "llvm/IR/DiagnosticInfo.h"
+#include "llvm/IR/DiagnosticPrinter.h"
 #include "llvm/IR/LLVMContext.h"
 #include "llvm/IR/LegacyPassManager.h"
 #include "llvm/IR/Module.h"
@@ -59,6 +61,20 @@ struct BreakStructPhiNodesPass : PassInfoMixin<BreakStructPhiNodesPass> {
 using namespace llvm;
 
 namespace {
+
+class TritonLLVMDiagnosticHandler : public llvm::DiagnosticHandler {
+public:
+  bool handleDiagnostics(const llvm::DiagnosticInfo &diagnostic) override {
+    if (diagnostic.getSeverity() != llvm::DS_Error)
+      return false;
+    llvm::raw_string_ostream stream(message);
+    llvm::DiagnosticPrinterRawOStream printer(stream);
+    diagnostic.print(printer);
+    return true;
+  }
+
+  std::string message;
+};
 
 // Set an LLVM command-line option using addOccurrence (simulates command-line)
 // and return its original value. Using addOccurrence instead of setValue is
@@ -338,6 +354,9 @@ std::string translateLLVMIRToASM(
     const std::string &features, const std::vector<std::string> &flags,
     bool enable_fp_fusion, bool isObject, bool canonicalizeGEP) {
   using namespace mlir;
+  auto diagnosticHandler = std::make_unique<TritonLLVMDiagnosticHandler>();
+  auto *diagnosticHandlerPtr = diagnosticHandler.get();
+  module.getContext().setDiagnosticHandler(std::move(diagnosticHandler));
 
   // Apply flags
   for (const std::string &flag : flags) {
@@ -413,6 +432,8 @@ std::string translateLLVMIRToASM(
                              : llvm::CodeGenFileType::AssemblyFile;
     machine->addPassesToEmitFile(pass, pstream, nullptr, fileType);
     pass.run(module);
+    if (diagnosticHandlerPtr->HasErrors)
+      throw std::runtime_error(diagnosticHandlerPtr->message);
 
     if (enabledTiming) {
       reportAndResetTimings(&reportStream);

--- a/python/src/llvm.cc
+++ b/python/src/llvm.cc
@@ -62,18 +62,42 @@ using namespace llvm;
 
 namespace {
 
-class TritonLLVMDiagnosticHandler : public llvm::DiagnosticHandler {
-public:
-  bool handleDiagnostics(const llvm::DiagnosticInfo &diagnostic) override {
-    if (diagnostic.getSeverity() != llvm::DS_Error)
-      return false;
-    llvm::raw_string_ostream stream(message);
+class TritonLLVMDiagnosticCapture {
+  llvm::LLVMContext &context;
+  llvm::DiagnosticHandler::DiagnosticHandlerTy previousCallback;
+  void *previousContext;
+  std::string message;
+
+  static void handleDiagnostic(const llvm::DiagnosticInfo *diagnostic,
+                               void *context) {
+    auto *capture = static_cast<TritonLLVMDiagnosticCapture *>(context);
+    llvm::raw_string_ostream stream(capture->message);
+    stream << llvm::LLVMContext::getDiagnosticMessagePrefix(
+                  diagnostic->getSeverity())
+           << ": ";
     llvm::DiagnosticPrinterRawOStream printer(stream);
-    diagnostic.print(printer);
-    return true;
+    diagnostic->print(printer);
+    stream << '\n';
   }
 
-  std::string message;
+public:
+  explicit TritonLLVMDiagnosticCapture(llvm::LLVMContext &context)
+      : context(context),
+        previousCallback(context.getDiagnosticHandlerCallBack()),
+        previousContext(context.getDiagnosticContext()) {
+    context.setDiagnosticHandlerCallBack(handleDiagnostic, this);
+  }
+
+  ~TritonLLVMDiagnosticCapture() {
+    context.setDiagnosticHandlerCallBack(previousCallback, previousContext);
+  }
+
+  TritonLLVMDiagnosticCapture(const TritonLLVMDiagnosticCapture &) = delete;
+  TritonLLVMDiagnosticCapture &
+  operator=(const TritonLLVMDiagnosticCapture &) = delete;
+
+  bool hasErrors() const { return context.getDiagHandlerPtr()->HasErrors; }
+  const std::string &getMessage() const { return message; }
 };
 
 // Set an LLVM command-line option using addOccurrence (simulates command-line)
@@ -354,9 +378,6 @@ std::string translateLLVMIRToASM(
     const std::string &features, const std::vector<std::string> &flags,
     bool enable_fp_fusion, bool isObject, bool canonicalizeGEP) {
   using namespace mlir;
-  auto diagnosticHandler = std::make_unique<TritonLLVMDiagnosticHandler>();
-  auto *diagnosticHandlerPtr = diagnosticHandler.get();
-  module.getContext().setDiagnosticHandler(std::move(diagnosticHandler));
 
   // Apply flags
   for (const std::string &flag : flags) {
@@ -431,9 +452,11 @@ std::string translateLLVMIRToASM(
     auto fileType = isObject ? llvm::CodeGenFileType::ObjectFile
                              : llvm::CodeGenFileType::AssemblyFile;
     machine->addPassesToEmitFile(pass, pstream, nullptr, fileType);
+    TritonLLVMDiagnosticCapture diagnostics(module.getContext());
     pass.run(module);
-    if (diagnosticHandlerPtr->HasErrors)
-      throw std::runtime_error(diagnosticHandlerPtr->message);
+    if (diagnostics.hasErrors())
+      throw std::runtime_error(diagnostics.getMessage());
+    llvm::errs() << diagnostics.getMessage();
 
     if (enabledTiming) {
       reportAndResetTimings(&reportStream);

--- a/python/test/unit/language/test_compile_only.py
+++ b/python/test/unit/language/test_compile_only.py
@@ -1,8 +1,43 @@
+import re
+
+import pytest
+
 import triton
 import triton.language as tl
 from triton.backends.compiler import GPUTarget
-import re
 from triton.compiler import ASTSource
+
+
+def test_llvm_codegen_errors_are_catchable_for_invalid_inline_asm() -> None:
+
+    @triton.jit
+    def kernel(x_ptr, out_ptr, n: tl.constexpr, BLOCK: tl.constexpr):
+        offsets = tl.arange(0, BLOCK)
+        values = tl.load(x_ptr + offsets, mask=offsets < n, other=0.0)
+        packed = tl.inline_asm_elementwise(
+            asm="""
+            {
+                .reg .b16 result;
+                mov.u16 result, 0;
+                mov.u16 $0, result;
+            }
+            """,
+            constraints="=h,f",
+            args=[values],
+            dtype=tl.uint16,
+            is_pure=True,
+            pack=1,
+        )
+        tl.store(out_ptr + offsets, packed.to(tl.uint8), mask=offsets < n)
+
+    src = ASTSource(
+        fn=kernel,
+        signature={"x_ptr": "*fp32", "out_ptr": "*u8", "n": "constexpr", "BLOCK": "constexpr"},
+        constexprs={"n": 128, "BLOCK": 128},
+    )
+
+    with pytest.raises(RuntimeError, match="could not allocate output register for constraint 'h'"):
+        triton.compile(src, target=GPUTarget("hip", "gfx1200", 32))
 
 
 def test_compile_only_sm100() -> None:


### PR DESCRIPTION
This issue is reported in https://github.com/triton-lang/triton-windows/issues/45 and I think it's worth porting to the upstream Triton.

In `translateLLVMIRToASM`, if LLVM emits a diagnostic with severity error, we should catch it and throw a C++ runtime error, then it will be catched in Python subprocess and raised as an exception that downstream Python code can handle.

Notably, Triton 3.7.x pins LLVM `1f126a6dea50d185c0781743a667390037ae88bd`, which calls `exit(1)` if the diagnostic is unhandled. This explains the behavior reproduced in https://github.com/triton-lang/triton-windows/issues/45 . Now LLVM has removed the `exit(1)`, see https://github.com/llvm/llvm-project/pull/194858 , but I think we should still fail early in `translateLLVMIRToASM`.

<!---
The core Triton is a small number of people, and we receive many PRs (thank
you!).  To help us review your code more quickly, **if you are a new
contributor (less than 3 PRs merged) we ask that you complete the following
tasks and include the filled-out checklist in your PR description.**

Complete the following tasks before sending your PR, and replace `[ ]` with
`[x]` to indicate you have done them.
-->

# New contributor declaration
- [x] I am not making a trivial change, such as fixing a typo in a comment.

- [x] I have written a PR description following these
  [rules](https://cbea.ms/git-commit/#why-not-how).

- [x] I have run `pre-commit run --from-ref origin/main --to-ref HEAD`.

- Select one of the following.
  - [x] I have added tests.
    - `/test` for `lit` tests
    - `/unittest` for C++ tests
    - `/python/test` for end-to-end tests
  - [ ] This PR does not need a test because `FILL THIS IN`.

- Select one of the following.
  - [x] I have not added any `lit` tests.
  - [ ] The `lit` tests I have added follow these [best practices](https://mlir.llvm.org/getting_started/TestingGuide/#filecheck-best-practices),
    including the "tests should be minimal" section. (Usually running Python code
    and using the instructions it generates is not minimal.)
