### PR TITLE
[AMD] Propagate discardable attributes on the small-tensor pointer path

### DIFF
--- a/test/TritonGPU/amd/amd-canonicalize-pointers.mlir
+++ b/test/TritonGPU/amd/amd-canonicalize-pointers.mlir
@@ -1589,6 +1589,104 @@ module attributes {"ttg.num-warps" = 4 : i32} {
 
 // -----
 
+// Same as @propagate_divisibility, but small ptr case
+// (tt.pointer_range = 32), which routes through the small-tensor rewrite instead.
+module attributes {"ttg.num-warps" = 4 : i32} {
+  tt.func @propagate_divisibility_small_ptr(%arg0: !tt.ptr<f32> {tt.pointer_range = 32 : i32}) -> tensor<1024xf32> {
+    %c1024_i32 = arith.constant 1024 : i32
+    %0 = tt.get_program_id x : i32
+    %1 = arith.muli %0, %c1024_i32 : i32
+    %2 = tt.splat %1 : i32 -> tensor<1024xi32>
+    %3 = tt.splat %arg0 : !tt.ptr<f32> -> tensor<1024x!tt.ptr<f32>>
+    %4 = tt.addptr %3, %2 {tt.divisibility = 16 : i32, misc.misc = 3 : i32} : tensor<1024x!tt.ptr<f32>>, tensor<1024xi32>
+    %5 = tt.load %4 : tensor<1024x!tt.ptr<f32>>
+    tt.return %5 : tensor<1024xf32>
+  }
+}
+
+// CHECK-LABEL:   tt.func @propagate_divisibility_small_ptr(
+// CHECK-SAME:                         %[[VAL_0:.*]]: !tt.ptr<f32> {tt.pointer_range = 32 : i32}) -> tensor<1024xf32> {
+// CHECK:           %[[VAL_1:.*]] = arith.constant 1024 : i32
+// CHECK:           %[[VAL_2:.*]] = tt.get_program_id x : i32
+// CHECK:           %[[VAL_3:.*]] = arith.muli %[[VAL_2]], %[[VAL_1]] : i32
+// CHECK:           %[[VAL_4:.*]] = tt.splat %[[VAL_3]] : i32 -> tensor<1024xi32>
+// CHECK:           %[[VAL_5:.*]] = tt.splat %[[VAL_0]] : !tt.ptr<f32> -> tensor<1024x!tt.ptr<f32>>
+// CHECK:           %[[VAL_6:.*]] = tt.addptr %[[VAL_5]], %[[VAL_4]] {tt.divisibility = 16 : i32} : tensor<1024x!tt.ptr<f32>>, tensor<1024xi32>
+// CHECK:           %[[VAL_7:.*]] = tt.load %[[VAL_6]] : tensor<1024x!tt.ptr<f32>>
+// CHECK:           tt.return %[[VAL_7]] : tensor<1024xf32>
+// CHECK:         }
+
+// -----
+
+// Multiple tt.addptr ops: the second tt.addptr offsets by an unknown amount
+// and is not 16-byte aligned, so it must not carry the divisibility attribute.
+module attributes {"ttg.num-warps" = 4 : i32} {
+  tt.func @no_divisibility_leak_small_ptr(%arg0: !tt.ptr<f32> {tt.pointer_range = 32 : i32}, %arg1: i32) -> tensor<1024xf32> {
+    %c1024_i32 = arith.constant 1024 : i32
+    %0 = tt.get_program_id x : i32
+    %1 = arith.muli %0, %c1024_i32 : i32
+    %2 = tt.splat %1 : i32 -> tensor<1024xi32>
+    %3 = tt.splat %arg0 : !tt.ptr<f32> -> tensor<1024x!tt.ptr<f32>>
+    %4 = tt.addptr %3, %2 {tt.divisibility = 16 : i32} : tensor<1024x!tt.ptr<f32>>, tensor<1024xi32>
+    %5 = tt.load %4 : tensor<1024x!tt.ptr<f32>>
+    %6 = tt.splat %arg1 : i32 -> tensor<1024xi32>
+    %7 = tt.addptr %4, %6 : tensor<1024x!tt.ptr<f32>>, tensor<1024xi32>
+    %8 = tt.load %7 : tensor<1024x!tt.ptr<f32>>
+    %9 = arith.addf %5, %8 : tensor<1024xf32>
+    tt.return %9 : tensor<1024xf32>
+  }
+}
+
+// CHECK-LABEL:   tt.func @no_divisibility_leak_small_ptr(
+// CHECK-SAME:                         %[[VAL_0:.*]]: !tt.ptr<f32> {tt.pointer_range = 32 : i32},
+// CHECK-SAME:                         %[[VAL_1:.*]]: i32) -> tensor<1024xf32> {
+// CHECK:           %[[VAL_2:.*]] = arith.constant 1024 : i32
+// CHECK:           %[[VAL_3:.*]] = tt.get_program_id x : i32
+// CHECK:           %[[VAL_4:.*]] = arith.muli %[[VAL_3]], %[[VAL_2]] : i32
+// CHECK:           %[[VAL_5:.*]] = tt.splat %[[VAL_4]] : i32 -> tensor<1024xi32>
+// CHECK:           %[[VAL_6:.*]] = tt.splat %[[VAL_0]] : !tt.ptr<f32> -> tensor<1024x!tt.ptr<f32>>
+// CHECK:           %[[VAL_7:.*]] = tt.addptr %[[VAL_6]], %[[VAL_5]] {tt.divisibility = 16 : i32} : tensor<1024x!tt.ptr<f32>>, tensor<1024xi32>
+// CHECK:           %[[VAL_8:.*]] = tt.load %[[VAL_7]] : tensor<1024x!tt.ptr<f32>>
+// CHECK:           %[[VAL_9:.*]] = tt.splat %[[VAL_1]] : i32 -> tensor<1024xi32>
+// CHECK:           %[[VAL_10:.*]] = arith.addi %[[VAL_5]], %[[VAL_9]] : tensor<1024xi32>
+// CHECK:           %[[VAL_11:.*]] = tt.splat %[[VAL_0]] : !tt.ptr<f32> -> tensor<1024x!tt.ptr<f32>>
+// CHECK:           %[[VAL_12:.*]] = tt.addptr %[[VAL_11]], %[[VAL_10]] : tensor<1024x!tt.ptr<f32>>, tensor<1024xi32>
+// CHECK:           %[[VAL_13:.*]] = tt.load %[[VAL_12]] : tensor<1024x!tt.ptr<f32>>
+// CHECK:           %[[VAL_14:.*]] = arith.addf %[[VAL_8]], %[[VAL_13]] : tensor<1024xf32>
+// CHECK:           tt.return %[[VAL_14]] : tensor<1024xf32>
+// CHECK:         }
+
+// -----
+
+// The attr attached to the tt.addptr has rank 2, but the pointer
+// it annotates is rank 1, so the attr must be dropped.
+module attributes {"ttg.num-warps" = 4 : i32} {
+  tt.func @drop_rank_mismatched_attr(%arg0: !tt.ptr<f32> {tt.pointer_range = 32 : i32}) -> tensor<1024xf32> {
+    %c1024_i32 = arith.constant 1024 : i32
+    %0 = tt.get_program_id x : i32
+    %1 = arith.muli %0, %c1024_i32 : i32
+    %2 = tt.splat %1 : i32 -> tensor<1024xi32>
+    %3 = tt.splat %arg0 : !tt.ptr<f32> -> tensor<1024x!tt.ptr<f32>>
+    %4 = tt.addptr %3, %2 {tt.divisibility = dense<[1, 16]> : tensor<2xi32>} : tensor<1024x!tt.ptr<f32>>, tensor<1024xi32>
+    %5 = tt.load %4 : tensor<1024x!tt.ptr<f32>>
+    tt.return %5 : tensor<1024xf32>
+  }
+}
+
+// CHECK-LABEL:   tt.func @drop_rank_mismatched_attr(
+// CHECK-SAME:                         %[[VAL_0:.*]]: !tt.ptr<f32> {tt.pointer_range = 32 : i32}) -> tensor<1024xf32> {
+// CHECK:           %[[VAL_1:.*]] = arith.constant 1024 : i32
+// CHECK:           %[[VAL_2:.*]] = tt.get_program_id x : i32
+// CHECK:           %[[VAL_3:.*]] = arith.muli %[[VAL_2]], %[[VAL_1]] : i32
+// CHECK:           %[[VAL_4:.*]] = tt.splat %[[VAL_3]] : i32 -> tensor<1024xi32>
+// CHECK:           %[[VAL_5:.*]] = tt.splat %[[VAL_0]] : !tt.ptr<f32> -> tensor<1024x!tt.ptr<f32>>
+// CHECK:           %[[VAL_6:.*]] = tt.addptr %[[VAL_5]], %[[VAL_4]] : tensor<1024x!tt.ptr<f32>>, tensor<1024xi32>
+// CHECK:           %[[VAL_7:.*]] = tt.load %[[VAL_6]] : tensor<1024x!tt.ptr<f32>>
+// CHECK:           tt.return %[[VAL_7]] : tensor<1024xf32>
+// CHECK:         }
+
+// -----
+
 module attributes {"ttg.num-warps" = 4 : i32} {
   tt.func @divisiblity_changeing_dims(%arg0: !tt.ptr<f32>) -> tensor<1024x32xf32> {
     %c1024_i32 = arith.constant 1024 : i32

--- a/test/TritonGPU/amd/amd-canonicalize-pointers.mlir
+++ b/test/TritonGPU/amd/amd-canonicalize-pointers.mlir
@@ -1687,6 +1687,168 @@ module attributes {"ttg.num-warps" = 4 : i32} {
 
 // -----
 
+// A hint on a scalar tt.addptr, which AxisInfoAnalysis treats as rank 1.
+// The hint should be propagated.
+module attributes {"ttg.num-warps" = 4 : i32} {
+  tt.func @propagate_hints_scalar_ptr(%arg0: !tt.ptr<f32> {tt.pointer_range = 32 : i32}, %arg1: i32) -> f32 {
+    %c0_i32 = arith.constant 0 : i32
+    %c1_i32 = arith.constant 1 : i32
+    %c4_i32 = arith.constant 4 : i32
+    %cst = arith.constant 0.000000e+00 : f32
+    %0 = tt.addptr %arg0, %arg1 : !tt.ptr<f32>, i32
+    %res:2 = scf.for %i = %c0_i32 to %c4_i32 step %c1_i32 iter_args(%p = %0, %acc = %cst) -> (!tt.ptr<f32>, f32) : i32 {
+      %n = tt.addptr %p, %c1_i32 {tt.divisibility = 16 : i32} : !tt.ptr<f32>, i32
+      %l = tt.load %n : !tt.ptr<f32>
+      %a = arith.addf %acc, %l : f32
+      scf.yield %n, %a : !tt.ptr<f32>, f32
+    }
+    tt.return %res#1 : f32
+  }
+}
+
+// CHECK-LABEL:   tt.func @propagate_hints_scalar_ptr(
+// CHECK-SAME:                         %[[VAL_0:.*]]: !tt.ptr<f32> {tt.pointer_range = 32 : i32},
+// CHECK-SAME:                         %[[VAL_1:.*]]: i32) -> f32 {
+// CHECK:           %[[VAL_2:.*]]:2 = scf.for
+// CHECK:             %[[VAL_3:.*]] = arith.addi
+// CHECK:             %[[VAL_4:.*]] = tt.addptr %[[VAL_0]], %[[VAL_3]] {tt.divisibility = 16 : i32} : !tt.ptr<f32>, i32
+// CHECK:             %[[VAL_5:.*]] = tt.load %[[VAL_4]] : !tt.ptr<f32>
+
+// -----
+
+// A hint on a loop-carried pointer describes iteration 0 only: %ptr advances by
+// a runtime amount each iteration, so the claimed alignment cannot hold for all
+// of them, so the hint should be dropped.
+module attributes {"ttg.num-warps" = 4 : i32} {
+  tt.func @drop_hints_into_loop_body(%arg0: !tt.ptr<f32> {tt.pointer_range = 32 : i32}, %arg1: i32) -> tensor<1024xf32> {
+    %c0_i32 = arith.constant 0 : i32
+    %c1_i32 = arith.constant 1 : i32
+    %c4_i32 = arith.constant 4 : i32
+    %cst = arith.constant dense<0.000000e+00> : tensor<1024xf32>
+    %0 = tt.make_range {end = 1024 : i32, start = 0 : i32} : tensor<1024xi32>
+    %1 = tt.splat %arg0 : !tt.ptr<f32> -> tensor<1024x!tt.ptr<f32>>
+    %2 = tt.addptr %1, %0 {tt.divisibility = 16 : i32} : tensor<1024x!tt.ptr<f32>>, tensor<1024xi32>
+    %3 = tt.splat %arg1 : i32 -> tensor<1024xi32>
+    %res:2 = scf.for %i = %c0_i32 to %c4_i32 step %c1_i32 iter_args(%ptr = %2, %acc = %cst) -> (tensor<1024x!tt.ptr<f32>>, tensor<1024xf32>) : i32 {
+      %l = tt.load %ptr : tensor<1024x!tt.ptr<f32>>
+      %a = arith.addf %acc, %l : tensor<1024xf32>
+      %next = tt.addptr %ptr, %3 : tensor<1024x!tt.ptr<f32>>, tensor<1024xi32>
+      scf.yield %next, %a : tensor<1024x!tt.ptr<f32>>, tensor<1024xf32>
+    }
+    tt.return %res#1 : tensor<1024xf32>
+  }
+}
+
+// CHECK-LABEL:   tt.func @drop_hints_into_loop_body(
+// CHECK:           %[[LOOP:.*]]:2 = scf.for
+// CHECK:             %[[PTR:.*]] = tt.addptr %{{.*}}, %{{.*}} : tensor<1024x!tt.ptr<f32>>, tensor<1024xi32>
+// CHECK:             %[[L:.*]] = tt.load %[[PTR]] : tensor<1024x!tt.ptr<f32>>
+
+// -----
+
+// Per-dimension hints on a tt.addptr feeding the load directly: the rebuilt
+// pointer has the same type as the one it replaces, so the hints still describe
+// it and are re-attached.
+module attributes {"ttg.num-warps" = 4 : i32} {
+  tt.func @propagate_2d_hints_small_ptr(%arg0: !tt.ptr<f32> {tt.pointer_range = 32 : i32}, %arg1: i32) -> tensor<2x8xf32> {
+    %0 = tt.make_range {end = 8 : i32, start = 0 : i32} : tensor<8xi32>
+    %1 = tt.expand_dims %0 {axis = 0 : i32} : tensor<8xi32> -> tensor<1x8xi32>
+    %2 = tt.broadcast %1 : tensor<1x8xi32> -> tensor<2x8xi32>
+    %3 = tt.splat %arg1 : i32 -> tensor<2x8xi32>
+    %4 = arith.addi %2, %3 : tensor<2x8xi32>
+    %5 = tt.splat %arg0 : !tt.ptr<f32> -> tensor<2x8x!tt.ptr<f32>>
+    %6 = tt.addptr %5, %4 {tt.contiguity = dense<[1, 8]> : tensor<2xi32>, tt.divisibility = dense<[1, 16]> : tensor<2xi32>} : tensor<2x8x!tt.ptr<f32>>, tensor<2x8xi32>
+    %7 = tt.load %6 : tensor<2x8x!tt.ptr<f32>>
+    tt.return %7 : tensor<2x8xf32>
+  }
+}
+
+// CHECK-LABEL:   tt.func @propagate_2d_hints_small_ptr(
+// CHECK-SAME:                         %[[VAL_0:.*]]: !tt.ptr<f32> {tt.pointer_range = 32 : i32},
+// CHECK-SAME:                         %[[VAL_1:.*]]: i32) -> tensor<2x8xf32> {
+// CHECK:           %[[VAL_2:.*]] = tt.make_range {end = 8 : i32, start = 0 : i32} : tensor<8xi32>
+// CHECK:           %[[VAL_3:.*]] = tt.splat %[[VAL_1]] : i32 -> tensor<2x8xi32>
+// CHECK:           %[[VAL_4:.*]] = tt.expand_dims %[[VAL_2]] {axis = 0 : i32} : tensor<8xi32> -> tensor<1x8xi32>
+// CHECK:           %[[VAL_5:.*]] = tt.broadcast %[[VAL_4]] : tensor<1x8xi32> -> tensor<2x8xi32>
+// CHECK:           %[[VAL_6:.*]] = arith.addi %[[VAL_3]], %[[VAL_5]] : tensor<2x8xi32>
+// CHECK:           %[[VAL_7:.*]] = tt.splat %[[VAL_0]] : !tt.ptr<f32> -> tensor<2x8x!tt.ptr<f32>>
+// CHECK:           %[[VAL_8:.*]] = tt.addptr %[[VAL_7]], %[[VAL_6]] {tt.contiguity = dense<[1, 8]> : tensor<2xi32>, tt.divisibility = dense<[1, 16]> : tensor<2xi32>} : tensor<2x8x!tt.ptr<f32>>, tensor<2x8xi32>
+// CHECK:           %[[VAL_9:.*]] = tt.load %[[VAL_8]] : tensor<2x8x!tt.ptr<f32>>
+// CHECK:           tt.return %[[VAL_9]] : tensor<2x8xf32>
+// CHECK:         }
+
+// -----
+
+// Dropping is required here: the hints describe a 2x8 tensor and the reshape to
+// 4x4 keeps the rank, so no rank check could catch it, yet it truncates the
+// contiguous runs the hints claim. They must not reach the 4x4 pointer.
+module attributes {"ttg.num-warps" = 4 : i32} {
+  tt.func @drop_hints_across_reshape(%arg0: !tt.ptr<f32> {tt.pointer_range = 32 : i32}, %arg1: i32) -> tensor<4x4xf32> {
+    %0 = tt.make_range {end = 8 : i32, start = 0 : i32} : tensor<8xi32>
+    %1 = tt.expand_dims %0 {axis = 0 : i32} : tensor<8xi32> -> tensor<1x8xi32>
+    %2 = tt.broadcast %1 : tensor<1x8xi32> -> tensor<2x8xi32>
+    %3 = tt.splat %arg1 : i32 -> tensor<2x8xi32>
+    %4 = arith.addi %2, %3 : tensor<2x8xi32>
+    %5 = tt.splat %arg0 : !tt.ptr<f32> -> tensor<2x8x!tt.ptr<f32>>
+    %6 = tt.addptr %5, %4 {tt.contiguity = dense<[1, 8]> : tensor<2xi32>, tt.divisibility = dense<[1, 16]> : tensor<2xi32>} : tensor<2x8x!tt.ptr<f32>>, tensor<2x8xi32>
+    %7 = tt.reshape %6 allow_reorder : tensor<2x8x!tt.ptr<f32>> -> tensor<4x4x!tt.ptr<f32>>
+    %8 = tt.load %7 : tensor<4x4x!tt.ptr<f32>>
+    tt.return %8 : tensor<4x4xf32>
+  }
+}
+
+// CHECK-LABEL:   tt.func @drop_hints_across_reshape(
+// CHECK-SAME:                         %[[VAL_0:.*]]: !tt.ptr<f32> {tt.pointer_range = 32 : i32},
+// CHECK-SAME:                         %[[VAL_1:.*]]: i32) -> tensor<4x4xf32> {
+// CHECK:           %[[VAL_2:.*]] = tt.make_range {end = 8 : i32, start = 0 : i32} : tensor<8xi32>
+// CHECK:           %[[VAL_3:.*]] = tt.splat %[[VAL_1]] : i32 -> tensor<2x8xi32>
+// CHECK:           %[[VAL_4:.*]] = tt.expand_dims %[[VAL_2]] {axis = 0 : i32} : tensor<8xi32> -> tensor<1x8xi32>
+// CHECK:           %[[VAL_5:.*]] = tt.broadcast %[[VAL_4]] : tensor<1x8xi32> -> tensor<2x8xi32>
+// CHECK:           %[[VAL_6:.*]] = arith.addi %[[VAL_3]], %[[VAL_5]] : tensor<2x8xi32>
+// CHECK:           %[[VAL_7:.*]] = tt.reshape %[[VAL_6]] allow_reorder : tensor<2x8xi32> -> tensor<4x4xi32>
+// CHECK:           %[[VAL_8:.*]] = tt.splat %[[VAL_0]] : !tt.ptr<f32> -> tensor<4x4x!tt.ptr<f32>>
+// CHECK:           %[[VAL_9:.*]] = tt.addptr %[[VAL_8]], %[[VAL_7]] : tensor<4x4x!tt.ptr<f32>>, tensor<4x4xi32>
+// CHECK:           %[[VAL_10:.*]] = tt.load %[[VAL_9]] : tensor<4x4x!tt.ptr<f32>>
+// CHECK:           tt.return %[[VAL_10]] : tensor<4x4xf32>
+// CHECK:         }
+
+// -----
+
+// Dropping is a deliberate choice here, not a requirement: a broadcast only
+// expands unit dimensions, so contiguity [1, 8] and divisibility [1, 16] would
+// still hold for the 2x8 result. Hints are recovered only from a tt.addptr
+// feeding the access directly, so the broadcast in between drops them anyway.
+// This pins that conservatism, and the optimization it gives up.
+module attributes {"ttg.num-warps" = 4 : i32} {
+  tt.func @drop_hints_across_broadcast(%arg0: !tt.ptr<f32> {tt.pointer_range = 32 : i32}, %arg1: i32) -> tensor<2x8xf32> {
+    %0 = tt.make_range {end = 8 : i32, start = 0 : i32} : tensor<8xi32>
+    %1 = tt.expand_dims %0 {axis = 0 : i32} : tensor<8xi32> -> tensor<1x8xi32>
+    %2 = tt.splat %arg1 : i32 -> tensor<1x8xi32>
+    %3 = arith.addi %1, %2 : tensor<1x8xi32>
+    %4 = tt.splat %arg0 : !tt.ptr<f32> -> tensor<1x8x!tt.ptr<f32>>
+    %5 = tt.addptr %4, %3 {tt.contiguity = dense<[1, 8]> : tensor<2xi32>, tt.divisibility = dense<[1, 16]> : tensor<2xi32>} : tensor<1x8x!tt.ptr<f32>>, tensor<1x8xi32>
+    %6 = tt.broadcast %5 : tensor<1x8x!tt.ptr<f32>> -> tensor<2x8x!tt.ptr<f32>>
+    %7 = tt.load %6 : tensor<2x8x!tt.ptr<f32>>
+    tt.return %7 : tensor<2x8xf32>
+  }
+}
+
+// CHECK-LABEL:   tt.func @drop_hints_across_broadcast(
+// CHECK-SAME:                         %[[VAL_0:.*]]: !tt.ptr<f32> {tt.pointer_range = 32 : i32},
+// CHECK-SAME:                         %[[VAL_1:.*]]: i32) -> tensor<2x8xf32> {
+// CHECK:           %[[VAL_2:.*]] = tt.make_range {end = 8 : i32, start = 0 : i32} : tensor<8xi32>
+// CHECK:           %[[VAL_3:.*]] = tt.splat %[[VAL_1]] : i32 -> tensor<1x8xi32>
+// CHECK:           %[[VAL_4:.*]] = tt.expand_dims %[[VAL_2]] {axis = 0 : i32} : tensor<8xi32> -> tensor<1x8xi32>
+// CHECK:           %[[VAL_5:.*]] = arith.addi %[[VAL_3]], %[[VAL_4]] : tensor<1x8xi32>
+// CHECK:           %[[VAL_6:.*]] = tt.broadcast %[[VAL_5]] : tensor<1x8xi32> -> tensor<2x8xi32>
+// CHECK:           %[[VAL_7:.*]] = tt.splat %[[VAL_0]] : !tt.ptr<f32> -> tensor<2x8x!tt.ptr<f32>>
+// CHECK:           %[[VAL_8:.*]] = tt.addptr %[[VAL_7]], %[[VAL_6]] : tensor<2x8x!tt.ptr<f32>>, tensor<2x8xi32>
+// CHECK:           %[[VAL_9:.*]] = tt.load %[[VAL_8]] : tensor<2x8x!tt.ptr<f32>>
+// CHECK:           tt.return %[[VAL_9]] : tensor<2x8xf32>
+// CHECK:         }
+
+// -----
+
 module attributes {"ttg.num-warps" = 4 : i32} {
   tt.func @divisiblity_changeing_dims(%arg0: !tt.ptr<f32>) -> tensor<1024x32xf32> {
     %c1024_i32 = arith.constant 1024 : i32

--- a/third_party/amd/lib/TritonAMDGPUTransforms/CanonicalizePointers.cpp
+++ b/third_party/amd/lib/TritonAMDGPUTransforms/CanonicalizePointers.cpp
@@ -453,6 +453,14 @@ static const std::string kSCFElseRewrittenAttr =
 static const std::string kSCFIfOpYieldFatPtrOffsets =
     kPtrCanonPrefix + "scf-if-yield-fatptr-offsets__";
 
+/// Hints (see getHintAttrNames) read off the `tt.addptr` directly defining a
+/// pointer-like operand, keyed by (consuming op, operand index).
+/// collectMemOpHints builds this before the conversion runs; it is read-only
+/// from then on, which is what lets the hints describe the shape the consuming
+/// op originally asked for rather than whatever the pointer chain ends up with.
+using MemOpHints =
+    DenseMap<std::pair<Operation *, unsigned>, SmallVector<NamedAttribute>>;
+
 /// This struct is basically a thin wrapper over DenseMap<fatPtr, fatPtrAttrs>
 /// where fatPtr == (base, offset) and fatPtrAttrs is itself a map of (name,
 /// attribute).
@@ -560,25 +568,63 @@ void FatPointers::collectFatPointerAttributes(const KeyT &k) {
     pointerAttrs[k]->attributes[baseAttr.getName()] = baseAttr.getValue();
 }
 
-static ArrayRef<StringRef> getPropagatedAttrNames() {
+static ArrayRef<StringRef> getHintAttrNames() {
   static constexpr StringRef names[] = {"tt.divisibility", "tt.contiguity",
                                         "tt.constancy"};
   return names;
 }
 
-// The attributes carry one entry per tensor dimension and AxisInfoAnalysis
-// reads them back indexed by the op's rank. An attribute whose length disagrees
-// with the destination pointer rank would produce an inconsistent AxisInfo
-// (reading out of bounds), so only propagate an attr when its rank matches the
-// target; attributes outside getPropagatedAttrNames have no per-dimension data
-// and are always safe.
-static bool attrRankMatchesTarget(StringRef name, Attribute attr,
-                                  int64_t targetRank) {
-  if (!llvm::is_contained(getPropagatedAttrNames(), name))
-    return true;
+// AxisInfoAnalysis reads hints indexed by the rank of the op carrying it,
+// so a hint whose length disagrees with the pointer it annotates would produce
+// an inconsistent AxisInfo. Such a hint should be dropped.
+static bool hintRankMatches(Attribute attr, int64_t rank) {
   if (auto dense = dyn_cast<DenseElementsAttr>(attr))
-    return dense.getNumElements() == targetRank;
-  return targetRank == 1;
+    return dense.getNumElements() == rank;
+  return rank == 1;
+}
+
+// Collect into `memOpHints` the hints found on the `tt.addptr` that directly
+// defines each pointer-like operand in `func`, keyed by the op consuming that
+// operand and the operand index, so that reattachMemOpHints can put them back
+// once the pointer feeding it has been rebuilt.
+static void collectMemOpHints(tt::FuncOp func, MemOpHints &memOpHints) {
+  func.walk([&](Operation *op) {
+    for (auto [idx, operand] : llvm::enumerate(op->getOperands())) {
+      auto addPtrOp = operand.getDefiningOp<tt::AddPtrOp>();
+      if (!addPtrOp)
+        continue;
+      auto ptrTy = dyn_cast<RankedTensorType>(addPtrOp.getType());
+      int64_t rank = ptrTy ? ptrTy.getRank() : 1;
+      SmallVector<NamedAttribute> hints = tt::filterDiscardableAttrs(
+          addPtrOp.getOperation(), getHintAttrNames());
+      llvm::erase_if(hints, [&](const NamedAttribute &hint) {
+        return !hintRankMatches(hint.getValue(), rank);
+      });
+      if (!hints.empty())
+        memOpHints[{op, static_cast<unsigned>(idx)}] = std::move(hints);
+    }
+  });
+}
+
+// Re-apply the hints recorded (in memOpHints) for the `tt.addptr` op.
+static void reattachMemOpHints(const MemOpHints &memOpHints,
+                               const FatPointers::FatPtrAttrs &fatPtrAttrs,
+                               Operation *op, unsigned operandIdx,
+                               Value newPtr) {
+  // The large-tensor path already carries hints, by moving them onto the scalar
+  // base pointer bump it creates. The small-tensor path never builds that bump,
+  // since it keeps the offset as a tensor and defers materialization to here,
+  // so it has no attachment point to reuse. Hence this.
+  if (!fatPtrAttrs.isSmallTensor)
+    return;
+  auto it = memOpHints.find({op, operandIdx});
+  if (it == memOpHints.end())
+    return;
+  auto addPtrOp = newPtr.getDefiningOp<tt::AddPtrOp>();
+  if (!addPtrOp)
+    return;
+  for (const NamedAttribute &hint : it->second)
+    addPtrOp->setDiscardableAttr(hint.getName(), hint.getValue());
 }
 
 Value createTensorPointer(RewriterBase &rewriter, Value basePtr, Value offset,
@@ -591,8 +637,7 @@ Value createTensorPointer(RewriterBase &rewriter, Value basePtr, Value offset,
     auto addPtrOp =
         tt::AddPtrOp::create(rewriter, loc, basePtr.getType(), basePtr, offset);
     for (const auto &attribute : fatPtrAttrs.attributes)
-      if (attrRankMatchesTarget(attribute.first, attribute.second, /*rank=*/1))
-        addPtrOp->setAttr(attribute.first, attribute.second);
+      addPtrOp->setAttr(attribute.first, attribute.second);
     return addPtrOp.getResult();
   }
 
@@ -614,9 +659,7 @@ Value createTensorPointer(RewriterBase &rewriter, Value basePtr, Value offset,
       tt::AddPtrOp::create(rewriter, loc, tensorPtrType, tensorPtr, offset);
 
   for (const auto &attribute : fatPtrAttrs.attributes)
-    if (attrRankMatchesTarget(attribute.first, attribute.second,
-                              tensorType.getRank()))
-      addPtrOp->setAttr(attribute.first, attribute.second);
+    addPtrOp->setAttr(attribute.first, attribute.second);
   return addPtrOp.getResult();
 }
 
@@ -647,10 +690,11 @@ struct PointerCanonicalizationPattern : ConversionPattern {
   PointerCanonicalizationPattern(MLIRContext *context,
                                  llvm::SetVector<Operation *> &opsToRewrite,
                                  FatPointers &fatPtrs,
+                                 const MemOpHints &memOpHints,
                                  llvm::SmallPtrSet<Block *, 8> &convertedBlocks,
                                  PatternBenefit benefit = 1)
       : ConversionPattern(SourceOp::getOperationName(), benefit, context),
-        fatPtrs(fatPtrs), opToRewrite(opsToRewrite),
+        fatPtrs(fatPtrs), memOpHints(memOpHints), opToRewrite(opsToRewrite),
         convertedBlocks(convertedBlocks) {}
 
   LogicalResult
@@ -669,6 +713,7 @@ struct PointerCanonicalizationPattern : ConversionPattern {
                    ConversionPatternRewriter &rewriter) const = 0;
 
   FatPointers &fatPtrs;
+  const MemOpHints &memOpHints;
   llvm::SetVector<Operation *> &opToRewrite;
   llvm::SmallPtrSet<Block *, 8> &convertedBlocks;
 };
@@ -783,8 +828,8 @@ public:
       return rewriteSmallTensorPtr(addPtrOp, adaptor, rewriter);
 
     // Query all discardable attributes that we want to preserve
-    SmallVector<NamedAttribute> propagatedAttrs = tt::filterDiscardableAttrs(
-        addPtrOp.getOperation(), getPropagatedAttrNames());
+    SmallVector<NamedAttribute> propagatedAttrs =
+        tt::filterDiscardableAttrs(addPtrOp.getOperation(), getHintAttrNames());
     auto currPtrTy = llvm::dyn_cast<RankedTensorType>(addPtrOp.getType());
     int currPtrRank = currPtrTy ? currPtrTy.getRank() : 1;
     auto doSetDiscardableAttrs = [&](tt::AddPtrOp newAddPtrOp) {
@@ -891,10 +936,6 @@ private:
     rewriter.setInsertionPoint(addPtrOp);
 
     const auto &oldAttr = fatPtrs.at({fatPtrBase, fatPtrOffset});
-
-    // Query all discardable attributes that we want to preserve
-    SmallVector<NamedAttribute> propagatedAttrs = tt::filterDiscardableAttrs(
-        addPtrOp.getOperation(), getPropagatedAttrNames());
 
     LDBG("smal-tensor addPtr: " << addPtrOp);
     LDBG("   - isSmallTensor: " << oldAttr.isSmallTensor);
@@ -1065,16 +1106,6 @@ private:
     auto nextFatPtr = std::pair{fatPtrBase, newOffset};
     fatPtrs[nextFatPtr] = oldAttr;
     fatPtrs[nextFatPtr].canNarrow = false;
-    // Add the attributes we want to preserve into the table. They
-    // are attached to the op later, in createTensorPointer. An attribute
-    // from a previous addptr describes the pointer before this addptr's
-    // offset operand was folded in, which can break it (a 16-byte aligned
-    // pointer plus a runtime offset is no longer 16-byte aligned), so erase
-    // those attributes instead of merging into them.
-    for (StringRef name : getPropagatedAttrNames())
-      fatPtrs[nextFatPtr].attributes.erase(name);
-    for (const NamedAttribute &attr : propagatedAttrs)
-      fatPtrs[nextFatPtr].attributes[attr.getName().strref()] = attr.getValue();
 
     return success();
   }
@@ -1736,8 +1767,10 @@ public:
     const FatPointers::FatPtrAttrs &fatPtrAttrs =
         this->fatPtrs.at({fatPtrBase, fatPtrOffset});
     SmallVector<Value> operands = op->getOperands();
-    operands[PtrLikeIdx] = createTensorPointer(
-        rewriter, fatPtrBase, fatPtrOffset, curLoc, fatPtrAttrs);
+    Value newPtr = createTensorPointer(rewriter, fatPtrBase, fatPtrOffset,
+                                       curLoc, fatPtrAttrs);
+    reattachMemOpHints(this->memOpHints, fatPtrAttrs, op, PtrLikeIdx, newPtr);
+    operands[PtrLikeIdx] = newPtr;
 
     if (op->getNumResults())
       rewriter.replaceOpWithNewOp<SourceOp>(
@@ -2050,6 +2083,10 @@ void TritonAMDGPUCanonicalizePointersPass::runOnOperation() {
     return;
 
   FatPointers fatPrs;
+  // Must run before the rewrites start replacing the tt.addptr ops.
+  MemOpHints memOpHints;
+  collectMemOpHints(func, memOpHints);
+
   PatternRewriter rewriter(&getContext());
   // Convert tt.func; %1 = unrealize_cast(%arg0: tt.ptr, c0: i32) -> tt.ptr
   InitFuncPtrArgs pat(&getContext(), fatPrs, enableLargeTensorPtrCanon);
@@ -2134,7 +2171,7 @@ void TritonAMDGPUCanonicalizePointersPass::runOnOperation() {
       ConvertExpandDims, ConvertReshape, ConvertSCFYieldOp, ConvertSCFIfOp,
       ConvertSCFConditionOp, ConvertSCFWhileOp, ConvertCFCondBranch,
       ConvertCFBranch, ConvertArithSelectOp, ConvertReturnOp>(
-      patterns.getContext(), opsToRewrite, fatPrs, convertedBlocks);
+      patterns.getContext(), opsToRewrite, fatPrs, memOpHints, convertedBlocks);
   if (failed(applyPartialConversion(func, target, std::move(patterns), config)))
     return signalPassFailure();
 
@@ -2143,7 +2180,7 @@ void TritonAMDGPUCanonicalizePointersPass::runOnOperation() {
   target.addIllegalOp<UnrealizedConversionCastOp>();
   patterns.clear();
   patterns.add<ConvertUnimplementedOpUnrealizedCasts>(
-      patterns.getContext(), opsToRewrite, fatPrs, convertedBlocks);
+      patterns.getContext(), opsToRewrite, fatPrs, memOpHints, convertedBlocks);
   if (failed(applyPartialConversion(func, target, std::move(patterns), config)))
     return signalPassFailure();
 

--- a/third_party/amd/lib/TritonAMDGPUTransforms/CanonicalizePointers.cpp
+++ b/third_party/amd/lib/TritonAMDGPUTransforms/CanonicalizePointers.cpp
@@ -560,6 +560,27 @@ void FatPointers::collectFatPointerAttributes(const KeyT &k) {
     pointerAttrs[k]->attributes[baseAttr.getName()] = baseAttr.getValue();
 }
 
+static ArrayRef<StringRef> getPropagatedAttrNames() {
+  static constexpr StringRef names[] = {"tt.divisibility", "tt.contiguity",
+                                        "tt.constancy"};
+  return names;
+}
+
+// The attributes carry one entry per tensor dimension and AxisInfoAnalysis
+// reads them back indexed by the op's rank. An attribute whose length disagrees
+// with the destination pointer rank would produce an inconsistent AxisInfo
+// (reading out of bounds), so only propagate an attr when its rank matches the
+// target; attributes outside getPropagatedAttrNames have no per-dimension data
+// and are always safe.
+static bool attrRankMatchesTarget(StringRef name, Attribute attr,
+                                  int64_t targetRank) {
+  if (!llvm::is_contained(getPropagatedAttrNames(), name))
+    return true;
+  if (auto dense = dyn_cast<DenseElementsAttr>(attr))
+    return dense.getNumElements() == targetRank;
+  return targetRank == 1;
+}
+
 Value createTensorPointer(RewriterBase &rewriter, Value basePtr, Value offset,
                           Location loc,
                           const FatPointers::FatPtrAttrs &fatPtrAttrs) {
@@ -570,7 +591,8 @@ Value createTensorPointer(RewriterBase &rewriter, Value basePtr, Value offset,
     auto addPtrOp =
         tt::AddPtrOp::create(rewriter, loc, basePtr.getType(), basePtr, offset);
     for (const auto &attribute : fatPtrAttrs.attributes)
-      addPtrOp->setAttr(attribute.first, attribute.second);
+      if (attrRankMatchesTarget(attribute.first, attribute.second, /*rank=*/1))
+        addPtrOp->setAttr(attribute.first, attribute.second);
     return addPtrOp.getResult();
   }
 
@@ -592,7 +614,9 @@ Value createTensorPointer(RewriterBase &rewriter, Value basePtr, Value offset,
       tt::AddPtrOp::create(rewriter, loc, tensorPtrType, tensorPtr, offset);
 
   for (const auto &attribute : fatPtrAttrs.attributes)
-    addPtrOp->setAttr(attribute.first, attribute.second);
+    if (attrRankMatchesTarget(attribute.first, attribute.second,
+                              tensorType.getRank()))
+      addPtrOp->setAttr(attribute.first, attribute.second);
   return addPtrOp.getResult();
 }
 
@@ -759,10 +783,8 @@ public:
       return rewriteSmallTensorPtr(addPtrOp, adaptor, rewriter);
 
     // Query all discardable attributes that we want to preserve
-    std::array<StringRef, 3> propagateList{"tt.divisibility", "tt.contiguity",
-                                           "tt.constancy"};
-    SmallVector<NamedAttribute> propagatedAttrs =
-        tt::filterDiscardableAttrs(addPtrOp.getOperation(), propagateList);
+    SmallVector<NamedAttribute> propagatedAttrs = tt::filterDiscardableAttrs(
+        addPtrOp.getOperation(), getPropagatedAttrNames());
     auto currPtrTy = llvm::dyn_cast<RankedTensorType>(addPtrOp.getType());
     int currPtrRank = currPtrTy ? currPtrTy.getRank() : 1;
     auto doSetDiscardableAttrs = [&](tt::AddPtrOp newAddPtrOp) {
@@ -869,6 +891,10 @@ private:
     rewriter.setInsertionPoint(addPtrOp);
 
     const auto &oldAttr = fatPtrs.at({fatPtrBase, fatPtrOffset});
+
+    // Query all discardable attributes that we want to preserve
+    SmallVector<NamedAttribute> propagatedAttrs = tt::filterDiscardableAttrs(
+        addPtrOp.getOperation(), getPropagatedAttrNames());
 
     LDBG("smal-tensor addPtr: " << addPtrOp);
     LDBG("   - isSmallTensor: " << oldAttr.isSmallTensor);
@@ -1039,6 +1065,16 @@ private:
     auto nextFatPtr = std::pair{fatPtrBase, newOffset};
     fatPtrs[nextFatPtr] = oldAttr;
     fatPtrs[nextFatPtr].canNarrow = false;
+    // Add the attributes we want to preserve into the table. They
+    // are attached to the op later, in createTensorPointer. An attribute
+    // from a previous addptr describes the pointer before this addptr's
+    // offset operand was folded in, which can break it (a 16-byte aligned
+    // pointer plus a runtime offset is no longer 16-byte aligned), so erase
+    // those attributes instead of merging into them.
+    for (StringRef name : getPropagatedAttrNames())
+      fatPtrs[nextFatPtr].attributes.erase(name);
+    for (const NamedAttribute &attr : propagatedAttrs)
+      fatPtrs[nextFatPtr].attributes[attr.getName().strref()] = attr.getValue();
 
     return success();
   }


### PR DESCRIPTION
`tritonamdgpu-canonicalize-pointers` preserves addptr's discardable attributes (tt.divisibility, tt.contiguity, tt.constancy) when it rewrites the pointer, but only on the general (large-tensor) path, and only when the rank of the old and the new pointer match. 

On the small-tensor path (i.e., if `tt.pointer_range = 32`), the rewrite rebuilds the pointers without propagating these attributes, so they are silently dropped.

This PR:
- **Adds support for propagating attributes on the small-tensor pointer path**: It uses `MemOpHints`, a mapping between the op and the hint, which gets recorded before the pointer is rewritten, and then re-stamped after the pointer is rewritten. The hints are preserved on tt.addptr ops only; propagating hints on other ops is brittle and unsafe in the general case. Therefore, hints survive only when the tt.addptr feeds the access directly, or when the offset collapses onto the scalar base. Broadcast, reshape, and loop-carried block arguments all drop them. 
- **Adds several LIT test cases**:
  - `@propagate_divisibility_small_ptr`: Minimal usecase where we propagate the attributes
  - `@no_divisibility_leak_small_ptr`: Case with 2 `tt.addptr`: the 2nd should not take the first op's attributes
  - `@drop_rank_mismatched_attr`: Negative case where the attribute has a rank mismatch and we should not propagate it
  - `@propagate_hints_scalar_ptr`: Case where hint is a scalar (`tt.divisibility = 16 : i32`) instead of a ranked tensor
  - `@drop_hints_into_loop_body`: Case with a loop; hint must be dropped, propagating would be unsafe
  - `@propagate_2d_hints_small_ptr`: Case to show that 2D hints are propagated too
  - `@drop_hints_across_reshape`: If there is an op between the tt.addptr and the tt.load, hints are not propagated
  - `@drop_hints_across_broadcast`: Same, altough broadcast does not invalidate the hints (IR would be correct) we also skip the hints (conservative)
