### PR TITLE
[NVIDIA][Membar] Synchronize multi-warpgroup WGMMA reads after wait(0)

### DIFF
--- a/include/triton/Analysis/Membar.h
+++ b/include/triton/Analysis/Membar.h
@@ -89,6 +89,9 @@ struct BlockInfo {
 
   SliceMapT syncReadSlices;
   SliceMapT syncWriteSlices;
+  // Shared-memory reads issued by asynchronous operations that have not
+  // reached their completion wait. A CTA barrier alone cannot complete them.
+  SliceMapT pendingAsyncReadSlices;
 
   BlockInfo() = default;
 
@@ -101,7 +104,20 @@ struct BlockInfo {
     for (auto &slice : other.syncWriteSlices)
       syncWriteSlices[slice.first].insert(slice.second.begin(),
                                           slice.second.end());
+    for (auto &slice : other.pendingAsyncReadSlices)
+      pendingAsyncReadSlices[slice.first].insert(slice.second.begin(),
+                                                 slice.second.end());
     return *this;
+  }
+
+  /// Makes locally completed asynchronous reads visible to the regular
+  /// dependence analysis. A later conflicting write will then require a CTA
+  /// barrier before it can proceed.
+  void completeAsyncReads() {
+    for (auto &slice : pendingAsyncReadSlices)
+      syncReadSlices[slice.first].insert(slice.second.begin(),
+                                         slice.second.end());
+    pendingAsyncReadSlices.clear();
   }
 
   void dump() {
@@ -118,6 +134,15 @@ struct BlockInfo {
     }
     err << "  Write Intervals:\n";
     for (auto &[slice, ops] : syncWriteSlices) {
+      err << "    ";
+      slice.print(err);
+      err << " ";
+      for (auto &op : ops)
+        err << op->getName() << " ";
+      err << "\n";
+    }
+    err << "  Pending async read intervals:\n";
+    for (auto &[slice, ops] : pendingAsyncReadSlices) {
       err << "    ";
       slice.print(err);
       err << " ";
@@ -144,7 +169,8 @@ struct BlockInfo {
                          sliceFilter, allocation);
   }
 
-  /// Clears the slices because a barrier is inserted.
+  /// Clears synchronized slices because a barrier is inserted. Pending
+  /// asynchronous reads remain live until their completion wait.
   void sync() {
     syncReadSlices.clear();
     syncWriteSlices.clear();
@@ -153,7 +179,8 @@ struct BlockInfo {
   /// Compares two BlockInfo objects.
   bool operator==(const BlockInfo &other) const {
     return syncReadSlices == other.syncReadSlices &&
-           syncWriteSlices == other.syncWriteSlices;
+           syncWriteSlices == other.syncWriteSlices &&
+           pendingAsyncReadSlices == other.pendingAsyncReadSlices;
   }
 
   bool operator!=(const BlockInfo &other) const { return !(*this == other); }
@@ -194,6 +221,8 @@ inline BlockInfo translateBlockInfoToCallsite(const BlockInfo &calleeBlockInfo,
                   translatedBlockInfo.syncReadSlices);
   translateSlices(calleeBlockInfo.syncWriteSlices,
                   translatedBlockInfo.syncWriteSlices);
+  translateSlices(calleeBlockInfo.pendingAsyncReadSlices,
+                  translatedBlockInfo.pendingAsyncReadSlices);
   return translatedBlockInfo;
 }
 

--- a/lib/Analysis/Membar.cpp
+++ b/lib/Analysis/Membar.cpp
@@ -368,6 +368,15 @@ void MembarAnalysis::update(Operation *op, BlockInfo *blockInfo,
     blockInfo->sync();
   }
 
+  // wgmma.wait_group is local to one warp group. Once every WGMMA is complete
+  // locally, restore its shared-memory reads to the dependence state so that a
+  // later conflicting write gets a CTA barrier. Reads must survive barriers
+  // that occur before the wait because those barriers do not complete WGMMA.
+  if (auto wait = dyn_cast<ttng::WarpGroupDotWaitOp>(op);
+      wait && wait.getPendings() == 0 && triton::gpu::lookupNumWarps(op) > 4) {
+    blockInfo->completeAsyncReads();
+  }
+
   // If the current op is an (async) memory wait and there is no later sync
   // point before memory is accessed, insert a barrier op and sync. This avoids
   // redundant barriers by deferring the barrier to the later sync point.
@@ -416,6 +425,11 @@ void MembarAnalysis::update(Operation *op, BlockInfo *blockInfo,
         }
       }
     }
+  }
+
+  if (auto dot = dyn_cast<ttng::WarpGroupDotOp>(op);
+      dot && dot.getIsAsync() && triton::gpu::lookupNumWarps(op) > 4) {
+    curBlockInfo.pendingAsyncReadSlices = curBlockInfo.syncReadSlices;
   }
 
   // Scratch buffer operations consist of a series of shared memory operations

