### PR TITLE
[BACKEND] Account for view offsets in TMEM barrier aliasing

### DIFF
--- a/lib/Dialect/TritonNvidiaGPU/Transforms/TMemBarrierInsertion.cpp
+++ b/lib/Dialect/TritonNvidiaGPU/Transforms/TMemBarrierInsertion.cpp
@@ -6,6 +6,7 @@
 
 #include "mlir/Dialect/Arith/IR/Arith.h"
 #include "mlir/Dialect/SCF/IR/SCF.h"
+#include "mlir/IR/Matchers.h"
 #include "mlir/Interfaces/ControlFlowInterfaces.h"
 #include "llvm/ADT/DenseSet.h"
 
@@ -82,13 +83,29 @@ static bool isTensorMemory(Value value) {
          isa<TensorMemorySpaceAttr>(memDescType.getMemorySpace());
 }
 
-static void appendRootAllocs(Value value, SmallVectorImpl<TMEMAllocOp> &allocs,
+// Offset of a view relative to the root allocation, in physical TMEM
+// coordinates (rows, 32-bit columns).
+struct TMemViewOffset {
+  int64_t row = 0;
+  int64_t col = 0;
+  bool known = true;
+};
+
+// A root allocation reached from a view, together with the view's offset
+// within it. Two views of one allocation can be physically disjoint, so the
+// offset is what lets the interval model tell them apart.
+struct RootAlloc {
+  TMEMAllocOp alloc;
+  TMemViewOffset offset;
+};
+
+static void appendRootAllocs(Value value, SmallVectorImpl<RootAlloc> &allocs,
                              bool &unknown) {
   DenseSet<Value> seen;
-  SmallVector<Value> worklist{value};
+  SmallVector<std::pair<Value, TMemViewOffset>> worklist{{value, {}}};
 
   while (!worklist.empty()) {
-    Value current = worklist.pop_back_val();
+    auto [current, offset] = worklist.pop_back_val();
     if (!seen.insert(current).second)
       continue;
 
@@ -108,25 +125,27 @@ static void appendRootAllocs(Value value, SmallVectorImpl<TMEMAllocOp> &allocs,
               std::distance(branch->getSuccessors().begin(), it);
           SuccessorOperands args = branch.getSuccessorOperands(successorIndex);
           worklist.push_back(
-              args.getForwardedOperands()[arg.getArgNumber() -
-                                          args.getProducedOperandCount()]);
+              {args.getForwardedOperands()[arg.getArgNumber() -
+                                           args.getProducedOperandCount()],
+               offset});
         }
         continue;
       }
 
       if (auto ws = dyn_cast<ttg::WarpSpecializePartitionsOp>(parentOp)) {
-        worklist.push_back(ws.getExplicitCaptures()[arg.getArgNumber()]);
+        worklist.push_back(
+            {ws.getExplicitCaptures()[arg.getArgNumber()], offset});
       } else if (auto forOp = dyn_cast<scf::ForOp>(parentOp)) {
         unsigned idx = arg.getArgNumber() - 1;
-        worklist.push_back(forOp.getYieldedValues()[idx]);
-        worklist.push_back(forOp.getInits()[idx]);
+        worklist.push_back({forOp.getYieldedValues()[idx], offset});
+        worklist.push_back({forOp.getInits()[idx], offset});
       } else if (auto whileOp = dyn_cast<scf::WhileOp>(parentOp)) {
         unsigned idx = arg.getArgNumber();
         if (arg.getParentRegion() == &whileOp.getAfter()) {
-          worklist.push_back(whileOp.getConditionOp().getArgs()[idx]);
+          worklist.push_back({whileOp.getConditionOp().getArgs()[idx], offset});
         } else {
-          worklist.push_back(whileOp.getYieldedValues()[idx]);
-          worklist.push_back(whileOp.getInits()[idx]);
+          worklist.push_back({whileOp.getYieldedValues()[idx], offset});
+          worklist.push_back({whileOp.getInits()[idx], offset});
         }
       } else {
         unknown = true;
@@ -142,22 +161,48 @@ static void appendRootAllocs(Value value, SmallVectorImpl<TMEMAllocOp> &allocs,
 
     unsigned resultIndex = cast<OpResult>(current).getResultNumber();
     if (auto alloc = dyn_cast<TMEMAllocOp>(defOp)) {
-      allocs.push_back(alloc);
-    } else if (defOp->hasTrait<OpTrait::MemDescViewTrait>()) {
-      worklist.push_back(defOp->getOperand(0));
+      allocs.push_back({alloc, offset});
+    } else if (auto index = dyn_cast<ttg::MemDescIndexOp>(defOp)) {
+      // Multi-buffered views advance the base pointer by one buffer's worth of
+      // 32-bit columns, matching MemDescIndexOpConversion.
+      APInt indexValue;
+      TMemViewOffset next = offset;
+      if (matchPattern(index.getIndex(), m_ConstantInt(&indexValue)))
+        next.col += indexValue.getSExtValue() *
+                    getTmemAllocSizes(index.getType()).numCols;
+      else
+        next.known = false;
+      worklist.push_back({index.getSrc(), next});
     } else if (auto slice = dyn_cast<TMEMSubSliceOp>(defOp)) {
-      worklist.push_back(slice.getSrc());
+      // getTMemSubSliceOffset packs the column offset in the low 16 bits and
+      // the row offset in the high 16 bits, as the lowering does.
+      uint32_t packed = getTMemSubSliceOffset(
+          slice.getSrc().getType(), slice.getOffset(), slice.getDim());
+      TMemViewOffset next = offset;
+      next.col += packed & 0xffff;
+      next.row += packed >> 16;
+      worklist.push_back({slice.getSrc(), next});
+    } else if (isa<ttg::MemDescReinterpretOp, ttg::MemDescTransOp,
+                   ttg::MemDescReshapeOp>(defOp)) {
+      // Pure reinterpretations do not move the base pointer.
+      worklist.push_back({defOp->getOperand(0), offset});
+    } else if (defOp->hasTrait<OpTrait::MemDescViewTrait>()) {
+      // Keep walking to the root, but do not pretend the offset is known.
+      TMemViewOffset next = offset;
+      next.known = false;
+      worklist.push_back({defOp->getOperand(0), next});
     } else if (auto selectOp = dyn_cast<arith::SelectOp>(defOp)) {
-      worklist.push_back(selectOp.getTrueValue());
-      worklist.push_back(selectOp.getFalseValue());
+      worklist.push_back({selectOp.getTrueValue(), offset});
+      worklist.push_back({selectOp.getFalseValue(), offset});
     } else if (auto ifOp = dyn_cast<scf::IfOp>(defOp)) {
-      worklist.push_back(ifOp.thenYield().getOperand(resultIndex));
-      worklist.push_back(ifOp.elseYield().getOperand(resultIndex));
+      worklist.push_back({ifOp.thenYield().getOperand(resultIndex), offset});
+      worklist.push_back({ifOp.elseYield().getOperand(resultIndex), offset});
     } else if (auto forOp = dyn_cast<scf::ForOp>(defOp)) {
-      worklist.push_back(forOp.getYieldedValues()[resultIndex]);
-      worklist.push_back(forOp.getInits()[resultIndex]);
+      worklist.push_back({forOp.getYieldedValues()[resultIndex], offset});
+      worklist.push_back({forOp.getInits()[resultIndex], offset});
     } else if (auto whileOp = dyn_cast<scf::WhileOp>(defOp)) {
-      worklist.push_back(whileOp.getConditionOp().getArgs()[resultIndex]);
+      worklist.push_back(
+          {whileOp.getConditionOp().getArgs()[resultIndex], offset});
     } else {
       unknown = true;
     }
@@ -165,46 +210,54 @@ static void appendRootAllocs(Value value, SmallVectorImpl<TMEMAllocOp> &allocs,
 }
 
 static SmallVector<AllocationSlice> getTMemSlices(Value value) {
-  SmallVector<TMEMAllocOp> allocs;
+  SmallVector<RootAlloc> allocs;
   bool unknown = false;
   appendRootAllocs(value, allocs, unknown);
 
   SmallVector<AllocationSlice> slices;
-  if (unknown || allocs.empty()) {
+  auto everything = [&]() -> SmallVector<AllocationSlice> {
+    slices.clear();
     slices.emplace_back(
         Interval<size_t>(0, std::numeric_limits<size_t>::max()));
     return slices;
-  }
+  };
 
-  for (TMEMAllocOp alloc : allocs) {
+  if (unknown || allocs.empty())
+    return everything();
+
+  // The accessed extent is the view's own footprint, not the whole allocation.
+  auto viewTy = dyn_cast<ttg::MemDescType>(value.getType());
+  if (!viewTy)
+    return everything();
+  TMemAllocation viewSize = getTmemAllocSizes(viewTy);
+
+  for (RootAlloc &root : allocs) {
     auto colAttr =
-        alloc->getAttrOfType<IntegerAttr>("tensor_memory_col_offset");
+        root.alloc->getAttrOfType<IntegerAttr>("tensor_memory_col_offset");
     auto rowAttr =
-        alloc->getAttrOfType<IntegerAttr>("tensor_memory_row_offset");
-    if (!colAttr || !rowAttr) {
-      slices.clear();
-      slices.emplace_back(
-          Interval<size_t>(0, std::numeric_limits<size_t>::max()));
-      return slices;
-    }
+        root.alloc->getAttrOfType<IntegerAttr>("tensor_memory_row_offset");
+    if (!colAttr || !rowAttr)
+      return everything();
 
-    int64_t colOffset = colAttr.getInt();
-    int64_t rowOffset = rowAttr.getInt();
-    TMemAllocation allocSize = getTmemAllocSizes(alloc.getType());
+    TMemAllocation allocSize = getTmemAllocSizes(root.alloc.getType());
+    // Fall back to the whole allocation when the view offset is not statically
+    // known, so an unresolved view can never look narrower than it is.
+    bool useView = root.offset.known;
+    int64_t colOffset = colAttr.getInt() + (useView ? root.offset.col : 0);
+    int64_t rowOffset = rowAttr.getInt() + (useView ? root.offset.row : 0);
+    int64_t numRows = useView ? viewSize.numRows : allocSize.numRows;
+    int64_t numCols = useView ? viewSize.numCols : allocSize.numCols;
+
     if (rowOffset % kRowOffsetGranularity != 0 ||
-        allocSize.numRows % kAllocRowGranularity != 0) {
-      slices.clear();
-      slices.emplace_back(
-          Interval<size_t>(0, std::numeric_limits<size_t>::max()));
-      return slices;
-    }
+        numRows % kAllocRowGranularity != 0)
+      return everything();
 
     int64_t rowGroup = rowOffset / kRowOffsetGranularity;
-    int64_t numRowGroups = allocSize.numRows / kAllocRowGranularity;
+    int64_t numRowGroups = numRows / kAllocRowGranularity;
     for (int64_t row = 0; row < numRowGroups; ++row) {
       size_t start = static_cast<size_t>(rowGroup + row) * kFlattenedRowStride +
                      static_cast<size_t>(colOffset);
-      slices.emplace_back(Interval<size_t>(start, start + allocSize.numCols));
+      slices.emplace_back(Interval<size_t>(start, start + numCols));
     }
   }
   return slices;

--- a/test/TritonNvidiaGPU/tmem_barrier_insertion.mlir
+++ b/test/TritonNvidiaGPU/tmem_barrier_insertion.mlir
@@ -330,4 +330,111 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32} {
     ttng.tmem_copy %arg1, %0 : !ttg.memdesc<128x128xf32, #shared_copy, #ttg.shared_memory>, !ttg.memdesc<128x128xf32, #tmem128, #ttng.tensor_memory, mutable>
     tt.return
   }
+
+  // Two multi-buffered views of one allocation that land on different physical
+  // columns do not alias, so no barrier is needed between them.
+  // CHECK-LABEL: @ld_then_st_disjoint_buffers
+  // CHECK: ttng.tmem_load
+  // CHECK-NEXT: ttng.tmem_store
+  // CHECK-NOT: ttg.barrier
+  tt.func @ld_then_st_disjoint_buffers(%arg0: tensor<128x128xf32, #blocked>) {
+    %true = arith.constant true
+    %c0 = arith.constant 0 : i32
+    %c1 = arith.constant 1 : i32
+    %0 = ttng.tmem_alloc {tensor_memory_col_offset = 0 : i32, tensor_memory_row_offset = 0 : i32} : () -> !ttg.memdesc<2x128x128xf32, #tmem128, #ttng.tensor_memory, mutable>
+    ttg.barrier local
+    %rd = ttg.memdesc_index %0[%c0] : !ttg.memdesc<2x128x128xf32, #tmem128, #ttng.tensor_memory, mutable> -> !ttg.memdesc<128x128xf32, #tmem128, #ttng.tensor_memory, mutable>
+    %wr = ttg.memdesc_index %0[%c1] : !ttg.memdesc<2x128x128xf32, #tmem128, #ttng.tensor_memory, mutable> -> !ttg.memdesc<128x128xf32, #tmem128, #ttng.tensor_memory, mutable>
+    %1 = ttng.tmem_load %rd : !ttg.memdesc<128x128xf32, #tmem128, #ttng.tensor_memory, mutable> -> tensor<128x128xf32, #blocked>
+    ttng.tmem_store %arg0, %wr, %true : tensor<128x128xf32, #blocked> -> !ttg.memdesc<128x128xf32, #tmem128, #ttng.tensor_memory, mutable>
+    tt.return
+  }
+
+  // Same allocation, same buffer index: the views do alias and the WAR still
+  // needs ordering.
+  // CHECK-LABEL: @ld_then_st_same_buffer
+  // CHECK: ttng.tmem_load
+  // CHECK-NEXT: ttg.barrier local
+  // CHECK-NEXT: ttng.tmem_store
+  tt.func @ld_then_st_same_buffer(%arg0: tensor<128x128xf32, #blocked>) {
+    %true = arith.constant true
+    %c1 = arith.constant 1 : i32
+    %0 = ttng.tmem_alloc {tensor_memory_col_offset = 0 : i32, tensor_memory_row_offset = 0 : i32} : () -> !ttg.memdesc<2x128x128xf32, #tmem128, #ttng.tensor_memory, mutable>
+    ttg.barrier local
+    %rd = ttg.memdesc_index %0[%c1] : !ttg.memdesc<2x128x128xf32, #tmem128, #ttng.tensor_memory, mutable> -> !ttg.memdesc<128x128xf32, #tmem128, #ttng.tensor_memory, mutable>
+    %wr = ttg.memdesc_index %0[%c1] : !ttg.memdesc<2x128x128xf32, #tmem128, #ttng.tensor_memory, mutable> -> !ttg.memdesc<128x128xf32, #tmem128, #ttng.tensor_memory, mutable>
+    %1 = ttng.tmem_load %rd : !ttg.memdesc<128x128xf32, #tmem128, #ttng.tensor_memory, mutable> -> tensor<128x128xf32, #blocked>
+    ttng.tmem_store %arg0, %wr, %true : tensor<128x128xf32, #blocked> -> !ttg.memdesc<128x128xf32, #tmem128, #ttng.tensor_memory, mutable>
+    tt.return
+  }
+
+  // A dynamic buffer index cannot prove disjointness: stay conservative.
+  // CHECK-LABEL: @ld_then_st_dynamic_buffer
+  // CHECK: ttng.tmem_load
+  // CHECK-NEXT: ttg.barrier local
+  // CHECK-NEXT: ttng.tmem_store
+  tt.func @ld_then_st_dynamic_buffer(%arg0: tensor<128x128xf32, #blocked>, %idx: i32) {
+    %true = arith.constant true
+    %c0 = arith.constant 0 : i32
+    %0 = ttng.tmem_alloc {tensor_memory_col_offset = 0 : i32, tensor_memory_row_offset = 0 : i32} : () -> !ttg.memdesc<2x128x128xf32, #tmem128, #ttng.tensor_memory, mutable>
+    ttg.barrier local
+    %rd = ttg.memdesc_index %0[%c0] : !ttg.memdesc<2x128x128xf32, #tmem128, #ttng.tensor_memory, mutable> -> !ttg.memdesc<128x128xf32, #tmem128, #ttng.tensor_memory, mutable>
+    %wr = ttg.memdesc_index %0[%idx] : !ttg.memdesc<2x128x128xf32, #tmem128, #ttng.tensor_memory, mutable> -> !ttg.memdesc<128x128xf32, #tmem128, #ttng.tensor_memory, mutable>
+    %1 = ttng.tmem_load %rd : !ttg.memdesc<128x128xf32, #tmem128, #ttng.tensor_memory, mutable> -> tensor<128x128xf32, #blocked>
+    ttng.tmem_store %arg0, %wr, %true : tensor<128x128xf32, #blocked> -> !ttg.memdesc<128x128xf32, #tmem128, #ttng.tensor_memory, mutable>
+    tt.return
+  }
+
+  // tmem_subslice offsets are honoured too: two column subslices of one
+  // allocation that do not overlap need no barrier between them.
+  // CHECK-LABEL: @ld_then_st_disjoint_subslices
+  // CHECK: ttng.tmem_load
+  // CHECK-NEXT: ttng.tmem_store
+  // CHECK-NOT: ttg.barrier
+  tt.func @ld_then_st_disjoint_subslices(%arg0: tensor<128x64xf32, #blocked>) {
+    %true = arith.constant true
+    %0 = ttng.tmem_alloc {tensor_memory_col_offset = 0 : i32, tensor_memory_row_offset = 0 : i32} : () -> !ttg.memdesc<128x128xf32, #tmem128, #ttng.tensor_memory, mutable>
+    ttg.barrier local
+    %rd = ttng.tmem_subslice %0 {offset = 0 : i32} : !ttg.memdesc<128x128xf32, #tmem128, #ttng.tensor_memory, mutable> -> !ttg.memdesc<128x64xf32, #tmem128, #ttng.tensor_memory, mutable, 128x128>
+    %wr = ttng.tmem_subslice %0 {offset = 64 : i32} : !ttg.memdesc<128x128xf32, #tmem128, #ttng.tensor_memory, mutable> -> !ttg.memdesc<128x64xf32, #tmem128, #ttng.tensor_memory, mutable, 128x128>
+    %1 = ttng.tmem_load %rd : !ttg.memdesc<128x64xf32, #tmem128, #ttng.tensor_memory, mutable, 128x128> -> tensor<128x64xf32, #blocked>
+    ttng.tmem_store %arg0, %wr, %true : tensor<128x64xf32, #blocked> -> !ttg.memdesc<128x64xf32, #tmem128, #ttng.tensor_memory, mutable, 128x128>
+    tt.return
+  }
+
+  // Overlapping subslices of one allocation still need the barrier.
+  // CHECK-LABEL: @ld_then_st_overlapping_subslices
+  // CHECK: ttng.tmem_load
+  // CHECK-NEXT: ttg.barrier local
+  // CHECK-NEXT: ttng.tmem_store
+  tt.func @ld_then_st_overlapping_subslices(%arg0: tensor<128x64xf32, #blocked>) {
+    %true = arith.constant true
+    %0 = ttng.tmem_alloc {tensor_memory_col_offset = 0 : i32, tensor_memory_row_offset = 0 : i32} : () -> !ttg.memdesc<128x128xf32, #tmem128, #ttng.tensor_memory, mutable>
+    ttg.barrier local
+    %rd = ttng.tmem_subslice %0 {offset = 64 : i32} : !ttg.memdesc<128x128xf32, #tmem128, #ttng.tensor_memory, mutable> -> !ttg.memdesc<128x64xf32, #tmem128, #ttng.tensor_memory, mutable, 128x128>
+    %wr = ttng.tmem_subslice %0 {offset = 64 : i32} : !ttg.memdesc<128x128xf32, #tmem128, #ttng.tensor_memory, mutable> -> !ttg.memdesc<128x64xf32, #tmem128, #ttng.tensor_memory, mutable, 128x128>
+    %1 = ttng.tmem_load %rd : !ttg.memdesc<128x64xf32, #tmem128, #ttng.tensor_memory, mutable, 128x128> -> tensor<128x64xf32, #blocked>
+    ttng.tmem_store %arg0, %wr, %true : tensor<128x64xf32, #blocked> -> !ttg.memdesc<128x64xf32, #tmem128, #ttng.tensor_memory, mutable, 128x128>
+    tt.return
+  }
+
+  // memdesc_reinterpret does not move the base pointer, so the buffer offset
+  // underneath it still decides aliasing.
+  // CHECK-LABEL: @ld_then_st_reinterpret_disjoint_buffers
+  // CHECK: ttng.tmem_load
+  // CHECK-NEXT: ttng.tmem_store
+  // CHECK-NOT: ttg.barrier
+  tt.func @ld_then_st_reinterpret_disjoint_buffers(%arg0: tensor<128x128xf32, #blocked>) {
+    %true = arith.constant true
+    %c0 = arith.constant 0 : i32
+    %c1 = arith.constant 1 : i32
+    %0 = ttng.tmem_alloc {tensor_memory_col_offset = 0 : i32, tensor_memory_row_offset = 0 : i32} : () -> !ttg.memdesc<2x128x128xi32, #tmem128, #ttng.tensor_memory, mutable>
+    ttg.barrier local
+    %v = ttg.memdesc_reinterpret %0 : !ttg.memdesc<2x128x128xi32, #tmem128, #ttng.tensor_memory, mutable> -> !ttg.memdesc<2x128x128xf32, #tmem128, #ttng.tensor_memory, mutable>
+    %rd = ttg.memdesc_index %v[%c0] : !ttg.memdesc<2x128x128xf32, #tmem128, #ttng.tensor_memory, mutable> -> !ttg.memdesc<128x128xf32, #tmem128, #ttng.tensor_memory, mutable>
+    %wr = ttg.memdesc_index %v[%c1] : !ttg.memdesc<2x128x128xf32, #tmem128, #ttng.tensor_memory, mutable> -> !ttg.memdesc<128x128xf32, #tmem128, #ttng.tensor_memory, mutable>
+    %1 = ttng.tmem_load %rd : !ttg.memdesc<128x128xf32, #tmem128, #ttng.tensor_memory, mutable> -> tensor<128x128xf32, #blocked>
+    ttng.tmem_store %arg0, %wr, %true : tensor<128x128xf32, #blocked> -> !ttg.memdesc<128x128xf32, #tmem128, #ttng.tensor_memory, mutable>
+    tt.return
+  }
 }


### PR DESCRIPTION
`getTMemSlices` resolves every memdesc view to its root `tmem_alloc` and then uses
that allocation's offset and full size. Two views of one allocation that live on
different physical columns therefore always look like they alias, and the pass
inserts a CTA barrier between them.

The clearest case is a multi-buffered TMEM accumulator:

```mlir
%acc = ttng.tmem_alloc : () -> !ttg.memdesc<2x128x128xf32, #tmem, #ttng.tensor_memory, mutable>

%rd = ttg.memdesc_index %acc[0]   // slot 0, physical columns 0..127
%wr = ttg.memdesc_index %acc[1]   // slot 1, physical columns 128..255

%v = ttng.tmem_load %rd
ttng.tmem_store %val, %wr
```

Both views resolve to `%acc`, so both get the interval of the whole allocation,
they intersect, the load→store pair is classified WAR, and a barrier is inserted.
The two slots do not overlap in physical TMEM — distinct pipeline slots are being
serialized against each other, which is exactly the kind of unnecessary barrier
this pass was introduced to remove.

## Change

Carry the view's offset while walking to the root, and use the view's own extent
instead of the whole allocation's:

- constant `memdesc_index` → `col += index * numCols`
- `tmem_subslice` → `getTMemSubSliceOffset()` (low 16 bits column, high 16 bits row)
- `memdesc_reinterpret` / `trans` / `reshape` → base unchanged

Each offset is computed with the same helper the corresponding lowering uses, so
the analysis cannot drift from the addresses actually generated.

Anything unresolved falls back to the whole allocation, so a view can never be
made to look narrower than it is:

| situation | behaviour |
|---|---|
| dynamic `memdesc_index` | mark unknown → whole allocation |
| unmodelled view op | mark unknown → whole allocation |
| missing `tensor_memory_*_offset` attribute | whole address space |
| row offset not 16-aligned / rows not a multiple of 64 | whole address space |

No hazard rule changes. Behaviour for genuinely overlapping accesses is identical,
and every hazard kind (WAR/RAW/WAW and the load→MMA / store→MMA cases) benefits,
since they all share this interval computation.

## Performance

Measured on `_attn_fwd_ws` in
[`blackwell_fa_ws_pipelined_persistent.py`](https://github.com/facebookexperimental/triton/blob/c3966b8c7b79b8ef4bc25b001152ad1b71aa5e25/third_party/tlx/tutorials/blackwell_fa_ws_pipelined_persistent.py#L285),
a downstream warp-specialized Blackwell Flash-Attention forward kernel. It uses
multi-buffered TMEM accumulators heavily — the
[`NUM_MMA_GROUPS`-deep allocations](https://github.com/facebookexperimental/triton/blob/c3966b8c7b79b8ef4bc25b001152ad1b71aa5e25/third_party/tlx/tutorials/blackwell_fa_ws_pipelined_persistent.py#L391)
are exactly the 3D `tensor_memory` memdesc shape sketched above. B200,
clock-locked, `BATCH=4, H=32, HEAD_DIM=128`, non-causal, 20 interleaved
repetitions per arm. The pass inserts 21 barriers there; this patch shows 10 of
them to be unnecessary.

| N_CTX | 1024 | 2048 | 4096 | 8192 |
|---|---|---|---|---|
| speedup | +2.15% | +1.26% | +3.08% | +1.15% |
| P(faster) | 0.90 | 0.60 | 1.00 | 0.95 |

Relative to the scheme this pass replaced (an unconditional barrier after every
TMEM store) the cumulative gain is +2.3% to +4.1%.

Upstream kernels use only single-buffered TMEM today, so this is not reproducible
in-tree; the added lit cases pin the modelling behaviour instead.

### Where the time actually goes

Profiled with Nsight Compute 2026.2.1 at N_CTX=4096, single launch after autotune.
The mechanism is not the obvious one, and it generalises beyond this kernel.

The work is identical — only the rendezvous count changes (`BAR.SYNC` 84 → 78;
`LDTM` 18 and `STTM` 14 unchanged). Occupancy is also unchanged (24.99% → 24.97%,
16 active warps/SM). What changes is how many resident warps can issue:

| | before | after |
|---|---|---|
| eligible warps per scheduler | 0.39 | **0.43** (+10.3%) |
| scheduler cycles with no eligible warp | 66.44% | **64.37%** |
| warp cycles per issued instruction | 11.41 | **11.01** |
| compute (SM) throughput | 62.59% | 64.33% |

Decomposing that −0.40 warp-cycles:

| stall reason | Δ | share |
|---|---|---|
| long scoreboard | **−0.270** | **67%** |
| dispatch stall | −0.110 | 27% |
| **barrier** | **−0.080** | **20%** |
| mio throttle | −0.040 | |
| wait / math pipe / short scoreboard | +0.130 | against |

Only 20% of the gain is time saved waiting at the barrier itself. Two thirds is
reduced long-scoreboard stall — waiting on memory — even though no memory
instruction changed. A barrier does not merely cost its own wait: it re-aligns the
warps, so they then reach the same long-latency load together and stall together
with nothing left for the scheduler to issue. Without it they keep a phase offset
and cover each other's latency. This kernel is severely latency-bound (0.39 of 4
warps per scheduler eligible on average), so that phase offset is essentially its
only latency-hiding mechanism.

## Test plan

`test/TritonNvidiaGPU/tmem_barrier_insertion.mlir` gains five cases:

- `@disjoint_buffer_slots` — the motivating case; load slot 0, store slot 1, no barrier
- `@same_buffer_slot` — same slot, barrier still inserted
- `@disjoint_subslices` — `tmem_subslice` on disjoint columns, no barrier
- `@overlapping_subslices` — overlapping columns, barrier inserted
- `@dynamic_index_conservative` — non-constant index, barrier inserted (fallback)

Existing cases are unchanged, including `@ld_then_st`.

---

Authored with Claude.
