### PR TITLE
Fix redundant insertion point in visit_IfExp and add empty list check in _quantile

### DIFF
--- a/python/triton/compiler/code_generator.py
+++ b/python/triton/compiler/code_generator.py
@@ -1028,7 +1028,6 @@ class CodeGenerator(ast.NodeVisitor):
                     self.builder.set_insertion_point_to_end(if_op.get_then_block())
                     self.builder.create_yield_op([then_val.handle])
 
-                self.builder.set_insertion_point_to_end(if_op.get_then_block())
                 else_block.merge_block_before(if_op.get_else_block())
                 if ret_type_ir:
                     self.builder.set_insertion_point_to_end(if_op.get_else_block())

--- a/python/triton/testing.py
+++ b/python/triton/testing.py
@@ -28,6 +28,8 @@ def nvsmi(attrs):
 
 def _quantile(a, q):
     n = len(a)
+    if n == 0:
+        raise ValueError("Cannot compute quantile of an empty list")
     a = sorted(a)
 
     def get_quantile(q):


### PR DESCRIPTION
## Changes

### 1. Remove redundant insertion point in visit_IfExp (code_generator.py)
- Removed redundant set_insertion_point_to_end(if_op.get_then_block()) call
- This insertion point was already set earlier and the redundant call had no effect

### 2. Add empty list defensive check in _quantile (testing.py)
- Added check for empty list input to prevent IndexError
- Raises ValueError with clear message when attempting to compute quantile of empty sequence

## Testing
**Note**: Full test suite could not be run locally due to environment constraints (requires Linux with NVIDIA GPU and CUDA toolchain for Triton compilation). Changes are based on static analysis and code review.

- Changes are minimal and safe (defensive programming, code cleanup)
- Rely on CI/CD automated testing for verification

## Impact
- No breaking changes
- Improves code robustness and maintainability