### PR TITLE
[NVIDIA] Work around SM100 ptxas integer abs miscompile

### DIFF
--- a/python/test/unit/language/test_core.py
+++ b/python/test/unit/language/test_core.py
@@ -1162,10 +1162,60 @@ def test_fdiv_ieee_rounding(device):
 # ----------------
 
 
+@triton.jit
+def integer_abs_mask(m, n):
+    """Create a two-dimensional neighborhood mask from flattened indices."""
+    center_row = tl.maximum(tl.minimum(m // 128, 121), 6)
+    center_col = tl.maximum(tl.minimum(m % 128, 121), 6)
+    row_distance = tl.abs(center_row - n // 128)
+    col_distance = tl.abs(center_col - n % 128)
+    return tl.maximum(row_distance, col_distance) <= 6
+
+
+@triton.jit
+def integer_abs_ptxas_kernel(q_ptr, k_ptr, out_ptr):
+    """Keep a TCGen5 dot live while reducing an integer neighborhood mask."""
+    block_m: tl.constexpr = 128
+    block_n: tl.constexpr = 64
+    head_dim: tl.constexpr = 64
+    m_offset = tl.arange(0, block_m)[:, None]
+    m = 89 * 128 + m_offset
+    d = tl.arange(0, head_dim)[None, :]
+    q = tl.load(q_ptr + m_offset * head_dim + d)
+    count = tl.zeros([block_m], tl.float32)
+    dot_sum = tl.zeros([block_m], tl.float32)
+    n = 83 * 128 + tl.arange(0, block_n)[None, :]
+    kv_offset = 0
+    for _ in range(26):
+        n_offset = tl.arange(0, block_n)[:, None]
+        k = tl.load(k_ptr + (kv_offset + n_offset) * head_dim + d)
+        qk = tl.dot(q, tl.trans(k), input_precision="ieee")
+        count += tl.sum(integer_abs_mask(m, n).to(tl.float32), 1)
+        dot_sum += tl.sum(qk, 1)
+        n += block_n
+        kv_offset += block_n
+    tl.store(out_ptr + tl.arange(0, block_m), count + dot_sum)
+
+
 @pytest.mark.interpreter
 @pytest.mark.parametrize("dtype_x", [(dtype_x) for dtype_x in dtypes_with_bfloat16])
 def test_abs(dtype_x, device):
     _test_unary(dtype_x, 'tl.abs(x)', 'np.abs(x) ', device=device)
+
+
+@pytest.mark.skipif(
+    not is_cuda() or torch.cuda.get_device_capability() != (10, 0),
+    reason="Requires SM100",
+)
+def test_integer_abs_ptxas_fusion(device):
+    """Check that optimized ptxas preserves both operands of integer abs."""
+    q = torch.zeros((128, 64), device=device, dtype=torch.float16)
+    k = torch.zeros((26 * 64, 64), device=device, dtype=torch.float16)
+    out = torch.empty(128, device=device)
+
+    integer_abs_ptxas_kernel[(1, )](q, k, out, num_warps=4, num_stages=3)
+
+    torch.testing.assert_close(out, torch.full_like(out, 13 * 13))
 
 
 @pytest.mark.interpreter

--- a/third_party/nvidia/backend/compiler.py
+++ b/third_party/nvidia/backend/compiler.py
@@ -496,6 +496,15 @@ class CUDABackend(BaseBackend):
         ptx_version = f'{ptx_version//10}.{ptx_version%10}'
         ret = re.sub(r'\.version \d+\.\d+', f'.version {ptx_version}', ret, flags=re.MULTILINE)
         ret = re.sub(r'\.target sm_\d+', f'.target sm_{capability}', ret, flags=re.MULTILINE)
+        if capability >= 100:
+            # Avoid ptxas miscompiling max(x, -x) when fusing it into VIMNMX3.
+            ret = re.sub(
+                (r"^([ \t]*)neg\.s32[ \t]+(%r\d+),[ \t]*(%r\d+);[ \t]*\n"
+                 r"[ \t]*max\.s32[ \t]+(%r\d+),[ \t]*\3,[ \t]*\2;"),
+                r"\1neg.s32 \2, \3;\n\1abs.s32 \4, \3;",
+                ret,
+                flags=re.MULTILINE,
+            )
         if not knobs.compilation.dump_ir_extract_di_local_variables:
             # Remove the debug flag that prevents ptxas from optimizing the code
             # Note: if this flag is removed, the source var name and type info will be lost when ptx was compiled into cubin


### PR DESCRIPTION
## Summary

- Canonicalize emitted SM100+ PTX integer-abs idioms from `neg.s32` + `max.s32` to `abs.s32`.
- Avoid an optimized ptxas `VIMNMX3` fusion that drops the negated operand and changes `max(abs(x), y)` into `max(x, y)`.
- Add an SM100 regression covering the failure with a live TCGen5 dot and integer neighborhood mask.

Related issue: https://github.com/pytorch/pytorch/issues/190973

## Root cause

LLVM emits valid PTX equivalent to:

```ptx
neg.s32 neg_x, x;
max.s32 abs_x, x, neg_x;
max.s32 distance, abs_x, abs_y;
```

In the failing kernel, optimized ptxas fuses this into:

```text
VIMNMX3 R167, R8, R8, R167, !PT
```

The negated source has been coalesced with `R8`. On an input spanning `18 ... 0 ... -13` with the other operand equal to 6, cuda-gdb shows the result become `18 ... 7, 6, 6, ...`, leaving 20 mask lanes live instead of 13.

Emitting `abs.s32` prevents the malformed fusion while preserving the original `neg.s32` definition in case it has other uses.

## Reproducers

- Original end-to-end test: [`pytorch-labs/attention-gym::test_natten_masks`](https://github.com/pytorch-labs/attention-gym/blob/main/test/test_natten.py)
- Trimmed Python/Triton kernel: [`repro.py`](https://gist.github.com/drisspg/4ced47465f083119405a28e6a5833872)
- Standalone CUDA Driver API + original 261 KB PTX: [ptxas compiler repro package](https://gist.github.com/drisspg/4ced47465f083119405a28e6a5833872)

The standalone package requires no Python, PyTorch, Triton, or Inductor at runtime. Its optimized cubin has a maximum count error of 819 across 20 rows; compiling the same PTX with ptxas O0 is exact.

## Testing

- `pytest -q python/test/unit/language/test_core.py::test_integer_abs_ptxas_fusion`
  - Before: fails with maximum count error 819.
  - After: passes on GB200.
- `pytest -q test/test_natten.py::test_natten_masks` in `pytorch-labs/attention-gym`
  - Passes all row-major, tiled, and Morton forward, dQ, dK, and dV comparisons with normal optimized ptxas.

<details>
<summary>Investigation details</summary>

- ptxas O0 passes; O1, O2, and O3 fail with byte-identical input PTX.
- Disabling LLVM SLP avoids the forward symptom but originally leaves dQ wrong, showing that SLP only changes the exposing code shape.
- Compute Sanitizer memcheck, initcheck, racecheck, and synccheck remain clean while the reduced kernel is wrong.
- cuda-gdb traces the first wrong value to the malformed `VIMNMX3`; all subsequent predicate, reduction, shared-memory, accumulation, and store operations preserve that value correctly.
- Rewriting only the steady-loop absolute value fixes 12 iterations; rewriting its separately generated epilogue copy fixes the remaining iteration.
- The failure reproduces with ptxas from CUDA 12.8, 13.0, 13.1, and bundled 13.3.

</details>

