### PR TITLE
[AMD] Re-enable true16 feature for gfx11

### DIFF
--- a/third_party/amd/backend/compiler.py
+++ b/third_party/amd/backend/compiler.py
@@ -58,7 +58,7 @@ def is_consan_supported(arch):
 
 
 def disable_real_true16_feature(arch):
-    return '-real-true16' if arch.startswith('gfx11') else ''
+    return '-real-true16' if arch.startswith('gfx11') and arch != 'gfx1100' else ''
 
 
 def _parse_llvm_fn_attrs(attrs):

--- a/third_party/amd/backend/compiler.py
+++ b/third_party/amd/backend/compiler.py
@@ -57,10 +57,6 @@ def is_consan_supported(arch):
     return arch in ["gfx1250"]
 
 
-def disable_real_true16_feature(arch):
-    return '-real-true16' if arch.startswith('gfx11') and arch != 'gfx1100' else ''
-
-
 def _parse_llvm_fn_attrs(attrs):
     if not isinstance(attrs, str):
         return tuple(attrs)
@@ -547,7 +543,7 @@ class HIPBackend(BaseBackend):
         flags = []
         if is_expert_scheduling_enabled(options.arch):
             flags.append("amdgpu-expert-scheduling-mode")
-        features = disable_real_true16_feature(options.arch)
+        features = ''
         ir_hash = hashlib.sha256(src.encode("utf-8")).hexdigest()
         dump_file_id = names[0] + '_' + ir_hash
         _ = llvm.translate_to_mir(src, amd.TARGET_TRIPLE, options.arch, features, flags, options.enable_fp_fusion,
@@ -573,8 +569,6 @@ class HIPBackend(BaseBackend):
         target_features = []
         if knobs.compilation.enable_asan:
             target_features.append('+xnack')
-        if true16 := disable_real_true16_feature(options.arch):
-            target_features.append(true16)
         hsaco = amd.assemble_amdgcn(src, options.arch, ','.join(target_features))
         with tempfile.NamedTemporaryFile() as tmp_out:
             with tempfile.NamedTemporaryFile() as tmp_in:


### PR DESCRIPTION
<!---
The core Triton is a small number of people, and we receive many PRs (thank
you!).  To help us review your code more quickly, **if you are a new
contributor (less than 3 PRs merged) we ask that you complete the following
tasks and include the filled-out checklist in your PR description.**

Complete the following tasks before sending your PR, and replace `[ ]` with
`[x]` to indicate you have done them.
-->
Triton currently skips -real-true16 for gfx100 target because enabling true16 previously caused a severe compile-time regression in scaled FP4/FP8 dot kernels.
That issue was fixed by this PR on LLVM https://github.com/llvm/llvm-project/pull/208136

Tested locally and I did not see any compile time issue on gfx100
# New contributor declaration
- [x] I am not making a trivial change, such as fixing a typo in a comment.

- [x] I have written a PR description following these
  [rules](https://cbea.ms/git-commit/#why-not-how).

- [x] I have run `pre-commit run --from-ref origin/main --to-ref HEAD`.

- Select one of the following.
  - [ ] I have added tests.
    - `/test` for `lit` tests
    - `/unittest` for C++ tests
    - `/python/test` for end-to-end tests
  - [x] This PR does not need a test because `it fixes a compile time issue on scaled do tests`.

- Select one of the following.
  - [x] I have not added any `lit` tests.
  - [ ] The `lit` tests I have added follow these [best practices](https://mlir.llvm.org/getting_started/TestingGuide/#filecheck-best-practices),
    including the "tests should be minimal" section. (Usually running Python code
    and using the instructions it generates is not minimal.)
