### PR TITLE
[AMD][GLUON] Allow compact scales for fp `scaled_upcast'

### DIFF
--- a/python/triton/experimental/gluon/language/amd/_ops.py
+++ b/python/triton/experimental/gluon/language/amd/_ops.py
@@ -140,8 +140,14 @@ def _scaled_upcast(src, scale, elem_type, axis, semantic):
 
     expected_shape = list(src.type.shape)
     expected_shape[axis] *= 2
-    _check(scale.type.shape == expected_shape,
-           lambda: f"Expected scale shape for fp4 scaled_upcast to be {expected_shape} but got {scale.type.shape}")
+    _check(
+        scale.type.shape[:axis] + scale.type.shape[axis + 1:] == expected_shape[:axis] + expected_shape[axis + 1:],
+        lambda: f"Expected scale shape for scaled_upcast to match output shape on non-axis dims: "
+        f"{expected_shape}, but got {scale.type.shape}")
+    _check(
+        scale.type.shape[axis] > 0 and expected_shape[axis] % scale.type.shape[axis] == 0,
+        lambda: f"Expected output axis extent {expected_shape[axis]} to be divisible by scale axis extent "
+        f"{scale.type.shape[axis]}")
     _check(scale.dtype in {ttgl.int8, ttgl.uint8, ttgl.bfloat16},
            lambda: f"Unsupported scale dtype for fp4 scaled_upcast: {scale.dtype}")
 

--- a/python/triton/experimental/gluon/language/amd/gfx1250/__init__.py
+++ b/python/triton/experimental/gluon/language/amd/gfx1250/__init__.py
@@ -113,11 +113,15 @@ def scaled_upcast(src, scale, elem_type, axis=None, _semantic=None):
     Upcast an fp4 or fp8 tensor and fold raw E8M0 scale payload into the
     GFX1250 scaled-upcast op.
 
-    The scale tensor must use raw E8M0 payload in `int8` or `uint8`, and must
-    already have the expanded output shape and scaled-upcast result layout.
-    For fp4 inputs, that is the canonical unpacked layout implied by `src`
-    and `axis`. `elem_type` must be `fp16` or `bf16`. GFX1250 keeps those
-    bytes in the native `cvt.scale.pk8` payload form.
+    The scale tensor must use raw E8M0 payload in `int8` or `uint8`.
+    For fp8, scale shape/layout match `src`.
+    For fp4, expanded or compact scales are supported along `axis` dimension.
+    Expanded scales are broadcasted to one scale value per upcast output value,
+    e.g. fp4 bytes `[M, K / 2]` -> output `[M, K]` with scale `[M, K]`.
+    Compact scales keep one scale value per native scale block, e.g. output
+    `[M, K]` with `axis=1` and scale block 32 uses scale `[M, K / 32]`.
+    `elem_type` must be `fp16` or `bf16`. GFX1250 keeps those bytes in the native
+    `cvt.scale.pk8` payload form.
     """
     axis = _unwrap_if_constexpr(axis)
     elem_type = _unwrap_if_constexpr(elem_type)

--- a/test/TritonGPU/amd/amd-scaled-upcast-gfx1250.mlir
+++ b/test/TritonGPU/amd/amd-scaled-upcast-gfx1250.mlir
@@ -6,38 +6,17 @@
 #mma = #ttg.amd_wmma<{version = 3, ctaLayout = {warp = [[0, 1], [1, 0]]}, isTranspose = true, instrShape = [16, 16, 32]}>
 module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.target = "hip:gfx1250", "ttg.threads-per-warp" = 32 : i32} {
   tt.func public @wmma_dot_scaled_mxfp8_bf16(%arg0: tensor<32x128xf8E4M3FN, #blocked>, %arg1: tensor<32x128xi8, #blocked>, %arg2: tensor<32x128x!tt.ptr<bf16>, #blocked>) {
-    // CHECK: %[[SCALE:.*]] = llvm.extractvalue %arg1[0] : !llvm.struct<(i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8)>
-    // CHECK: %[[SCALE_1:.*]] = llvm.extractvalue %arg1[8] : !llvm.struct<(i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8)>
-    // CHECK: %[[SCALE_2:.*]] = llvm.extractvalue %arg1[16] : !llvm.struct<(i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8)>
-    // CHECK: %[[SCALE_3:.*]] = llvm.extractvalue %arg1[24] : !llvm.struct<(i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8)>
-
-    // CHECK: llvm.insertelement %[[SCALE]], {{.*}} : vector<4xi8>
-    // CHECK: llvm.insertelement %[[SCALE]], {{.*}} : vector<4xi8>
-    // CHECK: llvm.insertelement %[[SCALE]], {{.*}} : vector<4xi8>
-    // CHECK: %[[V0:.*]] = llvm.insertelement %[[SCALE]], {{.*}} : vector<4xi8>
-    // CHECK: %[[SCALE_INT32:.*]] = llvm.bitcast %[[V0]] : vector<4xi8> to i32
-    // CHECK: rocdl.cvt.scale.pk8.bf16.fp8 {{.*}}, %[[SCALE_INT32]][0] : vector<8xbf16>
-
-    // CHECK: llvm.insertelement %[[SCALE_1]], {{.*}} : vector<4xi8>
-    // CHECK: llvm.insertelement %[[SCALE_1]], {{.*}} : vector<4xi8>
-    // CHECK: llvm.insertelement %[[SCALE_1]], {{.*}} : vector<4xi8>
-    // CHECK: %[[V1:.*]] = llvm.insertelement %[[SCALE_1]], {{.*}} : vector<4xi8>
-    // CHECK: %[[SCALE_INT32_1:.*]] = llvm.bitcast %[[V1]] : vector<4xi8> to i32
-    // CHECK: rocdl.cvt.scale.pk8.bf16.fp8 {{.*}}, %[[SCALE_INT32_1]][0] : vector<8xbf16>
-
-    // CHECK: llvm.insertelement %[[SCALE_2]], {{.*}} : vector<4xi8>
-    // CHECK: llvm.insertelement %[[SCALE_2]], {{.*}} : vector<4xi8>
-    // CHECK: llvm.insertelement %[[SCALE_2]], {{.*}} : vector<4xi8>
-    // CHECK: %[[V2:.*]] = llvm.insertelement %[[SCALE_2]], {{.*}} : vector<4xi8>
-    // CHECK: %[[SCALE_INT32_2:.*]] = llvm.bitcast %[[V2]] : vector<4xi8> to i32
-    // CHECK: rocdl.cvt.scale.pk8.bf16.fp8 {{.*}}, %[[SCALE_INT32_2]][0] : vector<8xbf16>
-
-    // CHECK: llvm.insertelement %[[SCALE_3]], {{.*}} : vector<4xi8>
-    // CHECK: llvm.insertelement %[[SCALE_3]], {{.*}} : vector<4xi8>
-    // CHECK: llvm.insertelement %[[SCALE_3]], {{.*}} : vector<4xi8>
-    // CHECK: %[[V3:.*]] = llvm.insertelement %[[SCALE_3]], {{.*}} : vector<4xi8>
-    // CHECK: %[[SCALE_INT32_3:.*]] = llvm.bitcast %[[V3]] : vector<4xi8> to i32
-    // CHECK: rocdl.cvt.scale.pk8.bf16.fp8 {{.*}}, %[[SCALE_INT32_3]][0] : vector<8xbf16>
+    // Non-broadcast scale layouts use FP8 Block16 mode (opSel=8): byte 0 feeds
+    // lanes 0..15 and byte 1 feeds lanes 16..31. Byte 1 is lane (j^16)'s scale,
+    // gathered via permlanex16.
+    // CHECK: %[[S:.+]] = llvm.extractvalue %arg1[0] : !llvm.struct
+    // CHECK: %[[Z:.+]] = llvm.zext %[[S]] : i8 to i32
+    // CHECK: %[[P:.+]] = rocdl.permlanex16 %[[Z]], %[[Z]], {{.*}}, true, false : i32, i32
+    // CHECK: %[[X:.+]] = llvm.trunc %[[P]] : i32 to i8
+    // CHECK: %[[V0:.+]] = llvm.insertelement %[[S]], %{{.+}}[%{{.+}} : i32] : vector<4xi8>
+    // CHECK: %[[V1:.+]] = llvm.insertelement %[[X]], %[[V0]][%{{.+}} : i32] : vector<4xi8>
+    // CHECK: %[[SI:.+]] = llvm.bitcast %[[V1]] : vector<4xi8> to i32
+    // CHECK: rocdl.cvt.scale.pk8.bf16.fp8 %{{.+}}, %[[SI]][8] : vector<8xbf16>
     %7 = amdg.scaled_upcast_fp8 %arg0 scale %arg1 : tensor<32x128xf8E4M3FN, #blocked>, tensor<32x128xi8, #blocked> -> tensor<32x128xbf16, #blocked>
     tt.store %arg2, %7 : tensor<32x128x!tt.ptr<bf16>, #blocked>
     tt.return
@@ -52,41 +31,70 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.targ
 #smem = #ttg.shared_memory
 module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.shared = 2048 : i32, ttg.target = "hip:gfx1250", "ttg.threads-per-warp" = 32 : i32} {
   tt.func public @cvt_scale_pk8_bf16_fp4(%output: tensor<16x64x!tt.ptr<bf16>, #ttg.dot_op<{opIdx = 0, parent = #mma, kWidth = 8}>>, %15: tensor<16x32xi8, #ttg.dot_op<{opIdx = 0, parent = #mma, kWidth = 4}>>, %27: tensor<16x64xi8, #ttg.dot_op<{opIdx = 0, parent = #mma, kWidth = 8}>>) attributes {noinline = false} {
-    // CHECK: %[[SCALE:.*]] = llvm.extractvalue %arg2[0] : !llvm.struct<(i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8)>
-    // CHECK: %[[SCALE_1:.*]] = llvm.extractvalue %arg2[8] : !llvm.struct<(i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8)>
-    // CHECK: %[[SCALE_2:.*]] = llvm.extractvalue %arg2[16] : !llvm.struct<(i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8)>
-    // CHECK: %[[SCALE_3:.*]] = llvm.extractvalue %arg2[24] : !llvm.struct<(i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8)>
-
-    // CHECK: llvm.insertelement %[[SCALE]], {{.*}} : vector<4xi8>
-    // CHECK: llvm.insertelement %[[SCALE]], {{.*}} : vector<4xi8>
-    // CHECK: llvm.insertelement %[[SCALE]], {{.*}} : vector<4xi8>
-    // CHECK: %[[V0:.*]] = llvm.insertelement %[[SCALE]], {{.*}} : vector<4xi8>
-    // CHECK: %[[SCALE_INT32:.*]] = llvm.bitcast %[[V0]] : vector<4xi8> to i32
-    // CHECK: rocdl.cvt.scale.pk8.bf16.fp4 {{.*}}, %[[SCALE_INT32]][0] : vector<8xbf16>
-
-    // CHECK: llvm.insertelement %[[SCALE_1]], {{.*}} : vector<4xi8>
-    // CHECK: llvm.insertelement %[[SCALE_1]], {{.*}} : vector<4xi8>
-    // CHECK: llvm.insertelement %[[SCALE_1]], {{.*}} : vector<4xi8>
-    // CHECK: %[[V1:.*]] = llvm.insertelement %[[SCALE_1]], {{.*}} : vector<4xi8>
-    // CHECK: %[[SCALE_INT32_1:.*]] = llvm.bitcast %[[V1]] : vector<4xi8> to i32
-    // CHECK: rocdl.cvt.scale.pk8.bf16.fp4 {{.*}}, %[[SCALE_INT32_1]][0] : vector<8xbf16>
-
-    // CHECK: llvm.insertelement %[[SCALE_2]], {{.*}} : vector<4xi8>
-    // CHECK: llvm.insertelement %[[SCALE_2]], {{.*}} : vector<4xi8>
-    // CHECK: llvm.insertelement %[[SCALE_2]], {{.*}} : vector<4xi8>
-    // CHECK: %[[V2:.*]] = llvm.insertelement %[[SCALE_2]], {{.*}} : vector<4xi8>
-    // CHECK: %[[SCALE_INT32_2:.*]] = llvm.bitcast %[[V2]] : vector<4xi8> to i32
-    // CHECK: rocdl.cvt.scale.pk8.bf16.fp4 {{.*}}, %[[SCALE_INT32_2]][0] : vector<8xbf16>
-
-    // CHECK: llvm.insertelement %[[SCALE_3]], {{.*}} : vector<4xi8>
-    // CHECK: llvm.insertelement %[[SCALE_3]], {{.*}} : vector<4xi8>
-    // CHECK: llvm.insertelement %[[SCALE_3]], {{.*}} : vector<4xi8>
-    // CHECK: %[[V3:.*]] = llvm.insertelement %[[SCALE_3]], {{.*}} : vector<4xi8>
-    // CHECK: %[[SCALE_INT32_3:.*]] = llvm.bitcast %[[V3]] : vector<4xi8> to i32
-    // CHECK: rocdl.cvt.scale.pk8.bf16.fp4 {{.*}}, %[[SCALE_INT32_3]][0] : vector<8xbf16>
+    // This scale layout is not broadcast across the lane^16 split, so the 4
+    // scale registers used by the emitted pk8 groups are exchanged cross-lane
+    // (permlanex16) to co-locate lane (j^16)'s scale into byte 1 for the upper
+    // output lanes.
+    // CHECK-COUNT-4: rocdl.permlanex16 {{.*}}, true, false : i32, i32
+    // CHECK-NOT: rocdl.permlanex16
+    // CHECK: rocdl.cvt.scale.pk8.bf16.fp4 {{.*}} : vector<8xbf16>
 
     %28 = amdg.scaled_upcast_fp4 %15 scale %27 {axis = 1 : i32} : tensor<16x32xi8, #ttg.dot_op<{opIdx = 0, parent = #mma, kWidth = 4}>>, tensor<16x64xi8, #ttg.dot_op<{opIdx = 0, parent = #mma, kWidth = 8}>> -> tensor<16x64xbf16, #ttg.dot_op<{opIdx = 0, parent = #mma, kWidth = 8}>>
     tt.store %output, %28 : tensor<16x64x!tt.ptr<bf16>, #ttg.dot_op<{opIdx = 0, parent = #mma, kWidth = 8}>>
+    tt.return
+  }
+}
+
+// -----
+
+// Compact scale: one E8M0 scale per 32 output elements along the K axis.
+#packed = #ttg.blocked<{sizePerThread = [1, 16], threadsPerWarp = [1, 32], warpsPerCTA = [1, 1], order = [1, 0]}>
+#unpacked = #ttg.blocked<{sizePerThread = [1, 32], threadsPerWarp = [1, 32], warpsPerCTA = [1, 1], order = [1, 0]}>
+#compact = #ttg.blocked<{sizePerThread = [1, 1], threadsPerWarp = [1, 32], warpsPerCTA = [1, 1], order = [1, 0]}>
+module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 1 : i32, ttg.target = "hip:gfx1250", "ttg.threads-per-warp" = 32 : i32} {
+  tt.func public @cvt_scale_pk8_bf16_fp4_compact(%output: tensor<1x1024x!tt.ptr<bf16>, #unpacked>, %x: tensor<1x512xi8, #packed>, %scale: tensor<1x32xi8, #compact>) {
+    // CHECK: rocdl.cvt.scale.pk8.bf16.fp4
+    %up = amdg.scaled_upcast_fp4 %x scale %scale {axis = 1 : i32} : tensor<1x512xi8, #packed>, tensor<1x32xi8, #compact> -> tensor<1x1024xbf16, #unpacked>
+    tt.store %output, %up : tensor<1x1024x!tt.ptr<bf16>, #unpacked>
+    tt.return
+  }
+}
+
+// -----
+
+#packed = #ttg.blocked<{sizePerThread = [1, 4], threadsPerWarp = [8, 4], warpsPerCTA = [1, 1], order = [1, 0]}>
+#unpacked = #ttg.blocked<{sizePerThread = [1, 8], threadsPerWarp = [8, 4], warpsPerCTA = [1, 1], order = [1, 0]}>
+#scale = #ttg.blocked<{sizePerThread = [1, 2], threadsPerWarp = [8, 4], warpsPerCTA = [1, 1], order = [1, 0]}>
+module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 1 : i32, ttg.target = "hip:gfx1250", "ttg.threads-per-warp" = 32 : i32} {
+  // CHECK-LABEL: llvm.func @cvt_scale_pk8_bf16_fp4_contig8
+  tt.func public @cvt_scale_pk8_bf16_fp4_contig8(%output: tensor<8x64x!tt.ptr<bf16>, #unpacked>, %x: tensor<8x32xi8, #packed>, %scale: tensor<8x2xi8, #scale>) {
+    // Two K blocks -> block 0 uses scale[0], block 1 uses scale[1].
+    // CHECK: %[[S0:.+]] = llvm.extractvalue %{{.+}}[0] : !llvm.struct<(i8, i8)>
+    // CHECK: %[[S1:.+]] = llvm.extractvalue %{{.+}}[1] : !llvm.struct<(i8, i8)>
+    // CHECK: llvm.insertelement %[[S0]]
+    // CHECK: rocdl.cvt.scale.pk8.bf16.fp4
+    // CHECK: llvm.insertelement %[[S1]]
+    // CHECK: rocdl.cvt.scale.pk8.bf16.fp4
+    %up = amdg.scaled_upcast_fp4 %x scale %scale {axis = 1 : i32} : tensor<8x32xi8, #packed>, tensor<8x2xi8, #scale> -> tensor<8x64xbf16, #unpacked>
+    tt.store %output, %up : tensor<8x64x!tt.ptr<bf16>, #unpacked>
+    tt.return
+  }
+}
+
+// -----
+
+#packed = #ttg.linear<{register = [[0, 1], [0, 2], [0, 8], [0, 4]], lane = [[1, 0], [2, 0], [4, 0], [8, 0], [16, 0]], warp = [], block = []}>
+#unpacked = #ttg.linear<{register = [[0, 1], [0, 2], [0, 4], [0, 16], [0, 8]], lane = [[1, 0], [2, 0], [4, 0], [8, 0], [16, 0]], warp = [], block = []}>
+#scale = #ttg.linear<{register = [[0, 1]], lane = [[1, 0], [2, 0], [4, 0], [8, 0], [16, 0]], warp = [], block = []}>
+module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 1 : i32, ttg.target = "hip:gfx1250", "ttg.threads-per-warp" = 32 : i32} {
+  // CHECK-LABEL: llvm.func @cvt_scale_pk8_bf16_fp4_interleaved
+  tt.func public @cvt_scale_pk8_bf16_fp4_interleaved(%output: tensor<32x32x!tt.ptr<bf16>, #unpacked>, %x: tensor<32x16xi8, #packed>, %scale: tensor<32x2xi8, #scale>) {
+    // CHECK: rocdl.cvt.scale.pk8.bf16.fp4 {{.*}}, %[[SI0:.+]][0] : vector<8xbf16>
+    // CHECK: rocdl.cvt.scale.pk8.bf16.fp4 {{.*}}, %[[SI1:.+]][0] : vector<8xbf16>
+    // CHECK: rocdl.cvt.scale.pk8.bf16.fp4 {{.*}}, %[[SI0]][0] : vector<8xbf16>
+    // CHECK: rocdl.cvt.scale.pk8.bf16.fp4 {{.*}}, %[[SI1]][0] : vector<8xbf16>
+    %up = amdg.scaled_upcast_fp4 %x scale %scale {axis = 1 : i32} : tensor<32x16xi8, #packed>, tensor<32x2xi8, #scale> -> tensor<32x32xbf16, #unpacked>
+    tt.store %output, %up : tensor<32x32x!tt.ptr<bf16>, #unpacked>
     tt.return
   }
 }

--- a/test/TritonGPU/amd/invalid.mlir
+++ b/test/TritonGPU/amd/invalid.mlir
@@ -481,7 +481,7 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 8 : i32, ttg.targ
 #fp4_scale_bad = #ttg.blocked<{sizePerThread = [1, 8], threadsPerWarp = [4, 16], warpsPerCTA = [1, 1], order = [1, 0]}>
 module attributes {"ttg.target" = "hip:gfx950", "ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 1 : i32, "ttg.threads-per-warp" = 64 : i32} {
   tt.func @scaled_upcast_fp4_incompatible_scale_encoding(%src: tensor<16x32xi8, #fp4_src>, %scale: tensor<16x64xbf16, #fp4_scale_bad>) {
-    // expected-error @+1 {{scale and output encodings are not compatible}}
+    // expected-error @+1 {{scale encoding is not compatible with the inferred scale layout}}
     %0 = amdg.scaled_upcast_fp4 %src scale %scale {axis = 1 : i32} : tensor<16x32xi8, #fp4_src>, tensor<16x64xbf16, #fp4_scale_bad> -> tensor<16x64xbf16, #fp4_dst>
     tt.return
   }
@@ -540,6 +540,21 @@ module attributes {"ttg.target" = "hip:gfx950", "ttg.num-ctas" = 1 : i32, "ttg.n
   tt.func @scaled_upcast_fp8_invalid_result_type(%src: tensor<16x64xf8E4M3FN, #blocked>, %scale: tensor<16x64xbf16, #blocked>) {
     // expected-error @+1 {{must be ranked tensor of 16-bit float or bfloat16 type values}}
     %0 = amdg.scaled_upcast_fp8 %src scale %scale : tensor<16x64xf8E4M3FN, #blocked>, tensor<16x64xbf16, #blocked> -> tensor<16x64xf32, #blocked>
+    tt.return
+  }
+}
+
+// -----
+
+// Compact scale where the scale layout does not match the value layout, so one
+// scale value spans multiple scale blocks.
+#packed = #ttg.linear<{register = [[0, 16], [0, 1], [0, 2], [0, 4], [0, 8]], lane = [[1, 0], [2, 0], [4, 0], [8, 0], [16, 0]], warp = [], block = []}>
+#unpacked = #ttg.linear<{register = [[0, 1], [0, 32], [0, 2], [0, 4], [0, 8], [0, 16]], lane = [[1, 0], [2, 0], [4, 0], [8, 0], [16, 0]], warp = [], block = []}>
+#scale = #ttg.linear<{register = [[0, 1]], lane = [[1, 0], [2, 0], [4, 0], [8, 0], [16, 0]], warp = [], block = []}>
+module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 1 : i32, ttg.target = "hip:gfx1250", "ttg.threads-per-warp" = 32 : i32} {
+  tt.func @scaled_upcast_fp4_pk8_group_straddles_scale_block(%x: tensor<32x32xi8, #packed>, %s: tensor<32x2xi8, #scale>) {
+    // expected-error @+1 {{the 8 elements of a v_cvt_scale_pk8 group would not share a single scale}}
+    %u = amdg.scaled_upcast_fp4 %x scale %s {axis = 1 : i32} : tensor<32x32xi8, #packed>, tensor<32x2xi8, #scale> -> tensor<32x64xbf16, #unpacked>
     tt.return
   }
 }
@@ -664,6 +679,62 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.targ
   ) {
     // expected-error @+1 {{is inconsistent with the shared memory allocation layout}}
     %token = amdg.async_tdm_copy_global_to_local %tensorDesc into %memDesc : !tt.tensordesc<64x64xf16, #load_desc> -> !ttg.memdesc<64x64xf16, #load_alloc, #smem, mutable>
+    tt.return
+  }
+}
+
+// -----
+
+// scaled_upcast_fp4: scale and output rank mismatch.
+module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 1 : i32, ttg.target = "hip:gfx1250", "ttg.threads-per-warp" = 32 : i32} {
+  tt.func @scaled_upcast_fp4_rank_mismatch(%x: tensor<16x32xi8>, %s: tensor<64xi8>) {
+    // expected-error @+1 {{scale and output must have the same rank}}
+    %u = amdg.scaled_upcast_fp4 %x scale %s {axis = 1 : i32} : tensor<16x32xi8>, tensor<64xi8> -> tensor<16x64xbf16>
+    tt.return
+  }
+}
+
+// -----
+
+// scaled_upcast_fp4: axis out of range for the tensor rank.
+module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 1 : i32, ttg.target = "hip:gfx1250", "ttg.threads-per-warp" = 32 : i32} {
+  tt.func @scaled_upcast_fp4_axis_out_of_range(%x: tensor<16x32xi8>, %s: tensor<16x64xi8>) {
+    // expected-error @+1 {{axis out of range: 2 for rank 2}}
+    %u = amdg.scaled_upcast_fp4 %x scale %s {axis = 2 : i32} : tensor<16x32xi8>, tensor<16x64xi8> -> tensor<16x64xbf16>
+    tt.return
+  }
+}
+
+// -----
+
+// scaled_upcast_fp4: scale and output differ on a non-scaled dimension.
+module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 1 : i32, ttg.target = "hip:gfx1250", "ttg.threads-per-warp" = 32 : i32} {
+  tt.func @scaled_upcast_fp4_non_axis_mismatch(%x: tensor<16x32xi8>, %s: tensor<8x64xi8>) {
+    // expected-error @+1 {{scale and output must match on non-axis dimensions}}
+    %u = amdg.scaled_upcast_fp4 %x scale %s {axis = 1 : i32} : tensor<16x32xi8>, tensor<8x64xi8> -> tensor<16x64xbf16>
+    tt.return
+  }
+}
+
+// -----
+
+// scaled_upcast_fp4: output axis extent not divisible by the scale axis extent.
+module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 1 : i32, ttg.target = "hip:gfx1250", "ttg.threads-per-warp" = 32 : i32} {
+  tt.func @scaled_upcast_fp4_axis_not_divisible(%x: tensor<16x32xi8>, %s: tensor<16x48xi8>) {
+    // expected-error @+1 {{expected output.shape[axis] to be divisible by scale.shape[axis]}}
+    %u = amdg.scaled_upcast_fp4 %x scale %s {axis = 1 : i32} : tensor<16x32xi8>, tensor<16x48xi8> -> tensor<16x64xbf16>
+    tt.return
+  }
+}
+
+// -----
+
+// scaled_upcast_fp4: scale carries an encoding but the output does not.
+#enc = #ttg.blocked<{sizePerThread = [1, 8], threadsPerWarp = [8, 4], warpsPerCTA = [1, 1], order = [1, 0]}>
+module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 1 : i32, ttg.target = "hip:gfx1250", "ttg.threads-per-warp" = 32 : i32} {
+  tt.func @scaled_upcast_fp4_one_sided_encoding(%x: tensor<16x32xi8>, %s: tensor<16x64xi8, #enc>) {
+    // expected-error @+1 {{scale and output must both have an encoding, or neither}}
+    %u = amdg.scaled_upcast_fp4 %x scale %s {axis = 1 : i32} : tensor<16x32xi8>, tensor<16x64xi8, #enc> -> tensor<16x64xbf16>
     tt.return
   }
 }

--- a/third_party/amd/include/Dialect/TritonAMDGPU/IR/TritonAMDGPUOps.td
+++ b/third_party/amd/include/Dialect/TritonAMDGPU/IR/TritonAMDGPUOps.td
@@ -584,6 +584,12 @@ def ScaledUpcastFp4Op : TT_AMDGPU_Op<"scaled_upcast_fp4", [Pure, DeclareOpInterf
         `:` type($input) `,` type($scale) `->` type($output)
   }];
 
+  let extraClassDeclaration = [{
+    static std::optional<mlir::triton::LinearLayout>
+    computeScaleLayout(const mlir::triton::LinearLayout &outputLayout,
+                       int64_t axis, int64_t elementsPerScale);
+  }];
+
   let hasVerifier = 1;
 }
 

--- a/third_party/amd/lib/Dialect/TritonAMDGPU/IR/Dialect.cpp
+++ b/third_party/amd/lib/Dialect/TritonAMDGPU/IR/Dialect.cpp
@@ -140,7 +140,167 @@ LogicalResult verifyTDMCommonLayout(Operation *op,
   return verifyTDMLayoutConsistency(op, descTy, smemTy);
 }
 
+// The v_cvt_scale_pk8 lowering upcasts 8 register-consecutive fp4 values with a
+// single scale, check that 8 elements in the scale layout are all broadcasts.
+bool pk8GroupSharesSingleScale(const LinearLayout &scaleLL,
+                               StringAttr kRegister) {
+  if (scaleLL.getInDimSizeLog2(kRegister) < 3)
+    return false;
+  auto outDims = llvm::to_vector(scaleLL.getOutDimNames());
+  return scaleLL.resizeInDim(kRegister, /*newSize=*/8)
+      .sublayoutIsZero({kRegister}, outDims);
+}
+
+// Validates the output/scale shape relationship and returns the number of
+// output elements each scale covers along the scaled axis (>= 1), or nullopt if
+// the shapes are incompatible. A block of 1 means the scales are expanded to
+// the output shape; anything larger means compact scales.
+std::optional<int64_t> scaledUpcastFp4ScaleBlock(ScaledUpcastFp4Op op) {
+  auto outputShape = op.getOutput().getType().getShape();
+  auto scaleShape = op.getScale().getType().getShape();
+  int64_t axis = op.getAxis();
+  if (axis < 0 || axis >= static_cast<int64_t>(outputShape.size()))
+    return std::nullopt;
+  if (outputShape.size() != scaleShape.size())
+    return std::nullopt;
+  int64_t outputAxis = outputShape[axis];
+  int64_t scaleAxis = scaleShape[axis];
+  if (scaleAxis <= 0 || outputAxis % scaleAxis != 0)
+    return std::nullopt;
+
+  return outputAxis / scaleAxis;
+}
+
+std::optional<LinearLayout>
+computeCompactScaleLayoutForOp(ScaledUpcastFp4Op op, Attribute outputEnc) {
+  auto scaleBlock = scaledUpcastFp4ScaleBlock(op);
+  if (!scaleBlock || *scaleBlock == 1)
+    return std::nullopt;
+  if (!outputEnc || !isa<gpu::LayoutEncodingTrait>(outputEnc))
+    return std::nullopt;
+  auto outputLL =
+      gpu::toLinearLayout(op.getOutput().getType().getShape(),
+                          cast<gpu::LayoutEncodingTrait>(outputEnc));
+  return ScaledUpcastFp4Op::computeScaleLayout(outputLL, op.getAxis(),
+                                               *scaleBlock);
+}
+
+std::optional<Attribute>
+inferScaledUpcastFp4ScaleEncoding(ScaledUpcastFp4Op op, Attribute outputEnc) {
+  auto scaleBlock = scaledUpcastFp4ScaleBlock(op);
+  if (!scaleBlock)
+    return std::nullopt;
+  // Expanded scales have the same axis extent as the output and reuse
+  // outputEnc.
+  if (*scaleBlock == 1)
+    return outputEnc;
+  // Compact scales: drop the broadcast register bases so the inferred layout
+  // keeps a single register per distinct scale value.
+  auto compact = computeCompactScaleLayoutForOp(op, outputEnc);
+  if (!compact)
+    return std::nullopt;
+
+  auto kRegister = StringAttr::get(outputEnc.getContext(), "register");
+  return gpu::LinearEncodingAttr::get(
+      outputEnc.getContext(), compact->removeZeroBasesAlongDim(kRegister));
+}
+
+LogicalResult verifyScaledUpcastFp4ScaleLayout(ScaledUpcastFp4Op op) {
+  RankedTensorType scaleTy = op.getScale().getType();
+  auto scaleEnc = scaleTy.getEncoding();
+  auto outputEnc = op.getOutput().getType().getEncoding();
+  if (!scaleEnc != !outputEnc)
+    return op.emitError()
+           << "scale and output must both have an encoding, or neither";
+  if (!scaleEnc)
+    return success();
+
+  // Reduce a scale encoding to one register per distinct scale, so the final
+  // comparison matches up to redundant register broadcasting (a thread may keep
+  // one register per distinct scale rather than replicating it across every
+  // output register it covers).
+  auto kRegister = StringAttr::get(op.getContext(), "register");
+  auto stripped = [&](Attribute enc) {
+    return mlir::triton::gpu::toLinearLayout(
+               scaleTy.getShape(), cast<gpu::LayoutEncodingTrait>(enc))
+        .removeZeroBasesAlongDim(kRegister);
+  };
+
+  std::optional<LinearLayout> expectedLL;
+  if (auto compact = computeCompactScaleLayoutForOp(op, outputEnc)) {
+    // Compact scales: the 8 register-consecutive fp4 of a v_cvt_scale_pk8 group
+    // must share a single scale; otherwise the lowering has no single held
+    // scale to apply to the group (e.g. a group that spans two scale blocks
+    // along the scaled axis, or one that crosses rows of a non-scaled dim).
+    if (!pk8GroupSharesSingleScale(*compact, kRegister))
+      return op.emitError()
+             << "the 8 elements of a v_cvt_scale_pk8 group would not share a "
+                "single scale; the scaled axis must place 8 register-"
+                "consecutive elements within one scale block";
+    expectedLL = compact->removeZeroBasesAlongDim(kRegister);
+  } else if (auto expectedEnc =
+                 inferScaledUpcastFp4ScaleEncoding(op, outputEnc)) {
+    // Expanded scales reuse the output encoding.
+    expectedLL = stripped(*expectedEnc);
+  } else {
+    return op.emitError() << "could not infer expected scale encoding";
+  }
+
+  if (stripped(scaleEnc) != *expectedLL)
+    return op.emitError()
+           << "scale encoding is not compatible with the inferred scale layout";
+  return success();
+}
+
 } // namespace
+
+// Derive the layout of a scale tensor from the upcast output layout. A compact
+// scale holds a single value per `elementsPerScale` consecutive output elements
+// along `axis`, so the scale that an output element at coordinate `k` needs is
+// `scale[..., k / elementsPerScale, ...]`, i.e. the output coordinate with its
+// low `log2(elementsPerScale)` bits dropped (right-shifted). Output positions
+// that fall inside the same scale tile map to the same scale and so collapse to
+// broadcast (zero) bases along the scaled axis. `elementsPerScale` must be a
+// power of two.
+std::optional<LinearLayout>
+ScaledUpcastFp4Op::computeScaleLayout(const LinearLayout &outputLayout,
+                                      int64_t axis, int64_t elementsPerScale) {
+  // For expanded scales the scale layout is the same as the output layout.
+  if (elementsPerScale == 1)
+    return outputLayout;
+  if (elementsPerScale <= 0 || !llvm::isPowerOf2_64(elementsPerScale))
+    return std::nullopt;
+
+  auto ctx = outputLayout.getOutDimNames().begin()->getContext();
+  auto axisDim = StringAttr::get(ctx, llvm::formatv("dim{0}", axis).str());
+
+  if (!outputLayout.hasOutDim(axisDim) ||
+      outputLayout.getOutDimSize(axisDim) % elementsPerScale != 0)
+    return std::nullopt;
+
+  // Build a `divisor` map from output coordinates to scale coordinates that
+  // floor-divides (right shift) the scaled axis by `elementsPerScale` and
+  // leaves every other dimension unchanged (identity).
+  LinearLayout scaleDivisor = LinearLayout::empty();
+  for (StringAttr outDim : outputLayout.getOutDimNames()) {
+    int32_t size = outputLayout.getOutDimSize(outDim);
+    if (outDim != axisDim) {
+      scaleDivisor *= LinearLayout::identity1D(size, outDim, outDim);
+      continue;
+    }
+
+    // floor-divide the scaled axis by elementsPerScale: drop the low
+    // log2(elementsPerScale) bits, shift the remaining bits down.
+    scaleDivisor *=
+        LinearLayout::zeros1D(elementsPerScale, outDim, outDim) *
+        LinearLayout::identity1D(size / elementsPerScale, outDim, outDim);
+  }
+
+  // Compose the divisor with the output layout to get the scale layout. For
+  // each input it yields the scale coordinate that the output element at that
+  // input needs.
+  return outputLayout.compose(scaleDivisor);
+}
 
 LogicalResult ExtractSliceOp::verify() {
   // Basic type/rank checks.
@@ -364,24 +524,32 @@ LogicalResult ScaledUpcastFp4Op::verify() {
   RankedTensorType inputTy = getInput().getType();
   RankedTensorType outputTy = getOutput().getType();
   RankedTensorType scaleTy = getScale().getType();
-  auto scaleEnc = scaleTy.getEncoding();
-  auto outputEnc = outputTy.getEncoding();
+  auto outputShape = outputTy.getShape();
+  auto scaleShape = scaleTy.getShape();
+  if (outputShape.size() != scaleShape.size())
+    return emitError() << "scale and output must have the same rank";
 
-  if (outputTy.getShape() != scaleTy.getShape())
-    return emitError() << "scale and output should have the same shape";
+  int64_t axis = getAxis();
+  int64_t rank = outputTy.getRank();
+  if (axis < 0 || axis >= rank)
+    return emitError() << "axis out of range: " << getAxis() << " for rank "
+                       << rank;
 
-  if (bool(scaleEnc) != bool(outputEnc))
-    return emitError()
-           << "scale and output must both have an encoding, or neither";
+  for (int64_t dim = 0; dim < rank; ++dim) {
+    if (dim == axis)
+      continue;
+    if (outputShape[dim] != scaleShape[dim])
+      return emitError()
+             << "scale and output must match on non-axis dimensions";
+  }
+  if (scaleShape[axis] <= 0 || outputShape[axis] % scaleShape[axis] != 0)
+    return emitError() << "expected output.shape[axis] to be divisible by "
+                          "scale.shape[axis], but got output["
+                       << axis << "]=" << outputShape[axis] << ", scale["
+                       << axis << "]=" << scaleShape[axis];
 
-  if (scaleEnc && !mlir::triton::gpu::areLayoutsEquivalent(
-                      outputTy.getShape(),
-                      cast<mlir::triton::gpu::LayoutEncodingTrait>(scaleEnc),
-                      cast<mlir::triton::gpu::LayoutEncodingTrait>(outputEnc)))
-    return emitError() << "scale and output encodings are not compatible:\n"
-                       << mlir::triton::gpu::toLinearLayout(outputTy).toString()
-                       << "\n"
-                       << mlir::triton::gpu::toLinearLayout(scaleTy).toString();
+  if (failed(verifyScaledUpcastFp4ScaleLayout(*this)))
+    return failure();
 
   return mlir::triton::gpu::Fp4ToFpOp::verifyFp4ToFp(*this, inputTy, outputTy,
                                                      getAxis());
@@ -389,9 +557,12 @@ LogicalResult ScaledUpcastFp4Op::verify() {
 
 Attribute ScaledUpcastFp4Op::inferDstEncoding(unsigned opIdx,
                                               Attribute srcEnc) {
-  // The layout of scale is the same as that of the result
-  if (opIdx == 1)
-    return srcEnc;
+  // The layout of scale is either identical to the output or a quotient along
+  // the scaled axis (compact scales).
+  if (opIdx == 1) {
+    auto scaleEnc = inferScaledUpcastFp4ScaleEncoding(*this, srcEnc);
+    return scaleEnc.value_or(Attribute());
+  }
   Attribute dstEnc;
   auto shape = getOutput().getType().getShape();
 
@@ -409,9 +580,12 @@ Attribute ScaledUpcastFp4Op::inferDstEncoding(unsigned opIdx,
 
 Attribute ScaledUpcastFp4Op::inferSrcEncoding(unsigned opIdx,
                                               Attribute dstEnc) {
-  // The layout of scale is the same as that of the result
-  if (opIdx == 1)
-    return dstEnc;
+  // The layout of scale is either identical to the output or a quotient along
+  // the scaled axis (compact scales).
+  if (opIdx == 1) {
+    auto scaleEnc = inferScaledUpcastFp4ScaleEncoding(*this, dstEnc);
+    return scaleEnc.value_or(Attribute());
+  }
   Attribute srcEnc;
   auto shape = getOutput().getType().getShape();
 

--- a/third_party/amd/lib/TritonAMDGPUDialectToLLVM/ScaledUpcastToLLVM.cpp
+++ b/third_party/amd/lib/TritonAMDGPUDialectToLLVM/ScaledUpcastToLLVM.cpp
@@ -16,6 +16,62 @@ using mlir::LLVM::AMD::upcast8xMxfp8fp4_HW;
 // TODO: using if-then-else to repalce ternary operator on template
 namespace {
 
+// For each v_cvt_scale_pk8 group of 8 fp4 (4 consecutive input bytes) that a
+// thread holds, return the index into the thread's scale registers of the scale
+// to apply to that group.
+SmallVector<int> computeFp4GroupScaleRegisters(amdgpu::ScaledUpcastFp4Op op,
+                                               int64_t numInputBytes) {
+  MLIRContext *ctx = op.getContext();
+  auto outTy = op.getType();
+  auto scaleTy = op.getScale().getType();
+  int64_t axis = op.getAxis();
+  int64_t elementsPerScale = outTy.getShape()[axis] / scaleTy.getShape()[axis];
+
+  LinearLayout outLL = triton::gpu::toLinearLayout(outTy);
+  LinearLayout scaleLL = triton::gpu::toLinearLayout(scaleTy);
+  auto kReg = StringAttr::get(ctx, "register");
+  auto kLane = StringAttr::get(ctx, "lane");
+  auto kWarp = StringAttr::get(ctx, "warp");
+  auto kBlock = StringAttr::get(ctx, "block");
+
+  auto outToScaleLL = amdgpu::ScaledUpcastFp4Op::computeScaleLayout(
+      outLL, axis, elementsPerScale);
+  assert(outToScaleLL && "expected valid scale layout after verifier");
+  LinearLayout outRegToScaleReg = outToScaleLL->invertAndCompose(scaleLL);
+
+  // One intrinsic spans 8 fp4 values
+  int64_t numGroups = (2 * numInputBytes) / 8;
+  SmallVector<int> groupScaleReg;
+  groupScaleReg.reserve(numGroups);
+  for (int g = 0; g < numGroups; ++g) {
+    auto scaleCoord =
+        outRegToScaleReg.apply({{kReg, static_cast<int32_t>(8 * g)},
+                                {kLane, 0},
+                                {kWarp, 0},
+                                {kBlock, 0}});
+    auto regIt = llvm::find_if(
+        scaleCoord, [&](const auto &dimVal) { return dimVal.first == kReg; });
+    assert(regIt != scaleCoord.end() && "scale register mapping missing");
+    groupScaleReg.push_back(regIt->second);
+  }
+  return groupScaleReg;
+}
+
+// Returns true if the scale layout gives lane `j` and lane `j^16` the same
+// scale value (i.e. the lane basis for the value-16 bit is all zeros). In that
+// case both output-lane halves of a v_cvt_scale_pk8 already share a scale.
+bool isScaleLane16Broadcast(RankedTensorType scaleTy) {
+  MLIRContext *ctx = scaleTy.getContext();
+  LinearLayout scaleLL = triton::gpu::toLinearLayout(scaleTy);
+  auto kLane = StringAttr::get(ctx, "lane");
+  // Lane value 16 corresponds to basis position log2(16) = 4.
+  constexpr int kLane16Pos = 4;
+  if (scaleLL.getInDimSizeLog2(kLane) <= kLane16Pos)
+    return true;
+  ArrayRef<int32_t> basis16 = scaleLL.getBasis(kLane, kLane16Pos);
+  return llvm::all_of(basis16, [](int32_t v) { return v == 0; });
+}
+
 struct ScaledUpcastFp4OpPattern
     : ConvertOpToLLVMPattern<amdgpu::ScaledUpcastFp4Op> {
 
@@ -41,19 +97,50 @@ struct ScaledUpcastFp4OpPattern
 
     auto b = TritonLLVMOpBuilder(loc, rewriter);
     if (targetInfo.supportsCvtPkScalePk8()) {
-      assert(scaleVals.size() == 2 * inputVals.size());
+      auto groupScaleReg =
+          computeFp4GroupScaleRegisters(upcastOp, inputVals.size());
+
+      // FP4/FP6 v_cvt_scale_pk8 with opSel=0 sources the scale for output
+      // lanes 16..31 from byte 1 of the *lower* 16 lanes' Vscale while output
+      // lanes 0..15 use byte 0. When the scale layout is not broadcast across
+      // the lane^16 split, lane j and lane j+16 carry different scales, so we
+      // must co-locate lane (j^16)'s scale into byte 1 of lane j via a
+      // cross-lane exchange. Broadcast (e.g. wmma) layouts already share the
+      // scale, so we skip the exchange there.
+      // TODO: we could also check if lane0 holds the scale lane16 requires to
+      // avoid the v_permlane16_swap.
+      bool broadcast = isScaleLane16Broadcast(upcastOp.getScale().getType());
+      SmallVector<Value> crossScaleVals(scaleVals.size());
+      auto getCrossScale = [&](int scaleIdx) -> Value {
+        if (broadcast)
+          return Value();
+        if (!crossScaleVals[scaleIdx]) {
+          Value s32 = b.zext(i32_ty, scaleVals[scaleIdx]);
+          // Will be lowered to v_permlane16_swap so it's quite cheap.
+          Value partner = targetInfo.shuffleXor(rewriter, loc, s32, 16);
+          crossScaleVals[scaleIdx] = b.trunc(i8_ty, partner);
+        }
+        return crossScaleVals[scaleIdx];
+      };
+
       for (int i = 0; i < inputVals.size(); i += 4) {
+        int scaleIdx = groupScaleReg[i / 4];
+        Value crossScale = getCrossScale(scaleIdx);
 
         const auto &converted =
             elemType.isF16()
                 ? upcast8xMxfp8fp4_HW<ROCDL::CvtPkScalePk8F16Fp4Op>(
-                      rewriter, loc, inputVals, i, scaleVals)
+                      rewriter, loc, inputVals, i, scaleVals, scaleIdx,
+                      crossScale)
                 : upcast8xMxfp8fp4_HW<ROCDL::CvtPkScalePk8Bf16Fp4Op>(
-                      rewriter, loc, inputVals, i, scaleVals);
+                      rewriter, loc, inputVals, i, scaleVals, scaleIdx,
+                      crossScale);
 
         results.append(converted.begin(), converted.end());
       }
     } else if (targetInfo.supportsHwScaledUpcast()) {
+      assert(scaleVals.size() == 2 * inputVals.size() &&
+             "compact fp4 scales are only supported on pk scale path");
       for (int i = 0; i < inputVals.size(); i += 4) {
         SmallVector<Value, 4> v4i32 =
             elemType.isF16()
@@ -70,6 +157,8 @@ struct ScaledUpcastFp4OpPattern
         }
       }
     } else {
+      assert(scaleVals.size() == 2 * inputVals.size() &&
+             "compact fp4 scales are only supported on pk scale path");
       // Software emulation: upcast fp4 via LUT, then multiply by scale.
       bool toFp16 = elemType.isF16();
       auto isaFamily = targetInfo.getISAFamily();
@@ -147,19 +236,38 @@ struct ScaledUpcastFp8OpPattern
     SmallVector<Value> results;
     results.reserve(inputVals.size());
     if (targetInfo.supportsCvtPkScalePk8()) {
+      // Broadcast layouts can use FP8 Block32 (opSel=0). Otherwise use Block16
+      // (opSel=8) and pack lane j^16's scale into byte 1.
+      bool broadcast = isScaleLane16Broadcast(upcastOp.getScale().getType());
+      SmallVector<Value> crossScaleVals(scaleVals.size());
+      auto getCrossScale = [&](int scaleIdx) -> Value {
+        if (broadcast)
+          return Value();
+        if (!crossScaleVals[scaleIdx]) {
+          Value s32 = b.zext(i32_ty, scaleVals[scaleIdx]);
+          Value partner = targetInfo.shuffleXor(rewriter, loc, s32, 16);
+          crossScaleVals[scaleIdx] = b.trunc(i8_ty, partner);
+        }
+        return crossScaleVals[scaleIdx];
+      };
       for (int i = 0; i < inputVals.size(); i += 8) {
+        Value crossScale = getCrossScale(i);
         const auto &converted =
             elemType.isF16()
                 ? (isa<Float8E4M3FNType>(fp8ElemType)
                        ? upcast8xMxfp8fp4_HW<ROCDL::CvtPkScalePk8F16Fp8Op>(
-                             rewriter, loc, inputVals, i, scaleVals)
+                             rewriter, loc, inputVals, i, scaleVals, i,
+                             crossScale)
                        : upcast8xMxfp8fp4_HW<ROCDL::CvtPkScalePk8F16Bf8Op>(
-                             rewriter, loc, inputVals, i, scaleVals))
+                             rewriter, loc, inputVals, i, scaleVals, i,
+                             crossScale))
                 : (isa<Float8E4M3FNType>(fp8ElemType)
                        ? upcast8xMxfp8fp4_HW<ROCDL::CvtPkScalePk8Bf16Fp8Op>(
-                             rewriter, loc, inputVals, i, scaleVals)
+                             rewriter, loc, inputVals, i, scaleVals, i,
+                             crossScale)
                        : upcast8xMxfp8fp4_HW<ROCDL::CvtPkScalePk8Bf16Bf8Op>(
-                             rewriter, loc, inputVals, i, scaleVals));
+                             rewriter, loc, inputVals, i, scaleVals, i,
+                             crossScale));
 
         results.append(converted.begin(), converted.end());
       }

--- a/third_party/amd/lib/TritonAMDGPUToLLVM/Utility.h
+++ b/third_party/amd/lib/TritonAMDGPUToLLVM/Utility.h
@@ -234,21 +234,18 @@ upcast4xMxfp8_HW(RewriterBase &rewriter, Location loc, ArrayRef<Value> xVals,
 //
 // 3) for `opSel` used in the rocdl.cvt.scale.pk8
 //
-// From the SP guide, the `opSel` is defined as:
+// Scale selection for v_cvt_scale_pk8 is driven by opSel and four Vscale bytes.
+// For the modes used here, byte 0 holds the local lane's scale. For F4/F6
+// opSel=0, lanes 0..15 read byte 0 and lanes 16..31 read byte 1, so
+// crossLaneScale (when present) is packed into byte 1. For F8, opSel=0 uses
+// byte 0 for both lane halves when the scale layout is lane^16-broadcast;
+// otherwise opSel=8 selects Block16 mode and byte 1 supplies the lane^16 scale.
 //
-// OPSEL[0:2]  |  Lane0..15 of SRC0         | Lane16..31 of SRC0
-// -----------------------------------------------------------
-// 000         |  Lane0..15 of Vscale[7:0]  | <-- same
-//
-// which means if OPSEL is zero, hardware requires every lane and lane+16 share
-// the same scale. In the meantime, as comments for parameter `inputVals`,
-// `lane` and `lane+16` hold one row of input tile,
-//
-// In the end, `opSel` is zero.
 template <typename ConvertOp>
 SmallVector<Value, 8> upcast8xMxfp8fp4_HW(RewriterBase &rewriter, Location loc,
                                           ArrayRef<Value> inputVals, int idx,
-                                          ArrayRef<Value> scales) {
+                                          ArrayRef<Value> scales, int scaleIdx,
+                                          Value crossLaneScale = Value()) {
   auto b = TritonLLVMOpBuilder(loc, rewriter);
 
   bool toFp16 = (std::is_same_v<ConvertOp, ROCDL::CvtPkScalePk8F16Fp8Op> ||
@@ -268,15 +265,18 @@ SmallVector<Value, 8> upcast8xMxfp8fp4_HW(RewriterBase &rewriter, Location loc,
       fromFP4 ? b.bitcast(packedVec, i32_ty)
               : b.bitcast(packedVec, vec_ty(i32_ty, packedSize / sizeof(int)));
 
+  assert(scaleIdx >= 0 && scaleIdx < static_cast<int>(scales.size()));
+  Value localScale = scales[scaleIdx];
+  Value partnerScale = crossLaneScale ? crossLaneScale : localScale;
+  unsigned scaleSel = !fromFP4 && crossLaneScale ? 8 : 0;
   Value packedScale = b.undef(vec_ty(i8_ty, 4));
-  auto scaleIdx = fromFP4 ? (idx + idx) : idx;
-  for (int ii : llvm::seq(4))
-    packedScale =
-        b.insert_element(packedScale, scales[scaleIdx], b.i32_val(ii));
+  packedScale = b.insert_element(packedScale, localScale, b.i32_val(0));
+  if (fromFP4 || crossLaneScale)
+    packedScale = b.insert_element(packedScale, partnerScale, b.i32_val(1));
   Value scaleInt32 = b.bitcast(packedScale, i32_ty);
-  auto res = ConvertOp::create(rewriter, loc, resType, packedVec, scaleInt32,
-                               /*opSel*/ 0)
-                 .getRes();
+  auto res =
+      ConvertOp::create(rewriter, loc, resType, packedVec, scaleInt32, scaleSel)
+          .getRes();
   Value elements = b.bitcast(res, vec_ty(resElemType, 8));
 
   SmallVector<Value, 8> results;

--- a/third_party/amd/python/test/test_gluon_gfx1250.py
+++ b/third_party/amd/python/test/test_gluon_gfx1250.py
@@ -135,11 +135,18 @@ def test_compile_gemm(a_dtype, b_dtype, k_dim, BLOCK_M, BLOCK_N, BLOCK_K):
 
 
 @pytest.mark.skipif(not is_hip_gfx1250(), reason="Requires GFX1250")
-def test_runtime_scaled_upcast_fp4():
+@pytest.mark.parametrize("compact_scale", [
+    False,
+    True,
+], ids=["expanded_scale", "compact_scale"])
+@pytest.mark.parametrize("BLOCK_K", [64, 128, 256], ids=lambda v: f"BLOCK_K{v}")
+def test_runtime_scaled_upcast_fp4(compact_scale, BLOCK_K):
 
     @gluon.jit
-    def scaled_upcast_fp4_kernel(x_ptr, scale_ptr, y_ptr, BLOCK_M: ttgl.constexpr, BLOCK_K: ttgl.constexpr):
+    def scaled_upcast_fp4_kernel(x_ptr, scale_ptr, y_ptr, BLOCK_M: ttgl.constexpr, BLOCK_K: ttgl.constexpr,
+                                 SCALE_FACTOR: ttgl.constexpr, COMPACT_SCALE: ttgl.constexpr):
         packed_layout: ttgl.constexpr = ttgl.BlockedLayout([1, 4], [8, 4], [4, 1], [1, 0])
+        compact_layout: ttgl.constexpr = ttgl.BlockedLayout([1, BLOCK_K // SCALE_FACTOR], [8, 4], [4, 1], [1, 0])
         unpacked_layout: ttgl.constexpr = ttgl.BlockedLayout([1, 8], [8, 4], [4, 1], [1, 0])
 
         offs_m = ttgl.arange(0, BLOCK_M, layout=ttgl.SliceLayout(1, packed_layout))
@@ -147,25 +154,94 @@ def test_runtime_scaled_upcast_fp4():
         x_offsets = offs_m[:, None] * (BLOCK_K // 2) + offs_k_packed[None, :]
         x = ttgl.load(x_ptr + x_offsets)
 
-        offs_scale_m = ttgl.arange(0, BLOCK_M, layout=ttgl.SliceLayout(1, unpacked_layout))
-        offs_scale_k = ttgl.arange(0, BLOCK_K, layout=ttgl.SliceLayout(0, unpacked_layout))
-        scale_offsets = offs_scale_m[:, None] * BLOCK_K + offs_scale_k[None, :]
+        if COMPACT_SCALE:
+            scale_layout: ttgl.constexpr = compact_layout
+            scale_k: ttgl.constexpr = BLOCK_K // SCALE_FACTOR
+        else:
+            scale_layout: ttgl.constexpr = unpacked_layout
+            scale_k: ttgl.constexpr = BLOCK_K
+        offs_scale_m = ttgl.arange(0, BLOCK_M, layout=ttgl.SliceLayout(1, scale_layout))
+        offs_scale_k = ttgl.arange(0, scale_k, layout=ttgl.SliceLayout(0, scale_layout))
+        scale_offsets = offs_scale_m[:, None] * scale_k + offs_scale_k[None, :]
         scale = ttgl.load(scale_ptr + scale_offsets)
 
         y = ttgl.amd.gfx1250.scaled_upcast(x, scale, ttgl.bfloat16, axis=1)
-        ttgl.store(y_ptr + scale_offsets, y)
+        out_layout: ttgl.constexpr = y.type.layout
+        offs_out_m = ttgl.arange(0, BLOCK_M, layout=ttgl.SliceLayout(1, out_layout))
+        offs_out_k = ttgl.arange(0, BLOCK_K, layout=ttgl.SliceLayout(0, out_layout))
+        out_offsets = offs_out_m[:, None] * BLOCK_K + offs_out_k[None, :]
+        ttgl.store(y_ptr + out_offsets, y)
 
     BLOCK_M = 16
-    BLOCK_K = 64
     SCALE_FACTOR = 32
     torch.manual_seed(42)
 
     x, x_ref = create_mxfp_operand(0, BLOCK_M, BLOCK_K, "e2m1")
     scale, scale_ref = create_mxfp_scale(0, BLOCK_M, BLOCK_K, "e8m0", SCALE_FACTOR)
-    scale = scale.repeat_interleave(SCALE_FACTOR, dim=1).contiguous()
+    if not compact_scale:
+        scale = scale.repeat_interleave(SCALE_FACTOR, dim=1).contiguous()
     y = torch.empty((BLOCK_M, BLOCK_K), dtype=torch.bfloat16, device="cuda")
 
-    pgm = scaled_upcast_fp4_kernel[(1, )](x.cuda(), scale.cuda(), y, BLOCK_M, BLOCK_K, num_warps=4)
+    pgm = scaled_upcast_fp4_kernel[(1, )](x.cuda(), scale.cuda(), y, BLOCK_M, BLOCK_K, SCALE_FACTOR, compact_scale,
+                                          num_warps=4)
+
+    assert pgm.asm["amdgcn"].count("v_cvt_scale_pk8_bf16_fp4") == BLOCK_K // 32
+    y_ref = (x_ref * scale_ref).to(torch.bfloat16)
+    torch.testing.assert_close(y.cpu(), y_ref, atol=0, rtol=0)
+
+
+@pytest.mark.skipif(not is_hip_gfx1250(), reason="Requires GFX1250")
+def test_runtime_scaled_upcast_fp4_bf16_gemm_layouts():
+    # Test packed / compact-scale DistributedLinearLayouts used when upcasting an fp4 weight tile to bf16 for a WMMA GEMM.
+    @gluon.jit
+    def scaled_upcast_fp4_bf16_gemm_kernel(x_ptr, scale_ptr, y_ptr, BLOCK_N: ttgl.constexpr, BLOCK_K: ttgl.constexpr,
+                                           SCALE_FACTOR: ttgl.constexpr):
+        packed_layout: ttgl.constexpr = ttgl.DistributedLinearLayout(
+            reg_bases=[[0, 1], [0, 2], [0, 8], [0, 16], [0, 32], [0, 64], [0, 128], [64, 0]],
+            lane_bases=[[1, 0], [2, 0], [4, 0], [8, 0], [0, 4]],
+            warp_bases=[[16, 0], [32, 0]],
+            block_bases=[],
+            shape=[BLOCK_N, BLOCK_K // 2],
+        )
+        compact_scale_layout: ttgl.constexpr = ttgl.DistributedLinearLayout(
+            reg_bases=[[0, 1], [0, 2], [0, 4], [0, 8], [64, 0]],
+            lane_bases=[[1, 0], [2, 0], [4, 0], [8, 0], [0, 0]],
+            warp_bases=[[16, 0], [32, 0]],
+            block_bases=[],
+            shape=[BLOCK_N, BLOCK_K // SCALE_FACTOR],
+        )
+
+        offs_n = ttgl.arange(0, BLOCK_N, layout=ttgl.SliceLayout(1, packed_layout))
+        offs_k_packed = ttgl.arange(0, BLOCK_K // 2, layout=ttgl.SliceLayout(0, packed_layout))
+        x_offsets = offs_n[:, None] * (BLOCK_K // 2) + offs_k_packed[None, :]
+        x = ttgl.load(x_ptr + x_offsets)
+
+        scale_k: ttgl.constexpr = BLOCK_K // SCALE_FACTOR
+        offs_scale_n = ttgl.arange(0, BLOCK_N, layout=ttgl.SliceLayout(1, compact_scale_layout))
+        offs_scale_k = ttgl.arange(0, scale_k, layout=ttgl.SliceLayout(0, compact_scale_layout))
+        scale_offsets = offs_scale_n[:, None] * scale_k + offs_scale_k[None, :]
+        scale = ttgl.load(scale_ptr + scale_offsets)
+
+        y = ttgl.amd.gfx1250.scaled_upcast(x, scale, ttgl.bfloat16, axis=1)
+        out_layout: ttgl.constexpr = y.type.layout
+        offs_out_n = ttgl.arange(0, BLOCK_N, layout=ttgl.SliceLayout(1, out_layout))
+        offs_out_k = ttgl.arange(0, BLOCK_K, layout=ttgl.SliceLayout(0, out_layout))
+        out_offsets = offs_out_n[:, None] * BLOCK_K + offs_out_k[None, :]
+        ttgl.store(y_ptr + out_offsets, y)
+
+    # Shapes match a typical fp4 weight tile: packed [128, 256] i8 == [128, 512] fp4,
+    # compact scale [128, 16] (one e8m0 per 32 elements along K).
+    BLOCK_N = 128
+    BLOCK_K = 512
+    SCALE_FACTOR = 32
+    torch.manual_seed(42)
+
+    x, x_ref = create_mxfp_operand(0, BLOCK_N, BLOCK_K, "e2m1")
+    scale, scale_ref = create_mxfp_scale(0, BLOCK_N, BLOCK_K, "e8m0", SCALE_FACTOR)
+    y = torch.empty((BLOCK_N, BLOCK_K), dtype=torch.bfloat16, device="cuda")
+
+    pgm = scaled_upcast_fp4_bf16_gemm_kernel[(1, )](x.cuda(), scale.cuda(), y, BLOCK_N, BLOCK_K, SCALE_FACTOR,
+                                                    num_warps=4)
 
     assert "v_cvt_scale_pk8_bf16_fp4" in pgm.asm["amdgcn"]
     y_ref = (x_ref * scale_ref).to(torch.bfloat16)
@@ -173,11 +249,72 @@ def test_runtime_scaled_upcast_fp4():
 
 
 @pytest.mark.skipif(not is_hip_gfx1250(), reason="Requires GFX1250")
-def test_runtime_scaled_upcast_fp8():
+@pytest.mark.parametrize("fp8_dtype", ["e4m3", "e5m2"])
+@pytest.mark.parametrize("out_dtype", ["bf16", "f16"], ids=lambda v: f"out_{v}")
+def test_runtime_scaled_upcast_fp8(fp8_dtype, out_dtype):
+    # Cover all four v_cvt_scale_pk8 fp8 instructions: {bf16,f16} output x
+    # {fp8 (e4m3), bf8 (e5m2)} input.
+    torch_fp8 = {"e4m3": torch.float8_e4m3fn, "e5m2": torch.float8_e5m2}[fp8_dtype]
+    ttgl_out = {"bf16": ttgl.bfloat16, "f16": ttgl.float16}[out_dtype]
+    torch_out = {"bf16": torch.bfloat16, "f16": torch.float16}[out_dtype]
+    in_mnemonic = {"e4m3": "fp8", "e5m2": "bf8"}[fp8_dtype]
+
+    @gluon.jit
+    def scaled_upcast_fp8_kernel(x_ptr, scale_ptr, y_ptr, BLOCK_M: ttgl.constexpr, BLOCK_K: ttgl.constexpr,
+                                 OUT_DTYPE: ttgl.constexpr):
+        # FP8 v_cvt_scale_pk8 (opSel=0) reads the same Vscale byte for both
+        # output-lane halves, so it requires a scale layout that is broadcast
+        # across the lane^16 split (lane_bases[4] = [0, 0]).
+        layout: ttgl.constexpr = ttgl.DistributedLinearLayout(
+            reg_bases=[[0, 1], [0, 2], [0, 4], [0, 8], [0, 16], [0, 32]],
+            lane_bases=[[1, 0], [2, 0], [4, 0], [8, 0], [0, 0]],
+            warp_bases=[],
+            block_bases=[],
+            shape=[BLOCK_M, BLOCK_K],
+        )
+
+        offs_m = ttgl.arange(0, BLOCK_M, layout=ttgl.SliceLayout(1, layout))
+        offs_k = ttgl.arange(0, BLOCK_K, layout=ttgl.SliceLayout(0, layout))
+        offsets = offs_m[:, None] * BLOCK_K + offs_k[None, :]
+        x = ttgl.load(x_ptr + offsets)
+        scale = ttgl.load(scale_ptr + offsets)
+
+        y = ttgl.amd.gfx1250.scaled_upcast(x, scale, OUT_DTYPE)
+        ttgl.store(y_ptr + offsets, y)
+
+    BLOCK_M = 16
+    BLOCK_K = 64
+    SCALE_FACTOR = 32
+    torch.manual_seed(42)
+
+    x, x_ref = create_mxfp_operand(0, BLOCK_M, BLOCK_K, fp8_dtype)
+    x = x.view(torch_fp8)
+    scale, scale_ref = create_mxfp_scale(0, BLOCK_M, BLOCK_K, "e8m0", SCALE_FACTOR)
+    scale = scale.repeat_interleave(SCALE_FACTOR, dim=1).contiguous()
+    y = torch.empty((BLOCK_M, BLOCK_K), dtype=torch_out, device="cuda")
+
+    pgm = scaled_upcast_fp8_kernel[(1, )](x.cuda(), scale.cuda(), y, BLOCK_M, BLOCK_K, ttgl_out, num_warps=1)
+
+    assert f"v_cvt_scale_pk8_{out_dtype}_{in_mnemonic}" in pgm.asm["amdgcn"]
+    y_ref = (x_ref * scale_ref).to(torch_out)
+    torch.testing.assert_close(y.cpu(), y_ref, atol=0, rtol=0)
+
+
+@pytest.mark.skipif(not is_hip_gfx1250(), reason="Requires GFX1250")
+def test_runtime_scaled_upcast_fp8_non_broadcast_block16():
 
     @gluon.jit
     def scaled_upcast_fp8_kernel(x_ptr, scale_ptr, y_ptr, BLOCK_M: ttgl.constexpr, BLOCK_K: ttgl.constexpr):
-        layout: ttgl.constexpr = ttgl.BlockedLayout([1, 8], [8, 4], [4, 1], [1, 0])
+        # This layout is not broadcast across lane^16 (lane_bases[4] = [16, 0]).
+        # FP8 lowering uses v_cvt_scale_pk8 Block16 mode (opSel=8) and packs
+        # lane (j^16)'s scale into byte 1 via a cross-lane exchange.
+        layout: ttgl.constexpr = ttgl.DistributedLinearLayout(
+            reg_bases=[[0, 1], [0, 2], [0, 4], [0, 8], [0, 16], [0, 32]],
+            lane_bases=[[1, 0], [2, 0], [4, 0], [8, 0], [16, 0]],
+            warp_bases=[],
+            block_bases=[],
+            shape=[BLOCK_M, BLOCK_K],
+        )
 
         offs_m = ttgl.arange(0, BLOCK_M, layout=ttgl.SliceLayout(1, layout))
         offs_k = ttgl.arange(0, BLOCK_K, layout=ttgl.SliceLayout(0, layout))
@@ -188,7 +325,7 @@ def test_runtime_scaled_upcast_fp8():
         y = ttgl.amd.gfx1250.scaled_upcast(x, scale, ttgl.bfloat16)
         ttgl.store(y_ptr + offsets, y)
 
-    BLOCK_M = 16
+    BLOCK_M = 32
     BLOCK_K = 64
     SCALE_FACTOR = 32
     torch.manual_seed(42)
@@ -199,7 +336,7 @@ def test_runtime_scaled_upcast_fp8():
     scale = scale.repeat_interleave(SCALE_FACTOR, dim=1).contiguous()
     y = torch.empty((BLOCK_M, BLOCK_K), dtype=torch.bfloat16, device="cuda")
 
-    pgm = scaled_upcast_fp8_kernel[(1, )](x.cuda(), scale.cuda(), y, BLOCK_M, BLOCK_K, num_warps=4)
+    pgm = scaled_upcast_fp8_kernel[(1, )](x.cuda(), scale.cuda(), y, BLOCK_M, BLOCK_K, num_warps=1)
 
     assert "v_cvt_scale_pk8_bf16_fp8" in pgm.asm["amdgcn"]
     y_ref = (x_ref * scale_ref).to(torch.bfloat16)


### PR DESCRIPTION
Before this PR scaled_upcast required unpacked scales which did result in unnecessary reshape + convert_layout, which did cause a roundtrip to LDS in some cases. With this PR we can do a `scaled_upcast` which directly feeds a dot without any expensive `convert_layouts` (they will be nops).

The lowering is generalized to build a map from 8-packed elements to their scales value instead of hardcoding the distribution of scales to registers. This allows us to handle arbitrary "BLOCK_SCALE" values along the axis dim, the only real requirement is that 8 contiguous fp4 values use the same scale (intrinsic requirement).
The verifier is extended to infer the scale layout from the output encoding which will also be used to verify the passed layout from Gluon. Note that we remove broadcasting dims for the comparison since the lowering will do the coordinate based lookup so broadcasting dims will be ignored anyways.

The intrinsic also supports `opsel` to densely pack/select the fp8 scales into/from registers, this will be added in a follow up PR and will be done purely in the lowering of the op.