### PR TITLE
[Blackwell] Fix incorrectly pipelined RMW accumulator consumed by another MMA

### DIFF
--- a/include/triton/Dialect/TritonGPU/Transforms/MMAv5PipelineUtility.h
+++ b/include/triton/Dialect/TritonGPU/Transforms/MMAv5PipelineUtility.h
@@ -77,6 +77,13 @@ TMEMAllocOp createTMemAlloc(OpBuilder &builder, TMEMAllocOp oldTMemAllocOp,
 // mma to read back the accumulator for RMW.
 bool hasAccReadModifyWrite(MMAv5OpInterface mma, scf::ForOp forOp);
 
+// Return true if the accumulator of `mma` is loaded inside the loop and that
+// loaded value (transitively) feeds an operand of a *different* MMAv5 op in the
+// loop. When combined with a read-modify-write accumulator, this makes the
+// accumulator unsafe to multi-buffer: the pipeliner rotates it into a register
+// value and the other MMA reads a desynchronized copy.
+bool isAccReadByAnotherMMA(MMAv5OpInterface mma, scf::ForOp forOp);
+
 } // namespace triton::nvidia_gpu
 } // namespace mlir
 

--- a/lib/Dialect/TritonGPU/Transforms/Pipeliner/AssignLatencies.cpp
+++ b/lib/Dialect/TritonGPU/Transforms/Pipeliner/AssignLatencies.cpp
@@ -189,9 +189,22 @@ public:
              !ttng::hasLoadsAfterMMA(mma, forOp))) {
           // MMA can be overlapped with itself
           mmaSelfLatency[mma] = 1;
-          if (!ttng::requiresAccMultiBuffering(mma, forOp) ||
-              (ttng::isAccMultibufferingPossible(mma, forOp) &&
-               !getDisallowAccMultiBuffer(forOp))) {
+          // A read-modify-written accumulator (loaded from TMEM, modified, and
+          // stored back across iterations) that is ALSO consumed by a different
+          // MMA in the loop cannot be safely multi-buffered / rotated across
+          // pipeline stages: the pipeliner hoists the accumulator into a
+          // rotated register value, so the other MMA reads a desynchronized
+          // copy and the loop silently miscompiles. A purely self-recurrent RMW
+          // accumulator (only read back by its own MMA) is still safe to
+          // pipeline via `tt.self_latency`, so we must not disable pipelining
+          // for that case.
+          bool accRMWConsumedByOtherMMA =
+              ttng::hasAccReadModifyWrite(mma, forOp) &&
+              ttng::isAccReadByAnotherMMA(mma, forOp);
+          if (!accRMWConsumedByOtherMMA &&
+              (!ttng::requiresAccMultiBuffering(mma, forOp) ||
+               (ttng::isAccMultibufferingPossible(mma, forOp) &&
+                !getDisallowAccMultiBuffer(forOp)))) {
             // MMA's users can be pushed to the next stage
             opLatency[&op] = 1;
           }

--- a/lib/Dialect/TritonGPU/Transforms/Pipeliner/MMAv5PipelineUtility.cpp
+++ b/lib/Dialect/TritonGPU/Transforms/Pipeliner/MMAv5PipelineUtility.cpp
@@ -214,6 +214,50 @@ bool ttng::hasAccReadModifyWrite(ttng::MMAv5OpInterface mma, scf::ForOp forOp) {
   return false;
 }
 
+bool ttng::isAccReadByAnotherMMA(ttng::MMAv5OpInterface mma, scf::ForOp forOp) {
+  auto tmemAlloc = mma.getAccumulator().getDefiningOp<ttng::TMEMAllocOp>();
+  if (!tmemAlloc || !forOp.isDefinedOutsideOfLoop(tmemAlloc))
+    return false;
+  // Seed the walk with the values loaded from the accumulator inside the loop.
+  SmallVector<Value> worklist;
+  for (auto user : tmemAlloc->getUsers()) {
+    if (isa<ttng::TMEMLoadOp>(user) && forOp->isAncestor(user->getParentOp()))
+      worklist.push_back(user->getResult(0));
+  }
+  DenseSet<Value> seen;
+  while (!worklist.empty()) {
+    Value v = worklist.pop_back_val();
+    if (!seen.insert(v).second)
+      continue;
+    for (OpOperand &use : v.getUses()) {
+      Operation *owner = use.getOwner();
+      // Reaching a different MMA (as any operand, including the accumulator of
+      // that other MMA) is the unsafe pattern we are looking for.
+      if (auto otherMma = dyn_cast<ttng::MMAv5OpInterface>(owner)) {
+        if (otherMma.getOperation() != mma.getOperation())
+          return true;
+        continue;
+      }
+      // The store-back leg of the read-modify-write cycle is not a consumer.
+      if (isa<ttng::TMEMStoreOp>(owner))
+        continue;
+      // Follow values through terminators: into scf.if results and into the
+      // for-loop's iter-args (matches hasAccReadModifyWrite's traversal).
+      if (auto yield = dyn_cast<scf::YieldOp>(owner)) {
+        if (auto ifOp = dyn_cast<scf::IfOp>(yield->getParentOp()))
+          worklist.push_back(ifOp.getResult(use.getOperandNumber()));
+        if (yield->getParentOp() == forOp)
+          worklist.push_back(forOp.getRegionIterArg(use.getOperandNumber()));
+        continue;
+      }
+      // Propagate through elementwise / convert / local_alloc / etc.
+      for (Value res : owner->getResults())
+        worklist.push_back(res);
+    }
+  }
+  return false;
+}
+
 static bool accUseFlagSetToFalse(ttng::MMAv5OpInterface mma, scf::ForOp forOp) {
   Value accUseFlag = mma.useAccumulator();
   if (matchPattern(accUseFlag, m_Zero())) {

--- a/test/TritonGPU/pipeline-assign-latencies.mlir
+++ b/test/TritonGPU/pipeline-assign-latencies.mlir
@@ -1223,3 +1223,53 @@ tt.func @tc_gen5_mma_alloc_block_arg(%lb : index, %ub : index, %step : index,
   tt.return
 }
 }
+
+// -----
+
+// A read-modify-written accumulator (TMEM load -> modify -> store back) that
+// is ALSO consumed as an operand of a different MMA in the loop must not be
+// pipelined: multi-buffering would rotate it into a register value and the
+// other MMA would read a desynchronized copy (silent miscompile). The state
+// MMA gets only tt.self_latency; the consumer MMA (fresh acc) still pipelines.
+#blocked = #ttg.blocked<{sizePerThread = [1, 8], threadsPerWarp = [2, 16], warpsPerCTA = [4, 1], order = [1, 0]}>
+#blocked1 = #ttg.blocked<{sizePerThread = [1, 128], threadsPerWarp = [32, 1], warpsPerCTA = [4, 1], order = [1, 0]}>
+#shared = #ttg.nvmma_shared<{swizzlingByteWidth = 128, transposed = false, elementBitWidth = 16}>
+#smem = #ttg.shared_memory
+#tmem = #ttng.tensor_memory_encoding<blockM = 128, blockN = 128, colStride = 1>
+module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.target = "cuda:100", "ttg.threads-per-warp" = 32 : i32} {
+  // CHECK-LABEL: @rmw_acc_read_by_other_mma
+  tt.func public @rmw_acc_read_by_other_mma(%arg0: tensor<128x128x!tt.ptr<f16>, #blocked> {tt.contiguity = dense<[1, 16]> : tensor<2xi32>, tt.divisibility = dense<[16, 16]> : tensor<2xi32>}, %arg1: tensor<128x128x!tt.ptr<f16>, #blocked> {tt.contiguity = dense<[1, 16]> : tensor<2xi32>, tt.divisibility = dense<[16, 16]> : tensor<2xi32>}, %arg2: i32) -> tensor<128x128xf16, #blocked1> {
+    %true = arith.constant true
+    %cst = arith.constant dense<0.000000e+00> : tensor<128x128xf32, #blocked1>
+    %cst_0 = arith.constant dense<2.000000e+00> : tensor<128x128xf32, #blocked1>
+    %c0_i32 = arith.constant 0 : i32
+    %c1_i32 = arith.constant 1 : i32
+    %0, %acc_tok = ttng.tmem_alloc : () -> (!ttg.memdesc<128x128xf32, #tmem, #ttng.tensor_memory, mutable>, !ttg.async.token)
+    %other, %other_tok0 = ttng.tmem_alloc : () -> (!ttg.memdesc<128x128xf32, #tmem, #ttng.tensor_memory, mutable>, !ttg.async.token)
+    %init_tok = ttng.tmem_store %cst, %0[%acc_tok], %true : tensor<128x128xf32, #blocked1> -> !ttg.memdesc<128x128xf32, #tmem, #ttng.tensor_memory, mutable>
+    %oinit_tok = ttng.tmem_store %cst, %other[%other_tok0], %true : tensor<128x128xf32, #blocked1> -> !ttg.memdesc<128x128xf32, #tmem, #ttng.tensor_memory, mutable>
+    %last:2 = scf.for %arg3 = %c0_i32 to %arg2 step %c1_i32 iter_args(%tok = %init_tok, %otok = %oinit_tok) -> (!ttg.async.token, !ttg.async.token) : i32 {
+      %3 = tt.load %arg0 : tensor<128x128x!tt.ptr<f16>, #blocked>
+      %4 = ttg.local_alloc %3 : (tensor<128x128xf16, #blocked>) -> !ttg.memdesc<128x128xf16, #shared, #smem, mutable>
+      %5 = tt.load %arg1 : tensor<128x128x!tt.ptr<f16>, #blocked>
+      %6 = ttg.local_alloc %5 : (tensor<128x128xf16, #blocked>) -> !ttg.memdesc<128x128xf16, #shared, #smem, mutable>
+      %7, %load_tok = ttng.tmem_load %0[%tok] : !ttg.memdesc<128x128xf32, #tmem, #ttng.tensor_memory, mutable> -> tensor<128x128xf32, #blocked1>
+      // The loaded accumulator value is consumed as an operand of another MMA.
+      %acc_h = arith.truncf %7 : tensor<128x128xf32, #blocked1> to tensor<128x128xf16, #blocked1>
+      %acc_s = ttg.local_alloc %acc_h : (tensor<128x128xf16, #blocked1>) -> !ttg.memdesc<128x128xf16, #shared, #smem, mutable>
+      // The consumer MMA (fresh accumulator) is still pipelined.
+      // CHECK: ttng.tc_gen5_mma {{.*}} {tt.latency = 1 : i32, tt.self_latency = 1 : i32}
+      %cons_tok = ttng.tc_gen5_mma %acc_s, %6, %other[%otok], %true, %true : !ttg.memdesc<128x128xf16, #shared, #smem, mutable>, !ttg.memdesc<128x128xf16, #shared, #smem, mutable>, !ttg.memdesc<128x128xf32, #tmem, #ttng.tensor_memory, mutable>
+      %8 = arith.mulf %7, %cst_0 : tensor<128x128xf32, #blocked1>
+      %store_tok = ttng.tmem_store %8, %0[%load_tok], %true : tensor<128x128xf32, #blocked1> -> !ttg.memdesc<128x128xf32, #tmem, #ttng.tensor_memory, mutable>
+      // The RMW state accumulator is read by another MMA, so it must NOT be
+      // pipelined (no tt.latency), only self-overlapped (tt.self_latency).
+      // CHECK: ttng.tc_gen5_mma %{{.*}}, %{{.*}}, %{{.*}} {tt.self_latency = 1 : i32}
+      %mma_tok = ttng.tc_gen5_mma %4, %6, %0[%store_tok], %true, %true : !ttg.memdesc<128x128xf16, #shared, #smem, mutable>, !ttg.memdesc<128x128xf16, #shared, #smem, mutable>, !ttg.memdesc<128x128xf32, #tmem, #ttng.tensor_memory, mutable>
+      scf.yield %mma_tok, %cons_tok : !ttg.async.token, !ttg.async.token
+    } {tt.scheduled_max_stage = 2 : i32}
+    %1, %res_tok = ttng.tmem_load %0[%last#0] : !ttg.memdesc<128x128xf32, #tmem, #ttng.tensor_memory, mutable> -> tensor<128x128xf32, #blocked1>
+    %2 = arith.truncf %1 : tensor<128x128xf32, #blocked1> to tensor<128x128xf16, #blocked1>
+    tt.return %2 : tensor<128x128xf16, #blocked1>
+  }
+}


### PR DESCRIPTION
On sm_100, a loop-carried TMEM accumulator that is read-modify-written across iterations (tmem_load -> elementwise-modify -> tmem_store) and is ALSO consumed as an operand of a *different* MMA in the same loop is silently miscompiled at num_warps>=4 (async tcgen05 path) with num_stages>=2. AssignLatencies gives the state MMA `tt.latency = 1`, so the pipeliner multi-buffers the accumulator by hoisting it into a rotated register iter-arg; the consuming MMA then reads a desynchronized copy of the accumulator. num_warps<=2 (register mma.sync) and num_stages=1 are unaffected.

This shows up in chunked simple-GLA / Mamba-2 (SSD) forward kernels, where the recurrent [K,V] state is decayed (elementwise-scaled) each chunk and used both to produce the inter-chunk output (dot(q, state)) and to accumulate the next state (state += dot(k, v)).

The existing `hasAccReadModifyWrite` guard that erases the MMA latency was only applied on the warp-specialized path, so non-warp-specialized loops hit the bug. A purely self-recurrent RMW accumulator (only read back by its own MMA) is still safely pipelined via `tt.self_latency` (see #6761), so pipelining must not be disabled for that case -- which is why simply relanding the earlier cyclic-accumulator fix does not cover this.

Add `isAccReadByAnotherMMA` (following the accumulator's loaded value through scf.if results and for-loop iter-args, matching `hasAccReadModifyWrite`) and, only in the combined RMW + consumed-by- another-MMA case, skip pushing the MMA's users to the next stage (no `tt.latency`). Self-recurrent RMW accumulators keep their behavior.

Adds a lit test `@rmw_acc_read_by_other_mma`.

<!---
The core Triton is a small number of people, and we receive many PRs (thank
you!).  To help us review your code more quickly, **if you are a new
contributor (less than 3 PRs merged) we ask that you complete the following
tasks and include the filled-out checklist in your PR description.**

Complete the following tasks before sending your PR, and replace `[ ]` with
`[x]` to indicate you have done them.
-->

# New contributor declaration
- [x] I am not making a trivial change, such as fixing a typo in a comment.

- [x] I have written a PR description following these
  [rules](https://cbea.ms/git-commit/#why-not-how).

- [x] I have run `pre-commit run --from-ref origin/main --to-ref HEAD`.

- Select one of the following.
  - [x] I have added tests.
    - `/test` for `lit` tests
    - `/unittest` for C++ tests
    - `/python/test` for end-to-end tests
  - [ ] This PR does not need a test because `FILL THIS IN`.

- Select one of the following.
  - [ ] I have not added any `lit` tests.
  - [x] The `lit` tests I have added follow these [best practices](https://mlir.llvm.org/getting_started/TestingGuide/#filecheck-best-practices),
    including the "tests should be minimal" section. (Usually running Python code
    and using the instructions it generates is not minimal.)
