### PR TITLE
Support independent activation scale TMA modes

### DIFF
--- a/python/triton_kernels/triton_kernels/matmul.py
+++ b/python/triton_kernels/triton_kernels/matmul.py
@@ -647,6 +647,7 @@ def matmul(a, b, bias,
     } if fused_comm is not None else {}
     b_strides = b.storage.data.stride()[:3] if b_is_shuffled else b.storage.data.stride()
     extra_kernel_kwargs = {"W_SHUFFLED": b_is_shuffled} if opt_flags.is_persistent else {}
+    # Only pass the new mode when it differs; omitted/default None preserves pre-PR behavior.
     if a_scale_tma_mode != a_tma_mode:
         extra_kernel_kwargs["X_SCALE_TMA_MODE"] = a_scale_tma_mode
     n_valid_slices = b_tensor_or_tma.shape[0] if ragged_dimension == "M" else n_slices

--- a/python/triton_kernels/triton_kernels/matmul.py
+++ b/python/triton_kernels/triton_kernels/matmul.py
@@ -589,11 +589,13 @@ def matmul(a, b, bias,
         b_scale_tensor_or_tma = None if b_scale is None else b_scale.storage.data
     # create tma descriptor for x_scale
     a_scale_has_tma = False
+    a_scale_tma_mode = None
     if a_has_mx and isinstance(a_scale.storage.layout, BlackwellActMXScaleLayout):
         # check if we can use tma for x scale
         assert opt_flags.is_persistent, "swizzled x scale is only supported for persistent case"
         assert opt_flags.block_m == 128 and opt_flags.block_k >= 128, "block_m and block_k must be at least 128 if x scale is swizzled"
         a_scale_has_tma = True
+        a_scale_tma_mode = "ragged" if a_scale.storage.layout.ragged_metadata is not None else "dense"
     if a_scale_has_tma:
         scale_block_k = opt_flags.block_k // mx_block_size
         a_scale_tma_block_size = [opt_flags.block_m, scale_block_k]
@@ -645,6 +647,8 @@ def matmul(a, b, bias,
     } if fused_comm is not None else {}
     b_strides = b.storage.data.stride()[:3] if b_is_shuffled else b.storage.data.stride()
     extra_kernel_kwargs = {"W_SHUFFLED": b_is_shuffled} if opt_flags.is_persistent else {}
+    if a_scale_tma_mode != a_tma_mode:
+        extra_kernel_kwargs["X_SCALE_TMA_MODE"] = a_scale_tma_mode
     n_valid_slices = b_tensor_or_tma.shape[0] if ragged_dimension == "M" else n_slices
     (kernels._p_matmul if opt_flags.is_persistent else kernels._matmul)[(grid,)](
                    c_tensor_or_tma, c.storage.data, *out_matmul.stride(),

--- a/python/triton_kernels/triton_kernels/matmul_details/_p_matmul.py
+++ b/python/triton_kernels/triton_kernels/matmul_details/_p_matmul.py
@@ -383,16 +383,14 @@ def _p_matmul(
                     mask_m = off_m + tl.arange(0, BLOCK_M) < shape_m
                     x_scales = tl.load(XMxScalePtrs, mask=mask_k_scale[None, :] & mask_m[:, None], other=0.0)
                 else: # use TMA for x scale load - only cover batched case for now
-                    if X_SCALE_TMA_MODE is None:
-                        if X_TMA_MODE == "dense":
-                            off_m_scale = off_x_z * ((M + 127) // 128) + off_m // 128
-                        else:
-                            tl.static_assert(X_TMA_MODE == "ragged")
-                            off_m_scale = slice_block_off_m + off_m // 128
-                    elif X_SCALE_TMA_MODE == "dense":
+                    # Defaults to X_TMA_MODE.
+                    x_scale_tma_mode: tl.constexpr = X_TMA_MODE if X_SCALE_TMA_MODE is None else X_SCALE_TMA_MODE
+                    if x_scale_tma_mode == "dense":
+                        # Address dense scales independently of the activation-value layout.
                         off_m_scale = off_x_z * ((M + 127) // 128) + off_m // 128
                     else:
-                        tl.static_assert(X_SCALE_TMA_MODE == "ragged")
+                        # Address preswizzled scales by ragged slice, independently of dense gathered values.
+                        tl.static_assert(x_scale_tma_mode == "ragged")
                         # slice_block_off_m points to the start of the current slice in the padded version
                         # + off_m points to the current block in the slice
                         off_m_scale = slice_block_off_m + off_m // 128

--- a/python/triton_kernels/triton_kernels/matmul_details/_p_matmul.py
+++ b/python/triton_kernels/triton_kernels/matmul_details/_p_matmul.py
@@ -113,6 +113,7 @@ def _p_matmul(
              NUM_SMS: tl.constexpr,
              X_TMA_MODE: tl.constexpr,
              Y_TMA_MODE: tl.constexpr,
+             X_SCALE_TMA_MODE: tl.constexpr = None,
              Y_MX_SCALE_LAYOUT: tl.constexpr = None,
              OUT_N_TILE_ALIGNED: tl.constexpr = False,
              TOKENS_PER_EXPT_FOR_ANNOTATION=None,
@@ -382,9 +383,16 @@ def _p_matmul(
                     mask_m = off_m + tl.arange(0, BLOCK_M) < shape_m
                     x_scales = tl.load(XMxScalePtrs, mask=mask_k_scale[None, :] & mask_m[:, None], other=0.0)
                 else: # use TMA for x scale load - only cover batched case for now
-                    if X_TMA_MODE == "dense":
+                    if X_SCALE_TMA_MODE is None:
+                        if X_TMA_MODE == "dense":
+                            off_m_scale = off_x_z * ((M + 127) // 128) + off_m // 128
+                        else:
+                            tl.static_assert(X_TMA_MODE == "ragged")
+                            off_m_scale = slice_block_off_m + off_m // 128
+                    elif X_SCALE_TMA_MODE == "dense":
                         off_m_scale = off_x_z * ((M + 127) // 128) + off_m // 128
                     else:
+                        tl.static_assert(X_SCALE_TMA_MODE == "ragged")
                         # slice_block_off_m points to the start of the current slice in the padded version
                         # + off_m points to the current block in the slice
                         off_m_scale = slice_block_off_m + off_m // 128


### PR DESCRIPTION
## Summary

- Track the activation MX-scale TMA mode independently from the activation-value TMA mode.
- Pass `X_SCALE_TMA_MODE` only when scale and value addressing differ, preserving the existing specialization otherwise.
- Use the scale layout's dense or ragged mode when computing swizzled activation-scale offsets.

This fixes persistent Blackwell matmul cases where ragged activation-scale metadata requires different addressing from the activation values.

## Validation

Not run per request. The focused Blackwell test requires an active CUDA driver.

Device: not tested.

## Lines Changed

| Type | Added | Removed | Net |
| --- | ---: | ---: | ---: |
| Tests | 0 | 0 | 0 |
| Core Logic | 13 | 1 | +12 |
| AutoGenerated | 0 | 0 | 0 |
| Total | 13 | 1 | +12 |

## Reviewers Guide

- Critical changes: `python/triton_kernels/triton_kernels/matmul.py` derives and forwards the activation-scale TMA mode.
- Critical changes: `python/triton_kernels/triton_kernels/matmul_details/_p_matmul.py` selects dense or ragged scale offsets independently.
- Mostly movements: none.