### PR TITLE
[frontend] Validate 16-byte stride alignment in make_tensor_descriptor

### DIFF
--- a/python/test/gluon/test_core.py
+++ b/python/test/gluon/test_core.py
@@ -6,6 +6,7 @@ from itertools import product
 
 import triton
 import triton.language as tl
+from triton import CompilationError
 
 from triton._internal_testing import (
     is_compile_warmup,
@@ -1093,6 +1094,41 @@ def test_device_tma_store():
 
     tma_device_store_kernel[(1, )](out, XBLOCK, smem_layout)
     torch.testing.assert_close(out, torch.zeros_like(out))
+
+
+@pytest.mark.skipif(not is_hopper_or_newer(), reason="Requires Hopper")
+def test_device_tma_stride_alignment():
+
+    @gluon.jit
+    def kernel(input_ptr, XBLOCK: ttgl.constexpr, stride_m: ttgl.constexpr, smem_layout: ttgl.constexpr):
+        tma.make_tensor_descriptor(
+            input_ptr,
+            shape=[XBLOCK, XBLOCK],
+            strides=[stride_m, 1],
+            block_shape=[XBLOCK, XBLOCK],
+            layout=smem_layout,
+        )
+
+    XBLOCK = 16
+    inp = torch.zeros((XBLOCK, XBLOCK), device="cuda", dtype=torch.float16)
+    smem_layout = ttgl.NVMMASharedLayout(
+        swizzle_byte_width=32,
+        element_bitwidth=16,
+        rank=2,
+        transposed=False,
+        fp4_padded=False,
+    )
+
+    def alloc_fn(size: int, alignment: int, stream: int):
+        return torch.empty(size, device="cuda", dtype=torch.int8)
+
+    triton.set_allocator(alloc_fn)
+
+    # float16 is 2 bytes, so a stride of 15 => 30 bytes, which is not 16-byte aligned.
+    with pytest.raises(CompilationError, match="16-byte aligned"):
+        kernel[(1, )](inp, XBLOCK, 15, smem_layout)
+    # A stride of 16 => 32 bytes is aligned.
+    kernel[(1, )](inp, XBLOCK, XBLOCK, smem_layout)
 
 
 @gluon.jit

--- a/python/test/unit/language/test_tensor_descriptor.py
+++ b/python/test/unit/language/test_tensor_descriptor.py
@@ -4,7 +4,7 @@ import numpy as np
 
 import triton
 import triton.language as tl
-from triton._internal_testing import is_hopper, is_sm12x, is_interpreter, numpy_random, to_triton, unwrap_tensor, tma_dtypes, to_numpy
+from triton._internal_testing import is_hopper, is_sm12x, is_interpreter, numpy_random, to_triton, unwrap_tensor, tma_dtypes, to_numpy, run_in_process
 from triton.tools.mxfp import MXFP4Tensor, MXScaleTensor
 from typing import Optional
 from triton._internal_testing import is_compile_warmup, is_cuda, is_hip, is_hip_cdna3
@@ -1820,3 +1820,72 @@ def test_tensor_descriptor_store_downcast(dtype_str, device):
     kernel[(grid_m, grid_n)](desc, M, N, M_BLOCK=M_BLOCK, N_BLOCK=N_BLOCK)
     ref = torch.arange(M * N, dtype=torch.float32, device=device).reshape(M, N).to(torch_dtype)
     torch.testing.assert_close(out, ref)
+
+
+@pytest.mark.parametrize("dtype_str, misaligned_stride, aligned_stride",
+                         [("float16", 511, 512),  # 2 bytes: 1022 B rejected, 1024 B ok
+                          ("bfloat16", 511, 512),  # 2 bytes
+                          ("float32", 255, 256),  # 4 bytes: 1020 B rejected, 1024 B ok
+                          ])
+def test_tensor_descriptor_stride_alignment(dtype_str, misaligned_stride, aligned_stride, device):
+    if not is_cuda():
+        pytest.skip("Requires TMA support")
+    dtype = getattr(torch, dtype_str)
+
+    @triton.jit
+    def kernel(a_ptr, M, N, stride_m: tl.constexpr, M_BLOCK: tl.constexpr, N_BLOCK: tl.constexpr):
+        desc = tl.make_tensor_descriptor(a_ptr, shape=[M, N], strides=[stride_m, 1], block_shape=[M_BLOCK, N_BLOCK])
+        desc.load([0, 0])
+
+    def alloc_fn(size: int, align: int, stream: Optional[int]):
+        return torch.empty(size, dtype=torch.int8, device=device)
+
+    triton.set_allocator(alloc_fn)
+    a = torch.empty((32, aligned_stride), dtype=dtype, device=device)
+
+    with pytest.raises(CompilationError, match="16-byte aligned"):
+        kernel[(1, )](a, 32, misaligned_stride, stride_m=misaligned_stride, M_BLOCK=8, N_BLOCK=64)
+
+    kernel[(1, )](a, 32, aligned_stride, stride_m=aligned_stride, M_BLOCK=8, N_BLOCK=64)
+
+
+def _run_tensor_descriptor_dynamic_stride_iisan(device, stride_m_val):
+    triton.knobs.refresh_knobs()
+
+    @triton.jit
+    def kernel(a_ptr, M, N, stride_m, M_BLOCK: tl.constexpr, N_BLOCK: tl.constexpr):
+        desc = tl.make_tensor_descriptor(
+            a_ptr,
+            shape=[M, N],
+            strides=[stride_m, 1],
+            block_shape=[M_BLOCK, N_BLOCK],
+        )
+        desc.load([0, 0])
+
+    def alloc_fn(size: int, align: int, stream: Optional[int]):
+        return torch.empty(size, dtype=torch.int8, device=device)
+
+    triton.set_allocator(alloc_fn)
+    a = torch.empty((32, 512), dtype=torch.bfloat16, device=device)
+    stride_m = torch.tensor(stride_m_val, device=device, dtype=torch.int64)
+    kernel[(1, )](a, 32, 512, stride_m, M_BLOCK=8, N_BLOCK=64)
+    torch.cuda.synchronize()
+
+
+@pytest.mark.skipif(not is_cuda() or torch.cuda.get_device_capability()[0] < 9, reason="Requires TMA (Hopper+)")
+def test_tensor_descriptor_stride_alignment_iisan_dynamic(device):
+    base_env = {"CUDA_LAUNCH_BLOCKING": "1", "TRITON_INSTRUMENTATION_MODE": "iisan"}
+
+    ok = run_in_process(_run_tensor_descriptor_dynamic_stride_iisan, (device, 512), env=base_env)
+    assert ok.exc is None, ok.exc
+
+    bad = run_in_process(_run_tensor_descriptor_dynamic_stride_iisan, (device, 511), env=base_env)
+    assert bad.exc is not None
+    assert any(msg in str(bad.exc).lower() for msg in ["device-side assert", "unspecified launch failure"])
+
+    without_iisan = run_in_process(
+        _run_tensor_descriptor_dynamic_stride_iisan,
+        (device, 511),
+        env={"CUDA_LAUNCH_BLOCKING": "1", "TRITON_INSTRUMENTATION_MODE": ""},
+    )
+    assert without_iisan.exc is None, without_iisan.exc

--- a/python/test/unit/language/test_tensor_descriptor.py
+++ b/python/test/unit/language/test_tensor_descriptor.py
@@ -4,7 +4,7 @@ import numpy as np
 
 import triton
 import triton.language as tl
-from triton._internal_testing import is_hopper, is_sm12x, is_interpreter, numpy_random, to_triton, unwrap_tensor, tma_dtypes, to_numpy
+from triton._internal_testing import is_hopper, is_sm12x, is_interpreter, numpy_random, to_triton, unwrap_tensor, tma_dtypes, to_numpy, run_in_process
 from triton.tools.mxfp import MXFP4Tensor, MXScaleTensor
 from typing import Optional
 from triton._internal_testing import is_cuda, is_hip, is_hip_cdna3
@@ -1814,3 +1814,72 @@ def test_tensor_descriptor_store_downcast(dtype_str, device):
     kernel[(grid_m, grid_n)](desc, M, N, M_BLOCK=M_BLOCK, N_BLOCK=N_BLOCK)
     ref = torch.arange(M * N, dtype=torch.float32, device=device).reshape(M, N).to(torch_dtype)
     torch.testing.assert_close(out, ref)
+
+
+@pytest.mark.parametrize("dtype_str, misaligned_stride, aligned_stride",
+                         [("float16", 511, 512),  # 2 bytes: 1022 B rejected, 1024 B ok
+                          ("bfloat16", 511, 512),  # 2 bytes
+                          ("float32", 255, 256),  # 4 bytes: 1020 B rejected, 1024 B ok
+                          ])
+def test_tensor_descriptor_stride_alignment(dtype_str, misaligned_stride, aligned_stride, device):
+    if not is_cuda():
+        pytest.skip("Requires TMA support")
+    dtype = getattr(torch, dtype_str)
+
+    @triton.jit
+    def kernel(a_ptr, M, N, stride_m: tl.constexpr, M_BLOCK: tl.constexpr, N_BLOCK: tl.constexpr):
+        desc = tl.make_tensor_descriptor(a_ptr, shape=[M, N], strides=[stride_m, 1], block_shape=[M_BLOCK, N_BLOCK])
+        desc.load([0, 0])
+
+    def alloc_fn(size: int, align: int, stream: Optional[int]):
+        return torch.empty(size, dtype=torch.int8, device=device)
+
+    triton.set_allocator(alloc_fn)
+    a = torch.empty((32, aligned_stride), dtype=dtype, device=device)
+
+    with pytest.raises(CompilationError, match="16-byte aligned"):
+        kernel[(1, )](a, 32, misaligned_stride, stride_m=misaligned_stride, M_BLOCK=8, N_BLOCK=64)
+
+    kernel[(1, )](a, 32, aligned_stride, stride_m=aligned_stride, M_BLOCK=8, N_BLOCK=64)
+
+
+def _run_tensor_descriptor_dynamic_stride_iisan(device, stride_m_val):
+    triton.knobs.refresh_knobs()
+
+    @triton.jit
+    def kernel(a_ptr, M, N, stride_m, M_BLOCK: tl.constexpr, N_BLOCK: tl.constexpr):
+        desc = tl.make_tensor_descriptor(
+            a_ptr,
+            shape=[M, N],
+            strides=[stride_m, 1],
+            block_shape=[M_BLOCK, N_BLOCK],
+        )
+        desc.load([0, 0])
+
+    def alloc_fn(size: int, align: int, stream: Optional[int]):
+        return torch.empty(size, dtype=torch.int8, device=device)
+
+    triton.set_allocator(alloc_fn)
+    a = torch.empty((32, 512), dtype=torch.bfloat16, device=device)
+    stride_m = torch.tensor(stride_m_val, device=device, dtype=torch.int64)
+    kernel[(1, )](a, 32, 512, stride_m, M_BLOCK=8, N_BLOCK=64)
+    torch.cuda.synchronize()
+
+
+@pytest.mark.skipif(not is_cuda() or torch.cuda.get_device_capability()[0] < 9, reason="Requires TMA (Hopper+)")
+def test_tensor_descriptor_stride_alignment_iisan_dynamic(device):
+    base_env = {"CUDA_LAUNCH_BLOCKING": "1", "TRITON_INSTRUMENTATION_MODE": "iisan"}
+
+    ok = run_in_process(_run_tensor_descriptor_dynamic_stride_iisan, (device, 512), env=base_env)
+    assert ok.exc is None, ok.exc
+
+    bad = run_in_process(_run_tensor_descriptor_dynamic_stride_iisan, (device, 511), env=base_env)
+    assert bad.exc is not None
+    assert any(msg in str(bad.exc).lower() for msg in ["device-side assert", "unspecified launch failure"])
+
+    without_iisan = run_in_process(
+        _run_tensor_descriptor_dynamic_stride_iisan,
+        (device, 511),
+        env={"CUDA_LAUNCH_BLOCKING": "1", "TRITON_INSTRUMENTATION_MODE": ""},
+    )
+    assert without_iisan.exc is None, without_iisan.exc

--- a/python/test/unit/language/test_tensor_descriptor.py
+++ b/python/test/unit/language/test_tensor_descriptor.py
@@ -1827,7 +1827,7 @@ def test_tensor_descriptor_store_downcast(dtype_str, device):
                           ("bfloat16", 511, 512),  # 2 bytes
                           ("float32", 255, 256),  # 4 bytes: 1020 B rejected, 1024 B ok
                           ])
