### PR TITLE
[FRONTEND] Reject mismatched tuple unpacking

### DIFF
--- a/python/test/unit/language/test_frontend.py
+++ b/python/test/unit/language/test_frontend.py
@@ -421,6 +421,46 @@ def test_tuple_assignment_constexpr_tuple_normalizes_recursively():
     run_parser(kernel)
 
 
+def test_tuple_assignment_rejects_too_many_values():
+
+    @triton.jit
+    def kernel():
+        a, b = (1, 2, 3)  # noqa: F841
+
+    with pytest.raises(CompilationError, match="too many values to unpack"):
+        run_parser(kernel)
+
+
+def test_tuple_assignment_rejects_too_few_values():
+
+    @triton.jit
+    def kernel():
+        a, b, c = (1, 2)  # noqa: F841
+
+    with pytest.raises(CompilationError, match=r"not enough values to unpack \(expected 3, got 2\)"):
+        run_parser(kernel)
+
+
+def test_tuple_assignment_rejects_nested_mismatch():
+
+    @triton.jit
+    def kernel():
+        (a, b), c = ((1, 2, 3), 4)  # noqa: F841
+
+    with pytest.raises(CompilationError, match="too many values to unpack"):
+        run_parser(kernel)
+
+
+def test_tuple_assignment_rejects_starred_target():
+
+    @triton.jit
+    def kernel():
+        a, *rest = (1, 2, 3)  # noqa: F841
+
+    with pytest.raises(CompilationError, match="starred assignment targets are not supported"):
+        run_parser(kernel)
+
+
 def test_list_comprehension_if_filter():
 
     @triton.jit

--- a/python/triton/compiler/code_generator.py
+++ b/python/triton/compiler/code_generator.py
@@ -749,6 +749,16 @@ class CodeGenerator(ast.NodeVisitor):
 
         def _sanitize_target_value(target, value):
             if isinstance(target, ast.Tuple) and isinstance(value, language.tuple):
+                if any(isinstance(elt, ast.Starred) for elt in target.elts):
+                    raise NotImplementedError("starred assignment targets are not supported")
+                num_targets, num_values = len(target.elts), len(value.values)
+                if num_targets != num_values:
+                    # Match CPython's errors for mismatched unpacking.
+                    if num_values > num_targets:
+                        message = f"too many values to unpack (expected {num_targets})"
+                    else:
+                        message = f"not enough values to unpack (expected {num_targets}, got {num_values})"
+                    raise ValueError(message)
                 vals = [_sanitize_target_value(elt, val) for elt, val in zip(target.elts, value.values)]
                 vals = [constexpr(val) if val is None else val for val in vals]
                 types = [val.type for val in vals]


### PR DESCRIPTION
Tuple unpacking paired targets with values using `zip` without first checking their lengths. As a result, `a, b = (1, 2, 3)` compiled and silently discarded the `3`, while too few values surfaced an internal `IndexError`. This differs from CPython and `TRITON_INTERPRET=1`, which reject both forms.

```python
@triton.jit
def kernel():
    a, b = (1, 2, 3)  # compiled successfully; the `3` was dropped
```

This patch checks the arity before unpacking and reports CPython-style errors. Because target sanitization is recursive, a mismatch nested inside a target is rejected as well:

```python
(a, b), c = ((1, 2, 3), 4)
```

Triton does not currently support starred assignment targets. Reject them before the arity check, whose fixed-length assumption would otherwise produce a misleading mismatch error. This applies to the supported `tl.tuple` unpacking path.

Adds four parser-only tests in `python/test/unit/language/test_frontend.py`, covering too many values, too few values, a nested mismatch, and a starred target; all four fail before this change.