### PR TITLE
[NVIDIA] Fix TMA shared-memory subviews

### DIFF
--- a/lib/Dialect/TritonNvidiaGPU/IR/Ops.cpp
+++ b/lib/Dialect/TritonNvidiaGPU/IR/Ops.cpp
@@ -721,6 +721,15 @@ static LogicalResult verifyAsyncTMAStoreOp(Operation *op,
   // do not support fp4_padded operands.
   if (isFp4Padded(srcEnc))
     return op->emitOpError("does not support fp4_padded operands");
+  auto shape = dropPipeliningDim(srcType.getShape(), srcEnc);
+  auto allocation = toLinearLayout(
+      dropPipeliningDim(srcType.getAllocShape(), srcEnc), srcEnc);
+  auto block = StringAttr::get(op->getContext(), "block");
+  for (const auto &basis : allocation.getBases().lookup(block))
+    for (auto [component, size] : llvm::zip_equal(basis, shape))
+      if (component >= size)
+        return op->emitOpError(
+            "source subview may have an origin in another CTA");
   return verifyTMAEncoding(op, desc.getType(), srcEnc);
 }
 

--- a/lib/Dialect/TritonNvidiaGPU/IR/Ops.cpp
+++ b/lib/Dialect/TritonNvidiaGPU/IR/Ops.cpp
@@ -710,6 +710,18 @@ static LogicalResult verifyAsyncTMALoadOp(Operation *op,
     return op->emitOpError("cannot store into immutable memory");
   if (failed(verifyTMAEncoding(op, desc, resultType.getEncoding())))
     return failure();
+  auto block = StringAttr::get(op->getContext(), "block");
+  uint32_t barrierMask =
+      toLinearLayout(barrier.getType()).getFreeVariableMasks().lookup(block);
+  auto shape =
+      dropPipeliningDim(resultType.getShape(), resultType.getEncoding());
+  auto allocation = toLinearLayout(resultType);
+  for (auto [bit, basis] : llvm::enumerate(allocation.getBases().lookup(block)))
+    for (auto [component, size] : llvm::zip_equal(basis, shape))
+      if (component >= size && (bit || barrierMask > 1))
+        return op->emitOpError(
+            "TMA destination and completion barrier must belong to the same "
+            "CTA or a CTA pair");
   return success();
 }
 

