### PR TITLE
[tools] Preserve Gluon sugar when slicing kernels

### DIFF
--- a/python/test/unit/tools/test_slice_kernel.py
+++ b/python/test/unit/tools/test_slice_kernel.py
@@ -212,6 +212,30 @@ def kernel() -> int:
     assert_code_equal(output, expected)
 
 
+def test_slice_kernel_preserves_gluon_builtin_sugar(tmp_path):
+    pkg, mod = _make_package(
+        tmp_path,
+        {
+            "kernel_mod.py":
+            """
+                import triton.experimental.gluon.language as gl
+
+                def kernel() -> None:
+                    gl.static_assert(True)
+            """,
+        },
+    )
+
+    output = slice_kernel([f"{mod('kernel_mod')}:kernel"], ["triton"], target=TranslatorTarget.GENERIC)
+    expected = R"""
+import triton.experimental.gluon.language as gl
+
+def kernel() -> None:
+    gl.static_assert(True)
+    """
+    assert_code_equal(output, expected)
+
+
 def test_slice_kernel_supports_injected_decorator_matchers(tmp_path):
     pkg, mod = _make_package(
         tmp_path,

--- a/python/triton/tools/triton_to_gluon_translator/slice_kernel.py
+++ b/python/triton/tools/triton_to_gluon_translator/slice_kernel.py
@@ -415,10 +415,9 @@ def sugar_rewrite(module: str, alias: str) -> RewriteFn:
 
 
 def add_sugar_rewrites(rewrites: list[RewriteFn], translate_to_gluon: bool) -> None:
-    if translate_to_gluon:
-        rewrites.append(sugar_rewrite("triton.experimental.gluon.language", "gl"))
-        rewrites.append(sugar_rewrite("triton.experimental.gluon", "gluon"))
-    else:
+    rewrites.append(sugar_rewrite("triton.experimental.gluon.language", "gl"))
+    rewrites.append(sugar_rewrite("triton.experimental.gluon", "gluon"))
+    if not translate_to_gluon:
         rewrites.append(sugar_rewrite("triton.language", "tl"))
         rewrites.append(sugar_rewrite("triton", "triton"))
 


### PR DESCRIPTION
PR description written by Codex

Preserve public Gluon aliases when slicing without translating to Gluon. Wrapped Gluon builtins such as `gl.static_assert` report the underlying `triton.language.core` module, which made a first slice and a re-slice produce different source.

The non-translating slicer now applies the existing Gluon sugar rewrites before generic Triton rewrites. Translation behavior is unchanged.

Validation:
- upstream focused regression: passes on this change and fails on the parent with `triton.language.core.static_assert`
- upstream `python/test/unit/tools/test_slice_kernel.py`: 20 passed, 2 xfailed; one additional environment/source-wheel skew failure also reproduces on the parent
- downstream `project/tritonberry/tests/test_slice_kernel.py`: 17 passed; the parent fails only `test_idempotence[False]`
- downstream slicer/translator integration: 2,627 passed, 9 skipped
- pre-commit on both changed files

## Stack
Merge bottom-up:
- [ ] #10917 (this PR)
