### PR TITLE
[CI] Measure NVIDIA test time breakdown

### DIFF
--- a/.github/workflows/integration-tests-nvidia.yml
+++ b/.github/workflows/integration-tests-nvidia.yml
@@ -11,7 +11,7 @@ jobs:
   integration-tests-nvidia:
     name: integration-tests-nvidia (${{ matrix.config.name }})
     runs-on: ${{ matrix.config.runs_on }}
-    timeout-minutes: 60
+    timeout-minutes: 120
     # Let A100 and H100 continue even if GB200 fails, as it's a bit flaky
     continue-on-error: ${{ startsWith(matrix.config.runner_type, 'nvidia-gb200') }}
     strategy:
@@ -89,9 +89,25 @@ jobs:
       - name: Run lit tests
         run: make test-lit
       - name: Run triton tests
+        env:
+          PYTEST_PLUGINS: triton._ci_timing
+          TRITON_CI_TIMING_DIR: ${{ startsWith(matrix.config.runner_type, 'nvidia-gb200') && '/tmp/triton-ci-timing' || '' }}
+          TRITON_CI_TIMING_LABEL: triton-tests
         run: make NUM_PROCS=24 test-unit
       - name: Run gluon tests
+        env:
+          PYTEST_PLUGINS: triton._ci_timing
+          TRITON_CI_TIMING_DIR: ${{ startsWith(matrix.config.runner_type, 'nvidia-gb200') && '/tmp/triton-ci-timing' || '' }}
+          TRITON_CI_TIMING_LABEL: gluon-tests
         run: make NUM_PROCS=24 test-gluon
+      - name: Upload GB200 timing
+        if: ${{ always() && startsWith(matrix.config.runner_type, 'nvidia-gb200') }}
+        uses: actions/upload-artifact@v4
+        with:
+          name: gb200-ci-timing-${{ github.run_id }}-${{ github.run_attempt }}
+          path: /tmp/triton-ci-timing
+          if-no-files-found: error
+          retention-days: 3
       - name: Run gsan tests
         run: make NUM_PROCS=24 test-gsan
       - name: Run interpreter tests

--- a/.github/workflows/integration-tests-nvidia.yml
+++ b/.github/workflows/integration-tests-nvidia.yml
@@ -9,14 +9,16 @@ on:
 
 jobs:
   integration-tests-nvidia:
-    name: integration-tests-nvidia (${{ matrix.config.name }})
+    name: integration-tests-nvidia (${{ matrix.config.name }}, timing-${{ matrix.timing_mode }})
     runs-on: ${{ matrix.config.runs_on }}
     timeout-minutes: 120
-    # Let A100 and H100 continue even if GB200 fails, as it's a bit flaky
+    # GB200 is allowed to fail because it is a bit flaky.
     continue-on-error: ${{ startsWith(matrix.config.runner_type, 'nvidia-gb200') }}
     strategy:
+      fail-fast: false
       matrix:
         config: ${{ fromJson(inputs.matrix) }}
+        timing_mode: [compile, gpu]
     env:
       RUNNER_TYPE: ${{ matrix.config.runner_type }}
       TRITON_BUILD_WITH_CCACHE: "true"
@@ -87,44 +89,67 @@ jobs:
       - name: CCache Stats
         run: ccache --print-stats
       - name: Run lit tests
+        if: ${{ matrix.timing_mode == 'compile' }}
         run: make test-lit
+      - name: Record timing target
+        run: |
+          mkdir -p /tmp/triton-ci-timing
+          printf 'head_sha=%s\nrunner_type=%s\ntiming_mode=%s\n' \
+            "$GITHUB_SHA" "$RUNNER_TYPE" "${{ matrix.timing_mode }}" \
+            > /tmp/triton-ci-timing/target.txt
+          nvidia-smi -q -x > /tmp/triton-ci-timing/nvidia-smi-before.xml
       - name: Run triton tests
         env:
           PYTEST_PLUGINS: triton._ci_timing
-          TRITON_CI_TIMING_DIR: ${{ startsWith(matrix.config.runner_type, 'nvidia-gb200') && '/tmp/triton-ci-timing' || '' }}
+          TRITON_CI_TIMING_DIR: /tmp/triton-ci-timing
           TRITON_CI_TIMING_LABEL: triton-tests
-          TRITON_CI_TIMING_GPU: "0"
+          TRITON_CI_TIMING_GPU: ${{ matrix.timing_mode == 'gpu' && '1' || '0' }}
+          TRITON_CI_TIMING_PHASE_TESTS: "10"
+          TRITON_PROFILE_BUFFER_SIZE: "4194304"
+          TRITON_CACHE_DIR: /tmp/triton-ci-cache-${{ matrix.timing_mode }}
         run: make NUM_PROCS=24 test-unit
       - name: Run gluon tests
         env:
           PYTEST_PLUGINS: triton._ci_timing
-          TRITON_CI_TIMING_DIR: ${{ startsWith(matrix.config.runner_type, 'nvidia-gb200') && '/tmp/triton-ci-timing' || '' }}
+          TRITON_CI_TIMING_DIR: /tmp/triton-ci-timing
           TRITON_CI_TIMING_LABEL: gluon-tests
-          TRITON_CI_TIMING_GPU: "0"
+          TRITON_CI_TIMING_GPU: ${{ matrix.timing_mode == 'gpu' && '1' || '0' }}
+          TRITON_CI_TIMING_PHASE_TESTS: "10"
+          TRITON_PROFILE_BUFFER_SIZE: "4194304"
+          TRITON_CACHE_DIR: /tmp/triton-ci-cache-${{ matrix.timing_mode }}
         run: make NUM_PROCS=24 test-gluon
-      - name: Upload GB200 timing
-        if: ${{ always() && startsWith(matrix.config.runner_type, 'nvidia-gb200') }}
+      - name: Record final GPU state
+        if: ${{ always() }}
+        run: nvidia-smi -q -x > /tmp/triton-ci-timing/nvidia-smi-after.xml
+      - name: Upload NVIDIA timing
+        if: ${{ always() }}
         uses: actions/upload-artifact@v4
         with:
-          name: gb200-ci-timing-${{ github.run_id }}-${{ github.run_attempt }}
+          name: nvidia-ci-timing-${{ matrix.config.name }}-${{ matrix.timing_mode }}-${{ github.run_id }}-${{ github.run_attempt }}
           path: /tmp/triton-ci-timing
           if-no-files-found: error
           retention-days: 3
       - name: Run gsan tests
+        if: ${{ matrix.timing_mode == 'compile' }}
         run: make NUM_PROCS=24 test-gsan
       - name: Run interpreter tests
-        if: ${{ matrix.config.runner_type == 'nvidia-h100' }}
+        if: ${{ matrix.timing_mode == 'compile' && matrix.config.runner_type == 'nvidia-h100' }}
         run: make test-interpret
       - name: Run regression tests
+        if: ${{ matrix.timing_mode == 'compile' }}
         run: make test-regression
       - name: Run microbenchmark tests
+        if: ${{ matrix.timing_mode == 'compile' }}
         # Microbenchmark never fail but running them gives us an easy way to track performance changes.
         run: make test-microbenchmark
       - name: Run C++ unittests
+        if: ${{ matrix.timing_mode == 'compile' }}
         run: make test-cpp
       - name: Run Proton tests
+        if: ${{ matrix.timing_mode == 'compile' }}
         run: make test-proton
       - name: Inspect cache directories
+        if: ${{ matrix.timing_mode == 'compile' }}
         run: |
           mkdir -p ~/.triton
           du -h -d 1 ~/.triton
@@ -132,7 +157,7 @@ jobs:
           mkdir -p ~/.ccache
           du -h -d 1 ~/.ccache
       - name: Save build dependencies cache
