### PR TITLE
[WIP][AMDGPU][GFX1250] micro-warp specialization for L2 prefetch

### DIFF
--- a/python/src/gluon_ir.cc
+++ b/python/src/gluon_ir.cc
@@ -1255,6 +1255,13 @@ void init_gluon_ir(py::module_ &m) {
                  returnOffsets ? UnitAttr::get(self.getContext()) : nullptr);
              return returnOffsets ? op->getResult(0) : nullptr;
            })
+      .def("create_tdm_prefetch_v2",
+           [](GluonOpBuilder &self, Value descPtr0,
+              std::vector<Value> &indices0, Value descPtr1,
+              std::vector<Value> &indices1, Value pred, bool speculative) {
+             self.create<ttag::TDMPrefetchV2Op>(descPtr0, indices0, descPtr1,
+                                                indices1, pred, speculative);
+           })
       .def("create_async_tdm_wait",
            [](GluonOpBuilder &self, int num) {
              ValueRange tokens;

--- a/python/triton/experimental/gluon/language/amd/gfx1250/tdm.py
+++ b/python/triton/experimental/gluon/language/amd/gfx1250/tdm.py
@@ -475,6 +475,28 @@ def prefetch(src: tensor_descriptor, offsets: List[ttgl.constexpr | ttgl.tensor]
 
 
 @builtin
+def prefetch_v2(src0: tensor_descriptor, offsets0: List[ttgl.constexpr | ttgl.tensor], src1: tensor_descriptor,
+                offsets1: List[ttgl.constexpr | ttgl.tensor], pred: bool = True, speculative: bool = False,
+                _semantic=None) -> None:
+    """Prefetches a block of tensor specified in tensor descriptor from global memory into L2. Speculative prefetches can generate more
+    efficient assembly because they do not require out of bounds checks. However, they are dropped by the hardware if their virtual address translation is not cached.
+    So speculative should only be set if previous iterations have accessed the same virtual page (e.g. column major)
+    Args:
+        src (tensor_descriptor): the source tensor descriptor.
+        offsets (List[int]): the offsets from the base pointer in the tensor descriptor.
+        pred (bool, optional): Predicate to enable or disable the prefetch. Defaults to True.
+        speculative (bool, optional): Whether the prefetch is speculative. Defaults to False.
+    """
+    offset_handles0 = _semantic._convert_to_ir_values(offsets0, require_i64=False)
+    offset_handles1 = _semantic._convert_to_ir_values(offsets1, require_i64=False)
+    pred = _semantic.to_tensor(pred)
+    pred_handle = pred.handle
+    speculative = _unwrap_if_constexpr(speculative)
+    _semantic.builder.create_tdm_prefetch_v2(src0.handle, offset_handles0, src1.handle, offset_handles1, pred_handle,
+                                             speculative)
+
+
+@builtin
 def _test_prefetch_with_offsets(src: tensor_descriptor, offsets: List[ttgl.constexpr | ttgl.tensor], pred: bool = True,
                                 speculative: bool = False, _semantic=None) -> ttgl.tensor:
     """Test-only prefetch variant that returns offsets for validation."""

--- a/third_party/amd/include/Dialect/TritonAMDGPU/IR/TritonAMDGPUOps.td
+++ b/third_party/amd/include/Dialect/TritonAMDGPU/IR/TritonAMDGPUOps.td
@@ -1045,6 +1045,39 @@ def TDMPrefetchOp : TT_AMDGPU_Op<"tdm_prefetch", [
   }];
 }
 
+
+
+def TDMPrefetchV2Op : TT_AMDGPU_Op<"tdm_prefetch_v2", [
+    MemoryEffects<[MemWrite<L2Cache>]>,
+    AttrSizedOperandSegments,
+    DeclareOpInterfaceMethods<PredicatedOpInterface>
+  ]> {
+  let summary = "Prefetch data based on a TDM descriptor from global memory to L2.";
+
+  let description = [{
+    This operation prefetches data from global memory to L2. It is analogous to the AsyncTDMCopyGlobalToLocalOp,
+    but it does not copy the data to local memory and instead only prefetches the data into the L2 cache.
+    Speculative prefetches can generate more efficient assembly because they do not require out of bounds checks.
+    However, they are dropped by the hardware in case the virtual address translation is not already cached at CU level.
+  }];
+
+  let arguments = (ins
+    Arg<TT_TensorDescType, "", [MemRead<GlobalMemory>]>:$desc0,
+    Variadic<I32>:$indices0,
+    Arg<TT_TensorDescType, "", [MemRead<GlobalMemory>]>:$desc1,
+    Variadic<I32>:$indices1,
+    I1:$pred,
+    BoolAttr:$speculative
+  );
+
+  let results = (outs);
+
+  let assemblyFormat = [{
+    $desc0 `[` $indices0 `]` $desc1 `[` $indices1 `]` `,` $pred `,` `speculative` `=` $speculative
+    attr-dict `:` qualified(type($desc0)) qualified(type($desc1))
+  }];
+}
+
 //===----------------------------------------------------------------------===//
 // UpdateTensorDescriptorOp
 //===----------------------------------------------------------------------===//

--- a/third_party/amd/lib/Dialect/TritonAMDGPU/IR/Dialect.cpp
+++ b/third_party/amd/lib/Dialect/TritonAMDGPU/IR/Dialect.cpp
@@ -1426,4 +1426,12 @@ Type TDMPrefetchOp::getPredicateOperandTypeLike() {
   return IntegerType::get(getContext(), 1);
 }
 
+Value TDMPrefetchV2Op::getPredicateOperand() { return getPred(); }
+void TDMPrefetchV2Op::setPredicateOperand(Value pred) {
+  getPredMutable().assign(pred);
+}
+Type TDMPrefetchV2Op::getPredicateOperandTypeLike() {
+  return IntegerType::get(getContext(), 1);
+}
+
 } // namespace mlir::triton::amdgpu

