### PR TITLE
[FRONTEND] Fix tl.arange rejecting a negative start

### DIFF
--- a/python/test/unit/language/test_core.py
+++ b/python/test/unit/language/test_core.py
@@ -4681,7 +4681,7 @@ def test_dot_without_load(dtype_str, device):
 
 
 @pytest.mark.interpreter
-@pytest.mark.parametrize("start", [0, 1, 7, 16])
+@pytest.mark.parametrize("start", [-128, -64, -16, 0, 1, 7, 16])
 @pytest.mark.parametrize("num_ctas", num_ctas_list)
 def test_arange(start, num_ctas, device):
     BLOCK = 128

--- a/python/triton/language/semantic.py
+++ b/python/triton/language/semantic.py
@@ -578,9 +578,7 @@ class TritonSemantic(Generic[TensorTy]):
     def arange(self, start: int, end: int, *, ret_ty: tl.block_type = None) -> TensorTy:
         if not isinstance(start, int) or not isinstance(end, int):
             raise ValueError("arange's arguments must be of type tl.constexpr")
-        is_start_int64 = bool(start >> 32)
-        is_end_int64 = bool(end >> 32)
-        if is_start_int64 or is_end_int64:
+        if start < -2**31 or end > 2**31 - 1:
             raise ValueError("arange must fit in int32")
         if end <= start:
             raise ValueError("arange's end argument must be greater than the start argument")


### PR DESCRIPTION
Replace the guard with an explicit int32 range check on the produced values ([start, end)). 

<!---
The core Triton is a small number of people, and we receive many PRs (thank
you!).  To help us review your code more quickly, **if you are a new
contributor (less than 3 PRs merged) we ask that you complete the following
tasks and include the filled-out checklist in your PR description.**

Complete the following tasks before sending your PR, and replace `[ ]` with
`[x]` to indicate you have done them.
-->

# New contributor declaration
- [ ] I am not making a trivial change, such as fixing a typo in a comment.

- [x] I have written a PR description following these
  [rules](https://cbea.ms/git-commit/#why-not-how).

- [x] I have run `pre-commit run --from-ref origin/main --to-ref HEAD`.

- Select one of the following.
  - [x] I have added tests.
    - `/test` for `lit` tests
    - `/unittest` for C++ tests
    - `/python/test` for end-to-end tests
  - [ ] This PR does not need a test because `FILL THIS IN`.

- Select one of the following.
  - [x] I have not added any `lit` tests.
  - [ ] The `lit` tests I have added follow these [best practices](https://mlir.llvm.org/getting_started/TestingGuide/#filecheck-best-practices),
    including the "tests should be minimal" section. (Usually running Python code
    and using the instructions it generates is not minimal.)
