### PR TITLE
Add CLC mode to triton_kernels matmul

### DIFF
--- a/python/triton_kernels/tests/test_matmul_details/test_opt_flags_nvidia.py
+++ b/python/triton_kernels/tests/test_matmul_details/test_opt_flags_nvidia.py
@@ -180,6 +180,29 @@ def test_matmul_blackwell_scale_small_n(device):
     assert_close(ref_y, tri_y, maxtol=3e-2, rmstol=None)
 
 
+def test_matmul_clc(device):
+    if device != "cuda" or not torch.cuda.is_available() or not is_cuda():
+        pytest.skip("requires CUDA")
+    if torch.cuda.get_device_capability()[0] < 10:
+        pytest.skip("requires Blackwell or newer")
+
+    torch.manual_seed(0)
+    m, n, k = 4096, 1024, 128
+    a = torch.randn((m, k), device=device, dtype=torch.bfloat16)
+    b = torch.randn((k, n), device=device, dtype=torch.bfloat16)
+    with scoped_opt_flags_constraints({
+            "clc": True,
+            "block_m": 128,
+            "block_n": 128,
+            "block_k": 64,
+            "split_k": 1,
+    }):
+        tri_y = matmul(a, b, None)
+
+    ref_y = matmul_torch(a, b, None, precision_config=PrecisionConfig())
+    assert_close(ref_y, tri_y, maxtol=3e-2, rmstol=None)
+
+
 def test_matmul_blackwell_shuffled_mxfp4_weight(device):
     if device != "cuda" or not torch.cuda.is_available():
         pytest.skip("requires CUDA")

--- a/python/triton_kernels/tests/test_matmul_details/test_opt_flags_nvidia.py
+++ b/python/triton_kernels/tests/test_matmul_details/test_opt_flags_nvidia.py
@@ -13,6 +13,7 @@ from triton_kernels.tensor import FP4, UINT8, Storage, Tensor, convert_layout, w
 from triton_kernels.tensor_details import layout
 from triton_kernels.tensor_details.layout import BlackwellMX4ValueShuffledLayout
 from triton_kernels.tensor_details.layout_details.blackwell_scale import BlackwellMXScaleLayout
+from triton_kernels.tensor_details.ragged_tensor import make_ragged_tensor_metadata_torch
 from triton_kernels.testing import assert_close
 
 
@@ -180,7 +181,8 @@ def test_matmul_blackwell_scale_small_n(device):
     assert_close(ref_y, tri_y, maxtol=3e-2, rmstol=None)
 
 
-def test_matmul_clc(device):
+@pytest.mark.parametrize("split_k", [1, 2])
+def test_matmul_clc(device, split_k):
     if device != "cuda" or not torch.cuda.is_available() or not is_cuda():
         pytest.skip("requires CUDA")
     if torch.cuda.get_device_capability()[0] < 10:
@@ -195,12 +197,27 @@ def test_matmul_clc(device):
             "block_m": 128,
             "block_n": 128,
             "block_k": 64,
-            "split_k": 1,
+            "split_k": split_k,
     }):
         tri_y = matmul(a, b, None)
 
     ref_y = matmul_torch(a, b, None, precision_config=PrecisionConfig())
     assert_close(ref_y, tri_y, maxtol=3e-2, rmstol=None)
+
+
+def test_matmul_clc_rejects_ragged_m_grid(device):
+    if device != "cuda" or not torch.cuda.is_available() or not is_cuda():
+        pytest.skip("requires CUDA")
+    if torch.cuda.get_device_capability()[0] < 10:
+        pytest.skip("requires Blackwell or newer")
+
+    slice_sizes = torch.tensor([64, 0, 64], dtype=torch.int32, device=device)
+    metadata = make_ragged_tensor_metadata_torch(slice_sizes, 128)
+    a = torch.randn((128, 64), device=device, dtype=torch.bfloat16)
+    b = torch.randn((3, 64, 128), device=device, dtype=torch.bfloat16)
+    with scoped_opt_flags_constraints({"clc": True}):
+        with pytest.raises(InapplicableConstraint, match="host-known grid"):
+            matmul(a, b, None, a_ragged_metadata=metadata)
 
 
 def test_matmul_blackwell_shuffled_mxfp4_weight(device):

--- a/python/triton_kernels/triton_kernels/matmul.py
+++ b/python/triton_kernels/triton_kernels/matmul.py
@@ -432,6 +432,10 @@ def matmul(a, b, bias,
         rhs_layout=b.storage.layout,
         epilogue_reduction_n=fused_activation.specs.reduction_n,
     )
+    if opt_flags.clc and ragged_dimension == "M":
+        raise InapplicableConstraint("CLC requires a host-known grid and does not support ragged-M matmul")
+    if opt_flags.clc and opt_flags.idle_sms:
+        raise InapplicableConstraint("CLC does not support leaving SMs idle")
     if b_is_shuffled:
         if b.dtype.bitwidth != 4:
             raise ValueError("Shuffled weights are only supported for mxfp4 values")
