### PR TITLE
fix(nvidia): apply TMA bit-85 workaround on CUDA 13.2/13.3

### DIFF
--- a/third_party/nvidia/backend/driver.c
+++ b/third_party/nvidia/backend/driver.c
@@ -678,7 +678,18 @@ static PyObject *fillTMADescriptorTiled(PyObject *self, PyObject *args) {
   CUresult driver_version_result = cuDriverGetVersion(&driver_version);
   assert(driver_version_result == CUDA_SUCCESS);
 
-  if (driver_version <= 13010) {
+  // The cuTensorMapEncodeTiled() bit-85 bug (sporadic Blackwell IMA/MMU faults
+  // for <128KB non-dense tensors; NVIDIA 595.71.05 release notes) is also
+  // present in the CUDA 13.2 and 13.3 forward-compatibility userspace drivers.
+  // They report 13020 and 13030 respectively, even when the host kernel driver
+  // is still affected. Gating only through 13010 therefore skips the mitigation
+  // under cuda-compat / NGC stacks that still exhibit the fault (e.g. MXFP4 MoE
+  // UTMALDG.5D illegal memory accesses on B200).
+  //
+  // Keep the official <128KB condition below and extend the
+  // compatibility-driver gate through CUDA 13.3. Clearing bit 85 is NVIDIA's
+  // documented workaround.
+  if (driver_version <= 13030) {
     int max_byte_index = 0;
     for (int i = 0; i < rank; ++i) {
       int bytes_stride = i == 0 ? elemSize : stridesLL[i - 1];

--- a/third_party/nvidia/backend/driver.c
+++ b/third_party/nvidia/backend/driver.c
@@ -678,17 +678,8 @@ static PyObject *fillTMADescriptorTiled(PyObject *self, PyObject *args) {
   CUresult driver_version_result = cuDriverGetVersion(&driver_version);
   assert(driver_version_result == CUDA_SUCCESS);
 
-  // The cuTensorMapEncodeTiled() bit-85 bug (sporadic Blackwell IMA/MMU faults
-  // for <128KB non-dense tensors; NVIDIA 595.71.05 release notes) is also
-  // present in the CUDA 13.2 and 13.3 forward-compatibility userspace drivers.
-  // They report 13020 and 13030 respectively, even when the host kernel driver
-  // is still affected. Gating only through 13010 therefore skips the mitigation
-  // under cuda-compat / NGC stacks that still exhibit the fault (e.g. MXFP4 MoE
-  // UTMALDG.5D illegal memory accesses on B200).
-  //
-  // Keep the official <128KB condition below and extend the
-  // compatibility-driver gate through CUDA 13.3. Clearing bit 85 is NVIDIA's
-  // documented workaround.
+  // CUDA 13.2/13.3 forward-compat reports 13020/13030 but still needs the
+  // bit-85 workaround for <128KB non-dense TMA descriptors.
   if (driver_version <= 13030) {
     int max_byte_index = 0;
     for (int i = 0; i < rank; ++i) {


### PR DESCRIPTION
# New contributor declaration
- [x] I am not making a trivial change, such as fixing a typo in a comment.

- [x] I have written a PR description following these
  [rules](https://cbea.ms/git-commit/#why-not-how).

- [ ] I have run `pre-commit run --from-ref origin/main --to-ref HEAD`.

- Select one of the following.
  - [ ] I have added tests.
    - `/test` for `lit` tests
    - `/unittest` for C++ tests
    - `/python/test` for end-to-end tests
  - [x] This PR does not need a test because the bug requires a CUDA 13.2/13.3 forward-compat driver plus affected Blackwell hardware; the mitigation predicate and descriptor mutation are unchanged from the existing CUTLASS-aligned workaround.

- Select one of the following.
  - [x] I have not added any `lit` tests.
  - [ ] The `lit` tests I have added follow these [best practices](https://mlir.llvm.org/getting_started/TestingGuide/#filecheck-best-practices),
    including the "tests should be minimal" section. (Usually running Python code
    and using the instructions it generates is not minimal.)

## Why

`cuTensorMapEncodeTiled()` has a known bit-85 bug for small (`<128KB`) non-dense tensor-map descriptors on affected Blackwell stacks (NVIDIA 595.71.05 release notes). Triton already clears bit 85 when `cuDriverGetVersion() <= 13010`, following [CUTLASS](https://github.com/NVIDIA/cutlass/commit/b7ecaa605dd70326900433695e11ebfec407edd2).

CUDA 13.2 / 13.3 forward-compatibility userspace drivers still report `13020` / `13030` while remaining affected. Under those stacks the current `<= 13010` gate skips the mitigation. We observed deterministic `UTMALDG.5D` illegal memory accesses on B200 for MXFP4 MoE kernels under NGC PyTorch 26.06 (CUDA 13.3).

## What changed

Extend the existing tiled TMA bit-85 workaround gate from driver API `13010` through `13030`. The official `<128KB` condition and descriptor mutation are unchanged.

```mermaid
flowchart LR
    A[Create tiled TMA descriptor] --> B{driver API <= 13030?}
    B -->|no| D[Use descriptor unchanged]
    B -->|yes| C{non-dense allocation < 128KB?}
    C -->|yes| E[Clear descriptor bit 85]
    C -->|no| D
```

## Testing

- Validated via Fireworks B200 integration after the equivalent fork change:
  - distributed: `TestDeepseek3Distributed.test_mx_moe_tp`
  - model: `TestOpenAI.test_mxfp4_moe`
- Fork reference: https://github.com/fw-ai/triton/pull/6 (stacked on the CUDA 13.2 extension in https://github.com/fw-ai/triton/pull/4)


Made with [Cursor](https://cursor.com)