### PR TITLE
[GSan][IR] Make GDC ops IR nodes, and support PDL in GSan

### DIFF
--- a/include/triton/Conversion/TritonGPUToLLVM/WarpSpecializeUtility.h
+++ b/include/triton/Conversion/TritonGPUToLLVM/WarpSpecializeUtility.h
@@ -27,6 +27,7 @@ public:
   virtual ~WarpSpecializeBarrierHelper() = default;
 
   virtual bool isBarrierOp(Operation *op) const = 0;
+  virtual bool isBarrierHandleOp(Operation *op) const { return false; }
   virtual Type getBarrierHandleType(MLIRContext *ctx) const = 0;
   virtual FailureOr<Value>
   getBarrierHandle(TritonLLVMIRRewriter &b,

--- a/include/triton/Dialect/Triton/IR/TritonOps.td
+++ b/include/triton/Dialect/Triton/IR/TritonOps.td
@@ -316,6 +316,20 @@ def TT_StoreOp : TT_Op<"store", [
 //
 // Atomic Ops
 //
+def TT_GridDependencyWaitOp
+    : TT_Op<"grid_dependency_wait", [MemoryEffects<[MemRead<GlobalMemory>, MemWrite<GlobalMemory>]>]> {
+    let summary = "wait for prerequisite grids and acquire their memory writes";
+    let arguments = (ins);
+    let assemblyFormat = "attr-dict";
+}
+
+def TT_GridDependencyLaunchDependentsOp
+    : TT_Op<"grid_dependency_launch_dependents", [MemoryEffects<[MemWrite<GlobalMemory>]>]> {
+    let summary = "allow dependent grids to begin execution";
+    let arguments = (ins);
+    let assemblyFormat = "attr-dict";
+}
+
 def TT_AtomicPollOp : TT_Op<"atomic_poll", [
   TypesMatchWith<"ptr type matches expected type", "expected", "ptr",
                  "getPointerTypeSameShape($_self)">

--- a/include/triton/Dialect/TritonInstrument/IR/TritonInstrumentOps.td
+++ b/include/triton/Dialect/TritonInstrument/IR/TritonInstrumentOps.td
@@ -105,7 +105,22 @@ def TTI_ExperimentalLocalGatherOp
 def TTI_ExperimentalGSanInitOp
     : TTI_Op<"experimental_gsan_init"> {
   let summary = "Initialize GSan thread";
+  let arguments = (ins BoolAttr:$acquireStreamClock);
+  let assemblyFormat = "$acquireStreamClock attr-dict";
+}
+
+def TTI_ExperimentalGSanKernelExitOp
+    : TTI_Op<"experimental_gsan_kernel_exit", [MemoryEffects<[MemWrite<GlobalMemory>]>]> {
+  let summary = "Publish a completed GSan thread clock to its launch stream";
   let arguments = (ins);
+  let assemblyFormat = "attr-dict";
+}
+
+def TTI_ExperimentalGSanGridDependencyWaitOp
+    : TTI_Op<"experimental_gsan_grid_dependency_wait", [MemoryEffects<[MemRead<GlobalMemory>, MemWrite<GlobalMemory>]>]> {
+  let summary = "Acquire completed predecessor clocks after a grid dependency wait";
+  let arguments = (ins);
+  let assemblyFormat = "attr-dict";
 }
 
 def TTI_ExperimentalGSanTensorDescInfoOp

--- a/lib/Conversion/TritonGPUToLLVM/WarpSpecializeUtility.cpp
+++ b/lib/Conversion/TritonGPUToLLVM/WarpSpecializeUtility.cpp
@@ -31,6 +31,19 @@ static std::string mangleFunctionName(StringRef name) {
   return (name + "_ws").str();
 }
 
+static LogicalResult
+lowerBarrierHandle(Operation *op, std::optional<unsigned> partitionIdx,
+                   WarpSpecializeBarrierHelper &barrierHelper) {
+  TritonLLVMIRRewriter b(op->getLoc(), op);
+  FailureOr<Value> handle = barrierHelper.getBarrierHandle(b, partitionIdx);
+  if (failed(handle))
+    return failure();
+  assert(op->getNumResults() == 1 && "barrier handle op must have one result");
+  op->getResult(0).replaceAllUsesWith(*handle);
+  op->erase();
+  return success();
+}
+
 static LogicalResult lowerBarrier(Operation *op, unsigned numWarps,
                                   std::optional<unsigned> partitionIdx,
                                   WarpSpecializeBarrierHelper &barrierHelper) {
@@ -71,6 +84,10 @@ lowerKernelBarriers(LLVM::LLVMFuncOp func,
       wsOps.push_back(wsOp.getParentOp());
       return WalkResult::skip();
     }
+    if (barrierHelper.isBarrierHandleOp(op)) {
+      auto result = lowerBarrierHandle(op, /*partitionIdx=*/{}, barrierHelper);
+      return succeeded(result) ? WalkResult::skip() : WalkResult::interrupt();
+    }
     if (barrierHelper.isBarrierOp(op)) {
       auto barRes =
           lowerBarrier(op, defaultNumWarps, /*partitionIdx=*/{}, barrierHelper);
@@ -95,6 +112,8 @@ lowerKernelBarriers(LLVM::LLVMFuncOp func,
     for (auto [idx, partition] : llvm::enumerate(op.getPartitionRegions())) {
       unsigned numWarps = op.getPartitionNumWarps()[idx];
       WalkResult result = partition->walk([&, idx = idx](Operation *op) {
+        if (barrierHelper.isBarrierHandleOp(op))
+          return WalkResult(lowerBarrierHandle(op, idx, barrierHelper));
         if (barrierHelper.isBarrierOp(op)) {
           return WalkResult(lowerBarrier(op, numWarps, idx, barrierHelper));
         }
@@ -142,7 +161,12 @@ lowerInnerFunctionBarriers(LLVM::LLVMFuncOp func,
   unsigned numWarps = numWarpsAttr.getInt();
 
   func.walk([&](Operation *op) {
-    if (barrierHelper.isBarrierOp(op)) {
+    if (barrierHelper.isBarrierHandleOp(op)) {
+      assert(op->getNumResults() == 1 &&
+             "barrier handle op must have one result");
+      op->getResult(0).replaceAllUsesWith(handle);
+      op->erase();
+    } else if (barrierHelper.isBarrierOp(op)) {
       TritonLLVMIRRewriter b(op->getLoc(), op);
       barrierHelper.createBarrier(b, numWarps, handle);
       op->erase();
@@ -174,8 +198,17 @@ LogicalResult mlir::triton::lowerWarpSpecializeBarriers(
     wsKernels.push_back(func);
   }
   // No warp specialization found.
-  if (wsKernels.empty())
+  if (wsKernels.empty()) {
+    WalkResult result = module.walk([&](Operation *op) {
+      if (!barrierHelper.isBarrierHandleOp(op))
+        return WalkResult::advance();
+      return WalkResult(
+          lowerBarrierHandle(op, /*partitionIdx=*/{}, barrierHelper));
+    });
+    if (result.wasInterrupted())
+      return failure();
     return success();
+  }
 
   DenseSet<StringAttr> innerFunctions;
   for (LLVM::LLVMFuncOp func : module.getOps<LLVM::LLVMFuncOp>()) {

--- a/lib/Conversion/TritonInstrumentToLLVM/GSanToLLVM.cpp
+++ b/lib/Conversion/TritonInstrumentToLLVM/GSanToLLVM.cpp
@@ -9,6 +9,7 @@
 #include "llvm/ADT/SmallString.h"
 #include "llvm/Support/LogicalResult.h"
 #include <limits>
+#include <type_traits>
 
 namespace tt = mlir::triton;
 namespace tti = mlir::triton::instrument;
@@ -38,8 +39,14 @@ static constexpr StringLiteral kGSanAtomicBeginRuntimeFn =
 static constexpr StringLiteral kGSanAtomicEndRuntimeFn =
     "__triton_gsan_atomic_end_scalar";
 static constexpr StringLiteral kGSanInitRuntimeFn = "__triton_gsan_init";
+static constexpr StringLiteral kGSanKernelExitRuntimeFn =
+    "__triton_gsan_kernel_exit";
+static constexpr StringLiteral kGSanGridDependencyWaitRuntimeFn =
+    "__triton_gsan_grid_dependency_wait";
 static constexpr StringLiteral kGSanGlobalStateArgAttr =
     "tti.gsan_global_state";
+static constexpr StringLiteral kGSanStreamClockArgAttr =
+    "tti.gsan_stream_clock";
 
 LLVM::LLVMFuncOp
 getOrCreateGSanRuntimeFunction(ConversionPatternRewriter &rewriter,
@@ -51,7 +58,10 @@ getOrCreateGSanRuntimeFunction(ConversionPatternRewriter &rewriter,
   auto *ctx = rewriter.getContext();
   SmallVector<Type> argTys;
   if (funcName == kGSanInitRuntimeFn) {
-    argTys = {ptr_ty(ctx), ptr_ty(ctx), i32_ty};
+    argTys = {ptr_ty(ctx), ptr_ty(ctx), i32_ty, ptr_ty(ctx), i32_ty};
+  } else if (funcName == kGSanKernelExitRuntimeFn ||
+             funcName == kGSanGridDependencyWaitRuntimeFn) {
+    argTys = {ptr_ty(ctx), ptr_ty(ctx), ptr_ty(ctx), i32_ty};
   } else if (funcName == kGSanLoadTensorRuntimeFn ||
              funcName == kGSanStoreTensorRuntimeFn) {
     argTys = {ptr_ty(ctx), ptr_ty(ctx), i32_ty, i32_ty, ptr_ty(ctx), i32_ty};
@@ -323,6 +333,23 @@ FailureOr<Value> getGSanGlobalStateArg(Operation *op,
     return arg;
   }
   return emitError(loc, "Unable to find gsan global state");
+}
+
+FailureOr<Value> getGSanStreamClockArg(Operation *op,
+                                       ConversionPatternRewriter &rewriter,
+                                       Location loc) {
+  auto funcOp = op->getParentOfType<FunctionOpInterface>();
+  for (unsigned i = 0; i < funcOp.getNumArguments(); ++i) {
+    if (!funcOp.getArgAttr(i, kGSanStreamClockArgAttr))
+      continue;
+    Value arg = funcOp.getArgument(i);
+    if (arg.getType() == ptr_ty(rewriter.getContext()))
+      return arg;
+    TritonLLVMOpBuilder b(loc, rewriter);
+    arg = b.addrspacecast(ptr_ty(rewriter.getContext()), arg);
+    return arg;
+  }
+  return emitError(loc, "Unable to find gsan stream clock");
 }
 
 static LLVM::LLVMStructType
@@ -823,15 +850,51 @@ public:
     auto gsanGlobalStatePtr = getGSanGlobalStateArg(op, rewriter, loc);
     if (failed(gsanGlobalStatePtr))
       return failure();
+    auto streamClockPtr = getGSanStreamClockArg(op, rewriter, loc);
+    if (failed(streamClockPtr))
+      return failure();
 
     auto runtimeFunc =
         getOrCreateGSanRuntimeFunction(rewriter, kGSanInitRuntimeFn);
 
     TritonLLVMOpBuilder b(loc, rewriter);
     auto sourceLoc = materializeSourceLocation(rewriter, loc);
-    b.call(runtimeFunc,
-           ValueRange{*gsanGlobalStatePtr, sourceLoc.file, sourceLoc.line});
+    b.call(runtimeFunc, ValueRange{*gsanGlobalStatePtr, *streamClockPtr,
+                                   b.i32_val(op.getAcquireStreamClock()),
+                                   sourceLoc.file, sourceLoc.line});
     b.barrier(ttg::AddrSpace::Local);
+    rewriter.eraseOp(op);
+    return success();
+  }
+};
+
+template <typename OpTy>
+struct GSanStreamClockOpConversion : public ConvertOpToLLVMPattern<OpTy> {
+  using ConvertOpToLLVMPattern<OpTy>::ConvertOpToLLVMPattern;
+
+  LogicalResult
+  matchAndRewrite(OpTy op, typename OpTy::Adaptor adaptor,
+                  ConversionPatternRewriter &rewriter) const override {
+    auto loc = op.getLoc();
+    auto gsanGlobalStatePtr = getGSanGlobalStateArg(op, rewriter, loc);
+    auto streamClockPtr = getGSanStreamClockArg(op, rewriter, loc);
+    if (failed(gsanGlobalStatePtr) || failed(streamClockPtr))
+      return failure();
+
+    StringRef runtimeFn;
+    if constexpr (std::is_same_v<OpTy, tti::ExperimentalGSanKernelExitOp>)
+      runtimeFn = kGSanKernelExitRuntimeFn;
+    else
+      runtimeFn = kGSanGridDependencyWaitRuntimeFn;
+    auto runtimeFunc = getOrCreateGSanRuntimeFunction(rewriter, runtimeFn);
+    TritonLLVMOpBuilder b(loc, rewriter);
+    if constexpr (std::is_same_v<OpTy, tti::ExperimentalGSanKernelExitOp>)
+      b.barrier(ttg::AddrSpace::Local);
+    auto sourceLoc = materializeSourceLocation(rewriter, loc);
+    b.call(runtimeFunc, ValueRange{*gsanGlobalStatePtr, *streamClockPtr,
+                                   sourceLoc.file, sourceLoc.line});
+    if constexpr (!std::is_same_v<OpTy, tti::ExperimentalGSanKernelExitOp>)
+      b.barrier(ttg::AddrSpace::Local);
     rewriter.eraseOp(op);
     return success();
   }
@@ -844,6 +907,10 @@ void mlir::triton::populateGSanToLLVMPatterns(
     ModuleAxisInfoAnalysis &axisInfoAnalysis,
     const TargetInfoBase &targetInfo) {
   patterns.add<GSanInitOpConversion>(typeConverter);
+  patterns.add<
+      GSanStreamClockOpConversion<tti::ExperimentalGSanKernelExitOp>,
+      GSanStreamClockOpConversion<tti::ExperimentalGSanGridDependencyWaitOp>>(
+      typeConverter);
   patterns.add<GSanTensorDescInfoOpConversion>(typeConverter);
   patterns.add<GSanAtomicPollOpConversion>(typeConverter, targetInfo);
   patterns.add<GSanAtomicCASOpConversion>(typeConverter, targetInfo);

--- a/lib/Conversion/TritonInstrumentToLLVM/GSanToLLVM.cpp
+++ b/lib/Conversion/TritonInstrumentToLLVM/GSanToLLVM.cpp
@@ -61,8 +61,10 @@ getOrCreateGSanRuntimeFunction(ConversionPatternRewriter &rewriter,
   if (funcName == kGSanInitRuntimeFn) {
     argTys = {ptr_ty(ctx), ptr_ty(ctx), i64_ty,      i32_ty, i32_ty,
               i32_ty,      i32_ty,      ptr_ty(ctx), i32_ty};
-  } else if (funcName == kGSanKernelExitRuntimeFn ||
-             funcName == kGSanGridDependencyWaitRuntimeFn) {
+  } else if (funcName == kGSanKernelExitRuntimeFn) {
+    argTys = {ptr_ty(ctx), ptr_ty(ctx), i64_ty,      i32_ty,
+              i32_ty,      i32_ty,      ptr_ty(ctx), i32_ty};
+  } else if (funcName == kGSanGridDependencyWaitRuntimeFn) {
     argTys = {ptr_ty(ctx), ptr_ty(ctx), i64_ty, i32_ty, i32_ty, i32_ty};
   } else if (funcName == kGSanLoadTensorRuntimeFn ||
              funcName == kGSanStoreTensorRuntimeFn) {
@@ -926,9 +928,13 @@ struct GSanStreamClockOpConversion : public ConvertOpToLLVMPattern<OpTy> {
     auto numThreads = b.i32_val(ttg::lookupNumWarps(op) *
                                 ttg::lookupThreadsPerWarp(rewriter));
     auto barrierId = b.i32_val(getGSanBarrierId(op));
-    b.call(runtimeFunc,
-           ValueRange{*gsanGlobalStatePtr, *streamClockPtr, *kernelId,
-                      threadIdx, numThreads, barrierId});
+    SmallVector<Value> args{*gsanGlobalStatePtr, *streamClockPtr, *kernelId,
+                            threadIdx,           numThreads,      barrierId};
+    if constexpr (std::is_same_v<OpTy, tti::ExperimentalGSanKernelExitOp>) {
+      auto sourceLoc = materializeSourceLocation(rewriter, loc);
+      args.append({sourceLoc.file, sourceLoc.line});
+    }
+    b.call(runtimeFunc, args);
     rewriter.eraseOp(op);
     return success();
   }

--- a/lib/Conversion/TritonInstrumentToLLVM/GSanToLLVM.cpp
+++ b/lib/Conversion/TritonInstrumentToLLVM/GSanToLLVM.cpp
@@ -922,8 +922,6 @@ struct GSanStreamClockOpConversion : public ConvertOpToLLVMPattern<OpTy> {
       runtimeFn = kGSanGridDependencyWaitRuntimeFn;
     auto runtimeFunc = getOrCreateGSanRuntimeFunction(rewriter, runtimeFn);
     TritonLLVMOpBuilder b(loc, rewriter);
-    if constexpr (std::is_same_v<OpTy, tti::ExperimentalGSanKernelExitOp>)
-      b.barrier(ttg::AddrSpace::Local);
     auto threadIdx = mlir::getThreadId(rewriter, loc);
     auto numThreads = b.i32_val(ttg::lookupNumWarps(op) *
                                 ttg::lookupThreadsPerWarp(rewriter));
@@ -931,8 +929,6 @@ struct GSanStreamClockOpConversion : public ConvertOpToLLVMPattern<OpTy> {
     b.call(runtimeFunc,
            ValueRange{*gsanGlobalStatePtr, *streamClockPtr, *kernelId,
                       threadIdx, numThreads, barrierId});
-    if constexpr (!std::is_same_v<OpTy, tti::ExperimentalGSanKernelExitOp>)
-      b.barrier(ttg::AddrSpace::Local);
     rewriter.eraseOp(op);
     return success();
   }

--- a/lib/Conversion/TritonInstrumentToLLVM/GSanToLLVM.cpp
+++ b/lib/Conversion/TritonInstrumentToLLVM/GSanToLLVM.cpp
@@ -1,6 +1,7 @@
 #include "mlir/Conversion/LLVMCommon/Pattern.h"
 #include "mlir/IR/ImplicitLocOpBuilder.h"
 #include "mlir/IR/TypeUtilities.h"
+#include "third_party/nvidia/include/Dialect/NVGPU/IR/Dialect.h"
 #include "third_party/nvidia/include/TritonNVIDIAGPUToLLVM/AtomicPTXBuilder.h"
 #include "third_party/nvidia/include/TritonNVIDIAGPUToLLVM/PTXAsmFormat.h"
 #include "triton/Conversion/TritonGPUToLLVM/PatternTritonGPUOpToLLVM.h"
@@ -365,17 +366,6 @@ FailureOr<Value> getGSanKernelIdArg(Operation *op,
       return funcOp.getArgument(i);
   }
   return emitError(loc, "Unable to find gsan kernel ID");
-}
-
-unsigned getGSanBarrierId(Operation *op) {
-  Region *region = op->getParentRegion();
-  while (region) {
-    Operation *parent = region->getParentOp();
-    if (isa<ttg::WarpSpecializePartitionsOp>(parent))
-      return region->getRegionNumber() + 2;
-    region = parent ? parent->getParentRegion() : nullptr;
-  }
-  return 0;
 }
 
 static LLVM::LLVMStructType
@@ -891,7 +881,7 @@ public:
     auto threadIdx = mlir::getThreadId(rewriter, loc);
     auto numThreads = b.i32_val(ttg::lookupNumWarps(op) *
                                 ttg::lookupThreadsPerWarp(rewriter));
-    auto barrierId = b.i32_val(getGSanBarrierId(op));
+    Value barrierId = tt::nvgpu::WarpGroupBarrierIdOp::create(rewriter, loc);
     b.call(runtimeFunc,
            ValueRange{*gsanGlobalStatePtr, *streamClockPtr, *kernelId,
                       b.i32_val(op.getAcquireStreamClock()), threadIdx,
@@ -927,7 +917,7 @@ struct GSanStreamClockOpConversion : public ConvertOpToLLVMPattern<OpTy> {
     auto threadIdx = mlir::getThreadId(rewriter, loc);
     auto numThreads = b.i32_val(ttg::lookupNumWarps(op) *
                                 ttg::lookupThreadsPerWarp(rewriter));
-    auto barrierId = b.i32_val(getGSanBarrierId(op));
+    Value barrierId = tt::nvgpu::WarpGroupBarrierIdOp::create(rewriter, loc);
     SmallVector<Value> args{*gsanGlobalStatePtr, *streamClockPtr, *kernelId,
                             threadIdx,           numThreads,      barrierId};
     if constexpr (std::is_same_v<OpTy, tti::ExperimentalGSanKernelExitOp>) {

--- a/lib/Conversion/TritonInstrumentToLLVM/GSanToLLVM.cpp
+++ b/lib/Conversion/TritonInstrumentToLLVM/GSanToLLVM.cpp
@@ -47,6 +47,7 @@ static constexpr StringLiteral kGSanGlobalStateArgAttr =
     "tti.gsan_global_state";
 static constexpr StringLiteral kGSanStreamClockArgAttr =
     "tti.gsan_stream_clock";
+static constexpr StringLiteral kGSanKernelIdArgAttr = "tti.gsan_kernel_id";
 
 LLVM::LLVMFuncOp
 getOrCreateGSanRuntimeFunction(ConversionPatternRewriter &rewriter,
@@ -58,10 +59,11 @@ getOrCreateGSanRuntimeFunction(ConversionPatternRewriter &rewriter,
   auto *ctx = rewriter.getContext();
   SmallVector<Type> argTys;
   if (funcName == kGSanInitRuntimeFn) {
-    argTys = {ptr_ty(ctx), ptr_ty(ctx), i32_ty, ptr_ty(ctx), i32_ty};
+    argTys = {ptr_ty(ctx), ptr_ty(ctx), i64_ty,      i32_ty, i32_ty,
+              i32_ty,      i32_ty,      ptr_ty(ctx), i32_ty};
   } else if (funcName == kGSanKernelExitRuntimeFn ||
              funcName == kGSanGridDependencyWaitRuntimeFn) {
-    argTys = {ptr_ty(ctx), ptr_ty(ctx), ptr_ty(ctx), i32_ty};
+    argTys = {ptr_ty(ctx), ptr_ty(ctx), i64_ty, i32_ty, i32_ty, i32_ty};
   } else if (funcName == kGSanLoadTensorRuntimeFn ||
              funcName == kGSanStoreTensorRuntimeFn) {
     argTys = {ptr_ty(ctx), ptr_ty(ctx), i32_ty, i32_ty, ptr_ty(ctx), i32_ty};
@@ -350,6 +352,28 @@ FailureOr<Value> getGSanStreamClockArg(Operation *op,
     return arg;
   }
   return emitError(loc, "Unable to find gsan stream clock");
+}
+
+FailureOr<Value> getGSanKernelIdArg(Operation *op,
+                                    ConversionPatternRewriter &rewriter,
+                                    Location loc) {
+  auto funcOp = op->getParentOfType<FunctionOpInterface>();
+  for (unsigned i = 0; i < funcOp.getNumArguments(); ++i) {
+    if (funcOp.getArgAttr(i, kGSanKernelIdArgAttr))
+      return funcOp.getArgument(i);
+  }
+  return emitError(loc, "Unable to find gsan kernel ID");
+}
+
+unsigned getGSanBarrierId(Operation *op) {
+  Region *region = op->getParentRegion();
+  while (region) {
+    Operation *parent = region->getParentOp();
+    if (isa<ttg::WarpSpecializePartitionsOp>(parent))
+      return region->getRegionNumber() + 2;
+    region = parent ? parent->getParentRegion() : nullptr;
+  }
+  return 0;
 }
 
 static LLVM::LLVMStructType
@@ -853,15 +877,23 @@ public:
     auto streamClockPtr = getGSanStreamClockArg(op, rewriter, loc);
     if (failed(streamClockPtr))
       return failure();
+    auto kernelId = getGSanKernelIdArg(op, rewriter, loc);
+    if (failed(kernelId))
+      return failure();
 
     auto runtimeFunc =
         getOrCreateGSanRuntimeFunction(rewriter, kGSanInitRuntimeFn);
 
     TritonLLVMOpBuilder b(loc, rewriter);
     auto sourceLoc = materializeSourceLocation(rewriter, loc);
-    b.call(runtimeFunc, ValueRange{*gsanGlobalStatePtr, *streamClockPtr,
-                                   b.i32_val(op.getAcquireStreamClock()),
-                                   sourceLoc.file, sourceLoc.line});
+    auto threadIdx = mlir::getThreadId(rewriter, loc);
+    auto numThreads = b.i32_val(ttg::lookupNumWarps(op) *
+                                ttg::lookupThreadsPerWarp(rewriter));
+    auto barrierId = b.i32_val(getGSanBarrierId(op));
+    b.call(runtimeFunc,
+           ValueRange{*gsanGlobalStatePtr, *streamClockPtr, *kernelId,
+                      b.i32_val(op.getAcquireStreamClock()), threadIdx,
+                      numThreads, barrierId, sourceLoc.file, sourceLoc.line});
     b.barrier(ttg::AddrSpace::Local);
     rewriter.eraseOp(op);
     return success();
@@ -878,7 +910,9 @@ struct GSanStreamClockOpConversion : public ConvertOpToLLVMPattern<OpTy> {
     auto loc = op.getLoc();
     auto gsanGlobalStatePtr = getGSanGlobalStateArg(op, rewriter, loc);
     auto streamClockPtr = getGSanStreamClockArg(op, rewriter, loc);
-    if (failed(gsanGlobalStatePtr) || failed(streamClockPtr))
+    auto kernelId = getGSanKernelIdArg(op, rewriter, loc);
+    if (failed(gsanGlobalStatePtr) || failed(streamClockPtr) ||
+        failed(kernelId))
       return failure();
 
     StringRef runtimeFn;
@@ -890,9 +924,13 @@ struct GSanStreamClockOpConversion : public ConvertOpToLLVMPattern<OpTy> {
     TritonLLVMOpBuilder b(loc, rewriter);
     if constexpr (std::is_same_v<OpTy, tti::ExperimentalGSanKernelExitOp>)
       b.barrier(ttg::AddrSpace::Local);
-    auto sourceLoc = materializeSourceLocation(rewriter, loc);
-    b.call(runtimeFunc, ValueRange{*gsanGlobalStatePtr, *streamClockPtr,
-                                   sourceLoc.file, sourceLoc.line});
+    auto threadIdx = mlir::getThreadId(rewriter, loc);
+    auto numThreads = b.i32_val(ttg::lookupNumWarps(op) *
+                                ttg::lookupThreadsPerWarp(rewriter));
+    auto barrierId = b.i32_val(getGSanBarrierId(op));
+    b.call(runtimeFunc,
+           ValueRange{*gsanGlobalStatePtr, *streamClockPtr, *kernelId,
+                      threadIdx, numThreads, barrierId});
     if constexpr (!std::is_same_v<OpTy, tti::ExperimentalGSanKernelExitOp>)
       b.barrier(ttg::AddrSpace::Local);
     rewriter.eraseOp(op);

--- a/lib/Dialect/TritonInstrument/Transforms/GlobalSanitizer.cpp
+++ b/lib/Dialect/TritonInstrument/Transforms/GlobalSanitizer.cpp
@@ -31,6 +31,7 @@ namespace {
 
 static constexpr const char kGSanGlobalStateArgAttr[] = "tti.gsan_global_state";
 static constexpr const char kGSanStreamClockArgAttr[] = "tti.gsan_stream_clock";
+static constexpr const char kGSanKernelIdArgAttr[] = "tti.gsan_kernel_id";
 static constexpr const char kDisableSetMaxRegisterAttr[] =
     "tti.disable_setmaxregister";
 
@@ -372,6 +373,7 @@ public:
     OpBuilder builder(module);
     Type gsanStatePtrTy = tt::PointerType::get(builder.getI8Type(), 1);
     Type streamClockPtrTy = tt::PointerType::get(builder.getI32Type(), 1);
+    Type kernelIdTy = builder.getI64Type();
     auto launchPdl = module->getAttrOfType<IntegerAttr>("tti.gsan_launch_pdl");
     bool acquireStreamClock = !launchPdl || launchPdl.getInt() == 0;
     DenseSet<StringRef> calledFuncs;
@@ -386,11 +388,13 @@ public:
                                  funcTy.getInputs().end());
       inputTys.push_back(gsanStatePtrTy);
       inputTys.push_back(streamClockPtrTy);
+      inputTys.push_back(kernelIdTy);
       func.setType(FunctionType::get(module.getContext(), inputTys,
                                      funcTy.getResults()));
 
       func.getBody().addArgument(gsanStatePtrTy, func.getLoc());
       func.getBody().addArgument(streamClockPtrTy, func.getLoc());
+      func.getBody().addArgument(kernelIdTy, func.getLoc());
       SmallVector<Attribute> newArgAttrs;
       if (auto argAttrs = func.getAllArgAttrs())
         newArgAttrs.append(argAttrs.begin(), argAttrs.end());
@@ -399,9 +403,11 @@ public:
       }
       if (!newArgAttrs.empty())
         func.setAllArgAttrs(newArgAttrs);
-      func.setArgAttr(func.getNumArguments() - 2, kGSanGlobalStateArgAttr,
+      func.setArgAttr(func.getNumArguments() - 3, kGSanGlobalStateArgAttr,
                       builder.getUnitAttr());
-      func.setArgAttr(func.getNumArguments() - 1, kGSanStreamClockArgAttr,
+      func.setArgAttr(func.getNumArguments() - 2, kGSanStreamClockArgAttr,
+                      builder.getUnitAttr());
+      func.setArgAttr(func.getNumArguments() - 1, kGSanKernelIdArgAttr,
                       builder.getUnitAttr());
 
       bool isEntry = !calledFuncs.contains(func.getSymName());
@@ -420,15 +426,17 @@ public:
     module.walk([&](tt::CallOp op) { callOps.push_back(op); });
     for (tt::CallOp callOp : callOps) {
       auto caller = callOp->getParentOfType<tt::FuncOp>();
-      assert(caller && caller.getNumArguments() >= 2 &&
+      assert(caller && caller.getNumArguments() >= 3 &&
              "expected triton.call to be nested under a Triton function");
 
       SmallVector<Value> operands(callOp.getOperands().begin(),
                                   callOp.getOperands().end());
-      Value gsanState = caller.getArgument(caller.getNumArguments() - 2);
-      Value streamClock = caller.getArgument(caller.getNumArguments() - 1);
+      Value gsanState = caller.getArgument(caller.getNumArguments() - 3);
+      Value streamClock = caller.getArgument(caller.getNumArguments() - 2);
+      Value kernelId = caller.getArgument(caller.getNumArguments() - 1);
       operands.push_back(getGSanStateForCall(callOp, gsanState));
       operands.push_back(getGSanStateForCall(callOp, streamClock));
+      operands.push_back(getGSanStateForCall(callOp, kernelId));
 
       OpBuilder b(callOp);
       auto newCallOp =

--- a/lib/Dialect/TritonInstrument/Transforms/GlobalSanitizer.cpp
+++ b/lib/Dialect/TritonInstrument/Transforms/GlobalSanitizer.cpp
@@ -30,6 +30,7 @@ namespace ttng = mlir::triton::nvidia_gpu;
 namespace {
 
 static constexpr const char kGSanGlobalStateArgAttr[] = "tti.gsan_global_state";
+static constexpr const char kGSanStreamClockArgAttr[] = "tti.gsan_stream_clock";
 static constexpr const char kDisableSetMaxRegisterAttr[] =
     "tti.disable_setmaxregister";
 
@@ -370,6 +371,9 @@ public:
     ModuleOp module = getOperation();
     OpBuilder builder(module);
     Type gsanStatePtrTy = tt::PointerType::get(builder.getI8Type(), 1);
+    Type streamClockPtrTy = tt::PointerType::get(builder.getI32Type(), 1);
+    auto launchPdl = module->getAttrOfType<IntegerAttr>("tti.gsan_launch_pdl");
+    bool acquireStreamClock = !launchPdl || launchPdl.getInt() == 0;
     DenseSet<StringRef> calledFuncs;
     module.walk(
         [&](tt::CallOp callOp) { calledFuncs.insert(callOp.getCallee()); });
@@ -381,10 +385,12 @@ public:
       SmallVector<Type> inputTys(funcTy.getInputs().begin(),
                                  funcTy.getInputs().end());
       inputTys.push_back(gsanStatePtrTy);
+      inputTys.push_back(streamClockPtrTy);
       func.setType(FunctionType::get(module.getContext(), inputTys,
                                      funcTy.getResults()));
 
       func.getBody().addArgument(gsanStatePtrTy, func.getLoc());
+      func.getBody().addArgument(streamClockPtrTy, func.getLoc());
       SmallVector<Attribute> newArgAttrs;
       if (auto argAttrs = func.getAllArgAttrs())
         newArgAttrs.append(argAttrs.begin(), argAttrs.end());
@@ -393,13 +399,20 @@ public:
       }
       if (!newArgAttrs.empty())
         func.setAllArgAttrs(newArgAttrs);
-      func.setArgAttr(func.getNumArguments() - 1, kGSanGlobalStateArgAttr,
+      func.setArgAttr(func.getNumArguments() - 2, kGSanGlobalStateArgAttr,
+                      builder.getUnitAttr());
+      func.setArgAttr(func.getNumArguments() - 1, kGSanStreamClockArgAttr,
                       builder.getUnitAttr());
 
       bool isEntry = !calledFuncs.contains(func.getSymName());
       if (isEntry) {
         OpBuilder b(&func.front(), func.front().begin());
-        ExperimentalGSanInitOp::create(b, func.getLoc());
+        ExperimentalGSanInitOp::create(b, func.getLoc(), acquireStreamClock);
+        func.walk([&](tt::ReturnOp returnOp) {
+          OpBuilder returnBuilder(returnOp);
+          ExperimentalGSanKernelExitOp::create(returnBuilder,
+                                               returnOp.getLoc());
+        });
       }
     }
 
@@ -407,13 +420,15 @@ public:
     module.walk([&](tt::CallOp op) { callOps.push_back(op); });
     for (tt::CallOp callOp : callOps) {
       auto caller = callOp->getParentOfType<tt::FuncOp>();
-      assert(caller && caller.getNumArguments() > 0 &&
+      assert(caller && caller.getNumArguments() >= 2 &&
              "expected triton.call to be nested under a Triton function");
 
       SmallVector<Value> operands(callOp.getOperands().begin(),
                                   callOp.getOperands().end());
-      Value gsanState = caller.getArgument(caller.getNumArguments() - 1);
+      Value gsanState = caller.getArgument(caller.getNumArguments() - 2);
+      Value streamClock = caller.getArgument(caller.getNumArguments() - 1);
       operands.push_back(getGSanStateForCall(callOp, gsanState));
+      operands.push_back(getGSanStateForCall(callOp, streamClock));
 
       OpBuilder b(callOp);
       auto newCallOp =
@@ -467,6 +482,10 @@ public:
             b.replaceOp(op, newOp);
           })
           .Case([&](tt::AtomicPollOp op) { instrumentAtomicPoll(op); })
+          .Case([&](tt::GridDependencyWaitOp op) {
+            b.setInsertionPointAfter(op);
+            ExperimentalGSanGridDependencyWaitOp::create(b, op.getLoc());
+          })
           .Case([&](ttg::WarpSpecializeOp op) {
             op->setAttr(kDisableSetMaxRegisterAttr, builder.getUnitAttr());
           });

--- a/python/src/ir.cc
+++ b/python/src/ir.cc
@@ -1880,6 +1880,12 @@ void init_triton_ir(py::module_ &m) {
            [](TritonOpBuilder &self, Value src, Value indices, int axis)
                -> Value { return self.create<GatherOp>(src, indices, axis); })
       // Force GPU barrier
+      .def("create_grid_dependency_wait",
+           [](TritonOpBuilder &self) { self.create<GridDependencyWaitOp>(); })
+      .def("create_grid_dependency_launch_dependents",
+           [](TritonOpBuilder &self) {
+             self.create<GridDependencyLaunchDependentsOp>();
+           })
       .def("create_barrier",
            [](TritonOpBuilder &self) {
              self.create<triton::gpu::BarrierOp>(triton::gpu::AddrSpace::All);

--- a/python/test/gsan/test_gsan.py
+++ b/python/test/gsan/test_gsan.py
@@ -176,13 +176,13 @@ def test_programmatic_dependent_launch_wait_synchronizes_vector_clocks(with_gsan
 
 
 @pytest.mark.skipif(not is_hopper_or_newer(), reason="PDL requires SM90 or newer")
-def test_programmatic_dependent_launch_sees_two_kernels_back_without_wait(with_gsan, capfd):
+def test_normal_launch_after_programmatic_dependent_launch_acquires_all_predecessors(with_gsan, capfd):
     payload = torch.zeros(2, dtype=torch.int32, device="cuda")
     result = torch.full((1, ), -1, dtype=torch.int32, device="cuda")
 
     _pdl_stage_kernel[(1, )](payload, INDEX=0, WAIT_PREDECESSOR=False, num_warps=1)
     _pdl_stage_kernel[(1, )](payload, INDEX=1, WAIT_PREDECESSOR=True, num_warps=1, launch_pdl=True)
-    _pdl_two_back_consumer_kernel[(1, )](payload, result, num_warps=1, launch_pdl=True)
+    _pdl_two_back_consumer_kernel[(1, )](payload, result, num_warps=1)
     torch.cuda.synchronize()
 
     torch.testing.assert_close(result, torch.tensor([1000], dtype=torch.int32, device="cuda"))

--- a/python/test/gsan/test_gsan.py
+++ b/python/test/gsan/test_gsan.py
@@ -214,12 +214,29 @@ def _gluon_ws_pdl_wait_worker(payload_ptr, result_ptr, layout: gl.constexpr):
     gl.store(result_ptr + offsets, values)
 
 
+@gluon.jit(noinline=True)
+def _gluon_ws_pdl_wait_noinline_worker(payload_ptr, result_ptr, layout: gl.constexpr):
+    tl.extra.cuda.gdc_wait()
+    offsets = gl.arange(0, 128, layout=layout)
+    values = gl.load(payload_ptr + offsets)
+    gl.store(result_ptr + offsets, values)
+
+
 @gluon.jit
 def _gluon_ws_pdl_wait_kernel(payload_ptr, result_ptr):
     layout: gl.constexpr = gl.BlockedLayout([1], [32], [4], [0])
     gl.warp_specialize([
         (_gluon_ws_pdl_wait_default, (payload_ptr, result_ptr, layout)),
         (_gluon_ws_pdl_wait_worker, (payload_ptr, result_ptr, layout)),
+    ], [4], [24])
+
+
+@gluon.jit
+def _gluon_ws_pdl_wait_noinline_kernel(payload_ptr, result_ptr):
+    layout: gl.constexpr = gl.BlockedLayout([1], [32], [4], [0])
+    gl.warp_specialize([
+        (_gluon_ws_pdl_wait_default, (payload_ptr, result_ptr, layout)),
+        (_gluon_ws_pdl_wait_noinline_worker, (payload_ptr, result_ptr, layout)),
     ], [4], [24])
 
 
@@ -252,6 +269,21 @@ def test_programmatic_dependent_launch_wait_inside_warp_specialize(with_gsan, ca
     torch.cuda.synchronize()
 
     torch.testing.assert_close(result, torch.arange(1000, 1128, device="cuda", dtype=torch.int32))
+    assert "griddepcontrol.wait" in compiled.asm["ptx"]
+    _assert_no_gsan_runtime_output(capfd)
+
+
+@pytest.mark.skipif(not is_hopper_or_newer(), reason="PDL requires SM90 or newer")
+def test_programmatic_dependent_launch_wait_inside_noinline_warp_specialize(with_gsan, capfd):
+    payload = torch.empty((128, ), dtype=torch.int32, device="cuda")
+    result = torch.full_like(payload, -1)
+
+    _pdl_producer_kernel[(128, )](payload, num_warps=1)
+    compiled = _gluon_ws_pdl_wait_noinline_kernel[(1, )](payload, result, num_warps=4, launch_pdl=True)
+    torch.cuda.synchronize()
+
+    torch.testing.assert_close(result, torch.arange(1000, 1128, device="cuda", dtype=torch.int32))
+    assert "tt.call" in compiled.asm["ttgir"]
     assert "griddepcontrol.wait" in compiled.asm["ptx"]
     _assert_no_gsan_runtime_output(capfd)
 

--- a/python/test/gsan/test_gsan.py
+++ b/python/test/gsan/test_gsan.py
@@ -146,6 +146,20 @@ def _pdl_consumer_kernel(payload_ptr, result_ptr):
     tl.store(result_ptr + pid, value)
 
 
+@triton.jit
+def _pdl_stage_kernel(payload_ptr, INDEX: tl.constexpr, WAIT_PREDECESSOR: tl.constexpr):
+    if WAIT_PREDECESSOR:
+        tl.extra.cuda.gdc_wait()
+    tl.store(payload_ptr + INDEX, 1000 + INDEX)
+    tl.extra.cuda.gdc_launch_dependents()
+
+
+@triton.jit
+def _pdl_two_back_consumer_kernel(payload_ptr, result_ptr):
+    value = tl.load(payload_ptr)
+    tl.store(result_ptr, value)
+
+
 @pytest.mark.skipif(not is_hopper_or_newer(), reason="PDL requires SM90 or newer")
 def test_programmatic_dependent_launch_wait_synchronizes_vector_clocks(with_gsan, capfd):
     payload = torch.zeros(2, dtype=torch.int32, device="cuda")
@@ -161,6 +175,20 @@ def test_programmatic_dependent_launch_wait_synchronizes_vector_clocks(with_gsan
     _assert_no_gsan_runtime_output(capfd)
 
 
+@pytest.mark.skipif(not is_hopper_or_newer(), reason="PDL requires SM90 or newer")
+def test_programmatic_dependent_launch_sees_two_kernels_back_without_wait(with_gsan, capfd):
+    payload = torch.zeros(2, dtype=torch.int32, device="cuda")
+    result = torch.full((1, ), -1, dtype=torch.int32, device="cuda")
+
+    _pdl_stage_kernel[(1, )](payload, INDEX=0, WAIT_PREDECESSOR=False, num_warps=1)
+    _pdl_stage_kernel[(1, )](payload, INDEX=1, WAIT_PREDECESSOR=True, num_warps=1, launch_pdl=True)
+    _pdl_two_back_consumer_kernel[(1, )](payload, result, num_warps=1, launch_pdl=True)
+    torch.cuda.synchronize()
+
+    torch.testing.assert_close(result, torch.tensor([1000], dtype=torch.int32, device="cuda"))
+    _assert_no_gsan_runtime_output(capfd)
+
+
 @gluon.jit
 def _gluon_ws_completion_default(out_ptr, layout: gl.constexpr):
     offsets = gl.arange(0, 128, layout=layout)
@@ -171,6 +199,28 @@ def _gluon_ws_completion_default(out_ptr, layout: gl.constexpr):
 def _gluon_ws_completion_worker(out_ptr, layout: gl.constexpr):
     offsets = 128 + gl.arange(0, 128, layout=layout)
     gl.store(out_ptr + offsets, offsets)
+
+
+@gluon.jit
+def _gluon_ws_pdl_wait_default(payload_ptr, result_ptr, layout: gl.constexpr):
+    pass
+
+
+@gluon.jit
+def _gluon_ws_pdl_wait_worker(payload_ptr, result_ptr, layout: gl.constexpr):
+    tl.extra.cuda.gdc_wait()
+    offsets = gl.arange(0, 128, layout=layout)
+    values = gl.load(payload_ptr + offsets)
+    gl.store(result_ptr + offsets, values)
+
+
+@gluon.jit
+def _gluon_ws_pdl_wait_kernel(payload_ptr, result_ptr):
+    layout: gl.constexpr = gl.BlockedLayout([1], [32], [4], [0])
+    gl.warp_specialize([
+        (_gluon_ws_pdl_wait_default, (payload_ptr, result_ptr, layout)),
+        (_gluon_ws_pdl_wait_worker, (payload_ptr, result_ptr, layout)),
+    ], [4], [24])
 
 
 @gluon.jit
@@ -190,6 +240,20 @@ def test_gluon_warp_specialize_completes(with_gsan):
     _gluon_ws_completion_kernel[(1, )](out, num_warps=4)
     torch.cuda.synchronize()
     torch.testing.assert_close(out, expected)
+
+
+@pytest.mark.skipif(not is_hopper_or_newer(), reason="PDL requires SM90 or newer")
+def test_programmatic_dependent_launch_wait_inside_warp_specialize(with_gsan, capfd):
+    payload = torch.empty((128, ), dtype=torch.int32, device="cuda")
+    result = torch.full_like(payload, -1)
+
+    _pdl_producer_kernel[(128, )](payload, num_warps=1)
+    compiled = _gluon_ws_pdl_wait_kernel[(1, )](payload, result, num_warps=4, launch_pdl=True)
+    torch.cuda.synchronize()
+
+    torch.testing.assert_close(result, torch.arange(1000, 1128, device="cuda", dtype=torch.int32))
+    assert "griddepcontrol.wait" in compiled.asm["ptx"]
+    _assert_no_gsan_runtime_output(capfd)
 
 
 @gluon.jit

--- a/python/test/gsan/test_gsan.py
+++ b/python/test/gsan/test_gsan.py
@@ -131,6 +131,26 @@ def test_load_store_updates_shadow(with_gsan):
     assert cell1.num_reads == 1
 
 
+@pytest.mark.skipif(not is_cuda(), reason="GSan requires CUDA")
+def test_cuda_graph_capture_is_rejected(with_gsan):
+    target = torch.zeros(1, dtype=torch.int32, device="cuda")
+    scratch = torch.zeros_like(target)
+    load_one_i32[(1, )](target, scratch, num_warps=1)
+    torch.cuda.synchronize()
+
+    cuda_utils = triton.runtime.driver.active.utils
+    assert not cuda_utils.is_stream_capturing(torch.cuda.current_stream().cuda_stream)
+
+    graph = torch.cuda.CUDAGraph()
+    with torch.cuda.graph(graph):
+        scratch.zero_()
+        assert cuda_utils.is_stream_capturing(torch.cuda.current_stream().cuda_stream)
+        with pytest.raises(RuntimeError, match="GSan does not support CUDA graph capture"):
+            load_one_i32[(1, )](target, scratch, num_warps=1)
+
+    assert not cuda_utils.is_stream_capturing(torch.cuda.current_stream().cuda_stream)
+
+
 @triton.jit
 def _pdl_producer_kernel(payload_ptr):
     pid = tl.program_id(0)

--- a/python/test/gsan/test_gsan.py
+++ b/python/test/gsan/test_gsan.py
@@ -131,6 +131,36 @@ def test_load_store_updates_shadow(with_gsan):
     assert cell1.num_reads == 1
 
 
+@triton.jit
+def _pdl_producer_kernel(payload_ptr):
+    pid = tl.program_id(0)
+    tl.store(payload_ptr + pid, 1000 + pid)
+    tl.extra.cuda.gdc_launch_dependents()
+
+
+@triton.jit
+def _pdl_consumer_kernel(payload_ptr, result_ptr):
+    tl.extra.cuda.gdc_wait()
+    pid = tl.program_id(0)
+    value = tl.load(payload_ptr + pid)
+    tl.store(result_ptr + pid, value)
+
+
+@pytest.mark.skipif(not is_hopper_or_newer(), reason="PDL requires SM90 or newer")
+def test_programmatic_dependent_launch_wait_synchronizes_vector_clocks(with_gsan, capfd):
+    payload = torch.zeros(2, dtype=torch.int32, device="cuda")
+    result = torch.full_like(payload, -1)
+
+    _pdl_producer_kernel[(2, )](payload, num_warps=1)
+    compiled = _pdl_consumer_kernel[(2, )](payload, result, num_warps=1, launch_pdl=True)
+    torch.cuda.synchronize()
+
+    torch.testing.assert_close(result, torch.tensor([1000, 1001], device="cuda", dtype=torch.int32))
+    assert "griddepcontrol.wait" in compiled.asm["ptx"]
+    assert "red.relaxed.gpu.max.u32" in compiled.asm["ptx"]
+    _assert_no_gsan_runtime_output(capfd)
+
+
 @gluon.jit
 def _gluon_ws_completion_default(out_ptr, layout: gl.constexpr):
     offsets = gl.arange(0, 128, layout=layout)

--- a/python/test/gsan/test_gsan_failures.py
+++ b/python/test/gsan/test_gsan_failures.py
@@ -87,6 +87,13 @@ def _pdl_consumer_without_wait_kernel(payload_ptr, scratch_ptr):
 
 
 @triton.jit
+def _pdl_conditional_wait_kernel(should_wait_ptr, scratch_ptr):
+    if tl.load(should_wait_ptr) != 0:
+        tl.extra.cuda.gdc_wait()
+    tl.store(scratch_ptr, 1)
+
+
+@triton.jit
 def _pdl_transitively_acquired_producer_kernel(payload_ptr, flag_ptr):
     pid = tl.program_id(0)
     if pid == 0:
@@ -298,6 +305,16 @@ def _run_pdl_without_wait_case() -> None:
 
 
 @run_with_gsan
+def _run_pdl_missing_wait_case() -> None:
+    payload = torch.zeros(1, dtype=torch.int32, device="cuda")
+    should_wait = torch.zeros(1, dtype=torch.int32, device="cuda")
+    scratch = torch.zeros(1, dtype=torch.int32, device="cuda")
+    _pdl_producer_kernel[(1, )](payload, num_warps=1)
+    _pdl_conditional_wait_kernel[(1, )](should_wait, scratch, num_warps=1, launch_pdl=True)
+    torch.cuda.synchronize()
+
+
+@run_with_gsan
 def _run_pdl_persistent_state_without_wait_case() -> None:
     num_sms = torch.cuda.get_device_properties(torch.cuda.current_device()).multi_processor_count
     payload = torch.zeros(1, dtype=torch.int32, device="cuda")
@@ -500,6 +517,17 @@ def test_write_after_read():
 def test_write_after_write():
     _run_failure_case("waw", runner=_run_waw_case, source_function=_waw_kernel.fn, marker="tl.store(ptr, 2)",
                       error="Write after write race detected")
+
+
+@pytest.mark.skipif(not is_hopper_or_newer(), reason="PDL requires SM90 or newer")
+def test_programmatic_dependent_launch_requires_wait():
+    _run_failure_case(
+        "pdl_missing_wait",
+        runner=_run_pdl_missing_wait_case,
+        source_function=_pdl_conditional_wait_kernel.fn,
+        marker="def _pdl_conditional_wait_kernel",
+        error="kernel launched with programmatic dependent launch did not call gdc_wait",
+    )
 
 
 @pytest.mark.skipif(not is_hopper_or_newer(), reason="PDL requires SM90 or newer")

--- a/python/test/gsan/test_gsan_failures.py
+++ b/python/test/gsan/test_gsan_failures.py
@@ -87,6 +87,23 @@ def _pdl_consumer_without_wait_kernel(payload_ptr, scratch_ptr):
 
 
 @triton.jit
+def _pdl_transitively_acquired_producer_kernel(payload_ptr, flag_ptr):
+    pid = tl.program_id(0)
+    if pid == 0:
+        tl.store(payload_ptr, 1000)
+        tl.atomic_xchg(flag_ptr, 1, sem="release", scope="gpu")
+    else:
+        atomic_poll(flag_ptr, 1, sem="acquire", scope="gpu")
+    tl.extra.cuda.gdc_launch_dependents()
+
+
+@triton.jit
+def _pdl_transitively_acquired_consumer_without_wait_kernel(payload_ptr, scratch_ptr):
+    value = tl.load(payload_ptr)
+    tl.store(scratch_ptr + tl.program_id(0), value)
+
+
+@triton.jit
 def _cross_sm_atomic_sync_kernel(payload_ptr, flag_ptr, counter_ptr, scratch_ptr, producer_sem: tl.constexpr,
                                  consumer_sem: tl.constexpr, scope: tl.constexpr):
     pid = tl.program_id(0)
@@ -277,6 +294,17 @@ def _run_pdl_without_wait_case() -> None:
     scratch = torch.zeros(1, dtype=torch.int32, device="cuda")
     _pdl_producer_kernel[(2, )](payload, num_warps=1)
     _pdl_consumer_without_wait_kernel[(1, )](payload, scratch, num_warps=1, launch_pdl=True)
+    torch.cuda.synchronize()
+
+
+@run_with_gsan
+def _run_pdl_persistent_state_without_wait_case() -> None:
+    num_sms = torch.cuda.get_device_properties(torch.cuda.current_device()).multi_processor_count
+    payload = torch.zeros(1, dtype=torch.int32, device="cuda")
+    flag = torch.zeros(1, dtype=torch.int32, device="cuda")
+    scratch = torch.zeros(num_sms, dtype=torch.int32, device="cuda")
+    _pdl_transitively_acquired_producer_kernel[(num_sms, )](payload, flag, num_warps=1)
+    _pdl_transitively_acquired_consumer_without_wait_kernel[(num_sms, )](payload, scratch, num_warps=1, launch_pdl=True)
     torch.cuda.synchronize()
 
 
@@ -481,6 +509,17 @@ def test_programmatic_dependent_launch_without_wait_reports_race():
         runner=_run_pdl_without_wait_case,
         source_function=_pdl_consumer_without_wait_kernel.fn,
         marker="value = tl.load(payload_ptr + 1)",
+        error="Read after write race detected",
+    )
+
+
+@pytest.mark.skipif(not is_hopper_or_newer(), reason="PDL requires SM90 or newer")
+def test_programmatic_dependent_launch_does_not_inherit_persistent_sm_dependencies():
+    _run_failure_case(
+        "pdl_persistent_state_without_wait",
+        runner=_run_pdl_persistent_state_without_wait_case,
+        source_function=_pdl_transitively_acquired_consumer_without_wait_kernel.fn,
+        marker="value = tl.load(payload_ptr)",
         error="Read after write race detected",
     )
 

--- a/python/test/gsan/test_gsan_failures.py
+++ b/python/test/gsan/test_gsan_failures.py
@@ -9,7 +9,7 @@ import torch
 import triton
 import triton.language as tl
 
-from triton._internal_testing import is_blackwell, is_cuda, run_in_process
+from triton._internal_testing import is_blackwell, is_cuda, is_hopper_or_newer, run_in_process
 from triton.experimental.gsan import create_mem_pool
 from triton.experimental.gsan._testing_utils import atomic_poll
 from triton.tools.tensor_descriptor import TensorDescriptor
@@ -71,6 +71,19 @@ def _waw_kernel(ptr, scratch_ptr, counter_ptr):
     else:
         atomic_poll(counter_ptr, 1)
         tl.store(ptr, 2)
+
+
+@triton.jit
+def _pdl_producer_kernel(payload_ptr):
+    pid = tl.program_id(0)
+    tl.store(payload_ptr + pid, 1000 + pid)
+    tl.extra.cuda.gdc_launch_dependents()
+
+
+@triton.jit
+def _pdl_consumer_without_wait_kernel(payload_ptr, scratch_ptr):
+    value = tl.load(payload_ptr + 1)
+    tl.store(scratch_ptr, value)
 
 
 @triton.jit
@@ -256,6 +269,15 @@ def _run_waw_case() -> None:
     scratch = torch.zeros(1, dtype=torch.int32, device="cuda")
     counter = torch.zeros(1, dtype=torch.int32, device="cuda")
     _waw_kernel[(2, )](target, scratch, counter, num_warps=1)
+
+
+@run_with_gsan
+def _run_pdl_without_wait_case() -> None:
+    payload = torch.zeros(2, dtype=torch.int32, device="cuda")
+    scratch = torch.zeros(1, dtype=torch.int32, device="cuda")
+    _pdl_producer_kernel[(2, )](payload, num_warps=1)
+    _pdl_consumer_without_wait_kernel[(1, )](payload, scratch, num_warps=1, launch_pdl=True)
+    torch.cuda.synchronize()
 
 
 @run_with_gsan
@@ -450,6 +472,17 @@ def test_write_after_read():
 def test_write_after_write():
     _run_failure_case("waw", runner=_run_waw_case, source_function=_waw_kernel.fn, marker="tl.store(ptr, 2)",
                       error="Write after write race detected")
+
+
+@pytest.mark.skipif(not is_hopper_or_newer(), reason="PDL requires SM90 or newer")
+def test_programmatic_dependent_launch_without_wait_reports_race():
+    _run_failure_case(
+        "pdl_without_wait",
+        runner=_run_pdl_without_wait_case,
+        source_function=_pdl_consumer_without_wait_kernel.fn,
+        marker="value = tl.load(payload_ptr + 1)",
+        error="Read after write race detected",
+    )
 
 
 def test_mixed_scope_release_rmw_accumulation():

--- a/python/test/gsan/test_symmetric_memory.py
+++ b/python/test/gsan/test_symmetric_memory.py
@@ -11,10 +11,8 @@ import triton
 import triton.language as tl
 
 from triton._internal_testing import is_cuda, run_in_process
-from triton.experimental.gsan import symmetric_memory
-from triton.experimental.gsan._allocator import get_runtime_state_layout
+from triton.experimental.gsan import _stream_sync, symmetric_memory
 from triton.experimental.gsan._testing_utils import atomic_poll, shadow_cell_from_address, shadow_tensor_for, SHADOW_GRANULARITY_BYTES
-from triton.experimental.gsan._utils import uint8_cuda_tensor_from_ptr
 
 
 def _get_free_tcp_port() -> int:
@@ -23,20 +21,22 @@ def _get_free_tcp_port() -> int:
         return int(sock.getsockname()[1])
 
 
-def _vector_clocks(runtime_state_device: int, access_device: int) -> tuple[torch.Tensor, dict[str, int]]:
-    layout = get_runtime_state_layout(runtime_state_device)
-    region_size = layout["thread_state_stride_bytes"] * layout["num_sms"]
-    region = uint8_cuda_tensor_from_ptr(layout["thread_state_base_ptr"], region_size, access_device)
-    clocks = torch.as_strided(
-        region.view(torch.uint16)[layout["thread_state_header_size_bytes"] // 2:],
-        size=(layout["num_sms"], layout["num_threads"]),
-        stride=(layout["thread_state_stride_bytes"] // 2, 1),
-    )
-    return clocks, layout
+def _assert_barrier_synchronizes_stream_clocks(hdl, device_index: int, group: dist.ProcessGroup) -> None:
+    stream = torch.cuda.current_stream(device_index)
+    stream_state = _stream_sync._launch_stream_state(device_index, stream.cuda_stream)
+    kernel_id = stream_state.next_kernel_id
+    assert kernel_id > 0
 
+    previous_clock = stream_state.clocks[(kernel_id - 1) % 3].cpu()
+    peer_clocks = [None] * hdl.world_size
+    dist.all_gather_object(peer_clocks, previous_clock, group=group)
 
-def _local_vector_clocks(device_index: int) -> tuple[torch.Tensor, dict[str, int]]:
-    return _vector_clocks(device_index, device_index)
+    hdl.barrier(channel=0)
+
+    assert stream_state.next_kernel_id == kernel_id + 1
+    synced_clock = stream_state.clocks[kernel_id % 3].cpu()
+    expected_clock = torch.stack(peer_clocks).amax(dim=0)
+    assert torch.all(synced_clock >= expected_clock).item()
 
 
 @triton.jit
@@ -63,6 +63,12 @@ def _single_cta_no_atomic_sync_kernel(payload_ptr, peer_payload_ptr, seen_peer_p
 @triton.jit
 def _store_scalar_kernel(peer_buf, byte_offset, value):
     tl.store(peer_buf + byte_offset, value)
+
+
+@triton.jit
+def _load_scalar_kernel(buf, byte_offset, out):
+    value = tl.load(buf + byte_offset)
+    tl.store(out, value)
 
 
 def _run_symmetric_memory_checks(rank: int, world_size: int) -> None:
@@ -103,15 +109,7 @@ def _run_symmetric_memory_checks(rank: int, world_size: int) -> None:
     if rank == 1:
         assert torch.all(local_shadow == 29).item()
 
-    local_clocks, layout = _local_vector_clocks(rank)
-    local_clocks.zero_()
-    local_tid = rank * layout["num_sms"]
-    peer_tid = peer * layout["num_sms"]
-    local_clocks[0, local_tid] = rank + 11
-    hdl.barrier(channel=0)
-    synced_clocks, _ = _local_vector_clocks(rank)
-    assert torch.all(synced_clocks[:, local_tid] == (rank + 11)).item()
-    assert torch.all(synced_clocks[:, peer_tid] == (peer + 11)).item()
+    _assert_barrier_synchronizes_stream_clocks(hdl, rank, dist.group.WORLD)
 
     del peer_buf
     del local_shadow
@@ -232,10 +230,16 @@ def _run_multi_node_simulated_symmetric_memory_checks(rank: int, world_size: int
     untouched_shadow_before = shadow_cell_from_address(buf.data_ptr() + untouched_shadow_offset,
                                                        device_index=device_index)
 
-    _store_scalar_kernel[(1, )](peer_buf, outgoing_shadow_offset, rank + 151, num_warps=1)
-    torch.cuda.synchronize()
-    hdl.barrier(channel=0)
-    dist.barrier()
+    stream = torch.cuda.Stream(device=dev)
+    seen_after_barrier = torch.empty((1, ), dtype=torch.uint8, device=dev)
+    with torch.cuda.stream(stream):
+        _store_scalar_kernel[(1, )](peer_buf, outgoing_shadow_offset, rank + 151, num_warps=1)
+        torch.cuda.synchronize()
+        hdl.barrier(channel=0)
+        dist.barrier()
+        _load_scalar_kernel[(1, )](buf, incoming_shadow_offset, seen_after_barrier, num_warps=1)
+        torch.cuda.synchronize()
+    assert int(seen_after_barrier.item()) == prev + 151
 
     incoming_shadow_after = shadow_cell_from_address(buf.data_ptr() + incoming_shadow_offset, device_index=device_index)
     untouched_shadow_after = shadow_cell_from_address(buf.data_ptr() + untouched_shadow_offset,
@@ -246,16 +250,7 @@ def _run_multi_node_simulated_symmetric_memory_checks(rank: int, world_size: int
     assert incoming_shadow_after.write_clock.epoch != 0
     assert untouched_shadow_after == untouched_shadow_before
 
-    local_clocks, layout = _vector_clocks(rank, device_index)
-    local_clocks.zero_()
-    local_tid = rank * layout["num_sms"]
-    local_clocks[0, local_tid] = rank + 211
-    hdl.barrier(channel=0)
-
-    synced_clocks, _ = _vector_clocks(rank, device_index)
-    for global_rank in range(world_size):
-        tid = global_rank * layout["num_sms"]
-        assert torch.all(synced_clocks[:, tid] == (global_rank + 211)).item()
+    _assert_barrier_synchronizes_stream_clocks(hdl, device_index, dist.group.WORLD)
 
     del peer_buf
     torch.cuda.synchronize()

--- a/python/triton/experimental/gsan/__init__.py
+++ b/python/triton/experimental/gsan/__init__.py
@@ -1,5 +1,4 @@
 from ._allocator import ShareableHandleType, configure, create_mem_pool, freeze_config, get_allocator
-from ._stream_sync import warmup_gsan_kernels
 
 __all__ = [
     "ShareableHandleType",
@@ -7,7 +6,6 @@ __all__ = [
     "create_mem_pool",
     "freeze_config",
     "get_allocator",
-    "warmup_gsan_kernels",
 ]
 
 _LAZY_LOAD_MODULES = {"symmetric_memory"}

--- a/python/triton/experimental/gsan/_stream_sync.py
+++ b/python/triton/experimental/gsan/_stream_sync.py
@@ -34,6 +34,17 @@ def _runtime_state_layout(runtime_state_device: int, access_device: int) -> _Run
     )
 
 
+@functools.lru_cache()
+def get_launch_stream_clock(device: int, stream: int):
+    """Return the persistent completion clock for one CUDA launch stream."""
+    import torch
+
+    layout = _runtime_state_layout(get_device_rank(device), device)
+    cuda_stream = torch.cuda.ExternalStream(stream, device=device) if stream else torch.cuda.default_stream(device)
+    with torch.cuda.device(device), torch.cuda.stream(cuda_stream):
+        return torch.zeros(layout.num_threads, dtype=torch.int32, device=device)
+
+
 @contextmanager
 def _compile_without_gsan():
     with triton.knobs.compilation.scope():

--- a/python/triton/experimental/gsan/_stream_sync.py
+++ b/python/triton/experimental/gsan/_stream_sync.py
@@ -1,7 +1,6 @@
 from __future__ import annotations
 
 import functools
-from contextlib import contextmanager
 from dataclasses import dataclass
 
 import triton
@@ -59,70 +58,15 @@ def get_launch_stream_clock(device: int, stream: int):
     return state.clocks, kernel_id
 
 
-@contextmanager
-def _compile_without_gsan():
+@triton.jit(do_not_specialize=["rank", "epoch"])
+def _synchronize_process_group_barrier_kernel(counters, rank, epoch, WORLD_SIZE: tl.constexpr):
+    tl.atomic_xchg(counters + rank, epoch, sem="release", scope="sys")
+    for peer in tl.static_range(WORLD_SIZE):
+        tl.atomic_poll(counters + peer, epoch, sem="acquire", scope="sys")
+
+
+def synchronize_process_group_barrier(counters, rank: int, epoch: int, world_size: int) -> None:
+    """Synchronize all ranks through an instrumented system-scope atomic."""
     with triton.knobs.compilation.scope():
-        triton.knobs.compilation.instrumentation_mode = ""
-        yield
-
-
-def _check_compatible_runtime_state_layout(lhs: _RuntimeStateLayout, rhs: _RuntimeStateLayout) -> None:
-    if (lhs.thread_state_stride_bytes != rhs.thread_state_stride_bytes
-            or lhs.thread_state_header_size_bytes != rhs.thread_state_header_size_bytes or lhs.num_sms != rhs.num_sms
-            or lhs.num_threads != rhs.num_threads):
-        raise RuntimeError("GSan runtime state layout mismatch across synchronized devices.")
-
-
-@triton.jit
-def _synchronize_process_group_barrier_kernel(local_thread_state_region, peer_thread_state_regions, stride_bytes,
-                                              num_sms, num_threads, header_bytes, BLOCK_SIZE: tl.constexpr,
-                                              N_PEERS: tl.constexpr):
-    pid = tl.program_id(axis=0)
-    offsets = pid * BLOCK_SIZE + tl.arange(0, BLOCK_SIZE)
-    mask = offsets < num_threads
-    max_clocks = tl.full([BLOCK_SIZE], 0, tl.uint16)
-
-    for peer in tl.static_range(N_PEERS):
-        peer_thread_state_region = peer_thread_state_regions[peer]
-        # Each rank first collapses its local per-SM clocks, so every SM on a peer
-        # carries the same vector clock at this point. Reading SM0 is sufficient.
-        vector_clock_ptr = (peer_thread_state_region + header_bytes).to(tl.pointer_type(tl.uint16))
-        peer_clocks = tl.load(vector_clock_ptr + offsets, mask=mask, other=0)
-        max_clocks = tl.maximum(peer_clocks, max_clocks)
-
-    for sm in range(num_sms):
-        vector_clock_ptr = (local_thread_state_region + sm * stride_bytes + header_bytes).to(tl.pointer_type(tl.uint16))
-        tl.store(vector_clock_ptr + offsets, max_clocks, mask=mask)
-
-
-def synchronize_process_group_barrier(device: int, peer_devices: tuple[int, ...]) -> None:
-    """Join vector clocks across the devices participating in a process-group barrier.
-
-    The peer runtime-state mappings are already imported by symmetric-memory rendezvous.
-    This helper computes the elementwise maximum of all participating devices' per-SM
-    vector clocks and writes that join back into the local device's per-SM state.
-    """
-    if not peer_devices:
-        return
-
-    local_layout = _runtime_state_layout(get_device_rank(device), device)
-    peer_regions = []
-    for peer_device in peer_devices:
-        peer_layout = _runtime_state_layout(peer_device, device)
-        _check_compatible_runtime_state_layout(local_layout, peer_layout)
-        peer_regions.append(peer_layout.thread_state_region)
-
-    BLOCK_SIZE = 128
-    grid = (triton.cdiv(local_layout.num_threads, BLOCK_SIZE), 1, 1)
-    with _compile_without_gsan():
-        _synchronize_process_group_barrier_kernel[grid](
-            local_layout.thread_state_region,
-            tuple(peer_regions),
-            local_layout.thread_state_stride_bytes,
-            local_layout.num_sms,
-            local_layout.num_threads,
-            local_layout.thread_state_header_size_bytes,
-            BLOCK_SIZE=BLOCK_SIZE,
-            N_PEERS=len(peer_regions),
-            num_warps=1,
-        )
+        triton.knobs.compilation.instrumentation_mode = "gsan"
+        _synchronize_process_group_barrier_kernel[(1, )](counters, rank, epoch, WORLD_SIZE=world_size, num_warps=1)

--- a/python/triton/experimental/gsan/_stream_sync.py
+++ b/python/triton/experimental/gsan/_stream_sync.py
@@ -20,6 +20,12 @@ class _RuntimeStateLayout:
     num_threads: int
 
 
+@dataclass
+class _LaunchStreamState:
+    clocks: object
+    next_kernel_id: int = 0
+
+
 @functools.lru_cache()
 def _runtime_state_layout(runtime_state_device: int, access_device: int) -> _RuntimeStateLayout:
     layout = get_runtime_state_layout(runtime_state_device)
@@ -35,14 +41,22 @@ def _runtime_state_layout(runtime_state_device: int, access_device: int) -> _Run
 
 
 @functools.lru_cache()
-def get_launch_stream_clock(device: int, stream: int):
-    """Return the persistent completion clock for one CUDA launch stream."""
+def _launch_stream_state(device: int, stream: int) -> _LaunchStreamState:
     import torch
 
     layout = _runtime_state_layout(get_device_rank(device), device)
     cuda_stream = torch.cuda.ExternalStream(stream, device=device) if stream else torch.cuda.default_stream(device)
     with torch.cuda.device(device), torch.cuda.stream(cuda_stream):
-        return torch.zeros(layout.num_threads, dtype=torch.int32, device=device)
+        clocks = torch.zeros((3, layout.num_threads), dtype=torch.int32, device=device)
+    return _LaunchStreamState(clocks=clocks)
+
+
+def get_launch_stream_clock(device: int, stream: int):
+    """Return a stream's triple-buffered clocks and monotonically increasing launch ID."""
+    state = _launch_stream_state(device, stream)
+    kernel_id = state.next_kernel_id
+    state.next_kernel_id += 1
+    return state.clocks, kernel_id
 
 
 @contextmanager
@@ -50,39 +64,6 @@ def _compile_without_gsan():
     with triton.knobs.compilation.scope():
         triton.knobs.compilation.instrumentation_mode = ""
         yield
-
-
-def warmup_gsan_kernels() -> None:
-    """Compile GSan support kernels without initializing the GSan runtime."""
-    with _compile_without_gsan():
-        _synchronize_vector_clocks_kernel.warmup(
-            triton.MockTensor(tl.uint8),
-            0,
-            0,
-            0,
-            0,
-            BLOCK_SIZE=128,
-            grid=(1, ),
-            num_warps=1,
-        )
-
-
-@triton.jit(do_not_specialize=["stride_bytes", "num_sms", "num_threads", "header_bytes"])
-def _synchronize_vector_clocks_kernel(thread_state_region, stride_bytes, num_sms, num_threads, header_bytes,
-                                      BLOCK_SIZE: tl.constexpr):
-    pid = tl.program_id(axis=0)
-    offsets = pid * BLOCK_SIZE + tl.arange(0, BLOCK_SIZE)
-    mask = offsets < num_threads
-    max_clocks = tl.full([BLOCK_SIZE], 0, tl.uint16)
-
-    for sm in range(num_sms):
-        vector_clock_ptr = (thread_state_region + sm * stride_bytes + header_bytes).to(tl.pointer_type(tl.uint16))
-        thread_clocks = tl.load(vector_clock_ptr + offsets, mask=mask, other=0)
-        max_clocks = tl.maximum(thread_clocks, max_clocks)
-
-    for sm in range(num_sms):
-        vector_clock_ptr = (thread_state_region + sm * stride_bytes + header_bytes).to(tl.pointer_type(tl.uint16))
-        tl.store(vector_clock_ptr + offsets, max_clocks, mask=mask)
 
 
 def _check_compatible_runtime_state_layout(lhs: _RuntimeStateLayout, rhs: _RuntimeStateLayout) -> None:
@@ -112,27 +93,6 @@ def _synchronize_process_group_barrier_kernel(local_thread_state_region, peer_th
     for sm in range(num_sms):
         vector_clock_ptr = (local_thread_state_region + sm * stride_bytes + header_bytes).to(tl.pointer_type(tl.uint16))
         tl.store(vector_clock_ptr + offsets, max_clocks, mask=mask)
-
-
-def synchronize_launch_stream(device: int) -> None:
-    """This models the implicit synchronization between kernel launches.
-
-    To do this, we compute the elementwise maximum of all SMs' vector clocks, and set every SM's clock to this starting point.
-
-    This makes all reads and writes transitively visible to other threads.
-    """
-    layout = _runtime_state_layout(get_device_rank(device), device)
-    grid = (triton.cdiv(layout.num_threads, 128), 1, 1)
-    with _compile_without_gsan():
-        _synchronize_vector_clocks_kernel[grid](
-            layout.thread_state_region,
-            layout.thread_state_stride_bytes,
-            layout.num_sms,
-            layout.num_threads,
-            layout.thread_state_header_size_bytes,
-            BLOCK_SIZE=128,
-            num_warps=1,
-        )
 
 
 def synchronize_process_group_barrier(device: int, peer_devices: tuple[int, ...]) -> None:

--- a/python/triton/experimental/gsan/src/GSan.h
+++ b/python/triton/experimental/gsan/src/GSan.h
@@ -82,10 +82,12 @@ struct ThreadState {
   // monotonic counter, used for stochastic read clock updates
   uint32_t numReads;
 
+  uint32_t gdcWaitCalled : 1;
+
   // Index to head of the circular clock buffer, plus a bit to mark if the
   // vector clock has changed since the last clock buffer write (to allow reuse)
   uint32_t clockBufferDirty : 1;
-  uint32_t clockBufferHead : 31;
+  uint32_t clockBufferHead : 30;
 
   // Reader-writer lock controlling access to the vector clock and clock buffer
   uint32_t lock;

--- a/python/triton/experimental/gsan/src/GSanLibrary.cu
+++ b/python/triton/experimental/gsan/src/GSanLibrary.cu
@@ -249,6 +249,7 @@ GSAN_DEVICE void acquireStreamClock(ThreadState *state,
                                     const uint32_t *streamClock,
                                     uint32_t threadIdx, uint32_t numThreads,
                                     uint32_t barrierId) {
+  syncThreads(barrierId, numThreads);
   if (threadIdx == 0)
     rwLockAcquireWrite(state->lock);
   syncThreads(barrierId, numThreads);
@@ -270,6 +271,7 @@ GSAN_DEVICE void acquireStreamClock(ThreadState *state,
 GSAN_DEVICE void publishStreamClock(ThreadState *state, uint32_t *streamClock,
                                     uint32_t threadIdx, uint32_t numThreads,
                                     uint32_t barrierId) {
+  syncThreads(barrierId, numThreads);
   if (threadIdx == 0)
     rwLockAcquireRead(state->lock);
   syncThreads(barrierId, numThreads);

--- a/python/triton/experimental/gsan/src/GSanLibrary.cu
+++ b/python/triton/experimental/gsan/src/GSanLibrary.cu
@@ -240,10 +240,40 @@ GSAN_DEVICE bool canAccumulateReleaseRmw(ThreadState *state, AtomicScope scope,
                                    getGlobalState(state));
 }
 
-GSAN_DEVICE void initThread(GlobalState *globals, Location loc) {
+GSAN_DEVICE void acquireStreamClock(ThreadState *state,
+                                    const uint32_t *streamClock) {
+  bool changed = false;
+  auto *globals = getGlobalState(state);
+  for (int i = 0; i < globals->numThreads; ++i) {
+    auto epoch = __scoped_atomic_load_n(streamClock + i, __ATOMIC_ACQUIRE,
+                                        __MEMORY_SCOPE_SYSTEM);
+    if (state->vectorClock[i] < epoch) {
+      state->vectorClock[i] = static_cast<epoch_t>(epoch);
+      changed = true;
+    }
+  }
+  if (changed)
+    state->clockBufferDirty = 1;
+}
+
+GSAN_DEVICE void publishStreamClock(ThreadState *state, uint32_t *streamClock) {
+  auto *globals = getGlobalState(state);
+  for (int i = 0; i < globals->numThreads; ++i) {
+    uint32_t current = state->vectorClock[i];
+    asm volatile("red.relaxed.gpu.max.u32 [%0], %1;"
+                 :
+                 : "l"(streamClock + i), "r"(current)
+                 : "memory");
+  }
+}
+
+GSAN_DEVICE void initThread(GlobalState *globals, uint32_t *streamClock,
+                            bool acquireOnEntry, Location loc) {
   auto *state = getThreadState(globals);
 
   if (getThreadIdxX() == 0) {
+    if (acquireOnEntry)
+      acquireStreamClock(state, streamClock);
     auto smid = getSmId();
     auto tid = getDeviceThreadId(globals, smid);
 
@@ -689,9 +719,34 @@ __triton_gsan_load_tensor(void *globalState, const char *stackPtr, int numElems,
 }
 
 extern "C" GSAN_DEVICE void
-__triton_gsan_init(void *globalState, const char *file, unsigned line) {
+__triton_gsan_init(void *globalState, gsan::uint32_t *streamClock,
+                   int acquireOnEntry, const char *file, unsigned line) {
   auto loc = gsan::Location{file, line};
-  gsan::initThread(reinterpret_cast<gsan::GlobalState *>(globalState), loc);
+  gsan::initThread(reinterpret_cast<gsan::GlobalState *>(globalState),
+                   streamClock, acquireOnEntry != 0, loc);
+}
+
+extern "C" GSAN_DEVICE void
+__triton_gsan_kernel_exit(void *globalState, gsan::uint32_t *streamClock,
+                          const char *file, unsigned line) {
+  (void)file;
+  (void)line;
+  auto *state =
+      gsan::getThreadState(reinterpret_cast<gsan::GlobalState *>(globalState));
+  if (gsan::getThreadIdxX() == 0)
+    gsan::publishStreamClock(state, streamClock);
+}
+
+extern "C" GSAN_DEVICE void
+__triton_gsan_grid_dependency_wait(void *globalState,
+                                   const gsan::uint32_t *streamClock,
+                                   const char *file, unsigned line) {
+  (void)file;
+  (void)line;
+  auto *state =
+      gsan::getThreadState(reinterpret_cast<gsan::GlobalState *>(globalState));
+  if (gsan::getThreadIdxX() == 0)
+    gsan::acquireStreamClock(state, streamClock);
 }
 
 extern "C" GSAN_DEVICE void

--- a/python/triton/experimental/gsan/src/GSanLibrary.cu
+++ b/python/triton/experimental/gsan/src/GSanLibrary.cu
@@ -83,7 +83,12 @@ GSAN_DEVICE inline uintptr_t roundUp(uintptr_t ptr, uintptr_t align) {
 
 GSAN_DEVICE uint32_t getSmId() { return __nvvm_read_ptx_sreg_smid(); }
 
-GSAN_DEVICE uint32_t getThreadIdxX() { return __nvvm_read_ptx_sreg_tid_x(); }
+GSAN_DEVICE void syncThreads(uint32_t barrierId, uint32_t numThreads) {
+  asm volatile("bar.sync %0, %1;"
+               :
+               : "r"(barrierId), "r"(numThreads)
+               : "memory");
+}
 
 GSAN_DEVICE uintptr_t getThreadStateStrideBytes(GlobalState *globals) {
   auto clocksPerThread = 1u + globals->clockBufferSize;
@@ -241,42 +246,77 @@ GSAN_DEVICE bool canAccumulateReleaseRmw(ThreadState *state, AtomicScope scope,
 }
 
 GSAN_DEVICE void acquireStreamClock(ThreadState *state,
-                                    const uint32_t *streamClock) {
-  bool changed = false;
+                                    const uint32_t *streamClock,
+                                    uint32_t threadIdx, uint32_t numThreads,
+                                    uint32_t barrierId) {
+  if (threadIdx == 0)
+    rwLockAcquireWrite(state->lock);
+  syncThreads(barrierId, numThreads);
+
   auto *globals = getGlobalState(state);
-  for (int i = 0; i < globals->numThreads; ++i) {
-    auto epoch = __scoped_atomic_load_n(streamClock + i, __ATOMIC_ACQUIRE,
-                                        __MEMORY_SCOPE_SYSTEM);
-    if (state->vectorClock[i] < epoch) {
+  for (int i = threadIdx; i < globals->numThreads; i += numThreads) {
+    auto epoch = streamClock[i];
+    if (state->vectorClock[i] < epoch)
       state->vectorClock[i] = static_cast<epoch_t>(epoch);
-      changed = true;
-    }
   }
-  if (changed)
+  if (threadIdx == 0)
     state->clockBufferDirty = 1;
+
+  syncThreads(barrierId, numThreads);
+  if (threadIdx == 0)
+    rwLockReleaseWrite(state->lock);
 }
 
-GSAN_DEVICE void publishStreamClock(ThreadState *state, uint32_t *streamClock) {
+GSAN_DEVICE void publishStreamClock(ThreadState *state, uint32_t *streamClock,
+                                    uint32_t threadIdx, uint32_t numThreads,
+                                    uint32_t barrierId) {
+  if (threadIdx == 0)
+    rwLockAcquireRead(state->lock);
+  syncThreads(barrierId, numThreads);
+
   auto *globals = getGlobalState(state);
-  for (int i = 0; i < globals->numThreads; ++i) {
+  for (int i = threadIdx; i < globals->numThreads; i += numThreads) {
     uint32_t current = state->vectorClock[i];
     asm volatile("red.relaxed.gpu.max.u32 [%0], %1;"
                  :
                  : "l"(streamClock + i), "r"(current)
                  : "memory");
   }
+
+  syncThreads(barrierId, numThreads);
+  if (threadIdx == 0)
+    rwLockReleaseRead(state->lock);
 }
 
-GSAN_DEVICE void initThread(GlobalState *globals, uint32_t *streamClock,
-                            bool acquireOnEntry, Location loc) {
+GSAN_DEVICE uint32_t *getStreamClock(uint32_t *streamClocks,
+                                     __UINT64_TYPE__ kernelId, unsigned offset,
+                                     GlobalState *globals) {
+  return streamClocks + ((kernelId + offset) % 3) * globals->numThreads;
+}
+
+GSAN_DEVICE void initThread(GlobalState *globals, uint32_t *streamClocks,
+                            __UINT64_TYPE__ kernelId, bool acquirePrevious,
+                            uint32_t threadIdx, uint32_t numThreads,
+                            uint32_t barrierId, Location loc) {
   auto *state = getThreadState(globals);
+  if (threadIdx == 0)
+    rwLockAcquireWrite(state->lock);
+  syncThreads(barrierId, numThreads);
 
-  if (getThreadIdxX() == 0) {
-    if (acquireOnEntry)
-      acquireStreamClock(state, streamClock);
-    auto smid = getSmId();
-    auto tid = getDeviceThreadId(globals, smid);
+  // A dependent grid can begin once its predecessor has signaled, but the
+  // grid two launches back has completed by then. Replace all non-local clock
+  // entries so persistent SM state cannot acquire the predecessor implicitly.
+  auto *streamClock =
+      getStreamClock(streamClocks, kernelId, acquirePrevious ? 2 : 1, globals);
+  auto tid = state->threadId;
+  for (int i = threadIdx; i < globals->numThreads; i += numThreads) {
+    if (i == tid)
+      continue;
+    auto epoch = streamClock[i];
+    state->vectorClock[i] = static_cast<epoch_t>(epoch);
+  }
 
+  if (threadIdx == 0) {
     // Preserve the synchronized vector clock from prior launches on this
     // stream and advance the local epoch for the new kernel entry.
     auto *clock = state->vectorClock;
@@ -284,6 +324,10 @@ GSAN_DEVICE void initThread(GlobalState *globals, uint32_t *streamClock,
     clock[tid] += 1;
     state->clockBufferDirty = 1;
   }
+
+  syncThreads(barrierId, numThreads);
+  if (threadIdx == 0)
+    rwLockReleaseWrite(state->lock);
 }
 
 struct Range {
@@ -719,34 +763,35 @@ __triton_gsan_load_tensor(void *globalState, const char *stackPtr, int numElems,
 }
 
 extern "C" GSAN_DEVICE void
-__triton_gsan_init(void *globalState, gsan::uint32_t *streamClock,
-                   int acquireOnEntry, const char *file, unsigned line) {
+__triton_gsan_init(void *globalState, gsan::uint32_t *streamClocks,
+                   __UINT64_TYPE__ kernelId, int acquirePrevious,
+                   unsigned threadIdx, unsigned numThreads, unsigned barrierId,
+                   const char *file, unsigned line) {
   auto loc = gsan::Location{file, line};
   gsan::initThread(reinterpret_cast<gsan::GlobalState *>(globalState),
-                   streamClock, acquireOnEntry != 0, loc);
+                   streamClocks, kernelId, acquirePrevious != 0, threadIdx,
+                   numThreads, barrierId, loc);
 }
 
 extern "C" GSAN_DEVICE void
-__triton_gsan_kernel_exit(void *globalState, gsan::uint32_t *streamClock,
-                          const char *file, unsigned line) {
-  (void)file;
-  (void)line;
-  auto *state =
-      gsan::getThreadState(reinterpret_cast<gsan::GlobalState *>(globalState));
-  if (gsan::getThreadIdxX() == 0)
-    gsan::publishStreamClock(state, streamClock);
+__triton_gsan_kernel_exit(void *globalState, gsan::uint32_t *streamClocks,
+                          __UINT64_TYPE__ kernelId, unsigned threadIdx,
+                          unsigned numThreads, unsigned barrierId) {
+  auto *globals = reinterpret_cast<gsan::GlobalState *>(globalState);
+  auto *state = gsan::getThreadState(globals);
+  gsan::publishStreamClock(
+      state, gsan::getStreamClock(streamClocks, kernelId, 0, globals),
+      threadIdx, numThreads, barrierId);
 }
 
-extern "C" GSAN_DEVICE void
-__triton_gsan_grid_dependency_wait(void *globalState,
-                                   const gsan::uint32_t *streamClock,
-                                   const char *file, unsigned line) {
-  (void)file;
-  (void)line;
-  auto *state =
-      gsan::getThreadState(reinterpret_cast<gsan::GlobalState *>(globalState));
-  if (gsan::getThreadIdxX() == 0)
-    gsan::acquireStreamClock(state, streamClock);
+extern "C" GSAN_DEVICE void __triton_gsan_grid_dependency_wait(
+    void *globalState, gsan::uint32_t *streamClocks, __UINT64_TYPE__ kernelId,
+    unsigned threadIdx, unsigned numThreads, unsigned barrierId) {
+  auto *globals = reinterpret_cast<gsan::GlobalState *>(globalState);
+  auto *state = gsan::getThreadState(globals);
+  gsan::acquireStreamClock(
+      state, gsan::getStreamClock(streamClocks, kernelId, 2, globals),
+      threadIdx, numThreads, barrierId);
 }
 
 extern "C" GSAN_DEVICE void

--- a/python/triton/experimental/gsan/src/GSanLibrary.cu
+++ b/python/triton/experimental/gsan/src/GSanLibrary.cu
@@ -133,6 +133,7 @@ GSAN_DEVICE ThreadState *getThreadState(GlobalState *globals) {
     state->reserveBase = globals->reserveBase;
     state->numReads = 0;
     state->clockBufferDirty = 0;
+    state->gdcWaitCalled = 0;
     state->clockBufferHead = 0;
     state->threadId = getDeviceThreadId(globals, smid);
     __scoped_atomic_thread_fence(__ATOMIC_RELEASE, __MEMORY_SCOPE_SYSTEM);
@@ -260,8 +261,10 @@ GSAN_DEVICE void acquireStreamClock(ThreadState *state,
     if (state->vectorClock[i] < epoch)
       state->vectorClock[i] = static_cast<epoch_t>(epoch);
   }
-  if (threadIdx == 0)
+  if (threadIdx == 0) {
     state->clockBufferDirty = 1;
+    state->gdcWaitCalled = 1;
+  }
 
   syncThreads(barrierId, numThreads);
   if (threadIdx == 0)
@@ -270,10 +273,14 @@ GSAN_DEVICE void acquireStreamClock(ThreadState *state,
 
 GSAN_DEVICE void publishStreamClock(ThreadState *state, uint32_t *streamClock,
                                     uint32_t threadIdx, uint32_t numThreads,
-                                    uint32_t barrierId) {
+                                    uint32_t barrierId, Location loc) {
   syncThreads(barrierId, numThreads);
-  if (threadIdx == 0)
+  if (threadIdx == 0) {
     rwLockAcquireRead(state->lock);
+    assert_msg(loc, state->gdcWaitCalled,
+               "kernel launched with programmatic dependent launch did not "
+               "call gdc_wait");
+  }
   syncThreads(barrierId, numThreads);
 
   auto *globals = getGlobalState(state);
@@ -301,8 +308,10 @@ GSAN_DEVICE void initThread(GlobalState *globals, uint32_t *streamClocks,
                             uint32_t threadIdx, uint32_t numThreads,
                             uint32_t barrierId, Location loc) {
   auto *state = getThreadState(globals);
-  if (threadIdx == 0)
+  if (threadIdx == 0) {
     rwLockAcquireWrite(state->lock);
+    state->gdcWaitCalled = acquirePrevious;
+  }
   syncThreads(barrierId, numThreads);
 
   // A dependent grid can begin once its predecessor has signaled, but the
@@ -778,12 +787,14 @@ __triton_gsan_init(void *globalState, gsan::uint32_t *streamClocks,
 extern "C" GSAN_DEVICE void
 __triton_gsan_kernel_exit(void *globalState, gsan::uint32_t *streamClocks,
                           __UINT64_TYPE__ kernelId, unsigned threadIdx,
-                          unsigned numThreads, unsigned barrierId) {
+                          unsigned numThreads, unsigned barrierId,
+                          const char *file, unsigned line) {
+  auto loc = gsan::Location{file, line};
   auto *globals = reinterpret_cast<gsan::GlobalState *>(globalState);
   auto *state = gsan::getThreadState(globals);
   gsan::publishStreamClock(
       state, gsan::getStreamClock(streamClocks, kernelId, 0, globals),
-      threadIdx, numThreads, barrierId);
+      threadIdx, numThreads, barrierId, loc);
 }
 
 extern "C" GSAN_DEVICE void __triton_gsan_grid_dependency_wait(

--- a/python/triton/experimental/gsan/symmetric_memory.py
+++ b/python/triton/experimental/gsan/symmetric_memory.py
@@ -23,8 +23,8 @@ import torch.distributed.distributed_c10d as c10d
 
 from . import _stream_sync
 from ._allocator import (ShareableHandleType, configure as _configure, create_mem_pool, export_allocation_handles,
-                         export_runtime_state_handle, free_allocation, import_allocation_handles,
-                         import_runtime_state_handle)
+                         export_allocation_memhandle_regions, export_runtime_state_handle, free_allocation,
+                         import_allocation_handles, import_runtime_state_handle)
 from ._utils import uint8_cuda_tensor_from_ptr
 
 _RendezvousCacheKey: TypeAlias = tuple[int, int, int]
@@ -188,7 +188,9 @@ class GSanSymmetricMemoryHandle:
         device_index: int,
         buffer_size: int,
         peer_ptrs: tuple[int, ...],
-        peer_device_indices: tuple[int, ...],
+        peer_offsets: tuple[int, ...],
+        barrier_tensor: torch.Tensor | None = None,
+        barrier_handle: GSanSymmetricMemoryHandle | None = None,
         cache_key: _RendezvousCacheKey | None = None,
     ):
         self._group = group
@@ -197,7 +199,10 @@ class GSanSymmetricMemoryHandle:
         self._device_index = device_index
         self._buffer_size = buffer_size
         self._peer_ptrs = tuple(peer_ptrs)
-        self._peer_device_indices = tuple(int(v) for v in peer_device_indices)
+        self._peer_offsets = tuple(peer_offsets)
+        self._barrier_tensor = barrier_tensor
+        self._barrier_handle = barrier_handle
+        self._barrier_epoch = 0
         self._cache_key = cache_key
         self._closed = False
 
@@ -216,9 +221,11 @@ class GSanSymmetricMemoryHandle:
             raise NotImplementedError("Only channel=0 is supported in GSan symmetric memory.")
         _ = timeout_ms
         if self._world_size > 1:
-            torch.cuda.synchronize(self._device_index)
-            dist.barrier(group=self._group)
-            _stream_sync.synchronize_process_group_barrier(self._device_index, self._peer_device_indices)
+            if self._barrier_handle is None:
+                raise RuntimeError("GSan symmetric-memory barrier counter is unavailable.")
+            counters = self._barrier_handle.get_buffer(0, (self._world_size, ), torch.int32)
+            self._barrier_epoch += 1
+            _stream_sync.synchronize_process_group_barrier(counters, self._rank, self._barrier_epoch, self._world_size)
             torch.cuda.synchronize(self._device_index)
             dist.barrier(group=self._group)
 
@@ -244,7 +251,7 @@ class GSanSymmetricMemoryHandle:
             raise ValueError(
                 f"Requested slice ({offset_bytes + req_bytes} bytes) exceeds buffer size {self._buffer_size} bytes.")
 
-        base_ptr = self._peer_ptrs[rank]
+        base_ptr = self._peer_ptrs[rank] + self._peer_offsets[rank]
         if base_ptr == 0:
             raise RuntimeError(f"Peer rank {rank} has no mapped buffer.")
 
@@ -258,6 +265,8 @@ class GSanSymmetricMemoryHandle:
         for rank, ptr in enumerate(self._peer_ptrs):
             if rank != self._rank:
                 free_allocation(ptr, self._device_index)
+        if self._barrier_handle is not None:
+            self._barrier_handle.close()
         if self._cache_key is not None:
             _RENDEZVOUS_CACHE.pop(self._cache_key)
 
@@ -296,7 +305,7 @@ _RENDEZVOUS_CACHE: weakref.WeakValueDictionary[_RendezvousCacheKey,
 _RUNTIME_BOOTSTRAP_CACHE: dict[_RuntimeBootstrapCacheKey, set[int]] = {}
 
 
-def rendezvous(tensor: torch.Tensor, group) -> GSanSymmetricMemoryHandle:
+def rendezvous(tensor: torch.Tensor, group, *, _create_barrier: bool = True) -> GSanSymmetricMemoryHandle:
     if not isinstance(tensor, torch.Tensor):
         raise TypeError("rendezvous: tensor must be a torch.Tensor")
     if tensor.device.type != "cuda":
@@ -332,7 +341,7 @@ def rendezvous(tensor: torch.Tensor, group) -> GSanSymmetricMemoryHandle:
             device_index=device_index,
             buffer_size=buffer_size,
             peer_ptrs=(base_ptr, ),
-            peer_device_indices=(rank, ),
+            peer_offsets=(0, ),
             cache_key=cache_key,
         )
         _RENDEZVOUS_CACHE[cache_key] = handle
@@ -348,6 +357,8 @@ def rendezvous(tensor: torch.Tensor, group) -> GSanSymmetricMemoryHandle:
 
     with contextlib.ExitStack() as stack:
         real_fd, shadow_fd, alloc_size = export_allocation_handles(base_ptr, ShareableHandleType.POSIX_FILE_DESCRIPTOR)
+        allocation_base, _, _, _ = export_allocation_memhandle_regions(base_ptr)
+        allocation_offset = base_ptr - allocation_base
 
         stack.callback(os.close, real_fd)
         stack.callback(os.close, shadow_fd)
@@ -366,6 +377,7 @@ def rendezvous(tensor: torch.Tensor, group) -> GSanSymmetricMemoryHandle:
             "device_index": int(device_index),
             "nbytes": buffer_size,
             "alloc_size": int(alloc_size),
+            "allocation_offset": allocation_offset,
             "runtime_state_alloc_size": (None if runtime_state_alloc_size is None else int(runtime_state_alloc_size)),
         }
 
@@ -386,11 +398,11 @@ def rendezvous(tensor: torch.Tensor, group) -> GSanSymmetricMemoryHandle:
                 raise RuntimeError("rendezvous: all ranks must use tensors with identical byte size.")
             if meta["alloc_size"] != first["alloc_size"]:
                 raise RuntimeError("rendezvous: all ranks must use identical GSan allocation sizes.")
+            if meta["allocation_offset"] < 0 or meta["allocation_offset"] + meta["nbytes"] > meta["alloc_size"]:
+                raise RuntimeError("rendezvous: tensor storage exceeds its GSan allocation.")
             runtime_meta_size = meta["runtime_state_alloc_size"]
             if runtime_meta_size is not None and int(runtime_meta_size) <= 0:
                 raise RuntimeError("rendezvous: runtime_state_alloc_size must be > 0 when provided.")
-        peer_device_indices = tuple(range(world_size))
-
         token_holder = [uuid.uuid4().hex if rank == 0 else None]
         dist.broadcast_object_list(token_holder, group=process_group, group_src=0)
         token = str(token_holder[0])
@@ -475,6 +487,14 @@ def rendezvous(tensor: torch.Tensor, group) -> GSanSymmetricMemoryHandle:
         if peers_needing_runtime_bootstrap:
             runtime_bootstrapped_peers.update(peers_needing_runtime_bootstrap)
 
+    barrier_tensor = None
+    barrier_handle = None
+    if _create_barrier:
+        barrier_tensor = empty((world_size, ), dtype=torch.int32, device=tensor.device)
+        barrier_tensor.zero_()
+        torch.cuda.synchronize(device_index)
+        barrier_handle = rendezvous(barrier_tensor, process_group, _create_barrier=False)
+
     handle = GSanSymmetricMemoryHandle(
         group=process_group,
         rank=rank,
@@ -482,7 +502,9 @@ def rendezvous(tensor: torch.Tensor, group) -> GSanSymmetricMemoryHandle:
         device_index=device_index,
         buffer_size=buffer_size,
         peer_ptrs=peer_ptrs,
-        peer_device_indices=peer_device_indices,
+        peer_offsets=tuple(0 if peer == rank else int(meta["allocation_offset"]) for peer, meta in enumerate(metas)),
+        barrier_tensor=barrier_tensor,
+        barrier_handle=barrier_handle,
         cache_key=cache_key,
     )
     _RENDEZVOUS_CACHE[cache_key] = handle

--- a/python/triton/language/semantic.py
+++ b/python/triton/language/semantic.py
@@ -1817,6 +1817,12 @@ class TritonSemantic(Generic[TensorTy]):
     def debug_barrier(self) -> TensorTy:
         return self.tensor(self.builder.create_barrier(), tl.void)
 
+    def grid_dependency_wait(self) -> None:
+        self.builder.create_grid_dependency_wait()
+
+    def grid_dependency_launch_dependents(self) -> None:
+        self.builder.create_grid_dependency_launch_dependents()
+
     def device_print(self, prefix: str, args: List[TensorTy], hex: bool) -> TensorTy:
         # It makes sense visually for prefix to end in ": "; make it so.  Also,
         # non-empty prefixes should start with " ".

--- a/test/Conversion/tritongpu_to_llvm_gsan.mlir
+++ b/test/Conversion/tritongpu_to_llvm_gsan.mlir
@@ -3,7 +3,7 @@
 #blocked = #ttg.blocked<{sizePerThread = [1], threadsPerWarp = [32], warpsPerCTA = [4], order = [0]}>
 module attributes {"ttg.instrumentation_mode" = "gsan", "ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32} {
   // CHECK-LABEL: llvm.func @load_store
-  // CHECK: llvm.call @__triton_gsan_init(%{{.*}}, %{{.*}}, %{{.*}}) : (!llvm.ptr, !llvm.ptr, i32) -> ()
+  // CHECK: llvm.call @__triton_gsan_init({{.*}}) : (!llvm.ptr, !llvm.ptr, i64, i32, i32, i32, i32, !llvm.ptr, i32) -> ()
   // CHECK: nvvm.barrier
   // CHECK: llvm.store %{{.*}} : i64, !llvm.ptr
   // CHECK: llvm.store %{{.*}} : i8, !llvm.ptr

--- a/test/Conversion/warp_specialize_to_llvm.mlir
+++ b/test/Conversion/warp_specialize_to_llvm.mlir
@@ -102,6 +102,9 @@ llvm.mlir.global external @global_smem() {addr_space = 3 : i32, alignment = 16 :
 // CHECK: llvm.func internal @inner_func_nw4_ws(%arg0: i32)
 llvm.func internal @inner_func_nw4() attributes {"ws_num_warps" = 4 : i32} {
   // CHECK: [[C128:%.*]] = llvm.mlir.constant(128 : i32)
+  // CHECK: "use.barrier_id"(%arg0) : (i32) -> ()
+  %barrier_id = nvg.warp_group_barrier_id
+  "use.barrier_id"(%barrier_id) : (i32) -> ()
   // CHECK: nvvm.barrier id = %arg0 number_of_threads = [[C128]]
   // CHECK: llvm.call @inner_func_nw4_ws(%arg0) : (i32) -> ()
   nvvm.barrier

--- a/test/TritonGPU/gsan.mlir
+++ b/test/TritonGPU/gsan.mlir
@@ -102,15 +102,19 @@ module attributes {"ttg.num-warps" = 1 : i32, "ttg.threads-per-warp" = 32 : i32}
 module attributes {"ttg.num-ctas" = 2 : i32, "ttg.num-warps" = 4 : i32, "ttg.threads-per-warp" = 32 : i32} {
   // CHECK-LABEL: tt.func public @instrumented_call_in_warp_specialize
   // CHECK-SAME: %[[STATE:[^:, )]+]]: !tt.ptr<i8>
+  // CHECK-SAME: %[[STREAM_CLOCK:[^:, )]+]]: !tt.ptr<i32>
+  // CHECK-SAME: %[[KERNEL_ID:[^:, )]+]]: i64
   tt.func public @instrumented_call_in_warp_specialize(%value: i32) {
-    // CHECK: ttg.warp_specialize(%{{.*}}, %[[STATE]])
+    // CHECK: ttg.warp_specialize(%{{.*}}, %[[STATE]], %[[STREAM_CLOCK]], %[[KERNEL_ID]])
     ttg.warp_specialize(%value)
     default {
       ttg.warp_yield
     }
-    // CHECK: partition0(%[[VALUE:[^:, )]+]]: i32, %[[PARTITION_STATE:[^:, )]+]]: !tt.ptr<i8>) num_warps(4)
+    // CHECK: partition0(%[[VALUE:[^:, )]+]]: i32, %[[PARTITION_STATE:[^:, )]+]]: !tt.ptr<i8>,
+    // CHECK-SAME: %[[PARTITION_STREAM_CLOCK:[^:, )]+]]: !tt.ptr<i32>, %[[PARTITION_KERNEL_ID:[^:, )]+]]: i64) num_warps(4)
     partition0(%partition_value: i32) num_warps(4) {
-      // CHECK: tt.call @identity(%[[VALUE]], %[[PARTITION_STATE]]) : (i32, !tt.ptr<i8>) -> i32
+      // CHECK: tt.call @identity(%[[VALUE]], %[[PARTITION_STATE]], %[[PARTITION_STREAM_CLOCK]], %[[PARTITION_KERNEL_ID]])
+      // CHECK-SAME: : (i32, !tt.ptr<i8>, !tt.ptr<i32>, i64) -> i32
       %result = tt.call @identity(%partition_value) : (i32) -> i32
       ttg.warp_return
     } : (i32) -> ()

--- a/third_party/nvidia/backend/compiler.py
+++ b/third_party/nvidia/backend/compiler.py
@@ -375,6 +375,7 @@ class CUDABackend(BaseBackend):
 
         if "gsan" in options.instrumentation_mode:
             # GSan introduces layout conversions, so must come before shared memory allocation
+            mod.set_attr("tti.gsan_launch_pdl", ir.builder(mod.context).get_int32_attr(int(options.launch_pdl)))
             passes.ttgpuir.add_global_sanitizer(pm)
 
         passes.ttgpuir.add_combine_tensor_select_and_if(pm)

--- a/third_party/nvidia/backend/driver.c
+++ b/third_party/nvidia/backend/driver.c
@@ -263,6 +263,20 @@ static PyObject *getDefaultStream(PyObject *self, PyObject *args) {
   return PyLong_FromUnsignedLongLong(0);
 }
 
+static PyObject *isStreamCapturing(PyObject *self, PyObject *args) {
+  uint64_t stream;
+  if (!PyArg_ParseTuple(args, "K", &stream)) {
+    return NULL;
+  }
+
+  CUstreamCaptureStatus status;
+  CUDA_CHECK_AND_RETURN_NULL(cuStreamIsCapturing((CUstream)stream, &status));
+  return PyBool_FromLong(status != CU_STREAM_CAPTURE_STATUS_NONE);
+
+cleanup:
+  return NULL;
+}
+
 static PyObject *loadBinary(PyObject *self, PyObject *args) {
   const char *name;
   const char *data;
@@ -1542,6 +1556,8 @@ static PyMethodDef ModuleMethods[] = {
      "Set the current CUDA device index"},
     {"get_default_stream", getDefaultStream, METH_VARARGS,
      "Get the CUDA default stream for torch-free launches"},
+    {"is_stream_capturing", isStreamCapturing, METH_VARARGS,
+     "Check whether a CUDA stream is being captured"},
     {"cuOccupancyMaxActiveClusters", occupancyMaxActiveClusters, METH_VARARGS,
      "Python interface for cuOccupancyMaxActiveClusters function"},
     {"set_printf_fifo_size", setPrintfFifoSize, METH_VARARGS,

--- a/third_party/nvidia/backend/driver.py
+++ b/third_party/nvidia/backend/driver.py
@@ -120,6 +120,7 @@ class CudaUtils(object):
         self.get_current_device = mod.get_current_device
         self.set_current_device = mod.set_current_device
         self.get_default_stream = mod.get_default_stream
+        self.is_stream_capturing = mod.is_stream_capturing
         self.get_device_capability = mod.get_device_capability
         self.get_device_properties = mod.get_device_properties
         self.cuOccupancyMaxActiveClusters = mod.cuOccupancyMaxActiveClusters
@@ -324,6 +325,9 @@ class CudaLauncher(object):
 
         kernel_args = args
         if self.gsan_enabled:
+            if active_driver.utils.is_stream_capturing(stream):
+                raise RuntimeError("GSan does not support CUDA graph capture")
+
             import triton.experimental.gsan._allocator as gsan_allocator
             import triton.experimental.gsan._stream_sync as gsan_stream_sync
             device = triton.runtime.driver.active.get_current_device()

--- a/third_party/nvidia/backend/driver.py
+++ b/third_party/nvidia/backend/driver.py
@@ -281,6 +281,7 @@ class CudaLauncher(object):
         if self.gsan_enabled:
             signature["_gsan_globals_ptr"] = "*i8"
             signature["_gsan_stream_clock_ptr"] = "*i32"
+            signature["_gsan_kernel_id"] = "i64"
 
         launcher = triton.runtime.driver.active.utils.launch
         expanded_signature = expand_signature(signature.values(), tensordesc_meta, "nvTmaDesc")
@@ -328,8 +329,8 @@ class CudaLauncher(object):
             device = triton.runtime.driver.active.get_current_device()
             device_rank = gsan_allocator.get_device_rank(device)
             gsan_state_ptr = gsan_allocator.get_global_state_pointer() + device_rank * GSAN_PER_DEVICE_STATE_STRIDE
-            stream_clock = gsan_stream_sync.get_launch_stream_clock(device, stream)
-            kernel_args = (*args, gsan_state_ptr, stream_clock)
+            stream_clock, kernel_id = gsan_stream_sync.get_launch_stream_clock(device, stream)
+            kernel_args = (*args, gsan_state_ptr, stream_clock, kernel_id)
 
         self.launch(gridX, gridY, gridZ, stream, function, self.launch_cooperative_grid, self.launch_pdl,
                     kernel_metadata, launch_metadata, launch_enter_hook, launch_exit_hook, global_scratch,

--- a/third_party/nvidia/backend/driver.py
+++ b/third_party/nvidia/backend/driver.py
@@ -280,6 +280,7 @@ class CudaLauncher(object):
         self.gsan_enabled = "gsan" in getattr(metadata, "instrumentation_mode", "")
         if self.gsan_enabled:
             signature["_gsan_globals_ptr"] = "*i8"
+            signature["_gsan_stream_clock_ptr"] = "*i32"
 
         launcher = triton.runtime.driver.active.utils.launch
         expanded_signature = expand_signature(signature.values(), tensordesc_meta, "nvTmaDesc")
@@ -323,17 +324,16 @@ class CudaLauncher(object):
         kernel_args = args
         if self.gsan_enabled:
             import triton.experimental.gsan._allocator as gsan_allocator
+            import triton.experimental.gsan._stream_sync as gsan_stream_sync
             device = triton.runtime.driver.active.get_current_device()
             device_rank = gsan_allocator.get_device_rank(device)
             gsan_state_ptr = gsan_allocator.get_global_state_pointer() + device_rank * GSAN_PER_DEVICE_STATE_STRIDE
-            kernel_args = (*args, gsan_state_ptr)
+            stream_clock = gsan_stream_sync.get_launch_stream_clock(device, stream)
+            kernel_args = (*args, gsan_state_ptr, stream_clock)
 
         self.launch(gridX, gridY, gridZ, stream, function, self.launch_cooperative_grid, self.launch_pdl,
                     kernel_metadata, launch_metadata, launch_enter_hook, launch_exit_hook, global_scratch,
                     profile_scratch, self.arg_annotations, self.kernel_signature, kernel_args)
-        if self.gsan_enabled:
-            import triton.experimental.gsan._stream_sync as gsan_stream_sync
-            gsan_stream_sync.synchronize_launch_stream(device)
 
 
 class CudaDriver(GPUDriver):

--- a/third_party/nvidia/include/Dialect/NVGPU/IR/NVGPUOps.td
+++ b/third_party/nvidia/include/Dialect/NVGPU/IR/NVGPUOps.td
@@ -110,6 +110,12 @@ def NVGPU_ClusterCTAIdOp : NVGPU_Op<"cluster_id", [Pure]> {
   let assemblyFormat = "attr-dict";
 }
 
+def NVGPU_WarpGroupBarrierIdOp : NVGPU_Op<"warp_group_barrier_id"> {
+  let summary = "Get the named barrier ID for the current warp group";
+  let results = (outs I32:$result);
+  let assemblyFormat = "attr-dict";
+}
+
 def NVGPU_LoadAcquireOp : NVGPU_Op<"ld_acquire", [MemoryEffects<[MemRead, MemWrite]>]> {
   let arguments = (
     ins LLVM_PointerGlobal:$addr,

--- a/third_party/nvidia/language/cuda/gdc.py
+++ b/third_party/nvidia/language/cuda/gdc.py
@@ -20,8 +20,7 @@ def gdc_wait(_semantic=None):
 
     See https://docs.nvidia.com/cuda/parallel-thread-execution/index.html#parallel-synchronization-and-communication-instructions-griddepcontrol for more details.
     """
-    core.inline_asm_elementwise("griddepcontrol.wait; // dummy $0", "=r", [], dtype=core.int32, is_pure=False, pack=1,
-                                _semantic=_semantic)
+    _semantic.grid_dependency_wait()
 
 
 @core.extern
@@ -38,5 +37,4 @@ def gdc_launch_dependents(_semantic=None):
 
     See https://docs.nvidia.com/cuda/parallel-thread-execution/index.html#parallel-synchronization-and-communication-instructions-griddepcontrol for more details.
     """
-    core.inline_asm_elementwise("griddepcontrol.launch_dependents; // dummy $0", "=r", [], dtype=core.int32,
-                                is_pure=False, pack=1, _semantic=_semantic)
+    _semantic.grid_dependency_launch_dependents()

--- a/third_party/nvidia/lib/TritonNVIDIAGPUToLLVM/BarrierOpToLLVM.cpp
+++ b/third_party/nvidia/lib/TritonNVIDIAGPUToLLVM/BarrierOpToLLVM.cpp
@@ -33,6 +33,7 @@
 #include "llvm/Support/MathExtras.h"
 
 #include "Utility.h"
+#include <type_traits>
 
 using namespace mlir;
 using namespace mlir::triton;
@@ -48,6 +49,24 @@ void mlir::triton::NVIDIA::createFenceMBarrierInitReleaseCluster(
 }
 
 namespace {
+template <typename OpTy>
+struct GridDependencyOpConversion : public ConvertOpToLLVMPattern<OpTy> {
+  using ConvertOpToLLVMPattern<OpTy>::ConvertOpToLLVMPattern;
+
+  LogicalResult
+  matchAndRewrite(OpTy op, typename OpTy::Adaptor adaptor,
+                  ConversionPatternRewriter &rewriter) const override {
+    PTXBuilder ptxBuilder;
+    if constexpr (std::is_same_v<OpTy, triton::GridDependencyWaitOp>)
+      (*ptxBuilder.create("griddepcontrol.wait"))();
+    else
+      (*ptxBuilder.create("griddepcontrol.launch_dependents"))();
+    ptxBuilder.launch(rewriter, op.getLoc(), void_ty(rewriter.getContext()));
+    rewriter.eraseOp(op);
+    return success();
+  }
+};
+
 Value getElectWarp0OrThread0(const NVIDIA::TargetInfo &targetInfo,
                              TritonLLVMOpBuilder &b) {
   if (targetInfo.getComputeCapability() >= 90) {
@@ -639,6 +658,10 @@ void mlir::triton::NVIDIA::populateBarrierOpToLLVMPatterns(
     PatternBenefit benefit, NVIDIA::TargetInfo &targetInfo) {
   bool supportsMBarrierMulticast = targetInfo.getComputeCapability() == 107;
   patterns.add<FenceAsyncSharedOpConversion>(typeConverter, benefit);
+  patterns.add<
+      GridDependencyOpConversion<triton::GridDependencyWaitOp>,
+      GridDependencyOpConversion<triton::GridDependencyLaunchDependentsOp>>(
+      typeConverter, benefit);
   patterns.add<FenceMBarrierInitReleaseClusterOpConversion>(typeConverter,
                                                             benefit);
   patterns.add<InitBarrierOpConversion, InvalBarrierOpConversion>(

--- a/third_party/nvidia/lib/TritonNVIDIAGPUToLLVM/ConvertWarpSpecializeToLLVM.cpp
+++ b/third_party/nvidia/lib/TritonNVIDIAGPUToLLVM/ConvertWarpSpecializeToLLVM.cpp
@@ -1,3 +1,4 @@
+#include "Dialect/NVGPU/IR/Dialect.h"
 #include "TargetInfo.h"
 #include "Utility.h"
 #include "mlir/Analysis/TopologicalSortUtils.h"
@@ -46,6 +47,10 @@ public:
 
   bool isBarrierOp(Operation *op) const override {
     return isa<NVVM::BarrierOp>(op);
+  }
+
+  bool isBarrierHandleOp(Operation *op) const override {
+    return isa<mlir::triton::nvgpu::WarpGroupBarrierIdOp>(op);
   }
 
   Type getBarrierHandleType(MLIRContext *ctx) const override {


### PR DESCRIPTION
This changes how GSan models stream synchronization. Each stream maintains a ring buffer of three vector clocks, and each kernel receives a monotonically increasing `kernel_id`.

- At kernel completion, each CTA publishes its vector clock using an atomic max on `stream_clock[kernel_id % 3]`.
- For a normal launch, the kernel initializes its clock from `stream_clock[(kernel_id - 1) % 3]`, acquiring the previous kernel’s aggregated clock.
- For a PDL launch, the kernel initializes from `stream_clock[(kernel_id - 2) % 3]`, acquiring the kernel from two launches ago.
- When a PDL kernel executes `gdc_wait`, it acquires `stream_clock[(kernel_id - 1) % 3]`, synchronizing with its immediate predecessor.

This also completely removes the need for the separate `synchronize_launch_stream` function.