### PR TITLE
[GSan] Stabilize distributed race diagnostics

### DIFF
--- a/python/test/gsan/test_symmetric_memory.py
+++ b/python/test/gsan/test_symmetric_memory.py
@@ -2,6 +2,8 @@ from __future__ import annotations
 
 import os
 import socket
+import sys
+import tempfile
 import time
 from datetime import timedelta
 
@@ -12,7 +14,7 @@ import torch.multiprocessing as mp
 import triton
 import triton.language as tl
 
-from triton._internal_testing import is_cuda, run_in_process
+from triton._internal_testing import is_cuda
 from triton.experimental.gsan import _stream_sync, symmetric_memory
 from triton.experimental.gsan._testing_utils import atomic_poll, shadow_cell_from_address, shadow_tensor_for, SHADOW_GRANULARITY_BYTES
 
@@ -401,24 +403,33 @@ def _distributed_worker_multi_node_simulated(rank: int, world_size: int, master_
         dist.destroy_process_group()
 
 
-def _distributed_worker_single_cta_no_atomic_sync(rank: int, world_size: int, master_port: int) -> None:
+def _distributed_worker_single_cta_no_atomic_sync(rank: int, world_size: int, master_port: int, results) -> None:
     dev = f"cuda:{rank}"
     os.environ["WORLD_SIZE"] = str(world_size)
     os.environ["MASTER_ADDR"] = "127.0.0.1"
     os.environ["MASTER_PORT"] = str(master_port)
+    os.environ["CUDA_LAUNCH_BLOCKING"] = "1"
     dist.init_process_group(backend="gloo", rank=rank, world_size=world_size, timeout=_PROCESS_GROUP_TIMEOUT)
     torch.cuda.set_device(dev)
     try:
-        _run_single_cta_no_atomic_sync_check(rank, world_size)
+        with tempfile.TemporaryFile(mode="w+b") as driver_stderr:
+            saved_stderr_fd = os.dup(2)
+            error = None
+            try:
+                os.dup2(driver_stderr.fileno(), 2)
+                try:
+                    _run_single_cta_no_atomic_sync_check(rank, world_size)
+                except RuntimeError as exc:
+                    error = str(exc)
+            finally:
+                sys.stderr.flush()
+                os.dup2(saved_stderr_fd, 2)
+                os.close(saved_stderr_fd)
+            driver_stderr.seek(0)
+            results.put((rank, error, driver_stderr.read().decode()))
         dist.barrier()
     finally:
         dist.destroy_process_group()
-
-
-def _run_single_cta_no_atomic_sync_failure_case() -> None:
-    world_size = 2
-    master_port = _get_free_tcp_port()
-    _spawn_distributed(_distributed_worker_single_cta_no_atomic_sync, world_size, master_port)
 
 
 @pytest.mark.skipif(not is_cuda(), reason="requires CUDA backend")
@@ -466,9 +477,19 @@ def test_gsan_symmetric_memory_single_cta_no_atomic_sync_fails():
     if torch.cuda.device_count() < 2:
         pytest.skip("requires 2 CUDA devices")
 
-    result = run_in_process(_run_single_cta_no_atomic_sync_failure_case, env={"CUDA_LAUNCH_BLOCKING": "1"})
-    assert result.exc is not None
-    assert "race detected" in result.driver_stderr_output
+    world_size = 2
+    master_port = _get_free_tcp_port()
+    results = mp.get_context("forkserver").Queue()
+    try:
+        _spawn_distributed(_distributed_worker_single_cta_no_atomic_sync, world_size, master_port, results)
+        reports = [results.get_nowait() for _ in range(world_size)]
+    finally:
+        results.close()
+
+    failures = [(rank, error, stderr) for rank, error, stderr in reports if error is not None]
+    assert failures, reports
+    assert all("device-side assert triggered" in error for _, error, _ in failures), reports
+    assert any("race detected" in stderr for _, _, stderr in failures), reports
 
 
 def _run_triton_kernels_convert_dp_to_ep_with_gsan_pool(rank: int, world_size: int) -> None:


### PR DESCRIPTION
PR description written by Codex

Capture GSan race diagnostics independently in each distributed GPU worker and keep both workers alive until their results are collected. This prevents expected device assertions from terminating sibling workers before the race report is captured.

Validated with 24 consecutive two-GPU race-test passes and the full GSan suite (148 passed, one skipped).

## Stack
Merge bottom-up:
- [ ] #11191 (this PR)
