### PR TITLE
[COALESCE] Keep a store and its read-back layout-consistent

### DIFF
--- a/lib/Dialect/TritonGPU/Transforms/Coalesce.cpp
+++ b/lib/Dialect/TritonGPU/Transforms/Coalesce.cpp
@@ -68,6 +68,61 @@ static void pickDescriptorLoadStoreLayout(
   });
 }
 
+// Get the (kernel arg, offset) a pointer addresses by walking its
+// splat/addptr chain. Returns null if it is not a single addptr off a kernel
+// argument.
+static std::pair<Value, Value> getBaseAndOffset(Value ptr) {
+  Value offset;
+  while (Operation *def = ptr.getDefiningOp()) {
+    if (auto addPtr = dyn_cast<AddPtrOp>(def)) {
+      if (offset) // keep it simple: only one addptr
+        return {};
+      offset = addPtr.getOffset();
+      ptr = addPtr.getPtr();
+    } else if (auto splat = dyn_cast<SplatOp>(def)) {
+      ptr = splat.getSrc();
+    } else {
+      return {};
+    }
+  }
+  if (!offset || !isa<BlockArgument>(ptr))
+    return {};
+  return {ptr, offset};
+}
+
+// If a store and a later load hit the same buffer, Coalesce may give them
+// different layouts, so one thread reads back what another wrote. Give the
+// store the load's layout so each thread reads back its own data. We match on
+// the (arg, offset) addressed, so different regions of a buffer are left alone.
+static void alignReadBackStores(ModuleOp moduleOp,
+                                llvm::MapVector<Operation *, Attribute> &map) {
+  moduleOp.walk([&](triton::FuncOp func) {
+    for (Block &block : func.getBody()) {
+      llvm::DenseMap<std::pair<Value, Value>, StoreOp> lastStore;
+      for (Operation &op : block) {
+        if (auto store = dyn_cast<StoreOp>(&op)) {
+          if (!map.count(store))
+            continue;
+          std::pair<Value, Value> key = getBaseAndOffset(store.getPtr());
+          if (key.first)
+            lastStore[key] = store;
+        } else if (auto load = dyn_cast<LoadOp>(&op)) {
+          std::pair<Value, Value> key = getBaseAndOffset(load.getPtr());
+          if (!key.first)
+            continue;
+          auto storeIt = lastStore.find(key);
+          if (storeIt == lastStore.end())
+            continue;
+          auto loadLayoutIt = map.find(load);
+          auto storeLayoutIt = map.find(storeIt->second);
+          if (loadLayoutIt != map.end() && storeLayoutIt != map.end())
+            storeLayoutIt->second = loadLayoutIt->second;
+        }
+      }
+    }
+  });
+}
+
 struct CoalescePass : public impl::TritonGPUCoalesceBase<CoalescePass> {
   static Type getNewType(Type type, Attribute encoding) {
     RankedTensorType tensorType = cast<RankedTensorType>(type);
@@ -106,6 +161,9 @@ struct CoalescePass : public impl::TritonGPUCoalesceBase<CoalescePass> {
 
     // Also pick a layout for descriptor load/store ops.
     pickDescriptorLoadStoreLayout(moduleOp, layoutMap);
+
+    // Match a store's layout to its read-back so the two do not race.
+    alignReadBackStores(moduleOp, layoutMap);
 
     // For each memory op that has a layout L1:
     // 1. Create a coalesced memory layout L2 of the pointer operands

--- a/test/TritonGPU/coalesce.mlir
+++ b/test/TritonGPU/coalesce.mlir
@@ -312,3 +312,61 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.targ
     tt.return
   }
 }
+
+// -----
+
+// A store and a read-back of the same buffer must share one layout, or a
+// thread reads back what another wrote. The wide f16 load pushes the read
+// layout to [1, 8] while the f32 store is clamped to [1, 4]; the store must
+// take the read-back's layout.
+
+#blocked = #ttg.blocked<{sizePerThread = [1, 1], threadsPerWarp = [1, 32], warpsPerCTA = [1, 4], order = [1, 0]}>
+module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, "ttg.threads-per-warp" = 32 : i32} {
+  // CHECK-LABEL: @readback_same_layout
+  tt.func public @readback_same_layout(%arg0: !tt.ptr<f32> {tt.divisibility = 16 : i32}, %arg1: !tt.ptr<f16> {tt.divisibility = 16 : i32}) {
+    %cst = arith.constant dense<0.000000e+00> : tensor<8x256xf32, #blocked>
+    %r = tt.make_range {end = 256 : i32, start = 0 : i32} : tensor<256xi32, #ttg.slice<{dim = 0, parent = #blocked}>>
+    %re = tt.expand_dims %r {axis = 0 : i32} : tensor<256xi32, #ttg.slice<{dim = 0, parent = #blocked}>> -> tensor<1x256xi32, #blocked>
+    %off = tt.broadcast %re : tensor<1x256xi32, #blocked> -> tensor<8x256xi32, #blocked>
+    %sp = tt.splat %arg0 : !tt.ptr<f32> -> tensor<8x256x!tt.ptr<f32>, #blocked>
+    %p = tt.addptr %sp, %off : tensor<8x256x!tt.ptr<f32>, #blocked>, tensor<8x256xi32, #blocked>
+    %sp16 = tt.splat %arg1 : !tt.ptr<f16> -> tensor<8x256x!tt.ptr<f16>, #blocked>
+    %p16 = tt.addptr %sp16, %off : tensor<8x256x!tt.ptr<f16>, #blocked>, tensor<8x256xi32, #blocked>
+    %w = tt.load %p16 : tensor<8x256x!tt.ptr<f16>, #blocked>
+    // The store adopts the read-back's layout, so the two share one encoding.
+    // CHECK: tt.store %{{.*}} : tensor<8x256x!tt.ptr<f32>, [[ENC:#[a-z0-9]+]]>
+    tt.store %p, %cst : tensor<8x256x!tt.ptr<f32>, #blocked>
+    // CHECK: tt.load %{{.*}} : tensor<8x256x!tt.ptr<f32>, [[ENC]]>
+    %v = tt.load %p : tensor<8x256x!tt.ptr<f32>, #blocked>
+    tt.return
+  }
+}
+
+// -----
+
+// The read-back may rebuild its own pointer instead of reusing the store's.
+// Matching on the (arg, offset) it addresses still pairs them.
+
+#blocked = #ttg.blocked<{sizePerThread = [1, 1], threadsPerWarp = [1, 32], warpsPerCTA = [1, 4], order = [1, 0]}>
+module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, "ttg.threads-per-warp" = 32 : i32} {
+  // CHECK-LABEL: @readback_recomputed_pointer
+  tt.func public @readback_recomputed_pointer(%arg0: !tt.ptr<f32> {tt.divisibility = 16 : i32}, %arg1: !tt.ptr<f16> {tt.divisibility = 16 : i32}) {
+    %cst = arith.constant dense<0.000000e+00> : tensor<8x256xf32, #blocked>
+    %r = tt.make_range {end = 256 : i32, start = 0 : i32} : tensor<256xi32, #ttg.slice<{dim = 0, parent = #blocked}>>
+    %re = tt.expand_dims %r {axis = 0 : i32} : tensor<256xi32, #ttg.slice<{dim = 0, parent = #blocked}>> -> tensor<1x256xi32, #blocked>
+    %off = tt.broadcast %re : tensor<1x256xi32, #blocked> -> tensor<8x256xi32, #blocked>
+    %sp16 = tt.splat %arg1 : !tt.ptr<f16> -> tensor<8x256x!tt.ptr<f16>, #blocked>
+    %p16 = tt.addptr %sp16, %off : tensor<8x256x!tt.ptr<f16>, #blocked>, tensor<8x256xi32, #blocked>
+    %w = tt.load %p16 : tensor<8x256x!tt.ptr<f16>, #blocked>
+    %sp = tt.splat %arg0 : !tt.ptr<f32> -> tensor<8x256x!tt.ptr<f32>, #blocked>
+    %p = tt.addptr %sp, %off : tensor<8x256x!tt.ptr<f32>, #blocked>, tensor<8x256xi32, #blocked>
+    // CHECK: tt.store %{{.*}} : tensor<8x256x!tt.ptr<f32>, [[ENC:#[a-z0-9]+]]>
+    tt.store %p, %cst : tensor<8x256x!tt.ptr<f32>, #blocked>
+    // Read-back rebuilds its own pointer to the same address.
+    %sp2 = tt.splat %arg0 : !tt.ptr<f32> -> tensor<8x256x!tt.ptr<f32>, #blocked>
+    %p2 = tt.addptr %sp2, %off : tensor<8x256x!tt.ptr<f32>, #blocked>, tensor<8x256xi32, #blocked>
+    // CHECK: tt.load %{{.*}} : tensor<8x256x!tt.ptr<f32>, [[ENC]]>
+    %v = tt.load %p2 : tensor<8x256x!tt.ptr<f32>, #blocked>
+    tt.return
+  }
+}


### PR DESCRIPTION
Coalesce picks a layout per op, so a store and a later load of the same buffer can get different layouts, and a thread reads back what another wrote (no barrier between them).

Fix: when a store and a load address the same `(arg, offset)`, give the store the load's layout so the round-trip stays within a thread.

Fixes #10924.