### PR TITLE
[Backend] Build for llvm/llvm-project@909ba8d35

### DIFF
--- a/cmake/llvm-build-info.json
+++ b/cmake/llvm-build-info.json
@@ -1,5 +1,5 @@
 {
-  "llvm_hash": "41c4167cd066e8a9c3185917cafa9bef2cbfdb6d",
+  "llvm_hash": "909ba8d3508cf7177da65a4d1399f7bc5a3a4b98",
   "repository": "triton-lang/llvm-project",
   "build_number": 1
 }

--- a/cmake/llvm-build-info.json
+++ b/cmake/llvm-build-info.json
@@ -1,5 +1,5 @@
 {
   "llvm_hash": "909ba8d3508cf7177da65a4d1399f7bc5a3a4b98",
-  "repository": "triton-lang/llvm-project",
+  "repository": "llvm/llvm-project",
   "build_number": 1
 }


### PR DESCRIPTION
```
commit 909ba8d3508cf7177da65a4d1399f7bc5a3a4b98
Author: Changpeng Fang <changpeng.fang@amd.com>
Date:   Thu Jul 16 12:30:39 2026 -0700

    [AMDGPU] Select upper 16-bits for inline constants in packed BF16 (#209861)
    
    From gfx1250 software programming guide, v_pk_*_bf16 instructions using
    inline constants must use OPSEL to select the upper 16-bits.
    
    Fixes: LCOMPILER-2445

```