### PR TITLE
[BC Breaking] fix(language): promote fp8 division and modulo to float32

### DIFF
--- a/docs/python-api/triton-semantics.rst
+++ b/docs/python-api/triton-semantics.rst
@@ -18,6 +18,8 @@ The algorithm is as follows:
 
 4. **Prefer unsigned** Otherwise (same width, different signedness), they are promoted to the unsigned dtype: ``(int32, uint32) -> uint32``
 
+Division and modulo are an exception to the rules above: they do not exist natively for floating point dtypes narrower than ``float32``, so if either operand is a float (of any width), both operands are promoted to ``float32`` for these two operations. Integer division and modulo keep integer promotion.
+
 The rules are a bit different when they involve a scalar. By scalar here we mean a numeric literal, a variable marked with `tl.constexpr` or a combination of these. These are represented by NumPy scalars and have types ``bool``, ``int`` and ``float``.
 
 When an operation involves a tensor and a scalar:

--- a/python/test/unit/language/test_frontend.py
+++ b/python/test/unit/language/test_frontend.py
@@ -848,6 +848,26 @@ def test_return_promotion():
     run_parser(kernel)
 
 
+def test_fp8_div_mod_promotion():
+    # `/` and `%` do not exist natively for fp8, so the result of a division or
+    # modulo between fp8 operands is promoted to fp32 -- the same rule already
+    # applied to float16 and bfloat16. Other ops keep the existing fp8
+    # promotion (same fp8 stays that fp8, mixed fp8 goes to float16).
+
+    @triton.jit
+    def kernel():
+        x = tl.full((8, ), 0, tl.float16).to(tl.float8e5)
+        y = tl.full((8, ), 0, tl.float16).to(tl.float8e5)
+        z = tl.full((8, ), 0, tl.float16).to(tl.float8e4nv)
+        tl.static_assert((x / y).dtype == tl.float32)
+        tl.static_assert((x / z).dtype == tl.float32)
+        tl.static_assert((x % y).dtype == tl.float32)
+        tl.static_assert((x * y).dtype == tl.float8e5)
+        tl.static_assert((x * z).dtype == tl.float16)
+
+    run_parser(kernel)
+
+
 # ===-----------------------------------------------------------------------===#
 # Aggregate inheritance, __post_init__, and aggregate_replace tests
 # ===-----------------------------------------------------------------------===#

--- a/python/test/unit/language/test_frontend.py
+++ b/python/test/unit/language/test_frontend.py
@@ -864,6 +864,13 @@ def test_fp8_div_mod_promotion():
         tl.static_assert((x % y).dtype == tl.float32)
         tl.static_assert((x * y).dtype == tl.float8e5)
         tl.static_assert((x * z).dtype == tl.float16)
+        # A scalar operand doesn't participate in promotion, so / and % against
+        # an fp8 tensor must upcast to fp32 for the same reason, while other ops
+        # keep the fp8 tensor type.
+        tl.static_assert((2.0 / x).dtype == tl.float32)
+        tl.static_assert((x / 2.0).dtype == tl.float32)
+        tl.static_assert((x % 2).dtype == tl.float32)
+        tl.static_assert((x * 2.0).dtype == tl.float8e5)
 
     run_parser(kernel)
 

--- a/python/test/unit/language/test_frontend.py
+++ b/python/test/unit/language/test_frontend.py
@@ -849,28 +849,44 @@ def test_return_promotion():
 
 
 def test_fp8_div_mod_promotion():
-    # `/` and `%` do not exist natively for fp8, so the result of a division or
-    # modulo between fp8 operands is promoted to fp32 -- the same rule already
-    # applied to float16 and bfloat16. Other ops keep the existing fp8
-    # promotion (same fp8 stays that fp8, mixed fp8 goes to float16).
+    # `/` and `%` do not exist natively for floats narrower than fp32, so the
+    # result of a division or modulo with a floating operand is promoted to
+    # fp32 -- one rule covering fp8, fp16 and bfloat16, tensor and scalar
+    # operands alike. Other ops keep the existing promotions (same fp8 stays
+    # that fp8, mixed fp8 goes to float16).
 
     @triton.jit
     def kernel():
         x = tl.full((8, ), 0, tl.float16).to(tl.float8e5)
         y = tl.full((8, ), 0, tl.float16).to(tl.float8e5)
         z = tl.full((8, ), 0, tl.float16).to(tl.float8e4nv)
