### PR TITLE
[AMD] Fix missing MachineSink fence for scalar atomic-in-loop on gfx950

### DIFF
--- a/test/Conversion/amd/tritongpu_to_llvm.mlir
+++ b/test/Conversion/amd/tritongpu_to_llvm.mlir
@@ -69,7 +69,7 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32} {
     // CHECK: llvm.atomicrmw
     // CHECK: llvm.store
     // CHECK: llvm.br
-    // COMMON: llvm.inline_asm has_side_effects asm_dialect = att operand_attrs = [] "", "~{memory}"
+    // COMMON: llvm.inline_asm {{.*}}"~{memory}"
     // COMMON: llvm.fence syncscope("workgroup") release {llvm.mmra = [[$LOCAL_MMRA_TAG]]}
     // COMMON-NEXT: rocdl.s.barrier
     // COMMON-NEXT: llvm.fence syncscope("workgroup") acquire {llvm.mmra = [[$LOCAL_MMRA_TAG]]}
@@ -91,7 +91,7 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32} {
     // COMMON-NOT: rocdl.s.barrier
     // COMMON: llvm.atomicrmw fadd {{.*}} acquire
     // COMMON: llvm.store {{.*}} : f32, !llvm.ptr<3>
-    // COMMON: llvm.inline_asm has_side_effects asm_dialect = att operand_attrs = [] "", "~{memory}"
+    // COMMON: llvm.inline_asm {{.*}}"~{memory}"
     // COMMON: rocdl.s.barrier
     // COMMON: llvm.load {{.*}} : !llvm.ptr<3> -> f32
     // COMMON-NOT: rocdl.s.barrier

--- a/test/Conversion/amd/tritongpu_to_llvm.mlir
+++ b/test/Conversion/amd/tritongpu_to_llvm.mlir
@@ -63,13 +63,13 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32} {
   // CHECK-LABEL: atomic_add_f32_scalar
   // GFX1250-LABEL: atomic_add_f32_scalar
   tt.func @atomic_add_f32_scalar(%arg0 : !tt.ptr<f32>, %arg1 : i1, %arg2 : f32) {
-    // Scalar atomics should not have the compiler fence (no tensorTy)
-    // GFX1250-NOT: llvm.inline_asm
+    // Scalar atomics need the compiler fence on every target now, not just GFX1250.
     // CHECK: llvm.cond_br
     // GFX1250: llvm.cond_br
     // CHECK: llvm.atomicrmw
     // CHECK: llvm.store
     // CHECK: llvm.br
+    // COMMON: llvm.inline_asm has_side_effects asm_dialect = att operand_attrs = [] "", "~{memory}"
     // COMMON: llvm.fence syncscope("workgroup") release {llvm.mmra = [[$LOCAL_MMRA_TAG]]}
     // COMMON-NEXT: rocdl.s.barrier
     // COMMON-NEXT: llvm.fence syncscope("workgroup") acquire {llvm.mmra = [[$LOCAL_MMRA_TAG]]}
@@ -91,6 +91,7 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32} {
     // COMMON-NOT: rocdl.s.barrier
     // COMMON: llvm.atomicrmw fadd {{.*}} acquire
     // COMMON: llvm.store {{.*}} : f32, !llvm.ptr<3>
+    // COMMON: llvm.inline_asm has_side_effects asm_dialect = att operand_attrs = [] "", "~{memory}"
     // COMMON: rocdl.s.barrier
     // COMMON: llvm.load {{.*}} : !llvm.ptr<3> -> f32
     // COMMON-NOT: rocdl.s.barrier

--- a/third_party/amd/lib/TritonAMDGPUToLLVM/LoadStoreOpToLLVM.cpp
+++ b/third_party/amd/lib/TritonAMDGPUToLLVM/LoadStoreOpToLLVM.cpp
@@ -172,6 +172,23 @@ LogicalResult emitFence(Operation *op, ConversionPatternRewriter &rewriter,
   return success();
 }
 
+// Stops LLVM's MachineSink from sinking loads past a barrier that follows.
+// Workaround for https://github.com/llvm/llvm-project/issues/181708.
+void emitMachineSinkBarrierFence(ConversionPatternRewriter &rewriter,
+                                 Location loc) {
+  auto asmDialectAttr = LLVM::AsmDialectAttr::get(rewriter.getContext(),
+                                                  LLVM::AsmDialect::AD_ATT);
+  auto asmTy = LLVM::LLVMVoidType::get(rewriter.getContext());
+  LLVM::InlineAsmOp::create(
+      rewriter, loc, asmTy,
+      /*operands=*/ValueRange{},
+      /*asm_string=*/"",
+      /*constraints=*/"~{memory}",
+      /*has_side_effects=*/true,
+      /*is_align_stack=*/false, LLVM::TailCallKind::None, asmDialectAttr,
+      /*operand_attrs=*/ArrayAttr::get(rewriter.getContext(), {}));
+}
+
 Value emitRedundantThreadPredicateNonNull(
     const llvm::MapVector<StringAttr, int32_t> &freeVarMasks,
     ConversionPatternRewriter &rewriter, Location loc,
@@ -2392,49 +2409,9 @@ struct AtomicRMWOpConversion
                   loc, rewriter, targetInfo, op.getOperation()))
             : std::nullopt;
 
-    // Emit a compiler fence to prevent LLVM's MachineSink from sinking
-    // preceding LDS loads (e.g., from ConvertLayoutOps that feed into this
-    // atomic) past barriers introduced by the atomic lowering below.
-    //
-    // Root cause: MachineSink's isSafeToMove() only sets SawStore for
-    // instructions with mayStore(), not for UnmodeledSideEffects. AMDGPU
-    // barriers have UnmodeledSideEffects but not mayStore(), so loads can
-    // be sunk past them into successor blocks.
-    //
-    // When buffer atomics are not enabled for the target (see
-    // ConvertToBufferOps.cpp), this AtomicRMWOp lowering path is used instead.
-    // emitAtomicRMW() below creates a condBr that splits the current block to
-    // mask which threads execute the atomic. Without this fence, preceding LDS
-    // loads (from ConvertLayoutOps or reduce cross-warp communication) can be
-    // sunk past barriers in the successor blocks. On targets where buffer
-    // atomics ARE enabled (e.g., gfx950), LLVM replaces the condBr with buffer
-    // atomic OOB offset masking, eliminating the block split entirely and
-    // avoiding this issue.
-    //
-    // This inline asm has mayStore()=true via the "~{memory}" constraint,
-    // which sets SawStore in MachineSink's bottom-up walk, preventing any
-    // preceding loads from being sunk past this point.
-    //
-    // This is the only fence needed: emitAtomicRMW() is the only lowering
-    // pattern that creates a condBr splitting a block with preceding LDS
-    // loads where successor blocks contain barriers. If new lowering
-    // patterns with similar structure are added, they will need their own
-    // fence.
-    //
-    // This is a workaround for
-    // https://github.com/llvm/llvm-project/issues/181708.
+    // Needed on GFX1250 because buffer atomics don't remove the condBr there.
     if (tensorTy && targetInfo.getISAFamily() == ISAFamily::GFX1250) {
-      auto asmDialectAttr = LLVM::AsmDialectAttr::get(rewriter.getContext(),
-                                                      LLVM::AsmDialect::AD_ATT);
-      auto asmTy = LLVM::LLVMVoidType::get(rewriter.getContext());
-      LLVM::InlineAsmOp::create(
-          rewriter, loc, asmTy,
-          /*operands=*/ValueRange{},
-          /*asm_string=*/"",
-          /*constraints=*/"~{memory}",
-          /*has_side_effects=*/true,
-          /*is_align_stack=*/false, LLVM::TailCallKind::None, asmDialectAttr,
-          /*operand_attrs=*/ArrayAttr::get(rewriter.getContext(), {}));
+      emitMachineSinkBarrierFence(rewriter, loc);
     }
 
     SmallVector<Value> resultVals(elemsPerThread);
@@ -2497,6 +2474,11 @@ struct AtomicRMWOpConversion
             return success();
           }
           Value atomPtr = *atomicSharedMemBase;