--- a/lib/Dialect/TritonNvidiaGPU/IR/Ops.cpp
+++ b/lib/Dialect/TritonNvidiaGPU/IR/Ops.cpp
@@ -764,11 +764,6 @@ static LogicalResult verifyAsyncTMAGatherScatterOp(Operation *op,
     return op->emitOpError("result tensor element type must match block (")
            << blockType.getElementType() << "), but got " << memDescType;
 
-  ArrayRef<int64_t> allocShape = memDescType.getAllocShape();
-  if (allocShape.size() < 2 ||
-      memDescType.getShape() != allocShape.take_back(2))
-    return op->emitOpError("memdesc shape must match alloc shape");
-
   auto xOffsetsType = cast<RankedTensorType>(indicesType);
   if (xOffsetsType.getEncoding()) {
     auto xCoordsLayout = triton::gpu::toLinearLayout(xOffsetsType);

--- a/lib/Dialect/TritonNvidiaGPU/IR/Ops.cpp
+++ b/lib/Dialect/TritonNvidiaGPU/IR/Ops.cpp
@@ -722,8 +722,7 @@ static LogicalResult verifyAsyncTMAStoreOp(Operation *op,
   if (isFp4Padded(srcEnc))
     return op->emitOpError("does not support fp4_padded operands");
   auto shape = dropPipeliningDim(srcType.getShape(), srcEnc);
-  auto allocation = toLinearLayout(
-      dropPipeliningDim(srcType.getAllocShape(), srcEnc), srcEnc);
+  auto allocation = toLinearLayout(srcType);
   auto block = StringAttr::get(op->getContext(), "block");
   for (const auto &basis : allocation.getBases().lookup(block))
     for (auto [component, size] : llvm::zip_equal(basis, shape))

--- a/python/test/gluon/test_core.py
+++ b/python/test/gluon/test_core.py
@@ -3512,7 +3512,7 @@ def test_shared_subslice_two_ctas(op):
 
 
 @gluon.jit
-def cross_cta_tma_load_kernel(in_desc, out, cga_layout: ttgl.constexpr):
+def cross_cta_tma_kernel(desc, out, cga_layout: ttgl.constexpr, MODE: ttgl.constexpr):
     alloc_layout: ttgl.constexpr = ttgl.BlockedLayout([1, 1], [4, 8], [4, 1], [1, 0], cga_layout=cga_layout)
     shared_layout: ttgl.constexpr = ttgl.NVMMASharedLayout(128, 32, rank=2, cga_layout=cga_layout)
     parent = ttgl.allocate_shared_memory(
@@ -3522,17 +3522,22 @@ def cross_cta_tma_load_kernel(in_desc, out, cga_layout: ttgl.constexpr):
         value=ttgl.full([256, 64], -5, ttgl.int32, layout=alloc_layout),
     )
     tile = parent.slice(128, 128, dim=0)
-    bar = mbarrier.allocate_mbarrier()
-    mbarrier.init(bar, count=1)
-    mbarrier.expect(bar, in_desc.nbytes_per_cta)
-    tma.async_load(in_desc, [0, 0], bar, tile)
-    mbarrier.wait(bar, phase=0)
-    ttgl.barrier(cluster=True)
-    result = parent.load(alloc_layout)
-    rows = ttgl.arange(0, 256)[:, None]
-    cols = ttgl.arange(0, 64)[None, :]
-    offsets = ttgl.set_auto_layout(rows * 64 + cols, result.type.layout)
-    ttgl.store(out + offsets, result)
+    if MODE == "load":
+        bar = mbarrier.allocate_mbarrier()
+        mbarrier.init(bar, count=1)
+        mbarrier.expect(bar, desc.nbytes_per_cta)
+        tma.async_load(desc, [0, 0], bar, tile)
+        mbarrier.wait(bar, phase=0)
+        ttgl.barrier(cluster=True)
+        result = parent.load(alloc_layout)
+        rows = ttgl.arange(0, 256)[:, None]
+        cols = ttgl.arange(0, 64)[None, :]
+        offsets = ttgl.set_auto_layout(rows * 64 + cols, result.type.layout)
+        ttgl.store(out + offsets, result)
+    elif MODE == "store":
+        tma.async_store(desc, [0, 0], tile)
+    else:
+        tma.async_atomic_add(desc, [0, 0], tile)
 
 
 @pytest.mark.skipif(not is_blackwell(), reason="Requires Blackwell CTA-pair completion")
@@ -3543,7 +3548,7 @@ def test_cross_cta_tma_load(cga_layout):
     layout = ttgl.NVMMASharedLayout(128, 32, rank=2, cga_layout=cga_layout)
     desc = TensorDescriptor.from_tensor(inp, [128, 64], layout)
 
-    compiled = cross_cta_tma_load_kernel[(1, )](desc, out, cga_layout, num_warps=4, num_ctas=1 << len(cga_layout))
+    compiled = cross_cta_tma_kernel[(1, )](desc, out, cga_layout, "load", num_warps=4, num_ctas=1 << len(cga_layout))
     assert "mapa.shared::cluster" in compiled.asm["ptx"]
     assert "cp.async.bulk.tensor.2d.cta_group::2.shared::cluster.global" in compiled.asm["ptx"]
     torch.testing.assert_close(out, torch.cat((torch.full_like(inp, -5), inp)), atol=0, rtol=0)
@@ -3558,26 +3563,9 @@ def test_cross_cta_tma_load_rejects_nonpeer_barrier(capfd):
     desc = TensorDescriptor.from_tensor(inp, [128, 64], layout)
 
     with pytest.raises(RuntimeError, match="PassManager::run failed"):
-        cross_cta_tma_load_kernel.warmup(desc, out, cga_layout, grid=(1, ), num_warps=4, num_ctas=4)
+        cross_cta_tma_kernel.warmup(desc, out, cga_layout, MODE="load", grid=(1, ), num_warps=4, num_ctas=4)
     captured = capfd.readouterr()
     assert "TMA destination and completion barrier must belong to the same CTA or a CTA pair" in captured.err
-
-
-@gluon.jit
-def cross_cta_tma_store_kernel(out_desc, REDUCE: ttgl.constexpr):
-    alloc_layout: ttgl.constexpr = ttgl.BlockedLayout([1, 1], [4, 8], [4, 1], [1, 0], cga_layout=((1, 0), ))
-    shared_layout: ttgl.constexpr = ttgl.NVMMASharedLayout(128, 32, rank=2, cga_layout=((1, 0), ))
-    parent = ttgl.allocate_shared_memory(
-        ttgl.int32,
-        [256, 64],
-        shared_layout,
-        value=ttgl.full([256, 64], 1, ttgl.int32, layout=alloc_layout),
-    )
-    tile = parent.slice(128, 128, dim=0)
-    if REDUCE:
-        tma.async_atomic_add(out_desc, [0, 0], tile)
-    else:
-        tma.async_store(out_desc, [0, 0], tile)
 
 
 @pytest.mark.skipif(not is_hopper_or_newer(), reason="Requires Hopper")
@@ -3588,7 +3576,8 @@ def test_cross_cta_tma_store_rejected(reduce, capfd):
     desc = TensorDescriptor.from_tensor(out, [128, 64], layout)
 
     with pytest.raises(RuntimeError, match="error encountered during parsing"):
-        cross_cta_tma_store_kernel.warmup(desc, REDUCE=reduce, grid=(1, ), num_warps=4, num_ctas=2)
+        cross_cta_tma_kernel.warmup(desc, out, ((1, 0), ), MODE="reduce" if reduce else "store", grid=(1, ),
+                                    num_warps=4, num_ctas=2)
     captured = capfd.readouterr()
     assert "source subview may have an origin in another CTA" in captured.out + captured.err
 

--- a/python/test/gluon/test_core.py
+++ b/python/test/gluon/test_core.py
@@ -460,6 +460,81 @@ def test_tma_gather_scatter_multi_cta(cga_layout):
 
 
 @gluon.jit
+def tma_gather_scatter_subslice_kernel(in_desc, out_desc, gather_idx_ptr, scatter_idx_ptr, parent_out,
+                                       KIND: ttgl.constexpr):
+    if KIND == "row":
+        cga_layout: ttgl.constexpr = ()
+    else:
+        cga_layout: ttgl.constexpr = ((1, 0), )
+    shared_layout: ttgl.constexpr = ttgl.NVMMASharedLayout(128, 16, rank=2, cga_layout=cga_layout)
+    parent_layout: ttgl.constexpr = ttgl.BlockedLayout([1, 1], [4, 8], [4, 1], [1, 0], cga_layout=cga_layout)
+    indices_layout: ttgl.constexpr = ttgl.SliceLayout(
+        1, ttgl.BlockedLayout([4, 1], [1, 32], [4, 1], [0, 1], cga_layout=cga_layout))
+
+    if KIND == "column":
+        parent = ttgl.allocate_shared_memory(ttgl.float16, [64, 256], shared_layout,
+                                             value=ttgl.full([64, 256], -7, ttgl.float16, layout=parent_layout))
+        tile = parent.slice(128, 128, dim=1)
+    else:
+        parent = ttgl.allocate_shared_memory(ttgl.float16, [128, 128], shared_layout,
+                                             value=ttgl.full([128, 128], -7, ttgl.float16, layout=parent_layout))
+        tile = parent.slice(64, 64, dim=0)
+
+    gather_idx = ttgl.load(gather_idx_ptr + ttgl.arange(0, 64, layout=indices_layout))
+    barrier = mbarrier.allocate_mbarrier()
+    mbarrier.init(barrier, count=1)
+    mbarrier.expect(barrier, tile.nbytes_per_cta)
+    blackwell_tma.async_gather(in_desc, gather_idx, 0, barrier, tile)
+    mbarrier.wait(barrier, phase=0, deps=[tile])
+    if KIND != "row":
+        ttgl.barrier(cluster=True)
+
+    if KIND != "remote":
+        scatter_idx = ttgl.load(scatter_idx_ptr + ttgl.arange(0, 64, layout=indices_layout))
+        blackwell_tma.async_scatter(out_desc, scatter_idx, 0, tile)
+        tma.store_wait(0)
+
+    values = parent.load(parent_layout)
+    if KIND == "column":
+        offsets = ttgl.arange(0, 64)[:, None] * 256 + ttgl.arange(0, 256)[None, :]
+    else:
+        offsets = ttgl.arange(0, 128)[:, None] * 128 + ttgl.arange(0, 128)[None, :]
+    ttgl.store(parent_out + ttgl.set_auto_layout(offsets, values.type.layout), values)
+
+
+@pytest.mark.skipif(not is_blackwell(), reason="Requires Blackwell")
+@pytest.mark.parametrize("kind", ["row", "column", "remote"])
+def test_tma_gather_scatter_subslice(kind):
+    values = torch.arange(64 * 128, dtype=torch.float16, device="cuda").reshape(64, 128)
+    scatter_out = torch.zeros_like(values)
+    parent_out = torch.empty((64, 256) if kind == "column" else (128, 128), dtype=torch.float16, device="cuda")
+    gather_idx = torch.arange(63, -1, -1, dtype=torch.int32, device="cuda")
+    scatter_idx = (torch.arange(64, dtype=torch.int32, device="cuda") + 1) % 64
+    cga_layout = () if kind == "row" else ((1, 0), )
+    shared_layout = ttgl.NVMMASharedLayout(128, 16, rank=2, cga_layout=cga_layout)
+    in_desc = TensorDescriptor.from_tensor(values, [1, 128], shared_layout)
+    out_desc = TensorDescriptor.from_tensor(scatter_out, [1, 128], shared_layout)
+
+    compiled = tma_gather_scatter_subslice_kernel[(1, )](in_desc, out_desc, gather_idx, scatter_idx, parent_out, kind,
+                                                         num_warps=4, num_ctas=1 << len(cga_layout))
+
+    gathered = values[gather_idx.to(torch.int64)]
+    expected_parent = torch.full_like(parent_out, -7)
+    if kind == "column":
+        expected_parent[:, 128:] = gathered
+    else:
+        expected_parent[64:] = gathered
+    if kind == "remote":
+        assert "mapa.shared::cluster" in compiled.asm["ptx"]
+        assert "tile::gather4.cta_group::2.shared::cluster" in compiled.asm["ptx"]
+    else:
+        expected_scatter = torch.zeros_like(values)
+        expected_scatter[scatter_idx.to(torch.int64)] = gathered
+        torch.testing.assert_close(scatter_out, expected_scatter, atol=0, rtol=0)
+    torch.testing.assert_close(parent_out, expected_parent, atol=0, rtol=0)
+
+
+@gluon.jit
 def tcgen05_mma_multicast_commit_kernel(a_desc, b_desc, out_ptrs, BLOCK_M: ttgl.constexpr, BLOCK_N: ttgl.constexpr,
                                         acc_tmem_layout: ttgl.constexpr, blocked_c: ttgl.constexpr):
     smem_a = ttgl.allocate_shared_memory(a_desc.dtype, a_desc.block_shape, a_desc.layout)

--- a/python/test/gluon/test_core.py
+++ b/python/test/gluon/test_core.py
@@ -460,45 +460,33 @@ def test_tma_gather_scatter_multi_cta(cga_layout):
 
 
 @gluon.jit
-def tma_gather_scatter_subslice_kernel(in_desc, out_desc, gather_idx_ptr, scatter_idx_ptr, parent_out,
-                                       KIND: ttgl.constexpr):
-    if KIND == "row":
-        cga_layout: ttgl.constexpr = ()
-    else:
-        cga_layout: ttgl.constexpr = ((1, 0), )
+def tma_gather_scatter_subslice_kernel(in_desc, out_desc, parent_out, KIND: ttgl.constexpr):
+    cga_layout: ttgl.constexpr = () if KIND == "row" else ((1, 0), )
     shared_layout: ttgl.constexpr = ttgl.NVMMASharedLayout(128, 16, rank=2, cga_layout=cga_layout)
     parent_layout: ttgl.constexpr = ttgl.BlockedLayout([1, 1], [4, 8], [4, 1], [1, 0], cga_layout=cga_layout)
     indices_layout: ttgl.constexpr = ttgl.SliceLayout(
         1, ttgl.BlockedLayout([4, 1], [1, 32], [4, 1], [0, 1], cga_layout=cga_layout))
+    shape: ttgl.constexpr = (64, 256) if KIND == "column" else (128, 128)
+    parent = ttgl.allocate_shared_memory(ttgl.float16, shape, shared_layout,
+                                         value=ttgl.full(shape, -7, ttgl.float16, layout=parent_layout))
+    dim: ttgl.constexpr = 1 if KIND == "column" else 0
+    tile = parent.slice(shape[dim] // 2, shape[dim] // 2, dim=dim)
 
-    if KIND == "column":
-        parent = ttgl.allocate_shared_memory(ttgl.float16, [64, 256], shared_layout,
-                                             value=ttgl.full([64, 256], -7, ttgl.float16, layout=parent_layout))
-        tile = parent.slice(128, 128, dim=1)
-    else:
-        parent = ttgl.allocate_shared_memory(ttgl.float16, [128, 128], shared_layout,
-                                             value=ttgl.full([128, 128], -7, ttgl.float16, layout=parent_layout))
-        tile = parent.slice(64, 64, dim=0)
-
-    gather_idx = ttgl.load(gather_idx_ptr + ttgl.arange(0, 64, layout=indices_layout))
+    indices = ttgl.arange(0, 64, layout=indices_layout)
     barrier = mbarrier.allocate_mbarrier()
     mbarrier.init(barrier, count=1)
     mbarrier.expect(barrier, tile.nbytes_per_cta)
-    blackwell_tma.async_gather(in_desc, gather_idx, 0, barrier, tile)
+    blackwell_tma.async_gather(in_desc, 63 - indices, 0, barrier, tile)
     mbarrier.wait(barrier, phase=0, deps=[tile])
     if KIND != "row":
         ttgl.barrier(cluster=True)
 
     if KIND != "remote":
-        scatter_idx = ttgl.load(scatter_idx_ptr + ttgl.arange(0, 64, layout=indices_layout))
-        blackwell_tma.async_scatter(out_desc, scatter_idx, 0, tile)
+        blackwell_tma.async_scatter(out_desc, (indices + 1) % 64, 0, tile)
         tma.store_wait(0)
 
     values = parent.load(parent_layout)
-    if KIND == "column":
-        offsets = ttgl.arange(0, 64)[:, None] * 256 + ttgl.arange(0, 256)[None, :]
-    else:
-        offsets = ttgl.arange(0, 128)[:, None] * 128 + ttgl.arange(0, 128)[None, :]
+    offsets = ttgl.arange(0, shape[0])[:, None] * shape[1] + ttgl.arange(0, shape[1])[None, :]
     ttgl.store(parent_out + ttgl.set_auto_layout(offsets, values.type.layout), values)
 
 
@@ -508,17 +496,15 @@ def test_tma_gather_scatter_subslice(kind):
     values = torch.arange(64 * 128, dtype=torch.float16, device="cuda").reshape(64, 128)
     scatter_out = torch.zeros_like(values)
     parent_out = torch.empty((64, 256) if kind == "column" else (128, 128), dtype=torch.float16, device="cuda")
-    gather_idx = torch.arange(63, -1, -1, dtype=torch.int32, device="cuda")
-    scatter_idx = (torch.arange(64, dtype=torch.int32, device="cuda") + 1) % 64
     cga_layout = () if kind == "row" else ((1, 0), )
     shared_layout = ttgl.NVMMASharedLayout(128, 16, rank=2, cga_layout=cga_layout)
     in_desc = TensorDescriptor.from_tensor(values, [1, 128], shared_layout)
     out_desc = TensorDescriptor.from_tensor(scatter_out, [1, 128], shared_layout)
 
-    compiled = tma_gather_scatter_subslice_kernel[(1, )](in_desc, out_desc, gather_idx, scatter_idx, parent_out, kind,
-                                                         num_warps=4, num_ctas=1 << len(cga_layout))
+    compiled = tma_gather_scatter_subslice_kernel[(1, )](in_desc, out_desc, parent_out, kind, num_warps=4,
+                                                         num_ctas=1 << len(cga_layout))
 
-    gathered = values[gather_idx.to(torch.int64)]
+    gathered = values.flip(0)
     expected_parent = torch.full_like(parent_out, -7)
     if kind == "column":
         expected_parent[:, 128:] = gathered
@@ -528,9 +514,7 @@ def test_tma_gather_scatter_subslice(kind):
         assert "mapa.shared::cluster" in compiled.asm["ptx"]
         assert "tile::gather4.cta_group::2.shared::cluster" in compiled.asm["ptx"]
     else:
-        expected_scatter = torch.zeros_like(values)
-        expected_scatter[scatter_idx.to(torch.int64)] = gathered
-        torch.testing.assert_close(scatter_out, expected_scatter, atol=0, rtol=0)
+        torch.testing.assert_close(scatter_out, gathered.roll(1, 0), atol=0, rtol=0)
     torch.testing.assert_close(parent_out, expected_parent, atol=0, rtol=0)
 
 
@@ -3590,12 +3574,8 @@ def test_shared_subslice_two_ctas(op):
 def cross_cta_tma_kernel(desc, out, cga_layout: ttgl.constexpr, MODE: ttgl.constexpr):
     alloc_layout: ttgl.constexpr = ttgl.BlockedLayout([1, 1], [4, 8], [4, 1], [1, 0], cga_layout=cga_layout)
     shared_layout: ttgl.constexpr = ttgl.NVMMASharedLayout(128, 32, rank=2, cga_layout=cga_layout)
-    parent = ttgl.allocate_shared_memory(
-        ttgl.int32,
-        [256, 64],
-        shared_layout,
-        value=ttgl.full([256, 64], -5, ttgl.int32, layout=alloc_layout),
-    )
+    parent = ttgl.allocate_shared_memory(ttgl.int32, [256, 64], shared_layout,
+                                         value=ttgl.full([256, 64], -5, ttgl.int32, layout=alloc_layout))
     tile = parent.slice(128, 128, dim=0)
     if MODE == "load":
         bar = mbarrier.allocate_mbarrier()
@@ -3605,9 +3585,8 @@ def cross_cta_tma_kernel(desc, out, cga_layout: ttgl.constexpr, MODE: ttgl.const
         mbarrier.wait(bar, phase=0)
         ttgl.barrier(cluster=True)
         result = parent.load(alloc_layout)
-        rows = ttgl.arange(0, 256)[:, None]
-        cols = ttgl.arange(0, 64)[None, :]
-        offsets = ttgl.set_auto_layout(rows * 64 + cols, result.type.layout)
+        offsets = ttgl.arange(0, 256)[:, None] * 64 + ttgl.arange(0, 64)[None, :]
+        offsets = ttgl.set_auto_layout(offsets, result.type.layout)
         ttgl.store(out + offsets, result)
     elif MODE == "store":
         tma.async_store(desc, [0, 0], tile)
@@ -3616,17 +3595,13 @@ def cross_cta_tma_kernel(desc, out, cga_layout: ttgl.constexpr, MODE: ttgl.const
 
 
 @pytest.mark.skipif(not is_hopper_or_newer(), reason="Requires Hopper")
-@pytest.mark.parametrize(
-    "mode,cga_layout",
-    [
-        ("load", ((1, 0), )),
-        ("load", ((1, 0), (0, 0))),
-        ("load", ((0, 0), (1, 0))),
-        ("store", ((1, 0), )),
-        ("reduce", ((1, 0), )),
-    ],
-    ids=["two-ctas", "four-ctas", "nonpeer", "store", "reduce"],
-)
+@pytest.mark.parametrize("mode,cga_layout", [
+    ("load", ((1, 0), )),
+    ("load", ((1, 0), (0, 0))),
+    ("load", ((0, 0), (1, 0))),
+    ("store", ((1, 0), )),
+    ("reduce", ((1, 0), )),
+], ids=["two-ctas", "four-ctas", "nonpeer", "store", "reduce"])
 def test_cross_cta_tma(mode, cga_layout, capfd):
     if mode == "load" and not is_blackwell():
         pytest.skip("Requires Blackwell CTA-pair completion")

--- a/python/test/gluon/test_core.py
+++ b/python/test/gluon/test_core.py
@@ -3540,46 +3540,40 @@ def cross_cta_tma_kernel(desc, out, cga_layout: ttgl.constexpr, MODE: ttgl.const
         tma.async_atomic_add(desc, [0, 0], tile)
 
 
-@pytest.mark.skipif(not is_blackwell(), reason="Requires Blackwell CTA-pair completion")
-@pytest.mark.parametrize("cga_layout", [((1, 0), ), ((1, 0), (0, 0))], ids=["two-ctas", "four-ctas"])
-def test_cross_cta_tma_load(cga_layout):
+@pytest.mark.skipif(not is_hopper_or_newer(), reason="Requires Hopper")
+@pytest.mark.parametrize(
+    "mode,cga_layout",
+    [
+        ("load", ((1, 0), )),
+        ("load", ((1, 0), (0, 0))),
+        ("load", ((0, 0), (1, 0))),
+        ("store", ((1, 0), )),
+        ("reduce", ((1, 0), )),
+    ],
+    ids=["two-ctas", "four-ctas", "nonpeer", "store", "reduce"],
+)
+def test_cross_cta_tma(mode, cga_layout, capfd):
+    if mode == "load" and not is_blackwell():
+        pytest.skip("Requires Blackwell CTA-pair completion")
     inp = torch.arange(128 * 64, device="cuda", dtype=torch.int32).reshape(128, 64)
     out = torch.full((256, 64), -1, device="cuda", dtype=torch.int32)
     layout = ttgl.NVMMASharedLayout(128, 32, rank=2, cga_layout=cga_layout)
     desc = TensorDescriptor.from_tensor(inp, [128, 64], layout)
 
-    compiled = cross_cta_tma_kernel[(1, )](desc, out, cga_layout, "load", num_warps=4, num_ctas=1 << len(cga_layout))
-    assert "mapa.shared::cluster" in compiled.asm["ptx"]
-    assert "cp.async.bulk.tensor.2d.cta_group::2.shared::cluster.global" in compiled.asm["ptx"]
-    torch.testing.assert_close(out, torch.cat((torch.full_like(inp, -5), inp)), atol=0, rtol=0)
-
-
-@pytest.mark.skipif(not is_blackwell(), reason="Requires Blackwell")
-def test_cross_cta_tma_load_rejects_nonpeer_barrier(capfd):
-    inp = torch.arange(128 * 64, device="cuda", dtype=torch.int32).reshape(128, 64)
-    out = torch.empty((256, 64), device="cuda", dtype=torch.int32)
-    cga_layout = ((0, 0), (1, 0))
-    layout = ttgl.NVMMASharedLayout(128, 32, rank=2, cga_layout=cga_layout)
-    desc = TensorDescriptor.from_tensor(inp, [128, 64], layout)
-
-    with pytest.raises(RuntimeError, match="PassManager::run failed"):
-        cross_cta_tma_kernel.warmup(desc, out, cga_layout, MODE="load", grid=(1, ), num_warps=4, num_ctas=4)
-    captured = capfd.readouterr()
-    assert "TMA destination and completion barrier must belong to the same CTA or a CTA pair" in captured.err
-
-
-@pytest.mark.skipif(not is_hopper_or_newer(), reason="Requires Hopper")
-@pytest.mark.parametrize("reduce", [False, True], ids=["store", "reduce"])
-def test_cross_cta_tma_store_rejected(reduce, capfd):
-    out = torch.zeros((128, 64), device="cuda", dtype=torch.int32)
-    layout = ttgl.NVMMASharedLayout(128, 32, rank=2, cga_layout=((1, 0), ))
-    desc = TensorDescriptor.from_tensor(out, [128, 64], layout)
-
-    with pytest.raises(RuntimeError, match="error encountered during parsing"):
-        cross_cta_tma_kernel.warmup(desc, out, ((1, 0), ), MODE="reduce" if reduce else "store", grid=(1, ),
-                                    num_warps=4, num_ctas=2)
-    captured = capfd.readouterr()
-    assert "source subview may have an origin in another CTA" in captured.out + captured.err
+    if mode != "load":
+        with pytest.raises(RuntimeError, match="error encountered during parsing"):
+            cross_cta_tma_kernel.warmup(desc, out, cga_layout, MODE=mode, grid=(1, ), num_warps=4, num_ctas=2)
+        assert "source subview may have an origin in another CTA" in "".join(capfd.readouterr())
+    elif cga_layout[0] == (0, 0):
+        with pytest.raises(RuntimeError, match="PassManager::run failed"):
+            cross_cta_tma_kernel.warmup(desc, out, cga_layout, MODE=mode, grid=(1, ), num_warps=4, num_ctas=4)
+        captured = capfd.readouterr()
+        assert "TMA destination and completion barrier must belong to the same CTA or a CTA pair" in captured.err
+    else:
+        compiled = cross_cta_tma_kernel[(1, )](desc, out, cga_layout, mode, num_warps=4, num_ctas=1 << len(cga_layout))
+        assert "mapa.shared::cluster" in compiled.asm["ptx"]
+        assert "cp.async.bulk.tensor.2d.cta_group::2.shared::cluster.global" in compiled.asm["ptx"]
+        torch.testing.assert_close(out, torch.cat((torch.full_like(inp, -5), inp)), atol=0, rtol=0)
 
 
 @gluon.jit

--- a/python/test/gluon/test_core.py
+++ b/python/test/gluon/test_core.py
@@ -3565,10 +3565,10 @@ def test_cross_cta_tma(mode, cga_layout, capfd):
             cross_cta_tma_kernel.warmup(desc, out, cga_layout, MODE=mode, grid=(1, ), num_warps=4, num_ctas=2)
         assert "source subview may have an origin in another CTA" in "".join(capfd.readouterr())
     elif cga_layout[0] == (0, 0):
-        with pytest.raises(RuntimeError, match="PassManager::run failed"):
+        with pytest.raises(RuntimeError, match="error encountered during parsing"):
             cross_cta_tma_kernel.warmup(desc, out, cga_layout, MODE=mode, grid=(1, ), num_warps=4, num_ctas=4)
-        captured = capfd.readouterr()
-        assert "TMA destination and completion barrier must belong to the same CTA or a CTA pair" in captured.err
+        assert "TMA destination and completion barrier must belong to the same CTA or a CTA pair" in "".join(
+            capfd.readouterr())
     else:
         compiled = cross_cta_tma_kernel[(1, )](desc, out, cga_layout, mode, num_warps=4, num_ctas=1 << len(cga_layout))
         assert "mapa.shared::cluster" in compiled.asm["ptx"]

--- a/python/test/gluon/test_core.py
+++ b/python/test/gluon/test_core.py
@@ -3512,6 +3512,88 @@ def test_shared_subslice_two_ctas(op):
 
 
 @gluon.jit
+def cross_cta_tma_load_kernel(in_desc, out, cga_layout: ttgl.constexpr):
+    alloc_layout: ttgl.constexpr = ttgl.BlockedLayout([1, 1], [4, 8], [4, 1], [1, 0], cga_layout=cga_layout)
+    shared_layout: ttgl.constexpr = ttgl.NVMMASharedLayout(128, 32, rank=2, cga_layout=cga_layout)
+    parent = ttgl.allocate_shared_memory(
+        ttgl.int32,
+        [256, 64],
+        shared_layout,
+        value=ttgl.full([256, 64], -5, ttgl.int32, layout=alloc_layout),
+    )
+    tile = parent.slice(128, 128, dim=0)
+    bar = mbarrier.allocate_mbarrier()
+    mbarrier.init(bar, count=1)
+    mbarrier.expect(bar, in_desc.nbytes_per_cta)
+    tma.async_load(in_desc, [0, 0], bar, tile)
+    mbarrier.wait(bar, phase=0)
+    ttgl.barrier(cluster=True)
+    result = parent.load(alloc_layout)
+    rows = ttgl.arange(0, 256)[:, None]
+    cols = ttgl.arange(0, 64)[None, :]
+    offsets = ttgl.set_auto_layout(rows * 64 + cols, result.type.layout)
+    ttgl.store(out + offsets, result)
+
+
+@pytest.mark.skipif(not is_blackwell(), reason="Requires Blackwell CTA-pair completion")
+@pytest.mark.parametrize("cga_layout", [((1, 0), ), ((1, 0), (0, 0))], ids=["two-ctas", "four-ctas"])
+def test_cross_cta_tma_load(cga_layout):
+    inp = torch.arange(128 * 64, device="cuda", dtype=torch.int32).reshape(128, 64)
+    out = torch.full((256, 64), -1, device="cuda", dtype=torch.int32)
+    layout = ttgl.NVMMASharedLayout(128, 32, rank=2, cga_layout=cga_layout)
+    desc = TensorDescriptor.from_tensor(inp, [128, 64], layout)
+
+    compiled = cross_cta_tma_load_kernel[(1, )](desc, out, cga_layout, num_warps=4, num_ctas=1 << len(cga_layout))
+    assert "mapa.shared::cluster" in compiled.asm["ptx"]
+    assert "cp.async.bulk.tensor.2d.cta_group::2.shared::cluster.global" in compiled.asm["ptx"]
+    torch.testing.assert_close(out, torch.cat((torch.full_like(inp, -5), inp)), atol=0, rtol=0)
+
+
+@pytest.mark.skipif(not is_blackwell(), reason="Requires Blackwell")
+def test_cross_cta_tma_load_rejects_nonpeer_barrier(capfd):
+    inp = torch.arange(128 * 64, device="cuda", dtype=torch.int32).reshape(128, 64)
+    out = torch.empty((256, 64), device="cuda", dtype=torch.int32)
+    cga_layout = ((0, 0), (1, 0))
+    layout = ttgl.NVMMASharedLayout(128, 32, rank=2, cga_layout=cga_layout)
+    desc = TensorDescriptor.from_tensor(inp, [128, 64], layout)
+
+    with pytest.raises(RuntimeError, match="PassManager::run failed"):
+        cross_cta_tma_load_kernel.warmup(desc, out, cga_layout, grid=(1, ), num_warps=4, num_ctas=4)
+    captured = capfd.readouterr()
+    assert "TMA destination and completion barrier must belong to the same CTA or a CTA pair" in captured.err
+
+
+@gluon.jit
+def cross_cta_tma_store_kernel(out_desc, REDUCE: ttgl.constexpr):
+    alloc_layout: ttgl.constexpr = ttgl.BlockedLayout([1, 1], [4, 8], [4, 1], [1, 0], cga_layout=((1, 0), ))
+    shared_layout: ttgl.constexpr = ttgl.NVMMASharedLayout(128, 32, rank=2, cga_layout=((1, 0), ))
+    parent = ttgl.allocate_shared_memory(
+        ttgl.int32,
+        [256, 64],
+        shared_layout,
+        value=ttgl.full([256, 64], 1, ttgl.int32, layout=alloc_layout),
+    )
+    tile = parent.slice(128, 128, dim=0)
+    if REDUCE:
+        tma.async_atomic_add(out_desc, [0, 0], tile)
+    else:
+        tma.async_store(out_desc, [0, 0], tile)
+
+
+@pytest.mark.skipif(not is_hopper_or_newer(), reason="Requires Hopper")
+@pytest.mark.parametrize("reduce", [False, True], ids=["store", "reduce"])
+def test_cross_cta_tma_store_rejected(reduce, capfd):
+    out = torch.zeros((128, 64), device="cuda", dtype=torch.int32)
+    layout = ttgl.NVMMASharedLayout(128, 32, rank=2, cga_layout=((1, 0), ))
+    desc = TensorDescriptor.from_tensor(out, [128, 64], layout)
+
+    with pytest.raises(RuntimeError, match="error encountered during parsing"):
+        cross_cta_tma_store_kernel.warmup(desc, REDUCE=reduce, grid=(1, ), num_warps=4, num_ctas=2)
+    captured = capfd.readouterr()
+    assert "source subview may have an origin in another CTA" in captured.out + captured.err
+
+
+@gluon.jit
 def shared_subslice_swizzled_register_block_kernel(inp, out, alloc_layout: ttgl.constexpr, tile_layout: ttgl.constexpr,
                                                    shared_layout: ttgl.constexpr):
     rows = ttgl.arange(0, 4, layout=ttgl.SliceLayout(1, alloc_layout))

--- a/test/Conversion/tma_to_llvm.mlir
+++ b/test/Conversion/tma_to_llvm.mlir
@@ -166,4 +166,16 @@ tt.func @tma_scatter(%arg0: !tt.tensordesc<1x128xbf16, #shared1>, %arg1: tensor<
   tt.return
 }
 
+// CHECK-LABEL: @tma_gather_scatter_column_subslice
+tt.func @tma_gather_scatter_column_subslice(%desc: !tt.tensordesc<1x128xbf16, #shared1>, %indices: tensor<32xi32, #ttg.slice<{dim = 0, parent = #blocked}>>, %y: i32, %parent: !ttg.memdesc<32x256xbf16, #shared1, #smem, mutable>, %barrier: !ttg.memdesc<1xi64, #shared, #smem, mutable>, %pred: i1) {
+  // CHECK: add i32 {{.*}}, 4096
+  // CHECK: getelementptr
+  // CHECK: cp.async.bulk.tensor.2d.tile::gather4.shared::cta.global
+  // CHECK: cp.async.bulk.tensor.2d.tile::scatter4.global.shared::cta
+  %view = ttg.memdesc_subslice %parent [0, 128] : !ttg.memdesc<32x256xbf16, #shared1, #smem, mutable> -> !ttg.memdesc<32x128xbf16, #shared1, #smem, mutable, 32x256>
+  ttng.async_tma_gather %desc[%indices, %y] %view, %barrier, %pred : !tt.tensordesc<1x128xbf16, #shared1>, tensor<32xi32, #ttg.slice<{dim = 0, parent = #blocked}>>, i32, !ttg.memdesc<1xi64, #shared, #smem, mutable>, !ttg.memdesc<32x128xbf16, #shared1, #smem, mutable, 32x256>, i1
+  ttng.async_tma_scatter %desc[%indices, %y] %view : !tt.tensordesc<1x128xbf16, #shared1>, tensor<32xi32, #ttg.slice<{dim = 0, parent = #blocked}>>, i32, !ttg.memdesc<32x128xbf16, #shared1, #smem, mutable, 32x256>
+  tt.return
+}
+
 }

--- a/test/Conversion/tritongpu_to_llvm_blackwell.mlir
+++ b/test/Conversion/tritongpu_to_llvm_blackwell.mlir
@@ -1470,6 +1470,7 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.shar
 
 #barrier = #ttg.swizzled_shared<{vec = 1, perPhase = 1, maxPhase = 1, order = [0], CGALayout = [[1]]}>
 #shared = #ttg.nvmma_shared<{swizzlingByteWidth = 128, transposed = false, elementBitWidth = 32, CGALayout = [[1, 0]]}>
+#blocked = #ttg.blocked<{sizePerThread = [4, 1], threadsPerWarp = [1, 32], warpsPerCTA = [4, 1], order = [0, 1], CGALayout = [[1, 0]]}>
 #smem = #ttg.shared_memory
 module attributes {"ttg.num-ctas" = 2 : i32, "ttg.num-warps" = 4 : i32} {
   // CHECK-LABEL: @tma_load_remote_cta
@@ -1478,6 +1479,15 @@ module attributes {"ttg.num-ctas" = 2 : i32, "ttg.num-warps" = 4 : i32} {
   tt.func @tma_load_remote_cta(%desc: !tt.tensordesc<128x64xi32, #shared>, %parent: !ttg.memdesc<256x64xi32, #shared, #smem, mutable>, %bar: !ttg.memdesc<2xi64, #barrier, #smem>, %x: i32, %pred: i1) {
     %view = ttg.memdesc_subslice %parent [128, 0] : !ttg.memdesc<256x64xi32, #shared, #smem, mutable> -> !ttg.memdesc<128x64xi32, #shared, #smem, mutable, 256x64>
     ttng.async_tma_copy_global_to_local %desc[%x, %x] %view, %bar, %pred : !tt.tensordesc<128x64xi32, #shared>, !ttg.memdesc<2xi64, #barrier, #smem> -> !ttg.memdesc<128x64xi32, #shared, #smem, mutable, 256x64>
+    tt.return
+  }
+
+  // CHECK-LABEL: @tma_gather_remote_cta
+  // CHECK: nvvm.mapa
+  // CHECK: cp.async.bulk.tensor.2d.tile::gather4.cta_group::2.shared::cluster.global
+  tt.func @tma_gather_remote_cta(%desc: !tt.tensordesc<1x64xi32, #shared>, %parent: !ttg.memdesc<256x64xi32, #shared, #smem, mutable>, %bar: !ttg.memdesc<2xi64, #barrier, #smem>, %indices: tensor<128xi32, #ttg.slice<{dim = 1, parent = #blocked}>>, %y: i32, %pred: i1) {
+    %view = ttg.memdesc_subslice %parent [128, 0] : !ttg.memdesc<256x64xi32, #shared, #smem, mutable> -> !ttg.memdesc<128x64xi32, #shared, #smem, mutable, 256x64>
+    ttng.async_tma_gather %desc[%indices, %y] %view, %bar, %pred : !tt.tensordesc<1x64xi32, #shared>, tensor<128xi32, #ttg.slice<{dim = 1, parent = #blocked}>>, i32, !ttg.memdesc<2xi64, #barrier, #smem>, !ttg.memdesc<128x64xi32, #shared, #smem, mutable, 256x64>, i1
     tt.return
   }
 }

--- a/test/Conversion/tritongpu_to_llvm_blackwell.mlir
+++ b/test/Conversion/tritongpu_to_llvm_blackwell.mlir
@@ -1465,3 +1465,35 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.shar
     tt.return
   }
 }
+
+// -----
+
+#barrier = #ttg.swizzled_shared<{vec = 1, perPhase = 1, maxPhase = 1, order = [0], CGALayout = [[1]]}>
+#shared = #ttg.nvmma_shared<{swizzlingByteWidth = 128, transposed = false, elementBitWidth = 32, CGALayout = [[1, 0]]}>
+#smem = #ttg.shared_memory
+module attributes {"ttg.num-ctas" = 2 : i32, "ttg.num-warps" = 4 : i32} {
+  // CHECK-LABEL: @tma_load_remote_cta
+  // CHECK: nvvm.mapa
+  // CHECK: cp.async.bulk.tensor.2d.cta_group::2.shared::cluster.global
+  tt.func @tma_load_remote_cta(%desc: !tt.tensordesc<128x64xi32, #shared>, %parent: !ttg.memdesc<256x64xi32, #shared, #smem, mutable>, %bar: !ttg.memdesc<2xi64, #barrier, #smem>, %x: i32, %pred: i1) {
+    %view = ttg.memdesc_subslice %parent [128, 0] : !ttg.memdesc<256x64xi32, #shared, #smem, mutable> -> !ttg.memdesc<128x64xi32, #shared, #smem, mutable, 256x64>
+    ttng.async_tma_copy_global_to_local %desc[%x, %x] %view, %bar, %pred : !tt.tensordesc<128x64xi32, #shared>, !ttg.memdesc<2xi64, #barrier, #smem> -> !ttg.memdesc<128x64xi32, #shared, #smem, mutable, 256x64>
+    tt.return
+  }
+}
+
+// -----
+
+#barrier = #ttg.swizzled_shared<{vec = 1, perPhase = 1, maxPhase = 1, order = [0], CGALayout = [[1], [2]]}>
+#shared = #ttg.nvmma_shared<{swizzlingByteWidth = 128, transposed = false, elementBitWidth = 32, CGALayout = [[1, 0], [0, 0]]}>
+#smem = #ttg.shared_memory
+module attributes {"ttg.num-ctas" = 4 : i32, "ttg.num-warps" = 4 : i32} {
+  // CHECK-LABEL: @tma_load_remote_cta_in_four_cta_cluster
+  // CHECK: nvvm.mapa
+  // CHECK: cp.async.bulk.tensor.2d.cta_group::2.shared::cluster.global
+  tt.func @tma_load_remote_cta_in_four_cta_cluster(%desc: !tt.tensordesc<128x64xi32, #shared>, %parent: !ttg.memdesc<256x64xi32, #shared, #smem, mutable>, %bar: !ttg.memdesc<4xi64, #barrier, #smem>, %x: i32, %pred: i1) {
+    %view = ttg.memdesc_subslice %parent [128, 0] : !ttg.memdesc<256x64xi32, #shared, #smem, mutable> -> !ttg.memdesc<128x64xi32, #shared, #smem, mutable, 256x64>
+    ttng.async_tma_copy_global_to_local %desc[%x, %x] %view, %bar, %pred : !tt.tensordesc<128x64xi32, #shared>, !ttg.memdesc<4xi64, #barrier, #smem> -> !ttg.memdesc<128x64xi32, #shared, #smem, mutable, 256x64>
+    tt.return
+  }
+}

--- a/test/TritonNvidiaGPU/invalid.mlir
+++ b/test/TritonNvidiaGPU/invalid.mlir
@@ -1653,16 +1653,12 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.targ
 #shared = #ttg.nvmma_shared<{swizzlingByteWidth = 128, transposed = false, elementBitWidth = 32, CGALayout = [[1, 0]]}>
 #smem = #ttg.shared_memory
 module attributes {"ttg.num-ctas" = 2 : i32, "ttg.num-warps" = 4 : i32, ttg.target = "cuda:90", "ttg.threads-per-warp" = 32 : i32} {
-  tt.func @tma_store_rejects_remote_source(%desc: !tt.tensordesc<128x64xi32, #shared>, %x: i32) {
-    %parent = ttg.local_alloc : () -> !ttg.memdesc<256x64xi32, #shared, #smem, mutable>
-    %view = ttg.memdesc_subslice %parent [128, 0] : !ttg.memdesc<256x64xi32, #shared, #smem, mutable> -> !ttg.memdesc<128x64xi32, #shared, #smem, mutable, 256x64>
+  tt.func @tma_store_rejects_remote_source(%desc: !tt.tensordesc<128x64xi32, #shared>, %view: !ttg.memdesc<128x64xi32, #shared, #smem, mutable, 256x64>, %x: i32) {
     // expected-error @below {{source subview may have an origin in another CTA}}
     ttng.async_tma_copy_local_to_global %desc[%x, %x] %view : !tt.tensordesc<128x64xi32, #shared>, !ttg.memdesc<128x64xi32, #shared, #smem, mutable, 256x64>
     tt.return
   }
-  tt.func @tma_reduce_rejects_remote_source(%desc: !tt.tensordesc<128x64xi32, #shared>, %x: i32) {
-    %parent = ttg.local_alloc : () -> !ttg.memdesc<256x64xi32, #shared, #smem, mutable>
-    %view = ttg.memdesc_subslice %parent [128, 0] : !ttg.memdesc<256x64xi32, #shared, #smem, mutable> -> !ttg.memdesc<128x64xi32, #shared, #smem, mutable, 256x64>
+  tt.func @tma_reduce_rejects_remote_source(%desc: !tt.tensordesc<128x64xi32, #shared>, %view: !ttg.memdesc<128x64xi32, #shared, #smem, mutable, 256x64>, %x: i32) {
     // expected-error @below {{source subview may have an origin in another CTA}}
     ttng.async_tma_reduce add, %desc[%x, %x] %view : !tt.tensordesc<128x64xi32, #shared>, !ttg.memdesc<128x64xi32, #shared, #smem, mutable, 256x64>
     tt.return

--- a/test/TritonNvidiaGPU/invalid.mlir
+++ b/test/TritonNvidiaGPU/invalid.mlir
@@ -1651,6 +1651,7 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.targ
 // -----
 
 #shared = #ttg.nvmma_shared<{swizzlingByteWidth = 128, transposed = false, elementBitWidth = 32, CGALayout = [[1, 0]]}>
+#blocked = #ttg.blocked<{sizePerThread = [4, 1], threadsPerWarp = [1, 32], warpsPerCTA = [4, 1], order = [0, 1], CGALayout = [[1, 0]]}>
 #smem = #ttg.shared_memory
 module attributes {"ttg.num-ctas" = 2 : i32, "ttg.num-warps" = 4 : i32, ttg.target = "cuda:90", "ttg.threads-per-warp" = 32 : i32} {
   tt.func @tma_store_rejects_remote_source(%desc: !tt.tensordesc<128x64xi32, #shared>, %view: !ttg.memdesc<128x64xi32, #shared, #smem, mutable, 256x64>, %x: i32) {
@@ -1661,6 +1662,12 @@ module attributes {"ttg.num-ctas" = 2 : i32, "ttg.num-warps" = 4 : i32, ttg.targ
   tt.func @tma_reduce_rejects_remote_source(%desc: !tt.tensordesc<128x64xi32, #shared>, %view: !ttg.memdesc<128x64xi32, #shared, #smem, mutable, 256x64>, %x: i32) {
     // expected-error @below {{source subview may have an origin in another CTA}}
     ttng.async_tma_reduce add, %desc[%x, %x] %view : !tt.tensordesc<128x64xi32, #shared>, !ttg.memdesc<128x64xi32, #shared, #smem, mutable, 256x64>
+    tt.return
+  }
+
+  tt.func @tma_scatter_rejects_remote_source(%desc: !tt.tensordesc<1x64xi32, #shared>, %view: !ttg.memdesc<128x64xi32, #shared, #smem, mutable, 256x64>, %indices: tensor<128xi32, #ttg.slice<{dim = 1, parent = #blocked}>>, %y: i32) {
+    // expected-error @below {{source subview may have an origin in another CTA}}
+    ttng.async_tma_scatter %desc[%indices, %y] %view : !tt.tensordesc<1x64xi32, #shared>, tensor<128xi32, #ttg.slice<{dim = 1, parent = #blocked}>>, i32, !ttg.memdesc<128x64xi32, #shared, #smem, mutable, 256x64>
     tt.return
   }
 }

--- a/test/TritonNvidiaGPU/invalid.mlir
+++ b/test/TritonNvidiaGPU/invalid.mlir
@@ -1660,13 +1660,6 @@ module attributes {"ttg.num-ctas" = 2 : i32, "ttg.num-warps" = 4 : i32, ttg.targ
     ttng.async_tma_copy_local_to_global %desc[%x, %x] %view : !tt.tensordesc<128x64xi32, #shared>, !ttg.memdesc<128x64xi32, #shared, #smem, mutable, 256x64>
     tt.return
   }
-}
-
-// -----
-
-#shared = #ttg.nvmma_shared<{swizzlingByteWidth = 128, transposed = false, elementBitWidth = 32, CGALayout = [[1, 0]]}>
-#smem = #ttg.shared_memory
-module attributes {"ttg.num-ctas" = 2 : i32, "ttg.num-warps" = 4 : i32, ttg.target = "cuda:90", "ttg.threads-per-warp" = 32 : i32} {
   tt.func @tma_reduce_rejects_remote_source(%desc: !tt.tensordesc<128x64xi32, #shared>, %x: i32) {
     %parent = ttg.local_alloc : () -> !ttg.memdesc<256x64xi32, #shared, #smem, mutable>
     %view = ttg.memdesc_subslice %parent [128, 0] : !ttg.memdesc<256x64xi32, #shared, #smem, mutable> -> !ttg.memdesc<128x64xi32, #shared, #smem, mutable, 256x64>

--- a/test/TritonNvidiaGPU/invalid.mlir
+++ b/test/TritonNvidiaGPU/invalid.mlir
@@ -1647,3 +1647,31 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.targ
     tt.return
   }
 }
+
+// -----
+
+#shared = #ttg.nvmma_shared<{swizzlingByteWidth = 128, transposed = false, elementBitWidth = 32, CGALayout = [[1, 0]]}>
+#smem = #ttg.shared_memory
+module attributes {"ttg.num-ctas" = 2 : i32, "ttg.num-warps" = 4 : i32, ttg.target = "cuda:90", "ttg.threads-per-warp" = 32 : i32} {
+  tt.func @tma_store_rejects_remote_source(%desc: !tt.tensordesc<128x64xi32, #shared>, %x: i32) {
+    %parent = ttg.local_alloc : () -> !ttg.memdesc<256x64xi32, #shared, #smem, mutable>
+    %view = ttg.memdesc_subslice %parent [128, 0] : !ttg.memdesc<256x64xi32, #shared, #smem, mutable> -> !ttg.memdesc<128x64xi32, #shared, #smem, mutable, 256x64>
+    // expected-error @below {{source subview may have an origin in another CTA}}
+    ttng.async_tma_copy_local_to_global %desc[%x, %x] %view : !tt.tensordesc<128x64xi32, #shared>, !ttg.memdesc<128x64xi32, #shared, #smem, mutable, 256x64>
+    tt.return
+  }
+}
+
+// -----
+
+#shared = #ttg.nvmma_shared<{swizzlingByteWidth = 128, transposed = false, elementBitWidth = 32, CGALayout = [[1, 0]]}>
+#smem = #ttg.shared_memory
+module attributes {"ttg.num-ctas" = 2 : i32, "ttg.num-warps" = 4 : i32, ttg.target = "cuda:90", "ttg.threads-per-warp" = 32 : i32} {
+  tt.func @tma_reduce_rejects_remote_source(%desc: !tt.tensordesc<128x64xi32, #shared>, %x: i32) {
+    %parent = ttg.local_alloc : () -> !ttg.memdesc<256x64xi32, #shared, #smem, mutable>
+    %view = ttg.memdesc_subslice %parent [128, 0] : !ttg.memdesc<256x64xi32, #shared, #smem, mutable> -> !ttg.memdesc<128x64xi32, #shared, #smem, mutable, 256x64>
+    // expected-error @below {{source subview may have an origin in another CTA}}
+    ttng.async_tma_reduce add, %desc[%x, %x] %view : !tt.tensordesc<128x64xi32, #shared>, !ttg.memdesc<128x64xi32, #shared, #smem, mutable, 256x64>
+    tt.return
+  }
+}

--- a/third_party/nvidia/lib/TritonNVIDIAGPUToLLVM/LoadStoreOpToLLVM.cpp
+++ b/third_party/nvidia/lib/TritonNVIDIAGPUToLLVM/LoadStoreOpToLLVM.cpp
@@ -1157,10 +1157,6 @@ struct AsyncTMACopyGlobalToLocalOpConversion
 
     uint32_t barrierMask =
         toLinearLayout(barrierTy).getFreeVariableMasks().lookup(kBlock);
-    if (affineBlockMask && ((barrierMask | affineBlockMask) & ~uint64_t{1}))
-      return op.emitError(
-          "TMA destination and completion barrier must belong to the same "
-          "CTA or a CTA pair");
     // Use a cross-CTA mbarrier pointer when the barrier mask is set.
     bool crossCTABarrier = barrierMask != 0;
     if (crossCTABarrier) {

--- a/third_party/nvidia/lib/TritonNVIDIAGPUToLLVM/LoadStoreOpToLLVM.cpp
+++ b/third_party/nvidia/lib/TritonNVIDIAGPUToLLVM/LoadStoreOpToLLVM.cpp
@@ -1106,10 +1106,6 @@ struct AsyncTMACopyGlobalToLocalOpConversion
         typeConverter->convertType(barrierTy.getElementType()), rewriter);
     auto dstMemObj = LLVM::getSharedMemoryObjectFromStruct(
         loc, adaptor.getResult(), llvmElemTy, rewriter);
-    auto [affineOffset, affineBlockOffset] =
-        dstMemObj.getShmemOffsetAndBlock(loc, rewriter, dstTy);
-    Value dstBase = b.gep(dstMemObj.getBase().getType(), llvmElemTy,
-                          dstMemObj.getBase(), affineOffset);
     uint64_t affineBlockMask =
         LLVM::SharedMemoryObject::getMaskSpanOffsetsAndBlocks(dstTy).second;
 
@@ -1188,14 +1184,13 @@ struct AsyncTMACopyGlobalToLocalOpConversion
       Value boxPred =
           b.and_(pred, b.icmp_ult(id, b.i32_val(numWarpsToCopy * warpSize)));
       ::mlir::triton::PTXBuilder ptxBuilderTMA;
-      Type elemPtrTy = ptr_ty(rewriter.getContext(), 3);
       Value copyIdxVal = b.add(warpID, b.i32_val(copyIdx));
       auto sharedAddress = applyLinearLayout(
           loc, rewriter, msgToShared, {{kMsg, copyIdxVal}, {kBlock, ctaId}});
-      Value shMemOffset = sharedAddress[0].second;
-      Value shMemPtr = b.gep(elemPtrTy, llvmElemTy, dstBase, shMemOffset);
+      auto [shMemPtr, targetCTA] = materializeLocalAddrs(
+          loc, dstTy, dstMemObj, llvmElemTy,
+          {{sharedAddress[0].second, sharedAddress[1].second}}, rewriter)[0];
       if (affineBlockMask) {
-        Value targetCTA = b.xor_(sharedAddress[1].second, affineBlockOffset);
         shMemPtr = NVVM::MapaOp::create(rewriter, loc,
                                         ptr_ty(rewriter.getContext(), 7),
                                         shMemPtr, targetCTA);
@@ -1466,14 +1461,9 @@ static LogicalResult iterateGatherScatterIndices(
   if (enc.getFp4Padded())
     yOffsetValue = b.mul(yOffsetValue, b.i32_val(2));
   Type llvmElemTy = typeConverter.convertType(smemType.getElementType());
-  Type elemPtrTy = ptr_ty(ctx, /*addrspace=*/3);
   auto smemObj = LLVM::getSharedMemoryObjectFromStruct(loc, smemObjValue,
                                                        llvmElemTy, rewriter);
-  auto [affineOffset, affineBlockOffset] =
-      smemObj.getShmemOffsetAndBlock(loc, rewriter, smemType);
-  Value smemBase =
-      b.gep(elemPtrTy, llvmElemTy, smemObj.getBase(), affineOffset);
-  bool crossCTADestination =
+  bool crossCTA =
       LLVM::SharedMemoryObject::getMaskSpanOffsetsAndBlocks(smemType).second;
 
   unsigned threadsPerWarp = xCoordsLayout.getInDimSize(kLane);
@@ -1543,10 +1533,10 @@ static LogicalResult iterateGatherScatterIndices(
                                        {kMsg, msgIdVal}});
       assert(result.size() == 2 && result.front().first == "offset" &&
              result.back().first == "block");
-      Value shMemOffset = result.front().second;
-      Value shMemPtr = b.gep(elemPtrTy, llvmElemTy, smemBase, shMemOffset);
-      if (crossCTADestination) {
-        Value targetCTA = b.xor_(result.back().second, affineBlockOffset);
+      auto [shMemPtr, targetCTA] = materializeLocalAddrs(
+          loc, smemType, smemObj, llvmElemTy,
+          {{result.front().second, result.back().second}}, rewriter)[0];
+      if (crossCTA) {
         shMemPtr = NVVM::MapaOp::create(rewriter, loc, ptr_ty(ctx, 7), shMemPtr,
                                         targetCTA);
       }
@@ -1602,10 +1592,9 @@ LogicalResult AsyncTMAGatherOpConversion::matchAndRewrite(
     barrierPtr =
         LLVM::NVIDIA::getLeaderAddress(loc, rewriter, barrierPtr, barrierTy);
   }
-  bool crossCTADestination =
-      LLVM::SharedMemoryObject::getMaskSpanOffsetsAndBlocks(
-          op.getResult().getType())
-          .second;
+  bool crossCTA = LLVM::SharedMemoryObject::getMaskSpanOffsetsAndBlocks(
+                      op.getResult().getType())
+                      .second;
 
   std::string ctaGroup;
   if (getModuleTwoCTAs(op)) {
@@ -1615,7 +1604,7 @@ LogicalResult AsyncTMAGatherOpConversion::matchAndRewrite(
         getCGALayout(barrierTy.getEncoding()) == oneCTACGALayout;
     ctaGroup = oneCTABarrier ? ".cta_group::1" : ".cta_group::2";
   }
-  if (crossCTADestination)
+  if (crossCTA)
     ctaGroup = ".cta_group::2";
 
   // Callback to generate the gather4 instruction.
@@ -1624,8 +1613,7 @@ LogicalResult AsyncTMAGatherOpConversion::matchAndRewrite(
     std::string tmaInst = "@$0 cp.async.bulk.tensor.2d.tile::gather4";
     tmaInst += ctaGroup;
     tmaInst += ".shared::";
-    tmaInst += (crossCTABarrier || multicast || crossCTADestination) ? "cluster"
-                                                                     : "cta";
+    tmaInst += (crossCTABarrier || multicast || crossCTA) ? "cluster" : "cta";
     tmaInst += ".global.mbarrier::complete_tx::bytes";
     if (multicast)
       tmaInst += ".multicast::cluster";

--- a/third_party/nvidia/lib/TritonNVIDIAGPUToLLVM/LoadStoreOpToLLVM.cpp
+++ b/third_party/nvidia/lib/TritonNVIDIAGPUToLLVM/LoadStoreOpToLLVM.cpp
@@ -1413,11 +1413,10 @@ static LinearLayout getUnswizzledLayout(triton::gpu::MemDescType type) {
     assert(isa<ttg::SwizzledSharedEncodingAttr>(type.getEncoding()));
     return ttg::toLinearLayout(type);
   }
-  assert(type.getShape() == type.getAllocShape().take_back(type.getRank()));
   // TMA gather/scatter only supports tiled mode
   return ttg::nvmmaSharedToLinearLayout(
-      type.getShape(), cast<NVMMASharedEncodingAttr>(type.getEncoding()),
-      ttg::TMAMode::Tiled, /*disableSwizzle=*/true);
+      ttg::dropPipeliningDim(type.getAllocShape(), type.getEncoding()),
+      mmaEncoding, ttg::TMAMode::Tiled, /*disableSwizzle=*/true);
 }
 
 // This function is shared between the TMA gather and scatter lowerings. It
@@ -1458,11 +1457,7 @@ static LogicalResult iterateGatherScatterIndices(
           "x offsets are not grouped by 4 contiguous elements");
   }
 
-  // TMA expects the memdesc shape to match the alloc shape.
   triton::gpu::MemDescType smemType = smem.getType();
-  ArrayRef<int64_t> allocShape = smemType.getAllocShape();
-  if (allocShape.size() < 2 || smemType.getShape() != allocShape.take_back(2))
-    return op->emitError("memdesc shape must match alloc shape");
   // `NVMMASharedEncodingAttr` means the core matrix tiles are placed next to
   // each other in shared memory, which lines up with how `gather4` loads data.
   auto enc = dyn_cast<NVMMASharedEncodingAttr>(smemType.getEncoding());
@@ -1474,7 +1469,12 @@ static LogicalResult iterateGatherScatterIndices(
   Type elemPtrTy = ptr_ty(ctx, /*addrspace=*/3);
   auto smemObj = LLVM::getSharedMemoryObjectFromStruct(loc, smemObjValue,
                                                        llvmElemTy, rewriter);
-  Value smemBase = smemObj.getShmemAffineBase(loc, rewriter, smemType);
+  auto [affineOffset, affineBlockOffset] =
+      smemObj.getShmemOffsetAndBlock(loc, rewriter, smemType);
+  Value smemBase =
+      b.gep(elemPtrTy, llvmElemTy, smemObj.getBase(), affineOffset);
+  bool crossCTADestination =
+      LLVM::SharedMemoryObject::getMaskSpanOffsetsAndBlocks(smemType).second;
 
   unsigned threadsPerWarp = xCoordsLayout.getInDimSize(kLane);
 
@@ -1503,7 +1503,8 @@ static LogicalResult iterateGatherScatterIndices(
   // swizzle tile size, e.g. [4, 32] vs. [8, 32], then, for example, the address
   // of the 0th element of row 4 will not be at the start of the segment.
   LinearLayout sharedLayout = getUnswizzledLayout(smemType);
-  LinearLayout msgToShared = msgLayout.invertAndCompose(sharedLayout);
+  LinearLayout msgToShared =
+      invertAndComposeBlockLocal(sharedLayout, msgLayout);
 
   // If there are too few rows, warps will have redundant data.
   auto freeVars = xCoordsLayout.getFreeVariableMasks();
@@ -1543,9 +1544,12 @@ static LogicalResult iterateGatherScatterIndices(
       assert(result.size() == 2 && result.front().first == "offset" &&
              result.back().first == "block");
       Value shMemOffset = result.front().second;
-      // Because we checked that the memdesc's allocshape and shape match, we
-      // can ignore the strides and directly index into the shmem object.
       Value shMemPtr = b.gep(elemPtrTy, llvmElemTy, smemBase, shMemOffset);
+      if (crossCTADestination) {
+        Value targetCTA = b.xor_(result.back().second, affineBlockOffset);
+        shMemPtr = NVVM::MapaOp::create(rewriter, loc, ptr_ty(ctx, 7), shMemPtr,
+                                        targetCTA);
+      }
       Value yOffset = b.add(yOffsetValue, b.i32_val(msgId * msgSize));
 
       callback(pred, shMemPtr, yOffset, ArrayRef(xOffsets).slice(regId, 4));
@@ -1598,6 +1602,10 @@ LogicalResult AsyncTMAGatherOpConversion::matchAndRewrite(
     barrierPtr =
         LLVM::NVIDIA::getLeaderAddress(loc, rewriter, barrierPtr, barrierTy);
   }
+  bool crossCTADestination =
+      LLVM::SharedMemoryObject::getMaskSpanOffsetsAndBlocks(
+          op.getResult().getType())
+          .second;
 
   std::string ctaGroup;
   if (getModuleTwoCTAs(op)) {
@@ -1607,6 +1615,8 @@ LogicalResult AsyncTMAGatherOpConversion::matchAndRewrite(
         getCGALayout(barrierTy.getEncoding()) == oneCTACGALayout;
     ctaGroup = oneCTABarrier ? ".cta_group::1" : ".cta_group::2";
   }
+  if (crossCTADestination)
+    ctaGroup = ".cta_group::2";
 
   // Callback to generate the gather4 instruction.
   auto callback = [&](Value pred, Value shMemPtr, Value yOffset,
@@ -1614,7 +1624,8 @@ LogicalResult AsyncTMAGatherOpConversion::matchAndRewrite(
     std::string tmaInst = "@$0 cp.async.bulk.tensor.2d.tile::gather4";
     tmaInst += ctaGroup;
     tmaInst += ".shared::";
-    tmaInst += (crossCTABarrier || multicast) ? "cluster" : "cta";
+    tmaInst += (crossCTABarrier || multicast || crossCTADestination) ? "cluster"
+                                                                     : "cta";
     tmaInst += ".global.mbarrier::complete_tx::bytes";
     if (multicast)
       tmaInst += ".multicast::cluster";

--- a/third_party/nvidia/lib/TritonNVIDIAGPUToLLVM/LoadStoreOpToLLVM.cpp
+++ b/third_party/nvidia/lib/TritonNVIDIAGPUToLLVM/LoadStoreOpToLLVM.cpp
@@ -1077,11 +1077,7 @@ getMsgToUnpackedOffsetLayout(const LinearLayout &packedLayout,
 struct AsyncTMACopyGlobalToLocalOpConversion
     : public ConvertOpToLLVMPattern<
           triton::nvidia_gpu::AsyncTMACopyGlobalToLocalOp> {
-  AsyncTMACopyGlobalToLocalOpConversion(const LLVMTypeConverter &converter,
-                                        int computeCapability,
-                                        PatternBenefit benefit)
-      : ConvertOpToLLVMPattern(converter, benefit),
-        computeCapability(computeCapability) {}
+  using ConvertOpToLLVMPattern::ConvertOpToLLVMPattern;
 
   LogicalResult
   matchAndRewrite(triton::nvidia_gpu::AsyncTMACopyGlobalToLocalOp op,
@@ -1165,10 +1161,6 @@ struct AsyncTMACopyGlobalToLocalOpConversion
       return op.emitError(
           "TMA destination and completion barrier must belong to the same "
           "CTA or a CTA pair");
-    if (affineBlockMask && computeCapability < 100)
-      return op.emitError(
-          "TMA destination and completion barrier must belong to the same "
-          "CTA before Blackwell");
     // Use a cross-CTA mbarrier pointer when the barrier mask is set.
     bool crossCTABarrier = barrierMask != 0;
     if (crossCTABarrier) {
@@ -1275,7 +1267,6 @@ struct AsyncTMACopyGlobalToLocalOpConversion
     rewriter.eraseOp(op);
     return success();
   }
-  int computeCapability;
 };
 
 LogicalResult convertTMAStoreLikeOp(Operation *op,
@@ -1816,9 +1807,8 @@ void mlir::triton::NVIDIA::populateLoadStoreOpToLLVMPatterns(
       typeConverter, targetInfo, computeCapability, axisInfoAnalysis, benefit);
   patterns.add<AsyncCommitGroupOpConversion, AsyncWaitOpConversion,
                AsyncCopyMbarrierArriveOpConversion>(typeConverter, benefit);
-  patterns.add<AsyncTMACopyGlobalToLocalOpConversion>(
-      typeConverter, computeCapability, benefit);
-  patterns.add<AsyncTMACopyLocalToGlobalOpConversion,
+  patterns.add<AsyncTMACopyGlobalToLocalOpConversion,
+               AsyncTMACopyLocalToGlobalOpConversion,
                AsyncTMAReduceOpConversion, AsyncTMAGatherOpConversion,
                AsyncTMAScatterOpConversion, TMAStoreWaitOpConversion>(
       typeConverter, benefit);

--- a/third_party/nvidia/lib/TritonNVIDIAGPUToLLVM/LoadStoreOpToLLVM.cpp
+++ b/third_party/nvidia/lib/TritonNVIDIAGPUToLLVM/LoadStoreOpToLLVM.cpp
@@ -1142,8 +1142,6 @@ struct AsyncTMACopyGlobalToLocalOpConversion
     auto ctx = op.getContext();
     auto kMsg = str_attr("msg");
     auto kBlock = str_attr("block");
-    bool crossCTAAccess =
-        affineBlockMask || !msgToShared.isIdentityOnOutDim(kBlock);
     const auto numCopies = msgToOffset.getInDimSize(kMsg);
     auto ctaId = nvgpu::ClusterCTAIdOp::create(rewriter, loc);
     // We multicast if the flag is on and the block layout has broadcasting
@@ -1163,17 +1161,11 @@ struct AsyncTMACopyGlobalToLocalOpConversion
 
     uint32_t barrierMask =
         toLinearLayout(barrierTy).getFreeVariableMasks().lookup(kBlock);
-    uint64_t completionMask = barrierMask | affineBlockMask;
-    unsigned blockOutput = msgToShared.getOutDimIndex(kBlock);
-    for (const auto &[dim, bases] : msgToShared.getBases())
-      for (auto [index, basis] : llvm::enumerate(bases))
-        completionMask |=
-            basis[blockOutput] ^ (dim == kBlock ? uint64_t{1} << index : 0);
-    if (crossCTAAccess && (completionMask & ~uint64_t{1}))
+    if (affineBlockMask && ((barrierMask | affineBlockMask) & ~uint64_t{1}))
       return op.emitError(
           "TMA destination and completion barrier must belong to the same "
           "CTA or a CTA pair");
-    if (crossCTAAccess && completionMask && computeCapability < 100)
+    if (affineBlockMask && computeCapability < 100)
       return op.emitError(
           "TMA destination and completion barrier must belong to the same "
           "CTA before Blackwell");
@@ -1185,7 +1177,7 @@ struct AsyncTMACopyGlobalToLocalOpConversion
     }
 
     std::string ctaGroup;
-    if (crossCTAAccess && completionMask) {
+    if (affineBlockMask) {
       ctaGroup = "cta_group::2.";
     } else if (getModuleTwoCTAs(op)) {
       auto oneCTACGALayout = ttg::CGAEncodingAttr::get1DLayout(
@@ -1214,7 +1206,7 @@ struct AsyncTMACopyGlobalToLocalOpConversion
           loc, rewriter, msgToShared, {{kMsg, copyIdxVal}, {kBlock, ctaId}});
       Value shMemOffset = sharedAddress[0].second;
       Value shMemPtr = b.gep(elemPtrTy, llvmElemTy, dstBase, shMemOffset);
-      if (crossCTAAccess) {
+      if (affineBlockMask) {
         Value targetCTA = b.xor_(sharedAddress[1].second, affineBlockOffset);
         shMemPtr = NVVM::MapaOp::create(rewriter, loc,
                                         ptr_ty(rewriter.getContext(), 7),
@@ -1227,8 +1219,8 @@ struct AsyncTMACopyGlobalToLocalOpConversion
       std::string tmaInst =
           "@$0 cp.async.bulk.tensor." + std::to_string(rank) + "d." + ctaGroup +
           "shared::" +
-          ((crossCTABarrier || multicast || crossCTAAccess) ? "cluster"
-                                                            : "cta") +
+          ((crossCTABarrier || multicast || affineBlockMask) ? "cluster"
+                                                             : "cta") +
           ".global" + (isIm2Col ? ".im2col" : "") +
           ".mbarrier::complete_tx::bytes";
       if (multicast)

--- a/third_party/nvidia/lib/TritonNVIDIAGPUToLLVM/LoadStoreOpToLLVM.cpp
+++ b/third_party/nvidia/lib/TritonNVIDIAGPUToLLVM/LoadStoreOpToLLVM.cpp
@@ -1077,7 +1077,11 @@ getMsgToUnpackedOffsetLayout(const LinearLayout &packedLayout,
 struct AsyncTMACopyGlobalToLocalOpConversion
     : public ConvertOpToLLVMPattern<
           triton::nvidia_gpu::AsyncTMACopyGlobalToLocalOp> {
-  using ConvertOpToLLVMPattern::ConvertOpToLLVMPattern;
+  AsyncTMACopyGlobalToLocalOpConversion(const LLVMTypeConverter &converter,
+                                        int computeCapability,
+                                        PatternBenefit benefit)
+      : ConvertOpToLLVMPattern(converter, benefit),
+        computeCapability(computeCapability) {}
 
   LogicalResult
   matchAndRewrite(triton::nvidia_gpu::AsyncTMACopyGlobalToLocalOp op,
@@ -1106,7 +1110,12 @@ struct AsyncTMACopyGlobalToLocalOpConversion
         typeConverter->convertType(barrierTy.getElementType()), rewriter);
     auto dstMemObj = LLVM::getSharedMemoryObjectFromStruct(
         loc, adaptor.getResult(), llvmElemTy, rewriter);
-    Value dstBase = dstMemObj.getShmemAffineBase(loc, rewriter, dstTy);
+    auto [affineOffset, affineBlockOffset] =
+        dstMemObj.getShmemOffsetAndBlock(loc, rewriter, dstTy);
+    Value dstBase = b.gep(dstMemObj.getBase().getType(), llvmElemTy,
+                          dstMemObj.getBase(), affineOffset);
+    uint64_t affineBlockMask =
+        LLVM::SharedMemoryObject::getMaskSpanOffsetsAndBlocks(dstTy).second;
 
     auto voidTy = void_ty(op->getContext());
     auto id = getThreadId(rewriter, loc);
@@ -1126,12 +1135,15 @@ struct AsyncTMACopyGlobalToLocalOpConversion
 
     auto msgToPackedOffset = getMsgToPackedOffsetLayout(smemTy, tmaMode);
     auto smemLayout = ttg::toLinearLayout(smemTy);
-    auto msgToShared = msgToPackedOffset.invertAndCompose(smemLayout);
+    auto msgToShared =
+        invertAndComposeBlockLocal(smemLayout, msgToPackedOffset);
     auto msgToOffset = getMsgToUnpackedOffsetLayout(msgToPackedOffset, smemTy);
 
     auto ctx = op.getContext();
     auto kMsg = str_attr("msg");
     auto kBlock = str_attr("block");
+    bool crossCTAAccess =
+        affineBlockMask || !msgToShared.isIdentityOnOutDim(kBlock);
     const auto numCopies = msgToOffset.getInDimSize(kMsg);
     auto ctaId = nvgpu::ClusterCTAIdOp::create(rewriter, loc);
     // We multicast if the flag is on and the block layout has broadcasting
@@ -1151,6 +1163,20 @@ struct AsyncTMACopyGlobalToLocalOpConversion
 
     uint32_t barrierMask =
         toLinearLayout(barrierTy).getFreeVariableMasks().lookup(kBlock);
+    uint64_t completionMask = barrierMask | affineBlockMask;
+    unsigned blockOutput = msgToShared.getOutDimIndex(kBlock);
+    for (const auto &[dim, bases] : msgToShared.getBases())
+      for (auto [index, basis] : llvm::enumerate(bases))
+        completionMask |=
+            basis[blockOutput] ^ (dim == kBlock ? uint64_t{1} << index : 0);
+    if (crossCTAAccess && (completionMask & ~uint64_t{1}))
+      return op.emitError(
+          "TMA destination and completion barrier must belong to the same "
+          "CTA or a CTA pair");
+    if (crossCTAAccess && completionMask && computeCapability < 100)
+      return op.emitError(
+          "TMA destination and completion barrier must belong to the same "
+          "CTA before Blackwell");
     // Use a cross-CTA mbarrier pointer when the barrier mask is set.
     bool crossCTABarrier = barrierMask != 0;
     if (crossCTABarrier) {
@@ -1159,7 +1185,9 @@ struct AsyncTMACopyGlobalToLocalOpConversion
     }
 
     std::string ctaGroup;
-    if (getModuleTwoCTAs(op)) {
+    if (crossCTAAccess && completionMask) {
+      ctaGroup = "cta_group::2.";
+    } else if (getModuleTwoCTAs(op)) {
       auto oneCTACGALayout = ttg::CGAEncodingAttr::get1DLayout(
           op->getContext(), ttg::lookupNumCTAs(op));
       bool oneCTABarrier =
@@ -1182,18 +1210,25 @@ struct AsyncTMACopyGlobalToLocalOpConversion
       ::mlir::triton::PTXBuilder ptxBuilderTMA;
       Type elemPtrTy = ptr_ty(rewriter.getContext(), 3);
       Value copyIdxVal = b.add(warpID, b.i32_val(copyIdx));
-      Value shMemOffset =
-          applyLinearLayout(loc, rewriter, msgToShared,
-                            {{kMsg, copyIdxVal}, {kBlock, ctaId}})[0]
-              .second;
+      auto sharedAddress = applyLinearLayout(
+          loc, rewriter, msgToShared, {{kMsg, copyIdxVal}, {kBlock, ctaId}});
+      Value shMemOffset = sharedAddress[0].second;
       Value shMemPtr = b.gep(elemPtrTy, llvmElemTy, dstBase, shMemOffset);
+      if (crossCTAAccess) {
+        Value targetCTA = b.xor_(sharedAddress[1].second, affineBlockOffset);
+        shMemPtr = NVVM::MapaOp::create(rewriter, loc,
+                                        ptr_ty(rewriter.getContext(), 7),
+                                        shMemPtr, targetCTA);
+      }
       SmallVector<PTXBuilder::Operand *> operands = {
           ptxBuilderTMA.newOperand(boxPred, "b"),
           ptxBuilderTMA.newOperand(shMemPtr, "r"),
           ptxBuilderTMA.newOperand(adaptor.getDesc(), "l")};
       std::string tmaInst =
           "@$0 cp.async.bulk.tensor." + std::to_string(rank) + "d." + ctaGroup +
-          "shared::" + ((crossCTABarrier || multicast) ? "cluster" : "cta") +
+          "shared::" +
+          ((crossCTABarrier || multicast || crossCTAAccess) ? "cluster"
+                                                            : "cta") +
           ".global" + (isIm2Col ? ".im2col" : "") +
           ".mbarrier::complete_tx::bytes";
       if (multicast)
@@ -1248,6 +1283,9 @@ struct AsyncTMACopyGlobalToLocalOpConversion
     rewriter.eraseOp(op);
     return success();
   }
+
+private:
+  int computeCapability;
 };
 
 LogicalResult convertTMAStoreLikeOp(Operation *op,
@@ -1788,8 +1826,9 @@ void mlir::triton::NVIDIA::populateLoadStoreOpToLLVMPatterns(
       typeConverter, targetInfo, computeCapability, axisInfoAnalysis, benefit);
   patterns.add<AsyncCommitGroupOpConversion, AsyncWaitOpConversion,
                AsyncCopyMbarrierArriveOpConversion>(typeConverter, benefit);
-  patterns.add<AsyncTMACopyGlobalToLocalOpConversion,
-               AsyncTMACopyLocalToGlobalOpConversion,
+  patterns.add<AsyncTMACopyGlobalToLocalOpConversion>(
+      typeConverter, computeCapability, benefit);
+  patterns.add<AsyncTMACopyLocalToGlobalOpConversion,
                AsyncTMAReduceOpConversion, AsyncTMAGatherOpConversion,
                AsyncTMAScatterOpConversion, TMAStoreWaitOpConversion>(
       typeConverter, benefit);

--- a/third_party/nvidia/lib/TritonNVIDIAGPUToLLVM/LoadStoreOpToLLVM.cpp
+++ b/third_party/nvidia/lib/TritonNVIDIAGPUToLLVM/LoadStoreOpToLLVM.cpp
@@ -1177,15 +1177,15 @@ struct AsyncTMACopyGlobalToLocalOpConversion
     }
 
     std::string ctaGroup;
-    if (affineBlockMask) {
-      ctaGroup = "cta_group::2.";
-    } else if (getModuleTwoCTAs(op)) {
+    if (getModuleTwoCTAs(op)) {
       auto oneCTACGALayout = ttg::CGAEncodingAttr::get1DLayout(
           op->getContext(), ttg::lookupNumCTAs(op));
       bool oneCTABarrier =
           getCGALayout(barrierTy.getEncoding()) == oneCTACGALayout;
       ctaGroup = oneCTABarrier ? "cta_group::1." : "cta_group::2.";
     }
+    if (affineBlockMask)
+      ctaGroup = "cta_group::2.";
 
     // The bounding box inner dimension must be less than or equal to the
     // swizzle size.
@@ -1275,8 +1275,6 @@ struct AsyncTMACopyGlobalToLocalOpConversion
     rewriter.eraseOp(op);
     return success();
   }
-
-private:
   int computeCapability;
 };
 


### PR DESCRIPTION
PR description written by Codex

TMA loads and gathers can target the wrong CTA for shared-memory subviews, while stores, reductions, and scatters can illegally read remote shared memory. Gather and scatter also reject valid CTA-local subviews.

Preserve allocation-based shared-memory addresses and CTA ownership when lowering TMA loads and gathers, support local gather/scatter subviews, and reject remote store, reduction, and scatter sources.

Validated with 285 compiler lit tests, 113 C++ layout tests, 192 Blackwell TMA GPU tests, 240 frontend tests, and gather/scatter sanitizer coverage.

## Stack
Merge bottom-up:
- [ ] #11064 (this PR)
