### PR TITLE
fix(autotuner): reject invalid top_k values

### DIFF
--- a/python/test/unit/runtime/test_autotuner.py
+++ b/python/test/unit/runtime/test_autotuner.py
@@ -310,6 +310,52 @@ def test_prune_configs_fractional_top_k_after_early_prune():
     assert benchmarked == [1, 2, 3]
 
 
+@pytest.mark.parametrize(
+    ("top_k", "error_type"),
+    [
+        (0, ValueError),
+        (-1, ValueError),
+        (0.0, ValueError),
+        (-0.5, ValueError),
+        (1.1, ValueError),
+        (float("nan"), ValueError),
+        (float("inf"), ValueError),
+        (float("-inf"), ValueError),
+        (True, TypeError),
+        (False, TypeError),
+        (None, TypeError),
+        ("1", TypeError),
+    ],
+)
+def test_prune_configs_rejects_invalid_top_k(top_k, error_type):
+    configs = [triton.Config(kwargs={'BLOCK_SIZE': block_size}) for block_size in range(1, 4)]
+
+    class Kernel:
+
+        def __init__(self):
+            self.fn = lambda: None
+
+        def run(self, **kwargs):
+            pass
+
+    tuner = triton.runtime.Autotuner(
+        Kernel(),
+        arg_names=[],
+        configs=configs,
+        key=[],
+        reset_to_zero=None,
+        restore_value=None,
+        do_bench=lambda kernel_call, quantiles: [1.0] * 3,
+        prune_configs_by={
+            'perf_model': lambda **kwargs: kwargs['BLOCK_SIZE'],
+            'top_k': top_k,
+        },
+    )
+
+    with pytest.raises(error_type, match="top_k must be a positive integer or a float in the range"):
+        tuner.run()
+
+
 def test_config_ir_override_changes_disk_cache_key():
     # Autotuner derives persisted result-cache keys from Config.__str__().
     first = triton.Config(kwargs={"BLOCK_SIZE": 32}, ir_override="first.ttir")

--- a/python/triton/runtime/autotuner.py
+++ b/python/triton/runtime/autotuner.py
@@ -24,7 +24,8 @@ class Autotuner(KernelInterface):
         """
         :param prune_configs_by: a dict of functions that are used to prune configs, fields:
             'perf_model': performance model used to predicate running time with different configs, returns running time
-            'top_k': number of configs to bench
+            'top_k': number of configs to bench (a positive integer), or fraction of configs to bench
+                (a float in (0.0, 1.0])
             'early_config_prune': a function used to prune configs. It should have the signature
                 `prune_configs_by( configs: List[triton.Config], named_args: Dict[str, Any], **kwargs: Dict[str, Any]) -> List[triton.Config]:`
                 and return pruned configs. It should return at least one config.
@@ -290,15 +291,20 @@ class Autotuner(KernelInterface):
                     "No valid autotuner configs after pruning. `early_config_prune` should return at least one config.")
         if self.perf_model:
             top_k = self.configs_top_k
-            if isinstance(top_k, float) and top_k <= 1.0:
+            top_k_error = ("Error while pruning configs, top_k must be a positive integer or a float in the "
+                           "range (0.0, 1.0]")
+            if isinstance(top_k, bool) or not isinstance(top_k, (float, int)):
+                raise TypeError(top_k_error)
+            elif isinstance(top_k, float):
+                if not 0.0 < top_k <= 1.0:
+                    raise ValueError(top_k_error)
                 # Keep at least one config: a small fraction over a small config
                 # set rounds down to zero, which would prune everything and crash
                 # the later min() on an empty set. early_config_prune already
                 # guarantees at least one config; mirror that here.
                 top_k = max(1, int(len(pruned_configs) * top_k))
-            elif not isinstance(top_k, int):
-                # Slice index must be an integer
-                raise TypeError("Error while pruning configs, top_k must be either 1) a float <= 1.0 or 2) an int")
+            elif top_k <= 0:
+                raise ValueError(top_k_error)
 
             if len(pruned_configs) > top_k:
                 est_timing = {
@@ -439,7 +445,8 @@ def autotune(configs, key, prune_configs_by=None, reset_to_zero=None, restore_va
     :type key: list[str]
     :param prune_configs_by: a dict of functions that are used to prune configs, fields:
         'perf_model': performance model used to predicate running time with different configs, returns running time
-        'top_k': number of configs to bench
+        'top_k': number of configs to bench (a positive integer), or fraction of configs to bench
+            (a float in (0.0, 1.0])
         'early_config_prune': a function used to prune configs. It should have the signature
                 `prune_configs_by( configs: List[triton.Config], named_args: Dict[str, Any], **kwargs: Dict[str, Any]) -> List[triton.Config]:`
                 and return pruned configs. It should return at least one config.


### PR DESCRIPTION
Fixes #11072.

`prune_configs_by["top_k"]` is documented as the number or fraction of
autotuner configurations to benchmark, but its value range was not validated.

As a result, `top_k=0` eventually failed while selecting from an empty timing
set, negative integers became Python slice bounds, and non-positive fractions
silently retained one configuration. Float values outside the supported range
instead produced a misleading type error.

This defines and enforces the intended contract:

- integers must be positive;
- floats must be in `(0.0, 1.0]`;
- booleans and other types are rejected.

Validation remains in the performance-model pruning path, after
`early_config_prune`. Fractions therefore continue to be calculated from the
surviving candidate set, and `top_k` remains inactive when no performance
model is configured.

The parameterized regression test exercises zero and negative integers,
out-of-range finite floats, NaN, both infinities, booleans, and non-numeric
values through `Autotuner.run()`.

## Regression proof

The before-fix behaviors were reproduced through the public
`Autotuner.run()` pruning path. The relevant pruning branches remain present
at this branch's base `56f47b51df09`:

| `top_k` | Base behavior | Behavior with this change |
|---|---|---|
| `0` | Produces an empty timing set and later fails in `min()` | `ValueError` |
| negative integer | Becomes a negative slice bound | `ValueError` |
| non-positive float | Silently retains one configuration | `ValueError` |
| float above `1.0`, NaN, infinity | Misleading `TypeError` | `ValueError` |
| boolean or non-numeric value | Inherits integer behavior or fails later | `TypeError` |

The parameterized validation test exercises those branches and passes with the
range/type checks. The existing fractional-after-early-prune test remains
green.

## Test plan

```text
TRITON_INTERPRET=1 python3 -m pytest -s --tb=short \
  python/test/unit/runtime/test_autotuner.py::test_prune_configs_rejects_invalid_top_k \
  python/test/unit/runtime/test_autotuner.py::test_prune_configs_fractional_top_k_after_early_prune

13 passed
```

# New contributor declaration

- [x] I am not making a trivial change, such as fixing a typo in a comment.

- [x] I have written a PR description following these
  [rules](https://cbea.ms/git-commit/#why-not-how).

- [x] I have run `pre-commit run --from-ref origin/main --to-ref HEAD`.

- Select one of the following.
  - [x] I have added tests.
    - `/test` for `lit` tests
    - `/unittest` for C++ tests
    - `/python/test` for end-to-end tests
  - [ ] This PR does not need a test.

- Select one of the following.
  - [x] I have not added any `lit` tests.
  - [ ] The `lit` tests I have added follow these [best practices](https://mlir.llvm.org/getting_started/TestingGuide/#filecheck-best-practices),
    including the "tests should be minimal" section. (Usually running Python code
    and using the instructions it generates is not minimal.)
