### PR TITLE
[NVIDIA] Fix multicast TMA shared-memory subviews

### DIFF
--- a/lib/Dialect/TritonNvidiaGPU/IR/Ops.cpp
+++ b/lib/Dialect/TritonNvidiaGPU/IR/Ops.cpp
@@ -675,10 +675,12 @@ static LogicalResult verifyTMABarrierLayout(Operation *op, Value barrier) {
 }
 
 static LogicalResult verifyTMAEncoding(Operation *op, TensorDescInterface desc,
-                                       Attribute enc) {
-  auto nvmma = dyn_cast<NVMMASharedEncodingAttr>(enc);
+                                       MemDescType memDesc) {
+  auto nvmma = dyn_cast<NVMMASharedEncodingAttr>(memDesc.getEncoding());
   if (!nvmma)
     return op->emitOpError("TMA descriptor must have NVMMA shared layout");
+  if (nvmma.getRank() != memDesc.getRank())
+    return op->emitOpError("TMA shared memory and layout ranks must match");
   auto descEnc =
       dyn_cast_if_present<NVMMASharedEncodingAttr>(desc.getSharedLayout());
   // NOTE: Cannot do descEnc != enc as the encodings may differ in rank for
@@ -706,7 +708,7 @@ static LogicalResult verifyAsyncTMALoadOp(Operation *op,
     return failure();
   if (!resultType.getMutableMemory())
     return op->emitOpError("cannot store into immutable memory");
-  if (failed(verifyTMAEncoding(op, desc, resultType.getEncoding())))
+  if (failed(verifyTMAEncoding(op, desc, resultType)))
     return failure();
   auto block = StringAttr::get(op->getContext(), "block");
   uint32_t barrierMask =
@@ -739,7 +741,7 @@ static LogicalResult verifyAsyncTMAStoreOp(Operation *op,
       if (component >= size)
         return op->emitOpError(
             "source subview may have an origin in another CTA");
-  return verifyTMAEncoding(op, desc.getType(), srcEnc);
+  return verifyTMAEncoding(op, desc.getType(), srcType);
 }
 
 static LogicalResult verifyAsyncTMAGatherScatterOp(Operation *op,

--- a/python/test/gluon/test_core.py
+++ b/python/test/gluon/test_core.py
@@ -230,12 +230,12 @@ def test_tma():
 
 
 @gluon.jit
-def tma_im2col_kernel(in_desc, out_desc):
+def tma_im2col_kernel(in_desc, out_desc, MULTICAST: ttgl.constexpr):
     smem = ttgl.allocate_shared_memory(in_desc.dtype, in_desc.block_shape, in_desc.layout)
     bar = mbarrier.allocate_mbarrier()
     mbarrier.init(bar, count=1)
     mbarrier.expect(bar, in_desc.block_type.nbytes)
-    tma.async_load_im2col(in_desc, [0, 0, 0, 0], [0, 0], bar, smem)
+    tma.async_load_im2col(in_desc, [0, 0, 0, 0], [0, 0], bar, smem, multicast=MULTICAST)
     mbarrier.wait(bar, phase=0)
     mbarrier.invalidate(bar)
     tma.async_store(out_desc, [0, 0], smem)
@@ -246,7 +246,8 @@ def tma_im2col_kernel(in_desc, out_desc):
 @pytest.mark.parametrize("pixels_per_column", [32, 256, 512, 1024])
 @pytest.mark.parametrize("channels_per_pixel", [32])
 @pytest.mark.parametrize("swizzle_byte_width", [32])
-def test_tma_im2col(pixels_per_column, channels_per_pixel, swizzle_byte_width):
+@pytest.mark.parametrize("multicast", [False, True], ids=["unicast", "multicast"])
+def test_tma_im2col(pixels_per_column, channels_per_pixel, swizzle_byte_width, multicast):
     smem_bytes = pixels_per_column * channels_per_pixel * 4 + 8192  # block + mbarrier overhead
     if smem_bytes > 200000:
         pytest.skip(f"Skipping: shared memory {smem_bytes} exceeds limit")
@@ -262,6 +263,7 @@ def test_tma_im2col(pixels_per_column, channels_per_pixel, swizzle_byte_width):
         rank=2,
         transposed=False,
         fp4_padded=False,
+        cga_layout=((0, 0), ) if multicast else (),
     )
 
     in_desc = gluon.nvidia.hopper.TensorDescriptorIm2Col(
@@ -276,7 +278,8 @@ def test_tma_im2col(pixels_per_column, channels_per_pixel, swizzle_byte_width):
         pixel_box_upper_corner=[0, 0],
     )
     out_desc = gluon.nvidia.hopper.TensorDescriptor.from_tensor(out, block_shape, layout)
-    tma_im2col_kernel[(1, )](in_desc, out_desc, num_warps=1)
+    compiled = tma_im2col_kernel[(1, )](in_desc, out_desc, multicast, num_warps=1, num_ctas=2 if multicast else 1)
+    assert (".im2col.mbarrier::complete_tx::bytes.multicast::cluster" in compiled.asm["ptx"]) == multicast
     torch.testing.assert_close(out, inp.reshape(pixels_per_column, channels_per_pixel), atol=0, rtol=0)
 
 
@@ -461,27 +464,36 @@ def test_tma_gather_scatter_multi_cta(cga_layout):
 
 @gluon.jit
 def tma_gather_scatter_subslice_kernel(in_desc, out_desc, parent_out, KIND: ttgl.constexpr):
-    cga_layout: ttgl.constexpr = () if KIND == "row" else ((1, 0), )
+    if KIND == "row":
+        cga_layout: ttgl.constexpr = ()
+    elif KIND == "column_sharded":
+        cga_layout: ttgl.constexpr = ((0, 1), )
+    elif KIND == "mixed_remote":
+        cga_layout: ttgl.constexpr = ((1, 0), (0, 1))
+    elif KIND == "remote_multicast":
+        cga_layout: ttgl.constexpr = ((1, 0), (0, 0))
+    else:
+        cga_layout: ttgl.constexpr = ((1, 0), )
     shared_layout: ttgl.constexpr = ttgl.NVMMASharedLayout(128, 16, rank=2, cga_layout=cga_layout)
     parent_layout: ttgl.constexpr = ttgl.BlockedLayout([1, 1], [4, 8], [4, 1], [1, 0], cga_layout=cga_layout)
     indices_layout: ttgl.constexpr = ttgl.SliceLayout(
         1, ttgl.BlockedLayout([4, 1], [1, 32], [4, 1], [0, 1], cga_layout=cga_layout))
-    shape: ttgl.constexpr = (64, 256) if KIND == "column" else (128, 128)
+    shape: ttgl.constexpr = (64, 256) if KIND == "column" or KIND == "column_sharded" else (128, 128)
     parent = ttgl.allocate_shared_memory(ttgl.float16, shape, shared_layout,
                                          value=ttgl.full(shape, -7, ttgl.float16, layout=parent_layout))
-    dim: ttgl.constexpr = 1 if KIND == "column" else 0
+    dim: ttgl.constexpr = 1 if KIND == "column" or KIND == "column_sharded" else 0
     tile = parent.slice(shape[dim] // 2, shape[dim] // 2, dim=dim)
 
     indices = ttgl.arange(0, 64, layout=indices_layout)
     barrier = mbarrier.allocate_mbarrier()
     mbarrier.init(barrier, count=1)
     mbarrier.expect(barrier, tile.nbytes_per_cta)
-    blackwell_tma.async_gather(in_desc, 63 - indices, 0, barrier, tile)
+    blackwell_tma.async_gather(in_desc, 63 - indices, 0, barrier, tile, multicast=KIND == "remote_multicast")
     mbarrier.wait(barrier, phase=0, deps=[tile])
     if KIND != "row":
         ttgl.barrier(cluster=True)
 
-    if KIND != "remote":
+    if KIND == "row" or KIND == "column":
         blackwell_tma.async_scatter(out_desc, (indices + 1) % 64, 0, tile)
         tma.store_wait(0)
 
@@ -491,12 +503,20 @@ def tma_gather_scatter_subslice_kernel(in_desc, out_desc, parent_out, KIND: ttgl
 
 
 @pytest.mark.skipif(not is_blackwell(), reason="Requires Blackwell")
-@pytest.mark.parametrize("kind", ["row", "column", "remote"])
+@pytest.mark.parametrize("kind", ["row", "column", "remote", "column_sharded", "mixed_remote", "remote_multicast"])
 def test_tma_gather_scatter_subslice(kind):
     values = torch.arange(64 * 128, dtype=torch.float16, device="cuda").reshape(64, 128)
     scatter_out = torch.zeros_like(values)
-    parent_out = torch.empty((64, 256) if kind == "column" else (128, 128), dtype=torch.float16, device="cuda")
-    cga_layout = () if kind == "row" else ((1, 0), )
+    parent_out = torch.empty((64, 256) if kind in ("column", "column_sharded") else (128, 128), dtype=torch.float16,
+                             device="cuda")
+    cga_layout = {
+        "row": (),
+        "column": ((1, 0), ),
+        "remote": ((1, 0), ),
+        "column_sharded": ((0, 1), ),
+        "mixed_remote": ((1, 0), (0, 1)),
+        "remote_multicast": ((1, 0), (0, 0)),
+    }[kind]
     shared_layout = ttgl.NVMMASharedLayout(128, 16, rank=2, cga_layout=cga_layout)
     in_desc = TensorDescriptor.from_tensor(values, [1, 128], shared_layout)
     out_desc = TensorDescriptor.from_tensor(scatter_out, [1, 128], shared_layout)
@@ -506,11 +526,11 @@ def test_tma_gather_scatter_subslice(kind):
 
     gathered = values.flip(0)
     expected_parent = torch.full_like(parent_out, -7)
-    if kind == "column":
+    if kind in ("column", "column_sharded"):
         expected_parent[:, 128:] = gathered
     else:
         expected_parent[64:] = gathered
-    if kind == "remote":
+    if kind in ("remote", "column_sharded", "mixed_remote", "remote_multicast"):
         assert "mapa.shared::cluster" in compiled.asm["ptx"]
         assert "tile::gather4.cta_group::2.shared::cluster" in compiled.asm["ptx"]
     else:
@@ -3683,11 +3703,11 @@ def cross_cta_tma_kernel(desc, out, cga_layout: ttgl.constexpr, MODE: ttgl.const
     parent = ttgl.allocate_shared_memory(ttgl.int32, [256, 64], shared_layout,
                                          value=ttgl.full([256, 64], -5, ttgl.int32, layout=alloc_layout))
     tile = parent.slice(128, 128, dim=0)
-    if MODE == "load":
+    if MODE == "load" or MODE == "multicast":
         bar = mbarrier.allocate_mbarrier()
         mbarrier.init(bar, count=1)
         mbarrier.expect(bar, desc.nbytes_per_cta)
-        tma.async_load(desc, [0, 0], bar, tile)
+        tma.async_load(desc, [0, 0], bar, tile, multicast=MODE == "multicast")
         mbarrier.wait(bar, phase=0)
         ttgl.barrier(cluster=True)
         result = parent.load(alloc_layout)
@@ -3704,19 +3724,20 @@ def cross_cta_tma_kernel(desc, out, cga_layout: ttgl.constexpr, MODE: ttgl.const
 @pytest.mark.parametrize("mode,cga_layout", [
     ("load", ((1, 0), )),
     ("load", ((1, 0), (0, 0))),
+    ("multicast", ((1, 0), (0, 0))),
     ("load", ((0, 0), (1, 0))),
     ("store", ((1, 0), )),
     ("reduce", ((1, 0), )),
-], ids=["two-ctas", "four-ctas", "nonpeer", "store", "reduce"])
+], ids=["two-ctas", "four-ctas", "multicast", "nonpeer", "store", "reduce"])
 def test_cross_cta_tma(mode, cga_layout, capfd):
-    if mode == "load" and not is_blackwell():
+    if mode in ("load", "multicast") and not is_blackwell():
         pytest.skip("Requires Blackwell CTA-pair completion")
     inp = torch.arange(128 * 64, device="cuda", dtype=torch.int32).reshape(128, 64)
     out = torch.full((256, 64), -1, device="cuda", dtype=torch.int32)
     layout = ttgl.NVMMASharedLayout(128, 32, rank=2, cga_layout=cga_layout)
     desc = TensorDescriptor.from_tensor(inp, [128, 64], layout)
 
-    if mode != "load":
+    if mode not in ("load", "multicast"):
         with pytest.raises(RuntimeError, match="error encountered during parsing"):
             cross_cta_tma_kernel.warmup(desc, out, cga_layout, MODE=mode, grid=(1, ), num_warps=4, num_ctas=2)
         assert "source subview may have an origin in another CTA" in "".join(capfd.readouterr())

--- a/python/test/gluon/test_frontend.py
+++ b/python/test/gluon/test_frontend.py
@@ -4492,6 +4492,14 @@ def test_mismatch_shape_and_layout_rank():
     assert "tensor shape and layout rank mismatch" in str(e.value.__cause__)
 
 
+def test_tma_descriptor_layout_rank():
+    tensor = MockTensor(ttgl.int32, (2, 32, 64))
+    layout = ttgl.NVMMASharedLayout(128, 32, rank=2)
+
+    with pytest.raises(AssertionError, match="layout rank must match block shape rank"):
+        TensorDescriptor.from_tensor(tensor, [2, 32, 64], layout)
+
+
 def test_non_scalar_loop_bounds():
 
     @gluon.jit

--- a/python/triton/experimental/gluon/nvidia/hopper.py
+++ b/python/triton/experimental/gluon/nvidia/hopper.py
@@ -21,6 +21,7 @@ def _validate_common_descriptor(tensor, shape, strides, layout, padding, round_f
         assert shape_dim > 0, "shape must be positive"
     assert strides[-1] == 1, "Last dimension must be contiguous"
     assert isinstance(layout, NVMMASharedLayout), "Layout must be NVMMASharedLayout"
+    assert layout.rank == len(block_shape), "layout rank must match block shape rank"
     assert padding == "zero" or padding == "nan", "Illegal value for padding"
     if padding == "nan":
         assert tensor.dtype.is_floating_point, "Padding option `nan` is only supported for floating point tensors"

--- a/test/Conversion/tritongpu_to_llvm_blackwell.mlir
+++ b/test/Conversion/tritongpu_to_llvm_blackwell.mlir
@@ -1506,4 +1506,30 @@ module attributes {"ttg.num-ctas" = 4 : i32, "ttg.num-warps" = 4 : i32} {
     ttng.async_tma_copy_global_to_local %desc[%x, %x] %view, %bar, %pred : !tt.tensordesc<128x64xi32, #shared>, !ttg.memdesc<4xi64, #barrier, #smem> -> !ttg.memdesc<128x64xi32, #shared, #smem, mutable, 256x64>
     tt.return
   }
+
+  // CHECK-LABEL: @tma_multicast_remote_cta
+  // CHECK: %[[DST:[^ ]+]] = nvvm.mapa %{{.*}}, %[[CTA:[^ ]+]] :
+  // CHECK: %[[SHIFT:[^ ]+]] = llvm.and %[[CTA]], %{{.*}} : i32
+  // CHECK: %[[MASK:[^ ]+]] = llvm.shl %{{.*}}, %[[SHIFT]] : i32
+  // CHECK: cp.async.bulk.tensor.2d.cta_group::2.shared::cluster.global.mbarrier::complete_tx::bytes.multicast::cluster
+  // CHECK-SAME: %[[DST]], {{.*}}, %[[MASK]]
+  tt.func @tma_multicast_remote_cta(%desc: !tt.tensordesc<128x64xi32, #shared>, %parent: !ttg.memdesc<256x64xi32, #shared, #smem, mutable>, %bar: !ttg.memdesc<4xi64, #barrier, #smem>, %x: i32, %pred: i1) {
+    %view = ttg.memdesc_subslice %parent [128, 0] : !ttg.memdesc<256x64xi32, #shared, #smem, mutable> -> !ttg.memdesc<128x64xi32, #shared, #smem, mutable, 256x64>
+    ttng.async_tma_copy_global_to_local %desc[%x, %x] %view, %bar, %pred {multicast} : !tt.tensordesc<128x64xi32, #shared>, !ttg.memdesc<4xi64, #barrier, #smem> -> !ttg.memdesc<128x64xi32, #shared, #smem, mutable, 256x64>
+    tt.return
+  }
+}
+
+// -----
+
+#barrier = #ttg.swizzled_shared<{vec = 1, perPhase = 1, maxPhase = 1, order = [0], CGALayout = [[1]]}>
+#shared = #ttg.nvmma_shared<{swizzlingByteWidth = 128, transposed = false, elementBitWidth = 32, CGALayout = [[0, 0]]}>
+#smem = #ttg.shared_memory
+module attributes {"ttg.num-ctas" = 2 : i32, "ttg.num-warps" = 4 : i32} {
+  // CHECK-LABEL: @tma_im2col_multicast
+  // CHECK: cp.async.bulk.tensor.4d.shared::cluster.global.im2col.mbarrier::complete_tx::bytes.multicast::cluster [$1], [$2, {$3, $4, $5, $6}], [$7], {$8, $9}, $10;
+  tt.func @tma_im2col_multicast(%desc: !ttng.tensordesc_im2col<128x64xi32, #shared>, %dst: !ttg.memdesc<128x64xi32, #shared, #smem, mutable>, %bar: !ttg.memdesc<2xi64, #barrier, #smem>, %x: i32, %offset: i16, %pred: i1) {
+    ttng.async_tma_copy_global_to_local %desc[%x, %x, %x, %x] offsets = [%offset, %offset] %dst, %bar, %pred {multicast} : !ttng.tensordesc_im2col<128x64xi32, #shared>, !ttg.memdesc<2xi64, #barrier, #smem> -> !ttg.memdesc<128x64xi32, #shared, #smem, mutable>
+    tt.return
+  }
 }

--- a/test/TritonNvidiaGPU/invalid.mlir
+++ b/test/TritonNvidiaGPU/invalid.mlir
@@ -985,6 +985,24 @@ module attributes {"ttg.num-ctas" = 2 : i32, "ttg.num-warps" = 4 : i32, ttg.targ
 
 // -----
 
+#nvmma = #ttg.nvmma_shared<{swizzlingByteWidth = 128, transposed = false, elementBitWidth = 32}>
+#barrier = #ttg.swizzled_shared<{vec = 1, perPhase = 1, maxPhase = 1, order = [0]}>
+#smem = #ttg.shared_memory
+module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32} {
+  tt.func @tma_layout_rank_mismatch(
+      %desc: !tt.tensordesc<2x32x64xi32, #nvmma>,
+      %dst: !ttg.memdesc<2x32x64xi32, #nvmma, #smem, mutable>,
+      %barrier: !ttg.memdesc<1xi64, #barrier, #smem, mutable>) {
+    %zero = arith.constant 0 : i32
+    %true = arith.constant true
+    // expected-error @below {{TMA shared memory and layout ranks must match}}
+    ttng.async_tma_copy_global_to_local %desc[%zero, %zero, %zero] %dst, %barrier, %true : !tt.tensordesc<2x32x64xi32, #nvmma>, !ttg.memdesc<1xi64, #barrier, #smem, mutable> -> !ttg.memdesc<2x32x64xi32, #nvmma, #smem, mutable>
+    tt.return
+  }
+}
+
+// -----
+
 // Test invalid TensorDescIm2ColType: rank-3 blockType (must be rank-2)
 module attributes {"ttg.num-warps" = 4 : i32, "ttg.num-ctas" = 1 : i32} {
   // expected-error @below {{TensorDescIm2ColType requires rank-2 shape, got rank 3}}

--- a/third_party/nvidia/lib/TritonNVIDIAGPUToLLVM/LoadStoreOpToLLVM.cpp
+++ b/third_party/nvidia/lib/TritonNVIDIAGPUToLLVM/LoadStoreOpToLLVM.cpp
@@ -1138,13 +1138,10 @@ struct AsyncTMACopyGlobalToLocalOpConversion
     auto ctaId = nvgpu::ClusterCTAIdOp::create(rewriter, loc);
     // We multicast if the flag is on and the block layout has broadcasting
     bool multicast = op.getMulticast();
-    Value multicastMask;
+    uint32_t maskCGABroadcast =
+        smemLayout.getFreeVariableMasks().lookup(kBlock);
     Value barrierPtr = barrierMemObj.getBase();
     if (multicast) {
-      uint32_t maskCGABroadcast =
-          smemLayout.getFreeVariableMasks().lookup(kBlock);
-      multicastMask =
-          LLVM::NVIDIA::createTMAMulticastMask(loc, rewriter, maskCGABroadcast);
       // If we multicast, we emit the full message from the representative CTA
       // meaning the CTA with the lowest CTA id in a multicast group.
       auto ctaIdInGroup = b.and_(ctaId, b.i32_val(maskCGABroadcast));
@@ -1230,10 +1227,6 @@ struct AsyncTMACopyGlobalToLocalOpConversion
       }
       operands.push_back(ptxBuilderTMA.newOperand(barrierPtr, "r"));
       tmaInst += "}], [$" + std::to_string(operandIdx++) + "]";
-      if (multicast) {
-        operands.push_back(ptxBuilderTMA.newOperand(multicastMask, "h"));
-        tmaInst += ", $" + std::to_string(operandIdx++);
-      }
       if (isIm2Col) {
         auto im2colOffsets = adaptor.getOffsets();
         if (!im2colOffsets.empty()) {
@@ -1248,6 +1241,12 @@ struct AsyncTMACopyGlobalToLocalOpConversion
           }
           tmaInst += "}";
         }
+      }
+      if (multicast) {
+        auto multicastMask = LLVM::NVIDIA::createTMAMulticastMask(
+            loc, rewriter, maskCGABroadcast, targetCTA);
+        operands.push_back(ptxBuilderTMA.newOperand(multicastMask, "h"));
+        tmaInst += ", $" + std::to_string(operandIdx++);
       }
       tmaInst += ";";
 
@@ -1426,7 +1425,7 @@ static LogicalResult iterateGatherScatterIndices(
     mlir::TypedValue<RankedTensorType> xCoords,
     mlir::TypedValue<ttg::MemDescType> smem, Value smemObjValue,
     Value xOffsetsValue, Value yOffsetValue, Value pred,
-    function_ref<void(Value, Value, Value, ArrayRef<Value>)> callback) {
+    function_ref<void(Value, Value, Value, Value, ArrayRef<Value>)> callback) {
   MLIRContext *ctx = op->getContext();
   Location loc = op->getLoc();
   auto b = TritonLLVMOpBuilder(loc, rewriter);
@@ -1484,9 +1483,17 @@ static LogicalResult iterateGatherScatterIndices(
   unsigned msgSize = innerBlockSize / numMessagesPerRow;
   LinearLayout msgToCol =
       LinearLayout::strided1D(numMessagesPerRow, msgSize, kMsg, kDim1);
-  LinearLayout msgLayout = xCoordsLayout * msgToCol;
   LinearLayout msgToOffset =
       getMsgToPackedOffsetLayout(smemType, ttg::TMAMode::Tiled);
+  LinearLayout msgLayout = xCoordsLayout * msgToCol;
+  auto msgBases = msgLayout.getBases();
+  for (auto [bit, basis] : llvm::enumerate(msgBases[kBlock]))
+    basis.back() = msgToOffset.getBasis(kBlock, bit, kDim1);
+  auto msgOutDims = msgLayout.getOutDims();
+  msgOutDims[msgLayout.getOutDimIndex(kDim1)].second =
+      smemType.getShape().back();
+  msgLayout = LinearLayout(std::move(msgBases), msgOutDims,
+                           /*requireSurjective=*/false);
 
   // `gather4` will put the segments of the 4 rows consecutively in
   // shared memory. However, if the 4 rows are smaller than the shared memory
@@ -1542,7 +1549,8 @@ static LogicalResult iterateGatherScatterIndices(
       }
       Value yOffset = b.add(yOffsetValue, b.i32_val(msgId * msgSize));
 
-      callback(pred, shMemPtr, yOffset, ArrayRef(xOffsets).slice(regId, 4));
+      callback(pred, shMemPtr, targetCTA, yOffset,
+               ArrayRef(xOffsets).slice(regId, 4));
     };
   }
 
@@ -1573,13 +1581,11 @@ LogicalResult AsyncTMAGatherOpConversion::matchAndRewrite(
   auto kBlock = StringAttr::get(op.getContext(), "block");
   bool multicast = op.getMulticast();
   Value pred = adaptor.getPred();
-  Value multicastMask;
+  uint32_t maskCGABroadcast = 0;
   if (multicast) {
-    uint32_t maskCGABroadcast = ttg::toLinearLayout(op.getResult().getType())
-                                    .getFreeVariableMasks()
-                                    .lookup(kBlock);
-    multicastMask =
-        LLVM::NVIDIA::createTMAMulticastMask(loc, rewriter, maskCGABroadcast);
+    maskCGABroadcast = ttg::toLinearLayout(op.getResult().getType())
+                           .getFreeVariableMasks()
+                           .lookup(kBlock);
     Value ctaId = nvgpu::ClusterCTAIdOp::create(rewriter, loc);
     Value ctaIdInGroup = b.and_(ctaId, b.i32_val(maskCGABroadcast));
     pred = b.and_(pred, b.icmp_eq(ctaIdInGroup, b.i32_val(0)));
@@ -1608,8 +1614,8 @@ LogicalResult AsyncTMAGatherOpConversion::matchAndRewrite(
     ctaGroup = ".cta_group::2";
 
   // Callback to generate the gather4 instruction.
-  auto callback = [&](Value pred, Value shMemPtr, Value yOffset,
-                      ArrayRef<Value> xOffsets) {
+  auto callback = [&](Value pred, Value shMemPtr, Value targetCTA,
+                      Value yOffset, ArrayRef<Value> xOffsets) {
     std::string tmaInst = "@$0 cp.async.bulk.tensor.2d.tile::gather4";
     tmaInst += ctaGroup;
     tmaInst += ".shared::";
@@ -1634,8 +1640,11 @@ LogicalResult AsyncTMAGatherOpConversion::matchAndRewrite(
     for (Value xOffset : xOffsets)
       operands.push_back(ptxBuilder.newOperand(xOffset, "r"));
     operands.push_back(ptxBuilder.newOperand(barrierPtr, "r"));
-    if (multicast)
+    if (multicast) {
+      auto multicastMask = LLVM::NVIDIA::createTMAMulticastMask(
+          loc, rewriter, maskCGABroadcast, targetCTA);
       operands.push_back(ptxBuilder.newOperand(multicastMask, "h"));
+    }
 
     auto &tma = *ptxBuilder.create(tmaInst);
     tma(operands, /*attachOnlyMLIRArgs=*/true);
@@ -1681,7 +1690,7 @@ LogicalResult AsyncTMAScatterOpConversion::matchAndRewrite(
   }
 
   // Callback to generate the scatter4 instruction.
-  auto callback = [&](Value pred, Value shMemPtr, Value yOffset,
+  auto callback = [&](Value pred, Value shMemPtr, Value, Value yOffset,
                       ArrayRef<Value> xOffsets) {
     std::string tmaInst = "@$0 cp.async.bulk.tensor.2d.tile::scatter4.global"
                           ".shared::cta.bulk_group "

--- a/third_party/nvidia/lib/TritonNVIDIAGPUToLLVM/Utility.cpp
+++ b/third_party/nvidia/lib/TritonNVIDIAGPUToLLVM/Utility.cpp
@@ -140,12 +140,13 @@ Value createElectPredicateWarp0(Location loc, OpBuilder &rewriter) {
 }
 
 Value createTMAMulticastMask(Location loc, ConversionPatternRewriter &rewriter,
-                             uint16_t broadcastBits) {
+                             uint16_t broadcastBits, Value ctaId) {
   int numCTAs = triton::gpu::lookupNumCTAs(rewriter);
   auto encoding =
       triton::nvidia_gpu::getTMAMulticastMaskEncoding(numCTAs, broadcastBits);
   auto b = TritonLLVMOpBuilder(loc, rewriter);
-  auto ctaId = nvgpu::ClusterCTAIdOp::create(rewriter, loc);
+  if (!ctaId)
+    ctaId = nvgpu::ClusterCTAIdOp::create(rewriter, loc);
   Value base = b.and_(ctaId, b.i32_val(encoding.fixedBits));
   return b.shl(b.i32_val(encoding.pattern), base);
 }

--- a/third_party/nvidia/lib/TritonNVIDIAGPUToLLVM/Utility.h
+++ b/third_party/nvidia/lib/TritonNVIDIAGPUToLLVM/Utility.h
@@ -63,7 +63,7 @@ LogicalResult lowerLdStMatrix(
 // where for ctaId, it sets as 1's the positions that are in the same broadcast
 // group
 Value createTMAMulticastMask(Location loc, ConversionPatternRewriter &rewriter,
-                             uint16_t broadcastBits);
+                             uint16_t broadcastBits, Value ctaId = {});
 
 uint32_t getCGABroadcastMask(mlir::triton::gpu::MemDescType barrierTy);
 


### PR DESCRIPTION
PR description written by Codex

Multicast TMA operations and column-sharded gathers can target the wrong CTA, mixed-CTA gathers can trap, and multicast im2col emits invalid PTX. Mismatched descriptor layouts can also survive verification and crash lowering.

Preserve destination CTA ownership across TMA loads and gathers, emit im2col operands in PTX order, and reject invalid descriptor ranks.

Validated against 2,079 GPU matrix cases, 4,114 IR configurations, the complete compiler lit and Gluon frontend suites, and Compute Sanitizer.

## Stack
Merge bottom-up:
- [ ] #11136 (this PR)
