### PR TITLE
[MemBar] Fix atomic handling

### DIFF
--- a/lib/Analysis/Membar.cpp
+++ b/lib/Analysis/Membar.cpp
@@ -268,12 +268,89 @@ bool containsLocalBarrier(Operation *op) {
   return false;
 }
 
+struct LocalBarrierStages {
+  // Stages are independent: for example, a release atomic with scratch has
+  // both a leading ordering barrier and a scratch rendezvous.
+  bool beforeMemoryEffects = false;
+  bool afterMemoryEffects = false;
+  bool betweenMemoryEffects = false;
+};
+
+static Allocation::BufferId getScratchBufferId(Operation *op,
+                                               Allocation *allocation) {
+  // A call's allocation belongs to the callee and is translated separately.
+  if (isa<triton::CallOp>(op))
+    return Allocation::InvalidBufferId;
+  return allocation->getBufferId(op);
+}
+
+static bool scratchBufferUsesWarpSync(Operation *op) {
+  auto cvt = dyn_cast<triton::gpu::ConvertLayoutOp>(op);
+  if (!cvt)
+    return false;
+
+  auto srcTy = cast<RankedTensorType>(cvt.getSrc().getType());
+  auto dstTy = cast<RankedTensorType>(cvt.getType());
+  auto srcLayout = triton::gpu::toLinearLayout(srcTy);
+  auto dstLayout = triton::gpu::toLinearLayout(dstTy);
+  auto kWarp = StringAttr::get(op->getContext(), "warp");
+  return mlir::isCvtDimSync(srcLayout, dstLayout, kWarp);
+}
+
+static LocalBarrierStages getLocalBarrierStages(Operation *op,
+                                                Allocation *allocation) {
+  LocalBarrierStages stages;
+  auto scratchBufferId = getScratchBufferId(op, allocation);
+  bool hasScratchBarrier = scratchBufferId != Allocation::InvalidBufferId &&
+                           !scratchBufferUsesWarpSync(op);
+
+  // Atomic polls always end in a rendezvous. With scratch, the rendezvous is
+  // between the scratch write and read; otherwise it follows all effects.
+  if (isa<triton::AtomicPollOp>(op)) {
+    stages.betweenMemoryEffects = hasScratchBarrier;
+    stages.afterMemoryEffects = !hasScratchBarrier;
+    return stages;
+  }
+
+  if (auto atomic = dyn_cast<triton::AtomicOpInterface>(op)) {
+    auto sem = atomic.getMemSemantic();
+    stages.beforeMemoryEffects = sem == triton::MemSemantic::RELEASE ||
+                                 sem == triton::MemSemantic::ACQUIRE_RELEASE;
+    stages.afterMemoryEffects =
+        !hasScratchBarrier && (sem == triton::MemSemantic::ACQUIRE ||
+                               sem == triton::MemSemantic::ACQUIRE_RELEASE);
+    // Scalar-result broadcast uses a scratch write, rendezvous, and read for
+    // every memory semantic, including relaxed.
+    stages.betweenMemoryEffects = hasScratchBarrier;
+    return stages;
+  }
+
+  // Scratch-backed operations contain a rendezvous between their scratch
+  // write and read phases. Other barrier-like operations behave as a barrier
+  // immediately before the operation.
+  stages.betweenMemoryEffects = hasScratchBarrier;
+  stages.beforeMemoryEffects = containsLocalBarrier(op);
+  return stages;
+}
+
 // Returns true if the same block has a later wait or local barrier before any
 // memory effect or nested control flow.
