### PR TITLE
[FRONTEND] Fix tl.range with a runtime negative step

### DIFF
--- a/python/test/unit/language/test_core.py
+++ b/python/test/unit/language/test_core.py
@@ -6522,6 +6522,27 @@ def test_static_range(device):
 
 
 @pytest.mark.interpreter
+def test_tl_range_runtime_step(device):
+    # A runtime (non-constexpr) negative step must iterate downward like Python
+    # range / the interpreter, instead of silently running zero iterations. The
+    # empty cases must also match Python range. See issue #10950.
+    @triton.jit
+    def sum_kernel(X, Z, start, stop, step):
+        acc = 0.0
+        for i in tl.range(start, stop, step):
+            acc += tl.load(X + i)
+        tl.store(Z, acc)
+
+    N = 128
+    x = torch.arange(0, N, dtype=torch.float32, device=device)  # x[i] == i
+    for start, stop, step in [(88, -1, -8), (0, 89, 8), (5, -1, -1), (10, 5, 1), (5, 10, -1)]:
+        out = torch.zeros(1, dtype=torch.float32, device=device)
+        sum_kernel[(1, )](x, out, start, stop, step)
+        expect = float(sum(range(start, stop, step)))
+        assert out.item() == expect, (start, stop, step, out.item(), expect)
+
+
+@pytest.mark.interpreter
 def test_tl_range_num_stages(device):
     if is_hip():
         pytest.skip("test_tl_range is not supported in HIP")

--- a/python/triton/compiler/code_generator.py
+++ b/python/triton/compiler/code_generator.py
@@ -1292,6 +1292,9 @@ class CodeGenerator(ast.NodeVisitor):
             step = constexpr(-step.value)
             negative_step = True
             lb, ub = ub, lb
+        # A runtime (non-constexpr) step may be negative at runtime, which we
+        # cannot detect here; normalize such loops below so any step sign works.
+        step_is_constexpr = _is_constexpr(step)
         lb = self.semantic.to_tensor(lb)
         ub = self.semantic.to_tensor(ub)
         step = self.semantic.to_tensor(step)
@@ -1316,6 +1319,23 @@ class CodeGenerator(ast.NodeVisitor):
         lb = self.builder.create_int_cast(lb, iv_ir_type, iv_is_signed)
         ub = self.builder.create_int_cast(ub, iv_ir_type, iv_is_signed)
         step = self.builder.create_int_cast(step, iv_ir_type, iv_is_signed)
+        # scf.for only counts upward, so a runtime step that is negative would
+        # silently run zero iterations. For a runtime step of unknown sign,
+        # iterate over a non-negative trip count and reconstruct the induction
+        # variable as `lb + k * step`, matching Python range / the interpreter.
+        for_lb, for_ub, for_step = lb, ub, step
+        if not step_is_constexpr:
+
+            def _iv_const(v):
+                h = self.semantic.to_tensor(constexpr(v)).handle
+                return self.builder.create_int_cast(h, iv_ir_type, iv_is_signed)
+
+            zero, one = _iv_const(0), _iv_const(1)
+            sign = self.builder.create_select(self.builder.create_icmpSGT(step, zero), one, _iv_const(-1))
+            # trip_count = max(0, (ub - lb + step - sign) // step)
+            numer = self.builder.create_sub(self.builder.create_add(self.builder.create_sub(ub, lb), step), sign)
+            trip_count = self.builder.create_maxsi(self.builder.create_sdiv(numer, step), zero)
+            for_lb, for_ub, for_step = zero, trip_count, one
         # Create placeholder for the loop induction variable
         iv_placeholder = self.builder.create_poison(iv_ir_type)
         self.set_value(node.target.id, language.core.tensor(iv_placeholder, iv_type))
@@ -1328,7 +1348,7 @@ class CodeGenerator(ast.NodeVisitor):
 
             # create ForOp
             self._set_insertion_point_and_loc(ip, last_loc)
-            for_op = self.builder.create_for_op(lb, ub, step, init_handles)
+            for_op = self.builder.create_for_op(for_lb, for_ub, for_step, init_handles)
             if _unwrap_if_constexpr(num_stages) is not None:
                 for_op.set_attr("tt.num_stages", self.builder.get_int32_attr(num_stages))
             if _unwrap_if_constexpr(loop_unroll_factor) is not None:
@@ -1363,7 +1383,10 @@ class CodeGenerator(ast.NodeVisitor):
             # update induction variable with actual value, and replace all uses
             self.builder.set_insertion_point_to_start(for_op_body)
             iv = for_op.get_induction_var()
-            if negative_step:
+            if not step_is_constexpr:
+                # Reconstruct the user's induction variable: iv = lb + k * step.
+                iv = self.builder.create_add(lb, self.builder.create_mul(iv, step))
+            elif negative_step:
                 iv = self.builder.create_sub(ub, iv)
                 iv = self.builder.create_add(iv, lb)
             iv_placeholder.replace_all_uses_with(iv)


### PR DESCRIPTION
 The bug: When you write for i in tl.range(start, stop, step) and the step is negative, Triton has to flip the loop around so it counts down correctly. But it only did that flip when the step was a fixed number written in your code.

If the step was a runtime value (a number that only shows up when the kernel runs), Triton skipped the flip and handed the loop to the low-level machinery as-is. That machinery only counts upward — so a negative runtime step made the loop run zero times and quietly gave a wrong answer.

The fix: Since the compiler can't see whether a runtime step is positive or negative, we now handle any runtime step the same safe way:

  1. Figure out its sign while the kernel runs.
  2. Compute how many times the loop should run: max(0, (stop - start + step - sign) // step).
  3. Rebuild each loop value as start + k*step.

This makes a runtime step — positive or negative — behave exactly like Python's range and the interpreter. Loops with a constant step are untouched.


Fixes #10950.

<!---
The core Triton is a small number of people, and we receive many PRs (thank
you!).  To help us review your code more quickly, **if you are a new
contributor (less than 3 PRs merged) we ask that you complete the following
tasks and include the filled-out checklist in your PR description.**

Complete the following tasks before sending your PR, and replace `[ ]` with
`[x]` to indicate you have done them.
-->

# New contributor declaration
- [x] I am not making a trivial change, such as fixing a typo in a comment.

- [x] I have written a PR description following these
  [rules](https://cbea.ms/git-commit/#why-not-how).

- [x] I have run `pre-commit run --from-ref origin/main --to-ref HEAD`.

- Select one of the following.
  - [x] I have added tests.
    - `/test` for `lit` tests
    - `/unittest` for C++ tests
    - `/python/test` for end-to-end tests
  - [ ] This PR does not need a test because `FILL THIS IN`.

- Select one of the following.
  - [x] I have not added any `lit` tests.
  - [ ] The `lit` tests I have added follow these [best practices](https://mlir.llvm.org/getting_started/TestingGuide/#filecheck-best-practices),
    including the "tests should be minimal" section. (Usually running Python code
    and using the instructions it generates is not minimal.)