@@ -509,7 +513,7 @@ def matmul(a, b, bias,
         grid_m = a_ragged_metadata.n_blocks(a_ragged_metadata.n_slices, M, opt_flags.block_m)
     grid_n = triton.cdiv(N, opt_flags.block_n)
     grid = batch_size * grid_m * grid_n * opt_flags.split_k
-    if opt_flags.is_persistent:
+    if opt_flags.is_persistent and not opt_flags.clc:
         available_sms = target_info.num_sms() - opt_flags.idle_sms
         grid = min(opt_flags.occupancy_target * available_sms, grid)
     # canonicalize storage
@@ -645,6 +649,8 @@ def matmul(a, b, bias,
     } if fused_comm is not None else {}
     b_strides = b.storage.data.stride()[:3] if b_is_shuffled else b.storage.data.stride()
     extra_kernel_kwargs = {"W_SHUFFLED": b_is_shuffled} if opt_flags.is_persistent else {}
+    if opt_flags.clc:
+        extra_kernel_kwargs.update(CLC=True, clc=True)
     n_valid_slices = b_tensor_or_tma.shape[0] if ragged_dimension == "M" else n_slices
     (kernels._p_matmul if opt_flags.is_persistent else kernels._matmul)[(grid,)](
                    c_tensor_or_tma, c.storage.data, *out_matmul.stride(),

--- a/python/triton_kernels/triton_kernels/matmul_details/_p_matmul.py
+++ b/python/triton_kernels/triton_kernels/matmul_details/_p_matmul.py
@@ -246,8 +246,8 @@ def _p_matmul(
 
     DISALLOW_ACC_MULTI_BUFFER: tl.constexpr = is_w_microscaled and BLOCK_M * BLOCK_N >= 128 * 256
 
-    loop_start = 0 if CLC else tl.program_id(0)
-    loop_end = 1 if CLC else num_blocks
+    loop_start = tl.program_id(0)
+    loop_end = loop_start + 1 if CLC else num_blocks
     loop_step = 1 if CLC else NUM_SMS
     for block_id in tl.range(
         loop_start, loop_end, loop_step,
@@ -256,9 +256,6 @@ def _p_matmul(
         # Workaround for compile error in hopper warp specialization
         warp_specialize=FLATTEN_LOOPS and not CLC,
     ):
-        if CLC:
-            block_id = tl.program_id(0)
-
         pid_z, pid_m, pid_n, pid_k = compute_pids(block_id, useful_grid_m, grid_n, num_blocks, XCD_SWIZZLE, GROUP_M, SPLIT_K)
 
         # ------------------------------------------------------------

--- a/python/triton_kernels/triton_kernels/matmul_details/_p_matmul.py
+++ b/python/triton_kernels/triton_kernels/matmul_details/_p_matmul.py
@@ -120,6 +120,7 @@ def _p_matmul(
              SWAP_XW: tl.constexpr = False,
              IS_EPILOGUE_QUANT_MX: tl.constexpr = False,
              Y_VALUE_PACK_FACTOR: tl.constexpr = 1,
+             CLC: tl.constexpr = False,
              FLATTEN_LOOPS: tl.constexpr = True,
              W_SHUFFLED: tl.constexpr = False,
              pYPtrs=None,
@@ -245,13 +246,18 @@ def _p_matmul(
 
     DISALLOW_ACC_MULTI_BUFFER: tl.constexpr = is_w_microscaled and BLOCK_M * BLOCK_N >= 128 * 256
 
+    loop_start = 0 if CLC else tl.program_id(0)
+    loop_end = 1 if CLC else num_blocks
+    loop_step = 1 if CLC else NUM_SMS
     for block_id in tl.range(
-        tl.program_id(0), num_blocks, NUM_SMS,
-        flatten=FLATTEN_LOOPS,
+        loop_start, loop_end, loop_step,
+        flatten=FLATTEN_LOOPS and not CLC,
         disallow_acc_multi_buffer=DISALLOW_ACC_MULTI_BUFFER,
         # Workaround for compile error in hopper warp specialization
-        warp_specialize=FLATTEN_LOOPS,
+        warp_specialize=FLATTEN_LOOPS and not CLC,
     ):
+        if CLC:
+            block_id = tl.program_id(0)
 
         pid_z, pid_m, pid_n, pid_k = compute_pids(block_id, useful_grid_m, grid_n, num_blocks, XCD_SWIZZLE, GROUP_M, SPLIT_K)
 

--- a/python/triton_kernels/triton_kernels/matmul_details/_p_matmul.py
+++ b/python/triton_kernels/triton_kernels/matmul_details/_p_matmul.py
@@ -246,8 +246,8 @@ def _p_matmul(
 
     DISALLOW_ACC_MULTI_BUFFER: tl.constexpr = is_w_microscaled and BLOCK_M * BLOCK_N >= 128 * 256
 
-    loop_start = tl.program_id(0)
-    loop_end = loop_start + 1 if CLC else num_blocks
+    loop_start = 0 if CLC else tl.program_id(0)
+    loop_end = 1 if CLC else num_blocks
     loop_step = 1 if CLC else NUM_SMS
     for block_id in tl.range(
         loop_start, loop_end, loop_step,
@@ -256,6 +256,9 @@ def _p_matmul(
         # Workaround for compile error in hopper warp specialization
         warp_specialize=FLATTEN_LOOPS and not CLC,
     ):
+        if CLC:
+            block_id = tl.program_id(0)
+
         pid_z, pid_m, pid_n, pid_k = compute_pids(block_id, useful_grid_m, grid_n, num_blocks, XCD_SWIZZLE, GROUP_M, SPLIT_K)
 
         # ------------------------------------------------------------

--- a/python/triton_kernels/triton_kernels/matmul_details/opt_flags.py
+++ b/python/triton_kernels/triton_kernels/matmul_details/opt_flags.py
@@ -34,6 +34,7 @@ class OptFlags:
     arch: str
     occupancy_target: int
     target_kernel_kwargs: dict
+    clc: bool = False
 
 
 def max_allowable_mn(
@@ -185,6 +186,7 @@ def make_default_opt_flags_amd(
         w_cache_modifier=w_cache_modifier,
         split_k=split_k,
         is_persistent=is_persistent,
+        clc=False,
         idle_sms=constraints.get("idle_sms", _get_idle_sms()),
         epilogue_subtile=epilogue_subtile,
         arch=None,
@@ -218,7 +220,7 @@ def make_default_opt_flags_nvidia(
     mx_block_size=None,
     epilogue_reduction_n=1,
 ):
-    constraints_supported = {"block_m", "block_n", "block_k", "split_k", "is_persistent", "epilogue_subtile", "num_stages", "idle_sms", "max_allowable_mn", "num_warps", "disable_mx4_block_swap"}
+    constraints_supported = {"block_m", "block_n", "block_k", "split_k", "is_persistent", "clc", "epilogue_subtile", "num_stages", "idle_sms", "max_allowable_mn", "num_warps", "disable_mx4_block_swap"}
     unsupported = set(constraints.keys()) - constraints_supported
     assert not unsupported, f"Given unsupported constraint: {unsupported}"
     is_large_ragged_nvfp4 = (
@@ -282,6 +284,14 @@ def make_default_opt_flags_nvidia(
     n_sms = torch.cuda.get_device_properties(0).multi_processor_count
     tiles_per_sm = grid_size_tma / n_sms
     supports_persistent = can_use_persistent_tma and (arch is None or int(arch[2:-1]) >= 9)
+    clc = constraints.get("clc", False)
+    if clc:
+        if not cuda_capability_geq(10, 0):
+            raise InapplicableConstraint("cannot enforce `clc=True` constraint before NVIDIA SM100")
+        if not supports_persistent:
+            raise InapplicableConstraint("cannot enforce `clc=True` constraint without persistent TMA support")
+        if constraints.get("is_persistent", True) is False:
+            raise InapplicableConstraint("`clc=True` requires `is_persistent=True`")
     a_mx_scale_layout = None if not isinstance(precision_config.a_mx_scale, Tensor) else precision_config.a_mx_scale.storage.layout
     b_mx_scale_layout = None if not isinstance(precision_config.b_mx_scale, Tensor) else precision_config.b_mx_scale.storage.layout
 
@@ -289,7 +299,9 @@ def make_default_opt_flags_nvidia(
         return layout is None or isinstance(layout, StridedLayout)
 
     requires_persistent = (not _is_layout_strided(a_mx_scale_layout) or not _is_layout_strided(b_mx_scale_layout)) and target_info.has_native_mxfp()
-    if constraints.get("is_persistent", None) is not None:
+    if clc:
+        is_persistent = True
+    elif constraints.get("is_persistent", None) is not None:
         if requires_persistent and not constraints["is_persistent"]:
             raise InapplicableConstraint("cannot enforce `is_persistent=False` constraint because persistent kernel is required")
         is_persistent = constraints["is_persistent"]
@@ -437,6 +449,7 @@ def make_default_opt_flags_nvidia(
         w_cache_modifier=None,
         split_k=split_k,
         is_persistent=is_persistent,
+        clc=clc,
         epilogue_subtile=epilogue_subtile,
         arch=arch,
         target_kernel_kwargs=dict(


### PR DESCRIPTION
Adds an opt-flags CLC mode for NVIDIA SM100+ matmuls. The mode reuses the persistent TMA kernel body, launches the full logical grid, and specializes away the software persistent scheduling loop when CLC is enabled. Ragged-M and idle-SM configurations are rejected because CLC needs an exact host-known grid.

Validated on GB200 with dense and split-K matmuls, plus coverage for ragged-M rejection. The focused pytest selection passes all three tests, and generated PTX contains `clusterlaunchcontrol.try_cancel`.
