### PR TITLE
[NVIDIA] Skip barriers between commuting shared atomics

### DIFF
--- a/include/triton/Dialect/TritonGPU/IR/TritonGPUOps.td
+++ b/include/triton/Dialect/TritonGPU/IR/TritonGPUOps.td
@@ -495,6 +495,10 @@ def TTG_LocalAtomicScatterRMWOp : TTG_Op<"local_atomic_scatter_rmw", [
   );
   let results = (outs TT_Tensor:$result);
 
+  let extraClassDeclaration = [{
+    bool isCommutative();
+  }];
+
   let assemblyFormat = [{
     $atomic_rmw_op `,` $dst `[` $indices `]` `,` $values (`,` $mask^)? attr-dict `:`
     functional-type(operands, results)

--- a/lib/Dialect/TritonGPU/IR/Ops.cpp
+++ b/lib/Dialect/TritonGPU/IR/Ops.cpp
@@ -1052,6 +1052,26 @@ LogicalResult LocalScatterOp::verify() {
 }
 
 // LocalAtomicScatterRMWOp
+bool LocalAtomicScatterRMWOp::isCommutative() {
+  if (!getResult().use_empty() ||
+      !getDst().getType().getElementType().isInteger())
+    return false;
+
+  switch (getAtomicRmwOp()) {
+  case RMWOp::ADD:
+  case RMWOp::AND:
+  case RMWOp::OR:
+  case RMWOp::XOR:
+  case RMWOp::MAX:
+  case RMWOp::MIN:
+  case RMWOp::UMAX:
+  case RMWOp::UMIN:
+    return true;
+  default:
+    return false;
+  }
+}
+
 LogicalResult LocalAtomicScatterRMWOp::verify() {
   auto dstTy = getDst().getType();
   auto valuesTy = cast<RankedTensorType>(getValues().getType());

--- a/test/Analysis/test-membar-ttng.mlir
+++ b/test/Analysis/test-membar-ttng.mlir
@@ -229,3 +229,85 @@ module attributes {"ttg.num-warps" = 4 : i32} {
     tt.return
   }
 }
+
+// -----
+
+#blocked = #ttg.blocked<{sizePerThread = [1], threadsPerWarp = [32], warpsPerCTA = [4], order = [0]}>
+#shared = #ttg.swizzled_shared<{vec = 1, perPhase = 1, maxPhase = 1, order = [0]}>
+#smem = #ttg.shared_memory
+
+module attributes {"ttg.num-warps" = 4 : i32, "ttg.num-ctas" = 1 : i32} {
+  // CHECK-LABEL: @unused_integer_atomic_adds
+  tt.func @unused_integer_atomic_adds(
+      %indices: tensor<128xi32, #blocked>,
+      %values: tensor<128xi32, #blocked>,
+      %mask: tensor<128xi1, #blocked>) -> tensor<128xi32, #blocked> {
+    %zero = arith.constant dense<0> : tensor<128xi32, #blocked>
+    %shared = ttg.local_alloc : () -> !ttg.memdesc<128xi32, #shared, #smem, mutable>
+    // CHECK: ttg.local_store
+    // CHECK-NEXT: ttg.barrier local
+    // CHECK-NEXT: {{.*}}ttg.local_atomic_scatter_rmw add
+    // CHECK-NEXT: {{.*}}ttg.local_atomic_scatter_rmw add
+    // CHECK-NEXT: {{.*}}ttg.local_atomic_scatter_rmw add
+    // CHECK-NEXT: ttg.barrier local
+    // CHECK-NEXT: {{.*}}ttg.local_load
+    ttg.local_store %zero, %shared : tensor<128xi32, #blocked> -> !ttg.memdesc<128xi32, #shared, #smem, mutable>
+    %first = ttg.local_atomic_scatter_rmw add, %shared[%indices], %values {axis = 0 : i32} : (!ttg.memdesc<128xi32, #shared, #smem, mutable>, tensor<128xi32, #blocked>, tensor<128xi32, #blocked>) -> tensor<128xi32, #blocked>
+    %second = ttg.local_atomic_scatter_rmw add, %shared[%indices], %values, %mask {axis = 0 : i32} : (!ttg.memdesc<128xi32, #shared, #smem, mutable>, tensor<128xi32, #blocked>, tensor<128xi32, #blocked>, tensor<128xi1, #blocked>) -> tensor<128xi32, #blocked>
+    %third = ttg.local_atomic_scatter_rmw add, %shared[%indices], %values {axis = 0 : i32} : (!ttg.memdesc<128xi32, #shared, #smem, mutable>, tensor<128xi32, #blocked>, tensor<128xi32, #blocked>) -> tensor<128xi32, #blocked>
+    %final = ttg.local_load %shared : !ttg.memdesc<128xi32, #shared, #smem, mutable> -> tensor<128xi32, #blocked>
+    tt.return %final : tensor<128xi32, #blocked>
+  }
+
+  // CHECK-LABEL: @first_atomic_result_used
+  tt.func @first_atomic_result_used(
+      %indices: tensor<128xi32, #blocked>,
+      %values: tensor<128xi32, #blocked>) -> tensor<128xi32, #blocked> {
+    %shared = ttg.local_alloc : () -> !ttg.memdesc<128xi32, #shared, #smem, mutable>
+    // CHECK: {{.*}}ttg.local_atomic_scatter_rmw add
+    // CHECK-NEXT: ttg.barrier local
+    // CHECK-NEXT: {{.*}}ttg.local_atomic_scatter_rmw add
+    %first = ttg.local_atomic_scatter_rmw add, %shared[%indices], %values {axis = 0 : i32} : (!ttg.memdesc<128xi32, #shared, #smem, mutable>, tensor<128xi32, #blocked>, tensor<128xi32, #blocked>) -> tensor<128xi32, #blocked>
+    %second = ttg.local_atomic_scatter_rmw add, %shared[%indices], %values {axis = 0 : i32} : (!ttg.memdesc<128xi32, #shared, #smem, mutable>, tensor<128xi32, #blocked>, tensor<128xi32, #blocked>) -> tensor<128xi32, #blocked>
+    tt.return %first : tensor<128xi32, #blocked>
+  }
+
+  // CHECK-LABEL: @second_atomic_result_used
+  tt.func @second_atomic_result_used(
+      %indices: tensor<128xi32, #blocked>,
+      %values: tensor<128xi32, #blocked>) -> tensor<128xi32, #blocked> {
+    %shared = ttg.local_alloc : () -> !ttg.memdesc<128xi32, #shared, #smem, mutable>
+    // CHECK: {{.*}}ttg.local_atomic_scatter_rmw add
+    // CHECK-NEXT: ttg.barrier local
+    // CHECK-NEXT: {{.*}}ttg.local_atomic_scatter_rmw add
+    %first = ttg.local_atomic_scatter_rmw add, %shared[%indices], %values {axis = 0 : i32} : (!ttg.memdesc<128xi32, #shared, #smem, mutable>, tensor<128xi32, #blocked>, tensor<128xi32, #blocked>) -> tensor<128xi32, #blocked>
+    %second = ttg.local_atomic_scatter_rmw add, %shared[%indices], %values {axis = 0 : i32} : (!ttg.memdesc<128xi32, #shared, #smem, mutable>, tensor<128xi32, #blocked>, tensor<128xi32, #blocked>) -> tensor<128xi32, #blocked>
+    tt.return %second : tensor<128xi32, #blocked>
+  }
+
+  // CHECK-LABEL: @unused_integer_atomic_max
+  tt.func @unused_integer_atomic_max(
+      %indices: tensor<128xi32, #blocked>,
+      %values: tensor<128xi32, #blocked>) {
+    %shared = ttg.local_alloc : () -> !ttg.memdesc<128xi32, #shared, #smem, mutable>
+    // CHECK: {{.*}}ttg.local_atomic_scatter_rmw max
+    // CHECK-NEXT: ttg.barrier local
+    // CHECK-NEXT: {{.*}}ttg.local_atomic_scatter_rmw max
+    %first = ttg.local_atomic_scatter_rmw max, %shared[%indices], %values {axis = 0 : i32} : (!ttg.memdesc<128xi32, #shared, #smem, mutable>, tensor<128xi32, #blocked>, tensor<128xi32, #blocked>) -> tensor<128xi32, #blocked>
+    %second = ttg.local_atomic_scatter_rmw max, %shared[%indices], %values {axis = 0 : i32} : (!ttg.memdesc<128xi32, #shared, #smem, mutable>, tensor<128xi32, #blocked>, tensor<128xi32, #blocked>) -> tensor<128xi32, #blocked>
+    tt.return
+  }
+
+  // CHECK-LABEL: @unused_floating_atomic_adds
+  tt.func @unused_floating_atomic_adds(
+      %indices: tensor<128xi32, #blocked>,
+      %values: tensor<128xf32, #blocked>) {
+    %shared = ttg.local_alloc : () -> !ttg.memdesc<128xf32, #shared, #smem, mutable>
+    // CHECK: {{.*}}ttg.local_atomic_scatter_rmw fadd
+    // CHECK-NEXT: ttg.barrier local
+    // CHECK-NEXT: {{.*}}ttg.local_atomic_scatter_rmw fadd
+    %first = ttg.local_atomic_scatter_rmw fadd, %shared[%indices], %values {axis = 0 : i32} : (!ttg.memdesc<128xf32, #shared, #smem, mutable>, tensor<128xf32, #blocked>, tensor<128xi32, #blocked>) -> tensor<128xf32, #blocked>
+    %second = ttg.local_atomic_scatter_rmw fadd, %shared[%indices], %values {axis = 0 : i32} : (!ttg.memdesc<128xf32, #shared, #smem, mutable>, tensor<128xf32, #blocked>, tensor<128xi32, #blocked>) -> tensor<128xf32, #blocked>
+    tt.return
+  }
+}

--- a/test/Analysis/test-membar-ttng.mlir
+++ b/test/Analysis/test-membar-ttng.mlir
@@ -285,16 +285,87 @@ module attributes {"ttg.num-warps" = 4 : i32, "ttg.num-ctas" = 1 : i32} {
     tt.return %second : tensor<128xi32, #blocked>
   }
 
-  // CHECK-LABEL: @unused_integer_atomic_max
-  tt.func @unused_integer_atomic_max(
+  // CHECK-LABEL: @unused_commutative_integer_atomics
+  tt.func @unused_commutative_integer_atomics(
       %indices: tensor<128xi32, #blocked>,
       %values: tensor<128xi32, #blocked>) {
     %shared = ttg.local_alloc : () -> !ttg.memdesc<128xi32, #shared, #smem, mutable>
+    // CHECK: {{.*}}ttg.local_atomic_scatter_rmw and
+    // CHECK-NEXT: {{.*}}ttg.local_atomic_scatter_rmw and
+    // CHECK-NEXT: ttg.barrier local
+    // CHECK-NEXT: {{.*}}ttg.local_atomic_scatter_rmw or
+    // CHECK-NEXT: {{.*}}ttg.local_atomic_scatter_rmw or
+    // CHECK-NEXT: ttg.barrier local
+    // CHECK-NEXT: {{.*}}ttg.local_atomic_scatter_rmw xor
+    // CHECK-NEXT: {{.*}}ttg.local_atomic_scatter_rmw xor
+    // CHECK-NEXT: ttg.barrier local
     // CHECK: {{.*}}ttg.local_atomic_scatter_rmw max
+    // CHECK-NEXT: {{.*}}ttg.local_atomic_scatter_rmw max
+    // CHECK-NEXT: ttg.barrier local
+    // CHECK-NEXT: {{.*}}ttg.local_atomic_scatter_rmw min
+    // CHECK-NEXT: {{.*}}ttg.local_atomic_scatter_rmw min
+    // CHECK-NEXT: ttg.barrier local
+    // CHECK-NEXT: {{.*}}ttg.local_atomic_scatter_rmw umax
+    // CHECK-NEXT: {{.*}}ttg.local_atomic_scatter_rmw umax
+    // CHECK-NEXT: ttg.barrier local
+    // CHECK-NEXT: {{.*}}ttg.local_atomic_scatter_rmw umin
+    // CHECK-NEXT: {{.*}}ttg.local_atomic_scatter_rmw umin
+    %and0 = ttg.local_atomic_scatter_rmw and, %shared[%indices], %values {axis = 0 : i32} : (!ttg.memdesc<128xi32, #shared, #smem, mutable>, tensor<128xi32, #blocked>, tensor<128xi32, #blocked>) -> tensor<128xi32, #blocked>
+    %and1 = ttg.local_atomic_scatter_rmw and, %shared[%indices], %values {axis = 0 : i32} : (!ttg.memdesc<128xi32, #shared, #smem, mutable>, tensor<128xi32, #blocked>, tensor<128xi32, #blocked>) -> tensor<128xi32, #blocked>
+    %or0 = ttg.local_atomic_scatter_rmw or, %shared[%indices], %values {axis = 0 : i32} : (!ttg.memdesc<128xi32, #shared, #smem, mutable>, tensor<128xi32, #blocked>, tensor<128xi32, #blocked>) -> tensor<128xi32, #blocked>
+    %or1 = ttg.local_atomic_scatter_rmw or, %shared[%indices], %values {axis = 0 : i32} : (!ttg.memdesc<128xi32, #shared, #smem, mutable>, tensor<128xi32, #blocked>, tensor<128xi32, #blocked>) -> tensor<128xi32, #blocked>
+    %xor0 = ttg.local_atomic_scatter_rmw xor, %shared[%indices], %values {axis = 0 : i32} : (!ttg.memdesc<128xi32, #shared, #smem, mutable>, tensor<128xi32, #blocked>, tensor<128xi32, #blocked>) -> tensor<128xi32, #blocked>
+    %xor1 = ttg.local_atomic_scatter_rmw xor, %shared[%indices], %values {axis = 0 : i32} : (!ttg.memdesc<128xi32, #shared, #smem, mutable>, tensor<128xi32, #blocked>, tensor<128xi32, #blocked>) -> tensor<128xi32, #blocked>
+    %max0 = ttg.local_atomic_scatter_rmw max, %shared[%indices], %values {axis = 0 : i32} : (!ttg.memdesc<128xi32, #shared, #smem, mutable>, tensor<128xi32, #blocked>, tensor<128xi32, #blocked>) -> tensor<128xi32, #blocked>
+    %max1 = ttg.local_atomic_scatter_rmw max, %shared[%indices], %values {axis = 0 : i32} : (!ttg.memdesc<128xi32, #shared, #smem, mutable>, tensor<128xi32, #blocked>, tensor<128xi32, #blocked>) -> tensor<128xi32, #blocked>
+    %min0 = ttg.local_atomic_scatter_rmw min, %shared[%indices], %values {axis = 0 : i32} : (!ttg.memdesc<128xi32, #shared, #smem, mutable>, tensor<128xi32, #blocked>, tensor<128xi32, #blocked>) -> tensor<128xi32, #blocked>
+    %min1 = ttg.local_atomic_scatter_rmw min, %shared[%indices], %values {axis = 0 : i32} : (!ttg.memdesc<128xi32, #shared, #smem, mutable>, tensor<128xi32, #blocked>, tensor<128xi32, #blocked>) -> tensor<128xi32, #blocked>
+    %umax0 = ttg.local_atomic_scatter_rmw umax, %shared[%indices], %values {axis = 0 : i32} : (!ttg.memdesc<128xi32, #shared, #smem, mutable>, tensor<128xi32, #blocked>, tensor<128xi32, #blocked>) -> tensor<128xi32, #blocked>
+    %umax1 = ttg.local_atomic_scatter_rmw umax, %shared[%indices], %values {axis = 0 : i32} : (!ttg.memdesc<128xi32, #shared, #smem, mutable>, tensor<128xi32, #blocked>, tensor<128xi32, #blocked>) -> tensor<128xi32, #blocked>
+    %umin0 = ttg.local_atomic_scatter_rmw umin, %shared[%indices], %values {axis = 0 : i32} : (!ttg.memdesc<128xi32, #shared, #smem, mutable>, tensor<128xi32, #blocked>, tensor<128xi32, #blocked>) -> tensor<128xi32, #blocked>
+    %umin1 = ttg.local_atomic_scatter_rmw umin, %shared[%indices], %values {axis = 0 : i32} : (!ttg.memdesc<128xi32, #shared, #smem, mutable>, tensor<128xi32, #blocked>, tensor<128xi32, #blocked>) -> tensor<128xi32, #blocked>
+    tt.return
+  }
+
+  // CHECK-LABEL: @unused_mixed_integer_atomics
+  tt.func @unused_mixed_integer_atomics(
+      %indices: tensor<128xi32, #blocked>,
+      %values: tensor<128xi32, #blocked>) {
+    %shared = ttg.local_alloc : () -> !ttg.memdesc<128xi32, #shared, #smem, mutable>
+    // CHECK: {{.*}}ttg.local_atomic_scatter_rmw add
     // CHECK-NEXT: ttg.barrier local
     // CHECK-NEXT: {{.*}}ttg.local_atomic_scatter_rmw max
-    %first = ttg.local_atomic_scatter_rmw max, %shared[%indices], %values {axis = 0 : i32} : (!ttg.memdesc<128xi32, #shared, #smem, mutable>, tensor<128xi32, #blocked>, tensor<128xi32, #blocked>) -> tensor<128xi32, #blocked>
-    %second = ttg.local_atomic_scatter_rmw max, %shared[%indices], %values {axis = 0 : i32} : (!ttg.memdesc<128xi32, #shared, #smem, mutable>, tensor<128xi32, #blocked>, tensor<128xi32, #blocked>) -> tensor<128xi32, #blocked>
+    %add = ttg.local_atomic_scatter_rmw add, %shared[%indices], %values {axis = 0 : i32} : (!ttg.memdesc<128xi32, #shared, #smem, mutable>, tensor<128xi32, #blocked>, tensor<128xi32, #blocked>) -> tensor<128xi32, #blocked>
+    %max = ttg.local_atomic_scatter_rmw max, %shared[%indices], %values {axis = 0 : i32} : (!ttg.memdesc<128xi32, #shared, #smem, mutable>, tensor<128xi32, #blocked>, tensor<128xi32, #blocked>) -> tensor<128xi32, #blocked>
+    tt.return
+  }
+
+  // CHECK-LABEL: @unused_atomic_exchanges
+  tt.func @unused_atomic_exchanges(
+      %indices: tensor<128xi32, #blocked>,
+      %values: tensor<128xi32, #blocked>) {
+    %shared = ttg.local_alloc : () -> !ttg.memdesc<128xi32, #shared, #smem, mutable>
+    // CHECK: {{.*}}ttg.local_atomic_scatter_rmw exch
+    // CHECK-NEXT: ttg.barrier local
+    // CHECK-NEXT: {{.*}}ttg.local_atomic_scatter_rmw exch
+    %first = ttg.local_atomic_scatter_rmw exch, %shared[%indices], %values {axis = 0 : i32} : (!ttg.memdesc<128xi32, #shared, #smem, mutable>, tensor<128xi32, #blocked>, tensor<128xi32, #blocked>) -> tensor<128xi32, #blocked>
+    %second = ttg.local_atomic_scatter_rmw exch, %shared[%indices], %values {axis = 0 : i32} : (!ttg.memdesc<128xi32, #shared, #smem, mutable>, tensor<128xi32, #blocked>, tensor<128xi32, #blocked>) -> tensor<128xi32, #blocked>
+    tt.return
+  }
+
+  // CHECK-LABEL: @unused_mixed_width_integer_atomic_adds
+  tt.func @unused_mixed_width_integer_atomic_adds(
+      %indices32: tensor<128xi32, #blocked>,
+      %values32: tensor<128xi32, #blocked>,
+      %indices64: tensor<64xi32, #blocked>,
+      %values64: tensor<64xi64, #blocked>) {
+    %shared32 = ttg.local_alloc : () -> !ttg.memdesc<128xi32, #shared, #smem, mutable>
+    %shared64 = ttg.memdesc_reinterpret %shared32 : !ttg.memdesc<128xi32, #shared, #smem, mutable> -> !ttg.memdesc<64xi64, #shared, #smem, mutable>
+    // CHECK: {{.*}}ttg.local_atomic_scatter_rmw add
+    // CHECK-NEXT: ttg.barrier local
+    // CHECK-NEXT: {{.*}}ttg.local_atomic_scatter_rmw add
+    %narrow = ttg.local_atomic_scatter_rmw add, %shared32[%indices32], %values32 {axis = 0 : i32} : (!ttg.memdesc<128xi32, #shared, #smem, mutable>, tensor<128xi32, #blocked>, tensor<128xi32, #blocked>) -> tensor<128xi32, #blocked>
+    %wide = ttg.local_atomic_scatter_rmw add, %shared64[%indices64], %values64 {axis = 0 : i32} : (!ttg.memdesc<64xi64, #shared, #smem, mutable>, tensor<64xi64, #blocked>, tensor<64xi32, #blocked>) -> tensor<64xi64, #blocked>
     tt.return
   }
 

--- a/third_party/nvidia/lib/TritonNVIDIAGPUToLLVM/TritonGPUToLLVM.cpp
+++ b/third_party/nvidia/lib/TritonNVIDIAGPUToLLVM/TritonGPUToLLVM.cpp
@@ -309,31 +309,14 @@ bool NVIDIA::canSkipBarSync(Operation *before, Operation *after,
       isa<ttng::WaitBarrierOp>(after))
     return true;
 
-  // Identical same-width integer reductions commute if old values are unused.
+  // Identical same-width commutative atomics can be freely reordered.
   auto beforeAtomic = dyn_cast<triton::gpu::LocalAtomicScatterRMWOp>(before);
   auto afterAtomic = dyn_cast<triton::gpu::LocalAtomicScatterRMWOp>(after);
-  if (beforeAtomic && afterAtomic && beforeAtomic.getResult().use_empty() &&
-      afterAtomic.getResult().use_empty() &&
-      beforeAtomic.getDst().getType().getElementType().isInteger() &&
-      beforeAtomic.getDst().getType().getElementType() ==
-          afterAtomic.getDst().getType().getElementType() &&
-      beforeAtomic.getAtomicRmwOp() == afterAtomic.getAtomicRmwOp()) {
-    switch (beforeAtomic.getAtomicRmwOp()) {
-    case RMWOp::ADD:
-    case RMWOp::AND:
-    case RMWOp::OR:
-    case RMWOp::XOR:
-    case RMWOp::MAX:
-    case RMWOp::MIN:
-    case RMWOp::UMAX:
-    case RMWOp::UMIN:
-      return true;
-    default:
-      break;
-    }
-  }
-
-  return false;
+  return beforeAtomic && afterAtomic && beforeAtomic.isCommutative() &&
+         afterAtomic.isCommutative() &&
+         beforeAtomic.getAtomicRmwOp() == afterAtomic.getAtomicRmwOp() &&
+         beforeAtomic.getDst().getType().getElementType() ==
+             afterAtomic.getDst().getType().getElementType();
 }
 
 } // namespace triton

--- a/third_party/nvidia/lib/TritonNVIDIAGPUToLLVM/TritonGPUToLLVM.cpp
+++ b/third_party/nvidia/lib/TritonNVIDIAGPUToLLVM/TritonGPUToLLVM.cpp
@@ -309,17 +309,29 @@ bool NVIDIA::canSkipBarSync(Operation *before, Operation *after,
       isa<ttng::WaitBarrierOp>(after))
     return true;
 
-  // Integer additions commute when neither atomic's previous value is used.
+  // Identical same-width integer reductions commute if old values are unused.
   auto beforeAtomic = dyn_cast<triton::gpu::LocalAtomicScatterRMWOp>(before);
   auto afterAtomic = dyn_cast<triton::gpu::LocalAtomicScatterRMWOp>(after);
-  if (beforeAtomic && afterAtomic &&
-      beforeAtomic.getAtomicRmwOp() == RMWOp::ADD &&
-      afterAtomic.getAtomicRmwOp() == RMWOp::ADD &&
-      beforeAtomic.getResult().use_empty() &&
+  if (beforeAtomic && afterAtomic && beforeAtomic.getResult().use_empty() &&
       afterAtomic.getResult().use_empty() &&
       beforeAtomic.getDst().getType().getElementType().isInteger() &&
-      afterAtomic.getDst().getType().getElementType().isInteger())
-    return true;
+      beforeAtomic.getDst().getType().getElementType() ==
+          afterAtomic.getDst().getType().getElementType() &&
+      beforeAtomic.getAtomicRmwOp() == afterAtomic.getAtomicRmwOp()) {
+    switch (beforeAtomic.getAtomicRmwOp()) {
+    case RMWOp::ADD:
+    case RMWOp::AND:
+    case RMWOp::OR:
+    case RMWOp::XOR:
+    case RMWOp::MAX:
+    case RMWOp::MIN:
+    case RMWOp::UMAX:
+    case RMWOp::UMIN:
+      return true;
+    default:
+      break;
+    }
+  }
 
   return false;
 }

--- a/third_party/nvidia/lib/TritonNVIDIAGPUToLLVM/TritonGPUToLLVM.cpp
+++ b/third_party/nvidia/lib/TritonNVIDIAGPUToLLVM/TritonGPUToLLVM.cpp
@@ -309,6 +309,18 @@ bool NVIDIA::canSkipBarSync(Operation *before, Operation *after,
       isa<ttng::WaitBarrierOp>(after))
     return true;
 
+  // Integer additions commute when neither atomic's previous value is used.
+  auto beforeAtomic = dyn_cast<triton::gpu::LocalAtomicScatterRMWOp>(before);
+  auto afterAtomic = dyn_cast<triton::gpu::LocalAtomicScatterRMWOp>(after);
+  if (beforeAtomic && afterAtomic &&
+      beforeAtomic.getAtomicRmwOp() == RMWOp::ADD &&
+      afterAtomic.getAtomicRmwOp() == RMWOp::ADD &&
+      beforeAtomic.getResult().use_empty() &&
+      afterAtomic.getResult().use_empty() &&
+      beforeAtomic.getDst().getType().getElementType().isInteger() &&
+      afterAtomic.getDst().getType().getElementType().isInteger())
+    return true;
+
   return false;
 }
 


### PR DESCRIPTION
PR description written by Codex

Skip CTA barriers between identical integer shared-memory atomic ADD, AND, OR, XOR, MAX, MIN, UMAX, or UMIN operations when both results are unused and element types match. Keep barriers for mixed-width aliases, other operations, floating-point addition, observed results, initialization, and final reads.
