### PR TITLE
[interpreter] Count tl.histogram bins in int32, not the input dtype

### DIFF
--- a/python/test/unit/language/test_core.py
+++ b/python/test/unit/language/test_core.py
@@ -3194,6 +3194,31 @@ def test_histogram_silent_data_corruption(device):
     histogram_kernel[(1, )](x, z)
     assert z[1] == 1, f"Second element shouldn't be affected, expected_buffer=[1, 1], actual_buffer={z}"
 
+@pytest.mark.interpreter
+@pytest.mark.parametrize("dtype_str, M", [("int8", 300), ("int16", 70000), ("int32", 300)])
+def test_histogram_narrow_input_dtype(dtype_str, M, device):
+    # The bin count must not depend on the width of the input element type:
+    # tl.histogram always returns int32. Counts >= 2**8 / 2**16 used to wrap when
+    # they were accumulated in the input dtype.
+    if M > 4096 and not is_interpreter():
+        pytest.skip("block size needed to exceed the int16 modulus is impractical on device")
+
+    @triton.jit
+    def histogram_kernel(x_ptr, z_ptr, M: tl.constexpr, N: tl.constexpr):
+        offset1 = tl.arange(0, M)
+        offset2 = tl.arange(0, N)
+        x = tl.load(x_ptr + offset1)
+        z = tl.histogram(x, N)
+        tl.store(z_ptr + offset2, z)
+
+    N = 2
+    # M elements all landing in bin 0, so the expected count is exactly M.
+    x = torch.zeros((triton.next_power_of_2(M), ), device=device, dtype=getattr(torch, dtype_str))
+    x[M:] = 1
+    z = torch.empty(N, dtype=torch.int32, device=device)
+    histogram_kernel[(1, )](x, z, M=triton.next_power_of_2(M), N=N)
+    assert z[0] == M, f"expected bin 0 count {M}, got {z[0].item()}"
+
 
 # ------------------------
 # test histogram with mask

--- a/python/test/unit/runtime/test_autotuner.py
+++ b/python/test/unit/runtime/test_autotuner.py
@@ -262,6 +262,48 @@ def test_prune_configs_fractional_top_k_keeps_one(device: str):
     _kernel[grid](dst, src, N=N)
     torch.testing.assert_close(src, dst)
 
+def test_prune_configs_fractional_top_k_uses_pruned_count(device: str):
+    # A fractional top_k is a fraction of the configs that survived
+    # early_config_prune, not of the original config list. With 8 configs
+    # pruned down to 4 and top_k=0.5, exactly 2 configs should be benchmarked;
+    # scaling the original count instead would give top_k=4 and bench all 4.
+    N = 1024
+    src = torch.randn(N, device=device)
+    dst = torch.empty(N, device=device)
+
+    benched = []
+
+    def counting_bench(kernel_call, quantiles=None, **kwargs):
+        benched.append(1)
+        return do_bench(kernel_call, quantiles=quantiles, **kwargs)
+
+    def early_config_prune(configs, named_args, **kwargs):
+        return [c for c in configs if c.kwargs['BLOCK_SIZE'] >= 32]
+
+    def perf_model(*args, **kwargs):
+        return kwargs['BLOCK_SIZE']
+
+    configs = [triton.Config(kwargs={'BLOCK_SIZE': bs}) for bs in [1, 2, 4, 8, 32, 64, 128, 256]]
+    prune_configs_by = {
+        'perf_model': perf_model,
+        'early_config_prune': early_config_prune,
+        'top_k': 0.5,
+    }
+
+    @triton.autotune(configs=configs, key=['N'], prune_configs_by=prune_configs_by, do_bench=counting_bench)
+    @triton.jit
+    def _kernel(dst, src, N, BLOCK_SIZE: tl.constexpr):
+        offsets = tl.program_id(0) * BLOCK_SIZE + tl.arange(0, BLOCK_SIZE)
+        x = tl.load(src + offsets, mask=offsets < N)
+        tl.store(dst + offsets, x, mask=offsets < N)
+
+    grid = lambda META: (triton.cdiv(N, META['BLOCK_SIZE']), )
+    _kernel[grid](dst, src, N=N)
+    torch.testing.assert_close(src, dst)
+    assert len(benched) == 2
+
+
+
 
 def test_config_ir_override_changes_disk_cache_key():
     # Autotuner derives persisted result-cache keys from Config.__str__().

--- a/python/triton/runtime/autotuner.py
+++ b/python/triton/runtime/autotuner.py
@@ -296,6 +296,7 @@ class Autotuner(KernelInterface):
                 # the later min() on an empty set. early_config_prune already
                 # guarantees at least one config; mirror that here.
                 top_k = max(1, int(len(self.configs) * top_k))
+                top_k = max(1, int(len(pruned_configs) * top_k))
             elif not isinstance(top_k, int):
                 # Slice index must be an integer
                 raise TypeError("Error while pruning configs, top_k must be either 1) a float <= 1.0 or 2) an int")

--- a/python/triton/runtime/interpreter.py
+++ b/python/triton/runtime/interpreter.py
@@ -734,6 +734,16 @@ class InterpreterBuilder:
         # But unexpectedly int64 values are being returned causing
         # tl.store to write 8 bytes instead of 4 bytes which lead to silent data corruption
         dummy_weights = np.ones_like(data.data, dtype=data.data.dtype)
+        # np.histogram takes the dtype of its result from `weights` and otherwise
+        # defaults to int64, which made tl.store write 8 bytes instead of 4 and
+        # silently corrupt the neighbouring data. Deriving the weights dtype from
+        # the *input* instead fixed that, but overshot for sub-32-bit integer
+        # inputs: the count itself was then accumulated in int8/int16 and wrapped
+        # (a true count of 300 came back as 44 for an int8 input).
+        # tl.histogram always yields an int32 result regardless of the input dtype
+        # (see semantic.py), and the GPU accumulates with an i32 atomic add, so
+        # count in int32 here to match both.
+        dummy_weights = np.ones_like(data.data, dtype=np.int32)
 
         # force all masked elements to zero
         data = np.where(mask.data, data.data, np.zeros_like(data.data))


### PR DESCRIPTION
# New contributor declaration
- [x] I am not making a trivial change, such as fixing a typo in a comment.
- [x] I have written a PR description following these
  [rules](https://cbea.ms/git-commit/#why-not-how).
- [x] I have run `pre-commit run --from-ref origin/main --to-ref HEAD`.
- Select one of the following.
  - [x] I have added tests.
    - `/test` for `lit` tests
    - `/unittest` for C++ tests
    - `/python/test` for end-to-end tests
  - [ ] This PR does not need a test because `FILL THIS IN`.
- Select one of the following.
  - [x] I have not added any `lit` tests.
  - [ ] The `lit` tests I have added follow these [best practices](https://mlir.llvm.org/getting_started/TestingGuide/#filecheck-best-practices),
    including the "tests should be minimal" section. (Usually running Python code
    and using the instructions it generates is not minimal.)