### PR TITLE
[BACKEND] Fix replicated side effects in inline asm

### DIFF
--- a/include/triton/Conversion/TritonGPUToLLVM/Utility.h
+++ b/include/triton/Conversion/TritonGPUToLLVM/Utility.h
@@ -795,6 +795,13 @@ SmallVector<Value> inlineRegion(RewriterBase &rewriter, Region &region,
 std::tuple</*prevBlock=*/Block *, /*ifBlock=*/Block *, /*thenBlock=*/Block *>
 createIfBlock(RewriterBase &b, Location loc, Value cnd);
 
+SmallVector<Value>
+broadcastTensorResult(Operation *op, RankedTensorType tensorTy,
+                      ConversionPatternRewriter &rewriter,
+                      SmallVector<Value> resultVals, Type valueElemTy,
+                      TritonLLVMOpBuilder &b, Value threadPred,
+                      const TargetInfoBase &targetInfo);
+
 void finalizeTensorAtomicResults(Operation *op, RankedTensorType tensorTy,
                                  ConversionPatternRewriter &rewriter,
                                  SmallVector<Value> &resultVals,

--- a/include/triton/Dialect/Triton/IR/TritonOps.td
+++ b/include/triton/Dialect/Triton/IR/TritonOps.td
@@ -922,6 +922,10 @@ def TT_ElementwiseInlineAsmOp : TT_Op<"elementwise_inline_asm", [
 
     The asm block is given `packed_element` elements at a time.  Exactly which
     elems it receives is unspecified.
+
+    When `pure` is false, each logical group of packed elements executes the
+    asm block once, even if the tensor layout replicates those elements across
+    physical threads.
   }];
 
   let arguments = (ins StrAttr:$asm_string, StrAttr:$constraints, BoolAttr:$pure, I32Attr:$packed_element, Variadic<AnyTypeOf<[TT_Type]>>:$args);

--- a/lib/Analysis/Allocation.cpp
+++ b/lib/Analysis/Allocation.cpp
@@ -92,6 +92,32 @@ static SmallVector<unsigned> getRepShapeForAtomic(Value result) {
   return smemShape;
 }
 
+static unsigned getInlineAsmResultScratchSize(Value result) {
+  if (result.use_empty())
+    return 0;
+
+  SmallVector<unsigned> smemShape;
+  if (auto tensorTy = dyn_cast<RankedTensorType>(result.getType())) {
+    auto freeVariableMasks =
+        gpu::toLinearLayout(tensorTy).getFreeVariableMasks();
+    auto *ctx = tensorTy.getContext();
+    bool hasThreadReplication =
+        freeVariableMasks.lookup(StringAttr::get(ctx, "lane")) != 0 ||
+        freeVariableMasks.lookup(StringAttr::get(ctx, "warp")) != 0 ||
+        freeVariableMasks.lookup(StringAttr::get(ctx, "block")) != 0;
+    if (!hasThreadReplication)
+      return 0;
+    smemShape = convertType<unsigned>(gpu::getShapePerCTA(tensorTy));
+  } else {
+    smemShape.push_back(1);
+  }
+
+  unsigned elems = getNumScratchElements(smemShape);
+  Type elemTy = getElementTypeOrSelf(result.getType());
+  unsigned bitWidth = getIntOrFloatOrPtrBitWidth(elemTy);
+  return elems * std::max(8u, bitWidth) / 8;
+}
+
 unsigned defaultAllocationAnalysisScratchSizeFn(Operation *op) {
   if (auto reduceOp = dyn_cast<ReduceOp>(op)) {
     return ReduceOpHelper(reduceOp).getScratchSizeInBytes();
@@ -125,6 +151,14 @@ unsigned defaultAllocationAnalysisScratchSizeFn(Operation *op) {
     // need to be broadcast through shared memory.
     if (!poll.getTimeout())
       return 0;
+  }
+  if (auto inlineAsm = dyn_cast<ElementwiseInlineAsmOp>(op)) {
+    if (inlineAsm.getPure())
+      return 0;
+    unsigned bytes = 0;
+    for (Value result : inlineAsm.getResults())
+      bytes = std::max(bytes, getInlineAsmResultScratchSize(result));
+    return bytes;
   }
   if (isa<gpu::LocalAtomicScatterRMWOp, AtomicPollOp>(op) ||
       isa<AtomicOpInterface>(op)) {

--- a/lib/Conversion/TritonGPUToLLVM/ElementwiseOpToLLVM.cpp
+++ b/lib/Conversion/TritonGPUToLLVM/ElementwiseOpToLLVM.cpp
@@ -198,9 +198,13 @@ struct ElementwiseInlineAsmOpConversion
     : public ConvertOpToLLVMPattern<ElementwiseInlineAsmOp> {
   using Base = ConvertOpToLLVMPattern<ElementwiseInlineAsmOp>;
 
-  using Base::Base;
   using Adaptor = typename Base::OpAdaptor;
   typedef typename Base::OpAdaptor OpAdaptor;
+
+  explicit ElementwiseInlineAsmOpConversion(LLVMTypeConverter &typeConverter,
+                                            const TargetInfoBase &targetInfo,
+                                            PatternBenefit benefit = 1)
+      : Base(typeConverter, benefit), targetInfo(targetInfo) {}
 
   // If operand size is smaller than 32 bits, pack in groups of 32 bits.
   SmallVector<Value> packOperands(ElementwiseInlineAsmOp op,
@@ -236,7 +240,8 @@ struct ElementwiseInlineAsmOpConversion
   SmallVector<SmallVector<Value>>
   createDestOps(ElementwiseInlineAsmOp op, OpAdaptor adaptor,
                 ConversionPatternRewriter &rewriter,
-                MultipleOperandsRange operands, Location loc) const {
+                MultipleOperandsRange operands, Location loc,
+                Value threadPred) const {
     auto ctx = op->getContext();
     auto b = TritonLLVMOpBuilder(loc, rewriter);
 
@@ -269,18 +274,46 @@ struct ElementwiseInlineAsmOpConversion
     Type asmRetType =
         asmRetTypes.size() > 1 ? struct_ty(asmRetTypes) : asmRetTypes[0];
 
-    Value asmResults = LLVM::InlineAsmOp::create(
-                           rewriter, loc, asmRetType,
-                           /*operands=*/packedOperands,
-                           /*asm_string=*/op.getAsmString(),
-                           /*constraints=*/op.getConstraints(),
-                           /*has_side_effects=*/!op.getPure(),
-                           /*is_align_stack=*/false, LLVM::TailCallKind::None,
-                           /*asm_dialect=*/
-                           LLVM::AsmDialectAttr::get(rewriter.getContext(),
-                                                     LLVM::AsmDialect::AD_ATT),
-                           /*operand_attrs=*/ArrayAttr())
-                           ->getResult(0);
+    auto emitInlineAsm = [&]() -> Value {
+      return LLVM::InlineAsmOp::create(
+                 rewriter, loc, asmRetType,
+                 /*operands=*/packedOperands,
+                 /*asm_string=*/op.getAsmString(),
+                 /*constraints=*/op.getConstraints(),
+                 /*has_side_effects=*/!op.getPure(),
+                 /*is_align_stack=*/false, LLVM::TailCallKind::None,
+                 /*asm_dialect=*/
+                 LLVM::AsmDialectAttr::get(rewriter.getContext(),
+                                           LLVM::AsmDialect::AD_ATT),
+                 /*operand_attrs=*/ArrayAttr())
+          ->getResult(0);
+    };
+
+    Value asmResults;
+    if (!threadPred) {
+      asmResults = emitInlineAsm();
+    } else {
+      Block *currentBlock = rewriter.getInsertionBlock();
+      Block *continuation =
+          currentBlock->splitBlock(rewriter.getInsertionPoint());
+      Region *region = currentBlock->getParent();
+      Block *asmBlock =
+          rewriter.createBlock(region, Region::iterator(continuation));
+      BlockArgument mergedResult = continuation->addArgument(asmRetType, loc);
+
+      rewriter.setInsertionPointToEnd(currentBlock);
+      Value undef = b.undef(asmRetType);
+      LLVM::CondBrOp::create(rewriter, loc, threadPred, asmBlock, ValueRange{},
+                             continuation, ValueRange{undef});
+
+      rewriter.setInsertionPointToEnd(asmBlock);
+      Value executedResult = emitInlineAsm();
+      LLVM::BrOp::create(rewriter, loc, ValueRange{executedResult},
+                         continuation);
+
+      rewriter.setInsertionPointToStart(continuation);
+      asmResults = mergedResult;
+    }
 
     // asmResults is a flat struct; pack its values into
     // [return_value][op.getPackedElement()].
@@ -329,6 +362,11 @@ struct ElementwiseInlineAsmOpConversion
     assert(all_of(unpackedOperands, [&](auto &operands) {
       return operands.size() == numElemsPerThread;
     }));
+    if (!op.getPure() && numElemsPerThread % op.getPackedElement() != 0) {
+      return op.emitError(
+          "side-effecting inline asm requires packed_element to divide the "
+          "number of unique elements per thread");
+    }
     if (numElemsPerThread % op.getPackedElement() != 0) {
       // Pad with the undef for each operand to have a multiple of
       // op.getPackedElement() elements.
@@ -338,6 +376,20 @@ struct ElementwiseInlineAsmOpConversion
         for (int i = 0; i < numPaddedValue; i++) {
           operands.push_back(b.undef(operands[0].getType()));
         }
+      }
+    }
+
+    Value threadPred;
+    if (!op.getPure()) {
+      auto freeVarMasks = getFreeVariableMasks(resultTy);
+      auto *ctx = op->getContext();
+      bool hasThreadReplication =
+          freeVarMasks.lookup(StringAttr::get(ctx, "lane")) != 0 ||
+          freeVarMasks.lookup(StringAttr::get(ctx, "warp")) != 0 ||
+          freeVarMasks.lookup(StringAttr::get(ctx, "block")) != 0;
+      if (hasThreadReplication) {
+        threadPred = emitRedundantThreadPredicate(freeVarMasks, rewriter, loc,
+                                                  targetInfo);
       }
     }
 
@@ -358,7 +410,7 @@ struct ElementwiseInlineAsmOpConversion
           block[j].push_back(os[i + j]);
         }
       }
-      auto cur = createDestOps(op, adaptor, rewriter, block, loc);
+      auto cur = createDestOps(op, adaptor, rewriter, block, loc, threadPred);
       assert(cur.size() == unpackedResults.size());
       for (unsigned j = 0; j < cur.size(); j++) {
         unpackedResults[j].insert(unpackedResults[j].end(), cur[j].begin(),
@@ -368,6 +420,44 @@ struct ElementwiseInlineAsmOpConversion
     for (auto &results : unpackedResults) {
       results.resize(numElemsPerThread);
     }
+
+    SmallVector<unsigned> usedResultIndices;
+    if (threadPred) {
+      for (auto [index, result] : llvm::enumerate(op->getResults())) {
+        if (!result.use_empty())
+          usedResultIndices.push_back(index);
+      }
+      if (!usedResultIndices.empty() && !op->hasAttr("allocation.offset")) {
+        return op.emitError(
+            "missing shared-memory allocation for replicated inline asm "
+            "result");
+      }
+    }
+
+    for (auto [broadcastIndex, resultIndex] :
+         llvm::enumerate(usedResultIndices)) {
+      Type originalResultTy = op->getResult(resultIndex).getType();
+      Type valueElemTy = getTypeConverter()->convertType(
+          getElementTypeOrSelf(originalResultTy));
+      if (auto tensorTy = dyn_cast<RankedTensorType>(originalResultTy)) {
+        unpackedResults[resultIndex] = broadcastTensorResult(
+            op, tensorTy, rewriter, unpackedResults[resultIndex], valueElemTy,
+            b, threadPred, targetInfo);
+      } else {
+        assert(unpackedResults[resultIndex].size() == 1);
+        unpackedResults[resultIndex][0] = broadcastScalarAtomicResult(
+            op, valueElemTy, unpackedResults[resultIndex][0], rewriter, b,
+            threadPred, targetInfo);
+      }
+
+      if (broadcastIndex + 1 != usedResultIndices.size()) {
+        if (lookupNumCTAs(op) == 1)
+          targetInfo.barrier(loc, rewriter, AddrSpace::Local);
+        else
+          targetInfo.clusterBarrier(loc, rewriter, op);
+      }
+    }
+
     // Reorder and pack the results.
     SmallVector<Value> outs;
     for (int i = 0; i < unpackedResults.size(); i++) {
@@ -379,6 +469,9 @@ struct ElementwiseInlineAsmOpConversion
     rewriter.replaceOp(op, outs);
     return success();
   }
+
+private:
+  const TargetInfoBase &targetInfo;
 };
 
 struct AbsIOpConversion
@@ -706,7 +799,8 @@ void mlir::triton::populateElementwiseOpToLLVMPatterns(
                                     benefit);
   patterns.add<ExternElementwiseOpConversion>(typeConverter, axisInfoAnalysis,
                                               benefit);
-  patterns.add<ElementwiseInlineAsmOpConversion>(typeConverter, benefit);
+  patterns.add<ElementwiseInlineAsmOpConversion>(typeConverter, targetInfo,
+                                                 benefit);
   patterns.add<AbsIOpConversion>(typeConverter, axisInfoAnalysis, benefit);
   patterns.add<AbsFOpConversion>(typeConverter, axisInfoAnalysis, benefit);
   patterns.add<SelectOpConversion>(typeConverter, axisInfoAnalysis, benefit);

--- a/lib/Conversion/TritonGPUToLLVM/Utility.cpp
+++ b/lib/Conversion/TritonGPUToLLVM/Utility.cpp
@@ -2132,22 +2132,15 @@ std::tuple<Block *, Block *, Block *> createIfBlock(RewriterBase &b,
   return {prevBlock, ifBlock, thenBlock};
 }
 
-void finalizeTensorAtomicResults(Operation *op, RankedTensorType tensorTy,
-                                 ConversionPatternRewriter &rewriter,
-                                 SmallVector<Value> &resultVals,
-                                 Type valueElemTy, TritonLLVMOpBuilder &b,
-                                 Value threadPred,
-                                 const TargetInfoBase &targetInfo,
-                                 const LLVMTypeConverter *typeConverter) {
+SmallVector<Value>
+broadcastTensorResult(Operation *op, RankedTensorType tensorTy,
+                      ConversionPatternRewriter &rewriter,
+                      SmallVector<Value> resultVals, Type valueElemTy,
+                      TritonLLVMOpBuilder &b, Value threadPred,
+                      const TargetInfoBase &targetInfo) {
+  assert(op->hasAttr("allocation.offset"));
   auto *ctx = rewriter.getContext();
   auto loc = op->getLoc();
-  if (!op->hasAttr("allocation.offset")) {
-    // No broadcasting, just pack the values into a struct
-    Value resultStruct =
-        packTensorElements(loc, typeConverter, resultVals, rewriter, tensorTy);
-    rewriter.replaceOp(op, {resultStruct});
-    return;
-  }
 
   auto kOffset = str_attr("offset");
   auto kBlock = str_attr("block");
@@ -2210,12 +2203,32 @@ void finalizeTensorAtomicResults(Operation *op, RankedTensorType tensorTy,
   else
     targetInfo.barrier(loc, rewriter, triton::gpu::AddrSpace::Local);
 
-  resultVals =
-      lowerLdSt(loc, ctx, loadCvt, /*valsArray=*/{}, valueElemTy, smemBases,
-                /*paddingShifts=*/{}, /*affineOffset=*/b.i32_val(0),
-                /*maskSpanAffineOffset=*/0, /*affineBlockOffset=*/Value(),
-                /*maskSpanAffineBlock=*/0, laneId, warpId, rewriter, targetInfo,
-                /*maybeMaxVecElems=*/{}, emitLd);
+  return lowerLdSt(loc, ctx, loadCvt, /*valsArray=*/{}, valueElemTy, smemBases,
+                   /*paddingShifts=*/{}, /*affineOffset=*/b.i32_val(0),
+                   /*maskSpanAffineOffset=*/0, /*affineBlockOffset=*/Value(),
+                   /*maskSpanAffineBlock=*/0, laneId, warpId, rewriter,
+                   targetInfo, /*maybeMaxVecElems=*/{}, emitLd);
+}
+
+void finalizeTensorAtomicResults(Operation *op, RankedTensorType tensorTy,
+                                 ConversionPatternRewriter &rewriter,
+                                 SmallVector<Value> &resultVals,
+                                 Type valueElemTy, TritonLLVMOpBuilder &b,
+                                 Value threadPred,
+                                 const TargetInfoBase &targetInfo,
+                                 const LLVMTypeConverter *typeConverter) {
+  auto loc = op->getLoc();
+  if (op->hasAttr("allocation.offset")) {
+    resultVals = broadcastTensorResult(op, tensorTy, rewriter, resultVals,
+                                       valueElemTy, b, threadPred, targetInfo);
+  } else {
+    // No broadcasting, just pack the values into a struct.
+    Value resultStruct =
+        packTensorElements(loc, typeConverter, resultVals, rewriter, tensorTy);
+    rewriter.replaceOp(op, {resultStruct});
+    return;
+  }
+
   // Create the result struct and replace the operation
   Value resultStruct = packUniqueTensorElements(loc, typeConverter, resultVals,
                                                 rewriter, tensorTy);

--- a/python/test/unit/language/test_core.py
+++ b/python/test/unit/language/test_core.py
@@ -5466,6 +5466,56 @@ def test_inline_asm_with_pointers(num_ctas, device):
     np.testing.assert_equal(y_ref, to_numpy(y_tri))
 
 
+def test_inline_asm_replicated_side_effects(device):
+    if not is_cuda():
+        pytest.skip('test_inline_asm is only supported in CUDA')
+
+    @triton.jit
+    def kernel(cells, output, N: tl.constexpr):
+        offsets = tl.arange(0, N)
+        result = tl.inline_asm_elementwise(
+            "red.global.add.u32 [$1], 1; mov.u32 $0, 7;",
+            "=r,l",
+            [cells + offsets],
+            dtype=tl.int32,
+            is_pure=False,
+            pack=1,
+        )
+        tl.store(output + offsets, result)
+
+    N = 32
+    cells = torch.zeros(N, dtype=torch.int32, device=device)
+    output = torch.empty_like(cells)
+    kernel[(1, )](cells, output, N=N, num_warps=4)
+
+    torch.testing.assert_close(cells, torch.ones_like(cells))
+    torch.testing.assert_close(output, torch.full_like(output, 7))
+
+
+def test_inline_asm_side_effect_pack_misaligned(device, capfd):
+    if not is_cuda():
+        pytest.skip('test_inline_asm is only supported in CUDA')
+
+    @triton.jit
+    def kernel(cells, N: tl.constexpr):
+        offsets = tl.arange(0, N)
+        tl.inline_asm_elementwise(
+            "red.global.add.u32 [$2], 1; red.global.add.u32 [$3], 1; "
+            "mov.u32 $0, 0; mov.u32 $1, 0;",
+            "=r,=r,l,l",
+            [cells + offsets],
+            dtype=tl.int32,
+            is_pure=False,
+            pack=2,
+        )
+
+    cells = torch.empty(32, dtype=torch.int32, device=device)
+    with pytest.raises(RuntimeError, match="PassManager::run failed"):
+        kernel.warmup(cells=cells, N=32, grid=(1, ), num_warps=4)
+
+    assert "side-effecting inline asm requires packed_element" in capfd.readouterr().err
+
+
 def test_inline_asm_multiple_outputs(device):
     if not is_cuda():
         pytest.skip('test_inline_asm is only supported in CUDA')

--- a/python/triton/language/core.py
+++ b/python/triton/language/core.py
@@ -3389,6 +3389,10 @@ def inline_asm_elementwise(asm: str, constraints: str, args: Sequence, dtype: Un
         Input elements of size less than 4 bytes are packed into 4-byte
         registers.
 
+        When :code:`is_pure` is false, each logical group of packed elements
+        executes once, even if its tensor layout replicates those elements
+        across physical threads.
+
         This op does not support empty :code:`dtype` -- the inline asm must
         return at least one tensor, even if you don't need it.  You can work
         around this by returning a dummy tensor of arbitrary type; it shouldn't

--- a/test/Conversion/tritongpu_to_llvm.mlir
+++ b/test/Conversion/tritongpu_to_llvm.mlir
@@ -2099,6 +2099,37 @@ module attributes {"ttg.target" = "cuda:80", "ttg.num-ctas" = 1 : i32, "ttg.num-
 
 // -----
 
+#replicated = #ttg.blocked<{sizePerThread = [1], threadsPerWarp = [32], warpsPerCTA = [4], order = [0]}>
+module attributes {"ttg.target" = "cuda:80", "ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, "ttg.threads-per-warp" = 32 : i32} {
+  // CHECK-LABEL: inline_asm_replicated_side_effect_dead_result
+  // CHECK: llvm.cond_br
+  // CHECK: llvm.inline_asm has_side_effects
+  // CHECK-SAME: "red.global.add.u32 [$1], 1; mov.u32 $0, 0;"
+  // CHECK-NOT: st.shared
+  // CHECK-NOT: nvvm.barrier
+  // CHECK: llvm.return
+  tt.func public @inline_asm_replicated_side_effect_dead_result(%ptrs: tensor<32x!tt.ptr<i32>, #replicated>) {
+    %unused = tt.elementwise_inline_asm "red.global.add.u32 [$1], 1; mov.u32 $0, 0;" {constraints = "=r,l", packed_element = 1 : i32, pure = false} %ptrs : tensor<32x!tt.ptr<i32>, #replicated> -> tensor<32xi32, #replicated>
+    tt.return
+  }
+
+  // CHECK-LABEL: inline_asm_replicated_side_effect_live_result
+  // CHECK: llvm.cond_br
+  // CHECK: llvm.inline_asm has_side_effects
+  // CHECK-SAME: "red.global.add.u32 [$1], 1; mov.u32 $0, 7;"
+  // CHECK: st.shared
+  // CHECK: nvvm.barrier
+  // CHECK: llvm.load
+  // CHECK: llvm.return
+  tt.func public @inline_asm_replicated_side_effect_live_result(%ptrs: tensor<32x!tt.ptr<i32>, #replicated>, %out: tensor<32x!tt.ptr<i32>, #replicated>) {
+    %result = tt.elementwise_inline_asm "red.global.add.u32 [$1], 1; mov.u32 $0, 7;" {constraints = "=r,l", packed_element = 1 : i32, pure = false} %ptrs : tensor<32x!tt.ptr<i32>, #replicated> -> tensor<32xi32, #replicated>
+    tt.store %out, %result : tensor<32x!tt.ptr<i32>, #replicated>
+    tt.return
+  }
+}
+
+// -----
+
 //  CHECK-LABEL: reduce_slice
 //  CHECK-NOT: st.shared
 //  CHECK-NOT: ld.shared


### PR DESCRIPTION
`tl.inline_asm_elementwise(..., is_pure=False)` currently lowers one asm call per physical tensor replica, so layouts with replicated lane, warp, or CTA bits run the same logical side effect multiple times.

For impure asm, derive the redundant-thread mask from the result layout, execute each packed group only on its canonical physical owner, and broadcast live results back through the existing atomic-result shared-memory path. Dead results avoid scratch allocation and barriers. Multiple live results reuse one max-sized scratch allocation. Packing that would require padded dummy executions is rejected explicitly.

Pure asm and impure asm without physical replication keep the existing lowering.

This is complementary to #11001: that prevents rematerialization from cloning write-effecting ops; this fixes replicas inherent in a single op's layout.

Tests:
- built `triton-opt` from source with the pinned LLVM toolchain
- full `test/Conversion/tritongpu_to_llvm.mlir` lit file
- complete CUDA inline-asm group: 7 passed on one Tesla T4

Fixes #11065.