### PR TITLE
[SM120] Support mixed FP8 and FP4 scaled dot

### DIFF
--- a/include/triton/Dialect/TritonGPU/IR/LinearLayoutConversions.h
+++ b/include/triton/Dialect/TritonGPU/IR/LinearLayoutConversions.h
@@ -55,6 +55,15 @@ LinearLayout toLinearLayout(TensorOrMemDesc type);
 // with the allocShape as the shape, otherwise the layout will be incorrect!
 LinearLayout toLinearLayout(ArrayRef<int64_t> shape, Attribute layout);
 
+// Returns the layout of individually represented register elements.
+//
+// Usually this is identical to toLinearLayout. For encodings such as
+// fp4Unpacked, the logical tensor retains its packed shape while each packed
+// element is represented by multiple register elements. This layout gives
+// those register elements distinct coordinates.
+LinearLayout toRegisterElementLinearLayout(ArrayRef<int64_t> shape,
+                                           Attribute layout);
+
 // Returns the linear component of a padded shared encoding. The encoding must
 // satisfy isPaddedEncoding (asserts otherwise).
 //

--- a/include/triton/Dialect/TritonGPU/IR/TritonGPUAttrDefs.td
+++ b/include/triton/Dialect/TritonGPU/IR/TritonGPUAttrDefs.td
@@ -1445,6 +1445,9 @@ kWidth defines number of consecutive elements stored by one thread along k dimen
 Some layouts do not use this parameter, either because they have a fixed number of
 elements along the K dim, or they use all elements of the tensor along the K dim.
 
+fp4Unpacked specifies that each byte containing two packed fp4 elements is
+unpacked into two bytes, with each fp4 value occupying bits [3:0] of its byte.
+
 # WGMMA Notes
 We require kWidth to be provided for Hopper because the dtype at loading might be
 different from the dtype at WGMMA, due to casting. The kWidth is determined by the
@@ -1471,7 +1474,8 @@ vecIdx (index of the element in the quad; this is always along the k-dim)
     ins
     "unsigned":$opIdx,
     "Attribute":$parent,
-    DefaultValuedParameter<"unsigned", "0">:$kWidth
+    DefaultValuedParameter<"unsigned", "0">:$kWidth,
+    DefaultValuedParameter<"bool", "false">:$fp4Unpacked
   );
 
   let builders = [
@@ -1480,11 +1484,18 @@ vecIdx (index of the element in the quad; this is always along the k-dim)
                      "Type":$eltTy), [{
       NvidiaMmaEncodingAttr parentAttr = mlir::dyn_cast<NvidiaMmaEncodingAttr>(parent);
       if (!parentAttr || (!parentAttr.isAmpere() && !parentAttr.isHopper()))
-        return $_get(context, opIdx, parent, 0);
+        return $_get(context, opIdx, parent, 0, /*fp4Unpacked=*/false);
       // For MMAV2 and V3
       unsigned bitwidth = eltTy.getIntOrFloatBitWidth();
       unsigned kWidth = std::max(32 / bitwidth, 1u);
-      return $_get(context, opIdx, parent, kWidth);
+      return $_get(context, opIdx, parent, kWidth, /*fp4Unpacked=*/false);
+    }]>,
+    // Backwards-compatible builder: fp4Unpacked defaults to false so existing
+    // get(opIdx, parent, kWidth) call sites are unaffected by the new parameter.
+    AttrBuilder<(ins "unsigned":$opIdx,
+                     "Attribute":$parent,
+                     "unsigned":$kWidth), [{
+      return $_get(context, opIdx, parent, kWidth, /*fp4Unpacked=*/false);
     }]>
   ];
 

--- a/include/triton/Dialect/TritonNvidiaGPU/IR/TargetFeatures.h
+++ b/include/triton/Dialect/TritonNvidiaGPU/IR/TargetFeatures.h
@@ -42,6 +42,7 @@ public:
   bool supportLdMatrix() const { return computeCapability >= 75; }
   bool supportStMatrix() const { return computeCapability >= 90; }
   bool supportLdStMatrixB8() const { return computeCapability >= 100; }
+  bool supportsFp4Ldmatrix() const { return computeCapability >= 100; }
 
   bool supportBitwidth16Elementwise() const {
     // Hopper (sm90) and newer.

--- a/lib/Conversion/TritonGPUToLLVM/Utility.cpp
+++ b/lib/Conversion/TritonGPUToLLVM/Utility.cpp
@@ -1066,7 +1066,8 @@ SmallVector<Value> unpackTensorElements(Location loc, Value llvmStruct,
                                         Type originalType) {
   if (auto tensorTy = dyn_cast<RankedTensorType>(originalType))
     return broadcastAs(unpackUniqueTensorElements(loc, llvmStruct, rewriter),
-                       triton::gpu::toLinearLayout(tensorTy));
+                       triton::gpu::toRegisterElementLinearLayout(
+                           tensorTy.getShape(), tensorTy.getEncoding()));
   return unpackLLElements(loc, llvmStruct, rewriter);
 }
 
