### PR TITLE
[triton-ext] Coalesce `.extend_with()` into a single top-level function

### DIFF
--- a/examples/plugins/DialectPlugins/DialectPlugin/lib/DialectPlugin/DialectPluginDialect.cpp
+++ b/examples/plugins/DialectPlugins/DialectPlugin/lib/DialectPlugin/DialectPluginDialect.cpp
@@ -31,7 +31,7 @@ void DialectPluginDialect::initialize() {
 #include "triton/Tools/PluginUtils.h"
 #include "llvm/Config/llvm-config.h"
 
-static const char *PLUGIN_NAME = "DialectPlugin";
+static const char *PLUGIN_NAME = "dialect-plugin";
 static const char *DIALECT_NAME = "DialectPlugin";
 static const char *PASS_NAME = "plugingpu_conversion";
 static const char *VERSION = "0.1.0";

--- a/examples/plugins/TritonPlugin.cpp
+++ b/examples/plugins/TritonPlugin.cpp
@@ -57,7 +57,7 @@ static void registerTritonPluginPass() {
   });
 }
 
-static const char *PLUGIN_NAME = "TritonPlugin";
+static const char *PLUGIN_NAME = "triton-plugin";
 static const char *PASS_NAME = "plugin";
 static const char *VERSION = "0.1.0";
 

--- a/python/src/ir.cc
+++ b/python/src/ir.cc
@@ -32,6 +32,7 @@
 #include "mlir/Target/LLVMIR/Dialect/LLVMIR/LLVMToLLVMIRTranslation.h"
 #include "mlir/Transforms/LocationSnapshot.h"
 
+#include "plugin_registration.h"
 #include "triton/Conversion/TritonGPUToLLVM/Utility.h"
 #include "triton/Dialect/Gluon/IR/Dialect.h"
 #include "triton/Dialect/Triton/IR/Dialect.h"
@@ -55,6 +56,10 @@ using namespace triton;
 namespace tt = triton;
 namespace ttg = triton::gpu;
 namespace ttng = triton::nvidia_gpu;
+
+// Plugins whose dialects should be registered in `load_dialects`. Populated by
+// `extendTritonWith` when a Triton extension is loaded.
+static std::vector<mlir::triton::plugin::TritonPlugin> plugins;
 
 // Function to parse a comma-separated string into a vector of C-style strings
 llvm::SmallVector<const char *, 3>
