### PR TITLE
[FRONTEND] Normalize negative dim in squeeze / unsqueeze

### DIFF
--- a/python/test/unit/language/test_core.py
+++ b/python/test/unit/language/test_core.py
@@ -813,6 +813,45 @@ def test_expand_dims_error_cases(device):
     assert re.search(r"duplicate axes, normalized axes = \[0, 0\]", str(exc_info.value.__cause__))
 
 
+@pytest.mark.interpreter
+def test_squeeze_unsqueeze_negative_dim(device):
+
+    @triton.jit
+    def kernel(dummy, N: tl.constexpr):
+        offset1 = tl.arange(0, N)
+
+        t = tl.unsqueeze(offset1, -1)
+        tl.static_assert(t.shape == [N, 1])
+
+        t = tl.unsqueeze(offset1, -2)
+        tl.static_assert(t.shape == [1, N])
+
+        t = tl.unsqueeze(tl.expand_dims(offset1, 0), -1)
+        tl.static_assert(t.shape == [1, N, 1])
+
+        t = tl.squeeze(tl.expand_dims(offset1, 1), -1)
+        tl.static_assert(t.shape == [N])
+
+        t = tl.squeeze(tl.expand_dims(offset1, 0), -2)
+        tl.static_assert(t.shape == [N])
+
+    N = 32
+    dummy_tensor = torch.empty((), device=device)
+    kernel[(1, )](dummy_tensor, N)
+
+    @triton.jit
+    def unsqueeze_out_of_range(dummy, N: tl.constexpr):
+        tl.unsqueeze(tl.arange(0, N), -3)
+
+    @triton.jit
+    def squeeze_out_of_range(dummy, N: tl.constexpr):
+        tl.squeeze(tl.expand_dims(tl.arange(0, N), 1), -3)
+
+    for bad in (unsqueeze_out_of_range, squeeze_out_of_range):
+        with pytest.raises(triton.TritonError):
+            bad[(1, )](dummy_tensor, N)
+
+
 # ----------------------------
 # test invalid program id axis
 # ----------------------------

