### PR TITLE
[CORE] Avoid side effects in assertions

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -10,4 +10,4 @@
 - Compiler crashes sometimes print an MLIR reproducer (external_resources / mlir_reproducer). Save the full MLIR + {-# ... #-} metadata to `/tmp/<file>.mlir`, then run `triton-opt /tmp/<file>.mlir --run-reproducer` to reproduce locally.
 
 ## C++ Guidelines
-- Never put side-effecting code in `assert`. Assertions may be compiled out, so perform mutations and other required computation before the assertion and assert only the resulting condition.
+- In C++, never put side-effecting code in `assert`. Assertions may be compiled out, so perform mutations and other required computation before the assertion and assert only the resulting condition. This guideline does not apply to Python `assert` statements.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -8,3 +8,6 @@
 - Run lit from the build dir:  `cd BUILD_DIR; ninja triton-opt; lit -v test/<path>.mlir` (example: `lit -v test/TritonNvidiaGPU/tmem_layouts.mlir`).
 - Lit tests can be run locally (no GPU required).
 - Compiler crashes sometimes print an MLIR reproducer (external_resources / mlir_reproducer). Save the full MLIR + {-# ... #-} metadata to `/tmp/<file>.mlir`, then run `triton-opt /tmp/<file>.mlir --run-reproducer` to reproduce locally.
+
+## C++ Guidelines
+- Never put side-effecting code in `assert`. Assertions may be compiled out, so perform mutations and other required computation before the assertion and assert only the resulting condition.

--- a/lib/Dialect/TritonInstrument/IR/FunctionBuilder.cpp
+++ b/lib/Dialect/TritonInstrument/IR/FunctionBuilder.cpp
@@ -126,7 +126,8 @@ Value reduce(ImplicitLocOpBuilder &b, Value tensor, ArrayRef<int> axes) {
   for (int axis : axes) {
     assert(axis >= 0 && axis < tensorType.getRank() &&
            "invalid reduction axis");
-    assert(reducedAxes.insert(axis).second && "duplicate reduction axis");
+    assert(!reducedAxes.contains(axis) && "duplicate reduction axis");
+    reducedAxes.insert(axis);
   }
 
   SmallVector<int32_t> transposeOrder;

--- a/lib/Tools/LayoutUtils.cpp
+++ b/lib/Tools/LayoutUtils.cpp
@@ -271,15 +271,17 @@ LinearLayout renameLinearLayoutDims(
     llvm::DenseMap<StringAttr, StringAttr> result;
     for (auto [oldDim, newDim] : renames) {
       assert(existing.contains(oldDim) && "dimension to rename does not exist");
-      assert(result.try_emplace(oldDim, newDim).second &&
-             "dimension renamed more than once");
+      assert(!result.contains(oldDim) && "dimension renamed more than once");
+      result.try_emplace(oldDim, newDim);
     }
 
     llvm::SmallDenseSet<StringAttr> finalNames;
     for (StringAttr dim : dimNames) {
       StringAttr renamed = result.lookup(dim);
-      assert(finalNames.insert(renamed ? renamed : dim).second &&
+      StringAttr finalName = renamed ? renamed : dim;
+      assert(!finalNames.contains(finalName) &&
              "renaming creates duplicate dimensions");
+      finalNames.insert(finalName);
     }
     return result;
   };

--- a/third_party/nvidia/lib/Dialect/NVWS/Transforms/InsertTmemAref.cpp
+++ b/third_party/nvidia/lib/Dialect/NVWS/Transforms/InsertTmemAref.cpp
@@ -418,7 +418,9 @@ struct TMEMAref {
     buffer = {};
   }
   void release(OpBuilder &b, Location loc) {
-    assert(asyncOp[partitionId]);
+    auto asyncOpIt = asyncOp.find(partitionId);
+    assert(asyncOpIt != asyncOp.end() && asyncOpIt->second);
+    AsyncOp currentAsyncOp = *asyncOpIt->second;
     StageCluster stageCluster;
     if (partitionId)
       stageCluster = stageClusters[*partitionId];
@@ -426,13 +428,13 @@ struct TMEMAref {
       createInto<ArefPutExitOp>(
           b, loc, {partitionId, stageCluster}, aref, token,
           b.getArrayAttr(SmallVector<Attribute>{
-              AsyncOpAttr::get(b.getContext(), *asyncOp[partitionId])}));
+              AsyncOpAttr::get(b.getContext(), currentAsyncOp)}));
       kind = GET;
     } else {
       createInto<ArefGetExitOp>(
           b, loc, {partitionId, stageCluster}, aref, token,
           b.getArrayAttr(SmallVector<Attribute>{
-              AsyncOpAttr::get(b.getContext(), *asyncOp[partitionId])}));
+              AsyncOpAttr::get(b.getContext(), currentAsyncOp)}));
       kind = PUT;
     }
   }


### PR DESCRIPTION
PR description written by Codex

Move required LinearLayout dimension-map construction, ConSan reduction-axis tracking, and NVWS async-op lookup out of C++ assertions so Release builds preserve behavior. Add repository guidance prohibiting side effects in C++ assertions.

This fixes TMA gather/scatter verification, ConSan transpose construction, and NVWS async-op lookup under `-DNDEBUG`.

## Stack
Merge bottom-up:
- [ ] #11062 (this PR)
