### PR TITLE
[CONSAN] Track compiler-owned shared scratch

### DIFF
--- a/include/triton/Analysis/Allocation.h
+++ b/include/triton/Analysis/Allocation.h
@@ -150,6 +150,11 @@ public:
     return bufferSet.at(bufferId).kind == BufferT::BufferKind::Virtual;
   }
 
+  /// Returns if the given buffer is compiler-owned operation scratch.
+  bool isScratchBuffer(BufferId bufferId) const {
+    return bufferSet.at(bufferId).kind == BufferT::BufferKind::Scratch;
+  }
+
   /// Returns if the given buffer is an explicit buffer.
   bool isExplicitBuffer(BufferId bufferId) const {
     return bufferSet.at(bufferId).kind == BufferT::BufferKind::Explicit;
@@ -164,9 +169,9 @@ public:
 private:
   /// A class that represents a shared memory buffer
   struct BufferT {
-    /// Explicit: ttg.local_alloc
-    /// Scratch: ttg.convert_layout
-    /// Virtual: triton.call
+    /// Explicit: SSA-visible shared-memory allocations such as ttg.local_alloc.
+    /// Scratch: compiler-owned shared memory used by an operation or function.
+    /// Virtual: a caller's view of a callee's shared-memory frame.
     enum class BufferKind { Explicit, Scratch, Virtual };
 
     BufferKind kind;

--- a/include/triton/Analysis/Utility.h
+++ b/include/triton/Analysis/Utility.h
@@ -276,9 +276,13 @@ bool cvtNeedsWarpShuffle(RankedTensorType srcTy, RankedTensorType dstTy);
 // memory. This is a feasibility predicate, not that policy decision.
 bool cvtCanUseWarpShuffle(RankedTensorType srcTy, RankedTensorType dstTy);
 
+// Whether the enclosing function requires layout conversions to use warp
+// shuffles. ConvertLayoutOp is expected to be nested in a function.
+bool cvtIsWarpShuffleForced(triton::gpu::ConvertLayoutOp cvt);
+
 // The enclosing function requests warp shuffles and the conversion topology
-// permits them. Unlike cvtAlwaysUseWarpShuffle, this predicate is safe to call
-// before shared-memory allocation has attached fallback metadata.
+// permits them. This predicate does not diagnose an infeasible request and is
+// therefore safe to call from shared-memory allocation analysis.
 bool cvtUsesForcedWarpShuffle(triton::gpu::ConvertLayoutOp cvt);
 
 // Conversion from `srcTy` to `dstTy` involves data exchange across threads,

--- a/include/triton/Analysis/Utility.h
+++ b/include/triton/Analysis/Utility.h
@@ -272,8 +272,14 @@ bool cvtReordersRegisters(RankedTensorType srcTy, RankedTensorType dstTy);
 bool cvtNeedsWarpShuffle(RankedTensorType srcTy, RankedTensorType dstTy);
 
 // The conversion does not move values across warps or CTAs, so a lowering may
-// choose warp shuffles even when the ordinary cost model prefers shared memory.
+// choose warp shuffles even when the ordinary cost policy prefers shared
+// memory. This is a feasibility predicate, not that policy decision.
 bool cvtCanUseWarpShuffle(RankedTensorType srcTy, RankedTensorType dstTy);
+
+// The enclosing function requests warp shuffles and the conversion topology
+// permits them. Unlike cvtAlwaysUseWarpShuffle, this predicate is safe to call
+// before shared-memory allocation has attached fallback metadata.
+bool cvtUsesForcedWarpShuffle(triton::gpu::ConvertLayoutOp cvt);
 
 // Conversion from `srcTy` to `dstTy` involves data exchange across threads,
 // warps, and possibly blocks.

--- a/include/triton/Analysis/Utility.h
+++ b/include/triton/Analysis/Utility.h
@@ -271,6 +271,10 @@ bool cvtReordersRegisters(RankedTensorType srcTy, RankedTensorType dstTy);
 // within a warp.  No data exchange across warps or blocks is needed.
 bool cvtNeedsWarpShuffle(RankedTensorType srcTy, RankedTensorType dstTy);
 
+// The conversion does not move values across warps or CTAs, so a lowering may
+// choose warp shuffles even when the ordinary cost model prefers shared memory.
+bool cvtCanUseWarpShuffle(RankedTensorType srcTy, RankedTensorType dstTy);
+
 // Conversion from `srcTy` to `dstTy` involves data exchange across threads,
 // warps, and possibly blocks.
 bool cvtNeedsSharedMemory(RankedTensorType srcTy, RankedTensorType dstTy);

--- a/include/triton/Conversion/TritonGPUToLLVM/Utility.h
+++ b/include/triton/Conversion/TritonGPUToLLVM/Utility.h
@@ -345,8 +345,10 @@ LLVM::LLVMFuncOp appendOrGetExternFuncOp(RewriterBase &rewriter, Operation *op,
 // Multiply a square layout with 1 input and output dimension with a vector
 Value matrixVectorProd(TritonLLVMOpBuilder &b, const LinearLayout &A, Value x);
 
-// Whether the convert layout should be forced to use warp shuffles.
-bool cvtAlwaysUseWarpShuffle(triton::gpu::ConvertLayoutOp cvt);
+// Whether the convert layout should be forced to use warp shuffles. Returns
+// failure if forcing shuffles was requested for a conversion that cannot be
+// implemented within one warp.
+FailureOr<bool> cvtAlwaysUseWarpShuffle(triton::gpu::ConvertLayoutOp cvt);
 
 // Return a predicate that is true only if the current thread holds unique data,
 // according to freeVarsMask. The predicate may be null to indicate no

--- a/include/triton/Dialect/TritonInstrument/IR/ConSanConstants.h
+++ b/include/triton/Dialect/TritonInstrument/IR/ConSanConstants.h
@@ -3,10 +3,17 @@
 
 #include "llvm/ADT/StringRef.h"
 
+#include <cstdint>
+
 namespace mlir::triton::instrument {
 
 inline constexpr llvm::StringLiteral kConSanExtraCaptureBytesAttr =
     "consan.extra_capture_bytes";
+
+// Shared-memory addresses are represented by their 24-bit object-relative
+// address throughout the instrumentation dialect. Keep static allocator
+// regions within the same representable range used by memdesc materialization.
+inline constexpr uint32_t kSharedMemoryObjectMask = (1u << 24) - 1;
 
 } // namespace mlir::triton::instrument
 

--- a/include/triton/Dialect/TritonInstrument/IR/FunctionBuilder.h
+++ b/include/triton/Dialect/TritonInstrument/IR/FunctionBuilder.h
@@ -3,6 +3,7 @@
 
 #include "triton/Dialect/TritonInstrument/IR/Utility.h"
 
+#include <optional>
 #include <string>
 #include <variant>
 
@@ -271,6 +272,14 @@ public:
   void createTrackProxyAccessesCall(ImplicitLocOpBuilder &b, Value mbar,
                                     int thread, Value pred,
                                     Operation *insertPoint, Value barrierCTAs);
+  // trackProxyAccessesForBuffer: snapshot the current base thread's packed
+  // generic access/fence frontier for shared-memory regions fully contained
+  // in buffer. This is used by async-proxy writes that complete a barrier:
+  // waiting on that barrier orders only the bytes written by the operation.
+  void createTrackProxyAccessesForBufferCall(
+      ImplicitLocOpBuilder &b, Value mbar, MaterializedBufferRegion buffer,
+      int thread, Value pred, Operation *insertPoint, Value barrierCTAs,
+      Value effectCTAs);
   // transferProxyAccesses: merge a barrier's packed proxy frontier into the
   // waiting base thread.
   void createTransferProxyAccessesCall(ImplicitLocOpBuilder &b, Value mbar,
@@ -343,6 +352,11 @@ public:
       bool excludeSelf = false);
 
 private:
+  void createTrackProxyAccessesCallImpl(
+      ImplicitLocOpBuilder &b, Value mbar, int thread, Value pred,
+      Operation *insertPoint, Value barrierCTAs,
+      std::optional<MaterializedBufferRegion> buffer, Value effectCTAs);
+
   ModuleOp module;
   AuxDataMap &auxData;
 };

--- a/include/triton/Dialect/TritonInstrument/IR/FunctionBuilder.h
+++ b/include/triton/Dialect/TritonInstrument/IR/FunctionBuilder.h
@@ -74,6 +74,16 @@ private:
   SmallVector<Arg> args;
 };
 
+/// A byte-addressed memory region materialized in the address representation
+/// used by ConSan's buffer descriptors. The base may come from either an SSA
+/// memdesc or a compiler-owned static shared-memory allocation.
+struct MaterializedBufferRegion {
+  // Masked runtime address in the memory object's address space. For shared
+  // memory this includes the function's shared-memory base pointer.
+  Value baseAddress;
+  uint32_t length;
+};
+
 class FunctionBuilder {
 public:
   FunctionBuilder(ModuleOp module, AuxDataMap &auxData)
@@ -148,31 +158,34 @@ public:
   // as visible to the threads set in threadMask. Clears out any other threads
   // from the visibility bitmask. We know this is safe because there cannot be
   // outstanding writes to this buffer at this point.
-  void createSetWriteVisibilityCall(ImplicitLocOpBuilder &b, Value buf,
-                                    uint32_t length, uint64_t threadMask,
-                                    Value pred, MemType memType,
-                                    Operation *insertPoint, Value effectCTAs);
+  void createSetWriteVisibilityCall(ImplicitLocOpBuilder &b,
+                                    MaterializedBufferRegion buffer,
+                                    uint64_t threadMask, Value pred,
+                                    MemType memType, Operation *insertPoint,
+                                    Value effectCTAs);
   // setReadVisibility: add the threads set in threadMask to the buffer's read
   // visibility bitmask.
-  void createSetReadVisibilityCall(ImplicitLocOpBuilder &b, Value buf,
-                                   uint32_t length, uint64_t threadMask,
-                                   Value pred, MemType memType,
-                                   Operation *insertPoint, Value effectCTAs);
+  void createSetReadVisibilityCall(ImplicitLocOpBuilder &b,
+                                   MaterializedBufferRegion buffer,
+                                   uint64_t threadMask, Value pred,
+                                   MemType memType, Operation *insertPoint,
+                                   Value effectCTAs);
   // clearWriteTracking: clear all the information about threads writing to a
   // buffer.
-  void createClearWriteTrackingCall(ImplicitLocOpBuilder &b, Value buf,
-                                    uint32_t length, Value pred,
+  void createClearWriteTrackingCall(ImplicitLocOpBuilder &b,
+                                    MaterializedBufferRegion buffer, Value pred,
                                     MemType memType, Operation *insertPoint,
                                     Value effectCTAs);
   // clearReadVisibility: clear the read visibility for a buffer.
-  void createClearReadVisibilityCall(ImplicitLocOpBuilder &b, Value buf,
-                                     uint32_t length, Value pred,
-                                     MemType memType, Operation *insertPoint,
-                                     Value effectCTAs);
+  void createClearReadVisibilityCall(ImplicitLocOpBuilder &b,
+                                     MaterializedBufferRegion buffer,
+                                     Value pred, MemType memType,
+                                     Operation *insertPoint, Value effectCTAs);
   // clearReadTracking: clear the read tracking for a buffer.
-  void createClearReadTrackingCall(ImplicitLocOpBuilder &b, Value buf,
-                                   uint32_t length, Value pred, MemType memType,
-                                   Operation *insertPoint, Value effectCTAs);
+  void createClearReadTrackingCall(ImplicitLocOpBuilder &b,
+                                   MaterializedBufferRegion buffer, Value pred,
+                                   MemType memType, Operation *insertPoint,
+                                   Value effectCTAs);
   // trackVisibleWrites: snapshot buffers currently visible to the thread into
   // the tracking table for a barrier.
   void createTrackVisibleWritesCall(ImplicitLocOpBuilder &b, Value mbar,
@@ -186,7 +199,7 @@ public:
   // trackBarrierWriteForBuffer: mark a specific buffer as tracked by a
   // barrier in the write-tracking table.
   void createTrackBarrierWriteForBufferCall(ImplicitLocOpBuilder &b, Value mbar,
-                                            Value buf, uint32_t length,
+                                            MaterializedBufferRegion buffer,
                                             Value pred, MemType memType,
                                             Operation *insertPoint,
                                             Value barrierCTAs,
@@ -213,18 +226,19 @@ public:
                                       MemType memType, Operation *insertPoint);
   // verifyWriteVisibility: ensure the thread either sees the latest write or no
   // other thread is writing the buffer.
-  void createVerifyWriteVisibilityCall(ImplicitLocOpBuilder &b, Value buf,
-                                       uint32_t length, int thread,
-                                       StringRef operandName, Value pred,
-                                       MemType memType, Operation *insertPoint,
+  void createVerifyWriteVisibilityCall(ImplicitLocOpBuilder &b,
+                                       MaterializedBufferRegion buffer,
+                                       int thread, StringRef operandName,
+                                       Value pred, MemType memType,
+                                       Operation *insertPoint,
                                        Value effectCTAs);
   // verifyReadVisibility: ensure all reads from the buffer are visible to the
   // thread.
-  void createVerifyReadVisibilityCall(ImplicitLocOpBuilder &b, Value buf,
-                                      uint32_t length, int thread,
-                                      StringRef operandName, Value pred,
-                                      MemType memType, Operation *insertPoint,
-                                      Value effectCTAs);
+  void createVerifyReadVisibilityCall(ImplicitLocOpBuilder &b,
+                                      MaterializedBufferRegion buffer,
+                                      int thread, StringRef operandName,
+                                      Value pred, MemType memType,
+                                      Operation *insertPoint, Value effectCTAs);
   // copyWriteVisibility: replicate the write visibility bit of sourceThread to
   // every destination thread in destMask.
   void createCopyWriteVisibilityCall(ImplicitLocOpBuilder &b, int sourceThread,
@@ -242,9 +256,10 @@ public:
                                           Operation *insertPoint);
   // setProxyAccess: record a generic-proxy access by the current base thread
   // and invalidate prior proxy-fence coverage for that source thread.
-  void createSetProxyAccessCall(ImplicitLocOpBuilder &b, Value buf,
-                                uint32_t length, int thread, Value pred,
-                                Operation *insertPoint, Value effectCTAs);
+  void createSetProxyAccessCall(ImplicitLocOpBuilder &b,
+                                MaterializedBufferRegion buffer, int thread,
+                                Value pred, Operation *insertPoint,
+                                Value effectCTAs);
   // fenceProxyAccesses: mark all generic accesses visible to the current base
   // thread as covered by fence.proxy.async. A CTA fence covers the current
   // buffer row; a cluster fence covers every cluster buffer row.
@@ -268,8 +283,8 @@ public:
                                                  Operation *insertPoint);
   // verifyProxyAccess: assert that every generic-proxy access visible to the
   // issuing base thread has crossed fence.proxy.async.
-  void createVerifyProxyAccessCall(ImplicitLocOpBuilder &b, Value buf,
-                                   uint32_t length, int thread,
+  void createVerifyProxyAccessCall(ImplicitLocOpBuilder &b,
+                                   MaterializedBufferRegion buffer, int thread,
                                    StringRef operandName, Value pred,
                                    Operation *insertPoint, Value effectCTAs);
   // copyProxyAccesses: copy a parent base thread's packed proxy frontier to
@@ -284,9 +299,9 @@ public:
                                              Operation *insertPoint);
   // stageAccessForCommit: mark the buffer as staged (value -1) in the
   // outstanding commit table for this thread.
-  void createStageAccessForCommitCall(ImplicitLocOpBuilder &b, Value buf,
-                                      uint32_t length, int thread, Value pred,
-                                      MemType memType,
+  void createStageAccessForCommitCall(ImplicitLocOpBuilder &b,
+                                      MaterializedBufferRegion buffer,
+                                      int thread, Value pred, MemType memType,
                                       CommitKind::Kind commitKind,
                                       Operation *insertPoint);
   // commitAccesses: convert staged entries to 1 and increment outstanding
@@ -322,7 +337,7 @@ public:
   // When excludeSelf is true, the calling thread's own column is masked out
   // so that only other partitions' outstanding commits are checked.
   void createCheckOutstandingCommitsCall(
-      ImplicitLocOpBuilder &b, Value buf, uint32_t length, int thread,
+      ImplicitLocOpBuilder &b, MaterializedBufferRegion buffer, int thread,
       StringRef pendingAccessType, Value pred, MemType memType,
       CommitKind::Kind commitKind, Operation *insertPoint, Value effectCTAs,
       bool excludeSelf = false);

--- a/include/triton/Dialect/TritonInstrument/IR/TritonInstrument.md
+++ b/include/triton/Dialect/TritonInstrument/IR/TritonInstrument.md
@@ -109,6 +109,12 @@ atomic result broadcasts, tensor-map creation, warp-specialize captures, and
 backend-specific operations. Virtual call frames and function-owned scheduler
 state are not operation effects and publish no size metadata.
 
+Allocation must run before ConSan, and `allocation.size` is the authoritative
+marker that an operation has non-empty compiler scratch at this point in the
+pipeline. A transform that introduces scratch-using operations after allocation
+must rerun allocation before ConSan. ConSan does not infer missing metadata from
+operation kinds because scratch requirements are target- and lowering-specific.
+
 Reduction lowering creates additional `ttg.convert_layout` operations after
 ConSan, so the parent `tt.reduce` carries the effect for their already allocated
 interval. A scratch effect must wait for earlier asynchronous readers or

--- a/include/triton/Dialect/TritonInstrument/IR/TritonInstrument.md
+++ b/include/triton/Dialect/TritonInstrument/IR/TritonInstrument.md
@@ -119,7 +119,8 @@ Reduction lowering creates additional `ttg.convert_layout` operations after
 ConSan, so the parent `tt.reduce` carries the effect for their already allocated
 interval. A scratch effect must wait for earlier asynchronous readers or
 writers, and its lowering leaves no pending asynchronous access when the
-operation returns. Conversions forced to use warp shuffles allocate no scratch.
+operation returns. Conversions forced to use warp shuffles allocate no scratch
+and fail compilation if the conversion is not warp-local.
 Cross-CTA convert and reduce effects retain their operation-specific routing.
 Scratch-backed atomic broadcasts are predicated to the producer CTA and routed
 to every CTA that consumes the replicated result.

--- a/include/triton/Dialect/TritonInstrument/IR/TritonInstrument.md
+++ b/include/triton/Dialect/TritonInstrument/IR/TritonInstrument.md
@@ -100,6 +100,18 @@ can be represented directly. Scratch state is zero-initialized once before the
 instrumented body runs, and the initialization is followed by a CTA or cluster
 barrier before any instrumented operation can use it.
 
+Compiler-owned shared-memory scratch does not always have an SSA memdesc for
+BufferRegion analysis to discover. ConSan additionally tracks the allocator's
+static byte interval for `ttg.convert_layout` operations present when ConSan
+runs after shared-memory allocation. Reduction lowering creates additional
+`ttg.convert_layout` operations after ConSan, so ConSan tracks their already
+allocated interval as an effect of the parent `tt.reduce`. Each operation is
+modeled as one synchronous generic-proxy write over its complete interval: it
+must wait for earlier asynchronous readers or writers, and its lowering leaves
+no pending asynchronous scratch access when the operation returns. Conversions
+forced to use warp shuffles are excluded because their reserved allocator slot
+is not accessed by lowering.
+
 The exact auxiliary data layout is intentionally documented next to the
 implementation in `AuxDataMap` in
 `include/triton/Dialect/TritonInstrument/IR/Utility.h`.
@@ -305,6 +317,9 @@ The common hook implementation covers these TritonGPU operations:
   and atomic scatter RMW conservatively cover their full destination
   descriptors because their indices are runtime values.
 - `ttg.local_alloc` with a source: barrier-tracked shared-memory write.
+- `ttg.convert_layout` and scratch-using `tt.reduce`: allocator-provided shared
+  scratch is modeled as a synchronous generic-proxy write over its allocated
+  byte interval.
 
 These shared-memory effects are generic-proxy accesses for the proxy-ordering
 model.

--- a/include/triton/Dialect/TritonInstrument/IR/TritonInstrument.md
+++ b/include/triton/Dialect/TritonInstrument/IR/TritonInstrument.md
@@ -177,6 +177,11 @@ places that ordinary read visibility is transported:
 - A frontier-tracked mbarrier arrive copies the issuing base thread's current
   proxy frontier into the barrier tracking row. The local copy remains live, so
   an arrive does not make a later async access by the arriving thread legal.
+- An async-proxy write that signals an mbarrier snapshots the issuing base
+  thread's frontier at launch time, after its proxy-ordering check, but only for
+  tracked shared-memory regions fully contained in the write destination. This
+  lets the completion wait transport a fence immediately preceding a TMA load
+  without publishing unrelated or only partially overwritten regions.
 - A successful mbarrier wait merges the selected barrier row into the waiting
   base thread's row. A fence before the wait cannot cover accesses learned only
   by that wait; a fence after the wait can.

--- a/include/triton/Dialect/TritonInstrument/IR/TritonInstrument.md
+++ b/include/triton/Dialect/TritonInstrument/IR/TritonInstrument.md
@@ -100,17 +100,24 @@ can be represented directly. Scratch state is zero-initialized once before the
 instrumented body runs, and the initialization is followed by a CTA or cluster
 barrier before any instrumented operation can use it.
 
-Compiler-owned shared-memory scratch does not always have an SSA memdesc for
-BufferRegion analysis to discover. ConSan additionally tracks the allocator's
-static byte interval for `ttg.convert_layout` operations present when ConSan
-runs after shared-memory allocation. Reduction lowering creates additional
-`ttg.convert_layout` operations after ConSan, so ConSan tracks their already
-allocated interval as an effect of the parent `tt.reduce`. Each operation is
-modeled as one synchronous generic-proxy write over its complete interval: it
-must wait for earlier asynchronous readers or writers, and its lowering leaves
-no pending asynchronous scratch access when the operation returns. Conversions
-forced to use warp shuffles are excluded because their reserved allocator slot
-is not accessed by lowering.
+Compiler-owned shared-memory scratch does not have an SSA memdesc for
+BufferRegion analysis to discover. Allocation therefore publishes the static
+byte interval of every operation-local scratch buffer, and ConSan models it as
+one synchronous generic-proxy write over the complete interval. This covers
+scratch used by layout conversions, reductions, scans, gathers, histograms,
+atomic result broadcasts, tensor-map creation, warp-specialize captures, and
+backend-specific operations. Virtual call frames and function-owned scheduler
+state are not operation effects and publish no size metadata.
+
+Reduction lowering creates additional `ttg.convert_layout` operations after
+ConSan, so the parent `tt.reduce` carries the effect for their already allocated
+interval. A scratch effect must wait for earlier asynchronous readers or
+writers, and its lowering leaves no pending asynchronous access when the
+operation returns. Conversions forced to use warp shuffles allocate no scratch;
+ConSan also ignores stale scratch metadata on such conversions from older IR.
+Cross-CTA convert and reduce effects retain their operation-specific routing.
+Scratch-backed atomic broadcasts are predicated to the producer CTA and routed
+to every CTA that consumes the replicated result.
 
 The exact auxiliary data layout is intentionally documented next to the
 implementation in `AuxDataMap` in
@@ -317,9 +324,10 @@ The common hook implementation covers these TritonGPU operations:
   and atomic scatter RMW conservatively cover their full destination
   descriptors because their indices are runtime values.
 - `ttg.local_alloc` with a source: barrier-tracked shared-memory write.
-- `ttg.convert_layout` and scratch-using `tt.reduce`: allocator-provided shared
-  scratch is modeled as a synchronous generic-proxy write over its allocated
-  byte interval.
+- Any operation with allocator-provided operation-local shared scratch: a
+  synchronous generic-proxy write over its allocated byte interval. Forced
+  warp-shuffle conversions are excluded because they do not touch scratch;
+  convert, reduce, and scratch-backed atomic broadcasts use CTA-aware routing.
 
 These shared-memory effects are generic-proxy accesses for the proxy-ordering
 model.

--- a/include/triton/Dialect/TritonInstrument/IR/TritonInstrument.md
+++ b/include/triton/Dialect/TritonInstrument/IR/TritonInstrument.md
@@ -119,8 +119,7 @@ Reduction lowering creates additional `ttg.convert_layout` operations after
 ConSan, so the parent `tt.reduce` carries the effect for their already allocated
 interval. A scratch effect must wait for earlier asynchronous readers or
 writers, and its lowering leaves no pending asynchronous access when the
-operation returns. Conversions forced to use warp shuffles allocate no scratch;
-ConSan also ignores stale scratch metadata on such conversions from older IR.
+operation returns. Conversions forced to use warp shuffles allocate no scratch.
 Cross-CTA convert and reduce effects retain their operation-specific routing.
 Scratch-backed atomic broadcasts are predicated to the producer CTA and routed
 to every CTA that consumes the replicated result.
@@ -332,8 +331,9 @@ The common hook implementation covers these TritonGPU operations:
 - `ttg.local_alloc` with a source: barrier-tracked shared-memory write.
 - Any operation with allocator-provided operation-local shared scratch: a
   synchronous generic-proxy write over its allocated byte interval. Forced
-  warp-shuffle conversions are excluded because they do not touch scratch;
-  convert, reduce, and scratch-backed atomic broadcasts use CTA-aware routing.
+  warp-shuffle conversions publish no scratch metadata because allocation
+  reserves no scratch for them; convert, reduce, and scratch-backed atomic
+  broadcasts use CTA-aware routing.
 
 These shared-memory effects are generic-proxy accesses for the proxy-ordering
 model.

--- a/include/triton/Dialect/TritonInstrument/IR/TritonInstrumentOps.td
+++ b/include/triton/Dialect/TritonInstrument/IR/TritonInstrumentOps.td
@@ -63,6 +63,20 @@ def TTI_ExperimentalMemDescToI32Op : TTI_Op<"experimental_memdesc_to_i32", [Pure
   let assemblyFormat = "$memdesc attr-dict `:` type($memdesc)";
 }
 
+def TTI_ExperimentalSharedMemoryOffsetToI32Op
+    : TTI_Op<"experimental_shared_memory_offset_to_i32", [Pure]> {
+  let summary = "Materialize a shared-memory byte offset as an i32 address";
+  let description = [{
+    Add a statically allocated byte offset to the current function's shared
+    memory base, then return the masked 32-bit address used by ConSan buffer
+    descriptors. This represents compiler-owned shared-memory scratch that has
+    no SSA memdesc.
+  }];
+  let arguments = (ins I32Attr:$offset);
+  let results = (outs I32:$result);
+  let assemblyFormat = "$offset attr-dict";
+}
+
 def TTI_ExperimentalClusterCTAIdOp
     : TTI_Op<"experimental_cluster_cta_id", [Pure]> {
   let summary = "Get the CTA id within the current cluster";

--- a/include/triton/Dialect/TritonInstrument/IR/Utility.h
+++ b/include/triton/Dialect/TritonInstrument/IR/Utility.h
@@ -280,7 +280,8 @@ private:
   LogicalResult getBuffersAndBarriers(
       ModuleOp module,
       SmallVector<SmallVector<triton::BufferRegion>, 2> &bufRegions,
-      SmallVector<triton::BufferRegion> &barrierRegions);
+      SmallVector<triton::BufferRegion> &barrierRegions,
+      const ConSanTargetHooks *hooks);
   void passToWarpSpecialize(triton::FuncOp func, ValueType value,
                             RegionToValueMap &map, int &captureCounter,
                             int64_t &captureBytes);

--- a/include/triton/Dialect/TritonInstrument/Transforms/ConSanTargetHooks.h
+++ b/include/triton/Dialect/TritonInstrument/Transforms/ConSanTargetHooks.h
@@ -137,6 +137,11 @@ public:
   virtual Value getIssuerCTAPred(ImplicitLocOpBuilder &b,
                                  Operation *op) const = 0;
 
+  // Creates the target-specific cluster rendezvous used to publish ConSan's
+  // shared lock initialization. Some targets represent it as multiple ops.
+  virtual SmallVector<Operation *>
+  createInitClusterBarrier(ImplicitLocOpBuilder &b) const = 0;
+
   // For scratch-backed operations whose result is replicated across CTAs,
   // returns the CTA-id bits that identify peers sharing one scratch result.
   // The target hook also predicates instrumentation to the producer CTA.
@@ -195,10 +200,11 @@ public:
       }
     }
 
-    // allocation.size is published only for operation-local compiler scratch,
-    // making it the generic marker for an SSA-less shared-memory effect.
-    // allocation.offset alone is also used by explicit buffers, virtual call
-    // frames, function scheduler state, and late synthetic conversions.
+    // Allocation runs before ConSan and publishes allocation.size only for
+    // operation-local compiler scratch, making it the authoritative generic
+    // marker for an SSA-less shared-memory effect. allocation.offset alone is
+    // also used by explicit buffers, virtual call frames, function scheduler
+    // state, and late synthetic conversions.
     if (auto cvtOp = dyn_cast<ttg::ConvertLayoutOp>(op);
         cvtOp && cvtUsesForcedWarpShuffle(cvtOp)) {
       // Accept metadata produced by older pipelines that reserved scratch even

--- a/include/triton/Dialect/TritonInstrument/Transforms/ConSanTargetHooks.h
+++ b/include/triton/Dialect/TritonInstrument/Transforms/ConSanTargetHooks.h
@@ -22,9 +22,11 @@ struct MemEffectsOpInfo {
   // this for ordering operations whose semantics are a release of prior work.
   //
   // EffectWrites does not snapshot the whole thread frontier. Instead, it
-  // attaches only the explicit write effects of this op to the barrier. A later
-  // wait publishes those op-local writes and nothing else. Use this for PTX ops
-  // that perform the write and also signal the barrier via
+  // attaches only the explicit write effects of this op to the barrier. For an
+  // async-proxy shared-memory write, it also snapshots the proxy frontier only
+  // for tracked regions fully contained in that write. A later wait publishes
+  // those op-local writes and proxy-ordering facts, and nothing else. Use this
+  // for PTX ops that perform the write and also signal the barrier via
   // `mbarrier::complete_tx`.
   enum class BarrierTrackingMode {
     Frontier,

--- a/include/triton/Dialect/TritonInstrument/Transforms/ConSanTargetHooks.h
+++ b/include/triton/Dialect/TritonInstrument/Transforms/ConSanTargetHooks.h
@@ -137,6 +137,14 @@ public:
   virtual Value getIssuerCTAPred(ImplicitLocOpBuilder &b,
                                  Operation *op) const = 0;
 
+  // For scratch-backed operations whose result is replicated across CTAs,
+  // returns the CTA-id bits that identify peers sharing one scratch result.
+  // The target hook also predicates instrumentation to the producer CTA.
+  virtual std::optional<uint16_t>
+  getScratchCTABroadcastMask(Operation *op) const {
+    return std::nullopt;
+  }
+
   virtual FailureOr<std::optional<MemEffectsOpInfo>>
   getMemEffectsOpInfo(Operation *op) const {
     namespace ttg = triton::gpu;
@@ -187,81 +195,62 @@ public:
       }
     }
 
-    auto addStaticSharedScratchEffect =
-        [&](Operation *scratchOp, StringRef operationName) -> LogicalResult {
-      auto offset = scratchOp->getAttrOfType<IntegerAttr>("allocation.offset");
-      auto size = scratchOp->getAttrOfType<IntegerAttr>("allocation.size");
-      if (!offset && !size) {
-        scratchOp->emitError() << "shared-memory " << operationName
-                               << " is missing scratch allocation metadata";
-        return failure();
-      }
-      if (bool(offset) != bool(size)) {
-        scratchOp->emitError()
-            << operationName << " scratch allocation metadata must include "
-            << "both allocation.offset and allocation.size";
-        return failure();
-      }
+    // allocation.size is published only for operation-local compiler scratch,
+    // making it the generic marker for an SSA-less shared-memory effect.
+    // allocation.offset alone is also used by explicit buffers, virtual call
+    // frames, function scheduler state, and late synthetic conversions.
+    if (auto cvtOp = dyn_cast<ttg::ConvertLayoutOp>(op);
+        cvtOp && cvtUsesForcedWarpShuffle(cvtOp)) {
+      // Accept metadata produced by older pipelines that reserved scratch even
+      // though lowering is forced to use warp shuffles and never touches it.
+      return info;
+    }
 
-      int64_t offsetValue = offset.getInt();
-      int64_t sizeValue = size.getInt();
-      constexpr uint64_t maxSharedMemorySize =
-          uint64_t{kSharedMemoryObjectMask} + 1;
-      bool isValid = offsetValue >= 0 && sizeValue > 0;
-      if (isValid) {
-        uint64_t unsignedOffset = static_cast<uint64_t>(offsetValue);
-        uint64_t unsignedSize = static_cast<uint64_t>(sizeValue);
-        isValid = unsignedOffset <= maxSharedMemorySize &&
-                  unsignedSize <= maxSharedMemorySize - unsignedOffset;
-      }
-      if (!isValid) {
-        scratchOp->emitError()
-            << "invalid " << operationName
-            << " scratch allocation metadata: offset " << offsetValue
-            << ", size " << sizeValue
-            << "; the interval must be non-empty and fit in the 24-bit "
-               "shared-memory address space";
-        return failure();
-      }
+    Attribute sizeAttr = op->getAttr("allocation.size");
+    if (!sizeAttr)
+      return info;
+    auto size = dyn_cast<IntegerAttr>(sizeAttr);
+    auto offset = op->getAttrOfType<IntegerAttr>("allocation.offset");
+    if (!size || !offset) {
+      op->emitError()
+          << "compiler scratch metadata requires integer allocation.offset "
+             "and allocation.size attributes";
+      return failure();
+    }
 
+    int64_t offsetValue = offset.getInt();
+    int64_t sizeValue = size.getInt();
+    constexpr uint64_t maxSharedMemorySize =
+        uint64_t{kSharedMemoryObjectMask} + 1;
+    bool isValid = offsetValue >= 0 && sizeValue > 0;
+    if (isValid) {
+      uint64_t unsignedOffset = static_cast<uint64_t>(offsetValue);
+      uint64_t unsignedSize = static_cast<uint64_t>(sizeValue);
+      isValid = unsignedOffset <= maxSharedMemorySize &&
+                unsignedSize <= maxSharedMemorySize - unsignedOffset;
+    }
+    if (!isValid) {
+      op->emitError() << "invalid compiler scratch allocation metadata: offset "
+                      << offsetValue << ", size " << sizeValue
+                      << "; the interval must be non-empty and fit in the "
+                         "24-bit shared-memory address space";
+      return failure();
+    }
+
+    if (!info)
       info.emplace();
+    if (info->trackingKind == MemEffectsOpInfo::TrackingKind::None)
       info->trackingKind = MemEffectsOpInfo::TrackingKind::Barrier;
-      info->operandEffects.emplace_back(
-          MemEffectsOpInfo::Effects::Write,
-          BufferRegion{static_cast<uint32_t>(offsetValue),
-                       static_cast<uint32_t>(sizeValue)},
-          "Scratch");
-      return success();
-    };
-
-    if (auto cvtOp = dyn_cast<ttg::ConvertLayoutOp>(op)) {
-      auto func = cvtOp->getParentOfType<mlir::triton::FuncOp>();
-      bool forceWarpShuffle =
-          func && func->hasAttrOfType<UnitAttr>("always_use_warp_shuffle") &&
-          cvtCanUseWarpShuffle(cvtOp.getSrc().getType(), cvtOp.getType());
-      // Allocation analysis may reserve an otherwise-needed scratch slot for
-      // conversions that lowering is explicitly forced to implement with
-      // warp shuffles.
-      if (forceWarpShuffle)
-        return info;
-
-      bool needsSharedMemory =
-          cvtNeedsSharedMemory(cvtOp.getSrc().getType(), cvtOp.getType());
-      if (!needsSharedMemory)
-        return info;
-      if (failed(addStaticSharedScratchEffect(cvtOp, "convert_layout")))
-        return failure();
+    if (info->trackingKind != MemEffectsOpInfo::TrackingKind::Barrier) {
+      op->emitError("compiler scratch cannot be combined with asynchronous "
+                    "operation effect tracking");
+      return failure();
     }
-    if (auto reduceOp = dyn_cast<mlir::triton::ReduceOp>(op)) {
-      bool hasAllocationMetadata = reduceOp->hasAttr("allocation.offset") ||
-                                   reduceOp->hasAttr("allocation.size");
-      bool needsSharedMemory =
-          hasAllocationMetadata ||
-          ReduceOpHelper(reduceOp).getScratchSizeInBytes() != 0;
-      if (needsSharedMemory &&
-          failed(addStaticSharedScratchEffect(reduceOp, "reduce")))
-        return failure();
-    }
+    info->operandEffects.emplace_back(
+        MemEffectsOpInfo::Effects::Write,
+        BufferRegion{static_cast<uint32_t>(offsetValue),
+                     static_cast<uint32_t>(sizeValue)},
+        "Scratch");
     return info;
   }
 

--- a/include/triton/Dialect/TritonInstrument/Transforms/ConSanTargetHooks.h
+++ b/include/triton/Dialect/TritonInstrument/Transforms/ConSanTargetHooks.h
@@ -2,7 +2,6 @@
 #define TRITONINSTRUMENT_CONSAN_TARGET_HOOKS_H
 
 #include "mlir/IR/BuiltinOps.h"
-#include "triton/Analysis/Utility.h"
 #include "triton/Dialect/TritonGPU/IR/Dialect.h"
 #include "triton/Dialect/TritonInstrument/IR/Utility.h"
 #include <functional>
@@ -205,13 +204,6 @@ public:
     // marker for an SSA-less shared-memory effect. allocation.offset alone is
     // also used by explicit buffers, virtual call frames, function scheduler
     // state, and late synthetic conversions.
-    if (auto cvtOp = dyn_cast<ttg::ConvertLayoutOp>(op);
-        cvtOp && cvtUsesForcedWarpShuffle(cvtOp)) {
-      // Accept metadata produced by older pipelines that reserved scratch even
-      // though lowering is forced to use warp shuffles and never touches it.
-      return info;
-    }
-
     Attribute sizeAttr = op->getAttr("allocation.size");
     if (!sizeAttr)
       return info;

--- a/include/triton/Dialect/TritonInstrument/Transforms/ConSanTargetHooks.h
+++ b/include/triton/Dialect/TritonInstrument/Transforms/ConSanTargetHooks.h
@@ -2,12 +2,14 @@
 #define TRITONINSTRUMENT_CONSAN_TARGET_HOOKS_H
 
 #include "mlir/IR/BuiltinOps.h"
+#include "triton/Analysis/Utility.h"
 #include "triton/Dialect/TritonGPU/IR/Dialect.h"
 #include "triton/Dialect/TritonInstrument/IR/Utility.h"
 #include <functional>
 #include <memory>
 #include <optional>
 #include <string>
+#include <variant>
 
 namespace mlir::triton::instrument {
 
@@ -30,16 +32,26 @@ struct MemEffectsOpInfo {
     EffectWrites,
   };
   struct Effects {
+    struct StaticSharedBuffer {
+      BufferRegion region;
+    };
+    using Buffer = std::variant<Value, StaticSharedBuffer>;
+
     enum RW { Read, Write } rw;
     enum class Proxy { Generic, Async } proxy;
-    Value buf;
+    Buffer buffer;
     std::string operandName = "";
     uint32_t length = 0;
 
     Effects(RW rw, Value buf, std::string operandName = "",
             Proxy proxy = Proxy::Generic)
-        : rw(rw), proxy(proxy), buf(buf), operandName(operandName),
+        : rw(rw), proxy(proxy), buffer(buf), operandName(operandName),
           length(getMemDescLength(buf)) {}
+
+    Effects(RW rw, BufferRegion region, std::string operandName = "",
+            Proxy proxy = Proxy::Generic)
+        : rw(rw), proxy(proxy), buffer(StaticSharedBuffer{region}),
+          operandName(operandName), length(region.length) {}
   };
   struct BarrierInfo {
     Value barrier;
@@ -125,7 +137,7 @@ public:
   virtual Value getIssuerCTAPred(ImplicitLocOpBuilder &b,
                                  Operation *op) const = 0;
 
-  virtual std::optional<MemEffectsOpInfo>
+  virtual FailureOr<std::optional<MemEffectsOpInfo>>
   getMemEffectsOpInfo(Operation *op) const {
     namespace ttg = triton::gpu;
     std::optional<MemEffectsOpInfo> info;
@@ -173,6 +185,82 @@ public:
         info->operandEffects.emplace_back(MemEffectsOpInfo::Effects::Write,
                                           allocOp.getResult());
       }
+    }
+
+    auto addStaticSharedScratchEffect =
+        [&](Operation *scratchOp, StringRef operationName) -> LogicalResult {
+      auto offset = scratchOp->getAttrOfType<IntegerAttr>("allocation.offset");
+      auto size = scratchOp->getAttrOfType<IntegerAttr>("allocation.size");
+      if (!offset && !size) {
+        scratchOp->emitError() << "shared-memory " << operationName
+                               << " is missing scratch allocation metadata";
+        return failure();
+      }
+      if (bool(offset) != bool(size)) {
+        scratchOp->emitError()
+            << operationName << " scratch allocation metadata must include "
+            << "both allocation.offset and allocation.size";
+        return failure();
+      }
+
+      int64_t offsetValue = offset.getInt();
+      int64_t sizeValue = size.getInt();
+      constexpr uint64_t maxSharedMemorySize =
+          uint64_t{kSharedMemoryObjectMask} + 1;
+      bool isValid = offsetValue >= 0 && sizeValue > 0;
+      if (isValid) {
+        uint64_t unsignedOffset = static_cast<uint64_t>(offsetValue);
+        uint64_t unsignedSize = static_cast<uint64_t>(sizeValue);
+        isValid = unsignedOffset <= maxSharedMemorySize &&
+                  unsignedSize <= maxSharedMemorySize - unsignedOffset;
+      }
+      if (!isValid) {
+        scratchOp->emitError()
+            << "invalid " << operationName
+            << " scratch allocation metadata: offset " << offsetValue
+            << ", size " << sizeValue
+            << "; the interval must be non-empty and fit in the 24-bit "
+               "shared-memory address space";
+        return failure();
+      }
+
+      info.emplace();
+      info->trackingKind = MemEffectsOpInfo::TrackingKind::Barrier;
+      info->operandEffects.emplace_back(
+          MemEffectsOpInfo::Effects::Write,
+          BufferRegion{static_cast<uint32_t>(offsetValue),
+                       static_cast<uint32_t>(sizeValue)},
+          "Scratch");
+      return success();
+    };
+
+    if (auto cvtOp = dyn_cast<ttg::ConvertLayoutOp>(op)) {
+      auto func = cvtOp->getParentOfType<mlir::triton::FuncOp>();
+      bool forceWarpShuffle =
+          func && func->hasAttrOfType<UnitAttr>("always_use_warp_shuffle") &&
+          cvtCanUseWarpShuffle(cvtOp.getSrc().getType(), cvtOp.getType());
+      // Allocation analysis may reserve an otherwise-needed scratch slot for
+      // conversions that lowering is explicitly forced to implement with
+      // warp shuffles.
+      if (forceWarpShuffle)
+        return info;
+
+      bool needsSharedMemory =
+          cvtNeedsSharedMemory(cvtOp.getSrc().getType(), cvtOp.getType());
+      if (!needsSharedMemory)
+        return info;
+      if (failed(addStaticSharedScratchEffect(cvtOp, "convert_layout")))
+        return failure();
+    }
+    if (auto reduceOp = dyn_cast<mlir::triton::ReduceOp>(op)) {
+      bool hasAllocationMetadata = reduceOp->hasAttr("allocation.offset") ||
+                                   reduceOp->hasAttr("allocation.size");
+      bool needsSharedMemory =
+          hasAllocationMetadata ||
+          ReduceOpHelper(reduceOp).getScratchSizeInBytes() != 0;
+      if (needsSharedMemory &&
+          failed(addStaticSharedScratchEffect(reduceOp, "reduce")))
+        return failure();
     }
     return info;
   }

--- a/lib/Analysis/Allocation.cpp
+++ b/lib/Analysis/Allocation.cpp
@@ -114,6 +114,8 @@ unsigned defaultAllocationAnalysisScratchSizeFn(Operation *op) {
            getBitwidth(dstTy) / 8;
   }
   if (auto cvtLayout = dyn_cast<gpu::ConvertLayoutOp>(op)) {
+    if (cvtUsesForcedWarpShuffle(cvtLayout))
+      return 0;
     auto srcTy = cvtLayout.getSrc().getType();
     auto dstTy = cvtLayout.getType();
     if (!cvtNeedsSharedMemory(srcTy, dstTy))

--- a/lib/Analysis/Utility.cpp
+++ b/lib/Analysis/Utility.cpp
@@ -1330,6 +1330,12 @@ bool cvtCanUseWarpShuffle(RankedTensorType srcTy, RankedTensorType dstTy) {
   return !llvm::is_contained(dims, kBlock) && !llvm::is_contained(dims, kWarp);
 }
 
+bool cvtUsesForcedWarpShuffle(triton::gpu::ConvertLayoutOp cvt) {
+  auto func = cvt->getParentOfType<FunctionOpInterface>();
+  return func && func->hasAttrOfType<UnitAttr>("always_use_warp_shuffle") &&
+         cvtCanUseWarpShuffle(cvt.getSrc().getType(), cvt.getType());
+}
+
 bool cvtNeedsSharedMemory(RankedTensorType srcTy, RankedTensorType dstTy) {
   return !cvtReordersRegisters(srcTy, dstTy) &&
          !cvtNeedsWarpShuffle(srcTy, dstTy);

--- a/lib/Analysis/Utility.cpp
+++ b/lib/Analysis/Utility.cpp
@@ -1332,7 +1332,6 @@ bool cvtCanUseWarpShuffle(RankedTensorType srcTy, RankedTensorType dstTy) {
 
 bool cvtIsWarpShuffleForced(triton::gpu::ConvertLayoutOp cvt) {
   auto func = cvt->getParentOfType<FunctionOpInterface>();
-  assert(func && "convert_layout must be nested in a function");
   return func->hasAttrOfType<UnitAttr>("always_use_warp_shuffle");
 }
 

--- a/lib/Analysis/Utility.cpp
+++ b/lib/Analysis/Utility.cpp
@@ -1321,6 +1321,15 @@ bool cvtNeedsWarpShuffle(RankedTensorType srcTy, RankedTensorType dstTy) {
   return false;
 }
 
+bool cvtCanUseWarpShuffle(RankedTensorType srcTy, RankedTensorType dstTy) {
+  auto layout = minimalCvtLayout(srcTy, dstTy);
+  MLIRContext *ctx = srcTy.getContext();
+  auto kBlock = StringAttr::get(ctx, "block");
+  auto kWarp = StringAttr::get(ctx, "warp");
+  auto dims = layout.getInDimNames();
+  return !llvm::is_contained(dims, kBlock) && !llvm::is_contained(dims, kWarp);
+}
+
 bool cvtNeedsSharedMemory(RankedTensorType srcTy, RankedTensorType dstTy) {
   return !cvtReordersRegisters(srcTy, dstTy) &&
          !cvtNeedsWarpShuffle(srcTy, dstTy);

--- a/lib/Analysis/Utility.cpp
+++ b/lib/Analysis/Utility.cpp
@@ -1330,9 +1330,14 @@ bool cvtCanUseWarpShuffle(RankedTensorType srcTy, RankedTensorType dstTy) {
   return !llvm::is_contained(dims, kBlock) && !llvm::is_contained(dims, kWarp);
 }
 
-bool cvtUsesForcedWarpShuffle(triton::gpu::ConvertLayoutOp cvt) {
+bool cvtIsWarpShuffleForced(triton::gpu::ConvertLayoutOp cvt) {
   auto func = cvt->getParentOfType<FunctionOpInterface>();
-  return func && func->hasAttrOfType<UnitAttr>("always_use_warp_shuffle") &&
+  assert(func && "convert_layout must be nested in a function");
+  return func->hasAttrOfType<UnitAttr>("always_use_warp_shuffle");
+}
+
+bool cvtUsesForcedWarpShuffle(triton::gpu::ConvertLayoutOp cvt) {
+  return cvtIsWarpShuffleForced(cvt) &&
          cvtCanUseWarpShuffle(cvt.getSrc().getType(), cvt.getType());
 }
 

--- a/lib/Conversion/TritonGPUToLLVM/AllocateSharedMemoryUtility.cpp
+++ b/lib/Conversion/TritonGPUToLLVM/AllocateSharedMemoryUtility.cpp
@@ -1,4 +1,5 @@
 #include "triton/Conversion/TritonGPUToLLVM/AllocateSharedMemoryUtility.h"
+#include "triton/Dialect/Triton/IR/Dialect.h"
 #include "triton/Dialect/TritonGPU/IR/Dialect.h"
 
 namespace mlir::triton::gpu {
@@ -11,11 +12,15 @@ void attachAllocationSizeAndOffsetAttr(ModuleOp mod,
   mod.walk<mlir::WalkOrder::PreOrder>([&](FunctionOpInterface funcOp) {
     auto *funcAllocation = allocation.getFuncData(funcOp);
     funcOp.walk([&](Operation *op) {
-      // Handle scratch buffers (from operations like convert_layout)
+      // Handle compiler-owned scratch buffers.
       auto oBufferId = funcAllocation->getBufferId(op);
       if (oBufferId != Allocation::InvalidBufferId) {
         int offset = funcAllocation->getOffset(oBufferId);
         op->setAttr("allocation.offset", IntegerAttr::get(i32Ty, offset));
+        if (isa<ConvertLayoutOp, mlir::triton::ReduceOp>(op)) {
+          size_t size = funcAllocation->getAllocatedSize(oBufferId);
+          op->setAttr("allocation.size", IntegerAttr::get(i32Ty, size));
+        }
         return;
       }
 

--- a/lib/Conversion/TritonGPUToLLVM/AllocateSharedMemoryUtility.cpp
+++ b/lib/Conversion/TritonGPUToLLVM/AllocateSharedMemoryUtility.cpp
@@ -17,7 +17,10 @@ void attachAllocationSizeAndOffsetAttr(ModuleOp mod,
       if (oBufferId != Allocation::InvalidBufferId) {
         int offset = funcAllocation->getOffset(oBufferId);
         op->setAttr("allocation.offset", IntegerAttr::get(i32Ty, offset));
-        if (isa<ConvertLayoutOp, mlir::triton::ReduceOp>(op)) {
+        // Function scratch is scheduler state rather than memory accessed by
+        // the function op itself. Virtual call frames are not Scratch buffers.
+        if (funcAllocation->isScratchBuffer(oBufferId) &&
+            !isa<FunctionOpInterface>(op)) {
           size_t size = funcAllocation->getAllocatedSize(oBufferId);
           op->setAttr("allocation.size", IntegerAttr::get(i32Ty, size));
         }

--- a/lib/Conversion/TritonGPUToLLVM/ConvertLayoutOpToLLVM.cpp
+++ b/lib/Conversion/TritonGPUToLLVM/ConvertLayoutOpToLLVM.cpp
@@ -56,11 +56,12 @@ struct ConvertLayoutOpConversion
       return op.emitError("ConvertLayoutOp  supports GenericLinearEncoding "
                           " only when the conversion is transfer between "
                           "values in the same thread.");
-    bool alwaysUseWarpShuffle = cvtAlwaysUseWarpShuffle(op);
+    FailureOr<bool> alwaysUseWarpShuffle = cvtAlwaysUseWarpShuffle(op);
+    if (failed(alwaysUseWarpShuffle))
+      return failure();
     assert(to_vector(conversion.getInDimNames()) ==
            to_vector(conversion.getOutDimNames()));
     if (llvm::is_contained(dims, kBlock) || llvm::is_contained(dims, kWarp)) {
-      assert(!alwaysUseWarpShuffle);
       // Transfer between values in the same CTA, or across CTAs. We move values
       // through (distributed) shared memory.
       transferSwizzlingLocalMem(op, adaptor.getSrc(), rewriter);
@@ -69,7 +70,7 @@ struct ConvertLayoutOpConversion
       // Case 3. Transfer between values in the same warp, in which case we try
       //         to move values using warp shuffles, though if the pattern is
       //         expensive enough we fall back to using shared memory
-      if (cvtNeedsWarpShuffle(srcTy, dstTy) || alwaysUseWarpShuffle)
+      if (cvtNeedsWarpShuffle(srcTy, dstTy) || *alwaysUseWarpShuffle)
         return transferWithinWarp(op, adaptor, rewriter);
 
       transferSwizzlingLocalMem(op, adaptor.getSrc(), rewriter);

--- a/lib/Conversion/TritonGPUToLLVM/Utility.cpp
+++ b/lib/Conversion/TritonGPUToLLVM/Utility.cpp
@@ -251,9 +251,6 @@ Value matrixVectorProd(TritonLLVMOpBuilder &b, const LinearLayout &A, Value x) {
 }
 
 FailureOr<bool> cvtAlwaysUseWarpShuffle(ConvertLayoutOp cvt) {
-  // ConvertLayoutOp lowering runs after functions have been converted to the
-  // target function dialect (for example LLVM::LLVMFuncOp), so do not assume
-  // that the enclosing operation is still a tt.func.
   if (cvtUsesForcedWarpShuffle(cvt))
     return true;
   if (!cvtIsWarpShuffleForced(cvt))

--- a/lib/Conversion/TritonGPUToLLVM/Utility.cpp
+++ b/lib/Conversion/TritonGPUToLLVM/Utility.cpp
@@ -250,18 +250,17 @@ Value matrixVectorProd(TritonLLVMOpBuilder &b, const LinearLayout &A, Value x) {
   return b.or_(orPart, xorPart, /*disjoint=*/true);
 }
 
-bool cvtAlwaysUseWarpShuffle(ConvertLayoutOp cvt) {
+FailureOr<bool> cvtAlwaysUseWarpShuffle(ConvertLayoutOp cvt) {
   // ConvertLayoutOp lowering runs after functions have been converted to the
   // target function dialect (for example LLVM::LLVMFuncOp), so do not assume
   // that the enclosing operation is still a tt.func.
   if (cvtUsesForcedWarpShuffle(cvt))
     return true;
-  auto func = cvt->getParentOfType<FunctionOpInterface>();
-  if (!func || !func->hasAttrOfType<UnitAttr>("always_use_warp_shuffle"))
+  if (!cvtIsWarpShuffleForced(cvt))
     return false;
-  assert(cvt->getAttrOfType<IntegerAttr>("allocation.offset") &&
-         "forced non-warp-local conversion requires shared-memory fallback");
-  return false;
+  cvt.emitError("'always_use_warp_shuffle' requires a warp-local layout "
+                "conversion");
+  return failure();
 }
 
 Value maybeAnd(OpBuilder &builder, Location loc, Value a, Value b) {

--- a/lib/Conversion/TritonGPUToLLVM/Utility.cpp
+++ b/lib/Conversion/TritonGPUToLLVM/Utility.cpp
@@ -254,11 +254,11 @@ bool cvtAlwaysUseWarpShuffle(ConvertLayoutOp cvt) {
   // ConvertLayoutOp lowering runs after functions have been converted to the
   // target function dialect (for example LLVM::LLVMFuncOp), so do not assume
   // that the enclosing operation is still a tt.func.
+  if (cvtUsesForcedWarpShuffle(cvt))
+    return true;
   auto func = cvt->getParentOfType<FunctionOpInterface>();
   if (!func || !func->hasAttrOfType<UnitAttr>("always_use_warp_shuffle"))
     return false;
-  if (cvtCanUseWarpShuffle(cvt.getSrc().getType(), cvt.getType()))
-    return true;
   assert(cvt->getAttrOfType<IntegerAttr>("allocation.offset") &&
          "forced non-warp-local conversion requires shared-memory fallback");
   return false;

--- a/lib/Conversion/TritonGPUToLLVM/Utility.cpp
+++ b/lib/Conversion/TritonGPUToLLVM/Utility.cpp
@@ -251,7 +251,12 @@ Value matrixVectorProd(TritonLLVMOpBuilder &b, const LinearLayout &A, Value x) {
 }
 
 bool cvtAlwaysUseWarpShuffle(ConvertLayoutOp cvt) {
-  return cvt->getParentOp()->hasAttrOfType<UnitAttr>("always_use_warp_shuffle");
+  // ConvertLayoutOp lowering runs after functions have been converted to the
+  // target function dialect (for example LLVM::LLVMFuncOp), so do not assume
+  // that the enclosing operation is still a tt.func.
+  auto func = cvt->getParentOfType<FunctionOpInterface>();
+  return func && func->hasAttrOfType<UnitAttr>("always_use_warp_shuffle") &&
+         cvtCanUseWarpShuffle(cvt.getSrc().getType(), cvt.getType());
 }
 
 Value maybeAnd(OpBuilder &builder, Location loc, Value a, Value b) {

--- a/lib/Conversion/TritonGPUToLLVM/Utility.cpp
+++ b/lib/Conversion/TritonGPUToLLVM/Utility.cpp
@@ -255,8 +255,13 @@ bool cvtAlwaysUseWarpShuffle(ConvertLayoutOp cvt) {
   // target function dialect (for example LLVM::LLVMFuncOp), so do not assume
   // that the enclosing operation is still a tt.func.
   auto func = cvt->getParentOfType<FunctionOpInterface>();
-  return func && func->hasAttrOfType<UnitAttr>("always_use_warp_shuffle") &&
-         cvtCanUseWarpShuffle(cvt.getSrc().getType(), cvt.getType());
+  if (!func || !func->hasAttrOfType<UnitAttr>("always_use_warp_shuffle"))
+    return false;
+  if (cvtCanUseWarpShuffle(cvt.getSrc().getType(), cvt.getType()))
+    return true;
+  assert(cvt->getAttrOfType<IntegerAttr>("allocation.offset") &&
+         "forced non-warp-local conversion requires shared-memory fallback");
+  return false;
 }
 
 Value maybeAnd(OpBuilder &builder, Location loc, Value a, Value b) {

--- a/lib/Conversion/TritonInstrumentToLLVM/InstrumentationToLLVM.cpp
+++ b/lib/Conversion/TritonInstrumentToLLVM/InstrumentationToLLVM.cpp
@@ -22,10 +22,6 @@ namespace ttg = tt::gpu;
 namespace tti = mlir::triton::instrument;
 namespace ttng = mlir::triton::nvidia_gpu;
 
-// The first 24 bits of the shared memory object are CTA-invariant
-// The next 4 bits are the CTA index
-constexpr uint32_t kSharedMemoryObjectMask = (1u << 24) - 1;
-
 ////////////////////////////////////////////
 // Utility functions
 ////////////////////////////////////////////
@@ -47,7 +43,7 @@ Value createMemDescToI32(RewriterBase &rewriter, Location loc,
   auto elemSize = srcElemTy.getIntOrFloatBitWidth() / 8;
   offset = b.mul(offset, b.i32_val(elemSize));
   return b.and_(b.add(offset, b.ptrtoint(i32Ty, smemObj.getBase())),
-                b.i32_val(kSharedMemoryObjectMask));
+                b.i32_val(tti::kSharedMemoryObjectMask));
 }
 
 ////////////////////////////////////////////
@@ -123,7 +119,7 @@ struct BufferDescriptorsOpConversion
 
     SmallVector<uint64_t> maskVals(offsets.size(),
                                    op.getMemType() == tti::MemType::SHARED_MEM
-                                       ? kSharedMemoryObjectMask
+                                       ? tti::kSharedMemoryObjectMask
                                        : 0xffffffffu);
     Value maskTensor =
         createInitializedIntArrayTensor(rewriter, loc, encoding, maskVals);
@@ -326,6 +322,30 @@ public:
   }
 };
 
+struct SharedMemoryOffsetToI32OpConversion
+    : public ConvertOpToLLVMPattern<
+          tti::ExperimentalSharedMemoryOffsetToI32Op> {
+public:
+  using ConvertOpToLLVMPattern<
+      tti::ExperimentalSharedMemoryOffsetToI32Op>::ConvertOpToLLVMPattern;
+
+  LogicalResult
+  matchAndRewrite(tti::ExperimentalSharedMemoryOffsetToI32Op op,
+                  OpAdaptor adaptor,
+                  ConversionPatternRewriter &rewriter) const override {
+    auto func = op->getParentOfType<FunctionOpInterface>();
+    assert(func && "shared-memory offset must be inside a function");
+
+    TritonLLVMOpBuilder b(op.getLoc(), rewriter);
+    Value base = b.ptrtoint(rewriter.getI32Type(),
+                            LLVM::getStackPointer(rewriter, func));
+    Value address = b.add(base, b.i32_val(op.getOffset()));
+    rewriter.replaceOp(
+        op, b.and_(address, b.i32_val(tti::kSharedMemoryObjectMask)));
+    return success();
+  }
+};
+
 struct ClusterCTAIdOpConversion
     : public ConvertOpToLLVMPattern<tti::ExperimentalClusterCTAIdOp> {
   ClusterCTAIdOpConversion(const LLVMTypeConverter &converter,
@@ -453,6 +473,7 @@ void mlir::triton::populateInstrumentationToLLVMPatterns(
   patterns.add<LockAcquireOpConversion>(typeConverter, targetInfo);
   patterns.add<LockReleaseOpConversion>(typeConverter, targetInfo);
   patterns.add<MemDescToI32OpConversion>(typeConverter);
+  patterns.add<SharedMemoryOffsetToI32OpConversion>(typeConverter);
   patterns.add<ClusterCTAIdOpConversion>(typeConverter, targetInfo);
   patterns.add<LocalGatherOpConversion>(typeConverter, targetInfo);
 }

--- a/lib/Dialect/TritonInstrument/IR/FunctionBuilder.cpp
+++ b/lib/Dialect/TritonInstrument/IR/FunctionBuilder.cpp
@@ -247,6 +247,38 @@ Value createBufferDescriptor(ImplicitLocOpBuilder &b, Value offsetI32,
   return arith::OrIOp::create(b, lengthShifted, offsetI64);
 }
 
+// Return the descriptor rows whose entire byte interval is covered by
+// [offset, offset + length). Restricting completion-barrier proxy state by
+// containment (rather than overlap) prevents a partial async write from
+// publishing generic accesses to bytes it did not write.
+Value createBuffersContainedInRegionMask(ImplicitLocOpBuilder &b, Value buffers,
+                                         Value offsetI32, Value lengthI32) {
+  auto buffersType = cast<RankedTensorType>(buffers.getType());
+  Value offsetMask =
+      tti::createConstIntTensor(b, b.getLoc(), 0xffffffff, buffersType);
+  Value shift = tti::createConstIntTensor(b, b.getLoc(), 32, buffersType);
+  Value zero = tti::createConstIntTensor(b, b.getLoc(), 0, buffersType);
+  Value bufferOffsets = arith::AndIOp::create(b, buffers, offsetMask);
+  Value bufferLengths = arith::ShRUIOp::create(b, buffers, shift);
+  Value bufferEnds = arith::AddIOp::create(b, bufferOffsets, bufferLengths);
+
+  Value regionOffsetI64 = arith::ExtUIOp::create(b, b.getI64Type(), offsetI32);
+  Value regionLengthI64 = arith::ExtUIOp::create(b, b.getI64Type(), lengthI32);
+  Value regionEndI64 =
+      arith::AddIOp::create(b, regionOffsetI64, regionLengthI64);
+  Value regionOffset = triton::SplatOp::create(b, buffersType, regionOffsetI64);
+  Value regionEnd = triton::SplatOp::create(b, buffersType, regionEndI64);
+
+  Value startsInside = arith::CmpIOp::create(b, arith::CmpIPredicate::uge,
+                                             bufferOffsets, regionOffset);
+  Value endsInside = arith::CmpIOp::create(b, arith::CmpIPredicate::ule,
+                                           bufferEnds, regionEnd);
+  Value nonEmpty =
+      arith::CmpIOp::create(b, arith::CmpIPredicate::ne, bufferLengths, zero);
+  return arith::AndIOp::create(
+      b, nonEmpty, arith::AndIOp::create(b, startsInside, endsInside));
+}
+
 std::tuple<Block *, Block *, Block *> createIfBlock(ImplicitLocOpBuilder &b,
                                                     Value cnd) {
   // #prevBlock
@@ -2989,8 +3021,27 @@ void FunctionBuilder::createTrackProxyAccessesCall(ImplicitLocOpBuilder &b,
                                                    Value pred,
                                                    Operation *insertPoint,
                                                    Value barrierCTAs) {
+  createTrackProxyAccessesCallImpl(b, mbar, thread, pred, insertPoint,
+                                   barrierCTAs, std::nullopt, Value());
+}
+
+void FunctionBuilder::createTrackProxyAccessesForBufferCall(
+    ImplicitLocOpBuilder &b, Value mbar, MaterializedBufferRegion buffer,
+    int thread, Value pred, Operation *insertPoint, Value barrierCTAs,
+    Value effectCTAs) {
+  createTrackProxyAccessesCallImpl(b, mbar, thread, pred, insertPoint,
+                                   barrierCTAs, buffer, effectCTAs);
+}
+
+void FunctionBuilder::createTrackProxyAccessesCallImpl(
+    ImplicitLocOpBuilder &b, Value mbar, int thread, Value pred,
+    Operation *insertPoint, Value barrierCTAs,
+    std::optional<MaterializedBufferRegion> buffer, Value effectCTAs) {
+  bool filterByBuffer = buffer.has_value();
+  auto &buffersMap = auxData.buffers[(int)MemType::SHARED_MEM];
   if (auxData.barriers.empty() || auxData.proxyAccessVisibility.empty() ||
-      auxData.proxyAccessTracking.empty())
+      auxData.proxyAccessTracking.empty() ||
+      (filterByBuffer && buffersMap.empty()))
     return;
   if (!pred)
     pred = arith::ConstantIntOp::create(b, 1, 1);
@@ -3000,6 +3051,7 @@ void FunctionBuilder::createTrackProxyAccessesCall(ImplicitLocOpBuilder &b,
   auto barriersType = cast<RankedTensorType>(barriers.type);
   auto visibilityType = cast<RankedTensorType>(visibility.type);
   auto trackingType = cast<RankedTensorType>(tracking.type);
+  RankedTensorType buffersType;
   SmallVector<Value> args = {
       tti::ExperimentalMemDescToI32Op::create(b, mbar),
       arith::ConstantIntOp::create(b, getMemDescLength(mbar), 32),
@@ -3009,11 +3061,22 @@ void FunctionBuilder::createTrackProxyAccessesCall(ImplicitLocOpBuilder &b,
       visibility.value,
       tracking.value,
       barrierCTAs};
+  ManglingArgs specializationArgs{barriersType, visibilityType, trackingType};
+  if (filterByBuffer) {
+    ValueType buffers = buffersMap.at(insertPoint);
+    buffersType = cast<RankedTensorType>(buffers.type);
+    args.append({buffer->baseAddress,
+                 arith::ConstantIntOp::create(b, buffer->length, 32),
+                 buffers.value, effectCTAs});
+    specializationArgs.append(buffersType);
+  }
   createCallToCachedFunction(
-      b, "track_proxy_accesses", args, /*assertInfo=*/std::nullopt,
-      {barriersType, visibilityType, trackingType},
-      [visibilityType, trackingType](ImplicitLocOpBuilder &fb,
-                                     Block *entryBlock) {
+      b,
+      filterByBuffer ? "track_proxy_accesses_for_buffer"
+                     : "track_proxy_accesses",
+      args, /*assertInfo=*/std::nullopt, specializationArgs,
+      [visibilityType, trackingType, filterByBuffer](ImplicitLocOpBuilder &fb,
+                                                     Block *entryBlock) {
         Value mbarOffset = entryBlock->getArgument(0);
         Value lengthVal = entryBlock->getArgument(1);
         Value pred = entryBlock->getArgument(2);
@@ -3022,6 +3085,11 @@ void FunctionBuilder::createTrackProxyAccessesCall(ImplicitLocOpBuilder &b,
         Value visibilityPtr = entryBlock->getArgument(5);
         Value trackingPtr = entryBlock->getArgument(6);
         Value barrierCTAs = entryBlock->getArgument(7);
+        Value bufOffset = filterByBuffer ? entryBlock->getArgument(8) : Value();
+        Value bufLength = filterByBuffer ? entryBlock->getArgument(9) : Value();
+        Value buffers = filterByBuffer ? entryBlock->getArgument(10) : Value();
+        Value effectCTAs =
+            filterByBuffer ? entryBlock->getArgument(11) : Value();
 
         auto [prevBlock, ifBlock, thenBlock] = createIfBlock(fb, pred);
         fb.setInsertionPointToStart(ifBlock);
@@ -3035,6 +3103,17 @@ void FunctionBuilder::createTrackProxyAccessesCall(ImplicitLocOpBuilder &b,
         sourceMask = arith::AndIOp::create(
             fb, sourceMask,
             createDimMask(fb, threadVal, visibilityType, /*dim=*/3));
+        Value containedBuffers;
+        if (filterByBuffer) {
+          containedBuffers = createBuffersContainedInRegionMask(
+              fb, buffers, bufOffset, bufLength);
+          Value visibilityBuffers =
+              convertAndBroadcast(fb, containedBuffers, {1}, visibilityType);
+          sourceMask = arith::AndIOp::create(fb, sourceMask, visibilityBuffers);
+          sourceMask = arith::AndIOp::create(
+              fb, sourceMask,
+              createCTASetMask(fb, visibilityType, /*dim=*/0, effectCTAs));
+        }
         Value zeroVisibility =
             tti::createConstIntTensor(fb, fb.getLoc(), 0, visibilityType);
         Value source =
@@ -3051,11 +3130,20 @@ void FunctionBuilder::createTrackProxyAccessesCall(ImplicitLocOpBuilder &b,
             createCTASetMask(fb, trackingType, /*dim=*/2, barrierCTAs);
         Value trackMask =
             arith::AndIOp::create(fb, barriersEqBar, barrierCTAMask);
+        if (filterByBuffer) {
+          Value trackingBuffers =
+              convertAndBroadcast(fb, containedBuffers, {1}, trackingType);
+          trackMask = arith::AndIOp::create(fb, trackMask, trackingBuffers);
+          trackMask = arith::AndIOp::create(
+              fb, trackMask,
+              createCTASetMask(fb, trackingType, /*dim=*/0, effectCTAs));
+        }
         Value withSource = arith::OrIOp::create(fb, tracking, source);
         Value updated =
             arith::SelectOp::create(fb, trackMask, withSource, tracking);
+        Value storeMask = filterByBuffer ? trackMask : barrierCTAMask;
         createMaskedStoreScratchMemory(fb, fb.getLoc(), trackingPtr, updated,
-                                       trackingType, barrierCTAMask);
+                                       trackingType, storeMask);
 
         fb.setInsertionPointToEnd(thenBlock);
         triton::ReturnOp::create(fb);

--- a/lib/Dialect/TritonInstrument/IR/FunctionBuilder.cpp
+++ b/lib/Dialect/TritonInstrument/IR/FunctionBuilder.cpp
@@ -1477,8 +1477,9 @@ void FunctionBuilder::createUpdateBarrierStateCall(
 }
 
 void FunctionBuilder::createSetWriteVisibilityCall(
-    ImplicitLocOpBuilder &b, Value buf, uint32_t length, uint64_t threadMask,
-    Value pred, MemType memType, Operation *insertPoint, Value effectCTAs) {
+    ImplicitLocOpBuilder &b, MaterializedBufferRegion buffer,
+    uint64_t threadMask, Value pred, MemType memType, Operation *insertPoint,
+    Value effectCTAs) {
 
   if (auxData.buffers[(int)memType].empty() ||
       auxData.writeVisibility[(int)memType].empty()) {
@@ -1494,8 +1495,8 @@ void FunctionBuilder::createSetWriteVisibilityCall(
       auxData.writeVisibility[(int)memType].at(insertPoint).value;
   auto writeVisibilityType = cast<RankedTensorType>(
       auxData.writeVisibility[(int)memType].at(insertPoint).type);
-  Value bufOffset = tti::ExperimentalMemDescToI32Op::create(b, buf);
-  Value lengthVal = arith::ConstantIntOp::create(b, length, 32);
+  Value bufOffset = buffer.baseAddress;
+  Value lengthVal = arith::ConstantIntOp::create(b, buffer.length, 32);
   SmallVector<Value> args = {bufOffset,     lengthVal,  pred,
                              threadMaskVal, buffersVal, writeVisibilityVal,
                              effectCTAs};
@@ -1540,8 +1541,9 @@ void FunctionBuilder::createSetWriteVisibilityCall(
 }
 
 void FunctionBuilder::createSetReadVisibilityCall(
-    ImplicitLocOpBuilder &b, Value buf, uint32_t length, uint64_t threadMask,
-    Value pred, MemType memType, Operation *insertPoint, Value effectCTAs) {
+    ImplicitLocOpBuilder &b, MaterializedBufferRegion buffer,
+    uint64_t threadMask, Value pred, MemType memType, Operation *insertPoint,
+    Value effectCTAs) {
 
   if (auxData.buffers[(int)memType].empty() ||
       auxData.readVisibility[(int)memType].empty()) {
@@ -1557,8 +1559,8 @@ void FunctionBuilder::createSetReadVisibilityCall(
       auxData.readVisibility[(int)memType].at(insertPoint).value;
   auto readVisibilityType = cast<RankedTensorType>(
       auxData.readVisibility[(int)memType].at(insertPoint).type);
-  Value bufOffset = tti::ExperimentalMemDescToI32Op::create(b, buf);
-  Value lengthVal = arith::ConstantIntOp::create(b, length, 32);
+  Value bufOffset = buffer.baseAddress;
+  Value lengthVal = arith::ConstantIntOp::create(b, buffer.length, 32);
   SmallVector<Value> args = {bufOffset,     lengthVal,  pred,
                              threadMaskVal, buffersVal, readVisibilityVal,
                              effectCTAs};
@@ -1620,11 +1622,9 @@ void FunctionBuilder::createSetReadVisibilityCall(
       });
 }
 
-void FunctionBuilder::createClearWriteTrackingCall(ImplicitLocOpBuilder &b,
-                                                   Value buf, uint32_t length,
-                                                   Value pred, MemType memType,
-                                                   Operation *insertPoint,
-                                                   Value effectCTAs) {
+void FunctionBuilder::createClearWriteTrackingCall(
+    ImplicitLocOpBuilder &b, MaterializedBufferRegion buffer, Value pred,
+    MemType memType, Operation *insertPoint, Value effectCTAs) {
   if (auxData.buffers[(int)memType].empty() ||
       auxData.writeTracking[(int)memType].empty()) {
     return;
@@ -1638,8 +1638,8 @@ void FunctionBuilder::createClearWriteTrackingCall(ImplicitLocOpBuilder &b,
       auxData.writeTracking[(int)memType].at(insertPoint).value;
   auto writeTrackingType = cast<RankedTensorType>(
       auxData.writeTracking[(int)memType].at(insertPoint).type);
-  Value bufOffset = tti::ExperimentalMemDescToI32Op::create(b, buf);
-  Value lengthVal = arith::ConstantIntOp::create(b, length, 32);
+  Value bufOffset = buffer.baseAddress;
+  Value lengthVal = arith::ConstantIntOp::create(b, buffer.length, 32);
   SmallVector<Value> args = {bufOffset,  lengthVal,        pred,
                              buffersVal, writeTrackingVal, effectCTAs};
   createCallToCachedFunction(
@@ -1678,11 +1678,9 @@ void FunctionBuilder::createClearWriteTrackingCall(ImplicitLocOpBuilder &b,
       });
 }
 
-void FunctionBuilder::createClearReadVisibilityCall(ImplicitLocOpBuilder &b,
-                                                    Value buf, uint32_t length,
-                                                    Value pred, MemType memType,
-                                                    Operation *insertPoint,
-                                                    Value effectCTAs) {
+void FunctionBuilder::createClearReadVisibilityCall(
+    ImplicitLocOpBuilder &b, MaterializedBufferRegion buffer, Value pred,
+    MemType memType, Operation *insertPoint, Value effectCTAs) {
   if (auxData.buffers[(int)memType].empty() ||
       auxData.readVisibility[(int)memType].empty()) {
     return;
@@ -1696,8 +1694,8 @@ void FunctionBuilder::createClearReadVisibilityCall(ImplicitLocOpBuilder &b,
       auxData.readVisibility[(int)memType].at(insertPoint).value;
   auto readVisibilityType = cast<RankedTensorType>(
       auxData.readVisibility[(int)memType].at(insertPoint).type);
-  Value bufOffset = tti::ExperimentalMemDescToI32Op::create(b, buf);
-  Value lengthVal = arith::ConstantIntOp::create(b, length, 32);
+  Value bufOffset = buffer.baseAddress;
+  Value lengthVal = arith::ConstantIntOp::create(b, buffer.length, 32);
   SmallVector<Value> args = {bufOffset,  lengthVal,         pred,
                              buffersVal, readVisibilityVal, effectCTAs};
   createCallToCachedFunction(
@@ -1737,11 +1735,9 @@ void FunctionBuilder::createClearReadVisibilityCall(ImplicitLocOpBuilder &b,
       });
 }
 
-void FunctionBuilder::createClearReadTrackingCall(ImplicitLocOpBuilder &b,
-                                                  Value buf, uint32_t length,
-                                                  Value pred, MemType memType,
-                                                  Operation *insertPoint,
-                                                  Value effectCTAs) {
+void FunctionBuilder::createClearReadTrackingCall(
+    ImplicitLocOpBuilder &b, MaterializedBufferRegion buffer, Value pred,
+    MemType memType, Operation *insertPoint, Value effectCTAs) {
 
   if (auxData.buffers[(int)memType].empty() ||
       auxData.readTracking[(int)memType].empty()) {
@@ -1756,8 +1752,8 @@ void FunctionBuilder::createClearReadTrackingCall(ImplicitLocOpBuilder &b,
       auxData.readTracking[(int)memType].at(insertPoint).value;
   auto readTrackingType = cast<RankedTensorType>(
       auxData.readTracking[(int)memType].at(insertPoint).type);
-  Value bufOffset = tti::ExperimentalMemDescToI32Op::create(b, buf);
-  Value lengthVal = arith::ConstantIntOp::create(b, length, 32);
+  Value bufOffset = buffer.baseAddress;
+  Value lengthVal = arith::ConstantIntOp::create(b, buffer.length, 32);
   SmallVector<Value> args = {bufOffset,  lengthVal,       pred,
                              buffersVal, readTrackingVal, effectCTAs};
   createCallToCachedFunction(
@@ -1977,8 +1973,8 @@ void FunctionBuilder::createTrackVisibleReadsCall(ImplicitLocOpBuilder &b,
 }
 
 void FunctionBuilder::createTrackBarrierWriteForBufferCall(
-    ImplicitLocOpBuilder &b, Value mbar, Value buf, uint32_t length, Value pred,
-    MemType memType, Operation *insertPoint, Value barrierCTAs,
+    ImplicitLocOpBuilder &b, Value mbar, MaterializedBufferRegion buffer,
+    Value pred, MemType memType, Operation *insertPoint, Value barrierCTAs,
     Value effectCTAs) {
   if (auxData.barriers.empty() || auxData.buffers[(int)memType].empty() ||
       auxData.writeTracking[(int)memType].empty()) {
@@ -1999,8 +1995,8 @@ void FunctionBuilder::createTrackBarrierWriteForBufferCall(
   uint32_t mbarLength = getMemDescLength(mbar);
   Value mbarOffset = tti::ExperimentalMemDescToI32Op::create(b, mbar);
   Value mbarLengthVal = arith::ConstantIntOp::create(b, mbarLength, 32);
-  Value bufOffset = tti::ExperimentalMemDescToI32Op::create(b, buf);
-  Value bufLengthVal = arith::ConstantIntOp::create(b, length, 32);
+  Value bufOffset = buffer.baseAddress;
+  Value bufLengthVal = arith::ConstantIntOp::create(b, buffer.length, 32);
   SmallVector<Value> args = {mbarOffset, mbarLengthVal,    pred,
                              bufOffset,  bufLengthVal,     barriersVal,
                              buffersVal, writeTrackingVal, barrierCTAs,
@@ -2363,7 +2359,7 @@ void FunctionBuilder::createTransferVisibleReadsCall(
 }
 
 void FunctionBuilder::createVerifyWriteVisibilityCall(
-    ImplicitLocOpBuilder &b, Value buf, uint32_t length, int thread,
+    ImplicitLocOpBuilder &b, MaterializedBufferRegion buffer, int thread,
     StringRef operandName, Value pred, MemType memType, Operation *insertPoint,
     Value effectCTAs) {
   if (auxData.buffers[(int)memType].empty() ||
@@ -2382,8 +2378,8 @@ void FunctionBuilder::createVerifyWriteVisibilityCall(
       auxData.writeVisibility[(int)memType].at(insertPoint).value;
   auto writeVisibilityType = cast<RankedTensorType>(
       auxData.writeVisibility[(int)memType].at(insertPoint).type);
-  Value bufOffset = tti::ExperimentalMemDescToI32Op::create(b, buf);
-  Value lengthVal = arith::ConstantIntOp::create(b, length, 32);
+  Value bufOffset = buffer.baseAddress;
+  Value lengthVal = arith::ConstantIntOp::create(b, buffer.length, 32);
   std::string message = "Buffer being accessed has outstanding writes.";
   if (!operandName.empty())
     message += " Operand: " + operandName.str();
@@ -2468,7 +2464,7 @@ void FunctionBuilder::createVerifyWriteVisibilityCall(
 }
 
 void FunctionBuilder::createVerifyReadVisibilityCall(
-    ImplicitLocOpBuilder &b, Value buf, uint32_t length, int thread,
+    ImplicitLocOpBuilder &b, MaterializedBufferRegion buffer, int thread,
     StringRef operandName, Value pred, MemType memType, Operation *insertPoint,
     Value effectCTAs) {
   if (auxData.buffers[(int)memType].empty() ||
@@ -2487,8 +2483,8 @@ void FunctionBuilder::createVerifyReadVisibilityCall(
       auxData.readVisibility[(int)memType].at(insertPoint).value;
   auto readVisibilityType = cast<RankedTensorType>(
       auxData.readVisibility[(int)memType].at(insertPoint).type);
-  Value bufOffset = tti::ExperimentalMemDescToI32Op::create(b, buf);
-  Value lengthVal = arith::ConstantIntOp::create(b, length, 32);
+  Value bufOffset = buffer.baseAddress;
+  Value lengthVal = arith::ConstantIntOp::create(b, buffer.length, 32);
   std::string message = "Buffer being accessed has outstanding reads";
   if (!operandName.empty())
     message += ". Operand: " + operandName.str();
@@ -2805,7 +2801,7 @@ void FunctionBuilder::createPublishClusterVisibilityCall(
 }
 
 void FunctionBuilder::createSetProxyAccessCall(ImplicitLocOpBuilder &b,
-                                               Value buf, uint32_t length,
+                                               MaterializedBufferRegion buffer,
                                                int thread, Value pred,
                                                Operation *insertPoint,
                                                Value effectCTAs) {
@@ -2821,8 +2817,8 @@ void FunctionBuilder::createSetProxyAccessCall(ImplicitLocOpBuilder &b,
   auto visibilityType = cast<RankedTensorType>(visibility.type);
   bool hasTracking = !auxData.proxyAccessTracking.empty();
   RankedTensorType trackingType;
-  SmallVector<Value> args = {tti::ExperimentalMemDescToI32Op::create(b, buf),
-                             arith::ConstantIntOp::create(b, length, 32),
+  SmallVector<Value> args = {buffer.baseAddress,
+                             arith::ConstantIntOp::create(b, buffer.length, 32),
                              pred,
                              arith::ConstantIntOp::create(b, thread, 32),
                              buffers.value,
@@ -3192,7 +3188,7 @@ void FunctionBuilder::createClearBarrierProxyAccessTrackingCall(
 }
 
 void FunctionBuilder::createVerifyProxyAccessCall(
-    ImplicitLocOpBuilder &b, Value buf, uint32_t length, int thread,
+    ImplicitLocOpBuilder &b, MaterializedBufferRegion buffer, int thread,
     StringRef operandName, Value pred, Operation *insertPoint,
     Value effectCTAs) {
   auto &buffersMap = auxData.buffers[(int)MemType::SHARED_MEM];
@@ -3207,8 +3203,8 @@ void FunctionBuilder::createVerifyProxyAccessCall(
   ValueType visibility = auxData.proxyAccessVisibility.at(insertPoint);
   auto buffersType = cast<RankedTensorType>(buffers.type);
   auto visibilityType = cast<RankedTensorType>(visibility.type);
-  Value bufOffset = tti::ExperimentalMemDescToI32Op::create(b, buf);
-  Value lengthVal = arith::ConstantIntOp::create(b, length, 32);
+  Value bufOffset = buffer.baseAddress;
+  Value lengthVal = arith::ConstantIntOp::create(b, buffer.length, 32);
   Value threadVal = arith::ConstantIntOp::create(b, thread, 32);
   std::string message =
       "Async shared-memory access is missing fence_async_shared";
@@ -3371,8 +3367,9 @@ void FunctionBuilder::createPublishClusterProxyAccessesCall(
 }
 
 void FunctionBuilder::createStageAccessForCommitCall(
-    ImplicitLocOpBuilder &b, Value buf, uint32_t length, int thread, Value pred,
-    MemType memType, CommitKind::Kind commitKind, Operation *insertPoint) {
+    ImplicitLocOpBuilder &b, MaterializedBufferRegion buffer, int thread,
+    Value pred, MemType memType, CommitKind::Kind commitKind,
+    Operation *insertPoint) {
   if (auxData.buffers[(int)memType].empty() ||
       auxData.commits[commitKind].empty()) {
     return;
@@ -3384,8 +3381,8 @@ void FunctionBuilder::createStageAccessForCommitCall(
   auto buffersType = cast<RankedTensorType>(buffers.type);
   auto commitsType = cast<RankedTensorType>(outstandingCommits.type);
   Value threadVal = arith::ConstantIntOp::create(b, thread, 32);
-  Value bufOffset = tti::ExperimentalMemDescToI32Op::create(b, buf);
-  Value lengthVal = arith::ConstantIntOp::create(b, length, 32);
+  Value bufOffset = buffer.baseAddress;
+  Value lengthVal = arith::ConstantIntOp::create(b, buffer.length, 32);
   SmallVector<Value> args = {bufOffset,     lengthVal,
                              pred,          threadVal,
                              buffers.value, outstandingCommits.value};
@@ -3807,7 +3804,7 @@ void FunctionBuilder::createClearOutstandingCommitsTransferBothCall(
 }
 
 void FunctionBuilder::createCheckOutstandingCommitsCall(
-    ImplicitLocOpBuilder &b, Value buf, uint32_t length, int thread,
+    ImplicitLocOpBuilder &b, MaterializedBufferRegion buffer, int thread,
     StringRef pendingAccessType, Value pred, MemType memType,
     CommitKind::Kind commitKind, Operation *insertPoint, Value effectCTAs,
     bool excludeSelf) {
@@ -3821,13 +3818,13 @@ void FunctionBuilder::createCheckOutstandingCommitsCall(
   ValueType outstandingCommits = auxData.commits[commitKind].at(insertPoint);
   assert(thread < auxData.threadLayout.numBaseThreads &&
          "Commit-count tracking must operate on base threads");
-  Value bufOffset = tti::ExperimentalMemDescToI32Op::create(b, buf);
+  Value bufOffset = buffer.baseAddress;
   if (!pred)
     pred = arith::ConstantIntOp::create(b, 1, 1);
   auto buffersType = cast<RankedTensorType>(buffers.type);
   auto commitsType = cast<RankedTensorType>(outstandingCommits.type);
   Value threadVal = arith::ConstantIntOp::create(b, thread, 32);
-  Value lengthVal = arith::ConstantIntOp::create(b, length, 32);
+  Value lengthVal = arith::ConstantIntOp::create(b, buffer.length, 32);
   std::string message =
       "Accessing buffer with pending access. Pending access type: " +
       pendingAccessType.str();

--- a/lib/Dialect/TritonInstrument/IR/Utility.cpp
+++ b/lib/Dialect/TritonInstrument/IR/Utility.cpp
@@ -778,11 +778,10 @@ LogicalResult AuxDataMap::getBuffersAndBarriers(
   barrierRegions = analysis->getAllUsedBufferRegions(
       BufferRegionAnalysis::RegionType::BARRIER);
 
-  // Compiler-owned scratch buffers, such as convert_layout's temporary shared
-  // memory, have no SSA memdesc for BufferRegionAnalysis to discover. Collect
-  // their target-provided static regions from the same effects ConSan will
-  // instrument below. Merging them here also makes overlap with explicit
-  // buffers visible to the alias matrix.
+  // Compiler-owned operation scratch has no SSA memdesc for
+  // BufferRegionAnalysis to discover. Collect its allocator-provided static
+  // regions from the same effects ConSan will instrument below. Merging them
+  // here also makes overlap with explicit buffers visible to the alias matrix.
   if (hooks) {
     WalkResult result = module.walk([&](Operation *op) -> WalkResult {
       auto info = hooks->getMemEffectsOpInfo(op);

--- a/lib/Dialect/TritonInstrument/IR/Utility.cpp
+++ b/lib/Dialect/TritonInstrument/IR/Utility.cpp
@@ -706,8 +706,10 @@ LogicalResult AuxDataMap::populateAndPassToWarpSpecialize(
       arith::CmpIOp::create(b, arith::CmpIPredicate::eq, ctaId, zero);
   ExperimentalLockReleaseOp::create(b, lockVal, isCTA0);
   if (numCTAs > 1) {
-    auto clusterBarrier = ClusterBarrierOp::create(b, b.getLoc());
-    internalClusterBarriers.push_back(clusterBarrier.getOperation());
+    auto clusterBarriers = hooks->createInitClusterBarrier(b);
+    assert(!clusterBarriers.empty() &&
+           "target must provide a cluster initialization barrier");
+    llvm::append_range(internalClusterBarriers, clusterBarriers);
   } else {
     BarrierOp::create(b, b.getLoc(), AddrSpace::Local);
   }

--- a/lib/Dialect/TritonInstrument/IR/Utility.cpp
+++ b/lib/Dialect/TritonInstrument/IR/Utility.cpp
@@ -543,7 +543,7 @@ LogicalResult AuxDataMap::populateAndPassToWarpSpecialize(
     ModuleOp module, FunctionBuilder &fb, const ConSanTargetHooks *hooks) {
   SmallVector<SmallVector<BufferRegion>, numMemTypes> bufRegions(numMemTypes);
   SmallVector<BufferRegion> barrierRegions;
-  if (failed(getBuffersAndBarriers(module, bufRegions, barrierRegions)))
+  if (failed(getBuffersAndBarriers(module, bufRegions, barrierRegions, hooks)))
     return failure();
   int numCTAs = lookupNumCTAs(module);
   threadLayout = getThreadLayout(module, hooks);
@@ -762,7 +762,7 @@ LogicalResult AuxDataMap::populateAndPassToWarpSpecialize(
 
 LogicalResult AuxDataMap::getBuffersAndBarriers(
     ModuleOp module, SmallVector<SmallVector<BufferRegion>, 2> &bufRegions,
-    SmallVector<BufferRegion> &barrierRegions) {
+    SmallVector<BufferRegion> &barrierRegions, const ConSanTargetHooks *hooks) {
   // Collect shared memory buffers allocated in the module
   std::unique_ptr<DataFlowSolver> solver = createDataFlowSolver();
   triton::BufferRegionAnalysis *analysis =
@@ -778,8 +778,39 @@ LogicalResult AuxDataMap::getBuffersAndBarriers(
   barrierRegions = analysis->getAllUsedBufferRegions(
       BufferRegionAnalysis::RegionType::BARRIER);
 
+  // Compiler-owned scratch buffers, such as convert_layout's temporary shared
+  // memory, have no SSA memdesc for BufferRegionAnalysis to discover. Collect
+  // their target-provided static regions from the same effects ConSan will
+  // instrument below. Merging them here also makes overlap with explicit
+  // buffers visible to the alias matrix.
+  if (hooks) {
+    WalkResult result = module.walk([&](Operation *op) -> WalkResult {
+      auto info = hooks->getMemEffectsOpInfo(op);
+      if (failed(info))
+        return WalkResult::interrupt();
+      if (!*info)
+        return WalkResult::advance();
+      for (const auto &effect : (*info)->operandEffects) {
+        auto *staticBuffer =
+            std::get_if<MemEffectsOpInfo::Effects::StaticSharedBuffer>(
+                &effect.buffer);
+        if (!staticBuffer)
+          continue;
+        bufRegions[static_cast<int>(MemType::SHARED_MEM)].push_back(
+            staticBuffer->region);
+      }
+      return WalkResult::advance();
+    });
+    if (result.wasInterrupted())
+      return failure();
+  }
+
   for (MemType memType : {MemType::SHARED_MEM, MemType::TENSOR_MEM}) {
     int iMemType = (int)memType;
+    llvm::sort(bufRegions[iMemType]);
+    bufRegions[iMemType].erase(
+        std::unique(bufRegions[iMemType].begin(), bufRegions[iMemType].end()),
+        bufRegions[iMemType].end());
     if (bufRegions[iMemType].empty()) {
       continue;
     }

--- a/lib/Dialect/TritonInstrument/Transforms/CMakeLists.txt
+++ b/lib/Dialect/TritonInstrument/Transforms/CMakeLists.txt
@@ -10,6 +10,7 @@ add_triton_library(TritonInstrumentTransforms
   LINK_LIBS PUBLIC
   MLIRTransforms
   MLIRTransformUtils
+  TritonAnalysis
   TritonIR
   TritonGPUIR
   TritonNvidiaGPUIR

--- a/lib/Dialect/TritonInstrument/Transforms/ConcurrencySanitizer.cpp
+++ b/lib/Dialect/TritonInstrument/Transforms/ConcurrencySanitizer.cpp
@@ -508,6 +508,26 @@ Value getLocalLoadStoreRecipientCTAs(ImplicitLocOpBuilder &b,
 }
 
 Value getMemEffectCTAs(ImplicitLocOpBuilder &b, Operation *op) {
+  if (auto convert = dyn_cast<ttg::ConvertLayoutOp>(op)) {
+    // Convert-layout scratch has the source layout's CTA ownership. Stores are
+    // therefore local to the issuer, while loads may read the source scratch
+    // owned by peer CTAs. This block-level conversion matches the block
+    // mapping of the swizzled scratch layout used by lowering.
+    LinearLayout srcLayout = ttg::toLinearLayout(convert.getSrc().getType());
+    LinearLayout dstLayout = ttg::toLinearLayout(convert.getType());
+    Value loadCTAs = getLocalMemoryRecipientCTAs(
+        b, invertAndComposeBlockLocal(srcLayout, dstLayout));
+    return arith::OrIOp::create(b, currentCTAMask(b), loadCTAs);
+  }
+  if (auto reduce = dyn_cast<tt::ReduceOp>(op)) {
+    // Reduce lowering creates its scratch-backed conversions after ConSan.
+    // Intra-CTA reductions only access the issuer's scratch. Cross-CTA
+    // reductions are not currently expected after layout optimization, but
+    // conservatively cover the cluster if one reaches this pipeline stage.
+    if (!ReduceOpHelper(reduce).isReduceWithinCTA())
+      return allCTAsMask(b);
+    return currentCTAMask(b);
+  }
   if (auto load = dyn_cast<ttg::LocalLoadOp>(op)) {
     return getLocalLoadStoreRecipientCTAs(b, load.getSrc().getType(),
                                           load.getType());
@@ -587,7 +607,8 @@ public:
 
     ImplicitLocOpBuilder b(entryPoint.getLoc(), entryPoint);
     b.setInsertionPointToStart(&entryPoint.getBody().front());
-    instrumentMemoryOperations(b, funcBuilder);
+    if (failed(instrumentMemoryOperations(b, funcBuilder)))
+      return failure();
     initializeAllocations();
     return success();
   }
@@ -624,10 +645,10 @@ private:
     }
   }
 
-  void instrumentMemoryOperations(ImplicitLocOpBuilder &b,
-                                  tti::FunctionBuilder &funcBuilder) {
+  LogicalResult instrumentMemoryOperations(ImplicitLocOpBuilder &b,
+                                           tti::FunctionBuilder &funcBuilder) {
     SmallVector<ttng::ClusterBarrierOp> clusterBarriers;
-    module.walk([&](Operation *op) {
+    WalkResult walkResult = module.walk([&](Operation *op) -> WalkResult {
       CriticalSectionListener listener;
       b.setListener(&listener);
 
@@ -650,10 +671,13 @@ private:
         b.setListener(nullptr);
         instrumentBarrierWait(op, info->alloc, info->phase, info->pred, thread,
                               baseThread, funcBuilder);
-        return;
+        return WalkResult::advance();
       }
 
-      instrumentMemEffects(b, op, thread, funcBuilder);
+      if (failed(instrumentMemEffects(b, op, thread, funcBuilder))) {
+        b.setListener(nullptr);
+        return WalkResult::interrupt();
+      }
       b.setLoc(op->getLoc());
       if (auto info = hooks->getAsyncProxyFenceInfo(op)) {
         funcBuilder.createFenceProxyAccessesCall(
@@ -784,7 +808,10 @@ private:
 
       listener.maybeWrapWithCriticalSection(b, auxData, nullptr);
       b.setListener(nullptr);
+      return WalkResult::advance();
     });
+    if (walkResult.wasInterrupted())
+      return failure();
 
     // Cluster rendezvous polling introduces control-flow blocks, so add it
     // after the operation walk rather than invalidating the walk iterators.
@@ -798,6 +825,7 @@ private:
           b, auxData.getClusterBarrierSlot(op), baseThread,
           /*publishVisibility=*/!clusterBarrier.getRelaxed(), op);
     }
+    return success();
   }
 
   void instrumentBarrierWait(Operation *op, Value alloc, Value phase,
@@ -835,81 +863,99 @@ private:
     tti::ExperimentalLockReleaseOp::create(wb, lock, pred);
   }
 
-  void instrumentMemEffects(ImplicitLocOpBuilder &b, Operation *op, int thread,
-                            tti::FunctionBuilder &funcBuilder) {
+  LogicalResult instrumentMemEffects(ImplicitLocOpBuilder &b, Operation *op,
+                                     int thread,
+                                     tti::FunctionBuilder &funcBuilder) {
     int baseThread = getBaseThread(thread, auxData.threadLayout);
-    std::optional<MemEffectsOpInfo> opInfo = hooks->getMemEffectsOpInfo(op);
-    if (!opInfo) {
-      return;
-    }
+    auto opInfoResult = hooks->getMemEffectsOpInfo(op);
+    if (failed(opInfoResult))
+      return failure();
+    std::optional<MemEffectsOpInfo> opInfo = std::move(*opInfoResult);
+    if (!opInfo)
+      return success();
     Value pred = opInfo->pred;
     Value issuerCTAPred = hooks->getIssuerCTAPred(b, op);
     pred = tti::maybeAnd(b, pred, issuerCTAPred);
     Value effectCTAs = getMemEffectCTAs(b, op);
-    for (auto effect : opInfo->operandEffects) {
-      Value buf = effect.buf;
-      auto bufType = cast<ttg::MemDescType>(buf.getType());
-      MemType memType = MemType::TENSOR_MEM;
-      if (isa<ttg::SharedEncodingTrait>(bufType.getEncoding())) {
-        memType = MemType::SHARED_MEM;
+    struct MaterializedEffect {
+      tti::MaterializedBufferRegion buffer;
+      MemType memType;
+    };
+    SmallVector<MaterializedEffect> materializedEffects;
+    materializedEffects.reserve(opInfo->operandEffects.size());
+
+    for (const auto &effect : opInfo->operandEffects) {
+      MaterializedEffect materialized;
+      if (auto *buf = std::get_if<Value>(&effect.buffer)) {
+        auto bufType = cast<ttg::MemDescType>(buf->getType());
+        materialized.memType = MemType::TENSOR_MEM;
+        if (isa<ttg::SharedEncodingTrait>(bufType.getEncoding()))
+          materialized.memType = MemType::SHARED_MEM;
+        materialized.buffer = {tti::ExperimentalMemDescToI32Op::create(b, *buf),
+                               effect.length};
+      } else {
+        const auto &staticBuffer =
+            std::get<MemEffectsOpInfo::Effects::StaticSharedBuffer>(
+                effect.buffer);
+        materialized.memType = MemType::SHARED_MEM;
+        materialized.buffer = {
+            tti::ExperimentalSharedMemoryOffsetToI32Op::create(
+                b, b.getI32IntegerAttr(staticBuffer.region.baseOffset)),
+            staticBuffer.region.length};
       }
+      materializedEffects.push_back(materialized);
+
+      auto buffer = materialized.buffer;
+      MemType memType = materialized.memType;
       if (memType == MemType::SHARED_MEM) {
         if (effect.proxy == MemEffectsOpInfo::Effects::Proxy::Async) {
           funcBuilder.createVerifyProxyAccessCall(
-              b, buf, effect.length, baseThread, effect.operandName, pred, op,
-              effectCTAs);
+              b, buffer, baseThread, effect.operandName, pred, op, effectCTAs);
         } else {
-          funcBuilder.createSetProxyAccessCall(
-              b, buf, effect.length, baseThread, pred, op, effectCTAs);
+          funcBuilder.createSetProxyAccessCall(b, buffer, baseThread, pred, op,
+                                               effectCTAs);
         }
       }
       if (effect.rw == MemEffectsOpInfo::Effects::Read) {
         // For op that is reading, we only need to check if anything else
         // is writing to the same buffer.
-        addWriteChecks(b, funcBuilder, op, buf, effect.length, pred, memType,
-                       thread, effect.operandName, effectCTAs,
-                       opInfo->commitKind);
+        addWriteChecks(b, funcBuilder, op, buffer, pred, memType, thread,
+                       effect.operandName, effectCTAs, opInfo->commitKind);
         if (opInfo->trackingKind == MemEffectsOpInfo::TrackingKind::Barrier) {
           funcBuilder.createSetReadVisibilityCall(
-              b, buf, effect.length,
-              getThreadPeersMask(thread, auxData.threadLayout), pred, memType,
-              op, effectCTAs);
+              b, buffer, getThreadPeersMask(thread, auxData.threadLayout), pred,
+              memType, op, effectCTAs);
         }
         if (opInfo->trackingKind ==
             MemEffectsOpInfo::TrackingKind::CommitCount) {
           assert(memType == MemType::SHARED_MEM);
-          funcBuilder.createStageAccessForCommitCall(b, buf, effect.length,
-                                                     baseThread, pred, memType,
-                                                     opInfo->commitKind, op);
+          funcBuilder.createStageAccessForCommitCall(
+              b, buffer, baseThread, pred, memType, opInfo->commitKind, op);
         }
       }
       if (effect.rw == MemEffectsOpInfo::Effects::Write) {
         // Op is writing to the buffer, we need to check if anything else
         // is reading or writing to the same buffer.
-        addWriteChecks(b, funcBuilder, op, buf, effect.length, pred, memType,
-                       thread, effect.operandName, effectCTAs,
-                       opInfo->commitKind);
-        addReadChecks(b, funcBuilder, op, buf, effect.length, pred, memType,
-                      thread, effect.operandName, effectCTAs,
-                      opInfo->commitKind);
+        addWriteChecks(b, funcBuilder, op, buffer, pred, memType, thread,
+                       effect.operandName, effectCTAs, opInfo->commitKind);
+        addReadChecks(b, funcBuilder, op, buffer, pred, memType, thread,
+                      effect.operandName, effectCTAs, opInfo->commitKind);
         if (opInfo->trackingKind == MemEffectsOpInfo::TrackingKind::Barrier) {
           funcBuilder.createSetWriteVisibilityCall(
-              b, buf, effect.length,
-              getThreadPeersMask(thread, auxData.threadLayout), pred, memType,
-              op, effectCTAs);
-          funcBuilder.createClearWriteTrackingCall(b, buf, effect.length, pred,
-                                                   memType, op, effectCTAs);
-          funcBuilder.createClearReadVisibilityCall(b, buf, effect.length, pred,
-                                                    memType, op, effectCTAs);
-          funcBuilder.createClearReadTrackingCall(b, buf, effect.length, pred,
-                                                  memType, op, effectCTAs);
+              b, buffer, getThreadPeersMask(thread, auxData.threadLayout), pred,
+              memType, op, effectCTAs);
+          funcBuilder.createClearWriteTrackingCall(b, buffer, pred, memType, op,
+                                                   effectCTAs);
+          funcBuilder.createClearReadVisibilityCall(b, buffer, pred, memType,
+                                                    op, effectCTAs);
+          funcBuilder.createClearReadTrackingCall(b, buffer, pred, memType, op,
+                                                  effectCTAs);
         }
         if (opInfo->trackingKind ==
             MemEffectsOpInfo::TrackingKind::CommitCount) {
           assert(memType == MemType::SHARED_MEM);
-          funcBuilder.createStageAccessForCommitCall(b, buf, effect.length,
-                                                     baseThread, pred, memType,
-                                                     opInfo->commitKind, op);
+          funcBuilder.createStageAccessForCommitCall(
+              b, buffer, baseThread, pred, memType, opInfo->commitKind, op);
         }
       }
     }
@@ -933,16 +979,13 @@ private:
             b, barrier, baseThread, combinedPred, op, recipientCTAs);
       } else if (barrierInfo.trackingMode ==
                  MemEffectsOpInfo::BarrierTrackingMode::EffectWrites) {
-        for (const auto &effect : opInfo->operandEffects) {
+        for (auto [effect, materialized] :
+             llvm::zip(opInfo->operandEffects, materializedEffects)) {
           if (effect.rw != MemEffectsOpInfo::Effects::Write)
             continue;
-          auto bufType = cast<ttg::MemDescType>(effect.buf.getType());
-          MemType memType = MemType::TENSOR_MEM;
-          if (isa<ttg::SharedEncodingTrait>(bufType.getEncoding()))
-            memType = MemType::SHARED_MEM;
           funcBuilder.createTrackBarrierWriteForBufferCall(
-              b, barrier, effect.buf, effect.length, combinedPred, memType, op,
-              recipientCTAs, effectCTAs);
+              b, barrier, materialized.buffer, combinedPred,
+              materialized.memType, op, recipientCTAs, effectCTAs);
         }
       }
       if (barrierInfo.count > 0 || barrierInfo.txCount != 0) {
@@ -960,16 +1003,17 @@ private:
       funcBuilder.createCommitAccessesCall(b, baseThread, pred,
                                            opInfo->commitKind, op);
     }
+    return success();
   }
 
   void addWriteChecks(ImplicitLocOpBuilder &b,
                       tti::FunctionBuilder &funcBuilder, Operation *op,
-                      Value buf, uint32_t length, Value pred, MemType memType,
-                      int thread, const std::string &operandName,
-                      Value effectCTAs,
+                      tti::MaterializedBufferRegion buffer, Value pred,
+                      MemType memType, int thread,
+                      const std::string &operandName, Value effectCTAs,
                       CommitKind::Kind opCommitKind = CommitKind::None) {
-    funcBuilder.createVerifyWriteVisibilityCall(
-        b, buf, length, thread, operandName, pred, memType, op, effectCTAs);
+    funcBuilder.createVerifyWriteVisibilityCall(b, buffer, thread, operandName,
+                                                pred, memType, op, effectCTAs);
     // commit-num-based synchronization is only supported for shared memory
     if (memType == MemType::SHARED_MEM) {
       for (const auto &commitKindDesc :
@@ -977,7 +1021,7 @@ private:
         bool excludeSelf = (opCommitKind == commitKindDesc.kind &&
                             hooks->isOrderedCommitKind(opCommitKind));
         funcBuilder.createCheckOutstandingCommitsCall(
-            b, buf, length, getBaseThread(thread, auxData.threadLayout),
+            b, buffer, getBaseThread(thread, auxData.threadLayout),
             commitKindDesc.operationDesc, pred, memType, commitKindDesc.kind,
             op, effectCTAs, excludeSelf);
       }
@@ -985,12 +1029,12 @@ private:
   }
 
   void addReadChecks(ImplicitLocOpBuilder &b, tti::FunctionBuilder &funcBuilder,
-                     Operation *op, Value buf, uint32_t length, Value pred,
-                     MemType memType, int thread,
+                     Operation *op, tti::MaterializedBufferRegion buffer,
+                     Value pred, MemType memType, int thread,
                      const std::string &operandName, Value effectCTAs,
                      CommitKind::Kind opCommitKind = CommitKind::None) {
-    funcBuilder.createVerifyReadVisibilityCall(
-        b, buf, length, thread, operandName, pred, memType, op, effectCTAs);
+    funcBuilder.createVerifyReadVisibilityCall(b, buffer, thread, operandName,
+                                               pred, memType, op, effectCTAs);
     // commit-num-based synchronization is only supported for shared memory
     if (memType == MemType::SHARED_MEM) {
       for (const auto &commitKindDesc :
@@ -998,7 +1042,7 @@ private:
         bool excludeSelf = (opCommitKind == commitKindDesc.kind &&
                             hooks->isOrderedCommitKind(opCommitKind));
         funcBuilder.createCheckOutstandingCommitsCall(
-            b, buf, length, getBaseThread(thread, auxData.threadLayout),
+            b, buffer, getBaseThread(thread, auxData.threadLayout),
             commitKindDesc.operationDesc, pred, memType, commitKindDesc.kind,
             op, effectCTAs, excludeSelf);
       }

--- a/lib/Dialect/TritonInstrument/Transforms/ConcurrencySanitizer.cpp
+++ b/lib/Dialect/TritonInstrument/Transforms/ConcurrencySanitizer.cpp
@@ -1,6 +1,7 @@
 #include "mlir/Analysis/SliceAnalysis.h"
 #include "mlir/IR/ImplicitLocOpBuilder.h"
 #include "mlir/Transforms/Passes.h"
+#include "triton/Analysis/Utility.h"
 #include "triton/Dialect/Triton/IR/Utility.h"
 #include "triton/Dialect/TritonGPU/IR/Dialect.h"
 #include "triton/Dialect/TritonGPU/IR/LinearLayoutConversions.h"

--- a/lib/Dialect/TritonInstrument/Transforms/ConcurrencySanitizer.cpp
+++ b/lib/Dialect/TritonInstrument/Transforms/ConcurrencySanitizer.cpp
@@ -998,6 +998,12 @@ private:
           funcBuilder.createTrackBarrierWriteForBufferCall(
               b, barrier, materialized.buffer, combinedPred,
               materialized.memType, op, recipientCTAs, effectCTAs);
+          if (materialized.memType == MemType::SHARED_MEM &&
+              effect.proxy == MemEffectsOpInfo::Effects::Proxy::Async) {
+            funcBuilder.createTrackProxyAccessesForBufferCall(
+                b, barrier, materialized.buffer, baseThread, combinedPred, op,
+                recipientCTAs, effectCTAs);
+          }
         }
       }
       if (barrierInfo.count > 0 || barrierInfo.txCount != 0) {

--- a/lib/Dialect/TritonInstrument/Transforms/ConcurrencySanitizer.cpp
+++ b/lib/Dialect/TritonInstrument/Transforms/ConcurrencySanitizer.cpp
@@ -507,7 +507,8 @@ Value getLocalLoadStoreRecipientCTAs(ImplicitLocOpBuilder &b,
       b, getLocalLoadStoreConversion(memDescTy, regTy));
 }
 
-Value getMemEffectCTAs(ImplicitLocOpBuilder &b, Operation *op) {
+Value getMemEffectCTAs(ImplicitLocOpBuilder &b, Operation *op,
+                       const ConSanTargetHooks *hooks) {
   if (auto convert = dyn_cast<ttg::ConvertLayoutOp>(op)) {
     // Convert-layout scratch has the source layout's CTA ownership. Stores are
     // therefore local to the issuer, while loads may read the source scratch
@@ -552,11 +553,21 @@ Value getMemEffectCTAs(ImplicitLocOpBuilder &b, Operation *op) {
                                            scatter.getAxis()));
   }
   if (auto atomic = dyn_cast<ttg::LocalAtomicScatterRMWOp>(op)) {
-    return getLocalMemoryRecipientCTAs(
+    Value recipients = getLocalMemoryRecipientCTAs(
         b, getLocalGatherScatterConversion(atomic.getDst().getType(),
                                            atomic.getValues().getType(),
                                            atomic.getAxis()));
+    if (auto mask = hooks->getScratchCTABroadcastMask(op)) {
+      Value scratchRecipients =
+          *mask ? getRecipientCTAsForBroadcastMasks(b, {*mask})
+                : currentCTAMask(b);
+      recipients = arith::OrIOp::create(b, recipients, scratchRecipients);
+    }
+    return recipients;
   }
+  if (auto mask = hooks->getScratchCTABroadcastMask(op))
+    return *mask ? getRecipientCTAsForBroadcastMasks(b, {*mask})
+                 : currentCTAMask(b);
   if (auto tmaLoad = dyn_cast<ttng::TMALoadLikeOpInterface>(op)) {
     if (tmaLoad.getMulticast())
       return getMulticastRecipientCTAs(b, tmaLoad.getResult());
@@ -876,7 +887,7 @@ private:
     Value pred = opInfo->pred;
     Value issuerCTAPred = hooks->getIssuerCTAPred(b, op);
     pred = tti::maybeAnd(b, pred, issuerCTAPred);
-    Value effectCTAs = getMemEffectCTAs(b, op);
+    Value effectCTAs = getMemEffectCTAs(b, op, hooks);
     struct MaterializedEffect {
       tti::MaterializedBufferRegion buffer;
       MemType memType;

--- a/lib/Dialect/TritonInstrument/Transforms/PrepareConSanCaptures.cpp
+++ b/lib/Dialect/TritonInstrument/Transforms/PrepareConSanCaptures.cpp
@@ -1,8 +1,6 @@
 #include "triton/Dialect/TritonInstrument/Transforms/Passes.h"
 
 #include "mlir/IR/BuiltinTypes.h"
-#include "triton/Analysis/Utility.h"
-#include "triton/Dialect/Triton/IR/Dialect.h"
 #include "triton/Dialect/TritonGPU/IR/Dialect.h"
 #include "triton/Dialect/TritonInstrument/IR/Utility.h"
 #include "triton/Dialect/TritonInstrument/Transforms/ConSanTargetHooks.h"
@@ -26,17 +24,12 @@ namespace tti = mlir::triton::instrument;
 bool hasSharedMemoryBuffers(ModuleOp mod) {
   bool result = false;
   mod.walk([&](ttg::LocalAllocOp op) { result |= op.isSharedMemoryAlloc(); });
-  mod.walk([&](ttg::ConvertLayoutOp op) {
-    auto func = op->getParentOfType<mlir::triton::FuncOp>();
-    bool forceWarpShuffle =
-        func && func->hasAttrOfType<UnitAttr>("always_use_warp_shuffle") &&
-        cvtCanUseWarpShuffle(op.getSrc().getType(), op.getType());
-    result |= !forceWarpShuffle &&
-              cvtNeedsSharedMemory(op.getSrc().getType(), op.getType());
-  });
-  mod.walk([&](mlir::triton::ReduceOp op) {
-    result |= ReduceOpHelper(op).getScratchSizeInBytes() != 0;
-  });
+  // ConSan always passes its lock pointer to warp-specialized regions. That
+  // capture is itself operation-local shared scratch, which makes shared
+  // memory active and requires the read/write visibility captures too. Treat
+  // every warp-specialized kernel as the stable fixed point (three captures),
+  // independent of which user or compiler scratch operations it contains.
+  mod.walk([&](ttg::WarpSpecializeOp) { result = true; });
   return result;
 }
 

--- a/lib/Dialect/TritonInstrument/Transforms/PrepareConSanCaptures.cpp
+++ b/lib/Dialect/TritonInstrument/Transforms/PrepareConSanCaptures.cpp
@@ -1,6 +1,7 @@
 #include "triton/Dialect/TritonInstrument/Transforms/Passes.h"
 
 #include "mlir/IR/BuiltinTypes.h"
+#include "triton/Analysis/Utility.h"
 #include "triton/Dialect/Triton/IR/Dialect.h"
 #include "triton/Dialect/TritonGPU/IR/Dialect.h"
 #include "triton/Dialect/TritonInstrument/IR/Utility.h"
@@ -25,6 +26,17 @@ namespace tti = mlir::triton::instrument;
 bool hasSharedMemoryBuffers(ModuleOp mod) {
   bool result = false;
   mod.walk([&](ttg::LocalAllocOp op) { result |= op.isSharedMemoryAlloc(); });
+  mod.walk([&](ttg::ConvertLayoutOp op) {
+    auto func = op->getParentOfType<mlir::triton::FuncOp>();
+    bool forceWarpShuffle =
+        func && func->hasAttrOfType<UnitAttr>("always_use_warp_shuffle") &&
+        cvtCanUseWarpShuffle(op.getSrc().getType(), op.getType());
+    result |= !forceWarpShuffle &&
+              cvtNeedsSharedMemory(op.getSrc().getType(), op.getType());
+  });
+  mod.walk([&](mlir::triton::ReduceOp op) {
+    result |= ReduceOpHelper(op).getScratchSizeInBytes() != 0;
+  });
   return result;
 }
 
@@ -94,15 +106,15 @@ public:
       return signalPassFailure();
     }
 
-    int numActiveMemTypes = (hasSharedMemoryBuffers(mod) ? 1 : 0) +
-                            (hasTensorMemoryBuffers(mod) ? 1 : 0);
+    bool hasSharedBuffers = hasSharedMemoryBuffers(mod);
+    int numActiveMemTypes =
+        (hasSharedBuffers ? 1 : 0) + (hasTensorMemoryBuffers(mod) ? 1 : 0);
     // NVIDIA inserts a terminal cluster barrier after this pass.
     bool hasClusterBarriers = target == "nvidia" && ttg::lookupNumCTAs(mod) > 1;
     int totalCaptures = tti::estimateConSanCaptureCount(
         numActiveMemTypes, hasBarriers(mod), hasClusterBarriers,
         getNumCommitKinds(mod, hooks.get()),
-        hasSharedMemoryBuffers(mod) &&
-            hooks->needsAsyncProxyFenceTracking(mod));
+        hasSharedBuffers && hooks->needsAsyncProxyFenceTracking(mod));
     int extraBytes = totalCaptures * tti::kCaptureSizeBytes;
 
     auto i32Ty = IntegerType::get(mod.getContext(), 32);

--- a/lib/Dialect/TritonNvidiaGPU/Transforms/ConSanNVIDIA.cpp
+++ b/lib/Dialect/TritonNvidiaGPU/Transforms/ConSanNVIDIA.cpp
@@ -138,9 +138,12 @@ public:
     return getLeaderCTAPredicate(b, mask);
   }
 
-  std::optional<MemEffectsOpInfo>
+  FailureOr<std::optional<MemEffectsOpInfo>>
   getMemEffectsOpInfo(Operation *op) const override {
-    auto info = ConSanTargetHooks::getMemEffectsOpInfo(op);
+    auto baseInfo = ConSanTargetHooks::getMemEffectsOpInfo(op);
+    if (failed(baseInfo))
+      return failure();
+    auto info = std::move(*baseInfo);
     if (info)
       return info;
     if (auto expectOp = dyn_cast<ttng::BarrierExpectOp>(op)) {

--- a/lib/Dialect/TritonNvidiaGPU/Transforms/ConSanNVIDIA.cpp
+++ b/lib/Dialect/TritonNvidiaGPU/Transforms/ConSanNVIDIA.cpp
@@ -155,6 +155,11 @@ public:
     return getLeaderCTAPredicate(b, mask);
   }
 
+  SmallVector<Operation *>
+  createInitClusterBarrier(ImplicitLocOpBuilder &b) const override {
+    return {ClusterBarrierOp::create(b, b.getLoc()).getOperation()};
+  }
+
   std::optional<uint16_t>
   getScratchCTABroadcastMask(Operation *op) const override {
     return getAtomicScratchBroadcastMask(op);

--- a/lib/Dialect/TritonNvidiaGPU/Transforms/ConSanNVIDIA.cpp
+++ b/lib/Dialect/TritonNvidiaGPU/Transforms/ConSanNVIDIA.cpp
@@ -35,6 +35,21 @@ uint32_t getBlockBroadcastMask(Type type) {
   return toLinearLayout(memDescTy).getFreeVariableMasks().lookup(kBlock);
 }
 
+std::optional<uint16_t> getAtomicScratchBroadcastMask(Operation *op) {
+  if (!op->hasAttr("allocation.size") ||
+      !isa<AtomicPollOp, AtomicRMWOp, AtomicCASOp, ttg::LocalAtomicScatterRMWOp,
+           tti::ExperimentalGSanAtomicRMWOp, tti::ExperimentalGSanAtomicCASOp>(
+          op))
+    return std::nullopt;
+
+  Type resultTy = op->getResult(0).getType();
+  if (auto tensorTy = dyn_cast<RankedTensorType>(resultTy)) {
+    auto kBlock = StringAttr::get(op->getContext(), "block");
+    return ttg::toLinearLayout(tensorTy).getFreeVariableMasks().lookup(kBlock);
+  }
+  return static_cast<uint16_t>(ttg::lookupNumCTAs(op) - 1);
+}
+
 } // namespace
 
 class NVIDIAConSanHooks : public tti::ConSanTargetHooks {
@@ -121,6 +136,8 @@ public:
     }
     if (auto storeOp = dyn_cast<ttng::TMAStoreLikeOpInterface>(op))
       mask = getBlockBroadcastMask(storeOp.getSrc().getType());
+    if (auto scratchMask = getAtomicScratchBroadcastMask(op))
+      mask = *scratchMask;
     if (isa<ttng::CLCTryCancelOp>(op) && ttg::lookupNumCTAs(op) > 1) {
       Value ctaId = tti::ExperimentalClusterCTAIdOp::create(b, b.getLoc());
       return arith::CmpIOp::create(b, arith::CmpIPredicate::eq, ctaId,
@@ -136,6 +153,11 @@ public:
     if (!mask)
       return nullptr;
     return getLeaderCTAPredicate(b, mask);
+  }
+
+  std::optional<uint16_t>
+  getScratchCTABroadcastMask(Operation *op) const override {
+    return getAtomicScratchBroadcastMask(op);
   }
 
   FailureOr<std::optional<MemEffectsOpInfo>>

--- a/python/test/gluon/test_consan.py
+++ b/python/test/gluon/test_consan.py
@@ -1041,6 +1041,78 @@ def test_tma_store(FAILURE, device, run_wrapper, monkeypatch, num_ctas):
     kernel[(1, )](output_desc, FAILURE=FAILURE, num_warps=4, num_ctas=num_ctas)
 
 
+@pytest.mark.skipif(not is_cuda() or torch.cuda.get_device_capability()[0] < 9, reason="Requires Hopper or newer")
+@pytest.mark.parametrize(
+    "FAILURE",
+    [pytest.param(True, id="reused-pending-source"), pytest.param(False, id="stable-source")],
+)
+def test_tma_store_convert_layout_scratch(FAILURE, device, run_wrapper, monkeypatch):
+    if run_wrapper:
+        result = run_in_process(test_tma_store_convert_layout_scratch, (FAILURE, device, False, monkeypatch))
+        if FAILURE:
+            assert_expected_cuda_failure(result.exc)
+            assert "Accessing buffer with pending access. Pending access type: async_copy_shared_to_global" in result.driver_stderr_output
+        else:
+            assert result.exc is None
+            assert result.driver_stderr_output == ""
+        return
+
+    monkeypatch.setenv("TRITON_INSTRUMENTATION_MODE", "consan")
+    monkeypatch.setenv("CUDA_LAUNCH_BLOCKING", "1")
+    knobs.refresh_knobs()
+
+    @gluon.jit
+    def kernel(output_desc, input, sink, iterations, FAILURE: ttgl.constexpr):
+        src_layout: ttgl.constexpr = ttgl.BlockedLayout([1], [32], [4], [0])
+        dst_layout: ttgl.constexpr = ttgl.SliceLayout(
+            1, ttgl.BlockedLayout([1, 1], [1, 32], [1, 4], [1, 0]))
+        src_offsets = ttgl.arange(0, 128, layout=src_layout)
+        dst_offsets = ttgl.arange(0, 128, layout=dst_layout)
+        persistent_page = ttgl.allocate_shared_memory(ttgl.int32, [128], output_desc.layout)
+        if not FAILURE:
+            stable_source_page = ttgl.allocate_shared_memory(ttgl.int32, [128], output_desc.layout)
+
+        for iteration in range(iterations):
+            base = iteration * 128
+
+            # On iteration 1, the conversion scratch aliases iteration 0's
+            # deallocated source while its TMA read can still be pending.
+            value = ttgl.load(input + base + src_offsets)
+            converted = ttgl.convert_layout(value, dst_layout)
+            ttgl.store(sink + base + dst_offsets, converted)
+
+            # Keep one unrelated store pending so wait(1) does not complete the
+            # source transfer below.
+            tma.store_wait(1)
+            persistent_page.store(value)
+            hopper.fence_async_shared()
+            tma.async_copy_shared_to_global(output_desc, [2 * base], persistent_page)
+
+            tma.store_wait(1)
+            if FAILURE:
+                source_page = ttgl.allocate_shared_memory(ttgl.int32, [128], output_desc.layout, value)
+            else:
+                stable_source_page.store(value)
+                source_page = stable_source_page
+            hopper.fence_async_shared()
+            tma.async_copy_shared_to_global(output_desc, [2 * base + 128], source_page)
+            if FAILURE:
+                source_page._keep_alive()
+
+        tma.store_wait(0)
+        persistent_page._keep_alive()
+        if not FAILURE:
+            stable_source_page._keep_alive()
+
+    iterations = 2
+    output = torch.empty(iterations * 2 * 128, dtype=torch.int32, device=device)
+    input = torch.arange(iterations * 128, dtype=torch.int32, device=device)
+    sink = torch.empty_like(input)
+    shared_layout = ttgl.NVMMASharedLayout.get_default_for([128], ttgl.int32)
+    output_desc = gluon.nvidia.hopper.TensorDescriptor.from_tensor(output, [128], shared_layout)
+    kernel[(1, )](output_desc, input, sink, iterations, FAILURE=FAILURE, num_warps=4)
+
+
 @pytest.mark.skipif(not is_cuda() or torch.cuda.get_device_capability()[0] < 10, reason="Requires blackwell or newer")
 @pytest.mark.parametrize("FAILURE", [True, False])
 @pytest.mark.parametrize("MEM_ACCESS_KIND", ["tma_cp", "local_store", "tmem_load", "tmem_store"])

--- a/python/test/gluon/test_consan.py
+++ b/python/test/gluon/test_consan.py
@@ -1044,7 +1044,8 @@ def test_tma_store(FAILURE, device, run_wrapper, monkeypatch, num_ctas):
 @pytest.mark.skipif(not is_cuda() or torch.cuda.get_device_capability()[0] < 9, reason="Requires Hopper or newer")
 @pytest.mark.parametrize(
     "FAILURE",
-    [pytest.param(True, id="reused-pending-source"), pytest.param(False, id="stable-source")],
+    [pytest.param(True, id="reused-pending-source"),
+     pytest.param(False, id="stable-source")],
 )
 def test_tma_store_convert_layout_scratch(FAILURE, device, run_wrapper, monkeypatch):
     if run_wrapper:
@@ -1064,8 +1065,7 @@ def test_tma_store_convert_layout_scratch(FAILURE, device, run_wrapper, monkeypa
     @gluon.jit
     def kernel(output_desc, input, sink, iterations, FAILURE: ttgl.constexpr):
         src_layout: ttgl.constexpr = ttgl.BlockedLayout([1], [32], [4], [0])
-        dst_layout: ttgl.constexpr = ttgl.SliceLayout(
-            1, ttgl.BlockedLayout([1, 1], [1, 32], [1, 4], [1, 0]))
+        dst_layout: ttgl.constexpr = ttgl.SliceLayout(1, ttgl.BlockedLayout([1, 1], [1, 32], [1, 4], [1, 0]))
         src_offsets = ttgl.arange(0, 128, layout=src_layout)
         dst_offsets = ttgl.arange(0, 128, layout=dst_layout)
         persistent_page = ttgl.allocate_shared_memory(ttgl.int32, [128], output_desc.layout)

--- a/test/Conversion/allocate_shared_memory.mlir
+++ b/test/Conversion/allocate_shared_memory.mlir
@@ -1,4 +1,4 @@
-// RUN: triton-opt %s --allocate-shared-memory | FileCheck %s
+// RUN: triton-opt %s -split-input-file --allocate-shared-memory | FileCheck %s
 
 #blocked = #ttg.blocked<{sizePerThread = [1, 1], threadsPerWarp = [32, 1], warpsPerCTA = [2, 2], order = [1, 0]}>
 
@@ -11,6 +11,43 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32} {
 tt.func @gather_op(%arg0: tensor<1024x256xi32, #blocked>, %arg1: tensor<128x256xf32, #blocked>) {
   // CHECK-NEXT: allocation.offset = 0 : i32
   %0 = tt.gather %arg1[%arg0] {axis = 0 : i32} : (tensor<128x256xf32, #blocked>, tensor<1024x256xi32, #blocked>) -> tensor<1024x256xf32, #blocked>
+  tt.return
+}
+
+}
+
+// -----
+
+#reduce = #ttg.blocked<{sizePerThread = [1, 2], threadsPerWarp = [1, 32], warpsPerCTA = [1, 4], order = [1, 0]}>
+
+module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32} {
+
+// CHECK-LABEL: @reduce_scratch_size
+tt.func @reduce_scratch_size(%arg0: tensor<1x256xf32, #reduce>) {
+  // CHECK: "tt.reduce"
+  // CHECK: }) {allocation.offset = 0 : i32, allocation.size = 16 : i32}
+  %0 = "tt.reduce"(%arg0) <{axis = 1 : i32}> ({
+  ^bb0(%lhs: f32, %rhs: f32):
+    %sum = arith.addf %lhs, %rhs : f32
+    tt.reduce.return %sum : f32
+  }) : (tensor<1x256xf32, #reduce>) -> tensor<1xf32, #ttg.slice<{dim = 1, parent = #reduce}>>
+  tt.return
+}
+
+}
+
+// -----
+
+#src = #ttg.blocked<{sizePerThread = [1], threadsPerWarp = [32], warpsPerCTA = [4], order = [0]}>
+#dst_parent = #ttg.blocked<{sizePerThread = [1, 1], threadsPerWarp = [1, 32], warpsPerCTA = [1, 4], order = [1, 0]}>
+#dst = #ttg.slice<{dim = 1, parent = #dst_parent}>
+
+module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32} {
+
+// CHECK-LABEL: @convert_layout_scratch_size
+tt.func @convert_layout_scratch_size(%arg0: tensor<128xi32, #src>) {
+  // CHECK: ttg.convert_layout {{.*}} {allocation.offset = 0 : i32, allocation.size = 512 : i32}
+  %0 = ttg.convert_layout %arg0 : tensor<128xi32, #src> -> tensor<128xi32, #dst>
   tt.return
 }
 

--- a/test/Conversion/allocate_shared_memory.mlir
+++ b/test/Conversion/allocate_shared_memory.mlir
@@ -9,8 +9,80 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32} {
 // CHECK-LABEL: @gather_op
 // TODO(jeff): Optimize the lowering to reduce shared memory usage.
 tt.func @gather_op(%arg0: tensor<1024x256xi32, #blocked>, %arg1: tensor<128x256xf32, #blocked>) {
-  // CHECK-NEXT: allocation.offset = 0 : i32
+  // CHECK-NEXT: allocation.offset = 0 : i32, allocation.size = 131072 : i32
   %0 = tt.gather %arg1[%arg0] {axis = 0 : i32} : (tensor<128x256xf32, #blocked>, tensor<1024x256xi32, #blocked>) -> tensor<1024x256xf32, #blocked>
+  tt.return
+}
+
+}
+
+// -----
+
+#atomic_blocked = #ttg.blocked<{sizePerThread = [1], threadsPerWarp = [32], warpsPerCTA = [4], order = [0]}>
+#atomic_shared = #ttg.swizzled_shared<{vec = 1, perPhase = 1, maxPhase = 1, order = [0]}>
+#atomic_smem = #ttg.shared_memory
+
+// CHECK-LABEL: module
+// CHECK-SAME: ttg.shared = 132 : i32
+module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32} {
+
+// CHECK-LABEL: @local_atomic_scratch_size
+tt.func @local_atomic_scratch_size(
+    %indices: tensor<1xi32, #atomic_blocked>,
+    %values: tensor<1xi32, #atomic_blocked>,
+    %out: tensor<1x!tt.ptr<i32>, #atomic_blocked>) {
+  // CHECK: %[[ATOMIC_DST:.*]] = ttg.local_alloc {allocation.offset = 0 : i32}
+  %dst = ttg.local_alloc
+      : () -> !ttg.memdesc<1xi32, #atomic_shared, #atomic_smem, mutable>
+  // CHECK: ttg.local_atomic_scatter_rmw {{.*}} {allocation.offset = 128 : i32, allocation.size = 4 : i32, axis = 0 : i32}
+  %old = ttg.local_atomic_scatter_rmw add, %dst[%indices], %values {axis = 0 : i32}
+      : (!ttg.memdesc<1xi32, #atomic_shared, #atomic_smem, mutable>,
+         tensor<1xi32, #atomic_blocked>, tensor<1xi32, #atomic_blocked>)
+      -> tensor<1xi32, #atomic_blocked>
+  tt.store %out, %old : tensor<1x!tt.ptr<i32>, #atomic_blocked>
+  tt.return
+}
+
+}
+
+// -----
+
+#shuffle_src = #ttg.linear<{register = [[0, 1], [0, 2], [0, 4]], lane = [[1, 0], [0, 0], [0, 0], [0, 0], [0, 0]], warp = [], block = []}>
+#shuffle_dst = #ttg.linear<{register = [[1, 0], [0, 4]], lane = [[0, 0], [0, 0], [0, 1], [0, 2], [0, 0]], warp = [], block = []}>
+
+// CHECK-LABEL: module
+// CHECK-SAME: ttg.shared = 0 : i32
+module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 1 : i32, "ttg.threads-per-warp" = 32 : i32} {
+
+// CHECK-LABEL: @forced_warp_shuffle_has_no_scratch
+tt.func @forced_warp_shuffle_has_no_scratch(
+    %arg0: tensor<2x8xi16, #shuffle_src>) attributes {always_use_warp_shuffle} {
+  // CHECK-NOT: allocation.offset
+  // CHECK: ttg.convert_layout
+  %0 = ttg.convert_layout %arg0 : tensor<2x8xi16, #shuffle_src> -> tensor<2x8xi16, #shuffle_dst>
+  tt.return
+}
+
+}
+
+// -----
+
+#call_shared = #ttg.swizzled_shared<{vec = 1, perPhase = 1, maxPhase = 1, order = [0]}>
+#call_smem = #ttg.shared_memory
+
+// CHECK-LABEL: module
+// CHECK-SAME: ttg.shared = 4 : i32
+module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 1 : i32, "ttg.threads-per-warp" = 32 : i32} {
+
+tt.func private @scratch_callee() attributes {noinline = true} {
+  %0 = ttg.local_alloc : () -> !ttg.memdesc<1xi32, #call_shared, #call_smem, mutable>
+  tt.return
+}
+
+// CHECK-LABEL: @virtual_call_frame_has_no_size
+tt.func @virtual_call_frame_has_no_size() {
+  // CHECK: tt.call @scratch_callee() {allocation.offset = 0 : i32}
+  tt.call @scratch_callee() : () -> ()
   tt.return
 }
 

--- a/test/Conversion/amd/allocate_shared_memory.mlir
+++ b/test/Conversion/amd/allocate_shared_memory.mlir
@@ -17,7 +17,7 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.targ
 
 // CHECK-LABEL: @convert_layout_swizzled
 tt.func @convert_layout_swizzled(%arg0: tensor<256x256xi32, #blocked1>) {
-  // CHECK-NEXT: allocation.offset = 0 : i32
+  // CHECK-NEXT: allocation.offset = 0 : i32, allocation.size = 131072 : i32
   %0 = ttg.convert_layout %arg0 : tensor<256x256xi32, #blocked1> -> tensor<256x256xi32, #blocked2>
   tt.return
 }
@@ -33,8 +33,9 @@ tt.func @convert_layout_swizzled(%arg0: tensor<256x256xi32, #blocked1>) {
 module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.target = "hip:gfx1250", "ttg.threads-per-warp" = 32 : i32, "ttg.total-num-warps" = 8 : i32} {
 
 // CHECK-LABEL: @ws_tensordesc_2d_capture
-// CHECK: allocation.offset = 48 : i32
+// CHECK-SAME: attributes {allocation.offset = 48 : i32}
 tt.func @ws_tensordesc_2d_capture(%desc: !tt.tensordesc<64x64xf16>) {
+  // CHECK: ttg.warp_specialize({{.*}}) attributes {allocation.offset = 0 : i32, allocation.size = 48 : i32
   ttg.warp_specialize(%desc) attributes {warpGroupStartIds = array<i32: 4>}
   default {
     ttg.warp_yield
@@ -56,8 +57,9 @@ tt.func @ws_tensordesc_2d_capture(%desc: !tt.tensordesc<64x64xf16>) {
 module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.target = "hip:gfx1250", "ttg.threads-per-warp" = 32 : i32, "ttg.total-num-warps" = 8 : i32} {
 
 // CHECK-LABEL: @ws_tensordesc_5d_capture
-// CHECK: allocation.offset = 80 : i32
+// CHECK-SAME: attributes {allocation.offset = 80 : i32}
 tt.func @ws_tensordesc_5d_capture(%desc: !tt.tensordesc<8x8x8x16x16xf16>) {
+  // CHECK: ttg.warp_specialize({{.*}}) attributes {allocation.offset = 0 : i32, allocation.size = 80 : i32
   ttg.warp_specialize(%desc) attributes {warpGroupStartIds = array<i32: 4>}
   default {
     ttg.warp_yield
@@ -65,6 +67,29 @@ tt.func @ws_tensordesc_5d_capture(%desc: !tt.tensordesc<8x8x8x16x16xf16>) {
   partition0(%arg0: !tt.tensordesc<8x8x8x16x16xf16>) num_warps(4) {
     ttg.warp_return
   } : (!tt.tensordesc<8x8x8x16x16xf16>) -> ()
+  tt.return
+}
+
+}
+
+// -----
+
+#atomic_broadcast = #ttg.blocked<{sizePerThread = [1], threadsPerWarp = [32], warpsPerCTA = [4], order = [0]}>
+
+// CHECK-LABEL: module
+// CHECK-SAME: ttg.shared = 64 : i32
+module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.target = "hip:gfx1250", "ttg.threads-per-warp" = 32 : i32} {
+
+// CHECK-LABEL: @buffer_atomic_scratch_size
+tt.func @buffer_atomic_scratch_size(
+    %base: !tt.ptr<i32>,
+    %offsets: tensor<16xi32, #atomic_broadcast>,
+    %values: tensor<16xi32, #atomic_broadcast>,
+    %out: tensor<16x!tt.ptr<i32>, #atomic_broadcast>) {
+  // CHECK: amdg.buffer_atomic_rmw {{.*}} {allocation.offset = 0 : i32, allocation.size = 64 : i32}
+  %old = amdg.buffer_atomic_rmw add, acq_rel, gpu, %values, %base[%offsets]
+      : tensor<16xi32, #atomic_broadcast>
+  tt.store %out, %old : tensor<16x!tt.ptr<i32>, #atomic_broadcast>
   tt.return
 }
 

--- a/test/Conversion/amd/allocate_shared_memory.mlir
+++ b/test/Conversion/amd/allocate_shared_memory.mlir
@@ -94,3 +94,26 @@ tt.func @buffer_atomic_scratch_size(
 }
 
 }
+
+// -----
+
+#atomic_broadcast_2cta = #ttg.blocked<{sizePerThread = [1], threadsPerWarp = [32], warpsPerCTA = [4], order = [0], CGALayout = [[0]]}>
+
+// CHECK-LABEL: module
+// CHECK-SAME: ttg.shared = 64 : i32
+module attributes {"ttg.num-ctas" = 2 : i32, "ttg.num-warps" = 4 : i32, ttg.target = "hip:gfx1250", "ttg.threads-per-warp" = 32 : i32} {
+
+// CHECK-LABEL: @buffer_atomic_cross_cta_scratch_size
+tt.func @buffer_atomic_cross_cta_scratch_size(
+    %base: !tt.ptr<i32>,
+    %offsets: tensor<16xi32, #atomic_broadcast_2cta>,
+    %values: tensor<16xi32, #atomic_broadcast_2cta>,
+    %out: tensor<16x!tt.ptr<i32>, #atomic_broadcast_2cta>) {
+  // CHECK: amdg.buffer_atomic_rmw {{.*}} {allocation.offset = 0 : i32, allocation.size = 64 : i32}
+  %old = amdg.buffer_atomic_rmw add, acq_rel, gpu, %values, %base[%offsets]
+      : tensor<16xi32, #atomic_broadcast_2cta>
+  tt.store %out, %old : tensor<16x!tt.ptr<i32>, #atomic_broadcast_2cta>
+  tt.return
+}
+
+}

--- a/test/Conversion/tritongpu_to_llvm.mlir
+++ b/test/Conversion/tritongpu_to_llvm.mlir
@@ -839,6 +839,24 @@ module attributes {"ttg.num-warps" = 1 : i32} {
 
 // -----
 
+#forced_shuffle_src = #ttg.linear<{register = [[0, 1], [0, 2], [0, 4]], lane = [[1, 0], [0, 0], [0, 0], [0, 0], [0, 0]], warp = [], block = []}>
+#forced_shuffle_dst = #ttg.linear<{register = [[1, 0], [0, 4]], lane = [[0, 0], [0, 0], [0, 1], [0, 2], [0, 0]], warp = [], block = []}>
+
+module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 1 : i32} {
+  // CHECK-LABEL: @convert_layout_forced_expensive_warp_local
+  tt.func @convert_layout_forced_expensive_warp_local(
+      %arg0: tensor<2x8xi16, #forced_shuffle_src>) attributes {always_use_warp_shuffle} {
+    // CHECK-NOT: llvm.mlir.addressof @global_smem
+    // CHECK: nvvm.shfl.sync
+    // CHECK-NOT: llvm.mlir.addressof @global_smem
+    %0 = ttg.convert_layout %arg0
+        : tensor<2x8xi16, #forced_shuffle_src> -> tensor<2x8xi16, #forced_shuffle_dst>
+    tt.return
+  }
+}
+
+// -----
+
 #blocked0 = #ttg.blocked<{sizePerThread = [1, 4], threadsPerWarp = [8, 4], warpsPerCTA = [2, 2], order = [1, 0]}>
 #blocked1 = #ttg.blocked<{sizePerThread = [4, 1], threadsPerWarp = [4, 8], warpsPerCTA = [2, 2], order = [0, 1]}>
 module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32} {

--- a/test/Conversion/tritongpu_to_llvm.mlir
+++ b/test/Conversion/tritongpu_to_llvm.mlir
@@ -862,7 +862,7 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 1 : i32} {
 module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32} {
   // CHECK: llvm.mlir.global external @global_smem
   // CHECK-LABEL: convert_layout_blocked_blocked
-  tt.func @convert_layout_blocked_blocked(%arg0: tensor<32x32xf32, #blocked0>) attributes {always_use_warp_shuffle} {
+  tt.func @convert_layout_blocked_blocked(%arg0: tensor<32x32xf32, #blocked0>) {
     // CHECK: llvm.mlir.addressof @global_smem
     // CHECK-COUNT-8: llvm.store
     // CHECK: nvvm.barrier

--- a/test/Conversion/tritongpu_to_llvm.mlir
+++ b/test/Conversion/tritongpu_to_llvm.mlir
@@ -844,10 +844,10 @@ module attributes {"ttg.num-warps" = 1 : i32} {
 module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32} {
   // CHECK: llvm.mlir.global external @global_smem
   // CHECK-LABEL: convert_layout_blocked_blocked
-  tt.func @convert_layout_blocked_blocked(%arg0: tensor<32x32xf32, #blocked0>) {
+  tt.func @convert_layout_blocked_blocked(%arg0: tensor<32x32xf32, #blocked0>) attributes {always_use_warp_shuffle} {
     // CHECK: llvm.mlir.addressof @global_smem
     // CHECK-COUNT-8: llvm.store
-    // CHECK-: nvvm.barrier
+    // CHECK: nvvm.barrier
     // CHECK-COUNT-8: llvm.load
     %0 = ttg.convert_layout %arg0 : tensor<32x32xf32, #blocked0> -> tensor<32x32xf32, #blocked1>
     tt.return

--- a/test/Conversion/tritongpu_to_llvm_invalid.mlir
+++ b/test/Conversion/tritongpu_to_llvm_invalid.mlir
@@ -1,0 +1,15 @@
+// RUN: triton-opt %s --allocate-shared-memory-nv --convert-triton-gpu-to-llvm -verify-diagnostics
+
+#blocked0 = #ttg.blocked<{sizePerThread = [1, 4], threadsPerWarp = [8, 4], warpsPerCTA = [2, 2], order = [1, 0]}>
+#blocked1 = #ttg.blocked<{sizePerThread = [4, 1], threadsPerWarp = [4, 8], warpsPerCTA = [2, 2], order = [0, 1]}>
+
+module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32} {
+  tt.func @convert_layout_forced_non_warp_local(
+      %arg0: tensor<32x32xf32, #blocked0>) attributes {always_use_warp_shuffle} {
+    // expected-error @+2 {{'always_use_warp_shuffle' requires a warp-local layout conversion}}
+    // expected-error @+1 {{failed to legalize operation 'ttg.convert_layout' that was explicitly marked illegal}}
+    %0 = ttg.convert_layout %arg0
+        : tensor<32x32xf32, #blocked0> -> tensor<32x32xf32, #blocked1>
+    tt.return
+  }
+}

--- a/test/Conversion/tritoninstrument_to_llvm.mlir
+++ b/test/Conversion/tritoninstrument_to_llvm.mlir
@@ -73,11 +73,32 @@ tt.func private @experimental_lock_release(
 #smem = #ttg.shared_memory
 module attributes {"ttg.num-warps" = 4 : i32, ttg.target = "cuda:90"} {
 // CHECK-LABEL: @experimental_memdesc_to_i32
-// CHECK:  llvm.ptrtoint %1 : !llvm.ptr<3> to i32
+// CHECK: %[[MEMDESC_PTR:.*]] = llvm.extractvalue {{.*}}[0]
+// CHECK: %[[BYTE_OFFSET:.*]] = llvm.mul {{.*}} : i32
+// CHECK: %[[MEMDESC_BASE:.*]] = llvm.ptrtoint %[[MEMDESC_PTR]] : !llvm.ptr<3> to i32
+// CHECK: %[[MEMDESC_ADDRESS:.*]] = llvm.add %[[BYTE_OFFSET]], %[[MEMDESC_BASE]] : i32
+// CHECK: %[[MEMDESC_MASK:.*]] = llvm.mlir.constant(16777215 : i32)
+// CHECK: llvm.and %[[MEMDESC_ADDRESS]], %[[MEMDESC_MASK]] : i32
 tt.func private @experimental_memdesc_to_i32(
   %memdesc: !ttg.memdesc<32x32xf32, #shared, #smem, mutable>
 ) {
   tti.experimental_memdesc_to_i32 %memdesc : !ttg.memdesc<32x32xf32, #shared, #smem, mutable>
+  tt.return
+}
+}
+
+// -----
+
+#blocked = #ttg.blocked<{sizePerThread = [2], threadsPerWarp = [32], warpsPerCTA = [4], order = [0]}>
+module attributes {"ttg.num-warps" = 4 : i32, ttg.target = "cuda:90"} {
+// CHECK-LABEL: @experimental_shared_memory_offset_to_i32
+// CHECK: %[[BASE:.*]] = llvm.ptrtoint %arg0 : !llvm.ptr<3> to i32
+// CHECK: %[[OFFSET:.*]] = llvm.mlir.constant(42 : i32)
+// CHECK: %[[ADDRESS:.*]] = llvm.add %[[BASE]], %[[OFFSET]] : i32
+// CHECK: %[[MASK:.*]] = llvm.mlir.constant(16777215 : i32)
+// CHECK: llvm.and %[[ADDRESS]], %[[MASK]] : i32
+tt.func private @experimental_shared_memory_offset_to_i32() {
+  tti.experimental_shared_memory_offset_to_i32 42
   tt.return
 }
 }

--- a/test/TritonGPU/amd/amd-consan.mlir
+++ b/test/TritonGPU/amd/amd-consan.mlir
@@ -1025,3 +1025,27 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.shar
     tt.return
   }
 }
+
+// -----
+
+#buffer_atomic_broadcast = #ttg.blocked<{sizePerThread = [1], threadsPerWarp = [32], warpsPerCTA = [4], order = [0]}>
+
+module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.shared = 64 : i32, ttg.target = "hip:gfx1250", ttg.tensor_memory_size = 0 : i32, "ttg.threads-per-warp" = 32 : i32, "ttg.total-num-warps" = 4 : i32} {
+  // CHECK-LABEL: @buffer_atomic_shared_scratch
+  tt.func public @buffer_atomic_shared_scratch(
+      %base: !tt.ptr<i32>,
+      %offsets: tensor<16xi32, #buffer_atomic_broadcast>,
+      %values: tensor<16xi32, #buffer_atomic_broadcast>,
+      %out: tensor<16x!tt.ptr<i32>, #buffer_atomic_broadcast>) {
+    // CHECK-DAG: tti.experimental_buffer_descriptors [0], [64], shared_mem
+    // CHECK: %[[BUFFER_ATOMIC_SCRATCH:.*]] = tti.experimental_shared_memory_offset_to_i32 0
+    // CHECK: %[[BUFFER_ATOMIC_LENGTH:.*]] = arith.constant 64 : i32
+    // CHECK: tt.call @__triton_consan_set_write_visibility{{.*}}(%[[BUFFER_ATOMIC_SCRATCH]], %[[BUFFER_ATOMIC_LENGTH]]
+    // CHECK: amdg.buffer_atomic_rmw
+    %old = amdg.buffer_atomic_rmw add, acq_rel, gpu, %values, %base[%offsets] {
+        allocation.offset = 0 : i32, allocation.size = 64 : i32}
+        : tensor<16xi32, #buffer_atomic_broadcast>
+    tt.store %out, %old : tensor<16x!tt.ptr<i32>, #buffer_atomic_broadcast>
+    tt.return
+  }
+}

--- a/test/TritonGPU/amd/amd-consan.mlir
+++ b/test/TritonGPU/amd/amd-consan.mlir
@@ -1049,3 +1049,77 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.shar
     tt.return
   }
 }
+
+// -----
+
+#buffer_atomic_broadcast_2cta = #ttg.blocked<{sizePerThread = [1], threadsPerWarp = [32], warpsPerCTA = [4], order = [0], CGALayout = [[0]]}>
+
+module attributes {"ttg.num-ctas" = 2 : i32, "ttg.num-warps" = 4 : i32, ttg.shared = 64 : i32, ttg.target = "hip:gfx1250", ttg.tensor_memory_size = 0 : i32, "ttg.threads-per-warp" = 32 : i32, "ttg.total-num-warps" = 4 : i32} {
+  // CHECK-LABEL: @buffer_atomic_cross_cta_shared_scratch
+  tt.func public @buffer_atomic_cross_cta_shared_scratch(
+      %base: !tt.ptr<i32>,
+      %offsets: tensor<16xi32, #buffer_atomic_broadcast_2cta>,
+      %values: tensor<16xi32, #buffer_atomic_broadcast_2cta>,
+      %out: tensor<16x!tt.ptr<i32>, #buffer_atomic_broadcast_2cta>) {
+    // Only CTA 0 produces the broadcast result; both CTA rows consume its
+    // scratch interval.
+    // CHECK: amdg.cluster_barrier_arrive
+    // CHECK-NEXT: amdg.cluster_barrier_wait
+    // CHECK: tti.experimental_lock_acquire
+    // CHECK-NEXT: %[[PRODUCER_CTA:.*]] = tti.experimental_cluster_cta_id
+    // CHECK: %[[PRODUCER_MASK:.*]] = arith.constant 1 : i32
+    // CHECK: %[[CTA_IN_GROUP:.*]] = arith.andi %[[PRODUCER_CTA]], %[[PRODUCER_MASK]] : i32
+    // CHECK: %[[PRODUCER_ZERO:.*]] = arith.constant 0 : i32
+    // CHECK: %[[PRODUCER:.*]] = arith.cmpi eq, %[[CTA_IN_GROUP]], %[[PRODUCER_ZERO]] : i32
+    // CHECK: %[[RECIPIENT_CTA:.*]] = tti.experimental_cluster_cta_id
+    // CHECK: %[[RECIPIENTS_INIT:.*]] = arith.constant 0 : i32
+    // CHECK: %[[FIXED_BITS:.*]] = arith.constant 0 : i32
+    // CHECK: %[[RECIPIENT_BASE:.*]] = arith.andi %[[RECIPIENT_CTA]], %[[FIXED_BITS]] : i32
+    // CHECK: %[[ALL_ROWS:.*]] = arith.constant 3 : i32
+    // CHECK: %[[GROUP_ROWS:.*]] = arith.shli %[[ALL_ROWS]], %[[RECIPIENT_BASE]] : i32
+    // CHECK: %[[RECIPIENTS:.*]] = arith.ori %[[RECIPIENTS_INIT]], %[[GROUP_ROWS]] : i32
+    // CHECK: %[[SCRATCH:.*]] = tti.experimental_shared_memory_offset_to_i32 0
+    // CHECK: %[[VERIFY_WRITE_LENGTH:.*]] = arith.constant 64 : i32
+    // CHECK-NEXT: {{.*}} = tt.call @__triton_consan_verify_write_visibility{{.*}}(%[[SCRATCH]], %[[VERIFY_WRITE_LENGTH]], %[[PRODUCER]], {{.*}}%[[RECIPIENTS]])
+    // CHECK: %[[VERIFY_READ_LENGTH:.*]] = arith.constant 64 : i32
+    // CHECK-NEXT: {{.*}} = tt.call @__triton_consan_verify_read_visibility{{.*}}(%[[SCRATCH]], %[[VERIFY_READ_LENGTH]], %[[PRODUCER]], {{.*}}%[[RECIPIENTS]])
+    // CHECK: %[[SET_WRITE_LENGTH:.*]] = arith.constant 64 : i32
+    // CHECK-NEXT: tt.call @__triton_consan_set_write_visibility{{.*}}(%[[SCRATCH]], %[[SET_WRITE_LENGTH]], %[[PRODUCER]], {{.*}}%[[RECIPIENTS]])
+    // CHECK: %[[CLEAR_READ_LENGTH:.*]] = arith.constant 64 : i32
+    // CHECK-NEXT: tt.call @__triton_consan_clear_read_visibility{{.*}}(%[[SCRATCH]], %[[CLEAR_READ_LENGTH]], %[[PRODUCER]], {{.*}}%[[RECIPIENTS]])
+    // CHECK: amdg.buffer_atomic_rmw
+    %old = amdg.buffer_atomic_rmw add, acq_rel, gpu, %values, %base[%offsets] {
+        allocation.offset = 0 : i32, allocation.size = 64 : i32}
+        : tensor<16xi32, #buffer_atomic_broadcast_2cta>
+    tt.store %out, %old : tensor<16x!tt.ptr<i32>, #buffer_atomic_broadcast_2cta>
+    tt.return
+  }
+}
+
+// -----
+
+module attributes {"ttg.num-ctas" = 2 : i32, "ttg.num-warps" = 1 : i32, ttg.shared = 4 : i32, ttg.target = "hip:gfx1250", ttg.tensor_memory_size = 0 : i32, "ttg.threads-per-warp" = 32 : i32, "ttg.total-num-warps" = 1 : i32} {
+  // CHECK-LABEL: @scalar_atomic_scratch_stays_cta_local
+  tt.func public @scalar_atomic_scratch_stays_cta_local(
+      %ptr: !tt.ptr<i32>, %out: !tt.ptr<i32>) {
+    %one = arith.constant 1 : i32
+    // AMD scalar atomic result staging is CTA-local. Each CTA instruments its
+    // own scratch row without a canonical-producer predicate.
+    // CHECK: tti.experimental_lock_acquire
+    // CHECK-NEXT: %[[SCALAR_CTA:.*]] = tti.experimental_cluster_cta_id
+    // CHECK: %[[SCALAR_ONE:.*]] = arith.constant 1 : i32
+    // CHECK: %[[SCALAR_RECIPIENT:.*]] = arith.shli %[[SCALAR_ONE]], %[[SCALAR_CTA]] : i32
+    // CHECK: %[[SCALAR_SCRATCH:.*]] = tti.experimental_shared_memory_offset_to_i32 0
+    // CHECK: tt.call @__triton_consan_set_write_visibility{{.*}}(%[[SCALAR_SCRATCH]], {{.*}}, %true{{[^,]*}}, {{.*}}%[[SCALAR_RECIPIENT]])
+    // CHECK: tt.atomic_rmw
+    %old = tt.atomic_rmw add, relaxed, gpu, %ptr, %one {
+        allocation.offset = 0 : i32, allocation.size = 4 : i32}
+        : (!tt.ptr<i32>, i32) -> i32
+    tt.store %out, %old : !tt.ptr<i32>
+    // Keep the AMD dialect loaded in this standalone split module. Production
+    // AMD pipelines load it before ConSan as an allocation-pass dependency.
+    amdg.cluster_barrier_arrive
+    amdg.cluster_barrier_wait
+    tt.return
+  }
+}

--- a/test/TritonGPU/amd/amd-consan.mlir
+++ b/test/TritonGPU/amd/amd-consan.mlir
@@ -163,12 +163,10 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 1 : i32, ttg.shar
 
     // CHECK: %[[A_I64:.*]] = tti.experimental_memdesc_to_i32 %[[A:.*]] :
     // CHECK: tt.call @__triton_consan_verify_write_visibility_noalias_nw1{{.*}}(%[[A_I64]]
-    // CHECK: %[[A_I64:.*]] = tti.experimental_memdesc_to_i32 %[[A]] :
     // CHECK: %[[THREAD_BIT:.*]] = arith.constant 0 : i32
     // CHECK: tt.call @__triton_consan_check_outstanding_commits{{.*}}(%[[A_I64]], {{.*}}, %[[THREAD_BIT]], %[[BUFFERS]], %[[WRT_COMMITS_GLOB]]
     // CHECK: tt.call @__triton_consan_verify_read_visibility_noalias_nw1
     // CHECK: %[[THREAD_BIT:.*]] = arith.constant 0 : i32
-    // CHECK: %[[A_I64:.*]] = tti.experimental_memdesc_to_i32 %[[A]] :
     // CHECK: tt.call @__triton_consan_stage_access_for_commit_nw1{{.*}}(%[[A_I64]], {{.*}}, %[[THREAD_BIT]], %[[BUFFERS]], %[[WRT_COMMITS_GLOB]]
     // CHECK: ttg.async_copy_global_to_local %{{.*}}, %[[A]]
 
@@ -199,13 +197,10 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 1 : i32, ttg.shar
 
     // CHECK: %[[A_I64:.*]] = tti.experimental_memdesc_to_i32 %[[A:.*]] :
     // CHECK: tt.call @__triton_consan_verify_write_visibility_noalias{{.*}}(%[[A_I64]]
-    // CHECK: %[[A_I64:.*]] = tti.experimental_memdesc_to_i32 %[[A]] :
     // CHECK: %[[THREAD_BIT:.*]] = arith.constant 0 : i32
     // CHECK: tt.call @__triton_consan_check_outstanding_commits{{.*}}(%[[A_I64]], {{.*}}, %[[THREAD_BIT]], %[[BUFFERS]], %[[WRT_COMMITS_GLOB]]
-    // CHECK: %[[A_I64:.*]] = tti.experimental_memdesc_to_i32 %[[A]] :
     // CHECK: tt.call @__triton_consan_verify_read_visibility{{.*}}(%[[A_I64]]
     // CHECK: %[[THREAD_BIT:.*]] = arith.constant 0 : i32
-    // CHECK: %[[A_I64:.*]] = tti.experimental_memdesc_to_i32 %[[A]] :
     // CHECK: tt.call @__triton_consan_stage_access_for_commit{{.*}}(%[[A_I64]], {{.*}}, %[[THREAD_BIT]], %[[BUFFERS]], %[[WRT_COMMITS_GLOB]]
     // CHECK: ttg.async_copy_global_to_local %{{.*}}, %[[A]]
     %bar = ttg.local_alloc {allocation.offset = 65536 : i32} : () -> !ttg.memdesc<1xi64, #shared1, #smem, mutable>
@@ -264,7 +259,6 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 1 : i32, ttg.shar
     // CHECK: %[[BUF:.*]] = ttg.local_alloc
     // CHECK: %[[BUF_I64:.*]] = tti.experimental_memdesc_to_i32 %[[BUF:.*]] :
     // CHECK: tt.call @__triton_consan_verify_write_visibility{{.*}}(%[[BUF_I64]]
-    // CHECK: %[[BUF_I64:.*]] = tti.experimental_memdesc_to_i32 %[[BUF:.*]] :
     // CHECK: tt.call @__triton_consan_verify_read_visibility{{.*}}(%[[BUF_I64]]
     %buf = ttg.local_alloc %data {allocation.offset = 0 : i32} : (tensor<32x32xf16, #blocked>) -> !ttg.memdesc<32x32xf16, #shared, #smem, mutable>
     %bar = ttg.local_alloc {allocation.offset = 4096 : i32} : () -> !ttg.memdesc<1xi64, #shared1, #smem, mutable>
@@ -990,6 +984,44 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.shar
       ttg.local_load %arg1 : !ttg.memdesc<32xf32, #shared, #smem, mutable> -> tensor<32xf32>
       ttg.warp_return
     } : (!ttg.memdesc<32xf32, #shared, #smem, mutable>, !ttg.memdesc<32xf32, #shared, #smem, mutable>, !ttg.memdesc<1xi64, #shared, #smem, mutable>) -> ()
+    tt.return
+  }
+}
+
+// -----
+
+#convert_shared = #ttg.swizzled_shared<{vec = 1, perPhase = 1, maxPhase = 1, order = [0]}>
+#convert_smem = #ttg.shared_memory
+#convert_src = #ttg.blocked<{sizePerThread = [1], threadsPerWarp = [32], warpsPerCTA = [4], order = [0]}>
+#convert_dst_parent = #ttg.blocked<{sizePerThread = [1, 1], threadsPerWarp = [1, 32], warpsPerCTA = [1, 4], order = [1, 0]}>
+#convert_dst = #ttg.slice<{dim = 1, parent = #convert_dst_parent}>
+
+module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.shared = 65544 : i32, ttg.target = "hip:gfx1250", "ttg.threads-per-warp" = 32 : i32, "ttg.total-num-warps" = 4 : i32} {
+  // CHECK-LABEL: @convert_layout_shared_scratch
+  tt.func public @convert_layout_shared_scratch(
+      %desc: !tt.tensordesc<256xi32>) {
+    // The conversion's 512-byte scratch range aliases the first half of the
+    // outstanding TDM store's 1024-byte source range.
+    // CHECK-DAG: %[[BUFS:.*]] = tti.experimental_buffer_descriptors [0, 0], [512, 1024], shared_mem
+    // CHECK-DAG: %[[ALIASES:.*]] = arith.constant dense<true> : tensor<2x2xi1, #{{.*}}>
+    %buf = ttg.local_alloc {allocation.offset = 0 : i32}
+        : () -> !ttg.memdesc<256xi32, #convert_shared, #convert_smem, mutable>
+    amdg.async_tdm_copy_local_to_global %desc from %buf
+        : !ttg.memdesc<256xi32, #convert_shared, #convert_smem, mutable>
+          -> !tt.tensordesc<256xi32>
+    ttg.local_dealloc %buf
+        : !ttg.memdesc<256xi32, #convert_shared, #convert_smem, mutable>
+
+    %value = arith.constant dense<0> : tensor<128xi32, #convert_src>
+    // CHECK: %[[SCRATCH:.*]] = tti.experimental_shared_memory_offset_to_i32 0
+    // CHECK: tt.call @__triton_consan_verify_read_visibility
+    // CHECK: %[[SCRATCH_LENGTH:.*]] = arith.constant 512 : i32
+    // CHECK-NEXT: {{.*}} = tt.call @__triton_consan_check_outstanding_commits{{.*}}(%[[SCRATCH]], %[[SCRATCH_LENGTH]], {{.*}}, %[[BUFS]], {{.*}}, %[[ALIASES]])
+    // CHECK: ttg.convert_layout
+    %converted = ttg.convert_layout %value {allocation.offset = 0 : i32, allocation.size = 512 : i32}
+        : tensor<128xi32, #convert_src> -> tensor<128xi32, #convert_dst>
+
+    amdg.async_tdm_wait {num = 0 : i32}
     tt.return
   }
 }

--- a/test/TritonGPU/consan-capture-reservation.mlir
+++ b/test/TritonGPU/consan-capture-reservation.mlir
@@ -2,12 +2,40 @@
 // RUN: not triton-opt %t/missing.mlir -allow-unregistered-dialect -tritoninstrument-concurrency-sanitizer 2>&1 | FileCheck %t/missing.mlir --check-prefix=MISSING
 // RUN: not triton-opt %t/too-small.mlir -allow-unregistered-dialect -tritoninstrument-concurrency-sanitizer 2>&1 | FileCheck %t/too-small.mlir --check-prefix=SMALL
 // RUN: not triton-opt %t/cross-cta-affine.mlir -allow-unregistered-dialect -tritoninstrument-concurrency-sanitizer 2>&1 | FileCheck %t/cross-cta-affine.mlir --check-prefix=AFFINE
+// RUN: triton-opt %t/convert-only.mlir -tritoninstrument-prepare-consan-captures="target=nvidia" | FileCheck %t/convert-only.mlir --check-prefix=CONVERT
+// RUN: triton-opt %t/reduce-only.mlir -tritoninstrument-prepare-consan-captures="target=nvidia" | FileCheck %t/reduce-only.mlir --check-prefix=REDUCE
+// RUN: not triton-opt %t/convert-missing-metadata.mlir -tritoninstrument-concurrency-sanitizer 2>&1 | FileCheck %t/convert-missing-metadata.mlir --check-prefix=CVT-MISSING
+// RUN: not triton-opt %t/convert-partial-metadata.mlir -tritoninstrument-concurrency-sanitizer 2>&1 | FileCheck %t/convert-partial-metadata.mlir --check-prefix=CVT-PARTIAL
+// RUN: not triton-opt %t/convert-invalid-metadata.mlir -tritoninstrument-concurrency-sanitizer 2>&1 | FileCheck %t/convert-invalid-metadata.mlir --check-prefix=CVT-INVALID
 
 //--- missing.mlir
 
 module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, "ttg.threads-per-warp" = 32 : i32, "ttg.total-num-warps" = 4 : i32, ttg.shared = 0 : i32, ttg.target = "cuda:90", ttg.tensor_memory_size = 0 : i32} {
   tt.func public @missing_reservation() {
     // MISSING: WarpSpecialize op is missing 'consan.extra_capture_bytes'
+    ttg.warp_specialize()
+    default {
+      ttg.warp_yield
+    }
+    partition0() num_warps(4) {
+      ttg.warp_return
+    } : () -> ()
+    tt.return
+  }
+}
+
+//--- reduce-only.mlir
+
+#reduce = #ttg.blocked<{sizePerThread = [1, 2], threadsPerWarp = [1, 32], warpsPerCTA = [1, 4], order = [1, 0]}>
+
+module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, "ttg.threads-per-warp" = 32 : i32, "ttg.total-num-warps" = 4 : i32, ttg.shared = 16 : i32, ttg.target = "cuda:90", ttg.tensor_memory_size = 0 : i32} {
+  tt.func public @reduce_only_reservation(%arg0: tensor<1x256xf32, #reduce>) {
+    %0 = "tt.reduce"(%arg0) <{axis = 1 : i32}> ({
+    ^bb0(%lhs: f32, %rhs: f32):
+      %sum = arith.addf %lhs, %rhs : f32
+      tt.reduce.return %sum : f32
+    }) : (tensor<1x256xf32, #reduce>) -> tensor<1xf32, #ttg.slice<{dim = 1, parent = #reduce}>>
+    // REDUCE: ttg.warp_specialize() attributes {consan.extra_capture_bytes = 24 : i32}
     ttg.warp_specialize()
     default {
       ttg.warp_yield
@@ -48,6 +76,69 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, "ttg.thr
     partition0() num_warps(4) {
       ttg.warp_return
     } : () -> ()
+    tt.return
+  }
+}
+
+//--- convert-only.mlir
+
+#src = #ttg.blocked<{sizePerThread = [1], threadsPerWarp = [32], warpsPerCTA = [4], order = [0]}>
+#dst_parent = #ttg.blocked<{sizePerThread = [1, 1], threadsPerWarp = [1, 32], warpsPerCTA = [1, 4], order = [1, 0]}>
+#dst = #ttg.slice<{dim = 1, parent = #dst_parent}>
+
+module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, "ttg.threads-per-warp" = 32 : i32, "ttg.total-num-warps" = 4 : i32, ttg.shared = 512 : i32, ttg.target = "cuda:90", ttg.tensor_memory_size = 0 : i32} {
+  tt.func public @convert_only_reservation(%arg0: tensor<128xi32, #src>) {
+    %0 = ttg.convert_layout %arg0 : tensor<128xi32, #src> -> tensor<128xi32, #dst>
+    // CONVERT: ttg.warp_specialize() attributes {consan.extra_capture_bytes = 24 : i32}
+    ttg.warp_specialize()
+    default {
+      ttg.warp_yield
+    }
+    partition0() num_warps(4) {
+      ttg.warp_return
+    } : () -> ()
+    tt.return
+  }
+}
+
+//--- convert-missing-metadata.mlir
+
+#src = #ttg.blocked<{sizePerThread = [1], threadsPerWarp = [32], warpsPerCTA = [4], order = [0]}>
+#dst_parent = #ttg.blocked<{sizePerThread = [1, 1], threadsPerWarp = [1, 32], warpsPerCTA = [1, 4], order = [1, 0]}>
+#dst = #ttg.slice<{dim = 1, parent = #dst_parent}>
+
+module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, "ttg.threads-per-warp" = 32 : i32, "ttg.total-num-warps" = 4 : i32, ttg.shared = 512 : i32, ttg.target = "cuda:90", ttg.tensor_memory_size = 0 : i32} {
+  tt.func public @convert_missing_metadata(%arg0: tensor<128xi32, #src>) {
+    // CVT-MISSING: error: shared-memory convert_layout is missing scratch allocation metadata
+    %0 = ttg.convert_layout %arg0 : tensor<128xi32, #src> -> tensor<128xi32, #dst>
+    tt.return
+  }
+}
+
+//--- convert-partial-metadata.mlir
+
+#src = #ttg.blocked<{sizePerThread = [1], threadsPerWarp = [32], warpsPerCTA = [4], order = [0]}>
+#dst_parent = #ttg.blocked<{sizePerThread = [1, 1], threadsPerWarp = [1, 32], warpsPerCTA = [1, 4], order = [1, 0]}>
+#dst = #ttg.slice<{dim = 1, parent = #dst_parent}>
+
+module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, "ttg.threads-per-warp" = 32 : i32, "ttg.total-num-warps" = 4 : i32, ttg.shared = 512 : i32, ttg.target = "cuda:90", ttg.tensor_memory_size = 0 : i32} {
+  tt.func public @convert_partial_metadata(%arg0: tensor<128xi32, #src>) {
+    // CVT-PARTIAL: error: convert_layout scratch allocation metadata must include both allocation.offset and allocation.size
+    %0 = ttg.convert_layout %arg0 {allocation.offset = 0 : i32} : tensor<128xi32, #src> -> tensor<128xi32, #dst>
+    tt.return
+  }
+}
+
+//--- convert-invalid-metadata.mlir
+
+#src = #ttg.blocked<{sizePerThread = [1], threadsPerWarp = [32], warpsPerCTA = [4], order = [0]}>
+#dst_parent = #ttg.blocked<{sizePerThread = [1, 1], threadsPerWarp = [1, 32], warpsPerCTA = [1, 4], order = [1, 0]}>
+#dst = #ttg.slice<{dim = 1, parent = #dst_parent}>
+
+module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, "ttg.threads-per-warp" = 32 : i32, "ttg.total-num-warps" = 4 : i32, ttg.shared = 512 : i32, ttg.target = "cuda:90", ttg.tensor_memory_size = 0 : i32} {
+  tt.func public @convert_invalid_metadata(%arg0: tensor<128xi32, #src>) {
+    // CVT-INVALID: error: invalid convert_layout scratch allocation metadata: offset 16777215, size 2
+    %0 = ttg.convert_layout %arg0 {allocation.offset = 16777215 : i32, allocation.size = 2 : i32} : tensor<128xi32, #src> -> tensor<128xi32, #dst>
     tt.return
   }
 }

--- a/test/TritonGPU/consan-capture-reservation.mlir
+++ b/test/TritonGPU/consan-capture-reservation.mlir
@@ -4,9 +4,10 @@
 // RUN: not triton-opt %t/cross-cta-affine.mlir -allow-unregistered-dialect -tritoninstrument-concurrency-sanitizer 2>&1 | FileCheck %t/cross-cta-affine.mlir --check-prefix=AFFINE
 // RUN: triton-opt %t/convert-only.mlir -tritoninstrument-prepare-consan-captures="target=nvidia" | FileCheck %t/convert-only.mlir --check-prefix=CONVERT
 // RUN: triton-opt %t/reduce-only.mlir -tritoninstrument-prepare-consan-captures="target=nvidia" | FileCheck %t/reduce-only.mlir --check-prefix=REDUCE
-// RUN: not triton-opt %t/convert-missing-metadata.mlir -tritoninstrument-concurrency-sanitizer 2>&1 | FileCheck %t/convert-missing-metadata.mlir --check-prefix=CVT-MISSING
-// RUN: not triton-opt %t/convert-partial-metadata.mlir -tritoninstrument-concurrency-sanitizer 2>&1 | FileCheck %t/convert-partial-metadata.mlir --check-prefix=CVT-PARTIAL
-// RUN: not triton-opt %t/convert-invalid-metadata.mlir -tritoninstrument-concurrency-sanitizer 2>&1 | FileCheck %t/convert-invalid-metadata.mlir --check-prefix=CVT-INVALID
+// RUN: triton-opt %t/empty-ws.mlir -tritoninstrument-prepare-consan-captures="target=nvidia" | FileCheck %t/empty-ws.mlir --check-prefix=EMPTY
+// RUN: triton-opt %t/empty-ws.mlir -tritoninstrument-prepare-consan-captures="target=nvidia" --allocate-shared-memory-nv -tritoninstrument-concurrency-sanitizer | FileCheck %t/empty-ws.mlir --check-prefix=EMPTY-INTEGRATION
+// RUN: not triton-opt %t/scratch-missing-offset.mlir -tritoninstrument-concurrency-sanitizer 2>&1 | FileCheck %t/scratch-missing-offset.mlir --check-prefix=SCRATCH-MISSING-OFFSET
+// RUN: not triton-opt %t/scratch-invalid.mlir -tritoninstrument-concurrency-sanitizer 2>&1 | FileCheck %t/scratch-invalid.mlir --check-prefix=SCRATCH-INVALID
 
 //--- missing.mlir
 
@@ -101,43 +102,48 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, "ttg.thr
   }
 }
 
-//--- convert-missing-metadata.mlir
+//--- empty-ws.mlir
 
-#src = #ttg.blocked<{sizePerThread = [1], threadsPerWarp = [32], warpsPerCTA = [4], order = [0]}>
-#dst_parent = #ttg.blocked<{sizePerThread = [1, 1], threadsPerWarp = [1, 32], warpsPerCTA = [1, 4], order = [1, 0]}>
-#dst = #ttg.slice<{dim = 1, parent = #dst_parent}>
-
-module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, "ttg.threads-per-warp" = 32 : i32, "ttg.total-num-warps" = 4 : i32, ttg.shared = 512 : i32, ttg.target = "cuda:90", ttg.tensor_memory_size = 0 : i32} {
-  tt.func public @convert_missing_metadata(%arg0: tensor<128xi32, #src>) {
-    // CVT-MISSING: error: shared-memory convert_layout is missing scratch allocation metadata
-    %0 = ttg.convert_layout %arg0 : tensor<128xi32, #src> -> tensor<128xi32, #dst>
+module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, "ttg.threads-per-warp" = 32 : i32, "ttg.total-num-warps" = 8 : i32, ttg.shared = 0 : i32, ttg.target = "cuda:90", ttg.tensor_memory_size = 0 : i32} {
+  tt.func public @empty_ws_reservation() {
+    // The lock capture makes WarpSpecialize scratch a shared-memory effect,
+    // so the stable reservation is lock + write/read visibility pointers.
+    // EMPTY: ttg.warp_specialize() attributes {consan.extra_capture_bytes = 24 : i32}
+    // EMPTY-INTEGRATION: ttg.warp_specialize({{.*}}allocation.size = 24 : i32
+    ttg.warp_specialize()
+    default {
+      ttg.warp_yield
+    }
+    partition0() num_warps(4) {
+      ttg.warp_return
+    } : () -> ()
     tt.return
   }
 }
 
-//--- convert-partial-metadata.mlir
+//--- scratch-missing-offset.mlir
 
 #src = #ttg.blocked<{sizePerThread = [1], threadsPerWarp = [32], warpsPerCTA = [4], order = [0]}>
 #dst_parent = #ttg.blocked<{sizePerThread = [1, 1], threadsPerWarp = [1, 32], warpsPerCTA = [1, 4], order = [1, 0]}>
 #dst = #ttg.slice<{dim = 1, parent = #dst_parent}>
 
 module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, "ttg.threads-per-warp" = 32 : i32, "ttg.total-num-warps" = 4 : i32, ttg.shared = 512 : i32, ttg.target = "cuda:90", ttg.tensor_memory_size = 0 : i32} {
-  tt.func public @convert_partial_metadata(%arg0: tensor<128xi32, #src>) {
-    // CVT-PARTIAL: error: convert_layout scratch allocation metadata must include both allocation.offset and allocation.size
-    %0 = ttg.convert_layout %arg0 {allocation.offset = 0 : i32} : tensor<128xi32, #src> -> tensor<128xi32, #dst>
+  tt.func public @scratch_missing_offset(%arg0: tensor<128xi32, #src>) {
+    // SCRATCH-MISSING-OFFSET: error: compiler scratch metadata requires integer allocation.offset and allocation.size attributes
+    %0 = ttg.convert_layout %arg0 {allocation.size = 512 : i32} : tensor<128xi32, #src> -> tensor<128xi32, #dst>
     tt.return
   }
 }
 
-//--- convert-invalid-metadata.mlir
+//--- scratch-invalid.mlir
 
 #src = #ttg.blocked<{sizePerThread = [1], threadsPerWarp = [32], warpsPerCTA = [4], order = [0]}>
 #dst_parent = #ttg.blocked<{sizePerThread = [1, 1], threadsPerWarp = [1, 32], warpsPerCTA = [1, 4], order = [1, 0]}>
 #dst = #ttg.slice<{dim = 1, parent = #dst_parent}>
 
 module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, "ttg.threads-per-warp" = 32 : i32, "ttg.total-num-warps" = 4 : i32, ttg.shared = 512 : i32, ttg.target = "cuda:90", ttg.tensor_memory_size = 0 : i32} {
-  tt.func public @convert_invalid_metadata(%arg0: tensor<128xi32, #src>) {
-    // CVT-INVALID: error: invalid convert_layout scratch allocation metadata: offset 16777215, size 2
+  tt.func public @scratch_invalid(%arg0: tensor<128xi32, #src>) {
+    // SCRATCH-INVALID: error: invalid compiler scratch allocation metadata: offset 16777215, size 2
     %0 = ttg.convert_layout %arg0 {allocation.offset = 16777215 : i32, allocation.size = 2 : i32} : tensor<128xi32, #src> -> tensor<128xi32, #dst>
     tt.return
   }

--- a/test/TritonGPU/consan.mlir
+++ b/test/TritonGPU/consan.mlir
@@ -165,13 +165,15 @@ module attributes {"ttg.num-ctas" = 2 : i32, "ttg.num-warps" = 4 : i32, ttg.shar
 #local_atomic_shared = #ttg.swizzled_shared<{vec = 1, perPhase = 1, maxPhase = 1, order = [1, 0], CGALayout = [[0, 1]]}>
 #local_atomic_tma_shared = #ttg.nvmma_shared<{swizzlingByteWidth = 64, transposed = false, elementBitWidth = 32, CGALayout = [[0, 1]]}>
 #local_atomic_smem = #ttg.shared_memory
-#local_atomic_blocked = #ttg.blocked<{sizePerThread = [1, 1], threadsPerWarp = [1, 32], warpsPerCTA = [1, 4], order = [1, 0], CGALayout = [[0, 1]]}>
-module attributes {"ttg.num-ctas" = 2 : i32, "ttg.num-warps" = 4 : i32, ttg.shared = 1024 : i32, ttg.target = "cuda:90", ttg.tensor_memory_size = 0 : i32, "ttg.threads-per-warp" = 32 : i32, "ttg.total-num-warps" = 4 : i32} {
+#local_atomic_blocked = #ttg.blocked<{sizePerThread = [1, 1], threadsPerWarp = [1, 32], warpsPerCTA = [2, 4], order = [1, 0], CGALayout = [[0, 1]]}>
+module attributes {"ttg.num-ctas" = 2 : i32, "ttg.num-warps" = 8 : i32, ttg.shared = 1536 : i32, ttg.target = "cuda:90", ttg.tensor_memory_size = 0 : i32, "ttg.threads-per-warp" = 32 : i32, "ttg.total-num-warps" = 8 : i32} {
   // CHECK-LABEL: @local_atomic_scatter_rmw_effects
-  tt.func public @local_atomic_scatter_rmw_effects(%out: !tt.tensordesc<8x32xi32, #local_atomic_tma_shared>) {
+  tt.func public @local_atomic_scatter_rmw_effects(
+      %out: !tt.tensordesc<8x32xi32, #local_atomic_tma_shared>,
+      %result: tensor<8x32x!tt.ptr<i32>, #local_atomic_blocked>) {
     // The atomic is the allocation's only user, so this descriptor proves
     // BufferRegion discovers its full destination.
-    // CHECK-DAG: tti.experimental_buffer_descriptors [0, 512], [512, 512], shared_mem : tensor<2xi64
+    // CHECK-DAG: tti.experimental_buffer_descriptors [0, 512, 1024, 0], [512, 512, 512, 0], shared_mem : tensor<4xi64
     %c0 = arith.constant 0 : i32
     %indices = arith.constant dense<0> : tensor<8x32xi32, #local_atomic_blocked>
     %values = arith.constant dense<1> : tensor<8x32xi32, #local_atomic_blocked>
@@ -180,7 +182,11 @@ module attributes {"ttg.num-ctas" = 2 : i32, "ttg.num-warps" = 4 : i32, ttg.shar
     %proxy = ttg.local_alloc {allocation.offset = 512 : i32} : () -> !ttg.memdesc<8x32xi32, #local_atomic_tma_shared, #local_atomic_smem, mutable>
 
     // Runtime indices along the sharded axis can target either CTA row.
-    // CHECK: %[[ATOMIC_CTAS:.*]] = arith.constant 3 : i32
+    // The destination spans the cluster, while the non-broadcast result
+    // scratch is local to the issuer. The combined effect must retain both.
+    // CHECK: %[[ATOMIC_DST_CTAS:.*]] = arith.constant 3 : i32
+    // CHECK: %[[ATOMIC_CURRENT_CTA:.*]] = arith.shli {{.*}} : i32
+    // CHECK: %[[ATOMIC_CTAS:.*]] = arith.ori %[[ATOMIC_DST_CTAS]], %[[ATOMIC_CURRENT_CTA]] : i32
     // CHECK: %[[ATOMIC_BUF:.*]] = tti.experimental_memdesc_to_i32 %[[ATOMIC_DST]]
     // CHECK: %[[ATOMIC_BYTES:.*]] = arith.constant 512 : i32
     // CHECK: tt.call @__triton_consan_set_proxy_access{{.*}}(%[[ATOMIC_BUF]], %[[ATOMIC_BYTES]], {{.*}}%[[ATOMIC_CTAS]])
@@ -189,9 +195,68 @@ module attributes {"ttg.num-ctas" = 2 : i32, "ttg.num-warps" = 4 : i32, ttg.shar
     // CHECK: tt.call @__triton_consan_set_write_visibility{{.*}}({{.*}}%[[ATOMIC_CTAS]]{{.*}})
     // CHECK: tt.call @__triton_consan_clear_read_visibility{{.*}}({{.*}}%[[ATOMIC_CTAS]]{{.*}})
     // CHECK: ttg.local_atomic_scatter_rmw
-    %old = ttg.local_atomic_scatter_rmw add, %dst[%indices], %values {axis = 1 : i32} : (!ttg.memdesc<8x32xi32, #local_atomic_shared, #local_atomic_smem, mutable>, tensor<8x32xi32, #local_atomic_blocked>, tensor<8x32xi32, #local_atomic_blocked>) -> tensor<8x32xi32, #local_atomic_blocked>
+    %old = ttg.local_atomic_scatter_rmw add, %dst[%indices], %values {allocation.offset = 1024 : i32, allocation.size = 512 : i32, axis = 1 : i32} : (!ttg.memdesc<8x32xi32, #local_atomic_shared, #local_atomic_smem, mutable>, tensor<8x32xi32, #local_atomic_blocked>, tensor<8x32xi32, #local_atomic_blocked>) -> tensor<8x32xi32, #local_atomic_blocked>
+    tt.store %result, %old : tensor<8x32x!tt.ptr<i32>, #local_atomic_blocked>
     // Enable proxy tracking without giving the atomic destination another user.
     ttng.async_tma_copy_local_to_global %out[%c0, %c0] %proxy : !tt.tensordesc<8x32xi32, #local_atomic_tma_shared>, !ttg.memdesc<8x32xi32, #local_atomic_tma_shared, #local_atomic_smem, mutable>
+    tt.return
+  }
+}
+
+// -----
+
+#append_shared = #ttg.swizzled_shared<{vec = 1, perPhase = 1, maxPhase = 1, order = [0]}>
+#append_smem = #ttg.shared_memory
+#append_blocked = #ttg.blocked<{sizePerThread = [1], threadsPerWarp = [32], warpsPerCTA = [4], order = [0]}>
+module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.shared = 132 : i32, ttg.target = "cuda:90", ttg.tensor_memory_size = 0 : i32, "ttg.threads-per-warp" = 32 : i32, "ttg.total-num-warps" = 4 : i32} {
+  // CHECK-LABEL: @local_atomic_preserves_destination_effect
+  tt.func public @local_atomic_preserves_destination_effect(
+      %indices: tensor<1xi32, #append_blocked>,
+      %values: tensor<1xi32, #append_blocked>,
+      %out: tensor<1x!tt.ptr<i32>, #append_blocked>) {
+    // CHECK-DAG: tti.experimental_buffer_descriptors [0, 128], [4, 4], shared_mem
+    // CHECK: %[[APPEND_DST:.*]] = ttg.local_alloc {allocation.offset = 0 : i32}
+    %dst = ttg.local_alloc {allocation.offset = 0 : i32}
+        : () -> !ttg.memdesc<1xi32, #append_shared, #append_smem, mutable>
+
+    // The destination memdesc and compiler scratch must both survive effect
+    // construction for the same operation.
+    // CHECK: %[[APPEND_DST_I32:.*]] = tti.experimental_memdesc_to_i32 %[[APPEND_DST]]
+    // CHECK: %[[APPEND_SCRATCH:.*]] = tti.experimental_shared_memory_offset_to_i32 128
+    // CHECK: ttg.local_atomic_scatter_rmw
+    %old = ttg.local_atomic_scatter_rmw add, %dst[%indices], %values {
+        allocation.offset = 128 : i32, allocation.size = 4 : i32, axis = 0 : i32}
+        : (!ttg.memdesc<1xi32, #append_shared, #append_smem, mutable>,
+           tensor<1xi32, #append_blocked>, tensor<1xi32, #append_blocked>)
+        -> tensor<1xi32, #append_blocked>
+    tt.store %out, %old : tensor<1x!tt.ptr<i32>, #append_blocked>
+    tt.return
+  }
+}
+
+// -----
+
+module attributes {"ttg.num-ctas" = 2 : i32, "ttg.num-warps" = 1 : i32, ttg.shared = 4 : i32, ttg.target = "cuda:90", ttg.tensor_memory_size = 0 : i32, "ttg.threads-per-warp" = 32 : i32, "ttg.total-num-warps" = 1 : i32} {
+  // CHECK-LABEL: @scalar_atomic_scratch_broadcast
+  tt.func public @scalar_atomic_scratch_broadcast(
+      %ptr: !tt.ptr<i32>, %out: !tt.ptr<i32>) {
+    %one = arith.constant 1 : i32
+    // Only CTA 0 produces the scalar result; both CTAs consume its scratch.
+    // CHECK: tti.experimental_lock_acquire
+    // CHECK: %[[SCALAR_CTA:.*]] = tti.experimental_cluster_cta_id
+    // CHECK: %[[SCALAR_IS_PRODUCER:.*]] = arith.cmpi eq, {{.*}} : i32
+    // CHECK: %[[SCALAR_ALL_CTAS:.*]] = arith.constant 3 : i32
+    // CHECK: %[[SCALAR_SHIFTED_RECIPIENTS:.*]] = arith.shli %[[SCALAR_ALL_CTAS]], {{.*}} : i32
+    // CHECK: %[[SCALAR_RECIPIENTS:.*]] = arith.ori {{.*}}, %[[SCALAR_SHIFTED_RECIPIENTS]] : i32
+    // CHECK: %[[SCALAR_SCRATCH:.*]] = tti.experimental_shared_memory_offset_to_i32 0
+    // CHECK: tt.call @__triton_consan_set_write_visibility{{.*}}(%[[SCALAR_SCRATCH]], {{.*}}, {{.*}}%[[SCALAR_IS_PRODUCER]], {{.*}}%[[SCALAR_RECIPIENTS]])
+    // CHECK: tt.atomic_rmw
+    %old = tt.atomic_rmw add, relaxed, gpu, %ptr, %one {
+        allocation.offset = 0 : i32, allocation.size = 4 : i32}
+        : (!tt.ptr<i32>, i32) -> i32
+    tt.store %out, %old : !tt.ptr<i32>
+    // Keep the NVIDIA dialect loaded in this standalone split module.
+    ttng.cluster_barrier {relaxed = true}
     tt.return
   }
 }

--- a/test/TritonGPU/consan.mlir
+++ b/test/TritonGPU/consan.mlir
@@ -232,6 +232,132 @@ module attributes {"ttg.num-ctas" = 2 : i32, "ttg.num-warps" = 4 : i32, ttg.shar
 
 // -----
 
+#convert_shared = #ttg.nvmma_shared<{swizzlingByteWidth = 0, transposed = false, elementBitWidth = 32, rank = 1}>
+#convert_smem = #ttg.shared_memory
+#convert_src = #ttg.blocked<{sizePerThread = [1], threadsPerWarp = [32], warpsPerCTA = [4], order = [0]}>
+#convert_dst_parent = #ttg.blocked<{sizePerThread = [1, 1], threadsPerWarp = [1, 32], warpsPerCTA = [1, 4], order = [1, 0]}>
+#convert_dst = #ttg.slice<{dim = 1, parent = #convert_dst_parent}>
+
+module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.shared = 65544 : i32, ttg.target = "cuda:90", ttg.tensor_memory_size = 0 : i32, "ttg.threads-per-warp" = 32 : i32, "ttg.total-num-warps" = 4 : i32} {
+  // CHECK-LABEL: @convert_layout_shared_scratch
+  tt.func public @convert_layout_shared_scratch(
+      %desc: !tt.tensordesc<256xi32, #convert_shared>) {
+    // The conversion's 512-byte scratch range aliases the first half of the
+    // outstanding TMA store's 1024-byte source range.
+    // CHECK-DAG: %[[BUFS:.*]] = tti.experimental_buffer_descriptors [0, 0], [512, 1024], shared_mem
+    // CHECK-DAG: %[[ALIASES:.*]] = arith.constant dense<true> : tensor<2x2xi1, #{{.*}}>
+    %c0 = arith.constant 0 : i32
+    %buf = ttg.local_alloc {allocation.offset = 0 : i32}
+        : () -> !ttg.memdesc<256xi32, #convert_shared, #convert_smem, mutable>
+    ttng.async_tma_copy_local_to_global %desc[%c0] %buf
+        : !tt.tensordesc<256xi32, #convert_shared>,
+          !ttg.memdesc<256xi32, #convert_shared, #convert_smem, mutable>
+    ttg.local_dealloc %buf
+        : !ttg.memdesc<256xi32, #convert_shared, #convert_smem, mutable>
+
+    %value = arith.constant dense<0> : tensor<128xi32, #convert_src>
+    // CHECK: %[[SCRATCH:.*]] = tti.experimental_shared_memory_offset_to_i32 0
+    // CHECK: tt.call @__triton_consan_set_proxy_access
+    // CHECK: %[[SCRATCH_WRITE_LENGTH:.*]] = arith.constant 512 : i32
+    // CHECK-NEXT: {{.*}} = tt.call @__triton_consan_verify_write_visibility{{.*}}(%[[SCRATCH]], %[[SCRATCH_WRITE_LENGTH]], {{.*}})
+    // CHECK: tt.call @__triton_consan_verify_read_visibility
+    // CHECK: %[[SCRATCH_LENGTH:.*]] = arith.constant 512 : i32
+    // CHECK-NEXT: {{.*}} = tt.call @__triton_consan_check_outstanding_commits{{.*}}(%[[SCRATCH]], %[[SCRATCH_LENGTH]], {{.*}}, %[[BUFS]], {{.*}}, %[[ALIASES]])
+    // CHECK: ttg.convert_layout
+    %converted = ttg.convert_layout %value {allocation.offset = 0 : i32, allocation.size = 512 : i32}
+        : tensor<128xi32, #convert_src> -> tensor<128xi32, #convert_dst>
+
+    ttng.async_tma_store_wait {pendings = 0 : i32}
+    tt.return
+  }
+
+}
+
+// -----
+
+#reduce_shared = #ttg.nvmma_shared<{swizzlingByteWidth = 0, transposed = false, elementBitWidth = 32, rank = 1}>
+#reduce_smem = #ttg.shared_memory
+#reduce_layout = #ttg.blocked<{sizePerThread = [1, 2], threadsPerWarp = [1, 32], warpsPerCTA = [1, 4], order = [1, 0]}>
+
+module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.shared = 65544 : i32, ttg.target = "cuda:90", ttg.tensor_memory_size = 0 : i32, "ttg.threads-per-warp" = 32 : i32, "ttg.total-num-warps" = 4 : i32} {
+  // Reduce lowering synthesizes its scratch-backed convert_layout operations
+  // after ConSan, so the parent reduction carries the static scratch effect.
+  // CHECK-LABEL: @reduce_shared_scratch
+  tt.func public @reduce_shared_scratch(
+      %desc: !tt.tensordesc<256xi32, #reduce_shared>) {
+    // Regions sort by (base, length): the explicit source is [0, 1024] and
+    // reduction scratch is [256, 272).
+    // CHECK-DAG: %[[REDUCE_BUFS:.*]] = tti.experimental_buffer_descriptors [0, 256], [1024, 16], shared_mem
+    // CHECK-DAG: %[[REDUCE_ALIASES:.*]] = arith.constant dense<true> : tensor<2x2xi1, #{{.*}}>
+    %c0 = arith.constant 0 : i32
+    %buf = ttg.local_alloc {allocation.offset = 0 : i32}
+        : () -> !ttg.memdesc<256xi32, #reduce_shared, #reduce_smem, mutable>
+    ttng.async_tma_copy_local_to_global %desc[%c0] %buf
+        : !tt.tensordesc<256xi32, #reduce_shared>,
+          !ttg.memdesc<256xi32, #reduce_shared, #reduce_smem, mutable>
+    ttg.local_dealloc %buf
+        : !ttg.memdesc<256xi32, #reduce_shared, #reduce_smem, mutable>
+
+    %value = arith.constant dense<0.000000e+00> : tensor<1x256xf32, #reduce_layout>
+    // CHECK: %[[REDUCE_SCRATCH:.*]] = tti.experimental_shared_memory_offset_to_i32 256
+    // CHECK: tt.call @__triton_consan_verify_read_visibility
+    // CHECK: %[[REDUCE_LENGTH:.*]] = arith.constant 16 : i32
+    // CHECK-NEXT: {{.*}} = tt.call @__triton_consan_check_outstanding_commits{{.*}}(%[[REDUCE_SCRATCH]], %[[REDUCE_LENGTH]], {{.*}}, %[[REDUCE_BUFS]], {{.*}}, %[[REDUCE_ALIASES]])
+    // CHECK: "tt.reduce"
+    %reduced = "tt.reduce"(%value) <{axis = 1 : i32}> ({
+    ^bb0(%lhs: f32, %rhs: f32):
+      %sum = arith.addf %lhs, %rhs : f32
+      tt.reduce.return %sum : f32
+    }) {allocation.offset = 256 : i32, allocation.size = 16 : i32}
+        : (tensor<1x256xf32, #reduce_layout>) -> tensor<1xf32, #ttg.slice<{dim = 1, parent = #reduce_layout}>>
+
+    ttng.async_tma_store_wait {pendings = 0 : i32}
+    tt.return
+  }
+}
+
+// -----
+
+#cross_src = #ttg.blocked<{sizePerThread = [1, 1], threadsPerWarp = [1, 32], warpsPerCTA = [1, 4], order = [1, 0], CGALayout = [[1, 0]]}>
+#cross_dst = #ttg.blocked<{sizePerThread = [1, 1], threadsPerWarp = [1, 32], warpsPerCTA = [1, 4], order = [1, 0], CGALayout = [[0, 1]]}>
+
+module attributes {"ttg.num-ctas" = 2 : i32, "ttg.num-warps" = 4 : i32, ttg.shared = 512 : i32, ttg.target = "cuda:90", ttg.tensor_memory_size = 0 : i32, "ttg.threads-per-warp" = 32 : i32, "ttg.total-num-warps" = 4 : i32} {
+  // CHECK-LABEL: @convert_layout_cross_cta_scratch
+  tt.func public @convert_layout_cross_cta_scratch(
+      %value: tensor<8x32xi32, #cross_src>) {
+    // Every issuer stores to its own scratch and loads from both CTA rows.
+    // CHECK: %[[PEER_CTAS:.*]] = arith.constant 3 : i32
+    // CHECK: %[[CONVERT_CTAS:.*]] = arith.ori {{.*}}, %[[PEER_CTAS]] : i32
+    // CHECK: tt.call @__triton_consan_set_write_visibility{{.*}}({{.*}}%[[CONVERT_CTAS]]{{.*}})
+    // CHECK: ttg.convert_layout
+    %converted = ttg.convert_layout %value {allocation.offset = 0 : i32, allocation.size = 512 : i32}
+        : tensor<8x32xi32, #cross_src> -> tensor<8x32xi32, #cross_dst>
+    // Keep the NVIDIA dialect loaded in this standalone split module.
+    ttng.cluster_barrier {relaxed = true}
+    tt.return
+  }
+}
+
+// -----
+
+#shuffle_src = #ttg.linear<{register = [[0, 1], [0, 2], [0, 4]], lane = [[1, 0], [0, 0], [0, 0], [0, 0], [0, 0]], warp = [], block = []}>
+#shuffle_dst = #ttg.linear<{register = [[1, 0], [0, 4]], lane = [[0, 0], [0, 0], [0, 1], [0, 2], [0, 0]], warp = [], block = []}>
+
+module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 1 : i32, ttg.shared = 32 : i32, ttg.target = "cuda:90", ttg.tensor_memory_size = 0 : i32, "ttg.threads-per-warp" = 32 : i32, "ttg.total-num-warps" = 1 : i32} {
+  // CHECK-LABEL: @convert_layout_forced_warp_shuffle
+  tt.func public @convert_layout_forced_warp_shuffle(
+      %value: tensor<2x8xi16, #shuffle_src>) attributes {always_use_warp_shuffle} {
+    // CHECK-NOT: tti.experimental_shared_memory_offset_to_i32
+    // CHECK: ttg.convert_layout
+    // CHECK-NOT: tti.experimental_shared_memory_offset_to_i32
+    %converted = ttg.convert_layout %value {allocation.offset = 0 : i32, allocation.size = 32 : i32}
+        : tensor<2x8xi16, #shuffle_src> -> tensor<2x8xi16, #shuffle_dst>
+    tt.return
+  }
+}
+
+// -----
+
 #shared = #ttg.nvmma_shared<{swizzlingByteWidth = 128, transposed = false, elementBitWidth = 32}>
 #shared1 = #ttg.swizzled_shared<{vec = 1, perPhase = 1, maxPhase = 1, order = [0]}>
 #smem = #ttg.shared_memory
@@ -907,32 +1033,25 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 1 : i32, ttg.shar
 
     // CHECK: ttng.init_barrier
     // CHECK: arith.shli
-    // CHECK: %[[TC_BIT:.*]] = arith.constant 1 : i32
     // CHECK: %[[A_I64:.*]] = tti.experimental_memdesc_to_i32 %[[A:.*]] :
+    // CHECK: %[[TC_BIT:.*]] = arith.constant 1 : i32
     // CHECK: tt.call @__triton_consan_verify_write_visibility{{.*}}%[[A_I64]], {{[^,]+}}, %{{[^,]+}}, %[[TC_BIT]], %[[SM_BUFS]], %[[SM_WRITE_VISIBILITY_GLOB]]
     // CHECK: %[[TC_MASK:.*]] = arith.constant 2 : i64
-    // CHECK: %[[A_I64:.*]] = tti.experimental_memdesc_to_i32 %[[A]] :
     // CHECK: tt.call @__triton_consan_set_read_visibility{{.*}}%[[A_I64]], {{[^,]+}}, %{{[^,]+}}, %[[TC_MASK]], %[[SM_BUFS]], %[[SM_READ_VISIBILITY_GLOB]]
-    // CHECK: %[[TC_BIT:.*]] = arith.constant 1 : i32
     // CHECK: %[[B_I64:.*]] = tti.experimental_memdesc_to_i32 %[[B:.*]] :
+    // CHECK: %[[TC_BIT:.*]] = arith.constant 1 : i32
     // CHECK: tt.call @__triton_consan_verify_write_visibility{{.*}}%[[B_I64]], {{[^,]+}}, %{{[^,]+}}, %[[TC_BIT]], %[[SM_BUFS]], %[[SM_WRITE_VISIBILITY_GLOB]]
     // CHECK: %[[TC_MASK:.*]] = arith.constant 2 : i64
-    // CHECK: %[[B_I64:.*]] = tti.experimental_memdesc_to_i32 %[[B]] :
     // CHECK: tt.call @__triton_consan_set_read_visibility{{.*}}%[[B_I64]], {{[^,]+}}, %{{[^,]+}}, %[[TC_MASK]], %[[SM_BUFS]], %[[SM_READ_VISIBILITY_GLOB]]
-    // CHECK: %[[TC_BIT:.*]] = arith.constant 1 : i32
     // CHECK: %[[ACC_I64:.*]] = tti.experimental_memdesc_to_i32 %[[ACC:.*]] :
+    // CHECK: %[[TC_BIT:.*]] = arith.constant 1 : i32
     // CHECK: tt.call @__triton_consan_verify_write_visibility{{.*}}%[[ACC_I64]], {{[^,]+}}, %{{[^,]+}}, %[[TC_BIT]], %[[TM_BUFS]], %[[TM_WRITE_VISIBILITY_GLOB]]
     // CHECK: %[[TC_BIT:.*]] = arith.constant 1 : i32
-    // CHECK: %[[ACC_I64:.*]] = tti.experimental_memdesc_to_i32 %[[ACC]] :
     // CHECK: tt.call @__triton_consan_verify_read_visibility{{.*}}%[[ACC_I64]], {{[^,]+}}, %{{[^,]+}}, %[[TC_BIT]], %[[TM_BUFS]], %[[TM_READ_VISIBILITY_GLOB]]
     // CHECK: %[[TC_MASK:.*]] = arith.constant 2 : i64
-    // CHECK: %[[ACC_I64:.*]] = tti.experimental_memdesc_to_i32 %[[ACC]] :
     // CHECK: tt.call @__triton_consan_set_write_visibility{{.*}}%[[ACC_I64]], {{[^,]+}}, %{{[^,]+}}, %[[TC_MASK]], %[[TM_BUFS]], %[[TM_WRITE_VISIBILITY_GLOB]]
-    // CHECK: %[[ACC_I64:.*]] = tti.experimental_memdesc_to_i32 %[[ACC]] :
     // CHECK: tt.call @__triton_consan_clear_write_tracking{{.*}}%[[ACC_I64]], {{[^,]+}}, %{{[^,]+}}, %[[TM_BUFS]], %[[TM_WRITE_TRACKING_GLOB]]
-    // CHECK: %[[ACC_I64:.*]] = tti.experimental_memdesc_to_i32 %[[ACC]] :
     // CHECK: tt.call @__triton_consan_clear_read_visibility{{.*}}%[[ACC_I64]], {{[^,]+}}, %{{[^,]+}}, %[[TM_BUFS]], %[[TM_READ_VISIBILITY_GLOB]]
-    // CHECK: %[[ACC_I64:.*]] = tti.experimental_memdesc_to_i32 %[[ACC]] :
     // CHECK: tt.call @__triton_consan_clear_read_tracking{{.*}}%[[ACC_I64]], {{.*}}, %[[TM_BUFS]], %{{[^,]+}}
     // CHECK: tt.call @__triton_consan_verify_barrier_initialized
     // CHECK: %[[TC_BIT:.*]] = arith.constant 1 : i32
@@ -985,32 +1104,25 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 1 : i32, ttg.shar
 
     // CHECK: ttng.init_barrier
     // CHECK: arith.shli
-    // CHECK: %[[TC_BIT:.*]] = arith.constant 1 : i32
     // CHECK: %[[A_I64:.*]] = tti.experimental_memdesc_to_i32 %[[A:.*]] :
+    // CHECK: %[[TC_BIT:.*]] = arith.constant 1 : i32
     // CHECK: tt.call @__triton_consan_verify_write_visibility{{.*}}%[[A_I64]], {{[^,]+}}, %{{[^,]+}}, %[[TC_BIT]], %[[TM_BUFS]], %[[TM_WRITE_VISIBILITY_GLOB]]
     // CHECK: %[[TC_MASK:.*]] = arith.constant 2 : i64
-    // CHECK: %[[A_I64:.*]] = tti.experimental_memdesc_to_i32 %[[A]] :
     // CHECK: tt.call @__triton_consan_set_read_visibility{{.*}}%[[A_I64]], {{[^,]+}}, %{{[^,]+}}, %[[TC_MASK]], %[[TM_BUFS]], %[[TM_READ_VISIBILITY_GLOB]]
-    // CHECK: %[[TC_BIT:.*]] = arith.constant 1 : i32
     // CHECK: %[[B_I64:.*]] = tti.experimental_memdesc_to_i32 %[[B:.*]] :
+    // CHECK: %[[TC_BIT:.*]] = arith.constant 1 : i32
     // CHECK: tt.call @__triton_consan_verify_write_visibility{{.*}}%[[B_I64]], {{[^,]+}}, %{{[^,]+}}, %[[TC_BIT]], %[[SM_BUFS]], %[[SM_WRITE_VISIBILITY_GLOB]]
     // CHECK: %[[TC_MASK:.*]] = arith.constant 2 : i64
-    // CHECK: %[[B_I64:.*]] = tti.experimental_memdesc_to_i32 %[[B]] :
     // CHECK: tt.call @__triton_consan_set_read_visibility{{.*}}%[[B_I64]], {{[^,]+}}, %{{[^,]+}}, %[[TC_MASK]], %[[SM_BUFS]], %[[SM_READ_VISIBILITY_GLOB]]
-    // CHECK: %[[TC_BIT:.*]] = arith.constant 1 : i32
     // CHECK: %[[ACC_I64:.*]] = tti.experimental_memdesc_to_i32 %[[ACC:.*]] :
+    // CHECK: %[[TC_BIT:.*]] = arith.constant 1 : i32
     // CHECK: tt.call @__triton_consan_verify_write_visibility{{.*}}%[[ACC_I64]], {{[^,]+}}, %{{[^,]+}}, %[[TC_BIT]], %[[TM_BUFS]], %[[TM_WRITE_VISIBILITY_GLOB]]
     // CHECK: %[[TC_BIT:.*]] = arith.constant 1 : i32
-    // CHECK: %[[ACC_I64:.*]] = tti.experimental_memdesc_to_i32 %[[ACC]] :
     // CHECK: tt.call @__triton_consan_verify_read_visibility{{.*}}%[[ACC_I64]], {{[^,]+}}, %{{[^,]+}}, %[[TC_BIT]], %[[TM_BUFS]], %[[TM_READ_VISIBILITY_GLOB]]
     // CHECK: %[[TC_MASK:.*]] = arith.constant 2 : i64
-    // CHECK: %[[ACC_I64:.*]] = tti.experimental_memdesc_to_i32 %[[ACC]] :
     // CHECK: tt.call @__triton_consan_set_write_visibility{{.*}}%[[ACC_I64]], {{[^,]+}}, %{{[^,]+}}, %[[TC_MASK]], %[[TM_BUFS]], %[[TM_WRITE_VISIBILITY_GLOB]]
-    // CHECK: %[[ACC_I64:.*]] = tti.experimental_memdesc_to_i32 %[[ACC]] :
     // CHECK: tt.call @__triton_consan_clear_write_tracking{{.*}}%[[ACC_I64]], {{[^,]+}}, %{{[^,]+}}, %[[TM_BUFS]], %[[TM_WRITE_TRACKING_GLOB]]
-    // CHECK: %[[ACC_I64:.*]] = tti.experimental_memdesc_to_i32 %[[ACC]] :
     // CHECK: tt.call @__triton_consan_clear_read_visibility{{.*}}%[[ACC_I64]], {{[^,]+}}, %{{[^,]+}}, %[[TM_BUFS]], %[[TM_READ_VISIBILITY_GLOB]]
-    // CHECK: %[[ACC_I64:.*]] = tti.experimental_memdesc_to_i32 %[[ACC]] :
     // CHECK: tt.call @__triton_consan_clear_read_tracking{{.*}}%[[ACC_I64]], {{.*}}, %[[TM_BUFS]], %{{[^,]+}}
     // CHECK: tt.call @__triton_consan_verify_barrier_initialized
     // CHECK: %[[TC_BIT:.*]] = arith.constant 1 : i32
@@ -1103,12 +1215,10 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 1 : i32, ttg.shar
 
     // CHECK: %[[A_I64:.*]] = tti.experimental_memdesc_to_i32 %[[A:.*]] :
     // CHECK: tt.call @__triton_consan_verify_write_visibility_noalias_nw1{{.*}}(%[[A_I64]]
-    // CHECK: %[[A_I64:.*]] = tti.experimental_memdesc_to_i32 %[[A]] :
     // CHECK: %[[THREAD_BIT:.*]] = arith.constant 0 : i32
     // CHECK: tt.call @__triton_consan_check_outstanding_commits{{.*}}(%[[A_I64]], {{.*}}, %[[THREAD_BIT]], %[[BUFFERS]], %[[WRT_COMMITS_GLOB]]
     // CHECK: tt.call @__triton_consan_verify_read_visibility_noalias_nw1
     // CHECK: %[[THREAD_BIT:.*]] = arith.constant 0 : i32
-    // CHECK: %[[A_I64:.*]] = tti.experimental_memdesc_to_i32 %[[A]] :
     // CHECK: tt.call @__triton_consan_stage_access_for_commit_nw1{{.*}}(%[[A_I64]], {{.*}}, %[[THREAD_BIT]], %[[BUFFERS]], %[[WRT_COMMITS_GLOB]]
     // CHECK: ttg.async_copy_global_to_local %{{.*}}, %[[A]]
 
@@ -1140,13 +1250,10 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 1 : i32, ttg.shar
 
     // CHECK: %[[A_I64:.*]] = tti.experimental_memdesc_to_i32 %[[A:.*]] :
     // CHECK: tt.call @__triton_consan_verify_write_visibility_noalias{{.*}}(%[[A_I64]]
-    // CHECK: %[[A_I64:.*]] = tti.experimental_memdesc_to_i32 %[[A]] :
     // CHECK: %[[THREAD_BIT:.*]] = arith.constant 0 : i32
     // CHECK: tt.call @__triton_consan_check_outstanding_commits{{.*}}(%[[A_I64]], {{.*}}, %[[THREAD_BIT]], %[[BUFFERS]], %[[WRT_COMMITS_GLOB]]
-    // CHECK: %[[A_I64:.*]] = tti.experimental_memdesc_to_i32 %[[A]] :
     // CHECK: tt.call @__triton_consan_verify_read_visibility{{.*}}(%[[A_I64]]
     // CHECK: %[[THREAD_BIT:.*]] = arith.constant 0 : i32
-    // CHECK: %[[A_I64:.*]] = tti.experimental_memdesc_to_i32 %[[A]] :
     // CHECK: tt.call @__triton_consan_stage_access_for_commit{{.*}}(%[[A_I64]], {{.*}}, %[[THREAD_BIT]], %[[BUFFERS]], %[[WRT_COMMITS_GLOB]]
     // CHECK: ttg.async_copy_global_to_local %{{.*}}, %[[A]]
     %bar = ttg.local_alloc {allocation.offset = 65536 : i32} : () -> !ttg.memdesc<1xi64, #shared1, #smem, mutable>
@@ -1350,7 +1457,6 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.shar
     // CHECK: %[[BUF:.*]] = ttg.local_alloc
     // CHECK: %[[BUF_I64:.*]] = tti.experimental_memdesc_to_i32 %[[BUF:.*]] :
     // CHECK: tt.call @__triton_consan_verify_write_visibility{{.*}}(%[[BUF_I64]]
-    // CHECK: %[[BUF_I64:.*]] = tti.experimental_memdesc_to_i32 %[[BUF:.*]] :
     // CHECK: tt.call @__triton_consan_verify_read_visibility{{.*}}(%[[BUF_I64]]
     %buf = ttg.local_alloc %acc {allocation.offset = 0 : i32} : (tensor<128x128xf16, #mma>) -> !ttg.memdesc<128x128xf16, #shared, #smem, mutable>
     %bar = ttg.local_alloc {allocation.offset = 4096 : i32} : () -> !ttg.memdesc<1xi64, #shared1, #smem, mutable>
@@ -1373,7 +1479,6 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.shar
     // CHECK: %[[BUF:.*]] = ttng.tmem_alloc
     // CHECK: %[[BUF_I64:.*]] = tti.experimental_memdesc_to_i32 %[[BUF:.*]] :
     // CHECK: tt.call @__triton_consan_verify_write_visibility{{.*}}(%[[BUF_I64]]
-    // CHECK: %[[BUF_I64:.*]] = tti.experimental_memdesc_to_i32 %[[BUF:.*]] :
     // CHECK: tt.call @__triton_consan_verify_read_visibility{{.*}}(%[[BUF_I64]]
     %buf = ttng.tmem_alloc %acc { tensor_memory_col_offset = 0 : i32, tensor_memory_row_offset = 0 : i32 } : (tensor<128x128xf16, #blocked>) -> !ttg.memdesc<128x128xf16, #tmem, #ttng.tensor_memory, mutable>
     %bar = ttg.local_alloc {allocation.offset = 4096 : i32} : () -> !ttg.memdesc<1xi64, #shared1, #smem, mutable>

--- a/test/TritonGPU/consan.mlir
+++ b/test/TritonGPU/consan.mlir
@@ -340,6 +340,63 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.shar
 
 // -----
 
+#frontier_shared = #ttg.nvmma_shared<{swizzlingByteWidth = 0, transposed = false, elementBitWidth = 32, rank = 1}>
+#frontier_barrier = #ttg.swizzled_shared<{vec = 1, perPhase = 1, maxPhase = 1, order = [0]}>
+#frontier_smem = #ttg.shared_memory
+#frontier_src = #ttg.blocked<{sizePerThread = [1], threadsPerWarp = [32], warpsPerCTA = [4], order = [0]}>
+#frontier_dst_parent = #ttg.blocked<{sizePerThread = [1, 1], threadsPerWarp = [1, 32], warpsPerCTA = [1, 4], order = [1, 0]}>
+#frontier_dst = #ttg.slice<{dim = 1, parent = #frontier_dst_parent}>
+
+module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.shared = 8200 : i32, ttg.target = "cuda:90", ttg.tensor_memory_size = 0 : i32, "ttg.threads-per-warp" = 32 : i32, "ttg.total-num-warps" = 4 : i32} {
+  // The helper must select complete descriptor intervals, rather than all
+  // proxy state or every overlapping region.
+  // CHECK-LABEL: tt.func private @__triton_consan_track_proxy_accesses_for_buffer
+  // CHECK-SAME: %arg8: i32, %arg9: i32, %arg10: tensor<4xi64
+  // CHECK: arith.cmpi uge
+  // CHECK: arith.cmpi ule
+  // CHECK: arith.cmpi ne
+  // CHECK-LABEL: @tma_completion_tracks_contained_proxy_frontier
+  tt.func public @tma_completion_tracks_contained_proxy_frontier(
+      %desc: !tt.tensordesc<1024xi32, #frontier_shared>) {
+    // The conversion scratch is contained in the TMA destination. The third
+    // descriptor only partially overlaps it, while the fourth is disjoint;
+    // neither may be published by TMA completion.
+    // CHECK-DAG: %[[FRONTIER_BUFS:.*]] = tti.experimental_buffer_descriptors [0, 0, 3840, 4608], [512, 4096, 512, 512], shared_mem
+    %c0 = arith.constant 0 : i32
+    %true = arith.constant true
+    %value = arith.constant dense<0> : tensor<128xi32, #frontier_src>
+    %converted = ttg.convert_layout %value {allocation.offset = 0 : i32, allocation.size = 512 : i32}
+        : tensor<128xi32, #frontier_src> -> tensor<128xi32, #frontier_dst>
+    %partial = ttg.local_alloc %value {allocation.offset = 3840 : i32}
+        : (tensor<128xi32, #frontier_src>) -> !ttg.memdesc<128xi32, #frontier_shared, #frontier_smem, mutable>
+    %dst = ttg.local_alloc {allocation.offset = 0 : i32}
+        : () -> !ttg.memdesc<1024xi32, #frontier_shared, #frontier_smem, mutable>
+    %bar = ttg.local_alloc {allocation.offset = 8192 : i32}
+        : () -> !ttg.memdesc<1xi64, #frontier_barrier, #frontier_smem, mutable>
+    ttng.init_barrier %bar, 1
+        : !ttg.memdesc<1xi64, #frontier_barrier, #frontier_smem, mutable>
+    ttng.barrier_expect %bar, 4096, %true
+        : !ttg.memdesc<1xi64, #frontier_barrier, #frontier_smem, mutable>
+    ttng.fence_async_shared {bCluster = false}
+
+    // This access occurs after the fence and is outside the TMA destination.
+    %unrelated = ttg.local_alloc %value {allocation.offset = 4608 : i32}
+        : (tensor<128xi32, #frontier_src>) -> !ttg.memdesc<128xi32, #frontier_shared, #frontier_smem, mutable>
+
+    // CHECK: tt.call @__triton_consan_track_barrier_write_for_buffer
+    // CHECK: %[[TRACK_DST_LEN:.*]] = arith.constant 4096 : i32
+    // CHECK-NEXT: tt.call @__triton_consan_track_proxy_accesses_for_buffer{{.*}}({{.*}}, {{.*}}, {{.*}}, {{.*}}, {{.*}}, {{.*}}, {{.*}}, {{.*}}, {{.*}}, %[[TRACK_DST_LEN]], %[[FRONTIER_BUFS]], {{.*}})
+    // CHECK: ttng.async_tma_copy_global_to_local
+    ttng.async_tma_copy_global_to_local %desc[%c0] %dst, %bar, %true
+        : !tt.tensordesc<1024xi32, #frontier_shared>,
+          !ttg.memdesc<1xi64, #frontier_barrier, #frontier_smem, mutable>
+          -> !ttg.memdesc<1024xi32, #frontier_shared, #frontier_smem, mutable>
+    tt.return
+  }
+}
+
+// -----
+
 #reduce_shared = #ttg.nvmma_shared<{swizzlingByteWidth = 0, transposed = false, elementBitWidth = 32, rank = 1}>
 #reduce_smem = #ttg.shared_memory
 #reduce_layout = #ttg.blocked<{sizePerThread = [1, 2], threadsPerWarp = [1, 32], warpsPerCTA = [1, 4], order = [1, 0]}>
@@ -588,6 +645,7 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 1 : i32, ttg.shar
     // CHECK: tt.call @__triton_consan_clear_read_visibility
     // CHECK: tt.call @__triton_consan_clear_read_tracking
     // CHECK: tt.call @__triton_consan_track_barrier_write_for_buffer
+    // CHECK: tt.call @__triton_consan_track_proxy_accesses_for_buffer
     // CHECK: tt.call @__triton_consan_verify_barrier_arrive
     // CHECK: tt.call @__triton_consan_update_barrier_state
     ttng.async_tma_copy_global_to_local %arg0[%c0_i32, %c0_i32] %0, %bar, %true : !tt.tensordesc<32x32xf32, #shared>, !ttg.memdesc<1xi64, #shared1, #smem, mutable> -> !ttg.memdesc<32x32xf32, #shared, #smem, mutable>
@@ -727,7 +785,12 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 1 : i32, ttg.shar
     // CHECK: tt.call @__triton_consan_verify_barrier_arrive
     // CHECK: tt.call @__triton_consan_update_barrier_state
     // CHECK: ttng.barrier_expect
-    // CHECK-COUNT-2: tt.call @__triton_consan_track_barrier_write_for_buffer
+    // CHECK: tt.call @__triton_consan_track_barrier_write_for_buffer
+    // CHECK: tt.call @__triton_consan_track_proxy_accesses_for_buffer
+    // CHECK: ttng.async_tma_copy_global_to_local
+    // CHECK: tt.call @__triton_consan_track_barrier_write_for_buffer
+    // CHECK: tt.call @__triton_consan_track_proxy_accesses_for_buffer
+    // CHECK: ttng.async_tma_copy_global_to_local
     ttng.async_tma_copy_global_to_local %a[%c0_i32, %c0_i32] %a_smem, %bar, %true : !tt.tensordesc<32x32xf32, #shared>, !ttg.memdesc<1xi64, #shared1, #smem, mutable> -> !ttg.memdesc<32x32xf32, #shared, #smem, mutable>
     ttng.async_tma_copy_global_to_local %b[%c0_i32, %c0_i32] %b_smem, %bar, %true : !tt.tensordesc<32x32xf32, #shared>, !ttg.memdesc<1xi64, #shared1, #smem, mutable> -> !ttg.memdesc<32x32xf32, #shared, #smem, mutable>
 

--- a/test/TritonGPU/consan.mlir
+++ b/test/TritonGPU/consan.mlir
@@ -405,24 +405,6 @@ module attributes {"ttg.num-ctas" = 2 : i32, "ttg.num-warps" = 4 : i32, ttg.shar
 
 // -----
 
-#shuffle_src = #ttg.linear<{register = [[0, 1], [0, 2], [0, 4]], lane = [[1, 0], [0, 0], [0, 0], [0, 0], [0, 0]], warp = [], block = []}>
-#shuffle_dst = #ttg.linear<{register = [[1, 0], [0, 4]], lane = [[0, 0], [0, 0], [0, 1], [0, 2], [0, 0]], warp = [], block = []}>
-
-module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 1 : i32, ttg.shared = 32 : i32, ttg.target = "cuda:90", ttg.tensor_memory_size = 0 : i32, "ttg.threads-per-warp" = 32 : i32, "ttg.total-num-warps" = 1 : i32} {
-  // CHECK-LABEL: @convert_layout_forced_warp_shuffle
-  tt.func public @convert_layout_forced_warp_shuffle(
-      %value: tensor<2x8xi16, #shuffle_src>) attributes {always_use_warp_shuffle} {
-    // CHECK-NOT: tti.experimental_shared_memory_offset_to_i32
-    // CHECK: ttg.convert_layout
-    // CHECK-NOT: tti.experimental_shared_memory_offset_to_i32
-    %converted = ttg.convert_layout %value {allocation.offset = 0 : i32, allocation.size = 32 : i32}
-        : tensor<2x8xi16, #shuffle_src> -> tensor<2x8xi16, #shuffle_dst>
-    tt.return
-  }
-}
-
-// -----
-
 #shared = #ttg.nvmma_shared<{swizzlingByteWidth = 128, transposed = false, elementBitWidth = 32}>
 #shared1 = #ttg.swizzled_shared<{vec = 1, perPhase = 1, maxPhase = 1, order = [0]}>
 #smem = #ttg.shared_memory

--- a/third_party/amd/lib/Analysis/AMDGPUAllocation.cpp
+++ b/third_party/amd/lib/Analysis/AMDGPUAllocation.cpp
@@ -68,6 +68,8 @@ unsigned AMDAllocationAnalysisScratchSizeFn(Operation *op,
   }
 
   if (auto cvtLayout = dyn_cast<mlir::triton::gpu::ConvertLayoutOp>(op)) {
+    if (cvtUsesForcedWarpShuffle(cvtLayout))
+      return 0;
     auto srcTy = cvtLayout.getSrc().getType();
     auto dstTy = cvtLayout.getType();
     return getConvertLayoutScratchInBytes(srcTy, dstTy, targetInfo);

--- a/third_party/amd/lib/TritonAMDGPUTransforms/ConSanAMD.cpp
+++ b/third_party/amd/lib/TritonAMDGPUTransforms/ConSanAMD.cpp
@@ -91,9 +91,12 @@ public:
     return nullptr;
   }
 
-  std::optional<MemEffectsOpInfo>
+  FailureOr<std::optional<MemEffectsOpInfo>>
   getMemEffectsOpInfo(Operation *op) const override {
-    auto info = ConSanTargetHooks::getMemEffectsOpInfo(op);
+    auto baseInfo = ConSanTargetHooks::getMemEffectsOpInfo(op);
+    if (failed(baseInfo))
+      return failure();
+    auto info = std::move(*baseInfo);
     if (info)
       return info;
     // AsyncTDMCopyGlobalToLocalOp: Async copy from global to shared memory.

--- a/third_party/amd/lib/TritonAMDGPUTransforms/ConSanAMD.cpp
+++ b/third_party/amd/lib/TritonAMDGPUTransforms/ConSanAMD.cpp
@@ -16,6 +16,35 @@ using tti::WaitOpInfo;
 
 namespace mlir {
 
+namespace {
+
+Value getLeaderCTAPredicate(ImplicitLocOpBuilder &b, uint32_t broadcastMask) {
+  Value ctaId = tti::ExperimentalClusterCTAIdOp::create(b, b.getLoc());
+  Value ctaIdInGroup = arith::AndIOp::create(
+      b, ctaId, arith::ConstantIntOp::create(b, broadcastMask, 32));
+  return arith::CmpIOp::create(b, arith::CmpIPredicate::eq, ctaIdInGroup,
+                               arith::ConstantIntOp::create(b, 0, 32));
+}
+
+std::optional<uint16_t> getAtomicScratchBroadcastMask(Operation *op) {
+  if (!op->hasAttr("allocation.size") ||
+      !isa<ttag::BufferAtomicCASOp, ttag::BufferAtomicRMWOp,
+           triton::AtomicRMWOp, triton::AtomicCASOp,
+           ttg::LocalAtomicScatterRMWOp>(op))
+    return std::nullopt;
+
+  // These tensor-result paths all use finalizeTensorAtomicResults, which
+  // broadcasts through shared memory from the canonical producer CTA. Scalar
+  // AMD atomics use CTA-local staging instead.
+  auto tensorTy = dyn_cast<RankedTensorType>(op->getResult(0).getType());
+  if (!tensorTy)
+    return std::nullopt;
+  auto kBlock = StringAttr::get(op->getContext(), "block");
+  return ttg::toLinearLayout(tensorTy).getFreeVariableMasks().lookup(kBlock);
+}
+
+} // namespace
+
 class AMDConSanHooks : public tti::ConSanTargetHooks {
 public:
   bool isTMAOp(Operation *op) const override {
@@ -86,9 +115,24 @@ public:
     return std::nullopt;
   }
 
-  Value getIssuerCTAPred(ImplicitLocOpBuilder & /*b*/,
-                         Operation * /*op*/) const override {
+  Value getIssuerCTAPred(ImplicitLocOpBuilder &b,
+                         Operation *op) const override {
+    if (auto scratchMask = getAtomicScratchBroadcastMask(op);
+        scratchMask && *scratchMask)
+      return getLeaderCTAPredicate(b, *scratchMask);
     return nullptr;
+  }
+
+  SmallVector<Operation *>
+  createInitClusterBarrier(ImplicitLocOpBuilder &b) const override {
+    auto arrive = ttag::ClusterBarrierArriveOp::create(b, b.getLoc());
+    auto wait = ttag::ClusterBarrierWaitOp::create(b, b.getLoc());
+    return {arrive.getOperation(), wait.getOperation()};
+  }
+
+  std::optional<uint16_t>
+  getScratchCTABroadcastMask(Operation *op) const override {
+    return getAtomicScratchBroadcastMask(op);
   }
 
   FailureOr<std::optional<MemEffectsOpInfo>>

--- a/third_party/nvidia/lib/TritonNVIDIAGPUToLLVM/Allocation.cpp
+++ b/third_party/nvidia/lib/TritonNVIDIAGPUToLLVM/Allocation.cpp
@@ -70,6 +70,8 @@ std::function<unsigned(Operation *)>
 getNvidiaAllocationAnalysisScratchSizeFn(TargetInfoBase &targetInfo) {
   auto allocation = [&targetInfo](Operation *op) -> unsigned {
     if (auto cvtOp = dyn_cast<triton::gpu::ConvertLayoutOp>(op)) {
+      if (cvtUsesForcedWarpShuffle(cvtOp))
+        return 0;
       auto srcTy = cvtOp.getSrc().getType();
       auto dstTy = cvtOp.getType();
       if (!cvtNeedsSharedMemory(srcTy, dstTy))

--- a/third_party/nvidia/lib/TritonNVIDIAGPUToLLVM/ConvertLayoutOpToLLVM.cpp
+++ b/third_party/nvidia/lib/TritonNVIDIAGPUToLLVM/ConvertLayoutOpToLLVM.cpp
@@ -43,7 +43,11 @@ struct ConvertLayoutOpSwizzlingConversion
 
     assert(to_vector(conversion.getInDimNames()) ==
            to_vector(conversion.getOutDimNames()));
-    if (!cvtAlwaysUseWarpShuffle(op) && cvtNeedsSharedMemory(srcTy, dstTy)) {
+    // Forced conversions are handled by the common pattern, which owns the
+    // diagnostic when the conversion is not warp-local.
+    if (cvtIsWarpShuffleForced(op))
+      return failure();
+    if (cvtNeedsSharedMemory(srcTy, dstTy)) {
       auto loc = op.getLoc();
 
       auto llvmElemTy = getTypeConverter()->convertType(srcTy.getElementType());


### PR DESCRIPTION
## Summary

ConSan previously tracked only shared-memory regions represented by SSA memdescs. Compiler-owned scratch uses the same shared-memory arena but has no memdesc, so its reuse could race with outstanding asynchronous accesses without being diagnosed.

This change publishes the offset and size of compiler-owned scratch allocations, materializes those regions in ConSan's runtime address space, and models scratch-using operations as accesses to them. For async-proxy writes that complete an mbarrier, ConSan also attaches the producer's post-fence proxy state only to tracked regions fully contained in the write destination. A completion wait therefore transports the ordering justified by that write without publishing unrelated or partially overlapping regions.

## Reviewer notes

- `allocation.size` is the contract that an operation actually uses scratch. `tt.reduce` is modeled at the parent operation because its scratch-backed conversions are created after ConSan runs.
- Destination containment for async-proxy completion is deliberate: fully contained aliases inherit the post-fence state, while partial overlaps remain conservative.
- `always_use_warp_shuffle` is a hard no-scratch contract: feasible conversions allocate no scratch, while infeasible forced conversions produce a diagnostic instead of falling back after allocation.
- Scratch discovery is generic, but cross-CTA routing remains operation-specific for conversions, reductions, and tensor-atomic broadcasts; other scratch effects are CTA-local.