-def test_tensor_descriptor_stride_alignment(dtype_str, misaligned_stride, aligned_stride, device):
+def test_tensor_descriptor_stride_alignment(dtype_str, misaligned_stride, aligned_stride, device, with_allocator):
     if not is_cuda():
         pytest.skip("Requires TMA support")
     dtype = getattr(torch, dtype_str)
@@ -1837,10 +1837,6 @@ def test_tensor_descriptor_stride_alignment(dtype_str, misaligned_stride, aligne
         desc = tl.make_tensor_descriptor(a_ptr, shape=[M, N], strides=[stride_m, 1], block_shape=[M_BLOCK, N_BLOCK])
         desc.load([0, 0])
 
-    def alloc_fn(size: int, align: int, stream: Optional[int]):
-        return torch.empty(size, dtype=torch.int8, device=device)
-
-    triton.set_allocator(alloc_fn)
     a = torch.empty((32, aligned_stride), dtype=dtype, device=device)
 
     with pytest.raises(CompilationError, match="16-byte aligned"):
@@ -1849,7 +1845,7 @@ def test_tensor_descriptor_stride_alignment(dtype_str, misaligned_stride, aligne
     kernel[(1, )](a, 32, aligned_stride, stride_m=aligned_stride, M_BLOCK=8, N_BLOCK=64)
 
 
-def _run_tensor_descriptor_dynamic_stride_iisan(device, stride_m_val):
+def _run_tensor_descriptor_dynamic_iisan(device, stride_m_val, base_byte_offset=0):
     triton.knobs.refresh_knobs()
 
     @triton.jit
@@ -1866,26 +1862,34 @@ def _run_tensor_descriptor_dynamic_stride_iisan(device, stride_m_val):
         return torch.empty(size, dtype=torch.int8, device=device)
 
     triton.set_allocator(alloc_fn)
-    a = torch.empty((32, 512), dtype=torch.bfloat16, device=device)
-    stride_m = torch.tensor(stride_m_val, device=device, dtype=torch.int64)
-    kernel[(1, )](a, 32, 512, stride_m, M_BLOCK=8, N_BLOCK=64)
+
+    n_bytes = 32 * 512 * 2  # bfloat16
+    buf = torch.empty(n_bytes + base_byte_offset, dtype=torch.int8, device=device)
+    a = buf[base_byte_offset:base_byte_offset + n_bytes].view(torch.bfloat16).reshape(32, 512)
+
+    kernel[(1, )](a, 32, 512, stride_m_val, M_BLOCK=8, N_BLOCK=64)
     torch.cuda.synchronize()
 
 
 @pytest.mark.skipif(not is_cuda() or torch.cuda.get_device_capability()[0] < 9, reason="Requires TMA (Hopper+)")
-def test_tensor_descriptor_stride_alignment_iisan_dynamic(device):
+def test_tensor_descriptor_alignment_iisan_dynamic(device):
+
     base_env = {"CUDA_LAUNCH_BLOCKING": "1", "TRITON_INSTRUMENTATION_MODE": "iisan"}
 
-    ok = run_in_process(_run_tensor_descriptor_dynamic_stride_iisan, (device, 512), env=base_env)
+    ok = run_in_process(_run_tensor_descriptor_dynamic_iisan, (device, 512, 0), env=base_env)
     assert ok.exc is None, ok.exc
 
-    bad = run_in_process(_run_tensor_descriptor_dynamic_stride_iisan, (device, 511), env=base_env)
-    assert bad.exc is not None
-    assert any(msg in str(bad.exc).lower() for msg in ["device-side assert", "unspecified launch failure"])
+    bad_stride = run_in_process(_run_tensor_descriptor_dynamic_iisan, (device, 511, 0), env=base_env)
+    assert bad_stride.exc is not None
+    assert "device-side assert" in str(bad_stride.exc).lower(), bad_stride.exc
+
+    bad_ptr = run_in_process(_run_tensor_descriptor_dynamic_iisan, (device, 512, 8), env=base_env)
+    assert bad_ptr.exc is not None
+    assert "device-side assert" in str(bad_ptr.exc).lower(), bad_ptr.exc
 
     without_iisan = run_in_process(
-        _run_tensor_descriptor_dynamic_stride_iisan,
-        (device, 511),
+        _run_tensor_descriptor_dynamic_iisan,
+        (device, 511, 0),
         env={"CUDA_LAUNCH_BLOCKING": "1", "TRITON_INSTRUMENTATION_MODE": ""},
     )
     assert without_iisan.exc is None, without_iisan.exc

--- a/python/triton/experimental/gluon/language/nvidia/hopper/tma.py
+++ b/python/triton/experimental/gluon/language/nvidia/hopper/tma.py
@@ -445,8 +445,14 @@ def make_tensor_descriptor(
     if last_stride != 1:
         raise ValueError(f"Tensor descriptor last dim must be 1 but got {last_stride}")
 
+    _semantic._check_tensor_descriptor_alignment_static(strides, elem_size)
+
+    stride_sources = strides
     shape = [_semantic.make_scalar(x, ttgl.int32) for x in shape]
     strides = [_semantic.make_scalar(ttgl._unwrap_if_constexpr(x), ttgl.int64) for x in strides]
+
+    if _semantic.builder.options.enable_iisan:
+        _semantic._iisan_check_tensor_descriptor_alignment(base, strides, elem_size, stride_sources)
 
     # Check whether `block_shape` is static
     block_shape = ttgl._unwrap_shape(block_shape)

--- a/python/triton/language/semantic.py
+++ b/python/triton/language/semantic.py
@@ -1871,6 +1871,20 @@ class TritonSemantic(Generic[TensorTy]):
             return [self._convert_elem_to_ir_value(elem, require_i64) for elem in list_like]
         return [self._convert_elem_to_ir_value(list_like, require_i64)]
 
+    def _iisan_check_tensor_descriptor_stride_alignment(self, strides: List[TensorTy], elem_size: int,
+                                                        stride_sources: List) -> None:
+        # Gluon TMA ops emit similar alignment checks when instrumentation_mode=iisan.
+        align_bytes = self.make_scalar(16, tl.int64)
+        zero = self.make_scalar(0, tl.int64)
+        elem_bytes = self.make_scalar(elem_size, tl.int64)
+        for source, stride in zip(stride_sources[:-1], strides[:-1]):
+            if isinstance(tl._unwrap_if_constexpr(source), int):
+                continue
+            byte_stride = self.mul(stride, elem_bytes, sanitize_overflow=False)
+            rem = self.mod(byte_stride, align_bytes)
+            is_aligned = self.equal(rem, zero)
+            self.device_assert(is_aligned, "Tensor descriptor strides must be 16-byte aligned", None)
+
     def make_tensor_descriptor(self, base: TensorTy, shape: List[TensorTy], strides: List[TensorTy],
                                block_shape: List[tl.constexpr], padding_option: str = "zero") -> tl.tensor_descriptor:
         ndim = len(shape)
@@ -1892,8 +1906,19 @@ class TritonSemantic(Generic[TensorTy]):
         if last_stride != 1:
             raise ValueError(f"Tensor descriptor last dim must be 1 but got {last_stride}")
 
+        for stride in strides[:-1]:
+            static_stride = tl._unwrap_if_constexpr(stride)
+            if isinstance(static_stride, int) and (static_stride * elem_size) % 16 != 0:
+                raise ValueError(
+                    f"Tensor descriptor strides must be 16-byte aligned, but got a stride of {static_stride} * {elem_size} = {static_stride * elem_size} bytes"
+                )
+
+        stride_sources = strides
         shape = [self.make_scalar(x, tl.int32) for x in shape]
         strides = [self.make_scalar(tl._unwrap_if_constexpr(x), tl.int64) for x in strides]
+
+        if getattr(self.builder.options, "enable_iisan", False):
+            self._iisan_check_tensor_descriptor_stride_alignment(strides, elem_size, stride_sources)
 
         # Check whether `block_shape` is static
         block_shape = tl._unwrap_shape(block_shape)

--- a/python/triton/language/semantic.py
+++ b/python/triton/language/semantic.py
@@ -1865,6 +1865,20 @@ class TritonSemantic(Generic[TensorTy]):
             return [self._convert_elem_to_ir_value(elem, require_i64) for elem in list_like]
         return [self._convert_elem_to_ir_value(list_like, require_i64)]
 
+    def _iisan_check_tensor_descriptor_stride_alignment(self, strides: List[TensorTy], elem_size: int,
+                                                        stride_sources: List) -> None:
+        # Gluon TMA ops emit similar alignment checks when instrumentation_mode=iisan.
+        align_bytes = self.make_scalar(16, tl.int64)
+        zero = self.make_scalar(0, tl.int64)
+        elem_bytes = self.make_scalar(elem_size, tl.int64)
+        for source, stride in zip(stride_sources[:-1], strides[:-1]):
+            if isinstance(tl._unwrap_if_constexpr(source), int):
+                continue
+            byte_stride = self.mul(stride, elem_bytes, sanitize_overflow=False)
+            rem = self.mod(byte_stride, align_bytes)
+            is_aligned = self.equal(rem, zero)
+            self.device_assert(is_aligned, "Tensor descriptor strides must be 16-byte aligned", None)
+
     def make_tensor_descriptor(self, base: TensorTy, shape: List[TensorTy], strides: List[TensorTy],
                                block_shape: List[tl.constexpr], padding_option: str = "zero") -> tl.tensor_descriptor:
         ndim = len(shape)
@@ -1886,8 +1900,19 @@ class TritonSemantic(Generic[TensorTy]):
         if last_stride != 1:
             raise ValueError(f"Tensor descriptor last dim must be 1 but got {last_stride}")
 
+        for stride in strides[:-1]:
+            static_stride = tl._unwrap_if_constexpr(stride)
+            if isinstance(static_stride, int) and (static_stride * elem_size) % 16 != 0:
+                raise ValueError(
+                    f"Tensor descriptor strides must be 16-byte aligned, but got a stride of {static_stride} * {elem_size} = {static_stride * elem_size} bytes"
+                )
+
+        stride_sources = strides
         shape = [self.make_scalar(x, tl.int32) for x in shape]
         strides = [self.make_scalar(tl._unwrap_if_constexpr(x), tl.int64) for x in strides]
+
+        if getattr(self.builder.options, "enable_iisan", False):
+            self._iisan_check_tensor_descriptor_stride_alignment(strides, elem_size, stride_sources)
 
         # Check whether `block_shape` is static
         block_shape = tl._unwrap_shape(block_shape)

--- a/python/triton/language/semantic.py
+++ b/python/triton/language/semantic.py
@@ -1865,19 +1865,33 @@ class TritonSemantic(Generic[TensorTy]):
             return [self._convert_elem_to_ir_value(elem, require_i64) for elem in list_like]
         return [self._convert_elem_to_ir_value(list_like, require_i64)]
 
-    def _iisan_check_tensor_descriptor_stride_alignment(self, strides: List[TensorTy], elem_size: int,
-                                                        stride_sources: List) -> None:
-        # Gluon TMA ops emit similar alignment checks when instrumentation_mode=iisan.
+    def _check_tensor_descriptor_alignment_static(self, strides: List[TensorTy], elem_size: int) -> None:
+        # Reject statically-known strides that aren't 16-byte aligned per TMA requirement.
+        # Shared by the `tl` and `gluon` `make_tensor_descriptor` builders.
+        for stride in strides[:-1]:
+            static_stride = tl._unwrap_if_constexpr(stride)
+            if isinstance(static_stride, int) and (static_stride * elem_size) % 16 != 0:
+                raise ValueError(f"Tensor descriptor strides must be 16-byte aligned, but got a stride of "
+                                 f"{static_stride} * {elem_size} = {static_stride * elem_size} bytes")
+
+    def _iisan_check_tensor_descriptor_alignment(self, base: TensorTy, strides: List[TensorTy], elem_size: int,
+                                                 stride_sources: List) -> None:
+        # Emit device-side alignment asserts under instrumentation_mode=iisan for the values the
+        # static check can't see: the base pointer and any dynamic (runtime) strides.
         align_bytes = self.make_scalar(16, tl.int64)
         zero = self.make_scalar(0, tl.int64)
         elem_bytes = self.make_scalar(elem_size, tl.int64)
+
+        base_addr = self.cast(base, tl.int64)
+        base_rem = self.mod(base_addr, align_bytes)
+        self.device_assert(self.equal(base_rem, zero), "Tensor descriptor base pointer must be 16-byte aligned", None)
+
         for source, stride in zip(stride_sources[:-1], strides[:-1]):
             if isinstance(tl._unwrap_if_constexpr(source), int):
                 continue
             byte_stride = self.mul(stride, elem_bytes, sanitize_overflow=False)
             rem = self.mod(byte_stride, align_bytes)
-            is_aligned = self.equal(rem, zero)
-            self.device_assert(is_aligned, "Tensor descriptor strides must be 16-byte aligned", None)
+            self.device_assert(self.equal(rem, zero), "Tensor descriptor strides must be 16-byte aligned", None)
 
     def make_tensor_descriptor(self, base: TensorTy, shape: List[TensorTy], strides: List[TensorTy],
                                block_shape: List[tl.constexpr], padding_option: str = "zero") -> tl.tensor_descriptor:
@@ -1900,19 +1914,14 @@ class TritonSemantic(Generic[TensorTy]):
         if last_stride != 1:
             raise ValueError(f"Tensor descriptor last dim must be 1 but got {last_stride}")
 
-        for stride in strides[:-1]:
-            static_stride = tl._unwrap_if_constexpr(stride)
-            if isinstance(static_stride, int) and (static_stride * elem_size) % 16 != 0:
-                raise ValueError(
-                    f"Tensor descriptor strides must be 16-byte aligned, but got a stride of {static_stride} * {elem_size} = {static_stride * elem_size} bytes"
-                )
+        self._check_tensor_descriptor_alignment_static(strides, elem_size)
 
         stride_sources = strides
         shape = [self.make_scalar(x, tl.int32) for x in shape]
         strides = [self.make_scalar(tl._unwrap_if_constexpr(x), tl.int64) for x in strides]
 
         if getattr(self.builder.options, "enable_iisan", False):
-            self._iisan_check_tensor_descriptor_stride_alignment(strides, elem_size, stride_sources)
+            self._iisan_check_tensor_descriptor_alignment(base, strides, elem_size, stride_sources)
 
         # Check whether `block_shape` is static
         block_shape = tl._unwrap_shape(block_shape)


### PR DESCRIPTION
### Summary (updated)

TMA needs every non-contiguous descriptor stride to be 16-byte aligned. Host `TensorDescriptor` already checks; device `tl.make_tensor_descriptor` did not, so misaligned strides could silence wrong results on device TMA (#10927, tried on sm100).

Example: bf16 `[M, K]`, `K=511` → row stride 1022 B (not ÷16) → broken tiles + wrong `tl.dot`. 

### Fixes

- Compile-time `ValueError` for **static** misaligned strides (matches host message).
- **Dynamic** strides: still a precondition in normal builds; **`TRITON_INSTRUMENTATION_MODE=iisan`** adds device asserts for non-constexpr strides only (Gluon TMA pattern — no always-on / debug-only assert).

summary of how solved:
```
Case                          normal              iisan
static misaligned stride      compile error       compile error
dynamic misaligned stride     no check            device assert
dynamic aligned stride          unchanged           unchanged
```

### checklist
- [x] I am not making a trivial change, such as fixing a typo in a comment.
- [x] I have written a PR description following these [rules](https://cbea.ms/git-commit/#why-not-how).
- [x] I have run `pre-commit run --from-ref origin/main --to-ref HEAD`.
- [x] I have added tests (`/python/test`).
- [x] I have not added any `lit` tests.

Fixes #10927

<details>
<summary>Env — develop & test</summary>

- Triton: this branch on `triton-lang/triton` main + frontend changes in `semantic.py`
- Tests: `python/test/unit/language/test_tensor_descriptor.py` (static compile error, iisan dynamic stride on Hopper+)
- iisan: `TRITON_INSTRUMENTATION_MODE=iisan`, `CUDA_LAUNCH_BLOCKING=1` in subprocess tests

</details>

<details>
<summary>Env — where #10927 shows up</summary>

- **Bug:** device-side descriptor + TMA gather/load × `tl.dot`, misaligned leading stride → wrong output (reported on **Blackwell sm100**)
- **Repro shape:** bf16, leading stride not multiple of 16 bytes (e.g. `K=511`)

</details>

<details>
<summary>Driver / API — host vs device</summary>

- **Host** `TensorDescriptor` / `cuTensorMapEncodeTiled`: invalid stride → **`CUDA_ERROR_INVALID_VALUE`** (seen with driver **580.159.03**, CUDA **13.0**)
- **Device** `tl.make_tensor_descriptor`: builds tensormap on-device, **does not** call that encode path → **no driver error**, silent miscompute until this PR (compile error or iisan assert)

</details>