### PR TITLE
[FRONTEND] Keep list comprehension targets local

### DIFF
--- a/python/test/unit/language/test_frontend.py
+++ b/python/test/unit/language/test_frontend.py
@@ -444,6 +444,57 @@ def test_list_comprehension_if_filter():
     run_parser(kernel)
 
 
+def test_list_comprehension_does_not_clobber_outer_scope():
+
+    @triton.jit
+    def kernel():
+        # `x` must keep its outer value after the comprehension.
+        x: tl.constexpr = 99
+        vals: tl.constexpr = [x for x in (1, 2, 3)]
+        tl.static_assert(len(vals) == 3)
+        tl.static_assert(x == 99)
+
+    run_parser(kernel)
+
+
+@doesnt_compile
+@triton.jit
+def test_list_comprehension_target_does_not_leak():
+    # `y` must be undefined after the comprehension.
+    vals: tl.constexpr = [y for y in (1, 2, 3)]
+    tl.static_assert(vals[0] == 1)
+    tl.static_assert(y == 3)  # noqa: F821
+
+
+def test_list_comprehension_scope_restored_after_tensor_ternary():
+
+    @triton.jit
+    def kernel():
+        # Tensor ternaries replace the scope dictionaries while visiting the body.
+        x: tl.constexpr = 99
+        c = tl.to_tensor(1) > 0
+        vals = [(tl.to_tensor(1) if c else tl.to_tensor(2)) for x in (1, 2, 3)]  # noqa: F841
+        tl.static_assert(x == 99)
+
+    run_parser(kernel)
+
+
+def test_list_comprehension_does_not_pollute_if_branch_merge():
+
+    @triton.jit
+    def kernel(c):
+        # The target must not linger in `local_defs`: otherwise the branch merge
+        # sees a phantom `t` in the `if` block that collides with the real `t`
+        # defined in the `else` block.
+        cc = c > 0
+        if cc:
+            vals = [t for t in (1, 2, 3)]  # noqa: F841
+        else:
+            t = tl.zeros([4], tl.int32)  # noqa: F841
+
+    run_parser(kernel, args=(1, ))
+
+
 def test_named_expr_respects_prior_constexpr_annotation():
 
     @triton.jit

--- a/python/triton/compiler/code_generator.py
+++ b/python/triton/compiler/code_generator.py
@@ -549,20 +549,19 @@ class CodeGenerator(ast.NodeVisitor):
         absent = object()
         saved = {attr: getattr(self, attr).get(target, absent) for attr in ("lscope", "local_defs")}
 
-        try:
-            results = []
-            for item in iter:
-                self.set_value(target, item)
-                # Apply the comprehension's `if` filters (conditions are constexpr).
-                if all(self.visit(cond) for cond in comp.ifs):
-                    results.append(self.visit(node.elt))
-        finally:
-            for attr, old in saved.items():
-                scope = getattr(self, attr)
-                if old is absent:
-                    scope.pop(target, None)
-                else:
-                    scope[target] = old
+        results = []
+        for item in iter:
+            self.set_value(target, item)
+            # Apply the comprehension's `if` filters (conditions are constexpr).
+            if all(self.visit(cond) for cond in comp.ifs):
+                results.append(self.visit(node.elt))
+
+        for attr, old in saved.items():
+            scope = getattr(self, attr)
+            if old is absent:
+                scope.pop(target, None)
+            else:
+                scope[target] = old
         return tl_tuple(results)
 
     # By design, only non-kernel functions can return

--- a/python/triton/compiler/code_generator.py
+++ b/python/triton/compiler/code_generator.py
@@ -542,12 +542,27 @@ class CodeGenerator(ast.NodeVisitor):
         if not isinstance(iter, tl_tuple):
             raise NotImplementedError("only tuple comprehensions are supported")
 
-        results = []
-        for item in iter:
-            self.set_value(comp.target.id, item)
-            # Apply the comprehension's `if` filters (the conditions are constexpr).
-            if all(self.visit(cond) for cond in comp.ifs):
-                results.append(self.visit(node.elt))
+        # Comprehension targets do not leak into the enclosing scope. `set_value`
+        # updates both scope maps, and visiting the body may replace them, so
+        # restore the saved bindings through the live attributes.
+        target = comp.target.id
+        absent = object()
+        saved = {attr: getattr(self, attr).get(target, absent) for attr in ("lscope", "local_defs")}
+
+        try:
+            results = []
+            for item in iter:
+                self.set_value(target, item)
+                # Apply the comprehension's `if` filters (conditions are constexpr).
+                if all(self.visit(cond) for cond in comp.ifs):
+                    results.append(self.visit(node.elt))
+        finally:
+            for attr, old in saved.items():
+                scope = getattr(self, attr)
+                if old is absent:
+                    scope.pop(target, None)
+                else:
+                    scope[target] = old
         return tl_tuple(results)
 
     # By design, only non-kernel functions can return


### PR DESCRIPTION
`CodeGenerator.visit_ListComp` lowers tuple comprehensions by binding the iteration target with `set_value`. Since `set_value` writes to both `lscope` and `local_defs`, the target remained in the enclosing scope after the comprehension finished.

For example, an existing binding was clobbered by the last iteration:

```python
x: tl.constexpr = 99
vals: tl.constexpr = [x for x in (1, 2, 3)]
tl.static_assert(x == 99)  # fails because x becomes 3
```

Likewise, a fresh target remained visible after the comprehension instead of being undefined as required by Python 3 list-comprehension scoping. A stale entry in `local_defs` could also make a later control-flow merge see a phantom definition.

This patch snapshots the target's previous bindings in `lscope` and `local_defs` and restores them after evaluating the comprehension. It restores through the live scope attributes because visiting the body may replace the scope dictionaries when entering a subregion.

This is a follow-up to #10888, which fixed `if` filters in the same list-comprehension lowering path; this patch fixes target scoping independently of filtering.

Added four parser-only tests in `python/test/unit/language/test_frontend.py`, covering preservation of an outer binding, removal of a fresh target, replacement of the scope dictionaries, and subsequent `if/else` branch merging.