### PR TITLE
[TritonGPU] Preserve safe hoisting without remat splitting

### DIFF
--- a/include/triton/Dialect/TritonGPU/Transforms/Passes.td
+++ b/include/triton/Dialect/TritonGPU/Transforms/Passes.td
@@ -264,7 +264,8 @@ def TritonGPURemoveLayoutConversions : Pass<"tritongpu-remove-layout-conversions
   let options = [
     Option<"disableRematSplitting", "disable-remat-splitting",
            "bool", /*default*/"false",
-           "prevent backward rematerialization from duplicating operations">
+           "prevent rematerialization from splitting or duplicating "
+           "convert-layout work">
   ];
 }
 

--- a/lib/Dialect/TritonGPU/Transforms/RemoveLayoutConversions.cpp
+++ b/lib/Dialect/TritonGPU/Transforms/RemoveLayoutConversions.cpp
@@ -984,8 +984,7 @@ void LayoutRematerialization::hoistConvertOnTopOfExtOrBroadcast(
   funcOp.walk(
       [&](ConvertLayoutOp convertOp) { convertOps.push_back(convertOp); });
   for (ConvertLayoutOp convertOp : convertOps) {
-    if (!hoistConvertOnTopOfExtOrBroadcast(convertOp,
-                                           disableRematSplitting)) {
+    if (!hoistConvertOnTopOfExtOrBroadcast(convertOp, disableRematSplitting)) {
       // If the conversion didn't get removed, consider it for reuse in future
       // backward slices.
       addRematValue(convertOp.getSrc(), convertOp.getType().getEncoding(),

--- a/lib/Dialect/TritonGPU/Transforms/RemoveLayoutConversions.cpp
+++ b/lib/Dialect/TritonGPU/Transforms/RemoveLayoutConversions.cpp
@@ -1145,9 +1145,6 @@ bool isRematBeneficial(ConvertLayoutOp convertOp, const SetVector<Value> &slice,
         nonSliceOnlyValues.insert(operand);
   }
 
-  // In no-split mode, every value in the rematerialized slice must die with
-  // the original conversion. Otherwise rewriteSlice would clone part of the
-  // producer graph while the original path remains live.
   if (disableRematSplitting && !nonSliceOnlyValues.empty()) {
     LDBG("  skipped rematerialization because it would split the slice");
     return false;
@@ -1465,7 +1462,7 @@ bool LayoutRematerialization::hoistConvertOnTopOfExtOrBroadcast(
   int64_t newCvtCost =
       getConvertCost(extOrBroadcastOp->getOperand(0), srcEncoding);
   if (!isRematBeneficial(convertOp, slice, layout, newCvtCost,
-                         disableRematSplitting))
+                         /*disableRematSplitting=*/disableRematSplitting))
     return false;
   // Move the convert before the ext op and rewrite the slice.
   OpBuilder builder(extOrBroadcastOp);
@@ -1617,18 +1614,11 @@ bool backwardRematerialization(ModuleOp module, bool disableRematSplitting) {
 void hoistConvert(ModuleOp module, bool disableRematSplitting) {
   SmallVector<ConvertLayoutOp> convertOps;
   module.walk([&](FuncOp funcOp) {
-    // This helper accepts one size-nondecreasing boundary (a widening cast,
-    // broadcast, or expand-dims), so it replaces one conversion with one
-    // no-larger conversion. isRematBeneficial rejects the rewrite under
-    // disableRematSplitting if any value in the rematerialized slice survives
-    // outside that slice.
     LayoutRematerialization(funcOp).hoistConvertOnTopOfExtOrBroadcast(
         disableRematSplitting);
     if (disableRematSplitting)
       return;
 
-    // These hoists may introduce conversions on conditional edges or after
-    // multiple loads, so keep them disabled when splitting is prohibited.
     LayoutRematerialization(funcOp).hoistConvertIntoConditionals();
     LayoutRematerialization(funcOp).hoistConvertDotOperand();
   });
@@ -1694,10 +1684,8 @@ public:
       cleanupConvertOps();
     } while (changed);
 
-    // 3. For remaining converts, try to hoist them above operations that
-    // generate larger tensors in order to reduce the cost of the convert op.
-    // With remat splitting disabled, only the single-convert cast/broadcast
-    // hoist is allowed.
+    // 3. For remaining converts, try to hoist them above cast generating
+    // larger size types in order to reduce the cost of the convert op.
     hoistConvert(m, disableRematSplitting);
     LLVM_DEBUG({
       DBGS() << "Module after hoisting converts:\n";

--- a/lib/Dialect/TritonGPU/Transforms/RemoveLayoutConversions.cpp
+++ b/lib/Dialect/TritonGPU/Transforms/RemoveLayoutConversions.cpp
@@ -133,7 +133,7 @@ public:
 
   // TODO: Merge the three hoistConvert*(); functions as they are duplicate code
   void hoistConvertDotOperand();
-  void hoistConvertOnTopOfExtOrBroadcast();
+  void hoistConvertOnTopOfExtOrBroadcast(bool disableRematSplitting);
   void hoistConvertIntoConditionals();
 
   /// Attempt to hoist \p convertOp above operations that make the tensor larger
@@ -141,7 +141,8 @@ public:
   /// possible, rematerialize the slice between the convert and that operation
   /// and hoist the convert above it.
   /// \return true if \p convertOp was hoisted, false otherwise.
-  bool hoistConvertOnTopOfExtOrBroadcast(ConvertLayoutOp convertOp);
+  bool hoistConvertOnTopOfExtOrBroadcast(ConvertLayoutOp convertOp,
+                                         bool disableRematSplitting);
 
   /// Attempt to hoist \p convertOp into conditionals so the conversion is only
   /// conditionally executed. If this is possible, rematerialize the slice
@@ -976,13 +977,15 @@ bool LayoutRematerialization::backwardRematerialization(
   return changed;
 }
 
-void LayoutRematerialization::hoistConvertOnTopOfExtOrBroadcast() {
+void LayoutRematerialization::hoistConvertOnTopOfExtOrBroadcast(
+    bool disableRematSplitting) {
   // Go through each ConvertLayoutOp.
   SmallVector<ConvertLayoutOp> convertOps;
   funcOp.walk(
       [&](ConvertLayoutOp convertOp) { convertOps.push_back(convertOp); });
   for (ConvertLayoutOp convertOp : convertOps) {
-    if (!hoistConvertOnTopOfExtOrBroadcast(convertOp)) {
+    if (!hoistConvertOnTopOfExtOrBroadcast(convertOp,
+                                           disableRematSplitting)) {
       // If the conversion didn't get removed, consider it for reuse in future
       // backward slices.
       addRematValue(convertOp.getSrc(), convertOp.getType().getEncoding(),
@@ -1142,6 +1145,9 @@ bool isRematBeneficial(ConvertLayoutOp convertOp, const SetVector<Value> &slice,
         nonSliceOnlyValues.insert(operand);
   }
 
+  // In no-split mode, every value in the rematerialized slice must die with
+  // the original conversion. Otherwise rewriteSlice would clone part of the
+  // producer graph while the original path remains live.
   if (disableRematSplitting && !nonSliceOnlyValues.empty()) {
     LDBG("  skipped rematerialization because it would split the slice");
     return false;
@@ -1397,7 +1403,7 @@ bool LayoutRematerialization::hoistConvertDotOperand(
 // For convert left we try to hoist them above type extension to reduce the cost
 // of the convert.
 bool LayoutRematerialization::hoistConvertOnTopOfExtOrBroadcast(
-    ConvertLayoutOp convertOp) {
+    ConvertLayoutOp convertOp, bool disableRematSplitting) {
   // DotOperand is hoisted by hoistDotOperand
   RankedTensorType targetType = convertOp.getType();
   if (isa<DotOperandEncodingAttr>(targetType.getEncoding()))
@@ -1459,7 +1465,7 @@ bool LayoutRematerialization::hoistConvertOnTopOfExtOrBroadcast(
   int64_t newCvtCost =
       getConvertCost(extOrBroadcastOp->getOperand(0), srcEncoding);
   if (!isRematBeneficial(convertOp, slice, layout, newCvtCost,
-                         /*disableRematSplitting=*/false))
+                         disableRematSplitting))
     return false;
   // Move the convert before the ext op and rewrite the slice.
   OpBuilder builder(extOrBroadcastOp);
@@ -1608,10 +1614,21 @@ bool backwardRematerialization(ModuleOp module, bool disableRematSplitting) {
   return changed;
 }
 
-void hoistConvert(ModuleOp module) {
+void hoistConvert(ModuleOp module, bool disableRematSplitting) {
   SmallVector<ConvertLayoutOp> convertOps;
-  module.walk([](FuncOp funcOp) {
-    LayoutRematerialization(funcOp).hoistConvertOnTopOfExtOrBroadcast();
+  module.walk([&](FuncOp funcOp) {
+    // This helper accepts one size-nondecreasing boundary (a widening cast,
+    // broadcast, or expand-dims), so it replaces one conversion with one
+    // no-larger conversion. isRematBeneficial rejects the rewrite under
+    // disableRematSplitting if any value in the rematerialized slice survives
+    // outside that slice.
+    LayoutRematerialization(funcOp).hoistConvertOnTopOfExtOrBroadcast(
+        disableRematSplitting);
+    if (disableRematSplitting)
+      return;
+
+    // These hoists may introduce conversions on conditional edges or after
+    // multiple loads, so keep them disabled when splitting is prohibited.
     LayoutRematerialization(funcOp).hoistConvertIntoConditionals();
     LayoutRematerialization(funcOp).hoistConvertDotOperand();
   });
@@ -1677,15 +1694,15 @@ public:
       cleanupConvertOps();
     } while (changed);
 
-    if (!disableRematSplitting) {
-      // 3. For remaining converts, try to hoist them above cast generating
-      // larger size types in order to reduce the cost of the convert op.
-      hoistConvert(m);
-      LLVM_DEBUG({
-        DBGS() << "Module after hoisting converts:\n";
-        m.dump();
-      });
-    }
+    // 3. For remaining converts, try to hoist them above operations that
+    // generate larger tensors in order to reduce the cost of the convert op.
+    // With remat splitting disabled, only the single-convert cast/broadcast
+    // hoist is allowed.
+    hoistConvert(m, disableRematSplitting);
+    LLVM_DEBUG({
+      DBGS() << "Module after hoisting converts:\n";
+      m.dump();
+    });
 
     // 4. Prepare dead iter args to be cleaned up by dead code elimination in
     // the pattern rewriter below.

--- a/test/TritonGPU/remove-layout-conversions-disable-remat.mlir
+++ b/test/TritonGPU/remove-layout-conversions-disable-remat.mlir
@@ -31,10 +31,27 @@
 // NO-SPLIT-NEXT: %[[OUTPUT_CONVERT:.+]] = ttg.convert_layout %[[ASM]]
 // NO-SPLIT-NEXT: tt.return %[[OUTPUT_CONVERT]], %[[OUTPUT_CONVERT]], %[[ASM]]
 
+// NO-SPLIT-LABEL: @hoist_broadcast
+// NO-SPLIT: %[[CONVERT:.+]] = ttg.convert_layout %arg0
+// NO-SPLIT-NEXT: %[[BROADCAST:.+]] = tt.broadcast %[[CONVERT]]
+// NO-SPLIT-NEXT: tt.return %[[BROADCAST]]
+
+// NO-SPLIT-LABEL: @hoist_ext
+// NO-SPLIT: %[[CONVERT:.+]] = ttg.convert_layout %arg0
+// NO-SPLIT-NEXT: %[[EXT:.+]] = arith.extui %[[CONVERT]]
+// NO-SPLIT-NEXT: tt.return %[[EXT]]
+
+// NO-SPLIT-LABEL: @reject_hoist_broadcast_multi_use
+// NO-SPLIT: %[[BROADCAST:.+]] = tt.broadcast %arg0
+// NO-SPLIT-NEXT: %[[CONVERT:.+]] = ttg.convert_layout %[[BROADCAST]]
+// NO-SPLIT-NEXT: tt.return %[[CONVERT]], %[[BROADCAST]]
+
 #blocked = #ttg.blocked<{sizePerThread = [1, 4], threadsPerWarp = [1, 32], warpsPerCTA = [4, 2], order = [1, 0], CGALayout = [[0, 1]]}>
 #src = #ttg.linear<{register = [[1, 0], [2, 0], [4, 0], [8, 0], [16, 0], [32, 0], [64, 0]], lane = [[0, 1], [0, 2], [0, 4], [0, 8], [0, 16]], warp = [[0, 32], [0, 64], [0, 128]], block = [[0, 256]]}>
 #packed = #ttg.linear<{register = [[0, 0, 1], [0, 1, 0], [4, 0, 0], [8, 0, 0], [16, 0, 0], [32, 0, 0], [64, 0, 0]], lane = [[0, 2, 0], [0, 4, 0], [0, 8, 0], [0, 16, 0], [0, 32, 0]], warp = [[0, 64, 0], [1, 0, 0], [2, 0, 0]], block = [[0, 128, 0]]}>
 #target = #ttg.linear<{register = [[0, 1]], lane = [[0, 2], [0, 4], [0, 8], [0, 16], [0, 32]], warp = [[0, 64], [0, 0], [0, 0]], block = [[0, 128]]}>
+#hoist_src = #ttg.blocked<{sizePerThread = [4, 1], threadsPerWarp = [16, 2], warpsPerCTA = [1, 8], order = [0, 1], CGALayout = [[0, 1]]}>
+#hoist_dst = #ttg.blocked<{sizePerThread = [1, 1], threadsPerWarp = [32, 1], warpsPerCTA = [8, 1], order = [0, 1], CGALayout = [[0, 1]]}>
 
 module attributes {"ttg.num-ctas" = 2 : i32, "ttg.num-warps" = 8 : i32} {
   tt.func @nested_convert_single_use(%arg0: tensor<128x512xf32, #src>) -> tensor<128x256xi64, #target> {
@@ -54,5 +71,23 @@ module attributes {"ttg.num-ctas" = 2 : i32, "ttg.num-warps" = 8 : i32} {
     %3 = ttg.convert_layout %2 : tensor<128x256xi64, #ttg.slice<{dim = 2, parent = #packed}>> -> tensor<128x256xi64, #target>
     %4 = ttg.convert_layout %2 : tensor<128x256xi64, #ttg.slice<{dim = 2, parent = #packed}>> -> tensor<128x256xi64, #target>
     tt.return %3, %4, %2 : tensor<128x256xi64, #target>, tensor<128x256xi64, #target>, tensor<128x256xi64, #ttg.slice<{dim = 2, parent = #packed}>>
+  }
+
+  tt.func @hoist_broadcast(%arg0: tensor<64x1xi32, #hoist_src>) -> tensor<64x2xi32, #hoist_dst> {
+    %0 = tt.broadcast %arg0 : tensor<64x1xi32, #hoist_src> -> tensor<64x2xi32, #hoist_src>
+    %1 = ttg.convert_layout %0 : tensor<64x2xi32, #hoist_src> -> tensor<64x2xi32, #hoist_dst>
+    tt.return %1 : tensor<64x2xi32, #hoist_dst>
+  }
+
+  tt.func @hoist_ext(%arg0: tensor<64x2xi1, #hoist_src>) -> tensor<64x2xi32, #hoist_dst> {
+    %0 = arith.extui %arg0 : tensor<64x2xi1, #hoist_src> to tensor<64x2xi32, #hoist_src>
+    %1 = ttg.convert_layout %0 : tensor<64x2xi32, #hoist_src> -> tensor<64x2xi32, #hoist_dst>
+    tt.return %1 : tensor<64x2xi32, #hoist_dst>
+  }
+
+  tt.func @reject_hoist_broadcast_multi_use(%arg0: tensor<64x1xi32, #hoist_src>) -> (tensor<64x2xi32, #hoist_dst>, tensor<64x2xi32, #hoist_src>) {
+    %0 = tt.broadcast %arg0 : tensor<64x1xi32, #hoist_src> -> tensor<64x2xi32, #hoist_src>
+    %1 = ttg.convert_layout %0 : tensor<64x2xi32, #hoist_src> -> tensor<64x2xi32, #hoist_dst>
+    tt.return %1, %0 : tensor<64x2xi32, #hoist_dst>, tensor<64x2xi32, #hoist_src>
   }
 }


### PR DESCRIPTION
PR description written by Codex

Allow non-duplicating cast/broadcast layout-conversion hoists when rematerialization splitting is disabled, while retaining the existing multi-use guard. This fixes four ConSan matmul compilations whose shared-memory requirement was 236,764 bytes; SM100 compilation now requires 228,572 bytes with the same 12-warp, 2-CTA configuration.

The focused removal, ConSan, and FPSan lit tests pass. This draft intentionally keeps the change scoped: forward layout-conflict resolution is still not shared-memory-aware and can increase conversion scratch for unrelated multi-layout cases.

## Stack
Merge bottom-up:
- [ ] #11003 (this PR)
