### PR TITLE
[BACKEND] Add Triton and LLVM versions to dumped IR

### DIFF
--- a/python/src/llvm.cc
+++ b/python/src/llvm.cc
@@ -2,15 +2,18 @@
 #include "mlir/Target/LLVMIR/LLVMTranslationInterface.h"
 #include "mlir/Target/LLVMIR/ModuleTranslation.h"
 #include "triton/Tools/Sys/GetEnv.h"
+#include "triton/Version.h"
 #include "llvm/ADT/SmallVector.h"
 #include "llvm/Analysis/ScopedNoAliasAA.h"
 #include "llvm/Analysis/TargetTransformInfo.h"
 #include "llvm/CodeGen/MIRParser/MIRParser.h"
 #include "llvm/CodeGen/MachineModuleInfo.h"
 #include "llvm/CodeGen/MachineRegisterInfo.h"
+#include "llvm/Config/llvm-config.h"
 #include "llvm/IR/DebugInfo.h"
 #include "llvm/IR/LLVMContext.h"
 #include "llvm/IR/LegacyPassManager.h"
+#include "llvm/IR/Metadata.h"
 #include "llvm/IR/Module.h"
 #include "llvm/IR/PassManager.h"
 #include "llvm/IR/Verifier.h"
@@ -27,6 +30,7 @@
 #include "llvm/Support/Signals.h"
 #include "llvm/Support/SourceMgr.h"
 #include "llvm/Support/TargetSelect.h"
+#include "llvm/Support/VCSRevision.h"
 #include "llvm/Target/TargetMachine.h"
 #include "llvm/Transforms/IPO/AlwaysInliner.h"
 #include "llvm/Transforms/InstCombine/InstCombine.h"
@@ -650,6 +654,22 @@ void init_triton_llvm(py::module_ &m) {
         return llvmMod;
       },
       py::keep_alive<0, 2>(), py::call_guard<py::gil_scoped_release>());
+
+  // Add Triton and LLVM versions to the module.
+  m.def("add_version_info", [](llvm::Module *mod) {
+    llvm::LLVMContext &ctx = mod->getContext();
+    // Use llvm.ident metadata so the versions appear in the asm as well.
+    auto *ident = mod->getOrInsertNamedMetadata("llvm.ident");
+    auto addIdent = [&](llvm::StringRef s) {
+      ident->addOperand(llvm::MDNode::get(ctx, {llvm::MDString::get(ctx, s)}));
+    };
+    addIdent("Triton version " TRITON_VERSION);
+#ifdef LLVM_REVISION
+    addIdent("LLVM version " LLVM_VERSION_STRING " (" LLVM_REVISION ")");
+#else
+    addIdent("LLVM version " LLVM_VERSION_STRING);
+#endif
+  });
 
   m.def("attach_datalayout", [](llvm::Module *mod, const std::string triple,
                                 const std::string proc,

--- a/python/test/unit/test_debug_dump.py
+++ b/python/test/unit/test_debug_dump.py
@@ -47,3 +47,31 @@ def test_fn_dump(capfd, device, fresh_triton_cache):
         _kernel[grid](src, N, BLOCK_SIZE)
     captured = capfd.readouterr()
     assert "IR Dump Before" not in captured.err
+
+
+def test_version_info(device, tmp_path, fresh_knobs):
+    fresh_knobs.compilation.always_compile = True
+    fresh_knobs.compilation.dump_ir = True
+    fresh_knobs.cache.dump_dir = str(tmp_path)
+
+    N = 1024
+    src = torch.zeros(N, device=device)
+
+    @triton.jit
+    def _kernel(src, N, BLOCK_SIZE: tl.constexpr):
+        offsets = tl.program_id(0) * BLOCK_SIZE + tl.arange(0, BLOCK_SIZE)
+        x = tl.load(src + offsets, mask=offsets < N) + 1
+        tl.store(src + offsets, x, mask=offsets < N)
+
+    _kernel[(triton.cdiv(N, 16), )](src, N, 16)
+
+    llir_files = list(tmp_path.rglob("*.llir"))
+    assert len(llir_files) == 1
+    llir = llir_files[0].read_text()
+
+    # !llvm.ident = !{!0, !1}
+    # !0 = !{!"Triton version <version>"}
+    # !1 = !{!"LLVM version <version> (<revision>)"}
+    assert "!llvm.ident = !{" in llir
+    assert '!{!"Triton version ' in llir
+    assert '!{!"LLVM version ' in llir

--- a/third_party/amd/backend/compiler.py
+++ b/third_party/amd/backend/compiler.py
@@ -527,6 +527,9 @@ class HIPBackend(BaseBackend):
         metadata["profile_scratch_align"] = src.get_int_attr("ttg.profile_scratch_memory_alignment") or 1
 
         amd.cleanup_bitcode_metadata(llvm_mod)
+        # Add Triton and LLVM versions to the dumped IR.
+        if knobs.compilation.dump_ir:
+            llvm.add_version_info(llvm_mod)
         # Disable inlining of print related functions,
         # because inlining of these function could slow down compilation significantly
         amd.disable_print_inline(llvm_mod)

--- a/third_party/nvidia/backend/compiler.py
+++ b/third_party/nvidia/backend/compiler.py
@@ -468,6 +468,10 @@ class CUDABackend(BaseBackend):
         metadata["global_scratch_align"] = src.get_int_attr("ttg.global_scratch_memory_alignment") or 1
         metadata["profile_scratch_size"] = src.get_int_attr("ttg.profile_scratch_memory_size") or 0
         metadata["profile_scratch_align"] = src.get_int_attr("ttg.profile_scratch_memory_alignment") or 1
+
+        # Add Triton and LLVM versions to the dumped IR.
+        if knobs.compilation.dump_ir:
+            llvm.add_version_info(llvm_mod)
         ret = str(llvm_mod)
         del llvm_mod
         del context


### PR DESCRIPTION
Dumped IR files recorded nothing about the toolchain that produced them, which made it difficult to reproduce issues after a while, especially when working with multiple LLVM versions. Add Triton and LLVM versions using `llvm.ident` so both appear in LLVM IR and asm files.