### PR TITLE
[AMD] Fix swapped structured binding in emitFence for buffer atomics

### DIFF
--- a/test/Conversion/amd/buffer_load_store.mlir
+++ b/test/Conversion/amd/buffer_load_store.mlir
@@ -238,6 +238,36 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 1 : i32} {
 
 // -----
 
+#blocked0 = #ttg.blocked<{sizePerThread = [1], threadsPerWarp = [64], warpsPerCTA = [1], order = [0]}>
+module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 1 : i32, "ttg.threads-per-warp" = 64 : i32} {
+    // CHECK-LABEL: buffer_atomic_rmw_fadd_acquire
+    // No release fence before the atomic for acquire ordering
+    // CHECK-NOT: llvm.fence syncscope("agent") release
+    // CHECK: llvm.call_intrinsic "llvm.amdgcn.raw.ptr.buffer.atomic.fadd"({{.*}}) : (f32, !llvm.ptr<8>, i32, i32, i32) -> f32
+    // CHECK: llvm.fence syncscope("agent") acquire
+    tt.func public @buffer_atomic_rmw_fadd_acquire(%arg0: !tt.ptr<f32> {tt.divisibility = 16 : i32}, %offsets : tensor<64xi32, #blocked0>{tt.divisibility=16:i32}, %values : tensor<64xf32, #blocked0>) {
+        %ret = amdg.buffer_atomic_rmw fadd, acquire, gpu, %values, %arg0[%offsets] : tensor<64xf32, #blocked0>
+        tt.return
+    }
+}
+
+// -----
+
+#blocked0 = #ttg.blocked<{sizePerThread = [1], threadsPerWarp = [64], warpsPerCTA = [1], order = [0]}>
+module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 1 : i32, "ttg.threads-per-warp" = 64 : i32} {
+    // CHECK-LABEL: buffer_atomic_rmw_fadd_release
+    // CHECK: llvm.fence syncscope("agent") release
+    // CHECK: llvm.call_intrinsic "llvm.amdgcn.raw.ptr.buffer.atomic.fadd"({{.*}}) : (f32, !llvm.ptr<8>, i32, i32, i32) -> f32
+    // No acquire fence after the atomic for release ordering
+    // CHECK-NOT: llvm.fence syncscope("agent") acquire
+    tt.func public @buffer_atomic_rmw_fadd_release(%arg0: !tt.ptr<f32> {tt.divisibility = 16 : i32}, %offsets : tensor<64xi32, #blocked0>{tt.divisibility=16:i32}, %values : tensor<64xf32, #blocked0>) {
+        %ret = amdg.buffer_atomic_rmw fadd, release, gpu, %values, %arg0[%offsets] : tensor<64xf32, #blocked0>
+        tt.return
+    }
+}
+
+// -----
+
 #blocked0 = #ttg.blocked<{sizePerThread = [1], threadsPerWarp = [64], warpsPerCTA = [4], order = [0]}>
 module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, "ttg.threads-per-warp" = 64 : i32} {
     // CHECK-LABEL: buffer_atomic_rmw_fmax_f32

--- a/third_party/amd/lib/TritonAMDGPUToLLVM/LoadStoreOpToLLVM.cpp
+++ b/third_party/amd/lib/TritonAMDGPUToLLVM/LoadStoreOpToLLVM.cpp
@@ -149,7 +149,7 @@ LogicalResult emitFence(Operation *op, ConversionPatternRewriter &rewriter,
   // LLVM::FenceOp lowering will emit the required cache ops and s_waitcnt
   // vmcnt(0) instrs
 
-  auto [emitReleaseFence, emitAcquireFence] = getOrderingFlags(memOrdering);
+  auto [emitAcquireFence, emitReleaseFence] = getOrderingFlags(memOrdering);
   if (MemSyncScope::SYSTEM == memScope)
     return rewriter.notifyMatchFailure(
         op, "System memory scope is not supported for Buffer Atomic Ops");


### PR DESCRIPTION
The function getOrderingFlags() returns {emitAcquireFence, emitReleaseFence}, but the caller bound it as {emitReleaseFence, emitAcquireFence}, swapping the two. This caused acquire semantics to emit a pre-atomic release fence and release semantics to do the opposite — both wrong. This patch fixed the wrong binding.