### PR TITLE
[DNR][BACKEND] Reduce layout conversions at memory boundaries

### DIFF
--- a/lib/Dialect/TritonGPU/Transforms/RemoveLayoutConversions.cpp
+++ b/lib/Dialect/TritonGPU/Transforms/RemoveLayoutConversions.cpp
@@ -1795,13 +1795,47 @@ private:
   DenseMap<unsigned, Value> predicates;
 };
 
+bool rewriteReductionStoreLayout(StoreOp store) {
+  if (!store.getMask())
+    return false;
+
+  auto pointer = store.getPtr().getDefiningOp<ConvertLayoutOp>();
+  auto mask = store.getMask().getDefiningOp<ConvertLayoutOp>();
+  auto value = store.getValue().getDefiningOp<ConvertLayoutOp>();
+  if (!pointer || !mask || !value ||
+      !value.getSrc().getDefiningOp<ReduceOp>() ||
+      !pointer.getSrc().getDefiningOp<AddPtrOp>())
+    return false;
+
+  auto source = cast<RankedTensorType>(pointer.getSrc().getType());
+  auto predicate = cast<RankedTensorType>(mask.getSrc().getType());
+  auto payload = cast<RankedTensorType>(value.getSrc().getType());
+  Attribute encoding = source.getEncoding();
+  if (source.getRank() != 2 || source.getDimSize(1) != 1 ||
+      source.getShape() != payload.getShape() ||
+      predicate.getEncoding() != encoding ||
+      !payload.getElementType().isInteger(32))
+    return false;
+
+  OpBuilder builder(store);
+  auto result = ConvertLayoutOp::create(builder, store.getLoc(),
+                                        payload.cloneWithEncoding(encoding),
+                                        value.getSrc());
+  store.getPtrMutable().assign(pointer.getSrc());
+  store.getMaskMutable().assign(mask.getSrc());
+  store.getValueMutable().assign(result.getResult());
+  return true;
+}
+
 bool rewriteIndexedStoreExpressions(ModuleOp module) {
   SmallVector<StoreOp> stores;
   module.walk([&](StoreOp store) { stores.push_back(store); });
 
   bool changed = false;
-  for (StoreOp store : stores)
+  for (StoreOp store : stores) {
     changed |= IndexedStoreExpression(store).rewrite();
+    changed |= rewriteReductionStoreLayout(store);
+  }
   return changed;
 }
 } // namespace

--- a/lib/Dialect/TritonGPU/Transforms/RemoveLayoutConversions.cpp
+++ b/lib/Dialect/TritonGPU/Transforms/RemoveLayoutConversions.cpp
@@ -22,7 +22,9 @@
 #include "triton/Dialect/TritonGPU/Transforms/Passes.h"
 #include "triton/Dialect/TritonGPU/Transforms/TritonGPUConversion.h"
 #include "triton/Dialect/TritonGPU/Transforms/Utility.h"
+#include "llvm/Support/MathExtras.h"
 #include <deque>
+#include <limits>
 
 namespace mlir::triton::gpu {
 
@@ -1601,6 +1603,207 @@ void hoistConvert(ModuleOp module, bool disableRematSplitting) {
     LayoutRematerialization(funcOp).hoistConvertDotOperand();
   });
 }
+
+class IndexedStoreExpression {
+public:
+  explicit IndexedStoreExpression(StoreOp store) : store(store) {}
+
+  bool rewrite() {
+    target = dyn_cast<RankedTensorType>(store.getValue().getType());
+    if (!target || !target.hasStaticShape() || !store.getValue().hasOneUse())
+      return false;
+
+    int64_t size = target.getNumElements();
+    if (size <= 0 || size > std::numeric_limits<int32_t>::max() ||
+        !llvm::isPowerOf2_64(static_cast<uint64_t>(size)))
+      return false;
+
+    auto *interface =
+        target.getEncoding()
+            .getDialect()
+            .getRegisteredInterface<triton::DialectInferLayoutInterface>();
+    if (!interface ||
+        failed(interface->inferReshapeOpEncoding(
+            target.getShape(), target.getEncoding(), ArrayRef<int64_t>{size},
+            flatEncoding, /*allowReorder=*/false, store.getLoc())) ||
+        failed(plan(store.getValue(), 0)))
+      return false;
+
+    unsigned joins = 0;
+    unsigned conversions = 0;
+    bool communicates = false;
+    for (Operation *operation : operations) {
+      if (auto conversion = dyn_cast<ConvertLayoutOp>(operation)) {
+        ++conversions;
+        communicates |= !cvtReordersRegisters(conversion.getSrc().getType(),
+                                              conversion.getType());
+      }
+      joins += isa<JoinOp>(operation);
+      if (!isa<SplatOp, MakeRangeOp, arith::ConstantOp>(operation) &&
+          llvm::any_of(operation->getUsers(), [&](Operation *user) {
+            return user == store ? operation->getResult(0) != store.getValue()
+                                 : !operations.contains(user);
+          }))
+        return false;
+    }
+    if (!joins || conversions < 2 || !communicates)
+      return false;
+
+    OpBuilder builder(store);
+    auto flatType =
+        RankedTensorType::get({size}, builder.getI32Type(), flatEncoding);
+    Value range = MakeRangeOp::create(builder, store.getLoc(), flatType, 0,
+                                      static_cast<int32_t>(size));
+    auto indexType = RankedTensorType::get(
+        target.getShape(), builder.getI32Type(), target.getEncoding());
+    indices = ReshapeOp::create(builder, store.getLoc(), indexType, range);
+    store.getValueMutable().assign(materialize(store.getValue(), 0, builder));
+
+    for (Operation *operation : operations)
+      if (isOpTriviallyDead(operation))
+        operation->erase();
+    return true;
+  }
+
+private:
+  LogicalResult plan(Value value, unsigned depth) {
+    auto type = dyn_cast<RankedTensorType>(value.getType());
+    if (!type || depth > 30 ||
+        (target.getNumElements() >> depth) != type.getNumElements())
+      return failure();
+
+    auto [existing, inserted] = depths.try_emplace(value, depth);
+    if (!inserted)
+      return success(existing->second == depth);
+
+    Operation *operation = value.getDefiningOp();
+    if (!operation || operation->getNumResults() != 1 ||
+        !isMemoryEffectFree(operation) || operations.size() >= 512)
+      return failure();
+    bool leaf = isa<SplatOp, MakeRangeOp, arith::ConstantOp>(operation);
+    if (!leaf && operation->getBlock() != store->getBlock())
+      return failure();
+    operations.insert(operation);
+
+    if (auto conversion = dyn_cast<ConvertLayoutOp>(operation))
+      return plan(conversion.getSrc(), depth);
+    if (auto reshape = dyn_cast<ReshapeOp>(operation))
+      return reshape.getAllowReorder() ? failure()
+                                       : plan(reshape.getSrc(), depth);
+    if (auto join = dyn_cast<JoinOp>(operation)) {
+      if (type.getShape().empty() || type.getShape().back() != 2)
+        return failure();
+      return success(succeeded(plan(join.getLhs(), depth + 1)) &&
+                     succeeded(plan(join.getRhs(), depth + 1)));
+    }
+    if (auto splat = dyn_cast<SplatOp>(operation))
+      return success(!isa<RankedTensorType>(splat.getSrc().getType()));
+    if (auto range = dyn_cast<MakeRangeOp>(operation))
+      return success(range.getType().getElementType().isInteger(32));
+    if (auto constant = dyn_cast<arith::ConstantOp>(operation)) {
+      auto elements = dyn_cast<DenseElementsAttr>(constant.getValue());
+      return success(elements && elements.isSplat());
+    }
+    if (!operation->hasTrait<OpTrait::Elementwise>())
+      return failure();
+
+    for (Value operand : operation->getOperands())
+      if (auto argument = dyn_cast<RankedTensorType>(operand.getType());
+          argument && (argument.getShape() != type.getShape() ||
+                       failed(plan(operand, depth))))
+        return failure();
+    return success();
+  }
+
+  Value constant(OpBuilder &builder, Location location, int32_t value) {
+    auto type = cast<RankedTensorType>(indices.getType());
+    return arith::ConstantOp::create(
+        builder, location, type,
+        DenseElementsAttr::get(type, builder.getI32IntegerAttr(value)));
+  }
+
+  Value materialize(Value value, unsigned depth, OpBuilder &builder) {
+    if (Value existing = rewritten.lookup(value))
+      return existing;
+
+    Operation *operation = value.getDefiningOp();
+    if (auto conversion = dyn_cast<ConvertLayoutOp>(operation))
+      return rewritten[value] =
+                 materialize(conversion.getSrc(), depth, builder);
+    if (auto reshape = dyn_cast<ReshapeOp>(operation))
+      return rewritten[value] = materialize(reshape.getSrc(), depth, builder);
+
+    if (auto join = dyn_cast<JoinOp>(operation)) {
+      Value lhs = materialize(join.getLhs(), depth + 1, builder);
+      Value rhs = materialize(join.getRhs(), depth + 1, builder);
+      auto [predicate, inserted] = predicates.try_emplace(depth, Value());
+      if (inserted) {
+        Value mask = constant(builder, join.getLoc(), int32_t{1} << depth);
+        Value zero = constant(builder, join.getLoc(), 0);
+        Value masked =
+            arith::AndIOp::create(builder, join.getLoc(), indices, mask);
+        predicate->second = arith::CmpIOp::create(
+            builder, join.getLoc(), arith::CmpIPredicate::ne, masked, zero);
+      }
+      return rewritten[value] = arith::SelectOp::create(
+                 builder, join.getLoc(), predicate->second, rhs, lhs);
+    }
+
+    if (auto range = dyn_cast<MakeRangeOp>(operation)) {
+      Value result = indices;
+      if (depth)
+        result = arith::ShRUIOp::create(
+            builder, range.getLoc(), result,
+            constant(builder, range.getLoc(), static_cast<int32_t>(depth)));
+      if (int64_t start = range.getStartAttr().getInt(); start != 0)
+        result = arith::AddIOp::create(
+            builder, range.getLoc(), result,
+            constant(builder, range.getLoc(), static_cast<int32_t>(start)));
+      return rewritten[value] = result;
+    }
+
+    auto original = cast<RankedTensorType>(value.getType());
+    auto type = RankedTensorType::get(
+        target.getShape(), original.getElementType(), target.getEncoding());
+    if (auto splat = dyn_cast<SplatOp>(operation))
+      return rewritten[value] =
+                 SplatOp::create(builder, splat.getLoc(), type, splat.getSrc());
+    if (auto splat = dyn_cast<arith::ConstantOp>(operation)) {
+      auto elements = cast<DenseElementsAttr>(splat.getValue());
+      auto values =
+          DenseElementsAttr::get(type, elements.getSplatValue<Attribute>());
+      return rewritten[value] = arith::ConstantOp::create(
+                 builder, splat.getLoc(), type, values);
+    }
+
+    IRMapping mapping;
+    for (Value operand : operation->getOperands())
+      if (isa<RankedTensorType>(operand.getType()))
+        mapping.map(operand, materialize(operand, depth, builder));
+    Operation *replacement = builder.clone(*operation, mapping);
+    replacement->getResult(0).setType(type);
+    return rewritten[value] = replacement->getResult(0);
+  }
+
+  StoreOp store;
+  RankedTensorType target;
+  Attribute flatEncoding;
+  Value indices;
+  SetVector<Operation *> operations;
+  DenseMap<Value, unsigned> depths;
+  DenseMap<Value, Value> rewritten;
+  DenseMap<unsigned, Value> predicates;
+};
+
+bool rewriteIndexedStoreExpressions(ModuleOp module) {
+  SmallVector<StoreOp> stores;
+  module.walk([&](StoreOp store) { stores.push_back(store); });
+
+  bool changed = false;
+  for (StoreOp store : stores)
+    changed |= IndexedStoreExpression(store).rewrite();
+  return changed;
+}
 } // namespace
 
 class TritonGPURemoveLayoutConversionsPass
