### PR TITLE
[BACKEND] Emit .{release,acquire}.cluster in barrier ops

### DIFF
--- a/include/triton/Dialect/TritonNvidiaGPU/IR/TritonNvidiaGPUOps.td
+++ b/include/triton/Dialect/TritonNvidiaGPU/IR/TritonNvidiaGPUOps.td
@@ -323,8 +323,8 @@ def TTNG_WaitBarrierOp : TTNG_Op<"wait_barrier", [AttrSizedOperandSegments,
     Blocks the program progress until the mbarrier object in `alloc` completes
     its current phase.
 
-    This lowers a waitloop using PTX instruction
-    mbarrier.try_wait.parity.shared::cta.b64.
+    This lowers a waitloop using the PTX instruction
+    mbarrier.try_wait.parity{.acquire.cluster}.shared::cta.b64.
 
     Accepts an optional list of memory dependencies. If present, it is assumed
     that any of the dependencies may be accessed until the barrier completes.

--- a/include/triton/Dialect/TritonNvidiaGPU/Transforms/ClusterBarrierInsertion.h
+++ b/include/triton/Dialect/TritonNvidiaGPU/Transforms/ClusterBarrierInsertion.h
@@ -8,6 +8,8 @@ namespace mlir {
 namespace triton {
 namespace nvidia_gpu {
 
+bool isDistributedMultiCTAOp(Operation *op, bool isRead);
+
 /// Inserts cluster barriers (cluster_barrier) using the provided
 /// shared-memory allocation analysis.
 void runClusterBarrierInsertion(ModuleAllocation &moduleAllocation,

--- a/lib/Dialect/TritonNvidiaGPU/Transforms/ClusterBarrierInsertion.cpp
+++ b/lib/Dialect/TritonNvidiaGPU/Transforms/ClusterBarrierInsertion.cpp
@@ -19,15 +19,11 @@ namespace mlir {
 namespace triton {
 namespace nvidia_gpu {
 
-namespace {
-
 namespace ttg = mlir::triton::gpu;
 namespace ttng = mlir::triton::nvidia_gpu;
 
-static bool isDistributedMultiCTAOp(Operation *op, bool isRead) {
+static bool hasClusterSync(Operation *op) {
   if (auto cvt = dyn_cast<ttg::ConvertLayoutOp>(op)) {
-    if (!isRead)
-      return false;
     auto srcTy = cvt.getSrc().getType();
     auto dstTy = cvt.getType();
     auto kBlock = StringAttr::get(op->getContext(), "block");
@@ -35,8 +31,6 @@ static bool isDistributedMultiCTAOp(Operation *op, bool isRead) {
                          kBlock);
   }
   if (auto reduce = dyn_cast<triton::ReduceOp>(op)) {
-    if (!isRead)
-      return false;
     auto srcTy = reduce.getInputTypes()[0];
     auto splitNum = ttg::getCTASplitNum(srcTy.getEncoding());
     return splitNum[reduce.getAxis()] > 1;
@@ -52,6 +46,16 @@ static bool isDistributedMultiCTAOp(Operation *op, bool isRead) {
   }
   return false;
 }
+
+bool isDistributedMultiCTAOp(Operation *op, bool isRead) {
+  if (!isRead && isa<ttg::ConvertLayoutOp, triton::ReduceOp>(op))
+    return false;
+  if (isa<ttng::CLCTryCancelOp>(op))
+    return ttg::lookupNumCTAs(op) > 1;
+  return hasClusterSync(op);
+}
+
+namespace {
 
 static bool isPreAllocAliasSliceFilter(const AllocationSlice &lhsSlice,
                                        const AllocationSlice &rhsSlice,
@@ -409,8 +413,7 @@ void ClusterBarrierAnalysis::update(Operation *op, BlockInfo *blockInfo,
 
     // Clear prior distributed dependencies if we have inserted a cluster
     // barrier, or if the scratch op itself performs a cluster-level sync.
-    bool hasClusterSync = isDistributedMultiCTAOp(op, /*isRead=*/true);
-    if (insertClusterBarrierNeeded || hasClusterSync)
+    if (insertClusterBarrierNeeded || hasClusterSync(op))
       blockInfo->sync();
 
     curBlockInfo.syncReadSlices[scratchSlice].insert(op);

--- a/lib/Dialect/TritonNvidiaGPU/Transforms/ClusterBarrierInsertion.cpp
+++ b/lib/Dialect/TritonNvidiaGPU/Transforms/ClusterBarrierInsertion.cpp
@@ -22,8 +22,21 @@ namespace nvidia_gpu {
 namespace ttg = mlir::triton::gpu;
 namespace ttng = mlir::triton::nvidia_gpu;
 
-static bool hasClusterSync(Operation *op) {
+static bool hasTCGen5Commit(Operation *op) {
+  SmallVector<Value> descs;
+  if (auto mma = dyn_cast<ttng::MMAv5OpInterface>(op))
+    descs = mma.getCompletionDescs();
+  else if (auto commit = dyn_cast<ttng::TCGen5CommitOp>(op))
+    llvm::append_range(descs, commit.getDescs());
+  else
+    return false;
+  return !ttng::getCTABroadcastMasks(ttng::getModuleTwoCTAs(op), descs).empty();
+}
+
+bool isDistributedMultiCTAOp(Operation *op, bool isRead) {
   if (auto cvt = dyn_cast<ttg::ConvertLayoutOp>(op)) {
+    if (!isRead)
+      return false;
     auto srcTy = cvt.getSrc().getType();
     auto dstTy = cvt.getType();
     auto kBlock = StringAttr::get(op->getContext(), "block");
@@ -31,28 +44,20 @@ static bool hasClusterSync(Operation *op) {
                          kBlock);
   }
   if (auto reduce = dyn_cast<triton::ReduceOp>(op)) {
+    if (!isRead)
+      return false;
     auto srcTy = reduce.getInputTypes()[0];
     auto splitNum = ttg::getCTASplitNum(srcTy.getEncoding());
     return splitNum[reduce.getAxis()] > 1;
   }
-  if (auto mma = dyn_cast<ttng::MMAv5OpInterface>(op)) {
-    return mma.getTwoCtas();
+  if (isa<ttng::CLCTryCancelOp, ttng::AsyncSharedStoreOp>(op)) {
+    return ttg::lookupNumCTAs(op) > 1;
   } else if (isa<ttng::TMEMCopyOp>(op)) {
     return ttng::getModuleTwoCTAs(op);
-  } else if (auto tma = dyn_cast<ttng::AsyncTMACopyGlobalToLocalOp>(op)) {
-    return tma.getMulticast();
-  } else if (auto tma = dyn_cast<ttng::AsyncTMAGatherOp>(op)) {
+  } else if (auto tma = dyn_cast<ttng::TMALoadLikeOpInterface>(op)) {
     return tma.getMulticast();
   }
-  return false;
-}
-
-bool isDistributedMultiCTAOp(Operation *op, bool isRead) {
-  if (!isRead && isa<ttg::ConvertLayoutOp, triton::ReduceOp>(op))
-    return false;
-  if (isa<ttng::CLCTryCancelOp>(op))
-    return ttg::lookupNumCTAs(op) > 1;
-  return hasClusterSync(op);
+  return hasTCGen5Commit(op);
 }
 
 namespace {
@@ -106,17 +111,20 @@ usesTrackedBarrierInCrossCTAConsumerOp(Operation *op,
 
   if (auto mma = dyn_cast<ttng::MMAv5OpInterface>(op)) {
     auto barrierOp = cast<ttg::MBarrierOpInterface>(op);
-    return mma.getTwoCtas() &&
+    return hasTCGen5Commit(op) &&
            llvm::any_of(barrierOp.getBarriers(), aliasesTracked);
   }
   if (auto commit = dyn_cast<ttng::TCGen5CommitOp>(op)) {
-    return ttng::getModuleTwoCTAs(op) && aliasesTracked(commit.getBarrier());
+    return hasTCGen5Commit(op) && aliasesTracked(commit.getBarrier());
   }
   if (auto tma = dyn_cast<ttng::TMALoadLikeOpInterface>(op)) {
     return tma.getMulticast() && aliasesTracked(tma.getBarrier());
   }
   if (auto clc = dyn_cast<ttng::CLCTryCancelOp>(op)) {
     return aliasesTracked(clc.getMbarrier());
+  }
+  if (auto store = dyn_cast<ttng::AsyncSharedStoreOp>(op)) {
+    return aliasesTracked(store.getMbarrier());
   }
   return false;
 }
@@ -413,7 +421,8 @@ void ClusterBarrierAnalysis::update(Operation *op, BlockInfo *blockInfo,
 
     // Clear prior distributed dependencies if we have inserted a cluster
     // barrier, or if the scratch op itself performs a cluster-level sync.
-    if (insertClusterBarrierNeeded || hasClusterSync(op))
+    if (insertClusterBarrierNeeded ||
+        isDistributedMultiCTAOp(op, /*isRead=*/true))
       blockInfo->sync();
 
     curBlockInfo.syncReadSlices[scratchSlice].insert(op);

--- a/lib/Dialect/TritonNvidiaGPU/Transforms/ClusterBarrierInsertion.cpp
+++ b/lib/Dialect/TritonNvidiaGPU/Transforms/ClusterBarrierInsertion.cpp
@@ -22,7 +22,7 @@ namespace nvidia_gpu {
 namespace ttg = mlir::triton::gpu;
 namespace ttng = mlir::triton::nvidia_gpu;
 
-static bool hasTCGen5Commit(Operation *op) {
+static bool hasTCGen5CommitCrossCTA(Operation *op) {
   SmallVector<Value> descs;
   if (auto mma = dyn_cast<ttng::MMAv5OpInterface>(op))
     descs = mma.getCompletionDescs();
@@ -57,7 +57,7 @@ bool isDistributedMultiCTAOp(Operation *op, bool isRead) {
   } else if (auto tma = dyn_cast<ttng::TMALoadLikeOpInterface>(op)) {
     return tma.getMulticast();
   }
-  return hasTCGen5Commit(op);
+  return hasTCGen5CommitCrossCTA(op);
 }
 
 namespace {
@@ -111,11 +111,11 @@ usesTrackedBarrierInCrossCTAConsumerOp(Operation *op,
 
   if (auto mma = dyn_cast<ttng::MMAv5OpInterface>(op)) {
     auto barrierOp = cast<ttg::MBarrierOpInterface>(op);
-    return hasTCGen5Commit(op) &&
+    return hasTCGen5CommitCrossCTA(op) &&
            llvm::any_of(barrierOp.getBarriers(), aliasesTracked);
   }
   if (auto commit = dyn_cast<ttng::TCGen5CommitOp>(op)) {
-    return hasTCGen5Commit(op) && aliasesTracked(commit.getBarrier());
+    return hasTCGen5CommitCrossCTA(op) && aliasesTracked(commit.getBarrier());
   }
   if (auto tma = dyn_cast<ttng::TMALoadLikeOpInterface>(op)) {
     return tma.getMulticast() && aliasesTracked(tma.getBarrier());

--- a/lib/Dialect/TritonNvidiaGPU/Transforms/ClusterBarrierInsertion.cpp
+++ b/lib/Dialect/TritonNvidiaGPU/Transforms/ClusterBarrierInsertion.cpp
@@ -421,8 +421,8 @@ void ClusterBarrierAnalysis::update(Operation *op, BlockInfo *blockInfo,
 
     // Clear prior distributed dependencies if we have inserted a cluster
     // barrier, or if the scratch op itself performs a cluster-level sync.
-    if (insertClusterBarrierNeeded ||
-        isDistributedMultiCTAOp(op, /*isRead=*/true))
+    bool hasClusterSync = isDistributedMultiCTAOp(op, /*isRead=*/true);
+    if (insertClusterBarrierNeeded || hasClusterSync)
       blockInfo->sync();
 
     curBlockInfo.syncReadSlices[scratchSlice].insert(op);

--- a/python/examples/gluon/03-matmul-multicta.py
+++ b/python/examples/gluon/03-matmul-multicta.py
@@ -512,15 +512,15 @@ def _matmul_kernel(
 
     clc_barriers = mbarrier.allocate_mbarrier(batch=ACC_STAGES)
     clc_planar_ready_bars = mbarrier.allocate_mbarrier(batch=ACC_STAGES)
-    clc_consumed_bars = mbarrier.allocate_mbarrier(batch=ACC_STAGES, two_ctas=TWO_CTAS)
+    cga_layout: gl.constexpr = [[0]] * (gl.num_ctas().bit_length() - 1)
+    clc_layout: gl.constexpr = gl.SwizzledSharedLayout(1, 1, 1, [0], cga_layout=cga_layout)
+    clc_consumed_bars = gl.allocate_shared_memory(gl.int64, [ACC_STAGES, 1], clc_layout)
     for i in gl.static_range(ACC_STAGES):
         mbarrier.init(clc_barriers.index(i), count=1)
         mbarrier.init(clc_planar_ready_bars.index(i), count=1)
         # Every partition but itself arrives on the barrier
         mbarrier.init(clc_consumed_bars.index(i), count=N_PARTITIONS - 1)
 
-    cga_layout: gl.constexpr = [[0]] * (gl.num_ctas().bit_length() - 1)
-    clc_layout: gl.constexpr = gl.SwizzledSharedLayout(1, 1, 1, [0], cga_layout=cga_layout)
     clc_result_buffers = gl.allocate_shared_memory(gl.int64, [clc_barriers.shape[0], 2], clc_layout)
     clc_planar_pid_buffers = gl.allocate_shared_memory(gl.int64, [clc_barriers.shape[0], 1], clc_layout)
 

--- a/python/examples/gluon/04-2cta-block-scale-matmul.py
+++ b/python/examples/gluon/04-2cta-block-scale-matmul.py
@@ -712,15 +712,15 @@ def mma_scaled_warp_specialized_kernel(a_desc, b_desc, c_desc, a_scale_desc, b_s
 
     clc_barriers = mbarrier.allocate_mbarrier(batch=num_acc_buffers)
     clc_planar_ready_bars = mbarrier.allocate_mbarrier(batch=num_acc_buffers)
-    clc_consumed_bars = mbarrier.allocate_mbarrier(batch=num_acc_buffers, two_ctas=TWO_CTAS)
+    cga_layout_clc: gl.constexpr = [[0]] * (gl.num_ctas().bit_length() - 1)
+    clc_layout: gl.constexpr = gl.SwizzledSharedLayout(1, 1, 1, [0], cga_layout=cga_layout_clc)
+    clc_consumed_bars = gl.allocate_shared_memory(gl.int64, [num_acc_buffers, 1], clc_layout)
     if scheduler == SCHEDULER_CLC:
         for i in gl.static_range(num_acc_buffers):
             mbarrier.init(clc_barriers.index(i), count=1)
             mbarrier.init(clc_planar_ready_bars.index(i), count=1)
             mbarrier.init(clc_consumed_bars.index(i), count=N_PARTITIONS - 1)
 
-    cga_layout_clc: gl.constexpr = [[0]] * (gl.num_ctas().bit_length() - 1)
-    clc_layout: gl.constexpr = gl.SwizzledSharedLayout(1, 1, 1, [0], cga_layout=cga_layout_clc)
     clc_result_buffers = gl.allocate_shared_memory(gl.int64, [clc_barriers.shape[0], 2], clc_layout)
     clc_planar_pid_buffers = gl.allocate_shared_memory(gl.int64, [clc_barriers.shape[0], 1], clc_layout)
 

--- a/python/test/gluon/test_core.py
+++ b/python/test/gluon/test_core.py
@@ -186,7 +186,10 @@ def test_async_shared_store():
 
     compiled = async_shared_store_kernel[(1, )](out, block, num_warps=4, num_ctas=2)
 
-    assert "st.async.weak.shared::cluster.mbarrier::complete_tx::bytes" in compiled.asm["ptx"]
+    ptx = compiled.asm["ptx"]
+    assert "mbarrier.arrive.expect_tx.release.cluster.shared::cta.b64" in ptx
+    assert "st.async.weak.shared::cluster.mbarrier::complete_tx::bytes" in ptx
+    assert "mbarrier.try_wait.parity.acquire.cluster.shared::cta.b64" in ptx
     torch.testing.assert_close(out, torch.arange(block, device="cuda", dtype=torch.int32))
 
 
@@ -197,7 +200,10 @@ def test_async_shared_store_packed_f16():
 
     compiled = async_shared_store_f16_kernel[(1, )](out, block, num_warps=4, num_ctas=2)
 
-    assert "st.async.weak.shared::cluster.mbarrier::complete_tx::bytes.b32" in compiled.asm["ptx"]
+    ptx = compiled.asm["ptx"]
+    assert "mbarrier.arrive.expect_tx.release.cluster.shared::cta.b64" in ptx
+    assert "st.async.weak.shared::cluster.mbarrier::complete_tx::bytes.b32" in ptx
+    assert "mbarrier.try_wait.parity.acquire.cluster.shared::cta.b64" in ptx
     torch.testing.assert_close(out, torch.arange(block, device="cuda", dtype=torch.float16))
 
 

--- a/python/tutorials/gluon/14-multicta.py
+++ b/python/tutorials/gluon/14-multicta.py
@@ -1019,14 +1019,14 @@ def matmul_multicta_kernel(
 
     clc_barriers = mbarrier.allocate_mbarrier(batch=ACC_STAGES)
     clc_planar_ready_bars = mbarrier.allocate_mbarrier(batch=ACC_STAGES)
-    clc_consumed_bars = mbarrier.allocate_mbarrier(batch=ACC_STAGES, two_ctas=two_ctas)
+    cga_layout: gl.constexpr = [[0]] * (gl.num_ctas().bit_length() - 1)
+    clc_layout: gl.constexpr = gl.SwizzledSharedLayout(1, 1, 1, [0], cga_layout=cga_layout)
+    clc_consumed_bars = gl.allocate_shared_memory(gl.int64, [ACC_STAGES, 1], clc_layout)
     for i in gl.static_range(ACC_STAGES):
         mbarrier.init(clc_barriers.index(i), count=1)
         mbarrier.init(clc_planar_ready_bars.index(i), count=1)
         mbarrier.init(clc_consumed_bars.index(i), count=n_partitions - 1)
 
-    cga_layout: gl.constexpr = [[0]] * (gl.num_ctas().bit_length() - 1)
-    clc_layout: gl.constexpr = gl.SwizzledSharedLayout(1, 1, 1, [0], cga_layout=cga_layout)
     clc_result_buffers = gl.allocate_shared_memory(
         gl.int64,
         [clc_barriers.shape[0], 2],

--- a/test/Conversion/clc_to_llvm.mlir
+++ b/test/Conversion/clc_to_llvm.mlir
@@ -18,9 +18,15 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32} {
 #smem = #ttg.shared_memory
 module attributes {"ttg.num-ctas" = 2 : i32, "ttg.num-warps" = 4 : i32} {
   // CHECK-LABEL: clc_try_cancel_multicast
-  tt.func @clc_try_cancel_multicast(%result: !ttg.memdesc<2xi64, #shared_clc, #smem>, %mbar: !ttg.memdesc<1xi64, #barrier, #smem>) {
+  tt.func @clc_try_cancel_multicast(%result: !ttg.memdesc<2xi64, #shared_clc, #smem>, %mbar: !ttg.memdesc<1xi64, #barrier, #smem>, %phase: i32, %pred: i1) {
+    // CHECK: mbarrier.arrive.expect_tx.release.cluster.shared::cta.b64
+    ttng.barrier_expect %mbar, 16, %pred : !ttg.memdesc<1xi64, #barrier, #smem>
     // CHECK: clusterlaunchcontrol.try_cancel.async.shared::cta.mbarrier::complete_tx::bytes.multicast::cluster::all.b128
     ttng.clc_try_cancel %result, %mbar : !ttg.memdesc<2xi64, #shared_clc, #smem>, !ttg.memdesc<1xi64, #barrier, #smem>
+    // CHECK: mbarrier.try_wait.parity.acquire.cluster.shared::cta.b64
+    ttng.wait_barrier %mbar, %phase : !ttg.memdesc<1xi64, #barrier, #smem>
+    // CHECK: mbarrier.arrive.release.cluster.shared::cta.b64
+    ttng.arrive_barrier %mbar, 1 : !ttg.memdesc<1xi64, #barrier, #smem>
     tt.return
   }
 }

--- a/test/Conversion/clc_to_llvm.mlir
+++ b/test/Conversion/clc_to_llvm.mlir
@@ -18,15 +18,15 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32} {
 #smem = #ttg.shared_memory
 module attributes {"ttg.num-ctas" = 2 : i32, "ttg.num-warps" = 4 : i32} {
   // CHECK-LABEL: clc_try_cancel_multicast
-  tt.func @clc_try_cancel_multicast(%result: !ttg.memdesc<2xi64, #shared_clc, #smem>, %mbar: !ttg.memdesc<1xi64, #barrier, #smem>, %phase: i32, %pred: i1) {
+  tt.func @clc_try_cancel_multicast(%result: !ttg.memdesc<2xi64, #shared_clc, #smem>, %mbar: !ttg.memdesc<2xi64, #barrier, #smem>, %phase: i32, %pred: i1) {
     // CHECK: mbarrier.arrive.expect_tx.release.cluster.shared::cta.b64
-    ttng.barrier_expect %mbar, 16, %pred : !ttg.memdesc<1xi64, #barrier, #smem>
+    ttng.barrier_expect %mbar, 16, %pred : !ttg.memdesc<2xi64, #barrier, #smem>
     // CHECK: clusterlaunchcontrol.try_cancel.async.shared::cta.mbarrier::complete_tx::bytes.multicast::cluster::all.b128
-    ttng.clc_try_cancel %result, %mbar : !ttg.memdesc<2xi64, #shared_clc, #smem>, !ttg.memdesc<1xi64, #barrier, #smem>
+    ttng.clc_try_cancel %result, %mbar : !ttg.memdesc<2xi64, #shared_clc, #smem>, !ttg.memdesc<2xi64, #barrier, #smem>
     // CHECK: mbarrier.try_wait.parity.acquire.cluster.shared::cta.b64
-    ttng.wait_barrier %mbar, %phase : !ttg.memdesc<1xi64, #barrier, #smem>
+    ttng.wait_barrier %mbar, %phase : !ttg.memdesc<2xi64, #barrier, #smem>
     // CHECK: mbarrier.arrive.release.cluster.shared::cta.b64
-    ttng.arrive_barrier %mbar, 1 : !ttg.memdesc<1xi64, #barrier, #smem>
+    ttng.arrive_barrier %mbar, 1 : !ttg.memdesc<2xi64, #barrier, #smem>
     tt.return
   }
 }

--- a/test/Conversion/tma_multicast_to_llvm.mlir
+++ b/test/Conversion/tma_multicast_to_llvm.mlir
@@ -9,24 +9,25 @@
 module attributes {"ttg.num-ctas" = 2 : i32, "ttg.num-warps" = 4 : i32, ttg.target = "cuda:100"} {
 
 // CHECK-LABEL: @tma_gather_multicast
-tt.func public @tma_gather_multicast(%arg0: !tt.tensordesc<1x128xbf16, #shared_gather_bcast>, %arg1: !ttg.memdesc<1xi64, #shared_bar_bcast, #smem, mutable>, %arg2: tensor<32xi32, #ttg.slice<{dim = 0, parent = #blocked_bcast}>>, %arg3: i32, %arg4: !ttg.memdesc<32x128xbf16, #shared_gather_bcast, #smem, mutable>, %arg5: i1, %arg6: i32, %arg7: !ttg.memdesc<1xi64, #shared_bar_local, #smem, mutable>) {
+tt.func public @tma_gather_multicast(%arg0: !tt.tensordesc<1x128xbf16, #shared_gather_bcast>, %arg1: !ttg.memdesc<1xi64, #shared_bar_bcast, #smem, mutable>, %arg2: tensor<32xi32, #ttg.slice<{dim = 0, parent = #blocked_bcast}>>, %arg3: i32, %arg4: !ttg.memdesc<32x128xbf16, #shared_gather_bcast, #smem, mutable>, %arg5: i1, %arg6: i32, %arg7: !ttg.memdesc<2xi64, #shared_bar_local, #smem, mutable>) {
   // CHECK: mbarrier.arrive.expect_tx.release.cluster.shared::cta.b64
-  ttng.barrier_expect %arg7, 16, %arg5 : !ttg.memdesc<1xi64, #shared_bar_local, #smem, mutable>
+  ttng.barrier_expect %arg7, 16, %arg5 : !ttg.memdesc<2xi64, #shared_bar_local, #smem, mutable>
   // CHECK: [[BAR:%.*]] = extractvalue {{.*}} %1, 0
   // CHECK: [[BAR_INT:%.*]] = ptrtoint ptr addrspace(3) [[BAR]] to i64
   // CHECK: [[LEADER_BAR_INT:%.*]] = and i64 [[BAR_INT]],
   // CHECK: [[LEADER_BAR:%.*]] = inttoptr i64 [[LEADER_BAR_INT]] to ptr addrspace(3)
   // CHECK: [[ELECT:%.*]] = tail call { i32, i1 } @llvm.nvvm.elect.sync
   // CHECK: [[ELECT_PRED:%.*]] = extractvalue { i32, i1 } [[ELECT]], 1
-  // CHECK: [[PRED:%.*]] = and i1 {{.*}}, [[ELECT_PRED]]
+  // CHECK: [[CTA_ELECT_PRED:%.*]] = and i1 {{.*}}, [[ELECT_PRED]]
+  // CHECK: [[PRED:%.*]] = and i1 {{.*}}, [[CTA_ELECT_PRED]]
   // CHECK: "@$0 cp.async.bulk.tensor.2d.tile::gather4.shared::cluster.global.mbarrier::complete_tx::bytes.multicast::cluster [$1], [$2, {$3, $4, $5, $6, $7}], [$8], $9;", "b,r,l,r,r,r,r,r,r,h"
   // CHECK-SAME: (i1 [[PRED]], ptr addrspace(3) {{.*}}, ptr nonnull %0, i32 %3, i32 {{.*}}, i32 {{.*}}, i32 {{.*}}, i32 {{.*}}, ptr addrspace(3) [[LEADER_BAR]], i32 {{(%[0-9]+|3)}})
   ttng.async_tma_gather %arg0[%arg2, %arg3] %arg4, %arg1, %arg5 {multicast} : !tt.tensordesc<1x128xbf16, #shared_gather_bcast>, tensor<32xi32, #ttg.slice<{dim = 0, parent = #blocked_bcast}>>, i32, !ttg.memdesc<1xi64, #shared_bar_bcast, #smem, mutable>, !ttg.memdesc<32x128xbf16, #shared_gather_bcast, #smem, mutable>, i1
 
   // CHECK: mbarrier.try_wait.parity.acquire.cluster.shared::cta.b64
-  ttng.wait_barrier %arg7, %arg6 : !ttg.memdesc<1xi64, #shared_bar_local, #smem, mutable>
+  ttng.wait_barrier %arg7, %arg6 : !ttg.memdesc<2xi64, #shared_bar_local, #smem, mutable>
   // CHECK: mbarrier.arrive.release.cluster.shared::cta.b64
-  ttng.arrive_barrier %arg7, 1 : !ttg.memdesc<1xi64, #shared_bar_local, #smem, mutable>
+  ttng.arrive_barrier %arg7, 1 : !ttg.memdesc<2xi64, #shared_bar_local, #smem, mutable>
 
   // CHECK: ret void
   tt.return

--- a/test/Conversion/tma_multicast_to_llvm.mlir
+++ b/test/Conversion/tma_multicast_to_llvm.mlir
@@ -1,14 +1,17 @@
-// RUN: triton-opt %s --convert-triton-gpu-to-llvm --convert-nv-gpu-to-llvm | mlir-translate -mlir-to-llvmir | opt -S -O1 | FileCheck %s
+// RUN: triton-opt %s --convert-triton-gpu-to-llvm=compute-capability=90 --convert-nv-gpu-to-llvm | mlir-translate -mlir-to-llvmir | opt -S -O1 | FileCheck %s
 
 #blocked_bcast = #ttg.blocked<{sizePerThread = [1, 4], threadsPerWarp = [32, 1], warpsPerCTA = [1, 4], order = [1, 0], CGALayout = [[0, 0]]}>
 #shared_bar_bcast = #ttg.swizzled_shared<{vec = 1, perPhase = 1, maxPhase = 1, order = [0], CGALayout = [[0]]}>
+#shared_bar_local = #ttg.swizzled_shared<{vec = 1, perPhase = 1, maxPhase = 1, order = [0], CGALayout = [[1]]}>
 #shared_gather_bcast = #ttg.nvmma_shared<{swizzlingByteWidth = 128, transposed = false, elementBitWidth = 16, CGALayout = [[0, 0]]}>
 #smem = #ttg.shared_memory
 
 module attributes {"ttg.num-ctas" = 2 : i32, "ttg.num-warps" = 4 : i32, ttg.target = "cuda:100"} {
 
 // CHECK-LABEL: @tma_gather_multicast
-tt.func public @tma_gather_multicast(%arg0: !tt.tensordesc<1x128xbf16, #shared_gather_bcast>, %arg1: !ttg.memdesc<1xi64, #shared_bar_bcast, #smem, mutable>, %arg2: tensor<32xi32, #ttg.slice<{dim = 0, parent = #blocked_bcast}>>, %arg3: i32, %arg4: !ttg.memdesc<32x128xbf16, #shared_gather_bcast, #smem, mutable>, %arg5: i1) {
+tt.func public @tma_gather_multicast(%arg0: !tt.tensordesc<1x128xbf16, #shared_gather_bcast>, %arg1: !ttg.memdesc<1xi64, #shared_bar_bcast, #smem, mutable>, %arg2: tensor<32xi32, #ttg.slice<{dim = 0, parent = #blocked_bcast}>>, %arg3: i32, %arg4: !ttg.memdesc<32x128xbf16, #shared_gather_bcast, #smem, mutable>, %arg5: i1, %arg6: i32, %arg7: !ttg.memdesc<1xi64, #shared_bar_local, #smem, mutable>) {
+  // CHECK: mbarrier.arrive.expect_tx.release.cluster.shared::cta.b64
+  ttng.barrier_expect %arg7, 16, %arg5 : !ttg.memdesc<1xi64, #shared_bar_local, #smem, mutable>
   // CHECK: [[BAR:%.*]] = extractvalue {{.*}} %1, 0
   // CHECK: [[BAR_INT:%.*]] = ptrtoint ptr addrspace(3) [[BAR]] to i64
   // CHECK: [[LEADER_BAR_INT:%.*]] = and i64 [[BAR_INT]],
@@ -19,6 +22,11 @@ tt.func public @tma_gather_multicast(%arg0: !tt.tensordesc<1x128xbf16, #shared_g
   // CHECK: "@$0 cp.async.bulk.tensor.2d.tile::gather4.shared::cluster.global.mbarrier::complete_tx::bytes.multicast::cluster [$1], [$2, {$3, $4, $5, $6, $7}], [$8], $9;", "b,r,l,r,r,r,r,r,r,h"
   // CHECK-SAME: (i1 [[PRED]], ptr addrspace(3) {{.*}}, ptr nonnull %0, i32 %3, i32 {{.*}}, i32 {{.*}}, i32 {{.*}}, i32 {{.*}}, ptr addrspace(3) [[LEADER_BAR]], i32 {{(%[0-9]+|3)}})
   ttng.async_tma_gather %arg0[%arg2, %arg3] %arg4, %arg1, %arg5 {multicast} : !tt.tensordesc<1x128xbf16, #shared_gather_bcast>, tensor<32xi32, #ttg.slice<{dim = 0, parent = #blocked_bcast}>>, i32, !ttg.memdesc<1xi64, #shared_bar_bcast, #smem, mutable>, !ttg.memdesc<32x128xbf16, #shared_gather_bcast, #smem, mutable>, i1
+
+  // CHECK: mbarrier.try_wait.parity.acquire.cluster.shared::cta.b64
+  ttng.wait_barrier %arg7, %arg6 : !ttg.memdesc<1xi64, #shared_bar_local, #smem, mutable>
+  // CHECK: mbarrier.arrive.release.cluster.shared::cta.b64
+  ttng.arrive_barrier %arg7, 1 : !ttg.memdesc<1xi64, #shared_bar_local, #smem, mutable>
 
   // CHECK: ret void
   tt.return

--- a/test/Conversion/tritongpu_to_llvm_blackwell.mlir
+++ b/test/Conversion/tritongpu_to_llvm_blackwell.mlir
@@ -839,6 +839,71 @@ tt.func @tc_gen5_commit(%arg0: !ttg.memdesc<1xi64, #shared, #smem, mutable>, %pr
 
 // -----
 
+#shared = #ttg.nvmma_shared<{swizzlingByteWidth = 128, transposed = false, elementBitWidth = 16, CGALayout = [[0, 0]]}>
+#barrier = #ttg.swizzled_shared<{vec = 1, perPhase = 1, maxPhase = 1, order = [0], CGALayout = [[1]]}>
+#smem = #ttg.shared_memory
+module attributes {"ttg.num-ctas" = 2 : i32, "ttg.num-warps" = 4 : i32} {
+  // CHECK-LABEL: @tc_gen5_commit_multicast
+  // CHECK: tcgen05.commit.cta_group::1.mbarrier::arrive::one.shared::cluster.multicast::cluster.b64
+  // CHECK: mbarrier.try_wait.parity.acquire.cluster.shared::cta.b64
+  tt.func @tc_gen5_commit_multicast(%barrier: !ttg.memdesc<2xi64, #barrier, #smem, mutable>, %desc: !ttg.memdesc<128x128xf16, #shared, #smem>, %pred: i1, %phase: i32) {
+    ttng.tc_gen5_commit %barrier, %pred descs %desc : !ttg.memdesc<2xi64, #barrier, #smem, mutable>, !ttg.memdesc<128x128xf16, #shared, #smem>
+    ttng.wait_barrier %barrier, %phase : !ttg.memdesc<2xi64, #barrier, #smem, mutable>
+    tt.return
+  }
+}
+
+// -----
+
+#shared = #ttg.nvmma_shared<{swizzlingByteWidth = 32, transposed = false, elementBitWidth = 16, CGALayout = [[0, 0]]}>
+#barrier = #ttg.swizzled_shared<{vec = 1, perPhase = 1, maxPhase = 1, order = [0], CGALayout = [[1]]}>
+#tmem = #ttng.tensor_memory_encoding<blockM = 128, blockN = 128, colStride = 1, CGALayout = [[0, 0]]>
+#smem = #ttg.shared_memory
+module attributes {"ttg.num-ctas" = 2 : i32, "ttg.num-warps" = 4 : i32} {
+  // CHECK-LABEL: @tc_gen5_mma_multicast
+  // CHECK: tcgen05.commit.cta_group::1.mbarrier::arrive::one.shared::cluster.multicast::cluster.b64
+  // CHECK: mbarrier.try_wait.parity.acquire.cluster.shared::cta.b64
+  tt.func @tc_gen5_mma_multicast(%a: !ttg.memdesc<128x128xf16, #shared, #smem>, %b: !ttg.memdesc<128x128xf16, #shared, #smem>, %acc: !ttg.memdesc<128x128xf32, #tmem, #ttng.tensor_memory, mutable>, %barrier: !ttg.memdesc<2xi64, #barrier, #smem, mutable>, %pred: i1, %phase: i32) {
+    %false = arith.constant false
+    ttng.tc_gen5_mma %a, %b, %acc, %false, %pred, %barrier[%pred] {is_async, multicast} : !ttg.memdesc<128x128xf16, #shared, #smem>, !ttg.memdesc<128x128xf16, #shared, #smem>, !ttg.memdesc<128x128xf32, #tmem, #ttng.tensor_memory, mutable>, !ttg.memdesc<2xi64, #barrier, #smem, mutable>
+    ttng.wait_barrier %barrier, %phase : !ttg.memdesc<2xi64, #barrier, #smem, mutable>
+    tt.return
+  }
+}
+
+// -----
+
+#shared = #ttg.nvmma_shared<{swizzlingByteWidth = 128, transposed = false, elementBitWidth = 16, CGALayout = [[1, 0]]}>
+#barrier = #ttg.swizzled_shared<{vec = 1, perPhase = 1, maxPhase = 1, order = [0], CGALayout = [[1]]}>
+#smem = #ttg.shared_memory
+module attributes {"ttg.num-ctas" = 2 : i32, "ttg.num-warps" = 4 : i32} {
+  // CHECK-LABEL: @tc_gen5_commit_without_multicast
+  // CHECK: tcgen05.commit.cta_group::1.mbarrier::arrive::one.shared::cluster.b64
+  // CHECK: mbarrier.try_wait.parity.shared::cta.b64
+  tt.func @tc_gen5_commit_without_multicast(%barrier: !ttg.memdesc<2xi64, #barrier, #smem, mutable>, %desc: !ttg.memdesc<128x128xf16, #shared, #smem>, %pred: i1, %phase: i32) {
+    ttng.tc_gen5_commit %barrier, %pred descs %desc : !ttg.memdesc<2xi64, #barrier, #smem, mutable>, !ttg.memdesc<128x128xf16, #shared, #smem>
+    ttng.wait_barrier %barrier, %phase : !ttg.memdesc<2xi64, #barrier, #smem, mutable>
+    tt.return
+  }
+}
+
+// -----
+
+#barrier = #ttg.swizzled_shared<{vec = 1, perPhase = 1, maxPhase = 1, order = [0], CGALayout = [[1]]}>
+#smem = #ttg.shared_memory
+module attributes {"ttg.num-ctas" = 2 : i32, "ttg.num-warps" = 4 : i32, "ttng.two-ctas" = true} {
+  // CHECK-LABEL: @tc_gen5_commit_two_ctas
+  // CHECK: tcgen05.commit.cta_group::2.mbarrier::arrive::one.shared::cluster.multicast::cluster.b64
+  // CHECK: mbarrier.try_wait.parity.acquire.cluster.shared::cta.b64
+  tt.func @tc_gen5_commit_two_ctas(%barrier: !ttg.memdesc<2xi64, #barrier, #smem, mutable>, %pred: i1, %phase: i32) {
+    ttng.tc_gen5_commit %barrier, %pred : !ttg.memdesc<2xi64, #barrier, #smem, mutable>
+    ttng.wait_barrier %barrier, %phase : !ttg.memdesc<2xi64, #barrier, #smem, mutable>
+    tt.return
+  }
+}
+
+// -----
+
 #tmem_f32 = #ttng.tensor_memory_encoding<blockM = 128, blockN = 16, colStride = 1>
 #tmem_f16 = #ttng.tensor_memory_encoding<blockM = 128, blockN = 16, colStride = 2>
 

--- a/test/Conversion/tritongpu_to_llvm_blackwell.mlir
+++ b/test/Conversion/tritongpu_to_llvm_blackwell.mlir
@@ -490,7 +490,8 @@ module attributes {"ttg.num-warps" = 4 : i32, "ttg.num-ctas" = 2 : i32, "ttg.thr
 
 // CHECK-LABEL: @tmem_copy_2d_2cta
 tt.func public @tmem_copy_2d_2cta(%src: !ttg.memdesc<128x32xi8, #shared, #ttg.shared_memory>,
-                             %dst: !ttg.memdesc<128x32xi8, #tmem_scales, #ttng.tensor_memory, mutable>) {
+                             %dst: !ttg.memdesc<128x32xi8, #tmem_scales, #ttng.tensor_memory, mutable>,
+                             %barrier: !ttg.memdesc<1xi64, #shared1, #ttg.shared_memory>, %phase: i32, %pred: i1) {
   // CHECK: [[ZERO:%.*]] = llvm.mlir.constant(0 : i32)
   // CHECK: [[IS_WARP_0:%.*]] = llvm.icmp "eq" {{.*}}, [[ZERO]] : i32
   // CHECK: [[ELECT:%.*]] = nvvm.elect.sync
@@ -502,6 +503,12 @@ tt.func public @tmem_copy_2d_2cta(%src: !ttg.memdesc<128x32xi8, #shared, #ttg.sh
   // CHECK-COUNT-8: tcgen05.cp.cta_group::2.warpx4.32x128b
   // CHECK-NOT: tcgen05.commit
   ttng.tmem_copy %src, %dst : !ttg.memdesc<128x32xi8, #shared, #ttg.shared_memory>, !ttg.memdesc<128x32xi8, #tmem_scales, #ttng.tensor_memory, mutable>
+  // CHECK: mbarrier.arrive.expect_tx.release.cluster.shared::cluster.b64
+  ttng.barrier_expect %barrier, 16, %pred : !ttg.memdesc<1xi64, #shared1, #ttg.shared_memory>
+  // CHECK: mbarrier.try_wait.parity.acquire.cluster.shared::cta.b64
+  ttng.wait_barrier %barrier, %phase : !ttg.memdesc<1xi64, #shared1, #ttg.shared_memory>
+  // CHECK: mbarrier.arrive.release.cluster.shared::cluster.b64
+  ttng.arrive_barrier %barrier, 1 : !ttg.memdesc<1xi64, #shared1, #ttg.shared_memory>
   tt.return
   }
 }

--- a/test/Conversion/tritonnvidiagpu_to_llvm.mlir
+++ b/test/Conversion/tritonnvidiagpu_to_llvm.mlir
@@ -157,11 +157,17 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32} {
 #smem = #ttg.shared_memory
 module attributes {"ttg.num-ctas" = 2 : i32, "ttg.num-warps" = 4 : i32} {
   // CHECK-LABEL: async_shared_store
+  // CHECK: mbarrier.arrive.expect_tx.release.cluster.shared::cta.b64
   // CHECK: nvvm.mapa
   // CHECK: nvvm.mapa
   // CHECK: st.async.weak.shared::cluster.mbarrier::complete_tx::bytes.b32
+  // CHECK: mbarrier.try_wait.parity.acquire.cluster.shared::cta.b64
   tt.func @async_shared_store(%src: tensor<128xi32, #blocked>, %dst: !ttg.memdesc<128xi32, #shared1, #smem, mutable>, %mbarrier: !ttg.memdesc<2xi64, #shared0, #smem, mutable>) {
+    %true = arith.constant true
+    %phase = arith.constant 0 : i32
+    ttng.barrier_expect %mbarrier, 512, %true : !ttg.memdesc<2xi64, #shared0, #smem, mutable>
     ttng.async_shared_store %src, %dst, %mbarrier : tensor<128xi32, #blocked> -> !ttg.memdesc<128xi32, #shared1, #smem, mutable>, !ttg.memdesc<2xi64, #shared0, #smem, mutable>
+    ttng.wait_barrier %mbarrier, %phase deps %dst : !ttg.memdesc<2xi64, #shared0, #smem, mutable>, !ttg.memdesc<128xi32, #shared1, #smem, mutable>
     tt.return
   }
 }

--- a/test/Conversion/tritonnvidiagpu_to_llvm.mlir
+++ b/test/Conversion/tritonnvidiagpu_to_llvm.mlir
@@ -116,15 +116,17 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32} {
 #smem = #ttg.shared_memory
 module attributes {"ttg.num-ctas" = 2 : i32, "ttg.num-warps" = 4 : i32} {
   // CHECK-LABEL: arrive_barrier_cluster_broadcast
-  tt.func @arrive_barrier_cluster_broadcast(%alloc: !ttg.memdesc<1xi64, #shared0, #smem>) {
+  tt.func @arrive_barrier_cluster_broadcast(%alloc: !ttg.memdesc<1xi64, #shared0, #smem>, %phase: i32) {
     // CHECK: nvvm.barrier
     // CHECK-NOT: nvg.cluster_id
     // CHECK: llvm.ptrtoint
     // CHECK: llvm.and
     // CHECK: llvm.inttoptr
-    // CHECK: mbarrier.arrive.shared::cluster.b64
+    // CHECK: mbarrier.arrive.release.cluster.shared::cluster.b64
     // CHECK-NOT: mbarrier.arrive.shared::cta.b64
     ttng.arrive_barrier %alloc, 1 : !ttg.memdesc<1xi64, #shared0, #smem>
+    // CHECK: mbarrier.try_wait.parity.acquire.cluster.shared::cta.b64
+    ttng.wait_barrier %alloc, %phase : !ttg.memdesc<1xi64, #shared0, #smem>
     tt.return
   }
 }
@@ -462,7 +464,7 @@ module attributes {"ttg.num-ctas" = 2 : i32, "ttg.num-warps" = 4 : i32} {
   // CHECK: llvm.ptrtoint
   // CHECK: llvm.and
   // CHECK: llvm.inttoptr
-  // CHECK: @$0 mbarrier.arrive.expect_tx.shared::cluster.b64 _, [$1], 16384;
+  // CHECK: @$0 mbarrier.arrive.expect_tx.release.cluster.shared::cluster.b64 _, [$1], 16384;
   // CHECK-NOT: mbarrier.arrive.shared::cluster.b64
   tt.func @expect_barrier_cluster_broadcast(%barrier: !ttg.memdesc<1xi64, #shared0, #smem, mutable>, %pred: i1) {
     ttng.barrier_expect %barrier, 16384, %pred : !ttg.memdesc<1xi64, #shared0, #smem, mutable>

--- a/test/TritonNvidiaGPU/membar-cluster.mlir
+++ b/test/TritonNvidiaGPU/membar-cluster.mlir
@@ -517,6 +517,80 @@ module attributes {"ttg.num-ctas" = 2 : i32, "ttg.num-warps" = 4 : i32, ttg.targ
 
 // -----
 
+#blockedStore = #ttg.blocked<{sizePerThread = [1], threadsPerWarp = [32], warpsPerCTA = [4], order = [0], CGALayout = [[0]]}>
+#sharedStore = #ttg.swizzled_shared<{vec = 1, perPhase = 1, maxPhase = 1, order = [0], CGALayout = [[0]]}>
+#barrierStore = #ttg.swizzled_shared<{vec = 1, perPhase = 1, maxPhase = 1, order = [0], CGALayout = [[1]]}>
+#smem = #ttg.shared_memory
+
+module attributes {"ttg.num-ctas" = 2 : i32, "ttg.num-warps" = 4 : i32, ttg.target = "cuda:90", "ttg.threads-per-warp" = 32 : i32} {
+  // Async shared stores can complete per-CTA barriers remotely, so the init
+  // must be visible throughout the cluster before the store is issued.
+  // CHECK-LABEL: @cluster_async_shared_store_with_per_cta_barrier
+  // CHECK: ttng.init_barrier
+  // CHECK-NEXT: ttng.fence_mbarrier_init_release_cluster
+  // CHECK-NEXT: ttng.cluster_barrier {relaxed = true}
+  // CHECK-NEXT: ttng.async_shared_store
+  // CHECK: tt.return
+  tt.func @cluster_async_shared_store_with_per_cta_barrier(%src: tensor<128xi32, #blockedStore>) {
+    %dst = ttg.local_alloc : () -> !ttg.memdesc<128xi32, #sharedStore, #smem, mutable>
+    %barrier = ttg.local_alloc : () -> !ttg.memdesc<2xi64, #barrierStore, #smem, mutable>
+    ttng.init_barrier %barrier, 1 : !ttg.memdesc<2xi64, #barrierStore, #smem, mutable>
+    ttng.async_shared_store %src, %dst, %barrier : tensor<128xi32, #blockedStore> -> !ttg.memdesc<128xi32, #sharedStore, #smem, mutable>, !ttg.memdesc<2xi64, #barrierStore, #smem, mutable>
+    tt.return
+  }
+}
+
+// -----
+
+#sharedCommit = #ttg.nvmma_shared<{swizzlingByteWidth = 128, transposed = false, elementBitWidth = 16, CGALayout = [[0, 0]]}>
+#barrierCommit = #ttg.swizzled_shared<{vec = 1, perPhase = 1, maxPhase = 1, order = [0], CGALayout = [[1]]}>
+#smem = #ttg.shared_memory
+
+module attributes {"ttg.num-ctas" = 2 : i32, "ttg.num-warps" = 4 : i32, ttg.target = "cuda:100", "ttg.threads-per-warp" = 32 : i32} {
+  // A commit with multicast descriptors can complete per-CTA barriers on
+  // other CTAs even when this is not a two-CTA MMA kernel.
+  // CHECK-LABEL: @cluster_tc_gen5_commit_multicast_with_per_cta_barrier
+  // CHECK: ttng.init_barrier
+  // CHECK-NEXT: ttng.fence_mbarrier_init_release_cluster
+  // CHECK-NEXT: ttng.cluster_barrier {relaxed = true}
+  // CHECK-NEXT: ttng.tc_gen5_commit
+  // CHECK: tt.return
+  tt.func @cluster_tc_gen5_commit_multicast_with_per_cta_barrier(%desc: !ttg.memdesc<128x128xf16, #sharedCommit, #smem>) {
+    %barrier = ttg.local_alloc : () -> !ttg.memdesc<2xi64, #barrierCommit, #smem, mutable>
+    ttng.init_barrier %barrier, 1 : !ttg.memdesc<2xi64, #barrierCommit, #smem, mutable>
+    ttng.tc_gen5_commit %barrier descs %desc : !ttg.memdesc<2xi64, #barrierCommit, #smem, mutable>, !ttg.memdesc<128x128xf16, #sharedCommit, #smem>
+    tt.return
+  }
+}
+
+// -----
+
+#sharedMMA = #ttg.nvmma_shared<{swizzlingByteWidth = 32, transposed = false, elementBitWidth = 16, CGALayout = [[0, 0]]}>
+#barrierMMA = #ttg.swizzled_shared<{vec = 1, perPhase = 1, maxPhase = 1, order = [0], CGALayout = [[1]]}>
+#tmemMMA = #ttng.tensor_memory_encoding<blockM = 128, blockN = 128, colStride = 1, CGALayout = [[0, 0]]>
+#smem = #ttg.shared_memory
+
+module attributes {"ttg.num-ctas" = 2 : i32, "ttg.num-warps" = 4 : i32, ttg.target = "cuda:100", "ttg.threads-per-warp" = 32 : i32} {
+  // Multicast MMA completion also fans out to per-CTA barriers without
+  // requiring a two-CTA MMA.
+  // CHECK-LABEL: @cluster_tc_gen5_mma_multicast_with_per_cta_barrier
+  // CHECK: ttng.init_barrier
+  // CHECK-NEXT: ttng.fence_mbarrier_init_release_cluster
+  // CHECK-NEXT: ttng.cluster_barrier {relaxed = true}
+  // CHECK-NEXT: ttng.tc_gen5_mma
+  // CHECK: tt.return
+  tt.func @cluster_tc_gen5_mma_multicast_with_per_cta_barrier(%a: !ttg.memdesc<128x128xf16, #sharedMMA, #smem>, %b: !ttg.memdesc<128x128xf16, #sharedMMA, #smem>, %acc: !ttg.memdesc<128x128xf32, #tmemMMA, #ttng.tensor_memory, mutable>) {
+    %false = arith.constant false
+    %true = arith.constant true
+    %barrier = ttg.local_alloc : () -> !ttg.memdesc<2xi64, #barrierMMA, #smem, mutable>
+    ttng.init_barrier %barrier, 1 : !ttg.memdesc<2xi64, #barrierMMA, #smem, mutable>
+    ttng.tc_gen5_mma %a, %b, %acc, %false, %true, %barrier[%true] {is_async, multicast} : !ttg.memdesc<128x128xf16, #sharedMMA, #smem>, !ttg.memdesc<128x128xf16, #sharedMMA, #smem>, !ttg.memdesc<128x128xf32, #tmemMMA, #ttng.tensor_memory, mutable>, !ttg.memdesc<2xi64, #barrierMMA, #smem, mutable>
+    tt.return
+  }
+}
+
+// -----
+
 #nvmma = #ttg.nvmma_shared<{swizzlingByteWidth = 128, transposed = false, elementBitWidth = 16, CGALayout = [[0, 0]]}>
 #barrierEnc = #ttg.swizzled_shared<{vec = 1, perPhase = 1, maxPhase = 1, order = [0], CGALayout = [[0]]}>
 #blocked = #ttg.blocked<{sizePerThread = [1, 4], threadsPerWarp = [8, 4], warpsPerCTA = [4, 1], order = [0, 1], CGALayout = [[1, 0]]}>

--- a/third_party/nvidia/lib/TritonNVIDIAGPUToLLVM/BarrierOpToLLVM.cpp
+++ b/third_party/nvidia/lib/TritonNVIDIAGPUToLLVM/BarrierOpToLLVM.cpp
@@ -191,7 +191,11 @@ struct InvalBarrierOpConversion
 
 struct BarrierExpectConversion
     : public ConvertOpToLLVMPattern<triton::nvidia_gpu::BarrierExpectOp> {
-  using ConvertOpToLLVMPattern::ConvertOpToLLVMPattern;
+  bool isCrossCluster;
+  BarrierExpectConversion(LLVMTypeConverter &typeConverter,
+                          PatternBenefit benefit, bool isCrossCluster)
+      : ConvertOpToLLVMPattern(typeConverter, benefit),
+        isCrossCluster(isCrossCluster) {}
 
   LogicalResult
   matchAndRewrite(triton::nvidia_gpu::BarrierExpectOp op, OpAdaptor adaptor,
@@ -211,14 +215,17 @@ struct BarrierExpectConversion
     Value id = getThreadId(rewriter, loc);
     Value pred = b.icmp_eq(id, b.i32_val(0));
     pred = b.and_(pred, adaptor.getPred());
-    bool crossCluster = LLVM::NVIDIA::getCGABroadcastMask(barrierTy) != 0;
+    bool isCrossClusterBarrier =
+        LLVM::NVIDIA::getCGABroadcastMask(barrierTy) != 0;
     Value leaderBarrierPtr = LLVM::NVIDIA::getLeaderAddress(
         loc, rewriter, smemObj.getBase(), barrierTy);
 
     ::mlir::triton::PTXBuilder expectPtxBuilder;
     const std::string expectPtx =
         "@$0 mbarrier.arrive.expect_tx." +
-        std::string(crossCluster ? "shared::cluster" : "shared::cta") +
+        std::string(isCrossCluster || isCrossClusterBarrier ? "release.cluster."
+                                                            : "") +
+        std::string(isCrossClusterBarrier ? "shared::cluster" : "shared::cta") +
         ".b64 _, [$1], " + std::to_string(op.getSize()) + ";";
     auto &expectOp = *expectPtxBuilder.create(expectPtx);
     expectOp({expectPtxBuilder.newOperand(pred, "b"),
@@ -235,11 +242,12 @@ struct BarrierExpectConversion
 struct WaitBarrierOpConversion
     : public ConvertOpToLLVMPattern<triton::nvidia_gpu::WaitBarrierOp> {
   const NVIDIA::TargetInfo *targetInfo;
+  bool isCrossCluster;
   WaitBarrierOpConversion(LLVMTypeConverter &typeConverter,
                           PatternBenefit benefit,
-                          NVIDIA::TargetInfo &targetInfo)
-      : ConvertOpToLLVMPattern(typeConverter, benefit),
-        targetInfo(&targetInfo) {}
+                          NVIDIA::TargetInfo &targetInfo, bool isCrossCluster)
+      : ConvertOpToLLVMPattern(typeConverter, benefit), targetInfo(&targetInfo),
+        isCrossCluster(isCrossCluster) {}
 
   LogicalResult
   matchAndRewrite(triton::nvidia_gpu::WaitBarrierOp op, OpAdaptor adaptor,
@@ -256,6 +264,10 @@ struct WaitBarrierOpConversion
             LLVM::NVIDIA::getLeaderCTAPredicate(loc, rewriter, barrierTy))
       pred = b.and_(pred, *leaderPred);
 
+    bool isCrossClusterBarrier =
+        LLVM::NVIDIA::getCGABroadcastMask(barrierTy) != 0;
+    std::string acquire =
+        isCrossCluster || isCrossClusterBarrier ? ".acquire.cluster" : "";
     bool predicated = pred && !matchPattern(pred, m_NonZero());
     std::string ptx;
     if (targetInfo->getComputeCapability() < 90) {
@@ -264,7 +276,8 @@ struct WaitBarrierOpConversion
 {
 	.reg .pred complete;
 	waitLoop:
-	mbarrier.test_wait.parity.shared::cta.b64 complete, [$0], $1;
+	mbarrier.test_wait.parity)" +
+              acquire + R"(.shared::cta.b64 complete, [$0], $1;
 	@!complete nanosleep.u32 20;
 	@!complete bra.uni waitLoop;
 }
@@ -275,7 +288,8 @@ struct WaitBarrierOpConversion
 	@!$2 bra.uni skipWait;
 	.reg .pred complete;
 	waitLoop:
-	mbarrier.test_wait.parity.shared::cta.b64 complete, [$0], $1;
+	mbarrier.test_wait.parity)" +
+              acquire + R"(.shared::cta.b64 complete, [$0], $1;
 	@!complete nanosleep.u32 20;
 	@!complete bra.uni waitLoop;
 	skipWait:
@@ -288,7 +302,8 @@ struct WaitBarrierOpConversion
 {
 	.reg .pred complete;
 	waitLoop:
-	mbarrier.try_wait.parity.shared::cta.b64 complete, [$0], $1;
+	mbarrier.try_wait.parity)" +
+              acquire + R"(.shared::cta.b64 complete, [$0], $1;
 	@!complete bra.uni waitLoop;
 }
 )";
@@ -298,7 +313,8 @@ struct WaitBarrierOpConversion
 	@!$2 bra.uni skipWait;
 	.reg .pred complete;
 	waitLoop:
-	mbarrier.try_wait.parity.shared::cta.b64 complete, [$0], $1;
+	mbarrier.try_wait.parity)" +
+              acquire + R"(.shared::cta.b64 complete, [$0], $1;
 	@!complete bra.uni waitLoop;
 	skipWait:
 }
@@ -322,7 +338,11 @@ struct WaitBarrierOpConversion
 
 struct ArriveBarrierOpConversion
     : public ConvertOpToLLVMPattern<triton::nvidia_gpu::ArriveBarrierOp> {
-  using ConvertOpToLLVMPattern::ConvertOpToLLVMPattern;
+  bool isCrossCluster;
+  ArriveBarrierOpConversion(LLVMTypeConverter &typeConverter,
+                            PatternBenefit benefit, bool isCrossCluster)
+      : ConvertOpToLLVMPattern(typeConverter, benefit),
+        isCrossCluster(isCrossCluster) {}
 
   LogicalResult
   matchAndRewrite(triton::nvidia_gpu::ArriveBarrierOp op, OpAdaptor adaptor,
@@ -346,14 +366,17 @@ struct ArriveBarrierOpConversion
     if (op.getPred())
       pred = b.and_(pred, adaptor.getPred());
 
-    bool isCrossCluster = LLVM::NVIDIA::getCGABroadcastMask(barrierTy) != 0;
+    bool isCrossClusterBarrier =
+        LLVM::NVIDIA::getCGABroadcastMask(barrierTy) != 0;
 
     Value barrierPtr = LLVM::NVIDIA::getLeaderAddress(
         loc, rewriter, smemObj.getBase(), barrierTy);
     // TODO: Add phase result as needed.
     std::stringstream ptxAsm;
     ptxAsm << "@$0 mbarrier.arrive."
-           << (isCrossCluster ? "shared::cluster" : "shared::cta")
+           << (isCrossCluster || isCrossClusterBarrier ? "release.cluster."
+                                                       : "")
+           << (isCrossClusterBarrier ? "shared::cluster" : "shared::cta")
            << ".b64 _, [$1]";
     if (op.getCount() > 1) {
       ptxAsm << ", " << op.getCount();
@@ -548,15 +571,18 @@ struct CLCGetProgramIdOpConversion
 
 void mlir::triton::NVIDIA::populateBarrierOpToLLVMPatterns(
     LLVMTypeConverter &typeConverter, RewritePatternSet &patterns,
-    PatternBenefit benefit, NVIDIA::TargetInfo &targetInfo) {
+    PatternBenefit benefit, NVIDIA::TargetInfo &targetInfo,
+    bool isCrossCluster) {
   patterns.add<FenceAsyncSharedOpConversion>(typeConverter, benefit);
   patterns.add<FenceMBarrierInitReleaseClusterOpConversion>(typeConverter,
                                                             benefit);
   patterns.add<InitBarrierOpConversion, InvalBarrierOpConversion>(
       typeConverter, benefit, targetInfo);
-  patterns.add<WaitBarrierOpConversion>(typeConverter, benefit, targetInfo);
-  patterns.add<BarrierExpectConversion>(typeConverter, benefit);
-  patterns.add<ArriveBarrierOpConversion>(typeConverter, benefit);
+  patterns.add<WaitBarrierOpConversion>(typeConverter, benefit, targetInfo,
+                                        isCrossCluster);
+  patterns.add<BarrierExpectConversion>(typeConverter, benefit, isCrossCluster);
+  patterns.add<ArriveBarrierOpConversion>(typeConverter, benefit,
+                                          isCrossCluster);
   patterns.add<CLCTryCancelOpConversion>(typeConverter, benefit, targetInfo);
   patterns.add<CLCLoadResultOpConversion>(typeConverter, benefit, targetInfo);
   patterns.add<CLCIsCanceledOpConversion>(typeConverter, benefit, targetInfo);

--- a/third_party/nvidia/lib/TritonNVIDIAGPUToLLVM/BarrierOpToLLVM.cpp
+++ b/third_party/nvidia/lib/TritonNVIDIAGPUToLLVM/BarrierOpToLLVM.cpp
@@ -262,7 +262,7 @@ struct WaitBarrierOpConversion
     auto pred = adaptor.getPred();
     if (auto leaderPred =
             LLVM::NVIDIA::getLeaderCTAPredicate(loc, rewriter, barrierTy))
-      pred = b.and_(pred, *leaderPred);
+      pred = pred ? b.and_(pred, *leaderPred) : *leaderPred;
 
     bool isCrossClusterBarrier =
         LLVM::NVIDIA::getCGABroadcastMask(barrierTy) != 0;

--- a/third_party/nvidia/lib/TritonNVIDIAGPUToLLVM/PatternTritonGPUOpToLLVM.h
+++ b/third_party/nvidia/lib/TritonNVIDIAGPUToLLVM/PatternTritonGPUOpToLLVM.h
@@ -13,7 +13,8 @@ namespace NVIDIA {
 void populateBarrierOpToLLVMPatterns(LLVMTypeConverter &typeConverter,
                                      RewritePatternSet &patterns,
                                      PatternBenefit benefit,
-                                     NVIDIA::TargetInfo &info);
+                                     NVIDIA::TargetInfo &info,
+                                     bool isCrossCluster);
 
 void createFenceMBarrierInitReleaseCluster(OpBuilder &builder, Location loc,
                                            Value pred);

--- a/third_party/nvidia/lib/TritonNVIDIAGPUToLLVM/TritonGPUToLLVM.cpp
+++ b/third_party/nvidia/lib/TritonNVIDIAGPUToLLVM/TritonGPUToLLVM.cpp
@@ -174,8 +174,17 @@ struct ConvertTritonGPUToLLVM
                                                targetInfo, benefit);
     mlir::triton::populateGatherOpToLLVMPatterns(typeConverter, patterns,
                                                  targetInfo, benefit);
+    bool isCrossCluster =
+        computeCapability >= 90 &&
+        triton::gpu::TritonGPUDialect::getNumCTAs(mod) >= 2 &&
+        mod.walk([](Operation *op) {
+             return ttng::isDistributedMultiCTAOp(op, /*isRead=*/true)
+                        ? WalkResult::interrupt()
+                        : WalkResult::advance();
+           })
+            .wasInterrupted();
     populateBarrierOpToLLVMPatterns(typeConverter, patterns, benefit,
-                                    targetInfo);
+                                    targetInfo, isCrossCluster);
     populateClusterOpsToLLVMPatterns(typeConverter, patterns, benefit,
                                      targetInfo);
     mlir::triton::populateHistogramOpToLLVMPatterns(typeConverter, patterns,


### PR DESCRIPTION
We emit it in all arrive/expect/waits whenever there is at least one op
that crosses CTAs. The idea here is that we cannot always just infer
from the `cga_layout` of the mbarrier whether we should emit it, as when
doing broadcasting from one to many (TMA, `tcgen05_commit`...) the
barrier's CGA layout is just `[[1], [2], ...]` (no broadcasting). As
such we err on the side of caution and we add it to all mbars in the
kernel.

We also add a fix for kernels with `num_ctas > 2` where we were not
signaling all the CTAs having finished using the CLC result, we were
just signaling CTA0 and 1. This was a remnant from when we didn't
support `num_ctas > 2` very well.

We also take this chance to fix a couple things the clustermbar pass was
missing that codex found.
