### PR TITLE
Prefer {Optional,Required}PassInfoMixin

### DIFF
--- a/lib/Target/LLVMIR/LLVMPasses.h
+++ b/lib/Target/LLVMIR/LLVMPasses.h
@@ -7,7 +7,8 @@ namespace llvm {
 // Pass to pre-process LLVM IR before optimization and break up phi of struct.
 // Breaking up those phis into elementary types allows better optimizations
 // downstream.
-struct BreakStructPhiNodesPass : PassInfoMixin<BreakStructPhiNodesPass> {
+struct BreakStructPhiNodesPass
+    : OptionalPassInfoMixin<BreakStructPhiNodesPass> {
   PreservedAnalyses run(Function &F, FunctionAnalysisManager &AM);
 
   static StringRef name() { return "BreakStructPhiNodesPass"; }

--- a/python/src/llvm.cc
+++ b/python/src/llvm.cc
@@ -50,7 +50,8 @@
 namespace py = nanobind;
 
 namespace llvm {
-struct BreakStructPhiNodesPass : PassInfoMixin<BreakStructPhiNodesPass> {
+struct BreakStructPhiNodesPass
+    : OptionalPassInfoMixin<BreakStructPhiNodesPass> {
   PreservedAnalyses run(Function &F, FunctionAnalysisManager &AM);
   static StringRef name() { return "BreakStructPhiNodesPass"; }
 };

--- a/test/lib/Instrumentation/GPUHello.cpp
+++ b/test/lib/Instrumentation/GPUHello.cpp
@@ -12,7 +12,7 @@ using namespace std;
 
 namespace {
 
-struct GpuHello : public PassInfoMixin<GpuHello> {
+struct GpuHello : public RequiredPassInfoMixin<GpuHello> {
   PreservedAnalyses run(Module &module, ModuleAnalysisManager &) {
     bool modifiedCodeGen = runOnModule(module);
 
@@ -20,9 +20,6 @@ struct GpuHello : public PassInfoMixin<GpuHello> {
                             : llvm::PreservedAnalyses::all());
   }
   bool runOnModule(llvm::Module &module);
-  // isRequired being set to true keeps this pass from being skipped
-  // if it has the optnone LLVM attribute
-  static bool isRequired() { return true; }
 };
 
 } // end anonymous namespace


### PR DESCRIPTION
Raw PassInfoMixin will be removed in LLVM 24. LLVM 23 prefers using OptionalPassInfoMixin or RequiredPassInfoMixin to specify intent around optnone rather than explicitly setting isRequired.

<!---
The core Triton is a small number of people, and we receive many PRs (thank
you!).  To help us review your code more quickly, **if you are a new
contributor (less than 3 PRs merged) we ask that you complete the following
tasks and include the filled-out checklist in your PR description.**

Complete the following tasks before sending your PR, and replace `[ ]` with
`[x]` to indicate you have done them.
-->

# New contributor declaration
- [x] I am not making a trivial change, such as fixing a typo in a comment.

- [x] I have written a PR description following these
  [rules](https://cbea.ms/git-commit/#why-not-how).

- [x] I have run `pre-commit run --from-ref origin/main --to-ref HEAD`.

- Select one of the following.
  - [ ] I have added tests.
    - `/test` for `lit` tests
    - `/unittest` for C++ tests
    - `/python/test` for end-to-end tests
  - [x] This PR does not need a test because `This is an NFC refactoring that should not change any behavior.`.

- Select one of the following.
  - [x] I have not added any `lit` tests.
  - [ ] The `lit` tests I have added follow these [best practices](https://mlir.llvm.org/getting_started/TestingGuide/#filecheck-best-practices),
    including the "tests should be minimal" section. (Usually running Python code
    and using the instructions it generates is not minimal.)
