### PR TITLE
 [NVWS][CLC] Add warp-specilaization to CLC

### DIFF
--- a/include/triton/Dialect/TritonGPU/Transforms/Partition.h
+++ b/include/triton/Dialect/TritonGPU/Transforms/Partition.h
@@ -3,16 +3,16 @@
 
 #include "mlir/Support/LLVM.h"
 #include "llvm/ADT/ArrayRef.h"
-#include "llvm/ADT/DenseMap.h"
 #include "llvm/ADT/SmallVector.h"
 
 namespace mlir {
 class Operation;
 class OpOperand;
 class OpResult;
-class Region;
+class LoopLikeOpInterface;
 namespace scf {
 class ForOp;
+class WhileOp;
 } // namespace scf
 } // namespace mlir
 
@@ -41,23 +41,25 @@ public:
   // from a different partition or a previous iteration of the current
   // partition. E.g. partition B(i) may have inputs from A(i) or B(i-1). Note
   // that the same value may be visited more than once.
-  void iterateInputs(scf::ForOp loop,
+  void iterateInputs(LoopLikeOpInterface loop,
                      function_ref<void(OpOperand &)> callback) const;
   // Iterate the outputs of the partition. Output values are those that are
   // consumed by a different partition or a future iteration of the current
   // partition. E.g. partition A(i) may have outputs to B(i) or A(i+1). Note
   // that the same value may be visited more than once.
   void
-  iterateOutputs(scf::ForOp loop,
+  iterateOutputs(LoopLikeOpInterface loop,
                  function_ref<void(Operation *, OpOperand &)> callback) const;
   // Iterate the defining ops of the inputs to the partition in the current and
   // previous iterations, including the distance in the past.
   void iterateDefs(scf::ForOp loop,
                    function_ref<void(OpResult, unsigned)> callback) const;
+  void iterateDefs(scf::WhileOp loop,
+                   function_ref<void(OpResult, unsigned)> callback) const;
   // Iterate the uses of all outputs of the partition in the current iteration
   // and in future iterations, including the distance in the future.
   void iterateUses(
-      scf::ForOp loop,
+      LoopLikeOpInterface loop,
       function_ref<void(OpResult, OpOperand &, unsigned)> callback) const;
 
 private:
@@ -93,9 +95,9 @@ public:
   // Get the number of partitions.
   unsigned getNumPartitions() const { return partitions.size(); }
 
-  // Deserialize a partition set from an `scf.for` op using the attributes
-  // tagged on operations in its body.
-  static FailureOr<PartitionSet> fromLoop(scf::ForOp loop);
+  // Deserialize a partition set from an `scf.for` or `scf.while` using the
+  // attributes tagged on operations in its regions.
+  static FailureOr<PartitionSet> fromLoop(LoopLikeOpInterface loop);
 
   // Debug dump the partition set.
   LLVM_DUMP_METHOD void dump() const;

--- a/include/triton/Dialect/TritonGPU/Transforms/PartitionSchedulingUtility.h
+++ b/include/triton/Dialect/TritonGPU/Transforms/PartitionSchedulingUtility.h
@@ -24,6 +24,7 @@ enum Flags : uint8_t {
   TMEM = 1 << 4,
   SFU = 1 << 5,
   VIEW = 1 << 6,
+  CLC = 1 << 7,
 };
 
 inline Flags &operator|=(Flags &lhs, Flags rhs) {
@@ -320,16 +321,21 @@ public:
   }
 
   bool inLoopBody() {
-    if (op)
-      return op->getParentOfType<scf::ForOp>();
+    if (op) {
+      return op->getParentOfType<scf::ForOp>() ||
+             op->getParentOfType<scf::WhileOp>();
+    }
     if (auto blockArg = dyn_cast<BlockArgument>(value)) {
       auto parentOp = blockArg.getOwner()->getParentOp();
-      return isa<scf::ForOp>(parentOp) ||
-             parentOp->getParentOfType<scf::ForOp>();
+      return isa<scf::ForOp, scf::WhileOp>(parentOp) ||
+             parentOp->getParentOfType<scf::ForOp>() ||
+             parentOp->getParentOfType<scf::WhileOp>();
     }
     auto result = cast<OpResult>(value);
     auto op = result.getOwner();
-    return isa<scf::ForOp>(op) || op->getParentOfType<scf::ForOp>();
+    return isa<scf::ForOp, scf::WhileOp>(op) ||
+           op->getParentOfType<scf::ForOp>() ||
+           op->getParentOfType<scf::WhileOp>();
   }
 
   bool containsLoopBody() {
@@ -353,6 +359,12 @@ public:
         if (blockArg.getArgNumber() == 0)
           return "ind var";
         return "iter arg " + std::to_string(blockArg.getArgNumber() - 1);
+      }
+      if (auto whileOp = dyn_cast<scf::WhileOp>(parentOp)) {
+        StringRef region = blockArg.getParentRegion() == &whileOp.getBefore()
+                               ? "before"
+                               : "after";
+        return region.str() + " arg " + std::to_string(blockArg.getArgNumber());
       }
       return "?";
     }

--- a/include/triton/Dialect/TritonGPU/Transforms/Passes.td
+++ b/include/triton/Dialect/TritonGPU/Transforms/Passes.td
@@ -121,6 +121,25 @@ def TritonGPUAutomaticWarpSpecialization : Pass<"tritongpu-automatic-warp-specia
   ];
 }
 
+def TritonGPUNormalizeWSWhileLoops : Pass<"tritongpu-normalize-ws-while-loops", "mlir::ModuleOp"> {
+  let summary = "normalize while loops used by warp specialization";
+
+  let description = [{
+    For CLC `scf.while` operations, promotes `tt.warp_specialize` from one or
+    more direct sibling `scf.for` operations to the enclosing loop. Then
+    normalizes every `scf.while` nested in a warp-specialized loop to use
+    matching state and result signatures.
+  }];
+
+  let dependentDialects = [
+    "mlir::triton::TritonDialect",
+    "mlir::triton::gpu::TritonGPUDialect",
+    "mlir::triton::nvidia_gpu::TritonNvidiaGPUDialect",
+    "mlir::scf::SCFDialect",
+    "mlir::arith::ArithDialect"
+  ];
+}
+
 def TritonGPUPartitionLoops : Pass<"tritongpu-partition-loops", "mlir::ModuleOp"> {
   let summary = "split scheduled loops into `ttg.warp_specialize`";
 

--- a/include/triton/Dialect/TritonGPU/Transforms/PipeliningUtility.h
+++ b/include/triton/Dialect/TritonGPU/Transforms/PipeliningUtility.h
@@ -80,9 +80,9 @@ Operation *wrapInMaskOp(RewriterBase &rewriter, Operation *op, Value pred);
 // lowering to predicated operations
 void resolveMaskOp(ModuleOp moduleOp);
 
-// Return true if the given ForOp has the attribute
+// Return true if the given loop has the attribute
 // `tt.disallow_acc_multi_buffer` set to true.
-bool getDisallowAccMultiBuffer(scf::ForOp forOp);
+bool getDisallowAccMultiBuffer(LoopLikeOpInterface loop);
 
 // Return the definition of the given value. If the value is a loop-carried
 // dependency, return the definition and the distance to it.

--- a/include/triton/Dialect/TritonGPU/Transforms/WarpSpecialization.h
+++ b/include/triton/Dialect/TritonGPU/Transforms/WarpSpecialization.h
@@ -4,6 +4,7 @@
 #include "mlir/Support/LogicalResult.h"
 
 namespace mlir {
+class LoopLikeOpInterface;
 namespace scf {
 class ForOp;
 } // namespace scf
@@ -17,7 +18,7 @@ LogicalResult rewritePartitionDependencies(scf::ForOp &loop);
 // rewritten to be reference semantic, partitiong the loop into a
 // `ttg.warp_specialize` by duplicating the loop for each partition and
 // rematerializing, as necessary, operations in the root partition.
-LogicalResult partitionLoop(scf::ForOp loop);
+LogicalResult partitionLoop(LoopLikeOpInterface loop);
 } // namespace triton::gpu
 } // namespace mlir
 

--- a/lib/Dialect/TritonGPU/Transforms/CMakeLists.txt
+++ b/lib/Dialect/TritonGPU/Transforms/CMakeLists.txt
@@ -31,6 +31,7 @@ add_triton_library(TritonGPUTransforms
   CoalesceUtils.cpp
   LayoutPropagationUtility.cpp
   WarpSpecialization/AutomaticWarpSpecialization.cpp
+  WarpSpecialization/NormalizeWSWhileLoops.cpp
   WarpSpecialization/Partition.cpp
   WarpSpecialization/OptimizePartitionWarps.cpp
   WarpSpecialization/PartitionBuilder.cpp

--- a/lib/Dialect/TritonGPU/Transforms/Pipeliner/PipeliningUtility.cpp
+++ b/lib/Dialect/TritonGPU/Transforms/Pipeliner/PipeliningUtility.cpp
@@ -249,10 +249,10 @@ void mlir::triton::resolveMaskOp(ModuleOp moduleOp) {
   }
 }
 
-// Return true if the given ForOp has the attribute
+// Return true if the given loop has the attribute
 // `tt.disallow_acc_multi_buffer` set to true.
