### PR TITLE
[FRONTEND] Support tuple targets in list comprehensions

### DIFF
--- a/python/test/unit/language/test_frontend.py
+++ b/python/test/unit/language/test_frontend.py
@@ -484,6 +484,53 @@ def test_list_comprehension_if_filter():
     run_parser(kernel)
 
 
+def test_list_comprehension_tuple_target():
+
+    @triton.jit
+    def kernel():
+        vals: tl.constexpr = [a + b for a, b in ((1, 2), (3, 4))]
+        tl.static_assert(len(vals) == 2)
+        tl.static_assert(vals[0] == 3)
+        tl.static_assert(vals[1] == 7)
+
+        nested: tl.constexpr = [a + b + c for a, (b, c) in ((1, (2, 3)), (4, (5, 6)))]
+        tl.static_assert(len(nested) == 2)
+        tl.static_assert(nested[0] == 6)
+        tl.static_assert(nested[1] == 15)
+
+    run_parser(kernel)
+
+
+def test_list_comprehension_tuple_target_rejects_mismatch():
+
+    @triton.jit
+    def kernel():
+        vals = [a + b for a, b in ((1, 2, 3), )]  # noqa: F841
+
+    with pytest.raises(CompilationError, match="too many values to unpack"):
+        run_parser(kernel)
+
+
+def test_list_comprehension_tuple_target_rejects_scalar_item():
+
+    @triton.jit
+    def kernel():
+        vals = [a + b for a, b in (1, 2)]  # noqa: F841
+
+    with pytest.raises(CompilationError, match="cannot unpack non-iterable value"):
+        run_parser(kernel)
+
+
+def test_list_comprehension_tuple_target_rejects_starred_target():
+
+    @triton.jit
+    def kernel():
+        vals = [a for a, *rest in ((1, 2, 3), )]  # noqa: F841
+
+    with pytest.raises(CompilationError, match="starred assignment targets are not supported"):
+        run_parser(kernel)
+
+
 def test_named_expr_respects_prior_constexpr_annotation():
 
     @triton.jit

--- a/python/triton/compiler/code_generator.py
+++ b/python/triton/compiler/code_generator.py
@@ -544,7 +544,9 @@ class CodeGenerator(ast.NodeVisitor):
 
         results = []
         for item in iter:
-            self.set_value(comp.target.id, item)
+            if isinstance(comp.target, ast.Tuple):
+                item = self._sanitize_target_value(comp.target, item, sanitize_leaf=False)
+            self.assignTarget(comp.target, item)
             # Apply the comprehension's `if` filters (the conditions are constexpr).
             if all(self.visit(cond) for cond in comp.ifs):
                 results.append(self.visit(node.elt))
@@ -734,8 +736,8 @@ class CodeGenerator(ast.NodeVisitor):
         assert isinstance(target, ast.Name)
         self.set_value(self.visit(target), value)
 
-    def visit_Assign(self, node):
-        # construct values to assign
+    def _sanitize_target_value(self, target, value, sanitize_leaf=True):
+
         def _sanitize_value(value):
             if isinstance(value, language.tuple):
                 return _apply_to_tuple_values(value, _sanitize_value)
@@ -747,36 +749,38 @@ class CodeGenerator(ast.NodeVisitor):
                 value = self.semantic.to_tensor(value)
             return value
 
-        def _sanitize_target_value(target, value):
-            if isinstance(target, ast.Tuple) and isinstance(value, language.tuple):
-                if any(isinstance(elt, ast.Starred) for elt in target.elts):
-                    raise NotImplementedError("starred assignment targets are not supported")
-                num_targets, num_values = len(target.elts), len(value.values)
-                if num_targets != num_values:
-                    # Match CPython's errors for mismatched unpacking.
-                    if num_values > num_targets:
-                        message = f"too many values to unpack (expected {num_targets})"
-                    else:
-                        message = f"not enough values to unpack (expected {num_targets}, got {num_values})"
-                    raise ValueError(message)
-                vals = [_sanitize_target_value(elt, val) for elt, val in zip(target.elts, value.values)]
-                vals = [constexpr(val) if val is None else val for val in vals]
-                types = [val.type for val in vals]
-                return language.tuple(vals, language.tuple_type(types, value.type.fields))
-            if isinstance(target, ast.Name):
-                annotation = self.pending_annotations.pop(target.id, None)
-                if annotation == constexpr:
-                    return normalize_value(value)
-            return _sanitize_value(value)
+        if isinstance(target, ast.Tuple):
+            if not isinstance(value, language.tuple):
+                raise TypeError("cannot unpack non-iterable value")
+            if any(isinstance(elt, ast.Starred) for elt in target.elts):
+                raise NotImplementedError("starred assignment targets are not supported")
+            num_targets, num_values = len(target.elts), len(value.values)
+            if num_targets != num_values:
+                # Match CPython's errors for mismatched unpacking.
+                if num_values > num_targets:
+                    message = f"too many values to unpack (expected {num_targets})"
+                else:
+                    message = f"not enough values to unpack (expected {num_targets}, got {num_values})"
+                raise ValueError(message)
+            vals = [self._sanitize_target_value(elt, val, sanitize_leaf) for elt, val in zip(target.elts, value.values)]
+            vals = [constexpr(val) if val is None else val for val in vals]
+            types = [val.type for val in vals]
+            return language.tuple(vals, language.tuple_type(types, value.type.fields))
+        if isinstance(target, ast.Name):
+            annotation = self.pending_annotations.pop(target.id, None)
+            if annotation == constexpr:
+                return normalize_value(value)
+        return _sanitize_value(value) if sanitize_leaf else value
 
