### PR TITLE
[AMD] rocprofsdk finalization fix for proton

### DIFF
--- a/third_party/proton/csrc/lib/Profiler/RocprofSDK/RocprofSDKProfiler.cpp
+++ b/third_party/proton/csrc/lib/Profiler/RocprofSDK/RocprofSDKProfiler.cpp
@@ -566,12 +566,12 @@ struct RocprofSDKProfiler::RocprofSDKProfilerPimpl
                     rocprofiler_tracing_operation_t operation,
                     rocprofiler_callback_tracing_hip_api_data_t *payload);
 #if PROTON_ROCPROFILER_SDK_HAS_HIP_GRAPH
-  static void handleStreamCaptureBegin(
-      rocprofiler_tracing_operation_t operation);
+  static void
+  handleStreamCaptureBegin(rocprofiler_tracing_operation_t operation);
   static void handleCapturedKernelEnter();
-  static void handleGraphRuntimeExit(
-      rocprofiler_tracing_operation_t operation,
-      rocprofiler_callback_tracing_hip_api_data_t *payload);
+  static void
+  handleGraphRuntimeExit(rocprofiler_tracing_operation_t operation,
+                         rocprofiler_callback_tracing_hip_api_data_t *payload);
 #endif
   static void markerCallback(rocprofiler_callback_tracing_record_t record,
                              rocprofiler_user_data_t *userData, void *arg);
