### PR TITLE
[Gluon] Support aggregate operator dispatch

### DIFF
--- a/python/test/gluon/test_frontend.py
+++ b/python/test/gluon/test_frontend.py
@@ -1,6 +1,7 @@
 import expecttest
 import pytest
 import re
+from dataclasses import replace
 
 from triton.backends.compiler import GPUTarget
 from triton.experimental import gluon
@@ -519,39 +520,11 @@ class ForwardOnlyAggregate:
 
 @gluon.aggregate
 class NotImplementedAggregate:
-    __triton_operator_priority__ = 7
     value: tl.tensor
 
     @gluon.constexpr_function
     def __add__(self, rhs):
         return NotImplemented
-
-
-def _tensor_tuple_is_power_of_two(value):
-    return value > 0 and value & (value - 1) == 0
-
-
-def _tensor_tuple_decompose_extent(extent, minimum_padding_size):
-    padded_extent = ((extent + minimum_padding_size - 1) // minimum_padding_size) * minimum_padding_size
-    chunks = []
-    remaining = padded_extent
-    while remaining:
-        chunk = 1 << (remaining.bit_length() - 1)
-        chunks.append(chunk)
-        remaining -= chunk
-    return tuple(chunks), padded_extent - extent
-
-
-def _tensor_tuple_derive_layout(template, split_dim, largest_chunk, chunk):
-    size_per_thread = list(template.size_per_thread)
-    size_per_thread[split_dim] = max(1, size_per_thread[split_dim] * chunk // largest_chunk)
-    return ttgl.BlockedLayout(
-        size_per_thread=size_per_thread,
-        threads_per_warp=list(template.threads_per_warp),
-        warps_per_cta=list(template.warps_per_cta),
-        order=list(template.order),
-        cga_layout=[list(basis) for basis in template.cga_layout],
-    )
 
 
 def TensorTuple(shape, layout, minimum_padding_size=1):
@@ -562,46 +535,43 @@ def TensorTuple(shape, layout, minimum_padding_size=1):
     largest chunk. Smaller chunks retain its thread/warp/CTA topology and scale
     ``size_per_thread`` along the irregular dimension when possible.
     """
+    def is_power_of_two(value):
+        return value > 0 and value & (value - 1) == 0
+
     shape = tuple(shape)
     assert isinstance(layout, ttgl.BlockedLayout), "TensorTuple requires a BlockedLayout template"
     assert len(shape) == layout.rank, "shape and layout ranks must match"
     assert all(isinstance(dim, int) and dim > 0 for dim in shape), "shape dimensions must be positive integers"
-    assert _tensor_tuple_is_power_of_two(minimum_padding_size), \
+    assert isinstance(minimum_padding_size, int) and is_power_of_two(minimum_padding_size), \
         "minimum_padding_size must be a positive power of two"
 
-    irregular_dims = tuple(i for i, dim in enumerate(shape) if not _tensor_tuple_is_power_of_two(dim))
+    irregular_dims = [i for i, dim in enumerate(shape) if not is_power_of_two(dim)]
     assert len(irregular_dims) == 1, "shape must have exactly one non-power-of-two dimension"
     split_dim = irregular_dims[0]
 
-    chunks, padding = _tensor_tuple_decompose_extent(shape[split_dim], minimum_padding_size)
-    offsets = []
-    physical_shapes = []
-    logical_shapes = []
-    layouts = []
-    offset = 0
-    remaining = shape[split_dim]
-    for chunk in chunks:
-        logical_chunk = min(chunk, remaining)
-        physical_shape = list(shape)
-        physical_shape[split_dim] = chunk
-        logical_shape = list(shape)
-        logical_shape[split_dim] = logical_chunk
-        offsets.append(offset)
-        physical_shapes.append(tuple(physical_shape))
-        logical_shapes.append(tuple(logical_shape))
-        layouts.append(_tensor_tuple_derive_layout(layout, split_dim, chunks[0], chunk))
-        offset += chunk
-        remaining -= logical_chunk
+    def with_split_extent(extent):
+        return shape[:split_dim] + (extent, ) + shape[split_dim + 1:]
 
-    offsets = tuple(offsets)
-    physical_shapes = tuple(physical_shapes)
-    logical_shapes = tuple(logical_shapes)
-    layouts = tuple(layouts)
+    extent = shape[split_dim]
+    padded_extent = ((extent + minimum_padding_size - 1) // minimum_padding_size) * minimum_padding_size
+    chunks = tuple(1 << bit for bit in range(padded_extent.bit_length() - 1, -1, -1)
+                   if padded_extent & (1 << bit))
+    padding = padded_extent - extent
+    offsets = tuple(sum(chunks[:i]) for i in range(len(chunks)))
+    physical_shapes = tuple(with_split_extent(chunk) for chunk in chunks)
+    logical_shapes = tuple(with_split_extent(chunk) for chunk in chunks[:-1])
+    logical_shapes += (with_split_extent(chunks[-1] - padding), )
+
+    def derive_layout(chunk):
+        size_per_thread = list(layout.size_per_thread)
+        size_per_thread[split_dim] = max(1, size_per_thread[split_dim] * chunk // chunks[0])
+        return replace(layout, size_per_thread=size_per_thread)
+
+    layouts = tuple(derive_layout(chunk) for chunk in chunks)
 
     jit_shape = ttgl.constexpr(shape)
     jit_split_dim = ttgl.constexpr(split_dim)
     jit_chunks = ttgl.constexpr(chunks)
-    jit_num_chunks = ttgl.constexpr(len(chunks))
     jit_offsets = ttgl.constexpr(offsets)
     jit_physical_shapes = ttgl.constexpr(physical_shapes)
     jit_logical_shapes = ttgl.constexpr(logical_shapes)
@@ -615,7 +585,7 @@ def TensorTuple(shape, layout, minimum_padding_size=1):
         def arange(start: ttgl.constexpr = 0):
             ttgl.static_assert(len(jit_shape) == 1, "arange requires a rank-1 TensorTuple")
             values = ()
-            for i in ttgl.static_range(jit_num_chunks):
+            for i in ttgl.static_range(len(jit_chunks)):
                 value = ttgl.arange(
                     start + jit_offsets[i],
                     start + jit_offsets[i] + jit_chunks[i],
@@ -627,7 +597,7 @@ def TensorTuple(shape, layout, minimum_padding_size=1):
         @gluon.jit
         def full(value, dtype: ttgl.constexpr):
             values = ()
-            for i in ttgl.static_range(jit_num_chunks):
+            for i in ttgl.static_range(len(jit_chunks)):
                 values += (ttgl.full(jit_physical_shapes[i], value, dtype, jit_layouts[i]), )
             return TensorTupleType(values)
 
@@ -635,7 +605,7 @@ def TensorTuple(shape, layout, minimum_padding_size=1):
         def valid_mask():
             ttgl.static_assert(len(jit_shape) == 1, "valid_mask requires a rank-1 TensorTuple")
             values = ()
-            for i in ttgl.static_range(jit_num_chunks):
+            for i in ttgl.static_range(len(jit_chunks)):
                 offsets = ttgl.arange(
                     jit_offsets[i],
                     jit_offsets[i] + jit_chunks[i],
@@ -646,126 +616,77 @@ def TensorTuple(shape, layout, minimum_padding_size=1):
             return TensorTupleType(values)
 
         @gluon.jit
-        def __add__(self, rhs):
-            values = ()
+        def _binary(self, rhs, method_name: ttgl.constexpr):
             if isinstance(rhs, TensorTupleType):
-                for i in ttgl.static_range(jit_num_chunks):
-                    values += (self.values[i] + rhs.values[i], )
+                rhs = rhs.values
             else:
-                for i in ttgl.static_range(jit_num_chunks):
-                    values += (self.values[i] + rhs, )
+                rhs = (rhs, ) * len(jit_chunks)
+            values = ()
+            for i in ttgl.static_range(len(jit_chunks)):
+                values += (getattr(self.values[i], method_name)(rhs[i]), )
             return TensorTupleType(values)
+
+        @gluon.jit
+        def __add__(self, rhs):
+            return self._binary(rhs, "__add__")
 
         @gluon.jit
         def __radd__(self, lhs):
-            return self + lhs
+            return self._binary(lhs, "__radd__")
 
         @gluon.jit
         def __sub__(self, rhs):
-            values = ()
-            if isinstance(rhs, TensorTupleType):
-                for i in ttgl.static_range(jit_num_chunks):
-                    values += (self.values[i] - rhs.values[i], )
-            else:
-                for i in ttgl.static_range(jit_num_chunks):
-                    values += (self.values[i] - rhs, )
-            return TensorTupleType(values)
+            return self._binary(rhs, "__sub__")
 
         @gluon.jit
         def __rsub__(self, lhs):
-            values = ()
-            for i in ttgl.static_range(jit_num_chunks):
-                values += (lhs - self.values[i], )
-            return TensorTupleType(values)
+            return self._binary(lhs, "__rsub__")
 
         @gluon.jit
         def __mul__(self, rhs):
-            values = ()
-            if isinstance(rhs, TensorTupleType):
-                for i in ttgl.static_range(jit_num_chunks):
-                    values += (self.values[i] * rhs.values[i], )
-            else:
-                for i in ttgl.static_range(jit_num_chunks):
-                    values += (self.values[i] * rhs, )
-            return TensorTupleType(values)
+            return self._binary(rhs, "__mul__")
 
         @gluon.jit
         def __rmul__(self, lhs):
-            return self * lhs
+            return self._binary(lhs, "__rmul__")
 
         @gluon.jit
         def __truediv__(self, rhs):
-            values = ()
-            if isinstance(rhs, TensorTupleType):
-                for i in ttgl.static_range(jit_num_chunks):
-                    values += (self.values[i] / rhs.values[i], )
-            else:
-                for i in ttgl.static_range(jit_num_chunks):
-                    values += (self.values[i] / rhs, )
-            return TensorTupleType(values)
+            return self._binary(rhs, "__truediv__")
 
         @gluon.jit
         def __rtruediv__(self, lhs):
-            values = ()
-            for i in ttgl.static_range(jit_num_chunks):
-                values += (lhs / self.values[i], )
-            return TensorTupleType(values)
+            return self._binary(lhs, "__rtruediv__")
+
+        @gluon.jit
+        def __lt__(self, rhs):
+            return self._binary(rhs, "__lt__")
+
+        @gluon.jit
+        def __le__(self, rhs):
+            return self._binary(rhs, "__le__")
+
+        @gluon.jit
+        def __gt__(self, rhs):
+            return self._binary(rhs, "__gt__")
+
+        @gluon.jit
+        def __ge__(self, rhs):
+            return self._binary(rhs, "__ge__")
+
+        @gluon.jit
+        def __and__(self, rhs):
+            return self._binary(rhs, "__and__")
+
+        @gluon.jit
+        def __or__(self, rhs):
+            return self._binary(rhs, "__or__")
 
         @gluon.jit
         def __neg__(self):
             values = ()
-            for i in ttgl.static_range(jit_num_chunks):
+            for i in ttgl.static_range(len(jit_chunks)):
                 values += (-self.values[i], )
-            return TensorTupleType(values)
-
-        @gluon.jit
-        def __lt__(self, rhs):
-            values = ()
-            for i in ttgl.static_range(jit_num_chunks):
-                values += (self.values[i] < rhs, )
-            return TensorTupleType(values)
-
-        @gluon.jit
-        def __le__(self, rhs):
-            values = ()
-            for i in ttgl.static_range(jit_num_chunks):
-                values += (self.values[i] <= rhs, )
-            return TensorTupleType(values)
-
-        @gluon.jit
-        def __gt__(self, rhs):
-            values = ()
-            for i in ttgl.static_range(jit_num_chunks):
-                values += (self.values[i] > rhs, )
-            return TensorTupleType(values)
-
-        @gluon.jit
-        def __ge__(self, rhs):
-            values = ()
-            for i in ttgl.static_range(jit_num_chunks):
-                values += (self.values[i] >= rhs, )
-            return TensorTupleType(values)
-
-        @gluon.jit
-        def __and__(self, rhs):
-            values = ()
-            if isinstance(rhs, TensorTupleType):
-                for i in ttgl.static_range(jit_num_chunks):
-                    values += (self.values[i] & rhs.values[i], )
-            else:
-                for i in ttgl.static_range(jit_num_chunks):
-                    values += (self.values[i] & rhs, )
-            return TensorTupleType(values)
-
-        @gluon.jit
-        def __or__(self, rhs):
-            values = ()
-            if isinstance(rhs, TensorTupleType):
-                for i in ttgl.static_range(jit_num_chunks):
-                    values += (self.values[i] | rhs.values[i], )
-            else:
-                for i in ttgl.static_range(jit_num_chunks):
-                    values += (self.values[i] | rhs, )
             return TensorTupleType(values)
 
     TensorTupleType.shape = shape
@@ -783,8 +704,40 @@ _TENSOR_TUPLE_LAYOUT = ttgl.BlockedLayout([2], [32], [4], [0])
 _TENSOR_TUPLE_288 = TensorTuple((288, ), _TENSOR_TUPLE_LAYOUT, minimum_padding_size=64)
 
 
+@filecheck_test
 @gluon.jit
-def tensor_tuple_frontend_kernel():
+def test_tensor_tuple_frontend_ir():
+    # CHECK-DAG: [[HEAD_LAYOUT:#.*]] = #ttg.blocked<{sizePerThread = [2], threadsPerWarp = [32], warpsPerCTA = [4], order = [0]}>
+    # CHECK-DAG: [[TAIL_LAYOUT:#.*]] = #ttg.blocked<{sizePerThread = [1], threadsPerWarp = [32], warpsPerCTA = [4], order = [0]}>
+    # CHECK-LABEL: tt.func public @test_tensor_tuple_frontend_ir()
+    # CHECK: [[OFFSETS:%.*]]:2 = tt.call {{.*}}TensorTupleType.arange
+    # CHECK: [[SCALAR:%.*]] = arith.constant 4 : i32
+    # CHECK: {{%.*}}:2 = tt.call {{.*}}TensorTupleType.__add__{{.*}}([[OFFSETS]]#0, [[OFFSETS]]#1, [[SCALAR]])
+    # CHECK: {{%.*}}:2 = tt.call {{.*}}TensorTupleType.__radd__{{.*}}([[OFFSETS]]#0, [[OFFSETS]]#1, [[SCALAR]])
+    # CHECK: {{%.*}}:2 = tt.call {{.*}}TensorTupleType.__rsub__{{.*}}([[OFFSETS]]#0, [[OFFSETS]]#1, [[SCALAR]])
+    # CHECK: {{%.*}}:2 = tt.call {{.*}}TensorTupleType.__gt__{{.*}}([[OFFSETS]]#0, [[OFFSETS]]#1, [[SCALAR]])
+
+    # CHECK-LABEL: tt.func private {{.*}}TensorTupleType.arange
+    # CHECK: [[HEAD_RANGE:%.*]] = tt.make_range {end = 256 : i32, start = 0 : i32} : tensor<256xi32, [[HEAD_LAYOUT]]>
+    # CHECK-NEXT: [[TAIL_RANGE:%.*]] = tt.make_range {end = 320 : i32, start = 256 : i32} : tensor<64xi32, [[TAIL_LAYOUT]]>
+    # CHECK-NEXT: tt.return [[HEAD_RANGE]], [[TAIL_RANGE]]
+
+    # CHECK-LABEL: tt.func private {{.*}}TensorTupleType.valid_mask
+    # CHECK: [[VALID_HEAD_RANGE:%.*]] = tt.make_range {end = 256 : i32, start = 0 : i32} : tensor<256xi32, [[HEAD_LAYOUT]]>
+    # CHECK: [[HEAD_END:%.*]] = arith.constant dense<256> : tensor<256xi32, [[HEAD_LAYOUT]]>
+    # CHECK: [[HEAD_MASK:%.*]] = arith.cmpi slt, [[VALID_HEAD_RANGE]], [[HEAD_END]]
+    # CHECK: [[VALID_TAIL_RANGE:%.*]] = tt.make_range {end = 320 : i32, start = 256 : i32} : tensor<64xi32, [[TAIL_LAYOUT]]>
+    # CHECK: [[TAIL_END:%.*]] = arith.constant dense<288> : tensor<64xi32, [[TAIL_LAYOUT]]>
+    # CHECK: [[TAIL_MASK:%.*]] = arith.cmpi slt, [[VALID_TAIL_RANGE]], [[TAIL_END]]
+    # CHECK: tt.return [[HEAD_MASK]], [[TAIL_MASK]]
+
+    # CHECK-LABEL: tt.func private {{.*}}TensorTupleType._binary{{.*}}__rsub__
+    # CHECK: [[SPLAT_LHS:%.*]] = tt.splat %arg2 : i32 -> tensor<256xi32, [[HEAD_LAYOUT]]>
+    # CHECK-NEXT: {{%.*}} = arith.subi [[SPLAT_LHS]], %arg0
+
+    # CHECK-LABEL: tt.func private {{.*}}TensorTupleType._binary{{.*}}__gt__
+    # CHECK: [[SPLAT_RHS:%.*]] = tt.splat %arg2 : i32 -> tensor<256xi32, [[HEAD_LAYOUT]]>
+    # CHECK-NEXT: {{%.*}} = arith.cmpi sgt, %arg0, [[SPLAT_RHS]]
     offsets = _TENSOR_TUPLE_288.arange()
     filled = _TENSOR_TUPLE_288.full(3, ttgl.int32)
     values = -(2 * offsets + filled - offsets) / 2
@@ -803,8 +756,27 @@ def tensor_tuple_frontend_kernel():
         anchor(reflected_cmp.values[i])
 
 
+@filecheck_test
 @gluon.jit
-def operator_dispatch_compatibility_kernel():
+def test_operator_dispatch_ir():
+    # CHECK: [[LAYOUT:#.*]] = #ttg.blocked
+    # CHECK-LABEL: tt.func public @test_operator_dispatch_ir()
+    # CHECK: [[VALUE:%.*]] = tt.make_range {end = 128 : i32, start = 0 : i32} : tensor<128xi32, [[LAYOUT]]>
+    # CHECK: {{%.*}} = arith.addi [[VALUE]], [[VALUE]]
+    # CHECK: [[ADD_RHS:%.*]] = arith.constant dense<4> : tensor<128xi32, [[LAYOUT]]>
+    # CHECK-NEXT: {{%.*}} = arith.addi [[VALUE]], [[ADD_RHS]]
+    # CHECK: [[ADD_LHS:%.*]] = arith.constant dense<4> : tensor<128xi32, [[LAYOUT]]>
+    # CHECK-NEXT: {{%.*}} = arith.addi [[ADD_LHS]], [[VALUE]]
+    # CHECK: [[SUB_RHS:%.*]] = arith.constant dense<4> : tensor<128xi32, [[LAYOUT]]>
+    # CHECK-NEXT: {{%.*}} = arith.subi [[VALUE]], [[SUB_RHS]]
+    # CHECK: [[SUB_LHS:%.*]] = arith.constant dense<4> : tensor<128xi32, [[LAYOUT]]>
+    # CHECK-NEXT: {{%.*}} = arith.subi [[SUB_LHS]], [[VALUE]]
+    # CHECK: [[CMP_RHS:%.*]] = arith.constant dense<4> : tensor<128xi32, [[LAYOUT]]>
+    # CHECK-NEXT: {{%.*}} = arith.cmpi slt, [[VALUE]], [[CMP_RHS]]
+    # CHECK: [[CMP_LHS:%.*]] = arith.constant dense<4> : tensor<128xi32, [[LAYOUT]]>
+    # CHECK-NEXT: {{%.*}} = arith.cmpi slt, [[CMP_LHS]], [[VALUE]]
+    # CHECK: [[ZERO:%.*]] = arith.constant dense<0> : tensor<128xi32, [[LAYOUT]]>
+    # CHECK-NEXT: {{%.*}} = arith.subi [[ZERO]], [[VALUE]]
     layout: ttgl.constexpr = ttgl.BlockedLayout([1], [32], [4], [0])
     value = ttgl.arange(0, 128, layout=layout)
     scalar_tensor = ttgl.to_tensor(4)
@@ -821,8 +793,16 @@ def operator_dispatch_compatibility_kernel():
     anchor(pair[1])
 
 
+@filecheck_test
 @gluon.jit
-def operator_dispatch_boolean_kernel():
+def test_operator_dispatch_boolean_ir():
+    # CHECK: [[LAYOUT:#.*]] = #ttg.blocked
+    # CHECK-LABEL: tt.func public @test_operator_dispatch_boolean_ir()
+    # CHECK: [[VALUE:%.*]] = tt.make_range {{.*}} : tensor<128xi32, [[LAYOUT]]>
+    # CHECK: [[RESULT:%.*]] = tt.call {{.*}}ForwardOnlyAggregate.logical_and{{.*}}([[VALUE]], [[VALUE]])
+    # CHECK-LABEL: tt.func private {{.*}}ForwardOnlyAggregate.logical_and
+    # CHECK: [[AND:%.*]] = arith.andi %arg0, %arg1 : tensor<128xi32, [[LAYOUT]]>
+    # CHECK-NEXT: tt.return [[AND]]
     layout: ttgl.constexpr = ttgl.BlockedLayout([1], [32], [4], [0])
     value = ttgl.arange(0, 128, layout=layout)
     result = ForwardOnlyAggregate(value) and ForwardOnlyAggregate(value)
@@ -843,7 +823,7 @@ def operator_dispatch_not_implemented_kernel():
     NotImplementedAggregate(value) + 1
 
 
-def test_tensor_tuple_frontend():
+def test_tensor_tuple_metadata():
     assert _TENSOR_TUPLE_288.physical_shapes == ((256, ), (64, ))
     assert _TENSOR_TUPLE_288.logical_shapes == ((256, ), (32, ))
     assert _TENSOR_TUPLE_288.offsets == (0, 256)
@@ -858,29 +838,8 @@ def test_tensor_tuple_frontend():
     assert tensor_tuple_2d.logical_shapes == ((8, 256), (8, 61))
     assert [layout.size_per_thread for layout in tensor_tuple_2d.layouts] == [[1, 4], [1, 1]]
 
-    ir = anonymize_ir(run_parser(tensor_tuple_frontend_kernel, target=BLACKWELL_TARGET).str_nodebug())
-    assert "end = 256 : i32, start = 0 : i32" in ir
-    assert "end = 320 : i32, start = 256 : i32" in ir
-    assert "tensor<256xi32" in ir
-    assert "tensor<64xi32" in ir
-    assert "arith.muli" in ir
-    assert "arith.addi" in ir
-    assert "arith.subi" in ir
-    assert "arith.cmpi slt" in ir
 
-
-def test_operator_dispatch():
-    assert tl.constexpr.__triton_operator_priority__ == 0
-    assert tl.tensor.__triton_operator_priority__ == 1
-    assert ForwardOnlyAggregate.__triton_operator_priority__ == 2
-    assert NotImplementedAggregate.__triton_operator_priority__ == 7
-
-    ir = anonymize_ir(run_parser(operator_dispatch_compatibility_kernel).str_nodebug())
-    assert "arith.addi" in ir
-    assert "arith.subi" in ir
-    assert "arith.cmpi" in ir
-    assert "arith.andi" in run_parser(operator_dispatch_boolean_kernel).str_nodebug()
-
+def test_operator_dispatch_errors():
     with pytest.raises(CompilationError, match=r"unsupported operand type\(s\) for \+"):
         run_parser(operator_dispatch_missing_reflected_kernel)
     with pytest.raises(CompilationError, match=r"unsupported operand type\(s\) for \+"):

--- a/python/test/gluon/test_frontend.py
+++ b/python/test/gluon/test_frontend.py
@@ -527,6 +527,15 @@ class NotImplementedAggregate:
         return NotImplemented
 
 
+@gluon.aggregate
+class ReflectedOnlyAggregate:
+    value: tl.tensor
+
+    @gluon.jit
+    def __radd__(self, lhs):
+        return ReflectedOnlyAggregate(lhs.value + self.value)
+
+
 @gluon.jit
 def operator_dispatch_optional_annotation(value: ttgl.tensor, other: ttgl.tensor | None = None):
     return value
@@ -817,6 +826,21 @@ def test_operator_dispatch_boolean_ir():
     layout: ttgl.constexpr = ttgl.BlockedLayout([1], [32], [4], [0])
     value = ttgl.arange(0, 128, layout=layout)
     result = ForwardOnlyAggregate(value) and ForwardOnlyAggregate(value)
+    anchor(result.value)
+
+
+@filecheck_test
+@gluon.jit
+def test_operator_dispatch_not_implemented_fallback_ir():
+    # CHECK-LABEL: tt.func public @test_operator_dispatch_not_implemented_fallback_ir()
+    # CHECK: [[VALUE:%.*]] = tt.make_range
+    # CHECK: {{%.*}} = tt.call {{.*}}ReflectedOnlyAggregate.__radd__{{.*}}([[VALUE]], [[VALUE]])
+    # CHECK-LABEL: tt.func private {{.*}}ReflectedOnlyAggregate.__radd__
+    # CHECK: [[RESULT:%.*]] = arith.addi %arg1, %arg0
+    # CHECK-NEXT: tt.return [[RESULT]]
+    layout: ttgl.constexpr = ttgl.BlockedLayout([1], [32], [4], [0])
+    value = ttgl.arange(0, 128, layout=layout)
+    result = NotImplementedAggregate(value) + ReflectedOnlyAggregate(value)
     anchor(result.value)
 
 

--- a/python/test/gluon/test_frontend.py
+++ b/python/test/gluon/test_frontend.py
@@ -527,6 +527,11 @@ class NotImplementedAggregate:
         return NotImplemented
 
 
+@gluon.jit
+def operator_dispatch_optional_annotation(value: ttgl.tensor, other: ttgl.tensor | None = None):
+    return value
+
+
 def TensorTuple(shape, layout, minimum_padding_size=1):
     """Prototype an aggregate for one irregular tensor dimension.
 
@@ -535,6 +540,7 @@ def TensorTuple(shape, layout, minimum_padding_size=1):
     largest chunk. Smaller chunks retain its thread/warp/CTA topology and scale
     ``size_per_thread`` along the irregular dimension when possible.
     """
+
     def is_power_of_two(value):
         return value > 0 and value & (value - 1) == 0
 
@@ -554,8 +560,7 @@ def TensorTuple(shape, layout, minimum_padding_size=1):
 
     extent = shape[split_dim]
     padded_extent = ((extent + minimum_padding_size - 1) // minimum_padding_size) * minimum_padding_size
-    chunks = tuple(1 << bit for bit in range(padded_extent.bit_length() - 1, -1, -1)
-                   if padded_extent & (1 << bit))
+    chunks = tuple(1 << bit for bit in range(padded_extent.bit_length() - 1, -1, -1) if padded_extent & (1 << bit))
     padding = padded_extent - extent
     offsets = tuple(sum(chunks[:i]) for i in range(len(chunks)))
     physical_shapes = tuple(with_split_extent(chunk) for chunk in chunks)
@@ -777,11 +782,16 @@ def test_operator_dispatch_ir():
     # CHECK-NEXT: {{%.*}} = arith.cmpi slt, [[CMP_LHS]], [[VALUE]]
     # CHECK: [[ZERO:%.*]] = arith.constant dense<0> : tensor<128xi32, [[LAYOUT]]>
     # CHECK-NEXT: {{%.*}} = arith.subi [[ZERO]], [[VALUE]]
+    # CHECK: [[ANNOTATED:%.*]] = tt.call @{{.*}}operator_dispatch_optional_annotation{{.*}}([[VALUE]])
     layout: ttgl.constexpr = ttgl.BlockedLayout([1], [32], [4], [0])
     value = ttgl.arange(0, 128, layout=layout)
     scalar_tensor = ttgl.to_tensor(4)
     pair = (value, ) + (value, )
     ttgl.static_assert(3 + 4 == 7)
+    ttgl.static_assert(((3, 4) or (5, 6)) == (3, 4))
+    ttgl.static_assert(((3, 4) and (5, 6)) == (5, 6))
+    ttgl.static_assert(((3, 4) and ()) == ())
+    ttgl.static_assert((() or (5, 6)) == (5, 6))
     anchor(value + value)
     anchor(value + 4)
     anchor(4 + value)
@@ -790,6 +800,7 @@ def test_operator_dispatch_ir():
     anchor(value < scalar_tensor)
     anchor(scalar_tensor < value)
     anchor(-value)
+    anchor(operator_dispatch_optional_annotation(value))
     anchor(pair[1])
 
 

--- a/python/test/gluon/test_frontend.py
+++ b/python/test/gluon/test_frontend.py
@@ -504,6 +504,389 @@ class Pair:
     second: tl.tensor
 
 
+@gluon.aggregate
+class ForwardOnlyAggregate:
+    value: tl.tensor
+
+    @gluon.jit
+    def __add__(self, rhs):
+        return ForwardOnlyAggregate(self.value + rhs)
+
+    @gluon.jit
+    def logical_and(self, rhs):
+        return ForwardOnlyAggregate(self.value & rhs.value)
+
+
+@gluon.aggregate
+class NotImplementedAggregate:
+    __triton_operator_priority__ = 7
+    value: tl.tensor
+
+    @gluon.constexpr_function
+    def __add__(self, rhs):
+        return NotImplemented
+
+
+def _tensor_tuple_is_power_of_two(value):
+    return value > 0 and value & (value - 1) == 0
+
+
+def _tensor_tuple_decompose_extent(extent, minimum_padding_size):
+    padded_extent = ((extent + minimum_padding_size - 1) // minimum_padding_size) * minimum_padding_size
+    chunks = []
+    remaining = padded_extent
+    while remaining:
+        chunk = 1 << (remaining.bit_length() - 1)
+        chunks.append(chunk)
+        remaining -= chunk
+    return tuple(chunks), padded_extent - extent
+
+
+def _tensor_tuple_derive_layout(template, split_dim, largest_chunk, chunk):
+    size_per_thread = list(template.size_per_thread)
+    size_per_thread[split_dim] = max(1, size_per_thread[split_dim] * chunk // largest_chunk)
+    return ttgl.BlockedLayout(
+        size_per_thread=size_per_thread,
+        threads_per_warp=list(template.threads_per_warp),
+        warps_per_cta=list(template.warps_per_cta),
+        order=list(template.order),
+        cga_layout=[list(basis) for basis in template.cga_layout],
+    )
+
+
+def TensorTuple(shape, layout, minimum_padding_size=1):
+    """Prototype an aggregate for one irregular tensor dimension.
+
+    The irregular dimension is padded to a multiple of ``minimum_padding_size``
+    and binary-decomposed into power-of-two chunks. ``layout`` describes the
+    largest chunk. Smaller chunks retain its thread/warp/CTA topology and scale
+    ``size_per_thread`` along the irregular dimension when possible.
+    """
+    shape = tuple(shape)
+    assert isinstance(layout, ttgl.BlockedLayout), "TensorTuple requires a BlockedLayout template"
+    assert len(shape) == layout.rank, "shape and layout ranks must match"
+    assert all(isinstance(dim, int) and dim > 0 for dim in shape), "shape dimensions must be positive integers"
+    assert _tensor_tuple_is_power_of_two(minimum_padding_size), \
+        "minimum_padding_size must be a positive power of two"
+
+    irregular_dims = tuple(i for i, dim in enumerate(shape) if not _tensor_tuple_is_power_of_two(dim))
+    assert len(irregular_dims) == 1, "shape must have exactly one non-power-of-two dimension"
+    split_dim = irregular_dims[0]
+
+    chunks, padding = _tensor_tuple_decompose_extent(shape[split_dim], minimum_padding_size)
+    offsets = []
+    physical_shapes = []
+    logical_shapes = []
+    layouts = []
+    offset = 0
+    remaining = shape[split_dim]
+    for chunk in chunks:
+        logical_chunk = min(chunk, remaining)
+        physical_shape = list(shape)
+        physical_shape[split_dim] = chunk
+        logical_shape = list(shape)
+        logical_shape[split_dim] = logical_chunk
+        offsets.append(offset)
+        physical_shapes.append(tuple(physical_shape))
+        logical_shapes.append(tuple(logical_shape))
+        layouts.append(_tensor_tuple_derive_layout(layout, split_dim, chunks[0], chunk))
+        offset += chunk
+        remaining -= logical_chunk
+
+    offsets = tuple(offsets)
+    physical_shapes = tuple(physical_shapes)
+    logical_shapes = tuple(logical_shapes)
+    layouts = tuple(layouts)
+
+    jit_shape = ttgl.constexpr(shape)
+    jit_split_dim = ttgl.constexpr(split_dim)
+    jit_chunks = ttgl.constexpr(chunks)
+    jit_num_chunks = ttgl.constexpr(len(chunks))
+    jit_offsets = ttgl.constexpr(offsets)
+    jit_physical_shapes = ttgl.constexpr(physical_shapes)
+    jit_logical_shapes = ttgl.constexpr(logical_shapes)
+    jit_layouts = ttgl.constexpr(layouts)
+
+    @gluon.aggregate
+    class TensorTupleType:
+        values: ttgl.tuple
+
+        @gluon.jit
+        def arange(start: ttgl.constexpr = 0):
+            ttgl.static_assert(len(jit_shape) == 1, "arange requires a rank-1 TensorTuple")
+            values = ()
+            for i in ttgl.static_range(jit_num_chunks):
+                value = ttgl.arange(
+                    start + jit_offsets[i],
+                    start + jit_offsets[i] + jit_chunks[i],
+                    layout=jit_layouts[i],
+                )
+                values += (value, )
+            return TensorTupleType(values)
+
+        @gluon.jit
+        def full(value, dtype: ttgl.constexpr):
+            values = ()
+            for i in ttgl.static_range(jit_num_chunks):
+                values += (ttgl.full(jit_physical_shapes[i], value, dtype, jit_layouts[i]), )
+            return TensorTupleType(values)
+
+        @gluon.jit
+        def valid_mask():
+            ttgl.static_assert(len(jit_shape) == 1, "valid_mask requires a rank-1 TensorTuple")
+            values = ()
+            for i in ttgl.static_range(jit_num_chunks):
+                offsets = ttgl.arange(
+                    jit_offsets[i],
+                    jit_offsets[i] + jit_chunks[i],
+                    layout=jit_layouts[i],
+                )
+                logical_end = jit_offsets[i] + jit_logical_shapes[i][jit_split_dim]
+                values += (offsets < logical_end, )
+            return TensorTupleType(values)
+
+        @gluon.jit
+        def __add__(self, rhs):
+            values = ()
+            if isinstance(rhs, TensorTupleType):
+                for i in ttgl.static_range(jit_num_chunks):
+                    values += (self.values[i] + rhs.values[i], )
+            else:
+                for i in ttgl.static_range(jit_num_chunks):
+                    values += (self.values[i] + rhs, )
+            return TensorTupleType(values)
+
+        @gluon.jit
+        def __radd__(self, lhs):
+            return self + lhs
+
+        @gluon.jit
+        def __sub__(self, rhs):
+            values = ()
+            if isinstance(rhs, TensorTupleType):
+                for i in ttgl.static_range(jit_num_chunks):
+                    values += (self.values[i] - rhs.values[i], )
+            else:
+                for i in ttgl.static_range(jit_num_chunks):
+                    values += (self.values[i] - rhs, )
+            return TensorTupleType(values)
+
+        @gluon.jit
+        def __rsub__(self, lhs):
+            values = ()
+            for i in ttgl.static_range(jit_num_chunks):
+                values += (lhs - self.values[i], )
+            return TensorTupleType(values)
+
+        @gluon.jit
+        def __mul__(self, rhs):
+            values = ()
+            if isinstance(rhs, TensorTupleType):
+                for i in ttgl.static_range(jit_num_chunks):
+                    values += (self.values[i] * rhs.values[i], )
+            else:
+                for i in ttgl.static_range(jit_num_chunks):
+                    values += (self.values[i] * rhs, )
+            return TensorTupleType(values)
+
+        @gluon.jit
+        def __rmul__(self, lhs):
+            return self * lhs
+
+        @gluon.jit
+        def __truediv__(self, rhs):
+            values = ()
+            if isinstance(rhs, TensorTupleType):
+                for i in ttgl.static_range(jit_num_chunks):
+                    values += (self.values[i] / rhs.values[i], )
+            else:
+                for i in ttgl.static_range(jit_num_chunks):
+                    values += (self.values[i] / rhs, )
+            return TensorTupleType(values)
+
+        @gluon.jit
+        def __rtruediv__(self, lhs):
+            values = ()
+            for i in ttgl.static_range(jit_num_chunks):
+                values += (lhs / self.values[i], )
+            return TensorTupleType(values)
+
+        @gluon.jit
+        def __neg__(self):
+            values = ()
+            for i in ttgl.static_range(jit_num_chunks):
+                values += (-self.values[i], )
+            return TensorTupleType(values)
+
+        @gluon.jit
+        def __lt__(self, rhs):
+            values = ()
+            for i in ttgl.static_range(jit_num_chunks):
+                values += (self.values[i] < rhs, )
+            return TensorTupleType(values)
+
+        @gluon.jit
+        def __le__(self, rhs):
+            values = ()
+            for i in ttgl.static_range(jit_num_chunks):
+                values += (self.values[i] <= rhs, )
+            return TensorTupleType(values)
+
+        @gluon.jit
+        def __gt__(self, rhs):
+            values = ()
+            for i in ttgl.static_range(jit_num_chunks):
+                values += (self.values[i] > rhs, )
+            return TensorTupleType(values)
+
+        @gluon.jit
+        def __ge__(self, rhs):
+            values = ()
+            for i in ttgl.static_range(jit_num_chunks):
+                values += (self.values[i] >= rhs, )
+            return TensorTupleType(values)
+
+        @gluon.jit
+        def __and__(self, rhs):
+            values = ()
+            if isinstance(rhs, TensorTupleType):
+                for i in ttgl.static_range(jit_num_chunks):
+                    values += (self.values[i] & rhs.values[i], )
+            else:
+                for i in ttgl.static_range(jit_num_chunks):
+                    values += (self.values[i] & rhs, )
+            return TensorTupleType(values)
+
+        @gluon.jit
+        def __or__(self, rhs):
+            values = ()
+            if isinstance(rhs, TensorTupleType):
+                for i in ttgl.static_range(jit_num_chunks):
+                    values += (self.values[i] | rhs.values[i], )
+            else:
+                for i in ttgl.static_range(jit_num_chunks):
+                    values += (self.values[i] | rhs, )
+            return TensorTupleType(values)
+
+    TensorTupleType.shape = shape
+    TensorTupleType.split_dim = split_dim
+    TensorTupleType.offsets = offsets
+    TensorTupleType.physical_shapes = physical_shapes
+    TensorTupleType.logical_shapes = logical_shapes
+    TensorTupleType.layouts = layouts
+    TensorTupleType.padding = padding
+    TensorTupleType.num_chunks = len(chunks)
+    return TensorTupleType
+
+
+_TENSOR_TUPLE_LAYOUT = ttgl.BlockedLayout([2], [32], [4], [0])
+_TENSOR_TUPLE_288 = TensorTuple((288, ), _TENSOR_TUPLE_LAYOUT, minimum_padding_size=64)
+
+
+@gluon.jit
+def tensor_tuple_frontend_kernel():
+    offsets = _TENSOR_TUPLE_288.arange()
+    filled = _TENSOR_TUPLE_288.full(3, ttgl.int32)
+    values = -(2 * offsets + filled - offsets) / 2
+    masks = _TENSOR_TUPLE_288.valid_mask() & (offsets < 280)
+    scalar_tensor = ttgl.to_tensor(4)
+    tensor_rhs = offsets + scalar_tensor
+    tensor_lhs = scalar_tensor + offsets
+    reverse_sub = scalar_tensor - offsets
+    reflected_cmp = scalar_tensor < offsets
+    for i in ttgl.static_range(2):
+        anchor(values.values[i])
+        anchor(masks.values[i])
+        anchor(tensor_rhs.values[i])
+        anchor(tensor_lhs.values[i])
+        anchor(reverse_sub.values[i])
+        anchor(reflected_cmp.values[i])
+
+
+@gluon.jit
+def operator_dispatch_compatibility_kernel():
+    layout: ttgl.constexpr = ttgl.BlockedLayout([1], [32], [4], [0])
+    value = ttgl.arange(0, 128, layout=layout)
+    scalar_tensor = ttgl.to_tensor(4)
+    pair = (value, ) + (value, )
+    ttgl.static_assert(3 + 4 == 7)
+    anchor(value + value)
+    anchor(value + 4)
+    anchor(4 + value)
+    anchor(value - scalar_tensor)
+    anchor(scalar_tensor - value)
+    anchor(value < scalar_tensor)
+    anchor(scalar_tensor < value)
+    anchor(-value)
+    anchor(pair[1])
+
+
+@gluon.jit
+def operator_dispatch_boolean_kernel():
+    layout: ttgl.constexpr = ttgl.BlockedLayout([1], [32], [4], [0])
+    value = ttgl.arange(0, 128, layout=layout)
+    result = ForwardOnlyAggregate(value) and ForwardOnlyAggregate(value)
+    anchor(result.value)
+
+
+@gluon.jit
+def operator_dispatch_missing_reflected_kernel():
+    layout: ttgl.constexpr = ttgl.BlockedLayout([1], [32], [4], [0])
+    value = ttgl.arange(0, 128, layout=layout)
+    value + ForwardOnlyAggregate(value)
+
+
+@gluon.jit
+def operator_dispatch_not_implemented_kernel():
+    layout: ttgl.constexpr = ttgl.BlockedLayout([1], [32], [4], [0])
+    value = ttgl.arange(0, 128, layout=layout)
+    NotImplementedAggregate(value) + 1
+
+
+def test_tensor_tuple_frontend():
+    assert _TENSOR_TUPLE_288.physical_shapes == ((256, ), (64, ))
+    assert _TENSOR_TUPLE_288.logical_shapes == ((256, ), (32, ))
+    assert _TENSOR_TUPLE_288.offsets == (0, 256)
+    assert _TENSOR_TUPLE_288.padding == 32
+    assert _TENSOR_TUPLE_288.layouts[0].size_per_thread == [2]
+    assert _TENSOR_TUPLE_288.layouts[1].size_per_thread == [1]
+
+    layout_2d = ttgl.BlockedLayout([1, 4], [1, 32], [1, 4], [1, 0])
+    tensor_tuple_2d = TensorTuple((8, 317), layout_2d, minimum_padding_size=64)
+    assert tensor_tuple_2d.split_dim == 1
+    assert tensor_tuple_2d.physical_shapes == ((8, 256), (8, 64))
+    assert tensor_tuple_2d.logical_shapes == ((8, 256), (8, 61))
+    assert [layout.size_per_thread for layout in tensor_tuple_2d.layouts] == [[1, 4], [1, 1]]
+
+    ir = anonymize_ir(run_parser(tensor_tuple_frontend_kernel, target=BLACKWELL_TARGET).str_nodebug())
+    assert "end = 256 : i32, start = 0 : i32" in ir
+    assert "end = 320 : i32, start = 256 : i32" in ir
+    assert "tensor<256xi32" in ir
+    assert "tensor<64xi32" in ir
+    assert "arith.muli" in ir
+    assert "arith.addi" in ir
+    assert "arith.subi" in ir
+    assert "arith.cmpi slt" in ir
+
+
+def test_operator_dispatch():
+    assert tl.constexpr.__triton_operator_priority__ == 0
+    assert tl.tensor.__triton_operator_priority__ == 1
+    assert ForwardOnlyAggregate.__triton_operator_priority__ == 2
+    assert NotImplementedAggregate.__triton_operator_priority__ == 7
+
+    ir = anonymize_ir(run_parser(operator_dispatch_compatibility_kernel).str_nodebug())
+    assert "arith.addi" in ir
+    assert "arith.subi" in ir
+    assert "arith.cmpi" in ir
+    assert "arith.andi" in run_parser(operator_dispatch_boolean_kernel).str_nodebug()
+
+    with pytest.raises(CompilationError, match=r"unsupported operand type\(s\) for \+"):
+        run_parser(operator_dispatch_missing_reflected_kernel)
+    with pytest.raises(CompilationError, match=r"unsupported operand type\(s\) for \+"):
+        run_parser(operator_dispatch_not_implemented_kernel)
+
+
 @gluon.jit
 def anchor(x):
     pass

--- a/python/triton/compiler/code_generator.py
+++ b/python/triton/compiler/code_generator.py
@@ -50,7 +50,7 @@ def _is_triton_tensor(o: Any) -> bool:
 
 
 def _is_dynamic_value(o: Any) -> bool:
-    return _is_triton_value(o) and not isinstance(o, constexpr)
+    return _is_triton_value(o) and not isinstance(o, (constexpr, tl_tuple))
 
 
 def _is_not_implemented(o: Any) -> bool:
@@ -808,7 +808,7 @@ class CodeGenerator(ast.NodeVisitor):
             return 2
         if isinstance(value, tensor):
             return 1
-        return 0 if _is_triton_value(value) else -1
+        return 0
 
     def _call_operator(self, node, owner, method_name, *args):
         method = getattr(owner, method_name, None)
@@ -829,6 +829,8 @@ class CodeGenerator(ast.NodeVisitor):
 
     def _apply_binary_method(self, node, operator, lhs, rhs):
         """Resolve an operator owner before lowering exactly one method."""
+        if not _is_triton_value(lhs) and isinstance(rhs, constexpr):
+            lhs = constexpr(lhs)
         forward_method, reflected_method, symbol = operator
         lhs_priority = self._operator_priority(lhs)
         rhs_priority = self._operator_priority(rhs)

--- a/python/triton/compiler/code_generator.py
+++ b/python/triton/compiler/code_generator.py
@@ -49,6 +49,14 @@ def _is_triton_tensor(o: Any) -> bool:
     return isinstance(o, tensor)
 
 
+def _is_dynamic_value(o: Any) -> bool:
+    return _is_triton_value(o) and not isinstance(o, constexpr)
+
+
+def _is_not_implemented(o: Any) -> bool:
+    return _unwrap_if_constexpr(o) is NotImplemented
+
+
 def _is_constexpr(o: Any) -> bool:
     return o is None or isinstance(o, (constexpr, language.core.dtype, JITCallable))
 
@@ -59,13 +67,6 @@ def _is_non_scalar_tensor(o: Any) -> bool:
 
 def _is_list_like(o: Any) -> bool:
     return isinstance(o, (list, tuple))
-
-
-@dataclass(frozen=True)
-class _OperatorSpec:
-    forward_method: str
-    reflected_method: str
-    symbol: str
 
 
 def _check_fn_args(node, fn, args):
@@ -803,75 +804,78 @@ class CodeGenerator(ast.NodeVisitor):
 
     @staticmethod
     def _operator_priority(value):
-        # Raw Python objects sort below frontend values, whose base priority is 0.
-        return getattr(type(value), "__triton_operator_priority__", -1)
+        if getattr(type(value), "__triton_aggregate__", False):
+            return 2
+        if isinstance(value, tensor):
+            return 1
+        return 0 if _is_triton_value(value) else -1
 
-    @staticmethod
-    def _operator_type_name(value):
-        if isinstance(value, constexpr):
-            value = value.value
-        return type(value).__name__
-
-    def _get_operator_method(self, owner, method_name):
-        method = getattr(owner, method_name)
+    def _call_operator(self, node, owner, method_name, *args):
+        method = getattr(owner, method_name, None)
+        if method is None:
+            return False, None
         if _is_triton_value(owner) and isinstance(method, JITFunction):
-            return BoundJITMethod(owner, method)
-        return method
+            method = BoundJITMethod(owner, method)
+        return True, self.call_Function(node, method, list(args), {})
 
     def _unsupported_binary_operator(self, node, symbol, lhs, rhs):
-        lhs_type = self._operator_type_name(lhs)
-        rhs_type = self._operator_type_name(rhs)
+        lhs_type, rhs_type = (type(_unwrap_if_constexpr(value)).__name__ for value in (lhs, rhs))
         return self._unsupported(node, f"unsupported operand type(s) for {symbol}: '{lhs_type}' and '{rhs_type}'")
+
+    def _get_operator(self, node, op, kind):
+        if (operator := self._operators.get(type(op))) is None:
+            raise self._unsupported(node, f"AST {kind} operator '{type(op).__name__}' is not (currently) implemented.")
+        return operator
 
     def _apply_binary_method(self, node, operator, lhs, rhs):
         """Resolve an operator owner before lowering exactly one method."""
+        forward_method, reflected_method, symbol = operator
         lhs_priority = self._operator_priority(lhs)
         rhs_priority = self._operator_priority(rhs)
         highest_priority = max(lhs_priority, rhs_priority)
-
-        lhs_candidate = (lhs_priority, lhs, operator.forward_method, rhs)
-        rhs_candidate = (rhs_priority, rhs, operator.reflected_method, lhs)
+        candidates = [(lhs, forward_method, rhs), (rhs, reflected_method, lhs)]
         if lhs_priority == rhs_priority and type(lhs) is not type(rhs) and isinstance(rhs, type(lhs)):
-            candidates = (rhs_candidate, lhs_candidate)
-        else:
-            candidates = (lhs_candidate, rhs_candidate)
+            candidates.reverse()
 
-        for priority, owner, method_name, other in candidates:
-            if priority != highest_priority:
+        for owner, method_name, other in candidates:
+            if self._operator_priority(owner) != highest_priority:
                 continue
-            try:
-                method = self._get_operator_method(owner, method_name)
-            except AttributeError:
+            found, result = self._call_operator(node, owner, method_name, other)
+            if not found:
                 continue
-            result = self.call_Function(node, method, [other], {})
-            if result is NotImplemented or (isinstance(result, constexpr) and result.value is NotImplemented):
-                raise self._unsupported_binary_operator(node, operator.symbol, lhs, rhs)
+            if _is_not_implemented(result):
+                raise self._unsupported_binary_operator(node, symbol, lhs, rhs)
             return result
 
-        raise self._unsupported_binary_operator(node, operator.symbol, lhs, rhs)
+        raise self._unsupported_binary_operator(node, symbol, lhs, rhs)
 
     def visit_BinOp(self, node):
         lhs = self.visit(node.left)
         rhs = self.visit(node.right)
-        operator = self._operator_for_bin_op.get(type(node.op))
-        if operator is None:
-            raise self._unsupported(node,
-                                    "AST binary operator '{}' is not (currently) implemented.".format(node.op.__name__))
+        operator = self._get_operator(node, node.op, "binary")
         return self._apply_binary_method(node, operator, lhs, rhs)
 
-    _operator_for_bin_op: Dict[Type[ast.operator], _OperatorSpec] = {
-        ast.Add: _OperatorSpec('__add__', '__radd__', '+'),
-        ast.Sub: _OperatorSpec('__sub__', '__rsub__', '-'),
-        ast.Mult: _OperatorSpec('__mul__', '__rmul__', '*'),
-        ast.Div: _OperatorSpec('__truediv__', '__rtruediv__', '/'),
-        ast.FloorDiv: _OperatorSpec('__floordiv__', '__rfloordiv__', '//'),
-        ast.Mod: _OperatorSpec('__mod__', '__rmod__', '%'),
-        ast.Pow: _OperatorSpec('__pow__', '__rpow__', '**'),
-        ast.LShift: _OperatorSpec('__lshift__', '__rlshift__', '<<'),
-        ast.RShift: _OperatorSpec('__rshift__', '__rrshift__', '>>'),
-        ast.BitAnd: _OperatorSpec('__and__', '__rand__', '&'),
-        ast.BitOr: _OperatorSpec('__or__', '__ror__', '|'),
-        ast.BitXor: _OperatorSpec('__xor__', '__rxor__', '^'),
+    _operators: Dict[Type[ast.AST], Tuple[str, str, str]] = {
+        ast.Add: ('__add__', '__radd__', '+'),
+        ast.Sub: ('__sub__', '__rsub__', '-'),
+        ast.Mult: ('__mul__', '__rmul__', '*'),
+        ast.Div: ('__truediv__', '__rtruediv__', '/'),
+        ast.FloorDiv: ('__floordiv__', '__rfloordiv__', '//'),
+        ast.Mod: ('__mod__', '__rmod__', '%'),
+        ast.Pow: ('__pow__', '__rpow__', '**'),
+        ast.LShift: ('__lshift__', '__rlshift__', '<<'),
+        ast.RShift: ('__rshift__', '__rrshift__', '>>'),
+        ast.BitAnd: ('__and__', '__rand__', '&'),
+        ast.BitOr: ('__or__', '__ror__', '|'),
+        ast.BitXor: ('__xor__', '__rxor__', '^'),
+        ast.Eq: ('__eq__', '__eq__', '=='),
+        ast.NotEq: ('__ne__', '__ne__', '!='),
+        ast.Lt: ('__lt__', '__gt__', '<'),
+        ast.LtE: ('__le__', '__ge__', '<='),
+        ast.Gt: ('__gt__', '__lt__', '>'),
+        ast.GtE: ('__ge__', '__le__', '>='),
+        ast.And: ('logical_and', 'logical_and', 'and'),
+        ast.Or: ('logical_or', 'logical_or', 'or'),
     }
 
     def visit_then_else_blocks(self, node, liveins, then_block, else_block):
@@ -1127,35 +1131,21 @@ class CodeGenerator(ast.NodeVisitor):
             return constexpr(lhs_value is rhs_value)
         if type(node.ops[0]) is ast.IsNot:
             return constexpr(lhs_value is not rhs_value)
-        operator = self._operator_for_comp_op.get(type(node.ops[0]))
-        if operator is None:
-            raise self._unsupported(
-                node, "AST comparison operator '{}' is not (currently) implemented.".format(node.ops[0].__name__))
+        operator = self._get_operator(node, node.ops[0], "comparison")
         return self._apply_binary_method(node, operator, lhs, rhs)
-
-    _operator_for_comp_op: Dict[Type[ast.cmpop], _OperatorSpec] = {
-        ast.Eq: _OperatorSpec('__eq__', '__eq__', '=='),
-        ast.NotEq: _OperatorSpec('__ne__', '__ne__', '!='),
-        ast.Lt: _OperatorSpec('__lt__', '__gt__', '<'),
-        ast.LtE: _OperatorSpec('__le__', '__ge__', '<='),
-        ast.Gt: _OperatorSpec('__gt__', '__lt__', '>'),
-        ast.GtE: _OperatorSpec('__ge__', '__le__', '>='),
-    }
 
     def visit_UnaryOp(self, node):
         operand = self.visit(node.operand)
         fn = self._method_name_for_unary_op.get(type(node.op))
         if fn is None:
             raise self._unsupported(node, f"AST unary operator '{node.op.__name__}' is not (currently) implemented.")
-        try:
-            method = self._get_operator_method(operand, fn)
-        except AttributeError:
-            if fn == "__not__" and not (_is_triton_value(operand) and not isinstance(operand, constexpr)):
+        found, result = self._call_operator(node, operand, fn)
+        if not found:
+            if fn == "__not__" and not _is_dynamic_value(operand):
                 return constexpr(not operand)
             raise self._unsupported(
                 node, f"AST unary operator '{fn}' is not (currently) implemented on type {type(operand).__name__}")
-        result = self.call_Function(node, method, [], {})
-        if result is NotImplemented or (isinstance(result, constexpr) and result.value is NotImplemented):
+        if _is_not_implemented(result):
             raise self._unsupported(
                 node, f"AST unary operator '{fn}' is not (currently) implemented on type {type(operand).__name__}")
         return result
@@ -1530,10 +1520,8 @@ class CodeGenerator(ast.NodeVisitor):
         return constexpr(node.value)
 
     def visit_BoolOp(self, node: ast.BoolOp):
-        method_name = self._method_name_for_bool_op.get(type(node.op))
-        if method_name is None:
-            raise self._unsupported(
-                node, "AST boolean operator '{}' is not (currently) implemented.".format(node.op.__name__))
+        operator = self._get_operator(node, node.op, "boolean")
+        method_name = operator[0]
 
         nontrivial_values = []
 
@@ -1541,7 +1529,7 @@ class CodeGenerator(ast.NodeVisitor):
             # we visit the values in order, executing their side-effects
             # and possibly early-exiting:
             value = self.visit(subnode)
-            if not (_is_triton_value(value) and not isinstance(value, constexpr)):
+            if not _is_dynamic_value(value):
                 # this is a constexpr, so we might be able to short-circuit:
                 bv = bool(value)
                 if (bv is False) and (method_name == "logical_and"):
@@ -1575,15 +1563,11 @@ class CodeGenerator(ast.NodeVisitor):
         while len(nontrivial_values) >= 2:
             rhs = nontrivial_values.pop()
             lhs = nontrivial_values.pop()
-            symbol = "and" if method_name == "logical_and" else "or"
-            operator = _OperatorSpec(method_name, method_name, symbol)
             res = self._apply_binary_method(node, operator, lhs, rhs)
             nontrivial_values.append(res)
 
         assert len(nontrivial_values) == 1
         return nontrivial_values[0]
-
-    _method_name_for_bool_op: Dict[Type[ast.boolop], str] = {ast.And: 'logical_and', ast.Or: 'logical_or'}
 
     def get_Attribute(self, lhs, attr):
         if _is_triton_tensor(lhs) and attr == "T":

--- a/python/triton/compiler/code_generator.py
+++ b/python/triton/compiler/code_generator.py
@@ -49,7 +49,7 @@ def _is_triton_tensor(o: Any) -> bool:
     return isinstance(o, tensor)
 
 
-def _is_dynamic_value(o: Any) -> bool:
+def _is_dynamic_boolean_operand(o: Any) -> bool:
     return _is_triton_value(o) and not isinstance(o, (constexpr, tl_tuple))
 
 
@@ -846,7 +846,7 @@ class CodeGenerator(ast.NodeVisitor):
             if not found:
                 continue
             if _is_not_implemented(result):
-                raise self._unsupported_binary_operator(node, symbol, lhs, rhs)
+                continue
             return result
 
         raise self._unsupported_binary_operator(node, symbol, lhs, rhs)
@@ -1143,7 +1143,7 @@ class CodeGenerator(ast.NodeVisitor):
             raise self._unsupported(node, f"AST unary operator '{node.op.__name__}' is not (currently) implemented.")
         found, result = self._call_operator(node, operand, fn)
         if not found:
-            if fn == "__not__" and not _is_dynamic_value(operand):
+            if fn == "__not__" and not _is_dynamic_boolean_operand(operand):
                 return constexpr(not operand)
             raise self._unsupported(
                 node, f"AST unary operator '{fn}' is not (currently) implemented on type {type(operand).__name__}")
@@ -1531,7 +1531,7 @@ class CodeGenerator(ast.NodeVisitor):
             # we visit the values in order, executing their side-effects
             # and possibly early-exiting:
             value = self.visit(subnode)
-            if not _is_dynamic_value(value):
+            if not _is_dynamic_boolean_operand(value):
                 # this is a constexpr, so we might be able to short-circuit:
                 bv = bool(value)
                 if (bv is False) and (method_name == "logical_and"):

--- a/python/triton/compiler/code_generator.py
+++ b/python/triton/compiler/code_generator.py
@@ -61,6 +61,13 @@ def _is_list_like(o: Any) -> bool:
     return isinstance(o, (list, tuple))
 
 
+@dataclass(frozen=True)
+class _OperatorSpec:
+    forward_method: str
+    reflected_method: str
+    symbol: str
+
+
 def _check_fn_args(node, fn, args):
     if fn.noinline:
         for idx, arg in enumerate(args):
@@ -794,43 +801,77 @@ class CodeGenerator(ast.NodeVisitor):
         args = [self.visit(x) for x in node.elts]
         return language.tuple(args)
 
-    def _apply_binary_method(self, node, method_name, lhs, rhs):
-        # TODO: raise something meaningful if getattr fails below, esp for reverse method
-        if _is_triton_tensor(lhs):
-            return getattr(lhs, method_name)(rhs, _semantic=self.semantic)
-        if _is_triton_tensor(rhs):
-            reverse_method_name = re.sub(r"__(.*)__", r"__r\1__", method_name)
-            return getattr(rhs, reverse_method_name)(lhs, _semantic=self.semantic)
-        if not isinstance(lhs, (constexpr, language.tuple)) and isinstance(rhs, constexpr):
-            lhs = constexpr(lhs)
-        if isinstance(lhs, constexpr):
-            fn = getattr(lhs, method_name)
+    @staticmethod
+    def _operator_priority(value):
+        # Raw Python objects sort below frontend values, whose base priority is 0.
+        return getattr(type(value), "__triton_operator_priority__", -1)
+
+    @staticmethod
+    def _operator_type_name(value):
+        if isinstance(value, constexpr):
+            value = value.value
+        return type(value).__name__
+
+    def _get_operator_method(self, owner, method_name):
+        method = getattr(owner, method_name)
+        if _is_triton_value(owner) and isinstance(method, JITFunction):
+            return BoundJITMethod(owner, method)
+        return method
+
+    def _unsupported_binary_operator(self, node, symbol, lhs, rhs):
+        lhs_type = self._operator_type_name(lhs)
+        rhs_type = self._operator_type_name(rhs)
+        return self._unsupported(node, f"unsupported operand type(s) for {symbol}: '{lhs_type}' and '{rhs_type}'")
+
+    def _apply_binary_method(self, node, operator, lhs, rhs):
+        """Resolve an operator owner before lowering exactly one method."""
+        lhs_priority = self._operator_priority(lhs)
+        rhs_priority = self._operator_priority(rhs)
+        highest_priority = max(lhs_priority, rhs_priority)
+
+        lhs_candidate = (lhs_priority, lhs, operator.forward_method, rhs)
+        rhs_candidate = (rhs_priority, rhs, operator.reflected_method, lhs)
+        if lhs_priority == rhs_priority and type(lhs) is not type(rhs) and isinstance(rhs, type(lhs)):
+            candidates = (rhs_candidate, lhs_candidate)
         else:
-            fn = self.get_Attribute(lhs, method_name)
-        return self.call_Function(node, fn, [rhs], {})
+            candidates = (lhs_candidate, rhs_candidate)
+
+        for priority, owner, method_name, other in candidates:
+            if priority != highest_priority:
+                continue
+            try:
+                method = self._get_operator_method(owner, method_name)
+            except AttributeError:
+                continue
+            result = self.call_Function(node, method, [other], {})
+            if result is NotImplemented or (isinstance(result, constexpr) and result.value is NotImplemented):
+                raise self._unsupported_binary_operator(node, operator.symbol, lhs, rhs)
+            return result
+
+        raise self._unsupported_binary_operator(node, operator.symbol, lhs, rhs)
 
     def visit_BinOp(self, node):
         lhs = self.visit(node.left)
         rhs = self.visit(node.right)
-        method_name = self._method_name_for_bin_op.get(type(node.op))
-        if method_name is None:
+        operator = self._operator_for_bin_op.get(type(node.op))
+        if operator is None:
             raise self._unsupported(node,
                                     "AST binary operator '{}' is not (currently) implemented.".format(node.op.__name__))
-        return self._apply_binary_method(node, method_name, lhs, rhs)
+        return self._apply_binary_method(node, operator, lhs, rhs)
 
-    _method_name_for_bin_op: Dict[Type[ast.operator], str] = {
-        ast.Add: '__add__',
-        ast.Sub: '__sub__',
-        ast.Mult: '__mul__',
-        ast.Div: '__truediv__',
-        ast.FloorDiv: '__floordiv__',
-        ast.Mod: '__mod__',
-        ast.Pow: '__pow__',
-        ast.LShift: '__lshift__',
-        ast.RShift: '__rshift__',
-        ast.BitAnd: '__and__',
-        ast.BitOr: '__or__',
-        ast.BitXor: '__xor__',
+    _operator_for_bin_op: Dict[Type[ast.operator], _OperatorSpec] = {
+        ast.Add: _OperatorSpec('__add__', '__radd__', '+'),
+        ast.Sub: _OperatorSpec('__sub__', '__rsub__', '-'),
+        ast.Mult: _OperatorSpec('__mul__', '__rmul__', '*'),
+        ast.Div: _OperatorSpec('__truediv__', '__rtruediv__', '/'),
+        ast.FloorDiv: _OperatorSpec('__floordiv__', '__rfloordiv__', '//'),
+        ast.Mod: _OperatorSpec('__mod__', '__rmod__', '%'),
+        ast.Pow: _OperatorSpec('__pow__', '__rpow__', '**'),
+        ast.LShift: _OperatorSpec('__lshift__', '__rlshift__', '<<'),
+        ast.RShift: _OperatorSpec('__rshift__', '__rrshift__', '>>'),
+        ast.BitAnd: _OperatorSpec('__and__', '__rand__', '&'),
+        ast.BitOr: _OperatorSpec('__or__', '__ror__', '|'),
+        ast.BitXor: _OperatorSpec('__xor__', '__rxor__', '^'),
     }
 
     def visit_then_else_blocks(self, node, liveins, then_block, else_block):
@@ -1086,14 +1127,19 @@ class CodeGenerator(ast.NodeVisitor):
             return constexpr(lhs_value is rhs_value)
         if type(node.ops[0]) is ast.IsNot:
             return constexpr(lhs_value is not rhs_value)
-        method_name = self._method_name_for_comp_op.get(type(node.ops[0]))
-        if method_name is None:
+        operator = self._operator_for_comp_op.get(type(node.ops[0]))
+        if operator is None:
             raise self._unsupported(
                 node, "AST comparison operator '{}' is not (currently) implemented.".format(node.ops[0].__name__))
-        return self._apply_binary_method(node, method_name, lhs, rhs)
+        return self._apply_binary_method(node, operator, lhs, rhs)
 
-    _method_name_for_comp_op: Dict[Type[ast.cmpop], str] = {
-        ast.Eq: '__eq__', ast.NotEq: '__ne__', ast.Lt: '__lt__', ast.LtE: '__le__', ast.Gt: '__gt__', ast.GtE: '__ge__'
+    _operator_for_comp_op: Dict[Type[ast.cmpop], _OperatorSpec] = {
+        ast.Eq: _OperatorSpec('__eq__', '__eq__', '=='),
+        ast.NotEq: _OperatorSpec('__ne__', '__ne__', '!='),
+        ast.Lt: _OperatorSpec('__lt__', '__gt__', '<'),
+        ast.LtE: _OperatorSpec('__le__', '__ge__', '<='),
+        ast.Gt: _OperatorSpec('__gt__', '__lt__', '>'),
+        ast.GtE: _OperatorSpec('__ge__', '__le__', '>='),
     }
 
     def visit_UnaryOp(self, node):
@@ -1101,15 +1147,18 @@ class CodeGenerator(ast.NodeVisitor):
         fn = self._method_name_for_unary_op.get(type(node.op))
         if fn is None:
             raise self._unsupported(node, f"AST unary operator '{node.op.__name__}' is not (currently) implemented.")
-        if _is_triton_tensor(operand):
-            return getattr(operand, fn)(_semantic=self.semantic)
         try:
-            return getattr(operand, fn)()
+            method = self._get_operator_method(operand, fn)
         except AttributeError:
-            if fn == "__not__":
+            if fn == "__not__" and not (_is_triton_value(operand) and not isinstance(operand, constexpr)):
                 return constexpr(not operand)
             raise self._unsupported(
                 node, f"AST unary operator '{fn}' is not (currently) implemented on type {type(operand).__name__}")
+        result = self.call_Function(node, method, [], {})
+        if result is NotImplemented or (isinstance(result, constexpr) and result.value is NotImplemented):
+            raise self._unsupported(
+                node, f"AST unary operator '{fn}' is not (currently) implemented on type {type(operand).__name__}")
+        return result
 
     _method_name_for_unary_op: Dict[Type[ast.unaryop], str] = {
         ast.USub: '__neg__', ast.UAdd: '__pos__', ast.Not: '__not__', ast.Invert: '__invert__'
@@ -1492,7 +1541,7 @@ class CodeGenerator(ast.NodeVisitor):
             # we visit the values in order, executing their side-effects
             # and possibly early-exiting:
             value = self.visit(subnode)
-            if not _is_triton_tensor(value):
+            if not (_is_triton_value(value) and not isinstance(value, constexpr)):
                 # this is a constexpr, so we might be able to short-circuit:
                 bv = bool(value)
                 if (bv is False) and (method_name == "logical_and"):
@@ -1504,7 +1553,7 @@ class CodeGenerator(ast.NodeVisitor):
                 # otherwise, our constexpr has no effect on the output of the
                 # expression so we do not append it to nontrivial_values.
             else:
-                if value.type.is_block():
+                if _is_triton_tensor(value) and value.type.is_block():
                     lineno = getattr(node, "lineno", None)
                     if lineno is not None:
                         lineno += self.begin_line
@@ -1526,7 +1575,9 @@ class CodeGenerator(ast.NodeVisitor):
         while len(nontrivial_values) >= 2:
             rhs = nontrivial_values.pop()
             lhs = nontrivial_values.pop()
-            res = self._apply_binary_method(node, method_name, lhs, rhs)
+            symbol = "and" if method_name == "logical_and" else "or"
+            operator = _OperatorSpec(method_name, method_name, symbol)
+            res = self._apply_binary_method(node, operator, lhs, rhs)
             nontrivial_values.append(res)
 
         assert len(nontrivial_values) == 1

--- a/python/triton/language/core.py
+++ b/python/triton/language/core.py
@@ -157,8 +157,6 @@ class const:
 class base_value:
     """Base class of values that exist in the triton IR (i.e. not constexprs).
     """
-    # Higher-priority values own mixed-type frontend operator dispatch.
-    __triton_operator_priority__ = 0
     type: base_type
 
     def _set_name(self, builder: ir.builder, name: str) -> None:
@@ -888,8 +886,6 @@ class tensor(base_value):
        of methods.  Not what I want, but I can't figure out how to fix it.  Give
        it its own section so it looks intentional. :)
     """
-
-    __triton_operator_priority__ = 1
 
     def __init__(self, handle, type: dtype):
         """Not called by user code."""
@@ -1676,7 +1672,6 @@ def _aggregate(cls):
     class aggregate_value(base_value):
         __triton_builtin__ = True
         __triton_aggregate__ = True
-        __triton_operator_priority__ = getattr(cls, "__triton_operator_priority__", 2)
         __annotations__ = all_annotations
 
         @classmethod

--- a/python/triton/language/core.py
+++ b/python/triton/language/core.py
@@ -157,6 +157,8 @@ class const:
 class base_value:
     """Base class of values that exist in the triton IR (i.e. not constexprs).
     """
+    # Higher-priority values own mixed-type frontend operator dispatch.
+    __triton_operator_priority__ = 0
     type: base_type
 
     def _set_name(self, builder: ir.builder, name: str) -> None:
@@ -886,6 +888,8 @@ class tensor(base_value):
        of methods.  Not what I want, but I can't figure out how to fix it.  Give
        it its own section so it looks intentional. :)
     """
+
+    __triton_operator_priority__ = 1
 
     def __init__(self, handle, type: dtype):
         """Not called by user code."""
@@ -1672,6 +1676,7 @@ def _aggregate(cls):
     class aggregate_value(base_value):
         __triton_builtin__ = True
         __triton_aggregate__ = True
+        __triton_operator_priority__ = getattr(cls, "__triton_operator_priority__", 2)
         __annotations__ = all_annotations
 
         @classmethod


### PR DESCRIPTION
Allow `@aggregate` types to participate in operator resolution with clear rules on resolution precedence for forward and reversed operators. 

Actual functional diff is +92, -57. 

Big test case adds an example on how to automatically decompose non-power-of-2 tensors using metaprogramming.