### PR TITLE
[ConSan] Detect shared scratch overlapping live barriers

### DIFF
--- a/include/triton/Dialect/TritonInstrument/IR/FunctionBuilder.h
+++ b/include/triton/Dialect/TritonInstrument/IR/FunctionBuilder.h
@@ -122,6 +122,13 @@ public:
   void createVerifyBarrierInitializedCall(ImplicitLocOpBuilder &b, Value mbar,
                                           Value pred, Operation *insertPoint,
                                           Value recipientCTAs);
+  // verifyBarrierMemoryAvailable: reject shared-memory scratch that overlaps
+  // any initialized barrier whose storage has not been invalidated.
+  void createVerifyBarrierMemoryAvailableCall(ImplicitLocOpBuilder &b,
+                                              uint32_t offset, uint32_t length,
+                                              Value pred,
+                                              Operation *insertPoint,
+                                              Value recipientCTAs);
   // initBarrierState: Initialize the tracked barrier state to phase 0 and set
   // both the initial and current arrival counts. A zero state denotes an
   // invalidated/uninitialized barrier.

--- a/lib/Conversion/TritonGPUToLLVM/AllocateSharedMemoryUtility.cpp
+++ b/lib/Conversion/TritonGPUToLLVM/AllocateSharedMemoryUtility.cpp
@@ -16,6 +16,11 @@ void attachAllocationSizeAndOffsetAttr(ModuleOp mod,
       if (oBufferId != Allocation::InvalidBufferId) {
         int offset = funcAllocation->getOffset(oBufferId);
         op->setAttr("allocation.offset", IntegerAttr::get(i32Ty, offset));
+        if (!isa<FunctionOpInterface>(op) &&
+            !funcAllocation->isVirtualBuffer(oBufferId)) {
+          int size = funcAllocation->getAllocatedSize(oBufferId);
+          op->setAttr("allocation.size", IntegerAttr::get(i32Ty, size));
+        }
         return;
       }
 

--- a/lib/Dialect/TritonInstrument/IR/FunctionBuilder.cpp
+++ b/lib/Dialect/TritonInstrument/IR/FunctionBuilder.cpp
@@ -1063,6 +1063,83 @@ void FunctionBuilder::createVerifyBarrierInitializedCall(
       });
 }
 