+        h = tl.full((8, ), 0, tl.float16)
+        b = tl.full((8, ), 0, tl.bfloat16)
+        i = tl.full((8, ), 0, tl.int32)
         tl.static_assert((x / y).dtype == tl.float32)
         tl.static_assert((x / z).dtype == tl.float32)
         tl.static_assert((x % y).dtype == tl.float32)
         tl.static_assert((x * y).dtype == tl.float8e5)
         tl.static_assert((x * z).dtype == tl.float16)
+        # fp16 and bfloat16 division/modulo upcast through the same rule
+        tl.static_assert((h / h).dtype == tl.float32)
+        tl.static_assert((h % h).dtype == tl.float32)
+        tl.static_assert((b / b).dtype == tl.float32)
+        tl.static_assert((h * h).dtype == tl.float16)
+        tl.static_assert((b * b).dtype == tl.bfloat16)
+        # integer division and modulo keep integer promotion
+        tl.static_assert((i // i).dtype == tl.int32)
+        tl.static_assert((i % i).dtype == tl.int32)
         # A scalar operand doesn't participate in promotion, so / and % against
-        # an fp8 tensor must upcast to fp32 for the same reason, while other ops
-        # keep the fp8 tensor type.
+        # a float tensor must upcast to fp32 for the same reason, while other
+        # ops keep the tensor's type.
         tl.static_assert((2.0 / x).dtype == tl.float32)
         tl.static_assert((x / 2.0).dtype == tl.float32)
         tl.static_assert((x % 2).dtype == tl.float32)
+        tl.static_assert((h / 2.0).dtype == tl.float32)
         tl.static_assert((x * 2.0).dtype == tl.float8e5)
+        tl.static_assert((h * 2.0).dtype == tl.float16)
+        tl.static_assert((i // 2).dtype == tl.int32)
 
     run_parser(kernel)
 

--- a/python/triton/language/semantic.py
+++ b/python/triton/language/semantic.py
@@ -102,8 +102,11 @@ class TritonSemantic(Generic[TensorTy]):
                 return tl.bfloat16
         if a_ty.is_bf16() or b_ty.is_bf16():
             return tl.float32
-        # 5) return fp16 if operands are different fp8
+        # 5) return fp16 if operands are different fp8, unless we're doing / or
+        #    %, which do not exist natively for fp8 (same as half/bf16 above)
         if a_ty.is_fp8() and b_ty.is_fp8():
+            if div_or_mod:
+                return tl.float32
             return a_ty if a_ty == b_ty else tl.float16
         if not a_ty.is_int() or not b_ty.is_int():
             raise TypeError(f"unexpected type {a_ty} and {b_ty}")

--- a/python/triton/language/semantic.py
+++ b/python/triton/language/semantic.py
@@ -73,8 +73,8 @@ class TritonSemantic(Generic[TensorTy]):
         if a_is_scalar != b_is_scalar:
             scalar_ty, tensor_ty = (a_ty, b_ty) if a_is_scalar else (b_ty, a_ty)
             if scalar_ty.kind().value <= tensor_ty.kind().value:
-                # Upcast because of 3) and 4) below!
-                if div_or_mod and (tensor_ty in (tl.float16, tl.bfloat16)):
+                # Upcast because of 3), 4) and 5) below!
+                if div_or_mod and (tensor_ty in (tl.float16, tl.bfloat16) or tensor_ty.is_fp8()):
                     return tl.float32
                 return tensor_ty
 

--- a/python/triton/language/semantic.py
+++ b/python/triton/language/semantic.py
@@ -73,8 +73,8 @@ class TritonSemantic(Generic[TensorTy]):
         if a_is_scalar != b_is_scalar:
             scalar_ty, tensor_ty = (a_ty, b_ty) if a_is_scalar else (b_ty, a_ty)
             if scalar_ty.kind().value <= tensor_ty.kind().value:
-                # Upcast because of 3), 4) and 5) below!
-                if div_or_mod and (tensor_ty in (tl.float16, tl.bfloat16) or tensor_ty.is_fp8()):
+                # Upcast because of 2) below!
+                if div_or_mod and tensor_ty.is_floating():
                     return tl.float32
                 return tensor_ty
 
@@ -82,31 +82,25 @@ class TritonSemantic(Generic[TensorTy]):
         #    converted to double
         if a_ty.is_fp64() or b_ty.is_fp64():
             return tl.float64
-        # 2) if one operand is float, the other is implicitly
+        # 2) if we have a div or a mod we upcast to `fp32` as div and mod are
+        #    not supported for floats with bitwidth < 32
+        if div_or_mod and (a_ty.is_floating() or b_ty.is_floating()):
+            return tl.float32
+        # 3) if one operand is float, the other is implicitly
         #    converted to float
         if a_ty.is_fp32() or b_ty.is_fp32():
             return tl.float32
-        # 3 ) if one operand is half, the other is implicitly converted to half
-        #     unless we're doing / or %, which do not exist natively in PTX for fp16.
+        # 4 ) if one operand is half, the other is implicitly converted to half
         #     Supported PTX op: add, sub, mul, fma, neg, abs, min, max, tanh, ex2, setp
         if a_ty.is_fp16() or b_ty.is_fp16():
-            if div_or_mod:
-                return tl.float32
-            else:
-                return tl.float16
-        # 4) return bf16 only if both operands are of bf16
+            return tl.float16
+        # 5) return bf16 only if both operands are of bf16
         if a_ty.is_bf16() and b_ty.is_bf16():
-            if div_or_mod:
-                return tl.float32
-            else:
-                return tl.bfloat16
+            return tl.bfloat16
         if a_ty.is_bf16() or b_ty.is_bf16():
             return tl.float32
-        # 5) return fp16 if operands are different fp8, unless we're doing / or
-        #    %, which do not exist natively for fp8 (same as half/bf16 above)
+        # 6) return fp16 if operands are different fp8
         if a_ty.is_fp8() and b_ty.is_fp8():
-            if div_or_mod:
-                return tl.float32
             return a_ty if a_ty == b_ty else tl.float16
         if not a_ty.is_int() or not b_ty.is_int():
             raise TypeError(f"unexpected type {a_ty} and {b_ty}")


### PR DESCRIPTION
## Summary

`computation_type_impl` already upcast `float16`/`bfloat16` to `float32` for `/` and `%`, because those operations have no native form below fp32. But the fp8 rule and the scalar branch didn't apply the same logic, so `fp8 / fp8`, `fp8 % fp8`, and `scalar / fp8_tensor` kept fp8/fp16 types for division and modulo.

Per lezcano's review, this PR now unifies the rule instead of patching per-dtype: a single rule between rules 1 and 2 —

```python
# 2) if we have a div or a mod we upcast to `fp32` as div and mod are
#    not supported for floats with bitwidth < 32
if div_or_mod and (a_ty.is_floating() or b_ty.is_floating()):
    return tl.float32
```

— and removes the per-dtype `div_or_mod` branches it subsumes. The scalar branch now checks `tensor_ty.is_floating()` so scalar-vs-fp8 division is covered by the same rule. `triton-semantics.rst` documents the fp32 upcast for div/mod.

## Test plan

- New `test_fp8_div_mod_promotion` covers the matrix: fp8 same/mixed, fp16, bf16, int (keeps integer promotion for `//` and `%`), and scalar-vs-tensor operands, for both `/`/`%` and non-division ops.
- Verified on Linux with no GPU: the full 18-case type matrix through `computation_type_impl` passes, and the parser-level `static_assert` kernel passes.
