### PR TITLE
[FRONTEND] Document that tl.range requires a positive runtime step

### DIFF
--- a/python/triton/compiler/code_generator.py
+++ b/python/triton/compiler/code_generator.py
@@ -1243,7 +1243,8 @@ class CodeGenerator(ast.NodeVisitor):
             step = iter_args[2] if len(iter_args) > 2 else self.visit(ast.Constant(1))
         else:
             raise RuntimeError('Only `range` and `static_range` iterators are currently supported')
-        # handle negative constant step (not supported by scf.for in MLIR)
+        # handle negative constant step (not supported by scf.for in MLIR).
+        # Only a constexpr step can be normalized here; a runtime step must be positive.
         negative_step = False
         if _is_constexpr(step) and step.value < 0:
             step = constexpr(-step.value)

--- a/python/triton/language/core.py
+++ b/python/triton/language/core.py
@@ -3770,7 +3770,8 @@ class range(base_value):
         :code:`triton.jit` functions. In addition, it allows user to pass extra attributes to the compiler.
     :param arg1: the start value.
     :param arg2: the end value.
-    :param step: the step value.
+    :param step: the step value. A negative step is supported only when it is a
+        :code:`constexpr`; a runtime (non-:code:`constexpr`) step must be positive.
     :param num_stages: pipeline the loop into this many stages (so there are
         :code:`num_stages` iterations of the loop in flight at once).
 


### PR DESCRIPTION
Refs #10950.

A `tl.range(start, stop, step)` whose `step` is a runtime (non-`constexpr`) negative value runs zero iterations on the GPU: the body never executes and the accumulator is returned unmodified, with no error. With `lb < ub` (e.g. `tl.range(5, 10, -3)`) the emitted ascending `scf.for` has a negative step, the trip count wraps, and the loop reads out of bounds. A constexpr negative step, a runtime positive step, and `TRITON_INTERPRET=1` all iterate downward correctly.

`scf.for` is ascending, so `visit_For` normalizes a negative step by swapping `lb`/`ub`, negating the step, and remapping the induction variable. That normalization is gated on `_is_constexpr(step) and step.value < 0`, so a runtime step cannot be normalized (its sign is unknown at compile time) and only a positive runtime step is valid. The `tl.range` docstring did not state this.

Per review, this documents the limitation rather than adding a runtime check: the `tl.range` docstring and the normalization site now state that a negative step is supported only as a `constexpr` and a runtime step must be positive.

- [docstring](https://github.com/triton-lang/triton/blob/b64a99d0a33237a93c9031b5393f49e48d4202c5/python/triton/language/core.py#L3773-L3774)
- [normalization site](https://github.com/triton-lang/triton/blob/b64a99d0a33237a93c9031b5393f49e48d4202c5/python/triton/compiler/code_generator.py#L1246-L1247)
