### PR TITLE
[BC Breaking] [Gluon] Rename descriptor reinterpret API

### DIFF
--- a/docs/programming-guide/chapter-3/fpsan.rst
+++ b/docs/programming-guide/chapter-3/fpsan.rst
@@ -456,7 +456,7 @@ Supported Gluon operations include:
 - ``tcgen05_copy`` and ``tcgen05_commit``
 - ``allocate_tensor_memory``
 - tensor-memory descriptor methods such as ``load``, ``load_min``,
-  ``load_max``, ``store``, ``slice``, ``index``, and ``_reinterpret``
+  ``load_max``, ``store``, ``slice``, ``index``, and ``reinterpret``
 - AMD ``mfma``, ``mfma_scaled``, ``wmma``, ``wmma_scaled``, and
   ``scaled_upcast``
 

--- a/python/examples/gluon/01-attention-forward.py
+++ b/python/examples/gluon/01-attention-forward.py
@@ -383,7 +383,7 @@ class AttentionProgram:
 @gluon.jit
 def _borrow_s_as_p(config, s_tmem):
     cols: gl.constexpr = s_tmem.dtype.primitive_bitwidth // config.dtype.primitive_bitwidth
-    p_tmem = s_tmem._reinterpret(config.dtype, [config.SPLIT_M, cols * config.BLOCK_N], config.p_tmem_layout)
+    p_tmem = s_tmem.reinterpret(config.dtype, [config.SPLIT_M, cols * config.BLOCK_N], config.p_tmem_layout)
     return p_tmem.slice(0, config.BLOCK_N)
 
 
@@ -391,7 +391,7 @@ def _borrow_s_as_p(config, s_tmem):
 def _borrow_s_as_alpha(config, s_tmem):
     alpha_layout: gl.constexpr = TensorMemoryLayout([config.SPLIT_M_PER_CTA, 1], col_stride=1,
                                                     cga_layout=config.CGA_LAYOUT, two_ctas=gl.num_ctas() > 1)
