### PR TITLE
[Release] [Cherry-Pick] [NVIDIA] Double-buffer synthetic cluster barriers (#10669)

### DIFF
--- a/include/triton/Dialect/TritonNvidiaGPU/Transforms/ClusterBarrierMbarAllocator.h
+++ b/include/triton/Dialect/TritonNvidiaGPU/Transforms/ClusterBarrierMbarAllocator.h
@@ -4,6 +4,8 @@
 #include "mlir/IR/BuiltinOps.h"
 #include "llvm/ADT/StringRef.h"
 
+#include <cstdint>
+
 namespace mlir {
 namespace triton {
 namespace nvidia_gpu {
@@ -12,6 +14,10 @@ inline constexpr llvm::StringLiteral kClusterBarrierMbarOffsetAttrName =
     "ttg.mbar_offset";
 inline constexpr llvm::StringLiteral kWSClusterBarrierCountAttrName =
     "ttg.ws_cluster_barrier_count";
+inline constexpr int64_t kClusterBarrierMbarSlotSize = 16;
+inline constexpr int64_t kClusterBarrierMbarBufferCount = 2;
+inline constexpr int64_t kClusterBarrierMbarAllocationSize =
+    kClusterBarrierMbarSlotSize * kClusterBarrierMbarBufferCount;
 
 inline void copyClusterBarrierMbarOffset(Operation *src, Operation *dst) {
   if (Attribute attr = src->getAttr(kClusterBarrierMbarOffsetAttrName))

--- a/lib/Dialect/TritonNvidiaGPU/Transforms/ClusterBarrierMbarAllocator.cpp
+++ b/lib/Dialect/TritonNvidiaGPU/Transforms/ClusterBarrierMbarAllocator.cpp
@@ -84,7 +84,7 @@ void runClusterBarrierMbarAllocator(ModuleOp mod) {
     auto [it, inserted] = regionOffsets.try_emplace(region);
     if (inserted) {
       it->second = builder.getI32IntegerAttr(nextOffset);
-      nextOffset += 16;
+      nextOffset += kClusterBarrierMbarAllocationSize;
     }
     op->setAttr(kClusterBarrierMbarOffsetAttrName, it->second);
   });

--- a/python/test/unit/language/test_compile_only.py
+++ b/python/test/unit/language/test_compile_only.py
@@ -103,7 +103,7 @@ module attributes {"ttg.num-ctas" = 2 : i32, "ttg.num-warps" = 4 : i32, ttg.targ
     assert "mbarrier.arrive.release.cluster.shared::cluster.b64" in ptx
     assert "mbarrier.try_wait.parity.acquire.cluster.shared::cta.b64" in ptx
     assert "mapa" not in ptx
-    assert k.metadata.shared == 24
+    assert k.metadata.shared == 40
     assert k.asm["cubin"] != b""
 
 

--- a/test/Conversion/tritonnvidiagpu_to_llvm.mlir
+++ b/test/Conversion/tritonnvidiagpu_to_llvm.mlir
@@ -763,10 +763,12 @@ module attributes {"ttg.num-ctas" = 16 : i32, "ttg.num-warps" = 1 : i32, "ttg.th
 
 module attributes {"ttg.num-ctas" = 2 : i32, "ttg.num-warps" = 4 : i32, ttg.shared = 5 : i32, "ttg.threads-per-warp" = 32 : i32} {
   // CHECK: module attributes {
-  // CHECK-DAG: ttg.shared = 24 : i32
+  // CHECK-DAG: ttg.shared = 40 : i32
   // CHECK-DAG: ttg.ws_cluster_barrier_count = 1 : i32
   // CHECK-LABEL: @cluster_barrier_inside_warp_specialize
-  // CHECK: "@$0 mbarrier.init.shared::cta.b64 [$1], 1;"
+  // CHECK-COUNT-2: "@$0 mbarrier.init.shared::cta.b64 [$1], 1;"
+  // CHECK: st.shared::cta.b32
+  // CHECK-NOT: st.shared::cta.b32
   // CHECK: fence.mbarrier_init.release.cluster
   // CHECK: nvvm.cluster.arrive.relaxed
   // CHECK-NEXT: nvvm.cluster.wait
@@ -774,14 +776,18 @@ module attributes {"ttg.num-ctas" = 2 : i32, "ttg.num-warps" = 4 : i32, ttg.shar
     ttg.warp_specialize()
     default {
       // CHECK: nvvm.barrier
-      // CHECK: %[[PARITY:.*]] = llvm.load
+      // CHECK: %[[COUNTER:.*]] = llvm.load
+      // CHECK: %[[BARRIER_IDX:.*]] = llvm.and %[[COUNTER]]
+      // CHECK: %[[PARITY:.*]] = llvm.lshr %[[COUNTER]]
+      // CHECK: %[[BARRIER:.*]] = llvm.getelementptr %{{.*}}[%[[BARRIER_IDX]]]
       // CHECK: %[[BARRIER_INT:.*]] = llvm.ptrtoint
       // CHECK: %[[PEER_BARRIER_INT:.*]] = llvm.xor %[[BARRIER_INT]],
       // CHECK: llvm.inttoptr %[[PEER_BARRIER_INT]]
       // CHECK-NOT: mapa
       // CHECK: mbarrier.arrive.release.cluster.shared::cluster.b64
       // CHECK: mbarrier.try_wait.parity.acquire.cluster.shared::cta.b64
-      // CHECK: llvm.xor %[[PARITY]],
+      // CHECK: %[[NEXT_COUNTER:.*]] = llvm.add %[[COUNTER]]
+      // CHECK: llvm.and %[[NEXT_COUNTER]]
       // CHECK: st.shared::cta.b32
       // CHECK: nvvm.barrier
       ttng.cluster_barrier
@@ -818,10 +824,10 @@ module attributes {"ttg.num-ctas" = 2 : i32, "ttg.num-warps" = 4 : i32, ttg.shar
 
 module attributes {"ttg.num-ctas" = 2 : i32, "ttg.num-warps" = 4 : i32, ttg.shared = 5 : i32, "ttg.threads-per-warp" = 32 : i32} {
   // CHECK: module attributes {
-  // CHECK-DAG: ttg.shared = 40 : i32
+  // CHECK-DAG: ttg.shared = 72 : i32
   // CHECK-DAG: ttg.ws_cluster_barrier_count = 2 : i32
   // CHECK-LABEL: @cluster_barrier_inside_warp_specialize_reuses_slots
-  // CHECK-COUNT-2: mbarrier.init.shared::cta.b64
+  // CHECK-COUNT-4: mbarrier.init.shared::cta.b64
   // CHECK-COUNT-1: fence.mbarrier_init.release.cluster
   // CHECK-COUNT-1: nvvm.cluster.arrive.relaxed
   // CHECK-COUNT-3: mbarrier.arrive.release.cluster.shared::cluster.b64

--- a/test/TritonNvidiaGPU/cluster-barrier-mbar-allocator.mlir
+++ b/test/TritonNvidiaGPU/cluster-barrier-mbar-allocator.mlir
@@ -7,7 +7,7 @@
 
 module attributes {"ttg.num-ctas" = 2 : i32, "ttg.num-warps" = 4 : i32, ttg.shared = 5 : i32, ttg.target = "cuda:90", "ttg.threads-per-warp" = 32 : i32} {
   // CHECK: module attributes {
-  // CHECK-DAG: ttg.shared = 40 : i32
+  // CHECK-DAG: ttg.shared = 72 : i32
   // CHECK-DAG: ttg.ws_cluster_barrier_count = 2 : i32
   // CHECK-LABEL: @cluster_barrier_mbar_allocator
   tt.func @cluster_barrier_mbar_allocator(%ptr: !tt.ptr<i32>) {
@@ -37,7 +37,7 @@ module attributes {"ttg.num-ctas" = 2 : i32, "ttg.num-warps" = 4 : i32, ttg.shar
       ttg.warp_yield
     }
     partition0() num_warps(4) {
-      // CHECK: ttng.cluster_barrier {ttg.mbar_offset = 24 : i32}
+      // CHECK: ttng.cluster_barrier {ttg.mbar_offset = 40 : i32}
       ttng.cluster_barrier
       ttg.warp_return
     } : () -> ()

--- a/third_party/nvidia/lib/TritonNVIDIAGPUToLLVM/ClusterOpsToLLVM.cpp
+++ b/third_party/nvidia/lib/TritonNVIDIAGPUToLLVM/ClusterOpsToLLVM.cpp
@@ -214,13 +214,22 @@ struct ClusterBarrierOpConversion
     auto loc = op.getLoc();
     auto b = TritonLLVMOpBuilder(loc, rewriter);
     auto func = op->getParentOfType<FunctionOpInterface>();
-    Value barrierPtr = getClusterBarrierMbarPtr(
+    Value barrierPtr0 = getClusterBarrierMbarPtr(
         loc, rewriter, func, mbarOffset.getInt(), targetInfo);
-    auto ptrTy = cast<LLVM::LLVMPointerType>(barrierPtr.getType());
-    Value parityPtr = b.gep(ptrTy, i8_ty, barrierPtr, LLVM::GEPArg(8));
+    auto ptrTy = cast<LLVM::LLVMPointerType>(barrierPtr0.getType());
+    Value counterPtr = b.gep(ptrTy, i8_ty, barrierPtr0, LLVM::GEPArg(8));
 
     NVVM::BarrierOp::create(rewriter, loc);
-    Value parity = b.load(i32_ty, parityPtr);
+    Value counter = b.load(i32_ty, counterPtr);
+    // A delayed CTA can miss a phase if a peer reuses one mbarrier twice
+    // before it starts waiting. Alternate two slots so each slot is reused
+    // only after an intervening rendezvous. The low counter bit selects the
+    // slot and the high bit is that slot's parity.
+    Value barrierIdx = b.and_(counter, b.i32_val(1));
+    Value parity = b.lshr(counter, b.i32_val(1));
+    auto barrierSlotTy = LLVM::LLVMArrayType::get(
+        i8_ty, triton::nvidia_gpu::kClusterBarrierMbarSlotSize);
+    Value barrierPtr = b.gep(ptrTy, barrierSlotTy, barrierPtr0, barrierIdx);
     Value pred = b.icmp_eq(getThreadId(rewriter, loc), b.i32_val(0));
     Value barrierInt = b.ptrtoint(i32_ty, barrierPtr);
     int numCTAs = triton::gpu::lookupNumCTAs(op);
@@ -231,8 +240,8 @@ struct ClusterBarrierOpConversion
       createMBarrierArrive(rewriter, loc, pred, peerBarrierPtr, relaxed);
     }
     createMBarrierWait(rewriter, loc, barrierPtr, parity);
-    targetInfo.storeShared(rewriter, loc, parityPtr,
-                           b.xor_(parity, b.i32_val(1)), pred);
+    Value nextCounter = b.and_(b.add(counter, b.i32_val(1)), b.i32_val(3));
+    targetInfo.storeShared(rewriter, loc, counterPtr, nextCounter, pred);
     NVVM::BarrierOp::create(rewriter, loc);
     rewriter.eraseOp(op);
     return success();
@@ -271,15 +280,26 @@ struct InitializeWSClusterBarriers
     auto sharedAttr = mod->getAttrOfType<IntegerAttr>("ttg.shared");
     int64_t shared = sharedAttr ? sharedAttr.getInt() : 0;
     int64_t count = countAttr.getInt();
-    int64_t offset = shared - count * 16;
+    int64_t offset =
+        shared - count * triton::nvidia_gpu::kClusterBarrierMbarAllocationSize;
     int numCTAs = triton::gpu::lookupNumCTAs(kernel);
-    for (int64_t i = 0; i < count; ++i, offset += 16) {
-      Value barrierPtr =
+    for (int64_t i = 0; i < count;
+         ++i, offset += triton::nvidia_gpu::kClusterBarrierMbarAllocationSize) {
+      Value barrierPtr0 =
           getClusterBarrierMbarPtr(loc, rewriter, kernel, offset, targetInfo);
-      auto ptrTy = cast<LLVM::LLVMPointerType>(barrierPtr.getType());
-      Value parityPtr = b.gep(ptrTy, i8_ty, barrierPtr, LLVM::GEPArg(8));
-      createMBarrierInit(rewriter, loc, initPred, barrierPtr, numCTAs - 1);
-      targetInfo.storeShared(rewriter, loc, parityPtr, b.i32_val(0), initPred);
+      for (int64_t slot = 0;
+           slot < triton::nvidia_gpu::kClusterBarrierMbarBufferCount; ++slot) {
+        Value barrierPtr = barrierPtr0;
+        if (slot != 0)
+          barrierPtr = getClusterBarrierMbarPtr(
+              loc, rewriter, kernel,
+              offset + slot * triton::nvidia_gpu::kClusterBarrierMbarSlotSize,
+              targetInfo);
+        createMBarrierInit(rewriter, loc, initPred, barrierPtr, numCTAs - 1);
+      }
+      auto ptrTy = cast<LLVM::LLVMPointerType>(barrierPtr0.getType());
+      Value counterPtr = b.gep(ptrTy, i8_ty, barrierPtr0, LLVM::GEPArg(8));
+      targetInfo.storeShared(rewriter, loc, counterPtr, b.i32_val(0), initPred);
     }
 
     NVIDIA::createFenceMBarrierInitReleaseCluster(rewriter, loc, initPred);


### PR DESCRIPTION
This is a backport of an upstream PR: https://github.com/triton-lang/triton/pull/10669

This is required before the release/3.8.x backport of #10992 so the warp-specialized cluster-barrier lowering uses the upstream double-buffered implementation.