### PR TITLE
[ConSan] Optimize ConSan by fusing helper functions

### DIFF
--- a/include/triton/Dialect/TritonInstrument/IR/FunctionBuilder.h
+++ b/include/triton/Dialect/TritonInstrument/IR/FunctionBuilder.h
@@ -151,9 +151,9 @@ public:
   // setReadVisibility: add the threads set in threadMask to the buffer's read
   // visibility bitmask.
   void createSetReadVisibilityCall(ImplicitLocOpBuilder &b, Value bufferMask,
-                                   uint64_t threadMask,
-                                   Value pred, MemType memType,
-                                   Operation *insertPoint, Value effectCTAs);
+                                   uint64_t threadMask, Value pred,
+                                   MemType memType, Operation *insertPoint,
+                                   Value effectCTAs);
   // trackVisibleAccesses: snapshot the available read and write visibility
   // frontiers into their independent barrier tracking tables.
   void createTrackVisibleAccessesCall(ImplicitLocOpBuilder &b, Value mbar,

--- a/include/triton/Dialect/TritonInstrument/IR/FunctionBuilder.h
+++ b/include/triton/Dialect/TritonInstrument/IR/FunctionBuilder.h
@@ -132,9 +132,10 @@ public:
   // waiting bits for the barrier.
   void createInvalidateBarrierStateCall(ImplicitLocOpBuilder &b, Value mbar,
                                         Value pred, Operation *insertPoint);
-  // verifyAndUpdateBarrierState: Validate and apply an arrive count and a
-  // tx-count delta using one snapshot of the tracked barrier state. Triggers
-  // an assertion without modifying the state when either count is invalid.
+  // verifyAndUpdateBarrierState: Validate barrier initialization, an arrive
+  // count, and a tx-count delta using one snapshot of the tracked barrier
+  // state. Preserve independent initialization and underflow assertions and
+  // do not modify invalid state.
   void createVerifyAndUpdateBarrierStateCall(ImplicitLocOpBuilder &b,
                                              Value mbar, int count, Value pred,
                                              Operation *insertPoint,

--- a/include/triton/Dialect/TritonInstrument/IR/FunctionBuilder.h
+++ b/include/triton/Dialect/TritonInstrument/IR/FunctionBuilder.h
@@ -177,16 +177,12 @@ public:
   void createClearBarrierReadTrackingCall(ImplicitLocOpBuilder &b, Value mbar,
                                           Value pred, MemType memType,
                                           Operation *insertPoint);
-  // transferVisibleWrites: transfer write visibility tracked by a barrier to
-  // all threads in threadMask.
-  void createTransferVisibleWritesCall(ImplicitLocOpBuilder &b, Value mbar,
-                                       uint64_t threadMask, Value pred,
-                                       MemType memType, Operation *insertPoint);
-  // transferVisibleReads: transfer read visibility tracked by a barrier to all
-  // threads in threadMask.
-  void createTransferVisibleReadsCall(ImplicitLocOpBuilder &b, Value mbar,
-                                      uint64_t threadMask, Value pred,
-                                      MemType memType, Operation *insertPoint);
+  // transferVisibleAccesses: transfer the barrier's independently tracked
+  // write and read visibility to all threads in threadMask.
+  void createTransferVisibleAccessesCall(ImplicitLocOpBuilder &b, Value mbar,
+                                         uint64_t threadMask, Value pred,
+                                         MemType memType,
+                                         Operation *insertPoint);
   // verifyWriteVisibility: ensure the thread either sees the latest write or no
   // other thread is writing the buffer.
   void createVerifyWriteVisibilityCall(ImplicitLocOpBuilder &b,

--- a/include/triton/Dialect/TritonInstrument/IR/FunctionBuilder.h
+++ b/include/triton/Dialect/TritonInstrument/IR/FunctionBuilder.h
@@ -140,31 +140,17 @@ public:
                                              Operation *insertPoint,
                                              Value recipientCTAs,
                                              int txCount = 0);
-  // setWriteVisibility: Set the write visibility for a buffer. Marks the buffer
-  // as visible to the threads set in threadMask. Clears out any other threads
-  // from the visibility bitmask. We know this is safe because there cannot be
-  // outstanding writes to this buffer at this point.
-  void createSetWriteVisibilityCall(ImplicitLocOpBuilder &b, Value bufferMask,
-                                    uint64_t threadMask, Value pred,
-                                    MemType memType, Operation *insertPoint,
-                                    Value effectCTAs);
+  // publishWriteVisibility: publish the writing threads for a buffer and clear
+  // its obsolete write tracking, read visibility, and read tracking.
+  void createPublishWriteVisibilityCall(ImplicitLocOpBuilder &b,
+                                        Value bufferMask, uint64_t threadMask,
+                                        Value pred, MemType memType,
+                                        Operation *insertPoint,
+                                        Value effectCTAs);
   // setReadVisibility: add the threads set in threadMask to the buffer's read
   // visibility bitmask.
   void createSetReadVisibilityCall(ImplicitLocOpBuilder &b, Value bufferMask,
-                                   uint64_t threadMask, Value pred,
-                                   MemType memType, Operation *insertPoint,
-                                   Value effectCTAs);
-  // clearWriteTracking: clear all the information about threads writing to a
-  // buffer.
-  void createClearWriteTrackingCall(ImplicitLocOpBuilder &b, Value bufferMask,
-                                    Value pred, MemType memType,
-                                    Operation *insertPoint, Value effectCTAs);
-  // clearReadVisibility: clear the read visibility for a buffer.
-  void createClearReadVisibilityCall(ImplicitLocOpBuilder &b, Value bufferMask,
-                                     Value pred, MemType memType,
-                                     Operation *insertPoint, Value effectCTAs);
-  // clearReadTracking: clear the read tracking for a buffer.
-  void createClearReadTrackingCall(ImplicitLocOpBuilder &b, Value bufferMask,
+                                   uint64_t threadMask,
                                    Value pred, MemType memType,
                                    Operation *insertPoint, Value effectCTAs);
   // trackVisibleAccesses: snapshot the available read and write visibility

--- a/include/triton/Dialect/TritonInstrument/IR/FunctionBuilder.h
+++ b/include/triton/Dialect/TritonInstrument/IR/FunctionBuilder.h
@@ -132,20 +132,14 @@ public:
   // waiting bits for the barrier.
   void createInvalidateBarrierStateCall(ImplicitLocOpBuilder &b, Value mbar,
                                         Value pred, Operation *insertPoint);
-  // verifyBarrierArrive: Check that applying the arrive count would not drive
-  // the tracked current count negative, and that applying the tx-count delta
-  // would keep it in range. Triggers an assertion on failure.
-  void createVerifyBarrierArriveCall(ImplicitLocOpBuilder &b, Value mbar,
-                                     int count, Value pred,
-                                     Operation *insertPoint,
-                                     Value recipientCTAs, int txCount = 0);
-  // updateBarrierState: Apply an arrive count to the tracked barrier state,
-  // apply a tx-count delta, toggling the phase when both counts reach zero and
-  // reloading the current count from the initial count.
-  void createUpdateBarrierStateCall(ImplicitLocOpBuilder &b, Value mbar,
-                                    int count, Value pred,
-                                    Operation *insertPoint, Value recipientCTAs,
-                                    int txCount = 0);
+  // verifyAndUpdateBarrierState: Validate and apply an arrive count and a
+  // tx-count delta using one snapshot of the tracked barrier state. Triggers
+  // an assertion without modifying the state when either count is invalid.
+  void createVerifyAndUpdateBarrierStateCall(ImplicitLocOpBuilder &b,
+                                             Value mbar, int count, Value pred,
+                                             Operation *insertPoint,
+                                             Value recipientCTAs,
+                                             int txCount = 0);
   // setWriteVisibility: Set the write visibility for a buffer. Marks the buffer
   // as visible to the threads set in threadMask. Clears out any other threads
   // from the visibility bitmask. We know this is safe because there cannot be

--- a/include/triton/Dialect/TritonInstrument/IR/FunctionBuilder.h
+++ b/include/triton/Dialect/TritonInstrument/IR/FunctionBuilder.h
@@ -238,11 +238,11 @@ public:
   void createTrackProxyAccessesForBufferCall(
       ImplicitLocOpBuilder &b, Value mbar, Value bufferMask, int thread,
       Value pred, Operation *insertPoint, Value barrierCTAs, Value effectCTAs);
-  // transferProxyAccesses: merge a barrier's packed proxy frontier into the
-  // waiting base thread.
-  void createTransferProxyAccessesCall(ImplicitLocOpBuilder &b, Value mbar,
-                                       int thread, Value pred,
-                                       Operation *insertPoint);
+  // completeBarrierWait: merge the barrier's available proxy frontier and
+  // clear the issuing base thread's waiting flag and phase.
+  void createCompleteBarrierWaitCall(ImplicitLocOpBuilder &b, Value mbar,
+                                     int thread, Value pred,
+                                     Operation *insertPoint);
   // clearBarrierProxyAccessTracking: clear packed proxy state associated with
   // an invalidated barrier.
   void createClearBarrierProxyAccessTrackingCall(ImplicitLocOpBuilder &b,

--- a/include/triton/Dialect/TritonInstrument/IR/FunctionBuilder.h
+++ b/include/triton/Dialect/TritonInstrument/IR/FunctionBuilder.h
@@ -167,16 +167,12 @@ public:
   void createClearReadTrackingCall(ImplicitLocOpBuilder &b, Value bufferMask,
                                    Value pred, MemType memType,
                                    Operation *insertPoint, Value effectCTAs);
-  // trackVisibleWrites: snapshot buffers currently visible to the thread into
-  // the tracking table for a barrier.
-  void createTrackVisibleWritesCall(ImplicitLocOpBuilder &b, Value mbar,
-                                    int thread, Value pred, MemType memType,
-                                    Operation *insertPoint, Value barrierCTAs);
-  // trackVisibleReads: snapshot buffers currently visible to the thread into
-  // the read tracking table for a barrier.
-  void createTrackVisibleReadsCall(ImplicitLocOpBuilder &b, Value mbar,
-                                   int thread, Value pred, MemType memType,
-                                   Operation *insertPoint, Value barrierCTAs);
+  // trackVisibleAccesses: snapshot the available read and write visibility
+  // frontiers into their independent barrier tracking tables.
+  void createTrackVisibleAccessesCall(ImplicitLocOpBuilder &b, Value mbar,
+                                      int thread, Value pred, MemType memType,
+                                      Operation *insertPoint,
+                                      Value barrierCTAs);
   // trackBarrierWriteForBuffer: mark a specific buffer as tracked by a
   // barrier in the write-tracking table.
   void createTrackBarrierWriteForBufferCall(ImplicitLocOpBuilder &b, Value mbar,

--- a/lib/Conversion/TritonInstrumentToLLVM/InstrumentationToLLVM.cpp
+++ b/lib/Conversion/TritonInstrumentToLLVM/InstrumentationToLLVM.cpp
@@ -62,15 +62,10 @@ struct AssertUniformOpConversion
                   ConversionPatternRewriter &rewriter) const override {
     TritonLLVMIRRewriter b(op.getLoc(), rewriter);
     Value tid = getThreadId(b, op.getLoc());
-    Value threadIdIsZero = b.icmp_eq(tid, b.i32_val(0));
-
-    auto [prevBlock, ifBlock, thenBlock] =
-        createIfBlock(rewriter, op.getLoc(), threadIdIsZero);
-    rewriter.setInsertionPointToStart(ifBlock);
-    AssertOp::create(rewriter, op.getLoc(), adaptor.getCondition(),
-                     adaptor.getMessage());
+    Value threadIdIsNotZero = b.icmp_ne(tid, b.i32_val(0));
+    Value condition = b.or_(threadIdIsNotZero, adaptor.getCondition());
+    AssertOp::create(rewriter, op.getLoc(), condition, adaptor.getMessage());
     rewriter.eraseOp(op);
-    rewriter.setInsertionPointToStart(thenBlock);
     return success();
   }
 };

--- a/lib/Dialect/TritonInstrument/IR/FunctionBuilder.cpp
+++ b/lib/Dialect/TritonInstrument/IR/FunctionBuilder.cpp
@@ -1244,12 +1244,9 @@ void FunctionBuilder::createVerifyAndUpdateBarrierStateCall(
   SmallVector<Value> args = {mbarOffset,       lengthVal,    countVal,
                              txCountVal,       pred,         barriersVal,
                              barrierStatesVal, recipientCTAs};
-  AssertInfo assertInfo{
-      "Barrier arrive underflow: current count or tx-count would become "
-      "invalid",
-      b.getI1Type()};
-  createCallToCachedFunction(
-      b, "verify_and_update_barrier_state", args, assertInfo,
+  AssertInfo statusInfo{"", b.getI32Type()};
+  Value status = createCallToCachedFunction(
+      b, "verify_and_update_barrier_state", args, statusInfo,
       {barriersType, barrierStatesType},
       [barrierStatesType](ImplicitLocOpBuilder &fb, Block *entryBlock) {
         Value mbarOffset = entryBlock->getArgument(0);
@@ -1270,6 +1267,19 @@ void FunctionBuilder::createVerifyAndUpdateBarrierStateCall(
 
         Value zero32 =
             tti::createConstIntTensor(fb, fb.getLoc(), 0, barrierStatesType);
+        Value initialized =
+            arith::CmpIOp::create(fb, arith::CmpIPredicate::ne, states, zero32);
+        auto condType = cast<RankedTensorType>(initialized.getType());
+        Value vTrue = tti::createConstIntTensor(fb, fb.getLoc(), 1, condType);
+        initialized = arith::SelectOp::create(fb, mask, initialized, vTrue);
+        Value ctaMask =
+            createCTASetMask(fb, condType, /*dim=*/0, recipientCTAs);
+        initialized = arith::SelectOp::create(fb, ctaMask, initialized, vTrue);
+        Value predTensor = triton::SplatOp::create(fb, condType, pred);
+        initialized =
+            arith::SelectOp::create(fb, predTensor, initialized, vTrue);
+        Value allInitialized = reduceAll<arith::AndIOp>(fb, initialized);
+
         Value maskFF = tti::createConstIntTensor(
             fb, fb.getLoc(), BarrierBits::countMask, barrierStatesType);
         Value shiftCurrentTensor = tti::createConstIntTensor(
@@ -1322,19 +1332,13 @@ void FunctionBuilder::createVerifyAndUpdateBarrierStateCall(
                                   newTxCountMasked, maxTxCount));
         Value valid =
             arith::AndIOp::create(fb, arrivalsNonNegative, txCountInRange);
-        Value vTrue = tti::createConstIntTensor(
-            fb, fb.getLoc(), 1, cast<RankedTensorType>(valid.getType()));
-        auto condType = cast<RankedTensorType>(valid.getType());
-        Value ctaMask =
-            createCTASetMask(fb, condType, /*dim=*/0, recipientCTAs);
         valid = arith::SelectOp::create(fb, ctaMask, valid, vTrue);
-        Value predTensor = triton::SplatOp::create(
-            fb, cast<RankedTensorType>(valid.getType()), pred);
         Value predicatedValid =
             arith::SelectOp::create(fb, predTensor, valid, vTrue);
 
         Value allValid = reduceAll<arith::AndIOp>(fb, predicatedValid);
-        Value shouldUpdate = arith::AndIOp::create(fb, pred, allValid);
+        Value shouldUpdate = arith::AndIOp::create(
+            fb, pred, arith::AndIOp::create(fb, allInitialized, allValid));
         auto [prevBlock, ifBlock, thenBlock] = createIfBlock(fb, shouldUpdate);
         fb.setInsertionPointToStart(ifBlock);
 
@@ -1382,8 +1386,26 @@ void FunctionBuilder::createVerifyAndUpdateBarrierStateCall(
                                           barrierStatesType, recipientCTAs);
 
         fb.setInsertionPointToEnd(thenBlock);
-        triton::ReturnOp::create(fb, allValid);
-      });
+        Value initializedBit =
+            arith::ExtUIOp::create(fb, fb.getI32Type(), allInitialized);
+        Value validBit = arith::ExtUIOp::create(fb, fb.getI32Type(), allValid);
+        Value shift = arith::ConstantIntOp::create(fb, 1, 32);
+        validBit = arith::ShLIOp::create(fb, validBit, shift);
+        Value status = arith::OrIOp::create(fb, initializedBit, validBit);
+        triton::ReturnOp::create(fb, status);
+      },
+      /*emitAssert=*/false);
+
+  Value initialized = arith::TruncIOp::create(b, b.getI1Type(), status);
+  tti::createAssertInThread(
+      b, initialized,
+      "Barrier used before initialization or after invalidation");
+  Value shift = arith::ConstantIntOp::create(b, 1, 32);
+  Value valid = arith::TruncIOp::create(
+      b, b.getI1Type(), arith::ShRUIOp::create(b, status, shift));
+  tti::createAssertInThread(b, valid,
+                            "Barrier arrive underflow: current count or "
+                            "tx-count would become invalid");
 }
 
 void FunctionBuilder::createPublishWriteVisibilityCall(

--- a/lib/Dialect/TritonInstrument/IR/FunctionBuilder.cpp
+++ b/lib/Dialect/TritonInstrument/IR/FunctionBuilder.cpp
@@ -842,14 +842,25 @@ Value FunctionBuilder::createCheckAllActiveWaitingCall(ImplicitLocOpBuilder &b,
             arith::AndIOp::create(fb, waitingOr, activeMaskTensor);
         Value eqPerCTA = arith::CmpIOp::create(fb, arith::CmpIPredicate::eq,
                                                waitingMasked, activeMaskTensor);
-        Value allFinishedOrWaiting = reduceAll<arith::AndIOp>(fb, eqPerCTA);
-        Value zeroMask = tti::createConstIntTensor(fb, fb.getLoc(), 0,
-                                                   activeMasksGlobalType);
-        Value activePerCTA = arith::CmpIOp::create(fb, arith::CmpIPredicate::ne,
-                                                   activeMasks, zeroMask);
-        Value anyUnfinished = reduceAll<arith::OrIOp>(fb, activePerCTA);
-        Value deadlocked =
-            arith::AndIOp::create(fb, allFinishedOrWaiting, anyUnfinished);
+        Value zeroMask =
+            tti::createConstIntTensor(fb, fb.getLoc(), 0, waitingOrType);
+        Value noActivePerCTA = arith::CmpIOp::create(
+            fb, arith::CmpIPredicate::eq, activeMaskTensor, zeroMask);
+        auto deadlockStatusType =
+            cast<RankedTensorType>(eqPerCTA.getType()).clone(fb.getI32Type());
+        Value waitingBits =
+            arith::ExtUIOp::create(fb, deadlockStatusType, eqPerCTA);
+        Value noActiveBits =
+            arith::ExtUIOp::create(fb, deadlockStatusType, noActivePerCTA);
+        Value statusShift =
+            tti::createConstIntTensor(fb, fb.getLoc(), 1, deadlockStatusType);
+        noActiveBits = arith::ShLIOp::create(fb, noActiveBits, statusShift);
+        Value statusBits =
+            arith::OrIOp::create(fb, waitingBits, noActiveBits);
+        Value status = reduceAll<arith::AndIOp>(fb, statusBits);
+        Value deadlockStatus = arith::ConstantIntOp::create(fb, 1, 32);
+        Value deadlocked = arith::CmpIOp::create(
+            fb, arith::CmpIPredicate::eq, status, deadlockStatus);
 
         Value vTrue = arith::ConstantOp::create(
             fb, deadlocked.getType(), fb.getIntegerAttr(fb.getI1Type(), 1));

--- a/lib/Dialect/TritonInstrument/IR/FunctionBuilder.cpp
+++ b/lib/Dialect/TritonInstrument/IR/FunctionBuilder.cpp
@@ -1578,180 +1578,153 @@ void FunctionBuilder::createClearReadTrackingCall(ImplicitLocOpBuilder &b,
                              memType, effectCTAs);
 }
 
-void FunctionBuilder::createTrackVisibleWritesCall(ImplicitLocOpBuilder &b,
-                                                   Value mbar, int thread,
-                                                   Value pred, MemType memType,
-                                                   Operation *insertPoint,
-                                                   Value barrierCTAs) {
-  if (auxData.barriers.empty() ||
-      auxData.writeVisibility[(int)memType].empty() ||
-      auxData.writeTracking[(int)memType].empty()) {
+void FunctionBuilder::createTrackVisibleAccessesCall(
+    ImplicitLocOpBuilder &b, Value mbar, int thread, Value pred,
+    MemType memType, Operation *insertPoint, Value barrierCTAs) {
+  if (auxData.barriers.empty())
     return;
-  }
+
+  const bool trackWrites = !auxData.writeVisibility[(int)memType].empty() &&
+                           !auxData.writeTracking[(int)memType].empty();
+  const bool trackReads = !auxData.readVisibility[(int)memType].empty() &&
+                          !auxData.readTracking[(int)memType].empty();
+  if (!trackWrites && !trackReads)
+    return;
+
   if (!pred)
     pred = arith::ConstantIntOp::create(b, 1, 1);
-  Value threadVal = arith::ConstantIntOp::create(b, thread, 32);
-  Value barriersVal = auxData.barriers.at(insertPoint).value;
-  auto barriersType =
-      cast<RankedTensorType>(auxData.barriers.at(insertPoint).type);
-  Value writeVisibilityVal =
-      auxData.writeVisibility[(int)memType].at(insertPoint).value;
-  auto writeVisibilityType = cast<RankedTensorType>(
-      auxData.writeVisibility[(int)memType].at(insertPoint).type);
-  Value writeTrackingVal =
-      auxData.writeTracking[(int)memType].at(insertPoint).value;
-  auto writeTrackingType = cast<RankedTensorType>(
-      auxData.writeTracking[(int)memType].at(insertPoint).type);
-  uint32_t length = getMemDescLength(mbar);
-  Value mbarOffset = tti::ExperimentalMemDescToI32Op::create(b, mbar);
-  Value lengthVal = arith::ConstantIntOp::create(b, length, 32);
-  SmallVector<Value> args = {mbarOffset,       lengthVal,   pred,
-                             threadVal,        barriersVal, writeVisibilityVal,
-                             writeTrackingVal, barrierCTAs};
+  ValueType barriers = auxData.barriers.at(insertPoint);
+  auto barriersType = cast<RankedTensorType>(barriers.type);
+  SmallVector<Value> args = {
+      tti::ExperimentalMemDescToI32Op::create(b, mbar),
+      arith::ConstantIntOp::create(b, getMemDescLength(mbar), 32),
+      pred,
+      arith::ConstantIntOp::create(b, thread, 32),
+      barriers.value,
+      barrierCTAs,
+  };
+  ManglingArgs specializationArgs;
+  specializationArgs.append(barriersType);
+  specializationArgs.append(static_cast<uint64_t>(memType));
+  specializationArgs.append(static_cast<uint64_t>(trackWrites));
+  specializationArgs.append(static_cast<uint64_t>(trackReads));
+
+  RankedTensorType writeVisibilityType;
+  RankedTensorType writeTrackingType;
+  if (trackWrites) {
+    ValueType visibility =
+        auxData.writeVisibility[(int)memType].at(insertPoint);
+    ValueType tracking = auxData.writeTracking[(int)memType].at(insertPoint);
+    writeVisibilityType = cast<RankedTensorType>(visibility.type);
+    writeTrackingType = cast<RankedTensorType>(tracking.type);
+    args.append({visibility.value, tracking.value});
+    specializationArgs.append(writeVisibilityType);
+    specializationArgs.append(writeTrackingType);
+  }
+
+  RankedTensorType readVisibilityType;
+  RankedTensorType readTrackingType;
+  if (trackReads) {
+    ValueType visibility = auxData.readVisibility[(int)memType].at(insertPoint);
+    ValueType tracking = auxData.readTracking[(int)memType].at(insertPoint);
+    readVisibilityType = cast<RankedTensorType>(visibility.type);
+    readTrackingType = cast<RankedTensorType>(tracking.type);
+    args.append({visibility.value, tracking.value});
+    specializationArgs.append(readVisibilityType);
+    specializationArgs.append(readTrackingType);
+  }
+
   createCallToCachedFunction(
-      b, "track_visible_writes", args,
-      /*assertInfo=*/std::nullopt,
-      {barriersType, writeVisibilityType, writeTrackingType, (uint64_t)memType},
-      [writeVisibilityType, writeTrackingType](ImplicitLocOpBuilder &fb,
-                                               Block *entryBlock) {
+      b, "track_visible_accesses", args, /*assertInfo=*/std::nullopt,
+      specializationArgs,
+      [trackWrites, trackReads, writeVisibilityType, writeTrackingType,
+       readVisibilityType,
+       readTrackingType](ImplicitLocOpBuilder &fb, Block *entryBlock) {
         Value mbarOffset = entryBlock->getArgument(0);
         Value lengthVal = entryBlock->getArgument(1);
         Value pred = entryBlock->getArgument(2);
         Value threadVal = entryBlock->getArgument(3);
         Value barriers = entryBlock->getArgument(4);
-        Value writeVisibilityPtr = entryBlock->getArgument(5);
-        Value writeTrackingPtr = entryBlock->getArgument(6);
-        Value barrierCTAs = entryBlock->getArgument(7);
+        Value barrierCTAs = entryBlock->getArgument(5);
+        unsigned nextArg = 6;
 
         auto [prevBlock, ifBlock, thenBlock] = createIfBlock(fb, pred);
         fb.setInsertionPointToStart(ifBlock);
-
-        Value writeVisibility = tti::createLoadScratchMemory(
-            fb, fb.getLoc(), writeVisibilityPtr, writeVisibilityType);
-        Value writeTracking = tti::createLoadScratchMemory(
-            fb, fb.getLoc(), writeTrackingPtr, writeTrackingType);
         Value descriptor = createBufferDescriptor(fb, mbarOffset, lengthVal);
         Value barriersEqBar =
             createCmpIntTensorScalar(fb, barriers, descriptor);
-        barriersEqBar =
-            convertAndBroadcast(fb, barriersEqBar, {3}, writeTrackingType);
-        Value barrierCTAMask =
-            createCTASetMask(fb, writeTrackingType, /*dim=*/2, barrierCTAs);
-        barriersEqBar =
-            arith::AndIOp::create(fb, barriersEqBar, barrierCTAMask);
-        Value threadI64 =
-            arith::ExtUIOp::create(fb, fb.getI64Type(), threadVal);
-        Value one64 = arith::ConstantIntOp::create(fb, 1, 64);
-        Value threadBitScalar = arith::ShLIOp::create(fb, one64, threadI64);
-        Value threadBit =
-            triton::SplatOp::create(fb, writeVisibilityType, threadBitScalar);
-        Value visibleWrites =
-            arith::AndIOp::create(fb, writeVisibility, threadBit);
-        visibleWrites = arith::CmpIOp::create(fb, arith::CmpIPredicate::eq,
-                                              visibleWrites, threadBit);
-        Value sourceCTAMask = createCTASetMask(
-            fb, writeVisibilityType, /*dim=*/2, createCurrentCTAMask(fb));
-        visibleWrites = arith::AndIOp::create(fb, visibleWrites, sourceCTAMask);
-        visibleWrites = reduceLastDim<arith::OrIOp>(fb, visibleWrites);
-        visibleWrites =
-            convertAndBroadcast(fb, visibleWrites, {0, 1}, writeTrackingType);
-        Value barAndVisible =
-            arith::AndIOp::create(fb, barriersEqBar, visibleWrites);
-        Value writeTrackingOne =
-            tti::createConstIntTensor(fb, fb.getLoc(), 1, writeTrackingType);
-        Value newTracking = arith::SelectOp::create(
-            fb, barAndVisible, writeTrackingOne, writeTracking);
-        createMaskedStoreScratchMemory(fb, fb.getLoc(), writeTrackingPtr,
-                                       newTracking, writeTrackingType,
-                                       barrierCTAMask);
+        Value currentCTA = createCurrentCTAMask(fb);
 
-        fb.setInsertionPointToEnd(thenBlock);
-        triton::ReturnOp::create(fb);
-      });
-}
+        if (trackWrites) {
+          Value visibilityPtr = entryBlock->getArgument(nextArg++);
+          Value trackingPtr = entryBlock->getArgument(nextArg++);
+          Value visibility = tti::createLoadScratchMemory(
+              fb, fb.getLoc(), visibilityPtr, writeVisibilityType);
+          Value tracking = tti::createLoadScratchMemory(
+              fb, fb.getLoc(), trackingPtr, writeTrackingType);
+          Value barrierMask =
+              convertAndBroadcast(fb, barriersEqBar, {3}, writeTrackingType);
+          Value barrierCTAMask =
+              createCTASetMask(fb, writeTrackingType, /*dim=*/2, barrierCTAs);
+          barrierMask = arith::AndIOp::create(fb, barrierMask, barrierCTAMask);
+          Value threadI64 =
+              arith::ExtUIOp::create(fb, fb.getI64Type(), threadVal);
+          Value one64 = arith::ConstantIntOp::create(fb, 1, 64);
+          Value threadBitScalar = arith::ShLIOp::create(fb, one64, threadI64);
+          Value threadBit =
+              triton::SplatOp::create(fb, writeVisibilityType, threadBitScalar);
+          Value visibleWrites =
+              arith::AndIOp::create(fb, visibility, threadBit);
+          visibleWrites = arith::CmpIOp::create(fb, arith::CmpIPredicate::eq,
+                                                visibleWrites, threadBit);
+          Value sourceCTAMask =
+              createCTASetMask(fb, writeVisibilityType, /*dim=*/2, currentCTA);
+          visibleWrites =
+              arith::AndIOp::create(fb, visibleWrites, sourceCTAMask);
+          visibleWrites = reduceLastDim<arith::OrIOp>(fb, visibleWrites);
+          visibleWrites =
+              convertAndBroadcast(fb, visibleWrites, {0, 1}, writeTrackingType);
+          Value barAndVisible =
+              arith::AndIOp::create(fb, barrierMask, visibleWrites);
+          Value one =
+              tti::createConstIntTensor(fb, fb.getLoc(), 1, writeTrackingType);
+          Value updated =
+              arith::SelectOp::create(fb, barAndVisible, one, tracking);
+          createMaskedStoreScratchMemory(fb, fb.getLoc(), trackingPtr, updated,
+                                         writeTrackingType, barrierCTAMask);
+        }
 
-void FunctionBuilder::createTrackVisibleReadsCall(ImplicitLocOpBuilder &b,
-                                                  Value mbar, int thread,
-                                                  Value pred, MemType memType,
-                                                  Operation *insertPoint,
-                                                  Value barrierCTAs) {
-
-  if (auxData.barriers.empty() ||
-      auxData.readVisibility[(int)memType].empty() ||
-      auxData.readTracking[(int)memType].empty()) {
-    return;
-  }
-  if (!pred)
-    pred = arith::ConstantIntOp::create(b, 1, 1);
-  Value threadVal = arith::ConstantIntOp::create(b, thread, 32);
-  Value barriersVal = auxData.barriers.at(insertPoint).value;
-  auto barriersType =
-      cast<RankedTensorType>(auxData.barriers.at(insertPoint).type);
-  Value readVisibilityVal =
-      auxData.readVisibility[(int)memType].at(insertPoint).value;
-  auto readVisibilityType = cast<RankedTensorType>(
-      auxData.readVisibility[(int)memType].at(insertPoint).type);
-  Value readTrackingVal =
-      auxData.readTracking[(int)memType].at(insertPoint).value;
-  auto readTrackingType = cast<RankedTensorType>(
-      auxData.readTracking[(int)memType].at(insertPoint).type);
-  uint32_t length = getMemDescLength(mbar);
-  Value mbarOffset = tti::ExperimentalMemDescToI32Op::create(b, mbar);
-  Value lengthVal = arith::ConstantIntOp::create(b, length, 32);
-  SmallVector<Value> args = {mbarOffset,      lengthVal,   pred,
-                             threadVal,       barriersVal, readVisibilityVal,
-                             readTrackingVal, barrierCTAs};
-  createCallToCachedFunction(
-      b, "track_visible_reads", args,
-      /*assertInfo=*/std::nullopt,
-      {barriersType, readVisibilityType, readTrackingType, (uint64_t)memType},
-      [readVisibilityType, readTrackingType](ImplicitLocOpBuilder &fb,
-                                             Block *entryBlock) {
-        Value mbarOffset = entryBlock->getArgument(0);
-        Value lengthVal = entryBlock->getArgument(1);
-        Value pred = entryBlock->getArgument(2);
-        Value threadVal = entryBlock->getArgument(3);
-        Value barriers = entryBlock->getArgument(4);
-        Value readVisibilityPtr = entryBlock->getArgument(5);
-        Value readTrackingPtr = entryBlock->getArgument(6);
-        Value barrierCTAs = entryBlock->getArgument(7);
-
-        auto [prevBlock, ifBlock, thenBlock] = createIfBlock(fb, pred);
-        fb.setInsertionPointToStart(ifBlock);
-
-        Value readVisibility = tti::createLoadScratchMemory(
-            fb, fb.getLoc(), readVisibilityPtr, readVisibilityType);
-        Value readTracking = tti::createLoadScratchMemory(
-            fb, fb.getLoc(), readTrackingPtr, readTrackingType);
-        Value descriptor = createBufferDescriptor(fb, mbarOffset, lengthVal);
-        Value barriersEqBar =
-            createCmpIntTensorScalar(fb, barriers, descriptor);
-        barriersEqBar =
-            convertAndBroadcast(fb, barriersEqBar, {3}, readTrackingType);
-        Value barrierCTAMask =
-            createCTASetMask(fb, readTrackingType, /*dim=*/2, barrierCTAs);
-        barriersEqBar =
-            arith::AndIOp::create(fb, barriersEqBar, barrierCTAMask);
-        Value threadColumnMask =
-            createDimMask(fb, threadVal, readVisibilityType, /*dim=*/3);
-        Value readVisibilityZero =
-            tti::createConstIntTensor(fb, fb.getLoc(), 0, readVisibilityType);
-        Value visibleReads = arith::SelectOp::create(
-            fb, threadColumnMask, readVisibility, readVisibilityZero);
-        Value sourceCTAMask = createCTASetMask(
-            fb, readVisibilityType, /*dim=*/2, createCurrentCTAMask(fb));
-        visibleReads = arith::SelectOp::create(fb, sourceCTAMask, visibleReads,
-                                               readVisibilityZero);
-        visibleReads = reduce<arith::OrIOp>(fb, visibleReads, {2, 3});
-        visibleReads =
-            convertAndBroadcast(fb, visibleReads, {0, 1, 4}, readTrackingType);
-        Value readTrackingOrVisible =
-            arith::OrIOp::create(fb, readTracking, visibleReads);
-        Value newTracking = arith::SelectOp::create(
-            fb, barriersEqBar, readTrackingOrVisible, readTracking);
-        createMaskedStoreScratchMemory(fb, fb.getLoc(), readTrackingPtr,
-                                       newTracking, readTrackingType,
-                                       barrierCTAMask);
+        if (trackReads) {
+          Value visibilityPtr = entryBlock->getArgument(nextArg++);
+          Value trackingPtr = entryBlock->getArgument(nextArg++);
+          Value visibility = tti::createLoadScratchMemory(
+              fb, fb.getLoc(), visibilityPtr, readVisibilityType);
+          Value tracking = tti::createLoadScratchMemory(
+              fb, fb.getLoc(), trackingPtr, readTrackingType);
+          Value barrierMask =
+              convertAndBroadcast(fb, barriersEqBar, {3}, readTrackingType);
+          Value barrierCTAMask =
+              createCTASetMask(fb, readTrackingType, /*dim=*/2, barrierCTAs);
+          barrierMask = arith::AndIOp::create(fb, barrierMask, barrierCTAMask);
+          Value threadColumnMask =
+              createDimMask(fb, threadVal, readVisibilityType, /*dim=*/3);
+          Value zero =
+              tti::createConstIntTensor(fb, fb.getLoc(), 0, readVisibilityType);
+          Value visibleReads =
+              arith::SelectOp::create(fb, threadColumnMask, visibility, zero);
+          Value sourceCTAMask =
+              createCTASetMask(fb, readVisibilityType, /*dim=*/2, currentCTA);
+          visibleReads =
+              arith::SelectOp::create(fb, sourceCTAMask, visibleReads, zero);
+          visibleReads = reduce<arith::OrIOp>(fb, visibleReads, {2, 3});
+          visibleReads = convertAndBroadcast(fb, visibleReads, {0, 1, 4},
+                                             readTrackingType);
+          Value withVisible = arith::OrIOp::create(fb, tracking, visibleReads);
+          Value updated =
+              arith::SelectOp::create(fb, barrierMask, withVisible, tracking);
+          createMaskedStoreScratchMemory(fb, fb.getLoc(), trackingPtr, updated,
+                                         readTrackingType, barrierCTAMask);
+        }
 
         fb.setInsertionPointToEnd(thenBlock);
         triton::ReturnOp::create(fb);

--- a/lib/Dialect/TritonInstrument/IR/FunctionBuilder.cpp
+++ b/lib/Dialect/TritonInstrument/IR/FunctionBuilder.cpp
@@ -2382,6 +2382,8 @@ void FunctionBuilder::createPublishClusterVisibilityCall(
       {writeVisibilityType, readVisibilityType, (uint64_t)partitionScoped},
       [writeVisibilityType, readVisibilityType,
        numBaseThreads = auxData.threadLayout.numBaseThreads,
+       onlySynchronousThreads = auxData.threadLayout.totalNumThreads ==
+                                auxData.threadLayout.numBaseThreads,
        partitionScoped](ImplicitLocOpBuilder &fb, Block *entryBlock) {
         Value pred = entryBlock->getArgument(0);
         Value threadVal = entryBlock->getArgument(1);
@@ -2419,6 +2421,8 @@ void FunctionBuilder::createPublishClusterVisibilityCall(
               zeroWrites);
           syncWrites = arith::SelectOp::create(fb, hasThreadWrite, peersMask,
                                                zeroWrites);
+        } else if (onlySynchronousThreads) {
+          syncWrites = writeVisibility;
         } else {
           // Top-level cluster barriers represent all synchronous threads. A
           // base-thread bit distinguishes synchronous work from async-only
@@ -2456,6 +2460,11 @@ void FunctionBuilder::createPublishClusterVisibilityCall(
               fb, threadPeersMaskVal, readVisibilityType, /*columnDim=*/3);
           readsForCluster = arith::SelectOp::create(fb, peerColumns,
                                                     readsForThread, zeroReads);
+        } else if (onlySynchronousThreads) {
+          readsForCluster = reduce<arith::OrIOp>(fb, readVisibility,
+                                                 {2, 3, 4});
+          readsForCluster = convertAndBroadcast(fb, readsForCluster, {0, 1},
+                                                readVisibilityType);
         } else {
           uint64_t baseThreadMask = (1ULL << numBaseThreads) - 1;
           Value readBaseMask = tti::createConstIntTensor(

--- a/lib/Dialect/TritonInstrument/IR/FunctionBuilder.cpp
+++ b/lib/Dialect/TritonInstrument/IR/FunctionBuilder.cpp
@@ -1278,7 +1278,6 @@ void FunctionBuilder::createVerifyAndUpdateBarrierStateCall(
         Value predTensor = triton::SplatOp::create(fb, condType, pred);
         initialized =
             arith::SelectOp::create(fb, predTensor, initialized, vTrue);
-        Value allInitialized = reduceAll<arith::AndIOp>(fb, initialized);
 
         Value maskFF = tti::createConstIntTensor(
             fb, fb.getLoc(), BarrierBits::countMask, barrierStatesType);
@@ -1336,7 +1335,23 @@ void FunctionBuilder::createVerifyAndUpdateBarrierStateCall(
         Value predicatedValid =
             arith::SelectOp::create(fb, predTensor, valid, vTrue);
 
-        Value allValid = reduceAll<arith::AndIOp>(fb, predicatedValid);
+        auto statusType = condType.clone(fb.getI32Type());
+        Value initializedBits =
+            arith::ExtUIOp::create(fb, statusType, initialized);
+        Value validBits =
+            arith::ExtUIOp::create(fb, statusType, predicatedValid);
+        Value statusShift =
+            tti::createConstIntTensor(fb, fb.getLoc(), 1, statusType);
+        validBits = arith::ShLIOp::create(fb, validBits, statusShift);
+        Value statusBits =
+            arith::OrIOp::create(fb, initializedBits, validBits);
+        Value packedStatus = reduceAll<arith::AndIOp>(fb, statusBits);
+        Value allInitialized =
+            arith::TruncIOp::create(fb, fb.getI1Type(), packedStatus);
+        Value validShift = arith::ConstantIntOp::create(fb, 1, 32);
+        Value allValid = arith::TruncIOp::create(
+            fb, fb.getI1Type(),
+            arith::ShRUIOp::create(fb, packedStatus, validShift));
         Value shouldUpdate = arith::AndIOp::create(
             fb, pred, arith::AndIOp::create(fb, allInitialized, allValid));
         auto [prevBlock, ifBlock, thenBlock] = createIfBlock(fb, shouldUpdate);
@@ -1386,13 +1401,7 @@ void FunctionBuilder::createVerifyAndUpdateBarrierStateCall(
                                           barrierStatesType, recipientCTAs);
 
         fb.setInsertionPointToEnd(thenBlock);
-        Value initializedBit =
-            arith::ExtUIOp::create(fb, fb.getI32Type(), allInitialized);
-        Value validBit = arith::ExtUIOp::create(fb, fb.getI32Type(), allValid);
-        Value shift = arith::ConstantIntOp::create(fb, 1, 32);
-        validBit = arith::ShLIOp::create(fb, validBit, shift);
-        Value status = arith::OrIOp::create(fb, initializedBit, validBit);
-        triton::ReturnOp::create(fb, status);
+        triton::ReturnOp::create(fb, packedStatus);
       },
       /*emitAssert=*/false);
 

--- a/lib/Dialect/TritonInstrument/IR/FunctionBuilder.cpp
+++ b/lib/Dialect/TritonInstrument/IR/FunctionBuilder.cpp
@@ -1386,51 +1386,119 @@ void FunctionBuilder::createVerifyAndUpdateBarrierStateCall(
       });
 }
 
-void FunctionBuilder::createSetWriteVisibilityCall(
+void FunctionBuilder::createPublishWriteVisibilityCall(
     ImplicitLocOpBuilder &b, Value bufferMask, uint64_t threadMask, Value pred,
     MemType memType, Operation *insertPoint, Value effectCTAs) {
-
-  if (auxData.writeVisibility[(int)memType].empty()) {
+  const bool publishWrite = !auxData.writeVisibility[(int)memType].empty();
+  const bool clearWrites = !auxData.writeTracking[(int)memType].empty();
+  const bool clearReads = !auxData.readVisibility[(int)memType].empty();
+  const bool clearReadTracking = !auxData.readTracking[(int)memType].empty();
+  if (!publishWrite && !clearWrites && !clearReads && !clearReadTracking)
     return;
-  }
+
   if (!pred)
     pred = arith::ConstantIntOp::create(b, 1, 1);
   Value threadMaskVal = arith::ConstantIntOp::create(b, threadMask, 64);
-  Value writeVisibilityVal =
-      auxData.writeVisibility[(int)memType].at(insertPoint).value;
-  auto writeVisibilityType = cast<RankedTensorType>(
-      auxData.writeVisibility[(int)memType].at(insertPoint).type);
-  SmallVector<Value> args = {bufferMask, pred, threadMaskVal,
-                             writeVisibilityVal, effectCTAs};
+  SmallVector<Value> args = {bufferMask, pred, threadMaskVal, effectCTAs};
+  ManglingArgs specializationArgs;
+  specializationArgs.append(static_cast<uint64_t>(memType));
+  specializationArgs.append(static_cast<uint64_t>(publishWrite));
+  specializationArgs.append(static_cast<uint64_t>(clearWrites));
+  specializationArgs.append(static_cast<uint64_t>(clearReads));
+  specializationArgs.append(static_cast<uint64_t>(clearReadTracking));
+
+  RankedTensorType writeVisibilityType;
+  if (publishWrite) {
+    ValueType visibility =
+        auxData.writeVisibility[(int)memType].at(insertPoint);
+    writeVisibilityType = cast<RankedTensorType>(visibility.type);
+    args.push_back(visibility.value);
+    specializationArgs.append(writeVisibilityType);
+  }
+
+  RankedTensorType writeTrackingType;
+  if (clearWrites) {
+    ValueType tracking = auxData.writeTracking[(int)memType].at(insertPoint);
+    writeTrackingType = cast<RankedTensorType>(tracking.type);
+    args.push_back(tracking.value);
+    specializationArgs.append(writeTrackingType);
+  }
+
+  RankedTensorType readVisibilityType;
+  if (clearReads) {
+    ValueType visibility = auxData.readVisibility[(int)memType].at(insertPoint);
+    readVisibilityType = cast<RankedTensorType>(visibility.type);
+    args.push_back(visibility.value);
+    specializationArgs.append(readVisibilityType);
+  }
+
+  RankedTensorType readTrackingType;
+  if (clearReadTracking) {
+    ValueType tracking = auxData.readTracking[(int)memType].at(insertPoint);
+    readTrackingType = cast<RankedTensorType>(tracking.type);
+    args.push_back(tracking.value);
+    specializationArgs.append(readTrackingType);
+  }
+
   createCallToCachedFunction(
-      b, "set_write_visibility", args,
-      /*assertInfo=*/std::nullopt, {writeVisibilityType, (uint64_t)memType},
-      [writeVisibilityType](ImplicitLocOpBuilder &fb, Block *entryBlock) {
+      b, "publish_write_visibility", args, /*assertInfo=*/std::nullopt,
+      specializationArgs,
+      [publishWrite, clearWrites, clearReads, clearReadTracking,
+       writeVisibilityType, writeTrackingType, readVisibilityType,
+       readTrackingType](ImplicitLocOpBuilder &fb, Block *entryBlock) {
         Value bufferMask = entryBlock->getArgument(0);
         Value pred = entryBlock->getArgument(1);
         Value threadMaskVal = entryBlock->getArgument(2);
-        Value writeVisibilityPtr = entryBlock->getArgument(3);
-        Value effectCTAs = entryBlock->getArgument(4);
+        Value effectCTAs = entryBlock->getArgument(3);
+        unsigned nextArg = 4;
 
         auto [prevBlock, ifBlock, thenBlock] = createIfBlock(fb, pred);
         fb.setInsertionPointToStart(ifBlock);
 
-        Value writeVisibility = tti::createLoadScratchMemory(
-            fb, fb.getLoc(), writeVisibilityPtr, writeVisibilityType);
-        bufferMask =
-            convertAndBroadcast(fb, bufferMask, {1}, writeVisibilityType);
-        Value relationMask =
-            createLeadCTAEffectMask(fb, writeVisibilityType, effectCTAs);
-        bufferMask = arith::AndIOp::create(fb, bufferMask, relationMask);
-        auto elemType = cast<IntegerType>(writeVisibilityType.getElementType());
-        Value threadMaskElem = adjustIntegerWidth(fb, threadMaskVal, elemType);
-        Value threadMaskTensor =
-            triton::SplatOp::create(fb, writeVisibilityType, threadMaskElem);
-        Value newVisibility = arith::SelectOp::create(
-            fb, bufferMask, threadMaskTensor, writeVisibility);
-        createMaskedStoreScratchMemory(fb, fb.getLoc(), writeVisibilityPtr,
-                                       newVisibility, writeVisibilityType,
-                                       relationMask);
+        if (publishWrite) {
+          Value visibilityPtr = entryBlock->getArgument(nextArg++);
+          Value visibility = tti::createLoadScratchMemory(
+              fb, fb.getLoc(), visibilityPtr, writeVisibilityType);
+          Value visibilityMask =
+              convertAndBroadcast(fb, bufferMask, {1}, writeVisibilityType);
+          Value relationMask =
+              createLeadCTAEffectMask(fb, writeVisibilityType, effectCTAs);
+          visibilityMask =
+              arith::AndIOp::create(fb, visibilityMask, relationMask);
+          auto elemType =
+              cast<IntegerType>(writeVisibilityType.getElementType());
+          Value threadMaskElem =
+              adjustIntegerWidth(fb, threadMaskVal, elemType);
+          Value threadMaskTensor =
+              triton::SplatOp::create(fb, writeVisibilityType, threadMaskElem);
+          Value updated = arith::SelectOp::create(fb, visibilityMask,
+                                                  threadMaskTensor, visibility);
+          createMaskedStoreScratchMemory(fb, fb.getLoc(), visibilityPtr,
+                                         updated, writeVisibilityType,
+                                         relationMask);
+        }
+
+        auto clearTable = [&](RankedTensorType tableType) {
+          Value tablePtr = entryBlock->getArgument(nextArg++);
+          Value table = tti::createLoadScratchMemory(fb, fb.getLoc(), tablePtr,
+                                                     tableType);
+          Value tableMask =
+              convertAndBroadcast(fb, bufferMask, {1}, tableType);
+          Value ctaMask =
+              createCTASetMask(fb, tableType, /*dim=*/0, effectCTAs);
+          tableMask = arith::AndIOp::create(fb, tableMask, ctaMask);
+          Value zero = tti::createConstIntTensor(fb, fb.getLoc(), 0, tableType);
+          Value updated = arith::SelectOp::create(fb, tableMask, zero, table);
+          createMaskedStoreScratchMemory(fb, fb.getLoc(), tablePtr, updated,
+                                         tableType, ctaMask);
+        };
+
+        if (clearWrites)
+          clearTable(writeTrackingType);
+        if (clearReads)
+          clearTable(readVisibilityType);
+        if (clearReadTracking)
+          clearTable(readTrackingType);
 
         fb.setInsertionPointToEnd(thenBlock);
         triton::ReturnOp::create(fb);
@@ -1504,78 +1572,6 @@ void FunctionBuilder::createSetReadVisibilityCall(
         fb.setInsertionPointToEnd(thenBlock);
         triton::ReturnOp::create(fb);
       });
-}
-
-static void createClearBufferStateCall(ImplicitLocOpBuilder &b,
-                                       StringRef functionName, Value bufferMask,
-                                       Value pred, ValueType state,
-                                       MemType memType, Value effectCTAs) {
-  if (!pred)
-    pred = arith::ConstantIntOp::create(b, 1, 1);
-  auto stateType = cast<RankedTensorType>(state.type);
-  SmallVector<Value> args = {bufferMask, pred, state.value, effectCTAs};
-  createCallToCachedFunction(
-      b, functionName.str(), args, /*assertInfo=*/std::nullopt,
-      {stateType, (uint64_t)memType},
-      [stateType](ImplicitLocOpBuilder &fb, Block *entryBlock) {
-        Value bufferMask = entryBlock->getArgument(0);
-        Value pred = entryBlock->getArgument(1);
-        Value statePtr = entryBlock->getArgument(2);
-        Value effectCTAs = entryBlock->getArgument(3);
-
-        auto [prevBlock, ifBlock, thenBlock] = createIfBlock(fb, pred);
-        fb.setInsertionPointToStart(ifBlock);
-
-        Value state =
-            tti::createLoadScratchMemory(fb, fb.getLoc(), statePtr, stateType);
-        bufferMask = convertAndBroadcast(fb, bufferMask, {1}, stateType);
-        Value ctaMask = createCTASetMask(fb, stateType, /*dim=*/0, effectCTAs);
-        bufferMask = arith::AndIOp::create(fb, bufferMask, ctaMask);
-        Value zero = tti::createConstIntTensor(fb, fb.getLoc(), 0, stateType);
-        Value updated = arith::SelectOp::create(fb, bufferMask, zero, state);
-        createMaskedStoreScratchMemory(fb, fb.getLoc(), statePtr, updated,
-                                       stateType, ctaMask);
-
-        fb.setInsertionPointToEnd(thenBlock);
-        triton::ReturnOp::create(fb);
-      });
-}
-
-void FunctionBuilder::createClearWriteTrackingCall(ImplicitLocOpBuilder &b,
-                                                   Value bufferMask, Value pred,
-                                                   MemType memType,
-                                                   Operation *insertPoint,
-                                                   Value effectCTAs) {
-  if (auxData.writeTracking[(int)memType].empty())
-    return;
-  createClearBufferStateCall(
-      b, "clear_write_tracking", bufferMask, pred,
-      auxData.writeTracking[(int)memType].at(insertPoint), memType, effectCTAs);
-}
-
-void FunctionBuilder::createClearReadVisibilityCall(ImplicitLocOpBuilder &b,
-                                                    Value bufferMask,
-                                                    Value pred, MemType memType,
-                                                    Operation *insertPoint,
-                                                    Value effectCTAs) {
-  if (auxData.readVisibility[(int)memType].empty())
-    return;
-  createClearBufferStateCall(
-      b, "clear_read_visibility", bufferMask, pred,
-      auxData.readVisibility[(int)memType].at(insertPoint), memType,
-      effectCTAs);
-}
-
-void FunctionBuilder::createClearReadTrackingCall(ImplicitLocOpBuilder &b,
-                                                  Value bufferMask, Value pred,
-                                                  MemType memType,
-                                                  Operation *insertPoint,
-                                                  Value effectCTAs) {
-  if (auxData.readTracking[(int)memType].empty())
-    return;
-  createClearBufferStateCall(b, "clear_read_tracking", bufferMask, pred,
-                             auxData.readTracking[(int)memType].at(insertPoint),
-                             memType, effectCTAs);
 }
 
 void FunctionBuilder::createTrackVisibleAccessesCall(

--- a/lib/Dialect/TritonInstrument/IR/FunctionBuilder.cpp
+++ b/lib/Dialect/TritonInstrument/IR/FunctionBuilder.cpp
@@ -489,9 +489,9 @@ void FunctionBuilder::createFillGlobalTensorCall(ImplicitLocOpBuilder &b,
                                                  Value ptr,
                                                  RankedTensorType type,
                                                  Value scalar) {
-  type = tti::getIntTensorType(
-      b.getInsertionBlock()->getParent(), {type.getNumElements()},
-      type.getElementType().getIntOrFloatBitWidth());
+  type = tti::getIntTensorType(b.getInsertionBlock()->getParent(),
+                               {type.getNumElements()},
+                               type.getElementType().getIntOrFloatBitWidth());
   createCallToCachedFunction(
       b, "fill_global_tensor", {ptr, scalar}, /*assertInfo=*/std::nullopt,
       {type}, [type](ImplicitLocOpBuilder &fb, Block *entryBlock) {
@@ -858,12 +858,11 @@ Value FunctionBuilder::createCheckAllActiveWaitingCall(ImplicitLocOpBuilder &b,
         Value statusShift =
             tti::createConstIntTensor(fb, fb.getLoc(), 1, deadlockStatusType);
         noActiveBits = arith::ShLIOp::create(fb, noActiveBits, statusShift);
-        Value statusBits =
-            arith::OrIOp::create(fb, waitingBits, noActiveBits);
+        Value statusBits = arith::OrIOp::create(fb, waitingBits, noActiveBits);
         Value status = reduceAll<arith::AndIOp>(fb, statusBits);
         Value deadlockStatus = arith::ConstantIntOp::create(fb, 1, 32);
-        Value deadlocked = arith::CmpIOp::create(
-            fb, arith::CmpIPredicate::eq, status, deadlockStatus);
+        Value deadlocked = arith::CmpIOp::create(fb, arith::CmpIPredicate::eq,
+                                                 status, deadlockStatus);
 
         Value vTrue = arith::ConstantOp::create(
             fb, deadlocked.getType(), fb.getIntegerAttr(fb.getI1Type(), 1));
@@ -1357,8 +1356,7 @@ void FunctionBuilder::createVerifyAndUpdateBarrierStateCall(
         Value statusShift =
             tti::createConstIntTensor(fb, fb.getLoc(), 1, statusType);
         validBits = arith::ShLIOp::create(fb, validBits, statusShift);
-        Value statusBits =
-            arith::OrIOp::create(fb, initializedBits, validBits);
+        Value statusBits = arith::OrIOp::create(fb, initializedBits, validBits);
         Value packedStatus = reduceAll<arith::AndIOp>(fb, statusBits);
         Value allInitialized =
             arith::TruncIOp::create(fb, fb.getI1Type(), packedStatus);
@@ -1527,8 +1525,7 @@ void FunctionBuilder::createPublishWriteVisibilityCall(
           Value tablePtr = entryBlock->getArgument(nextArg++);
           Value table = tti::createLoadScratchMemory(fb, fb.getLoc(), tablePtr,
                                                      tableType);
-          Value tableMask =
-              convertAndBroadcast(fb, bufferMask, {1}, tableType);
+          Value tableMask = convertAndBroadcast(fb, bufferMask, {1}, tableType);
           Value ctaMask =
               createCTASetMask(fb, tableType, /*dim=*/0, effectCTAs);
           tableMask = arith::AndIOp::create(fb, tableMask, ctaMask);
@@ -2111,8 +2108,7 @@ void FunctionBuilder::createVerifyWriteVisibilityCall(
         Value writeVisibilityZero =
             tti::createConstIntTensor(fb, fb.getLoc(), 0, writeVisibilityType);
         Value noOneIsWriting = arith::CmpIOp::create(
-            fb, arith::CmpIPredicate::eq, writeVisibility,
-            writeVisibilityZero);
+            fb, arith::CmpIPredicate::eq, writeVisibility, writeVisibilityZero);
         Value threadI64 =
             arith::ExtUIOp::create(fb, fb.getI64Type(), threadVal);
         Value threadMask =
@@ -2461,8 +2457,7 @@ void FunctionBuilder::createPublishClusterVisibilityCall(
           readsForCluster = arith::SelectOp::create(fb, peerColumns,
                                                     readsForThread, zeroReads);
         } else if (onlySynchronousThreads) {
-          readsForCluster = reduce<arith::OrIOp>(fb, readVisibility,
-                                                 {2, 3, 4});
+          readsForCluster = reduce<arith::OrIOp>(fb, readVisibility, {2, 3, 4});
           readsForCluster = convertAndBroadcast(fb, readsForCluster, {0, 1},
                                                 readVisibilityType);
         } else {
@@ -2861,8 +2856,7 @@ void FunctionBuilder::createCompleteBarrierWaitCall(ImplicitLocOpBuilder &b,
         Value frontier =
             arith::SelectOp::create(fb, selected, tracking, zeroTracking);
         frontier = reduce<arith::OrIOp>(fb, frontier, {2, 3});
-        frontier =
-            convertAndBroadcast(fb, frontier, {0, 1, 4}, visibilityType);
+        frontier = convertAndBroadcast(fb, frontier, {0, 1, 4}, visibilityType);
 
         Value targetMask =
             createCTASetMask(fb, visibilityType, /*dim=*/2, currentCTA);
@@ -2877,12 +2871,11 @@ void FunctionBuilder::createCompleteBarrierWaitCall(ImplicitLocOpBuilder &b,
 
         if (clearWaiting) {
           Value waitingPtr = entryBlock->getArgument(7);
-          Value waiting = tti::createLoadScratchMemory(
-              fb, fb.getLoc(), waitingPtr, waitingType);
+          Value waiting = tti::createLoadScratchMemory(fb, fb.getLoc(),
+                                                       waitingPtr, waitingType);
           Value waitingBarrierMask =
               convertAndBroadcast(fb, barriersEqBar, {1}, waitingType);
-          Value ctaMask =
-              createLeadCTAEffectMask(fb, waitingType, currentCTA);
+          Value ctaMask = createLeadCTAEffectMask(fb, waitingType, currentCTA);
           waitingBarrierMask =
               arith::AndIOp::create(fb, waitingBarrierMask, ctaMask);
 
@@ -2906,8 +2899,8 @@ void FunctionBuilder::createCompleteBarrierWaitCall(ImplicitLocOpBuilder &b,
               triton::SplatOp::create(fb, waitingType, clearMask);
           Value clearedWaiting =
               arith::AndIOp::create(fb, waiting, clearMaskTensor);
-          Value updated = arith::SelectOp::create(
-              fb, waitingBarrierMask, clearedWaiting, waiting);
+          Value updated = arith::SelectOp::create(fb, waitingBarrierMask,
+                                                  clearedWaiting, waiting);
           createMaskedStoreScratchMemory(fb, fb.getLoc(), waitingPtr, updated,
                                          waitingType, ctaMask);
         }

--- a/lib/Dialect/TritonInstrument/IR/FunctionBuilder.cpp
+++ b/lib/Dialect/TritonInstrument/IR/FunctionBuilder.cpp
@@ -2902,7 +2902,9 @@ void FunctionBuilder::createVerifyProxyAccessCall(ImplicitLocOpBuilder &b,
         fenced = arith::AndIOp::create(fb, fenced, seenMask);
         Value notFenced = arith::XOrIOp::create(fb, fenced, seenMask);
         Value missing = arith::AndIOp::create(fb, seen, notFenced);
-        Value missingAny = reduceAll<arith::OrIOp>(fb, missing);
+        Value missingBits =
+            arith::CmpIOp::create(fb, arith::CmpIPredicate::ne, missing, zero);
+        Value missingAny = reduceAll<arith::OrIOp>(fb, missingBits);
         Value zeroScalar = arith::ConstantOp::create(
             fb, missingAny.getType(),
             fb.getIntegerAttr(missingAny.getType(), 0));

--- a/lib/Dialect/TritonInstrument/IR/FunctionBuilder.cpp
+++ b/lib/Dialect/TritonInstrument/IR/FunctionBuilder.cpp
@@ -2782,13 +2782,18 @@ void FunctionBuilder::createTrackProxyAccessesCallImpl(
       });
 }
 
-void FunctionBuilder::createTransferProxyAccessesCall(ImplicitLocOpBuilder &b,
-                                                      Value mbar, int thread,
-                                                      Value pred,
-                                                      Operation *insertPoint) {
-  if (auxData.barriers.empty() || auxData.proxyAccessVisibility.empty() ||
-      auxData.proxyAccessTracking.empty())
+void FunctionBuilder::createCompleteBarrierWaitCall(ImplicitLocOpBuilder &b,
+                                                    Value mbar, int thread,
+                                                    Value pred,
+                                                    Operation *insertPoint) {
+  if (auxData.barriers.empty())
     return;
+  if (auxData.proxyAccessVisibility.empty() ||
+      auxData.proxyAccessTracking.empty()) {
+    createClearWaitingCall(b, mbar, thread, pred, insertPoint);
+    return;
+  }
+  const bool clearWaiting = !auxData.waiting.empty();
   if (!pred)
     pred = arith::ConstantIntOp::create(b, 1, 1);
   ValueType barriers = auxData.barriers.at(insertPoint);
@@ -2805,11 +2810,25 @@ void FunctionBuilder::createTransferProxyAccessesCall(ImplicitLocOpBuilder &b,
       barriers.value,
       visibility.value,
       tracking.value};
+  ManglingArgs specializationArgs;
+  specializationArgs.append(barriersType);
+  specializationArgs.append(visibilityType);
+  specializationArgs.append(trackingType);
+  specializationArgs.append(static_cast<uint64_t>(clearWaiting));
+
+  RankedTensorType waitingType;
+  if (clearWaiting) {
+    ValueType waiting = auxData.waiting.at(insertPoint);
+    waitingType = cast<RankedTensorType>(waiting.type);
+    args.push_back(waiting.value);
+    specializationArgs.append(waitingType);
+  }
+
   createCallToCachedFunction(
-      b, "transfer_proxy_accesses", args, /*assertInfo=*/std::nullopt,
-      {barriersType, visibilityType, trackingType},
-      [visibilityType, trackingType](ImplicitLocOpBuilder &fb,
-                                     Block *entryBlock) {
+      b, "complete_barrier_wait", args, /*assertInfo=*/std::nullopt,
+      specializationArgs,
+      [clearWaiting, visibilityType, trackingType,
+       waitingType](ImplicitLocOpBuilder &fb, Block *entryBlock) {
         Value mbarOffset = entryBlock->getArgument(0);
         Value lengthVal = entryBlock->getArgument(1);
         Value pred = entryBlock->getArgument(2);
@@ -2820,26 +2839,28 @@ void FunctionBuilder::createTransferProxyAccessesCall(ImplicitLocOpBuilder &b,
 
         auto [prevBlock, ifBlock, thenBlock] = createIfBlock(fb, pred);
         fb.setInsertionPointToStart(ifBlock);
+        Value descriptor = createBufferDescriptor(fb, mbarOffset, lengthVal);
+        Value barriersEqBar =
+            createCmpIntTensorScalar(fb, barriers, descriptor);
+        Value currentCTA = createCurrentCTAMask(fb);
+
         Value visibility = tti::createLoadScratchMemory(
             fb, fb.getLoc(), visibilityPtr, visibilityType);
         Value tracking = tti::createLoadScratchMemory(
             fb, fb.getLoc(), trackingPtr, trackingType);
-        Value descriptor = createBufferDescriptor(fb, mbarOffset, lengthVal);
-        Value barriersEqBar =
-            createCmpIntTensorScalar(fb, barriers, descriptor);
-        barriersEqBar =
+        Value proxyBarrierMask =
             convertAndBroadcast(fb, barriersEqBar, {3}, trackingType);
-        Value currentCTA = createCurrentCTAMask(fb);
         Value barrierCTAMask =
             createCTASetMask(fb, trackingType, /*dim=*/2, currentCTA);
         Value selected =
-            arith::AndIOp::create(fb, barriersEqBar, barrierCTAMask);
+            arith::AndIOp::create(fb, proxyBarrierMask, barrierCTAMask);
         Value zeroTracking =
             tti::createConstIntTensor(fb, fb.getLoc(), 0, trackingType);
         Value frontier =
             arith::SelectOp::create(fb, selected, tracking, zeroTracking);
         frontier = reduce<arith::OrIOp>(fb, frontier, {2, 3});
-        frontier = convertAndBroadcast(fb, frontier, {0, 1, 4}, visibilityType);
+        frontier =
+            convertAndBroadcast(fb, frontier, {0, 1, 4}, visibilityType);
 
         Value targetMask =
             createCTASetMask(fb, visibilityType, /*dim=*/2, currentCTA);
@@ -2851,6 +2872,43 @@ void FunctionBuilder::createTransferProxyAccessesCall(ImplicitLocOpBuilder &b,
             arith::SelectOp::create(fb, targetMask, withFrontier, visibility);
         createMaskedStoreScratchMemory(fb, fb.getLoc(), visibilityPtr, updated,
                                        visibilityType, targetMask);
+
+        if (clearWaiting) {
+          Value waitingPtr = entryBlock->getArgument(7);
+          Value waiting = tti::createLoadScratchMemory(
+              fb, fb.getLoc(), waitingPtr, waitingType);
+          Value waitingBarrierMask =
+              convertAndBroadcast(fb, barriersEqBar, {1}, waitingType);
+          Value ctaMask =
+              createLeadCTAEffectMask(fb, waitingType, currentCTA);
+          waitingBarrierMask =
+              arith::AndIOp::create(fb, waitingBarrierMask, ctaMask);
+
+          Value bitsPerThread =
+              arith::ConstantIntOp::create(fb, WaitingBits::bitsPerThread, 32);
+          Value flagBit =
+              arith::ConstantIntOp::create(fb, WaitingBits::flagBit, 32);
+          Value phaseBit =
+              arith::ConstantIntOp::create(fb, WaitingBits::phaseBit, 32);
+          Value one = arith::ConstantIntOp::create(fb, 1, 32);
+          Value minusOne = arith::ConstantIntOp::create(fb, -1, 32);
+          Value baseTimesBits =
+              arith::MulIOp::create(fb, threadVal, bitsPerThread);
+          Value flagShift = arith::AddIOp::create(fb, baseTimesBits, flagBit);
+          Value phaseShift = arith::AddIOp::create(fb, baseTimesBits, phaseBit);
+          Value flagMask = arith::ShLIOp::create(fb, one, flagShift);
+          Value phaseMask = arith::ShLIOp::create(fb, one, phaseShift);
+          Value bits = arith::OrIOp::create(fb, flagMask, phaseMask);
+          Value clearMask = arith::XOrIOp::create(fb, bits, minusOne);
+          Value clearMaskTensor =
+              triton::SplatOp::create(fb, waitingType, clearMask);
+          Value clearedWaiting =
+              arith::AndIOp::create(fb, waiting, clearMaskTensor);
+          Value updated = arith::SelectOp::create(
+              fb, waitingBarrierMask, clearedWaiting, waiting);
+          createMaskedStoreScratchMemory(fb, fb.getLoc(), waitingPtr, updated,
+                                         waitingType, ctaMask);
+        }
 
         fb.setInsertionPointToEnd(thenBlock);
         triton::ReturnOp::create(fb);

--- a/lib/Dialect/TritonInstrument/IR/FunctionBuilder.cpp
+++ b/lib/Dialect/TritonInstrument/IR/FunctionBuilder.cpp
@@ -1874,181 +1874,160 @@ void FunctionBuilder::createClearBarrierReadTrackingCall(
       auxData.readTracking[(int)memType].at(insertPoint), memType);
 }
 
-void FunctionBuilder::createTransferVisibleWritesCall(
+void FunctionBuilder::createTransferVisibleAccessesCall(
     ImplicitLocOpBuilder &b, Value mbar, uint64_t threadMask, Value pred,
     MemType memType, Operation *insertPoint) {
-
-  if (auxData.barriers.empty() ||
-      auxData.writeVisibility[(int)memType].empty() ||
-      auxData.writeTracking[(int)memType].empty()) {
+  if (auxData.barriers.empty())
     return;
-  }
+
+  const bool transferWrites = !auxData.writeVisibility[(int)memType].empty() &&
+                              !auxData.writeTracking[(int)memType].empty();
+  const bool transferReads = !auxData.readVisibility[(int)memType].empty() &&
+                             !auxData.readTracking[(int)memType].empty();
+  if (!transferWrites && !transferReads)
+    return;
+
   if (!pred)
     pred = arith::ConstantIntOp::create(b, 1, 1);
   Value threadMaskVal = arith::ConstantIntOp::create(b, threadMask, 64);
-  Value barriersVal = auxData.barriers.at(insertPoint).value;
-  auto barriersType =
-      cast<RankedTensorType>(auxData.barriers.at(insertPoint).type);
-  Value writeVisibilityVal =
-      auxData.writeVisibility[(int)memType].at(insertPoint).value;
-  auto writeVisibilityType = cast<RankedTensorType>(
-      auxData.writeVisibility[(int)memType].at(insertPoint).type);
-  Value writeTrackingVal =
-      auxData.writeTracking[(int)memType].at(insertPoint).value;
-  auto writeTrackingType = cast<RankedTensorType>(
-      auxData.writeTracking[(int)memType].at(insertPoint).type);
-  uint32_t length = getMemDescLength(mbar);
-  Value mbarOffset = tti::ExperimentalMemDescToI32Op::create(b, mbar);
-  Value lengthVal = arith::ConstantIntOp::create(b, length, 32);
-  SmallVector<Value> args = {mbarOffset,      lengthVal,   pred,
-                             threadMaskVal,   barriersVal, writeVisibilityVal,
-                             writeTrackingVal};
+  ValueType barriers = auxData.barriers.at(insertPoint);
+  auto barriersType = cast<RankedTensorType>(barriers.type);
+  SmallVector<Value> args = {
+      tti::ExperimentalMemDescToI32Op::create(b, mbar),
+      arith::ConstantIntOp::create(b, getMemDescLength(mbar), 32),
+      pred,
+      threadMaskVal,
+      barriers.value,
+  };
+  ManglingArgs specializationArgs;
+  specializationArgs.append(barriersType);
+  specializationArgs.append(static_cast<uint64_t>(memType));
+  specializationArgs.append(static_cast<uint64_t>(transferWrites));
+  specializationArgs.append(static_cast<uint64_t>(transferReads));
+
+  RankedTensorType writeVisibilityType;
+  RankedTensorType writeTrackingType;
+  if (transferWrites) {
+    ValueType visibility =
+        auxData.writeVisibility[(int)memType].at(insertPoint);
+    ValueType tracking = auxData.writeTracking[(int)memType].at(insertPoint);
+    writeVisibilityType = cast<RankedTensorType>(visibility.type);
+    writeTrackingType = cast<RankedTensorType>(tracking.type);
+    args.append({visibility.value, tracking.value});
+    specializationArgs.append(writeVisibilityType);
+    specializationArgs.append(writeTrackingType);
+  }
+
+  RankedTensorType readVisibilityType;
+  RankedTensorType readTrackingType;
+  if (transferReads) {
+    ValueType visibility = auxData.readVisibility[(int)memType].at(insertPoint);
+    ValueType tracking = auxData.readTracking[(int)memType].at(insertPoint);
+    readVisibilityType = cast<RankedTensorType>(visibility.type);
+    readTrackingType = cast<RankedTensorType>(tracking.type);
+    args.append({visibility.value, tracking.value});
+    specializationArgs.append(readVisibilityType);
+    specializationArgs.append(readTrackingType);
+  }
+
   createCallToCachedFunction(
-      b, "transfer_visible_writes", args,
-      /*assertInfo=*/std::nullopt,
-      {barriersType, writeVisibilityType, writeTrackingType, (uint64_t)memType},
-      [writeVisibilityType, writeTrackingType](ImplicitLocOpBuilder &fb,
-                                               Block *entryBlock) {
+      b, "transfer_visible_accesses", args, /*assertInfo=*/std::nullopt,
+      specializationArgs,
+      [transferWrites, transferReads, writeVisibilityType, writeTrackingType,
+       readVisibilityType,
+       readTrackingType](ImplicitLocOpBuilder &fb, Block *entryBlock) {
         Value mbarOffset = entryBlock->getArgument(0);
         Value lengthVal = entryBlock->getArgument(1);
         Value pred = entryBlock->getArgument(2);
         Value threadMaskVal = entryBlock->getArgument(3);
         Value barriers = entryBlock->getArgument(4);
-        Value writeVisibilityPtr = entryBlock->getArgument(5);
-        Value writeTrackingPtr = entryBlock->getArgument(6);
+        unsigned nextArg = 5;
 
         auto [prevBlock, ifBlock, thenBlock] = createIfBlock(fb, pred);
         fb.setInsertionPointToStart(ifBlock);
-
-        Value writeVisibility = tti::createLoadScratchMemory(
-            fb, fb.getLoc(), writeVisibilityPtr, writeVisibilityType);
-        Value writeTracking = tti::createLoadScratchMemory(
-            fb, fb.getLoc(), writeTrackingPtr, writeTrackingType);
         Value descriptor = createBufferDescriptor(fb, mbarOffset, lengthVal);
         Value barriersEqBar =
             createCmpIntTensorScalar(fb, barriers, descriptor);
-        barriersEqBar =
-            convertAndBroadcast(fb, barriersEqBar, {3}, writeTrackingType);
         Value currentCTA = createCurrentCTAMask(fb);
-        Value barrierCTAMask =
-            createCTASetMask(fb, writeTrackingType, /*dim=*/2, currentCTA);
-        barriersEqBar =
-            arith::AndIOp::create(fb, barriersEqBar, barrierCTAMask);
-        Value zeroTracking =
-            tti::createConstIntTensor(fb, fb.getLoc(), 0, writeTrackingType);
-        Value trackingBuffers = arith::SelectOp::create(
-            fb, barriersEqBar, writeTracking, zeroTracking);
-        trackingBuffers = reduce<arith::OrIOp>(fb, trackingBuffers, {2, 3});
-        trackingBuffers = convertAndBroadcast(fb, trackingBuffers, {0, 1},
-                                              writeVisibilityType);
-        auto trackingBuffersType =
-            cast<RankedTensorType>(trackingBuffers.getType());
-        Value trackingBuffersOne =
-            tti::createConstIntTensor(fb, fb.getLoc(), 1, trackingBuffersType);
-        trackingBuffers = arith::CmpIOp::create(
-            fb, arith::CmpIPredicate::eq, trackingBuffers, trackingBuffersOne);
-        auto elemType = cast<IntegerType>(writeVisibilityType.getElementType());
-        Value threadMaskElem = adjustIntegerWidth(fb, threadMaskVal, elemType);
-        Value threadMaskTensor =
-            triton::SplatOp::create(fb, writeVisibilityType, threadMaskElem);
-        Value zeroVisibility =
-            tti::createConstIntTensor(fb, fb.getLoc(), 0, writeVisibilityType);
-        Value trackingThreadBit = arith::SelectOp::create(
-            fb, trackingBuffers, threadMaskTensor, zeroVisibility);
-        Value newVisibility =
-            arith::OrIOp::create(fb, writeVisibility, trackingThreadBit);
-        Value waitingCTAMask =
-            createCTASetMask(fb, writeVisibilityType, /*dim=*/2, currentCTA);
-        createMaskedStoreScratchMemory(fb, fb.getLoc(), writeVisibilityPtr,
-                                       newVisibility, writeVisibilityType,
-                                       waitingCTAMask);
 
-        fb.setInsertionPointToEnd(thenBlock);
-        triton::ReturnOp::create(fb);
-      });
-}
+        if (transferWrites) {
+          Value visibilityPtr = entryBlock->getArgument(nextArg++);
+          Value trackingPtr = entryBlock->getArgument(nextArg++);
+          Value visibility = tti::createLoadScratchMemory(
+              fb, fb.getLoc(), visibilityPtr, writeVisibilityType);
+          Value tracking = tti::createLoadScratchMemory(
+              fb, fb.getLoc(), trackingPtr, writeTrackingType);
+          Value barrierMask =
+              convertAndBroadcast(fb, barriersEqBar, {3}, writeTrackingType);
+          Value barrierCTAMask =
+              createCTASetMask(fb, writeTrackingType, /*dim=*/2, currentCTA);
+          barrierMask = arith::AndIOp::create(fb, barrierMask, barrierCTAMask);
+          Value zeroTracking =
+              tti::createConstIntTensor(fb, fb.getLoc(), 0, writeTrackingType);
+          Value trackingBuffers =
+              arith::SelectOp::create(fb, barrierMask, tracking, zeroTracking);
+          trackingBuffers = reduce<arith::OrIOp>(fb, trackingBuffers, {2, 3});
+          trackingBuffers = convertAndBroadcast(fb, trackingBuffers, {0, 1},
+                                                writeVisibilityType);
+          auto trackingBuffersType =
+              cast<RankedTensorType>(trackingBuffers.getType());
+          Value trackingBuffersOne = tti::createConstIntTensor(
+              fb, fb.getLoc(), 1, trackingBuffersType);
+          trackingBuffers =
+              arith::CmpIOp::create(fb, arith::CmpIPredicate::eq,
+                                    trackingBuffers, trackingBuffersOne);
+          auto elemType =
+              cast<IntegerType>(writeVisibilityType.getElementType());
+          Value threadMaskElem =
+              adjustIntegerWidth(fb, threadMaskVal, elemType);
+          Value threadMaskTensor =
+              triton::SplatOp::create(fb, writeVisibilityType, threadMaskElem);
+          Value zeroVisibility = tti::createConstIntTensor(fb, fb.getLoc(), 0,
+                                                           writeVisibilityType);
+          Value trackingThreadBit = arith::SelectOp::create(
+              fb, trackingBuffers, threadMaskTensor, zeroVisibility);
+          Value updated =
+              arith::OrIOp::create(fb, visibility, trackingThreadBit);
+          Value waitingCTAMask =
+              createCTASetMask(fb, writeVisibilityType, /*dim=*/2, currentCTA);
+          createMaskedStoreScratchMemory(fb, fb.getLoc(), visibilityPtr,
+                                         updated, writeVisibilityType,
+                                         waitingCTAMask);
+        }
 
-void FunctionBuilder::createTransferVisibleReadsCall(
-    ImplicitLocOpBuilder &b, Value mbar, uint64_t threadMask, Value pred,
-    MemType memType, Operation *insertPoint) {
-
-  if (auxData.barriers.empty() ||
-      auxData.readVisibility[(int)memType].empty() ||
-      auxData.readTracking[(int)memType].empty()) {
-    return;
-  }
-  if (!pred)
-    pred = arith::ConstantIntOp::create(b, 1, 1);
-  Value threadMaskVal = arith::ConstantIntOp::create(b, threadMask, 64);
-  Value barriersVal = auxData.barriers.at(insertPoint).value;
-  auto barriersType =
-      cast<RankedTensorType>(auxData.barriers.at(insertPoint).type);
-  Value readVisibilityVal =
-      auxData.readVisibility[(int)memType].at(insertPoint).value;
-  auto readVisibilityType = cast<RankedTensorType>(
-      auxData.readVisibility[(int)memType].at(insertPoint).type);
-  Value readTrackingVal =
-      auxData.readTracking[(int)memType].at(insertPoint).value;
-  auto readTrackingType = cast<RankedTensorType>(
-      auxData.readTracking[(int)memType].at(insertPoint).type);
-  uint32_t length = getMemDescLength(mbar);
-  Value mbarOffset = tti::ExperimentalMemDescToI32Op::create(b, mbar);
-  Value lengthVal = arith::ConstantIntOp::create(b, length, 32);
-  SmallVector<Value> args = {mbarOffset,     lengthVal,   pred,
-                             threadMaskVal,  barriersVal, readVisibilityVal,
-                             readTrackingVal};
-  createCallToCachedFunction(
-      b, "transfer_visible_reads", args,
-      /*assertInfo=*/std::nullopt,
-      {barriersType, readVisibilityType, readTrackingType, (uint64_t)memType},
-      [readVisibilityType, readTrackingType](ImplicitLocOpBuilder &fb,
-                                             Block *entryBlock) {
-        Value mbarOffset = entryBlock->getArgument(0);
-        Value lengthVal = entryBlock->getArgument(1);
-        Value pred = entryBlock->getArgument(2);
-        Value threadMaskVal = entryBlock->getArgument(3);
-        Value barriers = entryBlock->getArgument(4);
-        Value readVisibilityPtr = entryBlock->getArgument(5);
-        Value readTrackingPtr = entryBlock->getArgument(6);
-
-        auto [prevBlock, ifBlock, thenBlock] = createIfBlock(fb, pred);
-        fb.setInsertionPointToStart(ifBlock);
-
-        Value readVisibility = tti::createLoadScratchMemory(
-            fb, fb.getLoc(), readVisibilityPtr, readVisibilityType);
-        Value readTracking = tti::createLoadScratchMemory(
-            fb, fb.getLoc(), readTrackingPtr, readTrackingType);
-        Value descriptor = createBufferDescriptor(fb, mbarOffset, lengthVal);
-        Value barriersEqBar =
-            createCmpIntTensorScalar(fb, barriers, descriptor);
-        barriersEqBar =
-            convertAndBroadcast(fb, barriersEqBar, {3}, readTrackingType);
-        Value currentCTA = createCurrentCTAMask(fb);
-        Value barrierCTAMask =
-            createCTASetMask(fb, readTrackingType, /*dim=*/2, currentCTA);
-        barriersEqBar =
-            arith::AndIOp::create(fb, barriersEqBar, barrierCTAMask);
-        Value readTrackingZero =
-            tti::createConstIntTensor(fb, fb.getLoc(), 0, readTrackingType);
-        Value trackingBar = arith::SelectOp::create(
-            fb, barriersEqBar, readTracking, readTrackingZero);
-        trackingBar = reduce<arith::OrIOp>(fb, trackingBar, {2, 3});
-        trackingBar =
-            convertAndBroadcast(fb, trackingBar, {0, 1, 4}, readVisibilityType);
-        Value readVisibilityOrTracking =
-            arith::OrIOp::create(fb, readVisibility, trackingBar);
-        Value threadColumnMask =
-            createThreadColumnMask(fb, threadMaskVal, readVisibilityType,
-                                   /*columnDim=*/3);
-        Value waitingCTAMask =
-            createCTASetMask(fb, readVisibilityType, /*dim=*/2, currentCTA);
-        threadColumnMask =
-            arith::AndIOp::create(fb, threadColumnMask, waitingCTAMask);
-        Value newVisibility = arith::SelectOp::create(
-            fb, threadColumnMask, readVisibilityOrTracking, readVisibility);
-        createMaskedStoreScratchMemory(fb, fb.getLoc(), readVisibilityPtr,
-                                       newVisibility, readVisibilityType,
-                                       waitingCTAMask);
+        if (transferReads) {
+          Value visibilityPtr = entryBlock->getArgument(nextArg++);
+          Value trackingPtr = entryBlock->getArgument(nextArg++);
+          Value visibility = tti::createLoadScratchMemory(
+              fb, fb.getLoc(), visibilityPtr, readVisibilityType);
+          Value tracking = tti::createLoadScratchMemory(
+              fb, fb.getLoc(), trackingPtr, readTrackingType);
+          Value barrierMask =
+              convertAndBroadcast(fb, barriersEqBar, {3}, readTrackingType);
+          Value barrierCTAMask =
+              createCTASetMask(fb, readTrackingType, /*dim=*/2, currentCTA);
+          barrierMask = arith::AndIOp::create(fb, barrierMask, barrierCTAMask);
+          Value zeroTracking =
+              tti::createConstIntTensor(fb, fb.getLoc(), 0, readTrackingType);
+          Value trackingBar =
+              arith::SelectOp::create(fb, barrierMask, tracking, zeroTracking);
+          trackingBar = reduce<arith::OrIOp>(fb, trackingBar, {2, 3});
+          trackingBar = convertAndBroadcast(fb, trackingBar, {0, 1, 4},
+                                            readVisibilityType);
+          Value visibilityOrTracking =
+              arith::OrIOp::create(fb, visibility, trackingBar);
+          Value threadColumnMask = createThreadColumnMask(
+              fb, threadMaskVal, readVisibilityType, /*columnDim=*/3);
+          Value waitingCTAMask =
+              createCTASetMask(fb, readVisibilityType, /*dim=*/2, currentCTA);
+          threadColumnMask =
+              arith::AndIOp::create(fb, threadColumnMask, waitingCTAMask);
+          Value updated = arith::SelectOp::create(
+              fb, threadColumnMask, visibilityOrTracking, visibility);
+          createMaskedStoreScratchMemory(fb, fb.getLoc(), visibilityPtr,
+                                         updated, readVisibilityType,
+                                         waitingCTAMask);
+        }
 
         fb.setInsertionPointToEnd(thenBlock);
         triton::ReturnOp::create(fb);

--- a/lib/Dialect/TritonInstrument/IR/FunctionBuilder.cpp
+++ b/lib/Dialect/TritonInstrument/IR/FunctionBuilder.cpp
@@ -2110,10 +2110,9 @@ void FunctionBuilder::createVerifyWriteVisibilityCall(
         bufferMask = arith::AndIOp::create(fb, bufferMask, relationMask);
         Value writeVisibilityZero =
             tti::createConstIntTensor(fb, fb.getLoc(), 0, writeVisibilityType);
-        Value bufVisibility = arith::SelectOp::create(
-            fb, bufferMask, writeVisibility, writeVisibilityZero);
         Value noOneIsWriting = arith::CmpIOp::create(
-            fb, arith::CmpIPredicate::eq, bufVisibility, writeVisibilityZero);
+            fb, arith::CmpIPredicate::eq, writeVisibility,
+            writeVisibilityZero);
         Value threadI64 =
             arith::ExtUIOp::create(fb, fb.getI64Type(), threadVal);
         Value threadMask =
@@ -2123,7 +2122,7 @@ void FunctionBuilder::createVerifyWriteVisibilityCall(
         Value bufferThreadBit =
             arith::ShLIOp::create(fb, bufferMaskExt, threadMask);
         Value bufferHasVisibility =
-            arith::AndIOp::create(fb, bufVisibility, bufferThreadBit);
+            arith::AndIOp::create(fb, writeVisibility, bufferThreadBit);
         bufferHasVisibility = arith::CmpIOp::create(
             fb, arith::CmpIPredicate::eq, bufferHasVisibility, bufferThreadBit);
         Value writeVisible =

--- a/lib/Dialect/TritonInstrument/IR/FunctionBuilder.cpp
+++ b/lib/Dialect/TritonInstrument/IR/FunctionBuilder.cpp
@@ -1586,10 +1586,7 @@ void FunctionBuilder::createSetReadVisibilityCall(
         Value relationMask =
             createLeadCTAEffectMask(fb, readVisibilityType, effectCTAs);
         Value threadCTAMask =
-            createCTASetMask(fb, readVisibilityType, /*dim=*/2, effectCTAs);
-        threadCTAMask = arith::AndIOp::create(
-            fb, threadCTAMask,
-            createCTASetMask(fb, readVisibilityType, /*dim=*/4, effectCTAs));
+            createCTASetMask(fb, readVisibilityType, /*dim=*/4, effectCTAs);
         Value sameCTA = arith::CmpIOp::create(
             fb, arith::CmpIPredicate::eq,
             createDimIndices(fb, readVisibilityType, /*dim=*/2),

--- a/lib/Dialect/TritonInstrument/IR/FunctionBuilder.cpp
+++ b/lib/Dialect/TritonInstrument/IR/FunctionBuilder.cpp
@@ -489,6 +489,9 @@ void FunctionBuilder::createFillGlobalTensorCall(ImplicitLocOpBuilder &b,
                                                  Value ptr,
                                                  RankedTensorType type,
                                                  Value scalar) {
+  type = tti::getIntTensorType(
+      b.getInsertionBlock()->getParent(), {type.getNumElements()},
+      type.getElementType().getIntOrFloatBitWidth());
   createCallToCachedFunction(
       b, "fill_global_tensor", {ptr, scalar}, /*assertInfo=*/std::nullopt,
       {type}, [type](ImplicitLocOpBuilder &fb, Block *entryBlock) {

--- a/lib/Dialect/TritonInstrument/IR/FunctionBuilder.cpp
+++ b/lib/Dialect/TritonInstrument/IR/FunctionBuilder.cpp
@@ -1643,7 +1643,6 @@ void FunctionBuilder::createTrackVisibleAccessesCall(
   };
   ManglingArgs specializationArgs;
   specializationArgs.append(barriersType);
-  specializationArgs.append(static_cast<uint64_t>(memType));
   specializationArgs.append(static_cast<uint64_t>(trackWrites));
   specializationArgs.append(static_cast<uint64_t>(trackReads));
 
@@ -1841,8 +1840,7 @@ void FunctionBuilder::createTrackBarrierWriteForBufferCall(
 static void createClearBarrierTrackingCall(ImplicitLocOpBuilder &b,
                                            StringRef functionName, Value mbar,
                                            Value pred, ValueType barriers,
-                                           ValueType tracking,
-                                           std::optional<MemType> memType) {
+                                           ValueType tracking) {
   if (!pred)
     pred = arith::ConstantIntOp::create(b, 1, 1);
   auto barriersType = cast<RankedTensorType>(barriers.type);
@@ -1852,8 +1850,6 @@ static void createClearBarrierTrackingCall(ImplicitLocOpBuilder &b,
       arith::ConstantIntOp::create(b, getMemDescLength(mbar), 32), pred,
       barriers.value, tracking.value};
   ManglingArgs specializationArgs{barriersType, trackingType};
-  if (memType)
-    specializationArgs.append(static_cast<uint64_t>(*memType));
   createCallToCachedFunction(
       b, functionName.str(), args, /*assertInfo=*/std::nullopt,
       specializationArgs,
@@ -1900,7 +1896,7 @@ void FunctionBuilder::createClearBarrierWriteTrackingCall(
   createClearBarrierTrackingCall(
       b, "clear_barrier_write_tracking", mbar, pred,
       auxData.barriers.at(insertPoint),
-      auxData.writeTracking[(int)memType].at(insertPoint), memType);
+      auxData.writeTracking[(int)memType].at(insertPoint));
 }
 
 void FunctionBuilder::createClearBarrierReadTrackingCall(
@@ -1913,7 +1909,7 @@ void FunctionBuilder::createClearBarrierReadTrackingCall(
   createClearBarrierTrackingCall(
       b, "clear_barrier_read_tracking", mbar, pred,
       auxData.barriers.at(insertPoint),
-      auxData.readTracking[(int)memType].at(insertPoint), memType);
+      auxData.readTracking[(int)memType].at(insertPoint));
 }
 
 void FunctionBuilder::createTransferVisibleAccessesCall(
@@ -1943,7 +1939,6 @@ void FunctionBuilder::createTransferVisibleAccessesCall(
   };
   ManglingArgs specializationArgs;
   specializationArgs.append(barriersType);
-  specializationArgs.append(static_cast<uint64_t>(memType));
   specializationArgs.append(static_cast<uint64_t>(transferWrites));
   specializationArgs.append(static_cast<uint64_t>(transferReads));
 
@@ -2385,8 +2380,7 @@ void FunctionBuilder::createPublishClusterVisibilityCall(
   createCallToCachedFunction(
       b, "publish_cluster_visibility", args,
       /*assertInfo=*/std::nullopt,
-      {writeVisibilityType, readVisibilityType, (uint64_t)memType,
-       (uint64_t)partitionScoped},
+      {writeVisibilityType, readVisibilityType, (uint64_t)partitionScoped},
       [writeVisibilityType, readVisibilityType,
        numBaseThreads = auxData.threadLayout.numBaseThreads,
        partitionScoped](ImplicitLocOpBuilder &fb, Block *entryBlock) {
@@ -2923,8 +2917,7 @@ void FunctionBuilder::createClearBarrierProxyAccessTrackingCall(
          "barrier descriptors must exist when clearing proxy tracking");
   createClearBarrierTrackingCall(b, "clear_barrier_proxy_tracking", mbar, pred,
                                  auxData.barriers.at(insertPoint),
-                                 auxData.proxyAccessTracking.at(insertPoint),
-                                 std::nullopt);
+                                 auxData.proxyAccessTracking.at(insertPoint));
 }
 
 void FunctionBuilder::createVerifyProxyAccessCall(ImplicitLocOpBuilder &b,

--- a/lib/Dialect/TritonInstrument/IR/FunctionBuilder.cpp
+++ b/lib/Dialect/TritonInstrument/IR/FunctionBuilder.cpp
@@ -1215,7 +1215,7 @@ void FunctionBuilder::createInvalidateBarrierStateCall(ImplicitLocOpBuilder &b,
       });
 }
 
-void FunctionBuilder::createVerifyBarrierArriveCall(
+void FunctionBuilder::createVerifyAndUpdateBarrierStateCall(
     ImplicitLocOpBuilder &b, Value mbar, int count, Value pred,
     Operation *insertPoint, Value recipientCTAs, int txCount) {
   assert(count >= 0 && (uint64_t)count <= BarrierBits::countMask &&
@@ -1249,7 +1249,7 @@ void FunctionBuilder::createVerifyBarrierArriveCall(
       "invalid",
       b.getI1Type()};
   createCallToCachedFunction(
-      b, "verify_barrier_arrive", args, assertInfo,
+      b, "verify_and_update_barrier_state", args, assertInfo,
       {barriersType, barrierStatesType},
       [barrierStatesType](ImplicitLocOpBuilder &fb, Block *entryBlock) {
         Value mbarOffset = entryBlock->getArgument(0);
@@ -1333,124 +1333,37 @@ void FunctionBuilder::createVerifyBarrierArriveCall(
         Value predicatedValid =
             arith::SelectOp::create(fb, predTensor, valid, vTrue);
 
-        triton::ReturnOp::create(fb,
-                                 reduceAll<arith::AndIOp>(fb, predicatedValid));
-      });
-}
-
-void FunctionBuilder::createUpdateBarrierStateCall(
-    ImplicitLocOpBuilder &b, Value mbar, int count, Value pred,
-    Operation *insertPoint, Value recipientCTAs, int txCount) {
-  assert(count >= 0 && (uint64_t)count <= BarrierBits::countMask &&
-         "barrier update count exceeds barrier state capacity");
-  assert(txCount >= BarrierBits::txCountMin &&
-         txCount <= BarrierBits::txCountMax &&
-         "barrier tx-count delta exceeds barrier state capacity");
-
-  if (auxData.barriers.empty() || auxData.barrierStates.empty()) {
-    return;
-  }
-  if (!pred) {
-    pred = arith::ConstantIntOp::create(b, 1, 1);
-  }
-  Value countVal = arith::ConstantIntOp::create(b, count, 32);
-  Value txCountVal = arith::ConstantIntOp::create(b, txCount, 64);
-  Value barriersVal = auxData.barriers.at(insertPoint).value;
-  auto barriersType =
-      cast<RankedTensorType>(auxData.barriers.at(insertPoint).type);
-  Value barrierStatesVal = auxData.barrierStates.at(insertPoint).value;
-  auto barrierStatesType =
-      cast<RankedTensorType>(auxData.barrierStates.at(insertPoint).type);
-  uint32_t length = getMemDescLength(mbar);
-  Value mbarOffset = tti::ExperimentalMemDescToI32Op::create(b, mbar);
-  Value lengthVal = arith::ConstantIntOp::create(b, length, 32);
-  SmallVector<Value> args = {mbarOffset,       lengthVal,    countVal,
-                             txCountVal,       pred,         barriersVal,
-                             barrierStatesVal, recipientCTAs};
-  createCallToCachedFunction(
-      b, "update_barrier_state", args,
-      /*assertInfo=*/std::nullopt, {barriersType, barrierStatesType},
-      [barrierStatesType](ImplicitLocOpBuilder &fb, Block *entryBlock) {
-        Value mbarOffset = entryBlock->getArgument(0);
-        Value lengthVal = entryBlock->getArgument(1);
-        Value count = entryBlock->getArgument(2);
-        Value txCount = entryBlock->getArgument(3);
-        Value pred = entryBlock->getArgument(4);
-
-        Value barriers = entryBlock->getArgument(5);
-        Value statesPtr = entryBlock->getArgument(6);
-        Value recipientCTAs = entryBlock->getArgument(7);
-
-        auto [prevBlock, ifBlock, thenBlock] = createIfBlock(fb, pred);
+        Value allValid = reduceAll<arith::AndIOp>(fb, predicatedValid);
+        Value shouldUpdate = arith::AndIOp::create(fb, pred, allValid);
+        auto [prevBlock, ifBlock, thenBlock] = createIfBlock(fb, shouldUpdate);
         fb.setInsertionPointToStart(ifBlock);
 
-        Value states = tti::createLoadScratchMemory(fb, fb.getLoc(), statesPtr,
-                                                    barrierStatesType);
-        Value descriptor = createBufferDescriptor(fb, mbarOffset, lengthVal);
-        Value mask = createCmpIntTensorScalar(fb, barriers, descriptor);
-        mask = convertAndBroadcast(fb, mask, {1}, barrierStatesType);
-
-        Value zero32 =
-            tti::createConstIntTensor(fb, fb.getLoc(), 0, barrierStatesType);
         Value one32 =
             tti::createConstIntTensor(fb, fb.getLoc(), 1, barrierStatesType);
-        Value maskFF = tti::createConstIntTensor(
-            fb, fb.getLoc(), BarrierBits::countMask, barrierStatesType);
         Value shiftInitTensor = tti::createConstIntTensor(
             fb, fb.getLoc(), BarrierBits::initCountLsb, barrierStatesType);
-        Value shiftCurrentTensor = tti::createConstIntTensor(
-            fb, fb.getLoc(), BarrierBits::currentCountLsb, barrierStatesType);
-        Value shiftTxTensor = tti::createConstIntTensor(
-            fb, fb.getLoc(), BarrierBits::txCountLsb, barrierStatesType);
-        Value shiftTxSignTensor = tti::createConstIntTensor(
-            fb, fb.getLoc(), 64 - BarrierBits::txCountBitWidth,
-            barrierStatesType);
-
         Value phase = arith::AndIOp::create(fb, states, one32);
         Value initCount = arith::ShRUIOp::create(fb, states, shiftInitTensor);
         initCount = arith::AndIOp::create(fb, initCount, maskFF);
-        Value currentCount =
-            arith::ShRUIOp::create(fb, states, shiftCurrentTensor);
-        currentCount = arith::AndIOp::create(fb, currentCount, maskFF);
-        Value currentTxCount =
-            arith::ShRUIOp::create(fb, states, shiftTxTensor);
-        currentTxCount =
-            arith::ShLIOp::create(fb, currentTxCount, shiftTxSignTensor);
-        currentTxCount =
-            arith::ShRSIOp::create(fb, currentTxCount, shiftTxSignTensor);
-
-        Value countMask =
-            arith::ConstantIntOp::create(fb, BarrierBits::countMask, 64);
-        Value countWide = adjustIntegerWidth(
-            fb, count, cast<IntegerType>(barrierStatesType.getElementType()));
-        Value maskedCount = arith::AndIOp::create(fb, countWide, countMask);
-        Value arriveCount =
-            triton::SplatOp::create(fb, barrierStatesType, maskedCount);
-        Value txCountTensor =
-            triton::SplatOp::create(fb, barrierStatesType, txCount);
-
-        Value newCurrent = arith::SubIOp::create(fb, currentCount, arriveCount);
-        Value newCurrentMasked =
+        Value updatedCurrent =
             arith::SelectOp::create(fb, mask, newCurrent, currentCount);
-        Value newTxCount =
-            arith::AddIOp::create(fb, currentTxCount, txCountTensor);
-        Value newTxCountMasked =
+        Value updatedTxCount =
             arith::SelectOp::create(fb, mask, newTxCount, currentTxCount);
 
         Value zeroCond = arith::AndIOp::create(
             fb,
-            arith::CmpIOp::create(fb, arith::CmpIPredicate::eq,
-                                  newCurrentMasked, zero32),
-            arith::CmpIOp::create(fb, arith::CmpIPredicate::eq,
-                                  newTxCountMasked, zero32));
+            arith::CmpIOp::create(fb, arith::CmpIPredicate::eq, updatedCurrent,
+                                  zero32),
+            arith::CmpIOp::create(fb, arith::CmpIPredicate::eq, updatedTxCount,
+                                  zero32));
         zeroCond = arith::AndIOp::create(fb, zeroCond, mask);
         Value zeroCondI32 =
             arith::ExtUIOp::create(fb, barrierStatesType, zeroCond);
         Value newPhase = arith::XOrIOp::create(fb, phase, zeroCondI32);
         Value newCurrentValue =
-            arith::SelectOp::create(fb, zeroCond, initCount, newCurrentMasked);
+            arith::SelectOp::create(fb, zeroCond, initCount, updatedCurrent);
         Value newTxCountValue =
-            arith::SelectOp::create(fb, zeroCond, zero32, newTxCountMasked);
+            arith::SelectOp::create(fb, zeroCond, zero32, updatedTxCount);
 
         Value initField = arith::ShLIOp::create(fb, initCount, shiftInitTensor);
         Value currentField =
@@ -1469,7 +1382,7 @@ void FunctionBuilder::createUpdateBarrierStateCall(
                                           barrierStatesType, recipientCTAs);
 
         fb.setInsertionPointToEnd(thenBlock);
-        triton::ReturnOp::create(fb);
+        triton::ReturnOp::create(fb, allValid);
       });
 }
 

--- a/lib/Dialect/TritonInstrument/Transforms/ConcurrencySanitizer.cpp
+++ b/lib/Dialect/TritonInstrument/Transforms/ConcurrencySanitizer.cpp
@@ -1072,9 +1072,7 @@ private:
         // If the op has barriers, we treat it as a commit emitted for each
         // barrier.
         for (MemType memType : {MemType::SHARED_MEM, MemType::TENSOR_MEM}) {
-          funcBuilder.createTrackVisibleWritesCall(
-              b, barrier, thread, combinedPred, memType, op, recipientCTAs);
-          funcBuilder.createTrackVisibleReadsCall(
+          funcBuilder.createTrackVisibleAccessesCall(
               b, barrier, thread, combinedPred, memType, op, recipientCTAs);
         }
         funcBuilder.createTrackProxyAccessesCall(

--- a/lib/Dialect/TritonInstrument/Transforms/ConcurrencySanitizer.cpp
+++ b/lib/Dialect/TritonInstrument/Transforms/ConcurrencySanitizer.cpp
@@ -1057,8 +1057,9 @@ private:
       Value barrier = barrierInfo.barrier;
       Value combinedPred = tti::maybeAnd(b, barrierInfo.pred, pred);
       Value recipientCTAs = getBarrierRecipientCTAs(b, op);
-      funcBuilder.createVerifyBarrierInitializedCall(b, barrier, combinedPred,
-                                                     op, recipientCTAs);
+      if (barrierInfo.count == 0 && barrierInfo.txCount == 0)
+        funcBuilder.createVerifyBarrierInitializedCall(b, barrier, combinedPred,
+                                                       op, recipientCTAs);
       if (barrierInfo.trackingMode ==
           MemEffectsOpInfo::BarrierTrackingMode::Frontier) {
         // If the op has barriers, we treat it as a commit emitted for each

--- a/lib/Dialect/TritonInstrument/Transforms/ConcurrencySanitizer.cpp
+++ b/lib/Dialect/TritonInstrument/Transforms/ConcurrencySanitizer.cpp
@@ -950,8 +950,7 @@ private:
           wb, alloc, getThreadPeersMask(thread, auxData.threadLayout), pred,
           memType, op);
     }
-    funcBuilder.createCompleteBarrierWaitCall(wb, alloc, baseThread, pred,
-                                              op);
+    funcBuilder.createCompleteBarrierWaitCall(wb, alloc, baseThread, pred, op);
     tti::ExperimentalLockReleaseOp::create(wb, lock, pred);
   }
 
@@ -1040,9 +1039,8 @@ private:
                       effect.operandName, effectCTAs, opInfo->commitKind);
         if (opInfo->trackingKind == MemEffectsOpInfo::TrackingKind::Barrier) {
           funcBuilder.createPublishWriteVisibilityCall(
-              b, bufferMask,
-              getThreadPeersMask(thread, auxData.threadLayout), pred, memType,
-              op, effectCTAs);
+              b, bufferMask, getThreadPeersMask(thread, auxData.threadLayout),
+              pred, memType, op, effectCTAs);
         }
         if (opInfo->trackingKind ==
             MemEffectsOpInfo::TrackingKind::CommitCount) {

--- a/lib/Dialect/TritonInstrument/Transforms/ConcurrencySanitizer.cpp
+++ b/lib/Dialect/TritonInstrument/Transforms/ConcurrencySanitizer.cpp
@@ -1043,15 +1043,10 @@ private:
         addReadChecks(b, funcBuilder, op, bufferMask, pred, memType, thread,
                       effect.operandName, effectCTAs, opInfo->commitKind);
         if (opInfo->trackingKind == MemEffectsOpInfo::TrackingKind::Barrier) {
-          funcBuilder.createSetWriteVisibilityCall(
-              b, bufferMask, getThreadPeersMask(thread, auxData.threadLayout),
-              pred, memType, op, effectCTAs);
-          funcBuilder.createClearWriteTrackingCall(b, bufferMask, pred, memType,
-                                                   op, effectCTAs);
-          funcBuilder.createClearReadVisibilityCall(b, bufferMask, pred,
-                                                    memType, op, effectCTAs);
-          funcBuilder.createClearReadTrackingCall(b, bufferMask, pred, memType,
-                                                  op, effectCTAs);
+          funcBuilder.createPublishWriteVisibilityCall(
+              b, bufferMask,
+              getThreadPeersMask(thread, auxData.threadLayout), pred, memType,
+              op, effectCTAs);
         }
         if (opInfo->trackingKind ==
             MemEffectsOpInfo::TrackingKind::CommitCount) {

--- a/lib/Dialect/TritonInstrument/Transforms/ConcurrencySanitizer.cpp
+++ b/lib/Dialect/TritonInstrument/Transforms/ConcurrencySanitizer.cpp
@@ -950,9 +950,8 @@ private:
           wb, alloc, getThreadPeersMask(thread, auxData.threadLayout), pred,
           memType, op);
     }
-    funcBuilder.createTransferProxyAccessesCall(wb, alloc, baseThread, pred,
-                                                op);
-    funcBuilder.createClearWaitingCall(wb, alloc, baseThread, pred, op);
+    funcBuilder.createCompleteBarrierWaitCall(wb, alloc, baseThread, pred,
+                                              op);
     tti::ExperimentalLockReleaseOp::create(wb, lock, pred);
   }
 

--- a/lib/Dialect/TritonInstrument/Transforms/ConcurrencySanitizer.cpp
+++ b/lib/Dialect/TritonInstrument/Transforms/ConcurrencySanitizer.cpp
@@ -946,10 +946,7 @@ private:
     wb.setInsertionPointAfter(op);
     tti::ExperimentalLockAcquireOp::create(wb, lock, pred);
     for (MemType memType : {MemType::SHARED_MEM, MemType::TENSOR_MEM}) {
-      funcBuilder.createTransferVisibleWritesCall(
-          wb, alloc, getThreadPeersMask(thread, auxData.threadLayout), pred,
-          memType, op);
-      funcBuilder.createTransferVisibleReadsCall(
+      funcBuilder.createTransferVisibleAccessesCall(
           wb, alloc, getThreadPeersMask(thread, auxData.threadLayout), pred,
           memType, op);
     }

--- a/lib/Dialect/TritonInstrument/Transforms/ConcurrencySanitizer.cpp
+++ b/lib/Dialect/TritonInstrument/Transforms/ConcurrencySanitizer.cpp
@@ -1097,10 +1097,7 @@ private:
         }
       }
       if (barrierInfo.count > 0 || barrierInfo.txCount != 0) {
-        funcBuilder.createVerifyBarrierArriveCall(
-            b, barrier, barrierInfo.count, combinedPred, op, recipientCTAs,
-            barrierInfo.txCount);
-        funcBuilder.createUpdateBarrierStateCall(
+        funcBuilder.createVerifyAndUpdateBarrierStateCall(
             b, barrier, barrierInfo.count, combinedPred, op, recipientCTAs,
             barrierInfo.txCount);
       }

--- a/test/Conversion/tritoninstrument_to_llvm.mlir
+++ b/test/Conversion/tritoninstrument_to_llvm.mlir
@@ -32,6 +32,25 @@ tt.func private @experimental_buffer_descriptors_shared() {
 
 // -----
 
+module attributes {"ttg.num-warps" = 4 : i32, ttg.target = "cuda:90"} {
+// CHECK-LABEL: @experimental_assert_uniform(
+// CHECK: %[[RAW_TID:.*]] = nvvm.read.ptx.sreg.tid.x
+// CHECK: %[[TID:.*]] = llvm.and %[[RAW_TID]], %{{.*}} : i32
+// CHECK: %[[ZERO:.*]] = llvm.mlir.constant(0 : i32)
+// CHECK: %[[NOT_THREAD_ZERO:.*]] = llvm.icmp "ne" %[[TID]], %[[ZERO]] : i32
+// CHECK: %[[CONDITION:.*]] = llvm.or %[[NOT_THREAD_ZERO]], %arg0 : i1
+// CHECK: llvm.cond_br
+// CHECK: llvm.call @__assertfail
+// CHECK-NOT: llvm.cond_br
+// CHECK: llvm.return
+tt.func private @experimental_assert_uniform(%arg0: i1) {
+  tti.experimental_assert_uniform %arg0, "uniform assertion"
+  tt.return
+}
+}
+
+// -----
+
 #blocked = #ttg.blocked<{sizePerThread = [2], threadsPerWarp = [32], warpsPerCTA = [4], order = [0]}>
 #shared = #ttg.nvmma_shared<{swizzlingByteWidth = 128, transposed = false, elementBitWidth = 32}>
 #smem = #ttg.shared_memory

--- a/test/TritonGPU/amd/amd-consan.mlir
+++ b/test/TritonGPU/amd/amd-consan.mlir
@@ -907,6 +907,15 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.shar
 #smem = #ttg.shared_memory
 
 module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.shared = 65544 : i32, ttg.target = "hip:gfx1250", "ttg.threads-per-warp" = 32 : i32, "ttg.total-num-warps" = 8 : i32} {
+  // CHECK: tt.func private @__triton_consan_check_all_active_waiting
+  // CHECK: %[[DEADLOCK_WAITING_BITS:.*]] = arith.extui {{.*}} : tensor<{{.*}}xi1{{.*}}> to tensor<{{.*}}xi32
+  // CHECK: %[[DEADLOCK_IDLE_BITS:.*]] = arith.extui {{.*}} : tensor<{{.*}}xi1{{.*}}> to tensor<{{.*}}xi32
+  // CHECK: %[[DEADLOCK_SHIFTED_IDLE_BITS:.*]] = arith.shli %[[DEADLOCK_IDLE_BITS]]
+  // CHECK: %[[DEADLOCK_BITS:.*]] = arith.ori %[[DEADLOCK_WAITING_BITS]], %[[DEADLOCK_SHIFTED_IDLE_BITS]]
+  // CHECK: %[[DEADLOCK_STATUS:.*]] = "tt.reduce"(%[[DEADLOCK_BITS]]) <{axis = 0 : i32}>
+  // CHECK: arith.andi {{.*}} : i32
+  // CHECK-NOT: "tt.reduce"
+  // CHECK: arith.cmpi eq, %[[DEADLOCK_STATUS]], {{.*}} : i32
   // CHECK-LABEL: @ws_wait_barrier
   tt.func public @ws_wait_barrier() {
     %smem = ttg.local_alloc {allocation.offset = 0 : i32} : () -> !ttg.memdesc<128x128xf16, #shared, #smem, mutable>

--- a/test/TritonGPU/amd/amd-consan.mlir
+++ b/test/TritonGPU/amd/amd-consan.mlir
@@ -466,10 +466,7 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 8 : i32, ttg.shar
     // CHECK: tt.call @__triton_consan_init_barrier_state
     // CHECK: tt.call @__triton_consan_verify_write_visibility
     // CHECK: tt.call @__triton_consan_verify_read_visibility
-    // CHECK: tt.call @__triton_consan_set_write_visibility
-    // CHECK: tt.call @__triton_consan_clear_write_tracking
-    // CHECK: tt.call @__triton_consan_clear_read_visibility
-    // CHECK: tt.call @__triton_consan_clear_read_tracking
+    // CHECK: tt.call @__triton_consan_publish_write_visibility
     // CHECK: tt.call @__triton_consan_verify_barrier_initialized
     // CHECK: tt.call @__triton_consan_track_visible_accesses
     // CHECK: tt.call @__triton_consan_verify_and_update_barrier_state
@@ -503,10 +500,7 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 8 : i32, ttg.shar
     // First TDM copy: full effects + barrier instrumentation
     // CHECK: tt.call @__triton_consan_verify_write_visibility
     // CHECK: tt.call @__triton_consan_verify_read_visibility
-    // CHECK: tt.call @__triton_consan_set_write_visibility
-    // CHECK: tt.call @__triton_consan_clear_write_tracking
-    // CHECK: tt.call @__triton_consan_clear_read_visibility
-    // CHECK: tt.call @__triton_consan_clear_read_tracking
+    // CHECK: tt.call @__triton_consan_publish_write_visibility
     // CHECK: tt.call @__triton_consan_verify_barrier_initialized
     // CHECK: tt.call @__triton_consan_track_visible_accesses
     // CHECK: tt.call @__triton_consan_verify_and_update_barrier_state
@@ -516,10 +510,7 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 8 : i32, ttg.shar
     // Second TDM copy: same full instrumentation
     // CHECK: tt.call @__triton_consan_verify_write_visibility
     // CHECK: tt.call @__triton_consan_verify_read_visibility
-    // CHECK: tt.call @__triton_consan_set_write_visibility
-    // CHECK: tt.call @__triton_consan_clear_write_tracking
-    // CHECK: tt.call @__triton_consan_clear_read_visibility
-    // CHECK: tt.call @__triton_consan_clear_read_tracking
+    // CHECK: tt.call @__triton_consan_publish_write_visibility
     // CHECK: tt.call @__triton_consan_verify_barrier_initialized
     // CHECK: tt.call @__triton_consan_track_visible_accesses
     // CHECK: tt.call @__triton_consan_verify_and_update_barrier_state

--- a/test/TritonGPU/amd/amd-consan.mlir
+++ b/test/TritonGPU/amd/amd-consan.mlir
@@ -383,6 +383,15 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 1 : i32, ttg.shar
 #smem = #ttg.shared_memory
 #blocked = #ttg.blocked<{sizePerThread = [1, 8], threadsPerWarp = [8, 4], warpsPerCTA = [1, 1], order = [1, 0]}>
 module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 1 : i32, ttg.shared = 65544 : i32, ttg.target = "hip:gfx1250", "ttg.threads-per-warp" = 32 : i32, "ttg.total-num-warps" = 1 : i32} {
+  // CHECK: tt.func private @__triton_consan_verify_and_update_barrier_state
+  // CHECK: %[[BARRIER_INIT_BITS:.*]] = arith.extui {{.*}} : tensor<{{.*}}xi1{{.*}}> to tensor<{{.*}}xi32
+  // CHECK: %[[BARRIER_VALID_BITS:.*]] = arith.extui {{.*}} : tensor<{{.*}}xi1{{.*}}> to tensor<{{.*}}xi32
+  // CHECK: %[[BARRIER_SHIFTED_VALID_BITS:.*]] = arith.shli %[[BARRIER_VALID_BITS]]
+  // CHECK: %[[BARRIER_STATUS_BITS:.*]] = arith.ori %[[BARRIER_INIT_BITS]], %[[BARRIER_SHIFTED_VALID_BITS]]
+  // CHECK: %[[BARRIER_PACKED_STATUS:.*]] = "tt.reduce"(%{{.*}}) <{axis = 0 : i32}>
+  // CHECK: arith.andi {{.*}} : i32
+  // CHECK-NOT: "tt.reduce"
+  // CHECK: tt.return %[[BARRIER_PACKED_STATUS]] : i32
   // CHECK-LABEL: @amdg_arrive_barrier
   tt.func public @amdg_arrive_barrier() {
     // CHECK-DAG: %[[BSTATE_GLOB:.*]] = ttg.global_scratch_alloc {alignment = 16 : i32, nbytes = 4 : i32, shared_cluster_state, third_party_allocation, tt.divisibility = 16 : i64} : !tt.ptr<i32>

--- a/test/TritonGPU/amd/amd-consan.mlir
+++ b/test/TritonGPU/amd/amd-consan.mlir
@@ -5,7 +5,7 @@
 #smem = #ttg.shared_memory
 #blocked = #ttg.blocked<{sizePerThread = [1, 8], threadsPerWarp = [8, 4], warpsPerCTA = [1, 1], order = [1, 0]}>
 module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 1 : i32, ttg.shared = 65544 : i32, ttg.target = "hip:gfx1250", "ttg.threads-per-warp" = 32 : i32, "ttg.total-num-warps" = 1 : i32} {
-  // CHECK-LABEL: tt.func private @__triton_consan_verify_write_visibility_noalias
+  // CHECK-LABEL: tt.func private @__triton_consan_verify_write_visibility_
   // CHECK: %[[WRITE_VISIBILITY:.*]] = tt.load
   // CHECK: arith.cmpi eq, %[[WRITE_VISIBILITY]],
   // CHECK: %[[SELECTED_THREAD_BIT:.*]] = arith.shli
@@ -1217,13 +1217,17 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.shar
     %buffer = ttg.local_alloc {allocation.offset = 0 : i32} : () -> !ttg.memdesc<256x128xf16, #shared, #smem, mutable>
     %barrier = ttg.local_alloc {allocation.offset = 65536 : i32} : () -> !ttg.memdesc<1xi64, #barrier_shared, #smem, mutable>
     amdg.init_barrier %barrier, 8 : !ttg.memdesc<1xi64, #barrier_shared, #smem, mutable>
-    // CHECK: tt.call @__triton_consan_verify_barrier_arrive
-    // CHECK: tt.call @__triton_consan_update_barrier_state
+    // CHECK: tt.call @__triton_consan_verify_and_update_barrier_state
+    // CHECK: tti.experimental_assert_uniform {{.*}}, "Barrier used before initialization or after invalidation"
+    // CHECK: tti.experimental_assert_uniform {{.*}}, "Barrier arrive underflow: current count or tx-count would become invalid"
+    // CHECK-NOT: tt.call @__triton_consan_update_barrier_state
     // CHECK-NOT: tt.call @__triton_consan_commit_accesses
     // CHECK: amdg.async_tdm_gather
     %gather = amdg.async_tdm_gather %desc[%rows] to %buffer, barrier = %barrier : tensor<64xi32, #ttg.slice<{dim = 0, parent = #idx_parent}>>, !ttg.memdesc<256x128xf16, #shared, #smem, mutable>, !ttg.memdesc<1xi64, #barrier_shared, #smem, mutable> -> !tt.tensordesc<64x128xf16>
-    // CHECK: tt.call @__triton_consan_verify_barrier_arrive
-    // CHECK: tt.call @__triton_consan_update_barrier_state
+    // CHECK: tt.call @__triton_consan_verify_and_update_barrier_state
+    // CHECK: tti.experimental_assert_uniform {{.*}}, "Barrier used before initialization or after invalidation"
+    // CHECK: tti.experimental_assert_uniform {{.*}}, "Barrier arrive underflow: current count or tx-count would become invalid"
+    // CHECK-NOT: tt.call @__triton_consan_update_barrier_state
     // CHECK-NOT: tt.call @__triton_consan_commit_accesses
     // CHECK: amdg.async_tdm_scatter
     %scatter = amdg.async_tdm_scatter %desc[%rows] from %buffer, barrier = %barrier : tensor<64xi32, #ttg.slice<{dim = 0, parent = #idx_parent}>>, !ttg.memdesc<256x128xf16, #shared, #smem, mutable>, !ttg.memdesc<1xi64, #barrier_shared, #smem, mutable> -> !tt.tensordesc<64x128xf16>

--- a/test/TritonGPU/amd/amd-consan.mlir
+++ b/test/TritonGPU/amd/amd-consan.mlir
@@ -368,8 +368,7 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 1 : i32, ttg.shar
     // CHECK: amdg.wait_barrier
     amdg.wait_barrier %bar, %c0_i32 : !ttg.memdesc<1xi64, #shared1, #smem, mutable>
     // CHECK: tti.experimental_lock_acquire
-    // CHECK: tt.call @__triton_consan_transfer_visible_writes{{.*}}%[[BARRIERS]], %[[WRITE_VISIBILITY_GLOB]], %[[WRITE_TRACKING_GLOB]]
-    // CHECK: tt.call @__triton_consan_transfer_visible_reads{{.*}}%[[BARRIERS]], %[[READ_VISIBILITY_GLOB]], %[[READ_TRACKING_GLOB]]
+    // CHECK: tt.call @__triton_consan_transfer_visible_accesses{{.*}}%[[BARRIERS]], %[[WRITE_VISIBILITY_GLOB]], %[[WRITE_TRACKING_GLOB]], %[[READ_VISIBILITY_GLOB]], %[[READ_TRACKING_GLOB]]) : {{.*}}!tt.ptr<i64>, !tt.ptr<i8>, !tt.ptr<i64>, !tt.ptr<i64>) -> ()
     // CHECK: tt.call @__triton_consan_clear_waiting
     // CHECK: tti.experimental_lock_release
     ttg.local_load %0 : !ttg.memdesc<32x32xf32, #shared, #smem, mutable> -> tensor<32x32xf32, #blocked>

--- a/test/TritonGPU/amd/amd-consan.mlir
+++ b/test/TritonGPU/amd/amd-consan.mlir
@@ -5,6 +5,12 @@
 #smem = #ttg.shared_memory
 #blocked = #ttg.blocked<{sizePerThread = [1, 8], threadsPerWarp = [8, 4], warpsPerCTA = [1, 1], order = [1, 0]}>
 module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 1 : i32, ttg.shared = 65544 : i32, ttg.target = "hip:gfx1250", "ttg.threads-per-warp" = 32 : i32, "ttg.total-num-warps" = 1 : i32} {
+  // CHECK-LABEL: tt.func private @__triton_consan_verify_write_visibility_noalias
+  // CHECK: %[[WRITE_VISIBILITY:.*]] = tt.load
+  // CHECK: arith.cmpi eq, %[[WRITE_VISIBILITY]],
+  // CHECK: %[[SELECTED_THREAD_BIT:.*]] = arith.shli
+  // CHECK: %[[VISIBLE_THREAD_BITS:.*]] = arith.andi %[[WRITE_VISIBILITY]], %[[SELECTED_THREAD_BIT]]
+  // CHECK: arith.cmpi eq, %[[VISIBLE_THREAD_BITS]], %[[SELECTED_THREAD_BIT]]
   // CHECK-LABEL: @single_local_alloc
   tt.func public @single_local_alloc() {
     // CHECK: %[[WRITE_VISIBILITY_GLOB:.*]] = ttg.global_scratch_alloc {alignment = 16 : i32, nbytes = 8 : i32, shared_cluster_state, third_party_allocation, tt.divisibility = 16 : i64} : !tt.ptr<i64>

--- a/test/TritonGPU/amd/amd-consan.mlir
+++ b/test/TritonGPU/amd/amd-consan.mlir
@@ -397,8 +397,8 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 1 : i32, ttg.shar
     // CHECK: tt.call @__triton_consan_verify_barrier_initialized
     // CHECK: tt.call @__triton_consan_track_visible_writes
     // CHECK: tt.call @__triton_consan_track_visible_reads
-    // CHECK: tt.call @__triton_consan_verify_barrier_arrive
-    // CHECK: tt.call @__triton_consan_update_barrier_state
+    // CHECK: tt.call @__triton_consan_verify_and_update_barrier_state
+    // CHECK-NOT: tt.call @__triton_consan_update_barrier_state
     // CHECK: tti.experimental_lock_release
     %phase = amdg.arrive_barrier %bar, 1 : !ttg.memdesc<1xi64, #shared1, #smem, mutable> -> i32
     ttg.local_load %0 : !ttg.memdesc<32x32xf32, #shared, #smem, mutable> -> tensor<32x32xf32, #blocked>
@@ -431,8 +431,8 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 1 : i32, ttg.shar
   tt.func public @amdg_arrive_barrier_without_init() {
     %bar = ttg.local_alloc {allocation.offset = 65536 : i32} : () -> !ttg.memdesc<1xi64, #shared1, #smem, mutable>
     // CHECK: tt.call @__triton_consan_verify_barrier_initialized
-    // CHECK: tt.call @__triton_consan_verify_barrier_arrive
-    // CHECK: tt.call @__triton_consan_update_barrier_state
+    // CHECK: tt.call @__triton_consan_verify_and_update_barrier_state
+    // CHECK-NOT: tt.call @__triton_consan_update_barrier_state
     %phase = amdg.arrive_barrier %bar, 1 : !ttg.memdesc<1xi64, #shared1, #smem, mutable> -> i32
     tt.return
   }
@@ -473,8 +473,8 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 8 : i32, ttg.shar
     // CHECK: tt.call @__triton_consan_clear_read_tracking
     // CHECK: tt.call @__triton_consan_verify_barrier_initialized
     // CHECK: tt.call @__triton_consan_track_visible_writes
-    // CHECK: tt.call @__triton_consan_verify_barrier_arrive
-    // CHECK: tt.call @__triton_consan_update_barrier_state
+    // CHECK: tt.call @__triton_consan_verify_and_update_barrier_state
+    // CHECK-NOT: tt.call @__triton_consan_update_barrier_state
     %1 = amdg.async_tdm_copy_global_to_local %desc into %0, barrier = %bar : !tt.tensordesc<32x32xf32>, !ttg.memdesc<1xi64, #shared1, #smem, mutable> -> !ttg.memdesc<32x32xf32, #shared, #smem, mutable>
     tt.return
   }
@@ -510,8 +510,8 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 8 : i32, ttg.shar
     // CHECK: tt.call @__triton_consan_clear_read_tracking
     // CHECK: tt.call @__triton_consan_verify_barrier_initialized
     // CHECK: tt.call @__triton_consan_track_visible_writes
-    // CHECK: tt.call @__triton_consan_verify_barrier_arrive
-    // CHECK: tt.call @__triton_consan_update_barrier_state
+    // CHECK: tt.call @__triton_consan_verify_and_update_barrier_state
+    // CHECK-NOT: tt.call @__triton_consan_update_barrier_state
     %0 = amdg.async_tdm_copy_global_to_local %a into %a_smem, barrier = %bar : !tt.tensordesc<32x32xf32>, !ttg.memdesc<1xi64, #shared1, #smem, mutable> -> !ttg.memdesc<32x32xf32, #shared, #smem, mutable>
 
     // Second TDM copy: same full instrumentation
@@ -523,8 +523,8 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 8 : i32, ttg.shar
     // CHECK: tt.call @__triton_consan_clear_read_tracking
     // CHECK: tt.call @__triton_consan_verify_barrier_initialized
     // CHECK: tt.call @__triton_consan_track_visible_writes
-    // CHECK: tt.call @__triton_consan_verify_barrier_arrive
-    // CHECK: tt.call @__triton_consan_update_barrier_state
+    // CHECK: tt.call @__triton_consan_verify_and_update_barrier_state
+    // CHECK-NOT: tt.call @__triton_consan_update_barrier_state
     %1 = amdg.async_tdm_copy_global_to_local %b into %b_smem, barrier = %bar : !tt.tensordesc<32x32xf32>, !ttg.memdesc<1xi64, #shared1, #smem, mutable> -> !ttg.memdesc<32x32xf32, #shared, #smem, mutable>
 
     %c0_phase = arith.constant 0 : i32
@@ -553,7 +553,7 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 8 : i32, ttg.shar
     // CHECK: tt.call @__triton_consan_check_outstanding_commits_excl_self
     // CHECK: tt.call @__triton_consan_stage_access_for_commit
     // CHECK: tt.call @__triton_consan_commit_accesses
-    // CHECK-NOT: tt.call @__triton_consan_verify_barrier_arrive
+    // CHECK-NOT: tt.call @__triton_consan_verify_and_update_barrier_state
     %1 = amdg.async_tdm_copy_global_to_local %desc into %0 : !tt.tensordesc<32x32xf32> -> !ttg.memdesc<32x32xf32, #shared, #smem, mutable>
     tt.return
   }
@@ -624,8 +624,8 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 8 : i32, ttg.shar
     // CHECK: tt.call @__triton_consan_verify_barrier_initialized
     // CHECK: tt.call @__triton_consan_track_visible_writes
     // CHECK: tt.call @__triton_consan_track_visible_reads
-    // CHECK: tt.call @__triton_consan_verify_barrier_arrive
-    // CHECK: tt.call @__triton_consan_update_barrier_state
+    // CHECK: tt.call @__triton_consan_verify_and_update_barrier_state
+    // CHECK-NOT: tt.call @__triton_consan_update_barrier_state
     // CHECK-NOT: tt.call @__triton_consan_stage_access_for_commit
     amdg.async_tdm_copy_local_to_global %desc from %0, barrier = %bar : !ttg.memdesc<32x32xf32, #shared, #smem, mutable>, !ttg.memdesc<1xi64, #shared1, #smem, mutable> -> !tt.tensordesc<32x32xf32>
     tt.return

--- a/test/TritonGPU/amd/amd-consan.mlir
+++ b/test/TritonGPU/amd/amd-consan.mlir
@@ -395,8 +395,7 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 1 : i32, ttg.shar
     // CHECK: tt.call @__triton_consan_init_barrier_state
     // CHECK: tti.experimental_lock_acquire
     // CHECK: tt.call @__triton_consan_verify_barrier_initialized
-    // CHECK: tt.call @__triton_consan_track_visible_writes
-    // CHECK: tt.call @__triton_consan_track_visible_reads
+    // CHECK: tt.call @__triton_consan_track_visible_accesses
     // CHECK: tt.call @__triton_consan_verify_and_update_barrier_state
     // CHECK-NOT: tt.call @__triton_consan_update_barrier_state
     // CHECK: tti.experimental_lock_release
@@ -472,7 +471,7 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 8 : i32, ttg.shar
     // CHECK: tt.call @__triton_consan_clear_read_visibility
     // CHECK: tt.call @__triton_consan_clear_read_tracking
     // CHECK: tt.call @__triton_consan_verify_barrier_initialized
-    // CHECK: tt.call @__triton_consan_track_visible_writes
+    // CHECK: tt.call @__triton_consan_track_visible_accesses
     // CHECK: tt.call @__triton_consan_verify_and_update_barrier_state
     // CHECK-NOT: tt.call @__triton_consan_update_barrier_state
     %1 = amdg.async_tdm_copy_global_to_local %desc into %0, barrier = %bar : !tt.tensordesc<32x32xf32>, !ttg.memdesc<1xi64, #shared1, #smem, mutable> -> !ttg.memdesc<32x32xf32, #shared, #smem, mutable>
@@ -509,7 +508,7 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 8 : i32, ttg.shar
     // CHECK: tt.call @__triton_consan_clear_read_visibility
     // CHECK: tt.call @__triton_consan_clear_read_tracking
     // CHECK: tt.call @__triton_consan_verify_barrier_initialized
-    // CHECK: tt.call @__triton_consan_track_visible_writes
+    // CHECK: tt.call @__triton_consan_track_visible_accesses
     // CHECK: tt.call @__triton_consan_verify_and_update_barrier_state
     // CHECK-NOT: tt.call @__triton_consan_update_barrier_state
     %0 = amdg.async_tdm_copy_global_to_local %a into %a_smem, barrier = %bar : !tt.tensordesc<32x32xf32>, !ttg.memdesc<1xi64, #shared1, #smem, mutable> -> !ttg.memdesc<32x32xf32, #shared, #smem, mutable>
@@ -522,7 +521,7 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 8 : i32, ttg.shar
     // CHECK: tt.call @__triton_consan_clear_read_visibility
     // CHECK: tt.call @__triton_consan_clear_read_tracking
     // CHECK: tt.call @__triton_consan_verify_barrier_initialized
-    // CHECK: tt.call @__triton_consan_track_visible_writes
+    // CHECK: tt.call @__triton_consan_track_visible_accesses
     // CHECK: tt.call @__triton_consan_verify_and_update_barrier_state
     // CHECK-NOT: tt.call @__triton_consan_update_barrier_state
     %1 = amdg.async_tdm_copy_global_to_local %b into %b_smem, barrier = %bar : !tt.tensordesc<32x32xf32>, !ttg.memdesc<1xi64, #shared1, #smem, mutable> -> !ttg.memdesc<32x32xf32, #shared, #smem, mutable>
@@ -622,8 +621,7 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 8 : i32, ttg.shar
     // CHECK: tt.call @__triton_consan_verify_write_visibility
     // CHECK: tt.call @__triton_consan_set_read_visibility
     // CHECK: tt.call @__triton_consan_verify_barrier_initialized
-    // CHECK: tt.call @__triton_consan_track_visible_writes
-    // CHECK: tt.call @__triton_consan_track_visible_reads
+    // CHECK: tt.call @__triton_consan_track_visible_accesses
     // CHECK: tt.call @__triton_consan_verify_and_update_barrier_state
     // CHECK-NOT: tt.call @__triton_consan_update_barrier_state
     // CHECK-NOT: tt.call @__triton_consan_stage_access_for_commit

--- a/test/TritonGPU/amd/amd-consan.mlir
+++ b/test/TritonGPU/amd/amd-consan.mlir
@@ -393,9 +393,10 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 1 : i32, ttg.shar
     amdg.init_barrier %bar, 1 : !ttg.memdesc<1xi64, #shared1, #smem, mutable>
     // CHECK: tt.call @__triton_consan_init_barrier_state
     // CHECK: tti.experimental_lock_acquire
-    // CHECK: tt.call @__triton_consan_verify_barrier_initialized
     // CHECK: tt.call @__triton_consan_track_visible_accesses
     // CHECK: tt.call @__triton_consan_verify_and_update_barrier_state
+    // CHECK: tti.experimental_assert_uniform {{.*}}, "Barrier used before initialization or after invalidation"
+    // CHECK: tti.experimental_assert_uniform {{.*}}, "Barrier arrive underflow: current count or tx-count would become invalid"
     // CHECK-NOT: tt.call @__triton_consan_update_barrier_state
     // CHECK: tti.experimental_lock_release
     %phase = amdg.arrive_barrier %bar, 1 : !ttg.memdesc<1xi64, #shared1, #smem, mutable> -> i32
@@ -428,8 +429,9 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 1 : i32, ttg.shar
   // CHECK-LABEL: @amdg_arrive_barrier_without_init
   tt.func public @amdg_arrive_barrier_without_init() {
     %bar = ttg.local_alloc {allocation.offset = 65536 : i32} : () -> !ttg.memdesc<1xi64, #shared1, #smem, mutable>
-    // CHECK: tt.call @__triton_consan_verify_barrier_initialized
     // CHECK: tt.call @__triton_consan_verify_and_update_barrier_state
+    // CHECK: tti.experimental_assert_uniform {{.*}}, "Barrier used before initialization or after invalidation"
+    // CHECK: tti.experimental_assert_uniform {{.*}}, "Barrier arrive underflow: current count or tx-count would become invalid"
     // CHECK-NOT: tt.call @__triton_consan_update_barrier_state
     %phase = amdg.arrive_barrier %bar, 1 : !ttg.memdesc<1xi64, #shared1, #smem, mutable> -> i32
     tt.return
@@ -466,9 +468,10 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 8 : i32, ttg.shar
     // CHECK: tt.call @__triton_consan_verify_write_visibility
     // CHECK: tt.call @__triton_consan_verify_read_visibility
     // CHECK: tt.call @__triton_consan_publish_write_visibility
-    // CHECK: tt.call @__triton_consan_verify_barrier_initialized
     // CHECK: tt.call @__triton_consan_track_visible_accesses
     // CHECK: tt.call @__triton_consan_verify_and_update_barrier_state
+    // CHECK: tti.experimental_assert_uniform {{.*}}, "Barrier used before initialization or after invalidation"
+    // CHECK: tti.experimental_assert_uniform {{.*}}, "Barrier arrive underflow: current count or tx-count would become invalid"
     // CHECK-NOT: tt.call @__triton_consan_update_barrier_state
     %1 = amdg.async_tdm_copy_global_to_local %desc into %0, barrier = %bar : !tt.tensordesc<32x32xf32>, !ttg.memdesc<1xi64, #shared1, #smem, mutable> -> !ttg.memdesc<32x32xf32, #shared, #smem, mutable>
     tt.return
@@ -500,9 +503,10 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 8 : i32, ttg.shar
     // CHECK: tt.call @__triton_consan_verify_write_visibility
     // CHECK: tt.call @__triton_consan_verify_read_visibility
     // CHECK: tt.call @__triton_consan_publish_write_visibility
-    // CHECK: tt.call @__triton_consan_verify_barrier_initialized
     // CHECK: tt.call @__triton_consan_track_visible_accesses
     // CHECK: tt.call @__triton_consan_verify_and_update_barrier_state
+    // CHECK: tti.experimental_assert_uniform {{.*}}, "Barrier used before initialization or after invalidation"
+    // CHECK: tti.experimental_assert_uniform {{.*}}, "Barrier arrive underflow: current count or tx-count would become invalid"
     // CHECK-NOT: tt.call @__triton_consan_update_barrier_state
     %0 = amdg.async_tdm_copy_global_to_local %a into %a_smem, barrier = %bar : !tt.tensordesc<32x32xf32>, !ttg.memdesc<1xi64, #shared1, #smem, mutable> -> !ttg.memdesc<32x32xf32, #shared, #smem, mutable>
 
@@ -510,9 +514,10 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 8 : i32, ttg.shar
     // CHECK: tt.call @__triton_consan_verify_write_visibility
     // CHECK: tt.call @__triton_consan_verify_read_visibility
     // CHECK: tt.call @__triton_consan_publish_write_visibility
-    // CHECK: tt.call @__triton_consan_verify_barrier_initialized
     // CHECK: tt.call @__triton_consan_track_visible_accesses
     // CHECK: tt.call @__triton_consan_verify_and_update_barrier_state
+    // CHECK: tti.experimental_assert_uniform {{.*}}, "Barrier used before initialization or after invalidation"
+    // CHECK: tti.experimental_assert_uniform {{.*}}, "Barrier arrive underflow: current count or tx-count would become invalid"
     // CHECK-NOT: tt.call @__triton_consan_update_barrier_state
     %1 = amdg.async_tdm_copy_global_to_local %b into %b_smem, barrier = %bar : !tt.tensordesc<32x32xf32>, !ttg.memdesc<1xi64, #shared1, #smem, mutable> -> !ttg.memdesc<32x32xf32, #shared, #smem, mutable>
 
@@ -610,9 +615,10 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 8 : i32, ttg.shar
     // CHECK: tt.call @__triton_consan_init_barrier_state
     // CHECK: tt.call @__triton_consan_verify_write_visibility
     // CHECK: tt.call @__triton_consan_set_read_visibility
-    // CHECK: tt.call @__triton_consan_verify_barrier_initialized
     // CHECK: tt.call @__triton_consan_track_visible_accesses
     // CHECK: tt.call @__triton_consan_verify_and_update_barrier_state
+    // CHECK: tti.experimental_assert_uniform {{.*}}, "Barrier used before initialization or after invalidation"
+    // CHECK: tti.experimental_assert_uniform {{.*}}, "Barrier arrive underflow: current count or tx-count would become invalid"
     // CHECK-NOT: tt.call @__triton_consan_update_barrier_state
     // CHECK-NOT: tt.call @__triton_consan_stage_access_for_commit
     amdg.async_tdm_copy_local_to_global %desc from %0, barrier = %bar : !ttg.memdesc<32x32xf32, #shared, #smem, mutable>, !ttg.memdesc<1xi64, #shared1, #smem, mutable> -> !tt.tensordesc<32x32xf32>

--- a/test/TritonGPU/consan.mlir
+++ b/test/TritonGPU/consan.mlir
@@ -1052,9 +1052,11 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 1 : i32, ttg.shar
   // CHECK-LABEL: @tcgen5_mma
   tt.func public @tcgen5_mma(%arg0: !tt.tensordesc<32x32xf32, #shared>) {
     // CHECK-DAG: %[[SM_WRITE_VISIBILITY_GLOB:.*]] = ttg.global_scratch_alloc {alignment = 16 : i32, nbytes = 16 : i32, shared_cluster_state, third_party_allocation, tt.divisibility = 16 : i64} : !tt.ptr<i64>
+    // CHECK-DAG: tt.call @[[FILL_TWO_I64:__triton_consan_fill_global_tensor[^ (]*T2xI64]](%[[SM_WRITE_VISIBILITY_GLOB]],
     // CHECK-DAG: %[[SM_READ_VISIBILITY_GLOB:.*]] = ttg.global_scratch_alloc {alignment = 16 : i32, nbytes = 32 : i32, shared_cluster_state, third_party_allocation, tt.divisibility = 16 : i64} : !tt.ptr<i64>
     // CHECK-DAG: %[[TM_WRITE_VISIBILITY_GLOB:.*]] = ttg.global_scratch_alloc {alignment = 16 : i32, nbytes = 8 : i32, shared_cluster_state, third_party_allocation, tt.divisibility = 16 : i64} : !tt.ptr<i64>
-    // CHECK-DAG: tt.call @__triton_consan_fill_global_tensor{{.*}}T1x1x1x2x1xI64(%[[TM_READ_VISIBILITY_GLOB:[^,]+]],
+    // CHECK-DAG: %[[TM_READ_VISIBILITY_GLOB:.*]] = ttg.global_scratch_alloc {alignment = 16 : i32, nbytes = 16 : i32, shared_cluster_state, third_party_allocation, tt.divisibility = 16 : i64} : !tt.ptr<i64>
+    // CHECK-DAG: tt.call @[[FILL_TWO_I64]](%[[TM_READ_VISIBILITY_GLOB]],
     // CHECK-DAG: %[[BARRIERS:.*]] = tti.experimental_buffer_descriptors [65536], [{{.*}}], shared_mem : tensor<1xi64
 
     // CHECK-DAG: %[[SM_WRITE_TRACKING_GLOB:.*]] = ttg.global_scratch_alloc {alignment = 16 : i32, nbytes = 2 : i32, shared_cluster_state, third_party_allocation, tt.divisibility = 16 : i64} : !tt.ptr<i8>

--- a/test/TritonGPU/consan.mlir
+++ b/test/TritonGPU/consan.mlir
@@ -180,6 +180,13 @@ module attributes {"ttg.num-ctas" = 2 : i32, "ttg.num-warps" = 4 : i32, ttg.shar
 #proxy_smem = #ttg.shared_memory
 #proxy_blocked = #ttg.blocked<{sizePerThread = [1, 32], threadsPerWarp = [32, 1], warpsPerCTA = [1, 1], order = [0, 1]}>
 module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 1 : i32, ttg.shared = 4104 : i32, ttg.target = "cuda:90", ttg.tensor_memory_size = 0 : i32, "ttg.threads-per-warp" = 32 : i32, "ttg.total-num-warps" = 1 : i32} {
+  // CHECK: tt.func private @__triton_consan_verify_proxy_access_noalias_nw1
+  // CHECK: arith.xori {{.*}} : tensor<{{.*}}xi64
+  // CHECK-NEXT: %[[MISSING_PROXY_BITS:.*]] = arith.andi {{.*}} : tensor<{{.*}}xi64
+  // CHECK-NEXT: %[[HAS_MISSING_PROXY_BITS:.*]] = arith.cmpi ne, %[[MISSING_PROXY_BITS]], {{.*}} : tensor<{{.*}}xi64
+  // CHECK-NEXT: %[[MISSING_PROXY_PREDICATES:.*]] = tt.reshape %[[HAS_MISSING_PROXY_BITS]]{{.*}} -> tensor<{{.*}}xi1
+  // CHECK: "tt.reduce"(%[[MISSING_PROXY_PREDICATES]])
+  // CHECK: arith.ori {{.*}} : i1
   // CHECK-LABEL: @proxy_fence_state_transitions
   tt.func public @proxy_fence_state_transitions(%out: !tt.tensordesc<32x32xf32, #proxy_shared>) {
     %c0 = arith.constant 0 : i32

--- a/test/TritonGPU/consan.mlir
+++ b/test/TritonGPU/consan.mlir
@@ -944,8 +944,7 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 1 : i32, ttg.shar
     // CHECK: ttng.wait_barrier
     ttng.wait_barrier %bar, %c0_i32, %true : !ttg.memdesc<1xi64, #shared1, #smem, mutable>
     // CHECK: tti.experimental_lock_acquire
-    // CHECK: tt.call @__triton_consan_transfer_visible_writes{{.*}}%[[BARRIERS]], %[[WRITE_VISIBILITY_GLOB]], %[[WRITE_TRACKING_GLOB]]
-    // CHECK: tt.call @__triton_consan_transfer_visible_reads{{.*}}%[[BARRIERS]], %[[READ_VISIBILITY_GLOB]], %[[READ_TRACKING_GLOB]]
+    // CHECK: tt.call @__triton_consan_transfer_visible_accesses{{.*}}%[[BARRIERS]], %[[WRITE_VISIBILITY_GLOB]], %[[WRITE_TRACKING_GLOB]], %[[READ_VISIBILITY_GLOB]], %[[READ_TRACKING_GLOB]]) : {{.*}}!tt.ptr<i64>, !tt.ptr<i8>, !tt.ptr<i64>, !tt.ptr<i64>) -> ()
     // CHECK: tt.call @__triton_consan_clear_waiting
     // CHECK: tti.experimental_lock_release
     ttg.local_load %0 : !ttg.memdesc<32x32xf32, #shared, #smem, mutable> -> tensor<32x32xf32, #blocked>

--- a/test/TritonGPU/consan.mlir
+++ b/test/TritonGPU/consan.mlir
@@ -250,8 +250,7 @@ module attributes {"ttg.num-ctas" = 2 : i32, "ttg.num-warps" = 4 : i32, ttg.shar
     // CHECK: tt.call @__triton_consan_set_proxy_access{{.*}}({{.*}}%[[SCATTER_CTAS]]{{.*}})
     // CHECK: tt.call @__triton_consan_verify_write_visibility{{.*}}({{.*}}%[[SCATTER_CTAS]]{{.*}})
     // CHECK: tt.call @__triton_consan_verify_read_visibility{{.*}}({{.*}}%[[SCATTER_CTAS]]{{.*}})
-    // CHECK: tt.call @__triton_consan_set_write_visibility{{.*}}({{.*}}%[[SCATTER_CTAS]]{{.*}})
-    // CHECK: tt.call @__triton_consan_clear_read_visibility{{.*}}({{.*}}%[[SCATTER_CTAS]]{{.*}})
+    // CHECK: tt.call @__triton_consan_publish_write_visibility{{.*}}({{.*}}%[[SCATTER_CTAS]]{{.*}})
     // CHECK: ttg.local_scatter
     ttg.local_scatter %dst[%indices], %values {axis = 0 : i32} : !ttg.memdesc<8x32xi32, #local_gather_scatter_shared, #local_gather_scatter_smem, mutable>, tensor<8x32xi32, #local_gather_scatter_blocked>, tensor<8x32xi32, #local_gather_scatter_blocked>
 
@@ -289,8 +288,7 @@ module attributes {"ttg.num-ctas" = 2 : i32, "ttg.num-warps" = 4 : i32, ttg.shar
     // CHECK: tt.call @__triton_consan_set_proxy_access{{.*}}({{.*}}%[[ATOMIC_CTAS]])
     // CHECK: tt.call @__triton_consan_verify_write_visibility{{.*}}({{.*}}%[[ATOMIC_CTAS]]{{.*}})
     // CHECK: tt.call @__triton_consan_verify_read_visibility{{.*}}({{.*}}%[[ATOMIC_CTAS]]{{.*}})
-    // CHECK: tt.call @__triton_consan_set_write_visibility{{.*}}({{.*}}%[[ATOMIC_CTAS]]{{.*}})
-    // CHECK: tt.call @__triton_consan_clear_read_visibility{{.*}}({{.*}}%[[ATOMIC_CTAS]]{{.*}})
+    // CHECK: tt.call @__triton_consan_publish_write_visibility{{.*}}({{.*}}%[[ATOMIC_CTAS]]{{.*}})
     // CHECK: ttg.local_atomic_scatter_rmw
     %old = ttg.local_atomic_scatter_rmw add, %dst[%indices], %values {axis = 1 : i32} : (!ttg.memdesc<8x32xi32, #local_atomic_shared, #local_atomic_smem, mutable>, tensor<8x32xi32, #local_atomic_blocked>, tensor<8x32xi32, #local_atomic_blocked>) -> tensor<8x32xi32, #local_atomic_blocked>
     // Enable proxy tracking without giving the atomic destination another user.
@@ -312,7 +310,7 @@ module attributes {"ttg.num-ctas" = 2 : i32, "ttg.num-warps" = 4 : i32, ttg.shar
     // A source-backed allocation lowers through the local-store path.
     // CHECK: ttg.local_alloc %{{.*}}
     // CHECK: %[[ALLOC_CTAS:.*]] = arith.constant 3 : i32
-    // CHECK: tt.call @__triton_consan_set_write_visibility{{.*}}({{.*}}%[[ALLOC_CTAS]]{{.*}})
+    // CHECK: tt.call @__triton_consan_publish_write_visibility{{.*}}({{.*}}%[[ALLOC_CTAS]]{{.*}})
     %buf = ttg.local_alloc %values {allocation.offset = 0 : i32} : (tensor<8x32xi32, #local_access_blocked>) -> !ttg.memdesc<8x32xi32, #local_access_shared, #local_access_smem, mutable>
 
     // The register and shared layouts shard different logical axes, so every
@@ -555,10 +553,7 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 1 : i32, ttg.shar
     // CHECK-NOT: tt.call @__triton_consan_update_barrier_state
     // CHECK: tt.call @__triton_consan_verify_write_visibility
     // CHECK: tt.call @__triton_consan_verify_read_visibility
-    // CHECK: tt.call @__triton_consan_set_write_visibility
-    // CHECK: tt.call @__triton_consan_clear_write_tracking
-    // CHECK: tt.call @__triton_consan_clear_read_visibility
-    // CHECK: tt.call @__triton_consan_clear_read_tracking
+    // CHECK: tt.call @__triton_consan_publish_write_visibility
     // CHECK: tt.call @__triton_consan_track_barrier_write_for_buffer
     // CHECK: tt.call @__triton_consan_verify_and_update_barrier_state
     // CHECK-NOT: tt.call @__triton_consan_update_barrier_state
@@ -585,7 +580,7 @@ module attributes {"ttg.num-ctas" = 2 : i32, "ttg.num-warps" = 1 : i32, ttg.shar
     // CHECK: %[[CLC_THREAD:.*]] = arith.constant 1 : i32
     // CHECK: tt.call @__triton_consan_verify_write_visibility{{.*}}%[[CLC_THREAD]]
     // CHECK: %[[CLC_MASK:.*]] = arith.constant 2 : i64
-    // CHECK: tt.call @__triton_consan_set_write_visibility{{.*}}%[[CLC_MASK]]
+    // CHECK: tt.call @__triton_consan_publish_write_visibility{{.*}}%[[CLC_MASK]]
     // CHECK: tt.call @__triton_consan_track_barrier_write_for_buffer{{.*}}_I1
     ttng.clc_try_cancel %result, %bar : !ttg.memdesc<2xi64, #shared_clc, #smem, mutable>, !ttg.memdesc<1xi64, #barrier, #smem, mutable>
     ttng.barrier_expect %bar, 16, %true : !ttg.memdesc<1xi64, #barrier, #smem, mutable>
@@ -828,10 +823,7 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.shar
 
     // CHECK: tt.call @__triton_consan_verify_write_visibility
     // CHECK: tt.call @__triton_consan_verify_read_visibility
-    // CHECK: tt.call @__triton_consan_set_write_visibility
-    // CHECK: tt.call @__triton_consan_clear_write_tracking
-    // CHECK: tt.call @__triton_consan_clear_read_visibility
-    // CHECK: tt.call @__triton_consan_clear_read_tracking
+    // CHECK: tt.call @__triton_consan_publish_write_visibility
     // CHECK: tt.call @__triton_consan_track_barrier_write_for_buffer
     ttng.async_tma_gather %arg0[%x_offsets, %c0_i32] %0, %bar, %true : !tt.tensordesc<1x32xf32, #shared>, tensor<32xi32>, i32, !ttg.memdesc<1xi64, #shared1, #smem, mutable>, !ttg.memdesc<32x32xf32, #shared, #smem, mutable>, i1
     tt.return
@@ -1060,10 +1052,7 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 1 : i32, ttg.shar
     // CHECK: %[[TC_BIT:.*]] = arith.constant 1 : i32
     // CHECK: tt.call @__triton_consan_verify_read_visibility{{.*}}%[[TM_READ_VISIBILITY_GLOB]]
     // CHECK: %[[TC_MASK:.*]] = arith.constant 2 : i64
-    // CHECK: tt.call @__triton_consan_set_write_visibility{{.*}}%[[TC_MASK]], %[[TM_WRITE_VISIBILITY_GLOB]]
-    // CHECK: tt.call @__triton_consan_clear_write_tracking{{.*}}%[[TM_WRITE_TRACKING_GLOB]]
-    // CHECK: tt.call @__triton_consan_clear_read_visibility{{.*}}%[[TM_READ_VISIBILITY_GLOB]]
-    // CHECK: tt.call @__triton_consan_clear_read_tracking
+    // CHECK: tt.call @__triton_consan_publish_write_visibility
     // CHECK: tt.call @__triton_consan_verify_barrier_initialized
     // CHECK: %[[BAR_I64:.*]] = tti.experimental_memdesc_to_i32 %[[BAR:.*]] :
     // CHECK: %[[TC_BIT:.*]] = arith.constant 1 : i32
@@ -1120,10 +1109,7 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 1 : i32, ttg.shar
     // CHECK: %[[TC_BIT:.*]] = arith.constant 1 : i32
     // CHECK: tt.call @__triton_consan_verify_read_visibility{{.*}}%[[TM_READ_VISIBILITY_GLOB]]
     // CHECK: %[[TC_MASK:.*]] = arith.constant 2 : i64
-    // CHECK: tt.call @__triton_consan_set_write_visibility{{.*}}%[[TC_MASK]], %[[TM_WRITE_VISIBILITY_GLOB]]
-    // CHECK: tt.call @__triton_consan_clear_write_tracking{{.*}}%[[TM_WRITE_TRACKING_GLOB]]
-    // CHECK: tt.call @__triton_consan_clear_read_visibility{{.*}}%[[TM_READ_VISIBILITY_GLOB]]
-    // CHECK: tt.call @__triton_consan_clear_read_tracking
+    // CHECK: tt.call @__triton_consan_publish_write_visibility
     // CHECK: tt.call @__triton_consan_verify_barrier_initialized
     // CHECK: %[[BAR_I64:.*]] = tti.experimental_memdesc_to_i32 %[[BAR:.*]] :
     // CHECK: %[[TC_BIT:.*]] = arith.constant 1 : i32
@@ -1544,10 +1530,7 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.shar
     // CHECK: tt.call @__triton_consan_check_outstanding_commits
     // CHECK: tt.call @__triton_consan_verify_read_visibility
     // CHECK: tt.call @__triton_consan_check_outstanding_commits
-    // CHECK: tt.call @__triton_consan_set_write_visibility
-    // CHECK: tt.call @__triton_consan_clear_write_tracking
-    // CHECK: tt.call @__triton_consan_clear_read_visibility
-    // CHECK: tt.call @__triton_consan_clear_read_tracking
+    // CHECK: tt.call @__triton_consan_publish_write_visibility
     // CHECK: tti.experimental_lock_release
     // CHECK: ttg.local_store
     ttg.local_store %acc, %buf : tensor<128x128xf16, #mma> -> !ttg.memdesc<128x128xf16, #shared, #smem, mutable>

--- a/test/TritonGPU/consan.mlir
+++ b/test/TritonGPU/consan.mlir
@@ -200,7 +200,7 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 1 : i32, ttg.shar
     // CHECK: tt.call @__triton_consan_track_proxy_accesses
     ttng.arrive_barrier %bar, 1, %true : !ttg.memdesc<1xi64, #proxy_bar_shared, #proxy_smem, mutable>
     // CHECK: ttng.wait_barrier
-    // CHECK: tt.call @__triton_consan_transfer_proxy_accesses
+    // CHECK: tt.call @__triton_consan_complete_barrier_wait
     ttng.wait_barrier %bar, %c0, %true : !ttg.memdesc<1xi64, #proxy_bar_shared, #proxy_smem, mutable>
     // CHECK: tt.call @__triton_consan_fence_proxy_accesses
     ttng.fence_async_shared {bCluster = false}

--- a/test/TritonGPU/consan.mlir
+++ b/test/TritonGPU/consan.mlir
@@ -550,8 +550,7 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 1 : i32, ttg.shar
     ttng.barrier_expect %bar, 4096, %true : !ttg.memdesc<1xi64, #shared1, #smem, mutable>
     // CHECK: tt.call @__triton_consan_init_barrier_state
     // CHECK: tt.call @__triton_consan_verify_barrier_initialized
-    // CHECK: tt.call @__triton_consan_track_visible_writes
-    // CHECK: tt.call @__triton_consan_track_visible_reads
+    // CHECK: tt.call @__triton_consan_track_visible_accesses
     // CHECK: tt.call @__triton_consan_verify_and_update_barrier_state
     // CHECK-NOT: tt.call @__triton_consan_update_barrier_state
     // CHECK: tt.call @__triton_consan_verify_write_visibility
@@ -982,8 +981,7 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 1 : i32, ttg.shar
     // CHECK: tt.call @__triton_consan_init_barrier_state
     // CHECK: tti.experimental_lock_acquire
     // CHECK: tt.call @__triton_consan_verify_barrier_initialized
-    // CHECK: tt.call @__triton_consan_track_visible_writes
-    // CHECK: tt.call @__triton_consan_track_visible_reads
+    // CHECK: tt.call @__triton_consan_track_visible_accesses
     // CHECK: tt.call @__triton_consan_verify_and_update_barrier_state
     // CHECK-NOT: tt.call @__triton_consan_update_barrier_state
     // CHECK: tti.experimental_lock_release
@@ -1067,18 +1065,12 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 1 : i32, ttg.shar
     // CHECK: tt.call @__triton_consan_clear_read_visibility{{.*}}%[[TM_READ_VISIBILITY_GLOB]]
     // CHECK: tt.call @__triton_consan_clear_read_tracking
     // CHECK: tt.call @__triton_consan_verify_barrier_initialized
-    // CHECK: %[[TC_BIT:.*]] = arith.constant 1 : i32
     // CHECK: %[[BAR_I64:.*]] = tti.experimental_memdesc_to_i32 %[[BAR:.*]] :
-    // CHECK: tt.call @__triton_consan_track_visible_writes{{.*}}%[[BAR_I64]], {{.*}}, %[[TC_BIT]], %[[BARRIERS]], %[[SM_WRITE_VISIBILITY_GLOB]], %[[SM_WRITE_TRACKING_GLOB]]
     // CHECK: %[[TC_BIT:.*]] = arith.constant 1 : i32
+    // CHECK: tt.call @__triton_consan_track_visible_accesses{{.*}}%[[BAR_I64]]{{.*}}%[[TC_BIT]]{{.*}}%[[BARRIERS]]{{.*}}%[[SM_WRITE_VISIBILITY_GLOB]]{{.*}}%[[SM_WRITE_TRACKING_GLOB]]{{.*}}%[[SM_READ_VISIBILITY_GLOB]], %{{[^,)]+}}) : {{.*}}!tt.ptr<i8>, !tt.ptr<i64>, !tt.ptr<i64>) -> ()
     // CHECK: %[[BAR_I64:.*]] = tti.experimental_memdesc_to_i32 %[[BAR]] :
-    // CHECK: tt.call @__triton_consan_track_visible_reads{{.*}}%[[BAR_I64]], {{.*}}, %[[TC_BIT]], %[[BARRIERS]], %[[SM_READ_VISIBILITY_GLOB]], %{{[^,]+}}
     // CHECK: %[[TC_BIT:.*]] = arith.constant 1 : i32
-    // CHECK: %[[BAR_I64:.*]] = tti.experimental_memdesc_to_i32 %[[BAR]] :
-    // CHECK: tt.call @__triton_consan_track_visible_writes{{.*}}%[[BAR_I64]], {{.*}}, %[[TC_BIT]], %[[BARRIERS]], %[[TM_WRITE_VISIBILITY_GLOB]], %[[TM_WRITE_TRACKING_GLOB]]
-    // CHECK: %[[TC_BIT:.*]] = arith.constant 1 : i32
-    // CHECK: %[[BAR_I64:.*]] = tti.experimental_memdesc_to_i32 %[[BAR]] :
-    // CHECK: tt.call @__triton_consan_track_visible_reads{{.*}}%[[BAR_I64]], {{.*}}, %[[TC_BIT]], %[[BARRIERS]], %[[TM_READ_VISIBILITY_GLOB]], %{{[^,]+}}
+    // CHECK: tt.call @__triton_consan_track_visible_accesses{{.*}}%[[BAR_I64]]{{.*}}%[[TC_BIT]]{{.*}}%[[BARRIERS]]{{.*}}%[[TM_WRITE_VISIBILITY_GLOB]]{{.*}}%[[TM_WRITE_TRACKING_GLOB]]{{.*}}%[[TM_READ_VISIBILITY_GLOB]], %{{[^,)]+}}) : {{.*}}!tt.ptr<i8>, !tt.ptr<i64>, !tt.ptr<i64>) -> ()
     // CHECK: ttng.tc_gen5_mma
     %c0_i32 = arith.constant 0 : i32
     %0 = ttg.local_alloc {allocation.offset = 0 : i32} : () -> !ttg.memdesc<128x128xf16, #shared, #smem, mutable>
@@ -1133,18 +1125,12 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 1 : i32, ttg.shar
     // CHECK: tt.call @__triton_consan_clear_read_visibility{{.*}}%[[TM_READ_VISIBILITY_GLOB]]
     // CHECK: tt.call @__triton_consan_clear_read_tracking
     // CHECK: tt.call @__triton_consan_verify_barrier_initialized
-    // CHECK: %[[TC_BIT:.*]] = arith.constant 1 : i32
     // CHECK: %[[BAR_I64:.*]] = tti.experimental_memdesc_to_i32 %[[BAR:.*]] :
-    // CHECK: tt.call @__triton_consan_track_visible_writes{{.*}}%[[BAR_I64]], {{.*}}, %[[TC_BIT]], %[[BARRIERS]], %[[SM_WRITE_VISIBILITY_GLOB]], %[[SM_WRITE_TRACKING_GLOB]]
     // CHECK: %[[TC_BIT:.*]] = arith.constant 1 : i32
+    // CHECK: tt.call @__triton_consan_track_visible_accesses{{.*}}%[[BAR_I64]]{{.*}}%[[TC_BIT]]{{.*}}%[[BARRIERS]]{{.*}}%[[SM_WRITE_VISIBILITY_GLOB]]{{.*}}%[[SM_WRITE_TRACKING_GLOB]]{{.*}}%[[SM_READ_VISIBILITY_GLOB]], %{{[^,)]+}}) : {{.*}}!tt.ptr<i8>, !tt.ptr<i64>, !tt.ptr<i64>) -> ()
     // CHECK: %[[BAR_I64:.*]] = tti.experimental_memdesc_to_i32 %[[BAR]] :
-    // CHECK: tt.call @__triton_consan_track_visible_reads{{.*}}%[[BAR_I64]], {{.*}}, %[[TC_BIT]], %[[BARRIERS]], %[[SM_READ_VISIBILITY_GLOB]], %{{[^,]+}}
     // CHECK: %[[TC_BIT:.*]] = arith.constant 1 : i32
-    // CHECK: %[[BAR_I64:.*]] = tti.experimental_memdesc_to_i32 %[[BAR]] :
-    // CHECK: tt.call @__triton_consan_track_visible_writes{{.*}}%[[BAR_I64]], {{.*}}, %[[TC_BIT]], %[[BARRIERS]], %[[TM_WRITE_VISIBILITY_GLOB]], %[[TM_WRITE_TRACKING_GLOB]]
-    // CHECK: %[[TC_BIT:.*]] = arith.constant 1 : i32
-    // CHECK: %[[BAR_I64:.*]] = tti.experimental_memdesc_to_i32 %[[BAR]] :
-    // CHECK: tt.call @__triton_consan_track_visible_reads{{.*}}%[[BAR_I64]], {{.*}}, %[[TC_BIT]], %[[BARRIERS]], %[[TM_READ_VISIBILITY_GLOB]], %{{[^,]+}}
+    // CHECK: tt.call @__triton_consan_track_visible_accesses{{.*}}%[[BAR_I64]]{{.*}}%[[TC_BIT]]{{.*}}%[[BARRIERS]]{{.*}}%[[TM_WRITE_VISIBILITY_GLOB]]{{.*}}%[[TM_WRITE_TRACKING_GLOB]]{{.*}}%[[TM_READ_VISIBILITY_GLOB]], %{{[^,)]+}}) : {{.*}}!tt.ptr<i8>, !tt.ptr<i64>, !tt.ptr<i64>) -> ()
     // CHECK: tt.call @__triton_consan_verify_and_update_barrier_state
     // CHECK-NOT: tt.call @__triton_consan_update_barrier_state
     // CHECK: tti.experimental_lock_release
@@ -1179,10 +1165,8 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 1 : i32, ttg.shar
     ttng.init_barrier %bar, 1 : !ttg.memdesc<1xi64, #shared1, #smem, mutable>
     // CHECK: tt.call @__triton_consan_init_barrier_state
     %true = arith.constant true
-    // CHECK: tt.call @__triton_consan_track_visible_writes
-    // CHECK: tt.call @__triton_consan_track_visible_reads
-    // CHECK: tt.call @__triton_consan_track_visible_writes
-    // CHECK: tt.call @__triton_consan_track_visible_reads
+    // CHECK: tt.call @__triton_consan_track_visible_accesses
+    // CHECK: tt.call @__triton_consan_track_visible_accesses
     // CHECK: tt.call @__triton_consan_verify_and_update_barrier_state
     // CHECK-NOT: tt.call @__triton_consan_update_barrier_state
     ttng.tc_gen5_commit %bar : !ttg.memdesc<1xi64, #shared1, #smem, mutable>

--- a/test/TritonGPU/consan.mlir
+++ b/test/TritonGPU/consan.mlir
@@ -534,6 +534,15 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 1 : i32, ttg.shar
 #shared1 = #ttg.swizzled_shared<{vec = 1, perPhase = 1, maxPhase = 1, order = [0]}>
 #smem = #ttg.shared_memory
 module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 1 : i32, ttg.shared = 65544 : i32, ttg.target = "cuda:90", ttg.tensor_memory_size = 0 : i32, "ttg.threads-per-warp" = 32 : i32, "ttg.total-num-warps" = 1 : i32} {
+  // CHECK: tt.func private @__triton_consan_verify_and_update_barrier_state
+  // CHECK: %[[BARRIER_INIT_BITS:.*]] = arith.extui {{.*}} : tensor<{{.*}}xi1{{.*}}> to tensor<{{.*}}xi32
+  // CHECK: %[[BARRIER_VALID_BITS:.*]] = arith.extui {{.*}} : tensor<{{.*}}xi1{{.*}}> to tensor<{{.*}}xi32
+  // CHECK: %[[BARRIER_SHIFTED_VALID_BITS:.*]] = arith.shli %[[BARRIER_VALID_BITS]]
+  // CHECK: %[[BARRIER_STATUS_BITS:.*]] = arith.ori %[[BARRIER_INIT_BITS]], %[[BARRIER_SHIFTED_VALID_BITS]]
+  // CHECK: %[[BARRIER_PACKED_STATUS:.*]] = "tt.reduce"(%{{.*}}) <{axis = 0 : i32}>
+  // CHECK: arith.andi {{.*}} : i32
+  // CHECK-NOT: "tt.reduce"
+  // CHECK: tt.return %[[BARRIER_PACKED_STATUS]] : i32
   // CHECK-LABEL: @async_tma_copy_global_to_local
   tt.func public @async_tma_copy_global_to_local(%arg0: !tt.tensordesc<32x32xf32, #shared>) {
     // CHECK-DAG: %[[WRITE_VISIBILITY_GLOB:.*]] = ttg.global_scratch_alloc {alignment = 16 : i32, nbytes = 8 : i32, shared_cluster_state, third_party_allocation, tt.divisibility = 16 : i64} : !tt.ptr<i64>

--- a/test/TritonGPU/consan.mlir
+++ b/test/TritonGPU/consan.mlir
@@ -117,10 +117,14 @@ module attributes {"ttg.num-ctas" = 8 : i32, "ttg.num-warps" = 1 : i32, ttg.shar
     // CHECK: %[[EXPECT_PATTERN:.*]] = arith.constant 5 : i32
     // CHECK: %[[EXPECT_RECIPIENTS:.*]] = arith.shli %[[EXPECT_PATTERN]], %[[EXPECT_BASE]] : i32
     // CHECK: tt.call @__triton_consan_verify_and_update_barrier_state{{.*}}({{.*}}%[[EXPECT_PRED]]{{.*}}%[[EXPECT_RECIPIENTS]])
+    // CHECK: tti.experimental_assert_uniform {{.*}}, "Barrier used before initialization or after invalidation"
+    // CHECK: tti.experimental_assert_uniform {{.*}}, "Barrier arrive underflow: current count or tx-count would become invalid"
     // CHECK: ttng.barrier_expect
     ttng.barrier_expect %bar, 16 {fromCTA = 5 : i32}, %true : !ttg.memdesc<8xi64, #barrier_fromCTA, #smem_fromCTA, mutable>
 
     // CHECK: tt.call @__triton_consan_verify_and_update_barrier_state
+    // CHECK: tti.experimental_assert_uniform {{.*}}, "Barrier used before initialization or after invalidation"
+    // CHECK: tti.experimental_assert_uniform {{.*}}, "Barrier arrive underflow: current count or tx-count would become invalid"
     // CHECK: ttng.arrive_barrier
     ttng.arrive_barrier %bar, 1, %true {fromCTA = 5 : i32} : !ttg.memdesc<8xi64, #barrier_fromCTA, #smem_fromCTA, mutable>
     tt.return
@@ -547,15 +551,18 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 1 : i32, ttg.shar
     // mbarrier.arrive.expect_tx and is what should update ConSan's barrier state.
     ttng.barrier_expect %bar, 4096, %true : !ttg.memdesc<1xi64, #shared1, #smem, mutable>
     // CHECK: tt.call @__triton_consan_init_barrier_state
-    // CHECK: tt.call @__triton_consan_verify_barrier_initialized
     // CHECK: tt.call @__triton_consan_track_visible_accesses
     // CHECK: tt.call @__triton_consan_verify_and_update_barrier_state
+    // CHECK: tti.experimental_assert_uniform {{.*}}, "Barrier used before initialization or after invalidation"
+    // CHECK: tti.experimental_assert_uniform {{.*}}, "Barrier arrive underflow: current count or tx-count would become invalid"
     // CHECK-NOT: tt.call @__triton_consan_update_barrier_state
     // CHECK: tt.call @__triton_consan_verify_write_visibility
     // CHECK: tt.call @__triton_consan_verify_read_visibility
     // CHECK: tt.call @__triton_consan_publish_write_visibility
     // CHECK: tt.call @__triton_consan_track_barrier_write_for_buffer
     // CHECK: tt.call @__triton_consan_verify_and_update_barrier_state
+    // CHECK: tti.experimental_assert_uniform {{.*}}, "Barrier used before initialization or after invalidation"
+    // CHECK: tti.experimental_assert_uniform {{.*}}, "Barrier arrive underflow: current count or tx-count would become invalid"
     // CHECK-NOT: tt.call @__triton_consan_update_barrier_state
     ttng.async_tma_copy_global_to_local %arg0[%c0_i32, %c0_i32] %0, %bar, %true : !tt.tensordesc<32x32xf32, #shared>, !ttg.memdesc<1xi64, #shared1, #smem, mutable> -> !ttg.memdesc<32x32xf32, #shared, #smem, mutable>
     tt.return
@@ -690,8 +697,9 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 1 : i32, ttg.shar
     ttng.barrier_expect %bar, 8192, %true : !ttg.memdesc<1xi64, #shared1, #smem, mutable>
 
     // CHECK: tt.call @__triton_consan_init_barrier_state
-    // CHECK: tt.call @__triton_consan_verify_barrier_initialized
     // CHECK: tt.call @__triton_consan_verify_and_update_barrier_state
+    // CHECK: tti.experimental_assert_uniform {{.*}}, "Barrier used before initialization or after invalidation"
+    // CHECK: tti.experimental_assert_uniform {{.*}}, "Barrier arrive underflow: current count or tx-count would become invalid"
     // CHECK-NOT: tt.call @__triton_consan_update_barrier_state
     // CHECK: ttng.barrier_expect
     // CHECK-COUNT-2: tt.call @__triton_consan_track_barrier_write_for_buffer
@@ -971,9 +979,10 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 1 : i32, ttg.shar
     ttng.init_barrier %bar, 1 : !ttg.memdesc<1xi64, #shared1, #smem, mutable>
     // CHECK: tt.call @__triton_consan_init_barrier_state
     // CHECK: tti.experimental_lock_acquire
-    // CHECK: tt.call @__triton_consan_verify_barrier_initialized
     // CHECK: tt.call @__triton_consan_track_visible_accesses
     // CHECK: tt.call @__triton_consan_verify_and_update_barrier_state
+    // CHECK: tti.experimental_assert_uniform {{.*}}, "Barrier used before initialization or after invalidation"
+    // CHECK: tti.experimental_assert_uniform {{.*}}, "Barrier arrive underflow: current count or tx-count would become invalid"
     // CHECK-NOT: tt.call @__triton_consan_update_barrier_state
     // CHECK: tti.experimental_lock_release
     ttng.arrive_barrier %bar, 2, %true : !ttg.memdesc<1xi64, #shared1, #smem, mutable>
@@ -1008,8 +1017,9 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 1 : i32, ttg.shar
   tt.func public @arrive_barrier_without_init() {
     %true = arith.constant true
     %bar = ttg.local_alloc {allocation.offset = 65536 : i32} : () -> !ttg.memdesc<1xi64, #shared1, #smem, mutable>
-    // CHECK: tt.call @__triton_consan_verify_barrier_initialized
     // CHECK: tt.call @__triton_consan_verify_and_update_barrier_state
+    // CHECK: tti.experimental_assert_uniform {{.*}}, "Barrier used before initialization or after invalidation"
+    // CHECK: tti.experimental_assert_uniform {{.*}}, "Barrier arrive underflow: current count or tx-count would become invalid"
     // CHECK-NOT: tt.call @__triton_consan_update_barrier_state
     ttng.arrive_barrier %bar, 1, %true : !ttg.memdesc<1xi64, #shared1, #smem, mutable>
     tt.return
@@ -1052,13 +1062,15 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 1 : i32, ttg.shar
     // CHECK: tt.call @__triton_consan_verify_read_visibility{{.*}}%[[TM_READ_VISIBILITY_GLOB]]
     // CHECK: %[[TC_MASK:.*]] = arith.constant 2 : i64
     // CHECK: tt.call @__triton_consan_publish_write_visibility
-    // CHECK: tt.call @__triton_consan_verify_barrier_initialized
     // CHECK: %[[BAR_I64:.*]] = tti.experimental_memdesc_to_i32 %[[BAR:.*]] :
     // CHECK: %[[TC_BIT:.*]] = arith.constant 1 : i32
     // CHECK: tt.call @__triton_consan_track_visible_accesses{{.*}}%[[BAR_I64]]{{.*}}%[[TC_BIT]]{{.*}}%[[BARRIERS]]{{.*}}%[[SM_WRITE_VISIBILITY_GLOB]]{{.*}}%[[SM_WRITE_TRACKING_GLOB]]{{.*}}%[[SM_READ_VISIBILITY_GLOB]], %{{[^,)]+}}) : {{.*}}!tt.ptr<i8>, !tt.ptr<i64>, !tt.ptr<i64>) -> ()
     // CHECK: %[[BAR_I64:.*]] = tti.experimental_memdesc_to_i32 %[[BAR]] :
     // CHECK: %[[TC_BIT:.*]] = arith.constant 1 : i32
     // CHECK: tt.call @__triton_consan_track_visible_accesses{{.*}}%[[BAR_I64]]{{.*}}%[[TC_BIT]]{{.*}}%[[BARRIERS]]{{.*}}%[[TM_WRITE_VISIBILITY_GLOB]]{{.*}}%[[TM_WRITE_TRACKING_GLOB]]{{.*}}%[[TM_READ_VISIBILITY_GLOB]], %{{[^,)]+}}) : {{.*}}!tt.ptr<i8>, !tt.ptr<i64>, !tt.ptr<i64>) -> ()
+    // CHECK: tt.call @__triton_consan_verify_and_update_barrier_state
+    // CHECK: tti.experimental_assert_uniform {{.*}}, "Barrier used before initialization or after invalidation"
+    // CHECK: tti.experimental_assert_uniform {{.*}}, "Barrier arrive underflow: current count or tx-count would become invalid"
     // CHECK: ttng.tc_gen5_mma
     %c0_i32 = arith.constant 0 : i32
     %0 = ttg.local_alloc {allocation.offset = 0 : i32} : () -> !ttg.memdesc<128x128xf16, #shared, #smem, mutable>
@@ -1109,7 +1121,6 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 1 : i32, ttg.shar
     // CHECK: tt.call @__triton_consan_verify_read_visibility{{.*}}%[[TM_READ_VISIBILITY_GLOB]]
     // CHECK: %[[TC_MASK:.*]] = arith.constant 2 : i64
     // CHECK: tt.call @__triton_consan_publish_write_visibility
-    // CHECK: tt.call @__triton_consan_verify_barrier_initialized
     // CHECK: %[[BAR_I64:.*]] = tti.experimental_memdesc_to_i32 %[[BAR:.*]] :
     // CHECK: %[[TC_BIT:.*]] = arith.constant 1 : i32
     // CHECK: tt.call @__triton_consan_track_visible_accesses{{.*}}%[[BAR_I64]]{{.*}}%[[TC_BIT]]{{.*}}%[[BARRIERS]]{{.*}}%[[SM_WRITE_VISIBILITY_GLOB]]{{.*}}%[[SM_WRITE_TRACKING_GLOB]]{{.*}}%[[SM_READ_VISIBILITY_GLOB]], %{{[^,)]+}}) : {{.*}}!tt.ptr<i8>, !tt.ptr<i64>, !tt.ptr<i64>) -> ()
@@ -1117,6 +1128,8 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 1 : i32, ttg.shar
     // CHECK: %[[TC_BIT:.*]] = arith.constant 1 : i32
     // CHECK: tt.call @__triton_consan_track_visible_accesses{{.*}}%[[BAR_I64]]{{.*}}%[[TC_BIT]]{{.*}}%[[BARRIERS]]{{.*}}%[[TM_WRITE_VISIBILITY_GLOB]]{{.*}}%[[TM_WRITE_TRACKING_GLOB]]{{.*}}%[[TM_READ_VISIBILITY_GLOB]], %{{[^,)]+}}) : {{.*}}!tt.ptr<i8>, !tt.ptr<i64>, !tt.ptr<i64>) -> ()
     // CHECK: tt.call @__triton_consan_verify_and_update_barrier_state
+    // CHECK: tti.experimental_assert_uniform {{.*}}, "Barrier used before initialization or after invalidation"
+    // CHECK: tti.experimental_assert_uniform {{.*}}, "Barrier arrive underflow: current count or tx-count would become invalid"
     // CHECK-NOT: tt.call @__triton_consan_update_barrier_state
     // CHECK: tti.experimental_lock_release
     // CHECK: ttng.tc_gen5_mma

--- a/test/TritonGPU/consan.mlir
+++ b/test/TritonGPU/consan.mlir
@@ -1181,8 +1181,9 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 1 : i32, ttg.shar
     ttng.init_barrier %bar, 1 : !ttg.memdesc<1xi64, #shared1, #smem, mutable>
     // CHECK: tt.call @__triton_consan_init_barrier_state
     %true = arith.constant true
-    // CHECK: tt.call @__triton_consan_track_visible_accesses
-    // CHECK: tt.call @__triton_consan_track_visible_accesses
+    // Identical shared- and tensor-memory tracking layouts reuse one helper.
+    // CHECK: tt.call @[[TRACK_VISIBLE:__triton_consan_track_visible_accesses[^ (]*]]
+    // CHECK: tt.call @[[TRACK_VISIBLE]]
     // CHECK: tt.call @__triton_consan_verify_and_update_barrier_state
     // CHECK-NOT: tt.call @__triton_consan_update_barrier_state
     ttng.tc_gen5_commit %bar : !ttg.memdesc<1xi64, #shared1, #smem, mutable>

--- a/test/TritonGPU/consan.mlir
+++ b/test/TritonGPU/consan.mlir
@@ -2042,6 +2042,12 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.shar
 #smem_cluster_publish = #ttg.shared_memory
 #blocked_cluster_publish = #ttg.blocked<{sizePerThread = [1, 32], threadsPerWarp = [32, 1], warpsPerCTA = [1, 1], order = [0, 1], CGALayout = [[1, 0]]}>
 module attributes {"ttg.num-ctas" = 2 : i32, "ttg.num-warps" = 1 : i32, ttg.shared = 65544 : i32, ttg.target = "cuda:90", ttg.tensor_memory_size = 0 : i32, "ttg.threads-per-warp" = 32 : i32, "ttg.total-num-warps" = 1 : i32} {
+  // All logical threads in this module are synchronous. The cluster
+  // publication must still propagate both visibility frontiers, but it need
+  // not filter either frontier against nonexistent asynchronous threads.
+  // CHECK-LABEL: tt.func private @__triton_consan_publish_cluster_visibility{{.*}}_I0
+  // CHECK-NOT: arith.cmpi ne
+  // CHECK: tt.return
   // CHECK-LABEL: @cluster_barrier_publish_protocol
   tt.func public @cluster_barrier_publish_protocol() {
     %buf = ttg.local_alloc {allocation.offset = 0 : i32} : () -> !ttg.memdesc<32x32xf32, #shared_cluster_publish, #smem_cluster_publish, mutable>

--- a/test/TritonGPU/consan.mlir
+++ b/test/TritonGPU/consan.mlir
@@ -9,6 +9,12 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 1 : i32, ttg.shar
   // CHECK-DAG: #[[BUFS_L:.*]] = #ttg.linear<{register = [], lane = {{\[}}[0], [0], [0], [0], [0]], warp = [], block = []}>
   // CHECK-DAG: #[[BUFS_THREADS_L:.*]] = #ttg.linear<{register = [], lane = {{\[}}[0, 0, 0], [0, 0, 0], [0, 0, 0], [0, 0, 0], [0, 0, 0]], warp = [], block = []}>
   // CHECK-DAG: #[[BUFS_BARS_L:.*]] = #ttg.linear<{register = [], lane = {{\[}}[0, 0], [0, 0], [0, 0], [0, 0], [0, 0]], warp = [], block = []}>
+  // CHECK-LABEL: tt.func private @__triton_consan_verify_write_visibility_noalias
+  // CHECK: %[[WRITE_VISIBILITY:.*]] = tt.load
+  // CHECK: arith.cmpi eq, %[[WRITE_VISIBILITY]],
+  // CHECK: %[[SELECTED_THREAD_BIT:.*]] = arith.shli
+  // CHECK: %[[VISIBLE_THREAD_BITS:.*]] = arith.andi %[[WRITE_VISIBILITY]], %[[SELECTED_THREAD_BIT]]
+  // CHECK: arith.cmpi eq, %[[VISIBLE_THREAD_BITS]], %[[SELECTED_THREAD_BIT]]
   // CHECK: @single_local_alloc
   tt.func public @single_local_alloc() {
     // CHECK: %[[WRITE_VISIBILITY_GLOB:.*]] = ttg.global_scratch_alloc {alignment = 16 : i32, nbytes = 8 : i32, shared_cluster_state, third_party_allocation, tt.divisibility = 16 : i64} : !tt.ptr<i64>

--- a/test/TritonGPU/consan.mlir
+++ b/test/TritonGPU/consan.mlir
@@ -1271,6 +1271,15 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 1 : i32, ttg.shar
 #shared1 = #ttg.swizzled_shared<{vec = 1, perPhase = 1, maxPhase = 1, order = [0], CGALayout = [[1]]}>
 #smem = #ttg.shared_memory
 module attributes {"ttg.num-ctas" = 2 : i32, "ttg.num-warps" = 1 : i32, ttg.shared = 65544 : i32, ttg.target = "cuda:90", ttg.tensor_memory_size = 0 : i32, "ttg.threads-per-warp" = 32 : i32, "ttg.total-num-warps" = 1 : i32} {
+  // CHECK: tt.func private @__triton_consan_check_all_active_waiting
+  // CHECK: %[[DEADLOCK_WAITING_BITS:.*]] = arith.extui {{.*}} : tensor<{{.*}}xi1{{.*}}> to tensor<{{.*}}xi32
+  // CHECK: %[[DEADLOCK_IDLE_BITS:.*]] = arith.extui {{.*}} : tensor<{{.*}}xi1{{.*}}> to tensor<{{.*}}xi32
+  // CHECK: %[[DEADLOCK_SHIFTED_IDLE_BITS:.*]] = arith.shli %[[DEADLOCK_IDLE_BITS]]
+  // CHECK: %[[DEADLOCK_BITS:.*]] = arith.ori %[[DEADLOCK_WAITING_BITS]], %[[DEADLOCK_SHIFTED_IDLE_BITS]]
+  // CHECK: %[[DEADLOCK_STATUS:.*]] = "tt.reduce"(%[[DEADLOCK_BITS]]) <{axis = 0 : i32}>
+  // CHECK: arith.andi {{.*}} : i32
+  // CHECK-NOT: "tt.reduce"
+  // CHECK: arith.cmpi eq, %[[DEADLOCK_STATUS]], {{.*}} : i32
   // CHECK-LABEL: @wait_barrier_multi_cta
   tt.func public @wait_barrier_multi_cta() {
     // The dummy descriptor is the virtual cluster-barrier slot. It uses the

--- a/test/TritonGPU/consan.mlir
+++ b/test/TritonGPU/consan.mlir
@@ -9,7 +9,7 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 1 : i32, ttg.shar
   // CHECK-DAG: #[[BUFS_L:.*]] = #ttg.linear<{register = [], lane = {{\[}}[0], [0], [0], [0], [0]], warp = [], block = []}>
   // CHECK-DAG: #[[BUFS_THREADS_L:.*]] = #ttg.linear<{register = [], lane = {{\[}}[0, 0, 0], [0, 0, 0], [0, 0, 0], [0, 0, 0], [0, 0, 0]], warp = [], block = []}>
   // CHECK-DAG: #[[BUFS_BARS_L:.*]] = #ttg.linear<{register = [], lane = {{\[}}[0, 0], [0, 0], [0, 0], [0, 0], [0, 0]], warp = [], block = []}>
-  // CHECK-LABEL: tt.func private @__triton_consan_verify_write_visibility_noalias
+  // CHECK-LABEL: tt.func private @__triton_consan_verify_write_visibility_
   // CHECK: %[[WRITE_VISIBILITY:.*]] = tt.load
   // CHECK: arith.cmpi eq, %[[WRITE_VISIBILITY]],
   // CHECK: %[[SELECTED_THREAD_BIT:.*]] = arith.shli
@@ -186,7 +186,7 @@ module attributes {"ttg.num-ctas" = 2 : i32, "ttg.num-warps" = 4 : i32, ttg.shar
 #proxy_smem = #ttg.shared_memory
 #proxy_blocked = #ttg.blocked<{sizePerThread = [1, 32], threadsPerWarp = [32, 1], warpsPerCTA = [1, 1], order = [0, 1]}>
 module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 1 : i32, ttg.shared = 4104 : i32, ttg.target = "cuda:90", ttg.tensor_memory_size = 0 : i32, "ttg.threads-per-warp" = 32 : i32, "ttg.total-num-warps" = 1 : i32} {
-  // CHECK: tt.func private @__triton_consan_verify_proxy_access_noalias_nw1
+  // CHECK: tt.func private @__triton_consan_verify_proxy_access_nw1
   // CHECK: arith.xori {{.*}} : tensor<{{.*}}xi64
   // CHECK-NEXT: %[[MISSING_PROXY_BITS:.*]] = arith.andi {{.*}} : tensor<{{.*}}xi64
   // CHECK-NEXT: %[[HAS_MISSING_PROXY_BITS:.*]] = arith.cmpi ne, %[[MISSING_PROXY_BITS]], {{.*}} : tensor<{{.*}}xi64
@@ -1061,8 +1061,8 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 1 : i32, ttg.shar
     // CHECK-DAG: tt.call @[[FILL_TWO_I64:__triton_consan_fill_global_tensor[^ (]*T2xI64]](%[[SM_WRITE_VISIBILITY_GLOB]],
     // CHECK-DAG: %[[SM_READ_VISIBILITY_GLOB:.*]] = ttg.global_scratch_alloc {alignment = 16 : i32, nbytes = 32 : i32, shared_cluster_state, third_party_allocation, tt.divisibility = 16 : i64} : !tt.ptr<i64>
     // CHECK-DAG: %[[TM_WRITE_VISIBILITY_GLOB:.*]] = ttg.global_scratch_alloc {alignment = 16 : i32, nbytes = 8 : i32, shared_cluster_state, third_party_allocation, tt.divisibility = 16 : i64} : !tt.ptr<i64>
-    // CHECK-DAG: %[[TM_READ_VISIBILITY_GLOB:.*]] = ttg.global_scratch_alloc {alignment = 16 : i32, nbytes = 16 : i32, shared_cluster_state, third_party_allocation, tt.divisibility = 16 : i64} : !tt.ptr<i64>
-    // CHECK-DAG: tt.call @[[FILL_TWO_I64]](%[[TM_READ_VISIBILITY_GLOB]],
+    // CHECK-DAG: ttg.global_scratch_alloc {alignment = 16 : i32, nbytes = 16 : i32, shared_cluster_state, third_party_allocation, tt.divisibility = 16 : i64} : !tt.ptr<i64>
+    // CHECK-DAG: tt.call @[[FILL_TWO_I64]]
     // CHECK-DAG: %[[BARRIERS:.*]] = tti.experimental_buffer_descriptors [65536], [{{.*}}], shared_mem : tensor<1xi64
 
     // CHECK-DAG: %[[SM_WRITE_TRACKING_GLOB:.*]] = ttg.global_scratch_alloc {alignment = 16 : i32, nbytes = 2 : i32, shared_cluster_state, third_party_allocation, tt.divisibility = 16 : i64} : !tt.ptr<i8>
@@ -1083,7 +1083,7 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 1 : i32, ttg.shar
     // CHECK: %[[TC_BIT:.*]] = arith.constant 1 : i32
     // CHECK: tt.call @__triton_consan_verify_write_visibility{{.*}}%[[TM_WRITE_VISIBILITY_GLOB]]
     // CHECK: %[[TC_BIT:.*]] = arith.constant 1 : i32
-    // CHECK: tt.call @__triton_consan_verify_read_visibility{{.*}}%[[TM_READ_VISIBILITY_GLOB]]
+    // CHECK: tt.call @__triton_consan_verify_read_visibility{{.*}}T1x1x1x2x1xI64
     // CHECK: %[[TC_MASK:.*]] = arith.constant 2 : i64
     // CHECK: tt.call @__triton_consan_publish_write_visibility
     // CHECK: %[[BAR_I64:.*]] = tti.experimental_memdesc_to_i32 %[[BAR:.*]] :
@@ -1091,7 +1091,7 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 1 : i32, ttg.shar
     // CHECK: tt.call @__triton_consan_track_visible_accesses{{.*}}%[[BAR_I64]]{{.*}}%[[TC_BIT]]{{.*}}%[[BARRIERS]]{{.*}}%[[SM_WRITE_VISIBILITY_GLOB]]{{.*}}%[[SM_WRITE_TRACKING_GLOB]]{{.*}}%[[SM_READ_VISIBILITY_GLOB]], %{{[^,)]+}}) : {{.*}}!tt.ptr<i8>, !tt.ptr<i64>, !tt.ptr<i64>) -> ()
     // CHECK: %[[BAR_I64:.*]] = tti.experimental_memdesc_to_i32 %[[BAR]] :
     // CHECK: %[[TC_BIT:.*]] = arith.constant 1 : i32
-    // CHECK: tt.call @__triton_consan_track_visible_accesses{{.*}}%[[BAR_I64]]{{.*}}%[[TC_BIT]]{{.*}}%[[BARRIERS]]{{.*}}%[[TM_WRITE_VISIBILITY_GLOB]]{{.*}}%[[TM_WRITE_TRACKING_GLOB]]{{.*}}%[[TM_READ_VISIBILITY_GLOB]], %{{[^,)]+}}) : {{.*}}!tt.ptr<i8>, !tt.ptr<i64>, !tt.ptr<i64>) -> ()
+    // CHECK: tt.call @__triton_consan_track_visible_accesses{{.*}}%[[BAR_I64]]{{.*}}%[[TC_BIT]]{{.*}}%[[BARRIERS]]{{.*}}%[[TM_WRITE_VISIBILITY_GLOB]]{{.*}}%[[TM_WRITE_TRACKING_GLOB]]{{.*}}%[[TM_READ_VISIBILITY_GLOB:.*]], %{{[^,)]+}}) : {{.*}}!tt.ptr<i8>, !tt.ptr<i64>, !tt.ptr<i64>) -> ()
     // CHECK: tt.call @__triton_consan_verify_and_update_barrier_state
     // CHECK: tti.experimental_assert_uniform {{.*}}, "Barrier used before initialization or after invalidation"
     // CHECK: tti.experimental_assert_uniform {{.*}}, "Barrier arrive underflow: current count or tx-count would become invalid"

--- a/test/TritonGPU/consan.mlir
+++ b/test/TritonGPU/consan.mlir
@@ -116,11 +116,11 @@ module attributes {"ttg.num-ctas" = 8 : i32, "ttg.num-warps" = 1 : i32, ttg.shar
     // CHECK: %[[EXPECT_BASE:.*]] = arith.andi %[[EXPECT_RECIPIENT_CTA]], %[[EXPECT_FIXED]] : i32
     // CHECK: %[[EXPECT_PATTERN:.*]] = arith.constant 5 : i32
     // CHECK: %[[EXPECT_RECIPIENTS:.*]] = arith.shli %[[EXPECT_PATTERN]], %[[EXPECT_BASE]] : i32
-    // CHECK: tt.call @__triton_consan_verify_barrier_arrive{{.*}}({{.*}}%[[EXPECT_PRED]]{{.*}}%[[EXPECT_RECIPIENTS]])
+    // CHECK: tt.call @__triton_consan_verify_and_update_barrier_state{{.*}}({{.*}}%[[EXPECT_PRED]]{{.*}}%[[EXPECT_RECIPIENTS]])
     // CHECK: ttng.barrier_expect
     ttng.barrier_expect %bar, 16 {fromCTA = 5 : i32}, %true : !ttg.memdesc<8xi64, #barrier_fromCTA, #smem_fromCTA, mutable>
 
-    // CHECK: tt.call @__triton_consan_verify_barrier_arrive
+    // CHECK: tt.call @__triton_consan_verify_and_update_barrier_state
     // CHECK: ttng.arrive_barrier
     ttng.arrive_barrier %bar, 1, %true {fromCTA = 5 : i32} : !ttg.memdesc<8xi64, #barrier_fromCTA, #smem_fromCTA, mutable>
     tt.return
@@ -552,8 +552,8 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 1 : i32, ttg.shar
     // CHECK: tt.call @__triton_consan_verify_barrier_initialized
     // CHECK: tt.call @__triton_consan_track_visible_writes
     // CHECK: tt.call @__triton_consan_track_visible_reads
-    // CHECK: tt.call @__triton_consan_verify_barrier_arrive
-    // CHECK: tt.call @__triton_consan_update_barrier_state
+    // CHECK: tt.call @__triton_consan_verify_and_update_barrier_state
+    // CHECK-NOT: tt.call @__triton_consan_update_barrier_state
     // CHECK: tt.call @__triton_consan_verify_write_visibility
     // CHECK: tt.call @__triton_consan_verify_read_visibility
     // CHECK: tt.call @__triton_consan_set_write_visibility
@@ -561,8 +561,8 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 1 : i32, ttg.shar
     // CHECK: tt.call @__triton_consan_clear_read_visibility
     // CHECK: tt.call @__triton_consan_clear_read_tracking
     // CHECK: tt.call @__triton_consan_track_barrier_write_for_buffer
-    // CHECK: tt.call @__triton_consan_verify_barrier_arrive
-    // CHECK: tt.call @__triton_consan_update_barrier_state
+    // CHECK: tt.call @__triton_consan_verify_and_update_barrier_state
+    // CHECK-NOT: tt.call @__triton_consan_update_barrier_state
     ttng.async_tma_copy_global_to_local %arg0[%c0_i32, %c0_i32] %0, %bar, %true : !tt.tensordesc<32x32xf32, #shared>, !ttg.memdesc<1xi64, #shared1, #smem, mutable> -> !ttg.memdesc<32x32xf32, #shared, #smem, mutable>
     tt.return
   }
@@ -661,11 +661,11 @@ module attributes {"ttg.num-ctas" = 2 : i32, "ttg.num-warps" = 1 : i32, "ttng.tw
     // CHECK: scf.for
     scf.for %i = %c0 to %c2 step %c1 {
       // CHECK: arith.constant 4096 : i64
-      // CHECK: tt.call @__triton_consan_verify_barrier_arrive
+      // CHECK: tt.call @__triton_consan_verify_and_update_barrier_state
       // CHECK: ttng.barrier_expect
       ttng.barrier_expect %bar, 4096, %true : !ttg.memdesc<1xi64, #shared1, #smem, mutable>
       // CHECK: arith.constant -8192 : i64
-      // CHECK: tt.call @__triton_consan_verify_barrier_arrive
+      // CHECK: tt.call @__triton_consan_verify_and_update_barrier_state
       // CHECK: ttng.async_tma_gather
       ttng.async_tma_gather %desc[%x_offsets, %c0_i32] %result, %bar, %true {multicast} : !tt.tensordesc<1x32xf32, #shared>, tensor<32xi32, #offsets>, i32, !ttg.memdesc<1xi64, #shared1, #smem, mutable>, !ttg.memdesc<32x32xf32, #shared, #smem, mutable>, i1
     }
@@ -697,8 +697,8 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 1 : i32, ttg.shar
 
     // CHECK: tt.call @__triton_consan_init_barrier_state
     // CHECK: tt.call @__triton_consan_verify_barrier_initialized
-    // CHECK: tt.call @__triton_consan_verify_barrier_arrive
-    // CHECK: tt.call @__triton_consan_update_barrier_state
+    // CHECK: tt.call @__triton_consan_verify_and_update_barrier_state
+    // CHECK-NOT: tt.call @__triton_consan_update_barrier_state
     // CHECK: ttng.barrier_expect
     // CHECK-COUNT-2: tt.call @__triton_consan_track_barrier_write_for_buffer
     ttng.async_tma_copy_global_to_local %a[%c0_i32, %c0_i32] %a_smem, %bar, %true : !tt.tensordesc<32x32xf32, #shared>, !ttg.memdesc<1xi64, #shared1, #smem, mutable> -> !ttg.memdesc<32x32xf32, #shared, #smem, mutable>
@@ -984,8 +984,8 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 1 : i32, ttg.shar
     // CHECK: tt.call @__triton_consan_verify_barrier_initialized
     // CHECK: tt.call @__triton_consan_track_visible_writes
     // CHECK: tt.call @__triton_consan_track_visible_reads
-    // CHECK: tt.call @__triton_consan_verify_barrier_arrive
-    // CHECK: tt.call @__triton_consan_update_barrier_state
+    // CHECK: tt.call @__triton_consan_verify_and_update_barrier_state
+    // CHECK-NOT: tt.call @__triton_consan_update_barrier_state
     // CHECK: tti.experimental_lock_release
     ttng.arrive_barrier %bar, 2, %true : !ttg.memdesc<1xi64, #shared1, #smem, mutable>
     ttg.local_load %0 : !ttg.memdesc<32x32xf32, #shared, #smem, mutable> -> tensor<32x32xf32, #blocked>
@@ -1020,8 +1020,8 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 1 : i32, ttg.shar
     %true = arith.constant true
     %bar = ttg.local_alloc {allocation.offset = 65536 : i32} : () -> !ttg.memdesc<1xi64, #shared1, #smem, mutable>
     // CHECK: tt.call @__triton_consan_verify_barrier_initialized
-    // CHECK: tt.call @__triton_consan_verify_barrier_arrive
-    // CHECK: tt.call @__triton_consan_update_barrier_state
+    // CHECK: tt.call @__triton_consan_verify_and_update_barrier_state
+    // CHECK-NOT: tt.call @__triton_consan_update_barrier_state
     ttng.arrive_barrier %bar, 1, %true : !ttg.memdesc<1xi64, #shared1, #smem, mutable>
     tt.return
   }
@@ -1145,8 +1145,8 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 1 : i32, ttg.shar
     // CHECK: %[[TC_BIT:.*]] = arith.constant 1 : i32
     // CHECK: %[[BAR_I64:.*]] = tti.experimental_memdesc_to_i32 %[[BAR]] :
     // CHECK: tt.call @__triton_consan_track_visible_reads{{.*}}%[[BAR_I64]], {{.*}}, %[[TC_BIT]], %[[BARRIERS]], %[[TM_READ_VISIBILITY_GLOB]], %{{[^,]+}}
-    // CHECK: tt.call @__triton_consan_verify_barrier_arrive
-    // CHECK: tt.call @__triton_consan_update_barrier_state
+    // CHECK: tt.call @__triton_consan_verify_and_update_barrier_state
+    // CHECK-NOT: tt.call @__triton_consan_update_barrier_state
     // CHECK: tti.experimental_lock_release
     // CHECK: ttng.tc_gen5_mma
     %c0_i32 = arith.constant 0 : i32
@@ -1183,8 +1183,8 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 1 : i32, ttg.shar
     // CHECK: tt.call @__triton_consan_track_visible_reads
     // CHECK: tt.call @__triton_consan_track_visible_writes
     // CHECK: tt.call @__triton_consan_track_visible_reads
-    // CHECK: tt.call @__triton_consan_verify_barrier_arrive
-    // CHECK: tt.call @__triton_consan_update_barrier_state
+    // CHECK: tt.call @__triton_consan_verify_and_update_barrier_state
+    // CHECK-NOT: tt.call @__triton_consan_update_barrier_state
     ttng.tc_gen5_commit %bar : !ttg.memdesc<1xi64, #shared1, #smem, mutable>
     ttg.local_load %0 : !ttg.memdesc<128x128xf16, #shared, #smem, mutable> -> tensor<128x128xf16, #blocked>
     ttng.tmem_load %result : !ttg.memdesc<128x128xf16, #tmem, #ttng.tensor_memory, mutable> -> tensor<128x128xf16>


### PR DESCRIPTION
Improve consan compile time and runtime by fusing consecutive helper functions together.

There's another targeted optimization which makes `uniform_assert` not generate two nested conditional blocks by passing a predicate.

Impact:

ConSan example | Cold compile | Runtime
-- | -- | --
01-attention-forward | 13.277 → 9.498 s, 28.46% faster | 10.903 → 9.180 ms, 15.81% faster
05-fused-gather | 24.635 → 23.937 s, 2.83% faster | 975.952 → 925.220 ms, 5.20% faster
