### PR TITLE
[AMD][gfx1250] Add noalias_args pointer contract

### DIFF
--- a/include/triton/Conversion/TritonGPUToLLVM/Utility.h
+++ b/include/triton/Conversion/TritonGPUToLLVM/Utility.h
@@ -812,6 +812,8 @@ triton::FuncOp amendFuncOp(triton::FuncOp funcOp,
                            ConversionPatternRewriter &rewriter,
                            const TargetInfoBase &targetInfo);
 void handleArgPtrDatatype(triton::FuncOp funcOp, LLVM::LLVMFuncOp &llvmFuncOp);
+void handlePointerContractArgs(triton::FuncOp funcOp,
+                               LLVM::LLVMFuncOp &llvmFuncOp);
 } // namespace mlir
 
 #endif

--- a/lib/Conversion/TritonGPUToLLVM/Utility.cpp
+++ b/lib/Conversion/TritonGPUToLLVM/Utility.cpp
@@ -2297,6 +2297,22 @@ triton::FuncOp amendFuncOp(triton::FuncOp funcOp,
   return amendedFuncOp;
 }
 
+void handlePointerContractArgs(triton::FuncOp funcOp,
+                               LLVM::LLVMFuncOp &llvmFuncOp) {
+  // Map the tt.noalias caller contract to LLVM noalias on pointer args. Arg
+  // indices align with llvmFuncOp's leading args (scratch args are appended
+  // after), matching handleArgPtrDatatype.
+  MLIRContext *ctx = funcOp.getContext();
+  FunctionType fty = funcOp.getFunctionType();
+  for (unsigned i = 0; i < fty.getNumInputs(); ++i) {
+    if (!isa<triton::PointerType>(fty.getInput(i)))
+      continue;
+    if (funcOp.getArgAttr(i, "tt.noalias"))
+      llvmFuncOp.setArgAttr(i, LLVM::LLVMDialect::getNoAliasAttrName(),
+                            UnitAttr::get(ctx));
+  }
+}
+
 void handleArgPtrDatatype(triton::FuncOp funcOp, LLVM::LLVMFuncOp &llvmFuncOp) {
   // The convertion from triton::PointerType to LLVM::LLVMPointerType losts
   // the pointee datatype information.

--- a/python/triton/experimental/gluon/_runtime.py
+++ b/python/triton/experimental/gluon/_runtime.py
@@ -68,6 +68,7 @@ def jit(
     do_not_specialize_on_alignment: Optional[Iterable[int | str]] = None,
     debug: Optional[bool] = None,
     noinline: Optional[bool] = None,
+    noalias_args: Optional[Iterable[int | str]] = None,
 ) -> Callable[[T], GluonJITFunction[T]]:
     ...
 
@@ -82,6 +83,7 @@ def jit(
     do_not_specialize_on_alignment: Optional[Iterable[int | str]] = None,
     debug: Optional[bool] = None,
     noinline: Optional[bool] = None,
+    noalias_args: Optional[Iterable[int | str]] = None,
 ) -> Union[GluonJITFunction[T], Callable[[T], JITFunction[T]]]:
     """
     Decorator for JIT-compiling a function using the Triton compiler.
@@ -112,6 +114,7 @@ def jit(
             noinline=noinline,
             repr=repr,
             launch_metadata=launch_metadata,
+            noalias_args=noalias_args,
         )
 
     if fn is not None:

--- a/python/triton/runtime/jit.py
+++ b/python/triton/runtime/jit.py
@@ -304,11 +304,14 @@ class KernelParam:
     """Represents a parameter (name plus metadata) to a @jit'ed function."""
 
     def __init__(self, num: int, param: inspect.Parameter, do_not_specialize: bool,
-                 do_not_specialize_on_alignment: bool):
+                 do_not_specialize_on_alignment: bool, noalias: bool = False):
         self.num = num
         self._param = param
         self.do_not_specialize = do_not_specialize
         self.do_not_specialize_on_alignment = do_not_specialize_on_alignment
+        # noalias caller contract on a pointer arg -> tt.noalias (lowered to LLVM
+        # noalias by FuncOpToLLVM).
+        self.noalias = noalias
 
     @cached_property
     def name(self):
@@ -720,6 +723,13 @@ class JITFunction(JITCallable, KernelInterface[T]):
         attrvals = ['' if x[0] == 'constexpr' else x[1] for x in specialization]
         attrs = find_paths_if(attrvals, lambda _, x: isinstance(x, str))
         attrs = {k: backend.parse_attr(get_iterable_path(attrvals, k)) for k in attrs}
