### PR TITLE
Fix float32 variant of test_libdevice_rint silently checking float64

### DIFF
--- a/python/test/unit/language/test_core.py
+++ b/python/test/unit/language/test_core.py
@@ -7260,7 +7260,7 @@ def test_libdevice_rint(dtype_str, device):
     x0_np = np.random.uniform(iinfo32.min, iinfo32.max + 1, size)
     x1_np = np.random.uniform(iinfo64.min, iinfo64.max + 1, size)
     x2_np = np.array([-2.5, -1.5, -0.5, -0., 0., 0.5, 1.5, 2.5, float("inf"), -float("inf"), float("nan")])
-    x_np = np.concatenate((x0_np, x1_np, x2_np))
+    x_np = np.concatenate((x0_np, x1_np, x2_np)).astype(dtype_str)
     x_tri = to_triton(x_np, device=device, dst_type=dtype_str)
 
     @triton.jit


### PR DESCRIPTION
# Description

The float32 parametrization of `test_libdevice_rint` never actually exercised float32. Its input comes from `np.random.uniform`, which always yields float64, and `to_triton`'s `dst_type` argument does not cast plain float types -- so a real fp64 tensor reached the device in both parametrizations.

On A770, which has no fp64 hardware, this made the float32 case fail at module build (ZE_RESULT_ERROR_MODULE_BUILD_FAILURE, "Double type is not supported") -- indistinguishable from the genuine float64 case, even though float32 is fully supported there.

Casting the input to the parametrized dtype makes each case test the precision it claims to.

# New contributor declaration
- [x] I am not making a trivial change, such as fixing a typo in a comment.

- [x] I have written a PR description following these
  [rules](https://cbea.ms/git-commit/#why-not-how).

- [x] I have run `pre-commit run --from-ref origin/main --to-ref HEAD`.

- Select one of the following.
  - [ ] I have added tests.
    - `/test` for `lit` tests
    - `/unittest` for C++ tests
    - `/python/test` for end-to-end tests
  - [x] This PR does not need a test because this PR fixes one

- Select one of the following.
  - [x] I have not added any `lit` tests.
  - [ ] The `lit` tests I have added follow these [best practices](https://mlir.llvm.org/getting_started/TestingGuide/#filecheck-best-practices),
    including the "tests should be minimal" section. (Usually running Python code
    and using the instructions it generates is not minimal.)