@@ -336,24 +341,6 @@ void init_triton_ir(py::module_ &m) {
 
   py::class_<SourceMgrDiagnosticHandler>(m, "source_mgr_diag")
       .def(py::init<llvm::SourceMgr &, MLIRContext *>());
-
-  static std::vector<mlir::triton::plugin::TritonPlugin> plugins;
-  m.def(
-      "extend_dialects_with",
-      [](const std::string &libPath) {
-        // Load the plugin library.
-        auto pluginOrErr = mlir::triton::plugin::TritonPlugin::load(libPath);
-        if (!pluginOrErr) {
-          std::string errMsg = llvm::toString(pluginOrErr.takeError());
-          throw std::runtime_error(errMsg);
-        }
-        auto plugin = std::move(*pluginOrErr);
-
-        // Store the plugin for later (i.e., `load_dialects`)
-        plugins.push_back(std::move(plugin));
-      },
-      "Given a path to a Triton extension, register any dialects to be loaded "
-      "in `load_dialects`.");
 
   m.def("load_dialects", [](MLIRContext &context) {
     DialectRegistry registry;
@@ -1919,36 +1906,6 @@ void init_triton_ir(py::module_ &m) {
                                                   paddingOption);
            });
 
-  // Add an `extend_with` static method that dynamically loads a plugin and
-  // registers its custom operations as builder methods.
-  auto builderPtr =
-      std::make_shared<py::class_<TritonOpBuilder>>(TritonOpBuilderBinding);
-  TritonOpBuilderBinding.def_static(
-      "extend_with",
-      [builderPtr](const std::string &path) {
-        // Load the plugin library.
-        auto pluginOrErr = mlir::triton::plugin::TritonPlugin::load(path);
-        if (!pluginOrErr) {
-          std::string errMsg = llvm::toString(pluginOrErr.takeError());
-          throw std::runtime_error(errMsg);
-        }
-        auto plugin = std::move(*pluginOrErr);
-
-        // Extend the builder class with the ops defined in the plugin.
-        py::gil_scoped_acquire acquire;
-        for (const auto &op : plugin.listOps()) {
-          std::string wrapped = std::string("create_") + op.name;
-          builderPtr->def(wrapped.c_str(),
-                          [op](TritonOpBuilder &self, std::vector<Value> args) {
-                            args.insert(args.begin(), Value());
-                            op.addOp(self, args);
-                            return args[0];
-                          });
-        }
-      },
-      "Given a path to a Triton extension, load it and create builder methods "
-      "for each operation.");
-
   py::class_<PassManager>(m, "pass_manager")
       .def(py::init<MLIRContext *>())
       .def("enable_debug",
@@ -2055,6 +2012,68 @@ void init_triton_ir(py::module_ &m) {
               throw std::runtime_error("PassManager::run failed");
           },
           py::call_guard<py::gil_scoped_release>());
+}
+
+// Top-level `libtriton.extend_with(path)`: load a Triton extension once and
+// register all of its dialects, custom operations, and passes.
+//
+// All registration is contained here rather than dispersed across translation
+// units. We reach the relevant Python objects by walking the top-level module
+// tree (`m`) via `py::getattr` at call time -- when the interpreter is
+// guaranteed alive -- so that no nanobind Python handle is cached in a C++
+// static (a static handle would be destroyed after `Py_Finalize`, causing a
+// use-after-free `Py_DECREF` at process teardown).
+//
+// Because the walk depends on the module structure, a change to that structure
+// (e.g. renaming `ir.builder`) will raise an `AttributeError` here; this is
+// intentionally guarded by a test (see `test_extend_with.py`).
+void extendTritonWith(py::module_ m, const std::string &path) {
+  // Load the plugin library.
+  auto pluginOrErr = mlir::triton::plugin::TritonPlugin::load(path);
+  if (!pluginOrErr) {
+    std::string errMsg = llvm::toString(pluginOrErr.takeError());
+    throw std::runtime_error(errMsg);
+  }
+  auto plugin = std::move(*pluginOrErr);
+
+  // Append the plugin's contributions in each place, holding the GIL. The
+  // plugin is loaded permanently (see `TritonPlugin::load`), so the operation
+  // and pass callbacks remain valid even though only the dialect plugins are
+  // retained (for later `load_dialects`).
+  py::gil_scoped_acquire acquire;
+
+  // Register the plugin's custom operations as `create_<op>` methods on the
+  // `ir.builder` class.
+  auto builderClass = py::borrow<py::class_<TritonOpBuilder>>(
+      py::getattr(py::getattr(m, "ir"), "builder"));
+  for (const auto &op : plugin.listOps()) {
+    std::string wrapped = std::string("create_") + op.name;
+    builderClass.def(wrapped.c_str(), [op](TritonOpBuilder &self,
+                                           std::vector<mlir::Value> args) {
+      args.insert(args.begin(), mlir::Value());
+      op.addOp(self, args);
+      return args[0];
+    });
+  }
+
+  // Register the plugin's passes as `add_<pass>` functions in a per-plugin
+  // `passes.<plugin_name>` submodule.
+  auto passesModule = py::borrow<py::module_>(py::getattr(m, "passes"));
+  std::string submoduleName = plugin.getPluginName().str();
+  std::replace(submoduleName.begin(), submoduleName.end(), '-', '_');
+  auto pluginPasses = passesModule.def_submodule(submoduleName.c_str());
+  for (const auto &pass : plugin.listPasses()) {
+    std::string wrapped = std::string("add_") + pass.name;
+    pluginPasses.def(
+        wrapped.c_str(),
+        [pass](mlir::PassManager &pm, std::vector<std::string> args) {
+          pass.addPass(&pm, args);
+        },
+        py::arg("pm"), py::arg("args") = std::vector<std::string>());
+  }
+
+  // Retain the plugin so `load_dialects` can register its dialects later.
+  plugins.push_back(std::move(plugin));
 }
 
 namespace {

--- a/python/src/main.cc
+++ b/python/src/main.cc
@@ -1,6 +1,8 @@
+#include "plugin_registration.h"
 #include "llvm/ADT/StringRef.h"
 #include "llvm/Support/Signals.h"
 #include <nanobind/nanobind.h>
+#include <nanobind/stl/string.h>
 
 namespace py = nanobind;
 
@@ -72,4 +74,17 @@ NB_MODULE(libtriton, m) {
   auto gluon_m = m.def_submodule("gluon_ir");
   init_gluon_ir(gluon_m);
   FOR_EACH_P(INIT_BACKEND, TRITON_BACKENDS_TUPLE)
+
+  // Single, top-level entry point for extending Triton with a plugin. This must
+  // be defined after the module tree (`ir`, `passes`, ...) has been built so
+  // that it can append the plugin's dialects, operations, and passes in each
+  // place. The top-level module is captured by value (its lifetime is owned by
+  // nanobind, which cleans it up while the interpreter is still valid) and
+  // forwarded so that `extendTritonWith` can walk the module tree at call time.
+  // See `extendTritonWith` in `ir.cc`.
+  m.def(
+      "extend_with",
+      [m](const std::string &path) { extendTritonWith(m, path); },
+      "Given a path to a Triton extension, load it once and register its "
+      "dialects, custom operations, and passes.");
 }

--- a/python/src/passes.cc
+++ b/python/src/passes.cc
@@ -117,35 +117,6 @@ void init_triton_passes_ttgpuir(py::module_ &m) {
   });
 }
 
