### PR TITLE
Remove unused variable 'kernels' from 02-fused-softmax.py

### DIFF
--- a/python/tutorials/02-fused-softmax.py
+++ b/python/tutorials/02-fused-softmax.py
@@ -118,7 +118,6 @@ NUM_REGS = properties["max_num_regs"]
 SIZE_SMEM = properties["max_shared_mem"]
 WARP_SIZE = properties["warpSize"]
 target = triton.runtime.driver.active.get_current_target()
-kernels = {}
 
 
 def softmax(x):


### PR DESCRIPTION
Hi,
The assignment 

```
kernels = {} 
```

in https://github.com/triton-lang/triton/blob/8512cf89a305cd4202a2bc4206d17805128d2c0c/python/tutorials/02-fused-softmax.py#L121 is never accessed and can potentially be removed.