+
+          // Scalar atomics never use buffer atomics, so they always hit the
+          // same condBr-then-barrier pattern the fence above protects.
+          // Needed here on every target, not just GFX1250.
+          emitMachineSinkBarrierFence(rewriter, loc);
           b.barrier(triton::gpu::AddrSpace::Local);
           Value ret = b.load(valueElemTy, atomPtr);
 

--- a/third_party/amd/python/test/test_atomic_add_in_loop_gfx950.py
+++ b/third_party/amd/python/test/test_atomic_add_in_loop_gfx950.py
@@ -1,0 +1,85 @@
+"""
+Regression test for https://github.com/triton-lang/triton/issues/11037.
+tl.atomic_add inside a while loop hangs on AMD gfx950 (MI350 class).
+"""
+
+import numpy as np
+import pytest
+import torch
+import triton
+import triton.language as tl
+from triton.compiler import ASTSource, compile as triton_compile
+from triton.backends.compiler import GPUTarget
+from triton._internal_testing import is_hip_cdna4
+
+TARGET = GPUTarget("hip", "gfx950", 64)
+
+
+@triton.jit
+def single(counter_ptr, out_ptr, N):
+    idx = tl.atomic_add(counter_ptr, 1)
+    if idx < N:
+        tl.store(out_ptr + idx, idx + 1)
+
+
+@triton.jit
+def steal(counter_ptr, out_ptr, N):
+    idx = tl.atomic_add(counter_ptr, 1)
+    while idx < N:
+        tl.store(out_ptr + idx, idx + 1)
+        idx = tl.atomic_add(counter_ptr, 1)
+
+
+def compile_steal():
+    src = ASTSource(
+        fn=steal,
+        signature={"counter_ptr": "*i32", "out_ptr": "*i32", "N": "i32"},
+        constexprs={},
+    )
+    compiled = triton_compile(src, target=TARGET)
+    return compiled.asm["amdgcn"]
+
+
+def test_fence_precedes_barrier_for_scalar_atomic_in_loop():
+    """The scalar atomic's LDS-broadcast barrier must be preceded by the
+    MachineSink compiler fence, just like the tensor-atomic case on gfx1250."""
+
+    amdgcn = compile_steal()
+    lines = amdgcn.splitlines()
+
+    # The fence itself does not show up as a named instruction, so check
+    # instruction order instead: condBr, then the atomic, then the barrier.
+    barrier_idx = next((i for i, l in enumerate(lines) if "s_barrier" in l), None)
+    assert barrier_idx is not None, "expected an s_barrier broadcasting the atomic result"
+
+    cbranch_idx = next((i for i, l in enumerate(lines) if "s_cbranch" in l), None)
+    assert cbranch_idx is not None, "expected an s_cbranch from the atomic's condBr thread masking"
+
+    global_atomic_idx = next((i for i, l in enumerate(lines) if "global_atomic" in l), None)
+    assert global_atomic_idx is not None, "expected a global_atomic instruction"
+
+    # Ordering must be: condBr, atomic (inside the masked block), barrier.
+    assert cbranch_idx < global_atomic_idx < barrier_idx, (
+        "unexpected instruction ordering around the atomic's condBr/barrier; "
+        f"s_cbranch={cbranch_idx}, global_atomic={global_atomic_idx}, s_barrier={barrier_idx}")
+
+
+@pytest.mark.skipif(not is_hip_cdna4(), reason="Requires gfx950 (MI350-class) hardware")
+def test_gpu_work_stealing_terminates():
+    """Exact repro from #11037: single-atomic control must pass, and the
+    work-stealing while-loop kernel must terminate with correct output."""
+
+    n_progs, N = 1024, 1024
+    counter = torch.zeros(1, dtype=torch.int32, device="cuda")
+    out = torch.zeros(N, dtype=torch.int32, device="cuda")
+    single[(n_progs, )](counter, out, N)
+    torch.cuda.synchronize()
+    assert torch.equal(out, torch.arange(1, N + 1, dtype=torch.int32, device="cuda"))
+
+    n_progs, N = 64, 50000
+    counter = torch.zeros(1, dtype=torch.int32, device="cuda")
+    out = torch.zeros(N, dtype=torch.int32, device="cuda")
+    steal[(n_progs, )](counter, out, N)
+    torch.cuda.synchronize()
+    assert int(counter[0]) == N
+    np.testing.assert_array_equal(out.cpu().numpy(), np.arange(1, N + 1, dtype=np.int32))


