### PR TITLE
Add JUnit output to the test runner

### DIFF
--- a/python/test/unit/runtime/test_driver.py
+++ b/python/test/unit/runtime/test_driver.py
@@ -2,6 +2,7 @@ import os
 import sys
 from concurrent.futures import Future, ThreadPoolExecutor
 from multiprocessing.connection import Client
+from pathlib import Path
 from types import SimpleNamespace
 
 import cloudpickle
@@ -131,6 +132,31 @@ def test_compile_warmup_assigns_gpu_before_xdist_worker_initialization(monkeypat
     pytest_xdist_setupnodes(None, specs)
 
     assert [spec.env[variable] for spec in specs] == expected
+
+
+def test_runner_assigns_unique_junit_reports(monkeypatch, tmp_path):
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.delenv("TRITON_TEST_JUNIT_DIR", raising=False)
+    assert not any(argument.startswith("--junitxml=") for argument in _test_runner._pytest("test.py"))
+
+    commands = []
+    monkeypatch.setattr(
+        _test_runner, "_unit", lambda args: commands.extend(
+            (_test_runner._pytest("first.py"), _test_runner._pytest("second.py"))) or 0)
+    assert _test_runner._suite(SimpleNamespace(name="unit", junit_dir="reports")) == 0
+
+    reports = [
+        Path(argument.removeprefix("--junitxml="))
+        for command in commands
+        for argument in command
+        if argument.startswith("--junitxml=")
+    ]
+    assert len(reports) == len(set(reports)) == 2
+    assert all(report.parent == (tmp_path / "reports").resolve() for report in reports)
+    assert reports[0].name.startswith("pytest-first-")
+    assert reports[1].name.startswith("pytest-second-")
+    assert all(report.name.endswith("-results.xml") for report in reports)
+    assert (tmp_path / "reports").is_dir()
 
 
 @pytest.mark.parametrize(("capability", "num_gpus", "kernel_workers"), [(8, 1, 6), (9, 1, 4), (10, 2, 6), (10, 4, 12)])

--- a/python/triton/_test_runner.py
+++ b/python/triton/_test_runner.py
@@ -6,6 +6,7 @@ import os
 import signal
 import subprocess
 import sys
+import uuid
 from pathlib import Path
 
 from triton._compile_warmup import _require_complete_warmup, summarize_compile_trace
@@ -38,6 +39,18 @@ def _pytest(*arguments, workers=None, import_mode=None, distribution="worksteal"
         command.append(f"--import-mode={import_mode}")
     if workers is not None:
         command.extend(("-n", str(workers), f"--dist={distribution}"))
+    if directory := os.environ.get("TRITON_TEST_JUNIT_DIR"):
+        directory = Path(directory).resolve()
+        directory.mkdir(parents=True, exist_ok=True)
+        label = "unit"
+        for target in arguments:
+            if target.startswith("-") or ("/" not in target and not target.endswith(".py")):
+                continue
+            path = Path(target.rstrip("/"))
+            label = path.stem.removeprefix("test_") if path.suffix else "-".join(path.parts[-2:])
+            label = label.replace("_", "-")
+            break
+        command.append(f"--junitxml={directory / f'pytest-{label}-{uuid.uuid4().hex}-results.xml'}")
     command.extend(arguments)
     return command
 
@@ -195,6 +208,8 @@ def _gsan(args):
 
 
 def _suite(args):
+    if args.junit_dir is not None:
+        os.environ["TRITON_TEST_JUNIT_DIR"] = args.junit_dir
     return {"unit": _unit, "gsan": _gsan, "gluon": _gluon}[args.name](args)
 
 
@@ -227,6 +242,8 @@ def _main(argv=None):
     suite.add_argument("--example-procs", type=int, default=4)
     suite.add_argument("--debug-procs", type=int, default=4)
     suite.add_argument("--kernel-procs", type=int)
+    suite.add_argument("--junit-dir", default=os.environ.get("TRITON_TEST_JUNIT_DIR"),
+                       help="write one JUnit XML report per pytest subprocess to this directory")
     suite.set_defaults(run=_suite)
 
     report = commands.add_parser("report", help="summarize cache coverage and validate completeness")


### PR DESCRIPTION
This PR was authored with the help of Codex Sol 5.6

---

- add `--junit-dir` support to `python -m triton._test_runner suite`
- write a distinct JUnit XML report for each pytest subprocess
- support the unit, Gluon, and GSAN runner partitions
- resolve relative report directories before launching subprocesses
- add coverage for report naming, concurrent partitions, and relative paths

## Motivation

Downstream CI systems need machine-readable test results from Triton's
source-owned test runner. Supplying JUnit paths inside the runner keeps test
selection, parallelism, and report partitioning under the same ownership and
prevents concurrent pytest subprocesses from overwriting one another.

JUnit output remains opt-in. Existing invocations behave unchanged unless
`--junit-dir` or `TRITON_TEST_JUNIT_DIR` is provided.

## Testing

- `python -m pytest -q python/test/unit/runtime/test_driver.py`
- `pre-commit run --from-ref github/main --to-ref HEAD`

References:
- https://docs.pytest.org/en/stable/how-to/output.html#creating-junitxml-format-files