### PR TITLE
[Pipeliner] Preserve load latency through scf.if results

### DIFF
--- a/lib/Dialect/TritonGPU/Transforms/Pipeliner/AssignLatencies.cpp
+++ b/lib/Dialect/TritonGPU/Transforms/Pipeliner/AssignLatencies.cpp
@@ -25,6 +25,27 @@ namespace {
 // assignLatencies
 //===----------------------------------------------------------------------===//
 
+// Return the operations that define an operand. For an `scf.if` result, the
+// definitions are the values yielded by each branch rather than the `scf.if`
+// op itself.
+static SmallVector<Operation *> getOperandDefs(Value operand) {
+  SmallVector<Operation *> defs;
+  std::function<void(Value)> collectDefs = [&](Value value) {
+    auto result = dyn_cast<OpResult>(value);
+    auto ifOp = result ? dyn_cast<scf::IfOp>(result.getOwner()) : nullptr;
+    if (!ifOp) {
+      defs.push_back(value.getDefiningOp());
+      return;
+    }
+
+    unsigned resultNumber = result.getResultNumber();
+    for (scf::YieldOp yield : {ifOp.thenYield(), ifOp.elseYield()})
+      collectDefs(yield.getOperand(resultNumber));
+  };
+  collectDefs(operand);
+  return defs;
+}
+
 bool hasLoopCarriedAccumulatorCycle(ttng::MMAv5OpInterface mma,
                                     scf::ForOp forOp) {
   Value start = mma.getAccDep();
@@ -379,9 +400,13 @@ loadOpsToIndirectionLevel(scf::ForOp forOp, bool pipelineWithoutDot,
               continue;
           }
           Value v = operand;
-          Operation *defOp = v.getDefiningOp();
-          if (defOp && defOp->getBlock() == op->getBlock()) {
-            dfs(defOp, finalUser, distance);
+          for (Operation *defOp : getOperandDefs(v)) {
+            if (!defOp)
+              continue;
+            auto ifOp = v.getDefiningOp<scf::IfOp>();
+            bool isBranchDef = ifOp && ifOp->isAncestor(defOp);
+            if (defOp->getBlock() == op->getBlock() || isBranchDef)
+              dfs(defOp, finalUser, distance);
           }
         }
       };

--- a/lib/Dialect/TritonGPU/Transforms/Pipeliner/ScheduleLoops.cpp
+++ b/lib/Dialect/TritonGPU/Transforms/Pipeliner/ScheduleLoops.cpp
@@ -140,10 +140,30 @@ void scheduleRemainingToLastStage(scf::ForOp forOp, CoarseSchedule &schedule,
 }
 
 namespace {
+// Return the operation in the loop body that owns a latency operation nested
+// only in `scf.if` regions. Other nested region-bearing operations, including
+// nested loops, have their own scheduling semantics.
+Operation *getLatencyOwner(scf::ForOp forOp, Operation *op) {
+  Operation *owner = forOp.getBody()->findAncestorOpInBlock(*op);
+  if (!owner)
+    return nullptr;
+  if (owner == op)
+    return owner;
+  if (!isa<scf::IfOp>(owner))
+    return nullptr;
+  for (Operation *ancestor = op->getParentOp(); ancestor != owner;
+       ancestor = ancestor->getParentOp()) {
+    if (!ancestor || !isa<scf::IfOp>(ancestor))
+      return nullptr;
+  }
+  return owner;
+}
+
 bool hasLatenciesAssigned(scf::ForOp forOp,
                           const DenseMap<Operation *, int> &opLatency) {
-  for (auto &op : forOp.getBody()->without_terminator()) {
-    if (opLatency.count(&op))
+  for (auto [op, latency] : opLatency) {
+    (void)latency;
+    if (getLatencyOwner(forOp, op))
       return true;
   }
   return false;
@@ -151,13 +171,63 @@ bool hasLatenciesAssigned(scf::ForOp forOp,
 
 CoarseSchedule scheduleKeyOps(scf::ForOp forOp,
                               const DenseMap<Operation *, int> &opLatency) {
+  // The pipeline expander assigns stages to operations in the loop body, not
+  // to operations in nested regions. Attribute a nested latency to its
+  // top-level ancestor so, for example, an `scf.if` containing a load is
+  // scheduled at the load's stage.
+  DenseMap<Operation *, int> topLevelLatency;
+  // A top-level op is one indivisible scheduling unit, so collapse nested
+  // latency chains to their longest path. Each nested op has exactly one
+  // top-level ancestor in this loop body, making an op-only memo sufficient.
+  DenseMap<Operation *, int> nestedDistance;
+  std::function<int(Value, Operation *)> computeValueDistance;
+  std::function<int(Operation *, Operation *)> computeNestedDistance =
+      [&](Operation *op, Operation *topLevel) {
+        auto it = nestedDistance.find(op);
+        if (it != nestedDistance.end())
+          return it->second;
+        int distance = opLatency.lookup(op);
+        int operandDistance = 0;
+        for (Value operand : op->getOperands())
+          operandDistance = std::max(operandDistance,
+                                     computeValueDistance(operand, topLevel));
+        return nestedDistance[op] = distance + operandDistance;
+      };
+  computeValueDistance = [&](Value value, Operation *topLevel) {
+    auto result = dyn_cast<OpResult>(value);
+    if (auto ifOp = result ? dyn_cast<scf::IfOp>(result.getOwner()) : nullptr) {
+      unsigned resultNumber = result.getResultNumber();
+      return std::max(computeValueDistance(
+                          ifOp.thenYield().getOperand(resultNumber), topLevel),
+                      computeValueDistance(
+                          ifOp.elseYield().getOperand(resultNumber), topLevel));
+    }
+    Operation *def = value.getDefiningOp();
+    if (!def || !topLevel->isProperAncestor(def))
+      return 0;
+    return computeNestedDistance(def, topLevel);
+  };
+  for (auto [op, latency] : opLatency) {
+    Operation *topLevel = getLatencyOwner(forOp, op);
+    if (!topLevel)
+      continue;
+    int projectedLatency =
+        topLevel == op
+            ? latency
+            : opLatency.lookup(topLevel) + computeNestedDistance(op, topLevel);
+    auto [it, inserted] =
+        topLevelLatency.try_emplace(topLevel, projectedLatency);
+    if (!inserted)
+      it->second = std::max(it->second, projectedLatency);
+  }
+
   llvm::MapVector<Operation *, int> opToStage;
   // Find terminator for later reference
   auto terminator = cast<scf::YieldOp>(forOp.getBody()->getTerminator());
   // Determine all operations that have a non-zero latency
   SmallVector<Operation *> latOps;
   for (auto &op : forOp.getBody()->without_terminator()) {
-    if (opLatency.count(&op))
+    if (topLevelLatency.count(&op))
       latOps.push_back(&op);
   }
   // If no latency ops, nothing to schedule
@@ -184,8 +254,8 @@ CoarseSchedule scheduleKeyOps(scf::ForOp forOp,
         maxDist = distUser;
     }
     int lat = 0;
-    if (opLatency.count(op))
-      lat = opLatency.lookup(op);
+    if (topLevelLatency.count(op))
+      lat = topLevelLatency.lookup(op);
     // If an op has no users (maxDist == -1) but has latency, we include its
     // latency otherwise it contributes 0 to the distance.
     int d = lat + (maxDist < 0 ? 0 : maxDist);
@@ -231,7 +301,7 @@ CoarseSchedule scheduleKeyOps(scf::ForOp forOp,
     if (!ifOp)
       continue;
     // If the `scf.if` op itself is a latency op, skip it.
-    if (opLatency.contains(ifOp))
+    if (topLevelLatency.contains(ifOp))
       continue;
     // Ensure this does not create scheduling conflicts by ensuring the forward
     // slice of the `scf.if` does not contain ops that are already scheduled, as

--- a/test/TritonGPU/pipeline-assign-latencies.mlir
+++ b/test/TritonGPU/pipeline-assign-latencies.mlir
@@ -36,6 +36,36 @@ tt.func @default_stages(%lb : index, %ub : index, %step : index,
   tt.return %loop#2: tensor<128x128xf32, #C>
 }
 
+// CHECK-LABEL: @conditional_load
+tt.func @conditional_load(%lb : index, %ub : index, %step : index,
+                  %cond : i1,
+                  %a_ptr_init : tensor<128x32x!tt.ptr<f16>, #AL> {tt.divisibility = dense<[16, 16]> : tensor<2xi32>, tt.contiguity = dense<[1, 32]> : tensor<2xi32>},
+                  %b_ptr_init : tensor<32x128x!tt.ptr<f16>, #BL> {tt.divisibility = dense<[16, 16]> : tensor<2xi32>, tt.contiguity = dense<[1, 32]> : tensor<2xi32>}) -> tensor<128x128xf32, #C> {
+  %a_zero = arith.constant dense<0.00e+00> : tensor<128x32xf16, #AL>
+  %c_init = arith.constant dense<0.00e+00> : tensor<128x128xf32, #C>
+  %loop = scf.for %iv = %lb to %ub step %step iter_args(%prev_c = %c_init) -> tensor<128x128xf32, #C> {
+    %a_ = scf.if %cond -> tensor<128x32xf16, #AL> {
+      %nested = scf.if %cond -> tensor<128x32xf16, #AL> {
+        // CHECK: tt.load {{.*}} {tt.latency = 2 : i32}
+        %loaded = tt.load %a_ptr_init : tensor<128x32x!tt.ptr<f16>, #AL>
+        scf.yield %loaded : tensor<128x32xf16, #AL>
+      } else {
+        scf.yield %a_zero : tensor<128x32xf16, #AL>
+      }
+      scf.yield %nested : tensor<128x32xf16, #AL>
+    } else {
+      scf.yield %a_zero : tensor<128x32xf16, #AL>
+    }
+    %a = ttg.convert_layout %a_ : tensor<128x32xf16, #AL> -> tensor<128x32xf16, #A>
+    // CHECK: tt.load {{.*}} {tt.latency = 2 : i32}
+    %b_ = tt.load %b_ptr_init : tensor<32x128x!tt.ptr<f16>, #BL>
+    %b = ttg.convert_layout %b_ : tensor<32x128xf16, #BL> -> tensor<32x128xf16, #B>
+    %c = tt.dot %a, %b, %prev_c : tensor<128x32xf16, #A> * tensor<32x128xf16, #B> -> tensor<128x128xf32, #C>
+    scf.yield %c : tensor<128x128xf32, #C>
+  }
+  tt.return %loop : tensor<128x128xf32, #C>
+}
+
 // CHECK-LABEL: @small_load
 // We should *not* assign latency to the load of b_ptr.
 tt.func @small_load(%lb : index, %ub : index, %step : index,

--- a/test/TritonGPU/pipeline-schedule-loop.mlir
+++ b/test/TritonGPU/pipeline-schedule-loop.mlir
@@ -25,6 +25,81 @@ tt.func @one_dep(%lb : index, %ub : index, %step : index,
   tt.return %loop#0 : tensor<128x32xf16, #A>
 }
 
+// CHECK-LABEL: @if_result_dependency
+tt.func @if_result_dependency(%lb : index, %ub : index, %step : index,
+                              %cond : i1, %ptr : !tt.ptr<i32>) {
+  scf.for %iv = %lb to %ub step %step {
+    // CHECK: scf.if
+    // CHECK: } {loop.cluster = {{.*}}, loop.stage = 0 : i32}
+    %value = scf.if %cond -> i32 {
+      %loaded = tt.load %ptr {tt.latency = 2 : i32} : !tt.ptr<i32>
+      scf.yield %loaded : i32
+    } else {
+      %zero = arith.constant 0 : i32
+      scf.yield %zero : i32
+    }
+    // CHECK: tt.load {{.*}} {loop.cluster = {{.*}}, loop.stage = 0 : i32
+    %other = tt.load %ptr {tt.latency = 2 : i32} : !tt.ptr<i32>
+    // CHECK: "use"(%{{.*}}, %{{.*}}) {{.*}}loop.stage = 2 : i32
+    "use"(%value, %other) : (i32, i32) -> ()
+  }
+  tt.return
+}
+
+// CHECK-LABEL: @if_result_latency_chain
+tt.func @if_result_latency_chain(%lb : index, %ub : index, %step : index,
+                                 %cond : i1) {
+  scf.for %iv = %lb to %ub step %step {
+    // CHECK: scf.if
+    // CHECK: } {loop.cluster = {{.*}}, loop.stage = 0 : i32}
+    %value = scf.if %cond -> i32 {
+      %first = scf.if %cond -> i32 {
+        %then = "first"() {tt.latency = 1 : i32} : () -> i32
+        scf.yield %then : i32
+      } else {
+        %else = "alternate"() {tt.latency = 1 : i32} : () -> i32
+        scf.yield %else : i32
+      }
+      %second = "second"(%first) {tt.latency = 1 : i32} : (i32) -> i32
+      scf.yield %second : i32
+    } else {
+      %other = "other"() {tt.latency = 1 : i32} : () -> i32
+      scf.yield %other : i32
+    }
+    // CHECK: "use"(%{{.*}}) {{.*}}loop.stage = 2 : i32
+    "use"(%value) : (i32) -> ()
+  }
+  tt.return
+}
+
+// CHECK-LABEL: @nested_loop_latency_is_local
+tt.func @nested_loop_latency_is_local(%lb : index, %ub : index, %step : index) {
+  scf.for %outer_iv = %lb to %ub step %step {
+    %result = scf.for %inner_iv = %lb to %ub step %step iter_args(%arg = %lb) -> index {
+      %next = "inner.producer"(%arg) {tt.latency = 2 : i32} : (index) -> index
+      scf.yield %next : index
+    }
+    // A nested loop owns its latency; the outer loop must remain unscheduled.
+    // CHECK: "outer.use"(%{{.*}}) : (index) -> ()
+    "outer.use"(%result) : (index) -> ()
+  }
+  tt.return
+}
+
+// CHECK-LABEL: @non_if_region_latency_is_local
+tt.func @non_if_region_latency_is_local(%lb : index, %ub : index, %step : index) {
+  scf.for %iv = %lb to %ub step %step {
+    %result = scf.execute_region -> index {
+      %produced = "region.producer"(%lb) {tt.latency = 2 : i32} : (index) -> index
+      scf.yield %produced : index
+    }
+    // Only `scf.if` regions are projected into the enclosing loop's schedule.
+    // CHECK: "outer.region_use"(%{{.*}}) : (index) -> ()
+    "outer.region_use"(%result) : (index) -> ()
+  }
+  tt.return
+}
+
 // CHECK-LABEL: @parallel_deps
 tt.func @parallel_deps(%lb : index, %ub : index, %step : index,
                        %a_ptr_init : tensor<128x32x!tt.ptr<f16>, #A>,


### PR DESCRIPTION
Closes #11013.

Conditional loads returned through `scf.if` could lose their software-pipeline distance. Latency assignment stopped at the `scf.if` result, while loop scheduling only recognized latency operations directly in the loop body. Another top-level latency anchor could therefore establish a three-stage schedule while the conditional producer remained with its consumer in the last stage.

```text
Before                          After

conditional load               conditional load
       │                               │
scf.if: stage 2                 scf.if: stage 0
       │                               │
consumer: stage 2               consumer: stage 2

iteration lead = 2 - 2 = 0      iteration lead = 2 - 0 = 2
```

This change:

- follows `scf.if` results to the corresponding values yielded by both branches during load-latency discovery;
- projects latency paths nested through `scf.if` regions onto the enclosing top-level `scf.if`;
- uses the maximum branch-local path sum when several nested latency paths share the same top-level owner;
- leaves nested loops and other region-bearing operations responsible for their own latencies.

The regression tests exercise automatic latency assignment, the mixed conditional/top-level anchor case, nested latency chains, nested-loop ownership, and non-`scf.if` region ownership.

### Suggested review order

1. `AssignLatencies.cpp`: follow values yielded from `scf.if`.
2. `ScheduleLoops.cpp`: project supported nested latency paths onto their scheduling owner.
3. The two lit regressions and region-ownership controls.

### Testing

- `make`
- `ninja triton-opt`
- `lit -v test/TritonGPU/pipeline-assign-latencies.mlir test/TritonGPU/pipeline-schedule-loop.mlir` — 2/2 passed
- The same regressions fail against the base implementation.
- `pre-commit run --from-ref origin/main --to-ref HEAD`

# New contributor declaration
- [x] I am not making a trivial change, such as fixing a typo in a comment.

- [x] I have written a PR description following these
  [rules](https://cbea.ms/git-commit/#why-not-how).

- [x] I have run `pre-commit run --from-ref origin/main --to-ref HEAD`.

- [x] I have added tests.
  - `/test` for `lit` tests

- [x] The `lit` tests I have added follow these [best practices](https://mlir.llvm.org/getting_started/TestingGuide/#filecheck-best-practices), including the "tests should be minimal" section.
