### PR TITLE
[FPSan] Support BF16 matmul accumulation

### DIFF
--- a/lib/Analysis/Utility.cpp
+++ b/lib/Analysis/Utility.cpp
@@ -1124,6 +1124,8 @@ bool supportMMA(triton::DotOp op, int version) {
     RankedTensorType typeA = op.getA().getType();
     int k = typeA.getShape().back();
     auto retType = op.getType();
+    if (retType.getElementType().isBF16())
+      return false;
     auto retShapePerCTA = getShapePerCTA(retType);
     auto rank = retShapePerCTA.size();
     int numWarps = lookupNumWarps(op);
@@ -1159,6 +1161,8 @@ bool supportMMA(triton::DotOp op, int version) {
     auto retType = op.getType();
     RankedTensorType typeA = op.getA().getType();
     int k = typeA.getShape().back();
+    if (retType.getElementType().isBF16())
+      return false;
     // If k size is smaller than the native mma size, we cannot use MMA.
     if (k < 256 / aElemTy.getIntOrFloatBitWidth())
       return false;

--- a/python/test/gluon/test_fpsan.py
+++ b/python/test/gluon/test_fpsan.py
@@ -2022,6 +2022,58 @@ def test_dot_explicit_and_implicit_upcasts_match(device, src_type, mid_type, m, 
     _assert_payload_equal(explicit, explicit_expected)
 
 
+@pytest.mark.skipif(not is_cuda(), reason="Requires NVIDIA dot acceleration")
+@pytest.mark.parametrize("payloads", [(0x00FF, 0x0101, 0x0001, 0x0001), (0x0001, 0x0001, 0x0100, 0x0100)])
+def test_bf16_dot_sharding(device, payloads, fresh_knobs):
+    _require_cuda_backend(device)
+
+    size = 64
+    a0, b0, a1, b1 = payloads
+    a_payload = np.zeros((size, size), dtype=np.uint64)
+    b_payload = np.zeros((size, size), dtype=np.uint64)
+    a_payload[0, 0], b_payload[0, 0] = a0, b0
+    a_payload[0, size // 2], b_payload[size // 2, 0] = a1, b1
+    a_bits = _unmix_payload_to_float_bits(a_payload, "bf16")
+    b_bits = _unmix_payload_to_float_bits(b_payload, "bf16")
+    _, aw = _as_float_bits_tensor(a_bits, "bf16")
+    _, bw = _as_float_bits_tensor(b_bits, "bf16")
+    whole, wholew = _as_float_bits_tensor(np.empty((size, size), dtype=np.int16), "bf16")
+    left, leftw = _as_float_bits_tensor(np.empty((size, size), dtype=np.int16), "bf16")
+    right, rightw = _as_float_bits_tensor(np.empty((size, size), dtype=np.int16), "bf16")
+    split, splitw = _as_float_bits_tensor(np.empty((size, size), dtype=np.int16), "bf16")
+
+    @triton.jit
+    def dot_kernel(a, b, out, K_START: tl.constexpr, K: tl.constexpr, SIZE: tl.constexpr):
+        rows = tl.arange(0, SIZE)[:, None]
+        cols = tl.arange(0, SIZE)[None, :]
+        kk_a = tl.arange(0, K)[None, :] + K_START
+        kk_b = tl.arange(0, K)[:, None] + K_START
+        av = tl.load(a + rows * SIZE + kk_a)
+        bv = tl.load(b + kk_b * SIZE + cols)
+        acc = tl.zeros((SIZE, SIZE), dtype=tl.bfloat16)
+        tl.store(out + rows * SIZE + cols, tl.dot(av, bv, acc=acc, out_dtype=tl.bfloat16))
+
+    @triton.jit
+    def add_kernel(x, y, out, SIZE: tl.constexpr):
+        offsets = tl.arange(0, SIZE * SIZE)
+        tl.store(out + offsets, tl.load(x + offsets) + tl.load(y + offsets))
+
+    fresh_knobs.compilation.instrumentation_mode = ""
+    with pytest.raises(triton.CompilationError, match="out_dtype=bfloat16 is unsupported"):
+        dot_kernel[(1, )](aw, bw, wholew, K_START=0, K=size, SIZE=size, num_warps=4)
+
+    fresh_knobs.compilation.instrumentation_mode = "fpsan"
+    compiled = dot_kernel[(1, )](aw, bw, wholew, K_START=0, K=size, SIZE=size, num_warps=4)
+    dot_kernel[(1, )](aw, bw, leftw, K_START=0, K=size // 2, SIZE=size, num_warps=4)
+    dot_kernel[(1, )](aw, bw, rightw, K_START=size // 2, K=size // 2, SIZE=size, num_warps=4)
+    add_kernel[(1, )](leftw, rightw, splitw, SIZE=size, num_warps=4)
+
+    assert "ttng.tc_gen5_mma" not in compiled.asm["ttgir"]
+    expected = _mm_payload_bits(a_bits, b_bits, None, "bf16", "bf16", "bf16")
+    _assert_payload_equal(whole, expected)
+    _assert_payload_equal(split, expected)
+
+
 @pytest.mark.skipif(not is_cuda(), reason="Requires NVIDIA MMA v2")
 @pytest.mark.parametrize(("type_a", "type_b", "acc_type", "m", "n", "k", "instr_m"), _MMA_V2_CASES)
 def test_mma_v2(device, type_a, type_b, acc_type, m, n, k, instr_m, fresh_knobs):

--- a/python/test/unit/language/test_compile_errors.py
+++ b/python/test/unit/language/test_compile_errors.py
@@ -6,6 +6,7 @@ import warnings
 import torch
 import triton
 import triton.language as tl
+from triton.backends.compiler import GPUTarget
 from triton.compiler.errors import CompilationError, CompileTimeAssertionFailure
 import traceback
 from triton._internal_testing import is_cuda, is_hip, is_hip_cdna4
@@ -446,6 +447,25 @@ def test_max_num_imprecise_acc_limit():
         assert (str(e.value.__cause__) == "max_num_imprecise_acc (128) must be <= K (64)")
     except AssertionError as assertion_err:
         raise assertion_err from e.value
+
+
+def test_bf16_dot_fpsan_rejected_on_hip():
+
+    @triton.jit
+    def dot_kernel():
+        size: tl.constexpr = 64
+        a = tl.full((size, size), 0.0, tl.bfloat16)
+        acc = tl.zeros((size, size), tl.bfloat16)
+        tl.dot(a, a, acc=acc, out_dtype=tl.bfloat16)
+
+    src = triton.compiler.ASTSource(fn=dot_kernel, signature={}, constexprs={})
+    with pytest.raises(CompilationError) as e:
+        triton.compile(
+            src,
+            target=GPUTarget("hip", "gfx942", 64),
+            options={"instrumentation_mode": "fpsan"},
+        )
+    assert "out_dtype=bfloat16 is unsupported" in str(e.value.__cause__)
 
 
 extra_words = "These are extra words in the error message."

--- a/python/triton/language/semantic.py
+++ b/python/triton/language/semantic.py
@@ -1509,9 +1509,15 @@ class TritonSemantic(Generic[TensorTy]):
             _0 = self.builder.get_int32(0)
             ret_scalar_ty = tl.int32
         elif out_dtype.is_bf16():
-            raise ValueError(
-                "out_dtype=bfloat16 is unsupported. Please use out_dtype=float32/float16 and cast with `.to(tl.bfloat16)`"
-            )
+            instrumentation_mode = getattr(self.builder.options, "instrumentation_mode", "")
+            fpsan_bf16_dot = ("fpsan" in instrumentation_mode and lhs.type.scalar.is_bf16()
+                              and rhs.type.scalar.is_bf16())
+            if not fpsan_bf16_dot:
+                raise ValueError(
+                    "out_dtype=bfloat16 is unsupported. Please use out_dtype=float32/float16 and cast with `.to(tl.bfloat16)`"
+                )
+            _0 = self.builder.get_bf16(0)
+            ret_scalar_ty = tl.bfloat16
         elif lhs.type.scalar.is_fp32() or lhs.type.scalar.is_bf16():
             _0 = self.builder.get_fp32(0)
             ret_scalar_ty = tl.float32

--- a/python/triton/language/semantic.py
+++ b/python/triton/language/semantic.py
@@ -1510,7 +1510,9 @@ class TritonSemantic(Generic[TensorTy]):
             ret_scalar_ty = tl.int32
         elif out_dtype.is_bf16():
             instrumentation_mode = getattr(self.builder.options, "instrumentation_mode", "")
-            fpsan_bf16_dot = ("fpsan" in instrumentation_mode and lhs.type.scalar.is_bf16()
+            backend_name = getattr(self.builder.options, "backend_name", "")
+            # AMD matmul acceleration promotes BF16 accumulators to F32 before FPSan.
+            fpsan_bf16_dot = (backend_name == "cuda" and "fpsan" in instrumentation_mode and lhs.type.scalar.is_bf16()
                               and rhs.type.scalar.is_bf16())
             if not fpsan_bf16_dot:
                 raise ValueError(

--- a/python/triton_kernels/triton_kernels/matmul.py
+++ b/python/triton_kernels/triton_kernels/matmul.py
@@ -4,6 +4,7 @@ from dataclasses import dataclass
 import itertools
 import torch
 import triton
+import triton.language as tl
 from enum import Enum, auto
 import math
 from typing import Callable
@@ -137,6 +138,7 @@ class PrecisionConfig:
     c_microblock_size: int | None = None
     c_value_pack_factor: int = 1
     out_dtype: torch.dtype | None = None
+    acc_dtype: torch.dtype | None = None
     # None keeps split-K scratch in the accumulator dtype.
     intermediate_out_dtype: torch.dtype | None = None
     enforce_bitwise_invariance: bool = False
@@ -315,9 +317,12 @@ def matmul(a, b, bias,
     if not isinstance(a, Tensor):
         dtype = FP4 if a_has_mx and a.dtype == torch.uint8 else None
         a = wrap_torch_tensor(a, dtype=dtype)
+    acc_dtype = precision_config.acc_dtype
     intermediate_out_dtype = precision_config.intermediate_out_dtype
     if intermediate_out_dtype is None:
-        intermediate_out_dtype = torch.float64 if a.dtype == b.dtype == FP64 else torch.float32
+        intermediate_out_dtype = acc_dtype if acc_dtype is not None else (
+            torch.float64 if a.dtype == b.dtype == FP64 else torch.float32
+        )
     a_scale_dtype = None if a_scale is None else a_scale.storage.data.dtype
     b_scale_dtype = None if b_scale is None else b_scale.storage.data.dtype
     # NOTE: uint8 scale means OCP E8M0 here. Direct NVFP-style scales stay float8_e4m3fn.
@@ -710,6 +715,7 @@ def matmul(a, b, bias,
                        FnName.QUANTIZE_NVFP4.name,
                    ),
                    Y_VALUE_PACK_FACTOR=precision_config.c_value_pack_factor,
+                   ACC_DTYPE=None if acc_dtype is None else getattr(tl, str(acc_dtype).removeprefix("torch.")),
                    NUM_SMS = grid if opt_flags.is_persistent else 0,
                    **fused_comm_kwargs,
                    **opt_flags.target_kernel_kwargs,

--- a/python/triton_kernels/triton_kernels/matmul_details/_matmul.py
+++ b/python/triton_kernels/triton_kernels/matmul_details/_matmul.py
@@ -107,6 +107,7 @@ def _matmul(
              all_writes_issued=None,
              reduce_rank = 0,
              n_reduce_shards: tl.constexpr = 1,
+             ACC_DTYPE: tl.constexpr = None,
              ):
     tl.assume(stride_y_k >= 0)
     tl.assume(stride_y_z >= 0)
@@ -381,7 +382,9 @@ def _matmul(
     else:
         WTensorScalePtrs = None
     # compute output
-    acc_dtype: tl.constexpr = tl.float64 if x_type == tl.float64 and w_type == tl.float64 else tl.float32
+    acc_dtype: tl.constexpr = ACC_DTYPE if ACC_DTYPE is not None else (
+        tl.float64 if x_type == tl.float64 and w_type == tl.float64 else tl.float32
+    )
     acc = tl.zeros((BLOCK_N, BLOCK_M) if SWAP_XW else (BLOCK_M, BLOCK_N), dtype=acc_dtype)
     x_k_limit = K_X + BLOCK_K * SPLIT_K
     w_k_limit = K_W + PACKED_BLOCK_K_W * SPLIT_K

--- a/python/triton_kernels/triton_kernels/matmul_details/_p_matmul.py
+++ b/python/triton_kernels/triton_kernels/matmul_details/_p_matmul.py
@@ -127,6 +127,7 @@ def _p_matmul(
              all_writes_issued=None,
              reduce_rank=0,
              n_reduce_shards: tl.constexpr = 1,
+             ACC_DTYPE: tl.constexpr = None,
              ):
     # tl.static_assert(SWIZZLE_MX_VALUE is None, "NYI. Value swizzling")
 
@@ -320,7 +321,9 @@ def _p_matmul(
                 XTensorScalePtrs += slice_off_m * stride_x_tensor_scale_m
             XTensorScalePtrs += scale_offs_m.to(index_type) * stride_x_tensor_scale_m
 
-        acc_dtype: tl.constexpr = tl.float64 if x_type == tl.float64 and w_type == tl.float64 else tl.float32
+        acc_dtype: tl.constexpr = ACC_DTYPE if ACC_DTYPE is not None else (
+            tl.float64 if x_type == tl.float64 and w_type == tl.float64 else tl.float32
+        )
         acc = tl.zeros((BLOCK_N, BLOCK_M) if SWAP_XW else (BLOCK_M, BLOCK_N), dtype=acc_dtype)
 
         # ------------------------------------------------------------


### PR DESCRIPTION
<!-- PR title: [FPSan] Support BF16 matmul accumulation -->

## Summary

- Allow BF16 `tl.dot` accumulation only when FPSan is enabled and both operands are BF16.
- Keep BF16-accumulating dots off MMA v3/v5 so FPSan can instrument their arithmetic.
- Add an explicit `acc_dtype` to `triton_kernels.matmul`, including persistent and split-K paths.

## Motivation

FPSan BF16 payload arithmetic must preserve BF16 accumulation semantics. Previously, the language frontend rejected BF16 dot outputs, while `triton_kernels.matmul` always initialized non-FP64 accumulators as FP32. On Hopper and Blackwell, accelerated MMA selection also attempted to lower BF16 accumulators to hardware operations that only support FP32 accumulation for BF16 inputs.

This change permits BF16 dot results only inside FPSan, falls back from unsupported MMA v3/v5 lowering, and threads the requested accumulator dtype through both matmul kernels. When split-K is used without an explicit intermediate dtype, its scratch buffer now follows the accumulator dtype. This keeps whole and sharded BF16 payload accumulation consistent.

## Testing

- `make`
- `pytest -s --tb=short python/test/gluon/test_fpsan.py::test_bf16_dot_sharding` (2 passed)
- `pytest -s --tb=short python/triton_kernels/tests/test_matmul_details/test_opt_flags_split_k.py::test_split_k_uses_intermediate_out_dtype` (1 passed)
- Manual FPSan BF16 `triton_kernels.matmul` smoke tests for non-persistent, persistent, and split-K execution
- `pre-commit run --from-ref origin/main --to-ref HEAD`
