### PR TITLE
[NVIDIA] Allow SM120 cluster lowering for multi-CTA kernels

### DIFF
--- a/include/triton/Dialect/TritonNvidiaGPU/IR/TargetFeatures.h
+++ b/include/triton/Dialect/TritonNvidiaGPU/IR/TargetFeatures.h
@@ -33,9 +33,7 @@ public:
 
   int getComputeCapability() const { return computeCapability; }
 
-  bool supportClusterOps() const {
-    return computeCapability >= 90 && computeCapability / 10 != 12;
-  }
+  bool supportClusterOps() const { return computeCapability >= 90; }
 
   bool supportMaximumMinimum() const { return computeCapability >= 80; }
 

--- a/test/Conversion/tritonnvidiagpu_to_llvm_sm120_cluster.mlir
+++ b/test/Conversion/tritonnvidiagpu_to_llvm_sm120_cluster.mlir
@@ -1,0 +1,20 @@
+// RUN: triton-opt %s --allocate-shared-memory-nv='compute-capability=120' --convert-triton-gpu-to-llvm='compute-capability=120' --convert-nv-gpu-to-llvm | mlir-translate --mlir-to-llvmir | FileCheck %s
+
+#blocked = #ttg.blocked<{sizePerThread = [1], threadsPerWarp = [32], warpsPerCTA = [4], order = [0], CGALayout = [[0]]}>
+#shared_barrier = #ttg.swizzled_shared<{vec = 1, perPhase = 1, maxPhase = 1, order = [0], CGALayout = [[1]]}>
+#shared_store = #ttg.swizzled_shared<{vec = 1, perPhase = 1, maxPhase = 1, order = [0], CGALayout = [[0]]}>
+#smem = #ttg.shared_memory
+
+module attributes {"ttg.target" = "cuda:120", "ttg.num-ctas" = 2 : i32, "ttg.num-warps" = 4 : i32, "ttg.threads-per-warp" = 32 : i32} {
+  // CHECK-LABEL: @sm120_async_shared_store
+  // CHECK: fence.mbarrier_init.release.cluster
+  // CHECK: st.async.weak.shared::cluster.mbarrier::complete_tx::bytes.b32
+  tt.func public @sm120_async_shared_store(
+      %src: tensor<128xi32, #blocked>,
+      %dst: !ttg.memdesc<128xi32, #shared_store, #smem, mutable>,
+      %mbarrier: !ttg.memdesc<2xi64, #shared_barrier, #smem, mutable>) {
+    ttng.fence_mbarrier_init_release_cluster
+    ttng.async_shared_store %src, %dst, %mbarrier : tensor<128xi32, #blocked> -> !ttg.memdesc<128xi32, #shared_store, #smem, mutable>, !ttg.memdesc<2xi64, #shared_barrier, #smem, mutable>
+    tt.return
+  }
+}


### PR DESCRIPTION
# New contributor declaration
- [x] I am not making a trivial change, such as fixing a typo in a comment.

- [x] I have written a PR description following these
  [rules](https://cbea.ms/git-commit/#why-not-how).

- [x] I have run `pre-commit run --from-ref origin/main --to-ref HEAD`.

- [x] I have added tests.
  - `/test` for `lit` tests

- [x] The `lit` tests I have added follow these [best practices](https://mlir.llvm.org/getting_started/TestingGuide/#filecheck-best-practices), including the "tests should be minimal" section.

---

## Why

SM120 supports thread-block clusters and distributed shared memory, but Triton reports the target as not cluster-capable. This prevents multi-CTA Gluon kernels that use asynchronous distributed shared-memory stores from compiling on SM120:

```text
Gluon kernel with num_ctas=2 and hopper.async_store
  -> ttng.async_shared_store
  -> supportClusterOps(120) == false
  -> error: requires cluster-capable SM90+
```

The false result comes from an SM12 exception in `TargetFeatures::supportClusterOps()`. The exception was introduced when target feature checks were centralized in #10175. For `fence_mbarrier_init_release_cluster`, that changed the previous `computeCapability >= 90` check to one that rejects SM120. `ttng.async_shared_store` later reused the same predicate and inherited the rejection.

This does not match NVIDIA target support: the [CUDA compute-capability table](https://docs.nvidia.com/cuda/cuda-programming-guide/05-appendices/compute-capabilities.html) lists thread-block clusters and distributed shared memory for 12.x, and [`st.async.shared::cluster`](https://docs.nvidia.com/cuda/parallel-thread-execution/#data-movement-and-conversion-instructions-st-async) requires `sm_90` or newer.

## What changed

Remove the SM12 exception so cluster operations use the same `sm_90+` capability rule as the PTX ISA.

Add a minimal two-CTA SM120 lowering test. It fails on the previous predicate with:

```text
requires cluster-capable SM90+
```

With this change, the module lowers to the expected cluster instructions:

```text
fence.mbarrier_init.release.cluster
st.async.weak.shared::cluster.mbarrier::complete_tx::bytes.b32
```

The change only corrects the target capability gate; it does not alter cluster scheduling, layouts, or instruction selection.

## Relationship to #10966

Closed PR #10966 found the same inconsistency but treated `supportClusterOps()` as authoritative: because option parsing accepted `num_ctas=2` while the helper rejected SM120, it proposed rejecting the configuration earlier.

Revalidation showed the inverse. NVIDIA documents cluster support for 12.x, and the exact fence and asynchronous-store instructions emitted by this lowering assembled for `sm_120` with `ptxas` 12.8.93, 13.0.88, and 13.2.86. Accepting `num_ctas=2` was therefore correct; the SM12 exception in the shared capability predicate is the defect this PR fixes.

Fixes #10973.

## Test plan

- `MAX_JOBS=8 make dev-install NUM_PROCS=8`
- `MAX_JOBS=8 make NUM_PROCS=8`
- `lit -v test/Conversion/tritonnvidiagpu_to_llvm_sm120_cluster.mlir` — passed, 1/1
- Reinstated the previous SM12 exclusion and reran the regression test — failed with `requires cluster-capable SM90+`
- Restored this change and reran the regression test — passed, 1/1
- `pre-commit run --from-ref origin/main --to-ref HEAD`