### PR TITLE
[AMD][BACKEND] Fix rank reducing TDM for INNER_DIM > 1024bytes

### DIFF
--- a/python/test/unit/language/test_tensor_descriptor.py
+++ b/python/test/unit/language/test_tensor_descriptor.py
@@ -967,7 +967,7 @@ def test_tensor_descriptor_batched_gemm_3d_tma(device):
 
 @pytest.mark.parametrize("dtype_str", tma_dtypes)
 @pytest.mark.parametrize("ndim", [3, 4, 5])
-@pytest.mark.parametrize("INNER_BLOCK", [16, 32, 64, 128])
+@pytest.mark.parametrize("INNER_BLOCK", [16, 32, 64, 128, 1024])
 def test_tensor_descriptor_rank_reducing_load(dtype_str, ndim, INNER_BLOCK, device):
 
     @triton.jit

--- a/test/TritonGPU/amd/amd-optimize-descriptor-encoding.mlir
+++ b/test/TritonGPU/amd/amd-optimize-descriptor-encoding.mlir
@@ -221,3 +221,22 @@ tt.func public @descriptor_fallback(%arg0: !tt.ptr<f32>, %arg1: i32, %arg2: i32,
   tt.return
 }
 }
+
+// -----
+
+#blocked = #ttg.blocked<{sizePerThread = [4], threadsPerWarp = [32], warpsPerCTA = [4], order = [0]}>
+module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.target = "hip:gfx1250", "ttg.threads-per-warp" = 32 : i32} {
+// CHECK-DAG: #[[$PADDED_AT_LIMIT:.*]] = #ttg.padded_shared<[512:+8] {order = [1, 0], shape = [1, 512]}>
+// CHECK-LABEL: @descriptor_load_rank_reduced_pad
+tt.func public @descriptor_load_rank_reduced_pad(%arg0: !tt.ptr<i16>, %arg1: i64) -> tensor<512xi16, #blocked> {
+  %c0_i32 = arith.constant 0 : i32
+  %c1_i32 = arith.constant 1 : i32
+  %c1_i64 = arith.constant 1 : i64
+  %c512_i32 = arith.constant 512 : i32
+  // CHECK: tt.make_tensor_descriptor {{.*}} : <i16>, <1x512xi16, #[[$PADDED_AT_LIMIT]]>
+  %0 = tt.make_tensor_descriptor %arg0, [%c1_i32, %c512_i32], [%arg1, %c1_i64] : <i16>, <1x512xi16>
+  // CHECK: tt.descriptor_load {{.*}} : !tt.tensordesc<1x512xi16, #[[$PADDED_AT_LIMIT]]> -> tensor<512xi16
+  %1 = tt.descriptor_load %0[%c0_i32, %c0_i32] : !tt.tensordesc<1x512xi16> -> tensor<512xi16, #blocked>
+  tt.return %1 : tensor<512xi16, #blocked>
+}
+}

--- a/test/TritonGPU/amd/amd-optimize-descriptor-encoding.mlir
+++ b/test/TritonGPU/amd/amd-optimize-descriptor-encoding.mlir
@@ -221,22 +221,3 @@ tt.func public @descriptor_fallback(%arg0: !tt.ptr<f32>, %arg1: i32, %arg2: i32,
   tt.return
 }
 }
-
-// -----
-
-#blocked = #ttg.blocked<{sizePerThread = [4], threadsPerWarp = [32], warpsPerCTA = [4], order = [0]}>
-module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.target = "hip:gfx1250", "ttg.threads-per-warp" = 32 : i32} {
-// CHECK-DAG: #[[$PADDED_AT_LIMIT:.*]] = #ttg.padded_shared<[512:+8] {order = [1, 0], shape = [1, 512]}>
-// CHECK-LABEL: @descriptor_load_rank_reduced_pad
-tt.func public @descriptor_load_rank_reduced_pad(%arg0: !tt.ptr<i16>, %arg1: i64) -> tensor<512xi16, #blocked> {
-  %c0_i32 = arith.constant 0 : i32
-  %c1_i32 = arith.constant 1 : i32
-  %c1_i64 = arith.constant 1 : i64
-  %c512_i32 = arith.constant 512 : i32
-  // CHECK: tt.make_tensor_descriptor {{.*}} : <i16>, <1x512xi16, #[[$PADDED_AT_LIMIT]]>
-  %0 = tt.make_tensor_descriptor %arg0, [%c1_i32, %c512_i32], [%arg1, %c1_i64] : <i16>, <1x512xi16>
-  // CHECK: tt.descriptor_load {{.*}} : !tt.tensordesc<1x512xi16, #[[$PADDED_AT_LIMIT]]> -> tensor<512xi16
-  %1 = tt.descriptor_load %0[%c0_i32, %c0_i32] : !tt.tensordesc<1x512xi16> -> tensor<512xi16, #blocked>
-  tt.return %1 : tensor<512xi16, #blocked>
-}
-}

