### PR TITLE
[TritonGPU] Allow arbitrary reinterpret of subslices

### DIFF
--- a/include/triton/Dialect/TritonGPU/IR/TritonGPUOps.td
+++ b/include/triton/Dialect/TritonGPU/IR/TritonGPUOps.td
@@ -338,12 +338,9 @@ def TTG_MemDescReinterpretOp : TTG_Op<"memdesc_reinterpret", [Pure, MemDescViewT
 
   let description = [{
     The `ttg.memdesc_reinterpret` operation reinterprets a memory descriptor
-    as one with a different shape and element type. The logical storage size of
-    the result must not exceed that of the source. Because memory descriptors
-    lack strides, this operation is only valid if the original memory descriptor
-    is contiguous. Contiguous tensor-memory source subviews may be
-    reinterpreted; other subviews must be taken after reinterpreting their
-    parent descriptor.
+    as one with a different shape and element type. Every physical byte,
+    tensor-memory row, and pipeline stage accessed by the result must belong to
+    the source view. The result must not itself be a layout subview.
   }];
 
   let arguments = (ins TTG_MemDescType:$src);

--- a/include/triton/Dialect/TritonNvidiaGPU/IR/TritonNvidiaGPUOps.td
+++ b/include/triton/Dialect/TritonNvidiaGPU/IR/TritonNvidiaGPUOps.td
@@ -1020,8 +1020,9 @@ def TTNG_TMEMSubSliceOp : TTNG_Op<"tmem_subslice", [Pure,
   let description = [{
     This operation takes a subslice of a tensor memory allocation and returns a
     new descriptor containing the address and a view of the subslice.
-    This is similar to ttg.memdesc_subslice and can slice either dimension of a
-    2D tensor memory descriptor, including non-contiguous views within a CTA.
+    This is similar to ttg.memdesc_subslice and can slice either physical-layout
+    dimension or the leading pipeline dimension of an ordinary descriptor. Scale
+    descriptors support their two physical-layout dimensions.
   }];
   let arguments = (ins TTG_MemDescType:$src, I32Attr:$offset,
                        DefaultValuedAttr<I32Attr, "1">:$dim);

--- a/include/triton/Tools/LinearLayout.h
+++ b/include/triton/Tools/LinearLayout.h
@@ -535,6 +535,10 @@ public:
   // TODO(jlebar): Replace with divideLeft.
   int32_t getNumConsecutiveInOut() const;
 
+  // Returns the largest contiguous prefix of an output dimension contained in
+  // the image of this layout projected onto that dimension.
+  [[nodiscard]] int32_t contiguousElemsAlongOutputDim(StringAttr outDim) const;
+
   // Reorders the in/out dimensions of the layout.  This is mostly cosmetic
   // (affecting e.g. the order of getIn/OutDimNames), but it also affects the
   // behavior of reshape.

--- a/lib/Analysis/BufferRegion.cpp
+++ b/lib/Analysis/BufferRegion.cpp
@@ -62,7 +62,11 @@ unsigned getMemDescSize(ttg::MemDescType ty) {
   for (auto [dim, size] : llvm::zip_equal(logicalDims, shape))
     view = view.resizeInDim(dim, size);
   auto offsetDim = StringAttr::get(ty.getContext(), "offset");
-  uint64_t viewSpan = getOutputBasisMask(view, logicalDims, offsetDim) + 1;
+  // Zero physical bases are still owned by the allocation and its subviews.
+  uint64_t zeroMask = (allocation.getInDimSize(offsetDim) - 1) &
+                      ~getInputBasisMask(allocation, offsetDim, logicalDims);
+  uint64_t viewSpan =
+      (getOutputBasisMask(view, logicalDims, offsetDim) | zeroMask) + 1;
   return ((stages - 1) * allocation.getInDimSize(offsetDim) + viewSpan) *
          elSize;
 }
@@ -138,7 +142,7 @@ FailureOr<uint32_t> getMemDescSubsliceByteOffset(ttg::MemDescSubsliceOp op) {
 
   StringAttr offsetDim = StringAttr::get(ctx, "offset");
   StringAttr blockDim = StringAttr::get(ctx, "block");
-  mlir::triton::LinearLayout inverse = layout.invert();
+  mlir::triton::LinearLayout inverse = layout.pseudoinvert();
   auto mapped = inverse.apply(logicalOffsets);
   if (mapped.size() != 2 || mapped[0].first != offsetDim ||
       mapped[1].first != blockDim) {

--- a/lib/Analysis/BufferRegion.cpp
+++ b/lib/Analysis/BufferRegion.cpp
@@ -37,13 +37,34 @@ uint64_t getAllocationOffset(ttng::TMEMAllocOp op) {
 }
 
 unsigned getMemDescSize(ttg::MemDescType ty) {
+  auto encoding = ty.getEncoding();
+  auto shape = ttg::dropPipeliningDim(ty.getShape(), encoding);
+  auto allocShape = ttg::dropPipeliningDim(ty.getAllocShape(), encoding);
+  uint64_t stages = product(ty.getShape().drop_back(shape.size()));
+
   if (isa<ttng::TensorMemorySpaceAttr>(ty.getMemorySpace())) {
-    return ttng::getTmemAllocSizes(ty).numCols;
+    if (stages == 1)
+      return ttng::getTmemAllocSizes(ty).numCols;
+    uint32_t stageCols =
+        ttng::getTMemSubSliceOffset(ty, /*offset=*/1, /*dim=*/0);
+    return (stages - 1) * stageCols +
+           ttng::getTmemAllocSizes(ty).numCols / stages;
   }
   assert(isa<ttg::SharedMemorySpaceAttr>(ty.getMemorySpace()) &&
          "Unsupported memory space");
   unsigned elSize = ty.getElementType().getIntOrFloatBitWidth() / 8;
-  return product(ttg::getShapePerCTA(ty)) * elSize;
+  if (ttg::isPaddedEncoding(encoding))
+    return product(ttg::getShapePerCTA(ty)) * elSize;
+
+  auto allocation = ttg::toLinearLayout(allocShape, encoding);
+  auto view = allocation.pseudoinvert();
+  auto logicalDims = llvm::to_vector(view.getInDimNames());
+  for (auto [dim, size] : llvm::zip_equal(logicalDims, shape))
+    view = view.resizeInDim(dim, size);
+  auto offsetDim = StringAttr::get(ty.getContext(), "offset");
+  uint64_t viewSpan = getOutputBasisMask(view, logicalDims, offsetDim) + 1;
+  return ((stages - 1) * allocation.getInDimSize(offsetDim) + viewSpan) *
+         elSize;
 }
 
 unsigned getAllocSize(ttg::LocalAllocOp op) {

--- a/lib/Analysis/BufferRegion.cpp
+++ b/lib/Analysis/BufferRegion.cpp
@@ -312,6 +312,19 @@ LogicalResult BufferRegionAnalysis::visitOperation(
     }
     return success();
   }
+  if (auto reinterpretOp = dyn_cast<ttg::MemDescReinterpretOp>(op)) {
+    auto type = reinterpretOp.getType();
+    uint32_t size = getMemDescSize(type);
+    if (auto padded = ttg::getPaddedEncoding(type.getEncoding())) {
+      unsigned elementSize = type.getElementType().getIntOrFloatBitWidth() / 8;
+      size = padded.getPaddedSize({size / elementSize}) * elementSize;
+    }
+    for (auto &region : operands[0]->getValue().regions)
+      regionInfo.regions.insert({region.baseOffset, size});
+    for (auto *result : results)
+      propagateIfChanged(result, result->join(regionInfo));
+    return success();
+  }
   if (auto selectOp = dyn_cast<arith::SelectOp>(op)) {
     if (isa<ttg::MemDescType>(selectOp.getType())) {
       regionInfo =
@@ -323,8 +336,7 @@ LogicalResult BufferRegionAnalysis::visitOperation(
     }
   }
   // "Passthrough" ops that don't modify the buffer regions.
-  if (isa<ttg::MemDescTransOp, ttg::MemDescReshapeOp,
-          ttg::MemDescReinterpretOp>(op)) {
+  if (isa<ttg::MemDescTransOp, ttg::MemDescReshapeOp>(op)) {
     // Just propagate the regions from the operand.
     RegionInfo in = operands[0]->getValue();
     for (auto &region : in.regions) {

--- a/lib/Dialect/TritonGPU/IR/Ops.cpp
+++ b/lib/Dialect/TritonGPU/IR/Ops.cpp
@@ -1130,6 +1130,8 @@ LogicalResult MemDescSubsliceOp::verify() {
   if (srcTy.getRank() != dstTy.getRank()) {
     return emitError("result rank must equal to input rank");
   }
+  if (srcTy.getAllocShape() != dstTy.getAllocShape())
+    return emitError("source and result must have the same allocation shape");
 
   auto srcEnc = srcTy.getEncoding();
   auto dstEnc = dstTy.getEncoding();

--- a/lib/Dialect/TritonGPU/IR/Ops.cpp
+++ b/lib/Dialect/TritonGPU/IR/Ops.cpp
@@ -661,11 +661,23 @@ LogicalResult MemDescReinterpretOp::verify() {
   // the destination layouts must be equal.
   auto srcEnc = srcTy.getEncoding();
   auto dstEnc = dstTy.getEncoding();
+  auto isLayoutSubview = [](MemDescType ty) {
+    auto encoding = ty.getEncoding();
+    return dropPipeliningDim(ty.getShape(), encoding) !=
+           dropPipeliningDim(ty.getAllocShape(), encoding);
+  };
+  if (isa<PartitionedSharedEncodingAttr>(srcEnc) ||
+      isa<PartitionedSharedEncodingAttr>(dstEnc))
+    return emitError("cannot reinterpret partitioned shared layouts");
+
   if (isPaddedEncoding(srcEnc) != isPaddedEncoding(dstEnc))
     return emitError(
         "cannot reinterpret between padded and non-padded layouts");
 
   if (isPaddedEncoding(srcEnc)) {
+    if (isLayoutSubview(srcTy))
+      return emitError("cannot reinterpret a padded source subview");
+
     auto getPadPattern = [](MemDescType ty) {
       auto enc = getPaddedEncoding(ty.getEncoding());
       auto elmtSize = ty.getElementType().getIntOrFloatBitWidth() / 8;
@@ -690,71 +702,122 @@ LogicalResult MemDescReinterpretOp::verify() {
     return emitError("source and result must have the same memory space");
   if (srcTy.getMutableMemory() != dstTy.getMutableMemory())
     return emitError("source and result must have the same mutability");
-  auto isLayoutSubview = [](MemDescType ty) {
-    auto encoding = ty.getEncoding();
-    return dropPipeliningDim(ty.getShape(), encoding) !=
-           dropPipeliningDim(ty.getAllocShape(), encoding);
-  };
   bool srcIsLayoutSubview = isLayoutSubview(srcTy);
   bool srcIsTmem =
       isa<nvidia_gpu::TensorMemorySpaceAttr>(srcTy.getMemorySpace());
-  if (isLayoutSubview(dstTy) || (srcIsLayoutSubview && !srcIsTmem))
-    return emitError("source and result must not be subviews; reinterpret the "
-                     "parent descriptor and then take a subview");
-  if (srcIsLayoutSubview) {
-    auto rank = cast<LayoutEncodingTrait>(srcEnc).getRank();
-    auto allocLayout =
-        toLinearLayout(srcTy.getAllocShape().take_back(rank), srcEnc);
-    auto viewLayout = toLinearLayout(srcTy);
-    const auto &allocBases = allocLayout.getBases();
-    const auto &viewBases = viewLayout.getBases();
-    if (viewBases.size() != allocBases.size())
-      return emitError("source subview must be contiguous");
-    for (auto [view, alloc] : llvm::zip_equal(viewBases, allocBases)) {
-      if (view.first != alloc.first ||
-          view.second.size() > alloc.second.size() ||
-          !std::equal(view.second.begin(), view.second.end(),
-                      alloc.second.begin()))
-        return emitError("source subview must be contiguous");
-    }
-  }
+  if (isLayoutSubview(dstTy))
+    return emitError("result must not be a subview");
   assert((isa<SharedMemorySpaceAttr, nvidia_gpu::TensorMemorySpaceAttr>(
               srcTy.getMemorySpace()) &&
           "expected shared or tensor memory"));
+
+  auto allocationLayout = [](MemDescType ty) {
+    return isPaddedEncoding(ty.getEncoding())
+               ? paddedLinearLayout(ty)
+               : toLinearLayout(
+                     dropPipeliningDim(ty.getAllocShape(), ty.getEncoding()),
+                     ty.getEncoding());
+  };
+
+  auto srcAllocation = allocationLayout(srcTy);
+  auto dstAllocation = allocationLayout(dstTy);
   if (srcIsTmem) {
     auto srcAlloc = nvidia_gpu::getTmemAllocSizes(srcTy);
     auto dstAlloc = nvidia_gpu::getTmemAllocSizes(dstTy);
-    if (dstAlloc.numRows > srcAlloc.numRows ||
-        dstAlloc.numCols > srcAlloc.numCols)
-      return emitError()
-             << "result logical storage size must not exceed source "
-                "logical storage size ("
-             << srcAlloc.numRows << "x" << srcAlloc.numCols << " vs "
-             << dstAlloc.numRows << "x" << dstAlloc.numCols << ")";
-    return success();
+    if (dstAlloc.numRows > srcAlloc.numRows)
+      return emitError() << "result tensor-memory row footprint ("
+                         << dstAlloc.numRows << ") exceeds the source view ("
+                         << srcAlloc.numRows << ")";
+
+    auto row = StringAttr::get(getContext(), "row");
+    auto srcLogicalDims = llvm::to_vector(srcAllocation.getOutDimNames());
+    auto dstLogicalDims = llvm::to_vector(dstAllocation.getOutDimNames());
+    uint64_t allocationRows =
+        getInputBasisMask(srcAllocation, row, srcLogicalDims);
+    uint64_t visibleRows =
+        getInputBasisMask(toLinearLayout(srcTy), row, srcLogicalDims);
+    uint64_t destinationRows =
+        getInputBasisMask(dstAllocation, row, dstLogicalDims);
+    if (destinationRows & (allocationRows & ~visibleRows))
+      return emitError(
+          "result accesses tensor-memory rows outside the source subview");
   }
-  auto getViewNumBits = [](MemDescType ty) {
-    auto encoding = ty.getEncoding();
-    auto shape = dropPipeliningDim(ty.getAllocShape(), encoding);
-    LinearLayout layout = isPaddedEncoding(encoding)
-                              ? paddedLinearLayout(shape, encoding)
-                              : toLinearLayout(shape, encoding);
-    int64_t numLayoutCopies = 1;
-    for (int64_t dim : ty.getShape().drop_back(shape.size()))
-      numLayoutCopies *= dim;
-    // Shared memory is allocated by offset; prefix dimensions outside the
-    // layout-ranked suffix represent separate copies of that allocation.
-    auto *ctx = ty.getContext();
-    auto dim = StringAttr::get(ctx, "offset");
-    return numLayoutCopies * layout.getInDimSize(dim) *
-           ty.getElementTypeBitWidth();
-  };
-  auto srcNumBits = getViewNumBits(srcTy);
-  auto dstNumBits = getViewNumBits(dstTy);
-  if (dstNumBits > srcNumBits)
-    return emitError() << "result logical storage size must not exceed source "
-                          "logical storage size ("
-                       << srcNumBits << " vs " << dstNumBits << ")";
+
+  auto addressDim = StringAttr::get(getContext(), srcIsTmem ? "col" : "offset");
+  unsigned unitBits = srcIsTmem ? 32 : 8;
+  unsigned srcElementBits = srcTy.getElementTypeBitWidth();
+  unsigned dstElementBits = dstTy.getElementTypeBitWidth();
+  // Pipeline dimensions outside the layout-ranked suffix represent separate
+  // copies of the physical allocation.
+  uint64_t srcStride = llvm::divideCeil(
+      uint64_t(srcAllocation.getInDimSize(addressDim)) * srcElementBits,
+      uint64_t(unitBits));
+  uint64_t dstStride = llvm::divideCeil(
+      uint64_t(dstAllocation.getInDimSize(addressDim)) * dstElementBits,
+      uint64_t(unitBits));
+  auto srcShape = dropPipeliningDim(srcTy.getShape(), srcEnc);
+  auto dstShape = dropPipeliningDim(dstTy.getShape(), dstEnc);
+  int64_t srcStages = product(srcTy.getShape().drop_back(srcShape.size()));
+  int64_t dstStages = product(dstTy.getShape().drop_back(dstShape.size()));
+  if (dstStride * dstStages > srcStride * srcStages)
+    return emitError() << "result "
+                       << (srcIsTmem ? "tensor-memory column" : "shared-memory")
+                       << " footprint (" << dstStride * dstStages
+                       << (srcIsTmem ? " columns" : " bytes")
+                       << ") exceeds the source view (" << srcStride * srcStages
+                       << (srcIsTmem ? " columns)" : " bytes)");
+
+  // A complete layout tile, including a slice only along the pipeline
+  // dimension, owns every byte in its allocation regardless of zero bases.
+  if (!srcIsLayoutSubview)
+    return success();
+
+  // Remember that we disallow dstTy that's a subview.
+  // A destination without a subview owns its entire physical allocation, even
+  // when its layout has zero bases. Compare its physical footprint against the
+  // source subview's owned offsets, including zero bases in its allocation.
+  auto sourceOffsets = srcAllocation.pseudoinvert();
+  auto logicalDims = llvm::to_vector(sourceOffsets.getInDimNames());
+  for (auto [dim, size] : llvm::zip_equal(logicalDims, srcShape))
+    sourceOffsets = sourceOffsets.resizeInDim(dim, size);
+  sourceOffsets = sourceOffsets.sublayout(logicalDims, {addressDim});
+  // sourceOffset is now a map logicalDims -> offset
+  // with logicalDims of shape srcShape
+
+  // We add a dimension `free` mapping to all the offsets that had
+  // zero bases in the layout as those were owned by the allocation
+  // even if empty, so they can be reinterpreted
+  auto ownedBases = sourceOffsets.getBases();
+  auto freeDim = StringAttr::get(getContext(), "free");
+  uint64_t zeroMask =
+      (srcAllocation.getInDimSize(addressDim) - 1) &
+      ~getInputBasisMask(srcAllocation, addressDim, logicalDims);
+  for (uint64_t bits = zeroMask; bits; bits &= bits - 1)
+    ownedBases[freeDim].push_back({int32_t{1} << llvm::countr_zero(bits)});
+  sourceOffsets =
+      LinearLayout(std::move(ownedBases), sourceOffsets.getOutDims(),
+                   /*requireSurjective=*/false);
+
+  uint64_t contiguousElems =
+      sourceOffsets.contiguousElemsAlongOutputDim(addressDim);
+  // Tensor memory owns whole 32-bit columns, including subword padding.
+  uint64_t contiguousUnits =
+      llvm::divideCeil(contiguousElems * srcElementBits, uint64_t(unitBits));
+  if (contiguousElems == srcAllocation.getInDimSize(addressDim))
+    contiguousUnits = srcStride * srcStages;
+
+  if (dstStride * dstStages > contiguousUnits)
+    return emitError() << "result "
+                       << (srcIsTmem ? "tensor-memory column" : "shared-memory")
+                       << " footprint includes "
+                       << (srcIsTmem ? "columns" : "offsets")
+                       << " not owned by the source subview ("
+                       << dstStride * dstStages
+                       << (srcIsTmem ? " columns requested; "
+                                     : " bytes requested; ")
+                       << contiguousUnits
+                       << (srcIsTmem ? " contiguous columns available)"
+                                     : " contiguous bytes available)");
   return success();
 }
 

--- a/lib/Dialect/TritonGPU/IR/Types.cpp
+++ b/lib/Dialect/TritonGPU/IR/Types.cpp
@@ -1,5 +1,6 @@
 #include "triton/Dialect/TritonGPU/IR/Types.h"
 #include "mlir/IR/DialectImplementation.h" // required by `Types.cpp.inc`
+#include "triton/Dialect/Triton/IR/Utility.h"
 #include "triton/Dialect/TritonGPU/IR/Dialect.h"
 #include "triton/Dialect/TritonNvidiaGPU/IR/Dialect.h"
 #include "triton/Tools/LayoutUtils.h"
@@ -95,6 +96,10 @@ LogicalResult MemDescType::verify(function_ref<InFlightDiagnostic()> emitError,
   if (shape.empty()) {
     return emitError() << "rank 0 memdesc is not allowed";
   }
+  unsigned bitwidth = getIntOrFloatOrPtrBitWidth(elementType);
+  if (bitwidth != 1 && bitwidth < 8)
+    return emitError() << "element type bit width must be 1 or at least 8; got "
+                       << bitwidth;
   if (llvm::is_contained(shape, 0))
     return emitError() << "shape has 0 dimension";
   if (llvm::is_contained(allocShape, 0))

--- a/lib/Dialect/TritonGPU/IR/Types.cpp
+++ b/lib/Dialect/TritonGPU/IR/Types.cpp
@@ -95,19 +95,28 @@ LogicalResult MemDescType::verify(function_ref<InFlightDiagnostic()> emitError,
   if (shape.empty()) {
     return emitError() << "rank 0 memdesc is not allowed";
   }
-  // Every dimension but the first (to allow for pipelining) must be a power of
-  // 2
-  if (!llvm::all_of(shape.drop_front(1), [](int64_t dim) {
-        return llvm::isPowerOf2_64(dim) && dim > 0;
-      }))
-    return emitError()
-           << "shape must have power-of-2 and non-zero dimensions; got "
-           << shape;
-  if (shape.front() == 0)
+  if (llvm::is_contained(shape, 0))
     return emitError() << "shape has 0 dimension";
+  if (llvm::is_contained(allocShape, 0))
+    return emitError() << "alloc shape has 0 dimension";
   if (allocShape.size() < shape.size())
     return emitError()
            << "alloc shape must have at least as many dimensions as shape";
+  // Every layout dimension must be a power of 2; only a leading pipeline
+  // dimension may have another positive size.
+  ArrayRef<int64_t> layoutShape =
+      encoding ? dropPipeliningDim(shape, encoding) : shape.drop_front(1);
+  ArrayRef<int64_t> layoutAllocShape =
+      encoding ? dropPipeliningDim(allocShape, encoding)
+               : allocShape.drop_front(1);
+  if (!llvm::all_of(layoutShape, llvm::isPowerOf2_64))
+    return emitError()
+           << "shape must have power-of-2 and non-zero dimensions; got "
+           << shape;
+  if (!llvm::all_of(layoutAllocShape, llvm::isPowerOf2_64))
+    return emitError()
+           << "alloc shape must have power-of-2 and non-zero dimensions; got "
+           << allocShape;
   if (llvm::any_of(
           llvm::zip(shape, allocShape.take_back(shape.size())),
           [](auto pair) { return std::get<0>(pair) > std::get<1>(pair); }))
@@ -121,19 +130,6 @@ LogicalResult MemDescType::verify(function_ref<InFlightDiagnostic()> emitError,
     }
     if (shape.size() != 2 && shape.size() != 3) {
       return emitError() << "rank must be 2 or 3";
-    }
-    auto isPowerOfTwo = [](int64_t dim) {
-      return llvm::isPowerOf2_64(dim) && dim > 0;
-    };
-    if (!llvm::all_of(shape.take_back(2), isPowerOfTwo)) {
-      return emitError()
-             << "shape must have power-of-2 and non-zero dimensions; got "
-             << shape;
-    }
-    if (!llvm::all_of(allocShape.take_back(2), isPowerOfTwo)) {
-      return emitError()
-             << "alloc shape must have power-of-2 and non-zero dimensions; got "
-             << allocShape;
     }
     unsigned bitwidth = elementType.getIntOrFloatBitWidth();
     if (bitwidth * enc.getColStride() > 32) {

--- a/lib/Dialect/TritonGPU/IR/Types.cpp
+++ b/lib/Dialect/TritonGPU/IR/Types.cpp
@@ -107,13 +107,28 @@ LogicalResult MemDescType::verify(function_ref<InFlightDiagnostic()> emitError,
   if (allocShape.size() < shape.size())
     return emitError()
            << "alloc shape must have at least as many dimensions as shape";
+  auto layoutEncoding = dyn_cast_if_present<LayoutEncodingTrait>(encoding);
+  if (!layoutEncoding ||
+      !isa<nvidia_gpu::TensorMemoryEncodingAttr, SharedEncodingTrait,
+           nvidia_gpu::TensorMemoryScalesEncodingAttr>(encoding))
+    return emitError() << encoding << " is not a valid encoding";
+  auto rank = layoutEncoding.getRank();
+  if (isa<nvidia_gpu::TensorMemoryEncodingAttr>(encoding)) {
+    if (shape.size() != 2 && shape.size() != 3)
+      return emitError() << "rank must be 2 or 3";
+  } else if (isa<SharedEncodingTrait>(encoding)) {
+    if (!(rank == shape.size() || rank == shape.size() - 1))
+      return emitError() << "rank must be equal to or one less than "
+                         << "the shape size. Got " << rank << " and "
+                         << shape.size();
+  } else if (shape.size() != 2) {
+    return emitError() << "tensor-memory scale descriptors must have rank 2; "
+                       << "got " << shape.size();
+  }
   // Every layout dimension must be a power of 2; only a leading pipeline
   // dimension may have another positive size.
-  ArrayRef<int64_t> layoutShape =
-      encoding ? dropPipeliningDim(shape, encoding) : shape.drop_front(1);
-  ArrayRef<int64_t> layoutAllocShape =
-      encoding ? dropPipeliningDim(allocShape, encoding)
-               : allocShape.drop_front(1);
+  ArrayRef<int64_t> layoutShape = dropPipeliningDim(shape, encoding);
+  ArrayRef<int64_t> layoutAllocShape = dropPipeliningDim(allocShape, encoding);
   if (!llvm::all_of(layoutShape, llvm::isPowerOf2_64))
     return emitError()
            << "shape must have power-of-2 and non-zero dimensions; got "
@@ -133,10 +148,11 @@ LogicalResult MemDescType::verify(function_ref<InFlightDiagnostic()> emitError,
     if (memorySpace != nvidia_gpu::TensorMemorySpaceAttr::get(ctx)) {
       return emitError() << "memorySpace must be TensorMemorySpace";
     }
-    if (shape.size() != 2 && shape.size() != 3) {
-      return emitError() << "rank must be 2 or 3";
-    }
     unsigned bitwidth = elementType.getIntOrFloatBitWidth();
+    if (bitwidth < 8)
+      return emitError()
+             << "tensor-memory element type bit width must be at least 8; got "
+             << bitwidth;
     if (bitwidth * enc.getColStride() > 32) {
       return emitError()
              << "bitwidth * colStride must be less than or equal to 32. Got "
@@ -163,26 +179,16 @@ LogicalResult MemDescType::verify(function_ref<InFlightDiagnostic()> emitError,
                          << ll.getOutDimSize(dims[0]) << "x"
                          << ll.getOutDimSize(dims[1]);
     }
-  } else if (auto enc = dyn_cast<SharedEncodingTrait>(encoding)) {
+  } else if (isa<SharedEncodingTrait>(encoding)) {
     if (memorySpace != SharedMemorySpaceAttr::get(ctx)) {
       return emitError()
              << "memorySpace must be SharedMemorySpace for shared encoding. "
              << "Got " << memorySpace;
     }
-    auto rank = cast<LayoutEncodingTrait>(enc).getRank();
-    if (!(rank == shape.size() || rank == shape.size() - 1)) {
-      return emitError() << "rank must be equal to or one less than "
-                         << "the shape size. Got " << rank << " and "
-                         << shape.size();
-    }
   } else if (auto enc = dyn_cast<nvidia_gpu::TensorMemoryScalesEncodingAttr>(
                  encoding)) {
     if (memorySpace != nvidia_gpu::TensorMemorySpaceAttr::get(ctx)) {
       return emitError() << "memorySpace must be TensorMemorySpace";
-    }
-    if (shape.size() != 2) {
-      return emitError() << "tensor-memory scale descriptors must have rank 2; "
-                         << "got " << shape.size();
     }
     if (allocShape.size() != 2) {
       return emitError() << "Scales don't currently support multibuffering";
@@ -191,8 +197,6 @@ LogicalResult MemDescType::verify(function_ref<InFlightDiagnostic()> emitError,
     if (bitwidth != 8) {
       return emitError() << "bitwidth must be 8";
     }
-  } else {
-    return emitError() << encoding << " is not a valid encoding";
   }
 
   // PaddedSharedEncodingAttr is also a SharedEncodingTrait but we have some

--- a/lib/Dialect/TritonGPU/IR/Types.cpp
+++ b/lib/Dialect/TritonGPU/IR/Types.cpp
@@ -121,9 +121,12 @@ LogicalResult MemDescType::verify(function_ref<InFlightDiagnostic()> emitError,
       return emitError() << "rank must be equal to or one less than "
                          << "the shape size. Got " << rank << " and "
                          << shape.size();
-  } else if (shape.size() != 2) {
-    return emitError() << "tensor-memory scale descriptors must have rank 2; "
-                       << "got " << shape.size();
+  } else {
+    assert(isa<nvidia_gpu::TensorMemoryScalesEncodingAttr>(encoding) &&
+           "expected tensor-memory scales encoding");
+    if (shape.size() != 2)
+      return emitError() << "tensor-memory scale descriptors must have rank 2; "
+                         << "got " << shape.size();
   }
   // Every layout dimension must be a power of 2; only a leading pipeline
   // dimension may have another positive size.

--- a/lib/Dialect/TritonGPU/IR/Types.cpp
+++ b/lib/Dialect/TritonGPU/IR/Types.cpp
@@ -175,6 +175,10 @@ LogicalResult MemDescType::verify(function_ref<InFlightDiagnostic()> emitError,
     if (memorySpace != nvidia_gpu::TensorMemorySpaceAttr::get(ctx)) {
       return emitError() << "memorySpace must be TensorMemorySpace";
     }
+    if (shape.size() != 2) {
+      return emitError() << "tensor-memory scale descriptors must have rank 2; "
+                         << "got " << shape.size();
+    }
     if (allocShape.size() != 2) {
       return emitError() << "Scales don't currently support multibuffering";
     }

--- a/lib/Dialect/TritonInstrument/Transforms/FpSanitizer.cpp
+++ b/lib/Dialect/TritonInstrument/Transforms/FpSanitizer.cpp
@@ -359,8 +359,8 @@ public:
         return std::nullopt;
 
       auto baseTy = cast<ttg::MemDescType>(subslice.getSrc().getType());
-      if (baseTy.getRank() != 2 || memTy.getRank() != 2 ||
-          baseInfo->tensorType.getRank() != 2)
+      if (baseTy.getRank() != memTy.getRank() ||
+          baseTy.getRank() != baseInfo->tensorType.getRank())
         return std::nullopt;
 
       OpBuilder::InsertionGuard guard(rewriter);
@@ -368,8 +368,12 @@ public:
       auto loc = subslice.getLoc();
       // Scratch tensors are column-major. Keep the parent shape so a row
       // slice and any following column slices retain the original stride.
+      auto layoutShape = ttg::dropPipeliningDim(baseInfo->tensorType.getShape(),
+                                                baseTy.getEncoding());
       int64_t stride =
-          subslice.getDim() == 0 ? 1 : baseInfo->tensorType.getShape().front();
+          subslice.getDim() == baseTy.getRank() - 1 ? layoutShape.front() : 1;
+      if (baseTy.getRank() == 3 && subslice.getDim() == 0)
+        stride = product(layoutShape);
       int64_t offset = subslice.getOffset();
       auto offsetVal = arith::ConstantOp::create(
           rewriter, loc, rewriter.getI32IntegerAttr(offset));

--- a/lib/Dialect/TritonNvidiaGPU/IR/Dialect.cpp
+++ b/lib/Dialect/TritonNvidiaGPU/IR/Dialect.cpp
@@ -112,6 +112,17 @@ TMemAllocation getTmemAllocSizes(MemDescType memDescType) {
 
 uint32_t getTMemSubSliceOffset(MemDescType memDescType, int32_t offset,
                                int32_t dim) {
+  auto layoutShape =
+      dropPipeliningDim(memDescType.getAllocShape(), memDescType.getEncoding());
+  if (memDescType.getRank() == 3 && dim == 0) {
+    auto layout = toLinearLayout(layoutShape, memDescType.getEncoding());
+    auto colDim = StringAttr::get(memDescType.getContext(), "col");
+    return offset * llvm::divideCeil(layout.getInDimSize(colDim) *
+                                         memDescType.getElementTypeBitWidth(),
+                                     32);
+  }
+
+  dim -= memDescType.getRank() - layoutShape.size();
   auto llInv = toLinearLayout(memDescType).pseudoinvert();
   auto dimNames = llvm::to_vector(llInv.getInDimNames());
   SmallVector<std::pair<StringAttr, int32_t>> logicalOffsets;

--- a/lib/Dialect/TritonNvidiaGPU/IR/Ops.cpp
+++ b/lib/Dialect/TritonNvidiaGPU/IR/Ops.cpp
@@ -1673,22 +1673,31 @@ LogicalResult TMEMSubSliceOp::verify() {
     return emitOpError("The source and result must have the same encoding.");
   if (srcTy.getAllocShape() != dstTy.getAllocShape())
     return emitOpError("The source and result must have the same alloc shape.");
-  if (srcTy.getRank() != 2)
-    return emitOpError("The result must be a 2D tensor memory buffer.");
-  if (dstTy.getRank() != 2)
-    return emitOpError("The result must be a 2D tensor memory buffer.");
+  if (srcTy.getRank() != dstTy.getRank() ||
+      (srcTy.getRank() != 2 && srcTy.getRank() != 3))
+    return emitOpError("The source and result must both be 2D or 3D tensor "
+                       "memory buffers.");
   auto dim = getDim();
-  if (dim < 0 || dim > 1)
-    return emitOpError("The slice dimension must be 0 or 1.");
-  if (dstTy.getDimSize(1 - dim) != srcTy.getDimSize(1 - dim))
-    return emitOpError("The result must have the same size as the source in "
-                       "the dimension that is not being sliced.");
+  if (dim < 0 || dim >= srcTy.getRank())
+    return emitOpError("The slice dimension must be within the descriptor "
+                       "rank.");
+  for (int axis = 0; axis < srcTy.getRank(); ++axis)
+    if (axis != dim && dstTy.getDimSize(axis) != srcTy.getDimSize(axis))
+      return emitOpError("The result must have the same size as the source in "
+                         "the dimensions that are not being sliced.");
   auto srcShape = srcTy.getShape();
   auto dstShape = dstTy.getShape();
   auto offset = getOffset();
-  if (offset < 0 || offset + dstShape[dim] > srcShape[dim]) {
+  if (offset < 0 || int64_t(offset) + dstShape[dim] > srcShape[dim]) {
     return emitError("The split offset may not exceed the source shape");
   }
+
+  if (srcTy.getRank() == 3 && dim == 0)
+    return success();
+
+  srcShape = dropPipeliningDim(srcShape, srcTy.getEncoding());
+  dstShape = dropPipeliningDim(dstShape, dstTy.getEncoding());
+  dim -= srcTy.getRank() - srcShape.size();
   auto srcLL = toLinearLayout(srcTy);
   if (offset & (dstShape[dim] - 1)) {
     // An unaligned slice can carry through the logical bits between its

--- a/lib/Tools/LinearLayout.cpp
+++ b/lib/Tools/LinearLayout.cpp
@@ -318,6 +318,22 @@ int32_t LinearLayout::getNumConsecutiveInOut() const {
       .size;
 }
 
+int32_t LinearLayout::contiguousElemsAlongOutputDim(StringAttr outDim) const {
+  assert(hasOutDim(outDim) && "output dimension is not in the layout");
+  auto projected = sublayout(llvm::to_vector(getInDimNames()), {outDim});
+  auto outsideDim =
+      StringAttr::get(outDim.getContext(), "__contiguous_outside");
+  auto outside = identity1D(getOutDimSize(outDim), outsideDim, outDim);
+
+  // The outside component of this pseudoinverse is a cokernel map: its kernel
+  // is exactly the projected layout's image.
+  auto inverse = *lstsq(projected.concatIns(outside),
+                        identity1D(getOutDimSize(outDim), outDim, outDim));
+  uint64_t outsideMask = getInputBasisMask(inverse, outDim, {outsideDim});
+  return outsideMask ? int32_t{1} << llvm::countr_zero(outsideMask)
+                     : getOutDimSize(outDim);
+}
+
 LinearLayout LinearLayout::transposeIns(ArrayRef<StringAttr> newInDims) const {
   assertDimsEqualIgnoringOrder(newInDims, getInDimNames());
 

--- a/python/test/gluon/test_core.py
+++ b/python/test/gluon/test_core.py
@@ -1844,6 +1844,34 @@ def test_tmem_copy_2d():
         torch.testing.assert_close(x_res, warp)
 
 
+@pytest.mark.skipif(not is_blackwell(), reason="Requires Blackwell")
+def test_tmem_pipeline_stage_subslice_index_reinterpret():
+
+    @gluon.jit
+    def kernel(inp, out):
+        parent = allocate_tensor_memory(ttgl.float32, [5, 128, 64], TensorMemoryLayout([128, 64], col_stride=1))
+        layout: ttgl.constexpr = parent.index(0).get_reg_layout()
+        rows = ttgl.arange(0, 128, layout=ttgl.SliceLayout(1, layout))[:, None]
+        cols = ttgl.arange(0, 64, layout=ttgl.SliceLayout(0, layout))[None, :]
+        for stage in ttgl.static_range(5):
+            parent.index(stage).store(ttgl.load(inp + stage * 8192 + rows * 64 + cols))
+        stages = parent.slice(2, 2, dim=0)
+        first = stages._reinterpret().index(0)
+        first.store(first.load() + 11.0)
+        second = stages.slice(1, 1, dim=0).index(0)
+        second.store(second.load() + 7.0)
+        for stage in ttgl.static_range(5):
+            ttgl.store(out + stage * 8192 + rows * 64 + cols, parent.index(stage).load(layout))
+
+    inp = torch.arange(5 * 128 * 64, device="cuda", dtype=torch.int32).remainder(64).float().reshape(5, 128, 64)
+    out = torch.empty_like(inp)
+    kernel[(1, )](inp, out, num_warps=4)
+    expected = inp.clone()
+    expected[2] += 11
+    expected[3] += 7
+    torch.testing.assert_close(out, expected, atol=0, rtol=0)
+
+
 @pytest.mark.parametrize("M, N, BLOCK_M, BLOCK_N", [(256, 128, 128, 128), (128, 256, 64, 128)])
 @pytest.mark.skipif(not is_blackwell(), reason="Requires Blackwell")
 def test_tmem_row_slice(M, N, BLOCK_M, BLOCK_N):

--- a/python/test/gluon/test_core.py
+++ b/python/test/gluon/test_core.py
@@ -5015,7 +5015,7 @@ def test_clc_basic(num_ctas):
         mbarrier.init(clc_mbar, count=1)
 
         # Large shared memory allocation to force 1 block per SM
-        dummy = ttgl.allocate_shared_memory(ttgl.int64, [smem_size // 8 - 32], clc_mbar.layout)
+        dummy = ttgl.allocate_shared_memory(ttgl.int64, [smem_size // 8 - 32, 1], clc_mbar.layout)
 
         clc.try_cancel(clc_result, clc_mbar)
         mbarrier.expect(clc_mbar, 16, from_cta=0x0)

--- a/python/test/gluon/test_frontend.py
+++ b/python/test/gluon/test_frontend.py
@@ -1255,6 +1255,21 @@ def test_tmem_subslice_noncontiguous():
     assert "!ttg.memdesc<128x256xf32" in ir
 
 
+@gluon.jit
+def tmem_pipeline_stage_subslice_kernel():
+    layout: ttgl.constexpr = TensorMemoryLayout(block=[128, 64], col_stride=1)
+    parent = blackwell.allocate_tensor_memory(ttgl.float32, [5, 128, 64], layout)
+    stages = parent.slice(2, 2, dim=0)
+    stages.slice(0, 32, dim=2)
+
+
+def test_tmem_pipeline_stage_subslice_constexpr():
+    ir = run_parser(tmem_pipeline_stage_subslice_kernel, target=BLACKWELL_TARGET).str_nodebug()
+    assert "dim = 0 : i32" in ir
+    assert "dim = 2 : i32" in ir
+    assert "mutable, 5x128x64>" in ir
+
+
 @filecheck_test
 @gluon.jit
 def test_tmem_reduction_default_layout_constexpr():

--- a/python/test/unit/language/test_compile_only.py
+++ b/python/test/unit/language/test_compile_only.py
@@ -26,7 +26,7 @@ def test_compile_only_ws_cluster_barrier_shared_memory(tmp_path) -> None:
 #shared = #ttg.swizzled_shared<{vec = 1, perPhase = 1, maxPhase = 1, order = [0], CGALayout = [[0]]}>
 module attributes {"ttg.num-ctas" = 2 : i32, "ttg.num-warps" = 4 : i32, ttg.target = "cuda:90", "ttg.threads-per-warp" = 32 : i32} {
   tt.func public @ws_cluster_barrier() {
-    %alloc = ttg.local_alloc : () -> !ttg.memdesc<5xi8, #shared, #ttg.shared_memory, mutable>
+    %alloc = ttg.local_alloc : () -> !ttg.memdesc<5x1xi8, #shared, #ttg.shared_memory, mutable>
     ttg.warp_specialize()
     default {
       ttng.cluster_barrier

--- a/python/triton/experimental/gluon/language/nvidia/blackwell/__init__.py
+++ b/python/triton/experimental/gluon/language/nvidia/blackwell/__init__.py
@@ -371,7 +371,7 @@ class tensor_memory_descriptor(base_value):
         Args:
             start (int): The starting index for subslice.
             length (int): The length of the subslice.
-            dim (int): The dimension to slice (default: 1).
+            dim (int): The dimension to slice, including a leading pipeline-stage dimension (default: 1).
 
         Returns:
             tensor_memory_descriptor: Descriptor for the subslice.
@@ -381,7 +381,7 @@ class tensor_memory_descriptor(base_value):
         dim = _unwrap_if_constexpr(dim)
         _check(isinstance(start, int), lambda: "start must be a constant int")
         _check(isinstance(length, int), lambda: "length must be a constant int")
-        _check(isinstance(dim, int) and dim in (0, 1), lambda: "dim must be 0 or 1")
+        _check(isinstance(dim, int) and dim in range(len(self.shape)), lambda: "invalid slice dimension")
         shape = list(self.shape)
         shape[dim] = length
         layout = self.type.layout

--- a/test/Analysis/test-allocation-partitioned.mlir
+++ b/test/Analysis/test-allocation-partitioned.mlir
@@ -27,6 +27,15 @@
 #PARTITIONED_2P_1G_SW = #ttg.partitioned_shared<{numPartitions = 2, numGroups = 1, partitionDim = 0, partitionLayout = #A_SHARED}>
 #PARTITIONED_4P_1G_SW = #ttg.partitioned_shared<{numPartitions = 4, numGroups = 1, partitionDim = 0, partitionLayout = #A_SHARED}>
 
+// Padded layouts produce non-power-of-two partition-buffer sizes while keeping
+// every physical layout dimension a power of two.
+#PADDED_STRADDLE_2P = #ttg.padded_shared<[128:+32] {order = [1, 0], shape = [512, 32]}>
+#PADDED_STRADDLE_4P = #ttg.padded_shared<[256:+64] {order = [1, 0], shape = [512, 32]}>
+#PARTITIONED_2P_STRADDLE = #ttg.partitioned_shared<{numPartitions = 2, numGroups = 1, partitionDim = 0, partitionLayout = #PADDED_STRADDLE_2P}>
+#PARTITIONED_4P_STRADDLE = #ttg.partitioned_shared<{numPartitions = 4, numGroups = 1, partitionDim = 0, partitionLayout = #PADDED_STRADDLE_4P}>
+#PADDED_BIG = #ttg.padded_shared<[256:+128] {order = [1, 0], shape = [1024, 32]}>
+#PARTITIONED_2P_BIG = #ttg.partitioned_shared<{numPartitions = 2, numGroups = 1, partitionDim = 0, partitionLayout = #PADDED_BIG}>
+
 #smem = #ttg.shared_memory
 
 module attributes {"ttg.num-warps" = 4 : i32, "ttg.num-ctas" = 1 : i32} {
@@ -190,36 +199,36 @@ tt.func @partition_exact_boundary() {
 }
 
 // Partition pieces that straddle a physical-partition boundary must
-// still be separated correctly and packed tightly. %a's two pieces (40000 bytes)
+// still be separated correctly and packed tightly. %a's two pieces (40928 bytes)
 // go to partitions 0 and 1; %b's four pieces fill the gaps, with piece 0
 // straddling partitions 0/1 (allowed: %b is not a neighbor of %a).
 // expected-remark @below {{partitioned_straddle}}
-// expected-remark @below {{size = 302144}}
+// expected-remark @below {{size = 303072}}
 tt.func @partitioned_straddle() {
-  // expected-remark @below {{offset = 0, size = 40000}}
-  // expected-remark @below {{offset = 80000, size = 40000}}
-  %a = ttg.local_alloc : () -> !ttg.memdesc<1250x32xf16, #PARTITIONED_2P_1G_SW, #ttg.shared_memory, mutable>
-  // expected-remark @below {{offset = 40000, size = 40000}}
-  // expected-remark @below {{offset = 131072, size = 40000}}
-  // expected-remark @below {{offset = 196608, size = 40000}}
-  // expected-remark @below {{offset = 262144, size = 40000}}
-  %b = ttg.local_alloc : () -> !ttg.memdesc<2500x32xf16, #PARTITIONED_4P_1G_SW, #ttg.shared_memory, mutable>
-  "use"(%a) : (!ttg.memdesc<1250x32xf16, #PARTITIONED_2P_1G_SW, #ttg.shared_memory, mutable>) -> ()
-  "use"(%b) : (!ttg.memdesc<2500x32xf16, #PARTITIONED_4P_1G_SW, #ttg.shared_memory, mutable>) -> ()
+  // expected-remark @below {{offset = 0, size = 40928}}
+  // expected-remark @below {{offset = 81856, size = 40928}}
+  %a = ttg.local_alloc : () -> !ttg.memdesc<1024x32xf16, #PARTITIONED_2P_STRADDLE, #ttg.shared_memory, mutable>
+  // expected-remark @below {{offset = 40928, size = 40928}}
+  // expected-remark @below {{offset = 131072, size = 40928}}
+  // expected-remark @below {{offset = 196608, size = 40928}}
+  // expected-remark @below {{offset = 262144, size = 40928}}
+  %b = ttg.local_alloc : () -> !ttg.memdesc<2048x32xf16, #PARTITIONED_4P_STRADDLE, #ttg.shared_memory, mutable>
+  "use"(%a) : (!ttg.memdesc<1024x32xf16, #PARTITIONED_2P_STRADDLE, #ttg.shared_memory, mutable>) -> ()
+  "use"(%b) : (!ttg.memdesc<2048x32xf16, #PARTITIONED_4P_STRADDLE, #ttg.shared_memory, mutable>) -> ()
   tt.return
 }
 
-// Two neighbors each larger than one physical partition (96000 bytes
+// Two neighbors each larger than one physical partition (98176 bytes
 // -> each spans ~1.5 partitions). Comparing only start partitions would leave
 // them sharing a partition; the footprint-based conflict check separates them
 // (partitions 0-1 and 2-3).
 // expected-remark @below {{two_big_neighbors}}
-// expected-remark @below {{size = 227072}}
+// expected-remark @below {{size = 229248}}
 tt.func @two_big_neighbors() {
-  // expected-remark @below {{offset = 0, size = 96000}}
-  // expected-remark @below {{offset = 131072, size = 96000}}
-  %a = ttg.local_alloc : () -> !ttg.memdesc<3000x32xf16, #PARTITIONED_2P_1G_SW, #ttg.shared_memory, mutable>
-  "use"(%a) : (!ttg.memdesc<3000x32xf16, #PARTITIONED_2P_1G_SW, #ttg.shared_memory, mutable>) -> ()
+  // expected-remark @below {{offset = 0, size = 98176}}
+  // expected-remark @below {{offset = 131072, size = 98176}}
+  %a = ttg.local_alloc : () -> !ttg.memdesc<2048x32xf16, #PARTITIONED_2P_BIG, #ttg.shared_memory, mutable>
+  "use"(%a) : (!ttg.memdesc<2048x32xf16, #PARTITIONED_2P_BIG, #ttg.shared_memory, mutable>) -> ()
   tt.return
 }
 }

--- a/test/Analysis/test-buffer-region.mlir
+++ b/test/Analysis/test-buffer-region.mlir
@@ -67,6 +67,7 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 1 : i32, ttg.shar
 
 #shared_holey = #ttg.shared_linear<{offset = [[0, 1], [0, 0], [1, 0], [2, 0]], block = []}, alignment = 16>
 #shared_dense = #ttg.shared_linear<{offset = [[0, 1], [0, 2], [1, 0], [2, 0]], block = []}, alignment = 16>
+#shared_dense_half = #ttg.shared_linear<{offset = [[0, 1], [0, 2], [1, 0]], block = []}, alignment = 16>
 #smem = #ttg.shared_memory
 
 module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 1 : i32, ttg.shared = 64 : i32, ttg.target = "cuda:90", ttg.tensor_memory_size = 0 : i32, "ttg.threads-per-warp" = 32 : i32, "ttg.total-num-warps" = 1 : i32} {
@@ -75,6 +76,14 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 1 : i32, ttg.shar
     %view = ttg.memdesc_reinterpret %alloc : !ttg.memdesc<4x2xi32, #shared_holey, #smem, mutable> -> !ttg.memdesc<4x4xi32, #shared_dense, #smem, mutable>
     // expected-remark @below {{Buffers: [0, 64]}}
     ttg.local_load %view : !ttg.memdesc<4x4xi32, #shared_dense, #smem, mutable> -> tensor<4x4xi32>
+    tt.return
+  }
+
+  tt.func public @shared_reinterpret_smaller_holey_region() {
+    %alloc = ttg.local_alloc {allocation.offset = 0 : i32} : () -> !ttg.memdesc<4x2xi32, #shared_holey, #smem, mutable>
+    %view = ttg.memdesc_reinterpret %alloc : !ttg.memdesc<4x2xi32, #shared_holey, #smem, mutable> -> !ttg.memdesc<2x4xi32, #shared_dense_half, #smem, mutable>
+    // expected-remark @below {{Buffers: [0, 32]}}
+    ttg.local_load %view : !ttg.memdesc<2x4xi32, #shared_dense_half, #smem, mutable> -> tensor<2x4xi32>
     tt.return
   }
 
@@ -100,13 +109,28 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 1 : i32, ttg.shar
     %parent = ttg.local_alloc {allocation.offset = 0 : i32} : () -> !ttg.memdesc<7x16x16xf16, #shared, #smem, mutable>
     %stages = ttg.memdesc_subslice %parent [3, 8, 0] : !ttg.memdesc<7x16x16xf16, #shared, #smem, mutable> -> !ttg.memdesc<2x8x16xf16, #shared, #smem, mutable, 7x16x16>
     %view = ttg.memdesc_reinterpret %stages : !ttg.memdesc<2x8x16xf16, #shared, #smem, mutable, 7x16x16> -> !ttg.memdesc<8x16xf16, #shared, #smem, mutable>
-    // expected-remark @below {{Buffers: [1792, 768]}}
+    // expected-remark @below {{Buffers: [1792, 256]}}
     ttg.local_load %view : !ttg.memdesc<8x16xf16, #shared, #smem, mutable> -> tensor<8x16xf16, #blocked>
     tt.return
   }
 
-  // expected-remark @below {{All Shared Regions: [1792, 768]}}
+  // expected-remark @below {{All Shared Regions: [1792, 256]}}
   tt.func private @print_all_regions() attributes {test.print_all_used_regions} {
+    tt.return
+  }
+}
+
+// -----
+
+#padded = #ttg.padded_shared<[4:+2] {order = [1, 0], shape = [4, 4]}>
+#smem = #ttg.shared_memory
+
+module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 1 : i32, ttg.shared = 44 : i32, ttg.target = "cuda:90", ttg.tensor_memory_size = 0 : i32, "ttg.threads-per-warp" = 32 : i32, "ttg.total-num-warps" = 1 : i32} {
+  tt.func public @padded_shared_reinterpret_region() {
+    %alloc = ttg.local_alloc {allocation.offset = 0 : i32} : () -> !ttg.memdesc<4x4xf16, #padded, #smem, mutable>
+    %view = ttg.memdesc_reinterpret %alloc : !ttg.memdesc<4x4xf16, #padded, #smem, mutable> -> !ttg.memdesc<4x4xbf16, #padded, #smem, mutable>
+    // expected-remark @below {{Buffers: [0, 44]}}
+    ttg.local_load %view : !ttg.memdesc<4x4xbf16, #padded, #smem, mutable> -> tensor<4x4xbf16>
     tt.return
   }
 }
@@ -148,7 +172,15 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 1 : i32, ttg.shar
     tt.return
   }
 
-  // expected-remark @below {{All Tensor Regions: [0, 128]}}
+  tt.func public @tensor_memory_reinterpret_smaller_region() {
+    %tm = ttng.tmem_alloc {tensor_memory_col_offset = 128 : i32, tensor_memory_row_offset = 0 : i32} : () -> !ttg.memdesc<128x128xf32, #tmem, #ttng.tensor_memory, mutable>
+    %view = ttg.memdesc_reinterpret %tm : !ttg.memdesc<128x128xf32, #tmem, #ttng.tensor_memory, mutable> -> !ttg.memdesc<128x128xf16, #tmem, #ttng.tensor_memory, mutable>
+    // expected-remark @below {{Buffers: [128, 64]}}
+    ttng.tmem_load %view : !ttg.memdesc<128x128xf16, #tmem, #ttng.tensor_memory, mutable> -> tensor<128x128xf16>
+    tt.return
+  }
+
+  // expected-remark @below {{All Tensor Regions: [0, 128], [128, 64]}}
   tt.func private @print_all_regions() attributes {test.print_all_used_regions} {
     tt.return
   }

--- a/test/Analysis/test-buffer-region.mlir
+++ b/test/Analysis/test-buffer-region.mlir
@@ -65,6 +65,33 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 1 : i32, ttg.shar
 
 // -----
 
+#shared_holey = #ttg.shared_linear<{offset = [[0, 1], [0, 0], [1, 0], [2, 0]], block = []}, alignment = 16>
+#shared_dense = #ttg.shared_linear<{offset = [[0, 1], [0, 2], [1, 0], [2, 0]], block = []}, alignment = 16>
+#smem = #ttg.shared_memory
+
+module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 1 : i32, ttg.shared = 64 : i32, ttg.target = "cuda:90", ttg.tensor_memory_size = 0 : i32, "ttg.threads-per-warp" = 32 : i32, "ttg.total-num-warps" = 1 : i32} {
+  tt.func public @shared_zero_bases_belong_to_allocation() {
+    %alloc = ttg.local_alloc {allocation.offset = 0 : i32} : () -> !ttg.memdesc<4x2xi32, #shared_holey, #smem, mutable>
+    %view = ttg.memdesc_reinterpret %alloc : !ttg.memdesc<4x2xi32, #shared_holey, #smem, mutable> -> !ttg.memdesc<4x4xi32, #shared_dense, #smem, mutable>
+    // expected-remark @below {{Buffers: [0, 64]}}
+    ttg.local_load %view : !ttg.memdesc<4x4xi32, #shared_dense, #smem, mutable> -> tensor<4x4xi32>
+    tt.return
+  }
+
+  tt.func public @shared_zero_bases_belong_to_subslices() {
+    %alloc = ttg.local_alloc {allocation.offset = 0 : i32} : () -> !ttg.memdesc<4x2xi32, #shared_holey, #smem, mutable>
+    %lower = ttg.memdesc_subslice %alloc [0, 0] : !ttg.memdesc<4x2xi32, #shared_holey, #smem, mutable> -> !ttg.memdesc<2x2xi32, #shared_holey, #smem, mutable, 4x2>
+    %upper = ttg.memdesc_subslice %alloc [2, 0] : !ttg.memdesc<4x2xi32, #shared_holey, #smem, mutable> -> !ttg.memdesc<2x2xi32, #shared_holey, #smem, mutable, 4x2>
+    // expected-remark @below {{Buffers: [0, 32]}}
+    ttg.local_load %lower : !ttg.memdesc<2x2xi32, #shared_holey, #smem, mutable, 4x2> -> tensor<2x2xi32>
+    // expected-remark @below {{Buffers: [32, 32]}}
+    ttg.local_load %upper : !ttg.memdesc<2x2xi32, #shared_holey, #smem, mutable, 4x2> -> tensor<2x2xi32>
+    tt.return
+  }
+}
+
+// -----
+
 #shared = #ttg.swizzled_shared<{vec = 1, perPhase = 1, maxPhase = 1, order = [1, 0]}>
 #smem = #ttg.shared_memory
 #blocked = #ttg.blocked<{sizePerThread = [1, 16], threadsPerWarp = [32, 1], warpsPerCTA = [1, 1], order = [0, 1]}>

--- a/test/Analysis/test-buffer-region.mlir
+++ b/test/Analysis/test-buffer-region.mlir
@@ -65,6 +65,27 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 1 : i32, ttg.shar
 
 // -----
 
+#shared = #ttg.swizzled_shared<{vec = 1, perPhase = 1, maxPhase = 1, order = [1, 0]}>
+#smem = #ttg.shared_memory
+#blocked = #ttg.blocked<{sizePerThread = [1, 16], threadsPerWarp = [32, 1], warpsPerCTA = [1, 1], order = [0, 1]}>
+module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 1 : i32, ttg.shared = 3584 : i32, ttg.target = "cuda:90", ttg.tensor_memory_size = 0 : i32, "ttg.threads-per-warp" = 32 : i32, "ttg.total-num-warps" = 1 : i32} {
+  tt.func public @gapped_pipeline_stage_subslice_region() {
+    %parent = ttg.local_alloc {allocation.offset = 0 : i32} : () -> !ttg.memdesc<7x16x16xf16, #shared, #smem, mutable>
+    %stages = ttg.memdesc_subslice %parent [3, 8, 0] : !ttg.memdesc<7x16x16xf16, #shared, #smem, mutable> -> !ttg.memdesc<2x8x16xf16, #shared, #smem, mutable, 7x16x16>
+    %view = ttg.memdesc_reinterpret %stages : !ttg.memdesc<2x8x16xf16, #shared, #smem, mutable, 7x16x16> -> !ttg.memdesc<8x16xf16, #shared, #smem, mutable>
+    // expected-remark @below {{Buffers: [1792, 768]}}
+    ttg.local_load %view : !ttg.memdesc<8x16xf16, #shared, #smem, mutable> -> tensor<8x16xf16, #blocked>
+    tt.return
+  }
+
+  // expected-remark @below {{All Shared Regions: [1792, 768]}}
+  tt.func private @print_all_regions() attributes {test.print_all_used_regions} {
+    tt.return
+  }
+}
+
+// -----
+
 #shared = #ttg.nvmma_shared<{swizzlingByteWidth = 128, transposed = false, elementBitWidth = 32}>
 #smem = #ttg.shared_memory
 #blocked = #ttg.blocked<{sizePerThread = [1, 32], threadsPerWarp = [32, 1], warpsPerCTA = [1, 1], order = [0, 1]}>
@@ -114,16 +135,17 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 1 : i32, ttg.shar
   tt.func public @tensor_memory_indexed(%idx: i32) {
     %cst = arith.constant dense<0.000000e+00> : tensor<128x128xf32>
     %true = arith.constant true
-    %tm = ttng.tmem_alloc {tensor_memory_col_offset = 0 : i32, tensor_memory_row_offset = 0 : i32} : () -> !ttg.memdesc<2x128x128xf32, #tmem, #ttng.tensor_memory, mutable>
-    %view = ttg.memdesc_index %tm[%idx] : !ttg.memdesc<2x128x128xf32, #tmem, #ttng.tensor_memory, mutable> -> !ttg.memdesc<128x128xf32, #tmem, #ttng.tensor_memory, mutable>
-    // expected-remark @below {{Buffers: [0, 128], [128, 128]}}
+    %tm = ttng.tmem_alloc {tensor_memory_col_offset = 0 : i32, tensor_memory_row_offset = 0 : i32} : () -> !ttg.memdesc<5x128x128xf32, #tmem, #ttng.tensor_memory, mutable>
+    %stages = ttng.tmem_subslice %tm {offset = 2 : i32, dim = 0 : i32} : !ttg.memdesc<5x128x128xf32, #tmem, #ttng.tensor_memory, mutable> -> !ttg.memdesc<2x128x128xf32, #tmem, #ttng.tensor_memory, mutable, 5x128x128>
+    %view = ttg.memdesc_index %stages[%idx] : !ttg.memdesc<2x128x128xf32, #tmem, #ttng.tensor_memory, mutable, 5x128x128> -> !ttg.memdesc<128x128xf32, #tmem, #ttng.tensor_memory, mutable>
+    // expected-remark @below {{Buffers: [256, 128], [384, 128]}}
     ttng.tmem_load %view : !ttg.memdesc<128x128xf32, #tmem, #ttng.tensor_memory, mutable> -> tensor<128x128xf32>
-    // expected-remark @below {{Buffers: [0, 128], [128, 128]}}
+    // expected-remark @below {{Buffers: [256, 128], [384, 128]}}
     ttng.tmem_store %cst, %view, %true : tensor<128x128xf32> -> !ttg.memdesc<128x128xf32, #tmem, #ttng.tensor_memory, mutable>
     tt.return
   }
 
-  // expected-remark @below {{All Tensor Regions: [0, 128], [128, 128]}}
+  // expected-remark @below {{All Tensor Regions: [256, 128], [384, 128]}}
   tt.func private @print_all_regions() attributes {test.print_all_used_regions} {
     tt.return
   }

--- a/test/Analysis/test-membar-ttng.mlir
+++ b/test/Analysis/test-membar-ttng.mlir
@@ -59,6 +59,7 @@ tt.func @tma_special_cases(%arg1: !tt.tensordesc<256x64xf16, #shared>, %arg2: !t
   %c0 = arith.constant 0 : i32
   %barrier = ttg.local_alloc : () -> !ttg.memdesc<1xi64, #shared1, #ttg.shared_memory, mutable>
   %alloc = ttg.local_alloc : () -> !ttg.memdesc<256x64xf16, #shared, #ttg.shared_memory, mutable>
+  %gather_alloc = ttg.local_alloc : () -> !ttg.memdesc<32x64xf16, #shared, #ttg.shared_memory, mutable>
   //      CHECK: ttng.init_barrier
   // CHECK-NEXT: ttng.init_barrier
   ttng.init_barrier %barrier, 1 : !ttg.memdesc<1xi64, #shared1, #ttg.shared_memory, mutable>
@@ -97,7 +98,7 @@ tt.func @tma_special_cases(%arg1: !tt.tensordesc<256x64xf16, #shared>, %arg2: !t
   // CHECK-NEXT: ttg.barrier local
   // CHECK-NEXT: ttng.async_tma_gather
   // CHECK-NEXT: ttng.wait_barrier
-  %view = ttg.memdesc_subslice %alloc [0, 0]  : !ttg.memdesc<256x64xf16, #shared, #ttg.shared_memory, mutable> -> !ttg.memdesc<32x64xf16, #shared, #ttg.shared_memory, mutable>
+  %view = ttg.memdesc_subslice %gather_alloc [0, 0]  : !ttg.memdesc<32x64xf16, #shared, #ttg.shared_memory, mutable> -> !ttg.memdesc<32x64xf16, #shared, #ttg.shared_memory, mutable>
   ttng.barrier_expect %barrier, 49152, %true : !ttg.memdesc<1xi64, #shared1, #ttg.shared_memory, mutable>
   ttng.async_tma_gather %arg2[%cx, %c0] %view, %barrier, %true : !tt.tensordesc<1x64xf16, #shared>, tensor<32xi32>, i32, !ttg.memdesc<1xi64, #shared1, #ttg.shared_memory, mutable>, !ttg.memdesc<32x64xf16, #shared, #ttg.shared_memory, mutable>, i1
   ttng.wait_barrier %barrier, %c0 : !ttg.memdesc<1xi64, #shared1, #ttg.shared_memory, mutable>

--- a/test/Analysis/test-membar.mlir
+++ b/test/Analysis/test-membar.mlir
@@ -215,10 +215,10 @@ tt.func @async_wait_scan_reaches_block_end(%arg: tensor<32x16xf16, #AL>, %cond: 
 tt.func @subview() {
   %cst0 = arith.constant dense<0.000000e+00> : tensor<32x16xf16, #AL>
   %a = ttg.local_alloc %cst0 : (tensor<32x16xf16, #AL>) -> !ttg.memdesc<32x16xf16, #A_SHARED, #ttg.shared_memory>
-  %0 = ttg.memdesc_subslice %a [0, 0] : !ttg.memdesc<32x16xf16, #A_SHARED, #ttg.shared_memory> -> !ttg.memdesc<16x16xf16, #A_SHARED, #ttg.shared_memory>
+  %0 = ttg.memdesc_subslice %a [0, 0] : !ttg.memdesc<32x16xf16, #A_SHARED, #ttg.shared_memory> -> !ttg.memdesc<16x16xf16, #A_SHARED, #ttg.shared_memory, 32x16>
   // CHECK: ttg.barrier local
   // CHECK-NEXT: ttg.local_load
-  %1 = ttg.local_load %0 : !ttg.memdesc<16x16xf16, #A_SHARED, #ttg.shared_memory> -> tensor<16x16xf16, #AL>
+  %1 = ttg.local_load %0 : !ttg.memdesc<16x16xf16, #A_SHARED, #ttg.shared_memory, 32x16> -> tensor<16x16xf16, #AL>
   // CHECK: ttg.barrier local
   // CHECK-NEXT: ttg.local_alloc
   %2 = ttg.local_alloc %1 : (tensor<16x16xf16, #AL>) -> !ttg.memdesc<16x16xf16, #A_SHARED, #ttg.shared_memory>

--- a/test/Conversion/amd/tritongpu_to_llvm.mlir
+++ b/test/Conversion/amd/tritongpu_to_llvm.mlir
@@ -35,6 +35,30 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32} {
 
 // -----
 
+#shared = #ttg.amd_rotating_shared<{vec = 1, perPhase = 1, maxPhase = 1, order = [1, 0]}>
+#smem = #ttg.shared_memory
+#blocked = #ttg.blocked<{sizePerThread = [1, 1], threadsPerWarp = [8, 8], warpsPerCTA = [2, 2], order = [1, 0]}>
+module attributes {"ttg.target" = "hip:gfx942", "ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, "ttg.threads-per-warp" = 64 : i32} {
+  // COMMON-LABEL: @amd_pipeline_stage_subslice_index
+  // COMMON-DAG: llvm.mlir.constant(256 : i32)
+  // CHECK-DAG: llvm.getelementptr {{.*}}[768]
+  // GFX950-DAG: llvm.mlir.constant(768 : i32)
+  // GFX1250-DAG: llvm.mlir.constant(768 : i32)
+  // GFX906-DAG: llvm.mlir.constant(768 : i32)
+  // COMMON: llvm.mul
+  // COMMON: llvm.getelementptr
+  tt.func @amd_pipeline_stage_subslice_index(%index: i32) {
+    %parent = ttg.local_alloc : () -> !ttg.memdesc<7x16x16xf16, #shared, #smem, mutable>
+    %stages = ttg.memdesc_subslice %parent [3, 0, 0] : !ttg.memdesc<7x16x16xf16, #shared, #smem, mutable> -> !ttg.memdesc<2x16x16xf16, #shared, #smem, mutable, 7x16x16>
+    %view = ttg.memdesc_index %stages[%index] : !ttg.memdesc<2x16x16xf16, #shared, #smem, mutable, 7x16x16> -> !ttg.memdesc<16x16xf16, #shared, #smem, mutable>
+    %zero = arith.constant dense<0.0> : tensor<16x16xf16, #blocked>
+    ttg.local_store %zero, %view : tensor<16x16xf16, #blocked> -> !ttg.memdesc<16x16xf16, #shared, #smem, mutable>
+    tt.return
+  }
+}
+
+// -----
+
 module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32} {
   // CHECK-LABEL: atomic_add_f32_scalar
   // GFX1250-LABEL: atomic_add_f32_scalar

--- a/test/Conversion/lower_tensor_memory_to_llvm.mlir
+++ b/test/Conversion/lower_tensor_memory_to_llvm.mlir
@@ -1,5 +1,7 @@
 // RUN: triton-opt %s --test-print-membar --convert-triton-gpu-to-llvm --convert-warp-specialize-to-llvm --convert-nv-gpu-to-llvm -allow-unregistered-dialect | FileCheck %s
 
+#tmem = #ttng.tensor_memory_encoding<blockM = 128, blockN = 64, colStride = 1, CGALayout = [[0, 0]]>
+
 module attributes {"ttg.target" = "cuda:103", "ttg.num-ctas" = 2 : i32, "ttg.num-warps" = 4 : i32, "ttg.total-num-warps" = 8 : i32, ttg.tensor_memory_size = 128 : i32, "ttng.two-ctas" = true} {
   // CHECK-LABEL: @automatic_tmem_lifecycle
   // CHECK: nvvm.cluster.arrive
@@ -23,4 +25,17 @@ module attributes {"ttg.target" = "cuda:103", "ttg.num-ctas" = 2 : i32, "ttg.num
     } : () -> ()
     llvm.return
   }
+
+  // CHECK-LABEL: @tmem_pipeline_stage_subslice_index
+  // CHECK-DAG: llvm.mlir.constant(128 : i32)
+  // CHECK-DAG: llvm.mlir.constant(64 : i32)
+  // CHECK: llvm.add
+  // CHECK: llvm.mul
+  // CHECK: llvm.add
+  tt.func private @tmem_pipeline_stage_subslice_index(%parent: !ttg.memdesc<5x128x64xf32, #tmem, #ttng.tensor_memory, mutable>, %index: i32) -> !ttg.memdesc<128x64xf32, #tmem, #ttng.tensor_memory, mutable> attributes {"ws_num_warps" = 4 : i32} {
+    %stages = ttng.tmem_subslice %parent {offset = 2 : i32, dim = 0 : i32} : !ttg.memdesc<5x128x64xf32, #tmem, #ttng.tensor_memory, mutable> -> !ttg.memdesc<2x128x64xf32, #tmem, #ttng.tensor_memory, mutable, 5x128x64>
+    %view = ttg.memdesc_index %stages[%index] : !ttg.memdesc<2x128x64xf32, #tmem, #ttng.tensor_memory, mutable, 5x128x64> -> !ttg.memdesc<128x64xf32, #tmem, #ttng.tensor_memory, mutable>
+    tt.return %view : !ttg.memdesc<128x64xf32, #tmem, #ttng.tensor_memory, mutable>
+  }
+
 }

--- a/test/Proton/amd/protongpu_to_llvm.mlir
+++ b/test/Proton/amd/protongpu_to_llvm.mlir
@@ -46,8 +46,8 @@ module attributes {"ttg.num-warps" = 8 : i32} {
     // CHECK-DAG: %[[ADDR2:.*]] = llvm.select %[[P2]], %{{.*}}, %[[ADDR1]]
     // CHECK-DAG: %[[P3:.*]] = llvm.icmp "eq" %[[WARPID]], %{{.*}}
     // CHECK-DAG: %[[ADDR3:.*]] = llvm.select %[[P3]], %{{.*}}, %[[ADDR2]]
-    %0 = ttg.local_alloc : () -> !ttg.memdesc<96xi32, #shared, #smem, mutable>
-    %3 = proton_gpu.segment_alloc %0 : !ttg.memdesc<96xi32, #shared, #smem, mutable> -> !proton_gpu.segment<384, #smem, warp, [0, 1, 2]>
+    %0 = ttg.local_alloc : () -> !ttg.memdesc<96x1xi32, #shared, #smem, mutable>
+    %3 = proton_gpu.segment_alloc %0 : !ttg.memdesc<96x1xi32, #shared, #smem, mutable> -> !proton_gpu.segment<384, #smem, warp, [0, 1, 2]>
     tt.return %3 : !proton_gpu.segment<384, #smem, warp, [0, 1, 2]>
   }
 }

--- a/test/Proton/nvidia/protongpu_to_llvm.mlir
+++ b/test/Proton/nvidia/protongpu_to_llvm.mlir
@@ -42,8 +42,8 @@ module attributes {"ttg.num-warps" = 8 : i32} {
     // CHECK-DAG: %[[ADDR2:.*]] = llvm.select %[[P2]], %{{.*}}, %[[ADDR1]]
     // CHECK-DAG: %[[P3:.*]] = llvm.icmp "eq" %[[WARPID]], %{{.*}}
     // CHECK-DAG: %[[ADDR3:.*]] = llvm.select %[[P3]], %{{.*}}, %[[ADDR2]]
-    %0 = ttg.local_alloc : () -> !ttg.memdesc<96xi32, #shared, #smem, mutable>
-    %3 = proton_gpu.segment_alloc %0 : !ttg.memdesc<96xi32, #shared, #smem, mutable> -> !proton_gpu.segment<384, #smem, warp, [0, 1, 2]>
+    %0 = ttg.local_alloc : () -> !ttg.memdesc<96x1xi32, #shared, #smem, mutable>
+    %3 = proton_gpu.segment_alloc %0 : !ttg.memdesc<96x1xi32, #shared, #smem, mutable> -> !proton_gpu.segment<384, #smem, warp, [0, 1, 2]>
     tt.return %3 : !proton_gpu.segment<384, #smem, warp, [0, 1, 2]>
   }
 }

--- a/test/Proton/proton_to_protongpu.mlir
+++ b/test/Proton/proton_to_protongpu.mlir
@@ -1,5 +1,6 @@
 // RUN: triton-opt --split-input-file -convert-proton-to-protongpu="max-shared-mem-size=32768" -canonicalize -cse %s | FileCheck %s
 // RUN: triton-opt --split-input-file -convert-proton-to-protongpu="buffer-type=global buffer-size=1024" -canonicalize -cse %s | FileCheck --check-prefix=CHECK-GMEM %s
+// RUN: triton-opt --split-input-file -convert-proton-to-protongpu="max-shared-mem-size=32768 sampling-strategy=selective sampling-options=0,1,2" -canonicalize -cse %s | FileCheck --check-prefix=CHECK-SELECTIVE %s
 
 module {
   // CHECK-LABEL: no_record
@@ -13,9 +14,12 @@ module {
 
 module attributes {"ttg.num-warps" = 8 : i32} {
   // CHECK-LABEL: simple_record
+  // CHECK-SELECTIVE-LABEL: tt.func @simple_record
+  // CHECK-SELECTIVE: %[[SELECTIVE_BUF:.*]] = ttg.local_alloc{{.*}}!ttg.memdesc<192x1xi32, #shared, #smem, mutable>
+  // CHECK-SELECTIVE: proton_gpu.segment_alloc %[[SELECTIVE_BUF]]{{.*}}<768, #smem, warp, [0, 1, 2]>
   // CHECK: %[[SCRATCH:.*]] = ttg.global_scratch_alloc {alignment = 128 : i32, nbytes = 1152 : i32, third_party_allocation} : !tt.ptr<i32>
   // CHECK: proton_gpu.initialize %[[SCRATCH]] : !tt.ptr<i32>
-  // CHECK: %[[BUF:.*]] = ttg.local_alloc  : () -> !ttg.memdesc<256xi32, #shared, #smem, mutable>
+  // CHECK: %[[BUF:.*]] = ttg.local_alloc  : () -> !ttg.memdesc<256x1xi32, #shared, #smem, mutable>
   // CHECK: %[[SEGMENT:.*]] = proton_gpu.segment_alloc %[[BUF]]
   // CHECK: %[[START:.*]] = proton_gpu.read_counter : i32
   // CHECK: proton_gpu.circular_store start %[[SEGMENT]], %[[START]] {scopeId = 0 : i32} : !proton_gpu.segment<1024, #smem, warp>, i32
@@ -114,8 +118,8 @@ module attributes {"ttg.num-warps" = 8 : i32} {
 // CHECK: module attributes {"ttg.num-warps" = 4 : i32, "ttg.total-num-warps" = 8 : i32} {
 // CHECK:   tt.func @convert_warp_specialize() {
 // CHECK:     %[[SCRATCH:.*]] = ttg.global_scratch_alloc {alignment = 128 : i32, nbytes = 1152 : i32, third_party_allocation} : !tt.ptr<i32>
-// CHECK:     %[[MEMDESC:.*]] = ttg.local_alloc : () -> !ttg.memdesc<256xi32, #shared, #smem, mutable>
-// CHECK:     %[[SEGMENT:.*]] = proton_gpu.segment_alloc %[[MEMDESC]] : !ttg.memdesc<256xi32, #shared, #smem, mutable> -> <1024, #smem, warp>
+// CHECK:     %[[MEMDESC:.*]] = ttg.local_alloc : () -> !ttg.memdesc<256x1xi32, #shared, #smem, mutable>
+// CHECK:     %[[SEGMENT:.*]] = proton_gpu.segment_alloc %[[MEMDESC]] : !ttg.memdesc<256x1xi32, #shared, #smem, mutable> -> <1024, #smem, warp>
 // CHECK:     proton_gpu.init_ctx %[[SCRATCH]] : !tt.ptr<i32>
 // CHECK:     %[[COUNTER1:.*]] = proton_gpu.read_counter : i32
 // CHECK:     proton_gpu.circular_store start %[[SEGMENT]], %[[COUNTER1]] {scopeId = 0 : i32} : !proton_gpu.segment<1024, #smem, warp>, i32
@@ -127,15 +131,15 @@ module attributes {"ttg.num-warps" = 8 : i32} {
 // CHECK:       proton_gpu.circular_store end %[[SEGMENT]], %[[COUNTER3]] {scopeId = 1 : i32} : !proton_gpu.segment<1024, #smem, warp>, i32
 // CHECK:       ttg.warp_yield
 // CHECK:     }
-// CHECK:     partition0(%[[ARG0:.*]]: !ttg.memdesc<256xi32, #shared, #smem, mutable>, %[[ARG1:.*]]: !tt.ptr<i32>) num_warps(1) {
-// CHECK:       %[[SEGMENT2:.*]] = proton_gpu.segment_alloc %[[ARG0]] : !ttg.memdesc<256xi32, #shared, #smem, mutable> -> <1024, #smem, warp>
+// CHECK:     partition0(%[[ARG0:.*]]: !ttg.memdesc<256x1xi32, #shared, #smem, mutable>, %[[ARG1:.*]]: !tt.ptr<i32>) num_warps(1) {
+// CHECK:       %[[SEGMENT2:.*]] = proton_gpu.segment_alloc %[[ARG0]] : !ttg.memdesc<256x1xi32, #shared, #smem, mutable> -> <1024, #smem, warp>
 // CHECK:       proton_gpu.restore_ctx %[[SEGMENT2]], %[[ARG1]] : !proton_gpu.segment<1024, #smem, warp>, !tt.ptr<i32>
 // CHECK:       %[[COUNTER4:.*]] = proton_gpu.read_counter : i32
 // CHECK:       proton_gpu.circular_store start %[[SEGMENT2]], %[[COUNTER4]] {scopeId = 2 : i32} : !proton_gpu.segment<1024, #smem, warp>, i32
 // CHECK:       %[[COUNTER5:.*]] = proton_gpu.read_counter : i32
 // CHECK:       proton_gpu.circular_store end %[[SEGMENT2]], %[[COUNTER5]] {scopeId = 2 : i32} : !proton_gpu.segment<1024, #smem, warp>, i32
 // CHECK:       ttg.warp_return
-// CHECK:     } : (!ttg.memdesc<256xi32, #shared, #smem, mutable>, !tt.ptr<i32>) -> ()
+// CHECK:     } : (!ttg.memdesc<256x1xi32, #shared, #smem, mutable>, !tt.ptr<i32>) -> ()
 // CHECK:     %[[COUNTER6:.*]] = proton_gpu.read_counter : i32
 // CHECK:     proton_gpu.circular_store end %[[SEGMENT]], %[[COUNTER6]] {scopeId = 0 : i32} : !proton_gpu.segment<1024, #smem, warp>, i32
 // CHECK: ttg.barrier local|global_read|global_write

--- a/test/Proton/protongpu_transforms.mlir
+++ b/test/Proton/protongpu_transforms.mlir
@@ -4,7 +4,7 @@ module attributes {"ttg.num-warps" = 8 : i32} {
   // CHECK-LABEL: simple_record
   // CHECK: %[[SCRATCH:.*]] = ttg.global_scratch_alloc {alignment = 128 : i32, nbytes = 1152 : i32, third_party_allocation} : !tt.ptr<i32>
   // CHECK-NEXT: proton_gpu.initialize %[[SCRATCH]] : !tt.ptr<i32>
-  // CHECK-NEXT: %[[BUF:.*]] = ttg.local_alloc  : () -> !ttg.memdesc<256xi32, #shared, #smem, mutable>
+  // CHECK-NEXT: %[[BUF:.*]] = ttg.local_alloc  : () -> !ttg.memdesc<256x1xi32, #shared, #smem, mutable>
   // CHECK-NEXT: %[[SEGMENT:.*]] = proton_gpu.segment_alloc %[[BUF]]
   // CHECK-NEXT: %[[START:.*]] = proton_gpu.read_counter : i32
   // CHECK-NEXT: %[[END:.*]] = proton_gpu.read_counter : i32
@@ -26,7 +26,7 @@ module attributes {"ttg.num-warps" = 8 : i32} {
   // CHECK-LABEL: simple_record
   // CHECK: %[[SCRATCH:.*]] = ttg.global_scratch_alloc {alignment = 128 : i32, nbytes = 1152 : i32, third_party_allocation} : !tt.ptr<i32>
   // CHECK-NEXT: proton_gpu.initialize %[[SCRATCH]] : !tt.ptr<i32>
-  // CHECK-NEXT: %[[BUF:.*]] = ttg.local_alloc  : () -> !ttg.memdesc<256xi32, #shared, #smem, mutable>
+  // CHECK-NEXT: %[[BUF:.*]] = ttg.local_alloc  : () -> !ttg.memdesc<256x1xi32, #shared, #smem, mutable>
   // CHECK-NEXT: %[[SEGMENT:.*]] = proton_gpu.segment_alloc %[[BUF]]
   // CHECK-NEXT: %[[START1:.*]] = proton_gpu.read_counter : i32
   // CHECK-NEXT: %[[START2:.*]] = proton_gpu.read_counter : i32

--- a/test/TritonGPU/amd/amd-consan.mlir
+++ b/test/TritonGPU/amd/amd-consan.mlir
@@ -324,11 +324,11 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 1 : i32, ttg.shar
     // CHECK-DAG: tti.experimental_buffer_descriptors [0, 128], [256, 128], shared_mem : tensor<2xi64
     // CHECK-DAG: arith.constant dense<true> : tensor<2x2xi1
     %buf0 = ttg.local_alloc {allocation.offset = 0 : i32} : () -> !ttg.memdesc<64xf32, #shared, #smem, mutable>
-    %buf1 = ttg.memdesc_subslice %buf0 [32] : !ttg.memdesc<64xf32, #shared, #smem, mutable> -> !ttg.memdesc<32xf32, #shared, #smem, mutable>
+    %buf1 = ttg.memdesc_subslice %buf0 [32] : !ttg.memdesc<64xf32, #shared, #smem, mutable> -> !ttg.memdesc<32xf32, #shared, #smem, mutable, 64>
     %bar = ttg.local_alloc {allocation.offset = 4096 : i32} : () -> !ttg.memdesc<1xi64, #shared, #smem, mutable>
     amdg.init_barrier %bar, 1 : !ttg.memdesc<1xi64, #shared, #smem, mutable>
     ttg.local_load %buf0 : !ttg.memdesc<64xf32, #shared, #smem, mutable> -> tensor<64xf32>
-    ttg.local_load %buf1 : !ttg.memdesc<32xf32, #shared, #smem, mutable> -> tensor<32xf32>
+    ttg.local_load %buf1 : !ttg.memdesc<32xf32, #shared, #smem, mutable, 64> -> tensor<32xf32>
     tt.return
   }
 }

--- a/test/TritonGPU/amd/invalid.mlir
+++ b/test/TritonGPU/amd/invalid.mlir
@@ -314,45 +314,6 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.targ
 
 // -----
 
-// Gather of a sub-byte element type: the lds_addr byte-delta scaling truncates
-// to zero for <8-bit elements.
-#blocked = #ttg.blocked<{sizePerThread = [16, 1], threadsPerWarp = [1, 32], warpsPerCTA = [1, 4], order = [1, 0]}>
-#slice = #ttg.slice<{dim = 1, parent = #blocked}>
-#shared = #ttg.swizzled_shared<{vec = 1, perPhase = 1, maxPhase = 1, order = [1, 0]}>
-#smem = #ttg.shared_memory
-module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.target = "hip:gfx1250", "ttg.threads-per-warp" = 32 : i32} {
-  tt.func @tdm_gather_invalid_subbyte_element(
-    %tensorDesc: !tt.tensordesc<16x64xi4, #shared>,
-    %memDesc: !ttg.memdesc<16x64xi4, #shared, #smem, mutable>,
-    %row_indices: tensor<16xi32, #slice>
-  ) {
-    // expected-error @+1 {{TDM gather requires element types of at least 8 bits}}
-    %token = amdg.async_tdm_gather %tensorDesc[%row_indices] to %memDesc : tensor<16xi32, #slice>, !ttg.memdesc<16x64xi4, #shared, #smem, mutable> -> !tt.tensordesc<16x64xi4, #shared>
-    tt.return
-  }
-}
-
-// -----
-
-// Scatter of a sub-byte element type: same lds_addr byte-delta truncation.
-#blocked = #ttg.blocked<{sizePerThread = [16, 1], threadsPerWarp = [1, 32], warpsPerCTA = [1, 4], order = [1, 0]}>
-#slice = #ttg.slice<{dim = 1, parent = #blocked}>
-#shared = #ttg.swizzled_shared<{vec = 1, perPhase = 1, maxPhase = 1, order = [1, 0]}>
-#smem = #ttg.shared_memory
-module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.target = "hip:gfx1250", "ttg.threads-per-warp" = 32 : i32} {
-  tt.func @tdm_scatter_invalid_subbyte_element(
-    %tensorDesc: !tt.tensordesc<16x64xi4, #shared>,
-    %memDesc: !ttg.memdesc<16x64xi4, #shared, #smem, mutable>,
-    %row_indices: tensor<16xi32, #slice>
-  ) {
-    // expected-error @+1 {{TDM scatter requires element types of at least 8 bits}}
-    %token = amdg.async_tdm_scatter %tensorDesc[%row_indices] from %memDesc : tensor<16xi32, #slice>, !ttg.memdesc<16x64xi4, #shared, #smem, mutable> -> !tt.tensordesc<16x64xi4, #shared>
-    tt.return
-  }
-}
-
-// -----
-
 #blocked1 = #ttg.blocked<{sizePerThread = [16, 1], threadsPerWarp = [1, 32], warpsPerCTA = [1, 1], order = [1, 0], CGALayout = [[0, 0], [0, 0]]}>
 #slice1 = #ttg.slice<{dim = 1, parent = #blocked1}>
 #shared1 = #ttg.swizzled_shared<{vec = 1, perPhase = 1, maxPhase = 1, order = [1, 0], CGALayout = [[1, 0], [2, 0]]}>

--- a/test/TritonGPU/consan.mlir
+++ b/test/TritonGPU/consan.mlir
@@ -1757,11 +1757,11 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 1 : i32, ttg.shar
     // CHECK-DAG: tti.experimental_buffer_descriptors [0, 128], [256, 128], shared_mem : tensor<2xi64
     // CHECK-DAG: arith.constant dense<true> : tensor<2x2xi1
     %buf0 = ttg.local_alloc {allocation.offset = 0 : i32} : () -> !ttg.memdesc<64xf32, #shared, #smem, mutable>
-    %buf1 = ttg.memdesc_subslice %buf0 [32] : !ttg.memdesc<64xf32, #shared, #smem, mutable> -> !ttg.memdesc<32xf32, #shared, #smem, mutable>
+    %buf1 = ttg.memdesc_subslice %buf0 [32] : !ttg.memdesc<64xf32, #shared, #smem, mutable> -> !ttg.memdesc<32xf32, #shared, #smem, mutable, 64>
     %bar = ttg.local_alloc {allocation.offset = 4096 : i32} : () -> !ttg.memdesc<1xi64, #shared, #smem, mutable>
     ttng.init_barrier %bar, 1 : !ttg.memdesc<1xi64, #shared, #smem, mutable>
     ttg.local_load %buf0 : !ttg.memdesc<64xf32, #shared, #smem, mutable> -> tensor<64xf32>
-    ttg.local_load %buf1 : !ttg.memdesc<32xf32, #shared, #smem, mutable> -> tensor<32xf32>
+    ttg.local_load %buf1 : !ttg.memdesc<32xf32, #shared, #smem, mutable, 64> -> tensor<32xf32>
     tt.return
   }
 }

--- a/test/TritonGPU/invalid.mlir
+++ b/test/TritonGPU/invalid.mlir
@@ -164,7 +164,7 @@ tt.func public @result_1d_to_1d(%arg0: !ttg.memdesc<8xf32, #shared, #smem>) {
 #smem = #ttg.shared_memory
 tt.func public @subview_along_swizzling_pattern(%arg0: !ttg.memdesc<8x16xf32, #shared, #smem>) {
     // expected-error @+1 {{swizzling pattern}}
-    %a = ttg.memdesc_subslice %arg0 [0, 0] : !ttg.memdesc<8x16xf32, #shared, #smem> -> !ttg.memdesc<8x4xf32, #shared, #smem>
+    %a = ttg.memdesc_subslice %arg0 [0, 0] : !ttg.memdesc<8x16xf32, #shared, #smem> -> !ttg.memdesc<8x4xf32, #shared, #smem, 8x16>
     tt.return
 }
 
@@ -174,7 +174,7 @@ tt.func public @subview_along_swizzling_pattern(%arg0: !ttg.memdesc<8x16xf32, #s
 #smem = #ttg.shared_memory
 tt.func public @subview_along_swizzling(%arg0: !ttg.memdesc<8x16xf32, #shared, #smem>, %index: i32) {
     // expected-error @+1 {{tile}}
-    %a = ttg.memdesc_subslice %arg0 [2, 0] : !ttg.memdesc<8x16xf32, #shared, #smem> -> !ttg.memdesc<4x16xf32, #shared, #smem>
+    %a = ttg.memdesc_subslice %arg0 [2, 0] : !ttg.memdesc<8x16xf32, #shared, #smem> -> !ttg.memdesc<4x16xf32, #shared, #smem, 8x16>
     tt.return
 }
 
@@ -284,6 +284,22 @@ tt.func public @memdesc_reinterpret_changed_mutability(%arg0: !ttg.memdesc<8x16x
 tt.func public @memdesc_reinterpret_subview(%arg0: !ttg.memdesc<8x16xf16, #shared, #smem, 16x16>) {
     // expected-error @+1 {{source and result must not be subviews}}
     %a = ttg.memdesc_reinterpret %arg0 : !ttg.memdesc<8x16xf16, #shared, #smem, 16x16> -> !ttg.memdesc<8x16xf16, #shared, #smem>
+    tt.return
+}
+
+// -----
+
+#shared = #ttg.swizzled_shared<{vec = 1, perPhase = 1, maxPhase = 1, order = [1, 0]}>
+#smem = #ttg.shared_memory
+tt.func public @memdesc_subslice_alloc_shape_mismatch(%arg0: !ttg.memdesc<8x16xf32, #shared, #smem>) {
+    // expected-error @+1 {{source and result must have the same allocation shape}}
+    %a = ttg.memdesc_subslice %arg0 [0, 0] : !ttg.memdesc<8x16xf32, #shared, #smem> -> !ttg.memdesc<8x8xf32, #shared, #smem>
+    tt.return
+}
+
+tt.func public @memdesc_subslice_negative_offset(%arg0: !ttg.memdesc<8x16xf32, #shared, #smem>) {
+    // expected-error @+1 {{The split offset may not exceed the source shape}}
+    %negative = ttg.memdesc_subslice %arg0 [-4, 0] : !ttg.memdesc<8x16xf32, #shared, #smem> -> !ttg.memdesc<4x16xf32, #shared, #smem, 8x16>
     tt.return
 }
 

--- a/test/TritonGPU/invalid.mlir
+++ b/test/TritonGPU/invalid.mlir
@@ -824,6 +824,12 @@ tt.func @async_copy_invalid_other_type(%input: tensor<64x64x!tt.ptr<f16>, #block
 
 // -----
 
+#shared = #ttg.swizzled_shared<{vec = 1, perPhase = 1, maxPhase = 1, order = [0]}>
+// expected-error @below {{element type bit width must be 1 or at least 8; got 4}}
+!subbyte_memdesc = !ttg.memdesc<8xi4, #shared, #ttg.shared_memory>
+
+// -----
+
 #shared = #ttg.padded_shared<[4:+4] {offset=[[1, 0], [2, 0], [0, 1], [0, 2]], block=[]}>
 // expected-error @below {{rank must be equal to or one less than the shape size. Got 2 and 4}}
 !rank_too_high = !ttg.memdesc<4x4x4x4xf32, #shared, #ttg.shared_memory>

--- a/test/TritonGPU/invalid.mlir
+++ b/test/TritonGPU/invalid.mlir
@@ -251,7 +251,7 @@ tt.func public @result_dim_too_large(%arg0: !ttg.memdesc<8x16xf32, #shared1d, #s
 #shared = #ttg.swizzled_shared<{vec = 8, perPhase = 1, maxPhase = 4, order = [0, 1]}>
 #smem = #ttg.shared_memory
 tt.func public @memdesc_reinterpret_changed_storage_size(%arg0: !ttg.memdesc<8x16xf16, #shared, #smem>) {
-    // expected-error @+1 {{result logical storage size must not exceed source logical storage size}}
+    // expected-error @+1 {{result shared-memory footprint (512 bytes) exceeds the source view (256 bytes)}}
     %a = ttg.memdesc_reinterpret %arg0 : !ttg.memdesc<8x16xf16, #shared, #smem> -> !ttg.memdesc<8x16xf32, #shared, #smem>
     tt.return
 }
@@ -282,7 +282,7 @@ tt.func public @memdesc_reinterpret_changed_mutability(%arg0: !ttg.memdesc<8x16x
 #shared = #ttg.swizzled_shared<{vec = 8, perPhase = 1, maxPhase = 4, order = [0, 1]}>
 #smem = #ttg.shared_memory
 tt.func public @memdesc_reinterpret_subview(%arg0: !ttg.memdesc<8x16xf16, #shared, #smem, 16x16>) {
-    // expected-error @+1 {{source and result must not be subviews}}
+    // expected-error @+1 {{result shared-memory footprint includes offsets not owned by the source subview}}
     %a = ttg.memdesc_reinterpret %arg0 : !ttg.memdesc<8x16xf16, #shared, #smem, 16x16> -> !ttg.memdesc<8x16xf16, #shared, #smem>
     tt.return
 }
@@ -309,8 +309,83 @@ tt.func public @memdesc_subslice_negative_offset(%arg0: !ttg.memdesc<8x16xf32, #
 #shared_b = #ttg.nvmma_shared<{swizzlingByteWidth = 32, transposed = false, elementBitWidth = 16}>
 #smem = #ttg.shared_memory
 tt.func public @memdesc_reinterpret_multibuffer_subview_expands(%arg0: !ttg.memdesc<3x8x32xf16, #shared_a, #smem, 8x8x32>) {
-    // expected-error @+1 {{result logical storage size must not exceed source logical storage size}}
+    // expected-error @+1 {{result shared-memory footprint}}
     %a = ttg.memdesc_reinterpret %arg0 : !ttg.memdesc<3x8x32xf16, #shared_a, #smem, 8x8x32> -> !ttg.memdesc<16x8x16xf16, #shared_b, #smem>
+    tt.return
+}
+
+// -----
+
+#shared_dense = #ttg.shared_linear<{offset = [[0, 1], [0, 2], [1, 0], [2, 0]], block = []}, alignment = 16>
+#shared_tight = #ttg.shared_linear<{offset = [[0, 1], [1, 0], [2, 0]], block = []}, alignment = 16>
+#shared_holey = #ttg.shared_linear<{offset = [[0, 1], [0, 0], [1, 0], [2, 0]], block = []}, alignment = 16>
+#shared_swizzled = #ttg.shared_linear<{offset = [[0, 1], [1, 1], [2, 0]], block = []}, alignment = 16>
+#shared_pair = #ttg.shared_linear<{offset = [[0, 1]], block = []}, alignment = 16>
+#smem = #ttg.shared_memory
+tt.func public @memdesc_reinterpret_noncontiguous_subview_escapes(%arg0: !ttg.memdesc<4x4xi32, #shared_dense, #smem, mutable>) {
+    %view = ttg.memdesc_subslice %arg0 [0, 0] : !ttg.memdesc<4x4xi32, #shared_dense, #smem, mutable> -> !ttg.memdesc<4x2xi32, #shared_dense, #smem, mutable, 4x4>
+    // expected-error @+1 {{result shared-memory footprint includes offsets not owned by the source subview}}
+    %result = ttg.memdesc_reinterpret %view : !ttg.memdesc<4x2xi32, #shared_dense, #smem, mutable, 4x4> -> !ttg.memdesc<4x2xi32, #shared_tight, #smem, mutable>
+    tt.return
+}
+
+tt.func public @memdesc_reinterpret_noncontiguous_subview_claims_holes(%arg0: !ttg.memdesc<4x4xi32, #shared_dense, #smem, mutable>) {
+    %view = ttg.memdesc_subslice %arg0 [0, 0] : !ttg.memdesc<4x4xi32, #shared_dense, #smem, mutable> -> !ttg.memdesc<4x2xi32, #shared_dense, #smem, mutable, 4x4>
+    // expected-error @+1 {{result shared-memory footprint includes offsets not owned by the source subview}}
+    %result = ttg.memdesc_reinterpret %view : !ttg.memdesc<4x2xi32, #shared_dense, #smem, mutable, 4x4> -> !ttg.memdesc<4x2xi32, #shared_holey, #smem, mutable>
+    tt.return
+}
+
+tt.func public @memdesc_reinterpret_swizzled_subview_gap(%arg0: !ttg.memdesc<4x2xi32, #shared_swizzled, #smem, mutable>) {
+    %view = ttg.memdesc_subslice %arg0 [0, 0] : !ttg.memdesc<4x2xi32, #shared_swizzled, #smem, mutable> -> !ttg.memdesc<2x1xi32, #shared_swizzled, #smem, mutable, 4x2>
+    // expected-error @+1 {{result shared-memory footprint includes offsets not owned by the source subview}}
+    %result = ttg.memdesc_reinterpret %view : !ttg.memdesc<2x1xi32, #shared_swizzled, #smem, mutable, 4x2> -> !ttg.memdesc<1x2xi32, #shared_pair, #smem, mutable>
+    tt.return
+}
+
+// -----
+
+#shared = #ttg.swizzled_shared<{vec = 1, perPhase = 1, maxPhase = 1, order = [1, 0]}>
+#smem = #ttg.shared_memory
+tt.func public @memdesc_reinterpret_pipeline_subview_gap(%arg0: !ttg.memdesc<7x16x16xf16, #shared, #smem, mutable>) {
+    %gapped = ttg.memdesc_subslice %arg0 [3, 8, 0] : !ttg.memdesc<7x16x16xf16, #shared, #smem, mutable> -> !ttg.memdesc<2x8x16xf16, #shared, #smem, mutable, 7x16x16>
+    // expected-error @+1 {{result shared-memory footprint includes offsets not owned by the source subview}}
+    %gap = ttg.memdesc_reinterpret %gapped : !ttg.memdesc<2x8x16xf16, #shared, #smem, mutable, 7x16x16> -> !ttg.memdesc<16x16xf16, #shared, #smem, mutable>
+    tt.return
+}
+
+tt.func public @memdesc_reinterpret_pipeline_stage_expansion(%arg0: !ttg.memdesc<7x16x16xf16, #shared, #smem, mutable>) {
+    %stages = ttg.memdesc_subslice %arg0 [3, 0, 0] : !ttg.memdesc<7x16x16xf16, #shared, #smem, mutable> -> !ttg.memdesc<2x16x16xf16, #shared, #smem, mutable, 7x16x16>
+    // expected-error @+1 {{result shared-memory footprint}}
+    %expanded = ttg.memdesc_reinterpret %stages : !ttg.memdesc<2x16x16xf16, #shared, #smem, mutable, 7x16x16> -> !ttg.memdesc<4x16x16xf16, #shared, #smem, mutable>
+    tt.return
+}
+
+tt.func public @memdesc_reinterpret_result_layout_subview(%arg0: !ttg.memdesc<7x16x16xf16, #shared, #smem, mutable>) {
+    // expected-error @+1 {{result must not be a subview}}
+    %destination = ttg.memdesc_reinterpret %arg0 : !ttg.memdesc<7x16x16xf16, #shared, #smem, mutable> -> !ttg.memdesc<7x8x16xf16, #shared, #smem, mutable, 7x16x16>
+    tt.return
+}
+
+// -----
+
+#padded16 = #ttg.padded_shared<[128:+8] {order = [1, 0], shape = [16, 128]}>
+#padded8 = #ttg.padded_shared<[128:+8] {order = [1, 0], shape = [8, 128]}>
+#smem = #ttg.shared_memory
+tt.func public @memdesc_reinterpret_padded_subview(%arg0: !ttg.memdesc<8x128xf16, #padded16, #smem, mutable, 16x128>) {
+    // expected-error @+1 {{cannot reinterpret a padded source subview}}
+    %result = ttg.memdesc_reinterpret %arg0 : !ttg.memdesc<8x128xf16, #padded16, #smem, mutable, 16x128> -> !ttg.memdesc<8x128xf16, #padded8, #smem, mutable>
+    tt.return
+}
+
+// -----
+
+#shared_inner = #ttg.swizzled_shared<{vec = 1, perPhase = 1, maxPhase = 1, order = [1, 0]}>
+#partitioned = #ttg.partitioned_shared<{numPartitions = 2, numGroups = 2, partitionDim = 0, partitionLayout = #shared_inner}>
+#smem = #ttg.shared_memory
+tt.func public @memdesc_reinterpret_partitioned(%arg0: !ttg.memdesc<128x16xf16, #partitioned, #smem, mutable>) {
+    // expected-error @+1 {{cannot reinterpret partitioned shared layouts}}
+    %result = ttg.memdesc_reinterpret %arg0 : !ttg.memdesc<128x16xf16, #partitioned, #smem, mutable> -> !ttg.memdesc<128x16xi16, #partitioned, #smem, mutable>
     tt.return
 }
 
@@ -320,7 +395,7 @@ tt.func public @memdesc_reinterpret_multibuffer_subview_expands(%arg0: !ttg.memd
 #shared_b = #ttg.nvmma_shared<{swizzlingByteWidth = 32, transposed = false, elementBitWidth = 16}>
 #smem = #ttg.shared_memory
 tt.func public @memdesc_reinterpret_multibuffer_layout_subview(%arg0: !ttg.memdesc<3x4x32xf16, #shared_a, #smem, 8x8x32>) {
-    // expected-error @+1 {{source and result must not be subviews}}
+    // expected-error @+1 {{result shared-memory footprint}}
     %a = ttg.memdesc_reinterpret %arg0 : !ttg.memdesc<3x4x32xf16, #shared_a, #smem, 8x8x32> -> !ttg.memdesc<16x8x16xf16, #shared_b, #smem>
     tt.return
 }

--- a/test/TritonGPU/invalid.mlir
+++ b/test/TritonGPU/invalid.mlir
@@ -1,5 +1,41 @@
 // RUN: triton-opt --split-input-file %s --verify-diagnostics
 
+#shared = #ttg.swizzled_shared<{vec = 1, perPhase = 1, maxPhase = 1, order = [1, 0]}>
+#smem = #ttg.shared_memory
+// expected-error @+1 {{shape must have power-of-2 and non-zero dimensions; got 3, 4}}
+tt.func public @memdesc_non_power_of_two_layout_dimension(%arg0: !ttg.memdesc<3x4xi32, #shared, #smem, mutable, 4x4>) {
+  tt.return
+}
+
+// -----
+
+#shared = #ttg.swizzled_shared<{vec = 1, perPhase = 1, maxPhase = 1, order = [1, 0]}>
+#smem = #ttg.shared_memory
+// expected-error @+1 {{alloc shape must have power-of-2 and non-zero dimensions; got 3, 4}}
+tt.func public @memdesc_non_power_of_two_layout_allocation(%arg0: !ttg.memdesc<2x4xi32, #shared, #smem, mutable, 3x4>) {
+  tt.return
+}
+
+// -----
+
+#shared = #ttg.swizzled_shared<{vec = 1, perPhase = 1, maxPhase = 1, order = [1, 0]}>
+#smem = #ttg.shared_memory
+// expected-error @+1 {{shape has 0 dimension}}
+tt.func public @memdesc_zero_layout_dimension(%arg0: !ttg.memdesc<4x0xi32, #shared, #smem, mutable, 4x4>) {
+  tt.return
+}
+
+// -----
+
+#shared = #ttg.swizzled_shared<{vec = 1, perPhase = 1, maxPhase = 1, order = [1, 0]}>
+#smem = #ttg.shared_memory
+// expected-error @+1 {{alloc shape has 0 dimension}}
+tt.func public @memdesc_zero_allocation_dimension(%arg0: !ttg.memdesc<2x4xi32, #shared, #smem, mutable, 0x4>) {
+  tt.return
+}
+
+// -----
+
 #shared = #ttg.swizzled_shared<{vec = 1, perPhase = 1, maxPhase = 1, order = [0]}>
 #smem = #ttg.shared_memory
 tt.func public @local_alloc_i1() {

--- a/test/TritonGPU/invalid.mlir
+++ b/test/TritonGPU/invalid.mlir
@@ -36,6 +36,11 @@ tt.func public @memdesc_zero_allocation_dimension(%arg0: !ttg.memdesc<2x4xi32, #
 
 // -----
 
+// expected-error @below {{is not a valid encoding}}
+!invalid_memdesc_encoding = !ttg.memdesc<4xi32, #ttg.shared_memory, #ttg.shared_memory>
+
+// -----
+
 #shared = #ttg.swizzled_shared<{vec = 1, perPhase = 1, maxPhase = 1, order = [0]}>
 #smem = #ttg.shared_memory
 tt.func public @local_alloc_i1() {

--- a/test/TritonGPU/nvidia-fpsan.mlir
+++ b/test/TritonGPU/nvidia-fpsan.mlir
@@ -8,6 +8,26 @@
 #red = #ttg.slice<{dim = 1, parent = #blocked_reduce}>
 #tmem = #ttng.tensor_memory_encoding<blockM = 128, blockN = 128, colStride = 1>
 module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.shared = 65544 : i32, ttg.tensor_memory_size = 0 : i32, "ttg.total-num-warps" = 1 : i32} {
+  // CHECK-LABEL: @tmem_pipeline_stage_subslice_index
+  // CHECK-DAG: arith.constant 16384 : i32
+  // CHECK-DAG: arith.constant 32768 : i32
+  // CHECK: ttg.global_scratch_alloc
+  // CHECK: tt.addptr
+  // CHECK: tt.addptr
+  // CHECK-NOT: ttng.tmem_subslice
+  // CHECK-NOT: ttg.memdesc_index
+  tt.func public @tmem_pipeline_stage_subslice_index() {
+    %true = arith.constant true
+    %one = arith.constant 1 : i32
+    %zero = arith.constant dense<0.0> : tensor<128x128xf32, #blocked>
+    %buf = ttng.tmem_alloc {tensor_memory_col_offset = 0 : i32, tensor_memory_row_offset = 0 : i32} : () -> !ttg.memdesc<5x128x128xf32, #tmem, #ttng.tensor_memory, mutable>
+    %stages = ttng.tmem_subslice %buf {offset = 2 : i32, dim = 0 : i32} : !ttg.memdesc<5x128x128xf32, #tmem, #ttng.tensor_memory, mutable> -> !ttg.memdesc<2x128x128xf32, #tmem, #ttng.tensor_memory, mutable, 5x128x128>
+    %view = ttg.memdesc_index %stages[%one] : !ttg.memdesc<2x128x128xf32, #tmem, #ttng.tensor_memory, mutable, 5x128x128> -> !ttg.memdesc<128x128xf32, #tmem, #ttng.tensor_memory, mutable>
+    ttng.tmem_store %zero, %view, %true : tensor<128x128xf32, #blocked> -> !ttg.memdesc<128x128xf32, #tmem, #ttng.tensor_memory, mutable>
+    ttng.tmem_load %view : !ttg.memdesc<128x128xf32, #tmem, #ttng.tensor_memory, mutable> -> tensor<128x128xf32, #blocked>
+    tt.return
+  }
+
   // CHECK-LABEL: @tmem_load_store
   tt.func public @tmem_load_store() {
     // CHECK: ttg.global_scratch_alloc

--- a/test/TritonGPU/ops.mlir
+++ b/test/TritonGPU/ops.mlir
@@ -119,21 +119,21 @@ module attributes {"ttg.target" = "cuda:0", "ttg.num-ctas" = 2 : i32, "ttg.num-w
   // CHECK-LABEL: @subslice_non_trivial_block_cga_01
   tt.func @subslice_non_trivial_block_cga_01(%arg0: !ttg.memdesc<8x16xf32, #shared_cga_01, #smem>) {
     // CHECK: ttg.memdesc_subslice %{{.*}}[0, 0]
-    %0 = ttg.memdesc_subslice %arg0 [0, 0] : !ttg.memdesc<8x16xf32, #shared_cga_01, #smem> -> !ttg.memdesc<4x16xf32, #shared_cga_01, #smem>
+    %0 = ttg.memdesc_subslice %arg0 [0, 0] : !ttg.memdesc<8x16xf32, #shared_cga_01, #smem> -> !ttg.memdesc<4x16xf32, #shared_cga_01, #smem, 8x16>
     tt.return
   }
 
   // CHECK-LABEL: @subslice_non_trivial_block_cga_10
   tt.func @subslice_non_trivial_block_cga_10(%arg0: !ttg.memdesc<8x16xf32, #shared_cga_10, #smem>) {
     // CHECK: ttg.memdesc_subslice %{{.*}}[0, 0]
-    %0 = ttg.memdesc_subslice %arg0 [0, 0] : !ttg.memdesc<8x16xf32, #shared_cga_10, #smem> -> !ttg.memdesc<8x8xf32, #shared_cga_10, #smem>
+    %0 = ttg.memdesc_subslice %arg0 [0, 0] : !ttg.memdesc<8x16xf32, #shared_cga_10, #smem> -> !ttg.memdesc<8x8xf32, #shared_cga_10, #smem, 8x16>
     tt.return
   }
 
   // CHECK-LABEL: @subslice_broadcasted_block_cga_00
   tt.func @subslice_broadcasted_block_cga_00(%arg0: !ttg.memdesc<8x16xf32, #shared_cga_00, #smem>) {
     // CHECK: ttg.memdesc_subslice %{{.*}}[0, 0]
-    %0 = ttg.memdesc_subslice %arg0 [0, 0] : !ttg.memdesc<8x16xf32, #shared_cga_00, #smem> -> !ttg.memdesc<4x16xf32, #shared_cga_00, #smem>
+    %0 = ttg.memdesc_subslice %arg0 [0, 0] : !ttg.memdesc<8x16xf32, #shared_cga_00, #smem> -> !ttg.memdesc<4x16xf32, #shared_cga_00, #smem, 8x16>
     tt.return
   }
 
@@ -242,6 +242,24 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32} {
   // CHECK: ttg.memdesc_reinterpret
   tt.func @memdesc_reinterpret_smaller_tmem(%arg0: !ttg.memdesc<128x128xf32, #tmem, #ttng.tensor_memory>) {
     %0 = ttg.memdesc_reinterpret %arg0 : !ttg.memdesc<128x128xf32, #tmem, #ttng.tensor_memory> -> !ttg.memdesc<128x128xf16, #tmem, #ttng.tensor_memory>
+    tt.return
+  }
+}
+
+// -----
+
+#shared = #ttg.swizzled_shared<{vec = 1, perPhase = 1, maxPhase = 1, order = [1, 0]}>
+#smem = #ttg.shared_memory
+module attributes {"ttg.target" = "cuda:90", "ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, "ttg.threads-per-warp" = 32 : i32} {
+  // CHECK-LABEL: @memdesc_subslice_pipeline_stage_chain
+  // CHECK: ttg.memdesc_subslice {{.*}}[3, 0, 0]
+  // CHECK: ttg.memdesc_index
+  // CHECK: ttg.memdesc_reinterpret
+  tt.func @memdesc_subslice_pipeline_stage_chain(%arg0: !ttg.memdesc<7x16x16xf16, #shared, #smem, mutable>, %index: i32) {
+    %stages = ttg.memdesc_subslice %arg0 [3, 0, 0] : !ttg.memdesc<7x16x16xf16, #shared, #smem, mutable> -> !ttg.memdesc<2x16x16xf16, #shared, #smem, mutable, 7x16x16>
+    %indexed = ttg.memdesc_index %stages[%index] : !ttg.memdesc<2x16x16xf16, #shared, #smem, mutable, 7x16x16> -> !ttg.memdesc<16x16xf16, #shared, #smem, mutable>
+    %reinterpret = ttg.memdesc_reinterpret %stages : !ttg.memdesc<2x16x16xf16, #shared, #smem, mutable, 7x16x16> -> !ttg.memdesc<2x16x16xi16, #shared, #smem, mutable>
+    %last = ttg.memdesc_subslice %stages [1, 0, 0] : !ttg.memdesc<2x16x16xf16, #shared, #smem, mutable, 7x16x16> -> !ttg.memdesc<1x16x16xf16, #shared, #smem, mutable, 7x16x16>
     tt.return
   }
 }

--- a/test/TritonGPU/ops.mlir
+++ b/test/TritonGPU/ops.mlir
@@ -143,6 +143,14 @@ module attributes {"ttg.target" = "cuda:0", "ttg.num-ctas" = 2 : i32, "ttg.num-w
     %a = ttg.memdesc_subslice %arg0 [0, 0] : !ttg.memdesc<8x4xf32, #shared, #smem> -> !ttg.memdesc<4x4xf32, #shared, #smem, 8x4>
     tt.return
   }
+
+  // CHECK-LABEL: @memdesc_reinterpret_shared_sharding
+  tt.func @memdesc_reinterpret_shared_sharding(%broadcast: !ttg.memdesc<8x16xf16, #shared_cga_00, #smem, mutable>, %sharded: !ttg.memdesc<8x16xf16, #shared_cga_10, #smem, mutable>) {
+    %split = ttg.memdesc_reinterpret %broadcast : !ttg.memdesc<8x16xf16, #shared_cga_00, #smem, mutable> -> !ttg.memdesc<8x16xi16, #shared_cga_10, #smem, mutable>
+    %view = ttg.memdesc_subslice %sharded [0, 0] : !ttg.memdesc<8x16xf16, #shared_cga_10, #smem, mutable> -> !ttg.memdesc<4x16xf16, #shared_cga_10, #smem, mutable, 8x16>
+    %replicated = ttg.memdesc_reinterpret %view : !ttg.memdesc<4x16xf16, #shared_cga_10, #smem, mutable, 8x16> -> !ttg.memdesc<4x16xi16, #shared_cga_00, #smem, mutable>
+    tt.return
+  }
 }
 
 // -----
@@ -249,6 +257,10 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32} {
 // -----
 
 #shared = #ttg.swizzled_shared<{vec = 1, perPhase = 1, maxPhase = 1, order = [1, 0]}>
+#shared_dense = #ttg.shared_linear<{offset = [[0, 1], [0, 2], [1, 0], [2, 0]], block = []}, alignment = 16>
+#shared_holey = #ttg.shared_linear<{offset = [[0, 1], [0, 0], [1, 0], [2, 0]], block = []}, alignment = 16>
+#shared_holey_view = #ttg.shared_linear<{offset = [[0, 1], [0, 2], [1, 0]], block = []}, alignment = 16>
+#shared_padded = #ttg.padded_shared<[128:+8] {order = [1, 0], shape = [16, 128]}>
 #smem = #ttg.shared_memory
 module attributes {"ttg.target" = "cuda:90", "ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, "ttg.threads-per-warp" = 32 : i32} {
   // CHECK-LABEL: @memdesc_subslice_pipeline_stage_chain
@@ -260,6 +272,67 @@ module attributes {"ttg.target" = "cuda:90", "ttg.num-ctas" = 1 : i32, "ttg.num-
     %indexed = ttg.memdesc_index %stages[%index] : !ttg.memdesc<2x16x16xf16, #shared, #smem, mutable, 7x16x16> -> !ttg.memdesc<16x16xf16, #shared, #smem, mutable>
     %reinterpret = ttg.memdesc_reinterpret %stages : !ttg.memdesc<2x16x16xf16, #shared, #smem, mutable, 7x16x16> -> !ttg.memdesc<2x16x16xi16, #shared, #smem, mutable>
     %last = ttg.memdesc_subslice %stages [1, 0, 0] : !ttg.memdesc<2x16x16xf16, #shared, #smem, mutable, 7x16x16> -> !ttg.memdesc<1x16x16xf16, #shared, #smem, mutable, 7x16x16>
+    tt.return
+  }
+
+  // CHECK-LABEL: @memdesc_reinterpret_pipeline_subview_with_gaps
+  tt.func @memdesc_reinterpret_pipeline_subview_with_gaps(%arg0: !ttg.memdesc<7x16x16xf16, #shared, #smem, mutable>) {
+    %view = ttg.memdesc_subslice %arg0 [3, 8, 0] : !ttg.memdesc<7x16x16xf16, #shared, #smem, mutable> -> !ttg.memdesc<2x8x16xf16, #shared, #smem, mutable, 7x16x16>
+    %result = ttg.memdesc_reinterpret %view : !ttg.memdesc<2x8x16xf16, #shared, #smem, mutable, 7x16x16> -> !ttg.memdesc<8x16xi16, #shared, #smem, mutable>
+    %stages = ttg.memdesc_reinterpret %view : !ttg.memdesc<2x8x16xf16, #shared, #smem, mutable, 7x16x16> -> !ttg.memdesc<2x4x16xi16, #shared, #smem, mutable>
+    tt.return
+  }
+
+  // CHECK-LABEL: @memdesc_reinterpret_noncontiguous_shared_subview_prefix
+  tt.func @memdesc_reinterpret_noncontiguous_shared_subview_prefix(%arg0: !ttg.memdesc<4x4xi32, #shared_dense, #smem, mutable>) {
+    %view = ttg.memdesc_subslice %arg0 [0, 0] : !ttg.memdesc<4x4xi32, #shared_dense, #smem, mutable> -> !ttg.memdesc<4x2xi32, #shared_dense, #smem, mutable, 4x4>
+    %result = ttg.memdesc_reinterpret %view : !ttg.memdesc<4x2xi32, #shared_dense, #smem, mutable, 4x4> -> !ttg.memdesc<1x2xi32, #shared, #smem, mutable>
+    tt.return
+  }
+
+  // CHECK-LABEL: @memdesc_reinterpret_subview_owns_zero_bases
+  tt.func @memdesc_reinterpret_subview_owns_zero_bases(%arg0: !ttg.memdesc<2x2xi32, #shared_holey, #smem, mutable, 4x2>) {
+    %result = ttg.memdesc_reinterpret %arg0 : !ttg.memdesc<2x2xi32, #shared_holey, #smem, mutable, 4x2> -> !ttg.memdesc<2x4xi32, #shared_holey_view, #smem, mutable>
+    tt.return
+  }
+
+  // CHECK-LABEL: @memdesc_reinterpret_full_allocation_with_zero_bases
+  tt.func @memdesc_reinterpret_full_allocation_with_zero_bases(%arg0: !ttg.memdesc<4x2xi32, #shared_holey, #smem, mutable>) {
+    %result = ttg.memdesc_reinterpret %arg0 : !ttg.memdesc<4x2xi32, #shared_holey, #smem, mutable> -> !ttg.memdesc<4x4xi32, #shared_dense, #smem, mutable>
+    tt.return
+  }
+
+  // CHECK-LABEL: @memdesc_reinterpret_full_padded
+  tt.func @memdesc_reinterpret_full_padded(%arg0: !ttg.memdesc<16x128xf16, #shared_padded, #smem, mutable>) {
+    %result = ttg.memdesc_reinterpret %arg0 : !ttg.memdesc<16x128xf16, #shared_padded, #smem, mutable> -> !ttg.memdesc<16x128xbf16, #shared_padded, #smem, mutable>
+    tt.return
+  }
+}
+
+// -----
+
+#tmem = #ttng.tensor_memory_encoding<blockM = 128, blockN = 64, colStride = 1>
+module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32} {
+  // CHECK-LABEL: @tmem_reinterpret_noncontiguous_subview_prefix
+  tt.func @tmem_reinterpret_noncontiguous_subview_prefix(%arg0: !ttg.memdesc<256x256xf32, #tmem, #ttng.tensor_memory, mutable>) {
+    %view = ttng.tmem_subslice %arg0 {offset = 128 : i32, dim = 0 : i32} : !ttg.memdesc<256x256xf32, #tmem, #ttng.tensor_memory, mutable> -> !ttg.memdesc<128x256xf32, #tmem, #ttng.tensor_memory, mutable, 256x256>
+    %result = ttg.memdesc_reinterpret %view : !ttg.memdesc<128x256xf32, #tmem, #ttng.tensor_memory, mutable, 256x256> -> !ttg.memdesc<128x64xf32, #tmem, #ttng.tensor_memory, mutable>
+    tt.return
+  }
+
+  // CHECK-LABEL: @tmem_reinterpret_packed_subview_owns_column
+  tt.func @tmem_reinterpret_packed_subview_owns_column(%arg0: !ttg.memdesc<128x4xi8, #tmem, #ttng.tensor_memory, mutable>) {
+    %view = ttng.tmem_subslice %arg0 {offset = 0 : i32} : !ttg.memdesc<128x4xi8, #tmem, #ttng.tensor_memory, mutable> -> !ttg.memdesc<128x2xi8, #tmem, #ttng.tensor_memory, mutable, 128x4>
+    %result = ttg.memdesc_reinterpret %view : !ttg.memdesc<128x2xi8, #tmem, #ttng.tensor_memory, mutable, 128x4> -> !ttg.memdesc<128x4xi8, #tmem, #ttng.tensor_memory, mutable>
+    tt.return
+  }
+
+  // CHECK-LABEL: @tmem_subslice_pipeline_stage_chain
+  tt.func @tmem_subslice_pipeline_stage_chain(%arg0: !ttg.memdesc<5x128x128xf32, #tmem, #ttng.tensor_memory, mutable>, %index: i32) {
+    %stages = ttng.tmem_subslice %arg0 {offset = 2 : i32, dim = 0 : i32} : !ttg.memdesc<5x128x128xf32, #tmem, #ttng.tensor_memory, mutable> -> !ttg.memdesc<2x128x128xf32, #tmem, #ttng.tensor_memory, mutable, 5x128x128>
+    %indexed = ttg.memdesc_index %stages[%index] : !ttg.memdesc<2x128x128xf32, #tmem, #ttng.tensor_memory, mutable, 5x128x128> -> !ttg.memdesc<128x128xf32, #tmem, #ttng.tensor_memory, mutable>
+    %result = ttg.memdesc_reinterpret %stages : !ttg.memdesc<2x128x128xf32, #tmem, #ttng.tensor_memory, mutable, 5x128x128> -> !ttg.memdesc<2x128x128xf32, #tmem, #ttng.tensor_memory, mutable>
+    %last = ttng.tmem_subslice %stages {offset = 1 : i32, dim = 0 : i32} : !ttg.memdesc<2x128x128xf32, #tmem, #ttng.tensor_memory, mutable, 5x128x128> -> !ttg.memdesc<1x128x128xf32, #tmem, #ttng.tensor_memory, mutable, 5x128x128>
     tt.return
   }
 }

--- a/test/TritonNvidiaGPU/invalid.mlir
+++ b/test/TritonNvidiaGPU/invalid.mlir
@@ -1057,7 +1057,7 @@ module attributes {"ttg.num-ctas" = 4 : i32, "ttg.num-warps" = 4 : i32} {
 #tmem = #ttng.tensor_memory_encoding<blockM = 128, blockN = 128, colStride = 1>
 module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32} {
   tt.func public @memdesc_reinterpret_changed_storage_size_tmem(%arg0: !ttg.memdesc<128x128xf16, #tmem, #ttng.tensor_memory>) {
-    // expected-error @+1 {{result logical storage size must not exceed source logical storage size}}
+    // expected-error @+1 {{result tensor-memory column footprint}}
     %0 = ttg.memdesc_reinterpret %arg0 : !ttg.memdesc<128x128xf16, #tmem, #ttng.tensor_memory> -> !ttg.memdesc<128x128xf32, #tmem, #ttng.tensor_memory>
     tt.return
   }
@@ -1070,7 +1070,7 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32} {
 module attributes {"ttg.num-ctas" = 2 : i32, "ttg.num-warps" = 4 : i32} {
   tt.func public @memdesc_reinterpret_contiguous_subview_changed_storage_size_tmem(%arg0: !ttg.memdesc<256x512xf32, #tmem, #ttng.tensor_memory, mutable>) {
     %sub = ttng.tmem_subslice %arg0 {offset = 496 : i32} : !ttg.memdesc<256x512xf32, #tmem, #ttng.tensor_memory, mutable> -> !ttg.memdesc<256x16xf32, #tmem, #ttng.tensor_memory, mutable, 256x512>
-    // expected-error @+1 {{result logical storage size must not exceed source logical storage size}}
+    // expected-error @+1 {{result tensor-memory column footprint}}
     %0 = ttg.memdesc_reinterpret %sub : !ttg.memdesc<256x16xf32, #tmem, #ttng.tensor_memory, mutable, 256x512> -> !ttg.memdesc<256x32xi8, #tmem_scales, #ttng.tensor_memory, mutable>
     tt.return
   }
@@ -1082,8 +1082,20 @@ module attributes {"ttg.num-ctas" = 2 : i32, "ttg.num-warps" = 4 : i32} {
 module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32} {
   tt.func public @memdesc_reinterpret_tmem_scales_subview_expands(%arg0: !ttg.memdesc<128x8xi8, #tmem_scales, #ttng.tensor_memory, mutable>) {
     %sub = ttng.tmem_subslice %arg0 {offset = 4 : i32} : !ttg.memdesc<128x8xi8, #tmem_scales, #ttng.tensor_memory, mutable> -> !ttg.memdesc<128x4xi8, #tmem_scales, #ttng.tensor_memory, mutable, 128x8>
-    // expected-error @+1 {{result logical storage size must not exceed source logical storage size}}
+    // expected-error @+1 {{result tensor-memory column footprint}}
     %0 = ttg.memdesc_reinterpret %sub : !ttg.memdesc<128x4xi8, #tmem_scales, #ttng.tensor_memory, mutable, 128x8> -> !ttg.memdesc<128x8xi8, #tmem_scales, #ttng.tensor_memory, mutable>
+    tt.return
+  }
+}
+
+// -----
+
+#tmem_scales = #ttng.tensor_memory_scales_encoding<>
+module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32} {
+  tt.func public @memdesc_reinterpret_tmem_scales_restores_sliced_rows(%arg0: !ttg.memdesc<16x4xi8, #tmem_scales, #ttng.tensor_memory, mutable>) {
+    %sub = ttng.tmem_subslice %arg0 {offset = 0 : i32, dim = 0 : i32} : !ttg.memdesc<16x4xi8, #tmem_scales, #ttng.tensor_memory, mutable> -> !ttg.memdesc<8x4xi8, #tmem_scales, #ttng.tensor_memory, mutable, 16x4>
+    // expected-error @+1 {{result accesses tensor-memory rows outside the source subview}}
+    %0 = ttg.memdesc_reinterpret %sub : !ttg.memdesc<8x4xi8, #tmem_scales, #ttng.tensor_memory, mutable, 16x4> -> !ttg.memdesc<16x4xi8, #tmem_scales, #ttng.tensor_memory, mutable>
     tt.return
   }
 }
@@ -1094,8 +1106,21 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32} {
 module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32} {
   tt.func public @memdesc_reinterpret_noncontiguous_tmem_subview(%arg0: !ttg.memdesc<256x256xf32, #tmem, #ttng.tensor_memory, mutable>) {
     %sub = ttng.tmem_subslice %arg0 {offset = 128 : i32, dim = 0 : i32} : !ttg.memdesc<256x256xf32, #tmem, #ttng.tensor_memory, mutable> -> !ttg.memdesc<128x256xf32, #tmem, #ttng.tensor_memory, mutable, 256x256>
-    // expected-error @+1 {{source subview must be contiguous}}
+    // expected-error @+1 {{result tensor-memory column footprint includes columns not owned by the source subview}}
     %0 = ttg.memdesc_reinterpret %sub : !ttg.memdesc<128x256xf32, #tmem, #ttng.tensor_memory, mutable, 256x256> -> !ttg.memdesc<128x256xf32, #tmem, #ttng.tensor_memory, mutable>
+    tt.return
+  }
+}
+
+// -----
+
+#tmem = #ttng.tensor_memory_encoding<blockM = 128, blockN = 64, colStride = 1>
+module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32} {
+  tt.func public @memdesc_reinterpret_tmem_pipeline_subview_gap(%arg0: !ttg.memdesc<5x128x128xf32, #tmem, #ttng.tensor_memory, mutable>) {
+    %stages = ttng.tmem_subslice %arg0 {offset = 0 : i32, dim = 0 : i32} : !ttg.memdesc<5x128x128xf32, #tmem, #ttng.tensor_memory, mutable> -> !ttg.memdesc<2x128x128xf32, #tmem, #ttng.tensor_memory, mutable, 5x128x128>
+    %view = ttng.tmem_subslice %stages {offset = 0 : i32, dim = 2 : i32} : !ttg.memdesc<2x128x128xf32, #tmem, #ttng.tensor_memory, mutable, 5x128x128> -> !ttg.memdesc<2x128x64xf32, #tmem, #ttng.tensor_memory, mutable, 5x128x128>
+    // expected-error @+1 {{result tensor-memory column footprint includes columns not owned by the source subview}}
+    %result = ttg.memdesc_reinterpret %view : !ttg.memdesc<2x128x64xf32, #tmem, #ttng.tensor_memory, mutable, 5x128x128> -> !ttg.memdesc<128x128xf32, #tmem, #ttng.tensor_memory, mutable>
     tt.return
   }
 }
@@ -1107,7 +1132,7 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32} {
 module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32} {
   tt.func public @memdesc_reinterpret_tmem_subview_expands_rows(%arg0: !ttg.memdesc<64x128xf32, #tmem64, #ttng.tensor_memory, mutable>) {
     %sub = ttng.tmem_subslice %arg0 {offset = 64 : i32} : !ttg.memdesc<64x128xf32, #tmem64, #ttng.tensor_memory, mutable> -> !ttg.memdesc<64x64xf32, #tmem64, #ttng.tensor_memory, mutable, 64x128>
-    // expected-error @+1 {{result logical storage size must not exceed source logical storage size}}
+    // expected-error @+1 {{result tensor-memory row footprint (128) exceeds the source view (64)}}
     %0 = ttg.memdesc_reinterpret %sub : !ttg.memdesc<64x64xf32, #tmem64, #ttng.tensor_memory, mutable, 64x128> -> !ttg.memdesc<128x64xf32, #tmem128, #ttng.tensor_memory, mutable>
     tt.return
   }
@@ -1130,10 +1155,10 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32} {
 
 #tmem = #ttng.tensor_memory_encoding<blockM = 128, blockN = 128, colStride = 1>
 module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32} {
-  tt.func public @tmem_subslice_rank_not_2() {
+  tt.func public @tmem_subslice_rank_mismatch() {
     %md = ttng.tmem_alloc : () -> !ttg.memdesc<2x128x128xf32, #tmem, #ttng.tensor_memory, mutable>
-    // expected-error @+1 {{The result must be a 2D tensor memory buffer.}}
-    %sub = ttng.tmem_subslice %md {offset = 0 : i32} : !ttg.memdesc<2x128x128xf32, #tmem, #ttng.tensor_memory, mutable> -> !ttg.memdesc<2x128x128xf32, #tmem, #ttng.tensor_memory, mutable>
+    // expected-error @+1 {{The source and result must both be 2D or 3D tensor memory buffers.}}
+    %sub = ttng.tmem_subslice %md {offset = 0 : i32} : !ttg.memdesc<2x128x128xf32, #tmem, #ttng.tensor_memory, mutable> -> !ttg.memdesc<128x128xf32, #tmem, #ttng.tensor_memory, mutable, 2x128x128>
     tt.return
   }
 }
@@ -1144,7 +1169,7 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32} {
 module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32} {
   tt.func public @tmem_subslice_rows_mismatch() {
     %md = ttng.tmem_alloc : () -> !ttg.memdesc<256x128xf32, #tmem, #ttng.tensor_memory, mutable>
-    // expected-error @+1 {{The result must have the same size as the source in the dimension that is not being sliced.}}
+    // expected-error @+1 {{The result must have the same size as the source in the dimensions that are not being sliced.}}
     %sub = ttng.tmem_subslice %md {offset = 0 : i32} : !ttg.memdesc<256x128xf32, #tmem, #ttng.tensor_memory, mutable> -> !ttg.memdesc<128x128xf32, #tmem, #ttng.tensor_memory, mutable, 256x128>
     tt.return
   }
@@ -1205,6 +1230,20 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32} {
   tt.func public @tmem_subslice_negative_offset(%md: !ttg.memdesc<128x128xf32, #tmem, #ttng.tensor_memory, mutable>) {
     // expected-error @+1 {{The split offset may not exceed the source shape}}
     %sub = ttng.tmem_subslice %md {offset = -64 : i32} : !ttg.memdesc<128x128xf32, #tmem, #ttng.tensor_memory, mutable> -> !ttg.memdesc<128x64xf32, #tmem, #ttng.tensor_memory, mutable, 128x128>
+    tt.return
+  }
+}
+
+// -----
+
+#tmem = #ttng.tensor_memory_encoding<blockM = 128, blockN = 128, colStride = 1>
+module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32} {
+  tt.func public @tmem_subslice_stage_exceeds_view(
+      %source: !ttg.memdesc<2x128x128xf32, #tmem, #ttng.tensor_memory, mutable, 5x128x128>) {
+    // expected-error @+1 {{The split offset may not exceed the source shape}}
+    %expanded = ttng.tmem_subslice %source {offset = 1 : i32, dim = 0 : i32} :
+      !ttg.memdesc<2x128x128xf32, #tmem, #ttng.tensor_memory, mutable, 5x128x128> ->
+      !ttg.memdesc<2x128x128xf32, #tmem, #ttng.tensor_memory, mutable, 5x128x128>
     tt.return
   }
 }
@@ -1306,7 +1345,7 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32} {
 module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32} {
   tt.func public @tmem_subslice_invalid_dim() {
     %md = ttng.tmem_alloc : () -> !ttg.memdesc<256x128xf32, #tmem, #ttng.tensor_memory, mutable>
-    // expected-error @+1 {{The slice dimension must be 0 or 1.}}
+    // expected-error @+1 {{The slice dimension must be within the descriptor rank.}}
     %sub = ttng.tmem_subslice %md {offset = 0 : i32, dim = 2 : i32} : !ttg.memdesc<256x128xf32, #tmem, #ttng.tensor_memory, mutable> -> !ttg.memdesc<256x64xf32, #tmem, #ttng.tensor_memory, mutable, 256x128>
     tt.return
   }
@@ -1318,7 +1357,7 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32} {
 module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32} {
   tt.func public @tmem_subslice_negative_dim() {
     %md = ttng.tmem_alloc : () -> !ttg.memdesc<256x128xf32, #tmem, #ttng.tensor_memory, mutable>
-    // expected-error @+1 {{The slice dimension must be 0 or 1.}}
+    // expected-error @+1 {{The slice dimension must be within the descriptor rank.}}
     %sub = ttng.tmem_subslice %md {offset = 0 : i32, dim = -1 : i32} : !ttg.memdesc<256x128xf32, #tmem, #ttng.tensor_memory, mutable> -> !ttg.memdesc<256x64xf32, #tmem, #ttng.tensor_memory, mutable, 256x128>
     tt.return
   }

--- a/test/TritonNvidiaGPU/invalid.mlir
+++ b/test/TritonNvidiaGPU/invalid.mlir
@@ -5,6 +5,12 @@
 
 // -----
 
+#tmem = #ttng.tensor_memory_encoding<blockM = 128, blockN = 128, colStride = 1>
+// expected-error @below {{tensor-memory element type bit width must be at least 8; got 1}}
+!i1_tmem = !ttg.memdesc<128x128xi1, #tmem, #ttng.tensor_memory>
+
+// -----
+
 #shared_a = #ttg.nvmma_shared<{swizzlingByteWidth = 32, transposed = false, elementBitWidth = 8}>
 #shared = #ttg.nvmma_shared<{swizzlingByteWidth = 32, transposed = true, elementBitWidth = 8}>
 #tmem = #ttng.tensor_memory_encoding<blockM = 128, blockN = 128, colStride = 1>

--- a/test/TritonNvidiaGPU/invalid.mlir
+++ b/test/TritonNvidiaGPU/invalid.mlir
@@ -1065,6 +1065,16 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32} {
 
 // -----
 
+#tmem_scales = #ttng.tensor_memory_scales_encoding<>
+module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32} {
+  // expected-error @+1 {{tensor-memory scale descriptors must have rank 2; got 1}}
+  tt.func public @tmem_scales_rank_one(%arg0: !ttg.memdesc<16xi8, #tmem_scales, #ttng.tensor_memory, 128x16>) {
+    tt.return
+  }
+}
+
+// -----
+
 #tmem = #ttng.tensor_memory_encoding<blockM = 128, blockN = 256, colStride = 1, CGALayout = [[1, 0]]>
 #tmem_scales = #ttng.tensor_memory_scales_encoding<CGALayout = [[1, 0]]>
 module attributes {"ttg.num-ctas" = 2 : i32, "ttg.num-warps" = 4 : i32} {

--- a/test/TritonNvidiaGPU/ops.mlir
+++ b/test/TritonNvidiaGPU/ops.mlir
@@ -268,6 +268,7 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 8 : i32, ttg.targ
 }
 
 #tmem_window = #ttng.tensor_memory_encoding<blockM = 128, blockN = 256, colStride = 1, CGALayout = [[1, 0]]>
+#tmem_window_broadcast = #ttng.tensor_memory_encoding<blockM = 128, blockN = 256, colStride = 1, CGALayout = [[0, 0]]>
 #tmem_window_scale_a = #ttng.tensor_memory_scales_encoding<CGALayout = [[1, 0]]>
 #tmem_window_scale_b = #ttng.tensor_memory_scales_encoding<CGALayout = [[0, 0]]>
 module attributes {"ttg.num-ctas" = 2 : i32, "ttg.num-warps" = 4 : i32} {
@@ -285,6 +286,12 @@ module attributes {"ttg.num-ctas" = 2 : i32, "ttg.num-warps" = 4 : i32} {
     %scale_a = ttg.memdesc_reinterpret %scale_a_base : !ttg.memdesc<256x16xf32, #tmem_window, #ttng.tensor_memory, mutable, 256x512> -> !ttg.memdesc<256x16xi8, #tmem_window_scale_a, #ttng.tensor_memory, mutable>
     %scale_b_base = ttng.tmem_subslice %arg0 {offset = 480 : i32} : !ttg.memdesc<256x512xf32, #tmem_window, #ttng.tensor_memory, mutable> -> !ttg.memdesc<256x32xf32, #tmem_window, #ttng.tensor_memory, mutable, 256x512>
     %scale_b = ttg.memdesc_reinterpret %scale_b_base : !ttg.memdesc<256x32xf32, #tmem_window, #ttng.tensor_memory, mutable, 256x512> -> !ttg.memdesc<256x16xi8, #tmem_window_scale_b, #ttng.tensor_memory, mutable>
+    tt.return
+  }
+
+  // CHECK-LABEL: @tmem_reinterpret_sharding
+  tt.func public @tmem_reinterpret_sharding(%broadcast: !ttg.memdesc<256x128xf32, #tmem_window_broadcast, #ttng.tensor_memory, mutable>) {
+    %sharded = ttg.memdesc_reinterpret %broadcast : !ttg.memdesc<256x128xf32, #tmem_window_broadcast, #ttng.tensor_memory, mutable> -> !ttg.memdesc<256x128xf32, #tmem_window, #ttng.tensor_memory, mutable>
     tt.return
   }
 }

--- a/third_party/proton/Dialect/lib/ProtonToProtonGPU/ProtonToProtonGPUPass.cpp
+++ b/third_party/proton/Dialect/lib/ProtonToProtonGPU/ProtonToProtonGPUPass.cpp
@@ -292,7 +292,7 @@ public:
       Attribute sharedMemorySpace =
           triton::gpu::SharedMemorySpaceAttr::get(context);
       auto sharedBufferType = triton::gpu::MemDescType::get(
-          {allocBufferSize / 4}, builder.getI32Type(), encoding,
+          {allocBufferSize / 4, 1}, builder.getI32Type(), encoding,
           sharedMemorySpace, /*mutable_memory=*/true);
       buffer =
           triton::gpu::LocalAllocOp::create(builder, loc, sharedBufferType);

--- a/unittest/Dialect/TritonNvidiaGPU/NvmmaSmemAttrsTest.cpp
+++ b/unittest/Dialect/TritonNvidiaGPU/NvmmaSmemAttrsTest.cpp
@@ -164,7 +164,7 @@ TEST_F(NvmmaSmemAttrsTest, Fp4PaddedRequiresI8Storage) {
 }
 
 TEST_F(NvmmaSmemAttrsTest, InferNvmmaSmemAttrsRejectsNearMisses) {
-  auto i4Ty = IntegerType::get(&ctx, 4);
+  auto i8Ty = IntegerType::get(&ctx, 8);
   auto smem = SharedMemorySpaceAttr::get(&ctx);
   auto inferSharedLinearInfo = [&](LinearLayout layout) {
     SmallVector<int64_t> shape;
@@ -172,7 +172,7 @@ TEST_F(NvmmaSmemAttrsTest, InferNvmmaSmemAttrsRejectsNearMisses) {
       shape.push_back(size);
     auto sharedLinear = SharedLinearEncodingAttr::get(&ctx, std::move(layout),
                                                       /*layoutAlignment=*/1024);
-    auto memTy = MemDescType::get(shape, i4Ty, sharedLinear, smem);
+    auto memTy = MemDescType::get(shape, i8Ty, sharedLinear, smem);
     return getNvmmaSmemAttrs(memTy);
   };
   auto nonPaddedPrefix = LinearLayout({{S("offset"),

--- a/unittest/Tools/LinearLayoutTest.cpp
+++ b/unittest/Tools/LinearLayoutTest.cpp
@@ -717,6 +717,23 @@ TEST_F(LinearLayoutTest, NumConsecutiveInOut) {
                    .getNumConsecutiveInOut());
 }
 
+TEST_F(LinearLayoutTest, ContiguousElemsAlongOutputDim) {
+  EXPECT_EQ(8, LinearLayout::identity1D(8, S("offset"), S("offset"))
+                   .contiguousElemsAlongOutputDim(S("offset")));
+  EXPECT_EQ(1, LinearLayout({{S("logical"), {{3}}}}, {{S("offset"), 4}},
+                            /*requireSurjective=*/false)
+                   .contiguousElemsAlongOutputDim(S("offset")));
+  EXPECT_EQ(4,
+            LinearLayout({{S("lhs"), {{3}}}, {S("rhs"), {{1}}}}, {S("offset")})
+                .contiguousElemsAlongOutputDim(S("offset")));
+  EXPECT_EQ(2, LinearLayout({{S("logical"), {{1}, {4}}}}, {{S("offset"), 8}},
+                            /*requireSurjective=*/false)
+                   .contiguousElemsAlongOutputDim(S("offset")));
+  EXPECT_EQ(8, LinearLayout({{S("logical"), {{1}, {4}}}, {S("free"), {{2}}}},
+                            {S("offset")})
+                   .contiguousElemsAlongOutputDim(S("offset")));
+}
+
 TEST_F(LinearLayoutTest, EqualsChecksOutDimSizes) {
   EXPECT_FALSE(LinearLayout::identity1D(4, S("in"), S("out")) ==
                LinearLayout({{S("in"), {{1}, {2}}}}, {{S("out"), 8}},


### PR DESCRIPTION
This PR is best reviewed commit by commit!

We allow reshapes of subslices. The rules are:
- The dst type may not be a subslice itself
- The range covered by the dst type should be a contiguous chunk of memory owned by src
- An memdesc without a subview is considered contiguous in all its image. If it does not cover all its image (because it has broadcasting) that's fine, because the allocator will always allocate a full contiguous chunk of memory for a given tensor.

We also tighten a number of verifiers here and there.
