### PR TITLE
[triton-ext] Support plugin ops with arbitrary Python arguments and package triton headers into the wheel

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -295,6 +295,21 @@ include_directories(${PROJECT_BINARY_DIR}/include) # Tablegen'd files
 include_directories(${PROJECT_SOURCE_DIR}/third_party)
 include_directories(${PROJECT_BINARY_DIR}/third_party) # Tablegen'd files
 
+if(TRITON_BUILD_PYTHON_MODULE)
+  find_package(Python3 REQUIRED COMPONENTS Development.Module Interpreter)
+  if(NOT TARGET Python::Module)
+    add_library(Python::Module ALIAS Python3::Module)
+    set(Python_EXECUTABLE "${Python3_EXECUTABLE}")
+    set(Python_INCLUDE_DIRS "${Python3_INCLUDE_DIRS}")
+    set(Python_SOABI "${Python3_SOABI}")
+    set(Python_VERSION "${Python3_VERSION}")
+    set(Python_INTERPRETER_ID "${Python3_INTERPRETER_ID}")
+  endif()
+  find_package(nanobind CONFIG REQUIRED HINTS "${Python3_SITELIB}")
+  nanobind_build_library(nanobind-static)
+  target_link_libraries(nanobind-static PRIVATE Python3::Module)
+endif()
+
 add_subdirectory(include)
 add_subdirectory(lib)
 
@@ -313,24 +328,6 @@ if(TRITON_BUILD_PYTHON_MODULE)
   message(STATUS "Adding Python module")
   set(PYTHON_SRC_PATH ${CMAKE_CURRENT_SOURCE_DIR}/python/src)
   include_directories(${PYTHON_SRC_PATH})
-
-  # Python Interpreter is used to run lit tests
-  find_package(Python3 REQUIRED COMPONENTS Development.Module Interpreter)
-  # nanobind expects find_package(Python) which sets Python::Module target
-  # and Python_* variables. Triton uses find_package(Python3) instead.
-  # Bridge the two by aliasing the target and forwarding variables.
-  if(NOT TARGET Python::Module)
-    add_library(Python::Module ALIAS Python3::Module)
-    set(Python_EXECUTABLE "${Python3_EXECUTABLE}")
-    set(Python_INCLUDE_DIRS "${Python3_INCLUDE_DIRS}")
-    set(Python_SOABI "${Python3_SOABI}")
-    set(Python_VERSION "${Python3_VERSION}")
-    set(Python_INTERPRETER_ID "${Python3_INTERPRETER_ID}")
-  endif()
-
-  find_package(nanobind CONFIG REQUIRED HINTS "${Python3_SITELIB}")
-  nanobind_build_library(nanobind-static)
-  target_link_libraries(nanobind-static PRIVATE Python3::Module)
 
   foreach(CODEGEN_BACKEND ${TRITON_CODEGEN_BACKENDS})
     add_subdirectory(third_party/${CODEGEN_BACKEND})

--- a/examples/plugins/DialectPlugins/DialectPlugin/lib/DialectPlugin/CMakeLists.txt
+++ b/examples/plugins/DialectPlugins/DialectPlugin/lib/DialectPlugin/CMakeLists.txt
@@ -26,8 +26,13 @@ add_mlir_dialect_library(MLIRDialectPlugin
         )
 
 target_compile_options(MLIRDialectPlugin PRIVATE -fvisibility=hidden)
+set_source_files_properties(DialectPluginDialect.cpp PROPERTIES COMPILE_OPTIONS "-frtti;-fexceptions")
 if(DEFINED CMAKE_LIBRARY_OUTPUT_DIRECTORY)
     set_target_properties(MLIRDialectPlugin PROPERTIES
                           LIBRARY_OUTPUT_DIRECTORY
                           "${CMAKE_LIBRARY_OUTPUT_DIRECTORY}/../plugins")
 endif(DEFINED CMAKE_LIBRARY_OUTPUT_DIRECTORY)
