### PR TITLE
[ConSan] Distinguish readers from peer observers

### DIFF
--- a/include/triton/Dialect/TritonInstrument/IR/FunctionBuilder.h
+++ b/include/triton/Dialect/TritonInstrument/IR/FunctionBuilder.h
@@ -148,12 +148,12 @@ public:
                                         Value pred, MemType memType,
                                         Operation *insertPoint,
                                         Value effectCTAs);
-  // setReadVisibility: add the threads set in threadMask to the buffer's read
-  // visibility bitmask.
+  // setReadVisibility: record the actual reader in the visibility columns of
+  // each observer, including any synthetic peers.
   void createSetReadVisibilityCall(ImplicitLocOpBuilder &b, Value bufferMask,
-                                   uint64_t threadMask, Value pred,
-                                   MemType memType, Operation *insertPoint,
-                                   Value effectCTAs);
+                                   int reader, uint64_t observerMask,
+                                   Value pred, MemType memType,
+                                   Operation *insertPoint, Value effectCTAs);
   // trackVisibleAccesses: snapshot the available read and write visibility
   // frontiers into their independent barrier tracking tables.
   void createTrackVisibleAccessesCall(ImplicitLocOpBuilder &b, Value mbar,

--- a/lib/Dialect/TritonInstrument/IR/FunctionBuilder.cpp
+++ b/lib/Dialect/TritonInstrument/IR/FunctionBuilder.cpp
@@ -346,17 +346,6 @@ Value createDimMask(ImplicitLocOpBuilder &b, Value index,
   return convertAndBroadcast(b, mask1D, {dim}, maskType);
 }
 
-Value createDimIndices(ImplicitLocOpBuilder &b, RankedTensorType tensorType,
-                       int dim) {
-  assert(dim >= 0 && dim < tensorType.getRank() && "invalid tensor dimension");
-  auto indexType = tti::getSlicedTensorType(tensorType, {dim}, b.getI32Type());
-  Value range = triton::MakeRangeOp::create(b, indexType, /*start=*/0,
-                                            /*end=*/tensorType.getShape()[dim]);
-  auto fullIndexType = cast<RankedTensorType>(
-      tensorType.cloneWith(std::nullopt, b.getI32Type()));
-  return convertAndBroadcast(b, range, {dim}, fullIndexType);
-}
-
 Value createCurrentCTAMask(ImplicitLocOpBuilder &b) {
   Value ctaId = tti::ExperimentalClusterCTAIdOp::create(b, b.getLoc());
   return arith::ShLIOp::create(b, arith::ConstantIntOp::create(b, 1, 32),
@@ -1591,12 +1580,8 @@ void FunctionBuilder::createSetReadVisibilityCall(ImplicitLocOpBuilder &b,
         Value relationMask =
             createLeadCTAEffectMask(fb, readVisibilityType, effectCTAs);
         Value threadCTAMask =
-            createCTASetMask(fb, readVisibilityType, /*dim=*/4, effectCTAs);
-        Value sameCTA = arith::CmpIOp::create(
-            fb, arith::CmpIPredicate::eq,
-            createDimIndices(fb, readVisibilityType, /*dim=*/2),
-            createDimIndices(fb, readVisibilityType, /*dim=*/4));
-        threadCTAMask = arith::AndIOp::create(fb, threadCTAMask, sameCTA);
+            createCTASetMask(fb, readVisibilityType,
+                             /*dim=*/4, createCurrentCTAMask(fb));
         relationMask = arith::AndIOp::create(fb, relationMask, threadCTAMask);
         bufferMask = arith::AndIOp::create(fb, bufferMask, relationMask);
         auto elemType = cast<IntegerType>(readVisibilityType.getElementType());
@@ -2456,30 +2441,26 @@ void FunctionBuilder::createPublishClusterVisibilityCall(
           Value sourceColumn = arith::SelectOp::create(
               fb, createDimMask(fb, threadVal, readVisibilityType, /*dim=*/3),
               readVisibility, zeroReads);
-          Value readsForThread =
-              reduce<arith::OrIOp>(fb, sourceColumn, {2, 3, 4});
-          readsForThread = convertAndBroadcast(fb, readsForThread, {0, 1},
+          Value readsForThread = reduce<arith::OrIOp>(fb, sourceColumn, {2, 3});
+          readsForThread = convertAndBroadcast(fb, readsForThread, {0, 1, 4},
                                                readVisibilityType);
           Value peerColumns = createThreadColumnMask(
               fb, threadPeersMaskVal, readVisibilityType, /*columnDim=*/3);
           readsForCluster = arith::SelectOp::create(fb, peerColumns,
                                                     readsForThread, zeroReads);
         } else if (onlySynchronousThreads) {
-          readsForCluster = reduce<arith::OrIOp>(fb, readVisibility, {2, 3, 4});
-          readsForCluster = convertAndBroadcast(fb, readsForCluster, {0, 1},
+          readsForCluster = reduce<arith::OrIOp>(fb, readVisibility, {2, 3});
+          readsForCluster = convertAndBroadcast(fb, readsForCluster, {0, 1, 4},
                                                 readVisibilityType);
         } else {
           uint64_t baseThreadMask = (1ULL << numBaseThreads) - 1;
-          Value readBaseMask = tti::createConstIntTensor(
-              fb, fb.getLoc(), baseThreadMask, readVisibilityType);
-          Value hasBaseRead = arith::CmpIOp::create(
-              fb, arith::CmpIPredicate::ne,
-              arith::AndIOp::create(fb, readVisibility, readBaseMask),
-              zeroReads);
-          Value syncReads = arith::SelectOp::create(fb, hasBaseRead,
+          Value baseObserverColumns = createThreadColumnMask(
+              fb, arith::ConstantIntOp::create(fb, baseThreadMask, 64),
+              readVisibilityType, /*columnDim=*/3);
+          Value syncReads = arith::SelectOp::create(fb, baseObserverColumns,
                                                     readVisibility, zeroReads);
-          readsForCluster = reduce<arith::OrIOp>(fb, syncReads, {2, 3, 4});
-          readsForCluster = convertAndBroadcast(fb, readsForCluster, {0, 1},
+          readsForCluster = reduce<arith::OrIOp>(fb, syncReads, {2, 3});
+          readsForCluster = convertAndBroadcast(fb, readsForCluster, {0, 1, 4},
                                                 readVisibilityType);
         }
         Value newReadVisibility =

--- a/lib/Dialect/TritonInstrument/IR/FunctionBuilder.cpp
+++ b/lib/Dialect/TritonInstrument/IR/FunctionBuilder.cpp
@@ -1549,31 +1549,37 @@ void FunctionBuilder::createPublishWriteVisibilityCall(
       });
 }
 
-void FunctionBuilder::createSetReadVisibilityCall(
-    ImplicitLocOpBuilder &b, Value bufferMask, uint64_t threadMask, Value pred,
-    MemType memType, Operation *insertPoint, Value effectCTAs) {
+void FunctionBuilder::createSetReadVisibilityCall(ImplicitLocOpBuilder &b,
+                                                  Value bufferMask, int reader,
+                                                  uint64_t observerMask,
+                                                  Value pred, MemType memType,
+                                                  Operation *insertPoint,
+                                                  Value effectCTAs) {
 
   if (auxData.readVisibility[(int)memType].empty()) {
     return;
   }
   if (!pred)
     pred = arith::ConstantIntOp::create(b, 1, 1);
-  Value threadMaskVal = arith::ConstantIntOp::create(b, threadMask, 64);
+  Value readerMaskVal = arith::ConstantIntOp::create(b, 1ULL << reader, 64);
+  Value observerMaskVal = arith::ConstantIntOp::create(b, observerMask, 64);
   Value readVisibilityVal =
       auxData.readVisibility[(int)memType].at(insertPoint).value;
   auto readVisibilityType = cast<RankedTensorType>(
       auxData.readVisibility[(int)memType].at(insertPoint).type);
-  SmallVector<Value> args = {bufferMask, pred, threadMaskVal, readVisibilityVal,
-                             effectCTAs};
+  SmallVector<Value> args = {bufferMask,        pred,
+                             readerMaskVal,     observerMaskVal,
+                             readVisibilityVal, effectCTAs};
   createCallToCachedFunction(
       b, "set_read_visibility", args,
       /*assertInfo=*/std::nullopt, {readVisibilityType, (uint64_t)memType},
       [readVisibilityType](ImplicitLocOpBuilder &fb, Block *entryBlock) {
         Value bufferMask = entryBlock->getArgument(0);
         Value pred = entryBlock->getArgument(1);
-        Value threadMaskVal = entryBlock->getArgument(2);
-        Value readVisibilityPtr = entryBlock->getArgument(3);
-        Value effectCTAs = entryBlock->getArgument(4);
+        Value readerMaskVal = entryBlock->getArgument(2);
+        Value observerMaskVal = entryBlock->getArgument(3);
+        Value readVisibilityPtr = entryBlock->getArgument(4);
+        Value effectCTAs = entryBlock->getArgument(5);
 
         auto [prevBlock, ifBlock, thenBlock] = createIfBlock(fb, pred);
         fb.setInsertionPointToStart(ifBlock);
@@ -1594,18 +1600,18 @@ void FunctionBuilder::createSetReadVisibilityCall(
         relationMask = arith::AndIOp::create(fb, relationMask, threadCTAMask);
         bufferMask = arith::AndIOp::create(fb, bufferMask, relationMask);
         auto elemType = cast<IntegerType>(readVisibilityType.getElementType());
-        Value threadMaskElem = adjustIntegerWidth(fb, threadMaskVal, elemType);
-        Value threadBit =
-            triton::SplatOp::create(fb, readVisibilityType, threadMaskElem);
-        Value threadColumnMask =
-            createThreadColumnMask(fb, threadMaskVal, readVisibilityType,
+        Value readerMaskElem = adjustIntegerWidth(fb, readerMaskVal, elemType);
+        Value readerBit =
+            triton::SplatOp::create(fb, readVisibilityType, readerMaskElem);
+        Value observerColumnMask =
+            createThreadColumnMask(fb, observerMaskVal, readVisibilityType,
                                    /*columnDim=*/3);
-        Value readVisibilityOrThreadBit =
-            arith::OrIOp::create(fb, readVisibility, threadBit);
-        Value bufAndThread =
-            arith::AndIOp::create(fb, bufferMask, threadColumnMask);
+        Value readVisibilityOrReaderBit =
+            arith::OrIOp::create(fb, readVisibility, readerBit);
+        Value bufAndObserver =
+            arith::AndIOp::create(fb, bufferMask, observerColumnMask);
         Value newVisibility = arith::SelectOp::create(
-            fb, bufAndThread, readVisibilityOrThreadBit, readVisibility);
+            fb, bufAndObserver, readVisibilityOrReaderBit, readVisibility);
         createMaskedStoreScratchMemory(fb, fb.getLoc(), readVisibilityPtr,
                                        newVisibility, readVisibilityType,
                                        relationMask);

--- a/lib/Dialect/TritonInstrument/Transforms/ConcurrencySanitizer.cpp
+++ b/lib/Dialect/TritonInstrument/Transforms/ConcurrencySanitizer.cpp
@@ -1020,8 +1020,9 @@ private:
                        effect.operandName, effectCTAs, opInfo->commitKind);
         if (opInfo->trackingKind == MemEffectsOpInfo::TrackingKind::Barrier) {
           funcBuilder.createSetReadVisibilityCall(
-              b, bufferMask, getThreadPeersMask(thread, auxData.threadLayout),
-              pred, memType, op, effectCTAs);
+              b, bufferMask, thread,
+              getThreadPeersMask(thread, auxData.threadLayout), pred, memType,
+              op, effectCTAs);
         }
         if (opInfo->trackingKind ==
             MemEffectsOpInfo::TrackingKind::CommitCount) {

--- a/python/test/gluon/test_consan.py
+++ b/python/test/gluon/test_consan.py
@@ -679,6 +679,105 @@ def test_cluster_barrier_does_not_publish_later_read(device, run_wrapper, monkey
 
 
 @pytest.mark.skipif(not is_cuda() or torch.cuda.get_device_capability()[0] < 9, reason="Requires hopper or newer")
+@pytest.mark.parametrize("FAILURE", [True, False])
+@pytest.mark.parametrize("PUBLISHED", [True, False], ids=["published-reader", "remote-reader"])
+def test_remote_shared_load_reader_visibility(PUBLISHED, FAILURE, device, run_wrapper, monkeypatch):
+    if FAILURE and run_wrapper:
+        result = run_in_process(test_remote_shared_load_reader_visibility,
+                                (PUBLISHED, FAILURE, device, False, monkeypatch))
+        assert_expected_cuda_failure(result.exc)
+        assert "Buffer being accessed has outstanding reads" in result.driver_stderr_output
+        return
+
+    monkeypatch.setenv("TRITON_INSTRUMENTATION_MODE", "consan")
+    monkeypatch.setenv("CUDA_LAUNCH_BLOCKING", "1")
+    knobs.refresh_knobs()
+
+    @gluon.jit
+    def kernel(out, PUBLISHED: ttgl.constexpr, FAILURE: ttgl.constexpr):
+        alloc_layout: ttgl.constexpr = ttgl.BlockedLayout([1, 1], [1, 32], [1, 4], [1, 0], cga_layout=((1, 0), ))
+        tile_layout: ttgl.constexpr = ttgl.BlockedLayout([1, 1], [1, 32], [1, 4], [1, 0], cga_layout=((0, 0), ))
+        shared_layout: ttgl.constexpr = ttgl.SwizzledSharedLayout(1, 1, 1, [1, 0], cga_layout=((1, 0), ))
+        parent = ttgl.allocate_shared_memory(ttgl.int32, [4, 32], shared_layout, value=ttgl.full([4, 32], 0, ttgl.int32,
+                                                                                                 alloc_layout))
+        smem = parent.slice(2, 2, dim=0)
+        ttgl.barrier(cluster=True)
+
+        cta = ttgl.inline_asm_elementwise("mov.u32 $0, %cluster_ctarank;", "=r", [], dtype=ttgl.int32, is_pure=True,
+                                          pack=1)
+        if cta == 0:
+            ttgl.store(out + cta, ttgl.sum(ttgl.sum(smem.load(tile_layout), axis=1), axis=0))
+        if PUBLISHED:
+            ttgl.barrier(cluster=True)
+            if cta == 1:
+                ttgl.store(out + cta, ttgl.sum(ttgl.sum(smem.load(tile_layout), axis=1), axis=0))
+        if FAILURE:
+            hopper.cluster.barrier(relaxed=True)
+        else:
+            ttgl.barrier(cluster=True)
+        writer: ttgl.constexpr = 0 if PUBLISHED else 1
+        if cta == writer:
+            smem.store(ttgl.full([2, 32], 1, ttgl.int32, tile_layout))
+        ttgl.barrier(cluster=True)
+
+    out = torch.zeros(2, device=device, dtype=torch.int32)
+    kernel[(1, )](out, PUBLISHED=PUBLISHED, FAILURE=FAILURE, num_warps=4, num_ctas=2)
+
+
+@pytest.mark.skipif(not is_cuda() or torch.cuda.get_device_capability()[0] < 10, reason="Requires blackwell or newer")
+@pytest.mark.parametrize("FINISHED", [True, False])
+def test_cluster_barrier_publishes_only_observed_tensor_reads(FINISHED, device, run_wrapper, monkeypatch):
+    if not FINISHED and run_wrapper:
+        result = run_in_process(test_cluster_barrier_publishes_only_observed_tensor_reads,
+                                (FINISHED, device, False, monkeypatch))
+        assert_expected_cuda_failure(result.exc)
+        assert "Buffer being accessed has outstanding reads" in result.driver_stderr_output
+        return
+
+    monkeypatch.setenv("TRITON_INSTRUMENTATION_MODE", "consan")
+    monkeypatch.setenv("CUDA_LAUNCH_BLOCKING", "1")
+    knobs.refresh_knobs()
+
+    @gluon.jit
+    def kernel(input_desc, out, FINISHED: ttgl.constexpr):
+        cga_layout: ttgl.constexpr = ((0, 0), )
+        blocked_layout: ttgl.constexpr = ttgl.BlockedLayout([1, 4], [4, 8], [4, 1], [1, 0], cga_layout=cga_layout)
+        shared_layout: ttgl.constexpr = ttgl.NVMMASharedLayout(128, 32, rank=2, cga_layout=cga_layout)
+        tensor_layout: ttgl.constexpr = blackwell.TensorMemoryLayout([128, 128], col_stride=1, cga_layout=cga_layout)
+        smem = ttgl.allocate_shared_memory(ttgl.int32, [128, 128], shared_layout)
+        tensor = blackwell.allocate_tensor_memory(ttgl.int32, [128, 128], tensor_layout)
+        tensor_barrier = mbarrier.allocate_mbarrier()
+        tma_barrier = mbarrier.allocate_mbarrier()
+        mbarrier.init(tensor_barrier, count=1)
+        mbarrier.init(tma_barrier, count=1)
+
+        if not FINISHED:
+            ttgl.store(out, ttgl.sum(ttgl.sum(smem.load(blocked_layout), axis=1), axis=0))
+            hopper.fence_async_shared()
+        blackwell.tcgen05_copy(smem, tensor)
+        if FINISHED:
+            blackwell.tcgen05_commit(tensor_barrier)
+            mbarrier.wait(tensor_barrier, phase=0, deps=[smem])
+
+        ttgl.barrier(cluster=True)
+        hopper.fence_async_shared(cluster=True)
+        mbarrier.expect(tma_barrier, input_desc.nbytes_per_cta)
+        tma.async_load(input_desc, [0, 0], tma_barrier, smem, multicast=True)
+        mbarrier.wait(tma_barrier, phase=0, deps=[smem])
+        if not FINISHED:
+            blackwell.tcgen05_commit(tensor_barrier)
+            mbarrier.wait(tensor_barrier, phase=0, deps=[smem])
+        mbarrier.invalidate(tma_barrier)
+        mbarrier.invalidate(tensor_barrier)
+
+    values = torch.zeros((128, 128), device=device, dtype=torch.int32)
+    out = torch.empty(1, device=device, dtype=torch.int32)
+    shared_layout = ttgl.NVMMASharedLayout(128, 32, rank=2, cga_layout=((0, 0), ))
+    input_desc = gluon.nvidia.hopper.TensorDescriptor.from_tensor(values, [128, 128], shared_layout)
+    kernel[(1, )](input_desc, out, FINISHED=FINISHED, num_warps=4, num_ctas=2)
+
+
+@pytest.mark.skipif(not is_cuda() or torch.cuda.get_device_capability()[0] < 9, reason="Requires hopper or newer")
 @pytest.mark.parametrize(
     "OP,FAILURE",
     [

--- a/python/test/gluon/test_consan.py
+++ b/python/test/gluon/test_consan.py
@@ -1306,6 +1306,8 @@ def test_tcgen5_copy(FAILURE, MEM_ACCESS_KIND, device, run_wrapper, monkeypatch,
         smem.store(val)
         bar = mbarrier.allocate_mbarrier()
         mbarrier.init(bar, count=1)
+        # An earlier synchronous reader must not impersonate the tensor core.
+        ttgl.store(output + offs, smem.load(reg_layout))
         blackwell.tcgen05_copy(smem, tmem)
         blackwell.tcgen05_commit(bar)
         if not FAILURE:

--- a/python/test/unit/runtime/test_driver.py
+++ b/python/test/unit/runtime/test_driver.py
@@ -313,6 +313,29 @@ def _trace(directory, phase, test, digest, hit):
                                                   times=SimpleNamespace(total=125_000), cache_hit=hit)
 
 
+def test_compile_warmup_runner_discards_previous_job_traces(tmp_path, monkeypatch):
+    directory = tmp_path / "trace"
+    _trace(directory, "warmup-unit", "old.py::test", "old", False)
+    _trace(directory, "unit", "old.py::test", "old", False)
+    monkeypatch.setenv("TRITON_CI_COMPILE_TRACE_DIR", str(directory))
+    monkeypatch.setattr(_test_runner, "_validate_gpus", lambda count: None)
+    coordinator = SimpleNamespace(address="unused", close=lambda: None)
+    monkeypatch.setattr(_test_runner, "SharedWarmupCoordinator", lambda **kwargs: coordinator)
+
+    def run(command, **kwargs):
+        _trace(directory, "warmup-unit", "new.py::test", "new", False)
+        _trace(directory, "unit", "new.py::test", "new", True)
+        return 0
+
+    monkeypatch.setattr(_test_runner, "_run", run)
+    args = SimpleNamespace(warmup_procs=1, capture_procs=1, targets=[])
+
+    assert _test_runner._warmup(args) == 0
+    report = summarize_compile_trace(str(directory))
+    assert report["warmup_tests"] == 1
+    _require_complete_warmup(report)
+
+
 @pytest.mark.parametrize(
     ("records", "message"),
     [

--- a/python/triton/_test_runner.py
+++ b/python/triton/_test_runner.py
@@ -3,6 +3,7 @@
 import argparse
 import json
 import os
+import shutil
 import signal
 import subprocess
 import sys
@@ -98,6 +99,8 @@ def _warmup(args):
         if str(entry) not in sys.path:
             sys.path.insert(0, str(entry))
     directory = os.environ.get("TRITON_CI_COMPILE_TRACE_DIR")
+    if directory and Path(directory).is_dir():
+        shutil.rmtree(directory)
     coordinator = SharedWarmupCoordinator(max_workers=args.warmup_procs, trace_directory=directory)
     environment = _environment("warmup-unit", 1)
     environment["TRITON_WARMUP_COORDINATOR"] = coordinator.address

--- a/test/TritonGPU/consan.mlir
+++ b/test/TritonGPU/consan.mlir
@@ -1076,11 +1076,13 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 1 : i32, ttg.shar
     // CHECK: %[[TC_BIT:.*]] = arith.constant 1 : i32
     // CHECK: tt.call @__triton_consan_verify_write_visibility{{.*}}%[[SM_WRITE_VISIBILITY_GLOB]]
     // CHECK: %[[TC_MASK:.*]] = arith.constant 2 : i64
-    // CHECK: tt.call @__triton_consan_set_read_visibility{{.*}}%[[TC_MASK]], %[[SM_READ_VISIBILITY_GLOB]]
+    // CHECK: %[[TC_OBSERVER_MASK:.*]] = arith.constant 2 : i64
+    // CHECK: tt.call @__triton_consan_set_read_visibility{{.*}}%[[TC_MASK]], %[[TC_OBSERVER_MASK]], %[[SM_READ_VISIBILITY_GLOB]]
     // CHECK: %[[TC_BIT:.*]] = arith.constant 1 : i32
     // CHECK: tt.call @__triton_consan_verify_write_visibility{{.*}}%[[SM_WRITE_VISIBILITY_GLOB]]
     // CHECK: %[[TC_MASK:.*]] = arith.constant 2 : i64
-    // CHECK: tt.call @__triton_consan_set_read_visibility{{.*}}%[[TC_MASK]], %[[SM_READ_VISIBILITY_GLOB]]
+    // CHECK: %[[TC_OBSERVER_MASK:.*]] = arith.constant 2 : i64
+    // CHECK: tt.call @__triton_consan_set_read_visibility{{.*}}%[[TC_MASK]], %[[TC_OBSERVER_MASK]], %[[SM_READ_VISIBILITY_GLOB]]
     // CHECK: %[[TC_BIT:.*]] = arith.constant 1 : i32
     // CHECK: tt.call @__triton_consan_verify_write_visibility{{.*}}%[[TM_WRITE_VISIBILITY_GLOB]]
     // CHECK: %[[TC_BIT:.*]] = arith.constant 1 : i32
@@ -1135,11 +1137,13 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 1 : i32, ttg.shar
     // CHECK: %[[TC_BIT:.*]] = arith.constant 1 : i32
     // CHECK: tt.call @__triton_consan_verify_write_visibility{{.*}}%[[TM_WRITE_VISIBILITY_GLOB]]
     // CHECK: %[[TC_MASK:.*]] = arith.constant 2 : i64
-    // CHECK: tt.call @__triton_consan_set_read_visibility{{.*}}%[[TC_MASK]], %[[TM_READ_VISIBILITY_GLOB]]
+    // CHECK: %[[TC_OBSERVER_MASK:.*]] = arith.constant 2 : i64
+    // CHECK: tt.call @__triton_consan_set_read_visibility{{.*}}%[[TC_MASK]], %[[TC_OBSERVER_MASK]], %[[TM_READ_VISIBILITY_GLOB]]
     // CHECK: %[[TC_BIT:.*]] = arith.constant 1 : i32
     // CHECK: tt.call @__triton_consan_verify_write_visibility{{.*}}%[[SM_WRITE_VISIBILITY_GLOB]]
     // CHECK: %[[TC_MASK:.*]] = arith.constant 2 : i64
-    // CHECK: tt.call @__triton_consan_set_read_visibility{{.*}}%[[TC_MASK]], %[[SM_READ_VISIBILITY_GLOB]]
+    // CHECK: %[[TC_OBSERVER_MASK:.*]] = arith.constant 2 : i64
+    // CHECK: tt.call @__triton_consan_set_read_visibility{{.*}}%[[TC_MASK]], %[[TC_OBSERVER_MASK]], %[[SM_READ_VISIBILITY_GLOB]]
     // CHECK: %[[TC_BIT:.*]] = arith.constant 1 : i32
     // CHECK: tt.call @__triton_consan_verify_write_visibility{{.*}}%[[TM_WRITE_VISIBILITY_GLOB]]
     // CHECK: %[[TC_BIT:.*]] = arith.constant 1 : i32


### PR DESCRIPTION
PR description written by Codex

Track the actual shared-memory reader separately from synthetic peer threads that may observe it, preventing an earlier generic read from hiding an unfinished tensor-core access.

Validated with the complete NVIDIA ConSan suite (396 passed, 62 skipped), NVIDIA and AMD sanitizer FileCheck coverage, and pre-commit.