### PR TITLE
[AMD] Remove MachineSink fence workaround now that LLVM is fixed

### DIFF
--- a/test/Conversion/amd/tritongpu_to_llvm.mlir
+++ b/test/Conversion/amd/tritongpu_to_llvm.mlir
@@ -63,8 +63,6 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32} {
   // CHECK-LABEL: atomic_add_f32_scalar
   // GFX1250-LABEL: atomic_add_f32_scalar
   tt.func @atomic_add_f32_scalar(%arg0 : !tt.ptr<f32>, %arg1 : i1, %arg2 : f32) {
-    // Scalar atomics should not have the compiler fence (no tensorTy)
-    // GFX1250-NOT: llvm.inline_asm
     // CHECK: llvm.cond_br
     // GFX1250: llvm.cond_br
     // CHECK: llvm.atomicrmw
@@ -109,9 +107,6 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32} {
   // CHECK-LABEL: atomic_add_f32
   // GFX1250-LABEL: atomic_add_f32
   tt.func @atomic_add_f32(%arg0 : tensor<256x!tt.ptr<f32>, #blocked0>, %arg1 : tensor<256xi1, #blocked0>, %arg2 : tensor<256xf32, #blocked0>) {
-    // Tensor atomics on gfx1250 should have a compiler fence before the cond_br
-    // to prevent MachineSink from sinking LDS loads past barriers.
-    // GFX1250: llvm.inline_asm has_side_effects asm_dialect = att operand_attrs = [] "", "~{memory}"
     // GFX1250: llvm.cond_br
     // CHECK: llvm.cond_br
     // CHECK: llvm.atomicrmw

--- a/third_party/amd/lib/TritonAMDGPUToLLVM/LoadStoreOpToLLVM.cpp
+++ b/third_party/amd/lib/TritonAMDGPUToLLVM/LoadStoreOpToLLVM.cpp
@@ -2392,51 +2392,6 @@ struct AtomicRMWOpConversion
                   loc, rewriter, targetInfo, op.getOperation()))
             : std::nullopt;
 
-    // Emit a compiler fence to prevent LLVM's MachineSink from sinking
-    // preceding LDS loads (e.g., from ConvertLayoutOps that feed into this
-    // atomic) past barriers introduced by the atomic lowering below.
-    //
-    // Root cause: MachineSink's isSafeToMove() only sets SawStore for
-    // instructions with mayStore(), not for UnmodeledSideEffects. AMDGPU
-    // barriers have UnmodeledSideEffects but not mayStore(), so loads can
-    // be sunk past them into successor blocks.
-    //
-    // When buffer atomics are not enabled for the target (see
-    // ConvertToBufferOps.cpp), this AtomicRMWOp lowering path is used instead.
-    // emitAtomicRMW() below creates a condBr that splits the current block to
-    // mask which threads execute the atomic. Without this fence, preceding LDS
-    // loads (from ConvertLayoutOps or reduce cross-warp communication) can be
-    // sunk past barriers in the successor blocks. On targets where buffer
-    // atomics ARE enabled (e.g., gfx950), LLVM replaces the condBr with buffer
-    // atomic OOB offset masking, eliminating the block split entirely and
-    // avoiding this issue.
-    //
-    // This inline asm has mayStore()=true via the "~{memory}" constraint,
-    // which sets SawStore in MachineSink's bottom-up walk, preventing any
-    // preceding loads from being sunk past this point.
-    //
-    // This is the only fence needed: emitAtomicRMW() is the only lowering
-    // pattern that creates a condBr splitting a block with preceding LDS
-    // loads where successor blocks contain barriers. If new lowering
-    // patterns with similar structure are added, they will need their own
-    // fence.
-    //
-    // This is a workaround for
-    // https://github.com/llvm/llvm-project/issues/181708.
-    if (tensorTy && targetInfo.getISAFamily() == ISAFamily::GFX1250) {
-      auto asmDialectAttr = LLVM::AsmDialectAttr::get(rewriter.getContext(),
-                                                      LLVM::AsmDialect::AD_ATT);
-      auto asmTy = LLVM::LLVMVoidType::get(rewriter.getContext());
-      LLVM::InlineAsmOp::create(
-          rewriter, loc, asmTy,
-          /*operands=*/ValueRange{},
-          /*asm_string=*/"",
-          /*constraints=*/"~{memory}",
-          /*has_side_effects=*/true,
-          /*is_align_stack=*/false, LLVM::TailCallKind::None, asmDialectAttr,
-          /*operand_attrs=*/ArrayAttr::get(rewriter.getContext(), {}));
-    }
-
     SmallVector<Value> resultVals(elemsPerThread);
     for (size_t i = 0; i < elemsPerThread; i += vec) {
       // TODO: in case llMask is zero we can create only one branch for all

--- a/third_party/amd/python/test/test_atomic_machinesink_gfx1250.py
+++ b/third_party/amd/python/test/test_atomic_machinesink_gfx1250.py
@@ -1,25 +1,29 @@
 """
-E2E test verifying that the compiler fence prevents MachineSink from sinking
-LDS loads past barriers in tensor atomic RMW lowering on gfx1250.
+Regression test for the gfx1250 tensor atomic RMW MachineSink miscompile.
 
 Background: When buffer atomics are not enabled, AtomicRMWOp lowering creates
 a condBr (s_cbranch) to mask which threads execute the atomic. LLVM's
-MachineSink can sink preceding LDS loads (from reduce cross-warp communication)
-past barriers into the condBr's successor blocks, causing incorrect results.
+MachineSink could sink preceding LDS loads (from reduce cross-warp
+communication) past barriers into the condBr's successor blocks, producing
+incorrect results (llvm/llvm-project#181708).
 
-The compiler fence (inline asm with ~{memory}) has mayStore()=true, which sets
-SawStore in MachineSink's bottom-up walk, preventing loads from being sunk.
+This was originally worked around in Triton with an inline-asm compiler fence
+(triton-lang/triton#9624). The underlying LLVM bug is now fixed upstream
+(llvm/llvm-project#182000), so the fence has been removed and correctness is
+provided by LLVM itself.
 
-This test compiles a kernel that exercises the vulnerable pattern:
+This test guards against a regression (e.g. an LLVM downgrade) reintroducing
+the sink. It compiles a kernel that exercises the vulnerable pattern:
   2D load -> tl.sum (reduce, uses LDS) -> tl.atomic_add
 
-It checks the AMDGCN assembly to verify that the last ds_load (LDS load
-from the reduce) appears BEFORE the s_cbranch (condBr from emitAtomicRMW),
-not after it. If MachineSink sinks the load, it would appear after the branch.
+and checks the AMDGCN assembly to verify that the last ds_load (LDS load from
+the reduce) appears BEFORE the s_cbranch (condBr from emitAtomicRMW), not
+after it. If the load were sunk, it would appear after the branch.
 
 When running on a gfx1250 GPU, it also verifies correctness of the result.
 
-See https://github.com/llvm/llvm-project/issues/181708.
+See https://github.com/llvm/llvm-project/issues/181708 and its fix
+https://github.com/llvm/llvm-project/pull/182000.
 """
 
 import re
@@ -79,7 +83,9 @@ def test_ds_load_not_sunk_past_cbranch():
     """Verify that ds_load from reduce is not sunk past s_cbranch from atomic.
 
     This tests the non-buffer-atomic code path (global_atomic + condBr thread
-    masking), which is the path vulnerable to the MachineSink bug.
+    masking), which is the path vulnerable to the MachineSink bug. With the LLVM
+    fix in place, the load stays before the branch even though Triton no longer
+    emits a compiler fence.
     """
 
     # Disable buffer atomics to exercise the global_atomic + condBr path
@@ -115,7 +121,7 @@ def test_ds_load_not_sunk_past_cbranch():
     assert last_ds_load < first_cbranch_after_last_ds_load, (
         f"ds_load (line {last_ds_load}) was sunk past s_cbranch "
         f"(line {first_cbranch_after_last_ds_load}). "
-        f"The compiler fence may not be working.\n"
+        f"The LLVM MachineSink fix (llvm/llvm-project#182000) may have regressed.\n"
         f"ds_load line: {lines[last_ds_load].strip()}\n"
         f"s_cbranch line: {lines[first_cbranch_after_last_ds_load].strip()}")
 


### PR DESCRIPTION
PR #9624 added an inline-asm memory compiler fence in AtomicRMWOpConversion (gfx1250, tensor atomics) to work around llvm/llvm-project#181708, where MachineSink could sink a reduction's LDS load past the atomic-lowering barriers into the masked block, feeding stale data to the atomic. That LLVM bug is now fixed upstream (llvm/llvm-project#182000), and Triton's pinned LLVM contains the fix, so the workaround is redundant.

Remove the fence and the lit assertions that only checked its presence. Add test_tensor_atomic_rmw_no_lds_sink, a gfx1250 regression guard that FileCheck's the emitted ISA to assert the LDS load stays separated from the atomic by the barrier (ds_load -> s_barrier_wait -> atomic). Verified against the pre-fix LLVM: the test fails without the fence and passes with it, and passes on the fixed LLVM with the fence removed.