### PR TITLE
Remove can_reorder from reshape

### DIFF
--- a/include/triton/Dialect/Triton/IR/Dialect.h
+++ b/include/triton/Dialect/Triton/IR/Dialect.h
@@ -60,13 +60,10 @@ public:
   // makes the reshape a "nop", i.e. the same GPU threads contain the same
   // elements as before the reshape using legacy layouts.  This is not always
   // possible (in which case we fallback to using LinearLayouts)
-  // If allowReorder is set, an existing value in dstEnc is preferred when it
-  // still yields a non-expensive view.
   // In the future we'll always use LinearLayouts
   virtual LogicalResult
   inferReshapeOpEncoding(ArrayRef<int64_t> srcShape, Attribute srcEnc,
                          ArrayRef<int64_t> dstShape, Attribute &dstEnc,
-                         bool allowReorder,
                          std::optional<Location> loc) const = 0;
 
   // Check if two layouts are structurally the same, even if their names are

--- a/include/triton/Dialect/Triton/IR/TritonOps.td
+++ b/include/triton/Dialect/Triton/IR/TritonOps.td
@@ -483,24 +483,20 @@ def TT_ExpandDimsOp : TT_Op<"expand_dims", [Pure,
 
 def TT_ReshapeOp : TT_Op<"reshape", [Pure,
                                      SameOperandsAndResultElementType]> {
-    let summary = "reinterpret a tensor to a different shape. It may change elements order if the attribute is set.";
+    let summary = "reinterpret a tensor to a different shape";
     let description = [{
         reinterpret a tensor to a different shape.
-
-        If allow_reorder is set the compiler is free to change the order of
-        elements to generate more efficient code.
 
         If efficient_layout is set, this is a hint that the destination layout should be kept for performance reason.
         The compiler is still free to change it for better performance.
     }];
     let builders = [
-      OpBuilder<(ins "ArrayRef<int64_t>":$shape, "Value":$src,
-                     CArg<"bool", "false">:$allowReorder)>
+      OpBuilder<(ins "ArrayRef<int64_t>":$shape, "Value":$src)>
     ];
 
-    let arguments = (ins TT_Tensor:$src, UnitAttr:$allow_reorder, UnitAttr:$efficient_layout);
+    let arguments = (ins TT_Tensor:$src, UnitAttr:$efficient_layout);
     let results = (outs TT_Tensor:$result);
-    let assemblyFormat = "$src (`allow_reorder` $allow_reorder^)? (`efficient_layout` $efficient_layout^)? attr-dict `:` type($src) `->` type($result)";
+    let assemblyFormat = "$src (`efficient_layout` $efficient_layout^)? attr-dict `:` type($src) `->` type($result)";
     let hasCanonicalizeMethod = 1;
     let hasFolder = 1;
     let hasVerifier = 1;

--- a/lib/Dialect/Gluon/IR/Dialect.cpp
+++ b/lib/Dialect/Gluon/IR/Dialect.cpp
@@ -78,7 +78,7 @@ struct GluonInferLayoutInterface : public triton::DialectInferLayoutInterface {
 
   LogicalResult
   inferReshapeOpEncoding(ArrayRef<int64_t> srcShape, Attribute srcEnc,
-                         ArrayRef<int64_t> dstShape, Attribute &dstEnc, bool,
+                         ArrayRef<int64_t> dstShape, Attribute &dstEnc,
                          std::optional<Location> loc) const override {
     return inferAutoEncoding(srcEnc, dstEnc);
   }

--- a/lib/Dialect/Triton/IR/Ops.cpp
+++ b/lib/Dialect/Triton/IR/Ops.cpp
@@ -937,19 +937,18 @@ std::optional<unsigned> ReshapeOp::getExpandDimsAxis() {
 }
 
 void ReshapeOp::build(OpBuilder &builder, OperationState &state,
-                      ArrayRef<int64_t> shape, Value src, bool allowReorder) {
+                      ArrayRef<int64_t> shape, Value src) {
   auto srcTy = cast<RankedTensorType>(src.getType());
   auto srcEnc = srcTy.getEncoding();
   Attribute dstEnc;
   if (srcEnc) {
-    auto result =
-        cast<DialectInferLayoutInterface>(&srcEnc.getDialect())
-            ->inferReshapeOpEncoding(srcTy.getShape(), srcEnc, shape, dstEnc,
-                                     allowReorder, state.location);
+    auto result = cast<DialectInferLayoutInterface>(&srcEnc.getDialect())
+                      ->inferReshapeOpEncoding(srcTy.getShape(), srcEnc, shape,
+                                               dstEnc, state.location);
     assert(succeeded(result));
   }
   auto dstTy = RankedTensorType::get(shape, srcTy.getElementType(), dstEnc);
-  build(builder, state, dstTy, src, allowReorder);
+  build(builder, state, dstTy, src);
 }
 
 LogicalResult ReshapeOp::canonicalize(ReshapeOp op, PatternRewriter &rewriter) {
@@ -963,8 +962,7 @@ LogicalResult ReshapeOp::canonicalize(ReshapeOp op, PatternRewriter &rewriter) {
 
   // reshape(expand_dims(x)) -> x
   if (auto expandDims = dyn_cast<ExpandDimsOp>(definingOp)) {
-    if (!op.getAllowReorder() &&
-        op.getType() == expandDims.getSrc().getType()) {
+    if (op.getType() == expandDims.getSrc().getType()) {
       rewriter.replaceOp(op, expandDims.getSrc());
       return success();
     }
@@ -972,12 +970,8 @@ LogicalResult ReshapeOp::canonicalize(ReshapeOp op, PatternRewriter &rewriter) {
 
   // reshape(reshape) -> reshape
   if (auto parentReshape = dyn_cast<ReshapeOp>(definingOp)) {
-    // Allow reorder if either reshape allowed it
-    const bool allowReorder =
-        (op.getAllowReorder() || parentReshape.getAllowReorder());
-    rewriter.replaceOpWithNewOp<ReshapeOp>(op, op.getType(),
-                                           parentReshape.getSrc(), allowReorder,
-                                           op.getEfficientLayout());
+    rewriter.replaceOpWithNewOp<ReshapeOp>(
+        op, op.getType(), parentReshape.getSrc(), op.getEfficientLayout());
     return success();
   }
 
@@ -991,7 +985,7 @@ LogicalResult ReshapeOp::canonicalize(ReshapeOp op, PatternRewriter &rewriter) {
 }
 
 OpFoldResult ReshapeOp::fold(FoldAdaptor adaptor) {
-  if (getType() == getSrc().getType() && !getAllowReorder()) {
+  if (getType() == getSrc().getType()) {
     // no-op
     return getSrc();
   }
@@ -1019,15 +1013,12 @@ LogicalResult ReshapeOp::verify() {
   }
 
   // Check that we can infer the dst encoding from the src encoding and that the
-  // inferred dst encoding is the same as the given dst encoding. We pass the
-  // current dst encoding as a hint so that allowReorder reshapes are guaranteed
-  // to produce the current encoding iff it is valid.
-  Attribute inferredDstEnc = dstEnc;
+  // inferred dst encoding is the same as the given dst encoding.
+  Attribute inferredDstEnc;
   auto layoutInterface =
       cast<DialectInferLayoutInterface>(&srcEnc.getDialect());
   auto result = layoutInterface->inferReshapeOpEncoding(
-      srcTy.getShape(), srcEnc, dstTy.getShape(), inferredDstEnc,
-      getAllowReorder(), getLoc());
+      srcTy.getShape(), srcEnc, dstTy.getShape(), inferredDstEnc, getLoc());
   if (failed(result))
     return failure();
   return layoutInterface->verifyLayoutsAreEqual(

--- a/lib/Dialect/Triton/Transforms/Combine.cpp
+++ b/lib/Dialect/Triton/Transforms/Combine.cpp
@@ -193,29 +193,6 @@ public:
   }
 };
 
-// When reducing a 1D tensor the order of elements of the tensor doesn't matter.
-// Therefore we can relax the reshape to allow it to re-order elements.
-class CombineReshapeReducePatterns : public mlir::OpRewritePattern<ReshapeOp> {
-public:
-  using OpRewritePattern::OpRewritePattern;
-
-  mlir::LogicalResult
-  matchAndRewrite(triton::ReshapeOp reshapeOp,
-                  mlir::PatternRewriter &rewriter) const override {
-    if (reshapeOp.getAllowReorder())
-      return failure();
-    if (reshapeOp.getType().getRank() != 1)
-      return failure();
-    for (Operation *user : reshapeOp->getUsers()) {
-      if (!isa<triton::ReduceOp, triton::HistogramOp>(user))
-        return failure();
-    }
-    rewriter.modifyOpInPlace(reshapeOp,
-                             [&]() { reshapeOp.setAllowReorder(true); });
-    return success();
-  }
-};
-
 class RankedReduceDescriptorLoads : public mlir::OpRewritePattern<ReshapeOp> {
 public:
   using OpRewritePattern::OpRewritePattern;
@@ -307,7 +284,6 @@ public:
     patterns.add<CombineSelectMaskedLoadPattern>(context);
     patterns.add<CombineAddPtrPattern>(context);
     patterns.add<CombineBroadcastMulReducePattern>(context);
-    patterns.add<CombineReshapeReducePatterns>(context);
     patterns.add<RankedReduceDescriptorLoads>(context);
 
     if (applyPatternsGreedily(m, std::move(patterns)).failed())

--- a/lib/Dialect/TritonGPU/IR/Dialect.cpp
+++ b/lib/Dialect/TritonGPU/IR/Dialect.cpp
@@ -3531,17 +3531,11 @@ struct TritonGPUInferLayoutInterface
   LogicalResult
   inferReshapeOpEncoding(ArrayRef<int64_t> srcShape, Attribute srcEnc,
                          ArrayRef<int64_t> dstShape, Attribute &dstEnc,
-                         bool allowReorder,
                          std::optional<Location> loc) const override {
     if (product(srcShape) != product(dstShape)) {
       return emitOptionalError(loc, "numel of dst shape does not match "
                                     "numel of src shape");
     }
-    // If allowReorder is true, there are multiple valid encodings. Prefer the
-    // hint if it is set and valid.
-    if (allowReorder && dstEnc)
-      if (!isExpensiveView(srcShape, srcEnc, dstShape, dstEnc))
-        return success();
     auto result =
         inferReshapeOpLegacyEncoding(srcShape, srcEnc, dstShape, dstEnc);
     if (succeeded(result)) {

--- a/lib/Dialect/TritonGPU/IR/Ops.cpp
+++ b/lib/Dialect/TritonGPU/IR/Ops.cpp
@@ -124,20 +124,10 @@ struct CanonicalizeConvertFromReshape
     // If the layouts are structurally the same, the convert is trivial
     if (isConvertTrivial(convert)) {
       rewriter.replaceOpWithNewOp<triton::ReshapeOp>(
-          op, op.getType(), convert.getSrc(), op.getAllowReorder(),
-          op.getEfficientLayout());
+          op, op.getType(), convert.getSrc(), op.getEfficientLayout());
       return success();
     }
-
-    if (isExpensiveView(convert.getSrc().getType(), op.getType()))
-      return failure();
-    if (!op.getAllowReorder())
-      return failure();
-
-    rewriter.replaceOpWithNewOp<triton::ReshapeOp>(
-        op, op.getType(), convert.getSrc(), op.getAllowReorder(),
-        op.getEfficientLayout());
-    return mlir::success();
+    return failure();
   }
 };
 
@@ -308,28 +298,6 @@ struct CanonicalizeConvertFromConvert
     Operation *arg = op.getSrc().getDefiningOp();
     if (!arg)
       return failure();
-
-    // cvt(reshape) -> reshape
-    if (auto reshape = dyn_cast<ReshapeOp>(arg)) {
-      if (!reshape.getAllowReorder() || reshape.getEfficientLayout() ||
-          isExpensiveView(reshape.getSrc().getType(), op.getType()))
-        return failure();
-
-      // In TritonGPUToLLVM phase, ViewOp is converted to unpacking and packing
-      // operations, which requires the element type to match between unpacking
-      // and packing. However, part of values with dot operand encoding will be
-      // packed/unpacked as i32 elements instead of the underlying element type.
-      // To avoid errors, skip this folding when either the operand or result
-      // of view has a dot operand encoding.
-      if (hasDotOperandEncoding(op->getOperand(0)) ||
-          hasDotOperandEncoding(op->getResult(0)))
-        return failure();
-
-      rewriter.replaceOpWithNewOp<ReshapeOp>(op, op->getResult(0).getType(),
-                                             reshape.getResult(),
-                                             reshape.getAllowReorder());
-      return success();
-    }
 
     // cvt(histogram) -> histogram
     if (auto histogram = dyn_cast<HistogramOp>(arg)) {

--- a/lib/Dialect/TritonGPU/Transforms/DecomposeScaledBlocked.cpp
+++ b/lib/Dialect/TritonGPU/Transforms/DecomposeScaledBlocked.cpp
@@ -122,13 +122,11 @@ TypedValue<RankedTensorType> DecomposeScaledBlocked::broadcastScale(
   auto interface = cast<DialectInferLayoutInterface>(&dstEncoding.getDialect());
   Attribute broadcastEncoding;
   auto result = interface->inferReshapeOpEncoding(
-      resultShape, dstEncoding, broadcastShape, broadcastEncoding,
-      /*allowReorder=*/false, loc);
+      resultShape, dstEncoding, broadcastShape, broadcastEncoding, loc);
   assert(succeeded(result));
   Attribute srcEncoding;
-  result = interface->inferReshapeOpEncoding(expandedShape, broadcastEncoding,
-                                             scaleTy.getShape(), srcEncoding,
-                                             /*allowReorder=*/false, loc);
+  result = interface->inferReshapeOpEncoding(
+      expandedShape, broadcastEncoding, scaleTy.getShape(), srcEncoding, loc);
   assert(succeeded(result));
 
   auto srcType = scaleTy.cloneWithEncoding(srcEncoding);
@@ -142,9 +140,9 @@ TypedValue<RankedTensorType> DecomposeScaledBlocked::broadcastScale(
   // We know this layout avoids having any layout conversions after we expand
   // the scales, so mark the layout as efficient. Otherwise, forward layout
   // propagation may try to sink the convert layout.
-  auto expandScale = ReshapeOp::create(
-      rewriter, loc, expandType, scale,
-      /*allow_reorder=*/nullptr, /*efficient_layout=*/rewriter.getUnitAttr());
+  auto expandScale =
+      ReshapeOp::create(rewriter, loc, expandType, scale,
+                        /*efficient_layout=*/rewriter.getUnitAttr());
   // Broadcast the dimension to the microscaling factor.
   auto broadcastType = RankedTensorType::get(
       broadcastShape, scaleTy.getElementType(), broadcastEncoding);

--- a/lib/Dialect/TritonGPU/Transforms/OptimizeThreadLocality.cpp
+++ b/lib/Dialect/TritonGPU/Transforms/OptimizeThreadLocality.cpp
@@ -21,77 +21,6 @@ namespace gpu {
 #define GEN_PASS_DEF_TRITONGPUOPTIMIZETHREADLOCALITY
 #include "triton/Dialect/TritonGPU/Transforms/Passes.h.inc"
 
-namespace {
-// Change the destination layout of reshape ops allowing reorder when used by a
-// reduction in order to minimize the amount of cross thread communication for
-// the reduction.
-struct OptimizeReshapeLayoutPattern : public OpRewritePattern<ReshapeOp> {
-  OptimizeReshapeLayoutPattern(MLIRContext *context)
-      : OpRewritePattern<ReshapeOp>(context, 1) {}
-
-  LogicalResult matchAndRewrite(ReshapeOp viewOp,
-                                PatternRewriter &rewriter) const override {
-    if (!viewOp.getAllowReorder())
-      return failure();
-    std::optional<int> reductionAxis;
-    for (Operation *user : viewOp.getResult().getUsers()) {
-      if (auto reduceOp = dyn_cast<triton::ReduceOp>(user)) {
-        if (reductionAxis) {
-          if (reductionAxis != reduceOp.getAxis())
-            return failure();
-        } else {
-          reductionAxis = reduceOp.getAxis();
-        }
-      }
-    }
-    if (!reductionAxis)
-      return failure();
-    RankedTensorType tensorType = viewOp.getType();
-    if (auto blocked =
-            mlir::dyn_cast<BlockedEncodingAttr>(tensorType.getEncoding())) {
-      // If the layout already has all the elements along the reduction
-      // dimension in the same thread we can skip.
-      if (blocked.getThreadsPerWarp()[*reductionAxis] == 1 &&
-          blocked.getWarpsPerCTA()[*reductionAxis] == 1 &&
-          blocked.getCGALayout().getCTAsPerCGA()[*reductionAxis] == 1)
-        return failure();
-    }
-    ArrayRef<int64_t> shape = tensorType.getShape();
-    SmallVector<unsigned> order;
-    for (int i : triton::gpu::getOrder(tensorType)) {
-      if (i != *reductionAxis)
-        order.push_back(i);
-    }
-    // Make the reduction axis last so that elements won't be distributed
-    // amongst threads along this dimension.
-    order.push_back(*reductionAxis);
-    SmallVector<unsigned> sizePerThread(shape.size(), 1);
-    auto mod = viewOp->getParentOfType<ModuleOp>();
-    int numWarps = lookupNumWarps(viewOp);
-    int threadsPerWarp = TritonGPUDialect::getThreadsPerWarp(mod);
-    int numCTAs = TritonGPUDialect::getNumCTAs(mod);
-    auto encoding =
-        BlockedEncodingAttr::get(viewOp.getContext(), shape, sizePerThread,
-                                 order, numWarps, threadsPerWarp, numCTAs);
-    if (encoding == tensorType.getEncoding())
-      return failure();
-    RankedTensorType newType =
-        RankedTensorType::get(shape, tensorType.getElementType(), encoding);
-    if (triton::gpu::isExpensiveView(viewOp.getSrc().getType(), newType))
-      return failure();
-    rewriter.setInsertionPointAfter(viewOp);
-    rewriter.modifyOpInPlace(viewOp, [&]() {
-      viewOp.getResult().setType(newType);
-      viewOp.setEfficientLayout(true);
-    });
-    auto cvt = ConvertLayoutOp::create(rewriter, viewOp.getLoc(), tensorType,
-                                       viewOp.getResult());
-    rewriter.replaceAllUsesExcept(viewOp.getResult(), cvt.getResult(), cvt);
-    return success();
-  }
-};
-} // namespace
-
 // This function considers a gather op in isolation and attempts to determine
 // whether an optimized layout can be applied to the source and index tensors.
 static LogicalResult setOptimizedGatherLayout(GatherOp op, RewriterBase &b) {
@@ -245,9 +174,8 @@ class TritonGPUOptimizeThreadLocalityPass
   void runOnOperation() override {
     ModuleOp mod = getOperation();
 
-    // First try to optimize the layout of views and gathers.
+    // First try to optimize the layout of gathers.
     mlir::RewritePatternSet layoutPatterns(&getContext());
-    layoutPatterns.add<OptimizeReshapeLayoutPattern>(&getContext());
     layoutPatterns.add<OptimizeGatherLayoutPattern>(&getContext());
     if (mlir::applyPatternsGreedily(mod, std::move(layoutPatterns)).failed()) {
       signalPassFailure();
@@ -452,14 +380,19 @@ private:
   Operation *createReduce(OpBuilder &builder, triton::ReduceOp reduce,
                           Type viewOpTensorType) const {
     auto srcType = cast<RankedTensorType>(reduce.getOperands()[0].getType());
+    auto viewOpShape = cast<RankedTensorType>(viewOpTensorType).getShape();
     auto rank = srcType.getShape().size();
     builder.setInsertionPointAfter(reduce);
     IRMapping mapping;
     for (auto operand : reduce.getOperands()) {
-      auto viewOp = triton::ReshapeOp::create(
-          builder, reduce.getLoc(), viewOpTensorType, operand,
-          /*allowReorder=*/true, /*efficientLayout=*/true);
-      mapping.map(operand, viewOp);
+      auto viewOp = triton::ReshapeOp::create(builder, reduce.getLoc(),
+                                              viewOpShape, operand);
+      viewOp.setEfficientLayout(true);
+      Value mappedOperand = viewOp;
+      if (viewOp.getType() != viewOpTensorType)
+        mappedOperand = ConvertLayoutOp::create(
+            builder, reduce.getLoc(), viewOpTensorType, mappedOperand);
+      mapping.map(operand, mappedOperand);
     }
 
     auto newReduce = cloneWithInferType(builder, &(*reduce), mapping);

--- a/lib/Dialect/TritonGPU/Transforms/RemoveLayoutConversions.cpp
+++ b/lib/Dialect/TritonGPU/Transforms/RemoveLayoutConversions.cpp
@@ -228,14 +228,6 @@ bool isLayoutAnchor(Operation *op) {
   if (auto gatherOp = dyn_cast<GatherOp>(op))
     return gatherOp.getEfficientLayout();
 
-  // Heuristic: Mark permuting reshape as a layout anchor.  Its dst can be
-  // anything, so it stops forward-propagation of layouts.  We rely on the
-  // backwards pass to fix it up if necessary.  (If we didn't do this, then
-  // anything following the reshape won't be covered by the forward pass at
-  // all.)
-  if (auto reshape = dyn_cast<ReshapeOp>(op))
-    return reshape.getAllowReorder();
-
   return false;
 }
 

--- a/lib/Dialect/TritonGPU/Transforms/Utility.cpp
+++ b/lib/Dialect/TritonGPU/Transforms/Utility.cpp
@@ -522,23 +522,20 @@ static Attribute inferSrcEncoding(triton::TransposeOpInterface op,
 
 static Attribute inferReshapeOpDstEncoding(ArrayRef<int64_t> srcShape,
                                            Attribute srcEnc,
-                                           ArrayRef<int64_t> dstShape,
-                                           Attribute dstEncHint = {},
-                                           bool allowReorder = false) {
-  Attribute dstEnc = dstEncHint;
+                                           ArrayRef<int64_t> dstShape) {
+  Attribute dstEnc;
   auto result =
       srcEnc.getDialect()
           .getRegisteredInterface<triton::DialectInferLayoutInterface>()
           ->inferReshapeOpEncoding(srcShape, srcEnc, dstShape, dstEnc,
-                                   allowReorder, /*loc=*/std::nullopt);
+                                   /*loc=*/std::nullopt);
   assert(succeeded(result));
   return dstEnc;
 }
 
 static Attribute inferDstEncoding(triton::ReshapeOp op, Attribute encoding) {
-  return inferReshapeOpDstEncoding(
-      op.getSrc().getType().getShape(), encoding, op.getType().getShape(),
-      op.getType().getEncoding(), op.getAllowReorder());
+  return inferReshapeOpDstEncoding(op.getSrc().getType().getShape(), encoding,
+                                   op.getType().getShape());
 }
 
 static Attribute inferDstEncoding(GatherOp op, Attribute encoding) {
@@ -553,9 +550,8 @@ static Attribute inferSrcEncoding(triton::ReshapeOp op, Attribute encoding) {
   // as the encoding of x given the encoding of y in `reshape(y) -> x`.  It's an
   // invariant of inferReshapeOpNoReorderEncoding that it's symmetric in this
   // way.
-  return inferReshapeOpDstEncoding(
-      op.getType().getShape(), encoding, op.getSrc().getType().getShape(),
-      op.getSrc().getType().getEncoding(), op.getAllowReorder());
+  return inferReshapeOpDstEncoding(op.getType().getShape(), encoding,
+                                   op.getSrc().getType().getShape());
 }
 
 static bool isSingleValue(Value value) {
@@ -671,14 +667,6 @@ bool canUseResultEncoding(Operation *op, Attribute targetEncoding) {
     return true;
   }
 
-  if (auto reshape = dyn_cast<triton::ReshapeOp>(op)) {
-    auto reshapeDstType = reshape.getType();
-    RankedTensorType newDstType =
-        reshapeDstType.cloneWithEncoding(targetEncoding);
-    return reshape.getAllowReorder() && !reshape.getEfficientLayout() &&
-           !triton::gpu::isExpensiveView(reshape.getSrc().getType(),
-                                         newDstType);
-  }
   return isa<triton::gpu::ConvertLayoutOp, arith::ConstantOp,
              triton::MakeRangeOp, triton::SplatOp, triton::HistogramOp,
              triton::gpu::LocalAllocOp, triton::gpu::LocalLoadOp,

--- a/lib/Dialect/TritonInstrument/IR/FunctionBuilder.cpp
+++ b/lib/Dialect/TritonInstrument/IR/FunctionBuilder.cpp
@@ -157,8 +157,8 @@ Value reduceAll(ImplicitLocOpBuilder &b, Value tensor) {
   if (!tensorType || tensorType.getRank() == 0)
     return tensor;
   if (tensorType.getRank() != 1) {
-    tensor = triton::ReshapeOp::create(b, {tensorType.getNumElements()}, tensor,
-                                       /*allowReorder=*/true);
+    tensor =
+        triton::ReshapeOp::create(b, {tensorType.getNumElements()}, tensor);
   }
   return reduceLastDim<OpTy>(b, tensor);
 }

--- a/python/src/ir.cc
+++ b/python/src/ir.cc
@@ -1611,10 +1611,8 @@ void init_triton_ir(py::module_ &m) {
              self.create<DescriptorScatterOp>(desc, x_indices, y_index, value);
            })
       .def("create_reshape",
-           [](TritonOpBuilder &self, Value &arg, std::vector<int64_t> &shape,
-              bool allowReorder) -> Value {
-             return self.create<ReshapeOp>(shape, arg, allowReorder);
-           })
+           [](TritonOpBuilder &self, Value &arg, std::vector<int64_t> &shape)
+               -> Value { return self.create<ReshapeOp>(shape, arg); })
       .def("create_expand_dims",
            [](TritonOpBuilder &self, Value &arg, int axis) -> Value {
              return self.create<ExpandDimsOp>(arg, axis);

--- a/python/triton/language/semantic.py
+++ b/python/triton/language/semantic.py
@@ -638,7 +638,7 @@ class TritonSemantic(Generic[TensorTy]):
         if input.type.numel != numel:
             raise ValueError("reshape() cannot change total number of elements in tensor")
         ret_ty = tl.block_type(input.type.scalar, dst_shape)
-        return self.tensor(self.builder.create_reshape(input.handle, dst_shape, can_reorder), ret_ty)
+        return self.tensor(self.builder.create_reshape(input.handle, dst_shape), ret_ty)
 
     def expand_dims(self, input: TensorTy, axis: int) -> TensorTy:
         dst_shape = [tl._unwrap_if_constexpr(x) for x in input.shape]

--- a/python/triton/runtime/interpreter.py
+++ b/python/triton/runtime/interpreter.py
@@ -707,7 +707,7 @@ class InterpreterBuilder:
         return TensorHandle(1 / np.sqrt(arg.data), arg.dtype.scalar)
 
     # tensor operators
-    create_reshape = lambda self, arg, shape, allow_reorder: TensorHandle(arg.data.reshape(shape), arg.dtype.scalar)
+    create_reshape = lambda self, arg, shape: TensorHandle(arg.data.reshape(shape), arg.dtype.scalar)
 
     def create_trans(self, arg, perm):
         return TensorHandle(np.transpose(arg.data, perm), arg.dtype.scalar)

--- a/python/triton_kernels/triton_kernels/matmul_details/_p_matmul.py
+++ b/python/triton_kernels/triton_kernels/matmul_details/_p_matmul.py
@@ -708,7 +708,7 @@ def _p_matmul(
             else:
                 # Flexpoint
                 if USE_LOCAL_ABSMAX:
-                    out_view = tl.reshape(out, [out.numel // THREADS_PER_BLOCK, THREADS_PER_BLOCK], can_reorder=True)
+                    out_view = tl.reshape(out, [out.numel // THREADS_PER_BLOCK, THREADS_PER_BLOCK])
                     local_absmax = tl.maximum(local_absmax, nan_propagating_absmax_reduce(out_view, axis=0))
 
                 if PER_BATCH_OUT_SCALE:

--- a/python/triton_kernels/triton_kernels/numerics_details/flexpoint.py
+++ b/python/triton_kernels/triton_kernels/numerics_details/flexpoint.py
@@ -135,7 +135,7 @@ def nan_propagating_absmax_reduce(x, axis=None):
 
 @triton.jit
 def compute_scale(x, Out):
-    x_absmax = nan_propagating_absmax_reduce(tl.ravel(x, can_reorder=True))
+    x_absmax = nan_propagating_absmax_reduce(tl.ravel(x))
 
     # atomic_max does not propagate NaNs, so we replace them with +inf (0x7f800000).
     # We use integer minimum because NaNs are above +inf in integer representation.
@@ -173,7 +173,7 @@ def float_to_flex(
         zero = tl.cast(0.0, tl.int32)
         if mask is not None:
             x_int32 = tl.where(mask, x_int32, zero)
-        checksum_local = tl.xor_sum(tl.ravel(x_int32, can_reorder=True), 0)
+        checksum_local = tl.xor_sum(tl.ravel(x_int32), 0)
         tl.atomic_add(checksum_scale_ptr, checksum_local)
     if mask is not None:
         if actual_scale_ptr is not None:

--- a/python/triton_kernels/triton_kernels/swiglu_details/_swiglu.py
+++ b/python/triton_kernels/triton_kernels/swiglu_details/_swiglu.py
@@ -14,7 +14,7 @@ def clip(x, limit, clip_lower: tl.constexpr):
 
 @triton.jit
 def thread_local_absmax(x, BLOCK_SIZE: tl.constexpr, NUM_THREADS: tl.constexpr):
-    return tl.max(tl.reshape(tl.abs(x), [NUM_THREADS, BLOCK_SIZE // NUM_THREADS], can_reorder=True), axis=1)
+    return tl.max(tl.reshape(tl.abs(x), [NUM_THREADS, BLOCK_SIZE // NUM_THREADS]), axis=1)
 
 
 def swiglu_repr(specialization):

--- a/test/Conversion/tritongpu_to_llvm.mlir
+++ b/test/Conversion/tritongpu_to_llvm.mlir
@@ -431,7 +431,7 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32} {
   tt.func @basic_view_broadcast(%arg : tensor<256xf32,#blocked0>) {
     // CHECK: %[[T0:.*]] = llvm.extractvalue
     // CHECK: %[[T1:.*]] = llvm.extractvalue
-    %0 = tt.reshape %arg allow_reorder : tensor<256xf32, #blocked0> -> tensor<256x1xf32,#blocked2>
+    %0 = tt.reshape %arg : tensor<256xf32, #blocked0> -> tensor<256x1xf32,#blocked2>
     // CHECK: llvm.mlir.undef
     // CHECK: llvm.insertvalue %[[T0]]
     // CHECK: llvm.insertvalue %[[T1]]

--- a/test/Hopper/WarpSpecialization/ws_data_partition.mlir
+++ b/test/Hopper/WarpSpecialization/ws_data_partition.mlir
@@ -125,10 +125,10 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.targ
     %t0 = tt.trans %ld {async_task_id = array<i32: 0>, order = array<i32: 1, 0>} : tensor<64x128xf16, #blockedT> -> tensor<128x64xf16, #blocked>
     // CHECK: tt.reshape {{.*}} : tensor<64x64xf16,
     // CHECK: tt.reshape {{.*}} : tensor<64x64xf16,
-    %r0 = tt.reshape %t0 allow_reorder {async_task_id = array<i32: 0>} : tensor<128x64xf16, #blocked> -> tensor<128x64x1xf16, #blocked2>
+    %r0 = tt.reshape %t0 {async_task_id = array<i32: 0>} : tensor<128x64xf16, #blocked> -> tensor<128x64x1xf16, #blocked2>
     // CHECK: tt.reshape {{.*}} : tensor<64x64x1xf16,
     // CHECK: tt.reshape {{.*}} : tensor<64x64x1xf16,
-    %r1 = tt.reshape %r0 allow_reorder {async_task_id = array<i32: 0, 1, 2>} : tensor<128x64x1xf16, #blocked2> -> tensor<128x64xf16, #blocked>
+    %r1 = tt.reshape %r0 {async_task_id = array<i32: 0, 1, 2>} : tensor<128x64x1xf16, #blocked2> -> tensor<128x64xf16, #blocked>
     // CHECK: tt.join {{.*}} : tensor<64x64xf16,
     // CHECK: tt.join {{.*}} : tensor<64x64xf16,
     %0 = tt.join %r1, %r1 {async_task_id = array<i32: 0, 1, 2>} : tensor<128x64xf16, #blocked> -> tensor<128x64x2xf16, #blocked2>

--- a/test/Triton/combine.mlir
+++ b/test/Triton/combine.mlir
@@ -328,19 +328,19 @@ tt.func @test_canonicalize_expand_dims(%arg0: tensor<f32>, %arg1: tensor<1xf32>)
 
 // CHECK-LABEL: @test_canonicalize_view
 tt.func @test_canonicalize_view(%arg0: tensor<8xf32>, %arg1: tensor<f32>) -> (tensor<4x2xf32>, tensor<2x2x2xf32>, tensor<8xf32>, tensor<2x2x2xf32>) {
-    %view0 = tt.reshape %arg0 allow_reorder : tensor<8xf32> -> tensor<2x4xf32>
-    // CHECK: %{{.*}} = tt.reshape %arg0 allow_reorder : tensor<8xf32> -> tensor<4x2xf32>
-    %view1 = tt.reshape %view0 allow_reorder : tensor<2x4xf32> -> tensor<4x2xf32>
+    %view0 = tt.reshape %arg0 : tensor<8xf32> -> tensor<2x4xf32>
+    // CHECK: %{{.*}} = tt.reshape %arg0 : tensor<8xf32> -> tensor<4x2xf32>
+    %view1 = tt.reshape %view0 : tensor<2x4xf32> -> tensor<4x2xf32>
 
     %splat = tt.splat %arg1 : tensor<f32> -> tensor<8xf32>
     // CHECK: %{{.*}} = tt.splat %arg1 : tensor<f32> -> tensor<2x2x2xf32>
-    %view2 = tt.reshape %splat allow_reorder : tensor<8xf32> -> tensor<2x2x2xf32>
+    %view2 = tt.reshape %splat : tensor<8xf32> -> tensor<2x2x2xf32>
 
     %view3 = tt.reshape %arg0 : tensor<8xf32> -> tensor<8xf32>
     // CHECK: %{{.*}} = arith.addf %arg0, %arg0 : tensor<8xf32>
     %add = arith.addf %view3, %arg0 : tensor<8xf32>
 
-    // CHECK: %{{.*}} = tt.reshape %arg0 allow_reorder : tensor<8xf32> -> tensor<2x2x2xf32>
+    // CHECK: %{{.*}} = tt.reshape %arg0 : tensor<8xf32> -> tensor<2x2x2xf32>
     %reshape = tt.reshape %view0 : tensor<2x4xf32> -> tensor<2x2x2xf32>
 
     tt.return %view1, %view2, %add, %reshape : tensor<4x2xf32>, tensor<2x2x2xf32>, tensor<8xf32>, tensor<2x2x2xf32>
@@ -360,8 +360,8 @@ tt.func @test_canonicalize_reshape(%arg0: tensor<8xf32>, %arg1: tensor<f32>) -> 
     // CHECK: %{{.*}} = arith.addf %arg0, %arg0 : tensor<8xf32>
     %add = arith.addf %reshape3, %arg0 : tensor<8xf32>
 
-    // CHECK: %{{.*}} = tt.reshape %arg0 allow_reorder : tensor<8xf32> -> tensor<2x2x2xf32>
-    %view = tt.reshape %reshape0 allow_reorder : tensor<2x4xf32> -> tensor<2x2x2xf32>
+    // CHECK: %{{.*}} = tt.reshape %arg0 : tensor<8xf32> -> tensor<2x2x2xf32>
+    %view = tt.reshape %reshape0 : tensor<2x4xf32> -> tensor<2x2x2xf32>
 
     tt.return %reshape1, %reshape2, %add, %view : tensor<4x2xf32>, tensor<2x2x2xf32>, tensor<8xf32>, tensor<2x2x2xf32>
 }
@@ -396,7 +396,7 @@ tt.func @test_fold_views() -> (tensor<16x8xf32>, tensor<16x128xf32>, tensor<1x1x
     %a = arith.constant dense<1.0> : tensor<1x128xf32>
 
     // CHECK-DAG: %{{.*}} = arith.constant dense<1.{{.*}}> : tensor<16x8xf32>
-    %b = tt.reshape %a allow_reorder : tensor<1x128xf32> -> tensor<16x8xf32>
+    %b = tt.reshape %a : tensor<1x128xf32> -> tensor<16x8xf32>
 
     // CHECK-DAG: %{{.*}} = arith.constant dense<1.{{.*}}> : tensor<16x128xf32>
     %c = tt.broadcast %a : tensor<1x128xf32> -> tensor<16x128xf32>
@@ -425,7 +425,7 @@ tt.func @test_nested_transpose(%arg0: tensor<2x4x8xf32>) -> (tensor<8x2x4xf32>) 
 
 // CHECK-LABEL: test_reshape_reduce
 tt.func @test_reshape_reduce(%0: tensor<32x4x2xi32>) -> (i32, tensor<16xi32>) {
-  // CHECK: tt.reshape %{{.+}} allow_reorder : tensor<32x4x2xi32> -> tensor<256xi32>
+  // CHECK: tt.reshape %{{.+}} : tensor<32x4x2xi32> -> tensor<256xi32>
   %1 = tt.reshape %0 : tensor<32x4x2xi32> -> tensor<256xi32>
   %2 = "tt.reduce" (%1) ({
     ^bb0(%arg7: i32, %arg8: i32):

--- a/test/Triton/ops.mlir
+++ b/test/Triton/ops.mlir
@@ -227,12 +227,8 @@ tt.func @inline_asm_scalar(%0: i32) {
 tt.func @reshape(%0: tensor<512xi32>) {
   // CHECK: tt.reshape %{{.+}} : tensor<512xi32> -> tensor<16x32xi32>
   %1 = tt.reshape %0 : tensor<512xi32> -> tensor<16x32xi32>
-  // CHECK: tt.reshape %{{.+}} allow_reorder : tensor<512xi32> -> tensor<16x32xi32>
-  %2 = tt.reshape %0 allow_reorder : tensor<512xi32> -> tensor<16x32xi32>
-  // CHECK: tt.reshape %{{.+}} allow_reorder efficient_layout : tensor<512xi32> -> tensor<16x32xi32>
-  %3 = tt.reshape %0 allow_reorder efficient_layout : tensor<512xi32> -> tensor<16x32xi32>
   // CHECK: tt.reshape %{{.+}} efficient_layout : tensor<512xi32> -> tensor<16x32xi32>
-  %4 = tt.reshape %0 efficient_layout : tensor<512xi32> -> tensor<16x32xi32>
+  %2 = tt.reshape %0 efficient_layout : tensor<512xi32> -> tensor<16x32xi32>
   tt.return
 }
 

--- a/test/TritonGPU/amd/amd-convert-buffer-ops-small-tensor.mlir
+++ b/test/TritonGPU/amd/amd-convert-buffer-ops-small-tensor.mlir
@@ -251,6 +251,9 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32} {
 #blockedsrc = #ttg.blocked<{sizePerThread = [1, 4], threadsPerWarp = [1, 32], warpsPerCTA = [4, 1], order = [0, 1]}>
 #blocked = #ttg.blocked<{sizePerThread = [2, 2], threadsPerWarp = [32, 1], warpsPerCTA = [4, 1], order = [0, 1]}>
 #blockedtrans = #ttg.blocked<{sizePerThread = [2, 2], threadsPerWarp = [1, 32], warpsPerCTA = [1, 4], order = [1, 0]}>
+#linear = #ttg.linear<{register = [[0, 1], [1, 0]], lane = [[2, 0], [4, 0], [0, 0], [0, 0], [0, 0]], warp = [[0, 0], [0, 0]], block = []}>
+#lineartrans = #ttg.linear<{register = [[0, 1], [0, 2]], lane = [[0, 4], [1, 0], [0, 0], [0, 0], [0, 0]], warp = [[0, 0], [0, 0]], block = []}>
+#linearbroadcast = #ttg.linear<{register = [[0, 1], [4, 0]], lane = [[1, 0], [2, 0], [0, 0], [0, 0], [0, 0]], warp = [[0, 0], [0, 0]], block = []}>
 #blocked1 = #ttg.slice<{dim=0, parent=#blockedsrc}>
 #blocked2 = #ttg.slice<{dim=0, parent=#blockedtrans}>
 module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32} {
@@ -259,8 +262,10 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32} {
     %c10_i32 = arith.constant 5 : i32
     %0 = tt.make_range {end = 16 : i32, start = 0 : i32} : tensor<16xi32, #blocked1>
     %1 = tt.expand_dims %0 {axis = 0 : i32} : tensor<16xi32, #blocked1> -> tensor<1x16xi32, #blockedsrc>
-    %2 = tt.reshape %1 allow_reorder : tensor<1x16xi32, #blockedsrc> -> tensor<8x2xi32, #blocked>
-    %3 = tt.reshape %1 allow_reorder : tensor<1x16xi32, #blockedsrc> -> tensor<2x8xi32, #blockedtrans>
+    %reshaped2 = tt.reshape %1 : tensor<1x16xi32, #blockedsrc> -> tensor<8x2xi32, #linear>
+    %2 = ttg.convert_layout %reshaped2 : tensor<8x2xi32, #linear> -> tensor<8x2xi32, #blocked>
+    %reshaped3 = tt.reshape %1 : tensor<1x16xi32, #blockedsrc> -> tensor<2x8xi32, #lineartrans>
+    %3 = ttg.convert_layout %reshaped3 : tensor<2x8xi32, #lineartrans> -> tensor<2x8xi32, #blockedtrans>
     %4 = tt.trans %3 {order = array<i32: 1, 0>} : tensor<2x8xi32, #blockedtrans> -> tensor<8x2xi32, #blocked>
     %5 = ttg.convert_layout %4 : tensor<8x2xi32, #blocked> -> tensor<8x2xi32, #blocked>
     %6 = arith.addi %5, %2 : tensor<8x2xi32, #blocked>
@@ -268,7 +273,8 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32} {
     %8 = ttg.convert_layout %7 : tensor<8xi32, #blocked2> -> tensor<8xi32, #blocked2>
     %9 = tt.expand_dims %8 {axis = 0 : i32} : tensor<8xi32, #blocked2> -> tensor<1x8xi32, #blockedtrans>
     %10 = tt.broadcast %9 : tensor<1x8xi32, #blockedtrans> -> tensor<2x8xi32, #blockedtrans>
-    %11 = tt.reshape %10 allow_reorder : tensor<2x8xi32, #blockedtrans> -> tensor<8x2xi32, #blocked>
+    %reshaped11 = tt.reshape %10 : tensor<2x8xi32, #blockedtrans> -> tensor<8x2xi32, #linearbroadcast>
+    %11 = ttg.convert_layout %reshaped11 : tensor<8x2xi32, #linearbroadcast> -> tensor<8x2xi32, #blocked>
     %12 = tt.splat %c10_i32 : i32 -> tensor<8x2xi32, #blocked>
     %13 = arith.addi %11, %12 : tensor<8x2xi32, #blocked>
     %14 = arith.minsi %13, %5 : tensor<8x2xi32, #blocked>
@@ -314,7 +320,7 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32} {
     %8 = tt.gather %7[%zeros] {axis = 1 : i32} : (tensor<8x2xi32, #blocked>, tensor<8x1xi32, #blocked>) -> tensor<8x1xi32, #blocked>
     %9 = tt.gather %7[%ones] {axis = 1 : i32} : (tensor<8x2xi32, #blocked>, tensor<8x1xi32, #blocked>) -> tensor<8x1xi32, #blocked>
     %10 = arith.addi %8, %9 : tensor<8x1xi32, #blocked>
-    %11 = tt.reshape %10 allow_reorder : tensor<8x1xi32, #blocked> -> tensor<8xi32, #blocked1>
+    %11 = tt.reshape %10 : tensor<8x1xi32, #blocked> -> tensor<8xi32, #blocked1>
     %12 = tt.splat %arg0 : !tt.ptr<bf16> -> tensor<8x!tt.ptr<bf16>, #blocked1>
     %14 = tt.addptr %12, %11 : tensor<8x!tt.ptr<bf16>, #blocked1>, tensor<8xi32, #blocked1>
     // COMMON: %[[loaded:.*]] = amdg.buffer_load %arg0[%{{.*}}]

--- a/test/TritonGPU/amd/amd-convert-buffer-ops.mlir
+++ b/test/TritonGPU/amd/amd-convert-buffer-ops.mlir
@@ -291,6 +291,9 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32} {
 #blockedsrc = #ttg.blocked<{sizePerThread = [1, 4], threadsPerWarp = [1, 32], warpsPerCTA = [4, 1], order = [0, 1]}>
 #blocked = #ttg.blocked<{sizePerThread = [2, 2], threadsPerWarp = [32, 1], warpsPerCTA = [4, 1], order = [0, 1]}>
 #blockedtrans = #ttg.blocked<{sizePerThread = [2, 2], threadsPerWarp = [1, 32], warpsPerCTA = [1, 4], order = [1, 0]}>
+#linear = #ttg.linear<{register = [[0, 1], [1, 0]], lane = [[2, 0], [4, 0], [0, 0], [0, 0], [0, 0]], warp = [[0, 0], [0, 0]], block = []}>
+#lineartrans = #ttg.linear<{register = [[0, 1], [0, 2]], lane = [[0, 4], [1, 0], [0, 0], [0, 0], [0, 0]], warp = [[0, 0], [0, 0]], block = []}>
+#linearbroadcast = #ttg.linear<{register = [[0, 1], [4, 0]], lane = [[1, 0], [2, 0], [0, 0], [0, 0], [0, 0]], warp = [[0, 0], [0, 0]], block = []}>
 #blocked1 = #ttg.slice<{dim=0, parent=#blockedsrc}>
 #blocked2 = #ttg.slice<{dim=0, parent=#blockedtrans}>
 module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32} {
@@ -299,8 +302,10 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32} {
     %c10_i32 = arith.constant 5 : i32
     %0 = tt.make_range {end = 16 : i32, start = 0 : i32} : tensor<16xi32, #blocked1>
     %1 = tt.expand_dims %0 {axis = 0 : i32} : tensor<16xi32, #blocked1> -> tensor<1x16xi32, #blockedsrc>
-    %2 = tt.reshape %1 allow_reorder : tensor<1x16xi32, #blockedsrc> -> tensor<8x2xi32, #blocked>
-    %3 = tt.reshape %1 allow_reorder : tensor<1x16xi32, #blockedsrc> -> tensor<2x8xi32, #blockedtrans>
+    %reshaped2 = tt.reshape %1 : tensor<1x16xi32, #blockedsrc> -> tensor<8x2xi32, #linear>
+    %2 = ttg.convert_layout %reshaped2 : tensor<8x2xi32, #linear> -> tensor<8x2xi32, #blocked>
+    %reshaped3 = tt.reshape %1 : tensor<1x16xi32, #blockedsrc> -> tensor<2x8xi32, #lineartrans>
+    %3 = ttg.convert_layout %reshaped3 : tensor<2x8xi32, #lineartrans> -> tensor<2x8xi32, #blockedtrans>
     %4 = tt.trans %3 {order = array<i32: 1, 0>} : tensor<2x8xi32, #blockedtrans> -> tensor<8x2xi32, #blocked>
     %5 = ttg.convert_layout %4 : tensor<8x2xi32, #blocked> -> tensor<8x2xi32, #blocked>
     %6 = arith.addi %5, %2 : tensor<8x2xi32, #blocked>
@@ -308,7 +313,8 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32} {
     %8 = ttg.convert_layout %7 : tensor<8xi32, #blocked2> -> tensor<8xi32, #blocked2>
     %9 = tt.expand_dims %8 {axis = 0 : i32} : tensor<8xi32, #blocked2> -> tensor<1x8xi32, #blockedtrans>
     %10 = tt.broadcast %9 : tensor<1x8xi32, #blockedtrans> -> tensor<2x8xi32, #blockedtrans>
-    %11 = tt.reshape %10 allow_reorder : tensor<2x8xi32, #blockedtrans> -> tensor<8x2xi32, #blocked>
+    %reshaped11 = tt.reshape %10 : tensor<2x8xi32, #blockedtrans> -> tensor<8x2xi32, #linearbroadcast>
+    %11 = ttg.convert_layout %reshaped11 : tensor<8x2xi32, #linearbroadcast> -> tensor<8x2xi32, #blocked>
     %12 = tt.splat %c10_i32 : i32 -> tensor<8x2xi32, #blocked>
     %13 = arith.addi %11, %12 : tensor<8x2xi32, #blocked>
     %14 = arith.minsi %13, %5 : tensor<8x2xi32, #blocked>
@@ -354,7 +360,7 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32} {
     %8 = tt.gather %7[%zeros] {axis = 1 : i32} : (tensor<8x2xi32, #blocked>, tensor<8x1xi32, #blocked>) -> tensor<8x1xi32, #blocked>
     %9 = tt.gather %7[%ones] {axis = 1 : i32} : (tensor<8x2xi32, #blocked>, tensor<8x1xi32, #blocked>) -> tensor<8x1xi32, #blocked>
     %10 = arith.addi %8, %9 : tensor<8x1xi32, #blocked>
-    %11 = tt.reshape %10 allow_reorder : tensor<8x1xi32, #blocked> -> tensor<8xi32, #blocked1>
+    %11 = tt.reshape %10 : tensor<8x1xi32, #blocked> -> tensor<8xi32, #blocked1>
     %12 = tt.splat %arg0 : !tt.ptr<bf16> -> tensor<8x!tt.ptr<bf16>, #blocked1>
     %14 = tt.addptr %12, %11 : tensor<8x!tt.ptr<bf16>, #blocked1>, tensor<8xi32, #blocked1>
     // COMMON: %[[loaded:.*]] = amdg.buffer_load %arg0[%{{.*}}]

--- a/test/TritonGPU/amd/amd-range-analysis.mlir
+++ b/test/TritonGPU/amd/amd-range-analysis.mlir
@@ -1280,7 +1280,7 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32} {
     %10 = arith.addi %8, %9 : tensor<8x1xi32>
     // expected-remark@+2 {{unsigned : [0, 32] signed : [0, 32]}}
     // expected-remark@+1 {{non-neg}}
-    %11 = tt.reshape %10 allow_reorder : tensor<8x1xi32> -> tensor<8xi32>
+    %11 = tt.reshape %10 : tensor<8x1xi32> -> tensor<8xi32>
     tt.return
   }
 }
@@ -1348,8 +1348,8 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32} {
     %c10_i32 = arith.constant 5 : i32
     %0 = tt.make_range {end = 16 : i32, start = 0 : i32} : tensor<16xi32>
     %1 = tt.expand_dims %0 {axis = 0 : i32} : tensor<16xi32> -> tensor<1x16xi32>
-    %2 = tt.reshape %1 allow_reorder : tensor<1x16xi32> -> tensor<8x2xi32>
-    %3 = tt.reshape %1 allow_reorder : tensor<1x16xi32> -> tensor<2x8xi32>
+    %2 = tt.reshape %1 : tensor<1x16xi32> -> tensor<8x2xi32>
+    %3 = tt.reshape %1 : tensor<1x16xi32> -> tensor<2x8xi32>
     // expected-remark@+2 {{unsigned : [0, 15] signed : [0, 15]}}
     // expected-remark@+1 {{non-neg}}
     %4 = tt.trans %3 {order = array<i32: 1, 0>} : tensor<2x8xi32> -> tensor<8x2xi32>
@@ -1365,7 +1365,7 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32} {
     %8 = ttg.convert_layout %7 : tensor<8xi32> -> tensor<8xi32>
     %9 = tt.expand_dims %8 {axis = 0 : i32} : tensor<8xi32> -> tensor<1x8xi32>
     %10 = tt.broadcast %9 : tensor<1x8xi32> -> tensor<2x8xi32>
-    %11 = tt.reshape %10 allow_reorder : tensor<2x8xi32> -> tensor<8x2xi32>
+    %11 = tt.reshape %10 : tensor<2x8xi32> -> tensor<8x2xi32>
     %12 = tt.splat %c10_i32 : i32 -> tensor<8x2xi32>
     // expected-remark@+2 {{unsigned : [7, 14] signed : [7, 14]}}
     // expected-remark@+1 {{non-neg}}

--- a/test/TritonGPU/canonicalize.mlir
+++ b/test/TritonGPU/canonicalize.mlir
@@ -3,18 +3,19 @@
 
 // CHECK-LABEL: @test_canonicalize_convert_view
 // CHECK-SAME: (%[[ARG:.+]]: tensor<64x64xf32
-//   CHECK-NOT:   ttg.convert_layout
-//       CHECK:   %[[V:.+]] = tt.reshape %[[ARG]] allow_reorder
+//       CHECK:   %[[C:.+]] = ttg.convert_layout %[[ARG]]
+//       CHECK:   %[[V:.+]] = tt.reshape %[[C]]
 //       CHECK:   tt.return %[[V]]
 #blocked0 = #ttg.blocked<{sizePerThread = [1, 8], threadsPerWarp = [4, 8], warpsPerCTA = [8, 1], order = [1, 0]}>
 #blocked1 = #ttg.blocked<{sizePerThread = [1], threadsPerWarp = [32], warpsPerCTA = [8], order = [0]}>
 #blocked2 = #ttg.blocked<{sizePerThread = [1, 1], threadsPerWarp = [4, 8], warpsPerCTA = [8, 1], order = [0, 1]}>
+#linear = #ttg.linear<{register = [[2048], [8], [16], [32]], lane = [[64], [128], [1], [2], [4]], warp = [[256], [512], [1024]], block = []}>
 
 module attributes {"ttg.num-warps" = 8 : i32, "ttg.num-ctas" = 1 : i32, "ttg.target" = "cuda:80"} {
-tt.func @test_canonicalize_convert_view(%arg0: tensor<64x64xf32, #blocked0>) -> tensor<4096xf32, #blocked1> {
+tt.func @test_canonicalize_convert_view(%arg0: tensor<64x64xf32, #blocked0>) -> tensor<4096xf32, #linear> {
     %c = ttg.convert_layout %arg0 : tensor<64x64xf32, #blocked0> -> tensor<64x64xf32, #blocked2>
-    %r = tt.reshape %c allow_reorder : tensor<64x64xf32, #blocked2> -> tensor<4096xf32, #blocked1>
-    tt.return %r : tensor<4096xf32, #blocked1>
+    %r = tt.reshape %c : tensor<64x64xf32, #blocked2> -> tensor<4096xf32, #linear>
+    tt.return %r : tensor<4096xf32, #linear>
 }
 }  // end module
 
@@ -25,16 +26,17 @@ tt.func @test_canonicalize_convert_view(%arg0: tensor<64x64xf32, #blocked0>) -> 
 // CHECK-LABEL: @test_canonicalize_convert_expensive_view
 // CHECK-SAME: (%[[ARG:.+]]: tensor<256x16xf32
 //       CHECK:   %[[C:.+]] = ttg.convert_layout %[[ARG]]
-//       CHECK:   %[[V:.+]] = tt.reshape %[[C]] allow_reorder
+//       CHECK:   %[[V:.+]] = tt.reshape %[[C]]
 //       CHECK:   tt.return %[[V]]
 #blocked0 = #ttg.blocked<{sizePerThread = [1, 8], threadsPerWarp = [4, 8], warpsPerCTA = [8, 1], order = [1, 0]}>
 #blocked1 = #ttg.blocked<{sizePerThread = [1], threadsPerWarp = [32], warpsPerCTA = [8], order = [0]}>
 #blocked2 = #ttg.blocked<{sizePerThread = [1, 1], threadsPerWarp = [32, 1], warpsPerCTA = [8, 1], order = [0, 1]}>
+#linear = #ttg.linear<{register = [[1], [2], [4], [8]], lane = [[16], [32], [64], [128], [256]], warp = [[512], [1024], [2048]], block = []}>
 module attributes {"ttg.num-warps" = 8 : i32, "ttg.num-ctas" = 1 : i32, "ttg.target" = "cuda:80"} {
-tt.func @test_canonicalize_convert_expensive_view(%arg0: tensor<256x16xf32, #blocked0>) -> tensor<4096xf32, #blocked1> {
+tt.func @test_canonicalize_convert_expensive_view(%arg0: tensor<256x16xf32, #blocked0>) -> tensor<4096xf32, #linear> {
     %c = ttg.convert_layout %arg0 : tensor<256x16xf32, #blocked0> -> tensor<256x16xf32, #blocked2>
-    %r = tt.reshape %c allow_reorder : tensor<256x16xf32, #blocked2> -> tensor<4096xf32, #blocked1>
-    tt.return %r : tensor<4096xf32, #blocked1>
+    %r = tt.reshape %c : tensor<256x16xf32, #blocked2> -> tensor<4096xf32, #linear>
+    tt.return %r : tensor<4096xf32, #linear>
 }
 }  // end module
 
@@ -45,36 +47,34 @@ tt.func @test_canonicalize_convert_expensive_view(%arg0: tensor<256x16xf32, #blo
 // CHECK-LABEL: @test_canonicalize_convert_expensive_view
 // CHECK-SAME: (%[[ARG:.+]]: tensor<2xf32
 //       CHECK:   %[[C:.+]] = ttg.convert_layout %[[ARG]]
-//       CHECK:   %[[V:.+]] = tt.reshape %[[C]] allow_reorder
-//       CHECK:   tt.return %[[V]]
+//       CHECK:   tt.return %[[C]]
 #blocked = #ttg.blocked<{sizePerThread = [1, 1], threadsPerWarp = [8, 4], warpsPerCTA = [4, 1], order = [1, 0]}>
 #blocked1 = #ttg.blocked<{sizePerThread = [1], threadsPerWarp = [32], warpsPerCTA = [4], order = [0]}>
 module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.target = "cuda:80"} {
   tt.func @test_canonicalize_convert_expensive_view2(%arg0: tensor<2xf32, #ttg.slice<{dim = 1, parent = #blocked}>>) -> tensor<2xf32, #blocked1> {
     %c = ttg.convert_layout %arg0 : tensor<2xf32, #ttg.slice<{dim = 1, parent = #blocked}>> -> tensor<2xf32, #blocked1>
-    %r = tt.reshape %c allow_reorder : tensor<2xf32, #blocked1> -> tensor<2xf32, #blocked1>
+    %r = tt.reshape %c : tensor<2xf32, #blocked1> -> tensor<2xf32, #blocked1>
     tt.return %r : tensor<2xf32, #blocked1>
   }
 }
 
 // -----
 
-// test that the convert does get combined with the view even if the resulting operation
-// is an efficient view.
-// CHECK-LABEL: @test_canonicalize_convert_view
+// CHECK-LABEL: @test_canonicalize_convert_efficient_view
 // CHECK-SAME: (%[[ARG:.+]]: tensor<64x64xf32
-//   CHECK-NOT:   ttg.convert_layout
-//       CHECK:   %[[V:.+]] = tt.reshape %[[ARG]] allow_reorder
+//       CHECK:   %[[C:.+]] = ttg.convert_layout %[[ARG]]
+//       CHECK:   %[[V:.+]] = tt.reshape %[[C]] efficient_layout
 //       CHECK:   tt.return %[[V]]
 #blocked0 = #ttg.blocked<{sizePerThread = [1, 8], threadsPerWarp = [4, 8], warpsPerCTA = [8, 1], order = [1, 0]}>
 #blocked1 = #ttg.blocked<{sizePerThread = [1], threadsPerWarp = [32], warpsPerCTA = [8], order = [0]}>
 #blocked2 = #ttg.blocked<{sizePerThread = [1, 1], threadsPerWarp = [4, 8], warpsPerCTA = [8, 1], order = [0, 1]}>
+#linear = #ttg.linear<{register = [[2048], [8], [16], [32]], lane = [[64], [128], [1], [2], [4]], warp = [[256], [512], [1024]], block = []}>
 
 module attributes {"ttg.num-warps" = 8 : i32, "ttg.num-ctas" = 1 : i32, "ttg.target" = "cuda:80"} {
-tt.func @test_canonicalize_convert_view(%arg0: tensor<64x64xf32, #blocked0>) -> tensor<4096xf32, #blocked1> {
+tt.func @test_canonicalize_convert_efficient_view(%arg0: tensor<64x64xf32, #blocked0>) -> tensor<4096xf32, #linear> {
     %c = ttg.convert_layout %arg0 : tensor<64x64xf32, #blocked0> -> tensor<64x64xf32, #blocked2>
-    %r = tt.reshape %c allow_reorder efficient_layout : tensor<64x64xf32, #blocked2> -> tensor<4096xf32, #blocked1>
-    tt.return %r : tensor<4096xf32, #blocked1>
+    %r = tt.reshape %c efficient_layout : tensor<64x64xf32, #blocked2> -> tensor<4096xf32, #linear>
+    tt.return %r : tensor<4096xf32, #linear>
 }
 }  // end module
 

--- a/test/TritonGPU/combine.mlir
+++ b/test/TritonGPU/combine.mlir
@@ -2244,10 +2244,9 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 1 : i32, "ttg.thr
 module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 1 : i32, "ttg.threads-per-warp" = 32 : i32} {
   // CHECK-LABEL: @permuting_reshape_propagate
   tt.func public @permuting_reshape_propagate(%arg0: tensor<16x2xf32, #blocked>) -> tensor<32xf16, #blocked2> {
-    // CHECK-NOT: ttg.convert_layout
-    // CHECK: arith.truncf
     // CHECK: ttg.convert_layout
-    %a = tt.reshape %arg0 allow_reorder efficient_layout : tensor<16x2xf32, #blocked> -> tensor<32xf32, #blocked1>
+    // CHECK: arith.truncf
+    %a = tt.reshape %arg0 efficient_layout : tensor<16x2xf32, #blocked> -> tensor<32xf32, #blocked1>
     %b = ttg.convert_layout %a : tensor<32xf32, #blocked1> -> tensor<32xf32, #blocked2>
     %c = arith.truncf %b : tensor<32xf32, #blocked2> to tensor<32xf16, #blocked2>
     tt.return %c : tensor<32xf16, #blocked2>
@@ -2270,7 +2269,7 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32} {
     %1 = tt.splat %arg0 : !tt.ptr<i32> -> tensor<16x!tt.ptr<i32>, #blocked1>
     %2 = tt.addptr %1, %0 : tensor<16x!tt.ptr<i32>, #blocked1>, tensor<16xi32, #blocked1>
     %3 = tt.load %2 : tensor<16x!tt.ptr<i32>, #blocked1>
-    %4 = tt.reshape %3 allow_reorder : tensor<16xi32, #blocked1> -> tensor<8x2xi32, #blocked4>
+    %4 = tt.reshape %3 : tensor<16xi32, #blocked1> -> tensor<8x2xi32, #blocked4>
     %5 = ttg.convert_layout %4 : tensor<8x2xi32, #blocked4> -> tensor<8x2xi32, #blocked3>
     tt.return %5 : tensor<8x2xi32, #blocked3>
   }
@@ -2283,7 +2282,7 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32} {
     %1 = tt.splat %arg0 : !tt.ptr<i32> -> tensor<16x!tt.ptr<i32>, #blocked1>
     %2 = tt.addptr %1, %0 : tensor<16x!tt.ptr<i32>, #blocked1>, tensor<16xi32, #blocked1>
     %3 = tt.load %2 : tensor<16x!tt.ptr<i32>, #blocked1>
-    %4 = tt.reshape %3 allow_reorder efficient_layout : tensor<16xi32, #blocked1> -> tensor<8x2xi32, #blocked4>
+    %4 = tt.reshape %3 efficient_layout : tensor<16xi32, #blocked1> -> tensor<8x2xi32, #blocked4>
     %5 = ttg.convert_layout %4 : tensor<8x2xi32, #blocked4> -> tensor<8x2xi32, #blocked3>
     tt.return %5 : tensor<8x2xi32, #blocked3>
   }

--- a/test/TritonGPU/loop-pipeline-hip.mlir
+++ b/test/TritonGPU/loop-pipeline-hip.mlir
@@ -193,7 +193,7 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.targ
     %33:3 = scf.for %arg7 = %c0_i32 to %c5_i32 step %c1_i32 iter_args(%arg8 = %cst, %arg9 = %arg0, %arg10 = %arg1) -> (tensor<64x1x32xf32, #blocked>, tensor<1x512x!tt.ptr<f32>, #blocked2>, tensor<64x8x32x!tt.ptr<f32>, #blocked1>)  : i32 {
       %39 = tt.load %arg9 : tensor<1x512x!tt.ptr<f32>, #blocked2>
       %40 = tt.load %arg10 : tensor<64x8x32x!tt.ptr<f32>, #blocked1>
-      %41 = tt.reshape %39 allow_reorder : tensor<1x512xf32, #blocked2> -> tensor<64x1x8xf32, #blocked5>
+      %41 = tt.reshape %39 : tensor<1x512xf32, #blocked2> -> tensor<64x1x8xf32, #blocked5>
       %43 = ttg.convert_layout %41 : tensor<64x1x8xf32, #blocked5> -> tensor<64x1x8xf32, #ttg.dot_op<{opIdx = 0, parent = #blocked}>>
       %44 = ttg.convert_layout %40 : tensor<64x8x32xf32, #blocked1> -> tensor<64x8x32xf32, #ttg.dot_op<{opIdx = 1, parent = #blocked}>>
       %45 = tt.dot %43, %44, %arg8, inputPrecision = tf32 : tensor<64x1x8xf32, #ttg.dot_op<{opIdx = 0, parent = #blocked}>> * tensor<64x8x32xf32, #ttg.dot_op<{opIdx = 1, parent = #blocked}>> -> tensor<64x1x32xf32, #blocked>

--- a/test/TritonGPU/optimize-locality.mlir
+++ b/test/TritonGPU/optimize-locality.mlir
@@ -4,8 +4,8 @@
 // CHECK: %[[INIT_ARG:.*]] = arith.constant dense<0.000000e+00>
 // CHECK: %[[LOOP_OUTPUT:.*]] = scf.for {{.*}} iter_args(%[[FOR_ARG:.*]] = %[[INIT_ARG]]) -> {{.*}}
 // CHECK: %[[LOAD:.*]] = tt.load
-// CHECK: tt.reshape %[[LOAD]] allow_reorder efficient_layout : {{.*}} -> tensor<{{32x32x4xf32.*}}
-// CHECK-NEXT: %[[REDUCE:.*]] = "tt.reduce"({{%.*}}) <{axis = 2 : i32}>
+// CHECK: tt.reshape %[[LOAD]] efficient_layout : {{.*}} -> tensor<{{32x32x4xf32.*}}
+// CHECK: %[[REDUCE:.*]] = "tt.reduce"({{%.*}}) <{axis = 2 : i32}>
 // CHECK: arith.addf
 // CHECK: arith.addf %[[FOR_ARG]], %[[REDUCE]]
 // CHECK-NEXT: scf.yield
@@ -58,7 +58,7 @@ module attributes {"ttg.target" = "cuda:80", "ttg.num-ctas" = 1 : i32, "ttg.num-
 // CHECK: %[[LOOP_OUTPUT:.*]] = scf.for {{.*}} iter_args(%[[FOR_ARG:.*]] = %[[CST1]]) -> {{.*}}
 // CHECK: tt.load
 // CHECK: tt.reshape
-// CHECK-NEXT: %[[REDUCE:.*]] = "tt.reduce"({{%.*}}) <{axis = 2 : i32}>
+// CHECK: %[[REDUCE:.*]] = "tt.reduce"({{%.*}}) <{axis = 2 : i32}>
 // CHECK: arith.addf
 // CHECK: arith.addf %[[FOR_ARG]], %[[REDUCE]]
 // CHECK-NEXT: scf.yield
@@ -207,8 +207,8 @@ module attributes {"ttg.target" = "cuda:80", "ttg.num-ctas" = 1 : i32, "ttg.num-
 // CHECK: %[[INIT_ARG:.*]] = arith.constant dense<0xFF800000>
 // CHECK: %[[LOOP_OUTPUT:.*]] = scf.for {{.*}} iter_args(%[[FOR_ARG:.*]] = %[[INIT_ARG]]) -> {{.*}}
 // CHECK: %[[LOAD:.*]] = tt.load
-// CHECK: tt.reshape %[[LOAD]] allow_reorder efficient_layout : {{.*}} -> tensor<{{32x32x4xf32.*}}
-// CHECK-NEXT: %[[REDUCE:.*]] = "tt.reduce"({{%.*}}) <{axis = 2 : i32}>
+// CHECK: tt.reshape %[[LOAD]] efficient_layout : {{.*}} -> tensor<{{32x32x4xf32.*}}
+// CHECK: %[[REDUCE:.*]] = "tt.reduce"({{%.*}}) <{axis = 2 : i32}>
 // CHECK: arith.maximumf
 // CHECK: arith.maximumf %[[FOR_ARG]], %[[REDUCE]]
 // CHECK-NEXT: scf.yield
@@ -262,7 +262,7 @@ module attributes {"ttg.target" = "cuda:80", "ttg.num-ctas" = 1 : i32, "ttg.num-
 // CHECK: %[[LOOP_OUTPUT:.*]] = scf.for {{.*}} iter_args(%[[FOR_ARG:.*]] = %[[CST1]]) -> {{.*}}
 // CHECK: tt.load
 // CHECK: tt.reshape
-// CHECK-NEXT: %[[REDUCE:.*]] = "tt.reduce"({{%.*}}) <{axis = 2 : i32}>
+// CHECK: %[[REDUCE:.*]] = "tt.reduce"({{%.*}}) <{axis = 2 : i32}>
 // CHECK: arith.maximumf
 // CHECK: arith.maximumf %[[FOR_ARG]], %[[REDUCE]]
 // CHECK-NEXT: scf.yield
@@ -314,8 +314,8 @@ module attributes {"ttg.target" = "cuda:80", "ttg.num-ctas" = 1 : i32, "ttg.num-
 // CHECK: %[[CST:.*]] = arith.constant dense<0x7F800000>
 // CHECK: %[[LOOP_OUTPUT:.*]] = scf.for {{.*}} iter_args(%[[FOR_ARG:.*]] = %[[CST]]) -> {{.*}}
 // CHECK: %[[LOAD:.*]] = tt.load
-// CHECK: tt.reshape %[[LOAD]] allow_reorder efficient_layout : {{.*}} -> tensor<{{32x32x4xf32.*}}
-// CHECK-NEXT: %[[REDUCE:.*]] = "tt.reduce"({{%.*}}) <{axis = 2 : i32}>
+// CHECK: tt.reshape %[[LOAD]] efficient_layout : {{.*}} -> tensor<{{32x32x4xf32.*}}
+// CHECK: %[[REDUCE:.*]] = "tt.reduce"({{%.*}}) <{axis = 2 : i32}>
 // CHECK: arith.minimumf
 // CHECK: arith.minimumf %[[FOR_ARG]], %[[REDUCE]]
 // CHECK-NEXT: scf.yield
@@ -369,7 +369,7 @@ module attributes {"ttg.target" = "cuda:80", "ttg.num-ctas" = 1 : i32, "ttg.num-
 // CHECK: %[[LOOP_OUTPUT:.*]] = scf.for {{.*}} iter_args(%[[FOR_ARG:.*]] = %[[CST1]]) -> {{.*}}
 // CHECK: tt.load
 // CHECK: tt.reshape
-// CHECK-NEXT: %[[REDUCE:.*]] = "tt.reduce"({{%.*}}) <{axis = 2 : i32}>
+// CHECK: %[[REDUCE:.*]] = "tt.reduce"({{%.*}}) <{axis = 2 : i32}>
 // CHECK: arith.minimumf
 // CHECK: arith.minimumf %[[FOR_ARG]], %[[REDUCE]]
 // CHECK-NEXT: scf.yield
@@ -421,8 +421,8 @@ module attributes {"ttg.target" = "cuda:80", "ttg.num-ctas" = 1 : i32, "ttg.num-
 // CHECK: %[[CST:.*]] = arith.constant dense<1.000000e+00>
 // CHECK: %[[LOOP_OUTPUT:.*]] = scf.for {{.*}} iter_args(%[[FOR_ARG:.*]] = %[[CST]]) -> {{.*}}
 // CHECK: %[[LOAD:.*]] = tt.load
-// CHECK: tt.reshape %[[LOAD]] allow_reorder efficient_layout : {{.*}} -> tensor<{{32x32x4xf32.*}}
-// CHECK-NEXT: %[[REDUCE:.*]] = "tt.reduce"({{%.*}}) <{axis = 2 : i32}>
+// CHECK: tt.reshape %[[LOAD]] efficient_layout : {{.*}} -> tensor<{{32x32x4xf32.*}}
+// CHECK: %[[REDUCE:.*]] = "tt.reduce"({{%.*}}) <{axis = 2 : i32}>
 // CHECK: arith.mulf
 // CHECK: arith.mulf %[[FOR_ARG]], %[[REDUCE]]
 // CHECK-NEXT: scf.yield
@@ -476,7 +476,7 @@ module attributes {"ttg.target" = "cuda:80", "ttg.num-ctas" = 1 : i32, "ttg.num-
 // CHECK: %[[LOOP_OUTPUT:.*]] = scf.for {{.*}} iter_args(%[[FOR_ARG:.*]] = %[[CST1]]) -> {{.*}}
 // CHECK: tt.load
 // CHECK: tt.reshape
-// CHECK-NEXT: %[[REDUCE:.*]] = "tt.reduce"({{%.*}}) <{axis = 2 : i32}>
+// CHECK: %[[REDUCE:.*]] = "tt.reduce"({{%.*}}) <{axis = 2 : i32}>
 // CHECK: arith.mulf
 // CHECK: arith.mulf %[[FOR_ARG]], %[[REDUCE]]
 // CHECK-NEXT: scf.yield
@@ -570,51 +570,6 @@ module attributes {"ttg.target" = "cuda:80", "ttg.num-ctas" = 1 : i32, "ttg.num-
     %26 = ttg.convert_layout %19 : tensor<32xf32, #ttg.slice<{dim = 1, parent = #blocked}>> -> tensor<32xf32, #blocked1>
     tt.store %25, %26 : tensor<32x!tt.ptr<f32>, #blocked1>
     tt.return
-  }
-}
-
-// -----
-
-// CHECK-DAG: #[[$BLOCK0:.+]] = #ttg.blocked<{sizePerThread = [1, 16], threadsPerWarp = [4, 8], warpsPerCTA = [2, 1], order = [1, 0]}>
-// CHECK-DAG: #[[$BLOCK1:.+]] = #ttg.blocked<{sizePerThread = [1, 1], threadsPerWarp = [2, 16], warpsPerCTA = [2, 1], order = [1, 0]}>
-// CHECK-DAG: #[[$BLOCK2:.+]] = #ttg.blocked<{sizePerThread = [1, 1], threadsPerWarp = [32, 1], warpsPerCTA = [2, 1], order = [0, 1]}>
-// CHECK-LABEL: optimize_view_layout
-// CHECK: %[[R:.+]] = tt.reshape {{.*}} allow_reorder efficient_layout : tensor<8x128xf32, #[[$BLOCK0]]> -> tensor<64x16xf32, #[[$BLOCK2]]>
-// CHECK: %[[C:.+]] = ttg.convert_layout %[[R]] : tensor<64x16xf32, #[[$BLOCK2]]> -> tensor<64x16xf32, #[[$BLOCK1]]>
-// CHECK:  "tt.reduce"(%[[C]])
-#blocked = #ttg.blocked<{sizePerThread = [1, 16], threadsPerWarp = [4, 8], warpsPerCTA = [2, 1], order = [1, 0]}>
-#blocked1 = #ttg.blocked<{sizePerThread = [1, 1], threadsPerWarp = [2, 16], warpsPerCTA = [2, 1], order = [1, 0]}>
-module attributes {"ttg.target" = "cuda:80", "ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 2 : i32, "ttg.threads-per-warp" = 32 : i32} {
-  tt.func public @optimize_view_layout(%arg0: tensor<8x128xf32, #blocked>) -> tensor<64xf32, #ttg.slice<{dim = 1, parent = #blocked1}>> {
-    %0 = tt.reshape %arg0 allow_reorder : tensor<8x128xf32, #blocked> -> tensor<64x16xf32, #blocked1>
-    %1 = "tt.reduce"(%0) <{axis = 1 : i32}> ({
-    ^bb0(%arg1: f32, %arg2: f32):
-      %2 = arith.maximumf %arg1, %arg2 : f32
-      tt.reduce.return %2 : f32
-    }) : (tensor<64x16xf32, #blocked1>) -> tensor<64xf32, #ttg.slice<{dim = 1, parent = #blocked1}>>
-    tt.return %1 : tensor<64xf32, #ttg.slice<{dim = 1, parent = #blocked1}>>
-  }
-}
-
-// -----
-
-
-// CHECK-DAG: #[[$BLOCK0:.+]] = #ttg.blocked<{sizePerThread = [1, 1], threadsPerWarp = [2, 16], warpsPerCTA = [2, 1], order = [1, 0]}>
-// CHECK-DAG: #[[$BLOCK1:.+]] = #ttg.blocked<{sizePerThread = [1, 1], threadsPerWarp = [32, 1], warpsPerCTA = [2, 1], order = [0, 1]}>
-// CHECK-LABEL: optimize_view_layout_same_shape
-// CHECK: %[[R:.+]] = tt.reshape {{.*}} allow_reorder efficient_layout : tensor<64x16xf32, #[[$BLOCK0]]> -> tensor<64x16xf32, #[[$BLOCK1]]>
-// CHECK: %[[C:.+]] = ttg.convert_layout %[[R]] : tensor<64x16xf32, #[[$BLOCK1]]> -> tensor<64x16xf32, #[[$BLOCK0]]>
-// CHECK:  "tt.reduce"(%[[C]])
-#blocked = #ttg.blocked<{sizePerThread = [1, 1], threadsPerWarp = [2, 16], warpsPerCTA = [2, 1], order = [1, 0]}>
-module attributes {"ttg.target" = "cuda:80", "ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 2 : i32, "ttg.threads-per-warp" = 32 : i32} {
-  tt.func public @optimize_view_layout_same_shape(%arg0: tensor<64x16xf32, #blocked>) -> tensor<64xf32, #ttg.slice<{dim = 1, parent = #blocked}>> {
-    %0 = tt.reshape %arg0 allow_reorder : tensor<64x16xf32, #blocked> -> tensor<64x16xf32, #blocked>
-    %1 = "tt.reduce"(%0) <{axis = 1 : i32}> ({
-    ^bb0(%arg1: f32, %arg2: f32):
-      %2 = arith.maximumf %arg1, %arg2 : f32
-      tt.reduce.return %2 : f32
-    }) : (tensor<64x16xf32, #blocked>) -> tensor<64xf32, #ttg.slice<{dim = 1, parent = #blocked}>>
-    tt.return %1 : tensor<64xf32, #ttg.slice<{dim = 1, parent = #blocked}>>
   }
 }
 

--- a/third_party/amd/lib/TritonAMDGPUTransforms/CanonicalizePointers.cpp
+++ b/third_party/amd/lib/TritonAMDGPUTransforms/CanonicalizePointers.cpp
@@ -422,7 +422,7 @@ createDecomposeOffsetFromExpr(RewriterBase &rewriter, Location loc, Value expr,
                 rewriter, loc, reshapeOp.getSrc(), bitness, scalarToSplatMap);
             Value reshapeNonUniform = tt::ReshapeOp::create(
                 rewriter, loc, reshapeOp.getType(), nonUniform,
-                reshapeOp.getAllowReorder(), reshapeOp.getEfficientLayout());
+                reshapeOp.getEfficientLayout());
             return std::make_pair(uniform, reshapeNonUniform);
           })
           .Case<arith::AddIOp>([&](Operation *op) {
@@ -1619,9 +1619,9 @@ public:
         result.getShape(),
         llvm::cast<RankedTensorType>(fatPtrOffset.getType()).getElementType(),
         result.getEncoding());
-    auto newOffset = tt::ReshapeOp::create(
-        rewriter, reshapeOp.getLoc(), newResult, fatPtrOffset,
-        reshapeOp.getAllowReorder(), reshapeOp.getEfficientLayout());
+    auto newOffset =
+        tt::ReshapeOp::create(rewriter, reshapeOp.getLoc(), newResult,
+                              fatPtrOffset, reshapeOp.getEfficientLayout());
     rewriter.replaceOpWithMultiple(reshapeOp, {{fatPtrBase, newOffset}});
     fatPtrs[{fatPtrBase, newOffset}] = fatPtrs.at({fatPtrBase, fatPtrOffset});
 

--- a/unittest/Dialect/TritonGPU/DialectTest.cpp
+++ b/unittest/Dialect/TritonGPU/DialectTest.cpp
@@ -136,7 +136,7 @@ void testReshape(RankedTensorType srcTy, RankedTensorType dstTy,
         ctx, [&](Diagnostic &diag) { diags.push_back("  - " + diag.str()); });
     result = inferLayout->inferReshapeOpEncoding(
         srcTy.getShape(), srcTy.getEncoding(), dstTy.getShape(), inferredEnc,
-        /*allowReorder=*/false, UnknownLoc::get(ctx));
+        UnknownLoc::get(ctx));
   }
 
   // We expect the reshape to succeed as long as the inputs have the same
@@ -161,7 +161,7 @@ void testReshape(RankedTensorType srcTy, RankedTensorType dstTy,
     Attribute inferredSrcEnc;
     auto result = inferLayout->inferReshapeOpEncoding(
         dstTy.getShape(), inferredEnc, srcTy.getShape(), inferredSrcEnc,
-        /*allowReorder=*/false, UnknownLoc::get(ctx));
+        UnknownLoc::get(ctx));
     EXPECT_TRUE(succeeded(result))
         << "Inverse encoding inference (" << triton::join(dstTy.getShape(), "x")
         << " " << stringifyLLVMType(inferredEnc) << " -> "
@@ -436,8 +436,7 @@ TEST_F(JoinOpTest, JoinOpLayoutPropagation) {
       }
       Attribute reshapedEnc;
       result = inferLayout->inferReshapeOpEncoding(
-          transShape, transEnc, newShape, reshapedEnc,
-          /*allowReorder=*/false, std::nullopt);
+          transShape, transEnc, newShape, reshapedEnc, std::nullopt);
       assert(succeeded(result));
       // The layouts should be structurally the same
       // but reshapeEnc will likely be a LinearEncodingAttr


### PR DESCRIPTION
Drop support for reorderable reshapes. Keep the frontend flag for backward compatibility and just ignore it (which is perfectly valid).