### PR TITLE
[Triton] Restrict tt.splat result to a statically-shaped tensor

### DIFF
--- a/include/triton/Dialect/Triton/IR/TritonOps.td
+++ b/include/triton/Dialect/Triton/IR/TritonOps.td
@@ -449,7 +449,7 @@ def TT_SplatOp : TT_Op<"splat", [Pure,
 
     let arguments = (ins TT_Type:$src);
 
-    let results = (outs TT_Tensor:$result);
+    let results = (outs TT_StaticShapeTensor:$result);
 
     let assemblyFormat = "$src attr-dict `:` type($src) `->` type($result)";
 

--- a/include/triton/Dialect/Triton/IR/TritonTypes.td
+++ b/include/triton/Dialect/Triton/IR/TritonTypes.td
@@ -87,6 +87,7 @@ def TT_PtrLike : AnyTypeOf<[TT_Ptr, TT_PtrTensor]>;
 // Tensor Type
 def TT_FpIntTensor : RankedTensorOf<[TT_Float, TT_Int]>;
 def TT_Tensor : RankedTensorOf<[TT_Float, TT_Int, TT_Ptr]>;
+def TT_StaticShapeTensor : StaticShapeTensorOf<[TT_Float, TT_Int, TT_Ptr]>;
 
 // Any Type in Triton IR
 def TT_Type : AnyTypeOf<[TT_FloatLike, TT_IntLike, TT_PtrLike]>;

--- a/test/Triton/invalid.mlir
+++ b/test/Triton/invalid.mlir
@@ -657,3 +657,11 @@ module attributes {"ttg.num-warps" = 4 : i32, "ttg.threads-per-warp" = 32 : i32,
     tt.return
   }
 }
+
+// -----
+
+tt.func @splat_dynamic_shape(%v: i32) -> tensor<?xi32> {
+  // expected-error @below {{result #0 must be statically shaped tensor of floating-point or integer or ptr values, but got 'tensor<?xi32>'}}
+  %b = tt.splat %v : i32 -> tensor<?xi32>
+  tt.return %b : tensor<?xi32>
+}


### PR DESCRIPTION
`SplatOp::fold` builds a `SplatElementsAttr` from the result type, which requires a static shape; a dynamically-shaped result would assert. Rather than guard the fold, forbid the invalid input at the source: constrain the op's result to a statically-shaped tensor so a dynamically-shaped `tt.splat` is rejected by the verifier.

I decided against requiring `TT_Tensor` and requiring a static shape there as this would have a larger splash radius.

Authored with Claude.

# New contributor declaration
- [X] I am not making a trivial change, such as fixing a typo in a comment.

- [X] I have written a PR description following these
  [rules](https://cbea.ms/git-commit/#why-not-how).

- [X] I have run `pre-commit run --from-ref origin/main --to-ref HEAD`.

- Select one of the following.
  - [] I have added tests.
    - `/test` for `lit` tests
    - `/unittest` for C++ tests
    - `/python/test` for end-to-end tests
  - [X] This PR does not need a test because it cannot be generated with 

- Select one of the following.
  - [ ] I have not added any `lit` tests.
  - [X] The `lit` tests I have added follow these [best practices](https://mlir.llvm.org/getting_started/TestingGuide/#filecheck-best-practices),
    including the "tests should be minimal" section. (Usually running Python code
    and using the instructions it generates is not minimal.)
