### PR TITLE
[Backend][NVIDIA] Remove zero initialising default value for unmasked loads

### DIFF
--- a/test/Conversion/tritongpu_to_llvm.mlir
+++ b/test/Conversion/tritongpu_to_llvm.mlir
@@ -146,23 +146,23 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 2 : i32} {
     %8 = tt.addptr %7, %4 : tensor<256x!tt.ptr<f32>, #blocked0>, tensor<256xi32, #blocked0>
 
     // Load 4 elements from vector0
-    // CHECK: mov.u32 $0, 0x0
+    // CHECK-NOT: mov.u32 $0, 0x0
     // CHECK: ld.global.b32 { ${{.*}} }, [ ${{.*}} + 0 ];
-    // CHECK: mov.u32 $0, 0x0
+    // CHECK-NOT: mov.u32 $0, 0x0
     // CHECK: ld.global.b32 { ${{.*}} }, [ ${{.*}} + 0 ];
-    // CHECK: mov.u32 $0, 0x0
+    // CHECK-NOT: mov.u32 $0, 0x0
     // CHECK: ld.global.b32 { ${{.*}} }, [ ${{.*}} + 0 ];
-    // CHECK: mov.u32 $0, 0x0
+    // CHECK-NOT: mov.u32 $0, 0x0
     // CHECK: ld.global.b32 { ${{.*}} }, [ ${{.*}} + 0 ];
 
     // Load 4 elements from vector1
-    // CHECK: mov.u32 $0, 0x0
+    // CHECK-NOT: mov.u32 $0, 0x0
     // CHECK: ld.global.b32 { ${{.*}} }, [ ${{.*}} + 0 ];
-    // CHECK: mov.u32 $0, 0x0
+    // CHECK-NOT: mov.u32 $0, 0x0
     // CHECK: ld.global.b32 { ${{.*}} }, [ ${{.*}} + 0 ];
-    // CHECK: mov.u32 $0, 0x0
+    // CHECK-NOT: mov.u32 $0, 0x0
     // CHECK: ld.global.b32 { ${{.*}} }, [ ${{.*}} + 0 ];
-    // CHECK: mov.u32 $0, 0x0
+    // CHECK-NOT: mov.u32 $0, 0x0
     // CHECK: ld.global.b32 { ${{.*}} }, [ ${{.*}} + 0 ];
     %9 = tt.load %6 : tensor<256x!tt.ptr<f32>, #blocked0>
     %10 = tt.load %8 : tensor<256x!tt.ptr<f32>, #blocked0>
@@ -397,12 +397,12 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 2 : i32} {
     %8 = tt.addptr %7, %4 : tensor<128x!tt.ptr<f32>, #slice>, tensor<128xi32, #slice>
 
     // Load 2 element from vector0 without predicate
-    // CHECK: mov.u32 $0, 0x0
+    // CHECK-NOT: mov.u32 $0, 0x0
     // CHECK-NOT: @{{.*}} ld.global
     // CHECK-COUNT-2: ld.global.b32 { ${{.*}} }, [ ${{.*}} + 0 ];
 
     // Load 2 elements from vector1 without predicate
-    // CHECK: mov.u32 $0, 0x0
+    // CHECK-NOT: mov.u32 $0, 0x0
     // CHECK-NOT: @{{.*}} ld.global
     // CHECK-COUNT-2: ld.global.b32 { ${{.*}} }, [ ${{.*}} + 0 ];
     %9 = tt.load %6 : tensor<128x!tt.ptr<f32>, #slice>

--- a/third_party/nvidia/lib/TritonNVIDIAGPUToLLVM/LoadStoreOpToLLVM.cpp
+++ b/third_party/nvidia/lib/TritonNVIDIAGPUToLLVM/LoadStoreOpToLLVM.cpp
@@ -226,8 +226,10 @@ struct LoadOpConversion : public ConvertOpToLLVMPattern<triton::LoadOp>,
 
       // prepare asm operands
       auto *dstsOpr = ptxBuilder.newListOperand();
-      // If there is a `other` value, use it to init.
-      bool init = other == nullptr;
+      // zero inititialise a masked load when there is no 'other' value,
+      // otherwise use it to init. no need to init when there's no predicate
+      // (i.e. unmasked).
+      bool init = pred && !other;
       for (size_t wordIdx = 0; wordIdx < nWords; ++wordIdx) {
         auto *opr = ptxBuilder.newOperand(writeConstraint,
                                           init); // =r operations


### PR DESCRIPTION
Currently in nv `tt.load` lowering, zero initialisation of an default value does not check if a predicate exist, so every unmasked load unnecessarily emit a `mov` per element.

Fixed by requiring `pred` to have value(which is equivalent to having a `mask` here) to init.

```python
@triton.jit
def test_load(ptr, out, N: tl.constexpr):
    offs = tl.arange(0, N)
    x = tl.load(ptr + offs)
    tl.store(out + offs, x)

# N=128, num_warps=1

# ptx: before (4x mov per vectorized load)
# mov.u32 %r1, 0x0;
# mov.u32 %r2, 0x0;
# mov.u32 %r3, 0x0;
# mov.u32 %r4, 0x0;
# ld.global.v4.b32 { %r1, %r2, %r3, %r4 }, [ %rd1 + 0 ];

# ptx: after (just the load)
# ld.global.v4.b32 { %r1, %r2, %r3, %r4 }, [ %rd1 + 0 ];
```

<!---
The core Triton is a small number of people, and we receive many PRs (thank
you!).  To help us review your code more quickly, **if you are a new
contributor (less than 3 PRs merged) we ask that you complete the following
tasks and include the filled-out checklist in your PR description.**

Complete the following tasks before sending your PR, and replace `[ ]` with
`[x]` to indicate you have done them.
-->

# New contributor declaration
- [x] I am not making a trivial change, such as fixing a typo in a comment.

- [x] I have written a PR description following these
  [rules](https://cbea.ms/git-commit/#why-not-how).

- [x] I have run `pre-commit run --from-ref origin/main --to-ref HEAD`.

- Select one of the following.
  - [x] I have added tests.
    - `/test` for `lit` tests
    - `/unittest` for C++ tests
    - `/python/test` for end-to-end tests
  - [ ] This PR does not need a test because `FILL THIS IN`.

- Select one of the following.
  - [ ] I have not added any `lit` tests.
  - [x] The `lit` tests I have added follow these [best practices](https://mlir.llvm.org/getting_started/TestingGuide/#filecheck-best-practices),
    including the "tests should be minimal" section. (Usually running Python code
    and using the instructions it generates is not minimal.)