### PR TITLE
[Release] [Cherry-Pick] [BACKEND] Improve cluster_barrier codegen within WS (#10992)

### DIFF
--- a/include/triton/Dialect/TritonNvidiaGPU/IR/TargetFeatures.h
+++ b/include/triton/Dialect/TritonNvidiaGPU/IR/TargetFeatures.h
@@ -70,6 +70,7 @@ public:
   bool supports4xFp4Tcgen05MMA() const { return computeCapability == 107; }
   bool supports2xFp8Tcgen05MMA() const { return computeCapability == 107; }
   bool supportsReuseB() const { return computeCapability == 107; }
+  bool supportsMbarMulticast() const { return computeCapability == 107; }
 
 private:
   static constexpr char kTargetPrefix[] = "cuda:";

--- a/python/test/gluon/test_lowerings.py
+++ b/python/test/gluon/test_lowerings.py
@@ -176,12 +176,14 @@ def test_convert_1d_to_2d_slice_cga(num_ctas, device):
 
 
 @pytest.mark.skipif(not is_hopper_or_newer(), reason="Requires NVIDIA Hopper or newer")
-def test_cluster_barrier_in_warp_specialize(device):
+@pytest.mark.parametrize("num_ctas", [2, 4])
+def test_cluster_barrier_in_warp_specialize(device, num_ctas):
     BLOCK = ttgl.constexpr(128)
 
     @gluon.jit
     def partition(out, offset: ttgl.constexpr):
-        layout: ttgl.constexpr = ttgl.BlockedLayout([1], [32], [4], [0], cga_layout=[[0]])
+        layout: ttgl.constexpr = ttgl.BlockedLayout([1], [32], [4], [0],
+                                                    cga_layout=_make_cga_broadcast(1, ttgl.num_ctas()))
         offs = offset + ttgl.arange(0, BLOCK, layout=layout)
         ttgl.barrier(cluster=True)
         ttgl.store(out + offs, offs)
@@ -194,10 +196,10 @@ def test_cluster_barrier_in_warp_specialize(device):
         ], [4])
 
     out = torch.empty((2 * BLOCK.value, ), device=device, dtype=torch.int32)
-    compiled = kernel[(1, )](out, num_warps=4, num_ctas=2)
+    compiled = kernel[(1, )](out, num_warps=4, num_ctas=num_ctas)
 
     ptx = compiled.asm["ptx"]
-    assert ptx.count("mbarrier.arrive.release.cluster.shared::cluster.b64") >= 2
+    assert ptx.count("mbarrier.arrive.release.cluster.shared::cluster") == 2
     assert "mapa" not in ptx
     torch.testing.assert_close(out, torch.arange(2 * BLOCK.value, device=device, dtype=torch.int32))
 

--- a/test/Conversion/tritonnvidiagpu_to_llvm.mlir
+++ b/test/Conversion/tritonnvidiagpu_to_llvm.mlir
@@ -1,6 +1,7 @@
 // RUN: triton-opt %s -split-input-file --convert-triton-gpu-to-llvm=compute-capability=90 --initialize-ws-cluster-barriers=compute-capability=90 -reconcile-unrealized-casts | FileCheck %s
 // RUN: triton-opt %s -split-input-file --convert-triton-gpu-to-llvm='compute-capability=90 ptx-version=85' --initialize-ws-cluster-barriers='compute-capability=90 ptx-version=85' -reconcile-unrealized-casts | FileCheck --check-prefix=PTX85 %s
 // RUN: triton-opt %s -split-input-file --convert-triton-gpu-to-llvm='compute-capability=90 ptx-version=86' --initialize-ws-cluster-barriers='compute-capability=90 ptx-version=86' -reconcile-unrealized-casts | FileCheck --check-prefix=PTX86 %s
+// RUN: triton-opt %s -split-input-file --convert-triton-gpu-to-llvm='compute-capability=107 ptx-version=94' --initialize-ws-cluster-barriers='compute-capability=107 ptx-version=94' -reconcile-unrealized-casts | FileCheck --check-prefix=RUBIN %s
 
 #shared0 = #ttg.swizzled_shared<{vec = 1, perPhase = 1, maxPhase = 1, order = [0]}>
 #smem = #ttg.shared_memory