--- a/python/test/unit/tools/test_slice_kernel.py
+++ b/python/test/unit/tools/test_slice_kernel.py
@@ -343,8 +343,10 @@ def squeeze(x, dim: gl.constexpr):
     :param dim: the index of the dimension to remove
     :type dim: int
     '''
-    gl.static_assert(x.shape[dim] == 1)
-    return triton.tools.triton_to_gluon_translator.common_helpers.reset_to_default_layout(x.reshape(x.shape[:dim] + x.shape[dim + 1:]))
+    gl.static_assert(-len(x.shape) <= dim and dim < len(x.shape))
+    _dim: gl.constexpr = dim + len(x.shape) if dim < 0 else dim
+    gl.static_assert(x.shape[_dim] == 1)
+    return triton.tools.triton_to_gluon_translator.common_helpers.reset_to_default_layout(x.reshape(x.shape[:_dim] + x.shape[_dim + 1:]))
 
 
 @gluon.jit(repr=lambda _: 'custom_kernel_name')

--- a/python/triton/language/standard.py
+++ b/python/triton/language/standard.py
@@ -571,8 +571,10 @@ def squeeze(x, dim: core.constexpr):
     :param dim: the index of the dimension to remove
     :type dim: int
     """
-    core.static_assert(x.shape[dim] == 1)
-    return x.reshape(x.shape[:dim] + x.shape[dim + 1:])
+    core.static_assert(-len(x.shape) <= dim and dim < len(x.shape))
+    _dim: core.constexpr = dim + len(x.shape) if dim < 0 else dim
+    core.static_assert(x.shape[_dim] == 1)
+    return x.reshape(x.shape[:_dim] + x.shape[_dim + 1:])
 
 
 @jit
@@ -587,4 +589,7 @@ def unsqueeze(x, dim: core.constexpr):
     :param dim: the index at which the new dimension is inserted
     :type dim: int
     """
-    return x.reshape(x.shape[:dim] + (1, ) + x.shape[dim:])
+    ndim: core.constexpr = len(x.shape) + 1
+    core.static_assert(-ndim <= dim and dim < ndim)
+    _dim: core.constexpr = dim + ndim if dim < 0 else dim
+    return x.reshape(x.shape[:_dim] + (1, ) + x.shape[_dim:])


### PR DESCRIPTION
# New contributor declaration
- [x] I am not making a trivial change, such as fixing a typo in a comment.

- [x] I have written a PR description following these
  [rules](https://cbea.ms/git-commit/#why-not-how).

- [x] I have run `pre-commit run --from-ref origin/main --to-ref HEAD`.

- Select one of the following.
  - [x] I have added tests.
    - `/python/test/unit` for end-to-end tests

- Select one of the following.
  - [x] I have not added any `lit` tests.


---

## Summary

`tl.unsqueeze(x, dim)` and `tl.squeeze(x, dim)` document `dim` as an index that
may count from the end — like `torch`, `numpy`, and `tl.expand_dims` — but neither
normalizes a negative `dim` before it indexes `x.shape`. A negative `dim` therefore
names the wrong axis and, for `unsqueeze`, silently returns the wrong shape (no
error). For a `(4,)` input:

```python
tl.unsqueeze(x, -1)   # returns (1, 4); torch/expand_dims give (4, 1)
tl.unsqueeze(x, 1)    # returns (4, 1)  — the positive spelling is already correct
```

Because the shape is a `constexpr` fixed at compile time and `(1, 4)` is itself a
valid shape, nothing errors — the wrong shape just flows downstream. An outer
product `a[:, None] * b[None, :]` built with `unsqueeze(a, -1)` compiles and runs
but comes out transposed:

```python
@triton.jit
def outer(out_ptr):
    a = tl.arange(0, 4)
    b = tl.arange(0, 4) + 10
    col = tl.unsqueeze(a, -1)   # intended (4, 1); actually (1, 4)
    row = tl.unsqueeze(b, 0)    # (1, 4)
    tile = col * row
    i = tl.arange(0, 4)[:, None]
    j = tl.arange(0, 4)[None, :]
    tl.store(out_ptr + i * 4 + j, tile)

# observed (no error):       intended a[:, None] * b[None, :]:
#  [[ 0 11 24 39]             [[ 0  0  0  0]
#   [ 0 11 24 39]              [10 11 12 13]
#   [ 0 11 24 39]              [20 22 24 26]
#   [ 0 11 24 39]]             [30 33 36 39]]
```

`tl.squeeze` has the same missing normalization, but slices `x.shape[dim + 1:]`
with the still-negative `dim`, so `tl.squeeze((8, 1), -1)` builds a shape whose
element count does not match the input and raises a spurious
`reshape() cannot change total number of elements` error instead of returning
`(8,)`.

## Root cause

Both functions in `python/triton/language/standard.py` index `x.shape` with the
raw `dim`:

- `squeeze`: `x.reshape(x.shape[:dim] + x.shape[dim + 1:])`
- `unsqueeze`: `x.reshape(x.shape[:dim] + (1,) + x.shape[dim:])`

A negative `dim` is passed straight to the tuple slice, so it names a position
counted from the wrong end. The sibling primitives in the same area already handle
this: `flip` normalizes via `_get_flip_dim` (`if dim < 0: dim += len(shape)`) and
`expand_dims` via `_wrap_axis` (`axis if axis >= 0 else axis + ndim`), computed
against the result rank. `squeeze`/`unsqueeze` simply omit that step — and the
`unsqueeze` docstring names `expand_dims` as its equivalent, which it does not
match for negative `dim`.

## Fix

Normalize `dim` from the end before use, matching `flip`/`expand_dims`:
`unsqueeze` against the result rank (`len(x.shape) + 1`), `squeeze` against the
input rank (`len(x.shape)`). A non-negative `dim` is left unchanged, so existing
uses are unaffected.

## Test

Adds `test_squeeze_unsqueeze_negative_dim` (next to `test_expand_dims`), which
`static_assert`s the shapes of `unsqueeze`/`squeeze` at negative dims at compile
time. It fails before this change (the `unsqueeze(-1)` shape assert trips and the
`squeeze(-1)` case raises) and passes after, on both the compiled and interpreter
paths.