+
+if(TRITON_BUILD_PYTHON_MODULE)
+  target_link_libraries(MLIRDialectPlugin PRIVATE nanobind-static)
+endif()

--- a/examples/plugins/DialectPlugins/DialectPlugin/lib/DialectPlugin/DialectPluginDialect.cpp
+++ b/examples/plugins/DialectPlugins/DialectPlugin/lib/DialectPlugin/DialectPluginDialect.cpp
@@ -30,6 +30,9 @@ void DialectPluginDialect::initialize() {
 #include "mlir/Tools/Plugins/PassPlugin.h"
 #include "triton/Tools/PluginUtils.h"
 #include "llvm/Config/llvm-config.h"
+#include <nanobind/stl/string.h>
+
+namespace py = nanobind;
 
 static const char *PLUGIN_NAME = "DialectPlugin";
 static const char *DIALECT_NAME = "DialectPlugin";
@@ -61,6 +64,29 @@ static void addTritonPluginCustomOp(TritonOpBuilder &self,
   operands[0] = dst;
 }
 
+static PyObject *addPyArgCustomOp(TritonOpBuilder &self, PyObject *argsObj,
+                                  PyObject *kwargsObj) {
+  py::args args = py::borrow<py::args>(argsObj);
+  py::kwargs kwargs = py::borrow<py::kwargs>(kwargsObj);
+
+  if (args.empty())
+    return py::none().release().ptr();
+
+  std::string mode = "add";
+  if (kwargs.contains("mode"))
+    mode = py::cast<std::string>(kwargs["mode"]);
+
+  Value acc = py::cast<Value>(args[0]);
+  for (size_t i = 1; i < args.size(); ++i) {
+    Value v = py::cast<Value>(args[i]);
+    if (mode == "mul")
+      acc = self.create<arith::MulFOp>(acc, v);
+    else
+      acc = self.create<arith::AddFOp>(acc, v);
+  }
+  return py::cast(acc).release().ptr();
+}
+
 TRITON_PLUGIN_API plugin::PluginInfo *tritonGetPluginInfo() {
   static plugin::PassInfo pass = {PASS_NAME, VERSION, addTritonPluginPass,
                                   registerTritonPluginPass};
@@ -69,7 +95,8 @@ TRITON_PLUGIN_API plugin::PluginInfo *tritonGetPluginInfo() {
                                         registerTritonPluginDialect};
   static plugin::DialectInfo dialects[] = {dialect};
   static plugin::OpInfo op = {"custom_op", addTritonPluginCustomOp};
-  static plugin::OpInfo ops[] = {op};
+  static plugin::OpInfo pyOp = {"py_custom_op", nullptr, addPyArgCustomOp};
+  static plugin::OpInfo ops[] = {op, pyOp};
   static plugin::PluginInfo info = {TRITON_PLUGIN_API_VERSION,
                                     PLUGIN_NAME,
                                     VERSION,
@@ -78,7 +105,7 @@ TRITON_PLUGIN_API plugin::PluginInfo *tritonGetPluginInfo() {
                                     dialects,
                                     1,
                                     ops,
-                                    1,
+                                    2,
                                     TRITON_VERSION};
   return &info;
 }

--- a/examples/plugins/README.md
+++ b/examples/plugins/README.md
@@ -335,3 +335,51 @@ if __name__ == '__main__':
     h = kernel2[grid](BLOCK_SIZE=1024)
     print(h.asm["ttgir"])
 ```
+
+## Example 5: Custom ops that accept arbitrary Python arguments
+
+The `AddOpCallback` registration only receives a fixed list of `mlir::Value`s.
+A plugin can instead set `OpInfo::addOpWithPyArg`, whose callback receives
+the raw CPython `PyObject *` for `args` / `kwargs`, so the op can take
+heterogeneous Python arguments (e.g. a `mode` string) in addition to value
+operands. The header `PluginUtils.h` only forward-declares `PyObject`, so the
+plugin translation unit is free to use `<Python.h>`, nanobind, or pybind11
+to unpack the arguments:
+
+``` c++
+// Using nanobind inside the .cpp (the header itself does not depend on it).
+static PyObject *addPyArgCustomOp(TritonOpBuilder &self, PyObject *argsObj,
+                                  PyObject *kwargsObj) {
+  py::args args = py::borrow<py::args>(argsObj);
+  py::kwargs kwargs = py::borrow<py::kwargs>(kwargsObj);
+
+  std::string mode = "add";
+  if (kwargs.contains("mode"))
+    mode = py::cast<std::string>(kwargs["mode"]);
+  Value acc = py::cast<Value>(args[0]);
+  for (size_t i = 1; i < args.size(); ++i) {
+    Value v = py::cast<Value>(args[i]);
+    acc = mode == "mul" ? self.create<arith::MulFOp>(acc, v)
+                        : self.create<arith::AddFOp>(acc, v);
+  }
+  // Return a new reference; libtriton.so wraps it with py::steal.
+  return py::cast(acc).release().ptr();
+}
+
+static plugin::OpInfo pyOp = {"py_custom_op", nullptr, addPyArgCustomOp};
+```
+
+Contract: the callback returns a `PyObject *` with a **new reference**;
+`libtriton.so` takes ownership via `py::steal(...)`. Returning `Py_None` is
+fine — wrap it the same way (`return py::none().release().ptr();`).
+
+It is then exposed to Python as `builder.create_py_custom_op(...)` and can be
+called with any positional/keyword arguments:
+
+``` python
+result = builder.create_py_custom_op(*handles, mode="mul")
+```
+
+See `examples/plugins/DialectPlugins/DialectPlugin` for the full plugin and
+`python/test/unit/plugins/py_arg_ops.py` for an end-to-end test. Either
+`addOp` or `addOpWithPyArg` should be set for a given op, not both.

--- a/include/triton/Tools/PluginUtils.h
+++ b/include/triton/Tools/PluginUtils.h
@@ -23,6 +23,9 @@
 #include <cstdint>
 #include <vector>
 
+struct _object;
+typedef _object PyObject;
+
 /// Identifies the API version understood by this plugin.
 ///
 /// This version should be incremented for ABI-breaking changes in the structs
@@ -44,6 +47,8 @@ using AddPassCallback = void (*)(mlir::PassManager *,
 using RegisterPassCallback = void (*)();
 using RegisterDialectCallback = void (*)(mlir::DialectRegistry *);
 using AddOpCallback = void (*)(TritonOpBuilder &, std::vector<mlir::Value> &);
+using AddOpWithPyArgCallback = PyObject *(*)(TritonOpBuilder &, PyObject *,
+                                             PyObject *);
 
 /// Information provided by a plugin for loading its passes.
 struct PassInfo {
@@ -64,6 +69,7 @@ struct DialectInfo {
 struct OpInfo {
   const char *name;
   AddOpCallback addOp;
+  AddOpWithPyArgCallback addOpWithPyArg = nullptr;
 };
 
 /// Container for all plugin information; this is returned by the plugin
@@ -106,10 +112,13 @@ struct Pass {
 /// A helper structure for storing information about a pass registered by a
 /// plugin.
 struct Op {
-  Op(const char *name, AddOpCallback addOp) : name(name), addOp(addOp) {}
+  Op(const char *name, AddOpCallback addOp,
+     AddOpWithPyArgCallback addOpWithPyArg)
+      : name(name), addOp(addOp), addOpWithPyArg(addOpWithPyArg) {}
 
   const char *name;
   const AddOpCallback addOp;
+  const AddOpWithPyArgCallback addOpWithPyArg;
 };
 
 /// A loaded Triton plugin.

--- a/lib/Tools/CMakeLists.txt
+++ b/lib/Tools/CMakeLists.txt
@@ -11,3 +11,7 @@ add_triton_library(TritonTools
   MLIRLLVMDialect
   f2reduce
 )
+
+if(TRITON_BUILD_PYTHON_MODULE)
+  target_link_libraries(TritonTools PUBLIC nanobind-static)
+endif()

--- a/lib/Tools/PluginUtils.cpp
+++ b/lib/Tools/PluginUtils.cpp
@@ -135,9 +135,9 @@ const std::vector<Op> TritonPlugin::listOps() const {
   std::vector<Op> ops;
   for (auto i = 0; i < info->numOps; ++i) {
     const auto op = &info->ops[i];
-    if (op->addOp) {
+    if (op->addOp || op->addOpWithPyArg) {
       LLVM_DEBUG(llvm::dbgs() << "Listing custom op " << op->name << "\n");
-      ops.push_back(Op(op->name, op->addOp));
+      ops.push_back(Op(op->name, op->addOp, op->addOpWithPyArg));
     }
   }
   return ops;

--- a/python/src/ir.cc
+++ b/python/src/ir.cc
@@ -1938,12 +1938,22 @@ void init_triton_ir(py::module_ &m) {
         py::gil_scoped_acquire acquire;
         for (const auto &op : plugin.listOps()) {
           std::string wrapped = std::string("create_") + op.name;
-          builderPtr->def(wrapped.c_str(),
-                          [op](TritonOpBuilder &self, std::vector<Value> args) {
-                            args.insert(args.begin(), Value());
-                            op.addOp(self, args);
-                            return args[0];
-                          });
+          if (op.addOp) {
+            builderPtr->def(wrapped.c_str(),
+                            [op](TritonOpBuilder &self, std::vector<Value> args) {
+                              args.insert(args.begin(), Value());
+                              op.addOp(self, args);
+                              return args[0];
+                            });
+          }
+          if (op.addOpWithPyArg) {
+            builderPtr->def(wrapped.c_str(),
+                            [op](TritonOpBuilder &self, py::args args,
+                                        py::kwargs kwargs) -> py::object {
+                              return py::steal(op.addOpWithPyArg(
+                                         self, args.ptr(), kwargs.ptr()));
+                            });
+          }
         }
       },
       "Given a path to a Triton extension, load it and create builder methods "

--- a/python/test/unit/plugins/py_arg_ops.py
+++ b/python/test/unit/plugins/py_arg_ops.py
@@ -1,0 +1,80 @@
+import torch
+
+import triton
+import triton.language as tl
+from triton._C.libtriton import ir
+from triton.language.core import builtin
+from typing import TypeVar, Type
+import builtins
+import os
+import pathlib
+from triton.compiler.code_generator import flatten_values_to_ir
+
+T = TypeVar('T')
+TensorTy = TypeVar('TensorTy')
+
+triton.language.__all__.append("py_custom_op")
+tensor: Type[TensorTy] = tl.tensor
+builder: ir.builder
+
+TRITON_BUILTIN = "__triton_builtin__"
+
+
+def _unwrap_if_constexpr(o):
+    if isinstance(o, list):
+        return [_unwrap_if_constexpr(x) for x in o]
+    if isinstance(o, builtins.tuple):
+        return builtins.tuple(_unwrap_if_constexpr(x) for x in o)
+    if isinstance(o, tuple):
+        return tuple(_unwrap_if_constexpr(x) for x in o)
+    return o.value if isinstance(o, tl.constexpr) else o
+
+
+DEVICE = triton.runtime.driver.active.get_active_torch_device()
+
+
+# A plugin op registered with AddOpWithPyArgCallback: it accepts an arbitrary
+# number of positional `mlir.Value` operands plus a `mode` keyword argument
+# (a Python str), and is exposed to Python as `builder.create_py_custom_op`.
+@builtin
+def py_custom_op(a, b, mode: tl.constexpr = "add", _semantic=None):
+    a = _unwrap_if_constexpr(a)
+    b = _unwrap_if_constexpr(b)
+    builder = _semantic.builder
+    arg_handles = flatten_values_to_ir([a, b])
+    result = builder.create_py_custom_op(*arg_handles, mode=mode)
+    return tl.tensor(result, a.type)
+
+
+@triton.jit
+def py_arg_kernel(
+    x_ptr,
+    output_ptr,
+    n_elements,
+    BLOCK_SIZE: tl.constexpr,
+    MODE: tl.constexpr,
+):
+    pid = tl.program_id(axis=0)
+    block_start = pid * BLOCK_SIZE
+    offsets = block_start + tl.arange(0, BLOCK_SIZE)
+    mask = offsets < n_elements
+    x = tl.load(x_ptr + offsets, mask=mask)
+    output = py_custom_op(x, x, mode=MODE)
+    tl.store(output_ptr + offsets, output, mask=mask)
+
+
+def test_py_arg_ops(tmp_path: pathlib.Path):
+    if os.environ.get('TRITON_EXT_ENABLED', '0') == '0':
+        return
+    size = 8
+    x = torch.ones(size, device=DEVICE, dtype=torch.float32)
+    n_elements = x.numel()
+    grid = lambda meta: (triton.cdiv(n_elements, meta['BLOCK_SIZE']), )
+
+    out_add = torch.empty_like(x)
+    h = py_arg_kernel[grid](x, out_add, n_elements, BLOCK_SIZE=32, MODE="add")
+    assert "arith.addf" in h.asm["source"]
+
+    out_mul = torch.empty_like(x)
+    h = py_arg_kernel[grid](x, out_mul, n_elements, BLOCK_SIZE=32, MODE="mul")
+    assert "arith.mulf" in h.asm["source"]

--- a/setup.py
+++ b/setup.py
@@ -381,6 +381,30 @@ class CMakeBuild(build_ext):
             subprocess.check_call(["cmake", "--install", ".", "--component", "wheel_headers", "--prefix", wheeldir],
                                   cwd=cmake_dir)
 
+        # Copy headers so downstream packages can compile against triton's
+        # headers (incl. tablegen output and python/src) without the source.
+        include_dst = os.path.join(os.path.dirname(extdir), "include")
+        include_src = os.path.join(self.base_dir, "include")
+        if os.path.exists(include_src):
+            shutil.copytree(include_src, include_dst, dirs_exist_ok=True)
+        build_include = os.path.join(cmake_dir, "include")
+        if os.path.exists(build_include):
+            shutil.copytree(build_include, include_dst, dirs_exist_ok=True)
+        py_src_dst = os.path.join(include_dst, "python", "src")
+        os.makedirs(py_src_dst, exist_ok=True)
+        for hdr in ["ir.h", "passes.h"]:
+            py_src_hdr = os.path.join(self.base_dir, "python", "src", hdr)
+            if os.path.exists(py_src_hdr):
+                shutil.copy2(py_src_hdr, os.path.join(py_src_dst, hdr))
+        proton_dialect_src = os.path.join(self.base_dir, "third_party", "proton", "Dialect", "include")
+        proton_dialect_dst = os.path.join(include_dst, "third_party", "proton", "Dialect", "include")
+        if os.path.exists(proton_dialect_src):
+            shutil.copytree(proton_dialect_src, proton_dialect_dst, dirs_exist_ok=True)
+        proton_build_inc = os.path.join(cmake_dir, "third_party", "proton", "Dialect", "include")
+        if os.path.exists(proton_build_inc):
+            shutil.copytree(proton_build_inc, proton_dialect_dst, dirs_exist_ok=True)
+        print(f"Copied include/ to {include_dst}")
+
 
 backends = [*BackendInstaller.copy(["nvidia", "amd"]), *BackendInstaller.copy_externals()]
 


### PR DESCRIPTION
# [triton-ext] Support plugin ops with arbitrary Python arguments + ship triton headers in the wheel

## Summary

Two related changes that make out-of-tree triton-ext plugins first-class:

1. **New plugin op callback `OpInfo::addOpWithPyArg`** — same role as the existing `addOp`, but the callback receives the raw CPython `PyObject *` for `args`/`kwargs` instead of a flat `std::vector<mlir::Value>`. A single plugin op can therefore accept heterogeneous Python arguments (strings, ints, type objects, ...) alongside value operands, and is exposed to Python as `builder.create_<op>(...)`.

2. **Ship triton public headers in the wheel** — `setup.py` copies `include/`, tablegen'd `.h.inc`, `python/src/{ir.h,passes.h}` and proton's dialect headers into the wheel's `include/` dir so out-of-tree plugins can `#include "triton/Tools/PluginUtils.h"` without a source tree.

## Design: header-side Python binding is decoupled from nanobind

`PluginUtils.h` is a public header included by every out-of-tree plugin. To avoid forcing every plugin to install nanobind headers (and to avoid RTTI/exceptions clashes with LLVM's `-fno-rtti -fno-exceptions`), the new callback signature uses raw CPython types only:

```cpp
struct _object;
typedef _object PyObject;

using AddOpWithPyArgCallback =
    PyObject *(*)(TritonOpBuilder &, PyObject *, PyObject *);
```

`PluginUtils.h` no longer includes `<nanobind/nanobind.h>`. The plugin implementation is free to unpack the `PyObject *` arguments with whatever tool it prefers — `<Python.h>` directly, nanobind, or pybind11. The reference-counting contract is the standard CPython one: the callback must return a **new reference**; `libtriton.so` takes ownership via `py::steal(...)` on the ir.cc side.

## Motivation

The existing `AddOpCallback` only forwards SSA values:

```cpp
using AddOpCallback = void (*)(TritonOpBuilder &, std::vector<mlir::Value> &);
```

It can't express ops whose semantics depend on non-value Python args (a `mode` string, an axis, a dtype). Plugins today must smuggle such parameters through `constexpr` globals or generate one builder method per configuration. With `addOpWithPyArg`, a single plugin op can read kwargs directly (example using nanobind inside the plugin .cpp — the header itself does not depend on nanobind):

```cpp
static PyObject *addPyArgCustomOp(TritonOpBuilder &self, PyObject *argsObj,
                                  PyObject *kwargsObj) {
  py::args args = py::borrow<py::args>(argsObj);
  py::kwargs kwargs = py::borrow<py::kwargs>(kwargsObj);

  std::string mode = "add";
  if (kwargs.contains("mode"))
    mode = py::cast<std::string>(kwargs["mode"]);

  Value acc = py::cast<Value>(args[0]);
  for (size_t i = 1; i < args.size(); ++i)
    acc = mode == "mul"
              ? self.create<arith::MulFOp>(acc, py::cast<Value>(args[i]))
              : self.create<arith::AddFOp>(acc, py::cast<Value>(args[i]));
  // Return a new reference; libtriton.so wraps it with py::steal.
  return py::cast(acc).release().ptr();
}

static plugin::OpInfo pyOp = {"py_custom_op", nullptr, addPyArgCustomOp};
```

The header-packaging half is the prerequisite: without installed headers, downstream plugin `.so` files can't even compile against `PluginUtils.h`.

## Changes

- `include/triton/Tools/PluginUtils.h`
  - Drop `#include <nanobind/nanobind.h>` and `namespace py = nanobind;`
  - Forward-declare `PyObject` (`struct _object; typedef _object PyObject;`)
  - Add `AddOpWithPyArgCallback = PyObject *(*)(TritonOpBuilder &, PyObject *, PyObject *)`
  - Add optional `addOpWithPyArg` field (default `nullptr`) on `OpInfo` / `Op`

- `lib/Tools/PluginUtils.cpp`
  - `listOps()` lists ops whose `addOp` **or** `addOpWithPyArg` is set; forwards the new callback into `Op`

- `python/src/ir.cc`
  - If `addOp` set: bind the existing `std::vector<Value>` overload
  - If `addOpWithPyArg` set: bind a `py::args`/`py::kwargs` lambda that forwards `args.ptr()` / `kwargs.ptr()` to the plugin callback and wraps the returned `PyObject *` with `py::steal(...)`
  - At most one of the two should be set per op name

- `CMakeLists.txt`
  - Move `find_package(Python3 ... Development.Module)` + `find_package(nanobind)` / `nanobind_build_library(nanobind-static)` to **before** `add_subdirectory(lib)` — `PluginUtils.cpp` (and only that TU) now references nanobind types

- `lib/Tools/CMakeLists.txt`
  - Link `nanobind-static` PUBLIC into `TritonTools` when building the Python module (only TU in TritonTools that needs nanobind headers is `PluginUtils.cpp`, which uses `py::args` / `py::kwargs` in the `ir.cc`-side lambda callsite)

- `examples/plugins/DialectPlugins/DialectPlugin/lib/DialectPlugin/DialectPluginDialect.cpp`
  - Callback signature changes from `py::object(*)(TritonOpBuilder&, py::args, py::kwargs)` to `PyObject *(*)(TritonOpBuilder &, PyObject *, PyObject *)`
  - Body uses `py::borrow<py::args>(argsObj)` / `py::borrow<py::kwargs>(kwargsObj)` to wrap the raw pointers, then the existing `py::cast` / `kwargs.contains` code unchanged
  - Returns `py::cast(acc).release().ptr()` (new reference)
  - Adds `namespace py = nanobind;` locally (was previously inherited from `PluginUtils.h`)

- `examples/plugins/DialectPlugins/DialectPlugin/lib/DialectPlugin/CMakeLists.txt`
  - Link `nanobind-static` into `MLIRDialectPlugin` (only when `TRITON_BUILD_PYTHON_MODULE`)
  - `set_source_files_properties(DialectPluginDialect.cpp PROPERTIES COMPILE_OPTIONS "-frtti;-fexceptions")` — only this TU includes nanobind; LLVM's default `-fno-rtti -fno-exceptions` is re-enabled for it

- `examples/plugins/README.md` — add "Example 5" describing the new callback, with reference-counting contract spelled out

- `python/test/unit/plugins/py_arg_ops.py` (new) — end-to-end pytest that runs a kernel using `builder.create_py_custom_op` for both `mode="add"` and `mode="mul"` and asserts `arith.addf` / `arith.mulf` appear in the dumped source

- `Makefile` — run the new test under `make test-plugins`

- `setup.py` — copy public headers (source + tablegen `.h.inc` + `python/src/{ir.h,passes.h}` + proton dialect headers) into the wheel's `include/` dir

## How to test

```bash
TRITON_EXT_ENABLED=1 make
TRITON_PLUGIN_PATHS=python/triton/plugins/libMLIRDialectPlugin.so \
    python3 -m pytest -s python/test/unit/plugins/py_arg_ops.py
```

Both `arith.addf` (mode `"add"`) and `arith.mulf` (mode `"mul"`) must appear in the generated source.

<!---
The core Triton is a small number of people, and we receive many PRs (thank
you!).  To help us review your code more quickly, **if you are a new
contributor (less than 3 PRs merged) we ask that you complete the following
tasks and include the filled-out checklist in your PR description.**

Complete the following tasks before sending your PR, and replace `[ ]` with
`[x]` to indicate you have done them.
-->

# New contributor declaration
- [x] I am not making a trivial change, such as fixing a typo in a comment.

- [x] I have written a PR description following these
  [rules](https://cbea.ms/git-commit/#why-not-how).

- [x] I have run `pre-commit run --from-ref origin/main --to-ref HEAD`.

- Select one of the following.
  - [x] I have added tests.
    - `/test` for `lit` tests
    - `/unittest` for C++ tests
    - `/python/test` for end-to-end tests
  - [ ] This PR does not need a test because `FILL THIS IN`.

- Select one of the following.
  - [x] I have not added any `lit` tests.
  - [ ] The `lit` tests I have added follow these [best practices](https://mlir.llvm.org/getting_started/TestingGuide/#filecheck-best-practices),
    including the "tests should be minimal" section. (Usually running Python code
    and using the instructions it generates is not minimal.)