+        # user-declared noalias arg contract -> tt.noalias arg attribute, lowered
+        # to LLVM noalias by FuncOpToLLVM. Only real (non-constexpr) pointer args
+        # get it: an optional pointer passed as None specializes to constexpr and
+        # is not a runtime argument, so tagging it is invalid.
+        for p in self.params:
+            if p.noalias and specialization[p.num][0] != "constexpr":
+                attrs.setdefault((p.num, ), []).append(["tt.noalias", 1])
 
         return options, signature, constexprs, attrs
 
@@ -785,15 +795,17 @@ class JITFunction(JITCallable, KernelInterface[T]):
         return self._fn_name if self._repr is None else self._repr(_)
 
     def __init__(self, fn, version=None, do_not_specialize=None, do_not_specialize_on_alignment=None, debug=None,
-                 noinline=None, repr=None, launch_metadata=None):
+                 noinline=None, repr=None, launch_metadata=None, noalias_args=None):
         do_not_specialize = do_not_specialize if do_not_specialize else []
         do_not_specialize_on_alignment = do_not_specialize_on_alignment if do_not_specialize_on_alignment else []
+        noalias_args = noalias_args if noalias_args else []
 
         super().__init__(fn)
         self.module = fn.__module__
         self.version = version
         self.do_not_specialize = do_not_specialize
         self.do_not_specialize_on_alignment = do_not_specialize_on_alignment
+        self.noalias_args = noalias_args
         self._repr = repr
         self.launch_metadata = launch_metadata
         # Register for simple deserialization of JITFunction constants
@@ -803,7 +815,8 @@ class JITFunction(JITCallable, KernelInterface[T]):
         for i, param in enumerate(self.signature.parameters.values()):
             dns = i in do_not_specialize or param.name in do_not_specialize
             dns_oa = i in do_not_specialize_on_alignment or param.name in do_not_specialize_on_alignment
-            self.params.append(KernelParam(i, param, dns, dns_oa))
+            na = i in noalias_args or param.name in noalias_args
+            self.params.append(KernelParam(i, param, dns, dns_oa, na))
 
         # cache of just-in-time compiled kernels
         self.device_caches = defaultdict(self.create_binder)
@@ -947,6 +960,7 @@ def jit(
     do_not_specialize_on_alignment: Optional[Iterable[int | str]] = None,
     debug: Optional[bool] = None,
     noinline: Optional[bool] = None,
+    noalias_args: Optional[Iterable[int | str]] = None,
 ) -> Callable[[T], JITFunction[T]]:
     ...
 
