### PR TITLE
triton_kernels: avoid recompiling topk for row strides

### DIFF
--- a/python/triton_kernels/triton_kernels/topk_details/_topk_forward.py
+++ b/python/triton_kernels/triton_kernels/topk_details/_topk_forward.py
@@ -91,8 +91,8 @@ def streaming_topk(X, stride_xm, n_expts_tot, offs_m, mask_m, N_EXPTS_PAD: tl.co
 @triton.jit
 def _topk_forward(X, stride_xm,  # inputs
                   PeerYvs, PeerYis, stride_ym,  # topk values/indices
-                  USE_PROVIDED_INDX: tl.constexpr, PeerBits, stride_rm: tl.constexpr,
-                  stride_rn: tl.constexpr,  # bitmatrix
+                  USE_PROVIDED_INDX: tl.constexpr, PeerBits, stride_rm,
+                  stride_rn,  # bitmatrix
                   n_rows, n_expts_tot,  # shape
                   dst_offs_m, APPLY_SOFTMAX: tl.constexpr,  # constant
                   BLOCK_M: tl.constexpr, N_EXPTS_PAD: tl.constexpr, N_EXPTS_ACT: tl.constexpr, BLOCK_N: tl.constexpr):


### PR DESCRIPTION
## Summary

`_topk_forward` currently marks the bitmatrix strides as `tl.constexpr`, even though they vary with the runtime row count. This makes each new 32-row bucket create a distinct JIT cache key and can cause repeated cold compilations during variable-size LLM inference.

This change passes `stride_rm` and `stride_rn` as regular runtime arguments. The values remain aligned at runtime, while the kernel no longer recompiles for every row-count bucket.

## Related issue

Closes #10872.

## Verification

- `python3 -m py_compile python/triton_kernels/triton_kernels/topk_details/_topk_forward.py`
- `git diff --check`
- GPU benchmark unavailable in this environment; the issue report includes H100 A/B measurements showing one compile instead of repeated bucket-specific compiles with no steady-state regression.
