### PR TITLE
[FRONTEND] Support tuple-unpacking targets in list comprehensions

### DIFF
--- a/python/test/unit/language/test_frontend.py
+++ b/python/test/unit/language/test_frontend.py
@@ -484,6 +484,81 @@ def test_list_comprehension_if_filter():
     run_parser(kernel)
 
 
+def test_list_comprehension_tuple_target():
+
+    @triton.jit
+    def kernel():
+        # a tuple target unpacks each item and keeps the bindings constexpr
+        vals: tl.constexpr = [a + b for a, b in ((1, 2), (3, 4))]
+        tl.static_assert(len(vals) == 2)
+        tl.static_assert(vals[0] == 3)
+        tl.static_assert(vals[1] == 7)
+
+        # nested targets unpack recursively
+        nested: tl.constexpr = [a + b + c for a, (b, c) in ((1, (2, 3)), (4, (5, 6)))]
+        tl.static_assert(len(nested) == 2)
+        tl.static_assert(nested[0] == 6)
+        tl.static_assert(nested[1] == 15)
+
+        # tuple targets compose with `if` filters
+        filtered: tl.constexpr = [a for a, b in ((1, 2), (3, 4), (5, 6)) if b > 2]
+        tl.static_assert(len(filtered) == 2)
+        tl.static_assert(filtered[0] == 3)
+        tl.static_assert(filtered[1] == 5)
+
+    run_parser(kernel)
+
+
+def test_list_comprehension_target_rejects_too_many_values():
+
+    @triton.jit
+    def kernel():
+        vals: tl.constexpr = [a + b for a, b in ((1, 2, 3), )]  # noqa: F841
+
+    with pytest.raises(CompilationError, match=r"too many values to unpack \(expected 2\)"):
+        run_parser(kernel)
+
+
+def test_list_comprehension_target_rejects_too_few_values():
+
+    @triton.jit
+    def kernel():
+        vals: tl.constexpr = [a + b + c for a, b, c in ((1, 2), )]  # noqa: F841
+
+    with pytest.raises(CompilationError, match=r"not enough values to unpack \(expected 3, got 2\)"):
+        run_parser(kernel)
+
+
+def test_list_comprehension_target_rejects_scalar_item():
+
+    @triton.jit
+    def kernel():
+        vals: tl.constexpr = [a + b for a, b in (1, 2)]  # noqa: F841
+
+    with pytest.raises(CompilationError, match="cannot unpack non-tuple value"):
+        run_parser(kernel)
+
+
+def test_list_comprehension_target_rejects_starred_target():
+
+    @triton.jit
+    def kernel():
+        vals: tl.constexpr = [a for a, *rest in ((1, 2, 3), )]  # noqa: F841
+
+    with pytest.raises(CompilationError, match="starred assignment targets are not supported"):
+        run_parser(kernel)
+
+
+def test_tuple_assignment_rejects_scalar_value():
+
+    @triton.jit
+    def kernel():
+        a, b = 1  # noqa: F841
+
+    with pytest.raises(CompilationError, match="cannot unpack non-tuple value"):
+        run_parser(kernel)
+
+
 def test_named_expr_respects_prior_constexpr_annotation():
 
     @triton.jit

--- a/python/triton/compiler/code_generator.py
+++ b/python/triton/compiler/code_generator.py
@@ -544,7 +544,9 @@ class CodeGenerator(ast.NodeVisitor):
 
         results = []
         for item in iter:
-            self.set_value(comp.target.id, item)
+            # `assignTarget` binds plain names as well as (possibly nested) tuple
+            # targets, so `for a, b in ...` unpacks the same way tuple assignment does.
+            self.assignTarget(comp.target, item)
             # Apply the comprehension's `if` filters (the conditions are constexpr).
             if all(self.visit(cond) for cond in comp.ifs):
                 results.append(self.visit(node.elt))
@@ -721,13 +723,28 @@ class CodeGenerator(ast.NodeVisitor):
         # default: call visit_Assign
         return self.visit_Assign(node)
 
