### PR TITLE
[INTERPRETER] Fix tl.umulhi sign-extending signed operands

### DIFF
--- a/python/test/unit/language/test_core.py
+++ b/python/test/unit/language/test_core.py
@@ -2305,7 +2305,7 @@ def test_load_store_same_ptr(device):
 
 
 @pytest.mark.interpreter
-@pytest.mark.parametrize("dtype_str", ['int32'])
+@pytest.mark.parametrize("dtype_str", ['int32', 'int64'])
 def test_umulhi(dtype_str, device):
 
     @triton.jit
@@ -2316,28 +2316,30 @@ def test_umulhi(dtype_str, device):
         z = tl.umulhi(x, y)
         tl.store(Z + tl.arange(0, N), z)
 
-    def umulhi32(a, b):
-        # Convert to 64-bit unsigned integers to prevent overflow
-        a_64 = a.astype(np.int64)
-        b_64 = b.astype(np.int64)
+    bits = 32 if dtype_str == 'int32' else 64
 
-        # Perform the multiplication in 64-bit
-        product_64 = a_64 * b_64
-
-        # Shift right by 32 bits to get the high part of the product
-        result_high_32 = product_64 >> 32
-        return result_high_32
+    def umulhi_ref(a, b):
+        # umulhi is unsigned: reinterpret the operand bits as unsigned and take
+        # the high `bits` of the 2*bits-wide product. Signed operands with the
+        # top bit set must be treated as their raw bit pattern, not sign-extended.
+        mask = (1 << bits) - 1
+        hi = [((int(u) & mask) * (int(v) & mask)) >> bits for u, v in zip(a.tolist(), b.tolist())]
+        return np.array(hi, dtype=getattr(np, f"uint{bits}")).astype(a.dtype)
 
     rs = RandomState(17)
     N = 128
-    x = numpy_random((N, ), dtype_str=dtype_str, rs=rs, low=0)
+    iinfo = np.iinfo(getattr(np, dtype_str))
+    # Include negatives / top-bit-set values (the previously-untested path) plus
+    # explicit edge cases. Full signed range, not low=0.
+    edges = np.array([-1, -2, 1, iinfo.min, iinfo.max, iinfo.min + 1], dtype=getattr(np, dtype_str))
+    x = np.concatenate([edges, numpy_random((N - edges.size, ), dtype_str=dtype_str, rs=rs)])
+    y = np.concatenate([edges[::-1], numpy_random((N - edges.size, ), dtype_str=dtype_str, rs=rs)])
     x_tri = to_triton(x, device=device)
-    y = numpy_random((N, ), dtype_str=dtype_str, rs=rs, low=0)
     y_tri = to_triton(y, device=device)
     z_tri = torch.zeros_like(x_tri)
     kernel[(1, )](x_tri, y_tri, z_tri, N=N)
 
-    z_ref = umulhi32(x, y)
+    z_ref = umulhi_ref(x, y)
     np.testing.assert_equal(z_ref, to_numpy(z_tri))
 
 

--- a/python/triton/runtime/interpreter.py
+++ b/python/triton/runtime/interpreter.py
@@ -246,8 +246,11 @@ def _erf(x):
 
 def _umulhi_64(a, b):
     # Numpy does not support 128-bit multiplication
-    # So we have to implement it manually
-    return (int(a) * int(b)) >> 64
+    # So we have to implement it manually. umulhi is unsigned, so mask the
+    # operands to their raw 64-bit pattern -- a signed int64 would otherwise be
+    # sign-extended by Python's arbitrary-precision int() and corrupt the result.
+    mask = (1 << 64) - 1
+    return ((int(a) & mask) * (int(b) & mask)) >> 64
 
 
 def _e8m0_to_f32(scale):
@@ -646,10 +649,16 @@ class InterpreterBuilder:
         if dtype == np.int64 or dtype == np.uint64:
             return TensorHandle(np_umulhi_u64(lhs.data, rhs.data), lhs.dtype.scalar)
         else:
-            compute_dtype = getattr(np, f"uint{dtype.itemsize * 8 * 2}")
-            lhs_data = lhs.data.astype(compute_dtype)
-            rhs_data = rhs.data.astype(compute_dtype)
-            ret_data = np.multiply(lhs_data, rhs_data) >> (dtype.itemsize * 8)
+            bitwidth = dtype.itemsize * 8
+            # umulhi is unsigned: reinterpret the operands as unsigned before
+            # widening, otherwise a signed operand is sign-extended and the high
+            # bits are corrupted (e.g. int32 -1 -> 0xFFFFFFFFFFFFFFFF instead of
+            # 0x00000000FFFFFFFF).
+            unsigned_dtype = getattr(np, f"uint{bitwidth}")
+            compute_dtype = getattr(np, f"uint{bitwidth * 2}")
+            lhs_data = lhs.data.astype(unsigned_dtype).astype(compute_dtype)
+            rhs_data = rhs.data.astype(unsigned_dtype).astype(compute_dtype)
+            ret_data = np.multiply(lhs_data, rhs_data) >> bitwidth
             return TensorHandle(ret_data.astype(dtype), lhs.dtype.scalar)
 
     # ternary functions


### PR DESCRIPTION
tl.umulhi is an unsigned multiply-high and its public API accepts signed int32/int64 (math.umulhi's @_check_dtype). The interpreter widened the operands with `.astype(uint{2*bits})`, which sign-extends a negative signed value (int32 -1 -> 0xFFFFFFFFFFFFFFFF) instead of reinterpreting its raw bit pattern (0x00000000FFFFFFFF), corrupting the high bits and silently returning a wrong result. The 64-bit helper `_umulhi_64` had the same issue via Python's arbitrary-precision `int()`.

Reinterpret each operand as unsigned before widening, matching the compiled path (__nv_umulhi / __nv_umul64hi, which operate on the unsigned bit pattern). The Philox RNG is unaffected (it casts to uint32/uint64), so this only changes results for direct umulhi calls on signed operands.

Extend test_umulhi to cover int64 and negative / top-bit-set operands against an unsigned reference; the previous test used only non-negative int32 inputs and never exercised this path.

Fixes the interpreter's divergence from GPU umulhi semantics.

<!---
The core Triton is a small number of people, and we receive many PRs (thank
you!).  To help us review your code more quickly, **if you are a new
contributor (less than 3 PRs merged) we ask that you complete the following
tasks and include the filled-out checklist in your PR description.**

Complete the following tasks before sending your PR, and replace `[ ]` with
`[x]` to indicate you have done them.
-->

# New contributor declaration
- [ ] I am not making a trivial change, such as fixing a typo in a comment.

- [ ] I have written a PR description following these
  [rules](https://cbea.ms/git-commit/#why-not-how).

- [ ] I have run `pre-commit run --from-ref origin/main --to-ref HEAD`.

- Select one of the following.
  - [ ] I have added tests.
    - `/test` for `lit` tests
    - `/unittest` for C++ tests
    - `/python/test` for end-to-end tests
  - [ ] This PR does not need a test because `FILL THIS IN`.

- Select one of the following.
  - [ ] I have not added any `lit` tests.
  - [ ] The `lit` tests I have added follow these [best practices](https://mlir.llvm.org/getting_started/TestingGuide/#filecheck-best-practices),
    including the "tests should be minimal" section. (Usually running Python code
    and using the instructions it generates is not minimal.)
