### PR TITLE
[Release] [Cherry-Pick] [NVIDIA] Add packed arithmetic operation (#11002)

### DIFF
--- a/docs/gluon/api/nvidia.rst
+++ b/docs/gluon/api/nvidia.rst
@@ -9,3 +9,4 @@ Target-specific Gluon APIs for NVIDIA GPU generations.
    Ampere <nvidia.ampere>
    Hopper <nvidia.hopper>
    Blackwell <nvidia.blackwell>
+   Rubin <nvidia.rubin>

--- a/docs/gluon/api/nvidia.rubin.rst
+++ b/docs/gluon/api/nvidia.rubin.rst
@@ -1,0 +1,34 @@
+NVIDIA Rubin
+============
+
+.. currentmodule:: triton.experimental.gluon.language.nvidia.rubin
+
+.. autosummary::
+    :toctree: generated
+    :nosignatures:
+    :template: autosummary/gluon-module.rst
+
+    async_copy
+    clc
+    float2
+    mbarrier
+    tma
+
+
+.. autosummary::
+    :toctree: generated
+    :nosignatures:
+
+    allocate_tensor_memory
+    async_store
+    fence_async_shared
+    mma_v2
+    tensor_memory_descriptor
+    tensor_memory_descriptor_type
+    tcgen05_commit
+    tcgen05_copy
+    tcgen05_mma
+    tcgen05_mma_barrier_count
+    tcgen05_mma_scaled
+    TensorMemoryLayout
+    TensorMemoryScalesLayout

--- a/include/triton/Dialect/TritonNvidiaGPU/IR/Dialect.h
+++ b/include/triton/Dialect/TritonNvidiaGPU/IR/Dialect.h
@@ -59,6 +59,25 @@ LogicalResult verifyMMAv5Op(Operation *op);
 
 namespace mlir::triton::nvidia_gpu {
 
+struct PackedArithTypeInfo {
+  llvm::StringLiteral suffix;
+  unsigned lanes, registerBits;
+  char kind;
+
+  bool isFP4() const { return suffix == "e2m1x4"; }
+  unsigned storageLanes() const { return isFP4() ? lanes / 2 : lanes; }
+};
+
+struct PackedArithInstructionSpec {
+  const PackedArithTypeInfo *result;
+  SmallVector<const PackedArithTypeInfo *, 3> operands;
+  StringRef modifiers;
+  unsigned operandSuffixes;
+};
+
+PackedArithInstructionSpec getPackedArithInstructionSpec(PackedArithOp op);
+unsigned getPackedArithFp4Axis(PackedArithOp op);
+
 constexpr static char AttrTwoCTAsName[] = "ttng.two-ctas";
 
 inline bool getModuleTwoCTAs(ModuleOp mod) {

--- a/include/triton/Dialect/TritonNvidiaGPU/IR/TritonNvidiaGPUAttrDefs.td
+++ b/include/triton/Dialect/TritonNvidiaGPU/IR/TritonNvidiaGPUAttrDefs.td
@@ -47,6 +47,19 @@ def TTNG_TMEMLoadReduceModifierEnum : EnumAttr<TritonNvidiaGPU_Dialect, TTNG_TME
   let assemblyFormat = "`<` $value `>`";
 }
 
+def TTNG_PackedArithOpKindAttr : I32EnumAttr<
+    "PackedArithOpKind", "packed arithmetic operation",
+    [
+        I32EnumAttrCase<"ADD", 0, "add">,
+        I32EnumAttrCase<"SUB", 1, "sub">,
+        I32EnumAttrCase<"MUL", 2, "mul">,
+        I32EnumAttrCase<"FMA", 3, "fma">,
+        I32EnumAttrCase<"MIN", 4, "min">,
+        I32EnumAttrCase<"MAX", 5, "max">,
+    ]> {
+  let cppNamespace = "::mlir::triton::nvidia_gpu";
+}
+
 def TTNG_TensorMemoryScalesBlockRepOrderAttr : I32EnumAttr<
     "TensorMemoryScalesBlockRepOrder", "",
     [

--- a/include/triton/Dialect/TritonNvidiaGPU/IR/TritonNvidiaGPUOps.td
+++ b/include/triton/Dialect/TritonNvidiaGPU/IR/TritonNvidiaGPUOps.td
@@ -49,6 +49,35 @@ class TTNG_Op<string mnemonic, list<Trait> traits = []> :
        !listconcat(traits, [VerifyTensorLayoutsTrait, VerifyMemDescLayoutsTrait])> {
 }
 
+def TTNG_PackedArithOperandElement : AnyTypeOf<[
+  I8, F8E8M0FNU, F8E4M3FN, F8E5M2, F16, BF16, F32
+], "packed arithmetic operand element">;
+def TTNG_PackedArithResultElement : AnyTypeOf<[
+  F8E4M3FN, F8E5M2, F16, BF16, F32
+], "packed arithmetic result element">;
+
+def TTNG_PackedArithOp : TTNG_Op<"packed_arith", [Pure]> {
+  let summary = "Apply elementwise arithmetic using a packed PTX instruction";
+
+  let description = [{
+    Applies packed x2, mixed-precision, and FP8/FP4/UE8M0 x4 arithmetic.
+    Instruction types, modifiers, and grouping are inferred from tensor types.
+    FP4 uses lower-nibble-first i8 values along the inferred halved dimension.
+  }];
+
+  let arguments = (ins
+    TTNG_PackedArithOpKindAttr:$op_kind,
+    Variadic<RankedTensorOf<[TTNG_PackedArithOperandElement]>>:$operands
+  );
+  let results = (outs RankedTensorOf<[TTNG_PackedArithResultElement]>:$result);
+
+  let assemblyFormat = [{
+    $op_kind $operands attr-dict `:` functional-type($operands, $result)
+  }];
+
+  let hasVerifier = 1;
+}
+
 def TTNG_FenceAsyncSharedOp : TTNG_Op<"fence_async_shared"> {
   let arguments = (ins BoolAttr:$bCluster);
 

--- a/lib/Dialect/TritonInstrument/Transforms/FpSanitizer.cpp
+++ b/lib/Dialect/TritonInstrument/Transforms/FpSanitizer.cpp
@@ -1227,6 +1227,9 @@ Value scaleI8ToComputePayload(PatternRewriter &rewriter, Location loc,
 Value castDotScaledScaleToComputePayload(PatternRewriter &rewriter,
                                          Location loc, Value scaleSlice,
                                          FloatType computeElem) {
+  if (isa<Float8E8M0FNUType>(getElementTypeOrSelf(scaleSlice.getType())))
+    scaleSlice = arith::BitcastOp::create(
+        rewriter, loc, getIntTypeLike(scaleSlice.getType()), scaleSlice);
   Type computeIntTy =
       getTypeWithElement(scaleSlice.getType(),
                          IntegerType::get(rewriter.getContext(),
@@ -2032,6 +2035,62 @@ struct Fp4ToFpPattern : public OpRewritePattern<ttg::Fp4ToFpOp> {
     Value result = unpackPackedFp4Tensor(rewriter, loc, op.getSrc(),
                                          op.getAxis(), dstIntTy);
     rewriter.replaceOp(op, unembedToFloat(rewriter, loc, result, dstTy));
+    return success();
+  }
+};
+
+struct PackedArithPattern : public OpRewritePattern<ttng::PackedArithOp> {
+  using OpRewritePattern::OpRewritePattern;
+
+  LogicalResult matchAndRewrite(ttng::PackedArithOp op,
+                                PatternRewriter &rewriter) const override {
+    auto resultTy = op.getType();
+    auto resultIntTy = cast<RankedTensorType>(getIntTypeLike(resultTy));
+    auto loc = op.getLoc();
+
+    SmallVector<Value> payloads;
+    for (Value operand : op.getOperands()) {
+      auto operandTy = cast<RankedTensorType>(operand.getType());
+      if (operandTy.getElementType().isInteger(8)) {
+        payloads.push_back(unpackPackedFp4Tensor(
+            rewriter, loc, operand, ttng::getPackedArithFp4Axis(op),
+            resultIntTy));
+        continue;
+      }
+
+      Value payload = castDotScaledScaleToComputePayload(
+          rewriter, loc, operand, cast<FloatType>(resultTy.getElementType()));
+      if (payload.getType() != resultIntTy)
+        payload =
+            ttg::ConvertLayoutOp::create(rewriter, loc, resultIntTy, payload);
+      payloads.push_back(payload);
+    }
+
+    Value lhs = payloads[0], rhs = payloads[1];
+    Value result;
+    using Kind = ttng::PackedArithOpKind;
+    switch (op.getOpKind()) {
+    case Kind::ADD:
+      result = arith::AddIOp::create(rewriter, loc, lhs, rhs);
+      break;
+    case Kind::SUB:
+      result = arith::SubIOp::create(rewriter, loc, lhs, rhs);
+      break;
+    case Kind::MUL:
+      result = arith::MulIOp::create(rewriter, loc, lhs, rhs);
+      break;
+    case Kind::FMA:
+      lhs = arith::MulIOp::create(rewriter, loc, lhs, rhs);
+      result = arith::AddIOp::create(rewriter, loc, lhs, payloads[2]);
+      break;
+    case Kind::MIN:
+      result = arith::MinSIOp::create(rewriter, loc, lhs, rhs);
+      break;
+    case Kind::MAX:
+      result = arith::MaxSIOp::create(rewriter, loc, lhs, rhs);
+      break;
+    }
+    rewriter.replaceOp(op, unembedToFloat(rewriter, loc, result, resultTy));
     return success();
   }
 };
@@ -3092,18 +3151,19 @@ public:
 
     TmemScratchManager scratch(twoCTAs);
     RewritePatternSet patterns(&getContext());
-    patterns.add<BinaryFloatToIntPattern<arith::AddFOp, arith::AddIOp>,
-                 BinaryFloatToIntPattern<arith::SubFOp, arith::SubIOp>,
-                 BinaryFloatToIntPattern<arith::MulFOp, arith::MulIOp>,
-                 BinaryFloatToIntPattern<arith::MinimumFOp, arith::MinSIOp>,
-                 BinaryFloatToIntPattern<arith::MaximumFOp, arith::MaxSIOp>,
-                 BinaryFloatToIntPattern<arith::MinNumFOp, arith::MinSIOp>,
-                 BinaryFloatToIntPattern<arith::MaxNumFOp, arith::MaxSIOp>,
-                 NegFOpPattern, DivFOpPattern, PreciseDivFOpPattern,
-                 RemFOpPattern, FmaPattern, ExpOpPattern, Exp2OpPattern,
-                 CosOpPattern, SinOpPattern, ExtFOpPattern, TruncFOpPattern,
-                 FpToFpPattern, Fp4ToFpPattern, DotPattern, DotScaledPattern>(
-        &getContext());
+    patterns
+        .add<BinaryFloatToIntPattern<arith::AddFOp, arith::AddIOp>,
+             BinaryFloatToIntPattern<arith::SubFOp, arith::SubIOp>,
+             BinaryFloatToIntPattern<arith::MulFOp, arith::MulIOp>,
+             BinaryFloatToIntPattern<arith::MinimumFOp, arith::MinSIOp>,
+             BinaryFloatToIntPattern<arith::MaximumFOp, arith::MaxSIOp>,
+             BinaryFloatToIntPattern<arith::MinNumFOp, arith::MinSIOp>,
+             BinaryFloatToIntPattern<arith::MaxNumFOp, arith::MaxSIOp>,
+             NegFOpPattern, DivFOpPattern, PreciseDivFOpPattern, RemFOpPattern,
+             FmaPattern, ExpOpPattern, Exp2OpPattern, CosOpPattern,
+             SinOpPattern, ExtFOpPattern, TruncFOpPattern, FpToFpPattern,
+             Fp4ToFpPattern, PackedArithPattern, DotPattern, DotScaledPattern>(
+            &getContext());
     patterns.add<UnaryPattern<math::LogOp>>(&getContext(), UnaryOpId::Log);
     patterns.add<UnaryPattern<math::Log2Op>>(&getContext(), UnaryOpId::Log2);
     patterns.add<UnaryPattern<math::SqrtOp>>(&getContext(), UnaryOpId::Sqrt);

--- a/lib/Dialect/TritonNvidiaGPU/IR/Ops.cpp
+++ b/lib/Dialect/TritonNvidiaGPU/IR/Ops.cpp
@@ -1199,26 +1199,28 @@ LogicalResult TCGen5MMAScaledOp::verify() {
     // from both MN and K dimensions.
     return rowsPerCTA > 128 && scalesPerCTA > 4;
   };
-  if (isa<TensorMemorySpaceAttr>(aScaleType.getMemorySpace()) &&
-      isScaleBlockRepOrderRelevant(aScaleType)) {
+  auto verifyScaleEncoding = [&](MemDescType scaleType,
+                                 bool isA) -> LogicalResult {
+    if (!isa<TensorMemorySpaceAttr>(scaleType.getMemorySpace()))
+      return success();
+    bool isOrderRelevant = isScaleBlockRepOrderRelevant(scaleType);
     auto encoding =
-        dyn_cast<TensorMemoryScalesEncodingAttr>(aScaleType.getEncoding());
-    if (!encoding)
-      return emitOpError("A scales in tensor memory must use "
-                         "#ttng.tensor_memory_scales_encoding");
-    if (failed(verifyScaleBlockRepOrder(*this, encoding, /*isA=*/true)))
-      return failure();
-  }
-  if (isa<TensorMemorySpaceAttr>(bScaleType.getMemorySpace()) &&
-      isScaleBlockRepOrderRelevant(bScaleType)) {
-    auto encoding =
-        dyn_cast<TensorMemoryScalesEncodingAttr>(bScaleType.getEncoding());
-    if (!encoding)
-      return emitOpError("B scales in tensor memory must use "
-                         "#ttng.tensor_memory_scales_encoding");
-    if (failed(verifyScaleBlockRepOrder(*this, encoding, /*isA=*/false)))
-      return failure();
-  }
+        dyn_cast<TensorMemoryScalesEncodingAttr>(scaleType.getEncoding());
+    if (!encoding) {
+      if (!isOrderRelevant)
+        return success();
+      return emitOpError() << (isA ? "A" : "B")
+                           << " scales in tensor memory must use "
+                              "#ttng.tensor_memory_scales_encoding";
+    }
+    if (!isOrderRelevant && encoding.getBlockRepOrder() ==
+                                TensorMemoryScalesBlockRepOrder::MN_THEN_K)
+      return success();
+    return verifyScaleBlockRepOrder(*this, encoding, isA);
+  };
+  if (failed(verifyScaleEncoding(aScaleType, /*isA=*/true)) ||
+      failed(verifyScaleEncoding(bScaleType, /*isA=*/false)))
+    return failure();
   return success();
 }
 

--- a/lib/Dialect/TritonNvidiaGPU/IR/Ops.cpp
+++ b/lib/Dialect/TritonNvidiaGPU/IR/Ops.cpp
@@ -49,6 +49,213 @@ namespace mlir {
 namespace triton {
 namespace nvidia_gpu {
 
+// -- PackedArithOp --
+namespace {
+constexpr llvm::StringLiteral Half = "hb";
+constexpr llvm::StringLiteral X2 = "fhb";
+constexpr llvm::StringLiteral Alternate = "542u";
+constexpr llvm::StringLiteral AlternateResult = "54";
+
+struct PackedArithSignatureRule {
+  llvm::StringLiteral operations;
+  StringRef resultTypes;
+  StringRef operandTypes[3];
+  llvm::StringLiteral modifiers;
+  unsigned operandSuffixes;
+};
+} // namespace
+
+static const PackedArithTypeInfo &getPackedArithTypeInfo(Type elementType) {
+  static const struct {
+    TypeID type;
+    PackedArithTypeInfo info;
+  } types[] = {
+      {TypeID::get<Float32Type>(), {"f32x2", 2, 64, 'f'}},
+      {TypeID::get<Float16Type>(), {"f16x2", 2, 32, 'h'}},
+      {TypeID::get<BFloat16Type>(), {"bf16x2", 2, 32, 'b'}},
+      {TypeID::get<Float8E5M2Type>(), {"e5m2x4", 4, 32, '5'}},
+      {TypeID::get<Float8E4M3FNType>(), {"e4m3x4", 4, 32, '4'}},
+      {TypeID::get<IntegerType>(), {"e2m1x4", 4, 16, '2'}},
+      {TypeID::get<Float8E8M0FNUType>(), {"ue8m0x4", 4, 32, 'u'}},
+  };
+  for (const auto &type : types)
+    if (elementType.getTypeID() == type.type)
+      return type.info;
+  llvm_unreachable("unsupported packed arithmetic element type");
+}
+
+static FailureOr<PackedArithInstructionSpec>
+resolvePackedArithInstructionSpec(PackedArithOp op) {
+  auto kind = op.getOpKind();
+  const auto *result = &getPackedArithTypeInfo(op.getType().getElementType());
+  SmallVector<const PackedArithTypeInfo *, 3> operands;
+  for (Value operand : op.getOperands())
+    operands.push_back(&getPackedArithTypeInfo(
+        cast<RankedTensorType>(operand.getType()).getElementType()));
+
+  // clang-format off
+  static constexpr PackedArithSignatureRule signatures[] = {
+      // operations       result           operands                     modifiers  suffixes
+      {"add sub mul",    X2,              {"=", "="},                  "",        0},
+      {"fma",            X2,              {"=", "=", "="},             "rn",      0},
+      {"min max",        Half,            {"=", "="},                  "",        0},
+      {"add sub",        "f",             {Half, "f"},                 "",        2},
+      {"add sub",        "h",             {"f", "f"},                  "rz.ftz",  2},
+      {"add sub",        "b",             {"f", "f"},                  "rz",      2},
+      {"mul",            "h",             {"f", "f"},                  "ftz.rz",  2},
+      {"mul",            "b",             {"f", "f"},                  "rz",      2},
+      {"mul",            Half,            {"=", "!"},                  "",        2},
+      {"fma",            "f",             {Half, "f", "f"},            "rn",      3},
+      {"add sub",        AlternateResult, {Alternate, "="},            "",        1},
+      {"mul",            AlternateResult, {Alternate, Alternate},      "",        2},
+      {"fma",            AlternateResult, {Alternate, Alternate, "="}, "",        2},
+  };
+  // clang-format on
+
+  auto matches = [result](StringRef types, const PackedArithTypeInfo *info) {
+    if (types == "=")
+      return info == result;
+    if (types == "!")
+      return info != result && Half.contains(info->kind);
+    return types.contains(info->kind);
+  };
+  for (const PackedArithSignatureRule &signature : signatures) {
+    if (!StringRef(signature.operations)
+             .contains(stringifyPackedArithOpKind(kind)) ||
+        !matches(signature.resultTypes, result))
+      continue;
+    auto types = ArrayRef(signature.operandTypes).take_front(operands.size());
+    if (!llvm::all_of(llvm::zip_equal(operands, types), [&](auto pair) {
+          return matches(std::get<1>(pair), std::get<0>(pair));
+        }))
+      continue;
+    return PackedArithInstructionSpec{result, std::move(operands),
+                                      signature.modifiers,
+                                      signature.operandSuffixes};
+  }
+  return failure();
+}
+
+PackedArithInstructionSpec getPackedArithInstructionSpec(PackedArithOp op) {
+  auto spec = resolvePackedArithInstructionSpec(op);
+  assert(succeeded(spec) && "expected a verified packed arithmetic operation");
+  return std::move(*spec);
+}
+
+static std::optional<unsigned> inferPackedArithFp4Axis(PackedArithOp op) {
+  auto resultShape = op.getType().getShape();
+  std::optional<unsigned> axis;
+  for (Value operand : op.getOperands()) {
+    auto type = cast<RankedTensorType>(operand.getType());
+    if (!type.getElementType().isInteger(8))
+      continue;
+    if (type.getRank() != resultShape.size())
+      return std::nullopt;
+    auto shape = type.getShape();
+    auto [sourceDim, resultDim] = llvm::mismatch(shape, resultShape);
+    if (sourceDim == shape.end())
+      return std::nullopt;
+    unsigned differing = std::distance(shape.begin(), sourceDim);
+    if (2 * *sourceDim != *resultDim ||
+        !llvm::equal(shape.drop_front(differing + 1),
+                     resultShape.drop_front(differing + 1)) ||
+        (axis && *axis != differing))
+      return std::nullopt;
+    axis = differing;
+  }
+  return axis;
+}
+
+unsigned getPackedArithFp4Axis(PackedArithOp op) {
+  auto axis = inferPackedArithFp4Axis(op);
+  assert(axis && "expected a verified packed arithmetic operation with an "
+                 "FP4 operand");
+  return *axis;
+}
+
+LogicalResult PackedArithOp::verify() {
+  unsigned expectedOperands = getOpKind() == PackedArithOpKind::FMA ? 3 : 2;
+  if (getNumOperands() != expectedOperands)
+    return emitOpError() << stringifyPackedArithOpKind(getOpKind())
+                         << " expects " << expectedOperands
+                         << " operands but got " << getNumOperands();
+
+  auto tensorType = getResult().getType();
+  const auto &resultInfo = getPackedArithTypeInfo(tensorType.getElementType());
+  if (!isa_and_nonnull<DistributedEncodingTrait>(tensorType.getEncoding()))
+    return emitOpError("requires a distributed tensor layout");
+
+  auto instruction = resolvePackedArithInstructionSpec(*this);
+  if (failed(instruction)) {
+    auto diag = emitOpError()
+                << "unsupported " << stringifyPackedArithOpKind(getOpKind())
+                << " signature " << resultInfo.suffix << " <- (";
+    llvm::interleaveComma(getOperands(), diag, [&](Value operand) {
+      diag << getPackedArithTypeInfo(
+                  cast<RankedTensorType>(operand.getType()).getElementType())
+                  .suffix;
+    });
+    return diag << ")";
+  }
+
+  std::optional<unsigned> fp4Axis = inferPackedArithFp4Axis(*this);
+  if (!fp4Axis && llvm::any_of(instruction->operands,
+                               [](auto *info) { return info->isFP4(); }))
+    return emitOpError("requires every fp4 operand to have the result shape "
+                       "with the same single dimension halved");
+
+  unsigned packWidth = resultInfo.lanes;
+  unsigned resultRegisters = getUniqueElemsPerThread(tensorType);
+  if (resultRegisters < packWidth || resultRegisters % packWidth != 0)
+    return emitOpError() << "result layout must provide a multiple of "
+                         << packWidth << " unique elements per thread";
+
+  Attribute canonicalFp4Encoding;
+  if (fp4Axis) {
+    auto *dialect =
+        tensorType.getEncoding()
+            .getDialect()
+            .getRegisteredInterface<triton::DialectInferLayoutInterface>();
+    if (dialect &&
+        failed(dialect->inferFp4ToFpOpEncoding(
+            tensorType.getShape(), *fp4Axis, tensorType.getEncoding(),
+            canonicalFp4Encoding, /*fwdInference=*/false, std::nullopt)))
+      canonicalFp4Encoding = {};
+  }
+
+  for (auto [index, operand] : llvm::enumerate(getOperands())) {
+    auto operandType = cast<RankedTensorType>(operand.getType());
+    const auto &operandInfo = *instruction->operands[index];
+    if (operandInfo.isFP4()) {
+      if (!isa_and_nonnull<DistributedEncodingTrait>(
+              operandType.getEncoding()) ||
+          !canonicalFp4Encoding ||
+          !areLayoutsEquivalent(
+              operandType.getShape(),
+              cast<LayoutEncodingTrait>(canonicalFp4Encoding),
+              cast<LayoutEncodingTrait>(operandType.getEncoding())))
+        return emitOpError() << "fp4 operand " << index
+                             << " must have a layout compatible with the "
+                                "result";
+      continue;
+    }
+    if (operandType.getShape() != tensorType.getShape())
+      return emitOpError() << "operand " << index
+                           << " must have the result shape "
+                           << tensorType.getShape() << ", but got "
+                           << operandType.getShape();
+    if (!isa_and_nonnull<LayoutEncodingTrait>(operandType.getEncoding()) ||
+        !areLayoutsEquivalent(
+            tensorType.getShape(),
+            cast<LayoutEncodingTrait>(operandType.getEncoding()),
+            cast<LayoutEncodingTrait>(tensorType.getEncoding())))
+      return emitOpError() << "operand " << index
+                           << " must have a layout equivalent to the result";
+  }
+
+  return success();
+}
+
 // -- WarpGroupDotOp --
 LogicalResult WarpGroupDotOp::inferReturnTypes(
     MLIRContext *context, std::optional<Location> location, ValueRange operands,

--- a/python/src/gluon_ir.cc
+++ b/python/src/gluon_ir.cc
@@ -79,7 +79,11 @@ void printDiagStr(llvm::raw_ostream &os, const Diagnostic &diag) {
 }
 
 struct GluonOpBuilder : public TritonOpBuilder {
-  using TritonOpBuilder::TritonOpBuilder;
+  GluonOpBuilder(MLIRContext *context, std::string arch = "")
+      : TritonOpBuilder(context), arch(arch) {}
+
+  bool isRubin() const { return arch == "sm107"; }
+
   // Construct an attribute or type while calling its verifier. Error messages
   // are intercepted and sent back to Python via a C++ exception.
   template <typename AttrOrType, typename... ArgTs>
@@ -123,6 +127,9 @@ struct GluonOpBuilder : public TritonOpBuilder {
   getChecked(ArgTs &&...args) {
     return AttrOrType::get(std::forward<ArgTs>(args)...);
   }
+
+private:
+  std::string arch;
 };
 
 struct GluonLayouts {
@@ -133,6 +140,7 @@ struct GluonLayouts {
   py::handle DistributedLinearLayout;
   py::handle DotOperandLayout;
   py::handle NVMMADistributedLayout;
+  py::handle RubinTensorMemoryScalesLayout;
   py::handle TensorMemoryScalesLayout;
   py::handle TensorMemoryLayout;
   py::handle NVMMASharedLayout;
@@ -150,6 +158,8 @@ struct GluonLayouts {
         py::module::import("triton.experimental.gluon.language.amd._layouts");
     auto blackwellLayouts = py::module::import(
         "triton.experimental.gluon.language.nvidia.blackwell");
+    auto rubinLayouts =
+        py::module::import("triton.experimental.gluon.language.nvidia.rubin");
     AutoLayout = py::object(layouts.attr("AutoLayout")).release();
     CoalescedLayout = py::object(layouts.attr("CoalescedLayout")).release();
     BlockedLayout = py::object(layouts.attr("BlockedLayout")).release();
@@ -161,6 +171,8 @@ struct GluonLayouts {
         py::object(layouts.attr("NVMMADistributedLayout")).release();
     TensorMemoryScalesLayout =
         py::object(blackwellLayouts.attr("TensorMemoryScalesLayout")).release();
+    RubinTensorMemoryScalesLayout =
+        py::object(rubinLayouts.attr("TensorMemoryScalesLayout")).release();
     TensorMemoryLayout =
         py::object(blackwellLayouts.attr("TensorMemoryLayout")).release();
     NVMMASharedLayout = py::object(layouts.attr("NVMMASharedLayout")).release();
@@ -202,7 +214,7 @@ std::vector<llvm::ValueTypeFromRangeType<R>> toStdVector(R &&range) {
   return {range.begin(), range.end()};
 }
 
-py::object layoutToGluon(Attribute layout) {
+py::object layoutToGluon(Attribute layout, bool isRubin = false) {
   static GluonLayouts layouts;
   if (auto blocked = dyn_cast<ttg::BlockedEncodingAttr>(layout)) {
     auto cgaBases = getCgaLayoutBases(blocked.getCGALayout());
@@ -212,7 +224,7 @@ py::object layoutToGluon(Attribute layout) {
                                  toStdVector(blocked.getOrder()), cgaBases);
   } else if (auto sliced = dyn_cast<ttg::SliceEncodingAttr>(layout)) {
     return layouts.SliceLayout(sliced.getDim(),
-                               layoutToGluon(sliced.getParent()));
+                               layoutToGluon(sliced.getParent(), isRubin));
   } else if (auto linearEnc = dyn_cast<ttg::LinearEncodingTrait>(layout)) {
     const auto &ll = linearEnc.getLinearLayout();
     auto ctx = layout.getContext();
@@ -225,8 +237,9 @@ py::object layoutToGluon(Attribute layout) {
         ll.getBases().lookup(kWarp), ll.getBases().lookup(kBlock),
         toStdVector(ll.getOutDimSizes()));
   } else if (auto dotOp = dyn_cast<ttg::DotOperandEncodingAttr>(layout)) {
-    return layouts.DotOperandLayout(
-        dotOp.getOpIdx(), layoutToGluon(dotOp.getParent()), dotOp.getKWidth());
+    return layouts.DotOperandLayout(dotOp.getOpIdx(),
+                                    layoutToGluon(dotOp.getParent(), isRubin),
+                                    dotOp.getKWidth());
   } else if (auto mma = dyn_cast<ttg::NvidiaMmaEncodingAttr>(layout)) {
     auto cgaBases = getCgaLayoutBases(mma.getCGALayout());
     return layouts.NVMMADistributedLayout(
@@ -299,19 +312,22 @@ py::object layoutToGluon(Attribute layout) {
   } else if (auto partitioned =
                  dyn_cast<ttg::PartitionedSharedEncodingAttr>(layout)) {
     py::object partitionLayout =
-        layoutToGluon(partitioned.getPartitionLayout());
+        layoutToGluon(partitioned.getPartitionLayout(), isRubin);
     return layouts.PartitionedSharedLayout(
         partitioned.getNumPartitions(), partitioned.getNumGroups(),
         partitioned.getPartitionDim(), partitionLayout);
   } else if (auto tmemScales =
                  dyn_cast<ttng::TensorMemoryScalesEncodingAttr>(layout)) {
-    StringRef blockRepOrder =
-        tmemScales.getBlockRepOrder() ==
-                ttng::TensorMemoryScalesBlockRepOrder::K_THEN_MN
-            ? "kThenMn"
-            : "mnThenK";
-    return layouts.TensorMemoryScalesLayout(
-        getCgaLayoutBases(tmemScales.getCGALayout()), blockRepOrder);
+    auto cgaLayout = getCgaLayoutBases(tmemScales.getCGALayout());
+    if (isRubin) {
+      const char *blockRepOrder =
+          tmemScales.getBlockRepOrder() ==
+                  ttng::TensorMemoryScalesBlockRepOrder::K_THEN_MN
+              ? "kThenMn"
+              : "mnThenK";
+      return layouts.RubinTensorMemoryScalesLayout(cgaLayout, blockRepOrder);
+    }
+    return layouts.TensorMemoryScalesLayout(cgaLayout);
   } else if (auto tmem = dyn_cast<ttng::TensorMemoryEncodingAttr>(layout)) {
     return layouts.TensorMemoryLayout(
         std::vector<unsigned>{tmem.getBlockM(), tmem.getBlockN()},
@@ -340,7 +356,8 @@ void init_gluon_ir(py::module &&m) {
 
   py::class_<GluonOpBuilder, TritonOpBuilder>(
       m, "GluonOpBuilder", py::module_local(), py::dynamic_attr())
-      .def(py::init<MLIRContext *>())
+      .def(py::init<MLIRContext *, std::string>(), py::arg("context"),
+           py::arg("arch") = "")
       .def("get_op_builder", &GluonOpBuilder::getBuilder, ret::reference)
       .def("get_distributed_ty",
            [](GluonOpBuilder &self, Type &elementType,
@@ -420,14 +437,14 @@ void init_gluon_ir(py::module &&m) {
              if (isa<ttg::DistributedEncodingTrait>(layout)) {
                auto attr =
                    ttg::LinearEncodingAttr::get(ctx, std::move(linearLayout));
-               return layoutToGluon(attr);
+               return layoutToGluon(attr, self.isRubin());
              }
              if (isa<ttg::SharedEncodingTrait>(layout)) {
                auto alignment =
                    cast<ttg::SharedEncodingTrait>(layout).getAlignment();
                auto attr = ttg::SharedLinearEncodingAttr::get(
                    ctx, std::move(linearLayout), alignment);
-               return layoutToGluon(attr);
+               return layoutToGluon(attr, self.isRubin());
              }
 
              // TensorMemory encodings: keep the LinearLayout but wrap as
@@ -614,13 +631,13 @@ void init_gluon_ir(py::module &&m) {
            [](GluonOpBuilder &self, Value tensor) -> py::object {
              auto ty = dyn_cast<RankedTensorType>(tensor.getType());
              check(ty.getEncoding(), "expected a tensor with an encoding");
-             return layoutToGluon(ty.getEncoding());
+             return layoutToGluon(ty.getEncoding(), self.isRubin());
            })
       .def("get_gluon_layout_from_memdesc",
            [](GluonOpBuilder &self, Value memdesc) -> py::object {
              auto ty = dyn_cast<ttg::MemDescType>(memdesc.getType());
              check(ty.getEncoding(), "expected a memdesc with an encoding");
-             return layoutToGluon(ty.getEncoding());
+             return layoutToGluon(ty.getEncoding(), self.isRubin());
            })
       .def("get_tensor_descriptor_layout_type",
            [](GluonOpBuilder &self, Type blockType, bool isSigned,
@@ -883,7 +900,8 @@ void init_gluon_ir(py::module &&m) {
               Value result = op.getResult();
               Value red = op.getRed();
               auto redTy = cast<RankedTensorType>(red.getType());
-              py::object redLayout = layoutToGluon(redTy.getEncoding());
+              py::object redLayout =
+                  layoutToGluon(redTy.getEncoding(), self.isRubin());
               return py::make_tuple(result, red, redLayout);
             }
             Value result = op.getResult();

--- a/python/test/gluon/test_core.py
+++ b/python/test/gluon/test_core.py
@@ -28,6 +28,7 @@ from triton.experimental.gluon import language as ttgl
 from triton.experimental.gluon.language.nvidia.ampere import async_copy, mma_v2
 from triton.experimental.gluon.language.nvidia.hopper import tma, mbarrier, fence_async_shared
 from triton.experimental.gluon.language.nvidia import hopper
+from triton.experimental.gluon.language.nvidia import rubin
 from triton.experimental.gluon.language.nvidia.blackwell import tma as blackwell_tma
 from triton.experimental.gluon.language.amd.cdna4 import async_copy as cdna4_async_copy
 from triton.experimental.gluon.language.extra import libdevice
@@ -757,11 +758,11 @@ def test_mbarrier_arrive_multicast(num_ctas, cta_mask):
 
     @gluon.jit
     def kernel(out_ptr, cta_mask: ttgl.constexpr, init_count: ttgl.constexpr):
-        bar = mbarrier.allocate_mbarrier()
-        mbarrier.init(bar, count=init_count)
-        mbarrier.arrive(bar, cta_mask=cta_mask)
-        mbarrier.wait(bar, 0)
-        mbarrier.invalidate(bar)
+        bar = rubin.mbarrier.allocate_mbarrier()
+        rubin.mbarrier.init(bar, count=init_count)
+        rubin.mbarrier.arrive(bar, cta_mask=cta_mask)
+        rubin.mbarrier.wait(bar, 0)
+        rubin.mbarrier.invalidate(bar)
         ttgl.store(out_ptr + ttgl.program_id(0), ttgl.program_id(0))
 
     out = torch.zeros(num_ctas, device="cuda", dtype=torch.int32)
@@ -791,12 +792,12 @@ def test_mbarrier_arrive_broadcast_one_cta(num_ctas):
             is_pure=True,
             pack=1,
         )
-        bar = mbarrier.allocate_mbarrier()
-        mbarrier.init(bar, count=1)
+        bar = rubin.mbarrier.allocate_mbarrier()
+        rubin.mbarrier.init(bar, count=1)
         # CTA 0 does a multicast arrive, all CTAs wait.
-        mbarrier.arrive(bar, cta_mask=cta_mask, pred=cta_rank == 0)
-        mbarrier.wait(bar, 0)
-        mbarrier.invalidate(bar)
+        rubin.mbarrier.arrive(bar, cta_mask=cta_mask, pred=cta_rank == 0)
+        rubin.mbarrier.wait(bar, 0)
+        rubin.mbarrier.invalidate(bar)
         ttgl.store(out_ptr + pid, pid)
 
     out = torch.zeros(num_ctas, device="cuda", dtype=torch.int32)

--- a/python/test/gluon/test_frontend.py
+++ b/python/test/gluon/test_frontend.py
@@ -5,8 +5,10 @@ import re
 from triton.backends.compiler import GPUTarget
 from triton.experimental import gluon
 from triton.experimental.gluon import language as ttgl
+from triton.experimental.gluon.language._core import _unwrap_if_constexpr, builtin
 from triton.experimental.gluon.language.nvidia import blackwell
 from triton.experimental.gluon.language.nvidia import hopper
+from triton.experimental.gluon.language.nvidia import rubin
 from triton.experimental.gluon.language.nvidia.ampere import mbarrier as ampere_mbarrier
 from triton.experimental.gluon.language.nvidia.hopper import cluster
 from triton.experimental.gluon.language.nvidia.blackwell import mbarrier, tma, TensorMemoryLayout, TensorMemoryScalesLayout, async_copy
@@ -33,6 +35,7 @@ PTRRANGE_PAT = re.compile('(, )?tt.pointer_range = 32 : i32')
 LIBDEVICE_PAT = re.compile('{libname = "", libpath = "", pure = true, symbol = "__.*"}')
 
 BLACKWELL_TARGET = GPUTarget("cuda", 100, 32)
+RUBIN_TARGET = GPUTarget("cuda", 107, 32)
 HOPPER_TARGET = GPUTarget("cuda", 90, 32)
 AMPERE_TARGET = GPUTarget("cuda", 80, 32)
 HIP_TARGET_RDNA3 = GPUTarget("hip", "gfx1100", 32)
@@ -653,6 +656,19 @@ def test_async_shared_store(target):
     assert "ttng.async_shared_store" in anonymize_ir(mod.str_nodebug())
 
 
+def test_rubin_namespace_extends_blackwell():
+    assert ttgl.nvidia.rubin is rubin
+    assert rubin.TensorMemoryLayout is blackwell.TensorMemoryLayout
+    assert rubin.allocate_tensor_memory is blackwell.allocate_tensor_memory
+    assert rubin.tcgen05_mma_scaled is blackwell.tcgen05_mma_scaled
+    assert rubin.tma is blackwell.tma
+    assert rubin.mbarrier is not blackwell.mbarrier
+    assert rubin.mbarrier.allocate_mbarrier is blackwell.mbarrier.allocate_mbarrier
+
+    with pytest.raises(TypeError, match="block_rep_order"):
+        blackwell.TensorMemoryScalesLayout(block_rep_order="kThenMn")
+
+
 @gluon.jit
 def ampere_mbarrier_arrive_kernel():
     bar = ttgl.allocate_shared_memory(ttgl.int64, [1], ampere_mbarrier.MBarrierLayout())
@@ -670,28 +686,26 @@ def test_ampere_mbarrier_arrive(target):
     run_parser(ampere_mbarrier_arrive_kernel, target=target)
 
 
-def test_mbarrier_arrive_multicast_unsupported_target():
+def test_mbarrier_arrive_multicast_not_exposed_on_blackwell():
 
     @gluon.jit
     def kernel():
         bar = ttgl.allocate_shared_memory(ttgl.int64, [1], mbarrier.MBarrierLayout())
         mbarrier.arrive(bar, count=1, cta_mask=0x1)
 
-    with pytest.raises(CompilationError) as e:
+    with pytest.raises(CompilationError, match="cta_mask"):
         run_parser(kernel, *make_args(num_ctas=2), target=BLACKWELL_TARGET)
-
-    assert "multicast arrive requires Rubin" in str(e.value)
 
 
 def test_mbarrier_arrive_multicast_negative_mask():
 
     @gluon.jit
     def kernel():
-        bar = ttgl.allocate_shared_memory(ttgl.int64, [1], mbarrier.MBarrierLayout())
-        mbarrier.arrive(bar, count=1, cta_mask=-1)
+        bar = ttgl.allocate_shared_memory(ttgl.int64, [1], rubin.mbarrier.MBarrierLayout())
+        rubin.mbarrier.arrive(bar, count=1, cta_mask=-1)
 
     with pytest.raises(CompilationError) as e:
-        run_parser(kernel, *make_args(num_ctas=2), target=BLACKWELL_TARGET)
+        run_parser(kernel, *make_args(num_ctas=2), target=RUBIN_TARGET)
 
     assert "cta_mask must be positive" in str(e.value)
 
@@ -700,11 +714,11 @@ def test_mbarrier_arrive_multicast_mask_too_large():
 
     @gluon.jit
     def kernel():
-        bar = ttgl.allocate_shared_memory(ttgl.int64, [1], mbarrier.MBarrierLayout())
-        mbarrier.arrive(bar, count=1, cta_mask=2)
+        bar = ttgl.allocate_shared_memory(ttgl.int64, [1], rubin.mbarrier.MBarrierLayout())
+        rubin.mbarrier.arrive(bar, count=1, cta_mask=2)
 
     with pytest.raises(CompilationError) as e:
-        run_parser(kernel, *make_args(num_ctas=2), target=BLACKWELL_TARGET)
+        run_parser(kernel, *make_args(num_ctas=2), target=RUBIN_TARGET)
 
     assert "cta_mask must be <= num_ctas - 1" in str(e.value)
 
@@ -713,11 +727,11 @@ def test_mbarrier_arrive_multicast_non_int_mask():
 
     @gluon.jit
     def kernel():
-        bar = ttgl.allocate_shared_memory(ttgl.int64, [1], mbarrier.MBarrierLayout())
-        mbarrier.arrive(bar, count=1, cta_mask=1.5)
+        bar = ttgl.allocate_shared_memory(ttgl.int64, [1], rubin.mbarrier.MBarrierLayout())
+        rubin.mbarrier.arrive(bar, count=1, cta_mask=1.5)
 
     with pytest.raises(CompilationError) as e:
-        run_parser(kernel, *make_args(num_ctas=2), target=BLACKWELL_TARGET)
+        run_parser(kernel, *make_args(num_ctas=2), target=RUBIN_TARGET)
 
     assert "cta_mask must be an int" in str(e.value)
 
@@ -762,6 +776,35 @@ def tcgen05_mma_scaled_kernel(nvmma_layout: ttgl.constexpr, acc_layout: ttgl.con
     scale_b = blackwell.allocate_tensor_memory(ttgl.int8, [128, 32], scale_layout)
     acc = blackwell.allocate_tensor_memory(ttgl.float16, [128, 128], acc_layout)
     blackwell.tcgen05_mma_scaled(a, b, acc, scale_a, scale_b, "e5m2", "e5m2")
+
+
+@builtin
+def assert_tmem_scales_layout_roundtrip(memdesc, expected_layout, _semantic=None):
+    expected_layout = _unwrap_if_constexpr(expected_layout)
+    actual_layout = _semantic.builder.get_gluon_layout_from_memdesc(memdesc.handle)
+    assert actual_layout == expected_layout, f"expected {expected_layout}, got {actual_layout}"
+
+
+@gluon.jit
+def tmem_scales_layout_roundtrip_kernel(scale_layout: ttgl.constexpr):
+    scale = blackwell.allocate_tensor_memory(ttgl.int8, [128, 8], scale_layout)
+    assert_tmem_scales_layout_roundtrip(scale, scale_layout)
+
+
+@pytest.mark.parametrize(
+    "target,scale_layout",
+    [
+        pytest.param(BLACKWELL_TARGET, blackwell.TensorMemoryScalesLayout(), id="blackwell-mn-then-k"),
+        pytest.param(RUBIN_TARGET, rubin.TensorMemoryScalesLayout(), id="rubin-mn-then-k"),
+        pytest.param(
+            RUBIN_TARGET,
+            rubin.TensorMemoryScalesLayout(block_rep_order="kThenMn"),
+            id="rubin-k-then-mn",
+        ),
+    ],
+)
+def test_tmem_scales_layout_roundtrip(target, scale_layout):
+    run_parser(tmem_scales_layout_roundtrip_kernel, *make_args(scale_layout), target=target)
 
 
 def test_tcgen05_mma_scaled():

--- a/python/test/unit/language/test_compile_only.py
+++ b/python/test/unit/language/test_compile_only.py
@@ -1,6 +1,7 @@
 import triton
 import triton.language as tl
 from triton.backends.compiler import GPUTarget
+import pytest
 import re
 from triton.compiler import ASTSource
 
@@ -19,6 +20,62 @@ def test_compile_only_sm100() -> None:
     assert ".target sm_100a" in ptx
     assert ".address_size 64" in ptx
     assert k.asm["cubin"] != b""
+
+
+@pytest.mark.parametrize("element_type", ["f32", "f16", "bf16"])
+def test_compile_only_packed_arith_chains(element_type, tmp_path) -> None:
+    packed_type = f"{element_type}x2"
+    tensor_type = f"tensor<256x{element_type}, #blocked>"
+    pointer_type = f"!tt.ptr<{element_type}>"
+    operations = [
+        ("add", "%av, %bv", 2),
+        ("sub", "%add, %bv", 2),
+        ("mul", "%sub, %bv", 2),
+        ("fma", "%mul, %bv, %cv", 3),
+    ]
+    if element_type != "f32":
+        operations.extend([("min", "%fma, %bv", 2), ("max", "%min, %cv", 2)])
+
+    instructions = []
+    for name, operands, operand_count in operations:
+        tensor_types = ", ".join([tensor_type] * operand_count)
+        instructions.append(f"    %{name} = ttng.packed_arith {name} "
+                            f"{operands} : ({tensor_types}) -> {tensor_type}")
+    packed_operations = "\n".join(instructions)
+    result = operations[-1][0]
+    src = f"""
+#blocked = #ttg.blocked<{{sizePerThread = [2], threadsPerWarp = [32], warpsPerCTA = [4], order = [0]}}>
+module attributes {{"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.target = "cuda:100", "ttg.threads-per-warp" = 32 : i32}} {{
+  tt.func public @packed_chain_{element_type}(%a: {pointer_type} {{tt.divisibility = 16 : i32}}, %b: {pointer_type} {{tt.divisibility = 16 : i32}}, %c: {pointer_type} {{tt.divisibility = 16 : i32}}, %out: {pointer_type} {{tt.divisibility = 16 : i32}}) attributes {{noinline = false}} {{
+    %offsets = tt.make_range {{start = 0 : i32, end = 256 : i32}} : tensor<256xi32, #blocked>
+    %ap = tt.splat %a : {pointer_type} -> tensor<256x{pointer_type}, #blocked>
+    %bp = tt.splat %b : {pointer_type} -> tensor<256x{pointer_type}, #blocked>
+    %cp = tt.splat %c : {pointer_type} -> tensor<256x{pointer_type}, #blocked>
+    %op = tt.splat %out : {pointer_type} -> tensor<256x{pointer_type}, #blocked>
+    %aa = tt.addptr %ap, %offsets : tensor<256x{pointer_type}, #blocked>, tensor<256xi32, #blocked>
+    %ba = tt.addptr %bp, %offsets : tensor<256x{pointer_type}, #blocked>, tensor<256xi32, #blocked>
+    %ca = tt.addptr %cp, %offsets : tensor<256x{pointer_type}, #blocked>, tensor<256xi32, #blocked>
+    %oa = tt.addptr %op, %offsets : tensor<256x{pointer_type}, #blocked>, tensor<256xi32, #blocked>
+    %av = tt.load %aa : tensor<256x{pointer_type}, #blocked>
+    %bv = tt.load %ba : tensor<256x{pointer_type}, #blocked>
+    %cv = tt.load %ca : tensor<256x{pointer_type}, #blocked>
+{packed_operations}
+    tt.store %oa, %{result} : tensor<256x{pointer_type}, #blocked>
+    tt.return
+  }}
+}}
+"""
+    source_file = tmp_path / f"packed_chain_{element_type}.ttgir"
+    source_file.write_text(src)
+    ptx = triton.compile(str(source_file), target=GPUTarget("cuda", 100, 32)).asm["ptx"]
+    pattern = re.compile(
+        rf"^\s*(?P<operation>add|sub|mul|fma|min|max)\.(?:rn\.)?{packed_type}\s+"
+        r"(?P<output>%\w+),\s*(?P<input>%\w+)", re.MULTILINE)
+    emitted_operations = list(pattern.finditer(ptx))
+    assert [match.group("operation") for match in emitted_operations] == [name for name, _, _ in operations]
+    for previous, current in zip(emitted_operations, emitted_operations[1:]):
+        assert current.group("input") == previous.group("output")
+    assert "prmt.b32" not in ptx
 
 
 def test_compile_only_ws_cluster_barrier_shared_memory(tmp_path) -> None:

--- a/python/triton/compiler/code_generator.py
+++ b/python/triton/compiler/code_generator.py
@@ -292,7 +292,7 @@ class CodeGenerator(ast.NodeVisitor):
         self.is_gluon = is_gluon
         if is_gluon:
             from triton.experimental.gluon.language._semantic import GluonSemantic
-            self.builder = gluon_ir.GluonOpBuilder(context)
+            self.builder = gluon_ir.GluonOpBuilder(context, options.arch)
             self.semantic = GluonSemantic(self.builder)
         else:
             from triton.language.semantic import TritonSemantic

--- a/python/triton/experimental/gluon/language/nvidia/__init__.py
+++ b/python/triton/experimental/gluon/language/nvidia/__init__.py
@@ -1,4 +1,5 @@
 from . import blackwell
 from . import hopper
+from . import rubin
 
-__all__ = ["blackwell", "hopper"]
+__all__ = ["blackwell", "hopper", "rubin"]

--- a/python/triton/experimental/gluon/language/nvidia/blackwell/__init__.py
+++ b/python/triton/experimental/gluon/language/nvidia/blackwell/__init__.py
@@ -99,27 +99,22 @@ class TensorMemoryScalesLayout:
 
     Args:
         cga_layout (Optional[List[List[int]]]): CGA layout bases. Defaults to [].
-        block_rep_order (str): Order of repeated scale blocks. Must be either
-            ``"mnThenK"`` or ``"kThenMn"``. Defaults to ``"mnThenK"``.
     """
     cga_layout: List[List[int]] = field(default_factory=list)
-    block_rep_order: str = "mnThenK"
 
     def __post_init__(self):
         super().__setattr__("cga_layout", _unwrap_if_constexpr(self.cga_layout))
-        super().__setattr__("block_rep_order", _unwrap_if_constexpr(self.block_rep_order))
         assert all(len(basis) == 2 for basis in self.cga_layout)
-        assert self.block_rep_order in ("mnThenK", "kThenMn")
 
     def _to_ir(self, builder):
-        return builder.get_tensor_memory_scales_layout([list(basis) for basis in self.cga_layout], self.block_rep_order)
+        return builder.get_tensor_memory_scales_layout([list(basis) for basis in self.cga_layout])
 
     def mangle(self) -> str:
         cga_layout_str = "_".join("~".join(map(str, basis)) for basis in self.cga_layout)
-        return f"TLS{self.block_rep_order}_{cga_layout_str}TLS"
+        return f"TLS{cga_layout_str}TLS"
 
     def __hash__(self):
-        return hash((tuple(tuple(b) for b in self.cga_layout), self.block_rep_order))
+        return hash(tuple(tuple(b) for b in self.cga_layout))
 
 
 @dataclass(frozen=True)

--- a/python/triton/experimental/gluon/language/nvidia/hopper/mbarrier.py
+++ b/python/triton/experimental/gluon/language/nvidia/hopper/mbarrier.py
@@ -29,39 +29,17 @@ def expect(mbarrier, bytes_per_cta=None, pred=True, _semantic=None):
 
 
 @builtin
-def arrive(mbarrier, *, count=1, cta_mask=0, pred=True, _semantic=None):
+def arrive(mbarrier, *, count=1, pred=True, _semantic=None):
     """
     Arrive at an mbarrier with a specified count.
-
-    When ``cta_mask`` is non-zero, the arrive is multicast across the cluster.
-    Each bit set in the mask identifies a CTA ID dimension to multicast
-    along. CTA IDs ``a`` and ``b`` belong to the same equivalence class iff
-    ``a & ~cta_mask == b & ~cta_mask``; all CTAs in a class multicast to each
-    other. Multicast requires ``num_ctas > 1``, ``0 < cta_mask <= num_ctas - 1``,
-    and the barrier must have the identity CGA layout ``[[1], [2], ...]``. The
-    default value of ``cta_mask`` is 0 (no multicast).
 
     Args:
         mbarrier (shared_memory_descriptor): Barrier to be signalled.
         count (int): Count to arrive with. Defaults to 1.
-        cta_mask (int): CTA broadcast dimension bits (see above). Defaults
-            to 0 (no multicast). Must satisfy ``0 < cta_mask <= num_ctas - 1``
-            when non-zero.
         pred (bool): Scalar predicate. Operation is skipped if predicate is False. Defaults to True.
     """
     count = _unwrap_if_constexpr(count)
-    cta_mask = _unwrap_if_constexpr(cta_mask)
-    if not isinstance(cta_mask, int) or isinstance(cta_mask, bool):
-        raise TypeError(f"cta_mask must be an int, got {type(cta_mask).__name__}")
-    if cta_mask:
-        num_ctas = _semantic.builder.options.num_ctas
-        if cta_mask < 0:
-            raise ValueError(f"cta_mask must be positive, got {cta_mask}")
-        if cta_mask > num_ctas - 1:
-            raise ValueError(f"cta_mask must be <= num_ctas - 1 ({num_ctas - 1}), got {cta_mask}")
-        sm = int(_semantic.builder.options.arch.removeprefix("sm"))
-        if sm < 107:
-            raise ValueError(f"multicast arrive requires Rubin (sm_107+), got sm_{sm}")
+    cta_mask = 0
     pred = _semantic.to_tensor(pred)
     _semantic.builder.create_mbarrier_arrive(mbarrier.handle, count, cta_mask, pred.handle)
 

--- a/python/triton/experimental/gluon/language/nvidia/rubin/__init__.py
+++ b/python/triton/experimental/gluon/language/nvidia/rubin/__init__.py
@@ -1,0 +1,77 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from triton.experimental.gluon.language._core import _unwrap_if_constexpr
+
+from ..blackwell import (
+    TensorMemoryLayout,
+    _TensorMemoryLinearLayout,
+    allocate_tensor_memory,
+    async_copy,
+    async_store,
+    clc,
+    fence_async_shared,
+    float2,
+    mma_v2,
+    tensor_memory_descriptor,
+    tensor_memory_descriptor_type,
+    tcgen05_commit,
+    tcgen05_copy,
+    tcgen05_mma,
+    tcgen05_mma_barrier_count,
+    tcgen05_mma_scaled,
+    tma,
+)
+from ..blackwell import TensorMemoryScalesLayout as _BlackwellTensorMemoryScalesLayout
+from . import mbarrier
+
+__all__ = [
+    "allocate_tensor_memory",
+    "async_copy",
+    "async_store",
+    "clc",
+    "fence_async_shared",
+    "float2",
+    "mbarrier",
+    "mma_v2",
+    "tensor_memory_descriptor",
+    "tensor_memory_descriptor_type",
+    "tcgen05_commit",
+    "tcgen05_copy",
+    "tcgen05_mma",
+    "tcgen05_mma_barrier_count",
+    "tcgen05_mma_scaled",
+    "TensorMemoryLayout",
+    "TensorMemoryScalesLayout",
+    "tma",
+    "_TensorMemoryLinearLayout",
+]
+
+
+@dataclass(frozen=True, eq=True)
+class TensorMemoryScalesLayout(_BlackwellTensorMemoryScalesLayout):
+    """
+    Describes the layout for tensor memory scales in Rubin architecture.
+
+    Args:
+        cga_layout (Optional[List[List[int]]]): CGA layout bases. Defaults to [].
+        block_rep_order (str): Order of repeated scale blocks. Must be either
+            ``"mnThenK"`` or ``"kThenMn"``. Defaults to ``"mnThenK"``.
+    """
+    block_rep_order: str = "mnThenK"
+
+    def __post_init__(self):
+        super().__post_init__()
+        super().__setattr__("block_rep_order", _unwrap_if_constexpr(self.block_rep_order))
+        assert self.block_rep_order in ("mnThenK", "kThenMn")
+
+    def _to_ir(self, builder):
+        return builder.get_tensor_memory_scales_layout([list(basis) for basis in self.cga_layout], self.block_rep_order)
+
+    def mangle(self) -> str:
+        cga_layout_str = "_".join("~".join(map(str, basis)) for basis in self.cga_layout)
+        return f"TLS{self.block_rep_order}_{cga_layout_str}TLS"
+
+    def __hash__(self):
+        return hash((tuple(tuple(b) for b in self.cga_layout), self.block_rep_order))

--- a/python/triton/experimental/gluon/language/nvidia/rubin/mbarrier.py
+++ b/python/triton/experimental/gluon/language/nvidia/rubin/mbarrier.py
@@ -1,0 +1,56 @@
+from ..._core import _unwrap_if_constexpr, builtin
+from ..hopper.mbarrier import (
+    MBarrierLayout,
+    allocate_mbarrier,
+    expect,
+    fence_init_release_cluster,
+    init,
+    invalidate,
+    wait,
+)
+
+__all__ = [
+    "allocate_mbarrier",
+    "arrive",
+    "expect",
+    "fence_init_release_cluster",
+    "init",
+    "invalidate",
+    "MBarrierLayout",
+    "wait",
+]
+
+
+@builtin
+def arrive(mbarrier, *, count=1, cta_mask=0, pred=True, _semantic=None):
+    """
+    Arrive at an mbarrier with a specified count.
+
+    When ``cta_mask`` is non-zero, the arrive is multicast across the cluster.
+    Each bit set in the mask identifies a CTA ID dimension to multicast
+    along. CTA IDs ``a`` and ``b`` belong to the same equivalence class iff
+    ``a & ~cta_mask == b & ~cta_mask``; all CTAs in a class multicast to each
+    other. Multicast requires ``num_ctas > 1``, ``0 < cta_mask <= num_ctas - 1``,
+    and the barrier must have the identity CGA layout ``[[1], [2], ...]``. The
+    default value of ``cta_mask`` is 0 (no multicast).
+
+    Args:
+        mbarrier (shared_memory_descriptor): Barrier to be signalled.
+        count (int): Count to arrive with. Defaults to 1.
+        cta_mask (int): CTA broadcast dimension bits (see above). Defaults
+            to 0 (no multicast). Must satisfy ``0 < cta_mask <= num_ctas - 1``
+            when non-zero.
+        pred (bool): Scalar predicate. Operation is skipped if predicate is False. Defaults to True.
+    """
+    count = _unwrap_if_constexpr(count)
+    cta_mask = _unwrap_if_constexpr(cta_mask)
+    if not isinstance(cta_mask, int) or isinstance(cta_mask, bool):
+        raise TypeError(f"cta_mask must be an int, got {type(cta_mask).__name__}")
+    if cta_mask:
+        num_ctas = _semantic.builder.options.num_ctas
+        if cta_mask < 0:
+            raise ValueError(f"cta_mask must be positive, got {cta_mask}")
+        if cta_mask > num_ctas - 1:
+            raise ValueError(f"cta_mask must be <= num_ctas - 1 ({num_ctas - 1}), got {cta_mask}")
+    pred = _semantic.to_tensor(pred)
+    _semantic.builder.create_mbarrier_arrive(mbarrier.handle, count, cta_mask, pred.handle)

--- a/test/Conversion/tritongpu_to_llvm_rubin.mlir
+++ b/test/Conversion/tritongpu_to_llvm_rubin.mlir
@@ -1,4 +1,5 @@
-// RUN: triton-opt %s -split-input-file --convert-triton-gpu-to-llvm=compute-capability=107 -cse | FileCheck %s
+// RUN: triton-opt %s -split-input-file --convert-triton-gpu-to-llvm='compute-capability=107 ptx-version=94' -cse | FileCheck %s
+// RUN: triton-opt %s -split-input-file --convert-triton-gpu-to-llvm='compute-capability=107 ptx-version=93' -cse | FileCheck %s
 
 #shared = #ttg.nvmma_shared<{swizzlingByteWidth = 64, transposed = false, elementBitWidth = 8}>
 #shared1 = #ttg.nvmma_shared<{swizzlingByteWidth = 32, transposed = true, elementBitWidth = 8}>
@@ -214,5 +215,259 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 8 : i32, ttg.targ
     !ttg.memdesc<128x16xi8, #tmem_scales, #ttng.tensor_memory>,
     !ttg.memdesc<1xi64, #shared2, #ttg.shared_memory>
     tt.return
+  }
+}
+
+// -----
+
+#blocked = #ttg.blocked<{sizePerThread = [1, 2], threadsPerWarp = [32, 1], warpsPerCTA = [4, 1], order = [1, 0]}>
+module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.target = "cuda:107", "ttg.threads-per-warp" = 32 : i32} {
+  // CHECK-LABEL: @packed_arith_f32x2
+  // CHECK: llvm.insertelement {{.*}} : vector<2xf32>
+  // CHECK: llvm.bitcast {{.*}} : vector<2xf32> to i64
+  // CHECK: llvm.inline_asm {{.*}} "add.f32x2 $0, $1, $2;", "=l,l,l" {{.*}} : (i64, i64) -> i64
+  // CHECK: llvm.inline_asm {{.*}} "sub.f32x2 $0, $1, $2;", "=l,l,l" {{.*}} : (i64, i64) -> i64
+  // CHECK: llvm.inline_asm {{.*}} "mul.f32x2 $0, $1, $2;", "=l,l,l" {{.*}} : (i64, i64) -> i64
+  // CHECK: llvm.inline_asm {{.*}} "fma.rn.f32x2 $0, $1, $2, $3;", "=l,l,l,l" {{.*}} : (i64, i64, i64) -> i64
+  // CHECK: llvm.bitcast {{.*}} : i64 to vector<2xf32>
+  tt.func private @packed_arith_f32x2(
+      %a: tensor<128x2xf32, #blocked>,
+      %b: tensor<128x2xf32, #blocked>,
+      %c: tensor<128x2xf32, #blocked>) -> tensor<128x2xf32, #blocked> {
+    %add = ttng.packed_arith add %a, %b : (tensor<128x2xf32, #blocked>, tensor<128x2xf32, #blocked>) -> tensor<128x2xf32, #blocked>
+    %sub = ttng.packed_arith sub %add, %b : (tensor<128x2xf32, #blocked>, tensor<128x2xf32, #blocked>) -> tensor<128x2xf32, #blocked>
+    %mul = ttng.packed_arith mul %sub, %b : (tensor<128x2xf32, #blocked>, tensor<128x2xf32, #blocked>) -> tensor<128x2xf32, #blocked>
+    %fma = ttng.packed_arith fma %mul, %b, %c : (tensor<128x2xf32, #blocked>, tensor<128x2xf32, #blocked>, tensor<128x2xf32, #blocked>) -> tensor<128x2xf32, #blocked>
+    tt.return %fma : tensor<128x2xf32, #blocked>
+  }
+}
+
+// -----
+
+#result = #ttg.blocked<{sizePerThread = [4, 2], threadsPerWarp = [1, 32], warpsPerCTA = [1, 4], order = [0, 1]}>
+#fp4 = #ttg.blocked<{sizePerThread = [2, 2], threadsPerWarp = [1, 32], warpsPerCTA = [1, 4], order = [0, 1]}>
+#narrow_result = #ttg.blocked<{sizePerThread = [2, 2], threadsPerWarp = [1, 32], warpsPerCTA = [1, 4], order = [0, 1]}>
+#narrow_fp4 = #ttg.blocked<{sizePerThread = [1, 2], threadsPerWarp = [1, 32], warpsPerCTA = [1, 4], order = [0, 1]}>
+module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.target = "cuda:100", "ttg.threads-per-warp" = 32 : i32} {
+  // CHECK-LABEL: @packed_arith_fp4_axis0
+  // CHECK-COUNT-3: llvm.inline_asm {{.*}} "add.e4m3x4.e2m1x4 $0, $1, $2;", "=r,h,r"
+  tt.func @packed_arith_fp4_axis0(
+      %a: tensor<2x256xi8, #fp4>,
+      %b: tensor<4x256xf8E4M3FN, #result>,
+      %narrow_a: tensor<1x256xi8, #narrow_fp4>,
+      %narrow_b: tensor<2x256xf8E4M3FN, #narrow_result>) {
+    %0 = ttng.packed_arith add %a, %b : (tensor<2x256xi8, #fp4>, tensor<4x256xf8E4M3FN, #result>) -> tensor<4x256xf8E4M3FN, #result>
+    %1 = ttng.packed_arith add %narrow_a, %narrow_b : (tensor<1x256xi8, #narrow_fp4>, tensor<2x256xf8E4M3FN, #narrow_result>) -> tensor<2x256xf8E4M3FN, #narrow_result>
+    tt.return
+  }
+}
+
+// -----
+
+#perm = #ttg.linear<{register = [[2], [1]], lane = [[4], [8], [16], [32], [64]], warp = [[128], [256]], block = []}>
+#bcast = #ttg.linear<{register = [[0], [1]], lane = [[2], [4], [8], [16], [32]], warp = [[64], [128]], block = []}>
+#canonical = #ttg.linear<{register = [[1], [2]], lane = [[4], [8], [16], [32], [64]], warp = [[128], [256]], block = []}>
+#fp4 = #ttg.linear<{register = [[1]], lane = [[2], [4], [8], [16], [32]], warp = [[64], [128]], block = []}>
+module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.target = "cuda:100", "ttg.threads-per-warp" = 32 : i32} {
+  // CHECK-LABEL: @packed_arith_register_layouts
+  // CHECK: %[[A0:.*]] = llvm.extractvalue %arg0[0]
+  // CHECK: %[[A1:.*]] = llvm.extractvalue %arg0[1]
+  // CHECK: %[[A2:.*]] = llvm.extractvalue %arg0[2]
+  // CHECK: %[[A3:.*]] = llvm.extractvalue %arg0[3]
+  // CHECK: llvm.insertelement %[[A0]],
+  // CHECK: llvm.insertelement %[[A1]],
+  // CHECK: llvm.inline_asm {{.*}} "add.f32x2
+  // CHECK: llvm.insertelement %[[A2]],
+  // CHECK: llvm.insertelement %[[A3]],
+  // CHECK: llvm.inline_asm {{.*}} "add.f32x2
+  // CHECK: llvm.inline_asm {{.*}} "mul.f32x2
+  // CHECK-NOT: {{prmt|shfl\.sync}}
+  // CHECK: llvm.inline_asm {{.*}} "add.e4m3x4.e2m1x4 $0, $1, $2;", "=r,h,r"
+  // CHECK-NOT: {{prmt|shfl\.sync}}
+  tt.func @packed_arith_register_layouts(
+      %pa: tensor<512xf32, #perm>,
+      %pb: tensor<512xf32, #perm>,
+      %ba: tensor<256xf32, #bcast>,
+      %bb: tensor<256xf32, #bcast>,
+      %fp4: tensor<256xi8, #fp4>,
+      %f8: tensor<512xf8E4M3FN, #perm>) {
+    %perm = ttng.packed_arith add %pa, %pb : (tensor<512xf32, #perm>, tensor<512xf32, #perm>) -> tensor<512xf32, #perm>
+    %bcast = ttng.packed_arith mul %ba, %bb : (tensor<256xf32, #bcast>, tensor<256xf32, #bcast>) -> tensor<256xf32, #bcast>
+    %canonical = ttg.convert_layout %f8 : tensor<512xf8E4M3FN, #perm> -> tensor<512xf8E4M3FN, #canonical>
+    %result = ttng.packed_arith add %fp4, %canonical : (tensor<256xi8, #fp4>, tensor<512xf8E4M3FN, #canonical>) -> tensor<512xf8E4M3FN, #canonical>
+    %restored = ttg.convert_layout %result : tensor<512xf8E4M3FN, #canonical> -> tensor<512xf8E4M3FN, #perm>
+    tt.return
+  }
+}
+
+// -----
+
+#blocked = #ttg.blocked<{sizePerThread = [1, 2], threadsPerWarp = [32, 1], warpsPerCTA = [4, 1], order = [1, 0]}>
+module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.target = "cuda:107", "ttg.threads-per-warp" = 32 : i32} {
+  // CHECK-LABEL: @packed_arith_homogeneous_half
+  // CHECK: llvm.inline_asm {{.*}} "add.f16x2 $0, $1, $2;", "=r,r,r"
+  // CHECK: llvm.inline_asm {{.*}} "sub.f16x2 $0, $1, $2;", "=r,r,r"
+  // CHECK: llvm.inline_asm {{.*}} "mul.f16x2 $0, $1, $2;", "=r,r,r"
+  // CHECK: llvm.inline_asm {{.*}} "fma.rn.f16x2 $0, $1, $2, $3;", "=r,r,r,r"
+  // CHECK: llvm.inline_asm {{.*}} "min.f16x2 $0, $1, $2;", "=r,r,r"
+  // CHECK: llvm.inline_asm {{.*}} "max.f16x2 $0, $1, $2;", "=r,r,r"
+  // CHECK: llvm.inline_asm {{.*}} "add.bf16x2 $0, $1, $2;", "=r,r,r"
+  // CHECK: llvm.inline_asm {{.*}} "sub.bf16x2 $0, $1, $2;", "=r,r,r"
+  // CHECK: llvm.inline_asm {{.*}} "mul.bf16x2 $0, $1, $2;", "=r,r,r"
+  // CHECK: llvm.inline_asm {{.*}} "fma.rn.bf16x2 $0, $1, $2, $3;", "=r,r,r,r"
+  // CHECK: llvm.inline_asm {{.*}} "min.bf16x2 $0, $1, $2;", "=r,r,r"
+  // CHECK: llvm.inline_asm {{.*}} "max.bf16x2 $0, $1, $2;", "=r,r,r"
+  tt.func @packed_arith_homogeneous_half(
+      %f16a: tensor<128x2xf16, #blocked>,
+      %f16b: tensor<128x2xf16, #blocked>,
+      %f16c: tensor<128x2xf16, #blocked>,
+      %bf16a: tensor<128x2xbf16, #blocked>,
+      %bf16b: tensor<128x2xbf16, #blocked>,
+      %bf16c: tensor<128x2xbf16, #blocked>) {
+    %f16add = ttng.packed_arith add %f16a, %f16b : (tensor<128x2xf16, #blocked>, tensor<128x2xf16, #blocked>) -> tensor<128x2xf16, #blocked>
+    %f16sub = ttng.packed_arith sub %f16add, %f16b : (tensor<128x2xf16, #blocked>, tensor<128x2xf16, #blocked>) -> tensor<128x2xf16, #blocked>
+    %f16mul = ttng.packed_arith mul %f16sub, %f16b : (tensor<128x2xf16, #blocked>, tensor<128x2xf16, #blocked>) -> tensor<128x2xf16, #blocked>
+    %f16fma = ttng.packed_arith fma %f16mul, %f16b, %f16c : (tensor<128x2xf16, #blocked>, tensor<128x2xf16, #blocked>, tensor<128x2xf16, #blocked>) -> tensor<128x2xf16, #blocked>
+    %f16min = ttng.packed_arith min %f16fma, %f16b : (tensor<128x2xf16, #blocked>, tensor<128x2xf16, #blocked>) -> tensor<128x2xf16, #blocked>
+    %f16max = ttng.packed_arith max %f16min, %f16b : (tensor<128x2xf16, #blocked>, tensor<128x2xf16, #blocked>) -> tensor<128x2xf16, #blocked>
+    %bf16add = ttng.packed_arith add %bf16a, %bf16b : (tensor<128x2xbf16, #blocked>, tensor<128x2xbf16, #blocked>) -> tensor<128x2xbf16, #blocked>
+    %bf16sub = ttng.packed_arith sub %bf16add, %bf16b : (tensor<128x2xbf16, #blocked>, tensor<128x2xbf16, #blocked>) -> tensor<128x2xbf16, #blocked>
+    %bf16mul = ttng.packed_arith mul %bf16sub, %bf16b : (tensor<128x2xbf16, #blocked>, tensor<128x2xbf16, #blocked>) -> tensor<128x2xbf16, #blocked>
+    %bf16fma = ttng.packed_arith fma %bf16mul, %bf16b, %bf16c : (tensor<128x2xbf16, #blocked>, tensor<128x2xbf16, #blocked>, tensor<128x2xbf16, #blocked>) -> tensor<128x2xbf16, #blocked>
+    %bf16min = ttng.packed_arith min %bf16fma, %bf16b : (tensor<128x2xbf16, #blocked>, tensor<128x2xbf16, #blocked>) -> tensor<128x2xbf16, #blocked>
+    %bf16max = ttng.packed_arith max %bf16min, %bf16b : (tensor<128x2xbf16, #blocked>, tensor<128x2xbf16, #blocked>) -> tensor<128x2xbf16, #blocked>
+    tt.return
+  }
+}
+
+// -----
+
+#blocked = #ttg.blocked<{sizePerThread = [1, 4], threadsPerWarp = [32, 1], warpsPerCTA = [4, 1], order = [1, 0]}>
+#fp4 = #ttg.blocked<{sizePerThread = [1, 2], threadsPerWarp = [32, 1], warpsPerCTA = [4, 1], order = [1, 0]}>
+module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.target = "cuda:100", "ttg.threads-per-warp" = 32 : i32} {
+  // CHECK-LABEL: @packed_arith_alternate_x4
+  // CHECK: llvm.inline_asm {{.*}} "add.e4m3x4.e5m2x4 $0, $1, $2;", "=r,r,r" {{.*}} : (i32, i32) -> i32
+  // CHECK: llvm.bitcast {{.*}} : vector<2xi8> to i16
+  // CHECK: llvm.inline_asm {{.*}} "sub.e5m2x4.e2m1x4 $0, $1, $2;", "=r,h,r" {{.*}} : (i16, i32) -> i32
+  // CHECK: llvm.inline_asm {{.*}} "mul.e4m3x4.e2m1x4.e5m2x4 $0, $1, $2;", "=r,h,r" {{.*}} : (i16, i32) -> i32
+  // CHECK: llvm.inline_asm {{.*}} "fma.e5m2x4.e2m1x4.e4m3x4 $0, $1, $2, $3;", "=r,h,r,r" {{.*}} : (i16, i32, i32) -> i32
+  // CHECK: llvm.bitcast {{.*}} : i32 to vector<4xi8>
+  // CHECK: llvm.inline_asm {{.*}} "add.e4m3x4.ue8m0x4 $0, $1, $2;", "=r,r,r" {{.*}} : (i32, i32) -> i32
+  // CHECK: llvm.inline_asm {{.*}} "mul.e4m3x4.e2m1x4.e2m1x4 $0, $1, $2;", "=r,h,h" {{.*}} : (i16, i16) -> i32
+  // CHECK: llvm.inline_asm {{.*}} "fma.e4m3x4.ue8m0x4.e2m1x4 $0, $1, $2, $3;", "=r,r,h,r" {{.*}} : (i32, i16, i32) -> i32
+  tt.func @packed_arith_alternate_x4(
+      %e5m2: tensor<128x4xf8E5M2, #blocked>,
+      %e4m3: tensor<128x4xf8E4M3FN, #blocked>,
+      %ue8m0: tensor<128x4xf8E8M0FNU, #blocked>,
+      %e2m1: tensor<128x2xi8, #fp4>,
+      %e2m1b: tensor<128x2xi8, #fp4>) {
+    %add = ttng.packed_arith add %e5m2, %e4m3 : (tensor<128x4xf8E5M2, #blocked>, tensor<128x4xf8E4M3FN, #blocked>) -> tensor<128x4xf8E4M3FN, #blocked>
+    %sub = ttng.packed_arith sub %e2m1, %e5m2 : (tensor<128x2xi8, #fp4>, tensor<128x4xf8E5M2, #blocked>) -> tensor<128x4xf8E5M2, #blocked>
+    %mul = ttng.packed_arith mul %e2m1, %e5m2 : (tensor<128x2xi8, #fp4>, tensor<128x4xf8E5M2, #blocked>) -> tensor<128x4xf8E4M3FN, #blocked>
+    %fma = ttng.packed_arith fma %e2m1, %e4m3, %e5m2 : (tensor<128x2xi8, #fp4>, tensor<128x4xf8E4M3FN, #blocked>, tensor<128x4xf8E5M2, #blocked>) -> tensor<128x4xf8E5M2, #blocked>
+    %scale = ttng.packed_arith add %ue8m0, %e4m3 : (tensor<128x4xf8E8M0FNU, #blocked>, tensor<128x4xf8E4M3FN, #blocked>) -> tensor<128x4xf8E4M3FN, #blocked>
+    %two_fp4 = ttng.packed_arith mul %e2m1, %e2m1b : (tensor<128x2xi8, #fp4>, tensor<128x2xi8, #fp4>) -> tensor<128x4xf8E4M3FN, #blocked>
+    %scale_fp4 = ttng.packed_arith fma %ue8m0, %e2m1, %e4m3 : (tensor<128x4xf8E8M0FNU, #blocked>, tensor<128x2xi8, #fp4>, tensor<128x4xf8E4M3FN, #blocked>) -> tensor<128x4xf8E4M3FN, #blocked>
+    tt.return
+  }
+}
+
+// -----
+
+#blocked = #ttg.blocked<{sizePerThread = [1, 2], threadsPerWarp = [32, 1], warpsPerCTA = [4, 1], order = [1, 0]}>
+module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.target = "cuda:107", "ttg.threads-per-warp" = 32 : i32} {
+  // CHECK-LABEL: @packed_arith_mixed
+  // CHECK: llvm.inline_asm {{.*}} "mul.f16x2 $0, $1, $2;", "=r,r,r" {{.*}} : (i32, i32) -> i32
+  // CHECK: llvm.inline_asm {{.*}} "fma.rn.bf16x2 $0, $1, $2, $3;", "=r,r,r,r" {{.*}} : (i32, i32, i32) -> i32
+  // CHECK: llvm.inline_asm {{.*}} "add.f32x2.f16x2.f32x2 $0, $1, $2;", "=l,r,l" {{.*}} : (i32, i64) -> i64
+  // CHECK: llvm.inline_asm {{.*}} "add.f32x2.bf16x2.f32x2 $0, $1, $2;", "=l,r,l" {{.*}} : (i32, i64) -> i64
+  // CHECK: llvm.inline_asm {{.*}} "sub.f32x2.f16x2.f32x2 $0, $1, $2;", "=l,r,l" {{.*}} : (i32, i64) -> i64
+  // CHECK: llvm.inline_asm {{.*}} "sub.f32x2.bf16x2.f32x2 $0, $1, $2;", "=l,r,l" {{.*}} : (i32, i64) -> i64
+  // CHECK: llvm.inline_asm {{.*}} "add.rz.ftz.f16x2.f32x2.f32x2 $0, $1, $2;", "=r,l,l" {{.*}} : (i64, i64) -> i32
+  // CHECK: llvm.inline_asm {{.*}} "add.rz.bf16x2.f32x2.f32x2 $0, $1, $2;", "=r,l,l" {{.*}} : (i64, i64) -> i32
+  // CHECK: llvm.inline_asm {{.*}} "sub.rz.ftz.f16x2.f32x2.f32x2 $0, $1, $2;", "=r,l,l" {{.*}} : (i64, i64) -> i32
+  // CHECK: llvm.inline_asm {{.*}} "sub.rz.bf16x2.f32x2.f32x2 $0, $1, $2;", "=r,l,l" {{.*}} : (i64, i64) -> i32
+  // CHECK: llvm.inline_asm {{.*}} "mul.ftz.rz.f16x2.f32x2.f32x2 $0, $1, $2;", "=r,l,l" {{.*}} : (i64, i64) -> i32
+  // CHECK: llvm.inline_asm {{.*}} "mul.rz.bf16x2.f32x2.f32x2 $0, $1, $2;", "=r,l,l" {{.*}} : (i64, i64) -> i32
+  // CHECK: llvm.inline_asm {{.*}} "mul.bf16x2.bf16x2.f16x2 $0, $1, $2;", "=r,r,r" {{.*}} : (i32, i32) -> i32
+  // CHECK: llvm.inline_asm {{.*}} "mul.f16x2.f16x2.bf16x2 $0, $1, $2;", "=r,r,r" {{.*}} : (i32, i32) -> i32
+  // CHECK: llvm.inline_asm {{.*}} "fma.rn.f32x2.f16x2.f32x2.f32x2 $0, $1, $2, $3;", "=l,r,l,l" {{.*}} : (i32, i64, i64) -> i64
+  // CHECK: llvm.inline_asm {{.*}} "fma.rn.f32x2.bf16x2.f32x2.f32x2 $0, $1, $2, $3;", "=l,r,l,l" {{.*}} : (i32, i64, i64) -> i64
+  tt.func @packed_arith_mixed(
+      %f32a: tensor<128x2xf32, #blocked>,
+      %f32b: tensor<128x2xf32, #blocked>,
+      %f16: tensor<128x2xf16, #blocked>,
+      %bf16: tensor<128x2xbf16, #blocked>) {
+    %hom_f16 = ttng.packed_arith mul %f16, %f16 : (tensor<128x2xf16, #blocked>, tensor<128x2xf16, #blocked>) -> tensor<128x2xf16, #blocked>
+    %hom_bf16 = ttng.packed_arith fma %bf16, %bf16, %bf16 : (tensor<128x2xbf16, #blocked>, tensor<128x2xbf16, #blocked>, tensor<128x2xbf16, #blocked>) -> tensor<128x2xbf16, #blocked>
+    %add_up_f16 = ttng.packed_arith add %f16, %f32a : (tensor<128x2xf16, #blocked>, tensor<128x2xf32, #blocked>) -> tensor<128x2xf32, #blocked>
+    %add_up_bf16 = ttng.packed_arith add %bf16, %f32a : (tensor<128x2xbf16, #blocked>, tensor<128x2xf32, #blocked>) -> tensor<128x2xf32, #blocked>
+    %sub_up_f16 = ttng.packed_arith sub %f16, %f32a : (tensor<128x2xf16, #blocked>, tensor<128x2xf32, #blocked>) -> tensor<128x2xf32, #blocked>
+    %sub_up_bf16 = ttng.packed_arith sub %bf16, %f32a : (tensor<128x2xbf16, #blocked>, tensor<128x2xf32, #blocked>) -> tensor<128x2xf32, #blocked>
+    %down_f16 = ttng.packed_arith add %f32a, %f32b : (tensor<128x2xf32, #blocked>, tensor<128x2xf32, #blocked>) -> tensor<128x2xf16, #blocked>
+    %add_down_bf16 = ttng.packed_arith add %f32a, %f32b : (tensor<128x2xf32, #blocked>, tensor<128x2xf32, #blocked>) -> tensor<128x2xbf16, #blocked>
+    %sub_down_f16 = ttng.packed_arith sub %f32a, %f32b : (tensor<128x2xf32, #blocked>, tensor<128x2xf32, #blocked>) -> tensor<128x2xf16, #blocked>
+    %down_bf16 = ttng.packed_arith sub %f32a, %f32b : (tensor<128x2xf32, #blocked>, tensor<128x2xf32, #blocked>) -> tensor<128x2xbf16, #blocked>
+    %mul_down = ttng.packed_arith mul %f32a, %f32b : (tensor<128x2xf32, #blocked>, tensor<128x2xf32, #blocked>) -> tensor<128x2xf16, #blocked>
+    %mul_down_bf16 = ttng.packed_arith mul %f32a, %f32b : (tensor<128x2xf32, #blocked>, tensor<128x2xf32, #blocked>) -> tensor<128x2xbf16, #blocked>
+    %mul_cross = ttng.packed_arith mul %bf16, %f16 : (tensor<128x2xbf16, #blocked>, tensor<128x2xf16, #blocked>) -> tensor<128x2xbf16, #blocked>
+    %mul_cross_reverse = ttng.packed_arith mul %f16, %bf16 : (tensor<128x2xf16, #blocked>, tensor<128x2xbf16, #blocked>) -> tensor<128x2xf16, #blocked>
+    %fma_f16 = ttng.packed_arith fma %f16, %f32a, %f32b : (tensor<128x2xf16, #blocked>, tensor<128x2xf32, #blocked>, tensor<128x2xf32, #blocked>) -> tensor<128x2xf32, #blocked>
+    %fma_bf16 = ttng.packed_arith fma %bf16, %f32a, %f32b : (tensor<128x2xbf16, #blocked>, tensor<128x2xf32, #blocked>, tensor<128x2xf32, #blocked>) -> tensor<128x2xf32, #blocked>
+    tt.return
+  }
+}
+
+// -----
+
+#blocked = #ttg.blocked<{sizePerThread = [4, 2], threadsPerWarp = [1, 32], warpsPerCTA = [1, 4], order = [1, 0]}>
+module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.target = "cuda:100", "ttg.threads-per-warp" = 32 : i32} {
+  // CHECK-LABEL: @packed_arith_x4_register_order
+  // CHECK: %[[A0:.*]] = llvm.extractvalue %arg0[0]
+  // CHECK: %[[A1:.*]] = llvm.extractvalue %arg0[1]
+  // CHECK: %[[A2:.*]] = llvm.extractvalue %arg0[2]
+  // CHECK: %[[A3:.*]] = llvm.extractvalue %arg0[3]
+  // CHECK: %[[A4:.*]] = llvm.extractvalue %arg0[4]
+  // CHECK: %[[A5:.*]] = llvm.extractvalue %arg0[5]
+  // CHECK: %[[A6:.*]] = llvm.extractvalue %arg0[6]
+  // CHECK: %[[A7:.*]] = llvm.extractvalue %arg0[7]
+  // CHECK: llvm.insertelement %[[A0]],
+  // CHECK: llvm.insertelement %[[A1]],
+  // CHECK: llvm.insertelement %[[A2]],
+  // CHECK: llvm.insertelement %[[A3]],
+  // CHECK: llvm.inline_asm {{.*}} "add.e4m3x4.e4m3x4
+  // CHECK: llvm.insertelement %[[A4]],
+  // CHECK: llvm.insertelement %[[A5]],
+  // CHECK: llvm.insertelement %[[A6]],
+  // CHECK: llvm.insertelement %[[A7]],
+  // CHECK: llvm.inline_asm {{.*}} "add.e4m3x4.e4m3x4
+  tt.func private @packed_arith_x4_register_order(
+      %a: tensor<4x256xf8E4M3FN, #blocked>,
+      %b: tensor<4x256xf8E4M3FN, #blocked>) -> tensor<4x256xf8E4M3FN, #blocked> {
+    %0 = ttng.packed_arith add %a, %b : (tensor<4x256xf8E4M3FN, #blocked>, tensor<4x256xf8E4M3FN, #blocked>) -> tensor<4x256xf8E4M3FN, #blocked>
+    tt.return %0 : tensor<4x256xf8E4M3FN, #blocked>
+  }
+}
+
+// -----
+
+#blocked = #ttg.blocked<{sizePerThread = [2, 2], threadsPerWarp = [1, 32], warpsPerCTA = [1, 4], order = [1, 0]}>
+module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.target = "cuda:107", "ttg.threads-per-warp" = 32 : i32} {
+  // CHECK-LABEL: @packed_arith_x2_register_order
+  // CHECK: %[[A0:.*]] = llvm.extractvalue %arg0[0]
+  // CHECK: %[[A1:.*]] = llvm.extractvalue %arg0[1]
+  // CHECK: %[[A2:.*]] = llvm.extractvalue %arg0[2]
+  // CHECK: %[[A3:.*]] = llvm.extractvalue %arg0[3]
+  // CHECK: llvm.insertelement %[[A0]],
+  // CHECK: llvm.insertelement %[[A1]],
+  // CHECK: llvm.inline_asm {{.*}} "add.f32x2
+  // CHECK: llvm.insertelement %[[A2]],
+  // CHECK: llvm.insertelement %[[A3]],
+  // CHECK: llvm.inline_asm {{.*}} "add.f32x2
+  tt.func private @packed_arith_x2_register_order(
+      %a: tensor<2x256xf32, #blocked>,
+      %b: tensor<2x256xf32, #blocked>) -> tensor<2x256xf32, #blocked> {
+    %0 = ttng.packed_arith add %a, %b : (tensor<2x256xf32, #blocked>, tensor<2x256xf32, #blocked>) -> tensor<2x256xf32, #blocked>
+    tt.return %0 : tensor<2x256xf32, #blocked>
   }
 }

--- a/test/TritonGPU/fpsan.mlir
+++ b/test/TritonGPU/fpsan.mlir
@@ -25,6 +25,108 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, "ttg.thr
 
 // -----
 
+#packed = #ttg.blocked<{sizePerThread = [1, 4], threadsPerWarp = [32, 1], warpsPerCTA = [4, 1], order = [1, 0]}>
+#fp4 = #ttg.blocked<{sizePerThread = [1, 2], threadsPerWarp = [32, 1], warpsPerCTA = [4, 1], order = [1, 0]}>
+module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, "ttg.threads-per-warp" = 32 : i32} {
+  // CHECK-LABEL: @packed_arith_fpsan_ue8m0_multiple_fp4
+  tt.func public @packed_arith_fpsan_ue8m0_multiple_fp4(
+      %scale: tensor<128x4xf8E8M0FNU, #packed>,
+      %a: tensor<128x2xi8, #fp4>,
+      %b: tensor<128x2xi8, #fp4>,
+      %addend: tensor<128x4xf8E4M3FN, #packed>) -> tensor<128x4xf8E4M3FN, #packed> {
+    // CHECK: arith.muli
+    // CHECK: tti.experimental_fpsan_embed
+    // CHECK: arith.addi
+    // CHECK: arith.muli
+    // CHECK: arith.addi
+    // CHECK-NOT: ttng.packed_arith
+    %product = ttng.packed_arith mul %a, %b : (tensor<128x2xi8, #fp4>, tensor<128x2xi8, #fp4>) -> tensor<128x4xf8E4M3FN, #packed>
+    %scaled = ttng.packed_arith add %scale, %product : (tensor<128x4xf8E8M0FNU, #packed>, tensor<128x4xf8E4M3FN, #packed>) -> tensor<128x4xf8E4M3FN, #packed>
+    %result = ttng.packed_arith fma %scale, %a, %scaled : (tensor<128x4xf8E8M0FNU, #packed>, tensor<128x2xi8, #fp4>, tensor<128x4xf8E4M3FN, #packed>) -> tensor<128x4xf8E4M3FN, #packed>
+    tt.return %result : tensor<128x4xf8E4M3FN, #packed>
+  }
+}
+
+// -----
+
+#packed = #ttg.blocked<{sizePerThread = [1, 4], threadsPerWarp = [32, 1], warpsPerCTA = [4, 1], order = [1, 0]}>
+module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, "ttg.threads-per-warp" = 32 : i32} {
+  // CHECK-LABEL: @packed_arith_fpsan_x2
+  tt.func public @packed_arith_fpsan_x2(
+      %f32a: tensor<128x4xf32, #packed>,
+      %f32b: tensor<128x4xf32, #packed>,
+      %f32c: tensor<128x4xf32, #packed>,
+      %f16a: tensor<128x4xf16, #packed>,
+      %f16b: tensor<128x4xf16, #packed>) -> tensor<128x4xf16, #packed> {
+    // CHECK: tti.experimental_fpsan_embed
+    // CHECK: arith.addi
+    // CHECK: arith.subi
+    // CHECK: arith.muli
+    // CHECK: arith.addi
+    // CHECK: arith.extsi
+    // CHECK: arith.minsi
+    // CHECK: arith.maxsi
+    // CHECK-NOT: ttng.packed_arith
+    %add = ttng.packed_arith add %f32a, %f32b : (tensor<128x4xf32, #packed>, tensor<128x4xf32, #packed>) -> tensor<128x4xf32, #packed>
+    %sub = ttng.packed_arith sub %add, %f32b : (tensor<128x4xf32, #packed>, tensor<128x4xf32, #packed>) -> tensor<128x4xf32, #packed>
+    %mul = ttng.packed_arith mul %sub, %f32b : (tensor<128x4xf32, #packed>, tensor<128x4xf32, #packed>) -> tensor<128x4xf32, #packed>
+    %fma = ttng.packed_arith fma %mul, %f32b, %f32c : (tensor<128x4xf32, #packed>, tensor<128x4xf32, #packed>, tensor<128x4xf32, #packed>) -> tensor<128x4xf32, #packed>
+    %up = ttng.packed_arith add %f16a, %fma : (tensor<128x4xf16, #packed>, tensor<128x4xf32, #packed>) -> tensor<128x4xf32, #packed>
+    %down = ttng.packed_arith sub %up, %f32c : (tensor<128x4xf32, #packed>, tensor<128x4xf32, #packed>) -> tensor<128x4xf16, #packed>
+    %min = ttng.packed_arith min %down, %f16b : (tensor<128x4xf16, #packed>, tensor<128x4xf16, #packed>) -> tensor<128x4xf16, #packed>
+    %max = ttng.packed_arith max %min, %f16b : (tensor<128x4xf16, #packed>, tensor<128x4xf16, #packed>) -> tensor<128x4xf16, #packed>
+    tt.return %max : tensor<128x4xf16, #packed>
+  }
+}
+
+// -----
+
+#packed = #ttg.blocked<{sizePerThread = [1, 4], threadsPerWarp = [32, 1], warpsPerCTA = [4, 1], order = [1, 0]}>
+#fp4 = #ttg.blocked<{sizePerThread = [1, 2], threadsPerWarp = [32, 1], warpsPerCTA = [4, 1], order = [1, 0]}>
+module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, "ttg.threads-per-warp" = 32 : i32} {
+  // CHECK-LABEL: @packed_arith_fpsan_x4
+  tt.func public @packed_arith_fpsan_x4(
+      %fp4: tensor<128x2xi8, #fp4>,
+      %e4m3: tensor<128x4xf8E4M3FN, #packed>,
+      %e5m2: tensor<128x4xf8E5M2, #packed>) -> tensor<128x4xf8E4M3FN, #packed> {
+    // CHECK: arith.andi
+    // CHECK: arith.shrui
+    // CHECK: tt.join
+    // CHECK: tt.reshape
+    // CHECK: tti.experimental_fpsan_embed
+    // CHECK: arith.addi
+    // CHECK: arith.muli
+    // CHECK: arith.addi
+    // CHECK-NOT: ttng.packed_arith
+    %add = ttng.packed_arith add %fp4, %e4m3 : (tensor<128x2xi8, #fp4>, tensor<128x4xf8E4M3FN, #packed>) -> tensor<128x4xf8E4M3FN, #packed>
+    %mul = ttng.packed_arith mul %e5m2, %fp4 : (tensor<128x4xf8E5M2, #packed>, tensor<128x2xi8, #fp4>) -> tensor<128x4xf8E4M3FN, #packed>
+    %fma = ttng.packed_arith fma %fp4, %e5m2, %add : (tensor<128x2xi8, #fp4>, tensor<128x4xf8E5M2, #packed>, tensor<128x4xf8E4M3FN, #packed>) -> tensor<128x4xf8E4M3FN, #packed>
+    %out = ttng.packed_arith add %mul, %fma : (tensor<128x4xf8E4M3FN, #packed>, tensor<128x4xf8E4M3FN, #packed>) -> tensor<128x4xf8E4M3FN, #packed>
+    tt.return %out : tensor<128x4xf8E4M3FN, #packed>
+  }
+}
+
+// -----
+
+#result = #ttg.blocked<{sizePerThread = [4, 2], threadsPerWarp = [1, 32], warpsPerCTA = [1, 4], order = [0, 1]}>
+#fp4 = #ttg.blocked<{sizePerThread = [2, 2], threadsPerWarp = [1, 32], warpsPerCTA = [1, 4], order = [0, 1]}>
+module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, "ttg.threads-per-warp" = 32 : i32} {
+  // CHECK-LABEL: @packed_arith_fpsan_fp4_axis0
+  tt.func public @packed_arith_fpsan_fp4_axis0(
+      %fp4: tensor<2x256xi8, #fp4>,
+      %f8: tensor<4x256xf8E4M3FN, #result>) -> tensor<4x256xf8E4M3FN, #result> {
+    // CHECK: tt.join
+    // CHECK: tt.trans
+    // CHECK: tt.reshape
+    // CHECK: arith.addi
+    // CHECK-NOT: ttng.packed_arith
+    %out = ttng.packed_arith add %fp4, %f8 : (tensor<2x256xi8, #fp4>, tensor<4x256xf8E4M3FN, #result>) -> tensor<4x256xf8E4M3FN, #result>
+    tt.return %out : tensor<4x256xf8E4M3FN, #result>
+  }
+}
+
+// -----
+
 #blocked = #ttg.blocked<{sizePerThread = [1, 4], threadsPerWarp = [32, 1], warpsPerCTA = [4, 1], order = [1, 0]}>
 #dot_operand_a = #ttg.dot_op<{opIdx = 0, parent = #blocked}>
 #dot_operand_b = #ttg.dot_op<{opIdx = 1, parent = #blocked}>

--- a/test/TritonNvidiaGPU/invalid.mlir
+++ b/test/TritonNvidiaGPU/invalid.mlir
@@ -501,6 +501,33 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32} {
 
 #shared = #ttg.nvmma_shared<{swizzlingByteWidth = 64, transposed = false, elementBitWidth = 8}>
 #sharedT = #ttg.nvmma_shared<{swizzlingByteWidth = 64, transposed = true, elementBitWidth = 8}>
+#tmem = #ttng.tensor_memory_encoding<blockM = 128, blockN = 128, colStride = 1>
+#tmem_scales = #ttng.tensor_memory_scales_encoding<>
+#tmem_scales_k_then_mn = #ttng.tensor_memory_scales_encoding<blockRepOrder = kThenMn>
+module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.target = "cuda:100", "ttg.threads-per-warp" = 32 : i32} {
+  tt.func @tcgen5_mma_scaled_blackwell_k_then_mn(
+      %a: !ttg.memdesc<128x64xi8, #shared, #ttg.shared_memory>,
+      %b: !ttg.memdesc<64x128xi8, #sharedT, #ttg.shared_memory>,
+      %c: !ttg.memdesc<128x128xf32, #tmem, #ttng.tensor_memory, mutable>,
+      %scale_a: !ttg.memdesc<128x8xf8E4M3FN, #tmem_scales_k_then_mn, #ttng.tensor_memory>,
+      %scale_b: !ttg.memdesc<128x8xf8E4M3FN, #tmem_scales, #ttng.tensor_memory>,
+      %useAcc: i1,
+      %pred: i1) {
+    // expected-error @below {{A scales in tensor memory must use #ttng.tensor_memory_scales_encoding<blockRepOrder = mnThenK>}}
+    ttng.tc_gen5_mma_scaled %a, %b, %c, %scale_a, %scale_b, %useAcc, %pred lhs = e2m1 rhs = e2m1 :
+      !ttg.memdesc<128x64xi8, #shared, #ttg.shared_memory>,
+      !ttg.memdesc<64x128xi8, #sharedT, #ttg.shared_memory>,
+      !ttg.memdesc<128x128xf32, #tmem, #ttng.tensor_memory, mutable>,
+      !ttg.memdesc<128x8xf8E4M3FN, #tmem_scales_k_then_mn, #ttng.tensor_memory>,
+      !ttg.memdesc<128x8xf8E4M3FN, #tmem_scales, #ttng.tensor_memory>
+    tt.return
+  }
+}
+
+// -----
+
+#shared = #ttg.nvmma_shared<{swizzlingByteWidth = 64, transposed = false, elementBitWidth = 8}>
+#sharedT = #ttg.nvmma_shared<{swizzlingByteWidth = 64, transposed = true, elementBitWidth = 8}>
 #barrier = #ttg.swizzled_shared<{vec = 1, perPhase = 1, maxPhase = 1, order = [0]}>
 #tmem = #ttng.tensor_memory_encoding<blockM = 128, blockN = 256, colStride = 1>
 #tmem_scales = #ttng.tensor_memory_scales_encoding<>

--- a/test/TritonNvidiaGPU/invalid.mlir
+++ b/test/TritonNvidiaGPU/invalid.mlir
@@ -1139,3 +1139,227 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.targ
     tt.return
   }
 }
+
+// -----
+
+#blocked = #ttg.blocked<{sizePerThread = [2], threadsPerWarp = [32], warpsPerCTA = [4], order = [0]}>
+module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.target = "cuda:107", "ttg.threads-per-warp" = 32 : i32} {
+  tt.func @packed_arith_wrong_binary_arity(
+      %a: tensor<256xf32, #blocked>,
+      %b: tensor<256xf32, #blocked>,
+      %c: tensor<256xf32, #blocked>) {
+    // expected-error @below {{'ttng.packed_arith' op add expects 2 operands but got 3}}
+    %0 = ttng.packed_arith add %a, %b, %c : (tensor<256xf32, #blocked>, tensor<256xf32, #blocked>, tensor<256xf32, #blocked>) -> tensor<256xf32, #blocked>
+    tt.return
+  }
+}
+
+// -----
+
+#blocked = #ttg.blocked<{sizePerThread = [2], threadsPerWarp = [32], warpsPerCTA = [4], order = [0]}>
+module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.target = "cuda:107", "ttg.threads-per-warp" = 32 : i32} {
+  tt.func @packed_arith_wrong_fma_arity(
+      %a: tensor<256xf32, #blocked>,
+      %b: tensor<256xf32, #blocked>) {
+    // expected-error @below {{'ttng.packed_arith' op fma expects 3 operands but got 2}}
+    %0 = ttng.packed_arith fma %a, %b : (tensor<256xf32, #blocked>, tensor<256xf32, #blocked>) -> tensor<256xf32, #blocked>
+    tt.return
+  }
+}
+
+// -----
+
+#blocked = #ttg.blocked<{sizePerThread = [1], threadsPerWarp = [32], warpsPerCTA = [4], order = [0]}>
+module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.target = "cuda:107", "ttg.threads-per-warp" = 32 : i32} {
+  tt.func @packed_arith_insufficient_unique_elements(
+      %a: tensor<128xf32, #blocked>,
+      %b: tensor<128xf32, #blocked>) {
+    // expected-error @below {{'ttng.packed_arith' op result layout must provide a multiple of 2 unique elements per thread}}
+    %0 = ttng.packed_arith add %a, %b : (tensor<128xf32, #blocked>, tensor<128xf32, #blocked>) -> tensor<128xf32, #blocked>
+    tt.return
+  }
+}
+
+// -----
+
+#blocked = #ttg.blocked<{sizePerThread = [2], threadsPerWarp = [32], warpsPerCTA = [4], order = [0]}>
+module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.target = "cuda:107", "ttg.threads-per-warp" = 32 : i32} {
+  tt.func @packed_arith_unsupported_signature(
+      %f16: tensor<256xf16, #blocked>,
+      %f32: tensor<256xf32, #blocked>) {
+    // expected-error @below {{'ttng.packed_arith' op unsupported add signature f16x2 <- (f16x2, f32x2)}}
+    %0 = ttng.packed_arith add %f16, %f32 : (tensor<256xf16, #blocked>, tensor<256xf32, #blocked>) -> tensor<256xf16, #blocked>
+    tt.return
+  }
+}
+
+// -----
+
+#blocked = #ttg.blocked<{sizePerThread = [4], threadsPerWarp = [32], warpsPerCTA = [4], order = [0]}>
+module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.target = "cuda:100", "ttg.threads-per-warp" = 32 : i32} {
+  tt.func @packed_arith_invalid_alternate_result(
+      %a: tensor<256xi8, #blocked>,
+      %b: tensor<256xi8, #blocked>) {
+    // expected-error @below {{'ttng.packed_arith' op result #0 must be ranked tensor of packed arithmetic result element values}}
+    %0 = ttng.packed_arith mul %a, %b : (tensor<256xi8, #blocked>, tensor<256xi8, #blocked>) -> tensor<256xi8, #blocked>
+    tt.return
+  }
+}
+
+// -----
+
+#blocked = #ttg.blocked<{sizePerThread = [4], threadsPerWarp = [32], warpsPerCTA = [4], order = [0]}>
+module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.target = "cuda:100", "ttg.threads-per-warp" = 32 : i32} {
+  tt.func @packed_arith_mixed_widths(
+      %a: tensor<256xf16, #blocked>,
+      %b: tensor<256xf8E4M3FN, #blocked>) {
+    // expected-error @below {{'ttng.packed_arith' op unsupported add signature f32x2 <- (f16x2, e4m3x4)}}
+    %0 = ttng.packed_arith add %a, %b : (tensor<256xf16, #blocked>, tensor<256xf8E4M3FN, #blocked>) -> tensor<256xf32, #blocked>
+    tt.return
+  }
+}
+
+// -----
+
+#blocked = #ttg.blocked<{sizePerThread = [4], threadsPerWarp = [32], warpsPerCTA = [4], order = [0]}>
+module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.target = "cuda:100", "ttg.threads-per-warp" = 32 : i32} {
+  tt.func @packed_arith_alternate_addend_must_match_result(
+      %a: tensor<256xf8E5M2, #blocked>,
+      %b: tensor<256xf8E5M2, #blocked>) {
+    // expected-error @below {{'ttng.packed_arith' op unsupported add signature e4m3x4 <- (e5m2x4, e5m2x4)}}
+    %0 = ttng.packed_arith add %a, %b : (tensor<256xf8E5M2, #blocked>, tensor<256xf8E5M2, #blocked>) -> tensor<256xf8E4M3FN, #blocked>
+    tt.return
+  }
+}
+
+// -----
+
+#blocked = #ttg.blocked<{sizePerThread = [4], threadsPerWarp = [32], warpsPerCTA = [4], order = [0]}>
+#fp4 = #ttg.blocked<{sizePerThread = [2], threadsPerWarp = [32], warpsPerCTA = [4], order = [0]}>
+module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.target = "cuda:100", "ttg.threads-per-warp" = 32 : i32} {
+  tt.func @packed_arith_alternate_fma_addend_must_match_result(
+      %a: tensor<128xi8, #fp4>,
+      %b: tensor<256xf8E4M3FN, #blocked>,
+      %c: tensor<256xf8E5M2, #blocked>) {
+    // expected-error @below {{'ttng.packed_arith' op unsupported fma signature e4m3x4 <- (e2m1x4, e4m3x4, e5m2x4)}}
+    %0 = ttng.packed_arith fma %a, %b, %c : (tensor<128xi8, #fp4>, tensor<256xf8E4M3FN, #blocked>, tensor<256xf8E5M2, #blocked>) -> tensor<256xf8E4M3FN, #blocked>
+    tt.return
+  }
+}
+
+// -----
+
+#blocked = #ttg.blocked<{sizePerThread = [2], threadsPerWarp = [32], warpsPerCTA = [4], order = [0]}>
+module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.target = "cuda:100", "ttg.threads-per-warp" = 32 : i32} {
+  tt.func @packed_arith_x4_insufficient_unique_elements(
+      %a: tensor<2xf8E4M3FN, #blocked>,
+      %b: tensor<2xf8E4M3FN, #blocked>) {
+    // expected-error @below {{'ttng.packed_arith' op result layout must provide a multiple of 4 unique elements per thread}}
+    %0 = ttng.packed_arith add %a, %b : (tensor<2xf8E4M3FN, #blocked>, tensor<2xf8E4M3FN, #blocked>) -> tensor<2xf8E4M3FN, #blocked>
+    tt.return
+  }
+}
+
+// -----
+
+#blocked = #ttg.blocked<{sizePerThread = [2], threadsPerWarp = [32], warpsPerCTA = [4], order = [0]}>
+module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.target = "cuda:100", "ttg.threads-per-warp" = 32 : i32} {
+  tt.func @packed_arith_f32x2_min_is_unsupported(
+      %a: tensor<256xf32, #blocked>,
+      %b: tensor<256xf32, #blocked>) {
+    // expected-error @below {{'ttng.packed_arith' op unsupported min signature f32x2 <- (f32x2, f32x2)}}
+    %0 = ttng.packed_arith min %a, %b : (tensor<256xf32, #blocked>, tensor<256xf32, #blocked>) -> tensor<256xf32, #blocked>
+    tt.return
+  }
+}
+
+// -----
+
+#blocked = #ttg.blocked<{sizePerThread = [4], threadsPerWarp = [32], warpsPerCTA = [4], order = [0]}>
+module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.target = "cuda:100", "ttg.threads-per-warp" = 32 : i32} {
+  tt.func @packed_arith_x4_max_is_unsupported(
+      %a: tensor<256xf8E4M3FN, #blocked>,
+      %b: tensor<256xf8E4M3FN, #blocked>) {
+    // expected-error @below {{'ttng.packed_arith' op unsupported max signature e4m3x4 <- (e4m3x4, e4m3x4)}}
+    %0 = ttng.packed_arith max %a, %b : (tensor<256xf8E4M3FN, #blocked>, tensor<256xf8E4M3FN, #blocked>) -> tensor<256xf8E4M3FN, #blocked>
+    tt.return
+  }
+}
+
+// -----
+
+#blocked = #ttg.blocked<{sizePerThread = [4], threadsPerWarp = [32], warpsPerCTA = [4], order = [0]}>
+module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.target = "cuda:100", "ttg.threads-per-warp" = 32 : i32} {
+  tt.func @packed_arith_fp4_wrong_shape(
+      %a: tensor<256xi8, #blocked>,
+      %b: tensor<256xf8E4M3FN, #blocked>) {
+    // expected-error @below {{'ttng.packed_arith' op requires every fp4 operand to have the result shape with the same single dimension halved}}
+    %0 = ttng.packed_arith add %a, %b : (tensor<256xi8, #blocked>, tensor<256xf8E4M3FN, #blocked>) -> tensor<256xf8E4M3FN, #blocked>
+    tt.return
+  }
+}
+
+// -----
+
+#result = #ttg.blocked<{sizePerThread = [4], threadsPerWarp = [32], warpsPerCTA = [4], order = [0]}>
+#fp4 = #ttg.blocked<{sizePerThread = [1], threadsPerWarp = [32], warpsPerCTA = [4], order = [0]}>
+#linear_fp4 = #ttg.linear<{register = [[1], [2]], lane = [[4], [8], [16], [32], [64]], warp = [[128], [256]], block = []}>
+#permuted = #ttg.linear<{register = [[2], [1], [4]], lane = [[8], [16], [32], [64], [128]], warp = [[256], [512]], block = []}>
+module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.target = "cuda:100", "ttg.threads-per-warp" = 32 : i32} {
+  tt.func @packed_arith_fp4_wrong_layout(
+      %a: tensor<128xi8, #fp4>,
+      %b: tensor<256xf8E4M3FN, #result>) {
+    // expected-error @below {{'ttng.packed_arith' op fp4 operand 0 must have a layout compatible with the result}}
+    %0 = ttng.packed_arith add %a, %b : (tensor<128xi8, #fp4>, tensor<256xf8E4M3FN, #result>) -> tensor<256xf8E4M3FN, #result>
+    tt.return
+  }
+
+  tt.func @packed_arith_fp4_noncanonical_register_order(
+      %a: tensor<512xi8, #linear_fp4>,
+      %b: tensor<1024xf8E4M3FN, #permuted>) {
+    // expected-error @below {{'ttng.packed_arith' op fp4 operand 0 must have a layout compatible with the result}}
+    %0 = ttng.packed_arith add %a, %b : (tensor<512xi8, #linear_fp4>, tensor<1024xf8E4M3FN, #permuted>) -> tensor<1024xf8E4M3FN, #permuted>
+    tt.return
+  }
+}
+
+// -----
+
+#blocked = #ttg.blocked<{sizePerThread = [4], threadsPerWarp = [32], warpsPerCTA = [4], order = [0]}>
+module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.target = "cuda:100", "ttg.threads-per-warp" = 32 : i32} {
+  tt.func @packed_arith_fp6_is_unsupported(
+      %a: tensor<256xf6E3M2FN, #blocked>,
+      %b: tensor<256xf8E4M3FN, #blocked>) {
+    // expected-error @below {{'ttng.packed_arith' op operand #0 must be variadic of ranked tensor of packed arithmetic operand element values}}
+    %0 = ttng.packed_arith add %a, %b : (tensor<256xf6E3M2FN, #blocked>, tensor<256xf8E4M3FN, #blocked>) -> tensor<256xf8E4M3FN, #blocked>
+    tt.return
+  }
+}
+
+// -----
+
+#blocked = #ttg.blocked<{sizePerThread = [4], threadsPerWarp = [32], warpsPerCTA = [4], order = [0]}>
+module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.target = "cuda:100", "ttg.threads-per-warp" = 32 : i32} {
+  tt.func @packed_arith_ue8m0_addend_must_match_result(
+      %a: tensor<256xf8E4M3FN, #blocked>,
+      %b: tensor<256xf8E8M0FNU, #blocked>) {
+    // expected-error @below {{'ttng.packed_arith' op unsupported add signature e4m3x4 <- (e4m3x4, ue8m0x4)}}
+    %0 = ttng.packed_arith add %a, %b : (tensor<256xf8E4M3FN, #blocked>, tensor<256xf8E8M0FNU, #blocked>) -> tensor<256xf8E4M3FN, #blocked>
+    tt.return
+  }
+}
+
+// -----
+
+#result = #ttg.blocked<{sizePerThread = [4, 2], threadsPerWarp = [1, 32], warpsPerCTA = [1, 4], order = [1, 0]}>
+#fp4_axis0 = #ttg.blocked<{sizePerThread = [2, 2], threadsPerWarp = [1, 32], warpsPerCTA = [1, 4], order = [1, 0]}>
+#fp4_axis1 = #ttg.blocked<{sizePerThread = [4, 1], threadsPerWarp = [1, 32], warpsPerCTA = [1, 4], order = [1, 0]}>
+module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.target = "cuda:100", "ttg.threads-per-warp" = 32 : i32} {
+  tt.func @packed_arith_fp4_operands_require_matching_axes(
+      %axis0: tensor<2x256xi8, #fp4_axis0>,
+      %axis1: tensor<4x128xi8, #fp4_axis1>) {
+    // expected-error @below {{'ttng.packed_arith' op requires every fp4 operand to have the result shape with the same single dimension halved}}
+    %0 = ttng.packed_arith mul %axis0, %axis1 : (tensor<2x256xi8, #fp4_axis0>, tensor<4x128xi8, #fp4_axis1>) -> tensor<4x256xf8E4M3FN, #result>
+    tt.return
+  }
+}

--- a/test/TritonNvidiaGPU/ops.mlir
+++ b/test/TritonNvidiaGPU/ops.mlir
@@ -266,3 +266,87 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 8 : i32, ttg.targ
     tt.return
   }
 }
+// Packed arithmetic keeps scalar tensor semantics in TTNGIR and only groups
+// adjacent lanes when lowering to PTX.
+#packed_blocked = #ttg.blocked<{sizePerThread = [1, 2], threadsPerWarp = [32, 1], warpsPerCTA = [4, 1], order = [1, 0]}>
+module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.target = "cuda:107", "ttg.threads-per-warp" = 32 : i32} {
+  // CHECK-LABEL: @packed_arith
+  // CHECK: ttng.packed_arith add {{.*}} : (tensor<128x2xf32
+  // CHECK: ttng.packed_arith mul {{.*}} : (tensor<128x2xf16
+  // CHECK: ttng.packed_arith fma {{.*}} : (tensor<128x2xbf16
+  // CHECK: ttng.packed_arith add {{.*}} : (tensor<128x2xf16
+  // CHECK: ttng.packed_arith sub {{.*}} : (tensor<128x2xf32
+  // CHECK: ttng.packed_arith mul {{.*}} : (tensor<128x2xf16
+  // CHECK: ttng.packed_arith fma {{.*}} : (tensor<128x2xbf16
+  // CHECK: ttng.packed_arith min {{.*}} : (tensor<128x2xf16
+  // CHECK: ttng.packed_arith max {{.*}} : (tensor<128x2xbf16
+  tt.func @packed_arith(
+      %f32a: tensor<128x2xf32, #packed_blocked>,
+      %f32b: tensor<128x2xf32, #packed_blocked>,
+      %f32c: tensor<128x2xf32, #packed_blocked>,
+      %f16a: tensor<128x2xf16, #packed_blocked>,
+      %f16b: tensor<128x2xf16, #packed_blocked>,
+      %bf16a: tensor<128x2xbf16, #packed_blocked>,
+      %bf16b: tensor<128x2xbf16, #packed_blocked>,
+      %bf16c: tensor<128x2xbf16, #packed_blocked>) {
+    %f32 = ttng.packed_arith add %f32a, %f32b : (tensor<128x2xf32, #packed_blocked>, tensor<128x2xf32, #packed_blocked>) -> tensor<128x2xf32, #packed_blocked>
+    %f16 = ttng.packed_arith mul %f16a, %f16b : (tensor<128x2xf16, #packed_blocked>, tensor<128x2xf16, #packed_blocked>) -> tensor<128x2xf16, #packed_blocked>
+    %bf16 = ttng.packed_arith fma %bf16a, %bf16b, %bf16c : (tensor<128x2xbf16, #packed_blocked>, tensor<128x2xbf16, #packed_blocked>, tensor<128x2xbf16, #packed_blocked>) -> tensor<128x2xbf16, #packed_blocked>
+    %up = ttng.packed_arith add %f16a, %f32b : (tensor<128x2xf16, #packed_blocked>, tensor<128x2xf32, #packed_blocked>) -> tensor<128x2xf32, #packed_blocked>
+    %down = ttng.packed_arith sub %f32a, %f32b : (tensor<128x2xf32, #packed_blocked>, tensor<128x2xf32, #packed_blocked>) -> tensor<128x2xbf16, #packed_blocked>
+    %cross = ttng.packed_arith mul %f16a, %bf16b : (tensor<128x2xf16, #packed_blocked>, tensor<128x2xbf16, #packed_blocked>) -> tensor<128x2xf16, #packed_blocked>
+    %mixed_fma = ttng.packed_arith fma %bf16a, %f32b, %f32c : (tensor<128x2xbf16, #packed_blocked>, tensor<128x2xf32, #packed_blocked>, tensor<128x2xf32, #packed_blocked>) -> tensor<128x2xf32, #packed_blocked>
+    %min = ttng.packed_arith min %f16a, %f16b : (tensor<128x2xf16, #packed_blocked>, tensor<128x2xf16, #packed_blocked>) -> tensor<128x2xf16, #packed_blocked>
+    %max = ttng.packed_arith max %bf16a, %bf16b : (tensor<128x2xbf16, #packed_blocked>, tensor<128x2xbf16, #packed_blocked>) -> tensor<128x2xbf16, #packed_blocked>
+    tt.return
+  }
+}
+
+// The alternate packed instructions use byte-sized FP8 elements. E2M1 is
+// stored as two logical values per i8.
+#packed_x4 = #ttg.blocked<{sizePerThread = [1, 4], threadsPerWarp = [32, 1], warpsPerCTA = [4, 1], order = [1, 0]}>
+#packed_fp4 = #ttg.blocked<{sizePerThread = [1, 2], threadsPerWarp = [32, 1], warpsPerCTA = [4, 1], order = [1, 0]}>
+module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.target = "cuda:100", "ttg.threads-per-warp" = 32 : i32} {
+  // CHECK-LABEL: @packed_arith_alternate_types
+  // CHECK: ttng.packed_arith add {{.*}} : (tensor<128x4xf8E5M2
+  // CHECK: ttng.packed_arith sub {{.*}} : (tensor<128x2xi8
+  // CHECK: ttng.packed_arith mul {{.*}} : (tensor<128x2xi8
+  // CHECK: ttng.packed_arith fma {{.*}} : (tensor<128x2xi8
+  // CHECK: ttng.packed_arith add {{.*}} : (tensor<128x4xf8E8M0FNU
+  // CHECK: ttng.packed_arith mul {{.*}} : (tensor<128x2xi8{{.*}}, tensor<128x2xi8
+  // CHECK: ttng.packed_arith fma {{.*}} : (tensor<128x4xf8E8M0FNU
+  tt.func @packed_arith_alternate_types(
+      %e5m2: tensor<128x4xf8E5M2, #packed_x4>,
+      %e4m3: tensor<128x4xf8E4M3FN, #packed_x4>,
+      %ue8m0: tensor<128x4xf8E8M0FNU, #packed_x4>,
+      %e2m1: tensor<128x2xi8, #packed_fp4>,
+      %e2m1b: tensor<128x2xi8, #packed_fp4>) {
+    %add = ttng.packed_arith add %e5m2, %e4m3 : (tensor<128x4xf8E5M2, #packed_x4>, tensor<128x4xf8E4M3FN, #packed_x4>) -> tensor<128x4xf8E4M3FN, #packed_x4>
+    %sub = ttng.packed_arith sub %e2m1, %e5m2 : (tensor<128x2xi8, #packed_fp4>, tensor<128x4xf8E5M2, #packed_x4>) -> tensor<128x4xf8E5M2, #packed_x4>
+    %mul = ttng.packed_arith mul %e2m1, %e5m2 : (tensor<128x2xi8, #packed_fp4>, tensor<128x4xf8E5M2, #packed_x4>) -> tensor<128x4xf8E4M3FN, #packed_x4>
+    %fma = ttng.packed_arith fma %e2m1, %e4m3, %e5m2 : (tensor<128x2xi8, #packed_fp4>, tensor<128x4xf8E4M3FN, #packed_x4>, tensor<128x4xf8E5M2, #packed_x4>) -> tensor<128x4xf8E5M2, #packed_x4>
+    %scale = ttng.packed_arith add %ue8m0, %e4m3 : (tensor<128x4xf8E8M0FNU, #packed_x4>, tensor<128x4xf8E4M3FN, #packed_x4>) -> tensor<128x4xf8E4M3FN, #packed_x4>
+    %two_fp4 = ttng.packed_arith mul %e2m1, %e2m1b : (tensor<128x2xi8, #packed_fp4>, tensor<128x2xi8, #packed_fp4>) -> tensor<128x4xf8E4M3FN, #packed_x4>
+    %scale_fp4 = ttng.packed_arith fma %ue8m0, %e2m1, %e4m3 : (tensor<128x4xf8E8M0FNU, #packed_x4>, tensor<128x2xi8, #packed_fp4>, tensor<128x4xf8E4M3FN, #packed_x4>) -> tensor<128x4xf8E4M3FN, #packed_x4>
+    tt.return
+  }
+}
+
+// Packed arithmetic accepts register permutations and broadcast bases as long
+// as every thread owns each logical lane in a pack.
+#packed_perm = #ttg.linear<{register = [[2], [1]], lane = [[4], [8], [16], [32], [64]], warp = [[128], [256]], block = []}>
+#packed_bcast = #ttg.linear<{register = [[0], [1]], lane = [[2], [4], [8], [16], [32]], warp = [[64], [128]], block = []}>
+module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.target = "cuda:100", "ttg.threads-per-warp" = 32 : i32} {
+  // CHECK-LABEL: @packed_arith_register_layouts
+  // CHECK: ttng.packed_arith add
+  // CHECK: ttng.packed_arith mul
+  tt.func @packed_arith_register_layouts(
+      %pa: tensor<512xf32, #packed_perm>,
+      %pb: tensor<512xf32, #packed_perm>,
+      %ba: tensor<256xf32, #packed_bcast>,
+      %bb: tensor<256xf32, #packed_bcast>) {
+    %perm = ttng.packed_arith add %pa, %pb : (tensor<512xf32, #packed_perm>, tensor<512xf32, #packed_perm>) -> tensor<512xf32, #packed_perm>
+    %bcast = ttng.packed_arith mul %ba, %bb : (tensor<256xf32, #packed_bcast>, tensor<256xf32, #packed_bcast>) -> tensor<256xf32, #packed_bcast>
+    tt.return
+  }
+}

--- a/third_party/nvidia/backend/driver.c
+++ b/third_party/nvidia/backend/driver.c
@@ -148,13 +148,21 @@ static PyObject *getDeviceProperties(PyObject *self, PyObject *args) {
   int sm_clock_rate;
   int mem_clock_rate;
   int mem_bus_width;
+  int major;
+  int minor;
+
+  CUDA_CHECK_AND_RETURN_NULL(cuDeviceGetAttribute(
+      &major, CU_DEVICE_ATTRIBUTE_COMPUTE_CAPABILITY_MAJOR, device));
+  CUDA_CHECK_AND_RETURN_NULL(cuDeviceGetAttribute(
+      &minor, CU_DEVICE_ATTRIBUTE_COMPUTE_CAPABILITY_MINOR, device));
 
   // XXX: remove attribute enum def once latest cuda.h is in use
   int CU_DEVICE_ATTRIBUTE_MAX_OVERSIZED_SHARED_MEMORY_PER_BLOCK = 150;
-  if (CUDA_SUCCESS !=
-      cuDeviceGetAttribute(
-          &max_shared_mem,
-          CU_DEVICE_ATTRIBUTE_MAX_OVERSIZED_SHARED_MEMORY_PER_BLOCK, device)) {
+  if (major == 10 && minor == 7) {
+    CUDA_CHECK_AND_RETURN_NULL(cuDeviceGetAttribute(
+        &max_shared_mem,
+        CU_DEVICE_ATTRIBUTE_MAX_OVERSIZED_SHARED_MEMORY_PER_BLOCK, device));
+  } else {
     CUDA_CHECK_AND_RETURN_NULL(cuDeviceGetAttribute(
         &max_shared_mem, CU_DEVICE_ATTRIBUTE_MAX_SHARED_MEMORY_PER_BLOCK_OPTIN,
         device));

--- a/third_party/nvidia/lib/TritonNVIDIAGPUToLLVM/ElementwiseOpToLLVM.cpp
+++ b/third_party/nvidia/lib/TritonNVIDIAGPUToLLVM/ElementwiseOpToLLVM.cpp
@@ -1,5 +1,6 @@
 #include "PatternTritonGPUOpToLLVM.h"
 #include "TargetInfo.h"
+#include "TritonNVIDIAGPUToLLVM/AtomicPTXBuilder.h"
 #include "TritonNVIDIAGPUToLLVM/PTXAsmFormat.h"
 #include "Utility.h"
 #include "mlir/Dialect/LLVMIR/LLVMDialect.h"
@@ -7,6 +8,7 @@
 #include "triton/Conversion/TritonGPUToLLVM/ElementwiseOpToLLVMBase.h"
 #include "triton/Conversion/TritonGPUToLLVM/PatternTritonGPUOpToLLVM.h"
 #include "triton/Conversion/TritonGPUToLLVM/Utility.h"
+#include "triton/Dialect/TritonNvidiaGPU/IR/Dialect.h"
 
 using namespace mlir::triton::gpu;
 
@@ -655,6 +657,70 @@ struct ExpOpConversionApprox
   }
 };
 
+struct PackedArithOpConversion
+    : ConvertOpToLLVMPattern<nvidia_gpu::PackedArithOp> {
+  using ConvertOpToLLVMPattern::ConvertOpToLLVMPattern;
+
+  LogicalResult
+  matchAndRewrite(nvidia_gpu::PackedArithOp op, OpAdaptor adaptor,
+                  ConversionPatternRewriter &rewriter) const override {
+    Location loc = op.getLoc();
+    auto tensorType = op.getResult().getType();
+    auto spec = nvidia_gpu::getPackedArithInstructionSpec(op);
+    const auto &resultInfo = *spec.result;
+    unsigned packWidth = resultInfo.lanes;
+
+    SmallVector<SmallVector<Value>> operandValues;
+    for (Value operand : adaptor.getOperands())
+      operandValues.push_back(unpackLLElements(loc, operand, rewriter));
+    unsigned packCount =
+        operandValues.front().size() / spec.operands.front()->storageLanes();
+
+    Type resultRegisterType = int_ty(resultInfo.registerBits);
+    Type resultVectorType =
+        vec_ty(getTypeConverter()->convertType(tensorType.getElementType()),
+               packWidth);
+    TritonLLVMOpBuilder b(loc, rewriter);
+    SmallVector<Value> packedResults;
+    packedResults.reserve(packCount * packWidth);
+    for (unsigned packIndex = 0; packIndex < packCount; ++packIndex) {
+      PTXBuilder ptxBuilder;
+      SmallVector<PTXBuilder::Operand *> asmOperands;
+      asmOperands.push_back(ptxBuilder.newOperand(
+          "=" +
+          NVIDIA::getPtxRegisterSizeCode(resultInfo.registerBits, false)));
+      for (auto [index, values] : llvm::enumerate(operandValues)) {
+        const auto &info = *spec.operands[index];
+        unsigned width = info.storageLanes();
+        auto lanes = ArrayRef(values).slice(packIndex * width, width);
+        Value packed = b.bitcast(packLLVector(loc, lanes, rewriter),
+                                 int_ty(info.registerBits));
+        asmOperands.push_back(ptxBuilder.newOperand(
+            packed, NVIDIA::getPtxRegisterSizeCode(info.registerBits, false)));
+      }
+
+      auto &instruction =
+          *ptxBuilder.create(stringifyPackedArithOpKind(op.getOpKind()).str());
+      instruction.o(spec.modifiers.str(), !spec.modifiers.empty())
+          .o(resultInfo.suffix.str());
+      for (const auto *info :
+           ArrayRef(spec.operands).take_front(spec.operandSuffixes))
+        instruction.o(info->suffix.str());
+      instruction(asmOperands);
+
+      Value packedResult = ptxBuilder.launch(rewriter, loc, resultRegisterType,
+                                             /*hasSideEffect=*/false);
+      Value resultVector = b.bitcast(packedResult, resultVectorType);
+      llvm::append_range(packedResults,
+                         unpackLLVector(loc, resultVector, rewriter));
+    }
+
+    rewriter.replaceOp(op, packLLElements(loc, getTypeConverter(),
+                                          packedResults, rewriter, tensorType));
+    return success();
+  }
+};
+
 struct ClampFOpConversion
     : ElementwiseOpConversionBase<ClampFOp, ClampFOpConversion> {
   using Base = ElementwiseOpConversionBase<ClampFOp, ClampFOpConversion>;
@@ -842,6 +908,7 @@ void mlir::triton::NVIDIA::populateElementwiseOpToLLVMPatterns(
                                    computeCapability, benefit);
   patterns.add<FpToFpOpConversion>(typeConverter, axisInfoAnalysis,
                                    computeCapability, benefit);
+  patterns.add<PackedArithOpConversion>(typeConverter, benefit);
 
   // ExpOpConversionApprox will try using ex2.approx if the input type is
   // FP32. For other input types, ExpOpConversionApprox will return failure and


### PR DESCRIPTION
This is a backport of an upstream PR: https://github.com/triton-lang/triton/pull/11002

Additional changes:
- Preserved the release branch's FPSan registration and relevant operation tests.
- Used the release branch's register packing helpers in the LLVM lowering.