### PR TITLE
[AMD][BACKEND] Split multicast groups into smaller subgroups if exceeding HW limit

### DIFF
--- a/test/Conversion/amd/cluster_load.mlir
+++ b/test/Conversion/amd/cluster_load.mlir
@@ -1,4 +1,5 @@
 // RUN: triton-opt %s -split-input-file --allocate-shared-memory --convert-triton-amdgpu-to-llvm=gfx-arch=gfx1250 | FileCheck %s
+// RUN: triton-opt %s -split-input-file --allocate-shared-memory --convert-triton-amdgpu-to-llvm=gfx-arch=gfx1250 2>&1 | FileCheck %s --check-prefix=REMARK
 
 // CGA layout has no broadcasting so we should not emit cluster loads
 #blocked = #ttg.blocked<{sizePerThread = [1, 8], threadsPerWarp = [8, 4], warpsPerCTA = [4, 1], order = [1, 0], CGALayout = [[1, 0], [2, 0], [4, 0]]}>
@@ -25,6 +26,70 @@ module attributes {"ttg.num-ctas" = 8 : i32, "ttg.num-warps" = 4 : i32, ttg.shar
     // CHECK: %[[CTA_MASK:.*]] = llvm.shl %[[GROUP_MASK]], %[[SHIFT_AMOUNT]]
     // CHECK: llvm.amdgcn.cluster.load.b128{{.*}}, {{.*}}, %[[CTA_MASK]]
     // CHECK-NOT: llvm.amdgcn.cluster.load
+    // 4 CTAs fit into the mask limit so the group must not be split
+    // REMARK-NOT: exceeding the hardware limit
+    %6 = tt.load %arg0 : tensor<32x32x!tt.ptr<f16>, #blocked>
+    tt.return
+  }
+}
+
+// -----
+
+// 16 CTAs with communication groups {0,1,4,5,8,9,12,13} and
+// {2,3,6,7,10,11,14,15}. The eight-bit masks exceed gfx1250's limit of five
+// bits, so split each group into four-CTA subgroups selected by CTA id bit 3.
+// The retained free bits 0 and 2 give a mask of 0b110011 (51) and the shift is
+// taken from bit 1 (group offset) and bit 3 (subgroup) => -6 (~0b101).
+#blocked = #ttg.blocked<{sizePerThread = [1, 8], threadsPerWarp = [8, 4], warpsPerCTA = [4, 1], order = [1, 0], CGALayout = [[0, 0], [1, 0], [0, 0], [0, 0]]}>
+module attributes {"ttg.num-ctas" = 16 : i32, "ttg.num-warps" = 4 : i32, ttg.shared = 8192 : i32} {
+  // CHECK-LABEL: cluster_load_split_multicast_mask
+  tt.func public @cluster_load_split_multicast_mask(%arg0: tensor<32x32x!tt.ptr<f16>, #blocked> {tt.divisibility = dense<[16, 16]> : tensor<2xi32>, tt.contiguity = dense<[16, 16]> : tensor<2xi32>, tt.constancy = dense<[1, 1]> : tensor<2xi32>}) {
+    // CHECK: %[[CTA_ID:.*]] = rocdl.cluster.workgroup.id.x
+    // CHECK: %[[SUBGROUP_SELECTOR:.*]] = llvm.mlir.constant(-6 : i32) : i32
+    // CHECK: %[[SHIFT_AMOUNT:.*]] = llvm.and %[[CTA_ID]], %[[SUBGROUP_SELECTOR]]
+    // CHECK: %[[SUBGROUP_MASK:.*]] = llvm.mlir.constant(51 : i32) : i32
+    // CHECK: %[[CTA_MASK:.*]] = llvm.shl %[[SUBGROUP_MASK]], %[[SHIFT_AMOUNT]]
+    // CHECK: llvm.amdgcn.cluster.load.b128{{.*}}, {{.*}}, %[[CTA_MASK]]
+    // REMARK: remark: Multicast group contains 8 workgroups, exceeding the hardware limit of 5 set mask bits; splitting it into subgroups of 4 workgroups
+    // REMARK-NEXT: {{.*}}%split_multicast_load = tt.load
+    %split_multicast_load = tt.load %arg0 : tensor<32x32x!tt.ptr<f16>, #blocked>
+    tt.return
+  }
+}
+
+// -----
+
+// All 16 CTAs share the same data. Splitting into subgroups of 4 keeps the
+// broadcast mask constant (0b1111) and shifts it by the two dropped free bits.
+#blocked = #ttg.blocked<{sizePerThread = [1, 8], threadsPerWarp = [8, 4], warpsPerCTA = [4, 1], order = [1, 0], CGALayout = [[0, 0], [0, 0], [0, 0], [0, 0]]}>
+module attributes {"ttg.num-ctas" = 16 : i32, "ttg.num-warps" = 4 : i32, ttg.shared = 8192 : i32} {
+  // CHECK-LABEL: cluster_load_split_full_broadcast
+  tt.func public @cluster_load_split_full_broadcast(%arg0: tensor<32x32x!tt.ptr<f16>, #blocked> {tt.divisibility = dense<[16, 16]> : tensor<2xi32>, tt.contiguity = dense<[16, 16]> : tensor<2xi32>, tt.constancy = dense<[1, 1]> : tensor<2xi32>}) {
+    // CHECK: %[[CTA_ID:.*]] = rocdl.cluster.workgroup.id.x
+    // CHECK: %[[SUBGROUP_SELECTOR:.*]] = llvm.mlir.constant(-4 : i32) : i32
+    // CHECK: %[[SHIFT_AMOUNT:.*]] = llvm.and %[[CTA_ID]], %[[SUBGROUP_SELECTOR]]
+    // CHECK: %[[SUBGROUP_MASK:.*]] = llvm.mlir.constant(15 : i32) : i32
+    // CHECK: %[[CTA_MASK:.*]] = llvm.shl %[[SUBGROUP_MASK]], %[[SHIFT_AMOUNT]]
+    // CHECK: llvm.amdgcn.cluster.load.b128{{.*}}, {{.*}}, %[[CTA_MASK]]
+    // REMARK: remark: Multicast group contains 16 workgroups, exceeding the hardware limit of 5 set mask bits; splitting it into subgroups of 4 workgroups
+    // REMARK-NEXT: {{.*}}%split_full_broadcast_load = tt.load
+    %split_full_broadcast_load = tt.load %arg0 : tensor<32x32x!tt.ptr<f16>, #blocked>
+    tt.return
+  }
+}
+
+// -----
+
+// All 4 CTAs share the same data which fits into the mask limit, so the mask is
+// a constant and needs no shift by the cta id.
+#blocked = #ttg.blocked<{sizePerThread = [1, 8], threadsPerWarp = [8, 4], warpsPerCTA = [4, 1], order = [1, 0], CGALayout = [[0, 0], [0, 0]]}>
+module attributes {"ttg.num-ctas" = 4 : i32, "ttg.num-warps" = 4 : i32, ttg.shared = 8192 : i32} {
+  // CHECK-LABEL: cluster_load_full_broadcast
+  tt.func public @cluster_load_full_broadcast(%arg0: tensor<32x32x!tt.ptr<f16>, #blocked> {tt.divisibility = dense<[16, 16]> : tensor<2xi32>, tt.contiguity = dense<[16, 16]> : tensor<2xi32>, tt.constancy = dense<[1, 1]> : tensor<2xi32>}) {
+    // CHECK: %[[CTA_MASK:.*]] = llvm.mlir.constant(15 : i32) : i32
+    // CHECK-NOT: llvm.shl
+    // CHECK: llvm.amdgcn.cluster.load.b128{{.*}}, {{.*}}, %[[CTA_MASK]]
+    // REMARK-NOT: exceeding the hardware limit
     %6 = tt.load %arg0 : tensor<32x32x!tt.ptr<f16>, #blocked>
     tt.return
   }

--- a/third_party/amd/include/Dialect/TritonAMDGPU/IR/TargetFeatures.h
+++ b/third_party/amd/include/Dialect/TritonAMDGPU/IR/TargetFeatures.h
@@ -73,6 +73,7 @@ public:
 
   bool supportsTDM() const;
   bool supportsMultiCTALaunch() const;
+  unsigned getMaxMulticastMaskPopcount() const;
   bool supportsClusterLoadBitWidth(int bitWidth) const;
 
   bool supportsBufferAtomicRMW() const;

--- a/third_party/amd/include/Dialect/TritonAMDGPU/IR/TritonAMDGPUOps.td
+++ b/third_party/amd/include/Dialect/TritonAMDGPU/IR/TritonAMDGPUOps.td
@@ -505,7 +505,7 @@ def MaskedLoadOp : TT_AMDGPU_Op<"masked_load", []> {
     LLVM_AnyPointer:$ptr,
     I1:$mask,
     LLVM_Type:$falseVal,
-    Optional<I16>:$multicastMask,
+    Optional<I32>:$multicastMask,
     DefaultValuedAttr<TT_CacheModifierAttr, "::mlir::triton::CacheModifier::NONE">:$cache,
     DefaultValuedAttr<BoolAttr, "false">:$forceNoAlias
   );

--- a/third_party/amd/lib/Dialect/TritonAMDGPU/IR/TargetFeatures.cpp
+++ b/third_party/amd/lib/Dialect/TritonAMDGPU/IR/TargetFeatures.cpp
@@ -239,6 +239,10 @@ bool TargetFeatures::supportsTDM() const { return isGFX1250(); }
 
 bool TargetFeatures::supportsMultiCTALaunch() const { return isGFX1250(); }
 
+unsigned TargetFeatures::getMaxMulticastMaskPopcount() const {
+  return isGFX1250() ? 5 : 1;
+}
+
 bool TargetFeatures::supportsClusterLoadBitWidth(int bitWidth) const {
   if (getISAFamily() == ISAFamily::GFX1250) {
     return llvm::is_contained({32, 64, 128}, bitWidth);

--- a/third_party/amd/lib/TritonAMDGPUToLLVM/LoadStoreOpToLLVM.cpp
+++ b/third_party/amd/lib/TritonAMDGPUToLLVM/LoadStoreOpToLLVM.cpp
@@ -470,7 +470,7 @@ struct DirectToLdsLoadConversionBase : public LoadStoreConversionBase {
     if (isLoad && targetInfo.supportsMultiCTALaunch()) {
       ctaMulticastMask = LLVM::AMD::emitCtaMulticastMask(
           rewriter, loc, targetInfo.getClusterCTAId(rewriter, loc),
-          globalLayout);
+          globalLayout, targetInfo.getMaxMulticastMaskPopcount());
     }
 
     auto smemObj = LLVM::getSharedMemoryObjectFromStruct(loc, llShared,
@@ -590,7 +590,8 @@ struct LoadOpConversion : public ConvertOpToLLVMPattern<triton::LoadOp>,
         Value clusterCTAId = targetInfo.getClusterCTAId(rewriter, loc);
         auto regLayout = triton::gpu::toLinearLayout(tensorTy);
         multicastMask = LLVM::AMD::emitCtaMulticastMask(
-            rewriter, loc, clusterCTAId, regLayout);
+            rewriter, loc, clusterCTAId, regLayout,
+            targetInfo.getMaxMulticastMaskPopcount());
       }
     }
 
@@ -1275,7 +1276,7 @@ struct AsyncTDMCopyGlobalToLocalOpConversion
     if (targetInfo.supportsMultiCTALaunch()) {
       multicastMask = LLVM::AMD::emitCtaMulticastMask(
           rewriter, loc, targetInfo.getClusterCTAId(rewriter, loc),
-          sharedLayout);
+          sharedLayout, targetInfo.getMaxMulticastMaskPopcount());
     }
 
     SmallVector<Value> desc =