-    alpha_tmem = s_tmem._reinterpret(layout=alpha_layout)
+    alpha_tmem = s_tmem.reinterpret(layout=alpha_layout)
     return alpha_tmem.slice(config.BLOCK_N // 2, 1)
 
 
@@ -399,7 +399,7 @@ def _borrow_s_as_alpha(config, s_tmem):
 def _borrow_s_for_epilogue(config, s_tmem):
     layout: gl.constexpr = TensorMemoryLayout([config.SPLIT_M_PER_CTA, 1], col_stride=1, cga_layout=config.CGA_LAYOUT,
                                               two_ctas=gl.num_ctas() > 1)
-    s_tmem = s_tmem._reinterpret(layout=layout)
+    s_tmem = s_tmem.reinterpret(layout=layout)
     m_i_tmem = s_tmem.slice(config.BLOCK_N // 2 + 1, 1)
     l_i_tmem = s_tmem.slice(config.BLOCK_N // 2 + 2, 1)
     return m_i_tmem, l_i_tmem
@@ -886,7 +886,7 @@ def attention_kernel(  #
 
     q_chnl = get_desc_channel(desc_q, num_buffers=2)
     kv_chnl = get_desc_channel(desc_k, num_buffers=config.num_kv_buffers)
-    v_mem = kv_chnl.mem._reinterpret(layout=desc_v.layout)
+    v_mem = kv_chnl.mem.reinterpret(layout=desc_v.layout)
     o_chnl = TensorMemoryChannel.alloc(config.o_shape, gl.float32, config.o_tmem_layout, num_buffers=2,
                                        producer_two_ctas=gl.num_ctas() > 1)
     epi_chnl = SharedMemoryChannel.alloc(config.o_shape, config.dtype, gl.constexpr(desc_o.layout), num_buffers=2)

--- a/python/examples/gluon/06-overlapping-accumulator.py
+++ b/python/examples/gluon/06-overlapping-accumulator.py
@@ -273,10 +273,10 @@ def async_mma_scaled_impl(a_smem, b_smem, a_scale_smem, b_scale_smem, acc_tmem, 
     a_scale_layout: gl.constexpr = TensorMemoryScalesLayout(cga_layout=[[1, 0]] if two_ctas else [])
     b_scale_layout: gl.constexpr = TensorMemoryScalesLayout(cga_layout=[[0, 0]] if two_ctas else [])
     a_scale_tmem = tmem_pool.slice(tmem_plan.a_scale_offset,
-                                   tmem_plan.a_scale_cols)._reinterpret(dtype=a_scale.dtype, shape=a_scale.shape,
+                                   tmem_plan.a_scale_cols).reinterpret(dtype=a_scale.dtype, shape=a_scale.shape,
                                                                           layout=a_scale_layout)
     b_scale_tmem = tmem_pool.slice(tmem_plan.b_scale_offset,
-                                   tmem_plan.b_scale_cols)._reinterpret(dtype=b_scale.dtype, shape=b_scale.shape,
+                                   tmem_plan.b_scale_cols).reinterpret(dtype=b_scale.dtype, shape=b_scale.shape,
                                                                           layout=b_scale_layout)
 
     tcgen05_copy(a_scale, a_scale_tmem)

--- a/python/test/gluon/test_core.py
+++ b/python/test/gluon/test_core.py
@@ -1935,7 +1935,7 @@ def test_tmem_copy_2d():
         smem = ttgl.allocate_shared_memory(ttgl.int8, (smem_h, smem_w), layout=smem_layout)
         tmem_pool_layout: ttgl.constexpr = TensorMemoryLayout((num_rows, 256), col_stride=1)
         tmem_pool = allocate_tensor_memory(ttgl.float32, (num_rows, 512), layout=tmem_pool_layout)
-        tmem = tmem_pool.slice(480, num_cols)._reinterpret(ttgl.int8, (smem_h, smem_w), tmem_layout)
+        tmem = tmem_pool.slice(480, num_cols).reinterpret(ttgl.int8, (smem_h, smem_w), tmem_layout)
 
         barrier = ttgl.allocate_shared_memory(ttgl.int64, [1], ttgl.constexpr(mbarrier.MBarrierLayout()))
         mbarrier.init(barrier, count=1)
@@ -1945,7 +1945,7 @@ def test_tmem_copy_2d():
         tcgen05_commit(barrier)
         mbarrier.wait(barrier, phase=0)
         tmem_alias: ttgl.constexpr = TensorMemoryLayout((num_rows, num_cols), col_stride=1)
-        tmem = tmem._reinterpret(shape=(num_rows, num_cols), layout=tmem_alias)
+        tmem = tmem.reinterpret(shape=(num_rows, num_cols), layout=tmem_alias)
         value = tmem.load(blocked)
         ttgl.store(ttgl.set_auto_layout(out_ptrs, blocked), value)
 
@@ -1980,7 +1980,7 @@ def test_tmem_pipeline_stage_subslice_index_reinterpret():
         for stage in ttgl.static_range(5):
             parent.index(stage).store(ttgl.load(inp + stage * 8192 + rows * 64 + cols))
         stages = parent.slice(2, 2, dim=0)
-        first = stages._reinterpret().index(0)
+        first = stages.reinterpret().index(0)
         first.store(first.load() + 11.0)
         second = stages.slice(1, 1, dim=0).index(0)
         second.store(second.load() + 7.0)
@@ -2050,7 +2050,7 @@ def test_tmem_source_layout_contiguous_subslice():
 
         view = parent.slice(208, 256)
         view_layout: ttgl.constexpr = TensorMemoryLayout([128, 256], col_stride=1)
-        view = view._reinterpret(ttgl.float32, [128, 256], view_layout)
+        view = view.reinterpret(ttgl.float32, [128, 256], view_layout)
         view.store(view.load() + 7.0)
         ttgl.store(out + rows * 512 + cols, parent.load(parent_layout))
 
@@ -2169,13 +2169,13 @@ def test_tmem_subslice_block_m_64():
         s_tmem.store(s)
         o_tmem.store(s)
 
-        p_tmem_parent = s_tmem._reinterpret(ttgl.float16, [BLOCK_M, 2 * N], tmem_layout)
+        p_tmem_parent = s_tmem.reinterpret(ttgl.float16, [BLOCK_M, 2 * N], tmem_layout)
         p_tmem = p_tmem_parent.slice(0, N)
         p_tmem.store(ttgl.full((BLOCK_M, N), 0.0, dtype=ttgl.float16, layout=layout))
 
         d1_tmem_layout: ttgl.constexpr = TensorMemoryLayout((BLOCK_M, 2), col_stride=1)
 
-        d1_tmem_parent = s_tmem._reinterpret(layout=d1_tmem_layout)
+        d1_tmem_parent = s_tmem.reinterpret(layout=d1_tmem_layout)
         m_tmem = d1_tmem_parent.slice(N // 2, 2)
         d1_layout: ttgl.constexpr = m_tmem.get_reg_layout()
         m_tmem.store(ttgl.full((BLOCK_M, 2), 2.0, dtype=ttgl.float32, layout=d1_layout))
@@ -2358,7 +2358,7 @@ def test_slice_reinterpret():
         smem_layout_2d: ttgl.constexpr = ttgl.SwizzledSharedLayout(vec=1, per_phase=1, max_phase=1, order=[1, 0])
         smem = ttgl.allocate_shared_memory(ttgl.int8, [BLOCK], smem_layout_1d)
         smem_slice0 = smem.slice(0, SPLIT_BLOCK)
-        smem_i32 = smem._reinterpret(ttgl.int32, [2 * XBLOCK, YBLOCK], smem_layout_2d)
+        smem_i32 = smem.reinterpret(ttgl.int32, [2 * XBLOCK, YBLOCK], smem_layout_2d)
         smem_slice1 = smem_i32.slice(XBLOCK, XBLOCK, dim=0)
 
         offs = ttgl.arange(0, XBLOCK)[:, None] * YBLOCK + ttgl.arange(0, YBLOCK)[None, :]
@@ -3149,7 +3149,7 @@ def test_tcgen05_mma_scaled_lhs_tmem(a_format, a_torch_dtype, b_format, b_torch_
         mbarrier.init(bar, count=1)
         if A_FP4_PADDED:
             padded_layout: ttgl.constexpr = TensorMemoryLayout([M, A_K_INPUT], col_stride=1, fp4_padded=True)
-            a_tmem = a_tmem._reinterpret(a.dtype.element_ty, [M, A_K_INPUT], padded_layout)
+            a_tmem = a_tmem.reinterpret(a.dtype.element_ty, [M, A_K_INPUT], padded_layout)
         if B_IS_FP4:
             b_smem = b_smem.permute((1, 0))
         tcgen05_mma_scaled(a_tmem, b_smem, acc_tmem, a_scale_tmem, b_scale_tmem, A_FORMAT, B_FORMAT, use_acc=False,
@@ -3533,7 +3533,7 @@ def shared_gather_cga_kernel(
     # Seed each physical CTA with distinct layout-derived values, then view the
     # same allocation through the CGA layout under test.
     seed = ttgl.allocate_shared_memory(ttgl.int32, [block], seed_layout, value=offsets)
-    smem = seed._reinterpret(shape=[CTA_TILE << NUM_SHARD_BITS], layout=shared_layout)
+    smem = seed.reinterpret(shape=[CTA_TILE << NUM_SHARD_BITS], layout=shared_layout)
     ttgl.barrier(cluster=True)
 
     cta = offsets // CTA_TILE

--- a/python/test/gluon/test_fpsan.py
+++ b/python/test/gluon/test_fpsan.py
@@ -3092,7 +3092,7 @@ def test_tmem_copy_scales_in_warp_specialize_partition(device, scale_shape, two_
         bar = mbarrier.allocate_mbarrier()
         mbarrier.init(bar, count=1)
         physical_layout: gl.constexpr = TensorMemoryLayout((TMEM_ROWS, TMEM_COLS), col_stride=1, cga_layout=cga_layout)
-        physical = tmem._reinterpret(shape=(TMEM_ROWS, TMEM_COLS), layout=physical_layout)
+        physical = tmem.reinterpret(shape=(TMEM_ROWS, TMEM_COLS), layout=physical_layout)
 
         gl.warp_specialize(
             [

--- a/python/test/gluon/test_frontend.py
+++ b/python/test/gluon/test_frontend.py
@@ -478,7 +478,7 @@ def shared_memory_cast_kernel():
     smem = ttgl.allocate_shared_memory(ttgl.float16, [32, 1, 4, 64], layout_b)
     smem.reshape((128, 64))
 
-    smem._reinterpret(ttgl.int8, [16384], ttgl.SwizzledSharedLayout(1, 1, 1, [0]))
+    smem.reinterpret(ttgl.int8, [16384], ttgl.SwizzledSharedLayout(1, 1, 1, [0]))
 
 
 @pytest.mark.parametrize("target", ALL_TARGETS)
@@ -926,7 +926,7 @@ def test_reinterpret_parent_then_multibuffer_subslice():
     b_layout: ttgl.constexpr = ttgl.NVMMASharedLayout(32, 16, rank=2)
     arena = ttgl.allocate_shared_memory(ttgl.float16, [7, 8, 32], a_layout)
     # CHECK: [[B_PARENT:%.*]] = ttg.memdesc_reinterpret {{.*}} -> !ttg.memdesc<14x8x16xf16
-    b_parent = arena._reinterpret(ttgl.float16, [14, 8, 16], b_layout)
+    b_parent = arena.reinterpret(ttgl.float16, [14, 8, 16], b_layout)
     # CHECK: [[A_SUB:%.*]] = ttg.memdesc_subslice {{.*}}[0, 0, 0]
     a_stages = arena.slice(0, 3, dim=0)
     # CHECK: [[B_SUB:%.*]] = ttg.memdesc_subslice [[B_PARENT]][6, 0, 0] {{.*}} -> !ttg.memdesc<4x8x16xf16

--- a/python/triton/experimental/gluon/language/_core.py
+++ b/python/triton/experimental/gluon/language/_core.py
@@ -505,8 +505,8 @@ class shared_memory_descriptor(base_value):
         return _semantic.memdesc_reshape(self, shape)
 
     @builtin
-    def _reinterpret(self, dtype=None, shape=None, layout=None,
-                     _semantic: GluonSemantic = None) -> shared_memory_descriptor:
+    def reinterpret(self, dtype=None, shape=None, layout=None,
+                    _semantic: GluonSemantic = None) -> shared_memory_descriptor:
         """
         Reinterpret the shared memory descriptor as a different dtype, shape, or layout.
 

--- a/python/triton/experimental/gluon/language/nvidia/blackwell/__init__.py
+++ b/python/triton/experimental/gluon/language/nvidia/blackwell/__init__.py
@@ -497,8 +497,8 @@ class tensor_memory_descriptor(base_value):
         return ret
 
     @builtin
-    def _reinterpret(self, dtype=None, shape=None, layout=None,
-                     _semantic: GluonSemantic = None) -> tensor_memory_descriptor:
+    def reinterpret(self, dtype=None, shape=None, layout=None,
+                    _semantic: GluonSemantic = None) -> tensor_memory_descriptor:
         """
         Reinterpret tensor memory descriptor with a new dtype, shape, and layout.
 

--- a/python/tutorials/gluon/07-persistence.py
+++ b/python/tutorials/gluon/07-persistence.py
@@ -710,11 +710,11 @@ def persistent_matmul_pipelined_kernel(a_desc, b_desc, c_desc, c_half_desc, MMAI
         else:
             # Steal the next 2 B buffers for the epilogue.
             c0, c1 = c.reshape((BLOCK_M, 2, BLOCK_N // 2)).permute(0, 2, 1).split()
-            c0_buf = b_bufs.index(producer % (num_buffers + STEALB))._reinterpret(shape=c_half_desc.block_type.shape,
-                                                                                  layout=c_half_desc.layout)
+            c0_buf = b_bufs.index(producer % (num_buffers + STEALB)).reinterpret(shape=c_half_desc.block_type.shape,
+                                                                                 layout=c_half_desc.layout)
             c1_buf = b_bufs.index(
-                (producer + 1) % (num_buffers + STEALB))._reinterpret(shape=c_half_desc.block_type.shape,
-                                                                      layout=c_half_desc.layout)
+                (producer + 1) % (num_buffers + STEALB)).reinterpret(shape=c_half_desc.block_type.shape,
+                                                                     layout=c_half_desc.layout)
             c0_buf.store(c0)
             c1_buf.store(c1)
             fence_async_shared()


### PR DESCRIPTION
PR description written by Codex

Expose the Gluon descriptor reinterpret operation as `reinterpret` instead of the private-looking `_reinterpret` name. This is an intentional breaking API rename for shared-memory and tensor-memory descriptors, with all in-tree tests, examples, tutorial code, and FPSan documentation updated.

Validated with the affected Gluon frontend tests (5 passed), GPU tests (19 passed), and pre-commit.

## Stack
Merge bottom-up:
- [ ] #11131 (this PR)
