### PR TITLE
[BACKEND] Restrict broadcast-mul-reduce combine to f32

### DIFF
--- a/lib/Dialect/Triton/Transforms/Combine.cpp
+++ b/lib/Dialect/Triton/Transforms/Combine.cpp
@@ -112,8 +112,10 @@ public:
 class CombineBroadcastMulReducePattern : public RewritePattern {
 private:
   static bool isAddF32(const Operation *op) {
+    // The rewrite below creates an f32 zero scalar, so it can only handle f32
+    // reductions without producing an ill-typed tt.splat.
     if (auto addf = dyn_cast_or_null<arith::AddFOp>(op))
-      return addf.getType().getIntOrFloatBitWidth() <= 32;
+      return addf.getType().isF32();
     return false;
   }
 

--- a/test/Triton/combine.mlir
+++ b/test/Triton/combine.mlir
@@ -535,6 +535,22 @@ tt.func @test_combine_broadcast_mul_reduce_extra_broadcast(%arg0: tensor<32x1xf3
     tt.return %5 : tensor<32x32xf32>
 }
 
+// Do not combine f16: the rewrite currently splats an f32 zero scalar.
+// CHECK-LABEL: @test_combine_broadcast_mul_reduce_f16
+tt.func @test_combine_broadcast_mul_reduce_f16(%arg0: tensor<32x16x1xf16>, %arg1: tensor<1x16x32xf16>) -> tensor<32x32xf16> {
+    // CHECK-NOT: tt.dot
+    // CHECK: tt.reduce
+    %0 = tt.broadcast %arg0 : tensor<32x16x1xf16> -> tensor<32x16x32xf16>
+    %1 = tt.broadcast %arg1 : tensor<1x16x32xf16> -> tensor<32x16x32xf16>
+    %2 = arith.mulf %0, %1 : tensor<32x16x32xf16>
+    %3 = "tt.reduce"(%2) <{axis = 1 : i32}> ({
+    ^bb0(%arg2: f16, %arg3: f16):
+        %4 = arith.addf %arg2, %arg3 : f16
+        tt.reduce.return %4 : f16
+    }) : (tensor<32x16x32xf16>) -> tensor<32x32xf16>
+    tt.return %3 : tensor<32x32xf16>
+}
+
 // CHECK-LABEL: @test_combine_broadcast_mul_reduce_wrong_axis
 tt.func @test_combine_broadcast_mul_reduce_wrong_axis(%arg0: tensor<32x32xf32>, %arg1: tensor<32x32xf32>) -> tensor<32x32xf32> {
     // CHECK-NOT: tt.dot


### PR DESCRIPTION
`CombineBroadcastMulReducePattern` rewrites:

```python
tl.sum(x[:, :, None] * y[None, :, :], axis=1)
```

into:

```mlir
tt.dot(x, y)
```

Its `isAddF32` predicate accepted any floating-point `arith.addf` of 32 bits or fewer, but the rewrite hardcodes an `f32` zero scalar while typing the accumulator tensor from the source element type. For `f16`, this produces an ill-typed splat that fails verification:

```mlir
%zero = arith.constant 0.0 : f32
%acc = tt.splat %zero : f32 -> tensor<32x32xf16>
```

An ordinary half-precision kernel therefore fails to compile:

```python
@triton.jit
def kernel(...):
    x = tl.load(px + ox)  # (32, 16) fp16
    y = tl.load(py + oy)  # (16, 32) fp16
    r = tl.sum(x[:, :, None] * y[None, :, :], axis=1)
    tl.store(po + oo, r)
```

The predicate and rewrite have disagreed since the pattern was added in #1889, so no narrow-precision reduction could produce a valid `tt.dot`. This change therefore removes no working path: it matches only `f32`, the one type the current rewrite handles validly, while narrower reductions remain as `tt.reduce` instead of producing invalid IR.

Adds an `f16` negative lit test to `test/Triton/combine.mlir`.
