### PR TITLE
[proton] Export Python scope IDs in Chrome traces

### DIFF
--- a/third_party/proton/csrc/lib/Data/Dump/ChromeTrace.cpp
+++ b/third_party/proton/csrc/lib/Data/Dump/ChromeTrace.cpp
@@ -156,7 +156,7 @@ void dumpCpuScopeEvents(
       element["dur"] = dur;
       element["tid"] = details::getCpuLaneId(threadId);
       element["args"]["call_stack"] = buildCallStackJson(event.contexts);
-      element["args"]["proton_scope_id"] = event.scopeId;
+      element["args"]["scope_id"] = event.scopeId;
       object["traceEvents"].push_back(std::move(element));
     }
   }

--- a/third_party/proton/csrc/lib/Data/Dump/ChromeTrace.cpp
+++ b/third_party/proton/csrc/lib/Data/Dump/ChromeTrace.cpp
@@ -156,6 +156,7 @@ void dumpCpuScopeEvents(
       element["dur"] = dur;
       element["tid"] = details::getCpuLaneId(threadId);
       element["args"]["call_stack"] = buildCallStackJson(event.contexts);
+      element["args"]["proton_scope_id"] = event.scopeId;
       object["traceEvents"].push_back(std::move(element));
     }
   }

--- a/third_party/proton/csrc/lib/Data/Dump/TraceDataDump.h
+++ b/third_party/proton/csrc/lib/Data/Dump/TraceDataDump.h
@@ -62,17 +62,20 @@ struct KernelEvent {
 
 struct CpuScopeEvent {
   size_t eventId;
+  size_t scopeId;
   std::vector<Context> contexts;
   size_t threadId;
   uint64_t startTimeNs;
   uint64_t endTimeNs;
   const DataEntry::FlexibleMetricMap *flexibleMetrics{};
 
-  CpuScopeEvent(size_t eventId, const DataEntry::FlexibleMetricMap *metrics,
+  CpuScopeEvent(size_t eventId, size_t scopeId,
+                const DataEntry::FlexibleMetricMap *metrics,
                 std::vector<Context> contexts, size_t tid, uint64_t start,
                 uint64_t end)
-      : eventId(eventId), contexts(std::move(contexts)), threadId(tid),
-        startTimeNs(start), endTimeNs(end), flexibleMetrics(metrics) {}
+      : eventId(eventId), scopeId(scopeId), contexts(std::move(contexts)),
+        threadId(tid), startTimeNs(start), endTimeNs(end),
+        flexibleMetrics(metrics) {}
 };
 
 struct GraphScopeEvent {

--- a/third_party/proton/csrc/lib/Data/TraceData.cpp
+++ b/third_party/proton/csrc/lib/Data/TraceData.cpp
@@ -383,7 +383,7 @@ void TraceData::dumpChromeTrace(std::ostream &os, size_t phase) const {
     for (const auto &[_, event] : events) {
       if (event.hasCpuTimeRange()) { // CPU scope event
         cpuScopeEvents[event.threadId].emplace_back(
-            event.id,
+            event.id, event.scopeId,
             event.metricSet.flexibleMetrics.empty()
                 ? nullptr
                 : &event.metricSet.flexibleMetrics,

--- a/third_party/proton/test/test_profile.py
+++ b/third_party/proton/test/test_profile.py
@@ -1258,7 +1258,7 @@ def test_trace_flexible_metrics_no_kernel_anchor(tmp_path: pathlib.Path):
         trace_events[0]["args"]["call_stack"],
         trace_events[0]["args"]["metrics"],
     ) == ("metric", "metric_only: <foo, 1.000000>", ["ROOT", "metric_only"], {"foo": "1.000000"})
-    assert isinstance(trace_events[0]["args"]["proton_scope_id"], int)
+    assert isinstance(trace_events[0]["args"]["scope_id"], int)
 
 
 @pytest.mark.skipif(not is_cuda(), reason="Only CUDA backend supports cudagraph trace reconstruction")

--- a/third_party/proton/test/test_profile.py
+++ b/third_party/proton/test/test_profile.py
@@ -1258,6 +1258,7 @@ def test_trace_flexible_metrics_no_kernel_anchor(tmp_path: pathlib.Path):
         trace_events[0]["args"]["call_stack"],
         trace_events[0]["args"]["metrics"],
     ) == ("metric", "metric_only: <foo, 1.000000>", ["ROOT", "metric_only"], {"foo": "1.000000"})
+    assert isinstance(trace_events[0]["args"]["proton_scope_id"], int)
 
 
 @pytest.mark.skipif(not is_cuda(), reason="Only CUDA backend supports cudagraph trace reconstruction")


### PR DESCRIPTION
CPU Chrome events currently carry Proton's internal trace event ID for CPU-to-GPU flow matching, but that ID is not exposed by Python proton.scope. Preserve and export the original scope ID so an external tracer can deterministically link its scope-entry flow to the corresponding CPU event.

This allows us to do something like https://github.com/lightseekorg/tokenspeed/pull/740#issuecomment-5018496525