### PR TITLE
Fix getPartition overload ambiguity with clang-cl

### DIFF
--- a/lib/Dialect/TritonGPU/Transforms/WarpSpecialization/PartitionLoops.cpp
+++ b/lib/Dialect/TritonGPU/Transforms/WarpSpecialization/PartitionLoops.cpp
@@ -396,7 +396,7 @@ LogicalResult triton::gpu::partitionLoop(scf::ForOp loop) {
     return success();
 
   auto numPartitions = partitions.getNumPartitions();
-  auto defaultPartition = partitions.getPartition((int)0);
+  auto defaultPartition = partitions.getPartition(0u);
   auto loopVarCategories = classifyLoopVars(loop, defaultPartition, partitions);
   auto [loopVarIndices, newResultIndices] =
       getLoopVarIndicesToKeep(loop, defaultPartition, loopVarCategories);

--- a/lib/Dialect/TritonGPU/Transforms/WarpSpecialization/PartitionLoops.cpp
+++ b/lib/Dialect/TritonGPU/Transforms/WarpSpecialization/PartitionLoops.cpp
@@ -489,7 +489,7 @@ LogicalResult triton::gpu::partitionLoop(LoopLikeOpInterface loop) {
     return success();
 
   auto numPartitions = partitions.getNumPartitions();
-  auto defaultPartition = partitions.getPartition((int)0);
+  auto defaultPartition = partitions.getPartition(0u);
   auto loopVarCategories = classifyLoopVars(loop, defaultPartition, partitions);
   auto [loopVarIndices, newResultIndices] =
       getLoopVarIndicesToKeep(loop, defaultPartition, loopVarCategories);


### PR DESCRIPTION
## Summary

`PartitionSet` provides both `getPartition(unsigned)` and `getPartition(Operation *)`.

In clang-cl's MSVC compatibility mode, `(int)0` is also considered a possible null-pointer constant, making the call ambiguous. Using `0u` gives the intended unsigned-index overload an exact match.

The argument remains zero, so behavior is unchanged on GCC, Clang, and other platforms.

## Testing

- Reproduced the ambiguous `getPartition` diagnostic with TheRock clang-cl.
- Confirmed `PartitionLoops.cpp` compiles after the change.
- Built the `TritonGPUTransforms` target successfully.
- Ran `pre-commit run --from-ref origin/main --to-ref HEAD`.
- The existing lit test could not be run because local `triton-opt` linking was
  blocked by an unrelated prebuilt LLVM/MSVC runtime mismatch.

# New contributor declaration

- [x] I am not making a trivial change, such as fixing a typo in a comment.
- [x] I have written a PR description following these [rules](https://cbea.ms/git-commit/#why-not-how).
- [x] I have run `pre-commit run --from-ref origin/main --to-ref HEAD`.
- [x] This PR does not need a new test because it corrects overload resolution
  in an existing translation unit and was validated with a clang-cl before/after build.
- [x] I have not added any `lit` tests.
