### PR TITLE
[PIPELINER] Pipeline TMA stores in scf.while loops

### DIFF
--- a/include/triton/Dialect/TritonGPU/Transforms/PipeliningUtility.h
+++ b/include/triton/Dialect/TritonGPU/Transforms/PipeliningUtility.h
@@ -178,7 +178,8 @@ Value createIncrementModulo(OpBuilder &builder, Location loc, Value counter,
                             Value modulus, Value zero, Value one,
                             Value *outWrapCond = nullptr);
 
-scf::ForOp lowerTMADescriptors(scf::ForOp forOp, CoarseSchedule &schedule);
+LoopLikeOpInterface lowerTMADescriptors(LoopLikeOpInterface loop,
+                                        CoarseSchedule &schedule);
 
 DenseSet<Operation *>
 getTopLevelUsersInLoop(Operation *op, scf::ForOp forOp,

--- a/include/triton/Dialect/TritonGPU/Transforms/Schedule.h
+++ b/include/triton/Dialect/TritonGPU/Transforms/Schedule.h
@@ -28,7 +28,7 @@ loadOpsToIndirectionLevel(scf::ForOp forOp, bool pipelineWithoutDot,
 }; // namespace gpu
 
 /// Pipeline the TMA stores in the loop.
-bool pipelineTMAStores(scf::ForOp forOp);
+bool pipelineTMAStores(LoopLikeOpInterface loop);
 
 /// This does post-processing on the pipelined loop to try to pipeline wgmma
 /// ops.

--- a/lib/Dialect/TritonGPU/Transforms/Pipeliner/LowerLoops.cpp
+++ b/lib/Dialect/TritonGPU/Transforms/Pipeliner/LowerLoops.cpp
@@ -1058,7 +1058,7 @@ void lowerLoop(scf::ForOp forOp,
   }
   scf::ForOp newForOp = lowerMMAs(forOp, schedule);
   newForOp = lowerLoads(newForOp, schedule, axisInfoAnalysis);
-  newForOp = lowerTMADescriptors(newForOp, schedule);
+  newForOp = cast<scf::ForOp>(lowerTMADescriptors(newForOp, schedule));
   schedule.serialize(newForOp);
 }
 

