### PR TITLE
fix(autotuner): release CUDA memory retained by failed configs

### DIFF
--- a/python/test/unit/runtime/test_autotuner.py
+++ b/python/test/unit/runtime/test_autotuner.py
@@ -6,6 +6,7 @@ import pytest
 
 import pathlib
 import uuid
+import weakref
 from triton._internal_testing import is_cuda, is_hip_cdna2, is_rubin
 
 
@@ -13,6 +14,30 @@ def do_bench(kernel_call, quantiles, use_cuda_graph=False):
     if use_cuda_graph:
         return triton.testing.do_bench_cudagraph(kernel_call, quantiles=quantiles)
     return triton.testing.do_bench(kernel_call, quantiles=quantiles, warmup=1, rep=1)
+
+
+def test_autotuner_releases_failed_benchmark_arguments():
+
+    class Payload:
+        pass
+
+    def kernel():
+        pass
+
+    def failing_bench(kernel_call, quantiles):
+        error = triton.OutOfResources(2, 1, "test resource")
+        raise error
+
+    config = triton.Config({})
+    tuner = triton.runtime.Autotuner(kernel, [], [config], [], None, None, do_bench=failing_bench)
+    tuner.nargs = {}
+
+    payload = Payload()
+    payload_ref = weakref.ref(payload)
+    tuner._bench(payload, config=config)
+    del payload
+
+    assert payload_ref() is None
 
 
 @pytest.mark.parametrize('use_cuda_graph', [False, True])

--- a/python/triton/runtime/autotuner.py
+++ b/python/triton/runtime/autotuner.py
@@ -170,6 +170,7 @@ class Autotuner(KernelInterface):
         except (OutOfResources, CompileTimeAssertionFailure, PTXASError) as e:
             if verbose:
                 print(f"Autotuning failed with {e}")
+            e.__traceback__ = None
             return [float("inf"), float("inf"), float("inf")]
 
     def check_disk_cache(self, tuning_key, configs, bench_fn):


### PR DESCRIPTION
# New contributor declaration
- [x] I am not making a trivial change, such as fixing a typo in a comment.

- [x] I have written a PR description following these
  [rules](https://cbea.ms/git-commit/#why-not-how).

- [x] I have run `pre-commit run --from-ref origin/main --to-ref HEAD`.

- Select one of the following.
  - [x] I have added tests.
    - `/test` for `lit` tests
    - `/unittest` for C++ tests
    - `/python/test` for end-to-end tests
  - [ ] This PR does not need a test because `FILL THIS IN`.

- Select one of the following.
  - [x] I have not added any `lit` tests.
  - [ ] The `lit` tests I have added follow these [best practices](https://mlir.llvm.org/getting_started/TestingGuide/#filecheck-best-practices), including the "tests should be minimal" section.

---

## Summary

Failed autotune configurations can retain their Python traceback and keep
large CUDA tensors alive after tuning completes. This can cause later kernel
launches to OOM even when they reuse the cached winning configuration and do
not autotune again.

During autotuning, Triton may reject a kernel configuration because it uses
too many hardware resources. Triton catches this expected failure and tries
the next configuration.

The caught exception can retain its traceback. That traceback retains the
`Autotuner._bench` frame, which in turn retains the kernel arguments and
benchmark closure. When a raising frame also holds the exception, these
references form a cycle:

```text
exception -> traceback -> frames
                         |- raising frame -> local exception (cycle)
                         `- _bench frame -> kernel arguments
```

For large kernels, those arguments can include large CUDA tensors. The
rejected configuration is gone, but the tensors remain live until Python's
cyclic garbage collector eventually runs. Python GC is driven by host object
allocations and does not react directly to CUDA memory pressure.

This change clears the traceback after optional verbose logging. The rejected
benchmark's arguments can then be released as soon as `_bench` returns.
Exception messages, post-hooks, successful configurations, and unexpected
exceptions are unchanged.

## Regression test

The new test reproduces the cycle with a weak-referenced Python object and a
synthetic `OutOfResources` failure. It does not require a GPU or allocate
device memory.

Before the fix, the object remains alive until `gc.collect()`. After the fix,
it is released when `_bench` returns.

## Test plan

- Added `test_autotuner_releases_failed_benchmark_arguments`.
- Verified the regression check retains the payload on `upstream/main` and
  releases it with this change.
- `pre-commit run --from-ref origin/main --to-ref HEAD`
- `git diff --check upstream/main...HEAD`
