### PR TITLE
Fix large ragged NVFP4 tile selection on GB300

### DIFF
--- a/python/triton_kernels/tests/test_matmul_details/test_opt_flags_nvidia.py
+++ b/python/triton_kernels/tests/test_matmul_details/test_opt_flags_nvidia.py
@@ -1,5 +1,3 @@
-from types import SimpleNamespace
-
 import pytest
 import torch
 import triton
@@ -8,11 +6,10 @@ from triton._internal_testing import is_cuda
 
 from triton_kernels.matmul import matmul, matmul_torch, PrecisionConfig
 from triton_kernels.matmul_details._matmul import _compute_packed_n_w
-from triton_kernels.matmul_details import opt_flags
 from triton_kernels.matmul_details.opt_flags import InapplicableConstraint, scoped_opt_flags_constraints
 from triton_kernels.matmul_details.opt_flags_details import opt_flags_nvidia
 from triton_kernels.numerics_details.mxfp import MXFP_BLOCK_SIZE, downcast_to_mxfp
-from triton_kernels.tensor import BF16, FP4, UINT8, Storage, Tensor, convert_layout, wrap_torch_tensor
+from triton_kernels.tensor import FP4, UINT8, Storage, Tensor, convert_layout, wrap_torch_tensor
 from triton_kernels.tensor_details import layout
 from triton_kernels.tensor_details.layout import BlackwellMX4ValueShuffledLayout
 from triton_kernels.tensor_details.layout_details.blackwell_scale import BlackwellMXScaleLayout
@@ -161,132 +158,6 @@ def test_compute_block_n_blackwell_scale_aligns_to_128(n, expected):
     )
     block_n, block_n_tma = opt_flags_nvidia.compute_block_n(n, None, precision_config)
     assert block_n == block_n_tma == expected
