### PR TITLE
[AMD] Delegate NaN-propagating min/max to LLVM

### DIFF
--- a/test/Conversion/amd/minmax.mlir
+++ b/test/Conversion/amd/minmax.mlir
@@ -1,19 +1,11 @@
-// RUN: triton-opt %s --convert-triton-amdgpu-to-llvm=gfx-arch=gfx942 | FileCheck %s --check-prefix=GFX942
-// RUN: triton-opt %s --convert-triton-amdgpu-to-llvm=gfx-arch=gfx950 | FileCheck %s --check-prefix=GFX950
+// RUN: triton-opt %s --convert-triton-amdgpu-to-llvm=gfx-arch=gfx942 | FileCheck %s
+// RUN: triton-opt %s --convert-triton-amdgpu-to-llvm=gfx-arch=gfx950 | FileCheck %s
 
 module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, "ttg.threads-per-warp" = 32 : i32} {
 
-// GFX942: llvm.func @min_max
-// GFX942-COUNT-2: llvm.fcmp
-// GFX942: llvm.or
-// GFX942: llvm.intr.minnum
-// GFX942-COUNT-2: llvm.fcmp
-// GFX942: llvm.or
-// GFX942: llvm.intr.maxnum
-
-// GFX950: llvm.func @min_max
-// GFX950: llvm.intr.minimum
-// GFX950-NEXT: llvm.intr.maximum
+// CHECK: llvm.func @min_max
+// CHECK: llvm.intr.minimum
+// CHECK-NEXT: llvm.intr.maximum
   tt.func public @min_max(%arg0: f32, %arg1: f32) {
     %0 = arith.minimumf %arg0, %arg1 : f32
     %1 = arith.maximumf %arg0, %arg1 : f32

--- a/test/Conversion/amd/minmax.mlir
+++ b/test/Conversion/amd/minmax.mlir
@@ -1,5 +1,6 @@
 // RUN: triton-opt %s --convert-triton-amdgpu-to-llvm=gfx-arch=gfx942 | FileCheck %s
 // RUN: triton-opt %s --convert-triton-amdgpu-to-llvm=gfx-arch=gfx950 | FileCheck %s
+// RUN: triton-opt %s --convert-triton-amdgpu-to-llvm=gfx-arch=gfx1250 | FileCheck %s
 
 module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, "ttg.threads-per-warp" = 32 : i32} {
 

--- a/third_party/amd/lib/TritonAMDGPUToLLVM/ElementwiseOpToLLVM.cpp
+++ b/third_party/amd/lib/TritonAMDGPUToLLVM/ElementwiseOpToLLVM.cpp
@@ -551,10 +551,6 @@ void populateElementwiseOpToLLVMPatterns(
                                    benefit.getBenefit() + 1);
   triton::populateElementwiseOpToLLVMPatterns(
       typeConverter, patterns, axisInfoAnalysis, targetInfo, benefit);
-  bool hwNanPropagationSupported = targetInfo.supportMaximumMinimum();
-  triton::populateMinMaxFOpToLLVMPattern(typeConverter, patterns,
-                                         axisInfoAnalysis,
-                                         hwNanPropagationSupported, benefit);
   triton::populateClampFOpToLLVMPattern(typeConverter, patterns,
                                         axisInfoAnalysis, targetInfo, benefit);
 }


### PR DESCRIPTION
<!---
The core Triton is a small number of people, and we receive many PRs (thank
you!).  To help us review your code more quickly, **if you are a new
contributor (less than 3 PRs merged) we ask that you complete the following
tasks and include the filled-out checklist in your PR description.**

Complete the following tasks before sending your PR, and replace `[ ]` with
`[x]` to indicate you have done them.
-->
The AMD backend registers two competing patterns for `arith.minimumf`/`arith.maximumf`,
from the same function at the same benefit:

- a [direct translation](https://github.com/triton-lang/triton/blob/84cae05df02548bf0bb0a286d65b4943a1acbb2f/third_party/amd/lib/TritonAMDGPUToLLVM/ElementwiseOpToLLVM.cpp#L505-L510)
  to `llvm.minimum`/`llvm.maximum`
- [`populateMinMaxFOpToLLVMPattern`](https://github.com/triton-lang/triton/blob/84cae05df02548bf0bb0a286d65b4943a1acbb2f/third_party/amd/lib/TritonAMDGPUToLLVM/ElementwiseOpToLLVM.cpp#L554-L557),
  adding the shared [`MinMaxFOpConversion`](https://github.com/triton-lang/triton/blob/84cae05df02548bf0bb0a286d65b4943a1acbb2f/lib/Conversion/TritonGPUToLLVM/ElementwiseOpToLLVM.cpp#L448-L502),
  which hand-expands the NaN propagation into two `fcmp`s, an `or`, a `minnum`/`maxnum` and
  a `select` unless the target reports [`supportMaximumMinimum`](https://github.com/triton-lang/triton/blob/84cae05df02548bf0bb0a286d65b4943a1acbb2f/third_party/amd/lib/Dialect/TritonAMDGPU/IR/TargetFeatures.cpp#L281-L284)

The later registration wins, so the direct pattern never fires. This PR removes the second
one, leaving instruction selection and NaN propagation to the backend compiler.

## Test IR

Two Triton IR modules compute the IEEE NaN-propagating min and max of the same two f32
kernel arguments. Compiling a `.ttir` file enters the pipeline after the Triton stage, so
everything down to assembly is the real compiler and no AMD GPU is needed.

`direct.ttir` asks for it directly, which is what this PR now emits:

```mlir
module {
  tt.func public @direct_minmax(%lhs: f32, %rhs: f32, %min_ptr: !tt.ptr<f32>, %max_ptr: !tt.ptr<f32>) {
    %minimum = arith.minimumf %lhs, %rhs : f32
    %maximum = arith.maximumf %lhs, %rhs : f32
    tt.store %min_ptr, %minimum : !tt.ptr<f32>
    tt.store %max_ptr, %maximum : !tt.ptr<f32>
    tt.return
  }
}
```

`manual.ttir` writes the expansion out, modelling what the backend emitted before. On
gfx942 it reproduces the old assembly exactly:

```mlir
module {
  tt.func public @manual_minmax(%lhs: f32, %rhs: f32, %min_ptr: !tt.ptr<f32>, %max_ptr: !tt.ptr<f32>) {
    %nan = arith.constant 0x7FC00000 : f32
    %lhs_is_nan = arith.cmpf une, %lhs, %lhs : f32
    %rhs_is_nan = arith.cmpf une, %rhs, %rhs : f32
    %is_nan = arith.ori %lhs_is_nan, %rhs_is_nan : i1
    %min_num = arith.minnumf %lhs, %rhs : f32
    %max_num = arith.maxnumf %lhs, %rhs : f32
    %minimum = arith.select %is_nan, %nan, %min_num : f32
    %maximum = arith.select %is_nan, %nan, %max_num : f32
    tt.store %min_ptr, %minimum : !tt.ptr<f32>
    tt.store %max_ptr, %maximum : !tt.ptr<f32>
    tt.return
  }
}
```

## What changes

`supportMaximumMinimum` is true only for CDNA4 and GFX1250, so those targets already got
the intrinsics and are unchanged. Every other AMD target used the hand-written expansion.
Compiling `direct.ttir` before and after:

| Architecture | Before | After |
| ------------ | ----------------------- | ----------------------- |
| gfx942       | 7 instructions, 5 VGPRs | 5 instructions, 3 VGPRs |
| gfx950       | 2 instructions, 3 VGPRs | unchanged               |
| gfx1250      | 2 instructions, 3 VGPRs | unchanged               |

gfx942 has no native IEEE min/max, so both forms detect NaN with `v_cmp_u_f32` and select
the same canonical `0x7fc00000` quiet NaN, giving identical results. The hand-written one
additionally quiets both operands up front with two `v_max_f32_e64 vN, sX, sX`, which
`minnum`/`maxnum` require but which the select then discards. This also drops a hardware
gate that Triton has to keep in sync with new targets.



# New contributor declaration
- [x] I am not making a trivial change, such as fixing a typo in a comment.

- [x] I have written a PR description following these
  [rules](https://cbea.ms/git-commit/#why-not-how).

- [x] I have run `pre-commit run --from-ref origin/main --to-ref HEAD`.

- Select one of the following.
  - [x] I have added tests.
    - `/test` for `lit` tests
    - `/unittest` for C++ tests
    - `/python/test` for end-to-end tests
  - [ ] This PR does not need a test because `FILL THIS IN`.

- Select one of the following.
  - [ ] I have not added any `lit` tests.
  - [ ] The `lit` tests I have added follow these [best practices](https://mlir.llvm.org/getting_started/TestingGuide/#filecheck-best-practices),
    including the "tests should be minimal" section. (Usually running Python code
    and using the instructions it generates is not minimal.)


CC: @zhanglx13  @antiagainst  @AlexAUT  @yiqian1 