### PR TITLE
[release/3.8.x] Use torch CUDA check when available

### DIFF
--- a/third_party/nvidia/backend/driver.py
+++ b/third_party/nvidia/backend/driver.py
@@ -381,6 +381,12 @@ class CudaDriver(GPUDriver):
 
     @staticmethod
     def is_active():
+        # Temporary workaround for torch-loaded processes: cuInit(0) is not
+        # fork-safe after CUDA initialization and can make Triton report no
+        # active driver from forked workers.
+        torch = sys.modules.get("torch")
+        if torch is not None:
+            return torch.cuda.is_available() and torch.version.hip is None
         return _cuda_driver_is_active()
 
     def map_python_to_cpp_type(self, ty: str) -> str:


### PR DESCRIPTION
## Context
Triton #9578 changed `CudaDriver.is_active()` implementation from using `torch.cuda.is_available()` to`cuInit(0)`. This breaks some use cases for downstream customers like vLLM and PyTorch (vllm-project/vllm#46996 and pytorch/pytorch#189287) since `cuInit(0)` poisons the CUDA state of any forked children.

## Details
We explored several options for rearchitecting PyTorch/Triton to fix this in a scalable way, however to mitigate for Triton 3.8 release we are implementing a solution here to use the Torch CUDA availability check when torch is already imported. This restores behavior prior to the initial PR and fixes both issues linked above

Validated on H100

cc @ThomasRaoux @njriasan 