### PR TITLE
[NVIDIA] Reject multi-CTA configurations on SM12

### DIFF
--- a/python/test/unit/language/test_compile_only.py
+++ b/python/test/unit/language/test_compile_only.py
@@ -1,8 +1,24 @@
 import triton
 import triton.language as tl
+import pytest
 from triton.backends.compiler import GPUTarget
 import re
 from triton.compiler import ASTSource
+
+
+@pytest.mark.parametrize("capability", [120, 121])
+def test_compile_only_rejects_clusters_on_sm12(capability) -> None:
+    backend = triton.compiler.compiler.make_backend(GPUTarget("cuda", capability, 32))
+
+    with pytest.raises(ValueError, match="does not support cluster operations"):
+        backend.parse_options({"num_ctas": 2})
+
+
+@pytest.mark.parametrize("capability,num_ctas", [(90, 2), (120, 1)])
+def test_compile_only_accepts_supported_cluster_options(capability, num_ctas) -> None:
+    backend = triton.compiler.compiler.make_backend(GPUTarget("cuda", capability, 32))
+
+    assert backend.parse_options({"num_ctas": num_ctas}).num_ctas == num_ctas
 
 
 def test_compile_only_sm100() -> None:

--- a/test/Conversion/tritongpu_to_llvm_invalid.mlir
+++ b/test/Conversion/tritongpu_to_llvm_invalid.mlir
@@ -1,4 +1,4 @@
-// RUN: triton-opt %s --allocate-shared-memory-nv --convert-triton-gpu-to-llvm -verify-diagnostics
+// RUN: triton-opt -split-input-file %s --allocate-shared-memory-nv='compute-capability=120' --convert-triton-gpu-to-llvm='compute-capability=120' -verify-diagnostics
 
 #blocked0 = #ttg.blocked<{sizePerThread = [1, 4], threadsPerWarp = [8, 4], warpsPerCTA = [2, 2], order = [1, 0]}>
 #blocked1 = #ttg.blocked<{sizePerThread = [4, 1], threadsPerWarp = [4, 8], warpsPerCTA = [2, 2], order = [0, 1]}>
@@ -10,6 +10,15 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32} {
     // expected-error @+1 {{failed to legalize operation 'ttg.convert_layout' that was explicitly marked illegal}}
     %0 = ttg.convert_layout %arg0
         : tensor<32x32xf32, #blocked0> -> tensor<32x32xf32, #blocked1>
+    tt.return
+  }
+}
+
+// -----
+
+// expected-error @below {{num_ctas > 1 is not supported on sm_120}}
+module attributes {"ttg.num-ctas" = 2 : i32, "ttg.num-warps" = 4 : i32} {
+  tt.func @sm120_multi_cta() {
     tt.return
   }
 }

--- a/third_party/nvidia/backend/compiler.py
+++ b/third_party/nvidia/backend/compiler.py
@@ -193,14 +193,10 @@ class CUDABackend(BaseBackend):
         args.update({k: opts[k] for k in CUDAOptions.__dataclass_fields__.keys() if k in opts if opts[k] is not None})
         capability = int(self._parse_arch(args["arch"]))
 
