### PR TITLE
[autotuner] Scale fractional top_k by the pruned config count

### DIFF
--- a/python/test/unit/runtime/test_autotuner.py
+++ b/python/test/unit/runtime/test_autotuner.py
@@ -262,6 +262,48 @@ def test_prune_configs_fractional_top_k_keeps_one(device: str):
     _kernel[grid](dst, src, N=N)
     torch.testing.assert_close(src, dst)
 
+def test_prune_configs_fractional_top_k_uses_pruned_count(device: str):
+    # A fractional top_k is a fraction of the configs that survived
+    # early_config_prune, not of the original config list. With 8 configs
+    # pruned down to 4 and top_k=0.5, exactly 2 configs should be benchmarked;
+    # scaling the original count instead would give top_k=4 and bench all 4.
+    N = 1024
+    src = torch.randn(N, device=device)
+    dst = torch.empty(N, device=device)
+
+    benched = []
+
+    def counting_bench(kernel_call, quantiles=None, **kwargs):
+        benched.append(1)
+        return do_bench(kernel_call, quantiles=quantiles, **kwargs)
+
+    def early_config_prune(configs, named_args, **kwargs):
+        return [c for c in configs if c.kwargs['BLOCK_SIZE'] >= 32]
+
+    def perf_model(*args, **kwargs):
+        return kwargs['BLOCK_SIZE']
+
+    configs = [triton.Config(kwargs={'BLOCK_SIZE': bs}) for bs in [1, 2, 4, 8, 32, 64, 128, 256]]
+    prune_configs_by = {
+        'perf_model': perf_model,
+        'early_config_prune': early_config_prune,
+        'top_k': 0.5,
+    }
+
+    @triton.autotune(configs=configs, key=['N'], prune_configs_by=prune_configs_by, do_bench=counting_bench)
+    @triton.jit
+    def _kernel(dst, src, N, BLOCK_SIZE: tl.constexpr):
+        offsets = tl.program_id(0) * BLOCK_SIZE + tl.arange(0, BLOCK_SIZE)
+        x = tl.load(src + offsets, mask=offsets < N)
+        tl.store(dst + offsets, x, mask=offsets < N)
+
+    grid = lambda META: (triton.cdiv(N, META['BLOCK_SIZE']), )
+    _kernel[grid](dst, src, N=N)
+    torch.testing.assert_close(src, dst)
+    assert len(benched) == 2
+
+
+
 
 def test_config_ir_override_changes_disk_cache_key():
     # Autotuner derives persisted result-cache keys from Config.__str__().

--- a/python/triton/runtime/autotuner.py
+++ b/python/triton/runtime/autotuner.py
@@ -296,6 +296,7 @@ class Autotuner(KernelInterface):
                 # the later min() on an empty set. early_config_prune already
                 # guarantees at least one config; mirror that here.
                 top_k = max(1, int(len(self.configs) * top_k))
+                top_k = max(1, int(len(pruned_configs) * top_k))
             elif not isinstance(top_k, int):
                 # Slice index must be an integer
                 raise TypeError("Error while pruning configs, top_k must be either 1) a float <= 1.0 or 2) an int")


### PR DESCRIPTION
## Summary

Fixes #10964.

When `top_k` is given as a fraction, `Autotuner.prune_configs` computes the
integer cutoff from `len(self.configs)` — the full, original config list —
even though `early_config_prune` has already run by that point and the value
is used to slice `pruned_configs`. The fraction is therefore applied against
a set that is no longer the one being pruned.

The practical effect is that fractional `top_k` silently becomes a no-op
whenever `early_config_prune` removes a meaningful number of configs. With
8 configs pruned down to 4 and `top_k=0.5`, the cutoff evaluates to 4, the
`len(pruned_configs) > top_k` guard is false, and all 4 survivors get
benchmarked instead of the intended 2. The larger the early prune, the more
completely the fraction is ignored — which is backwards, since an aggressive
early prune is exactly when a user wants the perf model to narrow things
further.

## Change

`top_k = max(1, int(len(pruned_configs) * top_k))`

The `max(1, ...)` floor is unchanged and still guards the small-config-set
rounding case covered by `test_prune_configs_fractional_top_k_keeps_one`.

## Test

Adds `test_prune_configs_fractional_top_k_uses_pruned_count`, which combines
an `early_config_prune` (8 configs -> 4) with `top_k=0.5` and counts
`do_bench` invocations through a wrapping callback. Expects 2; fails with 4
on `main`.

Integer `top_k` is unaffected, and behavior is identical when no
`early_config_prune` is supplied, so existing autotune configurations should
see no change.