--- a/test/Analysis/test-membar.mlir
+++ b/test/Analysis/test-membar.mlir
@@ -1476,6 +1476,134 @@ module attributes {ttg.target = "cuda:90", "ttg.num-warps" = 8 : i32} {
     ttng.async_tma_copy_global_to_local %arg0[%arg2, %arg2, %arg2] %b_tile, %barrier, %arg3 : !tt.tensordesc<1x256x128xf8E5M2, #shared1>, !ttg.memdesc<1xi64, #shared2, #smem, mutable> -> !ttg.memdesc<256x128xf8E5M2, #shared1, #smem, mutable>
     tt.return
   }
+
+  // A CTA barrier before a full WGMMA wait cannot synchronize asynchronous
+  // shared-memory reads. Once every warp group has waited locally, another
+  // CTA barrier is required before the allocation can be overwritten.
+  // CHECK-LABEL: warp_dot_wait_cross_warpgroup_reuse
+  tt.func @warp_dot_wait_cross_warpgroup_reuse(%arg0: tensor<128x128x!tt.ptr<f8E5M2>>, %arg1: tensor<128x256xf32, #mma>, %arg2: tensor<128x128xi1>) {
+    %a_tile = ttg.local_alloc : () -> !ttg.memdesc<128x128xf8E5M2, #shared1, #smem, mutable>
+    %b_tile = ttg.local_alloc : () -> !ttg.memdesc<256x128xf8E5M2, #shared1, #smem, mutable>
+    %b_trans = ttg.memdesc_trans %b_tile {order = array<i32: 1, 0>} : !ttg.memdesc<256x128xf8E5M2, #shared1, #smem, mutable> -> !ttg.memdesc<128x256xf8E5M2, #shared3, #smem, mutable>
+
+    // CHECK: ttng.warp_group_dot
+    %dot = ttng.warp_group_dot %a_tile, %b_trans, %arg1 {inputPrecision = 0 : i32, isAsync = true, maxNumImpreciseAcc = 1073741824 : i32} : !ttg.memdesc<128x128xf8E5M2, #shared1, #smem, mutable> * !ttg.memdesc<128x256xf8E5M2, #shared3, #smem, mutable> -> tensor<128x256xf32, #mma>
+    // CHECK-NEXT: ttg.barrier local
+    ttg.barrier local
+    // CHECK-NEXT: ttng.warp_group_dot_wait
+    %0:3 = ttng.warp_group_dot_wait %dot, %a_tile, %b_trans {pendings = 0 : i32} : tensor<128x256xf32, #mma>, !ttg.memdesc<128x128xf8E5M2, #shared1, #smem, mutable>, !ttg.memdesc<128x256xf8E5M2, #shared3, #smem, mutable>
+    // CHECK-NEXT: ttg.barrier local
+    // CHECK-NEXT: ttg.async_copy_global_to_local
+    ttg.async_copy_global_to_local %arg0, %a_tile mask %arg2 {contiguity = 16 : i32} : tensor<128x128x!tt.ptr<f8E5M2>> -> <128x128xf8E5M2, #shared1, #smem, mutable>
+    tt.return
+  }
+
+  // Do not insert a barrier when no shared-memory write follows the wait.
+  // CHECK-LABEL: warp_dot_wait_cross_warpgroup_no_reuse
+  tt.func @warp_dot_wait_cross_warpgroup_no_reuse(%arg0: tensor<128x256xf32, #mma>) {
+    %a_tile = ttg.local_alloc : () -> !ttg.memdesc<128x128xf8E5M2, #shared1, #smem, mutable>
+    %b_tile = ttg.local_alloc : () -> !ttg.memdesc<256x128xf8E5M2, #shared1, #smem, mutable>
+    %b_trans = ttg.memdesc_trans %b_tile {order = array<i32: 1, 0>} : !ttg.memdesc<256x128xf8E5M2, #shared1, #smem, mutable> -> !ttg.memdesc<128x256xf8E5M2, #shared3, #smem, mutable>
+
+    // CHECK: ttng.warp_group_dot
+    %dot = ttng.warp_group_dot %a_tile, %b_trans, %arg0 {inputPrecision = 0 : i32, isAsync = true, maxNumImpreciseAcc = 1073741824 : i32} : !ttg.memdesc<128x128xf8E5M2, #shared1, #smem, mutable> * !ttg.memdesc<128x256xf8E5M2, #shared3, #smem, mutable> -> tensor<128x256xf32, #mma>
+    // CHECK-NEXT: ttg.barrier local
+    ttg.barrier local
+    // CHECK-NEXT: ttng.warp_group_dot_wait
+    %0:3 = ttng.warp_group_dot_wait %dot, %a_tile, %b_trans {pendings = 0 : i32} : tensor<128x256xf32, #mma>, !ttg.memdesc<128x128xf8E5M2, #shared1, #smem, mutable>, !ttg.memdesc<128x256xf8E5M2, #shared3, #smem, mutable>
+    // CHECK-NEXT: tt.return
+    tt.return
+  }
+
+  // Conservatively keep the union of shared-memory reads pending across a
+  // nonzero wait, then complete the union at the subsequent full wait.
+  // CHECK-LABEL: warp_dot_nonzero_then_full_wait
+  tt.func @warp_dot_nonzero_then_full_wait(%arg0: tensor<128x128x!tt.ptr<f8E5M2>>, %arg1: tensor<128x256xf32, #mma>, %arg2: tensor<128x128xi1>) {
+    %a_tile = ttg.local_alloc : () -> !ttg.memdesc<128x128xf8E5M2, #shared1, #smem, mutable>
+    %b_tile = ttg.local_alloc : () -> !ttg.memdesc<256x128xf8E5M2, #shared1, #smem, mutable>
+    %b_trans = ttg.memdesc_trans %b_tile {order = array<i32: 1, 0>} : !ttg.memdesc<256x128xf8E5M2, #shared1, #smem, mutable> -> !ttg.memdesc<128x256xf8E5M2, #shared3, #smem, mutable>
+
+    // CHECK: ttng.warp_group_dot
+    %dot = ttng.warp_group_dot %a_tile, %b_trans, %arg1 {inputPrecision = 0 : i32, isAsync = true, maxNumImpreciseAcc = 1073741824 : i32} : !ttg.memdesc<128x128xf8E5M2, #shared1, #smem, mutable> * !ttg.memdesc<128x256xf8E5M2, #shared3, #smem, mutable> -> tensor<128x256xf32, #mma>
+    // CHECK-NEXT: ttg.barrier local
+    ttg.barrier local
+    // CHECK-NEXT: %[[PARTIAL:.*]]:3 = ttng.warp_group_dot_wait {{.*}} {pendings = 1 : i32}
+    %partial:3 = ttng.warp_group_dot_wait %dot, %a_tile, %b_trans {pendings = 1 : i32} : tensor<128x256xf32, #mma>, !ttg.memdesc<128x128xf8E5M2, #shared1, #smem, mutable>, !ttg.memdesc<128x256xf8E5M2, #shared3, #smem, mutable>
+    // CHECK-NEXT: ttng.warp_group_dot_wait %[[PARTIAL]]#0, %[[PARTIAL]]#1, %[[PARTIAL]]#2 {pendings = 0 : i32}
+    %full:3 = ttng.warp_group_dot_wait %partial#0, %partial#1, %partial#2 {pendings = 0 : i32} : tensor<128x256xf32, #mma>, !ttg.memdesc<128x128xf8E5M2, #shared1, #smem, mutable>, !ttg.memdesc<128x256xf8E5M2, #shared3, #smem, mutable>
+    // CHECK-NEXT: ttg.barrier local
+    // CHECK-NEXT: ttg.async_copy_global_to_local
+    ttg.async_copy_global_to_local %arg0, %a_tile mask %arg2 {contiguity = 16 : i32} : tensor<128x128x!tt.ptr<f8E5M2>> -> <128x128xf8E5M2, #shared1, #smem, mutable>
+    tt.return
+  }
+
+  // A full wait does not require a barrier before writing a disjoint
+  // allocation.
+  // CHECK-LABEL: warp_dot_wait_cross_warpgroup_disjoint_reuse
+  tt.func @warp_dot_wait_cross_warpgroup_disjoint_reuse(%arg0: tensor<128x128x!tt.ptr<f8E5M2>>, %arg1: tensor<128x256xf32, #mma>, %arg2: tensor<128x128xi1>) {
+    %a_tile = ttg.local_alloc : () -> !ttg.memdesc<128x128xf8E5M2, #shared1, #smem, mutable>
+    %other_tile = ttg.local_alloc : () -> !ttg.memdesc<128x128xf8E5M2, #shared1, #smem, mutable>
+    %b_tile = ttg.local_alloc : () -> !ttg.memdesc<256x128xf8E5M2, #shared1, #smem, mutable>
+    %b_trans = ttg.memdesc_trans %b_tile {order = array<i32: 1, 0>} : !ttg.memdesc<256x128xf8E5M2, #shared1, #smem, mutable> -> !ttg.memdesc<128x256xf8E5M2, #shared3, #smem, mutable>
+
+    // CHECK: ttng.warp_group_dot
+    %dot = ttng.warp_group_dot %a_tile, %b_trans, %arg1 {inputPrecision = 0 : i32, isAsync = true, maxNumImpreciseAcc = 1073741824 : i32} : !ttg.memdesc<128x128xf8E5M2, #shared1, #smem, mutable> * !ttg.memdesc<128x256xf8E5M2, #shared3, #smem, mutable> -> tensor<128x256xf32, #mma>
+    // CHECK-NEXT: ttg.barrier local
+    ttg.barrier local
+    // CHECK-NEXT: ttng.warp_group_dot_wait
+    %0:3 = ttng.warp_group_dot_wait %dot, %a_tile, %b_trans {pendings = 0 : i32} : tensor<128x256xf32, #mma>, !ttg.memdesc<128x128xf8E5M2, #shared1, #smem, mutable>, !ttg.memdesc<128x256xf8E5M2, #shared3, #smem, mutable>
+    // CHECK-NEXT: ttg.async_copy_global_to_local
+    ttg.async_copy_global_to_local %arg0, %other_tile mask %arg2 {contiguity = 16 : i32} : tensor<128x128x!tt.ptr<f8E5M2>> -> <128x128xf8E5M2, #shared1, #smem, mutable>
+    tt.return
+  }
+
+  // Do not duplicate a CTA barrier that is already present after the wait.
+  // CHECK-LABEL: warp_dot_wait_cross_warpgroup_existing_barrier
+  tt.func @warp_dot_wait_cross_warpgroup_existing_barrier(%arg0: tensor<128x128x!tt.ptr<f8E5M2>>, %arg1: tensor<128x256xf32, #mma>, %arg2: tensor<128x128xi1>) {
+    %a_tile = ttg.local_alloc : () -> !ttg.memdesc<128x128xf8E5M2, #shared1, #smem, mutable>
+    %b_tile = ttg.local_alloc : () -> !ttg.memdesc<256x128xf8E5M2, #shared1, #smem, mutable>
+    %b_trans = ttg.memdesc_trans %b_tile {order = array<i32: 1, 0>} : !ttg.memdesc<256x128xf8E5M2, #shared1, #smem, mutable> -> !ttg.memdesc<128x256xf8E5M2, #shared3, #smem, mutable>
+
+    // CHECK: ttng.warp_group_dot
+    %dot = ttng.warp_group_dot %a_tile, %b_trans, %arg1 {inputPrecision = 0 : i32, isAsync = true, maxNumImpreciseAcc = 1073741824 : i32} : !ttg.memdesc<128x128xf8E5M2, #shared1, #smem, mutable> * !ttg.memdesc<128x256xf8E5M2, #shared3, #smem, mutable> -> tensor<128x256xf32, #mma>
+    // CHECK-NEXT: ttg.barrier local
+    ttg.barrier local
+    // CHECK-NEXT: ttng.warp_group_dot_wait
+    %0:3 = ttng.warp_group_dot_wait %dot, %a_tile, %b_trans {pendings = 0 : i32} : tensor<128x256xf32, #mma>, !ttg.memdesc<128x128xf8E5M2, #shared1, #smem, mutable>, !ttg.memdesc<128x256xf8E5M2, #shared3, #smem, mutable>
+    // CHECK-NEXT: ttg.barrier local
+    ttg.barrier local
+    // CHECK-NEXT: ttg.async_copy_global_to_local
+    ttg.async_copy_global_to_local %arg0, %a_tile mask %arg2 {contiguity = 16 : i32} : tensor<128x128x!tt.ptr<f8E5M2>> -> <128x128xf8E5M2, #shared1, #smem, mutable>
+    tt.return
+  }
+}
+
+// -----
+
+#shared1 = #ttg.nvmma_shared<{swizzlingByteWidth = 128, transposed = false, elementBitWidth = 8}>
+#shared3 = #ttg.nvmma_shared<{swizzlingByteWidth = 128, transposed = true, elementBitWidth = 8}>
+#smem = #ttg.shared_memory
+#mma = #ttg.nvidia_mma<{versionMajor = 3, versionMinor = 0, warpsPerCTA = [4, 1], instrShape = [16, 256, 32]}>
+
+module attributes {ttg.target = "cuda:90", "ttg.num-warps" = 4 : i32} {
+  // A single warp group is synchronized by its WGMMA wait and does not need a
+  // CTA barrier before reusing shared memory.
+  // CHECK-LABEL: warp_dot_wait_single_warpgroup_reuse
+  tt.func @warp_dot_wait_single_warpgroup_reuse(%arg0: tensor<128x128x!tt.ptr<f8E5M2>>, %arg1: tensor<128x256xf32, #mma>, %arg2: tensor<128x128xi1>) {
+    %a_tile = ttg.local_alloc : () -> !ttg.memdesc<128x128xf8E5M2, #shared1, #smem, mutable>
+    %b_tile = ttg.local_alloc : () -> !ttg.memdesc<256x128xf8E5M2, #shared1, #smem, mutable>
+    %b_trans = ttg.memdesc_trans %b_tile {order = array<i32: 1, 0>} : !ttg.memdesc<256x128xf8E5M2, #shared1, #smem, mutable> -> !ttg.memdesc<128x256xf8E5M2, #shared3, #smem, mutable>
+
+    // CHECK: ttng.warp_group_dot
+    %dot = ttng.warp_group_dot %a_tile, %b_trans, %arg1 {inputPrecision = 0 : i32, isAsync = true, maxNumImpreciseAcc = 1073741824 : i32} : !ttg.memdesc<128x128xf8E5M2, #shared1, #smem, mutable> * !ttg.memdesc<128x256xf8E5M2, #shared3, #smem, mutable> -> tensor<128x256xf32, #mma>
+    // CHECK-NEXT: ttg.barrier local
+    ttg.barrier local
+    // CHECK-NEXT: ttng.warp_group_dot_wait
+    %0:3 = ttng.warp_group_dot_wait %dot, %a_tile, %b_trans {pendings = 0 : i32} : tensor<128x256xf32, #mma>, !ttg.memdesc<128x128xf8E5M2, #shared1, #smem, mutable>, !ttg.memdesc<128x256xf8E5M2, #shared3, #smem, mutable>
+    // CHECK-NEXT: ttg.async_copy_global_to_local
+    ttg.async_copy_global_to_local %arg0, %a_tile mask %arg2 {contiguity = 16 : i32} : tensor<128x128x!tt.ptr<f8E5M2>> -> <128x128xf8E5M2, #shared1, #smem, mutable>
+    tt.return
+  }
 }
 
 // -----