--- a/third_party/amd/lib/TritonAMDGPUToLLVM/LoadStoreOpToLLVM.cpp
+++ b/third_party/amd/lib/TritonAMDGPUToLLVM/LoadStoreOpToLLVM.cpp
@@ -2618,21 +2618,96 @@ struct TDMPrefetchConversion
     auto [laneId, warpId] = getLaneAndWarpId(rewriter, loc);
     auto ctaId = targetInfo.getClusterCTAId(rewriter, loc);
 
-    auto offsets = mlir::LLVM::AMD::emitTDMPrefetch(
+    auto prefetchAddrs = mlir::LLVM::AMD::emitTDMPrefetch(
         rewriter, loc, desc, blockShape, threadsPerWarp, numWarps, numCTAs,
         offset, op.getPred(), elementType, laneId, warpId, ctaId,
         op.getSpeculative());
 
-    // If the op has no results, just erase it
-    if (op->getNumResults() == 0) {
-      rewriter.eraseOp(op);
-      return success();
+    constexpr int cacheScope = 8; // (8) = L2 scope
+    // encoding: 0 - speculative; 1 - non-speculative (see docs)
+    const int hintValue = cacheScope | static_cast<int>(!op.getSpeculative());
+    IntegerAttr hint = rewriter.getI32IntegerAttr(hintValue);
+
+    for (auto addr : prefetchAddrs) {
+      ROCDL::GlobalPrefetchOp::create(rewriter, loc, addr, hint, {}, {}, {});
     }
 
-    // Return offsets
-    Value resultStruct = packTensorElements(loc, getTypeConverter(), offsets,
-                                            rewriter, op.getType(0));
-    rewriter.replaceOp(op, {resultStruct});
+    rewriter.eraseOp(op);
+    return success();
+  }
+
+private:
+  const AMD::TargetInfo &targetInfo;
+};
+
+struct TDMPrefetchV2Conversion
+    : public ConvertOpToLLVMPattern<triton::amdgpu::TDMPrefetchV2Op> {
+  TDMPrefetchV2Conversion(LLVMTypeConverter &converter,
+                          const AMD::TargetInfo &targetInfo,
+                          PatternBenefit benefit)
+      : ConvertOpToLLVMPattern(converter, benefit), targetInfo(targetInfo) {}
+  using ConvertOpToLLVMPattern::ConvertOpToLLVMPattern;
+
+  LogicalResult
+  matchAndRewrite(triton::amdgpu::TDMPrefetchV2Op op, OpAdaptor adaptor,
+                  ConversionPatternRewriter &rewriter) const override {
+    auto loc = op.getLoc();
+    auto b = TritonLLVMOpBuilder(loc, rewriter);
+
+    auto a = adaptor.getDesc0();
+    SmallVector<std::tuple<TypedValue<triton::TensorDescType>, Value,
+                           SmallVector<Value>>>
+        data = {
+            {op.getDesc0(), adaptor.getDesc0(), adaptor.getIndices0()},
+            {op.getDesc1(), adaptor.getDesc1(), adaptor.getIndices1()},
+        };
+
+    SmallVector<SmallVector<Value>> prefetchAdds{2};
+
+    auto mod = op->getParentOfType<ModuleOp>();
+    int threadsPerWarp = TritonGPUDialect::getThreadsPerWarp(mod);
+    int halfWaves = lookupNumWarps(op) / 2;
+    int numCTAs = lookupNumCTAs(op);
+
+    auto [laneId, warpId] = getLaneAndWarpId(rewriter, loc);
+    auto ctaId = targetInfo.getClusterCTAId(rewriter, loc);
+
+    for (auto [idx, item] : llvm::enumerate(data)) {
+      auto &mlirDesc = std::get<0>(item);
+      auto &llvmDesc = std::get<1>(item);
+      auto &offset = std::get<2>(item);
+
+      auto tdescType = mlirDesc.getType();
+      SmallVector<int64_t> blockShape = llvm::to_vector(tdescType.getShape());
+      Type elementType =
+          getTypeConverter()->convertType(tdescType.getElementType());
+      SmallVector<Value> desc =
+          mlir::LLVM::AMD::unpackTDMDescriptor(rewriter, loc, llvmDesc);
+
+      prefetchAdds[idx] = mlir::LLVM::AMD::emitTDMPrefetch(
+          rewriter, loc, desc, blockShape, threadsPerWarp, halfWaves, numCTAs,
+          offset, op.getPred(), elementType, laneId, warpId, ctaId,
+          op.getSpeculative());
+    }
+
+    constexpr int cacheScope = 8; // (8) = L2 scope
+    // encoding: 0 - speculative; 1 - non-speculative (see docs)
+    const int hintValue = cacheScope | static_cast<int>(!op.getSpeculative());
+    IntegerAttr hint = rewriter.getI32IntegerAttr(hintValue);
+
+    assert(prefetchAdds[0].size() == prefetchAdds[1].size());
+    const size_t numPrefetchAddrs = prefetchAdds[0].size();
+    for (size_t i = 0; i < numPrefetchAddrs; ++i) {
+      Value pred = b.icmp_slt(warpId, b.i32_val(halfWaves));
+      Value prefetchPtr =
+          b.select(pred, prefetchAdds[0][i], prefetchAdds[1][i]);
+
+      ROCDL::GlobalPrefetchOp::create(rewriter, loc, prefetchPtr, hint, {}, {},
+                                      {});
+    }
+
+    rewriter.eraseOp(op);
+
     return success();
   }
 
@@ -2660,6 +2735,7 @@ void populateLoadStoreOpToLLVMPatterns(LLVMTypeConverter &typeConverter,
   patterns.add<TTGAsyncWaitOpConversion>(typeConverter, targetInfo, benefit);
   patterns.add<AsyncWaitOpConversion>(typeConverter, targetInfo, benefit);
   patterns.add<TDMPrefetchConversion>(typeConverter, targetInfo, benefit);
+  patterns.add<TDMPrefetchV2Conversion>(typeConverter, targetInfo, benefit);
   patterns.add<AsyncTDMIntrinsicWaitConversion>(typeConverter, benefit);
   patterns.add<AsyncCommitGroupOpConversion>(typeConverter, targetInfo,
                                              benefit);

--- a/third_party/amd/lib/TritonAMDGPUToLLVM/TDMUtility.cpp
+++ b/third_party/amd/lib/TritonAMDGPUToLLVM/TDMUtility.cpp
@@ -1627,10 +1627,6 @@ SmallVector<Value> emitTDMPrefetch(RewriterBase &rewriter, Location loc,
                                         {kWarp, warpId},
                                         {kBlock, ctaId}});
 
-  constexpr int cacheScope = 8; // (8) = L2 scope
-  const int hintValue = cacheScope | static_cast<int>(isSpeculative);
-  IntegerAttr hint = rewriter.getI32IntegerAttr(hintValue);
-
   // Iterate over each register and emit a prefetch intrinsic
   SmallVector<Value> offsets(ll.getInDimSize(kRegister));
   for (int reg = 0; reg < ll.getInDimSize(kRegister); reg++) {
@@ -1661,12 +1657,7 @@ SmallVector<Value> emitTDMPrefetch(RewriterBase &rewriter, Location loc,
     Value prefetchPtr =
         b.gep(globalPtrTy, elementType, tilePtr, clampedLocalOffset);
 
-    ROCDL::GlobalPrefetchOp::create(rewriter, loc, prefetchPtr, hint, {}, {},
-                                    {});
-
-    // We return the offsets for unit testing
-    offsets[reg] =
-        b.select(combinedPred, b.add(localOffset, tileOffset), b.i64_val(0));
+    offsets[reg] = prefetchPtr;
   }
   return offsets;
 }


### PR DESCRIPTION
Adds a new tdm_prefetch_v2 op that prefetches from two tensor descriptors in a single instruction, splitting the warps in a CTA into two halves so that each half computes/issues prefetch addresses for a different descriptor (micro-warp specialization), then selects the right address per-lane via warpId comparison before issuing the rocdl.global.prefetch intrinsic.

Status: Work in progress — marked WIP in the commit; no test coverage yet for tdm_prefetch_v2/prefetch_v2.

@guacamoleo @sriakrish 