### PR TITLE
[PIPELINE] Account for later-cluster waits in buffer sizing

### DIFF
--- a/lib/Dialect/TritonGPU/Transforms/Pipeliner/LowerLoops.cpp
+++ b/lib/Dialect/TritonGPU/Transforms/Pipeliner/LowerLoops.cpp
@@ -103,24 +103,26 @@ int getDefUseStageDiff(Operation *op, scf::ForOp forOp,
       topLevelWaitUsers.insert(topLevelUser);
     }
   }
-  for (Operation *topLevelUser : topLevelUsers) {
-    int _useStage = schedule[topLevelUser].first;
-    CoarseSchedule::Cluster _useCluster = schedule[topLevelUser].second;
-    if (*_useCluster > *defCluster) {
-      // Check if we need extra buffer due to unusual execution order
-      // The issue occurs when users of the load are scheduled in a later
-      // cluster, which happens when conditional code gets moved to epilogue
-      // cluster. This creates a race condition where the local load happens
-      // after the global-to-local copy for the next pipeline stage starts.
-      _useStage++;
+  auto getEffectiveUseStage = [&](Operation *user) {
+    int stage = schedule[user].first;
+    CoarseSchedule::Cluster cluster = schedule[user].second;
+    if (*cluster > *defCluster) {
+      // A later cluster can put the next iteration's producer before this use
+      // in the expanded schedule. Account for that overlap as an extra stage
+      // so their buffers cannot alias.
+      stage++;
     }
+    return stage;
+  };
+  for (Operation *topLevelUser : topLevelUsers) {
+    int _useStage = getEffectiveUseStage(topLevelUser);
     useStage = std::min(_useStage, useStage.value_or(_useStage));
   }
   // Waits tells us the buffer is still in use until the wait completes, we
   // can't simply load from the buffer and replace the uses of the buffer with
   // the load. The stage diff needs to account for the furthest wait.
   for (Operation *topLevelUser : topLevelWaitUsers) {
-    int _useStage = schedule[topLevelUser].first;
+    int _useStage = getEffectiveUseStage(topLevelUser);
     useStage = std::max(_useStage, useStage.value_or(_useStage));
   }
   if (!useStage)

--- a/test/TritonGPU/pipeline-lower-loop.mlir
+++ b/test/TritonGPU/pipeline-lower-loop.mlir
@@ -99,7 +99,9 @@ tt.func @one_dep_async(%lb : index, %ub : index, %step : index,
 
 module attributes {"ttg.num-warps" = 4 : i32, "ttg.num-ctas" = 1 : i32} {
 // CHECK-LABEL: @one_dep_barrier_wait
-// CHECK: ttg.local_alloc : () -> !ttg.memdesc<3x128x64
+// The wait is in a later cluster than the load, so it extends the buffer's
+// effective lifetime by one stage.
+// CHECK: ttg.local_alloc : () -> !ttg.memdesc<4x128x64
 tt.func @one_dep_barrier_wait(%lb : index, %ub : index, %step : index,
                  %a_ptr_init : tensor<128x64x!tt.ptr<f16>, #A> {tt.divisibility = dense<[16, 16]> : tensor<2xi32>, tt.contiguity = dense<[1, 16]> : tensor<2xi32>},
                  %bar : !ttg.memdesc<1xi64, #shared1, #ttg.shared_memory, mutable>,
@@ -123,7 +125,7 @@ tt.func @one_dep_barrier_wait(%lb : index, %ub : index, %step : index,
 
 module attributes {"ttg.num-warps" = 4 : i32, "ttg.num-ctas" = 1 : i32} {
 // CHECK-LABEL: @one_dep_barrier_wait_trans
-// CHECK: ttg.local_alloc : () -> !ttg.memdesc<3x128x64
+// CHECK: ttg.local_alloc : () -> !ttg.memdesc<4x128x64
 tt.func @one_dep_barrier_wait_trans(%lb : index, %ub : index, %step : index,
                  %a_ptr_init : tensor<128x64x!tt.ptr<f16>, #A> {tt.divisibility = dense<[16, 16]> : tensor<2xi32>, tt.contiguity = dense<[1, 16]> : tensor<2xi32>},
                  %bar : !ttg.memdesc<1xi64, #shared1, #ttg.shared_memory, mutable>,


### PR DESCRIPTION
Fixes #10977.

Completion waits now retain the same later-cluster stage adjustment used for
ordinary load users when the pipeliner determines shared-buffer depth.

`getDefUseStageDiff()` previously applied this adjustment while scanning all
users, but its separate furthest-wait calculation read the wait's raw stage
again. A wait at stage three in a later cluster was therefore treated as stage
three rather than effective stage four.

For the existing regression fixture:

| Operation | Stage | Cluster | Effective stage |
|---|---:|---:|---:|
| Load | 0 | 2 | 0 |
| Ordinary use | 2 | 0 | 2 |
| Completion wait | 3 | 3 | 4 |

The old calculation allocated three buffers:

```text
max(ordinary use 2, raw wait 3) = 3
```

This permits the following steady-state alias:

```text
cluster 2: producer(I+3) writes buffer (I+3) mod 3
cluster 3: wait(I) still holds buffer I mod 3

(I+3) mod 3 = I mod 3
```

The calculation now uses one effective-stage helper for both passes, producing
four buffers and preventing the producer from reusing the wait's live slice.

The regression updates the existing direct and transitive wait-dependency
fixtures. Restoring the old wait calculation makes both checks fail with three
buffers instead of four.

## Test plan

- `ninja -j1 triton-opt`
- `lit -v test/TritonGPU/pipeline-lower-loop.mlir`
- `pre-commit run --from-ref origin/main --to-ref HEAD`

# New contributor declaration

- [x] I am not making a trivial change, such as fixing a typo in a comment.

- [x] I have written a PR description following these
  [rules](https://cbea.ms/git-commit/#why-not-how).

- [x] I have run `pre-commit run --from-ref origin/main --to-ref HEAD`.

- [x] I have added tests.
  - `/test` for `lit` tests

- [x] The `lit` tests I have added follow these
  [best practices](https://mlir.llvm.org/getting_started/TestingGuide/#filecheck-best-practices),
  including the "tests should be minimal" section.
