### PR TITLE
[analysis] Generalize and refactor buffer region analysis

### DIFF
--- a/include/triton/Analysis/BufferRegion.h
+++ b/include/triton/Analysis/BufferRegion.h
@@ -1,6 +1,7 @@
 #ifndef TRITON_ANALYSIS_BUFFER_REGION_H
 #define TRITON_ANALYSIS_BUFFER_REGION_H
 
+#include <algorithm>
 #include <cstdint>
 #include <set>
 #include <tuple>
@@ -9,6 +10,7 @@
 #include "mlir/Analysis/DataFlow/SparseAnalysis.h"
 #include "mlir/IR/Value.h"
 #include "llvm/ADT/ArrayRef.h"
+#include "llvm/ADT/STLExtras.h"
 #include "llvm/ADT/SmallBitVector.h"
 #include "llvm/ADT/SmallVector.h"
 #include "llvm/ADT/SparseBitVector.h"
@@ -65,43 +67,82 @@ private:
 //===----------------------------------------------------------------------===//
 
 struct BufferRegion {
+  using CTAAddresses = std::pair<uint32_t, AddressSet>;
+
   /// Runtime descriptor key. It deliberately does not define geometry:
   /// distinct sparse views may have the same key.
   uint32_t baseOffset = 0;
   uint32_t length = 0;
   AddressSet addresses;
+  llvm::SmallVector<CTAAddresses, 2> ctaAddresses;
 
   /// Internal view provenance used while composing nested views.
   uint32_t storageBase = 0;
   uint32_t affineOffset = 0;
+  llvm::SmallVector<uint32_t, 2> partitionBases;
+  uint32_t affinePartitionOffset = 0;
+  uint32_t affineCTAOffset = 0;
 
   BufferRegion() = default;
   BufferRegion(uint32_t baseOffset, uint32_t length)
       : baseOffset(baseOffset), length(length),
         addresses(AddressSet::fromRange(baseOffset, length)),
-        storageBase(baseOffset) {}
+        ctaAddresses{{0, addresses}}, storageBase(baseOffset) {}
   BufferRegion(uint32_t baseOffset, uint32_t length, AddressSet addresses,
-               uint32_t storageBase, uint32_t affineOffset)
+               uint32_t storageBase, uint32_t affineOffset,
+               llvm::ArrayRef<uint32_t> partitionBases = {},
+               uint32_t affinePartitionOffset = 0,
+               llvm::ArrayRef<CTAAddresses> ctaAddresses = {},
+               uint32_t affineCTAOffset = 0)
       : baseOffset(baseOffset), length(length), addresses(std::move(addresses)),
-        storageBase(storageBase), affineOffset(affineOffset) {}
+        ctaAddresses(ctaAddresses), storageBase(storageBase),
+        affineOffset(affineOffset), partitionBases(partitionBases),
+        affinePartitionOffset(affinePartitionOffset),
+        affineCTAOffset(affineCTAOffset) {
+    if (this->ctaAddresses.empty() && !this->addresses.empty())
+      this->ctaAddresses.emplace_back(0, this->addresses);
+  }
 
   bool intersects(const BufferRegion &other) const {
-    return addresses.intersects(other.addresses);
+    return llvm::any_of(ctaAddresses, [&](const CTAAddresses &lhs) {
+      return llvm::any_of(other.ctaAddresses, [&](const CTAAddresses &rhs) {
+        return lhs.first == rhs.first && lhs.second.intersects(rhs.second);
+      });
+    });
   }
   bool contains(const BufferRegion &other) const {
-    return addresses.contains(other.addresses);
+    return llvm::all_of(other.ctaAddresses, [&](const CTAAddresses &rhs) {
+      return llvm::any_of(ctaAddresses, [&](const CTAAddresses &lhs) {
+        return lhs.first == rhs.first && lhs.second.contains(rhs.second);
+      });
+    });
   }
 
   bool operator==(const BufferRegion &other) const {
     return baseOffset == other.baseOffset && length == other.length &&
-           addresses == other.addresses && storageBase == other.storageBase &&
-           affineOffset == other.affineOffset;
+           addresses == other.addresses && ctaAddresses == other.ctaAddresses &&
+           storageBase == other.storageBase &&
+           affineOffset == other.affineOffset &&
+           partitionBases == other.partitionBases &&
+           affinePartitionOffset == other.affinePartitionOffset &&
+           affineCTAOffset == other.affineCTAOffset;
   }
 
   bool operator<(const BufferRegion &other) const {
-    return std::tie(baseOffset, length, addresses, storageBase, affineOffset) <
-           std::tie(other.baseOffset, other.length, other.addresses,
-                    other.storageBase, other.affineOffset);
+    auto lhs = std::tie(baseOffset, length, addresses, storageBase,
+                        affineOffset, affinePartitionOffset, affineCTAOffset);
+    auto rhs = std::tie(other.baseOffset, other.length, other.addresses,
+                        other.storageBase, other.affineOffset,
+                        other.affinePartitionOffset, other.affineCTAOffset);
+    if (lhs != rhs)
+      return lhs < rhs;
+    if (partitionBases != other.partitionBases)
+      return std::lexicographical_compare(
+          partitionBases.begin(), partitionBases.end(),
+          other.partitionBases.begin(), other.partitionBases.end());
+    return std::lexicographical_compare(
+        ctaAddresses.begin(), ctaAddresses.end(), other.ctaAddresses.begin(),
+        other.ctaAddresses.end());
   }
 
   template <typename T> void print(T &os) const {
@@ -118,9 +159,11 @@ struct BufferRegion {
 struct BufferStatePlan {
   unsigned numLanes = 0;
   llvm::SmallVector<llvm::SmallBitVector> regionMasks;
+  llvm::SmallBitVector unknownMask;
 };
 
-BufferStatePlan createBufferStatePlan(llvm::ArrayRef<BufferRegion> regions);
+BufferStatePlan createBufferStatePlan(llvm::ArrayRef<BufferRegion> regions,
+                                      bool includeUnknown = false);
 
 //===----------------------------------------------------------------------===//
 // RegionInfo lattice
@@ -129,32 +172,50 @@ BufferStatePlan createBufferStatePlan(llvm::ArrayRef<BufferRegion> regions);
 // This wraps a set of BufferRegions and provides lattice semantics
 //
 struct RegionInfo {
+  enum class Kind { Uninitialized, Exact, Unknown };
   using RegionList = std::set<BufferRegion>;
+
+  Kind kind = Kind::Uninitialized;
   RegionList regions;
 
   RegionInfo() = default;
-  RegionInfo(const RegionList &r) : regions(r) {}
+  RegionInfo(const RegionList &r) : kind(Kind::Exact), regions(r) {}
 
-  // Lattice join: union of regions
+  bool isUnknown() const { return kind == Kind::Unknown; }
+
   static RegionInfo join(const RegionInfo &lhs, const RegionInfo &rhs) {
+    if (lhs.isUnknown() || rhs.isUnknown())
+      return getPessimisticValueState();
+    if (lhs.kind == Kind::Uninitialized)
+      return rhs;
+    if (rhs.kind == Kind::Uninitialized)
+      return lhs;
     RegionInfo result = lhs;
     result.regions.insert(rhs.regions.begin(), rhs.regions.end());
     return result;
   }
 
   bool operator==(const RegionInfo &other) const {
-    return regions == other.regions;
+    return kind == other.kind && regions == other.regions;
   }
 
   template <typename T> void print(T &os) const {
+    if (isUnknown()) {
+      os << "unknown";
+      return;
+    }
     llvm::interleaveComma(regions, os,
                           [&](const BufferRegion &r) { r.print(os); });
   }
 
   static RegionInfo getPessimisticValueState(MLIRContext *context = nullptr) {
-    return RegionInfo(); // means "unknown / empty"
+    RegionInfo result;
+    result.kind = Kind::Unknown;
+    return result;
   }
-  static RegionInfo getPessimisticValueState(Value) { return RegionInfo(); }
+  static RegionInfo getPessimisticValueState(Value) {
+    return getPessimisticValueState();
+  }
 };
 
 //===----------------------------------------------------------------------===//
@@ -175,6 +236,12 @@ public:
 
   enum RegionType { SHARED_MEMORY, TENSOR_MEMORY, BARRIER, NUM_REGION_TYPES };
 
+  struct MemoryAccess {
+    Value value;
+    bool isWrite;
+  };
+
+  static llvm::SmallVector<MemoryAccess> getMemoryAccesses(Operation *op);
   static bool isMemoryAccessOperation(Operation *op);
 
   // ------------------------------
@@ -185,6 +252,10 @@ public:
   llvm::SmallVector<BufferRegion>
   getAllUsedBufferRegions(RegionType type) const {
     return llvm::to_vector(usedBufferRegions[type]);
+  }
+
+  bool hasUnknownUsedBufferRegions(RegionType type) const {
+    return usedUnknownBufferRegions[type];
   }
 
   void calculateUsedBufferRegions(Operation *op);
@@ -208,9 +279,8 @@ public:
 private:
   // Global registry of all regions
   std::set<BufferRegion> usedBufferRegions[NUM_REGION_TYPES];
+  bool usedUnknownBufferRegions[NUM_REGION_TYPES] = {};
   llvm::DenseMap<std::pair<Type, uint32_t>, AddressSet> footprintCache;
-
-  static void verifyOpIsSupported(Operation *op);
 };
 
 } // namespace mlir::triton

--- a/include/triton/Analysis/BufferRegion.h
+++ b/include/triton/Analysis/BufferRegion.h
@@ -27,7 +27,6 @@ public:
   AddressSet() = default;
 
   static AddressSet fromRange(uint32_t begin, uint32_t length);
-  static AddressSet fromAddresses(llvm::ArrayRef<uint32_t> addresses);
 
   void set(uint32_t address);
   void insert(const AddressSet &other);
@@ -37,7 +36,6 @@ public:
   auto begin() const { return addresses.begin(); }
   auto end() const { return addresses.end(); }
   bool empty() const { return addresses.empty(); }
-  bool contains(uint32_t address) const;
   bool intersects(const AddressSet &other) const;
   bool contains(const AddressSet &other) const;
   AddressSet translated(uint32_t delta) const;