@@ -1116,7 +1117,9 @@ Value packTensorElements(Location loc, const LLVMTypeConverter *typeConverter,
                          Type type) {
   if (auto tensorTy = dyn_cast<RankedTensorType>(type)) {
     auto uniqueResultVals =
-        actionRemoveBroadcastedRegs(triton::gpu::toLinearLayout(tensorTy))
+        actionRemoveBroadcastedRegs(
+            triton::gpu::toRegisterElementLinearLayout(tensorTy.getShape(),
+                                                       tensorTy.getEncoding()))
             .apply(resultVals);
     return packUniqueTensorElements(loc, typeConverter, uniqueResultVals,
                                     rewriter, type);

--- a/lib/Dialect/TritonGPU/IR/Dialect.cpp
+++ b/lib/Dialect/TritonGPU/IR/Dialect.cpp
@@ -130,8 +130,9 @@ unsigned getTotalElemsPerThread(Attribute layout, ArrayRef<int64_t> shape) {
 
 unsigned getUniqueElemsPerThread(Attribute layout, ArrayRef<int64_t> shape) {
   auto kReg = StringAttr::get(layout.getContext(), "register");
+  auto linearLayout = toRegisterElementLinearLayout(shape, layout);
   auto strippedLayout =
-      toLinearLayout(shape, layout).removeZeroBasesAlongDim(kReg);
+      actionRemoveBroadcastedRegs(linearLayout).apply(linearLayout);
   return strippedLayout.getInDimSize(kReg);
 }
 
@@ -2863,9 +2864,10 @@ CGAEncodingAttr DotOperandEncodingAttr::getCGALayout() const {
   return CGAEncodingAttr::get(getContext(),
                               layout.resizeOutDim(dims[kDim].first, 1));
 }
+
 LogicalResult DotOperandEncodingAttr::verify(
     function_ref<::mlir::InFlightDiagnostic()> emitError, unsigned opIdx,
-    Attribute parent, unsigned kWidth) {
+    Attribute parent, unsigned kWidth, [[maybe_unused]] bool fp4Unpacked) {
   if (opIdx != 0 && opIdx != 1) {
     return emitError() << "ttg.dot_op opIdx parameter can be 0 or 1, got: "
                        << opIdx;

--- a/lib/Dialect/TritonGPU/IR/LinearLayoutConversions.cpp
+++ b/lib/Dialect/TritonGPU/IR/LinearLayoutConversions.cpp
@@ -1018,15 +1018,25 @@ LinearLayout nvidiaDotToLinearLayout(ArrayRef<int64_t> shape,
 LinearLayout
 DotOperandEncodingAttr::toLinearLayout(ArrayRef<int64_t> shape) const {
   auto parent = getParent();
+  LinearLayout layout;
   if (auto blockedLayout = mlir::dyn_cast<BlockedEncodingAttr>(parent)) {
-    return fmaDotToLinearLayout(*this, shape);
+    layout = fmaDotToLinearLayout(*this, shape);
   } else if (auto mfmaLayout = mlir::dyn_cast<AMDMfmaEncodingAttr>(parent)) {
-    return mfmaDotToLinearLayout(*this, shape);
+    layout = mfmaDotToLinearLayout(*this, shape);
   } else if (auto wmmaLayout = mlir::dyn_cast<AMDWmmaEncodingAttr>(parent)) {
-    return wmmaDotOperandToLinearLayout(*this, shape);
+    layout = wmmaDotOperandToLinearLayout(*this, shape);
   } else {
-    return nvidiaDotToLinearLayout(shape, *this);
+    layout = nvidiaDotToLinearLayout(shape, *this);
   }
+
+  if (getFp4Unpacked()) {
+    MLIRContext *ctx = getContext();
+    int rank = shape.size();
+    int kDim = getOpIdx() == 0 ? rank - 1 : rank - 2;
+    auto kDimName = standardOutDimNames(ctx, rank)[kDim];
+    layout = LinearLayout::zeros1D(2, S("register"), kDimName) * layout;
+  }
+  return layout;
 }
 
 LinearLayout SliceEncodingAttr::toLinearLayout(ArrayRef<int64_t> shape) const {
@@ -1313,6 +1323,32 @@ LinearLayout toLinearLayout(ArrayRef<int64_t> shape, Attribute layout) {
   auto *ctx = layout.getContext();
   return ctx->getLoadedDialect<TritonGPUDialect>()->toLinearLayout(shape,
                                                                    layout);
+}
+
+static LinearLayout
+fp4UnpackedToRegisterElementLinearLayout(ArrayRef<int64_t> shape,
+                                         DotOperandEncodingAttr dot) {
+  assert(dot.getFp4Unpacked() && "expected an fp4Unpacked dot operand");
+  assert(shape.size() >= 2 &&
+         "fp4Unpacked dot operand must have at least two dimensions");
+  int kDim = dot.getOpIdx() == 0 ? shape.size() - 1 : shape.size() - 2;
+  auto packedDot = DotOperandEncodingAttr::get(dot.getContext(), dot.getOpIdx(),
+                                               dot.getParent(), dot.getKWidth(),
+                                               /*fp4Unpacked=*/false);
+  auto packedLayout = toLinearLayout(shape, packedDot);
+  auto kOut = standardOutDimNames(dot.getContext(), shape.size())[kDim];
+  auto kRegister = StringAttr::get(dot.getContext(), "register");
+  // Use an identity basis for the unpacked-nibble parity so the low and high
+  // nibbles remain distinct in register-element space.
+  return LinearLayout::identity1D(2, kRegister, kOut) * packedLayout;
+}
+
+LinearLayout toRegisterElementLinearLayout(ArrayRef<int64_t> shape,
+                                           Attribute layout) {
+  auto dot = dyn_cast<DotOperandEncodingAttr>(layout);
+  if (dot && dot.getFp4Unpacked())
+    return fp4UnpackedToRegisterElementLinearLayout(shape, dot);
+  return toLinearLayout(shape, layout);
 }
 
 LinearLayout paddedLinearLayout(ArrayRef<int64_t> shape, Attribute encoding) {

--- a/lib/Dialect/TritonGPU/Transforms/AccelerateMatmul.cpp
+++ b/lib/Dialect/TritonGPU/Transforms/AccelerateMatmul.cpp
@@ -152,7 +152,7 @@ warpsPerTileV3(DotOpInterface dotOp, const ArrayRef<int64_t> shape,
 // given value.
 static Value
 getSharedMemoryMMAOperand(Value v, mlir::PatternRewriter &rewriter, int opIdx,
-                          bool allowTranspose, bool isMMAv5Fp4Padded = false,
+                          bool allowTranspose, bool fp4Padded = false,
                           bool forceTranspose = false,
                           Operation *op = nullptr /*only for diagnostic*/) {
   OpBuilder::InsertionGuard g(rewriter);
@@ -192,7 +192,7 @@ getSharedMemoryMMAOperand(Value v, mlir::PatternRewriter &rewriter, int opIdx,
   auto CGALayout = getCGALayout(argType.getEncoding());
   auto newLayout = NVMMASharedEncodingAttr::get(
       argType.getContext(), argType.getShape(), newOrder, CGALayout,
-      argType.getElementType(), isMMAv5Fp4Padded);
+      argType.getElementType(), fp4Padded);
   auto newType = MemDescType::get(argType.getShape(), argType.getElementType(),
                                   newLayout, SharedMemorySpace);
   rewriter.setInsertionPointAfterValue(arg);
@@ -485,6 +485,25 @@ static Value convertDotOperandForMMA(Value v, int opIdx, int bitwidth,
   return ConvertLayoutOp::create(rewriter, v.getLoc(), newVType, v);
 }
 
+// This helper creates a `local_alloc` followed by a `local_load` for a packed
+// mxfp4 input. Thus, it stages a packed input through shared memory, and then
+// creates a fp4Unpacked dot operand. This is an optimisation for SM120.
+static Value stagePackedFp4OperandThroughSmem(Value v, int opIdx,
+                                              RankedTensorType newRetType,
+                                              PatternRewriter &rewriter) {
+  // Keep the packed (K) axis contiguous in SMEM for the dot operand.
+  Value smem = getSharedMemoryMMAOperand(v, rewriter, opIdx,
+                                         /*allowTranspose=*/false,
+                                         /*fp4Padded=*/true);
+  auto vType = cast<RankedTensorType>(v.getType());
+  auto dotEnc = DotOperandEncodingAttr::get(v.getContext(), opIdx,
+                                            newRetType.getEncoding(),
+                                            /*kWidth=*/2u,
+                                            /*fp4Unpacked=*/true);
+  auto regType = vType.cloneWithEncoding(dotEnc);
+  return LocalLoadOp::create(rewriter, v.getLoc(), regType, smem);
+}
+
 } // namespace
 
 class BlockedToMMA : public mlir::OpRewritePattern<DotOp> {
@@ -547,11 +566,11 @@ public:
                                     rewriter);
       } else {
         a = getSharedMemoryMMAOperand(a, rewriter, 0, allowTranspose,
-                                      /*isMMAv5Fp4Padded=*/false,
+                                      /*fp4Padded=*/false,
                                       /*forceTranspose=*/false, dotOp);
       }
       b = getSharedMemoryMMAOperand(b, rewriter, 1, allowTranspose,
-                                    /*isMMAv5Fp4Padded=*/false,
+                                    /*fp4Padded=*/false,
                                     /*forceTranspose=*/false, dotOp);
 
       newDot = triton::nvidia_gpu::WarpGroupDotOp::create(
@@ -737,6 +756,11 @@ public:
         mlir::isa<LinearEncodingAttr>(bScaleType.getEncoding())) {
       return failure();
     }
+
+    if (aScaleType.getElementType() != bScaleType.getElementType())
+      return failure();
+    bool isE4M3Scale = mlir::isa<Float8E4M3FNType>(aScaleType.getElementType());
+
     auto aElemType = dotOp.getAElemType();
     auto bElemType = dotOp.getBElemType();
     auto isFP8 = [&](ScaleDotElemType elemType) -> bool {
@@ -747,20 +771,26 @@ public:
       return elemType == ScaleDotElemType::E2M1;
     };
 
-    bool isFP4xFP4 = isFP4(aElemType) && isFP4(bElemType);
-    // TODO: Enable mixed-precision mxfp for sm120
-    if (!((isFP8(aElemType) && isFP8(bElemType)) || isFP4xFP4)) {
+    bool aFP8 = isFP8(aElemType), bFP8 = isFP8(bElemType);
+    bool aFP4 = isFP4(aElemType), bFP4 = isFP4(bElemType);
+    bool isFP4xFP4 = aFP4 && bFP4;
+    bool isMixedFp8Fp4 = (aFP8 && bFP4) || (aFP4 && bFP8);
+    if (!((aFP8 && bFP8) || isFP4xFP4 || isMixedFp8Fp4)) {
       return rewriter.notifyMatchFailure(
-          dotOp, "only FP8xFP8 and FP4xFP4 are supported on sm120");
+          dotOp, "this MMA lowering only supports FP8xFP8, FP4xFP4 and mixed "
+                 "FP8xFP4");
     }
-    if (isFP4xFP4 && (!dotOp.getLhsKPack() || !dotOp.getRhsKPack())) {
+    if (isE4M3Scale && !isFP4xFP4) {
       return rewriter.notifyMatchFailure(
-          dotOp, "SM120 native FP4xFP4 requires K-packed operands");
+          dotOp, "ue4m3 scales are only supported for FP4xFP4 MMA");
     }
 
-    auto scaleElemType = dotOp.getAScale().getType().getElementType();
-    if (scaleElemType != dotOp.getBScale().getType().getElementType()) {
-      return failure();
+    // The native paths unpack FP4 bytes along K. MN-packed FP4 operands must
+    // be decomposed instead.
+    if ((aFP4 && !dotOp.getLhsKPack()) || (bFP4 && !dotOp.getRhsKPack())) {
+      return rewriter.notifyMatchFailure(
+          dotOp, "FP4 operands in mixed-precision or FP4xFP4 MMA must be "
+                 "K-packed");
     }
 
     // Common MMA encoding creation
@@ -780,10 +810,19 @@ public:
     int bitwidthB = oldBType.getElementType().getIntOrFloatBitWidth();
     int minBitwidth = std::min(bitwidthA, bitwidthB);
 
-    Value newA = convertDotOperandForMMA(a, 0, minBitwidth,
-                                         mmaResult.newRetType, rewriter);
-    Value newB = convertDotOperandForMMA(b, 1, minBitwidth,
-                                         mmaResult.newRetType, rewriter);
+    // For mixed precision, the operand is staged through shared memory
+    // because we expect that this is consumed by the ldmatrix instruction
+    // later.
+    Value newA = (isMixedFp8Fp4 && aFP4)
+                     ? stagePackedFp4OperandThroughSmem(
+                           a, 0, mmaResult.newRetType, rewriter)
+                     : convertDotOperandForMMA(a, 0, minBitwidth,
+                                               mmaResult.newRetType, rewriter);
+    Value newB = (isMixedFp8Fp4 && bFP4)
+                     ? stagePackedFp4OperandThroughSmem(
+                           b, 1, mmaResult.newRetType, rewriter)
+                     : convertDotOperandForMMA(b, 1, minBitwidth,
+                                               mmaResult.newRetType, rewriter);
     const auto mmaWarps = mmaResult.mmaEnc.getWarpsPerCTA(); // [wM, wN]
     // Convert scales to Linear layout
     auto convertScale = [&](Value scale, int opIdx) -> Value {
@@ -893,12 +932,12 @@ public:
     // the packed axis, K, to be contiguous in SMEM
     a = getSharedMemoryMMAOperand(a, rewriter, 0,
                                   /*allowTranspose=*/!isAFP4,
-                                  /*isMMAv5Fp4Padded=*/isMMAv5Fp4PaddedLhs,
+                                  /*fp4Padded=*/isMMAv5Fp4PaddedLhs,
                                   /*forceTranspose=*/!dotOp.getLhsKPack(),
                                   dotOp);
     b = getSharedMemoryMMAOperand(b, rewriter, 1,
                                   /*allowTranspose=*/!isBFP4,
-                                  /*isMMAv5Fp4Padded=*/isMMAv5Fp4PaddedRhs,
+                                  /*fp4Padded=*/isMMAv5Fp4PaddedRhs,
                                   /*forceTranspose=*/!dotOp.getRhsKPack(),
                                   dotOp);
 

--- a/lib/Dialect/TritonGPU/Transforms/OptimizeDotOperands.cpp
+++ b/lib/Dialect/TritonGPU/Transforms/OptimizeDotOperands.cpp
@@ -82,13 +82,24 @@ public:
   }
 };
 
-// Rewrite
+// Rewrite a tensor transpose followed by a shared-memory allocation:
 //
-//   dot(alloc(trans() #shared1) ->
-//   dot(trans(alloc() #shared2))
+//   %src : tensor<MxN>
+//   %t = tt.trans %src             : tensor<NxM>
+//   %m = ttg.local_alloc %t        : memdesc<NxM, #shared_dst>
+//   user(%m)
 //
-// if dot is an MMAv3/v5 (because MMAv3/v5 allows us to fold transposes).
-class FuseTransMMAV3Plus : public OpRewritePattern<LocalAllocOp> {
+// into an allocation in the corresponding pre-transpose shared layout:
+//
+//   %m0 = ttg.local_alloc %src     : memdesc<MxN, #shared_src>
+//   %m = ttg.memdesc_trans %m0     : memdesc<NxM, #shared_dst>
+//   user(%m)
+//
+// where user is:
+//  - WGMMA/MMAv5, or
+//  - `ttg.local_load` if the allocation uses an `fp4Padded` shared memory
+//    encoding.
+class FuseTransIntoMemDesc : public OpRewritePattern<LocalAllocOp> {
 public:
   using OpRewritePattern::OpRewritePattern;
 
@@ -96,11 +107,11 @@ public:
                                 PatternRewriter &rewriter) const override {
     if (!allocOp.getSrc() || !allocOp->hasOneUse() ||
         !isa<triton::nvidia_gpu::WarpGroupDotOp,
-             triton::nvidia_gpu::MMAv5OpInterface>(
+             triton::nvidia_gpu::MMAv5OpInterface, LocalLoadOp>(
             *allocOp->getUsers().begin()))
       return failure();
 
-    // Match outerCvt(trans(innerCvt(x))).
+    // Match local_alloc(transpose(tensor)).
     auto trans = allocOp.getSrc().getDefiningOp<TransOp>();
     if (!trans || trans.getOrder() != ArrayRef<int32_t>({1, 0}))
       return failure();
@@ -111,6 +122,10 @@ public:
     if (!allocEncoding)
       return failure();
     RankedTensorType srcTy = trans.getSrc().getType();
+
+    if (isa<LocalLoadOp>(*allocOp->getUsers().begin()) &&
+        !allocEncoding.getFp4Padded())
+      return failure();
 
     Dialect &dialect = allocEncoding.getDialect();
     auto inferLayoutInterface = cast<DialectInferLayoutInterface>(&dialect);
@@ -323,7 +338,7 @@ public:
 
     mlir::RewritePatternSet patterns(context);
     patterns.add<SwizzleShmemConvert>(context);
-    patterns.add<FuseTransMMAV3Plus, ReshapeMemDesc>(context);
+    patterns.add<FuseTransIntoMemDesc, ReshapeMemDesc>(context);
     patterns.add<RewriteMmaOperandViewsToMemDescForDotOp>(context);
     ConvertLayoutOp::getCanonicalizationPatterns(patterns, context);
     if (failed(applyPatternsGreedily(m, std::move(patterns))))

--- a/python/src/gluon_ir.cc
+++ b/python/src/gluon_ir.cc
@@ -487,7 +487,8 @@ void init_gluon_ir(py::module_ &m) {
            [](GluonOpBuilder &self, unsigned opIdx, Attribute parent,
               unsigned kWidth) -> Attribute {
              return self.getChecked<ttg::DotOperandEncodingAttr>(
-                 self.getContext(), opIdx, parent, kWidth);
+                 self.getContext(), opIdx, parent, kWidth,
+                 /*fp4Unpacked=*/false);
            })
       .def("get_mma_layout",
            [](GluonOpBuilder &self, std::vector<unsigned> &version,

--- a/python/test/unit/language/test_matmul.py
+++ b/python/test/unit/language/test_matmul.py
@@ -1219,12 +1219,22 @@ def mxfp8_mxfp4_matmul(  #
 def test_mxfp8_mxfp4_matmul(M, N, K, BLOCK_M, BLOCK_N, BLOCK_K, NUM_STAGES, B_TRANS, PACK_B_ALONG_K, CONST_SCALE,
                             A_DATA_TYPE, B_DATA_TYPE, WITH_A_SCALE, WITH_B_SCALE, nonKDim, device):
     if is_cuda():
-        if torch.cuda.get_device_capability()[0] != 10:
-            pytest.skip("Requires compute capability == 10")
+        cc = torch.cuda.get_device_capability()[0]
+        if cc not in (10, 12):
+            pytest.skip("Requires compute capability == 10 or 12")
         if not (WITH_A_SCALE and WITH_B_SCALE):
             pytest.skip("None scale has not been tested on NV backend")
-        if not (A_DATA_TYPE == "float8e5" and B_DATA_TYPE == "float4"):
-            pytest.skip(f"(A: {A_DATA_TYPE}, B: {B_DATA_TYPE}) has not been tested on NV backend")
+        if cc == 10:
+            if not (A_DATA_TYPE == "float8e5" and B_DATA_TYPE == "float4"):
+                pytest.skip(f"(A: {A_DATA_TYPE}, B: {B_DATA_TYPE}) has not been tested on NV backend")
+        elif cc == 12:
+            fp8_types = ("float8e5", "float8e4nv")
+            is_mixed = (A_DATA_TYPE in fp8_types and B_DATA_TYPE == "float4") or \
+                       (A_DATA_TYPE == "float4" and B_DATA_TYPE in fp8_types)
+            if not is_mixed:
+                pytest.skip("Mixed fp8 x fp4 operands expected here")
+            if not PACK_B_ALONG_K:
+                pytest.skip("Mixed fp8 x fp4 requires K-packed fp4")
     elif is_hip():
         if not (is_hip_cdna4() or is_hip_gfx1250()):
             pytest.skip("Scaled mxfp4 & mxfp8 matmul is only natively supported on CDNA4 and above")
@@ -1312,8 +1322,11 @@ def test_mxfp8_mxfp4_matmul(M, N, K, BLOCK_M, BLOCK_N, BLOCK_K, NUM_STAGES, B_TR
     if is_hip_gfx1250() and B_DATA_TYPE == "float4" and not PACK_B_ALONG_K:
         assert "ds_load_tr4_b64" in out.asm["amdgcn"]
     if is_blackwell() and not is_rubin():
-        ttgir = out.asm["ttgir"]
-        assert "fp4Padded = true" in ttgir
+        # sm100: uses the padded fp4 shared memory layout.
+        assert "fp4Padded = true" in out.asm["ttgir"]
+    elif is_cuda() and torch.cuda.get_device_capability()[0] == 12:
+        # sm120: uses the fp4Unpacked register layout, staged through smem.
+        assert "kind::mxf8f6f4" in out.asm["ptx"]
 
     torch.testing.assert_close(ref_out, output, atol=1e-3, rtol=1e-3)
 

--- a/python/tutorials/10-block-scaled-matmul.py
+++ b/python/tutorials/10-block-scaled-matmul.py
@@ -5,8 +5,7 @@ This tutorial demonstrates a Triton implementation of block scaled matrix multip
 which is generic over FP4 and FP8 formats on NVIDIA and AMD GPUs.
 The tutorial supports OCP microscaling formats such as mxfp4 and mxfp8, and NVIDIA's nvfp4
 (on NVIDIA GPUs) and mxfp4 (on AMD GPUs). These matrix multiplications are hardware-accelerated
-using fifth-generation Tensor Cores on NVIDIA GPUs with compute capability 10, and by the CDNA4
-matrix cores on AMD GPUs.
+on NVIDIA GPUs with compute capability 10, 11, or 12, and by the CDNA4 matrix cores on AMD GPUs.
 Users can run the tutorial with each of the supported formats by passing the `--format`
 argument and can benchmark the performance of each by specifying matrix dimensions
 and iteration steps.
@@ -23,7 +22,10 @@ and iteration steps.
     # FP4 with Cluster Launch Control
     python 10-block-scaled-matmul.py --format nvfp4 --clc
 
-Future updates to this tutorial which support mixed precision block scaled matmul are planned.
+    # Mixed MXFP8 x MXFP4
+    python 10-block-scaled-matmul.py --format mixed -K 8192 --bench
+    python 10-block-scaled-matmul.py --format mixed -K 8192 --bench \
+        --block-m 128 --block-n 128 --block-k 128 --num-warps 4 --num-stages 2
 """
 
 # %%
@@ -140,7 +142,7 @@ def is_hip_cdna4():
 
 
 def supports_block_scaling():
-    return (is_cuda() and torch.cuda.get_device_capability()[0] in [10, 11]) or is_hip_cdna4()
+    return (is_cuda() and torch.cuda.get_device_capability()[0] in [10, 11, 12]) or is_hip_cdna4()
 
 
 def is_rubin():
@@ -285,6 +287,8 @@ def block_scaled_matmul(a_desc, a_scale_desc, b_desc, b_scale_desc, dtype_dst, M
         num_stages,
         disallow_acc_multi_buffer=configs["disallow_acc_multi_buffer"],
         clc=clc,
+        num_warps=configs["num_warps"],
+        num_stages=num_stages,
     )
     return output
 
@@ -335,10 +339,12 @@ def cublas_block_scaled_matmul(a, a_scale, b, b_scale, block_scale_type="mxfp8")
     return output
 
 
-def initialize_block_scaled(M, N, K, block_scale_type="nvfp4", compute_reference=False):
-    BLOCK_M = 128
-    BLOCK_N = 256
-    BLOCK_K = 256 if "fp4" in block_scale_type else 128
+def initialize_block_scaled(M, N, K, block_scale_type="nvfp4", compute_reference=False, *, block_m=None, block_n=None,
+                            block_k=None, num_warps=None, num_stages=None):
+    BLOCK_M = 128 if block_m is None else block_m
+    BLOCK_N = 256 if block_n is None else block_n
+    default_block_k = 256 if "fp4" in block_scale_type else 128
+    BLOCK_K = default_block_k if block_k is None else block_k
     VEC_SIZE = 16 if block_scale_type == "nvfp4" else 32
     assert block_scale_type in ["nvfp4", "mxfp4", "mxfp8", "mixed"], f"Invalid block scale type: {block_scale_type}"
     ELEM_PER_BYTE_A = 2 if "fp4" in block_scale_type else 1
@@ -425,15 +431,19 @@ def initialize_block_scaled(M, N, K, block_scale_type="nvfp4", compute_reference
         b_scale_ref = unpack_scale(b_scale_ref).repeat_interleave(VEC_SIZE, dim=1).T.contiguous()[:K, :N]
         reference = torch.matmul(a_ref.to(torch.float32) * a_scale_ref, b_ref * b_scale_ref)
 
-    if is_rubin():
-        num_stages = 6
-    else:
-        num_stages = 4
+    if num_stages is None:
+        if is_rubin():
+            num_stages = 6
+        elif is_cuda() and torch.cuda.get_device_capability()[0] == 12:
+            num_stages = 2
+        else:
+            num_stages = 4
 
     configs = {
         "BLOCK_SIZE_M": BLOCK_M,
         "BLOCK_SIZE_N": BLOCK_N,
         "BLOCK_SIZE_K": BLOCK_K,
+        "num_warps": num_warps,
         "num_stages": num_stages,
         "ELEM_PER_BYTE_A": ELEM_PER_BYTE_A,
         "ELEM_PER_BYTE_B": ELEM_PER_BYTE_B,
@@ -457,8 +467,10 @@ def initialize_block_scaled(M, N, K, block_scale_type="nvfp4", compute_reference
     return a_desc, a_scale_desc, b_desc, b_scale_desc, rep_m, rep_n, rep_k, configs, reference, a, b, a_scale_cublas, b_scale_cublas
 
 
-def validate_block_scaled(M, N, K, block_scale_type="nvfp4", clc=False):
-    results = initialize_block_scaled(M, N, K, block_scale_type, compute_reference=True)
+def validate_block_scaled(M, N, K, block_scale_type="nvfp4", clc=False, *, block_m=None, block_n=None, block_k=None,
+                          num_warps=None, num_stages=None):
+    results = initialize_block_scaled(M, N, K, block_scale_type, compute_reference=True, block_m=block_m,
+                                      block_n=block_n, block_k=block_k, num_warps=num_warps, num_stages=num_stages)
     a_desc, a_scale_desc, b_desc, b_scale_desc, rep_m, rep_n, rep_k, configs, reference = results[:9]
     a, b, a_scale_cublas, b_scale_cublas = results[9:]
 
@@ -477,13 +489,15 @@ def validate_block_scaled(M, N, K, block_scale_type="nvfp4", clc=False):
         print(f"✅ (pass {block_scale_type} - Triton only)")
 
 
-def bench_block_scaled(K, block_scale_type="nvfp4", reps=10, warmup_reps=10, clc=False):
+def bench_block_scaled(K, block_scale_type="nvfp4", reps=10, warmup_reps=10, clc=False, *, block_m=None, block_n=None,
+                       block_k=None, num_warps=None, num_stages=None):
     assert K % 128 == 0
     M = 8192
     N = 8192
     print(f"Problem Shape = {M}x{N}x{K}")
 
-    results = initialize_block_scaled(M, N, K, block_scale_type, compute_reference=False)
+    results = initialize_block_scaled(M, N, K, block_scale_type, compute_reference=False, block_m=block_m,
+                                      block_n=block_n, block_k=block_k, num_warps=num_warps, num_stages=num_stages)
     a_desc, a_scale_desc, b_desc, b_scale_desc, rep_m, rep_n, rep_k, configs, _ = results[:9]
     a, b, a_scale_cublas, b_scale_cublas = results[9:]
 
@@ -616,17 +630,20 @@ def shuffle_scales_cdna4(scales: torch.Tensor, mfma_nonkdim: int):
     return scales_shuffled
 
 
-def initialize_block_scaled_amd(M, N, K, mfma_nonkdim):
+def initialize_block_scaled_amd(M, N, K, mfma_nonkdim, *, block_m=None, block_n=None, block_k=None, num_warps=None,
+                                num_stages=None):
 
-    BLOCK_M = 128
-    BLOCK_N = 128
-    BLOCK_K = 256
+    BLOCK_M = 128 if block_m is None else block_m
+    BLOCK_N = 128 if block_n is None else block_n
+    BLOCK_K = 256 if block_k is None else block_k
+    num_warps = 8 if num_warps is None else num_warps
+    num_stages = 2 if num_stages is None else num_stages
     configs = {
         "BLOCK_M": BLOCK_M,
         "BLOCK_N": BLOCK_N,
         "BLOCK_K": BLOCK_K,
-        "num_stages": 2,
-        "num_warps": 8,
+        "num_stages": num_stages,
+        "num_warps": num_warps,
         "mfma_nonkdim": mfma_nonkdim,
     }
 
@@ -653,7 +670,8 @@ def initialize_block_scaled_amd(M, N, K, mfma_nonkdim):
     )
 
 
-def validate_block_scaled_amd(M, N, K, block_scale_type="mxfp4", mfma_nonkdim=16):
+def validate_block_scaled_amd(M, N, K, block_scale_type="mxfp4", mfma_nonkdim=16, *, block_m=None, block_n=None,
+                              block_k=None, num_warps=None, num_stages=None):
 
     def e8m0_to_f32(x):
         x_f32 = 2**((x - 127).to(torch.float32))
@@ -674,7 +692,8 @@ def validate_block_scaled_amd(M, N, K, block_scale_type="mxfp4", mfma_nonkdim=16
         return torch.mm(x_f32, w_f32.T).to(dtype)
 
     x_mxfp4, w_mxfp4, x_scales, w_scales, x_scales_triton, w_scales_triton, configs = \
-    initialize_block_scaled_amd(M, N, K, mfma_nonkdim)
+    initialize_block_scaled_amd(M, N, K, mfma_nonkdim, block_m=block_m, block_n=block_n, block_k=block_k,
+                                num_warps=num_warps, num_stages=num_stages)
 
     x = x_mxfp4.to_packed_tensor(dim=1)
     w = w_mxfp4.to_packed_tensor(dim=1)
@@ -716,14 +735,16 @@ def block_scaled_matmul_amd(x, w, x_scales_triton, w_scales_triton, configs):
     return triton_out
 
 
-def bench_block_scaled_amd(K, block_scale_type="mxfp4", reps=10, mfma_nonkdim=16):
+def bench_block_scaled_amd(K, block_scale_type="mxfp4", reps=10, mfma_nonkdim=16, *, block_m=None, block_n=None,
+                           block_k=None, num_warps=None, num_stages=None):
     assert K % 128 == 0
     M = 8192
     N = 8192
     print(f"Problem Shape = {M}x{N}x{K}")
 
     x_mxfp4, w_mxfp4, x_scales, w_scales, x_scales_triton, w_scales_triton, configs = \
-    initialize_block_scaled_amd(M, N, K, mfma_nonkdim)
+    initialize_block_scaled_amd(M, N, K, mfma_nonkdim, block_m=block_m, block_n=block_n, block_k=block_k,
+                                num_warps=num_warps, num_stages=num_stages)
 
     x = x_mxfp4.to_packed_tensor(dim=1)
     w = w_mxfp4.to_packed_tensor(dim=1)
@@ -743,7 +764,19 @@ if __name__ == "__main__":
     parser.add_argument("--bench", action="store_true", default=True)
     parser.add_argument("--format", type=str, choices=["mxfp4", "nvfp4", "mxfp8", "mixed"], default="nvfp4")
     parser.add_argument("--clc", action="store_true", help="Enable CLC scheduling on NVIDIA SM100+")
+    parser.add_argument("--block-m", type=int, help="override the M tile size")
+    parser.add_argument("--block-n", type=int, help="override the N tile size")
+    parser.add_argument("--block-k", type=int, help="override the K tile size")
+    parser.add_argument("--num-warps", type=int, help="override the number of warps")
+    parser.add_argument("--num-stages", type=int, help="override the number of pipeline stages")
     args = parser.parse_args()
+    tuning_options = {
+        "block_m": args.block_m,
+        "block_n": args.block_n,
+        "block_k": args.block_k,
+        "num_warps": args.num_warps,
+        "num_stages": args.num_stages,
+    }
 
     if args.clc and (not is_cuda() or torch.cuda.get_device_capability()[0] < 10):
         parser.error("--clc requires an NVIDIA SM100+ GPU")
@@ -758,20 +791,22 @@ if __name__ == "__main__":
         torch.manual_seed(42)
 
         if is_cuda():
-            validate_block_scaled(8192, 8192, 8192, block_scale_type=args.format, clc=args.clc)
+            validate_block_scaled(8192, 8192, 8192, block_scale_type=args.format, clc=args.clc, **tuning_options)
         elif is_hip_cdna4():
             assert args.format == "mxfp4", "AMD tutorial only supports mxpf4 format currently"
-            validate_block_scaled_amd(8192, 8192, 8192, block_scale_type=args.format, mfma_nonkdim=16)
-            validate_block_scaled_amd(8192, 8192, 8192, block_scale_type=args.format, mfma_nonkdim=32)
+            validate_block_scaled_amd(8192, 8192, 8192, block_scale_type=args.format, mfma_nonkdim=16, **tuning_options)
+            validate_block_scaled_amd(8192, 8192, 8192, block_scale_type=args.format, mfma_nonkdim=32, **tuning_options)
 
         if args.bench:
             proton.start("block_scaled_matmul", hook="triton")
             proton.deactivate()  # Skip argument creation
             for K in range(args.K_range[0], args.K_range[1] + 1, args.K_step):
                 if is_cuda():
-                    bench_block_scaled(K, reps=10000, block_scale_type=args.format, clc=args.clc)
+                    bench_block_scaled(K, reps=10000, block_scale_type=args.format, clc=args.clc, **tuning_options)
                 elif is_hip_cdna4():
-                    bench_block_scaled_amd(K, reps=10000, block_scale_type=args.format, mfma_nonkdim=16)
-                    bench_block_scaled_amd(K, reps=10000, block_scale_type=args.format, mfma_nonkdim=32)
+                    bench_block_scaled_amd(K, reps=10000, block_scale_type=args.format, mfma_nonkdim=16,
+                                           **tuning_options)
+                    bench_block_scaled_amd(K, reps=10000, block_scale_type=args.format, mfma_nonkdim=32,
+                                           **tuning_options)
             proton.finalize()
             show_profile("block_scaled_matmul")

--- a/test/Conversion/tritongpu_to_llvm_sm120.mlir
+++ b/test/Conversion/tritongpu_to_llvm_sm120.mlir
@@ -1,25 +1,120 @@
-// RUN: triton-opt %s -split-input-file --tritongpu-accelerate-matmul --allocate-shared-memory-nv='compute-capability=120' --convert-triton-gpu-to-llvm='compute-capability=120' --convert-nv-gpu-to-llvm | mlir-translate --mlir-to-llvmir | FileCheck %s
+// RUN: triton-opt %s -split-input-file --tritongpu-accelerate-matmul --allocate-shared-memory-nv='compute-capability=120' --convert-triton-gpu-to-llvm='compute-capability=120' | FileCheck %s
 
+// The fp4Padded shared encoding is lowered away by convert-to-llvm, so assert
+// it at the ttgir stage here.
+//
+// RUN: triton-opt %s -split-input-file --tritongpu-accelerate-matmul | FileCheck %s --check-prefix=TTGIR
+
+// Mixed-precision mxfp8 x mxfp4 on sm120 lowers to a kind::mxf8f6f4 block-scaled
+// mma.sync. The packed fp4 operand (2 e2m1 per byte, [16,128] i8) is staged
+// through fp4Padded shared memory and loaded into a kWidth=2 fp4Unpacked
+// register dot operand.
+//
+// The staged fp4 operand is loaded with the cooperative fp4 ldmatrix mode
+// (ldmatrix.m8n16.b8x16.b4x16_p64): the hardware decompresses each packed 4-bit
+// e2m1 into bits [3:0] of an 8-bit container. MMAv2 moves each value into bits
+// [5:2] immediately before the mixed-precision MMA.
 #blocked = #ttg.blocked<{sizePerThread = [1, 1], threadsPerWarp = [1, 32], warpsPerCTA = [1, 4], order = [1, 0]}>
 #blocked_k = #ttg.blocked<{sizePerThread = [1, 1], threadsPerWarp = [1, 32], warpsPerCTA = [4, 1], order = [0, 1]}>
-#mma = #ttg.nvidia_mma<{versionMajor = 2, versionMinor = 0, warpsPerCTA = [1, 4], instrShape = [16, 8]}>
 
 module attributes {"ttg.target" = "cuda:120", "ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, "ttg.threads-per-warp" = 32 : i32} {
-  // CHECK-LABEL: @sm120_mmav2_dot_scaled
-  // CHECK: mma.sync.aligned.m16n8k32.row.col.kind::mxf8f6f4.block_scale.scale_vec::1X
-  tt.func public @sm120_mmav2_dot_scaled(
-    %a: tensor<128x32xf8E5M2, #blocked_k>,
+  // CHECK-LABEL: @sm120_mmav2_dot_scaled_mixed
+  // CHECK: nvvm.ldmatrix {{.*}}<b8x16.b4x16_p64>{{.*}}num = 4{{.*}}<m = 8, n = 16>
+  // CHECK: %[[B_MASK:.+]] = llvm.mlir.constant(252645135 : i32) : i32
+  // CHECK: %[[B_MASKED:.+]] = llvm.and %{{.*}}, %[[B_MASK]] : i32
+  // CHECK: %[[B_SHIFT:.+]] = llvm.mlir.constant(2 : i32) : i32
+  // CHECK: llvm.shl %[[B_MASKED]], %[[B_SHIFT]] : i32
+  // CHECK: mma.sync.aligned.m16n8k32.row.col.kind::mxf8f6f4.block_scale.scale_vec::1X.f32.e4m3.e2m1.f32.ue8m0
+  // The packed fp4 operand %b is staged through fp4Padded shared memory and
+  // loaded into a kWidth=2 fp4Unpacked register dot operand (opIdx = 1).
+  // TTGIR-DAG: #[[$SHARED:.+]] = #ttg.nvmma_shared<{{.*}}elementBitWidth = 8, fp4Padded = true{{.*}}>
+  // TTGIR-LABEL: @sm120_mmav2_dot_scaled_mixed
+  // TTGIR: ttg.local_alloc {{.*}}-> !ttg.memdesc<{{.*}}xi8, #[[$SHARED]], #smem>
+  // TTGIR: ttg.local_load {{.*}}-> tensor<{{.*}}xi8, #ttg.dot_op<{opIdx = 1, {{.*}}kWidth = 2, fp4Unpacked = true}>>
+  tt.func public @sm120_mmav2_dot_scaled_mixed(
+    %a: tensor<128x32xf8E4M3FN, #blocked_k>,
     %sa: tensor<128x1xi8, #blocked>,
-    %b: tensor<32x128xf8E5M2, #blocked>,
+    %b: tensor<16x128xi8, #blocked>,
     %sb: tensor<128x1xi8, #blocked>,
     %out: !tt.ptr<f32>
   ){
     %c = arith.constant dense<0.000000e+00> : tensor<128x128xf32, #blocked>
-    %a_d = ttg.convert_layout %a : tensor<128x32xf8E5M2, #blocked_k> -> tensor<128x32xf8E5M2, #ttg.dot_op<{opIdx = 0, parent = #mma, kWidth = 4}>>
-    %b_d = ttg.convert_layout %b : tensor<32x128xf8E5M2, #blocked> -> tensor<32x128xf8E5M2, #ttg.dot_op<{opIdx = 1, parent = #mma, kWidth = 4}>>
-    %d = tt.dot_scaled %a_d scale %sa, %b_d scale %sb, %c lhs = e5m2 rhs = e5m2 {fastMath = false}
-      : tensor<128x32xf8E5M2, #ttg.dot_op<{opIdx = 0, parent = #mma, kWidth = 4}>>, tensor<128x1xi8, #blocked>
-        * tensor<32x128xf8E5M2, #ttg.dot_op<{opIdx = 1, parent = #mma, kWidth = 4}>>, tensor<128x1xi8, #blocked>
+    %d = tt.dot_scaled %a scale %sa, %b scale %sb, %c lhs = e4m3 rhs = e2m1 {fastMath = false}
+      : tensor<128x32xf8E4M3FN, #blocked_k>, tensor<128x1xi8, #blocked>
+        * tensor<16x128xi8, #blocked>, tensor<128x1xi8, #blocked>
+        -> tensor<128x128xf32, #blocked>
+    %out_splat = tt.splat %out : !tt.ptr<f32> -> tensor<128x1x!tt.ptr<f32>, #blocked>
+    %out_ptrs = tt.broadcast %out_splat : tensor<128x1x!tt.ptr<f32>, #blocked> -> tensor<128x128x!tt.ptr<f32>, #blocked>
+    %zero = arith.constant dense<0> : tensor<128x128xi1, #blocked>
+    tt.store %out_ptrs, %d, %zero : tensor<128x128x!tt.ptr<f32>, #blocked>
+    tt.return
+  }
+}
+
+// -----
+
+// Loading an fp4Padded SMEM source into an fp4Unpacked B register operand is
+// legal with transposed=false, but this layout cannot be divided by the
+// b4x16_p64 ldmatrix tile. I.e., for operand B, b4x16_p64 requires packed K to
+// be contiguous (transposed=true). But with transposed=false N is contiguous
+// instead, forcing the legal load to fall back to scalar loads that unpack
+// fp4Padded SMEM into fp4Unpacked registers.
+//
+#mma = #ttg.nvidia_mma<{versionMajor = 2, versionMinor = 0, warpsPerCTA = [2, 2], instrShape = [16, 8]}>
+#shared = #ttg.nvmma_shared<{swizzlingByteWidth = 32, transposed = false, elementBitWidth = 8, fp4Padded = true}>
+#smem = #ttg.shared_memory
+
+module attributes {"ttg.target" = "cuda:120", "ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, "ttg.threads-per-warp" = 32 : i32} {
+  // CHECK-LABEL: @sm120_fp4_unpacked_from_padded_smem_scalar_fallback
+  // CHECK-NOT: <b8x16.b4x16_p64>
+  // CHECK: llvm.load {{.*}} : !llvm.ptr<3> -> {{(i8|vector<[0-9]+xi8>)}}
+  // CHECK: llvm.and {{.*}} : i8
+  // CHECK: llvm.lshr {{.*}} : i8
+  // CHECK: llvm.and {{.*}} : i8
+  // CHECK-NOT: <b8x16.b4x16_p64>
+  // CHECK: llvm.call @vprintf
+  // CHECK: llvm.return
+  tt.func @sm120_fp4_unpacked_from_padded_smem_scalar_fallback(
+    %src: !ttg.memdesc<16x128xi8, #shared, #smem, mutable>
+  ) {
+    %0 = ttg.local_load %src
+      : !ttg.memdesc<16x128xi8, #shared, #smem, mutable>
+        -> tensor<16x128xi8, #ttg.dot_op<{opIdx = 1, parent = #mma, kWidth = 2, fp4Unpacked = true}>>
+    tt.print "fp4: " {hex = false, isSigned = array<i32: 0>} : %0 : tensor<16x128xi8, #ttg.dot_op<{opIdx = 1, parent = #mma, kWidth = 2, fp4Unpacked = true}>>
+    tt.return
+  }
+}
+
+// -----
+
+// Mirror case: packed fp4 A is staged through fp4Padded shared memory while
+// fp8 B remains in registers.
+#blocked = #ttg.blocked<{sizePerThread = [1, 1], threadsPerWarp = [1, 32], warpsPerCTA = [1, 4], order = [1, 0]}>
+#blocked_k = #ttg.blocked<{sizePerThread = [1, 1], threadsPerWarp = [1, 32], warpsPerCTA = [4, 1], order = [0, 1]}>
+
+module attributes {"ttg.target" = "cuda:120", "ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, "ttg.threads-per-warp" = 32 : i32} {
+  // CHECK-LABEL: @sm120_mmav2_dot_scaled_mixed_fp4_a
+  // CHECK: nvvm.ldmatrix {{.*}}<b8x16.b4x16_p64>{{.*}}num = 4{{.*}}<m = 8, n = 16>
+  // CHECK: %[[A_MASK:.+]] = llvm.mlir.constant(252645135 : i32) : i32
+  // CHECK: %[[A_MASKED:.+]] = llvm.and %{{.*}}, %[[A_MASK]] : i32
+  // CHECK: %[[A_SHIFT:.+]] = llvm.mlir.constant(2 : i32) : i32
+  // CHECK: llvm.shl %[[A_MASKED]], %[[A_SHIFT]] : i32
+  // CHECK: mma.sync.aligned.m16n8k32.row.col.kind::mxf8f6f4.block_scale.scale_vec::1X.f32.e2m1.e4m3.f32.ue8m0
+  // TTGIR-DAG: #[[$SHARED_A:.+]] = #ttg.nvmma_shared<{{.*}}elementBitWidth = 8, fp4Padded = true{{.*}}>
+  // TTGIR-LABEL: @sm120_mmav2_dot_scaled_mixed_fp4_a
+  // TTGIR: ttg.local_alloc {{.*}}-> !ttg.memdesc<{{.*}}xi8, #[[$SHARED_A]], #smem>
+  // TTGIR: ttg.local_load {{.*}}-> tensor<{{.*}}xi8, #ttg.dot_op<{opIdx = 0, {{.*}}kWidth = 2, fp4Unpacked = true}>>
+  tt.func public @sm120_mmav2_dot_scaled_mixed_fp4_a(
+    %a: tensor<128x16xi8, #blocked>,
+    %sa: tensor<128x1xi8, #blocked>,
+    %b: tensor<32x128xf8E4M3FN, #blocked_k>,
+    %sb: tensor<128x1xi8, #blocked>,
+    %out: !tt.ptr<f32>
+  ){
+    %c = arith.constant dense<0.000000e+00> : tensor<128x128xf32, #blocked>
+    %d = tt.dot_scaled %a scale %sa, %b scale %sb, %c lhs = e2m1 rhs = e4m3 {fastMath = false}
+      : tensor<128x16xi8, #blocked>, tensor<128x1xi8, #blocked>
+        * tensor<32x128xf8E4M3FN, #blocked_k>, tensor<128x1xi8, #blocked>
         -> tensor<128x128xf32, #blocked>
     %out_splat = tt.splat %out : !tt.ptr<f32> -> tensor<128x1x!tt.ptr<f32>, #blocked>
     %out_ptrs = tt.broadcast %out_splat : tensor<128x1x!tt.ptr<f32>, #blocked> -> tensor<128x128x!tt.ptr<f32>, #blocked>

--- a/test/TritonGPU/accelerate-matmul.mlir
+++ b/test/TritonGPU/accelerate-matmul.mlir
@@ -912,6 +912,146 @@ module attributes {"ttg.target" = "cuda:120", "ttg.num-ctas" = 1 : i32, "ttg.num
 
 // -----
 
+// Verify that for SM_120 with mixed FP8 x FP4 inputs, tt.dot_scaled is preserved
+// and the packed fp4 operand is staged through fp4Padded shared memory
+// (local_alloc + local_load) so the pipeliner can multi-buffer it, while the fp8
+// operand uses the register path. (Flow 2)
+
+#blocked2 = #ttg.blocked<{sizePerThread = [1, 1], threadsPerWarp = [1, 32], warpsPerCTA = [1, 4], order = [1, 0]}>
+#blocked2_k = #ttg.blocked<{sizePerThread = [1, 1], threadsPerWarp = [1, 32], warpsPerCTA = [4, 1], order = [0, 1]}>
+
+module attributes {"ttg.target" = "cuda:120", "ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, "ttg.threads-per-warp" = 32 : i32} {
+  // CHECK-DAG: #[[$MMA:.+]] = #ttg.nvidia_mma<{versionMajor = 2
+  // CHECK-DAG: #[[$SHARED:.+]] = #ttg.nvmma_shared<{{.*}}elementBitWidth = 8, fp4Padded = true{{.*}}>
+  // CHECK-LABEL: @sm120_dot_scaled_fp8_fp4_mixed
+  // The fp8 operand A stays in registers as a kWidth=4 dot operand.
+  // CHECK-DAG: %[[A:.+]] = ttg.convert_layout %arg0 {{.*}}-> tensor<128x64xf8E4M3FN, #ttg.dot_op<{opIdx = 0, parent = #[[$MMA]], kWidth = 4}>>
+  // The packed fp4 operand B is staged through shared memory, then loaded into a
+  // kWidth=2 fp4Unpacked register dot operand (the LocalLoadOp lowering expands
+  // the two e2m1 nibbles into separate 8-bit fields) that feeds the dot.
+  // CHECK-DAG: %[[SMEM:.+]] = ttg.local_alloc %arg2 {{.*}}-> !ttg.memdesc<32x128xi8, #[[$SHARED]], #smem>
+  // CHECK: %[[B:.+]] = ttg.local_load %[[SMEM]] {{.*}}-> tensor<32x128xi8, #ttg.dot_op<{opIdx = 1, parent = #[[$MMA]], kWidth = 2, fp4Unpacked = true}>>
+  // CHECK: tt.dot_scaled %[[A]] scale {{.*}}, %[[B]] scale {{.*}} lhs = e4m3 rhs = e2m1
+  // CHECK-NOT: ttg.fp4_to_fp
+  tt.func public @sm120_dot_scaled_fp8_fp4_mixed(
+    %a: tensor<128x64xf8E4M3FN, #blocked2_k>,
+    %scale_a: tensor<128x2xi8, #blocked2>,
+    %b: tensor<32x128xi8, #blocked2>,
+    %scale_b: tensor<128x2xi8, #blocked2>
+  ) -> tensor<128x128xf32, #blocked2> {
+    %cst = arith.constant dense<0.000000e+00> : tensor<128x128xf32, #blocked2>
+    %d = tt.dot_scaled %a scale %scale_a, %b scale %scale_b, %cst lhs = e4m3 rhs = e2m1 {fastMath = false}
+      : tensor<128x64xf8E4M3FN, #blocked2_k>, tensor<128x2xi8, #blocked2>
+        * tensor<32x128xi8, #blocked2>, tensor<128x2xi8, #blocked2>
+        -> tensor<128x128xf32, #blocked2>
+    tt.return %d : tensor<128x128xf32, #blocked2>
+  }
+}
+
+// -----
+
+// Mirror of the previous case: A is packed FP4 and B is FP8. The packed fp4 A
+// operand is staged through fp4Padded shared memory (local_alloc + local_load)
+// into a kWidth=2 opIdx=0 dot operand, while the fp8 B operand uses the register
+// path. (Flow 2)
+
+#blocked2 = #ttg.blocked<{sizePerThread = [1, 1], threadsPerWarp = [1, 32], warpsPerCTA = [1, 4], order = [1, 0]}>
+#blocked2_k = #ttg.blocked<{sizePerThread = [1, 1], threadsPerWarp = [1, 32], warpsPerCTA = [4, 1], order = [0, 1]}>
+
+module attributes {"ttg.target" = "cuda:120", "ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, "ttg.threads-per-warp" = 32 : i32} {
+  // CHECK-DAG: #[[$MMA:.+]] = #ttg.nvidia_mma<{versionMajor = 2
+  // CHECK-DAG: #[[$SHARED:.+]] = #ttg.nvmma_shared<{{.*}}elementBitWidth = 8, fp4Padded = true{{.*}}>
+  // CHECK-LABEL: @sm120_dot_scaled_fp4_fp8_mixed
+  // The fp8 operand B stays in registers as a kWidth=4 dot operand.
+  // CHECK-DAG: %[[B:.+]] = ttg.convert_layout %arg2 {{.*}}-> tensor<64x128xf8E4M3FN, #ttg.dot_op<{opIdx = 1, parent = #[[$MMA]], kWidth = 4}>>
+  // The packed fp4 operand A is staged through shared memory, then loaded into a
+  // kWidth=2 fp4Unpacked opIdx=0 register dot operand (the LocalLoadOp lowering
+  // expands the two e2m1 nibbles into separate 8-bit fields) that feeds the dot.
+  // CHECK-DAG: %[[SMEM:.+]] = ttg.local_alloc %arg0 {{.*}}-> !ttg.memdesc<128x32xi8, #[[$SHARED]], #smem>
+  // CHECK-DAG: %[[A:.+]] = ttg.local_load %[[SMEM]] {{.*}}-> tensor<128x32xi8, #ttg.dot_op<{opIdx = 0, parent = #[[$MMA]], kWidth = 2, fp4Unpacked = true}>>
+  // CHECK: tt.dot_scaled %[[A]] scale {{.*}}, %[[B]] scale {{.*}} lhs = e2m1 rhs = e4m3
+  // CHECK-NOT: ttg.fp4_to_fp
+  tt.func public @sm120_dot_scaled_fp4_fp8_mixed(
+    %a: tensor<128x32xi8, #blocked2>,
+    %scale_a: tensor<128x2xi8, #blocked2>,
+    %b: tensor<64x128xf8E4M3FN, #blocked2_k>,
+    %scale_b: tensor<128x2xi8, #blocked2>
+  ) -> tensor<128x128xf32, #blocked2> {
+    %cst = arith.constant dense<0.000000e+00> : tensor<128x128xf32, #blocked2>
+    %d = tt.dot_scaled %a scale %scale_a, %b scale %scale_b, %cst lhs = e2m1 rhs = e4m3 {fastMath = false}
+      : tensor<128x32xi8, #blocked2>, tensor<128x2xi8, #blocked2>
+        * tensor<64x128xf8E4M3FN, #blocked2_k>, tensor<128x2xi8, #blocked2>
+        -> tensor<128x128xf32, #blocked2>
+    tt.return %d : tensor<128x128xf32, #blocked2>
+  }
+}
+
+// -----
+
+// Verify that FP8 x FP8 with ue4m3 scales falls back to decomposition on
+// SM_120. Native ue4m3 scale support is limited to FP4 x FP4.
+
+#blocked2 = #ttg.blocked<{sizePerThread = [1, 1], threadsPerWarp = [1, 32], warpsPerCTA = [1, 4], order = [1, 0]}>
+#blocked2_k = #ttg.blocked<{sizePerThread = [1, 1], threadsPerWarp = [1, 32], warpsPerCTA = [4, 1], order = [0, 1]}>
+
+module attributes {"ttg.target" = "cuda:120", "ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, "ttg.threads-per-warp" = 32 : i32} {
+  // CHECK-LABEL: @sm120_dot_scaled_fp8_fp8_ue4m3_scale_fallback
+  // CHECK-NOT: tt.dot_scaled
+  // CHECK: tt.dot
+  // CHECK-NOT: tt.dot_scaled
+  // CHECK: tt.return
+  tt.func public @sm120_dot_scaled_fp8_fp8_ue4m3_scale_fallback(
+    %a: tensor<128x64xf8E4M3FN, #blocked2_k>,
+    %scale_a: tensor<128x4xf8E4M3FN, #blocked2>,
+    %b: tensor<64x128xf8E4M3FN, #blocked2>,
+    %scale_b: tensor<128x4xf8E4M3FN, #blocked2>
+  ) -> tensor<128x128xf32, #blocked2> {
+    %cst = arith.constant dense<0.000000e+00> : tensor<128x128xf32, #blocked2>
+    %d = tt.dot_scaled %a scale %scale_a, %b scale %scale_b, %cst lhs = e4m3 rhs = e4m3 {fastMath = false}
+      : tensor<128x64xf8E4M3FN, #blocked2_k>, tensor<128x4xf8E4M3FN, #blocked2>
+        * tensor<64x128xf8E4M3FN, #blocked2>, tensor<128x4xf8E4M3FN, #blocked2>
+        -> tensor<128x128xf32, #blocked2>
+    tt.return %d : tensor<128x128xf32, #blocked2>
+  }
+}
+
+// -----
+
+// A non-K-packed FP4 operand cannot use the native mixed mxf8f6f4 path. It
+// must be decomposed by unpacking along M instead of being staged through the
+// padded-SMEM/fp4Unpacked ldmatrix path.
+
+#blocked2 = #ttg.blocked<{sizePerThread = [1, 1], threadsPerWarp = [1, 32], warpsPerCTA = [1, 4], order = [1, 0]}>
+#blocked2_k = #ttg.blocked<{sizePerThread = [1, 1], threadsPerWarp = [1, 32], warpsPerCTA = [4, 1], order = [0, 1]}>
+
+module attributes {"ttg.target" = "cuda:120", "ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, "ttg.threads-per-warp" = 32 : i32} {
+  // CHECK-NOT: fp4Padded = true
+  // CHECK-LABEL: @sm120_dot_scaled_fp4_m_packed_decomposes
+  // CHECK-NOT: fp4Padded = true
+  // CHECK-NOT: fp4Unpacked = true
+  // CHECK-NOT: tt.dot_scaled
+  // CHECK: ttg.fp4_to_fp {{.*}} {axis = 0 : i32}
+  // CHECK-NOT: tt.dot_scaled
+  // CHECK: tt.dot
+  // CHECK-NOT: tt.dot_scaled
+  // CHECK: tt.return
+  tt.func public @sm120_dot_scaled_fp4_m_packed_decomposes(
+    %a: tensor<64x64xi8, #blocked2>,
+    %scale_a: tensor<128x2xi8, #blocked2>,
+    %b: tensor<64x128xf8E4M3FN, #blocked2_k>,
+    %scale_b: tensor<128x2xi8, #blocked2>
+  ) -> tensor<128x128xf32, #blocked2> {
+    %cst = arith.constant dense<0.000000e+00> : tensor<128x128xf32, #blocked2>
+    %d = tt.dot_scaled %a scale %scale_a, %b scale %scale_b, %cst lhs = e2m1 rhs = e4m3 {fastMath = false, lhs_k_pack = false}
+      : tensor<64x64xi8, #blocked2>, tensor<128x2xi8, #blocked2>
+        * tensor<64x128xf8E4M3FN, #blocked2_k>, tensor<128x2xi8, #blocked2>
+        -> tensor<128x128xf32, #blocked2>
+    tt.return %d : tensor<128x128xf32, #blocked2>
+  }
+}
+
+// -----
+
 // Verify that for SM_120 with mixed fp16/fp8 inputs, tt.dot_scaled falls back
 // to decomposition instead of native dot_scaled MMAv2 lowering.
 

--- a/test/TritonGPU/dot-operands.mlir
+++ b/test/TritonGPU/dot-operands.mlir
@@ -53,6 +53,32 @@ module attributes {"ttg.target" = "cuda:90", "ttg.num-ctas" = 1 : i32, "ttg.num-
 
 // -----
 
+#blocked_fp4 = #ttg.blocked<{sizePerThread = [1, 16], threadsPerWarp = [8, 4], warpsPerCTA = [4, 1], order = [1, 0]}>
+#blocked_fp4_t = #ttg.blocked<{sizePerThread = [16, 1], threadsPerWarp = [4, 8], warpsPerCTA = [1, 4], order = [0, 1]}>
+#shared_fp4_t = #ttg.nvmma_shared<{swizzlingByteWidth = 128, transposed = true, elementBitWidth = 8, fp4Padded = true}>
+#smem_fp4 = #ttg.shared_memory
+
+module attributes {"ttg.target" = "cuda:120", "ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, "ttg.threads-per-warp" = 32 : i32} {
+  // CHECK-DAG: #[[$BLOCKED_FP4_T:.*]] = #ttg.blocked<{sizePerThread = [16, 1], threadsPerWarp = [4, 8], warpsPerCTA = [1, 4], order = [0, 1]}>
+  // CHECK-DAG: #[[$FP4_SHARED:.*]] = #ttg.nvmma_shared<{swizzlingByteWidth = 128, transposed = false, elementBitWidth = 8, fp4Padded = true}>
+  // CHECK-DAG: #[[$FP4_SHARED_T:.*]] = #ttg.nvmma_shared<{swizzlingByteWidth = 128, transposed = true, elementBitWidth = 8, fp4Padded = true}>
+  // CHECK-LABEL: @sm120_fp4_transpose_in_shared_memory
+  // CHECK-NOT: tt.trans
+  // CHECK: %[[ALLOC:.*]] = ttg.local_alloc %arg0 : (tensor<256x64xi8, #{{.*}}>) -> !ttg.memdesc<256x64xi8, #[[$FP4_SHARED]], #smem>
+  // CHECK: %[[TRANS:.*]] = ttg.memdesc_trans %[[ALLOC]] {order = array<i32: 1, 0>} : !ttg.memdesc<256x64xi8, #[[$FP4_SHARED]], #smem> -> !ttg.memdesc<64x256xi8, #[[$FP4_SHARED_T]], #smem>
+  // CHECK: ttg.local_load %[[TRANS]] : !ttg.memdesc<64x256xi8, #[[$FP4_SHARED_T]], #smem> -> tensor<64x256xi8, #[[$BLOCKED_FP4_T]]>
+  tt.func @sm120_fp4_transpose_in_shared_memory(
+      %b: tensor<256x64xi8, #blocked_fp4>)
+      -> tensor<64x256xi8, #blocked_fp4_t> {
+    %b_t = tt.trans %b {order = array<i32: 1, 0>} : tensor<256x64xi8, #blocked_fp4> -> tensor<64x256xi8, #blocked_fp4_t>
+    %b_s = ttg.local_alloc %b_t : (tensor<64x256xi8, #blocked_fp4_t>) -> !ttg.memdesc<64x256xi8, #shared_fp4_t, #smem_fp4>
+    %b_r = ttg.local_load %b_s : !ttg.memdesc<64x256xi8, #shared_fp4_t, #smem_fp4> -> tensor<64x256xi8, #blocked_fp4_t>
+    tt.return %b_r : tensor<64x256xi8, #blocked_fp4_t>
+  }
+}
+
+// -----
+
 #blocked = #ttg.blocked<{sizePerThread = [16, 1], threadsPerWarp = [32, 1], warpsPerCTA = [4, 1], order = [1, 0]}>
 #blocked1 = #ttg.blocked<{sizePerThread = [1, 16], threadsPerWarp = [1, 32], warpsPerCTA = [1, 4], order = [0, 1]}>
 #shared = #ttg.nvmma_shared<{swizzlingByteWidth = 128, transposed = false, elementBitWidth = 16}>

--- a/test/TritonNvidiaGPU/invalid.mlir
+++ b/test/TritonNvidiaGPU/invalid.mlir
@@ -1,4 +1,4 @@
-// RUN: triton-opt --split-input-file %s --verify-diagnostics
+// RUN: triton-opt %s --split-input-file --allocate-shared-memory-nv='compute-capability=120' --convert-triton-gpu-to-llvm='compute-capability=120' --verify-diagnostics
 
 // expected-error @below {{fp4Padded tensor memory layout requires colStride 1 but got 2}}
 #bad_fp4_padded_tmem = #ttng.tensor_memory_encoding<blockM = 128, blockN = 64, colStride = 2, fp4Padded = true>
@@ -247,6 +247,33 @@ tt.func @wgmma(%a: tensor<128x128xf16, #ttg.dot_op<{opIdx = 0, parent = #mma, kW
   %0 = ttng.warp_group_dot %a, %b, %c : tensor<128x128xf16, #ttg.dot_op<{opIdx = 0, parent = #mma, kWidth = 1}>> * !ttg.memdesc<128x128xf16, #shared, #ttg.shared_memory> -> tensor<128x128xf16, #mma>
   tt.return
 }
+}
+
+// -----
+
+// A mixed FP8/FP4 SM120 MMA requires the FP4 operand to use the decompressed
+// fp4Unpacked register representation.
+#mma = #ttg.nvidia_mma<{versionMajor = 2, versionMinor = 0, warpsPerCTA = [2, 2], instrShape = [16, 8]}>
+#scale_a = #ttg.linear<{register = [[32, 0], [64, 0]], lane = [[8, 0], [0, 0], [1, 0], [2, 0], [4, 0]], warp = [[0, 0], [16, 0]], block = []}>
+#scale_b = #ttg.linear<{register = [[16, 0], [32, 0], [64, 0]], lane = [[0, 0], [0, 0], [1, 0], [2, 0], [4, 0]], warp = [[8, 0], [0, 0]], block = []}>
+
+module attributes {"ttg.target" = "cuda:120", "ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, "ttg.threads-per-warp" = 32 : i32} {
+  tt.func @sm120_mixed_mma_requires_fp4_unpacked(
+    %a: tensor<128x32xf8E4M3FN, #ttg.dot_op<{opIdx = 0, parent = #mma, kWidth = 4}>>,
+    %sa: tensor<128x1xi8, #scale_a>,
+    %b: tensor<16x128xi8, #ttg.dot_op<{opIdx = 1, parent = #mma, kWidth = 2}>>,
+    %sb: tensor<128x1xi8, #scale_b>,
+    %c: tensor<128x128xf32, #mma>
+  ) {
+    // expected-error@+2 {{SM120 mixed FP8/FP4 MMA requires its FP4 operand to use fp4Unpacked}}
+    // expected-error@+1 {{failed to legalize operation 'tt.dot_scaled' that was explicitly marked illegal}}
+    %d = tt.dot_scaled %a scale %sa, %b scale %sb, %c lhs = e4m3 rhs = e2m1 {fastMath = false}
+      : tensor<128x32xf8E4M3FN, #ttg.dot_op<{opIdx = 0, parent = #mma, kWidth = 4}>>, tensor<128x1xi8, #scale_a>
+        * tensor<16x128xi8, #ttg.dot_op<{opIdx = 1, parent = #mma, kWidth = 2}>>, tensor<128x1xi8, #scale_b>
+        -> tensor<128x128xf32, #mma>
+    tt.print "d: " {hex = false, isSigned = array<i32: 0>} : %d : tensor<128x128xf32, #mma>
+    tt.return
+  }
 }
 
 // -----

--- a/test/TritonNvidiaGPU/optimize_descriptor_encoding.mlir
+++ b/test/TritonNvidiaGPU/optimize_descriptor_encoding.mlir
@@ -86,6 +86,30 @@ tt.func public @descriptor_kernel_arg(%arg0: !tt.tensordesc<64x64xf16>, %arg1: i
 
 // -----
 
+// When a tensor descriptor's loaded value is placed into an fp4Padded
+// shared-memory allocation, ODE must assign that same fp4Padded = true encoding
+// to the tensor descriptor.
+
+#blocked = #ttg.blocked<{sizePerThread = [1, 16], threadsPerWarp = [8, 4], warpsPerCTA = [4, 1], order = [1, 0]}>
+#shared = #ttg.nvmma_shared<{swizzlingByteWidth = 128, transposed = false, elementBitWidth = 8, fp4Padded = true}>
+#smem = #ttg.shared_memory
+
+module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.target = "cuda:120", "ttg.threads-per-warp" = 32 : i32} {
+// CHECK-DAG: #[[BLOCKED_FP4:.*]] = #ttg.blocked<{sizePerThread = [1, 16], threadsPerWarp = [8, 4], warpsPerCTA = [4, 1], order = [1, 0]}>
+// CHECK-DAG: #[[FP4_PADDED:.*]] = #ttg.nvmma_shared<{swizzlingByteWidth = 128, transposed = false, elementBitWidth = 8, fp4Padded = true}>
+// CHECK: tt.func public @descriptor_arg_from_fp4_padded_use(%arg0: !tt.tensordesc<256x64xi8, #[[FP4_PADDED]]>)
+tt.func public @descriptor_arg_from_fp4_padded_use(%arg0: !tt.tensordesc<256x64xi8>) {
+  // CHECK: %[[LOAD:.*]] = tt.descriptor_load %arg0[{{.*}}] : !tt.tensordesc<256x64xi8, #[[FP4_PADDED]]> -> tensor<256x64xi8, #[[BLOCKED_FP4]]>
+  // CHECK: ttg.local_alloc %[[LOAD]] : (tensor<256x64xi8, #[[BLOCKED_FP4]]>) -> !ttg.memdesc<256x64xi8, #[[FP4_PADDED]], #smem>
+  %c0 = arith.constant 0 : i32
+  %0 = tt.descriptor_load %arg0[%c0, %c0] : !tt.tensordesc<256x64xi8> -> tensor<256x64xi8, #blocked>
+  %1 = ttg.local_alloc %0 : (tensor<256x64xi8, #blocked>) -> !ttg.memdesc<256x64xi8, #shared, #smem>
+  tt.return
+}
+}
+
+// -----
+
 #blocked = #ttg.blocked<{sizePerThread = [1, 8], threadsPerWarp = [2, 16], warpsPerCTA = [4, 1], order = [1, 0]}>
 #shared = #ttg.nvmma_shared<{swizzlingByteWidth = 32, transposed = true, elementBitWidth = 16}>
 #smem = #ttg.shared_memory

--- a/third_party/nvidia/lib/TritonNVIDIAGPUToLLVM/DotOpToLLVM/MMAv2.cpp
+++ b/third_party/nvidia/lib/TritonNVIDIAGPUToLLVM/DotOpToLLVM/MMAv2.cpp
@@ -7,6 +7,8 @@
 #include "triton/Dialect/TritonInstrument/IR/Dialect.h"
 #include "llvm/ADT/SmallVector.h"
 
+#include <optional>
+
 using namespace mlir;
 using namespace mlir::triton;
 
@@ -15,6 +17,43 @@ using ::mlir::triton::gpu::getOrderForDotOperand;
 using ::mlir::triton::gpu::NvidiaMmaEncodingAttr;
 
 namespace {
+
+// This helper returns:
+//  - 0 if A is FP4 and B is FP8.
+//  - 1 if A is FP8 and B is FP4.
+//  - nullopt if it is not mixed or uses unsupported formats.
+static std::optional<unsigned> getMixedFp8Fp4Operand(DotScaledOp op) {
+  auto isFp4 = [](ScaleDotElemType format, Type storageType) {
+    return format == ScaleDotElemType::E2M1 && storageType.isSignlessInteger(8);
+  };
+  auto isFp8 = [](ScaleDotElemType format, Type storageType) {
+    return (format == ScaleDotElemType::E4M3 &&
+            isa<Float8E4M3FNType>(storageType)) ||
+           (format == ScaleDotElemType::E5M2 &&
+            isa<Float8E5M2Type>(storageType));
+  };
+  Type aStorageType =
+      cast<RankedTensorType>(op.getA().getType()).getElementType();
+  Type bStorageType =
+      cast<RankedTensorType>(op.getB().getType()).getElementType();
+  bool aIsFp4 = isFp4(op.getAElemType(), aStorageType);
+  bool bIsFp4 = isFp4(op.getBElemType(), bStorageType);
+  bool aIsFp8 = isFp8(op.getAElemType(), aStorageType);
+  bool bIsFp8 = isFp8(op.getBElemType(), bStorageType);
+  if (aIsFp4 && bIsFp8)
+    return 0;
+  if (aIsFp8 && bIsFp4)
+    return 1;
+  return std::nullopt;
+}
+
+static bool isFp4OperandUnpacked(DotScaledOp op, unsigned fp4OperandIdx) {
+  assert((fp4OperandIdx == 0 || fp4OperandIdx == 1) &&
+         "expected an FP4 A or B operand");
+  Value fp4 = fp4OperandIdx == 0 ? op.getA() : op.getB();
+  auto fp4Type = cast<RankedTensorType>(fp4.getType());
+  return cast<DotOperandEncodingAttr>(fp4Type.getEncoding()).getFp4Unpacked();
+}
 
 using ValueTableV2 = std::map<std::array<int, 3>, Value>;
 
@@ -98,7 +137,9 @@ ValueTableV2 getValuesFromDotOperandLayoutStruct(
   };
 
   auto dot = cast<DotOperandEncodingAttr>(type.getEncoding());
-  auto kWidth = dot.getKWidth();
+  // Double kWidth for an fp4Unpacked operand because one byte gets decompressed
+  // into two bytes.
+  auto kWidth = dot.getKWidth() * (dot.getFp4Unpacked() ? 2 : 1);
   auto largeK = bitwidth * kWidth > std::max(32u, bitwidth);
 
   assert((bitwidth != 64 || largeK == false) &&
@@ -284,6 +325,11 @@ enum class TensorCoreType : uint8_t {
   FP32_FP8E5M2_FP8E4M3FN_FP32_SCALE_VEC_1X,
   FP32_FP8E4M3FN_FP8E5M2_FP32_SCALE_VEC_1X,
   FP32_FP8E4M3FN_FP8E4M3FN_FP32_SCALE_VEC_1X,
+  // scaled mixed-precision mxfp8 x mxfp4 (and mirror), mxf8f6f4, ue8m0 scales
+  FP32_FP8E4M3FN_FP4E2M1_FP32_SCALE_VEC_1X,
+  FP32_FP8E5M2_FP4E2M1_FP32_SCALE_VEC_1X,
+  FP32_FP4E2M1_FP8E4M3FN_FP32_SCALE_VEC_1X,
+  FP32_FP4E2M1_FP8E5M2_FP32_SCALE_VEC_1X,
   //
   FP32_FP4E2M1_FP4E2M1_FP32_SCALE_VEC_2X,
   FP32_NVFP4_NVFP4_FP32_SCALE_VEC_4X,
@@ -331,6 +377,10 @@ static Type getMmaRetType(TensorCoreType mmaType, MLIRContext *ctx) {
   case TensorCoreType::FP32_FP8E5M2_FP8E4M3FN_FP32_SCALE_VEC_1X:
   case TensorCoreType::FP32_FP8E4M3FN_FP8E5M2_FP32_SCALE_VEC_1X:
   case TensorCoreType::FP32_FP8E4M3FN_FP8E4M3FN_FP32_SCALE_VEC_1X:
+  case TensorCoreType::FP32_FP8E4M3FN_FP4E2M1_FP32_SCALE_VEC_1X:
+  case TensorCoreType::FP32_FP8E5M2_FP4E2M1_FP32_SCALE_VEC_1X:
+  case TensorCoreType::FP32_FP4E2M1_FP8E4M3FN_FP32_SCALE_VEC_1X:
+  case TensorCoreType::FP32_FP4E2M1_FP8E5M2_FP32_SCALE_VEC_1X:
   case TensorCoreType::FP32_FP4E2M1_FP4E2M1_FP32_SCALE_VEC_2X:
   case TensorCoreType::FP32_NVFP4_NVFP4_FP32_SCALE_VEC_4X:
     return fp32x4Ty;
@@ -369,6 +419,21 @@ static TensorCoreType getMmaTypeDotScaled(DotScaledOp op, RankedTensorType aTy,
       } else {
         return TensorCoreType::FP32_FP4E2M1_FP4E2M1_FP32_SCALE_VEC_2X;
       }
+    }
+
+    // Mixed fp4 and fp8 mma
+    auto fp4Operand = getMixedFp8Fp4Operand(op);
+    if (fp4Operand && *fp4Operand == 1 &&
+        op.getBScale().getType().getElementType().isSignlessInteger(8)) {
+      if (llvm::isa<Float8E4M3FNType>(aTy.getElementType()))
+        return TensorCoreType::FP32_FP8E4M3FN_FP4E2M1_FP32_SCALE_VEC_1X;
+      return TensorCoreType::FP32_FP8E5M2_FP4E2M1_FP32_SCALE_VEC_1X;
+    }
+    if (fp4Operand && *fp4Operand == 0 &&
+        op.getAScale().getType().getElementType().isSignlessInteger(8)) {
+      if (llvm::isa<Float8E4M3FNType>(bTy.getElementType()))
+        return TensorCoreType::FP32_FP4E2M1_FP8E4M3FN_FP32_SCALE_VEC_1X;
+      return TensorCoreType::FP32_FP4E2M1_FP8E5M2_FP32_SCALE_VEC_1X;
     }
   }
   return TensorCoreType::NOT_APPLICABLE;
@@ -491,6 +556,22 @@ inline static const std::map<TensorCoreType, std::string> mmaInstrPtxScaled = {
      "mma.sync.aligned.m16n8k32.row.col."
      "kind::mxf8f6f4.block_scale.scale_vec::"
      "1X.f32.e4m3.e4m3.f32.ue8m0"},
+    {TensorCoreType::FP32_FP8E4M3FN_FP4E2M1_FP32_SCALE_VEC_1X,
+     "mma.sync.aligned.m16n8k32.row.col."
+     "kind::mxf8f6f4.block_scale.scale_vec::"
+     "1X.f32.e4m3.e2m1.f32.ue8m0"},
+    {TensorCoreType::FP32_FP8E5M2_FP4E2M1_FP32_SCALE_VEC_1X,
+     "mma.sync.aligned.m16n8k32.row.col."
+     "kind::mxf8f6f4.block_scale.scale_vec::"
+     "1X.f32.e5m2.e2m1.f32.ue8m0"},
+    {TensorCoreType::FP32_FP4E2M1_FP8E4M3FN_FP32_SCALE_VEC_1X,
+     "mma.sync.aligned.m16n8k32.row.col."
+     "kind::mxf8f6f4.block_scale.scale_vec::"
+     "1X.f32.e2m1.e4m3.f32.ue8m0"},
+    {TensorCoreType::FP32_FP4E2M1_FP8E5M2_FP32_SCALE_VEC_1X,
+     "mma.sync.aligned.m16n8k32.row.col."
+     "kind::mxf8f6f4.block_scale.scale_vec::"
+     "1X.f32.e2m1.e5m2.f32.ue8m0"},
     {TensorCoreType::FP32_FP4E2M1_FP4E2M1_FP32_SCALE_VEC_2X,
      "mma.sync.aligned.m16n8k64.row.col."
      "kind::mxf4nvf4.block_scale.scale_vec::"
@@ -708,7 +789,8 @@ LogicalResult convertMMAImpl(
     DotOpInterface op, Value llvmA, Value llvmB, Value llvmC,
     const LLVMTypeConverter *typeConverter, ConversionPatternRewriter &rewriter,
     TensorCoreType mmaType, const NumRegisters &numRegisters,
-    const std::string &mmaInstruction, const EmitMmaCallback &emitMma) {
+    const std::string &mmaInstruction, const EmitMmaCallback &emitMma,
+    std::optional<unsigned> fp4OperandToCenter) {
   auto loc = op.getLoc();
   auto aType = cast<RankedTensorType>(op.getA().getType());
   auto bType = cast<RankedTensorType>(op.getB().getType());
@@ -730,14 +812,31 @@ LogicalResult convertMMAImpl(
 
   int bitwidth = aTensorTy.getElementType().getIntOrFloatBitWidth();
   auto dotOpA = cast<DotOperandEncodingAttr>(aTensorTy.getEncoding());
-  int kWidth = dotOpA.getKWidth();
-  auto repA =
-      cast<NvidiaMmaEncodingAttr>(dotOpA.getParent())
-          .getRepForOperand(aShapePerCTA, bitwidth, kWidth, dotOpA.getOpIdx());
   auto dotOpB = cast<DotOperandEncodingAttr>(bTensorTy.getEncoding());
-  auto repB =
-      cast<NvidiaMmaEncodingAttr>(dotOpB.getParent())
-          .getRepForOperand(bShapePerCTA, bitwidth, kWidth, dotOpB.getOpIdx());
+
+  // Double the effective kWidth for fp4Unpacked operands because one byte
+  // with two values get decompressed into two bytes.
+  auto effKWidth = [](DotOperandEncodingAttr d) {
+    if (d.getFp4Unpacked())
+      return d.getKWidth() * 2;
+    return d.getKWidth();
+  };
+  auto effShape = [](ArrayRef<int64_t> shape, DotOperandEncodingAttr d) {
+    SmallVector<int64_t> s(shape.begin(), shape.end());
+    if (!d.getFp4Unpacked())
+      return s;
+
+    int rank = s.size();
+    int kDim = d.getOpIdx() == 0 ? rank - 1 : rank - 2;
+    s[kDim] *= 2;
+    return s;
+  };
+  auto repA = cast<NvidiaMmaEncodingAttr>(dotOpA.getParent())
+                  .getRepForOperand(effShape(aShapePerCTA, dotOpA), bitwidth,
+                                    effKWidth(dotOpA), dotOpA.getOpIdx());
+  auto repB = cast<NvidiaMmaEncodingAttr>(dotOpB.getParent())
+                  .getRepForOperand(effShape(bShapePerCTA, dotOpB), bitwidth,
+                                    effKWidth(dotOpB), dotOpB.getOpIdx());
 
   assert(repA[2] == repB[1]);
   assert(repA[0] == repB[0]);
@@ -759,6 +858,16 @@ LogicalResult convertMMAImpl(
   auto hb = getValuesFromDotOperandLayoutStruct(typeConverter, loc, rewriter,
                                                 llvmB, repBatch, repN, repK,
                                                 bTensorTy, numRegisters);
+
+  // Target specific lowering of fp4Unpacked for the SM120: its mixed FP8/FP4
+  // MMA expects each e2m1 fp4 value in bits [5:2], while fp4Unpacked specifies
+  // fp4 values live in [3:0], so here we shift the value left by 2.
+  if (fp4OperandToCenter) {
+    Value mask = tb.i32_val(0x0f0f0f0f);
+    ValueTableV2 &fp4Table = *fp4OperandToCenter == 0 ? ha : hb;
+    for (auto &entry : fp4Table)
+      entry.second = tb.shl(tb.and_(entry.second, mask), tb.i32_val(2));
+  }
 
   int bitwidthRet = dTensorTy.getElementType().getIntOrFloatBitWidth();
   auto numMmaRets = bitwidthRet == 64 ? 2 : bitwidthRet / 8;
@@ -857,7 +966,8 @@ LogicalResult convertMMAWithInstruction(
   };
 
   return convertMMAImpl(op, llvmA, llvmB, llvmC, typeConverter, rewriter,
-                        mmaType, numRegisters, mmaInstruction, emit);
+                        mmaType, numRegisters, mmaInstruction, emit,
+                        std::nullopt);
 }
 
 } // namespace
@@ -908,6 +1018,12 @@ LogicalResult convertMMADotScaled(triton::DotScaledOp op,
   if (mmaInstrPtxScaled.find(mmaType) == mmaInstrPtxScaled.end())
     return op.emitError(
         "unsupported MMA instruction for the given operand/result types");
+
+  auto fp4OperandToCenter = getMixedFp8Fp4Operand(op);
+  if (fp4OperandToCenter && !isFp4OperandUnpacked(op, *fp4OperandToCenter))
+    return op.emitError(
+        "SM120 mixed FP8/FP4 MMA requires its FP4 operand to use "
+        "fp4Unpacked");
 
   SmallVector<Value> unpackedAScale = unpackTensorElements(
       op.getLoc(), adaptor.getAScale(), rewriter, op.getAScale().getType());
@@ -960,5 +1076,6 @@ LogicalResult convertMMADotScaled(triton::DotScaledOp op,
 
   return convertMMAImpl(op, adaptor.getA(), adaptor.getB(), adaptor.getC(),
                         typeConverter, rewriter, mmaType, numRegisters,
-                        mmaInstrPtxScaled.at(mmaType), emit);
+                        mmaInstrPtxScaled.at(mmaType), emit,
+                        fp4OperandToCenter);
 }

--- a/third_party/nvidia/lib/TritonNVIDIAGPUToLLVM/MemoryOpToLLVM.cpp
+++ b/third_party/nvidia/lib/TritonNVIDIAGPUToLLVM/MemoryOpToLLVM.cpp
@@ -78,10 +78,17 @@ LogicalResult lowerLdStMatrix(
     SmallVector<Value> &vals, // Input for stmatrix, output for ldmatrix
     SharedMemoryObject smemObj, ConversionPatternRewriter &rewriter,
     const NVIDIA::TargetInfo &targetInfo,
-    const LLVMTypeConverter *typeConverter) {
+    const LLVMTypeConverter *typeConverter, bool isFp4Padded = false) {
   auto *ctx = loc.getContext();
-  assert(regLayout.getFreeVariableMasks().lookup(str_attr("register")) == 0 &&
-         "expected register broadcasting to be removed by the caller");
+
+  // The unpacked FP4 register layout used with the padded-SMEM ldmatrix format
+  // is an exception here: its zero basis selects the low or high nibble of a
+  // packed byte, information that is absent from the tensor coordinate. The
+  // two register fields map to the same coordinate but contain different
+  // values, so they are not broadcast copies.
+  if (!isFp4Padded)
+    assert(regLayout.getFreeVariableMasks().lookup(str_attr("register")) == 0 &&
+           "expected register broadcasting to be removed by the caller");
   if (isa<PaddedSharedEncodingAttr>(memDescType.getEncoding())) {
     return failure();
   }
@@ -102,15 +109,83 @@ LogicalResult lowerLdStMatrix(
   auto affineOffset = smemObj.getShmemOffset(loc, rewriter, memDescType);
   auto maskSpanAffineOffset = smemObj.getMaskSpanOffsets(memDescType);
   auto llvmElemTy = typeConverter->convertType(memDescType.getElementType());
+  if (isFp4Padded)
+    return LLVM::NVIDIA::lowerLdStMatrix(
+        loc, cvt, /*transpose=*/false, vals, smemBase, affineOffset,
+        maskSpanAffineOffset, llvmElemTy, rewriter, targetInfo, isFp4Padded);
+
   for (bool transpose : {false, true}) {
     auto result = LLVM::NVIDIA::lowerLdStMatrix(
         loc, cvt, transpose, vals, smemBase, affineOffset, maskSpanAffineOffset,
-        llvmElemTy, rewriter, targetInfo);
+        llvmElemTy, rewriter, targetInfo, isFp4Padded);
     if (succeeded(result)) {
       return result;
     }
   }
   return failure();
+}
+
+// Lower a local_load whose result uses the fp4Unpacked mxfp4 dot encoding. The
+// source must use the fp4Padded NVMMA shared-memory encoding. First try the fp4
+// ldmatrix instruction; if the source and register layouts are not compatible
+// with that instruction, fall back to scalar loads.
+static LogicalResult lowerFp4UnpackedLocalLoad(
+    triton::gpu::LocalLoadOp op, triton::gpu::LocalLoadOp::Adaptor adaptor,
+    const LLVMTypeConverter *typeConverter, ConversionPatternRewriter &rewriter,
+    const NVIDIA::TargetInfo &targetInfo) {
+  auto loc = op.getLoc();
+  auto *ctx = op.getContext();
+  auto dstTy = op.getType();
+  auto dotEnc = cast<DotOperandEncodingAttr>(dstTy.getEncoding());
+  MemDescType memDescType = op.getSrc().getType();
+  assert(
+      cast<NVMMASharedEncodingAttr>(memDescType.getEncoding()).getFp4Padded() &&
+      "fp4Unpacked local load requires fp4Padded shared memory");
+
+  Type llvmElemTy = typeConverter->convertType(dstTy.getElementType());
+  auto smemObj = LLVM::getSharedMemoryObjectFromStruct(loc, adaptor.getSrc(),
+                                                       llvmElemTy, rewriter);
+
+  // First try to emit a fp4 ldmatrix.
+  SmallVector<Value> ldmatrixVals;
+  auto regLayout = toLinearLayout(dstTy);
+  auto result = lowerLdStMatrix(loc, regLayout, memDescType, ldmatrixVals,
+                                smemObj, rewriter, targetInfo, typeConverter,
+                                /*isFp4Padded=*/true);
+  if (succeeded(result)) {
+    Value packed =
+        packTensorElements(loc, typeConverter, ldmatrixVals, rewriter, dstTy);
+    rewriter.replaceOp(op, packed);
+    return success();
+  }
+
+  // If we can't emit a ldmatrix, fall back to scalar code.
+  auto packedEnc = DotOperandEncodingAttr::get(
+      ctx, dotEnc.getOpIdx(), dotEnc.getParent(), dotEnc.getKWidth(),
+      /*fp4Unpacked=*/false);
+  auto packedTy = dstTy.cloneWithEncoding(packedEnc);
+  auto packedRegLayout = toLinearLayout(packedTy);
+  auto sharedLayout = toLinearLayout(memDescType);
+
+  auto cvt = packedRegLayout.invertAndCompose(sharedLayout);
+  auto packedVals =
+      lowerLocalLdSt(loc, ctx, cvt, /*valsArray=*/{}, llvmElemTy, memDescType,
+                     smemObj, rewriter, targetInfo, op);
+
+  // Unpack each byte by extracting its low and high nibbles and placing them
+  // into separate bytes.
+  auto b = TritonLLVMOpBuilder(loc, rewriter);
+  SmallVector<Value> outVals;
+  outVals.reserve(packedVals.size() * 2);
+  for (Value v : packedVals) {
+    Value lo = b.and_(v, b.i8_val(0x0f));
+    Value hi = b.and_(b.lshr(v, b.i8_val(4)), b.i8_val(0x0f));
+    outVals.push_back(lo);
+    outVals.push_back(hi);
+  }
+  rewriter.replaceOp(
+      op, packTensorElements(loc, typeConverter, outVals, rewriter, dstTy));
+  return success();
 }
 
 struct LocalLoadOpConversion
@@ -130,6 +205,14 @@ public:
     auto *ctx = op.getContext();
     MemDescType memDescType = op.getSrc().getType();
     RankedTensorType dstTy = op.getType();
+
+    // fp4Unpacked mxfp4 operand: expand the packed bytes into one 8-bit field
+    // per e2m1 value as part of the load.
+    if (auto dotEnc = dyn_cast<DotOperandEncodingAttr>(dstTy.getEncoding()))
+      if (dotEnc.getFp4Unpacked())
+        return lowerFp4UnpackedLocalLoad(op, adaptor, getTypeConverter(),
+                                         rewriter, targetInfo);
+
     Type llvmElemTy = typeConverter->convertType(dstTy.getElementType());
     auto smemObj = LLVM::getSharedMemoryObjectFromStruct(
         op.getLoc(), adaptor.getSrc(), llvmElemTy, rewriter);

--- a/third_party/nvidia/lib/TritonNVIDIAGPUToLLVM/TargetInfo.h
+++ b/third_party/nvidia/lib/TritonNVIDIAGPUToLLVM/TargetInfo.h
@@ -48,6 +48,9 @@ public:
   bool supportLdStMatrixB8() const override {
     return targetFeatures.supportLdStMatrixB8();
   }
+  bool supportsFp4Ldmatrix() const {
+    return targetFeatures.supportsFp4Ldmatrix();
+  }
   bool supportBitwidth16Elementwise() const override {
     return targetFeatures.supportBitwidth16Elementwise();
   }

--- a/third_party/nvidia/lib/TritonNVIDIAGPUToLLVM/Utility.cpp
+++ b/third_party/nvidia/lib/TritonNVIDIAGPUToLLVM/Utility.cpp
@@ -197,7 +197,7 @@ LogicalResult lowerLdStMatrix(
     SmallVector<Value> &vals, // Input for stmatrix, output for ldmatrix
     Value smemBase, Value affineOffset, uint64_t maskSpanAffineOffset,
     Type llvmElemTy, ConversionPatternRewriter &rewriter,
-    const ::triton::NVIDIA::TargetInfo &targetInfo) {
+    const ::triton::NVIDIA::TargetInfo &targetInfo, bool isFp4Padded) {
   // Lower load via ldmatrix, store via stmatrix
 
   bool isStore = !vals.empty();
@@ -216,8 +216,12 @@ LogicalResult lowerLdStMatrix(
   auto kOffset = S("offset");
   auto kBlock = S("block");
   auto kAddr = S("addr");
+  auto kUnpack = S("unpack");
   auto smemPtrTy = ptr_ty(ctx, 3);
   auto bitwidth = getIntOrFloatOrPtrBitWidth(llvmElemTy);
+  if (isFp4Padded && (isStore || transpose || bitwidth != 8 ||
+                      !targetInfo.supportsFp4Ldmatrix()))
+    return failure();
   // In the contiguous case we can pack elements <= 32 bits
   // In the transpose case we just have the b8 and b16 cases
   if ((!transpose && bitwidth > 32) ||
@@ -234,7 +238,28 @@ LogicalResult lowerLdStMatrix(
   // Accumulate the permutations to apply the inverse for loads
   ColumnAction accPermReg =
       ColumnAction::identity(kReg, cvt.getInDimSizeLog2(kReg));
-  if (!transpose) {
+  if (isFp4Padded) {
+    // The fp4 ldmatrix tile uses all 32 lanes. Reject smaller lane layouts
+    // before composing them with the full instruction tile.
+    if (cvt.getInDimSize(kLane) < 32)
+      return failure();
+
+    // For one m8n16 result, each lane receives four expanded FP4 values.
+    // Register bit 0 selects low/high FP4 within a packed source byte.
+    // Register bit 1 selects one of the lane's two source data bytes.
+    // Lane bits 0 and 1 select one of four 2-byte groups in the source row's
+    // eight non-padding bytes.
+    tile = LinearLayout::identity1D(2, kReg, kUnpack) *
+           LinearLayout::identity1D(2, kReg, kOffset) *
+           LinearLayout::identity1D(4, kLane, kOffset);
+
+    // Lane bits 2 through 4 select one of eight matrix rows
+    fullTile = tile * LinearLayout::identity1D(8, kLane, kAddr);
+
+    assert(fullTile.isInvertible());
+    // Project out kUnpack to get the address-only tile used by divideLeft.
+    tile = tile.sublayout({kReg, kLane}, {kOffset});
+  } else if (!transpose) {
     tile = LinearLayout::identity1D(32 / bitwidth, kReg, kOffset) *
            LinearLayout::identity1D(4, kLane, kOffset);
     fullTile = tile * LinearLayout::identity1D(8, kLane, kAddr);
@@ -348,10 +373,14 @@ LogicalResult lowerLdStMatrix(
   // just add warps as compose belowe requires the dimensions of both layouts to
   // agree
   fullTileVec *= LinearLayout::identity1D(1, kWarp, kAddr);
-  // fullTile.invert() is a map from kOffset, kAddr into kReg, kLane, kWarp
-  // addrToOffset gives us a map from kAddr into kOffset, which is the map of
-  // the addresses each lane should hold
+  // fullTile.invert() maps instruction coordinates back to kReg, kLane, kWarp.
+  // For fp4, kUnpack distinguishes the two output registers sourced from one
+  // packed byte. Composing with reps must therefore erase kUnpack: changing it
+  // cannot change the shared-memory address. addrToOffset then gives the
+  // addresses each lane should hold.
   auto addrToOffset = fullTileVec.invert().compose(reps);
+  if (isFp4Padded)
+    assert(addrToOffset.sublayoutIsZero({kUnpack}, {kOffset}));
   // sanity check
   assert(addrToOffset.getInDimSizeLog2(kAddr) >= 3 &&
          addrToOffset.getInDimSizeLog2(kAddr) <= 5);
@@ -412,12 +441,18 @@ LogicalResult lowerLdStMatrix(
   if (transpose) {
     std::swap(m, n);
   }
+  if (isFp4Padded) {
+    m = 8;
+    n = 16;
+    eltType = NVVM::LdStMatrixEltType::B8X16_B4X16_P64;
+  }
   auto shape = NVVM::LdStMatrixShapeAttr::get(ctx, m, n);
 
   // Elements per op
   auto elemsPerInstr = fullTileVec.getInDimSize(kReg);
   auto elemsPerVec = 32 / bitwidth;
   auto vecTy = vec_ty(llvmElemTy, elemsPerVec);
+
   for (int i = 0; i < cvt.getInDimSize(kReg); i += nAdditive) {
     auto regIdx = reps.apply({{kReg, i}, {kLane, 0}, {kWarp, 0}})[0].second;
     auto regIdxI8 = regIdx * (bitwidth / 8);

--- a/third_party/nvidia/lib/TritonNVIDIAGPUToLLVM/Utility.h
+++ b/third_party/nvidia/lib/TritonNVIDIAGPUToLLVM/Utility.h
@@ -57,7 +57,8 @@ LogicalResult lowerLdStMatrix(
     SmallVector<Value> &vals, // Input for stmatrix, output for ldmatrix
     Value smemBase, Value affineOffset, uint64_t maskSpanAffineOffset,
     Type llvmElemTy, ConversionPatternRewriter &rewriter,
-    const mlir::triton::NVIDIA::TargetInfo &targetInfo);
+    const mlir::triton::NVIDIA::TargetInfo &targetInfo,
+    bool isFp4Padded = false);
 
 // Given a broadcast mask and the number of CTAs, create a mask of ones
 // where for ctaId, it sets as 1's the positions that are in the same broadcast

--- a/unittest/Dialect/TritonGPU/LinearLayoutConversionsTest.cpp
+++ b/unittest/Dialect/TritonGPU/LinearLayoutConversionsTest.cpp
@@ -4,6 +4,7 @@
 #include "triton/Dialect/TritonGPU/IR/Attributes.h"
 #include "triton/Dialect/TritonGPU/IR/Dialect.h"
 #include "triton/Dialect/TritonNvidiaGPU/IR/Dialect.h"
+#include "triton/Tools/LayoutUtils.h"
 #include "triton/Tools/StrUtil.h"
 #include "llvm/ADT/ArrayRef.h"
 #include "llvm/Support/Signals.h"
@@ -3495,6 +3496,199 @@ TEST_F(LinearLayoutConversionsTest,
           << dim0 << ", " << dim1 << "] with " << swizzleBytes << "B swizzle";
     }
   }
+}
+
+TEST_F(LinearLayoutConversionsTest, Fp4UnpackedDotOperandLayout) {
+  auto mmaEnc = mma(2, 0, {16, 8}, /*numWarps=*/{1, 1});
+
+  auto findOut =
+      [](const llvm::SmallVector<std::pair<StringAttr, int32_t>> &out,
+         StringAttr name) -> int32_t {
+    for (auto &kv : out)
+      if (kv.first == name)
+        return kv.second;
+    ADD_FAILURE() << "missing output dim " << name.str();
+    return 0;
+  };
+
+  auto check = [&](int opIdx, ArrayRef<int64_t> packedShape) {
+    auto packedDot = dot(mmaEnc, opIdx, /*kWidth=*/2);
+    auto unpackedDot = DotOperandEncodingAttr::get(
+        &ctx, opIdx, mmaEnc, /*kWidth=*/2, /*fp4Unpacked=*/true);
+    LinearLayout packed = toLinearLayout(packedShape, packedDot);
+    LinearLayout unpacked = toLinearLayout(packedShape, unpackedDot);
+
+    int rank = packedShape.size();
+    int kDim = opIdx == 0 ? rank - 1 : rank - 2;
+    SmallVector<int64_t> expandedShape(packedShape.begin(), packedShape.end());
+    expandedShape[kDim] *= 2;
+    auto expandedDot = dot(mmaEnc, opIdx, /*kWidth=*/4);
+    LinearLayout expanded = toLinearLayout(expandedShape, expandedDot);
+    LinearLayout registerElements =
+        toRegisterElementLinearLayout(packedShape, unpackedDot);
+
+    StringAttr kOut = opIdx == 0 ? S("dim1") : S("dim0");
+    StringAttr otherOut = opIdx == 0 ? S("dim0") : S("dim1");
+
+    EXPECT_EQ(toRegisterElementLinearLayout(packedShape, packedDot), packed);
+    EXPECT_EQ(registerElements, expanded);
+
+    // Same packed tensor shape (codomain), double the registers.
+    ASSERT_EQ(unpacked.getInDimSize(S("register")),
+              2 * packed.getInDimSize(S("register")));
+    EXPECT_EQ(getUniqueElemsPerThread(unpackedDot, packedShape),
+              unpacked.getInDimSize(S("register")));
+    ASSERT_EQ(unpacked.getOutDimSize(kOut), packed.getOutDimSize(kOut));
+    ASSERT_EQ(unpacked.getOutDimSize(otherOut), packed.getOutDimSize(otherOut));
+
+    // MMAv2 consumes the unpacked registers as an ordinary byte-expanded
+    // kWidth=4 operand. Register parity must therefore select consecutive K
+    // elements in the expanded layout.
+    ASSERT_EQ(expanded.getInDimSize(S("register")),
+              unpacked.getInDimSize(S("register")));
+    ASSERT_EQ(expanded.getOutDimSize(kOut), 2 * unpacked.getOutDimSize(kOut));
+    ASSERT_EQ(expanded.getOutDimSize(otherOut),
+              unpacked.getOutDimSize(otherOut));
+
+    int32_t numRegs = unpacked.getInDimSize(S("register"));
+    int32_t numLanes = unpacked.getInDimSize(S("lane"));
+    int32_t numWarps = unpacked.getInDimSize(S("warp"));
+    for (int32_t reg = 0; reg < numRegs; ++reg) {
+      for (int32_t lane = 0; lane < numLanes; ++lane) {
+        for (int32_t warp = 0; warp < numWarps; ++warp) {
+          auto unp = unpacked.apply({{S("register"), reg},
+                                     {S("lane"), lane},
+                                     {S("warp"), warp},
+                                     {S("block"), 0}});
+          auto pk = packed.apply({{S("register"), reg >> 1},
+                                  {S("lane"), lane},
+                                  {S("warp"), warp},
+                                  {S("block"), 0}});
+          auto exp = expanded.apply({{S("register"), reg},
+                                     {S("lane"), lane},
+                                     {S("warp"), warp},
+                                     {S("block"), 0}});
+          EXPECT_EQ(findOut(unp, kOut), findOut(pk, kOut))
+              << "opIdx=" << opIdx << " reg=" << reg << " lane=" << lane
+              << " warp=" << warp;
+          EXPECT_EQ(findOut(unp, otherOut), findOut(pk, otherOut))
+              << "opIdx=" << opIdx << " reg=" << reg << " lane=" << lane
+              << " warp=" << warp;
+          EXPECT_EQ(findOut(exp, kOut), 2 * findOut(unp, kOut) + (reg & 1))
+              << "opIdx=" << opIdx << " reg=" << reg << " lane=" << lane
+              << " warp=" << warp;
+          EXPECT_EQ(findOut(exp, otherOut), findOut(unp, otherOut))
+              << "opIdx=" << opIdx << " reg=" << reg << " lane=" << lane
+              << " warp=" << warp;
+        }
+      }
+    }
+  };
+
+  // A (opIdx 0): K is the contiguous dim.
+  check(/*opIdx=*/0, /*packedShape=*/{16, 16});
+  // B (opIdx 1): K is the outer dim.
+  check(/*opIdx=*/1, /*packedShape=*/{16, 8});
+
+  // Preserve the semantic parity bit while still removing genuine broadcasts
+  // introduced when the tensor is smaller than the MMA tile.
+  auto checkBroadcast = [&](int opIdx, ArrayRef<int64_t> packedShape) {
+    auto packedDot = dot(mmaEnc, opIdx, /*kWidth=*/2);
+    auto unpackedDot = DotOperandEncodingAttr::get(
+        &ctx, opIdx, mmaEnc, /*kWidth=*/2, /*fp4Unpacked=*/true);
+    SmallVector<int64_t> expandedShape(packedShape);
+    int kDim = opIdx == 0 ? packedShape.size() - 1 : packedShape.size() - 2;
+    expandedShape[kDim] *= 2;
+    auto expandedDot = dot(mmaEnc, opIdx, /*kWidth=*/4);
+
+    EXPECT_EQ(toRegisterElementLinearLayout(packedShape, unpackedDot),
+              toLinearLayout(expandedShape, expandedDot));
+    EXPECT_EQ(getUniqueElemsPerThread(unpackedDot, packedShape),
+              2 * getUniqueElemsPerThread(packedDot, packedShape));
+    EXPECT_EQ(getUniqueElemsPerThread(unpackedDot, packedShape),
+              getUniqueElemsPerThread(expandedDot, expandedShape));
+    EXPECT_LT(getUniqueElemsPerThread(unpackedDot, packedShape),
+              getTotalElemsPerThread(unpackedDot, packedShape));
+  };
+  checkBroadcast(/*opIdx=*/0, /*packedShape=*/{8, 16});
+  checkBroadcast(/*opIdx=*/1, /*packedShape=*/{8, 8});
+}
+
+// Verify fp4Unpacked register-element layouts are not limited to NVIDIA MMA.
+TEST_F(LinearLayoutConversionsTest,
+       Fp4UnpackedDotOperandLayoutIsTargetIndependent) {
+  auto parent = blocked(/*size*/ {1, 1}, /*threads*/ {1, 32}, /*warps*/ {1, 1},
+                        /*ctas*/ {1, 1}, /*splits*/ {1, 1}, /*order*/ {1, 0},
+                        /*cta order*/ {1, 0});
+  SmallVector<int64_t> shape = {1, 1};
+  auto packedDot = dot(parent, /*idx=*/0, /*kWidth=*/0);
+  auto unpackedDot = DotOperandEncodingAttr::get(
+      &ctx, /*opIdx=*/0, parent, /*kWidth=*/0, /*fp4Unpacked=*/true);
+  auto packedLayout = toLinearLayout(shape, packedDot);
+
+  EXPECT_EQ(toLinearLayout(shape, unpackedDot),
+            LinearLayout::zeros1D(2, S("register"), S("dim1")) * packedLayout);
+  EXPECT_EQ(toRegisterElementLinearLayout(shape, unpackedDot),
+            LinearLayout::identity1D(2, S("register"), S("dim1")) *
+                packedLayout);
+}
+
+TEST_F(LinearLayoutConversionsTest,
+       Fp4UnpackedRegisterWithPaddedSmemDividesByLdMatrixTile) {
+  auto mmaEnc = mma(2, 0, {16, 8}, /*numWarps=*/{2, 2});
+
+  auto kReg = S("register");
+  auto kLane = S("lane");
+  auto kWarp = S("warp");
+  auto kOffset = S("offset");
+  auto kAddr = S("addr");
+  auto kUnpack = S("unpack");
+
+  auto fullTile = LinearLayout::identity1D(2, kReg, kUnpack) *
+                  LinearLayout::identity1D(2, kReg, kOffset) *
+                  LinearLayout::identity1D(4, kLane, kOffset) *
+                  LinearLayout::identity1D(8, kLane, kAddr);
+  ASSERT_TRUE(fullTile.isInvertible());
+  auto tile =
+      fullTile.resizeInDim(kLane, 4).sublayout({kReg, kLane}, {kOffset});
+  EXPECT_EQ(tile, LinearLayout({{kReg, {{0}, {1}}}, {kLane, {{2}, {4}}}},
+                               {{kOffset, 8}},
+                               /*requireSurjective=*/false));
+
+  auto check = [&](int opIdx, ArrayRef<int64_t> packedShape, int swizzleBytes,
+                   bool transposed) {
+    auto unpackedDot = DotOperandEncodingAttr::get(
+        &ctx, opIdx, mmaEnc, /*kWidth=*/2, /*fp4Unpacked=*/true);
+    LinearLayout reg = toLinearLayout(packedShape, unpackedDot);
+    auto sharedEnc =
+        nvmmaShared(swizzleBytes, transposed,
+                    /*elementBitWidth=*/8, {1, 1}, {1, 1}, {1, 0}, {1, 0},
+                    /*fp4Padded=*/true);
+    LinearLayout smem = toLinearLayout(packedShape, sharedEnc);
+
+    auto maybeCvt = reg.invertAndCompose(smem).quotient({S("block")});
+    ASSERT_TRUE(maybeCvt) << "opIdx=" << opIdx;
+
+    auto maybePerm = regPermForDivide(*maybeCvt, tile, /*left=*/true);
+    ASSERT_TRUE(maybePerm) << "opIdx=" << opIdx << " cvt=" << *maybeCvt
+                           << " tile=" << tile;
+    auto cvt = maybePerm->apply(*maybeCvt);
+    auto maybeQuot = divideLeft(cvt, tile);
+    ASSERT_TRUE(maybeQuot) << "opIdx=" << opIdx;
+
+    auto reps = zerosLike(tile) * *maybeQuot;
+    auto fullTileVec = fullTile * LinearLayout::identity1D(4, kReg, kAddr);
+    fullTileVec *= LinearLayout::identity1D(1, kWarp, kAddr);
+    ASSERT_TRUE(fullTileVec.isInvertible()) << "opIdx=" << opIdx;
+    auto addrToOffset = fullTileVec.invert().compose(reps);
+    EXPECT_TRUE(addrToOffset.sublayoutIsZero({kUnpack}, {kOffset}))
+        << "opIdx=" << opIdx;
+  };
+
+  check(/*opIdx=*/0, /*packedShape=*/{128, 32}, /*swizzleBytes=*/64,
+        /*transposed=*/false);
+  check(/*opIdx=*/1, /*packedShape=*/{16, 128}, /*swizzleBytes=*/32,
+        /*transposed=*/true);
 }
 
 } // anonymous namespace


### PR DESCRIPTION
Enable mixed-precision tt.dot_scaled on SM120 for FP8 and packed FP4 operands in either order.

As described in [the PTX doc](https://docs.nvidia.com/cuda/parallel-thread-execution/index.html#warp-level-matrix-instructions-mma), the MMA instruction expects 4 bits to be placed in an unpacked byte as 00xxxx00. The new fp4 mode in [ldmatrix](https://docs.nvidia.com/cuda/parallel-thread-execution/index.html#warp-level-matrix-instructions-ldmatrix) was introduced to help create such register layouts. With `.src_fmt` .b4x16_p64 and `.dst_fmt` .b8x16, it allows copying packed fp4 values in smem into registers in an unpacked form. So a byte xxxxyyyy in smem is copied into two bytes in registers as 0000xxxx, 0000yyyy. Enabling this variant of ldmatrix is the key contribution of this work.

The approach relies on the following:
- The src SMEM format .b4x16_p64 is what we call `fp4Padded`, originally introduced for sm100 mixed precision. We can reuse the existing infrastructure to efficiently copy packed fp4 values in global memory into padded SMEM via TMA.
- To model the unpacked layout 0000xxxx in registers, we introduce a new attribute `fp4Unpacked` to `DotOperandEncoding`. Similarly to `fp4Padded` for SMEM, the logical shape is packed, but the physical storage in registers is doubled. Support for this was added to some linear layout utilities. With `fp4Padded` source and `fp4Unpacked` destination, we can model the new fp4 variant of ldmatrix exactly.
- The MMA instruction expects 4 bits to be unpacked as 00xxxx00 while the result of ldmatrix is 0000xxxx. We resolve this quirk at the lowest layer, `MMAV2.cpp`, by manual shifting, so that the rest of Triton can work with the MMA op as if its operand layout was `fp4Unpacked`, for which we have a LinearLayout representation.

In terms of lowering and passes, we roughly go through the following stages:
- `AccelerateMatmul`: introduces the MMA layouts and FP4 shared-memory staging; the fp4 operand is staged through `fp4Padded` shared memory and loaded into an `fp4Unpacked` register dot operand.
- `OptimizeDotOperands`: Extend `FuseTransMMAV3Plus` for sm120 so that `OptimizeDescriptorEncoding` can select an `fp4Padded` encoding for tensor descriptors, just like how it works for sm100 mixed-precision today.
- `LocalLoadOpConversion`: if we find `fp4Padded` source and `fp4Unpacked` destination, we emit the new fp4 ldmatrix instruction. If we cannot select ldmatrix for some reason, we fall back to scalar loads.
- `DotOpToLLVM/MMAv2`: Take care of the manual shifting, and emit the new mixed-precision mma.sync instruction.

Performance on 8k x 8k x 8k matmul, comparing against two baselines:

| Path | TFLOPs | Best configuration |
|---|---:|---|
| BF16 dequantization (main) | **217** | 128×128×64, 4 warps, 3 stages, no TMA |
| FP4→FP8 promotion ([PR 10746](https://github.com/triton-lang/triton/pull/10746)) | **488** | 128×128×64, 4 warps, 2 stages, TMA for A/B only |
| Native mixed-precision | **691** | 128×128×128, 4 warps, 2 stages, TMA for A/B and scales |

For reproducibility, we have used the following autotuning to script to find the optimal configurations:
https://gist.github.com/sjoerdmeijer/62efdf1db84c88ae246c0a92d3726599

<!---
The core Triton is a small number of people, and we receive many PRs (thank
you!).  To help us review your code more quickly, **if you are a new
contributor (less than 3 PRs merged) we ask that you complete the following
tasks and include the filled-out checklist in your PR description.**

Complete the following tasks before sending your PR, and replace `[ ]` with
`[x]` to indicate you have done them.
-->

# New contributor declaration
- [x] I am not making a trivial change, such as fixing a typo in a comment.

- [x] I have written a PR description following these
  [rules](https://cbea.ms/git-commit/#why-not-how).

- [x] I have run `pre-commit run --from-ref origin/main --to-ref HEAD`.

- Select one of the following.
  - [x] I have added tests.
    - `/test` for `lit` tests
    - `/unittest` for C++ tests
    - `/python/test` for end-to-end tests
  - [ ] This PR does not need a test because `FILL THIS IN`.

- Select one of the following.
  - [ ] I have not added any `lit` tests.
  - [x] The `lit` tests I have added follow these [best practices](https://mlir.llvm.org/getting_started/TestingGuide/#filecheck-best-practices),
    including the "tests should be minimal" section. (Usually running Python code
    and using the instructions it generates is not minimal.)
