### PR TITLE
[MLIR] Use constant-time block splits

### DIFF
--- a/lib/Conversion/TritonGPUToLLVM/ReduceScanCommon.h
+++ b/lib/Conversion/TritonGPUToLLVM/ReduceScanCommon.h
@@ -82,8 +82,7 @@ inline SmallVector<Value> applyCombineOp(Location loc,
   //    yield undef
   // }
   // #thenBlock
-  Block *thenBlock =
-      rewriter.splitBlock(currentBlock, rewriter.getInsertionPoint());
+  Block *thenBlock = currentBlock->splitBlock(rewriter.getInsertionPoint());
 
   auto returnOp = newCombine.getTerminator();
   auto results = SmallVector<Value>(returnOp->getOperands());

--- a/lib/Conversion/TritonGPUToLLVM/Utility.cpp
+++ b/lib/Conversion/TritonGPUToLLVM/Utility.cpp
@@ -2119,10 +2119,8 @@ SmallVector<Value> inlineRegionImpl(RewriterBase &rewriter, Region &region,
 std::tuple<Block *, Block *, Block *> createIfBlock(RewriterBase &b,
                                                     Location loc, Value cnd) {
   Block *prevBlock = b.getInsertionBlock();
-  Block *ifBlock = prevBlock->splitBlock(b.getInsertionPoint());
-
-  // Split a block after the call.
-  Block *thenBlock = ifBlock->splitBlock(ifBlock->begin());
+  Block *thenBlock = prevBlock->splitBlock(b.getInsertionPoint());
+  Block *ifBlock = b.createBlock(thenBlock);
   b.setInsertionPointToEnd(ifBlock);
   LLVM::BrOp::create(b, loc, thenBlock);
   b.setInsertionPointToEnd(prevBlock);

--- a/lib/Conversion/TritonGPUToLLVM/Utility.cpp
+++ b/lib/Conversion/TritonGPUToLLVM/Utility.cpp
@@ -2085,7 +2085,7 @@ SmallVector<Value> inlineRegionImpl(RewriterBase &rewriter, Region &region,
   //                                              └─────────┘
   auto *curBlock = rewriter.getInsertionBlock();
   auto opPosition = rewriter.getInsertionPoint();
-  auto *remainingOpsBlock = rewriter.splitBlock(curBlock, opPosition);
+  auto *remainingOpsBlock = curBlock->splitBlock(opPosition);
 
   IRMapping regionMap;
   Region &parent = *curBlock->getParent();
@@ -2119,10 +2119,10 @@ SmallVector<Value> inlineRegionImpl(RewriterBase &rewriter, Region &region,
 std::tuple<Block *, Block *, Block *> createIfBlock(RewriterBase &b,
                                                     Location loc, Value cnd) {
   Block *prevBlock = b.getInsertionBlock();
-  Block *ifBlock = b.splitBlock(prevBlock, b.getInsertionPoint());
+  Block *ifBlock = prevBlock->splitBlock(b.getInsertionPoint());
 
   // Split a block after the call.
-  Block *thenBlock = b.splitBlock(ifBlock, ifBlock->begin());
+  Block *thenBlock = ifBlock->splitBlock(ifBlock->begin());
   b.setInsertionPointToEnd(ifBlock);
   LLVM::BrOp::create(b, loc, thenBlock);
   b.setInsertionPointToEnd(prevBlock);

--- a/lib/Conversion/TritonGPUToLLVM/WarpSpecializeUtility.cpp
+++ b/lib/Conversion/TritonGPUToLLVM/WarpSpecializeUtility.cpp
@@ -525,7 +525,7 @@ LogicalResult mlir::triton::lowerWarpSpecializeCommon(
     WarpSpecializeOp ws = wsOps[i];
     auto &stateMap = warpToState[i];
     Block *before = ws->getBlock();
-    Block *after = b.splitBlock(before, ws->getIterator());
+    Block *after = before->splitBlock(ws->getIterator());
     TritonLLVMIRRewriter b(ws.getLoc(), OpBuilder::atBlockEnd(before));
     Type int8Type = b.getIntegerType(8);
     Value statePtrWs =

--- a/lib/Conversion/TritonInstrumentToLLVM/InstrumentationToLLVM.cpp
+++ b/lib/Conversion/TritonInstrumentToLLVM/InstrumentationToLLVM.cpp
@@ -187,8 +187,8 @@ struct LockAcquireOpConversion
     // Build: do { old = atom.global.acquire.cas.b32 [lock], 0, 1; } while (old
     // != 0);
     Block *prevBlock2 = b.getInsertionBlock();
-    Block *whileBlock = b.splitBlock(prevBlock2, b.getInsertionPoint());
-    Block *endBlock = b.splitBlock(whileBlock, whileBlock->begin());
+    Block *whileBlock = prevBlock2->splitBlock(b.getInsertionPoint());
+    Block *endBlock = whileBlock->splitBlock(whileBlock->begin());
     b.setInsertionPointToEnd(prevBlock2);
 
     Value elect;

--- a/third_party/amd/lib/TritonAMDGPUToLLVM/BarrierOpToLLVM.cpp
+++ b/third_party/amd/lib/TritonAMDGPUToLLVM/BarrierOpToLLVM.cpp
@@ -131,8 +131,7 @@ struct ClusterBarrierArriveOpConversion
     Value isFirstWarp = b.icmp_eq(warpId, b.i32_val(0));
 
     Block *currentBlock = rewriter.getInsertionBlock();
-    Block *afterBlock =
-        rewriter.splitBlock(currentBlock, rewriter.getInsertionPoint());
+    Block *afterBlock = currentBlock->splitBlock(rewriter.getInsertionPoint());
     Block *signalBlock = rewriter.createBlock(afterBlock);
     rewriter.setInsertionPointToEnd(currentBlock);
     LLVM::CondBrOp::create(rewriter, loc, isFirstWarp, signalBlock, afterBlock);

--- a/third_party/amd/lib/TritonAMDGPUToLLVM/LoadStoreOpToLLVM.cpp
+++ b/third_party/amd/lib/TritonAMDGPUToLLVM/LoadStoreOpToLLVM.cpp
@@ -188,8 +188,7 @@ Value emitRedundantThreadPredicateNonNull(
 std::pair<Block *, Block *> emitBranch(RewriterBase &rewriter, Location loc,
                                        Value cond) {
   Block *currentBlock = rewriter.getInsertionBlock();
-  Block *after =
-      rewriter.splitBlock(currentBlock, rewriter.getInsertionPoint());
+  Block *after = currentBlock->splitBlock(rewriter.getInsertionPoint());
   Block *body = rewriter.createBlock(after);
   rewriter.setInsertionPointToEnd(currentBlock);
   LLVM::CondBrOp::create(rewriter, loc, cond, body, after);

--- a/third_party/amd/lib/TritonAMDGPUToLLVM/MaskedOpsToLLVM.cpp
+++ b/third_party/amd/lib/TritonAMDGPUToLLVM/MaskedOpsToLLVM.cpp
@@ -87,8 +87,7 @@ public:
     }
 
     Block *currentBlock = rewriter.getInsertionBlock();
-    Block *afterLoad =
-        rewriter.splitBlock(currentBlock, rewriter.getInsertionPoint());
+    Block *afterLoad = currentBlock->splitBlock(rewriter.getInsertionPoint());
     afterLoad->addArgument({elemTy}, {loc});
 
     Block *trueBlock = rewriter.createBlock(afterLoad);
@@ -157,8 +156,7 @@ public:
     }
 
     Block *currentBlock = rewriter.getInsertionBlock();
-    Block *afterStore =
-        rewriter.splitBlock(currentBlock, rewriter.getInsertionPoint());
+    Block *afterStore = currentBlock->splitBlock(rewriter.getInsertionPoint());
     Block *trueBlock = rewriter.createBlock(afterStore);
     rewriter.setInsertionPointToEnd(currentBlock);
     LLVM::CondBrOp::create(rewriter, loc, mask, trueBlock, afterStore);

--- a/third_party/amd/lib/TritonAMDGPUToLLVM/SPMDOpToLLVM.cpp
+++ b/third_party/amd/lib/TritonAMDGPUToLLVM/SPMDOpToLLVM.cpp
@@ -36,7 +36,7 @@ struct CondBarrierOpConversion
     Location loc = op->getLoc();
     Block *currentBlock = rewriter.getInsertionBlock();
     Block *afterCondBarBlock =
-        rewriter.splitBlock(currentBlock, rewriter.getInsertionPoint());
+        currentBlock->splitBlock(rewriter.getInsertionPoint());
     Block *trueBlock = rewriter.createBlock(afterCondBarBlock);
     rewriter.setInsertionPointToEnd(currentBlock);
     LLVM::CondBrOp::create(rewriter, loc, adaptor.getPred(), trueBlock,

--- a/third_party/amd/lib/TritonAMDGPUToLLVM/TDMUtility.cpp
+++ b/third_party/amd/lib/TritonAMDGPUToLLVM/TDMUtility.cpp
@@ -1637,7 +1637,7 @@ SmallVector<Value> emitTDMPrefetch(RewriterBase &rewriter, Location loc,
     // Predicate and emit prefetch
     Block *currentBlock = rewriter.getInsertionBlock();
     Block *afterPrefetch =
-        rewriter.splitBlock(currentBlock, rewriter.getInsertionPoint());
+        currentBlock->splitBlock(rewriter.getInsertionPoint());
     Block *prefetchBlock = rewriter.createBlock(afterPrefetch);
     rewriter.setInsertionPointToEnd(currentBlock);
     LLVM::CondBrOp::create(rewriter, loc, combinedPred, prefetchBlock,

--- a/third_party/proton/Dialect/lib/ProtonGPUToLLVM/PatternProtonGPUOpToLLVM.cpp
+++ b/third_party/proton/Dialect/lib/ProtonGPUToLLVM/PatternProtonGPUOpToLLVM.cpp
@@ -114,7 +114,7 @@ struct InitializeOpConversion
     Block *prevBlock = op->getBlock();
 
     // Add the 'if' block.
-    Block *ifBlock = rewriter.splitBlock(prevBlock, op->getIterator());
+    Block *ifBlock = prevBlock->splitBlock(op->getIterator());
     rewriter.setInsertionPointToStart(ifBlock);
 
     // Write back 'preamble'.
@@ -144,7 +144,7 @@ struct InitializeOpConversion
     b.store(initTime, gmemInitTimePtr);
 
     // Add the 'else' block and the condition.
-    Block *thenBlock = rewriter.splitBlock(ifBlock, op->getIterator());
+    Block *thenBlock = ifBlock->splitBlock(op->getIterator());
     rewriter.setInsertionPointToEnd(prevBlock);
     cf::CondBranchOp::create(rewriter, loc, isFirstThread, ifBlock, thenBlock);
     rewriter.setInsertionPointToEnd(ifBlock);
@@ -258,7 +258,7 @@ private:
     //     └─ br continuation
     //   continuation
     Block *prevBlock = op->getBlock();
-    Block *continuation = rewriter.splitBlock(prevBlock, op->getIterator());
+    Block *continuation = prevBlock->splitBlock(op->getIterator());
     Block *leaderBlock = rewriter.createBlock(prevBlock->getParent(),
                                               Region::iterator(continuation));
     rewriter.setInsertionPointToEnd(prevBlock);
@@ -292,7 +292,7 @@ private:
                                 ConversionPatternRewriter &rewriter) const {
     auto loc = op.getLoc();
     auto b = TritonLLVMOpBuilder(loc, rewriter);
-    Block *afterStore = rewriter.splitBlock(continuation, op->getIterator());
+    Block *afterStore = continuation->splitBlock(op->getIterator());
     Block *storeBlock = rewriter.createBlock(op->getParentRegion(),
                                              Region::iterator(afterStore));
 
@@ -333,8 +333,8 @@ private:
     //   loopBody
     //     └─ br loopHeader (idx += threadStride)
     //   exitBlock
-    Block *copyBlock = rewriter.splitBlock(continuation, op->getIterator());
-    Block *exitBlock = rewriter.splitBlock(copyBlock, op->getIterator());
+    Block *copyBlock = continuation->splitBlock(op->getIterator());
+    Block *exitBlock = copyBlock->splitBlock(op->getIterator());
     Block *loopHeader = rewriter.createBlock(
         op->getParentRegion(), Region::iterator(exitBlock), {i32_ty}, {loc});
     Block *loopBody = rewriter.createBlock(
@@ -418,7 +418,7 @@ private:
     //     └─ ...body...
     //     └─ br continuation
     //   continuation
-    Block *continuation = rewriter.splitBlock(thenBlock, op->getIterator());
+    Block *continuation = thenBlock->splitBlock(op->getIterator());
     Block *leaderBlock = rewriter.createBlock(thenBlock->getParent(),
                                               Region::iterator(continuation));
     rewriter.setInsertionPointToEnd(thenBlock);
@@ -567,7 +567,7 @@ struct InitCtxOpConversion
     Block *prevBlock = op->getBlock();
 
     // Add the 'if' block.
-    Block *ifBlock = rewriter.splitBlock(prevBlock, op->getIterator());
+    Block *ifBlock = prevBlock->splitBlock(op->getIterator());
     rewriter.setInsertionPointToStart(ifBlock);
 
     // Initialize the `warp_index` section.
@@ -579,7 +579,7 @@ struct InitCtxOpConversion
     }
 
     // Add the 'else' block and the condition.
-    Block *thenBlock = rewriter.splitBlock(ifBlock, op->getIterator());
+    Block *thenBlock = ifBlock->splitBlock(op->getIterator());
     rewriter.setInsertionPointToEnd(prevBlock);
     cf::CondBranchOp::create(rewriter, loc, isFirstThread, ifBlock, thenBlock);
     rewriter.setInsertionPointToEnd(ifBlock);
@@ -673,7 +673,7 @@ struct SaveCtxOpConversion
     Block *prevBlock = op->getBlock();
 
     // Add the 'if' block.
-    Block *ifBlock = rewriter.splitBlock(prevBlock, op->getIterator());
+    Block *ifBlock = prevBlock->splitBlock(op->getIterator());
     rewriter.setInsertionPointToStart(ifBlock);
 
     // Update the `warp_index` section.
@@ -684,7 +684,7 @@ struct SaveCtxOpConversion
     b.store(index, gmemWarpIndexPtr);
 
     // Add the 'else' block and the condition.
-    Block *thenBlock = rewriter.splitBlock(ifBlock, op->getIterator());
+    Block *thenBlock = ifBlock->splitBlock(op->getIterator());
     rewriter.setInsertionPointToEnd(prevBlock);
     cf::CondBranchOp::create(rewriter, loc, isWarpMaster, ifBlock, thenBlock);
     rewriter.setInsertionPointToEnd(ifBlock);


### PR DESCRIPTION
`RewriterBase::splitBlock` is O(n), which can easily blow up to quadratic. This in particular hurts sanitizers because they generate a lot of `tt.assert` ops, each of which lowers via `splitBlock`. Switch to `Block::split` which is O(1). This is fine because we don't use the dialect rollback mechanism.

This is a 10-15% compile time speedup for some sanitized programs.