### PR TITLE
[NVIDIA] Lower SM90 and SM100 mbarriers with NVVM

### DIFF
--- a/python/test/unit/language/test_compile_only.py
+++ b/python/test/unit/language/test_compile_only.py
@@ -44,7 +44,7 @@ module attributes {"ttg.num-ctas" = 2 : i32, "ttg.num-warps" = 4 : i32, ttg.targ
     k = triton.compile(str(temp_file), target=GPUTarget("cuda", 90, 32))
     ptx = k.asm["ptx"]
     assert "mbarrier.arrive.release.cluster.shared::cluster.b64" in ptx
-    assert "mbarrier.try_wait.parity.acquire.cluster.shared::cta.b64" in ptx
+    assert "mbarrier.try_wait.parity.acquire.cluster.shared.b64" in ptx
     assert "mapa" not in ptx
     assert k.metadata.shared == 40
     assert k.asm["cubin"] != b""
@@ -125,7 +125,7 @@ def test_compile_only_dot() -> None:
                r"(.|\n)*"
                r"tcgen05.commit.cta_group::1.mbarrier::arrive::one.shared::cluster.b64"
                r"(.|\n)*"
-               r"mbarrier.try_wait.parity.shared::cta.b64"
+               r"mbarrier.try_wait.parity.shared.b64"
                r"(.|\n)*"
                r"tcgen05.ld.sync.aligned.16x32bx2.x32.b32"
                r"(.|\n)*"

--- a/test/Conversion/tritongpu_to_llvm.mlir
+++ b/test/Conversion/tritongpu_to_llvm.mlir
@@ -1639,8 +1639,8 @@ module attributes {"ttg.num-ctas" = 2 : i32, "ttg.num-warps" = 1 : i32, "ttg.tar
 module attributes {"ttg.num-ctas" = 2 : i32, "ttg.num-warps" = 4 : i32, "ttg.target" = "cuda:90", "ttg.threads-per-warp" = 32 : i32, "ttg.total-num-warps" = 8 : i32} {
   // Atomic ordering barriers must not introduce a nested warp specialization.
   // CHECK-LABEL: atomic_release_multi_cta_warp_specialize
-  // CHECK: mbarrier.arrive.release.cluster.shared::cluster.b64
-  // CHECK: mbarrier.try_wait.parity.acquire.cluster.shared::cta.b64
+  // CHECK: nvvm.mbarrier.arrive %{{.*}}, %{{.*}} {scope = #nvvm.mem_scope<cluster>} : !llvm.ptr<7>
+  // CHECK: nvvm.mbarrier.try_wait %{{.*}}, %{{.*}} {scope = #nvvm.mem_scope<cluster>} : !llvm.ptr<3>, i32 -> i1
   // CHECK: red.global.sys.release.add.u32
   tt.func @atomic_release_multi_cta_warp_specialize(%ptr : !tt.ptr<i32>, %mask : i1, %val : i32) {
     ttg.warp_specialize()

--- a/test/Conversion/tritonnvidiagpu_to_llvm.mlir
+++ b/test/Conversion/tritonnvidiagpu_to_llvm.mlir
@@ -7,7 +7,7 @@
 module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32} {
   // CHECK-LABEL: init_barrier
   tt.func @init_barrier(%alloc: !ttg.memdesc<1xi64, #shared0, #smem>) {
-    // CHECK: "@$0 mbarrier.init.shared::cta.b64 [$1], 1;", "b,r" %{{.*}}, %{{.*}} : (i1, !llvm.ptr<3>) -> !llvm.void
+    // CHECK: nvvm.mbarrier.init %{{.*}}, %{{.*}} : !llvm.ptr<3>, i32
     ttng.init_barrier %alloc, 1 : !ttg.memdesc<1xi64, #shared0, #smem>
     tt.return
   }
@@ -22,7 +22,7 @@ module attributes {"ttg.num-ctas" = 2 : i32, "ttg.num-warps" = 4 : i32} {
   tt.func @init_barrier_cluster_broadcast() {
     %alloc = ttg.local_alloc {allocation.offset = 0 : i32} : () -> !ttg.memdesc<1xi64, #shared0, #smem, mutable>
     // CHECK: nvg.cluster_id
-    // CHECK: @$0 mbarrier.init.shared::cta.b64 [$1], 2;
+    // CHECK: nvvm.mbarrier.init %{{.*}}, %{{.*}} : !llvm.ptr<3>, i32
     ttng.init_barrier %alloc, 1 : !ttg.memdesc<1xi64, #shared0, #smem, mutable>
     ttng.inval_barrier %alloc : !ttg.memdesc<1xi64, #shared0, #smem, mutable>
     tt.return
@@ -40,7 +40,7 @@ module attributes {"ttg.num-ctas" = 2 : i32, "ttg.num-warps" = 4 : i32} {
     // CHECK: llvm.ptrtoint
     // CHECK: llvm.and
     // CHECK: llvm.inttoptr
-    // CHECK: @$0 mbarrier.inval.shared::cta.b64 [$1];
+    // CHECK: nvvm.mbarrier.inval %{{.*}} : !llvm.ptr<3>
     ttng.inval_barrier %alloc : !ttg.memdesc<1xi64, #shared0, #smem, mutable>
     tt.return
   }
@@ -53,27 +53,17 @@ module attributes {"ttg.num-ctas" = 2 : i32, "ttg.num-warps" = 4 : i32} {
 module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32} {
   // CHECK-LABEL: wait_barrier
   tt.func @wait_barrier(%alloc: !ttg.memdesc<1xi64, #shared0, #smem>, %phase: i32, %pred: i1) {
-    // CHECK: waitLoop:
-    // CHECK: mbarrier.try_wait.parity.shared::cta.b64
-    // CHECK: @!complete bra.uni waitLoop
-    // CHECK-NOT: skipWait
-    // CHECK: %{{[0-9]+}}, %arg1 :
+    // CHECK: nvvm.mbarrier.try_wait %{{.*}}, %arg1 : !llvm.ptr<3>, i32 -> i1
+    // CHECK-NEXT: llvm.cond_br
     ttng.wait_barrier %alloc, %phase : !ttg.memdesc<1xi64, #shared0, #smem>
     %true = arith.constant true
 
-    // CHECK: waitLoop:
-    // CHECK: mbarrier.try_wait.parity.shared::cta.b64
-    // CHECK: @!complete bra.uni waitLoop
-    // CHECK-NOT: skipWait
-    // CHECK: %{{[0-9]+}}, %arg1 :
+    // CHECK: nvvm.mbarrier.try_wait %{{.*}}, %arg1 : !llvm.ptr<3>, i32 -> i1
+    // CHECK-NEXT: llvm.cond_br
     ttng.wait_barrier %alloc, %phase, %true : !ttg.memdesc<1xi64, #shared0, #smem>
 
-    // CHECK: @!$2 bra.uni skipWait
-    // CHECK: waitLoop:
-    // CHECK: mbarrier.try_wait.parity.shared::cta.b64
-    // CHECK: @!complete bra.uni waitLoop
-    // CHECK: skipWait:
-    // CHECK: %{{[0-9]+}}, %arg1, %arg2 :
+    // CHECK: llvm.cond_br %arg2
+    // CHECK: nvvm.mbarrier.try_wait %{{.*}}, %arg1 : !llvm.ptr<3>, i32 -> i1
     ttng.wait_barrier %alloc, %phase, %pred : !ttg.memdesc<1xi64, #shared0, #smem>
     tt.return
   }
@@ -88,7 +78,8 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32} {
     // CHECK-NEXT: [[RTID:%.*]] = llvm.and [[TID]], [[C127]]
     // CHECK-NEXT: [[C0:%.*]] = llvm.mlir.constant(0 : i32)
     // CHECK-NEXT: [[IS_ZERO:%.*]] = llvm.icmp "eq" [[RTID]], [[C0]]
-    // CHECK-NEXT: "@$0 mbarrier.arrive.shared::cta.b64 _, [$1], 2;", "b,r" [[IS_ZERO]], [[BASE]]
+    // CHECK-NEXT: llvm.cond_br [[IS_ZERO]], ^{{.*}}, ^{{.*}}
+    // CHECK: nvvm.mbarrier.arrive [[BASE]], %{{.*}} : !llvm.ptr<3>
     ttng.arrive_barrier %alloc, 2 : !ttg.memdesc<1xi64, #shared0, #smem>
     tt.return
   }
@@ -104,7 +95,8 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32} {
     // CHECK-NEXT: [[C0:%.*]] = llvm.mlir.constant(0 : i32)
     // CHECK-NEXT: [[IS_ZERO:%.*]] = llvm.icmp "eq" [[RTID]], [[C0]]
     // CHECK-NEXT: [[PRED:%.*]] = llvm.and [[IS_ZERO]], %arg1
-    // CHECK-NEXT: "@$0 mbarrier.arrive.shared::cta.b64 _, [$1], 2;", "b,r" [[PRED]], [[BASE]]
+    // CHECK-NEXT: llvm.cond_br [[PRED]], ^{{.*}}, ^{{.*}}
+    // CHECK: nvvm.mbarrier.arrive [[BASE]], %{{.*}} : !llvm.ptr<3>
     ttng.arrive_barrier %alloc, 2, %pred : !ttg.memdesc<1xi64, #shared0, #smem>
     tt.return
   }
@@ -122,8 +114,8 @@ module attributes {"ttg.num-ctas" = 2 : i32, "ttg.num-warps" = 4 : i32} {
     // CHECK: llvm.ptrtoint
     // CHECK: llvm.and
     // CHECK: llvm.inttoptr
-    // CHECK: mbarrier.arrive.shared::cluster.b64
-    // CHECK-NOT: mbarrier.arrive.shared::cta.b64
+    // CHECK: nvvm.mbarrier.arrive %{{.*}}, %{{.*}} : !llvm.ptr<7>
+    // CHECK-NOT: nvvm.mbarrier.arrive {{.*}} : !llvm.ptr<3>
     ttng.arrive_barrier %alloc, 1 : !ttg.memdesc<1xi64, #shared0, #smem>
     tt.return
   }
@@ -138,7 +130,7 @@ module attributes {"ttg.num-ctas" = 2 : i32, "ttg.num-warps" = 4 : i32} {
   // CHECK-LABEL: arrive_barrier_multicast_absent
   tt.func @arrive_barrier_multicast_absent(%alloc: !ttg.memdesc<2xi64, #shared0, #smem, mutable>) {
     // No ctaMask → non-multicast path.
-    // CHECK: mbarrier.arrive.shared::cta.b64
+    // CHECK: nvvm.mbarrier.arrive %{{.*}}, %{{.*}} : !llvm.ptr<3>
     // CHECK-NOT: mbarrier.arrive.shared::cluster.multicast
     ttng.arrive_barrier %alloc, 1 : !ttg.memdesc<2xi64, #shared0, #smem, mutable>
     tt.return
@@ -473,7 +465,7 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32} {
   // CHECK: [[C0:%.*]] = llvm.mlir.constant(0 : i32)
   // CHECK: [[IS_ZERO:%.*]] = llvm.icmp "eq" [[RTID]], [[C0]]
   // CHECK: [[PRED:%.*]] = llvm.and [[IS_ZERO]], %arg1
-  // CHECK: @$0 mbarrier.arrive.expect_tx.shared::cta.b64 _, [$1], 16384;
+  // CHECK: nvvm.mbarrier.arrive.expect_tx %{{.*}}, %{{.*}} : !llvm.ptr<3>, i32
   tt.func @expect_barrier(%barrier: !ttg.memdesc<1xi64, #shared0, #smem, mutable>, %pred: i1) {
     ttng.barrier_expect %barrier, 16384, %pred : !ttg.memdesc<1xi64, #shared0, #smem, mutable>
     tt.return
@@ -491,8 +483,8 @@ module attributes {"ttg.num-ctas" = 2 : i32, "ttg.num-warps" = 4 : i32} {
   // CHECK: llvm.ptrtoint
   // CHECK: llvm.and
   // CHECK: llvm.inttoptr
-  // CHECK: @$0 mbarrier.arrive.expect_tx.shared::cluster.b64 _, [$1], 16384;
-  // CHECK-NOT: mbarrier.arrive.shared::cluster.b64
+  // CHECK: nvvm.mbarrier.arrive.expect_tx %{{.*}}, %{{.*}} : !llvm.ptr<7>, i32
+  // CHECK-NOT: nvvm.mbarrier.arrive {{.*}} : !llvm.ptr<3>
   tt.func @expect_barrier_cluster_broadcast(%barrier: !ttg.memdesc<1xi64, #shared0, #smem, mutable>, %pred: i1) {
     ttng.barrier_expect %barrier, 16384, %pred : !ttg.memdesc<1xi64, #shared0, #smem, mutable>
     tt.return
@@ -600,7 +592,7 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.targ
 // CHECK-LABEL: mbarrier_sync_cluster_init
 module attributes {"ttg.num-ctas" = 2 : i32, "ttg.num-warps" = 4 : i32, ttg.target = "cuda:90", "ttg.threads-per-warp" = 32 : i32} {
   tt.func public @mbarrier_sync_cluster_init() {
-    // CHECK: fence.mbarrier_init.release.cluster
+    // CHECK: nvvm.fence.mbarrier.init
     // CHECK: nvvm.cluster.arrive.relaxed
     // CHECK-NEXT: nvvm.cluster.wait
     ttng.fence_mbarrier_init_release_cluster
@@ -861,10 +853,10 @@ module attributes {"ttg.num-ctas" = 2 : i32, "ttg.num-warps" = 4 : i32, ttg.shar
   // CHECK-DAG: ttg.shared = 40 : i32
   // CHECK-DAG: ttg.ws_cluster_barrier_count = 1 : i32
   // CHECK-LABEL: @cluster_barrier_inside_warp_specialize
-  // CHECK-COUNT-2: "@$0 mbarrier.init.shared::cta.b64 [$1], 1;"
+  // CHECK-COUNT-2: nvvm.mbarrier.init
   // CHECK: st.shared::cta.b32
   // CHECK-NOT: st.shared::cta.b32
-  // CHECK: fence.mbarrier_init.release.cluster
+  // CHECK: nvvm.fence.mbarrier.init
   // CHECK: nvvm.cluster.arrive.relaxed
   // CHECK-NEXT: nvvm.cluster.wait
   tt.func @cluster_barrier_inside_warp_specialize() {
@@ -879,8 +871,8 @@ module attributes {"ttg.num-ctas" = 2 : i32, "ttg.num-warps" = 4 : i32, ttg.shar
       // CHECK: %[[PEER_BARRIER_INT:.*]] = llvm.xor %[[BARRIER_INT]],
       // CHECK: llvm.inttoptr %[[PEER_BARRIER_INT]]
       // CHECK-NOT: mapa
-      // CHECK: mbarrier.arrive.release.cluster.shared::cluster.b64
-      // CHECK: mbarrier.try_wait.parity.acquire.cluster.shared::cta.b64
+      // CHECK: nvvm.mbarrier.arrive %{{.*}}, %{{.*}} {scope = #nvvm.mem_scope<cluster>} : !llvm.ptr<7>
+      // CHECK: nvvm.mbarrier.try_wait %{{.*}}, %{{.*}} {scope = #nvvm.mem_scope<cluster>} : !llvm.ptr<3>, i32 -> i1
       // CHECK: %[[NEXT_COUNTER:.*]] = llvm.add %[[COUNTER]]
       // CHECK: llvm.and %[[NEXT_COUNTER]]
       // CHECK: st.shared::cta.b32
@@ -899,9 +891,9 @@ module attributes {"ttg.num-ctas" = 2 : i32, "ttg.num-warps" = 4 : i32, ttg.shar
 
 module attributes {"ttg.num-ctas" = 2 : i32, "ttg.num-warps" = 4 : i32, ttg.shared = 0 : i32, "ttg.threads-per-warp" = 32 : i32} {
   // PTX85-LABEL: @relaxed_cluster_barrier_inside_warp_specialize
-  // PTX85: mbarrier.arrive.release.cluster.shared::cluster.b64
+  // PTX85: nvvm.mbarrier.arrive %{{.*}}, %{{.*}} {scope = #nvvm.mem_scope<cluster>} : !llvm.ptr<7>
   // PTX86-LABEL: @relaxed_cluster_barrier_inside_warp_specialize
-  // PTX86: mbarrier.arrive.relaxed.cluster.shared::cluster.b64
+  // PTX86: nvvm.mbarrier.arrive %{{.*}}, %{{.*}} {relaxed = true, scope = #nvvm.mem_scope<cluster>} : !llvm.ptr<7>
   tt.func @relaxed_cluster_barrier_inside_warp_specialize() {
     ttg.warp_specialize()
     default {
@@ -922,10 +914,10 @@ module attributes {"ttg.num-ctas" = 2 : i32, "ttg.num-warps" = 4 : i32, ttg.shar
   // CHECK-DAG: ttg.shared = 72 : i32
   // CHECK-DAG: ttg.ws_cluster_barrier_count = 2 : i32
   // CHECK-LABEL: @cluster_barrier_inside_warp_specialize_reuses_slots
-  // CHECK-COUNT-4: mbarrier.init.shared::cta.b64
-  // CHECK-COUNT-1: fence.mbarrier_init.release.cluster
+  // CHECK-COUNT-4: nvvm.mbarrier.init
+  // CHECK-COUNT-1: nvvm.fence.mbarrier.init
   // CHECK-COUNT-1: nvvm.cluster.arrive.relaxed
-  // CHECK-COUNT-3: mbarrier.arrive.release.cluster.shared::cluster.b64
+  // CHECK-COUNT-3: nvvm.mbarrier.arrive
   tt.func @cluster_barrier_inside_warp_specialize_reuses_slots() {
     ttg.warp_specialize() attributes {warpGroupStartIds = array<i32: 4>}
     default {
@@ -947,8 +939,8 @@ module attributes {"ttg.num-ctas" = 2 : i32, "ttg.num-warps" = 4 : i32, ttg.shar
   // CHECK: ttg.ws_cluster_barrier_count = 1 : i32
   // CHECK-LABEL: @cluster_barrier_created_during_conversion
   // CHECK: llvm.mlir.constant(8 : i32)
-  // CHECK: mbarrier.init.shared::cta.b64
-  // CHECK: mbarrier.arrive.release.cluster.shared::cluster.b64
+  // CHECK: nvvm.mbarrier.init
+  // CHECK: nvvm.mbarrier.arrive %{{.*}}, %{{.*}} {scope = #nvvm.mem_scope<cluster>} : !llvm.ptr<7>
   tt.func @cluster_barrier_created_during_conversion(%arg0: !tt.ptr<i32>) {
     ttg.warp_specialize()
     default {
@@ -972,8 +964,8 @@ module attributes {"ttg.num-ctas" = 2 : i32, "ttg.num-warps" = 4 : i32, ttg.shar
 module attributes {"ttg.num-ctas" = 2 : i32, "ttg.num-warps" = 4 : i32, ttg.shared = 512 : i32, "ttg.threads-per-warp" = 32 : i32} {
   // CHECK: ttg.ws_cluster_barrier_count = 1 : i32
   // CHECK-LABEL: @tensor_atomic_cluster_barrier_created_during_conversion
-  // CHECK: mbarrier.init.shared::cta.b64
-  // CHECK: mbarrier.arrive.release.cluster.shared::cluster.b64
+  // CHECK: nvvm.mbarrier.init
+  // CHECK: nvvm.mbarrier.arrive %{{.*}}, %{{.*}} {scope = #nvvm.mem_scope<cluster>} : !llvm.ptr<7>
   tt.func @tensor_atomic_cluster_barrier_created_during_conversion(%arg0: !tt.ptr<i32>) {
     ttg.warp_specialize()
     default {
@@ -999,8 +991,8 @@ module attributes {"ttg.num-ctas" = 2 : i32, "ttg.num-warps" = 4 : i32, ttg.shar
 module attributes {"ttg.num-ctas" = 2 : i32, "ttg.num-warps" = 4 : i32, ttg.shared = 16384 : i32, "ttg.threads-per-warp" = 32 : i32} {
   // CHECK: ttg.ws_cluster_barrier_count = 1 : i32
   // CHECK-LABEL: @cluster_barrier_created_within_reduce_lowering
-  // CHECK: mbarrier.init.shared::cta.b64
-  // CHECK: mbarrier.arrive.release.cluster.shared::cluster.b64
+  // CHECK: nvvm.mbarrier.init
+  // CHECK: nvvm.mbarrier.arrive %{{.*}}, %{{.*}} {scope = #nvvm.mem_scope<cluster>} : !llvm.ptr<7>
   tt.func @cluster_barrier_created_within_reduce_lowering() {
     ttg.warp_specialize()
     default {

--- a/third_party/nvidia/lib/TritonNVIDIAGPUToLLVM/BarrierOpToLLVM.cpp
+++ b/third_party/nvidia/lib/TritonNVIDIAGPUToLLVM/BarrierOpToLLVM.cpp
@@ -26,6 +26,7 @@
 #include "TritonNVIDIAGPUToLLVM/PTXAsmFormat.h"
 #include "mlir/Conversion/LLVMCommon/Pattern.h"
 #include "mlir/Dialect/GPU/IR/GPUDialect.h"
+#include "mlir/Dialect/LLVMIR/LLVMDialect.h"
 #include "mlir/Dialect/LLVMIR/NVVMDialect.h"
 #include "triton/Conversion/TritonGPUToLLVM/Utility.h"
 #include "triton/Dialect/Triton/IR/Dialect.h"
@@ -38,12 +39,81 @@ using namespace mlir::triton;
 
 namespace ttg = mlir::triton::gpu;
 
+namespace {
+void createPredicatedBlock(OpBuilder &builder, Location loc, Value pred,
+                           function_ref<void()> emit) {
+  Block *currentBlock = builder.getInsertionBlock();
+  Block *continuation = currentBlock->splitBlock(builder.getInsertionPoint());
+  Block *body = builder.createBlock(currentBlock->getParent(),
+                                    std::next(Region::iterator(currentBlock)));
+
+  builder.setInsertionPointToEnd(currentBlock);
+  LLVM::CondBrOp::create(builder, loc, pred, body, continuation);
+  builder.setInsertionPointToEnd(body);
+  emit();
+  LLVM::BrOp::create(builder, loc, continuation);
+  builder.setInsertionPointToStart(continuation);
+}
+
+Value castToSharedClusterPointer(OpBuilder &builder, Location loc, Value ptr) {
+  auto b = TritonLLVMOpBuilder(loc, builder);
+  Value address = b.ptrtoint(builder.getI32Type(), ptr);
+  return b.inttoptr(ptr_ty(builder.getContext(), 7), address);
+}
+} // namespace
+
 void mlir::triton::NVIDIA::createFenceMBarrierInitReleaseCluster(
     OpBuilder &builder, Location loc, Value pred) {
-  PTXBuilder ptxBuilder;
-  auto &fence = *ptxBuilder.create("fence.mbarrier_init.release.cluster");
-  fence().predicate(pred);
-  ptxBuilder.launch(builder, loc, void_ty(builder.getContext()));
+  createPredicatedBlock(builder, loc, pred, [&] {
+    NVVM::FenceMbarrierInitOp::create(builder, loc);
+  });
+}
+
+void mlir::triton::NVIDIA::createMBarrierInit(OpBuilder &builder, Location loc,
+                                              Value pred, Value barrierPtr,
+                                              int count) {
+  createPredicatedBlock(builder, loc, pred, [&] {
+    auto b = TritonLLVMOpBuilder(loc, builder);
+    NVVM::MBarrierInitOp::create(builder, loc, barrierPtr, b.i32_val(count),
+                                 Value{});
+  });
+}
+
+void mlir::triton::NVIDIA::createMBarrierArrive(
+    OpBuilder &builder, Location loc, Value pred, Value barrierPtr, int count,
+    bool clusterScope, bool clusterSpace, bool relaxed) {
+  if (clusterSpace)
+    barrierPtr = castToSharedClusterPointer(builder, loc, barrierPtr);
+  createPredicatedBlock(builder, loc, pred, [&] {
+    auto b = TritonLLVMOpBuilder(loc, builder);
+    NVVM::MBarrierArriveOp::create(
+        builder, loc, Type{}, barrierPtr, b.i32_val(count),
+        clusterScope ? NVVM::MemScopeKind::CLUSTER : NVVM::MemScopeKind::CTA,
+        relaxed);
+  });
+}
+
+void mlir::triton::NVIDIA::createMBarrierWait(OpBuilder &builder, Location loc,
+                                              Value pred, Value barrierPtr,
+                                              Value phase, bool clusterScope) {
+  Block *currentBlock = builder.getInsertionBlock();
+  Block *continuation = currentBlock->splitBlock(builder.getInsertionPoint());
+  Block *loop = builder.createBlock(currentBlock->getParent(),
+                                    std::next(Region::iterator(currentBlock)));
+
+  builder.setInsertionPointToEnd(currentBlock);
+  if (pred)
+    LLVM::CondBrOp::create(builder, loc, pred, loop, continuation);
+  else
+    LLVM::BrOp::create(builder, loc, loop);
+
+  auto scope =
+      clusterScope ? NVVM::MemScopeKind::CLUSTER : NVVM::MemScopeKind::CTA;
+  builder.setInsertionPointToEnd(loop);
+  Value complete = NVVM::MBarrierTryWaitOp::create(
+      builder, loc, barrierPtr, phase, Value{}, scope, /*relaxed=*/false);
+  LLVM::CondBrOp::create(builder, loc, complete, continuation, loop);
+  builder.setInsertionPointToStart(continuation);
 }
 
 namespace {
@@ -134,15 +204,8 @@ struct InitBarrierOpConversion
     // the same barrier.
     initCount *= numCTAs / barrierTy.getNumElements();
 
-    ::mlir::triton::PTXBuilder ptxBuilder;
-    const std::string ptx = "@$0 mbarrier.init.shared::cta.b64 [$1], " +
-                            std::to_string(initCount) + ";";
-    auto &barSyncOp = *ptxBuilder.create(ptx);
-    barSyncOp({ptxBuilder.newOperand(pred, "b"),
-               ptxBuilder.newOperand(smemObj.getBase(), "r")},
-              /*onlyAttachMLIRArgs=*/true);
-    auto voidTy = void_ty(op->getContext());
-    ptxBuilder.launch(rewriter, loc, voidTy);
+    NVIDIA::createMBarrierInit(rewriter, loc, pred, smemObj.getBase(),
+                               initCount);
     rewriter.eraseOp(op);
     return success();
   }
@@ -176,14 +239,9 @@ struct InvalBarrierOpConversion
       pred = b.and_(pred, *leaderPred);
     Value barrierPtr = LLVM::NVIDIA::getLeaderAddress(
         loc, rewriter, smemObj.getBase(), barrierTy);
-    ::mlir::triton::PTXBuilder ptxBuilder;
-    const std::string ptx = "@$0 mbarrier.inval.shared::cta.b64 [$1];";
-    auto &barSyncOp = *ptxBuilder.create(ptx);
-    barSyncOp({ptxBuilder.newOperand(pred, "b"),
-               ptxBuilder.newOperand(barrierPtr, "r")},
-              /*onlyAttachMLIRArgs=*/true);
-    auto voidTy = void_ty(op->getContext());
-    ptxBuilder.launch(rewriter, loc, voidTy);
+    createPredicatedBlock(rewriter, loc, pred, [&] {
+      NVVM::MBarrierInvalOp::create(rewriter, loc, barrierPtr);
+    });
     rewriter.eraseOp(op);
     return success();
   }
@@ -215,17 +273,14 @@ struct BarrierExpectConversion
     Value leaderBarrierPtr = LLVM::NVIDIA::getLeaderAddress(
         loc, rewriter, smemObj.getBase(), barrierTy);
 
-    ::mlir::triton::PTXBuilder expectPtxBuilder;
-    const std::string expectPtx =
-        "@$0 mbarrier.arrive.expect_tx." +
-        std::string(crossCluster ? "shared::cluster" : "shared::cta") +
-        ".b64 _, [$1], " + std::to_string(op.getSize()) + ";";
-    auto &expectOp = *expectPtxBuilder.create(expectPtx);
-    expectOp({expectPtxBuilder.newOperand(pred, "b"),
-              expectPtxBuilder.newOperand(leaderBarrierPtr, "r")},
-             /*onlyAttachMLIRArgs=*/true);
-    auto voidTy = void_ty(op->getContext());
-    expectPtxBuilder.launch(rewriter, loc, voidTy);
+    if (crossCluster)
+      leaderBarrierPtr =
+          castToSharedClusterPointer(rewriter, loc, leaderBarrierPtr);
+    createPredicatedBlock(rewriter, loc, pred, [&] {
+      NVVM::MBarrierArriveExpectTxOp::create(
+          rewriter, loc, Type{}, leaderBarrierPtr, b.i32_val(op.getSize()),
+          NVVM::MemScopeKind::CTA, /*relaxed=*/false, Value{});
+    });
 
     rewriter.eraseOp(op);
     return success();
@@ -248,7 +303,6 @@ struct WaitBarrierOpConversion
     auto smemObj = LLVM::getSharedMemoryObjectFromStruct(
         op.getLoc(), adaptor.getAlloc(),
         typeConverter->convertType(barrierTy.getElementType()), rewriter);
-    auto ctx = op.getContext();
     auto loc = op.getLoc();
     auto b = TritonLLVMOpBuilder(loc, rewriter);
     auto pred = adaptor.getPred();
@@ -256,65 +310,46 @@ struct WaitBarrierOpConversion
             LLVM::NVIDIA::getLeaderCTAPredicate(loc, rewriter, barrierTy))
       pred = b.and_(pred, *leaderPred);
 
-    bool predicated = pred && !matchPattern(pred, m_NonZero());
-    std::string ptx;
     if (targetInfo->getComputeCapability() < 90) {
-      if (!predicated) {
-        ptx = R"(
-{
-	.reg .pred complete;
-	waitLoop:
-	mbarrier.test_wait.parity.shared::cta.b64 complete, [$0], $1;
-	@!complete nanosleep.u32 20;
-	@!complete bra.uni waitLoop;
-}
-)";
-      } else {
-        ptx = R"(
+      // The NVPTX backend only selects the scoped parity-wait intrinsics for
+      // SM90+. Keep the PTX 7.x form until LLVM supports it for SM80.
+      bool predicated = pred && !matchPattern(pred, m_NonZero());
+      std::string ptx = predicated ? R"(
 {
 	@!$2 bra.uni skipWait;
 	.reg .pred complete;
-	waitLoop:
+waitLoop:
 	mbarrier.test_wait.parity.shared::cta.b64 complete, [$0], $1;
 	@!complete nanosleep.u32 20;
 	@!complete bra.uni waitLoop;
-	skipWait:
+skipWait:
+}
+)"
+                                   : R"(
+{
+	.reg .pred complete;
+waitLoop:
+	mbarrier.test_wait.parity.shared::cta.b64 complete, [$0], $1;
+	@!complete nanosleep.u32 20;
+	@!complete bra.uni waitLoop;
 }
 )";
-      }
+      PTXBuilder ptxBuilder;
+      auto &waitLoop = *ptxBuilder.create(ptx);
+      SmallVector<PTXBuilder::Operand *, 3> operands = {
+          ptxBuilder.newOperand(smemObj.getBase(), "r"),
+          ptxBuilder.newOperand(adaptor.getPhase(), "r")};
+      if (predicated)
+        operands.push_back(ptxBuilder.newOperand(pred, "b"));
+      waitLoop(operands, /*onlyAttachMLIRArgs=*/true);
+      ptxBuilder.launch(rewriter, loc, void_ty(getContext()));
     } else {
-      if (!predicated) {
-        ptx = R"(
-{
-	.reg .pred complete;
-	waitLoop:
-	mbarrier.try_wait.parity.shared::cta.b64 complete, [$0], $1;
-	@!complete bra.uni waitLoop;
-}
-)";
-      } else {
-        ptx = R"(
-{
-	@!$2 bra.uni skipWait;
-	.reg .pred complete;
-	waitLoop:
-	mbarrier.try_wait.parity.shared::cta.b64 complete, [$0], $1;
-	@!complete bra.uni waitLoop;
-	skipWait:
-}
-)";
-      }
+      if (pred && matchPattern(pred, m_NonZero()))
+        pred = Value{};
+      NVIDIA::createMBarrierWait(rewriter, loc, pred, smemObj.getBase(),
+                                 adaptor.getPhase(),
+                                 /*clusterScope=*/false);
     }
-    ::mlir::triton::PTXBuilder ptxBuilder;
-    auto &waitLoop = *ptxBuilder.create(ptx);
-    SmallVector<::mlir::triton::PTXBuilder::Operand *, 3> operands = {
-        ptxBuilder.newOperand(smemObj.getBase(), "r"),
-        ptxBuilder.newOperand(adaptor.getPhase(), "r")};
-    if (predicated)
-      operands.push_back(ptxBuilder.newOperand(pred, "b"));
-
-    waitLoop(operands, /*onlyAttachMLIRArgs=*/true);
-    ptxBuilder.launch(rewriter, loc, void_ty(ctx));
     rewriter.eraseOp(op);
     return success();
   }
@@ -322,7 +357,12 @@ struct WaitBarrierOpConversion
 
 struct ArriveBarrierOpConversion
     : public ConvertOpToLLVMPattern<triton::nvidia_gpu::ArriveBarrierOp> {
-  using ConvertOpToLLVMPattern::ConvertOpToLLVMPattern;
+  const NVIDIA::TargetInfo *targetInfo;
+  ArriveBarrierOpConversion(LLVMTypeConverter &typeConverter,
+                            PatternBenefit benefit,
+                            NVIDIA::TargetInfo &targetInfo)
+      : ConvertOpToLLVMPattern(typeConverter, benefit),
+        targetInfo(&targetInfo) {}
 
   LogicalResult
   matchAndRewrite(triton::nvidia_gpu::ArriveBarrierOp op, OpAdaptor adaptor,
@@ -351,34 +391,42 @@ struct ArriveBarrierOpConversion
 
     Value barrierPtr = LLVM::NVIDIA::getLeaderAddress(
         loc, rewriter, smemObj.getBase(), barrierTy);
-    // TODO: Add phase result as needed.
-    std::stringstream ptxAsm;
-    ptxAsm << "@$0 mbarrier.arrive."
-           << (isCrossClusterBarrier ? "shared::cluster" : "shared::cta");
-    if (op.isMulticast())
-      ptxAsm << ".multicast::cluster::32b";
-    ptxAsm << ".b64 _, [$1]";
-    if (op.getCount() > 1) {
-      ptxAsm << ", " << op.getCount();
-    }
-    if (op.isMulticast())
-      ptxAsm << ", $2";
-    ptxAsm << ";";
-
-    PTXBuilder ptxBuilder;
-    SmallVector<PTXBuilder::Operand *, 3> operands = {
-        ptxBuilder.newOperand(pred, "b"),
-        ptxBuilder.newOperand(barrierPtr, "r")};
     if (op.isMulticast()) {
+      // LLVM does not model the SM110+ multicast variant yet.
+      std::stringstream ptxAsm;
+      ptxAsm << "@$0 mbarrier.arrive.shared::cluster."
+                "multicast::cluster::32b.b64 _, [$1]";
+      if (op.getCount() > 1)
+        ptxAsm << ", " << op.getCount();
+      ptxAsm << ", $2;";
+
+      PTXBuilder ptxBuilder;
       Value mask = LLVM::NVIDIA::createTMAMulticastMask(
           loc, rewriter, static_cast<uint16_t>(op.getCtaMask()));
-      operands.push_back(ptxBuilder.newOperand(mask, "r"));
+      auto arriveOp = *ptxBuilder.create(ptxAsm.str());
+      arriveOp({ptxBuilder.newOperand(pred, "b"),
+                ptxBuilder.newOperand(barrierPtr, "r"),
+                ptxBuilder.newOperand(mask, "r")},
+               /*onlyAttachMLIRArgs=*/true);
+      ptxBuilder.launch(rewriter, loc, void_ty(getContext()));
+    } else if (targetInfo->getComputeCapability() < 90) {
+      // Explicit-count arrive intrinsics are only selected for SM90+.
+      std::stringstream ptx;
+      ptx << "@$0 mbarrier.arrive.shared::cta.b64 _, [$1]";
+      if (op.getCount() > 1)
+        ptx << ", " << op.getCount();
+      ptx << ";";
+      PTXBuilder ptxBuilder;
+      auto &arrive = *ptxBuilder.create(ptx.str());
+      arrive({ptxBuilder.newOperand(pred, "b"),
+              ptxBuilder.newOperand(barrierPtr, "r")},
+             /*onlyAttachMLIRArgs=*/true);
+      ptxBuilder.launch(rewriter, loc, void_ty(getContext()));
+    } else {
+      NVIDIA::createMBarrierArrive(
+          rewriter, loc, pred, barrierPtr, op.getCount(),
+          /*clusterScope=*/false, isCrossClusterBarrier);
     }
-
-    auto arriveOp = *ptxBuilder.create(ptxAsm.str());
-    arriveOp(operands, /*onlyAttachMLIRArgs=*/true);
-    auto voidTy = void_ty(getContext());
-    ptxBuilder.launch(rewriter, loc, voidTy);
 
     rewriter.eraseOp(op);
     return success();
@@ -566,7 +614,7 @@ void mlir::triton::NVIDIA::populateBarrierOpToLLVMPatterns(
       typeConverter, benefit, targetInfo);
   patterns.add<WaitBarrierOpConversion>(typeConverter, benefit, targetInfo);
   patterns.add<BarrierExpectConversion>(typeConverter, benefit);
-  patterns.add<ArriveBarrierOpConversion>(typeConverter, benefit);
+  patterns.add<ArriveBarrierOpConversion>(typeConverter, benefit, targetInfo);
   patterns.add<CLCTryCancelOpConversion>(typeConverter, benefit, targetInfo);
   patterns.add<CLCLoadResultOpConversion>(typeConverter, benefit, targetInfo);
   patterns.add<CLCIsCanceledOpConversion>(typeConverter, benefit, targetInfo);

--- a/third_party/nvidia/lib/TritonNVIDIAGPUToLLVM/ClusterOpsToLLVM.cpp
+++ b/third_party/nvidia/lib/TritonNVIDIAGPUToLLVM/ClusterOpsToLLVM.cpp
@@ -22,7 +22,6 @@
  */
 
 #include "PatternTritonGPUOpToLLVM.h"
-#include "TritonNVIDIAGPUToLLVM/PTXAsmFormat.h"
 #include "TritonNVIDIAGPUToLLVM/Passes.h"
 #include "mlir/Conversion/LLVMCommon/Pattern.h"
 #include "mlir/Dialect/LLVMIR/LLVMDialect.h"
@@ -57,42 +56,20 @@ static void createClusterWait(OpBuilder &b, Location loc) {
 
 static void createMBarrierInit(OpBuilder &b, Location loc, Value pred,
                                Value barrierPtr, int count) {
-  PTXBuilder ptxBuilder;
-  auto &init = *ptxBuilder.create("@$0 mbarrier.init.shared::cta.b64 [$1], " +
-                                  std::to_string(count) + ";");
-  init({ptxBuilder.newOperand(pred, "b"),
-        ptxBuilder.newOperand(barrierPtr, "r")},
-       /*onlyAttachMLIRArgs=*/true);
-  ptxBuilder.launch(b, loc, void_ty(b.getContext()));
+  NVIDIA::createMBarrierInit(b, loc, pred, barrierPtr, count);
 }
 
 static void createMBarrierArrive(OpBuilder &b, Location loc, Value pred,
                                  Value barrierPtr, bool relaxed) {
-  PTXBuilder ptxBuilder;
-  auto &arrive = *ptxBuilder.create(
-      "@$0 mbarrier.arrive." + std::string(relaxed ? "relaxed" : "release") +
-      ".cluster.shared::cluster.b64 _, [$1];");
-  arrive({ptxBuilder.newOperand(pred, "b"),
-          ptxBuilder.newOperand(barrierPtr, "r")},
-         /*onlyAttachMLIRArgs=*/true);
-  ptxBuilder.launch(b, loc, void_ty(b.getContext()));
+  NVIDIA::createMBarrierArrive(b, loc, pred, barrierPtr, /*count=*/1,
+                               /*clusterScope=*/true,
+                               /*clusterSpace=*/true, relaxed);
 }
 
 static void createMBarrierWait(OpBuilder &b, Location loc, Value barrierPtr,
                                Value parity) {
-  PTXBuilder ptxBuilder;
-  auto &wait =
-      *ptxBuilder.create("{\n"
-                         "\t.reg .pred complete;\n"
-                         "waitLoop:\n"
-                         "\tmbarrier.try_wait.parity.acquire.cluster.shared::"
-                         "cta.b64 complete, [$0], $1;\n"
-                         "\t@!complete bra.uni waitLoop;\n"
-                         "}\n");
-  wait({ptxBuilder.newOperand(barrierPtr, "r"),
-        ptxBuilder.newOperand(parity, "r")},
-       /*onlyAttachMLIRArgs=*/true);
-  ptxBuilder.launch(b, loc, void_ty(b.getContext()));
+  NVIDIA::createMBarrierWait(b, loc, Value{}, barrierPtr, parity,
+                             /*clusterScope=*/true);
 }
 
 static Value getClusterBarrierMbarPtr(Location loc, RewriterBase &rewriter,

--- a/third_party/nvidia/lib/TritonNVIDIAGPUToLLVM/PatternTritonGPUOpToLLVM.h
+++ b/third_party/nvidia/lib/TritonNVIDIAGPUToLLVM/PatternTritonGPUOpToLLVM.h
@@ -18,6 +18,16 @@ void populateBarrierOpToLLVMPatterns(LLVMTypeConverter &typeConverter,
 void createFenceMBarrierInitReleaseCluster(OpBuilder &builder, Location loc,
                                            Value pred);
 
+void createMBarrierInit(OpBuilder &builder, Location loc, Value pred,
+                        Value barrierPtr, int count);
+
+void createMBarrierArrive(OpBuilder &builder, Location loc, Value pred,
+                          Value barrierPtr, int count, bool clusterScope,
+                          bool clusterSpace, bool relaxed = false);
+
+void createMBarrierWait(OpBuilder &builder, Location loc, Value pred,
+                        Value barrierPtr, Value phase, bool clusterScope);
+
 void populateClusterOpsToLLVMPatterns(LLVMTypeConverter &typeConverter,
                                       RewritePatternSet &patterns,
                                       PatternBenefit benefit,


### PR DESCRIPTION
## Summary

Triton currently emits most NVIDIA `mbarrier` operations through inline PTX. This hides their synchronization semantics from MLIR and LLVM and duplicates instruction selection already implemented by LLVM's NVPTX backend.

Lower SM90 and SM100 mbarrier operations through the NVVM dialect instead. This covers initialization, invalidation, arrival, expected transaction arrival, parity waits, synthetic cluster barriers, and the mbarrier initialization fence.

## Details

- Use explicit LLVM control flow to preserve predication and spin-wait behavior because the LLVM NVVM intrinsics are not predicated.
- Represent remote barriers with shared-cluster address-space pointers so LLVM selects the `shared::cluster` forms.
- Preserve the current CTA scope for regular barriers and cluster scope for synthetic warp-specialization cluster barriers.
- Preserve relaxed arrival, explicit counts, and parity semantics.
- Keep the SM80 wait and explicit-count arrival inline PTX paths as compatibility fallbacks. The pinned NVPTX backend only selects the corresponding scoped intrinsics on SM90+.
- Keep the SM110+ multicast-arrive path inline because LLVM does not yet model that variant.
- Update PTX expectations for LLVM's canonical `shared` spelling, which is equivalent to `shared::cta`.

At Triton's pinned LLVM revision, the NVPTX TableGen definitions map these intrinsics directly to the same PTX opcodes and qualifiers. LLVM's `mbarrier*.ll` code-generation tests cover the mappings.

## Testing

- `pre-commit run --from-ref origin/main --to-ref HEAD`
- `make`
- `lit -v test/Conversion` (81/81 passed)
- `pytest -s --tb=short python/test/unit/language/test_compile_only.py::test_compile_only_ws_cluster_barrier_shared_memory python/test/unit/language/test_compile_only.py::test_compile_only_dot`
- Lowered the migrated forms through `llc` and assembled them with CUDA 13.3 `ptxas` for SM90 and SM100a.

# New contributor declaration
- [x] I am not making a trivial change, such as fixing a typo in a comment.

- [x] I have written a PR description following these
  [rules](https://cbea.ms/git-commit/#why-not-how).

- [x] I have run `pre-commit run --from-ref origin/main --to-ref HEAD`.

- [x] I have added tests.
  - `/test` for `lit` tests
  - `/unittest` for C++ tests
  - `/python/test` for end-to-end tests

- [x] I have not added any `lit` tests.
