### PR TITLE
[AMD] Don't assert in FoldTrueCmpIOp on a dynamically-shaped result

### DIFF
--- a/third_party/amd/lib/Analysis/RangeAnalysis.cpp
+++ b/third_party/amd/lib/Analysis/RangeAnalysis.cpp
@@ -821,6 +821,13 @@ struct FoldTrueCmpIOp : OpRewritePattern<arith::CmpIOp> {
     if (!result)
       return failure();
 
+    // getOneAttr/getZeroAttr build a splat DenseElementsAttr for a shaped
+    // result, which requires all dimensions to be static. A result with any
+    // dynamic dimension is still valid IR, so decline the fold.
+    if (auto shapedType = dyn_cast<ShapedType>(cmpOp.getType());
+        shapedType && !shapedType.hasStaticShape())
+      return failure();
+
     TypedAttr constAttr = *result ? rewriter.getOneAttr(cmpOp.getType())
                                   : rewriter.getZeroAttr(cmpOp.getType());
     rewriter.replaceOpWithNewOp<arith::ConstantOp>(cmpOp, constAttr);


### PR DESCRIPTION
`FoldTrueCmpIOp` replaces a provably true/false `arith.cmpi` with a splat constant via `getOneAttr/getZeroAttr(cmpOp.getType())`. For a shaped result this builds a `DenseElementsAttr`, which requires all dimensions to be static, so a dynamically-shaped `tensor<?xi1>` result asserts.

A dynamically-shaped cmpi is valid MLIR, and a canonicalization pattern must decline inputs it cannot handle rather than assert. Bail out when the result is a shaped type without a fully static shape.

No lit test is included: triggering the fold needs a dynamically-shaped cmpi whose operands carry analysis-known ranges, which in Triton IR can only be formed by splatting a scalar range into a dynamic tensor. The path is reached by downstream reusers of the AMD RangeAnalysis.

Authored with Claude.

<!---
The core Triton is a small number of people, and we receive many PRs (thank
you!).  To help us review your code more quickly, **if you are a new
contributor (less than 3 PRs merged) we ask that you complete the following
tasks and include the filled-out checklist in your PR description.**

Complete the following tasks before sending your PR, and replace `[ ]` with
`[x]` to indicate you have done them.
-->

# New contributor declaration
- [X] I am not making a trivial change, such as fixing a typo in a comment.

- [X] I have written a PR description following these
  [rules](https://cbea.ms/git-commit/#why-not-how).

- [X] I have run `pre-commit run --from-ref origin/main --to-ref HEAD`.

- Select one of the following.
  - [ ] I have added tests.
    - `/test` for `lit` tests
    - `/unittest` for C++ tests
    - `/python/test` for end-to-end tests
  - [X] This PR does not need a test because the code is currently unreachable from upstream Triton.

- Select one of the following.
  - [X] I have not added any `lit` tests.
  - [ ] The `lit` tests I have added follow these [best practices](https://mlir.llvm.org/getting_started/TestingGuide/#filecheck-best-practices),
    including the "tests should be minimal" section. (Usually running Python code
    and using the instructions it generates is not minimal.)
