### PR TITLE
[MultiCTA] Add `from_ctas` to arrive / expect

### DIFF
--- a/include/triton/Dialect/TritonNvidiaGPU/IR/TritonNvidiaGPUOps.td
+++ b/include/triton/Dialect/TritonNvidiaGPU/IR/TritonNvidiaGPUOps.td
@@ -298,7 +298,7 @@ def TTNG_BarrierExpectOp : TTNG_Op<"barrier_expect", [
   let description = [{
     This signals the barrier that `size` bytes are expected to be copied. The
     associated barrier wait will block until the expected number of bytes has
-    been copied. The optional `from_ctas` attribute is a CTA-ID
+    been copied. The optional `fromCTA` attribute is a CTA-ID
     basis-selection mask: set bits are preserved and unset bits are zeroed
     when selecting the CTA that routes the arrival to each per-CTA barrier.
   }];
@@ -309,13 +309,13 @@ def TTNG_BarrierExpectOp : TTNG_Op<"barrier_expect", [
     Arg<TTG_MemDescType, "", [MemWrite<SharedMemory>]>:$alloc,
     I32Attr:$size,
     I1:$pred,
-    OptionalAttr<I32Attr>:$from_ctas
+    OptionalAttr<I32Attr>:$fromCTA
   );
 
   let builders = [
     OpBuilder<(ins "Value":$alloc, "uint32_t":$size, "Value":$pred), [{
       build($_builder, $_state, alloc, $_builder.getI32IntegerAttr(size), pred,
-            /*from_ctas=*/IntegerAttr());
+            /*fromCTA=*/IntegerAttr());
     }]>
   ];
 
