### PR TITLE
[FRONTEND] Support compiling PTX IRSource inputs

### DIFF
--- a/python/test/unit/tools/test_irsource.py
+++ b/python/test/unit/tools/test_irsource.py
@@ -1,5 +1,7 @@
 import pathlib
+import pytest
 import triton
+from triton.backends.compiler import GPUTarget
 from triton.compiler import IRSource, make_backend
 from triton._C.libtriton import ir
 
@@ -90,3 +92,26 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 8 : i32, ttg.targ
 
     # now test compilation
     triton.compile(str(temp_file), target=target)
+
+
+@pytest.mark.skipif(target.backend != "cuda", reason="PTX compilation requires the NVIDIA backend")
+def test_ptx_compilation(tmp_path: pathlib.Path) -> None:
+    sample_ptx = r"""
+.version 8.0
+.target sm_80
+.address_size 64
+
+.visible .entry minimal_kernel()
+{
+    ret;
+}
+"""
+    temp_file = tmp_path / "minimal_kernel.ptx"
+    temp_file.write_text(sample_ptx)
+
+    compiled = triton.compile(str(temp_file), target=GPUTarget("cuda", 80, 32))
+
+    assert compiled.name == "minimal_kernel"
+    assert compiled.metadata.shared == 0
+    assert compiled.asm["ptx"] == sample_ptx
+    assert compiled.asm["cubin"]

--- a/python/triton/compiler/compiler.py
+++ b/python/triton/compiler/compiler.py
@@ -115,6 +115,8 @@ class IRSource:
         return hashlib.sha256(self.src.encode("utf-8")).hexdigest()
 
     def make_ir(self, target: GPUTarget, options, codegen_fns, module_map, context):
+        if self.ext == "ptx":
+            return self.src
         self.module.context = context
         return self.module
 
@@ -285,6 +287,9 @@ def compile(src, target=None, options=None, _env_vars=None):
         **options.__dict__,
         **env_vars,
     }
+    if isinstance(src, IRSource) and src.ext == "ptx":
+        metadata["name"] = src.name
+        metadata["shared"] = 0
     metadata["triton_version"] = __version__
     # run compilation pipeline  and populate metadata
     stages = dict()


### PR DESCRIPTION
## Summary

- pass PTX `IRSource` text directly to the first remaining backend stage
- initialize the kernel name and zero dynamic shared-memory metadata when the PTX-producing stages are skipped
- add a CUDA compile-only regression test for a minimal direct-PTX input

## Problem

`IRSource.__init__` intentionally does not construct an MLIR module for `.ptx` files. However, `IRSource.make_ir` unconditionally dereferences `self.module`, so:

```python
triton.compile("minimal.ptx", target=GPUTarget("cuda", 80, 32))
```

fails with:

```
AttributeError: 'IRSource' object has no attribute 'module'
```

Returning the PTX text alone lets `ptxas` run, but kernel construction then fails because the skipped LLVM/PTX stages normally populate `metadata["shared"]` and `metadata["name"]`.

## Testing

- `python3 -m py_compile python/triton/compiler/compiler.py python/test/unit/tools/test_irsource.py`
- Ruff 0.9.1 on the two changed files
- YAPF 0.43.0 diff check on the two changed files
- CUDA Toolkit 13.3 compile-only validation with a minimal SM80 PTX input: the patched path preserved the PTX, reported `name == "minimal_kernel"` and `shared == 0`, and produced a non-empty cubin; no kernel was launched
- The exact pytest node was not run on the remote development container because the existing module-level `get_current_target()` initialization found no active CUDA driver there; the regression test is included for CUDA CI

## Scope

This initializes dynamic shared memory to zero, matching direct PTX kernels that do not request nonzero launch-time shared memory. Supporting arbitrary `.extern .shared` requirements would need a separate explicit API rather than inferring a launch value from PTX text.
