### PR TITLE
[Triton] Don't assert in SplatOp::fold on a dynamically-shaped result

### DIFF
--- a/lib/Dialect/Triton/IR/Ops.cpp
+++ b/lib/Dialect/Triton/IR/Ops.cpp
@@ -774,6 +774,10 @@ OpFoldResult SplatOp::fold(FoldAdaptor adaptor) {
   if (!isa<FloatAttr, IntegerAttr>(value))
     return {};
   auto shapedType = cast<ShapedType>(getType());
+  // SplatElementsAttr requires a static shape; a dynamically-shaped result is
+  // still valid IR, so decline the fold instead of asserting.
+  if (!shapedType.hasStaticShape())
+    return {};
   auto ret = SplatElementsAttr::get(shapedType, ArrayRef<Attribute>(value));
   return ret;
 }

--- a/test/Triton/canonicalize.mlir
+++ b/test/Triton/canonicalize.mlir
@@ -260,3 +260,44 @@ tt.func @no_canonicalize_indivisible_offset(%base: tensor<128x!tt.ptr<f32>>) -> 
   %result = tt.int_to_ptr %offset_ptr_int : tensor<128xi64> -> tensor<128x!tt.ptr<f32>>
   tt.return %result : tensor<128x!tt.ptr<f32>>
 }
+
+// -----
+
+// A tt.splat of a scalar constant into a dynamic-shaped tensor must not fold to
+// a dense splat constant: SplatElementsAttr needs a static shape. The splat is
+// left unchanged.
+
+// CHECK-LABEL: @dynamic_splat_constant
+// CHECK: tt.splat
+tt.func @dynamic_splat_constant() -> tensor<?xi32> {
+  %c = arith.constant 1000 : i32
+  %s = tt.splat %c : i32 -> tensor<?xi32>
+  tt.return %s : tensor<?xi32>
+}
+
+// -----
+
+// A partially dynamic result also fails hasStaticShape (any dynamic dim is
+// enough), so the splat is likewise left unchanged.
+
+// CHECK-LABEL: @partial_dynamic_splat_constant
+// CHECK: tt.splat
+tt.func @partial_dynamic_splat_constant() -> tensor<4x?xi32> {
+  %c = arith.constant 1000 : i32
+  %s = tt.splat %c : i32 -> tensor<4x?xi32>
+  tt.return %s : tensor<4x?xi32>
+}
+
+// -----
+
+// Positive control: a tt.splat of a scalar constant into a statically-shaped
+// tensor is still folded to a dense splat constant.
+
+// CHECK-LABEL: @static_splat_constant
+// CHECK-NOT: tt.splat
+// CHECK: arith.constant dense<1000> : tensor<4xi32>
+tt.func @static_splat_constant() -> tensor<4xi32> {
+  %c = arith.constant 1000 : i32
+  %s = tt.splat %c : i32 -> tensor<4xi32>
+  tt.return %s : tensor<4xi32>
+}


### PR DESCRIPTION
`SplatOp::fold` folds a splat of a scalar constant into a dense constant by building a `SplatElementsAttr` from the result type. `SplatElementsAttr::get` requires a static shape, so a dynamically-shaped result asserts (or is UB in release).

A dynamically-shaped `tt.splat` is valid IR, and a fold must decline inputs it cannot handle rather than assert. Bail out when the result shape is not static; the splat is left for later lowering.

Authored with Claude.

# New contributor declaration
- [X] I am not making a trivial change, such as fixing a typo in a comment.

- [X] I have written a PR description following these
  [rules](https://cbea.ms/git-commit/#why-not-how).

- [X] I have run `pre-commit run --from-ref origin/main --to-ref HEAD`.

- Select one of the following.
  - [X] I have added tests.
    - `/test` for `lit` tests
    - `/unittest` for C++ tests
    - `/python/test` for end-to-end tests
  - [ ] This PR does not need a test because `FILL THIS IN`.

- Select one of the following.
  - [ ] I have not added any `lit` tests.
  - [X] The `lit` tests I have added follow these [best practices](https://mlir.llvm.org/getting_started/TestingGuide/#filecheck-best-practices),
    including the "tests should be minimal" section. (Usually running Python code
    and using the instructions it generates is not minimal.)
