### PR TITLE
[FPSAN] Mix every discarded downcast bit

### DIFF
--- a/docs/programming-guide/chapter-3/fpsan.rst
+++ b/docs/programming-guide/chapter-3/fpsan.rst
@@ -369,8 +369,8 @@ Supported operations:
 Rewrite:
 
 - signed integer extension when widening
-- when narrowing, mix every discarded high payload bit into the retained bits
-  with a wide multiply and ``unembed`` the result
+- when narrowing, fold the discarded high payload bits into the retained bits,
+  then truncate and ``unembed``
 - optionally, set ``TRITON_FPSAN_HOMOMORPHIC_CASTS=1`` to use simple payload
   truncation when narrowing; this preserves addition across independently
   downcast partial reductions

--- a/docs/programming-guide/chapter-3/fpsan.rst
+++ b/docs/programming-guide/chapter-3/fpsan.rst
@@ -369,8 +369,8 @@ Supported operations:
 Rewrite:
 
 - signed integer extension when widening
-- when narrowing, fold the discarded high payload bits into the retained bits,
-  then truncate and ``unembed``
+- when narrowing, mix every discarded high payload bit into the retained bits
+  with a wide multiply and ``unembed`` the result
 - optionally, set ``TRITON_FPSAN_HOMOMORPHIC_CASTS=1`` to use simple payload
   truncation when narrowing; this preserves addition across independently
   downcast partial reductions

--- a/lib/Dialect/TritonInstrument/Transforms/FpSanitizer.cpp
+++ b/lib/Dialect/TritonInstrument/Transforms/FpSanitizer.cpp
@@ -625,11 +625,10 @@ Value castSignedIntValueToType(PatternRewriter &rewriter, Location loc, Value v,
   return v;
 }
 