--- a/test/TritonGPU/amd/amd-rank-reduced-descriptor-load.mlir
+++ b/test/TritonGPU/amd/amd-rank-reduced-descriptor-load.mlir
@@ -1,0 +1,45 @@
+// RUN: triton-opt %s -split-input-file --tritonamdgpu-optimize-descriptor-encoding --tritonamdgpu-convert-tensor-ops | FileCheck %s
+
+
+#blocked = #ttg.blocked<{sizePerThread = [8], threadsPerWarp = [32], warpsPerCTA = [4], order = [0]}>
+
+module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.target = "hip:gfx1250", "ttg.threads-per-warp" = 32 : i32} {
+  // CHECK-DAG: #[[$DESC_LAYOUT:.*]] = #ttg.swizzled_shared<{vec = 1, perPhase = 1, maxPhase = 1, order = [1, 0]}>
+  // CHECK-DAG: #[[$ALLOC_LAYOUT:.*]] = #ttg.swizzled_shared<{vec = 1, perPhase = 1, maxPhase = 1, order = [0]}>
+  // CHECK-LABEL: @rank_reduced_descriptor_load_pad_limit
+  // CHECK: tt.make_tensor_descriptor {{.*}} : <i16>, <1x1024xi16, #[[$DESC_LAYOUT]]>
+  // CHECK: amdg.async_tdm_copy_global_to_local {{.*}} : !tt.tensordesc<1x1024xi16, #[[$DESC_LAYOUT]]> -> !ttg.memdesc<1024xi16, #[[$ALLOC_LAYOUT]],
+  tt.func public @rank_reduced_descriptor_load_pad_limit(
+      %base: !tt.ptr<i16>,
+      %stride: i64) -> tensor<1024xi16, #blocked> {
+    %c0_i32 = arith.constant 0 : i32
+    %c1_i32 = arith.constant 1 : i32
+    %c1_i64 = arith.constant 1 : i64
+    %c1024_i32 = arith.constant 1024 : i32
+    %desc = tt.make_tensor_descriptor %base, [%c1_i32, %c1024_i32], [%stride, %c1_i64] : <i16>, <1x1024xi16>
+    %result = tt.descriptor_load %desc[%c0_i32, %c0_i32] : !tt.tensordesc<1x1024xi16> -> tensor<1024xi16, #blocked>
+    tt.return %result : tensor<1024xi16, #blocked>
+  }
+}
+
+// -----
+
+#blocked_multi_cta = #ttg.blocked<{sizePerThread = [8], threadsPerWarp = [32], warpsPerCTA = [4], order = [0], CGALayout = [[1]]}>
+module attributes {"ttg.num-ctas" = 2 : i32, "ttg.num-warps" = 4 : i32, ttg.target = "hip:gfx1250", "ttg.threads-per-warp" = 32 : i32} {
+  // CHECK-DAG: #[[$MC_DESC_LAYOUT:.*]] = #ttg.swizzled_shared<{vec = 1, perPhase = 1, maxPhase = 1, order = [1, 0], CGALayout = {{\[\[0, 1\]\]}}}>
+  // CHECK-DAG: #[[$MC_ALLOC_LAYOUT:.*]] = #ttg.swizzled_shared<{vec = 1, perPhase = 1, maxPhase = 1, order = [0], CGALayout = {{\[\[1\]\]}}}>
+  // CHECK-LABEL: @multi_cta_rank_reduced_descriptor_load
+  // CHECK: tt.make_tensor_descriptor {{.*}} : <i16>, <1x2048xi16, #[[$MC_DESC_LAYOUT]]>
+  // CHECK: amdg.async_tdm_copy_global_to_local {{.*}} : !tt.tensordesc<1x2048xi16, #[[$MC_DESC_LAYOUT]]> -> !ttg.memdesc<2048xi16, #[[$MC_ALLOC_LAYOUT]],
+  tt.func public @multi_cta_rank_reduced_descriptor_load(
+      %base: !tt.ptr<i16>,
+      %stride: i64) -> tensor<2048xi16, #blocked_multi_cta> {
+    %c0_i32 = arith.constant 0 : i32
+    %c1_i32 = arith.constant 1 : i32
+    %c1_i64 = arith.constant 1 : i64
+    %c2048_i32 = arith.constant 2048 : i32
+    %desc = tt.make_tensor_descriptor %base, [%c1_i32, %c2048_i32], [%stride, %c1_i64] : <i16>, <1x2048xi16>
+    %result = tt.descriptor_load %desc[%c0_i32, %c0_i32] : !tt.tensordesc<1x2048xi16> -> tensor<2048xi16, #blocked_multi_cta>
+    tt.return %result : tensor<2048xi16, #blocked_multi_cta>
+  }
+}

