### PR TITLE
[FRONTEND] Correct unsigned tl.sum dtype promotion docs

### DIFF
--- a/python/triton/language/core.py
+++ b/python/triton/language/core.py
@@ -2883,7 +2883,7 @@ def _add_reduction_docstr(name: str, return_indices_arg: str = None, tie_break_a
     :type {tie_break_arg}: bool"""
         if dtype_arg is not None:
             docstr += f"""
-    :param {dtype_arg}: the desired data type of the returned tensor. If specified, the input tensor is casted to :code:`{dtype_arg}` before the operation is performed. This is useful for preventing data overflows. If not specified, integer and bool dtypes are upcasted to :code:`tl.int32` while float dtypes are kept as-is.
+    :param {dtype_arg}: the desired data type of the returned tensor. If specified, the input tensor is casted to :code:`{dtype_arg}` before the operation is performed. This is useful for preventing data overflows. If not specified, signed integer dtypes narrower than 32 bits are upcasted to :code:`tl.int32`, while unsigned integer and bool dtypes narrower than 32 bits are upcasted to :code:`tl.uint32`. Other dtypes are kept as-is.
     :type {dtype_arg}: tl.dtype"""
 
         func.__doc__ = docstr.format(name=name)


### PR DESCRIPTION
# New contributor declaration
- [x] I am not making a trivial change, such as fixing a typo in a comment.

- [x] I have written a PR description following these
  [rules](https://cbea.ms/git-commit/#why-not-how).

- [x] I have run `pre-commit run --from-ref origin/main --to-ref HEAD`.

- Select one of the following.
  - [x] This PR does not need a test because it only corrects a docstring.

- Select one of the following.
  - [x] I have not added any `lit` tests.

---

The `tl.sum` dtype documentation currently says all integer and bool
inputs are promoted to `tl.int32`.

#10893 corrected the float-promotion wording in this docstring, but the
remaining integer sentence still loses signedness.

The implementation preserves signedness:

- signed integer types narrower than 32 bits are promoted to `tl.int32`;
- unsigned integer types and bool are promoted to `tl.uint32`;
- other input types are kept as-is unless `dtype` is specified.

This updates the generated reduction docstring to match that behavior. There
is no runtime change.

## Test plan

- `pre-commit run --from-ref origin/main --to-ref HEAD`
- `python3 -m py_compile python/triton/language/core.py`
- `git diff --check`