@@ -73,20 +71,6 @@ struct BufferRegion {
   uint32_t baseOffset = 0;
   uint32_t length = 0;
   llvm::SmallVector<CTAAddresses, 2> ctaAddresses;
-
-  BufferRegion() = default;
-  BufferRegion(uint32_t baseOffset, uint32_t length)
-      : BufferRegion(baseOffset, length,
-                     AddressSet::fromRange(baseOffset, length)) {}
-  BufferRegion(uint32_t baseOffset, uint32_t length, AddressSet addresses)
-      : baseOffset(baseOffset), length(length) {
-    if (!addresses.empty())
-      ctaAddresses.emplace_back(0, std::move(addresses));
-  }
-  BufferRegion(uint32_t baseOffset, uint32_t length,
-               llvm::SmallVector<CTAAddresses, 2> ctaAddresses)
-      : baseOffset(baseOffset), length(length),
-        ctaAddresses(std::move(ctaAddresses)) {}
 
   bool intersects(const BufferRegion &other) const {
     return llvm::any_of(ctaAddresses, [&](const CTAAddresses &lhs) {

--- a/include/triton/Analysis/BufferRegion.h
+++ b/include/triton/Analysis/BufferRegion.h
@@ -72,35 +72,21 @@ struct BufferRegion {
   /// distinct sparse views may have the same key.
   uint32_t baseOffset = 0;
   uint32_t length = 0;
-  AddressSet addresses;
   llvm::SmallVector<CTAAddresses, 2> ctaAddresses;
-
-  /// Internal view provenance used while composing nested views.
-  uint32_t storageBase = 0;
-  uint32_t affineOffset = 0;
-  llvm::SmallVector<uint32_t, 2> partitionBases;
-  uint32_t affinePartitionOffset = 0;
-  uint32_t affineCTAOffset = 0;
 
   BufferRegion() = default;
   BufferRegion(uint32_t baseOffset, uint32_t length)
-      : baseOffset(baseOffset), length(length),
-        addresses(AddressSet::fromRange(baseOffset, length)),
-        ctaAddresses{{0, addresses}}, storageBase(baseOffset) {}
-  BufferRegion(uint32_t baseOffset, uint32_t length, AddressSet addresses,
-               uint32_t storageBase, uint32_t affineOffset,
-               llvm::ArrayRef<uint32_t> partitionBases = {},
-               uint32_t affinePartitionOffset = 0,
-               llvm::ArrayRef<CTAAddresses> ctaAddresses = {},
-               uint32_t affineCTAOffset = 0)
-      : baseOffset(baseOffset), length(length), addresses(std::move(addresses)),
-        ctaAddresses(ctaAddresses), storageBase(storageBase),
-        affineOffset(affineOffset), partitionBases(partitionBases),
-        affinePartitionOffset(affinePartitionOffset),
-        affineCTAOffset(affineCTAOffset) {
-    if (this->ctaAddresses.empty() && !this->addresses.empty())
-      this->ctaAddresses.emplace_back(0, this->addresses);
+      : BufferRegion(baseOffset, length,
+                     AddressSet::fromRange(baseOffset, length)) {}
+  BufferRegion(uint32_t baseOffset, uint32_t length, AddressSet addresses)
+      : baseOffset(baseOffset), length(length) {
+    if (!addresses.empty())
+      ctaAddresses.emplace_back(0, std::move(addresses));
   }
+  BufferRegion(uint32_t baseOffset, uint32_t length,
+               llvm::SmallVector<CTAAddresses, 2> ctaAddresses)
+      : baseOffset(baseOffset), length(length),
+        ctaAddresses(std::move(ctaAddresses)) {}
 
   bool intersects(const BufferRegion &other) const {
     return llvm::any_of(ctaAddresses, [&](const CTAAddresses &lhs) {
@@ -118,27 +104,42 @@ struct BufferRegion {
   }
 
   bool operator==(const BufferRegion &other) const {
-    return baseOffset == other.baseOffset && length == other.length &&
-           addresses == other.addresses && storageBase == other.storageBase &&
-           affineOffset == other.affineOffset &&
-           affinePartitionOffset == other.affinePartitionOffset &&
-           affineCTAOffset == other.affineCTAOffset &&
-           partitionBases == other.partitionBases &&
-           ctaAddresses == other.ctaAddresses;
+    return std::tie(baseOffset, length, ctaAddresses) ==
+           std::tie(other.baseOffset, other.length, other.ctaAddresses);
   }
 
   bool operator<(const BufferRegion &other) const {
-    return std::tie(baseOffset, length, addresses, storageBase, affineOffset,
-                    affinePartitionOffset, affineCTAOffset, partitionBases,
-                    ctaAddresses) <
-           std::tie(other.baseOffset, other.length, other.addresses,
-                    other.storageBase, other.affineOffset,
-                    other.affinePartitionOffset, other.affineCTAOffset,
-                    other.partitionBases, other.ctaAddresses);
+    return std::tie(baseOffset, length, ctaAddresses) <
+           std::tie(other.baseOffset, other.length, other.ctaAddresses);
   }
 
   template <typename T> void print(T &os) const {
     os << "[" << baseOffset << ", " << length << "]";
+  }
+};
+
+/// A physical region and the provenance required to compose descriptor views.
+struct BufferRegionView {
+  BufferRegion region;
+  uint32_t storageBase = 0;
+  uint32_t affineOffset = 0;
+  llvm::SmallVector<uint32_t, 2> partitionBases;
+  uint32_t affinePartitionOffset = 0;
+  uint32_t affineCTAOffset = 0;
+
+private:
+  auto key() const {
+    return std::tie(region, storageBase, affineOffset, affinePartitionOffset,
+                    affineCTAOffset, partitionBases);
+  }
+
+public:
+  bool operator==(const BufferRegionView &other) const {
+    return key() == other.key();
+  }
+
+  bool operator<(const BufferRegionView &other) const {
+    return key() < other.key();
   }
 };
 
@@ -161,17 +162,17 @@ BufferStatePlan createBufferStatePlan(llvm::ArrayRef<BufferRegion> regions,
 // RegionInfo lattice
 //===----------------------------------------------------------------------===//
 //
-// This wraps a set of BufferRegions and provides lattice semantics
+// This wraps a set of descriptor views and provides lattice semantics.
 //
 struct RegionInfo {
   enum class Kind { Uninitialized, Exact, Unknown };
-  using RegionList = std::set<BufferRegion>;
+  using ViewList = std::set<BufferRegionView>;
 
   Kind kind = Kind::Uninitialized;
-  RegionList regions;
+  ViewList views;
 
   RegionInfo() = default;
-  RegionInfo(const RegionList &r) : kind(Kind::Exact), regions(r) {}
+  RegionInfo(const ViewList &views) : kind(Kind::Exact), views(views) {}
 
   bool isUnknown() const { return kind == Kind::Unknown; }
 
@@ -183,12 +184,12 @@ struct RegionInfo {
     if (rhs.kind == Kind::Uninitialized)
       return lhs;
     RegionInfo result = lhs;
-    result.regions.insert(rhs.regions.begin(), rhs.regions.end());
+    result.views.insert(rhs.views.begin(), rhs.views.end());
     return result;
   }
 
   bool operator==(const RegionInfo &other) const {
-    return kind == other.kind && regions == other.regions;
+    return kind == other.kind && views == other.views;
   }
 
   template <typename T> void print(T &os) const {
@@ -196,8 +197,9 @@ struct RegionInfo {
       os << "unknown";
       return;
     }
-    llvm::interleaveComma(regions, os,
-                          [&](const BufferRegion &r) { r.print(os); });
+    llvm::interleaveComma(views, os, [&](const BufferRegionView &view) {
+      view.region.print(os);
+    });
   }
 
   static RegionInfo getPessimisticValueState(MLIRContext *context = nullptr) {
@@ -234,7 +236,6 @@ public:
   };
 
   static llvm::SmallVector<MemoryAccess> getMemoryAccesses(Operation *op);
-  static bool isMemoryAccessOperation(Operation *op);
 
   // ------------------------------
   // Public API for ConSan

--- a/include/triton/Analysis/BufferRegion.h
+++ b/include/triton/Analysis/BufferRegion.h
@@ -156,7 +156,7 @@ struct RegionInfo {
   ViewList views;
 
   RegionInfo() = default;
-  RegionInfo(const ViewList &views) : kind(Kind::Exact), views(views) {}
+  RegionInfo(ViewList views) : kind(Kind::Exact), views(std::move(views)) {}
 
   bool isUnknown() const { return kind == Kind::Unknown; }
 

--- a/include/triton/Analysis/BufferRegion.h
+++ b/include/triton/Analysis/BufferRegion.h
@@ -1,7 +1,6 @@
 #ifndef TRITON_ANALYSIS_BUFFER_REGION_H
 #define TRITON_ANALYSIS_BUFFER_REGION_H
 
-#include <algorithm>
 #include <cstdint>
 #include <set>
 #include <tuple>
@@ -120,29 +119,22 @@ struct BufferRegion {
 
   bool operator==(const BufferRegion &other) const {
     return baseOffset == other.baseOffset && length == other.length &&
-           addresses == other.addresses && ctaAddresses == other.ctaAddresses &&
-           storageBase == other.storageBase &&
+           addresses == other.addresses && storageBase == other.storageBase &&
            affineOffset == other.affineOffset &&
-           partitionBases == other.partitionBases &&
            affinePartitionOffset == other.affinePartitionOffset &&
-           affineCTAOffset == other.affineCTAOffset;
+           affineCTAOffset == other.affineCTAOffset &&
+           partitionBases == other.partitionBases &&
+           ctaAddresses == other.ctaAddresses;
   }
 
   bool operator<(const BufferRegion &other) const {
-    auto lhs = std::tie(baseOffset, length, addresses, storageBase,
-                        affineOffset, affinePartitionOffset, affineCTAOffset);
-    auto rhs = std::tie(other.baseOffset, other.length, other.addresses,
-                        other.storageBase, other.affineOffset,
-                        other.affinePartitionOffset, other.affineCTAOffset);
-    if (lhs != rhs)
-      return lhs < rhs;
-    if (partitionBases != other.partitionBases)
-      return std::lexicographical_compare(
-          partitionBases.begin(), partitionBases.end(),
-          other.partitionBases.begin(), other.partitionBases.end());
-    return std::lexicographical_compare(
-        ctaAddresses.begin(), ctaAddresses.end(), other.ctaAddresses.begin(),
-        other.ctaAddresses.end());
+    return std::tie(baseOffset, length, addresses, storageBase, affineOffset,
+                    affinePartitionOffset, affineCTAOffset, partitionBases,
+                    ctaAddresses) <
+           std::tie(other.baseOffset, other.length, other.addresses,
+                    other.storageBase, other.affineOffset,
+                    other.affinePartitionOffset, other.affineCTAOffset,
+                    other.partitionBases, other.ctaAddresses);
   }
 
   template <typename T> void print(T &os) const {

--- a/include/triton/Dialect/TritonInstrument/IR/Utility.h
+++ b/include/triton/Dialect/TritonInstrument/IR/Utility.h
@@ -270,11 +270,12 @@ struct AuxDataMap {
   // present; TMA/TC/CLC peer ranges are added only when the module uses them.
   ThreadLayout threadLayout;
 
+  bool hasAsyncCopyReads = false;
   bool hasAsyncProxyFenceTracking = false;
 
   LogicalResult populateAndPassToWarpSpecialize(ModuleOp module,
                                                 FunctionBuilder &funcBuilder,
-                                                const ConSanTargetHooks *hooks);
+                                                const ConSanTargetHooks &hooks);
 
   int getClusterBarrierSlot(Operation *op) const;
 
@@ -282,7 +283,7 @@ private:
   LogicalResult
   getBuffersAndBarriers(ModuleOp module,
                         SmallVector<triton::BufferRegion> &barrierRegions,
-                        const ConSanTargetHooks *hooks);
+                        const ConSanTargetHooks &hooks);
   void passToWarpSpecialize(triton::FuncOp func, ValueType value,
                             RegionToValueMap &map, int &captureCounter,
                             int64_t &captureBytes);

--- a/include/triton/Dialect/TritonInstrument/IR/Utility.h
+++ b/include/triton/Dialect/TritonInstrument/IR/Utility.h
@@ -118,6 +118,17 @@ struct ValueType {
       : value(value.first), type(value.second) {}
 };
 
+struct BufferStateCandidate {
+  uint32_t baseOffset = 0;
+  llvm::SmallBitVector mask;
+  uint32_t ctaMask = 0;
+};
+
+struct BufferStateCandidates {
+  SmallVector<BufferStateCandidate, 2> cases;
+  bool unknown = false;
+};
+
 // Map from IR region to ConSan auxiliary data.
 //
 // Aux data is created in the entry function and then either rematerialized or
@@ -226,10 +237,10 @@ struct AuxDataMap {
   RegionToValueMap commits[CommitKind::NumCommitKinds];
 
   // Stable exact region identities, the selected state-lane plan, and
-  // analysis-derived candidate IDs for each SSA memdesc.
+  // analysis-derived runtime-base, state-mask, and CTA cases for each memdesc.
   SmallVector<triton::BufferRegion> bufferRegions[numMemTypes];
   triton::BufferStatePlan bufferStatePlans[numMemTypes];
-  DenseMap<Value, SmallVector<uint32_t>> bufferCandidateIds[numMemTypes];
+  DenseMap<Value, BufferStateCandidates> bufferCandidates[numMemTypes];
 
   // scratch pointer, i32
   // Shared-cluster lock used to serialize ConSan instrumentation updates.

--- a/include/triton/Dialect/TritonInstrument/IR/Utility.h
+++ b/include/triton/Dialect/TritonInstrument/IR/Utility.h
@@ -236,9 +236,8 @@ struct AuxDataMap {
   // intra-CTA.
   RegionToValueMap commits[CommitKind::NumCommitKinds];
 
-  // Stable exact region identities, the selected state-lane plan, and
-  // analysis-derived runtime-base, state-mask, and CTA cases for each memdesc.
-  SmallVector<triton::BufferRegion> bufferRegions[numMemTypes];
+  // State-lane plans and analysis-derived runtime-base, state-mask, and CTA
+  // cases for each memdesc.
   triton::BufferStatePlan bufferStatePlans[numMemTypes];
   DenseMap<Value, BufferStateCandidates> bufferCandidates[numMemTypes];
 

--- a/include/triton/Dialect/TritonInstrument/Transforms/ConSanTargetHooks.h
+++ b/include/triton/Dialect/TritonInstrument/Transforms/ConSanTargetHooks.h
@@ -111,7 +111,8 @@ public:
   virtual std::optional<BarrierInvalidateInfo>
   getBarrierInvalidateInfo(Operation *op) const = 0;
 
-  virtual std::optional<WaitOpInfo> getWaitOpInfo(Operation *op) const = 0;
+  virtual std::optional<WaitOpInfo>
+  getWaitOpInfo(Operation *op, const AuxDataMap &auxData) const = 0;
 
   virtual std::optional<AsyncProxyFenceInfo>
   getAsyncProxyFenceInfo(Operation *op) const {
@@ -162,7 +163,8 @@ public:
 
   // Returns commit kinds used by addReadChecks to detect outstanding
   // read accesses to shared memory.
-  virtual SmallVector<CommitKindDesc> getOutstandingReadCommitKinds() const {
+  virtual SmallVector<CommitKindDesc>
+  getOutstandingReadCommitKinds(const AuxDataMap &auxData) const {
     return {};
   }
 
@@ -182,7 +184,7 @@ public:
 };
 
 LogicalResult runConcurrencySanitizer(ModuleOp module,
-                                      const ConSanTargetHooks *hooks);
+                                      const ConSanTargetHooks &hooks);
 
 using ConSanHooksFactory = std::function<std::unique_ptr<ConSanTargetHooks>()>;
 void registerConSanHooks(llvm::StringRef key, ConSanHooksFactory factory);

--- a/include/triton/Dialect/TritonInstrument/Transforms/ConSanTargetHooks.h
+++ b/include/triton/Dialect/TritonInstrument/Transforms/ConSanTargetHooks.h
@@ -128,52 +128,29 @@ public:
   virtual std::optional<MemEffectsOpInfo>
   getMemEffectsOpInfo(Operation *op) const {
     namespace ttg = triton::gpu;
-    std::optional<MemEffectsOpInfo> info;
     if (auto copyOp = dyn_cast<ttg::AsyncCopyGlobalToLocalOp>(op)) {
-      info.emplace();
-      info->trackingKind = MemEffectsOpInfo::TrackingKind::CommitCount;
-      info->commitKind = CommitKind::AsyncCp;
-      info->operandEffects.emplace_back(MemEffectsOpInfo::Effects::Write,
-                                        copyOp.getResult());
+      MemEffectsOpInfo info;
+      info.trackingKind = MemEffectsOpInfo::TrackingKind::CommitCount;
+      info.commitKind = CommitKind::AsyncCp;
+      info.operandEffects.emplace_back(MemEffectsOpInfo::Effects::Write,
+                                       copyOp.getResult());
+      return info;
     }
-    if (auto loadOp = dyn_cast<ttg::LocalLoadOp>(op)) {
-      info.emplace();
-      info->trackingKind = MemEffectsOpInfo::TrackingKind::Barrier;
-      info->operandEffects.emplace_back(MemEffectsOpInfo::Effects::Read,
-                                        loadOp.getSrc());
+
+    MemEffectsOpInfo info;
+    info.trackingKind = MemEffectsOpInfo::TrackingKind::Barrier;
+    auto barrierOp = dyn_cast<ttg::MBarrierOpInterface>(op);
+    for (const auto &access : BufferRegionAnalysis::getMemoryAccesses(op)) {
+      if (barrierOp &&
+          llvm::is_contained(barrierOp.getBarriers(), access.value))
+        continue;
+      info.operandEffects.emplace_back(access.isWrite
+                                           ? MemEffectsOpInfo::Effects::Write
+                                           : MemEffectsOpInfo::Effects::Read,
+                                       access.value);
     }
-    if (auto gatherOp = dyn_cast<ttg::LocalGatherOp>(op)) {
-      info.emplace();
-      info->trackingKind = MemEffectsOpInfo::TrackingKind::Barrier;
-      info->operandEffects.emplace_back(MemEffectsOpInfo::Effects::Read,
-                                        gatherOp.getSrc());
-    }
-    if (auto storeOp = dyn_cast<ttg::LocalStoreOp>(op)) {
-      info.emplace();
-      info->trackingKind = MemEffectsOpInfo::TrackingKind::Barrier;
-      info->operandEffects.emplace_back(MemEffectsOpInfo::Effects::Write,
-                                        storeOp.getDst());
-    }
-    if (auto scatterOp = dyn_cast<ttg::LocalScatterOp>(op)) {
-      info.emplace();
-      info->trackingKind = MemEffectsOpInfo::TrackingKind::Barrier;
-      info->operandEffects.emplace_back(MemEffectsOpInfo::Effects::Write,
-                                        scatterOp.getDst());
-    }
-    if (auto atomicOp = dyn_cast<ttg::LocalAtomicScatterRMWOp>(op)) {
-      info.emplace();
-      info->trackingKind = MemEffectsOpInfo::TrackingKind::Barrier;
-      info->operandEffects.emplace_back(MemEffectsOpInfo::Effects::Write,
-                                        atomicOp.getDst());
-    }
-    if (auto allocOp = dyn_cast<ttg::LocalAllocOp>(op)) {
-      if (allocOp.getSrc()) {
-        info.emplace();
-        info->trackingKind = MemEffectsOpInfo::TrackingKind::Barrier;
-        info->operandEffects.emplace_back(MemEffectsOpInfo::Effects::Write,
-                                          allocOp.getResult());
-      }
-    }
+    if (info.operandEffects.empty())
+      return std::nullopt;
     return info;
   }
 

--- a/lib/Analysis/BufferRegion.cpp
+++ b/lib/Analysis/BufferRegion.cpp
@@ -29,22 +29,18 @@ FailureOr<SmallVector<uint32_t, 2>> getAllocationOffsets(ttg::LocalAllocOp op) {
     return failure();
   }
   SmallVector<uint32_t, 2> offsets;
-  if (auto array = dyn_cast<ArrayAttr>(offsetAttr)) {
+  if (auto array = dyn_cast<ArrayAttr>(offsetAttr))
     for (Attribute offset : array)
       offsets.push_back(cast<IntegerAttr>(offset).getInt());
-  } else {
+  else
     offsets.push_back(cast<IntegerAttr>(offsetAttr).getInt());
-  }
   return offsets;
 }
 
 SmallVector<uint32_t, 2> advancePartitionBases(ArrayRef<uint32_t> bases,
                                                uint32_t offset) {
-  SmallVector<uint32_t, 2> advanced;
-  advanced.reserve(bases.size());
-  for (uint32_t base : bases)
-    advanced.push_back(base + offset);
-  return advanced;
+  return llvm::to_vector<2>(
+      llvm::map_range(bases, [=](uint32_t base) { return base + offset; }));
 }
 
 uint64_t getAllocationOffset(ttng::TMEMAllocOp op) {
@@ -92,94 +88,98 @@ struct MemDescFootprint {
   triton::AddressSet addresses;
   SmallVector<triton::BufferRegion::CTAAddresses, 2> ctaAddresses;
 
+  triton::AddressSet &forCTA(uint32_t cta) {
+    auto it = llvm::lower_bound(
+        ctaAddresses, cta,
+        [](const auto &entry, uint32_t cta) { return entry.first < cta; });
+    if (it == ctaAddresses.end() || it->first != cta)
+      it = ctaAddresses.insert(it, triton::BufferRegion::CTAAddresses{cta, {}});
+    return it->second;
+  }
+
   void set(uint32_t cta, uint32_t address) {
     addresses.set(address);
-    auto it = llvm::find_if(
-        ctaAddresses, [=](const auto &entry) { return entry.first == cta; });
-    if (it == ctaAddresses.end()) {
-      ctaAddresses.emplace_back(cta, triton::AddressSet());
-      it = std::prev(ctaAddresses.end());
-    }
-    it->second.set(address);
+    forCTA(cta).set(address);
   }
 
   void insert(const MemDescFootprint &other) {
     addresses.insert(other.addresses);
-    for (const auto &[cta, otherAddresses] : other.ctaAddresses) {
-      auto it = llvm::find_if(
-          ctaAddresses, [=](const auto &entry) { return entry.first == cta; });
-      if (it == ctaAddresses.end())
-        ctaAddresses.emplace_back(cta, otherAddresses);
-      else
-        it->second.insert(otherAddresses);
-    }
+    for (const auto &[cta, otherAddresses] : other.ctaAddresses)
+      forCTA(cta).insert(otherAddresses);
   }
 };
 
-FailureOr<MemDescFootprint> getMemDescAddresses(
+MemDescFootprint getMemDescAddresses(
     uint32_t storageBase, uint32_t affineOffset, ttg::MemDescType ty,
-    Operation *op,
     llvm::DenseMap<std::pair<Type, uint32_t>, triton::AddressSet> *cache =
         nullptr,
     ArrayRef<uint32_t> partitionBases = {}, uint32_t affinePartitionOffset = 0,
     uint32_t affineCTAOffset = 0) {
   bool isTmem = isa<ttng::TensorMemorySpaceAttr>(ty.getMemorySpace());
-  auto collectPages = [&]() -> FailureOr<MemDescFootprint> {
+  auto collectPages = [&]() {
     ttg::MemDescType pageTy =
         ty.cloneWith(ty.getShape().drop_front(), ty.getElementType());
     MemDescFootprint footprint;
     for (int64_t page = 0; page < ty.getDimSize(0); ++page) {
       uint32_t pageOffset = getMemDescStorageOffset(pageTy, page);
-      SmallVector<uint32_t, 2> pageBases =
-          advancePartitionBases(partitionBases, pageOffset);
-      FailureOr<MemDescFootprint> pageAddresses = getMemDescAddresses(
-          storageBase + pageOffset, affineOffset, pageTy, op,
-          /*cache=*/nullptr, pageBases, affinePartitionOffset, affineCTAOffset);
-      if (failed(pageAddresses))
-        return failure();
-      footprint.insert(*pageAddresses);
+      footprint.insert(getMemDescAddresses(
+          storageBase + pageOffset, affineOffset, pageTy, /*cache=*/nullptr,
+          advancePartitionBases(partitionBases, pageOffset),
+          affinePartitionOffset, affineCTAOffset));
     }
     return footprint;
   };
-  size_t encodingRank =
-      cast<ttg::LayoutEncodingTrait>(ty.getEncoding()).getRank();
-  if (encodingRank != ty.getRank()) {
-    if (encodingRank + 1 != ty.getRank()) {
-      op->emitError("unsupported multibuffer rank in exact buffer region "
-                    "analysis");
-      return failure();
-    }
+  if (cast<ttg::LayoutEncodingTrait>(ty.getEncoding()).getRank() !=
+      ty.getRank())
     return collectPages();
-  }
   triton::LinearLayout layout = ttg::isPaddedEncoding(ty.getEncoding())
                                     ? ttg::paddedLinearLayout(ty)
                                     : ttg::toLinearLayout(ty);
-  size_t layoutRank = llvm::size(layout.getOutDimNames());
-  if (layoutRank != ty.getRank()) {
-    if (layoutRank + 1 != ty.getRank()) {
-      op->emitError("unsupported multibuffer rank in exact buffer region "
-                    "analysis");
-      return failure();
-    }
+  if (llvm::size(layout.getOutDimNames()) != ty.getRank())
     return collectPages();
-  }
   triton::LinearLayout inverse = layout.pseudoinvert();
   MLIRContext *ctx = ty.getContext();
   SmallVector<StringAttr> dims = triton::standardOutDimNames(ctx, ty.getRank());
-  SmallVector<int64_t> shape(ty.getShape());
+  ArrayRef<int64_t> shape = ty.getShape();
   uint64_t numPoints = product(shape);
   uint32_t bitWidth = ty.getElementTypeBitWidth();
-  if (!isTmem && bitWidth % 8 != 0) {
-    op->emitError("sub-byte shared-memory elements are unsupported by exact "
-                  "buffer region analysis");
-    return failure();
-  }
 
   StringAttr offsetName = StringAttr::get(ctx, "offset");
   StringAttr blockName = StringAttr::get(ctx, "block");
   StringAttr partitionName = StringAttr::get(ctx, "partition");
   StringAttr rowName = StringAttr::get(ctx, "row");
   StringAttr colName = StringAttr::get(ctx, "col");
+
+  MemDescFootprint footprint;
+  auto addPhysicalAddress = [&](uint32_t offset, uint32_t row, uint32_t col,
+                                uint32_t partition, uint32_t block) {
+    uint32_t cta = block ^ affineCTAOffset;
+    if (isTmem) {
+      uint64_t bitBegin = static_cast<uint64_t>(col) * bitWidth;
+      uint32_t firstWord = bitBegin / 32;
+      uint32_t lastWord = llvm::divideCeil(bitBegin + bitWidth, uint64_t{32});
+      uint32_t relative = (row << 16) | firstWord;
+      uint64_t begin =
+          static_cast<uint64_t>(storageBase) + affineOffset + relative;
+      for (uint32_t word = firstWord; word < lastWord; ++word) {
+        uint64_t address = begin + (word - firstWord);
+        assert(address <= std::numeric_limits<uint32_t>::max());
+        footprint.set(cta, address);
+      }
+    } else {
+      uint32_t base = storageBase;
+      if (!partitionBases.empty())
+        base = partitionBases[partition ^ affinePartitionOffset];
+      uint32_t relative = offset * (bitWidth / 8);
+      uint32_t combined = affineOffset ^ relative;
+      uint64_t begin =
+          static_cast<uint64_t>(base) + applySharedPadding(combined, ty);
+      for (uint32_t byte = 0; byte < bitWidth / 8; ++byte) {
+        assert(begin + byte <= std::numeric_limits<uint32_t>::max());
+        footprint.set(cta, begin + byte);
+      }
+    }
+  };
 
   struct PhysicalBasis {
     uint32_t offset = 0;
@@ -192,10 +192,6 @@ FailureOr<MemDescFootprint> getMemDescAddresses(
   bool hasCTAAddressVariation = false;
   for (auto [dim, dimSize] : llvm::zip_equal(dims, shape)) {
     unsigned numBits = llvm::Log2_64(dimSize);
-    if (numBits > static_cast<unsigned>(inverse.getInDimSizeLog2(dim))) {
-      op->emitError("buffer footprint exceeds its linear-layout domain");
-      return failure();
-    }
     for (unsigned bit = 0; bit < numBits; ++bit) {
       auto basis = [&](StringAttr name) {
         return inverse.hasOutDim(name)
@@ -210,51 +206,16 @@ FailureOr<MemDescFootprint> getMemDescAddresses(
   }
 
   if (cache && partitionBases.empty() && !hasCTAAddressVariation) {
-    auto key = std::make_pair(Type(ty), affineOffset);
-    auto found = cache->find(key);
-    if (found == cache->end()) {
-      FailureOr<MemDescFootprint> relative =
-          getMemDescAddresses(/*storageBase=*/0, affineOffset, ty, op);
-      if (failed(relative))
-        return failure();
-      found = cache->try_emplace(key, std::move(relative->addresses)).first;
-    }
-    MemDescFootprint footprint;
+    auto [found, inserted] =
+        cache->try_emplace(std::make_pair(Type(ty), affineOffset));
+    if (inserted)
+      found->second =
+          getMemDescAddresses(/*storageBase=*/0, affineOffset, ty).addresses;
     footprint.addresses = found->second.translated(storageBase);
     if (!footprint.addresses.empty())
       footprint.ctaAddresses.emplace_back(affineCTAOffset, footprint.addresses);
     return footprint;
   }
-
-  MemDescFootprint footprint;
-  auto addPhysicalAddress = [&](const PhysicalBasis &physical) {
-    uint32_t cta = physical.block ^ affineCTAOffset;
-    if (isTmem) {
-      uint64_t bitBegin = static_cast<uint64_t>(physical.col) * bitWidth;
-      uint32_t firstWord = bitBegin / 32;
-      uint32_t lastWord = llvm::divideCeil(bitBegin + bitWidth, uint64_t{32});
-      uint32_t relative = (physical.row << 16) | firstWord;
-      uint64_t begin =
-          static_cast<uint64_t>(storageBase) + affineOffset + relative;
-      for (uint32_t word = firstWord; word < lastWord; ++word) {
-        uint64_t address = begin + (word - firstWord);
-        assert(address <= std::numeric_limits<uint32_t>::max());
-        footprint.set(cta, address);
-      }
-    } else {
-      uint32_t base = storageBase;
-      if (!partitionBases.empty())
-        base = partitionBases[physical.partition ^ affinePartitionOffset];
-      uint32_t relative = physical.offset * (bitWidth / 8);
-      uint32_t combined = affineOffset ^ relative;
-      uint64_t begin =
-          static_cast<uint64_t>(base) + applySharedPadding(combined, ty);
-      for (uint32_t byte = 0; byte < bitWidth / 8; ++byte) {
-        assert(begin + byte <= std::numeric_limits<uint32_t>::max());
-        footprint.set(cta, begin + byte);
-      }
-    }
-  };
 
   PhysicalBasis physical;
   for (uint64_t index = 0; index < numPoints; ++index) {
@@ -266,23 +227,20 @@ FailureOr<MemDescFootprint> getMemDescAddresses(
       physical.partition ^= basis.partition;
       physical.block ^= basis.block;
     }
-    addPhysicalAddress(physical);
+    addPhysicalAddress(physical.offset, physical.row, physical.col,
+                       physical.partition, physical.block);
   }
-  llvm::sort(footprint.ctaAddresses, llvm::less_first());
   return footprint;
 }
 
-FailureOr<triton::BufferRegion> getMemDescRegion(
+triton::BufferRegion getMemDescRegion(
     uint32_t storageBase, uint32_t affineOffset, ttg::MemDescType ty,
-    Operation *op,
     llvm::DenseMap<std::pair<Type, uint32_t>, triton::AddressSet> *cache,
     ArrayRef<uint32_t> partitionBases = {}, uint32_t affinePartitionOffset = 0,
     uint32_t affineCTAOffset = 0) {
-  FailureOr<MemDescFootprint> footprint = getMemDescAddresses(
-      storageBase, affineOffset, ty, op, cache, partitionBases,
-      affinePartitionOffset, affineCTAOffset);
-  if (failed(footprint))
-    return failure();
+  MemDescFootprint footprint =
+      getMemDescAddresses(storageBase, affineOffset, ty, cache, partitionBases,
+                          affinePartitionOffset, affineCTAOffset);
   uint32_t runtimeStorageBase = partitionBases.empty()
                                     ? storageBase
                                     : partitionBases[affinePartitionOffset];
@@ -291,9 +249,9 @@ FailureOr<triton::BufferRegion> getMemDescRegion(
                              ? affineOffset
                              : applySharedPadding(affineOffset, ty));
   return triton::BufferRegion(
-      baseOffset, getMemDescSize(ty), std::move(footprint->addresses),
+      baseOffset, getMemDescSize(ty), std::move(footprint.addresses),
       storageBase, affineOffset, partitionBases, affinePartitionOffset,
-      footprint->ctaAddresses, affineCTAOffset);
+      footprint.ctaAddresses, affineCTAOffset);
 }
 
 uint32_t getMemDescStorageOffset(ttg::MemDescType ty, unsigned index) {
@@ -380,7 +338,7 @@ getMemDescSubsliceUnpaddedOffsets(ttg::MemDescSubsliceOp op) {
   StringAttr partitionDim = StringAttr::get(ctx, "partition");
   mlir::triton::LinearLayout inverse = layout.pseudoinvert();
   auto mapped = inverse.apply(logicalOffsets);
-  uint32_t elementOffset = 0;
+  uint64_t elementOffset = 0;
   uint32_t blockOffset = 0;
   uint32_t partitionOffset = 0;
   for (auto [dim, offset] : mapped) {
@@ -391,20 +349,19 @@ getMemDescSubsliceUnpaddedOffsets(ttg::MemDescSubsliceOp op) {
     else if (dim == partitionDim)
       partitionOffset = static_cast<uint32_t>(offset);
   }
-  uint64_t totalElementOffset = elementOffset;
   if (offsets.size() != layoutRank) {
     uint64_t stride = ttg::getAllocationElems(
         encoding, ttg::dropPipeliningDim(srcTy.getAllocShape(), encoding));
     if (auto partitioned =
             dyn_cast<ttg::PartitionedSharedEncodingAttr>(encoding))
       stride /= partitioned.getNumPartitions();
-    totalElementOffset += static_cast<uint64_t>(offsets.front()) * stride;
+    elementOffset += static_cast<uint64_t>(offsets.front()) * stride;
   }
 
   uint64_t elementSizeBytes =
       srcTy.getElementType().getIntOrFloatBitWidth() / 8;
   assert(elementSizeBytes > 0 && "element size must be non-zero");
-  uint64_t byteOffset = totalElementOffset * elementSizeBytes;
+  uint64_t byteOffset = elementOffset * elementSizeBytes;
 
   assert(byteOffset <= std::numeric_limits<uint32_t>::max() &&
          "memdesc_subslice offset exceeds 32-bit range");
@@ -563,10 +520,8 @@ BufferStatePlan createBufferStatePlan(ArrayRef<BufferRegion> regions,
     componentPlans.push_back({component, std::move(atomMemberships)});
   }
 
-  if (includeUnknown) {
-    ++plan.numLanes;
-    plan.unknownMask = llvm::SmallBitVector(plan.numLanes, true);
-  }
+  if (includeUnknown)
+    plan.unknownMask = llvm::SmallBitVector(++plan.numLanes, true);
 
   for (llvm::SmallBitVector &mask : plan.regionMasks)
     mask.resize(plan.numLanes);
@@ -614,9 +569,9 @@ LogicalResult BufferRegionAnalysis::visitOperation(
     llvm::ArrayRef<const dataflow::Lattice<RegionInfo> *> operands,
     llvm::ArrayRef<dataflow::Lattice<RegionInfo> *> results) {
   RegionInfo regionInfo(RegionInfo::RegionList{});
-  auto propagateRegions = [&]() {
+  auto propagateRegions = [&](const RegionInfo &info) {
     for (auto *result : results)
-      propagateIfChanged(result, result->join(regionInfo));
+      propagateIfChanged(result, result->join(info));
     return success();
   };
   if (auto wsOp = dyn_cast<ttg::WarpSpecializeOp>(op)) {
@@ -639,31 +594,21 @@ LogicalResult BufferRegionAnalysis::visitOperation(
     ArrayRef<uint32_t> partitionBases = offsets->size() > 1
                                             ? ArrayRef<uint32_t>(*offsets)
                                             : ArrayRef<uint32_t>();
-    FailureOr<BufferRegion> region = getMemDescRegion(
-        offsets->front(), /*affineOffset=*/0, localAllocOp.getType(), op,
-        &footprintCache, partitionBases);
-    if (failed(region))
-      return failure();
-    regionInfo.regions.insert(std::move(*region));
-
-    return propagateRegions();
+    regionInfo.regions.insert(getMemDescRegion(
+        offsets->front(), /*affineOffset=*/0, localAllocOp.getType(),
+        &footprintCache, partitionBases));
+    return propagateRegions(regionInfo);
   }
   if (auto tmemAllocOp = dyn_cast<ttng::TMEMAllocOp>(op)) {
-    uint32_t offset = getAllocationOffset(tmemAllocOp);
-    FailureOr<BufferRegion> region = getMemDescRegion(
-        offset, /*affineOffset=*/0, tmemAllocOp.getType(), op, &footprintCache);
-    if (failed(region))
-      return failure();
-    regionInfo.regions.insert(std::move(*region));
-
-    return propagateRegions();
+    regionInfo.regions.insert(
+        getMemDescRegion(getAllocationOffset(tmemAllocOp), /*affineOffset=*/0,
+                         tmemAllocOp.getType(), &footprintCache));
+    return propagateRegions(regionInfo);
   }
   if (auto memdescIndexOp = dyn_cast<ttg::MemDescIndexOp>(op)) {
-    RegionInfo in = operands[0]->getValue();
-    if (in.isUnknown()) {
-      regionInfo = in;
-      return propagateRegions();
-    }
+    const RegionInfo &in = operands[0]->getValue();
+    if (in.isUnknown())
+      return propagateRegions(in);
     int numSubBuffers = getNumBuffers(memdescIndexOp);
     int firstSubBuffer = 0;
     int endSubBuffer = numSubBuffers;
@@ -678,94 +623,64 @@ LogicalResult BufferRegionAnalysis::visitOperation(
       for (int i = firstSubBuffer; i < endSubBuffer; ++i) {
         uint32_t stageOffset =
             getMemDescStorageOffset(memdescIndexOp.getType(), i);
-        uint32_t storageBase = region.storageBase + stageOffset;
-        SmallVector<uint32_t, 2> partitionBases =
-            advancePartitionBases(region.partitionBases, stageOffset);
-        FailureOr<BufferRegion> subBuffer = getMemDescRegion(
-            storageBase, region.affineOffset, memdescIndexOp.getType(), op,
-            &footprintCache, partitionBases, region.affinePartitionOffset,
-            region.affineCTAOffset);
-        if (failed(subBuffer))
-          return failure();
-        regionInfo.regions.insert(std::move(*subBuffer));
+        regionInfo.regions.insert(getMemDescRegion(
+            region.storageBase + stageOffset, region.affineOffset,
+            memdescIndexOp.getType(), &footprintCache,
+            advancePartitionBases(region.partitionBases, stageOffset),
+            region.affinePartitionOffset, region.affineCTAOffset));
       }
     }
 
-    return propagateRegions();
+    return propagateRegions(regionInfo);
   }
   if (auto memdescSubsliceOp = dyn_cast<ttg::MemDescSubsliceOp>(op)) {
-    RegionInfo in = operands[0]->getValue();
-    if (in.isUnknown()) {
-      regionInfo = in;
-      return propagateRegions();
-    }
+    const RegionInfo &in = operands[0]->getValue();
+    if (in.isUnknown())
+      return propagateRegions(in);
     MemDescSubsliceOffsets relativeOffset =
         getMemDescSubsliceUnpaddedOffsets(memdescSubsliceOp);
-    for (auto &region : in.regions) {
-      uint32_t affineOffset = region.affineOffset ^ relativeOffset.byteOffset;
-      uint32_t affinePartitionOffset =
-          region.affinePartitionOffset ^ relativeOffset.partitionOffset;
-      uint32_t affineCTAOffset =
-          region.affineCTAOffset ^ relativeOffset.ctaOffset;
-      FailureOr<BufferRegion> subBuffer = getMemDescRegion(
-          region.storageBase, affineOffset, memdescSubsliceOp.getType(), op,
-          &footprintCache, region.partitionBases, affinePartitionOffset,
-          affineCTAOffset);
-      if (failed(subBuffer))
-        return failure();
-      regionInfo.regions.insert(std::move(*subBuffer));
-    }
-    return propagateRegions();
+    for (auto &region : in.regions)
+      regionInfo.regions.insert(getMemDescRegion(
+          region.storageBase, region.affineOffset ^ relativeOffset.byteOffset,
+          memdescSubsliceOp.getType(), &footprintCache, region.partitionBases,
+          region.affinePartitionOffset ^ relativeOffset.partitionOffset,
+          region.affineCTAOffset ^ relativeOffset.ctaOffset));
+    return propagateRegions(regionInfo);
   }
   if (auto tmemSubsliceOp = dyn_cast<ttng::TMEMSubSliceOp>(op)) {
-    RegionInfo in = operands[0]->getValue();
-    if (in.isUnknown()) {
-      regionInfo = in;
-      return propagateRegions();
-    }
+    const RegionInfo &in = operands[0]->getValue();
+    if (in.isUnknown())
+      return propagateRegions(in);
     uint32_t relativeOffset = ttng::getTMemSubSliceOffset(
         tmemSubsliceOp.getSrc().getType(), tmemSubsliceOp.getOffset(),
         tmemSubsliceOp.getDim());
-    for (auto &region : in.regions) {
-      uint32_t affineOffset = region.affineOffset + relativeOffset;
-      FailureOr<BufferRegion> subBuffer = getMemDescRegion(
-          region.storageBase, affineOffset, tmemSubsliceOp.getType(), op,
-          &footprintCache, region.partitionBases, region.affinePartitionOffset,
-          region.affineCTAOffset);
-      if (failed(subBuffer))
-        return failure();
-      regionInfo.regions.insert(std::move(*subBuffer));
-    }
-    return propagateRegions();
+    for (auto &region : in.regions)
+      regionInfo.regions.insert(getMemDescRegion(
+          region.storageBase, region.affineOffset + relativeOffset,
+          tmemSubsliceOp.getType(), &footprintCache, region.partitionBases,
+          region.affinePartitionOffset, region.affineCTAOffset));
+    return propagateRegions(regionInfo);
   }
   if (auto selectOp = dyn_cast<arith::SelectOp>(op)) {
     if (isa<ttg::MemDescType>(selectOp.getType())) {
       regionInfo =
           RegionInfo::join(operands[1]->getValue(), operands[2]->getValue());
-      return propagateRegions();
+      return propagateRegions(regionInfo);
     }
   }
   if (auto reinterpretOp = dyn_cast<ttg::MemDescReinterpretOp>(op)) {
-    RegionInfo in = operands[0]->getValue();
-    if (in.isUnknown()) {
-      regionInfo = in;
-      return propagateRegions();
-    }
-    for (auto &region : in.regions) {
-      FailureOr<BufferRegion> reinterpreted = getMemDescRegion(
-          region.storageBase, region.affineOffset, reinterpretOp.getType(), op,
+    const RegionInfo &in = operands[0]->getValue();
+    if (in.isUnknown())
+      return propagateRegions(in);
+    for (auto &region : in.regions)
+      regionInfo.regions.insert(getMemDescRegion(
+          region.storageBase, region.affineOffset, reinterpretOp.getType(),
           &footprintCache, region.partitionBases, region.affinePartitionOffset,
-          region.affineCTAOffset);
-      if (failed(reinterpreted))
-        return failure();
-      regionInfo.regions.insert(std::move(*reinterpreted));
-    }
-    return propagateRegions();
+          region.affineCTAOffset));
+    return propagateRegions(regionInfo);
   }
-  if (isa<ttg::MemDescTransOp, ttg::MemDescReshapeOp>(op)) {
-    regionInfo = operands[0]->getValue();
-    return propagateRegions();
-  }
+  if (isa<ttg::MemDescTransOp, ttg::MemDescReshapeOp>(op))
+    return propagateRegions(operands[0]->getValue());
   if (isa<ttng::WarpGroupDotWaitOp>(op)) {
     for (auto [operand, result] : llvm::zip_equal(operands, results))
       propagateIfChanged(result, result->join(operand->getValue()));

--- a/lib/Analysis/BufferRegion.cpp
+++ b/lib/Analysis/BufferRegion.cpp
@@ -388,13 +388,6 @@ AddressSet AddressSet::fromRange(uint32_t begin, uint32_t length) {
   return result;
 }
 
-AddressSet AddressSet::fromAddresses(ArrayRef<uint32_t> input) {
-  AddressSet result;
-  for (uint32_t address : input)
-    result.set(address);
-  return result;
-}
-
 void AddressSet::set(uint32_t address) { addresses.set(address); }
 
 void AddressSet::insert(const AddressSet &other) {
@@ -409,10 +402,6 @@ AddressSet AddressSet::intersection(const AddressSet &other) const {
 
 void AddressSet::subtract(const AddressSet &other) {
   addresses.intersectWithComplement(other.addresses);
-}
-
-bool AddressSet::contains(uint32_t address) const {
-  return addresses.test(address);
 }
 
 bool AddressSet::intersects(const AddressSet &other) const {

--- a/lib/Analysis/BufferRegion.cpp
+++ b/lib/Analysis/BufferRegion.cpp
@@ -260,40 +260,11 @@ uint32_t getMemDescStorageOffset(ttg::MemDescType ty, unsigned index) {
   return applySharedPadding(static_cast<uint32_t>(unpadded), ty);
 }
 
-unsigned getNumBuffers(ttg::MemDescIndexOp memdescIndexOp) {
-  ttg::MemDescType ty =
-      cast<ttg::MemDescType>(memdescIndexOp.getSrc().getType());
-  return ty.getShape()[0];
-}
-
-llvm::DenseSet<Value> getBarrierOperands(Operation *op) {
-  if (auto barrierOp = dyn_cast<ttg::MBarrierOpInterface>(op)) {
-    auto barriers = barrierOp.getBarriers();
-    return llvm::DenseSet<Value>(barriers.begin(), barriers.end());
-  }
-
-  return llvm::DenseSet<Value>{};
-}
-
 bool isUsedAsBarrier(Value v) {
-  for (auto user : v.getUsers()) {
-    if (getBarrierOperands(user).contains(v)) {
-      return true;
-    }
-  }
-  return false;
-}
-
-bool isUsedAsSharedMemory(Value v) {
-  auto type = dyn_cast<ttg::MemDescType>(v.getType());
-  return type &&
-         isa_and_nonnull<ttg::SharedMemorySpaceAttr>(type.getMemorySpace());
-}
-
-bool isUsedAsTensorMemory(Value v) {
-  auto type = dyn_cast<ttg::MemDescType>(v.getType());
-  return type &&
-         isa_and_nonnull<ttng::TensorMemorySpaceAttr>(type.getMemorySpace());
+  return llvm::any_of(v.getUsers(), [&](Operation *user) {
+    auto barrierOp = dyn_cast<ttg::MBarrierOpInterface>(user);
+    return barrierOp && llvm::is_contained(barrierOp.getBarriers(), v);
+  });
 }
 
 struct MemDescSubsliceOffsets {
@@ -362,15 +333,15 @@ getMemDescSubsliceUnpaddedOffsets(ttg::MemDescSubsliceOp op) {
 }
 
 std::optional<triton::BufferRegionAnalysis::RegionType> getRegionType(Value v) {
-  if (isUsedAsBarrier(v)) {
+  if (isUsedAsBarrier(v))
     return triton::BufferRegionAnalysis::RegionType::BARRIER;
-  }
-  if (isUsedAsSharedMemory(v)) {
+  auto type = dyn_cast<ttg::MemDescType>(v.getType());
+  if (!type)
+    return std::nullopt;
+  if (isa<ttg::SharedMemorySpaceAttr>(type.getMemorySpace()))
     return triton::BufferRegionAnalysis::RegionType::SHARED_MEMORY;
-  }
-  if (isUsedAsTensorMemory(v)) {
+  if (isa<ttng::TensorMemorySpaceAttr>(type.getMemorySpace()))
     return triton::BufferRegionAnalysis::RegionType::TENSOR_MEMORY;
-  }
   return std::nullopt;
 }
 
@@ -593,7 +564,8 @@ LogicalResult BufferRegionAnalysis::visitOperation(
     const RegionInfo &in = operands[0]->getValue();
     if (in.isUnknown())
       return propagateRegions(in);
-    int numSubBuffers = getNumBuffers(memdescIndexOp);
+    int numSubBuffers =
+        cast<ttg::MemDescType>(memdescIndexOp.getSrc().getType()).getShape()[0];
     int firstSubBuffer = 0;
     int endSubBuffer = numSubBuffers;
     APInt constantIndex;

--- a/lib/Analysis/BufferRegion.cpp
+++ b/lib/Analysis/BufferRegion.cpp
@@ -179,7 +179,9 @@ MemDescFootprint getMemDescAddresses(
   };
   SmallVector<PhysicalBasis> bases;
   bool hasCTAAddressVariation = false;
-  for (auto [dim, dimSize] : llvm::zip_equal(dims, shape)) {
+  for (auto dimAndSize : llvm::zip_equal(dims, shape)) {
+    auto dim = std::get<0>(dimAndSize);
+    auto dimSize = std::get<1>(dimAndSize);
     unsigned numBits = llvm::Log2_64(dimSize);
     for (unsigned bit = 0; bit < numBits; ++bit) {
       auto basis = [&](StringAttr name) {

--- a/lib/Analysis/BufferRegion.cpp
+++ b/lib/Analysis/BufferRegion.cpp
@@ -6,6 +6,7 @@
 #include "mlir/Analysis/DataFlow/DeadCodeAnalysis.h"
 #include "mlir/Dialect/Arith/IR/Arith.h"
 #include "mlir/IR/Matchers.h"
+#include "mlir/Interfaces/SideEffectInterfaces.h"
 #include "triton/Dialect/Triton/IR/Utility.h"
 #include "triton/Dialect/TritonGPU/IR/Dialect.h"
 #include "triton/Dialect/TritonGPU/IR/LinearLayoutConversions.h"
@@ -20,26 +21,30 @@ using namespace mlir;
 
 namespace {
 // TODO: move to Utility.cpp/unify with TritonInstrument/Utility.cpp
-FailureOr<uint32_t> getAllocationOffset(ttg::LocalAllocOp op) {
+FailureOr<SmallVector<uint32_t, 2>> getAllocationOffsets(ttg::LocalAllocOp op) {
   auto offsetAttr = op->getAttr("allocation.offset");
   if (!offsetAttr) {
     op.emitError("ConcurrencySanitizer should run after "
                  "AllocateSharedMemory pass");
     return failure();
   }
-  auto offset = dyn_cast<IntegerAttr>(offsetAttr);
-  if (!offset) {
-    op.emitError("exact buffer-region analysis does not support shared-memory "
-                 "layouts with multiple physical allocation bases");
-    return failure();
+  SmallVector<uint32_t, 2> offsets;
+  if (auto array = dyn_cast<ArrayAttr>(offsetAttr)) {
+    for (Attribute offset : array)
+      offsets.push_back(cast<IntegerAttr>(offset).getInt());
+  } else {
+    offsets.push_back(cast<IntegerAttr>(offsetAttr).getInt());
   }
-  int64_t value = offset.getInt();
-  if (value < 0 ||
-      static_cast<uint64_t>(value) > std::numeric_limits<uint32_t>::max()) {
-    op.emitError("shared-memory allocation offset exceeds 32-bit range");
-    return failure();
-  }
-  return static_cast<uint32_t>(value);
+  return offsets;
+}
+
+SmallVector<uint32_t, 2> advancePartitionBases(ArrayRef<uint32_t> bases,
+                                               uint32_t offset) {
+  SmallVector<uint32_t, 2> advanced;
+  advanced.reserve(bases.size());
+  for (uint32_t base : bases)
+    advanced.push_back(base + offset);
+  return advanced;
 }
 
 uint64_t getAllocationOffset(ttng::TMEMAllocOp op) {
@@ -83,37 +88,58 @@ uint32_t applySharedPadding(uint32_t byteOffset, ttg::MemDescType ty) {
 
 uint32_t getMemDescStorageOffset(ttg::MemDescType ty, unsigned index);
 
-FailureOr<triton::AddressSet> getMemDescAddresses(
+struct MemDescFootprint {
+  triton::AddressSet addresses;
+  SmallVector<triton::BufferRegion::CTAAddresses, 2> ctaAddresses;
+
+  void set(uint32_t cta, uint32_t address) {
+    addresses.set(address);
+    auto it = llvm::find_if(
+        ctaAddresses, [=](const auto &entry) { return entry.first == cta; });
+    if (it == ctaAddresses.end()) {
+      ctaAddresses.emplace_back(cta, triton::AddressSet());
+      it = std::prev(ctaAddresses.end());
+    }
+    it->second.set(address);
+  }
+
+  void insert(const MemDescFootprint &other) {
+    addresses.insert(other.addresses);
+    for (const auto &[cta, otherAddresses] : other.ctaAddresses) {
+      auto it = llvm::find_if(
+          ctaAddresses, [=](const auto &entry) { return entry.first == cta; });
+      if (it == ctaAddresses.end())
+        ctaAddresses.emplace_back(cta, otherAddresses);
+      else
+        it->second.insert(otherAddresses);
+    }
+  }
+};
+
+FailureOr<MemDescFootprint> getMemDescAddresses(
     uint32_t storageBase, uint32_t affineOffset, ttg::MemDescType ty,
     Operation *op,
     llvm::DenseMap<std::pair<Type, uint32_t>, triton::AddressSet> *cache =
-        nullptr) {
-  if (cache) {
-    auto key = std::make_pair(Type(ty), affineOffset);
-    auto found = cache->find(key);
-    if (found != cache->end())
-      return found->second.translated(storageBase);
-    FailureOr<triton::AddressSet> relative =
-        getMemDescAddresses(/*storageBase=*/0, affineOffset, ty, op);
-    if (failed(relative))
-      return failure();
-    cache->try_emplace(key, *relative);
-    return relative->translated(storageBase);
-  }
+        nullptr,
+    ArrayRef<uint32_t> partitionBases = {}, uint32_t affinePartitionOffset = 0,
+    uint32_t affineCTAOffset = 0) {
   bool isTmem = isa<ttng::TensorMemorySpaceAttr>(ty.getMemorySpace());
-  auto collectPages = [&]() -> FailureOr<triton::AddressSet> {
+  auto collectPages = [&]() -> FailureOr<MemDescFootprint> {
     ttg::MemDescType pageTy =
         ty.cloneWith(ty.getShape().drop_front(), ty.getElementType());
-    triton::AddressSet addresses;
+    MemDescFootprint footprint;
     for (int64_t page = 0; page < ty.getDimSize(0); ++page) {
-      FailureOr<triton::AddressSet> pageAddresses = getMemDescAddresses(
-          storageBase + getMemDescStorageOffset(pageTy, page), affineOffset,
-          pageTy, op);
+      uint32_t pageOffset = getMemDescStorageOffset(pageTy, page);
+      SmallVector<uint32_t, 2> pageBases =
+          advancePartitionBases(partitionBases, pageOffset);
+      FailureOr<MemDescFootprint> pageAddresses = getMemDescAddresses(
+          storageBase + pageOffset, affineOffset, pageTy, op,
+          /*cache=*/nullptr, pageBases, affinePartitionOffset, affineCTAOffset);
       if (failed(pageAddresses))
         return failure();
-      addresses.insert(*pageAddresses);
+      footprint.insert(*pageAddresses);
     }
-    return addresses;
+    return footprint;
   };
   size_t encodingRank =
       cast<ttg::LayoutEncodingTrait>(ty.getEncoding()).getRank();
@@ -140,7 +166,7 @@ FailureOr<triton::AddressSet> getMemDescAddresses(
   triton::LinearLayout inverse = layout.pseudoinvert();
   MLIRContext *ctx = ty.getContext();
   SmallVector<StringAttr> dims = triton::standardOutDimNames(ctx, ty.getRank());
-  SmallVector<int64_t> shape = ttg::getShapePerCTA(ty);
+  SmallVector<int64_t> shape(ty.getShape());
   uint64_t numPoints = product(shape);
   uint32_t bitWidth = ty.getElementTypeBitWidth();
   if (!isTmem && bitWidth % 8 != 0) {
@@ -151,40 +177,19 @@ FailureOr<triton::AddressSet> getMemDescAddresses(
 
   StringAttr offsetName = StringAttr::get(ctx, "offset");
   StringAttr blockName = StringAttr::get(ctx, "block");
+  StringAttr partitionName = StringAttr::get(ctx, "partition");
   StringAttr rowName = StringAttr::get(ctx, "row");
   StringAttr colName = StringAttr::get(ctx, "col");
-  triton::AddressSet addresses;
-  auto addPhysicalAddress = [&](uint32_t offset, uint32_t row, uint32_t col) {
-    if (isTmem) {
-      uint64_t bitBegin = static_cast<uint64_t>(col) * bitWidth;
-      uint32_t firstWord = bitBegin / 32;
-      uint32_t lastWord = llvm::divideCeil(bitBegin + bitWidth, uint64_t{32});
-      uint32_t relative = (row << 16) | firstWord;
-      uint64_t begin =
-          static_cast<uint64_t>(storageBase) + affineOffset + relative;
-      for (uint32_t word = firstWord; word < lastWord; ++word) {
-        uint64_t address = begin + (word - firstWord);
-        assert(address <= std::numeric_limits<uint32_t>::max());
-        addresses.set(address);
-      }
-    } else {
-      uint32_t relative = offset * (bitWidth / 8);
-      uint32_t combined = affineOffset ^ relative;
-      uint64_t begin =
-          static_cast<uint64_t>(storageBase) + applySharedPadding(combined, ty);
-      for (uint32_t byte = 0; byte < bitWidth / 8; ++byte) {
-        assert(begin + byte <= std::numeric_limits<uint32_t>::max());
-        addresses.set(begin + byte);
-      }
-    }
-  };
 
   struct PhysicalBasis {
     uint32_t offset = 0;
     uint32_t row = 0;
     uint32_t col = 0;
+    uint32_t partition = 0;
+    uint32_t block = 0;
   };
   SmallVector<PhysicalBasis> bases;
+  bool hasCTAAddressVariation = false;
   for (auto [dim, dimSize] : llvm::zip_equal(dims, shape)) {
     unsigned numBits = llvm::Log2_64(dimSize);
     if (numBits > static_cast<unsigned>(inverse.getInDimSizeLog2(dim))) {
@@ -192,24 +197,64 @@ FailureOr<triton::AddressSet> getMemDescAddresses(
       return failure();
     }
     for (unsigned bit = 0; bit < numBits; ++bit) {
-      if (inverse.hasOutDim(blockName) &&
-          inverse.getBasis(dim, bit, blockName) != 0) {
-        op->emitError("buffer footprint differs across CTA-local layout "
-                      "instances");
-        return failure();
-      }
-      bases.push_back(
-          {inverse.hasOutDim(offsetName)
-               ? static_cast<uint32_t>(inverse.getBasis(dim, bit, offsetName))
-               : 0,
-           inverse.hasOutDim(rowName)
-               ? static_cast<uint32_t>(inverse.getBasis(dim, bit, rowName))
-               : 0,
-           inverse.hasOutDim(colName)
-               ? static_cast<uint32_t>(inverse.getBasis(dim, bit, colName))
-               : 0});
+      auto basis = [&](StringAttr name) {
+        return inverse.hasOutDim(name)
+                   ? static_cast<uint32_t>(inverse.getBasis(dim, bit, name))
+                   : 0;
+      };
+      uint32_t block = basis(blockName);
+      hasCTAAddressVariation |= block != 0;
+      bases.push_back({basis(offsetName), basis(rowName), basis(colName),
+                       basis(partitionName), block});
     }
   }
+
+  if (cache && partitionBases.empty() && !hasCTAAddressVariation) {
+    auto key = std::make_pair(Type(ty), affineOffset);
+    auto found = cache->find(key);
+    if (found == cache->end()) {
+      FailureOr<MemDescFootprint> relative =
+          getMemDescAddresses(/*storageBase=*/0, affineOffset, ty, op);
+      if (failed(relative))
+        return failure();
+      found = cache->try_emplace(key, std::move(relative->addresses)).first;
+    }
+    MemDescFootprint footprint;
+    footprint.addresses = found->second.translated(storageBase);
+    if (!footprint.addresses.empty())
+      footprint.ctaAddresses.emplace_back(affineCTAOffset, footprint.addresses);
+    return footprint;
+  }
+
+  MemDescFootprint footprint;
+  auto addPhysicalAddress = [&](const PhysicalBasis &physical) {
+    uint32_t cta = physical.block ^ affineCTAOffset;
+    if (isTmem) {
+      uint64_t bitBegin = static_cast<uint64_t>(physical.col) * bitWidth;
+      uint32_t firstWord = bitBegin / 32;
+      uint32_t lastWord = llvm::divideCeil(bitBegin + bitWidth, uint64_t{32});
+      uint32_t relative = (physical.row << 16) | firstWord;
+      uint64_t begin =
+          static_cast<uint64_t>(storageBase) + affineOffset + relative;
+      for (uint32_t word = firstWord; word < lastWord; ++word) {
+        uint64_t address = begin + (word - firstWord);
+        assert(address <= std::numeric_limits<uint32_t>::max());
+        footprint.set(cta, address);
+      }
+    } else {
+      uint32_t base = storageBase;
+      if (!partitionBases.empty())
+        base = partitionBases[physical.partition ^ affinePartitionOffset];
+      uint32_t relative = physical.offset * (bitWidth / 8);
+      uint32_t combined = affineOffset ^ relative;
+      uint64_t begin =
+          static_cast<uint64_t>(base) + applySharedPadding(combined, ty);
+      for (uint32_t byte = 0; byte < bitWidth / 8; ++byte) {
+        assert(begin + byte <= std::numeric_limits<uint32_t>::max());
+        footprint.set(cta, begin + byte);
+      }
+    }
+  };
 
   PhysicalBasis physical;
   for (uint64_t index = 0; index < numPoints; ++index) {
@@ -218,35 +263,49 @@ FailureOr<triton::AddressSet> getMemDescAddresses(
       physical.offset ^= basis.offset;
       physical.row ^= basis.row;
       physical.col ^= basis.col;
+      physical.partition ^= basis.partition;
+      physical.block ^= basis.block;
     }
-    addPhysicalAddress(physical.offset, physical.row, physical.col);
+    addPhysicalAddress(physical);
   }
-  return addresses;
+  llvm::sort(footprint.ctaAddresses, llvm::less_first());
+  return footprint;
 }
 
 FailureOr<triton::BufferRegion> getMemDescRegion(
     uint32_t storageBase, uint32_t affineOffset, ttg::MemDescType ty,
     Operation *op,
-    llvm::DenseMap<std::pair<Type, uint32_t>, triton::AddressSet> *cache) {
-  FailureOr<triton::AddressSet> addresses =
-      getMemDescAddresses(storageBase, affineOffset, ty, op, cache);
-  if (failed(addresses))
+    llvm::DenseMap<std::pair<Type, uint32_t>, triton::AddressSet> *cache,
+    ArrayRef<uint32_t> partitionBases = {}, uint32_t affinePartitionOffset = 0,
+    uint32_t affineCTAOffset = 0) {
+  FailureOr<MemDescFootprint> footprint = getMemDescAddresses(
+      storageBase, affineOffset, ty, op, cache, partitionBases,
+      affinePartitionOffset, affineCTAOffset);
+  if (failed(footprint))
     return failure();
-  uint32_t baseOffset =
-      storageBase + (isa<ttng::TensorMemorySpaceAttr>(ty.getMemorySpace())
-                         ? affineOffset
-                         : applySharedPadding(affineOffset, ty));
-  return triton::BufferRegion(baseOffset, getMemDescSize(ty),
-                              std::move(*addresses), storageBase, affineOffset);
+  uint32_t runtimeStorageBase = partitionBases.empty()
+                                    ? storageBase
+                                    : partitionBases[affinePartitionOffset];
+  uint32_t baseOffset = runtimeStorageBase +
+                        (isa<ttng::TensorMemorySpaceAttr>(ty.getMemorySpace())
+                             ? affineOffset
+                             : applySharedPadding(affineOffset, ty));
+  return triton::BufferRegion(
+      baseOffset, getMemDescSize(ty), std::move(footprint->addresses),
+      storageBase, affineOffset, partitionBases, affinePartitionOffset,
+      footprint->ctaAddresses, affineCTAOffset);
 }
 
 uint32_t getMemDescStorageOffset(ttg::MemDescType ty, unsigned index) {
   if (isa<ttng::TensorMemorySpaceAttr>(ty.getMemorySpace()))
     return index * ttng::getTmemAllocSizes(ty).numCols;
-  uint64_t unpadded = static_cast<uint64_t>(index) *
-                      ttg::getAllocationElems(ty.getEncoding(), ty.getShape(),
-                                              ty.getAllocShape()) *
-                      (ty.getElementTypeBitWidth() / 8);
+  uint64_t elems = ttg::getAllocationElems(ty.getEncoding(), ty.getShape(),
+                                           ty.getAllocShape());
+  if (auto partitioned =
+          dyn_cast<ttg::PartitionedSharedEncodingAttr>(ty.getEncoding()))
+    elems /= partitioned.getNumPartitions();
+  uint64_t unpadded =
+      static_cast<uint64_t>(index) * elems * (ty.getElementTypeBitWidth() / 8);
   assert(unpadded <= std::numeric_limits<uint32_t>::max());
   return applySharedPadding(static_cast<uint32_t>(unpadded), ty);
 }
@@ -287,22 +346,25 @@ bool isUsedAsTensorMemory(Value v) {
          isa_and_nonnull<ttng::TensorMemorySpaceAttr>(type.getMemorySpace());
 }
 
-FailureOr<uint32_t>
-getMemDescSubsliceUnpaddedByteOffset(ttg::MemDescSubsliceOp op) {
+struct MemDescSubsliceOffsets {
+  uint32_t byteOffset = 0;
+  uint32_t partitionOffset = 0;
+  uint32_t ctaOffset = 0;
+};
+
+MemDescSubsliceOffsets
+getMemDescSubsliceUnpaddedOffsets(ttg::MemDescSubsliceOp op) {
   auto srcTy = op.getSrc().getType();
   auto offsets = op.getOffsets();
   if (offsets.empty())
-    return 0;
+    return MemDescSubsliceOffsets{};
 
   Attribute encoding = srcTy.getEncoding();
   auto layoutOffsets = ttg::dropPipeliningDim(offsets, encoding);
   auto layoutRank = layoutOffsets.size();
-  mlir::triton::LinearLayout layout;
-  if (auto padded = dyn_cast<ttg::PaddedSharedEncodingAttr>(encoding)) {
-    layout = padded.getLinearComponent();
-  } else {
-    layout = ttg::toLinearLayout(srcTy);
-  }
+  mlir::triton::LinearLayout layout = ttg::isPaddedEncoding(encoding)
+                                          ? ttg::paddedLinearLayout(srcTy)
+                                          : ttg::toLinearLayout(srcTy);
 
   MLIRContext *ctx = op->getContext();
   SmallVector<StringAttr> dimNames =
@@ -315,34 +377,39 @@ getMemDescSubsliceUnpaddedByteOffset(ttg::MemDescSubsliceOp op) {
 
   StringAttr offsetDim = StringAttr::get(ctx, "offset");
   StringAttr blockDim = StringAttr::get(ctx, "block");
+  StringAttr partitionDim = StringAttr::get(ctx, "partition");
   mlir::triton::LinearLayout inverse = layout.pseudoinvert();
   auto mapped = inverse.apply(logicalOffsets);
-  if (mapped.size() != 2 || mapped[0].first != offsetDim ||
-      mapped[1].first != blockDim) {
-    op.emitError("unsupported memdesc subslice layout in buffer region "
-                 "analysis");
-    return failure();
+  uint32_t elementOffset = 0;
+  uint32_t blockOffset = 0;
+  uint32_t partitionOffset = 0;
+  for (auto [dim, offset] : mapped) {
+    if (dim == offsetDim)
+      elementOffset = static_cast<uint32_t>(offset);
+    else if (dim == blockDim)
+      blockOffset = static_cast<uint32_t>(offset);
+    else if (dim == partitionDim)
+      partitionOffset = static_cast<uint32_t>(offset);
   }
-  if (mapped[1].second != 0) {
-    op.emitError("memdesc subslices with cross-CTA affine offsets are "
-                 "unsupported by buffer region analysis");
-    return failure();
-  }
-  uint64_t elementOffset = static_cast<uint32_t>(mapped[0].second);
+  uint64_t totalElementOffset = elementOffset;
   if (offsets.size() != layoutRank) {
     uint64_t stride = ttg::getAllocationElems(
         encoding, ttg::dropPipeliningDim(srcTy.getAllocShape(), encoding));
-    elementOffset += static_cast<uint64_t>(offsets.front()) * stride;
+    if (auto partitioned =
+            dyn_cast<ttg::PartitionedSharedEncodingAttr>(encoding))
+      stride /= partitioned.getNumPartitions();
+    totalElementOffset += static_cast<uint64_t>(offsets.front()) * stride;
   }
 
   uint64_t elementSizeBytes =
       srcTy.getElementType().getIntOrFloatBitWidth() / 8;
   assert(elementSizeBytes > 0 && "element size must be non-zero");
-  uint64_t byteOffset = elementOffset * elementSizeBytes;
+  uint64_t byteOffset = totalElementOffset * elementSizeBytes;
 
   assert(byteOffset <= std::numeric_limits<uint32_t>::max() &&
          "memdesc_subslice offset exceeds 32-bit range");
-  return static_cast<uint32_t>(byteOffset);
+  return MemDescSubsliceOffsets{static_cast<uint32_t>(byteOffset),
+                                partitionOffset, blockOffset};
 }
 
 std::optional<triton::BufferRegionAnalysis::RegionType> getRegionType(Value v) {
@@ -418,7 +485,8 @@ AddressSet AddressSet::translated(uint32_t delta) const {
   return result;
 }
 
-BufferStatePlan createBufferStatePlan(ArrayRef<BufferRegion> regions) {
+BufferStatePlan createBufferStatePlan(ArrayRef<BufferRegion> regions,
+                                      bool includeUnknown) {
   BufferStatePlan plan;
   plan.regionMasks.resize(regions.size());
 
@@ -436,7 +504,8 @@ BufferStatePlan createBufferStatePlan(ArrayRef<BufferRegion> regions) {
       for (unsigned candidate = 0; candidate < regions.size(); ++candidate) {
         if (assigned.test(candidate) || regions[candidate].addresses.empty())
           continue;
-        if (!regions[current].intersects(regions[candidate]))
+        if (!regions[current].addresses.intersects(
+                regions[candidate].addresses))
           continue;
         assigned.set(candidate);
         worklist.push_back(candidate);
@@ -494,6 +563,11 @@ BufferStatePlan createBufferStatePlan(ArrayRef<BufferRegion> regions) {
     componentPlans.push_back({component, std::move(atomMemberships)});
   }
 
+  if (includeUnknown) {
+    ++plan.numLanes;
+    plan.unknownMask = llvm::SmallBitVector(plan.numLanes, true);
+  }
+
   for (llvm::SmallBitVector &mask : plan.regionMasks)
     mask.resize(plan.numLanes);
 
@@ -512,7 +586,7 @@ BufferStatePlan createBufferStatePlan(ArrayRef<BufferRegion> regions) {
 
     laneBegin += componentPlan.atomMemberships.size();
   }
-  assert(laneBegin == plan.numLanes);
+  assert(laneBegin + includeUnknown == plan.numLanes);
   return plan;
 }
 
@@ -539,7 +613,12 @@ LogicalResult BufferRegionAnalysis::visitOperation(
     Operation *op,
     llvm::ArrayRef<const dataflow::Lattice<RegionInfo> *> operands,
     llvm::ArrayRef<dataflow::Lattice<RegionInfo> *> results) {
-  RegionInfo regionInfo;
+  RegionInfo regionInfo(RegionInfo::RegionList{});
+  auto propagateRegions = [&]() {
+    for (auto *result : results)
+      propagateIfChanged(result, result->join(regionInfo));
+    return success();
+  };
   if (auto wsOp = dyn_cast<ttg::WarpSpecializeOp>(op)) {
     for (Region *region : wsOp.getPartitionRegions()) {
       if (region->empty())
@@ -553,20 +632,21 @@ LogicalResult BufferRegionAnalysis::visitOperation(
     return success();
   }
   if (auto localAllocOp = dyn_cast<ttg::LocalAllocOp>(op)) {
-    FailureOr<uint32_t> offset = getAllocationOffset(localAllocOp);
-    if (failed(offset))
+    FailureOr<SmallVector<uint32_t, 2>> offsets =
+        getAllocationOffsets(localAllocOp);
+    if (failed(offsets))
       return failure();
-    FailureOr<BufferRegion> region =
-        getMemDescRegion(*offset, /*affineOffset=*/0, localAllocOp.getType(),
-                         op, &footprintCache);
+    ArrayRef<uint32_t> partitionBases = offsets->size() > 1
+                                            ? ArrayRef<uint32_t>(*offsets)
+                                            : ArrayRef<uint32_t>();
+    FailureOr<BufferRegion> region = getMemDescRegion(
+        offsets->front(), /*affineOffset=*/0, localAllocOp.getType(), op,
+        &footprintCache, partitionBases);
     if (failed(region))
       return failure();
     regionInfo.regions.insert(std::move(*region));
 
-    for (auto *r : results) {
-      propagateIfChanged(r, r->join(regionInfo));
-    }
-    return success();
+    return propagateRegions();
   }
   if (auto tmemAllocOp = dyn_cast<ttng::TMEMAllocOp>(op)) {
     uint32_t offset = getAllocationOffset(tmemAllocOp);
@@ -576,13 +656,14 @@ LogicalResult BufferRegionAnalysis::visitOperation(
       return failure();
     regionInfo.regions.insert(std::move(*region));
 
-    for (auto *r : results) {
-      propagateIfChanged(r, r->join(regionInfo));
-    }
-    return success();
+    return propagateRegions();
   }
   if (auto memdescIndexOp = dyn_cast<ttg::MemDescIndexOp>(op)) {
     RegionInfo in = operands[0]->getValue();
+    if (in.isUnknown()) {
+      regionInfo = in;
+      return propagateRegions();
+    }
     int numSubBuffers = getNumBuffers(memdescIndexOp);
     int firstSubBuffer = 0;
     int endSubBuffer = numSubBuffers;
@@ -590,172 +671,162 @@ LogicalResult BufferRegionAnalysis::visitOperation(
     if (matchPattern(memdescIndexOp.getIndex(),
                      m_ConstantInt(&constantIndex))) {
       int64_t index = constantIndex.getSExtValue();
-      if (index < 0 || index >= numSubBuffers) {
-        op->emitError("constant memdesc index is out of bounds");
-        return failure();
-      }
       firstSubBuffer = index;
       endSubBuffer = index + 1;
     }
     for (auto &region : in.regions) {
       for (int i = firstSubBuffer; i < endSubBuffer; ++i) {
-        uint32_t storageBase =
-            region.storageBase +
+        uint32_t stageOffset =
             getMemDescStorageOffset(memdescIndexOp.getType(), i);
-        FailureOr<BufferRegion> subBuffer =
-            getMemDescRegion(storageBase, region.affineOffset,
-                             memdescIndexOp.getType(), op, &footprintCache);
+        uint32_t storageBase = region.storageBase + stageOffset;
+        SmallVector<uint32_t, 2> partitionBases =
+            advancePartitionBases(region.partitionBases, stageOffset);
+        FailureOr<BufferRegion> subBuffer = getMemDescRegion(
+            storageBase, region.affineOffset, memdescIndexOp.getType(), op,
+            &footprintCache, partitionBases, region.affinePartitionOffset,
+            region.affineCTAOffset);
         if (failed(subBuffer))
           return failure();
         regionInfo.regions.insert(std::move(*subBuffer));
       }
     }
 
-    for (auto *r : results) {
-      propagateIfChanged(r, r->join(regionInfo));
-    }
-    return success();
+    return propagateRegions();
   }
   if (auto memdescSubsliceOp = dyn_cast<ttg::MemDescSubsliceOp>(op)) {
     RegionInfo in = operands[0]->getValue();
-    FailureOr<uint32_t> relativeOffset =
-        getMemDescSubsliceUnpaddedByteOffset(memdescSubsliceOp);
-    if (failed(relativeOffset))
-      return failure();
+    if (in.isUnknown()) {
+      regionInfo = in;
+      return propagateRegions();
+    }
+    MemDescSubsliceOffsets relativeOffset =
+        getMemDescSubsliceUnpaddedOffsets(memdescSubsliceOp);
     for (auto &region : in.regions) {
-      uint32_t affineOffset = region.affineOffset ^ *relativeOffset;
-      FailureOr<BufferRegion> subBuffer =
-          getMemDescRegion(region.storageBase, affineOffset,
-                           memdescSubsliceOp.getType(), op, &footprintCache);
+      uint32_t affineOffset = region.affineOffset ^ relativeOffset.byteOffset;
+      uint32_t affinePartitionOffset =
+          region.affinePartitionOffset ^ relativeOffset.partitionOffset;
+      uint32_t affineCTAOffset =
+          region.affineCTAOffset ^ relativeOffset.ctaOffset;
+      FailureOr<BufferRegion> subBuffer = getMemDescRegion(
+          region.storageBase, affineOffset, memdescSubsliceOp.getType(), op,
+          &footprintCache, region.partitionBases, affinePartitionOffset,
+          affineCTAOffset);
       if (failed(subBuffer))
         return failure();
       regionInfo.regions.insert(std::move(*subBuffer));
     }
-    for (auto *r : results) {
-      propagateIfChanged(r, r->join(regionInfo));
-    }
-    return success();
+    return propagateRegions();
   }
   if (auto tmemSubsliceOp = dyn_cast<ttng::TMEMSubSliceOp>(op)) {
     RegionInfo in = operands[0]->getValue();
+    if (in.isUnknown()) {
+      regionInfo = in;
+      return propagateRegions();
+    }
     uint32_t relativeOffset = ttng::getTMemSubSliceOffset(
         tmemSubsliceOp.getSrc().getType(), tmemSubsliceOp.getOffset(),
         tmemSubsliceOp.getDim());
     for (auto &region : in.regions) {
       uint32_t affineOffset = region.affineOffset + relativeOffset;
-      FailureOr<BufferRegion> subBuffer =
-          getMemDescRegion(region.storageBase, affineOffset,
-                           tmemSubsliceOp.getType(), op, &footprintCache);
+      FailureOr<BufferRegion> subBuffer = getMemDescRegion(
+          region.storageBase, affineOffset, tmemSubsliceOp.getType(), op,
+          &footprintCache, region.partitionBases, region.affinePartitionOffset,
+          region.affineCTAOffset);
       if (failed(subBuffer))
         return failure();
       regionInfo.regions.insert(std::move(*subBuffer));
     }
-    for (auto *r : results) {
-      propagateIfChanged(r, r->join(regionInfo));
-    }
-    return success();
+    return propagateRegions();
   }
   if (auto selectOp = dyn_cast<arith::SelectOp>(op)) {
     if (isa<ttg::MemDescType>(selectOp.getType())) {
       regionInfo =
           RegionInfo::join(operands[1]->getValue(), operands[2]->getValue());
-      for (auto *r : results) {
-        propagateIfChanged(r, r->join(regionInfo));
-      }
-      return success();
+      return propagateRegions();
     }
   }
   if (auto reinterpretOp = dyn_cast<ttg::MemDescReinterpretOp>(op)) {
     RegionInfo in = operands[0]->getValue();
+    if (in.isUnknown()) {
+      regionInfo = in;
+      return propagateRegions();
+    }
     for (auto &region : in.regions) {
-      FailureOr<BufferRegion> reinterpreted =
-          getMemDescRegion(region.storageBase, region.affineOffset,
-                           reinterpretOp.getType(), op, &footprintCache);
+      FailureOr<BufferRegion> reinterpreted = getMemDescRegion(
+          region.storageBase, region.affineOffset, reinterpretOp.getType(), op,
+          &footprintCache, region.partitionBases, region.affinePartitionOffset,
+          region.affineCTAOffset);
       if (failed(reinterpreted))
         return failure();
       regionInfo.regions.insert(std::move(*reinterpreted));
     }
-    for (auto *r : results) {
-      propagateIfChanged(r, r->join(regionInfo));
-    }
-    return success();
+    return propagateRegions();
   }
-  // "Passthrough" ops that don't modify the buffer regions.
   if (isa<ttg::MemDescTransOp, ttg::MemDescReshapeOp>(op)) {
-    // Just propagate the regions from the operand.
-    RegionInfo in = operands[0]->getValue();
-    for (auto &region : in.regions) {
-      regionInfo.regions.insert(region);
-    }
-    for (auto *r : results) {
-      propagateIfChanged(r, r->join(regionInfo));
-    }
+    regionInfo = operands[0]->getValue();
+    return propagateRegions();
+  }
+  if (isa<ttng::WarpGroupDotWaitOp>(op)) {
+    for (auto [operand, result] : llvm::zip_equal(operands, results))
+      propagateIfChanged(result, result->join(operand->getValue()));
     return success();
   }
-  verifyOpIsSupported(op);
+  for (auto [result, lattice] : llvm::zip_equal(op->getResults(), results)) {
+    if (isa<ttg::MemDescType>(result.getType()))
+      propagateIfChanged(
+          lattice, lattice->join(RegionInfo::getPessimisticValueState(result)));
+  }
   return success();
 }
 
 void BufferRegionAnalysis::calculateUsedBufferRegions(Operation *op) {
   op->walk([&](Operation *op) {
-    auto insertRegionForValue = [&](Value v) {
-      RegionInfo regionInfo = getLatticeElement(v)->getValue();
-      std::optional<RegionType> regionType = getRegionType(v);
-      if (!regionType) {
-        return;
-      }
-      for (auto &region : regionInfo.regions) {
-        usedBufferRegions[*regionType].insert(region);
-      }
-    };
-    if (BufferRegionAnalysis::isMemoryAccessOperation(op)) {
-      // Allocas define their buffers with return value.
-      if (isa<ttg::LocalAllocOp, ttng::TMEMAllocOp>(op)) {
-        insertRegionForValue(op->getResult(0));
-      }
-      // All other operations access their operands.
-      for (auto operand : op->getOperands()) {
-        insertRegionForValue(operand);
-      }
+    for (const MemoryAccess &access : getMemoryAccesses(op)) {
+      std::optional<RegionType> regionType = getRegionType(access.value);
+      if (!regionType)
+        continue;
+      const RegionInfo &regionInfo =
+          getLatticeElement(access.value)->getValue();
+      if (regionInfo.isUnknown())
+        usedUnknownBufferRegions[*regionType] = true;
+      usedBufferRegions[*regionType].insert(regionInfo.regions.begin(),
+                                            regionInfo.regions.end());
     }
   });
 }
 
-bool BufferRegionAnalysis::isMemoryAccessOperation(Operation *op) {
-  if (isa<ttg::LocalLoadOp, ttg::LocalStoreOp, ttg::LocalGatherOp,
-          ttg::LocalScatterOp, ttg::LocalAtomicScatterRMWOp, ttng::TMEMLoadOp,
-          ttng::TMEMStoreOp, ttng::TMEMCopyOp, ttg::AsyncCopyGlobalToLocalOp,
-          ttng::TMAOpInterface, ttng::CLCLoadResultOp>(op)) {
-    return true;
+SmallVector<BufferRegionAnalysis::MemoryAccess>
+BufferRegionAnalysis::getMemoryAccesses(Operation *op) {
+  SmallVector<MemoryAccess> accesses;
+  auto memoryEffects = dyn_cast<MemoryEffectOpInterface>(op);
+  if (!memoryEffects)
+    return accesses;
+
+  SmallVector<MemoryEffects::EffectInstance> effects;
+  memoryEffects.getEffects(effects);
+  for (const MemoryEffects::EffectInstance &effect : effects) {
+    bool isWrite = isa<MemoryEffects::Write>(effect.getEffect());
+    if (!isWrite && !isa<MemoryEffects::Read>(effect.getEffect()))
+      continue;
+    if (effect.getResource() != ttg::SharedMemory::get() &&
+        effect.getResource() != ttng::TensorMemory::get())
+      continue;
+    Value value = effect.getValue();
+    if (!value || !isa<ttg::MemDescType>(value.getType()))
+      continue;
+    auto existing = llvm::find_if(accesses, [&](const MemoryAccess &access) {
+      return access.value == value;
+    });
+    if (existing == accesses.end())
+      accesses.push_back({value, isWrite});
+    else
+      existing->isWrite |= isWrite;
   }
-  if (isa<ttg::MBarrierOpInterface>(op)) {
-    return true;
-  }
-  // Allocations with operands write to the memory.
-  if (isa<ttg::LocalAllocOp, ttng::TMEMAllocOp>(op) &&
-      op->getNumOperands() > 0) {
-    return true;
-  }
-  if (isa<DotOpInterface>(op)) {
-    return true;
-  }
-  return false;
+  return accesses;
 }
 
-void BufferRegionAnalysis::verifyOpIsSupported(Operation *op) {
-  bool hasMemoryOperands = llvm::any_of(op->getOperands(), [](Value v) {
-    return isUsedAsSharedMemory(v) || isUsedAsTensorMemory(v);
-  });
-  if (!hasMemoryOperands) {
-    return;
-  }
-  if (isMemoryAccessOperation(op)) {
-    return;
-  }
-  op->emitError(
-      "Operation accessing memory unaccounted for in buffer region analysis");
-  llvm::report_fatal_error(
-      "Operation accessing memory unaccounted for in buffer region analysis");
+bool BufferRegionAnalysis::isMemoryAccessOperation(Operation *op) {
+  return !getMemoryAccesses(op).empty();
 }
 
 } // namespace mlir::triton

--- a/lib/Analysis/BufferRegion.cpp
+++ b/lib/Analysis/BufferRegion.cpp
@@ -84,30 +84,16 @@ uint32_t applySharedPadding(uint32_t byteOffset, ttg::MemDescType ty) {
 
 uint32_t getMemDescStorageOffset(ttg::MemDescType ty, unsigned index);
 
-struct MemDescFootprint {
-  triton::AddressSet addresses;
-  SmallVector<triton::BufferRegion::CTAAddresses, 2> ctaAddresses;
+using MemDescFootprint = SmallVector<triton::BufferRegion::CTAAddresses, 2>;
 
-  triton::AddressSet &forCTA(uint32_t cta) {
-    auto it = llvm::lower_bound(
-        ctaAddresses, cta,
-        [](const auto &entry, uint32_t cta) { return entry.first < cta; });
-    if (it == ctaAddresses.end() || it->first != cta)
-      it = ctaAddresses.insert(it, triton::BufferRegion::CTAAddresses{cta, {}});
-    return it->second;
-  }
-
-  void set(uint32_t cta, uint32_t address) {
-    addresses.set(address);
-    forCTA(cta).set(address);
-  }
-
-  void insert(const MemDescFootprint &other) {
-    addresses.insert(other.addresses);
-    for (const auto &[cta, otherAddresses] : other.ctaAddresses)
-      forCTA(cta).insert(otherAddresses);
-  }
-};
+triton::AddressSet &getAddressesForCTA(MemDescFootprint &footprint,
+                                       uint32_t cta) {
+  auto it = llvm::partition_point(
+      footprint, [cta](const auto &entry) { return entry.first < cta; });
+  if (it == footprint.end() || it->first != cta)
+    it = footprint.insert(it, triton::BufferRegion::CTAAddresses{cta, {}});
+  return it->second;
+}
 
 MemDescFootprint getMemDescAddresses(
     uint32_t storageBase, uint32_t affineOffset, ttg::MemDescType ty,
@@ -122,10 +108,12 @@ MemDescFootprint getMemDescAddresses(
     MemDescFootprint footprint;
     for (int64_t page = 0; page < ty.getDimSize(0); ++page) {
       uint32_t pageOffset = getMemDescStorageOffset(pageTy, page);
-      footprint.insert(getMemDescAddresses(
+      MemDescFootprint pageFootprint = getMemDescAddresses(
           storageBase + pageOffset, affineOffset, pageTy, /*cache=*/nullptr,
           advancePartitionBases(partitionBases, pageOffset),
-          affinePartitionOffset, affineCTAOffset));
+          affinePartitionOffset, affineCTAOffset);
+      for (const auto &[cta, addresses] : pageFootprint)
+        getAddressesForCTA(footprint, cta).insert(addresses);
     }
     return footprint;
   };
@@ -154,6 +142,7 @@ MemDescFootprint getMemDescAddresses(
   auto addPhysicalAddress = [&](uint32_t offset, uint32_t row, uint32_t col,
                                 uint32_t partition, uint32_t block) {
     uint32_t cta = block ^ affineCTAOffset;
+    auto &addresses = getAddressesForCTA(footprint, cta);
     if (isTmem) {
       uint64_t bitBegin = static_cast<uint64_t>(col) * bitWidth;
       uint32_t firstWord = bitBegin / 32;
@@ -164,7 +153,7 @@ MemDescFootprint getMemDescAddresses(
       for (uint32_t word = firstWord; word < lastWord; ++word) {
         uint64_t address = begin + (word - firstWord);
         assert(address <= std::numeric_limits<uint32_t>::max());
-        footprint.set(cta, address);
+        addresses.set(address);
       }
     } else {
       uint32_t base = storageBase;
@@ -176,7 +165,7 @@ MemDescFootprint getMemDescAddresses(
           static_cast<uint64_t>(base) + applySharedPadding(combined, ty);
       for (uint32_t byte = 0; byte < bitWidth / 8; ++byte) {
         assert(begin + byte <= std::numeric_limits<uint32_t>::max());
-        footprint.set(cta, begin + byte);
+        addresses.set(begin + byte);
       }
     }
   };
@@ -210,10 +199,9 @@ MemDescFootprint getMemDescAddresses(
         cache->try_emplace(std::make_pair(Type(ty), affineOffset));
     if (inserted)
       found->second =
-          getMemDescAddresses(/*storageBase=*/0, affineOffset, ty).addresses;
-    footprint.addresses = found->second.translated(storageBase);
-    if (!footprint.addresses.empty())
-      footprint.ctaAddresses.emplace_back(affineCTAOffset, footprint.addresses);
+          std::move(getMemDescAddresses(0, affineOffset, ty).front().second);
+    footprint.emplace_back(affineCTAOffset,
+                           found->second.translated(storageBase));
     return footprint;
   }
 
@@ -233,7 +221,7 @@ MemDescFootprint getMemDescAddresses(
   return footprint;
 }
 
-triton::BufferRegion getMemDescRegion(
+triton::BufferRegionView getMemDescView(
     uint32_t storageBase, uint32_t affineOffset, ttg::MemDescType ty,
     llvm::DenseMap<std::pair<Type, uint32_t>, triton::AddressSet> *cache,
     ArrayRef<uint32_t> partitionBases = {}, uint32_t affinePartitionOffset = 0,
@@ -248,10 +236,12 @@ triton::BufferRegion getMemDescRegion(
                         (isa<ttng::TensorMemorySpaceAttr>(ty.getMemorySpace())
                              ? affineOffset
                              : applySharedPadding(affineOffset, ty));
-  return triton::BufferRegion(
-      baseOffset, getMemDescSize(ty), std::move(footprint.addresses),
-      storageBase, affineOffset, partitionBases, affinePartitionOffset,
-      footprint.ctaAddresses, affineCTAOffset);
+  return {{baseOffset, getMemDescSize(ty), std::move(footprint)},
+          storageBase,
+          affineOffset,
+          llvm::to_vector<2>(partitionBases),
+          affinePartitionOffset,
+          affineCTAOffset};
 }
 
 uint32_t getMemDescStorageOffset(ttg::MemDescType ty, unsigned index) {
@@ -447,10 +437,15 @@ BufferStatePlan createBufferStatePlan(ArrayRef<BufferRegion> regions,
   BufferStatePlan plan;
   plan.regionMasks.resize(regions.size());
 
+  SmallVector<AddressSet> projectedAddresses(regions.size());
+  for (auto [region, projected] : llvm::zip(regions, projectedAddresses))
+    for (const auto &[cta, addresses] : region.ctaAddresses)
+      projected.insert(addresses);
+
   llvm::SmallBitVector assigned(regions.size());
   SmallVector<SmallVector<unsigned>> components;
   for (unsigned first = 0; first < regions.size(); ++first) {
-    if (assigned.test(first) || regions[first].addresses.empty())
+    if (assigned.test(first) || projectedAddresses[first].empty())
       continue;
     SmallVector<unsigned> component;
     SmallVector<unsigned> worklist = {first};
@@ -459,10 +454,8 @@ BufferStatePlan createBufferStatePlan(ArrayRef<BufferRegion> regions,
       unsigned current = worklist.pop_back_val();
       component.push_back(current);
       for (unsigned candidate = 0; candidate < regions.size(); ++candidate) {
-        if (assigned.test(candidate) || regions[candidate].addresses.empty())
-          continue;
-        if (!regions[current].addresses.intersects(
-                regions[candidate].addresses))
+        if (assigned.test(candidate) || !projectedAddresses[current].intersects(
+                                            projectedAddresses[candidate]))
           continue;
         assigned.set(candidate);
         worklist.push_back(candidate);
@@ -481,7 +474,7 @@ BufferStatePlan createBufferStatePlan(ArrayRef<BufferRegion> regions,
   for (const SmallVector<unsigned> &component : components) {
     SmallVector<Atom> atoms;
     for (auto [localId, regionId] : llvm::enumerate(component)) {
-      AddressSet uncovered = regions[regionId].addresses;
+      AddressSet uncovered = projectedAddresses[regionId];
       for (size_t atomId = 0, atomCount = atoms.size();
            atomId < atomCount && !uncovered.empty(); ++atomId) {
         auto &[addresses, atomMembership] = atoms[atomId];
@@ -568,7 +561,7 @@ LogicalResult BufferRegionAnalysis::visitOperation(
     Operation *op,
     llvm::ArrayRef<const dataflow::Lattice<RegionInfo> *> operands,
     llvm::ArrayRef<dataflow::Lattice<RegionInfo> *> results) {
-  RegionInfo regionInfo(RegionInfo::RegionList{});
+  RegionInfo regionInfo(RegionInfo::ViewList{});
   auto propagateRegions = [&](const RegionInfo &info) {
     for (auto *result : results)
       propagateIfChanged(result, result->join(info));
@@ -594,15 +587,15 @@ LogicalResult BufferRegionAnalysis::visitOperation(
     ArrayRef<uint32_t> partitionBases = offsets->size() > 1
                                             ? ArrayRef<uint32_t>(*offsets)
                                             : ArrayRef<uint32_t>();
-    regionInfo.regions.insert(getMemDescRegion(
-        offsets->front(), /*affineOffset=*/0, localAllocOp.getType(),
-        &footprintCache, partitionBases));
+    regionInfo.views.insert(getMemDescView(offsets->front(), /*affineOffset=*/0,
+                                           localAllocOp.getType(),
+                                           &footprintCache, partitionBases));
     return propagateRegions(regionInfo);
   }
   if (auto tmemAllocOp = dyn_cast<ttng::TMEMAllocOp>(op)) {
-    regionInfo.regions.insert(
-        getMemDescRegion(getAllocationOffset(tmemAllocOp), /*affineOffset=*/0,
-                         tmemAllocOp.getType(), &footprintCache));
+    regionInfo.views.insert(
+        getMemDescView(getAllocationOffset(tmemAllocOp), /*affineOffset=*/0,
+                       tmemAllocOp.getType(), &footprintCache));
     return propagateRegions(regionInfo);
   }
   if (auto memdescIndexOp = dyn_cast<ttg::MemDescIndexOp>(op)) {
@@ -619,15 +612,15 @@ LogicalResult BufferRegionAnalysis::visitOperation(
       firstSubBuffer = index;
       endSubBuffer = index + 1;
     }
-    for (auto &region : in.regions) {
+    for (const BufferRegionView &view : in.views) {
       for (int i = firstSubBuffer; i < endSubBuffer; ++i) {
         uint32_t stageOffset =
             getMemDescStorageOffset(memdescIndexOp.getType(), i);
-        regionInfo.regions.insert(getMemDescRegion(
-            region.storageBase + stageOffset, region.affineOffset,
+        regionInfo.views.insert(getMemDescView(
+            view.storageBase + stageOffset, view.affineOffset,
             memdescIndexOp.getType(), &footprintCache,
-            advancePartitionBases(region.partitionBases, stageOffset),
-            region.affinePartitionOffset, region.affineCTAOffset));
+            advancePartitionBases(view.partitionBases, stageOffset),
+            view.affinePartitionOffset, view.affineCTAOffset));
       }
     }
 
@@ -639,12 +632,12 @@ LogicalResult BufferRegionAnalysis::visitOperation(
       return propagateRegions(in);
     MemDescSubsliceOffsets relativeOffset =
         getMemDescSubsliceUnpaddedOffsets(memdescSubsliceOp);
-    for (auto &region : in.regions)
-      regionInfo.regions.insert(getMemDescRegion(
-          region.storageBase, region.affineOffset ^ relativeOffset.byteOffset,
-          memdescSubsliceOp.getType(), &footprintCache, region.partitionBases,
-          region.affinePartitionOffset ^ relativeOffset.partitionOffset,
-          region.affineCTAOffset ^ relativeOffset.ctaOffset));
+    for (const BufferRegionView &view : in.views)
+      regionInfo.views.insert(getMemDescView(
+          view.storageBase, view.affineOffset ^ relativeOffset.byteOffset,
+          memdescSubsliceOp.getType(), &footprintCache, view.partitionBases,
+          view.affinePartitionOffset ^ relativeOffset.partitionOffset,
+          view.affineCTAOffset ^ relativeOffset.ctaOffset));
     return propagateRegions(regionInfo);
   }
   if (auto tmemSubsliceOp = dyn_cast<ttng::TMEMSubSliceOp>(op)) {
@@ -654,11 +647,11 @@ LogicalResult BufferRegionAnalysis::visitOperation(
     uint32_t relativeOffset = ttng::getTMemSubSliceOffset(
         tmemSubsliceOp.getSrc().getType(), tmemSubsliceOp.getOffset(),
         tmemSubsliceOp.getDim());
-    for (auto &region : in.regions)
-      regionInfo.regions.insert(getMemDescRegion(
-          region.storageBase, region.affineOffset + relativeOffset,
-          tmemSubsliceOp.getType(), &footprintCache, region.partitionBases,
-          region.affinePartitionOffset, region.affineCTAOffset));
+    for (const BufferRegionView &view : in.views)
+      regionInfo.views.insert(getMemDescView(
+          view.storageBase, view.affineOffset + relativeOffset,
+          tmemSubsliceOp.getType(), &footprintCache, view.partitionBases,
+          view.affinePartitionOffset, view.affineCTAOffset));
     return propagateRegions(regionInfo);
   }
   if (auto selectOp = dyn_cast<arith::SelectOp>(op)) {
@@ -672,11 +665,11 @@ LogicalResult BufferRegionAnalysis::visitOperation(
     const RegionInfo &in = operands[0]->getValue();
     if (in.isUnknown())
       return propagateRegions(in);
-    for (auto &region : in.regions)
-      regionInfo.regions.insert(getMemDescRegion(
-          region.storageBase, region.affineOffset, reinterpretOp.getType(),
-          &footprintCache, region.partitionBases, region.affinePartitionOffset,
-          region.affineCTAOffset));
+    for (const BufferRegionView &view : in.views)
+      regionInfo.views.insert(getMemDescView(
+          view.storageBase, view.affineOffset, reinterpretOp.getType(),
+          &footprintCache, view.partitionBases, view.affinePartitionOffset,
+          view.affineCTAOffset));
     return propagateRegions(regionInfo);
   }
   if (isa<ttg::MemDescTransOp, ttg::MemDescReshapeOp>(op))
@@ -704,8 +697,8 @@ void BufferRegionAnalysis::calculateUsedBufferRegions(Operation *op) {
           getLatticeElement(access.value)->getValue();
       if (regionInfo.isUnknown())
         usedUnknownBufferRegions[*regionType] = true;
-      usedBufferRegions[*regionType].insert(regionInfo.regions.begin(),
-                                            regionInfo.regions.end());
+      for (const BufferRegionView &view : regionInfo.views)
+        usedBufferRegions[*regionType].insert(view.region);
     }
   });
 }
@@ -738,10 +731,6 @@ BufferRegionAnalysis::getMemoryAccesses(Operation *op) {
       existing->isWrite |= isWrite;
   }
   return accesses;
-}
-
-bool BufferRegionAnalysis::isMemoryAccessOperation(Operation *op) {
-  return !getMemoryAccesses(op).empty();
 }
 
 } // namespace mlir::triton

--- a/lib/Dialect/TritonInstrument/IR/Utility.cpp
+++ b/lib/Dialect/TritonInstrument/IR/Utility.cpp
@@ -27,6 +27,7 @@ namespace {
 
 DistributedEncodingTrait getWarpLocalEncoding(MLIRContext *ctx,
                                               ArrayRef<int64_t> shape,
+                                              unsigned threadsPerWarp,
                                               unsigned warps, unsigned numCTAs,
                                               unsigned bitwidth) {
   assert(!shape.empty() && "Expected non-empty shape");
@@ -41,13 +42,13 @@ DistributedEncodingTrait getWarpLocalEncoding(MLIRContext *ctx,
   // We pick a layout that vectorises global loads and stores.
   auto dim = StringAttr::get(ctx, "dim0");
   int numel = product(shape);
-  auto nlanes = std::min(numel, 32);
+  auto nlanes = std::min(numel, static_cast<int>(threadsPerWarp));
   auto nregs = numel / nlanes;
   auto vec = std::min<int>(kMaxVectorLengthBits / bitwidth, nregs);
   nregs /= vec;
   auto ll = LinearLayout::identity1D(vec, kRegister, dim) *
             LinearLayout::identity1D(nlanes, kLane, dim) *
-            LinearLayout::zeros1D(32 / nlanes, kLane, dim) *
+            LinearLayout::zeros1D(threadsPerWarp / nlanes, kLane, dim) *
             LinearLayout::zeros1D(warps, kWarp, dim) *
             LinearLayout::zeros1D(numCTAs, kBlock, dim) *
             LinearLayout::identity1D(nregs, kRegister, dim);
@@ -214,10 +215,12 @@ void createAssertInThread(ImplicitLocOpBuilder &b, Value condition,
 RankedTensorType getIntTensorType(Region *region, ArrayRef<int64_t> shape,
                                   unsigned bitWidth) {
   MLIRContext *ctx = region->getContext();
+  unsigned int threadsPerWarp = TritonGPUDialect::getThreadsPerWarp(
+      region->getParentOp()->getParentOfType<ModuleOp>());
   unsigned int warps = lookupNumWarps(region);
   unsigned int numCTAs = lookupNumCTAs(region->getParentOp());
-  DistributedEncodingTrait encoding =
-      getWarpLocalEncoding(ctx, shape, warps, numCTAs, bitWidth);
+  DistributedEncodingTrait encoding = getWarpLocalEncoding(
+      ctx, shape, threadsPerWarp, warps, numCTAs, bitWidth);
   Type elType = IntegerType::get(ctx, bitWidth);
   return RankedTensorType::get(shape, elType, encoding);
 }
@@ -701,10 +704,8 @@ AuxDataMap::getBuffersAndBarriers(ModuleOp module,
     });
   } else {
     module.walk([&](Operation *op) {
-      if (!BufferRegionAnalysis::isMemoryAccessOperation(op))
-        return;
-      llvm::for_each(op->getOperands(), collectCandidates);
-      llvm::for_each(op->getResults(), collectCandidates);
+      for (const auto &access : BufferRegionAnalysis::getMemoryAccesses(op))
+        collectCandidates(access.value);
     });
   }
 
@@ -719,14 +720,19 @@ AuxDataMap::getBuffersAndBarriers(ModuleOp module,
   for (MemType memType : {MemType::SHARED_MEM, MemType::TENSOR_MEM}) {
     int iMemType = (int)memType;
     ArrayRef<BufferRegion> regions = bufferRegions[iMemType];
-    if (regions.empty()) {
+    auto regionType = memType == MemType::SHARED_MEM
+                          ? BufferRegionAnalysis::SHARED_MEMORY
+                          : BufferRegionAnalysis::TENSOR_MEMORY;
+    bool hasUnknown = analysis->hasUnknownUsedBufferRegions(regionType);
+    if (regions.empty() && !hasUnknown)
       continue;
-    }
 
-    bufferStatePlans[iMemType] = triton::createBufferStatePlan(regions);
+    bufferStatePlans[iMemType] =
+        triton::createBufferStatePlan(regions, hasUnknown);
 
     for (const auto &[value, regionInfo] : candidates[iMemType]) {
-      SmallVector<uint32_t> ids;
+      BufferStateCandidates stateCandidates;
+      stateCandidates.unknown = regionInfo.isUnknown();
       for (const BufferRegion &candidate : regionInfo.regions) {
         auto it = llvm::lower_bound(regions, candidate);
         if (it == regions.end() || !(*it == candidate)) {
@@ -737,24 +743,23 @@ AuxDataMap::getBuffersAndBarriers(ModuleOp module,
           candidate.print(diag);
           return failure();
         }
-        ids.push_back(std::distance(regions.begin(), it));
-      }
-      const BufferStatePlan &plan = bufferStatePlans[iMemType];
-      llvm::SmallDenseMap<uint32_t, uint32_t> firstByBase;
-      SmallVector<uint32_t> distinguishableIds;
-      for (uint32_t id : ids) {
-        auto [it, inserted] =
-            firstByBase.try_emplace(regions[id].baseOffset, id);
-        if (!inserted && plan.regionMasks[it->second] != plan.regionMasks[id]) {
-          emitError(value.getLoc(),
-                    "ambiguous buffer-state cases share a runtime base");
-          return failure();
+        uint32_t id = std::distance(regions.begin(), it);
+        uint32_t ctaMask = 1u << candidate.affineCTAOffset;
+
+        auto existing = llvm::find_if(
+            stateCandidates.cases, [&](const BufferStateCandidate &state) {
+              return state.baseOffset == candidate.baseOffset;
+            });
+        if (existing == stateCandidates.cases.end()) {
+          stateCandidates.cases.push_back(
+              {candidate.baseOffset, bufferStatePlans[iMemType].regionMasks[id],
+               ctaMask});
+        } else {
+          existing->mask |= bufferStatePlans[iMemType].regionMasks[id];
+          existing->ctaMask |= ctaMask;
         }
-        if (inserted)
-          distinguishableIds.push_back(id);
       }
-      bufferCandidateIds[iMemType].try_emplace(value,
-                                               std::move(distinguishableIds));
+      bufferCandidates[iMemType].try_emplace(value, std::move(stateCandidates));
     }
   }
   return success();

--- a/lib/Dialect/TritonInstrument/IR/Utility.cpp
+++ b/lib/Dialect/TritonInstrument/IR/Utility.cpp
@@ -391,7 +391,7 @@ FuncOp getEntryPoint(ModuleOp module) {
 }
 
 AuxDataMap::ThreadLayout getThreadLayout(ModuleOp module,
-                                         const ConSanTargetHooks *hooks) {
+                                         const ConSanTargetHooks &hooks) {
   AuxDataMap::ThreadLayout layout;
   bool hasTMA = false;
   bool hasTC = false;
@@ -404,9 +404,9 @@ AuxDataMap::ThreadLayout getThreadLayout(ModuleOp module,
     if (auto wsOp = dyn_cast<WarpSpecializePartitionsOp>(op))
       layout.numBaseThreads = std::max<int>(
           layout.numBaseThreads, wsOp.getPartitionRegions().size() + 1);
-    hasTMA |= hooks->isTMAOp(op);
+    hasTMA |= hooks.isTMAOp(op);
     hasTC |= isa<MMAv5OpInterface, TCGen5CommitOp, TMEMCopyOp>(op);
-    hasCLC |= hooks->isCLCOp(op);
+    hasCLC |= hooks.isCLCOp(op);
   });
 
   assert(layout.numBaseThreads <= MAX_NUM_BASE_THREADS &&
@@ -471,14 +471,14 @@ Region *AuxDataMap::RegionToValueMap::getEnclosingParitionOrFunctionRegion(
 }
 
 LogicalResult AuxDataMap::populateAndPassToWarpSpecialize(
-    ModuleOp module, FunctionBuilder &fb, const ConSanTargetHooks *hooks) {
+    ModuleOp module, FunctionBuilder &fb, const ConSanTargetHooks &hooks) {
   SmallVector<BufferRegion> barrierRegions;
   if (failed(getBuffersAndBarriers(module, barrierRegions, hooks)))
     return failure();
   int numCTAs = lookupNumCTAs(module);
   threadLayout = getThreadLayout(module, hooks);
   hasAsyncProxyFenceTracking =
-      hooks && hooks->needsAsyncProxyFenceTracking(module) &&
+      hooks.needsAsyncProxyFenceTracking(module) &&
       bufferStatePlans[(int)MemType::SHARED_MEM].numLanes != 0;
   int captureCounter = 0;
   int64_t captureBytes = 0;
@@ -637,12 +637,9 @@ LogicalResult AuxDataMap::populateAndPassToWarpSpecialize(
     createCommitTensor(CommitKind::AsyncCp);
   }
 
-  if (hooks) {
-    for (auto kind : hooks->getRequiredCommitKinds(module)) {
-      if (commits[kind].empty())
-        createCommitTensor(kind);
-    }
-  }
+  for (auto kind : hooks.getRequiredCommitKinds(module))
+    if (commits[kind].empty())
+      createCommitTensor(kind);
 
   // Verify the actual capture count matches the expected one.
   if (captureCounter > 0) {
@@ -668,7 +665,7 @@ LogicalResult AuxDataMap::populateAndPassToWarpSpecialize(
 LogicalResult
 AuxDataMap::getBuffersAndBarriers(ModuleOp module,
                                   SmallVector<BufferRegion> &barrierRegions,
-                                  const ConSanTargetHooks *hooks) {
+                                  const ConSanTargetHooks &hooks) {
   // Collect shared memory buffers allocated in the module
   std::unique_ptr<DataFlowSolver> solver = createDataFlowSolver();
   triton::BufferRegionAnalysis *analysis =
@@ -694,20 +691,19 @@ AuxDataMap::getBuffersAndBarriers(ModuleOp module,
     candidates[static_cast<int>(*memType)].push_back(
         {value, analysis->getLatticeElement(value)->getValue()});
   };
-  if (hooks) {
-    module.walk([&](Operation *op) {
-      auto info = hooks->getMemEffectsOpInfo(op);
-      if (!info)
-        return;
-      for (const auto &effect : info->operandEffects)
-        collectCandidates(effect.buf);
-    });
-  } else {
-    module.walk([&](Operation *op) {
-      for (const auto &access : BufferRegionAnalysis::getMemoryAccesses(op))
-        collectCandidates(access.value);
-    });
-  }
+  module.walk([&](Operation *op) {
+    auto info = hooks.getMemEffectsOpInfo(op);
+    if (!info)
+      return;
+    if (info->trackingKind == MemEffectsOpInfo::TrackingKind::CommitCount &&
+        info->commitKind == CommitKind::AsyncCp)
+      hasAsyncCopyReads |= llvm::any_of(
+          info->operandEffects, [](const MemEffectsOpInfo::Effects &e) {
+            return e.rw == MemEffectsOpInfo::Effects::Read;
+          });
+    for (const auto &effect : info->operandEffects)
+      collectCandidates(effect.buf);
+  });
 
   analysis->calculateUsedBufferRegions(module);
   bufferRegions[(int)MemType::SHARED_MEM] = analysis->getAllUsedBufferRegions(
@@ -733,7 +729,8 @@ AuxDataMap::getBuffersAndBarriers(ModuleOp module,
     for (const auto &[value, regionInfo] : candidates[iMemType]) {
       BufferStateCandidates stateCandidates;
       stateCandidates.unknown = regionInfo.isUnknown();
-      for (const BufferRegion &candidate : regionInfo.regions) {
+      for (const BufferRegionView &view : regionInfo.views) {
+        const BufferRegion &candidate = view.region;
         auto it = llvm::lower_bound(regions, candidate);
         if (it == regions.end() || !(*it == candidate)) {
           InFlightDiagnostic diag = emitError(
@@ -744,7 +741,7 @@ AuxDataMap::getBuffersAndBarriers(ModuleOp module,
           return failure();
         }
         uint32_t id = std::distance(regions.begin(), it);
-        uint32_t ctaMask = 1u << candidate.affineCTAOffset;
+        uint32_t ctaMask = 1u << view.affineCTAOffset;
 
         auto existing = llvm::find_if(
             stateCandidates.cases, [&](const BufferStateCandidate &state) {

--- a/lib/Dialect/TritonInstrument/IR/Utility.cpp
+++ b/lib/Dialect/TritonInstrument/IR/Utility.cpp
@@ -495,8 +495,7 @@ LogicalResult AuxDataMap::populateAndPassToWarpSpecialize(
   });
   int numTrackedBarriers = numMBarriers + clusterBarrierSlots.size();
   if (numTrackedBarriers > 0)
-    barrierRegions.resize(llvm::NextPowerOf2(numTrackedBarriers - 1),
-                          BufferRegion{0, 0});
+    barrierRegions.resize(llvm::NextPowerOf2(numTrackedBarriers - 1));
 
   ImplicitLocOpBuilder b(entryPoint.getLoc(), entryPoint);
   b.setInsertionPointToStart(&entryPoint.getBody().front());
@@ -706,19 +705,16 @@ AuxDataMap::getBuffersAndBarriers(ModuleOp module,
   });
 
   analysis->calculateUsedBufferRegions(module);
-  bufferRegions[(int)MemType::SHARED_MEM] = analysis->getAllUsedBufferRegions(
-      BufferRegionAnalysis::RegionType::SHARED_MEMORY);
-  bufferRegions[(int)MemType::TENSOR_MEM] = analysis->getAllUsedBufferRegions(
-      BufferRegionAnalysis::RegionType::TENSOR_MEMORY);
   barrierRegions = analysis->getAllUsedBufferRegions(
       BufferRegionAnalysis::RegionType::BARRIER);
 
   for (MemType memType : {MemType::SHARED_MEM, MemType::TENSOR_MEM}) {
     int iMemType = (int)memType;
-    ArrayRef<BufferRegion> regions = bufferRegions[iMemType];
     auto regionType = memType == MemType::SHARED_MEM
                           ? BufferRegionAnalysis::SHARED_MEMORY
                           : BufferRegionAnalysis::TENSOR_MEMORY;
+    SmallVector<BufferRegion> regions =
+        analysis->getAllUsedBufferRegions(regionType);
     bool hasUnknown = analysis->hasUnknownUsedBufferRegions(regionType);
     if (regions.empty() && !hasUnknown)
       continue;

--- a/lib/Dialect/TritonInstrument/Transforms/ConcurrencySanitizer.cpp
+++ b/lib/Dialect/TritonInstrument/Transforms/ConcurrencySanitizer.cpp
@@ -88,11 +88,11 @@ std::optional<int> maybeGetPartitionIdx(Operation *op) {
   return maybeGetPartitionIdx(parent);
 }
 
-int getCurrentThread(Operation *op, const ConSanTargetHooks *hooks,
+int getCurrentThread(Operation *op, const ConSanTargetHooks &hooks,
                      const AuxDataMap::ThreadLayout &threadLayout) {
   // Default partition is 0, other partitions are idx + 1
   int thread = maybeGetPartitionIdx(op).value_or(-1) + 1;
-  if (hooks->isTMAOp(op)) {
+  if (hooks.isTMAOp(op)) {
     assert(threadLayout.hasTMAThreads() &&
            "TMA thread class must exist when instrumenting a TMA op");
     thread += threadLayout.tmaThreadOffset;
@@ -104,7 +104,7 @@ int getCurrentThread(Operation *op, const ConSanTargetHooks *hooks,
     thread += threadLayout.tcThreadOffset;
     return thread;
   }
-  if (hooks->isCLCOp(op)) {
+  if (hooks.isCLCOp(op)) {
     assert(threadLayout.hasCLCThreads() &&
            "CLC thread class must exist when instrumenting a CLC op");
     thread += threadLayout.clcThreadOffset;
@@ -693,7 +693,7 @@ Value getBarrierRecipientCTAs(ImplicitLocOpBuilder &b, Operation *op) {
 
 class ConcurrencySanitizerImpl {
 public:
-  ConcurrencySanitizerImpl(ModuleOp module, const ConSanTargetHooks *hooks)
+  ConcurrencySanitizerImpl(ModuleOp module, const ConSanTargetHooks &hooks)
       : module(module), hooks(hooks) {}
 
   LogicalResult run() {
@@ -763,7 +763,7 @@ private:
         b.setInsertionPointAfter(op);
       }
 
-      if (auto info = hooks->getBarrierWaitInfo(op)) {
+      if (auto info = hooks.getBarrierWaitInfo(op)) {
         // For waits we want to instrument it before and after, so we do it
         // manually inside instrumentBarrierWait (disable the critical section
         // listener and return early)
@@ -778,9 +778,9 @@ private:
         return WalkResult::interrupt();
       }
       b.setLoc(op->getLoc());
-      if (auto info = hooks->getAsyncProxyFenceInfo(op)) {
+      if (auto info = hooks.getAsyncProxyFenceInfo(op)) {
         funcBuilder.createFenceProxyAccessesCall(
-            b, baseThread, info->cluster, hooks->getIssuerCTAPred(b, op), op);
+            b, baseThread, info->cluster, hooks.getIssuerCTAPred(b, op), op);
       }
       if (auto wsOp = dyn_cast<ttg::WarpSpecializeOp>(op)) {
         funcBuilder.createSetActiveMaskCall(b, getActiveMask(wsOp), op);
@@ -806,16 +806,16 @@ private:
                                                     nullptr, op);
         }
       }
-      if (auto info = hooks->getBarrierInitInfo(op)) {
-        Value pred = hooks->getIssuerCTAPred(b, op);
+      if (auto info = hooks.getBarrierInitInfo(op)) {
+        Value pred = hooks.getIssuerCTAPred(b, op);
         funcBuilder.createVerifyBarrierCanInitCall(b, info->alloc, pred, op,
                                                    currentCTAMask(b));
         funcBuilder.createInitBarrierStateCall(b, info->alloc, info->count,
                                                pred, op);
       }
-      if (auto info = hooks->getBarrierInvalidateInfo(op)) {
+      if (auto info = hooks.getBarrierInvalidateInfo(op)) {
         Value barrier = info->alloc;
-        Value pred = hooks->getIssuerCTAPred(b, op);
+        Value pred = hooks.getIssuerCTAPred(b, op);
         funcBuilder.createVerifyBarrierInitializedCall(b, barrier, pred, op,
                                                        currentCTAMask(b));
         funcBuilder.createInvalidateBarrierStateCall(b, barrier, pred, op);
@@ -833,19 +833,13 @@ private:
           funcBuilder.createCommitAccessesCall(b, thread, nullptr,
                                                CommitKind::AsyncCp, op);
       }
-      if (auto asyncWaitOp = dyn_cast<ttg::AsyncWaitOp>(op)) {
-        funcBuilder.createClearOutstandingCommitsTransferWritesCall(
-            b, baseThread, getThreadPeersMask(thread, auxData.threadLayout),
-            asyncWaitOp.getNum(), nullptr, CommitKind::AsyncCp,
-            MemType::SHARED_MEM, op);
-      }
       if (auto wgmmaWaitOp = dyn_cast<ttng::WarpGroupDotWaitOp>(op)) {
         funcBuilder.createClearOutstandingCommitsTransferReadsCall(
             b, baseThread, getThreadPeersMask(thread, auxData.threadLayout),
             wgmmaWaitOp.getPendings(), nullptr, CommitKind::Wgmma,
             MemType::SHARED_MEM, op);
       }
-      if (auto info = hooks->getWaitOpInfo(op)) {
+      if (auto info = hooks.getWaitOpInfo(op, auxData)) {
         if (info->transferWrites && info->transferReads) {
           funcBuilder.createClearOutstandingCommitsTransferBothCall(
               b, baseThread, getThreadPeersMask(thread, auxData.threadLayout),
@@ -862,6 +856,11 @@ private:
               info->pendingCount, nullptr, info->commitKind,
               MemType::SHARED_MEM, op);
         }
+      } else if (auto asyncWaitOp = dyn_cast<ttg::AsyncWaitOp>(op)) {
+        funcBuilder.createClearOutstandingCommitsTransferWritesCall(
+            b, baseThread, getThreadPeersMask(thread, auxData.threadLayout),
+            asyncWaitOp.getNum(), nullptr, CommitKind::AsyncCp,
+            MemType::SHARED_MEM, op);
       }
       if (auto clusterBarrier = dyn_cast<ttng::ClusterBarrierOp>(op)) {
         if (!llvm::is_contained(auxData.internalClusterBarriers, op))
@@ -934,7 +933,7 @@ private:
                              Value pred, int thread, int baseThread,
                              tti::FunctionBuilder &funcBuilder) {
     ImplicitLocOpBuilder wb(op->getLoc(), op);
-    pred = tti::maybeAnd(wb, pred, hooks->getIssuerCTAPred(wb, op));
+    pred = tti::maybeAnd(wb, pred, hooks.getIssuerCTAPred(wb, op));
     Value lock = auxData.lock.at(op).value;
     // Pre-wait: mark waiting threads and check for deadlock.
     tti::ExperimentalLockAcquireOp::create(wb, lock, pred);
@@ -969,11 +968,11 @@ private:
                                      int thread,
                                      tti::FunctionBuilder &funcBuilder) {
     int baseThread = getBaseThread(thread, auxData.threadLayout);
-    std::optional<MemEffectsOpInfo> opInfo = hooks->getMemEffectsOpInfo(op);
+    std::optional<MemEffectsOpInfo> opInfo = hooks.getMemEffectsOpInfo(op);
     if (!opInfo)
       return success();
     Value pred = opInfo->pred;
-    Value issuerCTAPred = hooks->getIssuerCTAPred(b, op);
+    Value issuerCTAPred = hooks.getIssuerCTAPred(b, op);
     pred = tti::maybeAnd(b, pred, issuerCTAPred);
     Value defaultEffectCTAs = getMemEffectCTAs(b, op);
     struct MaterializedEffect {
@@ -1130,9 +1129,9 @@ private:
     // commit-num-based synchronization is only supported for shared memory
     if (memType == MemType::SHARED_MEM) {
       for (const auto &commitKindDesc :
-           hooks->getOutstandingWriteCommitKinds()) {
+           hooks.getOutstandingWriteCommitKinds()) {
         bool excludeSelf = (opCommitKind == commitKindDesc.kind &&
-                            hooks->isOrderedCommitKind(opCommitKind));
+                            hooks.isOrderedCommitKind(opCommitKind));
         funcBuilder.createCheckOutstandingCommitsCall(
             b, bufferMask, getBaseThread(thread, auxData.threadLayout),
             commitKindDesc.operationDesc, pred, memType, commitKindDesc.kind,
@@ -1151,9 +1150,9 @@ private:
     // commit-num-based synchronization is only supported for shared memory
     if (memType == MemType::SHARED_MEM) {
       for (const auto &commitKindDesc :
-           hooks->getOutstandingReadCommitKinds()) {
+           hooks.getOutstandingReadCommitKinds(auxData)) {
         bool excludeSelf = (opCommitKind == commitKindDesc.kind &&
-                            hooks->isOrderedCommitKind(opCommitKind));
+                            hooks.isOrderedCommitKind(opCommitKind));
         funcBuilder.createCheckOutstandingCommitsCall(
             b, bufferMask, getBaseThread(thread, auxData.threadLayout),
             commitKindDesc.operationDesc, pred, memType, commitKindDesc.kind,
@@ -1164,14 +1163,13 @@ private:
 
   ModuleOp module;
   AuxDataMap auxData;
-  const ConSanTargetHooks *hooks;
+  const ConSanTargetHooks &hooks;
 };
 
 } // namespace
 
 LogicalResult runConcurrencySanitizer(ModuleOp module,
-                                      const ConSanTargetHooks *hooks) {
-  assert(hooks && "hooks must not be null");
+                                      const ConSanTargetHooks &hooks) {
   ConcurrencySanitizerImpl impl(module, hooks);
   return impl.run();
 }
@@ -1190,7 +1188,7 @@ public:
                                                  : "";
     auto hooks = createConSanHooks(key);
     assert(hooks && "no ConSan hooks registered for target");
-    if (failed(runConcurrencySanitizer(module, hooks.get())))
+    if (failed(runConcurrencySanitizer(module, *hooks)))
       return signalPassFailure();
   }
 };

--- a/lib/Dialect/TritonInstrument/Transforms/ConcurrencySanitizer.cpp
+++ b/lib/Dialect/TritonInstrument/Transforms/ConcurrencySanitizer.cpp
@@ -644,10 +644,7 @@ Value getMemEffectCTAs(ImplicitLocOpBuilder &b, Value recipients,
 
   Value result = arith::ConstantIntOp::create(b, 0, 32);
   for (int source = 0; source < numCTAs; ++source) {
-    uint32_t targets = 0;
-    for (int offset = 0; offset < numCTAs; ++offset)
-      if (ownerMask & (1u << offset))
-        targets |= 1u << (source ^ offset);
+    uint32_t targets = translateXorMask(ownerMask, source, numCTAs);
     Value sourceBit = arith::ConstantIntOp::create(b, 1u << source, 32);
     Value present =
         arith::CmpIOp::create(b, arith::CmpIPredicate::ne,

--- a/lib/Dialect/TritonInstrument/Transforms/ConcurrencySanitizer.cpp
+++ b/lib/Dialect/TritonInstrument/Transforms/ConcurrencySanitizer.cpp
@@ -1,5 +1,6 @@
 #include "mlir/Analysis/SliceAnalysis.h"
 #include "mlir/IR/ImplicitLocOpBuilder.h"
+#include "mlir/IR/Matchers.h"
 #include "mlir/Transforms/Passes.h"
 #include "triton/Dialect/Triton/IR/Utility.h"
 #include "triton/Dialect/TritonGPU/IR/Dialect.h"
@@ -162,7 +163,7 @@ Value createStateMaskConstant(ImplicitLocOpBuilder &b,
 FailureOr<Value> createBufferStateMask(ImplicitLocOpBuilder &b,
                                        AuxDataMap &auxData, MemType memType,
                                        Value runtimeBase,
-                                       ArrayRef<uint32_t> candidateIds,
+                                       const BufferStateCandidates &candidates,
                                        Operation *op) {
   int index = static_cast<int>(memType);
   const BufferStatePlan &plan = auxData.bufferStatePlans[index];
@@ -170,15 +171,9 @@ FailureOr<Value> createBufferStateMask(ImplicitLocOpBuilder &b,
     op->emitError("active memdesc has no ConSan state plan");
     return failure();
   }
-  if (candidateIds.empty()) {
+  if (!candidates.unknown && candidates.cases.empty()) {
     op->emitError("active memdesc has no buffer-state candidates");
     return failure();
-  }
-  for (uint32_t id : candidateIds) {
-    if (id >= plan.regionMasks.size()) {
-      op->emitError("buffer-region candidate ID is out of bounds");
-      return failure();
-    }
   }
 
   auto writeVisibilityType =
@@ -186,16 +181,19 @@ FailureOr<Value> createBufferStateMask(ImplicitLocOpBuilder &b,
   RankedTensorType maskType =
       tti::getSlicedTensorType(writeVisibilityType, {1}, b.getI1Type());
 
+  if (candidates.unknown)
+    return createStateMaskConstant(b, maskType, plan.unknownMask);
+
   SmallVector<Value> predicates;
-  if (candidateIds.size() > 1) {
+  if (candidates.cases.size() > 1) {
     if (!runtimeBase) {
       op->emitError("dynamic buffer-state cases require a runtime base");
       return failure();
     }
     Value resolved = arith::ConstantIntOp::create(b, 0, 1);
-    for (uint32_t id : candidateIds) {
+    for (const BufferStateCandidate &candidate : candidates.cases) {
       Value base = tti::ExperimentalMemoryOffsetToI32Op::create(
-          b, auxData.bufferRegions[index][id].baseOffset, memType);
+          b, candidate.baseOffset, memType);
       Value predicate =
           arith::CmpIOp::create(b, arith::CmpIPredicate::eq, runtimeBase, base);
       predicates.push_back(predicate);
@@ -206,15 +204,13 @@ FailureOr<Value> createBufferStateMask(ImplicitLocOpBuilder &b,
         "internal ConSan error: active memdesc resolved to no buffer state");
   }
 
-  if (candidateIds.size() == 1)
-    return createStateMaskConstant(b, maskType,
-                                   plan.regionMasks[candidateIds.front()]);
+  if (candidates.cases.size() == 1)
+    return createStateMaskConstant(b, maskType, candidates.cases.front().mask);
 
   Value result =
       createStateMaskConstant(b, maskType, llvm::SmallBitVector(plan.numLanes));
-  for (auto [id, predicate] : llvm::zip(candidateIds, predicates)) {
-    Value candidate =
-        createStateMaskConstant(b, maskType, plan.regionMasks[id]);
+  for (auto [state, predicate] : llvm::zip(candidates.cases, predicates)) {
+    Value candidate = createStateMaskConstant(b, maskType, state.mask);
     Value predicateTensor = tt::SplatOp::create(b, maskType, predicate);
     candidate = arith::AndIOp::create(b, candidate, predicateTensor);
     result = arith::OrIOp::create(b, result, candidate);
@@ -624,6 +620,47 @@ Value getMemEffectCTAs(ImplicitLocOpBuilder &b, Operation *op) {
   return currentCTAMask(b);
 }
 
+Value getMemEffectCTAs(ImplicitLocOpBuilder &b, Value recipients,
+                       const BufferStateCandidates &candidates) {
+  if (candidates.unknown)
+    return allCTAsMask(b);
+
+  uint32_t ownerMask = 0;
+  for (const BufferStateCandidate &candidate : candidates.cases)
+    ownerMask |= candidate.ctaMask;
+
+  if (ownerMask == 1)
+    return recipients;
+
+  int numCTAs = ttg::lookupNumCTAs(b);
+  APInt constant;
+  if (matchPattern(recipients, m_ConstantInt(&constant))) {
+    uint32_t result = 0;
+    for (int offset = 0; offset < numCTAs; ++offset)
+      if (ownerMask & (1u << offset))
+        result |= translateXorMask(constant.getZExtValue(), offset, numCTAs);
+    return arith::ConstantIntOp::create(b, result, 32);
+  }
+
+  Value result = arith::ConstantIntOp::create(b, 0, 32);
+  for (int source = 0; source < numCTAs; ++source) {
+    uint32_t targets = 0;
+    for (int offset = 0; offset < numCTAs; ++offset)
+      if (ownerMask & (1u << offset))
+        targets |= 1u << (source ^ offset);
+    Value sourceBit = arith::ConstantIntOp::create(b, 1u << source, 32);
+    Value present =
+        arith::CmpIOp::create(b, arith::CmpIPredicate::ne,
+                              arith::AndIOp::create(b, recipients, sourceBit),
+                              arith::ConstantIntOp::create(b, 0, 32));
+    Value targetMask = arith::SelectOp::create(
+        b, present, arith::ConstantIntOp::create(b, targets, 32),
+        arith::ConstantIntOp::create(b, 0, 32));
+    result = arith::OrIOp::create(b, result, targetMask);
+  }
+  return result;
+}
+
 Value getBarrierRecipientCTAs(ImplicitLocOpBuilder &b, Operation *op) {
   if (isa<ttng::BarrierExpectOp, ttng::ArriveBarrierOp>(op)) {
     Value barrier = cast<ttg::MBarrierOpInterface>(op).getBarrier();
@@ -941,9 +978,10 @@ private:
     Value pred = opInfo->pred;
     Value issuerCTAPred = hooks->getIssuerCTAPred(b, op);
     pred = tti::maybeAnd(b, pred, issuerCTAPred);
-    Value effectCTAs = getMemEffectCTAs(b, op);
+    Value defaultEffectCTAs = getMemEffectCTAs(b, op);
     struct MaterializedEffect {
       Value bufferMask;
+      Value effectCTAs;
       MemType memType;
     };
     SmallVector<MaterializedEffect> materializedEffects;
@@ -954,17 +992,17 @@ private:
       Value buf = effect.buf;
       auto bufType = cast<ttg::MemDescType>(buf.getType());
       materialized.memType = MemType::TENSOR_MEM;
-      if (isa<ttg::SharedEncodingTrait>(bufType.getEncoding()))
+      if (isa<ttg::SharedMemorySpaceAttr>(bufType.getMemorySpace()))
         materialized.memType = MemType::SHARED_MEM;
       auto &candidateMap =
-          auxData.bufferCandidateIds[static_cast<int>(materialized.memType)];
+          auxData.bufferCandidates[static_cast<int>(materialized.memType)];
       auto candidateIt = candidateMap.find(buf);
       if (candidateIt == candidateMap.end()) {
-        op->emitError("missing exact buffer-region candidates for memdesc");
+        op->emitError("missing buffer-region candidates for memdesc");
         return failure();
       }
       Value runtimeBase;
-      if (candidateIt->second.size() > 1)
+      if (!candidateIt->second.unknown && candidateIt->second.cases.size() > 1)
         runtimeBase = tti::ExperimentalMemDescToI32Op::create(b, buf);
       FailureOr<Value> stateMask =
           createBufferStateMask(b, auxData, materialized.memType, runtimeBase,
@@ -972,9 +1010,12 @@ private:
       if (failed(stateMask))
         return failure();
       materialized.bufferMask = *stateMask;
+      materialized.effectCTAs =
+          getMemEffectCTAs(b, defaultEffectCTAs, candidateIt->second);
       materializedEffects.push_back(materialized);
 
       Value bufferMask = materialized.bufferMask;
+      Value effectCTAs = materialized.effectCTAs;
       MemType memType = materialized.memType;
       if (memType == MemType::SHARED_MEM) {
         if (effect.proxy == MemEffectsOpInfo::Effects::Proxy::Async) {
@@ -1055,12 +1096,12 @@ private:
             continue;
           funcBuilder.createTrackBarrierWriteForBufferCall(
               b, barrier, materialized.bufferMask, combinedPred,
-              materialized.memType, op, recipientCTAs, effectCTAs);
+              materialized.memType, op, recipientCTAs, materialized.effectCTAs);
           if (materialized.memType == MemType::SHARED_MEM &&
               effect.proxy == MemEffectsOpInfo::Effects::Proxy::Async) {
             funcBuilder.createTrackProxyAccessesForBufferCall(
                 b, barrier, materialized.bufferMask, baseThread, combinedPred,
-                op, recipientCTAs, effectCTAs);
+                op, recipientCTAs, materialized.effectCTAs);
           }
         }
       }

--- a/lib/Dialect/TritonInstrument/Transforms/PrepareConSanCaptures.cpp
+++ b/lib/Dialect/TritonInstrument/Transforms/PrepareConSanCaptures.cpp
@@ -59,11 +59,11 @@ bool hasCpAsync(ModuleOp mod) {
   return result;
 }
 
-int getNumCommitKinds(ModuleOp mod, const ConSanTargetHooks *hooks) {
+int getNumCommitKinds(ModuleOp mod, const ConSanTargetHooks &hooks) {
   std::array<bool, tti::CommitKind::NumCommitKinds> commitKinds{};
   if (hasCpAsync(mod))
     commitKinds[tti::CommitKind::AsyncCp] = true;
-  for (auto kind : hooks->getRequiredCommitKinds(mod)) {
+  for (auto kind : hooks.getRequiredCommitKinds(mod)) {
     if (kind >= 0 && kind < tti::CommitKind::NumCommitKinds)
       commitKinds[kind] = true;
   }
@@ -100,7 +100,7 @@ public:
     bool hasClusterBarriers = target == "nvidia" && ttg::lookupNumCTAs(mod) > 1;
     int totalCaptures = tti::estimateConSanCaptureCount(
         numActiveMemTypes, hasBarriers(mod), hasClusterBarriers,
-        getNumCommitKinds(mod, hooks.get()),
+        getNumCommitKinds(mod, *hooks),
         hasSharedMemoryBuffers(mod) &&
             hooks->needsAsyncProxyFenceTracking(mod));
     int extraBytes = totalCaptures * tti::kCaptureSizeBytes;

--- a/lib/Dialect/TritonNvidiaGPU/Transforms/ConSanNVIDIA.cpp
+++ b/lib/Dialect/TritonNvidiaGPU/Transforms/ConSanNVIDIA.cpp
@@ -149,9 +149,7 @@ public:
 
   std::optional<MemEffectsOpInfo>
   getMemEffectsOpInfo(Operation *op) const override {
-    auto info = ConSanTargetHooks::getMemEffectsOpInfo(op);
-    if (info)
-      return info;
+    std::optional<MemEffectsOpInfo> info;
     if (auto expectOp = dyn_cast<ttng::BarrierExpectOp>(op)) {
       info.emplace();
       info->trackingKind = MemEffectsOpInfo::TrackingKind::Barrier;
@@ -310,7 +308,7 @@ public:
       info->barriers.push_back(
           {arriveOp.getBarrier(), nullptr, (int)arriveOp.getCount()});
     }
-    return info;
+    return info ? info : ConSanTargetHooks::getMemEffectsOpInfo(op);
   }
 
   SmallVector<CommitKindDesc> getOutstandingReadCommitKinds() const override {

--- a/lib/Dialect/TritonNvidiaGPU/Transforms/ConSanNVIDIA.cpp
+++ b/lib/Dialect/TritonNvidiaGPU/Transforms/ConSanNVIDIA.cpp
@@ -75,7 +75,8 @@ public:
     return std::nullopt;
   }
 
-  std::optional<WaitOpInfo> getWaitOpInfo(Operation *op) const override {
+  std::optional<WaitOpInfo>
+  getWaitOpInfo(Operation *op, const tti::AuxDataMap &) const override {
     if (auto tmaStoreWaitOp = dyn_cast<ttng::TMAStoreWaitOp>(op))
       return WaitOpInfo{tti::CommitKind::TmaStore,
                         static_cast<int>(tmaStoreWaitOp.getPendings()),
@@ -311,7 +312,8 @@ public:
     return info ? info : ConSanTargetHooks::getMemEffectsOpInfo(op);
   }
 
-  SmallVector<CommitKindDesc> getOutstandingReadCommitKinds() const override {
+  SmallVector<CommitKindDesc>
+  getOutstandingReadCommitKinds(const tti::AuxDataMap &) const override {
     return {{tti::CommitKind::Wgmma, "warpgroup_mma operand read"},
             {tti::CommitKind::TmaStore, "async_copy_shared_to_global"}};
   }

--- a/test/Analysis/test-buffer-region-alias.mlir
+++ b/test/Analysis/test-buffer-region-alias.mlir
@@ -408,3 +408,123 @@ module attributes {test.print_state_plan, "ttg.num-ctas" = 1 : i32, "ttg.num-war
     tt.return
   }
 }
+
+// -----
+
+// Sixteen swizzled partitions must follow their physical-base array even
+// when the bases are out of order and a later group reuses a partition.
+#inner = #ttg.swizzled_shared<{vec = 4, perPhase = 2, maxPhase = 4, order = [1, 0]}>
+#partitioned = #ttg.partitioned_shared<{numPartitions = 16, numGroups = 2, partitionDim = 0, partitionLayout = #inner}>
+#smem = #ttg.shared_memory
+
+// expected-remark @below {{state-plan: lanes=3}}
+// expected-remark @below {{a_first case [61440, 1024]: mask={1}}}
+// expected-remark @below {{b_last case [0, 1024]: mask={0}}}
+// expected-remark @below {{c_next_group case [61504, 1024]: mask={2}}}
+// expected-remark @below {{d_first_reference case [61440, 64]: mask={1}}}
+// expected-remark @below {{e_last_reference case [0, 64]: mask={0}}}
+// expected-remark @below {{f_group_reference case [61504, 64]: mask={2}}}
+// expected-remark @below {{g_selected case [0, 1024]: mask={0}}}
+// expected-remark @below {{g_selected case [61440, 1024]: mask={1}}}
+module attributes {test.print_state_plan, test.state_plan_only, "ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 2 : i32, ttg.shared = 65536 : i32, ttg.target = "hip:gfx1250", "ttg.threads-per-warp" = 32 : i32, "ttg.total-num-warps" = 2 : i32} {
+  tt.func public @partitioned_swizzled_permuted_bases(%choose: i1) {
+    %parent = ttg.local_alloc {allocation.offset = [61440 : i32, 4096 : i32, 57344 : i32, 8192 : i32, 53248 : i32, 12288 : i32, 49152 : i32, 16384 : i32, 45056 : i32, 20480 : i32, 40960 : i32, 24576 : i32, 36864 : i32, 28672 : i32, 32768 : i32, 0 : i32]} : () -> !ttg.memdesc<32x32xf16, #partitioned, #smem, mutable>
+    %first = ttg.memdesc_subslice %parent [0, 0] : !ttg.memdesc<32x32xf16, #partitioned, #smem, mutable> -> !ttg.memdesc<1x32xf16, #partitioned, #smem, mutable, 32x32>
+    %last = ttg.memdesc_subslice %parent [15, 0] : !ttg.memdesc<32x32xf16, #partitioned, #smem, mutable> -> !ttg.memdesc<1x32xf16, #partitioned, #smem, mutable, 32x32>
+    %next_group = ttg.memdesc_subslice %parent [16, 0] : !ttg.memdesc<32x32xf16, #partitioned, #smem, mutable> -> !ttg.memdesc<1x32xf16, #partitioned, #smem, mutable, 32x32>
+    %first_reference = ttg.local_alloc {allocation.offset = 61440 : i32} : () -> !ttg.memdesc<1x32xf16, #inner, #smem, mutable>
+    %last_reference = ttg.local_alloc {allocation.offset = 0 : i32} : () -> !ttg.memdesc<1x32xf16, #inner, #smem, mutable>
+    %group_reference = ttg.local_alloc {allocation.offset = 61504 : i32} : () -> !ttg.memdesc<1x32xf16, #inner, #smem, mutable>
+    %selected = arith.select %choose, %first, %last : !ttg.memdesc<1x32xf16, #partitioned, #smem, mutable, 32x32>
+    %0 = ttg.local_load %first {test.region_name = "a_first"} : !ttg.memdesc<1x32xf16, #partitioned, #smem, mutable, 32x32> -> tensor<1x32xf16>
+    %1 = ttg.local_load %last {test.region_name = "b_last"} : !ttg.memdesc<1x32xf16, #partitioned, #smem, mutable, 32x32> -> tensor<1x32xf16>
+    %2 = ttg.local_load %next_group {test.region_name = "c_next_group"} : !ttg.memdesc<1x32xf16, #partitioned, #smem, mutable, 32x32> -> tensor<1x32xf16>
+    %3 = ttg.local_load %first_reference {test.region_name = "d_first_reference"} : !ttg.memdesc<1x32xf16, #inner, #smem, mutable> -> tensor<1x32xf16>
+    %4 = ttg.local_load %last_reference {test.region_name = "e_last_reference"} : !ttg.memdesc<1x32xf16, #inner, #smem, mutable> -> tensor<1x32xf16>
+    %5 = ttg.local_load %group_reference {test.region_name = "f_group_reference"} : !ttg.memdesc<1x32xf16, #inner, #smem, mutable> -> tensor<1x32xf16>
+    %6 = ttg.local_load %selected {test.region_name = "g_selected"} : !ttg.memdesc<1x32xf16, #partitioned, #smem, mutable, 32x32> -> tensor<1x32xf16>
+    tt.return
+  }
+}
+
+// -----
+
+// Padding and nested subslice offsets are relative to the selected partition.
+// The independent allocations expose the padded group and nested addresses.
+#inner = #ttg.padded_shared<[16:+4] {order = [1, 0], shape = [4, 16]}>
+#nested_inner = #ttg.padded_shared<[16:+4] {order = [1, 0], shape = [2, 16]}>
+#partitioned = #ttg.partitioned_shared<{numPartitions = 2, numGroups = 2, partitionDim = 0, partitionLayout = #inner}>
+#smem = #ttg.shared_memory
+
+// expected-remark @below {{state-plan: lanes=4}}
+// expected-remark @below {{a_first case [4096, 312]: mask={1}}}
+// expected-remark @below {{b_second case [128, 312]: mask={0}}}
+// expected-remark @below {{c_next_group case [4256, 312]: mask={2,3}}}
+// expected-remark @below {{d_nested case [4336, 152]: mask={3}}}
+// expected-remark @below {{e_group_reference case [4256, 152]: mask={2,3}}}
+// expected-remark @below {{f_nested_reference case [4336, 72]: mask={3}}}
+// expected-remark @below {{g_selected case [128, 312]: mask={0}}}
+// expected-remark @below {{g_selected case [4096, 312]: mask={1}}}
+module attributes {test.print_state_plan, test.state_plan_only, "ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 2 : i32, ttg.shared = 8192 : i32, ttg.target = "hip:gfx1250", "ttg.threads-per-warp" = 32 : i32, "ttg.total-num-warps" = 2 : i32} {
+  tt.func public @partitioned_padded_groups_and_nested_views(%choose: i1) {
+    %parent = ttg.local_alloc {allocation.offset = [4096 : i32, 128 : i32]} : () -> !ttg.memdesc<16x16xf16, #partitioned, #smem, mutable>
+    %first = ttg.memdesc_subslice %parent [0, 0] : !ttg.memdesc<16x16xf16, #partitioned, #smem, mutable> -> !ttg.memdesc<4x16xf16, #partitioned, #smem, mutable, 16x16>
+    %second = ttg.memdesc_subslice %parent [4, 0] : !ttg.memdesc<16x16xf16, #partitioned, #smem, mutable> -> !ttg.memdesc<4x16xf16, #partitioned, #smem, mutable, 16x16>
+    %next_group = ttg.memdesc_subslice %parent [8, 0] : !ttg.memdesc<16x16xf16, #partitioned, #smem, mutable> -> !ttg.memdesc<4x16xf16, #partitioned, #smem, mutable, 16x16>
+    %nested = ttg.memdesc_subslice %next_group [2, 0] : !ttg.memdesc<4x16xf16, #partitioned, #smem, mutable, 16x16> -> !ttg.memdesc<2x16xf16, #partitioned, #smem, mutable, 16x16>
+    %group_reference = ttg.local_alloc {allocation.offset = 4256 : i32} : () -> !ttg.memdesc<4x16xf16, #inner, #smem, mutable>
+    %nested_reference = ttg.local_alloc {allocation.offset = 4336 : i32} : () -> !ttg.memdesc<2x16xf16, #nested_inner, #smem, mutable>
+    %selected = arith.select %choose, %first, %second : !ttg.memdesc<4x16xf16, #partitioned, #smem, mutable, 16x16>
+    %0 = ttg.local_load %first {test.region_name = "a_first"} : !ttg.memdesc<4x16xf16, #partitioned, #smem, mutable, 16x16> -> tensor<4x16xf16>
+    %1 = ttg.local_load %second {test.region_name = "b_second"} : !ttg.memdesc<4x16xf16, #partitioned, #smem, mutable, 16x16> -> tensor<4x16xf16>
+    %2 = ttg.local_load %next_group {test.region_name = "c_next_group"} : !ttg.memdesc<4x16xf16, #partitioned, #smem, mutable, 16x16> -> tensor<4x16xf16>
+    %3 = ttg.local_load %nested {test.region_name = "d_nested"} : !ttg.memdesc<2x16xf16, #partitioned, #smem, mutable, 16x16> -> tensor<2x16xf16>
+    %4 = ttg.local_load %group_reference {test.region_name = "e_group_reference"} : !ttg.memdesc<4x16xf16, #inner, #smem, mutable> -> tensor<4x16xf16>
+    %5 = ttg.local_load %nested_reference {test.region_name = "f_nested_reference"} : !ttg.memdesc<2x16xf16, #nested_inner, #smem, mutable> -> tensor<2x16xf16>
+    %6 = ttg.local_load %selected {test.region_name = "g_selected"} : !ttg.memdesc<4x16xf16, #partitioned, #smem, mutable, 16x16> -> tensor<4x16xf16>
+    tt.return
+  }
+}
+
+// -----
+
+// Each padded pipeline stage advances every physical base. Dynamic indexing
+// retains all three stage candidates, and a stage subview matches its own
+// independently allocated physical partition.
+#inner = #ttg.padded_shared<[16:+4] {order = [1, 0], shape = [4, 16]}>
+#partitioned = #ttg.partitioned_shared<{numPartitions = 2, numGroups = 2, partitionDim = 0, partitionLayout = #inner}>
+#smem = #ttg.shared_memory
+
+// expected-remark @below {{state-plan: lanes=4}}
+// expected-remark @below {{a_stage0 case [4096, 632]: mask={2}}}
+// expected-remark @below {{b_stage1 case [4416, 632]: mask={3}}}
+// expected-remark @below {{c_stage2 case [4736, 632]: mask={0,1}}}
+// expected-remark @below {{d_stage2_reference case [4736, 632]: mask={0,1}}}
+// expected-remark @below {{e_stage2_piece case [768, 312]: mask={0}}}
+// expected-remark @below {{f_piece_reference case [768, 152]: mask={0}}}
+// expected-remark @below {{g_dynamic case [4096, 632]: mask={2}}}
+// expected-remark @below {{g_dynamic case [4416, 632]: mask={3}}}
+// expected-remark @below {{g_dynamic case [4736, 632]: mask={0,1}}}
+module attributes {test.print_state_plan, test.state_plan_only, "ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 2 : i32, ttg.shared = 8192 : i32, ttg.target = "hip:gfx1250", "ttg.threads-per-warp" = 32 : i32, "ttg.total-num-warps" = 2 : i32} {
+  tt.func public @partitioned_padded_dynamic_pipeline(%index: i32) {
+    %c0 = arith.constant 0 : i32
+    %c1 = arith.constant 1 : i32
+    %c2 = arith.constant 2 : i32
+    %parent = ttg.local_alloc {allocation.offset = [4096 : i32, 128 : i32]} : () -> !ttg.memdesc<3x16x16xf16, #partitioned, #smem, mutable>
+    %stage0 = ttg.memdesc_index %parent[%c0] : !ttg.memdesc<3x16x16xf16, #partitioned, #smem, mutable> -> !ttg.memdesc<16x16xf16, #partitioned, #smem, mutable>
+    %stage1 = ttg.memdesc_index %parent[%c1] : !ttg.memdesc<3x16x16xf16, #partitioned, #smem, mutable> -> !ttg.memdesc<16x16xf16, #partitioned, #smem, mutable>
+    %stage2 = ttg.memdesc_index %parent[%c2] : !ttg.memdesc<3x16x16xf16, #partitioned, #smem, mutable> -> !ttg.memdesc<16x16xf16, #partitioned, #smem, mutable>
+    %dynamic = ttg.memdesc_index %parent[%index] : !ttg.memdesc<3x16x16xf16, #partitioned, #smem, mutable> -> !ttg.memdesc<16x16xf16, #partitioned, #smem, mutable>
+    %stage2_reference = ttg.local_alloc {allocation.offset = [4736 : i32, 768 : i32]} : () -> !ttg.memdesc<16x16xf16, #partitioned, #smem, mutable>
+    %stage2_piece = ttg.memdesc_subslice %stage2 [4, 0] : !ttg.memdesc<16x16xf16, #partitioned, #smem, mutable> -> !ttg.memdesc<4x16xf16, #partitioned, #smem, mutable, 16x16>
+    %piece_reference = ttg.local_alloc {allocation.offset = 768 : i32} : () -> !ttg.memdesc<4x16xf16, #inner, #smem, mutable>
+    %0 = ttg.local_load %stage0 {test.region_name = "a_stage0"} : !ttg.memdesc<16x16xf16, #partitioned, #smem, mutable> -> tensor<16x16xf16>
+    %1 = ttg.local_load %stage1 {test.region_name = "b_stage1"} : !ttg.memdesc<16x16xf16, #partitioned, #smem, mutable> -> tensor<16x16xf16>
+    %2 = ttg.local_load %stage2 {test.region_name = "c_stage2"} : !ttg.memdesc<16x16xf16, #partitioned, #smem, mutable> -> tensor<16x16xf16>
+    %3 = ttg.local_load %stage2_reference {test.region_name = "d_stage2_reference"} : !ttg.memdesc<16x16xf16, #partitioned, #smem, mutable> -> tensor<16x16xf16>
+    %4 = ttg.local_load %stage2_piece {test.region_name = "e_stage2_piece"} : !ttg.memdesc<4x16xf16, #partitioned, #smem, mutable, 16x16> -> tensor<4x16xf16>
+    %5 = ttg.local_load %piece_reference {test.region_name = "f_piece_reference"} : !ttg.memdesc<4x16xf16, #inner, #smem, mutable> -> tensor<4x16xf16>
+    %6 = ttg.local_load %dynamic {test.region_name = "g_dynamic"} : !ttg.memdesc<16x16xf16, #partitioned, #smem, mutable> -> tensor<16x16xf16>
+    tt.return
+  }
+}

--- a/test/Analysis/test-buffer-region-alias.mlir
+++ b/test/Analysis/test-buffer-region-alias.mlir
@@ -9,8 +9,6 @@
 module attributes {test.print_state_plan, test.state_plan_only} {
   tt.func private @full() attributes {
     test.region_name = "a_full",
-    test.region_base = 0 : i32,
-    test.region_length = 8 : i32,
     test.region_addresses = array<i32: 0, 1, 2, 3, 4, 5, 6, 7>
   }
   tt.func private @even() attributes {

--- a/test/Analysis/test-buffer-region-layout-alias.mlir
+++ b/test/Analysis/test-buffer-region-layout-alias.mlir
@@ -360,6 +360,62 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 2 : i32, ttg.shar
 
 // -----
 
+// Partition selection follows the linear layout and physical base order, not
+// the slicing dimension or the numerical ordering of allocation offsets.
+#inner = #ttg.swizzled_shared<{vec = 1, perPhase = 1, maxPhase = 1, order = [1, 0]}>
+#partitioned = #ttg.partitioned_shared<{numPartitions = 4, numGroups = 2, partitionDim = 1, partitionLayout = #inner}>
+#smem = #ttg.shared_memory
+
+// CHECK-LABEL: column_partition_a_parent vs column_partition_a_parent: alias=true
+// CHECK: column_partition_a_parent vs column_partition_b_first: alias=true
+// CHECK: column_partition_a_parent vs column_partition_c_second: alias=true
+// CHECK: column_partition_a_parent vs column_partition_d_third: alias=true
+// CHECK: column_partition_a_parent vs column_partition_e_fourth: alias=true
+// CHECK: column_partition_a_parent vs column_partition_f_next_group: alias=true
+// CHECK: column_partition_a_parent vs column_partition_g_first_base: alias=true
+// CHECK: column_partition_a_parent vs column_partition_h_second_base: alias=true
+// CHECK: column_partition_a_parent vs column_partition_i_third_base: alias=true
+// CHECK: column_partition_a_parent vs column_partition_j_fourth_base: alias=true
+// CHECK: column_partition_a_parent vs column_partition_k_next_group_base: alias=true
+// CHECK: column_partition_b_first vs column_partition_c_second: alias=false
+// CHECK: column_partition_b_first vs column_partition_d_third: alias=false
+// CHECK: column_partition_b_first vs column_partition_e_fourth: alias=false
+// CHECK: column_partition_b_first vs column_partition_f_next_group: alias=false
+// CHECK: column_partition_b_first vs column_partition_g_first_base: alias=true, lhs_contains_rhs=true, rhs_contains_lhs=true
+// CHECK: column_partition_c_second vs column_partition_h_second_base: alias=true, lhs_contains_rhs=true, rhs_contains_lhs=true
+// CHECK: column_partition_d_third vs column_partition_i_third_base: alias=true, lhs_contains_rhs=true, rhs_contains_lhs=true
+// CHECK: column_partition_e_fourth vs column_partition_j_fourth_base: alias=true, lhs_contains_rhs=true, rhs_contains_lhs=true
+// CHECK: column_partition_f_next_group vs column_partition_k_next_group_base: alias=true, lhs_contains_rhs=true, rhs_contains_lhs=true
+module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 2 : i32, ttg.shared = 4096 : i32, ttg.target = "hip:gfx1250", "ttg.threads-per-warp" = 32 : i32, "ttg.total-num-warps" = 2 : i32} {
+  tt.func public @partitioned_four_column_physical_alias() {
+    %parent = ttg.local_alloc {allocation.offset = [3072 : i32, 1024 : i32, 0 : i32, 2048 : i32]} : () -> !ttg.memdesc<16x16xf16, #partitioned, #smem, mutable>
+    %first = ttg.memdesc_subslice %parent [0, 0] : !ttg.memdesc<16x16xf16, #partitioned, #smem, mutable> -> !ttg.memdesc<16x2xf16, #partitioned, #smem, mutable, 16x16>
+    %second = ttg.memdesc_subslice %parent [0, 2] : !ttg.memdesc<16x16xf16, #partitioned, #smem, mutable> -> !ttg.memdesc<16x2xf16, #partitioned, #smem, mutable, 16x16>
+    %third = ttg.memdesc_subslice %parent [0, 4] : !ttg.memdesc<16x16xf16, #partitioned, #smem, mutable> -> !ttg.memdesc<16x2xf16, #partitioned, #smem, mutable, 16x16>
+    %fourth = ttg.memdesc_subslice %parent [0, 6] : !ttg.memdesc<16x16xf16, #partitioned, #smem, mutable> -> !ttg.memdesc<16x2xf16, #partitioned, #smem, mutable, 16x16>
+    %next_group = ttg.memdesc_subslice %parent [0, 8] : !ttg.memdesc<16x16xf16, #partitioned, #smem, mutable> -> !ttg.memdesc<16x2xf16, #partitioned, #smem, mutable, 16x16>
+    %first_base = ttg.local_alloc {allocation.offset = 3072 : i32} : () -> !ttg.memdesc<16x2xf16, #inner, #smem, mutable>
+    %second_base = ttg.local_alloc {allocation.offset = 1024 : i32} : () -> !ttg.memdesc<16x2xf16, #inner, #smem, mutable>
+    %third_base = ttg.local_alloc {allocation.offset = 0 : i32} : () -> !ttg.memdesc<16x2xf16, #inner, #smem, mutable>
+    %fourth_base = ttg.local_alloc {allocation.offset = 2048 : i32} : () -> !ttg.memdesc<16x2xf16, #inner, #smem, mutable>
+    %next_group_base = ttg.local_alloc {allocation.offset = 3136 : i32} : () -> !ttg.memdesc<16x2xf16, #inner, #smem, mutable>
+    %0 = ttg.local_load %parent {test.region_name = "column_partition_a_parent"} : !ttg.memdesc<16x16xf16, #partitioned, #smem, mutable> -> tensor<16x16xf16>
+    %1 = ttg.local_load %first {test.region_name = "column_partition_b_first"} : !ttg.memdesc<16x2xf16, #partitioned, #smem, mutable, 16x16> -> tensor<16x2xf16>
+    %2 = ttg.local_load %second {test.region_name = "column_partition_c_second"} : !ttg.memdesc<16x2xf16, #partitioned, #smem, mutable, 16x16> -> tensor<16x2xf16>
+    %3 = ttg.local_load %third {test.region_name = "column_partition_d_third"} : !ttg.memdesc<16x2xf16, #partitioned, #smem, mutable, 16x16> -> tensor<16x2xf16>
+    %4 = ttg.local_load %fourth {test.region_name = "column_partition_e_fourth"} : !ttg.memdesc<16x2xf16, #partitioned, #smem, mutable, 16x16> -> tensor<16x2xf16>
+    %5 = ttg.local_load %next_group {test.region_name = "column_partition_f_next_group"} : !ttg.memdesc<16x2xf16, #partitioned, #smem, mutable, 16x16> -> tensor<16x2xf16>
+    %6 = ttg.local_load %first_base {test.region_name = "column_partition_g_first_base"} : !ttg.memdesc<16x2xf16, #inner, #smem, mutable> -> tensor<16x2xf16>
+    %7 = ttg.local_load %second_base {test.region_name = "column_partition_h_second_base"} : !ttg.memdesc<16x2xf16, #inner, #smem, mutable> -> tensor<16x2xf16>
+    %8 = ttg.local_load %third_base {test.region_name = "column_partition_i_third_base"} : !ttg.memdesc<16x2xf16, #inner, #smem, mutable> -> tensor<16x2xf16>
+    %9 = ttg.local_load %fourth_base {test.region_name = "column_partition_j_fourth_base"} : !ttg.memdesc<16x2xf16, #inner, #smem, mutable> -> tensor<16x2xf16>
+    %10 = ttg.local_load %next_group_base {test.region_name = "column_partition_k_next_group_base"} : !ttg.memdesc<16x2xf16, #inner, #smem, mutable> -> tensor<16x2xf16>
+    tt.return
+  }
+}
+
+// -----
+
 // A valid shared-linear layout can interleave CTA ownership within one
 // descriptor instead of expressing the CTA as a single affine view offset.
 #shared = #ttg.shared_linear<{offset = [[0, 1], [0, 2], [1, 0], [4, 0]], block = [[2, 0]]}, alignment = 16>
@@ -540,6 +596,117 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.shar
     %token = amdg.async_tdm_fused_copy_global_to_local %desc0, %desc1 into %first, %second {warp_used_hints = array<i32: 3, 12>} : !tt.tensordesc<64x64xf16, #shared>, !tt.tensordesc<64x64xf16, #shared> -> !ttg.memdesc<64x64xf16, #shared, #smem, mutable>, !ttg.memdesc<64x64xf16, #shared, #smem, mutable>
     %first_value = ttg.local_load %first {test.region_name = "amd_fused_a_first"} : !ttg.memdesc<64x64xf16, #shared, #smem, mutable> -> tensor<64x64xf16, #blocked>
     %second_value = ttg.local_load %second {test.region_name = "amd_fused_b_second"} : !ttg.memdesc<64x64xf16, #shared, #smem, mutable> -> tensor<64x64xf16, #blocked>
+    tt.return
+  }
+}
+
+// -----
+
+// A warp-group wait forwards each memory descriptor without accessing or
+// replacing the allocation it keeps alive.
+#shared = #ttg.swizzled_shared<{vec = 1, perPhase = 1, maxPhase = 1, order = [0]}>
+#smem = #ttg.shared_memory
+
+// CHECK-LABEL: wait_a_source vs wait_a_source: alias=true
+// CHECK: wait_a_source vs wait_b_result: alias=true, lhs_contains_rhs=true, rhs_contains_lhs=true
+// CHECK: wait_a_source vs wait_c_load: alias=true, lhs_contains_rhs=true, rhs_contains_lhs=true
+// CHECK: wait_b_result vs wait_c_load: alias=true, lhs_contains_rhs=true, rhs_contains_lhs=true
+module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 1 : i32, ttg.shared = 64 : i32, ttg.target = "cuda:90", ttg.tensor_memory_size = 0 : i32, "ttg.threads-per-warp" = 32 : i32, "ttg.total-num-warps" = 1 : i32} {
+  tt.func public @warp_group_wait_preserves_memdesc() {
+    %buffer = ttg.local_alloc {allocation.offset = 0 : i32} : () -> !ttg.memdesc<16xi32, #shared, #smem, mutable>
+    %source = ttg.local_load %buffer {test.region_name = "wait_a_source"} : !ttg.memdesc<16xi32, #shared, #smem, mutable> -> tensor<16xi32>
+    %waited = ttng.warp_group_dot_wait %buffer {pendings = 0 : i32, test.region_name = "wait_b_result"} : !ttg.memdesc<16xi32, #shared, #smem, mutable>
+    %result = ttg.local_load %waited {test.region_name = "wait_c_load"} : !ttg.memdesc<16xi32, #shared, #smem, mutable> -> tensor<16xi32>
+    tt.return
+  }
+}
+
+// -----
+
+// Unknown memory aliases every exact state while retaining one additional
+// state lane for hazards between independently unknown descriptors.
+#shared = #ttg.swizzled_shared<{vec = 1, perPhase = 1, maxPhase = 1, order = [0]}>
+#smem = #ttg.shared_memory
+
+// CHECK-LABEL: wildcard_a_known vs wildcard_a_known: alias=true
+// CHECK: wildcard_a_known vs wildcard_b_incoming: alias=true, lhs_contains_rhs=false, rhs_contains_lhs=false
+// CHECK: wildcard_b_incoming vs wildcard_b_incoming: alias=true, lhs_contains_rhs=false, rhs_contains_lhs=false
+// CHECK: wildcard_a_known case [0, 64]: mask={0}
+// CHECK: wildcard_b_incoming case unknown: mask={0,1}
+// CHECK: state-plan: lanes=2
+module attributes {test.print_state_plan, "ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 1 : i32, ttg.shared = 64 : i32, ttg.target = "cuda:90", ttg.tensor_memory_size = 0 : i32, "ttg.threads-per-warp" = 32 : i32, "ttg.total-num-warps" = 1 : i32} {
+  tt.func public @unknown_descriptor_state_masks(%incoming: !ttg.memdesc<16xi32, #shared, #smem, mutable>) {
+    %known = ttg.local_alloc {allocation.offset = 0 : i32} : () -> !ttg.memdesc<16xi32, #shared, #smem, mutable>
+    %0 = ttg.local_load %known {test.region_name = "wildcard_a_known"} : !ttg.memdesc<16xi32, #shared, #smem, mutable> -> tensor<16xi32>
+    %1 = ttg.local_load %incoming {test.region_name = "wildcard_b_incoming"} : !ttg.memdesc<16xi32, #shared, #smem, mutable> -> tensor<16xi32>
+    tt.return
+  }
+}
+
+// -----
+
+// An unknown-only module still has one state lane and cannot conclude that
+// two external descriptors are disjoint.
+#shared = #ttg.swizzled_shared<{vec = 1, perPhase = 1, maxPhase = 1, order = [0]}>
+#smem = #ttg.shared_memory
+
+// CHECK-LABEL: unknown_only_a_first vs unknown_only_a_first: alias=true
+// CHECK: unknown_only_a_first vs unknown_only_b_second: alias=true, lhs_contains_rhs=false, rhs_contains_lhs=false
+// CHECK: unknown_only_a_first case unknown: mask={0}
+// CHECK: unknown_only_b_second case unknown: mask={0}
+// CHECK: state-plan: lanes=1
+module attributes {test.print_state_plan, "ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 1 : i32, ttg.shared = 64 : i32, ttg.target = "cuda:90", ttg.tensor_memory_size = 0 : i32, "ttg.threads-per-warp" = 32 : i32, "ttg.total-num-warps" = 1 : i32} {
+  tt.func public @unknown_only_descriptor_state_masks(%first: !ttg.memdesc<16xi32, #shared, #smem, mutable>, %second: !ttg.memdesc<16xi32, #shared, #smem, mutable>) {
+    %0 = ttg.local_load %first {test.region_name = "unknown_only_a_first"} : !ttg.memdesc<16xi32, #shared, #smem, mutable> -> tensor<16xi32>
+    %1 = ttg.local_load %second {test.region_name = "unknown_only_b_second"} : !ttg.memdesc<16xi32, #shared, #smem, mutable> -> tensor<16xi32>
+    tt.return
+  }
+}
+
+// -----
+
+// Physical CTA identity separates peer-CTA aliases without duplicating state
+// lanes for the same projected physical bytes.
+#shared = #ttg.swizzled_shared<{vec = 1, perPhase = 1, maxPhase = 1, order = [1, 0], CGALayout = [[1, 0]]}>
+#blocked = #ttg.blocked<{sizePerThread = [1, 1], threadsPerWarp = [1, 32], warpsPerCTA = [1, 4], order = [1, 0], CGALayout = [[1, 0]]}>
+#smem = #ttg.shared_memory
+
+// CHECK-LABEL: cta_state_a_local vs cta_state_a_local: alias=true
+// CHECK: cta_state_a_local vs cta_state_b_remote: alias=false
+// CHECK: cta_state_a_local case {{.*}}: mask={0}
+// CHECK: cta_state_b_remote case {{.*}}: mask={0}
+// CHECK: state-plan: lanes=1
+module attributes {test.print_state_plan, "ttg.num-ctas" = 2 : i32, "ttg.num-warps" = 4 : i32, ttg.shared = 512 : i32, ttg.target = "cuda:90", ttg.tensor_memory_size = 0 : i32, "ttg.threads-per-warp" = 32 : i32, "ttg.total-num-warps" = 4 : i32} {
+  tt.func public @peer_ctas_share_projected_state_lane() {
+    %parent = ttg.local_alloc {allocation.offset = 0 : i32} : () -> !ttg.memdesc<4x32xi32, #shared, #smem, mutable>
+    %local = ttg.memdesc_subslice %parent [0, 0] : !ttg.memdesc<4x32xi32, #shared, #smem, mutable> -> !ttg.memdesc<2x32xi32, #shared, #smem, mutable, 4x32>
+    %remote = ttg.memdesc_subslice %parent [2, 0] : !ttg.memdesc<4x32xi32, #shared, #smem, mutable> -> !ttg.memdesc<2x32xi32, #shared, #smem, mutable, 4x32>
+    %0 = ttg.local_load %local {test.region_name = "cta_state_a_local"} : !ttg.memdesc<2x32xi32, #shared, #smem, mutable, 4x32> -> tensor<2x32xi32, #blocked>
+    %1 = ttg.local_load %remote {test.region_name = "cta_state_b_remote"} : !ttg.memdesc<2x32xi32, #shared, #smem, mutable, 4x32> -> tensor<2x32xi32, #blocked>
+    tt.return
+  }
+}
+
+// -----
+
+// TDM gather and scatter expose the exact shared-memory destination and
+// source in their declared memory effects.
+#shared = #ttg.swizzled_shared<{vec = 1, perPhase = 1, maxPhase = 1, order = [1, 0]}>
+#blocked = #ttg.blocked<{sizePerThread = [1, 1], threadsPerWarp = [4, 8], warpsPerCTA = [4, 1], order = [1, 0]}>
+#idx_parent = #ttg.blocked<{sizePerThread = [1, 16], threadsPerWarp = [32, 1], warpsPerCTA = [1, 4], order = [0, 1]}>
+#smem = #ttg.shared_memory
+
+// CHECK-LABEL: amd_tdm_a_gather vs amd_tdm_a_gather: alias=true
+// CHECK: amd_tdm_a_gather vs amd_tdm_b_scatter: alias=true, lhs_contains_rhs=true, rhs_contains_lhs=true
+// CHECK: amd_tdm_a_gather vs amd_tdm_c_other: alias=false
+// CHECK: amd_tdm_b_scatter vs amd_tdm_c_other: alias=false
+module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.shared = 131072 : i32, ttg.target = "hip:gfx1250", "ttg.threads-per-warp" = 32 : i32, "ttg.total-num-warps" = 4 : i32} {
+  tt.func public @amd_tdm_gather_scatter_shared_alias(%desc: !tt.tensordesc<64x128xf16>, %rows: tensor<64xi32, #ttg.slice<{dim = 0, parent = #idx_parent}>>) {
+    %buffer = ttg.local_alloc {allocation.offset = 0 : i32} : () -> !ttg.memdesc<256x128xf16, #shared, #smem, mutable>
+    %other = ttg.local_alloc {allocation.offset = 65536 : i32} : () -> !ttg.memdesc<256x128xf16, #shared, #smem, mutable>
+    %gather = amdg.async_tdm_gather %desc[%rows] to %buffer {test.region_name = "amd_tdm_a_gather"} : tensor<64xi32, #ttg.slice<{dim = 0, parent = #idx_parent}>>, !ttg.memdesc<256x128xf16, #shared, #smem, mutable> -> !tt.tensordesc<64x128xf16>
+    %scatter = amdg.async_tdm_scatter %desc[%rows] from %buffer {test.region_name = "amd_tdm_b_scatter"} : tensor<64xi32, #ttg.slice<{dim = 0, parent = #idx_parent}>>, !ttg.memdesc<256x128xf16, #shared, #smem, mutable> -> !tt.tensordesc<64x128xf16>
+    %value = ttg.local_load %other {test.region_name = "amd_tdm_c_other"} : !ttg.memdesc<256x128xf16, #shared, #smem, mutable> -> tensor<256x128xf16, #blocked>
     tt.return
   }
 }

--- a/test/Analysis/test-buffer-region-layout-alias.mlir
+++ b/test/Analysis/test-buffer-region-layout-alias.mlir
@@ -231,3 +231,315 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 1 : i32, ttg.shar
     tt.return
   }
 }
+
+// -----
+
+// A partitioned allocation owns every physical base, not the interval starting
+// at its first base. Subviews select a physical partition and remain exact
+// through nested views and runtime selection.
+#inner = #ttg.swizzled_shared<{vec = 1, perPhase = 1, maxPhase = 1, order = [1, 0]}>
+#partitioned = #ttg.partitioned_shared<{numPartitions = 2, numGroups = 2, partitionDim = 0, partitionLayout = #inner}>
+#smem = #ttg.shared_memory
+
+// CHECK-LABEL: partition_a_parent vs partition_a_parent: alias=true, lhs_contains_rhs=true, rhs_contains_lhs=true
+// CHECK: partition_a_parent vs partition_b_first: alias=true, lhs_contains_rhs=true, rhs_contains_lhs=false
+// CHECK: partition_a_parent vs partition_c_second: alias=true, lhs_contains_rhs=true, rhs_contains_lhs=false
+// CHECK: partition_a_parent vs partition_d_first_base: alias=true
+// CHECK: partition_a_parent vs partition_e_second_base: alias=true
+// CHECK: partition_a_parent vs partition_g_nested: alias=true
+// CHECK: partition_a_parent vs partition_h_nested_base: alias=true
+// CHECK: partition_b_first vs partition_c_second: alias=false
+// CHECK: partition_b_first vs partition_d_first_base: alias=true, lhs_contains_rhs=true, rhs_contains_lhs=true
+// CHECK: partition_b_first vs partition_e_second_base: alias=false
+// CHECK: partition_b_first vs partition_f_selected: alias=true
+// CHECK: partition_c_second vs partition_d_first_base: alias=false
+// CHECK: partition_c_second vs partition_e_second_base: alias=true, lhs_contains_rhs=true, rhs_contains_lhs=true
+// CHECK: partition_c_second vs partition_f_selected: alias=true
+// CHECK: partition_c_second vs partition_g_nested: alias=false
+// CHECK: partition_d_first_base vs partition_e_second_base: alias=false
+// CHECK: partition_g_nested vs partition_h_nested_base: alias=true, lhs_contains_rhs=true, rhs_contains_lhs=true
+// CHECK: partition_a_parent case [0, 512]: mask={0,1,2,3}
+// CHECK: partition_b_first case [0, 256]: mask={0}
+// CHECK: partition_c_second case [2048, 256]: mask={2}
+// CHECK: partition_d_first_base case [0, 128]: mask={0}
+// CHECK: partition_e_second_base case [2048, 128]: mask={2}
+// CHECK: partition_f_selected case [0, 256]: mask={0}
+// CHECK: partition_f_selected case [2048, 256]: mask={2}
+// CHECK: partition_g_nested case [2176, 256]: mask={3}
+// CHECK: partition_h_nested_base case [2176, 128]: mask={3}
+// CHECK: state-plan: lanes=4
+module attributes {test.print_state_plan, "ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 2 : i32, ttg.shared = 4096 : i32, ttg.target = "hip:gfx1250", "ttg.threads-per-warp" = 32 : i32, "ttg.total-num-warps" = 2 : i32} {
+  tt.func public @partitioned_shared_physical_alias(%choose: i1) {
+    %parent = ttg.local_alloc {allocation.offset = [0 : i32, 2048 : i32]} : () -> !ttg.memdesc<16x16xf16, #partitioned, #smem, mutable>
+    %first = ttg.memdesc_subslice %parent [0, 0] : !ttg.memdesc<16x16xf16, #partitioned, #smem, mutable> -> !ttg.memdesc<4x16xf16, #partitioned, #smem, mutable, 16x16>
+    %second = ttg.memdesc_subslice %parent [4, 0] : !ttg.memdesc<16x16xf16, #partitioned, #smem, mutable> -> !ttg.memdesc<4x16xf16, #partitioned, #smem, mutable, 16x16>
+    %outer = ttg.memdesc_subslice %parent [8, 0] : !ttg.memdesc<16x16xf16, #partitioned, #smem, mutable> -> !ttg.memdesc<8x16xf16, #partitioned, #smem, mutable, 16x16>
+    %nested = ttg.memdesc_subslice %outer [4, 0] : !ttg.memdesc<8x16xf16, #partitioned, #smem, mutable, 16x16> -> !ttg.memdesc<4x16xf16, #partitioned, #smem, mutable, 16x16>
+    %selected = arith.select %choose, %first, %second : !ttg.memdesc<4x16xf16, #partitioned, #smem, mutable, 16x16>
+    %first_base = ttg.local_alloc {allocation.offset = 0 : i32} : () -> !ttg.memdesc<4x16xf16, #inner, #smem, mutable>
+    %second_base = ttg.local_alloc {allocation.offset = 2048 : i32} : () -> !ttg.memdesc<4x16xf16, #inner, #smem, mutable>
+    %nested_base = ttg.local_alloc {allocation.offset = 2176 : i32} : () -> !ttg.memdesc<4x16xf16, #inner, #smem, mutable>
+    %0 = ttg.local_load %parent {test.region_name = "partition_a_parent"} : !ttg.memdesc<16x16xf16, #partitioned, #smem, mutable> -> tensor<16x16xf16>
+    %1 = ttg.local_load %first {test.region_name = "partition_b_first"} : !ttg.memdesc<4x16xf16, #partitioned, #smem, mutable, 16x16> -> tensor<4x16xf16>
+    %2 = ttg.local_load %second {test.region_name = "partition_c_second"} : !ttg.memdesc<4x16xf16, #partitioned, #smem, mutable, 16x16> -> tensor<4x16xf16>
+    %3 = ttg.local_load %first_base {test.region_name = "partition_d_first_base"} : !ttg.memdesc<4x16xf16, #inner, #smem, mutable> -> tensor<4x16xf16>
+    %4 = ttg.local_load %second_base {test.region_name = "partition_e_second_base"} : !ttg.memdesc<4x16xf16, #inner, #smem, mutable> -> tensor<4x16xf16>
+    %5 = ttg.local_load %selected {test.region_name = "partition_f_selected"} : !ttg.memdesc<4x16xf16, #partitioned, #smem, mutable, 16x16> -> tensor<4x16xf16>
+    %6 = ttg.local_load %nested {test.region_name = "partition_g_nested"} : !ttg.memdesc<4x16xf16, #partitioned, #smem, mutable, 16x16> -> tensor<4x16xf16>
+    %7 = ttg.local_load %nested_base {test.region_name = "partition_h_nested_base"} : !ttg.memdesc<4x16xf16, #inner, #smem, mutable> -> tensor<4x16xf16>
+    tt.return
+  }
+}
+
+// -----
+
+// Padding is local to each physical partition; a gap between partition bases
+// cannot be mistaken for part of either padded piece.
+#piece_padded = #ttg.padded_shared<[128:+4] {order = [1, 0], shape = [4, 16]}>
+#partitioned = #ttg.partitioned_shared<{numPartitions = 2, numGroups = 2, partitionDim = 0, partitionLayout = #piece_padded}>
+#smem = #ttg.shared_memory
+
+// CHECK-LABEL: padded_partition_a_parent vs padded_partition_a_parent: alias=true
+// CHECK: padded_partition_a_parent vs padded_partition_b_first: alias=true
+// CHECK: padded_partition_a_parent vs padded_partition_c_second: alias=true
+// CHECK: padded_partition_b_first vs padded_partition_c_second: alias=false
+// CHECK: padded_partition_b_first vs padded_partition_d_first_base: alias=true
+// CHECK: padded_partition_b_first vs padded_partition_e_second_base: alias=false
+// CHECK: padded_partition_c_second vs padded_partition_d_first_base: alias=false
+// CHECK: padded_partition_c_second vs padded_partition_e_second_base: alias=true
+module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 2 : i32, ttg.shared = 4096 : i32, ttg.target = "hip:gfx1250", "ttg.threads-per-warp" = 32 : i32, "ttg.total-num-warps" = 2 : i32} {
+  tt.func public @partitioned_padded_physical_alias() {
+    %parent = ttg.local_alloc {allocation.offset = [0 : i32, 2048 : i32]} : () -> !ttg.memdesc<16x16xf16, #partitioned, #smem, mutable>
+    %first = ttg.memdesc_subslice %parent [0, 0] : !ttg.memdesc<16x16xf16, #partitioned, #smem, mutable> -> !ttg.memdesc<4x16xf16, #partitioned, #smem, mutable, 16x16>
+    %second = ttg.memdesc_subslice %parent [4, 0] : !ttg.memdesc<16x16xf16, #partitioned, #smem, mutable> -> !ttg.memdesc<4x16xf16, #partitioned, #smem, mutable, 16x16>
+    %first_base = ttg.local_alloc {allocation.offset = 0 : i32} : () -> !ttg.memdesc<4x16xf16, #piece_padded, #smem, mutable>
+    %second_base = ttg.local_alloc {allocation.offset = 2048 : i32} : () -> !ttg.memdesc<4x16xf16, #piece_padded, #smem, mutable>
+    %0 = ttg.local_load %parent {test.region_name = "padded_partition_a_parent"} : !ttg.memdesc<16x16xf16, #partitioned, #smem, mutable> -> tensor<16x16xf16>
+    %1 = ttg.local_load %first {test.region_name = "padded_partition_b_first"} : !ttg.memdesc<4x16xf16, #partitioned, #smem, mutable, 16x16> -> tensor<4x16xf16>
+    %2 = ttg.local_load %second {test.region_name = "padded_partition_c_second"} : !ttg.memdesc<4x16xf16, #partitioned, #smem, mutable, 16x16> -> tensor<4x16xf16>
+    %3 = ttg.local_load %first_base {test.region_name = "padded_partition_d_first_base"} : !ttg.memdesc<4x16xf16, #piece_padded, #smem, mutable> -> tensor<4x16xf16>
+    %4 = ttg.local_load %second_base {test.region_name = "padded_partition_e_second_base"} : !ttg.memdesc<4x16xf16, #piece_padded, #smem, mutable> -> tensor<4x16xf16>
+    tt.return
+  }
+}
+
+// -----
+
+// Advancing a pipeline stage advances every physical partition base. A dynamic
+// stage aliases each possible static stage without making the stages overlap.
+#inner = #ttg.swizzled_shared<{vec = 1, perPhase = 1, maxPhase = 1, order = [1, 0]}>
+#partitioned = #ttg.partitioned_shared<{numPartitions = 2, numGroups = 2, partitionDim = 0, partitionLayout = #inner}>
+#smem = #ttg.shared_memory
+
+// CHECK-LABEL: stage_partition_a_first vs stage_partition_a_first: alias=true
+// CHECK: stage_partition_a_first vs stage_partition_b_second: alias=false
+// CHECK: stage_partition_a_first vs stage_partition_c_dynamic: alias=true
+// CHECK: stage_partition_a_first vs stage_partition_d_second_first: alias=false
+// CHECK: stage_partition_b_second vs stage_partition_c_dynamic: alias=true
+// CHECK: stage_partition_b_second vs stage_partition_d_second_first: alias=true
+// CHECK: stage_partition_b_second vs stage_partition_e_second_peer: alias=true
+// CHECK: stage_partition_d_second_first vs stage_partition_e_second_peer: alias=false
+module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 2 : i32, ttg.shared = 4096 : i32, ttg.target = "hip:gfx1250", "ttg.threads-per-warp" = 32 : i32, "ttg.total-num-warps" = 2 : i32} {
+  tt.func public @partitioned_multibuffer_physical_alias(%index: i32) {
+    %c0 = arith.constant 0 : i32
+    %c1 = arith.constant 1 : i32
+    %parent = ttg.local_alloc {allocation.offset = [0 : i32, 2048 : i32]} : () -> !ttg.memdesc<3x16x16xf16, #partitioned, #smem, mutable>
+    %first = ttg.memdesc_index %parent[%c0] : !ttg.memdesc<3x16x16xf16, #partitioned, #smem, mutable> -> !ttg.memdesc<16x16xf16, #partitioned, #smem, mutable>
+    %second = ttg.memdesc_index %parent[%c1] : !ttg.memdesc<3x16x16xf16, #partitioned, #smem, mutable> -> !ttg.memdesc<16x16xf16, #partitioned, #smem, mutable>
+    %dynamic = ttg.memdesc_index %parent[%index] : !ttg.memdesc<3x16x16xf16, #partitioned, #smem, mutable> -> !ttg.memdesc<16x16xf16, #partitioned, #smem, mutable>
+    %second_first = ttg.memdesc_subslice %second [0, 0] : !ttg.memdesc<16x16xf16, #partitioned, #smem, mutable> -> !ttg.memdesc<4x16xf16, #partitioned, #smem, mutable, 16x16>
+    %second_peer = ttg.memdesc_subslice %second [4, 0] : !ttg.memdesc<16x16xf16, #partitioned, #smem, mutable> -> !ttg.memdesc<4x16xf16, #partitioned, #smem, mutable, 16x16>
+    %0 = ttg.local_load %first {test.region_name = "stage_partition_a_first"} : !ttg.memdesc<16x16xf16, #partitioned, #smem, mutable> -> tensor<16x16xf16>
+    %1 = ttg.local_load %second {test.region_name = "stage_partition_b_second"} : !ttg.memdesc<16x16xf16, #partitioned, #smem, mutable> -> tensor<16x16xf16>
+    %2 = ttg.local_load %dynamic {test.region_name = "stage_partition_c_dynamic"} : !ttg.memdesc<16x16xf16, #partitioned, #smem, mutable> -> tensor<16x16xf16>
+    %3 = ttg.local_load %second_first {test.region_name = "stage_partition_d_second_first"} : !ttg.memdesc<4x16xf16, #partitioned, #smem, mutable, 16x16> -> tensor<4x16xf16>
+    %4 = ttg.local_load %second_peer {test.region_name = "stage_partition_e_second_peer"} : !ttg.memdesc<4x16xf16, #partitioned, #smem, mutable, 16x16> -> tensor<4x16xf16>
+    tt.return
+  }
+}
+
+// -----
+
+// A valid shared-linear layout can interleave CTA ownership within one
+// descriptor instead of expressing the CTA as a single affine view offset.
+#shared = #ttg.shared_linear<{offset = [[0, 1], [0, 2], [1, 0], [4, 0]], block = [[2, 0]]}, alignment = 16>
+#smem = #ttg.shared_memory
+
+// CHECK-LABEL: cta_block_a_parent vs cta_block_a_parent: alias=true
+// CHECK: cta_block_a_parent vs cta_block_b_lower: alias=true
+// CHECK: cta_block_a_parent vs cta_block_c_upper: alias=true
+// CHECK: cta_block_b_lower vs cta_block_c_upper: alias=false
+module attributes {"ttg.num-ctas" = 2 : i32, "ttg.num-warps" = 1 : i32, ttg.shared = 128 : i32, ttg.target = "cuda:90", ttg.tensor_memory_size = 0 : i32, "ttg.threads-per-warp" = 32 : i32, "ttg.total-num-warps" = 1 : i32} {
+  tt.func public @cross_cta_interleaved_linear_footprint() {
+    %parent = ttg.local_alloc {allocation.offset = 0 : i32} : () -> !ttg.memdesc<8x4xf32, #shared, #smem, mutable>
+    %lower = ttg.memdesc_subslice %parent [0, 0] : !ttg.memdesc<8x4xf32, #shared, #smem, mutable> -> !ttg.memdesc<4x4xf32, #shared, #smem, mutable, 8x4>
+    %upper = ttg.memdesc_subslice %parent [4, 0] : !ttg.memdesc<8x4xf32, #shared, #smem, mutable> -> !ttg.memdesc<4x4xf32, #shared, #smem, mutable, 8x4>
+    %0 = ttg.local_load %parent {test.region_name = "cta_block_a_parent"} : !ttg.memdesc<8x4xf32, #shared, #smem, mutable> -> tensor<8x4xf32>
+    %1 = ttg.local_load %lower {test.region_name = "cta_block_b_lower"} : !ttg.memdesc<4x4xf32, #shared, #smem, mutable, 8x4> -> tensor<4x4xf32>
+    %2 = ttg.local_load %upper {test.region_name = "cta_block_c_upper"} : !ttg.memdesc<4x4xf32, #shared, #smem, mutable, 8x4> -> tensor<4x4xf32>
+    tt.return
+  }
+}
+
+// -----
+
+// Peer-CTA views can share local byte offsets while selecting different
+// recipient CTAs. Runtime selection must preserve both candidates.
+#shared = #ttg.swizzled_shared<{vec = 1, perPhase = 1, maxPhase = 1, order = [1, 0], CGALayout = [[1, 0]]}>
+#blocked_sharded = #ttg.blocked<{sizePerThread = [1, 1], threadsPerWarp = [1, 32], warpsPerCTA = [1, 4], order = [1, 0], CGALayout = [[1, 0]]}>
+#smem = #ttg.shared_memory
+
+// CHECK-LABEL: cta_affine_a_parent vs cta_affine_a_parent: alias=true
+// CHECK: cta_affine_a_parent vs cta_affine_b_local: alias=true
+// CHECK: cta_affine_a_parent vs cta_affine_c_remote: alias=true
+// CHECK: cta_affine_a_parent vs cta_affine_d_disjoint: alias=false
+// CHECK: cta_affine_a_parent vs cta_affine_e_selected: alias=true
+// CHECK: cta_affine_b_local vs cta_affine_d_disjoint: alias=false
+// CHECK: cta_affine_c_remote vs cta_affine_d_disjoint: alias=false
+// CHECK: cta_affine_d_disjoint vs cta_affine_e_selected: alias=false
+module attributes {"ttg.num-ctas" = 2 : i32, "ttg.num-warps" = 4 : i32, ttg.shared = 1024 : i32, ttg.target = "cuda:90", ttg.tensor_memory_size = 0 : i32, "ttg.threads-per-warp" = 32 : i32, "ttg.total-num-warps" = 4 : i32} {
+  tt.func public @cross_cta_affine_physical_alias(%choose: i1) {
+    %parent = ttg.local_alloc {allocation.offset = 0 : i32} : () -> !ttg.memdesc<4x32xi32, #shared, #smem, mutable>
+    %local = ttg.memdesc_subslice %parent [0, 0] : !ttg.memdesc<4x32xi32, #shared, #smem, mutable> -> !ttg.memdesc<2x32xi32, #shared, #smem, mutable, 4x32>
+    %remote = ttg.memdesc_subslice %parent [2, 0] : !ttg.memdesc<4x32xi32, #shared, #smem, mutable> -> !ttg.memdesc<2x32xi32, #shared, #smem, mutable, 4x32>
+    %selected = arith.select %choose, %local, %remote : !ttg.memdesc<2x32xi32, #shared, #smem, mutable, 4x32>
+    %disjoint = ttg.local_alloc {allocation.offset = 256 : i32} : () -> !ttg.memdesc<2x32xi32, #shared, #smem, mutable>
+    %0 = ttg.local_load %parent {test.region_name = "cta_affine_a_parent"} : !ttg.memdesc<4x32xi32, #shared, #smem, mutable> -> tensor<4x32xi32, #blocked_sharded>
+    %1 = ttg.local_load %local {test.region_name = "cta_affine_b_local"} : !ttg.memdesc<2x32xi32, #shared, #smem, mutable, 4x32> -> tensor<2x32xi32, #blocked_sharded>
+    %2 = ttg.local_load %remote {test.region_name = "cta_affine_c_remote"} : !ttg.memdesc<2x32xi32, #shared, #smem, mutable, 4x32> -> tensor<2x32xi32, #blocked_sharded>
+    %3 = ttg.local_load %disjoint {test.region_name = "cta_affine_d_disjoint"} : !ttg.memdesc<2x32xi32, #shared, #smem, mutable> -> tensor<2x32xi32, #blocked_sharded>
+    %4 = ttg.local_load %selected {test.region_name = "cta_affine_e_selected"} : !ttg.memdesc<2x32xi32, #shared, #smem, mutable, 4x32> -> tensor<2x32xi32, #blocked_sharded>
+    tt.return
+  }
+}
+
+// -----
+
+// An externally supplied descriptor is unknown, not an empty physical region.
+// It may alias an in-function allocation and certainly aliases itself.
+#shared = #ttg.swizzled_shared<{vec = 1, perPhase = 1, maxPhase = 1, order = [0]}>
+#smem = #ttg.shared_memory
+
+// CHECK-LABEL: unknown_a_known vs unknown_a_known: alias=true
+// CHECK: unknown_a_known vs unknown_b_external: alias=true
+// CHECK: unknown_b_external vs unknown_b_external: alias=true
+module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 1 : i32, ttg.shared = 64 : i32, ttg.target = "cuda:90", ttg.tensor_memory_size = 0 : i32, "ttg.threads-per-warp" = 32 : i32, "ttg.total-num-warps" = 1 : i32} {
+  tt.func public @external_memdesc_is_unknown(%incoming: !ttg.memdesc<16xi32, #shared, #smem, mutable>) {
+    %known = ttg.local_alloc {allocation.offset = 0 : i32} : () -> !ttg.memdesc<16xi32, #shared, #smem, mutable>
+    %0 = ttg.local_load %known {test.region_name = "unknown_a_known"} : !ttg.memdesc<16xi32, #shared, #smem, mutable> -> tensor<16xi32>
+    %1 = ttg.local_load %incoming {test.region_name = "unknown_b_external"} : !ttg.memdesc<16xi32, #shared, #smem, mutable> -> tensor<16xi32>
+    tt.return
+  }
+}
+
+// -----
+
+// Extracting a runtime descriptor address is pure and must not be rejected as
+// an unaccounted-for memory access.
+#shared = #ttg.swizzled_shared<{vec = 1, perPhase = 1, maxPhase = 1, order = [0]}>
+#smem = #ttg.shared_memory
+
+// CHECK-LABEL: pure_a_descriptor vs pure_a_descriptor: alias=true
+// CHECK: pure_a_descriptor vs pure_b_load: alias=true
+module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 1 : i32, ttg.shared = 64 : i32, ttg.target = "cuda:90", ttg.tensor_memory_size = 0 : i32, "ttg.threads-per-warp" = 32 : i32, "ttg.total-num-warps" = 1 : i32} {
+  tt.func public @pure_memdesc_address_is_supported() {
+    %buffer = ttg.local_alloc {allocation.offset = 0 : i32} : () -> !ttg.memdesc<16xi32, #shared, #smem, mutable>
+    %address = tti.experimental_memdesc_to_i32 %buffer {test.region_name = "pure_a_descriptor"} : !ttg.memdesc<16xi32, #shared, #smem, mutable>
+    %value = ttg.local_load %buffer {test.region_name = "pure_b_load"} : !ttg.memdesc<16xi32, #shared, #smem, mutable> -> tensor<16xi32>
+    tt.return
+  }
+}
+
+// -----
+
+// Deallocation consumes a descriptor but is a free, not an unsupported read
+// or write.
+#shared = #ttg.swizzled_shared<{vec = 1, perPhase = 1, maxPhase = 1, order = [0]}>
+#smem = #ttg.shared_memory
+
+// CHECK-LABEL: deallocation_a_load vs deallocation_a_load: alias=true
+// CHECK: deallocation_a_load vs deallocation_b_free: alias=true
+module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 1 : i32, ttg.shared = 64 : i32, ttg.target = "cuda:90", ttg.tensor_memory_size = 0 : i32, "ttg.threads-per-warp" = 32 : i32, "ttg.total-num-warps" = 1 : i32} {
+  tt.func public @local_deallocation_is_supported() {
+    %buffer = ttg.local_alloc {allocation.offset = 0 : i32} : () -> !ttg.memdesc<16xi32, #shared, #smem, mutable>
+    %value = ttg.local_load %buffer {test.region_name = "deallocation_a_load"} : !ttg.memdesc<16xi32, #shared, #smem, mutable> -> tensor<16xi32>
+    ttg.local_dealloc %buffer {test.region_name = "deallocation_b_free"} : !ttg.memdesc<16xi32, #shared, #smem, mutable>
+    tt.return
+  }
+}
+
+// -----
+
+// AMD direct-to-LDS buffer loads have an explicit shared-memory write effect.
+#blocked = #ttg.blocked<{sizePerThread = [1, 1], threadsPerWarp = [1, 64], warpsPerCTA = [4, 1], order = [1, 0]}>
+#shared = #ttg.swizzled_shared<{vec = 1, perPhase = 1, maxPhase = 1, order = [1, 0]}>
+#smem = #ttg.shared_memory
+
+// CHECK-LABEL: amd_direct_a_buffer_load vs amd_direct_a_buffer_load: alias=true
+// CHECK: amd_direct_a_buffer_load vs amd_direct_b_local_load: alias=true
+module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.shared = 8192 : i32, ttg.target = "hip:gfx950", "ttg.threads-per-warp" = 64 : i32, "ttg.total-num-warps" = 4 : i32} {
+  tt.func public @amd_buffer_load_to_local_alias(%ptr: !tt.ptr<f32>, %offsets: tensor<32x64xi32, #blocked>) {
+    %buffer = ttg.local_alloc {allocation.offset = 0 : i32} : () -> !ttg.memdesc<32x64xf32, #shared, #smem, mutable>
+    %token = amdg.buffer_load_to_local %ptr[%offsets] into %buffer {test.region_name = "amd_direct_a_buffer_load"} : <f32>[tensor<32x64xi32, #blocked>] -> <32x64xf32, #shared, #smem, mutable>
+    %value = ttg.local_load %buffer {test.region_name = "amd_direct_b_local_load"} : !ttg.memdesc<32x64xf32, #shared, #smem, mutable> -> tensor<32x64xf32, #blocked>
+    tt.return
+  }
+}
+
+// -----
+
+// AMD packed, transposed LDS loads read the same physical bytes as an ordinary
+// local load even though their result shape and layout differ.
+#mma = #ttg.amd_mfma<{version = 4, warpsPerCTA = [2, 2], instrShape = [32, 32, 16], isTransposed = true}>
+#shared = #ttg.swizzled_shared<{vec = 1, perPhase = 1, maxPhase = 1, order = [0, 1]}>
+#smem = #ttg.shared_memory
+
+// CHECK-LABEL: amd_packed_a_transposed vs amd_packed_a_transposed: alias=true
+// CHECK: amd_packed_a_transposed vs amd_packed_b_local_load: alias=true
+module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.shared = 1024 : i32, ttg.target = "hip:gfx950", "ttg.threads-per-warp" = 64 : i32, "ttg.total-num-warps" = 4 : i32} {
+  tt.func public @amd_packed_transposed_local_load_alias() {
+    %buffer = ttg.local_alloc {allocation.offset = 0 : i32} : () -> !ttg.memdesc<16x64xi8, #shared, #smem, mutable>
+    %packed = amdg.local_load_packed_tranposed %buffer {test.region_name = "amd_packed_a_transposed"} : !ttg.memdesc<16x64xi8, #shared, #smem, mutable> -> tensor<32x32xi8, #ttg.dot_op<{opIdx = 0, parent = #mma, kWidth = 16}>>
+    %plain = ttg.local_load %buffer {test.region_name = "amd_packed_b_local_load"} : !ttg.memdesc<16x64xi8, #shared, #smem, mutable> -> tensor<16x64xi8>
+    tt.return
+  }
+}
+
+// -----
+
+// AMD asynchronous LDS-to-global copies read their source descriptor.
+#blocked = #ttg.blocked<{sizePerThread = [1, 1], threadsPerWarp = [4, 8], warpsPerCTA = [4, 1], order = [1, 0]}>
+#shared = #ttg.swizzled_shared<{vec = 1, perPhase = 1, maxPhase = 1, order = [1, 0]}>
+#smem = #ttg.shared_memory
+
+// CHECK-LABEL: amd_store_a_async_copy vs amd_store_a_async_copy: alias=true
+// CHECK: amd_store_a_async_copy vs amd_store_b_local_load: alias=true
+module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.shared = 4096 : i32, ttg.target = "hip:gfx1250", "ttg.threads-per-warp" = 32 : i32, "ttg.total-num-warps" = 4 : i32} {
+  tt.func public @amd_async_copy_local_to_global_alias(%dst: tensor<32x32x!tt.ptr<f32>, #blocked>) {
+    %buffer = ttg.local_alloc {allocation.offset = 0 : i32} : () -> !ttg.memdesc<32x32xf32, #shared, #smem, mutable>
+    %token = amdg.async_copy_local_to_global %buffer, %dst {test.region_name = "amd_store_a_async_copy"} : !ttg.memdesc<32x32xf32, #shared, #smem, mutable> -> tensor<32x32x!tt.ptr<f32>, #blocked>
+    %value = ttg.local_load %buffer {test.region_name = "amd_store_b_local_load"} : !ttg.memdesc<32x32xf32, #shared, #smem, mutable> -> tensor<32x32xf32, #blocked>
+    tt.return
+  }
+}
+
+// -----
+
+// A fused TDM load writes every variadic destination, not just the first one.
+#blocked = #ttg.blocked<{sizePerThread = [1, 1], threadsPerWarp = [4, 8], warpsPerCTA = [4, 1], order = [1, 0]}>
+#shared = #ttg.swizzled_shared<{vec = 1, perPhase = 1, maxPhase = 1, order = [1, 0]}>
+#smem = #ttg.shared_memory
+
+// CHECK-LABEL: amd_fused_a_first vs amd_fused_a_first: alias=true
+// CHECK: amd_fused_a_first vs amd_fused_b_second: alias=false
+// CHECK: amd_fused_b_second vs amd_fused_b_second: alias=true
+module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.shared = 16384 : i32, ttg.target = "hip:gfx1250", "ttg.threads-per-warp" = 32 : i32, "ttg.total-num-warps" = 4 : i32} {
+  tt.func public @amd_fused_tdm_variadic_destination_alias(%desc0: !tt.tensordesc<64x64xf16, #shared>, %desc1: !tt.tensordesc<64x64xf16, #shared>) {
+    %first = ttg.local_alloc {allocation.offset = 0 : i32} : () -> !ttg.memdesc<64x64xf16, #shared, #smem, mutable>
+    %second = ttg.local_alloc {allocation.offset = 8192 : i32} : () -> !ttg.memdesc<64x64xf16, #shared, #smem, mutable>
+    %token = amdg.async_tdm_fused_copy_global_to_local %desc0, %desc1 into %first, %second {warp_used_hints = array<i32: 3, 12>} : !tt.tensordesc<64x64xf16, #shared>, !tt.tensordesc<64x64xf16, #shared> -> !ttg.memdesc<64x64xf16, #shared, #smem, mutable>, !ttg.memdesc<64x64xf16, #shared, #smem, mutable>
+    %first_value = ttg.local_load %first {test.region_name = "amd_fused_a_first"} : !ttg.memdesc<64x64xf16, #shared, #smem, mutable> -> tensor<64x64xf16, #blocked>
+    %second_value = ttg.local_load %second {test.region_name = "amd_fused_b_second"} : !ttg.memdesc<64x64xf16, #shared, #smem, mutable> -> tensor<64x64xf16, #blocked>
+    tt.return
+  }
+}

--- a/test/Analysis/test-buffer-region.mlir
+++ b/test/Analysis/test-buffer-region.mlir
@@ -547,12 +547,11 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 1 : i32, ttg.shar
   ^no_alloc(%arg_in: !ttg.memdesc<32x32xf32, #shared, #smem, mutable>):
     cf.br ^merge(%arg_in : !ttg.memdesc<32x32xf32, #shared, #smem, mutable>)
   ^merge(%phi: !ttg.memdesc<32x32xf32, #shared, #smem, mutable>):
-    // expected-remark @below {{Buffers: [36864, 4096]}}
+    // expected-remark @below {{Buffers: unknown}}
     ttg.local_load %phi : !ttg.memdesc<32x32xf32, #shared, #smem, mutable> -> tensor<32x32xf32, #blocked>
     tt.return
   }
 
-  // expected-remark @below {{All Shared Regions: [36864, 4096]}}
   tt.func private @print_all_regions() attributes {test.print_all_used_regions} {
     tt.return
   }

--- a/test/TritonGPU/amd/amd-consan.mlir
+++ b/test/TritonGPU/amd/amd-consan.mlir
@@ -1052,3 +1052,156 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.shar
     tt.return
   }
 }
+
+// -----
+
+// Direct-to-LDS buffer loads participate in ordinary asynchronous-copy
+// commit groups instead of being treated as synchronous shared-memory writes.
+#blocked = #ttg.blocked<{sizePerThread = [1, 1], threadsPerWarp = [1, 64], warpsPerCTA = [4, 1], order = [1, 0]}>
+#shared = #ttg.swizzled_shared<{vec = 1, perPhase = 1, maxPhase = 1, order = [1, 0]}>
+#smem = #ttg.shared_memory
+
+module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.shared = 8192 : i32, ttg.target = "hip:gfx950", "ttg.threads-per-warp" = 64 : i32, "ttg.total-num-warps" = 4 : i32} {
+  // CHECK-LABEL: @buffer_load_to_local_tracks_async_commit
+  tt.func public @buffer_load_to_local_tracks_async_commit(%ptr: !tt.ptr<f32>, %offsets: tensor<32x64xi32, #blocked>) {
+    %buffer = ttg.local_alloc {allocation.offset = 0 : i32} : () -> !ttg.memdesc<32x64xf32, #shared, #smem, mutable>
+    // CHECK: tt.call @__triton_consan_verify_write_visibility
+    // CHECK: tt.call @__triton_consan_verify_read_visibility
+    // CHECK: tt.call @__triton_consan_stage_access_for_commit
+    // CHECK: amdg.buffer_load_to_local
+    %token = amdg.buffer_load_to_local %ptr[%offsets] into %buffer : <f32>[tensor<32x64xi32, #blocked>] -> <32x64xf32, #shared, #smem, mutable>
+    // CHECK: tt.call @__triton_consan_commit_accesses
+    // CHECK: ttg.async_commit_group
+    %group = ttg.async_commit_group tokens %token
+    // CHECK: tt.call @__triton_consan_clear_outstanding_commits_transfer_writes
+    // CHECK: ttg.async_wait
+    %wait = ttg.async_wait %group {num = 0 : i32}
+    tt.return
+  }
+}
+
+// -----
+
+// Packed transposed LDS loads receive the synchronous read instrumentation
+// described by their declared memory effects.
+#mma = #ttg.amd_mfma<{version = 4, warpsPerCTA = [2, 2], instrShape = [32, 32, 16], isTransposed = true}>
+#shared = #ttg.swizzled_shared<{vec = 1, perPhase = 1, maxPhase = 1, order = [0, 1]}>
+#smem = #ttg.shared_memory
+
+module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.shared = 1024 : i32, ttg.target = "hip:gfx950", "ttg.threads-per-warp" = 64 : i32, "ttg.total-num-warps" = 4 : i32} {
+  // CHECK-LABEL: @packed_transposed_load_tracks_read
+  tt.func public @packed_transposed_load_tracks_read() {
+    %buffer = ttg.local_alloc {allocation.offset = 0 : i32} : () -> !ttg.memdesc<16x64xi8, #shared, #smem, mutable>
+    // CHECK: tt.call @__triton_consan_verify_write_visibility
+    // CHECK: tt.call @__triton_consan_set_read_visibility
+    // CHECK: amdg.local_load_packed_tranposed
+    %value = amdg.local_load_packed_tranposed %buffer : !ttg.memdesc<16x64xi8, #shared, #smem, mutable> -> tensor<32x32xi8, #ttg.dot_op<{opIdx = 0, parent = #mma, kWidth = 16}>>
+    tt.return
+  }
+}
+
+// -----
+
+// An asynchronous LDS-to-global store is an outstanding shared-memory read;
+// a following write must check it and the native wait must publish both sides.
+#blocked = #ttg.blocked<{sizePerThread = [1, 1], threadsPerWarp = [4, 8], warpsPerCTA = [4, 1], order = [1, 0]}>
+#shared = #ttg.swizzled_shared<{vec = 1, perPhase = 1, maxPhase = 1, order = [1, 0]}>
+#smem = #ttg.shared_memory
+
+module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.shared = 4096 : i32, ttg.target = "hip:gfx1250", "ttg.threads-per-warp" = 32 : i32, "ttg.total-num-warps" = 4 : i32} {
+  // CHECK-LABEL: @async_copy_local_to_global_tracks_reads
+  tt.func public @async_copy_local_to_global_tracks_reads(%dst: tensor<32x32x!tt.ptr<f32>, #blocked>, %value: tensor<32x32xf32, #blocked>) {
+    %buffer = ttg.local_alloc {allocation.offset = 0 : i32} : () -> !ttg.memdesc<32x32xf32, #shared, #smem, mutable>
+    // CHECK: tt.call @__triton_consan_verify_write_visibility
+    // CHECK: tt.call @__triton_consan_stage_access_for_commit
+    // CHECK: amdg.async_copy_local_to_global
+    %token = amdg.async_copy_local_to_global %buffer, %dst : !ttg.memdesc<32x32xf32, #shared, #smem, mutable> -> tensor<32x32x!tt.ptr<f32>, #blocked>
+    // CHECK: tt.call @__triton_consan_commit_accesses
+    // CHECK: ttg.async_commit_group
+    %group = ttg.async_commit_group tokens %token
+    // CHECK: tt.call @__triton_consan_check_outstanding_commits
+    // CHECK: "Accessing buffer with pending access. Pending access type: async_copy_shared_to_global"
+    // CHECK: ttg.local_store
+    ttg.local_store %value, %buffer : tensor<32x32xf32, #blocked> -> !ttg.memdesc<32x32xf32, #shared, #smem, mutable>
+    // CHECK: tt.call @__triton_consan_clear_outstanding_commits_transfer_both
+    // CHECK: ttg.async_wait
+    %wait = ttg.async_wait %group {num = 0 : i32}
+    tt.return
+  }
+}
+
+// -----
+
+// Lowered AMD waits retain the same read-and-write completion behavior.
+#blocked = #ttg.blocked<{sizePerThread = [1, 1], threadsPerWarp = [4, 8], warpsPerCTA = [4, 1], order = [1, 0]}>
+#shared = #ttg.swizzled_shared<{vec = 1, perPhase = 1, maxPhase = 1, order = [1, 0]}>
+#smem = #ttg.shared_memory
+
+module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.shared = 4096 : i32, ttg.target = "hip:gfx1250", "ttg.threads-per-warp" = 32 : i32, "ttg.total-num-warps" = 4 : i32} {
+  // CHECK-LABEL: @lowered_async_wait_transfers_reads
+  tt.func public @lowered_async_wait_transfers_reads(%dst: tensor<32x32x!tt.ptr<f32>, #blocked>) {
+    %buffer = ttg.local_alloc {allocation.offset = 0 : i32} : () -> !ttg.memdesc<32x32xf32, #shared, #smem, mutable>
+    %token = amdg.async_copy_local_to_global %buffer, %dst : !ttg.memdesc<32x32xf32, #shared, #smem, mutable> -> tensor<32x32x!tt.ptr<f32>, #blocked>
+    %group = ttg.async_commit_group tokens %token
+    // CHECK: tt.call @__triton_consan_clear_outstanding_commits_transfer_both
+    // CHECK: amdg.async_wait
+    amdg.async_wait {"ttg.num_commit_groups" = 0 : i64, num_inst = 0 : i32}
+    tt.return
+  }
+}
+
+// -----
+
+// TDM gather and scatter use the TDM commit class and transfer both their
+// outstanding writes and reads when the TDM wait completes.
+#shared = #ttg.swizzled_shared<{vec = 1, perPhase = 1, maxPhase = 1, order = [1, 0]}>
+#smem = #ttg.shared_memory
+#idx_parent = #ttg.blocked<{sizePerThread = [1, 16], threadsPerWarp = [32, 1], warpsPerCTA = [1, 4], order = [0, 1]}>
+
+module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.shared = 65536 : i32, ttg.target = "hip:gfx1250", "ttg.threads-per-warp" = 32 : i32, "ttg.total-num-warps" = 4 : i32} {
+  // CHECK-LABEL: @tdm_gather_scatter_track_commits
+  tt.func public @tdm_gather_scatter_track_commits(%desc: !tt.tensordesc<64x128xf16>, %rows: tensor<64xi32, #ttg.slice<{dim = 0, parent = #idx_parent}>>) {
+    %buffer = ttg.local_alloc {allocation.offset = 0 : i32} : () -> !ttg.memdesc<256x128xf16, #shared, #smem, mutable>
+    // CHECK: tt.call @__triton_consan_stage_access_for_commit
+    // CHECK: tt.call @__triton_consan_commit_accesses
+    // CHECK: amdg.async_tdm_gather
+    %gather = amdg.async_tdm_gather %desc[%rows] to %buffer : tensor<64xi32, #ttg.slice<{dim = 0, parent = #idx_parent}>>, !ttg.memdesc<256x128xf16, #shared, #smem, mutable> -> !tt.tensordesc<64x128xf16>
+    // CHECK: tt.call @__triton_consan_stage_access_for_commit
+    // CHECK: tt.call @__triton_consan_commit_accesses
+    // CHECK: amdg.async_tdm_scatter
+    %scatter = amdg.async_tdm_scatter %desc[%rows] from %buffer : tensor<64xi32, #ttg.slice<{dim = 0, parent = #idx_parent}>>, !ttg.memdesc<256x128xf16, #shared, #smem, mutable> -> !tt.tensordesc<64x128xf16>
+    // CHECK: tt.call @__triton_consan_clear_outstanding_commits_transfer_both
+    // CHECK: amdg.async_tdm_wait
+    %wait = amdg.async_tdm_wait %scatter {num = 0 : i32}
+    tt.return
+  }
+}
+
+// -----
+
+// Barrier-completing TDM gather and scatter publish their own accesses through
+// the real barrier instead of creating implicit TDM commit groups.
+#shared = #ttg.swizzled_shared<{vec = 1, perPhase = 1, maxPhase = 1, order = [1, 0]}>
+#barrier_shared = #ttg.swizzled_shared<{vec = 1, perPhase = 1, maxPhase = 1, order = [0]}>
+#smem = #ttg.shared_memory
+#idx_parent = #ttg.blocked<{sizePerThread = [1, 16], threadsPerWarp = [32, 1], warpsPerCTA = [1, 4], order = [0, 1]}>
+
+module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.shared = 65544 : i32, ttg.target = "hip:gfx1250", "ttg.threads-per-warp" = 32 : i32, "ttg.total-num-warps" = 4 : i32} {
+  // CHECK-LABEL: @tdm_gather_scatter_track_barrier
+  tt.func public @tdm_gather_scatter_track_barrier(%desc: !tt.tensordesc<64x128xf16>, %rows: tensor<64xi32, #ttg.slice<{dim = 0, parent = #idx_parent}>>) {
+    %buffer = ttg.local_alloc {allocation.offset = 0 : i32} : () -> !ttg.memdesc<256x128xf16, #shared, #smem, mutable>
+    %barrier = ttg.local_alloc {allocation.offset = 65536 : i32} : () -> !ttg.memdesc<1xi64, #barrier_shared, #smem, mutable>
+    amdg.init_barrier %barrier, 8 : !ttg.memdesc<1xi64, #barrier_shared, #smem, mutable>
+    // CHECK: tt.call @__triton_consan_verify_barrier_arrive
+    // CHECK: tt.call @__triton_consan_update_barrier_state
+    // CHECK-NOT: tt.call @__triton_consan_commit_accesses
+    // CHECK: amdg.async_tdm_gather
+    %gather = amdg.async_tdm_gather %desc[%rows] to %buffer, barrier = %barrier : tensor<64xi32, #ttg.slice<{dim = 0, parent = #idx_parent}>>, !ttg.memdesc<256x128xf16, #shared, #smem, mutable>, !ttg.memdesc<1xi64, #barrier_shared, #smem, mutable> -> !tt.tensordesc<64x128xf16>
+    // CHECK: tt.call @__triton_consan_verify_barrier_arrive
+    // CHECK: tt.call @__triton_consan_update_barrier_state
+    // CHECK-NOT: tt.call @__triton_consan_commit_accesses
+    // CHECK: amdg.async_tdm_scatter
+    %scatter = amdg.async_tdm_scatter %desc[%rows] from %buffer, barrier = %barrier : tensor<64xi32, #ttg.slice<{dim = 0, parent = #idx_parent}>>, !ttg.memdesc<256x128xf16, #shared, #smem, mutable>, !ttg.memdesc<1xi64, #barrier_shared, #smem, mutable> -> !tt.tensordesc<64x128xf16>
+    tt.return
+  }
+}

--- a/test/TritonGPU/amd/amd-consan.mlir
+++ b/test/TritonGPU/amd/amd-consan.mlir
@@ -968,3 +968,87 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.shar
     tt.return
   }
 }
+
+// -----
+
+// Partitioned padded allocations have several simultaneous physical bases.
+#blocked = #ttg.blocked<{sizePerThread = [1, 1], threadsPerWarp = [8, 4], warpsPerCTA = [2, 1], order = [1, 0]}>
+#inner_padded = #ttg.padded_shared<[128:+4] {order = [1, 0], shape = [16, 16]}>
+#partitioned = #ttg.partitioned_shared<{numPartitions = 2, numGroups = 2, partitionDim = 0, partitionLayout = #inner_padded}>
+#smem = #ttg.shared_memory
+
+module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 2 : i32, ttg.shared = 66592 : i32, ttg.target = "hip:gfx1250", "ttg.threads-per-warp" = 32 : i32, "ttg.total-num-warps" = 2 : i32} {
+  // CHECK-LABEL: @partitioned_padded_local_load_store
+  // CHECK: ttg.local_alloc {allocation.offset = [0 : i32, 65536 : i32]}
+  // CHECK: tt.call @__triton_consan_verify_write_visibility
+  // CHECK: tt.call @__triton_consan_verify_read_visibility
+  // CHECK: ttg.local_store
+  // CHECK: tt.call @__triton_consan_verify_write_visibility
+  // CHECK: ttg.local_load
+  tt.func public @partitioned_padded_local_load_store(%value: tensor<16x16xf16, #blocked>) {
+    %buffer = ttg.local_alloc {allocation.offset = [0 : i32, 65536 : i32]} : () -> !ttg.memdesc<16x16xf16, #partitioned, #smem, mutable>
+    ttg.local_store %value, %buffer : tensor<16x16xf16, #blocked> -> !ttg.memdesc<16x16xf16, #partitioned, #smem, mutable>
+    %loaded = ttg.local_load %buffer : !ttg.memdesc<16x16xf16, #partitioned, #smem, mutable> -> tensor<16x16xf16, #blocked>
+    tt.return
+  }
+}
+
+// -----
+
+// Each partitioned subview has its own sanitizer lane; runtime descriptor
+// selection must retain the physical base and state mask of either piece.
+#blocked = #ttg.blocked<{sizePerThread = [1, 1], threadsPerWarp = [8, 4], warpsPerCTA = [2, 1], order = [1, 0]}>
+#inner = #ttg.swizzled_shared<{vec = 1, perPhase = 1, maxPhase = 1, order = [1, 0]}>
+#partitioned = #ttg.partitioned_shared<{numPartitions = 2, numGroups = 2, partitionDim = 0, partitionLayout = #inner}>
+#smem = #ttg.shared_memory
+
+module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 2 : i32, ttg.shared = 66592 : i32, ttg.target = "hip:gfx1250", "ttg.threads-per-warp" = 32 : i32, "ttg.total-num-warps" = 2 : i32} {
+  // CHECK-LABEL: @partitioned_shared_subslice_masks
+  // CHECK: arith.constant dense<[true, false]> : tensor<2xi1
+  // CHECK: tt.call @__triton_consan_verify_write_visibility
+  // CHECK: tt.call @__triton_consan_verify_read_visibility
+  // CHECK: ttg.local_store
+  // CHECK: arith.constant dense<[false, true]> : tensor<2xi1
+  // CHECK: tt.call @__triton_consan_verify_write_visibility
+  // CHECK: ttg.local_load
+  // CHECK: tti.experimental_memdesc_to_i32
+  // CHECK: tti.experimental_memory_offset_to_i32 0, shared_mem
+  // CHECK: tti.experimental_memory_offset_to_i32 65536, shared_mem
+  // CHECK: ttg.local_load
+  tt.func public @partitioned_shared_subslice_masks(%value: tensor<4x16xf16, #blocked>, %choose: i1) {
+    %buffer = ttg.local_alloc {allocation.offset = [0 : i32, 65536 : i32]} : () -> !ttg.memdesc<16x16xf16, #partitioned, #smem, mutable>
+    %first = ttg.memdesc_subslice %buffer [0, 0] : !ttg.memdesc<16x16xf16, #partitioned, #smem, mutable> -> !ttg.memdesc<4x16xf16, #partitioned, #smem, mutable, 16x16>
+    %second = ttg.memdesc_subslice %buffer [4, 0] : !ttg.memdesc<16x16xf16, #partitioned, #smem, mutable> -> !ttg.memdesc<4x16xf16, #partitioned, #smem, mutable, 16x16>
+    ttg.local_store %value, %first : tensor<4x16xf16, #blocked> -> !ttg.memdesc<4x16xf16, #partitioned, #smem, mutable, 16x16>
+    %loaded = ttg.local_load %second : !ttg.memdesc<4x16xf16, #partitioned, #smem, mutable, 16x16> -> tensor<4x16xf16, #blocked>
+    %selected = arith.select %choose, %first, %second : !ttg.memdesc<4x16xf16, #partitioned, #smem, mutable, 16x16>
+    %dynamic = ttg.local_load %selected : !ttg.memdesc<4x16xf16, #partitioned, #smem, mutable, 16x16> -> tensor<4x16xf16, #blocked>
+    tt.return
+  }
+}
+
+// -----
+
+// A fused TDM load must track every physical destination independently.
+#shared = #ttg.swizzled_shared<{vec = 1, perPhase = 1, maxPhase = 1, order = [1, 0]}>
+#smem = #ttg.shared_memory
+
+module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.shared = 16384 : i32, ttg.target = "hip:gfx1250", "ttg.threads-per-warp" = 32 : i32, "ttg.total-num-warps" = 4 : i32} {
+  // CHECK-LABEL: @fused_tdm_tracks_all_destinations
+  // CHECK: arith.constant dense<[true, false]> : tensor<2xi1
+  // CHECK: tt.call @__triton_consan_verify_write_visibility
+  // CHECK: tt.call @__triton_consan_verify_read_visibility
+  // CHECK: tt.call @__triton_consan_stage_access_for_commit
+  // CHECK: arith.constant dense<[false, true]> : tensor<2xi1
+  // CHECK: tt.call @__triton_consan_verify_write_visibility
+  // CHECK: tt.call @__triton_consan_verify_read_visibility
+  // CHECK: tt.call @__triton_consan_stage_access_for_commit
+  // CHECK: tt.call @__triton_consan_commit_accesses
+  // CHECK: amdg.async_tdm_fused_copy_global_to_local
+  tt.func public @fused_tdm_tracks_all_destinations(%desc0: !tt.tensordesc<64x64xf16, #shared>, %desc1: !tt.tensordesc<64x64xf16, #shared>) {
+    %first = ttg.local_alloc {allocation.offset = 0 : i32} : () -> !ttg.memdesc<64x64xf16, #shared, #smem, mutable>
+    %second = ttg.local_alloc {allocation.offset = 8192 : i32} : () -> !ttg.memdesc<64x64xf16, #shared, #smem, mutable>
+    %token = amdg.async_tdm_fused_copy_global_to_local %desc0, %desc1 into %first, %second {warp_used_hints = array<i32: 3, 12>} : !tt.tensordesc<64x64xf16, #shared>, !tt.tensordesc<64x64xf16, #shared> -> !ttg.memdesc<64x64xf16, #shared, #smem, mutable>, !ttg.memdesc<64x64xf16, #shared, #smem, mutable>
+    tt.return
+  }
+}

--- a/test/TritonGPU/amd/amd-consan.mlir
+++ b/test/TritonGPU/amd/amd-consan.mlir
@@ -228,6 +228,8 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 1 : i32, ttg.shar
     // CHECK: %[[THREAD_MASK:.*]] = arith.constant 1 : i64
     // CHECK: %[[OUTSTANDING_NUM:.*]] = arith.constant 42 : i32
     // CHECK: tt.call @__triton_consan_clear_outstanding_commits_transfer_writes{{.*}}(%[[THREAD_BIT]], %[[THREAD_MASK]], %[[OUTSTANDING_NUM]]
+    // CHECK-NOT: tt.call @__triton_consan_clear_outstanding_commits_transfer_
+    // CHECK: ttg.async_wait
     %shmem = ttg.local_alloc {allocation.offset = 0 : i32} : () -> !ttg.memdesc<32x32xf16, #shared, #smem, mutable>
     ttg.async_wait {num = 42 : i32}
     ttg.local_load %shmem : !ttg.memdesc<32x32xf16, #shared, #smem, mutable> -> tensor<32x32xf16, #blocked>
@@ -1074,6 +1076,7 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.shar
     // CHECK: ttg.async_commit_group
     %group = ttg.async_commit_group tokens %token
     // CHECK: tt.call @__triton_consan_clear_outstanding_commits_transfer_writes
+    // CHECK-NOT: tt.call @__triton_consan_clear_outstanding_commits_transfer_
     // CHECK: ttg.async_wait
     %wait = ttg.async_wait %group {num = 0 : i32}
     tt.return
@@ -1123,7 +1126,9 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.shar
     // CHECK: "Accessing buffer with pending access. Pending access type: async_copy_shared_to_global"
     // CHECK: ttg.local_store
     ttg.local_store %value, %buffer : tensor<32x32xf32, #blocked> -> !ttg.memdesc<32x32xf32, #shared, #smem, mutable>
+    // CHECK-NOT: tt.call @__triton_consan_clear_outstanding_commits_transfer_writes
     // CHECK: tt.call @__triton_consan_clear_outstanding_commits_transfer_both
+    // CHECK-NOT: tt.call @__triton_consan_clear_outstanding_commits_transfer_
     // CHECK: ttg.async_wait
     %wait = ttg.async_wait %group {num = 0 : i32}
     tt.return
@@ -1143,7 +1148,9 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.shar
     %buffer = ttg.local_alloc {allocation.offset = 0 : i32} : () -> !ttg.memdesc<32x32xf32, #shared, #smem, mutable>
     %token = amdg.async_copy_local_to_global %buffer, %dst : !ttg.memdesc<32x32xf32, #shared, #smem, mutable> -> tensor<32x32x!tt.ptr<f32>, #blocked>
     %group = ttg.async_commit_group tokens %token
+    // CHECK-NOT: tt.call @__triton_consan_clear_outstanding_commits_transfer_writes
     // CHECK: tt.call @__triton_consan_clear_outstanding_commits_transfer_both
+    // CHECK-NOT: tt.call @__triton_consan_clear_outstanding_commits_transfer_
     // CHECK: amdg.async_wait
     amdg.async_wait {"ttg.num_commit_groups" = 0 : i64, num_inst = 0 : i32}
     tt.return

--- a/test/TritonGPU/consan-capture-reservation.mlir
+++ b/test/TritonGPU/consan-capture-reservation.mlir
@@ -1,7 +1,6 @@
 // RUN: split-file %s %t
 // RUN: not triton-opt %t/missing.mlir -allow-unregistered-dialect -tritoninstrument-concurrency-sanitizer 2>&1 | FileCheck %t/missing.mlir --check-prefix=MISSING
 // RUN: not triton-opt %t/too-small.mlir -allow-unregistered-dialect -tritoninstrument-concurrency-sanitizer 2>&1 | FileCheck %t/too-small.mlir --check-prefix=SMALL
-// RUN: not triton-opt %t/cross-cta-affine.mlir -allow-unregistered-dialect -tritoninstrument-concurrency-sanitizer 2>&1 | FileCheck %t/cross-cta-affine.mlir --check-prefix=AFFINE
 
 //--- missing.mlir
 
@@ -15,23 +14,6 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, "ttg.thr
     partition0() num_warps(4) {
       ttg.warp_return
     } : () -> ()
-    tt.return
-  }
-}
-
-//--- cross-cta-affine.mlir
-
-#shared = #ttg.swizzled_shared<{vec = 1, perPhase = 1, maxPhase = 1, order = [1, 0], CGALayout = [[1, 0]]}>
-#smem = #ttg.shared_memory
-#blocked = #ttg.blocked<{sizePerThread = [1, 1], threadsPerWarp = [1, 32], warpsPerCTA = [1, 4], order = [1, 0], CGALayout = [[0, 0]]}>
-
-module attributes {"ttg.num-ctas" = 2 : i32, "ttg.num-warps" = 4 : i32, "ttg.threads-per-warp" = 32 : i32, "ttg.total-num-warps" = 4 : i32, ttg.shared = 512 : i32, ttg.target = "cuda:90", ttg.tensor_memory_size = 0 : i32} {
-  tt.func public @cross_cta_affine_subslice() {
-    %src = ttg.local_alloc {allocation.offset = 0 : i32} : () -> !ttg.memdesc<4x32xi32, #shared, #smem, mutable>
-    // AFFINE: error: memdesc subslices with cross-CTA affine offsets are unsupported by buffer region analysis
-    %tile = ttg.memdesc_subslice %src [2, 0] : !ttg.memdesc<4x32xi32, #shared, #smem, mutable> -> !ttg.memdesc<2x32xi32, #shared, #smem, mutable, 4x32>
-    %indices = arith.constant dense<0> : tensor<2x32xi32, #blocked>
-    %gathered = ttg.local_gather %tile[%indices] {axis = 1 : i32} : !ttg.memdesc<2x32xi32, #shared, #smem, mutable, 4x32>, tensor<2x32xi32, #blocked> -> tensor<2x32xi32, #blocked>
     tt.return
   }
 }

--- a/test/TritonGPU/consan.mlir
+++ b/test/TritonGPU/consan.mlir
@@ -2081,3 +2081,61 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 1 : i32, ttg.shar
     tt.return
   }
 }
+
+// -----
+
+// Cross-CTA subviews must direct every local memory access to the CTA that
+// owns its physical bytes. Runtime selection conservatively reaches both.
+#shared = #ttg.swizzled_shared<{vec = 1, perPhase = 1, maxPhase = 1, order = [1, 0], CGALayout = [[1, 0]]}>
+#blocked = #ttg.blocked<{sizePerThread = [1, 1], threadsPerWarp = [1, 32], warpsPerCTA = [1, 4], order = [1, 0], CGALayout = [[1, 0]]}>
+#smem = #ttg.shared_memory
+
+module attributes {"ttg.num-ctas" = 2 : i32, "ttg.num-warps" = 4 : i32, "ttg.threads-per-warp" = 32 : i32, "ttg.total-num-warps" = 4 : i32, ttg.shared = 512 : i32, ttg.target = "cuda:90", ttg.tensor_memory_size = 0 : i32} {
+  // CHECK-LABEL: @cross_cta_affine_subslice_recipients
+  tt.func public @cross_cta_affine_subslice_recipients(%choose: i1) {
+    // CHECK: %[[AFFINE_PARENT:.*]] = ttg.local_alloc
+    %parent = ttg.local_alloc {allocation.offset = 0 : i32} : () -> !ttg.memdesc<4x32xi32, #shared, #smem, mutable>
+    // CHECK: %[[LOCAL_VIEW:.*]] = ttg.memdesc_subslice %[[AFFINE_PARENT]][0, 0]
+    %local = ttg.memdesc_subslice %parent [0, 0] : !ttg.memdesc<4x32xi32, #shared, #smem, mutable> -> !ttg.memdesc<2x32xi32, #shared, #smem, mutable, 4x32>
+    // CHECK: %[[REMOTE_VIEW:.*]] = ttg.memdesc_subslice %[[AFFINE_PARENT]][2, 0]
+    %remote = ttg.memdesc_subslice %parent [2, 0] : !ttg.memdesc<4x32xi32, #shared, #smem, mutable> -> !ttg.memdesc<2x32xi32, #shared, #smem, mutable, 4x32>
+    // CHECK: arith.select {{.*}}, %[[LOCAL_VIEW]], %[[REMOTE_VIEW]]
+    %selected = arith.select %choose, %local, %remote : !ttg.memdesc<2x32xi32, #shared, #smem, mutable, 4x32>
+    %indices = arith.constant dense<0> : tensor<2x32xi32, #blocked>
+    %values = arith.constant dense<1> : tensor<2x32xi32, #blocked>
+    // CHECK: ttng.cluster_barrier
+    ttng.cluster_barrier
+    // CHECK: %[[LOCAL_CTAS:.*]] = arith.constant 1 : i32
+    // CHECK: tt.call @__triton_consan_verify_write_visibility{{.*}}({{.*}}%[[LOCAL_CTAS]])
+    // CHECK: ttg.local_load
+    %l = ttg.local_load %local : !ttg.memdesc<2x32xi32, #shared, #smem, mutable, 4x32> -> tensor<2x32xi32, #blocked>
+    // CHECK: %[[REMOTE_CTAS:.*]] = arith.constant 2 : i32
+    // CHECK: tt.call @__triton_consan_verify_write_visibility{{.*}}({{.*}}%[[REMOTE_CTAS]])
+    // CHECK: ttg.local_load
+    %r = ttg.local_load %remote : !ttg.memdesc<2x32xi32, #shared, #smem, mutable, 4x32> -> tensor<2x32xi32, #blocked>
+    // CHECK: %[[SELECTED_CTAS:.*]] = arith.constant 3 : i32
+    // CHECK: tt.call @__triton_consan_verify_write_visibility{{.*}}({{.*}}%[[SELECTED_CTAS]])
+    // CHECK: ttg.local_load
+    %s = ttg.local_load %selected : !ttg.memdesc<2x32xi32, #shared, #smem, mutable, 4x32> -> tensor<2x32xi32, #blocked>
+    // CHECK: %[[STORE_CTAS:.*]] = arith.constant 2 : i32
+    // CHECK: tt.call @__triton_consan_verify_write_visibility{{.*}}({{.*}}%[[STORE_CTAS]])
+    // CHECK: tt.call @__triton_consan_verify_read_visibility{{.*}}({{.*}}%[[STORE_CTAS]])
+    // CHECK: ttg.local_store
+    ttg.local_store %values, %remote : tensor<2x32xi32, #blocked> -> !ttg.memdesc<2x32xi32, #shared, #smem, mutable, 4x32>
+    // CHECK: %[[GATHER_CTAS:.*]] = arith.constant 2 : i32
+    // CHECK: tt.call @__triton_consan_verify_write_visibility{{.*}}({{.*}}%[[GATHER_CTAS]])
+    // CHECK: ttg.local_gather
+    %g = ttg.local_gather %remote[%indices] {axis = 1 : i32} : !ttg.memdesc<2x32xi32, #shared, #smem, mutable, 4x32>, tensor<2x32xi32, #blocked> -> tensor<2x32xi32, #blocked>
+    // CHECK: %[[SCATTER_CTAS:.*]] = arith.constant 2 : i32
+    // CHECK: tt.call @__triton_consan_verify_write_visibility{{.*}}({{.*}}%[[SCATTER_CTAS]])
+    // CHECK: tt.call @__triton_consan_verify_read_visibility{{.*}}({{.*}}%[[SCATTER_CTAS]])
+    // CHECK: ttg.local_scatter
+    ttg.local_scatter %remote[%indices], %values {axis = 1 : i32} : !ttg.memdesc<2x32xi32, #shared, #smem, mutable, 4x32>, tensor<2x32xi32, #blocked>, tensor<2x32xi32, #blocked>
+    // CHECK: %[[ATOMIC_CTAS:.*]] = arith.constant 2 : i32
+    // CHECK: tt.call @__triton_consan_verify_write_visibility{{.*}}({{.*}}%[[ATOMIC_CTAS]])
+    // CHECK: tt.call @__triton_consan_verify_read_visibility{{.*}}({{.*}}%[[ATOMIC_CTAS]])
+    // CHECK: ttg.local_atomic_scatter_rmw
+    %a = ttg.local_atomic_scatter_rmw add, %remote[%indices], %values {axis = 1 : i32} : (!ttg.memdesc<2x32xi32, #shared, #smem, mutable, 4x32>, tensor<2x32xi32, #blocked>, tensor<2x32xi32, #blocked>) -> tensor<2x32xi32, #blocked>
+    tt.return
+  }
+}

--- a/test/TritonGPU/consan.mlir
+++ b/test/TritonGPU/consan.mlir
@@ -2139,3 +2139,68 @@ module attributes {"ttg.num-ctas" = 2 : i32, "ttg.num-warps" = 4 : i32, "ttg.thr
     tt.return
   }
 }
+
+// -----
+
+// A known allocation and an external descriptor share the known state lane;
+// the unknown descriptor additionally covers its dedicated wildcard lane.
+#shared = #ttg.swizzled_shared<{vec = 1, perPhase = 1, maxPhase = 1, order = [0]}>
+#smem = #ttg.shared_memory
+
+module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 1 : i32, ttg.shared = 64 : i32, ttg.target = "cuda:90", ttg.tensor_memory_size = 0 : i32, "ttg.threads-per-warp" = 32 : i32, "ttg.total-num-warps" = 1 : i32} {
+  // CHECK-LABEL: @known_and_unknown_descriptor_state
+  tt.func public @known_and_unknown_descriptor_state(%incoming: !ttg.memdesc<16xi32, #shared, #smem, mutable>) {
+    // CHECK: %[[KNOWN:.*]] = ttg.local_alloc
+    %known = ttg.local_alloc {allocation.offset = 0 : i32} : () -> !ttg.memdesc<16xi32, #shared, #smem, mutable>
+    // CHECK: arith.constant dense<[true, false]> : tensor<2xi1
+    // CHECK: tt.call @__triton_consan_verify_write_visibility
+    // CHECK: ttg.local_load %[[KNOWN]]
+    %0 = ttg.local_load %known : !ttg.memdesc<16xi32, #shared, #smem, mutable> -> tensor<16xi32>
+    // CHECK: arith.constant dense<true> : tensor<2xi1
+    // CHECK: tt.call @__triton_consan_verify_write_visibility
+    // CHECK: ttg.local_load %arg0
+    %1 = ttg.local_load %incoming : !ttg.memdesc<16xi32, #shared, #smem, mutable> -> tensor<16xi32>
+    tt.return
+  }
+}
+
+// -----
+
+// An unknown-only module still allocates sanitizer state without fabricating
+// or dynamically comparing a physical allocation base.
+#shared = #ttg.swizzled_shared<{vec = 1, perPhase = 1, maxPhase = 1, order = [0]}>
+#smem = #ttg.shared_memory
+
+module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 1 : i32, ttg.shared = 64 : i32, ttg.target = "cuda:90", ttg.tensor_memory_size = 0 : i32, "ttg.threads-per-warp" = 32 : i32, "ttg.total-num-warps" = 1 : i32} {
+  // CHECK-LABEL: @unknown_only_descriptor_state
+  tt.func public @unknown_only_descriptor_state(%incoming: !ttg.memdesc<16xi32, #shared, #smem, mutable>) {
+    // CHECK: arith.constant dense<true> : tensor<1xi1
+    // CHECK: tt.call @__triton_consan_verify_write_visibility
+    // CHECK-NOT: tti.experimental_memdesc_to_i32
+    // CHECK: ttg.local_load %arg0
+    %0 = ttg.local_load %incoming : !ttg.memdesc<16xi32, #shared, #smem, mutable> -> tensor<16xi32>
+    tt.return
+  }
+}
+
+// -----
+
+// A warp-group wait forwards descriptor provenance to its result while
+// separately preserving its asynchronous read-completion semantics.
+#shared = #ttg.swizzled_shared<{vec = 1, perPhase = 1, maxPhase = 1, order = [0]}>
+#smem = #ttg.shared_memory
+
+module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 1 : i32, ttg.shared = 64 : i32, ttg.target = "cuda:90", ttg.tensor_memory_size = 0 : i32, "ttg.threads-per-warp" = 32 : i32, "ttg.total-num-warps" = 1 : i32} {
+  // CHECK-LABEL: @warp_group_wait_preserves_descriptor
+  tt.func public @warp_group_wait_preserves_descriptor() {
+    // CHECK: %[[BUFFER:.*]] = ttg.local_alloc
+    %buffer = ttg.local_alloc {allocation.offset = 0 : i32} : () -> !ttg.memdesc<16xi32, #shared, #smem, mutable>
+    // CHECK: tt.call @__triton_consan_clear_outstanding_commits_transfer_reads
+    // CHECK: %[[WAITED:.*]] = ttng.warp_group_dot_wait %[[BUFFER]]
+    %waited = ttng.warp_group_dot_wait %buffer {pendings = 0 : i32} : !ttg.memdesc<16xi32, #shared, #smem, mutable>
+    // CHECK: tt.call @__triton_consan_verify_write_visibility
+    // CHECK: ttg.local_load %[[WAITED]]
+    %value = ttg.local_load %waited : !ttg.memdesc<16xi32, #shared, #smem, mutable> -> tensor<16xi32>
+    tt.return
+  }
+}

--- a/test/lib/Analysis/TestBufferRegion.cpp
+++ b/test/lib/Analysis/TestBufferRegion.cpp
@@ -120,23 +120,23 @@ struct TestBufferRegionAliasPass
         addresses.push_back(static_cast<uint32_t>(address));
       }
       uint32_t base = 0;
-      if (auto baseAttr = op->getAttrOfType<IntegerAttr>("test.region_base"))
-        base = static_cast<uint32_t>(baseAttr.getInt());
       uint32_t length = 0;
-      if (auto lengthAttr =
-              op->getAttrOfType<IntegerAttr>("test.region_length")) {
-        length = static_cast<uint32_t>(lengthAttr.getInt());
-      } else if (!addresses.empty()) {
+      if (!addresses.empty()) {
         auto [min, max] =
             std::minmax_element(addresses.begin(), addresses.end());
         base = *min;
         length = *max - *min + 1;
       }
+      tt::BufferRegion region{base, length};
+      if (!addresses.empty()) {
+        tt::AddressSet addressSet;
+        for (uint32_t address : addresses)
+          addressSet.set(address);
+        region.ctaAddresses.emplace_back(0, std::move(addressSet));
+      }
       tt::RegionInfo info(tt::RegionInfo::ViewList{});
       info.views.insert(
-          {tt::BufferRegion(base, length,
-                            tt::AddressSet::fromAddresses(addresses)),
-           /*storageBase=*/base, /*affineOffset=*/0});
+          {std::move(region), /*storageBase=*/base, /*affineOffset=*/0});
       return info;
     }
 

--- a/test/lib/Analysis/TestBufferRegion.cpp
+++ b/test/lib/Analysis/TestBufferRegion.cpp
@@ -56,18 +56,14 @@ struct TestBufferRegionPass
     analysis->calculateUsedBufferRegions(moduleOp);
 
     moduleOp.walk([&](Operation *op) {
-      if (!triton::BufferRegionAnalysis::isMemoryAccessOperation(op))
-        return;
-
-      auto maybeMemDesc = llvm::find_if(op->getOperands(), [](Value operand) {
-        return isa<ttg::MemDescType>(operand.getType());
-      });
-
-      if (maybeMemDesc == op->operand_end())
-        return;
-
-      emitRegionInfo(op->getLoc(), "Buffers",
-                     analysis->getLatticeElement(*maybeMemDesc)->getValue());
+      for (const auto &access :
+           triton::BufferRegionAnalysis::getMemoryAccesses(op)) {
+        if (!llvm::is_contained(op->getOperands(), access.value))
+          continue;
+        emitRegionInfo(op->getLoc(), "Buffers",
+                       analysis->getLatticeElement(access.value)->getValue());
+        break;
+      }
     });
 
     llvm::SmallVector<Operation *> anchors;
@@ -136,10 +132,11 @@ struct TestBufferRegionAliasPass
         base = *min;
         length = *max - *min + 1;
       }
-      tt::RegionInfo info(tt::RegionInfo::RegionList{});
-      info.regions.insert(tt::BufferRegion(
-          base, length, tt::AddressSet::fromAddresses(addresses),
-          /*storageBase=*/base, /*affineOffset=*/0));
+      tt::RegionInfo info(tt::RegionInfo::ViewList{});
+      info.views.insert(
+          {tt::BufferRegion(base, length,
+                            tt::AddressSet::fromAddresses(addresses)),
+           /*storageBase=*/base, /*affineOffset=*/0});
       return info;
     }
 
@@ -155,9 +152,9 @@ struct TestBufferRegionAliasPass
   static bool mayAlias(const tt::RegionInfo &lhs, const tt::RegionInfo &rhs) {
     if (lhs.isUnknown() || rhs.isUnknown())
       return true;
-    return llvm::any_of(lhs.regions, [&](const tt::BufferRegion &a) {
-      return llvm::any_of(rhs.regions, [&](const tt::BufferRegion &b) {
-        return a.intersects(b);
+    return llvm::any_of(lhs.views, [&](const tt::BufferRegionView &a) {
+      return llvm::any_of(rhs.views, [&](const tt::BufferRegionView &b) {
+        return a.region.intersects(b.region);
       });
     });
   }
@@ -166,9 +163,9 @@ struct TestBufferRegionAliasPass
                        const tt::RegionInfo &contained) {
     if (container.isUnknown() || contained.isUnknown())
       return false;
-    return llvm::all_of(contained.regions, [&](const tt::BufferRegion &b) {
-      return llvm::any_of(container.regions, [&](const tt::BufferRegion &a) {
-        return a.contains(b);
+    return llvm::all_of(contained.views, [&](const tt::BufferRegionView &b) {
+      return llvm::any_of(container.views, [&](const tt::BufferRegionView &a) {
+        return a.region.contains(b.region);
       });
     });
   }
@@ -193,7 +190,8 @@ struct TestBufferRegionAliasPass
                 ArrayRef<std::pair<std::string, tt::RegionInfo>> namedRegions) {
     SmallVector<tt::BufferRegion> regions;
     for (const auto &[name, info] : namedRegions)
-      llvm::append_range(regions, info.regions);
+      for (const tt::BufferRegionView &view : info.views)
+        regions.push_back(view.region);
     llvm::sort(regions);
     regions.erase(std::unique(regions.begin(), regions.end()), regions.end());
 
@@ -211,8 +209,9 @@ struct TestBufferRegionAliasPass
         printMask(diag, plan.unknownMask);
         continue;
       }
-      SmallVector<tt::BufferRegion> candidates(info.regions.begin(),
-                                               info.regions.end());
+      SmallVector<tt::BufferRegion> candidates;
+      for (const tt::BufferRegionView &view : info.views)
+        candidates.push_back(view.region);
       llvm::sort(candidates);
       for (const tt::BufferRegion &candidate : candidates) {
         auto it = llvm::lower_bound(regions, candidate);

--- a/test/lib/Analysis/TestBufferRegion.cpp
+++ b/test/lib/Analysis/TestBufferRegion.cpp
@@ -136,7 +136,7 @@ struct TestBufferRegionAliasPass
         base = *min;
         length = *max - *min + 1;
       }
-      tt::RegionInfo info;
+      tt::RegionInfo info(tt::RegionInfo::RegionList{});
       info.regions.insert(tt::BufferRegion(
           base, length, tt::AddressSet::fromAddresses(addresses),
           /*storageBase=*/base, /*affineOffset=*/0));
@@ -153,6 +153,8 @@ struct TestBufferRegionAliasPass
   }
 
   static bool mayAlias(const tt::RegionInfo &lhs, const tt::RegionInfo &rhs) {
+    if (lhs.isUnknown() || rhs.isUnknown())
+      return true;
     return llvm::any_of(lhs.regions, [&](const tt::BufferRegion &a) {
       return llvm::any_of(rhs.regions, [&](const tt::BufferRegion &b) {
         return a.intersects(b);
@@ -162,6 +164,8 @@ struct TestBufferRegionAliasPass
 
   static bool contains(const tt::RegionInfo &container,
                        const tt::RegionInfo &contained) {
+    if (container.isUnknown() || contained.isUnknown())
+      return false;
     return llvm::all_of(contained.regions, [&](const tt::BufferRegion &b) {
       return llvm::any_of(container.regions, [&](const tt::BufferRegion &a) {
         return a.contains(b);
@@ -193,11 +197,20 @@ struct TestBufferRegionAliasPass
     llvm::sort(regions);
     regions.erase(std::unique(regions.begin(), regions.end()), regions.end());
 
-    tt::BufferStatePlan plan = tt::createBufferStatePlan(regions);
+    bool hasUnknown = llvm::any_of(namedRegions, [](const auto &named) {
+      return named.second.isUnknown();
+    });
+    tt::BufferStatePlan plan = tt::createBufferStatePlan(regions, hasUnknown);
     InFlightDiagnostic summary = module.emitRemark();
     summary << "state-plan: lanes=" << plan.numLanes;
 
     for (const auto &[name, info] : namedRegions) {
+      if (info.isUnknown()) {
+        InFlightDiagnostic diag = module.emitRemark();
+        diag << name << " case unknown: mask=";
+        printMask(diag, plan.unknownMask);
+        continue;
+      }
       SmallVector<tt::BufferRegion> candidates(info.regions.begin(),
                                                info.regions.end());
       llvm::sort(candidates);

--- a/third_party/amd/lib/TritonAMDGPUTransforms/ConSanAMD.cpp
+++ b/third_party/amd/lib/TritonAMDGPUTransforms/ConSanAMD.cpp
@@ -17,11 +17,12 @@ using tti::WaitOpInfo;
 namespace mlir {
 
 class AMDConSanHooks : public tti::ConSanTargetHooks {
+  mutable bool hasAsyncCopyReads = false;
+
 public:
   bool isTMAOp(Operation *op) const override {
-    return isa<ttag::AsyncTDMCopyGlobalToLocalOp,
-               ttag::AsyncTDMFusedCopyGlobalToLocalOp,
-               ttag::AsyncTDMCopyLocalToGlobalOp>(op);
+    return isa<ttag::TDMOpInterface, ttag::AsyncTDMFusedCopyGlobalToLocalOp>(
+        op);
   }
 
   // TDM ops from the same warp complete in issue order. ConSan's thread model
@@ -57,7 +58,7 @@ public:
     // by UpdateAsyncWaitCount — read the commit group count directly.
     if (auto asyncWaitOp = dyn_cast<ttg::AsyncWaitOp>(op)) {
       return WaitOpInfo{tti::CommitKind::AsyncCp, (int)asyncWaitOp.getNum(),
-                        /*transferWrites=*/true, /*transferReads=*/false};
+                        /*transferWrites=*/true, hasAsyncCopyReads};
     }
     // On non-asyncmark targets, amdgpu::AsyncWaitOp replaces ttg::AsyncWaitOp
     // after UpdateAsyncWaitCount. Read the preserved commit-group count.
@@ -65,7 +66,7 @@ public:
       if (auto attr = asyncWaitOp->getAttrOfType<IntegerAttr>(
               "ttg.num_commit_groups")) {
         return WaitOpInfo{tti::CommitKind::AsyncCp, (int)attr.getInt(),
-                          /*transferWrites=*/true, /*transferReads=*/false};
+                          /*transferWrites=*/true, hasAsyncCopyReads};
       }
       return std::nullopt;
     }
@@ -94,71 +95,72 @@ public:
 
   std::optional<MemEffectsOpInfo>
   getMemEffectsOpInfo(Operation *op) const override {
-    auto info = ConSanTargetHooks::getMemEffectsOpInfo(op);
-    if (info)
+    if (auto loadOp = dyn_cast<ttag::BufferLoadToLocalOp>(op)) {
+      MemEffectsOpInfo info;
+      info.trackingKind = MemEffectsOpInfo::TrackingKind::CommitCount;
+      info.commitKind = tti::CommitKind::AsyncCp;
+      info.operandEffects.emplace_back(MemEffectsOpInfo::Effects::Write,
+                                       loadOp.getDest());
       return info;
-    // AsyncTDMCopyGlobalToLocalOp: Async copy from global to shared memory.
-    // When a barrier is present, TDM signals it once per warp.
-    // The barrier init count must account for this (e.g. count=NUM_WARPS),
-    // so ConSan decrements the shadow counter by numWarps (one per warp).
-    // When no barrier is present, completion is tracked via the TDM wait
-    // counter (AsyncTDMWait), modeled as CommitCount with implicitCommit.
-    if (auto copyOp = dyn_cast<ttag::AsyncTDMCopyGlobalToLocalOp>(op)) {
-      info.emplace();
-      if (Value barrier = copyOp.getBarrier()) {
-        info->trackingKind = MemEffectsOpInfo::TrackingKind::Barrier;
-        int numWarps = ttg::lookupNumWarps(copyOp);
-        info->barriers.push_back({barrier, nullptr, numWarps});
-      } else {
-        info->trackingKind = MemEffectsOpInfo::TrackingKind::CommitCount;
-        info->commitKind = tti::CommitKind::TmaStore;
-        info->implicitCommit = true;
-      }
-      info->operandEffects.emplace_back(MemEffectsOpInfo::Effects::Write,
-                                        copyOp.getResult());
     }
-    // AsyncTDMFusedCopyGlobalToLocalOp: explicit fused async copy from global
-    // to one or more shared-memory destinations. It has no mbarrier operand, so
-    // completion is tracked through the TDM wait counter.
+
+    if (auto storeOp = dyn_cast<ttag::AsyncCopyLocalToGlobalOp>(op)) {
+      MemEffectsOpInfo info;
+      info.trackingKind = MemEffectsOpInfo::TrackingKind::CommitCount;
+      info.commitKind = tti::CommitKind::AsyncCp;
+      info.operandEffects.emplace_back(MemEffectsOpInfo::Effects::Read,
+                                       storeOp.getSrc());
+      return info;
+    }
+
+    if (isa<ttag::TDMOpInterface>(op)) {
+      MemEffectsOpInfo info;
+      Value barrier = cast<ttg::MBarrierOpInterface>(op).getBarrier();
+      if (barrier) {
+        info.trackingKind = MemEffectsOpInfo::TrackingKind::Barrier;
+        info.barriers.push_back({barrier, nullptr, ttg::lookupNumWarps(op)});
+      } else {
+        info.trackingKind = MemEffectsOpInfo::TrackingKind::CommitCount;
+        info.commitKind = tti::CommitKind::TmaStore;
+        info.implicitCommit = true;
+      }
+      for (const auto &access :
+           triton::BufferRegionAnalysis::getMemoryAccesses(op)) {
+        if (access.value != barrier)
+          info.operandEffects.emplace_back(
+              access.isWrite ? MemEffectsOpInfo::Effects::Write
+                             : MemEffectsOpInfo::Effects::Read,
+              access.value);
+      }
+      return info;
+    }
+
     if (auto fusedOp = dyn_cast<ttag::AsyncTDMFusedCopyGlobalToLocalOp>(op)) {
-      info.emplace();
-      info->trackingKind = MemEffectsOpInfo::TrackingKind::CommitCount;
-      info->commitKind = tti::CommitKind::TmaStore;
-      info->implicitCommit = true;
+      MemEffectsOpInfo info;
+      info.trackingKind = MemEffectsOpInfo::TrackingKind::CommitCount;
+      info.commitKind = tti::CommitKind::TmaStore;
+      info.implicitCommit = true;
       for (Value dest : fusedOp.getDests())
-        info->operandEffects.emplace_back(MemEffectsOpInfo::Effects::Write,
-                                          dest);
-    }
-    // AsyncTDMCopyLocalToGlobalOp: Async copy from shared to global memory
-    // Same principles as AsyncTDMCopyGlobalToLocalOp apply.
-    if (auto storeOp = dyn_cast<ttag::AsyncTDMCopyLocalToGlobalOp>(op)) {
-      info.emplace();
-      if (Value barrier = storeOp.getBarrier()) {
-        info->trackingKind = MemEffectsOpInfo::TrackingKind::Barrier;
-        int numWarps = ttg::lookupNumWarps(storeOp);
-        info->barriers.push_back({barrier, nullptr, numWarps});
-      } else {
-        info->trackingKind = MemEffectsOpInfo::TrackingKind::CommitCount;
-        info->commitKind = tti::CommitKind::TmaStore;
-        info->implicitCommit = true;
-      }
-      info->operandEffects.emplace_back(MemEffectsOpInfo::Effects::Read,
-                                        storeOp.getSrc());
+        info.operandEffects.emplace_back(MemEffectsOpInfo::Effects::Write,
+                                         dest);
+      return info;
     }
     // AMD ArriveBarrierOp: Explicit barrier arrival.
     // Arrive is per-THREAD when called explicitly (unlike TDM which
     // is per-warp). Scale by total threads in the partition so ConSan's shadow
     // barrier state matches the hardware arrival count.
     if (auto arriveOp = dyn_cast<ttag::ArriveBarrierOp>(op)) {
-      info.emplace();
-      info->trackingKind = MemEffectsOpInfo::TrackingKind::Barrier;
+      MemEffectsOpInfo info;
+      info.trackingKind = MemEffectsOpInfo::TrackingKind::Barrier;
       int numWarps = ttg::lookupNumWarps(arriveOp);
       auto mod = arriveOp->getParentOfType<ModuleOp>();
       int threadsPerWarp = ttg::TritonGPUDialect::getThreadsPerWarp(mod);
       int totalCount = (int)arriveOp.getCount() * numWarps * threadsPerWarp;
-      info->barriers.push_back({arriveOp.getBarrier(), nullptr, totalCount});
+      info.barriers.push_back({arriveOp.getBarrier(), nullptr, totalCount});
+      return info;
     }
-    return info;
+
+    return ConSanTargetHooks::getMemEffectsOpInfo(op);
   }
 
   SmallVector<CommitKindDesc> getOutstandingWriteCommitKinds() const override {
@@ -167,7 +169,12 @@ public:
   }
 
   SmallVector<CommitKindDesc> getOutstandingReadCommitKinds() const override {
-    return {{tti::CommitKind::TmaStore, "async_tdm_shared_to_global"}};
+    SmallVector<CommitKindDesc> kinds;
+    if (hasAsyncCopyReads)
+      kinds.push_back(
+          {tti::CommitKind::AsyncCp, "async_copy_shared_to_global"});
+    kinds.push_back({tti::CommitKind::TmaStore, "async_tdm_shared_to_global"});
+    return kinds;
   }
 
   SmallVector<tti::CommitKind::Kind>
@@ -175,14 +182,17 @@ public:
     SmallVector<tti::CommitKind::Kind> kinds;
     bool needsTdm = false;
     bool needsAsyncCp = false;
+    hasAsyncCopyReads = false;
     module.walk([&](Operation *op) {
-      if (isa<ttag::AsyncTDMCopyGlobalToLocalOp,
-              ttag::AsyncTDMFusedCopyGlobalToLocalOp,
-              ttag::AsyncTDMCopyLocalToGlobalOp, ttag::AsyncTDMWait,
-              ttag::AsyncTDMIntrinsicWait>(op))
+      if (isa<ttag::TDMOpInterface, ttag::AsyncTDMFusedCopyGlobalToLocalOp,
+              ttag::AsyncTDMWait, ttag::AsyncTDMIntrinsicWait>(op))
         needsTdm = true;
-      if (isa<ttag::AsyncWaitOp>(op))
+      if (isa<ttg::AsyncCopyGlobalToLocalOp, ttg::AsyncCommitGroupOp,
+              ttg::AsyncWaitOp, ttag::BufferLoadToLocalOp,
+              ttag::AsyncCopyLocalToGlobalOp, ttag::AsyncWaitOp>(op))
         needsAsyncCp = true;
+      if (isa<ttag::AsyncCopyLocalToGlobalOp>(op))
+        hasAsyncCopyReads = true;
     });
     if (needsTdm)
       kinds.push_back(tti::CommitKind::TmaStore);

--- a/third_party/amd/lib/TritonAMDGPUTransforms/ConSanAMD.cpp
+++ b/third_party/amd/lib/TritonAMDGPUTransforms/ConSanAMD.cpp
@@ -95,54 +95,29 @@ public:
 
   std::optional<MemEffectsOpInfo>
   getMemEffectsOpInfo(Operation *op) const override {
-    if (auto loadOp = dyn_cast<ttag::BufferLoadToLocalOp>(op)) {
+    bool isAsyncCopy =
+        isa<ttag::BufferLoadToLocalOp, ttag::AsyncCopyLocalToGlobalOp>(op);
+    if (isAsyncCopy || isTMAOp(op)) {
       MemEffectsOpInfo info;
-      info.trackingKind = MemEffectsOpInfo::TrackingKind::CommitCount;
-      info.commitKind = tti::CommitKind::AsyncCp;
-      info.operandEffects.emplace_back(MemEffectsOpInfo::Effects::Write,
-                                       loadOp.getDest());
-      return info;
-    }
-
-    if (auto storeOp = dyn_cast<ttag::AsyncCopyLocalToGlobalOp>(op)) {
-      MemEffectsOpInfo info;
-      info.trackingKind = MemEffectsOpInfo::TrackingKind::CommitCount;
-      info.commitKind = tti::CommitKind::AsyncCp;
-      info.operandEffects.emplace_back(MemEffectsOpInfo::Effects::Read,
-                                       storeOp.getSrc());
-      return info;
-    }
-
-    if (isa<ttag::TDMOpInterface>(op)) {
-      MemEffectsOpInfo info;
-      Value barrier = cast<ttg::MBarrierOpInterface>(op).getBarrier();
+      Value barrier;
+      if (auto barrierOp = dyn_cast<ttg::MBarrierOpInterface>(op))
+        barrier = barrierOp.getBarrier();
       if (barrier) {
         info.trackingKind = MemEffectsOpInfo::TrackingKind::Barrier;
         info.barriers.push_back({barrier, nullptr, ttg::lookupNumWarps(op)});
       } else {
         info.trackingKind = MemEffectsOpInfo::TrackingKind::CommitCount;
-        info.commitKind = tti::CommitKind::TmaStore;
-        info.implicitCommit = true;
+        info.commitKind =
+            isAsyncCopy ? tti::CommitKind::AsyncCp : tti::CommitKind::TmaStore;
+        info.implicitCommit = !isAsyncCopy;
       }
       for (const auto &access :
-           triton::BufferRegionAnalysis::getMemoryAccesses(op)) {
+           triton::BufferRegionAnalysis::getMemoryAccesses(op))
         if (access.value != barrier)
           info.operandEffects.emplace_back(
               access.isWrite ? MemEffectsOpInfo::Effects::Write
                              : MemEffectsOpInfo::Effects::Read,
               access.value);
-      }
-      return info;
-    }
-
-    if (auto fusedOp = dyn_cast<ttag::AsyncTDMFusedCopyGlobalToLocalOp>(op)) {
-      MemEffectsOpInfo info;
-      info.trackingKind = MemEffectsOpInfo::TrackingKind::CommitCount;
-      info.commitKind = tti::CommitKind::TmaStore;
-      info.implicitCommit = true;
-      for (Value dest : fusedOp.getDests())
-        info.operandEffects.emplace_back(MemEffectsOpInfo::Effects::Write,
-                                         dest);
       return info;
     }
     // AMD ArriveBarrierOp: Explicit barrier arrival.
@@ -169,12 +144,10 @@ public:
   }
 
   SmallVector<CommitKindDesc> getOutstandingReadCommitKinds() const override {
-    SmallVector<CommitKindDesc> kinds;
-    if (hasAsyncCopyReads)
-      kinds.push_back(
-          {tti::CommitKind::AsyncCp, "async_copy_shared_to_global"});
-    kinds.push_back({tti::CommitKind::TmaStore, "async_tdm_shared_to_global"});
-    return kinds;
+    if (!hasAsyncCopyReads)
+      return {{tti::CommitKind::TmaStore, "async_tdm_shared_to_global"}};
+    return {{tti::CommitKind::AsyncCp, "async_copy_shared_to_global"},
+            {tti::CommitKind::TmaStore, "async_tdm_shared_to_global"}};
   }
 
   SmallVector<tti::CommitKind::Kind>
@@ -184,15 +157,13 @@ public:
     bool needsAsyncCp = false;
     hasAsyncCopyReads = false;
     module.walk([&](Operation *op) {
-      if (isa<ttag::TDMOpInterface, ttag::AsyncTDMFusedCopyGlobalToLocalOp,
-              ttag::AsyncTDMWait, ttag::AsyncTDMIntrinsicWait>(op))
-        needsTdm = true;
-      if (isa<ttg::AsyncCopyGlobalToLocalOp, ttg::AsyncCommitGroupOp,
+      needsTdm |= isTMAOp(op) ||
+                  isa<ttag::AsyncTDMWait, ttag::AsyncTDMIntrinsicWait>(op);
+      needsAsyncCp |=
+          isa<ttg::AsyncCopyGlobalToLocalOp, ttg::AsyncCommitGroupOp,
               ttg::AsyncWaitOp, ttag::BufferLoadToLocalOp,
-              ttag::AsyncCopyLocalToGlobalOp, ttag::AsyncWaitOp>(op))
-        needsAsyncCp = true;
-      if (isa<ttag::AsyncCopyLocalToGlobalOp>(op))
-        hasAsyncCopyReads = true;
+              ttag::AsyncCopyLocalToGlobalOp, ttag::AsyncWaitOp>(op);
+      hasAsyncCopyReads |= isa<ttag::AsyncCopyLocalToGlobalOp>(op);
     });
     if (needsTdm)
       kinds.push_back(tti::CommitKind::TmaStore);

--- a/third_party/amd/lib/TritonAMDGPUTransforms/ConSanAMD.cpp
+++ b/third_party/amd/lib/TritonAMDGPUTransforms/ConSanAMD.cpp
@@ -17,8 +17,6 @@ using tti::WaitOpInfo;
 namespace mlir {
 
 class AMDConSanHooks : public tti::ConSanTargetHooks {
-  mutable bool hasAsyncCopyReads = false;
-
 public:
   bool isTMAOp(Operation *op) const override {
     return isa<ttag::TDMOpInterface, ttag::AsyncTDMFusedCopyGlobalToLocalOp>(
@@ -53,12 +51,13 @@ public:
     return std::nullopt;
   }
 
-  std::optional<WaitOpInfo> getWaitOpInfo(Operation *op) const override {
+  std::optional<WaitOpInfo>
+  getWaitOpInfo(Operation *op, const tti::AuxDataMap &auxData) const override {
     // On asyncmark targets (CDNA3/CDNA4), ttg::AsyncWaitOp is kept as-is
     // by UpdateAsyncWaitCount — read the commit group count directly.
     if (auto asyncWaitOp = dyn_cast<ttg::AsyncWaitOp>(op)) {
       return WaitOpInfo{tti::CommitKind::AsyncCp, (int)asyncWaitOp.getNum(),
-                        /*transferWrites=*/true, hasAsyncCopyReads};
+                        /*transferWrites=*/true, auxData.hasAsyncCopyReads};
     }
     // On non-asyncmark targets, amdgpu::AsyncWaitOp replaces ttg::AsyncWaitOp
     // after UpdateAsyncWaitCount. Read the preserved commit-group count.
@@ -66,7 +65,7 @@ public:
       if (auto attr = asyncWaitOp->getAttrOfType<IntegerAttr>(
               "ttg.num_commit_groups")) {
         return WaitOpInfo{tti::CommitKind::AsyncCp, (int)attr.getInt(),
-                          /*transferWrites=*/true, hasAsyncCopyReads};
+                          /*transferWrites=*/true, auxData.hasAsyncCopyReads};
       }
       return std::nullopt;
     }
@@ -98,7 +97,7 @@ public:
     bool isAsyncCopy =
         isa<ttag::BufferLoadToLocalOp, ttag::AsyncCopyLocalToGlobalOp>(op);
     if (isAsyncCopy || isTMAOp(op)) {
-      MemEffectsOpInfo info;
+      MemEffectsOpInfo info = *ConSanTargetHooks::getMemEffectsOpInfo(op);
       Value barrier;
       if (auto barrierOp = dyn_cast<ttg::MBarrierOpInterface>(op))
         barrier = barrierOp.getBarrier();
@@ -111,13 +110,6 @@ public:
             isAsyncCopy ? tti::CommitKind::AsyncCp : tti::CommitKind::TmaStore;
         info.implicitCommit = !isAsyncCopy;
       }
-      for (const auto &access :
-           triton::BufferRegionAnalysis::getMemoryAccesses(op))
-        if (access.value != barrier)
-          info.operandEffects.emplace_back(
-              access.isWrite ? MemEffectsOpInfo::Effects::Write
-                             : MemEffectsOpInfo::Effects::Read,
-              access.value);
       return info;
     }
     // AMD ArriveBarrierOp: Explicit barrier arrival.
@@ -143,8 +135,9 @@ public:
             {tti::CommitKind::TmaStore, "async_tdm_global_to_shared"}};
   }
 
-  SmallVector<CommitKindDesc> getOutstandingReadCommitKinds() const override {
-    if (!hasAsyncCopyReads)
+  SmallVector<CommitKindDesc>
+  getOutstandingReadCommitKinds(const tti::AuxDataMap &auxData) const override {
+    if (!auxData.hasAsyncCopyReads)
       return {{tti::CommitKind::TmaStore, "async_tdm_shared_to_global"}};
     return {{tti::CommitKind::AsyncCp, "async_copy_shared_to_global"},
             {tti::CommitKind::TmaStore, "async_tdm_shared_to_global"}};
@@ -155,7 +148,6 @@ public:
     SmallVector<tti::CommitKind::Kind> kinds;
     bool needsTdm = false;
     bool needsAsyncCp = false;
-    hasAsyncCopyReads = false;
     module.walk([&](Operation *op) {
       needsTdm |= isTMAOp(op) ||
                   isa<ttag::AsyncTDMWait, ttag::AsyncTDMIntrinsicWait>(op);
@@ -163,7 +155,6 @@ public:
           isa<ttg::AsyncCopyGlobalToLocalOp, ttg::AsyncCommitGroupOp,
               ttg::AsyncWaitOp, ttag::BufferLoadToLocalOp,
               ttag::AsyncCopyLocalToGlobalOp, ttag::AsyncWaitOp>(op);
-      hasAsyncCopyReads |= isa<ttag::AsyncCopyLocalToGlobalOp>(op);
     });
     if (needsTdm)
       kinds.push_back(tti::CommitKind::TmaStore);

--- a/third_party/nvidia/lib/TritonNVIDIAGPUToLLVM/TritonGPUToLLVM.cpp
+++ b/third_party/nvidia/lib/TritonNVIDIAGPUToLLVM/TritonGPUToLLVM.cpp
@@ -113,8 +113,8 @@ struct ConvertTritonGPUToLLVM
     if (enableConcurrencySanitizer) {
       auto hooks = mlir::triton::instrument::createConSanHooks("nvidia");
       assert(hooks && "no ConSan hooks registered for nvidia");
-      if (failed(mlir::triton::instrument::runConcurrencySanitizer(
-              mod, hooks.get())))
+      if (failed(
+              mlir::triton::instrument::runConcurrencySanitizer(mod, *hooks)))
         return signalPassFailure();
       mlir::PassManager cleanupPm(context);
       cleanupPm.addPass(mlir::triton::gluon::createGluonCanonicalize());

--- a/unittest/Analysis/UtilityTest.cpp
+++ b/unittest/Analysis/UtilityTest.cpp
@@ -67,19 +67,25 @@ TEST(Analysis, AddressSetExhaustiveEightUnitUniverse) {
   }
 }
 
-TEST(Analysis, BufferRegionIdentityPreservesSubviewProvenance) {
-  triton::AddressSet addresses = triton::AddressSet::fromRange(16, 8);
-  triton::BufferRegion fromSubview(
-      /*baseOffset=*/16, /*length=*/8, addresses,
-      /*storageBase=*/0, /*affineOffset=*/16);
-  triton::BufferRegion fromAllocation(
-      /*baseOffset=*/16, /*length=*/8, addresses,
-      /*storageBase=*/16, /*affineOffset=*/0);
+TEST(Analysis, BufferRegionViewPreservesSubviewProvenance) {
+  triton::BufferRegion region(
+      /*baseOffset=*/16, /*length=*/8,
+      triton::AddressSet::fromRange(/*begin=*/16, /*length=*/8));
+  triton::BufferRegionView fromSubview{region, /*storageBase=*/0,
+                                       /*affineOffset=*/16};
+  triton::BufferRegionView fromAllocation{region, /*storageBase=*/16,
+                                          /*affineOffset=*/0};
 
+  EXPECT_EQ(fromSubview.region, fromAllocation.region);
   EXPECT_FALSE(fromSubview == fromAllocation);
   triton::RegionInfo joined = triton::RegionInfo::join(
       triton::RegionInfo({fromSubview}), triton::RegionInfo({fromAllocation}));
-  EXPECT_EQ(joined.regions.size(), 2);
+  EXPECT_EQ(joined.views.size(), 2);
+
+  std::set<triton::BufferRegion> physicalRegions;
+  for (const triton::BufferRegionView &view : joined.views)
+    physicalRegions.insert(view.region);
+  EXPECT_EQ(physicalRegions.size(), 1);
 }
 
 namespace {
@@ -112,8 +118,7 @@ triton::BufferRegion makeRegion(unsigned id, unsigned addressMask,
       addresses.push_back(bit);
   return triton::BufferRegion(
       /*baseOffset=*/id * 16, /*length=*/universe,
-      triton::AddressSet::fromAddresses(addresses),
-      /*storageBase=*/0, /*affineOffset=*/0);
+      triton::AddressSet::fromAddresses(addresses));
 }
 
 bool planNeverMissesHazard(ArrayRef<unsigned> addressMasks, unsigned universe) {
@@ -255,8 +260,7 @@ TEST(Analysis, BufferStatePlanKeepsLargeSparsePartitionsExact) {
     for (uint32_t stripe = 0; stripe < stripeCount; ++stripe)
       addresses.insert(triton::AddressSet::fromRange(
           (stripe * tileCount + tile) * stripeLength, stripeLength));
-    regions.emplace_back(tile * stripeLength, tileLength, std::move(addresses),
-                         /*storageBase=*/0, /*affineOffset=*/0);
+    regions.emplace_back(tile * stripeLength, tileLength, std::move(addresses));
   }
 
   expectFullCoveragePartition(regions);

--- a/unittest/Analysis/UtilityTest.cpp
+++ b/unittest/Analysis/UtilityTest.cpp
@@ -27,20 +27,6 @@ TEST(Analysis, reorder) {
   }
 }
 
-TEST(Analysis, AddressSetMembership) {
-  triton::AddressSet set = triton::AddressSet::fromRange(1, 4);
-  set.insert(triton::AddressSet::fromRange(8, 6));
-  set.set(10);
-
-  EXPECT_TRUE(set.contains(1));
-  EXPECT_FALSE(set.contains(5));
-  EXPECT_TRUE(set.contains(13));
-
-  triton::AddressSet same =
-      triton::AddressSet::fromAddresses({13, 12, 11, 10, 9, 8, 4, 3, 2, 1, 10});
-  EXPECT_EQ(set, same);
-}
-
 TEST(Analysis, AddressSetExhaustiveEightUnitUniverse) {
   constexpr unsigned universe = 8;
   auto fromMask = [](unsigned mask) {
@@ -68,9 +54,10 @@ TEST(Analysis, AddressSetExhaustiveEightUnitUniverse) {
 }
 
 TEST(Analysis, BufferRegionViewPreservesSubviewProvenance) {
-  triton::BufferRegion region(
-      /*baseOffset=*/16, /*length=*/8,
-      triton::AddressSet::fromRange(/*begin=*/16, /*length=*/8));
+  triton::BufferRegion region{
+      /*baseOffset=*/16,
+      /*length=*/8,
+      {{0, triton::AddressSet::fromRange(/*begin=*/16, /*length=*/8)}}};
   triton::BufferRegionView fromSubview{region, /*storageBase=*/0,
                                        /*affineOffset=*/16};
   triton::BufferRegionView fromAllocation{region, /*storageBase=*/16,
@@ -112,13 +99,14 @@ void expectFullCoveragePartition(ArrayRef<triton::BufferRegion> regions) {
 
 triton::BufferRegion makeRegion(unsigned id, unsigned addressMask,
                                 unsigned universe) {
-  SmallVector<uint32_t> addresses;
+  triton::AddressSet addresses;
   for (unsigned bit = 0; bit < universe; ++bit)
     if (addressMask & (1u << bit))
-      addresses.push_back(bit);
-  return triton::BufferRegion(
-      /*baseOffset=*/id * 16, /*length=*/universe,
-      triton::AddressSet::fromAddresses(addresses));
+      addresses.set(bit);
+  triton::BufferRegion region{/*baseOffset=*/id * 16, /*length=*/universe};
+  if (!addresses.empty())
+    region.ctaAddresses.emplace_back(0, std::move(addresses));
+  return region;
 }
 
 bool planNeverMissesHazard(ArrayRef<unsigned> addressMasks, unsigned universe) {
@@ -239,9 +227,16 @@ TEST(Analysis, BufferStatePlanKeepsLargePaddedIntervalsExact) {
   constexpr uint32_t tileLength = 3648;
   SmallVector<triton::BufferRegion> regions;
   regions.reserve(tileCount);
-  regions.emplace_back(0, tileCount * tileLength);
-  for (uint32_t tile = 0; tile < tileCount - 1; ++tile)
-    regions.emplace_back(tile * tileLength, tileLength);
+  regions.push_back(
+      {0,
+       tileCount * tileLength,
+       {{0, triton::AddressSet::fromRange(0, tileCount * tileLength)}}});
+  for (uint32_t tile = 0; tile < tileCount - 1; ++tile) {
+    uint32_t base = tile * tileLength;
+    regions.push_back({base,
+                       tileLength,
+                       {{0, triton::AddressSet::fromRange(base, tileLength)}}});
+  }
 
   expectFullCoveragePartition(regions);
 }
@@ -253,14 +248,18 @@ TEST(Analysis, BufferStatePlanKeepsLargeSparsePartitionsExact) {
   constexpr uint32_t tileLength = stripeCount * stripeLength;
   SmallVector<triton::BufferRegion> regions;
   regions.reserve(tileCount);
-  regions.emplace_back(0, tileCount * tileLength);
+  regions.push_back(
+      {0,
+       tileCount * tileLength,
+       {{0, triton::AddressSet::fromRange(0, tileCount * tileLength)}}});
 
   for (uint32_t tile = 0; tile < tileCount - 1; ++tile) {
     triton::AddressSet addresses;
     for (uint32_t stripe = 0; stripe < stripeCount; ++stripe)
       addresses.insert(triton::AddressSet::fromRange(
           (stripe * tileCount + tile) * stripeLength, stripeLength));
-    regions.emplace_back(tile * stripeLength, tileLength, std::move(addresses));
+    regions.push_back(
+        {tile * stripeLength, tileLength, {{0, std::move(addresses)}}});
   }
 
   expectFullCoveragePartition(regions);


### PR DESCRIPTION
non-test diff: +595, -556

Generalize and clean up the buffer region analysis:
- Properly handle all the weird AMD layouts, in particular the one that comes with multiple base offsets
- Properly handle CTA offsets for memdesc subslices across CTAs
- Split BufferRegion (physical address sets) from BufferRegionView (view transformations on a buffer region) 
- Derive memory effects from MemoryEffectsOpInterface
- Fix some bugs in AMD op handling
- Delete unnecessary IR validation, since `ops supported by BufferRegion == valid IR`
-  Split the dataflow state from BufferRegion and actually model an `unknown` state