### PR TITLE
Materialize outDimNames before modifying TMEM layout

### DIFF
--- a/lib/Dialect/TritonGPU/IR/LinearLayoutConversions.cpp
+++ b/lib/Dialect/TritonGPU/IR/LinearLayoutConversions.cpp
@@ -1380,8 +1380,9 @@ LinearLayout toLinearLayout(MemDescType type) {
     auto shape = type.getShape().take_back(2);
     auto allocShape = type.getAllocShape().take_back(2);
     auto ll = toLinearLayout(allocShape, type.getEncoding());
+    auto outDims = llvm::to_vector(ll.getOutDimNames());
     // Trim the shape
-    for (auto [dim, size] : llvm::zip_equal(ll.getOutDimNames(), shape))
+    for (auto [dim, size] : llvm::zip_equal(outDims, shape))
       ll = ll.resizeOutDim(dim, size);
 
     auto kCol = StringAttr::get(type.getContext(), "col");


### PR DESCRIPTION
`getOutDimNames()` returns a view to the underlying outDims storage in the linear layout, but the linear layout is subsequently modified by changing the out dim shape in the trimming loop. This likely invalidates the dim iterator in the loop. On my Mac with clang 21 this results in a null attribute for the dim on iterations after the first which asserts in `resizeOutDim`. Materializing outDims up front and iterating the materialized vector solves the problem. 