@@ -811,6 +812,44 @@ module attributes {"ttg.num-ctas" = 2 : i32, "ttg.num-warps" = 4 : i32, ttg.shar
     ttg.warp_specialize()
     default {
       ttng.cluster_barrier {relaxed = true}
+      ttg.warp_yield
+    }
+    partition0() num_warps(4) {
+      ttg.warp_return
+    } : () -> ()
+    tt.return
+  }
+}
+
+// -----
+
+module attributes {"ttg.num-ctas" = 4 : i32, "ttg.num-warps" = 4 : i32, ttg.shared = 0 : i32, "ttg.threads-per-warp" = 32 : i32} {
+  // CHECK-LABEL: @cluster_barrier_inside_warp_specialize_rubin
+  // CHECK-COUNT-2: mbarrier.init.shared::cta.b64 [$1], 3;
+  // CHECK: nvvm.barrier
+  // CHECK: %[[RAW_TID:.*]] = nvvm.read.ptx.sreg.tid.x
+  // CHECK: %[[TID:.*]] = llvm.and %[[RAW_TID]], %{{.*}} : i32
+  // CHECK: %[[PEER_ID:.*]] = llvm.add %[[TID]], %{{.*}} : i32
+  // CHECK: %[[PEER_OFFSET:.*]] = llvm.shl %[[PEER_ID]], %{{.*}} : i32
+  // CHECK: %[[PEER_BARRIER:.*]] = llvm.xor %{{.*}}, %[[PEER_OFFSET]] : i32
+  // CHECK: %[[ARRIVE_PRED:.*]] = llvm.icmp "ult" %[[TID]], %{{.*}} : i32
+  // CHECK-COUNT-1: mbarrier.arrive.release.cluster.shared::cluster.b64
+  // CHECK-NOT: mbarrier.arrive
+  // CHECK: mbarrier.try_wait.parity.acquire.cluster.shared::cta.b64
+  // CHECK: nvvm.barrier
+  // RUBIN-LABEL: @cluster_barrier_inside_warp_specialize_rubin
+  // RUBIN-COUNT-2: mbarrier.init.shared::cta.b64 [$1], 3;
+  // RUBIN: %[[CTA:.*]] = nvvm.read.ptx.sreg.cluster.ctarank
+  // RUBIN: %[[ALL_CTAS:.*]] = llvm.mlir.constant(15 : i32) : i32
+  // RUBIN: %[[SELF_MASK:.*]] = llvm.shl %{{.*}}, %[[CTA]] : i32
+  // RUBIN: %[[PEER_MASK:.*]] = llvm.xor %[[ALL_CTAS]], %[[SELF_MASK]] : i32
+  // RUBIN-COUNT-1: mbarrier.arrive.release.cluster.shared::cluster.multicast::cluster::32b.b64 _, [$1], $2;
+  // RUBIN-NOT: mbarrier.arrive
+  // RUBIN: mbarrier.try_wait.parity.acquire.cluster.shared::cta.b64
+  tt.func @cluster_barrier_inside_warp_specialize_rubin() {
+    ttg.warp_specialize()
+    default {
+      ttng.cluster_barrier
       ttg.warp_yield
     }
     partition0() num_warps(4) {

--- a/third_party/nvidia/lib/TritonNVIDIAGPUToLLVM/ClusterOpsToLLVM.cpp
+++ b/third_party/nvidia/lib/TritonNVIDIAGPUToLLVM/ClusterOpsToLLVM.cpp
@@ -67,14 +67,25 @@ static void createMBarrierInit(OpBuilder &b, Location loc, Value pred,
 }
 
 static void createMBarrierArrive(OpBuilder &b, Location loc, Value pred,
-                                 Value barrierPtr, bool relaxed) {
+                                 Value barrierPtr, bool relaxed,
+                                 Value multicastMask = {}) {
   PTXBuilder ptxBuilder;
-  auto &arrive = *ptxBuilder.create(
-      "@$0 mbarrier.arrive." + std::string(relaxed ? "relaxed" : "release") +
-      ".cluster.shared::cluster.b64 _, [$1];");
-  arrive({ptxBuilder.newOperand(pred, "b"),
-          ptxBuilder.newOperand(barrierPtr, "r")},
-         /*onlyAttachMLIRArgs=*/true);
+  std::string ptx = "@$0 mbarrier.arrive." +
+                    std::string(relaxed ? "relaxed" : "release") +
+                    ".cluster.shared::cluster";
+  if (multicastMask)
+    ptx += ".multicast::cluster::32b";
+  ptx += ".b64 _, [$1]";
+  if (multicastMask)
+    ptx += ", $2";
+  ptx += ";";
+
+  SmallVector<PTXBuilder::Operand *> operands = {
+      ptxBuilder.newOperand(pred, "b"), ptxBuilder.newOperand(barrierPtr, "r")};
+  if (multicastMask)
+    operands.push_back(ptxBuilder.newOperand(multicastMask, "r"));
+  auto &arrive = *ptxBuilder.create(ptx);
+  arrive(operands, /*onlyAttachMLIRArgs=*/true);
   ptxBuilder.launch(b, loc, void_ty(b.getContext()));
 }
 
@@ -230,14 +241,23 @@ struct ClusterBarrierOpConversion
     auto barrierSlotTy = LLVM::LLVMArrayType::get(
         i8_ty, triton::nvidia_gpu::kClusterBarrierMbarSlotSize);
     Value barrierPtr = b.gep(ptrTy, barrierSlotTy, barrierPtr0, barrierIdx);
-    Value pred = b.icmp_eq(getThreadId(rewriter, loc), b.i32_val(0));
-    Value barrierInt = b.ptrtoint(i32_ty, barrierPtr);
+    Value threadId = getThreadId(rewriter, loc);
+    Value pred = b.icmp_eq(threadId, b.i32_val(0));
     int numCTAs = triton::gpu::lookupNumCTAs(op);
     bool relaxed = op.getRelaxed() && targetInfo.getPtxVersion() >= 86;
-    for (int i = 1; i < numCTAs; ++i) {
-      Value peerBarrierInt = b.xor_(barrierInt, b.i32_val(i << 24));
+    if (targetInfo.getTargetFeatures().supportsMbarMulticast()) {
+      Value ctaId = NVVM::ClusterId::create(rewriter, loc, i32_ty);
+      // Exclude the issuing CTA: the mbarriers expect numCTAs - 1 arrivals.
+      Value peerMask =
+          b.xor_(b.i32_val((1u << numCTAs) - 1), b.shl(b.i32_val(1), ctaId));
+      createMBarrierArrive(rewriter, loc, pred, barrierPtr, relaxed, peerMask);
+    } else {
+      Value barrierInt = b.ptrtoint(i32_ty, barrierPtr);
+      Value peerId = b.add(threadId, b.i32_val(1));
+      Value peerBarrierInt = b.xor_(barrierInt, b.shl(peerId, b.i32_val(24)));
       Value peerBarrierPtr = b.inttoptr(barrierPtr.getType(), peerBarrierInt);
-      createMBarrierArrive(rewriter, loc, pred, peerBarrierPtr, relaxed);
+      Value arrivePred = b.icmp_ult(threadId, b.i32_val(numCTAs - 1));
+      createMBarrierArrive(rewriter, loc, arrivePred, peerBarrierPtr, relaxed);
     }
     createMBarrierWait(rewriter, loc, barrierPtr, parity);
     Value nextCounter = b.and_(b.add(counter, b.i32_val(1)), b.i32_val(3));


### PR DESCRIPTION
This is a backport of an upstream PR: https://github.com/triton-lang/triton/pull/10992

Depends on #11137, which backports the double-buffered synthetic cluster barriers from #10669 required by the upstream implementation.