### PR TITLE
Add Windows ARM64 LLVM Build Support

### DIFF
--- a/.github/workflows/llvm-build.yml
+++ b/.github/workflows/llvm-build.yml
@@ -97,7 +97,7 @@ jobs:
 
     - name: Set up Python
       if: matrix.config.target-os != 'almalinux'
-      uses: actions/setup-python@v6
+      uses: actions/setup-python@v7
       with:
         python-version: 3.11
 

--- a/.github/workflows/llvm-build.yml
+++ b/.github/workflows/llvm-build.yml
@@ -78,24 +78,17 @@ jobs:
         echo "LLVM installation directory name: ${INSTALL_DIR}"
         echo "llvm_install_dir=${INSTALL_DIR}" >> ${GITHUB_ENV}
 
-    - name: Check LLVM Build Availability
+    - name: Check LLVM Build Does Not Exist
       shell: bash
       run: |
         URL="https://oaitriton.blob.core.windows.net/public/llvm-builds/${{ env.llvm_install_dir }}.tar.gz"
         HTTP_STATUS="$(curl --head --silent --show-error --output /dev/null --write-out "%{http_code}" "${URL}")"
-        if [ "${HTTP_STATUS}" = "200" ]; then
-          echo "LLVM build already exists: ${URL}"
-          echo "LLVM_BUILD_EXISTS=true" >> "${GITHUB_ENV}"
-        elif [ "${HTTP_STATUS}" = "404" ]; then
-          echo "LLVM build does not exist yet: ${URL}"
-          echo "LLVM_BUILD_EXISTS=false" >> "${GITHUB_ENV}"
-        else
-          echo "LLVM build availability could not be checked: ${URL} returned ${HTTP_STATUS}"
+        if [ "${HTTP_STATUS}" != "404" ]; then
+          echo "LLVM build already exists or could not be checked: ${URL} returned ${HTTP_STATUS}"
           exit 1
         fi
 
     - name: Checkout LLVM
-      if: env.LLVM_BUILD_EXISTS != 'true'
       uses: actions/checkout@v6
       with:
         repository: ${{ env.llvm_repository }}
@@ -103,19 +96,18 @@ jobs:
         ref: ${{ env.llvm_commit_hash }}
 
     - name: Set up Python
-      if: env.LLVM_BUILD_EXISTS != 'true' && matrix.config.target-os != 'almalinux'
+      if: matrix.config.target-os != 'almalinux'
       uses: actions/setup-python@v6
       with:
         python-version: 3.11
 
     - name: Set up MSVC
-      if: env.LLVM_BUILD_EXISTS != 'true' && matrix.config.target-os == 'windows'
+      if: matrix.config.target-os == 'windows'
       uses: ilammy/msvc-dev-cmd@v1.13.0
       with:
         arch: ${{ matrix.config.msvc_arch }}
 
     - name: Install Prerequisites
-      if: env.LLVM_BUILD_EXISTS != 'true'
       shell: bash
       run: |
         python3 -m pip install cmake ninja sccache
