### PR TITLE
RemoveLayoutConversions: drop dangling remat mapping entries for eras…

### DIFF
--- a/lib/Dialect/TritonGPU/Transforms/RemoveLayoutConversions.cpp
+++ b/lib/Dialect/TritonGPU/Transforms/RemoveLayoutConversions.cpp
@@ -180,6 +180,11 @@ public:
 
 private:
   void updateRematMapping(SmallVector<std::tuple<Value, Value>> &values);
+  // Erase any rematMapping entries whose key or remat value belongs to \p op
+  // (its own results, or the results / block arguments of nested operations).
+  // Must be called right before erasing \p op so the map never retains dangling
+  // keys/values (e.g. old loop body block args added during for/if rewrites).
+  void eraseRematMappingForErasedOp(Operation *op);
   // Map values to their rematerializations for a given encoding. We have to be
   // careful about what we put in this map because updateRematMapping only
   // updates keys, and doesn't search for rematerialized values that may be
@@ -213,6 +218,40 @@ void LayoutRematerialization::addRematValue(Value old, Attribute encoding,
                                             Value newV) {
   LDBG("addRematValue " << old << " encoding " << encoding << " " << newV);
   rematMapping[old][encoding] = newV;
+}
+
+void LayoutRematerialization::eraseRematMappingForErasedOp(Operation *op) {
+  // Collect every value that will be destroyed together with \p op: its own
+  // results, plus the results and block arguments of any nested operations
+  // (e.g. the body block arguments of an scf.for/scf.if being replaced).
+  llvm::SmallDenseSet<Value, 8> dying;
+  for (Value r : op->getResults())
+    dying.insert(r);
+  op->walk([&](Operation *nested) {
+    if (nested != op)
+      for (Value r : nested->getResults())
+        dying.insert(r);
+    for (Region &region : nested->getRegions())
+      for (Block &block : region)
+        for (BlockArgument arg : block.getArguments())
+          dying.insert(arg);
+  });
+  if (dying.empty())
+    return;
+  // Drop entries keyed on a dying value.
+  for (Value v : dying)
+    rematMapping.erase(v);
+  // Drop entries whose remat value is dying. (llvm::DenseMap::erase(iterator)
+  // returns void, so collect the encodings first, then erase by key.)
+  for (auto &keyAndRemats : rematMapping) {
+    auto &remats = keyAndRemats.second;
+    SmallVector<Attribute, 4> encodingsToErase;
+    for (auto &encAndVal : remats)
+      if (dying.contains(encAndVal.second))
+        encodingsToErase.push_back(encAndVal.first);
+    for (Attribute enc : encodingsToErase)
+      remats.erase(enc);
+  }
 }
 
 // Return true if the op is an op with a layout we don't want to change. We will
@@ -877,9 +916,12 @@ void LayoutRematerialization::rewriteSlice(
     builder.replaceAllUsesWith(std::get<0>(kv), std::get<1>(kv));
   }
 
+  eraseRematMappingForErasedOp(convertOp);
   convertOp->erase();
-  for (Operation *op : deadOps)
+  for (Operation *op : deadOps) {
+    eraseRematMappingForErasedOp(op);
     op->erase();
+  }
 }
 
 void LayoutRematerialization::rewriteSlice(
@@ -1233,6 +1275,7 @@ bool LayoutRematerialization::backwardRematerialization(
   if (newV && domInfo.properlyDominates(newV, convertOp)) {
     // Replace it with the remat'ed value.
     convertOp.replaceAllUsesWith(newV);
+    eraseRematMappingForErasedOp(convertOp);
     convertOp->erase();
     LDBG("found remat'ed value" << newV);
     return true;


### PR DESCRIPTION

## Summary
`LayoutRematerialization` in the `-tritongpu-remove-layout-conversions` pass can leave **dangling entries** in its `rematMapping` after ops are erased during backward rematerialization. In asserts-enabled builds this trips the destructor consistency check:

```
lib/Dialect/TritonGPU/Transforms/RemoveLayoutConversions.cpp:205:
LayoutRematerialization::~LayoutRematerialization():
Assertion `live.contains(key) && "remat mapping: key not present"' failed.
```

The pass fails with `PassManager::run failed` (pipeline aborts in `TritonGPURemoveLayoutConversions`). In release (no-assert) builds the same stale state is still latent: a later `getRematValue()` lookup can return a value whose defining op has been erased.

## Root cause
In `rewriteSlice()`, rewriting an `scf.for` / `scf.if` in the remat slice records remat values keyed on the **old** region's block arguments, e.g. for the for-loop path:

```cpp
// old loop-body block argument recorded as a remat key
addRematValue(oldArg, layout[oldArg], loopBody.getArgument(...));
...
deadOps.push_back(forOp.getOperation());
...
for (Operation *op : deadOps)
  op->erase();          // erases the old scf.for -> oldArg is now dangling
```

`updateRematMapping()` only migrates entries for values present in `replacements` (op **results**); it does not touch entries keyed on the **block arguments** (or nested results) of region ops that are about to be erased. So once the old `scf.for`/`scf.if` is deleted, any `rematMapping` key/value referring to its block args/results dangles.

## Fix
Add `eraseRematMappingForErasedOp(Operation *op)` and call it immediately before erasing the convert op and each `deadOps` entry (and in the hoist-dot-operand path). It removes any `rematMapping` key or remat value that belongs to the op being deleted — the op's results plus the results and block arguments of any nested ops. This keeps the map consistent and is a no-op for slices that don't erase region ops.

## Testing
- Surfaced while compiling **Mamba-2 (nemotron-h) backward** kernels (`_chunk_scan_bwd_ddAcs_stable_kernel`) on the **NVIDIA Rubin architecture (`sm_107`)** with Triton built from `main`. Before the fix, compilation aborts in `TritonGPURemoveLayoutConversions` with the assertion above; after the fix the kernels compile and the model trains with correct (finite) gradients.
- The failing slice spans an `scf.for` that is erased during remat, which is exactly the dangling-key path fixed here (adjacent to the earlier stale-remat-value fix in this pass).
- A minimal deterministic lit repro is awkward because the dangling entry only appears when a backward-remat slice crosses a subsequently-erased `scf.for`/`scf.if`; happy to add one if a maintainer wants it.

---

