### PR TITLE
[TritonGPU] Compute allocation sizes from linear layouts

### DIFF
--- a/include/triton/Dialect/TritonGPU/IR/Dialect.h
+++ b/include/triton/Dialect/TritonGPU/IR/Dialect.h
@@ -277,7 +277,11 @@ ArrayRef<T> dropPipeliningDim(ArrayRef<T> shape, Attribute layout) {
 
 // Returns the number of elements per CTA in the allocation's linear address
 // space. This does not include padding introduced by padded shared layouts.
+// Leading pipelining dimensions count full allocation stages, including any
+// gaps between visible subslices of consecutive stages.
 // If allocShape is provided, shape may describe a subslice of that allocation.
+// For a pipelined slice, it computes the length of the smallest (perhaps
+// non-contiguous) run from its first element to its last element.
 int64_t getAllocationElems(Attribute layout, ArrayRef<int64_t> shape,
                            ArrayRef<int64_t> allocShape = {});
 

--- a/include/triton/Dialect/TritonGPU/IR/Dialect.h
+++ b/include/triton/Dialect/TritonGPU/IR/Dialect.h
@@ -275,12 +275,11 @@ ArrayRef<T> dropPipeliningDim(ArrayRef<T> shape, Attribute layout) {
   return shape.take_back(cast<LayoutEncodingTrait>(layout).getRank());
 }
 
-// Returns the shape per CTA, which is "physically" allocated.
-// Such shapes may be bigger than the logical one due to, for example, padding
-// in shared memory.
-SmallVector<int64_t> getAllocationShapePerCTA(Attribute layout,
-                                              ArrayRef<int64_t> shape);
-SmallVector<int64_t> getAllocationShapePerCTA(Type type);
+// Returns the number of elements per CTA in the allocation's linear address
+// space. This does not include padding introduced by padded shared layouts.
+// If allocShape is provided, shape may describe a subslice of that allocation.
+int64_t getAllocationElems(Attribute layout, ArrayRef<int64_t> shape,
+                           ArrayRef<int64_t> allocShape = {});
 
 unsigned getNumCTAs(Attribute layout);
 

--- a/lib/Analysis/Allocation.cpp
+++ b/lib/Analysis/Allocation.cpp
@@ -193,17 +193,10 @@ private:
       unsigned numLogicalPieces = partitionedEnc.getNumLogicalPieces();
 
       // Calculate size per logical piece
-      auto partitionLayout = partitionedEnc.getPartitionLayout();
-      int64_t totalNumElems = 0;
-
-      if (auto paddedEnc =
-              dyn_cast<gpu::PaddedSharedEncodingAttr>(partitionLayout)) {
-        SmallVector<int64_t> unpaddedShape = gpu::getShapePerCTA(allocType);
-        totalNumElems = paddedEnc.getPaddedSize(unpaddedShape);
-      } else {
-        auto shapePerCTA = gpu::getAllocationShapePerCTA(allocType);
-        totalNumElems = product<int64_t>(shapePerCTA);
-      }
+      int64_t totalNumElems = gpu::getAllocationElems(
+          allocType.getEncoding(), allocType.getAllocShape());
+      if (auto padded = gpu::getPaddedEncoding(allocType.getEncoding()))
+        totalNumElems = padded.getPaddedSize({totalNumElems});
 
       int64_t totalBytes =
           totalNumElems *
@@ -221,15 +214,10 @@ private:
     }
 
     // Standard (non-partitioned) buffer allocation
-    int64_t numElems = 0;
-    if (auto paddedEnc =
-            dyn_cast<gpu::PaddedSharedEncodingAttr>(allocType.getEncoding())) {
-      SmallVector<int64_t> unpaddedShape = gpu::getShapePerCTA(allocType);
-      numElems = paddedEnc.getPaddedSize(unpaddedShape);
-    } else {
-      auto shapePerCTA = gpu::getAllocationShapePerCTA(allocType);
-      numElems = product<int64_t>(shapePerCTA);
-    }
+    int64_t numElems = gpu::getAllocationElems(allocType.getEncoding(),
+                                               allocType.getAllocShape());
+    if (auto padded = gpu::getPaddedEncoding(allocType.getEncoding()))
+      numElems = padded.getPaddedSize({numElems});
     int64_t bytes =
         numElems * getIntOrFloatOrPtrBitWidth(allocType.getElementType()) / 8;
 

--- a/lib/Analysis/BufferRegion.cpp
+++ b/lib/Analysis/BufferRegion.cpp
@@ -36,47 +36,13 @@ uint64_t getAllocationOffset(ttng::TMEMAllocOp op) {
   return colOffset | (rowOffset << 16);
 }
 