-        if args.get("num_ctas", 1) > 1:
-            if capability < 90:
-                raise ValueError((f"num_ctas > 1 requires NVIDIA SM90+ (Hopper). "
-                                  f"Current target is sm_{capability}. This configuration will fail. "
-                                  f"Please set num_ctas=1 or target an SM90+ GPU."))
-            if capability // 10 == 12:
-                raise ValueError((f"sm_{capability} does not support cluster operations. "
-                                  f"Please set num_ctas=1."))
+        if args.get("num_ctas", 1) > 1 and (capability < 90 or capability // 10 == 12):
+            raise ValueError((f"num_ctas > 1 is not supported on sm_{capability}: "
+                              f"this target does not support cluster operations. "
+                              f"Please set num_ctas=1."))
 
         if "supported_fp8_dtypes" not in args:
             supported_fp8_dtypes = set(CUDAOptions.supported_fp8_dtypes)

--- a/third_party/nvidia/backend/compiler.py
+++ b/third_party/nvidia/backend/compiler.py
@@ -193,10 +193,14 @@ class CUDABackend(BaseBackend):
         args.update({k: opts[k] for k in CUDAOptions.__dataclass_fields__.keys() if k in opts if opts[k] is not None})
         capability = int(self._parse_arch(args["arch"]))
 
-        if args.get("num_ctas", 1) > 1 and capability < 90:
-            raise ValueError((f"num_ctas > 1 requires NVIDIA SM90+ (Hopper). "
-                              f"Current target is sm_{capability}. This configuration will fail. "
-                              f"Please set num_ctas=1 or target an SM90+ GPU."))
+        if args.get("num_ctas", 1) > 1:
+            if capability < 90:
+                raise ValueError((f"num_ctas > 1 requires NVIDIA SM90+ (Hopper). "
+                                  f"Current target is sm_{capability}. This configuration will fail. "
+                                  f"Please set num_ctas=1 or target an SM90+ GPU."))
+            if capability // 10 == 12:
+                raise ValueError((f"sm_{capability} does not support cluster operations. "
+                                  f"Please set num_ctas=1."))
 
         if "supported_fp8_dtypes" not in args:
             supported_fp8_dtypes = set(CUDAOptions.supported_fp8_dtypes)

--- a/third_party/nvidia/lib/TritonNVIDIAGPUToLLVM/TritonGPUToLLVM.cpp
+++ b/third_party/nvidia/lib/TritonNVIDIAGPUToLLVM/TritonGPUToLLVM.cpp
@@ -98,6 +98,12 @@ struct ConvertTritonGPUToLLVM
     MLIRContext *context = &getContext();
     ModuleOp mod = getOperation();
     TargetInfo targetInfo(computeCapability, ptxVersion);
+    int numCTAs = triton::gpu::TritonGPUDialect::getNumCTAs(mod);
+    if (numCTAs > 1 && !targetInfo.getTargetFeatures().supportClusterOps()) {
+      mod.emitError() << "num_ctas > 1 is not supported on sm_"
+                      << computeCapability;
+      return signalPassFailure();
+    }
 
     // Allocate shared memory and set barrier
     ModuleAllocation allocation(
@@ -242,7 +248,6 @@ struct ConvertTritonGPUToLLVM
       return signalPassFailure();
 
     // Fold CTAId when there is only 1 CTA.
-    int numCTAs = triton::gpu::TritonGPUDialect::getNumCTAs(mod);
     if (numCTAs == 1) {
       mod.walk([](triton::nvgpu::ClusterCTAIdOp id) {
         OpBuilder b(id);


### PR DESCRIPTION
# New contributor declaration
- [x] I am not making a trivial change, such as fixing a typo in a comment.

- [x] I have written a PR description following these
  [rules](https://cbea.ms/git-commit/#why-not-how).

- [x] I have run `pre-commit run --from-ref origin/main --to-ref HEAD`.

- Select one of the following.
  - [x] I have added tests.
    - `/test` for `lit` tests
    - `/unittest` for C++ tests
    - `/python/test` for end-to-end tests

- Select one of the following.
  - [x] The `lit` tests I have added follow these [best practices](https://mlir.llvm.org/getting_started/TestingGuide/#filecheck-best-practices), including the "tests should be minimal" section.

---

SM120 and SM121 were accepted with `num_ctas > 1` even though
`TargetFeatures::supportClusterOps()` explicitly excludes compute-capability
major 12.

This change applies that contract at both compilation entry points:

- CUDA option parsing rejects sm120/sm121 multi-CTA configurations with an
  actionable diagnostic.
- TritonGPU-to-LLVM conversion checks `supportClusterOps()` before shared-memory
  allocation, cluster analysis, or lowering, covering direct TTGIR compilation.

```text
                            num_ctas > 1
                                  |
                    +-------------+-------------+
                    |                           |
            Python source path          direct TTGIR path
            parse_options()             conversion pass
                    |                           |
          equivalent capability          supportClusterOps()
                 predicate                       |
                    +-------------+-------------+
                                  |
                    same target capability result
                          /               \
                    unsupported         supported
                         |                   |
                   reject early       continue lowering
```

Existing behavior is preserved for sm120 single-CTA compilation and sm90
multi-CTA compilation.

Regression coverage checks that sm120 and sm121 reject `num_ctas=2`, sm120
accepts `num_ctas=1`, sm90 accepts `num_ctas=2`, and direct sm120 TTGIR with
`ttg.num-ctas = 2` fails conversion.

## Test plan

- `pre-commit run --from-ref origin/main --to-ref HEAD`
- `python3 -m py_compile third_party/nvidia/backend/compiler.py python/test/unit/language/test_compile_only.py`
- Import-isolated option-parsing source harness
- `git diff --check`

The added pytest and lit tests require execution in a configured Triton build.

Fixes #10963.
