### PR TITLE
[PROTON] Enable cudagraph metadata profiling

### DIFF
--- a/third_party/proton/CMakeLists.txt
+++ b/third_party/proton/CMakeLists.txt
@@ -18,7 +18,8 @@ if(NOT JSON_INCLUDE_DIR)
 endif()
 
 unset(PROTON_ROCPROFILER_SDK_HAS_HIP_GRAPH CACHE)
-set(CMAKE_REQUIRED_INCLUDES "${ROCPROFILER_SDK_INCLUDE_DIR}")
+set(_proton_saved_cmake_required_includes "${CMAKE_REQUIRED_INCLUDES}")
+set(CMAKE_REQUIRED_INCLUDES "${ROCPROFILER_SDK_INCLUDE_DIR};${ROCM_INCLUDE_DIR}")
 check_cxx_source_compiles([=[
   #include <rocprofiler-sdk/fwd.h>
   int main() {
@@ -26,6 +27,7 @@ check_cxx_source_compiles([=[
     return static_cast<int>(op);
   }
 ]=] PROTON_ROCPROFILER_SDK_HAS_HIP_GRAPH)
+set(CMAKE_REQUIRED_INCLUDES "${_proton_saved_cmake_required_includes}")
 
 if(PROTON_ROCPROFILER_SDK_HAS_HIP_GRAPH)
   message(STATUS "Proton ROCProfiler-SDK HIP graph tracing: enabled")

--- a/third_party/proton/csrc/lib/Profiler/RocprofSDK/RocprofSDKProfiler.cpp
+++ b/third_party/proton/csrc/lib/Profiler/RocprofSDK/RocprofSDKProfiler.cpp
@@ -469,9 +469,9 @@ buildGraphNodeEntries(const DataToEntryMap &dataToEntry, GraphState &graphState,
   return &externIdState;
 }
 
-void queueGraphMetrics(
-    PendingGraphPool *pendingGraphPool, const GraphState &graphState,
-    const RocprofSDKProfiler::ExternIdState *externIdState) {
+void queueGraphMetrics(PendingGraphPool *pendingGraphPool,
+                       const GraphState &graphState,
+                       const RocprofSDKProfiler::ExternIdState *externIdState) {
   if (graphState.metricSeqIdToNodeId.empty())
     return;
 
@@ -758,8 +758,7 @@ void RocprofSDKProfiler::RocprofSDKProfilerPimpl::handleCapturedKernelEnter() {
                                               metricKernelLaunchInfo.numWords});
       streamCaptureGraphState.metricSeqIdToNodeId.insert_or_assign(
           metricKernelLaunchInfo.seqId, nodeId);
-      streamCaptureGraphState.numMetricWords +=
-          metricKernelLaunchInfo.numWords;
+      streamCaptureGraphState.numMetricWords += metricKernelLaunchInfo.numWords;
     }
 
     for (auto *data : profiler.dataSet) {
@@ -792,8 +791,7 @@ void RocprofSDKProfiler::RocprofSDKProfilerPimpl::handleCapturedKernelEnter() {
         auto staticEntry =
             data->addOp(Data::kVirtualPhase, Data::kRootEntryId, contexts);
         nodeState.dataToEntryId.insert_or_assign(data, staticEntry.id);
-        streamCaptureGraphState
-            .dataToEntryIdToNodeStates[data][staticEntry.id]
+        streamCaptureGraphState.dataToEntryIdToNodeStates[data][staticEntry.id]
             .insert(&nodeState);
         auto flexibleMetricEntry =
             data->addOp(Data::kVirtualPhase, Data::kRootEntryId,
@@ -808,8 +806,7 @@ void RocprofSDKProfiler::RocprofSDKProfilerPimpl::handleCapturedKernelEnter() {
         auto staticEntry =
             data->addOp(Data::kVirtualPhase, Data::kRootEntryId, contexts);
         nodeState.dataToEntryId.insert_or_assign(data, staticEntry.id);
-        streamCaptureGraphState
-            .dataToEntryIdToNodeStates[data][staticEntry.id]
+        streamCaptureGraphState.dataToEntryIdToNodeStates[data][staticEntry.id]
             .insert(&nodeState);
       }
     }
@@ -987,9 +984,9 @@ void RocprofSDKProfiler::RocprofSDKProfilerPimpl::hipGraphCallback(
     } else if (findGraph &&
                !impl->graphStates[graphExecId].captureStatusChecked) {
       auto &graphState = impl->graphStates[graphExecId];
-      auto *externIdState = buildGraphNodeEntries(
-          dataToEntry, graphState, profiler.correlation.externIdToState,
-          externId);
+      auto *externIdState =
+          buildGraphNodeEntries(dataToEntry, graphState,
+                                profiler.correlation.externIdToState, externId);
       queueGraphMetrics(profiler.pendingGraphPool.get(), graphState,
                         externIdState);
     }

--- a/third_party/proton/csrc/lib/Profiler/RocprofSDK/RocprofSDKProfiler.cpp
+++ b/third_party/proton/csrc/lib/Profiler/RocprofSDK/RocprofSDKProfiler.cpp
@@ -246,7 +246,7 @@ private:
 
 std::unique_ptr<Metric> convertDispatchToMetric(
     const rocprofiler_buffer_tracing_kernel_dispatch_record_t *record,
-    uint64_t streamId) {
+    uint64_t streamId, bool isMetricKernel = false) {
   if (record->start_timestamp >= record->end_timestamp)
     return nullptr;
   auto deviceId = static_cast<uint64_t>(
@@ -254,7 +254,8 @@ std::unique_ptr<Metric> convertDispatchToMetric(
   return std::make_unique<KernelMetric>(
       static_cast<uint64_t>(record->start_timestamp),
       static_cast<uint64_t>(record->end_timestamp), 1, deviceId,
-      static_cast<uint64_t>(DeviceType::HIP), streamId);
+      static_cast<uint64_t>(DeviceType::HIP), streamId,
+      static_cast<uint64_t>(isMetricKernel));
 }
 
 // ---- Kernel name resolution at API ENTER time ----
@@ -468,6 +469,48 @@ buildGraphNodeEntries(const DataToEntryMap &dataToEntry, GraphState &graphState,
   return &externIdState;
 }
 
+void queueGraphMetrics(
+    PendingGraphPool *pendingGraphPool, const GraphState &graphState,
+    const RocprofSDKProfiler::ExternIdState *externIdState) {
+  if (graphState.metricSeqIdToNodeId.empty())
+    return;
+
+  PendingGraphQueue::SeqIdToStateMap seqIdToState;
+  size_t phase = Data::kNoCompletePhase;
+  for (const auto &[seqId, nodeId] : graphState.metricSeqIdToNodeId) {
+    const auto &metricNodeState = graphState.metricNodeIdToState.at(nodeId);
+    if (externIdState) {
+      for (const auto &[data, graphEntry] : externIdState->dataToGraphEntry) {
+        phase = graphEntry.phase;
+        auto &pendingMetricNode =
+            seqIdToState
+                .emplace(seqId,
+                         PendingGraphQueue::MetricNodeState{
+                             metricNodeState.metricId, {}})
+                .first->second;
+        auto entryId = Scope::DummyScopeId;
+        if (auto entryIdIter = metricNodeState.dataToEntryId.find(data);
+            entryIdIter != metricNodeState.dataToEntryId.end()) {
+          entryId = entryIdIter->second;
+        }
+        // Otherwise, a DummyScopeId entry indicates that we'll call
+        // upsertFlexibleMetric instead of upsertLinkedFlexibleMetric in
+        // emitMetricRecords, so that the flexible metric can be attached to
+        // the graph launch entry.
+        pendingMetricNode.dataToEntry.emplace(
+            data, DataEntry(entryId, phase, graphEntry.metricSet.get()));
+      }
+    }
+  }
+
+  // Whether a data is active or not, the GPU will write the metric data into
+  // the metric buffer if there is a metric node. So we need the complete number
+  // of metrics of a graph.
+  pendingGraphPool->flushIfNeeded(graphState.numMetricWords);
+  pendingGraphPool->push(phase, graphState.numMetricWords,
+                         std::move(seqIdToState));
+}
+
 void processGraphKernelRecord(
     RocprofSDKProfiler::ExternIdToStateMap &externIdToState,
     std::map<Data *, std::pair<size_t, size_t>> &dataPhases,
@@ -502,11 +545,13 @@ void processGraphKernelRecord(
         throw makeRuntimeError(
             "[PROTON] Kernel name is missing for a graph node.");
       }
+      const bool isMetricKernel = nodeState.status.isMetricNode();
       for (auto &[data, entry] : externState.dataToGraphEntry) {
         auto targetEntryIdIt = nodeState.dataToEntryId.find(data);
         if (targetEntryIdIt == nodeState.dataToEntryId.end())
           continue;
-        if (auto metric = convertDispatchToMetric(record, streamId)) {
+        if (auto metric =
+                convertDispatchToMetric(record, streamId, isMetricKernel)) {
           entry.upsertLinkedMetric(std::move(metric), targetEntryIdIt->second);
           detail::updateDataPhases(dataPhases, data, entry.phase);
         }
@@ -546,8 +591,11 @@ struct RocprofSDKProfiler::RocprofSDKProfilerPimpl
   RocprofSDKProfilerPimpl(RocprofSDKProfiler &profiler)
       : GPUProfiler<RocprofSDKProfiler>::GPUProfilerPimplInterface(profiler) {
     auto runtime = &HipRuntime::instance();
-    profiler.metricBuffer =
-        std::make_unique<MetricBuffer>(1024 * 1024 * 64, runtime);
+    profiler.metricBuffer = std::make_unique<MetricBuffer>(
+        getIntEnv("TRITON_PROFILE_METRIC_BUFFER_SIZE", 64 * 1024 * 1024),
+        runtime);
+    profiler.pendingGraphPool =
+        std::make_unique<PendingGraphPool>(profiler.metricBuffer.get());
   }
   virtual ~RocprofSDKProfilerPimpl() = default;
 
@@ -686,11 +734,10 @@ void RocprofSDKProfiler::RocprofSDKProfilerPimpl::handleStreamCaptureBegin(
     return;
   threadState.isStreamCapturing = true;
   streamCaptureGraphState = GraphState{};
+  threadState.profiler.metricBuffer->reserve();
 }
 
 void RocprofSDKProfiler::RocprofSDKProfilerPimpl::handleCapturedKernelEnter() {
-  if (!threadState.isStreamCapturing)
-    return;
   auto &profiler = threadState.profiler;
   if (profiler.isOpInProgress()) {
     auto &scope = threadState.scopeStack.back();
@@ -699,6 +746,21 @@ void RocprofSDKProfiler::RocprofSDKProfilerPimpl::handleCapturedKernelEnter() {
     nodeState.nodeId = nodeId;
     if (scope.name.empty())
       nodeState.status.setMissingName();
+    const bool isMetricKernelNode = threadState.isMetricKernelLaunching;
+    if (isMetricKernelNode) {
+      nodeState.status.setMetricNode();
+      auto metricKernelLaunchInfo =
+          threadState.metricKernelLaunchInfoQueue.front();
+      threadState.metricKernelLaunchInfoQueue.pop_front();
+      streamCaptureGraphState.metricNodeIdToState.insert_or_assign(
+          nodeId, GraphState::MetricNodeState{metricKernelLaunchInfo.seqId,
+                                              metricKernelLaunchInfo.metricId,
+                                              metricKernelLaunchInfo.numWords});
+      streamCaptureGraphState.metricSeqIdToNodeId.insert_or_assign(
+          metricKernelLaunchInfo.seqId, nodeId);
+      streamCaptureGraphState.numMetricWords +=
+          metricKernelLaunchInfo.numWords;
+    }
 
     for (auto *data : profiler.dataSet) {
       auto currentContexts = data->getContexts();
@@ -707,16 +769,49 @@ void RocprofSDKProfiler::RocprofSDKProfilerPimpl::handleCapturedKernelEnter() {
       for (const auto &context : currentContexts) {
         contexts.push_back(context);
       }
-      contexts.emplace_back(scope.name);
 
-      // Create a static capture entry for this graph node. The entry id is
-      // stable for the same node ordinal and is used during replay to link the
-      // graph launch entry to the original captured call path.
-      auto staticEntry =
-          data->addOp(Data::kVirtualPhase, Data::kRootEntryId, contexts);
-      nodeState.dataToEntryId.insert_or_assign(data, staticEntry.id);
-      streamCaptureGraphState.dataToEntryIdToNodeStates[data][staticEntry.id]
-          .insert(&nodeState);
+      if (isMetricKernelNode) {
+        auto flexibleMetricContexts = data->getContexts(false);
+        std::vector<Context> flexibleMetricEntryContexts;
+        flexibleMetricEntryContexts.emplace_back(GraphState::captureTag);
+        for (const auto &context : flexibleMetricContexts) {
+          flexibleMetricEntryContexts.push_back(context);
+        }
+        if (!threadState.isApiExternOp) { // Triton ops
+          flexibleMetricEntryContexts.emplace_back(scope.name);
+        }
+        contexts.emplace_back(GraphState::metricTag);
+        flexibleMetricEntryContexts.emplace_back(GraphState::metricTag);
+
+        // Create a static capture entry for this graph node. The entry id is
+        // stable for the same node ordinal and is used during replay to link
+        // the graph launch entry to the original captured call path.
+        // For metric nodes, timing info is attributed to a frame under a
+        // metadata state. Flexible metrics are attributed to the current GPU
+        // operation.
+        auto staticEntry =
+            data->addOp(Data::kVirtualPhase, Data::kRootEntryId, contexts);
+        nodeState.dataToEntryId.insert_or_assign(data, staticEntry.id);
+        streamCaptureGraphState
+            .dataToEntryIdToNodeStates[data][staticEntry.id]
+            .insert(&nodeState);
+        auto flexibleMetricEntry =
+            data->addOp(Data::kVirtualPhase, Data::kRootEntryId,
+                        flexibleMetricEntryContexts);
+        streamCaptureGraphState.metricNodeIdToState.at(nodeId)
+            .dataToEntryId.insert_or_assign(data, flexibleMetricEntry.id);
+      } else {
+        contexts.emplace_back(scope.name);
+        // Create a static capture entry for this graph node. The entry id is
+        // stable for the same node ordinal and is used during replay to link
+        // the graph launch entry to the original captured call path.
+        auto staticEntry =
+            data->addOp(Data::kVirtualPhase, Data::kRootEntryId, contexts);
+        nodeState.dataToEntryId.insert_or_assign(data, staticEntry.id);
+        streamCaptureGraphState
+            .dataToEntryIdToNodeStates[data][staticEntry.id]
+            .insert(&nodeState);
+      }
     }
   }
 }
@@ -892,8 +987,11 @@ void RocprofSDKProfiler::RocprofSDKProfilerPimpl::hipGraphCallback(
     } else if (findGraph &&
                !impl->graphStates[graphExecId].captureStatusChecked) {
       auto &graphState = impl->graphStates[graphExecId];
-      buildGraphNodeEntries(dataToEntry, graphState,
-                            profiler.correlation.externIdToState, externId);
+      auto *externIdState = buildGraphNodeEntries(
+          dataToEntry, graphState, profiler.correlation.externIdToState,
+          externId);
+      queueGraphMetrics(profiler.pendingGraphPool.get(), graphState,
+                        externIdState);
     }
     if (!dataToEntry.empty()) {
       auto &scope = threadState.scopeStack.back();
@@ -1272,6 +1370,7 @@ void RocprofSDKProfiler::RocprofSDKProfilerPimpl::doFlush() {
   profiler.correlation.flush(
       /*maxRetries=*/100, /*sleepUs=*/10,
       [&state]() { rocprofiler::flushBuffer<true>(state.kernelBuffer); });
+  profiler.pendingGraphPool->flushAll();
 }
 
 void RocprofSDKProfiler::RocprofSDKProfilerPimpl::doStop() {

--- a/third_party/proton/test/test_profile.py
+++ b/third_party/proton/test/test_profile.py
@@ -33,6 +33,12 @@ def _find_frame_by_name(frame, name):
     return None
 
 
+_skip_cudagraph_test = pytest.mark.skipif(
+    os.environ.get("PROTON_SKIP_CUDAGRAPH_TEST", "0") == "1",
+    reason="CUDAGraph test skipped due to environment constraints",
+)
+
+
 @pytest.mark.parametrize("context", ["shadow", "python"])
 def test_torch(context, tmp_path: pathlib.Path, device: str):
     temp_file = tmp_path / "test_torch.hatchet"
@@ -90,11 +96,8 @@ def test_triton(tmp_path: pathlib.Path, device: str):
     assert data[0]["children"][1]["frame"]["name"] == "test2"
 
 
+@_skip_cudagraph_test
 def test_cudagraph(tmp_path: pathlib.Path, device: str):
-    # TODO(Keren): Uncomment when rocprofiler-sdk has been updated
-    if os.environ.get("PROTON_SKIP_CUDAGRAPH_TEST", "0") == "1":
-        pytest.skip("CUDagraph test is disabled")
-
     stream = torch.cuda.Stream()
     torch.cuda.set_stream(stream)
 
@@ -1482,6 +1485,7 @@ def test_nvtx_range_push_pop(enable_nvtx, fresh_knobs, tmp_path: pathlib.Path, d
     assert kernel["metrics"]["count"] == 1
 
 
+@_skip_cudagraph_test
 def test_tensor_metrics_scope(tmp_path: pathlib.Path, device: str):
     temp_file = tmp_path / "test_tensor_metrics_scope.hatchet"
     proton.start(str(temp_file.with_suffix("")))
@@ -1511,6 +1515,7 @@ def test_tensor_metrics_scope(tmp_path: pathlib.Path, device: str):
     assert test_frame["metrics"]["x_std"] == 0.0
 
 
+@_skip_cudagraph_test
 def test_tensor_metrics_hook(tmp_path: pathlib.Path, device: str):
     temp_file = tmp_path / "test_tensor_metrics_hook.hatchet"
 
@@ -1545,7 +1550,7 @@ def test_tensor_metrics_hook(tmp_path: pathlib.Path, device: str):
     assert foo_test_frame["metrics"]["flops"] == 8.0
 
 
-@pytest.mark.skipif(not is_cuda(), reason="Only CUDA backend supports metrics profiling in cudagraphs")
+@_skip_cudagraph_test
 def test_tensor_metrics_cudagraph_hook(tmp_path: pathlib.Path, device: str):
     """
     Test triton kernels launched from metadata hooks and hook="triton"
@@ -1604,7 +1609,7 @@ def test_tensor_metrics_cudagraph_hook(tmp_path: pathlib.Path, device: str):
     assert _find_frame_by_name(metadata_frame, "metadata_helper_kernel") is not None
 
 
-@pytest.mark.skipif(not is_cuda(), reason="Only CUDA backend supports metrics profiling in cudagraphs")
+@_skip_cudagraph_test
 def test_tensor_metrics_cudagraph(tmp_path: pathlib.Path, device: str):
     stream = torch.cuda.Stream()
     torch.cuda.set_stream(stream)
@@ -1694,7 +1699,7 @@ def test_tensor_metrics_cudagraph(tmp_path: pathlib.Path, device: str):
     assert scope_d_frame["metrics"]["vec"] == [0, 10, 20, 30]
 
 
-@pytest.mark.skipif(not is_cuda(), reason="Only CUDA backend supports metrics profiling in cudagraphs")
+@_skip_cudagraph_test
 def test_tensor_metrics_cudagraph_deactivate(tmp_path: pathlib.Path, device: str):
     stream = torch.cuda.Stream()
     torch.cuda.set_stream(stream)
@@ -1747,7 +1752,7 @@ def test_tensor_metrics_cudagraph_deactivate(tmp_path: pathlib.Path, device: str
         assert c_frame["metrics"]["count"] == 10
 
 
-@pytest.mark.skipif(not is_cuda(), reason="Only CUDA backend supports metrics profiling in cudagraphs")
+@_skip_cudagraph_test
 def test_tensor_metrics_multi_device_cudagraph(tmp_path: pathlib.Path):
     if torch.cuda.device_count() < 2:
         pytest.skip("Requires at least two CUDA devices")


### PR DESCRIPTION
Pretty much the same as what we implemented in CUPTI. Will unify code later<git-pr-chain>

#### Commits in this PR
1. Enhance RocprofSDKProfiler with metric kernel support and graph metrics queuing
1. Refactor queueGraphMetrics and handleCapturedKernelEnter for improved readability
1. Update CMakeLists.txt to include ROCM_INCLUDE_DIR for HIP graph tracing checks
1. Add environment variable to skip CUDAGraph tests in profiling tests

#### [PR chain](https://github.com/jlebar/git-pr-chain)
1. 👉 #10989 👈 **YOU ARE HERE**
1. #10999
1. #11042


</git-pr-chain>