+void FunctionBuilder::createVerifyBarrierMemoryAvailableCall(
+    ImplicitLocOpBuilder &b, uint32_t offset, uint32_t length, Value pred,
+    Operation *insertPoint, Value recipientCTAs) {
+  if (!pred)
+    pred = arith::ConstantIntOp::create(b, 1, 1);
+
+  Value barriersVal = auxData.barriers.at(insertPoint).value;
+  auto barriersType =
+      cast<RankedTensorType>(auxData.barriers.at(insertPoint).type);
+  Value barrierStatesVal = auxData.barrierStates.at(insertPoint).value;
+  auto barrierStatesType =
+      cast<RankedTensorType>(auxData.barrierStates.at(insertPoint).type);
+  Value offsetVal = arith::ConstantIntOp::create(b, offset, 32);
+  Value lengthVal = arith::ConstantIntOp::create(b, length, 32);
+  SmallVector<Value> args = {offsetVal,   lengthVal,        pred,
+                             barriersVal, barrierStatesVal, recipientCTAs};
+  AssertInfo assertInfo{"Shared memory reused before barrier invalidation",
+                        b.getI1Type()};
+
+  createCallToCachedFunction(
+      b, "verify_barrier_memory_available", args, assertInfo,
+      {barriersType, barrierStatesType},
+      [barriersType, barrierStatesType](ImplicitLocOpBuilder &fb,
+                                        Block *entryBlock) {
+        Value accessOffset = entryBlock->getArgument(0);
+        Value accessLength = entryBlock->getArgument(1);
+        Value pred = entryBlock->getArgument(2);
+        Value barriers = entryBlock->getArgument(3);
+        Value statesPtr = entryBlock->getArgument(4);
+        Value recipientCTAs = entryBlock->getArgument(5);
+
+        Value offsetMask = tti::createConstIntTensor(fb, fb.getLoc(),
+                                                     UINT32_MAX, barriersType);
+        Value shift =
+            tti::createConstIntTensor(fb, fb.getLoc(), 32, barriersType);
+        Value barrierOffsets = arith::AndIOp::create(fb, barriers, offsetMask);
+        Value barrierLengths = arith::ShRUIOp::create(fb, barriers, shift);
+        Value barrierEnds =
+            arith::AddIOp::create(fb, barrierOffsets, barrierLengths);
+
+        Value accessOffsetI64 =
+            arith::ExtUIOp::create(fb, fb.getI64Type(), accessOffset);
+        Value accessLengthI64 =
+            arith::ExtUIOp::create(fb, fb.getI64Type(), accessLength);
+        Value accessEndI64 =
+            arith::AddIOp::create(fb, accessOffsetI64, accessLengthI64);
+        Value accessOffsets =
+            triton::SplatOp::create(fb, barriersType, accessOffsetI64);
+        Value accessEnds =
+            triton::SplatOp::create(fb, barriersType, accessEndI64);
+        Value startsBeforeBarrierEnds = arith::CmpIOp::create(
+            fb, arith::CmpIPredicate::ult, accessOffsets, barrierEnds);
+        Value barriersStartBeforeEnd = arith::CmpIOp::create(
+            fb, arith::CmpIPredicate::ult, barrierOffsets, accessEnds);
+        Value overlaps = arith::AndIOp::create(fb, startsBeforeBarrierEnds,
+                                               barriersStartBeforeEnd);
+        overlaps = convertAndBroadcast(fb, overlaps, {1}, barrierStatesType);
+
+        Value states = tti::createLoadScratchMemory(fb, fb.getLoc(), statesPtr,
+                                                    barrierStatesType);
+        Value zero =
+            tti::createConstIntTensor(fb, fb.getLoc(), 0, barrierStatesType);
+        Value inactive =
+            arith::CmpIOp::create(fb, arith::CmpIPredicate::eq, states, zero);
+        auto condType = cast<RankedTensorType>(inactive.getType());
+        Value vTrue = tti::createConstIntTensor(fb, fb.getLoc(), 1, condType);
+        Value available =
+            arith::SelectOp::create(fb, overlaps, inactive, vTrue);
+        Value ctaMask =
+            createCTASetMask(fb, condType, /*dim=*/0, recipientCTAs);
+        available = arith::SelectOp::create(fb, ctaMask, available, vTrue);
+        Value predTensor = triton::SplatOp::create(fb, condType, pred);
+        available = arith::SelectOp::create(fb, predTensor, available, vTrue);
+        triton::ReturnOp::create(fb, reduceAll<arith::AndIOp>(fb, available));
+      });
+}
+
 void FunctionBuilder::createInitBarrierStateCall(ImplicitLocOpBuilder &b,
                                                  Value mbar, int count,
                                                  Value pred,

--- a/lib/Dialect/TritonInstrument/Transforms/ConcurrencySanitizer.cpp
+++ b/lib/Dialect/TritonInstrument/Transforms/ConcurrencySanitizer.cpp
@@ -2,6 +2,7 @@
 #include "mlir/IR/ImplicitLocOpBuilder.h"
 #include "mlir/IR/Matchers.h"
 #include "mlir/Transforms/Passes.h"
+#include "triton/Analysis/Allocation.h"
 #include "triton/Dialect/Triton/IR/Utility.h"
 #include "triton/Dialect/TritonGPU/IR/Dialect.h"
 #include "triton/Dialect/TritonGPU/IR/LinearLayoutConversions.h"
@@ -771,6 +772,17 @@ private:
         instrumentBarrierWait(op, info->alloc, info->phase, info->pred, thread,
                               baseThread, funcBuilder);
         return WalkResult::advance();
+      }
+
+      if (!auxData.barriers.empty() &&
+          !isa<ttg::LocalAllocOp, ttng::TMEMAllocOp>(op)) {
+        if (auto offset = op->getAttrOfType<IntegerAttr>("allocation.offset")) {
+          unsigned scratchSize = defaultAllocationAnalysisScratchSizeFn(op);
+          if (scratchSize)
+            funcBuilder.createVerifyBarrierMemoryAvailableCall(
+                b, offset.getInt(), scratchSize, hooks.getIssuerCTAPred(b, op),
+                op, currentCTAMask(b));
+        }
       }
 
       if (failed(instrumentMemEffects(b, op, thread, funcBuilder))) {

--- a/lib/Dialect/TritonInstrument/Transforms/ConcurrencySanitizer.cpp
+++ b/lib/Dialect/TritonInstrument/Transforms/ConcurrencySanitizer.cpp
@@ -2,7 +2,6 @@
 #include "mlir/IR/ImplicitLocOpBuilder.h"
 #include "mlir/IR/Matchers.h"
 #include "mlir/Transforms/Passes.h"
-#include "triton/Analysis/Allocation.h"
 #include "triton/Dialect/Triton/IR/Utility.h"
 #include "triton/Dialect/TritonGPU/IR/Dialect.h"
 #include "triton/Dialect/TritonGPU/IR/LinearLayoutConversions.h"
@@ -774,15 +773,13 @@ private:
         return WalkResult::advance();
       }
 