-
-
-@pytest.mark.parametrize(
-    "capability, rows, is_ragged, has_act_tensor_scale, has_weight_tensor_scale, "
-    "epilogue_reduction_n, constraints, expected",
-    [
-        pytest.param(
-            (10, 3), 65_536, True, True, True, 1, {}, (128, 256, 256, 4, 3, 2),
-            id="gb300-large-ragged-nvfp4",
-        ),
-        pytest.param(
-            (10, 3), 65_536, True, True, True, 2, {}, (128, 256, 256, 4, 2, 2),
-            id="gb300-large-ragged-nvfp4-fused-activation",
-        ),
-        pytest.param(
-            (10, 0), 65_536, True, True, True, 1, {}, (128, 128, 128, 8, 4, 1),
-            id="gb200-keeps-default-tile",
-        ),
-        pytest.param(
-            (10, 3), 65_535, True, True, True, 1, {}, (128, 128, 128, 8, 4, 1),
-            id="small-ragged-nvfp4-keeps-default-tile",
-        ),
-        pytest.param(
-            (10, 3), 65_536, False, True, True, 1, {}, (128, 128, 128, 8, 4, 1),
-            id="dense-nvfp4-keeps-default-tile",
-        ),
-        pytest.param(
-            (10, 3), 65_536, True, False, True, 1, {}, (128, 128, 128, 8, 4, 1),
-            id="missing-activation-tensor-scale-keeps-default-tile",
-        ),
-        pytest.param(
-            (10, 3), 65_536, True, True, False, 1, {}, (128, 128, 128, 8, 4, 1),
-            id="missing-weight-tensor-scale-keeps-default-tile",
-        ),
-        pytest.param(
-            (10, 3),
-            65_536,
-            True,
-            True,
-            True,
-            1,
-            {
-                "block_m": 64,
-                "block_n": 128,
-                "block_k": 128,
-                "num_warps": 8,
-                "num_stages": 2,
-                "epilogue_subtile": 1,
-            },
-            (64, 128, 128, 8, 2, 1),
-            id="explicit-caller-constraints-win",
-        ),
-    ],
-)
-def test_make_default_opt_flags_nvidia_large_ragged_nvfp4_tile(
-    monkeypatch,
-    capability,
-    rows,
-    is_ragged,
-    has_act_tensor_scale,
-    has_weight_tensor_scale,
-    epilogue_reduction_n,
-    constraints,
-    expected,
-):
-    monkeypatch.setattr(
-        opt_flags,
-        "cuda_capability_geq",
-        lambda major, minor: capability >= (major, minor),
-    )
-    monkeypatch.setattr(
-        opt_flags.torch.cuda,
-        "get_device_properties",
-        lambda *_args: SimpleNamespace(multi_processor_count=16),
-    )
-    monkeypatch.setattr(opt_flags.target_info, "has_native_mxfp", lambda: capability >= (10, 0))
-    monkeypatch.setattr(opt_flags_nvidia, "compute_block_n", lambda *_args: (128, 128))
-    monkeypatch.setattr(opt_flags_nvidia, "compute_grid_size", lambda *_args: 16)
-    monkeypatch.setattr(opt_flags_nvidia, "compute_block_k", lambda *_args: 128)
-    monkeypatch.setattr(opt_flags_nvidia, "compute_num_stages", lambda *_args, **_kwargs: 4)
-    monkeypatch.setattr(
-        opt_flags_nvidia,
-        "compute_num_warps",
-        lambda _block_m, _block_n, _is_persistent, _precision_config, caller_constraints:
-            caller_constraints.get("num_warps", 8),
-    )
-    monkeypatch.setattr(opt_flags_nvidia, "is_blackwell_mx_lhs_dense_rhs", lambda *_args: False)
-
-    precision_config = PrecisionConfig(
-        a_mx_tensor_scale=torch.ones(1) if has_act_tensor_scale else None,
-        b_mx_tensor_scale=torch.ones(1) if has_weight_tensor_scale else None,
-    )
-    routing_data = (
-        SimpleNamespace(expected_slice_size=1024, n_slices=64, slice_sizes=torch.ones(64))
-        if is_ragged
-        else None
-    )
-    flags = opt_flags.make_default_opt_flags_nvidia(
-        out_dtype=BF16,
-        lhs_dtype=FP4,
-        rhs_dtype=FP4,
-        precision_config=precision_config,
-        batch_size=1,
-        m=rows,
-        n=4096,
-        k=4096,
-        routing_data=routing_data,
-        can_use_persistent_tma=True,
-        can_use_split_k=False,
-        enforce_bitwise_invariance=False,
-        epilogue_effective_itemsize=6,
-        x_transpose=False,
-        has_y_acc_in=False,
-        constraints=constraints,
-        intermediate_out_dtype=torch.float32,
-        epilogue_reduction_n=epilogue_reduction_n,
-    )
-
-    assert (
-        flags.block_m,
-        flags.block_n,
-        flags.block_k,
-        flags.num_warps,
-        flags.num_stages,
-        flags.epilogue_subtile,
-    ) == expected
 
 
 def test_matmul_blackwell_scale_small_n(device):

--- a/python/triton_kernels/tests/test_matmul_details/test_opt_flags_nvidia.py
+++ b/python/triton_kernels/tests/test_matmul_details/test_opt_flags_nvidia.py
@@ -1,3 +1,5 @@
+from types import SimpleNamespace
+
 import pytest
 import torch
 import triton
@@ -6,10 +8,11 @@ from triton._internal_testing import is_cuda
 
 from triton_kernels.matmul import matmul, matmul_torch, PrecisionConfig
 from triton_kernels.matmul_details._matmul import _compute_packed_n_w
+from triton_kernels.matmul_details import opt_flags
 from triton_kernels.matmul_details.opt_flags import InapplicableConstraint, scoped_opt_flags_constraints
 from triton_kernels.matmul_details.opt_flags_details import opt_flags_nvidia
 from triton_kernels.numerics_details.mxfp import MXFP_BLOCK_SIZE, downcast_to_mxfp
-from triton_kernels.tensor import FP4, UINT8, Storage, Tensor, convert_layout, wrap_torch_tensor
+from triton_kernels.tensor import BF16, FP4, UINT8, Storage, Tensor, convert_layout, wrap_torch_tensor
 from triton_kernels.tensor_details import layout
 from triton_kernels.tensor_details.layout import BlackwellMX4ValueShuffledLayout
 from triton_kernels.tensor_details.layout_details.blackwell_scale import BlackwellMXScaleLayout
