### PR TITLE
Fix reduce benchmark selector call

### DIFF
--- a/python/triton_kernels/bench/bench_reduce.py
+++ b/python/triton_kernels/bench/bench_reduce.py
@@ -60,7 +60,15 @@ def main():
     for s1 in _csv_ints(args.s1s):
         for k in _csv_ints(args.ks):
             for s0 in _csv_ints(args.s0s):
-                opt_flags = _select_reduce_forward_config(s0, s1, 1, k, False)
+                opt_flags = _select_reduce_forward_config(
+                    torch.float32,
+                    s0,
+                    s1,
+                    1,
+                    k,
+                    False,
+                    False,
+                )
                 median_ms, mean_ms, p90_ms = bench_reduce(k, s0, s1, args.iters, cache_killer)
                 print(
                     f"{k},{s0},{s1},{opt_flags.block_s0},{opt_flags.block_x_s1},{median_ms:.6f},{mean_ms:.6f},{p90_ms:.6f}",


### PR DESCRIPTION
## Summary

Update `bench_reduce.py` for the current `_select_reduce_forward_config`
signature.

The selector gained the `x_dtype` and `mask_chainable` parameters, but this
standalone benchmark retained the old five-argument call. Running it directly
therefore raises a `TypeError` before the benchmark starts. Pass the benchmark
input dtype and its non-chainable mask state so the configuration printed by
the benchmark matches the subsequent `reduce` invocation.

## Validation

```bash
python python/triton_kernels/bench/bench_reduce.py \
  --ks 1 \
  --s0s 1 \
  --s1s 8192 \
  --iters 1 \
  --flush-mb 0
```

`python3 -m py_compile python/triton_kernels/bench/bench_reduce.py`

# New contributor declaration

- [x] I am not making a trivial change, such as fixing a typo in a comment.
- [x] I have written a PR description following these [rules](https://cbea.ms/git-commit/#why-not-how).
- [x] I have run `pre-commit run --from-ref origin/main --to-ref HEAD`.
- [ ] I have added tests.
- [x] This PR does not need a new test because it repairs a standalone benchmark script that is not executed by the OSS test workflows; the direct invocation above exercises the corrected call.
- [x] I have not added any `lit` tests.
- [ ] The `lit` tests I have added follow these [best practices](https://mlir.llvm.org/getting_started/TestingGuide/#filecheck-best-practices), including the "tests should be minimal" section.
