### PR TITLE
[BACKEND] Diagnose unaligned TMA pipeline fallback

### DIFF
--- a/lib/Dialect/TritonGPU/Transforms/Pipeliner/AssignLatencies.cpp
+++ b/lib/Dialect/TritonGPU/Transforms/Pipeliner/AssignLatencies.cpp
@@ -157,6 +157,10 @@ public:
     if (auto loadOp = dyn_cast<tt::DescriptorLoadLikeOpInterface>(op)) {
       auto descTy = cast<tt::TensorDescType>(loadOp.getDesc().getType());
       if (descTy.getSharedLayout() && !canPipelineTMALoad(op)) {
+        op->emitRemark()
+            << "Not pipelining TMA load because the per-stage shared-memory "
+               "allocation size is not a multiple of the 128-byte TMA "
+               "alignment.";
         LDBG("TMA load " << *op
                          << " has a per-stage allocation that is not aligned "
                             "for pipelining");

--- a/test/TritonGPU/pipeline-assign-latencies.mlir
+++ b/test/TritonGPU/pipeline-assign-latencies.mlir
@@ -1,4 +1,5 @@
 // RUN: triton-opt %s -split-input-file -allow-unregistered-dialect -tritongpu-assign-latencies=num-stages=3 -canonicalize | FileCheck %s
+// RUN: triton-opt %s -split-input-file -allow-unregistered-dialect -tritongpu-assign-latencies=num-stages=3 -verify-diagnostics=only-expected -o /dev/null
 
 #AL = #ttg.blocked<{sizePerThread = [1, 4], threadsPerWarp = [4, 8], warpsPerCTA = [4, 1], order = [1, 0]}>
 #BL = #ttg.blocked<{sizePerThread = [1, 4], threadsPerWarp = [1, 32], warpsPerCTA = [4, 1], order = [1, 0]}>
@@ -394,8 +395,28 @@ module attributes {"ttg.num-warps" = 4 : i32, "ttg.num-ctas" = 1 : i32} {
                                     %lb: index, %ub: index, %step: index) {
     %c0 = arith.constant 0 : i32
     scf.for %iv = %lb to %ub step %step {
+      // expected-remark @below {{Not pipelining TMA load because the per-stage shared-memory allocation size is not a multiple of the 128-byte TMA alignment.}}
       %load = tt.descriptor_load %desc[%c0] : !tt.tensordesc<4xf32, #tiny_shared> -> tensor<4xf32, #tiny_blocked>
       "use"(%load) : (tensor<4xf32, #tiny_blocked>) -> ()
+    } {tt.num_stages = 3 : i32}
+    tt.return
+  }
+}
+
+// -----
+
+#aligned_blocked = #ttg.blocked<{sizePerThread = [1], threadsPerWarp = [32], warpsPerCTA = [4], order = [0]}>
+#aligned_shared = #ttg.nvmma_shared<{swizzlingByteWidth = 0, transposed = false, elementBitWidth = 32, rank = 1}>
+
+module attributes {"ttg.num-warps" = 4 : i32, "ttg.num-ctas" = 1 : i32} {
+  // CHECK-LABEL: @aligned_tma_stage_size
+  // CHECK: tt.descriptor_load {{.*}} {tt.latency = 2 : i32}
+  tt.func @aligned_tma_stage_size(%desc: !tt.tensordesc<32xf32, #aligned_shared>,
+                                  %lb: index, %ub: index, %step: index) {
+    %c0 = arith.constant 0 : i32
+    scf.for %iv = %lb to %ub step %step {
+      %load = tt.descriptor_load %desc[%c0] : !tt.tensordesc<32xf32, #aligned_shared> -> tensor<32xf32, #aligned_blocked>
+      "use"(%load) : (tensor<32xf32, #aligned_blocked>) -> ()
     } {tt.num_stages = 3 : i32}
     tt.return
   }


### PR DESCRIPTION
Automatic latency assignment rejects TMA descriptor loads whose per-stage shared-memory allocation is not 128-byte aligned. That rejection is required for correctness, but it occurred before the existing LowerLoops diagnostic could run, so users enabling remarks received no explanation for the missing pipeline.

Emit the existing unaligned-TMA remark at the early AssignLatencies decision point. Default frontend compilation remains quiet; the message is visible when `MLIR_ENABLE_DIAGNOSTICS=remarks` is enabled. This does not relax the alignment requirement or force TMA pipelining.

The regression covers both sides of the alignment predicate:

- `4xf32` is 16 bytes per stage, so `16 mod 128 != 0`; it is rejected and emits the remark.
- `32xf32` is 128 bytes per stage, so `128 mod 128 = 0`; it remains eligible and receives latency 2.

This is a diagnostic follow-up to #10474 and #10898.

### Testing

- `make`
- `lit -v test/TritonGPU/pipeline-assign-latencies.mlir` — 1/1 passed
- Compile-only CUDA sm90 frontend check with a `tl.make_tensor_descriptor(..., block_shape=[4])` loop:
  - default diagnostics remain quiet;
  - `MLIR_ENABLE_DIAGNOSTICS=remarks` emits the expected fallback message.
- `pre-commit run --from-ref origin/main --to-ref HEAD`

# New contributor declaration
- [x] I am not making a trivial change, such as fixing a typo in a comment.

- [x] I have written a PR description following these
  [rules](https://cbea.ms/git-commit/#why-not-how).

- [x] I have run `pre-commit run --from-ref origin/main --to-ref HEAD`.

- [x] I have added tests.
  - `/test` for `lit` tests

- [x] The `lit` tests I have added follow these [best practices](https://mlir.llvm.org/getting_started/TestingGuide/#filecheck-best-practices), including the "tests should be minimal" section.