+    def _check_unpackable(self, target: ast.Tuple, value):
+        # Diagnostics shared by tuple assignment and comprehension targets, so that
+        # both report starred targets and arity mismatches the same way.
+        if any(isinstance(elt, ast.Starred) for elt in target.elts):
+            raise NotImplementedError("starred assignment targets are not supported")
+        if not isinstance(value, language.tuple):
+            raise ValueError(f"cannot unpack non-tuple value of type {value.type}")
+        num_targets, num_values = len(target.elts), len(value.values)
+        if num_targets != num_values:
+            # Match CPython's errors for mismatched unpacking.
+            if num_values > num_targets:
+                raise ValueError(f"too many values to unpack (expected {num_targets})")
+            raise ValueError(f"not enough values to unpack (expected {num_targets}, got {num_values})")
+
     def assignTarget(self, target, value):
         assert isinstance(target.ctx, ast.Store)
         if isinstance(target, ast.Subscript):
             return self.visit_Subscript_Store(target, value)
         if isinstance(target, ast.Tuple):
-            for i, target in enumerate(target.elts):
-                self.assignTarget(target, value.values[i])
+            self._check_unpackable(target, value)
+            for elt, val in zip(target.elts, value.values):
+                self.assignTarget(elt, val)
             return
         if isinstance(target, ast.Attribute):
             raise NotImplementedError("Attribute assignment is not supported in triton")
@@ -749,16 +766,7 @@ class CodeGenerator(ast.NodeVisitor):
 
         def _sanitize_target_value(target, value):
             if isinstance(target, ast.Tuple) and isinstance(value, language.tuple):
-                if any(isinstance(elt, ast.Starred) for elt in target.elts):
-                    raise NotImplementedError("starred assignment targets are not supported")
-                num_targets, num_values = len(target.elts), len(value.values)
-                if num_targets != num_values:
-                    # Match CPython's errors for mismatched unpacking.
-                    if num_values > num_targets:
-                        message = f"too many values to unpack (expected {num_targets})"
-                    else:
-                        message = f"not enough values to unpack (expected {num_targets}, got {num_values})"
-                    raise ValueError(message)
+                self._check_unpackable(target, value)
                 vals = [_sanitize_target_value(elt, val) for elt, val in zip(target.elts, value.values)]
                 vals = [constexpr(val) if val is None else val for val in vals]
                 types = [val.type for val in vals]


### PR DESCRIPTION
Fixes #11073.

`CodeGenerator.visit_ListComp` bound the iteration target with `self.set_value(comp.target.id, item)`, which assumes the comprehension target is always a single `ast.Name`. A tuple target parses to an `ast.Tuple`, which has no `id`, so a comprehension like the one below failed during AST lowering with `AttributeError: 'Tuple' object has no attribute 'id'`, even though the equivalent tuple assignment works:

```python
@triton.jit
def kernel():
    vals: tl.constexpr = [a + b for a, b in ((1, 2), (3, 4))]
    tl.static_assert(vals[0] == 3)
    tl.static_assert(vals[1] == 7)
```

The fix binds the target with `assignTarget`, the helper `visit_Assign` already uses for assignment targets. For a plain `ast.Name` target it resolves to the same `set_value` call as before, so existing comprehensions are unchanged. For an `ast.Tuple` target it unpacks recursively, so nested targets such as `for a, (b, c) in ...` work, and the bound values stay constexpr because nothing is materialized into a tensor along the way.

Tuple assignment already produced CPython-style diagnostics for starred targets and arity mismatches, but those checks lived inside `visit_Assign._sanitize_target_value` and so were unreachable from the comprehension path. They are moved into a small `_check_unpackable` helper that both paths call, which gives comprehension targets the same messages. The helper also adds an explicit error when a tuple target receives a non-tuple value, replacing the `AttributeError: object has no attribute 'values'` that both paths raised before.

Testing: added parser-only tests in `python/test/unit/language/test_frontend.py` covering flat tuple targets, nested tuple targets, tuple targets combined with an `if` filter, too many values, too few values, a scalar item, and a starred target, plus one test for the improved scalar diagnostic on ordinary tuple assignment. These run through `run_parser` and need no GPU. I do not have a Triton build on this machine, so I verified the new control flow by replaying `visit_ListComp`, `assignTarget`, and `_check_unpackable` against real `ast` nodes in an isolated harness and confirmed each expected value and error message. `ruff` and `yapf` from the repo pre-commit config are clean on both changed files.