### PR TITLE
Avoid broadcast layouts for dense elementwise operations

### DIFF
--- a/lib/Dialect/TritonGPU/Transforms/RemoveLayoutConversions.cpp
+++ b/lib/Dialect/TritonGPU/Transforms/RemoveLayoutConversions.cpp
@@ -239,6 +239,15 @@ bool isLayoutAnchor(Operation *op) {
   return false;
 }
 
+// Look through layout conversions to identify values with repeated elements.
+// Their layouts do not describe how distinct values should be distributed
+// along the repeated dimensions.
+bool hasRepeatedElements(Value value) {
+  while (auto convert = value.getDefiningOp<ConvertLayoutOp>())
+    value = convert.getSrc();
+  return isa_and_nonnull<BroadcastOp, SplatOp>(value.getDefiningOp());
+}
+
 void LayoutPropagation::initAnchorLayout() {
   auto addAnchor = [&](Value v) {
     if (auto tensorType = dyn_cast<RankedTensorType>(v.getType())) {
@@ -291,6 +300,21 @@ SmallVector<Value> LayoutPropagation::propagateToUsers(Value value,
   SmallVector<Value> changed;
   for (OpOperand &use : value.getUses()) {
     Operation *user = use.getOwner();
+    bool hasMmaCandidate = llvm::any_of(info.encodings, [](Attribute encoding) {
+      return isa<MmaEncodingTrait>(encoding);
+    });
+    // A layout propagated from repeated data does not describe how distinct
+    // values should be distributed along the repeated dimensions. Let a
+    // non-repeated tensor peer determine the elementwise result's layout.
+    // Preserve the existing conflict preference for MMA layouts, where some
+    // conversions between encodings are known to be free.
+    if (user->hasTrait<OpTrait::Elementwise>() && hasRepeatedElements(value) &&
+        !hasMmaCandidate &&
+        llvm::any_of(user->getOperands(), [&](Value operand) {
+          return operand != value && isa<RankedTensorType>(operand.getType()) &&
+                 !hasRepeatedElements(operand);
+        }))
+      continue;
     if (auto forOp = dyn_cast<scf::ForOp>(user)) {
       Value arg = forOp.getTiedLoopRegionIterArg(&use);
       Value result = forOp.getTiedLoopResult(&use);

--- a/test/TritonGPU/combine.mlir
+++ b/test/TritonGPU/combine.mlir
@@ -2504,10 +2504,13 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 8 : i32, "ttg.thr
   // Verify that we don't hoist the convert on top of the broadcast. In general we should hoist the convert to reduce its cost
   // but because this would combine the 1st and 2nd convert and since the 1st convert is known to be a no-op this would
   // generate more expensive code.
+  // CHECK: [[$MMA256:#.*]] = #ttg.nvidia_mma<{{.*}}instrShape = [16, 256, 32]{{.*}}>
+  // CHECK: [[$MMA128:#.*]] = #ttg.nvidia_mma<{{.*}}instrShape = [16, 128, 32]{{.*}}>
   // CHECK-LABEL: @hoist_with_free_convert
   tt.func public @hoist_with_free_convert(%arg0: tensor<128x256xf32, #mma1>, %arg1: tensor<128x1xf32, #mma>) -> tensor<128x256xf32, #blocked> {
-    // CHECK: ttg.convert_layout
-    // CHECK: tt.broadcast
+    // CHECK: ttg.convert_layout %arg0 : tensor<128x256xf32, [[$MMA256]]> -> tensor<128x256xf32, [[$MMA128]]>
+    // CHECK: tt.broadcast %arg1 : tensor<128x1xf32, [[$MMA128]]> -> tensor<128x256xf32, [[$MMA128]]>
+    // CHECK: arith.addf {{.*}} : tensor<128x256xf32, [[$MMA128]]>
     // CHECK: ttg.convert_layout
     // CHECK: tt.return
     %0 = ttg.convert_layout %arg0 : tensor<128x256xf32, #mma1> -> tensor<128x256xf32, #mma>
@@ -4535,5 +4538,61 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 1 : i32, "ttg.thr
     %1 = ttg.convert_layout %0 : tensor<32xf32, #blocked1> -> tensor<32xf32, #blocked2>
     %2 = ttg.convert_layout %0 : tensor<32xf32, #blocked1> -> tensor<32xf32, #blocked3>
     tt.return %1, %2 : tensor<32xf32, #blocked2>, tensor<32xf32, #blocked3>
+  }
+}
+
+// -----
+
+// Keep a dense elementwise layout when the other operand is broadcast from a
+// reduction result. Otherwise, the broadcast layout can expand the chained
+// division into one scalar operation per tensor element.
+
+// CHECK: [[$DENSE:#.*]] = #ttg.blocked<{sizePerThread = [1, 1], threadsPerWarp = [1, 32], warpsPerCTA = [1, 4], order = [1, 0]}>
+// CHECK-LABEL: @prefer_dense_layout_over_broadcast
+// CHECK: %[[DIV0:.+]] = arith.divf {{.*}} : tensor<16x256xf32, [[$DENSE]]>
+// CHECK: %[[DIV1:.+]] = arith.divf %[[DIV0]], {{.*}} : tensor<16x256xf32, [[$DENSE]]>
+// CHECK: %[[REDUCE:.+]] = "tt.reduce"(%[[DIV1]]) <{axis = 1 : i32}>
+// CHECK: }) : (tensor<16x256xf32, [[$DENSE]]>) -> tensor<16xf32, #ttg.slice<{dim = 1, parent = [[$DENSE]]}>>
+#row = #ttg.blocked<{sizePerThread = [1, 1], threadsPerWarp = [32, 1], warpsPerCTA = [4, 1], order = [1, 0]}>
+#one_d = #ttg.blocked<{sizePerThread = [1], threadsPerWarp = [32], warpsPerCTA = [4], order = [0]}>
+#dense = #ttg.blocked<{sizePerThread = [1, 1], threadsPerWarp = [1, 32], warpsPerCTA = [1, 4], order = [1, 0]}>
+module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, "ttg.threads-per-warp" = 32 : i32} {
+  tt.func public @prefer_dense_layout_over_broadcast(%arg0: tensor<16x256xf32, #dense>) -> tensor<16x256xf32, #dense> {
+    %0 = "tt.reduce"(%arg0) <{axis = 1 : i32}> ({
+    ^bb0(%arg1: f32, %arg2: f32):
+      %4 = arith.addf %arg1, %arg2 : f32
+      tt.reduce.return %4 : f32
+    }) : (tensor<16x256xf32, #dense>) -> tensor<16xf32, #ttg.slice<{dim = 1, parent = #dense}>>
+    %1 = ttg.convert_layout %0 : tensor<16xf32, #ttg.slice<{dim = 1, parent = #dense}>> -> tensor<16xf32, #one_d>
+    %2 = tt.reshape %1 : tensor<16xf32, #one_d> -> tensor<16x1xf32, #row>
+    %3 = tt.broadcast %2 : tensor<16x1xf32, #row> -> tensor<16x256xf32, #row>
+    %4 = ttg.convert_layout %3 : tensor<16x256xf32, #row> -> tensor<16x256xf32, #dense>
+    %5 = arith.divf %arg0, %4 : tensor<16x256xf32, #dense>
+    %6 = arith.divf %5, %4 : tensor<16x256xf32, #dense>
+    %7 = "tt.reduce"(%6) <{axis = 1 : i32}> ({
+    ^bb0(%arg1: f32, %arg2: f32):
+      %8 = arith.addf %arg1, %arg2 : f32
+      tt.reduce.return %8 : f32
+    }) : (tensor<16x256xf32, #dense>) -> tensor<16xf32, #ttg.slice<{dim = 1, parent = #dense}>>
+    %8 = ttg.convert_layout %7 : tensor<16xf32, #ttg.slice<{dim = 1, parent = #dense}>> -> tensor<16xf32, #one_d>
+    %9 = tt.reshape %8 : tensor<16xf32, #one_d> -> tensor<16x1xf32, #row>
+    %10 = tt.broadcast %9 : tensor<16x1xf32, #row> -> tensor<16x256xf32, #row>
+    %11 = ttg.convert_layout %10 : tensor<16x256xf32, #row> -> tensor<16x256xf32, #dense>
+    %12 = arith.addf %11, %6 : tensor<16x256xf32, #dense>
+    tt.return %12 : tensor<16x256xf32, #dense>
+  }
+
+  // CHECK-LABEL: @keep_broadcast_layout_with_splat
+  // CHECK-NOT: ttg.convert_layout
+  // CHECK: arith.addf {{.*}} : tensor<16x256xf32, [[$ROW:#.*]]>
+  // CHECK-NOT: ttg.convert_layout
+  // CHECK: tt.return
+  tt.func public @keep_broadcast_layout_with_splat(%arg0: tensor<16x1xf32, #row>, %arg1: f32) -> tensor<16x256xf32, #row> {
+    %0 = tt.broadcast %arg0 : tensor<16x1xf32, #row> -> tensor<16x256xf32, #row>
+    %1 = ttg.convert_layout %0 : tensor<16x256xf32, #row> -> tensor<16x256xf32, #dense>
+    %2 = tt.splat %arg1 : f32 -> tensor<16x256xf32, #dense>
+    %3 = arith.addf %1, %2 : tensor<16x256xf32, #dense>
+    %4 = ttg.convert_layout %3 : tensor<16x256xf32, #dense> -> tensor<16x256xf32, #row>
+    tt.return %4 : tensor<16x256xf32, #row>
   }
 }


### PR DESCRIPTION
## Summary

Prevent layouts propagated from broadcast or splat values from overriding a non-repeated tensor layout on elementwise operations.

The conflict in #10987 moved the second division and reduction to a broadcast-derived linear layout, expanding two source divisions into thousands of scalar divisions. The existing preference for MMA layouts is preserved because some MMA conversions are known to be free.

Fixes #10987.

## Result

For the issue reproducer compiled offline for sm90:

- main: 19,130 PTX lines and 4,128 `div.full.f32` instructions
- this PR: 2,061 PTX lines and 64 `div.full.f32` instructions

## Testing

- `make`
- `lit -v test/TritonGPU` (128 passed)
- `pre-commit run --from-ref origin/main --to-ref HEAD`

GPU runtime testing was unavailable because the local NVIDIA driver currently reports an NVML driver/library version mismatch. The regression is covered at TTGIR level and with a real offline Triton-to-PTX compile.

# New contributor declaration
- [x] I am not making a trivial change, such as fixing a typo in a comment.

- [x] I have written a PR description following these
  [rules](https://cbea.ms/git-commit/#why-not-how).

- [x] I have run `pre-commit run --from-ref origin/main --to-ref HEAD`.

- [x] I have added tests.
  - `/test` for `lit` tests

- [ ] This PR does not need a test because `FILL THIS IN`.

- [ ] I have not added any `lit` tests.
- [x] The `lit` tests I have added follow these [best practices](https://mlir.llvm.org/getting_started/TestingGuide/#filecheck-best-practices), including the "tests should be minimal" section.