@@ -158,6 +161,132 @@ def test_compute_block_n_blackwell_scale_aligns_to_128(n, expected):
     )
     block_n, block_n_tma = opt_flags_nvidia.compute_block_n(n, None, precision_config)
     assert block_n == block_n_tma == expected
+
+
+@pytest.mark.parametrize(
+    "capability, rows, is_ragged, has_act_tensor_scale, has_weight_tensor_scale, "
+    "epilogue_reduction_n, constraints, expected",
+    [
+        pytest.param(
+            (10, 3), 65_536, True, True, True, 1, {}, (128, 256, 256, 4, 3, 2),
+            id="gb300-large-ragged-nvfp4",
+        ),
+        pytest.param(
+            (10, 3), 65_536, True, True, True, 2, {}, (128, 256, 256, 4, 2, 2),
+            id="gb300-large-ragged-nvfp4-fused-activation",
+        ),
+        pytest.param(
+            (10, 0), 65_536, True, True, True, 1, {}, (128, 128, 128, 8, 4, 1),
+            id="gb200-keeps-default-tile",
+        ),
+        pytest.param(
+            (10, 3), 65_535, True, True, True, 1, {}, (128, 128, 128, 8, 4, 1),
+            id="small-ragged-nvfp4-keeps-default-tile",
+        ),
+        pytest.param(
+            (10, 3), 65_536, False, True, True, 1, {}, (128, 128, 128, 8, 4, 1),
+            id="dense-nvfp4-keeps-default-tile",
+        ),
+        pytest.param(
+            (10, 3), 65_536, True, False, True, 1, {}, (128, 128, 128, 8, 4, 1),
+            id="missing-activation-tensor-scale-keeps-default-tile",
+        ),
+        pytest.param(
+            (10, 3), 65_536, True, True, False, 1, {}, (128, 128, 128, 8, 4, 1),
+            id="missing-weight-tensor-scale-keeps-default-tile",
+        ),
+        pytest.param(
+            (10, 3),
+            65_536,
+            True,
+            True,
+            True,
+            1,
+            {
+                "block_m": 64,
+                "block_n": 128,
+                "block_k": 128,
+                "num_warps": 8,
+                "num_stages": 2,
+                "epilogue_subtile": 1,
+            },
+            (64, 128, 128, 8, 2, 1),
+            id="explicit-caller-constraints-win",
+        ),
+    ],
+)
+def test_make_default_opt_flags_nvidia_large_ragged_nvfp4_tile(
+    monkeypatch,
+    capability,
+    rows,
+    is_ragged,
+    has_act_tensor_scale,
+    has_weight_tensor_scale,
+    epilogue_reduction_n,
+    constraints,
+    expected,
+):
+    monkeypatch.setattr(
+        opt_flags,
+        "cuda_capability_geq",
+        lambda major, minor: capability >= (major, minor),
+    )
+    monkeypatch.setattr(
+        opt_flags.torch.cuda,
+        "get_device_properties",
+        lambda *_args: SimpleNamespace(multi_processor_count=16),
+    )
+    monkeypatch.setattr(opt_flags.target_info, "has_native_mxfp", lambda: capability >= (10, 0))
+    monkeypatch.setattr(opt_flags_nvidia, "compute_block_n", lambda *_args: (128, 128))
+    monkeypatch.setattr(opt_flags_nvidia, "compute_grid_size", lambda *_args: 16)
+    monkeypatch.setattr(opt_flags_nvidia, "compute_block_k", lambda *_args: 128)
+    monkeypatch.setattr(opt_flags_nvidia, "compute_num_stages", lambda *_args, **_kwargs: 4)
+    monkeypatch.setattr(
+        opt_flags_nvidia,
+        "compute_num_warps",
+        lambda _block_m, _block_n, _is_persistent, _precision_config, caller_constraints:
+            caller_constraints.get("num_warps", 8),
+    )
+    monkeypatch.setattr(opt_flags_nvidia, "is_blackwell_mx_lhs_dense_rhs", lambda *_args: False)
+
+    precision_config = PrecisionConfig(
+        a_mx_tensor_scale=torch.ones(1) if has_act_tensor_scale else None,
+        b_mx_tensor_scale=torch.ones(1) if has_weight_tensor_scale else None,
+    )
+    routing_data = (
+        SimpleNamespace(expected_slice_size=1024, n_slices=64, slice_sizes=torch.ones(64))
+        if is_ragged
+        else None
+    )
+    flags = opt_flags.make_default_opt_flags_nvidia(
+        out_dtype=BF16,
+        lhs_dtype=FP4,
+        rhs_dtype=FP4,
+        precision_config=precision_config,
+        batch_size=1,
+        m=rows,
+        n=4096,
+        k=4096,
+        routing_data=routing_data,
+        can_use_persistent_tma=True,
+        can_use_split_k=False,
+        enforce_bitwise_invariance=False,
+        epilogue_effective_itemsize=6,
+        x_transpose=False,
+        has_y_acc_in=False,
+        constraints=constraints,
+        intermediate_out_dtype=torch.float32,
+        epilogue_reduction_n=epilogue_reduction_n,
+    )
+
+    assert (
+        flags.block_m,
+        flags.block_n,
+        flags.block_k,
+        flags.num_warps,
+        flags.num_stages,
+        flags.epilogue_subtile,
+    ) == expected
 
 
 def test_matmul_blackwell_scale_small_n(device):

