### PR TITLE
[Frontend] Have consistent upcasting semantics for scalar - tensor binops

### DIFF
--- a/docs/python-api/triton-semantics.rst
+++ b/docs/python-api/triton-semantics.rst
@@ -24,7 +24,7 @@ The rules are a bit different when they involve a scalar. By scalar here we mean
 
 When an operation involves a tensor and a scalar:
 
-1. If the scalar is of a kind lower or equal to the tensor, it will not participate in the promotion: ``(uint8, int) -> uint8``
+1. If the scalar is of a kind lower or equal to the tensor, it does not participate in the promotion, and the remaining promotion rules are applied to the tensor's dtype: ``(uint8, int) -> uint8``
 
 2. If the scalar is of a higher kind, we choose the lowest dtype in which it fits among ``int32`` < ``uint32`` < ``int64`` < ``uint64`` for ints and ``float32`` < ``float64`` for floats. Then, both the tensor and the scalar are promoted to this dtype: ``(int16, 4.0) -> float32``
 

--- a/python/test/unit/language/test_frontend.py
+++ b/python/test/unit/language/test_frontend.py
@@ -925,6 +925,7 @@ def test_fp8_div_mod_promotion():
         z = tl.full((8, ), 0, tl.float16).to(tl.float8e4nv)
         h = tl.full((8, ), 0, tl.float16)
         b = tl.full((8, ), 0, tl.bfloat16)
+        d = tl.full((8, ), 0, tl.float64)
         i = tl.full((8, ), 0, tl.int32)
         tl.static_assert((x / y).dtype == tl.float32)
         tl.static_assert((x / z).dtype == tl.float32)
@@ -941,12 +942,14 @@ def test_fp8_div_mod_promotion():
         tl.static_assert((i // i).dtype == tl.int32)
         tl.static_assert((i % i).dtype == tl.int32)
         # A scalar operand doesn't participate in promotion, so / and % against
-        # a float tensor must upcast to fp32 for the same reason, while other
+        # a narrow float tensor must upcast to fp32 for the same reason, while other
         # ops keep the tensor's type.
         tl.static_assert((2.0 / x).dtype == tl.float32)
         tl.static_assert((x / 2.0).dtype == tl.float32)
         tl.static_assert((x % 2).dtype == tl.float32)
         tl.static_assert((h / 2.0).dtype == tl.float32)
+        tl.static_assert((d / 2.0).dtype == tl.float64)
+        tl.static_assert((d % 2.0).dtype == tl.float64)
         tl.static_assert((x * 2.0).dtype == tl.float8e5)
         tl.static_assert((h * 2.0).dtype == tl.float16)
         tl.static_assert((i // 2).dtype == tl.int32)

--- a/python/triton/language/semantic.py
+++ b/python/triton/language/semantic.py
@@ -73,10 +73,8 @@ class TritonSemantic(Generic[TensorTy]):
         if a_is_scalar != b_is_scalar:
             scalar_ty, tensor_ty = (a_ty, b_ty) if a_is_scalar else (b_ty, a_ty)
             if scalar_ty.kind().value <= tensor_ty.kind().value:
-                # Upcast because of 2) below!
-                if div_or_mod and tensor_ty.is_floating():
-                    return tl.float32
-                return tensor_ty
+                # Ignore the scalar and apply the remaining promotion rules.
+                a_ty, b_ty = tensor_ty, tensor_ty
 
         # 1) if one operand is double, the other is implicitly
         #    converted to double


### PR DESCRIPTION
It also fixes the following issue:
https://github.com/triton-lang/triton/pull/10883#discussion_r3649238321
