### PR TITLE
[NVIDIA] Initial support for Rubin

### DIFF
--- a/include/triton/Dialect/TritonNvidiaGPU/IR/TargetFeatures.h
+++ b/include/triton/Dialect/TritonNvidiaGPU/IR/TargetFeatures.h
@@ -58,6 +58,8 @@ public:
     return computeCapability >= 103 && computeCapability / 10 != 12;
   }
 
+  bool supportsI8Tcgen05MMA() const { return computeCapability == 100; }
+
 private:
   static constexpr char kTargetPrefix[] = "cuda:";
 

--- a/include/triton/Dialect/TritonNvidiaGPU/IR/TargetFeatures.h
+++ b/include/triton/Dialect/TritonNvidiaGPU/IR/TargetFeatures.h
@@ -69,6 +69,7 @@ public:
   }
   bool supports4xFp4Tcgen05MMA() const { return computeCapability == 107; }
   bool supports2xFp8Tcgen05MMA() const { return computeCapability == 107; }
+  bool supportsReuseB() const { return computeCapability == 107; }
 
 private:
   static constexpr char kTargetPrefix[] = "cuda:";

--- a/include/triton/Dialect/TritonNvidiaGPU/IR/TargetFeatures.h
+++ b/include/triton/Dialect/TritonNvidiaGPU/IR/TargetFeatures.h
@@ -59,6 +59,10 @@ public:
   }
 
   bool supportsI8Tcgen05MMA() const { return computeCapability == 100; }
+  bool supportsExclusiveTMEMAlloc() const { return computeCapability == 107; }
+  int getMaxTMEMColumns() const {
+    return supportsExclusiveTMEMAlloc() ? 576 : 512;
+  }
 
 private:
   static constexpr char kTargetPrefix[] = "cuda:";

--- a/include/triton/Dialect/TritonNvidiaGPU/IR/TargetFeatures.h
+++ b/include/triton/Dialect/TritonNvidiaGPU/IR/TargetFeatures.h
@@ -63,6 +63,12 @@ public:
   int getMaxTMEMColumns() const {
     return supportsExclusiveTMEMAlloc() ? 576 : 512;
   }
+  bool requiresFp4Padding() const {
+    return computeCapability == 100 || computeCapability == 103 ||
+           computeCapability == 110;
+  }
+  bool supports4xFp4Tcgen05MMA() const { return computeCapability == 107; }
+  bool supports2xFp8Tcgen05MMA() const { return computeCapability == 107; }
 
 private:
   static constexpr char kTargetPrefix[] = "cuda:";

