### PR TITLE
[AMD] Fix buffer atomic exchange intrinsic

### DIFF
--- a/test/Conversion/amd/buffer_load_store.mlir
+++ b/test/Conversion/amd/buffer_load_store.mlir
@@ -240,6 +240,18 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 1 : i32} {
 
 #blocked0 = #ttg.blocked<{sizePerThread = [1], threadsPerWarp = [64], warpsPerCTA = [4], order = [0]}>
 module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, "ttg.threads-per-warp" = 64 : i32} {
+    // CHECK-LABEL: buffer_atomic_rmw_xchg_i32
+    // CHECK: llvm.call_intrinsic "llvm.amdgcn.raw.ptr.buffer.atomic.swap"({{.*}}) : (i32, !llvm.ptr<8>, i32, i32, i32) -> i32
+    tt.func public @buffer_atomic_rmw_xchg_i32(%arg0: !tt.ptr<i32> {tt.divisibility = 16 : i32}, %offsets : tensor<256xi32, #blocked0>{tt.divisibility=16:i32}, %values : tensor<256xi32, #blocked0>) {
+        %ret = amdg.buffer_atomic_rmw exch, acq_rel, gpu, %values, %arg0[%offsets] : tensor<256xi32, #blocked0>
+        tt.return
+    }
+}
+
+// -----
+
+#blocked0 = #ttg.blocked<{sizePerThread = [1], threadsPerWarp = [64], warpsPerCTA = [4], order = [0]}>
+module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, "ttg.threads-per-warp" = 64 : i32} {
     // CHECK-LABEL: buffer_atomic_rmw_fmax_f32
     // CHECK: llvm.call_intrinsic "llvm.amdgcn.raw.ptr.buffer.atomic.fmax"({{.*}}) : (f32, !llvm.ptr<8>, i32, i32, i32) -> f32
     tt.func public @buffer_atomic_rmw_fmax_f32(%arg0: !tt.ptr<f32> {tt.divisibility = 16 : i32}, %offsets : tensor<256xi32, #blocked0>{tt.divisibility=16:i32}, %values : tensor<256xf32, #blocked0>) {

--- a/third_party/amd/lib/TritonAMDGPUToLLVM/BufferOpsEmitter.cpp
+++ b/third_party/amd/lib/TritonAMDGPUToLLVM/BufferOpsEmitter.cpp
@@ -198,11 +198,15 @@ Value BufferEmitter::emitAtomicRMW(RMWOp rmwType, Type type, Value rsrcDesc,
   //   LLVM verifier to fail. When this is fixed, the ROCDL ops should be used
   //   here.
   auto rmwOpStr = stringifyRMWOp(rmwType).str();
-  // RMWOp::MAX / MIN stringify to "max" / "min", which are not real AMDGPU
-  // buffer-atomic intrinsic suffixes. The valid suffixes are
-  // .{s,u,f}{max,min}. RMWOp::UMAX and RMWOp::UMIN already stringify to
-  // "umax" / "umin" and need no override.
-  if (rmwType == RMWOp::MAX || rmwType == RMWOp::MIN) {
+  if (rmwType == RMWOp::XCHG) {
+    // RMWOp::XCHG stringifies to "exch", but the AMDGPU buffer-atomic
+    // intrinsic uses the "swap" suffix.
+    rmwOpStr = "swap";
+  } else if (rmwType == RMWOp::MAX || rmwType == RMWOp::MIN) {
+    // RMWOp::MAX / MIN stringify to "max" / "min", which are not real AMDGPU
+    // buffer-atomic intrinsic suffixes. The valid suffixes are
+    // .{s,u,f}{max,min}. RMWOp::UMAX and RMWOp::UMIN already stringify to
+    // "umax" / "umin" and need no override.
     StringRef prefix = isa<FloatType>(getElementTypeOrSelf(type)) ? "f" : "s";
     rmwOpStr = (prefix + rmwOpStr).str();
   }


### PR DESCRIPTION
Map Triton's exchange RMW to AMDGPU's swap suffix so LLVM can resolve the emitted intrinsic.

<!---
The core Triton is a small number of people, and we receive many PRs (thank
you!).  To help us review your code more quickly, **if you are a new
contributor (less than 3 PRs merged) we ask that you complete the following
tasks and include the filled-out checklist in your PR description.**

Complete the following tasks before sending your PR, and replace `[ ]` with
`[x]` to indicate you have done them.
-->
## Technical details
`BufferEmitter::emitAtomicRMW()` derives the AMDGPU intrinsic suffix using `stringifyRMWOp()`. `RMWOp::XCHG` stringifies to `exch`, matching Triton’s MLIR syntax, but LLVM names the corresponding AMDGPU intrinsic `swap`.

Before this change, Triton emitted the nonexistent intrinsic:

`llvm.amdgcn.raw.ptr.buffer.atomic.exch`
This caused MLIR-to-LLVM translation to fail:

error: could not find LLVM intrinsic:
```
"llvm.amdgcn.raw.ptr.buffer.atomic.exch"
error: LLVM Translation failed for operation: llvm.call_intrinsic
```
The fix explicitly maps `RMWOp::XCHG` to `swap` and adds regression coverage checking for:

`llvm.amdgcn.raw.ptr.buffer.atomic.swap`
# New contributor declaration
- [x] I am not making a trivial change, such as fixing a typo in a comment.

- [x] I have written a PR description following these
  [rules](https://cbea.ms/git-commit/#why-not-how).

- [ ] I have run `pre-commit run --from-ref origin/main --to-ref HEAD`.

- Select one of the following.
  - [x] I have added tests.
    - `/test` for `lit` tests
    - `/unittest` for C++ tests
    - `/python/test` for end-to-end tests
  - [ ] This PR does not need a test because `FILL THIS IN`.

- Select one of the following.
  - [ ] I have not added any `lit` tests.
  - [ ] The `lit` tests I have added follow these [best practices](https://mlir.llvm.org/getting_started/TestingGuide/#filecheck-best-practices),
    including the "tests should be minimal" section. (Usually running Python code
    and using the instructions it generates is not minimal.)

CC:  @AlexAUT  @zhanglx13  @antiagainst 