### PR TITLE
[triton-ext] Remove install targets added in #9534 and #9847

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -8,7 +8,6 @@ endif()
 
 project(triton CXX C)
 include(CTest)
-include(GNUInstallDirs)
 
 set(CMAKE_CXX_STANDARD 17)
 set(CMAKE_INCLUDE_CURRENT_DIR ON)
@@ -458,12 +457,6 @@ if(TRITON_BUILD_PYTHON_MODULE)
       CONTENT "${TRITON_EXPORT_SYMBOLS_FILE_CONTENT}")
   endif()
 
-  install(TARGETS triton
-    COMPONENT libraries
-    LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
-    ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR}
-  )
-
   if (NOT DEFINED LLVM_SYSPATH)
       message(FATAL_ERROR "LLVM_SYSPATH must be set.")
   endif()
@@ -538,24 +531,3 @@ if(TRITON_BUILD_UT)
     USES_TERMINAL
   )
 endif()
-
-################################################################################
-# Header installation
-################################################################################
-
-install(DIRECTORY ${PROJECT_SOURCE_DIR}/include/
-  COMPONENT headers
-  DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}
-  FILES_MATCHING PATTERN "*.h")
-install(DIRECTORY ${PROJECT_BINARY_DIR}/include/
-  COMPONENT headers
-  DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}
-  FILES_MATCHING PATTERN "*.h" PATTERN "*.h.inc")
-install(DIRECTORY ${PROJECT_SOURCE_DIR}/include/
-  COMPONENT headers
-  DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}
-  FILES_MATCHING PATTERN "*.td")
-install(DIRECTORY ${PROJECT_SOURCE_DIR}/python/
-  COMPONENT headers
-  DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/python
-  FILES_MATCHING PATTERN "*.h")

--- a/Makefile
+++ b/Makefile
@@ -5,7 +5,6 @@
 PYTHON ?= python3
 ROOT_DIR := $(realpath $(dir $(lastword $(MAKEFILE_LIST))))
 BUILD_DIR := $(shell PYTHONPATH="$(ROOT_DIR)/python" $(PYTHON) -c 'from build_helpers import get_cmake_dir; print(get_cmake_dir())')
-INSTALL_DIR ?= $(dir $(BUILD_DIR))install
 TRITON_OPT := $(BUILD_DIR)/bin/triton-opt
 PYTEST := $(PYTHON) -m pytest
 LLVM_BUILD_PATH ?= "$(ROOT_DIR)/.llvm-project/build"
@@ -117,12 +116,6 @@ dev-install-llvm:
 		LLVM_LIBRARY_DIR=$(LLVM_BUILD_PATH)/lib \
 		LLVM_SYSPATH=$(LLVM_BUILD_PATH) \
 	$(MAKE) dev-install
-
-# Package C++ artifacts
-
-.PHONY: install
-install:
-	cmake --install $(BUILD_DIR) --prefix $(INSTALL_DIR)
 
 # Updating lit tests
 

--- a/bin/CMakeLists.txt
+++ b/bin/CMakeLists.txt
@@ -89,13 +89,3 @@ target_link_libraries(triton-tensor-layout PRIVATE
   MLIRRegisterAllPasses
   MLIRTransforms
 )
-
-install(TARGETS
-  triton-opt
-  triton-reduce
-  triton-lsp
-  triton-llvm-opt
-  triton-tensor-layout
-  COMPONENT binaries
-  RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR}
-)


### PR DESCRIPTION
As of [triton-ext#111], triton-ext no longer needs the `make install` / `cmake --install` workflow introduced in #9534 and extended in #9847, so this removes those pieces: the `headers` and `libraries` CMake install components from the top-level `CMakeLists.txt`, the `binaries` install from `bin/CMakeLists.txt`, the `make install` target and `INSTALL_DIR` variable from the Makefile, and the now-unused `include(GNUInstallDirs)`.

[triton-ext#111]: https://github.com/triton-lang/triton-ext/pull/111

All of that is now bundled with the wheel in `setup.py` using the `wheel_headers` component introduced in #10847.