### PR TITLE
[Gluon][BC-Breaking] Fully deprecate bc aliases for async_load/store

### DIFF
--- a/python/examples/gluon/01-attention-forward.py
+++ b/python/examples/gluon/01-attention-forward.py
@@ -755,10 +755,10 @@ def _attn_fwd_epilogue(config, chnls, descs, M, STAGE: gl.constexpr):
         prog = scheduler.get_program(pid)
 
         o0_smem, o0_bar, epi_consumer = epi_consumer.acquire()
-        tma.async_copy_shared_to_global(desc_o, [prog.qo_offset_y + config.SPLIT_M * 0, 0], o0_smem)
+        tma.async_store(desc_o, [prog.qo_offset_y + config.SPLIT_M * 0, 0], o0_smem)
 
         o1_smem, o1_bar, epi_consumer = epi_consumer.acquire()
-        tma.async_copy_shared_to_global(desc_o, [prog.qo_offset_y + config.SPLIT_M * 1, 0], o1_smem)
+        tma.async_store(desc_o, [prog.qo_offset_y + config.SPLIT_M * 1, 0], o1_smem)
 
         tma.store_wait(1)
         mbarrier.arrive(o0_bar, count=1)

--- a/python/examples/gluon/03-matmul-multicta.py
+++ b/python/examples/gluon/03-matmul-multicta.py
@@ -447,7 +447,7 @@ def matmul_epilogue_partition(p):
             acc = acc_sub.load().to(dtype)
             tma.store_wait(pendings=SUBTILE_STAGES - 1)
             acc_smem.store(acc)
-            tma.async_copy_shared_to_global(p.c_desc, [off_m, off_n + SPLIT_TILE_N * s], acc_smem)
+            tma.async_store(p.c_desc, [off_m, off_n + SPLIT_TILE_N * s], acc_smem)
             sub_acc_state = sub_acc_state.next()
         # Signal that the accumulator slot can be reused only after all stores are done.
         mbarrier.arrive(p.acc_empty_bars.index(acc_state.index))

--- a/python/examples/gluon/04-2cta-block-scale-matmul.py
+++ b/python/examples/gluon/04-2cta-block-scale-matmul.py
@@ -618,7 +618,7 @@ def mma_scaled_epilogue_partition(p):
             acc = acc_sub.load().to(p.c_desc.dtype)
             tma.store_wait(pendings=subtile_stages - 1)
             acc_smem.store(acc)
-            tma.async_copy_shared_to_global(p.c_desc, [off_m, off_n + EPILOGUE_BLOCK_N * s], acc_smem)
+            tma.async_store(p.c_desc, [off_m, off_n + EPILOGUE_BLOCK_N * s], acc_smem)
             sub_acc_state = sub_acc_state.next()
         mbarrier.arrive(p.acc_empty_bars.index(acc_state.index), count=1)
         acc_state = acc_state.next()

--- a/python/examples/gluon/05-moe-bmm1-fused-gather.py
+++ b/python/examples/gluon/05-moe-bmm1-fused-gather.py
@@ -334,8 +334,8 @@ def load_weights(p: PartitionArgs):
 
             mbarrier.wait(w_empty_bar, phase, pred=issued >= p.w_num_bufs)
             mbarrier.expect(w_ready_bar, bytes_per_stage)
