### PR TITLE
[AMD][LAYOUTS] Restrict low-vector swizzle reorder to <=32 banks

### DIFF
--- a/lib/Tools/GenericSwizzling.cpp
+++ b/lib/Tools/GenericSwizzling.cpp
@@ -627,7 +627,7 @@ LinearLayout optimalSwizzlingLdSt(const LinearLayout &src,
   // e.g for fp32
   // src = {reg = [], lane = [1, 2, 4, 8, 16], warp = [32]}
   // dst = {reg = [8, 32], lane = [0, 0, 1, 2, 4], warp = [16]}
-  if (log2Vec < 2) {
+  if (log2Vec < 2 && numBanks <= 32) {
     auto smemFlat = smem.flattenOuts();
     // For every bank line, find if it is in regSrc or regDst
     // and if so, store the index in the vector

--- a/unittest/Dialect/TritonGPU/SwizzleTest.cpp
+++ b/unittest/Dialect/TritonGPU/SwizzleTest.cpp
@@ -19,6 +19,7 @@ using namespace mlir;
 using namespace mlir::triton;
 
 using mlir::triton::gpu::bankConflictsLdSt;
+using mlir::triton::gpu::getVecBitwidthLdSt;
 using mlir::triton::gpu::LocalMemOpTile;
 using mlir::triton::gpu::optimalSwizzling;
 using mlir::triton::gpu::optimalSwizzlingLdSt;
@@ -633,6 +634,32 @@ TEST_F(BankConflictTest, bankConflictsWavefront64) {
         << attrStr(c.reg) << "\n"
         << attrStr(c.shared);
   }
+}
+
+TEST_F(BankConflictTest, LowVectorF32MmaConvertKeeps64BankRegisterBasisHigh) {
+  auto S = [&](StringRef str) { return StringAttr::get(&ctx, str); };
+  auto src = mfma(4, {4, 1}, {32, 32, 16}, true);
+  auto dst = mfma(4, {4, 1}, {16, 16, 32}, true);
+  SmallVector<int64_t> shape = {128, 1};
+  auto srcLLRaw = toLL(shape, src);
+  auto dstLLRaw = toLL(shape, dst);
+  auto srcLL = actionRemoveBroadcastedRegs(srcLLRaw).apply(srcLLRaw);
+  auto dstLL = actionRemoveBroadcastedRegs(dstLLRaw).apply(dstLLRaw);
+
+  EXPECT_EQ(getVecBitwidthLdSt(srcLL, dstLL, /*bitwidth=*/32), 32);
+
+  auto smem = optimalSwizzlingLdSt(srcLL, dstLL, /*bitwidth=*/32,
+                                   /*numBanks=*/64);
+  auto [readConflicts, writeConflicts] =
+      bankConflictsLdSt(srcLL, dstLL, smem, /*bitwidth=*/32, /*numBanks=*/64);
+  EXPECT_EQ(readConflicts, 0);
+  EXPECT_EQ(writeConflicts, 0);
+  EXPECT_EQ(smem.getInDimSize(S("bank")), 64);
+  EXPECT_EQ(smem.getInDimSize(S("segment")), 2);
+
+  auto dstToSmem = dstLL.invertAndCompose(smem);
+  EXPECT_EQ(dstToSmem.getBasis(S("register"), /*pos=*/0, S("bank")), 32);
+  EXPECT_EQ(dstToSmem.getBasis(S("register"), /*pos=*/0, S("segment")), 0);
 }
 
 } // namespace


### PR DESCRIPTION
This is the workaround to fix: https://github.com/llvm/llvm-project/issues/206825

On gfx950 (wavefront64, numBanks=64), the log2Vec<2 low-vector reorder in optimalSwizzlingLdSt rotates a destination register basis into the lowest bank bit. For the low-vector f32 `#mma->#mma1` convert this yields a contiguous shared layout that lowers to ds_read_b64; that contiguous cross-wavefront LDS read races in the LDS/MFMA schedule on gfx950.

Guard the reorder with numBanks<=32 so 64-bank targets keep the register basis on a high bank bit (strided ds_read2 lowering), while preserving PR #9662's 64-bank swizzle model. Bank-conflict-free either way; this only backs off the vectorization-boost reorder where it is unsafe.

Adds a regression test that the low-vector f32 mma convert keeps the register basis high (bank=32) with zero bank conflicts at numBanks=64.