+    def visit_Assign(self, node):
         targets = [node.target] if isinstance(node, ast.AnnAssign) else node.targets
         assert len(targets) == 1
         target = targets[0]
         if isinstance(target, ast.Name):
             with self._name_loc_prefix(target.id):
-                values = _sanitize_target_value(target, self.visit(node.value))
+                values = self._sanitize_target_value(target, self.visit(node.value))
         else:
-            values = _sanitize_target_value(target, self.visit(node.value))
+            values = self._sanitize_target_value(target, self.visit(node.value))
         self.assignTarget(target, values)
 
     def visit_AugAssign(self, node):


### PR DESCRIPTION
Fixes #11073.

`CodeGenerator.visit_ListComp` bound each iteration value by reading
`comp.target.id`, which only works for a single-name target. A comprehension
such as:

```python
[a + b for a, b in ((1, 2), (3, 4))]
```

therefore failed during AST lowering instead of unpacking each tuple.

This moves assignment-target validation into a shared `CodeGenerator` method
and routes tuple comprehension targets through the existing recursive
`assignTarget` path. The two callers share structure validation but retain
their required leaf behavior:

```text
ordinary assignment ─┐
                     ├─ validate tuple shape/arity/starred targets ─┬─ sanitize assignment leaves
tuple comprehension ─┘                                             └─ preserve constexpr leaves
                                                                       │
                                                                       └─ recursively bind names
```

Preserving comprehension leaves matters because converting them to tensors
would make a constexpr comprehension fail later `tl.static_assert` checks.
Scalar iteration items now produce a controlled `cannot unpack` diagnostic
instead of an internal `.values` attribute error.

Parser-only regression tests cover simple and nested tuple targets, arity
mismatch, scalar items, starred targets, and the existing ordinary tuple
assignment diagnostics.

This change is behaviorally distinct from #11023, which addresses
comprehension scope restoration, but it touches the same lowering and should
be rebased or coordinated with that PR.

## Regression proof

The pre-fix visitor reads `comp.target.id`; that path is unchanged at this
branch's base `56f47b51df09`. A tuple target therefore fails before binding
either name:

```text
AttributeError: 'Tuple' object has no attribute 'id'
```

A scalar iteration item also falls through to an internal `.values` attribute
error rather than an unpacking diagnostic. With this change, simple and nested
tuple targets retain constexpr leaves and evaluate to the asserted values;
arity, scalar-item, and starred-target cases reach controlled compilation
diagnostics.

## Test plan

```text
python3 -m pytest -s --tb=short \
  python/test/unit/language/test_frontend.py \
  -k 'list_comprehension_tuple_target or tuple_assignment'

11 passed, 63 deselected
```

# New contributor declaration

- [x] I am not making a trivial change, such as fixing a typo in a comment.

- [x] I have written a PR description following these
  [rules](https://cbea.ms/git-commit/#why-not-how).

- [x] I have run `pre-commit run --from-ref origin/main --to-ref HEAD`.

- Select one of the following.
  - [x] I have added tests.
    - `/test` for `lit` tests
    - `/unittest` for C++ tests
    - `/python/test` for end-to-end tests
  - [ ] This PR does not need a test.

- Select one of the following.
  - [x] I have not added any `lit` tests.
  - [ ] The `lit` tests I have added follow these [best practices](https://mlir.llvm.org/getting_started/TestingGuide/#filecheck-best-practices),
    including the "tests should be minimal" section. (Usually running Python code
    and using the instructions it generates is not minimal.)
