### PR TITLE
[ConSan] Track multicast barrier recipients

### DIFF
--- a/lib/Dialect/TritonInstrument/Transforms/ConcurrencySanitizer.cpp
+++ b/lib/Dialect/TritonInstrument/Transforms/ConcurrencySanitizer.cpp
@@ -654,6 +654,10 @@ Value getMemEffectCTAs(ImplicitLocOpBuilder &b, Value recipients,
 }
 
 Value getBarrierRecipientCTAs(ImplicitLocOpBuilder &b, Operation *op) {
+  if (auto arrive = dyn_cast<ttng::ArriveBarrierOp>(op);
+      arrive && arrive.isMulticast())
+    return getRecipientCTAsForBroadcastMasks(
+        b, {static_cast<uint16_t>(arrive.getMulticastCTA())});
   if (isa<ttng::BarrierExpectOp, ttng::ArriveBarrierOp>(op)) {
     Value barrier = cast<ttg::MBarrierOpInterface>(op).getBarrier();
     std::optional<uint32_t> fromCTA;

--- a/python/test/gluon/test_consan.py
+++ b/python/test/gluon/test_consan.py
@@ -8,8 +8,9 @@ from triton.experimental.gluon import language as ttgl
 from triton.experimental.gluon.language.nvidia import blackwell
 from triton.experimental.gluon.language.nvidia import hopper
 from triton.experimental.gluon.language.nvidia import ampere
+from triton.experimental.gluon.language.nvidia import rubin
 from triton.experimental.gluon.language.nvidia.blackwell import allocate_tensor_memory, clc, mbarrier, tma
-from triton._internal_testing import is_compile_warmup, is_cuda, run_in_process
+from triton._internal_testing import is_compile_warmup, is_cuda, is_rubin, run_in_process
 
 pytestmark = [pytest.mark.enable_warmup(min_capability=9), pytest.mark.usefixtures("process_pool")]
 
@@ -197,6 +198,25 @@ def test_consan_initializes_allocations_with_nan(MEMORY_KIND, device, num_ctas):
     output = torch.empty((XBLOCK.value * num_ctas, XBLOCK.value), device=device, dtype=torch.float32)
     kernel[(1, )](output, MEMORY_KIND=MEMORY_KIND, num_warps=4, num_ctas=num_ctas)
     assert torch.isnan(output).all()
+
+
+@pytest.mark.skipif(not is_rubin(), reason="Requires Rubin")
+def test_mbarrier_arrive_multicast_completion(device, monkeypatch):
+    monkeypatch.setenv("TRITON_INSTRUMENTATION_MODE", "consan")
+    knobs.refresh_knobs()
+
+    @gluon.jit
+    def kernel(out):
+        bar = rubin.mbarrier.allocate_mbarrier()
+        rubin.mbarrier.init(bar, count=2)
+        rubin.mbarrier.arrive(bar, multicast_cta=1)
+        rubin.mbarrier.wait(bar, 0)
+        rubin.mbarrier.invalidate(bar)
+        ttgl.store(out + ttgl.program_id(0), ttgl.program_id(0))
+
+    output = torch.empty(2, device=device, dtype=torch.int32)
+    kernel[(2, )](output, num_ctas=2, num_warps=4)
+    torch.testing.assert_close(output, torch.arange(2, device=device, dtype=torch.int32))
 
 
 @pytest.mark.skipif(not is_cuda() or torch.cuda.get_device_capability()[0] < 9, reason="Requires hopper or newer")

--- a/test/TritonGPU/consan.mlir
+++ b/test/TritonGPU/consan.mlir
@@ -139,6 +139,62 @@ module attributes {"ttg.num-ctas" = 8 : i32, "ttg.num-warps" = 1 : i32, ttg.shar
 
 // -----
 
+#barrier_multicast_two = #ttg.swizzled_shared<{vec = 1, perPhase = 1, maxPhase = 1, order = [0], CGALayout = [[1]]}>
+#smem_multicast_two = #ttg.shared_memory
+module attributes {"ttg.num-ctas" = 2 : i32, "ttg.num-warps" = 1 : i32, ttg.shared = 16 : i32, ttg.target = "cuda:107", ttg.tensor_memory_size = 0 : i32, "ttg.threads-per-warp" = 32 : i32, "ttg.total-num-warps" = 1 : i32} {
+  // CHECK-LABEL: @mbarrier_multicast_two_ctas
+  tt.func public @mbarrier_multicast_two_ctas() {
+    %bar = ttg.local_alloc {allocation.offset = 0 : i32} : () -> !ttg.memdesc<2xi64, #barrier_multicast_two, #smem_multicast_two, mutable>
+    // CHECK: ttng.init_barrier
+    ttng.init_barrier %bar, 2 : !ttg.memdesc<2xi64, #barrier_multicast_two, #smem_multicast_two, mutable>
+    // CHECK: %[[TWO_PATTERN:.*]] = arith.constant 3 : i32
+    // CHECK: %[[TWO_SHIFT:.*]] = arith.shli %[[TWO_PATTERN]], {{.*}} : i32
+    // CHECK: %[[TWO_RECIPIENTS:.*]] = arith.ori {{.*}}, %[[TWO_SHIFT]] : i32
+    // CHECK: tt.call @__triton_consan_verify_and_update_barrier_state{{.*}}({{.*}}%[[TWO_RECIPIENTS]])
+    // CHECK: ttng.arrive_barrier {{.*}}multicastCTA = 1 : i32
+    ttng.arrive_barrier %bar, 1 {multicastCTA = 1 : i32} : !ttg.memdesc<2xi64, #barrier_multicast_two, #smem_multicast_two, mutable>
+    tt.return
+  }
+}
+
+// -----
+
+#barrier_multicast_four = #ttg.swizzled_shared<{vec = 1, perPhase = 1, maxPhase = 1, order = [0], CGALayout = [[1], [2]]}>
+#smem_multicast_four = #ttg.shared_memory
+module attributes {"ttg.num-ctas" = 4 : i32, "ttg.num-warps" = 1 : i32, ttg.shared = 64 : i32, ttg.target = "cuda:107", ttg.tensor_memory_size = 0 : i32, "ttg.threads-per-warp" = 32 : i32, "ttg.total-num-warps" = 1 : i32} {
+  // CHECK-LABEL: @mbarrier_multicast_four_ctas
+  tt.func public @mbarrier_multicast_four_ctas() {
+    %bar0 = ttg.local_alloc {allocation.offset = 0 : i32} : () -> !ttg.memdesc<4xi64, #barrier_multicast_four, #smem_multicast_four, mutable>
+    %bar1 = ttg.local_alloc {allocation.offset = 32 : i32} : () -> !ttg.memdesc<4xi64, #barrier_multicast_four, #smem_multicast_four, mutable>
+    // CHECK: ttng.init_barrier
+    ttng.init_barrier %bar0, 2 : !ttg.memdesc<4xi64, #barrier_multicast_four, #smem_multicast_four, mutable>
+    // CHECK: ttng.init_barrier
+    ttng.init_barrier %bar1, 2 : !ttg.memdesc<4xi64, #barrier_multicast_four, #smem_multicast_four, mutable>
+    // multicastCTA=1 reaches {0,1} or {2,3}.
+    // CHECK: %[[LOW_FIXED:.*]] = arith.constant 2 : i32
+    // CHECK: %[[LOW_BASE:.*]] = arith.andi {{.*}}, %[[LOW_FIXED]] : i32
+    // CHECK: %[[LOW_PATTERN:.*]] = arith.constant 3 : i32
+    // CHECK: %[[LOW_SHIFT:.*]] = arith.shli %[[LOW_PATTERN]], %[[LOW_BASE]] : i32
+    // CHECK: %[[LOW_RECIPIENTS:.*]] = arith.ori {{.*}}, %[[LOW_SHIFT]] : i32
+    // CHECK: tt.call @__triton_consan_verify_and_update_barrier_state{{.*}}({{.*}}%[[LOW_RECIPIENTS]])
+    // CHECK: ttng.arrive_barrier {{.*}}multicastCTA = 1 : i32
+    ttng.arrive_barrier %bar0, 1 {multicastCTA = 1 : i32} : !ttg.memdesc<4xi64, #barrier_multicast_four, #smem_multicast_four, mutable>
+    // multicastCTA=2 reaches {0,2} or {1,3}.
+    // CHECK: arith.constant 0 : i32
+    // CHECK-NEXT: %[[HIGH_FIXED:.*]] = arith.constant 1 : i32
+    // CHECK-NEXT: %[[HIGH_BASE:.*]] = arith.andi {{.*}}, %[[HIGH_FIXED]] : i32
+    // CHECK: %[[HIGH_PATTERN:.*]] = arith.constant 5 : i32
+    // CHECK: %[[HIGH_SHIFT:.*]] = arith.shli %[[HIGH_PATTERN]], %[[HIGH_BASE]] : i32
+    // CHECK: %[[HIGH_RECIPIENTS:.*]] = arith.ori {{.*}}, %[[HIGH_SHIFT]] : i32
+    // CHECK: tt.call @__triton_consan_verify_and_update_barrier_state{{.*}}({{.*}}%[[HIGH_RECIPIENTS]])
+    // CHECK: ttng.arrive_barrier {{.*}}multicastCTA = 2 : i32
+    ttng.arrive_barrier %bar1, 1 {multicastCTA = 2 : i32} : !ttg.memdesc<4xi64, #barrier_multicast_four, #smem_multicast_four, mutable>
+    tt.return
+  }
+}
+
+// -----
+
 #shared_cluster_ws = #ttg.swizzled_shared<{vec = 1, perPhase = 1, maxPhase = 1, order = [1, 0], CGALayout = [[1, 0]]}>
 #smem_cluster_ws = #ttg.shared_memory
 #blocked_cluster_ws = #ttg.blocked<{sizePerThread = [1, 32], threadsPerWarp = [32, 1], warpsPerCTA = [4, 1], order = [0, 1], CGALayout = [[1, 0]]}>


### PR DESCRIPTION
PR description written by Codex

Apply multicast mbarrier arrivals to every physical CTA selected by multicastCTA so ConSan updates each recipient's barrier state and visibility frontier.

Validated with NVIDIA and AMD ConSan FileCheck coverage, including two- and four-CTA multicast equivalence classes.