### PR TITLE
[Pipeliner] Respect single-stage loop settings during expansion

### DIFF
--- a/include/triton/Dialect/TritonGPU/Transforms/PipeliningUtility.h
+++ b/include/triton/Dialect/TritonGPU/Transforms/PipeliningUtility.h
@@ -165,6 +165,11 @@ gpu::SharedEncodingTrait getSharedEncoding(Operation *loadOp);
 // specified.
 int getNumStagesOrDefault(scf::ForOp forOp, int defaultNumStages);
 
+// Return true if a loop should undergo cross-iteration software pipelining.
+// Loops materialized inside a warp-specialize op carry compiler-generated
+// schedules that are independent of the source loop's stage setting.
+bool shouldPipelineLoop(scf::ForOp forOp, int defaultNumStages);
+
 // Given a result of MemDescIndex, or Alloca, create a MemDescIndex with a
 // single buffer slice (leading dimension equal to 1), at the given index.
 TypedValue<triton::gpu::MemDescType>

--- a/include/triton/Dialect/TritonGPU/Transforms/Schedule.h
+++ b/include/triton/Dialect/TritonGPU/Transforms/Schedule.h
@@ -17,6 +17,7 @@ namespace gpu {
 
 /// Lower the loops to prepare them for pipeline expansion.
 void lowerLoops(ModuleOp moduleOp);
+void lowerLoops(ModuleOp moduleOp, int defaultNumStages);
 
 bool hasGpuBarriers(scf::ForOp forOp);
 bool isSafeToPipeline(scf::ForOp forOp);

--- a/lib/Dialect/TritonGPU/Transforms/Pipeliner/LowerLoops.cpp
+++ b/lib/Dialect/TritonGPU/Transforms/Pipeliner/LowerLoops.cpp
@@ -1064,15 +1064,24 @@ void lowerLoop(scf::ForOp forOp,
 
 } // namespace
 
-void lowerLoops(ModuleOp moduleOp) {
+static void lowerLoops(ModuleOp moduleOp, std::optional<int> defaultNumStages) {
   triton::ModuleAxisInfoAnalysis axisInfoAnalysis(moduleOp);
   SmallVector<scf::ForOp> loops;
-  moduleOp->walk([&](scf::ForOp forOp) { loops.push_back(forOp); });
+  moduleOp->walk([&](scf::ForOp forOp) {
+    if (!defaultNumStages || shouldPipelineLoop(forOp, *defaultNumStages))
+      loops.push_back(forOp);
+  });
   if (loops.empty())
     return;
   for (auto forOp : loops) {
     lowerLoop(forOp, axisInfoAnalysis);
   }
+}
+
+void lowerLoops(ModuleOp moduleOp) { lowerLoops(moduleOp, std::nullopt); }
+
+void lowerLoops(ModuleOp moduleOp, int defaultNumStages) {
+  lowerLoops(moduleOp, std::optional<int>(defaultNumStages));
 }
 
 } // namespace gpu

--- a/lib/Dialect/TritonGPU/Transforms/Pipeliner/PipeliningUtility.cpp
+++ b/lib/Dialect/TritonGPU/Transforms/Pipeliner/PipeliningUtility.cpp
@@ -564,6 +564,11 @@ int mlir::triton::getNumStagesOrDefault(scf::ForOp forOp,
   return defaultNumStages;
 }
 
+bool mlir::triton::shouldPipelineLoop(scf::ForOp forOp, int defaultNumStages) {
+  return getNumStagesOrDefault(forOp, defaultNumStages) > 1 ||
+         forOp->getParentOfType<triton::gpu::WarpSpecializeOp>();
+}
+
 TypedValue<ttg::MemDescType>
 triton::createSingleBufferView(OpBuilder &builder, Value alloc, Value idx) {
   assert(isa<ttg::MemDescType>(alloc.getType()) && "Expected MemDescType");

--- a/lib/Dialect/TritonGPU/Transforms/Pipeliner/SoftwarePipeliner.cpp
+++ b/lib/Dialect/TritonGPU/Transforms/Pipeliner/SoftwarePipeliner.cpp
@@ -61,7 +61,7 @@ static bool hasMMAv5WaitsInLastStage(scf::ForOp forOp,
   return hasMMAv5 && hasWaitInLastStage;
 }
 
-static void expandLoops(ModuleOp moduleOp) {
+static void expandLoops(ModuleOp moduleOp, int defaultNumStages) {
   DenseSet<MaskOp> peeledMaskOps;
   auto processPeeledEpilogueOp = [&](RewriterBase &rewriter, Operation *op,
                                      bool isEpilogue) -> Operation * {
@@ -93,6 +93,8 @@ static void expandLoops(ModuleOp moduleOp) {
   SmallVector<scf::ForOp> loops;
   moduleOp->walk([&](scf::ForOp forOp) { loops.push_back(forOp); });
   for (scf::ForOp forOp : loops) {
+    if (!shouldPipelineLoop(forOp, defaultNumStages))
+      continue;
     CoarseSchedule schedule;
     if (failed(schedule.deSerialize(forOp))) {
       continue;
@@ -176,7 +178,7 @@ struct PipelinePass : public impl::TritonGPUPipelineBase<PipelinePass> {
     ModuleOp moduleOp = getOperation();
     // Transform the loop by introducing async operations to prepare it for
     // pipeline expansion.
-    lowerLoops(moduleOp);
+    lowerLoops(moduleOp, numStages);
     if (dumpIntermediateSteps) {
       ::mlir::triton::tools::mlirDumpsOrDbgs()
           << "// -----// SoftwarePipeliner internal IR Dump After: LowerLoops\n"
@@ -184,7 +186,7 @@ struct PipelinePass : public impl::TritonGPUPipelineBase<PipelinePass> {
     }
 
     // Apply the pipeline expansion.
-    expandLoops(moduleOp);
+    expandLoops(moduleOp, numStages);
     if (dumpIntermediateSteps) {
       ::mlir::triton::tools::mlirDumpsOrDbgs()
           << "// -----// SoftwarePipeliner internal IR Dump After: "

--- a/python/triton/language/core.py
+++ b/python/triton/language/core.py
@@ -3565,6 +3565,9 @@ class range(base_value):
     :param step: the step value.
     :param num_stages: pipeline the loop into this many stages (so there are
         :code:`num_stages` iterations of the loop in flight at once).
+        Values of 0 or 1 disable cross-iteration software pipelining for the
+        loop, but do not prevent target-specific asynchronous execution within
+        a single iteration.
 
         Note this is subtly different than passing :code:`num_stages` as a
         kernel argument.  The kernel argument only pipelines loads that feed

--- a/test/TritonGPU/loop-pipeline-expand.mlir
+++ b/test/TritonGPU/loop-pipeline-expand.mlir
@@ -1,4 +1,74 @@
-// RUN: triton-opt %s -split-input-file -tritongpu-pipeline | FileCheck %s --check-prefixes=CHECK
+// RUN: triton-opt %s -split-input-file -tritongpu-pipeline | FileCheck %s --check-prefixes=CHECK,STAGES-ZERO,STAGES-ONE,WARP-SCHEDULE
+// RUN: triton-opt %s -split-input-file -tritongpu-pipeline=num-stages=1 | FileCheck %s --check-prefix=DEFAULT-ONE
+
+module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.target = "cuda:90", "ttg.threads-per-warp" = 32 : i32} {
+  // STAGES-ZERO-LABEL: @num_stages_zero
+  // STAGES-ZERO-NEXT:    %[[RESULT:.*]] = scf.for
+  // STAGES-ZERO-NEXT:      %[[FIRST:.*]] = arith.addi
+  // STAGES-ZERO-NEXT:      %[[SECOND:.*]] = arith.addi
+  // STAGES-ZERO-NEXT:      scf.yield %[[SECOND]]
+  // STAGES-ZERO-NEXT:    } {tt.num_stages = 0 : i32}
+  tt.func public @num_stages_zero(%lb: i32, %ub: i32, %step: i32, %init: i32) -> i32 {
+    %result = scf.for %iv = %lb to %ub step %step iter_args(%acc = %init) -> i32 : i32 {
+      %first = arith.addi %iv, %acc {loop.cluster = 1 : i32, loop.stage = 0 : i32} : i32
+      %second = arith.addi %first, %acc {loop.cluster = 0 : i32, loop.stage = 1 : i32} : i32
+      scf.yield %second : i32
+    } {tt.num_stages = 0 : i32, tt.scheduled_max_stage = 1 : i32}
+    tt.return %result : i32
+  }
+
+  // STAGES-ONE-LABEL: @num_stages_one
+  // STAGES-ONE-NEXT:    %[[RESULT:.*]] = scf.for
+  // STAGES-ONE-NEXT:      %[[FIRST:.*]] = arith.addi
+  // STAGES-ONE-NEXT:      %[[SECOND:.*]] = arith.addi
+  // STAGES-ONE-NEXT:      scf.yield %[[SECOND]]
+  // STAGES-ONE-NEXT:    } {tt.num_stages = 1 : i32}
+  tt.func public @num_stages_one(%lb: i32, %ub: i32, %step: i32, %init: i32) -> i32 {
+    %result = scf.for %iv = %lb to %ub step %step iter_args(%acc = %init) -> i32 : i32 {
+      %first = arith.addi %iv, %acc {loop.cluster = 1 : i32, loop.stage = 0 : i32} : i32
+      %second = arith.addi %first, %acc {loop.cluster = 0 : i32, loop.stage = 1 : i32} : i32
+      scf.yield %second : i32
+    } {tt.num_stages = 1 : i32, tt.scheduled_max_stage = 1 : i32}
+    tt.return %result : i32
+  }
+
+  // DEFAULT-ONE-LABEL: @default_num_stages_one
+  // DEFAULT-ONE-NEXT:    %[[RESULT:.*]] = scf.for
+  // DEFAULT-ONE-NEXT:      %[[FIRST:.*]] = arith.addi
+  // DEFAULT-ONE-NEXT:      %[[SECOND:.*]] = arith.addi
+  // DEFAULT-ONE-NEXT:      scf.yield %[[SECOND]]
+  // DEFAULT-ONE-NEXT:    }
+  tt.func public @default_num_stages_one(%lb: i32, %ub: i32, %step: i32, %init: i32) -> i32 {
+    %result = scf.for %iv = %lb to %ub step %step iter_args(%acc = %init) -> i32 : i32 {
+      %first = arith.addi %iv, %acc {loop.cluster = 1 : i32, loop.stage = 0 : i32} : i32
+      %second = arith.addi %first, %acc {loop.cluster = 0 : i32, loop.stage = 1 : i32} : i32
+      scf.yield %second : i32
+    } {tt.scheduled_max_stage = 1 : i32}
+    tt.return %result : i32
+  }
+
+  // A loop produced inside warp specialization has an internal schedule whose
+  // stages are independent of the source loop's num_stages setting.
+  // WARP-SCHEDULE-LABEL: @warp_specialized_schedule
+  // WARP-SCHEDULE:          ttg.warp_specialize(
+  // WARP-SCHEDULE:          default {
+  // WARP-SCHEDULE-NEXT:       %[[PROLOGUE:.*]] = arith.addi
+  // WARP-SCHEDULE-NEXT:       %{{.*}}:2 = scf.for {{.*}} iter_args({{.*}}, {{.*}}) -> (i32, i32)
+  tt.func public @warp_specialized_schedule(%lb: i32, %ub: i32, %step: i32, %init: i32) -> i32 {
+    %ws_result = ttg.warp_specialize(%init)
+    default {
+      %result = scf.for %iv = %lb to %ub step %step iter_args(%acc = %init) -> i32 : i32 {
+        %first = arith.addi %iv, %acc {loop.cluster = 1 : i32, loop.stage = 0 : i32} : i32
+        %second = arith.addi %first, %acc {loop.cluster = 0 : i32, loop.stage = 1 : i32} : i32
+        scf.yield %second : i32
+      } {tt.num_stages = 1 : i32, tt.scheduled_max_stage = 1 : i32}
+      ttg.warp_yield %result : i32
+    } : (i32) -> i32
+    tt.return %ws_result : i32
+  }
+}
+
+// -----
 
 #blocked = #ttg.blocked<{sizePerThread = [1, 4], threadsPerWarp = [4, 8], warpsPerCTA = [4, 1], order = [1, 0]}>
 #blocked1 = #ttg.blocked<{sizePerThread = [1, 4], threadsPerWarp = [1, 32], warpsPerCTA = [4, 1], order = [1, 0]}>


### PR DESCRIPTION
Closes #11014.

`AssignLatencies` skips ordinary loops with `num_stages <= 1`, but later pipeline steps processed any loop carrying a serialized schedule. Existing metadata could therefore introduce a prologue, epilogue, and cross-iteration buffering despite an explicit or inherited single-stage setting.

This change gates per-loop lowering and expansion on the effective `num_stages`, while preserving compiler-generated schedules inside materialized `ttg.warp_specialize` operations.

| Effective `num_stages` | Ordinary loop | Loop inside materialized `ttg.warp_specialize` |
|---:|---|---|
| 0 | No cross-iteration software pipelining | Preserve generated schedule |
| 1 | No cross-iteration software pipelining; same-iteration async execution may remain | Preserve generated schedule |
| 2 or greater | Pipeline normally | Preserve generated schedule |

Same-iteration WGMMA asynchronous execution remains available at `num_stages=1`. The documentation now distinguishes that behavior from cross-iteration software pipelining.

### Testing

`test/TritonGPU/loop-pipeline-expand.mlir` covers:

- explicit `tt.num_stages = 0`;
- explicit `tt.num_stages = 1`;
- inherited pass default `num-stages=1`;
- expansion of a compiler-generated loop inside `ttg.warp_specialize`.

The first three cases expand on the base revision and remain unexpanded after the change. The focused lit test passes 1/1.

- `make`
- `lit -v test/TritonGPU/loop-pipeline-expand.mlir`
- `pre-commit run --from-ref origin/main --to-ref HEAD`

# New contributor declaration
- [x] I am not making a trivial change, such as fixing a typo in a comment.

- [x] I have written a PR description following these
  [rules](https://cbea.ms/git-commit/#why-not-how).

- [x] I have run `pre-commit run --from-ref origin/main --to-ref HEAD`.

- [x] I have added tests.
  - `/test` for `lit` tests

- [x] The `lit` tests I have added follow these [best practices](https://mlir.llvm.org/getting_started/TestingGuide/#filecheck-best-practices), including the "tests should be minimal" section.