@@ -1689,6 +1892,9 @@ public:
     if (applyPatternsGreedily(m, std::move(scfCleanup)).failed()) {
       LLVM_DEBUG(DBGS() << "scf cleanup did not converge\n");
     }
+
+    if (rewriteIndexedStoreExpressions(m))
+      cleanupConvertOps();
 
     LLVM_DEBUG({
       DBGS() << "Module after final cleanups:\n";

--- a/lib/Dialect/TritonGPU/Transforms/RemoveLayoutConversions.cpp
+++ b/lib/Dialect/TritonGPU/Transforms/RemoveLayoutConversions.cpp
@@ -248,6 +248,52 @@ void LayoutPropagation::initAnchorLayout() {
     }
   };
 
+  auto addAddressAnchor = [&](ConvertLayoutOp conversion) {
+    if (!conversion)
+      return;
+    Value source = conversion.getSrc();
+    if (auto bitcast = source.getDefiningOp<BitcastOp>())
+      source = bitcast.getSrc();
+    auto address = source.getDefiningOp<AddPtrOp>();
+    auto type = address
+                    ? dyn_cast<RankedTensorType>(address.getOffset().getType())
+                    : RankedTensorType{};
+    if (!type || type.getRank() != 1 ||
+        llvm::count_if(address.getOffset().getUsers(),
+                       [](Operation *user) { return isa<AddPtrOp>(user); }) < 2)
+      return;
+
+    SmallVector<Value> worklist{address.getOffset()};
+    SmallVector<Value> ranges;
+    DenseSet<Value> visited;
+    while (!worklist.empty()) {
+      Value current = worklist.pop_back_val();
+      if (!visited.insert(current).second)
+        continue;
+      auto currentType = dyn_cast<RankedTensorType>(current.getType());
+      Operation *producer = current.getDefiningOp();
+      if (!currentType || currentType.getRank() != 1 ||
+          currentType.getShape() != type.getShape() || !producer ||
+          !currentType.getElementType().isInteger())
+        return;
+      if (isa<MakeRangeOp>(producer)) {
+        ranges.push_back(current);
+        continue;
+      }
+      if (isa<SplatOp, arith::ConstantOp>(producer))
+        continue;
+      if (!isa<arith::ArithDialect>(producer->getDialect()) ||
+          !isMemoryEffectFree(producer))
+        return;
+      for (Value operand : producer->getOperands())
+        if (isa<RankedTensorType>(operand.getType()))
+          worklist.push_back(operand);
+    }
+
+    for (Value range : ranges)
+      layouts.try_emplace(range, conversion.getType().getEncoding());
+  };
+
   // Consider function args as anchors.  This makes it easier to write tests --
   // you can pass a tensor with an encoding as an arg, instead of explicitly
   // calling tt.load.
@@ -261,6 +307,19 @@ void LayoutPropagation::initAnchorLayout() {
         addAnchor(result);
       }
     }
+
+    if (auto load = dyn_cast<LoadOp>(op)) {
+      auto conversion = load.getPtr().getDefiningOp<ConvertLayoutOp>();
+      auto argument = conversion ? dyn_cast<BlockArgument>(conversion.getSrc())
+                                 : BlockArgument{};
+      if (argument && argument.getArgNumber() > 0 &&
+          isa<scf::ForOp>(argument.getOwner()->getParentOp()) &&
+          isa<PointerType>(conversion.getType().getElementType()))
+        layouts.try_emplace(argument, conversion.getType().getEncoding());
+      addAddressAnchor(conversion);
+    }
+    if (auto store = dyn_cast<StoreOp>(op))
+      addAddressAnchor(store.getPtr().getDefiningOp<ConvertLayoutOp>());
   });
 }
 
@@ -1827,15 +1886,78 @@ bool rewriteReductionStoreLayout(StoreOp store) {
   return true;
 }
 
+bool rewriteConstantStoreLayout(StoreOp store) {
+  if (!store.getMask())
+    return false;
+
+  auto pointer = store.getPtr().getDefiningOp<ConvertLayoutOp>();
+  auto mask = store.getMask().getDefiningOp<ConvertLayoutOp>();
+  auto constant = store.getValue().getDefiningOp<arith::ConstantOp>();
+  if (!pointer || !mask || !constant)
+    return false;
+
+  auto source = cast<RankedTensorType>(pointer.getSrc().getType());
+  auto predicate = cast<RankedTensorType>(mask.getSrc().getType());
+  auto payload = cast<RankedTensorType>(constant.getType());
+  auto values = dyn_cast<DenseElementsAttr>(constant.getValue());
+  if (source.getRank() != 1 || source.getShape() != payload.getShape() ||
+      predicate.getEncoding() != source.getEncoding() || !values ||
+      !values.isSplat())
+    return false;
+
+  OpBuilder builder(store);
+  auto type = payload.cloneWithEncoding(source.getEncoding());
+  auto value = arith::ConstantOp::create(
+      builder, store.getLoc(), type,
+      DenseElementsAttr::get(type, values.getSplatValue<Attribute>()));
+  store.getPtrMutable().assign(pointer.getSrc());
+  store.getMaskMutable().assign(mask.getSrc());
+  store.getValueMutable().assign(value.getResult());
+  return true;
+}
+
+bool rewriteAtomicPointerLayout(AtomicRMWOp atomic) {
+  if (!atomic.getMask() || !atomic.getResult().use_empty())
+    return false;
+
+  auto pointer = atomic.getPtr().getDefiningOp<ConvertLayoutOp>();
+  auto mask = atomic.getMask().getDefiningOp<ConvertLayoutOp>();
+  if (!pointer || !mask || !pointer.getSrc().getDefiningOp<AddPtrOp>())
+    return false;
+
+  auto source = cast<RankedTensorType>(pointer.getSrc().getType());
+  auto predicate = cast<RankedTensorType>(mask.getSrc().getType());
+  auto payload = cast<RankedTensorType>(atomic.getVal().getType());
+  if (source.getRank() != 1 || source.getShape() != payload.getShape() ||
+      predicate.getEncoding() != source.getEncoding())
+    return false;
+
+  OpBuilder builder(atomic);
+  auto type = payload.cloneWithEncoding(source.getEncoding());
+  Value value = atomic.getVal();
+  if (payload.getEncoding() != source.getEncoding())
+    value = ConvertLayoutOp::create(builder, atomic.getLoc(), type, value);
+  atomic.getPtrMutable().assign(pointer.getSrc());
+  atomic.getMaskMutable().assign(mask.getSrc());
+  atomic.getValMutable().assign(value);
+  atomic.getResult().setType(type);
+  return true;
+}
+
 bool rewriteIndexedStoreExpressions(ModuleOp module) {
   SmallVector<StoreOp> stores;
   module.walk([&](StoreOp store) { stores.push_back(store); });
+  SmallVector<AtomicRMWOp> atomics;
+  module.walk([&](AtomicRMWOp atomic) { atomics.push_back(atomic); });
 
   bool changed = false;
   for (StoreOp store : stores) {
     changed |= IndexedStoreExpression(store).rewrite();
     changed |= rewriteReductionStoreLayout(store);
+    changed |= rewriteConstantStoreLayout(store);
   }
+  for (AtomicRMWOp atomic : atomics)
+    changed |= rewriteAtomicPointerLayout(atomic);
   return changed;
 }
 } // namespace