@@ -383,18 +383,18 @@ def TTNG_ArriveBarrierOp : TTNG_Op<"arrive_barrier", [
     of at least 1 and decreases the pending arrival count of the mbarrier by
     the specified count.
 
-    When `ctaMask` is non-zero, the arrive is multicast across the cluster.
+    When `multicastCTA` is non-zero, the arrive is multicast across the cluster.
     Each bit set in the mask identifies a CTA ID dimension to multicast
     along. CTA IDs `a` and `b` belong to the same equivalence class iff
-    `a & ~ctaMask == b & ~ctaMask`; all CTAs in a class multicast to each
-    other. Multicast requires `numCTAs > 1`, `0 < ctaMask <= numCTAs - 1`,
+    `a & ~multicastCTA == b & ~multicastCTA`; all CTAs in a class multicast to each
+    other. Multicast requires `numCTAs > 1`, `0 < multicastCTA <= numCTAs - 1`,
     and the barrier must have the identity CGA layout `[[1], [2], ...]`. The
-    default value of `ctaMask` is 0 (no multicast).
+    default value of `multicastCTA` is 0 (no multicast).
 
-    The operation accepts an optional predicate and `from_ctas` attribute. The
+    The operation accepts an optional predicate and `fromCTA` attribute. The
     latter is a CTA-ID basis-selection mask: set bits are preserved and unset
     bits are zeroed when selecting the CTA that routes the arrival to each
-    per-CTA barrier. A non-identity `from_ctas` cannot be combined with
+    per-CTA barrier. A non-identity `fromCTA` cannot be combined with
     multicast.
 
     Example:
@@ -402,16 +402,16 @@ def TTNG_ArriveBarrierOp : TTNG_Op<"arrive_barrier", [
     ```mlir
     ttng.arrive_barrier %barrier, 2 : !ttg.memdesc<1xi64, #shared, #smem, mutable>
     ttng.arrive_barrier %barrier, 1, %pred : !ttg.memdesc<1xi64, #shared, #smem, mutable>
-    ttng.arrive_barrier %barrier, 1 {ctaMask = 1 : i32} : !ttg.memdesc<2xi64, #shared, #smem, mutable>
+    ttng.arrive_barrier %barrier, 1 {multicastCTA = 1 : i32} : !ttg.memdesc<2xi64, #shared, #smem, mutable>
     ```
   }];
 
   let arguments = (ins
     Arg<TTG_MemDescType, "", [MemRead<SharedMemory>, MemWrite<SharedMemory>]>:$alloc,
     I32Attr:$count,
-    DefaultValuedOptionalAttr<I32Attr, "0">:$ctaMask,
     Optional<I1>:$pred,
-    OptionalAttr<I32Attr>:$from_ctas
+    OptionalAttr<I32Attr>:$fromCTA,
+    DefaultValuedOptionalAttr<I32Attr, "0">:$multicastCTA
   );
 
   let assemblyFormat = [{
@@ -420,17 +420,17 @@ def TTNG_ArriveBarrierOp : TTNG_Op<"arrive_barrier", [
 
   let builders = [
     OpBuilder<(ins "Value":$alloc, "uint32_t":$count), [{
-      build($_builder, $_state, alloc, count, /*ctaMask=*/0u, /*pred=*/Value(),
-            /*from_ctas=*/IntegerAttr());
+      build($_builder, $_state, alloc, count, /*pred=*/Value(),
+            /*fromCTA=*/IntegerAttr(), /*multicastCTA=*/0u);
     }]>,
     OpBuilder<(ins "Value":$alloc, "uint32_t":$count, "Value":$pred), [{
-      build($_builder, $_state, alloc, count, /*ctaMask=*/0u, pred,
-            /*from_ctas=*/IntegerAttr());
+      build($_builder, $_state, alloc, count, pred, /*fromCTA=*/IntegerAttr(),
+            /*multicastCTA=*/0u);
     }]>
   ];
 
   let extraClassDeclaration = [{
-    bool isMulticast() { return getCtaMask() != 0; }
+    bool isMulticast() { return getMulticastCTA() != 0; }
   }];
 
   let hasVerifier = 1;

--- a/include/triton/Dialect/TritonNvidiaGPU/IR/TritonNvidiaGPUOps.td
+++ b/include/triton/Dialect/TritonNvidiaGPU/IR/TritonNvidiaGPUOps.td
@@ -298,15 +298,26 @@ def TTNG_BarrierExpectOp : TTNG_Op<"barrier_expect", [
   let description = [{
     This signals the barrier that `size` bytes are expected to be copied. The
     associated barrier wait will block until the expected number of bytes has
-    been copied.
+    been copied. The optional `from_ctas` attribute is a CTA-ID
+    basis-selection mask: set bits are preserved and unset bits are zeroed
+    when selecting the CTA that routes the arrival to each per-CTA barrier.
   }];
 
   let hasVerifier = 1;
+  let hasCanonicalizeMethod = 1;
   let arguments = (ins
     Arg<TTG_MemDescType, "", [MemWrite<SharedMemory>]>:$alloc,
     I32Attr:$size,
-    I1:$pred
+    I1:$pred,
+    OptionalAttr<I32Attr>:$from_ctas
   );
+
+  let builders = [
+    OpBuilder<(ins "Value":$alloc, "uint32_t":$size, "Value":$pred), [{
+      build($_builder, $_state, alloc, $_builder.getI32IntegerAttr(size), pred,
+            /*from_ctas=*/IntegerAttr());
+    }]>
+  ];
 
   let assemblyFormat = [{
     $alloc `,` $size attr-dict `,` $pred `:` qualified(type($alloc))
@@ -380,7 +391,11 @@ def TTNG_ArriveBarrierOp : TTNG_Op<"arrive_barrier", [
     and the barrier must have the identity CGA layout `[[1], [2], ...]`. The
     default value of `ctaMask` is 0 (no multicast).
 
-    The operation accepts an optional predicate.
+    The operation accepts an optional predicate and `from_ctas` attribute. The
+    latter is a CTA-ID basis-selection mask: set bits are preserved and unset
+    bits are zeroed when selecting the CTA that routes the arrival to each
+    per-CTA barrier. A non-identity `from_ctas` cannot be combined with
+    multicast.
 
     Example:
 
@@ -395,7 +410,8 @@ def TTNG_ArriveBarrierOp : TTNG_Op<"arrive_barrier", [
     Arg<TTG_MemDescType, "", [MemRead<SharedMemory>, MemWrite<SharedMemory>]>:$alloc,
     I32Attr:$count,
     DefaultValuedOptionalAttr<I32Attr, "0">:$ctaMask,
-    Optional<I1>:$pred
+    Optional<I1>:$pred,
+    OptionalAttr<I32Attr>:$from_ctas
   );
 
   let assemblyFormat = [{
@@ -404,10 +420,12 @@ def TTNG_ArriveBarrierOp : TTNG_Op<"arrive_barrier", [
 
   let builders = [
     OpBuilder<(ins "Value":$alloc, "uint32_t":$count), [{
-      build($_builder, $_state, alloc, count, /*ctaMask=*/0u, /*pred=*/Value());
+      build($_builder, $_state, alloc, count, /*ctaMask=*/0u, /*pred=*/Value(),
+            /*from_ctas=*/IntegerAttr());
     }]>,
     OpBuilder<(ins "Value":$alloc, "uint32_t":$count, "Value":$pred), [{
-      build($_builder, $_state, alloc, count, /*ctaMask=*/0u, pred);
+      build($_builder, $_state, alloc, count, /*ctaMask=*/0u, pred,
+            /*from_ctas=*/IntegerAttr());
     }]>
   ];
 
@@ -416,6 +434,7 @@ def TTNG_ArriveBarrierOp : TTNG_Op<"arrive_barrier", [
   }];
 
   let hasVerifier = 1;
+  let hasCanonicalizeMethod = 1;
 }
 
 def TTNG_AsyncCopyMbarrierArriveOp : TTNG_Op<"async_copy_mbarrier_arrive", [

--- a/lib/Dialect/Gluon/Transforms/CMakeLists.txt
+++ b/lib/Dialect/Gluon/Transforms/CMakeLists.txt
@@ -12,6 +12,7 @@ add_triton_library(GluonTransforms
   LINK_LIBS PUBLIC
   TritonIR
   TritonGPUIR
+  TritonNvidiaGPUIR
   GluonIR
   MLIRTransformUtils
 )

--- a/lib/Dialect/Gluon/Transforms/Canonicalize.cpp
+++ b/lib/Dialect/Gluon/Transforms/Canonicalize.cpp
@@ -61,6 +61,8 @@ void Canonicalize::runOnOperation() {
   IntToPtrOp::getCanonicalizationPatterns(patterns, ctx);
   ttg::WarpSpecializeOp::getCanonicalizationPatterns(patterns, ctx);
   ttg::WarpSpecializePartitionsOp::getCanonicalizationPatterns(patterns, ctx);
+  ttng::BarrierExpectOp::getCanonicalizationPatterns(patterns, ctx);
+  ttng::ArriveBarrierOp::getCanonicalizationPatterns(patterns, ctx);
 
   (void)applyPatternsGreedily(getOperation(), std::move(patterns));
 }

--- a/lib/Dialect/TritonInstrument/Transforms/ConcurrencySanitizer.cpp
+++ b/lib/Dialect/TritonInstrument/Transforms/ConcurrencySanitizer.cpp
@@ -550,10 +550,21 @@ Value getMemEffectCTAs(ImplicitLocOpBuilder &b, Operation *op) {
 }
 
 Value getBarrierRecipientCTAs(ImplicitLocOpBuilder &b, Operation *op) {
-  if (auto expectOp = dyn_cast<ttng::BarrierExpectOp>(op))
-    return getLeaderCTA(b, expectOp.getAlloc());
-  if (auto arriveOp = dyn_cast<ttng::ArriveBarrierOp>(op))
-    return getLeaderCTA(b, arriveOp.getAlloc());
+  if (isa<ttng::BarrierExpectOp, ttng::ArriveBarrierOp>(op)) {
+    Value barrier = cast<ttg::MBarrierOpInterface>(op).getBarrier();
+    std::optional<uint32_t> fromCTAs;
+    if (auto expectOp = dyn_cast<ttng::BarrierExpectOp>(op))
+      fromCTAs = expectOp.getFromCtas();
+    else
+      fromCTAs = cast<ttng::ArriveBarrierOp>(op).getFromCtas();
+    if (fromCTAs) {
+      int numCTAs = ttg::lookupNumCTAs(op);
+      uint32_t broadcastBits = ~*fromCTAs & (numCTAs - 1);
+      auto encoding = ttng::getTMAMulticastMaskEncoding(numCTAs, broadcastBits);
+      return createCTABitset(b, encoding.pattern, encoding.fixedBits);
+    }
+    return getLeaderCTA(b, barrier);
+  }
   if (auto arriveOp = dyn_cast<ttng::AsyncCopyMbarrierArriveOp>(op))
     return getLeaderCTA(b, arriveOp.getBarrier());
   if (auto tmaLoad = dyn_cast<ttng::TMALoadLikeOpInterface>(op)) {

--- a/lib/Dialect/TritonInstrument/Transforms/ConcurrencySanitizer.cpp
+++ b/lib/Dialect/TritonInstrument/Transforms/ConcurrencySanitizer.cpp
@@ -552,14 +552,14 @@ Value getMemEffectCTAs(ImplicitLocOpBuilder &b, Operation *op) {
 Value getBarrierRecipientCTAs(ImplicitLocOpBuilder &b, Operation *op) {
   if (isa<ttng::BarrierExpectOp, ttng::ArriveBarrierOp>(op)) {
     Value barrier = cast<ttg::MBarrierOpInterface>(op).getBarrier();
-    std::optional<uint32_t> fromCTAs;
+    std::optional<uint32_t> fromCTA;
     if (auto expectOp = dyn_cast<ttng::BarrierExpectOp>(op))
-      fromCTAs = expectOp.getFromCtas();
+      fromCTA = expectOp.getFromCTA();
     else
-      fromCTAs = cast<ttng::ArriveBarrierOp>(op).getFromCtas();
-    if (fromCTAs) {
+      fromCTA = cast<ttng::ArriveBarrierOp>(op).getFromCTA();
+    if (fromCTA) {
       int numCTAs = ttg::lookupNumCTAs(op);
-      uint32_t broadcastBits = ~*fromCTAs & (numCTAs - 1);
+      uint32_t broadcastBits = ~*fromCTA & (numCTAs - 1);
       auto encoding = ttng::getTMAMulticastMaskEncoding(numCTAs, broadcastBits);
       return createCTABitset(b, encoding.pattern, encoding.fixedBits);
     }

--- a/lib/Dialect/TritonNvidiaGPU/IR/Ops.cpp
+++ b/lib/Dialect/TritonNvidiaGPU/IR/Ops.cpp
@@ -193,11 +193,46 @@ LogicalResult InvalBarrierOp::verify() {
 
 TypedValue<MemDescType> InvalBarrierOp::getBarrier() { return getAlloc(); }
 
+static LogicalResult verifyBarrierFromCTAs(Operation *op, Value barrier,
+                                           std::optional<uint32_t> fromCTAs) {
+  if (!fromCTAs)
+    return success();
+
+  auto barrierTy = cast<MemDescType>(barrier.getType());
+  uint32_t numCTAs = gpu::lookupNumCTAs(op);
+  if (*fromCTAs >= numCTAs)
+    return op->emitOpError("from_ctas must be in the range [0, num_ctas - 1]");
+
+  auto expectedCGALayout =
+      CGAEncodingAttr::get1DLayout(op->getContext(), numCTAs);
+  if (barrierTy.getRank() != 1 || barrierTy.getNumElements() != numCTAs ||
+      getCGALayout(barrierTy.getEncoding()) != expectedCGALayout)
+    return op->emitOpError("from_ctas requires a 1D barrier with one element "
+                           "per CTA and canonical CGA layout");
+  return success();
+}
+
+template <typename BarrierOp>
+static LogicalResult canonicalizeBarrierFromCTAs(BarrierOp op,
+                                                 PatternRewriter &rewriter) {
+  if (op.getFromCtas() != gpu::lookupNumCTAs(op) - 1)
+    return failure();
+  rewriter.modifyOpInPlace(op, [&] { op.setFromCtasAttr(IntegerAttr()); });
+  return success();
+}
+
 // -- BarrierExpectOp --
 LogicalResult BarrierExpectOp::verify() {
   if (failed(verifyBarrierType(*this, getAlloc().getType())))
     return failure();
+  if (failed(verifyBarrierFromCTAs(*this, getAlloc(), getFromCtas())))
+    return failure();
   return success();
+}
+
+LogicalResult BarrierExpectOp::canonicalize(BarrierExpectOp op,
+                                            PatternRewriter &rewriter) {
+  return canonicalizeBarrierFromCTAs(op, rewriter);
 }
 
 TypedValue<MemDescType> BarrierExpectOp::getBarrier() { return getAlloc(); }
@@ -253,7 +288,17 @@ LogicalResult ArriveBarrierOp::verify() {
                                       "multicast barrier")))
       return failure();
   }
+  if (failed(verifyBarrierFromCTAs(*this, getAlloc(), getFromCtas())))
+    return failure();
+  if (isMulticast() && getFromCtas() &&
+      *getFromCtas() != gpu::lookupNumCTAs(getOperation()) - 1)
+    return emitOpError("from_ctas cannot be combined with multicast arrive");
   return success();
+}
+
+LogicalResult ArriveBarrierOp::canonicalize(ArriveBarrierOp op,
+                                            PatternRewriter &rewriter) {
+  return canonicalizeBarrierFromCTAs(op, rewriter);
 }
 
 TypedValue<MemDescType> ArriveBarrierOp::getBarrier() { return getAlloc(); }

--- a/lib/Dialect/TritonNvidiaGPU/IR/Ops.cpp
+++ b/lib/Dialect/TritonNvidiaGPU/IR/Ops.cpp
@@ -193,31 +193,31 @@ LogicalResult InvalBarrierOp::verify() {
 
 TypedValue<MemDescType> InvalBarrierOp::getBarrier() { return getAlloc(); }
 
-static LogicalResult verifyBarrierFromCTAs(Operation *op, Value barrier,
-                                           std::optional<uint32_t> fromCTAs) {
-  if (!fromCTAs)
+static LogicalResult verifyBarrierFromCTA(Operation *op, Value barrier,
+                                          std::optional<uint32_t> fromCTA) {
+  if (!fromCTA)
     return success();
 
   auto barrierTy = cast<MemDescType>(barrier.getType());
   uint32_t numCTAs = gpu::lookupNumCTAs(op);
-  if (*fromCTAs >= numCTAs)
-    return op->emitOpError("from_ctas must be in the range [0, num_ctas - 1]");
+  if (*fromCTA >= numCTAs)
+    return op->emitOpError("fromCTA must be in the range [0, num_ctas - 1]");
 
   auto expectedCGALayout =
       CGAEncodingAttr::get1DLayout(op->getContext(), numCTAs);
   if (barrierTy.getRank() != 1 || barrierTy.getNumElements() != numCTAs ||
       getCGALayout(barrierTy.getEncoding()) != expectedCGALayout)
-    return op->emitOpError("from_ctas requires a 1D barrier with one element "
+    return op->emitOpError("fromCTA requires a 1D barrier with one element "
                            "per CTA and canonical CGA layout");
   return success();
 }
 
 template <typename BarrierOp>
-static LogicalResult canonicalizeBarrierFromCTAs(BarrierOp op,
-                                                 PatternRewriter &rewriter) {
-  if (op.getFromCtas() != gpu::lookupNumCTAs(op) - 1)
+static LogicalResult canonicalizeBarrierFromCTA(BarrierOp op,
+                                                PatternRewriter &rewriter) {
+  if (op.getFromCTA() != gpu::lookupNumCTAs(op) - 1)
     return failure();
-  rewriter.modifyOpInPlace(op, [&] { op.setFromCtasAttr(IntegerAttr()); });
+  rewriter.modifyOpInPlace(op, [&] { op.setFromCTAAttr(IntegerAttr()); });
   return success();
 }
 
@@ -225,14 +225,14 @@ static LogicalResult canonicalizeBarrierFromCTAs(BarrierOp op,
 LogicalResult BarrierExpectOp::verify() {
   if (failed(verifyBarrierType(*this, getAlloc().getType())))
     return failure();
-  if (failed(verifyBarrierFromCTAs(*this, getAlloc(), getFromCtas())))
+  if (failed(verifyBarrierFromCTA(*this, getAlloc(), getFromCTA())))
     return failure();
   return success();
 }
 
 LogicalResult BarrierExpectOp::canonicalize(BarrierExpectOp op,
                                             PatternRewriter &rewriter) {
-  return canonicalizeBarrierFromCTAs(op, rewriter);
+  return canonicalizeBarrierFromCTA(op, rewriter);
 }
 
 TypedValue<MemDescType> BarrierExpectOp::getBarrier() { return getAlloc(); }
@@ -280,25 +280,25 @@ LogicalResult ArriveBarrierOp::verify() {
     int numCTAs = triton::gpu::lookupNumCTAs(getOperation());
     if (numCTAs <= 1)
       return emitOpError("multicast arrive requires num_ctas > 1");
-    if (getCtaMask() > static_cast<uint32_t>(numCTAs - 1))
-      return emitOpError("ctaMask exceeds numCTAs - 1");
+    if (getMulticastCTA() > static_cast<uint32_t>(numCTAs - 1))
+      return emitOpError("multicastCTA exceeds numCTAs - 1");
     auto expectedCGALayout =
         CGAEncodingAttr::get1DLayout(getContext(), numCTAs);
     if (failed(verifyBarrierCGALayout(*this, getAlloc(), expectedCGALayout,
                                       "multicast barrier")))
       return failure();
   }
-  if (failed(verifyBarrierFromCTAs(*this, getAlloc(), getFromCtas())))
+  if (failed(verifyBarrierFromCTA(*this, getAlloc(), getFromCTA())))
     return failure();
-  if (isMulticast() && getFromCtas() &&
-      *getFromCtas() != gpu::lookupNumCTAs(getOperation()) - 1)
-    return emitOpError("from_ctas cannot be combined with multicast arrive");
+  if (isMulticast() && getFromCTA() &&
+      *getFromCTA() != gpu::lookupNumCTAs(getOperation()) - 1)
+    return emitOpError("fromCTA cannot be combined with multicast arrive");
   return success();
 }
 
 LogicalResult ArriveBarrierOp::canonicalize(ArriveBarrierOp op,
                                             PatternRewriter &rewriter) {
-  return canonicalizeBarrierFromCTAs(op, rewriter);
+  return canonicalizeBarrierFromCTA(op, rewriter);
 }
 
 TypedValue<MemDescType> ArriveBarrierOp::getBarrier() { return getAlloc(); }

--- a/lib/Dialect/TritonNvidiaGPU/Transforms/ClusterBarrierInsertion.cpp
+++ b/lib/Dialect/TritonNvidiaGPU/Transforms/ClusterBarrierInsertion.cpp
@@ -129,10 +129,10 @@ usesTrackedBarrierInCrossCTAConsumerOp(Operation *op,
     return aliasesTracked(store.getMbarrier());
   }
   if (auto expect = dyn_cast<ttng::BarrierExpectOp>(op);
-      expect && expect.getFromCtas())
+      expect && expect.getFromCTA())
     return aliasesTracked(expect.getBarrier());
   if (auto arrive = dyn_cast<ttng::ArriveBarrierOp>(op))
-    return (arrive.isMulticast() || arrive.getFromCtas()) &&
+    return (arrive.isMulticast() || arrive.getFromCTA()) &&
            aliasesTracked(arrive.getAlloc());
   return false;
 }

--- a/lib/Dialect/TritonNvidiaGPU/Transforms/ClusterBarrierInsertion.cpp
+++ b/lib/Dialect/TritonNvidiaGPU/Transforms/ClusterBarrierInsertion.cpp
@@ -128,9 +128,12 @@ usesTrackedBarrierInCrossCTAConsumerOp(Operation *op,
   if (auto store = dyn_cast<ttng::AsyncSharedStoreOp>(op)) {
     return aliasesTracked(store.getMbarrier());
   }
-  if (auto arrive = dyn_cast<ttng::ArriveBarrierOp>(op)) {
-    return arrive.isMulticast() && aliasesTracked(arrive.getAlloc());
-  }
+  if (auto expect = dyn_cast<ttng::BarrierExpectOp>(op);
+      expect && expect.getFromCtas())
+    return aliasesTracked(expect.getBarrier());
+  if (auto arrive = dyn_cast<ttng::ArriveBarrierOp>(op))
+    return (arrive.isMulticast() || arrive.getFromCtas()) &&
+           aliasesTracked(arrive.getAlloc());
   return false;
 }
 

--- a/lib/Dialect/TritonNvidiaGPU/Transforms/ConSanNVIDIA.cpp
+++ b/lib/Dialect/TritonNvidiaGPU/Transforms/ConSanNVIDIA.cpp
@@ -115,6 +115,15 @@ public:
       mask = getBarrierMask(waitOp.getAlloc());
     if (auto invalOp = dyn_cast<ttng::InvalBarrierOp>(op))
       mask = getBarrierMask(invalOp.getAlloc());
+    if (isa<ttng::BarrierExpectOp, ttng::ArriveBarrierOp>(op)) {
+      std::optional<uint32_t> fromCTAs;
+      if (auto expectOp = dyn_cast<ttng::BarrierExpectOp>(op))
+        fromCTAs = expectOp.getFromCtas();
+      else
+        fromCTAs = cast<ttng::ArriveBarrierOp>(op).getFromCtas();
+      if (fromCTAs)
+        mask = ~*fromCTAs & (ttg::lookupNumCTAs(op) - 1);
+    }
     if (auto loadOp = dyn_cast<ttng::TMALoadLikeOpInterface>(op)) {
       if (loadOp.getMulticast())
         mask = getBlockBroadcastMask(loadOp.getResult().getType());

--- a/lib/Dialect/TritonNvidiaGPU/Transforms/ConSanNVIDIA.cpp
+++ b/lib/Dialect/TritonNvidiaGPU/Transforms/ConSanNVIDIA.cpp
@@ -116,13 +116,13 @@ public:
     if (auto invalOp = dyn_cast<ttng::InvalBarrierOp>(op))
       mask = getBarrierMask(invalOp.getAlloc());
     if (isa<ttng::BarrierExpectOp, ttng::ArriveBarrierOp>(op)) {
-      std::optional<uint32_t> fromCTAs;
+      std::optional<uint32_t> fromCTA;
       if (auto expectOp = dyn_cast<ttng::BarrierExpectOp>(op))
-        fromCTAs = expectOp.getFromCtas();
+        fromCTA = expectOp.getFromCTA();
       else
-        fromCTAs = cast<ttng::ArriveBarrierOp>(op).getFromCtas();
-      if (fromCTAs)
-        mask = ~*fromCTAs & (ttg::lookupNumCTAs(op) - 1);
+        fromCTA = cast<ttng::ArriveBarrierOp>(op).getFromCTA();
+      if (fromCTA)
+        mask = ~*fromCTA & (ttg::lookupNumCTAs(op) - 1);
     }
     if (auto loadOp = dyn_cast<ttng::TMALoadLikeOpInterface>(op)) {
       if (loadOp.getMulticast())

--- a/python/examples/gluon/03-matmul-multicta.py
+++ b/python/examples/gluon/03-matmul-multicta.py
@@ -344,7 +344,7 @@ def matmul_clc_partition(p):
         barrier = p.clc_barriers.index(state.index)
         result = p.clc_result_buffers.index(state.index)
         # 16: clc.try_cancel has a `.b128` modifier
-        mbarrier.expect(barrier, 16)
+        mbarrier.expect(barrier, 16, from_ctas=0x0)
         clc.try_cancel(result, barrier)
         mbarrier.wait(barrier, state.phase)
         clc_res = clc.load_result(result)

--- a/python/examples/gluon/03-matmul-multicta.py
+++ b/python/examples/gluon/03-matmul-multicta.py
@@ -344,7 +344,7 @@ def matmul_clc_partition(p):
         barrier = p.clc_barriers.index(state.index)
         result = p.clc_result_buffers.index(state.index)
         # 16: clc.try_cancel has a `.b128` modifier
-        mbarrier.expect(barrier, 16, from_ctas=0x0)
+        mbarrier.expect(barrier, 16, from_cta=0x0)
         clc.try_cancel(result, barrier)
         mbarrier.wait(barrier, state.phase)
         clc_res = clc.load_result(result)

--- a/python/examples/gluon/04-2cta-block-scale-matmul.py
+++ b/python/examples/gluon/04-2cta-block-scale-matmul.py
@@ -644,7 +644,7 @@ def mma_scaled_clc_partition(p):
         barrier = p.clc_barriers.index(state.index)
         result = p.clc_result_buffers.index(state.index)
         # 16: clc.try_cancel has a `.b128` modifier
-        mbarrier.expect(barrier, 16)
+        mbarrier.expect(barrier, 16, from_ctas=0x0)
         clc.try_cancel(result, barrier)
         mbarrier.wait(barrier, state.phase)
         clc_res = clc.load_result(result)

--- a/python/examples/gluon/04-2cta-block-scale-matmul.py
+++ b/python/examples/gluon/04-2cta-block-scale-matmul.py
@@ -644,7 +644,7 @@ def mma_scaled_clc_partition(p):
         barrier = p.clc_barriers.index(state.index)
         result = p.clc_result_buffers.index(state.index)
         # 16: clc.try_cancel has a `.b128` modifier
-        mbarrier.expect(barrier, 16, from_ctas=0x0)
+        mbarrier.expect(barrier, 16, from_cta=0x0)
         clc.try_cancel(result, barrier)
         mbarrier.wait(barrier, state.phase)
         clc_res = clc.load_result(result)

--- a/python/src/gluon_ir.cc
+++ b/python/src/gluon_ir.cc
@@ -939,20 +939,36 @@ void init_gluon_ir(py::module_ &m) {
            [](GluonOpBuilder &self, Value memDesc) {
              self.create<ttng::InvalBarrierOp>(memDesc);
            })
-      .def("create_mbarrier_expect",
-           [](GluonOpBuilder &self, Value memDesc, int bytes, Value pred) {
-             self.create<ttng::BarrierExpectOp>(memDesc, bytes, pred);
-           })
+      .def(
+          "create_mbarrier_expect",
+          [](GluonOpBuilder &self, Value memDesc, int bytes, Value pred,
+             std::optional<int> fromCTAs) {
+            IntegerAttr fromCTAsAttr =
+                fromCTAs ? self.getBuilder().getI32IntegerAttr(*fromCTAs)
+                         : IntegerAttr();
+            self.create<ttng::BarrierExpectOp>(memDesc, bytes, pred,
+                                               fromCTAsAttr);
+          },
+          py::arg("memDesc"), py::arg("bytes"), py::arg("pred"),
+          (py::arg("fromCTAs").none() = py::none()))
       .def("create_mbarrier_wait",
            [](GluonOpBuilder &self, Value memDesc, Value phase, Value pred,
               std::vector<Value> &deps) {
              self.create<ttng::WaitBarrierOp>(memDesc, phase, pred, deps);
            })
-      .def("create_mbarrier_arrive",
-           [](GluonOpBuilder &self, Value memDesc, uint32_t count,
-              uint32_t ctaMask, Value pred) {
-             self.create<ttng::ArriveBarrierOp>(memDesc, count, ctaMask, pred);
-           })
+      .def(
+          "create_mbarrier_arrive",
+          [](GluonOpBuilder &self, Value memDesc, uint32_t count,
+             uint32_t ctaMask, Value pred, std::optional<int> fromCTAs) {
+            IntegerAttr fromCTAsAttr =
+                fromCTAs ? self.getBuilder().getI32IntegerAttr(*fromCTAs)
+                         : IntegerAttr();
+            self.create<ttng::ArriveBarrierOp>(memDesc, count, ctaMask, pred,
+                                               fromCTAsAttr);
+          },
+          py::arg("memDesc"), py::arg("count"), py::arg("ctaMask"),
+          py::arg("pred"),
+          (py::arg("fromCTAs").none() = py::none()))
       .def(
           "create_cluster_barrier",
           [](GluonOpBuilder &self,

--- a/python/src/gluon_ir.cc
+++ b/python/src/gluon_ir.cc
@@ -942,15 +942,15 @@ void init_gluon_ir(py::module_ &m) {
       .def(
           "create_mbarrier_expect",
           [](GluonOpBuilder &self, Value memDesc, int bytes, Value pred,
-             std::optional<int> fromCTAs) {
-            IntegerAttr fromCTAsAttr =
-                fromCTAs ? self.getBuilder().getI32IntegerAttr(*fromCTAs)
-                         : IntegerAttr();
+             std::optional<int> fromCTA) {
+            IntegerAttr fromCTAAttr =
+                fromCTA ? self.getBuilder().getI32IntegerAttr(*fromCTA)
+                        : IntegerAttr();
             self.create<ttng::BarrierExpectOp>(memDesc, bytes, pred,
-                                               fromCTAsAttr);
+                                               fromCTAAttr);
           },
           py::arg("memDesc"), py::arg("bytes"), py::arg("pred"),
-          (py::arg("fromCTAs").none() = py::none()))
+          (py::arg("from_cta").none() = py::none()))
       .def("create_mbarrier_wait",
            [](GluonOpBuilder &self, Value memDesc, Value phase, Value pred,
               std::vector<Value> &deps) {
@@ -958,17 +958,17 @@ void init_gluon_ir(py::module_ &m) {
            })
       .def(
           "create_mbarrier_arrive",
-          [](GluonOpBuilder &self, Value memDesc, uint32_t count,
-             uint32_t ctaMask, Value pred, std::optional<int> fromCTAs) {
-            IntegerAttr fromCTAsAttr =
-                fromCTAs ? self.getBuilder().getI32IntegerAttr(*fromCTAs)
-                         : IntegerAttr();
-            self.create<ttng::ArriveBarrierOp>(memDesc, count, ctaMask, pred,
-                                               fromCTAsAttr);
+          [](GluonOpBuilder &self, Value memDesc, uint32_t count, Value pred,
+             std::optional<int> fromCTA, uint32_t multicastCTA) {
+            IntegerAttr fromCTAAttr =
+                fromCTA ? self.getBuilder().getI32IntegerAttr(*fromCTA)
+                        : IntegerAttr();
+            self.create<ttng::ArriveBarrierOp>(memDesc, count, pred,
+                                               fromCTAAttr, multicastCTA);
           },
-          py::arg("memDesc"), py::arg("count"), py::arg("ctaMask"),
-          py::arg("pred"),
-          (py::arg("fromCTAs").none() = py::none()))
+          py::arg("memDesc"), py::arg("count"), py::arg("pred"),
+          (py::arg("from_cta").none() = py::none()),
+          py::arg("multicast_cta") = 0)
       .def(
           "create_cluster_barrier",
           [](GluonOpBuilder &self,

--- a/python/test/gluon/test_consan.py
+++ b/python/test/gluon/test_consan.py
@@ -396,7 +396,7 @@ def test_clc_result_visibility(FAILURE, device, run_wrapper, monkeypatch, num_ct
         mbarrier.init(clc_bar, count=1)
 
         clc.try_cancel(clc_result, clc_bar)
-        mbarrier.expect(clc_bar, 16)
+        mbarrier.expect(clc_bar, 16, from_ctas=0x0)
         mbarrier.wait(clc_bar, 0, pred=(not FAILURE))
         response = clc.load_result(clc_result)
         mbarrier.wait(clc_bar, 0, pred=FAILURE)
@@ -429,9 +429,9 @@ def test_clc_double_try_cancel_result_overwrite(device, run_wrapper, monkeypatch
         mbarrier.init(bars.index(0), count=1)
         mbarrier.init(bars.index(1), count=1)
 
-        mbarrier.expect(bars.index(0), 16)
+        mbarrier.expect(bars.index(0), 16, from_ctas=0x0)
         clc.try_cancel(result, bars.index(0))
-        mbarrier.expect(bars.index(1), 16)
+        mbarrier.expect(bars.index(1), 16, from_ctas=0x0)
         clc.try_cancel(result, bars.index(1))
 
         mbarrier.wait(bars.index(0), 0)
@@ -460,7 +460,7 @@ def test_clc_result_reuse_after_cluster_barrier(device, run_wrapper, monkeypatch
         clc_bar = mbarrier.allocate_mbarrier()
         mbarrier.init(clc_bar, count=1)
 
-        mbarrier.expect(clc_bar, 16)
+        mbarrier.expect(clc_bar, 16, from_ctas=0x0)
         clc.try_cancel(clc_result, clc_bar)
         mbarrier.wait(clc_bar, 0)
         first = clc.load_result(clc_result)
@@ -469,7 +469,7 @@ def test_clc_result_reuse_after_cluster_barrier(device, run_wrapper, monkeypatch
         # next multi-CTA CLC request.
         hopper.fence_async_shared()
 
-        mbarrier.expect(clc_bar, 16)
+        mbarrier.expect(clc_bar, 16, from_ctas=0x0)
         clc.try_cancel(clc_result, clc_bar)
         mbarrier.wait(clc_bar, 1)
         second = clc.load_result(clc_result)
@@ -477,6 +477,62 @@ def test_clc_result_reuse_after_cluster_barrier(device, run_wrapper, monkeypatch
 
     output = torch.empty((1, ), device=device, dtype=torch.bool)
     kernel[(1, )](output, num_warps=4, num_ctas=2)
+
+
+@pytest.mark.skipif(not is_cuda() or torch.cuda.get_device_capability()[0] < 10, reason="Requires blackwell")
+@pytest.mark.parametrize("SYNCHRONIZED", [False, True], ids=["local-expect", "from-ctas0-expect"])
+def test_clc_slot_reuse_from_ctas(SYNCHRONIZED, device, run_wrapper, monkeypatch):
+    if run_wrapper:
+        result = run_in_process(test_clc_slot_reuse_from_ctas, (SYNCHRONIZED, device, False, monkeypatch))
+        if SYNCHRONIZED:
+            assert result.exc is None
+            assert result.driver_stderr_output == ""
+        else:
+            assert_expected_cuda_failure(result.exc)
+            assert "Buffer being accessed has outstanding reads" in result.driver_stderr_output
+        return
+
+    monkeypatch.setenv("TRITON_INSTRUMENTATION_MODE", "consan")
+    monkeypatch.setenv("CUDA_LAUNCH_BLOCKING", "1")
+    knobs.refresh_knobs()
+
+    @gluon.jit
+    def consumer(slot, sink, consumed, layout: ttgl.constexpr):
+        value = slot.load(layout)
+        sink.store(value)
+        mbarrier.arrive(consumed, count=1)
+
+    @gluon.jit
+    def clc_partition(slot, result, clc_bar, consumed, SYNCHRONIZED: ttgl.constexpr, layout: ttgl.constexpr):
+        mbarrier.wait(consumed, 0, deps=[slot])
+        if SYNCHRONIZED:
+            mbarrier.expect(clc_bar, 16, from_ctas=0x0)
+        else:
+            mbarrier.expect(clc_bar, 16)
+        clc.try_cancel(result, clc_bar)
+        mbarrier.wait(clc_bar, 0)
+        clc.load_result(result)
+        slot.store(ttgl.full([1], 1, ttgl.int64, layout=layout))
+
+    @gluon.jit
+    def kernel(SYNCHRONIZED: ttgl.constexpr):
+        cga_layout: ttgl.constexpr = multicast_cga_layout(ttgl.num_ctas(), 1)
+        shared_layout: ttgl.constexpr = ttgl.SwizzledSharedLayout(1, 1, 1, order=[0], cga_layout=cga_layout)
+        layout: ttgl.constexpr = ttgl.BlockedLayout([1], [32], [4], [0], cga_layout=cga_layout)
+        slot = ttgl.allocate_shared_memory(ttgl.int64, [1], shared_layout)
+        sink = ttgl.allocate_shared_memory(ttgl.int64, [1], shared_layout)
+        result = ttgl.allocate_shared_memory(ttgl.int64, [2], shared_layout)
+        clc_bar = mbarrier.allocate_mbarrier()
+        consumed = mbarrier.allocate_mbarrier(two_ctas=True)
+        mbarrier.init(clc_bar, count=1)
+        mbarrier.init(consumed, count=1)
+        slot.store(ttgl.full([1], 0, ttgl.int64, layout=layout))
+        ttgl.warp_specialize([
+            (consumer, (slot, sink, consumed, layout)),
+            (clc_partition, (slot, result, clc_bar, consumed, SYNCHRONIZED, layout)),
+        ], [4], [32])
+
+    kernel[(1, )](SYNCHRONIZED=SYNCHRONIZED, num_warps=4, num_ctas=2)
 
 
 @pytest.mark.skipif(not is_cuda() or torch.cuda.get_device_capability()[0] < 9, reason="Requires hopper or newer")

--- a/python/test/gluon/test_consan.py
+++ b/python/test/gluon/test_consan.py
@@ -396,7 +396,7 @@ def test_clc_result_visibility(FAILURE, device, run_wrapper, monkeypatch, num_ct
         mbarrier.init(clc_bar, count=1)
 
         clc.try_cancel(clc_result, clc_bar)
-        mbarrier.expect(clc_bar, 16, from_ctas=0x0)
+        mbarrier.expect(clc_bar, 16, from_cta=0x0)
         mbarrier.wait(clc_bar, 0, pred=(not FAILURE))
         response = clc.load_result(clc_result)
         mbarrier.wait(clc_bar, 0, pred=FAILURE)
@@ -429,9 +429,9 @@ def test_clc_double_try_cancel_result_overwrite(device, run_wrapper, monkeypatch
         mbarrier.init(bars.index(0), count=1)
         mbarrier.init(bars.index(1), count=1)
 
-        mbarrier.expect(bars.index(0), 16, from_ctas=0x0)
+        mbarrier.expect(bars.index(0), 16, from_cta=0x0)
         clc.try_cancel(result, bars.index(0))
-        mbarrier.expect(bars.index(1), 16, from_ctas=0x0)
+        mbarrier.expect(bars.index(1), 16, from_cta=0x0)
         clc.try_cancel(result, bars.index(1))
 
         mbarrier.wait(bars.index(0), 0)
@@ -460,7 +460,7 @@ def test_clc_result_reuse_after_cluster_barrier(device, run_wrapper, monkeypatch
         clc_bar = mbarrier.allocate_mbarrier()
         mbarrier.init(clc_bar, count=1)
 
-        mbarrier.expect(clc_bar, 16, from_ctas=0x0)
+        mbarrier.expect(clc_bar, 16, from_cta=0x0)
         clc.try_cancel(clc_result, clc_bar)
         mbarrier.wait(clc_bar, 0)
         first = clc.load_result(clc_result)
@@ -469,7 +469,7 @@ def test_clc_result_reuse_after_cluster_barrier(device, run_wrapper, monkeypatch
         # next multi-CTA CLC request.
         hopper.fence_async_shared()
 
-        mbarrier.expect(clc_bar, 16, from_ctas=0x0)
+        mbarrier.expect(clc_bar, 16, from_cta=0x0)
         clc.try_cancel(clc_result, clc_bar)
         mbarrier.wait(clc_bar, 1)
         second = clc.load_result(clc_result)
@@ -480,10 +480,10 @@ def test_clc_result_reuse_after_cluster_barrier(device, run_wrapper, monkeypatch
 
 
 @pytest.mark.skipif(not is_cuda() or torch.cuda.get_device_capability()[0] < 10, reason="Requires blackwell")
-@pytest.mark.parametrize("SYNCHRONIZED", [False, True], ids=["local-expect", "from-ctas0-expect"])
-def test_clc_slot_reuse_from_ctas(SYNCHRONIZED, device, run_wrapper, monkeypatch):
+@pytest.mark.parametrize("SYNCHRONIZED", [False, True], ids=["local-expect", "from-cta0-expect"])
+def test_clc_slot_reuse_from_cta(SYNCHRONIZED, device, run_wrapper, monkeypatch):
     if run_wrapper:
-        result = run_in_process(test_clc_slot_reuse_from_ctas, (SYNCHRONIZED, device, False, monkeypatch))
+        result = run_in_process(test_clc_slot_reuse_from_cta, (SYNCHRONIZED, device, False, monkeypatch))
         if SYNCHRONIZED:
             assert result.exc is None
             assert result.driver_stderr_output == ""
@@ -506,7 +506,7 @@ def test_clc_slot_reuse_from_ctas(SYNCHRONIZED, device, run_wrapper, monkeypatch
     def clc_partition(slot, result, clc_bar, consumed, SYNCHRONIZED: ttgl.constexpr, layout: ttgl.constexpr):
         mbarrier.wait(consumed, 0, deps=[slot])
         if SYNCHRONIZED:
-            mbarrier.expect(clc_bar, 16, from_ctas=0x0)
+            mbarrier.expect(clc_bar, 16, from_cta=0x0)
         else:
             mbarrier.expect(clc_bar, 16)
         clc.try_cancel(result, clc_bar)

--- a/python/test/gluon/test_core.py
+++ b/python/test/gluon/test_core.py
@@ -4935,7 +4935,7 @@ def test_clc_basic(num_ctas):
         dummy = ttgl.allocate_shared_memory(ttgl.int64, [smem_size // 8 - 32], clc_mbar.layout)
 
         clc.try_cancel(clc_result, clc_mbar)
-        mbarrier.expect(clc_mbar, 16)
+        mbarrier.expect(clc_mbar, 16, from_ctas=0x0)
         mbarrier.wait(clc_mbar, 0)
 
         response = clc.load_result(clc_result)

--- a/python/test/gluon/test_core.py
+++ b/python/test/gluon/test_core.py
@@ -738,7 +738,7 @@ def test_async_copy_mbarrier():
     torch.testing.assert_close(out[20:], torch.zeros((12, 32), **tensor_opts))
 
 
-# Equivalence-class multicast: cta_mask selects which CTA-ID bits to multicast
+# Equivalence-class multicast: multicast_cta selects which CTA-ID bits to multicast
 # along.  Two CTAs share a class when (id_a & ~mask) == (id_b & ~mask).
 #
 #   CTA ID   0x0  0x1  0x2  0x3  0x4  0x5  0x6  0x7
@@ -746,33 +746,33 @@ def test_async_copy_mbarrier():
 #   classes: {0,1,4,5}, {2,3,6,7}  (groups of 4)
 #
 # Multicast requires the identity CGA layout, so two_ctas barriers are not
-# supported. All legal cta_mask values are tested; cta_mask=0 exercises the
+# supported. All legal multicast_cta values are tested; multicast_cta=0 exercises the
 # non-multicast path.
 @pytest.mark.parametrize("num_ctas", [2, 4, 8])
-@pytest.mark.parametrize("cta_mask", range(8))
+@pytest.mark.parametrize("multicast_cta", range(8))
 @pytest.mark.skipif(not is_rubin(), reason="Requires Rubin")
-def test_mbarrier_arrive_multicast(num_ctas, cta_mask):
-    if cta_mask >= num_ctas:
-        pytest.skip("cta_mask must be < num_ctas")
-    init_count = 1 << cta_mask.bit_count()
+def test_mbarrier_arrive_multicast(num_ctas, multicast_cta):
+    if multicast_cta >= num_ctas:
+        pytest.skip("multicast_cta must be < num_ctas")
+    init_count = 1 << multicast_cta.bit_count()
 
     @gluon.jit
-    def kernel(out_ptr, cta_mask: ttgl.constexpr, init_count: ttgl.constexpr):
+    def kernel(out_ptr, multicast_cta: ttgl.constexpr, init_count: ttgl.constexpr):
         bar = rubin.mbarrier.allocate_mbarrier()
         rubin.mbarrier.init(bar, count=init_count)
-        rubin.mbarrier.arrive(bar, cta_mask=cta_mask)
+        rubin.mbarrier.arrive(bar, multicast_cta=multicast_cta)
         rubin.mbarrier.wait(bar, 0)
         rubin.mbarrier.invalidate(bar)
         ttgl.store(out_ptr + ttgl.program_id(0), ttgl.program_id(0))
 
     out = torch.zeros(num_ctas, device="cuda", dtype=torch.int32)
-    compiled = kernel[(num_ctas, )](out, cta_mask, init_count, num_ctas=num_ctas, num_warps=4)
+    compiled = kernel[(num_ctas, )](out, multicast_cta, init_count, num_ctas=num_ctas, num_warps=4)
 
     ttgir = compiled.asm["ttgir"]
-    if cta_mask:
-        assert f"ctaMask = {cta_mask} : i32" in ttgir, "Expected ctaMask in TTGIR"
+    if multicast_cta:
+        assert f"multicastCTA = {multicast_cta} : i32" in ttgir, "Expected multicastCTA in TTGIR"
     else:
-        assert "ctaMask" not in ttgir, "Expected no ctaMask in TTGIR"
+        assert "multicastCTA" not in ttgir, "Expected no multicastCTA in TTGIR"
 
     torch.testing.assert_close(out, torch.arange(num_ctas, device="cuda", dtype=torch.int32))
 
@@ -782,7 +782,7 @@ def test_mbarrier_arrive_multicast(num_ctas, cta_mask):
 def test_mbarrier_arrive_broadcast_one_cta(num_ctas):
 
     @gluon.jit
-    def kernel(out_ptr, cta_mask: ttgl.constexpr):
+    def kernel(out_ptr, multicast_cta: ttgl.constexpr):
         pid = ttgl.program_id(0)
         cta_rank = ttgl.inline_asm_elementwise(
             "mov.u32 $0, %cluster_ctarank;",
@@ -795,7 +795,7 @@ def test_mbarrier_arrive_broadcast_one_cta(num_ctas):
         bar = rubin.mbarrier.allocate_mbarrier()
         rubin.mbarrier.init(bar, count=1)
         # CTA 0 does a multicast arrive, all CTAs wait.
-        rubin.mbarrier.arrive(bar, cta_mask=cta_mask, pred=cta_rank == 0)
+        rubin.mbarrier.arrive(bar, multicast_cta=multicast_cta, pred=cta_rank == 0)
         rubin.mbarrier.wait(bar, 0)
         rubin.mbarrier.invalidate(bar)
         ttgl.store(out_ptr + pid, pid)
@@ -4935,7 +4935,7 @@ def test_clc_basic(num_ctas):
         dummy = ttgl.allocate_shared_memory(ttgl.int64, [smem_size // 8 - 32], clc_mbar.layout)
 
         clc.try_cancel(clc_result, clc_mbar)
-        mbarrier.expect(clc_mbar, 16, from_ctas=0x0)
+        mbarrier.expect(clc_mbar, 16, from_cta=0x0)
         mbarrier.wait(clc_mbar, 0)
 
         response = clc.load_result(clc_result)

--- a/python/test/gluon/test_frontend.py
+++ b/python/test/gluon/test_frontend.py
@@ -641,6 +641,31 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.targ
 
 
 @gluon.jit
+def mbarrier_from_ctas_kernel():
+    bar = mbarrier.allocate_mbarrier()
+    mbarrier.expect(bar, 4, from_ctas=5)
+    mbarrier.arrive(bar, count=1, from_ctas=5)
+
+
+def test_mbarrier_from_ctas():
+    mod = run_parser(mbarrier_from_ctas_kernel, *make_args(num_ctas=8), target=HOPPER_TARGET)
+    ir = anonymize_ir(mod.str_nodebug())
+    assert re.search(r"ttng\.barrier_expect %\d+, 4 \{from_ctas = 5 : i32\}, %true", ir)
+    assert re.search(r"ttng\.arrive_barrier %\d+, 1, %true_\d+ \{from_ctas = 5 : i32\}", ir)
+
+
+def test_rubin_mbarrier_arrive_from_ctas():
+
+    @gluon.jit
+    def kernel():
+        bar = rubin.mbarrier.allocate_mbarrier()
+        rubin.mbarrier.arrive(bar, from_ctas=0)
+
+    mod = run_parser(kernel, *make_args(num_ctas=2), target=RUBIN_TARGET)
+    assert "from_ctas = 0 : i32" in anonymize_ir(mod.str_nodebug())
+
+
+@gluon.jit
 def async_shared_store_kernel():
     layout: ttgl.constexpr = ttgl.BlockedLayout([1], [32], [4], [0], cga_layout=[[0]])
     shared_layout: ttgl.constexpr = ttgl.SwizzledSharedLayout(1, 1, 1, order=[0], cga_layout=[[0]])

--- a/python/test/gluon/test_frontend.py
+++ b/python/test/gluon/test_frontend.py
@@ -641,28 +641,28 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.targ
 
 
 @gluon.jit
-def mbarrier_from_ctas_kernel():
+def mbarrier_from_cta_kernel():
     bar = mbarrier.allocate_mbarrier()
-    mbarrier.expect(bar, 4, from_ctas=5)
-    mbarrier.arrive(bar, count=1, from_ctas=5)
+    mbarrier.expect(bar, 4, from_cta=5)
+    mbarrier.arrive(bar, count=1, from_cta=5)
 
 
-def test_mbarrier_from_ctas():
-    mod = run_parser(mbarrier_from_ctas_kernel, *make_args(num_ctas=8), target=HOPPER_TARGET)
+def test_mbarrier_from_cta():
+    mod = run_parser(mbarrier_from_cta_kernel, *make_args(num_ctas=8), target=HOPPER_TARGET)
     ir = anonymize_ir(mod.str_nodebug())
-    assert re.search(r"ttng\.barrier_expect %\d+, 4 \{from_ctas = 5 : i32\}, %true", ir)
-    assert re.search(r"ttng\.arrive_barrier %\d+, 1, %true_\d+ \{from_ctas = 5 : i32\}", ir)
+    assert re.search(r"ttng\.barrier_expect %\d+, 4 \{fromCTA = 5 : i32\}, %true", ir)
+    assert re.search(r"ttng\.arrive_barrier %\d+, 1, %true_\d+ \{fromCTA = 5 : i32\}", ir)
 
 
-def test_rubin_mbarrier_arrive_from_ctas():
+def test_rubin_mbarrier_arrive_from_cta():
 
     @gluon.jit
     def kernel():
         bar = rubin.mbarrier.allocate_mbarrier()
-        rubin.mbarrier.arrive(bar, from_ctas=0)
+        rubin.mbarrier.arrive(bar, from_cta=0)
 
     mod = run_parser(kernel, *make_args(num_ctas=2), target=RUBIN_TARGET)
-    assert "from_ctas = 0 : i32" in anonymize_ir(mod.str_nodebug())
+    assert "fromCTA = 0 : i32" in anonymize_ir(mod.str_nodebug())
 
 
 @gluon.jit
@@ -716,9 +716,9 @@ def test_mbarrier_arrive_multicast_not_exposed_on_blackwell():
     @gluon.jit
     def kernel():
         bar = ttgl.allocate_shared_memory(ttgl.int64, [1], mbarrier.MBarrierLayout())
-        mbarrier.arrive(bar, count=1, cta_mask=0x1)
+        mbarrier.arrive(bar, count=1, multicast_cta=0x1)
 
-    with pytest.raises(CompilationError, match="cta_mask"):
+    with pytest.raises(CompilationError, match="multicast_cta"):
         run_parser(kernel, *make_args(num_ctas=2), target=BLACKWELL_TARGET)
 
 
@@ -727,12 +727,12 @@ def test_mbarrier_arrive_multicast_negative_mask():
     @gluon.jit
     def kernel():
         bar = ttgl.allocate_shared_memory(ttgl.int64, [1], rubin.mbarrier.MBarrierLayout())
-        rubin.mbarrier.arrive(bar, count=1, cta_mask=-1)
+        rubin.mbarrier.arrive(bar, count=1, multicast_cta=-1)
 
     with pytest.raises(CompilationError) as e:
         run_parser(kernel, *make_args(num_ctas=2), target=RUBIN_TARGET)
 
-    assert "cta_mask must be positive" in str(e.value)
+    assert "multicast_cta must be positive" in str(e.value)
 
 
 def test_mbarrier_arrive_multicast_mask_too_large():
@@ -740,12 +740,12 @@ def test_mbarrier_arrive_multicast_mask_too_large():
     @gluon.jit
     def kernel():
         bar = ttgl.allocate_shared_memory(ttgl.int64, [1], rubin.mbarrier.MBarrierLayout())
-        rubin.mbarrier.arrive(bar, count=1, cta_mask=2)
+        rubin.mbarrier.arrive(bar, count=1, multicast_cta=2)
 
     with pytest.raises(CompilationError) as e:
         run_parser(kernel, *make_args(num_ctas=2), target=RUBIN_TARGET)
 
-    assert "cta_mask must be <= num_ctas - 1" in str(e.value)
+    assert "multicast_cta must be <= num_ctas - 1" in str(e.value)
 
 
 def test_mbarrier_arrive_multicast_non_int_mask():
@@ -753,12 +753,12 @@ def test_mbarrier_arrive_multicast_non_int_mask():
     @gluon.jit
     def kernel():
         bar = ttgl.allocate_shared_memory(ttgl.int64, [1], rubin.mbarrier.MBarrierLayout())
-        rubin.mbarrier.arrive(bar, count=1, cta_mask=1.5)
+        rubin.mbarrier.arrive(bar, count=1, multicast_cta=1.5)
 
     with pytest.raises(CompilationError) as e:
         run_parser(kernel, *make_args(num_ctas=2), target=RUBIN_TARGET)
 
-    assert "cta_mask must be an int" in str(e.value)
+    assert "multicast_cta must be an int" in str(e.value)
 
 
 @gluon.jit

--- a/python/triton/experimental/gluon/language/nvidia/ampere/mbarrier.py
+++ b/python/triton/experimental/gluon/language/nvidia/ampere/mbarrier.py
@@ -108,15 +108,19 @@ def wait(mbarrier, phase, pred=True, deps=(), _semantic=None):
 
 
 @builtin
-def arrive(mbarrier, *, pred=True, _semantic=None):
+def arrive(mbarrier, *, pred=True, from_ctas=None, _semantic=None):
     """
     Arrive on an mbarrier, signaling that a thread has reached the barrier.
 
     Args:
         mbarrier (shared_memory_descriptor): The barrier object to arrive on.
         pred (bool): Predicate. Operation is skipped if predicate is False. Defaults to True.
+        from_ctas (int, optional): Mask of CTA-ID bits preserved when routing the arrival, in
+            ``[0, num_ctas - 1]``. Defaults to ``num_ctas - 1``, which arrives from each CTA to itself; ``0``
+            routes from CTA 0 to every CTA.
     """
     count = 1
     cta_mask = 0
     pred = _semantic.to_tensor(pred)
-    _semantic.builder.create_mbarrier_arrive(mbarrier.handle, count, cta_mask, pred.handle)
+    from_ctas = _unwrap_if_constexpr(from_ctas)
+    _semantic.builder.create_mbarrier_arrive(mbarrier.handle, count, cta_mask, pred.handle, from_ctas)

--- a/python/triton/experimental/gluon/language/nvidia/ampere/mbarrier.py
+++ b/python/triton/experimental/gluon/language/nvidia/ampere/mbarrier.py
@@ -108,19 +108,19 @@ def wait(mbarrier, phase, pred=True, deps=(), _semantic=None):
 
 
 @builtin
-def arrive(mbarrier, *, pred=True, from_ctas=None, _semantic=None):
+def arrive(mbarrier, *, pred=True, from_cta=None, _semantic=None):
     """
     Arrive on an mbarrier, signaling that a thread has reached the barrier.
 
     Args:
         mbarrier (shared_memory_descriptor): The barrier object to arrive on.
         pred (bool): Predicate. Operation is skipped if predicate is False. Defaults to True.
-        from_ctas (int, optional): Mask of CTA-ID bits preserved when routing the arrival, in
+        from_cta (int, optional): Mask of CTA-ID bits preserved when routing the arrival, in
             ``[0, num_ctas - 1]``. Defaults to ``num_ctas - 1``, which arrives from each CTA to itself; ``0``
             routes from CTA 0 to every CTA.
     """
     count = 1
-    cta_mask = 0
+    multicast_cta = 0
+    from_cta = _unwrap_if_constexpr(from_cta)
     pred = _semantic.to_tensor(pred)
-    from_ctas = _unwrap_if_constexpr(from_ctas)
-    _semantic.builder.create_mbarrier_arrive(mbarrier.handle, count, cta_mask, pred.handle, from_ctas)
+    _semantic.builder.create_mbarrier_arrive(mbarrier.handle, count, pred.handle, from_cta, multicast_cta)

--- a/python/triton/experimental/gluon/language/nvidia/hopper/mbarrier.py
+++ b/python/triton/experimental/gluon/language/nvidia/hopper/mbarrier.py
@@ -13,7 +13,7 @@ __all__ = [
 
 
 @builtin
-def expect(mbarrier, bytes_per_cta=None, pred=True, from_ctas=None, _semantic=None):
+def expect(mbarrier, bytes_per_cta=None, pred=True, *, from_cta=None, _semantic=None):
     """
     Expect a specific number of bytes being copied. When they are copied, the barrier is signaled.
 
@@ -21,18 +21,18 @@ def expect(mbarrier, bytes_per_cta=None, pred=True, from_ctas=None, _semantic=No
         mbarrier (shared_memory_descriptor): Barrier that will be signaled when the operation is complete.
         bytes_per_cta (int): Expected byte count per CTA.
         pred (bool): Scalar predicate. Operation is skipped if predicate is False. Defaults to True.
-        from_ctas (int, optional): Mask of CTA-ID bits preserved when routing the arrival, in
+        from_cta (int, optional): Mask of CTA-ID bits preserved when routing the arrival, in
             ``[0, num_ctas - 1]``. Defaults to ``num_ctas - 1``, which arrives from each CTA to itself; ``0``
             routes from CTA 0 to every CTA.
     """
-    pred = _semantic.to_tensor(pred)
     bytes_per_cta = _unwrap_if_constexpr(bytes_per_cta)
-    from_ctas = _unwrap_if_constexpr(from_ctas)
-    _semantic.builder.create_mbarrier_expect(mbarrier.handle, bytes_per_cta, pred.handle, from_ctas)
+    from_cta = _unwrap_if_constexpr(from_cta)
+    pred = _semantic.to_tensor(pred)
+    _semantic.builder.create_mbarrier_expect(mbarrier.handle, bytes_per_cta, pred.handle, from_cta)
 
 
 @builtin
-def arrive(mbarrier, *, count=1, pred=True, from_ctas=None, _semantic=None):
+def arrive(mbarrier, *, count=1, pred=True, from_cta=None, _semantic=None):
     """
     Arrive at an mbarrier with a specified count.
 
@@ -40,12 +40,12 @@ def arrive(mbarrier, *, count=1, pred=True, from_ctas=None, _semantic=None):
         mbarrier (shared_memory_descriptor): Barrier to be signalled.
         count (int): Count to arrive with. Defaults to 1.
         pred (bool): Scalar predicate. Operation is skipped if predicate is False. Defaults to True.
-        from_ctas (int, optional): Mask of CTA-ID bits preserved when routing the arrival, in
+        from_cta (int, optional): Mask of CTA-ID bits preserved when routing the arrival, in
             ``[0, num_ctas - 1]``. Defaults to ``num_ctas - 1``, which arrives from each CTA to itself; ``0``
             routes from CTA 0 to every CTA.
     """
     count = _unwrap_if_constexpr(count)
-    cta_mask = 0
+    multicast_cta = 0
+    from_cta = _unwrap_if_constexpr(from_cta)
     pred = _semantic.to_tensor(pred)
-    from_ctas = _unwrap_if_constexpr(from_ctas)
-    _semantic.builder.create_mbarrier_arrive(mbarrier.handle, count, cta_mask, pred.handle, from_ctas)
+    _semantic.builder.create_mbarrier_arrive(mbarrier.handle, count, pred.handle, from_cta, multicast_cta)

--- a/python/triton/experimental/gluon/language/nvidia/hopper/mbarrier.py
+++ b/python/triton/experimental/gluon/language/nvidia/hopper/mbarrier.py
@@ -13,7 +13,7 @@ __all__ = [
 
 
 @builtin
-def expect(mbarrier, bytes_per_cta=None, pred=True, _semantic=None):
+def expect(mbarrier, bytes_per_cta=None, pred=True, from_ctas=None, _semantic=None):
     """
     Expect a specific number of bytes being copied. When they are copied, the barrier is signaled.
 
@@ -21,14 +21,18 @@ def expect(mbarrier, bytes_per_cta=None, pred=True, _semantic=None):
         mbarrier (shared_memory_descriptor): Barrier that will be signaled when the operation is complete.
         bytes_per_cta (int): Expected byte count per CTA.
         pred (bool): Scalar predicate. Operation is skipped if predicate is False. Defaults to True.
+        from_ctas (int, optional): Mask of CTA-ID bits preserved when routing the arrival, in
+            ``[0, num_ctas - 1]``. Defaults to ``num_ctas - 1``, which arrives from each CTA to itself; ``0``
+            routes from CTA 0 to every CTA.
     """
     pred = _semantic.to_tensor(pred)
     bytes_per_cta = _unwrap_if_constexpr(bytes_per_cta)
-    _semantic.builder.create_mbarrier_expect(mbarrier.handle, bytes_per_cta, pred.handle)
+    from_ctas = _unwrap_if_constexpr(from_ctas)
+    _semantic.builder.create_mbarrier_expect(mbarrier.handle, bytes_per_cta, pred.handle, from_ctas)
 
 
 @builtin
-def arrive(mbarrier, *, count=1, pred=True, _semantic=None):
+def arrive(mbarrier, *, count=1, pred=True, from_ctas=None, _semantic=None):
     """
     Arrive at an mbarrier with a specified count.
 
@@ -36,8 +40,12 @@ def arrive(mbarrier, *, count=1, pred=True, _semantic=None):
         mbarrier (shared_memory_descriptor): Barrier to be signalled.
         count (int): Count to arrive with. Defaults to 1.
         pred (bool): Scalar predicate. Operation is skipped if predicate is False. Defaults to True.
+        from_ctas (int, optional): Mask of CTA-ID bits preserved when routing the arrival, in
+            ``[0, num_ctas - 1]``. Defaults to ``num_ctas - 1``, which arrives from each CTA to itself; ``0``
+            routes from CTA 0 to every CTA.
     """
     count = _unwrap_if_constexpr(count)
     cta_mask = 0
     pred = _semantic.to_tensor(pred)
-    _semantic.builder.create_mbarrier_arrive(mbarrier.handle, count, cta_mask, pred.handle)
+    from_ctas = _unwrap_if_constexpr(from_ctas)
+    _semantic.builder.create_mbarrier_arrive(mbarrier.handle, count, cta_mask, pred.handle, from_ctas)

--- a/python/triton/experimental/gluon/language/nvidia/rubin/mbarrier.py
+++ b/python/triton/experimental/gluon/language/nvidia/rubin/mbarrier.py
@@ -20,7 +20,7 @@ __all__ = [
 
 
 @builtin
-def arrive(mbarrier, *, count=1, cta_mask=0, pred=True, _semantic=None):
+def arrive(mbarrier, *, count=1, cta_mask=0, pred=True, from_ctas=None, _semantic=None):
     """
     Arrive at an mbarrier with a specified count.
 
@@ -39,6 +39,9 @@ def arrive(mbarrier, *, count=1, cta_mask=0, pred=True, _semantic=None):
             to 0 (no multicast). Must satisfy ``0 < cta_mask <= num_ctas - 1``
             when non-zero.
         pred (bool): Scalar predicate. Operation is skipped if predicate is False. Defaults to True.
+        from_ctas (int, optional): Mask of CTA-ID bits preserved when routing the arrival, in
+            ``[0, num_ctas - 1]``. Defaults to ``num_ctas - 1``, which arrives from each CTA to itself; ``0``
+            routes from CTA 0 to every CTA. A non-identity mask cannot be combined with multicast.
     """
     count = _unwrap_if_constexpr(count)
     cta_mask = _unwrap_if_constexpr(cta_mask)
@@ -51,4 +54,5 @@ def arrive(mbarrier, *, count=1, cta_mask=0, pred=True, _semantic=None):
         if cta_mask > num_ctas - 1:
             raise ValueError(f"cta_mask must be <= num_ctas - 1 ({num_ctas - 1}), got {cta_mask}")
     pred = _semantic.to_tensor(pred)
-    _semantic.builder.create_mbarrier_arrive(mbarrier.handle, count, cta_mask, pred.handle)
+    from_ctas = _unwrap_if_constexpr(from_ctas)
+    _semantic.builder.create_mbarrier_arrive(mbarrier.handle, count, cta_mask, pred.handle, from_ctas)

--- a/python/triton/experimental/gluon/language/nvidia/rubin/mbarrier.py
+++ b/python/triton/experimental/gluon/language/nvidia/rubin/mbarrier.py
@@ -20,39 +20,39 @@ __all__ = [
 
 
 @builtin
-def arrive(mbarrier, *, count=1, cta_mask=0, pred=True, from_ctas=None, _semantic=None):
+def arrive(mbarrier, *, count=1, pred=True, from_cta=None, multicast_cta=0, _semantic=None):
     """
     Arrive at an mbarrier with a specified count.
 
-    When ``cta_mask`` is non-zero, the arrive is multicast across the cluster.
+    When ``multicast_cta`` is non-zero, the arrive is multicast across the cluster.
     Each bit set in the mask identifies a CTA ID dimension to multicast
     along. CTA IDs ``a`` and ``b`` belong to the same equivalence class iff
-    ``a & ~cta_mask == b & ~cta_mask``; all CTAs in a class multicast to each
-    other. Multicast requires ``num_ctas > 1``, ``0 < cta_mask <= num_ctas - 1``,
+    ``a & ~multicast_cta == b & ~multicast_cta``; all CTAs in a class multicast to each
+    other. Multicast requires ``num_ctas > 1``, ``0 < multicast_cta <= num_ctas - 1``,
     and the barrier must have the identity CGA layout ``[[1], [2], ...]``. The
-    default value of ``cta_mask`` is 0 (no multicast).
+    default value of ``multicast_cta`` is 0 (no multicast).
 
     Args:
         mbarrier (shared_memory_descriptor): Barrier to be signalled.
         count (int): Count to arrive with. Defaults to 1.
-        cta_mask (int): CTA broadcast dimension bits (see above). Defaults
-            to 0 (no multicast). Must satisfy ``0 < cta_mask <= num_ctas - 1``
-            when non-zero.
         pred (bool): Scalar predicate. Operation is skipped if predicate is False. Defaults to True.
-        from_ctas (int, optional): Mask of CTA-ID bits preserved when routing the arrival, in
+        from_cta (int, optional): Mask of CTA-ID bits preserved when routing the arrival, in
             ``[0, num_ctas - 1]``. Defaults to ``num_ctas - 1``, which arrives from each CTA to itself; ``0``
             routes from CTA 0 to every CTA. A non-identity mask cannot be combined with multicast.
+        multicast_cta (int): CTA broadcast dimension bits (see above). Defaults
+            to 0 (no multicast). Must satisfy ``0 < multicast_cta <= num_ctas - 1``
+            when non-zero.
     """
     count = _unwrap_if_constexpr(count)
-    cta_mask = _unwrap_if_constexpr(cta_mask)
-    if not isinstance(cta_mask, int) or isinstance(cta_mask, bool):
-        raise TypeError(f"cta_mask must be an int, got {type(cta_mask).__name__}")
-    if cta_mask:
+    from_cta = _unwrap_if_constexpr(from_cta)
+    multicast_cta = _unwrap_if_constexpr(multicast_cta)
+    if not isinstance(multicast_cta, int) or isinstance(multicast_cta, bool):
+        raise TypeError(f"multicast_cta must be an int, got {type(multicast_cta).__name__}")
+    if multicast_cta:
         num_ctas = _semantic.builder.options.num_ctas
-        if cta_mask < 0:
-            raise ValueError(f"cta_mask must be positive, got {cta_mask}")
-        if cta_mask > num_ctas - 1:
-            raise ValueError(f"cta_mask must be <= num_ctas - 1 ({num_ctas - 1}), got {cta_mask}")
+        if multicast_cta < 0:
+            raise ValueError(f"multicast_cta must be positive, got {multicast_cta}")
+        if multicast_cta > num_ctas - 1:
+            raise ValueError(f"multicast_cta must be <= num_ctas - 1 ({num_ctas - 1}), got {multicast_cta}")
     pred = _semantic.to_tensor(pred)
-    from_ctas = _unwrap_if_constexpr(from_ctas)
-    _semantic.builder.create_mbarrier_arrive(mbarrier.handle, count, cta_mask, pred.handle, from_ctas)
+    _semantic.builder.create_mbarrier_arrive(mbarrier.handle, count, pred.handle, from_cta, multicast_cta)

--- a/python/tutorials/gluon/14-multicta.py
+++ b/python/tutorials/gluon/14-multicta.py
@@ -846,7 +846,7 @@ def matmul_clc_partition(p):
         mbarrier.wait(p.clc_consumed_bars.index(consumed_state.index), consumed_state.phase, pred=(i >= acc_stages))
         barrier = p.clc_barriers.index(state.index)
         result = p.clc_result_buffers.index(state.index)
-        mbarrier.expect(barrier, 16)
+        mbarrier.expect(barrier, 16, from_ctas=0x0)
         clc.try_cancel(result, barrier)
         mbarrier.wait(barrier, state.phase)
         clc_res = clc.load_result(result)

--- a/python/tutorials/gluon/14-multicta.py
+++ b/python/tutorials/gluon/14-multicta.py
@@ -846,7 +846,7 @@ def matmul_clc_partition(p):
         mbarrier.wait(p.clc_consumed_bars.index(consumed_state.index), consumed_state.phase, pred=(i >= acc_stages))
         barrier = p.clc_barriers.index(state.index)
         result = p.clc_result_buffers.index(state.index)
-        mbarrier.expect(barrier, 16, from_ctas=0x0)
+        mbarrier.expect(barrier, 16, from_cta=0x0)
         clc.try_cancel(result, barrier)
         mbarrier.wait(barrier, state.phase)
         clc_res = clc.load_result(result)

--- a/test/Conversion/tritongpu_to_llvm_rubin.mlir
+++ b/test/Conversion/tritongpu_to_llvm_rubin.mlir
@@ -154,8 +154,8 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 8 : i32, ttg.targ
 #barrier = #ttg.swizzled_shared<{vec = 1, perPhase = 1, maxPhase = 1, order = [0], CGALayout = [[1]]}>
 #smem = #ttg.shared_memory
 module attributes {"ttg.num-ctas" = 2 : i32, "ttg.num-warps" = 4 : i32, ttg.target = "cuda:107"} {
-  // CHECK-LABEL: @arrive_barrier_from_ctas0_multicast
-  tt.func @arrive_barrier_from_ctas0_multicast(%barrier: !ttg.memdesc<2xi64, #barrier, #smem, mutable>, %pred: i1) {
+  // CHECK-LABEL: @arrive_barrier_fromCTA0_multicast
+  tt.func @arrive_barrier_fromCTA0_multicast(%barrier: !ttg.memdesc<2xi64, #barrier, #smem, mutable>, %pred: i1) {
     // CHECK: nvvm.barrier
     // CHECK: nvvm.read.ptx.sreg.tid.x
     // CHECK: llvm.icmp "eq"
@@ -165,7 +165,7 @@ module attributes {"ttg.num-ctas" = 2 : i32, "ttg.num-warps" = 4 : i32, ttg.targ
     // CHECK-NOT: llvm.ptrtoint
     // CHECK-NOT: llvm.xor
     // CHECK: @$0 mbarrier.arrive.shared::cluster.multicast::cluster::32b.b64 _, [$1], 2, $2;
-    ttng.arrive_barrier %barrier, 2, %pred {from_ctas = 0 : i32} : !ttg.memdesc<2xi64, #barrier, #smem, mutable>
+    ttng.arrive_barrier %barrier, 2, %pred {fromCTA = 0 : i32} : !ttg.memdesc<2xi64, #barrier, #smem, mutable>
     tt.return
   }
 }
@@ -175,8 +175,8 @@ module attributes {"ttg.num-ctas" = 2 : i32, "ttg.num-warps" = 4 : i32, ttg.targ
 #barrier = #ttg.swizzled_shared<{vec = 1, perPhase = 1, maxPhase = 1, order = [0], CGALayout = [[1], [2], [4]]}>
 #smem = #ttg.shared_memory
 module attributes {"ttg.num-ctas" = 8 : i32, "ttg.num-warps" = 4 : i32, ttg.target = "cuda:107"} {
-  // CHECK-LABEL: @expect_barrier_from_ctas0145_multicast
-  tt.func @expect_barrier_from_ctas0145_multicast(%barrier: !ttg.memdesc<8xi64, #barrier, #smem, mutable>, %pred: i1) {
+  // CHECK-LABEL: @expect_barrier_fromCTA0145_multicast
+  tt.func @expect_barrier_fromCTA0145_multicast(%barrier: !ttg.memdesc<8xi64, #barrier, #smem, mutable>, %pred: i1) {
     // CHECK: nvvm.barrier
     // CHECK: nvvm.read.ptx.sreg.tid.x
     // CHECK: llvm.icmp "eq"
@@ -188,7 +188,7 @@ module attributes {"ttg.num-ctas" = 8 : i32, "ttg.num-warps" = 4 : i32, ttg.targ
     // CHECK-NOT: llvm.ptrtoint
     // CHECK-NOT: llvm.xor
     // CHECK: @$0 mbarrier.arrive.expect_tx.shared::cluster.multicast::cluster::32b.b64 _, [$1], 16384, $2;
-    ttng.barrier_expect %barrier, 16384 {from_ctas = 5 : i32}, %pred : !ttg.memdesc<8xi64, #barrier, #smem, mutable>
+    ttng.barrier_expect %barrier, 16384 {fromCTA = 5 : i32}, %pred : !ttg.memdesc<8xi64, #barrier, #smem, mutable>
     tt.return
   }
 }

--- a/test/Conversion/tritongpu_to_llvm_rubin.mlir
+++ b/test/Conversion/tritongpu_to_llvm_rubin.mlir
@@ -151,6 +151,50 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 8 : i32, ttg.targ
 
 // -----
 
+#barrier = #ttg.swizzled_shared<{vec = 1, perPhase = 1, maxPhase = 1, order = [0], CGALayout = [[1]]}>
+#smem = #ttg.shared_memory
+module attributes {"ttg.num-ctas" = 2 : i32, "ttg.num-warps" = 4 : i32, ttg.target = "cuda:107"} {
+  // CHECK-LABEL: @arrive_barrier_from_ctas0_multicast
+  tt.func @arrive_barrier_from_ctas0_multicast(%barrier: !ttg.memdesc<2xi64, #barrier, #smem, mutable>, %pred: i1) {
+    // CHECK: nvvm.barrier
+    // CHECK: nvvm.read.ptx.sreg.tid.x
+    // CHECK: llvm.icmp "eq"
+    // CHECK-NOT: llvm.icmp "ult"
+    // CHECK: nvvm.read.ptx.sreg.cluster.ctarank
+    // CHECK: nvg.cluster_id
+    // CHECK-NOT: llvm.ptrtoint
+    // CHECK-NOT: llvm.xor
+    // CHECK: @$0 mbarrier.arrive.shared::cluster.multicast::cluster::32b.b64 _, [$1], 2, $2;
+    ttng.arrive_barrier %barrier, 2, %pred {from_ctas = 0 : i32} : !ttg.memdesc<2xi64, #barrier, #smem, mutable>
+    tt.return
+  }
+}
+
+// -----
+
+#barrier = #ttg.swizzled_shared<{vec = 1, perPhase = 1, maxPhase = 1, order = [0], CGALayout = [[1], [2], [4]]}>
+#smem = #ttg.shared_memory
+module attributes {"ttg.num-ctas" = 8 : i32, "ttg.num-warps" = 4 : i32, ttg.target = "cuda:107"} {
+  // CHECK-LABEL: @expect_barrier_from_ctas0145_multicast
+  tt.func @expect_barrier_from_ctas0145_multicast(%barrier: !ttg.memdesc<8xi64, #barrier, #smem, mutable>, %pred: i1) {
+    // CHECK: nvvm.barrier
+    // CHECK: nvvm.read.ptx.sreg.tid.x
+    // CHECK: llvm.icmp "eq"
+    // CHECK-NOT: llvm.icmp "ult"
+    // CHECK: nvvm.read.ptx.sreg.cluster.ctarank
+    // CHECK: nvg.cluster_id
+    // CHECK: llvm.mlir.constant(5 : i32)
+    // CHECK: llvm.shl
+    // CHECK-NOT: llvm.ptrtoint
+    // CHECK-NOT: llvm.xor
+    // CHECK: @$0 mbarrier.arrive.expect_tx.shared::cluster.multicast::cluster::32b.b64 _, [$1], 16384, $2;
+    ttng.barrier_expect %barrier, 16384 {from_ctas = 5 : i32}, %pred : !ttg.memdesc<8xi64, #barrier, #smem, mutable>
+    tt.return
+  }
+}
+
+// -----
+
 #shared = #ttg.nvmma_shared<{swizzlingByteWidth = 64, transposed = false, elementBitWidth = 8}>
 #shared1 = #ttg.nvmma_shared<{swizzlingByteWidth = 32, transposed = true, elementBitWidth = 8}>
 #shared2 = #ttg.swizzled_shared<{vec = 1, perPhase = 1, maxPhase = 1, order = [0]}>

--- a/test/Conversion/tritonnvidiagpu_to_llvm.mlir
+++ b/test/Conversion/tritonnvidiagpu_to_llvm.mlir
@@ -136,14 +136,14 @@ module attributes {"ttg.num-ctas" = 2 : i32, "ttg.num-warps" = 4 : i32} {
 #barrier = #ttg.swizzled_shared<{vec = 1, perPhase = 1, maxPhase = 1, order = [0], CGALayout = [[1]]}>
 #smem = #ttg.shared_memory
 module attributes {"ttg.num-ctas" = 2 : i32, "ttg.num-warps" = 4 : i32} {
-  // CHECK-LABEL: arrive_barrier_from_ctas0
-  tt.func @arrive_barrier_from_ctas0(%alloc: !ttg.memdesc<2xi64, #barrier, #smem, mutable>, %pred: i1) {
+  // CHECK-LABEL: arrive_barrier_fromCTA0
+  tt.func @arrive_barrier_fromCTA0(%alloc: !ttg.memdesc<2xi64, #barrier, #smem, mutable>, %pred: i1) {
     // CHECK: llvm.icmp "ult"
     // CHECK: nvvm.read.ptx.sreg.cluster.ctarank
     // CHECK: llvm.ptrtoint
     // CHECK: llvm.xor
     // CHECK: mbarrier.arrive.shared::cluster.b64
-    ttng.arrive_barrier %alloc, 1, %pred {from_ctas = 0 : i32} : !ttg.memdesc<2xi64, #barrier, #smem, mutable>
+    ttng.arrive_barrier %alloc, 1, %pred {fromCTA = 0 : i32} : !ttg.memdesc<2xi64, #barrier, #smem, mutable>
     tt.return
   }
 }
@@ -156,7 +156,7 @@ module attributes {"ttg.num-ctas" = 2 : i32, "ttg.num-warps" = 4 : i32} {
 module attributes {"ttg.num-ctas" = 2 : i32, "ttg.num-warps" = 4 : i32} {
   // CHECK-LABEL: arrive_barrier_multicast_absent
   tt.func @arrive_barrier_multicast_absent(%alloc: !ttg.memdesc<2xi64, #shared0, #smem, mutable>) {
-    // No ctaMask → non-multicast path.
+    // No multicastCTA → non-multicast path.
     // CHECK: mbarrier.arrive.shared::cta.b64
     // CHECK-NOT: mbarrier.arrive.shared::cluster.multicast
     ttng.arrive_barrier %alloc, 1 : !ttg.memdesc<2xi64, #shared0, #smem, mutable>
@@ -173,7 +173,7 @@ module attributes {"ttg.num-ctas" = 2 : i32, "ttg.num-warps" = 4 : i32} {
   tt.func @arrive_barrier_multicast(%alloc: !ttg.memdesc<2xi64, #shared0, #smem, mutable>) {
     // CHECK: mbarrier.arrive.shared::cluster.multicast::cluster::32b.b64 _, [${{.*}}], ${{.*}};
     // CHECK-NOT: mbarrier.arrive.shared::cta.b64
-    ttng.arrive_barrier %alloc, 1 {ctaMask = 1 : i32} : !ttg.memdesc<2xi64, #shared0, #smem, mutable>
+    ttng.arrive_barrier %alloc, 1 {multicastCTA = 1 : i32} : !ttg.memdesc<2xi64, #shared0, #smem, mutable>
     tt.return
   }
 }
@@ -217,8 +217,8 @@ module attributes {"ttg.num-ctas" = 2 : i32, "ttg.num-warps" = 4 : i32} {
 #barrier = #ttg.swizzled_shared<{vec = 1, perPhase = 1, maxPhase = 1, order = [0], CGALayout = [[1], [2], [4]]}>
 #smem = #ttg.shared_memory
 module attributes {"ttg.num-ctas" = 8 : i32, "ttg.num-warps" = 4 : i32} {
-  // CHECK-LABEL: expect_barrier_from_ctas0145
-  tt.func @expect_barrier_from_ctas0145(%barrier: !ttg.memdesc<8xi64, #barrier, #smem, mutable>, %pred: i1) {
+  // CHECK-LABEL: expect_barrier_fromCTA0145
+  tt.func @expect_barrier_fromCTA0145(%barrier: !ttg.memdesc<8xi64, #barrier, #smem, mutable>, %pred: i1) {
     // CHECK: llvm.mlir.constant(2 : i32)
     // CHECK: llvm.icmp "ult"
     // CHECK: nvvm.read.ptx.sreg.cluster.ctarank
@@ -227,7 +227,7 @@ module attributes {"ttg.num-ctas" = 8 : i32, "ttg.num-warps" = 4 : i32} {
     // CHECK: llvm.ptrtoint
     // CHECK: llvm.xor
     // CHECK: @$0 mbarrier.arrive.expect_tx.shared::cluster.b64 _, [$1], 16384;
-    ttng.barrier_expect %barrier, 16384 {from_ctas = 5 : i32}, %pred : !ttg.memdesc<8xi64, #barrier, #smem, mutable>
+    ttng.barrier_expect %barrier, 16384 {fromCTA = 5 : i32}, %pred : !ttg.memdesc<8xi64, #barrier, #smem, mutable>
     tt.return
   }
 }

--- a/test/Conversion/tritonnvidiagpu_to_llvm.mlir
+++ b/test/Conversion/tritonnvidiagpu_to_llvm.mlir
@@ -131,6 +131,23 @@ module attributes {"ttg.num-ctas" = 2 : i32, "ttg.num-warps" = 4 : i32} {
   }
 }
 
+// -----
+
+#barrier = #ttg.swizzled_shared<{vec = 1, perPhase = 1, maxPhase = 1, order = [0], CGALayout = [[1]]}>
+#smem = #ttg.shared_memory
+module attributes {"ttg.num-ctas" = 2 : i32, "ttg.num-warps" = 4 : i32} {
+  // CHECK-LABEL: arrive_barrier_from_ctas0
+  tt.func @arrive_barrier_from_ctas0(%alloc: !ttg.memdesc<2xi64, #barrier, #smem, mutable>, %pred: i1) {
+    // CHECK: llvm.icmp "ult"
+    // CHECK: nvvm.read.ptx.sreg.cluster.ctarank
+    // CHECK: llvm.ptrtoint
+    // CHECK: llvm.xor
+    // CHECK: mbarrier.arrive.shared::cluster.b64
+    ttng.arrive_barrier %alloc, 1, %pred {from_ctas = 0 : i32} : !ttg.memdesc<2xi64, #barrier, #smem, mutable>
+    tt.return
+  }
+}
+
 
 // -----
 
@@ -191,6 +208,26 @@ module attributes {"ttg.num-ctas" = 2 : i32, "ttg.num-warps" = 4 : i32} {
   // CHECK: st.async.weak.shared::cluster.mbarrier::complete_tx::bytes.b32
   tt.func @async_shared_store(%src: tensor<128xi32, #blocked>, %dst: !ttg.memdesc<128xi32, #shared1, #smem, mutable>, %mbarrier: !ttg.memdesc<2xi64, #shared0, #smem, mutable>) {
     ttng.async_shared_store %src, %dst, %mbarrier : tensor<128xi32, #blocked> -> !ttg.memdesc<128xi32, #shared1, #smem, mutable>, !ttg.memdesc<2xi64, #shared0, #smem, mutable>
+    tt.return
+  }
+}
+
+// -----
+
+#barrier = #ttg.swizzled_shared<{vec = 1, perPhase = 1, maxPhase = 1, order = [0], CGALayout = [[1], [2], [4]]}>
+#smem = #ttg.shared_memory
+module attributes {"ttg.num-ctas" = 8 : i32, "ttg.num-warps" = 4 : i32} {
+  // CHECK-LABEL: expect_barrier_from_ctas0145
+  tt.func @expect_barrier_from_ctas0145(%barrier: !ttg.memdesc<8xi64, #barrier, #smem, mutable>, %pred: i1) {
+    // CHECK: llvm.mlir.constant(2 : i32)
+    // CHECK: llvm.icmp "ult"
+    // CHECK: nvvm.read.ptx.sreg.cluster.ctarank
+    // CHECK: llvm.mlir.constant(2 : i32)
+    // CHECK: llvm.shl
+    // CHECK: llvm.ptrtoint
+    // CHECK: llvm.xor
+    // CHECK: @$0 mbarrier.arrive.expect_tx.shared::cluster.b64 _, [$1], 16384;
+    ttng.barrier_expect %barrier, 16384 {from_ctas = 5 : i32}, %pred : !ttg.memdesc<8xi64, #barrier, #smem, mutable>
     tt.return
   }
 }

--- a/test/TritonGPU/consan.mlir
+++ b/test/TritonGPU/consan.mlir
@@ -67,6 +67,43 @@ module attributes {"ttg.num-ctas" = 2 : i32, "ttg.num-warps" = 1 : i32, ttg.shar
 
 // -----
 
+#barrier_from_ctas = #ttg.swizzled_shared<{vec = 1, perPhase = 1, maxPhase = 1, order = [0], CGALayout = [[1], [2], [4]]}>
+#smem_from_ctas = #ttg.shared_memory
+module attributes {"ttg.num-ctas" = 8 : i32, "ttg.num-warps" = 1 : i32, ttg.shared = 64 : i32, ttg.target = "cuda:90", ttg.tensor_memory_size = 0 : i32, "ttg.threads-per-warp" = 32 : i32, "ttg.total-num-warps" = 1 : i32} {
+  // CHECK-LABEL: @mbarrier_from_ctas_basis_mask
+  tt.func public @mbarrier_from_ctas_basis_mask() {
+    %true = arith.constant true
+    %bar = ttg.local_alloc {allocation.offset = 0 : i32} : () -> !ttg.memdesc<8xi64, #barrier_from_ctas, #smem_from_ctas, mutable>
+    ttng.init_barrier %bar, 1 : !ttg.memdesc<8xi64, #barrier_from_ctas, #smem_from_ctas, mutable>
+
+    // from_ctas=5 preserves CTA-ID bits 0 and 2, selects CTA0, CTA1, CTA4,
+    // and CTA5 as issuers, and sends to CTA groups with matching fixed bits.
+    // CHECK: ttng.init_barrier
+    // CHECK: %[[EXPECT_CTA:.*]] = tti.experimental_cluster_cta_id : i32
+    // CHECK-NEXT: %[[EXPECT_OMITTED:.*]] = arith.constant 2 : i32
+    // CHECK-NEXT: %[[EXPECT_NON_ISSUER:.*]] = arith.andi %[[EXPECT_CTA]], %[[EXPECT_OMITTED]] : i32
+    // CHECK-NEXT: %[[EXPECT_ZERO:.*]] = arith.constant 0 : i32
+    // CHECK-NEXT: %[[EXPECT_ISSUER:.*]] = arith.cmpi eq, %[[EXPECT_NON_ISSUER]], %[[EXPECT_ZERO]] : i32
+    // CHECK-NEXT: %[[EXPECT_PRED:.*]] = arith.andi %true, %[[EXPECT_ISSUER]] : i1
+    // CHECK: arith.shli
+    // CHECK: %[[EXPECT_RECIPIENT_CTA:.*]] = tti.experimental_cluster_cta_id : i32
+    // CHECK: %[[EXPECT_FIXED:.*]] = arith.constant 5 : i32
+    // CHECK: %[[EXPECT_BASE:.*]] = arith.andi %[[EXPECT_RECIPIENT_CTA]], %[[EXPECT_FIXED]] : i32
+    // CHECK: %[[EXPECT_PATTERN:.*]] = arith.constant 5 : i32
+    // CHECK: %[[EXPECT_RECIPIENTS:.*]] = arith.shli %[[EXPECT_PATTERN]], %[[EXPECT_BASE]] : i32
+    // CHECK: tt.call @__triton_consan_verify_barrier_arrive{{.*}}({{.*}}%[[EXPECT_PRED]]{{.*}}%[[EXPECT_RECIPIENTS]])
+    // CHECK: ttng.barrier_expect
+    ttng.barrier_expect %bar, 16 {from_ctas = 5 : i32}, %true : !ttg.memdesc<8xi64, #barrier_from_ctas, #smem_from_ctas, mutable>
+
+    // CHECK: tt.call @__triton_consan_verify_barrier_arrive
+    // CHECK: ttng.arrive_barrier
+    ttng.arrive_barrier %bar, 1, %true {from_ctas = 5 : i32} : !ttg.memdesc<8xi64, #barrier_from_ctas, #smem_from_ctas, mutable>
+    tt.return
+  }
+}
+
+// -----
+
 #shared_cluster_ws = #ttg.swizzled_shared<{vec = 1, perPhase = 1, maxPhase = 1, order = [1, 0], CGALayout = [[1, 0]]}>
 #smem_cluster_ws = #ttg.shared_memory
 #blocked_cluster_ws = #ttg.blocked<{sizePerThread = [1, 32], threadsPerWarp = [32, 1], warpsPerCTA = [4, 1], order = [0, 1], CGALayout = [[1, 0]]}>

--- a/test/TritonGPU/consan.mlir
+++ b/test/TritonGPU/consan.mlir
@@ -67,16 +67,16 @@ module attributes {"ttg.num-ctas" = 2 : i32, "ttg.num-warps" = 1 : i32, ttg.shar
 
 // -----
 
-#barrier_from_ctas = #ttg.swizzled_shared<{vec = 1, perPhase = 1, maxPhase = 1, order = [0], CGALayout = [[1], [2], [4]]}>
-#smem_from_ctas = #ttg.shared_memory
+#barrier_fromCTA = #ttg.swizzled_shared<{vec = 1, perPhase = 1, maxPhase = 1, order = [0], CGALayout = [[1], [2], [4]]}>
+#smem_fromCTA = #ttg.shared_memory
 module attributes {"ttg.num-ctas" = 8 : i32, "ttg.num-warps" = 1 : i32, ttg.shared = 64 : i32, ttg.target = "cuda:90", ttg.tensor_memory_size = 0 : i32, "ttg.threads-per-warp" = 32 : i32, "ttg.total-num-warps" = 1 : i32} {
-  // CHECK-LABEL: @mbarrier_from_ctas_basis_mask
-  tt.func public @mbarrier_from_ctas_basis_mask() {
+  // CHECK-LABEL: @mbarrier_fromCTA_basis_mask
+  tt.func public @mbarrier_fromCTA_basis_mask() {
     %true = arith.constant true
-    %bar = ttg.local_alloc {allocation.offset = 0 : i32} : () -> !ttg.memdesc<8xi64, #barrier_from_ctas, #smem_from_ctas, mutable>
-    ttng.init_barrier %bar, 1 : !ttg.memdesc<8xi64, #barrier_from_ctas, #smem_from_ctas, mutable>
+    %bar = ttg.local_alloc {allocation.offset = 0 : i32} : () -> !ttg.memdesc<8xi64, #barrier_fromCTA, #smem_fromCTA, mutable>
+    ttng.init_barrier %bar, 1 : !ttg.memdesc<8xi64, #barrier_fromCTA, #smem_fromCTA, mutable>
 
-    // from_ctas=5 preserves CTA-ID bits 0 and 2, selects CTA0, CTA1, CTA4,
+    // fromCTA=5 preserves CTA-ID bits 0 and 2, selects CTA0, CTA1, CTA4,
     // and CTA5 as issuers, and sends to CTA groups with matching fixed bits.
     // CHECK: ttng.init_barrier
     // CHECK: %[[EXPECT_CTA:.*]] = tti.experimental_cluster_cta_id : i32
@@ -93,11 +93,11 @@ module attributes {"ttg.num-ctas" = 8 : i32, "ttg.num-warps" = 1 : i32, ttg.shar
     // CHECK: %[[EXPECT_RECIPIENTS:.*]] = arith.shli %[[EXPECT_PATTERN]], %[[EXPECT_BASE]] : i32
     // CHECK: tt.call @__triton_consan_verify_barrier_arrive{{.*}}({{.*}}%[[EXPECT_PRED]]{{.*}}%[[EXPECT_RECIPIENTS]])
     // CHECK: ttng.barrier_expect
-    ttng.barrier_expect %bar, 16 {from_ctas = 5 : i32}, %true : !ttg.memdesc<8xi64, #barrier_from_ctas, #smem_from_ctas, mutable>
+    ttng.barrier_expect %bar, 16 {fromCTA = 5 : i32}, %true : !ttg.memdesc<8xi64, #barrier_fromCTA, #smem_fromCTA, mutable>
 
     // CHECK: tt.call @__triton_consan_verify_barrier_arrive
     // CHECK: ttng.arrive_barrier
-    ttng.arrive_barrier %bar, 1, %true {from_ctas = 5 : i32} : !ttg.memdesc<8xi64, #barrier_from_ctas, #smem_from_ctas, mutable>
+    ttng.arrive_barrier %bar, 1, %true {fromCTA = 5 : i32} : !ttg.memdesc<8xi64, #barrier_fromCTA, #smem_fromCTA, mutable>
     tt.return
   }
 }

--- a/test/TritonNvidiaGPU/canonicalize.mlir
+++ b/test/TritonNvidiaGPU/canonicalize.mlir
@@ -33,16 +33,16 @@ llvm.func @preserve_ld_acquire(%arg0: !llvm.ptr<1>) {
 #barrier = #ttg.swizzled_shared<{vec = 1, perPhase = 1, maxPhase = 1, order = [0], CGALayout = [[1], [2], [4]]}>
 #smem = #ttg.shared_memory
 module attributes {"ttg.num-ctas" = 8 : i32, "ttg.num-warps" = 4 : i32} {
-// BARRIER-LABEL: @canonicalize_from_ctas
-tt.func @canonicalize_from_ctas(%barrier: !ttg.memdesc<8xi64, #barrier, #smem, mutable>, %pred: i1) {
+// BARRIER-LABEL: @canonicalize_fromCTA
+tt.func @canonicalize_fromCTA(%barrier: !ttg.memdesc<8xi64, #barrier, #smem, mutable>, %pred: i1) {
   // BARRIER-NEXT: ttng.barrier_expect %arg0, 16, %arg1 :
-  ttng.barrier_expect %barrier, 16 {from_ctas = 7 : i32}, %pred : !ttg.memdesc<8xi64, #barrier, #smem, mutable>
-  // BARRIER-NEXT: ttng.barrier_expect %arg0, 16 {from_ctas = 5 : i32}, %arg1 :
-  ttng.barrier_expect %barrier, 16 {from_ctas = 5 : i32}, %pred : !ttg.memdesc<8xi64, #barrier, #smem, mutable>
+  ttng.barrier_expect %barrier, 16 {fromCTA = 7 : i32}, %pred : !ttg.memdesc<8xi64, #barrier, #smem, mutable>
+  // BARRIER-NEXT: ttng.barrier_expect %arg0, 16 {fromCTA = 5 : i32}, %arg1 :
+  ttng.barrier_expect %barrier, 16 {fromCTA = 5 : i32}, %pred : !ttg.memdesc<8xi64, #barrier, #smem, mutable>
   // BARRIER-NEXT: ttng.arrive_barrier %arg0, 1, %arg1 :
-  ttng.arrive_barrier %barrier, 1, %pred {from_ctas = 7 : i32} : !ttg.memdesc<8xi64, #barrier, #smem, mutable>
-  // BARRIER-NEXT: ttng.arrive_barrier %arg0, 1, %arg1 {from_ctas = 5 : i32} :
-  ttng.arrive_barrier %barrier, 1, %pred {from_ctas = 5 : i32} : !ttg.memdesc<8xi64, #barrier, #smem, mutable>
+  ttng.arrive_barrier %barrier, 1, %pred {fromCTA = 7 : i32} : !ttg.memdesc<8xi64, #barrier, #smem, mutable>
+  // BARRIER-NEXT: ttng.arrive_barrier %arg0, 1, %arg1 {fromCTA = 5 : i32} :
+  ttng.arrive_barrier %barrier, 1, %pred {fromCTA = 5 : i32} : !ttg.memdesc<8xi64, #barrier, #smem, mutable>
   tt.return
 }
 }

--- a/test/TritonNvidiaGPU/canonicalize.mlir
+++ b/test/TritonNvidiaGPU/canonicalize.mlir
@@ -1,4 +1,5 @@
-// RUN: triton-opt %s -canonicalize | FileCheck %s
+// RUN: triton-opt %s -canonicalize | FileCheck %s --check-prefixes=CHECK,BARRIER
+// RUN: triton-opt %s -gluon-canonicalize | FileCheck %s --check-prefix=BARRIER
 
 #linear = #ttg.linear<{register = [[0, 1], [0, 2], [32, 0]], lane = [[1, 0], [2, 0], [4, 0], [8, 0], [16, 0]], warp = [[0, 0], [0, 0], [64, 0]], block = []}>
 #tmem_scales = #ttng.tensor_memory_scales_encoding<>
@@ -28,3 +29,20 @@ llvm.func @preserve_ld_acquire(%arg0: !llvm.ptr<1>) {
 }
 
 }  // end module
+
+#barrier = #ttg.swizzled_shared<{vec = 1, perPhase = 1, maxPhase = 1, order = [0], CGALayout = [[1], [2], [4]]}>
+#smem = #ttg.shared_memory
+module attributes {"ttg.num-ctas" = 8 : i32, "ttg.num-warps" = 4 : i32} {
+// BARRIER-LABEL: @canonicalize_from_ctas
+tt.func @canonicalize_from_ctas(%barrier: !ttg.memdesc<8xi64, #barrier, #smem, mutable>, %pred: i1) {
+  // BARRIER-NEXT: ttng.barrier_expect %arg0, 16, %arg1 :
+  ttng.barrier_expect %barrier, 16 {from_ctas = 7 : i32}, %pred : !ttg.memdesc<8xi64, #barrier, #smem, mutable>
+  // BARRIER-NEXT: ttng.barrier_expect %arg0, 16 {from_ctas = 5 : i32}, %arg1 :
+  ttng.barrier_expect %barrier, 16 {from_ctas = 5 : i32}, %pred : !ttg.memdesc<8xi64, #barrier, #smem, mutable>
+  // BARRIER-NEXT: ttng.arrive_barrier %arg0, 1, %arg1 :
+  ttng.arrive_barrier %barrier, 1, %pred {from_ctas = 7 : i32} : !ttg.memdesc<8xi64, #barrier, #smem, mutable>
+  // BARRIER-NEXT: ttng.arrive_barrier %arg0, 1, %arg1 {from_ctas = 5 : i32} :
+  ttng.arrive_barrier %barrier, 1, %pred {from_ctas = 5 : i32} : !ttg.memdesc<8xi64, #barrier, #smem, mutable>
+  tt.return
+}
+}

--- a/test/TritonNvidiaGPU/invalid.mlir
+++ b/test/TritonNvidiaGPU/invalid.mlir
@@ -636,7 +636,7 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.targ
   tt.func @arrive_barrier_multicast_invalid() {
     %bar = ttg.local_alloc : () -> !ttg.memdesc<1xi64, #shared, #smem, mutable>
     // expected-error @below {{multicast arrive requires num_ctas > 1}}
-    ttng.arrive_barrier %bar, 1 {ctaMask = 1 : i32} : !ttg.memdesc<1xi64, #shared, #smem, mutable>
+    ttng.arrive_barrier %bar, 1 {multicastCTA = 1 : i32} : !ttg.memdesc<1xi64, #shared, #smem, mutable>
     tt.return
   }
 }
@@ -649,7 +649,7 @@ module attributes {"ttg.num-ctas" = 2 : i32, "ttg.num-warps" = 4 : i32, ttg.targ
   tt.func @arrive_barrier_multicast_zero_count() {
     %bar = ttg.local_alloc : () -> !ttg.memdesc<1xi64, #shared, #smem, mutable>
     // expected-error @below {{count must be greater than or equal to 1}}
-    ttng.arrive_barrier %bar, 0 {ctaMask = 3 : i32} : !ttg.memdesc<1xi64, #shared, #smem, mutable>
+    ttng.arrive_barrier %bar, 0 {multicastCTA = 3 : i32} : !ttg.memdesc<1xi64, #shared, #smem, mutable>
     tt.return
   }
 }
@@ -661,8 +661,8 @@ module attributes {"ttg.num-ctas" = 2 : i32, "ttg.num-warps" = 4 : i32, ttg.targ
 module attributes {"ttg.num-ctas" = 2 : i32, "ttg.num-warps" = 4 : i32, ttg.target = "cuda:90"} {
   tt.func @arrive_barrier_multicast_mask_overflow() {
     %bar = ttg.local_alloc : () -> !ttg.memdesc<2xi64, #shared, #smem, mutable>
-    // expected-error @below {{ctaMask exceeds numCTAs - 1}}
-    ttng.arrive_barrier %bar, 1 {ctaMask = 7 : i32} : !ttg.memdesc<2xi64, #shared, #smem, mutable>
+    // expected-error @below {{multicastCTA exceeds numCTAs - 1}}
+    ttng.arrive_barrier %bar, 1 {multicastCTA = 7 : i32} : !ttg.memdesc<2xi64, #shared, #smem, mutable>
     tt.return
   }
 }
@@ -675,8 +675,8 @@ module attributes {"ttg.num-ctas" = 2 : i32, "ttg.num-warps" = 4 : i32, ttg.targ
   tt.func @arrive_barrier_multicast_negative_mask() {
     %bar = ttg.local_alloc : () -> !ttg.memdesc<2xi64, #shared, #smem, mutable>
     // Negative masks are invalid and are rejected by the mask bounds check.
-    // expected-error @below {{ctaMask exceeds numCTAs - 1}}
-    ttng.arrive_barrier %bar, 1 {ctaMask = -1 : i32} : !ttg.memdesc<2xi64, #shared, #smem, mutable>
+    // expected-error @below {{multicastCTA exceeds numCTAs - 1}}
+    ttng.arrive_barrier %bar, 1 {multicastCTA = -1 : i32} : !ttg.memdesc<2xi64, #shared, #smem, mutable>
     tt.return
   }
 }
@@ -689,7 +689,7 @@ module attributes {"ttg.num-ctas" = 2 : i32, "ttg.num-warps" = 4 : i32, ttg.targ
   tt.func @arrive_barrier_multicast_non_identity_cga() {
     %bar = ttg.local_alloc : () -> !ttg.memdesc<1xi64, #shared, #smem, mutable>
     // expected-error @below {{multicast barrier cga_layout must be [[1]], got [[0]]}}
-    ttng.arrive_barrier %bar, 1 {ctaMask = 1 : i32} : !ttg.memdesc<1xi64, #shared, #smem, mutable>
+    ttng.arrive_barrier %bar, 1 {multicastCTA = 1 : i32} : !ttg.memdesc<1xi64, #shared, #smem, mutable>
     tt.return
   }
 }
@@ -1004,14 +1004,14 @@ module attributes {"ttg.num-ctas" = 8 : i32, "ttg.num-warps" = 4 : i32} {
 #barrier = #ttg.swizzled_shared<{vec = 1, perPhase = 1, maxPhase = 1, order = [0], CGALayout = [[1], [2]]}>
 #smem = #ttg.shared_memory
 module attributes {"ttg.num-ctas" = 4 : i32, "ttg.num-warps" = 4 : i32} {
-  tt.func @barrier_expect_from_ctas_out_of_range(%bar: !ttg.memdesc<4xi64, #barrier, #smem, mutable>, %pred: i1) {
-    // expected-error @below {{from_ctas must be in the range [0, num_ctas - 1]}}
-    ttng.barrier_expect %bar, 16 {from_ctas = -1 : i32}, %pred : !ttg.memdesc<4xi64, #barrier, #smem, mutable>
+  tt.func @barrier_expect_fromCTA_out_of_range(%bar: !ttg.memdesc<4xi64, #barrier, #smem, mutable>, %pred: i1) {
+    // expected-error @below {{fromCTA must be in the range [0, num_ctas - 1]}}
+    ttng.barrier_expect %bar, 16 {fromCTA = -1 : i32}, %pred : !ttg.memdesc<4xi64, #barrier, #smem, mutable>
     tt.return
   }
-  tt.func @arrive_barrier_from_ctas_out_of_range(%bar: !ttg.memdesc<4xi64, #barrier, #smem, mutable>, %pred: i1) {
-    // expected-error @below {{from_ctas must be in the range [0, num_ctas - 1]}}
-    ttng.arrive_barrier %bar, 1, %pred {from_ctas = 4 : i32} : !ttg.memdesc<4xi64, #barrier, #smem, mutable>
+  tt.func @arrive_barrier_fromCTA_out_of_range(%bar: !ttg.memdesc<4xi64, #barrier, #smem, mutable>, %pred: i1) {
+    // expected-error @below {{fromCTA must be in the range [0, num_ctas - 1]}}
+    ttng.arrive_barrier %bar, 1, %pred {fromCTA = 4 : i32} : !ttg.memdesc<4xi64, #barrier, #smem, mutable>
     tt.return
   }
 }
@@ -1021,9 +1021,9 @@ module attributes {"ttg.num-ctas" = 4 : i32, "ttg.num-warps" = 4 : i32} {
 #barrier = #ttg.swizzled_shared<{vec = 1, perPhase = 1, maxPhase = 1, order = [0], CGALayout = [[0], [0]]}>
 #smem = #ttg.shared_memory
 module attributes {"ttg.num-ctas" = 4 : i32, "ttg.num-warps" = 4 : i32} {
-  tt.func @barrier_expect_from_ctas_noncanonical_layout(%bar: !ttg.memdesc<4xi64, #barrier, #smem, mutable>, %pred: i1) {
-    // expected-error @below {{from_ctas requires a 1D barrier with one element per CTA and canonical CGA layout}}
-    ttng.barrier_expect %bar, 16 {from_ctas = 1 : i32}, %pred : !ttg.memdesc<4xi64, #barrier, #smem, mutable>
+  tt.func @barrier_expect_fromCTA_noncanonical_layout(%bar: !ttg.memdesc<4xi64, #barrier, #smem, mutable>, %pred: i1) {
+    // expected-error @below {{fromCTA requires a 1D barrier with one element per CTA and canonical CGA layout}}
+    ttng.barrier_expect %bar, 16 {fromCTA = 1 : i32}, %pred : !ttg.memdesc<4xi64, #barrier, #smem, mutable>
     tt.return
   }
 }
@@ -1033,9 +1033,9 @@ module attributes {"ttg.num-ctas" = 4 : i32, "ttg.num-warps" = 4 : i32} {
 #barrier = #ttg.swizzled_shared<{vec = 1, perPhase = 1, maxPhase = 1, order = [0], CGALayout = [[1], [2]]}>
 #smem = #ttg.shared_memory
 module attributes {"ttg.num-ctas" = 4 : i32, "ttg.num-warps" = 4 : i32} {
-  tt.func @arrive_barrier_from_ctas_broadcast_layout(%bar: !ttg.memdesc<1xi64, #barrier, #smem, mutable>, %pred: i1) {
-    // expected-error @below {{from_ctas requires a 1D barrier with one element per CTA and canonical CGA layout}}
-    ttng.arrive_barrier %bar, 1, %pred {from_ctas = 1 : i32} : !ttg.memdesc<1xi64, #barrier, #smem, mutable>
+  tt.func @arrive_barrier_fromCTA_broadcast_layout(%bar: !ttg.memdesc<1xi64, #barrier, #smem, mutable>, %pred: i1) {
+    // expected-error @below {{fromCTA requires a 1D barrier with one element per CTA and canonical CGA layout}}
+    ttng.arrive_barrier %bar, 1, %pred {fromCTA = 1 : i32} : !ttg.memdesc<1xi64, #barrier, #smem, mutable>
     tt.return
   }
 }
@@ -1045,9 +1045,9 @@ module attributes {"ttg.num-ctas" = 4 : i32, "ttg.num-warps" = 4 : i32} {
 #barrier = #ttg.swizzled_shared<{vec = 1, perPhase = 1, maxPhase = 1, order = [0], CGALayout = [[1], [2]]}>
 #smem = #ttg.shared_memory
 module attributes {"ttg.num-ctas" = 4 : i32, "ttg.num-warps" = 4 : i32} {
-  tt.func @arrive_barrier_from_ctas_multicast(%bar: !ttg.memdesc<4xi64, #barrier, #smem, mutable>, %pred: i1) {
-    // expected-error @below {{from_ctas cannot be combined with multicast arrive}}
-    ttng.arrive_barrier %bar, 1, %pred {ctaMask = 1 : i32, from_ctas = 0 : i32} : !ttg.memdesc<4xi64, #barrier, #smem, mutable>
+  tt.func @arrive_barrier_fromCTA_multicast(%bar: !ttg.memdesc<4xi64, #barrier, #smem, mutable>, %pred: i1) {
+    // expected-error @below {{fromCTA cannot be combined with multicast arrive}}
+    ttng.arrive_barrier %bar, 1, %pred {multicastCTA = 1 : i32, fromCTA = 0 : i32} : !ttg.memdesc<4xi64, #barrier, #smem, mutable>
     tt.return
   }
 }

--- a/test/TritonNvidiaGPU/invalid.mlir
+++ b/test/TritonNvidiaGPU/invalid.mlir
@@ -1001,6 +1001,59 @@ module attributes {"ttg.num-ctas" = 8 : i32, "ttg.num-warps" = 4 : i32} {
 
 // -----
 
+#barrier = #ttg.swizzled_shared<{vec = 1, perPhase = 1, maxPhase = 1, order = [0], CGALayout = [[1], [2]]}>
+#smem = #ttg.shared_memory
+module attributes {"ttg.num-ctas" = 4 : i32, "ttg.num-warps" = 4 : i32} {
+  tt.func @barrier_expect_from_ctas_out_of_range(%bar: !ttg.memdesc<4xi64, #barrier, #smem, mutable>, %pred: i1) {
+    // expected-error @below {{from_ctas must be in the range [0, num_ctas - 1]}}
+    ttng.barrier_expect %bar, 16 {from_ctas = -1 : i32}, %pred : !ttg.memdesc<4xi64, #barrier, #smem, mutable>
+    tt.return
+  }
+  tt.func @arrive_barrier_from_ctas_out_of_range(%bar: !ttg.memdesc<4xi64, #barrier, #smem, mutable>, %pred: i1) {
+    // expected-error @below {{from_ctas must be in the range [0, num_ctas - 1]}}
+    ttng.arrive_barrier %bar, 1, %pred {from_ctas = 4 : i32} : !ttg.memdesc<4xi64, #barrier, #smem, mutable>
+    tt.return
+  }
+}
+
+// -----
+
+#barrier = #ttg.swizzled_shared<{vec = 1, perPhase = 1, maxPhase = 1, order = [0], CGALayout = [[0], [0]]}>
+#smem = #ttg.shared_memory
+module attributes {"ttg.num-ctas" = 4 : i32, "ttg.num-warps" = 4 : i32} {
+  tt.func @barrier_expect_from_ctas_noncanonical_layout(%bar: !ttg.memdesc<4xi64, #barrier, #smem, mutable>, %pred: i1) {
+    // expected-error @below {{from_ctas requires a 1D barrier with one element per CTA and canonical CGA layout}}
+    ttng.barrier_expect %bar, 16 {from_ctas = 1 : i32}, %pred : !ttg.memdesc<4xi64, #barrier, #smem, mutable>
+    tt.return
+  }
+}
+
+// -----
+
+#barrier = #ttg.swizzled_shared<{vec = 1, perPhase = 1, maxPhase = 1, order = [0], CGALayout = [[1], [2]]}>
+#smem = #ttg.shared_memory
+module attributes {"ttg.num-ctas" = 4 : i32, "ttg.num-warps" = 4 : i32} {
+  tt.func @arrive_barrier_from_ctas_broadcast_layout(%bar: !ttg.memdesc<1xi64, #barrier, #smem, mutable>, %pred: i1) {
+    // expected-error @below {{from_ctas requires a 1D barrier with one element per CTA and canonical CGA layout}}
+    ttng.arrive_barrier %bar, 1, %pred {from_ctas = 1 : i32} : !ttg.memdesc<1xi64, #barrier, #smem, mutable>
+    tt.return
+  }
+}
+
+// -----
+
+#barrier = #ttg.swizzled_shared<{vec = 1, perPhase = 1, maxPhase = 1, order = [0], CGALayout = [[1], [2]]}>
+#smem = #ttg.shared_memory
+module attributes {"ttg.num-ctas" = 4 : i32, "ttg.num-warps" = 4 : i32} {
+  tt.func @arrive_barrier_from_ctas_multicast(%bar: !ttg.memdesc<4xi64, #barrier, #smem, mutable>, %pred: i1) {
+    // expected-error @below {{from_ctas cannot be combined with multicast arrive}}
+    ttng.arrive_barrier %bar, 1, %pred {ctaMask = 1 : i32, from_ctas = 0 : i32} : !ttg.memdesc<4xi64, #barrier, #smem, mutable>
+    tt.return
+  }
+}
+
+// -----
+
 #tmem = #ttng.tensor_memory_encoding<blockM = 128, blockN = 128, colStride = 1>
 module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32} {
   tt.func public @memdesc_reinterpret_changed_storage_size_tmem(%arg0: !ttg.memdesc<128x128xf16, #tmem, #ttng.tensor_memory>) {

--- a/test/TritonNvidiaGPU/membar-cluster.mlir
+++ b/test/TritonNvidiaGPU/membar-cluster.mlir
@@ -509,7 +509,7 @@ module attributes {"ttg.num-ctas" = 2 : i32, "ttg.num-warps" = 4 : i32, ttg.targ
     ttng.clc_try_cancel %result, %barrier :
       !ttg.memdesc<2xi64, #sharedCLC, #smem, mutable>,
       !ttg.memdesc<2xi64, #barrierCLC, #smem, mutable>
-    ttng.barrier_expect %barrier, 16 {from_ctas = 0 : i32}, %true :
+    ttng.barrier_expect %barrier, 16 {fromCTA = 0 : i32}, %true :
       !ttg.memdesc<2xi64, #barrierCLC, #smem, mutable>
     tt.return
   }
@@ -591,22 +591,22 @@ module attributes {"ttg.num-ctas" = 2 : i32, "ttg.num-warps" = 4 : i32, ttg.targ
 
 // -----
 
-#barrierFromCTAs = #ttg.swizzled_shared<{vec = 1, perPhase = 1, maxPhase = 1, order = [0], CGALayout = [[1]]}>
+#barrierFromCTA = #ttg.swizzled_shared<{vec = 1, perPhase = 1, maxPhase = 1, order = [0], CGALayout = [[1]]}>
 #smem = #ttg.shared_memory
 
 module attributes {"ttg.num-ctas" = 2 : i32, "ttg.num-warps" = 4 : i32, ttg.target = "cuda:90", "ttg.threads-per-warp" = 32 : i32} {
   // A remote arrival can signal a per-CTA barrier before its peer has
   // completed initialization, so initialization requires cluster sync.
-  // CHECK-LABEL: @cluster_from_ctas_with_per_cta_barrier
+  // CHECK-LABEL: @cluster_fromCTA_with_per_cta_barrier
   // CHECK: ttng.init_barrier
   // CHECK-NEXT: ttng.fence_mbarrier_init_release_cluster
   // CHECK-NEXT: ttng.cluster_barrier {relaxed = true}
   // CHECK-NEXT: ttng.barrier_expect
-  tt.func @cluster_from_ctas_with_per_cta_barrier() {
+  tt.func @cluster_fromCTA_with_per_cta_barrier() {
     %true = arith.constant true
-    %barrier = ttg.local_alloc : () -> !ttg.memdesc<2xi64, #barrierFromCTAs, #smem, mutable>
-    ttng.init_barrier %barrier, 1 : !ttg.memdesc<2xi64, #barrierFromCTAs, #smem, mutable>
-    ttng.barrier_expect %barrier, 16 {from_ctas = 0 : i32}, %true : !ttg.memdesc<2xi64, #barrierFromCTAs, #smem, mutable>
+    %barrier = ttg.local_alloc : () -> !ttg.memdesc<2xi64, #barrierFromCTA, #smem, mutable>
+    ttng.init_barrier %barrier, 1 : !ttg.memdesc<2xi64, #barrierFromCTA, #smem, mutable>
+    ttng.barrier_expect %barrier, 16 {fromCTA = 0 : i32}, %true : !ttg.memdesc<2xi64, #barrierFromCTA, #smem, mutable>
     tt.return
   }
 }
@@ -882,13 +882,13 @@ module attributes {"ttg.num-ctas" = 2 : i32, "ttg.num-warps" = 4 : i32, ttg.targ
 #smem = #ttg.shared_memory
 
 module attributes {"ttg.num-ctas" = 2 : i32, "ttg.num-warps" = 4 : i32, ttg.target = "cuda:90", "ttg.threads-per-warp" = 32 : i32} {
-  // ctaMask absent is not a cross-CTA op; no fence or cluster barrier should be inserted.
-  // CHECK-LABEL: @cluster_arrive_barrier_no_cta_mask_no_sync
+  // multicastCTA absent is not a cross-CTA op; no fence or cluster barrier should be inserted.
+  // CHECK-LABEL: @cluster_arrive_barrier_no_multicastCTA_no_sync
   // CHECK: ttng.init_barrier
   // CHECK-NOT: ttng.fence_mbarrier_init_release_cluster
   // CHECK-NOT: ttng.cluster_barrier
   // CHECK: ttng.arrive_barrier
-  tt.func @cluster_arrive_barrier_no_cta_mask_no_sync() {
+  tt.func @cluster_arrive_barrier_no_multicastCTA_no_sync() {
     %c0 = arith.constant 0 : i32
     %barrier = ttg.local_alloc : () -> !ttg.memdesc<2xi64, #barrierEncMC, #smem, mutable>
     ttng.init_barrier %barrier, 1 : !ttg.memdesc<2xi64, #barrierEncMC, #smem, mutable>
@@ -915,7 +915,7 @@ module attributes {"ttg.num-ctas" = 2 : i32, "ttg.num-warps" = 4 : i32, ttg.targ
     %c0 = arith.constant 0 : i32
     %barrier = ttg.local_alloc : () -> !ttg.memdesc<2xi64, #barrierEncMC, #smem, mutable>
     ttng.init_barrier %barrier, 1 : !ttg.memdesc<2xi64, #barrierEncMC, #smem, mutable>
-    ttng.arrive_barrier %barrier, 1 {ctaMask = 1 : i32} : !ttg.memdesc<2xi64, #barrierEncMC, #smem, mutable>
+    ttng.arrive_barrier %barrier, 1 {multicastCTA = 1 : i32} : !ttg.memdesc<2xi64, #barrierEncMC, #smem, mutable>
     ttng.wait_barrier %barrier, %c0 : !ttg.memdesc<2xi64, #barrierEncMC, #smem, mutable>
     tt.return
   }

--- a/test/TritonNvidiaGPU/membar-cluster.mlir
+++ b/test/TritonNvidiaGPU/membar-cluster.mlir
@@ -509,7 +509,7 @@ module attributes {"ttg.num-ctas" = 2 : i32, "ttg.num-warps" = 4 : i32, ttg.targ
     ttng.clc_try_cancel %result, %barrier :
       !ttg.memdesc<2xi64, #sharedCLC, #smem, mutable>,
       !ttg.memdesc<2xi64, #barrierCLC, #smem, mutable>
-    ttng.barrier_expect %barrier, 16, %true :
+    ttng.barrier_expect %barrier, 16 {from_ctas = 0 : i32}, %true :
       !ttg.memdesc<2xi64, #barrierCLC, #smem, mutable>
     tt.return
   }
@@ -585,6 +585,28 @@ module attributes {"ttg.num-ctas" = 2 : i32, "ttg.num-warps" = 4 : i32, ttg.targ
     %barrier = ttg.local_alloc : () -> !ttg.memdesc<2xi64, #barrierMMA, #smem, mutable>
     ttng.init_barrier %barrier, 1 : !ttg.memdesc<2xi64, #barrierMMA, #smem, mutable>
     ttng.tc_gen5_mma %a, %b, %acc, %false, %true, %barrier[%true] {is_async, multicast} : !ttg.memdesc<128x128xf16, #sharedMMA, #smem>, !ttg.memdesc<128x128xf16, #sharedMMA, #smem>, !ttg.memdesc<128x128xf32, #tmemMMA, #ttng.tensor_memory, mutable>, !ttg.memdesc<2xi64, #barrierMMA, #smem, mutable>
+    tt.return
+  }
+}
+
+// -----
+
+#barrierFromCTAs = #ttg.swizzled_shared<{vec = 1, perPhase = 1, maxPhase = 1, order = [0], CGALayout = [[1]]}>
+#smem = #ttg.shared_memory
+
+module attributes {"ttg.num-ctas" = 2 : i32, "ttg.num-warps" = 4 : i32, ttg.target = "cuda:90", "ttg.threads-per-warp" = 32 : i32} {
+  // A remote arrival can signal a per-CTA barrier before its peer has
+  // completed initialization, so initialization requires cluster sync.
+  // CHECK-LABEL: @cluster_from_ctas_with_per_cta_barrier
+  // CHECK: ttng.init_barrier
+  // CHECK-NEXT: ttng.fence_mbarrier_init_release_cluster
+  // CHECK-NEXT: ttng.cluster_barrier {relaxed = true}
+  // CHECK-NEXT: ttng.barrier_expect
+  tt.func @cluster_from_ctas_with_per_cta_barrier() {
+    %true = arith.constant true
+    %barrier = ttg.local_alloc : () -> !ttg.memdesc<2xi64, #barrierFromCTAs, #smem, mutable>
+    ttng.init_barrier %barrier, 1 : !ttg.memdesc<2xi64, #barrierFromCTAs, #smem, mutable>
+    ttng.barrier_expect %barrier, 16 {from_ctas = 0 : i32}, %true : !ttg.memdesc<2xi64, #barrierFromCTAs, #smem, mutable>
     tt.return
   }
 }

--- a/test/TritonNvidiaGPU/ops.mlir
+++ b/test/TritonNvidiaGPU/ops.mlir
@@ -169,32 +169,32 @@ module attributes {"ttg.num-ctas" = 2 : i32, "ttg.num-warps" = 4 : i32} {
   // CHECK-LABEL: @arrive_barrier_multicast_absent
   tt.func @arrive_barrier_multicast_absent(%alloc: !ttg.memdesc<2xi64, #shared_cga, #ttg.shared_memory, mutable>) {
     // CHECK: ttng.arrive_barrier %arg0, 1 :
-    // CHECK-NOT: ctaMask
+    // CHECK-NOT: multicastCTA
     ttng.arrive_barrier %alloc, 1 : !ttg.memdesc<2xi64, #shared_cga, #ttg.shared_memory, mutable>
     tt.return
   }
 
-  // Explicit ctaMask = 0 is valid and elides on print like the default.
+  // Explicit multicastCTA = 0 is valid and elides on print like the default.
   // CHECK-LABEL: @arrive_barrier_multicast_zero
   tt.func @arrive_barrier_multicast_zero(%alloc: !ttg.memdesc<2xi64, #shared_cga, #ttg.shared_memory, mutable>) {
     // CHECK: ttng.arrive_barrier %arg0, 1 :
-    // CHECK-NOT: ctaMask
-    ttng.arrive_barrier %alloc, 1 {ctaMask = 0 : i32} : !ttg.memdesc<2xi64, #shared_cga, #ttg.shared_memory, mutable>
+    // CHECK-NOT: multicastCTA
+    ttng.arrive_barrier %alloc, 1 {multicastCTA = 0 : i32} : !ttg.memdesc<2xi64, #shared_cga, #ttg.shared_memory, mutable>
     tt.return
   }
 
   // CHECK-LABEL: @arrive_barrier_multicast
   tt.func @arrive_barrier_multicast(%alloc: !ttg.memdesc<2xi64, #shared_cga, #ttg.shared_memory, mutable>) {
-    // CHECK: ttng.arrive_barrier %arg0, 1 {ctaMask = 1 : i32} : !ttg.memdesc<2xi64,
-    ttng.arrive_barrier %alloc, 1 {ctaMask = 1 : i32} : !ttg.memdesc<2xi64, #shared_cga, #ttg.shared_memory, mutable>
+    // CHECK: ttng.arrive_barrier %arg0, 1 {multicastCTA = 1 : i32} : !ttg.memdesc<2xi64,
+    ttng.arrive_barrier %alloc, 1 {multicastCTA = 1 : i32} : !ttg.memdesc<2xi64, #shared_cga, #ttg.shared_memory, mutable>
     tt.return
   }
 
   // Round-trip the optional-pred-then-attr-dict spelling.
   // CHECK-LABEL: @arrive_barrier_multicast_pred
   tt.func @arrive_barrier_multicast_pred(%alloc: !ttg.memdesc<2xi64, #shared_cga, #ttg.shared_memory, mutable>, %pred: i1) {
-    // CHECK: ttng.arrive_barrier %arg0, 1, %arg1 {ctaMask = 1 : i32} : !ttg.memdesc<2xi64,
-    ttng.arrive_barrier %alloc, 1, %pred {ctaMask = 1 : i32} : !ttg.memdesc<2xi64, #shared_cga, #ttg.shared_memory, mutable>
+    // CHECK: ttng.arrive_barrier %arg0, 1, %arg1 {multicastCTA = 1 : i32} : !ttg.memdesc<2xi64,
+    ttng.arrive_barrier %alloc, 1, %pred {multicastCTA = 1 : i32} : !ttg.memdesc<2xi64, #shared_cga, #ttg.shared_memory, mutable>
     tt.return
   }
 }

--- a/third_party/nvidia/lib/TritonNVIDIAGPUToLLVM/BarrierOpToLLVM.cpp
+++ b/third_party/nvidia/lib/TritonNVIDIAGPUToLLVM/BarrierOpToLLVM.cpp
@@ -30,6 +30,7 @@
 #include "triton/Conversion/TritonGPUToLLVM/Utility.h"
 #include "triton/Dialect/Triton/IR/Dialect.h"
 #include "triton/Dialect/TritonGPU/IR/Dialect.h"
+#include "llvm/Support/MathExtras.h"
 
 #include "Utility.h"
 
@@ -55,6 +56,47 @@ Value getElectWarp0OrThread0(const NVIDIA::TargetInfo &targetInfo,
     auto tid = getThreadId(*b.builder, b.loc);
     return b.icmp_eq(tid, b.i32_val(0));
   }
+}
+
+struct FromCTAsLowering {
+  Value pred;
+  Value barrierPtr;
+  Value multicastMask;
+};
+
+FromCTAsLowering getFromCTAsLowering(Location loc,
+                                     ConversionPatternRewriter &rewriter,
+                                     Value barrierPtr, uint32_t fromCTAs,
+                                     bool supportsMBarrierMulticast) {
+  auto b = TritonLLVMOpBuilder(loc, rewriter);
+  uint32_t broadcastMask =
+      (triton::gpu::lookupNumCTAs(rewriter) - 1) & ~fromCTAs;
+  Type i32Ty = rewriter.getIntegerType(32);
+
+  Value id = getThreadId(rewriter, loc);
+  Value pred =
+      supportsMBarrierMulticast
+          ? b.icmp_eq(id, b.i32_val(0))
+          : b.icmp_ult(id, b.i32_val(1u << llvm::popcount(broadcastMask)));
+  Value ctaId = NVVM::ClusterId::create(rewriter, loc, i32Ty);
+  Value sourceCTA = b.and_(ctaId, b.i32_val(broadcastMask));
+  pred = b.and_(pred, b.icmp_eq(sourceCTA, b.i32_val(0)));
+
+  if (supportsMBarrierMulticast)
+    return {pred, barrierPtr,
+            LLVM::NVIDIA::createTMAMulticastMask(loc, rewriter, broadcastMask)};
+
+  Value peerOffset = b.i32_val(0);
+  unsigned srcBit = 0;
+  for (uint32_t mask = broadcastMask; mask; mask &= mask - 1, ++srcBit) {
+    unsigned dstBit = llvm::countr_zero(mask);
+    Value bit = b.and_(id, b.i32_val(1u << srcBit));
+    peerOffset = b.or_(peerOffset, b.shl(bit, b.i32_val(dstBit + 24 - srcBit)));
+  }
+  Value barrierInt = b.ptrtoint(i32Ty, barrierPtr);
+  Value peerBarrierInt = b.xor_(barrierInt, peerOffset);
+  Value peerBarrierPtr = b.inttoptr(barrierPtr.getType(), peerBarrierInt);
+  return {pred, peerBarrierPtr, {}};
 }
 
 struct FenceAsyncSharedOpConversion
@@ -191,7 +233,12 @@ struct InvalBarrierOpConversion
 
 struct BarrierExpectConversion
     : public ConvertOpToLLVMPattern<triton::nvidia_gpu::BarrierExpectOp> {
-  using ConvertOpToLLVMPattern::ConvertOpToLLVMPattern;
+  bool supportsMBarrierMulticast;
+  BarrierExpectConversion(LLVMTypeConverter &typeConverter,
+                          PatternBenefit benefit,
+                          bool supportsMBarrierMulticast)
+      : ConvertOpToLLVMPattern(typeConverter, benefit),
+        supportsMBarrierMulticast(supportsMBarrierMulticast) {}
 
   LogicalResult
   matchAndRewrite(triton::nvidia_gpu::BarrierExpectOp op, OpAdaptor adaptor,
@@ -210,20 +257,36 @@ struct BarrierExpectConversion
     // than an elect: LOP3.LUT vs. ELECT + ISETP.EQ.U32.AND.
     Value id = getThreadId(rewriter, loc);
     Value pred = b.icmp_eq(id, b.i32_val(0));
-    pred = b.and_(pred, adaptor.getPred());
-    bool crossCluster = LLVM::NVIDIA::getCGABroadcastMask(barrierTy) != 0;
-    Value leaderBarrierPtr = LLVM::NVIDIA::getLeaderAddress(
+    bool isCrossClusterBarrier =
+        LLVM::NVIDIA::getCGABroadcastMask(barrierTy) != 0;
+    Value barrierPtr = LLVM::NVIDIA::getLeaderAddress(
         loc, rewriter, smemObj.getBase(), barrierTy);
+    Value multicastMask;
+    if (std::optional<uint32_t> fromCTAs = op.getFromCtas()) {
+      FromCTAsLowering lowering =
+          getFromCTAsLowering(loc, rewriter, smemObj.getBase(), *fromCTAs,
+                              supportsMBarrierMulticast);
+      pred = lowering.pred;
+      barrierPtr = lowering.barrierPtr;
+      multicastMask = lowering.multicastMask;
+      isCrossClusterBarrier = true;
+    }
+    pred = b.and_(pred, adaptor.getPred());
 
     ::mlir::triton::PTXBuilder expectPtxBuilder;
     const std::string expectPtx =
         "@$0 mbarrier.arrive.expect_tx." +
-        std::string(crossCluster ? "shared::cluster" : "shared::cta") +
-        ".b64 _, [$1], " + std::to_string(op.getSize()) + ";";
+        std::string(isCrossClusterBarrier ? "shared::cluster" : "shared::cta") +
+        std::string(multicastMask ? ".multicast::cluster::32b" : "") +
+        ".b64 _, [$1], " + std::to_string(op.getSize()) +
+        std::string(multicastMask ? ", $2" : "") + ";";
     auto &expectOp = *expectPtxBuilder.create(expectPtx);
-    expectOp({expectPtxBuilder.newOperand(pred, "b"),
-              expectPtxBuilder.newOperand(leaderBarrierPtr, "r")},
-             /*onlyAttachMLIRArgs=*/true);
+    SmallVector<PTXBuilder::Operand *, 3> operands = {
+        expectPtxBuilder.newOperand(pred, "b"),
+        expectPtxBuilder.newOperand(barrierPtr, "r")};
+    if (multicastMask)
+      operands.push_back(expectPtxBuilder.newOperand(multicastMask, "r"));
+    expectOp(operands, /*onlyAttachMLIRArgs=*/true);
     auto voidTy = void_ty(op->getContext());
     expectPtxBuilder.launch(rewriter, loc, voidTy);
 
@@ -322,7 +385,12 @@ struct WaitBarrierOpConversion
 
 struct ArriveBarrierOpConversion
     : public ConvertOpToLLVMPattern<triton::nvidia_gpu::ArriveBarrierOp> {
-  using ConvertOpToLLVMPattern::ConvertOpToLLVMPattern;
+  bool supportsMBarrierMulticast;
+  ArriveBarrierOpConversion(LLVMTypeConverter &typeConverter,
+                            PatternBenefit benefit,
+                            bool supportsMBarrierMulticast)
+      : ConvertOpToLLVMPattern(typeConverter, benefit),
+        supportsMBarrierMulticast(supportsMBarrierMulticast) {}
 
   LogicalResult
   matchAndRewrite(triton::nvidia_gpu::ArriveBarrierOp op, OpAdaptor adaptor,
@@ -343,25 +411,34 @@ struct ArriveBarrierOpConversion
     // than an elect: LOP3.LUT vs. ELECT + ISETP.EQ.U32.AND.
     Value id = getThreadId(rewriter, loc);
     Value pred = b.icmp_eq(id, b.i32_val(0));
-    if (op.getPred())
-      pred = b.and_(pred, adaptor.getPred());
 
     bool isCrossClusterBarrier =
         op.isMulticast() || LLVM::NVIDIA::getCGABroadcastMask(barrierTy) != 0;
-
     Value barrierPtr = LLVM::NVIDIA::getLeaderAddress(
         loc, rewriter, smemObj.getBase(), barrierTy);
+    Value multicastMask;
+    if (std::optional<uint32_t> fromCTAs = op.getFromCtas()) {
+      FromCTAsLowering lowering =
+          getFromCTAsLowering(loc, rewriter, smemObj.getBase(), *fromCTAs,
+                              supportsMBarrierMulticast && !op.isMulticast());
+      pred = lowering.pred;
+      barrierPtr = lowering.barrierPtr;
+      multicastMask = lowering.multicastMask;
+      isCrossClusterBarrier = true;
+    }
+    if (op.getPred())
+      pred = b.and_(pred, adaptor.getPred());
     // TODO: Add phase result as needed.
     std::stringstream ptxAsm;
     ptxAsm << "@$0 mbarrier.arrive."
            << (isCrossClusterBarrier ? "shared::cluster" : "shared::cta");
-    if (op.isMulticast())
+    if (op.isMulticast() || multicastMask)
       ptxAsm << ".multicast::cluster::32b";
     ptxAsm << ".b64 _, [$1]";
     if (op.getCount() > 1) {
       ptxAsm << ", " << op.getCount();
     }
-    if (op.isMulticast())
+    if (op.isMulticast() || multicastMask)
       ptxAsm << ", $2";
     ptxAsm << ";";
 
@@ -370,10 +447,11 @@ struct ArriveBarrierOpConversion
         ptxBuilder.newOperand(pred, "b"),
         ptxBuilder.newOperand(barrierPtr, "r")};
     if (op.isMulticast()) {
-      Value mask = LLVM::NVIDIA::createTMAMulticastMask(
+      multicastMask = LLVM::NVIDIA::createTMAMulticastMask(
           loc, rewriter, static_cast<uint16_t>(op.getCtaMask()));
-      operands.push_back(ptxBuilder.newOperand(mask, "r"));
     }
+    if (multicastMask)
+      operands.push_back(ptxBuilder.newOperand(multicastMask, "r"));
 
     auto arriveOp = *ptxBuilder.create(ptxAsm.str());
     arriveOp(operands, /*onlyAttachMLIRArgs=*/true);
@@ -559,14 +637,17 @@ struct CLCGetProgramIdOpConversion
 void mlir::triton::NVIDIA::populateBarrierOpToLLVMPatterns(
     LLVMTypeConverter &typeConverter, RewritePatternSet &patterns,
     PatternBenefit benefit, NVIDIA::TargetInfo &targetInfo) {
+  bool supportsMBarrierMulticast = targetInfo.getComputeCapability() == 107;
   patterns.add<FenceAsyncSharedOpConversion>(typeConverter, benefit);
   patterns.add<FenceMBarrierInitReleaseClusterOpConversion>(typeConverter,
                                                             benefit);
   patterns.add<InitBarrierOpConversion, InvalBarrierOpConversion>(
       typeConverter, benefit, targetInfo);
   patterns.add<WaitBarrierOpConversion>(typeConverter, benefit, targetInfo);
-  patterns.add<BarrierExpectConversion>(typeConverter, benefit);
-  patterns.add<ArriveBarrierOpConversion>(typeConverter, benefit);
+  patterns.add<BarrierExpectConversion>(typeConverter, benefit,
+                                        supportsMBarrierMulticast);
+  patterns.add<ArriveBarrierOpConversion>(typeConverter, benefit,
+                                          supportsMBarrierMulticast);
   patterns.add<CLCTryCancelOpConversion>(typeConverter, benefit, targetInfo);
   patterns.add<CLCLoadResultOpConversion>(typeConverter, benefit, targetInfo);
   patterns.add<CLCIsCanceledOpConversion>(typeConverter, benefit, targetInfo);

--- a/third_party/nvidia/lib/TritonNVIDIAGPUToLLVM/BarrierOpToLLVM.cpp
+++ b/third_party/nvidia/lib/TritonNVIDIAGPUToLLVM/BarrierOpToLLVM.cpp
@@ -58,19 +58,19 @@ Value getElectWarp0OrThread0(const NVIDIA::TargetInfo &targetInfo,
   }
 }
 
-struct FromCTAsLowering {
+struct FromCTALowering {
   Value pred;
   Value barrierPtr;
   Value multicastMask;
 };
 
-FromCTAsLowering getFromCTAsLowering(Location loc,
-                                     ConversionPatternRewriter &rewriter,
-                                     Value barrierPtr, uint32_t fromCTAs,
-                                     bool supportsMBarrierMulticast) {
+FromCTALowering getFromCTALowering(Location loc,
+                                   ConversionPatternRewriter &rewriter,
+                                   Value barrierPtr, uint32_t fromCTA,
+                                   bool supportsMBarrierMulticast) {
   auto b = TritonLLVMOpBuilder(loc, rewriter);
   uint32_t broadcastMask =
-      (triton::gpu::lookupNumCTAs(rewriter) - 1) & ~fromCTAs;
+      (triton::gpu::lookupNumCTAs(rewriter) - 1) & ~fromCTA;
   Type i32Ty = rewriter.getIntegerType(32);
 
   Value id = getThreadId(rewriter, loc);
@@ -262,10 +262,10 @@ struct BarrierExpectConversion
     Value barrierPtr = LLVM::NVIDIA::getLeaderAddress(
         loc, rewriter, smemObj.getBase(), barrierTy);
     Value multicastMask;
-    if (std::optional<uint32_t> fromCTAs = op.getFromCtas()) {
-      FromCTAsLowering lowering =
-          getFromCTAsLowering(loc, rewriter, smemObj.getBase(), *fromCTAs,
-                              supportsMBarrierMulticast);
+    if (std::optional<uint32_t> fromCTA = op.getFromCTA()) {
+      FromCTALowering lowering =
+          getFromCTALowering(loc, rewriter, smemObj.getBase(), *fromCTA,
+                             supportsMBarrierMulticast);
       pred = lowering.pred;
       barrierPtr = lowering.barrierPtr;
       multicastMask = lowering.multicastMask;
@@ -417,10 +417,10 @@ struct ArriveBarrierOpConversion
     Value barrierPtr = LLVM::NVIDIA::getLeaderAddress(
         loc, rewriter, smemObj.getBase(), barrierTy);
     Value multicastMask;
-    if (std::optional<uint32_t> fromCTAs = op.getFromCtas()) {
-      FromCTAsLowering lowering =
-          getFromCTAsLowering(loc, rewriter, smemObj.getBase(), *fromCTAs,
-                              supportsMBarrierMulticast && !op.isMulticast());
+    if (std::optional<uint32_t> fromCTA = op.getFromCTA()) {
+      FromCTALowering lowering =
+          getFromCTALowering(loc, rewriter, smemObj.getBase(), *fromCTA,
+                             supportsMBarrierMulticast && !op.isMulticast());
       pred = lowering.pred;
       barrierPtr = lowering.barrierPtr;
       multicastMask = lowering.multicastMask;
@@ -448,7 +448,7 @@ struct ArriveBarrierOpConversion
         ptxBuilder.newOperand(barrierPtr, "r")};
     if (op.isMulticast()) {
       multicastMask = LLVM::NVIDIA::createTMAMulticastMask(
-          loc, rewriter, static_cast<uint16_t>(op.getCtaMask()));
+          loc, rewriter, static_cast<uint16_t>(op.getMulticastCTA()));
     }
     if (multicastMask)
       operands.push_back(ptxBuilder.newOperand(multicastMask, "r"));


### PR DESCRIPTION
We found this interesting problem with in multicta consan where you
have a pattern that looks as follows in the CLC partition:

``` python
@gluon.jit
def consumer(slot, sink, consumed, layout: ttgl.constexpr):
    value = slot.load(layout)
    sink.store(value)
    mbarrier.arrive(consumed, count=1)

@gluon.jit
def clc_partition(slot, result, clc_bar, consumed):
    mbarrier.wait(consumed, 0, deps=[slot])
    mbarrier.expect(clc_bar, 16)
    clc.try_cancel(result, clc_bar)
    mbarrier.wait(clc_bar, 0)
    clc.load_result(result)
    slot.store(gl.full([1], 1, gl.int64, layout=layout))

```

Assume the kernel has 2 CTAs.

Then, the way that CLC works on multicast is that CTA0 tries to cancel
a block, and if it manages to do so, multicasts the result to all CTAs
(into `result` in this example).

What's rather surprising is that waiting on CTA1 on the the `clc_bar` where
this arrive is broadcasted DOES NOT transfer the visibility of the
`slot.load` from CTA0 to CTA1 so it sees `slot.store` as a race.

This is quite crazy as clearly there isn't a way for `slot.store` to
execute before the `slot.load` in the `consumer` partition has finished!

According to codex:
```
In this case there is an operational chain:
load finishes
 → consumed arrival
 → consumed wait finishes
 → CLC is issued
 → CLC completes
 → CLC wait finishes
 → store executes
 so it is entirely reasonable to conclude that the load/store cannot physically overlap.
 What PTX declines to infer is a transitive memory-synchronization edge through CLC.
CLC guarantees completion and visibility of its own response writes; it does not say
that completion publishes arbitrary operations that happened before the request was issued.
 This is intentional conservatism in the model, not an internal contradiction: completion/execution
order and cross-thread memory causality are separate concepts. In fact, the official CLC
example explicitly inserts synchronization between iterations before reusing the response storage;
it does not rely on CLC completion to order prior accesses. PTX CLC example
```

This PR adds a `0 <= mask < num_ctas`  whose on-bits represent the bits of the CTA that we shall use as the origin of the arrive / expect. In other words, we predicate the instruction by `cta_id & mask`. This allows us in this case to send the arrive / expect from CTA0 to all CTAs effectively sending the frontier visibility from CTA0 to all other CTAs when they wait on the barrier.

e.g. for 8 CTAS and `mask = 0x011`:
```
CTA0 -> CTA0, CTA4
CTA1 -> CTA1, CTA5
CTA2 -> CTA2, CTA6
CTA3 -> CTA3, CTA7
CTA4-7 -> predicated
```
and 8CTAs for `mask = 0b110`:
```
CTA0 -> CTA0, CTA1
CTA1 -> predicated
CTA2 -> CTA2, CTA3
CTA3 -> predicated
CTA4 -> CTA4, CTA5
CTA5 -> predicated
CTA6 -> CTA6, CTA7
CTA7 -> predicated
...

I also renamed and reordered the masks that `arrive` may receive.