### PR TITLE
[triton_kernels] tune blackwell nvfp4 x nvfp4 opt flags

### DIFF
--- a/python/triton_kernels/tests/test_matmul_details/test_opt_flags_nvidia.py
+++ b/python/triton_kernels/tests/test_matmul_details/test_opt_flags_nvidia.py
@@ -8,17 +8,70 @@ from triton_kernels.matmul import matmul, matmul_torch, PrecisionConfig
 from triton_kernels.matmul_details._matmul import _compute_packed_n_w
 from triton_kernels.matmul_details.opt_flags import InapplicableConstraint, scoped_opt_flags_constraints
 from triton_kernels.matmul_details.opt_flags_details import opt_flags_nvidia
-from triton_kernels.numerics_details.mxfp import MXFP_BLOCK_SIZE, downcast_to_mxfp
+from triton_kernels.numerics_details.mxfp import MXFP_BLOCK_SIZE, NVFP_BLOCK_SIZE, downcast_to_mxfp
 from triton_kernels.tensor import FP4, UINT8, Storage, Tensor, convert_layout, wrap_torch_tensor
 from triton_kernels.tensor_details import layout
 from triton_kernels.tensor_details.layout import BlackwellMX4ValueShuffledLayout
-from triton_kernels.tensor_details.layout_details.blackwell_scale import BlackwellMXScaleLayout
+from triton_kernels.tensor_details.layout_details.blackwell_scale import BlackwellActMXScaleLayout, BlackwellMXScaleLayout
 from triton_kernels.testing import assert_close
 
 
 def _make_blackwell_scale_tensor():
     scale_storage = Storage(torch.empty((1, 128), dtype=torch.uint8), BlackwellMXScaleLayout())
     return Tensor(scale_storage, dtype=UINT8)
+
+
+def _make_blackwell_act_scale_tensor():
+    scale_storage = Storage(torch.empty((128, 16), dtype=torch.float8_e4m3fn), BlackwellActMXScaleLayout(None))
+    return Tensor(scale_storage, dtype=UINT8)
+
+
+def _make_blackwell_nvfp4_precision_config():
+    return PrecisionConfig(
+        a_mx_scale=_make_blackwell_act_scale_tensor(),
+        a_microblock_size=NVFP_BLOCK_SIZE.value,
+        b_mx_scale=_make_blackwell_scale_tensor(),
+        b_microblock_size=NVFP_BLOCK_SIZE.value,
+    )
+
+
+def _make_default_blackwell_nvfp4_flags(monkeypatch, m, n, k, constraints=None):
+    from types import SimpleNamespace
+
+    from triton_kernels.matmul_details import opt_flags
+    from triton_kernels.tensor import BF16
+
+    monkeypatch.setattr(opt_flags.torch.cuda, "get_device_capability", lambda: (10, 3))
+    monkeypatch.setattr(
+        opt_flags.torch.cuda,
+        "get_device_properties",
+        lambda _device: SimpleNamespace(multi_processor_count=132, shared_memory_per_block_optin=232448),
+    )
+    monkeypatch.setattr(opt_flags, "cuda_capability_geq", lambda major, minor: (10, 3) >= (major, minor))
+    monkeypatch.setattr(opt_flags.target_info, "has_native_mxfp", lambda: True)
+    monkeypatch.setattr(opt_flags.opt_flags_nvidia.target_info, "cuda_capability_geq",
+                        lambda major, minor: (10, 3) >= (major, minor))
+
+    return opt_flags.make_default_opt_flags_nvidia(
+        BF16,
+        FP4,
+        FP4,
+        _make_blackwell_nvfp4_precision_config(),
+        1,
+        m,
+        n,
+        k,
+        None,
+        True,
+        False,
+        False,
+        None,
+        False,
+        False,
+        constraints or {},
+        torch.float32,
+        mx_block_size=NVFP_BLOCK_SIZE.value,
+    )
 
 
 def _make_blackwell_mxfp4_weight(device, k, n):
@@ -158,6 +211,33 @@ def test_compute_block_n_blackwell_scale_aligns_to_128(n, expected):
     )
     block_n, block_n_tma = opt_flags_nvidia.compute_block_n(n, None, precision_config)
     assert block_n == block_n_tma == expected
+
+
+def test_blackwell_nvfp4_x_nvfp4_uses_gb300_persistent_tile(monkeypatch):
+    flags = _make_default_blackwell_nvfp4_flags(monkeypatch, 32768, 40960, 20480)
+
+    assert flags.is_persistent
+    assert (flags.block_m, flags.block_n, flags.block_k) == (128, 256, 256)
+    assert flags.num_warps == 8
+    assert flags.num_stages == 3
+    assert flags.epilogue_subtile == 4
+
+
+def test_blackwell_nvfp4_x_nvfp4_caps_warps_for_large_constrained_tile(monkeypatch):
+    flags = _make_default_blackwell_nvfp4_flags(monkeypatch, 32768, 40960, 20480, {"block_n": 512})
+
+    assert (flags.block_m, flags.block_n, flags.block_k) == (128, 512, 256)
+    assert flags.num_warps == 8
+
+
+def test_blackwell_nvfp4_x_nvfp4_uses_smaller_n_tile_for_small_shapes(monkeypatch):
+    flags = _make_default_blackwell_nvfp4_flags(monkeypatch, 1024, 1024, 1024)
+
+    assert flags.is_persistent
+    assert (flags.block_m, flags.block_n, flags.block_k) == (128, 128, 256)
+    assert flags.num_warps == 8
+    assert flags.num_stages == 3
+    assert flags.epilogue_subtile == 4
 
 
 def test_matmul_blackwell_scale_small_n(device):

