### PR TITLE
[NVIDIA] Allocate WS mbarriers for atomic ordering

### DIFF
--- a/lib/Dialect/TritonNvidiaGPU/Transforms/ClusterBarrierMbarAllocator.cpp
+++ b/lib/Dialect/TritonNvidiaGPU/Transforms/ClusterBarrierMbarAllocator.cpp
@@ -31,10 +31,8 @@ bool atomicNeedsClusterBarrier(Operation *op) {
 
   auto sem = isa<AtomicCASOp>(op) ? cast<AtomicCASOp>(op).getSem()
                                   : cast<AtomicRMWOp>(op).getSem();
-  if (sem == MemSemantic::RELEASE ||
-      sem == MemSemantic::ACQUIRE_RELEASE ||
-      (sem == MemSemantic::ACQUIRE &&
-       !op->hasAttr("allocation.offset")))
+  if (sem == MemSemantic::RELEASE || sem == MemSemantic::ACQUIRE_RELEASE ||
+      (sem == MemSemantic::ACQUIRE && !op->hasAttr("allocation.offset")))
     return true;
 
   if (op->getResult(0).use_empty())

--- a/lib/Dialect/TritonNvidiaGPU/Transforms/ClusterBarrierMbarAllocator.cpp
+++ b/lib/Dialect/TritonNvidiaGPU/Transforms/ClusterBarrierMbarAllocator.cpp
@@ -26,8 +26,18 @@ namespace {
 bool atomicNeedsClusterBarrier(Operation *op) {
   if (isa<AtomicPollOp>(op))
     return gpu::lookupNumCTAs(op) != 1;
-  if (!isa<AtomicCASOp, AtomicRMWOp>(op) || op->getResult(0).use_empty() ||
-      gpu::lookupNumCTAs(op) == 1)
+  if (!isa<AtomicCASOp, AtomicRMWOp>(op) || gpu::lookupNumCTAs(op) == 1)
+    return false;
+
+  auto sem = isa<AtomicCASOp>(op) ? cast<AtomicCASOp>(op).getSem()
+                                  : cast<AtomicRMWOp>(op).getSem();
+  if (sem == MemSemantic::RELEASE ||
+      sem == MemSemantic::ACQUIRE_RELEASE ||
+      (sem == MemSemantic::ACQUIRE &&
+       !op->hasAttr("allocation.offset")))
+    return true;
+
+  if (op->getResult(0).use_empty())
     return false;
   auto tensorTy = dyn_cast<RankedTensorType>(op->getResult(0).getType());
   if (!tensorTy)

--- a/test/Conversion/tritongpu_to_llvm.mlir
+++ b/test/Conversion/tritongpu_to_llvm.mlir
@@ -1636,6 +1636,27 @@ module attributes {"ttg.num-ctas" = 2 : i32, "ttg.num-warps" = 1 : i32, "ttg.tar
 
 // -----
 
+module attributes {"ttg.num-ctas" = 2 : i32, "ttg.num-warps" = 4 : i32, "ttg.target" = "cuda:90", "ttg.threads-per-warp" = 32 : i32, "ttg.total-num-warps" = 8 : i32} {
+  // Atomic ordering barriers must not introduce a nested warp specialization.
+  // CHECK-LABEL: atomic_release_multi_cta_warp_specialize
+  // CHECK: mbarrier.arrive.release.cluster.shared::cluster.b64
+  // CHECK: mbarrier.try_wait.parity.acquire.cluster.shared::cta.b64
+  // CHECK: red.global.sys.release.add.u32
+  tt.func @atomic_release_multi_cta_warp_specialize(%ptr : !tt.ptr<i32>, %mask : i1, %val : i32) {
+    ttg.warp_specialize()
+    default {
+      %old = tt.atomic_rmw add, release, sys, %ptr, %val, %mask : (!tt.ptr<i32>, i32, i1) -> i32
+      ttg.warp_yield
+    }
+    partition0() num_warps(4) {
+      ttg.warp_return
+    } : () -> ()
+    tt.return
+  }
+}
+
+// -----
+
 #blocked0 = #ttg.blocked<{sizePerThread = [1], threadsPerWarp = [32], warpsPerCTA = [4], order = [0]}>
 module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, "ttg.target" = "cuda:80"} {
   // CHECK-LABEL: atomic_add_use_result_broadcasting

--- a/test/TritonNvidiaGPU/cluster-barrier-mbar-allocator.mlir
+++ b/test/TritonNvidiaGPU/cluster-barrier-mbar-allocator.mlir
@@ -15,6 +15,7 @@ module attributes {"ttg.num-ctas" = 2 : i32, "ttg.num-warps" = 4 : i32, ttg.shar
     default {
       %c0 = arith.constant 0 : i32
       %c1 = arith.constant 1 : i32
+      %true = arith.constant true
       %cst = arith.constant dense<0.000000e+00> : tensor<256x128xf16, #blockedSplitM>
       // CHECK: ttg.convert_layout {{.*}} {ttg.mbar_offset = 8 : i32}
       %cvt = ttg.convert_layout %cst : tensor<256x128xf16, #blockedSplitM> -> tensor<256x128xf16, #blockedSplitN>
@@ -28,6 +29,10 @@ module attributes {"ttg.num-ctas" = 2 : i32, "ttg.num-warps" = 4 : i32, ttg.shar
       // CHECK: tt.atomic_cas {{.*}} {ttg.mbar_offset = 8 : i32}
       %cas = tt.atomic_cas acq_rel, gpu, %ptr, %c0, %c1 : (!tt.ptr<i32>, i32, i32) -> i32
       tt.store %ptr, %cas : !tt.ptr<i32>
+      // CHECK: tt.atomic_rmw {{.*}} {ttg.mbar_offset = 8 : i32}
+      %release = tt.atomic_rmw add, release, sys, %ptr, %c1, %true : (!tt.ptr<i32>, i32, i1) -> i32
+      // CHECK: tt.atomic_rmw {{.*}} {ttg.mbar_offset = 8 : i32}
+      %acquire = tt.atomic_rmw add, acquire, sys, %ptr, %c1, %true : (!tt.ptr<i32>, i32, i1) -> i32
       %ptrs = tt.splat %ptr : !tt.ptr<i32> -> tensor<128x!tt.ptr<i32>, #blockedBroadcast>
       %zeros = arith.constant dense<0> : tensor<128xi32, #blockedBroadcast>
       %ones = arith.constant dense<1> : tensor<128xi32, #blockedBroadcast>


### PR DESCRIPTION
PR description written by Codex

Reserve the warp-specialized cluster mbarrier allocation for multi-CTA atomics whose ordering semantics emit cluster barriers. This prevents release and acquire barriers created during atomic lowering from falling back to nested warp specialization.

Add allocator coverage and a standalone end-to-end lowering regression test for dead-result atomics.