@@ -961,6 +975,7 @@ def jit(
     do_not_specialize_on_alignment: Optional[Iterable[int | str]] = None,
     debug: Optional[bool] = None,
     noinline: Optional[bool] = None,
+    noalias_args: Optional[Iterable[int | str]] = None,
 ) -> KernelInterface[T]:
     """
     Decorator for JIT-compiling a function using the Triton compiler.
@@ -997,6 +1012,7 @@ def jit(
                 noinline=noinline,
                 repr=repr,
                 launch_metadata=launch_metadata,
+                noalias_args=noalias_args,
             )
 
     if fn is not None:

--- a/test/Conversion/amd/tt_arg_contract.mlir
+++ b/test/Conversion/amd/tt_arg_contract.mlir
@@ -1,0 +1,16 @@
+// The tt.noalias argument attribute (a frontend-surfaced caller contract) lowers
+// to the LLVM parameter attribute llvm.noalias on kernel pointer arguments.
+// See FuncOpToLLVM / handlePointerContractArgs.
+
+// RUN: triton-opt %s --convert-triton-amdgpu-to-llvm=gfx-arch=gfx1250 | FileCheck %s
+
+module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.target = "hip:gfx1250", "ttg.threads-per-warp" = 32 : i32} {
+  // CHECK-LABEL: llvm.func @contract
+  // CHECK-SAME: %arg0: !llvm.ptr<1> {llvm.noalias
+  // CHECK-NOT: %arg1: !llvm.ptr<1> {llvm.noalias
+  tt.func public @contract(
+      %arg0: !tt.ptr<i16> {tt.noalias = 1 : i32},
+      %arg1: !tt.ptr<f16>) {
+    tt.return
+  }
+}

--- a/third_party/amd/lib/TritonAMDGPUToLLVM/FuncOpToLLVM.cpp
+++ b/third_party/amd/lib/TritonAMDGPUToLLVM/FuncOpToLLVM.cpp
@@ -26,6 +26,7 @@ struct FuncOpConversion : public ConvertOpToLLVMPattern<triton::FuncOp> {
     auto ctx = funcOp->getContext();
     LLVM::LLVMFuncOp newFuncOp = *maybeNewFuncOp;
     handleArgPtrDatatype(funcOp, newFuncOp);
+    handlePointerContractArgs(funcOp, newFuncOp);
 
     if (triton::isKernel(funcOp)) {
       newFuncOp.setLinkage(LLVM::Linkage::External);

--- a/third_party/amd/python/examples/gluon/moe_gfx1250.py
+++ b/third_party/amd/python/examples/gluon/moe_gfx1250.py
@@ -978,7 +978,7 @@ class MoESliceNKProgram:
         return accumulator
 
 
-@gluon.jit
+@gluon.jit(noalias_args=["GatherIndx"])
 def _matmul(Y, stride_y_k, stride_y_z, stride_y_m, stride_y_n, X, stride_x_z, stride_x_m, stride_x_k, XMxScale,
             stride_x_mx_z, stride_x_mx_m, stride_x_mx_k, W, stride_w_e, stride_w_k, stride_w_n,
             W_TRANSPOSE: gl.constexpr, WMxScale, stride_w_mx_e, stride_w_mx_k, stride_w_mx_n, B, stride_b_e,  # Bias


### PR DESCRIPTION
## Summary

This PR adds an explicit `noalias_args` caller contract to `triton.jit` and `gluon.jit`, then lowers it through AMD FuncOp conversion to LLVM's `noalias` parameter attribute.

```python
  @triton.jit(noalias_args=["GatherIndx"])
  def kernel(..., GatherIndx, ...):
```

The frontend attaches tt.noalias to selected runtime pointer arguments. The AMD TritonGPU-to-LLVM lowering maps that attribute to noalias on the corresponding LLVM function parameter.

## Semantics

`noalias_args` is a caller contract, not a type qualifier. It does not make a pointer read-only, and it does not change which Triton operations are legal through that pointer. The contract follows LLVM parameter noalias semantics: memory accessed through pointer values based on the marked argument is not also accessed through pointer values not based on that argument during the kernel invocation. This is roughly analogous to C restrict.

This is intentionally separate from `tl.const` / `readonly` semantics. readonly answers whether the kernel writes through a pointer. noalias answers whether another pointer argument may refer to the same memory. They use similar LLVM parameter-attribute plumbing, but they are not the same semantic promise.

LLVM reference: https://llvm.org/docs/LangRef.html#parameter-attributes

## Motivation

The problem is a redundant VGPR-to-SGPR round trip on MI450 MoE TDM gather indices. The gather row indices are logically wave-uniform and are ultimately consumed as scalar operands by `tensor_load_to_lds`, but without enough aliasing information LLVM may still load them through vector memory instructions into VGPRs, then recover the scalar value with in-loop `v_readfirstlane_b32`.

The motivating gfx1250 case is the MoE a8w4 gather-index load. LLVM can infer that the kernel does not write through `GatherIndx` directly. However, without `noalias`, LLVM must still conservatively assume that a store through another pointer argument may clobber the gather-index buffer. In particular, the relevant store is the final TDM writeback through `Y`, lowered as `llvm.amdgcn.tensor.store.from.lds` / `tensor_store_from_lds`. The compiler cannot prove that this store's destination does not alias `GatherIndx` unless the caller provides that fact.

With `noalias` on `GatherIndx`, LLVM has the missing aliasing information. Its existing analysis and ISel path select scalar loads for the gather indices, avoiding the vector-load plus `v_readfirstlane_b32` round trip. No custom Triton s_load lowering or invariant-load metadata is needed. In the broader local prefill kernel, the static in-loop gather-index readfirstlane count went from 16 to 0.

### Before

In loop 16 v_readfirstlanes

```assembly
  v_readfirstlane_b32 s28, v56
  v_readfirstlane_b32 s61, v57
  v_readfirstlane_b32 s60, v52
  ...
  v_readfirstlane_b32 s31, v53
  tensor_load_to_lds s[88:91], s[44:51], s[28:31], s[60:63]
```

### After

All 16 v_readfirstlane_b32 are gone, tdm loads consume SGPR operands directly, and sgpr loads are hoisted out of loop in prologue:

```assembly
  s_load_b256 s[60:67], s[38:39], 0x4
  ...
```

I measured the performance impact of batch size of 256/512 prefill style MoE kernel and the speedup is between 1% to 2%. 

## Notes

  - This is not expected to be a broad win for unrelated kernels. The useful case is a wave-uniform pointer load where LLVM can infer direct read-only use, but still needs noalias to rule out clobbers through other pointer arguments.
  - noalias_args is opt-in. Triton does not mark all pointer arguments noalias by default because that would impose a caller contract that existing programs may violate.
  - Optional pointer arguments specialized to None are skipped because they become constexprs, not runtime LLVM function parameters.