-unsigned getMemDescSize(ttg::MemDescType ty) {
-  auto encoding = ty.getEncoding();
-  auto shape = ttg::dropPipeliningDim(ty.getShape(), encoding);
-  auto allocShape = ttg::dropPipeliningDim(ty.getAllocShape(), encoding);
-  uint64_t stages = product(ty.getShape().drop_back(shape.size()));
-
-  if (isa<ttng::TensorMemorySpaceAttr>(ty.getMemorySpace())) {
-    if (stages == 1)
-      return ttng::getTmemAllocSizes(ty).numCols;
-    uint32_t stageCols =
-        ttng::getTMemSubSliceOffset(ty, /*offset=*/1, /*dim=*/0);
-    return (stages - 1) * stageCols +
-           ttng::getTmemAllocSizes(ty).numCols / stages;
-  }
-  assert(isa<ttg::SharedMemorySpaceAttr>(ty.getMemorySpace()) &&
-         "Unsupported memory space");
-  unsigned elSize = ty.getElementType().getIntOrFloatBitWidth() / 8;
-  if (ttg::isPaddedEncoding(encoding))
-    return product(ttg::getShapePerCTA(ty)) * elSize;
-
-  auto allocation = ttg::toLinearLayout(allocShape, encoding);
-  auto view = allocation.pseudoinvert();
-  auto logicalDims = llvm::to_vector(view.getInDimNames());
-  for (auto [dim, size] : llvm::zip_equal(logicalDims, shape))
-    view = view.resizeInDim(dim, size);
-  auto offsetDim = StringAttr::get(ty.getContext(), "offset");
-  // Zero physical bases are still owned by the allocation and its subviews.
-  uint64_t zeroMask = (allocation.getInDimSize(offsetDim) - 1) &
-                      ~getInputBasisMask(allocation, offsetDim, logicalDims);
-  uint64_t viewSpan =
-      (getOutputBasisMask(view, logicalDims, offsetDim) | zeroMask) + 1;
-  return ((stages - 1) * allocation.getInDimSize(offsetDim) + viewSpan) *
-         elSize;
-}
-
 unsigned getAllocSize(ttg::LocalAllocOp op) {
-  return getMemDescSize(op.getType());
-}
-
-unsigned getAllocSize(ttng::TMEMAllocOp op) {
-  return getMemDescSize(op.getType());
+  auto type = op.getType();
+  int64_t numElems =
+      ttg::getAllocationElems(type.getEncoding(), type.getAllocShape());
+  if (auto padded = ttg::getPaddedEncoding(type.getEncoding()))
+    numElems = padded.getPaddedSize({numElems});
+  return numElems * type.getElementType().getIntOrFloatBitWidth() / 8;
 }
 
 unsigned getNumBuffers(ttg::MemDescIndexOp memdescIndexOp) {
@@ -157,35 +123,18 @@ FailureOr<uint32_t> getMemDescSubsliceByteOffset(ttg::MemDescSubsliceOp op) {
   }
   uint64_t elementOffset = static_cast<uint32_t>(mapped[0].second);
   if (offsets.size() != layoutRank) {
-    uint64_t stride = product(ttg::getAllocationShapePerCTA(
-        encoding, ttg::dropPipeliningDim(srcTy.getAllocShape(), encoding)));
+    uint64_t stride = ttg::getAllocationElems(
+        encoding, ttg::dropPipeliningDim(srcTy.getAllocShape(), encoding));
     elementOffset += static_cast<uint64_t>(offsets.front()) * stride;
   }
+
+  if (auto padded = ttg::getPaddedEncoding(encoding))
+    elementOffset = padded.getPaddedSize({int64_t(elementOffset + 1)}) - 1;
 
   uint64_t elementSizeBytes =
       srcTy.getElementType().getIntOrFloatBitWidth() / 8;
   assert(elementSizeBytes > 0 && "element size must be non-zero");
   uint64_t byteOffset = elementOffset * elementSizeBytes;
-
-  if (auto padded = dyn_cast<ttg::PaddedSharedEncodingAttr>(encoding)) {
-    uint64_t padBytes = 0;
-    for (auto &&[interval, padding] :
-         llvm::zip_equal(padded.getIntervals(), padded.getPaddings())) {
-      if (interval == 0 || padding == 0)
-        continue;
-      uint64_t intervalScaled =
-          static_cast<uint64_t>(interval) * elementSizeBytes;
-      uint64_t paddingScaled =
-          static_cast<uint64_t>(padding) * elementSizeBytes;
-      assert(llvm::isPowerOf2_64(intervalScaled) &&
-             llvm::isPowerOf2_64(paddingScaled) &&
-             "interval and padding must be powers of two in bytes");
-      unsigned intervalLog2 = llvm::Log2_64(intervalScaled);
-      unsigned paddingLog2 = llvm::Log2_64(paddingScaled);
-      padBytes += (byteOffset >> intervalLog2) << paddingLog2;
-    }
-    byteOffset += padBytes;
-  }
 
   assert(byteOffset <= std::numeric_limits<uint32_t>::max() &&
          "memdesc_subslice offset exceeds 32-bit range");
@@ -257,7 +206,7 @@ LogicalResult BufferRegionAnalysis::visitOperation(
   }
   if (auto tmemAllocOp = dyn_cast<ttng::TMEMAllocOp>(op)) {
     uint32_t offset = getAllocationOffset(tmemAllocOp);
-    uint32_t size = getAllocSize(tmemAllocOp);
+    uint32_t size = ttng::getTmemAllocSizes(tmemAllocOp.getType()).numCols;
     regionInfo.regions.insert({offset, size});
 
     for (auto *r : results) {
@@ -268,11 +217,25 @@ LogicalResult BufferRegionAnalysis::visitOperation(
   if (auto memdescIndexOp = dyn_cast<ttg::MemDescIndexOp>(op)) {
     RegionInfo in = operands[0]->getValue();
     int numSubBuffers = getNumBuffers(memdescIndexOp);
+    auto type = memdescIndexOp.getType();
+    bool isTmem = isa<ttng::TensorMemorySpaceAttr>(type.getMemorySpace());
+    uint32_t elementSize =
+        isTmem ? 1 : type.getElementType().getIntOrFloatBitWidth() / 8;
+    uint64_t stageElems =
+        isTmem ? ttng::getTmemAllocSizes(type).numCols
+               : ttg::getAllocationElems(type.getEncoding(), type.getShape(),
+                                         type.getAllocShape());
+    auto padded = ttg::getPaddedEncoding(type.getEncoding());
+    uint64_t stageSize =
+        padded ? padded.getPaddedSize({int64_t(stageElems)}) : stageElems;
     for (auto &region : in.regions) {
       for (int i = 0; i < numSubBuffers; i++) {
-        uint32_t subBufferSize = getMemDescSize(memdescIndexOp.getType());
+        uint64_t offset = i * stageElems;
+        if (padded)
+          offset = padded.getPaddedSize({int64_t(offset + 1)}) - 1;
         regionInfo.regions.insert(
-            {region.baseOffset + i * subBufferSize, subBufferSize});
+            {region.baseOffset + static_cast<uint32_t>(offset * elementSize),
+             static_cast<uint32_t>(stageSize * elementSize)});
       }
     }
 
@@ -283,7 +246,13 @@ LogicalResult BufferRegionAnalysis::visitOperation(
   }
   if (auto memdescSubsliceOp = dyn_cast<ttg::MemDescSubsliceOp>(op)) {
     RegionInfo in = operands[0]->getValue();
-    uint32_t subBufferSize = getMemDescSize(memdescSubsliceOp.getType());
+    auto type = memdescSubsliceOp.getType();
+    uint64_t numElems = ttg::getAllocationElems(
+        type.getEncoding(), type.getShape(), type.getAllocShape());
+    if (auto padded = ttg::getPaddedEncoding(type.getEncoding()))
+      numElems = padded.getPaddedSize({int64_t(numElems)});
+    uint32_t subBufferSize =
+        numElems * type.getElementType().getIntOrFloatBitWidth() / 8;
     FailureOr<uint32_t> relativeOffset =
         getMemDescSubsliceByteOffset(memdescSubsliceOp);
     if (failed(relativeOffset))
@@ -299,7 +268,15 @@ LogicalResult BufferRegionAnalysis::visitOperation(
   }
   if (auto tmemSubsliceOp = dyn_cast<ttng::TMEMSubSliceOp>(op)) {
     RegionInfo in = operands[0]->getValue();
-    uint32_t subBufferSize = getMemDescSize(tmemSubsliceOp.getType());
+    auto type = tmemSubsliceOp.getType();
+    uint64_t stages = product(type.getShape().drop_back(
+        ttg::dropPipeliningDim(type.getShape(), type.getEncoding()).size()));
+    uint32_t subBufferSize = ttng::getTmemAllocSizes(type).numCols;
+    if (stages > 1) {
+      uint32_t stageCols =
+          ttng::getTMemSubSliceOffset(type, /*offset=*/1, /*dim=*/0);
+      subBufferSize = (stages - 1) * stageCols + subBufferSize / stages;
+    }
     uint32_t relativeOffset = ttng::getTMemSubSliceOffset(
         tmemSubsliceOp.getSrc().getType(), tmemSubsliceOp.getOffset(),
         tmemSubsliceOp.getDim());
@@ -314,10 +291,15 @@ LogicalResult BufferRegionAnalysis::visitOperation(
   }
   if (auto reinterpretOp = dyn_cast<ttg::MemDescReinterpretOp>(op)) {
     auto type = reinterpretOp.getType();
-    uint32_t size = getMemDescSize(type);
-    if (auto padded = ttg::getPaddedEncoding(type.getEncoding())) {
-      unsigned elementSize = type.getElementType().getIntOrFloatBitWidth() / 8;
-      size = padded.getPaddedSize({size / elementSize}) * elementSize;
+    uint32_t size;
+    if (isa<ttng::TensorMemorySpaceAttr>(type.getMemorySpace())) {
+      size = ttng::getTmemAllocSizes(type).numCols;
+    } else {
+      uint64_t numElems = ttg::getAllocationElems(
+          type.getEncoding(), type.getShape(), type.getAllocShape());
+      if (auto padded = ttg::getPaddedEncoding(type.getEncoding()))
+        numElems = padded.getPaddedSize({int64_t(numElems)});
+      size = numElems * type.getElementType().getIntOrFloatBitWidth() / 8;
     }
     for (auto &region : operands[0]->getValue().regions)
       regionInfo.regions.insert({region.baseOffset, size});

--- a/lib/Conversion/TritonGPUToLLVM/ViewOpToLLVM.cpp
+++ b/lib/Conversion/TritonGPUToLLVM/ViewOpToLLVM.cpp
@@ -430,15 +430,14 @@ struct MemDescIndexOpConversion
     // reduced shape, so partitionDim=0 refers to the tensor's first dimension,
     // not the multi-buffer dimension that was just indexed away.
     //
-    // getAllocationShapePerCTA returns the correct number of fp4 elements that
+    // getAllocationElems returns the correct number of fp4 elements that
     // we need to skip when we have fp4Padded=True. getShapePerCTA does not
     // account for this.
-    auto allocShape = product(
-        getAllocationShapePerCTA(dstTy.getEncoding(), dstTy.getShape()));
-    int64_t stride = allocShape;
+    int64_t stride =
+        getAllocationElems(dstTy.getEncoding(), dstTy.getAllocShape());
     if (auto partEnc =
             dyn_cast<PartitionedSharedEncodingAttr>(dstTy.getEncoding())) {
-      stride = allocShape / partEnc.getNumPartitions();
+      stride /= partEnc.getNumPartitions();
     }
     Value offset = b.mul(op.getIndex(), b.i32_val(stride));
     auto smemObj = getSharedMemoryObjectFromStruct(loc, adaptor.getSrc(),
@@ -496,8 +495,8 @@ struct MemDescSubsliceOpConversion
 
     if (layoutOffsets.size() != opOffsetVals.size() &&
         opOffsetVals.front() != 0) {
-      int64_t stride = product(getAllocationShapePerCTA(
-          encoding, dropPipeliningDim(srcTy.getAllocShape(), encoding)));
+      int64_t stride = getAllocationElems(
+          encoding, dropPipeliningDim(srcTy.getAllocShape(), encoding));
       if (auto partEnc = dyn_cast<PartitionedSharedEncodingAttr>(encoding))
         stride /= partEnc.getNumPartitions();
       Value offset = b.i32_val(opOffsetVals.front() * stride);

--- a/lib/Dialect/TritonGPU/IR/Dialect.cpp
+++ b/lib/Dialect/TritonGPU/IR/Dialect.cpp
@@ -447,35 +447,38 @@ SmallVector<int64_t> getShapePerCTA(Attribute layout, ArrayRef<int64_t> shape) {
   return getShapePerCTA(getCTASplitNum(layout), shape);
 }
 
-SmallVector<int64_t> getAllocationShapePerCTA(Attribute layout,
-                                              ArrayRef<int64_t> shapeLogical) {
-  SmallVector<int64_t> shape(shapeLogical);
-  std::optional<int64_t> packedAxis;
-  if (auto sharedMMALayout = dyn_cast<NVMMASharedEncodingAttr>(layout)) {
-    if (sharedMMALayout.getFp4Padded())
-      packedAxis = getOrder(sharedMMALayout, shapeLogical)[0];
-  } else if (auto tmemLayout =
-                 dyn_cast<nvidia_gpu::TensorMemoryEncodingAttr>(layout)) {
-    // An fp4Padded TMEM descriptor keeps the packed Mx(K/2)xi8 shape. Allocate
-    // two physical columns per packed K coordinate so each logical FP4 element
-    // occupies one byte in TMEM.
-    if (tmemLayout.getFp4Padded())
-      packedAxis = 1;
-  }
-  if (packedAxis)
-    shape[*packedAxis] *= 2;
-  return getShapePerCTA(layout, shape);
-}
-
 SmallVector<int64_t> getShapePerCTA(Type type) {
   auto tensorType = cast<TensorOrMemDesc>(type);
   return getShapePerCTA(tensorType.getEncoding(), tensorType.getShape());
 }
 
-SmallVector<int64_t> getAllocationShapePerCTA(Type type) {
-  auto tensorType = cast<TensorOrMemDesc>(type);
-  return getAllocationShapePerCTA(tensorType.getEncoding(),
-                                  tensorType.getShape());
+int64_t getAllocationElems(Attribute encoding, ArrayRef<int64_t> shape,
+                           ArrayRef<int64_t> allocShape) {
+  if (allocShape.empty())
+    allocShape = shape;
+  auto layoutShape = dropPipeliningDim(shape, encoding);
+  auto allocationShape = dropPipeliningDim(allocShape, encoding);
+  auto layout = isPaddedEncoding(encoding)
+                    ? paddedLinearLayout(allocationShape, encoding)
+                    : toLinearLayout(allocationShape, encoding);
+  auto offsetDim = StringAttr::get(encoding.getContext(), "offset");
+  int64_t stages = product<int64_t>(shape.drop_back(layoutShape.size()));
+  int64_t elems = stages * layout.getInDimSize(offsetDim);
+  if (layoutShape != allocationShape) {
+    auto logicalDims = llvm::to_vector(layout.getOutDimNames());
+    LinearLayout identity = LinearLayout::empty();
+    for (auto [dim, size] : llvm::zip_equal(logicalDims, layoutShape))
+      identity *= LinearLayout::identity1D(size, dim, dim);
+    auto view = identity.invertAndCompose(layout);
+    uint64_t zeroMask = (layout.getInDimSize(offsetDim) - 1) &
+                        ~getInputBasisMask(layout, offsetDim, logicalDims);
+    int64_t viewElems =
+        (getOutputBasisMask(view, logicalDims, offsetDim) | zeroMask) + 1;
+    elems = (stages - 1) * layout.getInDimSize(offsetDim) + viewElems;
+  }
+  if (auto partitioned = dyn_cast<PartitionedSharedEncodingAttr>(encoding))
+    elems *= partitioned.getNumPartitions();
+  return elems;
 }
 
 SmallVector<unsigned> getMmaV2WarpsPerCTA(ArrayRef<int64_t> shape,

--- a/lib/Dialect/TritonGPU/IR/Dialect.cpp
+++ b/lib/Dialect/TritonGPU/IR/Dialect.cpp
@@ -454,6 +454,8 @@ SmallVector<int64_t> getShapePerCTA(Type type) {
 
 int64_t getAllocationElems(Attribute encoding, ArrayRef<int64_t> shape,
                            ArrayRef<int64_t> allocShape) {
+  assert(isa<SharedEncodingTrait>(encoding) &&
+         "expected a shared-memory encoding");
   if (allocShape.empty())
     allocShape = shape;
   auto layoutShape = dropPipeliningDim(shape, encoding);

--- a/lib/Dialect/TritonGPU/Transforms/Pipeliner/PipeliningUtility.cpp
+++ b/lib/Dialect/TritonGPU/Transforms/Pipeliner/PipeliningUtility.cpp
@@ -408,9 +408,9 @@ Value mlir::triton::createAlloc(Operation *insertBefore, RankedTensorType ty,
 bool mlir::triton::canPipelineTMALoad(Operation *op) {
   auto tensorTy = cast<RankedTensorType>(op->getResultTypes()[0]);
   auto sharedEncoding = getSharedEncoding(op);
-  int64_t stageSizeInBits = product(ttg::getAllocationShapePerCTA(
-                                sharedEncoding, tensorTy.getShape())) *
-                            tensorTy.getElementTypeBitWidth();
+  int64_t stageSizeInBits =
+      ttg::getAllocationElems(sharedEncoding, tensorTy.getShape()) *
+      tensorTy.getElementTypeBitWidth();
   return stageSizeInBits % (ttng::TMA_ALIGN * 8) == 0;
 }
 

--- a/python/test/gluon/test_lowerings.py
+++ b/python/test/gluon/test_lowerings.py
@@ -594,7 +594,9 @@ def _make_shared_layout(kind, shape):
         inner = ttgl.SwizzledSharedLayout(vec=4, per_phase=2, max_phase=4, order=order)
         return PartitionedSharedLayout(num_partitions=2, num_groups=1, partition_dim=0, partition_layout=inner)
     if kind == "partitioned_padded":
-        inner = ttgl.PaddedSharedLayout.with_identity_for(interval_padding_pairs=[[16, 4]], shape=list(shape),
+        piece_shape = list(shape)
+        piece_shape[0] //= 2
+        inner = ttgl.PaddedSharedLayout.with_identity_for(interval_padding_pairs=[[16, 4]], shape=piece_shape,
                                                           order=order)
         return PartitionedSharedLayout(num_partitions=2, num_groups=1, partition_dim=0, partition_layout=inner)
     raise ValueError(f"Unknown shared layout kind: {kind}")
@@ -2080,9 +2082,11 @@ def test_memdesc_subslice(M, N, M_tile_size, N_tile_size, shared_layout_cfg, dev
             padded_bytes = ((M * N * (pad_interval + pad_amount)) // pad_interval) * elem_size
             if padded_bytes >= get_hip_lds_size():
                 pytest.skip(f"Partitioned-padded allocation ({padded_bytes} B) exceeds LDS ({get_hip_lds_size()} B)")
+            piece_shape = [M, N]
+            piece_shape[partition_dim] //= num_partitions * num_groups
             inner_layout = ttgl.PaddedSharedLayout.with_identity_for(
                 interval_padding_pairs=[[pad_interval, pad_amount]],
-                shape=[M, N],
+                shape=piece_shape,
                 order=[1, 0],
             )
         shared_layout = PartitionedSharedLayout(
@@ -2242,9 +2246,11 @@ def test_partitioned_shared_layout(M, K, num_partitions, num_groups, partition_d
             order=[1, 0],
         )
     elif partition_layout_type == "padded":
+        piece_shape = [M, K]
+        piece_shape[partition_dim] //= num_partitions * num_groups
         inner_layout = ttgl.PaddedSharedLayout.with_identity_for(
             interval_padding_pairs=[[16, 4]],
-            shape=[M, K],
+            shape=piece_shape,
             order=[1, 0],
         )
     else:

--- a/test/Analysis/test-allocation.mlir
+++ b/test/Analysis/test-allocation.mlir
@@ -13,6 +13,7 @@
 #A_SHARED = #ttg.swizzled_shared<{vec = 2, perPhase = 2, maxPhase = 4, order = [1, 0]}>
 #A_SHARED_1D = #ttg.swizzled_shared<{vec = 2, perPhase = 2, maxPhase = 4, order = [0]}>
 #A_SHARED_T = #ttg.swizzled_shared<{vec = 2, perPhase = 2, maxPhase = 4, order = [0, 1]}>
+#A_SHARED_HOLEY = #ttg.shared_linear<{offset = [[0, 1], [0, 0], [1, 0], [2, 0]], block = []}, alignment = 16>
 #B_SHARED = #ttg.swizzled_shared<{vec = 2, perPhase = 2, maxPhase = 4, order = [1, 0]}>
 #C = #ttg.nvidia_mma<{versionMajor = 2, warpsPerCTA = [4, 1], instrShape = [16, 8]}>
 #A_DOT = #ttg.dot_op<{opIdx = 0, parent = #C, kWidth = 2}>
@@ -992,23 +993,37 @@ tt.func @tightly_packed_captures(%arg0: i8, %arg1: i64) {
   } : (i8, i64) -> ()
   tt.return
 }
-// expected-remark @below {{nvmma_alignment}}
-// expected-remark @below {{size = 1088}}
-tt.func @nvmma_alignment(%lb : index, %ub : index, %step : index, %A : !tt.ptr<f16>, %B : !tt.ptr<f16>) {
-  // expected-remark @below {{offset = 0, size = 256}}
-  %fp4 = ttg.local_alloc : () -> !ttg.memdesc<1x128xi8, #NVMMA_SHARED_FP4PADDED, #ttg.shared_memory, mutable>
-  // expected-remark @below {{offset = 0, size = 64}}
-  %a = ttg.local_alloc : () -> !ttg.memdesc<32xf16, #A_SHARED_1D, #ttg.shared_memory, mutable>
-  // expected-remark @below {{offset = 128, size = 64}}
-  %b = ttg.local_alloc : () -> !ttg.memdesc<8x8xi8, #NVMMA_SHARED_0, #ttg.shared_memory, mutable>
-  // expected-remark @below {{offset = 256, size = 64}}
-  %c = ttg.local_alloc : () -> !ttg.memdesc<4x16xi8, #NVMMA_SHARED_32, #ttg.shared_memory, mutable>
-  // expected-remark @below {{offset = 512, size = 64}}
-  %d = ttg.local_alloc : () -> !ttg.memdesc<2x32xi8, #NVMMA_SHARED_64, #ttg.shared_memory, mutable>
-  // expected-remark @below {{offset = 1024, size = 64}}
-  %e = ttg.local_alloc : () -> !ttg.memdesc<1x64xi8, #NVMMA_SHARED_128, #ttg.shared_memory, mutable>
+// expected-remark @below {{fp4_padded_shared_allocation}}
+// expected-remark @below {{size = 1024}}
+tt.func @fp4_padded_shared_allocation() {
+  // expected-remark @below {{offset = 0, size = 1024}}
+  %fp4 = ttg.local_alloc : () -> !ttg.memdesc<8x64xi8, #NVMMA_SHARED_FP4PADDED, #ttg.shared_memory, mutable>
+  tt.return
+}
 
-  ttg.local_dealloc %a : !ttg.memdesc<32xf16, #A_SHARED_1D, #ttg.shared_memory, mutable>
+// expected-remark @below {{nvmma_alignment}}
+// expected-remark @below {{size = 1536}}
+tt.func @nvmma_alignment(%lb : index, %ub : index, %step : index, %A : !tt.ptr<f16>, %B : !tt.ptr<f16>) {
+  // expected-remark @below {{offset = 0, size = 640}}
+  %a = ttg.local_alloc : () -> !ttg.memdesc<5x64xf16, #A_SHARED_1D, #ttg.shared_memory, mutable>
+  // expected-remark @below {{offset = 640, size = 64}}
+  %b = ttg.local_alloc : () -> !ttg.memdesc<8x8xi8, #NVMMA_SHARED_0, #ttg.shared_memory, mutable>
+  // expected-remark @below {{offset = 768, size = 128}}
+  %c = ttg.local_alloc : () -> !ttg.memdesc<8x16xi8, #NVMMA_SHARED_32, #ttg.shared_memory, mutable>
+  // expected-remark @below {{offset = 1024, size = 256}}
+  %d = ttg.local_alloc : () -> !ttg.memdesc<8x32xi8, #NVMMA_SHARED_64, #ttg.shared_memory, mutable>
+  // expected-remark @below {{offset = 1024, size = 512}}
+  %e = ttg.local_alloc : () -> !ttg.memdesc<8x64xi8, #NVMMA_SHARED_128, #ttg.shared_memory, mutable>
+
+  ttg.local_dealloc %a : !ttg.memdesc<5x64xf16, #A_SHARED_1D, #ttg.shared_memory, mutable>
+  tt.return
+}
+
+// expected-remark @below {{holey_shared_allocation}}
+// expected-remark @below {{size = 64}}
+tt.func @holey_shared_allocation() {
+  // expected-remark @below {{offset = 0, size = 64}}
+  %alloc = ttg.local_alloc : () -> !ttg.memdesc<4x2xi32, #A_SHARED_HOLEY, #ttg.shared_memory, mutable>
   tt.return
 }
 

--- a/test/Analysis/test-buffer-region.mlir
+++ b/test/Analysis/test-buffer-region.mlir
@@ -70,9 +70,11 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 1 : i32, ttg.shar
 #shared_dense_half = #ttg.shared_linear<{offset = [[0, 1], [0, 2], [1, 0]], block = []}, alignment = 16>
 #smem = #ttg.shared_memory
 
-module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 1 : i32, ttg.shared = 64 : i32, ttg.target = "cuda:90", ttg.tensor_memory_size = 0 : i32, "ttg.threads-per-warp" = 32 : i32, "ttg.total-num-warps" = 1 : i32} {
+module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 1 : i32, ttg.shared = 128 : i32, ttg.target = "cuda:90", ttg.tensor_memory_size = 0 : i32, "ttg.threads-per-warp" = 32 : i32, "ttg.total-num-warps" = 1 : i32} {
   tt.func public @shared_zero_bases_belong_to_allocation() {
     %alloc = ttg.local_alloc {allocation.offset = 0 : i32} : () -> !ttg.memdesc<4x2xi32, #shared_holey, #smem, mutable>
+    // expected-remark @below {{Buffers: [0, 64]}}
+    ttg.local_load %alloc : !ttg.memdesc<4x2xi32, #shared_holey, #smem, mutable> -> tensor<4x2xi32>
     %view = ttg.memdesc_reinterpret %alloc : !ttg.memdesc<4x2xi32, #shared_holey, #smem, mutable> -> !ttg.memdesc<4x4xi32, #shared_dense, #smem, mutable>
     // expected-remark @below {{Buffers: [0, 64]}}
     ttg.local_load %view : !ttg.memdesc<4x4xi32, #shared_dense, #smem, mutable> -> tensor<4x4xi32>
@@ -95,6 +97,24 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 1 : i32, ttg.shar
     ttg.local_load %lower : !ttg.memdesc<2x2xi32, #shared_holey, #smem, mutable, 4x2> -> tensor<2x2xi32>
     // expected-remark @below {{Buffers: [32, 32]}}
     ttg.local_load %upper : !ttg.memdesc<2x2xi32, #shared_holey, #smem, mutable, 4x2> -> tensor<2x2xi32>
+    tt.return
+  }
+
+  tt.func public @shared_zero_bases_pipeline_stages(%index: i32) {
+    %alloc = ttg.local_alloc {allocation.offset = 0 : i32} : () -> !ttg.memdesc<2x4x2xi32, #shared_holey, #smem, mutable>
+    %view = ttg.memdesc_index %alloc[%index] : !ttg.memdesc<2x4x2xi32, #shared_holey, #smem, mutable> -> !ttg.memdesc<4x2xi32, #shared_holey, #smem, mutable>
+    // expected-remark @below {{Buffers: [0, 64], [64, 64]}}
+    ttg.local_load %view : !ttg.memdesc<4x2xi32, #shared_holey, #smem, mutable> -> tensor<4x2xi32>
+    tt.return
+  }
+
+  tt.func public @shared_zero_bases_pipeline_subslice() {
+    %zero = arith.constant 0 : i32
+    %alloc = ttg.local_alloc {allocation.offset = 0 : i32} : () -> !ttg.memdesc<2x4x2xi32, #shared_holey, #smem, mutable>
+    %stage = ttg.memdesc_subslice %alloc [1, 0, 0] : !ttg.memdesc<2x4x2xi32, #shared_holey, #smem, mutable> -> !ttg.memdesc<1x4x2xi32, #shared_holey, #smem, mutable, 2x4x2>
+    %view = ttg.memdesc_index %stage[%zero] : !ttg.memdesc<1x4x2xi32, #shared_holey, #smem, mutable, 2x4x2> -> !ttg.memdesc<4x2xi32, #shared_holey, #smem, mutable>
+    // expected-remark @below {{Buffers: [64, 64]}}
+    ttg.local_load %view : !ttg.memdesc<4x2xi32, #shared_holey, #smem, mutable> -> tensor<4x2xi32>
     tt.return
   }
 }
@@ -125,12 +145,38 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 1 : i32, ttg.shar
 #padded = #ttg.padded_shared<[4:+2] {order = [1, 0], shape = [4, 4]}>
 #smem = #ttg.shared_memory
 
-module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 1 : i32, ttg.shared = 44 : i32, ttg.target = "cuda:90", ttg.tensor_memory_size = 0 : i32, "ttg.threads-per-warp" = 32 : i32, "ttg.total-num-warps" = 1 : i32} {
+module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 1 : i32, ttg.shared = 184 : i32, ttg.target = "cuda:90", ttg.tensor_memory_size = 0 : i32, "ttg.threads-per-warp" = 32 : i32, "ttg.total-num-warps" = 1 : i32} {
   tt.func public @padded_shared_reinterpret_region() {
     %alloc = ttg.local_alloc {allocation.offset = 0 : i32} : () -> !ttg.memdesc<4x4xf16, #padded, #smem, mutable>
     %view = ttg.memdesc_reinterpret %alloc : !ttg.memdesc<4x4xf16, #padded, #smem, mutable> -> !ttg.memdesc<4x4xbf16, #padded, #smem, mutable>
     // expected-remark @below {{Buffers: [0, 44]}}
     ttg.local_load %view : !ttg.memdesc<4x4xbf16, #padded, #smem, mutable> -> tensor<4x4xbf16>
+    tt.return
+  }
+
+  tt.func public @padded_shared_buffer_regions() {
+    %alloc = ttg.local_alloc {allocation.offset = 0 : i32} : () -> !ttg.memdesc<4x4xi32, #padded, #smem, mutable>
+    // expected-remark @below {{Buffers: [0, 88]}}
+    ttg.local_load %alloc : !ttg.memdesc<4x4xi32, #padded, #smem, mutable> -> tensor<4x4xi32>
+    tt.return
+  }
+
+  tt.func public @padded_shared_subslice_regions() {
+    %alloc = ttg.local_alloc {allocation.offset = 0 : i32} : () -> !ttg.memdesc<4x4xi32, #padded, #smem, mutable>
+    %lower = ttg.memdesc_subslice %alloc [0, 0] : !ttg.memdesc<4x4xi32, #padded, #smem, mutable> -> !ttg.memdesc<2x4xi32, #padded, #smem, mutable, 4x4>
+    %upper = ttg.memdesc_subslice %alloc [2, 0] : !ttg.memdesc<4x4xi32, #padded, #smem, mutable> -> !ttg.memdesc<2x4xi32, #padded, #smem, mutable, 4x4>
+    // expected-remark @below {{Buffers: [0, 40]}}
+    ttg.local_load %lower : !ttg.memdesc<2x4xi32, #padded, #smem, mutable, 4x4> -> tensor<2x4xi32>
+    // expected-remark @below {{Buffers: [48, 40]}}
+    ttg.local_load %upper : !ttg.memdesc<2x4xi32, #padded, #smem, mutable, 4x4> -> tensor<2x4xi32>
+    tt.return
+  }
+
+  tt.func public @padded_shared_pipeline_stages(%index: i32) {
+    %alloc = ttg.local_alloc {allocation.offset = 0 : i32} : () -> !ttg.memdesc<2x4x4xi32, #padded, #smem, mutable>
+    %view = ttg.memdesc_index %alloc[%index] : !ttg.memdesc<2x4x4xi32, #padded, #smem, mutable> -> !ttg.memdesc<4x4xi32, #padded, #smem, mutable>
+    // expected-remark @below {{Buffers: [0, 88], [96, 88]}}
+    ttg.local_load %view : !ttg.memdesc<4x4xi32, #padded, #smem, mutable> -> tensor<4x4xi32>
     tt.return
   }
 }

--- a/test/Conversion/amd/tritongpu_to_llvm.mlir
+++ b/test/Conversion/amd/tritongpu_to_llvm.mlir
@@ -664,7 +664,7 @@ module attributes {"ttg.target" = "hip:gfx942", "ttg.num-ctas" = 1 : i32, "ttg.n
     // Skip three constants from the stride calculation
     // GFX950: llvm.mlir.constant
     // GFX950: llvm.mlir.constant
-    // GFX950: llvm.mlir.constant
+    // GFX950: llvm.mlir.constant(4096 : i32)
 
     // GFX950-DAG: %[[CST0:.+]] = llvm.mlir.constant(0 : i32)
     // GFX950-DAG: %[[CST7:.+]] = llvm.mlir.constant(7 : i32)

--- a/test/Conversion/amd/tritongpu_to_llvm_gfx1250.mlir
+++ b/test/Conversion/amd/tritongpu_to_llvm_gfx1250.mlir
@@ -34,6 +34,8 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, "ttg.thr
 #blocked = #ttg.blocked<{sizePerThread = [1, 1], threadsPerWarp = [8, 4], warpsPerCTA = [2, 1], order = [1, 0]}>
 #inner_padded = #ttg.padded_shared<[128:+4] {order = [1, 0], shape = [16, 16]}>
 #partitioned = #ttg.partitioned_shared<{numPartitions = 2, numGroups = 2, partitionDim = 0, partitionLayout = #inner_padded}>
+#inner_padded_piece = #ttg.padded_shared<[128:+4] {order = [1, 0], shape = [4, 16]}>
+#partitioned_piece = #ttg.partitioned_shared<{numPartitions = 2, numGroups = 2, partitionDim = 0, partitionLayout = #inner_padded_piece}>
 #smem = #ttg.shared_memory
 module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 2 : i32, "ttg.threads-per-warp" = 32 : i32} {
   // GFX1250-LABEL: partitioned_shared_padded_local_alloc
@@ -41,6 +43,15 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 2 : i32, "ttg.thr
     // GFX1250: llvm.mlir.addressof @global_smem
     // GFX1250-COUNT-4: llvm.store {{.*}} : vector<{{[0-9]+}}xf16>, !llvm.ptr<3>
     %0 = ttg.local_alloc %arg0 : (tensor<16x16xf16, #blocked>) -> !ttg.memdesc<16x16xf16, #partitioned, #smem, mutable>
+    tt.return
+  }
+
+  // GFX1250-LABEL: partitioned_shared_padded_multibuffer_index
+  tt.func @partitioned_shared_padded_multibuffer_index(%index: i32) {
+    %parent = ttg.local_alloc : () -> !ttg.memdesc<2x16x16xf16, #partitioned_piece, #smem, mutable>
+    // GFX1250: llvm.mlir.constant(128 : i32)
+    // GFX1250: llvm.getelementptr
+    %view = ttg.memdesc_index %parent[%index] : !ttg.memdesc<2x16x16xf16, #partitioned_piece, #smem, mutable> -> !ttg.memdesc<16x16xf16, #partitioned_piece, #smem, mutable>
     tt.return
   }
 }

--- a/third_party/nvidia/lib/TritonNVIDIAGPUToLLVM/DotOpToLLVM/MMAv5.cpp
+++ b/third_party/nvidia/lib/TritonNVIDIAGPUToLLVM/DotOpToLLVM/MMAv5.cpp
@@ -497,8 +497,6 @@ struct DotConversion {
     unsigned K;
   } shape;
   int mmaSizeK;
-  SmallVector<int64_t> shapeA;
-  SmallVector<int64_t> shapeB;
   int numBitsPerElementA;
   int numBitsPerElementB;
   GetAccAddressFn getAccAddress;
@@ -570,8 +568,6 @@ LogicalResult convertDotImpl(const LLVMTypeConverter &typeConverter,
          "grep for [Note: numRepN > 1 and two_ctas]");
   int numRepK = ceil<unsigned>(K, mmaSizeK);
 
-  SmallVector<int64_t> shapeA = op.shapeA;
-  SmallVector<int64_t> shapeB = op.shapeB;
   // In A * B = C
   // For M=64 twoCTAs, B and C have the same split and A has a split half of C
   // along M.
@@ -712,8 +708,6 @@ LogicalResult convertDot(const LLVMTypeConverter &typeConverter,
     dot.mmaSizeK = 64;
   }
 
-  dot.shapeA = getShapePerCTA(aTensorTy);
-  dot.shapeB = getShapePerCTA(bTensorTy);
   dot.numBitsPerElementA = aTensorTy.getElementTypeBitWidth();
   dot.numBitsPerElementB = bTensorTy.getElementTypeBitWidth();
 
@@ -783,6 +777,9 @@ int getScaleFactorColsPerSet(mxfpKind kind, ttng::TCGen5MMAScaledOp op,
 };
 
 bool isFp4Padded(MemDescType operand) {
+  // An fp4Padded TMEM descriptor keeps the packed Mx(K/2)xi8 shape. Allocate
+  // two physical columns per packed K coordinate so each logical FP4 element
+  // occupies one byte in TMEM.
   if (auto tmemLayout =
           dyn_cast<ttng::TensorMemoryEncodingAttr>(operand.getEncoding()))
     return tmemLayout.getFp4Padded();
@@ -831,13 +828,6 @@ LogicalResult convertScaledDot(const LLVMTypeConverter &typeConverter,
   dot.shape.M = dstPerCTA[0];
   dot.shape.N = dstPerCTA[1];
   dot.shape.K = blockK; // K is not split across CTAs
-
-  dot.shapeA = triton::gpu::getAllocationShapePerCTA(aTensorTy);
-  dot.shapeB = triton::gpu::getAllocationShapePerCTA(bTensorTy);
-  if (opKindIsMXFP4) {
-    dot.shapeA[1] *= 2;
-    dot.shapeB[0] *= 2;
-  }
 
   bool hasFp4PaddedOperand = isFp4Padded(aTensorTy) || isFp4Padded(bTensorTy);
 


### PR DESCRIPTION
This spiraled a little bit from noting that `getAllocationShapePerCTA`
was incorrect for `SharedLinearLayout`s with broadcasting. I also noted
that we never really need the "allocation shape" as it's not even a well
defined concept in the presence of broadcasting.

Instead, we compute the number of elements that we need to allocate, which
is just the number of `kOffset` bases of the layout (+ pipelining)

We also kill `getMemDescSize` which had similar issues.

There is probably a bigger clean-up around computing shapes and things
around shapes as we have a million helpers that compute similar but
subtly different quantities without using the associated LinearLayouts,
but I'm leaving that one for another day.
