### PR TITLE
[NVIDIA] Lower tensor-map proxy fences with NVVM

### DIFF
--- a/test/Conversion/tritonnvidiagpu_to_llvm.mlir
+++ b/test/Conversion/tritonnvidiagpu_to_llvm.mlir
@@ -571,7 +571,10 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.targ
 // CHECK-LABEL: tensormap_fenceproxy_acquire
 module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.target = "cuda:90", "ttg.threads-per-warp" = 32 : i32} {
   tt.func public @tensormap_fenceproxy_acquire(%arg0: !tt.ptr<i8> {tt.divisibility = 16 : i32}) {
-    // CHECK: fence.proxy.tensormap::generic.acquire.gpu [ $0 + 0 ], 0x80;
+    // CHECK: llvm.cond_br
+    // CHECK: [[DESC:%.*]] = llvm.addrspacecast %arg0 : !llvm.ptr<1> to !llvm.ptr
+    // CHECK: [[SIZE:%.*]] = llvm.mlir.constant(128 : i32) : i32
+    // CHECK: nvvm.fence.proxy.acquire <gpu> [[DESC]], [[SIZE]]
     // ptxas missing fence workaround:
     // CHECK: cp.async.bulk.commit_group
     // CHECK: cp.async.bulk.wait_group.read 0

--- a/third_party/nvidia/lib/TritonNVIDIAGPUToLLVM/TMAToLLVM.cpp
+++ b/third_party/nvidia/lib/TritonNVIDIAGPUToLLVM/TMAToLLVM.cpp
@@ -4,6 +4,7 @@
 #include "PatternTritonGPUOpToLLVM.h"
 #include "TritonNVIDIAGPUToLLVM/PTXAsmFormat.h"
 
+#include "mlir/Dialect/LLVMIR/NVVMDialect.h"
 #include "mlir/IR/Value.h"
 #include "mlir/Transforms/DialectConversion.h"
 #include "triton/Conversion/TritonGPUToLLVM/Utility.h"
@@ -193,17 +194,17 @@ struct TensormapFenceproxyAcquireOpConversion
     PTXBuilder ptxBuilder;
     auto b = TritonLLVMOpBuilder(loc, rewriter);
 
-    // prepare asm operands
-    auto *descAddrOpr = ptxBuilder.newAddrOperand(adaptor.getDescPtr(), "l");
-    auto *sizeOpr = ptxBuilder.newConstantOperand(TMA_SIZE_BYTES);
-
-    // Define the instruction opcode
+    // Execute the fence collectively on the first warp in the block.
     constexpr int kWarpSize = 32;
     Value threadId = getThreadId(rewriter, loc);
     Value pred = b.icmp_slt(threadId, b.i32_val(kWarpSize));
-    auto &fence =
-        *ptxBuilder.create("fence.proxy.tensormap::generic.acquire.gpu");
-    fence(descAddrOpr, sizeOpr).predicate(pred);
+    auto [prevBlock, ifBlock, thenBlock] = createIfBlock(rewriter, loc, pred);
+    (void)prevBlock;
+    rewriter.setInsertionPointToStart(ifBlock);
+    Value descPtr = b.addrspacecast(ptr_ty(getContext()), adaptor.getDescPtr());
+    NVVM::FenceProxyAcquireOp::create(rewriter, loc, NVVM::MemScopeKind::GPU,
+                                      descPtr, b.i32_val(TMA_SIZE_BYTES));
+    rewriter.setInsertionPointToStart(thenBlock);
 
     // Workaround for a ptxas bug missing a fence after generic.acquire.gpu.
     // TODO: remove the workaround once ptxas is fixed.


### PR DESCRIPTION
## Summary

Replace the remaining supported compiler-generated inline NVIDIA fence with NVVM dialect operations.

The tensor-map acquire fence currently emits `fence.proxy.tensormap::generic.acquire.gpu` through inline PTX. Keeping this operation in NVVM exposes its synchronization semantics to MLIR and delegates PTX spelling and target validation to LLVM's NVPTX backend.

## Details

- Replace inline `fence.proxy.tensormap::generic.acquire.gpu` with `nvvm.fence.proxy.acquire`.
- Preserve first-warp predication with explicit LLVM control flow because the NVVM fence intrinsic is not predicated.
- Represent the fence's generic address explicitly with an address-space cast from the global tensor-map pointer.
- Preserve the existing inline `cp.async.bulk` PTXAS workaround unchanged.
- Preserve the final CTA synchronization barrier.

Other compiler-generated fence paths already use structured lowering:

- async/shared proxy fences use `nvvm.fence.proxy`;
- the mbarrier initialization fence is handled by #10937;
- atomic thread fences are represented by LLVM atomic ordering;
- Triton does not currently emit an inline `fence.sc.cluster` path.

`tensormap.cp_fenceproxy` remains inline because the pinned LLVM revision has no corresponding NVVM operation or LLVM intrinsic. It is a tensor-map copy instruction and requires LLVM support before it can be migrated.

At Triton's pinned LLVM revision, the NVPTX backend maps the new operation to the same `fence.proxy.tensormap::generic.acquire.gpu` PTX instruction.

## Testing

- `pre-commit run --from-ref origin/main --to-ref HEAD`
- `make`
- `lit -v test/Conversion` (81/81 passed)
- Lowered the tensor-map fence through `llc` and assembled it with CUDA 13.3 `ptxas` for SM90 and SM100a.

# New contributor declaration
- [x] I am not making a trivial change, such as fixing a typo in a comment.

- [x] I have written a PR description following these
  [rules](https://cbea.ms/git-commit/#why-not-how).

- [x] I have run `pre-commit run --from-ref origin/main --to-ref HEAD`.

- [x] I have added tests.
  - `/test` for `lit` tests
  - `/unittest` for C++ tests
  - `/python/test` for end-to-end tests

- [x] I have not added any `lit` tests.