-            tma.async_copy_global_to_shared(p.w_desc, [slice_idx, tile_k, pid_n, 0, 0], w_ready_bar, w_buf)
-            tma.async_copy_global_to_shared(
+            tma.async_load(p.w_desc, [slice_idx, tile_k, pid_n, 0, 0], w_ready_bar, w_buf)
+            tma.async_load(
                 p.scale_desc,
                 [0, scale_idx, off_k_scale, 0, 0],
                 w_ready_bar,

--- a/python/examples/gluon/06-overlapping-accumulator.py
+++ b/python/examples/gluon/06-overlapping-accumulator.py
@@ -531,7 +531,7 @@ def mma_scaled_epilogue_partition(p):
 
             tma.store_wait(pendings=subtile_stages - 1)
             acc_smem.store(acc)
-            tma.async_copy_shared_to_global(p.c_desc, [off_m, store_n], acc_smem)
+            tma.async_store(p.c_desc, [off_m, store_n], acc_smem)
             sub_acc_state = sub_acc_state.next()
         mbarrier.arrive(p.acc_empty_bars.index(acc_state.index), count=1)
         acc_state = acc_state.next()

--- a/python/test/gluon/test_consan.py
+++ b/python/test/gluon/test_consan.py
@@ -101,10 +101,10 @@ def failing_kernel(input):
     offs_m = ttgl.arange(0, XBLOCK, layout=ttgl.SliceLayout(dim=1, parent=blocked_layout))[:, None]
     offs_n = ttgl.arange(0, XBLOCK, layout=ttgl.SliceLayout(dim=0, parent=blocked_layout))[None, :]
     offs = offs_m * XBLOCK + offs_n
-    ampere.async_copy.async_copy_global_to_shared(smem, input + offs)
+    ampere.async_copy.async_load(smem, input + offs)
     ampere.async_copy.commit_group()
 
-    ampere.async_copy.async_copy_global_to_shared(smem, input + offs)
+    ampere.async_copy.async_load(smem, input + offs)
     ampere.async_copy.commit_group()
     ampere.async_copy.wait_group(0)
 
@@ -877,7 +877,7 @@ def test_tma_interleave_kernel(FAILURE, device, run_wrapper, monkeypatch, num_ct
         mbarrier.invalidate(bar.index(1))
 
         hopper.fence_async_shared()
-        tma.async_copy_shared_to_global(input_desc, [0, 0], smem.index(0))
+        tma.async_store(input_desc, [0, 0], smem.index(0))
         tma.store_wait(0)
 
     block_m = XBLOCK.value * num_ctas
@@ -1039,14 +1039,14 @@ def test_async_copy(FAILURE, device, run_wrapper, monkeypatch, num_ctas):
         offs_m = ttgl.arange(0, block_m, layout=ttgl.SliceLayout(dim=1, parent=blocked_layout))[:, None]
         offs_n = ttgl.arange(0, XBLOCK, layout=ttgl.SliceLayout(dim=0, parent=blocked_layout))[None, :]
         offs = offs_m * XBLOCK + offs_n
-        ampere.async_copy.async_copy_global_to_shared(smem.index(0), input + offs)
+        ampere.async_copy.async_load(smem.index(0), input + offs)
         ampere.async_copy.commit_group()
 
-        ampere.async_copy.async_copy_global_to_shared(smem.index(1), input + offs)
+        ampere.async_copy.async_load(smem.index(1), input + offs)
         ampere.async_copy.commit_group()
         ampere.async_copy.wait_group(2 if FAILURE else 1)
 
-        ampere.async_copy.async_copy_global_to_shared(smem.index(0), input + offs)
+        ampere.async_copy.async_load(smem.index(0), input + offs)
         ampere.async_copy.commit_group()
         ampere.async_copy.wait_group(0)
 
@@ -1081,8 +1081,8 @@ def test_tma_store(FAILURE, device, run_wrapper, monkeypatch, num_ctas):
         blocked_layout: ttgl.constexpr = ttgl.BlockedLayout(size_per_thread=[1, XBLOCK], threads_per_warp=[32, 1],
                                                             warps_per_cta=[4, 1], order=[0, 1], cga_layout=cga_layout)
         val = ttgl.full([block_m, XBLOCK], 42, ttgl.float16, blocked_layout)
-        tma.async_copy_shared_to_global(output_desc, [0, 0], smem.index(0))
-        tma.async_copy_shared_to_global(output_desc, [0, 0], smem.index(1))
+        tma.async_store(output_desc, [0, 0], smem.index(0))
+        tma.async_store(output_desc, [0, 0], smem.index(1))
         tma.store_wait(pendings=1)
         smem.index(0).store(val)
         if not FAILURE:
@@ -1178,7 +1178,7 @@ def test_tcgen5_mma(FAILURE, MEM_ACCESS_KIND, TWO_CTAS, device, run_wrapper, mon
                 input_desc.dtype, [block_m, block_n],
                 ttgl.NVMMASharedLayout.get_default_for([block_m, block_n], input_desc.dtype,
                                                        cga_layout=acc_layout.cga_layout), res.to(input_desc.dtype))
-            tma.async_copy_shared_to_global(output_desc, [0, 0], smemAcc)
+            tma.async_store(output_desc, [0, 0], smemAcc)
             tma.store_wait(0)
         elif MEM_ACCESS_KIND == "tmem_store":
             acc.store(ttgl.full([block_m, block_n], 42, ttgl.float32, acc_blocked_layout))
@@ -1941,7 +1941,7 @@ def test_fence_async_shared_across_warp_specialize(FENCE_LOCATION, device, run_w
             ttgl.barrier(cluster=True)
         if FENCE_LOCATION == "consumer":
             hopper.fence_async_shared()
-        tma.async_copy_shared_to_global(output_desc, [0, 0], smem)
+        tma.async_store(output_desc, [0, 0], smem)
         tma.store_wait(0)
 
     @gluon.jit
@@ -2566,14 +2566,14 @@ def test_ws_async_copy_commits(FAILURE, device, run_wrapper, monkeypatch, num_ct
         acc = ttgl.zeros([block_x], ttgl.float16, blocked_layout)
 
         # Prime pipeline
-        ampere.async_copy.async_copy_global_to_shared(smem.index(BASE + 0), input + offs)
+        ampere.async_copy.async_load(smem.index(BASE + 0), input + offs)
         ampere.async_copy.commit_group()
 
         for i in range(1, 10):
             dst = (i % 2)
             src = ((i - 1) % 2)
             if i < 9:
-                ampere.async_copy.async_copy_global_to_shared(smem.index(BASE + dst), input + offs)
+                ampere.async_copy.async_load(smem.index(BASE + dst), input + offs)
                 ampere.async_copy.commit_group()
                 ampere.async_copy.wait_group(1)
             else:
@@ -2626,9 +2626,9 @@ def test_ws_async_copy_wait_visibility(FAILURE, device, run_wrapper, monkeypatch
     def ws_default(input, smem, bar, FAILURE: ttgl.constexpr, layout: ttgl.constexpr):
         block_x: ttgl.constexpr = XBLOCK * ttgl.num_ctas()
         offs = ttgl.arange(0, block_x, layout)
-        ampere.async_copy.async_copy_global_to_shared(smem.index(0), input + offs)
+        ampere.async_copy.async_load(smem.index(0), input + offs)
         ampere.async_copy.commit_group()
-        ampere.async_copy.async_copy_global_to_shared(smem.index(1), input + offs)
+        ampere.async_copy.async_load(smem.index(1), input + offs)
         ampere.async_copy.commit_group()
         ampere.async_copy.wait_group(1)
         mbarrier.arrive(bar.index(0), count=1)
@@ -3488,7 +3488,7 @@ def test_aliasing_commit_tracking(MISSING_WAIT, OVERLAP, device, run_wrapper, mo
         offs_m = ttgl.arange(0, block_m, layout=ttgl.SliceLayout(dim=1, parent=layout))[:, None]
         offs_n = ttgl.arange(0, SIZE_N, layout=ttgl.SliceLayout(dim=0, parent=layout))[None, :]
         offs = offs_m * (XBLOCK * 2) + offs_n
-        ampere.async_copy.async_copy_global_to_shared(alias0, input + offs)
+        ampere.async_copy.async_load(alias0, input + offs)
         ampere.async_copy.commit_group()
         if not MISSING_WAIT:
             ampere.async_copy.wait_group(0)
@@ -3555,7 +3555,7 @@ def async_copy_mma_write_after_read_kernel(a_ptr, BLOCK_M: ttgl.constexpr, BLOCK
     offs_m = ttgl.arange(0, BLOCK_M, layout=ttgl.SliceLayout(1, blocked_layout))[:, None]
     offs_k = ttgl.arange(0, BLOCK_K, layout=ttgl.SliceLayout(0, blocked_layout))[None, :]
     offs = offs_m * BLOCK_K + offs_k
-    ampere.async_copy.async_copy_global_to_shared(a_smem, a_ptr + offs)
+    ampere.async_copy.async_load(a_smem, a_ptr + offs)
 
 
 @pytest.mark.skipif(not is_cuda() or torch.cuda.get_device_capability()[0] < 10, reason="Requires blackwell or newer")

--- a/python/test/gluon/test_core.py
+++ b/python/test/gluon/test_core.py
@@ -208,7 +208,7 @@ def tma_kernel(desc):
     layout: ttgl.constexpr = ttgl.BlockedLayout([1, 2], [4, 8], [4, 1], [1, 0])
     value = ttgl.full(desc.block_shape, 0, desc.dtype, layout)
     alloc = ttgl.allocate_shared_memory(desc.dtype, desc.block_shape, desc.layout, value)
-    tma.async_copy_shared_to_global(desc, [0, 0], alloc)
+    tma.async_store(desc, [0, 0], alloc)
     tma.store_wait(0)
     alloc._keep_alive()
 
@@ -238,7 +238,7 @@ def tma_im2col_kernel(in_desc, out_desc):
     tma.async_load_im2col(in_desc, [0, 0, 0, 0], [0, 0], bar, smem)
     mbarrier.wait(bar, phase=0)
     mbarrier.invalidate(bar)
-    tma.async_copy_shared_to_global(out_desc, [0, 0], smem)
+    tma.async_store(out_desc, [0, 0], smem)
     tma.store_wait(pendings=0)
 
 
@@ -289,7 +289,7 @@ def tma_round_f32_to_tf32_kernel(in_desc, out_desc):
     tma.async_load(in_desc, [0, 0], bar, smem)
     mbarrier.wait(bar, phase=0, deps=[smem])
     mbarrier.invalidate(bar)
-    tma.async_copy_shared_to_global(out_desc, [0, 0], smem)
+    tma.async_store(out_desc, [0, 0], smem)
     tma.store_wait(0)
     smem._keep_alive()
 
@@ -338,7 +338,7 @@ def tma_multicast_copy_kernel(in_desc, out_desc):
     tma.async_load(in_desc, [0, 0], bar, smem, multicast=True)
     mbarrier.wait(bar, phase=0, deps=[smem])
 
-    tma.async_copy_shared_to_global(out_desc, [0, 0], smem)
+    tma.async_store(out_desc, [0, 0], smem)
     tma.store_wait(0)
 
     mbarrier.invalidate(bar)
@@ -394,7 +394,7 @@ def tma_gather_scatter_kernel(in_desc, gather_out_desc, scatter_out_desc, gather
     mbarrier.invalidate(bar)
 
     scatter_offsets = ttgl.load(scatter_idx_ptr + ttgl.arange(0, BLOCK_M, layout=x_offsets_layout))
-    tma.async_copy_shared_to_global(gather_out_desc, [0, 0], smem)
+    tma.async_store(gather_out_desc, [0, 0], smem)
     blackwell_tma.async_scatter(scatter_out_desc, scatter_offsets, 0, smem)
     tma.store_wait(0)
 
@@ -713,7 +713,7 @@ def async_copy_mbarrier_kernel(out, inp, xnumel, XBLOCK: ttgl.constexpr, YBLOCK:
     xindex = ttgl.arange(0, XBLOCK, ttgl.SliceLayout(1, block_layout))[:, None]
     yindex = ttgl.arange(0, YBLOCK, ttgl.SliceLayout(0, block_layout))[None, :]
     mask = xindex < xnumel
-    async_copy.async_copy_global_to_shared(
+    async_copy.async_load(
         smem,
         inp + xindex * YBLOCK + yindex,
         mask,
@@ -869,7 +869,7 @@ def test_device_tma_store():
             block_shape=[XBLOCK, XBLOCK],
             layout=smem_layout,
         )
-        tma.async_copy_shared_to_global(out_desc, [0, 0], alloc)
+        tma.async_store(out_desc, [0, 0], alloc)
         tma.store_wait(0)
         alloc._keep_alive()
 
@@ -2338,7 +2338,7 @@ def test_tma_slice():
         blocked: ttgl.constexpr = ttgl.BlockedLayout([1, 1], [1, 32], [1, 4], [1, 0])
         smem_slice0.store(ttgl.zeros((XBLOCK, YBLOCK), dtype=ttgl.float32, layout=blocked))
 
-        tma.async_copy_shared_to_global(out_desc, [0, 0], smem_slice1)
+        tma.async_store(out_desc, [0, 0], smem_slice1)
         tma.store_wait(0)
 
     input = torch.rand((XBLOCK, YBLOCK), dtype=torch.float32, device="cuda")
@@ -5403,7 +5403,7 @@ def mma_scaled_tcgen05_copy_kernel(a_desc, b_desc, c_desc, a_scale_desc, b_scale
     acc = acc.to(c_desc.dtype)
     acc_smem = ttgl.allocate_shared_memory(c_desc.dtype, c_desc.block_type.shape, c_desc.layout)
     acc_smem.store(acc)
-    tma.async_copy_shared_to_global(c_desc, [off_m, off_n], acc_smem)
+    tma.async_store(c_desc, [off_m, off_n], acc_smem)
     tma.store_wait(0)
 
 

--- a/python/test/gluon/test_core.py
+++ b/python/test/gluon/test_core.py
@@ -995,13 +995,13 @@ def warpgroup_mma_wait_multi_warpgroup_kernel(a_ptr, b0_ptr, b1_ptr, out_ptr, D:
     acc = ttgl.zeros([M, D], ttgl.float32, c_layout)
     inflight = hopper.warpgroup_mma_init(acc)
 
-    async_copy.async_copy_global_to_shared(a_smem, a_ptr + aoffs)
+    async_copy.async_load(a_smem, a_ptr + aoffs)
     async_copy.commit_group()
 
     for i in tl.range(0, NBLK):
-        async_copy.async_copy_global_to_shared(b0_smem, b0_ptr + i * D * D + offs)
+        async_copy.async_load(b0_smem, b0_ptr + i * D * D + offs)
         acc = hopper.warpgroup_mma_wait(num_outstanding=0, deps=(inflight, ))
-        async_copy.async_copy_global_to_shared(b1_smem, b1_ptr + i * D * D + offs)
+        async_copy.async_load(b1_smem, b1_ptr + i * D * D + offs)
         async_copy.commit_group()
         async_copy.wait_group(0)
         hopper.fence_async_shared()

--- a/python/test/gluon/test_frontend.py
+++ b/python/test/gluon/test_frontend.py
@@ -2550,8 +2550,7 @@ def async_copy_kernel(inp, xnumel, XBLOCK: ttgl.constexpr):
     mask = ttgl.max_constancy(xindex < xnumel, 2)
 
     async_copy.async_load(smem, inp + xindex)
-    async_copy.async_load(smem, inp + xindex, mask, cache_modifier=".ca", eviction_policy="evict_last",
-                                           volatile=True)
+    async_copy.async_load(smem, inp + xindex, mask, cache_modifier=".ca", eviction_policy="evict_last", volatile=True)
 
     mbar = ttgl.allocate_shared_memory(ttgl.int64, [1], mbarrier.MBarrierLayout())
     async_copy.mbarrier_arrive(mbar)

--- a/python/test/gluon/test_frontend.py
+++ b/python/test/gluon/test_frontend.py
@@ -1605,7 +1605,7 @@ def async_tma_kernel(input_desc, XBLOCK: ttgl.constexpr):
 
     mbarrier.invalidate(bar)
 
-    tma.async_copy_shared_to_global(input_desc, [0, 0], smem)
+    tma.async_store(input_desc, [0, 0], smem)
     tma.store_wait(0)
 
 
@@ -2549,8 +2549,8 @@ def async_copy_kernel(inp, xnumel, XBLOCK: ttgl.constexpr):
     xindex = ttgl.arange(0, XBLOCK, block_layout)
     mask = ttgl.max_constancy(xindex < xnumel, 2)
 
-    async_copy.async_copy_global_to_shared(smem, inp + xindex)
-    async_copy.async_copy_global_to_shared(smem, inp + xindex, mask, cache_modifier=".ca", eviction_policy="evict_last",
+    async_copy.async_load(smem, inp + xindex)
+    async_copy.async_load(smem, inp + xindex, mask, cache_modifier=".ca", eviction_policy="evict_last",
                                            volatile=True)
 
     mbar = ttgl.allocate_shared_memory(ttgl.int64, [1], mbarrier.MBarrierLayout())
@@ -4986,7 +4986,7 @@ def test_nv_tma_descriptor_store_kernel(target):
             layout=smem_layout,
         )
         smem = ttgl.allocate_shared_memory(ttgl.float32, [XBLOCK, XBLOCK], smem_layout)
-        tma.async_copy_shared_to_global(input_desc, [0, 0], smem)
+        tma.async_store(input_desc, [0, 0], smem)
         tma.store_wait(0)
         tma.store_wait(0, read_only=True)
 

--- a/python/test/gsan/test_gsan.py
+++ b/python/test/gsan/test_gsan.py
@@ -726,7 +726,7 @@ def _gluon_async_copy_masked_kernel(out_ptr, in_ptr, n_elements, start_idx, BLOC
 
     offsets = start_idx + gl.arange(0, BLOCK, block_layout)
     mask = offsets < n_elements
-    async_copy.async_copy_global_to_shared(smem, in_ptr + offsets, mask=mask)
+    async_copy.async_load(smem, in_ptr + offsets, mask=mask)
     async_copy.commit_group()
     async_copy.wait_group(0)
 

--- a/python/triton/experimental/gluon/language/nvidia/ampere/async_copy.py
+++ b/python/triton/experimental/gluon/language/nvidia/ampere/async_copy.py
@@ -39,8 +39,9 @@ def async_load(smem, pointer, mask=None, cache_modifier="", eviction_policy="", 
                                                         cache_modifier, eviction_policy, volatile)
 
 
-# Backward-compatible alias
-async_copy_global_to_shared = async_load
+@builtin
+def async_copy_global_to_shared(*args, _semantic=None, **kwargs):
+    raise RuntimeError("async_copy_global_to_shared has been removed; call async_load instead")
 
 
 @builtin

--- a/python/triton/experimental/gluon/language/nvidia/hopper/tma.py
+++ b/python/triton/experimental/gluon/language/nvidia/hopper/tma.py
@@ -286,10 +286,19 @@ def async_store(tensor_desc, coord, src, _semantic=None):
     _semantic.builder.create_async_tma_copy_local_to_global(tensor_desc.handle, coord, src.handle)
 
 
-# Backward-compatible aliases
-async_copy_global_to_shared = async_load
-async_copy_global_to_shared_im2col = async_load_im2col
-async_copy_shared_to_global = async_store
+@builtin
+def async_copy_global_to_shared(*args, _semantic=None, **kwargs):
+    raise RuntimeError("async_copy_global_to_shared has been removed; call async_load instead")
+
+
+@builtin
+def async_copy_global_to_shared_im2col(*args, _semantic=None, **kwargs):
+    raise RuntimeError("async_copy_global_to_shared_im2col has been removed; call async_load_im2col instead")
+
+
+@builtin
+def async_copy_shared_to_global(*args, _semantic=None, **kwargs):
+    raise RuntimeError("async_copy_shared_to_global has been removed; call async_store instead")
 
 
 def _async_atomic_shared_to_global(kind, tensor_desc, coord, src, fn_name: str, _semantic=None):

--- a/python/triton/tools/triton_to_gluon_translator/nvidia_helpers.py
+++ b/python/triton/tools/triton_to_gluon_translator/nvidia_helpers.py
@@ -114,7 +114,7 @@ def tl_make_tensor_descriptor(base, shape, strides, block_shape, padding_option:
 def tl_store_tensor_descriptor(desc, offsets, value):
     alloc = ttgl.allocate_shared_memory(desc.dtype, desc.block_shape, desc.layout, value)
     fence_async_shared()
-    tma.async_copy_shared_to_global(desc, offsets, alloc)
+    tma.async_store(desc, offsets, alloc)
     tma.store_wait(0, read_only=False)
     alloc._keep_alive()
 

--- a/python/tutorials/gluon/04-tma.py
+++ b/python/tutorials/gluon/04-tma.py
@@ -105,7 +105,7 @@ def memcpy_1d_tma_kernel(in_desc, out_desc, XBLOCK: gl.constexpr):
 
     # Since the TMA store reads from shared memory, we don't even need to load
     # the result into registers. We can just store the result directly.
-    tma.async_copy_shared_to_global(out_desc, [pid * XBLOCK], smem)
+    tma.async_store(out_desc, [pid * XBLOCK], smem)
 
     # Unlike TMA reads, the completion of TMA stores is tracked by commit
     # groups, just like async copies. Each async TMA store is implicitly
@@ -141,7 +141,7 @@ def tma_message_passing_kernel(message_desc, ready, output, MESSAGE_SIZE: gl.con
         # TMA to write it to HBM.
         smem.store(offsets + 1000)
         fence_async_shared()
-        tma.async_copy_shared_to_global(message_desc, [0], smem)
+        tma.async_store(message_desc, [0], smem)
 
         # Before signaling CTA 1, wait for the TMA write to become visible in HBM.
         tma.store_wait(pendings=0, read_only=False)
@@ -228,16 +228,16 @@ def test_memcpy_1d_tma(XBLOCK, xnumel):
 # tma.async_load(desc, [0, 0], bar, smem)
 # ```
 #
-# Without the fence, async_copy_global_to_shared can start copying into `smem`
+# Without the fence, async_load can start copying into `smem`
 # while the shared memory load is still in progress.
 #
 # ```python
 # smem.store(value)
 # fence_async_shared()
-# tma.async_copy_shared_to_global(desc, [0, 0], smem)
+# tma.async_store(desc, [0, 0], smem)
 # ```
 #
-# Without the fence, async_copy_shared_to_global can start copying from `smem`
+# Without the fence, async_store can start copying from `smem`
 # before the shared memory store is complete.
 #
 # Note that certain cases imply total completion of a memory transaction and
@@ -259,7 +259,7 @@ def test_memcpy_1d_tma(XBLOCK, xnumel):
 # mbarrier.arrive(bar, count=1)
 # mbarrier.wait(bar, phase=0)
 # fence_async_shared()
-# tma.async_copy_shared_to_global(desc, [0, 0], smem)
+# tma.async_store(desc, [0, 0], smem)
 # ```
 
 
@@ -290,7 +290,7 @@ def perform_add(read_index, bars, a_smem, b_smem, c_smem, c_desc, xoff, layout: 
     c_smem.store(c_val)
     fence_async_shared()
     # Issue the store without waiting for it.
-    tma.async_copy_shared_to_global(c_desc, [xoff, yoff], c_smem)
+    tma.async_store(c_desc, [xoff, yoff], c_smem)
     return read_index + 1
 
 
@@ -418,7 +418,7 @@ if __name__ == "__main__":
 #
 # Note the following restrctions for TMA operations:
 # - The innermost coordinate must be 16-byte aligned. For example, for dtype float16,
-#   an async_copy_global_to_shared with coordinates [8, 4] is illegal, but [4, 8] is legal.
+#   an async_load with coordinates [8, 4] is illegal, but [4, 8] is legal.
 # - If the shared memory layout is fp4_padded, the innermost coordinate must be 128-byte aligned.
 #
 # Main takeaways:

--- a/python/tutorials/gluon/05-wgmma.py
+++ b/python/tutorials/gluon/05-wgmma.py
@@ -197,7 +197,7 @@ def small_mma_kernel(a_desc, b_desc, c_desc, d_desc,  #
     d_smem = gl.allocate_shared_memory(d_desc.dtype, d_desc.block_type.shape, d_desc.layout)
     d_smem.store(d)
     fence_async_shared()
-    tma.async_copy_shared_to_global(d_desc, [0, 0], d_smem)
+    tma.async_store(d_desc, [0, 0], d_smem)
     tma.store_wait(pendings=0)
 
 
@@ -376,7 +376,7 @@ def blocked_matmul_kernel(a_desc, b_desc, c_desc,  #
     c_smem = gl.allocate_shared_memory(dtype, c_desc.block_type.shape, c_desc.layout)
     c_smem.store(acc.to(dtype))
     fence_async_shared()
-    tma.async_copy_shared_to_global(c_desc, [off_m, off_n], c_smem)
+    tma.async_store(c_desc, [off_m, off_n], c_smem)
     tma.store_wait(pendings=0)
 
 
@@ -575,7 +575,7 @@ def blocked_matmul_pipelined_kernel(a_desc, b_desc, c_desc, num_warps: gl.conste
     c_smem = gl.allocate_shared_memory(dtype, c_desc.block_type.shape, c_desc.layout)
     c_smem.store(acc.to(dtype))
     fence_async_shared()
-    tma.async_copy_shared_to_global(c_desc, [off_m, off_n], c_smem)
+    tma.async_store(c_desc, [off_m, off_n], c_smem)
     tma.store_wait(pendings=0)
 
 

--- a/python/tutorials/gluon/06-tcgen05.py
+++ b/python/tutorials/gluon/06-tcgen05.py
@@ -249,7 +249,7 @@ def small_mma_kernel(a_desc, b_desc, c_desc, d_desc, tmem_block: gl.constexpr,  
     acc = acc_tmem.load()
     d_smem.store(acc)
     fence_async_shared()
-    tma.async_copy_shared_to_global(d_desc, [0, 0], d_smem)
+    tma.async_store(d_desc, [0, 0], d_smem)
     tma.store_wait(pendings=0)
 
 
@@ -353,7 +353,7 @@ def blocked_matmul_kernel(a_desc, b_desc, c_desc, TRANSPOSE_B: gl.constexpr, num
     c_smem = gl.allocate_shared_memory(dtype, c_desc.block_type.shape, c_desc.layout)
     c_smem.store(acc.to(dtype))
     fence_async_shared()
-    tma.async_copy_shared_to_global(c_desc, [off_m, off_n], c_smem)
+    tma.async_store(c_desc, [off_m, off_n], c_smem)
     tma.store_wait(pendings=0)
 
 
@@ -592,7 +592,7 @@ def blocked_matmul_pipelined_kernel(a_desc, b_desc, c_desc, num_warps: gl.conste
     ub = ub_tmem.load()
     c_smem.store(ub.to(dtype))
     fence_async_shared()
-    tma.async_copy_shared_to_global(c_desc, [off_m, off_n], c_smem)
+    tma.async_store(c_desc, [off_m, off_n], c_smem)
 
     # Wait VBN, VB epilogue
     mbarrier.wait(vb_bar, epilogue_phase)
@@ -600,7 +600,7 @@ def blocked_matmul_pipelined_kernel(a_desc, b_desc, c_desc, num_warps: gl.conste
     tma.store_wait(pendings=0)
     c_smem.store(vb.to(dtype))
     fence_async_shared()
-    tma.async_copy_shared_to_global(c_desc, [off_m + BLOCK_M, off_n], c_smem)
+    tma.async_store(c_desc, [off_m + BLOCK_M, off_n], c_smem)
     tma.store_wait(pendings=0)
 
 

--- a/python/tutorials/gluon/07-persistence.py
+++ b/python/tutorials/gluon/07-persistence.py
@@ -242,7 +242,7 @@ def matmul_pipelined_kernel(a_desc, b_desc, c_desc, MMAImpl: gl.constexpr, num_b
     c, mma = mma.take_result()
     c_smem.store(c.to(dtype))
     fence_async_shared()
-    tma.async_copy_shared_to_global(c_desc, [off_m, off_n], c_smem)
+    tma.async_store(c_desc, [off_m, off_n], c_smem)
     tma.store_wait(pendings=0)
 
 
@@ -405,7 +405,7 @@ def persistent_matmul_kernel(a_desc, b_desc, c_desc, MMAImpl: gl.constexpr, Sche
         c, mma = mma.take_result()
         c_smem.store(c.to(dtype))
         fence_async_shared()
-        tma.async_copy_shared_to_global(c_desc, [off_m, off_n], c_smem)
+        tma.async_store(c_desc, [off_m, off_n], c_smem)
         tma.store_wait(pendings=0)
 
 
@@ -701,12 +701,12 @@ def persistent_matmul_pipelined_kernel(a_desc, b_desc, c_desc, c_half_desc, MMAI
             tma.store_wait(pendings=0)
             c_buf.store(c)
             fence_async_shared()
-            tma.async_copy_shared_to_global(c_desc, [epilogue_off_m, epilogue_off_n], c_buf)
+            tma.async_store(c_desc, [epilogue_off_m, epilogue_off_n], c_buf)
         elif BLOCK_M == BLOCK_K:
             c_buf = b_bufs.index(producer % (num_buffers + STEALB))
             c_buf.store(c)
             fence_async_shared()
-            tma.async_copy_shared_to_global(c_desc, [epilogue_off_m, epilogue_off_n], c_buf)
+            tma.async_store(c_desc, [epilogue_off_m, epilogue_off_n], c_buf)
         else:
             # Steal the next 2 B buffers for the epilogue.
             c0, c1 = c.reshape((BLOCK_M, 2, BLOCK_N // 2)).permute(0, 2, 1).split()
@@ -718,8 +718,8 @@ def persistent_matmul_pipelined_kernel(a_desc, b_desc, c_desc, c_half_desc, MMAI
             c0_buf.store(c0)
             c1_buf.store(c1)
             fence_async_shared()
-            tma.async_copy_shared_to_global(c_half_desc, [epilogue_off_m, epilogue_off_n], c0_buf)
-            tma.async_copy_shared_to_global(c_half_desc, [epilogue_off_m, epilogue_off_n + BLOCK_N // 2], c1_buf)
+            tma.async_store(c_half_desc, [epilogue_off_m, epilogue_off_n], c0_buf)
+            tma.async_store(c_half_desc, [epilogue_off_m, epilogue_off_n + BLOCK_N // 2], c1_buf)
     tma.store_wait(pendings=0)
 
 

--- a/python/tutorials/gluon/08-warp-specialization.py
+++ b/python/tutorials/gluon/08-warp-specialization.py
@@ -103,7 +103,7 @@ if __name__ == "__main__" and not is_hopper_or_newer():
 # mbarrier.arrive(bar, count=1)
 #
 # mbarrier.wait(bar, phase=0)  # in partition B
-# tma.async_copy_shared_to_global(desc, [0, 0], smem)
+# tma.async_store(desc, [0, 0], smem)
 # ```
 #
 # A fence is needed somewhere between the shared memory store and the TMA store.
@@ -174,7 +174,7 @@ def store_partition(descs, barriers, buffers, xoff, numel, YBLOCK: gl.constexpr)
         # Wait for the compute partition to produce c.
         mbarrier.wait(c_ready_bar, phase)
         yoff = i * YBLOCK
-        tma.async_copy_shared_to_global(c_desc, [xoff, yoff], c_buf)
+        tma.async_store(c_desc, [xoff, yoff], c_buf)
 
         tma.store_wait(outstanding_stores)
         c_empty_bar = c_empty_bars.index((i - outstanding_stores) % num_buffers)
@@ -532,7 +532,7 @@ def matmul_epilogue_partition(p, SchedulerImpl: gl.constexpr):
             if i == 0:
                 mbarrier.arrive(acc_empty_bars.index(acc_state.index), count=1)
             fence_async_shared()
-            tma.async_copy_shared_to_global(p.c_desc, [off_m, off_n + SPLIT_N * i], acc_smem)
+            tma.async_store(p.c_desc, [off_m, off_n + SPLIT_N * i], acc_smem)
     # Overlap the last store with the wait, then wait for the last store here.
     tma.store_wait(pendings=0)
 

--- a/python/tutorials/gluon/09-tma-gather-scatter.py
+++ b/python/tutorials/gluon/09-tma-gather-scatter.py
@@ -33,7 +33,7 @@ Where `src.shape` must be `(x_offsets.shape[0], BLOCK_Y)`. In other words,
 scatter writes `src` to the tensor descriptor starting at `y_offset` but to
 separately-indexed rows of size `BLOCK_Y`.
 
-Like `async_copy_global_to_shared` and `async_copy_shared_to_global`,
+Like `async_load` and `async_store`,
 `async_gather` and `async_scatter` access shared memory through the async
 proxy, so fences need to be inserted as appropriate.
 """
@@ -440,8 +440,8 @@ def test_async_scatter(BLOCK_X, BLOCK_Y, y_offset, dtype, X_MAX, Y_MAX, fresh_kn
 
 
 # %%
-# `async_gather` and `async_scatter` can be pipelined just like `async_copy_global_to_shared`
-# and `async_copy_shared_to_global`. To demonstrate this, we will write a matmul kernel
+# `async_gather` and `async_scatter` can be pipelined just like `async_load`
+# and `async_store`. To demonstrate this, we will write a matmul kernel
 # that has a fused gather and fused scatter along the M dimension:
 # `out[out_scatter_indx, :] = X[X_gather_indx, :] @ W`.
 #
@@ -468,7 +468,7 @@ def issue_loads(producer, X_desc, W_desc, X_gather_indx_ptr, off_m, off_n, k, ba
     producer += 1
     bar = bars.index(index)
 
-    # The W tensor tile is loaded using a regular `async_copy_global_to_shared`.
+    # The W tensor tile is loaded using a regular `async_load`.
     mbarrier.expect(bar, W_desc.block_type.nbytes + BLOCK_M * X_desc.block_type.nbytes)
     tma.async_gather(X_desc, offs_x_m, k, bar, x_bufs.index(index), pred)
     tma.async_load(W_desc, [k, off_n], bar, w_bufs.index(index), pred)
@@ -646,7 +646,7 @@ def test_matmul_fused_gather_scatter(M, N, K, BLOCK_M, BLOCK_N, BLOCK_K, num_buf
 # %%
 # The main takeaway from this tutorial is understanding how to use `async_gather`
 # and `async_scatter`. These instructions provide a middle-ground between
-# block DMAs like `async_copy_global_to_shared` and `async_copy_shared_to_global`
+# block DMAs like `async_load` and `async_store`
 # and regular global loads and stores (`gl.load` and `gl.store`) by allowing
 # separately-indexed columns while maintaining the performance of TMAs.
 #
@@ -655,7 +655,7 @@ def test_matmul_fused_gather_scatter(M, N, K, BLOCK_M, BLOCK_N, BLOCK_K, num_buf
 #   `gl.store` when they can be used, but this is not always the case. Plus, TMA
 #   instructions use shared memory.
 # - Sometimes using `async_gather` or `async_scatter` instead of block DMA
-#   instructions like `async_copy_global_to_shared` and `async_copy_shared_to_global`
+#   instructions like `async_load` and `async_store`
 #   is actually faster, but these situations are rare.
 #
 # In general, you should consider these instructions when writing kernels and

--- a/python/tutorials/gluon/11-tcgen05-mma-scaled.py
+++ b/python/tutorials/gluon/11-tcgen05-mma-scaled.py
@@ -235,7 +235,7 @@ def simple_mma_scaled_kernel(a_desc, b_desc, c_desc, a_scale_ptr, a_scale_stride
     acc_smem = gl.allocate_shared_memory(c_desc.dtype, c_desc.block_type.shape, c_desc.layout)
     acc_smem.store(acc)
     fence_async_shared()
-    tma.async_copy_shared_to_global(c_desc, [off_m, off_n], acc_smem)
+    tma.async_store(c_desc, [off_m, off_n], acc_smem)
     tma.store_wait(0)
 
 
@@ -531,7 +531,7 @@ def mma_scaled_contig_kernel(a_desc, b_desc, c_desc, a_scale_ptr, b_scale_ptr, V
     acc_smem = gl.allocate_shared_memory(c_desc.dtype, c_desc.block_type.shape, c_desc.layout)
     acc_smem.store(acc)
     fence_async_shared()
-    tma.async_copy_shared_to_global(c_desc, [off_m, off_n], acc_smem)
+    tma.async_store(c_desc, [off_m, off_n], acc_smem)
     tma.store_wait(0)
     # ======= End unchanged code from `simple_mma_scaled_kernel` =======
 
@@ -770,7 +770,7 @@ def mma_scaled_packed_block_kernel(a_desc, b_desc, c_desc, a_scale_desc, b_scale
     acc_smem = gl.allocate_shared_memory(c_desc.dtype, c_desc.block_type.shape, c_desc.layout)
     acc_smem.store(acc)
     fence_async_shared()
-    tma.async_copy_shared_to_global(c_desc, [off_m, off_n], acc_smem)
+    tma.async_store(c_desc, [off_m, off_n], acc_smem)
     tma.store_wait(0)
     # ======= End unchanged code from `simple_mma_scaled_kernel` =======
 
@@ -1039,7 +1039,7 @@ def mma_scaled_tcgen05_copy_kernel(a_desc, b_desc, c_desc, a_scale_desc, b_scale
     acc_smem = gl.allocate_shared_memory(c_desc.dtype, c_desc.block_type.shape, c_desc.layout)
     acc_smem.store(acc)
     fence_async_shared()
-    tma.async_copy_shared_to_global(c_desc, [off_m, off_n], acc_smem)
+    tma.async_store(c_desc, [off_m, off_n], acc_smem)
     tma.store_wait(0)
     # ======= End unchanged code from `mma_scaled_packed_block_kernel` =======
 
@@ -1318,7 +1318,7 @@ def mma_scaled_pipelined_kernel(a_desc, b_desc, c_desc, a_scale_desc, b_scale_de
         tma.store_wait(0)
         acc_smem.store(acc)
         fence_async_shared()
-        tma.async_copy_shared_to_global(c_desc, [epilogue_pid_m * BLOCK_M, epilogue_pid_n * BLOCK_N], acc_smem)
+        tma.async_store(c_desc, [epilogue_pid_m * BLOCK_M, epilogue_pid_n * BLOCK_N], acc_smem)
 
     # Wait for the last store.
     tma.store_wait(0)
@@ -1403,7 +1403,7 @@ def mma_scaled_epilogue_partition(p):
         tma.store_wait(0)
         acc_smem.store(acc.to(p.c_desc.dtype))
         fence_async_shared()
-        tma.async_copy_shared_to_global(p.c_desc, [pid_m * p.BLOCK_M, pid_n * p.BLOCK_N], acc_smem)
+        tma.async_store(p.c_desc, [pid_m * p.BLOCK_M, pid_n * p.BLOCK_N], acc_smem)
     tma.store_wait(0)
 
 

--- a/python/tutorials/gluon/12-cluster-launch-control.py
+++ b/python/tutorials/gluon/12-cluster-launch-control.py
@@ -176,7 +176,7 @@ def persistent_matmul_kernel(a_desc, b_desc, c_desc, MMAImpl: gl.constexpr, Sche
         c, mma = mma.take_result()
         c_smem.store(c.to(dtype))
         fence_async_shared()
-        tma.async_copy_shared_to_global(c_desc, [off_m, off_n], c_smem)
+        tma.async_store(c_desc, [off_m, off_n], c_smem)
         tma.store_wait(pendings=0)
         scheduler = scheduler.advance()
 

--- a/python/tutorials/gluon/13-conv-im2col.py
+++ b/python/tutorials/gluon/13-conv-im2col.py
@@ -51,8 +51,8 @@ Access Boundary:
     The input tensor in global memory is NOT padded. When accessing outside
     [0, 0] to [H-1, W-1], TMA fills with the padding value.
 
-async_copy_global_to_shared_im2col:
-    async_copy_global_to_shared_im2col(tensor_desc, coord, offsets, barrier, result)
+async_load_im2col:
+    async_load_im2col(tensor_desc, coord, offsets, barrier, result)
     - coord: [batch_idx, start_h, start_w, channel_start] start coords
     - offsets: [h_offset, w_offset] spatial offsets (i16)
 
@@ -225,7 +225,7 @@ if __name__ == "__main__" and not t7.is_hopper_or_newer():
 #         | e  f  h  i |
 #
 #       In the real kernel, this is executed in the K-loop as one
-#       async_copy_global_to_shared_im2col per (r, s, ci_block).
+#       async_load_im2col per (r, s, ci_block).
 #
 # %%
 # Shared Kernel for All Examples
@@ -257,7 +257,7 @@ def tma_im2col_kernel(in_desc, out_desc, coord_n: int, coord_h: int, coord_w: in
     mbarrier.wait(bar, phase=0)
     mbarrier.invalidate(bar)
 
-    tma.async_copy_shared_to_global(out_desc, [0, 0], smem)
+    tma.async_store(out_desc, [0, 0], smem)
     tma.store_wait(pendings=0)
 
 
@@ -896,7 +896,7 @@ if __name__ == "__main__":
 #                     acc += A_tile @ B_tile^T
 #
 #         # Store output tile via TMA
-#         tma.async_copy_shared_to_global(...)
+#         tma.async_store(...)
 # ```
 #
 # Key insight: we never materialize the full im2col matrix; address generation
@@ -951,7 +951,7 @@ def store_output_tile(mma, dtype, out_desc, offs_m, offs_n):
     c_smem = ttgl.allocate_shared_memory(dtype, out_desc.block_shape, out_desc.layout)
     c_smem.store(acc.to(dtype))
     fence_async_shared()
-    tma.async_copy_shared_to_global(out_desc, [offs_m, offs_n], c_smem)
+    tma.async_store(out_desc, [offs_m, offs_n], c_smem)
     tma.store_wait(pendings=0)
 
 

--- a/python/tutorials/gluon/14-multicta.py
+++ b/python/tutorials/gluon/14-multicta.py
@@ -395,7 +395,7 @@ def two_cta_tcgen05_kernel(a_desc, b_desc, c_desc):
 
     c_smem = gl.allocate_shared_memory(c_desc.dtype, c_desc.block_shape, c_desc.layout)
     c_smem.store(acc.load().to(c_desc.dtype))
-    tma.async_copy_shared_to_global(c_desc, [0, 0], c_smem)
+    tma.async_store(c_desc, [0, 0], c_smem)
 
 
 def run_two_cta_tcgen05(a, b, c):
@@ -514,7 +514,7 @@ def tma_multicast_copy_kernel(in_desc, out_desc):
     tma.async_load(in_desc, [0, 0], bar, smem, multicast=True)
     mbarrier.wait(bar, phase=0, deps=[smem])
 
-    tma.async_copy_shared_to_global(out_desc, [0, 0], smem)
+    tma.async_store(out_desc, [0, 0], smem)
 
 
 def run_tma_multicast_copy(inp, out):
@@ -590,7 +590,7 @@ def tma_tcgen05_kernel(a_desc, b_desc, out_desc, NUM_K_TILES: gl.constexpr, acc_
 
     out_smem = gl.allocate_shared_memory(out_desc.dtype, out_desc.block_shape, out_desc.layout)
     out_smem.store(acc_tmem.load().to(out_desc.dtype))
-    tma.async_copy_shared_to_global(out_desc, [0, 0], out_smem)
+    tma.async_store(out_desc, [0, 0], out_smem)
 
 
 def tma_tcgen05_example(a, b):
@@ -953,7 +953,7 @@ def matmul_epilogue_partition(p):
             acc = acc_sub.load().to(dtype)
             tma.store_wait(pendings=subtile_stages - 1)
             acc_smem.store(acc)
-            tma.async_copy_shared_to_global(p.c_desc, [off_m, off_n + split_tile_n * s], acc_smem)
+            tma.async_store(p.c_desc, [off_m, off_n + split_tile_n * s], acc_smem)
             sub_acc_state = sub_acc_state.next()
         mbarrier.arrive(p.acc_empty_bars.index(acc_state.index))
         acc_state = acc_state.next()

--- a/third_party/proton/tutorials/intra_kernel/example_dsl.py
+++ b/third_party/proton/tutorials/intra_kernel/example_dsl.py
@@ -262,7 +262,7 @@ def blocked_matmul_pipelined_kernel(a_desc, b_desc, c_desc, num_warps: gl.conste
 
     c_smem = gl.allocate_shared_memory(dtype, c_desc.block_type.shape, c_desc.layout)
     c_smem.store(acc.to(dtype))
-    tma.async_copy_shared_to_global(c_desc, [off_m, off_n], c_smem)
+    tma.async_store(c_desc, [off_m, off_n], c_smem)
     tma.store_wait(pendings=0)
 
     pl.exit_scope("blocked_matmul_pipelined_kernel")


### PR DESCRIPTION
Looks like some uses of the old names have sneaked back in. Lets fully deprecate so the situation doesn't get worse.