-      if (!auxData.barriers.empty() &&
-          !isa<ttg::LocalAllocOp, ttng::TMEMAllocOp>(op)) {
-        if (auto offset = op->getAttrOfType<IntegerAttr>("allocation.offset")) {
-          unsigned scratchSize = defaultAllocationAnalysisScratchSizeFn(op);
-          if (scratchSize)
-            funcBuilder.createVerifyBarrierMemoryAvailableCall(
-                b, offset.getInt(), scratchSize, hooks.getIssuerCTAPred(b, op),
-                op, currentCTAMask(b));
-        }
+      if (!auxData.barriers.empty()) {
+        auto offset = op->getAttrOfType<IntegerAttr>("allocation.offset");
+        auto size = op->getAttrOfType<IntegerAttr>("allocation.size");
+        if (offset && size)
+          funcBuilder.createVerifyBarrierMemoryAvailableCall(
+              b, offset.getInt(), size.getInt(), hooks.getIssuerCTAPred(b, op),
+              op, currentCTAMask(b));
       }
 
       if (failed(instrumentMemEffects(b, op, thread, funcBuilder))) {

--- a/python/test/gluon/test_consan.py
+++ b/python/test/gluon/test_consan.py
@@ -3118,6 +3118,50 @@ def test_barrier_underflow(device, run_wrapper, monkeypatch, num_ctas):
 
 
 @pytest.mark.skipif(not is_cuda() or torch.cuda.get_device_capability()[0] < 9, reason="Requires hopper or newer")
+@pytest.mark.parametrize("NUM_CTAS", [1, 2])
+@pytest.mark.parametrize("WITH_INVALIDATE", [False, True])
+def test_barrier_scratch_reuse_requires_invalidate(WITH_INVALIDATE, NUM_CTAS, device, run_wrapper, monkeypatch):
+    if run_wrapper:
+        result = run_in_process(test_barrier_scratch_reuse_requires_invalidate,
+                                (WITH_INVALIDATE, NUM_CTAS, device, False, monkeypatch))
+        if WITH_INVALIDATE:
+            assert result.exc is None
+            assert result.driver_stderr_output == ""
+        else:
+            assert_expected_cuda_failure(result.exc)
+            assert "Shared memory reused before barrier invalidation" in result.driver_stderr_output
+        return
+
+    monkeypatch.setenv("TRITON_INSTRUMENTATION_MODE", "consan")
+    monkeypatch.setenv("CUDA_LAUNCH_BLOCKING", "1")
+    knobs.refresh_knobs()
+
+    @gluon.jit
+    def kernel(x, out, WITH_INVALIDATE: ttgl.constexpr):
+        cga_layout: ttgl.constexpr = default_cga_layout(ttgl.num_ctas(), 2)
+        src_layout: ttgl.constexpr = ttgl.BlockedLayout(size_per_thread=[1, 1], threads_per_warp=[4, 8],
+                                                        warps_per_cta=[4, 1], order=[1, 0], cga_layout=cga_layout)
+        dst_layout: ttgl.constexpr = ttgl.BlockedLayout(size_per_thread=[1, 1], threads_per_warp=[8, 4],
+                                                        warps_per_cta=[1, 4], order=[0, 1], cga_layout=cga_layout)
+        bar = mbarrier.allocate_mbarrier(batch=1)
+        mbarrier.init(bar.index(0), count=1)
+        if WITH_INVALIDATE:
+            mbarrier.invalidate(bar.index(0))
+
+        src_rows = ttgl.arange(0, 32, layout=ttgl.SliceLayout(1, src_layout))
+        src_cols = ttgl.arange(0, 32, layout=ttgl.SliceLayout(0, src_layout))
+        values = ttgl.load(x + src_rows[:, None] * 32 + src_cols[None, :])
+        converted = ttgl.convert_layout(values, dst_layout)
+        dst_rows = ttgl.arange(0, 32, layout=ttgl.SliceLayout(1, dst_layout))
+        dst_cols = ttgl.arange(0, 32, layout=ttgl.SliceLayout(0, dst_layout))
+        ttgl.store(out + dst_rows[:, None] * 32 + dst_cols[None, :], converted)
+
+    source = torch.randn((32, 32), device=device, dtype=torch.float32)
+    output = torch.empty_like(source)
+    kernel[(1, )](source, output, WITH_INVALIDATE=WITH_INVALIDATE, num_warps=4, num_ctas=NUM_CTAS)
+
+
+@pytest.mark.skipif(not is_cuda() or torch.cuda.get_device_capability()[0] < 9, reason="Requires hopper or newer")
 @pytest.mark.parametrize("WITH_INVALIDATE", [False, True])
 def test_barrier_reinit_requires_invalidate(WITH_INVALIDATE, device, run_wrapper, monkeypatch, num_ctas):
     if run_wrapper:

--- a/test/TritonGPU/consan.mlir
+++ b/test/TritonGPU/consan.mlir
@@ -2200,7 +2200,8 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.shar
         : !ttg.memdesc<1xi64, #scratch_barrier, #scratch_smem, mutable>
     // CHECK: tt.call @__triton_consan_verify_barrier_memory_available
     // CHECK: ttg.convert_layout
-    %converted = ttg.convert_layout %input {allocation.offset = 0 : i32}
+    %converted = ttg.convert_layout %input
+        {allocation.offset = 0 : i32, allocation.size = 4096 : i32}
         : tensor<32x32xf32, #scratch_src> -> tensor<32x32xf32, #scratch_dst>
     tt.return
   }

--- a/test/TritonGPU/consan.mlir
+++ b/test/TritonGPU/consan.mlir
@@ -2185,6 +2185,29 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 1 : i32, ttg.shar
 
 // -----
 
+#scratch_src = #ttg.blocked<{sizePerThread = [1, 1], threadsPerWarp = [4, 8], warpsPerCTA = [4, 1], order = [1, 0]}>
+#scratch_dst = #ttg.blocked<{sizePerThread = [1, 1], threadsPerWarp = [8, 4], warpsPerCTA = [1, 4], order = [0, 1]}>
+#scratch_barrier = #ttg.swizzled_shared<{vec = 1, perPhase = 1, maxPhase = 1, order = [0]}>
+#scratch_smem = #ttg.shared_memory
+
+module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.shared = 4096 : i32, ttg.target = "cuda:90", ttg.tensor_memory_size = 0 : i32, "ttg.threads-per-warp" = 32 : i32, "ttg.total-num-warps" = 4 : i32} {
+  // CHECK-LABEL: @layout_conversion_checks_barrier_lifetime
+  tt.func public @layout_conversion_checks_barrier_lifetime(
+      %input: tensor<32x32xf32, #scratch_src>) {
+    %bar = ttg.local_alloc {allocation.offset = 0 : i32}
+        : () -> !ttg.memdesc<1xi64, #scratch_barrier, #scratch_smem, mutable>
+    ttng.init_barrier %bar, 1
+        : !ttg.memdesc<1xi64, #scratch_barrier, #scratch_smem, mutable>
+    // CHECK: tt.call @__triton_consan_verify_barrier_memory_available
+    // CHECK: ttg.convert_layout
+    %converted = ttg.convert_layout %input {allocation.offset = 0 : i32}
+        : tensor<32x32xf32, #scratch_src> -> tensor<32x32xf32, #scratch_dst>
+    tt.return
+  }
+}
+
+// -----
+
 // A warp-group wait forwards descriptor provenance to its result while
 // separately preserving its asynchronous read-completion semantics.
 #shared = #ttg.swizzled_shared<{vec = 1, perPhase = 1, maxPhase = 1, order = [0]}>


### PR DESCRIPTION
PR description written by Codex

Detect compiler-generated shared-memory scratch that overlaps initialized mbarriers before invalidation. Record exact scratch-allocation extents to avoid false positives. Validated against the original failing GB300 kernel and the complete ConSan GPU suite: 388 passed, 62 skipped.

## Stack
Merge bottom-up:
- [ ] #11126
- [ ] #11120 (this PR)