### PR DESCRIPTION
Fixes #11037.

Problem
tl.atomic_add called inside a while loop for global work-stealing
hangs on gfx950. A single atomic call outside a loop works fine, so
the bug only shows up when the same atomic is called repeatedly in a
loop.

Root cause
A scalar atomic RMW whose result is used can never be lowered as a
buffer atomic, because canUseBufferOps() in ConvertToBufferOps.cpp
requires a tensor typed offset. So this case always goes through
emitAtomicRMW() in AtomicRMWOpsEmitter.cpp, which splits the code into
a branch: one lane runs the atomic, stores the result to LDS, and then
every lane hits a barrier to read the result back.

This exact pattern, a branch followed by a barrier, was already found
to be unsafe on some targets because LLVM's MachineSink pass can sink
loads past the barrier (llvm/llvm-project#181708). That was already
fixed for tensor atomics on GFX1250 in LoadStoreOpToLLVM.cpp, but the
fix never covered this scalar case, on any target.

A single execution of this pattern is harmless, which is why the
non-looped control kernel in the issue works. Replaying it every loop
iteration is what triggers the hang.

Fix
Added the same compiler fence before the barrier in the scalar atomic
path too, in third_party/amd/lib/TritonAMDGPUToLLVM/LoadStoreOpToLLVM.cpp.
Pulled the fence code into a small shared function,
emitMachineSinkBarrierFence(), used by both the existing GFX1250 tensor
case and the new scalar case. The fence is applied on every target for
the scalar case, since it never gets the buffer atomic path that would
otherwise avoid the branch.

Tests
- test/Conversion/amd/tritongpu_to_llvm.mlir: updated two existing lit
  tests (atomic_add_f32_scalar and atomic_rmw_acquire_staged_result) to
  check that the fence now appears before the barrier.
- third_party/amd/python/test/test_atomic_add_in_loop_gfx950.py: new
  end to end test, following the same pattern as
  test_compiler_fence_gfx1250.py. It compiles the exact steal kernel
  from the issue and checks instruction ordering in the generated
  assembly, and also runs the full repro on hardware when gfx950 is
  available.

Note
I do not have gfx950 hardware, so this has not been verified against
the actual repro yet. Would appreciate it if someone with access could
run the tests above and the original repro against this branch to
confirm it fixes the hang.