### PR TITLE
[Consan] Fix lit test CHECK sequence assuming a fixed C++ eval order 

### DIFF
--- a/test/Conversion/tritoninstrument_to_llvm.mlir
+++ b/test/Conversion/tritoninstrument_to_llvm.mlir
@@ -75,9 +75,9 @@ module attributes {"ttg.num-warps" = 4 : i32, ttg.target = "cuda:90"} {
 // CHECK-LABEL: @experimental_memdesc_to_i32
 // CHECK: %[[MEMDESC_PTR:.*]] = llvm.extractvalue {{.*}}[0]
 // CHECK: %[[BYTE_OFFSET:.*]] = llvm.mul {{.*}} : i32
-// CHECK: %[[MEMDESC_BASE:.*]] = llvm.ptrtoint %[[MEMDESC_PTR]] : !llvm.ptr<3> to i32
-// CHECK: %[[MEMDESC_ADDRESS:.*]] = llvm.add %[[BYTE_OFFSET]], %[[MEMDESC_BASE]] : i32
-// CHECK: %[[MEMDESC_MASK:.*]] = llvm.mlir.constant(16777215 : i32)
+// CHECK-DAG: %[[MEMDESC_BASE:.*]] = llvm.ptrtoint %[[MEMDESC_PTR]] : !llvm.ptr<3> to i32
+// CHECK-DAG: %[[MEMDESC_MASK:.*]] = llvm.mlir.constant(16777215 : i32)
+// CHECK-DAG: %[[MEMDESC_ADDRESS:.*]] = llvm.add %[[BYTE_OFFSET]], %[[MEMDESC_BASE]] : i32
 // CHECK: llvm.and %[[MEMDESC_ADDRESS]], %[[MEMDESC_MASK]] : i32
 tt.func private @experimental_memdesc_to_i32(
   %memdesc: !ttg.memdesc<32x32xf32, #shared, #smem, mutable>


### PR DESCRIPTION
One of the lit tests added in https://github.com/triton-lang/triton/pull/10879 assumes a fixed evaluation order from the C++ code at https://github.com/triton-lang/triton/blob/c670fe36a83cbb8cd1593848b48c43c9546e6bd4/lib/Conversion/TritonInstrumentToLLVM/InstrumentationToLLVM.cpp#L45-L46

But depending on a compiler behavior, the constant decl for `kSharedMemoryObjectMask` can be interleaved with `b.add` or `b.ptrtoint`. This test is currently failing in my environment, fixed by changing `CHECK` to `CHECK-DAG`.