--- a/lib/Dialect/TritonGPU/Transforms/Pipeliner/PipeliningUtility.cpp
+++ b/lib/Dialect/TritonGPU/Transforms/Pipeliner/PipeliningUtility.cpp
@@ -602,14 +602,15 @@ Value triton::createIncrementModulo(OpBuilder &builder, Location loc,
 /////////////////////////////
 
 static void
-allocTMABuffers(scf::ForOp forOp,
+allocTMABuffers(LoopLikeOpInterface loop,
                 llvm::MapVector<Operation *, Value> &tmaBufferMapping,
                 int maxStage) {
-  IRRewriter rewriter(forOp);
+  IRRewriter rewriter(loop);
+  Block *body = &loop.getLoopRegions().back()->front();
 
   // Create a multi-buffered allocation for each MakeTensorDescOp call in the
   // loop
-  forOp.walk([&](tt::MakeTensorDescOp op) {
+  body->walk([&](tt::MakeTensorDescOp op) {
     // TODO peter: walk to loop yield to find the init value if this is a
     // loop-carried value. That would save us from allocating another buffer
     // just for the init value
@@ -630,15 +631,16 @@ static Value subviewTMADescriptor(OpBuilder &builder, Location loc, Value alloc,
 }
 
 static LogicalResult rewriteTMABufferUpdates(
-    scf::ForOp forOp,
+    LoopLikeOpInterface loop,
     const llvm::MapVector<Operation *, Value> &tmaBufferMapping,
     ArrayRef<BlockArgument> tmaCounters, int numBuffers, Value one, Value zero,
+    MutableArrayRef<OpOperand> tmaCounterYields,
     triton::CoarseSchedule &schedule) {
   assert(tmaBufferMapping.size() == tmaCounters.size());
 
-  auto auxBuilder = mlir::OpBuilder(forOp);
+  auto auxBuilder = mlir::OpBuilder(loop);
   Value numBuffersVal =
-      arith::ConstantIntOp::create(auxBuilder, forOp.getLoc(), numBuffers, 32);
+      arith::ConstantIntOp::create(auxBuilder, loop.getLoc(), numBuffers, 32);
 
   for (auto [iOp, pair] : llvm::enumerate(tmaBufferMapping)) {
     auto &[op, alloc] = pair;
@@ -666,25 +668,25 @@ static LogicalResult rewriteTMABufferUpdates(
         builder, builder.getLoc(), counter, numBuffersVal, zero, one);
 
     // If we are in a (potentially nested) if region, propagate the counter
-    // up to the main for op body scope
-    IRRewriter rewriter(forOp);
+    // up to the main loop body scope
+    IRRewriter rewriter(loop);
     nextCounter = triton::sinkValueRedefinition(rewriter, counter, nextCounter,
                                                 op->getBlock());
 
     // Finally, rewrite the loop level yield
-    auto forYield = cast<scf::YieldOp>(forOp.getBody()->getTerminator());
-    forYield.setOperand(counter.getArgNumber() - 1, nextCounter);
+    tmaCounterYields[iOp].set(nextCounter);
     makeDescOp.erase();
   }
   return success();
 }
 
-scf::ForOp triton::lowerTMADescriptors(scf::ForOp forOp,
-                                       CoarseSchedule &schedule) {
+LoopLikeOpInterface triton::lowerTMADescriptors(LoopLikeOpInterface loop,
+                                                CoarseSchedule &schedule) {
   llvm::MapVector<Operation *, Value> tmaBufferMapping;
   int maxStage = schedule.getNumStages() - 1;
-  for (auto &op : forOp.getBody()->without_terminator()) {
-    if (auto wgMmaOp = dyn_cast<ttng::WarpGroupDotOp>(&op)) {
+  Block *body = &loop.getLoopRegions().back()->front();
+  for (Operation &op : body->without_terminator()) {
+    if (isa<ttng::WarpGroupDotOp>(op)) {
       // Hopper only: Add one more buffer slice if there is a WarpGroupDotOp,
       // as if it will be pipelined, we will effectively make the pipeline
       // one stage longer.
@@ -692,40 +694,56 @@ scf::ForOp triton::lowerTMADescriptors(scf::ForOp forOp,
       break;
     }
   }
-  allocTMABuffers(forOp, tmaBufferMapping, maxStage);
+  allocTMABuffers(loop, tmaBufferMapping, maxStage);
   if (tmaBufferMapping.empty())
-    return forOp;
+    return loop;
 
-  IRRewriter builder(forOp);
-  Location loc = forOp.getLoc();
+  IRRewriter builder(loop);
+  Location loc = loop.getLoc();
   Value zero = arith::ConstantIntOp::create(builder, loc, 0, 32);
   Value one = arith::ConstantIntOp::create(builder, loc, 1, 32);
   SmallVector<Value> newOperands;
-  unsigned newOperandIndex = forOp.getBody()->getNumArguments();
   // Create one counter per TMA buffer. This allows the descriptors to be
   // updated independently without needing to write duplicate of existing tma
   // descriptors.
-  unsigned tmaCounterArgsStartIdx = newOperandIndex + newOperands.size();
   for (int i = 0; i < tmaBufferMapping.size(); ++i) {
     newOperands.push_back(zero);
   }
 
-  forOp = addIterArgsToLoop(builder, forOp, newOperands);
-
-  auto tmaCounters = ArrayRef<BlockArgument>(forOp.getBody()->getArguments())
-                         .slice(tmaCounterArgsStartIdx);
-
-  // Update yield op with temporary yield values
-  auto forYield = cast<scf::YieldOp>(forOp.getBody()->getTerminator());
-  for (unsigned i = 0; i < newOperands.size(); ++i) {
-    forYield.getResultsMutable().append(newOperands[i]);
+  if (auto forOp = dyn_cast<scf::ForOp>(loop.getOperation())) {
+    forOp = addIterArgsToLoop(builder, forOp, newOperands);
+    auto yield = cast<scf::YieldOp>(forOp.getBody()->getTerminator());
+    for (Value operand : newOperands)
+      yield.getResultsMutable().append(operand);
+    loop = forOp;
+  } else {
+    auto whileOp = cast<scf::WhileOp>(loop.getOperation());
+    auto numBeforeArgs = whileOp.getBeforeArguments().size();
+    auto numAfterArgs = whileOp.getAfterArguments().size();
+    SmallVector<Type> resultTypes(newOperands.size(), builder.getI32Type());
+    auto oldWhile = whileOp;
+    whileOp = replaceWhileOpWithNewSignature(builder, whileOp, newOperands,
+                                             resultTypes);
+    oldWhile.erase();
+    for (int i = 0; i < newOperands.size(); ++i) {
+      whileOp.getConditionOp().getArgsMutable().append(
+          whileOp.getBeforeArguments()[numBeforeArgs + i]);
+      whileOp.getYieldOp().getResultsMutable().append(
+          whileOp.getAfterArguments()[numAfterArgs + i]);
+    }
+    loop = whileOp;
   }
 
-  if (failed(rewriteTMABufferUpdates(forOp, tmaBufferMapping, tmaCounters,
-                                     maxStage, one, zero, schedule))) {
+  body = &loop.getLoopRegions().back()->front();
+  auto tmaCounters = body->getArguments().take_back(tmaBufferMapping.size());
+  auto tmaCounterYields =
+      loop.getYieldedValuesMutable()->take_back(tmaBufferMapping.size());
+  if (failed(rewriteTMABufferUpdates(loop, tmaBufferMapping, tmaCounters,
+                                     maxStage, one, zero, tmaCounterYields,
+                                     schedule))) {
     llvm_unreachable("Failed to rewrite TMA ops");
   }
-  return forOp;
+  return loop;
 }
 
 DenseSet<Operation *>

--- a/lib/Dialect/TritonGPU/Transforms/Pipeliner/SoftwarePipeliner.cpp
+++ b/lib/Dialect/TritonGPU/Transforms/Pipeliner/SoftwarePipeliner.cpp
@@ -210,15 +210,20 @@ struct PipelinePass : public impl::TritonGPUPipelineBase<PipelinePass> {
       return signalPassFailure();
 
     {
-      SmallVector<scf::ForOp> loops;
+      SmallVector<LoopLikeOpInterface> loops;
       getOperation()->walk([&](scf::ForOp forOp) {
         // Bail out for loops with num_stage <= 1.
         if (getNumStagesOrDefault(forOp, numStages) > 1)
           loops.push_back(forOp);
       });
 
-      for (scf::ForOp forOp : loops) {
-        mlir::triton::pipelineTMAStores(forOp);
+      if (numStages > 1) {
+        getOperation()->walk(
+            [&](scf::WhileOp whileOp) { loops.push_back(whileOp); });
+      }
+
+      for (auto loopOp : loops) {
+        mlir::triton::pipelineTMAStores(loopOp);
       }
     }
   }

--- a/lib/Dialect/TritonGPU/Transforms/Pipeliner/TMAStoresPipeline.cpp
+++ b/lib/Dialect/TritonGPU/Transforms/Pipeliner/TMAStoresPipeline.cpp
@@ -16,14 +16,17 @@ struct TMAStore {
   mlir::TypedValue<RankedTensorType> src;
 };
 
-static SmallVector<TMAStore> getTMAStores(scf::ForOp forOp) {
+static SmallVector<TMAStore> getTMAStores(LoopLikeOpInterface loop) {
   SmallVector<TMAStore> tmaStores;
 
-  forOp.getBody()->walk<mlir::WalkOrder::PreOrder>([&](Operation *op) {
+  assert((isa<scf::ForOp, scf::WhileOp>(loop)) &&
+         "expected a For or While loop");
+  auto body = &loop.getLoopRegions().back()->front();
+  body->walk<mlir::WalkOrder::PreOrder>([&](Operation *op) {
     if (auto storeOp = dyn_cast<tt::DescriptorStoreLikeOpInterface>(op)) {
       tmaStores.push_back({storeOp, storeOp.getDesc(), storeOp.getSrc()});
       // Don't walk into nested loops.
-    } else if (isa<scf::ForOp>(op)) {
+    } else if (isa<scf::ForOp, scf::WhileOp>(op)) {
       return WalkResult::skip();
     }
     return WalkResult::advance();
@@ -36,9 +39,9 @@ static bool hasAcquireOrReleaseSemantic(tt::MemSemantic sem) {
   return sem != tt::MemSemantic::RELAXED;
 }
 
-static bool hasAcquireOrReleaseOp(scf::ForOp forOp) {
+static bool hasAcquireOrReleaseOp(LoopLikeOpInterface loop) {
   bool hasAcquireOrRelease = false;
-  forOp.getBody()->walk([&](Operation *op) {
+  loop->walk([&](Operation *op) {
     if (auto atomicRMW = dyn_cast<tt::AtomicRMWOp>(op)) {
       hasAcquireOrRelease = hasAcquireOrReleaseSemantic(atomicRMW.getSem());
     } else if (auto atomicCAS = dyn_cast<tt::AtomicCASOp>(op)) {
@@ -52,8 +55,8 @@ static bool hasAcquireOrReleaseOp(scf::ForOp forOp) {
   return hasAcquireOrRelease;
 }
 
-static Value createAlloc(scf::ForOp &forOp, const TMAStore &store) {
-  OpBuilder builder(forOp);
+static Value createAlloc(LoopLikeOpInterface loop, const TMAStore &store) {
+  OpBuilder builder(loop);
   RankedTensorType ty = store.src.getType();
   auto encoding =
       triton::nvidia_gpu::getEncodingFromDescriptor(store.op, ty, store.desc);
@@ -67,8 +70,7 @@ static Value createAlloc(scf::ForOp &forOp, const TMAStore &store) {
   return alloc;
 }
 
-static void createTMAAsyncCopy(scf::ForOp forOp, const TMAStore &store,
-                               Value alloc) {
+static void createTMAAsyncCopy(const TMAStore &store, Value alloc) {
   OpBuilder builder(store.op);
   Location loc = store.op->getLoc();
 
@@ -95,17 +97,17 @@ static void createTMAAsyncCopy(scf::ForOp forOp, const TMAStore &store,
   store.op->erase();
 }
 
-static void lowerTMADescriptorCreation(scf::ForOp forOp) {
+static void lowerTMADescriptorCreation(LoopLikeOpInterface loop) {
   // Use max_stage=3 to double buffer the descriptor.
   triton::CoarseSchedule schedule(3);
-  triton::lowerTMADescriptors(forOp, schedule);
+  triton::lowerTMADescriptors(loop, schedule);
 }
 
-bool mlir::triton::pipelineTMAStores(scf::ForOp forOp) {
-  SmallVector<TMAStore> tmaStores = getTMAStores(forOp);
+bool mlir::triton::pipelineTMAStores(LoopLikeOpInterface loop) {
+  SmallVector<TMAStore> tmaStores = getTMAStores(loop);
   if (tmaStores.empty())
     return false;
-  if (hasAcquireOrReleaseOp(forOp))
+  if (hasAcquireOrReleaseOp(loop))
     return false;
 
   DenseMap<Operation *, Value> storeToAlloc;
@@ -119,7 +121,7 @@ bool mlir::triton::pipelineTMAStores(scf::ForOp forOp) {
     auto key = std::make_pair(srcTy.getShape(), srcTy.getElementType());
     Value &alloc = allocs[key];
     if (!alloc) {
-      alloc = createAlloc(forOp, store);
+      alloc = createAlloc(loop, store);
     }
     storeToAlloc[store.op] = alloc;
   }
@@ -128,22 +130,22 @@ bool mlir::triton::pipelineTMAStores(scf::ForOp forOp) {
     return !triton::isHostSideDescriptor(store.desc);
   });
   for (const TMAStore &store : tmaStores) {
-    createTMAAsyncCopy(forOp, store, storeToAlloc[store.op]);
+    createTMAAsyncCopy(store, storeToAlloc[store.op]);
   }
 
   // Deallocate shared memory buffers.
-  OpBuilder builder(forOp);
-  builder.setInsertionPointAfter(forOp);
-  ttng::TMAStoreWaitOp::create(builder, forOp->getLoc(), 0,
+  OpBuilder builder(loop);
+  builder.setInsertionPointAfter(loop);
+  ttng::TMAStoreWaitOp::create(builder, loop->getLoc(), 0,
                                /*read_only=*/false);
   for (auto it : storeToAlloc) {
-    ttg::LocalDeallocOp::create(builder, forOp->getLoc(), it.second);
+    ttg::LocalDeallocOp::create(builder, loop->getLoc(), it.second);
   }
 
   if (hasDeviceSideTMA) {
     // This is a bit coarse as it would multibuffer any descriptor in the loop
     // but it likely to not have a big impact.
-    lowerTMADescriptorCreation(forOp);
+    lowerTMADescriptorCreation(loop);
   }
   return true;
 }

--- a/test/TritonGPU/loop-pipeline-hopper.mlir
+++ b/test/TritonGPU/loop-pipeline-hopper.mlir
@@ -1105,6 +1105,88 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.targ
 
 // -----
 
+#blocked_while_store = #ttg.blocked<{sizePerThread = [1, 1], threadsPerWarp = [1, 32], warpsPerCTA = [1, 4], order = [1, 0]}>
+#shared_while_store = #ttg.nvmma_shared<{swizzlingByteWidth = 64, transposed = false, elementBitWidth = 8}>
+module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.target = "cuda:90", "ttg.threads-per-warp" = 32 : i32} {
+  // CHECK-LABEL: tma_store_pipeline_while_host
+  tt.func public @tma_store_pipeline_while_host(%src: tensor<128x128xf32, #blocked_while_store>, %desc: !tt.tensordesc<128x128xf32, #shared_while_store>, %run: i1) {
+    // CHECK: %[[ALLOC:.+]] = ttg.local_alloc : () -> !ttg.memdesc<128x128xf32, #[[$SHARED:.+]], #smem, mutable>
+    // CHECK-NOT: ttg.global_scratch_alloc
+    // CHECK: scf.while
+    %loop = scf.while (%keep_going = %run) : (i1) -> i1 {
+      scf.condition(%keep_going) %keep_going : i1
+    } do {
+    ^bb0(%keep_going: i1):
+      %c0 = arith.constant 0 : i32
+      // CHECK: ttng.async_tma_store_wait {pendings = 0 : i32, read_only}
+      // CHECK-NEXT: ttg.local_store {{.*}}, %[[ALLOC]]
+      // CHECK-NEXT: ttng.fence_async_shared
+      // CHECK-NEXT: ttng.async_tma_copy_local_to_global {{.*}} %[[ALLOC]]
+      tt.descriptor_store %desc[%c0, %c0], %src : !tt.tensordesc<128x128xf32, #shared_while_store>, tensor<128x128xf32, #blocked_while_store>
+      scf.yield %keep_going : i1
+    }
+    // CHECK: ttng.async_tma_store_wait {pendings = 0 : i32}
+    // CHECK-NEXT: ttg.local_dealloc %[[ALLOC]]
+    tt.return
+  }
+}
+
+// -----
+
+#blocked_while_store = #ttg.blocked<{sizePerThread = [1, 1], threadsPerWarp = [1, 32], warpsPerCTA = [1, 4], order = [1, 0]}>
+#shared_while_store = #ttg.nvmma_shared<{swizzlingByteWidth = 64, transposed = false, elementBitWidth = 8}>
+module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.target = "cuda:90", "ttg.threads-per-warp" = 32 : i32} {
+  // CHECK-LABEL: tma_store_pipeline_while_device
+  tt.func public @tma_store_pipeline_while_device(%src: tensor<128x128xf32, #blocked_while_store>, %base: !tt.ptr<f32>, %run: i1, %before_only: i32) {
+    %c128_i32 = arith.constant 128 : i32
+    %c128_i64 = arith.constant 128 : i64
+    %c1_i64 = arith.constant 1 : i64
+    // CHECK: [[ZERO:%.*]] = arith.constant 0 : i32
+    // CHECK: %[[ALLOC:.+]] = ttg.local_alloc : () -> !ttg.memdesc<128x128xf32, #[[$SHARED:.+]], #smem, mutable>
+    // CHECK-NEXT: [[DESC_RING:%.*]] = ttg.global_scratch_alloc {alignment = 128 : i32, nbytes = 256 : i32}
+    // CHECK-NEXT: {{%.*}} = scf.while ({{.*}}, {{.*}}, [[BEFORE_COUNTER:%.*]] = [[ZERO]])
+    %loop = scf.while (%keep_going = %run, %unused = %before_only) : (i1, i32) -> i1 {
+      // CHECK: %[[BEFORE_DESC:.*]] = tt.make_tensor_descriptor %{{.*}}
+      // CHECK: tt.descriptor_store %[[BEFORE_DESC]]
+      %before_c0 = arith.constant 0 : i32
+      %before_desc = tt.make_tensor_descriptor %base, [%c128_i32, %c128_i32], [%c128_i64, %c1_i64] : <f32>, <128x128xf32, #shared_while_store>
+      tt.descriptor_store %before_desc[%before_c0, %before_c0], %src : !tt.tensordesc<128x128xf32, #shared_while_store>, tensor<128x128xf32, #blocked_while_store>
+      %continue = arith.cmpi sgt, %unused, %before_c0 : i32
+      // CHECK: scf.condition({{.*}}) {{%.*}}, [[BEFORE_COUNTER]] : i1, i32
+      scf.condition(%continue) %keep_going : i1
+    } do {
+    // CHECK: ^bb0({{%.*}}: i1, [[AFTER_COUNTER:%.*]]: i32):
+    ^bb0(%keep_going: i1):
+      %c0 = arith.constant 0 : i32
+      // CHECK: [[DESC_OFFSET:%.*]] = arith.muli [[AFTER_COUNTER]], {{.*}} : i32
+      // CHECK-NEXT: [[DESC_SLOT:%.*]] = tt.addptr [[DESC_RING]], [[DESC_OFFSET]]
+      // CHECK-NEXT: ttng.tensormap_create [[DESC_SLOT]]
+      // CHECK-NEXT: ttng.tensormap_fenceproxy_acquire [[DESC_SLOT]]
+      // CHECK-NEXT: [[DESC:%.*]] = ttng.reinterpret_tensor_descriptor [[DESC_SLOT]]
+      // CHECK-NEXT: [[COUNTER_INC:%.*]] = arith.addi [[AFTER_COUNTER]], {{.*}} : i32
+      // CHECK-NEXT: [[COUNTER_WRAP:%.*]] = arith.cmpi sge, [[COUNTER_INC]], {{.*}} : i32
+      // CHECK-NEXT: [[NEXT_COUNTER:%.*]] = arith.select [[COUNTER_WRAP]], [[ZERO]], [[COUNTER_INC]] : i32
+      %desc = tt.make_tensor_descriptor %base, [%c128_i32, %c128_i32], [%c128_i64, %c1_i64] : <f32>, <128x128xf32, #shared_while_store>
+      // CHECK: ttng.async_tma_store_wait {pendings = 0 : i32, read_only}
+      // CHECK-NEXT: ttg.local_store {{.*}}, %[[ALLOC]]
+      // CHECK-NEXT: ttng.fence_async_shared
+      // CHECK-NEXT: ttng.async_tma_copy_local_to_global [[DESC]]{{.*}} %[[ALLOC]]
+      tt.descriptor_store %desc[%c0, %c0], %src : !tt.tensordesc<128x128xf32, #shared_while_store>, tensor<128x128xf32, #blocked_while_store>
+      %true = arith.constant true
+      %next_keep_going = arith.xori %keep_going, %true : i1
+      %next_unused = arith.extui %keep_going : i1 to i32
+      // CHECK: scf.yield {{.*}}, {{.*}}, [[NEXT_COUNTER]] : i1, i32, i32
+      scf.yield %next_keep_going, %next_unused : i1, i32
+    }
+    // CHECK: ttng.async_tma_store_wait {pendings = 0 : i32}
+    // CHECK-NEXT: ttg.local_dealloc %[[ALLOC]]
+    // CHECK-NOT: tt.make_tensor_descriptor
+    tt.return
+  }
+}
+
+// -----
+
 #mma = #ttg.nvidia_mma<{versionMajor = 3, versionMinor = 0, warpsPerCTA = [4, 1], instrShape = [16, 32, 16]}>
 #shared = #ttg.nvmma_shared<{swizzlingByteWidth = 64, transposed = false, elementBitWidth = 16}>
 #shared1 = #ttg.nvmma_shared<{swizzlingByteWidth = 64, transposed = true, elementBitWidth = 16}>


### PR DESCRIPTION
Extend TMA-store pipelining from scf.for to scf.while loops (split from https://github.com/triton-lang/triton/pull/11116 with fix to  handle canonicalized loops with asymmetric before/after signatures without depending on the normalization used by CLC+WS).