-        if: github.ref == 'refs/heads/main'
+        if: ${{ matrix.timing_mode == 'compile' && github.ref == 'refs/heads/main' }}
         uses: actions/cache/save@v4
         with:
           path: |

--- a/.github/workflows/integration-tests-nvidia.yml
+++ b/.github/workflows/integration-tests-nvidia.yml
@@ -93,12 +93,14 @@ jobs:
           PYTEST_PLUGINS: triton._ci_timing
           TRITON_CI_TIMING_DIR: ${{ startsWith(matrix.config.runner_type, 'nvidia-gb200') && '/tmp/triton-ci-timing' || '' }}
           TRITON_CI_TIMING_LABEL: triton-tests
+          TRITON_CI_TIMING_GPU: "0"
         run: make NUM_PROCS=24 test-unit
       - name: Run gluon tests
         env:
           PYTEST_PLUGINS: triton._ci_timing
           TRITON_CI_TIMING_DIR: ${{ startsWith(matrix.config.runner_type, 'nvidia-gb200') && '/tmp/triton-ci-timing' || '' }}
           TRITON_CI_TIMING_LABEL: gluon-tests
+          TRITON_CI_TIMING_GPU: "0"
         run: make NUM_PROCS=24 test-gluon
       - name: Upload GB200 timing
         if: ${{ always() && startsWith(matrix.config.runner_type, 'nvidia-gb200') }}

--- a/python/triton/_ci_timing.py
+++ b/python/triton/_ci_timing.py
@@ -38,12 +38,14 @@ class _TimingState:
         self.output_dir.mkdir(parents=True, exist_ok=True)
         self.profile_base = self.output_dir / "gpu"
         self.profile_gpu = os.environ.get("TRITON_CI_TIMING_GPU", "1") != "0"
+        self.profile_phase_tests = int(os.environ.get("TRITON_CI_TIMING_PHASE_TESTS", "10"))
+        self.profile_phase = 0
+        self.profile_test_count = 0
 
         self.compile_events: list[list[int]] = []
         self.compile_lock = threading.Lock()
         self.listener_wrappers: list[Callable[..., None]] = []
         self.errors: list[str] = []
-        self.calibration: dict[str, int] | None = None
         self.proton_session: int | None = None
         self.mono_start_ns: int | None = None
         self.mono_tests_end_ns: int | None = None
@@ -52,6 +54,63 @@ class _TimingState:
         self.wall_end_ns: int | None = None
         self.exit_status: int | None = None
         self.finished = False
+
+    @staticmethod
+    def write_json(destination: Path, payload: dict[str, Any]) -> None:
+        temporary = destination.with_suffix(destination.suffix + ".tmp")
+        temporary.write_text(json.dumps(payload, separators=(",", ":")))
+        os.replace(temporary, destination)
+
+    def record_calibration(self) -> None:
+        import triton.profiler as proton
+
+        enter_before_ns = time.monotonic_ns()
+        proton.enter_scope(_CALIBRATION_SCOPE)
+        enter_after_ns = time.monotonic_ns()
+        time.sleep(0.002)
+        exit_before_ns = time.monotonic_ns()
+        proton.exit_scope(_CALIBRATION_SCOPE)
+        exit_after_ns = time.monotonic_ns()
+        calibration = {
+            "enter_before_ns": enter_before_ns,
+            "enter_after_ns": enter_after_ns,
+            "exit_before_ns": exit_before_ns,
+            "exit_after_ns": exit_after_ns,
+        }
+        profile_name = f"{self.profile_base.name}.part_{self.profile_phase}.chrome_trace"
+        sidecar = self.output_dir / f"{self.profile_base.name}.part_{self.profile_phase}.profile.json"
+        self.write_json(
+            sidecar,
+            {
+                "schema_version": 1,
+                "kind": "gpu_profile_phase",
+                "label": self.label,
+                "invocation": self.invocation,
+                "role": self.role,
+                "worker_id": self.worker_id,
+                "pid": os.getpid(),
+                "runner_type": os.environ.get("RUNNER_TYPE"),
+                "cuda_visible_devices": os.environ.get("CUDA_VISIBLE_DEVICES"),
+                "phase": self.profile_phase,
+                "calibration": calibration,
+                "profile": str(self.output_dir / profile_name),
+            },
+        )
+
+    def advance_profile_phase(self) -> None:
+        if self.proton_session is None or self.profile_phase_tests <= 0:
+            return
+        self.profile_test_count += 1
+        if self.profile_test_count % self.profile_phase_tests != 0:
+            return
+        try:
+            import triton.profiler as proton
+
+            self.profile_phase = proton.data.advance_phase(session=self.proton_session)
+            self.record_calibration()
+        except Exception:
+            self.errors.append("proton phase advance failed:\n" + traceback.format_exc())
+            self.profile_phase_tests = 0
 
     def install_compilation_listener(self) -> None:
         from triton import knobs
@@ -101,20 +160,9 @@ class _TimingState:
                 backend="cupti",
                 context="shadow",
                 data="trace",
+                mode="periodic_flushing:format=chrome_trace",
             )
-            enter_before_ns = time.monotonic_ns()
-            proton.enter_scope(_CALIBRATION_SCOPE)
-            enter_after_ns = time.monotonic_ns()
-            time.sleep(0.002)
-            exit_before_ns = time.monotonic_ns()
-            proton.exit_scope(_CALIBRATION_SCOPE)
-            exit_after_ns = time.monotonic_ns()
-            self.calibration = {
-                "enter_before_ns": enter_before_ns,
-                "enter_after_ns": enter_after_ns,
-                "exit_before_ns": exit_before_ns,
-                "exit_after_ns": exit_after_ns,
-            }
+            self.record_calibration()
         except Exception:
             self.errors.append("proton start failed:\n" + traceback.format_exc())
 
@@ -145,6 +193,7 @@ class _TimingState:
             "role": self.role,
             "worker_id": self.worker_id,
             "pid": os.getpid(),
+            "runner_type": os.environ.get("RUNNER_TYPE"),
             "cuda_visible_devices": os.environ.get("CUDA_VISIBLE_DEVICES"),
             "wall_start_ns": self.wall_start_ns,
             "wall_end_ns": self.wall_end_ns,
@@ -152,16 +201,16 @@ class _TimingState:
             "mono_tests_end_ns": self.mono_tests_end_ns,
             "mono_end_ns": self.mono_end_ns,
             "exit_status": self.exit_status,
-            "calibration": self.calibration,
-            "profile": str(self.profile_base.with_suffix(".chrome_trace")) if self.profile_gpu else None,
+            "calibration": None,
+            "profile": None,
+            "profile_phase_tests": self.profile_phase_tests if self.profile_gpu else None,
+            "profile_phases": self.profile_phase + 1 if self.profile_gpu else 0,
             "errors": self.errors,
             # Each event is [start, end, cache_hit, ir_init, lowering, store], all times in ns.
             "compile_events": compile_events,
         }
         destination = self.output_dir / "summary.json"
-        temporary = destination.with_suffix(".json.tmp")
-        temporary.write_text(json.dumps(payload, separators=(",", ":")))
-        os.replace(temporary, destination)
+        self.write_json(destination, payload)
 
 
 def pytest_configure(config: Any) -> None:
@@ -196,6 +245,11 @@ def pytest_runtest_call(item: Any) -> None:
 def pytest_runtest_teardown(item: Any) -> None:
     if _STATE is not None:
         _STATE.install_compilation_listener()
+
+
+def pytest_runtest_logfinish(nodeid: str, location: tuple[str, int | None, str]) -> None:
+    if _STATE is not None:
+        _STATE.advance_profile_phase()
 
 
 def pytest_sessionfinish(session: Any, exitstatus: int) -> None:

--- a/python/triton/_ci_timing.py
+++ b/python/triton/_ci_timing.py
@@ -1,0 +1,207 @@
+from __future__ import annotations
+
+import json
+import os
+import threading
+import time
+import traceback
+from pathlib import Path
+from typing import Any, Callable
+
+import pytest
+
+
+_CALIBRATION_SCOPE = "__triton_ci_timing_calibration__"
+_STATE: "_TimingState | None" = None
+
+
+def _safe_component(value: str) -> str:
+    return "".join(c if c.isalnum() or c in "._-" else "_" for c in value)
+
+
+class _TimingState:
+    def __init__(self, config: Any, root: Path) -> None:
+        worker_input = getattr(config, "workerinput", None)
+        if worker_input is not None:
+            self.invocation = worker_input.get("triton_ci_timing_invocation", f"orphan-{time.time_ns()}")
+            self.worker_id = worker_input.get("workerid", "worker")
+            self.role = "worker"
+        else:
+            self.invocation = f"{time.time_ns()}-{os.getpid()}"
+            self.worker_id = "controller"
+            num_processes = getattr(config.option, "numprocesses", None)
+            self.role = "controller" if num_processes not in (None, 0, "0") else "main"
+
+        self.label = os.environ.get("TRITON_CI_TIMING_LABEL", "unlabeled")
+        process_name = f"{_safe_component(self.worker_id)}-{os.getpid()}"
+        self.output_dir = root / _safe_component(self.label) / _safe_component(self.invocation) / process_name
+        self.output_dir.mkdir(parents=True, exist_ok=True)
+        self.profile_base = self.output_dir / "gpu"
+
+        self.compile_events: list[list[int]] = []
+        self.compile_lock = threading.Lock()
+        self.listener_wrappers: list[Callable[..., None]] = []
+        self.errors: list[str] = []
+        self.calibration: dict[str, int] | None = None
+        self.proton_session: int | None = None
+        self.mono_start_ns: int | None = None
+        self.mono_tests_end_ns: int | None = None
+        self.mono_end_ns: int | None = None
+        self.wall_start_ns: int | None = None
+        self.wall_end_ns: int | None = None
+        self.exit_status: int | None = None
+        self.finished = False
+
+    def install_compilation_listener(self) -> None:
+        from triton import knobs
+
+        previous = knobs.compilation.listener
+        if getattr(previous, "_triton_ci_timing_owner", None) is self:
+            return
+
+        def listener(*, src, metadata, metadata_group, times, cache_hit) -> None:
+            end_ns = time.monotonic_ns()
+            total_ns = times.total * 1000
+            event = [
+                end_ns - total_ns,
+                end_ns,
+                int(cache_hit),
+                times.ir_initialization * 1000,
+                times.total_lowering * 1000,
+                times.store_results * 1000,
+            ]
+            with self.compile_lock:
+                self.compile_events.append(event)
+            if previous is not None:
+                previous(
+                    src=src,
+                    metadata=metadata,
+                    metadata_group=metadata_group,
+                    times=times,
+                    cache_hit=cache_hit,
+                )
+
+        listener._triton_ci_timing_owner = self  # type: ignore[attr-defined]
+        self.listener_wrappers.append(listener)
+        knobs.compilation.listener = listener
+
+    def start(self) -> None:
+        self.wall_start_ns = time.time_ns()
+        self.mono_start_ns = time.monotonic_ns()
+        self.install_compilation_listener()
+        if self.role == "controller":
+            return
+
+        try:
+            import triton.profiler as proton
+
+            self.proton_session = proton.start(
+                str(self.profile_base),
+                backend="cupti",
+                context="shadow",
+                data="trace",
+            )
+            enter_before_ns = time.monotonic_ns()
+            proton.enter_scope(_CALIBRATION_SCOPE)
+            enter_after_ns = time.monotonic_ns()
+            time.sleep(0.002)
+            exit_before_ns = time.monotonic_ns()
+            proton.exit_scope(_CALIBRATION_SCOPE)
+            exit_after_ns = time.monotonic_ns()
+            self.calibration = {
+                "enter_before_ns": enter_before_ns,
+                "enter_after_ns": enter_after_ns,
+                "exit_before_ns": exit_before_ns,
+                "exit_after_ns": exit_after_ns,
+            }
+        except Exception:
+            self.errors.append("proton start failed:\n" + traceback.format_exc())
+
+    def finish(self, exit_status: int | None) -> None:
+        if self.finished:
+            return
+        self.finished = True
+        self.exit_status = exit_status
+        self.mono_tests_end_ns = time.monotonic_ns()
+        if self.proton_session is not None:
+            try:
+                import triton.profiler as proton
+
+                proton.finalize(self.proton_session)
+            except Exception:
+                self.errors.append("proton finalize failed:\n" + traceback.format_exc())
+        self.mono_end_ns = time.monotonic_ns()
+        self.wall_end_ns = time.time_ns()
+        self.write_summary()
+
+    def write_summary(self) -> None:
+        with self.compile_lock:
+            compile_events = list(self.compile_events)
+        payload = {
+            "schema_version": 1,
+            "label": self.label,
+            "invocation": self.invocation,
+            "role": self.role,
+            "worker_id": self.worker_id,
+            "pid": os.getpid(),
+            "cuda_visible_devices": os.environ.get("CUDA_VISIBLE_DEVICES"),
+            "wall_start_ns": self.wall_start_ns,
+            "wall_end_ns": self.wall_end_ns,
+            "mono_start_ns": self.mono_start_ns,
+            "mono_tests_end_ns": self.mono_tests_end_ns,
+            "mono_end_ns": self.mono_end_ns,
+            "exit_status": self.exit_status,
+            "calibration": self.calibration,
+            "profile": str(self.profile_base.with_suffix(".chrome_trace")),
+            "errors": self.errors,
+            # Each event is [start, end, cache_hit, ir_init, lowering, store], all times in ns.
+            "compile_events": compile_events,
+        }
+        destination = self.output_dir / "summary.json"
+        temporary = destination.with_suffix(".json.tmp")
+        temporary.write_text(json.dumps(payload, separators=(",", ":")))
+        os.replace(temporary, destination)
+
+
+def pytest_configure(config: Any) -> None:
+    global _STATE
+    root = os.environ.get("TRITON_CI_TIMING_DIR")
+    if not root:
+        return
+    _STATE = _TimingState(config, Path(root))
+
+
+@pytest.hookimpl(optionalhook=True)
+def pytest_configure_node(node: Any) -> None:
+    if _STATE is not None:
+        node.workerinput["triton_ci_timing_invocation"] = _STATE.invocation
+
+
+def pytest_sessionstart(session: Any) -> None:
+    if _STATE is not None:
+        _STATE.start()
+
+
+def pytest_runtest_setup(item: Any) -> None:
+    if _STATE is not None:
+        _STATE.install_compilation_listener()
+
+
+def pytest_runtest_call(item: Any) -> None:
+    if _STATE is not None:
+        _STATE.install_compilation_listener()
+
+
+def pytest_runtest_teardown(item: Any) -> None:
+    if _STATE is not None:
+        _STATE.install_compilation_listener()
+
+
+def pytest_sessionfinish(session: Any, exitstatus: int) -> None:
+    if _STATE is not None:
+        _STATE.finish(exitstatus)
+
+
+def pytest_unconfigure(config: Any) -> None:
+    if _STATE is not None and not _STATE.finished:
+        _STATE.finish(None)

--- a/python/triton/_ci_timing.py
+++ b/python/triton/_ci_timing.py
@@ -10,7 +10,6 @@ from typing import Any, Callable
 
 import pytest
 
-
 _CALIBRATION_SCOPE = "__triton_ci_timing_calibration__"
 _STATE: "_TimingState | None" = None
 
@@ -20,6 +19,7 @@ def _safe_component(value: str) -> str:
 
 
 class _TimingState:
+
     def __init__(self, config: Any, root: Path) -> None:
         worker_input = getattr(config, "workerinput", None)
         if worker_input is not None:
@@ -37,6 +37,7 @@ class _TimingState:
         self.output_dir = root / _safe_component(self.label) / _safe_component(self.invocation) / process_name
         self.output_dir.mkdir(parents=True, exist_ok=True)
         self.profile_base = self.output_dir / "gpu"
+        self.profile_gpu = os.environ.get("TRITON_CI_TIMING_GPU", "1") != "0"
 
         self.compile_events: list[list[int]] = []
         self.compile_lock = threading.Lock()
@@ -89,7 +90,7 @@ class _TimingState:
         self.wall_start_ns = time.time_ns()
         self.mono_start_ns = time.monotonic_ns()
         self.install_compilation_listener()
-        if self.role == "controller":
+        if self.role == "controller" or not self.profile_gpu:
             return
 
         try:
@@ -152,7 +153,7 @@ class _TimingState:
             "mono_end_ns": self.mono_end_ns,
             "exit_status": self.exit_status,
             "calibration": self.calibration,
-            "profile": str(self.profile_base.with_suffix(".chrome_trace")),
+            "profile": str(self.profile_base.with_suffix(".chrome_trace")) if self.profile_gpu else None,
             "errors": self.errors,
             # Each event is [start, end, cache_hit, ir_init, lowering, store], all times in ns.
             "compile_events": compile_events,