@@ -679,8 +679,8 @@ void tryBindGraphExecState(RocprofSDKProfiler::RocprofSDKProfilerPimpl *impl,
 // ---- HIP Runtime API callback (correlation tracking) ----
 
 #if PROTON_ROCPROFILER_SDK_HAS_HIP_GRAPH
-void RocprofSDKProfiler::RocprofSDKProfilerPimpl::
-    handleStreamCaptureBegin(rocprofiler_tracing_operation_t operation) {
+void RocprofSDKProfiler::RocprofSDKProfilerPimpl::handleStreamCaptureBegin(
+    rocprofiler_tracing_operation_t operation) {
   if (operation != ROCPROFILER_HIP_RUNTIME_API_ID_hipStreamBeginCapture &&
       operation != ROCPROFILER_HIP_RUNTIME_API_ID_hipStreamBeginCapture_spt)
     return;

--- a/third_party/proton/csrc/lib/Profiler/RocprofSDK/RocprofSDKProfiler.cpp
+++ b/third_party/proton/csrc/lib/Profiler/RocprofSDK/RocprofSDKProfiler.cpp
@@ -93,8 +93,6 @@ struct RocprofilerRuntimeState {
   rocprofiler_context_id_t profilingContext{};
   rocprofiler_buffer_id_t kernelBuffer{};
   rocprofiler_callback_thread_t callbackThread{};
-  rocprofiler_client_finalize_t finalizeFunc = nullptr;
-  rocprofiler_client_id_t *clientId{nullptr};
   bool configured{false};
   bool codeObjectStarted{false};
   bool profilingStarted{false};
@@ -1084,9 +1082,8 @@ void RocprofSDKProfiler::RocprofSDKProfilerPimpl::kernelBufferCallback(
 
 namespace {
 
-int protonToolInit(rocprofiler_client_finalize_t finiFunc, void *toolData) {
+int protonToolInit(rocprofiler_client_finalize_t, void *toolData) {
   auto *state = static_cast<RocprofilerRuntimeState *>(toolData);
-  state->finalizeFunc = finiFunc;
 
   // Context 1: lightweight, always-active context for code object tracking.
   // Captures kernel_id -> name mappings as kernels are compiled.
@@ -1224,9 +1221,6 @@ void protonToolFini(void *toolData) {
     }
   }
   rocprofiler::flushBuffer<false>(state->kernelBuffer);
-  if (state->finalizeFunc && state->clientId) {
-    state->finalizeFunc(*state->clientId);
-  }
 }
 
 rocprofiler_tool_configure_result_t *
@@ -1234,7 +1228,6 @@ protonConfigure(uint32_t version, const char *runtimeVersion, uint32_t priority,
                 rocprofiler_client_id_t *id) {
   auto &state = getRuntimeState();
   id->name = "ProtonRocprofSDK";
-  state.clientId = id;
   static rocprofiler_tool_configure_result_t config{
       sizeof(rocprofiler_tool_configure_result_t), &protonToolInit,
       &protonToolFini, static_cast<void *>(&state)};

--- a/third_party/proton/csrc/lib/Profiler/RocprofSDK/RocprofSDKProfiler.cpp
+++ b/third_party/proton/csrc/lib/Profiler/RocprofSDK/RocprofSDKProfiler.cpp
@@ -392,18 +392,6 @@ bool isKernelLaunchOperation(rocprofiler_tracing_operation_t op) {
   }
 }
 
-#if PROTON_ROCPROFILER_SDK_HAS_HIP_GRAPH
-bool isStreamCaptureBeginOperation(rocprofiler_tracing_operation_t op) {
-  return op == ROCPROFILER_HIP_RUNTIME_API_ID_hipStreamBeginCapture ||
-         op == ROCPROFILER_HIP_RUNTIME_API_ID_hipStreamBeginCapture_spt;
-}
-
-bool isStreamCaptureEndOperation(rocprofiler_tracing_operation_t op) {
-  return op == ROCPROFILER_HIP_RUNTIME_API_ID_hipStreamEndCapture ||
-         op == ROCPROFILER_HIP_RUNTIME_API_ID_hipStreamEndCapture_spt;
-}
-#endif
-
 // ---- Kernel dispatch processing (matches main's GPUProfiler interface) ----
 
 void processKernelRecord(
@@ -578,18 +566,13 @@ struct RocprofSDKProfiler::RocprofSDKProfilerPimpl
                     rocprofiler_tracing_operation_t operation,
                     rocprofiler_callback_tracing_hip_api_data_t *payload);
 #if PROTON_ROCPROFILER_SDK_HAS_HIP_GRAPH
-  static void handleStreamCaptureBegin();
+  static void handleStreamCaptureBegin(
+      rocprofiler_tracing_operation_t operation);
   static void handleCapturedKernelEnter();
-#endif
-  static void handleSuccessfulRuntimeExit(
+  static void handleGraphRuntimeExit(
       rocprofiler_tracing_operation_t operation,
-      rocprofiler_callback_tracing_hip_api_data_t *payload,
-      RocprofSDKProfilerPimpl *impl);
-#if PROTON_ROCPROFILER_SDK_HAS_HIP_GRAPH
-  static void handleStreamCaptureEnd(rocprofiler_tracing_operation_t operation);
+      rocprofiler_callback_tracing_hip_api_data_t *payload);
 #endif
-  static void handleKernelExit(rocprofiler_callback_tracing_record_t record,
-                               rocprofiler_tracing_operation_t operation);
   static void markerCallback(rocprofiler_callback_tracing_record_t record,
                              rocprofiler_user_data_t *userData, void *arg);
 #if PROTON_ROCPROFILER_SDK_HAS_HIP_GRAPH
@@ -696,7 +679,11 @@ void tryBindGraphExecState(RocprofSDKProfiler::RocprofSDKProfilerPimpl *impl,
 // ---- HIP Runtime API callback (correlation tracking) ----
 
 #if PROTON_ROCPROFILER_SDK_HAS_HIP_GRAPH
-void RocprofSDKProfiler::RocprofSDKProfilerPimpl::handleStreamCaptureBegin() {
+void RocprofSDKProfiler::RocprofSDKProfilerPimpl::
+    handleStreamCaptureBegin(rocprofiler_tracing_operation_t operation) {
+  if (operation != ROCPROFILER_HIP_RUNTIME_API_ID_hipStreamBeginCapture &&
+      operation != ROCPROFILER_HIP_RUNTIME_API_ID_hipStreamBeginCapture_spt)
+    return;
   threadState.isStreamCapturing = true;
   streamCaptureGraphState = GraphState{};
 }
@@ -740,10 +727,7 @@ void RocprofSDKProfiler::RocprofSDKProfilerPimpl::handleRuntimeEnter(
     rocprofiler_tracing_operation_t operation,
     rocprofiler_callback_tracing_hip_api_data_t *payload) {
 #if PROTON_ROCPROFILER_SDK_HAS_HIP_GRAPH
-  if (isStreamCaptureBeginOperation(operation)) {
-    handleStreamCaptureBegin();
-    return;
-  }
+  handleStreamCaptureBegin(operation);
 #endif
 
   if (!isKernelLaunchOperation(operation))
@@ -772,11 +756,12 @@ void RocprofSDKProfiler::RocprofSDKProfilerPimpl::handleRuntimeEnter(
       extractStreamId(operation, payload);
 }
 
-void RocprofSDKProfiler::RocprofSDKProfilerPimpl::handleSuccessfulRuntimeExit(
-    rocprofiler_tracing_operation_t operation,
-    rocprofiler_callback_tracing_hip_api_data_t *payload,
-    RocprofSDKProfilerPimpl *impl) {
 #if PROTON_ROCPROFILER_SDK_HAS_HIP_GRAPH
+void RocprofSDKProfiler::RocprofSDKProfilerPimpl::handleGraphRuntimeExit(
+    rocprofiler_tracing_operation_t operation,
+    rocprofiler_callback_tracing_hip_api_data_t *payload) {
+  auto &profiler = threadState.profiler;
+  auto *impl = static_cast<RocprofSDKProfilerPimpl *>(profiler.pImpl.get());
   switch (operation) {
   case ROCPROFILER_HIP_RUNTIME_API_ID_hipStreamEndCapture:
   case ROCPROFILER_HIP_RUNTIME_API_ID_hipStreamEndCapture_spt: {
@@ -784,9 +769,10 @@ void RocprofSDKProfiler::RocprofSDKProfilerPimpl::handleSuccessfulRuntimeExit(
         operation == ROCPROFILER_HIP_RUNTIME_API_ID_hipStreamEndCapture
             ? payload->args.hipStreamEndCapture.pGraph
             : payload->args.hipStreamEndCapture_spt.pGraph;
-    if (graphPtr && *graphPtr) {
+    if (graphPtr && *graphPtr)
       impl->graphToState.insert(*graphPtr, streamCaptureGraphState);
-    }
+    threadState.isStreamCapturing = false;
+    streamCaptureGraphState = GraphState{};
     break;
   }
   case ROCPROFILER_HIP_RUNTIME_API_ID_hipGraphInstantiate:
@@ -814,55 +800,31 @@ void RocprofSDKProfiler::RocprofSDKProfilerPimpl::handleSuccessfulRuntimeExit(
   default:
     break;
   }
-#else
-  (void)operation;
-  (void)payload;
-  (void)impl;
-#endif
-}
-
-#if PROTON_ROCPROFILER_SDK_HAS_HIP_GRAPH
-void RocprofSDKProfiler::RocprofSDKProfilerPimpl::handleStreamCaptureEnd(
-    rocprofiler_tracing_operation_t operation) {
-  if (isStreamCaptureEndOperation(operation)) {
-    threadState.isStreamCapturing = false;
-    streamCaptureGraphState = GraphState{};
-  }
 }
 #endif
-
-void RocprofSDKProfiler::RocprofSDKProfilerPimpl::handleKernelExit(
-    rocprofiler_callback_tracing_record_t record,
-    rocprofiler_tracing_operation_t operation) {
-  if (!isKernelLaunchOperation(operation))
-    return;
-  threadState.exitOp();
-#if PROTON_ROCPROFILER_SDK_HAS_HIP_GRAPH
-  if (threadState.isStreamCapturing)
-    return;
-#endif
-  auto &dataToEntry = threadState.dataToEntry;
-  bool deactivated = dataToEntry.empty();
-  auto &profiler = threadState.profiler;
-  if (deactivated) // Profiler is deactivated
-    return;
-  profiler.correlation.submit(record.correlation_id.internal);
-}
 
 void RocprofSDKProfiler::RocprofSDKProfilerPimpl::handleRuntimeExit(
     rocprofiler_callback_tracing_record_t record,
     rocprofiler_tracing_operation_t operation,
     rocprofiler_callback_tracing_hip_api_data_t *payload) {
   auto &profiler = threadState.profiler;
-  auto *impl = static_cast<RocprofSDKProfilerPimpl *>(profiler.pImpl.get());
-
-  if (payload && payload->retval.hipError_t_retval == hipSuccess) {
-    handleSuccessfulRuntimeExit(operation, payload, impl);
-  }
 #if PROTON_ROCPROFILER_SDK_HAS_HIP_GRAPH
-  handleStreamCaptureEnd(operation);
+  handleGraphRuntimeExit(operation, payload);
 #endif
-  handleKernelExit(record, operation);
+  if (!isKernelLaunchOperation(operation))
+    return;
+  // Deactivate should be checked before exitOp because exitOp will pop the
+  // scope stack and clear dataToEntry
+  auto &dataToEntry = threadState.dataToEntry;
+  const bool deactivated = dataToEntry.empty();
+  threadState.exitOp();
+#if PROTON_ROCPROFILER_SDK_HAS_HIP_GRAPH
+  if (threadState.isStreamCapturing)
+    return;
+#endif
+  if (deactivated) // Profiler is deactivated
+    return;
+  profiler.correlation.submit(record.correlation_id.internal);
 }
 
 void RocprofSDKProfiler::RocprofSDKProfilerPimpl::hipRuntimeCallback(
@@ -878,10 +840,7 @@ void RocprofSDKProfiler::RocprofSDKProfilerPimpl::hipRuntimeCallback(
 
   if (record.phase == ROCPROFILER_CALLBACK_PHASE_ENTER) {
     handleRuntimeEnter(record, operation, payload);
-    return;
-  }
-
-  if (record.phase == ROCPROFILER_CALLBACK_PHASE_EXIT) {
+  } else if (record.phase == ROCPROFILER_CALLBACK_PHASE_EXIT) {
     handleRuntimeExit(record, operation, payload);
   }
 }

--- a/third_party/proton/test/test_cmd.py
+++ b/third_party/proton/test/test_cmd.py
@@ -1,6 +1,7 @@
 import pytest
 import subprocess
 import json
+import os
 import pathlib
 import sys
 
@@ -8,6 +9,35 @@ import sys
 def test_help():
     # Only check if the viewer can be invoked
     subprocess.check_call(["proton", "-h"], stdout=subprocess.DEVNULL)
+
+
+def test_rocprofiler_multi_client_shutdown(tmp_path: pathlib.Path):
+    script = """
+import pathlib
+import sys
+
+import torch
+
+if torch.version.hip is None:
+    raise SystemExit(77)
+
+import triton.profiler as proton
+
+session = proton.start(str(pathlib.Path(sys.argv[1]).with_suffix("")))
+proton.finalize(session)
+"""
+    env = os.environ.copy()
+    env.pop("ROCPROFILER_REGISTER_FORCE_LOAD", None)
+    result = subprocess.run(
+        [sys.executable, "-c", script, str(tmp_path / "multi_client.hatchet")],
+        capture_output=True,
+        env=env,
+        text=True,
+        timeout=30,
+    )
+    if result.returncode == 77:
+        pytest.skip("Requires a HIP PyTorch build")
+    assert result.returncode == 0, result.stderr
 
 
 @pytest.mark.parametrize("mode", ["script", "python", "pytest"])


### PR DESCRIPTION

not ready for review 

there is a problem where rocprofsdk will call proton's finalization callback(as it is a client) and leads to a recursive deadlock. proton lifecycle is not respecting how rocprofsdk is meant to be used in this case. 