### PR TITLE
[BACKEND] Use target TTI for mandatory inlining

### DIFF
--- a/python/src/llvm.cc
+++ b/python/src/llvm.cc
@@ -362,8 +362,7 @@ std::string translateLLVMIRToASM(
   }
 
   // Set up target information before inlining so target-specific inline
-  // compatibility checks use the backend's TTI. In particular, NVPTX allows
-  // calls between functions with different target attributes.
+  // compatibility checks use the backend's TTI.
   module.setTargetTriple(Triple(triple));
   auto machine = createTargetMachine(&module, proc, enable_fp_fusion, features);
   module.setDataLayout(machine->createDataLayout());
@@ -374,9 +373,8 @@ std::string translateLLVMIRToASM(
       f.addFnAttr(llvm::Attribute::AlwaysInline);
   // verify and store llvm
   llvm::legacy::PassManager pm;
-  if (Triple(triple).isNVPTX())
-    pm.add(llvm::createTargetTransformInfoWrapperPass(
-        machine->getTargetIRAnalysis()));
+  pm.add(llvm::createTargetTransformInfoWrapperPass(
+      machine->getTargetIRAnalysis()));
   pm.add(llvm::createAlwaysInlinerLegacyPass());
   pm.add(llvm::createVerifierPass());
 

--- a/python/src/llvm.cc
+++ b/python/src/llvm.cc
@@ -361,12 +361,22 @@ std::string translateLLVMIRToASM(
     }
   }
 
+  // Set up target information before inlining so target-specific inline
+  // compatibility checks use the backend's TTI. In particular, NVPTX allows
+  // calls between functions with different target attributes.
+  module.setTargetTriple(Triple(triple));
+  auto machine = createTargetMachine(&module, proc, enable_fp_fusion, features);
+  module.setDataLayout(machine->createDataLayout());
+
   // inline everything
   for (llvm::Function &f : module.functions())
     if (!f.hasFnAttribute(llvm::Attribute::NoInline))
       f.addFnAttr(llvm::Attribute::AlwaysInline);
   // verify and store llvm
   llvm::legacy::PassManager pm;
+  if (Triple(triple).isNVPTX())
+    pm.add(llvm::createTargetTransformInfoWrapperPass(
+        machine->getTargetIRAnalysis()));
   pm.add(llvm::createAlwaysInlinerLegacyPass());
   pm.add(llvm::createVerifierPass());
 
@@ -387,11 +397,6 @@ std::string translateLLVMIRToASM(
     timePassesStr.clear();
   }
 
