### PR TITLE
[TritonGPU] Allow reinterpretation of contiguous memdesc subslices

### DIFF
--- a/include/triton/Dialect/TritonGPU/IR/TritonGPUOps.td
+++ b/include/triton/Dialect/TritonGPU/IR/TritonGPUOps.td
@@ -340,10 +340,8 @@ def TTG_MemDescReinterpretOp : TTG_Op<"memdesc_reinterpret", [Pure, MemDescViewT
     The `ttg.memdesc_reinterpret` operation reinterprets a memory descriptor
     as one with a different shape and element type. The logical storage size of
     the result must not exceed that of the source. Because memory descriptors
-    lack strides, this operation is only valid if the original memory descriptor
-    is contiguous. Reinterpretation of subviews is not allowed; reinterpret the
-    parent descriptor and then take a subview of the reinterpreted descriptor
-    instead.
+    lack strides, a source subview may only be reinterpreted if it is
+    contiguous. The result must not be a subview.
   }];
 
   let arguments = (ins TTG_MemDescType:$src);

--- a/lib/Dialect/TritonGPU/IR/Ops.cpp
+++ b/lib/Dialect/TritonGPU/IR/Ops.cpp
@@ -676,11 +676,8 @@ LinearLayout getViewLayout(MemDescType type) {
   for (auto dim : layout.getInDimNames()) {
     if (dim == kBlock)
       continue;
-    uint32_t freeMask = freeVariables.lookup(dim);
-    int32_t inputSize = layout.getInDimSize(dim);
-    while (inputSize > 1 && (freeMask & (inputSize >> 1)))
-      inputSize >>= 1;
-    layout = layout.resizeInDim(dim, inputSize);
+    uint32_t used = (layout.getInDimSize(dim) - 1) & ~freeVariables.lookup(dim);
+    layout = layout.resizeInDim(dim, llvm::bit_ceil(used + 1));
   }
   return layout;
 }

--- a/lib/Dialect/TritonGPU/IR/Ops.cpp
+++ b/lib/Dialect/TritonGPU/IR/Ops.cpp
@@ -653,40 +653,6 @@ OpFoldResult MemDescReinterpretOp::fold(FoldAdaptor adaptor) {
   return {};
 }
 
