### PR TITLE
[FRONTEND] Honor `if` filters in list comprehensions

### DIFF
--- a/python/test/unit/language/test_frontend.py
+++ b/python/test/unit/language/test_frontend.py
@@ -421,6 +421,29 @@ def test_tuple_assignment_constexpr_tuple_normalizes_recursively():
     run_parser(kernel)
 
 
+def test_list_comprehension_if_filter():
+
+    @triton.jit
+    def kernel():
+        # an `if` filter drops the elements whose condition is false
+        vals: tl.constexpr = [x for x in (10, 20, 30, 40) if x >= 30]
+        tl.static_assert(len(vals) == 2)
+        tl.static_assert(vals[0] == 30)
+        tl.static_assert(vals[1] == 40)
+
+        # multiple `if` clauses compose as "and"
+        multi: tl.constexpr = [x for x in (0, 1, 2, 3, 4, 5) if x > 1 if x % 2 == 0]
+        tl.static_assert(len(multi) == 2)
+        tl.static_assert(multi[0] == 2)
+        tl.static_assert(multi[1] == 4)
+
+        # an unfiltered comprehension is unchanged
+        allv: tl.constexpr = [x for x in (10, 20, 30, 40)]
+        tl.static_assert(len(allv) == 4)
+
+    run_parser(kernel)
+
+
 def test_named_expr_respects_prior_constexpr_annotation():
 
     @triton.jit

--- a/python/triton/compiler/code_generator.py
+++ b/python/triton/compiler/code_generator.py
@@ -537,7 +537,9 @@ class CodeGenerator(ast.NodeVisitor):
         results = []
         for item in iter:
             self.set_value(comp.target.id, item)
-            results.append(self.visit(node.elt))
+            # Apply the comprehension's `if` filters (the conditions are constexpr).
+            if all(self.visit(cond) for cond in comp.ifs):
+                results.append(self.visit(node.elt))
         return tl_tuple(results)
 
     # By design, only non-kernel functions can return


### PR DESCRIPTION
Fix #10887.

---

`CodeGenerator.visit_ListComp` iterated the comprehension's iterable and appended every element unconditionally, never evaluating the generator's `ifs`. A comprehension with a filter (`[x for x in (...) if cond]`) therefore silently kept the elements the filter should have dropped -- with no error -- diverging from both CPython and `TRITON_INTERPRET=1`.

Evaluate the `ifs` for each item and append only when all conditions hold. The iterable is a compile-time tuple, so each condition folds to a constexpr bool at trace time and no runtime branch is emitted; an empty `ifs` makes `all(...)` vacuously true, so unfiltered comprehensions are unchanged.

Adds `test_list_comprehension_if_filter` (parser-only, no device): it fails before this change (the `len(vals) == 2` static_assert trips because all four elements are kept) and passes after.

# New contributor declaration
- [x] I am not making a trivial change, such as fixing a typo in a comment.

- [x] I have written a PR description following these
  [rules](https://cbea.ms/git-commit/#why-not-how).

- [x] I have run `pre-commit run --from-ref origin/main --to-ref HEAD`.

- Select one of the following.
  - [x] I have added tests.
    - `/test` for `lit` tests
    - `/unittest` for C++ tests
    - `/python/test` for end-to-end tests

- Select one of the following.
  - [x] I have not added any `lit` tests.