@@ -123,7 +115,6 @@ jobs:
         rm -rf ${{ env.SCCACHE_DIR }}/*
 
     - name: Enable Cache
-      if: env.LLVM_BUILD_EXISTS != 'true'
       uses: actions/cache@v4
       with:
         path: ${{ env.SCCACHE_DIR }}
@@ -131,7 +122,7 @@ jobs:
         restore-keys: ${{ matrix.config.target-os }}-${{ matrix.config.arch }}-
 
     - name: Free disk space on Ubuntu
-      if: env.LLVM_BUILD_EXISTS != 'true' && matrix.config.arch == 'x64' && matrix.config.target-os == 'ubuntu'
+      if: matrix.config.arch == 'x64' && matrix.config.target-os == 'ubuntu'
       run: |
         df -h
         echo "Removing large packages"
@@ -142,7 +133,7 @@ jobs:
         df -h
 
     - name: Configure, Build, Test, and Install LLVM (Ubuntu, CentOS, and macOS)
-      if: env.LLVM_BUILD_EXISTS != 'true' && (matrix.config.target-os == 'ubuntu' || matrix.config.target-os == 'almalinux' || matrix.config.target-os == 'macos')
+      if: matrix.config.target-os == 'ubuntu' || matrix.config.target-os == 'almalinux' || matrix.config.target-os == 'macos'
       run: >
         cmake -GNinja -Bllvm-project/build
         -DCMAKE_BUILD_TYPE=Release
@@ -167,7 +158,7 @@ jobs:
         tar czf "${{ env.llvm_install_dir }}.tar.gz" "${{ env.llvm_install_dir }}"
 
     - name: Configure, Build, Test, and Install LLVM (Windows)
-      if: env.LLVM_BUILD_EXISTS != 'true' && matrix.config.target-os == 'windows'
+      if: matrix.config.target-os == 'windows'
       run: >
         cmake -GNinja -Bllvm-project/build
         -DCMAKE_BUILD_TYPE=Release
@@ -191,7 +182,6 @@ jobs:
 
 
     - name: Upload Build Artifacts
-      if: env.LLVM_BUILD_EXISTS != 'true'
       uses: actions/upload-artifact@v7
       with:
         name: llvm-${{ matrix.config.target-os }}-${{ matrix.config.arch }}
@@ -199,7 +189,7 @@ jobs:
           ${{ github.workspace }}/llvm-*-${{ matrix.config.target-os }}-${{ matrix.config.arch }}-*.tar.gz
 
     - name: Azure login
-      if: env.LLVM_BUILD_EXISTS != 'true' && github.repository == 'triton-lang/triton' && github.ref_name == 'main'
+      if: ${{ (github.repository == 'triton-lang/triton') && github.ref_name == 'main' }}
       uses: azure/login@v2
       with:
         client-id: ${{ secrets.AZURE_CLIENT_ID_LLVM }}
@@ -207,7 +197,7 @@ jobs:
         subscription-id: ${{ secrets.AZURE_SUBSCRIPTION_ID_LLVM }}
 
     - name: Upload LLVM Artifacts to Azure
-      if: env.LLVM_BUILD_EXISTS != 'true' && github.repository == 'triton-lang/triton' && github.ref_name == 'main'
+      if: ${{ (github.repository == 'triton-lang/triton') && github.ref_name == 'main' }}
       shell: bash -el {0}
       run: |
         sha256sum "${{ env.llvm_install_dir }}.tar.gz"
@@ -218,12 +208,11 @@ jobs:
         echo "Blob URL: ${URL}"
 
     - name: Azure Logout
-      if: env.LLVM_BUILD_EXISTS != 'true' && github.repository == 'triton-lang/triton' && github.ref_name == 'main'
+      if: ${{ (github.repository == 'triton-lang/triton') && github.ref_name == 'main' }}
       run: |
         az logout
         az cache purge
         az account clear
 
     - name: Dump Sccache Statistics
-      if: env.LLVM_BUILD_EXISTS != 'true'
       run: sccache --show-stats

--- a/.github/workflows/llvm-build.yml
+++ b/.github/workflows/llvm-build.yml
@@ -37,7 +37,8 @@ jobs:
         - {runner: 'AlmaLinux 8 ARM64', runs_on: 'ubuntu-22.04-arm', target-os: 'almalinux', arch: 'arm64', container: 'almalinux:8.10-20250411'}
         - {runner: 'MacOS X64', runs_on: 'macos-15-intel', target-os: 'macos', arch: 'x64'}
         - {runner: 'MacOS ARM64', runs_on: 'macos-15', target-os: 'macos', arch: 'arm64'}
-        - {runner: 'Windows 2022', runs_on: 'windows-2022', target-os: 'windows', arch: 'x64'}
+        - {runner: 'Windows 2022', runs_on: 'windows-2022', target-os: 'windows', arch: 'x64', msvc_arch: 'amd64'}
+        - {runner: 'Windows 11 ARM64', runs_on: 'windows-11-arm', target-os: 'windows', arch: 'arm64', msvc_arch: 'arm64'}
 
     steps:
 
@@ -77,17 +78,24 @@ jobs:
         echo "LLVM installation directory name: ${INSTALL_DIR}"
         echo "llvm_install_dir=${INSTALL_DIR}" >> ${GITHUB_ENV}
 
-    - name: Check LLVM Build Does Not Exist
+    - name: Check LLVM Build Availability
       shell: bash
       run: |
         URL="https://oaitriton.blob.core.windows.net/public/llvm-builds/${{ env.llvm_install_dir }}.tar.gz"
         HTTP_STATUS="$(curl --head --silent --show-error --output /dev/null --write-out "%{http_code}" "${URL}")"
-        if [ "${HTTP_STATUS}" != "404" ]; then
-          echo "LLVM build already exists or could not be checked: ${URL} returned ${HTTP_STATUS}"
+        if [ "${HTTP_STATUS}" = "200" ]; then
+          echo "LLVM build already exists: ${URL}"
+          echo "LLVM_BUILD_EXISTS=true" >> "${GITHUB_ENV}"
+        elif [ "${HTTP_STATUS}" = "404" ]; then
+          echo "LLVM build does not exist yet: ${URL}"
+          echo "LLVM_BUILD_EXISTS=false" >> "${GITHUB_ENV}"
+        else
+          echo "LLVM build availability could not be checked: ${URL} returned ${HTTP_STATUS}"
           exit 1
         fi
 
     - name: Checkout LLVM
+      if: env.LLVM_BUILD_EXISTS != 'true'
       uses: actions/checkout@v6
       with:
         repository: ${{ env.llvm_repository }}
@@ -95,18 +103,19 @@ jobs:
         ref: ${{ env.llvm_commit_hash }}
 
     - name: Set up Python
-      if: matrix.config.target-os != 'almalinux'
-      uses: actions/setup-python@v7
+      if: env.LLVM_BUILD_EXISTS != 'true' && matrix.config.target-os != 'almalinux'
+      uses: actions/setup-python@v6
       with:
         python-version: 3.11
 
     - name: Set up MSVC
-      if: matrix.config.arch == 'x64' && (matrix.config.target-os == 'windows')
+      if: env.LLVM_BUILD_EXISTS != 'true' && matrix.config.target-os == 'windows'
       uses: ilammy/msvc-dev-cmd@v1.13.0
       with:
-        arch: amd64
+        arch: ${{ matrix.config.msvc_arch }}
 
     - name: Install Prerequisites
+      if: env.LLVM_BUILD_EXISTS != 'true'
       shell: bash
       run: |
         python3 -m pip install cmake ninja sccache
@@ -114,6 +123,7 @@ jobs:
         rm -rf ${{ env.SCCACHE_DIR }}/*
 
     - name: Enable Cache
+      if: env.LLVM_BUILD_EXISTS != 'true'
       uses: actions/cache@v4
       with:
         path: ${{ env.SCCACHE_DIR }}
@@ -121,7 +131,7 @@ jobs:
         restore-keys: ${{ matrix.config.target-os }}-${{ matrix.config.arch }}-
 
     - name: Free disk space on Ubuntu
-      if: matrix.config.arch == 'x64' && matrix.config.target-os == 'ubuntu'
+      if: env.LLVM_BUILD_EXISTS != 'true' && matrix.config.arch == 'x64' && matrix.config.target-os == 'ubuntu'
       run: |
         df -h
         echo "Removing large packages"
@@ -132,7 +142,7 @@ jobs:
         df -h
 
     - name: Configure, Build, Test, and Install LLVM (Ubuntu, CentOS, and macOS)
-      if: matrix.config.target-os == 'ubuntu' || matrix.config.target-os == 'almalinux' || matrix.config.target-os == 'macos'
+      if: env.LLVM_BUILD_EXISTS != 'true' && (matrix.config.target-os == 'ubuntu' || matrix.config.target-os == 'almalinux' || matrix.config.target-os == 'macos')
       run: >
         cmake -GNinja -Bllvm-project/build
         -DCMAKE_BUILD_TYPE=Release
@@ -157,7 +167,7 @@ jobs:
         tar czf "${{ env.llvm_install_dir }}.tar.gz" "${{ env.llvm_install_dir }}"
 
     - name: Configure, Build, Test, and Install LLVM (Windows)
-      if: matrix.config.arch == 'x64' && (matrix.config.target-os == 'windows')
+      if: env.LLVM_BUILD_EXISTS != 'true' && matrix.config.target-os == 'windows'
       run: >
         cmake -GNinja -Bllvm-project/build
         -DCMAKE_BUILD_TYPE=Release
@@ -181,6 +191,7 @@ jobs:
 
 
     - name: Upload Build Artifacts
+      if: env.LLVM_BUILD_EXISTS != 'true'
       uses: actions/upload-artifact@v7
       with:
         name: llvm-${{ matrix.config.target-os }}-${{ matrix.config.arch }}
@@ -188,7 +199,7 @@ jobs:
           ${{ github.workspace }}/llvm-*-${{ matrix.config.target-os }}-${{ matrix.config.arch }}-*.tar.gz
 
     - name: Azure login
-      if: ${{ (github.repository == 'triton-lang/triton') && github.ref_name == 'main' }}
+      if: env.LLVM_BUILD_EXISTS != 'true' && github.repository == 'triton-lang/triton' && github.ref_name == 'main'
       uses: azure/login@v2
       with:
         client-id: ${{ secrets.AZURE_CLIENT_ID_LLVM }}
@@ -196,7 +207,7 @@ jobs:
         subscription-id: ${{ secrets.AZURE_SUBSCRIPTION_ID_LLVM }}
 
     - name: Upload LLVM Artifacts to Azure
-      if: ${{ (github.repository == 'triton-lang/triton') && github.ref_name == 'main' }}
+      if: env.LLVM_BUILD_EXISTS != 'true' && github.repository == 'triton-lang/triton' && github.ref_name == 'main'
       shell: bash -el {0}
       run: |
         sha256sum "${{ env.llvm_install_dir }}.tar.gz"
@@ -207,11 +218,12 @@ jobs:
         echo "Blob URL: ${URL}"
 
     - name: Azure Logout
-      if: ${{ (github.repository == 'triton-lang/triton') && github.ref_name == 'main' }}
+      if: env.LLVM_BUILD_EXISTS != 'true' && github.repository == 'triton-lang/triton' && github.ref_name == 'main'
       run: |
         az logout
         az cache purge
         az account clear
 
     - name: Dump Sccache Statistics
+      if: env.LLVM_BUILD_EXISTS != 'true'
       run: sccache --show-stats

--- a/cmake/llvm-build-info.json
+++ b/cmake/llvm-build-info.json
@@ -1,5 +1,5 @@
 {
   "llvm_hash": "e2a39f504fee836e4def9581bed817ecc327b9dc",
   "repository": "llvm/llvm-project",
-  "build_number": 1
+  "build_number": 2
 }


### PR DESCRIPTION
Hi @ptillet, I'm from Microsoft and recently I'm working on improving Python ecosystem support for Windows on Arm.
So I adds a new CI matrix entry for building LLVM on Windows ARM64 (`windows-11-arm`) and improves the existing build skip logic. Could you please help to review? Thanks.

## Changes

- **Add Windows ARM64 runner**: Adds a new matrix entry `{runner: 'Windows 11 ARM64', runs_on: 'windows-11-arm', target-os: 'windows', arch: 'arm64', msvc_arch: 'arm64'}` to the `llvm-build.yml` workflow.
- **Parameterize MSVC arch**: The existing Windows x64 entry is updated to include `msvc_arch: 'amd64'`, making the MSVC setup step use `matrix.config.msvc_arch` instead of the hardcoded `amd64`. This allows both x64 and ARM64 Windows builds to set up the correct MSVC toolchain.
- **Improve build-exists check**: Refactors the "Check LLVM Build Does Not Exist" step to distinguish between HTTP 200 (already exists → skip), 404 (needs building), and other error codes (fail), setting a `LLVM_BUILD_EXISTS` env variable. All subsequent build, upload, and artifact steps are gated on `env.LLVM_BUILD_EXISTS != 'true'`, avoiding redundant work when a build is already cached.
- **Simplify Windows build condition**: The Windows-specific CMake build step now simply checks `target-os == 'windows'` instead of also requiring `arch == 'x64'`, enabling ARM64 builds to use the same path.

## Pipeline run results:

https://github.com/vortex-captain/triton/actions/runs/30235264520

---

# New contributor declaration
- [x] I am not making a trivial change, such as fixing a typo in a comment.

- [x] I have written a PR description following these [rules](https://cbea.ms/git-commit/#why-not-how).

- [x] I have run `pre-commit run --from-ref origin/main --to-ref HEAD`.

- Select one of the following.
  - [ ] I have added tests.
  - [x] This PR does not need a test because it only modifies CI workflow configuration (`.github/workflows/llvm-build.yml`); correctness is validated by the CI run itself.

- Select one of the following.
  - [x] I have not added any `lit` tests.
  - [ ] The `lit` tests I have added follow these [best practices](https://mlir.llvm.org/getting_started/TestingGuide/#filecheck-best-practices).