--- a/python/triton_kernels/tests/test_matmul_details/test_opt_flags_nvidia.py
+++ b/python/triton_kernels/tests/test_matmul_details/test_opt_flags_nvidia.py
@@ -26,16 +26,21 @@ def _make_blackwell_act_scale_tensor():
     return Tensor(scale_storage, dtype=UINT8)
 
 
-def _make_blackwell_nvfp4_precision_config():
+def _make_strided_act_scale_tensor():
+    scale_storage = Storage(torch.empty((128, 16), dtype=torch.float8_e4m3fn), layout.StridedLayout(-1))
+    return Tensor(scale_storage, dtype=UINT8)
+
+
+def _make_blackwell_nvfp4_precision_config(*, swizzle_a_scale=True):
     return PrecisionConfig(
-        a_mx_scale=_make_blackwell_act_scale_tensor(),
+        a_mx_scale=_make_blackwell_act_scale_tensor() if swizzle_a_scale else _make_strided_act_scale_tensor(),
         a_microblock_size=NVFP_BLOCK_SIZE.value,
         b_mx_scale=_make_blackwell_scale_tensor(),
         b_microblock_size=NVFP_BLOCK_SIZE.value,
     )
 
 
-def _make_default_blackwell_nvfp4_flags(monkeypatch, m, n, k, constraints=None):
+def _make_default_blackwell_nvfp4_flags(monkeypatch, m, n, k, constraints=None, *, swizzle_a_scale=True):
     from types import SimpleNamespace
 
     from triton_kernels.matmul_details import opt_flags
@@ -56,7 +61,7 @@ def _make_default_blackwell_nvfp4_flags(monkeypatch, m, n, k, constraints=None):
         BF16,
         FP4,
         FP4,
-        _make_blackwell_nvfp4_precision_config(),
+        _make_blackwell_nvfp4_precision_config(swizzle_a_scale=swizzle_a_scale),
         1,
         m,
         n,