-namespace {
-
-LinearLayout getViewLayout(MemDescType type) {
-  auto encoding = type.getEncoding();
-  auto rank = cast<LayoutEncodingTrait>(encoding).getRank();
-  auto allocShape = type.getAllocShape().take_back(rank);
-  auto viewShape = type.getShape().take_back(rank);
-  LinearLayout layout = isPaddedEncoding(encoding)
-                            ? paddedLinearLayout(allocShape, encoding)
-                            : toLinearLayout(allocShape, encoding);
-
-  if (viewShape == allocShape)
-    return layout;
-
-  for (auto [dim, size] : llvm::zip_equal(layout.getOutDimNames(), viewShape))
-    layout = layout.resizeOutDim(dim, size);
-
-  // Only trim redundant high address bits; block mappings stay intact.
-  auto freeVariables = layout.getFreeVariableMasks();
-  auto kBlock = StringAttr::get(type.getContext(), "block");
-  for (auto dim : layout.getInDimNames()) {
-    if (dim == kBlock)
-      continue;
-    uint32_t freeMask = freeVariables.lookup(dim);
-    int32_t inputSize = layout.getInDimSize(dim);
-    while (inputSize > 1 && (freeMask & (inputSize >> 1)))
-      inputSize >>= 1;
-    layout = layout.resizeInDim(dim, inputSize);
-  }
-  return layout;
-}
-
-} // namespace
-
 LogicalResult MemDescReinterpretOp::verify() {
   auto srcTy = getSrc().getType();
   auto dstTy = getResult().getType();
@@ -735,13 +701,13 @@ LogicalResult MemDescReinterpretOp::verify() {
   if (isSubview(dstTy))
     return emitError("result must not be a subview");
 
-  auto srcLayout = getViewLayout(srcTy);
-  if (isSubview(srcTy) && !getLayoutWithinBlock(srcLayout).isInjective())
-    return emitError("source subview must be contiguous");
-  auto dstLayout = getViewLayout(dstTy);
-
-  auto getViewNumBits = [](MemDescType ty, const LinearLayout &layout) {
+  auto getViewNumBits = [](MemDescType ty) {
     auto rank = cast<LayoutEncodingTrait>(ty.getEncoding()).getRank();
+    auto shape = ty.getAllocShape().take_back(rank);
+    auto encoding = ty.getEncoding();
+    LinearLayout layout = isPaddedEncoding(encoding)
+                              ? paddedLinearLayout(shape, encoding)
+                              : toLinearLayout(shape, encoding);
     int64_t numLayoutCopies = 1;
     for (int64_t dim : ty.getAllocShape().drop_back(rank))
       numLayoutCopies *= dim;
@@ -750,12 +716,33 @@ LogicalResult MemDescReinterpretOp::verify() {
     // copies of that logical allocation.
     auto *ctx = ty.getContext();
     bool isSharedMemory = isa<SharedMemorySpaceAttr>(ty.getMemorySpace());
-    auto dim = StringAttr::get(ctx, isSharedMemory ? "offset" : "col");
-    return numLayoutCopies * layout.getInDimSize(dim) *
-           ty.getElementTypeBitWidth();
+    auto kStorage = StringAttr::get(ctx, isSharedMemory ? "offset" : "col");
+    int64_t storageSize = layout.getInDimSize(kStorage);
+    auto viewShape = ty.getShape().take_back(rank);
+    if (viewShape != shape) {
+      for (auto [dim, size] :
+           llvm::zip_equal(layout.getOutDimNames(), viewShape))
+        layout = layout.resizeOutDim(dim, size);
+      auto freeMasks = layout.getFreeVariableMasks();
+      auto kBlock = StringAttr::get(ctx, "block");
+      for (auto dim : layout.getInDimNames()) {
+        if (dim == kBlock)
+          continue;
+        // A contiguous view may only remove high address bits.
+        uint32_t usedMask =
+            (layout.getInDimSize(dim) - 1) & ~freeMasks.lookup(dim);
+        if (usedMask & (usedMask + 1))
+          return int64_t{-1};
+        if (dim == kStorage)
+          storageSize = usedMask + 1;
+      }
+    }
+    return numLayoutCopies * storageSize * ty.getElementTypeBitWidth();
   };
-  auto srcNumBits = getViewNumBits(srcTy, srcLayout);
-  auto dstNumBits = getViewNumBits(dstTy, dstLayout);
+  auto srcNumBits = getViewNumBits(srcTy);
+  if (srcNumBits < 0)
+    return emitError("source subview must be contiguous");
+  auto dstNumBits = getViewNumBits(dstTy);
   if (dstNumBits > srcNumBits)
     return emitError() << "result logical storage size must not exceed source "
                           "logical storage size ("

--- a/lib/Dialect/TritonGPU/IR/Ops.cpp
+++ b/lib/Dialect/TritonGPU/IR/Ops.cpp
@@ -655,29 +655,22 @@ OpFoldResult MemDescReinterpretOp::fold(FoldAdaptor adaptor) {
 
 namespace {
 
-LinearLayout getAllocationLayout(MemDescType type) {
-  auto rank = cast<LayoutEncodingTrait>(type.getEncoding()).getRank();
-  auto allocShape = type.getAllocShape().take_back(rank);
+LinearLayout getViewLayout(MemDescType type) {
   auto encoding = type.getEncoding();
-  return isPaddedEncoding(encoding) ? paddedLinearLayout(allocShape, encoding)
-                                    : toLinearLayout(allocShape, encoding);
-}
-
-std::optional<LinearLayout> getContiguousViewLayout(MemDescType type) {
-  auto rank = cast<LayoutEncodingTrait>(type.getEncoding()).getRank();
+  auto rank = cast<LayoutEncodingTrait>(encoding).getRank();
   auto allocShape = type.getAllocShape().take_back(rank);
   auto viewShape = type.getShape().take_back(rank);
-  LinearLayout layout = getAllocationLayout(type);
+  LinearLayout layout = isPaddedEncoding(encoding)
+                            ? paddedLinearLayout(allocShape, encoding)
+                            : toLinearLayout(allocShape, encoding);
 
   if (viewShape == allocShape)
     return layout;
 
-  // Restrict the allocation layout to the logical shape of the source view.
   for (auto [dim, size] : llvm::zip_equal(layout.getOutDimNames(), viewShape))
     layout = layout.resizeOutDim(dim, size);
 
-  // A contiguous view can only discard redundant high address bits. Keep the
-  // block mapping intact so contiguity is checked independently for each CTA.
+  // Only trim redundant high address bits; block mappings stay intact.
   auto freeVariables = layout.getFreeVariableMasks();
   auto kBlock = StringAttr::get(type.getContext(), "block");
   for (auto dim : layout.getInDimNames()) {
@@ -689,11 +682,6 @@ std::optional<LinearLayout> getContiguousViewLayout(MemDescType type) {
       inputSize >>= 1;
     layout = layout.resizeInDim(dim, inputSize);
   }
-
-  // Any remaining redundant within-CTA address bit represents a gap in the
-  // view and makes reinterpretation unsafe.
-  if (!getLayoutWithinBlock(layout).isInjective())
-    return std::nullopt;
   return layout;
 }
 
@@ -747,10 +735,10 @@ LogicalResult MemDescReinterpretOp::verify() {
   if (isSubview(dstTy))
     return emitError("result must not be a subview");
 
-  auto srcLayout = getContiguousViewLayout(srcTy);
-  if (!srcLayout)
+  auto srcLayout = getViewLayout(srcTy);
+  if (isSubview(srcTy) && !getLayoutWithinBlock(srcLayout).isInjective())
     return emitError("source subview must be contiguous");
-  auto dstLayout = getAllocationLayout(dstTy);
+  auto dstLayout = getViewLayout(dstTy);
 
   auto getViewNumBits = [](MemDescType ty, const LinearLayout &layout) {
     auto rank = cast<LayoutEncodingTrait>(ty.getEncoding()).getRank();
@@ -766,7 +754,7 @@ LogicalResult MemDescReinterpretOp::verify() {
     return numLayoutCopies * layout.getInDimSize(dim) *
            ty.getElementTypeBitWidth();
   };
-  auto srcNumBits = getViewNumBits(srcTy, *srcLayout);
+  auto srcNumBits = getViewNumBits(srcTy, srcLayout);
   auto dstNumBits = getViewNumBits(dstTy, dstLayout);
   if (dstNumBits > srcNumBits)
     return emitError() << "result logical storage size must not exceed source "

--- a/lib/Dialect/TritonGPU/IR/Ops.cpp
+++ b/lib/Dialect/TritonGPU/IR/Ops.cpp
@@ -653,6 +653,52 @@ OpFoldResult MemDescReinterpretOp::fold(FoldAdaptor adaptor) {
   return {};
 }
 
+namespace {
+
+LinearLayout getAllocationLayout(MemDescType type) {
+  auto rank = cast<LayoutEncodingTrait>(type.getEncoding()).getRank();
+  auto allocShape = type.getAllocShape().take_back(rank);
+  auto encoding = type.getEncoding();
+  return isPaddedEncoding(encoding) ? paddedLinearLayout(allocShape, encoding)
+                                    : toLinearLayout(allocShape, encoding);
+}
+
+std::optional<LinearLayout> getContiguousViewLayout(MemDescType type) {
+  auto rank = cast<LayoutEncodingTrait>(type.getEncoding()).getRank();
+  auto allocShape = type.getAllocShape().take_back(rank);
+  auto viewShape = type.getShape().take_back(rank);
+  LinearLayout layout = getAllocationLayout(type);
+
+  if (viewShape == allocShape)
+    return layout;
+
+  // Restrict the allocation layout to the logical shape of the source view.
+  for (auto [dim, size] : llvm::zip_equal(layout.getOutDimNames(), viewShape))
+    layout = layout.resizeOutDim(dim, size);
+
+  // A contiguous view can only discard redundant high address bits. Keep the
+  // block mapping intact so contiguity is checked independently for each CTA.
+  auto freeVariables = layout.getFreeVariableMasks();
+  auto kBlock = StringAttr::get(type.getContext(), "block");
+  for (auto dim : layout.getInDimNames()) {
+    if (dim == kBlock)
+      continue;
+    uint32_t freeMask = freeVariables.lookup(dim);
+    int32_t inputSize = layout.getInDimSize(dim);
+    while (inputSize > 1 && (freeMask & (inputSize >> 1)))
+      inputSize >>= 1;
+    layout = layout.resizeInDim(dim, inputSize);
+  }
+
+  // Any remaining redundant within-CTA address bit represents a gap in the
+  // view and makes reinterpretation unsafe.
+  if (!getLayoutWithinBlock(layout).isInjective())
+    return std::nullopt;
+  return layout;
+}
+
+} // namespace
+
 LogicalResult MemDescReinterpretOp::verify() {
   auto srcTy = getSrc().getType();
   auto dstTy = getResult().getType();
@@ -694,19 +740,20 @@ LogicalResult MemDescReinterpretOp::verify() {
     auto rank = cast<LayoutEncodingTrait>(ty.getEncoding()).getRank();
     return ty.getShape().take_back(rank) != ty.getAllocShape().take_back(rank);
   };
-  if (isSubview(srcTy) || isSubview(dstTy))
-    return emitError("source and result must not be subviews; reinterpret the "
-                     "parent descriptor and then take a subview");
   assert((isa<SharedMemorySpaceAttr, nvidia_gpu::TensorMemorySpaceAttr>(
               srcTy.getMemorySpace()) &&
           "expected shared or tensor memory"));
-  auto getViewNumBits = [](MemDescType ty) {
+
+  if (isSubview(dstTy))
+    return emitError("result must not be a subview");
+
+  auto srcLayout = getContiguousViewLayout(srcTy);
+  if (!srcLayout)
+    return emitError("source subview must be contiguous");
+  auto dstLayout = getAllocationLayout(dstTy);
+
+  auto getViewNumBits = [](MemDescType ty, const LinearLayout &layout) {
     auto rank = cast<LayoutEncodingTrait>(ty.getEncoding()).getRank();
-    auto shape = ty.getAllocShape().take_back(rank);
-    auto encoding = ty.getEncoding();
-    LinearLayout layout = isPaddedEncoding(encoding)
-                              ? paddedLinearLayout(shape, encoding)
-                              : toLinearLayout(shape, encoding);
     int64_t numLayoutCopies = 1;
     for (int64_t dim : ty.getAllocShape().drop_back(rank))
       numLayoutCopies *= dim;
@@ -719,8 +766,8 @@ LogicalResult MemDescReinterpretOp::verify() {
     return numLayoutCopies * layout.getInDimSize(dim) *
            ty.getElementTypeBitWidth();
   };
-  auto srcNumBits = getViewNumBits(srcTy);
-  auto dstNumBits = getViewNumBits(dstTy);
+  auto srcNumBits = getViewNumBits(srcTy, *srcLayout);
+  auto dstNumBits = getViewNumBits(dstTy, dstLayout);
   if (dstNumBits > srcNumBits)
     return emitError() << "result logical storage size must not exceed source "
                           "logical storage size ("

--- a/lib/Dialect/TritonGPU/IR/Ops.cpp
+++ b/lib/Dialect/TritonGPU/IR/Ops.cpp
@@ -653,6 +653,40 @@ OpFoldResult MemDescReinterpretOp::fold(FoldAdaptor adaptor) {
   return {};
 }
 
+namespace {
+
+LinearLayout getViewLayout(MemDescType type) {
+  auto encoding = type.getEncoding();
+  auto rank = cast<LayoutEncodingTrait>(encoding).getRank();
+  auto allocShape = type.getAllocShape().take_back(rank);
+  auto viewShape = type.getShape().take_back(rank);
+  LinearLayout layout = isPaddedEncoding(encoding)
+                            ? paddedLinearLayout(allocShape, encoding)
+                            : toLinearLayout(allocShape, encoding);
+
+  if (viewShape == allocShape)
+    return layout;
+
+  for (auto [dim, size] : llvm::zip_equal(layout.getOutDimNames(), viewShape))
+    layout = layout.resizeOutDim(dim, size);
+
+  // Only trim redundant high address bits; block mappings stay intact.
+  auto freeVariables = layout.getFreeVariableMasks();
+  auto kBlock = StringAttr::get(type.getContext(), "block");
+  for (auto dim : layout.getInDimNames()) {
+    if (dim == kBlock)
+      continue;
+    uint32_t freeMask = freeVariables.lookup(dim);
+    int32_t inputSize = layout.getInDimSize(dim);
+    while (inputSize > 1 && (freeMask & (inputSize >> 1)))
+      inputSize >>= 1;
+    layout = layout.resizeInDim(dim, inputSize);
+  }
+  return layout;
+}
+
+} // namespace
+
 LogicalResult MemDescReinterpretOp::verify() {
   auto srcTy = getSrc().getType();
   auto dstTy = getResult().getType();
@@ -701,13 +735,13 @@ LogicalResult MemDescReinterpretOp::verify() {
   if (isSubview(dstTy))
     return emitError("result must not be a subview");
 
-  auto getViewNumBits = [](MemDescType ty) {
+  auto srcLayout = getViewLayout(srcTy);
+  if (isSubview(srcTy) && !getLayoutWithinBlock(srcLayout).isInjective())
+    return emitError("source subview must be contiguous");
+  auto dstLayout = getViewLayout(dstTy);
+
+  auto getViewNumBits = [](MemDescType ty, const LinearLayout &layout) {
     auto rank = cast<LayoutEncodingTrait>(ty.getEncoding()).getRank();
-    auto shape = ty.getAllocShape().take_back(rank);
-    auto encoding = ty.getEncoding();
-    LinearLayout layout = isPaddedEncoding(encoding)
-                              ? paddedLinearLayout(shape, encoding)
-                              : toLinearLayout(shape, encoding);
     int64_t numLayoutCopies = 1;
     for (int64_t dim : ty.getAllocShape().drop_back(rank))
       numLayoutCopies *= dim;
@@ -716,33 +750,12 @@ LogicalResult MemDescReinterpretOp::verify() {
     // copies of that logical allocation.
     auto *ctx = ty.getContext();
     bool isSharedMemory = isa<SharedMemorySpaceAttr>(ty.getMemorySpace());
-    auto kStorage = StringAttr::get(ctx, isSharedMemory ? "offset" : "col");
-    int64_t storageSize = layout.getInDimSize(kStorage);
-    auto viewShape = ty.getShape().take_back(rank);
-    if (viewShape != shape) {
-      for (auto [dim, size] :
-           llvm::zip_equal(layout.getOutDimNames(), viewShape))
-        layout = layout.resizeOutDim(dim, size);
-      auto freeMasks = layout.getFreeVariableMasks();
-      auto kBlock = StringAttr::get(ctx, "block");
-      for (auto dim : layout.getInDimNames()) {
-        if (dim == kBlock)
-          continue;
-        // A contiguous view may only remove high address bits.
-        uint32_t usedMask =
-            (layout.getInDimSize(dim) - 1) & ~freeMasks.lookup(dim);
-        if (usedMask & (usedMask + 1))
-          return int64_t{-1};
-        if (dim == kStorage)
-          storageSize = usedMask + 1;
-      }
-    }
-    return numLayoutCopies * storageSize * ty.getElementTypeBitWidth();
+    auto dim = StringAttr::get(ctx, isSharedMemory ? "offset" : "col");
+    return numLayoutCopies * layout.getInDimSize(dim) *
+           ty.getElementTypeBitWidth();
   };
-  auto srcNumBits = getViewNumBits(srcTy);
-  if (srcNumBits < 0)
-    return emitError("source subview must be contiguous");
-  auto dstNumBits = getViewNumBits(dstTy);
+  auto srcNumBits = getViewNumBits(srcTy, srcLayout);
+  auto dstNumBits = getViewNumBits(dstTy, dstLayout);
   if (dstNumBits > srcNumBits)
     return emitError() << "result logical storage size must not exceed source "
                           "logical storage size ("

--- a/python/test/gluon/test_core.py
+++ b/python/test/gluon/test_core.py
@@ -1739,7 +1739,9 @@ def test_tmem_copy_2d():
             offset_bases=[[0, 1], [0, 2], [32, 0], [0, 4], [1, 0], [2, 0], [4, 0], [8, 0], [16, 0], [0, 8]])
         tmem_layout: ttgl.constexpr = TensorMemoryScalesLayout()
         smem = ttgl.allocate_shared_memory(ttgl.int8, (smem_h, smem_w), layout=smem_layout)
-        tmem = allocate_tensor_memory(ttgl.int8, (smem_h, smem_w), layout=tmem_layout)
+        tmem_pool_layout: ttgl.constexpr = TensorMemoryLayout((num_rows, 256), col_stride=1)
+        tmem_pool = allocate_tensor_memory(ttgl.float32, (num_rows, 512), layout=tmem_pool_layout)
+        tmem = tmem_pool.slice(480, num_cols)._reinterpret(ttgl.int8, (smem_h, smem_w), tmem_layout)
 
         barrier = ttgl.allocate_shared_memory(ttgl.int64, [1], ttgl.constexpr(mbarrier.MBarrierLayout()))
         mbarrier.init(barrier, count=1)
@@ -1769,7 +1771,7 @@ def test_tmem_copy_2d():
 
     warps = torch.chunk(z_tri, chunks=4, dim=0)
     for warp in warps:
-        torch.testing.assert_close(x_res, warp)
+        torch.testing.assert_close(x_res, warp, atol=0, rtol=0)
 
 
 @pytest.mark.parametrize("M, N, BLOCK_M, BLOCK_N", [(256, 128, 128, 128), (128, 256, 64, 128)])
@@ -2081,8 +2083,7 @@ def test_slice_reinterpret():
         smem_layout_2d: ttgl.constexpr = ttgl.SwizzledSharedLayout(vec=1, per_phase=1, max_phase=1, order=[1, 0])
         smem = ttgl.allocate_shared_memory(ttgl.int8, [BLOCK], smem_layout_1d)
         smem_slice0 = smem.slice(0, SPLIT_BLOCK)
-        smem_i32 = smem._reinterpret(ttgl.int32, [2 * XBLOCK, YBLOCK], smem_layout_2d)
-        smem_slice1 = smem_i32.slice(XBLOCK, XBLOCK, dim=0)
+        smem_slice1 = smem.slice(SPLIT_BLOCK, SPLIT_BLOCK)._reinterpret(ttgl.int32, [XBLOCK, YBLOCK], smem_layout_2d)
 
         offs = ttgl.arange(0, XBLOCK)[:, None] * YBLOCK + ttgl.arange(0, YBLOCK)[None, :]
         blocked: ttgl.constexpr = ttgl.BlockedLayout([1, 1], [1, NUM_THREADS], [1, 4], [1, 0])

--- a/test/Conversion/tritongpu_to_llvm.mlir
+++ b/test/Conversion/tritongpu_to_llvm.mlir
@@ -2884,23 +2884,15 @@ tt.func private @memdesc_reinterpret(%arg0: !ttg.memdesc<4x1024xi64, #shared0, #
 
 // CHECK-LABEL: @memdesc_reinterpret_contiguous_smem_subview
 tt.func private @memdesc_reinterpret_contiguous_smem_subview(%arg0: !ttg.memdesc<16x16xf16, #shared0, #ttg.shared_memory, mutable>) {
-  // CHECK: [[BASE:%.*]] = llvm.extractvalue %arg0[0]
   // CHECK: [[OFF0:%.*]] = llvm.extractvalue %arg0[1]
-  // CHECK: [[OFF1:%.*]] = llvm.extractvalue %arg0[2]
   // CHECK: [[C8:%.*]] = llvm.mlir.constant(8 : i32)
   // CHECK: [[NEW_OFF0:%.*]] = llvm.add [[OFF0]], [[C8]]
-  // CHECK: [[C0:%.*]] = llvm.mlir.constant(0 : i32)
-  // CHECK: [[NEW_OFF1:%.*]] = llvm.add [[OFF1]], [[C0]]
-  // CHECK: [[SUB0:%.*]] = llvm.mlir.undef
-  // CHECK: [[SUB1:%.*]] = llvm.insertvalue [[BASE]], [[SUB0]][0]
-  // CHECK: [[SUB2:%.*]] = llvm.insertvalue [[NEW_OFF0]], [[SUB1]][1]
-  // CHECK: [[SUB3:%.*]] = llvm.insertvalue [[NEW_OFF1]], [[SUB2]][2]
+  // CHECK: [[SUB2:%.*]] = llvm.insertvalue [[NEW_OFF0]], {{.*}}[1]
+  // CHECK: [[SUB3:%.*]] = llvm.insertvalue {{.*}}, [[SUB2]][2]
   %0 = ttg.memdesc_subslice %arg0 [8, 0] : !ttg.memdesc<16x16xf16, #shared0, #ttg.shared_memory, mutable> -> !ttg.memdesc<8x16xf16, #shared0, #ttg.shared_memory, mutable, 16x16>
   // CHECK: [[SUB_BASE:%.*]] = llvm.extractvalue [[SUB3]][0]
   // CHECK: [[SUB_OFF0:%.*]] = llvm.extractvalue [[SUB3]][1]
-  // CHECK: [[SUB_OFF1:%.*]] = llvm.extractvalue [[SUB3]][2]
   // CHECK: llvm.shl [[SUB_OFF0]],
-  // CHECK: llvm.shl [[SUB_OFF1]],
   // CHECK: [[NEW_BASE:%.*]] = llvm.getelementptr [[SUB_BASE]][{{.*}}] : (!llvm.ptr<3>, i32) -> !llvm.ptr<3>, f16
   // CHECK: [[RESET:%.*]] = llvm.mlir.constant(0 : i32)
   // CHECK: [[DST0:%.*]] = llvm.mlir.undef

--- a/test/Conversion/tritongpu_to_llvm.mlir
+++ b/test/Conversion/tritongpu_to_llvm.mlir
@@ -2882,6 +2882,35 @@ tt.func private @memdesc_reinterpret(%arg0: !ttg.memdesc<4x1024xi64, #shared0, #
   tt.return
 }
 
+// CHECK-LABEL: @memdesc_reinterpret_contiguous_smem_subview
+tt.func private @memdesc_reinterpret_contiguous_smem_subview(%arg0: !ttg.memdesc<16x16xf16, #shared0, #ttg.shared_memory, mutable>) {
+  // CHECK: [[BASE:%.*]] = llvm.extractvalue %arg0[0]
+  // CHECK: [[OFF0:%.*]] = llvm.extractvalue %arg0[1]
+  // CHECK: [[OFF1:%.*]] = llvm.extractvalue %arg0[2]
+  // CHECK: [[C8:%.*]] = llvm.mlir.constant(8 : i32)
+  // CHECK: [[NEW_OFF0:%.*]] = llvm.add [[OFF0]], [[C8]]
+  // CHECK: [[C0:%.*]] = llvm.mlir.constant(0 : i32)
+  // CHECK: [[NEW_OFF1:%.*]] = llvm.add [[OFF1]], [[C0]]
+  // CHECK: [[SUB0:%.*]] = llvm.mlir.undef
+  // CHECK: [[SUB1:%.*]] = llvm.insertvalue [[BASE]], [[SUB0]][0]
+  // CHECK: [[SUB2:%.*]] = llvm.insertvalue [[NEW_OFF0]], [[SUB1]][1]
+  // CHECK: [[SUB3:%.*]] = llvm.insertvalue [[NEW_OFF1]], [[SUB2]][2]
+  %0 = ttg.memdesc_subslice %arg0 [8, 0] : !ttg.memdesc<16x16xf16, #shared0, #ttg.shared_memory, mutable> -> !ttg.memdesc<8x16xf16, #shared0, #ttg.shared_memory, mutable, 16x16>
+  // CHECK: [[SUB_BASE:%.*]] = llvm.extractvalue [[SUB3]][0]
+  // CHECK: [[SUB_OFF0:%.*]] = llvm.extractvalue [[SUB3]][1]
+  // CHECK: [[SUB_OFF1:%.*]] = llvm.extractvalue [[SUB3]][2]
+  // CHECK: llvm.shl [[SUB_OFF0]],
+  // CHECK: llvm.shl [[SUB_OFF1]],
+  // CHECK: [[NEW_BASE:%.*]] = llvm.getelementptr [[SUB_BASE]][{{.*}}] : (!llvm.ptr<3>, i32) -> !llvm.ptr<3>, f16
+  // CHECK: [[RESET:%.*]] = llvm.mlir.constant(0 : i32)
+  // CHECK: [[DST0:%.*]] = llvm.mlir.undef
+  // CHECK: [[DST1:%.*]] = llvm.insertvalue [[NEW_BASE]], [[DST0]][0]
+  // CHECK: [[DST2:%.*]] = llvm.insertvalue [[RESET]], [[DST1]][1]
+  // CHECK: llvm.insertvalue [[RESET]], [[DST2]][2]
+  %1 = ttg.memdesc_reinterpret %0 : !ttg.memdesc<8x16xf16, #shared0, #ttg.shared_memory, mutable, 16x16> -> !ttg.memdesc<8x8xf32, #shared0, #ttg.shared_memory, mutable>
+  tt.return
+}
+
 }
 
 // -----

--- a/test/Conversion/tritongpu_to_llvm_blackwell.mlir
+++ b/test/Conversion/tritongpu_to_llvm_blackwell.mlir
@@ -834,6 +834,8 @@ tt.func @tc_gen5_commit(%arg0: !ttg.memdesc<1xi64, #shared, #smem, mutable>, %pr
 
 #tmem_f32 = #ttng.tensor_memory_encoding<blockM = 128, blockN = 16, colStride = 1>
 #tmem_f16 = #ttng.tensor_memory_encoding<blockM = 128, blockN = 16, colStride = 2>
+#tmem_window = #ttng.tensor_memory_encoding<blockM = 128, blockN = 256, colStride = 1>
+#tmem_scales = #ttng.tensor_memory_scales_encoding<>
 
 module attributes {"ttg.num-warps" = 4 : i32} {
 
@@ -842,6 +844,18 @@ tt.func private @reinterpret(%arg0: !ttg.memdesc<128x32xf32, #tmem_f32, #ttng.te
   %0 = ttg.memdesc_reinterpret %arg0 : !ttg.memdesc<128x32xf32, #tmem_f32, #ttng.tensor_memory> -> !ttg.memdesc<128x32xf16, #tmem_f16, #ttng.tensor_memory>
   // CHECK-NEXT: return %arg0
   tt.return %0 : !ttg.memdesc<128x32xf16, #tmem_f16, #ttng.tensor_memory>
+}
+
+// CHECK-LABEL: @tmem_subslice_reinterpret_scales
+tt.func private @tmem_subslice_reinterpret_scales(%arg0: !ttg.memdesc<128x512xf32, #tmem_window, #ttng.tensor_memory, mutable>) -> !ttg.memdesc<64x16xi8, #tmem_scales, #ttng.tensor_memory, mutable> {
+  // CHECK-NEXT: [[OFFSET:%.*]] = llvm.mlir.constant(480 : i32)
+  // CHECK-NEXT: [[BASE:%.*]] = llvm.ptrtoint %arg0 : !llvm.ptr<3> to i32
+  // CHECK-NEXT: [[NEW_BASE:%.*]] = llvm.add [[BASE]], [[OFFSET]] : i32
+  // CHECK-NEXT: [[TMEM:%.*]] = llvm.inttoptr [[NEW_BASE]] : i32 to !llvm.ptr<3>
+  %0 = ttng.tmem_subslice %arg0 {offset = 480 : i32} : !ttg.memdesc<128x512xf32, #tmem_window, #ttng.tensor_memory, mutable> -> !ttg.memdesc<128x32xf32, #tmem_window, #ttng.tensor_memory, mutable, 128x512>
+  %1 = ttg.memdesc_reinterpret %0 : !ttg.memdesc<128x32xf32, #tmem_window, #ttng.tensor_memory, mutable, 128x512> -> !ttg.memdesc<64x16xi8, #tmem_scales, #ttng.tensor_memory, mutable>
+  // CHECK-NEXT: llvm.return [[TMEM]] : !llvm.ptr<3>
+  tt.return %1 : !ttg.memdesc<64x16xi8, #tmem_scales, #ttng.tensor_memory, mutable>
 }
 
 }

--- a/test/TritonGPU/invalid.mlir
+++ b/test/TritonGPU/invalid.mlir
@@ -240,9 +240,29 @@ tt.func public @memdesc_reinterpret_changed_mutability(%arg0: !ttg.memdesc<8x16x
 
 #shared = #ttg.swizzled_shared<{vec = 8, perPhase = 1, maxPhase = 4, order = [0, 1]}>
 #smem = #ttg.shared_memory
-tt.func public @memdesc_reinterpret_subview(%arg0: !ttg.memdesc<8x16xf16, #shared, #smem, 16x16>) {
-    // expected-error @+1 {{source and result must not be subviews}}
+tt.func public @memdesc_reinterpret_noncontiguous_subview(%arg0: !ttg.memdesc<8x16xf16, #shared, #smem, 16x16>) {
+    // expected-error @+1 {{source subview must be contiguous}}
     %a = ttg.memdesc_reinterpret %arg0 : !ttg.memdesc<8x16xf16, #shared, #smem, 16x16> -> !ttg.memdesc<8x16xf16, #shared, #smem>
+    tt.return
+}
+
+// -----
+
+#shared = #ttg.swizzled_shared<{vec = 1, perPhase = 1, maxPhase = 1, order = [1, 0]}>
+#smem = #ttg.shared_memory
+tt.func public @memdesc_reinterpret_result_subview(%arg0: !ttg.memdesc<16x16xf16, #shared, #smem>) {
+    // expected-error @+1 {{result must not be a subview}}
+    %a = ttg.memdesc_reinterpret %arg0 : !ttg.memdesc<16x16xf16, #shared, #smem> -> !ttg.memdesc<8x16xf16, #shared, #smem, 16x16>
+    tt.return
+}
+
+// -----
+
+#shared = #ttg.swizzled_shared<{vec = 1, perPhase = 1, maxPhase = 1, order = [1, 0]}>
+#smem = #ttg.shared_memory
+tt.func public @memdesc_reinterpret_contiguous_subview_changed_storage_size(%arg0: !ttg.memdesc<8x16xf16, #shared, #smem, 16x16>) {
+    // expected-error @+1 {{result logical storage size must not exceed source logical storage size}}
+    %a = ttg.memdesc_reinterpret %arg0 : !ttg.memdesc<8x16xf16, #shared, #smem, 16x16> -> !ttg.memdesc<8x16xf32, #shared, #smem>
     tt.return
 }
 

--- a/test/TritonGPU/ops.mlir
+++ b/test/TritonGPU/ops.mlir
@@ -205,6 +205,15 @@ module attributes {"ttg.target" = "cuda:0", "ttg.num-ctas" = 1 : i32, "ttg.num-w
     %0 = ttg.memdesc_reinterpret %arg0 : !ttg.memdesc<32x2xi32, #shared2d, #smem, mutable> -> !ttg.memdesc<32x2xi16, #shared2d, #smem, mutable>
     tt.return
   }
+
+  // CHECK-LABEL: memdesc_reinterpret_contiguous_smem_subview
+  // CHECK: ttg.memdesc_subslice
+  // CHECK: ttg.memdesc_reinterpret
+  tt.func @memdesc_reinterpret_contiguous_smem_subview(%arg0 : !ttg.memdesc<16x16xf16, #shared2d, #smem, mutable>) {
+    %0 = ttg.memdesc_subslice %arg0 [8, 0] : !ttg.memdesc<16x16xf16, #shared2d, #smem, mutable> -> !ttg.memdesc<8x16xf16, #shared2d, #smem, mutable, 16x16>
+    %1 = ttg.memdesc_reinterpret %0 : !ttg.memdesc<8x16xf16, #shared2d, #smem, mutable, 16x16> -> !ttg.memdesc<8x8xf32, #shared2d, #smem, mutable>
+    tt.return
+  }
 }
 
 // -----

--- a/test/TritonGPU/ops.mlir
+++ b/test/TritonGPU/ops.mlir
@@ -205,15 +205,6 @@ module attributes {"ttg.target" = "cuda:0", "ttg.num-ctas" = 1 : i32, "ttg.num-w
     %0 = ttg.memdesc_reinterpret %arg0 : !ttg.memdesc<32x2xi32, #shared2d, #smem, mutable> -> !ttg.memdesc<32x2xi16, #shared2d, #smem, mutable>
     tt.return
   }
-
-  // CHECK-LABEL: memdesc_reinterpret_contiguous_smem_subview
-  // CHECK: ttg.memdesc_subslice
-  // CHECK: ttg.memdesc_reinterpret
-  tt.func @memdesc_reinterpret_contiguous_smem_subview(%arg0 : !ttg.memdesc<16x16xf16, #shared2d, #smem, mutable>) {
-    %0 = ttg.memdesc_subslice %arg0 [8, 0] : !ttg.memdesc<16x16xf16, #shared2d, #smem, mutable> -> !ttg.memdesc<8x16xf16, #shared2d, #smem, mutable, 16x16>
-    %1 = ttg.memdesc_reinterpret %0 : !ttg.memdesc<8x16xf16, #shared2d, #smem, mutable, 16x16> -> !ttg.memdesc<8x8xf32, #shared2d, #smem, mutable>
-    tt.return
-  }
 }
 
 // -----

--- a/test/TritonNvidiaGPU/invalid.mlir
+++ b/test/TritonNvidiaGPU/invalid.mlir
@@ -857,6 +857,19 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32} {
 
 // -----
 
+#tmem = #ttng.tensor_memory_encoding<blockM = 128, blockN = 256, colStride = 1, CGALayout = [[1, 0]]>
+#tmem_scales = #ttng.tensor_memory_scales_encoding<CGALayout = [[1, 0]]>
+module attributes {"ttg.num-ctas" = 2 : i32, "ttg.num-warps" = 4 : i32} {
+  tt.func public @memdesc_reinterpret_contiguous_subview_changed_storage_size_tmem(%arg0: !ttg.memdesc<256x512xf32, #tmem, #ttng.tensor_memory, mutable>) {
+    %sub = ttng.tmem_subslice %arg0 {offset = 496 : i32} : !ttg.memdesc<256x512xf32, #tmem, #ttng.tensor_memory, mutable> -> !ttg.memdesc<256x16xf32, #tmem, #ttng.tensor_memory, mutable, 256x512>
+    // expected-error @+1 {{result logical storage size must not exceed source logical storage size}}
+    %0 = ttg.memdesc_reinterpret %sub : !ttg.memdesc<256x16xf32, #tmem, #ttng.tensor_memory, mutable, 256x512> -> !ttg.memdesc<256x32xi8, #tmem_scales, #ttng.tensor_memory, mutable>
+    tt.return
+  }
+}
+
+// -----
+
 #shared1 = #ttg.swizzled_shared<{vec = 1, perPhase = 1, maxPhase = 1, order = [0]}>
 #tmem = #ttng.tensor_memory_encoding<blockM = 128, blockN = 128, colStride = 1>
 module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32} {

--- a/test/TritonNvidiaGPU/ops.mlir
+++ b/test/TritonNvidiaGPU/ops.mlir
@@ -231,3 +231,23 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 8 : i32, ttg.targ
     tt.return
   }
 }
+
+// -----
+
+#tmem_window = #ttng.tensor_memory_encoding<blockM = 128, blockN = 256, colStride = 1, CGALayout = [[1, 0]]>
+#tmem_window_scale_a = #ttng.tensor_memory_scales_encoding<CGALayout = [[1, 0]]>
+#tmem_window_scale_b = #ttng.tensor_memory_scales_encoding<CGALayout = [[0, 0]]>
+module attributes {"ttg.num-ctas" = 2 : i32, "ttg.num-warps" = 4 : i32} {
+  // CHECK-LABEL: @tmem_subslice_reinterpret_scales
+  // CHECK: ttng.tmem_subslice {{.*}} {offset = 464 : i32}
+  // CHECK: ttg.memdesc_reinterpret
+  // CHECK: ttng.tmem_subslice {{.*}} {offset = 480 : i32}
+  // CHECK: ttg.memdesc_reinterpret
+  tt.func public @tmem_subslice_reinterpret_scales(%arg0: !ttg.memdesc<256x512xf32, #tmem_window, #ttng.tensor_memory, mutable>) {
+    %scale_a_base = ttng.tmem_subslice %arg0 {offset = 464 : i32} : !ttg.memdesc<256x512xf32, #tmem_window, #ttng.tensor_memory, mutable> -> !ttg.memdesc<256x16xf32, #tmem_window, #ttng.tensor_memory, mutable, 256x512>
+    %scale_a = ttg.memdesc_reinterpret %scale_a_base : !ttg.memdesc<256x16xf32, #tmem_window, #ttng.tensor_memory, mutable, 256x512> -> !ttg.memdesc<256x16xi8, #tmem_window_scale_a, #ttng.tensor_memory, mutable>
+    %scale_b_base = ttng.tmem_subslice %arg0 {offset = 480 : i32} : !ttg.memdesc<256x512xf32, #tmem_window, #ttng.tensor_memory, mutable> -> !ttg.memdesc<256x32xf32, #tmem_window, #ttng.tensor_memory, mutable, 256x512>
+    %scale_b = ttg.memdesc_reinterpret %scale_b_base : !ttg.memdesc<256x32xf32, #tmem_window, #ttng.tensor_memory, mutable, 256x512> -> !ttg.memdesc<256x16xi8, #tmem_window_scale_b, #ttng.tensor_memory, mutable>
+    tt.return
+  }
+}


### PR DESCRIPTION
PR description written by Codex

Allow `ttg.memdesc_reinterpret` to accept contiguous SMEM and TMEM source subslices while rejecting non-contiguous, oversized, and destination subviews. Preserve the existing TMEM tile-alignment restriction.

Add verifier and nonzero-offset lowering coverage plus exact-result Gluon tests on GB300. Validated with `make`, the six focused lit tests, focused Gluon pytest, Ruff, YAPF, clang-format, and `git diff --check`.

## Stack
Merge bottom-up:
- [ ] #10915 (this PR)
