### PR TITLE
[build] job server fix

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -300,7 +300,9 @@ class CMakeBuild(build_ext):
         cmake_args += [f"-DCMAKE_BUILD_TYPE={cfg}"]
         if platform.system() == "Windows":
             cmake_args += [f"-DCMAKE_RUNTIME_OUTPUT_DIRECTORY_{cfg.upper()}={extdir}"]
-        else:
+        # This tests for "--jobserver-auth=fifo:" rather than "--jobserver-auth" because ninja
+        # only supports a jobserver in fifo mode. In other cases, use a default job count.
+        elif "--jobserver-auth=fifo:" not in os.environ.get("MAKEFLAGS", ""):
             max_jobs = os.getenv("MAX_JOBS", str(2 * os.cpu_count()))
             build_args += ['-j' + max_jobs]
 


### PR DESCRIPTION
[build] job server fix

Triton may be built as one step/rule within some outer project's build system.
That outer project may be built using `make`, with a jobserver enabled. In this
case, we want the Triton build to integrate with that jobserver, to limit the
total number of parallel jobs in the system to what's allowed by that
jobserver. However, if we pass `-j` to `cmake --build`, this forces the
underlying `make` or `ninja` to ignore any already-extant jobserver and run its
own, which is then unaware of jobs outside of the Triton build process. On some
systems, the default job limit of cpu_count*2 within Triton, plus the parallel
jobs run by the outer build system, can overload system memory, causing the
system to swap, become unresponsive, and fail due to the OOM killer. (As an
aside, this default is likely too aggressive on its own, irrespective of outer
job servers.)

Enhance Triton's `setup.py` to detect any outer jobserver and skip passing
the `-j` option to triton's build process.

Behaviour is now:
* No or non-parallel outer `make`:
  As before (ninja builds parallel by default).
* Outer parallel `make`, but old version of `make` that isn't in fifo mode:
  As before (ninja builds parallel by default).
* Outer parallel `make` that operates in fifo mode, but an old `ninja` that
  doesn't support `make`'s jobserver:
  (This Situation doesn't arise, because pyproject.toml causes an up-to-date
  ninja to be installed in the build environment.)
  As before (ninja builds parallel by default).
* Outer parallel `make` that operates in fifo mode, with a new `ninja` that
  supports integrating with `make`'s jobserver:
  `ninja` runs as many parallel jobs as the jobserver allows, which allows
  the outer build process to own/implement the choice of parallel job
  count.

<!---
The core Triton is a small number of people, and we receive many PRs (thank
you!).  To help us review your code more quickly, **if you are a new
contributor (less than 3 PRs merged) we ask that you complete the following
tasks and include the filled-out checklist in your PR description.**

Complete the following tasks before sending your PR, and replace `[ ]` with
`[x]` to indicate you have done them.
-->

# New contributor declaration
- [x] I am not making a trivial change, such as fixing a typo in a comment.

- [x] I have written a PR description following these
  [rules](https://cbea.ms/git-commit/#why-not-how).

- [x] I have run `pre-commit run --from-ref origin/main --to-ref HEAD`.

- Select one of the following.
  - [ ] I have added tests.
    - `/test` for `lit` tests
    - `/unittest` for C++ tests
    - `/python/test` for end-to-end tests
  - [x] This PR does not need a test because the change only affects the build process, not the build results.

- Select one of the following.
  - [x] I have not added any `lit` tests.
  - [ ] The `lit` tests I have added follow these [best practices](https://mlir.llvm.org/getting_started/TestingGuide/#filecheck-best-practices),
    including the "tests should be minimal" section. (Usually running Python code
    and using the instructions it generates is not minimal.)