-static bool hasSyncPointBeforeMemoryEffect(Operation *op) {
+static bool hasSyncPointBeforeMemoryEffect(Operation *op,
+                                           Allocation *allocation) {
   for (Operation *next = op->getNextNode(); next; next = next->getNextNode()) {
-    if (containsLocalBarrier(next) ||
+    auto stages = getLocalBarrierStages(next, allocation);
+    if (stages.beforeMemoryEffects ||
         next->hasTrait<mlir::OpTrait::MemWaitOpTrait>())
+      return true;
+
+    // A contained barrier follows the operation's incoming shared-memory
+    // effects, so it cannot protect those effects from the preceding wait.
+    if (stages.betweenMemoryEffects)
+      return false;
+
+    // Barriers classified as "after" have no shared-memory effects before
+    // them. Currently these are non-scratch atomics and polls.
+    if (stages.afterMemoryEffects)
       return true;
 
     if (isa<RegionBranchOpInterface>(next) || !isMemoryEffectFree(next))
@@ -285,8 +362,9 @@ static bool hasSyncPointBeforeMemoryEffect(Operation *op) {
 void MembarAnalysis::update(Operation *op, BlockInfo *blockInfo,
                             FuncBlockInfoMapT *funcBlockInfoMap,
                             OpBuilder *builder) {
-  if (containsLocalBarrier(op)) {
-    // If the current op is a local barrier, we sync previous reads and writes
+  auto barrierStages = getLocalBarrierStages(op, allocation);
+  if (barrierStages.beforeMemoryEffects) {
+    // Model a leading local barrier before handling the operation's effects.
     blockInfo->sync();
   }
 
@@ -294,7 +372,7 @@ void MembarAnalysis::update(Operation *op, BlockInfo *blockInfo,
   // point before memory is accessed, insert a barrier op and sync. This avoids
   // redundant barriers by deferring the barrier to the later sync point.
   if (op->hasTrait<mlir::OpTrait::MemWaitOpTrait>() &&
-      !hasSyncPointBeforeMemoryEffect(op)) {
+      !hasSyncPointBeforeMemoryEffect(op, allocation)) {
     builder->setInsertionPointAfter(op);
     insertBarrier(op, builder);
     blockInfo->sync();
@@ -302,7 +380,7 @@ void MembarAnalysis::update(Operation *op, BlockInfo *blockInfo,
   }
 
   BlockInfo curBlockInfo;
-  auto scratchBufferId = Allocation::InvalidBufferId;
+  auto scratchBufferId = getScratchBufferId(op, allocation);
   if (isa<triton::CallOp>(op)) {
     // Inter-function dependencies
     auto callOpInterface = dyn_cast<CallOpInterface>(op);
@@ -338,7 +416,6 @@ void MembarAnalysis::update(Operation *op, BlockInfo *blockInfo,
         }
       }
     }
-    scratchBufferId = allocation->getBufferId(op);
   }
 
   // Scratch buffer operations consist of a series of shared memory operations
@@ -346,20 +423,6 @@ void MembarAnalysis::update(Operation *op, BlockInfo *blockInfo,
   // read/write operations, and ending with a shared memory read, i.e., shared
   // memory write -> ... -> shared memory read.
   if (scratchBufferId != Allocation::InvalidBufferId) {
-    // Detect warp-synchronous convert-layout operations. These emit a
-    // warp-level barrier (warp.sync) rather than a CTA-wide barrier between
-    // the internal shared-memory write and read phases. For these ops, we must
-    // not globally clear pending dependencies.
-    bool isWarpSync = false;
-    if (auto cvt = dyn_cast<triton::gpu::ConvertLayoutOp>(op)) {
-      auto srcTy = cast<RankedTensorType>(cvt.getSrc().getType());
-      auto dstTy = cast<RankedTensorType>(cvt.getType());
-      auto srcLayout = triton::gpu::toLinearLayout(srcTy);
-      auto dstLayout = triton::gpu::toLinearLayout(dstTy);
-      auto kWarp = StringAttr::get(op->getContext(), "warp");
-      isWarpSync = mlir::isCvtDimSync(srcLayout, dstLayout, kWarp);
-    }
-
     bool hasExplicitSharedDeps = !curBlockInfo.syncReadSlices.empty() ||
                                  !curBlockInfo.syncWriteSlices.empty();
     if (hasExplicitSharedDeps &&
@@ -377,10 +440,16 @@ void MembarAnalysis::update(Operation *op, BlockInfo *blockInfo,
       builder->setInsertionPoint(op);
       insertBarrier(op, builder);
     }
-    // Ops with a scratch buffer that don't use warp.sync internally sync
-    // read/write on shared memory
-    if (insertCTABarrier || !isWarpSync)
+    if (insertCTABarrier)
       blockInfo->sync();
+
+    if (barrierStages.betweenMemoryEffects) {
+      // The internal barrier synchronizes all incoming effects. Do not carry
+      // them past the operation; only effects after the barrier are outgoing.
+      blockInfo->join(curBlockInfo);
+      blockInfo->sync();
+      curBlockInfo.sync();
+    }
     curBlockInfo.syncReadSlices[scratchSlice].insert(op);
   } else if (blockInfo->isIntersected(curBlockInfo, filter, allocation)) {
     builder->setInsertionPoint(op);
@@ -390,5 +459,10 @@ void MembarAnalysis::update(Operation *op, BlockInfo *blockInfo,
   // Update the region info, even if barrier is inserted, we have to maintain
   // the current op's read/write buffers.
   blockInfo->join(curBlockInfo);
+
+  if (barrierStages.afterMemoryEffects) {
+    // Model a trailing local barrier after handling the operation's effects.
+    blockInfo->sync();
+  }
 }
 } // namespace mlir

--- a/test/Analysis/test-membar.mlir
+++ b/test/Analysis/test-membar.mlir
@@ -156,6 +156,48 @@ tt.func @async_wait_existing_barrier(%arg: tensor<32x16xf16, #AL>) {
   tt.return
 }
 
+// An acquire barrier follows the shared-memory write used to broadcast a
+// scalar atomic result, so it cannot replace the barrier after the wait.
+// CHECK-LABEL: async_wait_before_atomic_acquire
+tt.func @async_wait_before_atomic_acquire(%ptr: !tt.ptr<i32>) -> i32 {
+  %c0_i32 = arith.constant 0 : i32
+  // CHECK: ttg.async_wait
+  // CHECK-NEXT: ttg.barrier local
+  // CHECK-NEXT: %{{.*}} = tt.atomic_cas acquire
+  ttg.async_wait {num = 0 : i32}
+  %result = tt.atomic_cas acquire, gpu, %ptr, %c0_i32, %c0_i32 : (!tt.ptr<i32>, i32, i32) -> i32
+  tt.return %result : i32
+}
+
+// A release barrier precedes the atomic's scratch write, so the membar pass
+// does not need to insert another barrier after the wait.
+// CHECK-LABEL: async_wait_before_atomic_release
+tt.func @async_wait_before_atomic_release(%ptr: !tt.ptr<i32>) -> i32 {
+  %c0_i32 = arith.constant 0 : i32
+  // CHECK: ttg.async_wait
+  // CHECK-NOT: ttg.barrier local
+  // CHECK: %{{.*}} = tt.atomic_cas release
+  ttg.async_wait {num = 0 : i32}
+  %result = tt.atomic_cas release, gpu, %ptr, %c0_i32, %c0_i32 : (!tt.ptr<i32>, i32, i32) -> i32
+  tt.return %result : i32
+}
+
+// Without scratch, the acquire barrier follows the atomic and synchronizes
+// prior shared-memory effects before the later load.
+// CHECK-LABEL: async_wait_before_atomic_acquire_no_scratch
+tt.func @async_wait_before_atomic_acquire_no_scratch(%ptr: !tt.ptr<i32>, %arg: tensor<32x16xf16, #AL>) {
+  %c0_i32 = arith.constant 0 : i32
+  %smem = ttg.local_alloc %arg : (tensor<32x16xf16, #AL>) -> !ttg.memdesc<32x16xf16, #A_SHARED, #ttg.shared_memory>
+  // CHECK: ttg.async_wait
+  // CHECK-NEXT: %{{.*}} = tt.atomic_cas acquire
+  // CHECK-NOT: ttg.barrier local
+  // CHECK: ttg.local_load
+  ttg.async_wait {num = 0 : i32}
+  %unused = tt.atomic_cas acquire, gpu, %ptr, %c0_i32, %c0_i32 : (!tt.ptr<i32>, i32, i32) -> i32
+  %result = ttg.local_load %smem : !ttg.memdesc<32x16xf16, #A_SHARED, #ttg.shared_memory> -> tensor<32x16xf16, #AL>
+  tt.return
+}
+
 // CHECK-LABEL: async_wait_scan_stops_at_memory_effect
 tt.func @async_wait_scan_stops_at_memory_effect(%arg: tensor<32x16xf16, #AL>) {
   %cst0 = ttg.local_alloc %arg : (tensor<32x16xf16, #AL>) -> !ttg.memdesc<32x16xf16, #A_SHARED, #ttg.shared_memory>
@@ -690,6 +732,59 @@ tt.func @atomic_poll_relaxed(%ptr: !tt.ptr<i32>, %expected: i32) {
   %matched = tt.atomic_poll relaxed, gpu, %ptr, %expected : !tt.ptr<i32>, i32 -> i1
   %result = ttg.local_load %smem : !ttg.memdesc<128x32xf16, #A_SHARED, #ttg.shared_memory> -> tensor<128x32xf16, #AL>
   tt.return
+}
+
+// A scalar acquire atomic reads its scratch buffer after its internal barrier.
+// Reusing that buffer in the next loop iteration therefore requires a barrier
+// before the next scratch write.
+// CHECK-LABEL: atomic_acquire_loop
+tt.func @atomic_acquire_loop(%ptr: !tt.ptr<i32>) -> i32 {
+  %c0_i32 = arith.constant 0 : i32
+  %lb = arith.constant 0 : index
+  %ub = arith.constant 10 : index
+  %step = arith.constant 1 : index
+  %result = scf.for %iv = %lb to %ub step %step iter_args(%acc = %c0_i32) -> i32 {
+    // CHECK: ttg.barrier local
+    // CHECK-NEXT: %{{.*}} = tt.atomic_cas acquire
+    %value = tt.atomic_cas acquire, gpu, %ptr, %c0_i32, %c0_i32 : (!tt.ptr<i32>, i32, i32) -> i32
+    %next = arith.addi %acc, %value : i32
+    scf.yield %next : i32
+  }
+  tt.return %result : i32
+}
+
+// The release barrier precedes the scratch write, while the broadcast barrier
+// remains between the scratch write and read. No extra barrier is needed.
+// CHECK-LABEL: atomic_release_loop
+tt.func @atomic_release_loop(%ptr: !tt.ptr<i32>) -> i32 {
+  // CHECK-NOT: ttg.barrier local
+  %c0_i32 = arith.constant 0 : i32
+  %lb = arith.constant 0 : index
+  %ub = arith.constant 10 : index
+  %step = arith.constant 1 : index
+  %result = scf.for %iv = %lb to %ub step %step iter_args(%acc = %c0_i32) -> i32 {
+    %value = tt.atomic_cas release, gpu, %ptr, %c0_i32, %c0_i32 : (!tt.ptr<i32>, i32, i32) -> i32
+    %next = arith.addi %acc, %value : i32
+    scf.yield %next : i32
+  }
+  tt.return %result : i32
+}
+
+// A timed poll also uses shared memory to broadcast its result.
+// CHECK-LABEL: atomic_poll_acquire_loop
+tt.func @atomic_poll_acquire_loop(%ptr: !tt.ptr<i32>, %expected: i32, %timeout: i64) -> i1 {
+  %false = arith.constant false
+  %lb = arith.constant 0 : index
+  %ub = arith.constant 10 : index
+  %step = arith.constant 1 : index
+  %result = scf.for %iv = %lb to %ub step %step iter_args(%acc = %false) -> i1 {
+    // CHECK: ttg.barrier local
+    // CHECK-NEXT: %{{.*}} = tt.atomic_poll acquire
+    %matched = tt.atomic_poll acquire, gpu, %ptr, %expected timeout %timeout : !tt.ptr<i32>, i32 -> i1
+    %next = arith.ori %acc, %matched : i1
+    scf.yield %next : i1
+  }
+  tt.return %result : i1
 }
 
 }


### PR DESCRIPTION
Currently containsLocalBarrier also assumes that the barrier happens before any memory effects, so an atomic with acquire effects which has the barrier after the memory effect is not handled correctly.

This splits it into 3 stages:
1. beforeMemoryEffects -> e.g. atomic with release semantics
2. betweenMemoryEffects -> e.g. a cross-warp convert layout
3. afterMemoryEffects -> e.g. atomic_poll without a timeout

Doing this allows us to model the outgoing memory effects more precisely, but not unconditionally skip inserting barriers before the op.