### PR TITLE
[AMD][Gluon] Add cdna5 alias for gfx1250 and document it

### DIFF
--- a/docs/gluon/api/amd.cdna5.rst
+++ b/docs/gluon/api/amd.cdna5.rst
@@ -1,0 +1,28 @@
+AMD CDNA 5
+==========
+
+.. currentmodule:: triton.experimental.gluon.language.amd.cdna5
+
+.. autosummary::
+    :toctree: generated
+    :nosignatures:
+    :template: autosummary/gluon-module.rst
+
+    async_copy
+    cluster
+    mbarrier
+    tdm
+
+
+.. autosummary::
+    :toctree: generated
+    :nosignatures:
+
+    buffer_load
+    buffer_store
+    get_wmma_scale_layout
+    make_partitioned_dot_layouts
+    scaled_upcast
+    wmma
+    wmma_scaled
+    PartitionedSharedLayout

--- a/docs/gluon/api/amd.rst
+++ b/docs/gluon/api/amd.rst
@@ -24,5 +24,6 @@ GPU Generations
 
    CDNA 3 <amd.cdna3>
    CDNA 4 <amd.cdna4>
+   CDNA 5 <amd.cdna5>
    RDNA 3 <amd.rdna3>
    RDNA 4 <amd.rdna4>

--- a/docs/gluon/api/runtime.rst
+++ b/docs/gluon/api/runtime.rst
@@ -26,3 +26,4 @@ Host-Side Descriptors
     nvidia.hopper.TensorDescriptor
     nvidia.hopper.TensorDescriptorIm2Col
     nvidia.blackwell.TensorDescriptor
+    amd.cdna5.TensorDescriptor

--- a/python/triton/experimental/gluon/amd/__init__.py
+++ b/python/triton/experimental/gluon/amd/__init__.py
@@ -1,3 +1,4 @@
 from . import gfx1250
+from . import cdna5
 
-__all__ = ["gfx1250"]
+__all__ = ["gfx1250", "cdna5"]

--- a/python/triton/experimental/gluon/amd/cdna5.py
+++ b/python/triton/experimental/gluon/amd/cdna5.py
@@ -1,0 +1,5 @@
+# CDNA 5 is the architecture name for the gfx1250 target; re-export its APIs.
+from .gfx1250 import *  # NOQA: F403
+from .gfx1250 import __all__ as __gfx1250_all
+
+__all__ = [*__gfx1250_all]

--- a/python/triton/experimental/gluon/language/amd/__init__.py
+++ b/python/triton/experimental/gluon/language/amd/__init__.py
@@ -3,9 +3,11 @@ from ._layouts import AMDMFMALayout, AMDWMMALayout
 from . import cdna3, cdna4
 from . import rdna3, rdna4
 from . import gfx1250
+from . import cdna5
 from .slice import slice
 from .warp_pipeline import warp_pipeline_stage
 
 __all__ = [
-    "AMDMFMALayout", "AMDWMMALayout", "cdna3", "cdna4", "rdna3", "rdna4", "gfx1250", "warp_pipeline_stage", "slice"
+    "AMDMFMALayout", "AMDWMMALayout", "cdna3", "cdna4", "cdna5", "rdna3", "rdna4", "gfx1250", "warp_pipeline_stage",
+    "slice"
 ]

--- a/python/triton/experimental/gluon/language/amd/cdna5/__init__.py
+++ b/python/triton/experimental/gluon/language/amd/cdna5/__init__.py
@@ -1,0 +1,5 @@
+# CDNA 5 is the architecture name for the gfx1250 target; re-export its APIs.
+from ..gfx1250 import *  # NOQA: F403
+from ..gfx1250 import __all__ as __gfx1250_all
+
+__all__ = [*__gfx1250_all]


### PR DESCRIPTION
CDNA 5 is the architecture name for the gfx1250 target. Add `gluon.language.amd.cdna5` and `gluon.amd.cdna5` as re-exports of the corresponding gfx1250 modules, to keep consistency with general naming conventions.

Also wire the new module into the Sphinx docs.