### PR TITLE
[DNR][ConSan] Restrict tensor-core completion visibility

### DIFF
--- a/include/triton/Dialect/TritonInstrument/IR/FunctionBuilder.h
+++ b/include/triton/Dialect/TritonInstrument/IR/FunctionBuilder.h
@@ -154,12 +154,21 @@ public:
                                    uint64_t threadMask, Value pred,
                                    MemType memType, Operation *insertPoint,
                                    Value effectCTAs);
+  // updateTensorCoreAccesses: record tensor-core reads and writes, and clear
+  // obsolete tensor-core provenance whenever any operation writes a buffer.
+  void createUpdateTensorCoreAccessesCall(ImplicitLocOpBuilder &b,
+                                          Value bufferMask, int baseThread,
+                                          RW rw, bool isTensorCore, Value pred,
+                                          MemType memType,
+                                          Operation *insertPoint,
+                                          Value effectCTAs);
   // trackVisibleAccesses: snapshot the available read and write visibility
-  // frontiers into their independent barrier tracking tables.
+  // frontiers into their independent barrier tracking tables. Tensor-core
+  // commits include only accesses recorded for eligible tensor-core operations.
   void createTrackVisibleAccessesCall(ImplicitLocOpBuilder &b, Value mbar,
                                       int thread, Value pred, MemType memType,
-                                      Operation *insertPoint,
-                                      Value barrierCTAs);
+                                      Operation *insertPoint, Value barrierCTAs,
+                                      bool tensorCoreOnly = false);
   // trackBarrierWriteForBuffer: mark a specific buffer as tracked by a
   // barrier in the write-tracking table.
   void createTrackBarrierWriteForBufferCall(ImplicitLocOpBuilder &b, Value mbar,

--- a/include/triton/Dialect/TritonInstrument/IR/Utility.h
+++ b/include/triton/Dialect/TritonInstrument/IR/Utility.h
@@ -61,8 +61,10 @@ constexpr int kCaptureSizeBytes = 8;
 inline int estimateConSanCaptureCount(int numActiveMemTypes, bool hasMBarriers,
                                       bool hasClusterBarriers,
                                       int numCommitKinds,
-                                      bool hasAsyncProxyFenceTracking) {
-  int perMemType = kCapturesPerMemType * numActiveMemTypes;
+                                      bool hasAsyncProxyFenceTracking,
+                                      bool hasTensorCoreTracking) {
+  int perMemType =
+      (kCapturesPerMemType + hasTensorCoreTracking) * numActiveMemTypes;
   int barrierCaptures =
       hasMBarriers || hasClusterBarriers ? kBarrierBaseCaptures : 0;
   if (hasMBarriers)
@@ -202,6 +204,11 @@ struct AuxDataMap {
   // Per-memory-type write frontier. Bit i means logical ConSan thread i can see
   // the latest write to the buffer row.
   RegionToValueMap writeVisibility[numMemTypes];
+
+  // scratch, <Cbuf x B x Cthr x i64>
+  // Tensor-core operations issued by each base thread. Bits [0..15] record
+  // reads and bits [16..31] record writes.
+  RegionToValueMap tensorCoreAccesses[numMemTypes];
 
   // scratch, <Cbuf x B x Cbar x K x i8>
   // Per-memory-type buffer/barrier map for writes that a barrier tracks.

--- a/include/triton/Dialect/TritonInstrument/Transforms/ConSanTargetHooks.h
+++ b/include/triton/Dialect/TritonInstrument/Transforms/ConSanTargetHooks.h
@@ -25,9 +25,15 @@ struct MemEffectsOpInfo {
   // wait publishes those op-local writes and nothing else. Use this for PTX ops
   // that perform the write and also signal the barrier via
   // `mbarrier::complete_tx`.
+  //
+  // TensorCore tracks only tensor-core reads and writes issued by the current
+  // partition, excluding its generic visibility frontier. In practice, this
+  // distinction matters for distributed shared memory: arrival on a remote
+  // mbarrier is not ordered with prior remote shared-memory writes.
   enum class BarrierTrackingMode {
     Frontier,
     EffectWrites,
+    TensorCore,
   };
   struct Effects {
     RW rw;

--- a/lib/Dialect/TritonInstrument/IR/FunctionBuilder.cpp
+++ b/lib/Dialect/TritonInstrument/IR/FunctionBuilder.cpp
@@ -1615,9 +1615,76 @@ void FunctionBuilder::createSetReadVisibilityCall(
       });
 }
 
+void FunctionBuilder::createUpdateTensorCoreAccessesCall(
+    ImplicitLocOpBuilder &b, Value bufferMask, int baseThread, RW rw,
+    bool isTensorCore, Value pred, MemType memType, Operation *insertPoint,
+    Value effectCTAs) {
+  if (auxData.tensorCoreAccesses[(int)memType].empty())
+    return;
+  if (!pred)
+    pred = arith::ConstantIntOp::create(b, 1, 1);
+
+  ValueType accesses = auxData.tensorCoreAccesses[(int)memType].at(insertPoint);
+  auto accessesType = cast<RankedTensorType>(accesses.type);
+  bool isWrite = rw == RW::Write;
+  uint64_t accessMask =
+      isTensorCore ? 1ULL << (baseThread + (isWrite ? MAX_NUM_BASE_THREADS : 0))
+                   : 0;
+  SmallVector<Value> args = {bufferMask, pred,
+                             arith::ConstantIntOp::create(b, accessMask, 64),
+                             accesses.value, effectCTAs};
+  createCallToCachedFunction(
+      b, "update_tensor_core_accesses", args, /*assertInfo=*/std::nullopt,
+      {accessesType, static_cast<uint64_t>(isWrite)},
+      [accessesType, isWrite](ImplicitLocOpBuilder &fb, Block *entryBlock) {
+        Value bufferMask = entryBlock->getArgument(0);
+        Value pred = entryBlock->getArgument(1);
+        Value accessMask = entryBlock->getArgument(2);
+        Value accessesPtr = entryBlock->getArgument(3);
+        Value effectCTAs = entryBlock->getArgument(4);
+
+        auto [prevBlock, ifBlock, thenBlock] = createIfBlock(fb, pred);
+        fb.setInsertionPointToStart(ifBlock);
+
+        Value accesses = tti::createLoadScratchMemory(
+            fb, fb.getLoc(), accessesPtr, accessesType);
+        Value affectedBuffers =
+            convertAndBroadcast(fb, bufferMask, {1}, accessesType);
+        affectedBuffers = arith::AndIOp::create(
+            fb, affectedBuffers,
+            createCTASetMask(fb, accessesType, /*dim=*/0, effectCTAs));
+        Value issuerBuffers =
+            arith::AndIOp::create(fb, affectedBuffers,
+                                  createCTASetMask(fb, accessesType, /*dim=*/2,
+                                                   createCurrentCTAMask(fb)));
+        Value accessBits =
+            triton::SplatOp::create(fb, accessesType, accessMask);
+        Value updated;
+        if (isWrite) {
+          Value zero =
+              tti::createConstIntTensor(fb, fb.getLoc(), 0, accessesType);
+          Value cleared =
+              arith::SelectOp::create(fb, affectedBuffers, zero, accesses);
+          updated =
+              arith::SelectOp::create(fb, issuerBuffers, accessBits, cleared);
+        } else {
+          Value withAccess = arith::OrIOp::create(fb, accesses, accessBits);
+          updated =
+              arith::SelectOp::create(fb, issuerBuffers, withAccess, accesses);
+        }
+        createMaskedStoreScratchMemory(
+            fb, fb.getLoc(), accessesPtr, updated, accessesType,
+            isWrite ? affectedBuffers : issuerBuffers);
+
+        fb.setInsertionPointToEnd(thenBlock);
+        triton::ReturnOp::create(fb);
+      });
+}
+
 void FunctionBuilder::createTrackVisibleAccessesCall(
     ImplicitLocOpBuilder &b, Value mbar, int thread, Value pred,
-    MemType memType, Operation *insertPoint, Value barrierCTAs) {
+    MemType memType, Operation *insertPoint, Value barrierCTAs,
+    bool tensorCoreOnly) {
   if (auxData.barriers.empty())
     return;
 
@@ -1645,6 +1712,17 @@ void FunctionBuilder::createTrackVisibleAccessesCall(
   specializationArgs.append(static_cast<uint64_t>(trackWrites));
   specializationArgs.append(static_cast<uint64_t>(trackReads));
 
+  RankedTensorType tensorCoreAccessesType;
+  if (tensorCoreOnly) {
+    ValueType accesses =
+        auxData.tensorCoreAccesses[(int)memType].at(insertPoint);
+    tensorCoreAccessesType = cast<RankedTensorType>(accesses.type);
+    int baseThread = thread % auxData.threadLayout.numBaseThreads;
+    args.append({accesses.value,
+                 arith::ConstantIntOp::create(b, 1ULL << baseThread, 64)});
+    specializationArgs.append(tensorCoreAccessesType);
+  }
+
   RankedTensorType writeVisibilityType;
   RankedTensorType writeTrackingType;
   if (trackWrites) {
@@ -1671,10 +1749,11 @@ void FunctionBuilder::createTrackVisibleAccessesCall(
   }
 
   createCallToCachedFunction(
-      b, "track_visible_accesses", args, /*assertInfo=*/std::nullopt,
-      specializationArgs,
+      b,
+      tensorCoreOnly ? "track_tensor_core_accesses" : "track_visible_accesses",
+      args, /*assertInfo=*/std::nullopt, specializationArgs,
       [trackWrites, trackReads, writeVisibilityType, writeTrackingType,
-       readVisibilityType,
+       readVisibilityType, tensorCoreOnly, tensorCoreAccessesType,
        readTrackingType](ImplicitLocOpBuilder &fb, Block *entryBlock) {
         Value mbarOffset = entryBlock->getArgument(0);
         Value lengthVal = entryBlock->getArgument(1);
@@ -1683,6 +1762,12 @@ void FunctionBuilder::createTrackVisibleAccessesCall(
         Value barriers = entryBlock->getArgument(4);
         Value barrierCTAs = entryBlock->getArgument(5);
         unsigned nextArg = 6;
+        Value tensorCoreAccessesPtr;
+        Value tensorCoreReadMask;
+        if (tensorCoreOnly) {
+          tensorCoreAccessesPtr = entryBlock->getArgument(nextArg++);
+          tensorCoreReadMask = entryBlock->getArgument(nextArg++);
+        }
 
         auto [prevBlock, ifBlock, thenBlock] = createIfBlock(fb, pred);
         fb.setInsertionPointToStart(ifBlock);
@@ -1690,6 +1775,20 @@ void FunctionBuilder::createTrackVisibleAccessesCall(
         Value barriersEqBar =
             createCmpIntTensorScalar(fb, barriers, descriptor);
         Value currentCTA = createCurrentCTAMask(fb);
+        Value tensorCoreAccesses;
+        if (tensorCoreOnly)
+          tensorCoreAccesses = tti::createLoadScratchMemory(
+              fb, fb.getLoc(), tensorCoreAccessesPtr, tensorCoreAccessesType);
+
+        auto getEligibleTensorCoreAccesses = [&](Value accessMask) {
+          Value mask =
+              triton::SplatOp::create(fb, tensorCoreAccessesType, accessMask);
+          Value accesses = arith::AndIOp::create(fb, tensorCoreAccesses, mask);
+          Value zero = tti::createConstIntTensor(fb, fb.getLoc(), 0,
+                                                 tensorCoreAccessesType);
+          return arith::CmpIOp::create(fb, arith::CmpIPredicate::ne, accesses,
+                                       zero);
+        };
 
         if (trackWrites) {
           Value visibilityPtr = entryBlock->getArgument(nextArg++);
@@ -1717,6 +1816,17 @@ void FunctionBuilder::createTrackVisibleAccessesCall(
               createCTASetMask(fb, writeVisibilityType, /*dim=*/2, currentCTA);
           visibleWrites =
               arith::AndIOp::create(fb, visibleWrites, sourceCTAMask);
+          if (tensorCoreOnly) {
+            Value writeMask = arith::ShLIOp::create(
+                fb, tensorCoreReadMask,
+                arith::ConstantIntOp::create(fb, MAX_NUM_BASE_THREADS, 64));
+            // Completing a tensor-core read also publishes the write it
+            // consumed, which allows the next producer to reuse that buffer.
+            Value accessMask =
+                arith::OrIOp::create(fb, tensorCoreReadMask, writeMask);
+            visibleWrites = arith::AndIOp::create(
+                fb, visibleWrites, getEligibleTensorCoreAccesses(accessMask));
+          }
           visibleWrites = reduceLastDim<arith::OrIOp>(fb, visibleWrites);
           visibleWrites =
               convertAndBroadcast(fb, visibleWrites, {0, 1}, writeTrackingType);
@@ -1752,6 +1862,20 @@ void FunctionBuilder::createTrackVisibleAccessesCall(
               createCTASetMask(fb, readVisibilityType, /*dim=*/2, currentCTA);
           visibleReads =
               arith::SelectOp::create(fb, sourceCTAMask, visibleReads, zero);
+          if (tensorCoreOnly) {
+            Value eligibleReads = convertAndBroadcast(
+                fb, getEligibleTensorCoreAccesses(tensorCoreReadMask),
+                {0, 1, 2}, readVisibilityType);
+            visibleReads =
+                arith::SelectOp::create(fb, eligibleReads, visibleReads, zero);
+            Value one = arith::ConstantIntOp::create(fb, 1, 64);
+            Value threadBit = arith::ShLIOp::create(
+                fb, one,
+                arith::ExtUIOp::create(fb, fb.getI64Type(), threadVal));
+            visibleReads = arith::AndIOp::create(
+                fb, visibleReads,
+                triton::SplatOp::create(fb, readVisibilityType, threadBit));
+          }
           visibleReads = reduce<arith::OrIOp>(fb, visibleReads, {2, 3});
           visibleReads = convertAndBroadcast(fb, visibleReads, {0, 1, 4},
                                              readTrackingType);

--- a/lib/Dialect/TritonInstrument/IR/Utility.cpp
+++ b/lib/Dialect/TritonInstrument/IR/Utility.cpp
@@ -526,6 +526,14 @@ LogicalResult AuxDataMap::populateAndPassToWarpSpecialize(
     passValueToWarpSpecialize(readVisibility[iMemType].at(entryRegion),
                               readVisibility[iMemType]);
 
+    if (threadLayout.hasTCThreads() && numMBarriers > 0) {
+      tensorCoreAccesses[iMemType].insert(
+          entryRegion,
+          createZeroInitStateTensor(b, {numCTAs, numBufs, numCTAs}, 64, fb));
+      passValueToWarpSpecialize(tensorCoreAccesses[iMemType].at(entryRegion),
+                                tensorCoreAccesses[iMemType]);
+    }
+
     if (memType == MemType::SHARED_MEM && hasAsyncProxyFenceTracking) {
       proxyAccessVisibility.insert(
           entryRegion,
@@ -650,7 +658,8 @@ LogicalResult AuxDataMap::populateAndPassToWarpSpecialize(
       numCommitKinds += !commits[i].empty();
     int expected = estimateConSanCaptureCount(
         numActiveMemTypes, numMBarriers > 0, !clusterBarrierSlots.empty(),
-        numCommitKinds, hasAsyncProxyFenceTracking);
+        numCommitKinds, hasAsyncProxyFenceTracking,
+        threadLayout.hasTCThreads() && numMBarriers > 0);
     assert(captureCounter == expected &&
            "capture count changed -- update estimateConSanCaptureCount if this "
            "is expected!");

--- a/lib/Dialect/TritonInstrument/Transforms/ConcurrencySanitizer.cpp
+++ b/lib/Dialect/TritonInstrument/Transforms/ConcurrencySanitizer.cpp
@@ -1049,6 +1049,12 @@ private:
               b, bufferMask, baseThread, pred, memType, opInfo->commitKind, op);
         }
       }
+      bool tensorCore = isTensorCoreOp(op);
+      if (tensorCore || effect.rw == RW::Write) {
+        funcBuilder.createUpdateTensorCoreAccessesCall(
+            b, bufferMask, baseThread, effect.rw, tensorCore, pred, memType, op,
+            effectCTAs);
+      }
     }
     for (const auto &barrierInfo : opInfo->barriers) {
       Value barrier = barrierInfo.barrier;
@@ -1067,6 +1073,13 @@ private:
         }
         funcBuilder.createTrackProxyAccessesCall(
             b, barrier, baseThread, combinedPred, op, recipientCTAs);
+      } else if (barrierInfo.trackingMode ==
+                 MemEffectsOpInfo::BarrierTrackingMode::TensorCore) {
+        for (MemType memType : {MemType::SHARED_MEM, MemType::TENSOR_MEM}) {
+          funcBuilder.createTrackVisibleAccessesCall(
+              b, barrier, thread, combinedPred, memType, op, recipientCTAs,
+              /*tensorCoreOnly=*/true);
+        }
       } else if (barrierInfo.trackingMode ==
                  MemEffectsOpInfo::BarrierTrackingMode::EffectWrites) {
         for (auto [effect, materialized] :

--- a/lib/Dialect/TritonInstrument/Transforms/PrepareConSanCaptures.cpp
+++ b/lib/Dialect/TritonInstrument/Transforms/PrepareConSanCaptures.cpp
@@ -49,6 +49,17 @@ bool hasBarriers(ModuleOp mod) {
   return result;
 }
 
+bool hasTensorCoreOps(ModuleOp mod) {
+  return mod
+      .walk([](Operation *op) {
+        return isa<ttng::MMAv5OpInterface, ttng::TCGen5CommitOp,
+                   ttng::TMEMCopyOp>(op)
+                   ? WalkResult::interrupt()
+                   : WalkResult::advance();
+      })
+      .wasInterrupted();
+}
+
 bool hasCpAsync(ModuleOp mod) {
   bool result = false;
   mod.walk([&](Operation *op) {
@@ -96,13 +107,14 @@ public:
 
     int numActiveMemTypes = (hasSharedMemoryBuffers(mod) ? 1 : 0) +
                             (hasTensorMemoryBuffers(mod) ? 1 : 0);
+    bool hasMBarriers = hasBarriers(mod);
     // NVIDIA inserts a terminal cluster barrier after this pass.
     bool hasClusterBarriers = target == "nvidia" && ttg::lookupNumCTAs(mod) > 1;
     int totalCaptures = tti::estimateConSanCaptureCount(
-        numActiveMemTypes, hasBarriers(mod), hasClusterBarriers,
+        numActiveMemTypes, hasMBarriers, hasClusterBarriers,
         getNumCommitKinds(mod, *hooks),
-        hasSharedMemoryBuffers(mod) &&
-            hooks->needsAsyncProxyFenceTracking(mod));
+        hasSharedMemoryBuffers(mod) && hooks->needsAsyncProxyFenceTracking(mod),
+        hasMBarriers && hasTensorCoreOps(mod));
     int extraBytes = totalCaptures * tti::kCaptureSizeBytes;
 
     auto i32Ty = IntegerType::get(mod.getContext(), 32);

--- a/lib/Dialect/TritonNvidiaGPU/Transforms/ConSanNVIDIA.cpp
+++ b/lib/Dialect/TritonNvidiaGPU/Transforms/ConSanNVIDIA.cpp
@@ -174,7 +174,9 @@ public:
       for (auto [barrier, barrierPred] :
            llvm::zip(mmav5Op.getCompletionBarriers(),
                      mmav5Op.getCompletionBarrierPreds())) {
-        info->barriers.push_back({barrier, barrierPred, 1});
+        info->barriers.push_back(
+            {barrier, barrierPred, 1,
+             MemEffectsOpInfo::BarrierTrackingMode::TensorCore});
       }
       namedOperands = {{mmav5Op.getA(), "A"},
                        {mmav5Op.getB(), "B"},
@@ -186,7 +188,9 @@ public:
     }
     if (auto commitOp = dyn_cast<ttng::TCGen5CommitOp>(op)) {
       info->pred = commitOp.getPred();
-      info->barriers.push_back({commitOp.getBarrier(), nullptr, 1});
+      info->barriers.push_back(
+          {commitOp.getBarrier(), nullptr, 1,
+           MemEffectsOpInfo::BarrierTrackingMode::TensorCore});
     }
     if (auto wgmmaOp = dyn_cast<ttng::WarpGroupDotOp>(op)) {
       if (wgmmaOp.getIsAsync() == true) {

--- a/python/test/gluon/test_consan.py
+++ b/python/test/gluon/test_consan.py
@@ -1167,6 +1167,81 @@ def test_tma_store(FAILURE, device, run_wrapper, monkeypatch, num_ctas):
 
 
 @pytest.mark.skipif(not is_cuda() or torch.cuda.get_device_capability()[0] < 10, reason="Requires blackwell or newer")
+@pytest.mark.parametrize("RELEASE", [False, True], ids=["missing-release", "explicit-release"])
+def test_tcgen5_commit_does_not_publish_distributed_writes(RELEASE, device, run_wrapper, monkeypatch):
+    if run_wrapper and not RELEASE:
+        result = run_in_process(test_tcgen5_commit_does_not_publish_distributed_writes,
+                                (RELEASE, device, False, monkeypatch))
+        assert_expected_cuda_failure(result.exc)
+        assert "Buffer being accessed has outstanding writes" in result.driver_stderr_output
+        return
+
+    monkeypatch.setenv("TRITON_INSTRUMENTATION_MODE", "consan")
+    monkeypatch.setenv("CUDA_LAUNCH_BLOCKING", "1")
+    knobs.refresh_knobs()
+
+    @gluon.jit
+    def producer(unrelated, a, b, acc, warmup, completion, publication, layout: ttgl.constexpr,
+                 RELEASE: ttgl.constexpr):
+        blackwell.tcgen05_mma(a, b, acc, use_acc=False, mbarriers=[warmup])
+        mbarrier.wait(warmup, phase=0)
+        cta = ttgl.inline_asm_elementwise("mov.u32 $0, %cluster_ctarank;", "=r", [], dtype=ttgl.int32, is_pure=True,
+                                          pack=1)
+        if cta == 0:
+            unrelated.store(ttgl.full([XBLOCK], 42, ttgl.int32, layout))
+        if RELEASE:
+            ttgl.barrier(cluster=True)
+            mbarrier.arrive(publication, count=1)
+        blackwell.tcgen05_commit(completion, descs=[a, b])
+
+    @gluon.jit
+    def consumer(output, unrelated, completion, publication, layout: ttgl.constexpr, RELEASE: ttgl.constexpr):
+        mbarrier.wait(completion, phase=0)
+        if RELEASE:
+            mbarrier.wait(publication, phase=0)
+        offsets = ttgl.arange(0, XBLOCK, layout)
+        ttgl.store(output + offsets, unrelated.load(layout))
+
+    @gluon.jit
+    def kernel(output, RELEASE: ttgl.constexpr):
+        layout: ttgl.constexpr = ttgl.BlockedLayout([1], [32], [4], [0], cga_layout=((0, ), ))
+        unrelated_layout: ttgl.constexpr = ttgl.SwizzledSharedLayout(1, 1, 1, order=[0], cga_layout=((1, ), ))
+        a_layout: ttgl.constexpr = ttgl.NVMMASharedLayout.get_default_for([256, 128], ttgl.float16,
+                                                                          cga_layout=((1, 0), ))
+        b_layout: ttgl.constexpr = ttgl.NVMMASharedLayout.get_default_for([128, 128], ttgl.float16,
+                                                                          cga_layout=((0, 1), ))
+        acc_layout: ttgl.constexpr = blackwell.TensorMemoryLayout([128, 128], col_stride=1, cga_layout=((1, 0), ),
+                                                                  two_ctas=True)
+
+        unrelated = ttgl.allocate_shared_memory(ttgl.int32, [XBLOCK], unrelated_layout)
+        a = ttgl.allocate_shared_memory(ttgl.float16, [256, 128], a_layout)
+        b = ttgl.allocate_shared_memory(ttgl.float16, [128, 128], b_layout)
+        acc = blackwell.allocate_tensor_memory(ttgl.float32, [256, 128], acc_layout)
+        warmup = mbarrier.allocate_mbarrier()
+        completion = mbarrier.allocate_mbarrier()
+        publication = mbarrier.allocate_mbarrier()
+        mbarrier.init(warmup, count=1)
+        mbarrier.init(completion, count=1)
+        if RELEASE:
+            mbarrier.init(publication, count=1)
+
+        ttgl.warp_specialize([
+            (producer, (unrelated, a, b, acc, warmup, completion, publication, layout, RELEASE)),
+            (consumer, (output, unrelated, completion, publication, layout, RELEASE)),
+        ], [4], [32])
+
+        mbarrier.invalidate(warmup)
+        mbarrier.invalidate(completion)
+        if RELEASE:
+            mbarrier.invalidate(publication)
+
+    output = torch.empty((XBLOCK.value, ), device=device, dtype=torch.int32)
+    kernel[(1, )](output, RELEASE=RELEASE, num_warps=4, num_ctas=2)
+    if RELEASE:
+        torch.testing.assert_close(output, torch.full_like(output, 42))
+
+
+@pytest.mark.skipif(not is_cuda() or torch.cuda.get_device_capability()[0] < 10, reason="Requires blackwell or newer")
 @pytest.mark.parametrize("FAILURE", [True, False])
 @pytest.mark.parametrize("MEM_ACCESS_KIND", ["tma_cp", "local_store", "tmem_load", "tmem_store"])
 @pytest.mark.parametrize("TWO_CTAS", [False, True])

--- a/test/TritonGPU/consan.mlir
+++ b/test/TritonGPU/consan.mlir
@@ -1077,6 +1077,7 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 1 : i32, ttg.shar
     // CHECK: tt.call @__triton_consan_verify_write_visibility{{.*}}%[[SM_WRITE_VISIBILITY_GLOB]]
     // CHECK: %[[TC_MASK:.*]] = arith.constant 2 : i64
     // CHECK: tt.call @__triton_consan_set_read_visibility{{.*}}%[[TC_MASK]], %[[SM_READ_VISIBILITY_GLOB]]
+    // CHECK: tt.call @__triton_consan_update_tensor_core_accesses
     // CHECK: %[[TC_BIT:.*]] = arith.constant 1 : i32
     // CHECK: tt.call @__triton_consan_verify_write_visibility{{.*}}%[[SM_WRITE_VISIBILITY_GLOB]]
     // CHECK: %[[TC_MASK:.*]] = arith.constant 2 : i64
@@ -1089,10 +1090,11 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 1 : i32, ttg.shar
     // CHECK: tt.call @__triton_consan_publish_write_visibility
     // CHECK: %[[BAR_I64:.*]] = tti.experimental_memdesc_to_i32 %[[BAR:.*]] :
     // CHECK: %[[TC_BIT:.*]] = arith.constant 1 : i32
-    // CHECK: tt.call @__triton_consan_track_visible_accesses{{.*}}%[[BAR_I64]]{{.*}}%[[TC_BIT]]{{.*}}%[[BARRIERS]]{{.*}}%[[SM_WRITE_VISIBILITY_GLOB]]{{.*}}%[[SM_WRITE_TRACKING_GLOB]]{{.*}}%[[SM_READ_VISIBILITY_GLOB]], %{{[^,)]+}}) : {{.*}}!tt.ptr<i8>, !tt.ptr<i64>, !tt.ptr<i64>) -> ()
+    // CHECK: tt.call @__triton_consan_track_tensor_core_accesses{{.*}}%[[BAR_I64]]{{.*}}%[[TC_BIT]]{{.*}}%[[BARRIERS]]{{.*}}%[[SM_WRITE_VISIBILITY_GLOB]]{{.*}}%[[SM_WRITE_TRACKING_GLOB]]{{.*}}%[[SM_READ_VISIBILITY_GLOB]], %{{[^,)]+}}) : {{.*}}!tt.ptr<i8>, !tt.ptr<i64>, !tt.ptr<i64>) -> ()
     // CHECK: %[[BAR_I64:.*]] = tti.experimental_memdesc_to_i32 %[[BAR]] :
     // CHECK: %[[TC_BIT:.*]] = arith.constant 1 : i32
-    // CHECK: tt.call @__triton_consan_track_visible_accesses{{.*}}%[[BAR_I64]]{{.*}}%[[TC_BIT]]{{.*}}%[[BARRIERS]]{{.*}}%[[TM_WRITE_VISIBILITY_GLOB]]{{.*}}%[[TM_WRITE_TRACKING_GLOB]]{{.*}}%[[TM_READ_VISIBILITY_GLOB:.*]], %{{[^,)]+}}) : {{.*}}!tt.ptr<i8>, !tt.ptr<i64>, !tt.ptr<i64>) -> ()
+    // CHECK: tt.call @__triton_consan_track_tensor_core_accesses{{.*}}%[[BAR_I64]]{{.*}}%[[TC_BIT]]{{.*}}%[[BARRIERS]]{{.*}}%[[TM_WRITE_VISIBILITY_GLOB]]{{.*}}%[[TM_WRITE_TRACKING_GLOB]]{{.*}}%[[TM_READ_VISIBILITY_GLOB:.*]], %{{[^,)]+}}) : {{.*}}!tt.ptr<i8>, !tt.ptr<i64>, !tt.ptr<i64>) -> ()
+    // CHECK-NOT: tt.call @__triton_consan_track_proxy_accesses
     // CHECK: tt.call @__triton_consan_verify_and_update_barrier_state
     // CHECK: tti.experimental_assert_uniform {{.*}}, "Barrier used before initialization or after invalidation"
     // CHECK: tti.experimental_assert_uniform {{.*}}, "Barrier arrive underflow: current count or tx-count would become invalid"
@@ -1148,10 +1150,10 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 1 : i32, ttg.shar
     // CHECK: tt.call @__triton_consan_publish_write_visibility
     // CHECK: %[[BAR_I64:.*]] = tti.experimental_memdesc_to_i32 %[[BAR:.*]] :
     // CHECK: %[[TC_BIT:.*]] = arith.constant 1 : i32
-    // CHECK: tt.call @__triton_consan_track_visible_accesses{{.*}}%[[BAR_I64]]{{.*}}%[[TC_BIT]]{{.*}}%[[BARRIERS]]{{.*}}%[[SM_WRITE_VISIBILITY_GLOB]]{{.*}}%[[SM_WRITE_TRACKING_GLOB]]{{.*}}%[[SM_READ_VISIBILITY_GLOB]], %{{[^,)]+}}) : {{.*}}!tt.ptr<i8>, !tt.ptr<i64>, !tt.ptr<i64>) -> ()
+    // CHECK: tt.call @__triton_consan_track_tensor_core_accesses{{.*}}%[[BAR_I64]]{{.*}}%[[TC_BIT]]{{.*}}%[[BARRIERS]]{{.*}}%[[SM_WRITE_VISIBILITY_GLOB]]{{.*}}%[[SM_WRITE_TRACKING_GLOB]]{{.*}}%[[SM_READ_VISIBILITY_GLOB]], %{{[^,)]+}}) : {{.*}}!tt.ptr<i8>, !tt.ptr<i64>, !tt.ptr<i64>) -> ()
     // CHECK: %[[BAR_I64:.*]] = tti.experimental_memdesc_to_i32 %[[BAR]] :
     // CHECK: %[[TC_BIT:.*]] = arith.constant 1 : i32
-    // CHECK: tt.call @__triton_consan_track_visible_accesses{{.*}}%[[BAR_I64]]{{.*}}%[[TC_BIT]]{{.*}}%[[BARRIERS]]{{.*}}%[[TM_WRITE_VISIBILITY_GLOB]]{{.*}}%[[TM_WRITE_TRACKING_GLOB]]{{.*}}%[[TM_READ_VISIBILITY_GLOB]], %{{[^,)]+}}) : {{.*}}!tt.ptr<i8>, !tt.ptr<i64>, !tt.ptr<i64>) -> ()
+    // CHECK: tt.call @__triton_consan_track_tensor_core_accesses{{.*}}%[[BAR_I64]]{{.*}}%[[TC_BIT]]{{.*}}%[[BARRIERS]]{{.*}}%[[TM_WRITE_VISIBILITY_GLOB]]{{.*}}%[[TM_WRITE_TRACKING_GLOB]]{{.*}}%[[TM_READ_VISIBILITY_GLOB]], %{{[^,)]+}}) : {{.*}}!tt.ptr<i8>, !tt.ptr<i64>, !tt.ptr<i64>) -> ()
     // CHECK: tt.call @__triton_consan_verify_and_update_barrier_state
     // CHECK: tti.experimental_assert_uniform {{.*}}, "Barrier used before initialization or after invalidation"
     // CHECK: tti.experimental_assert_uniform {{.*}}, "Barrier arrive underflow: current count or tx-count would become invalid"
@@ -1189,7 +1191,7 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 1 : i32, ttg.shar
     // CHECK: tt.call @__triton_consan_init_barrier_state
     %true = arith.constant true
     // Identical shared- and tensor-memory tracking layouts reuse one helper.
-    // CHECK: tt.call @[[TRACK_VISIBLE:__triton_consan_track_visible_accesses[^ (]*]]
+    // CHECK: tt.call @[[TRACK_VISIBLE:__triton_consan_track_tensor_core_accesses[^ (]*]]
     // CHECK: tt.call @[[TRACK_VISIBLE]]
     // CHECK: tt.call @__triton_consan_verify_and_update_barrier_state
     // CHECK-NOT: tt.call @__triton_consan_update_barrier_state


### PR DESCRIPTION
PR description written by Codex

Restrict tensor-core completion to qualifying tensor-core effects, while preserving prerequisite writes for tensor-core-read buffers. This prevents remote mbarriers from publishing unrelated distributed-shared-memory writes.

Validated with the complete ConSan suite (414 passed, 70 skipped), NVIDIA/AMD sanitizer lit tests, and targeted Gluon regressions.