### PR TITLE
[WS] Fix use-list iterator invalidation in cloneMultiPartitionDataOps

### DIFF
--- a/lib/Dialect/TritonGPU/Transforms/WarpSpecialization/PartitionScheduling.cpp
+++ b/lib/Dialect/TritonGPU/Transforms/WarpSpecialization/PartitionScheduling.cpp
@@ -1592,7 +1592,13 @@ private:
       // rewrite results
       for (auto newOp : newOps) {
         auto oldOp = mapping[newOp];
-        for (auto &use : oldOp->getUses()) {
+        // use.set() below unlinks the use from oldOp's use-chain while we
+        // are iterating that same chain, so without early-increment
+        // iteration only the first matching use is visited. The remaining
+        // same-partition users would keep pointing at the old
+        // multi-partition op, which insert-aref cannot handle (see the
+        // FIXME at the top of this function).
+        for (auto &use : llvm::make_early_inc_range(oldOp->getUses())) {
           auto user = use.getOwner();
           assert(user);
           auto userPartitions = getPartitionIds(user);

--- a/test/TritonGPU/partition-scheduling.mlir
+++ b/test/TritonGPU/partition-scheduling.mlir
@@ -181,6 +181,45 @@ tt.func @optimize_broadcast(%arg0: i32, %arg1: !tt.tensordesc<128x128xf32, #shar
   tt.return
 }
 
+// Regression test: when a multi-partition op has more than one user in the
+// same partition, ALL of those users must be redirected to that partition's
+// clone and the original multi-partition op must be erased. A use-list
+// iterator invalidation in cloneMultiPartitionDataOps used to redirect only
+// the first user, leaving a stale multi-partition op behind that crashed
+// insert-aref (assert(consumers.size() > 0)).
+// CHECK-LABEL: @clone_multi_partition_repeated_users
+tt.func @clone_multi_partition_repeated_users(%arg0: i32, %arg1: !tt.tensordesc<128x128xf32, #shared_f32>) {
+  %c0_i32 = arith.constant 0 : i32
+  %c1_i32 = arith.constant 1 : i32
+  // CHECK: scf.for
+  scf.for %i = %c0_i32 to %arg0 step %c1_i32 : i32 {
+    %md = tt.descriptor_load %arg1[%c0_i32, %c0_i32] {ttg.partition = array<i32: 1>} : !tt.tensordesc<128x128xf32, #shared_f32> -> tensor<128x128xf32, #load_blocked>
+    %smem = ttg.local_alloc %md {ttg.partition = array<i32: 1>} : (tensor<128x128xf32, #load_blocked>) -> !ttg.memdesc<128x128xf32, #shared_f32, #smem>
+    %tmp = ttg.local_load %smem {ttg.partition = array<i32: 1>} : !ttg.memdesc<128x128xf32, #shared_f32, #smem> -> tensor<128x128xf32, #load_blocked>
+    "use_memdesc"(%tmp) {ttg.partition = array<i32: 1>} : (tensor<128x128xf32, #load_blocked>) -> ()
+
+    // CHECK: [[X:%.*]] = "producer"{{.*}}partition = array<i32: 0>
+    %x = "producer"() {ttg.partition = array<i32: 0>, data} : () -> tensor<128xf32>
+
+    // CHECK-DAG: [[X0_P0:%.*]] = tt.expand_dims [[X]] {{.*}}partition = array<i32: 0>
+    // CHECK-DAG: [[X0_P1:%.*]] = tt.expand_dims [[X]] {{.*}}partition = array<i32: 1>
+    %x0 = tt.expand_dims %x {axis = 0 : i32} : tensor<128xf32> -> tensor<1x128xf32>
+    // CHECK-DAG: [[X1_P0:%.*]] = tt.broadcast [[X0_P0]] {{.*}}partition = array<i32: 0>
+    // CHECK-DAG: [[X1_P1:%.*]] = tt.broadcast [[X0_P1]] {{.*}}partition = array<i32: 1>
+    %x1 = tt.broadcast %x0 : tensor<1x128xf32> -> tensor<128x128xf32>
+
+    // Both partition-0 users must consume the partition-0 clone.
+    // CHECK: "use_a"([[X1_P0]]) {{.*}}partition = array<i32: 0>
+    "use_a"(%x1) {ttg.partition = array<i32: 0>, data} : (tensor<128x128xf32>) -> ()
+    // CHECK: "use_b"([[X1_P0]]) {{.*}}partition = array<i32: 0>
+    "use_b"(%x1) {ttg.partition = array<i32: 0>, data} : (tensor<128x128xf32>) -> ()
+    // CHECK: "use"([[X1_P1]]) {{.*}}partition = array<i32: 1>
+    "use"(%x1) {ttg.partition = array<i32: 1>, data} : (tensor<128x128xf32>) -> ()
+    // CHECK-NEXT: ttg.partition = array<i32: 0, 1>
+  } {tt.warp_specialize, ttg.partition.stages = [0 : i32, 1 : i32], ttg.warp_specialize.tag = 0 : i32}
+  tt.return
+}
+
 // CHECK-LABEL: @no_partitions
 tt.func @no_partitions(%arg0: i32) {
   %c0_i32 = arith.constant 0 : i32


### PR DESCRIPTION
`cloneMultiPartitionDataOps` in
`lib/Dialect/TritonGPU/Transforms/WarpSpecialization/PartitionScheduling.cpp`
clones a data op that partition scheduling assigned to multiple partitions
into one clone per partition, then rewrites the old op's uses to point at the
matching clone:

```cpp
for (auto &use : oldOp->getUses()) {
  ...
  use.set(newOp->getResult(idx));  // unlinks `use` from oldOp's use-chain
}
```

`use.set()` unlinks the current use from `oldOp`'s use-chain while that same
chain is being iterated, so only the first matching use is visited and
rewritten. Any remaining users in the same partition keep consuming the old
multi-partition op. The function's own header comment says it exists because
"insert-aref pass cannot currently handle these" — the surviving stale op is
exactly such an input: `NVWSInsertAref::insertArefs` buckets the stale op's
use under the residual partition (membership minus producer partitions),
while `getTransitiveConsumers` matches uses by exact partition-set equality
(`{0,1} != {1}`), finds zero consumers, and aborts the compile:

```
third_party/nvidia/lib/Dialect/NVWS/Transforms/InsertAref.cpp:448:
void createArefGet(...): Assertion `consumers.size() > 0' failed.
```

### Reproducer

The fused-attention tutorial (`python/tutorials/06-fused-attention.py`) with
`BLOCK_M ∈ {16, 32}` and `warp_specialize=True` on Blackwell
(`sm_100`/`sm_103a`) hits the assert at compile time. On this band there is
no tcgen05 MMA, partition scheduling duplicates the cheap softmax-correction
pair (`arith.subf` + `math.exp2`) into two partitions, and the pair has two
users in the same partition — the second user is left pointing at the stale
op. The tutorial's autotune space starts at `BLOCK_M=64`, so its tuner never
compiles this band; the crash surfaces as soon as the config is pinned
explicitly. Reproduced identically on the 3.7.1 wheel and on a source build
(asserts enabled); the affected code is unchanged at `main`.

Note this is a process abort, not a compile error — an autotuner sweeping
this band takes down the whole process rather than skipping the config.

### Fix

Iterate the use-chain with `llvm::make_early_inc_range` so every
same-partition use is visited and redirected. One line, plus a comment.

### Validation

- New lit regression test in `test/TritonGPU/partition-scheduling.mlir`
  (`@clone_multi_partition_repeated_users`): a multi-partition op with two
  users in one partition. On the old code only the first user is redirected
  and the stale multi-partition op survives (it keeps its
  `ttg.partition = array<i32: 0, 1>` tag and one user still consumes it), so
  the test fails; with the fix all users land on the per-partition clone and
  the original chain is erased.
- All existing cases in `partition-scheduling.mlir` pass unchanged with the
  fix.
- On a Blackwell (`sm_103a`) source build with asserts: the four
  previously-aborting tutorial configs (`BLOCK_M=16/32` × variants with
  `warp_specialize=True`) all compile after the fix. The non-causal unlocked
  configs pass an fp32 `F.scaled_dot_product_attention` reference check
  (max_abs_err ≈ 1.9e-3, same as tuner-space configs) plus repeated-launch
  bit-stability and two-stream interleaving checks.
- No behavior change on previously-compiling configs: 7/10 tutorial-config
  cubins byte-identical with and without the patch; the 3 that differ flip
  between two byte-variants that recur on both builds (pre-existing compile
  nondeterminism, uncorrelated with this patch), and all pass numerics.

This is a robustness fix, not a perf unlock: on the hardware we measured,
`warp_specialize=True` in the `BLOCK_M<64` band is slower than
`warp_specialize=False` at the same tile size — the point is that an
enumerable autotune coordinate must not abort the compiler process.

### Possible follow-up (not in this PR)

`InsertAref`'s consumer matching (membership bucketing vs exact-equality
matching) could use a defensive diagnostic pointing at PartitionScheduling
when it sees a multi-partition consumer. Two defensive guards inside
InsertAref were prototyped and rejected: dropping the vestigial bucket just
moves the failure to "operation destroyed but still has uses" in
TritonGPUPartitionLoops, because the dangling use is the real invariant
violation.

# New contributor declaration
- [x] I am not making a trivial change, such as fixing a typo in a comment.
- [x] I have written a PR description following these
  [rules](https://cbea.ms/git-commit/#why-not-how).
- [x] I have run `pre-commit run --from-ref origin/main --to-ref HEAD`.
- Select one of the following.
  - [x] I have added tests.
    - `/test` for `lit` tests
- Select one of the following.
  - [x] The `lit` tests I have added follow these [best practices](https://mlir.llvm.org/getting_started/TestingGuide/#filecheck-best-practices),
    including the "tests should be minimal" section.
cc @3gx @masahi
