### PR TITLE
[AMD] Optimize partitioned shared-memory base-pointer selection in lowerLdSt

### DIFF
--- a/lib/Conversion/TritonGPUToLLVM/Utility.cpp
+++ b/lib/Conversion/TritonGPUToLLVM/Utility.cpp
@@ -919,6 +919,27 @@ SmallVector<Value> lowerLdSt(
     regBaseI8 = b.xor_(regBaseI8, affineOffsetI8);
   }
 
+  // Pre-compute the base pointers for partitioned tensors.
+  SmallVector<Value> partitionBases;
+  if (isPartitioned) {
+    // Loop-invariant partition contribution (register = 0).
+    Value dynamicPartition = applyLinearLayout(loc, rewriter, partitionLayout,
+                                               {{kReg, b.i32_val(0)},
+                                                {kLane, laneId},
+                                                {kWarp, warpId},
+                                                {kBlock, blockId}})[0]
+                                 .second;
+    unsigned numPartitions = smemBases.size();
+    partitionBases.resize(numPartitions);
+    for (unsigned c = 0; c < numPartitions; ++c) {
+      // partitionBases[c] holds the base for register partitions that map to
+      // `c`, so reordering by `dynamicPartition ^ c` folds the loop-invariant
+      // part in once.
+      Value idx = b.xor_(dynamicPartition, b.i32_val(c));
+      partitionBases[c] = b.extract_element(basesVec, idx);
+    }
+  }
+
   SmallVector<Value> outVals;
   auto vecTy = vec_ty(llvmElemTy, elemsPerVec);
   for (int i = 0; i < cvt.getInDimSize(kReg); i += nAdditive) {
@@ -948,14 +969,13 @@ SmallVector<Value> lowerLdSt(
       // Select the appropriate base pointer for partitioned tensors
       Value smemBase = smemBases[0];
       if (isPartitioned) {
-        // Compute the partition index dynamically.
-        auto partitionResult = applyLinearLayout(loc, rewriter, partitionLayout,
-                                                 {{kReg, b.i32_val(i + j)},
-                                                  {kLane, laneId},
-                                                  {kWarp, warpId},
-                                                  {kBlock, blockId}});
-        Value partitionIdx = partitionResult[0].second;
-        smemBase = b.extract_element(basesVec, partitionIdx);
+        // The register-only partition contribution is a compile-time constant,
+        // so it indexes the pre-reordered array as a literal.
+        unsigned regPartition =
+            partitionLayout
+                .apply({{kReg, i + j}, {kLane, 0}, {kWarp, 0}, {kBlock, 0}})[0]
+                .second;
+        smemBase = partitionBases[regPartition];
       }
 
       Value innerCtaOffset;


### PR DESCRIPTION
When lowering loads/stores for partitioned shared-memory layouts (smemBases.size() > 1), the previous implementation recomputed the partition index inside the load/store loop — one applyLinearLayout plus a runtime extract_element per load — to pick the correct base pointer.

This PR hoists that work out of the loop so this optimization doesn't depend on LLVM codegen anymore. The partition index is a XOR of contributions:

partitionIdx = P_reg(register) ⊕ P_warp(warp) ⊕ P_lane(warp) ⊕ P_block(warp) 
The register term is a compile-time constant, while the warp/lane/block are runtime values but loop-invariant. We resolve the loop-invariant part once, reorder the base-pointer array by that value, and let each unrolled load index the reordered array with a compile-time-constant offset that folds to a literal.