### PR TITLE
[Compiler] Remove duplicate code in compile function

### DIFF
--- a/python/triton/compiler/compiler.py
+++ b/python/triton/compiler/compiler.py
@@ -311,10 +311,9 @@ def compile(src, target=None, options=None, _env_vars=None):
 
     if ir_source:
         ir_filename = f"{file_name}.{src.ext}"
-        metadata_group[ir_filename] = fn_cache_manager.put(module, ir_filename)
     else:
         ir_filename = f"{file_name}.source"
-        metadata_group[ir_filename] = fn_cache_manager.put(module, ir_filename)
+    metadata_group[ir_filename] = fn_cache_manager.put(module, ir_filename)
 
     use_ir_loc = knobs.compilation.use_ir_loc
     if ir_source and use_ir_loc:


### PR DESCRIPTION
# Content
Both control flows to IRSource and ASTSource cache the absolute file path.
This PR extracts the duplicated code from the if statement.

<!---
The core Triton is a small number of people, and we receive many PRs (thank
you!).  To help us review your code more quickly, **if you are a new
contributor (less than 3 PRs merged) we ask that you complete the following
tasks and include the filled-out checklist in your PR description.**

Complete the following tasks before sending your PR, and replace `[ ]` with
`[x]` to indicate you have done them.
-->

# New contributor declaration
- [x] I am not making a trivial change, such as fixing a typo in a comment.

- [x] I have written a PR description following these
  [rules](https://cbea.ms/git-commit/#why-not-how).

- [x] I have run `pre-commit run --from-ref origin/main --to-ref HEAD`.

- Select one of the following.
  - [ ] I have added tests.
    - `/test` for `lit` tests
    - `/unittest` for C++ tests
    - `/python/test` for end-to-end tests
  - [x] This PR does not need a test because it is simple refactoring.

- Select one of the following.
  - [x] I have not added any `lit` tests.
  - [ ] The `lit` tests I have added follow these [best practices](https://mlir.llvm.org/getting_started/TestingGuide/#filecheck-best-practices),
    including the "tests should be minimal" section. (Usually running Python code
    and using the instructions it generates is not minimal.)