-bool mlir::triton::getDisallowAccMultiBuffer(scf::ForOp forOp) {
-  return forOp->hasAttr(mlir::triton::kDisallowAccMultiBufferAttrName);
+bool mlir::triton::getDisallowAccMultiBuffer(LoopLikeOpInterface loop) {
+  return loop->hasAttr(mlir::triton::kDisallowAccMultiBufferAttrName);
 }
 
 std::pair<OpResult, int64_t>

--- a/lib/Dialect/TritonGPU/Transforms/WarpSpecialization/AutomaticWarpSpecialization.cpp
+++ b/lib/Dialect/TritonGPU/Transforms/WarpSpecialization/AutomaticWarpSpecialization.cpp
@@ -30,7 +30,7 @@ struct VerifyWarpSpecializationPartitions
       VerifyWarpSpecializationPartitions)
 
   void runOnOperation() override {
-    WalkResult result = getOperation().walk([&](scf::ForOp loop) {
+    WalkResult result = getOperation().walk([&](LoopLikeOpInterface loop) {
       if (!loop->hasAttr(kPartitionStagesAttrName))
         return WalkResult::advance();
       if (failed(verifyPartitionedLoop(loop))) {
@@ -53,12 +53,12 @@ struct AutomaticWarpSpecialization
 };
 
 void multiBufferTMADescriptors(ModuleOp mod, int numStages) {
-  SetVector<scf::ForOp> descUpdateLoops;
-  mod.walk([&](scf::ForOp loop) {
+  SetVector<LoopLikeOpInterface> descUpdateLoops;
+  mod.walk([&](LoopLikeOpInterface loop) {
     if (loop->hasAttr(kWarpSpecializeAttrName)) {
       loop.walk([&](triton::MakeTensorDescOp op) {
-        if (auto forOp = op->getParentOfType<scf::ForOp>()) {
-          descUpdateLoops.insert(forOp);
+        if (auto loopOp = op->getParentOfType<LoopLikeOpInterface>()) {
+          descUpdateLoops.insert(loopOp);
         }
       });
     }
@@ -99,6 +99,7 @@ void AutomaticWarpSpecialization::runOnOperation() {
     pm.addPass(createVerifyWarpSpecializationPartitionsPass());
   };
 
+  pm.addPass(createTritonGPUNormalizeWSWhileLoops());
   addPassWithPartitionVerifier(createTritonGPUPartitionScheduling());
   addPassWithPartitionVerifier(createNVWSHoistTmemStore());
   addPassWithPartitionVerifier(createNVWSInsertAref());

--- a/lib/Dialect/TritonGPU/Transforms/WarpSpecialization/NormalizeWSWhileLoops.cpp
+++ b/lib/Dialect/TritonGPU/Transforms/WarpSpecialization/NormalizeWSWhileLoops.cpp
@@ -1,4 +1,5 @@
 #include "mlir/Dialect/SCF/IR/SCF.h"
+#include "mlir/IR/IRMapping.h"
 #include "triton/Dialect/TritonGPU/Transforms/Passes.h"
 #include "triton/Dialect/TritonGPU/Transforms/PipeliningUtility.h"
 #include "triton/Dialect/TritonNvidiaGPU/IR/Dialect.h"
@@ -10,52 +11,111 @@ namespace mlir::triton::gpu {
 
 namespace {
 
-// Restore the one-to-one state/result signature expected by WS after
-// canonicalization removes unused scf.while results.
-//   canonicalized: %pid = scf.while (%pid, %active) -> i32
-//                    scf.condition(%active) %pid
-//   normalized:    %result:2 = scf.while (%pid, %active) -> (i32, i1)
-//                    scf.condition(%active) %pid, %active
+// Normalize `scf.while` to the form expected by WS, where the values forwarded
+// by `scf.condition` are the loop's before-region block arguments. Rotate the
+// loop by evaluating the original before region once before the loop and again
+// after each execution of the original body.
+//   canonicalized:
+//     %result = scf.while (%state = %initial) -> i32 {
+//       %value = compute_result(%state)
+//       %cond = compute_cond(%state)
+//       scf.condition(%cond) %value
+//     } do {
+//     ^bb0(%value: i32):
+//       %next_state = body(%value)
+//       scf.yield %next_state
+//     }
+//
+//   normalized:
+//     %initial_value = compute_result(%initial)
+//     %initial_cond = compute_cond(%initial)
+//     %result:2 = scf.while (%value = %initial_value,
+//                            %cond = %initial_cond) -> (i32, i1) {
+//       scf.condition(%cond) %value, %cond
+//     } do {
+//     ^bb0(%value: i32, %cond: i1):
+//       %next_state = body(%value)
+//       %next_value = compute_result(%next_state)
+//       %next_cond = compute_cond(%next_state)
+//       scf.yield %next_value, %next_cond
+//     }
+SmallVector<Value> cloneBlockBody(OpBuilder &builder, Block &block,
+                                  ValueRange arguments) {
+  assert(block.getNumArguments() == arguments.size());
+  IRMapping mapping;
+  mapping.map(block.getArguments(), arguments);
+  for (Operation &op : block.without_terminator())
+    builder.clone(op, mapping);
+
+  SmallVector<Value> terminatorOperands;
+  for (Value operand : block.getTerminator()->getOperands())
+    terminatorOperands.push_back(mapping.lookupOrDefault(operand));
+  return terminatorOperands;
+}
+
 scf::WhileOp normalizeWhile(scf::WhileOp loop) {
   auto beforeArgs = loop.getBeforeArguments();
   auto condition = loop.getConditionOp();
   if (llvm::equal(condition.getArgs(), beforeArgs))
     return loop;
 
-  SmallVector<unsigned> resultToState;
-  for (Value value : condition.getArgs())
-    resultToState.push_back(cast<BlockArgument>(value).getArgNumber());
+  auto &oldBefore = loop.getBefore().front();
+  auto &oldAfter = loop.getAfter().front();
+  auto oldYield = loop.getYieldOp();
+  auto oldYieldLoc = oldYield.getLoc();
+  SmallVector<NamedAttribute> oldYieldAttrs(oldYield->getAttrs());
+  OpBuilder builder(loop);
+
+  // Evaluate the old before region once to seed the normalized loop. The
+  // condition is carried as the last state value.
+  auto initial = cloneBlockBody(builder, oldBefore, loop.getInits());
+  auto initialCondition = initial.front();
+  SmallVector<Value> inits(initial.begin() + 1, initial.end());
+  inits.push_back(initialCondition);
 
   SmallVector<Type> stateTypes;
-  for (BlockArgument arg : beforeArgs)
-    stateTypes.push_back(arg.getType());
-  SmallVector<Location> argLocs(stateTypes.size(), loop.getLoc());
-  OpBuilder builder(loop);
+  SmallVector<Location> argLocs;
+  for (Value init : inits) {
+    stateTypes.push_back(init.getType());
+    argLocs.push_back(init.getLoc());
+  }
   auto newLoop =
-      scf::WhileOp::create(builder, loop.getLoc(), stateTypes, loop.getInits());
+      scf::WhileOp::create(builder, loop.getLoc(), stateTypes, inits);
   newLoop->setAttrs(loop->getAttrs());
-  Block *newBefore =
+  auto newBefore =
       builder.createBlock(&newLoop.getBefore(), {}, stateTypes, argLocs);
-  Block *newAfter =
+  auto newAfter =
       builder.createBlock(&newLoop.getAfter(), {}, stateTypes, argLocs);
 
-  Block &oldBefore = loop.getBefore().front();
-  Block &oldAfter = loop.getAfter().front();
-  newBefore->getOperations().splice(newBefore->end(),
-                                    oldBefore.getOperations());
+  // The normalized before region only forwards its block arguments.
+  builder.setInsertionPointToEnd(newBefore);
+  auto newCondition = scf::ConditionOp::create(builder, condition.getLoc(),
+                                               newBefore->getArguments().back(),
+                                               newBefore->getArguments());
+  newCondition->setAttrs(condition->getAttrs());
+
+  // Execute the old body, then evaluate the old before region to produce the
+  // state and condition for the next iteration.
+  for (auto [oldArg, newArg] : llvm::zip(
+           oldAfter.getArguments(), newAfter->getArguments().drop_back())) {
+    oldArg.replaceAllUsesWith(newArg);
+  }
+  SmallVector<Value> nextBeforeArgs(oldYield.getOperands());
+  oldYield.erase();
   newAfter->getOperations().splice(newAfter->end(), oldAfter.getOperations());
 
-  for (auto [oldArg, newArg] :
-       llvm::zip(oldBefore.getArguments(), newBefore->getArguments()))
-    oldArg.replaceAllUsesWith(newArg);
-  for (auto [resultIndex, stateIndex] : llvm::enumerate(resultToState))
-    oldAfter.getArgument(resultIndex)
-        .replaceAllUsesWith(newAfter->getArgument(stateIndex));
+  builder.setInsertionPointToEnd(newAfter);
+  auto next = cloneBlockBody(builder, oldBefore, nextBeforeArgs);
+  auto nextCondition = next.front();
+  SmallVector<Value> nextState(next.begin() + 1, next.end());
+  nextState.push_back(nextCondition);
+  auto newYield = scf::YieldOp::create(builder, oldYieldLoc, nextState);
+  newYield->setAttrs(oldYieldAttrs);
 
-  condition.getArgsMutable().assign(newBefore->getArguments());
-  for (auto [resultIndex, stateIndex] : llvm::enumerate(resultToState))
-    loop.getResult(resultIndex)
-        .replaceAllUsesWith(newLoop.getResult(stateIndex));
+  for (auto [oldResult, newResult] :
+       llvm::zip(loop.getResults(), newLoop.getResults())) {
+    oldResult.replaceAllUsesWith(newResult);
+  }
 
   loop.erase();
   return newLoop;
@@ -106,7 +166,9 @@ public:
         whiles.insert(whileOp);
       op->walk([&](scf::WhileOp whileOp) { whiles.insert(whileOp); });
     });
-    for (scf::WhileOp whileOp : whiles)
+    // Normalize inner loops first so cloning a before region only duplicates
+    // already-normalized nested loops.
+    for (scf::WhileOp whileOp : llvm::reverse(whiles))
       normalizeWhile(whileOp);
   }
 };

--- a/lib/Dialect/TritonGPU/Transforms/WarpSpecialization/NormalizeWSWhileLoops.cpp
+++ b/lib/Dialect/TritonGPU/Transforms/WarpSpecialization/NormalizeWSWhileLoops.cpp
@@ -1,0 +1,115 @@
+#include "mlir/Dialect/SCF/IR/SCF.h"
+#include "triton/Dialect/TritonGPU/Transforms/Passes.h"
+#include "triton/Dialect/TritonGPU/Transforms/PipeliningUtility.h"
+#include "triton/Dialect/TritonNvidiaGPU/IR/Dialect.h"
+
+namespace mlir::triton::gpu {
+
+#define GEN_PASS_DEF_TRITONGPUNORMALIZEWSWHILELOOPS
+#include "triton/Dialect/TritonGPU/Transforms/Passes.h.inc"
+
+namespace {
+
+// Restore the one-to-one state/result signature expected by WS after
+// canonicalization removes unused scf.while results.
+//   canonicalized: %pid = scf.while (%pid, %active) -> i32
+//                    scf.condition(%active) %pid
+//   normalized:    %result:2 = scf.while (%pid, %active) -> (i32, i1)
+//                    scf.condition(%active) %pid, %active
+scf::WhileOp normalizeWhile(scf::WhileOp loop) {
+  auto beforeArgs = loop.getBeforeArguments();
+  auto condition = loop.getConditionOp();
+  if (llvm::equal(condition.getArgs(), beforeArgs))
+    return loop;
+
+  SmallVector<unsigned> resultToState;
+  for (Value value : condition.getArgs())
+    resultToState.push_back(cast<BlockArgument>(value).getArgNumber());
+
+  SmallVector<Type> stateTypes;
+  for (BlockArgument arg : beforeArgs)
+    stateTypes.push_back(arg.getType());
+  SmallVector<Location> argLocs(stateTypes.size(), loop.getLoc());
+  OpBuilder builder(loop);
+  auto newLoop =
+      scf::WhileOp::create(builder, loop.getLoc(), stateTypes, loop.getInits());
+  newLoop->setAttrs(loop->getAttrs());
+  Block *newBefore =
+      builder.createBlock(&newLoop.getBefore(), {}, stateTypes, argLocs);
+  Block *newAfter =
+      builder.createBlock(&newLoop.getAfter(), {}, stateTypes, argLocs);
+
+  Block &oldBefore = loop.getBefore().front();
+  Block &oldAfter = loop.getAfter().front();
+  newBefore->getOperations().splice(newBefore->end(),
+                                    oldBefore.getOperations());
+  newAfter->getOperations().splice(newAfter->end(), oldAfter.getOperations());
+
+  for (auto [oldArg, newArg] :
+       llvm::zip(oldBefore.getArguments(), newBefore->getArguments()))
+    oldArg.replaceAllUsesWith(newArg);
+  for (auto [resultIndex, stateIndex] : llvm::enumerate(resultToState))
+    oldAfter.getArgument(resultIndex)
+        .replaceAllUsesWith(newAfter->getArgument(stateIndex));
+
+  condition.getArgsMutable().assign(newBefore->getArguments());
+  for (auto [resultIndex, stateIndex] : llvm::enumerate(resultToState))
+    loop.getResult(resultIndex)
+        .replaceAllUsesWith(newLoop.getResult(stateIndex));
+
+  loop.erase();
+  return newLoop;
+}
+
+class NormalizeWSWhileLoopsPass
+    : public impl::TritonGPUNormalizeWSWhileLoopsBase<
+          NormalizeWSWhileLoopsPass> {
+public:
+  void runOnOperation() override {
+    getOperation().walk([&](scf::WhileOp whileOp) {
+      bool isCLCWhile =
+          llvm::any_of(whileOp.getAfter().front(), [](Operation &op) {
+            return isa<nvidia_gpu::CLCTryCancelSyncOp>(op);
+          });
+      if (!isCLCWhile)
+        return;
+
+      bool warpSpecialize = false;
+      bool disallowAccMultiBuffer = false;
+      for (Operation &op : whileOp.getAfter().front()) {
+        auto forOp = dyn_cast<scf::ForOp>(op);
+        if (!forOp || !forOp->hasAttr(kWarpSpecializeAttrName))
+          continue;
+        warpSpecialize = true;
+        disallowAccMultiBuffer |=
+            forOp->hasAttr(kDisallowAccMultiBufferAttrName);
+        forOp->removeAttr(kWarpSpecializeAttrName);
+        forOp->removeAttr(kDisallowAccMultiBufferAttrName);
+      }
+      if (!warpSpecialize)
+        return;
+
+      whileOp->setAttr(kWarpSpecializeAttrName,
+                       UnitAttr::get(whileOp.getContext()));
+      if (disallowAccMultiBuffer) {
+        whileOp->setAttr(kDisallowAccMultiBufferAttrName,
+                         UnitAttr::get(whileOp.getContext()));
+      }
+    });
+
+    SetVector<scf::WhileOp> whiles;
+    getOperation().walk([&](Operation *op) {
+      if (!isa<scf::ForOp, scf::WhileOp>(op) ||
+          !op->hasAttr(kWarpSpecializeAttrName))
+        return;
+      if (auto whileOp = dyn_cast<scf::WhileOp>(op))
+        whiles.insert(whileOp);
+      op->walk([&](scf::WhileOp whileOp) { whiles.insert(whileOp); });
+    });
+    for (scf::WhileOp whileOp : whiles)
+      normalizeWhile(whileOp);
+  }
+};
+
+} // namespace
+} // namespace mlir::triton::gpu

--- a/lib/Dialect/TritonGPU/Transforms/WarpSpecialization/Partition.cpp
+++ b/lib/Dialect/TritonGPU/Transforms/WarpSpecialization/Partition.cpp
@@ -3,12 +3,12 @@
 #include "mlir/Dialect/SCF/IR/SCF.h"
 #include "mlir/Dialect/UB/IR/UBOps.h"
 #include "mlir/IR/BuiltinAttributes.h"
+#include "mlir/Interfaces/ControlFlowInterfaces.h"
+#include "mlir/Interfaces/LoopLikeInterface.h"
 #include "triton/Dialect/Triton/IR/Dialect.h"
 #include "triton/Dialect/TritonGPU/Transforms/PipeliningUtility.h"
 #include "triton/Dialect/TritonGPU/Transforms/Utility.h"
-#include "llvm/ADT/SCCIterator.h"
 #include "llvm/ADT/STLExtras.h"
-#include "llvm/IR/Use.h"
 
 using namespace mlir;
 using namespace triton;
@@ -46,10 +46,10 @@ LogicalResult verifyPartitionIdsAttr(Operation *op, StringRef attrName,
 
 LogicalResult verifyPartitionAttrs(Operation *op) {
   if (op->hasAttr(kWarpSpecializeAttrName)) {
-    if (!isa<scf::ForOp>(op)) {
+    if (!isa<scf::ForOp, scf::WhileOp>(op)) {
       return op->emitOpError("has unexpected attribute ")
              << kWarpSpecializeAttrName
-             << " which is expected only on `scf.for` ops";
+             << " which is expected only on `scf.for` or `scf.while` ops";
     }
 
     Operation *failedOp = nullptr;
@@ -118,7 +118,7 @@ LogicalResult verifyPartitionAttrs(Operation *op) {
   }
 
   if (auto outputsAttr = op->getAttr(kPartitionOutputsAttrName)) {
-    if (!isa<scf::ForOp, scf::IfOp, triton::ReduceOp>(op))
+    if (!isa<scf::ForOp, scf::WhileOp, scf::IfOp, triton::ReduceOp>(op))
       return op->emitOpError("has unexpected attribute ")
              << kPartitionOutputsAttrName;
 
@@ -168,8 +168,12 @@ bool Partition::hasOp(Operation *op) const {
   return partitionIds.contains(getIndex());
 }
 
-void Partition::iterateInputs(scf::ForOp loop,
+void Partition::iterateInputs(LoopLikeOpInterface loop,
                               function_ref<void(OpOperand &)> callback) const {
+  Value inductionVar;
+  if (auto forOp = dyn_cast<scf::ForOp>(loop.getOperation()))
+    inductionVar = forOp.getInductionVar();
+
   for (Operation *op : getOps()) {
     visitNestedOperands(op, [&](OpOperand &operand) {
       // Ignore implicit captures.
@@ -177,21 +181,16 @@ void Partition::iterateInputs(scf::ForOp loop,
       std::optional<SetVector<int>> partitionIds;
       if (hasPartition(value.getDefiningOp()))
         partitionIds = getPartitionIds(value.getDefiningOp());
-      if (value.getParentBlock() != loop.getBody())
+      if (value.getParentRegion()->getParentOp() != loop)
         return;
-      if (auto arg = dyn_cast<BlockArgument>(value)) {
-        assert(arg.getOwner() == loop.getBody());
-        // Ignore the induction variable.
-        if (arg == loop.getInductionVar())
-          return;
-        // This value originates from a previous iteration.
-        assert(llvm::is_contained(loop.getRegionIterArgs(), arg));
-        callback(operand);
-      } else if (!partitionIds ||
-                 !llvm::is_contained(*partitionIds, getIndex())) {
+      // Ignore the induction variable.
+      if (value == inductionVar)
+        return;
+      if ((isa<BlockArgument>(value) || !partitionIds ||
+           !partitionIds->contains(getIndex()))) {
         // This value originates from a different partition in the same
         // iteration.
-        assert(value.getDefiningOp()->getParentOp() == loop);
+        assert(value.getParentRegion()->getParentOp() == loop);
         callback(operand);
       }
     });
@@ -199,22 +198,22 @@ void Partition::iterateInputs(scf::ForOp loop,
 }
 
 void Partition::iterateOutputs(
-    scf::ForOp loop,
+    LoopLikeOpInterface loop,
     function_ref<void(Operation *, OpOperand &)> callback) const {
   for (Operation *op : getOps()) {
     for (OpOperand &use : op->getUses()) {
-      Operation *owner = loop.getBody()->findAncestorOpInBlock(*use.getOwner());
+      Operation *owner = nullptr;
+      for (Region *region : loop.getLoopRegions())
+        if ((owner = region->front().findAncestorOpInBlock(*use.getOwner())))
+          break;
       if (!owner) {
         continue;
       }
       std::optional<SetVector<int>> partitionIds;
       if (hasPartition(owner))
         partitionIds = getPartitionIds(owner);
-      if (isa<scf::YieldOp>(owner)) {
-        // This value is used in a subsequent iteration.
-        callback(owner, use);
-      } else if (!partitionIds ||
-                 !llvm::is_contained(*partitionIds, getIndex())) {
+      if (isa<scf::YieldOp, scf::ConditionOp>(owner) || !partitionIds ||
+          !partitionIds->contains(getIndex())) {
         // This value is used in a different partition in the same iteration.
         callback(owner, use);
       }
@@ -231,26 +230,52 @@ void Partition::iterateDefs(
   });
 }
 
+void Partition::iterateDefs(
+    scf::WhileOp loop, function_ref<void(OpResult, unsigned)> callback) const {
+  iterateInputs(loop, [&](OpOperand &input) {
+    auto value = input.get();
+    int distance = 0;
+    while (auto arg = dyn_cast<BlockArgument>(value)) {
+      value = loop.getYieldOp().getOperand(arg.getArgNumber());
+      ++distance;
+    }
+    auto def = dyn_cast<OpResult>(value);
+    if (def && loop->isProperAncestor(def.getDefiningOp()))
+      callback(def, distance);
+  });
+}
+
 void Partition::iterateUses(
-    scf::ForOp loop,
+    LoopLikeOpInterface loop,
     function_ref<void(OpResult, OpOperand &, unsigned)> callback) const {
   SmallVector<std::tuple<OpResult, OpOperand *, unsigned>> uses;
-  iterateOutputs(loop, [&](Operation *owner, OpOperand &use) {
+  iterateOutputs(loop, [&](Operation *, OpOperand &use) {
     uses.emplace_back(cast<OpResult>(use.get()), &use, 0);
   });
   while (!uses.empty()) {
     auto [output, use, distance] = uses.pop_back_val();
-    Operation *owner = loop.getBody()->findAncestorOpInBlock(*use->getOwner());
+    Operation *owner = nullptr;
+    for (Region *region : loop.getLoopRegions())
+      if ((owner = region->front().findAncestorOpInBlock(*use->getOwner())))
+        break;
     if (!owner) {
       continue;
     }
-    if (!isa<scf::YieldOp>(owner)) {
-      callback(output, *use, distance);
+    if (auto yield = dyn_cast<scf::YieldOp>(owner)) {
+      auto arg = loop.getRegionIterArgs()[use->getOperandNumber()];
+      for (OpOperand &argUse : arg.getUses())
+        uses.emplace_back(output, &argUse, distance + 1);
       continue;
     }
-    BlockArgument arg = loop.getRegionIterArg(use->getOperandNumber());
-    for (OpOperand &use : arg.getUses())
-      uses.emplace_back(output, &use, distance + 1);
+    if (auto condition = dyn_cast<scf::ConditionOp>(owner);
+        condition && use->getOperandNumber() > 0) {
+      auto body = &loop.getLoopRegions().back()->front();
+      auto arg = body->getArgument(use->getOperandNumber() - 1);
+      for (OpOperand &argUse : arg.getUses())
+        uses.emplace_back(output, &argUse, distance);
+      continue;
+    }
+    callback(output, *use, distance);
   }
 }
 
@@ -277,7 +302,7 @@ Partition *PartitionSet::getPartition(Operation *op) {
   return getPartition(id[0]);
 }
 
-FailureOr<PartitionSet> PartitionSet::fromLoop(scf::ForOp loop) {
+FailureOr<PartitionSet> PartitionSet::fromLoop(LoopLikeOpInterface loop) {
   if (failed(verifyPartitionedLoop(loop)))
     return failure();
 
@@ -294,7 +319,7 @@ FailureOr<PartitionSet> PartitionSet::fromLoop(scf::ForOp loop) {
   for (auto [idx, attr] : llvm::enumerate(stages)) {
     auto stage = dyn_cast<IntegerAttr>(attr);
     if (!stage || stage.getInt() < 0) {
-      return mlir::emitError(loop.getLoc(), "partition stages attribute '")
+      return mlir::emitError(loop->getLoc(), "partition stages attribute '")
              << kPartitionStagesAttrName << "' has invalid element " << attr;
     }
 
@@ -361,13 +386,17 @@ SmallVector<SetVector<int>, 4> getPartitionOutputs(Operation *op) {
 }
 
 SetVector<int> getPartitionIds(OpOperand *use) {
-  auto owner = use->getOwner();
-  if (isa<scf::YieldOp>(owner)) {
-    return getPartitionOutputs(owner->getParentOp())[use->getOperandNumber()];
+  Operation *owner = use->getOwner();
+  auto pos = use->getOperandNumber();
+  if (isa<scf::YieldOp, scf::ConditionOp>(owner)) {
+    auto idx = pos - isa<scf::ConditionOp>(owner);
+    return idx >= 0 ? getPartitionOutputs(owner->getParentOp())[idx]
+                    : getPartitionIds(owner);
   }
-  if (auto forOp = dyn_cast<scf::ForOp>(owner)) {
-    int idx = use->getOperandNumber() - forOp.getNumControlOperands();
-    return idx >= 0 ? getPartitionOutputs(owner)[idx] : getPartitionIds(forOp);
+  if (auto loop = dyn_cast<LoopLikeOpInterface>(owner)) {
+    auto numControlOperands = owner->getNumOperands() - loop.getInits().size();
+    auto idx = pos - numControlOperands;
+    return idx >= 0 ? getPartitionOutputs(owner)[idx] : getPartitionIds(owner);
   }
   return getPartitionIds(owner);
 }
@@ -386,7 +415,7 @@ std::optional<int> getWarpSpecializeTag(Operation *op) {
   return std::nullopt;
 }
 
-LogicalResult verifyPartitionedLoop(scf::ForOp loop) {
+LogicalResult verifyPartitionedLoop(LoopLikeOpInterface loop) {
   if (failed(verifyPartitionAttrs(loop)))
     return failure();
 

--- a/lib/Dialect/TritonGPU/Transforms/WarpSpecialization/Partition.cpp
+++ b/lib/Dialect/TritonGPU/Transforms/WarpSpecialization/Partition.cpp
@@ -389,14 +389,16 @@ SetVector<int> getPartitionIds(OpOperand *use) {
   Operation *owner = use->getOwner();
   auto pos = use->getOperandNumber();
   if (isa<scf::YieldOp, scf::ConditionOp>(owner)) {
-    auto idx = pos - isa<scf::ConditionOp>(owner);
-    return idx >= 0 ? getPartitionOutputs(owner->getParentOp())[idx]
-                    : getPartitionIds(owner);
+    unsigned numControlOperands = isa<scf::ConditionOp>(owner) ? 1 : 0;
+    if (pos < numControlOperands)
+      return getPartitionIds(owner);
+    return getPartitionOutputs(owner->getParentOp())[pos - numControlOperands];
   }
   if (auto loop = dyn_cast<LoopLikeOpInterface>(owner)) {
     auto numControlOperands = owner->getNumOperands() - loop.getInits().size();
-    auto idx = pos - numControlOperands;
-    return idx >= 0 ? getPartitionOutputs(owner)[idx] : getPartitionIds(owner);
+    if (pos < numControlOperands)
+      return getPartitionIds(owner);
+    return getPartitionOutputs(owner)[pos - numControlOperands];
   }
   return getPartitionIds(owner);
 }

--- a/lib/Dialect/TritonGPU/Transforms/WarpSpecialization/PartitionAttrs.h
+++ b/lib/Dialect/TritonGPU/Transforms/WarpSpecialization/PartitionAttrs.h
@@ -8,6 +8,7 @@
 namespace mlir {
 class Operation;
 class OpOperand;
+class LoopLikeOpInterface;
 namespace scf {
 class ForOp;
 } // namespace scf
@@ -27,7 +28,7 @@ bool hasPartition(Operation *op);
 bool hasWarpSpecializeTag(Operation *op);
 std::optional<int> getWarpSpecializeTag(Operation *op);
 
-LogicalResult verifyPartitionedLoop(scf::ForOp loop);
+LogicalResult verifyPartitionedLoop(LoopLikeOpInterface loop);
 
 } // namespace mlir::triton::gpu
 

--- a/lib/Dialect/TritonGPU/Transforms/WarpSpecialization/PartitionLoops.cpp
+++ b/lib/Dialect/TritonGPU/Transforms/WarpSpecialization/PartitionLoops.cpp
@@ -66,7 +66,7 @@ SetVector<int> getIfOpResultPartitionIds(scf::IfOp ifOp, Value value) {
   llvm_unreachable("value is not a result of if-stmt");
 }
 
-bool isTensorResultComputedBy(scf::ForOp loop, size_t resultIdx,
+bool isTensorResultComputedBy(LoopLikeOpInterface loop, size_t resultIdx,
                               const Partition *partition,
                               const PartitionSet &partitions) {
   auto value = loop.getYieldedValues()[resultIdx];
@@ -80,7 +80,7 @@ bool isTensorResultComputedBy(scf::ForOp loop, size_t resultIdx,
   return llvm::is_contained(partitionIds, partition->getIndex());
 }
 
-SmallVector<LoopVarCategory> classifyLoopVars(scf::ForOp loop,
+SmallVector<LoopVarCategory> classifyLoopVars(LoopLikeOpInterface loop,
                                               const Partition *partition,
                                               const PartitionSet &partitions) {
   auto isTensorResultFromOtherPartition = [&](int i) {
@@ -95,13 +95,13 @@ SmallVector<LoopVarCategory> classifyLoopVars(scf::ForOp loop,
     return false;
   };
 
-  SmallVector<LoopVarCategory> categories(loop.getNumRegionIterArgs());
+  SmallVector<LoopVarCategory> categories(loop.getRegionIterArgs().size());
   for (auto [i, arg] : llvm::enumerate(loop.getRegionIterArgs())) {
     auto partitionIds = getResultPartitionIds(loop, i);
     if (llvm::is_contained(partitionIds, partition->getIndex())) {
       categories[i] = LoopVarCategory::Used;
     } else if (isTensorResultFromOtherPartition(i) &&
-               !loop.getResult(i).use_empty()) {
+               !loop->getResult(i).use_empty()) {
       categories[i] = LoopVarCategory::TensorResultFromOtherPartition;
     } else {
       categories[i] = LoopVarCategory::Unused;
@@ -112,13 +112,13 @@ SmallVector<LoopVarCategory> classifyLoopVars(scf::ForOp loop,
 }
 
 std::pair<SmallVector<size_t>, SmallVector<std::optional<size_t>>>
-getLoopVarIndicesToKeep(scf::ForOp loop, const Partition *partition,
+getLoopVarIndicesToKeep(LoopLikeOpInterface loop, const Partition *partition,
                         ArrayRef<LoopVarCategory> loopVarCategories) {
   SmallVector<size_t> indices;
   // The null index means an invalid index, the corresponding loop variable in
   // the original loop is removed in the cloned loop
-  SmallVector<std::optional<size_t>> reverseIndices(loop.getNumRegionIterArgs(),
-                                                    std::nullopt);
+  SmallVector<std::optional<size_t>> reverseIndices(
+      loop.getRegionIterArgs().size(), std::nullopt);
   for (auto [i, arg] : llvm::enumerate(loop.getRegionIterArgs())) {
     if (loopVarCategories[i] == LoopVarCategory::Used) {
       reverseIndices[i] = indices.size();
@@ -129,7 +129,7 @@ getLoopVarIndicesToKeep(scf::ForOp loop, const Partition *partition,
 }
 
 std::pair<SmallVector<size_t>, SmallVector<std::optional<size_t>>>
-getLoopVarIndicesToKeep(scf::ForOp loop, const Partition *partition,
+getLoopVarIndicesToKeep(LoopLikeOpInterface loop, const Partition *partition,
                         const PartitionSet &partitions) {
   auto loopVarCategories = classifyLoopVars(loop, partition, partitions);
   return getLoopVarIndicesToKeep(loop, partition, loopVarCategories);
@@ -187,6 +187,61 @@ void cloneForOp(scf::ForOp forOp, SmallVector<WarpGroupBuilder> &builders,
     builders[i].setInsertionPointAfter(newForOp);
     newForOp.walk([&](Operation *op) { op->removeAttr(kPartitionAttrName); });
     newForOp->removeAttr(kPartitionStagesAttrName);
+  }
+}
+
+void cloneWhileOp(scf::WhileOp whileOp, SmallVector<WarpGroupBuilder> &builders,
+                  const PartitionSet &partitions) {
+  auto whilePartitions = getPartitionIds(whileOp);
+  SmallVector<scf::WhileOp> newWhileOps;
+
+  for (int i : whilePartitions) {
+    auto &b = builders[i];
+    auto partition = partitions.getPartition(i);
+    auto [stateIndices, _] =
+        getLoopVarIndicesToKeep(whileOp, partition, partitions);
+
+    SmallVector<Value> inits;
+    SmallVector<Type> resultTypes;
+    for (size_t oldIdx : stateIndices) {
+      inits.push_back(b.mapping.lookupOrDefault(whileOp.getInits()[oldIdx]));
+      resultTypes.push_back(whileOp.getResult(oldIdx).getType());
+    }
+
+    auto newWhile =
+        scf::WhileOp::create(b, whileOp.getLoc(), resultTypes, inits);
+    newWhile->setAttrs(whileOp->getAttrs());
+    newWhile->removeAttr(kPartitionOutputsAttrName);
+
+    auto before = &newWhile.getBefore().emplaceBlock();
+    auto after = &newWhile.getAfter().emplaceBlock();
+    for (auto [newIdx, oldIdx] : llvm::enumerate(stateIndices)) {
+      auto oldBefore = whileOp.getBeforeArguments()[oldIdx];
+      auto newBefore =
+          before->addArgument(oldBefore.getType(), oldBefore.getLoc());
+      b.mapping.map(oldBefore, newBefore);
+
+      auto oldAfter = whileOp.getAfterArguments()[oldIdx];
+      auto newAfter = after->addArgument(oldAfter.getType(), oldAfter.getLoc());
+      b.mapping.map(oldAfter, newAfter);
+
+      b.mapping.map(whileOp.getResult(oldIdx), newWhile.getResult(newIdx));
+    }
+
+    newWhileOps.push_back(newWhile);
+    b.setInsertionPointToStart(before);
+  }
+
+  cloneOpsInBlock(&whileOp.getBefore().front(), builders, partitions);
+  for (auto [i, newWhile] : llvm::zip(whilePartitions, newWhileOps)) {
+    builders[i].setInsertionPointToStart(&newWhile.getAfter().front());
+  }
+  cloneOpsInBlock(&whileOp.getAfter().front(), builders, partitions);
+
+  for (auto [i, newWhile] : llvm::zip(whilePartitions, newWhileOps)) {
+    builders[i].setInsertionPointAfter(newWhile);
+    newWhile.walk([&](Operation *op) { op->removeAttr(kPartitionAttrName); });
+    newWhile->removeAttr(kPartitionStagesAttrName);
   }
 }
 
@@ -285,10 +340,35 @@ void cloneOp(Operation *op, SmallVector<WarpGroupBuilder> &builders,
         "Ops are expected to be regionless at this point.");
   }
 
-  for (size_t idx : partitionIndices) {
-    auto &builder = builders[idx];
-    auto newOp = builder.clone(*op, builder.mapping);
-    mapRange(op->getResults(), newOp->getResults(), builder.mapping);
+  if (auto arefPhi = dyn_cast<nvws::ArefPhiOp>(op)) {
+    auto getValuePartitions = [](Value value) {
+      if (auto result = dyn_cast<OpResult>(value)) {
+        auto def = result.getDefiningOp();
+        if (!def->hasAttr(kPartitionOutputsAttrName))
+          return getPartitionIds(def);
+        return getPartitionOutputs(def)[result.getResultNumber()];
+      }
+      auto arg = cast<BlockArgument>(value);
+      auto forOp = cast<scf::ForOp>(arg.getOwner()->getParentOp());
+      return getPartitionOutputs(forOp)[arg.getArgNumber() - 1];
+    };
+    auto localPartitions = getValuePartitions(arefPhi.getLocal());
+    auto remotePartitions = getValuePartitions(arefPhi.getRemote());
+    for (size_t idx : partitionIndices) {
+      auto selected = localPartitions.contains(idx) ? arefPhi.getLocal()
+                                                    : arefPhi.getRemote();
+      assert(
+          (localPartitions.contains(idx) != remotePartitions.contains(idx)) &&
+          "expected exactly one aref.phi operand per partition");
+      builders[idx].mapping.map(
+          arefPhi.getResult(), builders[idx].mapping.lookupOrDefault(selected));
+    }
+  } else {
+    for (size_t idx : partitionIndices) {
+      auto &builder = builders[idx];
+      auto newOp = builder.clone(*op, builder.mapping);
+      mapRange(op->getResults(), newOp->getResults(), builder.mapping);
+    }
   }
 }
 
@@ -299,10 +379,20 @@ void cloneOpsInBlock(Block *block, SmallVector<WarpGroupBuilder> &builders,
 
     if (auto forOp = dyn_cast<scf::ForOp>(op)) {
       cloneForOp(forOp, builders, partitions);
+    } else if (auto whileOp = dyn_cast<scf::WhileOp>(op)) {
+      cloneWhileOp(whileOp, builders, partitions);
     } else if (auto ifOp = dyn_cast<scf::IfOp>(op)) {
       cloneIfOp(ifOp, builders, partitions);
     } else if (auto reduceOp = dyn_cast<triton::ReduceOp>(op)) {
       cloneReduceOp(reduceOp, builders, partitions);
+    } else if (auto conditionOp = dyn_cast<scf::ConditionOp>(op)) {
+      for (int idx : getPartitionIds(conditionOp)) {
+        auto &builder = builders[idx];
+        auto condition =
+            builder.mapping.lookupOrDefault(conditionOp.getCondition());
+        scf::ConditionOp::create(builder, conditionOp.getLoc(), condition,
+                                 builder.getInsertionBlock()->getArguments());
+      }
     } else if (auto yieldOp = dyn_cast<scf::YieldOp>(op)) {
       if (yieldOp.getOperands().empty()) {
         continue;
@@ -314,10 +404,11 @@ void cloneOpsInBlock(Block *block, SmallVector<WarpGroupBuilder> &builders,
       for (size_t idx : partitionIndices) {
         auto &builder = builders[idx];
         SmallVector<size_t> newOperandIndices;
-        if (auto forOp = dyn_cast<scf::ForOp>(yieldOp->getParentOp())) {
+        if (auto loopOp =
+                dyn_cast<LoopLikeOpInterface>(yieldOp->getParentOp())) {
           newOperandIndices =
               getLoopVarIndicesToKeep(
-                  forOp, partitions.getPartition(builder.partitionId),
+                  loopOp, partitions.getPartition(builder.partitionId),
                   partitions)
                   .first;
         } else {
@@ -351,7 +442,7 @@ void cloneOpsInBlock(Block *block, SmallVector<WarpGroupBuilder> &builders,
 
 } // namespace
 
-LogicalResult triton::gpu::partitionLoop(scf::ForOp loop) {
+LogicalResult triton::gpu::partitionLoop(LoopLikeOpInterface loop) {
   FailureOr<PartitionSet> partitionsOr = PartitionSet::fromLoop(loop);
   if (failed(partitionsOr))
     return failure();
@@ -361,6 +452,8 @@ LogicalResult triton::gpu::partitionLoop(scf::ForOp loop) {
   for (const Partition &partition : partitions.getPartitions()) {
     bool failed = false;
     auto callback = [&](OpResult output, OpOperand &use, unsigned distance) {
+      if (isa<nvws::ArefPhiOp>(use.getOwner()))
+        return;
       auto partitionIds = getPartitionIds(use.getOwner());
       if (llvm::is_contained(partitionIds, partition.getIndex()))
         return;
@@ -402,8 +495,8 @@ LogicalResult triton::gpu::partitionLoop(scf::ForOp loop) {
       getLoopVarIndicesToKeep(loop, defaultPartition, loopVarCategories);
 
   ImplicitLocOpBuilder topBuilder(loop.getLoc(), loop);
-  SmallVector<Value> tensorResultAllocs(loop.getNumRegionIterArgs());
-  for (auto [i, res] : llvm::enumerate(loop.getResults())) {
+  SmallVector<Value> tensorResultAllocs(loop.getRegionIterArgs().size());
+  for (auto [i, res] : llvm::enumerate(loop->getResults())) {
     if (loopVarCategories[i] ==
         LoopVarCategory::TensorResultFromOtherPartition) {
       auto ty = cast<RankedTensorType>(res.getType());
@@ -416,7 +509,7 @@ LogicalResult triton::gpu::partitionLoop(scf::ForOp loop) {
 
   SmallVector<Type> resultTypes;
   for (auto i : loopVarIndices) {
-    resultTypes.push_back(loop.getResultTypes()[i]);
+    resultTypes.push_back(loop->getResultTypes()[i]);
   }
 
   SmallVector<int32_t> numWarps(numPartitions, lookupNumWarps(loop));
@@ -439,8 +532,13 @@ LogicalResult triton::gpu::partitionLoop(scf::ForOp loop) {
     if (*getWarpSpecializeTag(op) != partitions.getTag())
       continue;
     if (op == loop) {
-      cloneForOp(loop, builders, partitions);
-      opsToErase.push_back(loop);
+      if (auto forOp = dyn_cast<scf::ForOp>(loop.getOperation())) {
+        cloneForOp(forOp, builders, partitions);
+      } else {
+        cloneWhileOp(cast<scf::WhileOp>(loop.getOperation()), builders,
+                     partitions);
+      }
+      opsToErase.push_back(loop.getOperation());
     } else {
       cloneOp(op, builders, getPartitionIds(op));
       opsToErase.push_back(op);
@@ -449,12 +547,18 @@ LogicalResult triton::gpu::partitionLoop(scf::ForOp loop) {
 
   for (auto [b, region, partition] : llvm::zip(
            builders, wgOp.getPartitionRegions(), partitions.getPartitions())) {
-    if (!llvm::is_contained(getPartitionIds(loop), b.partitionId)) {
+    if (!llvm::is_contained(getPartitionIds(loop.getOperation()),
+                            b.partitionId)) {
       nvws::WarpGroupYieldOp::create(b, wgOp.getLoc(), SmallVector<Value>{});
       continue;
     }
-    auto newForOp = *region.front().getOps<scf::ForOp>().begin();
-    auto outputs = newForOp.getResults();
+    Operation *newLoop = nullptr;
+    if (isa<scf::ForOp>(loop.getOperation())) {
+      newLoop = *region.front().getOps<scf::ForOp>().begin();
+    } else {
+      newLoop = *region.front().getOps<scf::WhileOp>().begin();
+    }
+    auto outputs = newLoop->getResults();
 
     if (b.partitionId == 0) {
       nvws::WarpGroupYieldOp::create(b, wgOp.getLoc(), outputs);
@@ -463,18 +567,18 @@ LogicalResult triton::gpu::partitionLoop(scf::ForOp loop) {
       // via SMEM.
       // The calls to getLoopVarIndicesToKeep and isTensorResultComputedBy
       // below are unnecessary if we can encode the partition index and the
-      // corresponding result tensor index of newForOp in
+      // corresponding result tensor index of the cloned loop in
       // LoopVarCategory::TensorResultFromOtherPartition. In the absence of such
       // language support, we end up computing the same information multiple
       // times.
       auto [_, reverseIndices] =
           getLoopVarIndicesToKeep(loop, &partition, partitions);
-      for (size_t i = 0; i < loop.getNumRegionIterArgs(); ++i) {
+      for (size_t i = 0; i < loop.getRegionIterArgs().size(); ++i) {
         if (loopVarCategories[i] ==
                 LoopVarCategory::TensorResultFromOtherPartition &&
             isTensorResultComputedBy(loop, i, &partition, partitions)) {
           assert(reverseIndices[i] && "A valid index is expected.");
-          auto result = newForOp.getResult(*reverseIndices[i]);
+          auto result = newLoop->getResult(*reverseIndices[i]);
           LocalStoreOp::create(b, wgOp.getLoc(), result, tensorResultAllocs[i]);
         }
       }
@@ -484,19 +588,20 @@ LogicalResult triton::gpu::partitionLoop(scf::ForOp loop) {
 
   topBuilder.setInsertionPointAfter(wgOp);
 
-  for (auto [i, res] : llvm::enumerate(loop.getResults())) {
+  for (auto [i, res] : llvm::enumerate(loop->getResults())) {
     if (res.use_empty())
       continue;
 
     if (loopVarCategories[i] ==
         LoopVarCategory::TensorResultFromOtherPartition) {
-      auto ty = cast<RankedTensorType>(loop.getResult(i).getType());
+      auto ty = cast<RankedTensorType>(loop->getResult(i).getType());
       auto output = LocalLoadOp::create(topBuilder, ty, tensorResultAllocs[i]);
       LocalDeallocOp::create(topBuilder, tensorResultAllocs[i]);
       res.replaceAllUsesWith(output);
     } else if (llvm::any_of(res.getUsers(), [&](Operation *user) {
                  return !hasPartition(user) ||
-                        (isa<scf::ForOp>(user) && hasWarpSpecializeTag(user));
+                        (isa<scf::ForOp, scf::WhileOp>(user) &&
+                         hasWarpSpecializeTag(user));
                })) {
       // If some users are in the root partition (no partition attribute) or
       // used by another warp-specialized loop, we need to replace their uses
@@ -531,15 +636,15 @@ struct PartitionLoops
 } // namespace
 
 void PartitionLoops::runOnOperation() {
-  // Collect for loops to warp specialize. This pass expects the loop to already
+  // Collect loops to warp specialize. This pass expects each loop to already
   // be annotated with partitions.
-  SmallVector<scf::ForOp> loops;
-  getOperation().walk([&](scf::ForOp loop) {
+  SmallVector<LoopLikeOpInterface> loops;
+  getOperation().walk([&](LoopLikeOpInterface loop) {
     if (loop->hasAttrOfType<ArrayAttr>(kPartitionStagesAttrName))
       loops.push_back(loop);
   });
 
-  for (scf::ForOp loop : loops) {
+  for (LoopLikeOpInterface loop : loops) {
     if (failed(partitionLoop(loop)))
       return signalPassFailure();
   }

--- a/lib/Dialect/TritonGPU/Transforms/WarpSpecialization/PartitionScheduling.cpp
+++ b/lib/Dialect/TritonGPU/Transforms/WarpSpecialization/PartitionScheduling.cpp
@@ -118,6 +118,27 @@ std::unique_ptr<Graph> buildGraph(Operation *region) {
               for (auto &op : block)
                 visitOperation(node, &op);
 
+        } else if (auto whileOp = dyn_cast<scf::WhileOp>(op)) {
+          auto node = graph->addNode(op, 0, 0);
+          nodes[op] = node;
+
+          // Create one recurrence node per loop-carried argument.
+          for (int idx = 0; idx < whileOp.getInits().size(); ++idx) {
+            auto beforeArg = whileOp.getBeforeArguments()[idx];
+            auto argNode = node->addNode(beforeArg, 2, 1);
+            node->addDefines(argNode);
+            operands[std::make_pair(op, idx)] = InputPort(argNode, 0);
+            values.emplace_back(OutputPort(argNode, 0), beforeArg);
+            values.emplace_back(OutputPort(argNode, 0),
+                                whileOp.getAfterArguments()[idx]);
+            values.emplace_back(OutputPort(argNode, 0), whileOp.getResult(idx));
+          }
+
+          for (auto &region : op->getRegions())
+            for (auto &block : region)
+              for (auto &op : block)
+                visitOperation(node, &op);
+
         } else if (auto ifOp = dyn_cast<scf::IfOp>(op)) {
           auto node = graph->addNode(op, 1, 0);
           nodes[op] = node;
@@ -156,15 +177,20 @@ std::unique_ptr<Graph> buildGraph(Operation *region) {
               for (auto &op : block)
                 visitOperation(node, &op);
 
+        } else if (isa<scf::ConditionOp>(op)) {
+          assert(isa<scf::WhileOp>(op->getParentOp()));
+          auto node = graph->addNode(op, 1, 0);
+          nodes[op] = node;
+          operands[std::make_pair(op, 0)] = InputPort(node, 0);
         } else if (isa<scf::YieldOp>(op)) {
 
-          if (auto forOp = dyn_cast<scf::ForOp>(op->getParentOp())) {
-            // map operands to yield in a for op to the iter arg nodes
-            auto for_node = nodes[op->getParentOp()];
-            for (size_t idx = 0; idx < op->getNumOperands(); idx++) {
-              auto block_arg_node =
-                  for_node->getDefines()[idx + 1]; // skip iter arg
-              operands[std::make_pair(op, idx)] = InputPort(block_arg_node, 1);
+          if (auto loop = dyn_cast<LoopLikeOpInterface>(op->getParentOp())) {
+            size_t offset = isa<scf::ForOp>(loop.getOperation());
+            auto loopNode = nodes[op->getParentOp()];
+            for (size_t idx = 0; idx < op->getNumOperands(); ++idx) {
+              auto blockArgNode =
+                  loopNode->getDefines()[idx + offset]; // skip iter arg
+              operands[std::make_pair(op, idx)] = InputPort(blockArgNode, 1);
             }
 
           } else if (auto ifOp = dyn_cast<scf::IfOp>(op->getParentOp())) {
@@ -221,6 +247,8 @@ SmallVector<OutputPort> initialDataValues(Graph *graph) {
         node->setDataValue(0);
         values.push_back({node, 0});
       }
+      if (isa<ttng::CLCTryCancelSyncOp>(op))
+        node->setDataValue(0);
       if (isa<ttng::TMEMLoadOp>(op)) {
         node->setDataValue(0);
         values.push_back({node, 0});
@@ -376,6 +404,12 @@ bool isTMEM(Node *node) {
   return flags & Flags::TMEM;
 }
 
+bool isCLC(Node *node) {
+  auto partition = node->getPartition();
+  auto flags = partition->getFlags();
+  return flags & Flags::CLC;
+}
+
 bool hasEligibleMemoryOps(Graph *graph) {
   bool found = false;
   graph->walk([&](Node *node) {
@@ -401,13 +435,13 @@ bool isCostlySFU(Node *node) {
   return (flags & Flags::SFU) && partition->getCost() > 256;
 }
 
-bool isForIterArg(Node *node) {
+bool isLoopBlockArg(Node *node) {
   if (node->isOp())
     return false;
   auto blockArg = dyn_cast<BlockArgument>(node->getValue());
   if (!blockArg)
     return false;
-  return isa<scf::ForOp>(blockArg.getOwner()->getParentOp());
+  return isa<scf::ForOp, scf::WhileOp>(blockArg.getOwner()->getParentOp());
 }
 
 bool isIfResult(Node *node) {
@@ -420,6 +454,13 @@ bool isIfResult(Node *node) {
 }
 
 SmallVector<std::pair<std::string, std::function<bool(Edge)>>> heuristics = {
+    // CLC issue and response allocation belong to the same partition.
+    {"clc_local_alloc",
+     [](Edge edge) {
+       return node_isa<ttng::CLCTryCancelSyncOp>(edge.getFromNode()) &&
+              node_isa<ttg::LocalAllocOp>(edge.getToNode());
+     }},
+
     // load followed by local alloc in same partition
     {"load_local_alloc",
      [](Edge edge) {
@@ -495,17 +536,17 @@ SmallVector<std::pair<std::string, std::function<bool(Edge)>>> heuristics = {
        return true;
      }},
 
-    // for op iter arg placed in same partition as op that produces
+    // loop block arg placed in same partition as op that produces
     // its value in the loop body (if it is not a token)
-    {"for_op_iter_arg",
+    {"loop_block_arg",
      [](Edge edge) {
        auto from = edge.getFromNode();
        auto to = edge.getToNode();
        if (from->getParent() != to->getParent())
          // skip if not both in the loop body
          return false;
-       if (!isForIterArg(to))
-         // skip is not to an iter arg
+       if (!isLoopBlockArg(to))
+         // skip if not to a loop block arg
          return false;
        if (isa<AsyncTokenType>(to->getValue().getType()))
          // skip if a token type
@@ -513,13 +554,13 @@ SmallVector<std::pair<std::string, std::function<bool(Edge)>>> heuristics = {
        return true;
      }},
 
-    // for op iter arg placed in same partition as op that consumes
+    // loop block arg placed in same partition as op that consumes
     // its value (if it is a token)
-    {"for_op_iter_arg_token",
+    {"loop_block_arg_token",
      [](Edge edge) {
        auto from = edge.getFromNode();
-       if (!isForIterArg(from))
-         // skip if not from an iter arg
+       if (!isLoopBlockArg(from))
+         // skip if not from a loop block arg
          return false;
        if (!isa<AsyncTokenType>(from->getValue().getType()))
          // skip if not a token
@@ -689,6 +730,16 @@ SmallVector<std::pair<std::string, std::function<bool(Edge)>>> heuristics = {
 };
 
 SmallVector<std::pair<std::string, std::function<bool(Edge)>>> constraints = {
+    // The CLC owns a dedicated worker partition.
+    {"clc",
+     [](Edge edge) {
+       auto from = edge.getFromNode();
+       auto to = edge.getToNode();
+       return (node_isa<ttng::CLCTryCancelSyncOp>(from) &&
+               node_isa<ttg::LocalAllocOp>(to)) ||
+              isCLC(from) == isCLC(to);
+     }},
+
     // don't merge manual partitions
     {"manual",
      [](Edge edge) {
@@ -1219,6 +1270,11 @@ void serialize(size_t idx, Operation *region, Graph *graph) {
     if (auto forOp = dyn_cast<scf::ForOp>(op)) {
       cast<scf::YieldOp>(forOp.getBody()->getTerminator())
           ->setAttr(kPartitionAttrName, partitionsAttr);
+    } else if (auto whileOp = dyn_cast<scf::WhileOp>(op)) {
+      whileOp.getBefore().front().getTerminator()->setAttr(kPartitionAttrName,
+                                                           partitionsAttr);
+      whileOp.getAfter().front().getTerminator()->setAttr(kPartitionAttrName,
+                                                          partitionsAttr);
     } else if (auto ifOp = dyn_cast<scf::IfOp>(op)) {
       ifOp.thenYield()->setAttr(kPartitionAttrName, partitionsAttr);
       if (!ifOp.getElseRegion().empty()) {
@@ -1277,12 +1333,16 @@ void serialize(size_t idx, Operation *region, Graph *graph) {
             setPartitionOutputsAttr(parentOp, blockArg.getArgNumber() - 1,
                                     forOp.getResultTypes().size(), node);
           }
+        } else if (auto whileOp = dyn_cast<scf::WhileOp>(parentOp)) {
+          assert(blockArg.getOwner() == &whileOp.getBefore().front());
+          setPartitionOutputsAttr(parentOp, blockArg.getArgNumber(),
+                                  whileOp.getResultTypes().size(), node);
         } else {
           assert(false);
         }
       } else if (auto result = dyn_cast<OpResult>(value)) {
         auto op = result.getOwner();
-        if (isa<scf::ForOp>(op)) {
+        if (isa<scf::ForOp, scf::WhileOp>(op)) {
           // do nothing (handled by block arg)
         } else if (auto ifOp = dyn_cast<scf::IfOp>(op)) {
           // result of an if
@@ -1365,10 +1425,13 @@ void assignPartitionIds(Graph *graph) {
   SmallVector<Partition *> store_partitions;
   SmallVector<Partition *> mma_partitions;
   SmallVector<Partition *> load_partitions;
+  SmallVector<Partition *> clc_partitions;
   SmallVector<Partition *> other_partitions;
 
   for (auto partition : graph->getPartitions()) {
-    if (partition->getFlags() & Flags::STORE)
+    if (partition->getFlags() & Flags::CLC)
+      clc_partitions.push_back(partition);
+    else if (partition->getFlags() & Flags::STORE)
       store_partitions.push_back(partition);
     else if (partition->getFlags() & Flags::MMA)
       mma_partitions.push_back(partition);
@@ -1395,6 +1458,10 @@ void assignPartitionIds(Graph *graph) {
     idx++;
   }
   for (auto partition : load_partitions) {
+    partition->id = idx;
+    idx++;
+  }
+  for (auto partition : clc_partitions) {
     partition->id = idx;
     idx++;
   }
@@ -1434,6 +1501,46 @@ void assignPartitionsForOpsWithNoUse(Graph *graph) {
   });
 }
 
+// Assign the While's partitions to every operation in its before region.
+void assignWhileBeforePartitions(scf::WhileOp whileOp, Graph *graph) {
+  const auto &partitions = graph->getRoot()->getPartitions();
+
+  Region &before = whileOp.getBefore();
+  graph->walk([&](Node *node) {
+    Region *region = node->isOp() ? node->getOp()->getParentRegion()
+                                  : node->getValue().getParentRegion();
+    if (region == &before || before.isAncestor(region))
+      node->addPartitions(partitions);
+  });
+}
+
+// Assign CLC response consumers to all partitions
+void assignCLCConsumers(scf::WhileOp whileOp, Graph *graph) {
+  SmallVector<Node *> stack;
+  graph->walk([&](Node *node) {
+    if (!node->isOp())
+      return;
+    auto load = dyn_cast<ttng::CLCLoadResultOp>(node->getOp());
+    if (!load || load->getParentOfType<scf::WhileOp>() != whileOp)
+      return;
+    auto alloc = load.getSrc().getDefiningOp<ttg::LocalAllocOp>();
+    if (alloc && alloc.getSrc().getDefiningOp<ttng::CLCTryCancelSyncOp>())
+      stack.push_back(node);
+  });
+
+  const auto &partitions = graph->getRoot()->getPartitions();
+  while (!stack.empty()) {
+    Node *node = stack.pop_back_val();
+    node->addPartitions(partitions);
+    for (Node *parent = node->getParent(); parent; parent = parent->getParent())
+      parent->addPartitions(partitions);
+    if (isLoopBlockArg(node))
+      continue;
+    for (Edge edge : node->getOutEdges())
+      stack.push_back(edge.getToNode());
+  }
+}
+
 } // namespace
 
 //===----------------------------------------------------------------------===//
@@ -1447,8 +1554,9 @@ struct PartitionScheduling
   void runOnOperation() override {
     // find ops to partition
     SmallVector<Operation *> ops;
-    getOperation().walk([&](scf::ForOp op) {
-      if (op->hasAttr(kWarpSpecializeAttrName))
+    getOperation().walk([&](Operation *op) {
+      if (isa<scf::ForOp, scf::WhileOp>(op) &&
+          op->hasAttr(kWarpSpecializeAttrName))
         ops.push_back(op);
     });
 
@@ -1458,7 +1566,7 @@ struct PartitionScheduling
       analyze(idx, op);
       if (hasPartition(op))
         cloneMultiPartitionDataOps(op);
-      if (auto loop = dyn_cast<scf::ForOp>(op);
+      if (auto loop = dyn_cast<LoopLikeOpInterface>(op);
           loop && loop->hasAttr(kPartitionStagesAttrName) &&
           failed(verifyPartitionedLoop(loop))) {
         signalPassFailure();
@@ -1509,6 +1617,12 @@ private:
     // partitions)
     duplicateCheapOps(graph.get(), key, vis_info);
     visualize(key, "final", "final", graph.get(), vis_info);
+
+    if (auto whileOp = dyn_cast<scf::WhileOp>(op)) {
+      assignWhileBeforePartitions(whileOp, graph.get());
+      if (whileOp->hasAttr(kWarpSpecializeAttrName))
+        assignCLCConsumers(whileOp, graph.get());
+    }
 
     LLVM_DEBUG({
       llvm::errs() << "\nfinal partitions:\n";

--- a/lib/Dialect/TritonGPU/Transforms/WarpSpecialization/PartitionSchedulingUtility.cpp
+++ b/lib/Dialect/TritonGPU/Transforms/WarpSpecialization/PartitionSchedulingUtility.cpp
@@ -26,6 +26,8 @@ llvm::raw_ostream &operator<<(llvm::raw_ostream &stream, Flags flags) {
       strs.push_back("SFU");
     if (flags & Flags::VIEW)
       strs.push_back("VIEW");
+    if (flags & Flags::CLC)
+      strs.push_back("CLC");
   }
   for (size_t i = 0; i < strs.size(); i++) {
     if (i != 0)
@@ -53,6 +55,8 @@ Flags getNodeFlags(Node *node) {
       return Flags::TMEM;
     if (isa<math::Exp2Op>(op))
       return Flags::SFU;
+    if (isa<ttng::CLCTryCancelSyncOp>(op))
+      return Flags::CLC;
     if (isViewOp(op))
       return Flags::VIEW;
   }

--- a/python/test/unit/language/test_clc.py
+++ b/python/test/unit/language/test_clc.py
@@ -1,4 +1,5 @@
 import pytest
+import re
 import torch
 
 import triton
@@ -7,6 +8,14 @@ from triton._internal_testing import supports_clc
 from triton.tools.tensor_descriptor import TensorDescriptor
 
 requires_clc = pytest.mark.skipif(not supports_clc(), reason="CLC requires NVIDIA SM100+")
+
+
+def _assert_clc_ws_ir(compiled):
+    ttgir = compiled.asm["ttgir"]
+    num_partitions = len(re.findall(r"^\s*partition\d+\(", ttgir, re.MULTILINE))
+    assert num_partitions > 0
+    assert ttgir.count("scf.while") == num_partitions + 1
+    assert ttgir.count("ttng.clc_try_cancel ") == 1
 
 
 @triton.jit
@@ -250,3 +259,82 @@ def test_clc_multicta_loop_reuse_consan(num_ctas, device, fresh_knobs):
     )
 
     torch.testing.assert_close(dst, src, atol=0, rtol=0)
+
+
+@triton.jit
+def _clc_ws_tma_matmul_kernel(
+    a_desc,
+    b_desc,
+    c_desc,
+    counts,
+    M: tl.constexpr,
+    N: tl.constexpr,
+    K: tl.constexpr,
+    BLOCK_M: tl.constexpr,
+    BLOCK_N: tl.constexpr,
+    BLOCK_K: tl.constexpr,
+):
+    tile_id = tl.program_id(0)
+    num_pid_n = tl.cdiv(N, BLOCK_N)
+    pid_m = tile_id // num_pid_n
+    pid_n = tile_id % num_pid_n
+    off_m = pid_m * BLOCK_M
+    off_n = pid_n * BLOCK_N
+    accumulator = tl.zeros((BLOCK_M, BLOCK_N), tl.float32)
+    for off_k in tl.range(0, K, BLOCK_K, num_stages=2, warp_specialize=True):
+        a = a_desc.load([off_m, off_k])
+        b = b_desc.load([off_k, off_n])
+        accumulator = tl.dot(a, b, accumulator)
+
+    c_desc.store([off_m, off_n], accumulator.to(tl.float16))
+    tl.atomic_add(counts + tile_id, 1)
+
+
+def _run_clc_ws_tma_matmul(M, N, K, device, num_ctas):
+    block_m, block_n, block_k = 128, 64, 64
+    torch.manual_seed(42)
+    a = torch.randn((M, K), dtype=torch.float16, device=device)
+    b = torch.randn((K, N), dtype=torch.float16, device=device)
+    c = torch.empty((M, N), dtype=torch.float16, device=device)
+    num_tiles = triton.cdiv(M, block_m) * triton.cdiv(N, block_n)
+    counts = torch.zeros((num_tiles, ), dtype=torch.int32, device=device)
+    a_desc = TensorDescriptor.from_tensor(a, [block_m, block_k])
+    b_desc = TensorDescriptor.from_tensor(b, [block_k, block_n])
+    c_desc = TensorDescriptor.from_tensor(c, [block_m, block_n])
+
+    compiled = _clc_ws_tma_matmul_kernel[(num_tiles, )](
+        a_desc,
+        b_desc,
+        c_desc,
+        counts,
+        M,
+        N,
+        K,
+        block_m,
+        block_n,
+        block_k,
+        num_warps=4,
+        num_stages=2,
+        num_ctas=num_ctas,
+        clc=True,
+    )
+    _assert_clc_ws_ir(compiled)
+    expected = torch.matmul(a.float(), b.float()).half()
+    torch.testing.assert_close(c, expected, atol=3e-2, rtol=3e-2)
+    return counts
+
+
+@requires_clc
+@pytest.mark.parametrize("M,N,K", [(512, 512, 192), (4096, 2048, 512), (2048, 2048, 128)])
+def test_clc_ws_tma_matmul_1cta(M, N, K, device):
+    counts = _run_clc_ws_tma_matmul(M, N, K, device, 1)
+    assert torch.all(counts == 1)
+
+
+@requires_clc
+def test_clc_ws_consan_1cta(device, fresh_knobs):
+    triton.knobs.compilation.instrumentation_mode = "consan"
+    num_sms = torch.cuda.get_device_properties(device).multi_processor_count
+    num_tiles = max(64, num_sms * 32)
+    counts = _run_clc_ws_tma_matmul(128, num_tiles * 64, 128, device, 1)
+    assert torch.all(counts == 1)

--- a/python/test/unit/language/test_warp_specialization.py
+++ b/python/test/unit/language/test_warp_specialization.py
@@ -1,6 +1,7 @@
 import torch
 import pytest
 import pathlib
+import re
 import triton
 import triton.language as tl
 
@@ -12,6 +13,16 @@ pytestmark = pytest.mark.enable_warmup(min_capability=9)
 
 def is_hopper_or_blackwell():
     return is_hopper() or is_blackwell()
+
+
+def _assert_clc_ws_ir(compiled):
+    if is_compile_warmup():
+        return
+    ttgir = compiled.asm["ttgir"]
+    num_partitions = len(re.findall(r"^\s*partition\d+\(", ttgir, re.MULTILINE))
+    assert num_partitions > 0
+    assert ttgir.count("scf.while") == num_partitions + 1
+    assert ttgir.count("ttng.clc_try_cancel ") == 1
 
 
 @pytest.mark.skipif(is_hip(), reason="warp specialization is not supported on hip devices")
@@ -317,6 +328,51 @@ def test_warp_specialize_tma_matmul(M, N, K, BLOCK_SIZE_M, BLOCK_SIZE_N, BLOCK_S
         assert "ttg.warp_specialize" in ttgir
 
 
+@pytest.mark.parametrize("M,N,K", [(512, 512, 192), (4096, 2048, 512), (2048, 2048, 64)])
+@pytest.mark.skipif(not is_blackwell(), reason="CLC requires Blackwell")
+def test_warp_specialize_tma_matmul_clc(M, N, K):
+    block_m, block_n, block_k = 128, 64, 64
+    num_stages, num_warps = 2, 4
+    group_size_m = 8
+    device = "cuda"
+
+    torch.manual_seed(42)
+    a = torch.randn((M, K), dtype=torch.float16, device=device)
+    b = torch.randn((N, K), dtype=torch.float16, device=device)
+    c = torch.empty((M, N), dtype=torch.float16, device=device)
+
+    def alloc_fn(size, align, stream):
+        return torch.empty(size, dtype=torch.int8, device=device)
+
+    triton.set_allocator(alloc_fn)
+    grid = (triton.cdiv(M, block_m) * triton.cdiv(N, block_n), )
+    compiled = matmul_tma_ws_kernel[grid](
+        a,
+        b,
+        c,
+        *a.stride(),
+        *b.stride(),
+        *c.stride(),
+        M,
+        N,
+        K,
+        num_stages,
+        block_m,
+        block_n,
+        block_k,
+        group_size_m,
+        num_warps=num_warps,
+        USE_FP8=False,
+        A_USE_TMA=True,
+        B_USE_TMA=True,
+        clc=True,
+    )
+    _assert_clc_ws_ir(compiled)
+
+    expected = torch.matmul(a.float(), b.float().T).half()
+    torch.testing.assert_close(c, expected, atol=3e-2, rtol=3e-2)
+
+
 @pytest.mark.parametrize("M, N, K", [(512, 512, 512)])
 @pytest.mark.parametrize("num_stages", [0, 3])
 @pytest.mark.parametrize("a_use_tma", [False, True])
@@ -541,6 +597,136 @@ def test_warp_specialize_attention_forward(M, N, BLOCK_M, HEAD_DIM, num_stages, 
                                                   BLOCK_M, HEAD_DIM, False, num_stages=num_stages, num_warps=num_warps)
     attention_inner_loop_kernel[(M // BLOCK_M, )](desc_q, desc_k, desc_v, desc_acc, l_i, m_i, M, N, 0.5, BLOCK_M,
                                                   HEAD_DIM, True, num_stages=num_stages, num_warps=num_warps)
+
+    torch.testing.assert_close(acc.to(torch.float32), acc_ref.to(torch.float32), atol=0, rtol=0)
+    torch.testing.assert_close(l_i.to(torch.float32), l_i_ref.to(torch.float32), atol=0, rtol=0)
+    torch.testing.assert_close(m_i.to(torch.float32), m_i_ref.to(torch.float32), atol=0, rtol=0)
+
+
+@pytest.mark.parametrize("M,N", [(8192, 8192), (1024, 1024)])
+@pytest.mark.parametrize("BLOCK_M", [64, 128])
+@pytest.mark.parametrize("HEAD_DIM", [64, 128])
+@pytest.mark.parametrize("num_warps", [4, 8])
+@pytest.mark.parametrize("use_fp8", [False, True])
+@pytest.mark.skipif(not is_blackwell(), reason="CLC requires Blackwell")
+def test_warp_specialize_attention_clc_forward(M, N, BLOCK_M, HEAD_DIM, num_warps, use_fp8):
+    num_stages = 2
+    dtype = torch.float8_e4m3fn if use_fp8 else torch.float16
+
+    torch.manual_seed(42)
+    q = torch.randn((M, HEAD_DIM), device="cuda").to(dtype)
+    k = torch.randn((N, HEAD_DIM), device="cuda").to(dtype)
+    v = torch.randn((N, HEAD_DIM), device="cuda").to(dtype)
+
+    acc_ref = torch.empty((M, HEAD_DIM), dtype=dtype, device="cuda")
+    l_i_ref = torch.empty((M, ), dtype=dtype, device="cuda")
+    m_i_ref = torch.empty((M, ), dtype=dtype, device="cuda")
+    acc = torch.empty((M, HEAD_DIM), dtype=dtype, device="cuda")
+    l_i = torch.empty((M, ), dtype=dtype, device="cuda")
+    m_i = torch.empty((M, ), dtype=dtype, device="cuda")
+
+    desc_q = TensorDescriptor(q, shape=[M, HEAD_DIM], strides=[HEAD_DIM, 1], block_shape=[BLOCK_M, HEAD_DIM])
+    desc_k = TensorDescriptor(k, shape=[N, HEAD_DIM], strides=[HEAD_DIM, 1], block_shape=[BLOCK_M, HEAD_DIM])
+    desc_v = TensorDescriptor(v, shape=[N, HEAD_DIM], strides=[HEAD_DIM, 1], block_shape=[BLOCK_M, HEAD_DIM])
+    desc_acc_ref = TensorDescriptor(acc_ref, shape=[M, HEAD_DIM], strides=[HEAD_DIM, 1],
+                                    block_shape=[BLOCK_M, HEAD_DIM])
+    desc_acc = TensorDescriptor(acc, shape=[M, HEAD_DIM], strides=[HEAD_DIM, 1], block_shape=[BLOCK_M, HEAD_DIM])
+
+    grid = (M // BLOCK_M, )
+    attention_inner_loop_kernel[grid](desc_q, desc_k, desc_v, desc_acc_ref, l_i_ref, m_i_ref, M, N, 0.5, BLOCK_M,
+                                      HEAD_DIM, False, num_stages=num_stages, num_warps=num_warps)
+    compiled = attention_inner_loop_kernel[grid](desc_q, desc_k, desc_v, desc_acc, l_i, m_i, M, N, 0.5, BLOCK_M,
+                                                 HEAD_DIM, True, num_stages=num_stages, num_warps=num_warps, clc=True)
+    _assert_clc_ws_ir(compiled)
+
+    torch.testing.assert_close(acc.to(torch.float32), acc_ref.to(torch.float32), atol=0, rtol=0)
+    torch.testing.assert_close(l_i.to(torch.float32), l_i_ref.to(torch.float32), atol=0, rtol=0)
+    torch.testing.assert_close(m_i.to(torch.float32), m_i_ref.to(torch.float32), atol=0, rtol=0)
+
+
+@triton.jit
+def attention_clc_aref_phi_kernel(  #
+        desc_q, desc_k, desc_v,  #
+        desc_acc, l_i_ptr, m_i_ptr,  #
+        M, N, qk_scale,  #
+        BLOCK_M: tl.constexpr,  #
+        HEAD_DIM: tl.constexpr,  #
+        warp_specialize: tl.constexpr  #
+):
+    m_i = tl.zeros([BLOCK_M], dtype=tl.float32) - float("inf")
+    l_i = tl.zeros([BLOCK_M], dtype=tl.float32) + 1.0
+    acc = tl.zeros([BLOCK_M, HEAD_DIM], dtype=tl.float32)
+
+    off_m = tl.program_id(0) * BLOCK_M
+    q = desc_q.load([off_m, 0])
+
+    for start_n in tl.range(0, N, HEAD_DIM, warp_specialize=warp_specialize):
+        start_n = tl.multiple_of(start_n, HEAD_DIM)
+        k = desc_k.load([start_n, 0]).T
+
+        qk = tl.dot(q, k)
+        m_ij = tl.maximum(m_i, tl.max(qk, 1) * qk_scale)
+        qk = qk * qk_scale - m_ij[:, None]
+        p = tl.math.exp2(qk)
+        alpha = tl.math.exp2(m_i - m_ij)
+        l_ij = tl.sum(p, 1)
+
+        if warp_specialize:
+            BM: tl.constexpr = acc.shape[0]
+            BN: tl.constexpr = acc.shape[1]
+            acc0, acc1 = acc.reshape([BM, 2, BN // 2]).permute(0, 2, 1).split()
+            acc0 = acc0 * alpha[:, None]
+            acc1 = acc1 * alpha[:, None]
+            acc = tl.join(acc0, acc1).permute(0, 2, 1).reshape([BM, BN])
+        else:
+            acc = acc * alpha[:, None]
+
+        v = desc_v.load([start_n, 0])
+        p = p.to(v.dtype)
+        acc = tl.dot(p, v, acc)
+
+        l_i = l_i * alpha + l_ij
+        m_i = m_ij
+
+    m_i += tl.math.log2(l_i)
+    acc = acc / l_i[:, None]
+    desc_acc.store([off_m, 0], acc.to(q.dtype))
+    tl.store(l_i_ptr + off_m + tl.arange(0, BLOCK_M), l_i)
+    tl.store(m_i_ptr + off_m + tl.arange(0, BLOCK_M), m_i)
+
+
+@pytest.mark.skipif(not is_blackwell(), reason="CLC requires Blackwell")
+def test_warp_specialize_attention_clc_aref_phi():
+    M = N = 1024
+    BLOCK_M = HEAD_DIM = 128
+    num_stages, num_warps = 2, 4
+    dtype = torch.float16
+
+    torch.manual_seed(42)
+    q = torch.randn((M, HEAD_DIM), device="cuda", dtype=dtype)
+    k = torch.randn((N, HEAD_DIM), device="cuda", dtype=dtype)
+    v = torch.randn((N, HEAD_DIM), device="cuda", dtype=dtype)
+
+    acc_ref = torch.empty((M, HEAD_DIM), dtype=dtype, device="cuda")
+    l_i_ref = torch.empty((M, ), dtype=dtype, device="cuda")
+    m_i_ref = torch.empty((M, ), dtype=dtype, device="cuda")
+    acc = torch.empty((M, HEAD_DIM), dtype=dtype, device="cuda")
+    l_i = torch.empty((M, ), dtype=dtype, device="cuda")
+    m_i = torch.empty((M, ), dtype=dtype, device="cuda")
+
+    desc_q = TensorDescriptor(q, shape=[M, HEAD_DIM], strides=[HEAD_DIM, 1], block_shape=[BLOCK_M, HEAD_DIM])
+    desc_k = TensorDescriptor(k, shape=[N, HEAD_DIM], strides=[HEAD_DIM, 1], block_shape=[BLOCK_M, HEAD_DIM])
+    desc_v = TensorDescriptor(v, shape=[N, HEAD_DIM], strides=[HEAD_DIM, 1], block_shape=[BLOCK_M, HEAD_DIM])
+    desc_acc_ref = TensorDescriptor(acc_ref, shape=[M, HEAD_DIM], strides=[HEAD_DIM, 1],
+                                    block_shape=[BLOCK_M, HEAD_DIM])
+    desc_acc = TensorDescriptor(acc, shape=[M, HEAD_DIM], strides=[HEAD_DIM, 1], block_shape=[BLOCK_M, HEAD_DIM])
+
+    grid = (M // BLOCK_M, )
+    attention_clc_aref_phi_kernel[grid](desc_q, desc_k, desc_v, desc_acc_ref, l_i_ref, m_i_ref, M, N, 0.5, BLOCK_M,
+                                        HEAD_DIM, True, num_stages=num_stages, num_warps=num_warps, clc=False)
+    compiled = attention_clc_aref_phi_kernel[grid](desc_q, desc_k, desc_v, desc_acc, l_i, m_i, M, N, 0.5, BLOCK_M,
+                                                   HEAD_DIM, True, num_stages=num_stages, num_warps=num_warps, clc=True)
+    _assert_clc_ws_ir(compiled)
 
     torch.testing.assert_close(acc.to(torch.float32), acc_ref.to(torch.float32), atol=0, rtol=0)
     torch.testing.assert_close(l_i.to(torch.float32), l_i_ref.to(torch.float32), atol=0, rtol=0)

--- a/python/tutorials/09-persistent-matmul.py
+++ b/python/tutorials/09-persistent-matmul.py
@@ -14,11 +14,8 @@ Users can pass command-line arguments to specify matrix dimensions and iteration
     # FP8
     python 09-persistent-matmul.py --prec fp8 --K_range 128 1024 --K_step 128
 
-    # FP16
+    # FP16 (includes CLC variants on supported devices)
     python 09-persistent-matmul.py --prec fp16 --K_range 128 1024 --K_step 128
-
-    # FP16 with Cluster Launch Control
-    python 09-persistent-matmul.py --prec fp16 --clc
 
 Note that currently this tutorial will fail on devices with a small shared memory size, such as RTX-4090.
 """
@@ -459,7 +456,7 @@ def matmul_kernel_tma_persistent(a_desc, b_desc, c_desc,  #
 # CLC scheduling loop.
 @triton.autotune(
     configs=matmul_tma_persistent_get_configs(pre_hook=matmul_tma_set_block_size_hook),
-    key=["M", "N", "K"],
+    key=["M", "N", "K", "WARP_SPECIALIZE"],
 )
 @triton.jit(launch_metadata=_matmul_launch_metadata)
 def matmul_kernel_tma_clc(a_desc, b_desc, c_desc,  #
@@ -470,6 +467,7 @@ def matmul_kernel_tma_clc(a_desc, b_desc, c_desc,  #
                           GROUP_SIZE_M: tl.constexpr,  #
                           FP8_OUTPUT: tl.constexpr,  #
                           EPILOGUE_SUBTILE: tl.constexpr,  #
+                          WARP_SPECIALIZE: tl.constexpr,  #
                           ):
     dtype = tl.float8e4nv if FP8_OUTPUT else tl.float16
 
@@ -489,7 +487,7 @@ def matmul_kernel_tma_clc(a_desc, b_desc, c_desc,  #
     offs_bn = pid_n * BLOCK_SIZE_N
     accumulator = tl.zeros((BLOCK_SIZE_M, BLOCK_SIZE_N), dtype=tl.float32)
 
-    for ki in tl.range(k_tiles):
+    for ki in tl.range(k_tiles, warp_specialize=WARP_SPECIALIZE):
         offs_k = ki * BLOCK_SIZE_K
         a = a_desc.load([offs_am, offs_k])
         b = b_desc.load([offs_bn, offs_k])
@@ -512,7 +510,7 @@ def matmul_kernel_tma_clc(a_desc, b_desc, c_desc,  #
         c_desc.store([offs_am, offs_bn], accumulator)
 
 
-def matmul_tma_clc(a, b):
+def matmul_tma_clc(a, b, warp_specialize: bool):
     assert HAS_TMA_CLC, "CLC TMA requires an NVIDIA SM100+ GPU with tensor descriptor support"
     assert a.shape[1] == b.shape[1], "Incompatible dimensions"  # b is transposed
     assert a.dtype == b.dtype, "Incompatible dtypes"
@@ -534,6 +532,7 @@ def matmul_tma_clc(a, b):
         a_desc, b_desc, c_desc,  #
         M, N, K,  #
         FP8_OUTPUT=dtype == torch.float8_e4m3fn,  #
+        WARP_SPECIALIZE=warp_specialize,  #
         clc=True,  #
     )
     return c
@@ -745,7 +744,7 @@ def bench_fn(label, reps, warmup_reps, fn, *args):
     print(f"\rBenchmarking {label}: done")
 
 
-def bench(K, dtype, reps=10000, warmup_reps=10000, clc=False):
+def bench(K, dtype, reps=10000, warmup_reps=10000):
     M = 8192
     N = 8192
     a = torch.randn((M, K), device="cuda", dtype=torch.float16).to(dtype)
@@ -760,13 +759,13 @@ def bench(K, dtype, reps=10000, warmup_reps=10000, clc=False):
         bench_fn("torch", reps, warmup_reps, torch_matmul, a, b)
     bench_fn("naive", reps, warmup_reps, matmul, a, b.T)
     bench_fn("persistent", reps, warmup_reps, matmul_persistent, a, b.T)
-    if clc:
-        bench_fn("clc_tma", reps, warmup_reps, matmul_tma_clc, a, b)
     warp_specialize = [False, True] if HAS_WARP_SPECIALIZE else [False]
     for ws in warp_specialize:
         ws_str = "_ws" if ws else ""
         # disable on-host warpspec on Hopper
         if HAS_HOST_TENSOR_DESC and not (is_hopper() and ws):
+            if HAS_TMA_CLC:
+                bench_fn(f"clc_tma{ws_str}", reps, warmup_reps, lambda a, b: matmul_tma_clc(a, b, ws), a, b)
             bench_fn(f"tma_persistent{ws_str}", reps, warmup_reps, lambda a, b: matmul_tma_persistent(a, b, ws), a, b)
             bench_fn(f"tma{ws_str}", reps, warmup_reps, lambda a, b: matmul_tma(a, b, ws), a, b)
         if HAS_TENSOR_DESC:
@@ -785,7 +784,7 @@ def run_test(expect, fn, a, b, label, enabled=True):
     print(f"\r  {label}: {icon}  ")
 
 
-def validate(M, N, K, dtype, clc=False):
+def validate(M, N, K, dtype):
     print(f"{M=}, {N=}, {K=}, verification naive vs: ")
     a = torch.randn((M, K), device="cuda", dtype=torch.float16).to(dtype)
     b = torch.randn((K, N), device="cuda", dtype=torch.float16).to(dtype)
@@ -795,10 +794,9 @@ def validate(M, N, K, dtype, clc=False):
     run_test(naive_result, torch_matmul, a, b, "Torch", enabled=dtype == torch.float16)
     run_test(naive_result, device_blas_matmul, a, b, device_blas_name(), enabled=device_blas is not None)
     run_test(naive_result, matmul_persistent, a, b.T, "Persistent")
-    run_test(naive_result, matmul_tma_clc, a, b, "CLC TMA", enabled=clc)
-
     kernels = [
         (matmul_tma, "TMA", HAS_HOST_TENSOR_DESC),
+        (matmul_tma_clc, "CLC TMA", HAS_TMA_CLC),
         (matmul_tma_persistent, "TMA Persistent", HAS_HOST_TENSOR_DESC),
         (matmul_descriptor_persistent, "Tensor Descriptor Persistent", HAS_TENSOR_DESC),
     ]
@@ -831,11 +829,7 @@ if __name__ == "__main__":
     parser.add_argument("--K_range", type=int, nargs=2)
     parser.add_argument("--K_step", type=int, default=512)
     parser.add_argument("--prec", type=str, choices=["fp8", "fp16"], default="fp16")
-    parser.add_argument("--clc", action="store_true", help="Enable CLC scheduling on NVIDIA SM100+")
     args = parser.parse_args()
-
-    if args.clc and not HAS_TMA_CLC:
-        parser.error("--clc requires an NVIDIA SM100+ GPU with tensor descriptor support")
 
     if args.prec == 'fp8' and (not hasattr(torch, "float8_e4m3fn") or not is_cuda()):
         print("This example requires CUDA/HIP with fp8 support.")
@@ -848,12 +842,12 @@ if __name__ == "__main__":
 
         torch.manual_seed(0)
 
-        validate(32, 32, 32, dtype, clc=args.clc)
-        validate(8192, 8192, args.K_range[0], dtype, clc=args.clc)
+        validate(32, 32, 32, dtype)
+        validate(8192, 8192, args.K_range[0], dtype)
 
         proton.start("matmul", hook="triton")
         proton.deactivate()
         for K in range(args.K_range[0], args.K_range[1] + 1, args.K_step):
-            bench(K, dtype, clc=args.clc)
+            bench(K, dtype)
         proton.finalize()
         show_profile(args.prec, "matmul")

--- a/test/NVWS/aref-tmem-insertion.mlir
+++ b/test/NVWS/aref-tmem-insertion.mlir
@@ -1023,3 +1023,104 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.targ
     tt.return
   }
 }
+
+// -----
+
+#blocked_while_tmem_aref = #ttg.blocked<{sizePerThread = [1, 128], threadsPerWarp = [32, 1], warpsPerCTA = [4, 1], order = [0, 1]}>
+#shared_while_tmem_aref = #ttg.nvmma_shared<{swizzlingByteWidth = 128, transposed = false, elementBitWidth = 16}>
+#shared_while_tmem_aref_t = #ttg.nvmma_shared<{swizzlingByteWidth = 128, transposed = true, elementBitWidth = 16}>
+#smem_while_tmem_aref = #ttg.shared_memory
+#tmem_while_tmem_aref = #ttng.tensor_memory_encoding<blockM = 128, blockN = 128, colStride = 1>
+module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.target = "cuda:100", "ttg.threads-per-warp" = 32 : i32} {
+  // CHECK-LABEL: @while_tmem_aref_single_stage
+  tt.func @while_tmem_aref_single_stage(%run: i1, %ub: i32, %a: !ttg.memdesc<128x64xf16, #shared_while_tmem_aref, #smem_while_tmem_aref>, %b: !ttg.memdesc<64x128xf16, #shared_while_tmem_aref_t, #smem_while_tmem_aref>) {
+    %c0 = arith.constant 0 : i32
+    %c1 = arith.constant 1 : i32
+    %true = arith.constant true
+    %zero = arith.constant dense<0.000000e+00> : tensor<128x128xf32, #blocked_while_tmem_aref>
+    // CHECK: [[TMEM_BUF:%.*]] = ttng.tmem_alloc : () -> !ttg.memdesc<1x128x128xf32,
+    // CHECK-NEXT: [[TMEM_AREF:%.*]] = nvws.aref.create [[TMEM_BUF]]
+    // CHECK-NEXT: scf.while
+    %loop = scf.while (%keep_going = %run) : (i1) -> i1 {
+      scf.condition(%keep_going) %keep_going : i1
+    } do {
+    ^bb0(%keep_going: i1):
+      %acc, %token = ttng.tmem_alloc {ttg.partition = array<i32: 0, 1>} : () -> (!ttg.memdesc<128x128xf32, #tmem_while_tmem_aref, #ttng.tensor_memory, mutable>, !ttg.async.token)
+      // CHECK: [[TMEM_WRITE:%.*]], [[TMEM_PUT_TOKEN:%.*]] = nvws.aref.put.enter [[TMEM_AREF]] {ttg.partition = array<i32: 1>}
+      // CHECK-NEXT: [[TMEM_WRITE_BUF:%.*]] = nvws.aref.buffer [[TMEM_AREF]], [[TMEM_PUT_TOKEN]] {ttg.partition = array<i32: 1>}
+      // CHECK-NEXT: ttng.tmem_store {{.*}}, [[TMEM_WRITE_BUF]]
+      %stored = ttng.tmem_store %zero, %acc[%token], %true {ttg.partition = array<i32: 1>} : tensor<128x128xf32, #blocked_while_tmem_aref> -> !ttg.memdesc<128x128xf32, #tmem_while_tmem_aref, #ttng.tensor_memory, mutable>
+      // CHECK-NEXT: [[TMEM_INNER:%.*]] = scf.for {{.*}} iter_args([[TMEM_ITER_TOKEN:%.*]] = [[TMEM_PUT_TOKEN]])
+      %inner = scf.for %k = %c0 to %ub step %c1 iter_args(%acc_token = %stored) -> (!ttg.async.token) : i32 {
+        // CHECK: [[TMEM_MMA_BUF:%.*]] = nvws.aref.buffer [[TMEM_AREF]], [[TMEM_ITER_TOKEN]] {ttg.partition = array<i32: 1>}
+        // CHECK-NEXT: ttng.tc_gen5_mma {{.*}}, [[TMEM_MMA_BUF]]
+        %next_token = ttng.tc_gen5_mma %a, %b, %acc[%acc_token], %true, %true {ttg.partition = array<i32: 1>} : !ttg.memdesc<128x64xf16, #shared_while_tmem_aref, #smem_while_tmem_aref>, !ttg.memdesc<64x128xf16, #shared_while_tmem_aref_t, #smem_while_tmem_aref>, !ttg.memdesc<128x128xf32, #tmem_while_tmem_aref, #ttng.tensor_memory, mutable>
+        scf.yield {ttg.partition = array<i32: 1>} %next_token : !ttg.async.token
+      } {ttg.partition = array<i32: 1>, ttg.partition.outputs = [array<i32: 1>]}
+      // CHECK: nvws.aref.put.exit [[TMEM_AREF]], [[TMEM_INNER]] [#nvws.async_op<tc5mma>] {ttg.partition = array<i32: 1>}
+      // CHECK-NEXT: {{%.*}}, [[TMEM_GET_TOKEN:%.*]] = nvws.aref.get.enter [[TMEM_AREF]] {ttg.partition = array<i32: 0>}
+      // CHECK-NEXT: [[TMEM_READ_BUF:%.*]] = nvws.aref.buffer [[TMEM_AREF]], [[TMEM_GET_TOKEN]] {ttg.partition = array<i32: 0>}
+      // CHECK-NEXT: [[TMEM_VALUE:%.*]], {{%.*}} = ttng.tmem_load [[TMEM_READ_BUF]]
+      // CHECK-NEXT: nvws.aref.get.exit [[TMEM_AREF]], [[TMEM_GET_TOKEN]] [#nvws.async_op<none>] {ttg.partition = array<i32: 0>}
+      %value, %loaded = ttng.tmem_load %acc[%inner] {ttg.partition = array<i32: 0>} : !ttg.memdesc<128x128xf32, #tmem_while_tmem_aref, #ttng.tensor_memory, mutable> -> tensor<128x128xf32, #blocked_while_tmem_aref>
+      // CHECK-NEXT: "consume"([[TMEM_VALUE]])
+      "consume"(%value) {ttg.partition = array<i32: 0>} : (tensor<128x128xf32, #blocked_while_tmem_aref>) -> ()
+      scf.yield {ttg.partition = array<i32: 0, 1>} %keep_going : i1
+    // CHECK: } attributes {tt.warp_specialize
+    } attributes {tt.warp_specialize, ttg.partition = array<i32: 0, 1>, ttg.partition.outputs = [array<i32: 0, 1>], ttg.partition.stages = [0 : i32, 1 : i32], ttg.warp_specialize.tag = 0 : i32}
+    tt.return
+  }
+}
+
+// -----
+
+// A TMEM allocation hoisted above a While carries its async token through the
+// symmetric before/after signatures. The ARef protocol remains balanced on
+// both the loop backedge and the loop-exit path.
+#blocked_while_hoisted = #ttg.blocked<{sizePerThread = [1, 128], threadsPerWarp = [32, 1], warpsPerCTA = [4, 1], order = [0, 1]}>
+#shared_while_hoisted = #ttg.nvmma_shared<{swizzlingByteWidth = 128, transposed = false, elementBitWidth = 16}>
+#shared_while_hoisted_t = #ttg.nvmma_shared<{swizzlingByteWidth = 128, transposed = true, elementBitWidth = 16}>
+#smem_while_hoisted = #ttg.shared_memory
+#tmem_while_hoisted = #ttng.tensor_memory_encoding<blockM = 128, blockN = 128, colStride = 1>
+module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.target = "cuda:100", "ttg.threads-per-warp" = 32 : i32} {
+  // CHECK-LABEL: @while_hoisted_tmem_aref_backedge
+  tt.func @while_hoisted_tmem_aref_backedge(%initial_pid: i32, %run: i1, %ub: i32, %a: !ttg.memdesc<128x64xf16, #shared_while_hoisted, #smem_while_hoisted>, %b: !ttg.memdesc<64x128xf16, #shared_while_hoisted_t, #smem_while_hoisted>) {
+    %c0 = arith.constant 0 : i32
+    %c1 = arith.constant 1 : i32
+    %false = arith.constant false
+    %true = arith.constant true
+    %zero = arith.constant dense<0.000000e+00> : tensor<128x128xf32, #blocked_while_hoisted>
+    // CHECK: [[TMEM_BUF:%.*]] = ttng.tmem_alloc : () -> !ttg.memdesc<1x128x128xf32,
+    // CHECK-NEXT: [[TMEM_AREF:%.*]] = nvws.aref.create [[TMEM_BUF]]
+    // CHECK: [[ROOT_BUF:%.*]], [[ROOT_TOKEN:%.*]] = nvws.aref.put.enter [[TMEM_AREF]]
+    // CHECK-NEXT: [[ROOT_VIEW:%.*]] = nvws.aref.buffer [[TMEM_AREF]], [[ROOT_TOKEN]]
+    // CHECK-NEXT: ttng.tmem_store {{.*}}, [[ROOT_VIEW]]
+    %acc, %token = ttng.tmem_alloc %zero : (tensor<128x128xf32, #blocked_while_hoisted>) -> (!ttg.memdesc<128x128xf32, #tmem_while_hoisted, #ttng.tensor_memory, mutable>, !ttg.async.token)
+    // CHECK: [[WHILE:%.*]]:3 = scf.while ({{.*}}, {{.*}}, [[WHILE_TOKEN:%.*]] = [[ROOT_TOKEN]])
+    %loop:3 = scf.while (%pid = %initial_pid, %keep_going = %run, %acc_token = %token) : (i32, i1, !ttg.async.token) -> (i32, i1, !ttg.async.token) {
+      // CHECK-NEXT: scf.condition({{.*}}) {{.*}}, {{.*}}, [[WHILE_TOKEN]] : i32, i1, !ttg.async.token
+      scf.condition(%keep_going) {ttg.partition = array<i32: 0, 1>} %pid, %keep_going, %acc_token : i32, i1, !ttg.async.token
+    } do {
+    // CHECK: ^bb0({{.*}}, {{.*}}, [[AFTER_TOKEN:%.*]]: !ttg.async.token):
+    ^bb0(%pid: i32, %keep_going: i1, %acc_token: !ttg.async.token):
+      %inner:2 = scf.for %k = %c0 to %ub step %c1 iter_args(%use_acc = %false, %iter_token = %acc_token) -> (i1, !ttg.async.token) : i32 {
+        // CHECK: [[MMA_BUF:%.*]] = nvws.aref.buffer [[TMEM_AREF]], {{%.*}} {ttg.partition = array<i32: 1>}
+        // CHECK-NEXT: ttng.tc_gen5_mma {{.*}}, [[MMA_BUF]]
+        %next_token = ttng.tc_gen5_mma %a, %b, %acc[%iter_token], %use_acc, %true {ttg.partition = array<i32: 1>} : !ttg.memdesc<128x64xf16, #shared_while_hoisted, #smem_while_hoisted>, !ttg.memdesc<64x128xf16, #shared_while_hoisted_t, #smem_while_hoisted>, !ttg.memdesc<128x128xf32, #tmem_while_hoisted, #ttng.tensor_memory, mutable>
+        scf.yield {ttg.partition = array<i32: 1>} %true, %next_token : i1, !ttg.async.token
+      } {ttg.partition = array<i32: 1>, ttg.partition.outputs = [array<i32: 1>, array<i32: 1>]}
+      // CHECK: nvws.aref.put.exit [[TMEM_AREF]]
+      // CHECK-NEXT: {{%.*}}, [[GET_TOKEN:%.*]] = nvws.aref.get.enter [[TMEM_AREF]] {ttg.partition = array<i32: 0>}
+      // CHECK: ttng.tmem_load
+      // CHECK-NEXT: nvws.aref.get.exit [[TMEM_AREF]], [[GET_TOKEN]]
+      %value, %loaded = ttng.tmem_load %acc[%inner#1] {ttg.partition = array<i32: 0>} : !ttg.memdesc<128x128xf32, #tmem_while_hoisted, #ttng.tensor_memory, mutable> -> tensor<128x128xf32, #blocked_while_hoisted>
+      "consume"(%value) {ttg.partition = array<i32: 0>} : (tensor<128x128xf32, #blocked_while_hoisted>) -> ()
+      // CHECK: {{%.*}}, [[BACKEDGE_TOKEN:%.*]] = nvws.aref.put.enter [[TMEM_AREF]] {ttg.partition = array<i32: 1>}
+      // CHECK-NEXT: scf.yield {{.*}} [[BACKEDGE_TOKEN]]
+      scf.yield {ttg.partition = array<i32: 0, 1>} %pid, %run, %loaded : i32, i1, !ttg.async.token
+    } attributes {tt.disallow_acc_multi_buffer, tt.warp_specialize, ttg.partition = array<i32: 0, 1>, ttg.partition.outputs = [array<i32: 0, 1>, array<i32: 0, 1>, array<i32: 1>], ttg.partition.stages = [0 : i32, 1 : i32], ttg.warp_specialize.tag = 0 : i32}
+    // CHECK: nvws.aref.put.exit [[TMEM_AREF]], [[WHILE]]#2
+    // CHECK: nvws.aref.get.enter [[TMEM_AREF]] {ttg.partition = array<i32: 0>
+    tt.return
+  }
+}

--- a/test/NVWS/assign_stage_phase.mlir
+++ b/test/NVWS/assign_stage_phase.mlir
@@ -174,6 +174,59 @@ module attributes {"ttg.target" = "cuda:0", "ttg.num-ctas" = 1 : i32, "ttg.num-w
 
 // -----
 
+#shared_clc_stage = #ttg.swizzled_shared<{vec = 1, perPhase = 1, maxPhase = 1, order = [0]}>
+#smem_clc_stage = #ttg.shared_memory
+module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.target = "cuda:100"} {
+  // CHECK-LABEL: @clc_collective_while_stage_phase
+  tt.func @clc_collective_while_stage_phase(%initial_work: i1, %initial_pid: i32) {
+    %ring = ttg.local_alloc {alignment = 16 : i32} : () -> !ttg.memdesc<2x2xi64, #shared_clc_stage, #smem_clc_stage, mutable>
+    %aref = nvws.aref.create %ring : <[!ttg.memdesc<2x2xi64, #shared_clc_stage, #smem_clc_stage, mutable>]>
+    // CHECK: [[C1:%.*]] = arith.constant 1 : i32
+    // CHECK-NEXT: [[C0:%.*]] = arith.constant 0 : i32
+    // CHECK-NEXT: {{%.*}}:6 = scf.while ({{%.*}} = {{%.*}}, {{%.*}} = {{%.*}}, [[PUT_STAGE:%.*]] = [[C1]], [[PUT_PHASE:%.*]] = [[C0]], [[GET_STAGE:%.*]] = [[C1]], [[GET_PHASE:%.*]] = [[C1]])
+    %loop:2 = scf.while (%has_work = %initial_work, %pid = %initial_pid) : (i1, i32) -> (i1, i32) {
+      // CHECK: scf.condition({{%.*}}) {ttg.partition = array<i32: 0, 1, 2, 3>} {{%.*}}, {{%.*}}, [[PUT_STAGE]], [[PUT_PHASE]], [[GET_STAGE]], [[GET_PHASE]]
+      scf.condition(%has_work) %has_work, %pid : i1, i32
+    } do {
+    ^bb0(%has_work: i1, %pid: i32):
+      // CHECK: [[PUT_ONE:%.*]] = arith.constant {ttg.partition = array<i32: 3>} 1 : i32
+      // CHECK-NEXT: [[PUT_INC:%.*]] = arith.addi [[PUT_STAGE]], [[PUT_ONE]] {ttg.partition = array<i32: 3>}
+      // CHECK-NEXT: [[PUT_TWO:%.*]] = arith.constant {ttg.partition = array<i32: 3>} 2 : i32
+      // CHECK-NEXT: [[PUT_WRAP:%.*]] = arith.cmpi eq, [[PUT_INC]], [[PUT_TWO]] {ttg.partition = array<i32: 3>}
+      // CHECK-NEXT: [[PUT_ZERO:%.*]] = arith.constant {ttg.partition = array<i32: 3>} 0 : i32
+      // CHECK-NEXT: [[PUT_SLOT:%.*]] = arith.select [[PUT_WRAP]], [[PUT_ZERO]], [[PUT_INC]] {ttg.partition = array<i32: 3>}
+      // CHECK-NEXT: [[PUT_TOGGLED:%.*]] = arith.xori [[PUT_PHASE]], [[PUT_ONE]] {ttg.partition = array<i32: 3>}
+      // CHECK-NEXT: [[PUT_NEXT_PHASE:%.*]] = arith.select [[PUT_WRAP]], [[PUT_TOGGLED]], [[PUT_PHASE]] {ttg.partition = array<i32: 3>}
+      // CHECK-NEXT: [[WRITE:%.*]], [[PUT_TOKEN:%.*]] = nvws.aref.put.enter {{%.*}}[[[PUT_SLOT]], [[PUT_NEXT_PHASE]]] {ttg.partition = array<i32: 3>}
+      %write, %put_token = nvws.aref.put.enter %aref {ttg.partition = array<i32: 3>} : <[!ttg.memdesc<2x2xi64, #shared_clc_stage, #smem_clc_stage, mutable>]> -> !ttg.memdesc<2xi64, #shared_clc_stage, #smem_clc_stage, mutable, 2x2>, !ttg.async.token
+      nvws.clc_try_cancel %write {ttg.partition = array<i32: 3>} : !ttg.memdesc<2xi64, #shared_clc_stage, #smem_clc_stage, mutable, 2x2>
+      // CHECK: nvws.aref.put.exit {{%.*}}[[[PUT_SLOT]]], [[PUT_TOKEN]] [#nvws.async_op<clc>] {ttg.partition = array<i32: 3>}
+      nvws.aref.put.exit %aref, %put_token [#nvws.async_op<clc>] {ttg.partition = array<i32: 3>} : <[!ttg.memdesc<2x2xi64, #shared_clc_stage, #smem_clc_stage, mutable>]>, !ttg.async.token
+      // CHECK-NEXT: [[GET_ONE:%.*]] = arith.constant {ttg.partition = array<i32: 0, 1, 2, 3>} 1 : i32
+      // CHECK-NEXT: [[GET_INC:%.*]] = arith.addi [[GET_STAGE]], [[GET_ONE]] {ttg.partition = array<i32: 0, 1, 2, 3>}
+      // CHECK-NEXT: [[GET_TWO:%.*]] = arith.constant {ttg.partition = array<i32: 0, 1, 2, 3>} 2 : i32
+      // CHECK-NEXT: [[GET_WRAP:%.*]] = arith.cmpi eq, [[GET_INC]], [[GET_TWO]] {ttg.partition = array<i32: 0, 1, 2, 3>}
+      // CHECK-NEXT: [[GET_ZERO:%.*]] = arith.constant {ttg.partition = array<i32: 0, 1, 2, 3>} 0 : i32
+      // CHECK-NEXT: [[GET_SLOT:%.*]] = arith.select [[GET_WRAP]], [[GET_ZERO]], [[GET_INC]] {ttg.partition = array<i32: 0, 1, 2, 3>}
+      // CHECK-NEXT: [[GET_TOGGLED:%.*]] = arith.xori [[GET_PHASE]], [[GET_ONE]] {ttg.partition = array<i32: 0, 1, 2, 3>}
+      // CHECK-NEXT: [[GET_NEXT_PHASE:%.*]] = arith.select [[GET_WRAP]], [[GET_TOGGLED]], [[GET_PHASE]] {ttg.partition = array<i32: 0, 1, 2, 3>}
+      // CHECK-NEXT: {{%.*}}, [[GET_TOKEN:%.*]] = nvws.aref.get.enter {{%.*}}[[[GET_SLOT]], [[GET_NEXT_PHASE]]] {ttg.partition = array<i32: 0, 1, 2, 3>}
+      %read, %get_token = nvws.aref.get.enter %aref {ttg.partition = array<i32: 0, 1, 2, 3>} : <[!ttg.memdesc<2x2xi64, #shared_clc_stage, #smem_clc_stage, mutable>]> -> !ttg.memdesc<2xi64, #shared_clc_stage, #smem_clc_stage, mutable, 2x2>, !ttg.async.token
+      %raw = ttng.clc_load_result %read {ttg.partition = array<i32: 0, 1, 2, 3>} : !ttg.memdesc<2xi64, #shared_clc_stage, #smem_clc_stage, mutable, 2x2> -> i128
+      // CHECK: nvws.aref.get.exit {{%.*}}[[[GET_SLOT]]], [[GET_TOKEN]] [#nvws.async_op<none>] {ttg.partition = array<i32: 0, 1, 2, 3>}
+      nvws.aref.get.exit %aref, %get_token [#nvws.async_op<none>] {ttg.partition = array<i32: 0, 1, 2, 3>} : <[!ttg.memdesc<2x2xi64, #shared_clc_stage, #smem_clc_stage, mutable>]>, !ttg.async.token
+      %next_work = ttng.clc_is_canceled %raw {ttg.partition = array<i32: 0, 1, 2, 3>} : i128 -> i1
+      %next_pid = ttng.clc_get_program_id %raw, x {ttg.partition = array<i32: 0, 1, 2, 3>} : i128 -> i32
+      // CHECK: scf.yield {ttg.partition = array<i32: 0, 1, 2, 3>} {{%.*}}, {{%.*}}, [[PUT_SLOT]], [[PUT_NEXT_PHASE]], [[GET_SLOT]], [[GET_NEXT_PHASE]]
+      scf.yield {ttg.partition = array<i32: 0, 1, 2, 3>} %next_work, %next_pid : i1, i32
+    // CHECK: attributes {{.*}}ttg.partition.outputs = [array<i32: 0, 1, 2, 3>, array<i32: 0, 1, 2, 3>, array<i32: 3>, array<i32: 3>, array<i32: 0, 1, 2, 3>, array<i32: 0, 1, 2, 3>]
+    } attributes {tt.warp_specialize, ttg.partition = array<i32: 0, 1, 2, 3>, ttg.partition.outputs = [array<i32: 0, 1, 2, 3>, array<i32: 0, 1, 2, 3>], ttg.partition.stages = [0 : i32, 1 : i32, 1 : i32, 0 : i32], ttg.warp_specialize.tag = 0 : i32}
+    tt.return
+  }
+}
+
+// -----
+
 
 #blocked = #ttg.blocked<{sizePerThread = [1, 128], threadsPerWarp = [32, 1], warpsPerCTA = [4, 1], order = [0, 1]}>
 #blocked1 = #ttg.blocked<{sizePerThread = [1, 1], threadsPerWarp = [1, 32], warpsPerCTA = [2, 2], order = [1, 0]}>
@@ -305,6 +358,45 @@ module attributes {"ttg.num-warps" = 4 : i32, ttg.target = "cuda:100"} {
       scf.yield %token_6 : !ttg.async.token
     } {tt.num_stages = 2 : i32, tt.warp_specialize, ttg.partition.stages = [0 : i32, 1 : i32, 0 : i32], ttg.warp_specialize.tag = 4 : i32, ttg.partition = array<i32: 0, 1, 2>, ttg.partition.outputs = [array<i32: 1>]}
     nvws.aref.put.exit %0[%c0_i32], %3 [#nvws.async_op<none>] : <[!ttg.memdesc<2x128x128xf32, #tmem, #ttng.tensor_memory, mutable>]>, !ttg.async.token
+    tt.return
+  }
+}
+
+// -----
+
+// One ordinary multi-partition get owns one collective stage/phase pair.
+#generic_collective_shared = #ttg.swizzled_shared<{vec = 1, perPhase = 1, maxPhase = 1, order = [0]}>
+#generic_collective_smem = #ttg.shared_memory
+module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.target = "cuda:100"} {
+  // CHECK-LABEL: @generic_collective_while_stage_phase
+  tt.func @generic_collective_while_stage_phase(%initial_work: i1, %initial_pid: i32) {
+    %ring = ttg.local_alloc : () -> !ttg.memdesc<2x4xi32, #generic_collective_shared, #generic_collective_smem, mutable>
+    %aref = nvws.aref.create %ring : <[!ttg.memdesc<2x4xi32, #generic_collective_shared, #generic_collective_smem, mutable>]>
+    // CHECK: [[C1:%.*]] = arith.constant 1 : i32
+    // CHECK-NEXT: [[C0:%.*]] = arith.constant 0 : i32
+    // CHECK-NEXT: {{%.*}}:6 = scf.while ({{%.*}} = {{%.*}}, {{%.*}} = {{%.*}}, [[PUT_STAGE:%.*]] = [[C1]], [[PUT_PHASE:%.*]] = [[C0]], [[GET_STAGE:%.*]] = [[C1]], [[GET_PHASE:%.*]] = [[C1]])
+    %loop:2 = scf.while (%has_work = %initial_work, %pid = %initial_pid) : (i1, i32) -> (i1, i32) {
+      // CHECK-NEXT: scf.condition({{%.*}}) {{.*}} {{%.*}}, {{%.*}}, [[PUT_STAGE]], [[PUT_PHASE]], [[GET_STAGE]], [[GET_PHASE]]
+      scf.condition(%has_work) %has_work, %pid : i1, i32
+    } do {
+    // CHECK: ^bb0({{%.*}}: i1, {{%.*}}: i32, [[AFTER_PUT_STAGE:%.*]]: i32, [[AFTER_PUT_PHASE:%.*]]: i32, [[AFTER_GET_STAGE:%.*]]: i32, [[AFTER_GET_PHASE:%.*]]: i32):
+    ^bb0(%has_work: i1, %pid: i32):
+      %write, %put_token = nvws.aref.put.enter %aref {ttg.partition = array<i32: 3>} : <[!ttg.memdesc<2x4xi32, #generic_collective_shared, #generic_collective_smem, mutable>]> -> !ttg.memdesc<4xi32, #generic_collective_shared, #generic_collective_smem, mutable, 2x4>, !ttg.async.token
+      "produce"(%write) {ttg.partition = array<i32: 3>} : (!ttg.memdesc<4xi32, #generic_collective_shared, #generic_collective_smem, mutable, 2x4>) -> ()
+      nvws.aref.put.exit %aref, %put_token [#nvws.async_op<none>] {ttg.partition = array<i32: 3>} : <[!ttg.memdesc<2x4xi32, #generic_collective_shared, #generic_collective_smem, mutable>]>, !ttg.async.token
+      // CHECK: [[GET_ONE:%.*]] = arith.constant {ttg.partition = array<i32: 0, 1, 2>} 1 : i32
+      // CHECK-NEXT: [[GET_INC:%.*]] = arith.addi [[AFTER_GET_STAGE]], [[GET_ONE]] {ttg.partition = array<i32: 0, 1, 2>}
+      // CHECK: [[GET_SLOT:%.*]] = arith.select {{%.*}}, {{%.*}}, [[GET_INC]] {ttg.partition = array<i32: 0, 1, 2>}
+      // CHECK: [[GET_NEXT_PHASE:%.*]] = arith.select {{%.*}}, {{%.*}}, [[AFTER_GET_PHASE]] {ttg.partition = array<i32: 0, 1, 2>}
+      // CHECK: {{%.*}}, [[GET_TOKEN:%.*]] = nvws.aref.get.enter {{%.*}}[[[GET_SLOT]], [[GET_NEXT_PHASE]]] {ttg.partition = array<i32: 0, 1, 2>}
+      %read, %get_token = nvws.aref.get.enter %aref {ttg.partition = array<i32: 0, 1, 2>} : <[!ttg.memdesc<2x4xi32, #generic_collective_shared, #generic_collective_smem, mutable>]> -> !ttg.memdesc<4xi32, #generic_collective_shared, #generic_collective_smem, mutable, 2x4>, !ttg.async.token
+      "consume"(%read) {ttg.partition = array<i32: 0, 1, 2>} : (!ttg.memdesc<4xi32, #generic_collective_shared, #generic_collective_smem, mutable, 2x4>) -> ()
+      // CHECK: nvws.aref.get.exit {{%.*}}[[[GET_SLOT]]], [[GET_TOKEN]] [#nvws.async_op<none>] {ttg.partition = array<i32: 0, 1, 2>}
+      nvws.aref.get.exit %aref, %get_token [#nvws.async_op<none>] {ttg.partition = array<i32: 0, 1, 2>} : <[!ttg.memdesc<2x4xi32, #generic_collective_shared, #generic_collective_smem, mutable>]>, !ttg.async.token
+      // CHECK: scf.yield {ttg.partition = array<i32: 0, 1, 2, 3>} {{%.*}}, {{%.*}}, {{%.*}}, {{%.*}}, [[GET_SLOT]], [[GET_NEXT_PHASE]]
+      scf.yield {ttg.partition = array<i32: 0, 1, 2, 3>} %has_work, %pid : i1, i32
+    // CHECK: attributes {{.*}}ttg.partition.outputs = [array<i32: 0, 1, 2, 3>, array<i32: 0, 1, 2, 3>, array<i32: 3>, array<i32: 3>, array<i32: 0, 1, 2>, array<i32: 0, 1, 2>]
+    } attributes {tt.warp_specialize, ttg.partition = array<i32: 0, 1, 2, 3>, ttg.partition.outputs = [array<i32: 0, 1, 2, 3>, array<i32: 0, 1, 2, 3>], ttg.partition.stages = [0 : i32, 1 : i32, 1 : i32, 0 : i32], ttg.warp_specialize.tag = 0 : i32}
     tt.return
   }
 }

--- a/test/NVWS/hoist_tmem_store.mlir
+++ b/test/NVWS/hoist_tmem_store.mlir
@@ -1,4 +1,5 @@
 // RUN: triton-opt %s -split-input-file --allow-unregistered-dialect --nvws-hoist-tmem-store | FileCheck %s
+// RUN: triton-opt %s -split-input-file --allow-unregistered-dialect --nvws-hoist-tmem-store --nvws-insert-tmem-aref --verify-diagnostics
 
 #blocked = #ttg.blocked<{sizePerThread = [1, 128], threadsPerWarp = [32, 1], warpsPerCTA = [4, 1], order = [0, 1]}>
 #blocked1 = #ttg.blocked<{sizePerThread = [1, 1], threadsPerWarp = [1, 32], warpsPerCTA = [1, 4], order = [1, 0]}>
@@ -92,4 +93,122 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.targ
     tt.return
   }
 
+}
+
+// -----
+
+#blocked_while_tmem = #ttg.blocked<{sizePerThread = [1, 128], threadsPerWarp = [32, 1], warpsPerCTA = [4, 1], order = [0, 1]}>
+#shared_while_tmem = #ttg.nvmma_shared<{swizzlingByteWidth = 128, transposed = false, elementBitWidth = 16}>
+#shared_while_tmem_t = #ttg.nvmma_shared<{swizzlingByteWidth = 128, transposed = true, elementBitWidth = 16}>
+#smem_while_tmem = #ttg.shared_memory
+#tmem_while_tmem = #ttng.tensor_memory_encoding<blockM = 128, blockN = 128, colStride = 1>
+module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.target = "cuda:100", "ttg.threads-per-warp" = 32 : i32} {
+  // CHECK-LABEL: @while_tmem_store_hoisted
+  tt.func @while_tmem_store_hoisted(%run: i1, %ub: i32, %a: !ttg.memdesc<128x64xf16, #shared_while_tmem, #smem_while_tmem>, %b: !ttg.memdesc<64x128xf16, #shared_while_tmem_t, #smem_while_tmem>) {
+    %c0 = arith.constant 0 : i32
+    %c1 = arith.constant 1 : i32
+    %false = arith.constant false
+    %true = arith.constant true
+    %zero = arith.constant dense<0.000000e+00> : tensor<128x128xf32, #blocked_while_tmem>
+    // CHECK: [[ACC:%.*]], [[TOKEN:%.*]] = ttng.tmem_alloc %{{.*}} :
+    // CHECK-NOT: ttng.tmem_store
+    // CHECK: scf.while ({{.*}}, [[BEFORE_TOKEN:%.*]] = [[TOKEN]])
+    %loop = scf.while (%keep_going = %run) : (i1) -> i1 {
+      // CHECK: scf.condition({{.*}}) {{.*}} [[BEFORE_TOKEN]]
+      scf.condition(%keep_going) %keep_going : i1
+    } do {
+    // CHECK: ^bb0({{.*}}, [[AFTER_TOKEN:%.*]]: !ttg.async.token):
+    ^bb0(%keep_going: i1):
+      %acc, %token = ttng.tmem_alloc %zero {ttg.partition = array<i32: 0, 1>} : (tensor<128x128xf32, #blocked_while_tmem>) -> (!ttg.memdesc<128x128xf32, #tmem_while_tmem, #ttng.tensor_memory, mutable>, !ttg.async.token)
+      // CHECK: scf.for {{.*}}iter_args({{.*}} = {{.*}}, {{.*}} = [[AFTER_TOKEN]])
+      %inner:2 = scf.for %k = %c0 to %ub step %c1 iter_args(%use_acc = %false, %acc_token = %token) -> (i1, !ttg.async.token) : i32 {
+        // CHECK: ttng.tc_gen5_mma {{.*}}, [[ACC]]
+        %next_token = ttng.tc_gen5_mma %a, %b, %acc[%acc_token], %use_acc, %true {ttg.partition = array<i32: 1>} : !ttg.memdesc<128x64xf16, #shared_while_tmem, #smem_while_tmem>, !ttg.memdesc<64x128xf16, #shared_while_tmem_t, #smem_while_tmem>, !ttg.memdesc<128x128xf32, #tmem_while_tmem, #ttng.tensor_memory, mutable>
+        // CHECK: scf.yield {{.*}} : i1, !ttg.async.token
+        scf.yield {ttg.partition = array<i32: 1>} %true, %next_token : i1, !ttg.async.token
+      } {ttg.partition = array<i32: 1>, ttg.partition.outputs = [array<i32: 1>, array<i32: 1>]}
+      scf.yield {ttg.partition = array<i32: 0, 1>} %keep_going : i1
+    // CHECK: ttg.partition.outputs = [array<i32: 0, 1>, array<i32: 1>]
+    } attributes {tt.warp_specialize, ttg.partition = array<i32: 0, 1>, ttg.partition.outputs = [array<i32: 0, 1>], ttg.partition.stages = [0 : i32, 1 : i32], ttg.warp_specialize.tag = 0 : i32}
+    tt.return
+  }
+}
+
+// -----
+
+// A loop-carried bound is safe when an assumption proves that the MMA loop
+// executes at least once on every While iteration.
+#blocked_while_positive = #ttg.blocked<{sizePerThread = [1, 128], threadsPerWarp = [32, 1], warpsPerCTA = [4, 1], order = [0, 1]}>
+#shared_while_positive = #ttg.nvmma_shared<{swizzlingByteWidth = 128, transposed = false, elementBitWidth = 16}>
+#shared_while_positive_t = #ttg.nvmma_shared<{swizzlingByteWidth = 128, transposed = true, elementBitWidth = 16}>
+#smem_while_positive = #ttg.shared_memory
+#tmem_while_positive = #ttng.tensor_memory_encoding<blockM = 128, blockN = 128, colStride = 1>
+module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.target = "cuda:100", "ttg.threads-per-warp" = 32 : i32} {
+  // CHECK-LABEL: @while_tmem_store_varying_positive_trip_count_hoisted
+  tt.func @while_tmem_store_varying_positive_trip_count_hoisted(%run: i1, %initial_ub: i32, %a: !ttg.memdesc<128x64xf16, #shared_while_positive, #smem_while_positive>, %b: !ttg.memdesc<64x128xf16, #shared_while_positive_t, #smem_while_positive>) {
+    %c0 = arith.constant 0 : i32
+    %c1 = arith.constant 1 : i32
+    %false = arith.constant false
+    %true = arith.constant true
+    %zero = arith.constant dense<0.000000e+00> : tensor<128x128xf32, #blocked_while_positive>
+    // CHECK: [[ACC:%.*]], [[TOKEN:%.*]] = ttng.tmem_alloc %{{.*}} :
+    // CHECK-NOT: ttng.tmem_store
+    // CHECK: scf.while ({{.*}}, {{.*}}, {{%.*}} = [[TOKEN]])
+    %loop:2 = scf.while (%keep_going = %run, %ub = %initial_ub) : (i1, i32) -> (i1, i32) {
+      scf.condition(%keep_going) %keep_going, %ub : i1, i32
+    } do {
+    ^bb0(%keep_going: i1, %ub: i32):
+      %positive = arith.cmpi sgt, %ub, %c0 : i32
+      llvm.intr.assume %positive : i1
+      %acc, %token = ttng.tmem_alloc {ttg.partition = array<i32: 0, 1>} : () -> (!ttg.memdesc<128x128xf32, #tmem_while_positive, #ttng.tensor_memory, mutable>, !ttg.async.token)
+      %stored = ttng.tmem_store %zero, %acc[%token], %true {ttg.partition = array<i32: 0>} : tensor<128x128xf32, #blocked_while_positive> -> !ttg.memdesc<128x128xf32, #tmem_while_positive, #ttng.tensor_memory, mutable>
+      // CHECK: scf.for {{.*}}iter_args({{.*}} = {{.*}}, {{.*}} = {{%.*}})
+      %inner:2 = scf.for %k = %c0 to %ub step %c1 iter_args(%use_acc = %false, %acc_token = %stored) -> (i1, !ttg.async.token) : i32 {
+        // CHECK: ttng.tc_gen5_mma {{.*}}, [[ACC]]
+        %next_token = ttng.tc_gen5_mma %a, %b, %acc[%acc_token], %use_acc, %true {ttg.partition = array<i32: 1>} : !ttg.memdesc<128x64xf16, #shared_while_positive, #smem_while_positive>, !ttg.memdesc<64x128xf16, #shared_while_positive_t, #smem_while_positive>, !ttg.memdesc<128x128xf32, #tmem_while_positive, #ttng.tensor_memory, mutable>
+        scf.yield {ttg.partition = array<i32: 1>} %true, %next_token : i1, !ttg.async.token
+      } {ttg.partition = array<i32: 1>, ttg.partition.outputs = [array<i32: 1>, array<i32: 1>]}
+      scf.yield {ttg.partition = array<i32: 0, 1>} %keep_going, %ub : i1, i32
+    } attributes {tt.warp_specialize, ttg.partition = array<i32: 0, 1>, ttg.partition.outputs = [array<i32: 0, 1>, array<i32: 0, 1>], ttg.partition.stages = [0 : i32, 1 : i32], ttg.warp_specialize.tag = 0 : i32}
+    tt.return
+  }
+}
+
+// -----
+
+// A bound recomputed in the While body may vary independently on every
+// iteration even when it has no SSA dependency on While-carried state.
+#blocked_while_body_bound = #ttg.blocked<{sizePerThread = [1, 128], threadsPerWarp = [32, 1], warpsPerCTA = [4, 1], order = [0, 1]}>
+#shared_while_body_bound = #ttg.nvmma_shared<{swizzlingByteWidth = 128, transposed = false, elementBitWidth = 16}>
+#shared_while_body_bound_t = #ttg.nvmma_shared<{swizzlingByteWidth = 128, transposed = true, elementBitWidth = 16}>
+#smem_while_body_bound = #ttg.shared_memory
+#tmem_while_body_bound = #ttng.tensor_memory_encoding<blockM = 128, blockN = 128, colStride = 1>
+module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.target = "cuda:100", "ttg.threads-per-warp" = 32 : i32} {
+  // CHECK-LABEL: @while_tmem_store_body_bound_not_hoisted
+  tt.func @while_tmem_store_body_bound_not_hoisted(%run: i1, %a: !ttg.memdesc<128x64xf16, #shared_while_body_bound, #smem_while_body_bound>, %b: !ttg.memdesc<64x128xf16, #shared_while_body_bound_t, #smem_while_body_bound>) {
+    %c0 = arith.constant 0 : i32
+    %c1 = arith.constant 1 : i32
+    %false = arith.constant false
+    %true = arith.constant true
+    %zero = arith.constant dense<0.000000e+00> : tensor<128x128xf32, #blocked_while_body_bound>
+    // CHECK: scf.while
+    %loop = scf.while (%keep_going = %run) : (i1) -> i1 {
+      scf.condition(%keep_going) %keep_going : i1
+    } do {
+    // CHECK: ^bb0
+    ^bb0(%keep_going: i1):
+      // CHECK: "varying_bound"
+      %ub = "varying_bound"() : () -> i32
+      // CHECK: ttng.tmem_alloc %{{.*}} {ttg.partition = array<i32: 1>}
+      // CHECK-NOT: ttng.tmem_store
+      %acc, %token = ttng.tmem_alloc {ttg.partition = array<i32: 0, 1>} : () -> (!ttg.memdesc<128x128xf32, #tmem_while_body_bound, #ttng.tensor_memory, mutable>, !ttg.async.token)
+      %stored = ttng.tmem_store %zero, %acc[%token], %true {ttg.partition = array<i32: 0>} : tensor<128x128xf32, #blocked_while_body_bound> -> !ttg.memdesc<128x128xf32, #tmem_while_body_bound, #ttng.tensor_memory, mutable>
+      %inner:2 = scf.for %k = %c0 to %ub step %c1 iter_args(%use_acc = %false, %acc_token = %stored) -> (i1, !ttg.async.token) : i32 {
+        %next_token = ttng.tc_gen5_mma %a, %b, %acc[%acc_token], %use_acc, %true {ttg.partition = array<i32: 1>} : !ttg.memdesc<128x64xf16, #shared_while_body_bound, #smem_while_body_bound>, !ttg.memdesc<64x128xf16, #shared_while_body_bound_t, #smem_while_body_bound>, !ttg.memdesc<128x128xf32, #tmem_while_body_bound, #ttng.tensor_memory, mutable>
+        scf.yield {ttg.partition = array<i32: 1>} %true, %next_token : i1, !ttg.async.token
+      } {ttg.partition = array<i32: 1>, ttg.partition.outputs = [array<i32: 1>, array<i32: 1>]}
+      scf.yield {ttg.partition = array<i32: 0, 1>} %keep_going : i1
+    } attributes {tt.warp_specialize, ttg.partition = array<i32: 0, 1>, ttg.partition.outputs = [array<i32: 0, 1>], ttg.partition.stages = [0 : i32, 1 : i32], ttg.warp_specialize.tag = 0 : i32}
+    tt.return
+  }
 }

--- a/test/NVWS/insert_aref.mlir
+++ b/test/NVWS/insert_aref.mlir
@@ -231,6 +231,101 @@ module attributes {"ttg.num-warps" = 4 : i32, ttg.target = "cuda:100"} {
 
 // -----
 
+#blocked_while_aref = #ttg.blocked<{sizePerThread = [1], threadsPerWarp = [32], warpsPerCTA = [4], order = [0]}>
+module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32} {
+  // CHECK-LABEL: @while_aref_allocation_before_root
+  tt.func @while_aref_allocation_before_root(%run: i1) {
+    // CHECK: [[WHILE_BUF:%.*]] = ttg.local_alloc
+    // CHECK-NEXT: [[WHILE_AREF:%.*]] = nvws.aref.create [[WHILE_BUF]]
+    // CHECK-NEXT: scf.while
+    scf.while (%keep_going = %run) : (i1) -> i1 {
+      scf.condition(%keep_going) %keep_going : i1
+    } do {
+    ^bb0(%keep_going: i1):
+      // CHECK: [[WHILE_PUT:%.*]], [[WHILE_PUT_TOKEN:%.*]] = nvws.aref.put.enter [[WHILE_AREF]]
+      // CHECK: nvws.aref.put.exit [[WHILE_AREF]], [[WHILE_PUT_TOKEN]]
+      %value = "produce"() {ttg.partition = array<i32: 2>} : () -> tensor<1xi32, #blocked_while_aref>
+      // CHECK: [[WHILE_GET:%.*]], [[WHILE_GET_TOKEN:%.*]] = nvws.aref.get.enter [[WHILE_AREF]]
+      // CHECK: [[WHILE_VALUE:%.*]] = ttg.local_load [[WHILE_GET]]
+      // CHECK: nvws.aref.get.exit [[WHILE_AREF]], [[WHILE_GET_TOKEN]]
+      // CHECK: "consume"([[WHILE_VALUE]])
+      "consume"(%value) {ttg.partition = array<i32: 0>} : (tensor<1xi32, #blocked_while_aref>) -> ()
+      scf.yield {ttg.partition = array<i32: 0, 2>} %keep_going : i1
+    } attributes {tt.warp_specialize, ttg.partition = array<i32: 0, 2>, ttg.partition.outputs = [array<i32: 0, 2>], ttg.partition.stages = [0 : i32, 0 : i32], ttg.warp_specialize.tag = 0 : i32}
+    tt.return
+  }
+}
+
+// -----
+
+#clc_registers = #ttg.linear<{register = [[1]], lane = [[0], [0], [0], [0], [0]], warp = [[0], [0]], block = []}>
+// CHECK: #shared = #ttg.swizzled_shared<{vec = 1, perPhase = 1, maxPhase = 1, order = [0]}>
+#shared_clc_aref = #ttg.swizzled_shared<{vec = 1, perPhase = 1, maxPhase = 1, order = [0]}>
+#smem_clc_aref = #ttg.shared_memory
+module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.target = "cuda:100"} {
+  // CHECK-LABEL: @clc_aref_complete_metadata
+  tt.func @clc_aref_complete_metadata(%initial_work: i1, %initial_pid: i32) {
+    // CHECK: [[CLC_RING:%.*]] = ttg.local_alloc {alignment = 16 : i32} : () -> !ttg.memdesc<2x2xi64, #shared,
+    // CHECK-NEXT: [[CLC_AREF:%.*]] = nvws.aref.create [[CLC_RING]]
+    // CHECK-NEXT: scf.while
+    %loop:2 = scf.while (%has_work = %initial_work, %pid = %initial_pid) : (i1, i32) -> (i1, i32) {
+      scf.condition(%has_work) %has_work, %pid : i1, i32
+    } do {
+    ^bb0(%has_work: i1, %pid: i32):
+      // CHECK: [[CLC_WRITE:%.*]], [[CLC_PUT_TOKEN:%.*]] = nvws.aref.put.enter [[CLC_AREF]] {loop.cluster = 0 : i32, loop.stage = 0 : i32, ttg.partition = array<i32: 3>}
+      // CHECK-SAME: -> !ttg.memdesc<2xi64, #shared, {{.*}}, mutable, 2x2>, !ttg.async.token
+      // CHECK-NEXT: nvws.clc_try_cancel [[CLC_WRITE]] {loop.cluster = 0 : i32, loop.stage = 0 : i32, ttg.partition = array<i32: 3>}
+      // CHECK-NEXT: nvws.aref.put.exit [[CLC_AREF]], [[CLC_PUT_TOKEN]] [#nvws.async_op<clc>] {loop.cluster = 0 : i32, loop.stage = 0 : i32, ttg.partition = array<i32: 3>}
+      %response = ttng.clc_try_cancel_sync {loop.cluster = 0 : i32, loop.stage = 0 : i32, ttg.partition = array<i32: 3>} : tensor<2xi64, #clc_registers>
+      %response_smem = ttg.local_alloc %response {alignment = 16 : i32, loop.cluster = 0 : i32, loop.stage = 0 : i32, ttg.partition = array<i32: 3>} : (tensor<2xi64, #clc_registers>) -> !ttg.memdesc<2xi64, #shared_clc_aref, #smem_clc_aref, mutable>
+      "compute"(%pid) {ttg.partition = array<i32: 0, 1, 2>} : (i32) -> ()
+      // CHECK-NOT: ttg.local_alloc %
+      // CHECK-NOT: ttg.local_load
+      // CHECK: [[CLC_READ:%.*]], [[CLC_GET_TOKEN:%.*]] = nvws.aref.get.enter [[CLC_AREF]] {loop.cluster = 0 : i32, loop.stage = 0 : i32, ttg.partition = array<i32: 0, 1, 2, 3>}
+      // CHECK-NEXT: [[CLC_RAW:%.*]] = ttng.clc_load_result [[CLC_READ]] {loop.cluster = 0 : i32, loop.stage = 0 : i32, ttg.partition = array<i32: 0, 1, 2, 3>}
+      // CHECK-NEXT: nvws.aref.get.exit [[CLC_AREF]], [[CLC_GET_TOKEN]] [#nvws.async_op<none>] {loop.cluster = 0 : i32, loop.stage = 0 : i32, ttg.partition = array<i32: 0, 1, 2, 3>}
+      %raw = ttng.clc_load_result %response_smem {loop.cluster = 0 : i32, loop.stage = 0 : i32, ttg.partition = array<i32: 0, 1, 2, 3>} : !ttg.memdesc<2xi64, #shared_clc_aref, #smem_clc_aref, mutable> -> i128
+      // CHECK-NOT: ttg.local_load
+      // CHECK: ttng.clc_is_canceled [[CLC_RAW]] {loop.cluster = 0 : i32, loop.stage = 0 : i32, ttg.partition = array<i32: 0, 1, 2, 3>}
+      %next_work = ttng.clc_is_canceled %raw {loop.cluster = 0 : i32, loop.stage = 0 : i32, ttg.partition = array<i32: 0, 1, 2, 3>} : i128 -> i1
+      // CHECK: ttng.clc_get_program_id [[CLC_RAW]], x {loop.cluster = 0 : i32, loop.stage = 0 : i32, ttg.partition = array<i32: 0, 1, 2, 3>}
+      // CHECK-NOT: ttg.local_load
+      %next_pid = ttng.clc_get_program_id %raw, x {loop.cluster = 0 : i32, loop.stage = 0 : i32, ttg.partition = array<i32: 0, 1, 2, 3>} : i128 -> i32
+      scf.yield {ttg.partition = array<i32: 0, 1, 2, 3>} %next_work, %next_pid : i1, i32
+    } attributes {tt.warp_specialize, ttg.partition = array<i32: 0, 1, 2, 3>, ttg.partition.outputs = [array<i32: 0, 1, 2, 3>, array<i32: 0, 1, 2, 3>], ttg.partition.stages = [0 : i32, 1 : i32, 1 : i32, 0 : i32], ttg.warp_specialize.tag = 0 : i32}
+    tt.return
+  }
+}
+
+// -----
+
+#clc_registers = #ttg.linear<{register = [[1]], lane = [[0], [0], [0], [0], [0]], warp = [[0], [0]], block = []}>
+#shared_clc_aref = #ttg.swizzled_shared<{vec = 1, perPhase = 1, maxPhase = 1, order = [0]}>
+#smem_clc_aref = #ttg.shared_memory
+module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.target = "cuda:100"} {
+  // CHECK-LABEL: @clc_aref_no_metadata_untouched
+  tt.func @clc_aref_no_metadata_untouched(%initial_work: i1) {
+    %loop = scf.while (%has_work = %initial_work) : (i1) -> i1 {
+      scf.condition(%has_work) %has_work : i1
+    } do {
+    ^bb0(%has_work: i1):
+      // CHECK-NOT: nvws.aref.create
+      // CHECK: %[[RESPONSE:.*]] = ttng.clc_try_cancel_sync : tensor<2xi64, #[[CLC_REGS:[A-Za-z0-9_]+]]>
+      %response = ttng.clc_try_cancel_sync : tensor<2xi64, #clc_registers>
+      // CHECK: %[[RESPONSE_SMEM:.*]] = ttg.local_alloc %[[RESPONSE]] {alignment = 16 : i32}
+      %response_smem = ttg.local_alloc %response {alignment = 16 : i32} : (tensor<2xi64, #clc_registers>) -> !ttg.memdesc<2xi64, #shared_clc_aref, #smem_clc_aref, mutable>
+      // CHECK: %[[RAW:.*]] = ttng.clc_load_result %[[RESPONSE_SMEM]]
+      %raw = ttng.clc_load_result %response_smem : !ttg.memdesc<2xi64, #shared_clc_aref, #smem_clc_aref, mutable> -> i128
+      // CHECK: ttng.clc_is_canceled %[[RAW]] : i128 -> i1
+      %next_work = ttng.clc_is_canceled %raw : i128 -> i1
+      scf.yield %next_work : i1
+    }
+    tt.return
+  }
+}
+
+// -----
+
 #blocked_scale = #ttg.blocked<{sizePerThread = [1, 1, 1, 1, 1], threadsPerWarp = [1, 1, 1, 32, 1], warpsPerCTA = [1, 2, 2, 1, 1], order = [3, 2, 1, 0, 4]}>
 #shared_scale_tma = #ttg.nvmma_shared<{swizzlingByteWidth = 0, transposed = false, elementBitWidth = 8, rank = 5}>
 #shared_scale_a = #ttg.shared_linear<{offset = [[0, 0, 0, 0, 1], [0, 0, 0, 0, 2], [0, 0, 0, 0, 4], [0, 0, 0, 0, 8], [0, 0, 0, 0, 16], [0, 0, 0, 0, 32], [0, 0, 0, 0, 64], [0, 0, 0, 0, 128], [0, 0, 0, 1, 0], [0, 0, 1, 0, 0], [0, 1, 0, 0, 0]]}, alignment = 128>
@@ -817,4 +912,72 @@ tt.func @aref_result_outside_scheduled_loop(%lb: i32, %ub: i32, %step: i32) {
   } {tt.warp_specialize, ttg.partition = array<i32: 0, 2>, ttg.partition.stages = [0, 1], ttg.warp_specialize.tag = 0 : i32}
   tt.return
 }
+}
+
+// -----
+
+#aref_phi_blocked = #ttg.blocked<{sizePerThread = [1], threadsPerWarp = [32], warpsPerCTA = [4], order = [0]}>
+module attributes {"ttg.num-warps" = 4 : i32} {
+  // CHECK-LABEL: @overlapping_collective_consumer
+  tt.func @overlapping_collective_consumer(%lb: i32, %ub: i32, %step: i32) {
+    // CHECK: %[[AREF:.*]] = nvws.aref.create
+    scf.for %i = %lb to %ub step %step : i32 {
+      // CHECK: %[[LOCAL:.*]] = "producer"() {ttg.partition = array<i32: 3>}
+      // CHECK: nvws.aref.put.enter %[[AREF]] {ttg.partition = array<i32: 3>}
+      %packed = "producer"() {ttg.partition = array<i32: 3>} : () -> tensor<4xi32, #aref_phi_blocked>
+      // CHECK: nvws.aref.get.enter %[[AREF]] {ttg.partition = array<i32: 0, 1, 2>}
+      // CHECK: %[[REMOTE:.*]] = ttg.local_load {{.*}} {ttg.partition = array<i32: 0, 1, 2>}
+      // CHECK: %[[SELECTED:.*]] = nvws.aref.phi %[[LOCAL]], %[[REMOTE]] {ttg.partition = array<i32: 0, 1, 2, 3>}
+      // CHECK: "consumer"(%[[SELECTED]]) {ttg.partition = array<i32: 0, 1, 2, 3>}
+      // CHECK-NOT: nvws.aref.get.enter {{.*}}ttg.partition = array<i32: 3>
+      "consumer"(%packed) {ttg.partition = array<i32: 0, 1, 2, 3>} : (tensor<4xi32, #aref_phi_blocked>) -> ()
+      scf.yield {ttg.partition = array<i32: 0, 1, 2, 3>}
+    } {tt.warp_specialize, ttg.partition = array<i32: 0, 1, 2, 3>, ttg.partition.stages = [0, 0, 0, 0], ttg.warp_specialize.tag = 0 : i32}
+    tt.return
+  }
+}
+
+// -----
+
+#aref_phi_iter_blocked = #ttg.blocked<{sizePerThread = [1], threadsPerWarp = [32], warpsPerCTA = [4], order = [0]}>
+module attributes {"ttg.num-warps" = 4 : i32} {
+  // CHECK-LABEL: @overlapping_collective_iter_arg
+  tt.func @overlapping_collective_iter_arg(%lb: i32, %ub: i32, %step: i32, %initial: tensor<4xi32, #aref_phi_iter_blocked>) {
+    // CHECK: scf.for {{.*}} iter_args(%[[STATE:.*]] =
+    %result = scf.for %i = %lb to %ub step %step iter_args(%state = %initial) -> tensor<4xi32, #aref_phi_iter_blocked> : i32 {
+      // CHECK: nvws.aref.put.enter {{.*}} {ttg.partition = array<i32: 3>}
+      // CHECK: nvws.aref.get.enter {{.*}} {ttg.partition = array<i32: 0, 1, 2>}
+      // CHECK: %[[REMOTE:.*]] = ttg.local_load {{.*}} {ttg.partition = array<i32: 0, 1, 2>}
+      // CHECK: %[[SELECTED:.*]] = nvws.aref.phi %[[STATE]], %[[REMOTE]] {ttg.partition = array<i32: 0, 1, 2, 3>}
+      // CHECK-NOT: nvws.aref.phi
+      // CHECK: "consumer"(%[[SELECTED]]) {ttg.partition = array<i32: 0, 1, 2, 3>}
+      "consumer"(%state) {ttg.partition = array<i32: 0, 1, 2, 3>} : (tensor<4xi32, #aref_phi_iter_blocked>) -> ()
+      %next = "producer"(%state) {ttg.partition = array<i32: 3>} : (tensor<4xi32, #aref_phi_iter_blocked>) -> tensor<4xi32, #aref_phi_iter_blocked>
+      scf.yield {ttg.partition = array<i32: 3>} %next : tensor<4xi32, #aref_phi_iter_blocked>
+    } {tt.warp_specialize, ttg.partition = array<i32: 0, 1, 2, 3>, ttg.partition.outputs = [array<i32: 3>], ttg.partition.stages = [0, 0, 0, 0], ttg.warp_specialize.tag = 0 : i32}
+    tt.return
+  }
+}
+
+// -----
+
+// Reduced Flash Attention recurrence: softmax state is local to partition 1,
+// while accumulator rescaling consumes it collectively in partitions 0 and 1.
+#attention_state = #ttg.blocked<{sizePerThread = [1], threadsPerWarp = [32], warpsPerCTA = [4], order = [0]}>
+module attributes {"ttg.num-warps" = 4 : i32} {
+  // CHECK-LABEL: @attention_loop_carried_collective_rescale
+  tt.func @attention_loop_carried_collective_rescale(%lb: i32, %ub: i32, %step: i32, %initial: tensor<128xf32, #attention_state>) {
+    // CHECK: scf.for {{.*}} iter_args(%[[STATE:.*]] =
+    %result = scf.for %i = %lb to %ub step %step iter_args(%state = %initial) -> tensor<128xf32, #attention_state> : i32 {
+      // CHECK: nvws.aref.put.enter {{.*}} {ttg.partition = array<i32: 1>}
+      // CHECK: nvws.aref.get.enter {{.*}} {ttg.partition = array<i32: 0>}
+      // CHECK: %[[REMOTE:.*]] = ttg.local_load {{.*}} {ttg.partition = array<i32: 0>}
+      // CHECK: %[[SELECTED:.*]] = nvws.aref.phi %[[STATE]], %[[REMOTE]] {ttg.partition = array<i32: 0, 1>}
+      // CHECK: "rescale_accumulator"(%[[SELECTED]]) {ttg.partition = array<i32: 0, 1>}
+      "rescale_accumulator"(%state) {ttg.partition = array<i32: 0, 1>} : (tensor<128xf32, #attention_state>) -> ()
+      %next = "update_softmax_state"(%state) {ttg.partition = array<i32: 1>} : (tensor<128xf32, #attention_state>) -> tensor<128xf32, #attention_state>
+      scf.yield {ttg.partition = array<i32: 1>} %next : tensor<128xf32, #attention_state>
+    } {tt.warp_specialize, ttg.partition = array<i32: 0, 1>, ttg.partition.outputs = [array<i32: 1>], ttg.partition.stages = [0, 0], ttg.warp_specialize.tag = 0 : i32}
+    tt.return
+  }
 }

--- a/test/NVWS/invalid.mlir
+++ b/test/NVWS/invalid.mlir
@@ -13,6 +13,54 @@ module attributes {"ttg.target" = "cuda:0", "ttg.num-ctas" = 1 : i32, "ttg.num-w
 
 // -----
 
+module attributes {"ttg.num-warps" = 4 : i32} {
+  tt.func @aref_phi_overlap() {
+    %lhs = arith.constant {ttg.partition = array<i32: 0, 1>} 1 : i32
+    %rhs = arith.constant {ttg.partition = array<i32: 1, 2>} 2 : i32
+    // expected-error @+1 {{partition 1 is owned by both phi operands}}
+    %selected = nvws.aref.phi %lhs, %rhs {ttg.partition = array<i32: 0, 1, 2>} : i32
+    tt.return
+  }
+}
+
+// -----
+
+module attributes {"ttg.num-warps" = 4 : i32} {
+  tt.func @aref_phi_uncovered() {
+    %lhs = arith.constant {ttg.partition = array<i32: 0>} 1 : i32
+    %rhs = arith.constant {ttg.partition = array<i32: 1>} 2 : i32
+    // expected-error @+1 {{operand partition union must exactly match the phi partition set}}
+    %selected = nvws.aref.phi %lhs, %rhs {ttg.partition = array<i32: 0, 1, 2>} : i32
+    tt.return
+  }
+}
+
+// -----
+
+module attributes {"ttg.num-warps" = 4 : i32} {
+  tt.func @aref_phi_unowned_operand() {
+    %lhs = arith.constant 1 : i32
+    %rhs = arith.constant {ttg.partition = array<i32: 1>} 2 : i32
+    // expected-error @+1 {{local operand must have partition ownership}}
+    %selected = nvws.aref.phi %lhs, %rhs {ttg.partition = array<i32: 0, 1>} : i32
+    tt.return
+  }
+}
+
+// -----
+
+module attributes {"ttg.num-warps" = 4 : i32} {
+  tt.func @aref_phi_missing_partition() {
+    %lhs = arith.constant {ttg.partition = array<i32: 0>} 1 : i32
+    %rhs = arith.constant {ttg.partition = array<i32: 1>} 2 : i32
+    // expected-error @+1 {{requires a non-empty ttg.partition annotation}}
+    %selected = nvws.aref.phi %lhs, %rhs : i32
+    tt.return
+  }
+}
+
+// -----
+
 #blocked = #ttg.blocked<{sizePerThread = [1, 128], threadsPerWarp = [32, 1], warpsPerCTA = [4, 1], order = [0, 1]}>
 #tmem = #ttng.tensor_memory_encoding<blockM = 128, blockN = 128, colStride = 1>
 module attributes {"ttg.target" = "cuda:100", "ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, "ttg.threads-per-warp" = 32 : i32} {

--- a/test/NVWS/lower_aref.mlir
+++ b/test/NVWS/lower_aref.mlir
@@ -636,3 +636,74 @@ module attributes {"ttg.num-warps" = 4 : i32, ttg.target = "cuda:100"} {
     tt.return
   }
 }
+
+// -----
+
+#shared_clc_lower = #ttg.swizzled_shared<{vec = 1, perPhase = 1, maxPhase = 1, order = [0]}>
+#smem_clc_lower = #ttg.shared_memory
+module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.target = "cuda:100"} {
+  // CHECK-LABEL: @clc_one_cta_double_buffer
+  tt.func @clc_one_cta_double_buffer(%initial_work: i1, %initial_pid: i32) {
+    // CHECK: [[CLC_RING:%.*]] = ttg.local_alloc {alignment = 16 : i32} : () -> !ttg.memdesc<2x2xi64,
+    %ring = ttg.local_alloc {alignment = 16 : i32} : () -> !ttg.memdesc<2x2xi64, #shared_clc_lower, #smem_clc_lower, mutable>
+    // CHECK-NEXT: [[CLC_EMPTY:%.*]] = ttg.local_alloc : () -> !ttg.memdesc<2x1xi64,
+    // CHECK-COUNT-2: ttng.init_barrier {{%.*}}, 4
+    // CHECK: [[CLC_FULL:%.*]] = ttg.local_alloc : () -> !ttg.memdesc<2x1xi64,
+    // CHECK-COUNT-2: ttng.init_barrier {{%.*}}, 1
+    %aref = nvws.aref.create %ring : <[!ttg.memdesc<2x2xi64, #shared_clc_lower, #smem_clc_lower, mutable>]>
+    %c1 = arith.constant 1 : i32
+    %c0 = arith.constant 0 : i32
+    // CHECK: scf.while
+    %loop:6 = scf.while (%has_work = %initial_work, %pid = %initial_pid, %put_stage = %c1, %put_phase = %c0, %get_stage = %c1, %get_phase = %c1) : (i1, i32, i32, i32, i32, i32) -> (i1, i32, i32, i32, i32, i32) {
+      scf.condition(%has_work) {ttg.partition = array<i32: 0, 1, 2, 3>} %has_work, %pid, %put_stage, %put_phase, %get_stage, %get_phase : i1, i32, i32, i32, i32, i32
+    } do {
+    ^bb0(%has_work: i1, %pid: i32, %put_stage: i32, %put_phase: i32, %get_stage: i32, %get_phase: i32):
+      %put_one = arith.constant {ttg.partition = array<i32: 3>} 1 : i32
+      %put_inc = arith.addi %put_stage, %put_one {ttg.partition = array<i32: 3>} : i32
+      %put_two = arith.constant {ttg.partition = array<i32: 3>} 2 : i32
+      %put_wrap = arith.cmpi eq, %put_inc, %put_two {ttg.partition = array<i32: 3>} : i32
+      %put_zero = arith.constant {ttg.partition = array<i32: 3>} 0 : i32
+      %put_slot = arith.select %put_wrap, %put_zero, %put_inc {ttg.partition = array<i32: 3>} : i32
+      %put_toggled = arith.xori %put_phase, %put_one {ttg.partition = array<i32: 3>} : i32
+      %put_next_phase = arith.select %put_wrap, %put_toggled, %put_phase {ttg.partition = array<i32: 3>} : i32
+      // CHECK: [[CLC_EMPTY_SLOT:%.*]] = ttg.memdesc_index [[CLC_EMPTY]][[[CLC_PUT_SLOT:%.*]]] {ttg.partition = array<i32: 3>}
+      // CHECK-NEXT: ttng.wait_barrier [[CLC_EMPTY_SLOT]], [[CLC_PUT_PHASE:%.*]] {ttg.partition = array<i32: 3>}
+      // CHECK-NEXT: [[CLC_RESPONSE:%.*]] = ttg.memdesc_index [[CLC_RING]][[[CLC_PUT_SLOT]]] {ttg.partition = array<i32: 3>} : {{.*}} -> !ttg.memdesc<2xi64,
+      %write, %put_token = nvws.aref.put.enter %aref[%put_slot, %put_next_phase] {ttg.partition = array<i32: 3>} : <[!ttg.memdesc<2x2xi64, #shared_clc_lower, #smem_clc_lower, mutable>]> -> !ttg.memdesc<2xi64, #shared_clc_lower, #smem_clc_lower, mutable, 2x2>, !ttg.async.token
+      // CHECK-NEXT: [[CLC_FULL_SLOT:%.*]] = ttg.memdesc_index [[CLC_FULL]][[[CLC_PUT_SLOT]]] {ttg.partition = array<i32: 3>}
+      // CHECK-NEXT: [[CLC_TRUE:%.*]] = arith.constant {ttg.partition = array<i32: 3>} true
+      // CHECK-NEXT: ttng.barrier_expect [[CLC_FULL_SLOT]], 16 {ttg.partition = array<i32: 3>}, [[CLC_TRUE]]
+      // CHECK-NEXT: ttng.clc_try_cancel [[CLC_RESPONSE]], [[CLC_FULL_SLOT]] {ttg.partition = array<i32: 3>}
+      // CHECK-NOT: ttng.arrive_barrier [[CLC_FULL_SLOT]]
+      nvws.clc_try_cancel %write {ttg.partition = array<i32: 3>} : !ttg.memdesc<2xi64, #shared_clc_lower, #smem_clc_lower, mutable, 2x2>
+      nvws.aref.put.exit %aref[%put_slot], %put_token [#nvws.async_op<clc>] {ttg.partition = array<i32: 3>} : <[!ttg.memdesc<2x2xi64, #shared_clc_lower, #smem_clc_lower, mutable>]>, !ttg.async.token
+      %get_one = arith.constant {ttg.partition = array<i32: 0, 1, 2, 3>} 1 : i32
+      %get_inc = arith.addi %get_stage, %get_one {ttg.partition = array<i32: 0, 1, 2, 3>} : i32
+      %get_two = arith.constant {ttg.partition = array<i32: 0, 1, 2, 3>} 2 : i32
+      %get_wrap = arith.cmpi eq, %get_inc, %get_two {ttg.partition = array<i32: 0, 1, 2, 3>} : i32
+      %get_zero = arith.constant {ttg.partition = array<i32: 0, 1, 2, 3>} 0 : i32
+      %get_slot = arith.select %get_wrap, %get_zero, %get_inc {ttg.partition = array<i32: 0, 1, 2, 3>} : i32
+      %get_toggled = arith.xori %get_phase, %get_one {ttg.partition = array<i32: 0, 1, 2, 3>} : i32
+      %get_next_phase = arith.select %get_wrap, %get_toggled, %get_phase {ttg.partition = array<i32: 0, 1, 2, 3>} : i32
+      // CHECK: [[CLC_GET_FULL:%.*]] = ttg.memdesc_index [[CLC_FULL]][[[CLC_GET_SLOT:%.*]]] {ttg.partition = array<i32: 0, 1, 2, 3>}
+      // CHECK-NEXT: ttng.wait_barrier [[CLC_GET_FULL]], [[CLC_GET_PHASE:%.*]] {ttg.partition = array<i32: 0, 1, 2, 3>}
+      // CHECK-NEXT: [[CLC_READ:%.*]] = ttg.memdesc_index [[CLC_RING]][[[CLC_GET_SLOT]]] {ttg.partition = array<i32: 0, 1, 2, 3>} : {{.*}} -> !ttg.memdesc<2xi64,
+      %read, %get_token = nvws.aref.get.enter %aref[%get_slot, %get_next_phase] {ttg.partition = array<i32: 0, 1, 2, 3>} : <[!ttg.memdesc<2x2xi64, #shared_clc_lower, #smem_clc_lower, mutable>]> -> !ttg.memdesc<2xi64, #shared_clc_lower, #smem_clc_lower, mutable, 2x2>, !ttg.async.token
+      // CHECK-NEXT: [[CLC_RAW:%.*]] = ttng.clc_load_result [[CLC_READ]] {ttg.partition = array<i32: 0, 1, 2, 3>}
+      %raw = ttng.clc_load_result %read {ttg.partition = array<i32: 0, 1, 2, 3>} : !ttg.memdesc<2xi64, #shared_clc_lower, #smem_clc_lower, mutable, 2x2> -> i128
+      // CHECK-NEXT: [[CLC_GET_EMPTY:%.*]] = ttg.memdesc_index [[CLC_EMPTY]][[[CLC_GET_SLOT]]] {ttg.partition = array<i32: 0, 1, 2, 3>}
+      // CHECK-NEXT: ttng.arrive_barrier [[CLC_GET_EMPTY]], 1 {ttg.partition = array<i32: 0, 1, 2, 3>}
+      nvws.aref.get.exit %aref[%get_slot], %get_token [#nvws.async_op<none>] {ttg.partition = array<i32: 0, 1, 2, 3>} : <[!ttg.memdesc<2x2xi64, #shared_clc_lower, #smem_clc_lower, mutable>]>, !ttg.async.token
+      // CHECK: ttng.clc_is_canceled [[CLC_RAW]] {ttg.partition = array<i32: 0, 1, 2, 3>}
+      %next_work = ttng.clc_is_canceled %raw {ttg.partition = array<i32: 0, 1, 2, 3>} : i128 -> i1
+      // CHECK: ttng.clc_get_program_id [[CLC_RAW]], x {ttg.partition = array<i32: 0, 1, 2, 3>}
+      %next_pid = ttng.clc_get_program_id %raw, x {ttg.partition = array<i32: 0, 1, 2, 3>} : i128 -> i32
+      scf.yield {ttg.partition = array<i32: 0, 1, 2, 3>} %next_work, %next_pid, %put_slot, %put_next_phase, %get_slot, %get_next_phase : i1, i32, i32, i32, i32, i32
+    // CHECK: } attributes
+    } attributes {tt.warp_specialize, ttg.partition = array<i32: 0, 1, 2, 3>, ttg.partition.outputs = [array<i32: 0, 1, 2, 3>, array<i32: 0, 1, 2, 3>, array<i32: 3>, array<i32: 3>, array<i32: 0, 1, 2, 3>, array<i32: 0, 1, 2, 3>], ttg.partition.stages = [0 : i32, 1 : i32, 1 : i32, 0 : i32], ttg.warp_specialize.tag = 0 : i32}
+    // CHECK-COUNT-4: ttng.inval_barrier
+    // CHECK-NOT: nvws.
+    ttg.local_dealloc %ring : !ttg.memdesc<2x2xi64, #shared_clc_lower, #smem_clc_lower, mutable>
+    tt.return
+  }
+}

--- a/test/NVWS/ops.mlir
+++ b/test/NVWS/ops.mlir
@@ -108,3 +108,19 @@ tt.func @token_producer_consumer() {
   nvws.consumer_release %0, %c0_i32 {async_task_id = dense<1> : vector<1xi32>} : tensor<3x!nvws.token>, i32
   tt.return
 }
+
+// -----
+
+module attributes {"ttg.num-warps" = 4 : i32} {
+  // CHECK-LABEL: @aref_phi
+  tt.func @aref_phi() -> i32 {
+    // CHECK: %[[LOCAL:.*]] = arith.constant {ttg.partition = array<i32: 3>} 1 : i32
+    %local = arith.constant {ttg.partition = array<i32: 3>} 1 : i32
+    // CHECK: %[[REMOTE:.*]] = arith.constant {ttg.partition = array<i32: 0, 1, 2>} 2 : i32
+    %remote = arith.constant {ttg.partition = array<i32: 0, 1, 2>} 2 : i32
+    // CHECK: %[[SELECTED:.*]] = nvws.aref.phi %[[LOCAL]], %[[REMOTE]] {ttg.partition = array<i32: 0, 1, 2, 3>} : i32
+    %selected = nvws.aref.phi %local, %remote {ttg.partition = array<i32: 0, 1, 2, 3>} : i32
+    // CHECK: tt.return %[[SELECTED]] : i32
+    tt.return %selected : i32
+  }
+}

--- a/test/TritonGPU/automatic-warp-specialization.mlir
+++ b/test/TritonGPU/automatic-warp-specialization.mlir
@@ -392,3 +392,78 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.targ
     tt.return
   }
 }
+
+// -----
+
+// AutomaticWS partitions one CLC While and emits a single physical CLC issue.
+#clc_aws_oper = #ttg.blocked<{sizePerThread = [1, 1], threadsPerWarp = [1, 32], warpsPerCTA = [2, 2], order = [1, 0]}>
+#clc_aws_acc = #ttg.blocked<{sizePerThread = [1, 128], threadsPerWarp = [32, 1], warpsPerCTA = [4, 1], order = [0, 1]}>
+#clc_aws_shared = #ttg.nvmma_shared<{swizzlingByteWidth = 128, transposed = false, elementBitWidth = 16}>
+#clc_aws_shared_t = #ttg.nvmma_shared<{swizzlingByteWidth = 128, transposed = true, elementBitWidth = 16}>
+#clc_aws_smem = #ttg.shared_memory
+#clc_aws_tmem = #ttng.tensor_memory_encoding<blockM = 128, blockN = 128, colStride = 1>
+#clc_aws_response = #ttg.linear<{register = [[1]], lane = [[0], [0], [0], [0], [0]], warp = [[0], [0]], block = []}>
+#clc_aws_response_shared = #ttg.swizzled_shared<{vec = 1, perPhase = 1, maxPhase = 1, order = [0]}>
+
+module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.target = "cuda:100"} {
+  // BASE-LABEL: @clc_while_aws
+  tt.func @clc_while_aws(
+      %a_desc: !tt.tensordesc<128x64xf16, #clc_aws_shared>,
+      %b_desc: !tt.tensordesc<128x64xf16, #clc_aws_shared>,
+      %out: !tt.ptr<i32>) {
+    %c0 = arith.constant 0 : i32
+    %c1 = arith.constant 1 : i32
+    %c6 = arith.constant 6 : i32
+    %true = arith.constant true
+    %false = arith.constant false
+    %pid0 = tt.get_program_id x : i32
+    // BASE: ttg.warp_specialize
+    // BASE: default
+    // BASE: ttng.clc_load_result
+    // BASE: ttng.clc_get_program_id
+    // BASE-NOT: ttng.clc_try_cancel
+    // BASE: partition0
+    // BASE: ttng.clc_load_result
+    // BASE: ttng.clc_get_program_id
+    // BASE-NOT: ttng.clc_try_cancel
+    // BASE: partition1
+    // BASE: ttng.clc_load_result
+    // BASE: ttng.clc_get_program_id
+    // BASE-NOT: ttng.clc_try_cancel
+    // BASE: partition2
+    // BASE: ttng.clc_try_cancel
+    // BASE-NOT: ttng.clc_try_cancel
+    // BASE: ttng.clc_load_result
+    // BASE: ttng.clc_get_program_id
+    scf.while (%pid = %pid0, %has_work = %true) : (i32, i1) -> (i32, i1) {
+      scf.condition(%has_work) %pid, %has_work : i32, i1
+    } do {
+    ^bb0(%pid: i32, %has_work: i1):
+      %response = ttng.clc_try_cancel_sync : tensor<2xi64, #clc_aws_response>
+      %response_smem = ttg.local_alloc %response {alignment = 16 : i32} : (tensor<2xi64, #clc_aws_response>) -> !ttg.memdesc<2xi64, #clc_aws_response_shared, #clc_aws_smem, mutable>
+      scf.for %k = %c0 to %c6 step %c1 : i32 {
+        %a = tt.descriptor_load %a_desc[%pid, %k] : !tt.tensordesc<128x64xf16, #clc_aws_shared> -> tensor<128x64xf16, #clc_aws_oper>
+        %b = tt.descriptor_load %b_desc[%pid, %k] : !tt.tensordesc<128x64xf16, #clc_aws_shared> -> tensor<128x64xf16, #clc_aws_oper>
+        %a_s = ttg.local_alloc %a : (tensor<128x64xf16, #clc_aws_oper>) -> !ttg.memdesc<128x64xf16, #clc_aws_shared, #clc_aws_smem>
+        %b_s0 = ttg.local_alloc %b : (tensor<128x64xf16, #clc_aws_oper>) -> !ttg.memdesc<128x64xf16, #clc_aws_shared, #clc_aws_smem>
+        %b_s = ttg.memdesc_trans %b_s0 {order = array<i32: 1, 0>} : !ttg.memdesc<128x64xf16, #clc_aws_shared, #clc_aws_smem> -> !ttg.memdesc<64x128xf16, #clc_aws_shared_t, #clc_aws_smem>
+        %acc_mem, %acc_tok = ttng.tmem_alloc : () -> (!ttg.memdesc<128x128xf32, #clc_aws_tmem, #ttng.tensor_memory, mutable>, !ttg.async.token)
+        %mma = ttng.tc_gen5_mma %a_s, %b_s, %acc_mem[%acc_tok], %false, %true : !ttg.memdesc<128x64xf16, #clc_aws_shared, #clc_aws_smem>, !ttg.memdesc<64x128xf16, #clc_aws_shared_t, #clc_aws_smem>, !ttg.memdesc<128x128xf32, #clc_aws_tmem, #ttng.tensor_memory, mutable>
+        %value, %load_tok = ttng.tmem_load %acc_mem[%mma] : !ttg.memdesc<128x128xf32, #clc_aws_tmem, #ttng.tensor_memory, mutable> -> tensor<128x128xf32, #clc_aws_acc>
+        "consume"(%value) : (tensor<128x128xf32, #clc_aws_acc>) -> ()
+      } {tt.warp_specialize, tt.num_stages = 2 : i32}
+      %out_ptr = tt.addptr %out, %pid : !tt.ptr<i32>, i32
+      tt.store %out_ptr, %pid : !tt.ptr<i32>
+      %raw = ttng.clc_load_result %response_smem : !ttg.memdesc<2xi64, #clc_aws_response_shared, #clc_aws_smem, mutable> -> i128
+      %next_has_work = ttng.clc_is_canceled %raw : i128 -> i1
+      %next_pid = scf.if %next_has_work -> i32 {
+        %stolen = ttng.clc_get_program_id %raw, x : i128 -> i32
+        scf.yield %stolen : i32
+      } else {
+        scf.yield %pid : i32
+      }
+      scf.yield %next_pid, %next_has_work : i32, i1
+    }
+    tt.return
+  }
+}

--- a/test/TritonGPU/normalize-ws-while-loops.mlir
+++ b/test/TritonGPU/normalize-ws-while-loops.mlir
@@ -55,22 +55,90 @@ module attributes {"ttg.num-warps" = 4 : i32} {
 // -----
 
 module attributes {"ttg.num-warps" = 4 : i32} {
+  // CHECK-LABEL: tt.func @normalize_computed_result(
+  // CHECK-SAME: %[[INITIAL:.*]]: i32, %[[ACTIVE:.*]]: i1, %[[LIMIT:.*]]: i32
+  tt.func @normalize_computed_result(%initial: i32, %run: i1,
+                                     %limit: i32) -> i32 {
+    %c1 = arith.constant 1 : i32
+    // CHECK: %[[INITIAL_RESULT:.*]] = arith.addi %[[INITIAL]], %{{.*}} : i32
+    // CHECK: %[[LOOP:.*]]:2 = scf.while ([[RESULT:%.*]] = %[[INITIAL_RESULT]], [[COND:%.*]] = %[[ACTIVE]])
+    %loop = scf.while (%state = %initial, %active = %run) : (i32, i1) -> i32 {
+      %result = arith.addi %state, %c1 : i32
+      // CHECK-NEXT: scf.condition([[COND]]) [[RESULT]], [[COND]] : i32, i1
+      scf.condition(%active) %result : i32
+    } do {
+    // CHECK: ^bb0([[BODY_RESULT:%.*]]: i32, %{{.*}}: i1):
+    ^bb0(%result: i32):
+      // CHECK: %[[NEXT_ACTIVE:.*]] = arith.cmpi slt, [[BODY_RESULT]], %[[LIMIT]] : i32
+      %next_active = arith.cmpi slt, %result, %limit : i32
+      scf.yield %result, %next_active : i32, i1
+    } attributes {tt.warp_specialize}
+    // CHECK: %[[NEXT_RESULT:.*]] = arith.addi [[BODY_RESULT]], %{{.*}} : i32
+    // CHECK: scf.yield %[[NEXT_RESULT]], %[[NEXT_ACTIVE]] : i32, i1
+    // CHECK: tt.return %[[LOOP]]#0 : i32
+    tt.return %loop : i32
+  }
+}
+
+// -----
+
+module attributes {"ttg.num-warps" = 4 : i32} {
+  // CHECK-LABEL: tt.func @normalize_nested_computed_results(
+  tt.func @normalize_nested_computed_results(%initial: i32, %run: i1,
+                                              %limit: i32) -> i32 {
+    %c1 = arith.constant 1 : i32
+    // CHECK: %[[OUTER_INITIAL_RESULT:.*]] = arith.addi %{{.*}}, %{{.*}} : i32
+    // CHECK-NEXT: %[[OUTER:.*]]:2 = scf.while ([[OUTER_RESULT:%.*]] = %[[OUTER_INITIAL_RESULT]], [[OUTER_COND:%.*]] = %{{.*}})
+    // CHECK-NEXT: scf.condition([[OUTER_COND]]) [[OUTER_RESULT]], [[OUTER_COND]] : i32, i1
+    %outer = scf.while (%state = %initial, %active = %run) : (i32, i1) -> i32 {
+      %result = arith.addi %state, %c1 : i32
+      scf.condition(%active) %result : i32
+    } do {
+    ^bb0(%result: i32):
+      // CHECK: %[[INNER_INITIAL_RESULT:.*]] = arith.addi [[OUTER_RESULT]], %{{.*}} : i32
+      // CHECK-NEXT: %[[INNER:.*]]:2 = scf.while ([[INNER_RESULT:%.*]] = %[[INNER_INITIAL_RESULT]], [[INNER_COND:%.*]] = %{{.*}})
+      // CHECK-NEXT: scf.condition([[INNER_COND]]) [[INNER_RESULT]], [[INNER_COND]] : i32, i1
+      %inner = scf.while (%inner_state = %result, %inner_active = %run) : (i32, i1) -> i32 {
+        %inner_result = arith.addi %inner_state, %c1 : i32
+        scf.condition(%inner_active) %inner_result : i32
+      } do {
+      ^bb0(%inner_result: i32):
+        // CHECK: %[[INNER_NEXT_ACTIVE:.*]] = arith.cmpi slt, [[INNER_RESULT]], %{{.*}} : i32
+        // CHECK-NEXT: %[[INNER_NEXT_RESULT:.*]] = arith.addi [[INNER_RESULT]], %{{.*}} : i32
+        // CHECK-NEXT: scf.yield %[[INNER_NEXT_RESULT]], %[[INNER_NEXT_ACTIVE]] : i32, i1
+        %inner_next_active = arith.cmpi slt, %inner_result, %limit : i32
+        scf.yield %inner_result, %inner_next_active : i32, i1
+      }
+      // CHECK: %[[OUTER_NEXT_ACTIVE:.*]] = arith.cmpi slt, %[[INNER]]#0, %{{.*}} : i32
+      // CHECK-NEXT: %[[OUTER_NEXT_RESULT:.*]] = arith.addi %[[INNER]]#0, %{{.*}} : i32
+      // CHECK-NEXT: scf.yield %[[OUTER_NEXT_RESULT]], %[[OUTER_NEXT_ACTIVE]] : i32, i1
+      %next_active = arith.cmpi slt, %inner, %limit : i32
+      scf.yield %inner, %next_active : i32, i1
+    } attributes {tt.warp_specialize}
+    // CHECK: tt.return %[[OUTER]]#0 : i32
+    tt.return %outer : i32
+  }
+}
+
+// -----
+
+module attributes {"ttg.num-warps" = 4 : i32} {
   // CHECK-LABEL: @normalize_while
   tt.func @normalize_while(%initial: i32, %run: i1) {
     %false = arith.constant false
-    // CHECK: %[[WHILE:.*]]:2 = scf.while ([[BEFORE_STATE:%.*]] = %{{.*}}, [[BEFORE_ACTIVE:%.*]] = %{{.*}})
+    // CHECK: %[[WHILE:.*]]:2 = scf.while ([[BEFORE_RESULT:%.*]] = %{{.*}}, [[BEFORE_COND:%.*]] = %{{.*}})
     %while = scf.while (%state = %initial, %active = %run) : (i32, i1) -> i1 {
-      // CHECK-NEXT: scf.condition([[BEFORE_ACTIVE]]) [[BEFORE_STATE]], [[BEFORE_ACTIVE]] : i32, i1
+      // CHECK-NEXT: scf.condition([[BEFORE_COND]]) [[BEFORE_RESULT]], [[BEFORE_COND]] : i1, i1
       scf.condition(%active) %active : i1
     } do {
-    // CHECK: ^bb0([[AFTER_STATE:%.*]]: i32, [[AFTER_ACTIVE:%.*]]: i1):
+    // CHECK: ^bb0([[AFTER_RESULT:%.*]]: i1, %{{.*}}: i1):
     ^bb0(%active: i1):
-      // CHECK: arith.xori [[AFTER_ACTIVE]], %{{.*}}
+      // CHECK: %[[NEXT:.*]] = arith.xori [[AFTER_RESULT]], %{{.*}}
       %next = arith.xori %active, %false : i1
-      // CHECK: scf.yield %{{.*}}, %{{.*}} : i32, i1
+      // CHECK: scf.yield %[[NEXT]], %[[NEXT]] : i1, i1
       scf.yield %initial, %next : i32, i1
     } attributes {tt.warp_specialize}
-    // CHECK: arith.extui %[[WHILE]]#1 : i1 to i32
+    // CHECK: arith.extui %[[WHILE]]#0 : i1 to i32
     %used = arith.extui %while : i1 to i32
     tt.return
   }

--- a/test/TritonGPU/normalize-ws-while-loops.mlir
+++ b/test/TritonGPU/normalize-ws-while-loops.mlir
@@ -1,0 +1,77 @@
+// RUN: triton-opt %s -split-input-file -tritongpu-normalize-ws-while-loops | FileCheck %s
+
+#blocked = #ttg.blocked<{sizePerThread = [2], threadsPerWarp = [32], warpsPerCTA = [4], order = [0]}>
+module attributes {"ttg.num-warps" = 4 : i32, ttg.target = "cuda:100"} {
+  // CHECK-LABEL: @move_ws_attributes_with_clc
+  tt.func @move_ws_attributes_with_clc(%run: i1, %lb: i32, %ub: i32,
+                                        %step: i32) {
+    // CHECK: scf.while
+    %loop = scf.while (%active = %run) : (i1) -> i1 {
+      scf.condition(%active) %active : i1
+    } do {
+    ^bb0(%active: i1):
+      // CHECK: ttng.clc_try_cancel_sync
+      %response = ttng.clc_try_cancel_sync : tensor<2xi64, #blocked>
+      // CHECK: scf.for
+      // CHECK-NEXT: }{{$}}
+      scf.for %i = %lb to %ub step %step : i32 {
+        scf.yield
+      } {tt.disallow_acc_multi_buffer, tt.warp_specialize}
+      // CHECK: scf.for
+      // CHECK-NEXT: }{{$}}
+      scf.for %i = %lb to %ub step %step : i32 {
+        scf.yield
+      } {tt.warp_specialize}
+      scf.yield %active : i1
+    // CHECK: } attributes {tt.disallow_acc_multi_buffer, tt.warp_specialize}
+    }
+    tt.return
+  }
+}
+
+// -----
+
+module attributes {"ttg.num-warps" = 4 : i32} {
+  // CHECK-LABEL: @keep_ws_attributes_without_clc
+  tt.func @keep_ws_attributes_without_clc(%run: i1, %lb: i32, %ub: i32,
+                                           %step: i32) {
+    // CHECK: scf.while
+    %loop = scf.while (%active = %run) : (i1) -> i1 {
+      scf.condition(%active) %active : i1
+    } do {
+    ^bb0(%active: i1):
+      // CHECK: scf.for
+      // CHECK-NEXT: } {tt.disallow_acc_multi_buffer, tt.warp_specialize}
+      scf.for %i = %lb to %ub step %step : i32 {
+        scf.yield
+      } {tt.disallow_acc_multi_buffer, tt.warp_specialize}
+      scf.yield %active : i1
+    // CHECK: }{{$}}
+    }
+    tt.return
+  }
+}
+
+// -----
+
+module attributes {"ttg.num-warps" = 4 : i32} {
+  // CHECK-LABEL: @normalize_while
+  tt.func @normalize_while(%initial: i32, %run: i1) {
+    %false = arith.constant false
+    // CHECK: %[[WHILE:.*]]:2 = scf.while ([[BEFORE_STATE:%.*]] = %{{.*}}, [[BEFORE_ACTIVE:%.*]] = %{{.*}})
+    %while = scf.while (%state = %initial, %active = %run) : (i32, i1) -> i1 {
+      // CHECK-NEXT: scf.condition([[BEFORE_ACTIVE]]) [[BEFORE_STATE]], [[BEFORE_ACTIVE]] : i32, i1
+      scf.condition(%active) %active : i1
+    } do {
+    // CHECK: ^bb0([[AFTER_STATE:%.*]]: i32, [[AFTER_ACTIVE:%.*]]: i1):
+    ^bb0(%active: i1):
+      // CHECK: arith.xori [[AFTER_ACTIVE]], %{{.*}}
+      %next = arith.xori %active, %false : i1
+      // CHECK: scf.yield %{{.*}}, %{{.*}} : i32, i1
+      scf.yield %initial, %next : i32, i1
+    } attributes {tt.warp_specialize}
+    // CHECK: arith.extui %[[WHILE]]#1 : i1 to i32
+    %used = arith.extui %while : i1 to i32
+    tt.return
+  }
+}

--- a/test/TritonGPU/partition-loops.mlir
+++ b/test/TritonGPU/partition-loops.mlir
@@ -438,3 +438,163 @@ tt.func @still_has_ssa_deps(%lb: i32, %ub: i32, %step: i32) {
 }
 
 }
+
+// -----
+
+#clc_pl_shared = #ttg.swizzled_shared<{vec = 1, perPhase = 1, maxPhase = 1, order = [0]}>
+#clc_pl_smem = #ttg.shared_memory
+
+module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.target = "cuda:100"} {
+  // CHECK-LABEL: @partition_clc_while
+  tt.func @partition_clc_while(
+      %response: !ttg.memdesc<2xi64, #clc_pl_shared, #clc_pl_smem, mutable>,
+      %initial_pid: i32, %initial_work: i1) {
+    // CHECK: nvws.warp_group
+    scf.while (%pid = %initial_pid, %has_work = %initial_work) : (i32, i1) -> (i32, i1) {
+      scf.condition(%has_work) {ttg.partition = array<i32: 0, 1, 2, 3>} %pid, %has_work : i32, i1
+    } do {
+    ^bb0(%pid: i32, %has_work: i1):
+      // CHECK: partition0 num_warps(4)
+      // CHECK-NEXT: {{%.*}}:2 = scf.while
+      // CHECK: "epilogue"
+      // CHECK: ttng.clc_is_canceled
+      // CHECK: scf.if
+      // CHECK: ttng.clc_get_program_id
+      "epilogue"(%pid) {ttg.partition = array<i32: 0>} : (i32) -> ()
+      // CHECK: partition1 num_warps(4)
+      // CHECK-NEXT: {{%.*}} = scf.while
+      // CHECK: "mma"
+      // CHECK: ttng.clc_is_canceled
+      // CHECK: scf.if
+      // CHECK: ttng.clc_get_program_id
+      "mma"(%pid) {ttg.partition = array<i32: 1>} : (i32) -> ()
+      // CHECK: partition2 num_warps(4)
+      // CHECK-NEXT: {{%.*}} = scf.while
+      // CHECK: "load"
+      // CHECK: ttng.clc_is_canceled
+      // CHECK: scf.if
+      // CHECK: ttng.clc_get_program_id
+      "load"(%pid) {ttg.partition = array<i32: 2>} : (i32) -> ()
+      // CHECK: partition3 num_warps(4)
+      // CHECK-NEXT: {{%.*}} = scf.while
+      // CHECK: nvws.clc_try_cancel
+      // CHECK-NOT: nvws.clc_try_cancel
+      // CHECK: ttng.clc_is_canceled
+      // CHECK: scf.if
+      // CHECK: ttng.clc_get_program_id
+      nvws.clc_try_cancel %response {ttg.partition = array<i32: 3>} : !ttg.memdesc<2xi64, #clc_pl_shared, #clc_pl_smem, mutable>
+      %raw = "response"() {ttg.partition = array<i32: 0, 1, 2, 3>} : () -> i128
+      %next_work = ttng.clc_is_canceled %raw {ttg.partition = array<i32: 0, 1, 2, 3>} : i128 -> i1
+      %next_pid = scf.if %next_work -> i32 {
+        %stolen = ttng.clc_get_program_id %raw, x {ttg.partition = array<i32: 0, 1, 2, 3>} : i128 -> i32
+        scf.yield {ttg.partition = array<i32: 0, 1, 2, 3>} %stolen : i32
+      } else {
+        scf.yield {ttg.partition = array<i32: 0, 1, 2, 3>} %pid : i32
+      } {ttg.partition = array<i32: 0, 1, 2, 3>, ttg.partition.outputs = [array<i32: 0, 1, 2, 3>]}
+      // CHECK: nvws.warp_group.return
+      // CHECK-NOT: nvws.warp_group
+      // CHECK-NOT: ttg.partition
+      scf.yield {ttg.partition = array<i32: 0, 1, 2, 3>} %next_pid, %next_work : i32, i1
+    } attributes {tt.warp_specialize, ttg.partition = array<i32: 0, 1, 2, 3>, ttg.partition.outputs = [array<i32: 0, 1, 2, 3>, array<i32: 0, 1, 2, 3>], ttg.partition.stages = [0, 0, 0, 0], ttg.warp_specialize.tag = 7 : i32}
+    tt.return
+  }
+}
+
+// -----
+
+module attributes {"ttg.num-warps" = 4 : i32} {
+  // CHECK-LABEL: @while_result_direct_partitioned_use
+  tt.func @while_result_direct_partitioned_use(%initial: i32) {
+    %c1 = arith.constant 1 : i32
+    %true = arith.constant true
+    %false = arith.constant false
+    // CHECK: nvws.warp_group
+    %loop:2 = scf.while (%state = %initial, %keep_going = %true) : (i32, i1) -> (i32, i1) {
+      // CHECK-NEXT: partition0 num_warps(4)
+      // CHECK-NEXT: {{%.*}} = scf.while
+      scf.condition(%keep_going) {ttg.partition = array<i32: 0, 1>} %state, %keep_going : i32, i1
+    } do {
+    ^bb0(%state: i32, %keep_going: i1):
+      // CHECK: partition1 num_warps(4)
+      // CHECK-NEXT: %[[RESULT:.*]] = scf.while
+      %next = arith.addi %state, %c1 {ttg.partition = array<i32: 1>} : i32
+      scf.yield {ttg.partition = array<i32: 0, 1>} %next, %false : i32, i1
+    } attributes {tt.warp_specialize, ttg.partition = array<i32: 0, 1>, ttg.partition.outputs = [array<i32: 1>, array<i32: 0, 1>], ttg.partition.stages = [0, 0], ttg.warp_specialize.tag = 0 : i32}
+    // CHECK: %[[AFTER_VALUE:.*]] = arith.addi %[[RESULT]],
+    %after_value = arith.addi %loop#0, %c1 {ttg.partition = array<i32: 1>, ttg.warp_specialize.tag = 0 : i32} : i32
+    // CHECK-NEXT: "after"(%[[AFTER_VALUE]])
+    "after"(%after_value) {ttg.partition = array<i32: 1>, ttg.warp_specialize.tag = 0 : i32} : (i32) -> ()
+    tt.return
+  }
+}
+
+// -----
+
+module attributes {"ttg.num-warps" = 4 : i32} {
+  // CHECK-LABEL: @aref_phi_for
+  tt.func @aref_phi_for(%lb: i32, %ub: i32, %step: i32) {
+    scf.for %i = %lb to %ub step %step : i32 {
+      %local = "local"() {ttg.partition = array<i32: 1>} : () -> i32
+      %remote = "remote"() {ttg.partition = array<i32: 0>} : () -> i32
+      // CHECK: partition0
+      // CHECK: %[[REMOTE:.*]] = "remote"
+      // CHECK: "consume"(%[[REMOTE]])
+      // CHECK: partition1
+      // CHECK: %[[LOCAL:.*]] = "local"
+      // CHECK: "consume"(%[[LOCAL]])
+      // CHECK-NOT: nvws.aref.phi
+      %selected = nvws.aref.phi %local, %remote {ttg.partition = array<i32: 0, 1>} : i32
+      "consume"(%selected) {ttg.partition = array<i32: 0, 1>} : (i32) -> ()
+      scf.yield {ttg.partition = array<i32: 0, 1>}
+    } {tt.warp_specialize, ttg.partition = array<i32: 0, 1>, ttg.partition.stages = [0, 0], ttg.warp_specialize.tag = 0 : i32}
+    tt.return
+  }
+}
+
+// -----
+
+module attributes {"ttg.num-warps" = 4 : i32} {
+  // CHECK-LABEL: @aref_phi_for_iter_arg
+  tt.func @aref_phi_for_iter_arg(%lb: i32, %ub: i32, %step: i32, %initial: i32) {
+    %result = scf.for %i = %lb to %ub step %step iter_args(%state = %initial) -> i32 : i32 {
+      %remote = "remote"() {ttg.partition = array<i32: 0>} : () -> i32
+      // CHECK: partition0
+      // CHECK: %[[REMOTE:.*]] = "remote"
+      // CHECK: "consume"(%[[REMOTE]])
+      // CHECK: partition1
+      // CHECK: "consume"(%{{.*}})
+      // CHECK-NOT: nvws.aref.phi
+      %selected = nvws.aref.phi %state, %remote {ttg.partition = array<i32: 0, 1>} : i32
+      "consume"(%selected) {ttg.partition = array<i32: 0, 1>} : (i32) -> ()
+      %next = "update"(%selected) {ttg.partition = array<i32: 1>} : (i32) -> i32
+      scf.yield {ttg.partition = array<i32: 1>} %next : i32
+    } {tt.warp_specialize, ttg.partition = array<i32: 0, 1>, ttg.partition.outputs = [array<i32: 1>], ttg.partition.stages = [0, 0], ttg.warp_specialize.tag = 0 : i32}
+    tt.return
+  }
+}
+
+// -----
+
+module attributes {"ttg.num-warps" = 4 : i32} {
+  // CHECK-LABEL: @aref_phi_while
+  tt.func @aref_phi_while(%run: i1) {
+    scf.while (%keep_going = %run) : (i1) -> i1 {
+      scf.condition(%keep_going) {ttg.partition = array<i32: 0, 1>} %keep_going : i1
+    } do {
+    ^bb0(%keep_going: i1):
+      %local = "local"() {ttg.partition = array<i32: 1>} : () -> i32
+      %remote = "remote"() {ttg.partition = array<i32: 0>} : () -> i32
+      // CHECK: partition0
+      // CHECK: %[[WHILE_REMOTE:.*]] = "remote"
+      // CHECK: "consume"(%[[WHILE_REMOTE]])
+      // CHECK: partition1
+      // CHECK: %[[WHILE_LOCAL:.*]] = "local"
+      // CHECK: "consume"(%[[WHILE_LOCAL]])
+      // CHECK-NOT: nvws.aref.phi
+      %selected = nvws.aref.phi %local, %remote {ttg.partition = array<i32: 0, 1>} : i32
+      "consume"(%selected) {ttg.partition = array<i32: 0, 1>} : (i32) -> ()
+      scf.yield {ttg.partition = array<i32: 0, 1>} %keep_going : i1
+    } attributes {tt.warp_specialize, ttg.partition = array<i32: 0, 1>, ttg.partition.outputs = [array<i32: 0, 1>], ttg.partition.stages = [0, 0], ttg.warp_specialize.tag = 0 : i32}
+    tt.return
+  }
+}

--- a/test/TritonGPU/partition-scheduling.mlir
+++ b/test/TritonGPU/partition-scheduling.mlir
@@ -743,3 +743,67 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.targ
     tt.return
   }
 }
+
+// -----
+
+#clc_ps_response = #ttg.linear<{register = [[1]], lane = [[0], [0], [0], [0], [0]], warp = [[0], [0]], block = []}>
+#clc_ps_response_shared = #ttg.swizzled_shared<{vec = 1, perPhase = 1, maxPhase = 1, order = [0]}>
+#clc_ps_oper = #ttg.blocked<{sizePerThread = [1, 1], threadsPerWarp = [1, 32], warpsPerCTA = [2, 2], order = [1, 0]}>
+#clc_ps_acc = #ttg.blocked<{sizePerThread = [1, 128], threadsPerWarp = [32, 1], warpsPerCTA = [4, 1], order = [0, 1]}>
+#clc_ps_shared = #ttg.nvmma_shared<{swizzlingByteWidth = 128, transposed = false, elementBitWidth = 16}>
+#clc_ps_shared_t = #ttg.nvmma_shared<{swizzlingByteWidth = 128, transposed = true, elementBitWidth = 16}>
+#clc_ps_smem = #ttg.shared_memory
+#clc_ps_tmem = #ttng.tensor_memory_encoding<blockM = 128, blockN = 128, colStride = 1>
+
+module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.target = "cuda:100"} {
+  // CHECK-LABEL: @clc_while_partitions
+  tt.func @clc_while_partitions(
+      %a_desc: !tt.tensordesc<128x64xf16, #clc_ps_shared>,
+      %b_desc: !tt.tensordesc<128x64xf16, #clc_ps_shared>,
+      %out: !tt.ptr<i32>) {
+    %c0 = arith.constant 0 : i32
+    %true = arith.constant true
+    %false = arith.constant false
+    %pid0 = tt.get_program_id x : i32
+    scf.while (%pid = %pid0, %has_work = %true) : (i32, i1) -> (i32, i1) {
+      // CHECK: scf.condition({{.*}}) {ttg.partition = array<i32: 0, 1, 2, 3>}
+      scf.condition(%has_work) %pid, %has_work : i32, i1
+    } do {
+    ^bb0(%pid: i32, %has_work: i1):
+      // CHECK: %[[RESPONSE:.*]] = ttng.clc_try_cancel_sync {ttg.partition = array<i32: 3>} : tensor<2xi64,
+      %response = ttng.clc_try_cancel_sync : tensor<2xi64, #clc_ps_response>
+      // CHECK-NEXT: %[[MARKER:.*]] = ttg.local_alloc %[[RESPONSE]] {alignment = 16 : i32, ttg.partition = array<i32: 3>}
+      %response_smem = ttg.local_alloc %response {alignment = 16 : i32} : (tensor<2xi64, #clc_ps_response>) -> !ttg.memdesc<2xi64, #clc_ps_response_shared, #clc_ps_smem, mutable>
+      // CHECK-COUNT-2: tt.descriptor_load {{.*}} {ttg.partition = array<i32: 2>}
+      %a = tt.descriptor_load %a_desc[%pid, %c0] : !tt.tensordesc<128x64xf16, #clc_ps_shared> -> tensor<128x64xf16, #clc_ps_oper>
+      %b = tt.descriptor_load %b_desc[%pid, %c0] : !tt.tensordesc<128x64xf16, #clc_ps_shared> -> tensor<128x64xf16, #clc_ps_oper>
+      %a_s = ttg.local_alloc %a : (tensor<128x64xf16, #clc_ps_oper>) -> !ttg.memdesc<128x64xf16, #clc_ps_shared, #clc_ps_smem>
+      %b_s0 = ttg.local_alloc %b : (tensor<128x64xf16, #clc_ps_oper>) -> !ttg.memdesc<128x64xf16, #clc_ps_shared, #clc_ps_smem>
+      %b_s = ttg.memdesc_trans %b_s0 {order = array<i32: 1, 0>} : !ttg.memdesc<128x64xf16, #clc_ps_shared, #clc_ps_smem> -> !ttg.memdesc<64x128xf16, #clc_ps_shared_t, #clc_ps_smem>
+      %acc_mem, %acc_tok = ttng.tmem_alloc : () -> (!ttg.memdesc<128x128xf32, #clc_ps_tmem, #ttng.tensor_memory, mutable>, !ttg.async.token)
+      // CHECK: ttng.tc_gen5_mma {{.*}} {ttg.partition = array<i32: 1>}
+      %mma = ttng.tc_gen5_mma %a_s, %b_s, %acc_mem[%acc_tok], %false, %true : !ttg.memdesc<128x64xf16, #clc_ps_shared, #clc_ps_smem>, !ttg.memdesc<64x128xf16, #clc_ps_shared_t, #clc_ps_smem>, !ttg.memdesc<128x128xf32, #clc_ps_tmem, #ttng.tensor_memory, mutable>
+      // CHECK: ttng.tmem_load {{.*}} {ttg.partition = array<i32: 0>}
+      %value, %load_tok = ttng.tmem_load %acc_mem[%mma] : !ttg.memdesc<128x128xf32, #clc_ps_tmem, #ttng.tensor_memory, mutable> -> tensor<128x128xf32, #clc_ps_acc>
+      "consume"(%value) : (tensor<128x128xf32, #clc_ps_acc>) -> ()
+      %out_ptr = tt.addptr %out, %pid : !tt.ptr<i32>, i32
+      tt.store %out_ptr, %pid : !tt.ptr<i32>
+      // CHECK: %[[RAW:.*]] = ttng.clc_load_result %[[MARKER]] {ttg.partition = array<i32: 0, 1, 2, 3>}
+      %raw = ttng.clc_load_result %response_smem : !ttg.memdesc<2xi64, #clc_ps_response_shared, #clc_ps_smem, mutable> -> i128
+      // CHECK: %[[HAS_WORK:.*]] = ttng.clc_is_canceled %[[RAW]] {ttg.partition = array<i32: 0, 1, 2, 3>} : i128 -> i1
+      %next_has_work = ttng.clc_is_canceled %raw : i128 -> i1
+      // CHECK: scf.if %[[HAS_WORK]] -> (i32)
+      %next_pid = scf.if %next_has_work -> i32 {
+        // CHECK: ttng.clc_get_program_id %[[RAW]], x {ttg.partition = array<i32: 0, 1, 2, 3>} : i128 -> i32
+        %stolen = ttng.clc_get_program_id %raw, x : i128 -> i32
+        scf.yield %stolen : i32
+      } else {
+        scf.yield %pid : i32
+      }
+      // CHECK: scf.yield {ttg.partition = array<i32: 0, 1, 2, 3>}
+      scf.yield %next_pid, %next_has_work : i32, i1
+    // CHECK: attributes {tt.warp_specialize, ttg.partition = array<i32: 0, 1, 2, 3>, ttg.partition.outputs = [array<i32: 0, 1, 2, 3>, array<i32: 0, 1, 2, 3>]
+    } attributes {tt.warp_specialize}
+    tt.return
+  }
+}

--- a/test/TritonNvidiaGPU/to-clc.mlir
+++ b/test/TritonNvidiaGPU/to-clc.mlir
@@ -89,6 +89,28 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.targ
 // -----
 
 module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.target = "cuda:100"} {
+  // CHECK-LABEL: tt.func public @marked_for
+  tt.func public @marked_for(%out: !tt.ptr<i32>) {
+    // CHECK: scf.while
+    // CHECK: ttng.clc_try_cancel_sync
+    // CHECK-NEXT: ttg.local_alloc
+    %pid = tt.get_program_id x : i32
+    %c0 = arith.constant 0 : index
+    %c1 = arith.constant 1 : index
+    // CHECK: scf.for
+    // CHECK: } {tt.warp_specialize}
+    scf.for %i = %c0 to %c1 step %c1 {
+      %ptr = tt.addptr %out, %pid : !tt.ptr<i32>, i32
+      tt.store %ptr, %pid : !tt.ptr<i32>
+    } {tt.warp_specialize}
+    // CHECK: ttng.clc_load_result
+    tt.return
+  }
+}
+
+// -----
+
+module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.target = "cuda:100"} {
   // CHECK-LABEL: tt.func public @no_pid
   tt.func public @no_pid(%out: !tt.ptr<i32>) {
     // CHECK: scf.while

--- a/third_party/nvidia/include/Dialect/NVWS/IR/NVWSAttrDefs.td
+++ b/third_party/nvidia/include/Dialect/NVWS/IR/NVWSAttrDefs.td
@@ -56,6 +56,7 @@ def NVWS_AsyncOpAttr: I32EnumAttr<
     I32EnumAttrCase<"TMEMCopy", 3, "tmem_copy">,
     I32EnumAttrCase<"CpAsync", 4, "cp_async">,
     I32EnumAttrCase<"WGMMA", 5, "wgmma">,
+    I32EnumAttrCase<"CLC", 6, "clc">,
   ]> {
   let cppNamespace = "::mlir::triton::nvws";
   let genSpecializedAttr = 0;

--- a/third_party/nvidia/include/Dialect/NVWS/IR/NVWSOps.td
+++ b/third_party/nvidia/include/Dialect/NVWS/IR/NVWSOps.td
@@ -61,6 +61,21 @@ def NVWS_ArefCreateOp : NVWS_Op<"aref.create", [
   let hasVerifier = 1;
 }
 
+def NVWS_ArefPhiOp : NVWS_Op<"aref.phi", [Pure, SameOperandsAndResultType]> {
+  let summary = "Select a local or remote aref value by partition";
+  let description = [{
+    Joins exactly two SSA values with disjoint partition ownership.  The
+    partition owning a physical clone selects the operand whose defining value
+    owns that partition.  Partition-loop construction resolves this operation
+    to the selected operand and emits no instruction.
+  }];
+
+  let arguments = (ins AnyType:$local, AnyType:$remote);
+  let results = (outs AnyType:$result);
+  let assemblyFormat = "$local `,` $remote attr-dict `:` type($result)";
+  let hasVerifier = 1;
+}
+
 def NVWS_ArefBufferOp : NVWS_Op<"aref.buffer", [DeclareOpInterfaceMethods<NVWS_ArefStageInterface>]> {
   let summary = "Get buffer from aref";
 
@@ -292,6 +307,22 @@ def NVWS_ConsumerReleaseOp : NVWS_Op<"consumer_release"> {
 
 def GlobalMemory : Resource<"::mlir::triton::GlobalMemory">;
 def SharedMemory : Resource<"::mlir::triton::gpu::SharedMemory">;
+
+def NVWS_CLCTryCancelOp : NVWS_Op<"clc_try_cancel"> {
+  let summary = "Issue a cluster launch control cancellation request";
+  let description = [{
+    Issues CLC cancellation request whose raw 16-byte response
+    is written into the supplied shared-memory buffer.
+  }];
+
+  let arguments = (ins
+    Arg<TTG_MemDescType, "", [MemWrite<SharedMemory>]>:$result
+  );
+
+  let assemblyFormat = [{
+    $result attr-dict `:` qualified(type($result))
+  }];
+}
 
 def NVWS_DescriptorLoadOp : NVWS_Op<"descriptor_load", [NVWS_DescriptorLoadOpInterface]> {
   let summary = "Load from descriptor and store into shared memory";

--- a/third_party/nvidia/lib/Dialect/NVWS/IR/Ops.cpp
+++ b/third_party/nvidia/lib/Dialect/NVWS/IR/Ops.cpp
@@ -1,3 +1,5 @@
+#include "lib/Dialect/TritonGPU/Transforms/WarpSpecialization/PartitionAttrs.h"
+#include "mlir/Dialect/SCF/IR/SCF.h"
 #include "mlir/IR/BuiltinTypes.h"
 #include "mlir/IR/Diagnostics.h"
 #include "mlir/IR/TypeRange.h"
@@ -40,6 +42,61 @@ LogicalResult ArefCreateOp::verify() {
   if (!llvm::all_equal(dims))
     return emitError("Leading dims of sliced aref inputs don't match.");
 
+  return success();
+}
+
+static FailureOr<SetVector<int>> getArefPhiOperandPartitions(Value value) {
+  if (auto result = dyn_cast<OpResult>(value)) {
+    Operation *def = result.getDefiningOp();
+    if (!gpu::hasPartition(def))
+      return failure();
+    if (!def->hasAttr(gpu::kPartitionOutputsAttrName))
+      return gpu::getPartitionIds(def);
+    auto outputs = gpu::getPartitionOutputs(def);
+    if (result.getResultNumber() >= outputs.size())
+      return failure();
+    return outputs[result.getResultNumber()];
+  }
+
+  auto arg = dyn_cast<BlockArgument>(value);
+  if (!arg || arg.getArgNumber() == 0)
+    return failure();
+  auto forOp = dyn_cast<scf::ForOp>(arg.getOwner()->getParentOp());
+  if (!forOp || !gpu::hasPartition(forOp) ||
+      !forOp->hasAttr(gpu::kPartitionOutputsAttrName))
+    return failure();
+  auto outputs = gpu::getPartitionOutputs(forOp);
+  unsigned resultNumber = arg.getArgNumber() - 1;
+  if (resultNumber >= outputs.size())
+    return failure();
+  return outputs[resultNumber];
+}
+
+LogicalResult ArefPhiOp::verify() {
+  if (!gpu::hasPartition(getOperation()))
+    return emitError("requires a non-empty ttg.partition annotation");
+
+  FailureOr<SetVector<int>> local = getArefPhiOperandPartitions(getLocal());
+  FailureOr<SetVector<int>> remote = getArefPhiOperandPartitions(getRemote());
+  if (failed(local) || local->empty())
+    return emitError("local operand must have partition ownership");
+  if (failed(remote) || remote->empty())
+    return emitError("remote operand must have partition ownership");
+
+  for (int partition : *local)
+    if (remote->contains(partition))
+      return emitError("partition ")
+             << partition << " is owned by both phi operands";
+
+  SetVector<int> covered(*local);
+  covered.insert(remote->begin(), remote->end());
+  SetVector<int> expected = gpu::getPartitionIds(getOperation());
+  if (covered.size() != expected.size() ||
+      llvm::any_of(covered, [&](int partition) {
+        return !expected.contains(partition);
+      }))
+    return emitError(
+        "operand partition union must exactly match the phi partition set");
   return success();
 }
 

--- a/third_party/nvidia/lib/Dialect/NVWS/Transforms/AssignStagePhase.cpp
+++ b/third_party/nvidia/lib/Dialect/NVWS/Transforms/AssignStagePhase.cpp
@@ -71,17 +71,25 @@ template <class T> struct AssignStagePhase {
     Value token;
   };
   Value aref;
-  int partitionId;
+  SetVector<int> partitionIds;
   DenseMap<std::pair<Operation *, Value>, int> tokToStagePosMap;
 
-  AssignStagePhase(Value aref, int partitionId)
-      : aref(aref), partitionId(partitionId) {}
+  AssignStagePhase(Value aref, SetVector<int> partitionIds)
+      : aref(aref), partitionIds(std::move(partitionIds)) {}
+
+  bool owns(Operation *op) const {
+    if (!hasPartition(op))
+      return true;
+    auto ids = getPartitionIds(op);
+    return llvm::all_of(partitionIds, [&](int id) { return ids.contains(id); });
+  }
+
+  SetVector<int> getOwnerPartitions() const { return partitionIds; }
 
   T getTypedOp(Operation *op) {
     if (auto opT = dyn_cast<T>(op)) {
       if (opT.getAref() == aref) {
-        if (!hasPartition(op) ||
-            llvm::is_contained(getPartitionIds(op), partitionId))
+        if (owns(op))
           return opT;
       }
     }
@@ -105,6 +113,14 @@ template <class T> struct AssignStagePhase {
           newTok = forOp.getRegionIterArgs()[*pos];
         }
         if (analyzeArefUseInBlock(forOp.getBody(), newTok))
+          return true;
+      } else if (auto whileOp = dyn_cast<scf::WhileOp>(op)) {
+        Value afterTok = token;
+        if (auto pos = findValuePosInRange(whileOp.getInits(), token))
+          afterTok = whileOp.getAfterArguments()[*pos];
+        // The before region computes the condition in the same partitions as
+        // the While and does not use arefs, so only inspect the after region.
+        if (analyzeArefUseInBlock(&whileOp.getAfter().front(), afterTok))
           return true;
       } else if (auto ifOp = dyn_cast<scf::IfOp>(op)) {
         if (analyzeArefUseInBlock(ifOp.thenBlock(), token))
@@ -190,6 +206,9 @@ template <class T> struct AssignStagePhase {
           argIds.insert(ids.begin(), ids.end());
         }
       }
+      // Unchanged stage/phase inherits this aref put/get group's owners.
+      if (argIds.empty())
+        argIds = getOwnerPartitions();
       forOpIds.insert(argIds.begin(), argIds.end());
       forOpOutputsIds.push_back(argIds);
     }
@@ -201,6 +220,71 @@ template <class T> struct AssignStagePhase {
       *arefIndexRefs[idx - nArgs] = forOp.getResult(idx);
     for (auto [idx, arefTokenRef] : arefTokenRefs)
       *arefTokenRef = forOp.getResult(idx);
+  }
+
+  void assignArefIndexInWhileOp(scf::WhileOp whileOp, StagePhase &index) {
+
+    Value newTok;
+    if (auto pos = findValuePosInRange(whileOp.getInits(), index.token))
+      newTok = whileOp.getAfterArguments()[*pos];
+    // find uses of arefs in the While body, only inspect after region
+    if (!analyzeArefUseInBlock(&whileOp.getAfter().front(), newTok))
+      return;
+
+    // add extra iterArgs to the While
+    SmallVector<Value> extraIterArgs{index.stage, index.phase};
+    SmallVector<Value *> arefIndexRefs{&index.stage, &index.phase};
+    llvm::MapVector<int, Value *> arefTokenRefs;
+    if (auto pos = findValuePosInRange(whileOp.getInits(), index.token))
+      arefTokenRefs[*pos] = &index.token;
+
+    // create new While with extra iterArgs
+    OpBuilder builder(whileOp);
+    auto nArgs = whileOp.getNumResults();
+    auto whileOpIds = getPartitionIds(whileOp);
+    auto whileOpOutputsIds = getPartitionOutputs(whileOp);
+    auto oldWhileOp = whileOp;
+    whileOp = replaceWhileOpWithNewSignature(
+        builder, whileOp, extraIterArgs,
+        TypeRange{index.stage.getType(), index.phase.getType()});
+    oldWhileOp.erase();
+
+    // forward the new state from the before region to the body
+    whileOp.getConditionOp().getArgsMutable().append(
+        whileOp.getBeforeArguments().drop_front(nArgs));
+
+    // update arefIndex with iterArgs in the While body
+    for (size_t idx = nArgs; idx < whileOp.getAfterArguments().size(); ++idx)
+      *arefIndexRefs[idx - nArgs] = whileOp.getAfterArguments()[idx];
+    for (auto [idx, arefTokenRef] : arefTokenRefs)
+      *arefTokenRef = whileOp.getAfterArguments()[idx];
+
+    // assign arefIndex in the While body
+    auto indexInBlock =
+        assignArefIndexInBlock(&whileOp.getAfter().front(), index);
+
+    // update yieldOp to return new indexes
+    auto yield = whileOp.getYieldOp();
+    SmallVector<Value> extraYieldArgs{indexInBlock.stage, indexInBlock.phase};
+    yield.getResultsMutable().append(extraYieldArgs);
+    for (auto [idx, _] : arefTokenRefs) {
+      if (yield.getOperand(idx) == indexInBlock.token)
+        tokToStagePosMap[{yield, indexInBlock.token}] = nArgs;
+    }
+
+    // update partitions of the While
+    auto ownerIds = getOwnerPartitions();
+    whileOpIds.insert(ownerIds.begin(), ownerIds.end());
+    whileOpOutputsIds.resize(whileOpOutputsIds.size() + extraYieldArgs.size(),
+                             ownerIds);
+    setPartition(whileOp, whileOpIds);
+    setPartitionOutputs(whileOp, whileOpOutputsIds);
+
+    // update arefIndex with results from new While
+    for (size_t idx = nArgs; idx < whileOp.getNumResults(); ++idx)
+      *arefIndexRefs[idx - nArgs] = whileOp.getResult(idx);
+    for (auto [idx, arefTokenRef] : arefTokenRefs)
+      *arefTokenRef = whileOp.getResult(idx);
   }
 
   void assignArefIndexInIfOp(scf::IfOp ifOp, StagePhase &index) {
@@ -330,6 +414,8 @@ template <class T> struct AssignStagePhase {
         opT.getPhaseMutable().assign(index.phase);
       } else if (auto forOp = dyn_cast<scf::ForOp>(op)) {
         assignArefIndexInForOp(forOp, index);
+      } else if (auto whileOp = dyn_cast<scf::WhileOp>(op)) {
+        assignArefIndexInWhileOp(whileOp, index);
       } else if (auto ifOp = dyn_cast<scf::IfOp>(op)) {
         assignArefIndexInIfOp(ifOp, index);
       }
@@ -372,34 +458,57 @@ template <class T> struct AssignStagePhase {
         auto iterTok = forOp.getRegionIterArg(tokPos);
         auto stagePos = tokToStagePosMap.at({forOp, iterTok});
         propagateStage(iterTok, forOp.getRegionIterArgs()[stagePos], visited);
+      } else if (auto whileOp = dyn_cast<scf::WhileOp>(owner)) {
+        auto tokPos = tokUse.getOperandNumber();
+        auto stagePos = *findValuePosInRange(whileOp.getInits(), stage);
+        propagateStageAcrossWhile(whileOp, tokPos, stagePos, visited);
       } else if (auto yieldOp = dyn_cast<scf::YieldOp>(owner)) {
         auto tokPos = tokUse.getOperandNumber();
         auto stagePos = tokToStagePosMap.at({yieldOp, token});
         auto parentOp = yieldOp->getParentOp();
-        propagateStage(parentOp->getResult(tokPos),
-                       parentOp->getResult(stagePos), visited);
+        if (auto whileOp = dyn_cast<scf::WhileOp>(parentOp)) {
+          propagateStageAcrossWhile(whileOp, tokPos, stagePos, visited);
+        } else {
+          propagateStage(parentOp->getResult(tokPos),
+                         parentOp->getResult(stagePos), visited);
+        }
       }
     }
   }
 
+  void propagateStageAcrossWhile(scf::WhileOp whileOp, unsigned tokenPos,
+                                 unsigned stagePos,
+                                 DenseSet<Operation *> &visited) {
+    propagateStage(whileOp.getAfterArguments()[tokenPos],
+                   whileOp.getAfterArguments()[stagePos], visited);
+    propagateStage(whileOp.getResult(tokenPos), whileOp.getResult(stagePos),
+                   visited);
+  }
+
   static LogicalResult run(ArefCreateOp arefOp) {
-    std::set<int> partitionIds;
+    SmallVector<SetVector<int>> ownerGroups;
     for (auto user : arefOp->getUsers()) {
-      // Each partition requires its own stage/phase tracking for proper
-      // multi-user handling; collect partition IDs in which this aref is used
-      if (isa<T>(user)) {
-        if (hasPartition(user)) {
-          auto ids = getPartitionIds(user);
-          partitionIds.insert(ids.begin(), ids.end());
-        }
-      }
+      // Track stage/phase once per distinct aref owner group.
+      if (!isa<T>(user) || !hasPartition(user))
+        continue;
+      auto ids = getPartitionIds(user);
+      bool exists = llvm::any_of(ownerGroups, [&](const SetVector<int> &group) {
+        return ids.size() == group.size() &&
+               llvm::all_of(ids, [&](int id) { return group.contains(id); });
+      });
+      if (!exists)
+        ownerGroups.push_back(std::move(ids));
     }
-    if (partitionIds.empty()) {
-      // if partitionIds is an empty set, it means aref ops used outside ttg.ws
-      // so we to insert a dummy partitionId for this aref, since we still need
-      // to assign correct phase
-      partitionIds.insert({0, 0});
+    if (ownerGroups.empty()) {
+      // No partition metadata means the aref is outside ttg.ws. Use one dummy
+      // owner so it still receives a valid stage and phase.
+      SetVector<int> singleton;
+      singleton.insert(0);
+      ownerGroups.push_back(std::move(singleton));
     }
+    llvm::sort(ownerGroups, [](const auto &lhs, const auto &rhs) {
+      return lhs.getArrayRef() < rhs.getArrayRef();
+    });
 
     // initialize indexes
     StagePhase index;
@@ -415,22 +524,22 @@ template <class T> struct AssignStagePhase {
     auto initPhase = std::is_same_v<T, ArefPutEnterOp> ? 0 : 1;
     index.phase = arith::ConstantIntOp::create(b, initPhase, 32);
 
-    for (auto partitionId : partitionIds) {
-      // assign stage/phase to enter/exit Ops in each partition aref is used
-      AssignStagePhase arefIndex(arefOp.getResult(), partitionId);
+    for (const SetVector<int> &ownerGroup : ownerGroups) {
+      // Assign stage/phase to enter/exit Ops in partitions aref is used
+      AssignStagePhase arefIndex(arefOp.getResult(), ownerGroup);
 
-      // assign stage/phase to enterOps
+      // Assign stage/phase to enter operations.
       arefIndex.assignArefIndexInBlock(arefOp->getBlock(), index);
 
-      // propagate stage to exitOps following enterOp token
-      for (auto user : arefOp->getUsers())
-        if (auto enterOp = dyn_cast<T>(user);
-            enterOp && (!hasPartition(enterOp) ||
-                        getPartitionIds(enterOp).front() == partitionId)) {
-          DenseSet<Operation *> visited;
-          arefIndex.propagateStage(enterOp.getToken(), enterOp.getStage(),
-                                   visited);
-        }
+      // Propagate stage to exit operations following each enter token.
+      for (auto user : arefOp->getUsers()) {
+        auto enterOp = dyn_cast<T>(user);
+        if (!enterOp || !arefIndex.owns(enterOp))
+          continue;
+        DenseSet<Operation *> visited;
+        arefIndex.propagateStage(enterOp.getToken(), enterOp.getStage(),
+                                 visited);
+      }
     }
 
     return success();

--- a/third_party/nvidia/lib/Dialect/NVWS/Transforms/HoistTmemStore.cpp
+++ b/third_party/nvidia/lib/Dialect/NVWS/Transforms/HoistTmemStore.cpp
@@ -26,6 +26,7 @@
 #include "mlir/Dialect/Arith/IR/Arith.h"
 #include "mlir/Dialect/LLVMIR/LLVMDialect.h"
 #include "mlir/Interfaces/InferIntRangeInterface.h"
+#include "mlir/Interfaces/LoopLikeInterface.h"
 #include "mlir/Interfaces/Utils/InferIntRangeCommon.h"
 #include "mlir/Pass/Pass.h"
 #include "mlir/Pass/PassManager.h"
@@ -53,22 +54,13 @@ namespace triton {
 namespace {
 
 bool underWSLoop(Operation *op) {
-  scf::ForOp topLevelFor = op->getParentOfType<scf::ForOp>();
-  if (!topLevelFor) {
-    return false;
-  }
-
-  if (topLevelFor->hasAttr(kWarpSpecializeAttrName)) {
-    return true;
-  } else {
-    while (auto outer = topLevelFor->getParentOfType<scf::ForOp>()) {
-      topLevelFor = outer;
-      if (outer->hasAttr(kWarpSpecializeAttrName)) {
-        return true;
-      }
+  for (Operation *parent = op->getParentOp(); parent;
+       parent = parent->getParentOp()) {
+    if (isa<scf::ForOp, scf::WhileOp>(parent) &&
+        parent->hasAttr(kWarpSpecializeAttrName)) {
+      return true;
     }
   }
-
   return false;
 }
 
@@ -197,18 +189,18 @@ bool canProveExecuteOnce(scf::ForOp forOp) {
 
 bool hoistTmemAlloc(ttng::TMEMAllocOp allocToHoist) {
   // extra loop nest
-  SmallVector<scf::ForOp> loopNest;
-  auto currentForOp = allocToHoist->getParentOfType<scf::ForOp>();
-  while (currentForOp && !currentForOp->hasAttr(kWarpSpecializeAttrName)) {
-    loopNest.push_back(currentForOp);
-    currentForOp = currentForOp->getParentOfType<scf::ForOp>();
+  SmallVector<LoopLikeOpInterface> loopNest;
+  auto currentLoop = allocToHoist->getParentOfType<LoopLikeOpInterface>();
+  while (currentLoop && !currentLoop->hasAttr(kWarpSpecializeAttrName)) {
+    loopNest.push_back(currentLoop);
+    currentLoop = currentLoop->getParentOfType<LoopLikeOpInterface>();
   }
 
-  if (!currentForOp) {
+  if (!currentLoop) {
     return false;
   }
 
-  loopNest.push_back(currentForOp);
+  loopNest.push_back(currentLoop);
 
   {
     // Check if hoisting across all loop nests is valid. Hoisting is invalid
@@ -226,9 +218,10 @@ bool hoistTmemAlloc(ttng::TMEMAllocOp allocToHoist) {
       return false;
     }
 
-    SmallVector<scf::ForOp> innerLoopNest{opt->first};
-    innerLoopNest.insert(innerLoopNest.begin(), loopNest.begin(),
-                         loopNest.end() - 1);
+    SmallVector<scf::ForOp> innerLoopNest;
+    for (LoopLikeOpInterface loop : ArrayRef(loopNest).drop_back())
+      innerLoopNest.push_back(cast<scf::ForOp>(loop.getOperation()));
+    innerLoopNest.push_back(opt->first);
 
     // Does the expression x depend on y?
     auto dependOn = [](Value x, Value y) {
@@ -246,11 +239,19 @@ bool hoistTmemAlloc(ttng::TMEMAllocOp allocToHoist) {
 
     for (auto [i, innerFor] : llvm::enumerate(innerLoopNest)) {
       for (int j = i; j < loopNest.size(); ++j) {
-        auto outerForIter = loopNest[j].getInductionVar();
-        if ((dependOn(innerFor.getLowerBound(), outerForIter) ||
-             dependOn(innerFor.getUpperBound(), outerForIter)) &&
-            !canProveExecuteOnce(innerFor)) {
-          // Cannot hoist this tmem alloc across the outer loop loopNest[j]
+        auto outerLoop = loopNest[j];
+        bool depends;
+        if (auto outerFor = dyn_cast<scf::ForOp>(outerLoop.getOperation())) {
+          auto outerForIter = outerFor.getInductionVar();
+          depends = dependOn(innerFor.getLowerBound(), outerForIter) ||
+                    dependOn(innerFor.getUpperBound(), outerForIter);
+        } else {
+          auto outerWhile = cast<scf::WhileOp>(outerLoop.getOperation());
+          depends =
+              !outerWhile.isDefinedOutsideOfLoop(innerFor.getLowerBound()) ||
+              !outerWhile.isDefinedOutsideOfLoop(innerFor.getUpperBound());
+        }
+        if (depends && !canProveExecuteOnce(innerFor)) {
           return false;
         }
       }
@@ -258,36 +259,49 @@ bool hoistTmemAlloc(ttng::TMEMAllocOp allocToHoist) {
   }
 
   // hoist to outside tt.warp_specialized loop
-  allocToHoist->moveBefore(currentForOp);
+  allocToHoist->moveBefore(currentLoop);
   allocToHoist->removeAttr(kPartitionAttrName);
 
   Value token = allocToHoist.getToken();
   assert(token.hasOneUse());
   auto &tokenUse = *token.getUses().begin();
+  auto currentForOp = cast<scf::ForOp>(tokenUse.getOwner());
   auto tokenPos =
       tokenUse.getOperandNumber() - currentForOp.getNumControlOperands();
   auto tokenPartition = getPartitionOutputs(tokenUse.getOwner())[tokenPos];
 
-  // thread token to for-op init/iter args from outer-to inner
+  // thread token to loop init/iter args from outer-to inner
   std::reverse(loopNest.begin(), loopNest.end());
-  for (auto &forOp : loopNest) {
-    OpBuilder b(forOp);
-    int nArgs = forOp.getRegionIterArgs().size();
-    forOp = addIterArgsToLoop(b, forOp, {token});
-
-    // update partitions for the forOp
-    if (forOp->hasAttr(kPartitionOutputsAttrName)) {
-      auto partitionOuputs = getPartitionOutputs(forOp);
-      partitionOuputs.push_back(tokenPartition);
-      setPartitionOutputs(forOp, partitionOuputs);
+  for (LoopLikeOpInterface &loop : loopNest) {
+    if (auto forOp = dyn_cast<scf::ForOp>(loop.getOperation())) {
+      OpBuilder builder(forOp);
+      forOp = addIterArgsToLoop(builder, forOp, {token});
+      token = forOp.getRegionIterArgs().back();
+      loop = forOp;
     } else {
-      setPartitionOutputs(forOp, {tokenPartition});
+      auto whileOp = cast<scf::WhileOp>(loop.getOperation());
+      auto oldWhile = whileOp;
+      OpBuilder builder(whileOp);
+      whileOp = replaceWhileOpWithNewSignature(builder, whileOp, {token},
+                                               {token.getType()});
+      oldWhile.erase();
+      whileOp.getConditionOp().getArgsMutable().append(
+          whileOp.getBeforeArguments().back());
+      token = whileOp.getAfterArguments().back();
+      loop = whileOp;
     }
-    auto partitions = getPartitionIds(forOp);
-    partitions.insert(tokenPartition.begin(), tokenPartition.end());
-    setPartition(forOp, partitions);
 
-    token = forOp.getRegionIterArg(nArgs);
+    // update partitions for the loop
+    if (loop->hasAttr(kPartitionOutputsAttrName)) {
+      auto outputs = getPartitionOutputs(loop);
+      outputs.push_back(tokenPartition);
+      setPartitionOutputs(loop, outputs);
+    } else {
+      setPartitionOutputs(loop, {tokenPartition});
+    }
+    auto partitions = getPartitionIds(loop);
+    partitions.insert(tokenPartition.begin(), tokenPartition.end());
+    setPartition(loop, partitions);
   }
 
   // set inner loop init_args with updated token
@@ -310,10 +324,17 @@ bool hoistTmemAlloc(ttng::TMEMAllocOp allocToHoist) {
 
   // append token to yield, from inner to outer loop
   std::reverse(loopNest.begin(), loopNest.end());
-  for (auto forOp : loopNest) {
-    appendToForOpYield(forOp, {token});
-    setPartition(forOp.getBody()->getTerminator(), getPartitionIds(forOp));
-    token = forOp->getResults().back();
+  for (auto loop : loopNest) {
+    if (auto forOp = dyn_cast<scf::ForOp>(loop.getOperation())) {
+      appendToForOpYield(forOp, {token});
+      setPartition(forOp.getBody()->getTerminator(), getPartitionIds(forOp));
+    } else {
+      cast<scf::WhileOp>(loop.getOperation())
+          .getYieldOp()
+          .getResultsMutable()
+          .append(token);
+    }
+    token = loop->getResults().back();
   }
 
   return true;
@@ -335,27 +356,33 @@ public:
     if (failed(applyPatternsGreedily(m, std::move(patterns))))
       signalPassFailure();
 
-    m.walk([&](scf::ForOp loop) {
-      if (loop->hasAttr(kWarpSpecializeAttrName)) {
-        SmallVector<ttng::TMEMAllocOp> tmemAllocToHoist;
-        loop.walk([&](ttng::TMEMAllocOp tmemAlloc) {
-          if (tmemAlloc.getSrc() && canRemoveTmemStore(tmemAlloc)) {
-            tmemAllocToHoist.push_back(tmemAlloc);
-          }
-        });
-
-        for (auto alloc : tmemAllocToHoist) {
-          if (!hoistTmemAlloc(alloc)) {
-            SetVector<int> mmaPartition;
-            mmaPartition.insert(1);
-            // tmem store remaining in the outer loop must belong to the MMA
-            // partition. This is required by aref-tmem-insert for correctly
-            // double buffering this accumulator.
-            setPartition(alloc, mmaPartition);
-          }
-        }
-      }
+    SmallVector<LoopLikeOpInterface> loops;
+    m.walk([&](LoopLikeOpInterface loop) {
+      if (isa<scf::ForOp, scf::WhileOp>(loop.getOperation()) &&
+          loop->hasAttr(kWarpSpecializeAttrName))
+        loops.push_back(loop);
     });
+
+    for (LoopLikeOpInterface loop : loops) {
+      SmallVector<ttng::TMEMAllocOp> tmemAllocToHoist;
+      loop->walk([&](ttng::TMEMAllocOp tmemAlloc) {
+        if (tmemAlloc.getSrc() && canRemoveTmemStore(tmemAlloc)) {
+          tmemAllocToHoist.push_back(tmemAlloc);
+        }
+      });
+
+      for (auto alloc : tmemAllocToHoist) {
+        if (hoistTmemAlloc(alloc))
+          continue;
+
+        SetVector<int> mmaPartition;
+        mmaPartition.insert(1);
+        // A TMEM store remaining in the outer loop must belong to the MMA
+        // partition. This is required by aref-tmem-insert for correctly
+        // double buffering this accumulator.
+        setPartition(alloc, mmaPartition);
+      }
+    }
   }
 }; // namespace triton
 

--- a/third_party/nvidia/lib/Dialect/NVWS/Transforms/InsertAref.cpp
+++ b/third_party/nvidia/lib/Dialect/NVWS/Transforms/InsertAref.cpp
@@ -38,8 +38,7 @@ struct ProducedValueInfo {
   Value result;
 };
 
-SmallVector<ProducedValueInfo> getProducedValues(Operation *op,
-                                                 Block *loopBody) {
+SmallVector<ProducedValueInfo> getProducedValues(Operation *op) {
   SmallVector<ProducedValueInfo> producedValues;
 
   if (!hasPartition(op))
@@ -83,6 +82,14 @@ template <typename AllocOp> auto isDescLoadAndAlloc(Value result) {
 
 template <typename AllocOp> auto isGlobalLoadAndAlloc(Value result) {
   return isLoadAndAlloc<AllocOp, triton::LoadOp>(result);
+}
+
+static triton::nvidia_gpu::CLCTryCancelSyncOp getCLCTryCancel(Value result) {
+  auto alloc = result.getDefiningOp<LocalAllocOp>();
+  return alloc && alloc.getSrc()
+             ? alloc.getSrc()
+                   .getDefiningOp<triton::nvidia_gpu::CLCTryCancelSyncOp>()
+             : triton::nvidia_gpu::CLCTryCancelSyncOp();
 }
 
 RankedTensorType getTensorTypeFromScalar(OpBuilder &builder, Value scalar) {
@@ -138,10 +145,15 @@ ArefCreateOp createAref(OpBuilder &builder, ProducedValueInfo &producedValue) {
     llvm::report_fatal_error(msg.c_str());
   }
 
-  MemDescType arefBufType = getMultiBufferedType(memDescType, 1);
+  auto clc = getCLCTryCancel(result);
+  int depth = clc ? 2 : 1;
+  MemDescType arefBufType = getMultiBufferedType(memDescType, depth);
   assert(isa<SharedMemorySpaceAttr>(arefBufType.getMemorySpace()));
   auto loc = result.getLoc();
-  auto alloc = triton::nvws::createAlloc(builder, loc, arefBufType, Value());
+  std::optional<int32_t> alignment =
+      clc ? std::optional<int32_t>(16) : std::nullopt;
+  auto alloc =
+      triton::nvws::createAlloc(builder, loc, arefBufType, Value(), alignment);
   return createArefCreateOp(builder, {arefBufType}, {alloc->getResult(0)}, loc);
 }
 
@@ -186,6 +198,15 @@ void createNVWSDescriptorLoadOp(OpBuilder &builder, Operation *ttDescLoadOp,
   }
 }
 
+void createNVWSCLCTryCancelOp(OpBuilder &builder,
+                              triton::nvidia_gpu::CLCTryCancelSyncOp clc,
+                              Value dataBuf,
+                              const SetVector<int> &producerPartitions,
+                              StageCluster stageCluster) {
+  triton::gpu::createInto<nvws::CLCTryCancelOp>(
+      builder, clc.getLoc(), producerPartitions, stageCluster, dataBuf);
+}
+
 StageCluster getStageClusterForProducer(Value producedValue) {
   if (auto arg = dyn_cast<BlockArgument>(producedValue)) {
     Value prevProducedValue;
@@ -195,7 +216,10 @@ StageCluster getStageClusterForProducer(Value producedValue) {
       if (!isa<scf::YieldOp>(terminator)) {
         return {};
       }
-      producedValue = terminator->getOperand(arg.getArgNumber() - 1);
+      auto loop = cast<LoopLikeOpInterface>(arg.getOwner()->getParentOp());
+      auto firstLane =
+          arg.getOwner()->getNumArguments() - loop.getRegionIterArgs().size();
+      producedValue = terminator->getOperand(arg.getArgNumber() - firstLane);
       arg = dyn_cast<BlockArgument>(producedValue);
     } while (arg && prevProducedValue != producedValue);
   }
@@ -241,10 +265,18 @@ SmallVector<Operation *> createArefPut(OpBuilder &builder, ArefCreateOp aref,
   } else if (isGlobalLoadAndAlloc<LocalAllocOp>(result)) {
     llvm_unreachable("cpasync not supported yet");
   } else if (auto alloc = result.getDefiningOp<LocalAllocOp>()) {
-    triton::gpu::createInto<LocalStoreOp>(builder, loc, producerPartitions,
-                                          stageCluster, alloc.getSrc(),
-                                          dataBuf);
-    staleOps.push_back(alloc);
+    if (auto clc = getCLCTryCancel(result)) {
+      createNVWSCLCTryCancelOp(builder, clc, dataBuf, producerPartitions,
+                               stageCluster);
+      producerKind = AsyncOp::CLC;
+      staleOps.push_back(alloc);
+      staleOps.push_back(clc);
+    } else {
+      triton::gpu::createInto<LocalStoreOp>(builder, loc, producerPartitions,
+                                            stageCluster, alloc.getSrc(),
+                                            dataBuf);
+      staleOps.push_back(alloc);
+    }
   } else if (auto tensorType = dyn_cast<RankedTensorType>(result.getType())) {
     if (auto descOp = result.getDefiningOp<triton::DescriptorOpInterface>()) {
       createNVWSDescriptorLoadOp(builder, descOp, dataBuf, producerPartitions,
@@ -331,7 +363,7 @@ SmallVector<Attribute> getConsumerAsyncOpKinds(ArrayRef<Operation *> consumers,
                                                MLIRContext *ctx) {
   SetVector<AsyncOp> kindSet;
   for (auto consumer : consumers) {
-    if (isa<scf::ForOp>(consumer) && consumers.size() > 1) {
+    if (isa<scf::ForOp, scf::WhileOp>(consumer) && consumers.size() > 1) {
       // In this case, a getExit is placed after the consumer loop. The
       // corresponding async kind attributes should be determined from other
       // consumer ops in the loop.
@@ -380,6 +412,12 @@ getEnterAndExitStageClustersOfUses(const SetVector<Value> &producedResults,
       return std::make_pair(stageCluster, stageCluster);
     }
     auto op = res.getDefiningOp();
+    // Look through aref.phi to the actual scheduled consumer.
+    auto users = getTopLevelUsersInLoop(op, forOp, filterUse);
+    auto phi = llvm::find_if(
+        users, [](Operation *user) { return isa<ArefPhiOp>(user); });
+    if (phi != users.end())
+      op = *phi;
     ops.push_back(op);
   }
 
@@ -392,31 +430,36 @@ getEnterAndExitStageClustersOfUses(const SetVector<Value> &producedResults,
   return std::make_pair(getStageCluster(firstOp), getStageCluster(lastOp));
 }
 
-void createArefGet(OpBuilder &builder, scf::ForOp loop, ArefCreateOp aref,
-                   const SetVector<Value> &results, int consumerPartition,
+void createArefGet(OpBuilder &builder, Operation *loop, ArefCreateOp aref,
+                   const SetVector<Value> &results,
+                   const SetVector<int> &remotePartitions,
+                   const SetVector<int> &consumerPartitions,
                    SmallVector<OpOperand *> &uses) {
   OpBuilder::InsertionGuard g(builder);
   // The vector "results" contains either
   // 1. One of local_load(desc_load()) or desc_load()
   // 2. Both of them
   // In the second case, we only need to emit one enter / exit since we know
-  // that the two results are used by consumers in the same partition.
+  // that the two results are used by consumers in the same partition group.
   assert(results.size() == 1 || results.size() == 2);
   auto loc = results[0].getLoc();
+  bool hasMemDesc = llvm::any_of(
+      results, [](Value result) { return isa<MemDescType>(result.getType()); });
+  SetVector<int> getPartitions =
+      hasMemDesc ? consumerPartitions : remotePartitions;
+  bool hasLocalConsumers = getPartitions.size() != consumerPartitions.size();
 
   scf::ForOp scheduledLoop;
   loop->walk([&](scf::ForOp op) {
-    if (op->hasAttr(mlir::triton::kScheduledMaxStageAttrName)) {
+    if (op->hasAttr(mlir::triton::kScheduledMaxStageAttrName))
       scheduledLoop = op;
-    }
   });
 
   auto filterUse = [&](Operation *user) {
-    if (hasPartition(user)) {
-      return llvm::is_contained(getPartitionIds(user), consumerPartition);
-    } else {
+    if (!hasPartition(user))
       return false;
-    }
+    auto partitions = getPartitionIds(user);
+    return partitions.getArrayRef() == consumerPartitions.getArrayRef();
   };
 
   // Filter results to include only those defined inside the scheduled loop
@@ -431,17 +474,23 @@ void createArefGet(OpBuilder &builder, scf::ForOp loop, ArefCreateOp aref,
     }
   }
 
-  auto [stageClusterEnter, stageClusterExit] =
-      getEnterAndExitStageClustersOfUses(resultsInScheduledLoop, filterUse,
-                                         scheduledLoop);
+  auto stageClusterEnterExit = getEnterAndExitStageClustersOfUses(
+      resultsInScheduledLoop, filterUse, scheduledLoop);
+  auto stageClusterEnter = stageClusterEnterExit.first;
+  auto stageClusterExit = stageClusterEnterExit.second;
+  auto clc = getCLCTryCancel(results[0]);
+  if (clc) {
+    auto markerAlloc = cast<LocalAllocOp>(results[0].getDefiningOp());
+    auto markerLoad = cast<nvidia_gpu::CLCLoadResultOp>(
+        *markerAlloc.getResult().getUsers().begin());
+    stageClusterEnter = stageClusterExit = getStageCluster(markerLoad);
+  }
 
-  SetVector<int> consumerPartitions;
-  consumerPartitions.insert(consumerPartition);
   auto arefBufType = cast<MemDescType>(aref.getOperand(0).getType());
   Type bufferType = getBufferViewType(arefBufType, /*mutable*/ false);
   Type tokenType = builder.getType<AsyncTokenType>();
   auto getEnterOp = triton::gpu::createInto<ArefGetEnterOp>(
-      builder, loc, consumerPartitions, stageClusterEnter, aref,
+      builder, loc, getPartitions, stageClusterEnter, aref,
       TypeRange{bufferType}, tokenType);
 
   auto consumers = getTransitiveConsumers(results, consumerPartitions);
@@ -452,43 +501,59 @@ void createArefGet(OpBuilder &builder, scf::ForOp loop, ArefCreateOp aref,
 
   Operation *exitInsertPointAfter = nullptr;
 
-  auto replaceUsesWithLocalLoad = [&](Value result, StageCluster stageCluster) {
-    auto localLoadOp = triton::gpu::createInto<LocalLoadOp>(
-        builder, loc, consumerPartitions, stageCluster, result.getType(),
-        dataBuf);
+  auto replaceUses = [&](Value result, Value remote) {
+    Value replacement = remote;
+    if (hasLocalConsumers) {
+      replacement = triton::gpu::createInto<ArefPhiOp>(
+          builder, loc, consumerPartitions, stageClusterEnter, result.getType(),
+          result, remote);
+    }
 
-    for (auto use : uses) {
-      if (use->get() == result) {
-        use->set(localLoadOp.getResult());
-      }
-    }
-    if (dataBuf.hasOneUse()) {
-      // If there is only one consumer for dataBuf, it is localLoadOp created
-      // above, and we hit this code path, the empty barrier can be released
-      // after local load.
-      exitInsertPointAfter = localLoadOp;
-    }
+    for (auto use : uses)
+      if (use->get() == result)
+        use->set(replacement);
   };
 
   for (auto result : results) {
     if (auto localAlloc = result.getDefiningOp<LocalAllocOp>()) {
-      auto callback = [&](Operation *oldOp, Operation *newOp) {
-        assert(llvm::is_contained(getPartitionIds(oldOp), consumerPartition));
-        setPartition(newOp, consumerPartitions);
-      };
-      replaceUsesAndPropagateType(builder, localAlloc, dataBuf, callback);
+      if (clc) {
+        auto markerLoad = cast<nvidia_gpu::CLCLoadResultOp>(
+            *localAlloc.getResult().getUsers().begin());
+        markerLoad.getSrcMutable().set(dataBuf);
+        exitInsertPointAfter = markerLoad;
+      } else {
+        // local_alloc communication propagates a different remote memdesc type,
+        // so it cannot form a same-typed aref.phi for overlapping consumers.
+        assert(!hasLocalConsumers &&
+               "expected local_alloc consumers to be fully remote");
+        auto callback = [&](Operation *oldOp, Operation *newOp) {
+          auto oldPartitions = getPartitionIds(oldOp);
+          assert(llvm::all_of(remotePartitions, [&](int id) {
+            return oldPartitions.contains(id);
+          }));
+          setPartition(newOp, remotePartitions);
+        };
+        replaceUsesAndPropagateType(builder, localAlloc, dataBuf, callback);
+      }
     } else if (isa<RankedTensorType>(result.getType())) {
-      replaceUsesWithLocalLoad(result, stageClusterEnter);
+      auto localLoadOp = triton::gpu::createInto<LocalLoadOp>(
+          builder, loc, remotePartitions, stageClusterEnter, result.getType(),
+          dataBuf);
+      replaceUses(result, localLoadOp.getResult());
+      if (dataBuf.hasOneUse()) {
+        // If there is only one consumer for dataBuf, it is localLoadOp created
+        // above, and we hit this code path, the empty barrier can be released
+        // after local load.
+        exitInsertPointAfter = localLoadOp;
+      }
     } else if (isa<FloatType, IntegerType>(result.getType())) {
       auto tensorType = getTensorTypeFromScalar(builder, result);
       auto localLoadOp = triton::gpu::createInto<LocalLoadOp>(
-          builder, loc, consumerPartitions, stageClusterEnter, tensorType,
+          builder, loc, remotePartitions, stageClusterEnter, tensorType,
           dataBuf);
       auto scalar = triton::gpu::createInto<triton::UnsplatOp>(
-          builder, loc, consumerPartitions, stageClusterEnter, localLoadOp);
-      for (auto use : uses) {
-        use->set(scalar);
-      }
+          builder, loc, remotePartitions, stageClusterEnter, localLoadOp);
+      replaceUses(result, scalar);
       exitInsertPointAfter = localLoadOp;
     } else {
       std::string msg = "createArefGet: unsupported produced value type: " +
@@ -504,7 +569,7 @@ void createArefGet(OpBuilder &builder, scf::ForOp loop, ArefCreateOp aref,
 
   builder.setInsertionPointAfter(exitInsertPointAfter);
 
-  triton::gpu::createInto<ArefGetExitOp>(builder, loc, consumerPartitions,
+  triton::gpu::createInto<ArefGetExitOp>(builder, loc, getPartitions,
                                          stageClusterExit, aref, token,
                                          builder.getArrayAttr(asyncKinds));
 };
@@ -519,25 +584,41 @@ Operation *getEarliestUserInBlock(Block *block, ArrayRef<OpOperand *> uses) {
   return block->findAncestorOpInBlock(*use->getOwner());
 }
 
-bool insertArefs(OpBuilder &builder, scf::ForOp loop, Block *block,
+bool insertArefs(OpBuilder &builder, LoopLikeOpInterface loop, Block *block,
                  ProducedValueInfo producedValue) {
-  // Collect uses of local_alloc(desc_load()) or desc_load() results by each
-  // partition
-  DenseMap<int, SetVector<Value>> resultsPerPartition;
-  DenseMap<int, SmallVector<OpOperand *>> usesPerPartition;
+  // Group uses of local_alloc(desc_load()) or desc_load() results by consumer
+  // partitions.
+  struct ConsumerGroup {
+    SetVector<int> consumers;
+    SetVector<Value> results;
+    SmallVector<OpOperand *> uses;
+  };
+  SmallVector<ConsumerGroup> consumerGroups;
   auto processResultUses = [&](Value result) {
     for (auto &use : result.getUses()) {
       auto user = use.getOwner();
-      // if use is outside ttg.ws, it may not have partition ids, skip it
+      // Do not recursively communicate through the aref.phi boundary.
+      if (isa<ArefPhiOp>(user))
+        continue;
+      // Ignore uses outside warp specialization.
       if (!hasPartition(user))
         continue;
       auto userPartitions = getPartitionIds(&use);
-      for (auto id : producedValue.partitions) {
-        userPartitions.remove(id);
-      }
-      for (auto id : userPartitions) {
-        resultsPerPartition[id].insert(result);
-        usesPerPartition[id].push_back(&use);
+      bool hasRemoteConsumer = llvm::any_of(userPartitions, [&](int id) {
+        return !producedValue.partitions.contains(id);
+      });
+      if (hasRemoteConsumer) {
+        auto it =
+            llvm::find_if(consumerGroups, [&](const ConsumerGroup &group) {
+              return group.consumers.getArrayRef() ==
+                     userPartitions.getArrayRef();
+            });
+        if (it == consumerGroups.end()) {
+          consumerGroups.push_back({userPartitions, {}, {}});
+          it = std::prev(consumerGroups.end());
+        }
+        it->results.insert(result);
+        it->uses.push_back(&use);
       }
     }
   };
@@ -550,7 +631,7 @@ bool insertArefs(OpBuilder &builder, scf::ForOp loop, Block *block,
     processResultUses(alloc.getSrc());
   }
 
-  if (resultsPerPartition.empty()) {
+  if (consumerGroups.empty()) {
     return false;
   }
 
@@ -564,13 +645,15 @@ bool insertArefs(OpBuilder &builder, scf::ForOp loop, Block *block,
 
   auto staleOps = createArefPut(builder, aref, producedValue);
 
-  for (auto [consumerPartition, results] : resultsPerPartition) {
+  for (ConsumerGroup &group : consumerGroups) {
     OpBuilder::InsertionGuard g(builder);
-    auto earliestUser =
-        getEarliestUserInBlock(block, usesPerPartition[consumerPartition]);
+    auto earliestUser = getEarliestUserInBlock(block, group.uses);
     builder.setInsertionPoint(earliestUser);
-    createArefGet(builder, loop, aref, results, consumerPartition,
-                  usesPerPartition[consumerPartition]);
+    SetVector<int> remotePartitions = group.consumers;
+    for (auto id : producedValue.partitions)
+      remotePartitions.remove(id);
+    createArefGet(builder, loop, aref, group.results, remotePartitions,
+                  group.consumers, group.uses);
   }
 
   for (auto op : staleOps) {
@@ -586,25 +669,32 @@ class NVWSArefInsertion
     : public triton::impl::NVWSInsertArefBase<NVWSArefInsertion> {
 public:
   void runOnFunction(triton::FuncOp func) {
-    SmallVector<scf::ForOp> loops;
-    func.walk([&](scf::ForOp loop) {
-      if (loop->hasAttr(triton::kWarpSpecializeAttrName) && hasPartition(loop))
+    SmallVector<LoopLikeOpInterface> loops;
+    func.walk([&](LoopLikeOpInterface loop) {
+      if (isa<scf::ForOp, scf::WhileOp>(loop.getOperation()) &&
+          loop->hasAttr(triton::kWarpSpecializeAttrName) &&
+          hasPartition(loop)) {
         loops.push_back(loop);
+      }
     });
 
-    for (scf::ForOp loop : loops) {
-      loop.walk([&](scf::ForOp forOp) {
-        // Communicate tensor arguments in iter_args from producer partition in
-        // current iteration to consumer partition in previous iteration or
-        // initial value
-        for (auto arg : forOp.getRegionIterArgs()) {
+    for (LoopLikeOpInterface loop : loops) {
+      loop->walk([&](LoopLikeOpInterface carriedLoop) {
+        if (!isa<scf::ForOp, scf::WhileOp>(carriedLoop.getOperation()))
+          return;
+
+        // Communicate loop-carried values from the producer partition in the
+        // previous iteration to consumers in the current iteration.
+        auto body = &carriedLoop.getLoopRegions().back()->front();
+        auto args = body->getArguments().take_back(
+            carriedLoop.getRegionIterArgs().size());
+        for (auto [lane, arg] : llvm::enumerate(args)) {
           if (isa<RankedTensorType, FloatType, IntegerType>(arg.getType())) {
-            auto producerPartition =
-                getPartitionOutputs(forOp)[arg.getArgNumber() - 1];
+            auto producerPartition = getPartitionOutputs(carriedLoop)[lane];
             ProducedValueInfo producedValue{producerPartition, arg};
-            OpBuilder builder(forOp);
-            builder.setInsertionPointToStart(forOp.getBody());
-            insertArefs(builder, loop, forOp.getBody(), producedValue);
+            OpBuilder builder(carriedLoop);
+            builder.setInsertionPointToStart(body);
+            insertArefs(builder, loop, body, producedValue);
           }
         }
       });
@@ -614,7 +704,7 @@ public:
       // local_alloc(desc_load()) first, followed by remaining register uses of
       // desc_load results.
       SmallVector<Operation *> memoryOps;
-      loop.walk([&](Operation *op) {
+      loop->walk([&](Operation *op) {
         if (op->getNumResults() > 0 &&
             (isDescLoadAndAlloc<LocalAllocOp>(op->getResult(0)) ||
              isa<LocalAllocOp>(op))) {
@@ -623,7 +713,7 @@ public:
       });
 
       for (auto op : memoryOps) {
-        auto producedValues = getProducedValues(op, loop.getBody());
+        auto producedValues = getProducedValues(op);
         for (auto producedValue : producedValues) {
           OpBuilder builder(op);
           insertArefs(builder, loop, op->getBlock(), producedValue);
@@ -631,11 +721,15 @@ public:
       }
 
       // handle non-tmem ops in the loop, including uses of desc_load results.
-      loop.walk([&](Operation *op) {
-        if (op == loop || isa<MMAv5OpInterface, TMEMAllocOp, TMEMStoreOp>(op)) {
+      loop->walk([&](Operation *op) {
+        if (op == loop ||
+            isa<MMAv5OpInterface, TMEMAllocOp, TMEMStoreOp,
+                ::mlir::triton::nvidia_gpu::CLCTryCancelSyncOp,
+                nvidia_gpu::CLCLoadResultOp, nvidia_gpu::CLCIsCanceledOp,
+                nvidia_gpu::CLCGetProgramIdOp>(op)) {
           return WalkResult::advance();
         }
-        auto producedValues = getProducedValues(op, loop.getBody());
+        auto producedValues = getProducedValues(op);
         for (auto producedValue : producedValues) {
           OpBuilder builder(op);
           builder.setInsertionPointAfter(op);

--- a/third_party/nvidia/lib/Dialect/NVWS/Transforms/InsertTmemAref.cpp
+++ b/third_party/nvidia/lib/Dialect/NVWS/Transforms/InsertTmemAref.cpp
@@ -41,7 +41,7 @@ using namespace triton::nvws;
 
 int getWsTag(Operation *op) {
   while (op && !hasWarpSpecializeTag(op)) {
-    op = op->getParentOfType<scf::ForOp>();
+    op = op->getParentOfType<LoopLikeOpInterface>();
   }
   assert(op);
   return *getWarpSpecializeTag(op);
@@ -154,21 +154,27 @@ struct TmemAccessDag {
     return addOp(*newTok.getUses().begin(), ifOpNode);
   }
 
-  Value addForOp(OpOperand &tokOperand, Node *forOpNode) {
-    auto forOp = cast<scf::ForOp>(tokOperand.getOwner());
-    auto tokPos = tokOperand.getOperandNumber() - 3;
-    auto tokDefOp = forOp.getYieldedValues()[tokPos].getDefiningOp();
-    assert(tokDefOp && "expecting a token definition op");
+  Value addLoopOp(OpOperand &tokOperand, Node *loopNode) {
+    auto loop = cast<LoopLikeOpInterface>(tokOperand.getOwner());
+    auto tokPos = tokOperand.getOperandNumber() -
+                  loop.getInitsMutable().front().getOperandNumber();
+    auto &yieldedToken = (*loop.getYieldedValuesMutable())[tokPos];
+    assert(yieldedToken.get().getDefiningOp() &&
+           "expecting a token definition op");
 
-    // Create access node for the for-loop body. The first op is nullptr,
+    auto bodyArgs =
+        loop.getLoopRegions().back()->front().getArguments().take_back(
+            loop.getRegionIterArgs().size());
+    auto tokArg = bodyArgs[tokPos];
+
+    // Create access node for the loop body. The first op is nullptr,
     // but it has partitionIdx, indicating which partition owns the Tmem when
     // entering the region
     auto subDag =
         std::make_unique<Node>(nullptr, nullptr, std::nullopt, nullptr);
-    auto tokArg = forOp.getRegionIterArg(tokPos);
     assert(tokArg.hasOneUse());
     addOp(*tokArg.getUses().begin(), subDag.get());
-    forOpNode->partitionId = getPartitionId(forOp, tokPos);
+    loopNode->partitionId = getPartitionId(loop, tokPos);
 
     // finalNode keep track of partition ownership transfer ownership when
     // before exiting the loop-body or re-entering loop body
@@ -176,19 +182,18 @@ struct TmemAccessDag {
     Node *finalNode = subDag->user.get();
     while (finalNode->user)
       finalNode = finalNode->user.get();
-    auto yieldOp = forOp.getBody()->getTerminator();
     finalNode->user =
-        std::make_unique<Node>(yieldOp, &yieldOp->getOpOperand(tokPos),
-                               forOpNode->partitionId, finalNode);
+        std::make_unique<Node>(yieldedToken.getOwner(), &yieldedToken,
+                               loopNode->partitionId, finalNode);
     finalNode->user->parentDag = subDag->user.get();
-    forOpNode->tokPos = tokPos;
+    loopNode->tokPos = tokPos;
 
     // subDag->user->parentDag = subDag->user.get();
     subDag->user->parent = nullptr;
-    subDag->user->parentDag = forOpNode;
+    subDag->user->parentDag = loopNode;
 
-    forOpNode->subDags.push_back(std::move(subDag->user));
-    return forOp.getResult(tokPos);
+    loopNode->subDags.push_back(std::move(subDag->user));
+    return loop->getResult(tokPos);
   }
 
   Value addOp(OpOperand &tokOperand, Node *node) {
@@ -197,7 +202,7 @@ struct TmemAccessDag {
 
     auto op = tokOperand.getOwner();
     std::optional<PartitionId> partitionId;
-    // tmem owning partition for if & for ops are inferred from their regions
+    // TMEM ownership for region ops is inferred from their regions.
     if (op->getNumRegions() == 0)
       partitionId = getPartitionId(op);
     node->user.reset(new Node(op, &tokOperand, partitionId, node));
@@ -210,8 +215,8 @@ struct TmemAccessDag {
       newTok = tmemStore.getToken();
     } else if (auto mmav5 = dyn_cast<MMAv5OpInterface>(op)) {
       newTok = mmav5.getToken();
-    } else if (auto forOp = dyn_cast<scf::ForOp>(op)) {
-      newTok = addForOp(tokOperand, newNode);
+    } else if (isa<scf::ForOp, scf::WhileOp>(op)) {
+      newTok = addLoopOp(tokOperand, newNode);
     } else {
       llvm_unreachable("unsupported user");
     }
@@ -375,12 +380,12 @@ OpT createInto(
                                          partitionIdStageCluster.second,
                                          std::forward<Args>(args)...);
   if (wsTag) {
-    auto forOp = op->template getParentOfType<scf::ForOp>();
-    while (forOp && !hasWarpSpecializeTag(forOp)) {
-      forOp = forOp->template getParentOfType<scf::ForOp>();
+    auto wsLoop = op->template getParentOfType<LoopLikeOpInterface>();
+    while (wsLoop && !hasWarpSpecializeTag(wsLoop)) {
+      wsLoop = wsLoop->template getParentOfType<LoopLikeOpInterface>();
     }
     // only set wsTag if op is outside tt.ws loop
-    if (!forOp) {
+    if (!wsLoop) {
       setWarpSpecializeTag(op, *wsTag);
     }
   }
@@ -482,9 +487,9 @@ insertTmemArefImpl(TmemAccessDag::Node *node,
       prevOp = node->parent->op;
       b.setInsertionPointAfter(prevOp);
     } else {
-      // if we are inside if-stmt or for-stmt subdag and need to change
-      // ownerhip, release at the top of the block
-      // the parentDag op would be if-stmt or for-stmt
+      // If we are inside an if-stmt or loop subdag and need to change
+      // ownership, release at the top of the block. The parentDag op is the
+      // enclosing region op.
       prevOp = node->parentDag->op;
       b.setInsertionPointToStart(node->op->getBlock());
     }
@@ -510,12 +515,10 @@ insertTmemArefImpl(TmemAccessDag::Node *node,
 
   for (auto &subDag : node->subDags) {
     auto subdagState = state;
-    if (auto forOp = dyn_cast<scf::ForOp>(node->op)) {
-      // forOp may have token operand, if so, we need to update the token and
-      // and reset buffer
+    if (isa<LoopLikeOpInterface>(node->op)) {
+      // A loop may have a token operand; update it and reset the buffer.
       if (node->tokOperand) {
-        subdagState.token =
-            forOp.getRegionIterArg(node->tokOperand->getOperandNumber() - 3);
+        subdagState.token = subDag->tokOperand->get();
         subdagState.buffer = {};
       }
     }
@@ -561,11 +564,11 @@ insertTmemArefImpl(TmemAccessDag::Node *node,
     }
   } else if (auto yieldOp = dyn_cast<scf::YieldOp>(node->op)) {
     yieldOp.setOperand(node->tokOperand->getOperandNumber(), state.token);
-  } else if (isa<scf::IfOp, scf::ForOp>(node->op)) {
+  } else if (isa<scf::IfOp, LoopLikeOpInterface>(node->op)) {
     if (node->tokPos) {
-      // forOp/if may return token, if so, update state token, and reset buffer
-      if (isa<scf::ForOp>(node->op))
-        node->op->setOperand(node->tokOperand->getOperandNumber(), state.token);
+      // A loop or if may return a token; update it and reset the buffer.
+      if (isa<LoopLikeOpInterface>(node->op))
+        node->tokOperand->set(state.token);
       state.token = node->op->getResult(*node->tokPos);
       state.buffer = {};
     }
@@ -654,7 +657,8 @@ int insertTmemAref(TmemAccessDag &accessDag, int numTmemBlocks) {
     for (auto user : allocOp.getResult().getUsers()) {
       if (auto mmaOp = dyn_cast<MMAv5OpInterface>(user)) {
         if (auto loop = dyn_cast<scf::ForOp>(user->getParentOp())) {
-          auto wsLoop = getOuterWSLoop(loop);
+          auto wsLoop =
+              getOuterWSLoop(cast<LoopLikeOpInterface>(loop.getOperation()));
           // Determine if the MMA accumulator can be multibuffered.
           bool accIsMultiBuffered =
               // MMAs in subsequent iterations can be overlapped.
@@ -679,9 +683,8 @@ int insertTmemAref(TmemAccessDag &accessDag, int numTmemBlocks) {
   OpBuilder b(allocOp);
 
   // alloc can be inside ws-loop, we need to find the entry point for ws-loop
-  auto outerWsLoop = allocOp->getParentOfType<scf::ForOp>();
-  while (outerWsLoop && !outerWsLoop->hasAttr(triton::kWarpSpecializeAttrName))
-    outerWsLoop = outerWsLoop->getParentOfType<scf::ForOp>();
+  auto outerWsLoop =
+      getOuterWSLoop(allocOp->getParentOfType<LoopLikeOpInterface>());
   if (outerWsLoop)
     b.setInsertionPoint(outerWsLoop);
   auto arefAlloc =
@@ -872,8 +875,8 @@ void workaroundForLoopScheduler(triton::FuncOp funcOp) {
 
 LogicalResult runOnFunction(triton::FuncOp funcOp) {
   // Skip this function if there is no warp specialized loop.
-  auto walkResult = funcOp.walk([&](scf::ForOp forOp) {
-    if (forOp->hasAttr(kWarpSpecializeAttrName))
+  auto walkResult = funcOp.walk([&](LoopLikeOpInterface loop) {
+    if (loop->hasAttr(kWarpSpecializeAttrName))
       return WalkResult::interrupt();
     return WalkResult::advance();
   });

--- a/third_party/nvidia/lib/Dialect/NVWS/Transforms/LowerAref.cpp
+++ b/third_party/nvidia/lib/Dialect/NVWS/Transforms/LowerAref.cpp
@@ -179,9 +179,9 @@ BarrierCount getArrivalCount(ArefCreateOp op) {
       continue;
     auto partitionIds = getPartitionIds(user);
 
-    assert(partitionIds.size() == 1);
-
     if (auto putExitOp = dyn_cast<ArefPutExitOp>(user)) {
+      assert(partitionIds.size() == 1 &&
+             "aref producer must have exactly one partition");
       if (producerGroups.count(partitionIds.front())) {
         continue;
       }
@@ -191,6 +191,7 @@ BarrierCount getArrivalCount(ArefCreateOp op) {
         case AsyncOp::TC5MMA:
         case AsyncOp::TMALoad:
         case AsyncOp::NONE:
+        case AsyncOp::CLC:
           count.producerPendingCount += 1;
           break;
         default:
@@ -198,19 +199,19 @@ BarrierCount getArrivalCount(ArefCreateOp op) {
         }
       }
     } else if (auto getExitOp = dyn_cast<ArefGetExitOp>(user)) {
-      if (consumerGroups.count(partitionIds.front())) {
-        continue;
-      }
-      consumerGroups.insert(partitionIds.front());
-      for (auto kind : castAsyncOpAttrs(getExitOp.getAsyncOps())) {
-        switch (kind) {
-        case AsyncOp::TC5MMA:
-        case AsyncOp::WGMMA:
-        case AsyncOp::NONE:
-          count.consumerPendingCount += 1;
-          break;
-        default:
-          llvm_unreachable("unsupported consumer kind");
+      for (int partitionId : partitionIds) {
+        if (!consumerGroups.insert(partitionId))
+          continue;
+        for (auto kind : castAsyncOpAttrs(getExitOp.getAsyncOps())) {
+          switch (kind) {
+          case AsyncOp::TC5MMA:
+          case AsyncOp::WGMMA:
+          case AsyncOp::NONE:
+            count.consumerPendingCount += 1;
+            break;
+          default:
+            llvm_unreachable("unsupported consumer kind");
+          }
         }
       }
     }
@@ -353,6 +354,30 @@ void lowerTMALoad(ArefPutEnterOp op, Value fullBarrier,
   }
 }
 
+void lowerCLC(ArefPutEnterOp op, Value fullBarrier, PatternRewriter &rewriter) {
+  SmallVector<nvws::CLCTryCancelOp> clcOps;
+  for (Value buffer : op.getBuffers()) {
+    for (Operation *user : buffer.getUsers()) {
+      if (auto clc = dyn_cast<nvws::CLCTryCancelOp>(user))
+        clcOps.push_back(clc);
+    }
+  }
+  assert(clcOps.size() == 1 && "expected one CLC producer per response aref");
+  auto clc = clcOps.front();
+  auto pred = arith::ConstantIntOp::create(rewriter, clc.getLoc(), 1, 1);
+  assignStageCluster(pred, getPartitionWsTagIds(clc), getStageCluster(clc),
+                     rewriter);
+  auto expect = nvidia_gpu::BarrierExpectOp::create(rewriter, clc.getLoc(),
+                                                    fullBarrier, 16, pred);
+  assignStageCluster(expect, getPartitionWsTagIds(clc), getStageCluster(clc),
+                     rewriter);
+  auto issue = nvidia_gpu::CLCTryCancelOp::create(rewriter, clc.getLoc(),
+                                                  clc.getResult(), fullBarrier);
+  assignStageCluster(issue, getPartitionWsTagIds(clc), getStageCluster(clc),
+                     rewriter);
+  clc.erase();
+}
+
 void insertWaitOp(PatternRewriter &rewriter, Operation *op, Value barrier,
                   Value phase, Value stage) {
   auto waitOp = WaitBarrierOp::create(rewriter, op->getLoc(), barrier, phase);
@@ -400,12 +425,20 @@ void rewritePutEnterOp(ArefPutEnterOp op, PatternRewriter &rewriter,
     return kind == AsyncOp::TMALoad || kind == AsyncOp::CpAsync;
   };
   auto hasTMA = [](AsyncOp kind) { return kind == AsyncOp::TMALoad; };
+  auto hasCLC = [](AsyncOp kind) { return kind == AsyncOp::CLC; };
 
   if (llvm::any_of(asyncKinds, hasTMA)) {
     Value fullBarrier =
         getFullBarrier(rewriter, loc, arefVal, op.getStage(),
                        getPartitionWsTagIds(op), getStageCluster(op));
     lowerTMALoad(op, fullBarrier, rewriter, arefVal);
+  }
+
+  if (llvm::any_of(asyncKinds, hasCLC)) {
+    Value fullBarrier =
+        getFullBarrier(rewriter, loc, arefVal, op.getStage(),
+                       getPartitionWsTagIds(op), getStageCluster(op));
+    lowerCLC(op, fullBarrier, rewriter);
   }
 
   if (llvm::any_of(asyncKinds, hasAsyncLoad)) {
@@ -484,6 +517,7 @@ void insertArriveBarrier(Location loc, ArrayRef<AsyncOp> asyncOps,
                                                     Value(), ValueRange{});
       break;
     case AsyncOp::TMALoad:
+    case AsyncOp::CLC:
       // nothing to do, the arrive is done by HW
       break;
     case AsyncOp::CpAsync:
@@ -919,8 +953,9 @@ public:
     mlir::ModuleOp m = getOperation();
 
     SmallVector<scf::ForOp> loops;
-    m.walk([&](scf::ForOp loop) {
-      if (loop->hasAttr(triton::kWarpSpecializeAttrName)) {
+    m.walk([&](Operation *loop) {
+      if (isa<scf::ForOp, scf::WhileOp>(loop) &&
+          loop->hasAttr(triton::kWarpSpecializeAttrName)) {
         loop->walk([&](scf::ForOp op) { loops.push_back(op); });
       }
     });

--- a/third_party/nvidia/lib/Dialect/NVWS/Transforms/Utilities.cpp
+++ b/third_party/nvidia/lib/Dialect/NVWS/Transforms/Utilities.cpp
@@ -10,8 +10,11 @@ using namespace mlir::triton::nvidia_gpu;
 namespace mlir::triton::nvws {
 
 Operation *createAlloc(OpBuilder &builder, Location loc,
-                       MemDescType memDescType, Value src) {
+                       MemDescType memDescType, Value src,
+                       std::optional<int32_t> alignment) {
   if (isa<SharedMemorySpaceAttr>(memDescType.getMemorySpace())) {
+    if (alignment)
+      return LocalAllocOp::create(builder, loc, memDescType, src, *alignment);
     return LocalAllocOp::create(builder, loc, memDescType, src);
   } else {
     assert(isa<TensorMemorySpaceAttr>(memDescType.getMemorySpace()));
@@ -54,10 +57,10 @@ MemDescType getArefMultiBufferedType(MemDescType bufTy, int depth) {
                                /*mutableMemory*/ true);
 }
 
-scf::ForOp getOuterWSLoop(scf::ForOp innerFor) {
-  auto wsLoop = innerFor;
+LoopLikeOpInterface getOuterWSLoop(LoopLikeOpInterface loop) {
+  auto wsLoop = loop;
   while (wsLoop && !wsLoop->hasAttr(triton::kWarpSpecializeAttrName)) {
-    wsLoop = wsLoop->getParentOfType<scf::ForOp>();
+    wsLoop = wsLoop->getParentOfType<LoopLikeOpInterface>();
   }
   return wsLoop;
 }

--- a/third_party/nvidia/lib/Dialect/NVWS/Transforms/Utilities.h
+++ b/third_party/nvidia/lib/Dialect/NVWS/Transforms/Utilities.h
@@ -1,13 +1,15 @@
 #ifndef NVIDIA_NVWS_TRANSFORMS_UTILITY_H_
 #define NVIDIA_NVWS_TRANSFORMS_UTILITY_H_
 
+#include "mlir/Interfaces/LoopLikeInterface.h"
 #include "nvidia/include/Dialect/NVWS/IR/Dialect.h"
 #include "triton/Dialect/TritonGPU/IR/Dialect.h"
 
 namespace mlir::triton::nvws {
 
 Operation *createAlloc(OpBuilder &builder, Location loc,
-                       gpu::MemDescType memDescType, Value src);
+                       gpu::MemDescType memDescType, Value src,
+                       std::optional<int32_t> alignment = std::nullopt);
 
 ArefCreateOp createArefCreateOp(OpBuilder &builder, ArrayRef<Type> arefTypes,
                                 ValueRange allocOps, Location loc);
@@ -22,22 +24,12 @@ inline std::optional<int> findValuePosInRange(const Range &range,
   return {};
 }
 
-#if 0
-struct PartitionId : std::pair<int, int> {
-  PartitionId(int index, int tag) : std::pair<int, int>(index, tag) {}
-  int &index() { return first; }
-  int &tag() { return second; }
-};
-
-std::optional<PartitionId> getPartitionId(Operation *op);
-#endif
-
 gpu::MemDescType getArefViewBufferType(gpu::MemDescType arefBufType);
 gpu::MemDescType getArefMultiBufferedType(gpu::MemDescType arefBufType,
                                           int depth);
 int getArefDepth(gpu::MemDescType bufTy);
 
-scf::ForOp getOuterWSLoop(scf::ForOp innerFor);
+LoopLikeOpInterface getOuterWSLoop(LoopLikeOpInterface loop);
 } // namespace mlir::triton::nvws
 
 #endif // NVIDIA_NVWS_TRANSFORMS_UTILITY_H_


### PR DESCRIPTION
Extend CLC with automatic warp specialization. Add CLC-aware scf.while normalization/partitioning and an NVWS cancellation path so CLC scheduling is correctly duplicated and lowered across partitions.
 

```
$ python python/tutorials/09-persistent-matmul.py -K512
..
├─ 926.196 741.954 matmul_kernel_tma [M=8192, N=8192, K=512]
├─ 938.895 731.919 matmul_kernel_tma_clc [M=8192, N=8192, K=512]
├─ 1181.097 581.828 matmul_kernel_tma_clc_ws [M=8192, N=8192, K=512]
├─ 1062.976 646.482 matmul_kernel_tma_persistent [M=8192, N=8192, K=512]
├─ 1199.541 572.881 matmul_kernel_tma_persistent_ws [M=8192, N=8192, K=512]
...

$ python python/tutorials/09-persistent-matmul.py -K512 --prec=fp8
...
├─ 1746.232 393.530 matmul_kernel_tma [M=8192, N=8192, K=512]
├─ 2069.452 332.066 matmul_kernel_tma_clc [M=8192, N=8192, K=512]
├─ 2449.515 280.543 matmul_kernel_tma_clc_ws [M=8192, N=8192, K=512]
├─ 2265.628 303.313 matmul_kernel_tma_persistent [M=8192, N=8192, K=512]
├─ 2506.464 274.169 matmul_kernel_tma_persistent_ws [M=8192, N=8192, K=512]
...


$ python python/tutorials/10-block-scaled-matmul.py -K512
...
├─ 1137.712 604.015 block_scaled_matmul_kernel_nvfp4 [M=8192, N=8192, K=512]
...

$ python python/tutorials/10-block-scaled-matmul.py -K512 --clc
...
├─ 1285.922 534.399 block_scaled_matmul_kernel_nvfp4 [M=8192, N=8192, K=512]
...
```


with this diff
```
--- a/python/tutorials/10-block-scaled-matmul.py
+++ b/python/tutorials/10-block-scaled-matmul.py
@@ -217,7 +217,7 @@ def block_scaled_matmul_kernel(  #

     accumulator = tl.zeros((BLOCK_M, BLOCK_N), dtype=tl.float32)
     for k in tl.range(0, tl.cdiv(K, BLOCK_K), num_stages=NUM_STAGES,
-                      disallow_acc_multi_buffer=disallow_acc_multi_buffer):
+                      disallow_acc_multi_buffer=disallow_acc_multi_buffer, warp_specialize=True):
         a = a_desc.load([offs_am, offs_k_a])
         b = b_desc.load([offs_bn, offs_k_b])
         scale_a = a_scale_desc.load([0, offs_scale_m, offs_scale_k, 0, 0])

$ python python/tutorials/10-block-scaled-matmul.py -K512
...
├─ 1049.382 654.856 block_scaled_matmul_kernel_nvfp4 [M=8192, N=8192, K=512]
...

$ python python/tutorials/10-block-scaled-matmul.py -K512 --clc
...
├─ 2145.899 320.236 block_scaled_matmul_kernel_nvfp4 [M=8192, N=8192, K=512]
...
```