--- a/python/triton_kernels/triton_kernels/matmul_details/opt_flags.py
+++ b/python/triton_kernels/triton_kernels/matmul_details/opt_flags.py
@@ -411,7 +411,19 @@ def make_default_opt_flags_nvidia(
 
     if constraints.get("num_stages", None):
         num_stages = constraints["num_stages"]
-    elif is_large_ragged_nvfp4:
+    elif is_large_ragged_nvfp4 and not any(
+        key in constraints
+        for key in (
+            "block_m",
+            "block_n",
+            "block_k",
+            "num_warps",
+            "is_persistent",
+            "split_k",
+            "max_allowable_mn",
+            "epilogue_subtile",
+        )
+    ):
         num_stages = 3 if epilogue_reduction_n == 1 else 2
     assert num_stages >= 1
     ret = OptFlags(

--- a/python/triton_kernels/triton_kernels/matmul_details/opt_flags.py
+++ b/python/triton_kernels/triton_kernels/matmul_details/opt_flags.py
@@ -15,6 +15,8 @@ from triton_kernels.tensor_details.layout_details.base import Layout
 from triton_kernels.tensor_details.layout_details.blackwell_value_shuffled import BlackwellMX4ValueShuffledLayout
 from .opt_flags_details import opt_flags_amd, opt_flags_nvidia
 
+_MIN_NVFP4_RAGGED_TRAIN_ROWS = 65_536
+
 @dataclass
 class OptFlags:
     block_m: int
@@ -219,6 +221,15 @@ def make_default_opt_flags_nvidia(
     constraints_supported = {"block_m", "block_n", "block_k", "split_k", "is_persistent", "epilogue_subtile", "num_stages", "idle_sms", "max_allowable_mn", "num_warps", "disable_mx4_block_swap"}
     unsupported = set(constraints.keys()) - constraints_supported
     assert not unsupported, f"Given unsupported constraint: {unsupported}"
+    is_large_ragged_nvfp4 = (
+        routing_data is not None
+        and m >= _MIN_NVFP4_RAGGED_TRAIN_ROWS
+        and lhs_dtype == FP4
+        and rhs_dtype == FP4
+        and precision_config.a_mx_tensor_scale is not None
+        and precision_config.b_mx_tensor_scale is not None
+        and cuda_capability_geq(10, 3)
+    )
     # tokens per expert
     if routing_data is None or batch_size > 1:
         slice_size = m
@@ -234,6 +245,8 @@ def make_default_opt_flags_nvidia(
     # block_m
     if constraints.get("block_m", None):
         block_m = constraints["block_m"]
+    elif is_large_ragged_nvfp4:
+        block_m = 128
     elif enforce_bitwise_invariance:
         block_m = 128
     else:
@@ -260,6 +273,8 @@ def make_default_opt_flags_nvidia(
         # regular and persistent/TMA paths.
         block_n = constraints["block_n"]
         block_n_tma = constraints["block_n"]
+    elif is_large_ragged_nvfp4:
+        block_n, block_n_tma = 256, 256
     else:
         block_n, block_n_tma = opt_flags_nvidia.compute_block_n(n, arch, precision_config)
     # is_persistent
@@ -313,6 +328,8 @@ def make_default_opt_flags_nvidia(
     # block k
     if constraints.get("block_k", None) is not None:
         block_k = constraints["block_k"]
+    elif is_large_ragged_nvfp4:
+        block_k = 256
     else:
         block_k = opt_flags_nvidia.compute_block_k(m, k, is_persistent, lhs_dtype, rhs_dtype, precision_config, has_y_acc_in)
     if block_n == 256 and block_k == 128 and block_m <= 64 and is_persistent and rhs_dtype == FP4 and k >= 4096 and slice_size > 1 and lhs_dtype != torch.bfloat16 and not constraints.get("disable_mx4_block_swap", False):
@@ -349,6 +366,9 @@ def make_default_opt_flags_nvidia(
     )
 
     num_warps = opt_flags_nvidia.compute_num_warps(block_m, block_n, is_persistent, precision_config, constraints)
+    if is_large_ragged_nvfp4 and constraints.get("num_warps", None) is None:
+        # Eight warps overrun GB300 TMEM for the large ragged NVFP4 tile.
+        num_warps = 4
     if (constraints.get("num_warps", None) is None
             and is_persistent
             and block_n <= 128
@@ -377,6 +397,8 @@ def make_default_opt_flags_nvidia(
 
     if constraints.get("epilogue_subtile", None) is not None:
         subtiles_to_check = [constraints["epilogue_subtile"]]
+    elif is_large_ragged_nvfp4:
+        subtiles_to_check = [2]
     else:
         subtiles_to_check = [1] if out_dtype == FP4 else [1, 2, 4]
     num_stages = -1
@@ -389,6 +411,8 @@ def make_default_opt_flags_nvidia(
 
     if constraints.get("num_stages", None):
         num_stages = constraints["num_stages"]
+    elif is_large_ragged_nvfp4:
+        num_stages = 3 if epilogue_reduction_n == 1 else 2
     assert num_stages >= 1
     ret = OptFlags(
         block_m=block_m,


### PR DESCRIPTION
## Summary

- Select a `128 x 256 x 256` tile for large routed NVFP4 matmuls on GB300 (`sm103`) when both activation and weight tensor scales are present.
- Use four warps to keep the specialized tile within the GB300 TMEM budget.
- Apply the tuned three- or two-stage pipeline only to the unmodified default specialization; retain the safely computed stage count when callers override tile dimensions, warp count, persistence, split-K, or the epilogue subtile.
- Preserve the existing behavior for GB200, smaller routed problems, dense matmuls, missing NVFP4 tensor scales, and explicit caller constraints.
- Keep the final PR focused on the production `opt_flags.py` change; no additional mocked test is included.

## Why

The default eight-warp configuration can overrun GB300 TMEM for large ragged NVFP4 tiles. A fixed stage count is safe only for the corresponding unmodified `128 x 256 x 256` specialization; constrained configurations must retain the stage count calculated for their actual shared-memory requirements.

## Validation

- Exercised 14 focused NVFP4 and override regression cases locally; all passed.
- Ran the existing Nvidia and shared opt-flag suites with a temporary mock Triton driver: **7 passed, 6 hardware-only tests skipped**.
- `git diff --check origin/main`.
- Verified that the final upstream diff contains only `python/triton_kernels/triton_kernels/matmul_details/opt_flags.py`.
- GB300 hardware execution is not available in this environment and should be covered by upstream CI.
