### PR TITLE
[runtime] Clear failed async compile futures

### DIFF
--- a/python/test/unit/runtime/test_cache.py
+++ b/python/test/unit/runtime/test_cache.py
@@ -986,6 +986,9 @@ def test_async_compile_error(fresh_triton_cache):
     # After the AsyncCompileMode context manager exits, the active mode should
     # be set to None again, even if there was an error.
     assert triton.runtime._async_compile.active_mode.get() is None
+    # Failed async placeholders must not stay cached; otherwise their Future
+    # objects keep exception tracebacks alive.
+    assert len(fn.device_caches[0][0]) == 0
 
 
 def test_higher_order_kernel(device, fresh_triton_cache, capsys):

--- a/python/test/unit/runtime/test_cache.py
+++ b/python/test/unit/runtime/test_cache.py
@@ -1045,6 +1045,9 @@ def test_async_compile_error(fresh_triton_cache):
     # After the AsyncCompileMode context manager exits, the active mode should
     # be set to None again, even if there was an error.
     assert triton.runtime._async_compile.active_mode.get() is None
+    # Failed async placeholders must not stay cached; otherwise their Future
+    # objects keep exception tracebacks alive.
+    assert len(fn.device_caches[0][0]) == 0
 
 
 def test_higher_order_kernel(device, fresh_triton_cache, capsys):

--- a/python/triton/runtime/_async_compile.py
+++ b/python/triton/runtime/_async_compile.py
@@ -8,10 +8,17 @@ active_mode: ContextVar[Optional[AsyncCompileMode]] = ContextVar("async_compile_
 
 class FutureKernel:
 
-    def __init__(self, finalize_compile: Callable, future: Future):
-        self.finalize_compile = finalize_compile
+    def __init__(self, future: Future):
+        # Several warmups can share one pending compile by cache key. Keep
+        # per-waiter callbacks so every JIT cache entry is finalized or cleaned.
+        self.finalize_compile = []
+        self.cleanup_compile = []
         self.kernel = None
         self.future = future
+
+    def add_callbacks(self, finalize_compile: Callable, cleanup_compile: Callable):
+        self.finalize_compile.append(finalize_compile)
+        self.cleanup_compile.append(cleanup_compile)
 
     def result(self, ignore_errors: bool = False):
         if self.kernel is not None:
@@ -20,11 +27,20 @@ class FutureKernel:
         try:
             kernel = self.future.result()
         except Exception:
+            for cleanup_compile in self.cleanup_compile:
+                cleanup_compile(self)
+            self.future = None
+            self.finalize_compile = []
+            self.cleanup_compile = []
             if ignore_errors:
                 return
             else:
                 raise
-        self.finalize_compile(kernel)
+        for finalize_compile in self.finalize_compile:
+            finalize_compile(kernel)
+        self.future = None
+        self.finalize_compile = []
+        self.cleanup_compile = []
         self.kernel = kernel
         return kernel
 
@@ -42,15 +58,17 @@ class AsyncCompileMode:
         self.raw_futures = []
         self.future_kernels = {}
 
-    def submit(self, key, compile_fn, finalize_fn):
+    def submit(self, key, compile_fn, finalize_fn, cleanup_fn):
         future = self.future_kernels.get(key)
         if future is not None:
+            future.add_callbacks(finalize_fn, cleanup_fn)
             return future
 
         future = self.executor.submit(compile_fn)
         future._key = key
         self.raw_futures.append(future)
-        future_kernel = FutureKernel(finalize_fn, future)
+        future_kernel = FutureKernel(future)
+        future_kernel.add_callbacks(finalize_fn, cleanup_fn)
         self.future_kernels[key] = future_kernel
         return future_kernel
 
@@ -63,5 +81,11 @@ class AsyncCompileMode:
     def __exit__(self, exc_type, exc_value, traceback):
         active_mode.set(None)
         # Finalize any outstanding compiles
-        for future in as_completed(self.raw_futures):
-            self.future_kernels[future._key].result(self.ignore_errors)
+        try:
+            for future in as_completed(self.raw_futures):
+                self.future_kernels[future._key].result(self.ignore_errors)
+        finally:
+            # Completed futures can still point back to compile frames so need
+            # to drop them to avoid resource leakage.
+            self.raw_futures = []
+            self.future_kernels = {}

--- a/python/triton/runtime/jit.py
+++ b/python/triton/runtime/jit.py
@@ -896,7 +896,13 @@ class JITFunction(JITCallable, KernelInterface[T]):
                 self._call_hook(knobs.runtime.jit_post_compile_hook, key, signature, target, device, constexprs,
                                 options, [attrs], warmup)
 
-            kernel = async_mode.submit(cache_key, async_compile, finalize_compile)
+            def cleanup_compile(future_kernel):
+                # On failure, remove the unresolved async placeholder from cache to avoid the failed
+                # Future's exception traceback holding and leaking compiler locals.
+                if kernel_cache.get(key) is future_kernel:
+                    del kernel_cache[key]
+
+            kernel = async_mode.submit(cache_key, async_compile, finalize_compile, cleanup_compile)
             kernel_cache[key] = kernel
         else:
             kernel = self.compile(src, target=target, options=options.__dict__)

--- a/python/triton/runtime/jit.py
+++ b/python/triton/runtime/jit.py
@@ -906,7 +906,13 @@ class JITFunction(JITCallable, KernelInterface[T]):
                 self._call_hook(knobs.runtime.jit_post_compile_hook, key, signature, target, device, constexprs,
                                 options, [attrs], warmup)
 
-            kernel = async_mode.submit(cache_key, async_compile, finalize_compile)
+            def cleanup_compile(future_kernel):
+                # On failure, remove the unresolved async placeholder from cache to avoid the failed
+                # Future's exception traceback holding and leaking compiler locals.
+                if kernel_cache.get(key) is future_kernel:
+                    del kernel_cache[key]
+
+            kernel = async_mode.submit(cache_key, async_compile, finalize_compile, cleanup_compile)
             kernel_cache[key] = kernel
         else:
             kernel = self.compile(src, target=target, options=options.__dict__)


### PR DESCRIPTION
AsyncCompileMode stores in-flight compiles in the JIT kernel cache as FutureKernel placeholders. When an async compile fails, the underlying concurrent.futures.Future retains the exception traceback. That traceback can keep compiler locals alive, including nanobind-wrapped IR objects such as ir.context.

This showed up in xdist worker teardown as a nanobind leak after runtime/test_cache.py::test_async_compile_error, even though the test itself passed. The failed FutureKernel stayed in fn.device_caches and kept the failed compile traceback reachable until interpreter shutdown.

Clean up failed async compiles by removing their FutureKernel placeholder from the kernel cache, dropping the retained Future and callback references after result/error handling, and clearing AsyncCompileMode's bookkeeping on exit. The test now asserts that a failed async warmup does not leave a cache entry behind.