### PR TITLE
[KERNELS] p_matmul: don't specialize on NUM_SMS (token-count-derived below SM saturation)

### DIFF
--- a/python/triton_kernels/triton_kernels/matmul_details/_p_matmul.py
+++ b/python/triton_kernels/triton_kernels/matmul_details/_p_matmul.py
@@ -110,7 +110,7 @@ def _p_matmul(
              EPILOGUE_SUBTILE: tl.constexpr,
              EVEN_K: tl.constexpr, SPLIT_K: tl.constexpr,
              W_CACHE_MODIFIER: tl.constexpr,
-             NUM_SMS: tl.constexpr,
+             NUM_SMS,
              X_TMA_MODE: tl.constexpr,
              Y_TMA_MODE: tl.constexpr,
              Y_MX_SCALE_LAYOUT: tl.constexpr = None,


### PR DESCRIPTION
Follow-up to #10872 / #10875, separate because it touches a scheduling parameter rather than strides.

`_p_matmul`'s `NUM_SMS: tl.constexpr` receives the launch grid (`grid if opt_flags.is_persistent else 0`). Below SM saturation the grid is `batch_size * cdiv(M, block_m) * grid_n * split_k`, i.e. a function of the runtime token count, so the persistent matmul recompiles every `block_m` step of M — exactly in the small-batch regime where persistent mode is selected.

`NUM_SMS` is only used as the persistent-loop stride (`tl.range(tl.program_id(0), num_blocks, NUM_SMS, ...)`) and the epilogue tile counter, so it can be a plain runtime argument. `tl.num_programs(0)` equals it by construction if that form is preferred. The non-persistent `_matmul` keeps its constexpr since its caller always passes 0.

Verified on the released package (sglang `triton_kernel` MoE backend, gpt-oss-20b on 1×H100): greedy outputs byte-identical to stock; on top of #10875 it reduced cold-start p95 TTFT 1384ms → 1098ms in a paired 200-request serving A/B.

🤖 Generated with [Claude Code](https://claude.com/claude-code)