### PR TITLE
[Compiler] Expose blocked TTGIR layout metadata to Python

### DIFF
--- a/python/src/ir.cc
+++ b/python/src/ir.cc
@@ -1,5 +1,6 @@
 #include "ir.h"
 
+#include <algorithm>
 #include <cstring>
 #include <nanobind/nanobind.h>
 #include <nanobind/stl/function.h>
@@ -229,6 +230,65 @@ py::list getTensorDescMetadata(ModuleOp &mod) {
         metadata["interval_padding_pairs"] = intervalPaddingPairs;
       }
     }
+    result.append(std::move(metadata));
+  }
+  return result;
+}
+
+void collectBlockedLayouts(
+    Attribute encoding,
+    llvm::SmallVectorImpl<ttg::BlockedEncodingAttr> &blockedLayouts) {
+  if (!encoding)
+    return;
+
+  if (auto blocked = dyn_cast<ttg::BlockedEncodingAttr>(encoding)) {
+    if (std::find(blockedLayouts.begin(), blockedLayouts.end(), blocked) ==
+        blockedLayouts.end())
+      blockedLayouts.push_back(blocked);
+    return;
+  }
+
+  if (auto slice = dyn_cast<ttg::SliceEncodingAttr>(encoding)) {
+    collectBlockedLayouts(slice.getParent(), blockedLayouts);
+    return;
+  }
+
+  if (auto dotOperand = dyn_cast<ttg::DotOperandEncodingAttr>(encoding))
+    collectBlockedLayouts(dotOperand.getParent(), blockedLayouts);
+}
+
+py::list getBlockedLayoutMetadata(ModuleOp &mod) {
+  llvm::SmallVector<ttg::BlockedEncodingAttr, 4> blockedLayouts;
+
+  auto collectType = [&](Type type) {
+    if (auto tensorType = dyn_cast<RankedTensorType>(type))
+      collectBlockedLayouts(tensorType.getEncoding(), blockedLayouts);
+    else if (auto memDescType = dyn_cast<ttg::MemDescType>(type))
+      collectBlockedLayouts(memDescType.getEncoding(), blockedLayouts);
+  };
+
+  mod.walk([&](Operation *op) {
+    for (Type type : op->getOperandTypes())
+      collectType(type);
+    for (Type type : op->getResultTypes())
+      collectType(type);
+    for (Region &region : op->getRegions())
+      for (Block &block : region)
+        for (Type type : block.getArgumentTypes())
+          collectType(type);
+  });
+
+  py::list result;
+  for (auto blocked : blockedLayouts) {
+    py::dict metadata;
+    metadata["size_per_thread"] = std::vector<unsigned>(
+        blocked.getSizePerThread().begin(), blocked.getSizePerThread().end());
+    metadata["threads_per_warp"] = std::vector<unsigned>(
+        blocked.getThreadsPerWarp().begin(), blocked.getThreadsPerWarp().end());
+    metadata["warps_per_cta"] = std::vector<unsigned>(
+        blocked.getWarpsPerCTA().begin(), blocked.getWarpsPerCTA().end());
+    metadata["order"] = std::vector<unsigned>(blocked.getOrder().begin(),
+                                              blocked.getOrder().end());
     result.append(std::move(metadata));
   }
   return result;
@@ -779,6 +839,7 @@ void init_triton_ir(py::module_ &m) {
              return py::int_(ret.getInt());
            })
       .def("get_tensordesc_metadata", getTensorDescMetadata)
+      .def("get_blocked_layout_metadata", getBlockedLayoutMetadata)
       .def("create_location_snapshot",
            [](ModuleOp &self, const std::string &fileName) -> void {
              auto printingFlags = getOpPrintingFlags();

--- a/python/test/unit/runtime/test_bindings.py
+++ b/python/test/unit/runtime/test_bindings.py
@@ -32,6 +32,20 @@ def add_kernel(
     tl.store(out_ptr + offsets, output, mask=mask)
 
 
+def test_blocked_layout_metadata():
+    compiled = add_kernel.warmup(
+        torch.float32,
+        torch.float32,
+        1024,
+        torch.float32,
+        _BLOCK_SIZE,
+        grid=(1, ),
+    )
+    assert compiled.metadata.blocked_layouts
+    expected_keys = {"size_per_thread", "threads_per_warp", "warps_per_cta", "order"}
+    assert all(layout.keys() == expected_keys for layout in compiled.metadata.blocked_layouts)
+
+
 def test_module_walk(device):
     """
     Test the MLIR bindings exposed for the out-of-tree walk.

--- a/python/triton/compiler/compiler.py
+++ b/python/triton/compiler/compiler.py
@@ -334,6 +334,8 @@ def compile(src, target=None, options=None, _env_vars=None):
         elif full_name := fn_override_manager.get_file(ir_filename):
             print(f"\nOverriding kernel with file {full_name}")
             next_module = parse(full_name, ext, context)
+        if ext == "ttgir":
+            metadata["blocked_layouts"] = next_module.get_blocked_layout_metadata()
         # If TRITON_STORE_BINARY_ONLY is 1, only store cubin/hsaco/json
         if (not store_only_binary) or (ext in ("cubin", "hsaco", "json")):
             metadata_group[ir_filename] = fn_cache_manager.put(next_module, ir_filename)


### PR DESCRIPTION
Addresses #9789.

## Why

TTGIR layouts are essential when diagnosing vectorization, thread-to-data
mapping, and memory-coalescing behavior. Today, Python tooling has to parse
`compiled.asm["ttgir"]` to recover blocked-layout parameters. That makes
performance analysis depend on MLIR's textual representation.

This change exposes the same information through a structured binding and
records it in compiled-kernel metadata, so callers do not need a regex parser.

## What changed

- Add `ir.module.get_blocked_layout_metadata()` to collect unique blocked
  encodings used by TTGIR tensor and memory-descriptor types.
- Preserve parent blocked encodings referenced by slice and dot-operand
  layouts.
- Populate `CompiledKernel.metadata.blocked_layouts` after the TTGIR stage.
- Add runtime binding coverage for the structured metadata.

Each blocked layout reports `size_per_thread`, `threads_per_warp`,
`warps_per_cta`, and `order`.

## Validation

- Native editable build completed successfully (`476/476` build targets).
- `make` completed successfully, including an incremental rebuild after
  formatting.
- `python -m pytest -s --tb=short python/test/unit/runtime/test_bindings.py`
  passed (`3 passed`).
- An RTX 3090 vector-add smoke test produced `max_abs_error=0.0` and returned
  structured blocked-layout metadata.
- `pre-commit run --from-ref origin/main --to-ref HEAD` passed for all
  applicable hooks.

## Scope

This PR intentionally exposes only blocked layouts. Other TTGIR encoding types
can be added in follow-up changes without changing the blocked-layout schema.

# New contributor declaration

- [x] I am not making a trivial change, such as fixing a typo in a comment.

- [x] I have written a PR description following these
  [rules](https://cbea.ms/git-commit/#why-not-how).

- [x] I have run `pre-commit run --from-ref origin/main --to-ref HEAD`.

- Select one of the following.
  - [x] I have added tests.
    - `/test` for `lit` tests
    - `/unittest` for C++ tests
    - `/python/test` for end-to-end tests
  - [ ] This PR does not need a test because `FILL THIS IN`.

- Select one of the following.
  - [x] I have not added any `lit` tests.
  - [ ] The `lit` tests I have added follow these [best practices](https://mlir.llvm.org/getting_started/TestingGuide/#filecheck-best-practices),
    including the "tests should be minimal" section. (Usually running Python code
    and using the instructions it generates is not minimal.)
