### PR TITLE
Fix interpreter histogram count overflow

### DIFF
--- a/python/test/unit/language/test_core.py
+++ b/python/test/unit/language/test_core.py
@@ -3196,6 +3196,27 @@ def test_histogram_silent_data_corruption(device):
     assert z[1] == 1, f"Second element shouldn't be affected, expected_buffer=[1, 1], actual_buffer={z}"
 
 
+@pytest.mark.interpreter
+@pytest.mark.parametrize("dtype, M", [(torch.int8, 128), (torch.int16, 32768)])
+def test_histogram_narrow_input_count_overflow(dtype, M, device):
+    if not is_interpreter():
+        pytest.skip("narrow integer histogram lowering is not supported yet")
+
+    @triton.jit
+    def histogram_kernel(x_ptr, z_ptr, M: tl.constexpr):
+        offsets = tl.arange(0, M)
+        x = tl.load(x_ptr + offsets)
+        z = tl.histogram(x, 2)
+        tl.store(z_ptr + tl.arange(0, 2), z)
+
+    x = torch.ones(M, device=device, dtype=dtype)
+    z = torch.empty(2, device=device, dtype=torch.int32)
+
+    histogram_kernel[(1, )](x, z, M=M)
+    expected = torch.tensor([0, M], device=device, dtype=torch.int32)
+    torch.testing.assert_close(z, expected)
+
+
 # ------------------------
 # test histogram with mask
 # ------------------------

--- a/python/triton/runtime/interpreter.py
+++ b/python/triton/runtime/interpreter.py
@@ -733,7 +733,7 @@ class InterpreterBuilder:
         # This is fix for interpreter cases where for example int32 tensor is being passed
         # But unexpectedly int64 values are being returned causing
         # tl.store to write 8 bytes instead of 4 bytes which lead to silent data corruption
-        dummy_weights = np.ones_like(data.data, dtype=data.data.dtype)
+        dummy_weights = np.ones_like(data.data, dtype=np.int32)
 
         # force all masked elements to zero
         data = np.where(mask.data, data.data, np.zeros_like(data.data))


### PR DESCRIPTION
Fixes #10889.

## What changed

- Accumulate interpreter histogram weights in `int32`, matching `tl.histogram`'s declared result dtype and the GPU's i32 accumulation.
- Add interpreter regression cases for int8 and int16 inputs at their first overflowing signed counts (128 and 32768).

## Why

The interpreter used the input element dtype for NumPy histogram weights. NumPy therefore accumulated counts in int8/int16, wrapping valid bin counts before the result was labeled as int32. Using explicit int32 weights retains the existing four-byte store guarantee while preventing narrow-input overflow.

## Impact

This only changes interpreter histogram accumulation for input types narrower than int32. Existing int32 behavior and the declared int32 output type are unchanged.

## Verification

- `python -m py_compile python/triton/runtime/interpreter.py python/test/unit/language/test_core.py`
- `ruff@0.9.1 check python/triton/runtime/interpreter.py python/test/unit/language/test_core.py`
- `yapf==0.43.0 --diff python/triton/runtime/interpreter.py python/test/unit/language/test_core.py`
- Standalone NumPy check of the exact old/new accumulation path: int8 produced -128 before and 128 after; int16 produced -32768 before and 32768 after; both fixed results are int32.
- The targeted pytest could not collect in this macOS partial clone because the native `triton._C` extension is not built. Per repository guidance, `make` was not run because this is a Python-only change.
