### PR TITLE
fix(autotuner): apply fractional top_k after early pruning

### DIFF
--- a/python/test/unit/runtime/test_autotuner.py
+++ b/python/test/unit/runtime/test_autotuner.py
@@ -263,6 +263,53 @@ def test_prune_configs_fractional_top_k_keeps_one(device: str):
     torch.testing.assert_close(src, dst)
 
 
+def test_prune_configs_fractional_top_k_after_early_prune():
+    configs = [triton.Config(kwargs={'BLOCK_SIZE': block_size}) for block_size in range(1, 11)]
+    estimated = []
+    launched = []
+    benchmarked = []
+
+    class Kernel:
+
+        def __init__(self):
+            self.fn = lambda: None
+
+        def run(self, **kwargs):
+            launched.append(kwargs['BLOCK_SIZE'])
+
+    def do_bench(kernel_call, quantiles):
+        kernel_call()
+        benchmarked.append(launched[-1])
+        return [launched[-1]] * 3
+
+    def early_config_prune(configs, named_args, **kwargs):
+        return configs[:6]
+
+    def perf_model(*args, **kwargs):
+        estimated.append(kwargs['BLOCK_SIZE'])
+        return kwargs['BLOCK_SIZE']
+
+    tuner = triton.runtime.Autotuner(
+        Kernel(),
+        arg_names=[],
+        configs=configs,
+        key=[],
+        reset_to_zero=None,
+        restore_value=None,
+        do_bench=do_bench,
+        prune_configs_by={
+            'early_config_prune': early_config_prune,
+            'perf_model': perf_model,
+            'top_k': 0.5,
+        },
+    )
+
+    tuner.run()
+
+    assert estimated == list(range(1, 7))
+    assert benchmarked == [1, 2, 3]
+
+
 def test_config_ir_override_changes_disk_cache_key():
     # Autotuner derives persisted result-cache keys from Config.__str__().
     first = triton.Config(kwargs={"BLOCK_SIZE": 32}, ir_override="first.ttir")

--- a/python/triton/runtime/autotuner.py
+++ b/python/triton/runtime/autotuner.py
@@ -295,7 +295,7 @@ class Autotuner(KernelInterface):
                 # set rounds down to zero, which would prune everything and crash
                 # the later min() on an empty set. early_config_prune already
                 # guarantees at least one config; mirror that here.
-                top_k = max(1, int(len(self.configs) * top_k))
+                top_k = max(1, int(len(pruned_configs) * top_k))
             elif not isinstance(top_k, int):
                 # Slice index must be an integer
                 raise TypeError("Error while pruning configs, top_k must be either 1) a float <= 1.0 or 2) an int")


### PR DESCRIPTION
# New contributor declaration
- [x] I am not making a trivial change, such as fixing a typo in a comment.

- [x] I have written a PR description following these
  [rules](https://cbea.ms/git-commit/#why-not-how).

- [x] I have run `pre-commit run --from-ref origin/main --to-ref HEAD`.

- Select one of the following.
  - [x] I have added tests.
    - `/test` for `lit` tests
    - `/unittest` for C++ tests
    - `/python/test` for end-to-end tests

- Select one of the following.
  - [x] I have not added any `lit` tests.

---

A fractional autotune `top_k` describes the fraction of candidate
configurations to benchmark. When `early_config_prune` was also configured,
the autotuner calculated that fraction from the original configuration list
instead of the surviving list.

```text
10 configured
      |
      v
6 survive early pruning
      |
      +-- old: top_k = 50% of 10 -> benchmark 5
      |
      +-- new: top_k = 50% of  6 -> benchmark 3
```

This change calculates fractional `top_k` from `pruned_configs`, the set
produced by `early_config_prune`.

Integer `top_k`, performance-model ordering, and the existing guarantee that a
fractional value retains at least one configuration are unchanged.

The new `test_prune_configs_fractional_top_k_after_early_prune` exercises
`Autotuner.run()` and verifies that early pruning retains 6 of 10
configurations, the performance model evaluates all 6 survivors, and
`top_k=0.5` benchmarks exactly the fastest 3.

Before the fix:

```text
assert [1, 2, 3, 4, 5] == [1, 2, 3]
1 failed
```

After the fix:

```text
1 passed
```

## Test plan

- `test_prune_configs_fractional_top_k_after_early_prune` (`1 passed`)
- `pre-commit run --from-ref origin/main --to-ref HEAD`
- `git diff --check`

Fixes #10964.