-void init_plugin_passes(py::module_ &m) {
-  auto m_ptr = std::make_shared<py::module_>(m);
-  m.def(
-      "extend_with",
-      [m_ptr](const std::string &path) {
-        // Load the plugin library.
-        auto pluginOrErr = mlir::triton::plugin::TritonPlugin::load(path);
-        if (!pluginOrErr) {
-          std::string errMsg = llvm::toString(pluginOrErr.takeError());
-          throw std::runtime_error(errMsg);
-        }
-        auto plugin = std::move(*pluginOrErr);
-
-        // Extend this submodule with the passes defined in the plugin.
-        py::gil_scoped_acquire acquire;
-        for (const auto &pass : plugin.listPasses()) {
-          std::string wrapped = std::string("add_") + pass.name;
-          m_ptr->def(
-              wrapped.c_str(),
-              [pass](mlir::PassManager &pm, std::vector<std::string> args) {
-                pass.addPass(&pm, args);
-              },
-              py::arg("pm"), py::arg("args") = std::vector<std::string>());
-        }
-      },
-      "Given a path to a Triton extension, load it and create `add_*` "
-      "functions for each pass.");
-}
-
 void init_triton_passes_convert(py::module_ &m) {
   using namespace mlir;
   ADD_PASS_WRAPPER_0("add_scf_to_cf", createSCFToControlFlowPass);
@@ -191,6 +162,6 @@ void init_triton_passes(py::module_ &m) {
   init_triton_passes_llvmir(llvmir_m);
   auto gluon_m = m.def_submodule("gluon");
   init_gluon_passes(gluon_m);
-  auto plugin_m = m.def_submodule("plugin");
-  init_plugin_passes(plugin_m);
+  // Per-plugin `passes.<plugin_name>` submodules are created lazily by
+  // `extendTritonWith` (see `ir.cc`) when a Triton extension is loaded.
 }

--- a/python/src/plugin_registration.h
+++ b/python/src/plugin_registration.h
@@ -1,0 +1,10 @@
+#pragma once
+
+#include <nanobind/nanobind.h>
+#include <string>
+
+// Top-level entry point behind `libtriton.extend_with(path)`. Loads a Triton
+// extension once and registers all of its dialects, custom operations, and
+// passes by walking the given top-level module (`ir.builder`, `passes`, ...).
+// Defined in `ir.cc`.
+void extendTritonWith(nanobind::module_ m, const std::string &path);

--- a/python/test/unit/plugins/custom_stages.py
+++ b/python/test/unit/plugins/custom_stages.py
@@ -34,9 +34,9 @@ def inspect_stages_hook(self=None, stages=None, options=None, language=None, cap
         pm = ir.pass_manager(mod.context)
         pm.enable_debug()
         if num_warps != 4:
-            passes.plugin.add_plugin(pm, [str(num_warps)])
+            passes.triton_plugin.add_plugin(pm, [str(num_warps)])
         else:
-            passes.plugin.add_plugin(pm)
+            passes.triton_plugin.add_plugin(pm)
         pm.run(mod, 'make_ttir_plugin')
         return mod
 
@@ -55,7 +55,7 @@ def inspect_stages_hook_dialect(self=None, stages=None, options=None, language=N
         mod = self.make_ttgir(mod, metadata, opt, capability)
         pm = ir.pass_manager(mod.context)
         pm.enable_debug()
-        passes.plugin.add_plugingpu_conversion(pm)
+        passes.dialect_plugin.add_plugingpu_conversion(pm)
         pm.run(mod, 'make_ttgir_plugin')
         return mod
 

--- a/python/test/unit/plugins/override_helper.py
+++ b/python/test/unit/plugins/override_helper.py
@@ -9,10 +9,9 @@ import custom_stages
 
 DEVICE = triton.runtime.driver.active.get_active_torch_device()
 
-# Extend dialects and passes with the passed plugin.
+# Extend Triton with the passed plugin (registers its dialects and passes).
 LIB = 'python/triton/plugins/libMLIRDialectPlugin.so'
-triton._C.libtriton.ir.extend_dialects_with(LIB)
-triton._C.libtriton.passes.plugin.extend_with(LIB)
+triton._C.libtriton.extend_with(LIB)
 
 
 def metadata_fn(grid: tuple, metadata: NamedTuple, args: dict):

--- a/python/test/unit/plugins/test_custom_ops.py
+++ b/python/test/unit/plugins/test_custom_ops.py
@@ -62,9 +62,9 @@ def test_custom_ops(tmp_path: pathlib.Path):
     if os.environ.get('TRITON_EXT_ENABLED', '0') == '0':
         return
 
-    # Extend Triton's operation builder with the plugin's operations.
+    # Extend Triton with the plugin (registers its custom operations).
     LIB = 'python/triton/plugins/libMLIRDialectPlugin.so'
-    triton._C.libtriton.ir.builder.extend_with(LIB)
+    triton._C.libtriton.extend_with(LIB)
 
     size = 8
     x = torch.zeros(size, device=DEVICE, dtype=torch.float32)

--- a/python/test/unit/plugins/test_extend_with.py
+++ b/python/test/unit/plugins/test_extend_with.py
@@ -1,0 +1,39 @@
+"""Regression tests for `libtriton.extend_with` and interpreter teardown.
+
+These tests do not require a GPU or a built plugin. They guard two invariants:
+
+1. Importing `triton._C.libtriton` and exiting must not segfault. A previous
+   refactor stored nanobind Python handles in C++ statics; those were destroyed
+   after `Py_Finalize`, causing a use-after-free `Py_DECREF` (SIGSEGV, exit 139)
+   at process teardown.
+
+2. `extend_with` walks the module tree (`ir.builder`, `passes`) via
+   `py::getattr` at call time. If that structure is renamed/restructured, the
+   walk breaks; this test fails loudly so the breakage is caught in CI.
+"""
+
+import subprocess
+import sys
+
+
+def test_libtriton_teardown_no_segfault():
+    # Import in a fresh subprocess so we can observe the *exit* code: the crash
+    # this guards against occurred only during interpreter teardown.
+    result = subprocess.run(
+        [sys.executable, "-c", "import triton._C.libtriton"],
+        capture_output=True,
+    )
+    assert result.returncode == 0, (f"importing libtriton crashed at teardown (returncode={result.returncode})\n"
+                                    f"stderr:\n{result.stderr.decode(errors='replace')}")
+
+
+def test_extend_with_module_structure():
+    # `extendTritonWith` (ir.cc) reaches these objects with `py::getattr`; if the
+    # module structure changes, the walk -- and this assertion -- must be updated
+    # together.
+    from triton._C import libtriton
+
+    assert hasattr(libtriton, "extend_with")
+    assert hasattr(libtriton, "ir"), "extend_with walks to `ir`"
+    assert hasattr(libtriton.ir, "builder"), "extend_with walks to `ir.builder`"
+    assert hasattr(libtriton, "passes"), "extend_with walks to `passes`"

--- a/python/test/unit/plugins/test_plugin.py
+++ b/python/test/unit/plugins/test_plugin.py
@@ -31,9 +31,9 @@ def test_op(capfd, device: str):
     if os.environ.get('TRITON_EXT_ENABLED', '0') == '0':
         return
 
-    # Extend Triton's passes with the plugin's passes.
+    # Extend Triton with the plugin (registers its passes).
     LIB = 'python/triton/plugins/libTritonPluginsTestLib.so'
-    triton._C.libtriton.passes.plugin.extend_with(LIB)
+    triton._C.libtriton.extend_with(LIB)
 
     size = 98432
     x = torch.rand(size, device=device)


### PR DESCRIPTION
PR #10775 added `.extend_with()` functions to `libtriton` so that Triton extensions can register themselves dynamically, which allows extensions to be distributed as Python wheels (see [triton-ext#111]). That change, however, left three separate entry points dispersed around the Python tree: `ir.extend_dialects_with()` for dialects,
`ir.builder.extend_with()` for custom operations, and `passes.plugin.extend_with()` for passes. A single plugin `.so` can carry any combination of these, so an extension's `__init__.py` had to call up to three functions to register itself.

This change coalesces those into a single, top-level `libtriton.extend_with("path/to/plugin.so")`. As before, we capture the Python module, but now walk the tree to attach the same callbacks as before in the same places as before. There is one exception: `add_<pass>` now lives in a per-plugin `passes.<plugin_name>` submodule.

This approach, a single function instead of three, is what I landed on after thinking a bit about #10775 ([comment]); unfortunately that was merged before I got to this. I think it will hold up better to changes in the plugin ABI or to Triton's Python API over time: in either case the extension wheels can avoid changes.

Assisted-by: OpenCode/anthropic/claude-opus-4-8

[triton-ext#111]: https://github.com/triton-lang/triton-ext/pull/111
[comment]: https://github.com/triton-lang/triton/pull/10775#issuecomment-5063201753
