### PR TITLE
[autotuner] Query the backend for applicable Config options

### DIFF
--- a/python/triton/backends/compiler.py
+++ b/python/triton/backends/compiler.py
@@ -1,7 +1,7 @@
 from abc import ABCMeta, abstractmethod
 from dataclasses import dataclass
 from enum import Enum
-from typing import Dict, Union
+from typing import Dict, Tuple, Union
 from types import ModuleType
 
 
@@ -22,6 +22,11 @@ class Language(Enum):
 
 class BaseBackend(metaclass=ABCMeta):
     supports_native_tensor_specialization = True
+
+    # Config option names (besides kwargs and ir_override) meaningful for this
+    # backend; the autotuner forwards and displays only these. Backends may
+    # override the default GPU knobs.
+    autotune_option_names: Tuple[str, ...] = ("num_warps", "num_ctas", "num_stages", "maxnreg")
 
     def __init__(self, target: GPUTarget) -> None:
         self.target = target

--- a/python/triton/runtime/autotuner.py
+++ b/python/triton/runtime/autotuner.py
@@ -5,7 +5,7 @@ import time
 import inspect
 import hashlib
 import json
-from functools import cached_property
+from functools import cached_property, lru_cache
 from typing import Dict, Tuple, List, Optional
 
 from .. import knobs
@@ -325,6 +325,22 @@ class Autotuner(KernelInterface):
         return ret
 
 
+# Option names to fall back on before the active backend can be resolved
+# (e.g. during Config construction at import time). Matches the historical set.
+_DEFAULT_OPTION_NAMES = ("num_warps", "num_ctas", "num_stages", "maxnreg")
+
+
+@lru_cache
+def _resolve_option_names(target):
+    """The autotune option names declared by the backend for `target`.
+
+    Cached per target because it is queried from Config.__hash__/__eq__, which
+    can be hot. Backends expose this via BaseBackend.autotune_option_names.
+    """
+    from triton.compiler.compiler import make_backend
+    return tuple(make_backend(target).autotune_option_names)
+
+
 class Config:
     """
     An object that represents a possible kernel configuration for the auto-tuner to try.
@@ -366,28 +382,28 @@ class Config:
         self.pre_hook = state.get("pre_hook", None)
         self.ir_override = state.get("ir_override", None)
 
+    @staticmethod
+    def _active_option_names():
+        try:
+            target = driver.active.get_current_target()
+        except Exception:
+            return _DEFAULT_OPTION_NAMES
+        return _resolve_option_names(target)
+
     def all_kwargs(self):
-        return {
-            **self.kwargs, **{
-                k: v
-                for (k, v) in (
-                    ("num_warps", self.num_warps),
-                    ("num_ctas", self.num_ctas),
-                    ("num_stages", self.num_stages),
-                    ("maxnreg", self.maxnreg),
-                    ("ir_override", self.ir_override),
-                ) if v is not None
-            }
-        }
+        # Backend declares which option knobs are meaningful for it; only those
+        # (plus the backend-agnostic ir_override) are forwarded to the compiler.
+        options = {name: getattr(self, name) for name in self._active_option_names() if hasattr(self, name)}
+        options["ir_override"] = self.ir_override
+        return {**self.kwargs, **{k: v for k, v in options.items() if v is not None}}
 
     def __str__(self):
         res = []
         for k, v in self.kwargs.items():
             res.append(f"{k}: {v}")
-        res.append(f"num_warps: {self.num_warps}")
-        res.append(f"num_ctas: {self.num_ctas}")
-        res.append(f"num_stages: {self.num_stages}")
-        res.append(f"maxnreg: {self.maxnreg}")
+        for name in self._active_option_names():
+            if hasattr(self, name):
+                res.append(f"{name}: {getattr(self, name)}")
         res.append(f"ir_override: {self.ir_override}")
         return ", ".join(res)
 


### PR DESCRIPTION
Add BaseBackend.autotune_option_names (defaulting to the GPU knobs num_warps/num_ctas/num_stages/maxnreg) and have Config.all_kwargs()/ __str__() consult the active backend instead of hardcoding that set. No behavior change for in-tree backends; it lets other backends keep inapplicable knobs out of autotuning, the cache key, and logs without editing shared code.


Change-Id: Idf0c1b8693a6b352221e1d81923e4e328b2b2a81

<!---
The core Triton is a small number of people, and we receive many PRs (thank
you!).  To help us review your code more quickly, **if you are a new
contributor (less than 3 PRs merged) we ask that you complete the following
tasks and include the filled-out checklist in your PR description.**

Complete the following tasks before sending your PR, and replace `[ ]` with
`[x]` to indicate you have done them.
-->

# New contributor declaration
- [x] I am not making a trivial change, such as fixing a typo in a comment.

- [x] I have written a PR description following these
  [rules](https://cbea.ms/git-commit/#why-not-how).

- [ ] I have run `pre-commit run --from-ref origin/main --to-ref HEAD`.

- Select one of the following.
  - [ ] I have added tests.
    - `/test` for `lit` tests
    - `/unittest` for C++ tests
    - `/python/test` for end-to-end tests
  - [x] This PR does not need a test because `FILL THIS IN`.

- Select one of the following.
  - [ ] I have not added any `lit` tests.
  - [ ] The `lit` tests I have added follow these [best practices](https://mlir.llvm.org/getting_started/TestingGuide/#filecheck-best-practices),
    including the "tests should be minimal" section. (Usually running Python code
    and using the instructions it generates is not minimal.)