--- a/lib/Dialect/TritonGPU/Transforms/RemoveLayoutConversions.cpp
+++ b/lib/Dialect/TritonGPU/Transforms/RemoveLayoutConversions.cpp
@@ -248,6 +248,14 @@ void LayoutPropagation::initAnchorLayout() {
     }
   };
 
+  auto peelConversions = [](Value value) {
+    while (auto conversion = value.getDefiningOp<ConvertLayoutOp>())
+      value = conversion.getSrc();
+    return value;
+  };
+
+  SmallVector<StoreOp, 8> stores;
+
   auto addAddressAnchor = [&](ConvertLayoutOp conversion) {
     if (!conversion)
       return;
@@ -318,9 +326,175 @@ void LayoutPropagation::initAnchorLayout() {
         layouts.try_emplace(argument, conversion.getType().getEncoding());
       addAddressAnchor(conversion);
     }
-    if (auto store = dyn_cast<StoreOp>(op))
+    if (auto store = dyn_cast<StoreOp>(op)) {
       addAddressAnchor(store.getPtr().getDefiningOp<ConvertLayoutOp>());
+      stores.push_back(store);
+    }
   });
+
+  auto dependsOn = [](Value value, Value target) {
+    SmallVector<Value, 16> worklist{value};
+    DenseSet<Value> visited;
+    while (!worklist.empty()) {
+      Value current = worklist.pop_back_val();
+      if (current == target)
+        return true;
+      if (!visited.insert(current).second)
+        continue;
+      Operation *producer = current.getDefiningOp();
+      if (!producer || !isMemoryEffectFree(producer) || visited.size() > 512)
+        continue;
+      for (Value operand : producer->getOperands())
+        if (isa<RankedTensorType>(operand.getType()))
+          worklist.push_back(operand);
+    }
+    return false;
+  };
+
+  // Keep a narrowing pack in its loaded layout until its physical split. An
+  // allow-reorder random input is otherwise independently anchored and pulls
+  // the complete 32-bit rounding expression into the output layout.
+  funcOp.walk([&](SplitOp split) {
+    auto result = dyn_cast<RankedTensorType>(split->getResult(0).getType());
+    if (!result || !result.getElementType().isInteger(8))
+      return;
+
+    Value input = peelConversions(split.getSrc());
+    auto view = input.getDefiningOp<ReshapeOp>();
+    auto truncate = view ? view.getSrc().getDefiningOp<arith::TruncIOp>()
+                         : arith::TruncIOp{};
+    auto source =
+        truncate ? dyn_cast<RankedTensorType>(truncate->getOperand(0).getType())
+                 : RankedTensorType{};
+    if (!view || view.getAllowReorder() || !source || source.getRank() != 2 ||
+        !source.getElementType().isInteger(32))
+      return;
+
+    Attribute loaded;
+    bool incompatibleLoads = false;
+    funcOp.walk([&](LoadOp load) {
+      auto type = dyn_cast<RankedTensorType>(load.getType());
+      if (!type || type.getShape() != source.getShape() ||
+          !isa<FloatType>(type.getElementType()))
+        return;
+      if (loaded && loaded != type.getEncoding()) {
+        incompatibleLoads = true;
+        return;
+      }
+      loaded = type.getEncoding();
+    });
+    if (!loaded || incompatibleLoads)
+      return;
+
+    Attribute output;
+    for (StoreOp store : stores) {
+      auto type = dyn_cast<RankedTensorType>(store.getValue().getType());
+      if (!type || type.getShape() != result.getShape() ||
+          !type.getElementType().isInteger(8))
+        continue;
+      if (!llvm::any_of(split->getResults(), [&](Value value) {
+            return dependsOn(store.getValue(), value);
+          }))
+        continue;
+      Attribute encoding =
+          cast<RankedTensorType>(store.getPtr().getType()).getEncoding();
+      if (output && output != encoding)
+        return;
+      output = encoding;
+    }
+    if (!output)
+      return;
+
+    SmallVector<Value, 32> worklist{truncate->getOperand(0)};
+    DenseSet<Value> visited;
+    SmallVector<ReshapeOp, 2> reordered;
+    while (!worklist.empty()) {
+      Value current = worklist.pop_back_val();
+      if (!visited.insert(current).second || visited.size() > 512)
+        continue;
+      auto type = dyn_cast<RankedTensorType>(current.getType());
+      Operation *producer = current.getDefiningOp();
+      if (!type || type.getShape() != source.getShape() || !producer ||
+          !isMemoryEffectFree(producer))
+        continue;
+      if (auto reshape = dyn_cast<ReshapeOp>(producer);
+          reshape && reshape.getAllowReorder()) {
+        reordered.push_back(reshape);
+        continue;
+      }
+      for (Value operand : producer->getOperands())
+        if (isa<RankedTensorType>(operand.getType()))
+          worklist.push_back(operand);
+    }
+    if (reordered.size() != 1)
+      return;
+
+    LayoutInfo &random = layouts[reordered.front().getResult()];
+    random.encodings.clear();
+    random.encodings.insert(loaded);
+    for (Value value : split->getResults())
+      layouts.try_emplace(value, LayoutInfo(output));
+  });
+
+  // Sibling selected-value/index stores agree on one hardware layout. Anchor
+  // their common packed selection after its high-rank reshape so that one
+  // upstream conversion can serve both stores and their softmax component.
+  auto selectionRoot = [&](StoreOp store) {
+    SmallVector<Value, 32> worklist{peelConversions(store.getValue())};
+    DenseSet<Value> visited;
+    SmallVector<ReshapeOp, 2> candidates;
+    while (!worklist.empty()) {
+      Value value = worklist.pop_back_val();
+      if (!visited.insert(value).second || visited.size() > 512)
+        continue;
+      Operation *producer = value.getDefiningOp();
+      if (!producer || !isMemoryEffectFree(producer))
+        continue;
+      if (auto reshape = dyn_cast<ReshapeOp>(producer)) {
+        auto target = dyn_cast<RankedTensorType>(reshape.getType());
+        auto source = dyn_cast<RankedTensorType>(reshape.getSrc().getType());
+        if (target && source && target.getRank() == 2 &&
+            source.getRank() > target.getRank() &&
+            target.getElementType().isInteger(32) &&
+            !reshape.getAllowReorder() &&
+            isa_and_nonnull<arith::SelectOp>(
+                reshape.getSrc().getDefiningOp())) {
+          candidates.push_back(reshape);
+          continue;
+        }
+      }
+      for (Value operand : producer->getOperands())
+        if (isa<RankedTensorType>(operand.getType()))
+          worklist.push_back(operand);
+    }
+    return candidates.size() == 1 ? candidates.front() : ReshapeOp{};
+  };
+
+  for (auto [index, first] : llvm::enumerate(stores)) {
+    auto firstType = dyn_cast<RankedTensorType>(first.getValue().getType());
+    if (!firstType || firstType.getRank() != 2 || !first.getMask())
+      continue;
+    for (StoreOp second : ArrayRef(stores).drop_front(index + 1)) {
+      auto secondType = dyn_cast<RankedTensorType>(second.getValue().getType());
+      if (!secondType || secondType.getShape() != firstType.getShape() ||
+          !second.getMask() ||
+          peelConversions(first.getMask()) !=
+              peelConversions(second.getMask()) ||
+          isa<FloatType>(firstType.getElementType()) ==
+              isa<FloatType>(secondType.getElementType()))
+        continue;
+
+      Attribute encoding =
+          cast<RankedTensorType>(first.getPtr().getType()).getEncoding();
+      if (encoding !=
+          cast<RankedTensorType>(second.getPtr().getType()).getEncoding())
+        continue;
+      ReshapeOp firstRoot = selectionRoot(first);
+      ReshapeOp secondRoot = selectionRoot(second);
+      if (firstRoot && firstRoot == secondRoot)
+        layouts.try_emplace(firstRoot.getResult(), LayoutInfo(encoding));
+    }
+  }
 }
 
 void LayoutPropagation::setEncoding(ValueRange values, LayoutInfo &info,
@@ -1854,6 +2028,51 @@ private:
   DenseMap<unsigned, Value> predicates;
 };
 
