### PR TITLE
[INTERPRETER] Compute bf16 ops in a value dtype

### DIFF
--- a/python/test/unit/language/test_core.py
+++ b/python/test/unit/language/test_core.py
@@ -1063,7 +1063,7 @@ def test_math_erf_op(dtype, device):
 
 
 @pytest.mark.interpreter
-@pytest.mark.parametrize("dtype", [dtype for dtype in ["float32", "float64"]])
+@pytest.mark.parametrize("dtype", [dtype for dtype in ["float32", "float64", "bfloat16"]])
 def test_math_fma_op(dtype, device):
     check_type_supported(dtype, device)
     SIZE = 128
@@ -1077,7 +1077,7 @@ def test_math_fma_op(dtype, device):
         z = tl.math.fma(x, y, w)
         tl.store(Z + off, z)
 
-    torch_dtype = torch.float32 if dtype == "float32" else torch.float64
+    torch_dtype = getattr(torch, dtype)
     x = torch.randn(SIZE, dtype=torch_dtype, device=device)
     y = torch.randn(SIZE, dtype=torch_dtype, device=device)
     w = torch.randn(SIZE, dtype=torch_dtype, device=device)
@@ -1085,6 +1085,38 @@ def test_math_fma_op(dtype, device):
     z_tri = torch.zeros_like(x)
     kernel[(1, )](z_tri, x, y, w, SIZE=SIZE, num_warps=4)
     torch.testing.assert_close(z_tri, z_ref)
+
+
+@pytest.mark.interpreter
+@pytest.mark.parametrize("op", ['+', '-', '*', '/', '<', 'neg'])
+def test_bfloat16_binop(op, device):
+    # bf16 arithmetic/comparison must run on the value, not its uint16 storage.
+    @triton.jit
+    def kernel(X, Y, Z, OP: tl.constexpr):
+        i = tl.arange(0, 4)
+        x = tl.load(X + i)
+        y = tl.load(Y + i)
+        if OP == 0:
+            z = x + y
+        elif OP == 1:
+            z = x - y
+        elif OP == 2:
+            z = x * y
+        elif OP == 3:
+            z = x / y
+        elif OP == 4:
+            z = (x < y).to(tl.int8)
+        else:
+            z = -x
+        tl.store(Z + i, z)
+
+    x = torch.tensor([2.5, -5.0, 3.0, 0.5], dtype=torch.bfloat16, device=device)
+    y = torch.tensor([2.0, 3.0, 3.0, 2.0], dtype=torch.bfloat16, device=device)
+    out_int = op == '<'
+    z = torch.empty(4, dtype=torch.int8 if out_int else torch.bfloat16, device=device)
+    kernel[(1, )](x, y, z, {'+': 0, '-': 1, '*': 2, '/': 3, '<': 4, 'neg': 5}[op])
+    ref = {'+': x + y, '-': x - y, '*': x * y, '/': x / y, '<': (x < y).to(torch.int8), 'neg': -x}[op]
+    assert (z == ref).all(), f"{op}: got {z.tolist()}, expected {ref.tolist()}"
 
 
 @pytest.mark.interpreter

--- a/python/triton/runtime/interpreter.py
+++ b/python/triton/runtime/interpreter.py
@@ -564,6 +564,11 @@ class InterpreterBuilder:
             # other integer type. Compute in a wider integer domain and
             # truncate back to one bit to match the GPU backend (issue #10919).
             output = (op(lhs.data.astype(np.int8), rhs.data.astype(np.int8)) & 1).astype(np.bool_)
+        elif tl_dtype == tl.bfloat16:
+            # bf16 is stored as uint16 bits; compute in float32 like the GPU.
+            output = op(self._bf16_to_f32(lhs.data), self._bf16_to_f32(rhs.data))
+            if output.dtype != np.bool_:
+                output = self._f32_to_bf16(output)
         else:
             output = op(lhs.data, rhs.data)
 
@@ -571,6 +576,14 @@ class InterpreterBuilder:
             output = output.astype(_get_np_dtype(tl_dtype))
 
         return TensorHandle(output, tl_dtype)
+
+    @staticmethod
+    def _bf16_to_f32(data):
+        return _convert_float(data, tl.bfloat16, tl.float32, None).view(np.float32)
+
+    @staticmethod
+    def _f32_to_bf16(data):
+        return _convert_float(data.astype(np.float32), tl.float32, tl.bfloat16, _ir.ROUNDING_MODE.RTNE).view(np.uint16)
 
     create_fadd = lambda self, lhs, rhs: self.binary_op(lhs, rhs, np.add)
     create_fmul = lambda self, lhs, rhs: self.binary_op(lhs, rhs, np.multiply)
@@ -671,10 +684,18 @@ class InterpreterBuilder:
     create_select = lambda self, cond, lhs, rhs: self.ternary_op(cond, lhs, rhs, np.where)
 
     def create_fma(self, x, y, z):
+        if z.dtype.scalar == tl.bfloat16:
+            output = self._bf16_to_f32(x.data) * self._bf16_to_f32(y.data) + self._bf16_to_f32(z.data)
+            return TensorHandle(self._f32_to_bf16(output), z.dtype.scalar)
         return TensorHandle(x.data * y.data + z.data, z.dtype.scalar)
 
     # unary functions
     def unary_op(self, arg, op):
+        if arg.dtype.scalar == tl.bfloat16:
+            output = op(self._bf16_to_f32(arg.data))
+            if output.dtype != np.bool_:
+                output = self._f32_to_bf16(output)
+            return TensorHandle(output, arg.dtype.scalar)
         return TensorHandle(op(arg.data), arg.dtype.scalar)
 
     def create_fabs(self, arg):
@@ -715,8 +736,8 @@ class InterpreterBuilder:
     def create_dot(self, a, b, d, input_precision, max_num_imprecise_acc):
         a_data = a.data
         b_data = b.data
-        if (a.dtype.primitive_bitwidth == 8 and a.dtype.is_floating()) or \
-           (b.dtype.primitive_bitwidth == 8 and b.dtype.is_floating()):
+        if (a.dtype.primitive_bitwidth < 32 and a.dtype.is_floating()) or \
+           (b.dtype.primitive_bitwidth < 32 and b.dtype.is_floating()):
             a_data = _convert_float(a_data, a.dtype, tl.float16, None).view(np.float16)
             b_data = _convert_float(b_data, b.dtype, tl.float16, None).view(np.float16)
         return TensorHandle(np.matmul(a_data, b_data, dtype=d.data.dtype) + d.data, d.dtype.scalar)


### PR DESCRIPTION
Refs #10919 (bf16 half; int1 half fixed in #10923).

The interpreter stores bf16 as a `uint16` bit pattern, but `binary_op`, `unary_op`, `create_fma` and `create_dot` ran the numpy op directly on that storage, so bf16 arithmetic and comparisons computed on the bit pattern instead of the value, diverging from the GPU. `2.5 + 2.0` gave `-2.9e-39` (from `16416 + 16384` as uint16) instead of `4.5`; `-5.0 < -2.0` gave `0` instead of `1` (bf16 is sign-magnitude, so uint16 order != value order).

This converts operands to float32 before the op (as the GPU does) and rounds the result back to bf16 (RTNE) after, covering `binary_op`, `unary_op` and `create_fma`; `create_dot` now converts any sub-32-bit float operand, not just 8-bit fp8. Adds interpreter tests for bf16 `binary_op`, comparison, `neg` and `fma`.
