### PR TITLE
[GSan] Deduplicate broadcast register accesses

### DIFF
--- a/lib/Conversion/TritonInstrumentToLLVM/GSanToLLVM.cpp
+++ b/lib/Conversion/TritonInstrumentToLLVM/GSanToLLVM.cpp
@@ -11,6 +11,7 @@
 #include "llvm/Support/LogicalResult.h"
 #include <limits>
 #include <type_traits>
+#include <utility>
 
 namespace tt = mlir::triton;
 namespace tti = mlir::triton::instrument;
@@ -128,10 +129,11 @@ materializeSourceLocation(ConversionPatternRewriter &rewriter, Location loc) {
 // Utility functions
 ////////////////////////////////////////////
 
-Value prepareTensorStackArg(ConversionPatternRewriter &rewriter, Location loc,
-                            ArrayRef<Value> ptrElems, ArrayRef<Value> maskElems,
-                            uint32_t regMask, Value threadPred,
-                            unsigned elemIndexStride) {
+std::pair<Value, unsigned>
+prepareTensorStackArg(ConversionPatternRewriter &rewriter, Location loc,
+                      ArrayRef<Value> ptrElems, ArrayRef<Value> maskElems,
+                      uint32_t regMask, Value threadPred,
+                      unsigned elemIndexStride) {
   auto *ctx = rewriter.getContext();
   TritonLLVMOpBuilder b(loc, rewriter);
   Value one = b.i32_val(1);
@@ -139,7 +141,9 @@ Value prepareTensorStackArg(ConversionPatternRewriter &rewriter, Location loc,
   Type i8Ty = rewriter.getI8Type();
   Type i64Ty = rewriter.getI64Type();
 
-  unsigned numElems = ptrElems.size();
+  unsigned numElems = 0;
+  for (unsigned i = 0; i < ptrElems.size(); ++i)
+    numElems += isCanonicalIndex(i * elemIndexStride, regMask);
   auto ptrArrayTy = array_ty(i64Ty, numElems);
   auto maskArrayTy = array_ty(i8Ty, numElems);
   SmallVector<Type> argsFieldTys = {ptrArrayTy, maskArrayTy};
@@ -147,16 +151,17 @@ Value prepareTensorStackArg(ConversionPatternRewriter &rewriter, Location loc,
   auto argsBuffer = LLVM::AllocaOp::create(rewriter, loc, ptr_ty(ctx), argsTy,
                                            one, /*alignment=*/0);
 
-  for (unsigned i = 0; i < numElems; ++i) {
-    Value idx = b.i32_val(i);
+  unsigned packedIndex = 0;
+  for (unsigned i = 0; i < ptrElems.size(); ++i) {
+    if (!isCanonicalIndex(i * elemIndexStride, regMask))
+      continue;
+    Value idx = b.i32_val(packedIndex++);
     Value ptrValue = b.ptrtoint(i64_ty, ptrElems[i]);
     Value ptrSlot =
         b.gep(ptr_ty(ctx), argsTy, argsBuffer, ValueRange{zero, zero, idx});
     b.store(ptrValue, ptrSlot);
 
     Value maskValue = maskElems.empty() ? b.true_val() : maskElems[i];
-    if (!isCanonicalIndex(i * elemIndexStride, regMask))
-      maskValue = b.false_val();
     maskValue = ttg::maybeAnd(rewriter, loc, maskValue, threadPred);
     Value maskByte = b.zext(i8Ty, maskValue);
     Value maskSlot =
@@ -164,7 +169,7 @@ Value prepareTensorStackArg(ConversionPatternRewriter &rewriter, Location loc,
     b.store(maskByte, maskSlot);
   }
 
-  return argsBuffer;
+  return {argsBuffer, numElems};
 }
 
 void emitTensorAccessRuntimeCall(ConversionPatternRewriter &rewriter,
@@ -177,15 +182,15 @@ void emitTensorAccessRuntimeCall(ConversionPatternRewriter &rewriter,
     return;
 
   TritonLLVMOpBuilder b(loc, rewriter);
-  auto stackPtr = prepareTensorStackArg(rewriter, loc, ptrElems, maskElems,
-                                        regMask, threadPred, elemIndexStride);
+  auto [stackPtr, numElems] = prepareTensorStackArg(
+      rewriter, loc, ptrElems, maskElems, regMask, threadPred, elemIndexStride);
   StringRef funcName =
       isStore ? kGSanStoreTensorRuntimeFn : kGSanLoadTensorRuntimeFn;
   auto runtimeFunc = getOrCreateGSanRuntimeFunction(rewriter, funcName);
   auto sourceLoc = materializeSourceLocation(rewriter, loc);
 
   b.call(runtimeFunc,
-         ValueRange{gsanGlobalStatePtr, stackPtr, b.i32_val(ptrElems.size()),
+         ValueRange{gsanGlobalStatePtr, stackPtr, b.i32_val(numElems),
                     b.i32_val(bytesPerElem), sourceLoc.file, sourceLoc.line});
 }
 
@@ -200,19 +205,18 @@ void emitAtomicTensorAccessRuntimeCall(ConversionPatternRewriter &rewriter,
     return;
 
   TritonLLVMOpBuilder b(loc, rewriter);
-  auto stackPtr =
+  auto [stackPtr, numElems] =
       prepareTensorStackArg(rewriter, loc, ptrElems, maskElems, regMask,
                             threadPred, /*elemIndexStride=*/1);
   auto runtimeFunc =
       getOrCreateGSanRuntimeFunction(rewriter, kGSanAtomicTensorRuntimeFn);
   auto sourceLoc = materializeSourceLocation(rewriter, loc);
 
-  b.call(runtimeFunc,
-         ValueRange{gsanGlobalStatePtr, stackPtr, b.i32_val(ptrElems.size()),
-                    b.i32_val(bytesPerElem),
-                    b.i32_val(static_cast<int32_t>(sem)),
-                    b.i32_val(static_cast<int32_t>(scope)), sourceLoc.file,
-                    sourceLoc.line});
+  b.call(runtimeFunc, ValueRange{gsanGlobalStatePtr, stackPtr,
+                                 b.i32_val(numElems), b.i32_val(bytesPerElem),
+                                 b.i32_val(static_cast<int32_t>(sem)),
+                                 b.i32_val(static_cast<int32_t>(scope)),
+                                 sourceLoc.file, sourceLoc.line});
 }
 
 unsigned getCanonicalIndex(unsigned index, unsigned freeVarMask) {
@@ -468,7 +472,7 @@ public:
                               maskAlign, bytesPerElem);
 
     auto ctx = op.getContext();
-    auto kReg = str_attr("reg");
+    auto kReg = str_attr("register");
     auto freeVarMasks = getFreeVariableMasks(ptrTy);
     auto threadPred = ttg::emitRedundantThreadPredicate(freeVarMasks, rewriter,
                                                         loc, *targetInfo);
@@ -529,7 +533,7 @@ public:
                               maskAlign, bytesPerElem);
 
     auto ctx = op.getContext();
-    auto kReg = str_attr("reg");
+    auto kReg = str_attr("register");
     auto freeVarMasks = getFreeVariableMasks(ptrTy);
     auto regMask = freeVarMasks.lookup(kReg);
     auto threadPred = ttg::emitRedundantThreadPredicate(freeVarMasks, rewriter,
@@ -645,7 +649,7 @@ public:
     auto freeVarMasks = getFreeVariableMasks(op.getPtr().getType());
     Value threadPred = ttg::emitRedundantThreadPredicate(freeVarMasks, rewriter,
                                                          loc, *targetInfo);
-    uint32_t regMask = freeVarMasks.lookup(str_attr("reg"));
+    uint32_t regMask = freeVarMasks.lookup(str_attr("register"));
     auto sourceLoc = materializeSourceLocation(rewriter, loc);
     auto eventStateTy = getGSanAtomicEventStateType(rewriter);
     Value eventState = LLVM::AllocaOp::create(rewriter, loc, ptr_ty(ctx),
@@ -750,7 +754,7 @@ public:
     auto freeVarMasks = getFreeVariableMasks(op.getPtr().getType());
     Value threadPred = ttg::emitRedundantThreadPredicate(freeVarMasks, rewriter,
                                                          loc, *targetInfo);
-    uint32_t regMask = freeVarMasks.lookup(str_attr("reg"));
+    uint32_t regMask = freeVarMasks.lookup(str_attr("register"));
     auto sourceLoc = materializeSourceLocation(rewriter, loc);
     auto eventStateTy = getGSanAtomicEventStateType(rewriter);
     Value eventState = LLVM::AllocaOp::create(rewriter, loc, ptr_ty(ctx),

--- a/test/Conversion/tritongpu_to_llvm_gsan.mlir
+++ b/test/Conversion/tritongpu_to_llvm_gsan.mlir
@@ -140,6 +140,44 @@ module attributes {"ttg.instrumentation_mode" = "gsan", "ttg.num-ctas" = 2 : i32
 
 // -----
 
+#broadcasted_registers = #ttg.blocked<{sizePerThread = [4], threadsPerWarp = [32], warpsPerCTA = [4], order = [0]}>
+
+module attributes {"ttg.instrumentation_mode" = "gsan", "ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, "ttg.threads-per-warp" = 32 : i32} {
+  // CHECK-LABEL: llvm.func @gsan_canonical_register_accesses
+  // CHECK: llvm.alloca %{{.*}} x !llvm.struct<(array<1 x i64>, array<1 x i8>)>
+  // CHECK: %[[LOAD_COUNT:.*]] = llvm.mlir.constant(1 : i32) : i32
+  // CHECK: llvm.call @__triton_gsan_load_tensor(%{{.*}}, %{{.*}}, %[[LOAD_COUNT]], %{{.*}}, %{{.*}}, %{{.*}})
+  // CHECK: llvm.alloca %{{.*}} x !llvm.struct<(array<1 x i64>, array<1 x i8>)>
+  // CHECK: %[[STORE_COUNT:.*]] = llvm.mlir.constant(1 : i32) : i32
+  // CHECK: llvm.call @__triton_gsan_store_tensor(%{{.*}}, %{{.*}}, %[[STORE_COUNT]], %{{.*}}, %{{.*}}, %{{.*}})
+  tt.func @gsan_canonical_register_accesses(
+      %ptrs: tensor<1x!tt.ptr<i32>, #broadcasted_registers>,
+      %vals: tensor<1xi32, #broadcasted_registers>,
+      %mask: tensor<1xi1, #broadcasted_registers>) {
+    %loaded = tt.load %ptrs, %mask : tensor<1x!tt.ptr<i32>, #broadcasted_registers>
+    tt.store %ptrs, %vals, %mask : tensor<1x!tt.ptr<i32>, #broadcasted_registers>
+    tt.return
+  }
+
+  // CHECK-LABEL: llvm.func @gsan_distinct_register_accesses
+  // CHECK: llvm.alloca %{{.*}} x !llvm.struct<(array<4 x i64>, array<4 x i8>)>
+  // CHECK: %[[DISTINCT_LOAD_COUNT:.*]] = llvm.mlir.constant(4 : i32) : i32
+  // CHECK: llvm.call @__triton_gsan_load_tensor(%{{.*}}, %{{.*}}, %[[DISTINCT_LOAD_COUNT]], %{{.*}}, %{{.*}}, %{{.*}})
+  // CHECK: llvm.alloca %{{.*}} x !llvm.struct<(array<4 x i64>, array<4 x i8>)>
+  // CHECK: %[[DISTINCT_STORE_COUNT:.*]] = llvm.mlir.constant(4 : i32) : i32
+  // CHECK: llvm.call @__triton_gsan_store_tensor(%{{.*}}, %{{.*}}, %[[DISTINCT_STORE_COUNT]], %{{.*}}, %{{.*}}, %{{.*}})
+  tt.func @gsan_distinct_register_accesses(
+      %ptrs: tensor<128x!tt.ptr<i32>, #broadcasted_registers>,
+      %vals: tensor<128xi32, #broadcasted_registers>,
+      %mask: tensor<128xi1, #broadcasted_registers>) {
+    %loaded = tt.load %ptrs, %mask : tensor<128x!tt.ptr<i32>, #broadcasted_registers>
+    tt.store %ptrs, %vals, %mask : tensor<128x!tt.ptr<i32>, #broadcasted_registers>
+    tt.return
+  }
+}
+
+// -----
+
 module attributes {"ttg.instrumentation_mode" = "gsan", "ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 1 : i32, "ttg.target" = "cuda:80", "ttg.threads-per-warp" = 32 : i32} {
   // CHECK-LABEL: llvm.func @gsan_atomic_broadcast_one_cta
   // CHECK: llvm.call @__triton_gsan_atomic_end_scalar


### PR DESCRIPTION
GSAN computes the register mask and only checks the non-duplicated values. However the typo "reg" vs "register" meant this mask was always set. Fix the typo, and further optimize it by trimming masked values from the GSAN state to improve compile time and runtime by like 5-8%.

## Stack
Merge bottom-up:
- [ ] #11172 (this PR)
