### PR TITLE
fix: include IR overrides in autotune cache keys

### DIFF
--- a/python/test/unit/runtime/test_autotuner.py
+++ b/python/test/unit/runtime/test_autotuner.py
@@ -263,6 +263,14 @@ def test_prune_configs_fractional_top_k_keeps_one(device: str):
     torch.testing.assert_close(src, dst)
 
 
+def test_config_ir_override_changes_disk_cache_key():
+    # Autotuner derives persisted result-cache keys from Config.__str__().
+    first = triton.Config(kwargs={"BLOCK_SIZE": 32}, ir_override="first.ttir")
+    second = triton.Config(kwargs={"BLOCK_SIZE": 32}, ir_override="second.ttir")
+
+    assert str(first) != str(second)
+
+
 @pytest.mark.parametrize("prune_kind", ["early_config_prune", "perf_model"])
 def test_pruned_single_config_skips_benchmark(prune_kind: str, device: str, fresh_knobs):
     N = 1024

--- a/python/triton/runtime/autotuner.py
+++ b/python/triton/runtime/autotuner.py
@@ -388,6 +388,7 @@ class Config:
         res.append(f"num_ctas: {self.num_ctas}")
         res.append(f"num_stages: {self.num_stages}")
         res.append(f"maxnreg: {self.maxnreg}")
+        res.append(f"ir_override: {self.ir_override}")
         return ", ".join(res)
 
     def __hash__(self):


### PR DESCRIPTION
## Summary

- Include `Config.ir_override` in the persisted autotune-result cache key.
- Add a regression test for distinct dedicated IR overrides.

## Why

Autotune cache hits reconstruct and launch the cached configuration. Previously, two configurations that differed only by the documented `ir_override` argument shared a cache key, which could select an earlier IR override.

## Checks

- `python -m compileall -q python/triton/runtime/autotuner.py python/test/unit/runtime/test_autotuner.py`
- Direct baseline-versus-fixed regression check for distinct `ir_override` values