-// Widening a floating-point payload is signed extension. Narrowing folds the
-// discarded high bits into the retained low bits before truncation. Values
-// produced by signed extension have uniform discarded bits, so normalizing by
-// the source sign makes `high` zero and narrowing remains a left inverse of
-// widening.
+// Widening a floating-point payload is signed extension. When narrowing, the
+// xor with the sign extension of the retained low bits vanishes for widened
+// payloads. A repeated odd multiplier folds every discarded residual bit into
+// the high word; a final xor shift diffuses it into the retained low bits.
 Value castFloatPayloadToType(PatternRewriter &rewriter, Location loc, Value v,
                              Type targetTy) {
   if (v.getType() == targetTy)
@@ -648,19 +647,27 @@ Value castFloatPayloadToType(PatternRewriter &rewriter, Location loc, Value v,
   if (homomorphicCasts && homomorphicCasts.getValue())
     return arith::TruncIOp::create(rewriter, loc, targetTy, v);
 
-  Value signShift = getUIntConstantLike(rewriter, loc, v.getType(),
-                                        static_cast<uint64_t>(srcWidth - 1));
-  Value sign = arith::ShRUIOp::create(rewriter, loc, v, signShift);
-  Value zero = getIntConstantLike(rewriter, loc, v.getType(), 0);
-  Value signMask = arith::SubIOp::create(rewriter, loc, zero, sign);
-  Value normalized = arith::XOrIOp::create(rewriter, loc, v, signMask);
-  Value highShift = getUIntConstantLike(rewriter, loc, v.getType(),
-                                        static_cast<uint64_t>(dstWidth));
-  Value high = arith::ShRUIOp::create(rewriter, loc, normalized, highShift);
-  Value multiplier = getIntConstantLike(rewriter, loc, v.getType(), 3511);
-  Value foldedHigh = arith::MulIOp::create(rewriter, loc, high, multiplier);
-  Value folded = arith::XOrIOp::create(rewriter, loc, v, foldedHigh);
-  return arith::TruncIOp::create(rewriter, loc, targetTy, folded);
+  assert(srcWidth <= 64 && "expected at most a 64-bit floating-point payload");
+  uint64_t digit = uint64_t{3511} & ((uint64_t{1} << dstWidth) - 1);
+  uint64_t repeatedMultiplier = 0;
+  for (unsigned shift = 0; shift < srcWidth; shift += dstWidth)
+    repeatedMultiplier |= digit << shift;
+
+  Value low = arith::TruncIOp::create(rewriter, loc, targetTy, v);
+  Value canonical = arith::ExtSIOp::create(rewriter, loc, v.getType(), low);
+  Value residual = arith::XOrIOp::create(rewriter, loc, v, canonical);
+  Value multiplier =
+      getUIntConstantLike(rewriter, loc, v.getType(), repeatedMultiplier);
+  Value product = arith::MulIOp::create(rewriter, loc, residual, multiplier);
+  Value highShift = getUIntConstantLike(
+      rewriter, loc, v.getType(), static_cast<uint64_t>(srcWidth - dstWidth));
+  Value highWide = arith::ShRUIOp::create(rewriter, loc, product, highShift);
+  Value high = arith::TruncIOp::create(rewriter, loc, targetTy, highWide);
+  Value diffusionShift = getUIntConstantLike(
+      rewriter, loc, targetTy, static_cast<uint64_t>(dstWidth / 2));
+  Value diffusion = arith::ShRUIOp::create(rewriter, loc, high, diffusionShift);
+  Value mixed = arith::XOrIOp::create(rewriter, loc, high, diffusion);
+  return arith::XOrIOp::create(rewriter, loc, low, mixed);
 }
 
 Value castScalarIntToIntLike(PatternRewriter &rewriter, Location loc,

--- a/lib/Dialect/TritonInstrument/Transforms/FpSanitizer.cpp
+++ b/lib/Dialect/TritonInstrument/Transforms/FpSanitizer.cpp
@@ -648,10 +648,9 @@ Value castFloatPayloadToType(PatternRewriter &rewriter, Location loc, Value v,
     return arith::TruncIOp::create(rewriter, loc, targetTy, v);
 
   assert(srcWidth <= 64 && "expected at most a 64-bit floating-point payload");
-  uint64_t digit = uint64_t{3511} & ((uint64_t{1} << dstWidth) - 1);
-  uint64_t repeatedMultiplier = 0;
-  for (unsigned shift = 0; shift < srcWidth; shift += dstWidth)
-    repeatedMultiplier |= digit << shift;
+  uint64_t dstMask = (uint64_t{1} << dstWidth) - 1;
+  uint64_t repeatedMultiplier =
+      (uint64_t{3511} & dstMask) * (~uint64_t{0} / dstMask);
 
   Value low = arith::TruncIOp::create(rewriter, loc, targetTy, v);
   Value canonical = arith::ExtSIOp::create(rewriter, loc, v.getType(), low);

--- a/python/test/gluon/test_fpsan.py
+++ b/python/test/gluon/test_fpsan.py
@@ -123,7 +123,8 @@ def _unmix_payload_u32_to_f32_bits_i32(v_u32: np.ndarray) -> np.ndarray:
 
 
 def _cast_float_payload_u64(payload, src_bitwidth: int, dst_bitwidth: int) -> np.ndarray:
-    x = payload.astype(np.uint64) & _low_mask_u64(src_bitwidth)
+    src_mask = _low_mask_u64(src_bitwidth)
+    x = payload.astype(np.uint64) & src_mask
     if dst_bitwidth == src_bitwidth:
         return x
 
@@ -132,11 +133,20 @@ def _cast_float_payload_u64(payload, src_bitwidth: int, dst_bitwidth: int) -> np
         extension = _low_mask_u64(dst_bitwidth) ^ _low_mask_u64(src_bitwidth)
         return np.where((x & sign) != 0, x | extension, x) & _low_mask_u64(dst_bitwidth)
 
-    normalized = np.where((x & sign) != 0, (~x) & _low_mask_u64(src_bitwidth), x)
-    high = normalized >> np.uint64(dst_bitwidth)
+    dst_mask = _low_mask_u64(dst_bitwidth)
+    low = x & dst_mask
+    low_sign = np.uint64(1 << (dst_bitwidth - 1))
+    extension = src_mask ^ dst_mask
+    canonical = np.where((low & low_sign) != 0, low | extension, low)
+    residual = x ^ canonical
+    digit = np.uint64(3511) & dst_mask
+    multiplier = np.uint64(0)
+    for shift in range(0, src_bitwidth, dst_bitwidth):
+        multiplier |= digit << np.uint64(shift)
     with np.errstate(over="ignore"):
-        folded = x ^ (high * np.uint64(3511))
-    return folded & _low_mask_u64(dst_bitwidth)
+        high = ((residual * multiplier) & src_mask) >> np.uint64(src_bitwidth - dst_bitwidth)
+    high ^= high >> np.uint64(dst_bitwidth // 2)
+    return (low ^ high) & dst_mask
 
 
 @pytest.mark.parametrize(("src_bitwidth", "dst_bitwidth"), [(8, 16), (8, 32), (16, 32), (16, 64), (32, 64)])
@@ -147,6 +157,52 @@ def test_float_payload_upcast_downcast_identity(src_bitwidth, dst_bitwidth):
     widened = _cast_float_payload_u64(payload, src_bitwidth, dst_bitwidth)
     narrowed = _cast_float_payload_u64(widened, dst_bitwidth, src_bitwidth)
     np.testing.assert_array_equal(narrowed, payload)
+
+
+@pytest.mark.parametrize(("src_bitwidth", "dst_bitwidth"), [
+    (16, 8),
+    (32, 8),
+    (32, 16),
+    (64, 8),
+    (64, 16),
+    (64, 32),
+])
+def test_float_payload_downcast_mixes_every_discarded_bit(src_bitwidth, dst_bitwidth):
+    rng = np.random.default_rng(src_bitwidth * 257 + dst_bitwidth)
+    src_mask = _low_mask_u64(src_bitwidth)
+    payload = rng.integers(0, np.iinfo(np.uint64).max, size=512, dtype=np.uint64) & src_mask
+    payload[:5] = np.asarray([0, 1, src_mask, 1 << (src_bitwidth - 1), 1 << (dst_bitwidth - 1)], dtype=np.uint64)
+    expected = _cast_float_payload_u64(payload, src_bitwidth, dst_bitwidth)
+
+    for bit in range(dst_bitwidth, src_bitwidth):
+        flipped = payload ^ (np.uint64(1) << np.uint64(bit))
+        actual = _cast_float_payload_u64(flipped, src_bitwidth, dst_bitwidth)
+        assert np.all(actual != expected), f"{src_bitwidth}-to-{dst_bitwidth} discarded bit {bit}"
+
+
+def test_float_payload_downcast_exhaustively_mixes_discarded_bits():
+    payload = np.arange(1 << 16, dtype=np.uint64)
+    expected = _cast_float_payload_u64(payload, 16, 8)
+
+    for bit in range(8, 16):
+        flipped = payload ^ (np.uint64(1) << np.uint64(bit))
+        actual = _cast_float_payload_u64(flipped, 16, 8)
+        assert np.all(actual != expected), f"discarded bit {bit}"
+
+
+@pytest.mark.parametrize(("src_bitwidth", "dst_bitwidth"), [
+    (16, 8),
+    (32, 8),
+    (32, 16),
+    (64, 8),
+    (64, 16),
+    (64, 32),
+])
+def test_float_payload_downcast_distinguishes_top_chunk(src_bitwidth, dst_bitwidth):
+    count = min(1 << dst_bitwidth, 1 << 16)
+    payload = np.arange(count, dtype=np.uint64) << np.uint64(src_bitwidth - dst_bitwidth)
+    narrowed = _cast_float_payload_u64(payload, src_bitwidth, dst_bitwidth)
+    assert np.unique(narrowed).size == count
 
 
 @pytest.mark.parametrize(("src_bitwidth", "dst_bitwidth", "x", "y"), [
@@ -1520,6 +1576,52 @@ def test_fma_payload_semantics(device, fresh_knobs):
         z.cpu().numpy().astype(np.int32, copy=False),
     )
     _assert_payload_equal(out_np, exp_np)
+
+
+@gluon.jit
+def _cast_payload_kernel(x_ptr, out_ptr, n_elements, DST_DTYPE: gl.constexpr, BLOCK: gl.constexpr,
+                         THREADS_PER_WARP: gl.constexpr):
+    pid = gl.program_id(0)
+    layout: gl.constexpr = gl.BlockedLayout(size_per_thread=[2], threads_per_warp=[THREADS_PER_WARP], warps_per_cta=[4],
+                                            order=[0])
+    offs = pid * BLOCK + gl.arange(0, BLOCK, layout=layout)
+    mask = offs < n_elements
+    x = gl.load(x_ptr + offs, mask=mask, other=0.0)
+    gl.store(out_ptr + offs, x.to(DST_DTYPE), mask=mask)
+
+
+@pytest.mark.parametrize(("src_dtype", "dst_dtype"), [
+    ("f16", "e4m3"),
+    ("f32", "e4m3"),
+    ("f32", "f16"),
+    ("f64", "e4m3"),
+    ("f64", "f16"),
+    ("f64", "f32"),
+])
+def test_cast_payload_mixes_every_discarded_bit(device, src_dtype, dst_dtype, fresh_knobs):
+    _require_cuda_backend(device)
+    fresh_knobs.compilation.instrumentation_mode = "fpsan"
+
+    src_bitwidth = _float_dtype_info(src_dtype)[0]
+    dst_bitwidth, _, dst_storage_dtype, _, _, dst_gl_dtype = _float_dtype_info(dst_dtype)
+    baselines = np.asarray(
+        [0, 1, _low_mask_u64(src_bitwidth), 1 << (src_bitwidth - 1), 1 << (dst_bitwidth - 1)],
+        dtype=np.uint64,
+    )
+    payload = np.concatenate(
+        [baselines] + [baselines ^ (np.uint64(1) << np.uint64(bit)) for bit in range(dst_bitwidth, src_bitwidth)])
+    input_bits = _unmix_payload_to_float_bits(payload, src_dtype)
+    _, xw = _as_float_bits_tensor(input_bits, src_dtype)
+    out, outw = _as_float_bits_tensor(np.empty(payload.shape, dtype=dst_storage_dtype), dst_dtype)
+
+    block = 128
+    grid = (triton.cdiv(payload.size, block), )
+    _cast_payload_kernel[grid](xw, outw, payload.size, DST_DTYPE=dst_gl_dtype, BLOCK=block,
+                               THREADS_PER_WARP=THREADS_PER_WARP)
+
+    _assert_payload_equal(out, _cast_float_bits(input_bits, src_dtype, dst_dtype))
+    actual = _mix_float_bits(out.cpu().numpy(), dst_dtype).reshape(-1, baselines.size)
+    assert np.all(actual[1:] != actual[0])
 
 
 @gluon.jit

--- a/python/test/gluon/test_fpsan.py
+++ b/python/test/gluon/test_fpsan.py
@@ -139,10 +139,7 @@ def _cast_float_payload_u64(payload, src_bitwidth: int, dst_bitwidth: int) -> np
     extension = src_mask ^ dst_mask
     canonical = np.where((low & low_sign) != 0, low | extension, low)
     residual = x ^ canonical
-    digit = np.uint64(3511) & dst_mask
-    multiplier = np.uint64(0)
-    for shift in range(0, src_bitwidth, dst_bitwidth):
-        multiplier |= digit << np.uint64(shift)
+    multiplier = (np.uint64(3511) & dst_mask) * (src_mask // dst_mask)
     with np.errstate(over="ignore"):
         high = ((residual * multiplier) & src_mask) >> np.uint64(src_bitwidth - dst_bitwidth)
     high ^= high >> np.uint64(dst_bitwidth // 2)
@@ -159,14 +156,7 @@ def test_float_payload_upcast_downcast_identity(src_bitwidth, dst_bitwidth):
     np.testing.assert_array_equal(narrowed, payload)
 
 
-@pytest.mark.parametrize(("src_bitwidth", "dst_bitwidth"), [
-    (16, 8),
-    (32, 8),
-    (32, 16),
-    (64, 8),
-    (64, 16),
-    (64, 32),
-])
+@pytest.mark.parametrize(("src_bitwidth", "dst_bitwidth"), [(16, 8), (32, 8), (32, 16), (64, 8), (64, 16), (64, 32)])
 def test_float_payload_downcast_mixes_every_discarded_bit(src_bitwidth, dst_bitwidth):
     rng = np.random.default_rng(src_bitwidth * 257 + dst_bitwidth)
     src_mask = _low_mask_u64(src_bitwidth)
@@ -178,31 +168,6 @@ def test_float_payload_downcast_mixes_every_discarded_bit(src_bitwidth, dst_bitw
         flipped = payload ^ (np.uint64(1) << np.uint64(bit))
         actual = _cast_float_payload_u64(flipped, src_bitwidth, dst_bitwidth)
         assert np.all(actual != expected), f"{src_bitwidth}-to-{dst_bitwidth} discarded bit {bit}"
-
-
-def test_float_payload_downcast_exhaustively_mixes_discarded_bits():
-    payload = np.arange(1 << 16, dtype=np.uint64)
-    expected = _cast_float_payload_u64(payload, 16, 8)
-
-    for bit in range(8, 16):
-        flipped = payload ^ (np.uint64(1) << np.uint64(bit))
-        actual = _cast_float_payload_u64(flipped, 16, 8)
-        assert np.all(actual != expected), f"discarded bit {bit}"
-
-
-@pytest.mark.parametrize(("src_bitwidth", "dst_bitwidth"), [
-    (16, 8),
-    (32, 8),
-    (32, 16),
-    (64, 8),
-    (64, 16),
-    (64, 32),
-])
-def test_float_payload_downcast_distinguishes_top_chunk(src_bitwidth, dst_bitwidth):
-    count = min(1 << dst_bitwidth, 1 << 16)
-    payload = np.arange(count, dtype=np.uint64) << np.uint64(src_bitwidth - dst_bitwidth)
-    narrowed = _cast_float_payload_u64(payload, src_bitwidth, dst_bitwidth)
-    assert np.unique(narrowed).size == count
 
 
 @pytest.mark.parametrize(("src_bitwidth", "dst_bitwidth", "x", "y"), [
@@ -1576,52 +1541,6 @@ def test_fma_payload_semantics(device, fresh_knobs):
         z.cpu().numpy().astype(np.int32, copy=False),
     )
     _assert_payload_equal(out_np, exp_np)
-
-
-@gluon.jit
-def _cast_payload_kernel(x_ptr, out_ptr, n_elements, DST_DTYPE: gl.constexpr, BLOCK: gl.constexpr,
-                         THREADS_PER_WARP: gl.constexpr):
-    pid = gl.program_id(0)
-    layout: gl.constexpr = gl.BlockedLayout(size_per_thread=[2], threads_per_warp=[THREADS_PER_WARP], warps_per_cta=[4],
-                                            order=[0])
-    offs = pid * BLOCK + gl.arange(0, BLOCK, layout=layout)
-    mask = offs < n_elements
-    x = gl.load(x_ptr + offs, mask=mask, other=0.0)
-    gl.store(out_ptr + offs, x.to(DST_DTYPE), mask=mask)
-
-
-@pytest.mark.parametrize(("src_dtype", "dst_dtype"), [
-    ("f16", "e4m3"),
-    ("f32", "e4m3"),
-    ("f32", "f16"),
-    ("f64", "e4m3"),
-    ("f64", "f16"),
-    ("f64", "f32"),
-])
-def test_cast_payload_mixes_every_discarded_bit(device, src_dtype, dst_dtype, fresh_knobs):
-    _require_cuda_backend(device)
-    fresh_knobs.compilation.instrumentation_mode = "fpsan"
-
-    src_bitwidth = _float_dtype_info(src_dtype)[0]
-    dst_bitwidth, _, dst_storage_dtype, _, _, dst_gl_dtype = _float_dtype_info(dst_dtype)
-    baselines = np.asarray(
-        [0, 1, _low_mask_u64(src_bitwidth), 1 << (src_bitwidth - 1), 1 << (dst_bitwidth - 1)],
-        dtype=np.uint64,
-    )
-    payload = np.concatenate(
-        [baselines] + [baselines ^ (np.uint64(1) << np.uint64(bit)) for bit in range(dst_bitwidth, src_bitwidth)])
-    input_bits = _unmix_payload_to_float_bits(payload, src_dtype)
-    _, xw = _as_float_bits_tensor(input_bits, src_dtype)
-    out, outw = _as_float_bits_tensor(np.empty(payload.shape, dtype=dst_storage_dtype), dst_dtype)
-
-    block = 128
-    grid = (triton.cdiv(payload.size, block), )
-    _cast_payload_kernel[grid](xw, outw, payload.size, DST_DTYPE=dst_gl_dtype, BLOCK=block,
-                               THREADS_PER_WARP=THREADS_PER_WARP)
-
-    _assert_payload_equal(out, _cast_float_bits(input_bits, src_dtype, dst_dtype))
-    actual = _mix_float_bits(out.cpu().numpy(), dst_dtype).reshape(-1, baselines.size)
-    assert np.all(actual[1:] != actual[0])
 
 
 @gluon.jit

--- a/test/TritonGPU/fpsan.mlir
+++ b/test/TritonGPU/fpsan.mlir
@@ -305,6 +305,7 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, "ttg.thr
 module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, "ttg.threads-per-warp" = 32 : i32} {
   // CHECK-LABEL: @tmem_scratch_sliced_payloads
   tt.func public @tmem_scratch_sliced_payloads(%arg0: tensor<128x64xf32, #tmem_split>) {
+    // CHECK: arith.constant dense<-1212696649>
     // CHECK: tt.store
     // CHECK-NOT: ttng.tmem_store
     %true = arith.constant true
@@ -520,29 +521,6 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32} {
     // CHECK-NOT: arith.truncf
     %0 = arith.truncf %a : tensor<4xf32> to tensor<4xf16>
     tt.return %0 : tensor<4xf16>
-  }
-}
-
-// -----
-
-module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32} {
-  // CHECK-LABEL: @cast_fp32_to_fp8
-  tt.func public @cast_fp32_to_fp8(%a: tensor<4xf32>) -> tensor<4xf8E4M3FN> {
-    // CHECK-DAG: %[[MULTIPLIER:.*]] = arith.constant dense<-1212696649>
-    // CHECK: %[[PAYLOAD:.*]] = tti.experimental_fpsan_embed
-    // CHECK: %[[LOW:.*]] = arith.trunci %[[PAYLOAD]]
-    // CHECK: %[[CANONICAL:.*]] = arith.extsi %[[LOW]]
-    // CHECK: %[[RESIDUAL:.*]] = arith.xori %[[PAYLOAD]], %[[CANONICAL]]
-    // CHECK: %[[PRODUCT:.*]] = arith.muli %[[RESIDUAL]], %[[MULTIPLIER]]
-    // CHECK: %[[HIGH_WIDE:.*]] = arith.shrui %[[PRODUCT]]
-    // CHECK: %[[HIGH:.*]] = arith.trunci %[[HIGH_WIDE]]
-    // CHECK: %[[DIFFUSION:.*]] = arith.shrui %[[HIGH]]
-    // CHECK: %[[MIXED:.*]] = arith.xori %[[HIGH]], %[[DIFFUSION]]
-    // CHECK: %[[NARROWED:.*]] = arith.xori %[[LOW]], %[[MIXED]]
-    // CHECK: tti.experimental_fpsan_unembed %[[NARROWED]]
-    // CHECK-NOT: tt.fp_to_fp
-    %0 = tt.fp_to_fp %a, rounding = rtne : tensor<4xf32> -> tensor<4xf8E4M3FN>
-    tt.return %0 : tensor<4xf8E4M3FN>
   }
 }
 

--- a/test/TritonGPU/fpsan.mlir
+++ b/test/TritonGPU/fpsan.mlir
@@ -505,19 +505,44 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32} {
 module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32} {
   // CHECK-LABEL: @cast_truncf
   tt.func public @cast_truncf(%a: tensor<4xf32>) -> tensor<4xf16> {
-    // CHECK-DAG: %[[MULTIPLIER:.*]] = arith.constant dense<3511>
+    // CHECK-DAG: %[[MULTIPLIER:.*]] = arith.constant dense<230100407>
     // CHECK: %[[PAYLOAD:.*]] = tti.experimental_fpsan_embed
-    // CHECK: %[[SIGN:.*]] = arith.shrui %[[PAYLOAD]]
-    // CHECK: %[[SIGN_MASK:.*]] = arith.subi {{.*}}, %[[SIGN]]
-    // CHECK: %[[NORMALIZED:.*]] = arith.xori %[[PAYLOAD]], %[[SIGN_MASK]]
-    // CHECK: %[[HIGH:.*]] = arith.shrui %[[NORMALIZED]]
-    // CHECK: %[[FOLDED_HIGH:.*]] = arith.muli %[[HIGH]], %[[MULTIPLIER]]
-    // CHECK: %[[FOLDED:.*]] = arith.xori %[[PAYLOAD]], %[[FOLDED_HIGH]]
-    // CHECK: %[[NARROWED:.*]] = arith.trunci %[[FOLDED]]
+    // CHECK: %[[LOW:.*]] = arith.trunci %[[PAYLOAD]]
+    // CHECK: %[[CANONICAL:.*]] = arith.extsi %[[LOW]]
+    // CHECK: %[[RESIDUAL:.*]] = arith.xori %[[PAYLOAD]], %[[CANONICAL]]
+    // CHECK: %[[PRODUCT:.*]] = arith.muli %[[RESIDUAL]], %[[MULTIPLIER]]
+    // CHECK: %[[HIGH_WIDE:.*]] = arith.shrui %[[PRODUCT]]
+    // CHECK: %[[HIGH:.*]] = arith.trunci %[[HIGH_WIDE]]
+    // CHECK: %[[DIFFUSION:.*]] = arith.shrui %[[HIGH]]
+    // CHECK: %[[MIXED:.*]] = arith.xori %[[HIGH]], %[[DIFFUSION]]
+    // CHECK: %[[NARROWED:.*]] = arith.xori %[[LOW]], %[[MIXED]]
     // CHECK: tti.experimental_fpsan_unembed %[[NARROWED]]
     // CHECK-NOT: arith.truncf
     %0 = arith.truncf %a : tensor<4xf32> to tensor<4xf16>
     tt.return %0 : tensor<4xf16>
+  }
+}
+
+// -----
+
+module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32} {
+  // CHECK-LABEL: @cast_fp32_to_fp8
+  tt.func public @cast_fp32_to_fp8(%a: tensor<4xf32>) -> tensor<4xf8E4M3FN> {
+    // CHECK-DAG: %[[MULTIPLIER:.*]] = arith.constant dense<-1212696649>
+    // CHECK: %[[PAYLOAD:.*]] = tti.experimental_fpsan_embed
+    // CHECK: %[[LOW:.*]] = arith.trunci %[[PAYLOAD]]
+    // CHECK: %[[CANONICAL:.*]] = arith.extsi %[[LOW]]
+    // CHECK: %[[RESIDUAL:.*]] = arith.xori %[[PAYLOAD]], %[[CANONICAL]]
+    // CHECK: %[[PRODUCT:.*]] = arith.muli %[[RESIDUAL]], %[[MULTIPLIER]]
+    // CHECK: %[[HIGH_WIDE:.*]] = arith.shrui %[[PRODUCT]]
+    // CHECK: %[[HIGH:.*]] = arith.trunci %[[HIGH_WIDE]]
+    // CHECK: %[[DIFFUSION:.*]] = arith.shrui %[[HIGH]]
+    // CHECK: %[[MIXED:.*]] = arith.xori %[[HIGH]], %[[DIFFUSION]]
+    // CHECK: %[[NARROWED:.*]] = arith.xori %[[LOW]], %[[MIXED]]
+    // CHECK: tti.experimental_fpsan_unembed %[[NARROWED]]
+    // CHECK-NOT: tt.fp_to_fp
+    %0 = tt.fp_to_fp %a, rounding = rtne : tensor<4xf32> -> tensor<4xf8E4M3FN>
+    tt.return %0 : tensor<4xf8E4M3FN>
   }
 }
 


### PR DESCRIPTION
PR description written by Codex

Mix every discarded FPSan payload bit with one wide multiply. Preserve signed-extension round trips and optional homomorphic casts.

Validated with 213 passing FPSan tests and all three compiler regressions.

## Stack
Merge bottom-up:
- [ ] #11083 (this PR)