### PR DESCRIPTION
## Summary

Preserve pending async WGMMA shared-memory reads across earlier CTA barriers. At a full `wait(0)`, return those reads to Membar's regular dependency state so a barrier is inserted only before an actual conflicting reuse.

This fixes multi-warpgroup execution without adding a barrier after every wait. Nonzero waits conservatively keep the pending read union.

Fixes #11047.

## Testing

- `make`
- `lit -v test/Analysis test/TritonGPU/loop-pipeline-hopper.mlir test/TritonGPU/dot-operands.mlir test/TritonNvidiaGPU/tma_lowering.mlir`
- `ctest --output-on-failure -R 'TestTritonAnalysis|NvmmaSmemAttrsTest'`
- `pre-commit run --from-ref origin/main --to-ref HEAD`
- Compiled the issue reproducer for sm90 and verified `wait_group 0 -> barrier.cta.sync -> conflicting cp.async`

# New contributor declaration
- [x] I am not making a trivial change, such as fixing a typo in a comment.

- [x] I have written a PR description following these
  [rules](https://cbea.ms/git-commit/#why-not-how).

- [x] I have run `pre-commit run --from-ref origin/main --to-ref HEAD`.

- Select one of the following.
  - [x] I have added tests.
    - `/test` for `lit` tests
    - `/unittest` for C++ tests
    - `/python/test` for end-to-end tests
  - [ ] This PR does not need a test because `FILL THIS IN`.

- Select one of the following.
  - [ ] I have not added any `lit` tests.
  - [x] The `lit` tests I have added follow these [best practices](https://mlir.llvm.org/getting_started/TestingGuide/#filecheck-best-practices),
    including the "tests should be minimal" section. (Usually running Python code
    and using the instructions it generates is not minimal.)