@@ -236,8 +241,68 @@ def test_blackwell_nvfp4_x_nvfp4_uses_smaller_n_tile_for_small_shapes(monkeypatc
     assert flags.is_persistent
     assert (flags.block_m, flags.block_n, flags.block_k) == (128, 128, 256)
     assert flags.num_warps == 8
+    assert flags.num_stages == 4
+    assert flags.epilogue_subtile == 1
+
+
+def test_blackwell_nvfp4_x_nvfp4_uses_low_k_epilogue_subtile(monkeypatch):
+    flags = _make_default_blackwell_nvfp4_flags(monkeypatch, 8192, 2048, 2048)
+
+    assert flags.is_persistent
+    assert (flags.block_m, flags.block_n, flags.block_k) == (128, 128, 256)
+    assert flags.num_warps == 8
+    assert flags.num_stages == 4
+    assert flags.epilogue_subtile == 1
+
+
+def test_blackwell_nvfp4_x_nvfp4_handles_strided_a_scales(monkeypatch):
+    flags = _make_default_blackwell_nvfp4_flags(monkeypatch, 8192, 2048, 2048, swizzle_a_scale=False)
+
+    assert flags.is_persistent
+    assert (flags.block_m, flags.block_n, flags.block_k) == (128, 256, 256)
+    assert flags.num_warps == 8
     assert flags.num_stages == 3
-    assert flags.epilogue_subtile == 4
+    assert flags.epilogue_subtile == 1
+
+
+def test_blackwell_nvfp4_x_nvfp4_uses_smaller_m_tile_for_small_strided_a_scales(monkeypatch):
+    flags = _make_default_blackwell_nvfp4_flags(monkeypatch, 1024, 1024, 1024, swizzle_a_scale=False)
+
+    assert flags.is_persistent
+    assert (flags.block_m, flags.block_n, flags.block_k) == (64, 128, 256)
+    assert flags.num_warps == 8
+    assert flags.num_stages == 4
+    assert flags.epilogue_subtile == 1
+
+
+def test_blackwell_nvfp4_x_nvfp4_uses_four_warps_for_mid_small_mn(monkeypatch):
+    flags = _make_default_blackwell_nvfp4_flags(monkeypatch, 2048, 2048, 8192)
+
+    assert flags.is_persistent
+    assert (flags.block_m, flags.block_n, flags.block_k) == (128, 256, 256)
+    assert flags.num_warps == 4
+    assert flags.num_stages == 3
+    assert flags.epilogue_subtile == 2
+
+
+def test_blackwell_nvfp4_x_nvfp4_keeps_large_tile_for_medium_low_k_strided_a_scales(monkeypatch):
+    flags = _make_default_blackwell_nvfp4_flags(monkeypatch, 4096, 1024, 4096, swizzle_a_scale=False)
+
+    assert flags.is_persistent
+    assert (flags.block_m, flags.block_n, flags.block_k) == (128, 256, 256)
+    assert flags.num_warps == 8
+    assert flags.num_stages == 3
+    assert flags.epilogue_subtile == 1
+
+
+def test_blackwell_nvfp4_x_nvfp4_uses_smaller_tile_for_strided_a_small_mn(monkeypatch):
+    flags = _make_default_blackwell_nvfp4_flags(monkeypatch, 2048, 512, 8192, swizzle_a_scale=False)
+
+    assert flags.is_persistent
+    assert (flags.block_m, flags.block_n, flags.block_k) == (64, 128, 256)
+    assert flags.num_warps == 8
+    assert flags.num_stages == 3
+    assert flags.epilogue_subtile == 1
 
 
 def test_matmul_blackwell_scale_small_n(device):

--- a/python/triton_kernels/triton_kernels/matmul_details/opt_flags.py
+++ b/python/triton_kernels/triton_kernels/matmul_details/opt_flags.py
@@ -269,6 +269,7 @@ def make_default_opt_flags_nvidia(
     supports_persistent = can_use_persistent_tma and (arch is None or int(arch[2:-1]) >= 9)
     a_mx_scale_layout = None if not isinstance(precision_config.a_mx_scale, Tensor) else precision_config.a_mx_scale.storage.layout
     b_mx_scale_layout = None if not isinstance(precision_config.b_mx_scale, Tensor) else precision_config.b_mx_scale.storage.layout
+    is_blackwell_nvfp4_x_nvfp4 = opt_flags_nvidia.is_blackwell_nvfp4_x_nvfp4(precision_config, lhs_dtype, rhs_dtype)
 
     def _is_layout_strided(layout: Layout | None) -> bool:
         return layout is None or isinstance(layout, StridedLayout)
@@ -306,15 +307,22 @@ def make_default_opt_flags_nvidia(
         # expanded operand in TMEM, so keep the accumulator tile below the
         # 512-column budget.
         block_n = min(block_n, 128)
+    if (is_persistent and constraints.get("block_n", None) is None and is_blackwell_nvfp4_x_nvfp4
+            and m is not None and m <= 4096 and n <= 1024 and k is not None and k <= 4096):
+        block_n = min(block_n, 128)
     # adjust block_m based on is_persistent signal
     if is_persistent and opt_flags_nvidia.is_x_scale_swizzled(precision_config):
         # a mx scale has been swizzled to BlackwellActMXScaleLayout, enforce block_m=128 to align with swizzling layout
+        block_m = 128
+    if is_persistent and is_blackwell_nvfp4_x_nvfp4 and constraints.get("block_m", None) is None:
         block_m = 128
     # block k
     if constraints.get("block_k", None) is not None:
         block_k = constraints["block_k"]
     else:
         block_k = opt_flags_nvidia.compute_block_k(m, k, is_persistent, lhs_dtype, rhs_dtype, precision_config, has_y_acc_in)
+        if is_persistent and is_blackwell_nvfp4_x_nvfp4 and (k is None or k >= 256):
+            block_k = max(block_k, 256)
     if block_n == 256 and block_k == 128 and block_m <= 64 and is_persistent and rhs_dtype == FP4 and k >= 4096 and slice_size > 1 and lhs_dtype != torch.bfloat16 and not constraints.get("disable_mx4_block_swap", False):
         # Swap block_n and block_k for mxfp4 weights so that block_k is a full cacheline, so long as K is sufficiently large.
         # TODO: swizzle the HBM layout of the weights instead
@@ -349,6 +357,9 @@ def make_default_opt_flags_nvidia(
     )
 
     num_warps = opt_flags_nvidia.compute_num_warps(block_m, block_n, is_persistent, precision_config, constraints)
+    if (constraints.get("num_warps", None) is None and is_persistent and is_blackwell_nvfp4_x_nvfp4
+            and block_m >= 128 and block_n >= 128 and block_k >= 256):
+        num_warps = 8
     if (constraints.get("num_warps", None) is None
             and is_persistent
             and block_n <= 128
@@ -377,6 +388,9 @@ def make_default_opt_flags_nvidia(
 
     if constraints.get("epilogue_subtile", None) is not None:
         subtiles_to_check = [constraints["epilogue_subtile"]]
+    elif (is_persistent and is_blackwell_nvfp4_x_nvfp4 and precision_config.c_mx_scale is None
+            and block_m >= 128 and block_n >= 128 and block_k >= 256):
+        subtiles_to_check = [4]
     else:
         subtiles_to_check = [1] if out_dtype == FP4 else [1, 2, 4]
     num_stages = -1
@@ -387,6 +401,9 @@ def make_default_opt_flags_nvidia(
         if ns > num_stages:
             epilogue_subtile, num_stages = ep, ns
 
+    if (constraints.get("num_stages", None) is None and is_persistent and is_blackwell_nvfp4_x_nvfp4
+            and block_m >= 128 and block_n <= 128 and block_k >= 256):
+        num_stages = min(num_stages, 3)
     if constraints.get("num_stages", None):
         num_stages = constraints["num_stages"]
     assert num_stages >= 1

--- a/python/triton_kernels/triton_kernels/matmul_details/opt_flags.py
+++ b/python/triton_kernels/triton_kernels/matmul_details/opt_flags.py
@@ -12,6 +12,7 @@ import torch
 from triton_kernels.tensor_details.layout_details.hopper_scale import HopperMXScaleLayout
 from triton_kernels.tensor_details.layout_details.strided import StridedLayout
 from triton_kernels.tensor_details.layout_details.base import Layout
+from triton_kernels.tensor_details.layout_details.blackwell_scale import BlackwellMXScaleLayout
 from triton_kernels.tensor_details.layout_details.blackwell_value_shuffled import BlackwellMX4ValueShuffledLayout
 from .opt_flags_details import opt_flags_amd, opt_flags_nvidia
 
@@ -269,10 +270,38 @@ def make_default_opt_flags_nvidia(
     supports_persistent = can_use_persistent_tma and (arch is None or int(arch[2:-1]) >= 9)
     a_mx_scale_layout = None if not isinstance(precision_config.a_mx_scale, Tensor) else precision_config.a_mx_scale.storage.layout
     b_mx_scale_layout = None if not isinstance(precision_config.b_mx_scale, Tensor) else precision_config.b_mx_scale.storage.layout
-    is_blackwell_nvfp4_x_nvfp4 = opt_flags_nvidia.is_blackwell_nvfp4_x_nvfp4(precision_config, lhs_dtype, rhs_dtype)
 
     def _is_layout_strided(layout: Layout | None) -> bool:
         return layout is None or isinstance(layout, StridedLayout)
+
+    is_blackwell_nvfp4_x_nvfp4 = (
+        opt_flags_nvidia.is_blackwell_nvfp4_x_nvfp4(precision_config, lhs_dtype, rhs_dtype)
+        and isinstance(b_mx_scale_layout, BlackwellMXScaleLayout)
+    )
+    # GB300 NVFP4 x NVFP4 tuning follows the amount of work available:
+    # first reduce epilogue pressure, then N tile pressure, and only strided
+    # activation-scale layouts may reduce M below the Blackwell act-scale tile.
+    has_blackwell_act_a_scale = is_blackwell_nvfp4_x_nvfp4 and opt_flags_nvidia.is_x_scale_swizzled(precision_config)
+    has_strided_a_scale = is_blackwell_nvfp4_x_nvfp4 and _is_layout_strided(a_mx_scale_layout)
+    is_low_k = k is not None and k <= 4096
+    is_medium_low_k = k is not None and k <= 8192 and n <= 2048
+    is_narrow_n = n <= 1024
+    is_mid_small_mn = k is not None and k <= 8192 and ((m is not None and m <= 2048) or n <= 512)
+    is_small_m_and_n = m is not None and m <= 2048 and n <= 512
+    is_small_blackwell_nvfp4_x_nvfp4 = (is_blackwell_nvfp4_x_nvfp4
+                                        and m is not None and m <= 4096
+                                        and n <= 1024
+                                        and k is not None and k <= 4096)
+    reduce_tile_for_strided_a_scale = has_strided_a_scale and (
+        (is_small_blackwell_nvfp4_x_nvfp4 and ((m is not None and m <= 2048) or n <= 512))
+        or (is_medium_low_k and is_small_m_and_n)
+    )
+    reduce_epilogue_for_strided_a_scale = has_strided_a_scale and (is_low_k or is_medium_low_k)
+    reduce_n_for_blackwell_act_a_scale = has_blackwell_act_a_scale and (is_low_k or (is_narrow_n and not is_mid_small_mn))
+    reduce_epilogue_for_blackwell_act_a_scale = has_blackwell_act_a_scale and (
+        reduce_n_for_blackwell_act_a_scale or is_small_blackwell_nvfp4_x_nvfp4
+    )
+    reduce_warps_for_mid_small_mn = has_blackwell_act_a_scale and not is_small_blackwell_nvfp4_x_nvfp4 and is_mid_small_mn
 
     requires_persistent = (not _is_layout_strided(a_mx_scale_layout) or not _is_layout_strided(b_mx_scale_layout)) and target_info.has_native_mxfp()
     if constraints.get("is_persistent", None) is not None:
@@ -307,15 +336,17 @@ def make_default_opt_flags_nvidia(
         # expanded operand in TMEM, so keep the accumulator tile below the
         # 512-column budget.
         block_n = min(block_n, 128)
-    if (is_persistent and constraints.get("block_n", None) is None and is_blackwell_nvfp4_x_nvfp4
-            and m is not None and m <= 4096 and n <= 1024 and k is not None and k <= 4096):
+    if (is_persistent and constraints.get("block_n", None) is None
+            and ((has_blackwell_act_a_scale and is_small_blackwell_nvfp4_x_nvfp4)
+                 or reduce_tile_for_strided_a_scale
+                 or reduce_n_for_blackwell_act_a_scale)):
         block_n = min(block_n, 128)
     # adjust block_m based on is_persistent signal
     if is_persistent and opt_flags_nvidia.is_x_scale_swizzled(precision_config):
         # a mx scale has been swizzled to BlackwellActMXScaleLayout, enforce block_m=128 to align with swizzling layout
         block_m = 128
     if is_persistent and is_blackwell_nvfp4_x_nvfp4 and constraints.get("block_m", None) is None:
-        block_m = 128
+        block_m = 64 if reduce_tile_for_strided_a_scale else 128
     # block k
     if constraints.get("block_k", None) is not None:
         block_k = constraints["block_k"]
@@ -357,7 +388,13 @@ def make_default_opt_flags_nvidia(
     )
 
     num_warps = opt_flags_nvidia.compute_num_warps(block_m, block_n, is_persistent, precision_config, constraints)
-    if (constraints.get("num_warps", None) is None and is_persistent and is_blackwell_nvfp4_x_nvfp4
+    if (constraints.get("num_warps", None) is None and is_persistent and reduce_tile_for_strided_a_scale
+            and block_m >= 64 and block_n >= 128 and block_k >= 256):
+        num_warps = 8
+    elif (constraints.get("num_warps", None) is None and is_persistent and reduce_warps_for_mid_small_mn
+            and block_m >= 128 and block_n >= 128 and block_k >= 256):
+        num_warps = 4
+    elif (constraints.get("num_warps", None) is None and is_persistent and is_blackwell_nvfp4_x_nvfp4
             and block_m >= 128 and block_n >= 128 and block_k >= 256):
         num_warps = 8
     if (constraints.get("num_warps", None) is None
@@ -388,6 +425,21 @@ def make_default_opt_flags_nvidia(
 
     if constraints.get("epilogue_subtile", None) is not None:
         subtiles_to_check = [constraints["epilogue_subtile"]]
+    elif (is_persistent and precision_config.c_mx_scale is None
+            and (is_small_blackwell_nvfp4_x_nvfp4
+                 or reduce_epilogue_for_strided_a_scale
+                 or reduce_epilogue_for_blackwell_act_a_scale)
+            and block_m >= 128 and block_n >= 128 and block_k >= 256):
+        subtiles_to_check = [1]
+    elif (is_persistent and reduce_tile_for_strided_a_scale
+            and precision_config.c_mx_scale is None and block_m >= 64 and block_n >= 128 and block_k >= 256):
+        subtiles_to_check = [1]
+    elif (is_persistent and reduce_warps_for_mid_small_mn and precision_config.c_mx_scale is None
+            and block_m >= 128 and block_n >= 256 and block_k >= 256):
+        subtiles_to_check = [2]
+    elif (is_persistent and is_blackwell_nvfp4_x_nvfp4 and precision_config.c_mx_scale is None
+            and block_m >= 128 and block_n >= 256 and block_k >= 256 and k is not None and k <= 2048):
+        subtiles_to_check = [2]
     elif (is_persistent and is_blackwell_nvfp4_x_nvfp4 and precision_config.c_mx_scale is None
             and block_m >= 128 and block_n >= 128 and block_k >= 256):
         subtiles_to_check = [4]
@@ -401,9 +453,18 @@ def make_default_opt_flags_nvidia(
         if ns > num_stages:
             epilogue_subtile, num_stages = ep, ns
 
-    if (constraints.get("num_stages", None) is None and is_persistent and is_blackwell_nvfp4_x_nvfp4
-            and block_m >= 128 and block_n <= 128 and block_k >= 256):
+    if (constraints.get("num_stages", None) is None and is_persistent
+            and ((has_blackwell_act_a_scale and is_small_blackwell_nvfp4_x_nvfp4)
+                 or reduce_tile_for_strided_a_scale
+                 or reduce_n_for_blackwell_act_a_scale)
+            and block_m >= 64 and block_n <= 128 and block_k >= 256):
+        num_stages = min(num_stages, 4)
+    if (constraints.get("num_stages", None) is None and is_persistent and reduce_tile_for_strided_a_scale
+            and not is_small_blackwell_nvfp4_x_nvfp4 and block_m >= 64 and block_n <= 128 and block_k >= 256):
         num_stages = min(num_stages, 3)
+    if (constraints.get("num_stages", None) is None and is_persistent and reduce_epilogue_for_strided_a_scale
+            and block_m >= 128 and block_n >= 256 and block_k >= 256):
+        num_stages = max(num_stages, 3)
     if constraints.get("num_stages", None):
         num_stages = constraints["num_stages"]
     assert num_stages >= 1

--- a/python/triton_kernels/triton_kernels/matmul_details/opt_flags_details/opt_flags_nvidia.py
+++ b/python/triton_kernels/triton_kernels/matmul_details/opt_flags_details/opt_flags_nvidia.py
@@ -1,7 +1,7 @@
 import torch
 import triton
 from triton_kernels import target_info
-from triton_kernels.numerics_details.mxfp_details._downcast_to_mxfp import MXFP_BLOCK_SIZE
+from triton_kernels.numerics_details.mxfp_details._downcast_to_mxfp import MXFP_BLOCK_SIZE, NVFP_BLOCK_SIZE
 from triton_kernels.tensor import FP4, FP16, FP32, BF16, Tensor
 from triton_kernels.tensor_details.layout import HopperMXScaleLayout
 from triton_kernels.tensor_details.layout_details.blackwell_scale import BlackwellActMXScaleLayout, BlackwellMXScaleLayout
@@ -11,6 +11,14 @@ def is_x_scale_swizzled(precision_config):
     return (precision_config is not None and precision_config.a_mx_scale is not None
             and isinstance(precision_config.a_mx_scale, Tensor)
             and isinstance(precision_config.a_mx_scale.storage.layout, BlackwellActMXScaleLayout))
+
+
+def is_blackwell_nvfp4_x_nvfp4(precision_config, lhs_dtype, rhs_dtype):
+    return (target_info.cuda_capability_geq(10, 0) and precision_config is not None and lhs_dtype == FP4
+            and rhs_dtype == FP4 and precision_config.a_mx_scale is not None
+            and precision_config.a_microblock_size == int(NVFP_BLOCK_SIZE)
+            and precision_config.b_mx_scale is not None
+            and precision_config.b_microblock_size == int(NVFP_BLOCK_SIZE))
 
 
 def is_blackwell_mx_lhs_dense_rhs(precision_config, lhs_dtype, rhs_dtype):
@@ -197,7 +205,10 @@ def compute_num_stages(
             # The fp32 accumulator stays in TMEM for the Blackwell SWAP_XW
             # persistent path. Fused reductions such as swiglu still need smem
             # for the unreduced output tile before the narrower TMA-store tile.
-            if epilogue_reduction_n > 1 or epilogue_subtile > 1:
+            has_simple_nvfp4_output = is_blackwell_nvfp4_x_nvfp4(
+                precision_config, lhs_dtype, rhs_dtype
+            ) and precision_config.c_mx_scale is None
+            if epilogue_reduction_n > 1 or (epilogue_subtile > 1 and not has_simple_nvfp4_output):
                 epilogue_smem += int(block_m * block_n * out_itemsize)
         smem_capacity -= epilogue_smem
         if x_transpose:


### PR DESCRIPTION
This PR improves the GB300 NVFP4 x NVFP4 matmul opt flag heuristic for Blackwell B-value/B-scale layouts by making the choices layout- and size-based instead of relying on model-path buckets.

The heuristic keeps the high-throughput large-shape persistent default around `BLOCK_M=128`, `BLOCK_N=256`, `BLOCK_K=256`, `num_warps=8`, `num_stages=3`, `epilogue_subtile=4`, and progressively reduces epilogue or tile pressure for smaller/low-K/narrow-N shapes. `BLOCK_K=256` remains the robust default.

Benchmarks were run on `second-dev-box` / GB300. Old is `main`; new is this PR. PFLOPS are median auto-config results from 5 reps.

## Speedup statistics

| layout | min | q10 | q25 | median | mean | q75 | q90 | max |
|---|---:|---:|---:|---:|---:|---:|---:|---:|
| Strided A scales | +5.2% | +11.2% | +21.7% | +33.6% | +43.5% | +65.7% | +84.2% | +129.8% |
| BlackwellActMXScaleLayout A scales | -2.7% | +3.2% | +8.5% | +30.3% | +29.3% | +38.5% | +47.0% | +97.0% |

## Strided A scales

A values are strided, B values use `BlackwellMXValueLayout`, and B scales use `BlackwellMXScaleLayout`.

| shape | old PFLOPS | new PFLOPS | improvement | result |
|---|---:|---:|---:|:---:|
| small_base (1024, 256, 1024) | 0.047 | 0.072 | +55.4% | ⚡️ |
| small_m_div4 (256, 256, 1024) | 0.012 | 0.018 | +56.4% | ⚡️ |
| small_m_div2 (512, 256, 1024) | 0.023 | 0.036 | +56.4% | ⚡️ |
| small_m_x2 (2048, 256, 1024) | 0.093 | 0.143 | +53.5% | ⚡️ |
| small_m_x4 (4096, 256, 1024) | 0.185 | 0.287 | +54.9% | ⚡️ |
| small_n_div4 (1024, 64, 1024) | 0.017 | 0.018 | +6.6% |  |
| small_n_div2 (1024, 128, 1024) | 0.033 | 0.036 | +10.1% |  |
| small_n_x2 (1024, 512, 1024) | 0.108 | 0.145 | +34.6% | ⬆️ |
| small_n_x4 (1024, 1024, 1024) | 0.214 | 0.284 | +32.5% | ⬆️ |
| small_k_div4 (1024, 256, 256) | 0.015 | 0.022 | +51.6% | ⚡️ |
| small_k_div2 (1024, 256, 512) | 0.027 | 0.041 | +49.7% | ⬆️ |
| small_k_x2 (1024, 256, 2048) | 0.048 | 0.090 | +86.6% | ⚡️ |
| small_k_x4 (1024, 256, 4096) | 0.088 | 0.151 | +70.8% | ⚡️ |
| small_mid_base (2048, 512, 2048) | 0.200 | 0.460 | +129.8% | 🔥 |
| small_mid_m_div4 (512, 512, 2048) | 0.051 | 0.091 | +76.9% | ⚡️ |
| small_mid_m_div2 (1024, 512, 2048) | 0.103 | 0.181 | +76.3% | ⚡️ |
| small_mid_m_x2 (4096, 512, 2048) | 0.386 | 0.656 | +70.0% | ⚡️ |
| small_mid_m_x4 (8192, 512, 2048) | 1.232 | 1.363 | +10.7% |  |
| small_mid_n_div4 (2048, 128, 2048) | 0.059 | 0.091 | +53.9% | ⚡️ |
| small_mid_n_div2 (2048, 256, 2048) | 0.096 | 0.177 | +85.0% | ⚡️ |
| small_mid_n_x2 (2048, 1024, 2048) | 0.387 | 0.668 | +72.6% | ⚡️ |
| small_mid_n_x4 (2048, 2048, 2048) | 1.244 | 1.373 | +10.4% |  |
| small_mid_k_div4 (2048, 512, 512) | 0.128 | 0.160 | +25.3% |  |
| small_mid_k_div2 (2048, 512, 1024) | 0.211 | 0.285 | +35.2% | ⬆️ |
| small_mid_k_x2 (2048, 512, 4096) | 0.362 | 0.694 | +91.5% | ⚡️ |
| small_mid_k_x4 (2048, 512, 8192) | 0.516 | 0.917 | +77.5% | ⚡️ |
| medium_base (4096, 1024, 4096) | 1.692 | 1.962 | +16.0% |  |
| medium_m_div4 (1024, 1024, 4096) | 0.362 | 0.689 | +90.3% | ⚡️ |
| medium_m_div2 (2048, 1024, 4096) | 0.534 | 0.895 | +67.6% | ⚡️ |
| medium_m_x2 (8192, 1024, 4096) | 2.003 | 2.392 | +19.4% |  |
| medium_m_x4 (16384, 1024, 4096) | 2.184 | 2.681 | +22.7% |  |
| medium_n_div4 (4096, 256, 4096) | 0.348 | 0.689 | +98.2% | ⚡️ |
| medium_n_div2 (4096, 512, 4096) | 0.539 | 0.891 | +65.1% | ⚡️ |
| medium_n_x2 (4096, 2048, 4096) | 2.005 | 2.386 | +19.0% |  |
| medium_n_x4 (4096, 4096, 4096) | 2.211 | 2.708 | +22.5% |  |
| medium_k_div4 (4096, 1024, 1024) | 0.838 | 0.882 | +5.2% |  |
| medium_k_div2 (4096, 1024, 2048) | 1.246 | 1.351 | +8.4% |  |
| medium_k_x2 (4096, 1024, 8192) | 2.055 | 2.489 | +21.1% |  |
| medium_k_x4 (4096, 1024, 16384) | 2.316 | 2.855 | +23.3% |  |
| mid_base (8192, 2048, 8192) | 2.332 | 3.000 | +28.6% |  |
| mid_m_div4 (2048, 2048, 8192) | 2.055 | 2.494 | +21.3% |  |
| mid_m_div2 (4096, 2048, 8192) | 2.278 | 2.811 | +23.4% |  |
| mid_m_x2 (16384, 2048, 8192) | 2.729 | 3.521 | +29.0% |  |
| mid_m_x4 (32768, 2048, 8192) | 2.792 | 3.618 | +29.6% |  |
| mid_n_div4 (8192, 512, 8192) | 2.052 | 2.488 | +21.2% |  |
| mid_n_div2 (8192, 1024, 8192) | 2.278 | 2.816 | +23.6% |  |
| mid_n_x2 (8192, 4096, 8192) | 2.755 | 3.513 | +27.5% |  |
| mid_n_x4 (8192, 8192, 8192) | 2.822 | 3.610 | +27.9% |  |
| mid_k_div4 (8192, 2048, 2048) | 1.893 | 2.245 | +18.6% |  |
| mid_k_div2 (8192, 2048, 4096) | 2.213 | 2.695 | +21.8% |  |
| mid_k_x2 (8192, 2048, 16384) | 2.385 | 3.223 | +35.2% | ⬆️ |
| mid_k_x4 (8192, 2048, 32768) | 2.396 | 3.359 | +40.2% | ⬆️ |

## BlackwellActMXScaleLayout A scales

A values are strided, B values use `BlackwellMXValueLayout`, and B scales use `BlackwellMXScaleLayout`.

| shape | old PFLOPS | new PFLOPS | improvement | result |
|---|---:|---:|---:|:---:|
| small_base (1024, 256, 1024) | 0.056 | 0.079 | +41.7% | ⬆️ |
| small_m_div4 (256, 256, 1024) | 0.014 | 0.020 | +38.2% | ⬆️ |
| small_m_div2 (512, 256, 1024) | 0.028 | 0.039 | +37.7% | ⬆️ |
| small_m_x2 (2048, 256, 1024) | 0.110 | 0.152 | +38.1% | ⬆️ |
| small_m_x4 (4096, 256, 1024) | 0.226 | 0.302 | +33.4% | ⬆️ |
| small_n_div4 (1024, 64, 1024) | 0.020 | 0.020 | -0.1% | ‼️ |
| small_n_div2 (1024, 128, 1024) | 0.038 | 0.037 | -1.5% | ‼️ |
| small_n_x2 (1024, 512, 1024) | 0.123 | 0.153 | +24.2% |  |
| small_n_x4 (1024, 1024, 1024) | 0.250 | 0.305 | +22.1% |  |
| small_k_div4 (1024, 256, 256) | 0.017 | 0.021 | +27.4% |  |
| small_k_div2 (1024, 256, 512) | 0.030 | 0.040 | +33.6% | ⬆️ |
| small_k_x2 (1024, 256, 2048) | 0.073 | 0.103 | +42.5% | ⬆️ |
| small_k_x4 (1024, 256, 4096) | 0.128 | 0.188 | +47.1% | ⬆️ |
| small_mid_base (2048, 512, 2048) | 0.288 | 0.384 | +33.2% | ⬆️ |
| small_mid_m_div4 (512, 512, 2048) | 0.075 | 0.101 | +35.6% | ⬆️ |
| small_mid_m_div2 (1024, 512, 2048) | 0.152 | 0.203 | +33.5% | ⬆️ |
| small_mid_m_x2 (4096, 512, 2048) | 0.561 | 1.066 | +89.8% | ⚡️ |
| small_mid_m_x4 (8192, 512, 2048) | 1.587 | 1.638 | +3.2% |  |
| small_mid_n_div4 (2048, 128, 2048) | 0.103 | 0.100 | -2.7% | ‼️ |
| small_mid_n_div2 (2048, 256, 2048) | 0.146 | 0.203 | +39.2% | ⬆️ |
| small_mid_n_x2 (2048, 1024, 2048) | 0.563 | 1.069 | +90.0% | ⚡️ |
| small_mid_n_x4 (2048, 2048, 2048) | 1.589 | 1.644 | +3.5% |  |
| small_mid_k_div4 (2048, 512, 512) | 0.139 | 0.162 | +16.8% |  |
| small_mid_k_div2 (2048, 512, 1024) | 0.248 | 0.302 | +21.5% |  |
| small_mid_k_x2 (2048, 512, 4096) | 0.514 | 0.708 | +37.9% | ⬆️ |
| small_mid_k_x4 (2048, 512, 8192) | 0.841 | 0.883 | +5.1% |  |
| medium_base (4096, 1024, 4096) | 2.385 | 2.543 | +6.6% |  |
| medium_m_div4 (1024, 1024, 4096) | 0.499 | 0.719 | +44.1% | ⬆️ |
| medium_m_div2 (2048, 1024, 4096) | 0.885 | 1.744 | +97.0% | ⚡️ |
| medium_m_x2 (8192, 1024, 4096) | 2.972 | 3.270 | +10.0% |  |
| medium_m_x4 (16384, 1024, 4096) | 3.130 | 3.820 | +22.0% |  |
| medium_n_div4 (4096, 256, 4096) | 0.499 | 0.735 | +47.3% | ⬆️ |
| medium_n_div2 (4096, 512, 4096) | 0.903 | 1.774 | +96.5% | ⚡️ |
| medium_n_x2 (4096, 2048, 4096) | 2.998 | 3.248 | +8.3% |  |
| medium_n_x4 (4096, 4096, 4096) | 3.386 | 4.059 | +19.9% |  |
| medium_k_div4 (4096, 1024, 1024) | 0.966 | 1.026 | +6.2% |  |
| medium_k_div2 (4096, 1024, 2048) | 1.584 | 1.664 | +5.1% |  |
| medium_k_x2 (4096, 1024, 8192) | 3.218 | 3.470 | +7.9% |  |
| medium_k_x4 (4096, 1024, 16384) | 3.854 | 3.861 | +0.2% |  |
| mid_base (8192, 2048, 8192) | 3.225 | 4.420 | +37.0% | ⬆️ |
| mid_m_div4 (2048, 2048, 8192) | 3.210 | 3.536 | +10.1% |  |
| mid_m_div2 (4096, 2048, 8192) | 3.734 | 4.312 | +15.5% |  |
| mid_m_x2 (16384, 2048, 8192) | 3.892 | 5.351 | +37.5% | ⬆️ |
| mid_m_x4 (32768, 2048, 8192) | 4.063 | 5.618 | +38.3% | ⬆️ |
| mid_n_div4 (8192, 512, 8192) | 3.234 | 3.511 | +8.6% |  |
| mid_n_div2 (8192, 1024, 8192) | 3.736 | 3.828 | +2.5% |  |
| mid_n_x2 (8192, 4096, 8192) | 3.970 | 5.431 | +36.8% | ⬆️ |
| mid_n_x4 (8192, 8192, 8192) | 3.675 | 5.311 | +44.5% | ⬆️ |
| mid_k_div4 (8192, 2048, 2048) | 2.665 | 3.141 | +17.9% |  |
| mid_k_div2 (8192, 2048, 4096) | 3.111 | 3.956 | +27.1% |  |
| mid_k_x2 (8192, 2048, 16384) | 3.331 | 4.734 | +42.1% | ⬆️ |
| mid_k_x4 (8192, 2048, 32768) | 3.106 | 4.521 | +45.5% | ⬆️ |

## Testing

Focused opt-flag tests on the PR checkout:
```bash
cd /root/code/triton
PYTHONPATH=/root/code/triton/python/triton_kernels /root/.pyenv/shims/python3 -m pytest -s --tb=short python/triton_kernels/tests/test_matmul_details/test_opt_flags_nvidia.py -k "blackwell_nvfp4_x_nvfp4"
```

Expanded old/new auto benchmark sweep:
```bash
cd /root/code/triton-main-baseline
PYTHONPATH=/root/code/triton-main-baseline/python/triton_kernels /root/.pyenv/shims/python3 /tmp/nvfp4_moe_smart_sweep.py --mode auto --reps 5 --family small --family small_mid --family medium --family mid --output /tmp/nvfp4_layout_scaled_main.csv

cd /root/code/triton
PYTHONPATH=/root/code/triton/python/triton_kernels /root/.pyenv/shims/python3 /tmp/nvfp4_moe_smart_sweep.py --mode auto --reps 5 --family small --family small_mid --family medium --family mid --output /tmp/nvfp4_layout_scaled_branch.csv
```
