### PR TITLE
Emit baseTimeNanoseconds in Proton chrome traces

### DIFF
--- a/third_party/proton/csrc/lib/Data/Dump/ChromeTrace.cpp
+++ b/third_party/proton/csrc/lib/Data/Dump/ChromeTrace.cpp
@@ -258,7 +258,12 @@ void dumpKernelMetricTrace(
     const std::map<size_t, std::vector<CpuScopeEvent>> &cpuScopeEvents,
     const std::map<size_t, std::vector<GraphScopeEvent>> &graphScopeEvents,
     std::ostream &os) {
-  json object = {{"displayTimeUnit", "us"}, {"traceEvents", json::array()}};
+  // baseTimeNanoseconds records the absolute time that event ts=0 refers to,
+  // mirroring torch>=2.4 chrome traces, so external tools (e.g. viztracer's
+  // ReportBuilder) can align this trace with traces from other profilers.
+  json object = {{"displayTimeUnit", "us"},
+                 {"baseTimeNanoseconds", minTimeStamp},
+                 {"traceEvents", json::array()}};
 
   emitTraceLaneMetadata(object, cpuScopeEvents, graphScopeEvents, kernelEvents);
   dumpCpuScopeEvents(minTimeStamp, cpuScopeEvents, object);
@@ -273,7 +278,9 @@ void dumpCpuOnlyTrace(
     uint64_t minTimeStamp,
     const std::map<size_t, std::vector<CpuScopeEvent>> &cpuScopeEvents,
     std::ostream &os) {
-  json object = {{"displayTimeUnit", "us"}, {"traceEvents", json::array()}};
+  json object = {{"displayTimeUnit", "us"},
+                 {"baseTimeNanoseconds", minTimeStamp},
+                 {"traceEvents", json::array()}};
   dumpCpuScopeEvents(minTimeStamp, cpuScopeEvents, object);
   os << object.dump() << "\n";
 }

--- a/third_party/proton/test/test_profile.py
+++ b/third_party/proton/test/test_profile.py
@@ -13,6 +13,7 @@ import json
 import pytest
 from typing import NamedTuple
 import threading
+import time
 
 import triton.language as tl
 import triton.profiler.hooks.launch as proton_launch
@@ -1160,6 +1161,11 @@ def test_trace(tmp_path: pathlib.Path, device: str):
         assert kernel_event["args"]["call_stack"] == ["ROOT", "test", "foo"]
         assert scope_event["ts"] <= kernel_event["ts"]
         assert kernel_event["ts"] + kernel_event["dur"] <= scope_event["ts"] + scope_event["dur"]
+        # ts=0 anchor for aligning with traces from other profilers
+        # (same contract as torch>=2.4 chrome traces).
+        base_time_ns = data["baseTimeNanoseconds"]
+        one_day_ns = 24 * 60 * 60 * 1_000_000_000
+        assert abs(time.time_ns() - base_time_ns) < one_day_ns
 
 
 @pytest.mark.skipif(not is_cuda(), reason="Only CUDA backend supports metrics profiling in cudagraphs")


### PR DESCRIPTION
Proton's chrome trace dump normalizes every event timestamp against the earliest event (minTimeStamp) and previously discarded that anchor, so nothing in the output said what absolute time ts=0 refers to. That made it impossible to align a Proton timeline with traces recorded by other profilers in the same run (viztracer, torch profiler, ...).

Record the anchor as a top-level baseTimeNanoseconds field in both the kernel-metric and CPU-only chrome trace dumps. This mirrors the contract of torch>=2.4 chrome traces, so tools that already merge torch traces by base-time offset (e.g. viztracer's ReportBuilder) work on Proton traces unchanged.

Extend test_trace to assert the field exists and is plausibly wall-clock anchored, and document the field in the README.