### PR TITLE
[Backend] Use single shuffle for warp-flip in reversed scan

### DIFF
--- a/lib/Conversion/TritonGPUToLLVM/ScanOpToLLVM.cpp
+++ b/lib/Conversion/TritonGPUToLLVM/ScanOpToLLVM.cpp
@@ -435,7 +435,8 @@ unpackInputs(Location loc, triton::ScanOp op, triton::ScanOpAdaptor adaptor,
 }
 
 // Flip the srcValues. Both reverses the chunks and reverses the lanes.
-// Lane reversal is done with a butterfly shuffle flip (divide and flip).
+// Lane reversal is done with a single butterfly shuffle: for power-of-two
+// warp sizes, `lane ^ (iWarpSize - 1)` equals `(iWarpSize - 1) - lane`.
 SmallVector<SmallVector<Value>>
 flipSrcValues(Location loc, triton::ScanOp op,
               ConversionPatternRewriter &rewriter,
@@ -445,10 +446,8 @@ flipSrcValues(Location loc, triton::ScanOp op,
   for (int i = 0; i < srcValues.size(); ++i) {
     int revIndex = srcValues.size() - i - 1;
     for (unsigned j = 0; j < op.getNumOperands(); ++j) {
-      for (unsigned k = iWarpSize / 2; k >= 1; k = k / 2) {
-        srcValues[revIndex][j] =
-            targetInfo.shuffleXor(rewriter, loc, srcValues[revIndex][j], k);
-      }
+      srcValues[revIndex][j] = targetInfo.shuffleXor(
+          rewriter, loc, srcValues[revIndex][j], iWarpSize - 1);
       values[i].push_back(srcValues[revIndex][j]);
     }
   }

--- a/test/Conversion/scan_to_llvm.mlir
+++ b/test/Conversion/scan_to_llvm.mlir
@@ -47,15 +47,12 @@ tt.func private @test_2d_grouped(%arg0: tensor<16x1xi32, #layout_2d>) -> tensor<
 
 // CHECK-LABEL: @test_1d_reversed
 tt.func private @test_1d_reversed(%arg0: tensor<8xi32, #layout>) -> tensor<8xi32, #layout> {
-  // CHECK: [[FLIP0:%.*]] = tail call i32 @llvm.nvvm.shfl.sync.bfly.i32(i32 -1, i32 %{{.*}}, i32 8, i32 31)
-  // CHECK: [[FLIP1:%.*]] = tail call i32 @llvm.nvvm.shfl.sync.bfly.i32(i32 -1, i32 [[FLIP0]], i32 4, i32 31)
-  // CHECK: [[FLIP2:%.*]] = tail call i32 @llvm.nvvm.shfl.sync.bfly.i32(i32 -1, i32 [[FLIP1]], i32 2, i32 31)
-  // CHECK: [[FLIP3:%.*]] = tail call i32 @llvm.nvvm.shfl.sync.bfly.i32(i32 -1, i32 [[FLIP2]], i32 1, i32 31)
-  // CHECK: tail call i32 @llvm.nvvm.shfl.sync.up.i32
-  // CHECK: [[UNFLIP0:%.*]] = tail call i32 @llvm.nvvm.shfl.sync.bfly.i32(i32 -1, i32 %{{.*}}, i32 8, i32 31)
-  // CHECK: [[UNFLIP1:%.*]] = tail call i32 @llvm.nvvm.shfl.sync.bfly.i32(i32 -1, i32 [[UNFLIP0]], i32 4, i32 31)
-  // CHECK: [[UNFLIP2:%.*]] = tail call i32 @llvm.nvvm.shfl.sync.bfly.i32(i32 -1, i32 [[UNFLIP1]], i32 2, i32 31)
-  // CHECK: tail call i32 @llvm.nvvm.shfl.sync.bfly.i32(i32 -1, i32 [[UNFLIP2]], i32 1, i32 31)
+  // CHECK-NOT: @llvm.nvvm.shfl.sync.bfly.i32
+  // CHECK: [[FLIPPED:%.*]] = tail call i32 @llvm.nvvm.shfl.sync.bfly.i32(i32 -1, i32 %{{.*}}, i32 15, i32 31)
+  // CHECK-NEXT: [[FIRST_SCAN:%.*]] = tail call i32 @llvm.nvvm.shfl.sync.up.i32(i32 -1, i32 [[FLIPPED]], i32 1, i32 0)
+  // CHECK-NOT: @llvm.nvvm.shfl.sync.bfly.i32
+  // CHECK: [[UNFLIPPED:%.*]] = tail call i32 @llvm.nvvm.shfl.sync.bfly.i32(i32 -1, i32 %{{.*}}, i32 15, i32 31)
+  // CHECK-NEXT: ret i32 [[UNFLIPPED]]
   %0 = "tt.scan"(%arg0) <{axis = 0 : i32, reverse = true}> ({
   ^bb0(%arg1: i32, %arg2: i32):
     %1 = arith.addi %arg1, %arg2 : i32

--- a/test/Conversion/scan_to_llvm.mlir
+++ b/test/Conversion/scan_to_llvm.mlir
@@ -45,6 +45,25 @@ tt.func private @test_2d_grouped(%arg0: tensor<16x1xi32, #layout_2d>) -> tensor<
   tt.return %0 : tensor<16x1xi32, #layout_2d>
 }
 
+// CHECK-LABEL: @test_1d_reversed
+tt.func private @test_1d_reversed(%arg0: tensor<8xi32, #layout>) -> tensor<8xi32, #layout> {
+  // CHECK: [[FLIP0:%.*]] = tail call i32 @llvm.nvvm.shfl.sync.bfly.i32(i32 -1, i32 %{{.*}}, i32 8, i32 31)
+  // CHECK: [[FLIP1:%.*]] = tail call i32 @llvm.nvvm.shfl.sync.bfly.i32(i32 -1, i32 [[FLIP0]], i32 4, i32 31)
+  // CHECK: [[FLIP2:%.*]] = tail call i32 @llvm.nvvm.shfl.sync.bfly.i32(i32 -1, i32 [[FLIP1]], i32 2, i32 31)
+  // CHECK: [[FLIP3:%.*]] = tail call i32 @llvm.nvvm.shfl.sync.bfly.i32(i32 -1, i32 [[FLIP2]], i32 1, i32 31)
+  // CHECK: tail call i32 @llvm.nvvm.shfl.sync.up.i32
+  // CHECK: [[UNFLIP0:%.*]] = tail call i32 @llvm.nvvm.shfl.sync.bfly.i32(i32 -1, i32 %{{.*}}, i32 8, i32 31)
+  // CHECK: [[UNFLIP1:%.*]] = tail call i32 @llvm.nvvm.shfl.sync.bfly.i32(i32 -1, i32 [[UNFLIP0]], i32 4, i32 31)
+  // CHECK: [[UNFLIP2:%.*]] = tail call i32 @llvm.nvvm.shfl.sync.bfly.i32(i32 -1, i32 [[UNFLIP1]], i32 2, i32 31)
+  // CHECK: tail call i32 @llvm.nvvm.shfl.sync.bfly.i32(i32 -1, i32 [[UNFLIP2]], i32 1, i32 31)
+  %0 = "tt.scan"(%arg0) <{axis = 0 : i32, reverse = true}> ({
+  ^bb0(%arg1: i32, %arg2: i32):
+    %1 = arith.addi %arg1, %arg2 : i32
+    tt.scan.return %1 : i32
+  }) : (tensor<8xi32, #layout>) -> tensor<8xi32, #layout>
+  tt.return %0 : tensor<8xi32, #layout>
+}
+
 // This just prevents the test functions from being DCE'd.
 tt.func public @anchor(%ptr: !llvm.ptr, %arg0: !llvm.struct<(i32)>, %arg1: !llvm.struct<(i32, i32)>, %arg2: !llvm.struct<(i32)>) {
   %0 = builtin.unrealized_conversion_cast %arg0 : !llvm.struct<(i32)> to tensor<8xi32, #layout>
@@ -61,6 +80,10 @@ tt.func public @anchor(%ptr: !llvm.ptr, %arg0: !llvm.struct<(i32)>, %arg1: !llvm
   %7 = tt.call @test_2d_grouped(%6) : (tensor<16x1xi32, #layout_2d>) -> tensor<16x1xi32, #layout_2d>
   %8 = builtin.unrealized_conversion_cast %7 : tensor<16x1xi32, #layout_2d> to !llvm.struct<(i32)>
   llvm.store volatile %8, %ptr : !llvm.struct<(i32)>, !llvm.ptr
+
+  %9 = tt.call @test_1d_reversed(%0) : (tensor<8xi32, #layout>) -> tensor<8xi32, #layout>
+  %10 = builtin.unrealized_conversion_cast %9 : tensor<8xi32, #layout> to !llvm.struct<(i32)>
+  llvm.store volatile %10, %ptr : !llvm.struct<(i32)>, !llvm.ptr
 
   tt.return
 }


### PR DESCRIPTION
Currently, a reversed scan is implemented as `flip(scan(flip))`.  Flipping is implemented as `log2(warpSize)` rounds of shuffles at warp-level. where thread `i` shuffle with thread `i ^ warpSize/2`, …, `i ^1`.

However given the algebraic identity `x ^ 0b11…1 + x = 0b11..1`, the same warp reversal operation can be done in just one `shuffleXor` with `warpSize - 1`(`=0b11..1 `for power of 2 `warpSize`). e.g. for warpSize = 32, thread 0 shuffle with 31, thread 1 shuffle with 30, etc.

Counting both flip and unflip this saves 8 shuffles for NVIDIA 32 thread warps and 10 for AMD wave64 per reversed scan.

```python
  @triton.jit
  def reverse_scan_kernel(x_ptr, out_ptr):
      offsets = tl.arange(0, 32)
      x = tl.load(x_ptr + offsets)

      # Lowers to tt.scan with reverse=true.
      y = tl.cumsum(x, axis=0, reverse=True)

      tl.store(out_ptr + offsets, y)

  # ptx: before
  # // flip: reverse all 32 lanes
  #   shfl.sync.bfly.b32 %r5,  %r1,  16, 31, -1;
  #   shfl.sync.bfly.b32 %r6,  %r5,   8, 31, -1;
  #   shfl.sync.bfly.b32 %r7,  %r6,   4, 31, -1;
  #   shfl.sync.bfly.b32 %r8,  %r7,   2, 31, -1;
  #   shfl.sync.bfly.b32 %r9,  %r8,   1, 31, -1;
  # //  scan: 
  #   ...
  # // unflip: restore lane order
  #   shfl.sync.bfly.b32 %r25, %r24, 16, 31, -1;
  #   shfl.sync.bfly.b32 %r26, %r25,  8, 31, -1;
  #   shfl.sync.bfly.b32 %r27, %r26,  4, 31, -1;
  #   shfl.sync.bfly.b32 %r28, %r27,  2, 31, -1;
  #   shfl.sync.bfly.b32 %r2,  %r28,  1, 31, -1;
  
  # ptx: after
  # // flip: reverse all 32 lanes with lane_id ^ 31
  #   shfl.sync.bfly.b32 %r5,  %r1,  31, 31, -1;
  # // inclusive scan:
  #   ...
  # // unflip: restore lane order with lane_id ^ 31
  #   shfl.sync.bfly.b32 %r2,  %r20, 31, 31, -1;
```

<!---
The core Triton is a small number of people, and we receive many PRs (thank
you!).  To help us review your code more quickly, **if you are a new
contributor (less than 3 PRs merged) we ask that you complete the following
tasks and include the filled-out checklist in your PR description.**

Complete the following tasks before sending your PR, and replace `[ ]` with
`[x]` to indicate you have done them.
-->

# New contributor declaration
- [x] I am not making a trivial change, such as fixing a typo in a comment.

- [x] I have written a PR description following these
  [rules](https://cbea.ms/git-commit/#why-not-how).

- [x] I have run `pre-commit run --from-ref origin/main --to-ref HEAD`.

- Select one of the following.
  - [x] I have added tests.
    - `/test` for `lit` tests
    - `/unittest` for C++ tests
    - `/python/test` for end-to-end tests
  - [ ] This PR does not need a test because `FILL THIS IN`.

- Select one of the following.
  - [ ] I have not added any `lit` tests.
  - [x] The `lit` tests I have added follow these [best practices](https://mlir.llvm.org/getting_started/TestingGuide/#filecheck-best-practices),
    including the "tests should be minimal" section. (Usually running Python code
    and using the instructions it generates is not minimal.)