@@ -1372,8 +1373,9 @@ struct AsyncTDMFusedCopyGlobalToLocalOpConversion
         m.padAmount = padEnc.getPaddings()[0];
       }
       if (targetInfo.supportsMultiCTALaunch())
-        m.multicastMask = LLVM::AMD::emitCtaMulticastMask(rewriter, loc, ctaId,
-                                                          m.sharedLayout);
+        m.multicastMask = LLVM::AMD::emitCtaMulticastMask(
+            rewriter, loc, ctaId, m.sharedLayout,
+            targetInfo.getMaxMulticastMaskPopcount());
 
       m.sharedEncoding = enc;
       m.shapePerCTA =
@@ -1660,8 +1662,9 @@ struct AsyncTDMGatherOpConversion
     if (targetInfo.supportsMultiCTALaunch()) {
       // Use the sharedLayout to compute the multicast mask because the index
       // layout only describes rows and misses information about columns.
-      multicastMask =
-          LLVM::AMD::emitCtaMulticastMask(rewriter, loc, ctaId, sharedLayout);
+      multicastMask = LLVM::AMD::emitCtaMulticastMask(
+          rewriter, loc, ctaId, sharedLayout,
+          targetInfo.getMaxMulticastMaskPopcount());
     }
 
     if (failed(mlir::LLVM::AMD::emitTDMGatherScatter(

--- a/third_party/amd/lib/TritonAMDGPUToLLVM/TargetInfo.cpp
+++ b/third_party/amd/lib/TritonAMDGPUToLLVM/TargetInfo.cpp
@@ -747,6 +747,10 @@ bool TargetInfo::supportsMultiCTALaunch() const {
   return targetFeatures.supportsMultiCTALaunch();
 }
 
+unsigned TargetInfo::getMaxMulticastMaskPopcount() const {
+  return targetFeatures.getMaxMulticastMaskPopcount();
+}
+
 bool TargetInfo::supportsTDM() const { return targetFeatures.supportsTDM(); }
 
 bool TargetInfo::supportsClusterLoadBitWidth(int biwWidth) const {

--- a/third_party/amd/lib/TritonAMDGPUToLLVM/TargetInfo.h
+++ b/third_party/amd/lib/TritonAMDGPUToLLVM/TargetInfo.h
@@ -124,6 +124,7 @@ public:
   bool useAsyncMarks() const;
 
   bool supportsMultiCTALaunch() const;
+  unsigned getMaxMulticastMaskPopcount() const;
   bool supportsTDM() const;
   bool supportsClusterLoadBitWidth(int biwWidth) const;
 

--- a/third_party/amd/lib/TritonAMDGPUToLLVM/Utility.cpp
+++ b/third_party/amd/lib/TritonAMDGPUToLLVM/Utility.cpp
@@ -389,8 +389,11 @@ Value llGetPid(Location loc, RewriterBase &rewriter, ModuleOp moduleOp,
 //   - Group 1: CTAs {2,3,6,7} (fixed bits = 0b010)
 // For CTA 5 (0b101): groupOffset = 0b101 & 0b010 = 0 => ctaMask = 0b00110011
 // For CTA 7 (0b111): groupOffset = 0b111 & 0b010 = 2 => ctaMask = 0b11001100
+// If the group does not fit into `maxMaskPopcount` mask bits it is split into
+// equally sized subgroups, see below.
 Value emitCtaMulticastMask(RewriterBase &rewriter, Location loc, Value groupId,
-                           const LinearLayout &regLayout) {
+                           const LinearLayout &regLayout,
+                           unsigned maxMaskPopcount) {
   TritonLLVMOpBuilder b(loc, rewriter);
 
   auto kBlock = StringAttr::get(rewriter.getContext(), "block");
@@ -401,38 +404,64 @@ Value emitCtaMulticastMask(RewriterBase &rewriter, Location loc, Value groupId,
     return Value();
   }
 
+  assert(maxMaskPopcount > 0 && "expected a non-zero multicast mask limit");
+
+  // A communication group spans 2^(number of free bits) CTAs, so we can only
+  // keep floor(log2(limit)) free bits. Dropping the highest free bits turns
+  // them into subgroup selectors.
+  // Example: freeVarMask = 0b1101 describes CTAs {0,1,4,5,8,9,12,13}; with a
+  // limit of 5 we keep bits 0 and 2 so bit 3 selects {0,1,4,5} or {8,9,12,13}.
+  int maxFreeBits = llvm::Log2_32(maxMaskPopcount);
+  int multicastFreeVarMask = freeVarMask;
+  while (llvm::popcount<uint32_t>(multicastFreeVarMask) > maxFreeBits)
+    multicastFreeVarMask ^= llvm::bit_floor<uint32_t>(multicastFreeVarMask);
+
+  if (multicastFreeVarMask != freeVarMask) {
+    unsigned numSharingCTAs = 1u << llvm::popcount<uint32_t>(freeVarMask);
+    unsigned numMulticastCTAs = 1u << maxFreeBits;
+    emitRemark(loc) << "Multicast group contains " << numSharingCTAs
+                    << " workgroups, exceeding the hardware limit of "
+                    << maxMaskPopcount << " set mask bits; splitting it into "
+                    << "subgroups of " << numMulticastCTAs
+                    << " workgroups. A cluster layout sharing data "
+                    << "among at most " << numMulticastCTAs
+                    << " workgroups may perform better.";
+  }
+
   // Construct the groupMask with 1s at all positions representing CTAs in the
-  // communication group. We start with 0b1 and iterate over free bits. For
-  // every free bit at position k, we copy the current pattern 2^k positions
+  // (sub)group. We start with 0b1 and iterate over the retained free bits. For
+  // every retained bit at position k, we copy the current pattern 2^k positions
   // higher.
-  // Example for freeVarMask = 0b101, x = non determined yet:
-  //   Initial:          groupMask = 0bxxxxxxx1 (positions {0})
-  //   Bit 0 (free):     groupMask = 0bxxxxxx11 (positions {0,1})
-  //   Bit 1 (non-free): groupMask = 0bxxxx0011 (positions {0,1})
-  //   Bit 2 (free):     groupMask = 0b00110011 (positions {0,1,4,5})
+  // Example for multicastFreeVarMask = 0b101, x = non determined yet:
+  //   Initial:              groupMask = 0bxxxxxxx1 (positions {0})
+  //   Bit 0 (retained):     groupMask = 0bxxxxxx11 (positions {0,1})
+  //   Bit 1 (not retained): groupMask = 0bxxxx0011 (positions {0,1})
+  //   Bit 2 (retained):     groupMask = 0b00110011 (positions {0,1,4,5})
   int groupMask = 1;
   for (int log2 = 0; log2 < regLayout.getInDimSizeLog2(kBlock); log2++) {
-    if (!(freeVarMask & (1 << log2)))
+    if (!(multicastFreeVarMask & (1 << log2)))
       continue;
     groupMask = groupMask | (groupMask << (1 << log2));
   }
-  // If all bits are set we broadcast to all CTAs so return the group mask.
-  if (freeVarMask == regLayout.getInDimSize(kBlock) - 1) {
+  // If all bits are retained we broadcast to all CTAs so return the group mask.
+  if (multicastFreeVarMask == regLayout.getInDimSize(kBlock) - 1) {
     return b.i32_val(groupMask);
   }
-  // The non-free bits set in the ctaId determine the group offset. For every
-  // non-free bit set at position k, we shift the groupMask by 2^k positions.
-  // This can be conviniently computed by masking the ctaId with the inverse
-  // of the freeVarMask.
-  // Example1: freeVarMask = 0b101
-  //   ~freeVarMask  = 0b010
-  //   shiftAmount   = 0b101 & 0b010 = 0b000 (no shift needed)
-  //   blockMask     = 0b110011 << 0 = 0b00110011
-  // Example2: freeVarMask = 0b101, ctaId = 0b111 (cta 7)
-  //   ~freeVarMask  = 0b010
-  //   shiftAmount   = 0b111 & 0b010 = 0b010 (shift by 2)
-  //   blockMask     = 0b110011 << 2 = 0b11001100
-  Value shiftAmount = b.and_(groupId, b.i32_val(~freeVarMask));
+  // The bits not retained (non-free bits plus subgroup selectors) set in the
+  // ctaId determine the group offset. For every such bit set at position k, we
+  // shift the groupMask by 2^k positions. This can be conveniently computed by
+  // masking the ctaId with the inverse of multicastFreeVarMask. Note that this
+  // never carries into a retained position because the shift amount and the
+  // groupMask cover disjoint bits.
+  // Example1: multicastFreeVarMask = 0b101
+  //   ~multicastFreeVarMask = 0b010
+  //   shiftAmount           = 0b101 & 0b010 = 0b000 (no shift needed)
+  //   blockMask             = 0b110011 << 0 = 0b00110011
+  // Example2: multicastFreeVarMask = 0b101, ctaId = 0b111 (cta 7)
+  //   ~multicastFreeVarMask = 0b010
+  //   shiftAmount           = 0b111 & 0b010 = 0b010 (shift by 2)
+  //   blockMask             = 0b110011 << 2 = 0b11001100
+  Value shiftAmount = b.and_(groupId, b.i32_val(~multicastFreeVarMask));
   Value ctaMask = b.shl(b.i32_val(groupMask), shiftAmount);
   return ctaMask;
 }

--- a/third_party/amd/lib/TritonAMDGPUToLLVM/Utility.h
+++ b/third_party/amd/lib/TritonAMDGPUToLLVM/Utility.h
@@ -50,9 +50,11 @@ Value permute(Location loc, RewriterBase &rewriter, Value a, Value b,
 Value llGetPid(Location loc, RewriterBase &rewriter, ModuleOp moduleOp,
                ProgramIDDim axis);
 
-// Emit the cta multicast mask for a given cta id based on the src layout
+// Emit the cta multicast mask for a given cta id based on the src layout.
+// Groups sharing data among more than maxMaskPopcount CTAs are split into
+// smaller subgroups because the hardware would otherwise drop the multicast.
 Value emitCtaMulticastMask(RewriterBase &rewriter, Location loc, Value blockId,
-                           const LinearLayout &cvt);
+                           const LinearLayout &cvt, unsigned maxMaskPopcount);
 
 std::pair<bool, bool>
 getCacheModifierFlagsForLoadStore(const triton::CacheModifier &cm, MemoryOp op);


### PR DESCRIPTION
On gfx1250 we are limited to multicast to at most 5 CTAs in the cluster. Multicast loads with more than 5 bits set will not multicast at all.
This PR splits the multicast groups into smaller subgroups if we exceed the limit to ensure we still get the multicast benefit. We can simply do this by limiting the number of free bits we use to construct the multicast groups.

We do not treat this as an error since the kernel could do this on purpose (multicast to all CTAs) and/or might have other operands which are split more efficiently. Instead we only emit a performance remark.