-  // create machine
-  module.setTargetTriple(Triple(triple));
-  auto machine = createTargetMachine(&module, proc, enable_fp_fusion, features);
-  // set data layout
-  module.setDataLayout(machine->createDataLayout());
   if (canonicalizeGEP && !disableLLVMOpt) {
     // The NVPTX pipeline otherwise exposes many equivalent GEPs to SLSR
     // without eliminating them first.

--- a/python/test/unit/cuda/test_denorm_cuda.py
+++ b/python/test/unit/cuda/test_denorm_cuda.py
@@ -1,0 +1,42 @@
+import pytest
+import torch
+import triton
+import triton.language as tl
+
+from triton._internal_testing import is_cuda
+from triton.language import core
+
+
+@core.extern
+def _fma(x, scale, lib_path: tl.constexpr, _semantic=None):
+    return core.extern_elementwise(
+        "test_denorm",
+        lib_path.value,
+        [x, scale],
+        {(core.float32, core.float32): ("fma", core.float32)},
+        is_pure=True,
+        _semantic=_semantic,
+    )
+
+
+@triton.jit
+def _kernel(x, scale, lib_path: tl.constexpr):
+    offsets = tl.arange(0, 2)
+    tl.store(x + offsets, _fma(tl.load(x + offsets), scale, lib_path))
+
+
+@pytest.mark.skipif(not is_cuda(), reason="CUDA only")
+def test_linked_function_preserves_denorms(tmp_path):
+    lib = tmp_path / "denorm.ll"
+    lib.write_text(r'''
+define float @fma(float %x, float %scale) #0 {
+  %result = call float @llvm.fma.f32(float %x, float %scale, float 0.000000e+00)
+  ret float %result
+}
+declare float @llvm.fma.f32(float, float, float)
+attributes #0 = { cold denormal_fpenv(float: preservesign) "target-cpu"="sm_100" }
+''')
+    bits = [1, -2147483645]
+    x = torch.tensor(bits, dtype=torch.int32, device="cuda").view(torch.float32)
+    _kernel[(1, )](x, 1.0, str(lib), extern_libs={"test_denorm": str(lib)})
+    assert x.view(torch.int32).tolist() == bits

--- a/python/test/unit/cuda/test_denorm_cuda.py
+++ b/python/test/unit/cuda/test_denorm_cuda.py
@@ -8,35 +8,39 @@ from triton.language import core
 
 
 @core.extern
-def _fma(x, scale, lib_path: tl.constexpr, _semantic=None):
+def _sin_f32(x, lib_path: tl.constexpr, _semantic=None):
     return core.extern_elementwise(
         "test_denorm",
         lib_path.value,
-        [x, scale],
-        {(core.float32, core.float32): ("fma", core.float32)},
+        [x],
+        {(core.float32, ): ("_sin_f32", core.float32)},
         is_pure=True,
         _semantic=_semantic,
     )
 
 
 @triton.jit
-def _kernel(x, scale, lib_path: tl.constexpr):
-    offsets = tl.arange(0, 2)
-    tl.store(x + offsets, _fma(tl.load(x + offsets), scale, lib_path))
+def _kernel(x, lib_path: tl.constexpr):
+    offsets = tl.arange(0, 1)
+    tl.store(x + offsets, _sin_f32(tl.load(x + offsets), lib_path))
 
 
 @pytest.mark.skipif(not is_cuda(), reason="CUDA only")
 def test_linked_function_preserves_denorms(tmp_path):
     lib = tmp_path / "denorm.ll"
     lib.write_text(r'''
-define float @fma(float %x, float %scale) #0 {
-  %result = call float @llvm.fma.f32(float %x, float %scale, float 0.000000e+00)
+define float @_sin_f32(float %x) #0 {
+  %scaled = fmul float %x, 0x3FE45F3060000000
+  %quadrant = call i32 @llvm.nvvm.f2i.rn.ftz(float %scaled)
+  %quadrant.f = sitofp i32 %quadrant to float
+  %result = call float @llvm.fma.f32(float %quadrant.f, float 0xBFF921FB40000000, float %x)
   ret float %result
 }
+declare i32 @llvm.nvvm.f2i.rn.ftz(float)
 declare float @llvm.fma.f32(float, float, float)
-attributes #0 = { cold denormal_fpenv(float: preservesign) "target-cpu"="sm_100" }
+attributes #0 = { cold denormal_fpenv(float: preservesign) "target-cpu"="sm_100" "target-features"="+ptx87,+sm_100" }
 ''')
-    bits = [1, -2147483645]
+    bits = [1]
     x = torch.tensor(bits, dtype=torch.int32, device="cuda").view(torch.float32)
-    _kernel[(1, )](x, 1.0, str(lib), extern_libs={"test_denorm": str(lib)})
+    _kernel[(1, )](x, str(lib), extern_libs={"test_denorm": str(lib)})
     assert x.view(torch.int32).tolist() == bits

--- a/python/test/unit/language/test_compile_only.py
+++ b/python/test/unit/language/test_compile_only.py
@@ -3,25 +3,6 @@ import triton.language as tl
 from triton.backends.compiler import GPUTarget
 import re
 from triton.compiler import ASTSource
-from triton.language import core
-
-
-@core.extern
-def _extern_poly(x, lib_path: tl.constexpr, _semantic=None):
-    return core.extern_elementwise(
-        "test_inline",
-        lib_path.value,
-        [x],
-        {(core.dtype("fp32"), ): ("test_poly", core.dtype("fp32"))},
-        is_pure=True,
-        _semantic=_semantic,
-    )
-
-
-@triton.jit
-def _extern_poly_kernel(x, out, lib_path: tl.constexpr):
-    value = tl.load(x)
-    tl.store(out, _extern_poly(value, lib_path))
 
 
 def test_compile_only_sm100() -> None:
@@ -38,40 +19,6 @@ def test_compile_only_sm100() -> None:
     assert ".target sm_100a" in ptx
     assert ".address_size 64" in ptx
     assert k.asm["cubin"] != b""
-
-
-def test_nvptx_always_inline_with_different_target_attributes(tmp_path) -> None:
-    lib = tmp_path / "test_inline.ll"
-    body = []
-    previous = "%x"
-    for i in range(128):
-        body.append(f"  %v{i} = tail call float @llvm.fma.f32(float {previous}, float %x, float 0x3F8110F7C0000000)")
-        previous = f"%v{i}"
-    lib.write_text("\n".join([
-        "define float @test_poly(float noundef %x) unnamed_addr #0 {",
-        *body,
-        f"  ret float {previous}",
-        "}",
-        "",
-        "declare float @llvm.fma.f32(float, float, float)",
-        "",
-        ('attributes #0 = { nofree nosync nounwind memory(none) '
-         '"denormal-fp-math-f32"="preserve-sign,preserve-sign" "frame-pointer"="all" '
-         '"no-trapping-math"="true" "target-cpu"="sm_100" "target-features"="+ptx87,+sm_100" }'),
-    ]))
-
-    src = ASTSource(
-        fn=_extern_poly_kernel,
-        signature={"x": "*fp32", "out": "*fp32", "lib_path": "constexpr"},
-        constexprs={"lib_path": str(lib)},
-    )
-    compiled = triton.compile(
-        src,
-        target=GPUTarget("cuda", 103, 32),
-        options={"extern_libs": {"test_inline": str(lib)}},
-    )
-
-    assert "test_poly" not in compiled.asm["ptx"]
 
 
 def test_compile_only_ws_cluster_barrier_shared_memory(tmp_path) -> None:

--- a/python/test/unit/language/test_compile_only.py
+++ b/python/test/unit/language/test_compile_only.py
@@ -3,6 +3,25 @@ import triton.language as tl
 from triton.backends.compiler import GPUTarget
 import re
 from triton.compiler import ASTSource
+from triton.language import core
+
+
+@core.extern
+def _extern_poly(x, lib_path: tl.constexpr, _semantic=None):
+    return core.extern_elementwise(
+        "test_inline",
+        lib_path.value,
+        [x],
+        {(core.dtype("fp32"), ): ("test_poly", core.dtype("fp32"))},
+        is_pure=True,
+        _semantic=_semantic,
+    )
+
+
+@triton.jit
+def _extern_poly_kernel(x, out, lib_path: tl.constexpr):
+    value = tl.load(x)
+    tl.store(out, _extern_poly(value, lib_path))
 
 
 def test_compile_only_sm100() -> None:
@@ -19,6 +38,40 @@ def test_compile_only_sm100() -> None:
     assert ".target sm_100a" in ptx
     assert ".address_size 64" in ptx
     assert k.asm["cubin"] != b""
+
+
+def test_nvptx_always_inline_with_different_target_attributes(tmp_path) -> None:
+    lib = tmp_path / "test_inline.ll"
+    body = []
+    previous = "%x"
+    for i in range(128):
+        body.append(f"  %v{i} = tail call float @llvm.fma.f32(float {previous}, float %x, float 0x3F8110F7C0000000)")
+        previous = f"%v{i}"
+    lib.write_text("\n".join([
+        "define float @test_poly(float noundef %x) unnamed_addr #0 {",
+        *body,
+        f"  ret float {previous}",
+        "}",
+        "",
+        "declare float @llvm.fma.f32(float, float, float)",
+        "",
+        ('attributes #0 = { nofree nosync nounwind memory(none) '
+         '"denormal-fp-math-f32"="preserve-sign,preserve-sign" "frame-pointer"="all" '
+         '"no-trapping-math"="true" "target-cpu"="sm_100" "target-features"="+ptx87,+sm_100" }'),
+    ]))
+
+    src = ASTSource(
+        fn=_extern_poly_kernel,
+        signature={"x": "*fp32", "out": "*fp32", "lib_path": "constexpr"},
+        constexprs={"lib_path": str(lib)},
+    )
+    compiled = triton.compile(
+        src,
+        target=GPUTarget("cuda", 103, 32),
+        options={"extern_libs": {"test_inline": str(lib)}},
+    )
+
+    assert "test_poly" not in compiled.asm["ptx"]
 
 
 def test_compile_only_ws_cluster_barrier_shared_memory(tmp_path) -> None:


### PR DESCRIPTION
move target setting before inlining to avoid potential mismatch in target