### PR TITLE
Modernize deprecated ::set-output to \

### DIFF
--- a/.github/workflows/runner-preparation.yml
+++ b/.github/workflows/runner-preparation.yml
@@ -101,11 +101,11 @@ jobs:
         if: env.enable_integration == 'true'
         run: |
           if [ x"${{ github.repository }}" == x"triton-lang/triton" ]; then
-            echo '::set-output name=matrix-NVIDIA::[{"name":"nvidia-a100","runner_type":"nvidia-a100","runs_on":["nvidia-a100"]},{"name":"nvidia-h100","runner_type":"nvidia-h100","runs_on":["nvidia-h100"]},{"name":"nvidia-gb200","runner_type":"nvidia-gb200","runs_on":{"group":"gb200-runner-set"}}]'
-            echo '::set-output name=matrix-AMD::[["self-hosted", "gfx90a"], ["amd-gfx942"], ["amd-gfx950"]]'
-            echo '::set-output name=matrix-MACOS::[["macos-latest"]]'
+            echo 'matrix-NVIDIA=[{"name":"nvidia-a100","runner_type":"nvidia-a100","runs_on":["nvidia-a100"]},{"name":"nvidia-h100","runner_type":"nvidia-h100","runs_on":["nvidia-h100"]},{"name":"nvidia-gb200","runner_type":"nvidia-gb200","runs_on":{"group":"gb200-runner-set"}}]' >> "$GITHUB_OUTPUT"
+            echo 'matrix-AMD=[["self-hosted", "gfx90a"], ["amd-gfx942"], ["amd-gfx950"]]' >> "$GITHUB_OUTPUT"
+            echo 'matrix-MACOS=[["macos-latest"]]' >> "$GITHUB_OUTPUT"
           else
-            echo '::set-output name=matrix-NVIDIA::[{"name":"ubuntu-latest","runner_type":"ubuntu-latest","runs_on":"ubuntu-latest"}]'
-            echo '::set-output name=matrix-AMD::["ubuntu-latest"]'
-            echo '::set-output name=matrix-MACOS::[["macos-latest"]]'
+            echo 'matrix-NVIDIA=[{"name":"ubuntu-latest","runner_type":"ubuntu-latest","runs_on":"ubuntu-latest"}]' >> "$GITHUB_OUTPUT"
+            echo 'matrix-AMD=["ubuntu-latest"]' >> "$GITHUB_OUTPUT"
+            echo 'matrix-MACOS=[["macos-latest"]]' >> "$GITHUB_OUTPUT"
           fi


### PR DESCRIPTION
GitHub deprecated the ::set-output workflow command in favor of writing to the $GITHUB_OUTPUT environment file. GitHub has since postponed actual removal indefinitely, so this workflow still runs fine today with only a deprecation warning — this is a forward-compatible modernization, not a repair of something currently broken.

This is a mechanically verified, byte-precise, line-for-line replacement of all 6 ::set-output call sites in this file with the equivalent $GITHUB_OUTPUT form. The transform was checked for syntax correctness, shell-context safety, runner-capability compatibility, and re-scanned afterward to confirm zero remaining deprecated call sites, then confirmed the resulting YAML still parses. No other content in the file was touched.

Happy to close this if it's not wanted or if there's a preferred way to handle the migration.