### PR TITLE
[Gluon] Fix FP8 expect_zero debug assertions

### DIFF
--- a/lib/Dialect/Gluon/Transforms/ResolveAutoEncodings.cpp
+++ b/lib/Dialect/Gluon/Transforms/ResolveAutoEncodings.cpp
@@ -36,6 +36,20 @@ LogicalResult inferAutoLayout(ModuleOp &mod) {
 
     if (failed(inferLayout(func, isAutoEncodingTensorType, seedEncodings)))
       return failure();
+
+    // A layout conversion does not otherwise constrain its source. If the
+    // source remains unresolved, prefer the destination encoding so the
+    // conversion is trivial without overriding constraints from other uses.
+    seedEncodings.clear();
+    func.walk([&](ttg::ConvertLayoutOp op) {
+      if (!isAutoEncodingTensorType(op.getSrc().getType()))
+        return;
+      auto resultTy = cast<RankedTensorType>(op.getType());
+      seedEncodings.push_back({op.getSrc(), resultTy.getEncoding()});
+    });
+    if (!seedEncodings.empty() &&
+        failed(inferLayout(func, isAutoEncodingTensorType, seedEncodings)))
+      return failure();
   }
   return success();
 }

--- a/python/test/gluon/test_frontend.py
+++ b/python/test/gluon/test_frontend.py
@@ -117,6 +117,28 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.targ
 """)
 
 
+@gluon.jit
+def expect_zero_fp8_kernel(ptr, BLOCK_SIZE: ttgl.constexpr):
+    layout: ttgl.constexpr = ttgl.BlockedLayout([1], [32], [4], [0])
+    offsets = ttgl.arange(0, BLOCK_SIZE, layout=layout)
+    value = ttgl.load(ptr + offsets)
+    mask = ttgl.full([BLOCK_SIZE], True, ttgl.int1, layout=ttgl.AutoLayout())
+    ttgl.expect_zero(value, mask)
+    mask.reshape([BLOCK_SIZE // 2, 2]).split()
+
+
+def test_expect_zero_fp8_debug():
+    module = run_parser(
+        expect_zero_fp8_kernel,
+        *make_args(MockTensor(ttgl.float8e4nv), BLOCK_SIZE=16, debug=True),
+        target=BLACKWELL_TARGET,
+    )
+    ir = module.str_nodebug()
+    assert "ttg.convert_layout" in ir
+    assert "tt.assert" in ir
+    assert "tt.split" in ir
+
+
 @filecheck_test
 @gluon.jit
 def test_histogram_frontend():

--- a/python/triton/experimental/gluon/language/_semantic.py
+++ b/python/triton/experimental/gluon/language/_semantic.py
@@ -249,6 +249,13 @@ class GluonSemantic(TritonSemantic[TensorTy]):
         handle = self.builder.create_convert_layout(ret_ty_ir, value.handle)
         return ttgl.tensor(handle, ret_ty)
 
+    def device_assert(self, cond: TensorTy, msg: str, mask: TensorTy | None) -> TensorTy:
+        if (self.builder.options.debug and mask is not None and isinstance(cond.type, ttgl.distributed_type)
+                and isinstance(mask.type, ttgl.distributed_type) and cond.shape == mask.shape
+                and not isinstance(cond.type.layout, AutoLayout) and cond.type.layout != mask.type.layout):
+            mask = self.convert_layout(mask, cond.type.layout)
+        return super().device_assert(cond, msg, mask)
+
     def allocate_shared(self, element_ty, shape, layout, value):
         _check(isinstance(element_ty, ttgl.dtype), lambda: f"expected 'element_ty' to be a dtype but got {element_ty}")
         _check(_is_int_list(shape), lambda: f"all elements of 'shape' must be integers but got {shape}")

--- a/python/triton/language/core.py
+++ b/python/triton/language/core.py
@@ -2722,9 +2722,11 @@ def expect_zero(x, mask, _semantic=None):
         return _semantic.where(mask, 0, x)
     if _semantic.builder.options.debug:
         x_tensor = _semantic.to_tensor(x)
+        if x_tensor.dtype.is_fp8():
+            x_tensor = _semantic.cast(x_tensor, float32)
         zero = _semantic.to_tensor(0)
-        cond = _semantic.or_(_semantic.equal(x_tensor, zero), _semantic.not_(mask))
-        _semantic.device_assert(cond, "expect_zero expected x == 0 where mask is true", None)
+        cond = _semantic.equal(x_tensor, zero)
+        _semantic.device_assert(cond, "expect_zero expected x == 0 where mask is true", mask)
     return x
 
 

--- a/test/Gluon/auto_encoding.mlir
+++ b/test/Gluon/auto_encoding.mlir
@@ -42,6 +42,33 @@ module attributes {"ttg.target" = "cuda:90", "ttg.num-ctas" = 1 : i32, "ttg.num-
 // -----
 
 #blocked = #ttg.blocked<{sizePerThread = [4], threadsPerWarp = [32], warpsPerCTA = [4], order = [0]}>
+#blocked1 = #ttg.blocked<{sizePerThread = [1], threadsPerWarp = [32], warpsPerCTA = [4], order = [0]}>
+
+module attributes {"ttg.target" = "cuda:90", "ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, "ttg.threads-per-warp" = 32 : i32} {
+  // CHECK-LABEL: @infer_convert_source_fallback
+  // CHECK: [[CST:%.*]] = arith.constant dense<7> : tensor<16xi32, [[BLOCKED:#.*]]>
+  // CHECK: [[CVT:%.*]] = ttg.convert_layout [[CST]] : tensor<16xi32, [[BLOCKED]]> -> tensor<16xi32, [[BLOCKED]]>
+  tt.func public @infer_convert_source_fallback() -> tensor<16xi32, #blocked> {
+    %0 = arith.constant dense<7> : tensor<16xi32, #gluon.auto_encoding>
+    %cvt = ttg.convert_layout %0 : tensor<16xi32, #gluon.auto_encoding> -> tensor<16xi32, #blocked>
+    tt.return %cvt : tensor<16xi32, #blocked>
+  }
+
+  // CHECK-LABEL: @infer_convert_source_with_other_constraint
+  // CHECK: [[CST:%.*]] = arith.constant dense<7> : tensor<16xi32, [[BLOCKED1:#.*]]>
+  // CHECK: [[CVT:%.*]] = ttg.convert_layout [[CST]] : tensor<16xi32, [[BLOCKED1]]> -> tensor<16xi32, [[BLOCKED:#.*]]>
+  tt.func public @infer_convert_source_with_other_constraint() -> (tensor<16xi32, #blocked>, tensor<16xi32, #blocked1>) {
+    %0 = arith.constant dense<7> : tensor<16xi32, #gluon.auto_encoding>
+    %cvt = ttg.convert_layout %0 : tensor<16xi32, #gluon.auto_encoding> -> tensor<16xi32, #blocked>
+    %set = gluon.set_auto_layout %0 : tensor<16xi32, #gluon.auto_encoding> -> tensor<16xi32, #blocked1>
+    tt.return %cvt, %set : tensor<16xi32, #blocked>, tensor<16xi32, #blocked1>
+  }
+}
+
+
+// -----
+
+#blocked = #ttg.blocked<{sizePerThread = [4], threadsPerWarp = [32], warpsPerCTA = [4], order = [0]}>
 
 module attributes {"ttg.target" = "cuda:90", "ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, "ttg.threads-per-warp" = 32 : i32} {
   tt.func public @infer_if(%arg0 : i1) -> tensor<16xi32, #blocked> {


### PR DESCRIPTION
## Summary

- widen FP8 values before the `expect_zero` debug equality check
- preserve independent auto-layout inference for reusable Gluon assertion masks

ConSan enables debug assertions, so an FP8 `expect_zero` currently fails when its value is compared with the integer zero literal. Passing the mask through `device_assert` also lets Gluon insert an assertion-local layout conversion instead of constraining later uses of the mask.