+bool rewriteSharedFloatConversion(ConvertLayoutOp conversion) {
+  if (conversion.getResult().use_empty())
+    return false;
+
+  auto bits = conversion.getSrc().getDefiningOp<BitcastOp>();
+  auto source = bits ? dyn_cast<RankedTensorType>(bits.getSrc().getType())
+                     : RankedTensorType{};
+  auto integer =
+      bits ? dyn_cast<RankedTensorType>(bits.getType()) : RankedTensorType{};
+  if (!source || source.getRank() != 2 || !source.getElementType().isF32() ||
+      !integer || !integer.getElementType().isInteger(32))
+    return false;
+
+  Attribute target = conversion.getType().getEncoding();
+  for (Operation *user : bits.getSrc().getUsers()) {
+    auto comparison = dyn_cast<arith::CmpFOp>(user);
+    if (!comparison || comparison.getLhs() != bits.getSrc() ||
+        comparison.getRhs() != bits.getSrc() ||
+        !comparison.getResult().hasOneUse())
+      continue;
+
+    auto predicate =
+        dyn_cast<ConvertLayoutOp>(*comparison.getResult().user_begin());
+    if (!predicate || predicate.getType().getEncoding() != target ||
+        predicate->getBlock() != conversion->getBlock())
+      continue;
+
+    Operation *insertion = predicate->isBeforeInBlock(conversion)
+                               ? predicate.getOperation()
+                               : conversion.getOperation();
+    OpBuilder builder(insertion);
+    auto value = ConvertLayoutOp::create(builder, conversion.getLoc(),
+                                         source.cloneWithEncoding(target),
+                                         bits.getSrc());
+    auto convertedBits = BitcastOp::create(
+        builder, bits.getLoc(), integer.cloneWithEncoding(target), value);
+    auto convertedPredicate = arith::CmpFOp::create(
+        builder, comparison.getLoc(), comparison.getPredicate(), value, value);
+    conversion.getResult().replaceAllUsesWith(convertedBits.getResult());
+    predicate.getResult().replaceAllUsesWith(convertedPredicate.getResult());
+    return true;
+  }
+  return false;
+}
+
 bool rewriteReductionStoreLayout(StoreOp store) {
   if (!store.getMask())
     return false;
@@ -1945,12 +2164,17 @@ bool rewriteAtomicPointerLayout(AtomicRMWOp atomic) {
 }
 
 bool rewriteIndexedStoreExpressions(ModuleOp module) {
+  SmallVector<ConvertLayoutOp> conversions;
+  module.walk(
+      [&](ConvertLayoutOp conversion) { conversions.push_back(conversion); });
   SmallVector<StoreOp> stores;
   module.walk([&](StoreOp store) { stores.push_back(store); });
   SmallVector<AtomicRMWOp> atomics;
   module.walk([&](AtomicRMWOp atomic) { atomics.push_back(atomic); });
 
   bool changed = false;
+  for (ConvertLayoutOp conversion : conversions)
+    changed |= rewriteSharedFloatConversion(conversion);
   for (StoreOp store : stores) {
     changed |= IndexedStoreExpression(store).rewrite();
     changed |= rewriteReductionStoreLayout(store);

--- a/python/test/unit/language/test_core.py
+++ b/python/test/unit/language/test_core.py
@@ -7303,3 +7303,76 @@ def test_libdevice_rint(dtype_str, device):
     rint_kernel[(triton.cdiv(numel, BLOCK_SIZE), )](res_out, x_tri, numel, BLOCK_SIZE)
     ref_out = np.rint(x_np)
     np.testing.assert_allclose(to_numpy(res_out), ref_out, rtol=0, atol=0, equal_nan=True)
+
+
+@triton.jit
+def _remove_layout_conversions_exact_order_join_chain_kernel(out_ptr, a0, a1, x0, x1, INDEXED: tl.constexpr):
+    va0 = tl.full((128, ), a0, tl.int32)
+    va1 = tl.full((128, ), a1, tl.int32)
+    vx0 = tl.full((128, ), x0, tl.int32)
+    vx1 = tl.full((128, ), x1, tl.int32)
+
+    if INDEXED:
+        source_indices = tl.arange(0, 128)
+        va0 = va0 ^ source_indices
+        va1 = va1 + source_indices
+        vx0 = vx0 ^ source_indices
+        vx1 = vx1 ^ source_indices
+
+    pair_a = tl.join(tl.reshape(va0, (1, 128)), tl.reshape(va1, (1, 128)))
+    pair_x0 = tl.join(tl.reshape(vx0, (1, 128)), tl.reshape(vx0, (1, 128)))
+    xor_256 = tl.reshape(pair_a, (256, )) ^ tl.reshape(pair_x0, (256, ))
+
+    chain_512 = tl.join(tl.reshape(pair_a, (1, 256)), tl.reshape(xor_256, (1, 256)))
+    pair_x1 = tl.join(tl.reshape(vx1, (1, 128)), tl.reshape(vx1, (1, 128)))
+    repeat_x1 = tl.join(tl.reshape(pair_x1, (1, 256)), tl.reshape(pair_x1, (1, 256)))
+    xor_512 = tl.reshape(chain_512, (512, )) ^ tl.reshape(repeat_x1, (512, ))
+
+    chain_1024 = tl.join(tl.reshape(chain_512, (1, 512)), tl.reshape(xor_512, (1, 512)))
+    repeat_a = tl.join(tl.reshape(va0, (1, 128)), tl.reshape(va0, (1, 128)))
+    repeat_a = tl.join(tl.reshape(repeat_a, (1, 256)), tl.reshape(repeat_a, (1, 256)))
+    repeat_a = tl.join(tl.reshape(repeat_a, (1, 512)), tl.reshape(repeat_a, (1, 512)))
+    xor_1024 = tl.reshape(chain_1024, (1024, )) ^ tl.reshape(repeat_a, (1024, ))
+
+    result = tl.join(tl.reshape(chain_1024, (1, 1024)), tl.reshape(xor_1024, (1, 1024)))
+    offsets = tl.program_id(0) * 2048 + tl.arange(0, 2048)
+    tl.store(out_ptr + offsets, tl.reshape(result, (2048, )))
+
+
+@pytest.mark.parametrize("indexed", [False, True])
+@pytest.mark.parametrize(
+    "values",
+    [
+        (17, 23, 41, 73),
+        (-17, 23, -41, 73),
+        (0, -1, 0x13579BDF, -0x13579BDF),
+        (0x7FFFFFFF, -0x7FFFFFFF, 0x12345678, -0x12345678),
+    ],
+)
+def test_remove_layout_conversions_exact_order_join_chain(device, indexed, values):
+    check_cuda_or_hip(device)
+
+    result = torch.empty((2048, ), device=device, dtype=torch.int32)
+    compiled = _remove_layout_conversions_exact_order_join_chain_kernel[(1, )](result, *values, INDEXED=indexed,
+                                                                               num_warps=4)
+
+    indices = torch.arange(2048, device=device, dtype=torch.int32)
+    source_indices = indices >> 4
+    va0 = torch.full_like(indices, values[0])
+    va1 = torch.full_like(indices, values[1])
+    vx0 = torch.full_like(indices, values[2])
+    vx1 = torch.full_like(indices, values[3])
+    if indexed:
+        va0 = va0 ^ source_indices
+        va1 = va1 + source_indices
+        vx0 = vx0 ^ source_indices
+        vx1 = vx1 ^ source_indices
+
+    first_pair = torch.where((indices & 8) != 0, va1, va0)
+    first_mix = first_pair ^ vx0
+    second_pair = torch.where((indices & 4) != 0, first_mix, first_pair)
+    third_pair = torch.where((indices & 2) != 0, second_pair ^ vx1, second_pair)
+    expected = torch.where((indices & 1) != 0, third_pair ^ va0, third_pair)
+
+    torch.testing.assert_close(result, expected, rtol=0, atol=0)
+    assert "ttg.convert_layout" not in compiled.asm["ttgir"]

--- a/python/test/unit/language/test_core.py
+++ b/python/test/unit/language/test_core.py
@@ -7379,6 +7379,80 @@ def test_remove_layout_conversions_exact_order_join_chain(device, indexed, value
 
 
 @triton.jit
+def _remove_layout_conversions_narrowed_pack_kernel(inputs, output, seed):
+    rows = tl.arange(0, 32)
+    columns = tl.arange(0, 128)
+    offsets = rows[:, None] * 128 + columns[None, :]
+    loaded = tl.load(inputs + offsets)
+
+    random_values = (tl.arange(0, 4096) << 8) | (seed & 255)
+    random = tl.reshape(random_values, (32, 128), can_reorder=True)
+    bits = loaded.to(tl.int32, bitcast=True)
+    narrowed = (bits ^ random).to(tl.int8)
+    left, right = tl.split(tl.reshape(narrowed, (32, 64, 2)))
+    packed = left | (right << 4)
+
+    output_offsets = rows[:, None] * 64 + tl.arange(0, 64)[None, :]
+    tl.store(output + output_offsets, packed)
+
+
+@pytest.mark.parametrize("seed", [0, 17, 0x13579BDF])
+def test_remove_layout_conversions_narrowed_pack(device, seed):
+    check_cuda_or_hip(device)
+
+    torch.manual_seed(0)
+    inputs = torch.randn((32, 128), device=device, dtype=torch.float32)
+    result = torch.empty((32, 64), device=device, dtype=torch.int8)
+    compiled = _remove_layout_conversions_narrowed_pack_kernel[(1, )](inputs, result, seed, num_warps=8)
+
+    narrowed = (inputs.view(torch.int32) ^ (seed & 255)).to(torch.int8)
+    expected = (narrowed[:, ::2] | (narrowed[:, 1::2].to(torch.int32) << 4)).to(torch.int8)
+    torch.testing.assert_close(result, expected, rtol=0, atol=0)
+
+    conversions = [line for line in compiled.asm["ttgir"].splitlines() if "ttg.convert_layout" in line]
+    assert all("xi32," not in line for line in conversions)
+
+
+@triton.jit
+def _remove_layout_conversions_selected_outputs_kernel(inputs, values, indices, n_rows):
+    rows = tl.program_id(0) * 32 + tl.arange(0, 32)
+    columns = tl.arange(0, 32)
+    mask = rows[:, None] < n_rows
+    loaded = tl.load(inputs + rows[:, None] * 32 + columns[None, :], mask=mask, other=0.)
+
+    bits = loaded.to(tl.int16, bitcast=True).to(tl.int32)
+    packed = (bits << 16) | columns[None, :]
+    sorted_values = tl.sort(packed, descending=True, dim=1)
+    positions = tl.broadcast_to(tl.arange(0, 2)[None, :], (32, 2))
+    selected = tl.gather(sorted_values, positions, axis=1)
+
+    scores = (selected >> 16).to(tl.int16).to(tl.float16, bitcast=True)
+    selected_indices = (selected & 65535).to(tl.int16)
+    output_offsets = rows[:, None] * 2 + tl.arange(0, 2)[None, :]
+    tl.store(values + output_offsets, scores, mask=mask)
+    tl.store(indices + output_offsets, selected_indices, mask=mask)
+
+
+@pytest.mark.parametrize("n_rows", [17, 33])
+def test_remove_layout_conversions_selected_outputs(device, n_rows):
+    check_cuda_or_hip(device)
+
+    columns = torch.arange(32, device=device, dtype=torch.float32)
+    rows = torch.arange(n_rows, device=device, dtype=torch.float32)
+    inputs = (columns[None, :] + rows[:, None] / 64).to(torch.float16)
+    values = torch.empty((n_rows, 2), device=device, dtype=torch.float16)
+    indices = torch.empty((n_rows, 2), device=device, dtype=torch.int16)
+    compiled = _remove_layout_conversions_selected_outputs_kernel[(triton.cdiv(n_rows, 32), )](inputs, values, indices,
+                                                                                               n_rows, num_warps=4)
+
+    expected_values, expected_indices = torch.topk(inputs, 2, dim=1)
+    torch.testing.assert_close(values, expected_values, rtol=0, atol=0)
+    torch.testing.assert_close(indices, expected_indices.to(torch.int16), rtol=0, atol=0)
+
+    assert compiled.asm["ttgir"].count("tt.store") == 2
+
+
+@triton.jit
 def _remove_layout_conversions_reduction_store_kernel(
     inputs,
     indices,

--- a/python/test/unit/language/test_core.py
+++ b/python/test/unit/language/test_core.py
@@ -7376,3 +7376,67 @@ def test_remove_layout_conversions_exact_order_join_chain(device, indexed, value
 
     torch.testing.assert_close(result, expected, rtol=0, atol=0)
     assert "ttg.convert_layout" not in compiled.asm["ttgir"]
+
+
+@triton.jit
+def _remove_layout_conversions_reduction_store_kernel(
+    inputs,
+    indices,
+    values,
+    bitmatrix,
+    n_rows,
+    APPLY_SOFTMAX: tl.constexpr,
+):
+    rows = tl.program_id(0) * 32 + tl.arange(0, 32)
+    columns = tl.arange(0, 4)
+    mask = rows[:, None] < n_rows
+
+    selected = tl.load(indices + rows[:, None] * 4 + columns[None, :], mask=mask)
+    gathered = tl.load(inputs + rows[:, None] * 32 + selected, mask=mask)
+    if APPLY_SOFTMAX:
+        gathered = tl.softmax(gathered.to(tl.float32), dim=1, keep_dims=True).to(inputs.dtype.element_ty)
+    tl.store(values + rows[:, None] * 4 + columns[None, :], gathered, mask=mask)
+
+    word = tl.arange(0, 1)
+    packed = tl.where(
+        (selected // 32)[:, :, None] == word[None, None, :],
+        (1 << (selected % 32))[:, :, None],
+        0,
+    )
+    reduced = tl.reduce_or(packed, axis=1)
+    tl.store(bitmatrix + rows[:, None], reduced, mask=mask)
+
+
+@pytest.mark.parametrize("n_rows", [31, 257])
+@pytest.mark.parametrize("apply_softmax", [False, True])
+def test_remove_layout_conversions_reduction_store(device, n_rows, apply_softmax):
+    check_cuda_or_hip(device)
+
+    torch.manual_seed(0)
+    inputs = torch.randn((n_rows, 32), device=device, dtype=torch.float16)
+    indices = torch.randint(0, 32, (n_rows, 4), device=device, dtype=torch.int32)
+    values = torch.empty((n_rows, 4), device=device, dtype=torch.float16)
+    bitmatrix = torch.empty((n_rows, 1), device=device, dtype=torch.int32)
+
+    compiled = _remove_layout_conversions_reduction_store_kernel[(triton.cdiv(n_rows,
+                                                                              32), )](inputs, indices, values,
+                                                                                      bitmatrix, n_rows,
+                                                                                      APPLY_SOFTMAX=apply_softmax,
+                                                                                      num_warps=4)
+
+    expected_values = torch.gather(inputs, 1, indices.to(torch.int64))
+    if apply_softmax:
+        expected_values = torch.softmax(expected_values.float(), dim=1).half()
+    torch.testing.assert_close(values, expected_values, rtol=1e-3, atol=1e-3)
+
+    expected_bits = torch.zeros_like(bitmatrix)
+    for column in range(indices.shape[1]):
+        expected_bits[:, 0] |= 1 << indices[:, column]
+    torch.testing.assert_close(bitmatrix, expected_bits, rtol=0, atol=0)
+
+    ir = compiled.asm["ttgir"]
+    store = next(line for line in reversed(ir.splitlines()) if "tt.store" in line)
+    operands = re.search(r"tt\.store\s+(%\w+),\s+(%\w+),\s+(%\w+)", store)
+    assert operands
+    for operand in (operands.group(1), operands.group(3)):
+        assert not re.search(rf"{re.escape(operand)}\s*=\s*ttg\.convert_layout", ir)

--- a/test/TritonGPU/combine.mlir
+++ b/test/TritonGPU/combine.mlir
@@ -1237,6 +1237,60 @@ module attributes {"ttg.num-warps" = 2 : i32, "ttg.num-ctas" = 1 : i32} {
 
 // -----
 
+// Exact-order joins can be evaluated from their final logical element indices.
+// Keep the store's physical layout and remove the intermediate exchanges.
+// CHECK-LABEL: @remat_indexed_store_join_chain
+// CHECK: tt.make_range
+// CHECK: arith.shrui
+// CHECK-NOT: ttg.convert_layout
+// CHECK: tt.store
+// CHECK: tt.return
+
+#scalar = #ttg.blocked<{sizePerThread = [1], threadsPerWarp = [32], warpsPerCTA = [4], order = [0]}>
+#row = #ttg.blocked<{sizePerThread = [1, 1], threadsPerWarp = [1, 32], warpsPerCTA = [1, 4], order = [1, 0]}>
+#joined = #ttg.blocked<{sizePerThread = [1, 1, 2], threadsPerWarp = [1, 32, 1], warpsPerCTA = [1, 4, 1], order = [2, 1, 0]}>
+#exchanged = #ttg.blocked<{sizePerThread = [1, 1, 1], threadsPerWarp = [1, 16, 2], warpsPerCTA = [1, 4, 1], order = [2, 1, 0]}>
+#wide = #ttg.linear<{register = [[0, 8, 0], [0, 16, 0]], lane = [[0, 0, 1], [0, 1, 0], [0, 2, 0], [0, 4, 0], [0, 32, 0]], warp = [[0, 64, 0], [0, 128, 0]], block = []}>
+#output = #ttg.linear<{register = [[16], [32]], lane = [[1], [2], [4], [8], [64]], warp = [[128], [256]], block = []}>
+
+module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.target = "cuda:100", "ttg.threads-per-warp" = 32 : i32} {
+  tt.func @remat_indexed_store_join_chain(%out: !tt.ptr<i32>, %left: i32, %right: i32, %seed: i32) {
+    %range = tt.make_range {end = 128 : i32, start = 0 : i32} : tensor<128xi32, #scalar>
+    %lhs_seed = tt.splat %left : i32 -> tensor<128xi32, #scalar>
+    %rhs_seed = tt.splat %right : i32 -> tensor<128xi32, #scalar>
+    %random_seed = tt.splat %seed : i32 -> tensor<128xi32, #scalar>
+    %lhs = arith.xori %lhs_seed, %range : tensor<128xi32, #scalar>
+    %rhs = arith.addi %rhs_seed, %range : tensor<128xi32, #scalar>
+    %random = arith.xori %random_seed, %range : tensor<128xi32, #scalar>
+
+    %lhs_row = tt.reshape %lhs : tensor<128xi32, #scalar> -> tensor<1x128xi32, #row>
+    %rhs_row = tt.reshape %rhs : tensor<128xi32, #scalar> -> tensor<1x128xi32, #row>
+    %first_join = tt.join %lhs_row, %rhs_row : tensor<1x128xi32, #row> -> tensor<1x128x2xi32, #joined>
+    %first_exchange = ttg.convert_layout %first_join : tensor<1x128x2xi32, #joined> -> tensor<1x128x2xi32, #exchanged>
+    %first_values = tt.reshape %first_exchange : tensor<1x128x2xi32, #exchanged> -> tensor<256xi32, #scalar>
+
+    %random_row = tt.reshape %random : tensor<128xi32, #scalar> -> tensor<1x128xi32, #row>
+    %second_join = tt.join %random_row, %random_row : tensor<1x128xi32, #row> -> tensor<1x128x2xi32, #joined>
+    %second_exchange = ttg.convert_layout %second_join : tensor<1x128x2xi32, #joined> -> tensor<1x128x2xi32, #exchanged>
+    %second_values = tt.reshape %second_exchange : tensor<1x128x2xi32, #exchanged> -> tensor<256xi32, #scalar>
+
+    %mixed = arith.xori %first_values, %second_values : tensor<256xi32, #scalar>
+    %upper = tt.reshape %first_exchange : tensor<1x128x2xi32, #exchanged> -> tensor<1x256xi32, #row>
+    %lower = tt.reshape %mixed : tensor<256xi32, #scalar> -> tensor<1x256xi32, #row>
+    %third_join = tt.join %upper, %lower : tensor<1x256xi32, #row> -> tensor<1x256x2xi32, #joined>
+    %third_exchange = ttg.convert_layout %third_join : tensor<1x256x2xi32, #joined> -> tensor<1x256x2xi32, #wide>
+    %value = tt.reshape %third_exchange : tensor<1x256x2xi32, #wide> -> tensor<512xi32, #output>
+
+    %offsets = tt.make_range {end = 512 : i32, start = 0 : i32} : tensor<512xi32, #output>
+    %base = tt.splat %out : !tt.ptr<i32> -> tensor<512x!tt.ptr<i32>, #output>
+    %address = tt.addptr %base, %offsets : tensor<512x!tt.ptr<i32>, #output>, tensor<512xi32, #output>
+    tt.store %address, %value : tensor<512x!tt.ptr<i32>, #output>
+    tt.return
+  }
+}
+
+// -----
+
 // CHECK-LABEL: reduce_cvt2
 // Match the reduction
 // CHECK-NOT: ttg.convert_layout

--- a/test/TritonGPU/combine.mlir
+++ b/test/TritonGPU/combine.mlir
@@ -1291,6 +1291,37 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.targ
 
 // -----
 
+// A reduced bitmatrix payload needs one conversion, but its address and mask
+// already agree on a directly usable store layout.
+// CHECK-LABEL: @reuse_reduction_store_pointer_layout
+// CHECK: [[POINTER:%.*]] = tt.addptr
+// CHECK: [[VALUE:%.*]] = ttg.convert_layout
+// CHECK-NOT: ttg.convert_layout
+// CHECK: tt.store [[POINTER]], [[VALUE]], %arg3
+
+#reduction = #ttg.blocked<{sizePerThread = [1, 1, 1], threadsPerWarp = [8, 4, 1], warpsPerCTA = [4, 1, 1], order = [2, 1, 0]}>
+#pointer = #ttg.blocked<{sizePerThread = [1, 1], threadsPerWarp = [32, 1], warpsPerCTA = [4, 1], order = [1, 0]}>
+#store = #ttg.blocked<{sizePerThread = [1, 1], threadsPerWarp = [32, 1], warpsPerCTA = [1, 4], order = [0, 1]}>
+
+module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.target = "cuda:100", "ttg.threads-per-warp" = 32 : i32} {
+  tt.func @reuse_reduction_store_pointer_layout(%destination: !tt.ptr<i32>, %input: tensor<32x4x1xi32, #reduction>, %offsets: tensor<32x1xi32, #pointer>, %mask: tensor<32x1xi1, #pointer>) {
+    %reduced = "tt.reduce"(%input) <{axis = 1 : i32}> ({
+    ^bb0(%lhs: i32, %rhs: i32):
+      %result = arith.ori %lhs, %rhs : i32
+      tt.reduce.return %result : i32
+    }) : (tensor<32x4x1xi32, #reduction>) -> tensor<32x1xi32, #ttg.slice<{dim = 1, parent = #reduction}>>
+    %base = tt.splat %destination : !tt.ptr<i32> -> tensor<32x1x!tt.ptr<i32>, #pointer>
+    %address = tt.addptr %base, %offsets : tensor<32x1x!tt.ptr<i32>, #pointer>, tensor<32x1xi32, #pointer>
+    %converted_address = ttg.convert_layout %address : tensor<32x1x!tt.ptr<i32>, #pointer> -> tensor<32x1x!tt.ptr<i32>, #store>
+    %converted_value = ttg.convert_layout %reduced : tensor<32x1xi32, #ttg.slice<{dim = 1, parent = #reduction}>> -> tensor<32x1xi32, #store>
+    %converted_mask = ttg.convert_layout %mask : tensor<32x1xi1, #pointer> -> tensor<32x1xi1, #store>
+    tt.store %converted_address, %converted_value, %converted_mask : tensor<32x1x!tt.ptr<i32>, #store>
+    tt.return
+  }
+}
+
+// -----
+
 // CHECK-LABEL: reduce_cvt2
 // Match the reduction
 // CHECK-NOT: ttg.convert_layout

--- a/test/TritonGPU/combine.mlir
+++ b/test/TritonGPU/combine.mlir
@@ -1322,6 +1322,121 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.targ
 
 // -----
 
+// CHECK-LABEL: @propagate_loop_memory_pointer
+// CHECK-NOT: ttg.convert_layout
+// CHECK: scf.for
+// CHECK-NOT: ttg.convert_layout
+// CHECK: tt.load
+// CHECK: tt.store
+// CHECK-NOT: ttg.convert_layout
+// CHECK: tt.return
+
+#loop_pointer = #ttg.blocked<{sizePerThread = [1], threadsPerWarp = [32], warpsPerCTA = [4], order = [0]}>
+#loop_memory = #ttg.blocked<{sizePerThread = [2], threadsPerWarp = [32], warpsPerCTA = [4], order = [0]}>
+
+module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.target = "cuda:100", "ttg.threads-per-warp" = 32 : i32} {
+  tt.func @propagate_loop_memory_pointer(%source: !tt.ptr<f32>, %destination: !tt.ptr<f32>, %mask: tensor<256xi1, #loop_memory>) {
+    %zero = arith.constant 0 : index
+    %one = arith.constant 1 : index
+    %four = arith.constant 4 : index
+    %step = arith.constant dense<256> : tensor<256xi32, #loop_pointer>
+    %offsets = tt.make_range {start = 0 : i32, end = 256 : i32} : tensor<256xi32, #loop_pointer>
+    %base = tt.splat %source : !tt.ptr<f32> -> tensor<256x!tt.ptr<f32>, #loop_pointer>
+    %initial = tt.addptr %base, %offsets : tensor<256x!tt.ptr<f32>, #loop_pointer>, tensor<256xi32, #loop_pointer>
+    %store_offsets = tt.make_range {start = 0 : i32, end = 256 : i32} : tensor<256xi32, #loop_memory>
+    %store_base = tt.splat %destination : !tt.ptr<f32> -> tensor<256x!tt.ptr<f32>, #loop_memory>
+    %store_pointer = tt.addptr %store_base, %store_offsets : tensor<256x!tt.ptr<f32>, #loop_memory>, tensor<256xi32, #loop_memory>
+    %result = scf.for %iteration = %zero to %four step %one iter_args(%pointer = %initial) -> (tensor<256x!tt.ptr<f32>, #loop_pointer>) {
+      %converted = ttg.convert_layout %pointer : tensor<256x!tt.ptr<f32>, #loop_pointer> -> tensor<256x!tt.ptr<f32>, #loop_memory>
+      %value = tt.load %converted, %mask : tensor<256x!tt.ptr<f32>, #loop_memory>
+      tt.store %store_pointer, %value, %mask : tensor<256x!tt.ptr<f32>, #loop_memory>
+      %next = tt.addptr %pointer, %step : tensor<256x!tt.ptr<f32>, #loop_pointer>, tensor<256xi32, #loop_pointer>
+      scf.yield %next : tensor<256x!tt.ptr<f32>, #loop_pointer>
+    }
+    tt.return
+  }
+}
+
+// -----
+
+// CHECK-LABEL: @propagate_shared_memory_address
+// CHECK-NOT: ttg.convert_layout
+// CHECK: tt.load
+// CHECK-NOT: ttg.convert_layout
+// CHECK: tt.load
+// CHECK-NOT: ttg.convert_layout
+// CHECK: tt.store
+// CHECK-NOT: ttg.convert_layout
+// CHECK: tt.return
+
+#shared_address = #ttg.blocked<{sizePerThread = [1], threadsPerWarp = [32], warpsPerCTA = [4], order = [0]}>
+#shared_memory = #ttg.blocked<{sizePerThread = [2], threadsPerWarp = [32], warpsPerCTA = [4], order = [0]}>
+
+module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.target = "cuda:100", "ttg.threads-per-warp" = 32 : i32} {
+  tt.func @propagate_shared_memory_address(%lhs: !tt.ptr<i32>, %rhs: !tt.ptr<i32>, %out: !tt.ptr<i32>, %mask: tensor<256xi1, #shared_memory>) {
+    %indices = tt.make_range {start = 0 : i32, end = 256 : i32} : tensor<256xi32, #shared_address>
+    %two = arith.constant dense<2> : tensor<256xi32, #shared_address>
+    %offsets = arith.muli %indices, %two : tensor<256xi32, #shared_address>
+    %lhs_base = tt.splat %lhs : !tt.ptr<i32> -> tensor<256x!tt.ptr<i32>, #shared_address>
+    %lhs_pointer = tt.addptr %lhs_base, %offsets : tensor<256x!tt.ptr<i32>, #shared_address>, tensor<256xi32, #shared_address>
+    %lhs_converted = ttg.convert_layout %lhs_pointer : tensor<256x!tt.ptr<i32>, #shared_address> -> tensor<256x!tt.ptr<i32>, #shared_memory>
+    %lhs_value = tt.load %lhs_converted, %mask : tensor<256x!tt.ptr<i32>, #shared_memory>
+    %rhs_base = tt.splat %rhs : !tt.ptr<i32> -> tensor<256x!tt.ptr<i32>, #shared_address>
+    %rhs_pointer = tt.addptr %rhs_base, %offsets : tensor<256x!tt.ptr<i32>, #shared_address>, tensor<256xi32, #shared_address>
+    %rhs_converted = ttg.convert_layout %rhs_pointer : tensor<256x!tt.ptr<i32>, #shared_address> -> tensor<256x!tt.ptr<i32>, #shared_memory>
+    %rhs_value = tt.load %rhs_converted, %mask : tensor<256x!tt.ptr<i32>, #shared_memory>
+    %result = arith.addi %lhs_value, %rhs_value : tensor<256xi32, #shared_memory>
+    %out_base = tt.splat %out : !tt.ptr<i32> -> tensor<256x!tt.ptr<i32>, #shared_address>
+    %out_pointer = tt.addptr %out_base, %offsets : tensor<256x!tt.ptr<i32>, #shared_address>, tensor<256xi32, #shared_address>
+    %out_converted = ttg.convert_layout %out_pointer : tensor<256x!tt.ptr<i32>, #shared_address> -> tensor<256x!tt.ptr<i32>, #shared_memory>
+    tt.store %out_converted, %result, %mask : tensor<256x!tt.ptr<i32>, #shared_memory>
+    tt.return
+  }
+}
+
+// -----
+
+// CHECK-LABEL: @reuse_constant_store_pointer_layout
+// CHECK-NOT: ttg.convert_layout
+// CHECK: tt.store %arg0, {{%.*}}, %arg1
+
+#constant_pointer = #ttg.blocked<{sizePerThread = [2], threadsPerWarp = [32], warpsPerCTA = [4], order = [0]}>
+#constant_store = #ttg.blocked<{sizePerThread = [1], threadsPerWarp = [32], warpsPerCTA = [4], order = [0]}>
+
+module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.target = "cuda:100", "ttg.threads-per-warp" = 32 : i32} {
+  tt.func @reuse_constant_store_pointer_layout(%pointer: tensor<256x!tt.ptr<i32>, #constant_pointer>, %mask: tensor<256xi1, #constant_pointer>) {
+    %converted_pointer = ttg.convert_layout %pointer : tensor<256x!tt.ptr<i32>, #constant_pointer> -> tensor<256x!tt.ptr<i32>, #constant_store>
+    %converted_mask = ttg.convert_layout %mask : tensor<256xi1, #constant_pointer> -> tensor<256xi1, #constant_store>
+    %constant = arith.constant dense<1> : tensor<256xi32, #constant_store>
+    tt.store %converted_pointer, %constant, %converted_mask : tensor<256x!tt.ptr<i32>, #constant_store>
+    tt.return
+  }
+}
+
+// -----
+
+// CHECK-LABEL: @reuse_atomic_pointer_layout
+// CHECK: [[POINTER:%.*]] = tt.addptr
+// CHECK: [[VALUE:%.*]] = ttg.convert_layout %arg2
+// CHECK-NOT: ttg.convert_layout
+// CHECK: tt.atomic_rmw add, relaxed, gpu, [[POINTER]], [[VALUE]], %arg1
+
+#atomic_pointer = #ttg.blocked<{sizePerThread = [2], threadsPerWarp = [32], warpsPerCTA = [4], order = [0]}>
+#atomic_value = #ttg.blocked<{sizePerThread = [1], threadsPerWarp = [32], warpsPerCTA = [4], order = [0]}>
+
+module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.target = "cuda:100", "ttg.threads-per-warp" = 32 : i32} {
+  tt.func @reuse_atomic_pointer_layout(%destination: !tt.ptr<i32>, %mask: tensor<256xi1, #atomic_pointer>, %value: tensor<256xi32, #atomic_value>, %indices: tensor<256xi32, #atomic_pointer>) {
+    %base = tt.splat %destination : !tt.ptr<i32> -> tensor<256x!tt.ptr<i32>, #atomic_pointer>
+    %pointer = tt.addptr %base, %indices : tensor<256x!tt.ptr<i32>, #atomic_pointer>, tensor<256xi32, #atomic_pointer>
+    %converted_pointer = ttg.convert_layout %pointer : tensor<256x!tt.ptr<i32>, #atomic_pointer> -> tensor<256x!tt.ptr<i32>, #atomic_value>
+    %converted_mask = ttg.convert_layout %mask : tensor<256xi1, #atomic_pointer> -> tensor<256xi1, #atomic_value>
+    %result = tt.atomic_rmw add, relaxed, gpu, %converted_pointer, %value, %converted_mask : (tensor<256x!tt.ptr<i32>, #atomic_value>, tensor<256xi32, #atomic_value>, tensor<256xi1, #atomic_value>) -> tensor<256xi32, #atomic_value>
+    tt.return
+  }
+}
+
+// -----
+
 // CHECK-LABEL: reduce_cvt2
 // Match the reduction
 // CHECK-NOT: ttg.convert_layout

--- a/test/TritonGPU/combine.mlir
+++ b/test/TritonGPU/combine.mlir
@@ -1322,6 +1322,98 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.targ
 
 // -----
 
+// Keep the wide rounding expression in the loaded layout, and exchange only
+// the narrowed i8 values at the physical packing boundary.
+// CHECK-LABEL: @pack_narrowed_values_in_load_layout
+// CHECK: [[LOADED:%.*]] = tt.load
+// CHECK-NOT: ttg.convert_layout
+// CHECK: arith.trunci
+// CHECK: [[PACKED:%.*]] = ttg.convert_layout {{.*}} : tensor<32x64x2xi8
+// CHECK-NOT: ttg.convert_layout
+// CHECK: tt.split [[PACKED]]
+// CHECK: tt.store
+
+#pack_loaded = #ttg.blocked<{sizePerThread = [8, 1], threadsPerWarp = [4, 8], warpsPerCTA = [1, 8], order = [0, 1]}>
+#pack_random = #ttg.blocked<{sizePerThread = [1, 16], threadsPerWarp = [4, 8], warpsPerCTA = [8, 1], order = [1, 0]}>
+#pack_view = #ttg.blocked<{sizePerThread = [1, 8, 2], threadsPerWarp = [4, 8, 1], warpsPerCTA = [8, 1, 1], order = [2, 1, 0]}>
+#pack_output = #ttg.blocked<{sizePerThread = [1, 8], threadsPerWarp = [4, 8], warpsPerCTA = [8, 1], order = [1, 0]}>
+#pack_range = #ttg.blocked<{sizePerThread = [1], threadsPerWarp = [32], warpsPerCTA = [8], order = [0]}>
+
+module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 8 : i32, ttg.target = "cuda:100", "ttg.threads-per-warp" = 32 : i32} {
+  tt.func @pack_narrowed_values_in_load_layout(%input: tensor<32x128x!tt.ptr<f32>, #pack_loaded>, %output: tensor<32x64x!tt.ptr<i8>, #pack_output>) {
+    %loaded = tt.load %input : tensor<32x128x!tt.ptr<f32>, #pack_loaded>
+    %bits = tt.bitcast %loaded : tensor<32x128xf32, #pack_loaded> -> tensor<32x128xi32, #pack_loaded>
+    %converted = ttg.convert_layout %bits : tensor<32x128xi32, #pack_loaded> -> tensor<32x128xi32, #pack_random>
+    %range = tt.make_range {start = 0 : i32, end = 4096 : i32} : tensor<4096xi32, #pack_range>
+    %random = tt.reshape %range allow_reorder : tensor<4096xi32, #pack_range> -> tensor<32x128xi32, #pack_random>
+    %mixed = arith.xori %converted, %random : tensor<32x128xi32, #pack_random>
+    %narrowed = arith.trunci %mixed : tensor<32x128xi32, #pack_random> to tensor<32x128xi8, #pack_random>
+    %pairs = tt.reshape %narrowed : tensor<32x128xi8, #pack_random> -> tensor<32x64x2xi8, #pack_view>
+    %left, %right = tt.split %pairs : tensor<32x64x2xi8, #pack_view> -> tensor<32x64xi8, #pack_output>
+    %packed = arith.ori %left, %right : tensor<32x64xi8, #pack_output>
+    tt.store %output, %packed : tensor<32x64x!tt.ptr<i8>, #pack_output>
+    tt.return
+  }
+}
+
+// -----
+
+// A selected floating value and its integer index share one packed i32 source.
+// Perform the layout exchange before unpacking instead of converting each
+// independently stored result.
+// CHECK-LABEL: @reuse_selected_value_and_index_layout
+// CHECK: [[SELECTED:%.*]] = arith.select
+// CHECK: [[CONVERTED:%.*]] = ttg.convert_layout [[SELECTED]]
+// CHECK-NOT: ttg.convert_layout
+// CHECK: tt.store
+// CHECK-NOT: ttg.convert_layout
+// CHECK: tt.store
+
+#selection_source = #ttg.blocked<{sizePerThread = [1, 1, 1], threadsPerWarp = [16, 1, 2], warpsPerCTA = [4, 1, 1], order = [2, 1, 0]}>
+#selection_result = #ttg.blocked<{sizePerThread = [1, 1], threadsPerWarp = [16, 2], warpsPerCTA = [4, 1], order = [1, 0]}>
+#selection_store = #ttg.blocked<{sizePerThread = [1, 1], threadsPerWarp = [32, 1], warpsPerCTA = [1, 4], order = [0, 1]}>
+
+module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.target = "cuda:100", "ttg.threads-per-warp" = 32 : i32} {
+  tt.func @reuse_selected_value_and_index_layout(%condition: tensor<32x1x2xi1, #selection_source>, %lhs: tensor<32x1x2xi32, #selection_source>, %rhs: tensor<32x1x2xi32, #selection_source>, %values: tensor<32x2x!tt.ptr<f16>, #selection_store>, %indices: tensor<32x2x!tt.ptr<i16>, #selection_store>, %mask: tensor<32x2xi1, #selection_store>) {
+    %selected = arith.select %condition, %lhs, %rhs : tensor<32x1x2xi1, #selection_source>, tensor<32x1x2xi32, #selection_source>
+    %flat = tt.reshape %selected : tensor<32x1x2xi32, #selection_source> -> tensor<32x2xi32, #selection_result>
+    %index = arith.trunci %flat : tensor<32x2xi32, #selection_result> to tensor<32x2xi16, #selection_result>
+    %score = tt.bitcast %index : tensor<32x2xi16, #selection_result> -> tensor<32x2xf16, #selection_result>
+    %converted_score = ttg.convert_layout %score : tensor<32x2xf16, #selection_result> -> tensor<32x2xf16, #selection_store>
+    %converted_index = ttg.convert_layout %index : tensor<32x2xi16, #selection_result> -> tensor<32x2xi16, #selection_store>
+    tt.store %values, %converted_score, %mask : tensor<32x2x!tt.ptr<f16>, #selection_store>
+    tt.store %indices, %converted_index, %mask : tensor<32x2x!tt.ptr<i16>, #selection_store>
+    tt.return
+  }
+}
+
+// -----
+
+// One float exchange can feed both its integer bitcast and its floating-point
+// validity predicate without separate i32 and i1 exchanges.
+// CHECK-LABEL: @reuse_float_bitcast_and_predicate_layout
+// CHECK: [[FLOAT:%.*]] = ttg.convert_layout %arg0 : tensor<32x128xf32
+// CHECK: [[BITS:%.*]] = tt.bitcast [[FLOAT]]
+// CHECK: [[PREDICATE:%.*]] = arith.cmpf oeq, [[FLOAT]], [[FLOAT]]
+// CHECK-NOT: ttg.convert_layout
+// CHECK: tt.store %arg1, [[BITS]], [[PREDICATE]]
+
+#float_source = #ttg.blocked<{sizePerThread = [8, 1], threadsPerWarp = [4, 8], warpsPerCTA = [1, 8], order = [0, 1]}>
+#float_target = #ttg.blocked<{sizePerThread = [1, 8], threadsPerWarp = [4, 8], warpsPerCTA = [8, 1], order = [1, 0]}>
+
+module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 8 : i32, ttg.target = "cuda:100", "ttg.threads-per-warp" = 32 : i32} {
+  tt.func @reuse_float_bitcast_and_predicate_layout(%source: tensor<32x128xf32, #float_source>, %pointer: tensor<32x128x!tt.ptr<i32>, #float_target>) {
+    %bits = tt.bitcast %source : tensor<32x128xf32, #float_source> -> tensor<32x128xi32, #float_source>
+    %converted_bits = ttg.convert_layout %bits : tensor<32x128xi32, #float_source> -> tensor<32x128xi32, #float_target>
+    %predicate = arith.cmpf oeq, %source, %source : tensor<32x128xf32, #float_source>
+    %converted_predicate = ttg.convert_layout %predicate : tensor<32x128xi1, #float_source> -> tensor<32x128xi1, #float_target>
+    tt.store %pointer, %converted_bits, %converted_predicate : tensor<32x128x!tt.ptr<i32>, #float_target>
+    tt.return
+  }
+}
+
+// -----
+
 // CHECK-LABEL: @propagate_loop_memory_pointer
 // CHECK-NOT: ttg.convert_layout
 // CHECK: scf.for


### PR DESCRIPTION
PR description written by Codex

Improve legacy layout-conversion removal by rematerializing packed store expressions in their final layout, preserving native pointer and mask layouts, keeping narrowing computations in their input layout, and sharing exchanges across selected value/index outputs and floating-point validity predicates.

Validated with all 148 TritonGPU/TritonNvidiaGPU lit tests, 17 GPU correctness tests, and a 31,693-kernel production replay: 1,329 improved, 2,543 fewer layout conversions, and no regressions. Representative packed downcasts reduce shared memory from 16 KiB to 4 KiB; top-k reduces barriers from 9 to 3 and PTX instructions from 675 to 526.

## Stack
Merge bottom-up:
- [ ] #11161 (this PR)