--- a/lib/Dialect/TritonGPU/Transforms/AccelerateMatmul.cpp
+++ b/lib/Dialect/TritonGPU/Transforms/AccelerateMatmul.cpp
@@ -31,7 +31,7 @@ namespace gpu {
 namespace {
 
 static bool isUnsupportedMMAv5Int8Dot(int computeCapability, DotOp op) {
-  if (computeCapability != 103)
+  if (nvidia_gpu::TargetFeatures(computeCapability).supportsI8Tcgen05MMA())
     return false;
   auto aElemTy = op.getA().getType().getElementType();
   auto bElemTy = op.getB().getType().getElementType();

--- a/lib/Dialect/TritonGPU/Transforms/AccelerateMatmul.cpp
+++ b/lib/Dialect/TritonGPU/Transforms/AccelerateMatmul.cpp
@@ -859,10 +859,29 @@ public:
       else if (isBFP4)
         IsBMixedPrecFp4 = true;
     }
-    // If we use txgen05.mma.kind.mxf864 we need to padd the fp4 operands:
+
+    bool isFp4MMA = isAFP4 && isBFP4;
+    bool requiresFp4Padding =
+        nvidia_gpu::TargetFeatures(computeCapability).requiresFp4Padding();
+
+    // On Blackwell, if we use mixed-precision MMA we need to pad the fp4
+    // operand
     // https://docs.nvidia.com/cuda/parallel-thread-execution/#tcgen05-packing-formats-mxf8f6f4-smem
-    bool isMMAv5Fp4PaddedLhs = IsAMixedPrecFp4 || !dotOp.getLhsKPack();
-    bool isMMAv5Fp4PaddedRhs = IsBMixedPrecFp4 || !dotOp.getRhsKPack();
+    // On Rubin, the fp4 operand must be packed in SMEM if MMA_K = 64 is used.
+    // However, MMA_K = 64 with MN-major fp4 is not supported. In this case,
+    // the fp4 operand must be padded and MMA_K = 32 must be used.
+    // MMA_K = 64 is also not supported when BLOCK_M = 64.
+    auto blockK = dotOp.getA().getType().getShape().back() * (isAFP4 ? 2 : 1);
+    auto blockM = dotOp.getA().getType().getShape()[0];
+    bool isMMAv5Fp4PaddedLhs =
+        (isFp4MMA && !dotOp.getLhsKPack()) || // fp4  x fp4 with M-major A
+        (IsAMixedPrecFp4 && (requiresFp4Padding || blockM == 64 ||
+                             blockK == 32 || !dotOp.getLhsKPack()));
+    bool isMMAv5Fp4PaddedRhs =
+        (isFp4MMA && !dotOp.getRhsKPack()) || // fp4  x fp4 with N-major B
+        (IsBMixedPrecFp4 &&
+         (requiresFp4Padding || blockK == 32 || !dotOp.getRhsKPack()));
+
     // For mixed-precision fp4 operands, set allowTranspose = false, to force
     // the packed axis, K, to be contiguous in SMEM
     a = getSharedMemoryMMAOperand(a, rewriter, 0,

--- a/lib/Dialect/TritonNvidiaGPU/Transforms/TensorMemoryAllocation.cpp
+++ b/lib/Dialect/TritonNvidiaGPU/Transforms/TensorMemoryAllocation.cpp
@@ -8,6 +8,7 @@
 #include "triton/Dialect/Triton/IR/Utility.h"
 #include "triton/Dialect/TritonGPU/IR/Dialect.h"
 #include "triton/Dialect/TritonGPU/IR/Traits.h"
+#include "triton/Dialect/TritonGPU/Transforms/Utility.h"
 #include "triton/Dialect/TritonNvidiaGPU/IR/Dialect.h"
 #include "triton/Dialect/TritonNvidiaGPU/Transforms/Passes.h"
 #include "llvm/ADT/EquivalenceClasses.h"
@@ -401,11 +402,12 @@ public:
     // TODO: handle cases with multiple function with TMEMAllocOp.
     int totalMemorySize = allocateTMem(mod, offsets);
 
-    std::array<int, 6> possibleAllocations = {0, 32, 64, 128, 256, 512};
-    // NOTE: if totalMemorySize > 512 we exceeded the maximum amount of tensor
-    // memory, but we let the compilation finish so that we can raise an
+    std::vector<int> possibleAllocations = {0, 32, 64, 128, 256, 512, 576};
+    // NOTE: if totalMemorySize > the maximum available for the target (512
+    // for Blackwell and 576 for Rubin), we exceeded the maximum amount of
+    // tensor memory, but we let the compilation finish so that we can raise an
     // exception in python for the auto-tuner.
-    if (totalMemorySize <= 512) {
+    if (totalMemorySize <= possibleAllocations.back()) {
       for (int size : possibleAllocations) {
         if (totalMemorySize <= size) {
           totalMemorySize = size;

--- a/python/examples/gluon/05-moe-bmm1-fused-gather.py
+++ b/python/examples/gluon/05-moe-bmm1-fused-gather.py
@@ -1530,7 +1530,7 @@ def test_op(c: MLPConfig, batch_size: int):
     assert_close(
         ref_y.to(torch.float32),
         cand_y.to(torch.float32),
-        maxtol=0.125,
+        maxtol=0.126,
         rmstol=None,
         description=f"{description}:out",
         verbose=False,

--- a/python/test/gluon/test_core.py
+++ b/python/test/gluon/test_core.py
@@ -5153,3 +5153,140 @@ def test_mma_scaled_tcgen05_copy(M, N, K, BLOCK_K, a_format, b_format, VEC_SIZE,
     C_ref = A_ref @ B_ref.T
     C = mma_scaled_tcgen05_copy(A, B, A_scale, B_scale, VEC_SIZE, BLOCK_M, BLOCK_N, BLOCK_K, ctas_per_cga, multicast)
     torch.testing.assert_close(C_ref, C.to(torch.float32), atol=1e-3, rtol=1e-3)
+
+
+@gluon.jit
+def tmem288k_simple_kernel(in_ptr, out_ptr, M: ttgl.constexpr, Ncol1: ttgl.constexpr, Ncol2: ttgl.constexpr,
+                           num_warps: ttgl.constexpr):
+    global_memory_layout: ttgl.constexpr = ttgl.BlockedLayout([1, 1], [1, 32], [1, num_warps], [1, 0])
+
+    offs_m = ttgl.arange(0, M, ttgl.SliceLayout(1, global_memory_layout))
+    offs_n128 = ttgl.arange(0, 128, ttgl.SliceLayout(0, global_memory_layout))
+    offs_n32 = ttgl.arange(0, 32, ttgl.SliceLayout(0, global_memory_layout))
+
+    N: ttgl.constexpr = Ncol1 + Ncol2
+
+    # Allocate some tensor memory.
+    tmem_layout: ttgl.constexpr = TensorMemoryLayout(
+        block=(128, 32),
+        col_stride=32 // in_ptr.dtype.element_ty.primitive_bitwidth,
+    )
+
+    tmem1 = allocate_tensor_memory(
+        element_ty=in_ptr.dtype.element_ty,
+        shape=[M, Ncol1],
+        layout=tmem_layout,
+    )
+    if Ncol2 > 0:
+        tmem2 = allocate_tensor_memory(
+            element_ty=in_ptr.dtype.element_ty,
+            shape=[M, Ncol2],
+            layout=tmem_layout,
+        )
+
+    # Get the register layout needed to access tensor memory from descriptors.
+    tmem_reg_layout1: ttgl.constexpr = tmem1.slice(0, 128).get_reg_layout(num_warps=num_warps)
+    if Ncol2 > 0:
+        tmem_reg_layout2: ttgl.constexpr = tmem2.slice(0, 32).get_reg_layout(num_warps=num_warps)
+
+    assert Ncol1 == 128 or Ncol1 == 256 or Ncol1 == 512
+
+    n1a: ttgl.constexpr = 0
+    offs = offs_m[:, None] * N + n1a + offs_n128[None, :]
+    input = ttgl.load(in_ptr + offs)
+    input = ttgl.convert_layout(input, tmem_reg_layout1)
+    tmem_slice = tmem1.slice(n1a, 128)
+    tmem_slice.store(input)
+
+    if Ncol1 > 128:
+        n1b: ttgl.constexpr = 128
+        offs = offs_m[:, None] * N + n1b + offs_n128[None, :]
+        input = ttgl.load(in_ptr + offs)
+        input = ttgl.convert_layout(input, tmem_reg_layout1)
+        tmem_slice = tmem1.slice(n1b, 128)
+        tmem_slice.store(input)
+
+    if Ncol1 > 256:
+        n1c: ttgl.constexpr = 256
+        offs = offs_m[:, None] * N + n1c + offs_n128[None, :]
+        input = ttgl.load(in_ptr + offs)
+        input = ttgl.convert_layout(input, tmem_reg_layout1)
+        tmem_slice = tmem1.slice(n1c, 128)
+        tmem_slice.store(input)
+
+        n1d: ttgl.constexpr = 384
+        offs = offs_m[:, None] * N + n1d + offs_n128[None, :]
+        input = ttgl.load(in_ptr + offs)
+        input = ttgl.convert_layout(input, tmem_reg_layout1)
+        tmem_slice = tmem1.slice(n1d, 128)
+        tmem_slice.store(input)
+
+    if Ncol2 > 0:
+        n2a: ttgl.constexpr = 0
+        offs = offs_m[:, None] * N + Ncol1 + n2a + offs_n32[None, :]
+        input = ttgl.load(in_ptr + offs)
+        input = ttgl.convert_layout(input, tmem_reg_layout2)
+        tmem_slice = tmem2.slice(n2a, 32)
+        tmem_slice.store(input)
+
+    if Ncol2 > 32:
+        n2b: ttgl.constexpr = 32
+        offs = offs_m[:, None] * N + Ncol1 + n2b + offs_n32[None, :]
+        input = ttgl.load(in_ptr + offs)
+        input = ttgl.convert_layout(input, tmem_reg_layout2)
+        tmem_slice = tmem2.slice(n2b, 32)
+        tmem_slice.store(input)
+
+    offs = offs_m[:, None] * N + n1a + offs_n128[None, :]
+    tmem_slice = tmem1.slice(n1a, 128)
+    output = tmem_slice.load(tmem_reg_layout1)
+    output = ttgl.convert_layout(output, global_memory_layout)
+    ttgl.store(out_ptr + offs, output)
+
+    if Ncol1 > 128:
+        offs = offs_m[:, None] * N + n1b + offs_n128[None, :]
+        tmem_slice = tmem1.slice(n1b, 128)
+        output = tmem_slice.load(tmem_reg_layout1)
+        output = ttgl.convert_layout(output, global_memory_layout)
+        ttgl.store(out_ptr + offs, output)
+
+    if Ncol1 > 256:
+        offs = offs_m[:, None] * N + n1c + offs_n128[None, :]
+        tmem_slice = tmem1.slice(n1c, 128)
+        output = tmem_slice.load(tmem_reg_layout1)
+        output = ttgl.convert_layout(output, global_memory_layout)
+        ttgl.store(out_ptr + offs, output)
+
+        offs = offs_m[:, None] * N + n1d + offs_n128[None, :]
+        tmem_slice = tmem1.slice(n1d, 128)
+        output = tmem_slice.load(tmem_reg_layout1)
+        output = ttgl.convert_layout(output, global_memory_layout)
+        ttgl.store(out_ptr + offs, output)
+
+    if Ncol2 > 0:
+        offs = offs_m[:, None] * N + Ncol1 + n2a + offs_n32[None, :]
+        tmem_slice = tmem2.slice(n2a, 32)
+        output = tmem_slice.load(tmem_reg_layout2)
+        output = ttgl.convert_layout(output, global_memory_layout)
+        ttgl.store(out_ptr + offs, output)
+
+    if Ncol2 > 32:
+        offs = offs_m[:, None] * N + Ncol1 + n2b + offs_n32[None, :]
+        tmem_slice = tmem2.slice(n2b, 32)
+        output = tmem_slice.load(tmem_reg_layout2)
+        output = ttgl.convert_layout(output, global_memory_layout)
+        ttgl.store(out_ptr + offs, output)
+
+
+@pytest.mark.skipif(not is_rubin(), reason="Requires Rubin")
+@pytest.mark.parametrize("Ncol1", [256, 512])
+@pytest.mark.parametrize("Ncol2", [32, 64])
+def test_tmem288k_simple(Ncol1: int, Ncol2: int):
+    M = 128
+    N = Ncol1 + Ncol2
+    input = torch.randn(M, N, dtype=torch.float32).to(device="cuda")
+    output = torch.empty_like(input)
+
+    num_warps = 4
+    tmem288k_simple_kernel[(1, )](input, output, M, Ncol1, Ncol2, num_warps=num_warps)
+    torch.testing.assert_close(input.cpu(), output.cpu(), atol=0, rtol=0)

--- a/python/test/gluon/test_core.py
+++ b/python/test/gluon/test_core.py
@@ -11,6 +11,7 @@ from triton._internal_testing import (
     is_ampere_or_newer,
     is_blackwell,
     is_blackwell_ultra,
+    is_rubin,
     is_hip_rdna,
     is_hip_rdna3,
     is_hip_rdna4,
@@ -4786,7 +4787,7 @@ def tmem_reduction_kernel(
     ttgl.store(red_ptr + offs_1d, reduced)
 
 
-@pytest.mark.skipif(not is_blackwell_ultra(), reason="Requires Blackwell Ultra")
+@pytest.mark.skipif(not (is_blackwell_ultra() or is_rubin()), reason="Requires Blackwell Ultra or Rubin")
 @pytest.mark.parametrize("red_op", ["min", "max"])
 @pytest.mark.parametrize("use_abs", [False, True])
 @pytest.mark.parametrize("propagate_nan", [tl.PropagateNan.NONE, tl.PropagateNan.ALL])
@@ -4877,7 +4878,8 @@ def test_clc_basic(num_ctas):
 
     dev_props = torch.cuda.get_device_properties("cuda")
     num_sms = dev_props.multi_processor_count
-    smem_size = dev_props.shared_memory_per_block_optin
+    device = triton.runtime.driver.active.get_current_device()
+    smem_size = max_shared_mem(device)
     grid = 2 * (num_sms // num_ctas)
 
     was_launched = torch.zeros([grid], dtype=torch.bool, device="cuda")

--- a/python/test/unit/language/test_compile_only.py
+++ b/python/test/unit/language/test_compile_only.py
@@ -212,7 +212,7 @@ def test_compile_only_dot_mxfp() -> None:
     assert re.search(pattern, str(ttgir)), "The TTGIR does not match the expected pattern."
 
     ptx = k.asm["ptx"]
-    pattern = (r"tcgen05.mma.cta_group::1.kind::mxf8f6f4.block_scale.scale_vec::1X")
+    pattern = (r"tcgen05.mma.cta_group::1.kind::mxf8f6f4.block_scale.block32")
     assert re.search(pattern, str(ptx)), "The PTX does not match the expected pattern."
     assert k.asm["cubin"] != b""
 

--- a/python/test/unit/language/test_core.py
+++ b/python/test/unit/language/test_core.py
@@ -3880,7 +3880,7 @@ def test_dot(M, N, K, num_warps, col_a, col_b, epilogue, input_precision, in_dty
         else:
             assert re.search(r'[mma|wgmma.mma_async].sync.aligned.m\d+n\d+k16(?:.row.col)?.f16.f16.f16', ptx)
     elif in_dtype == 'int8':
-        if is_tcgen5 and capability[0:2] != (10, 3):
+        if is_tcgen5 and capability[1] not in (3, 7):
             assert re.search(r'tcgen05.mma.cta_group::1.kind::i8', ptx)
         elif capability[0] == 7 and capability[1] == 5:  # Turing
             assert 'mma.sync.aligned.m8n8k16.row.col.satfinite.s32.s8.s8.s32' in ptx

--- a/python/test/unit/language/test_matmul.py
+++ b/python/test/unit/language/test_matmul.py
@@ -115,9 +115,9 @@ def get_src_element_ty_size(dtype_str):
 
 @pytest.mark.parametrize("dtype_src_str", ["float32", "tensorfloat32", "float16", "float8e5", "float64"])
 @pytest.mark.parametrize("dtype_dst_str", ["float32", "float16", "float64"])
-@pytest.mark.parametrize("BLOCK_M, BLOCK_N, BLOCK_K, NUM_STAGES", [(128, 128, 16, 4), (64, 128, 32, 4), (32, 32, 32, 4),
-                                                                   (256, 128, 32, 4), (64, 512, 32, 2),
-                                                                   (512, 64, 32, 2), (64, 16, 64, 4)])
+@pytest.mark.parametrize("BLOCK_M, BLOCK_N, BLOCK_K, NUM_STAGES",
+                         [(128, 128, 16, 4), (64, 128, 32, 4), (32, 32, 32, 4), (256, 128, 32, 4), (64, 512, 32, 2),
+                          (512, 64, 32, 2), (64, 16, 64, 4)] + ([(256, 128, 128, 3)] if is_rubin() else []))
 @pytest.mark.parametrize("NUM_CTAS", [1, 2])
 @pytest.mark.parametrize("NUM_WARPS", [4, 8])
 @pytest.mark.parametrize("EPILOGUE_SUBTILE", [True, False])
@@ -383,7 +383,7 @@ def fp8e8m0_to_float32(scale):
 @pytest.mark.interpreter
 @pytest.mark.parametrize("BLOCK_M, BLOCK_N, BLOCK_K", [(128, 128, 128), (256, 128, 128), (128, 256, 128),
                                                        (128, 256, 256), (128, 128, 64), (128, 64, 128), (128, 16, 256),
-                                                       (128, 16, 64)])
+                                                       (128, 16, 64)] + ([(256, 256, 128)] if is_rubin() else []))
 @pytest.mark.parametrize("NUM_STAGES", [1, 3])
 @pytest.mark.parametrize("NUM_WARPS", [4, 8])
 @pytest.mark.parametrize("nonKDim", ([0, 16, 32] if (is_hip_cdna() or is_hip_gfx1250()) else [0]))

--- a/python/test/unit/language/test_matmul.py
+++ b/python/test/unit/language/test_matmul.py
@@ -5,7 +5,7 @@ import triton
 import triton.language as tl
 from test_mxfp import MXFP4Tensor, MXScaleTensor
 import re
-from triton._internal_testing import is_cuda, is_hip, is_hip_cdna3, is_hip_cdna4, is_hip_cdna, is_hip_gfx1250
+from triton._internal_testing import is_cuda, is_rubin, is_hip, is_hip_cdna3, is_hip_cdna4, is_hip_cdna, is_hip_gfx1250
 
 
 def f8_to_f16(x, dtype):
@@ -403,7 +403,7 @@ def test_mxfp(BLOCK_M, BLOCK_N, BLOCK_K, NUM_STAGES, nonKDim, NUM_WARPS, device)
         if (BLOCK_M == 256 or BLOCK_N == 256) and BLOCK_K == 256:
             pytest.skip("Config requires too much shared memory")
 
-    if BLOCK_N == 256 and BLOCK_K == 256:
+    if not is_rubin() and BLOCK_N == 256 and BLOCK_K == 256:
         NUM_STAGES = min(NUM_STAGES, 2)
     torch.manual_seed(42)
     dtype_src_str = "float8e5"
@@ -789,10 +789,11 @@ def test_preshuffle_scale_mxfp_cdna4(M, N, K, BLOCK_M, BLOCK_N, BLOCK_K, DTYPE_A
 @pytest.mark.parametrize("USE_2D_SCALE_LOAD", [False, True])
 @pytest.mark.skipif(is_hip() or torch.cuda.get_device_capability()[0] != 10, reason="Requires compute capability == 10")
 def test_blocked_scale_mxfp(M, N, K, BLOCK_M, BLOCK_N, BLOCK_K, NUM_STAGES, USE_2D_SCALE_LOAD, device):
-    if BLOCK_N == 256 and BLOCK_K == 256:
-        NUM_STAGES = min(NUM_STAGES, 2)
-    elif BLOCK_K == 256:
-        NUM_STAGES = min(NUM_STAGES, 3)
+    if not is_rubin():
+        if BLOCK_N == 256 and BLOCK_K == 256:
+            NUM_STAGES = min(NUM_STAGES, 2)
+        elif BLOCK_K == 256:
+            NUM_STAGES = min(NUM_STAGES, 3)
     # since the block size are big we use num_warps = 8 to avoid pressure problems.
     num_warps = 8
     torch.manual_seed(42)
@@ -1217,7 +1218,7 @@ def test_mxfp8_mxfp4_matmul(M, N, K, BLOCK_M, BLOCK_N, BLOCK_K, NUM_STAGES, B_TR
             pytest.skip("Config requires too much shared memory")
     if not PACK_B_ALONG_K and B_DATA_TYPE != "float4":
         pytest.skip("Pack along K can only be False for float4")
-    if BLOCK_N == 256 and BLOCK_K == 256:
+    if not is_rubin() and BLOCK_N == 256 and BLOCK_K == 256:
         NUM_STAGES = 2
 
     torch.manual_seed(42)

--- a/python/test/unit/language/test_matmul.py
+++ b/python/test/unit/language/test_matmul.py
@@ -5,7 +5,7 @@ import triton
 import triton.language as tl
 from test_mxfp import MXFP4Tensor, MXScaleTensor
 import re
-from triton._internal_testing import is_cuda, is_rubin, is_hip, is_hip_cdna3, is_hip_cdna4, is_hip_cdna, is_hip_gfx1250
+from triton._internal_testing import is_cuda, is_hip, is_hip_cdna3, is_hip_cdna4, is_hip_cdna, is_hip_gfx1250, is_rubin, is_blackwell
 
 
 def f8_to_f16(x, dtype):
@@ -1289,7 +1289,7 @@ def test_mxfp8_mxfp4_matmul(M, N, K, BLOCK_M, BLOCK_N, BLOCK_K, NUM_STAGES, B_TR
                                    b.stride(0), b.stride(1), output.stride(0), output.stride(1), not CONST_SCALE,
                                    dtype_converter[A_DATA_TYPE], dtype_converter[B_DATA_TYPE], BLOCK_M, BLOCK_N,
                                    BLOCK_K, PACK_B_ALONG_K=PACK_B_ALONG_K, NUM_STAGES=NUM_STAGES, **kernel_kwargs)
-    if is_cuda():
+    if is_blackwell() and not is_rubin():
         ttgir = out.asm["ttgir"]
         assert "fp4Padded = true" in ttgir
 

--- a/python/test/unit/runtime/test_autotuner.py
+++ b/python/test/unit/runtime/test_autotuner.py
@@ -6,7 +6,7 @@ import pytest
 
 import pathlib
 import uuid
-from triton._internal_testing import is_cuda, is_hip_cdna2
+from triton._internal_testing import is_cuda, is_hip_cdna2, is_rubin
 
 
 def do_bench(kernel_call, quantiles, use_cuda_graph=False):
@@ -547,9 +547,10 @@ def test_exceed_tmem(device):
         tl.store(dst + tl.arange(0, BLOCK_SIZE * BLOCK_SIZE), c)
 
     dot_kernel[(1, )](dst)
+    tmem_size = 576 if is_rubin() else 512
     assert exception_out_of_resource is not None and str(
         exception_out_of_resource
-    ) == "out of resource: tensor memory, Required: 640, Hardware limit: 512. Reducing block sizes or `num_stages` may help."
+    ) == f"out of resource: tensor memory, Required: 640, Hardware limit: {tmem_size}. Reducing block sizes or `num_stages` may help."
 
 
 def test_exceed_threads(device):

--- a/python/triton/_internal_testing.py
+++ b/python/triton/_internal_testing.py
@@ -55,6 +55,10 @@ def is_blackwell_ultra():
     return is_cuda() and torch.cuda.get_device_capability()[0:2] == (10, 3)
 
 
+def is_rubin():
+    return is_cuda() and torch.cuda.get_device_capability()[0:2] == (10, 7)
+
+
 def is_hopper_or_newer():
     return is_cuda() and torch.cuda.get_device_capability()[0] >= 9
 

--- a/python/triton/compiler/compiler.py
+++ b/python/triton/compiler/compiler.py
@@ -469,6 +469,8 @@ class CompiledKernel:
         if hasattr(self.metadata, "tmem_size") and self.metadata.tmem_size is not None:
             # Use blackwell max tmem size for now, this should be moved in device properties
             max_tmem_size = 512  # tmem size in number of columns
+            if self.metadata.target.arch == 107:
+                max_tmem_size = 576
             if self.metadata.tmem_size > max_tmem_size:
                 raise_(OutOfResources(self.metadata.tmem_size, max_tmem_size, "tensor memory"))
         if knobs.runtime.kernel_load_start_hook is not None:

--- a/python/triton/tools/triton_to_gluon_translator/target.py
+++ b/python/triton/tools/triton_to_gluon_translator/target.py
@@ -16,6 +16,7 @@ class TranslatorTarget(str, Enum):
     SM90 = "sm90"
     SM100 = "sm100"
     SM103 = "sm103"
+    SM107 = "sm107"
     # AMD targets currently exercised by the translator test suite:
     GFX90A = "gfx90a"
     GFX1250 = "gfx1250"
@@ -46,6 +47,7 @@ class TranslatorTarget(str, Enum):
             TranslatorTarget.SM90,
             TranslatorTarget.SM100,
             TranslatorTarget.SM103,
+            TranslatorTarget.SM107,
         )
 
     @property
@@ -61,7 +63,7 @@ class TranslatorTarget(str, Enum):
             return f"{base}.amd_helpers"
 
         if self.is_nvidia:
-            if self in (TranslatorTarget.SM100, TranslatorTarget.SM103):
+            if self in (TranslatorTarget.SM100, TranslatorTarget.SM103, TranslatorTarget.SM107):
                 return f"{base}.blackwell_helpers"
             if self in (TranslatorTarget.SM90):
                 return f"{base}.hopper_helpers"

--- a/python/tutorials/10-block-scaled-matmul.py
+++ b/python/tutorials/10-block-scaled-matmul.py
@@ -140,6 +140,10 @@ def supports_block_scaling():
     return (is_cuda() and torch.cuda.get_device_capability()[0] in [10, 11]) or is_hip_cdna4()
 
 
+def is_rubin():
+    return torch.cuda.get_device_capability() == (10, 7)
+
+
 if is_cuda() and torch.cuda.get_device_capability()[0] in [10, 11]:
     from triton._C.libtriton import nvidia
     cublas_workspace = torch.empty(32 * 1024 * 1024, device="cuda", dtype=torch.uint8)
@@ -410,11 +414,16 @@ def initialize_block_scaled(M, N, K, block_scale_type="nvfp4", compute_reference
         b_scale_ref = unpack_scale(b_scale_ref).repeat_interleave(VEC_SIZE, dim=1).T.contiguous()[:K, :N]
         reference = torch.matmul(a_ref.to(torch.float32) * a_scale_ref, b_ref * b_scale_ref)
 
+    if is_rubin():
+        num_stages = 6
+    else:
+        num_stages = 4
+
     configs = {
         "BLOCK_SIZE_M": BLOCK_M,
         "BLOCK_SIZE_N": BLOCK_N,
         "BLOCK_SIZE_K": BLOCK_K,
-        "num_stages": 4,
+        "num_stages": num_stages,
         "ELEM_PER_BYTE_A": ELEM_PER_BYTE_A,
         "ELEM_PER_BYTE_B": ELEM_PER_BYTE_B,
         "VEC_SIZE": VEC_SIZE,

--- a/python/tutorials/10-block-scaled-matmul.py
+++ b/python/tutorials/10-block-scaled-matmul.py
@@ -192,6 +192,7 @@ def block_scaled_matmul_kernel(  #
         rep_n: tl.constexpr,  #
         rep_k: tl.constexpr,  #
         NUM_STAGES: tl.constexpr,  #
+        disallow_acc_multi_buffer: tl.constexpr,  #
 ):  #
     if output_type == 0:
         output_dtype = tl.float32
@@ -215,7 +216,8 @@ def block_scaled_matmul_kernel(  #
     MIXED_PREC: tl.constexpr = ELEM_PER_BYTE_A == 1 and ELEM_PER_BYTE_B == 2
 
     accumulator = tl.zeros((BLOCK_M, BLOCK_N), dtype=tl.float32)
-    for k in tl.range(0, tl.cdiv(K, BLOCK_K), num_stages=NUM_STAGES):
+    for k in tl.range(0, tl.cdiv(K, BLOCK_K), num_stages=NUM_STAGES,
+                      disallow_acc_multi_buffer=disallow_acc_multi_buffer):
         a = a_desc.load([offs_am, offs_k_a])
         b = b_desc.load([offs_bn, offs_k_b])
         scale_a = a_scale_desc.load([0, offs_scale_m, offs_scale_k, 0, 0])
@@ -274,6 +276,7 @@ def block_scaled_matmul(a_desc, a_scale_desc, b_desc, b_scale_desc, dtype_dst, M
         rep_n,
         rep_k,
         configs["num_stages"],
+        disallow_acc_multi_buffer=configs["disallow_acc_multi_buffer"],
     )
     return output
 
@@ -427,6 +430,7 @@ def initialize_block_scaled(M, N, K, block_scale_type="nvfp4", compute_reference
         "ELEM_PER_BYTE_A": ELEM_PER_BYTE_A,
         "ELEM_PER_BYTE_B": ELEM_PER_BYTE_B,
         "VEC_SIZE": VEC_SIZE,
+        "disallow_acc_multi_buffer": not is_rubin(),
     }
 
     # Flatten scales for cuBLAS

--- a/test/Conversion/nvgpu_to_llvm.mlir
+++ b/test/Conversion/nvgpu_to_llvm.mlir
@@ -119,6 +119,56 @@ llvm.func @tensor_memory_base_warpgroup() attributes {nvvm.kernel = 1 : ui1, nvv
 
 }
 
+// -----
+
+module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.shared = 65544 : i32, ttg.target = "cuda:107", ttg.tensor_memory_size = 576 : i32, "ttg.threads-per-warp" = 32 : i32} {
+  // CHECK-LABEL: @tensor_memory_exclusive_rubin
+  //      CHECK:    %[[TID:.+]] = nvvm.read.ptx.sreg.tid.x : i32
+  //      CHECK:    %[[C32:.+]] = llvm.mlir.constant(32 : i32) : i32
+  //      CHECK:    %[[PRED:.+]] = llvm.icmp "ult" %[[TID]], %[[C32]] : i32
+  //      CHECK:    %[[SHMEM:.+]] = llvm.mlir.addressof @global_smem : !llvm.ptr<3>
+  //      CHECK:    %[[A:.+]] = llvm.inline_asm has_side_effects
+  // CHECK-SAME:    "@$0 tcgen05.alloc.exclusive.cta_group::1.sync.aligned.shared::cta.b32 [$1], 576;", "b,r" %[[PRED]], %[[SHMEM]] : (i1, !llvm.ptr<3>) -> !llvm.void
+  //      CHECK:    %[[AR:.+]] = llvm.load %[[SHMEM]] : !llvm.ptr<3> -> i32
+  //      CHECK:    nvvm.barrier
+  //      CHECK:    "@$0 tcgen05.relinquish_alloc_permit.cta_group::1.sync.aligned;", "b" %[[PRED]]  : (i1) -> !llvm.void
+  //      CHECK:    nvvm.barrier
+  //      CHECK:    llvm.inline_asm has_side_effects asm_dialect = att operand_attrs = [] "@$0 tcgen05.dealloc.exclusive.cta_group::1.sync.aligned.b32 $1, 576;", "b,r" %[[PRED]], %{{.+}} : (i1, !llvm.ptr<6>) -> !llvm.void
+  llvm.mlir.global external @global_smem() {addr_space = 3 : i32, alignment = 16 : i64} : !llvm.array<0 x i8>
+  llvm.func @tensor_memory_exclusive_rubin() -> i32 attributes {nvvm.kernel = 1 : ui1, nvvm.maxntid = array<i32: 128>} {
+    %263 = nvg.tensor_memory_base
+    %264 = llvm.ptrtoint %263 : !llvm.ptr<6> to i32
+    llvm.return %264 : i32
+  }
+}
+
+// -----
+
+module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.shared = 65544 : i32, ttg.target = "cuda:107", ttg.tensor_memory_size = 512 : i32, "ttg.threads-per-warp" = 32 : i32} {
+  // CHECK-LABEL: @tensor_memory_no_exclusive_rubin
+  //      CHECK:    %[[TID:.+]] = nvvm.read.ptx.sreg.tid.x : i32
+  //      CHECK:    %[[C32:.+]] = llvm.mlir.constant(32 : i32) : i32
+  //      CHECK:    %[[PRED:.+]] = llvm.icmp "ult" %[[TID]], %[[C32]] : i32
+  //      CHECK:    %[[SHMEM:.+]] = llvm.mlir.addressof @global_smem : !llvm.ptr<3>
+  //      CHECK:    %[[A:.+]] = llvm.inline_asm has_side_effects
+  // CHECK-SAME:    "@$0 tcgen05.alloc.cta_group::1.sync.aligned.shared::cta.b32 [$1], 512;", "b,r" %[[PRED]], %[[SHMEM]] : (i1, !llvm.ptr<3>) -> !llvm.void
+  //      CHECK-NOT:  .exclusive
+  //      CHECK:    %[[AR:.+]] = llvm.load %[[SHMEM]] : !llvm.ptr<3> -> i32
+  //      CHECK:    nvvm.barrier
+  //      CHECK:    "@$0 tcgen05.relinquish_alloc_permit.cta_group::1.sync.aligned;", "b" %[[PRED]]  : (i1) -> !llvm.void
+  //      CHECK:    nvvm.barrier
+  //      CHECK:    llvm.inline_asm has_side_effects asm_dialect = att operand_attrs = [] "@$0 tcgen05.dealloc.cta_group::1.sync.aligned.b32 $1, 512;", "b,r" %[[PRED]], %{{.+}} : (i1, !llvm.ptr<6>) -> !llvm.void
+  //      CHECK-NOT:  .exclusive
+  llvm.mlir.global external @global_smem() {addr_space = 3 : i32, alignment = 16 : i64} : !llvm.array<0 x i8>
+  llvm.func @tensor_memory_no_exclusive_rubin() -> i32 attributes {nvvm.kernel = 1 : ui1, nvvm.maxntid = array<i32: 128>} {
+    %263 = nvg.tensor_memory_base
+    %264 = llvm.ptrtoint %263 : !llvm.ptr<6> to i32
+    llvm.return %264 : i32
+  }
+}
+
+// -----
+
 module attributes {"ttg.num-warps" = 1 : i32, "ttg.threads-per-warp" = 32 : i32} {
 
 // CHECK-LABEL: @one_warp

--- a/test/Conversion/tritongpu_to_llvm_blackwell.mlir
+++ b/test/Conversion/tritongpu_to_llvm_blackwell.mlir
@@ -302,7 +302,7 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32} {
   // CHECK-LABEL: @tc_gen5_mma_scaled_a_tmem
   // CHECK: %[[TMEM_BASE:.+]] = llvm.ptrtoint %arg2 : !llvm.ptr<3> to i32
   // CHECK: %[[A_BASE:.+]] = llvm.ptrtoint %arg0 : !llvm.ptr<3> to i32
-  // CHECK: @$7 tcgen05.mma.cta_group::1.kind::mxf8f6f4.block_scale.scale_vec::1X [ $0 + 0 ], [ $1 + 0 ], $2, $3, [ $4 + 0 ], [ $5 + 0 ], $6;", "r,r,l,r,r,r,b,b" %[[TMEM_BASE]], %[[A_BASE]]
+  // CHECK: @$7 tcgen05.mma.cta_group::1.kind::mxf8f6f4.block_scale.block32 [ $0 + 0 ], [ $1 + 0 ], $2, $3, [ $4 + 0 ], [ $5 + 0 ], $6;", "r,r,l,r,r,r,b,b" %[[TMEM_BASE]], %[[A_BASE]]
   tt.func @tc_gen5_mma_scaled_a_tmem(
       %a: !ttg.memdesc<128x256xf8E5M2, #tmem, #ttng.tensor_memory>,
       %b: !ttg.memdesc<256x64xf8E5M2, #shared, #ttg.shared_memory>,
@@ -337,10 +337,10 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32} {
   // CHECK: %[[P1:.+]] = llvm.and %{{.*}}, %[[P0]]  : i1
   // CHECK: llvm.cond_br %[[P1]]
   // CHECK: %[[DESC0:.+]] = llvm.mlir.constant(144708608 : i32) : i32
-  // CHECK: @$7 tcgen05.mma.cta_group::1.kind::mxf8f6f4.block_scale.scale_vec::1X [ $0 + 0 ], $1, $2, $3, [ $4 + 0 ], [ $5 + 0 ], $6;", "r,l,l,r,r,r,b,b" %[[TMEM_BASE]], %{{.+}}, %{{.+}}, %[[DESC0]], %{{.+}}, %{{.+}}, %arg5
+  // CHECK: @$7 tcgen05.mma.cta_group::1.kind::mxf8f6f4.block_scale.block32 [ $0 + 0 ], $1, $2, $3, [ $4 + 0 ], [ $5 + 0 ], $6;", "r,l,l,r,r,r,b,b" %[[TMEM_BASE]], %{{.+}}, %{{.+}}, %[[DESC0]], %{{.+}}, %{{.+}}, %arg5
   // CHECK: %[[TRUE:.+]] = llvm.mlir.constant(true) : i1
   // CHECK: %[[DESC1:.+]] = llvm.mlir.constant(681579536 : i32) : i32
-  // CHECK: @$7 tcgen05.mma.cta_group::1.kind::mxf8f6f4.block_scale.scale_vec::1X [ $0 + 0 ], $1, $2, $3, [ $4 + 0 ], [ $5 + 0 ], $6;", "r,l,l,r,r,r,b,b" %[[TMEM_BASE]], %{{.+}}, %{{.+}}, %[[DESC1]], %{{.+}}, %{{.+}}, %[[TRUE]]
+  // CHECK: @$7 tcgen05.mma.cta_group::1.kind::mxf8f6f4.block_scale.block32 [ $0 + 0 ], $1, $2, $3, [ $4 + 0 ], [ $5 + 0 ], $6;", "r,l,l,r,r,r,b,b" %[[TMEM_BASE]], %{{.+}}, %{{.+}}, %[[DESC1]], %{{.+}}, %{{.+}}, %[[TRUE]]
   tt.func @tc_gen5_mma_block_scale(%a: !ttg.memdesc<128x64xf8E4M3FN, #shared, #ttg.shared_memory>,
                        %b: !ttg.memdesc<32x128xi8, #shared1, #ttg.shared_memory>,
                        %c: !ttg.memdesc<128x128xf32, #tmem, #ttng.tensor_memory, mutable>,
@@ -371,13 +371,13 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32} {
 module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32} {
   // CHECK-LABEL: @tc_gen5_mma_block_scale_fp4_a
   // CHECK: %[[DESC0:.+]] = llvm.mlir.constant(144769664 : i32) : i32
-  // CHECK: @$7 tcgen05.mma.cta_group::1.kind::mxf8f6f4.block_scale.scale_vec::1X [ $0 + 0 ], $1, $2, $3, [ $4 + 0 ], [ $5 + 0 ], $6;", "r,l,l,r,r,r,b,b" %{{.+}}, %{{.+}}, %{{.+}}, %[[DESC0]]
+  // CHECK: @$7 tcgen05.mma.cta_group::1.kind::mxf8f6f4.block_scale.block32 [ $0 + 0 ], $1, $2, $3, [ $4 + 0 ], [ $5 + 0 ], $6;", "r,l,l,r,r,r,b,b" %{{.+}}, %{{.+}}, %{{.+}}, %[[DESC0]]
   // CHECK: %[[DESC1:.+]] = llvm.mlir.constant(681640592 : i32) : i32
-  // CHECK: @$7 tcgen05.mma.cta_group::1.kind::mxf8f6f4.block_scale.scale_vec::1X [ $0 + 0 ], $1, $2, $3, [ $4 + 0 ], [ $5 + 0 ], $6;", "r,l,l,r,r,r,b,b" %{{.+}}, %{{.+}}, %{{.+}}, %[[DESC1]]
+  // CHECK: @$7 tcgen05.mma.cta_group::1.kind::mxf8f6f4.block_scale.block32 [ $0 + 0 ], $1, $2, $3, [ $4 + 0 ], [ $5 + 0 ], $6;", "r,l,l,r,r,r,b,b" %{{.+}}, %{{.+}}, %{{.+}}, %[[DESC1]]
   // CHECK: %[[DESC2:.+]] = llvm.mlir.constant(1218511520 : i32) : i32
-  // CHECK: @$7 tcgen05.mma.cta_group::1.kind::mxf8f6f4.block_scale.scale_vec::1X [ $0 + 0 ], $1, $2, $3, [ $4 + 0 ], [ $5 + 0 ], $6;", "r,l,l,r,r,r,b,b" %{{.+}}, %{{.+}}, %{{.+}}, %[[DESC2]]
+  // CHECK: @$7 tcgen05.mma.cta_group::1.kind::mxf8f6f4.block_scale.block32 [ $0 + 0 ], $1, $2, $3, [ $4 + 0 ], [ $5 + 0 ], $6;", "r,l,l,r,r,r,b,b" %{{.+}}, %{{.+}}, %{{.+}}, %[[DESC2]]
   // CHECK: %[[DESC3:.+]] = llvm.mlir.constant(1755382448 : i32) : i32
-  // CHECK: @$7 tcgen05.mma.cta_group::1.kind::mxf8f6f4.block_scale.scale_vec::1X [ $0 + 0 ], $1, $2, $3, [ $4 + 0 ], [ $5 + 0 ], $6;", "r,l,l,r,r,r,b,b" %{{.+}}, %{{.+}}, %{{.+}}, %[[DESC3]]
+  // CHECK: @$7 tcgen05.mma.cta_group::1.kind::mxf8f6f4.block_scale.block32 [ $0 + 0 ], $1, $2, $3, [ $4 + 0 ], [ $5 + 0 ], $6;", "r,l,l,r,r,r,b,b" %{{.+}}, %{{.+}}, %{{.+}}, %[[DESC3]]
   tt.func @tc_gen5_mma_block_scale_fp4_a(%a: !ttg.memdesc<128x64xi8, #shared1, #ttg.shared_memory>,
                        %b: !ttg.memdesc<128x128xi8, #shared, #ttg.shared_memory>,
                        %c: !ttg.memdesc<128x128xf32, #tmem, #ttng.tensor_memory, mutable>,
@@ -540,8 +540,8 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32} {
   // CHECK-LABEL: @tc_gen5_mma_block_scale_nvfp4
   // CHECK: %[[TMEM_BASE:.+]] = llvm.ptrtoint %{{.*}} : !llvm.ptr<3> to i32
   // CHECK: %[[DESC0:.+]] = llvm.mlir.constant(138413184 : i32) : i32
-  // CHECK: @$7 tcgen05.mma.cta_group::1.kind::mxf4nvf4.block_scale.scale_vec::4X [ $0 + 0 ], $1, $2, $3, [ $4 + 0 ], [ $5 + 0 ], $6;", "r,l,l,r,r,r,b,b" %[[TMEM_BASE]], %{{.+}}, %{{.+}}, %[[DESC0]]
-  // CHECK: @$7 tcgen05.mma.cta_group::1.kind::mxf4nvf4.block_scale.scale_vec::4X [ $0 + 0 ], $1, $2, $3, [ $4 + 0 ], [ $5 + 0 ], $6;", "r,l,l,r,r,r,b,b" %[[TMEM_BASE]], %{{.+}}, %{{.+}}, %[[DESC0]]
+  // CHECK: @$7 tcgen05.mma.cta_group::1.kind::mxf4nvf4.block_scale.block16 [ $0 + 0 ], $1, $2, $3, [ $4 + 0 ], [ $5 + 0 ], $6;", "r,l,l,r,r,r,b,b" %[[TMEM_BASE]], %{{.+}}, %{{.+}}, %[[DESC0]]
+  // CHECK: @$7 tcgen05.mma.cta_group::1.kind::mxf4nvf4.block_scale.block16 [ $0 + 0 ], $1, $2, $3, [ $4 + 0 ], [ $5 + 0 ], $6;", "r,l,l,r,r,r,b,b" %[[TMEM_BASE]], %{{.+}}, %{{.+}}, %[[DESC0]]
   tt.func @tc_gen5_mma_block_scale_nvfp4(%a: !ttg.memdesc<128x64xi8, #shared, #ttg.shared_memory>,
                        %b: !ttg.memdesc<64x256xi8, #shared1, #ttg.shared_memory>,
                        %c: !ttg.memdesc<128x256xf32, #tmem, #ttng.tensor_memory, mutable>,
@@ -573,9 +573,9 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32} {
   // CHECK-LABEL: @tc_gen5_mma_block_scale_mxfp4
   // CHECK-DAG: %[[TMEM_BASE:.+]] = llvm.ptrtoint %{{.*}} : !llvm.ptr<3> to i32
   // CHECK: %[[DESC0:.+]] = llvm.mlir.constant(146801792 : i32) : i32
-  // CHECK: @$7 tcgen05.mma.cta_group::1.kind::mxf4.block_scale.scale_vec::2X [ $0 + 0 ], $1, $2, $3, [ $4 + 0 ], [ $5 + 0 ], $6;", "r,l,l,r,r,r,b,b" %[[TMEM_BASE]], %{{.+}}, %{{.+}}, %[[DESC0]]
+  // CHECK: @$7 tcgen05.mma.cta_group::1.kind::mxf4.block_scale.block32 [ $0 + 0 ], $1, $2, $3, [ $4 + 0 ], [ $5 + 0 ], $6;", "r,l,l,r,r,r,b,b" %[[TMEM_BASE]], %{{.+}}, %{{.+}}, %[[DESC0]]
   // CHECK: %[[DESC1:.+]] = llvm.mlir.constant(1220543648 : i32) : i32
-  // CHECK: @$7 tcgen05.mma.cta_group::1.kind::mxf4.block_scale.scale_vec::2X [ $0 + 0 ], $1, $2, $3, [ $4 + 0 ], [ $5 + 0 ], $6;", "r,l,l,r,r,r,b,b" %[[TMEM_BASE]], %{{.+}}, %{{.+}}, %[[DESC1]]
+  // CHECK: @$7 tcgen05.mma.cta_group::1.kind::mxf4.block_scale.block32 [ $0 + 0 ], $1, $2, $3, [ $4 + 0 ], [ $5 + 0 ], $6;", "r,l,l,r,r,r,b,b" %[[TMEM_BASE]], %{{.+}}, %{{.+}}, %[[DESC1]]
   tt.func @tc_gen5_mma_block_scale_mxfp4(%a: !ttg.memdesc<128x64xi8, #shared, #ttg.shared_memory>,
                        %b: !ttg.memdesc<64x256xi8, #shared1, #ttg.shared_memory>,
                        %c: !ttg.memdesc<128x256xf32, #tmem, #ttng.tensor_memory, mutable>,
@@ -1178,22 +1178,22 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32} {
       %pred: i1) {
     // CHECK: %[[ACC_BASE:.+]] = llvm.ptrtoint %arg4 : !llvm.ptr<3> to i32
     // CHECK: %[[A_E4M3_BASE:.+]] = llvm.ptrtoint %arg0 : !llvm.ptr<3> to i32
-    // CHECK: tcgen05.mma.cta_group::1.kind::mxf8f6f4.block_scale.scale_vec::1X [ $0 + 0 ], [ $1 + 0 ], $2
+    // CHECK: tcgen05.mma.cta_group::1.kind::mxf8f6f4.block_scale.block32 [ $0 + 0 ], [ $1 + 0 ], $2
     // CHECK-SAME: %[[ACC_BASE]], %[[A_E4M3_BASE]]
-    // CHECK: tcgen05.mma.cta_group::1.kind::mxf8f6f4.block_scale.scale_vec::1X [ $0 + 0 ], [ $1 + 8 ], $2
+    // CHECK: tcgen05.mma.cta_group::1.kind::mxf8f6f4.block_scale.block32 [ $0 + 0 ], [ $1 + 8 ], $2
     // CHECK-SAME: %[[ACC_BASE]], %[[A_E4M3_BASE]]
-    // CHECK: tcgen05.mma.cta_group::1.kind::mxf8f6f4.block_scale.scale_vec::1X [ $0 + 0 ], [ $1 + 16 ], $2
+    // CHECK: tcgen05.mma.cta_group::1.kind::mxf8f6f4.block_scale.block32 [ $0 + 0 ], [ $1 + 16 ], $2
     // CHECK-SAME: %[[ACC_BASE]], %[[A_E4M3_BASE]]
-    // CHECK: tcgen05.mma.cta_group::1.kind::mxf8f6f4.block_scale.scale_vec::1X [ $0 + 0 ], [ $1 + 24 ], $2
+    // CHECK: tcgen05.mma.cta_group::1.kind::mxf8f6f4.block_scale.block32 [ $0 + 0 ], [ $1 + 24 ], $2
     // CHECK-SAME: %[[ACC_BASE]], %[[A_E4M3_BASE]]
     // CHECK: %[[A_E5M2_BASE:.+]] = llvm.ptrtoint %arg1 : !llvm.ptr<3> to i32
-    // CHECK: tcgen05.mma.cta_group::1.kind::mxf8f6f4.block_scale.scale_vec::1X [ $0 + 0 ], [ $1 + 0 ], $2
+    // CHECK: tcgen05.mma.cta_group::1.kind::mxf8f6f4.block_scale.block32 [ $0 + 0 ], [ $1 + 0 ], $2
     // CHECK-SAME: %[[ACC_BASE]], %[[A_E5M2_BASE]]
-    // CHECK: tcgen05.mma.cta_group::1.kind::mxf8f6f4.block_scale.scale_vec::1X [ $0 + 0 ], [ $1 + 8 ], $2
+    // CHECK: tcgen05.mma.cta_group::1.kind::mxf8f6f4.block_scale.block32 [ $0 + 0 ], [ $1 + 8 ], $2
     // CHECK-SAME: %[[ACC_BASE]], %[[A_E5M2_BASE]]
-    // CHECK: tcgen05.mma.cta_group::1.kind::mxf8f6f4.block_scale.scale_vec::1X [ $0 + 0 ], [ $1 + 16 ], $2
+    // CHECK: tcgen05.mma.cta_group::1.kind::mxf8f6f4.block_scale.block32 [ $0 + 0 ], [ $1 + 16 ], $2
     // CHECK-SAME: %[[ACC_BASE]], %[[A_E5M2_BASE]]
-    // CHECK: tcgen05.mma.cta_group::1.kind::mxf8f6f4.block_scale.scale_vec::1X [ $0 + 0 ], [ $1 + 24 ], $2
+    // CHECK: tcgen05.mma.cta_group::1.kind::mxf8f6f4.block_scale.block32 [ $0 + 0 ], [ $1 + 24 ], $2
     // CHECK-SAME: %[[ACC_BASE]], %[[A_E5M2_BASE]]
     ttng.tc_gen5_mma_scaled %a_e4m3, %b_e5m2, %c, %scale_a, %scale_b, %useAcc, %pred lhs = e4m3 rhs = e5m2 :
        !ttg.memdesc<128x128xf8E4M3FN, #tmem_fp8_lhs, #ttng.tensor_memory>,
@@ -1221,13 +1221,13 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32} {
       %pred: i1) {
     // CHECK-DAG: %[[ACC_BASE:.+]] = llvm.ptrtoint %arg2 : !llvm.ptr<3> to i32
     // CHECK-DAG: %[[A_BASE:.+]] = llvm.ptrtoint %arg0 : !llvm.ptr<3> to i32
-    // CHECK: tcgen05.mma.cta_group::1.kind::mxf8f6f4.block_scale.scale_vec::1X [ $0 + 0 ], [ $1 + 0 ], $2
+    // CHECK: tcgen05.mma.cta_group::1.kind::mxf8f6f4.block_scale.block32 [ $0 + 0 ], [ $1 + 0 ], $2
     // CHECK-SAME: %[[ACC_BASE]], %[[A_BASE]]
-    // CHECK: tcgen05.mma.cta_group::1.kind::mxf8f6f4.block_scale.scale_vec::1X [ $0 + 0 ], [ $1 + 8 ], $2
+    // CHECK: tcgen05.mma.cta_group::1.kind::mxf8f6f4.block_scale.block32 [ $0 + 0 ], [ $1 + 8 ], $2
     // CHECK-SAME: %[[ACC_BASE]], %[[A_BASE]]
-    // CHECK: tcgen05.mma.cta_group::1.kind::mxf8f6f4.block_scale.scale_vec::1X [ $0 + 0 ], [ $1 + 16 ], $2
+    // CHECK: tcgen05.mma.cta_group::1.kind::mxf8f6f4.block_scale.block32 [ $0 + 0 ], [ $1 + 16 ], $2
     // CHECK-SAME: %[[ACC_BASE]], %[[A_BASE]]
-    // CHECK: tcgen05.mma.cta_group::1.kind::mxf8f6f4.block_scale.scale_vec::1X [ $0 + 0 ], [ $1 + 24 ], $2
+    // CHECK: tcgen05.mma.cta_group::1.kind::mxf8f6f4.block_scale.block32 [ $0 + 0 ], [ $1 + 24 ], $2
     // CHECK-SAME: %[[ACC_BASE]], %[[A_BASE]]
     ttng.tc_gen5_mma_scaled %a, %b, %c, %scale_a, %scale_b, %useAcc, %pred lhs = e2m1 rhs = e5m2 :
        !ttg.memdesc<128x64xi8, #tmem_fp4_padded_lhs, #ttng.tensor_memory>,
@@ -1257,13 +1257,13 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32} {
       %pred: i1) {
     // CHECK-DAG: %[[ACC_BASE:.+]] = llvm.ptrtoint %arg2 : !llvm.ptr<3> to i32
     // CHECK-DAG: %[[A_BASE:.+]] = llvm.ptrtoint %arg0 : !llvm.ptr<3> to i32
-    // CHECK: tcgen05.mma.cta_group::1.kind::mxf4.block_scale.scale_vec::2X [ $0 + 0 ], [ $1 + 0 ], $2
+    // CHECK: tcgen05.mma.cta_group::1.kind::mxf4.block_scale.block32 [ $0 + 0 ], [ $1 + 0 ], $2
     // CHECK-SAME: %[[ACC_BASE]], %[[A_BASE]]
-    // CHECK: tcgen05.mma.cta_group::1.kind::mxf4.block_scale.scale_vec::2X [ $0 + 0 ], [ $1 + 8 ], $2
+    // CHECK: tcgen05.mma.cta_group::1.kind::mxf4.block_scale.block32 [ $0 + 0 ], [ $1 + 8 ], $2
     // CHECK-SAME: %[[ACC_BASE]], %[[A_BASE]]
-    // CHECK: tcgen05.mma.cta_group::1.kind::mxf4.block_scale.scale_vec::2X [ $0 + 0 ], [ $1 + 16 ], $2
+    // CHECK: tcgen05.mma.cta_group::1.kind::mxf4.block_scale.block32 [ $0 + 0 ], [ $1 + 16 ], $2
     // CHECK-SAME: %[[ACC_BASE]], %[[A_BASE]]
-    // CHECK: tcgen05.mma.cta_group::1.kind::mxf4.block_scale.scale_vec::2X [ $0 + 0 ], [ $1 + 24 ], $2
+    // CHECK: tcgen05.mma.cta_group::1.kind::mxf4.block_scale.block32 [ $0 + 0 ], [ $1 + 24 ], $2
     // CHECK-SAME: %[[ACC_BASE]], %[[A_BASE]]
     ttng.tc_gen5_mma_scaled %a, %b, %c, %scale_a, %scale_b, %useAcc, %pred lhs = e2m1 rhs = e2m1 :
        !ttg.memdesc<128x128xi8, #tmem_fp4_dense_lhs, #ttng.tensor_memory>,

--- a/test/Conversion/tritongpu_to_llvm_rubin.mlir
+++ b/test/Conversion/tritongpu_to_llvm_rubin.mlir
@@ -120,3 +120,61 @@ module attributes {"ttg.num-ctas" = 2 : i32, "ttg.num-warps" = 4 : i32, ttg.targ
     tt.return
   }
 }
+
+// -----
+
+#mma = #ttg.nvidia_mma<{versionMajor = 3, versionMinor = 0, warpsPerCTA = [8, 1], instrShape = [16, 256, 32]}>
+#shared = #ttg.nvmma_shared<{swizzlingByteWidth = 32, transposed = false, elementBitWidth = 16}>
+#shared1 = #ttg.nvmma_shared<{swizzlingByteWidth = 32, transposed = true, elementBitWidth = 16}>
+#shared2 = #ttg.swizzled_shared<{vec = 1, perPhase = 1, maxPhase = 1, order = [0]}>
+#tmem = #ttng.tensor_memory_encoding<blockM = 128, blockN = 128, colStride = 1>
+module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 8 : i32} {
+  // CHECK-LABEL: @tc_gen5_mma_breuse
+  // CHECK: tcgen05.mma.cta_group::1.kind::f16.collector::b::fill
+  // CHECK: tcgen05.mma.cta_group::1.kind::f16.collector::b::lastuse
+  tt.func @tc_gen5_mma_breuse(%a: !ttg.memdesc<256x128xf16, #shared, #ttg.shared_memory>,
+                       %b: !ttg.memdesc<128x128xf16, #shared1, #ttg.shared_memory>,
+                       %c: !ttg.memdesc<256x128xf32, #tmem, #ttng.tensor_memory, mutable>,
+                       %useAcc: i1,
+                       %pred: i1,
+                       %barrier: !ttg.memdesc<1xi64, #shared2, #ttg.shared_memory>,
+                       %barrierPred: i1) {
+    ttng.tc_gen5_mma %a, %b, %c, %useAcc, %pred, %barrier[%barrierPred] {is_async} :
+       !ttg.memdesc<256x128xf16, #shared, #ttg.shared_memory>,
+       !ttg.memdesc<128x128xf16, #shared1, #ttg.shared_memory>,
+       !ttg.memdesc<256x128xf32, #tmem, #ttng.tensor_memory, mutable>,
+       !ttg.memdesc<1xi64, #shared2, #ttg.shared_memory>
+    tt.return
+  }
+}
+
+// -----
+
+#shared = #ttg.nvmma_shared<{swizzlingByteWidth = 64, transposed = false, elementBitWidth = 8}>
+#shared1 = #ttg.nvmma_shared<{swizzlingByteWidth = 32, transposed = true, elementBitWidth = 8}>
+#shared2 = #ttg.swizzled_shared<{vec = 1, perPhase = 1, maxPhase = 1, order = [0]}>
+#tmem = #ttng.tensor_memory_encoding<blockM = 128, blockN = 128, colStride = 1>
+#tmem_scales = #ttng.tensor_memory_scales_encoding<>
+module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32} {
+  // CHECK-LABEL: @tc_gen5_mma_block_scale_breuse
+  // CHECK: tcgen05.mma.cta_group::1.kind::mxf8f6f4.block_scale.block32.collector::b::fill
+  // CHECK: tcgen05.mma.cta_group::1.kind::mxf8f6f4.block_scale.block32.collector::b::lastuse
+  tt.func @tc_gen5_mma_block_scale_breuse(%a: !ttg.memdesc<256x64xf8E4M3FN, #shared, #ttg.shared_memory>,
+                       %b: !ttg.memdesc<32x128xi8, #shared1, #ttg.shared_memory>,
+                       %c: !ttg.memdesc<256x128xf32, #tmem, #ttng.tensor_memory, mutable>,
+                       %scale_a: !ttg.memdesc<256x2xi8, #tmem_scales, #ttng.tensor_memory>,
+                       %scale_b: !ttg.memdesc<128x2xi8, #tmem_scales, #ttng.tensor_memory>,
+                       %useAcc: i1,
+                       %pred: i1,
+                       %barrier: !ttg.memdesc<1xi64, #shared2, #ttg.shared_memory, mutable>,
+                       %barrierPred: i1) {
+    ttng.tc_gen5_mma_scaled %a, %b, %c, %scale_a, %scale_b, %useAcc, %pred lhs = e4m3 rhs = e2m1, %barrier[%barrierPred] {is_async} :
+    !ttg.memdesc<256x64xf8E4M3FN, #shared, #ttg.shared_memory>,
+    !ttg.memdesc<32x128xi8, #shared1, #ttg.shared_memory>,
+    !ttg.memdesc<256x128xf32, #tmem, #ttng.tensor_memory, mutable>,
+    !ttg.memdesc<256x2xi8, #tmem_scales, #ttng.tensor_memory>,
+    !ttg.memdesc<128x2xi8, #tmem_scales, #ttng.tensor_memory>,
+    !ttg.memdesc<1xi64, #shared2, #ttg.shared_memory, mutable>
+    tt.return
+  }
+}

--- a/test/Conversion/tritongpu_to_llvm_rubin.mlir
+++ b/test/Conversion/tritongpu_to_llvm_rubin.mlir
@@ -1,0 +1,122 @@
+// RUN: triton-opt %s -split-input-file --convert-triton-gpu-to-llvm=compute-capability=107 -cse | FileCheck %s
+
+#shared = #ttg.nvmma_shared<{swizzlingByteWidth = 64, transposed = false, elementBitWidth = 8}>
+#shared1 = #ttg.nvmma_shared<{swizzlingByteWidth = 32, transposed = true, elementBitWidth = 8}>
+#shared2 = #ttg.swizzled_shared<{vec = 1, perPhase = 1, maxPhase = 1, order = [0]}>
+#tmem = #ttng.tensor_memory_encoding<blockM = 128, blockN = 128, colStride = 1>
+#tmem_scales = #ttng.tensor_memory_scales_encoding<>
+module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.target = "cuda:107"} {
+  // CHECK-LABEL: @tc_gen5_mma_block_scale_fp8_sm107
+  // CHECK: %[[TMEM_BASE:.+]] = llvm.ptrtoint %arg2 : !llvm.ptr<3> to i32
+  // CHECK-COUNT-2: tcgen05.mma.cta_group::1.kind::mxf8f6f4.block_scale.block32
+  // CHECK-NOT: tcgen05.mma
+  tt.func @tc_gen5_mma_block_scale_fp8_sm107(%a: !ttg.memdesc<128x128xf8E4M3FN, #shared, #ttg.shared_memory>,
+                       %b: !ttg.memdesc<64x128xi8, #shared1, #ttg.shared_memory>,
+                       %c: !ttg.memdesc<128x128xf32, #tmem, #ttng.tensor_memory, mutable>,
+                       %scale_a: !ttg.memdesc<128x8xi8, #tmem_scales, #ttng.tensor_memory>,
+                       %scale_b: !ttg.memdesc<128x4xi8, #tmem_scales, #ttng.tensor_memory>,
+                       %useAcc: i1,
+                       %pred: i1,
+                       %barrier: !ttg.memdesc<1xi64, #shared2, #ttg.shared_memory, mutable>,
+                       %barrierPred: i1) {
+    ttng.tc_gen5_mma_scaled %a, %b, %c, %scale_a, %scale_b, %useAcc, %pred lhs = e4m3 rhs = e2m1, %barrier[%barrierPred] {is_async} :
+    !ttg.memdesc<128x128xf8E4M3FN, #shared, #ttg.shared_memory>,
+    !ttg.memdesc<64x128xi8, #shared1, #ttg.shared_memory>,
+    !ttg.memdesc<128x128xf32, #tmem, #ttng.tensor_memory, mutable>,
+    !ttg.memdesc<128x8xi8, #tmem_scales, #ttng.tensor_memory>,
+    !ttg.memdesc<128x4xi8, #tmem_scales, #ttng.tensor_memory>,
+    !ttg.memdesc<1xi64, #shared2, #ttg.shared_memory, mutable>
+    tt.return
+  }
+}
+
+// -----
+
+#shared = #ttg.nvmma_shared<{swizzlingByteWidth = 64, transposed = false, elementBitWidth = 8}>
+#shared1 = #ttg.nvmma_shared<{swizzlingByteWidth = 64, transposed = true, elementBitWidth = 8}>
+#shared2 = #ttg.swizzled_shared<{vec = 1, perPhase = 1, maxPhase = 1, order = [0]}>
+#tmem = #ttng.tensor_memory_encoding<blockM = 128, blockN = 128, colStride = 1>
+#tmem_scales_a = #ttng.tensor_memory_scales_encoding<>
+#tmem_scales_b = #ttng.tensor_memory_scales_encoding<>
+module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.target = "cuda:107"} {
+  // CHECK-LABEL: @tc_gen5_mma_block_scale_nvfp4_sm107_m256
+  // Verify that we select MMA_K = 64 for NVFP4 with M = 256
+  // CHECK-COUNT-4: tcgen05.mma.cta_group::1.kind::mxf4nvf4.block_scale.block16
+  tt.func @tc_gen5_mma_block_scale_nvfp4_sm107_m256(%a: !ttg.memdesc<256x128xi8, #shared, #ttg.shared_memory>,
+                       %b: !ttg.memdesc<128x128xi8, #shared1, #ttg.shared_memory>,
+                       %c: !ttg.memdesc<256x128xf32, #tmem, #ttng.tensor_memory, mutable>,
+                       %scale_a: !ttg.memdesc<256x8xf8E4M3FN, #tmem_scales_a, #ttng.tensor_memory>,
+                       %scale_b: !ttg.memdesc<128x8xf8E4M3FN, #tmem_scales_b, #ttng.tensor_memory>,
+                       %useAcc: i1,
+                       %pred: i1,
+                       %barrier: !ttg.memdesc<1xi64, #shared2, #ttg.shared_memory>,
+                       %barrierPred: i1) {
+    ttng.tc_gen5_mma_scaled %a, %b, %c, %scale_a, %scale_b, %useAcc, %pred lhs = e2m1 rhs = e2m1, %barrier[%barrierPred] {is_async} :
+    !ttg.memdesc<256x128xi8, #shared, #ttg.shared_memory>,
+    !ttg.memdesc<128x128xi8, #shared1, #ttg.shared_memory>,
+    !ttg.memdesc<256x128xf32, #tmem, #ttng.tensor_memory, mutable>,
+    !ttg.memdesc<256x8xf8E4M3FN, #tmem_scales_a, #ttng.tensor_memory>,
+    !ttg.memdesc<128x8xf8E4M3FN, #tmem_scales_b, #ttng.tensor_memory>,
+    !ttg.memdesc<1xi64, #shared2, #ttg.shared_memory>
+    tt.return
+  }
+}
+
+// -----
+
+#shared = #ttg.nvmma_shared<{swizzlingByteWidth = 64, transposed = false, elementBitWidth = 8}>
+#shared1 = #ttg.nvmma_shared<{swizzlingByteWidth = 64, transposed = true, elementBitWidth = 8}>
+#shared2 = #ttg.swizzled_shared<{vec = 1, perPhase = 1, maxPhase = 1, order = [0]}>
+#tmem = #ttng.tensor_memory_encoding<blockM = 128, blockN = 128, colStride = 1>
+module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.target = "cuda:107"} {
+  // CHECK-LABEL: @tc_gen5_mma_fp8_sm107
+  // CHECK: %[[TMEM_BASE:.+]] = llvm.ptrtoint %arg2 : !llvm.ptr<3> to i32
+  // FP8 x FP8 (non-scaled) with K=128 on sm107, generates 2 MMA instructions
+  // CHECK-COUNT-2: tcgen05.mma.cta_group::1.kind::f8f6f4
+  // CHECK-NOT: tcgen05.mma
+  tt.func @tc_gen5_mma_fp8_sm107(%a: !ttg.memdesc<128x128xf8E4M3FN, #shared, #ttg.shared_memory>,
+                       %b: !ttg.memdesc<128x128xf8E4M3FN, #shared1, #ttg.shared_memory>,
+                       %c: !ttg.memdesc<128x128xf32, #tmem, #ttng.tensor_memory, mutable>,
+                       %useAcc: i1,
+                       %pred: i1,
+                       %barrier: !ttg.memdesc<1xi64, #shared2, #ttg.shared_memory>,
+                       %barrierPred: i1) {
+    ttng.tc_gen5_mma %a, %b, %c, %useAcc, %pred, %barrier[%barrierPred] {is_async} :
+       !ttg.memdesc<128x128xf8E4M3FN, #shared, #ttg.shared_memory>,
+       !ttg.memdesc<128x128xf8E4M3FN, #shared1, #ttg.shared_memory>,
+       !ttg.memdesc<128x128xf32, #tmem, #ttng.tensor_memory, mutable>,
+       !ttg.memdesc<1xi64, #shared2, #ttg.shared_memory>
+    tt.return
+  }
+}
+
+// -----
+
+// MMA codegen recognizes a fp4-padded SharedLinear A operand and selects
+// the padded mxf8f6f4 MMA_K = 32 variant
+#shared_fp4_padded_sl = #ttg.shared_linear<{offset = [[0, 1], [0, 2], [0, 4], [0, 0], [0, 8], [0, 16], [0, 32], [1, 8], [2, 16], [4, 32], [8, 0], [16, 0], [32, 0], [64, 0]], block = [[128, 0]]}, alignment = 1024>
+#shared_b = #ttg.nvmma_shared<{swizzlingByteWidth = 128, transposed = true, elementBitWidth = 8, CGALayout = [[0, 1]]}>
+#smem = #ttg.shared_memory
+#tmem = #ttng.tensor_memory_encoding<blockM = 128, blockN = 32, colStride = 1, CGALayout = [[1, 0]], twoCTAs = true>
+#tmem_scales = #ttng.tensor_memory_scales_encoding<CGALayout = [[0, 0]]>
+#tmem_scales1 = #ttng.tensor_memory_scales_encoding<CGALayout = [[1, 0]]>
+module attributes {"ttg.num-ctas" = 2 : i32, "ttg.num-warps" = 4 : i32, ttg.target = "cuda:107", "ttg.threads-per-warp" = 32 : i32, "ttng.two-ctas" = true} {
+  // CHECK-LABEL: @tc_gen5_mma_scaled_fp4_padded_shared_linear_a
+  // CHECK-COUNT-4: tcgen05.mma.cta_group::2.kind::mxf8f6f4.block_scale.block32
+  // CHECK-NOT: tcgen05.mma
+  tt.func @tc_gen5_mma_scaled_fp4_padded_shared_linear_a(
+      %a: !ttg.memdesc<256x64xi8, #shared_fp4_padded_sl, #smem, mutable>,
+      %b: !ttg.memdesc<128x32xf8E4M3FN, #shared_b, #smem, mutable>,
+      %d: !ttg.memdesc<256x32xf32, #tmem, #ttng.tensor_memory, mutable>,
+      %sa: !ttg.memdesc<256x4xi8, #tmem_scales1, #ttng.tensor_memory, mutable>,
+      %sb: !ttg.memdesc<32x4xi8, #tmem_scales, #ttng.tensor_memory, mutable>,
+      %useAcc: i1, %pred: i1) {
+    ttng.tc_gen5_mma_scaled %a, %b, %d, %sa, %sb, %useAcc, %pred lhs = e2m1 rhs = e4m3 {two_ctas} :
+      !ttg.memdesc<256x64xi8, #shared_fp4_padded_sl, #smem, mutable>,
+      !ttg.memdesc<128x32xf8E4M3FN, #shared_b, #smem, mutable>,
+      !ttg.memdesc<256x32xf32, #tmem, #ttng.tensor_memory, mutable>,
+      !ttg.memdesc<256x4xi8, #tmem_scales1, #ttng.tensor_memory, mutable>,
+      !ttg.memdesc<32x4xi8, #tmem_scales, #ttng.tensor_memory, mutable>
+    tt.return
+  }
+}

--- a/test/NVWS/aref-tmem-insertion.mlir
+++ b/test/NVWS/aref-tmem-insertion.mlir
@@ -992,7 +992,7 @@ module attributes {"ttg.num-warps" = 4 : i32, ttg.target = "cuda:100"} {
       %val, %tok5 = ttng.tmem_load %res[%tok4] {ttg.partition = array<i32: 0>} : !ttg.memdesc<128x256xf32, #tmem, #ttng.tensor_memory, mutable> -> tensor<128x256xf32, #blocked>
       "use"(%val) {ttg.partition = array<i32: 0>} : (tensor<128x256xf32, #blocked>) -> ()
       scf.yield {ttg.partition = array<i32: 0, 1, 2>} %tok5 : !ttg.async.token
-    } {tt.warp_specialize, ttg.partition = array<i32: 0, 1, 2>, ttg.partition.outputs = [array<i32: 2>], ttg.warp_specialize.tag = 0 : i32}
+    } {tt.disallow_acc_multi_buffer, tt.warp_specialize, ttg.partition = array<i32: 0, 1, 2>, ttg.partition.outputs = [array<i32: 2>], ttg.warp_specialize.tag = 0 : i32}
     tt.return
   }
 }

--- a/test/TritonGPU/accelerate-matmul.mlir
+++ b/test/TritonGPU/accelerate-matmul.mlir
@@ -1064,3 +1064,41 @@ module attributes {"ttg.target" = "cuda:90", "ttg.num-ctas" = 1 : i32, "ttg.num-
     tt.return %d : tensor<64x8xf32, #blocked_fp16_n8>
   }
 }
+
+// -----
+
+#blocked = #ttg.blocked<{sizePerThread = [1, 1], threadsPerWarp = [32, 1], warpsPerCTA = [4, 1], order = [0, 1]}>
+#blocked1 = #ttg.blocked<{sizePerThread = [1, 1], threadsPerWarp = [16, 2], warpsPerCTA = [4, 1], order = [1, 0]}>
+#blocked2 = #ttg.blocked<{sizePerThread = [1, 1], threadsPerWarp = [2, 16], warpsPerCTA = [4, 1], order = [1, 0]}>
+module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.target = "cuda:107", "ttg.threads-per-warp" = 32 : i32} {
+  // On sm107 (Rubin), with blockK >= 64 for mixed-precision, fp4Padded should NOT be true
+  // CHECK-DAG: #[[$B:.+]] = #ttg.blocked<{sizePerThread = [1, 1], threadsPerWarp = [32, 1], warpsPerCTA = [4, 1], order = [0, 1]}>
+  // CHECK-DAG: #[[$S:.+]] = #ttg.nvmma_shared<{swizzlingByteWidth = 64, transposed = true, elementBitWidth = 8}>
+  tt.func public @mmav5_block_scaled_mixed_prec_sm107_k64(%a: tensor<128x128xi8, #blocked2>, %scale_a: tensor<128x4xi8, #blocked1>, %b: tensor<64x128xi8, #blocked>, %scale_b: tensor<128x4xi8, #blocked1>) -> tensor<128x128xf32, #blocked> {
+    %cst = arith.constant dense<0.000000e+00> : tensor<128x128xf32, #blocked>
+    // CHECK: ttg.local_alloc {{.*}} : (tensor<64x128xi8, #[[$B]]>) -> !ttg.memdesc<64x128xi8, #[[$S]], #smem>
+    %d = tt.dot_scaled %a scale %scale_a, %b scale %scale_b, %cst lhs = e4m3 rhs = e2m1 {fastMath = false} : tensor<128x128xi8, #blocked2>, tensor<128x4xi8, #blocked1> * tensor<64x128xi8, #blocked>, tensor<128x4xi8, #blocked1> -> tensor<128x128xf32, #blocked>
+    tt.return %d : tensor<128x128xf32, #blocked>
+  }
+}
+
+// -----
+
+// On Rubin, fp4Padded = true is needed when the fp4 operand is MN-major
+
+// LAYOUT_16x256{LITERAL}: #ttg.linear<{register = [[0, 1], [8, 0], [0, 8], [0, 16], [0, 32], [0, 64], [0, 128], [16, 0]], lane = [[0, 2], [0, 4], [1, 0], [2, 0], [4, 0]], warp = [[32, 0], [64, 0]], block = []}>
+// CHECK-DAG: #[[$SHARED_A:.+]] = #ttg.nvmma_shared<{swizzlingByteWidth = 128, transposed = false, elementBitWidth = 8}>
+// CHECK-DAG: #[[$SHARED_B:.+]] = #ttg.nvmma_shared<{swizzlingByteWidth = 128, transposed = false, elementBitWidth = 8, fp4Padded = true}>
+#blocked = #ttg.blocked<{sizePerThread = [1, 1], threadsPerWarp = [1, 32], warpsPerCTA = [1, 4], order = [1, 0]}>
+#blocked1 = #ttg.blocked<{sizePerThread = [1, 1], threadsPerWarp = [4, 8], warpsPerCTA = [4, 1], order = [1, 0]}>
+module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.target = "cuda:107", "ttg.threads-per-warp" = 32 : i32} {
+  // CHECK-LABEL: mmav5_scaled_n_packing_rubin
+  tt.func public @mmav5_scaled_n_packing_rubin(%arg0: tensor<128x256xf8E5M2, #blocked>, %arg1: tensor<128x8xi8, #blocked1>, %arg2: tensor<256x128xi8, #blocked>, %arg3: tensor<256x8xi8, #blocked1>, %arg4: tensor<128x256xf32, #blocked>) -> tensor<128x256xf32, #blocked> {
+    // CHECK-DAG: %[[A:.+]] = ttg.local_alloc %{{.+}} : (tensor<128x256xf8E5M2, #{{.+}}>) -> !ttg.memdesc<128x256xf8E5M2, #[[$SHARED_A]], #smem>
+    // CHECK-DAG: %[[B:.+]] = ttg.local_alloc %{{.+}} : (tensor<256x128xi8, #{{.+}}>) -> !ttg.memdesc<256x128xi8, #[[$SHARED_B]], #smem>
+    // CHECK: ttng.tc_gen5_mma_scaled %[[A]], %[[B]],
+    %cst = arith.constant dense<0.000000e+00> : tensor<128x128xf32, #blocked>
+    %0 = tt.dot_scaled %arg0 scale %arg1, %arg2 scale %arg3, %arg4 lhs = e5m2 rhs = e2m1 {fastMath = false, rhs_k_pack = false} : tensor<128x256xf8E5M2, #blocked>, tensor<128x8xi8, #blocked1> * tensor<256x128xi8, #blocked>, tensor<256x8xi8, #blocked1> -> tensor<128x256xf32, #blocked>
+    tt.return %0 : tensor<128x256xf32, #blocked>
+  }
+}

--- a/third_party/nvidia/backend/compiler.py
+++ b/third_party/nvidia/backend/compiler.py
@@ -36,7 +36,7 @@ def min_dot_size(target: GPUTarget):
 
 
 def get_ptxas(arch: int) -> knobs.NvidiaTool:
-    return knobs.nvidia.ptxas_blackwell if arch >= 100 else knobs.nvidia.ptxas
+    return knobs.nvidia.ptxas_blackwell if arch in [100, 103] else knobs.nvidia.ptxas
 
 
 @functools.lru_cache()
@@ -434,8 +434,14 @@ class CUDABackend(BaseBackend):
             raise RuntimeError(
                 "Address Sanitizer Error: Address sanitizer is currently only supported on the AMD backend")
         llvm_mod = llvm.to_module(mod, context)
-        proc = sm_arch_from_capability(capability)
-        features = get_features(options, self.target.arch)
+
+        if capability == 107:
+            cap_llvm = 100
+        else:
+            cap_llvm = capability
+
+        proc = sm_arch_from_capability(cap_llvm)
+        features = get_features(options, cap_llvm)
         triple = 'nvptx64-nvidia-cuda'
         nvidia.set_short_ptr()
         llvm.attach_datalayout(llvm_mod, triple, proc, features)
@@ -469,8 +475,14 @@ class CUDABackend(BaseBackend):
         ptx_version = get_ptx_version_from_options(opt, self.target.arch)
 
         triple = 'nvptx64-nvidia-cuda'
-        proc = sm_arch_from_capability(capability)
-        features = get_features(opt, self.target.arch)
+
+        if capability == 107:
+            cap_llvm = 100
+        else:
+            cap_llvm = capability
+
+        proc = sm_arch_from_capability(cap_llvm)
+        features = get_features(opt, cap_llvm)
         flags = ["nvptx-mad-wide-opt"]
         canonicalize_gep = "fpsan" in opt.instrumentation_mode
         ret = llvm.translate_to_asm(src, triple, proc, features, flags, opt.enable_fp_fusion, False, canonicalize_gep)

--- a/third_party/nvidia/backend/compiler.py
+++ b/third_party/nvidia/backend/compiler.py
@@ -36,7 +36,7 @@ def min_dot_size(target: GPUTarget):
 
 
 def get_ptxas(arch: int) -> knobs.NvidiaTool:
-    return knobs.nvidia.ptxas_blackwell if arch in [100, 103] else knobs.nvidia.ptxas
+    return knobs.nvidia.ptxas_blackwell if arch >= 100 else knobs.nvidia.ptxas
 
 
 @functools.lru_cache()

--- a/third_party/nvidia/backend/driver.c
+++ b/third_party/nvidia/backend/driver.c
@@ -8,6 +8,16 @@
 #define PY_SSIZE_T_CLEAN
 #include <Python.h>
 
+#ifndef CU_FUNC_ATTRIBUTE_SHARED_MEMORY_MODE
+#define CU_FUNC_ATTRIBUTE_SHARED_MEMORY_MODE 17
+#endif
+#ifndef CU_SHARED_MEMORY_MODE_ALLOW_OVERSIZED_SHARED_MEMORY
+#define CU_SHARED_MEMORY_MODE_ALLOW_OVERSIZED_SHARED_MEMORY 3
+#endif
+#ifndef CU_LAUNCH_ATTRIBUTE_SHARED_MEMORY_MODE
+#define CU_LAUNCH_ATTRIBUTE_SHARED_MEMORY_MODE 18
+#endif
+
 typedef struct {
   PyObject_HEAD;
   _Alignas(alignof(CUtensorMap)) CUtensorMap tensorMap;
@@ -138,9 +148,18 @@ static PyObject *getDeviceProperties(PyObject *self, PyObject *args) {
   int sm_clock_rate;
   int mem_clock_rate;
   int mem_bus_width;
-  CUDA_CHECK_AND_RETURN_NULL(cuDeviceGetAttribute(
-      &max_shared_mem, CU_DEVICE_ATTRIBUTE_MAX_SHARED_MEMORY_PER_BLOCK_OPTIN,
-      device));
+
+  // XXX: remove attribute enum def once latest cuda.h is in use
+  int CU_DEVICE_ATTRIBUTE_MAX_OVERSIZED_SHARED_MEMORY_PER_BLOCK = 150;
+  if (CUDA_SUCCESS !=
+      cuDeviceGetAttribute(
+          &max_shared_mem,
+          CU_DEVICE_ATTRIBUTE_MAX_OVERSIZED_SHARED_MEMORY_PER_BLOCK, device)) {
+    CUDA_CHECK_AND_RETURN_NULL(cuDeviceGetAttribute(
+        &max_shared_mem, CU_DEVICE_ATTRIBUTE_MAX_SHARED_MEMORY_PER_BLOCK_OPTIN,
+        device));
+  }
+
   CUDA_CHECK_AND_RETURN_NULL(cuDeviceGetAttribute(
       &max_num_regs, CU_DEVICE_ATTRIBUTE_MAX_REGISTERS_PER_BLOCK, device));
   CUDA_CHECK_AND_RETURN_NULL(cuDeviceGetAttribute(
@@ -278,18 +297,28 @@ static PyObject *loadBinary(PyObject *self, PyObject *args) {
   CUDA_CHECK_AND_RETURN_NULL_ALLOW_THREADS(cuDeviceGetAttribute(
       &shared_optin, CU_DEVICE_ATTRIBUTE_MAX_SHARED_MEMORY_PER_BLOCK_OPTIN,
       device));
+  assert(shared_optin <= 228 * 1024 && "sanity check");
   if (shared > 49152 && shared_optin > 49152) {
-    CUDA_CHECK_AND_RETURN_NULL_ALLOW_THREADS(
-        cuFuncSetCacheConfig(fun, CU_FUNC_CACHE_PREFER_SHARED));
-    int shared_total, shared_static;
-    CUDA_CHECK_AND_RETURN_NULL_ALLOW_THREADS(cuDeviceGetAttribute(
-        &shared_total, CU_DEVICE_ATTRIBUTE_MAX_SHARED_MEMORY_PER_MULTIPROCESSOR,
-        device));
-    CUDA_CHECK_AND_RETURN_NULL_ALLOW_THREADS(cuFuncGetAttribute(
-        &shared_static, CU_FUNC_ATTRIBUTE_SHARED_SIZE_BYTES, fun));
-    CUDA_CHECK_AND_RETURN_NULL_ALLOW_THREADS(
-        cuFuncSetAttribute(fun, CU_FUNC_ATTRIBUTE_MAX_DYNAMIC_SHARED_SIZE_BYTES,
-                           shared_optin - shared_static));
+    // XXX: remove attribute enum defs once latest cuda.h is in use
+    // try to use oversized shared memory via new API
+    // L1$ size is set to 8KB, CGA scheduling must be in SPREAD mode.
+    if (CUDA_SUCCESS !=
+        cuFuncSetAttribute(
+            fun, CU_FUNC_ATTRIBUTE_SHARED_MEMORY_MODE,
+            CU_SHARED_MEMORY_MODE_ALLOW_OVERSIZED_SHARED_MEMORY)) {
+      // use legacy api if cuda doesn't support oversized shared memory
+      CUDA_CHECK_AND_RETURN_NULL_ALLOW_THREADS(
+          cuFuncSetCacheConfig(fun, CU_FUNC_CACHE_PREFER_SHARED));
+      int shared_total, shared_static;
+      CUDA_CHECK_AND_RETURN_NULL_ALLOW_THREADS(cuDeviceGetAttribute(
+          &shared_total,
+          CU_DEVICE_ATTRIBUTE_MAX_SHARED_MEMORY_PER_MULTIPROCESSOR, device));
+      CUDA_CHECK_AND_RETURN_NULL_ALLOW_THREADS(cuFuncGetAttribute(
+          &shared_static, CU_FUNC_ATTRIBUTE_SHARED_SIZE_BYTES, fun));
+      CUDA_CHECK_AND_RETURN_NULL_ALLOW_THREADS(cuFuncSetAttribute(
+          fun, CU_FUNC_ATTRIBUTE_MAX_DYNAMIC_SHARED_SIZE_BYTES,
+          shared_optin - shared_static));
+    }
   }
   Py_END_ALLOW_THREADS;
 
@@ -951,6 +980,18 @@ static void _launch(int gridX, int gridY, int gridZ, int num_warps,
     config.hStream = stream;
     config.attrs = launchAttr;
     int num_attrs = 0;
+
+    if (shared_memory > 228 * 1024) {
+      {
+        // XXX: remove attribute defs once driver with new API is in use
+        // L1$ size is set to 8KB, CGA scheduling must be in SPREAD mode.
+        CUlaunchAttribute attr = {
+            .id = CU_LAUNCH_ATTRIBUTE_SHARED_MEMORY_MODE,
+            .value = CU_SHARED_MEMORY_MODE_ALLOW_OVERSIZED_SHARED_MEMORY};
+        launchAttr[num_attrs] = attr;
+        ++num_attrs;
+      }
+    }
 
     if (launch_pdl != 0) {
       CUlaunchAttribute pdlAttr = {

--- a/third_party/nvidia/lib/Dialect/NVWS/Transforms/InsertTmemAref.cpp
+++ b/third_party/nvidia/lib/Dialect/NVWS/Transforms/InsertTmemAref.cpp
@@ -576,21 +576,6 @@ insertTmemArefImpl(TmemAccessDag::Node *node,
   return node;
 }
 
-bool canDoubleBufferAcc(MMAv5OpInterface mmaOp, int numTmemBlocks) {
-  auto tmemDesc = mmaOp.getAccumulator().getType();
-  auto blockM = tmemDesc.getShape()[0];
-  auto blockN = tmemDesc.getShape()[1];
-  constexpr int numTMEMColumns = 512;
-  constexpr int numTMEMRows = 128;
-  if (numTmemBlocks + (blockM * blockN * 2) > numTMEMRows * numTMEMColumns) {
-    return false;
-  }
-  if (isa<TCGen5MMAScaledOp>(mmaOp) && blockN == 256) {
-    return false;
-  }
-  return true;
-};
-
 bool hasProducerConsumerPartitioning(TmemAccessDag &accessDag) {
   // TMEM partitioning follows a producer-consumer pattern if it has this
   // structure:
@@ -676,8 +661,7 @@ int insertTmemAref(TmemAccessDag &accessDag, int numTmemBlocks) {
               // multibuffering.
               isAccMultibufferingPossible(mmaOp, loop) &&
               // The user didn't disable it with a flag.
-              !getDisallowAccMultiBuffer(wsLoop) &&
-              canDoubleBufferAcc(mmaOp, numTmemBlocks);
+              !getDisallowAccMultiBuffer(wsLoop);
           isMultiStaged = isMultiStaged && accIsMultiBuffered;
         }
       }

--- a/third_party/nvidia/lib/NVGPUToLLVM/NVGPUToLLVMPass.cpp
+++ b/third_party/nvidia/lib/NVGPUToLLVM/NVGPUToLLVMPass.cpp
@@ -7,6 +7,8 @@
 #include "mlir/IR/PatternMatch.h"
 #include "mlir/Support/LogicalResult.h"
 #include "mlir/Transforms/GreedyPatternRewriteDriver.h"
+#include "triton/Dialect/TritonGPU/Transforms/Utility.h"
+#include "triton/Dialect/TritonNvidiaGPU/IR/TargetFeatures.h"
 
 #include "nvidia/lib/TritonNVIDIAGPUToLLVM/Utility.h"
 #include "llvm/Support/ErrorHandling.h"
@@ -518,7 +520,8 @@ public:
 };
 
 static Value createTMAlloc(IRRewriter &rewriter, LLVM::LLVMFuncOp func,
-                           size_t size, Value pred, bool twoCTAs) {
+                           std::string exclusive, size_t size, Value pred,
+                           bool twoCTAs) {
   PTXBuilder ptxBuilder;
   Location loc = func.getLoc();
   auto b = TritonLLVMOpBuilder(loc, rewriter);
@@ -528,9 +531,10 @@ static Value createTMAlloc(IRRewriter &rewriter, LLVM::LLVMFuncOp func,
     NVVM::ClusterArriveOp::create(rewriter, loc, UnitAttr::get(ctx));
     NVVM::ClusterWaitOp::create(rewriter, loc, UnitAttr::get(ctx));
   }
-  std::string ptxString =
-      "@$0 tcgen05.alloc.cta_group::" + std::to_string(twoCTAs ? 2 : 1) +
-      ".sync.aligned.shared::cta.b32 [$1], " + std::to_string(size) + ";";
+  std::string ptxString = "@$0 tcgen05.alloc" + exclusive +
+                          ".cta_group::" + std::to_string(twoCTAs ? 2 : 1) +
+                          ".sync.aligned.shared::cta.b32 [$1], " +
+                          std::to_string(size) + ";";
 
   auto &allocOp = *ptxBuilder.create(ptxString);
   allocOp(
@@ -554,8 +558,8 @@ static void createRelinquishAlloc(IRRewriter &rewriter, Location loc,
   ptxBuilder.launch(rewriter, loc, void_ty(rewriter.getContext()));
 }
 
-void freeTMAlloc(LLVM::LLVMFuncOp func, Value alloc, size_t size, Value pred,
-                 bool twoCTAs) {
+void freeTMAlloc(LLVM::LLVMFuncOp func, Value alloc, std::string exclusive,
+                 size_t size, Value pred, bool twoCTAs) {
   func.walk([&](LLVM::ReturnOp ret) {
     OpBuilder b(ret);
     auto ctx = ret->getContext();
@@ -566,9 +570,10 @@ void freeTMAlloc(LLVM::LLVMFuncOp func, Value alloc, size_t size, Value pred,
     PTXBuilder ptxBuilder;
     // Calculate the predicate in the inline asm to avoid creating long
     // liveranges.
-    std::string ptxString =
-        "@$0 tcgen05.dealloc.cta_group::" + std::to_string(twoCTAs ? 2 : 1) +
-        ".sync.aligned.b32 $1, " + std::to_string(size) + ";";
+    std::string ptxString = "@$0 tcgen05.dealloc" + exclusive +
+                            ".cta_group::" + std::to_string(twoCTAs ? 2 : 1) +
+                            ".sync.aligned.b32 $1, " + std::to_string(size) +
+                            ";";
     auto &dealloc = *ptxBuilder.create(ptxString);
     dealloc(
         {ptxBuilder.newOperand(pred, "b"), ptxBuilder.newOperand(alloc, "r")},
@@ -590,22 +595,32 @@ static Value initTensorMemory(LLVM::LLVMFuncOp func) {
   auto ctx = mod.getContext();
   auto loc = func.getLoc();
   auto b = TritonLLVMOpBuilder(loc, rewriter);
+  int computeCapability = 100;
+  if (mod->hasAttr("ttg.target"))
+    computeCapability = getNVIDIAComputeCapability(mod);
+  triton::nvidia_gpu::TargetFeatures targetFeatures(computeCapability);
   // A proper error will be raised by the frontend, but to allow compilation to
+  auto tmemMaxSize = targetFeatures.getMaxTMEMColumns();
   // continue we emit a trap.
-  if (size > 512) {
+  if (size > tmemMaxSize) {
     LLVM::Trap::create(rewriter, loc);
     return LLVM::UndefOp::create(rewriter, loc, ptr_ty(ctx, 6));
   }
 
+  std::string exclusive =
+      size == tmemMaxSize && targetFeatures.supportsExclusiveTMEMAlloc()
+          ? ".exclusive"
+          : "";
   bool useTwoCTAs = mlir::triton::nvidia_gpu::getModuleTwoCTAs(mod);
   // This code is only executed by the default warp group.
   Value threadId = NVVM::ThreadIdXOp::create(rewriter, loc, i32_ty);
   Value pred = b.icmp_ult(threadId, b.i32_val(32));
-  Value alloc = createTMAlloc(rewriter, func, size, pred, useTwoCTAs);
+  Value alloc =
+      createTMAlloc(rewriter, func, exclusive, size, pred, useTwoCTAs);
   createRelinquishAlloc(rewriter, loc, pred, useTwoCTAs);
   // TODO: pred will have a long liverange, we need to check if this is a
   // problem and how it can be fixed.
-  freeTMAlloc(func, alloc, size, pred, useTwoCTAs);
+  freeTMAlloc(func, alloc, exclusive, size, pred, useTwoCTAs);
   return alloc;
 }
 

--- a/third_party/nvidia/lib/TritonNVIDIAGPUToLLVM/DotOpToLLVM/MMAHelpers.h
+++ b/third_party/nvidia/lib/TritonNVIDIAGPUToLLVM/DotOpToLLVM/MMAHelpers.h
@@ -153,7 +153,7 @@ public:
     if (failed(desc))
       return failure();
 
-    Value baseb128 = b.zext(i64_ty, b.and_(baseSrcb128, b.i32_val(0x3FFF)));
+    Value baseb128 = b.zext(i64_ty, b.and_(baseSrcb128, b.i32_val(0x7FFF)));
     return DotOpMmaSmemLoader{*desc, baseb128, ll};
   }
 

--- a/third_party/nvidia/lib/TritonNVIDIAGPUToLLVM/DotOpToLLVM/MMAv5.cpp
+++ b/third_party/nvidia/lib/TritonNVIDIAGPUToLLVM/DotOpToLLVM/MMAv5.cpp
@@ -321,7 +321,8 @@ static Value createScaleInstDescriptorFp4(
 void createGen5MMA(ConversionPatternRewriter &rewriter, Location loc,
                    ttng::TCGen5MMAOp op, MemDescOperand a, Value b,
                    MemDescOperand d, Value pred, Value instDescriptor,
-                   Value useInitAcc, bool aInTMem, bool twoCTAs) {
+                   Value useInitAcc, bool aInTMem, bool twoCTAs,
+                   std::string collectorB) {
   PTXBuilder ptxBuilder;
   std::string opcode =
       "tcgen05.mma.cta_group::" + std::to_string(twoCTAs ? 2 : 1) + ".kind::";
@@ -339,6 +340,7 @@ void createGen5MMA(ConversionPatternRewriter &rewriter, Location loc,
   } else {
     assert(0 && "Unsupported type.");
   }
+  opcode += collectorB;
   auto *accOp = ptxBuilder.newAddrOperand(d.base, "r", *d.offset);
   assert(a.offset.has_value() == aInTMem);
   auto *aOp = aInTMem ? ptxBuilder.newAddrOperand(a.base, "r", *a.offset)
@@ -355,7 +357,8 @@ void createScaledGen5MMA(ConversionPatternRewriter &rewriter, Location loc,
                          ttng::TCGen5MMAScaledOp op, MemDescOperand a, Value b,
                          MemDescOperand d, Value scaleA, Value scaleB,
                          Value pred, Value instDescriptor, Value useInitAcc,
-                         bool aInTmem, mxfpKind mxfpInstKind, bool twoCTAs) {
+                         bool aInTmem, mxfpKind mxfpInstKind, bool twoCTAs,
+                         std::string collectorB) {
   PTXBuilder ptxBuilder;
   std::string opcode =
       "tcgen05.mma.cta_group::" + std::to_string(twoCTAs ? 2 : 1) + ".kind::";
@@ -368,6 +371,7 @@ void createScaledGen5MMA(ConversionPatternRewriter &rewriter, Location loc,
   } else {
     assert(0 && "Unsupported mxfp kind.");
   }
+  opcode += collectorB;
   auto *accOp = ptxBuilder.newAddrOperand(d.base, "r", *d.offset);
   assert(aInTmem == a.offset.has_value());
   auto *aOp = aInTmem ? ptxBuilder.newAddrOperand(a.base, "r", *a.offset)
@@ -422,6 +426,13 @@ void createMMACommit(ConversionPatternRewriter &rewriter, Location loc,
 // MMAv5 Conversion
 //===----------------------------------------------------------------------===//
 
+enum class ReuseB {
+  None,
+  Keep,
+  Use,
+  Lastuse,
+};
+
 // Information about how to lower a dot operation, shared between regular and
 // scaled dot.
 struct DotConversion {
@@ -442,7 +453,7 @@ struct DotConversion {
       ConversionPatternRewriter &, Location, int, int, const InstDesc &)>;
   using CreateMMAInstFn = std::function<void(
       ConversionPatternRewriter &, Location, MemDescOperand, MemDescOperand,
-      Value, Value, Value, const InstDesc &, int, int, int)>;
+      Value, Value, Value, const InstDesc &, int, int, int, ReuseB)>;
 
   struct {
     unsigned M;
@@ -464,7 +475,9 @@ LogicalResult convertDotImpl(const LLVMTypeConverter &typeConverter,
                              MemDescType dTensorTy, Value useDFlag, Value pred,
                              ValueRange barriers, ValueRange barrierPreds,
                              bool twoCTAs, ValueRange commitDescs,
-                             bool opKindIsMXFP4, const DotConversion &op) {
+                             bool opKindIsMXFP4,
+                             const ttng::TargetFeatures &targetFeatures,
+                             const DotConversion &op) {
   auto tb = TritonLLVMOpBuilder(loc, rewriter);
 
   // Only run mma on one thread. We currently use elect as ptxas is not able to
@@ -570,18 +583,41 @@ LogicalResult convertDotImpl(const LLVMTypeConverter &typeConverter,
 
   DotConversion::InstDesc desc{mmaSizeM, mmaSizeN, {numRepM, numRepN, numRepK},
                                transA,   transB,   aInTmem};
-  for (int m = 0; m < numRepM; m++) {
+
+  // B reuse requires M = 128 for 1CTA or 256 for 2CTA, which corresponds to
+  // the condition mmaSizeM == 128 here
+  if (numRepM == 2 && mmaSizeM == 128 && targetFeatures.supportsReuseB()) {
     for (int n = 0; n < numRepN; n++) {
       Value useInitAcc = useDFlag;
-      MemDescOperand accAddress = op.getAccAddress(rewriter, loc, m, n, desc);
       for (int k = 0; k < numRepK; k++) {
-        MemDescOperand a = aLoader->memLoad(
-            m * aOperandShape[0], k * aOperandShape[1], rewriter, loc);
         Value b = bLoader->smemLoad(k * bOperandShape[0], n * bOperandShape[1],
                                     rewriter, loc);
-        op.createMMAInst(rewriter, loc, accAddress, a, b, elect, useInitAcc,
-                         desc, m, n, k);
+        for (int m = 0; m < 2; m++) {
+          MemDescOperand accAddress =
+              op.getAccAddress(rewriter, loc, m, n, desc);
+          MemDescOperand a =
+              aLoader->memLoad(m * mmaSizeM, k * mmaSizeK, rewriter, loc);
+          ReuseB reuseB = m == 0 ? ReuseB::Keep : ReuseB::Lastuse;
+          op.createMMAInst(rewriter, loc, accAddress, a, b, elect, useInitAcc,
+                           desc, m, n, k, reuseB);
+        }
         useInitAcc = tb.i1_val(1);
+      }
+    }
+  } else {
+    for (int m = 0; m < numRepM; m++) {
+      for (int n = 0; n < numRepN; n++) {
+        Value useInitAcc = useDFlag;
+        MemDescOperand accAddress = op.getAccAddress(rewriter, loc, m, n, desc);
+        for (int k = 0; k < numRepK; k++) {
+          MemDescOperand a = aLoader->memLoad(
+              m * aOperandShape[0], k * aOperandShape[1], rewriter, loc);
+          Value b = bLoader->smemLoad(k * bOperandShape[0],
+                                      n * bOperandShape[1], rewriter, loc);
+          op.createMMAInst(rewriter, loc, accAddress, a, b, elect, useInitAcc,
+                           desc, m, n, k, ReuseB::None);
+          useInitAcc = tb.i1_val(1);
+        }
       }
     }
   }
@@ -595,6 +631,17 @@ LogicalResult convertDotImpl(const LLVMTypeConverter &typeConverter,
   }
   LLVM::BrOp::create(rewriter, loc, endBlock);
   return success();
+}
+
+std::string getCollectorBModifer(ReuseB reuseB) {
+  if (reuseB == ReuseB::Keep) {
+    return ".collector::b::fill";
+  } else if (reuseB == ReuseB::Use) {
+    return ".collector::b::use";
+  } else if (reuseB == ReuseB::Lastuse) {
+    return ".collector::b::lastuse";
+  }
+  return "";
 }
 
 LogicalResult convertDot(const LLVMTypeConverter &typeConverter,
@@ -647,7 +694,7 @@ LogicalResult convertDot(const LLVMTypeConverter &typeConverter,
                           MemDescOperand accAddress, MemDescOperand a, Value b,
                           Value pred, Value useInitAcc,
                           const DotConversion::InstDesc &desc, int m, int n,
-                          int k) {
+                          int k, ReuseB reuseB) {
     // mmaSizeM/N is the per-cta size M/N, while the 2CTA instruction expects
     // the 2CTA size mmaSize is always 64 / 128 so we double it for 2CTA
     auto mmaSizeM = twoCTAs ? desc.mmaSizeM * 2 : desc.mmaSizeM;
@@ -656,15 +703,16 @@ LogicalResult convertDot(const LLVMTypeConverter &typeConverter,
     Value instDescriptor =
         createInstDescriptor(rewriter, op, mmaSizeM, mmaSizeN, desc.transA,
                              desc.transB, dot.mmaSizeK);
+    auto collectorB = getCollectorBModifer(reuseB);
     createGen5MMA(rewriter, loc, op, a, b, accAddress, pred, instDescriptor,
-                  useInitAcc, desc.aInTmem, twoCTAs);
+                  useInitAcc, desc.aInTmem, twoCTAs, collectorB);
   };
 
   return convertDotImpl(
       typeConverter, rewriter, loc, op.getA(), op.getB(), adaptor.getA(),
       adaptor.getB(), dTensorTy, adaptor.getUseD(), adaptor.getPred(),
       adaptor.getBarriers(), adaptor.getBarrierPreds(), twoCTAs, commitDescs,
-      /*opKindIsMXFP4=*/false, dot);
+      /*opKindIsMXFP4=*/false, targetFeatures, dot);
 }
 
 int64_t getFormatBitSize(ScaleDotElemType type) {
@@ -785,7 +833,7 @@ LogicalResult convertScaledDot(const LLVMTypeConverter &typeConverter,
                           MemDescOperand accAddress, MemDescOperand a, Value b,
                           Value pred, Value useInitAcc,
                           const DotConversion::InstDesc &desc, int m, int n,
-                          int k) {
+                          int k, ReuseB reuseB) {
     auto [numRepM, numRepN, numRepK] = desc.repShape;
     int scaleFactorColsPerSet =
         getScaleFactorColsPerSet(mxfpInstKind, op, dot.mmaSizeK);
@@ -818,16 +866,17 @@ LogicalResult convertScaledDot(const LLVMTypeConverter &typeConverter,
           subWordIdx, subWordIdx, mxfpInstKind, blockK, dot.mmaSizeK);
     }
 
+    auto collectorB = getCollectorBModifer(reuseB);
     createScaledGen5MMA(rewriter, loc, op, a, b, accAddress, scaleA, scaleB,
                         pred, instDescriptor, useInitAcc, desc.aInTmem,
-                        mxfpInstKind, twoCTAs);
+                        mxfpInstKind, twoCTAs, collectorB);
   };
 
-  return convertDotImpl(typeConverter, rewriter, loc, op.getA(), op.getB(),
-                        adaptor.getA(), adaptor.getB(), dTensorTy,
-                        adaptor.getUseD(), adaptor.getPred(),
-                        adaptor.getBarriers(), adaptor.getBarrierPreds(),
-                        twoCTAs, commitDescs, opKindIsMXFP4, dot);
+  return convertDotImpl(
+      typeConverter, rewriter, loc, op.getA(), op.getB(), adaptor.getA(),
+      adaptor.getB(), dTensorTy, adaptor.getUseD(), adaptor.getPred(),
+      adaptor.getBarriers(), adaptor.getBarrierPreds(), twoCTAs, commitDescs,
+      opKindIsMXFP4, targetFeatures, dot);
 }
 
 //===----------------------------------------------------------------------===//

--- a/third_party/nvidia/lib/TritonNVIDIAGPUToLLVM/DotOpToLLVM/MMAv5.cpp
+++ b/third_party/nvidia/lib/TritonNVIDIAGPUToLLVM/DotOpToLLVM/MMAv5.cpp
@@ -101,9 +101,9 @@ inline mxfpKind getMXFPKind(ScaleDotElemType typeA, ScaleDotElemType typeB,
   return mxfpKind::mxf8f6f4;
 };
 
-Value createInstDescriptor(ConversionPatternRewriter &rewriter,
-                           ttng::TCGen5MMAOp op, int M, int N, bool transposeA,
-                           bool transposeB) {
+static Value createInstDescriptor(ConversionPatternRewriter &rewriter,
+                                  ttng::TCGen5MMAOp op, int M, int N,
+                                  bool transposeA, bool transposeB, int kSize) {
   Location loc = op.getLoc();
   auto b = TritonLLVMOpBuilder(loc, rewriter);
   union TCGen5InstructionDescriptor {
@@ -123,7 +123,7 @@ Value createInstDescriptor(ConversionPatternRewriter &rewriter,
       uint32_t N : 6;
       uint32_t : 1;
       uint32_t M : 5;
-      uint32_t : 1;
+      uint32_t kSize : 1;
       uint32_t shift : 2;
     };
   };
@@ -161,14 +161,18 @@ Value createInstDescriptor(ConversionPatternRewriter &rewriter,
   } else {
     desc.dType = dstElType.isF16() ? 0 : 1;
   }
+  if (kSize == 64)
+    desc.kSize = 1;
+
   return b.int_val(32, desc.descriptor);
 }
 
-Value createScaleInstDescriptor(ConversionPatternRewriter &rewriter,
-                                ttng::TCGen5MMAScaledOp op, int M, int N,
-                                bool transposeA, bool transposeB,
-                                int scaleFactorsubIdxA, int scaleFactorsubIdxB,
-                                mxfpKind mxfpInstKind) {
+static Value createScaleInstDescriptorFp8(ConversionPatternRewriter &rewriter,
+                                          ttng::TCGen5MMAScaledOp op, int M,
+                                          int N, bool transposeA,
+                                          bool transposeB,
+                                          int scaleFactorsubIdxA,
+                                          int scaleFactorsubIdxB, int kSize) {
   Location loc = op.getLoc();
   auto b = TritonLLVMOpBuilder(loc, rewriter);
   union TCGen5InstructionDescriptor {
@@ -186,13 +190,13 @@ Value createScaleInstDescriptor(ConversionPatternRewriter &rewriter,
       uint32_t transposeA : 1;
       uint32_t transposeB : 1;
       uint32_t N : 6;
-      uint32_t scaleType : 1;
-      uint32_t M : 5;
+      uint32_t scaleType : 2;
+      uint32_t M : 4;
       uint32_t AScaleFactor : 2;
-      uint32_t : 1;
+      uint32_t kSize : 1;
     };
   };
-  auto getTypeEncoding = [](ScaleDotElemType type, bool isMXF4) {
+  auto getTypeEncoding = [](ScaleDotElemType type) {
     switch (type) {
     case ScaleDotElemType::E4M3:
       return 0;
@@ -203,7 +207,7 @@ Value createScaleInstDescriptor(ConversionPatternRewriter &rewriter,
     case ScaleDotElemType::E3M2:
       return 4;
     case ScaleDotElemType::E2M1:
-      return !isMXF4 ? 5 : 1;
+      return 5;
     default:
       break;
     }
@@ -215,40 +219,96 @@ Value createScaleInstDescriptor(ConversionPatternRewriter &rewriter,
   desc.descriptor = 0;
   desc.transposeA = transposeA;
   desc.transposeB = transposeB;
-  desc.M = M >> 4;
+  desc.M = M >> 5;
   desc.N = N >> 3;
-  desc.aType =
-      getTypeEncoding(op.getAType(), mxfpInstKind != mxfpKind::mxf8f6f4);
-  desc.bType =
-      getTypeEncoding(op.getBType(), mxfpInstKind != mxfpKind::mxf8f6f4);
+  desc.aType = getTypeEncoding(op.getAType());
+  desc.bType = getTypeEncoding(op.getBType());
   desc.AScaleFactor = scaleFactorsubIdxA;
   desc.BScaleFactor = scaleFactorsubIdxB;
-  // Hardcoded UE8M0 scale type.
-  desc.scaleType = 1;
+  desc.scaleType = 1; // E8M0
 
-  if (mxfpInstKind != mxfpKind::mxf8f6f4) {
-    assert(desc.aType == 1 && desc.bType == 1);
-    assert(desc.AScaleFactor <= 1 && desc.BScaleFactor <= 1);
-    assert(desc.transposeA == 0 &&
-           "MMAv5 with kind=mxf4 does not support transpose");
-    assert(desc.transposeB == 0 &&
-           "MMAv5 with kind=mxf4 does not support transpose");
-    if (mxfpInstKind == mxfpKind::mxf4) {
-      desc.AScaleFactor *= 2;
-      desc.BScaleFactor *= 2;
-      assert(desc.AScaleFactor == 0 ||
-             desc.AScaleFactor == 2 &&
-                 "MMAv5 with kind=mxf4 only supports SFA_ID 0 or 2");
-      assert(desc.BScaleFactor == 0 ||
-             desc.BScaleFactor == 2 &&
-                 "MMAv5 with kind=mxf4 only supports SFB_ID 0 or 2");
-    } else if (mxfpInstKind == mxfpKind::mxf4nvf4) {
-      desc.scaleType = 0; // UE4M3
-      assert(desc.AScaleFactor == 0 &&
-             "MMAv5 with kind=mxf4nvf4 currently only supports SFA_ID 0");
-      assert(desc.BScaleFactor == 0 &&
-             "MMAv5 with kind=mxf4nvf4 currently only supports SFB_ID 0");
-    }
+  assert(kSize == 32 || kSize == 64);
+  if (kSize == 64) {
+    desc.kSize = 1;
+    desc.AScaleFactor *= 2;
+    desc.BScaleFactor *= 2;
+  }
+
+  return b.int_val(32, desc.descriptor);
+}
+
+static Value createScaleInstDescriptorFp4(
+    ConversionPatternRewriter &rewriter, ttng::TCGen5MMAScaledOp op, int M,
+    int N, bool transposeA, bool transposeB, int scaleFactorsubIdxA,
+    int scaleFactorsubIdxB, mxfpKind mxfpInstKind, int blockK, int kSize) {
+  Location loc = op.getLoc();
+  auto b = TritonLLVMOpBuilder(loc, rewriter);
+  union TCGen5InstructionDescriptor {
+    uint32_t descriptor;
+    struct {
+      uint32_t sparsitySelector : 2;
+      uint32_t sparsity : 1;
+      uint32_t kSizeUpper : 1;
+      uint32_t BScaleFactor : 2;
+      uint32_t : 1;
+      uint32_t aType : 3;
+      uint32_t bType : 2;
+      uint32_t : 1;
+      uint32_t negateA : 1;
+      uint32_t negateB : 1;
+      uint32_t transposeA : 1;
+      uint32_t transposeB : 1;
+      uint32_t N : 6;
+      uint32_t scaleType : 2;
+      uint32_t M : 4;
+      uint32_t AScaleFactor : 2;
+      uint32_t kSizeLower : 1;
+    };
+  };
+  static_assert(sizeof(TCGen5InstructionDescriptor) == 4,
+                "instruction descriptor size should be 32 bits.");
+  TCGen5InstructionDescriptor desc;
+  desc.descriptor = 0;
+  desc.transposeA = transposeA;
+  desc.transposeB = transposeB;
+  desc.M = M >> 5;
+  desc.N = N >> 3;
+  desc.aType = 1;
+  desc.bType = 1;
+  desc.AScaleFactor = scaleFactorsubIdxA;
+  desc.BScaleFactor = scaleFactorsubIdxB;
+  desc.scaleType =
+      llvm::isa<Float8E4M3FNType>(op.getAScale().getType().getElementType())
+          ? 0
+          : 1;
+
+  assert(kSize == 64 || kSize == 128);
+  if (kSize == 128) {
+    desc.kSizeUpper = 1;
+  }
+
+  assert(desc.AScaleFactor <= 1 && desc.BScaleFactor <= 1);
+  assert(desc.transposeA == 0 &&
+         "MMAv5 with kind=mxf4 does not support transpose");
+  assert(desc.transposeB == 0 &&
+         "MMAv5 with kind=mxf4 does not support transpose");
+
+  if (mxfpInstKind == mxfpKind::mxf4) {
+    desc.AScaleFactor *= 2;
+    desc.BScaleFactor *= 2;
+    assert(desc.AScaleFactor == 0 || desc.AScaleFactor == 2 &&
+                                         "MMAv5 with kind=mxf4 or "
+                                         "kind=mxf4nvf4 and .block32 only "
+                                         "supports SFA_ID 0 or 2");
+    assert(desc.BScaleFactor == 0 || desc.BScaleFactor == 2 &&
+                                         "MMAv5 with kind=mxf4 or "
+                                         "kind=mxf4nvf4 and .block32 only "
+                                         "supports SFB_ID 0 or 2");
+  } else if (mxfpInstKind == mxfpKind::mxf4nvf4) {
+    assert(desc.AScaleFactor == 0 &&
+           "MMAv5 with kind=mxf4nvf4 and .block16 only supports SFA_ID 0");
+    assert(desc.BScaleFactor == 0 &&
+           "MMAv5 with kind=mxf4nvf4 and .block16 only supports SFB_ID 0");
   }
 
   return b.int_val(32, desc.descriptor);
@@ -300,11 +360,11 @@ void createScaledGen5MMA(ConversionPatternRewriter &rewriter, Location loc,
   std::string opcode =
       "tcgen05.mma.cta_group::" + std::to_string(twoCTAs ? 2 : 1) + ".kind::";
   if (mxfpInstKind == mxfpKind::mxf8f6f4) {
-    opcode += "mxf8f6f4.block_scale.scale_vec::1X";
+    opcode += "mxf8f6f4.block_scale.block32";
   } else if (mxfpInstKind == mxfpKind::mxf4) {
-    opcode += "mxf4.block_scale.scale_vec::2X";
+    opcode += "mxf4.block_scale.block32";
   } else if (mxfpInstKind == mxfpKind::mxf4nvf4) {
-    opcode += "mxf4nvf4.block_scale.scale_vec::4X";
+    opcode += "mxf4nvf4.block_scale.block16";
   } else {
     assert(0 && "Unsupported mxfp kind.");
   }
@@ -540,7 +600,8 @@ LogicalResult convertDotImpl(const LLVMTypeConverter &typeConverter,
 LogicalResult convertDot(const LLVMTypeConverter &typeConverter,
                          ConversionPatternRewriter &rewriter, Location loc,
                          ttng::TCGen5MMAOp op,
-                         ttng::TCGen5MMAOpAdaptor &adaptor) {
+                         ttng::TCGen5MMAOpAdaptor &adaptor,
+                         const ttng::TargetFeatures &targetFeatures) {
   MemDescType aTensorTy = op.getA().getType();
   MemDescType bTensorTy = op.getB().getType();
   MemDescType dTensorTy = op.getD().getType();
@@ -555,6 +616,18 @@ LogicalResult convertDot(const LLVMTypeConverter &typeConverter,
   dot.shape.N = dstPerCTA[1];
   dot.shape.K = aTensorTy.getDimSize(1);
   dot.mmaSizeK = 256 / aTensorTy.getElementTypeBitWidth();
+
+  auto tensorMemAttr =
+      cast<ttng::TensorMemoryEncodingAttr>(dTensorTy.getEncoding());
+  unsigned mmaSizeM = tensorMemAttr.getBlockM();
+
+  // 2xfp8 requires M = 128 for 1CTA or 256 for 2CTA, which corresponds to
+  // the condition mmaSizeM == 128 here
+  if (targetFeatures.supports2xFp8Tcgen05MMA() &&
+      aTensorTy.getElementTypeBitWidth() == 8 &&
+      aTensorTy.getDimSize(1) >= 64 && mmaSizeM == 128) {
+    dot.mmaSizeK = 64;
+  }
 
   dot.shapeA = getShapePerCTA(aTensorTy);
   dot.shapeB = getShapePerCTA(bTensorTy);
@@ -580,8 +653,9 @@ LogicalResult convertDot(const LLVMTypeConverter &typeConverter,
     auto mmaSizeM = twoCTAs ? desc.mmaSizeM * 2 : desc.mmaSizeM;
     auto mmaSizeN = desc.mmaSizeN;
     assert(desc.mmaSizeM == 64 || desc.mmaSizeM == 128);
-    Value instDescriptor = createInstDescriptor(
-        rewriter, op, mmaSizeM, mmaSizeN, desc.transA, desc.transB);
+    Value instDescriptor =
+        createInstDescriptor(rewriter, op, mmaSizeM, mmaSizeN, desc.transA,
+                             desc.transB, dot.mmaSizeK);
     createGen5MMA(rewriter, loc, op, a, b, accAddress, pred, instDescriptor,
                   useInitAcc, desc.aInTmem, twoCTAs);
   };
@@ -610,12 +684,13 @@ int64_t getFormatBitSize(ScaleDotElemType type) {
   }
 }
 
-int getScaleFactorColsPerSet(mxfpKind kind) {
+int getScaleFactorColsPerSet(mxfpKind kind, ttng::TCGen5MMAScaledOp op,
+                             int kSize) {
   switch (kind) {
   case mxfpKind::mxf8f6f4:
-    return 1;
+    return kSize == 32 ? 1 : 2;
   case mxfpKind::mxf4:
-    return 2;
+    return kSize == 64 ? 2 : 4;
   case mxfpKind::mxf4nvf4:
     return 4;
   default:
@@ -623,13 +698,24 @@ int getScaleFactorColsPerSet(mxfpKind kind) {
   }
 };
 
+bool isFp4Padded(MemDescType operand) {
+  if (auto tmemLayout =
+          dyn_cast<ttng::TensorMemoryEncodingAttr>(operand.getEncoding()))
+    return tmemLayout.getFp4Padded();
+  auto attrs = ttng::getNvmmaSmemAttrs(operand);
+  assert(attrs && "expected MMAv5 shared operand to have NVMMA SMEM attrs");
+  return attrs->fp4Padded;
+}
+
 LogicalResult convertScaledDot(const LLVMTypeConverter &typeConverter,
                                ConversionPatternRewriter &rewriter,
                                Location loc, ttng::TCGen5MMAScaledOp op,
-                               ttng::TCGen5MMAScaledOpAdaptor &adaptor) {
+                               ttng::TCGen5MMAScaledOpAdaptor &adaptor,
+                               const ttng::TargetFeatures &targetFeatures) {
   MemDescType aTensorTy = op.getA().getType();
   MemDescType bTensorTy = op.getB().getType();
   MemDescType dTensorTy = op.getD().getType();
+  int blockK = op.getBlockK();
 
   mxfpKind mxfpInstKind = getMXFPKind(
       op.getAType(), op.getBType(), op.getAScale().getType().getElementType(),
@@ -639,20 +725,42 @@ LogicalResult convertScaledDot(const LLVMTypeConverter &typeConverter,
 
   DotConversion dot;
 
+  auto tensorMemAttr =
+      cast<ttng::TensorMemoryEncodingAttr>(dTensorTy.getEncoding());
+  unsigned mmaSizeM = tensorMemAttr.getBlockM();
+  unsigned mmaSizeN = tensorMemAttr.getBlockN();
+
   // Use per-CTA shape to correctly handle 2-CTA mode. getBlockM/N() returns
   // the full block shape (e.g., 256 for 2-CTA), but we need the per-CTA shape
   // (e.g., 128) to compute the correct number of MMA repetitions.
   SmallVector<int64_t> dstPerCTA = triton::gpu::getShapePerCTA(dTensorTy);
   dot.shape.M = dstPerCTA[0];
   dot.shape.N = dstPerCTA[1];
-  dot.shape.K = op.getBlockK(); // K is not split across CTAs
-  dot.mmaSizeK = !opKindIsMXFP4 ? 32 : 64;
+  dot.shape.K = blockK; // K is not split across CTAs
 
   dot.shapeA = triton::gpu::getAllocationShapePerCTA(aTensorTy);
   dot.shapeB = triton::gpu::getAllocationShapePerCTA(bTensorTy);
   if (opKindIsMXFP4) {
     dot.shapeA[1] *= 2;
     dot.shapeB[0] *= 2;
+  }
+
+  bool hasFp4PaddedOperand = isFp4Padded(aTensorTy) || isFp4Padded(bTensorTy);
+
+  if (!targetFeatures.supports4xFp4Tcgen05MMA() || hasFp4PaddedOperand ||
+      // M = 64 for 1CTA or 128 for 2CTA not supported for 2xfp8 / 4xfp4
+      mmaSizeM == 64 ||
+      // There are several cases where we need to disable 4xNVFP4 on Rubin:
+      // * MMA_N < 128 requires a special unpacked layout for scales B in TMEM
+      // (currently undocumented). tensorMemoryScalesToLinearLayout and lowering
+      // of tcgen05.cp need to be updated for this.
+      // * When BLOCK_M = 256, tensorMemoryScalesToLinearLayout returns an
+      // incorrect layout for scale A.
+      (mxfpInstKind == mxfpKind::mxf4nvf4 &&
+       (mmaSizeN < 128 || dot.shape.M == 256))) {
+    dot.mmaSizeK = opKindIsMXFP4 ? 64 : 32;
+  } else {
+    dot.mmaSizeK = opKindIsMXFP4 ? std::min(blockK, 128) : std::min(blockK, 64);
   }
 
   dot.numBitsPerElementA = getFormatBitSize(op.getAType());
@@ -679,7 +787,8 @@ LogicalResult convertScaledDot(const LLVMTypeConverter &typeConverter,
                           const DotConversion::InstDesc &desc, int m, int n,
                           int k) {
     auto [numRepM, numRepN, numRepK] = desc.repShape;
-    int scaleFactorColsPerSet = getScaleFactorColsPerSet(mxfpInstKind);
+    int scaleFactorColsPerSet =
+        getScaleFactorColsPerSet(mxfpInstKind, op, dot.mmaSizeK);
     int numColPerScaleBlockA = ceil<int>(
         ttng::getTmemAllocSizes(cast<MemDescType>(op.getAScale().getType()))
             .numCols,
@@ -695,12 +804,20 @@ LogicalResult convertScaledDot(const LLVMTypeConverter &typeConverter,
         baseScaleA, tb.i32_val((m + wordIdx * numRepM) * numColPerScaleBlockA));
     Value scaleB = tb.add(
         baseScaleB, tb.i32_val((n + wordIdx * numRepN) * numColPerScaleBlockB));
+    Value instDescriptor;
     // For 2CTA mode, the M dimension in the instruction descriptor must be
     // doubled to match the hardware's expectation for cta_group::2 operations.
-    Value instDescriptor = createScaleInstDescriptor(
-        rewriter, op, twoCTAs ? desc.mmaSizeM * 2 : desc.mmaSizeM,
-        desc.mmaSizeN, desc.transA, desc.transB, subWordIdx, subWordIdx,
-        mxfpInstKind);
+    int mmaM = twoCTAs ? desc.mmaSizeM * 2 : desc.mmaSizeM;
+    if (mxfpInstKind == mxfpKind::mxf8f6f4) {
+      instDescriptor = createScaleInstDescriptorFp8(
+          rewriter, op, mmaM, desc.mmaSizeN, desc.transA, desc.transB,
+          subWordIdx, subWordIdx, dot.mmaSizeK);
+    } else {
+      instDescriptor = createScaleInstDescriptorFp4(
+          rewriter, op, mmaM, desc.mmaSizeN, desc.transA, desc.transB,
+          subWordIdx, subWordIdx, mxfpInstKind, blockK, dot.mmaSizeK);
+    }
+
     createScaledGen5MMA(rewriter, loc, op, a, b, accAddress, scaleA, scaleB,
                         pred, instDescriptor, useInitAcc, desc.aInTmem,
                         mxfpInstKind, twoCTAs);
@@ -721,30 +838,46 @@ struct TCGen5MMAOpConversion
     : public ConvertOpToLLVMPattern<ttng::TCGen5MMAOp> {
   using ConvertOpToLLVMPattern::ConvertOpToLLVMPattern;
 
+  TCGen5MMAOpConversion(LLVMTypeConverter &converter, PatternBenefit benefit,
+                        const ttng::TargetFeatures &targetFeatures)
+      : ConvertOpToLLVMPattern<ttng::TCGen5MMAOp>(converter, benefit),
+        targetFeatures(targetFeatures) {}
+
   LogicalResult
   matchAndRewrite(ttng::TCGen5MMAOp op, OpAdaptor adaptor,
                   ConversionPatternRewriter &rewriter) const override {
     if (failed(convertDot(*getTypeConverter(), rewriter, op.getLoc(), op,
-                          adaptor)))
+                          adaptor, targetFeatures)))
       return failure();
     rewriter.eraseOp(op);
     return success();
   }
+
+  ttng::TargetFeatures targetFeatures;
 };
 
 struct TCGen5MMAScaledOpConversion
     : public ConvertOpToLLVMPattern<ttng::TCGen5MMAScaledOp> {
   using ConvertOpToLLVMPattern::ConvertOpToLLVMPattern;
 
+  TCGen5MMAScaledOpConversion(LLVMTypeConverter &converter,
+                              PatternBenefit benefit,
+                              const ttng::TargetFeatures &targetFeatures)
+      : ConvertOpToLLVMPattern<ttng::TCGen5MMAScaledOp>(converter, benefit),
+        targetFeatures(targetFeatures) {}
+
   LogicalResult
   matchAndRewrite(ttng::TCGen5MMAScaledOp op, OpAdaptor adaptor,
                   ConversionPatternRewriter &rewriter) const override {
     if (failed(convertScaledDot(*getTypeConverter(), rewriter, op.getLoc(), op,
-                                adaptor)))
+                                adaptor, targetFeatures)))
       return failure();
     rewriter.eraseOp(op);
     return success();
   }
+
+private:
+  ttng::TargetFeatures targetFeatures;
 };
 
 struct TCGen5CommitOpConversion
@@ -789,9 +922,11 @@ namespace NVIDIA {
 
 void populateTCGen5MMAOpToLLVMPattern(LLVMTypeConverter &typeConverter,
                                       RewritePatternSet &patterns,
-                                      PatternBenefit benefit) {
-  patterns.add<TCGen5MMAOpConversion, TCGen5MMAScaledOpConversion,
-               TCGen5CommitOpConversion>(typeConverter, benefit);
+                                      PatternBenefit benefit,
+                                      const TargetInfo &targetInfo) {
+  patterns.add<TCGen5MMAOpConversion, TCGen5MMAScaledOpConversion>(
+      typeConverter, benefit, targetInfo.getTargetFeatures());
+  patterns.add<TCGen5CommitOpConversion>(typeConverter, benefit);
 }
 
 } // namespace NVIDIA

--- a/third_party/nvidia/lib/TritonNVIDIAGPUToLLVM/PatternTritonGPUOpToLLVM.h
+++ b/third_party/nvidia/lib/TritonNVIDIAGPUToLLVM/PatternTritonGPUOpToLLVM.h
@@ -74,7 +74,8 @@ void populateClampFOpToLLVMPattern(LLVMTypeConverter &typeConverter,
 
 void populateTCGen5MMAOpToLLVMPattern(LLVMTypeConverter &typeConverter,
                                       RewritePatternSet &patterns,
-                                      PatternBenefit benefit);
+                                      PatternBenefit benefit,
+                                      const TargetInfo &targetInfo);
 
 void populateTensorMemoryOpToLLVMPattern(LLVMTypeConverter &typeConverter,
                                          RewritePatternSet &patterns,

--- a/third_party/nvidia/lib/TritonNVIDIAGPUToLLVM/TargetInfo.h
+++ b/third_party/nvidia/lib/TritonNVIDIAGPUToLLVM/TargetInfo.h
@@ -8,6 +8,8 @@ namespace mlir::triton::NVIDIA {
 
 class TargetInfo : public mlir::triton::TargetInfoBase {
 public:
+  explicit TargetInfo(int computeCapability)
+      : TargetInfo(computeCapability, /*ptxVersion=*/0) {}
   TargetInfo(int computeCapability, int ptxVersion)
       : targetFeatures(computeCapability), ptxVersion(ptxVersion) {}
 
@@ -94,6 +96,9 @@ public:
   int getPtxVersion() const { return ptxVersion; }
   int getComputeCapability() const {
     return targetFeatures.getComputeCapability();
+  }
+  const triton::nvidia_gpu::TargetFeatures &getTargetFeatures() const {
+    return targetFeatures;
   }
 
   bool isCuda() const override { return true; }

--- a/third_party/nvidia/lib/TritonNVIDIAGPUToLLVM/TritonGPUToLLVM.cpp
+++ b/third_party/nvidia/lib/TritonNVIDIAGPUToLLVM/TritonGPUToLLVM.cpp
@@ -206,8 +206,8 @@ struct ConvertTritonGPUToLLVM
         typeConverter, patterns, benefit);
     mlir::triton::populateMakeRangeOpToLLVMPattern(typeConverter, targetInfo,
                                                    patterns, benefit);
-    mlir::triton::NVIDIA::populateTCGen5MMAOpToLLVMPattern(typeConverter,
-                                                           patterns, benefit);
+    mlir::triton::NVIDIA::populateTCGen5MMAOpToLLVMPattern(
+        typeConverter, patterns, benefit, targetInfo);
     mlir::triton::NVIDIA::populateFp4ToFpToLLVMPatterns(typeConverter, patterns,
                                                         benefit);
     mlir::triton::populateInstrumentationToLLVMPatterns(typeConverter, patterns,


### PR DESCRIPTION
This is the first PR to add Rubin support to Triton - the basic structural enablement and key tcgen05 MMA enhancements:
- Increase SMEM capacity per SM to 328KB
- Increase TMEM capacity per SM to 288KB
- 2x MMA throughput increase for FP8 and FP4
- B buffer reuse

See the updated PTX documentation for the details on Rubin features.
https://docs.nvidia.com/cuda/developer-preview/13.4/parallel-thread-execution/index.html

Rubin enablement has been a collaborative effort between NVIDIA and OpenAI from the following contributors: 

NVIDIA
Masahiro Masuda @masahi 
Evghenii Gaburov @3gx
Clive Unger @CliveUnger
Adam Straw @adstraw 
Thierry Moreau @tmoreau89
Shanthal Vasanth @shanthalv
Jason Knight @binarybana

OpenAI:
Thomas Raoux @ThomasRaoux
Mario Lezcano @lezcano