### PR TITLE
[BACKEND] Disallow reinterpreting a subslice that crosses CTAs

### DIFF
--- a/lib/Dialect/TritonGPU/IR/Ops.cpp
+++ b/lib/Dialect/TritonGPU/IR/Ops.cpp
@@ -721,6 +721,14 @@ LogicalResult MemDescReinterpretOp::verify() {
 
   auto srcAllocation = allocationLayout(srcTy);
   auto dstAllocation = allocationLayout(dstTy);
+  auto srcShape = dropPipeliningDim(srcTy.getShape(), srcEnc);
+  auto blockDim = StringAttr::get(getContext(), "block");
+  for (const auto &basis : srcAllocation.getBases().lookup(blockDim))
+    for (auto [component, size] : llvm::zip_equal(basis, srcShape))
+      if (component >= size)
+        return emitError("cannot reinterpret a source subview sliced across "
+                         "CTAs");
+
   if (srcIsTmem) {
     auto srcAlloc = nvidia_gpu::getTmemAllocSizes(srcTy);
     auto dstAlloc = nvidia_gpu::getTmemAllocSizes(dstTy);
@@ -755,7 +763,6 @@ LogicalResult MemDescReinterpretOp::verify() {
   uint64_t dstStride = llvm::divideCeil(
       uint64_t(dstAllocation.getInDimSize(addressDim)) * dstElementBits,
       uint64_t(unitBits));
-  auto srcShape = dropPipeliningDim(srcTy.getShape(), srcEnc);
   auto dstShape = dropPipeliningDim(dstTy.getShape(), dstEnc);
   int64_t srcStages = product(srcTy.getShape().drop_back(srcShape.size()));
   int64_t dstStages = product(dstTy.getShape().drop_back(dstShape.size()));

--- a/test/TritonGPU/invalid.mlir
+++ b/test/TritonGPU/invalid.mlir
@@ -330,6 +330,33 @@ tt.func public @memdesc_reinterpret_subview(%arg0: !ttg.memdesc<8x16xf16, #share
 
 // -----
 
+#shared_split = #ttg.swizzled_shared<{vec = 1, perPhase = 1, maxPhase = 1, order = [1, 0], CGALayout = [[1, 0]]}>
+#shared_broadcast = #ttg.swizzled_shared<{vec = 1, perPhase = 1, maxPhase = 1, order = [1, 0], CGALayout = [[0, 0]]}>
+#smem = #ttg.shared_memory
+module attributes {"ttg.num-ctas" = 2 : i32, "ttg.num-warps" = 4 : i32, "ttg.threads-per-warp" = 32 : i32} {
+  tt.func @memdesc_reinterpret_shared_subview_slices_cta(%parent: !ttg.memdesc<8x16xf16, #shared_split, #smem, mutable>) {
+    %view = ttg.memdesc_subslice %parent [4, 0] : !ttg.memdesc<8x16xf16, #shared_split, #smem, mutable> -> !ttg.memdesc<4x16xf16, #shared_split, #smem, mutable, 8x16>
+    // expected-error @+1 {{cannot reinterpret a source subview sliced across CTAs}}
+    %result = ttg.memdesc_reinterpret %view : !ttg.memdesc<4x16xf16, #shared_split, #smem, mutable, 8x16> -> !ttg.memdesc<4x16xf16, #shared_broadcast, #smem, mutable>
+    tt.return
+  }
+}
+
+// -----
+
+#tmem_split = #ttng.tensor_memory_encoding<blockM = 128, blockN = 16, colStride = 1, CGALayout = [[0, 1]]>
+#tmem_broadcast = #ttng.tensor_memory_encoding<blockM = 128, blockN = 16, colStride = 1, CGALayout = [[0, 0]]>
+#tmem = #ttng.tensor_memory
+module attributes {"ttg.num-ctas" = 2 : i32, "ttg.num-warps" = 4 : i32, "ttg.threads-per-warp" = 32 : i32} {
+  tt.func @memdesc_reinterpret_tmem_subview_slices_cta(%view: !ttg.memdesc<128x32xf32, #tmem_split, #tmem, mutable, 128x128>) {
+    // expected-error @+1 {{cannot reinterpret a source subview sliced across CTAs}}
+    %result = ttg.memdesc_reinterpret %view : !ttg.memdesc<128x32xf32, #tmem_split, #tmem, mutable, 128x128> -> !ttg.memdesc<128x32xf32, #tmem_broadcast, #tmem, mutable>
+    tt.return
+  }
+}
+
+// -----
+
 #shared = #ttg.swizzled_shared<{vec = 1, perPhase = 1, maxPhase = 1, order = [1, 0]}>
 #smem = #ttg.shared_memory
 tt.func public @memdesc_subslice_alloc_shape_mismatch(%arg0: !ttg.memdesc<8x16xf32, #shared, #smem>) {

--- a/test/TritonGPU/ops.mlir
+++ b/test/TritonGPU/ops.mlir
@@ -145,10 +145,10 @@ module attributes {"ttg.target" = "cuda:0", "ttg.num-ctas" = 2 : i32, "ttg.num-w
   }
 
   // CHECK-LABEL: @memdesc_reinterpret_shared_sharding
-  tt.func @memdesc_reinterpret_shared_sharding(%broadcast: !ttg.memdesc<8x16xf16, #shared_cga_00, #smem, mutable>, %sharded: !ttg.memdesc<8x16xf16, #shared_cga_10, #smem, mutable>) {
+  tt.func @memdesc_reinterpret_shared_sharding(%broadcast: !ttg.memdesc<8x16xf16, #shared_cga_00, #smem, mutable>) {
     %split = ttg.memdesc_reinterpret %broadcast : !ttg.memdesc<8x16xf16, #shared_cga_00, #smem, mutable> -> !ttg.memdesc<8x16xi16, #shared_cga_10, #smem, mutable>
-    %view = ttg.memdesc_subslice %sharded [0, 0] : !ttg.memdesc<8x16xf16, #shared_cga_10, #smem, mutable> -> !ttg.memdesc<4x16xf16, #shared_cga_10, #smem, mutable, 8x16>
-    %replicated = ttg.memdesc_reinterpret %view : !ttg.memdesc<4x16xf16, #shared_cga_10, #smem, mutable, 8x16> -> !ttg.memdesc<4x16xi16, #shared_cga_00, #smem, mutable>
+    %view = ttg.memdesc_subslice %broadcast [0, 0] : !ttg.memdesc<8x16xf16, #shared_cga_00, #smem, mutable> -> !ttg.memdesc<4x16xf16, #shared_cga_00, #smem, mutable, 8x16>
+    %split_view = ttg.memdesc_reinterpret %view : !ttg.memdesc<4x16xf16, #shared_cga_00, #smem, mutable, 8x16> -> !ttg.memdesc<4x16xi16, #shared_cga_10, #smem, mutable>
     tt.return
   }
 }


### PR DESCRIPTION
This was miscompiling earlier. We ban it for now as it's quite a weird
thing to do. We could enable it if we find use cases.
