### PR TITLE
[NVIDIA] NFC: Make cluster barrier peerMask op creation order deterministic

### DIFF
--- a/third_party/nvidia/lib/TritonNVIDIAGPUToLLVM/ClusterOpsToLLVM.cpp
+++ b/third_party/nvidia/lib/TritonNVIDIAGPUToLLVM/ClusterOpsToLLVM.cpp
@@ -248,8 +248,6 @@ struct ClusterBarrierOpConversion
     if (targetInfo.getTargetFeatures().supportsMbarMulticast()) {
       Value ctaId = NVVM::ClusterId::create(rewriter, loc, i32_ty);
       // Exclude the issuing CTA: the mbarriers expect numCTAs - 1 arrivals.
-      // Create the operands in separate statements: nesting them would leave
-      // op creation order up to the host compiler's argument evaluation order.
       Value allCTAsMask = b.i32_val((1u << numCTAs) - 1);
       Value selfMask = b.shl(b.i32_val(1), ctaId);
       Value peerMask = b.xor_(allCTAsMask, selfMask);

--- a/third_party/nvidia/lib/TritonNVIDIAGPUToLLVM/ClusterOpsToLLVM.cpp
+++ b/third_party/nvidia/lib/TritonNVIDIAGPUToLLVM/ClusterOpsToLLVM.cpp
@@ -248,8 +248,11 @@ struct ClusterBarrierOpConversion
     if (targetInfo.getTargetFeatures().supportsMbarMulticast()) {
       Value ctaId = NVVM::ClusterId::create(rewriter, loc, i32_ty);
       // Exclude the issuing CTA: the mbarriers expect numCTAs - 1 arrivals.
-      Value peerMask =
-          b.xor_(b.i32_val((1u << numCTAs) - 1), b.shl(b.i32_val(1), ctaId));
+      // Create the operands in separate statements: nesting them would leave
+      // op creation order up to the host compiler's argument evaluation order.
+      Value allCTAsMask = b.i32_val((1u << numCTAs) - 1);
+      Value selfMask = b.shl(b.i32_val(1), ctaId);
+      Value peerMask = b.xor_(allCTAsMask, selfMask);
       createMBarrierArrive(rewriter, loc, pred, barrierPtr, relaxed, peerMask);
     } else {
       Value barrierInt = b.ptrtoint(i32_ty, barrierPtr);


### PR DESCRIPTION
<!---
The core Triton is a small number of people, and we receive many PRs (thank
you!).  To help us review your code more quickly, **if you are a new
contributor (less than 3 PRs merged) we ask that you complete the following
tasks and include the filled-out checklist in your PR description.**

Complete the following tasks before sending your PR, and replace `[ ]` with
`[x]` to indicate you have done them.
-->


With a GCC build, the following lit test fails:

      TRITON :: Conversion/tritonnvidiagpu_to_llvm.mlir

  The same source built with Clang passes. The failure is in the `RUBIN`
  check prefix, which checks the `cluster_barrier_inside_warp_specialize_rubin` function.

  The root cause is in `ClusterBarrierOpConversion::matchAndRewrite` in
  `ClusterOpsToLLVM.cpp`. The `peerMask` operands were created inline as
  nested call arguments:

  Value peerMask =
      b.xor_(b.i32_val((1u << numCTAs) - 1), b.shl(b.i32_val(1), ctaId));

  C++ leaves function argument evaluation order unspecified. Clang
  evaluates left-to-right here, creating the all-CTAs constant before the
  shift. GCC evaluates right-to-left, creating the shift first. The
  emitted IR is semantically identical, but the sequential CHECK lines
  in the lit test pin the constant before the shift and reject the GCC
  ordering.

# New contributor declaration
- [x] I am not making a trivial change, such as fixing a typo in a comment.

- [x] I have written a PR description following these
  [rules](https://cbea.ms/git-commit/#why-not-how).

- [x] I have run `pre-commit run --from-ref origin/main --to-ref HEAD`.

- Select one of the following.
  - [ ] I have added tests.
    - `/test` for `lit` tests
    - `/unittest` for C++ tests
    - `/python/test` for end-to-end tests
  - [x] This PR does not need a test because `it fixes a test`.

- Select one of the following.
  - [x] I have not added any `lit` tests.
  - [ ] The `lit` tests I have added follow these [best practices](https://mlir.llvm.org/getting_started/TestingGuide/#filecheck-best-practices),
    including the "tests should be minimal" section. (Usually running Python code
    and using the instructions it generates is not minimal.)