--- a/scripts/aggregate_ci_timing.py
+++ b/scripts/aggregate_ci_timing.py
@@ -1,0 +1,300 @@
+#!/usr/bin/env python3
+
+from __future__ import annotations
+
+import argparse
+import json
+import tempfile
+from collections import defaultdict
+from pathlib import Path
+from typing import Iterable
+
+
+Interval = tuple[int, int]
+CALIBRATION_SCOPE = "__triton_ci_timing_calibration__"
+
+
+def union_intervals(intervals: Iterable[Interval]) -> list[Interval]:
+    merged: list[Interval] = []
+    for start, end in sorted((start, end) for start, end in intervals if end > start):
+        if not merged or start > merged[-1][1]:
+            merged.append((start, end))
+        else:
+            merged[-1] = (merged[-1][0], max(merged[-1][1], end))
+    return merged
+
+
+def intersect_intervals(lhs: Iterable[Interval], rhs: Iterable[Interval]) -> list[Interval]:
+    left = union_intervals(lhs)
+    right = union_intervals(rhs)
+    result: list[Interval] = []
+    i = 0
+    j = 0
+    while i < len(left) and j < len(right):
+        start = max(left[i][0], right[j][0])
+        end = min(left[i][1], right[j][1])
+        if end > start:
+            result.append((start, end))
+        if left[i][1] <= right[j][1]:
+            i += 1
+        else:
+            j += 1
+    return result
+
+
+def duration(intervals: Iterable[Interval]) -> int:
+    return sum(end - start for start, end in union_intervals(intervals))
+
+
+def clip_intervals(intervals: Iterable[Interval], windows: Iterable[Interval]) -> list[Interval]:
+    return intersect_intervals(intervals, windows)
+
+
+def load_trace(summary_path: Path, summary: dict) -> tuple[list[Interval], int, list[str]]:
+    errors: list[str] = []
+    calibration = summary.get("calibration")
+    if not calibration:
+        return [], 0, [f"{summary_path}: missing calibration"]
+
+    trace_path = summary_path.parent / Path(summary["profile"]).name
+    if not trace_path.exists():
+        return [], 0, [f"{trace_path}: missing trace"]
+    try:
+        trace = json.loads(trace_path.read_text())
+    except Exception as exc:
+        return [], 0, [f"{trace_path}: {exc}"]
+
+    events = trace.get("traceEvents", [])
+    calibration_events = [
+        event
+        for event in events
+        if event.get("name") == CALIBRATION_SCOPE and event.get("cat") == "scope" and event.get("ph") == "X"
+    ]
+    if len(calibration_events) != 1:
+        return [], 0, [f"{trace_path}: expected one calibration event, found {len(calibration_events)}"]
+
+    calibration_event = calibration_events[0]
+    trace_anchor_us = float(calibration_event["ts"])
+    mono_anchor_ns = (int(calibration["enter_before_ns"]) + int(calibration["enter_after_ns"])) // 2
+    intervals: list[Interval] = []
+    raw_ns = 0
+    for event in events:
+        if event.get("cat") != "kernel" or event.get("ph") != "X":
+            continue
+        start_ns = mono_anchor_ns + round((float(event["ts"]) - trace_anchor_us) * 1000)
+        duration_ns = max(0, round(float(event["dur"]) * 1000))
+        intervals.append((start_ns, start_ns + duration_ns))
+        raw_ns += duration_ns
+    return intervals, raw_ns, errors
+
+
+def analyze(root: Path) -> dict:
+    summaries: list[tuple[Path, dict]] = []
+    errors: list[str] = []
+    for path in sorted(root.rglob("summary.json")):
+        try:
+            summary = json.loads(path.read_text())
+            summaries.append((path, summary))
+            errors.extend(f"{path}: {error}" for error in summary.get("errors", []))
+        except Exception as exc:
+            errors.append(f"{path}: {exc}")
+
+    by_invocation: dict[str, list[dict]] = defaultdict(list)
+    for _, summary in summaries:
+        by_invocation[summary["invocation"]].append(summary)
+
+    invocation_windows: dict[str, Interval] = {}
+    for invocation, group in by_invocation.items():
+        owners = [item for item in group if item["role"] in ("controller", "main")]
+        candidates = owners or group
+        starts = [int(item["mono_start_ns"]) for item in candidates if item.get("mono_start_ns") is not None]
+        ends = [int(item["mono_end_ns"]) for item in candidates if item.get("mono_end_ns") is not None]
+        if starts and ends:
+            invocation_windows[invocation] = (min(starts), max(ends))
+        else:
+            errors.append(f"{invocation}: missing session window")
+
+    groups: dict[str, dict[str, list | int]] = defaultdict(
+        lambda: {
+            "windows": [],
+            "compile": [],
+            "gpu": [],
+            "raw_compile_ns": 0,
+            "raw_gpu_ns": 0,
+            "compile_events": 0,
+            "cache_hits": 0,
+            "cache_misses": 0,
+            "ir_init_ns": 0,
+            "lowering_ns": 0,
+            "store_ns": 0,
+        }
+    )
+
+    seen_windows: set[tuple[str, str]] = set()
+    for path, summary in summaries:
+        label = summary["label"]
+        group = groups[label]
+        invocation = summary["invocation"]
+        window = invocation_windows.get(invocation)
+        if window is not None and (label, invocation) not in seen_windows:
+            group["windows"].append(window)
+            seen_windows.add((label, invocation))
+
+        for event in summary.get("compile_events", []):
+            start, end, cache_hit, ir_init, lowering, store = map(int, event)
+            group["compile"].append((start, end))
+            group["raw_compile_ns"] += end - start
+            group["compile_events"] += 1
+            group["cache_hits"] += cache_hit
+            group["cache_misses"] += 1 - cache_hit
+            group["ir_init_ns"] += ir_init
+            group["lowering_ns"] += lowering
+            group["store_ns"] += store
+
+        if summary["role"] != "controller" and not summary.get("errors"):
+            gpu_intervals, raw_gpu_ns, trace_errors = load_trace(path, summary)
+            group["gpu"].extend(gpu_intervals)
+            group["raw_gpu_ns"] += raw_gpu_ns
+            errors.extend(trace_errors)
+
+    results: dict[str, dict[str, int | float]] = {}
+    for label, group in sorted(groups.items()):
+        windows = union_intervals(group["windows"])
+        compile_intervals = clip_intervals(group["compile"], windows)
+        gpu_intervals = clip_intervals(group["gpu"], windows)
+        compile_ns = duration(compile_intervals)
+        gpu_ns = duration(gpu_intervals)
+        overlap_ns = duration(intersect_intervals(compile_intervals, gpu_intervals))
+        wall_ns = duration(windows)
+        host_ns = max(0, wall_ns - compile_ns - gpu_ns + overlap_ns)
+        results[label] = {
+            "wall_ns": wall_ns,
+            "compile_only_ns": compile_ns - overlap_ns,
+            "gpu_only_ns": gpu_ns - overlap_ns,
+            "compile_gpu_overlap_ns": overlap_ns,
+            "host_remainder_ns": host_ns,
+            "raw_compile_worker_ns": int(group["raw_compile_ns"]),
+            "raw_gpu_kernel_ns": int(group["raw_gpu_ns"]),
+            "compile_events": int(group["compile_events"]),
+            "cache_hits": int(group["cache_hits"]),
+            "cache_misses": int(group["cache_misses"]),
+            "ir_init_worker_ns": int(group["ir_init_ns"]),
+            "lowering_worker_ns": int(group["lowering_ns"]),
+            "store_worker_ns": int(group["store_ns"]),
+        }
+
+    return {
+        "schema_version": 1,
+        "summaries": len(summaries),
+        "results": results,
+        "errors": errors,
+    }
+
+
+def format_duration(ns: int) -> str:
+    seconds = ns / 1_000_000_000
+    minutes = int(seconds // 60)
+    remainder = seconds - minutes * 60
+    return f"{minutes}:{remainder:05.2f}"
+
+
+def print_table(analysis: dict) -> None:
+    headers = ["Suite", "Wall", "Compile only", "GPU only", "Overlap", "Host remainder"]
+    rows: list[list[str]] = []
+    for label, result in analysis["results"].items():
+        rows.append(
+            [
+                label,
+                format_duration(result["wall_ns"]),
+                format_duration(result["compile_only_ns"]),
+                format_duration(result["gpu_only_ns"]),
+                format_duration(result["compile_gpu_overlap_ns"]),
+                format_duration(result["host_remainder_ns"]),
+            ]
+        )
+
+    widths = [len(header) for header in headers]
+    for row in rows:
+        widths = [max(width, len(cell)) for width, cell in zip(widths, row)]
+
+    def fence(left: str, middle: str, right: str) -> str:
+        return left + middle.join("─" * (width + 2) for width in widths) + right
+
+    print(fence("┌", "┬", "┐"))
+    print("│ " + " │ ".join(header.ljust(width) for header, width in zip(headers, widths)) + " │")
+    print(fence("├", "┼", "┤"))
+    for row in rows:
+        print(
+            "│ "
+            + " │ ".join(
+                cell.ljust(width) if index == 0 else cell.rjust(width)
+                for index, (cell, width) in enumerate(zip(row, widths))
+            )
+            + " │"
+        )
+    print(fence("└", "┴", "┘"))
+
+
+def self_test() -> None:
+    assert union_intervals([(0, 10), (5, 12), (20, 30)]) == [(0, 12), (20, 30)]
+    assert intersect_intervals([(0, 10), (20, 30)], [(5, 25)]) == [(5, 10), (20, 25)]
+    windows = [(0, 100)]
+    compile_intervals = clip_intervals([(10, 40), (60, 80)], windows)
+    gpu_intervals = clip_intervals([(30, 70)], windows)
+    overlap = duration(intersect_intervals(compile_intervals, gpu_intervals))
+    assert duration(compile_intervals) == 50
+    assert duration(gpu_intervals) == 40
+    assert overlap == 20
+    assert duration(windows) - duration(compile_intervals) - duration(gpu_intervals) + overlap == 30
+
+    with tempfile.TemporaryDirectory() as tmp:
+        root = Path(tmp)
+        summary_path = root / "summary.json"
+        trace_path = root / "gpu.chrome_trace"
+        trace_path.write_text(
+            json.dumps(
+                {
+                    "traceEvents": [
+                        {"name": CALIBRATION_SCOPE, "cat": "scope", "ph": "X", "ts": 1000.0, "dur": 10.0},
+                        {"name": "kernel", "cat": "kernel", "ph": "X", "ts": 2000.0, "dur": 500.0},
+                    ]
+                }
+            )
+        )
+        summary = {
+            "profile": str(trace_path),
+            "calibration": {
+                "enter_before_ns": 10_000_000,
+                "enter_after_ns": 10_000_100,
+            },
+        }
+        gpu_intervals, raw_ns, errors = load_trace(summary_path, summary)
+        assert errors == []
+        assert gpu_intervals == [(11_000_050, 11_500_050)]
+        assert raw_ns == 500_000
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("root", nargs="?", type=Path)
+    parser.add_argument("--json", action="store_true")
+    parser.add_argument("--self-test", action="store_true")
+    args = parser.parse_args()
+    if args.self_test:
+        self_test()
+        return
+    if args.root is None:
+        parser.error("root is required unless --self-test is used")
+    result = analyze(args.root)
+    if args.json:
+        print(json.dumps(result, indent=2))
+    else:
+        print_table(result)
+        if result["errors"]:
+            print("\nErrors:")
+            for error in result["errors"]:
+                print(f"- {error}")
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/aggregate_ci_timing.py
+++ b/scripts/aggregate_ci_timing.py
@@ -78,6 +78,9 @@ def iter_trace_intervals(
     if not trace_path.exists():
         errors.append(f"{trace_path}: missing trace")
         return
+    if trace_path.stat().st_size == 0:
+        errors.append(f"{trace_path}: empty trace")
+        return
     try:
         events = iter_trace_events(trace_path)
         stream_count = 0
@@ -187,12 +190,22 @@ def stream_gpu_stats(
 
 def analyze(root: Path) -> dict:
     summaries: list[tuple[Path, dict]] = []
+    profile_phases: list[tuple[Path, dict]] = []
     errors: list[str] = []
     for path in sorted(root.rglob("summary.json")):
         try:
             summary = json.loads(path.read_text())
             summaries.append((path, summary))
             errors.extend(f"{path}: {error}" for error in summary.get("errors", []))
+        except Exception as exc:
+            errors.append(f"{path}: {exc}")
+    for path in sorted(root.rglob("*.profile.json")):
+        try:
+            profile = json.loads(path.read_text())
+            if profile.get("kind") != "gpu_profile_phase":
+                errors.append(f"{path}: unexpected profile sidecar kind")
+                continue
+            profile_phases.append((path, profile))
         except Exception as exc:
             errors.append(f"{path}: {exc}")
 
@@ -258,6 +271,9 @@ def analyze(root: Path) -> dict:
         if summary["role"] != "controller" and not summary.get("errors") and summary.get("profile"):
             group["traces"].append((path, summary))
 
+    for path, profile in profile_phases:
+        groups[profile["label"]]["traces"].append((path, profile))
+
     results: dict[str, dict[str, int | float]] = {}
     for label, group in sorted(groups.items()):
         windows = union_intervals(group["windows"])
@@ -293,6 +309,55 @@ def analyze(root: Path) -> dict:
     return {
         "schema_version": 1,
         "summaries": len(summaries),
+        "profile_phases": len(profile_phases),
+        "results": results,
+        "errors": errors,
+    }
+
+
+def combine_analyses(compile_analysis: dict, gpu_analysis: dict) -> dict:
+    errors = [f"compile: {error}" for error in compile_analysis["errors"]]
+    errors.extend(f"gpu: {error}" for error in gpu_analysis["errors"])
+    results: dict[str, dict[str, int | float]] = {}
+    labels = sorted(set(compile_analysis["results"]) | set(gpu_analysis["results"]))
+    for label in labels:
+        if label not in compile_analysis["results"]:
+            errors.append(f"{label}: missing compile-only result")
+            continue
+        if label not in gpu_analysis["results"]:
+            errors.append(f"{label}: missing GPU-trace result")
+            continue
+        compile_result = compile_analysis["results"][label]
+        gpu_result = gpu_analysis["results"][label]
+        compile_ns = compile_result["compile_only_ns"] + compile_result["compile_gpu_overlap_ns"]
+        gpu_ns = gpu_result["gpu_only_ns"] + gpu_result["compile_gpu_overlap_ns"]
+        overlap_ns = min(gpu_result["compile_gpu_overlap_ns"], compile_ns, gpu_ns)
+        wall_ns = compile_result["wall_ns"]
+        results[label] = {
+            "wall_ns": wall_ns,
+            "worker_shutdown_tail_ns": compile_result["worker_shutdown_tail_ns"],
+            "compile_only_ns": compile_ns - overlap_ns,
+            "gpu_only_ns": gpu_ns - overlap_ns,
+            "compile_gpu_overlap_ns": overlap_ns,
+            "host_remainder_ns": max(0, wall_ns - compile_ns - gpu_ns + overlap_ns),
+            "raw_compile_worker_ns": compile_result["raw_compile_worker_ns"],
+            "raw_gpu_kernel_ns": gpu_result["raw_gpu_kernel_ns"],
+            "gpu_kernel_events": gpu_result["gpu_kernel_events"],
+            "compile_events": compile_result["compile_events"],
+            "cache_hits": compile_result["cache_hits"],
+            "cache_misses": compile_result["cache_misses"],
+            "ir_init_worker_ns": compile_result["ir_init_worker_ns"],
+            "lowering_worker_ns": compile_result["lowering_worker_ns"],
+            "store_worker_ns": compile_result["store_worker_ns"],
+            "gpu_trace_wall_ns": gpu_result["wall_ns"],
+            "gpu_trace_compile_active_ns": gpu_result["compile_only_ns"] + gpu_result["compile_gpu_overlap_ns"],
+        }
+    return {
+        "schema_version": 1,
+        "combined_from_independent_runs": True,
+        "compile_summaries": compile_analysis["summaries"],
+        "gpu_summaries": gpu_analysis["summaries"],
+        "profile_phases": gpu_analysis["profile_phases"],
         "results": results,
         "errors": errors,
     }
@@ -371,10 +436,41 @@ def self_test() -> None:
         assert gpu_intervals == [(11_000_050, 11_500_050)]
         assert raw_ns == 500_000
 
+    compile_result = {
+        "wall_ns": 100,
+        "worker_shutdown_tail_ns": 1,
+        "compile_only_ns": 40,
+        "compile_gpu_overlap_ns": 0,
+        "raw_compile_worker_ns": 50,
+        "compile_events": 2,
+        "cache_hits": 1,
+        "cache_misses": 1,
+        "ir_init_worker_ns": 5,
+        "lowering_worker_ns": 40,
+        "store_worker_ns": 5,
+    }
+    gpu_result = {
+        "wall_ns": 120,
+        "compile_only_ns": 50,
+        "gpu_only_ns": 10,
+        "compile_gpu_overlap_ns": 20,
+        "raw_gpu_kernel_ns": 35,
+        "gpu_kernel_events": 3,
+    }
+    combined = combine_analyses(
+        {"summaries": 1, "profile_phases": 0, "results": {"test": compile_result}, "errors": []},
+        {"summaries": 1, "profile_phases": 2, "results": {"test": gpu_result}, "errors": []},
+    )
+    assert combined["results"]["test"]["compile_only_ns"] == 20
+    assert combined["results"]["test"]["gpu_only_ns"] == 10
+    assert combined["results"]["test"]["compile_gpu_overlap_ns"] == 20
+    assert combined["results"]["test"]["host_remainder_ns"] == 50
+
 
 def main() -> None:
     parser = argparse.ArgumentParser()
     parser.add_argument("root", nargs="?", type=Path)
+    parser.add_argument("--gpu-root", type=Path)
     parser.add_argument("--json", action="store_true")
     parser.add_argument("--self-test", action="store_true")
     args = parser.parse_args()
@@ -384,6 +480,8 @@ def main() -> None:
     if args.root is None:
         parser.error("root is required unless --self-test is used")
     result = analyze(args.root)
+    if args.gpu_root is not None:
+        result = combine_analyses(result, analyze(args.gpu_root))
     if args.json:
         print(json.dumps(result, indent=2))
     else:

--- a/scripts/aggregate_ci_timing.py
+++ b/scripts/aggregate_ci_timing.py
@@ -75,6 +75,13 @@ def iter_trace_intervals(
         return
 
     trace_path = summary_path.parent / Path(summary["profile"]).name
+    phase_zero_suffix = ".part_0.chrome_trace"
+    if not trace_path.exists() and trace_path.name.endswith(phase_zero_suffix):
+        profile_base = trace_path.name[:-len(phase_zero_suffix)]
+        phase_sidecars = list(summary_path.parent.glob(f"{profile_base}.part_*.profile.json"))
+        fallback = summary_path.parent / f"{profile_base}.chrome_trace"
+        if len(phase_sidecars) == 1 and fallback.exists():
+            trace_path = fallback
     if not trace_path.exists():
         errors.append(f"{trace_path}: missing trace")
         return
@@ -191,6 +198,7 @@ def stream_gpu_stats(
 def analyze(root: Path) -> dict:
     summaries: list[tuple[Path, dict]] = []
     profile_phases: list[tuple[Path, dict]] = []
+    profile_phases_by_dir: dict[Path, list[tuple[Path, dict]]] = defaultdict(list)
     errors: list[str] = []
     for path in sorted(root.rglob("summary.json")):
         try:
@@ -206,8 +214,20 @@ def analyze(root: Path) -> dict:
                 errors.append(f"{path}: unexpected profile sidecar kind")
                 continue
             profile_phases.append((path, profile))
+            profile_phases_by_dir[path.parent].append((path, profile))
         except Exception as exc:
             errors.append(f"{path}: {exc}")
+
+    summary_dirs = {path.parent for path, _ in summaries}
+    for directory in sorted(set(profile_phases_by_dir) - summary_dirs):
+        errors.append(f"{directory}: profile directory missing summary")
+    for path, summary in summaries:
+        if summary["role"] == "controller" or summary.get("profile_phase_tests") is None or summary.get("errors"):
+            continue
+        expected_phases = int(summary.get("profile_phases", 0))
+        actual_phases = len(profile_phases_by_dir[path.parent])
+        if actual_phases != expected_phases:
+            errors.append(f"{path.parent}: expected {expected_phases} profile phases, found {actual_phases}")
 
     by_invocation: dict[str, list[dict]] = defaultdict(list)
     for _, summary in summaries:
@@ -435,6 +455,36 @@ def self_test() -> None:
         assert errors == []
         assert gpu_intervals == [(11_000_050, 11_500_050)]
         assert raw_ns == 500_000
+
+        phase_sidecar = root / "gpu.part_0.profile.json"
+        phase_sidecar.write_text("{}")
+        summary["kind"] = "gpu_profile_phase"
+        summary["phase"] = 0
+        summary["profile"] = str(root / "gpu.part_0.chrome_trace")
+        gpu_intervals, raw_ns, errors = load_trace(phase_sidecar, summary)
+        assert errors == []
+        assert gpu_intervals == [(11_000_050, 11_500_050)]
+        assert raw_ns == 500_000
+
+    with tempfile.TemporaryDirectory() as tmp:
+        orphan = Path(tmp) / "orphan"
+        orphan.mkdir()
+        (orphan / "gpu.part_0.profile.json").write_text(
+            json.dumps({
+                "kind": "gpu_profile_phase",
+                "label": "test",
+                "invocation": "orphan",
+                "role": "worker",
+                "worker_id": "gw0",
+                "phase": 0,
+                "calibration": {
+                    "enter_before_ns": 0,
+                    "enter_after_ns": 0,
+                },
+                "profile": str(orphan / "gpu.part_0.chrome_trace"),
+            }))
+        orphan_analysis = analyze(Path(tmp))
+        assert f"{orphan}: profile directory missing summary" in orphan_analysis["errors"]
 
     compile_result = {
         "wall_ns": 100,

--- a/scripts/aggregate_ci_timing.py
+++ b/scripts/aggregate_ci_timing.py
@@ -3,12 +3,17 @@
 from __future__ import annotations
 
 import argparse
+import heapq
 import json
 import tempfile
 from collections import defaultdict
 from pathlib import Path
-from typing import Iterable
+from typing import Iterable, Iterator
 
+try:
+    import ijson
+except ImportError:
+    ijson = None
 
 Interval = tuple[int, int]
 CALIBRATION_SCOPE = "__triton_ci_timing_calibration__"
@@ -50,42 +55,134 @@ def clip_intervals(intervals: Iterable[Interval], windows: Iterable[Interval]) -
     return intersect_intervals(intervals, windows)
 
 
-def load_trace(summary_path: Path, summary: dict) -> tuple[list[Interval], int, list[str]]:
-    errors: list[str] = []
+def iter_trace_events(trace_path: Path) -> Iterator[dict]:
+    if ijson is not None:
+        with trace_path.open("rb") as stream:
+            yield from ijson.items(stream, "traceEvents.item", use_float=True)
+        return
+    yield from json.loads(trace_path.read_text()).get("traceEvents", [])
+
+
+def iter_trace_intervals(
+    summary_path: Path,
+    summary: dict,
+    stats: dict[str, int],
+    errors: list[str],
+) -> Iterator[Interval]:
     calibration = summary.get("calibration")
     if not calibration:
-        return [], 0, [f"{summary_path}: missing calibration"]
+        errors.append(f"{summary_path}: missing calibration")
+        return
 
     trace_path = summary_path.parent / Path(summary["profile"]).name
     if not trace_path.exists():
-        return [], 0, [f"{trace_path}: missing trace"]
+        errors.append(f"{trace_path}: missing trace")
+        return
     try:
-        trace = json.loads(trace_path.read_text())
+        events = iter_trace_events(trace_path)
+        stream_count = 0
+        trace_anchor_us: float | None = None
+        mono_anchor_ns = (int(calibration["enter_before_ns"]) + int(calibration["enter_after_ns"])) // 2
+        buffered: list[Interval] = []
+        last_start_ns: int | None = None
+        for event in events:
+            if event.get("ph") == "M":
+                name = event.get("args", {}).get("name", "")
+                if isinstance(name, str) and name.startswith("GPU Stream "):
+                    stream_count += 1
+                continue
+            if event.get("name") == CALIBRATION_SCOPE and event.get("cat") == "scope" and event.get("ph") == "X":
+                if trace_anchor_us is not None:
+                    errors.append(f"{trace_path}: multiple calibration events")
+                    return
+                trace_anchor_us = float(event["ts"])
+                continue
+            if event.get("cat") != "kernel" or event.get("ph") != "X":
+                continue
+            if trace_anchor_us is None:
+                errors.append(f"{trace_path}: kernel event precedes calibration")
+                return
+            start_ns = mono_anchor_ns + round((float(event["ts"]) - trace_anchor_us) * 1000)
+            duration_ns = max(0, round(float(event["dur"]) * 1000))
+            interval = (start_ns, start_ns + duration_ns)
+            stats["raw_gpu_ns"] += duration_ns
+            stats["kernel_events"] += 1
+            if stream_count > 1:
+                buffered.append(interval)
+            else:
+                if last_start_ns is not None and start_ns < last_start_ns:
+                    errors.append(f"{trace_path}: single-stream events are not time ordered")
+                    return
+                last_start_ns = start_ns
+                yield interval
     except Exception as exc:
-        return [], 0, [f"{trace_path}: {exc}"]
+        errors.append(f"{trace_path}: {exc}")
+        return
 
-    events = trace.get("traceEvents", [])
-    calibration_events = [
-        event
-        for event in events
-        if event.get("name") == CALIBRATION_SCOPE and event.get("cat") == "scope" and event.get("ph") == "X"
-    ]
-    if len(calibration_events) != 1:
-        return [], 0, [f"{trace_path}: expected one calibration event, found {len(calibration_events)}"]
+    if trace_anchor_us is None:
+        errors.append(f"{trace_path}: missing calibration event")
+        return
+    yield from sorted(buffered)
 
-    calibration_event = calibration_events[0]
-    trace_anchor_us = float(calibration_event["ts"])
-    mono_anchor_ns = (int(calibration["enter_before_ns"]) + int(calibration["enter_after_ns"])) // 2
-    intervals: list[Interval] = []
-    raw_ns = 0
-    for event in events:
-        if event.get("cat") != "kernel" or event.get("ph") != "X":
-            continue
-        start_ns = mono_anchor_ns + round((float(event["ts"]) - trace_anchor_us) * 1000)
-        duration_ns = max(0, round(float(event["dur"]) * 1000))
-        intervals.append((start_ns, start_ns + duration_ns))
-        raw_ns += duration_ns
-    return intervals, raw_ns, errors
+
+def load_trace(summary_path: Path, summary: dict) -> tuple[list[Interval], int, list[str]]:
+    errors: list[str] = []
+    stats = {"raw_gpu_ns": 0, "kernel_events": 0}
+    intervals = list(iter_trace_intervals(summary_path, summary, stats, errors))
+    return intervals, stats["raw_gpu_ns"], errors
+
+
+def stream_gpu_stats(
+    traces: list[tuple[Path, dict]],
+    windows: list[Interval],
+    compile_intervals: list[Interval],
+) -> tuple[int, int, int, int, list[str]]:
+    errors: list[str] = []
+    stats = {"raw_gpu_ns": 0, "kernel_events": 0}
+    streams = [iter_trace_intervals(path, summary, stats, errors) for path, summary in traces]
+
+    gpu_ns = 0
+    overlap_ns = 0
+    window_index = 0
+    compile_index = 0
+
+    def consume(start: int, end: int) -> None:
+        nonlocal gpu_ns, overlap_ns, window_index, compile_index
+        while window_index < len(windows) and windows[window_index][1] <= start:
+            window_index += 1
+        index = window_index
+        while index < len(windows) and windows[index][0] < end:
+            clipped_start = max(start, windows[index][0])
+            clipped_end = min(end, windows[index][1])
+            if clipped_end > clipped_start:
+                gpu_ns += clipped_end - clipped_start
+                while compile_index < len(compile_intervals) and compile_intervals[compile_index][1] <= clipped_start:
+                    compile_index += 1
+                compile_scan = compile_index
+                while compile_scan < len(compile_intervals) and compile_intervals[compile_scan][0] < clipped_end:
+                    overlap_start = max(clipped_start, compile_intervals[compile_scan][0])
+                    overlap_end = min(clipped_end, compile_intervals[compile_scan][1])
+                    if overlap_end > overlap_start:
+                        overlap_ns += overlap_end - overlap_start
+                    if compile_intervals[compile_scan][1] >= clipped_end:
+                        break
+                    compile_scan += 1
+                compile_index = compile_scan
+            index += 1
+
+    current: Interval | None = None
+    for start, end in heapq.merge(*streams, key=lambda interval: interval[0]):
+        if current is None:
+            current = (start, end)
+        elif start <= current[1]:
+            current = (current[0], max(current[1], end))
+        else:
+            consume(*current)
+            current = (start, end)
+    if current is not None:
+        consume(*current)
+
+    return gpu_ns, overlap_ns, stats["raw_gpu_ns"], stats["kernel_events"], errors
 
 
 def analyze(root: Path) -> dict:
@@ -104,6 +201,7 @@ def analyze(root: Path) -> dict:
         by_invocation[summary["invocation"]].append(summary)
 
     invocation_windows: dict[str, Interval] = {}
+    invocation_test_windows: dict[str, Interval] = {}
     for invocation, group in by_invocation.items():
         owners = [item for item in group if item["role"] in ("controller", "main")]
         candidates = owners or group
@@ -111,24 +209,29 @@ def analyze(root: Path) -> dict:
         ends = [int(item["mono_end_ns"]) for item in candidates if item.get("mono_end_ns") is not None]
         if starts and ends:
             invocation_windows[invocation] = (min(starts), max(ends))
+            workers = [item for item in group if item["role"] == "worker"]
+            test_candidates = workers or candidates
+            test_ends = [
+                int(item["mono_tests_end_ns"]) for item in test_candidates if item.get("mono_tests_end_ns") is not None
+            ]
+            invocation_test_windows[invocation] = (min(starts), max(test_ends) if test_ends else max(ends))
         else:
             errors.append(f"{invocation}: missing session window")
 
     groups: dict[str, dict[str, list | int]] = defaultdict(
         lambda: {
             "windows": [],
+            "full_windows": [],
             "compile": [],
-            "gpu": [],
+            "traces": [],
             "raw_compile_ns": 0,
-            "raw_gpu_ns": 0,
             "compile_events": 0,
             "cache_hits": 0,
             "cache_misses": 0,
             "ir_init_ns": 0,
             "lowering_ns": 0,
             "store_ns": 0,
-        }
-    )
+        })
 
     seen_windows: set[tuple[str, str]] = set()
     for path, summary in summaries:
@@ -137,7 +240,8 @@ def analyze(root: Path) -> dict:
         invocation = summary["invocation"]
         window = invocation_windows.get(invocation)
         if window is not None and (label, invocation) not in seen_windows:
-            group["windows"].append(window)
+            group["full_windows"].append(window)
+            group["windows"].append(invocation_test_windows[invocation])
             seen_windows.add((label, invocation))
 
         for event in summary.get("compile_events", []):
@@ -151,30 +255,33 @@ def analyze(root: Path) -> dict:
             group["lowering_ns"] += lowering
             group["store_ns"] += store
 
-        if summary["role"] != "controller" and not summary.get("errors"):
-            gpu_intervals, raw_gpu_ns, trace_errors = load_trace(path, summary)
-            group["gpu"].extend(gpu_intervals)
-            group["raw_gpu_ns"] += raw_gpu_ns
-            errors.extend(trace_errors)
+        if summary["role"] != "controller" and not summary.get("errors") and summary.get("profile"):
+            group["traces"].append((path, summary))
 
     results: dict[str, dict[str, int | float]] = {}
     for label, group in sorted(groups.items()):
         windows = union_intervals(group["windows"])
         compile_intervals = clip_intervals(group["compile"], windows)
-        gpu_intervals = clip_intervals(group["gpu"], windows)
         compile_ns = duration(compile_intervals)
-        gpu_ns = duration(gpu_intervals)
-        overlap_ns = duration(intersect_intervals(compile_intervals, gpu_intervals))
+        gpu_ns, overlap_ns, raw_gpu_ns, kernel_events, trace_errors = stream_gpu_stats(
+            group["traces"],
+            windows,
+            compile_intervals,
+        )
+        errors.extend(trace_errors)
         wall_ns = duration(windows)
+        full_wall_ns = duration(group["full_windows"])
         host_ns = max(0, wall_ns - compile_ns - gpu_ns + overlap_ns)
         results[label] = {
             "wall_ns": wall_ns,
+            "worker_shutdown_tail_ns": max(0, full_wall_ns - wall_ns),
             "compile_only_ns": compile_ns - overlap_ns,
             "gpu_only_ns": gpu_ns - overlap_ns,
             "compile_gpu_overlap_ns": overlap_ns,
             "host_remainder_ns": host_ns,
             "raw_compile_worker_ns": int(group["raw_compile_ns"]),
-            "raw_gpu_kernel_ns": int(group["raw_gpu_ns"]),
+            "raw_gpu_kernel_ns": raw_gpu_ns,
+            "gpu_kernel_events": kernel_events,
             "compile_events": int(group["compile_events"]),
             "cache_hits": int(group["cache_hits"]),
             "cache_misses": int(group["cache_misses"]),
@@ -199,19 +306,18 @@ def format_duration(ns: int) -> str:
 
 
 def print_table(analysis: dict) -> None:
-    headers = ["Suite", "Wall", "Compile only", "GPU only", "Overlap", "Host remainder"]
+    headers = ["Suite", "Test wall", "Compile only", "GPU only", "Overlap", "Host remainder", "Worker shutdown"]
     rows: list[list[str]] = []
     for label, result in analysis["results"].items():
-        rows.append(
-            [
-                label,
-                format_duration(result["wall_ns"]),
-                format_duration(result["compile_only_ns"]),
-                format_duration(result["gpu_only_ns"]),
-                format_duration(result["compile_gpu_overlap_ns"]),
-                format_duration(result["host_remainder_ns"]),
-            ]
-        )
+        rows.append([
+            label,
+            format_duration(result["wall_ns"]),
+            format_duration(result["compile_only_ns"]),
+            format_duration(result["gpu_only_ns"]),
+            format_duration(result["compile_gpu_overlap_ns"]),
+            format_duration(result["host_remainder_ns"]),
+            format_duration(result["worker_shutdown_tail_ns"]),
+        ])
 
     widths = [len(header) for header in headers]
     for row in rows:
@@ -224,14 +330,9 @@ def print_table(analysis: dict) -> None:
     print("│ " + " │ ".join(header.ljust(width) for header, width in zip(headers, widths)) + " │")
     print(fence("├", "┼", "┤"))
     for row in rows:
-        print(
-            "│ "
-            + " │ ".join(
-                cell.ljust(width) if index == 0 else cell.rjust(width)
-                for index, (cell, width) in enumerate(zip(row, widths))
-            )
-            + " │"
-        )
+        print("│ " + " │ ".join(
+            cell.ljust(width) if index == 0 else cell.rjust(width)
+            for index, (cell, width) in enumerate(zip(row, widths))) + " │")
     print(fence("└", "┴", "┘"))
 
 
@@ -252,15 +353,12 @@ def self_test() -> None:
         summary_path = root / "summary.json"
         trace_path = root / "gpu.chrome_trace"
         trace_path.write_text(
-            json.dumps(
-                {
-                    "traceEvents": [
-                        {"name": CALIBRATION_SCOPE, "cat": "scope", "ph": "X", "ts": 1000.0, "dur": 10.0},
-                        {"name": "kernel", "cat": "kernel", "ph": "X", "ts": 2000.0, "dur": 500.0},
-                    ]
-                }
-            )
-        )
+            json.dumps({
+                "traceEvents": [
+                    {"name": CALIBRATION_SCOPE, "cat": "scope", "ph": "X", "ts": 1000.0, "dur": 10.0},
+                    {"name": "kernel", "cat": "kernel", "ph": "X", "ts": 2000.0, "dur": 500.0},
+                ]
+            }))
         summary = {
             "profile": str(trace_path),
             "calibration": {


### PR DESCRIPTION
PR description written by Codex

Temporary observability change to measure the A100, H100, and GB200 unit and Gluon test breakdown. Independent compile-only and periodic CUPTI-trace jobs preserve normal wall timings, bound trace memory, and upload phase-calibrated artifacts. This draft is for measurement only and is not intended to merge.
