### PR TITLE
[triton_kernels] Support MX output fused communication

### DIFF
--- a/python/triton_kernels/triton_kernels/matmul.py
+++ b/python/triton_kernels/triton_kernels/matmul.py
@@ -620,6 +620,8 @@ def matmul(a, b, bias,
     out_matmul_scale_strides = out_matmul_scale.storage.data.stride() if out_matmul_has_mx else (None, None, None, None)
     out_matmul_scale_strides = pad_strides(out_matmul_scale_strides, 4)
     out_matmul_scale_layout = None if out_matmul_scale is None else out_matmul_scale.storage.layout.name
+    if fused_comm is not None and fused_comm.out_handles.ndim == 2 and out_matmul_scale_layout != "STRIDED":
+        raise NotImplementedError("fused comm MX scale handles require strided output scales")
     if (
         scatter_indx is not None
         and out_matmul_scale is not None

--- a/python/triton_kernels/triton_kernels/matmul.py
+++ b/python/triton_kernels/triton_kernels/matmul.py
@@ -58,6 +58,8 @@ class FnName(Enum):
 
 @dataclass(frozen=True)
 class FusedComm:
+    # [n_peers] for values-only output, or [2, n_peers] with value handles
+    # followed by MX scale handles.
     out_handles: torch.Tensor
     # Map from the kernel output coord to the destination shard idx and coord.
     # Used like:
@@ -284,8 +286,6 @@ def matmul(a, b, bias,
         fused_activation = FusedActivation(FnSpecs.default(), tuple())
     if epilogue is None:
         epilogue = Epilogue(FnSpecs.default(), tuple(), tuple(), False)
-    if fused_comm is not None and precision_config.c_mx_scale is not None:
-        raise NotImplementedError("fused comm with output MX scales is not supported")
     n_slices = max(1, b.shape[0]) if a_ragged_metadata is None else a_ragged_metadata.n_slices
     # unpack b scale
     b_scale = precision_config.b_mx_scale
@@ -637,7 +637,8 @@ def matmul(a, b, bias,
     # is True the fast code path, stride(-2) == 1 takes precedence, e.g., vs.
     # w_transpose = w_storage.data.stride()[-1] != 1
     fused_comm_kwargs = {
-        "pYPtrs": fused_comm.out_handles,
+        "pYPtrs": fused_comm.out_handles[0] if fused_comm.out_handles.ndim == 2 else fused_comm.out_handles,
+        "pYScalePtrs": fused_comm.out_handles[1] if fused_comm.out_handles.ndim == 2 else None,
         "map_dst_coord": fused_comm.map_dst_coord,
         "all_writes_issued": fused_comm.all_writes_issued,
         "reduce_rank": fused_comm.reduce_rank,

--- a/python/triton_kernels/triton_kernels/matmul_details/_matmul.py
+++ b/python/triton_kernels/triton_kernels/matmul_details/_matmul.py
@@ -103,6 +103,7 @@ def _matmul(
              Y_VALUE_PACK_FACTOR: tl.constexpr = 1,
              FLATTEN_LOOPS: tl.constexpr = True, # Only relevant to persistent kernel
              pYPtrs=None,
+             pYScalePtrs=None,
              map_dst_coord=None,
              all_writes_issued=None,
              reduce_rank = 0,
@@ -645,12 +646,35 @@ def _matmul(
     if pYPtrs is None:
         tl.store(YPtrs, out, mask=mask_store)
     else:
-        tl.static_assert(not is_out_fp4, "FP4 outputs are not supported with fused comms")
         tl.static_assert(Y_TMA_MODE is None, "TMA is not supported with fused comms")
+        if is_out_fp4:
+            fused_off_n = (OUT_BLOCK_N // 2) * pid_n
+            fused_offs_y_n = offs_y_n_store
+            fused_mask = mask_store
+        else:
+            fused_off_n = OUT_BLOCK_N * pid_n
+            fused_offs_y_n = offs_y_n
+            fused_mask = mask
         dst_shard_idx, dst_y_m, dst_y_n = map_dst_coord.fn(
             off_m if WriteBackIndx is None else None, offs_y_m,
-            OUT_BLOCK_N * pid_n, offs_y_n,
+            fused_off_n, fused_offs_y_n,
             *map_dst_coord.captured)
+        if pYScalePtrs is not None:
+            tl.static_assert(is_out_microscaled)
+            _, dst_scale_m, dst_scale_n = map_dst_coord.fn(
+                off_m if WriteBackIndx is None else None,
+                offs_y_m,
+                MX_SCALE_BLOCK_N * pid_n,
+                offs_y_n_scale,
+                *map_dst_coord.captured,
+            )
+            scale_offsets = (
+                dst_scale_m.to(index_type)[:, None]
+                * stride_y_mx_m
+                * n_reduce_shards
+                + reduce_rank * stride_y_mx_m
+                + dst_scale_n[None, :] * stride_y_mx_n
+            )
         offs_mn = (
             dst_y_m.to(index_type)[:, None] * stride_y_m * n_reduce_shards + reduce_rank * stride_y_m +
             dst_y_n[None, :] * stride_y_n
@@ -665,7 +689,16 @@ def _matmul(
                 tl.multiple_of(peer_Y_ptr, 16)
             else:
                 tl.multiple_of(peer_Y_ptr, [16, 16])
-            tl.store(peer_Y_ptr + offs_mn, out, mask=mask)
+            tl.store(peer_Y_ptr + offs_mn, out, mask=fused_mask)
+            if pYScalePtrs is not None:
+                peer_scale_ptr = tl.load(pYScalePtrs + peer).to(
+                    tl.pointer_type(YActualScale.dtype.element_ty)
+                )
+                tl.store(
+                    peer_scale_ptr + scale_offsets,
+                    out_scale,
+                    mask=scale_store_mask,
+                )
 
 
     if pYPtrs is not None:

--- a/python/triton_kernels/triton_kernels/matmul_details/_matmul.py
+++ b/python/triton_kernels/triton_kernels/matmul_details/_matmul.py
@@ -211,6 +211,7 @@ def _matmul(
             W_SLICE_SIZES_DIVISIBILITY: tl.constexpr =  _W_SLICE_SIZES_DIVISIBILITY // (BLOCK_K // PACKED_BLOCK_K_W)
 
     OUT_BLOCK_N: tl.constexpr = BLOCK_N // ACTIVATION_REDUCTION_N
+    OUT_VALUE_BLOCK_N: tl.constexpr = OUT_BLOCK_N // Y_VALUE_PACK_FACTOR
     yN = N // ACTIVATION_REDUCTION_N
 
     pid = tl.program_id(0)
@@ -571,12 +572,10 @@ def _matmul(
 
     if is_out_fp4:
         tl.static_assert(Y_TMA_MODE is None, "FP4 outputs are only supported without output TMA")
-        offs_y_n_store = pid_n * (OUT_BLOCK_N // 2) + tl.arange(0, OUT_BLOCK_N // 2)
-        YPtrs = Y + offs_y_m.to(index_type)[:, None] * stride_y_m + offs_y_n_store.to(index_type)[None, :] * stride_y_n
-        mask_store = mask_m[:, None] if OUT_N_TILE_ALIGNED else mask_m[:, None] & (offs_y_n_store[None, :] < tl.cdiv(yN, 2))
-    else:
-        YPtrs = Y + offs_y_m.to(index_type)[:, None] * stride_y_m + offs_y_n.to(index_type)[None, :] * stride_y_n
-        mask_store = mask_m[:, None] if OUT_N_TILE_ALIGNED else mask_m[:, None] & mask_n[None, :]
+    offs_y_n_store = pid_n * OUT_VALUE_BLOCK_N + tl.arange(0, OUT_VALUE_BLOCK_N)
+    YPtrs = Y + offs_y_m.to(index_type)[:, None] * stride_y_m + offs_y_n_store.to(index_type)[None, :] * stride_y_n
+    mask_n_store = offs_y_n_store < tl.cdiv(yN, Y_VALUE_PACK_FACTOR)
+    mask_store = mask_m[:, None] if OUT_N_TILE_ALIGNED else mask_m[:, None] & mask_n_store[None, :]
     mask = mask_m[:, None] if OUT_N_TILE_ALIGNED else mask_m[:, None] & mask_n[None, :]
 
     if OutAcc is not None:
@@ -647,17 +646,9 @@ def _matmul(
         tl.store(YPtrs, out, mask=mask_store)
     else:
         tl.static_assert(Y_TMA_MODE is None, "TMA is not supported with fused comms")
-        if is_out_fp4:
-            fused_off_n = (OUT_BLOCK_N // 2) * pid_n
-            fused_offs_y_n = offs_y_n_store
-            fused_mask = mask_store
-        else:
-            fused_off_n = OUT_BLOCK_N * pid_n
-            fused_offs_y_n = offs_y_n
-            fused_mask = mask
         dst_shard_idx, dst_y_m, dst_y_n = map_dst_coord.fn(
             off_m if WriteBackIndx is None else None, offs_y_m,
-            fused_off_n, fused_offs_y_n,
+            OUT_VALUE_BLOCK_N * pid_n, offs_y_n_store,
             *map_dst_coord.captured)
         if pYScalePtrs is not None:
             tl.static_assert(is_out_microscaled)
@@ -669,10 +660,7 @@ def _matmul(
                 *map_dst_coord.captured,
             )
             scale_offsets = (
-                dst_scale_m.to(index_type)[:, None]
-                * stride_y_mx_m
-                * n_reduce_shards
-                + reduce_rank * stride_y_mx_m
+                (dst_scale_m.to(index_type) * n_reduce_shards + reduce_rank)[:, None] * stride_y_mx_m
                 + dst_scale_n[None, :] * stride_y_mx_n
             )
         offs_mn = (
@@ -689,7 +677,7 @@ def _matmul(
                 tl.multiple_of(peer_Y_ptr, 16)
             else:
                 tl.multiple_of(peer_Y_ptr, [16, 16])
-            tl.store(peer_Y_ptr + offs_mn, out, mask=fused_mask)
+            tl.store(peer_Y_ptr + offs_mn, out, mask=mask_store)
             if pYScalePtrs is not None:
                 peer_scale_ptr = tl.load(pYScalePtrs + peer).to(
                     tl.pointer_type(YActualScale.dtype.element_ty)

--- a/python/triton_kernels/triton_kernels/matmul_details/_p_matmul.py
+++ b/python/triton_kernels/triton_kernels/matmul_details/_p_matmul.py
@@ -123,6 +123,7 @@ def _p_matmul(
              FLATTEN_LOOPS: tl.constexpr = True,
              W_SHUFFLED: tl.constexpr = False,
              pYPtrs=None,
+             pYScalePtrs=None,
              map_dst_coord=None,
              all_writes_issued=None,
              reduce_rank=0,
@@ -756,16 +757,36 @@ def _p_matmul(
                     offs_kzmn = pid_k1.to(index_type) * stride_y_k + start_z1.to(index_type) * stride_y_z + offs_y_m.to(index_type)[:, None] * stride_y_m + offs_y_n[None, :] * stride_y_n
                     tl.store(YPtr + offs_kzmn, out, mask=mask)
             else:
-                tl.static_assert(not is_out_fp4, "FP4 outputs are not supported with fused comms")
                 tl.static_assert(Y_TMA_MODE is None, "TMA is not supported with fused comms")
                 offs_y_n = out_off_n + tl.arange(0, OUT_BLOCK_N)
                 mask_n = offs_y_n < yN
+                if is_out_fp4:
+                    offs_y_n = out_off_n + tl.arange(0, OUT_BLOCK_N // 2)
+                    mask_n = offs_y_n < tl.cdiv(yN, 2)
                 mask = mask_m[:, None] if OUT_N_TILE_ALIGNED else mask_m[:, None] & mask_n[None, :]
 
                 dst_shard_idx, dst_y_m, dst_y_n = map_dst_coord.fn(
                     start_m1 + off_m1 if WriteBackIndx is None else None, offs_y_m,
                     out_off_n, offs_y_n,
                     *map_dst_coord.captured)
+                if pYScalePtrs is not None:
+                    tl.static_assert(is_out_microscaled)
+                    _, dst_scale_m, dst_scale_n = map_dst_coord.fn(
+                        start_m1 + off_m1 if WriteBackIndx is None else None,
+                        offs_y_m,
+                        out_off_n * 2 // MX_BLOCK_SIZE,
+                        offs_y_n_scale,
+                        *map_dst_coord.captured,
+                    )
+                    scale_offsets = (
+                        pid_k1.to(index_type) * stride_y_mx_k
+                        + start_z1.to(index_type) * stride_y_mx_z
+                        + dst_scale_m.to(index_type)[:, None]
+                        * stride_y_mx_m
+                        * n_reduce_shards
+                        + reduce_rank * stride_y_mx_m
+                        + dst_scale_n[None, :] * stride_y_mx_n
+                    )
                 offs_kzmn = (
                     pid_k1.to(index_type) * stride_y_k +
                     start_z1.to(index_type) * stride_y_z +
@@ -783,6 +804,15 @@ def _p_matmul(
                     else:
                         tl.multiple_of(peer_Y_ptr, [16, 16])
                     tl.store(peer_Y_ptr + offs_kzmn, out, mask=mask)
+                    if pYScalePtrs is not None:
+                        peer_scale_ptr = tl.load(pYScalePtrs + peer).to(
+                            tl.pointer_type(YActualScale.dtype.element_ty)
+                        )
+                        tl.store(
+                            peer_scale_ptr + scale_offsets,
+                            out_scale,
+                            mask=scale_store_mask,
+                        )
 
 
     # Update the flexpoint scales

--- a/python/triton_kernels/triton_kernels/matmul_details/_p_matmul.py
+++ b/python/triton_kernels/triton_kernels/matmul_details/_p_matmul.py
@@ -201,7 +201,6 @@ def _p_matmul(
     else:
         is_x_fp4: tl.constexpr = False
     is_out_microscaled: tl.constexpr = stride_y_mx_z is not None
-    is_out_fp4: tl.constexpr = is_out_microscaled and Y_VALUE_PACK_FACTOR == 2
 
     if RAGGED_DIMENSION == "M":
         useful_grid_m = tl.load(XBlockOffs + N_SLICES)
@@ -226,6 +225,7 @@ def _p_matmul(
         SUBTILE_FACTOR: tl.constexpr = EPILOGUE_SUBTILE
     EPILOGUE_BLOCK_N: tl.constexpr = BLOCK_N // SUBTILE_FACTOR
     OUT_BLOCK_N: tl.constexpr = EPILOGUE_BLOCK_N // ACTIVATION_REDUCTION_N
+    OUT_VALUE_BLOCK_N: tl.constexpr = OUT_BLOCK_N // Y_VALUE_PACK_FACTOR
     yN = N // ACTIVATION_REDUCTION_N
 
     num_blocks = batch_size * useful_grid_m * grid_n * SPLIT_K
@@ -728,10 +728,10 @@ def _p_matmul(
                     out = EPILOGUE_FN(out, *epilogue_fn_args, target_dtype=YPtr.dtype.element_ty, pid=len(accs)*tile_id1 + a_i)
 
             out = out.to(YPtr.dtype.element_ty)
-            if is_out_fp4:
-                out_off_n = out_off_n // 2
-                offs_y_n = out_off_n + tl.arange(0, OUT_BLOCK_N // 2)
-                mask_n = offs_y_n < tl.cdiv(yN, 2)
+            out_off_n = out_off_n // Y_VALUE_PACK_FACTOR
+            offs_y_n = out_off_n + tl.arange(0, OUT_VALUE_BLOCK_N)
+            mask_n = offs_y_n < tl.cdiv(yN, Y_VALUE_PACK_FACTOR)
+            mask = mask_m[:, None] if OUT_N_TILE_ALIGNED else mask_m[:, None] & mask_n[None, :]
 
             if pYPtrs is None:
                 if USE_SCATTER_TMA:
@@ -748,22 +748,10 @@ def _p_matmul(
                     store_ragged(Y, start_m1, eM1, [pid_k, off_m1, out_off_n], out, ragged_dim=1)
                 else:
                     tl.static_assert(Y_TMA_MODE is None)
-                    offs_y_n = out_off_n + tl.arange(0, OUT_BLOCK_N)
-                    mask_n = offs_y_n < yN
-                    if is_out_fp4:
-                        offs_y_n = out_off_n + tl.arange(0, OUT_BLOCK_N // 2)
-                        mask_n = offs_y_n < tl.cdiv(yN, 2)
-                    mask = mask_m[:, None] if OUT_N_TILE_ALIGNED else mask_m[:, None] & mask_n[None, :]
                     offs_kzmn = pid_k1.to(index_type) * stride_y_k + start_z1.to(index_type) * stride_y_z + offs_y_m.to(index_type)[:, None] * stride_y_m + offs_y_n[None, :] * stride_y_n
                     tl.store(YPtr + offs_kzmn, out, mask=mask)
             else:
                 tl.static_assert(Y_TMA_MODE is None, "TMA is not supported with fused comms")
-                offs_y_n = out_off_n + tl.arange(0, OUT_BLOCK_N)
-                mask_n = offs_y_n < yN
-                if is_out_fp4:
-                    offs_y_n = out_off_n + tl.arange(0, OUT_BLOCK_N // 2)
-                    mask_n = offs_y_n < tl.cdiv(yN, 2)
-                mask = mask_m[:, None] if OUT_N_TILE_ALIGNED else mask_m[:, None] & mask_n[None, :]
 
                 dst_shard_idx, dst_y_m, dst_y_n = map_dst_coord.fn(
                     start_m1 + off_m1 if WriteBackIndx is None else None, offs_y_m,
@@ -774,17 +762,14 @@ def _p_matmul(
                     _, dst_scale_m, dst_scale_n = map_dst_coord.fn(
                         start_m1 + off_m1 if WriteBackIndx is None else None,
                         offs_y_m,
-                        out_off_n * 2 // MX_BLOCK_SIZE,
+                        out_off_n * Y_VALUE_PACK_FACTOR // MX_BLOCK_SIZE,
                         offs_y_n_scale,
                         *map_dst_coord.captured,
                     )
                     scale_offsets = (
                         pid_k1.to(index_type) * stride_y_mx_k
                         + start_z1.to(index_type) * stride_y_mx_z
-                        + dst_scale_m.to(index_type)[:, None]
-                        * stride_y_mx_m
-                        * n_reduce_shards
-                        + reduce_rank * stride_y_mx_m
+                        + (dst_scale_m.to(index_type) * n_reduce_shards + reduce_rank)[:, None] * stride_y_mx_m
                         + dst_scale_n[None, :] * stride_y_mx_n
                     )
                 offs_kzmn = (


### PR DESCRIPTION
<!---
The core Triton is a small number of people, and we receive many PRs (thank
you!).  To help us review your code more quickly, **if you are a new
contributor (less than 3 PRs merged) we ask that you complete the following
tasks and include the filled-out checklist in your PR description.**

Complete the following tasks before sending your PR, and replace `[ ]` with
`[x]` to indicate you have done them.
-->

# New contributor declaration
- [x] I am not making a trivial change, such as fixing a typo in a comment.

- [ ] I have written a PR description following these
  [rules](https://cbea.ms/git-commit/#why-not-how).

- [ ] I have run `pre-commit run --from-ref origin/main --to-ref HEAD`.

- Select one of the following.
  - [ ] I have added tests.
    - `/test` for `lit` tests
    - `/unittest` for C++ tests
    - `/python/test` for end-to-end tests
  - [ ] This PR does not need a test because `FILL THIS IN`.

- Select one of the following.
  - [ ] I have not added any `lit` tests.
  - [ ] The `lit` tests I have added follow these [best practices](https://mlir.llvm.org/getting_started/TestingGuide/#filecheck-best-practices),
    including the "tests should be minimal" section. (Usually running Python code
    and using the instructions it generates is not minimal.)

## Summary

`matmul` previously rejected fused communication whenever the output used MX scales. Callers therefore could not have the matmul kernel write both quantized values and their block scales directly into peer output buffers.

This PR extends `FusedComm.out_handles` while preserving its existing values-only form:

- `[n_peers]` contains value-buffer handles.
- `[2, n_peers]` contains value-buffer handles followed by MX-scale-buffer handles.

Both the persistent and non-persistent kernels now map and store the physical value coordinates and scale-block coordinates independently for every destination peer. Output value coordinates are normalized through `Y_VALUE_PACK_FACTOR`, so the same flow handles unpacked MXFP8 values and packed FP4 values. Communicated scale buffers are currently restricted to strided layouts.

## Validation

- `pre-commit run --from-ref origin/main --to-ref HEAD`
- Python bytecode compilation for all three modified files
- Ruff on all three modified files
- Interpreter-mode pytest import and collection smoke test for `test_matmul.py`; the selected CUDA-only test skipped as expected

The fused peer-store path has not been exercised locally on a GPU because the available development checkout has no NVIDIA driver.

## Lines Changed

| Type | Added | Removed | Net |
| --- | ---: | ---: | ---: |
| Tests | 0 | 0 | 0 |
| Core Logic | 66 | 27 | +39 |
| AutoGenerated | 0 | 0 | 0 |
| Total | 66 | 27 | +39 |

## Reviewers Guide

- `python/triton_kernels/triton_kernels/matmul.py` defines the handle layout, rejects unsupported communicated scale layouts, and forwards value and scale handle arrays to the kernels.
- `python/triton_kernels/triton_kernels/matmul_details/_matmul.py` implements the non-persistent peer stores.
- `python/triton_kernels/triton_kernels/matmul_details/_p_matmul.py` implements the persistent peer stores, including batch and split-K scale offsets.

The key invariant is that the value buffer and scale buffer use different N-coordinate systems: values use physical packed-value coordinates, while scales use MX-block coordinates. Each coordinate system is passed through `map_dst_coord` separately before its peer store. There are no generated files or code movements in this PR.