### PR TITLE
[FRONTEND] Enforce the 32-bit integer input contract for tl.histogram

### DIFF
--- a/python/test/unit/language/test_compile_errors.py
+++ b/python/test/unit/language/test_compile_errors.py
@@ -582,3 +582,18 @@ def test_err_nested_function_def():
     err_msg = format_exception(e.type, value=e.value, tb=e.tb)
     assert "StopIteration" not in err_msg, "nested def should not leak StopIteration"
     assert "nested function" in err_msg, "error should mention nested function"
+
+
+@pytest.mark.parametrize("ptr_ty", ["*i8", "*i16", "*i64"])
+def test_err_histogram_non_32bit_int(ptr_ty):
+
+    @triton.jit
+    def kernel(x_ptr, z_ptr, N: tl.constexpr):
+        x = tl.load(x_ptr + tl.arange(0, 8))
+        tl.store(z_ptr + tl.arange(0, N), tl.histogram(x, N))
+
+    with pytest.raises(CompilationError) as e:
+        triton.compile(
+            triton.compiler.ASTSource(fn=kernel, signature={"x_ptr": ptr_ty, "z_ptr": "*i32", "N": "constexpr"},
+                                      constexprs={"N": 4}))
+    assert "histogram only supports 32-bit integer input" in str(e.value.__cause__)

--- a/python/test/unit/language/test_core.py
+++ b/python/test/unit/language/test_core.py
@@ -3110,21 +3110,6 @@ def test_histogram(M, N, device):
 
 
 @pytest.mark.interpreter
-@pytest.mark.parametrize("dtype", ['int8', 'int16', 'int64'])
-def test_histogram_rejects_non_32bit_int(dtype, device):
-
-    @triton.jit
-    def histogram_kernel(x_ptr, z_ptr, N: tl.constexpr):
-        x = tl.load(x_ptr + tl.arange(0, 8))
-        tl.store(z_ptr + tl.arange(0, N), tl.histogram(x, N))
-
-    x = torch.ones(8, device=device, dtype=getattr(torch, dtype))
-    z = torch.zeros(4, dtype=torch.int32, device=device)
-    with pytest.raises(triton.TritonError, match="histogram only supports 32-bit integer input"):
-        histogram_kernel[(1, )](x, z, N=4)
-
-
-@pytest.mark.interpreter
 def test_histogram_silent_data_corruption(device):
 
     @triton.jit

--- a/python/test/unit/language/test_core.py
+++ b/python/test/unit/language/test_core.py
@@ -3110,6 +3110,21 @@ def test_histogram(M, N, device):
 
 
 @pytest.mark.interpreter
+@pytest.mark.parametrize("dtype", ['int8', 'int16', 'int64'])
+def test_histogram_rejects_non_32bit_int(dtype, device):
+
+    @triton.jit
+    def histogram_kernel(x_ptr, z_ptr, N: tl.constexpr):
+        x = tl.load(x_ptr + tl.arange(0, 8))
+        tl.store(z_ptr + tl.arange(0, N), tl.histogram(x, N))
+
+    x = torch.ones(8, device=device, dtype=getattr(torch, dtype))
+    z = torch.zeros(4, dtype=torch.int32, device=device)
+    with pytest.raises(triton.TritonError, match="histogram only supports 32-bit integer input"):
+        histogram_kernel[(1, )](x, z, N=4)
+
+
+@pytest.mark.interpreter
 def test_histogram_silent_data_corruption(device):
 
     @triton.jit

--- a/python/triton/language/semantic.py
+++ b/python/triton/language/semantic.py
@@ -1798,7 +1798,8 @@ class TritonSemantic(Generic[TensorTy]):
 
     def histogram(self, input: TensorTy, num_bins: int, mask: Optional[TensorTy]) -> TensorTy:
         assert len(input.shape) == 1, "histogram only supports 1D input"
-        assert input.dtype.is_int(), "histogram only supports integer input"
+        if not (input.dtype.is_int() and input.dtype.int_bitwidth == 32):
+            raise ValueError(f"histogram only supports 32-bit integer input, but got {input.dtype}")
         if mask is not None:
             mask = self.broadcast_impl_shape(mask, input.shape)
             if not mask.type.scalar.is_bool():


### PR DESCRIPTION
Following the discussion, `tl.histogram` is intended to support only 32-bit integer input. Previously the two paths disagreed on a narrower/wider int: the interpreter silently miscounted, while the compiler crashed internally. Now both reject it up front with the same clear error.
