### PR TITLE
[INTERPRETER] Make int1 add/sub wrap around like the GPU

### DIFF
--- a/python/test/unit/language/test_core.py
+++ b/python/test/unit/language/test_core.py
@@ -432,6 +432,36 @@ def test_bin_op(dtype_x, dtype_y, op, num_ctas, device):
 
 
 @pytest.mark.interpreter
+@pytest.mark.parametrize("op", ['+', '-'])
+def test_int1_bin_op_wraparound(op, device):
+    # int1 is a 1-bit integer, so `+`/`-` wrap around mod 2 just like any other
+    # integer type. The GPU backend already does this; the interpreter must
+    # agree (see issue #10919, where `True + True` gave 0 on GPU but 1 in the
+    # interpreter).
+    @triton.jit
+    def kernel(X, Y, Z, SIZE: tl.constexpr):
+        off = tl.arange(0, SIZE)
+        x = tl.load(X + off)
+        y = tl.load(Y + off)
+        z = GENERATE_TEST_HERE
+        tl.store(Z + off, z)
+
+    kernel = patch_kernel(kernel, {'GENERATE_TEST_HERE': f'x {op} y'})
+
+    x = np.array([False, False, True, True])
+    y = np.array([False, True, False, True])
+    SIZE = x.size
+    wide = x.astype(np.int8) + y.astype(np.int8) if op == '+' else x.astype(np.int8) - y.astype(np.int8)
+    z_ref = np.mod(wide, 2).astype(bool)
+
+    x_tri = to_triton(x, device=device)
+    y_tri = to_triton(y, device=device)
+    z_tri = to_triton(np.empty(SIZE, dtype=bool), device=device)
+    kernel[(1, )](x_tri, y_tri, z_tri, SIZE=SIZE)
+    np.testing.assert_array_equal(z_ref, to_numpy(z_tri))
+
+
+@pytest.mark.interpreter
 @pytest.mark.parametrize("dtype, order", [(dtype, order) for dtype in dtypes_with_bfloat16 for order in [0, 1]])
 def test_addptr(dtype, order, device):
     check_type_supported(dtype, device)

--- a/python/triton/runtime/interpreter.py
+++ b/python/triton/runtime/interpreter.py
@@ -554,8 +554,17 @@ class InterpreterBuilder:
 
     # binary operators
     def binary_op(self, lhs, rhs, op):
-        output = op(lhs.data, rhs.data)
         tl_dtype = lhs.dtype.scalar
+
+        if lhs.data.dtype == np.bool_ and rhs.data.dtype == np.bool_:
+            # numpy uses logical/saturating semantics for bool arithmetic
+            # (True + True == True) and rejects bool subtraction outright, but
+            # Triton treats int1 as a 1-bit integer that wraps around like any
+            # other integer type. Compute in a wider integer domain and
+            # truncate back to one bit to match the GPU backend (issue #10919).
+            output = (op(lhs.data.astype(np.int8), rhs.data.astype(np.int8)) & 1).astype(np.bool_)
+        else:
+            output = op(lhs.data, rhs.data)
 
         if not _validate_np_data_size(output, tl_dtype):
             output = output.astype(_get_np_dtype(tl_dtype))


### PR DESCRIPTION
## Summary

Fixes #10919.

`int1 + int1` produced different results in the interpreter and on the GPU:

- **GPU:** `int1` is a 1-bit integer, so `arith.addi` wraps mod 2 and `True + True == 0`.
- **Interpreter:** `binary_op` ran numpy bool arithmetic, which is logical/saturating (`True + True == True == 1`), so it disagreed with the GPU.

As noted by @peterbell10 in the issue, `0` is the intended result (int1 should wrap like any other integer type), so the interpreter is the side to change; the GPU path is unchanged.

This also fixes a related interpreter crash: `int1 - int1` previously raised `TypeError: numpy boolean subtract ... is not supported`, since numpy rejects bool subtraction. It now wraps correctly (matching the GPU).

## Change

In `InterpreterBuilder.binary_op`, when the operand type is `int1`, compute the op in a wider integer domain (`int8`) and truncate back to one bit (`& 1`). This matches the GPU's 1-bit wraparound. Ops whose int1 results are already in `{0, 1}` (mul, and, or, xor, min, max, comparisons) are unaffected.

## Test

`test_int1_bin_op_wraparound` in `test_core.py` runs `int1 +/- int1` and asserts mod-2 wraparound. Marked `@pytest.mark.interpreter` so it runs on both the GPU and interpreter paths, pinning them together.