--- a/test/TritonGPU/amd/invalid.mlir
+++ b/test/TritonGPU/amd/invalid.mlir
@@ -646,6 +646,24 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.targ
 
 // -----
 
+// Dropping a non-unit descriptor dimension is not rank reduction and must not
+// make otherwise different swizzled layouts compatible.
+#non_unit_desc = #ttg.swizzled_shared<{vec = 1, perPhase = 1, maxPhase = 1, order = [1, 0]}>
+#non_unit_alloc = #ttg.swizzled_shared<{vec = 1, perPhase = 1, maxPhase = 1, order = [0]}>
+#smem = #ttg.shared_memory
+module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.target = "hip:gfx1250", "ttg.threads-per-warp" = 32 : i32} {
+  tt.func public @tdm_load_non_unit_dimension_is_not_rank_reduction(
+    %tensorDesc: !tt.tensordesc<2x32xf16, #non_unit_desc>,
+    %memDesc: !ttg.memdesc<64xf16, #non_unit_alloc, #smem, mutable>
+  ) {
+    // expected-error @+1 {{is inconsistent with the shared memory allocation layout}}
+    %token = amdg.async_tdm_copy_global_to_local %tensorDesc into %memDesc : !tt.tensordesc<2x32xf16, #non_unit_desc> -> !ttg.memdesc<64xf16, #non_unit_alloc, #smem, mutable>
+    tt.return
+  }
+}
+
+// -----
+
 // scaled_upcast_fp4: scale and output rank mismatch.
 module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 1 : i32, ttg.target = "hip:gfx1250", "ttg.threads-per-warp" = 32 : i32} {
   tt.func @scaled_upcast_fp4_rank_mismatch(%x: tensor<16x32xi8>, %s: tensor<64xi8>) {

--- a/third_party/amd/lib/Dialect/TritonAMDGPU/IR/Dialect.cpp
+++ b/third_party/amd/lib/Dialect/TritonAMDGPU/IR/Dialect.cpp
@@ -108,6 +108,20 @@ LogicalResult verifyTDMLayoutConsistency(Operation *op,
   Attribute allocLayout = smemTy.getEncoding();
 
   bool compatible = descLayout == allocLayout;
+  // Rank-reducing descriptor loads drop leading unit dimensions from the
+  // allocation, so the two swizzled encodings have different ranks even though
+  // they describe the same LDS layout. Compare the physical layouts with the
+  // dropped dimensions projected away.
+  int descRank = descTy.getShape().size();
+  int allocRank = smemTy.getRank();
+  if (descRank > allocRank &&
+      llvm::isa<gpu::SwizzledSharedEncodingAttr>(descLayout) &&
+      llvm::isa<gpu::SwizzledSharedEncodingAttr>(allocLayout)) {
+    auto descLL = gpu::toLinearLayout(descTy.getShape(), descLayout);
+    for (int i = 0; i < descRank - allocRank; ++i)
+      descLL = triton::removeStandardDim(descLL, 0);
+    compatible = descLL == gpu::toLinearLayout(smemTy);
+  }
   // Padded layouts bake in the tile shape, so compare the physical padding
   // only.
   auto descPad = llvm::dyn_cast<gpu::PaddedSharedEncodingAttr>(descLayout);
@@ -121,7 +135,9 @@ LogicalResult verifyTDMLayoutConsistency(Operation *op,
            << descLayout
            << ") is inconsistent with the shared memory allocation layout ("
            << allocLayout
-           << "); TDM uses a single shared layout so they must match";
+           << "); TDM accesses shared memory through the descriptor's layout, "
+              "so the allocation must describe the same physical layout, up to "
+              "leading unit dimensions dropped by a rank-reducing access";
   return success();
 }
 


### PR DESCRIPTION
TDM on gfx1250 supports up to 1024bytes padding intervals. For larger intervals we fall back to a (un)swizzled layout. The verifier was too strict as it was not comparing the rank reduced physical layout and rejected valid layout combinations for those cases.