### PR TITLE
[AMD][gfx1250] Handle partial MXFP scale K groups

### DIFF
--- a/third_party/amd/python/examples/gluon/mxfp_gemm_gfx1250.py
+++ b/third_party/amd/python/examples/gluon/mxfp_gemm_gfx1250.py
@@ -1905,16 +1905,19 @@ def create_tensor_descriptor(cfg: MXFPGEMMConfig, a_ptr, a_offs, b_ptr, b_offs, 
             a_scale_base = a_scale_ptr + a_scale_offs
         else:
             a_scale_base = b_scale_ptr + b_scale_offs
+        k_scale = (K + SCALE_BLOCK - 1) // SCALE_BLOCK
+        if cfg.SCALE_PRESHUFFLE:
+            k_scale = (k_scale + cfg.SCALE_KWIDTH - 1) // cfg.SCALE_KWIDTH * cfg.SCALE_KWIDTH
         a_scale_desc = gl.amd.gfx1250.tdm.make_tensor_descriptor(
             base=a_scale_base,  #
-            shape=(M // PRESHUFFLE_FACTOR, K // SCALE_BLOCK * PRESHUFFLE_FACTOR),  #
+            shape=(M // PRESHUFFLE_FACTOR, k_scale * PRESHUFFLE_FACTOR),  #
             strides=(stride_scale, 1),  #
             block_shape=(cfg.BLOCK_M_PRESHUFFLED, cfg.BLOCK_K_SCALE_PRESHUFFLED),  #
             layout=cfg.shared_layout_a_scale)
 
         b_scale_desc = gl.amd.gfx1250.tdm.make_tensor_descriptor(
             base=b_scale_ptr + b_scale_offs,  #
-            shape=(N // PRESHUFFLE_FACTOR, K // SCALE_BLOCK * PRESHUFFLE_FACTOR),  #
+            shape=(N // PRESHUFFLE_FACTOR, k_scale * PRESHUFFLE_FACTOR),  #
             strides=(stride_scale, 1),  #
             block_shape=(cfg.BLOCK_N_PRESHUFFLED, cfg.BLOCK_K_SCALE_PRESHUFFLED),  #
             layout=cfg.shared_layout_b_scale)
@@ -2089,18 +2092,22 @@ def init_data(dtype, d0: int, d1: int):
         raise NotImplementedError(f"NYI: unsupported dtype: {dtype}")
 
 
-def pack_scale(x):
+def pack_scale(x, scale_kwidth):
     if x is None:
         return x
     NON_K, K_SCALE = x.shape
     preshuffle_factor = 128
     num_chunk_m = NON_K // preshuffle_factor
-    SCALE_KWIDTH = 4 if K_SCALE >= 4 else K_SCALE
-    num_chunk_k = K_SCALE // SCALE_KWIDTH
+    num_chunk_k = (K_SCALE + scale_kwidth - 1) // scale_kwidth
+    K_SCALE_PADDED = num_chunk_k * scale_kwidth
 
-    x = x.view(num_chunk_m, 4, preshuffle_factor // 4, num_chunk_k, SCALE_KWIDTH)
+    if K_SCALE_PADDED != K_SCALE:
+        padding = torch.zeros((NON_K, K_SCALE_PADDED - K_SCALE), dtype=x.dtype, device=x.device)
+        x = torch.cat((x, padding), dim=1)
+
+    x = x.view(num_chunk_m, 4, preshuffle_factor // 4, num_chunk_k, scale_kwidth)
     x = x.permute(0, 3, 2, 1, 4).contiguous()
-    return x.view(NON_K // preshuffle_factor, K_SCALE * preshuffle_factor)
+    return x.view(NON_K // preshuffle_factor, K_SCALE_PADDED * preshuffle_factor)
 
 
 def interleave_b_columns(w_gate, w_up, DTYPE_B):
@@ -2186,8 +2193,9 @@ def test_runtime_mxgemm_tdm_8warps_pipeline(DTYPE_A, DTYPE_B, M, N, K, BLOCK_M, 
     b_scale = b_scale.data
 
     if SCALE_PRESHUFFLE:
-        a_scale = pack_scale(a_scale)
-        b_scale = pack_scale(b_scale)
+        scale_kwidth = min(4, BLOCK_K // SCALE_BLOCK)
+        a_scale = pack_scale(a_scale, scale_kwidth)
+        b_scale = pack_scale(b_scale, scale_kwidth)
 
     # mxfp4 input needs packed along the k dim, i.e., two mxfp4 are packed in one uint8
     if DTYPE_A in ['float4', 'float6_e2m3', 'float6_e3m2']:
@@ -2374,8 +2382,9 @@ def test_runtime_mxgemm_tdm_pipelined(DTYPE_A, DTYPE_B, M, N, K, BLOCK_M, BLOCK_
     b_scale = b_scale.data
 
     if SCALE_PRESHUFFLE:
-        a_scale = pack_scale(a_scale)
-        b_scale = pack_scale(b_scale)
+        scale_kwidth = min(4, BLOCK_K // SCALE_BLOCK)
+        a_scale = pack_scale(a_scale, scale_kwidth)
+        b_scale = pack_scale(b_scale, scale_kwidth)
 
     # mxfp4 input needs packed along the k dim, i.e., two mxfp4 are packed in one uint8
     if DTYPE_A in ['float4', 'float6_e2m3', 'float6_e3m2']:

--- a/third_party/amd/python/test/test_gluon_gfx1250.py
+++ b/third_party/amd/python/test/test_gluon_gfx1250.py
@@ -14,6 +14,60 @@ from triton.experimental import gluon
 import triton.experimental.gluon.language as ttgl
 from triton.experimental.gluon.language.amd.gfx1250 import get_wmma_scale_layout, PartitionedSharedLayout, _valid_dtype_combinations
 from triton._C.libtriton.gluon_ir import make_cga_layout
+from third_party.amd.python.examples.gluon.mxfp_gemm_gfx1250 import (
+    pack_scale as pack_mxfp_scale,
+    test_runtime_mxgemm_tdm_pipelined as run_mxgemm_tdm_pipelined,
+)
+
+
+def test_pack_mxfp_scale_pads_partial_k_chunk():
+    non_k = 128
+    for num_scale_groups, scale_kwidth, padded_groups in [
+        (1, 4, 4),
+        (7, 4, 8),  # K=196 has ceil(196 / 32) scale groups.
+        (8, 4, 8),
+    ]:
+        scale = torch.arange(non_k * num_scale_groups, dtype=torch.int32).reshape(non_k, num_scale_groups)
+
+        packed = pack_mxfp_scale(scale, scale_kwidth)
+
+        assert packed.shape == (non_k // 128, padded_groups * 128)
+        unpacked = packed.view(non_k // 128, padded_groups // scale_kwidth, 32, 4,
+                               scale_kwidth).permute(0, 3, 2, 1, 4).reshape(non_k, padded_groups)
+        torch.testing.assert_close(unpacked[:, :num_scale_groups], scale)
+        assert torch.count_nonzero(unpacked[:, num_scale_groups:]) == 0
+
+
+@pytest.mark.skipif(not is_hip_gfx1250(), reason="Requires GFX1250")
+@pytest.mark.parametrize("K,SCALE_PRESHUFFLE,SCHEDULE,TDM_SPLIT,BLOCK_K", [
+    (196, False, "baseline", False, 128),
+    (196, True, "baseline", False, 128),
+    (481, True, "sliceMNK", True, 256),
+    (512, True, "sliceMNK", True, 256),
+])
+def test_runtime_mxgemm_tdm_scale_k_tail(K, SCALE_PRESHUFFLE, SCHEDULE, TDM_SPLIT, BLOCK_K):
+    run_mxgemm_tdm_pipelined(
+        "float8_e4m3",
+        "float8_e4m3",
+        M=128,
+        N=128,
+        K=K,
+        BLOCK_M=128,
+        BLOCK_N=128,
+        BLOCK_K=BLOCK_K,
+        TRANSPOSE_B=True,
+        NUM_BUFFERS=2,
+        SCALE_PRESHUFFLE=SCALE_PRESHUFFLE,
+        WITH_A_SCALE=True,
+        SCHEDULE=SCHEDULE,
+        ASYNC_COPY_SCALE=False,
+        GROUP_SIZE_M=8,
+        L2_PREFETCH_DISTANCE=-1,
+        ACTIVATION="",
+        PARTIAL_TDM=False,
+        RESOLVE_PARTITION_CONFLICTS=False,
+        TDM_SPLIT=TDM_SPLIT,
+    )
 
 
 @gluon.jit


### PR DESCRIPTION
# New contributor declaration
- [x] I am not making a trivial change, such as fixing a typo in a comment.

- [x] I have written a PR description following these
  [rules](https://cbea.ms/git-commit/#why-not-how).

- [x] I have run `pre-commit run --from-ref origin/main --to-ref HEAD`.

- Select one of the following.
  - [x] I have added tests.
    - `/test` for `lit` tests
    - `/unittest` for C++ tests
    - `/python/test` for end-to-end tests

- Select one of the following.
  - [x] I have not added any `lit` tests.

---

Scale tensors contain `ceil(K / 32)` groups, but the GFX1250 MXFP GEMM
descriptors exposed `floor(K / 32)`. The final real group was outside the
descriptor whenever K was not divisible by 32.

Preshuffled scales had an additional failure mode: packing used a floor number
of K-width chunks, so inputs such as K=196 raised during reshape. Other tails,
such as K=481, packed successfully but remained truncated by the descriptor.

```text
K = 196, SCALE_BLOCK = 32

logical scale groups:  [0] [1] [2] [3] [4] [5] [6]   ceil(196/32) = 7
old descriptor bound:  [0] [1] [2] [3] [4] [5]       floor(196/32) = 6
                                                 ^
                                                 +-- real group omitted

new non-preshuffled:   [0] [1] [2] [3] [4] [5] [6]
new preshuffled:       [0] [1] [2] [3] | [4] [5] [6] [pad]
                       <--- chunk 0 --->   <---- chunk 1 ---->
```

This change:

- sizes non-preshuffled descriptors from `ceil(K / 32)`;
- pads preshuffled scale tensors to the scale tile's physical K-width;
- gives preshuffled descriptors the same padded extent;
- keeps the shared descriptor path used by the fused TDM-split schedule.

Padding uses zero scale bytes. These entries correspond only to matrix
elements past K, whose TDM data loads are also zero-filled, so padding does not
alter valid products.

Regression coverage in the existing GFX1250 Gluon test suite exercises the
example's packing and runtime entrypoints. It includes K=196 on both scale
layouts, K=481 through the fused TDM-split schedule, and a divisible K=512
control. Every runtime case has at least two K tiles for the two-buffer
pipeline.

## Test plan

- `pre-commit run --from-ref origin/main --to-ref HEAD`
- `python3 -m py_compile third_party/amd/python/examples/gluon/mxfp_gemm_gfx1250.py third_party/amd/python/test/test_gluon_gfx1250.py`
- CPU round-trip checks for sub-chunk, partial-chunk, and divisible packed scale extents
- `git diff --check`

The added numeric regression requires execution on GFX1250.

Fixes #10962.
