### PR TITLE
Fix byte-level race tracking in GSan

### DIFF
--- a/lib/Conversion/TritonInstrumentToLLVM/GSanToLLVM.cpp
+++ b/lib/Conversion/TritonInstrumentToLLVM/GSanToLLVM.cpp
@@ -280,9 +280,6 @@ unsigned getTensorAccessVecSize(OpT op,
     return contiguity;
 
   auto maskAlign = axisInfoAnalysis.getMaskAlignment(op.getMask());
-  if (bytesPerElem < kGSanShadowGranularityBytes) {
-    maskAlign = std::max(maskAlign, kGSanShadowGranularityBytes / bytesPerElem);
-  }
   return std::min(contiguity, maskAlign);
 }
 
@@ -505,8 +502,7 @@ public:
         axisInfoAnalysis(&axisInfoAnalysis) {}
 
   unsigned getVecSize(tti::ExperimentalGSanAtomicTensorAccessOp op) const {
-    // GSan tracks conflicts at shadow-cell granularity, so atomics may only be
-    // coalesced while they still fit inside a single shadow cell.
+    // Atomic accesses may only be coalesced within a single shadow cell.
     return getTensorAccessVecSize(op, *axisInfoAnalysis,
                                   /*keepWithinSingleShadowCell=*/true);
   }

--- a/python/test/gsan/test_allocator.py
+++ b/python/test/gsan/test_allocator.py
@@ -212,7 +212,7 @@ def test_default_topology_uses_cuda_device_indices():
 
 def test_malloc_free(_direct_allocator):
     malloc, free, reserve_ptr, reserve_size = _direct_allocator
-    real_base = reserve_ptr + reserve_size // 2
+    real_base = reserve_ptr + 3 * reserve_size // 4
 
     # First valid allocation should come from the real base and be reusable.
     p0 = malloc(1)
@@ -297,12 +297,12 @@ def test_mem_pool():
     assert reserve_ptr != 0
     assert reserve_size > 0
 
-    # Check real allocation is in higher half of reserve
-    real_base = reserve_ptr + reserve_size // 2
+    # Real allocations occupy the final quarter of the reservation.
+    real_base = reserve_ptr + 3 * reserve_size // 4
     assert real_base <= real.data_ptr() < reserve_ptr + reserve_size
 
     shadow = shadow_tensor_for(real)
-    assert reserve_ptr <= shadow.data_ptr() < reserve_ptr + reserve_size // 2
+    assert reserve_ptr <= shadow.data_ptr() < real_base
 
     # Test that real and shadow allocation can be used
     real.zero_()

--- a/python/test/gsan/test_gsan.py
+++ b/python/test/gsan/test_gsan.py
@@ -151,7 +151,7 @@ def _disjoint_subword_access_kernel(ptr, scratch_ptr, counter_ptr, ACCESS: tl.co
 
 
 @pytest.mark.skipif(not is_cuda(), reason="GSan requires CUDA")
-@pytest.mark.parametrize("dtype", [torch.float16, torch.float8_e4m3fn])
+@pytest.mark.parametrize("dtype", [torch.float16, torch.float8_e5m2])
 @pytest.mark.parametrize("access", ["raw", "war", "waw"])
 def test_disjoint_subword_accesses_do_not_race(with_gsan, capfd, dtype, access):
     target = torch.zeros(4, dtype=dtype, device="cuda")
@@ -189,7 +189,7 @@ def _masked_disjoint_subword_access_kernel(ptr, scratch_ptr, counter_ptr, ACCESS
 
 
 @pytest.mark.skipif(not is_cuda(), reason="GSan requires CUDA")
-@pytest.mark.parametrize("dtype", [torch.float16, torch.float8_e4m3fn])
+@pytest.mark.parametrize("dtype", [torch.float16, torch.float8_e5m2])
 @pytest.mark.parametrize("access", ["raw", "war", "waw"])
 def test_masked_disjoint_subword_accesses_do_not_race(with_gsan, capfd, dtype, access):
     target = torch.zeros(4, dtype=dtype, device="cuda")
@@ -221,7 +221,7 @@ def _ordered_subword_read_kernel(ptr, scratch_ptr, flag_ptr, ready_ptr):
 
 
 @pytest.mark.skipif(not is_cuda(), reason="GSan requires CUDA")
-@pytest.mark.parametrize("dtype", [torch.float16, torch.float8_e4m3fn])
+@pytest.mark.parametrize("dtype", [torch.float16, torch.float8_e5m2])
 def test_ordered_subword_read_is_not_invalidated_by_disjoint_read(with_gsan, capfd, dtype):
     target = torch.zeros(4, dtype=dtype, device="cuda")
     scratch = torch.zeros_like(target)

--- a/python/test/gsan/test_gsan.py
+++ b/python/test/gsan/test_gsan.py
@@ -131,6 +131,174 @@ def test_load_store_updates_shadow(with_gsan):
     assert cell1.num_reads == 1
 
 
+@triton.jit
+def _disjoint_subword_access_kernel(ptr, scratch_ptr, counter_ptr, ACCESS: tl.constexpr):
+    pid = tl.program_id(0)
+    if pid == 0:
+        if ACCESS == "war":
+            value = tl.load(ptr)
+            tl.store(scratch_ptr, value)
+        else:
+            tl.store(ptr, 1.0)
+        tl.atomic_add(counter_ptr, 1, sem="relaxed")
+    else:
+        atomic_poll(counter_ptr, 1)
+        if ACCESS == "raw":
+            value = tl.load(ptr + 1)
+            tl.store(scratch_ptr + 1, value)
+        else:
+            tl.store(ptr + 1, 2.0)
+
+
+@pytest.mark.skipif(not is_cuda(), reason="GSan requires CUDA")
+@pytest.mark.parametrize("dtype", [torch.float16, torch.float8_e4m3fn])
+@pytest.mark.parametrize("access", ["raw", "war", "waw"])
+def test_disjoint_subword_accesses_do_not_race(with_gsan, capfd, dtype, access):
+    target = torch.zeros(4, dtype=dtype, device="cuda")
+    scratch = torch.zeros_like(target)
+    counter = torch.zeros(1, dtype=torch.int32, device="cuda")
+
+    _disjoint_subword_access_kernel[(2, )](target, scratch, counter, ACCESS=access, num_warps=1)
+    torch.cuda.synchronize()
+
+    assert target[0].item() == (0 if access == "war" else 1)
+    assert target[1].item() == (0 if access == "raw" else 2)
+    _assert_no_gsan_runtime_output(capfd)
+
+
+@gluon.jit
+def _masked_disjoint_subword_access_kernel(ptr, scratch_ptr, counter_ptr, ACCESS: tl.constexpr):
+    layout: gl.constexpr = gl.BlockedLayout([4], [32], [1], [0])
+    pid = gl.program_id(0)
+    offsets = gl.arange(0, 128, layout=layout)
+    mask = offsets == pid
+    if pid == 0:
+        if ACCESS == "war":
+            values = gl.load(ptr + offsets, mask=mask)
+            gl.store(scratch_ptr + offsets, values, mask=mask)
+        else:
+            gl.store(ptr + offsets, 1.0, mask=mask)
+        gl.atomic_add(counter_ptr, 1, sem="relaxed")
+    else:
+        gl.atomic_poll(counter_ptr, 1, sem="relaxed", scope="gpu")
+        if ACCESS == "raw":
+            values = gl.load(ptr + offsets, mask=mask)
+            gl.store(scratch_ptr + offsets, values, mask=mask)
+        else:
+            gl.store(ptr + offsets, 2.0, mask=mask)
+
+
+@pytest.mark.skipif(not is_cuda(), reason="GSan requires CUDA")
+@pytest.mark.parametrize("dtype", [torch.float16, torch.float8_e4m3fn])
+@pytest.mark.parametrize("access", ["raw", "war", "waw"])
+def test_masked_disjoint_subword_accesses_do_not_race(with_gsan, capfd, dtype, access):
+    target = torch.zeros(4, dtype=dtype, device="cuda")
+    scratch = torch.zeros_like(target)
+    counter = torch.zeros(1, dtype=torch.int32, device="cuda")
+
+    _masked_disjoint_subword_access_kernel[(2, )](target, scratch, counter, ACCESS=access, num_warps=1)
+    torch.cuda.synchronize()
+
+    assert target[0].item() == (0 if access == "war" else 1)
+    assert target[1].item() == (0 if access == "raw" else 2)
+    _assert_no_gsan_runtime_output(capfd)
+
+
+@triton.jit
+def _ordered_subword_read_kernel(ptr, scratch_ptr, flag_ptr, ready_ptr):
+    pid = tl.program_id(0)
+    if pid == 0:
+        first = tl.load(ptr)
+        tl.store(scratch_ptr, first)
+        tl.atomic_xchg(flag_ptr, 1, sem="release", scope="gpu")
+        second = tl.load(ptr + 1)
+        tl.store(scratch_ptr + 1, second)
+        tl.atomic_add(ready_ptr, 1, sem="relaxed")
+    else:
+        atomic_poll(flag_ptr, 1, sem="acquire", scope="gpu")
+        atomic_poll(ready_ptr, 1)
+        tl.store(ptr, 3.0)
+
+
+@pytest.mark.skipif(not is_cuda(), reason="GSan requires CUDA")
+@pytest.mark.parametrize("dtype", [torch.float16, torch.float8_e4m3fn])
+def test_ordered_subword_read_is_not_invalidated_by_disjoint_read(with_gsan, capfd, dtype):
+    target = torch.zeros(4, dtype=dtype, device="cuda")
+    scratch = torch.zeros_like(target)
+    flag = torch.zeros(1, dtype=torch.int32, device="cuda")
+    ready = torch.zeros(1, dtype=torch.int32, device="cuda")
+
+    _ordered_subword_read_kernel[(2, )](target, scratch, flag, ready, num_warps=1)
+    torch.cuda.synchronize()
+
+    assert target[0].item() == 3
+    assert target[1].item() == 0
+    _assert_no_gsan_runtime_output(capfd)
+
+
+@triton.jit
+def _mixed_width_release_chain_kernel(payload_ptr, flags_ptr, wide_flags_ptr, ready_ptr, out_ptr):
+    pid = tl.program_id(0)
+    if pid < 2:
+        tl.store(payload_ptr + pid, 10 + pid)
+        tl.atomic_xchg(flags_ptr + pid, 1, sem="release", scope="gpu")
+        tl.atomic_add(ready_ptr, 1, sem="relaxed")
+    elif pid == 2:
+        atomic_poll(ready_ptr, 2)
+        tl.atomic_add(wide_flags_ptr, 1, sem="release", scope="gpu")
+    else:
+        atomic_poll(wide_flags_ptr, 4294967298, sem="acquire", scope="gpu")
+        first = tl.load(payload_ptr)
+        second = tl.load(payload_ptr + 1)
+        tl.store(out_ptr, first)
+        tl.store(out_ptr + 1, second)
+
+
+@pytest.mark.skipif(not is_cuda(), reason="GSan requires CUDA")
+def test_mixed_width_atomic_release_synchronizes_all_overlapping_writers(with_gsan, capfd):
+    payload = torch.zeros(2, dtype=torch.int32, device="cuda")
+    flags = torch.zeros(2, dtype=torch.int32, device="cuda")
+    wide_flags = flags.view(torch.int64)
+    ready = torch.zeros(1, dtype=torch.int32, device="cuda")
+    out = torch.full_like(payload, -1)
+
+    _mixed_width_release_chain_kernel[(4, )](payload, flags, wide_flags, ready, out, num_warps=1)
+    torch.cuda.synchronize()
+
+    torch.testing.assert_close(out, torch.tensor([10, 11], dtype=torch.int32, device="cuda"))
+    _assert_no_gsan_runtime_output(capfd)
+
+
+@triton.jit
+def _disjoint_subword_atomic_kernel(ptr, counter_ptr, ATOMIC_FIRST: tl.constexpr):
+    pid = tl.program_id(0)
+    if pid == 0:
+        if ATOMIC_FIRST:
+            tl.atomic_add(ptr, 1, sem="relaxed", scope="gpu")
+        else:
+            tl.store(ptr, 1)
+        tl.atomic_add(counter_ptr, 1, sem="relaxed")
+    else:
+        atomic_poll(counter_ptr, 1)
+        if ATOMIC_FIRST:
+            tl.store(ptr + 1, 2)
+        else:
+            tl.atomic_add(ptr + 1, 2, sem="relaxed", scope="gpu")
+
+
+@pytest.mark.skipif(not is_cuda(), reason="GSan requires CUDA")
+@pytest.mark.parametrize("atomic_first", [False, True])
+def test_disjoint_subword_atomic_and_non_atomic_accesses_do_not_race(with_gsan, capfd, atomic_first):
+    target = torch.zeros(2, dtype=torch.float16, device="cuda")
+    counter = torch.zeros(1, dtype=torch.int32, device="cuda")
+
+    _disjoint_subword_atomic_kernel[(2, )](target, counter, ATOMIC_FIRST=atomic_first, num_warps=1)
+    torch.cuda.synchronize()
+
+    torch.testing.assert_close(target, torch.tensor([1, 2], dtype=torch.float16, device="cuda"))
+    _assert_no_gsan_runtime_output(capfd)
+
+
 @pytest.mark.skipif(not is_cuda(), reason="GSan requires CUDA")
 def test_cuda_graph_capture_is_rejected(with_gsan):
     target = torch.zeros(1, dtype=torch.int32, device="cuda")

--- a/python/test/gsan/test_gsan_failures.py
+++ b/python/test/gsan/test_gsan_failures.py
@@ -74,6 +74,29 @@ def _waw_kernel(ptr, scratch_ptr, counter_ptr):
 
 
 @triton.jit
+def _overlapping_subword_access_kernel(ptr, scratch_ptr, counter_ptr, ACCESS: tl.constexpr):
+    pid = tl.program_id(0)
+    if pid == 0:
+        if ACCESS == "war":
+            first_value = tl.load(ptr)
+            tl.store(scratch_ptr, first_value)
+        else:
+            tl.store(ptr, 1.0)
+        tl.atomic_add(counter_ptr, 1, sem="relaxed")
+    elif pid == 1:
+        atomic_poll(counter_ptr, 1)
+        tl.store(ptr + 1, 2.0)
+        tl.atomic_add(counter_ptr, 1, sem="relaxed")
+    else:
+        atomic_poll(counter_ptr, 2)
+        if ACCESS == "raw":
+            overlapping_value = tl.load(ptr)
+            tl.store(scratch_ptr + 1, overlapping_value)
+        else:
+            tl.store(ptr, 3.0)
+
+
+@triton.jit
 def _pdl_producer_kernel(payload_ptr):
     pid = tl.program_id(0)
     tl.store(payload_ptr + pid, 1000 + pid)
@@ -293,6 +316,14 @@ def _run_waw_case() -> None:
     scratch = torch.zeros(1, dtype=torch.int32, device="cuda")
     counter = torch.zeros(1, dtype=torch.int32, device="cuda")
     _waw_kernel[(2, )](target, scratch, counter, num_warps=1)
+
+
+@run_with_gsan
+def _run_overlapping_subword_case(dtype, access: str) -> None:
+    target = torch.zeros(4, dtype=dtype, device="cuda")
+    scratch = torch.zeros_like(target)
+    counter = torch.zeros(1, dtype=torch.int32, device="cuda")
+    _overlapping_subword_access_kernel[(3, )](target, scratch, counter, ACCESS=access, num_warps=1)
 
 
 @run_with_gsan
@@ -517,6 +548,25 @@ def test_write_after_read():
 def test_write_after_write():
     _run_failure_case("waw", runner=_run_waw_case, source_function=_waw_kernel.fn, marker="tl.store(ptr, 2)",
                       error="Write after write race detected")
+
+
+@pytest.mark.parametrize("dtype", [torch.float16, torch.float8_e4m3fn])
+@pytest.mark.parametrize("access", ["raw", "war", "waw"])
+def test_overlapping_subword_access_after_disjoint_write(dtype, access):
+    marker = "overlapping_value = tl.load(ptr)" if access == "raw" else "tl.store(ptr, 3.0)"
+    error = {
+        "raw": "Read after write race detected",
+        "war": "Write after read race detected",
+        "waw": "Write after write race detected",
+    }[access]
+    _run_failure_case(
+        f"overlapping_subword_{dtype}_{access}",
+        runner=_run_overlapping_subword_case,
+        runner_args=(dtype, access),
+        source_function=_overlapping_subword_access_kernel.fn,
+        marker=marker,
+        error=error,
+    )
 
 
 @pytest.mark.skipif(not is_hopper_or_newer(), reason="PDL requires SM90 or newer")

--- a/python/test/gsan/test_gsan_failures.py
+++ b/python/test/gsan/test_gsan_failures.py
@@ -550,7 +550,7 @@ def test_write_after_write():
                       error="Write after write race detected")
 
 
-@pytest.mark.parametrize("dtype", [torch.float16, torch.float8_e4m3fn])
+@pytest.mark.parametrize("dtype", [torch.float16, torch.float8_e5m2])
 @pytest.mark.parametrize("access", ["raw", "war", "waw"])
 def test_overlapping_subword_access_after_disjoint_write(dtype, access):
     marker = "overlapping_value = tl.load(ptr)" if access == "raw" else "tl.store(ptr, 3.0)"

--- a/python/triton/experimental/gsan/src/GSan.h
+++ b/python/triton/experimental/gsan/src/GSan.h
@@ -53,11 +53,12 @@ static_assert(static_cast<int>(AtomicScope::MAX_VALUE) == 3);
 struct alignas(4) ShadowCell {
   static constexpr int kReadClockSize = 4;
   ScalarClock readClocks[kReadClockSize];
-  ScalarClock writeClock;
+  ScalarClock writeClocks[kShadowMemGranularityBytes];
+  uint8_t readMasks[kReadClockSize];
   uint16_t numReads;
   uint16_t lock;
 };
-static_assert(sizeof(ShadowCell) == 24);
+static_assert(sizeof(ShadowCell) == 40);
 static_assert(alignof(ShadowCell) == 4);
 
 struct GlobalState {
@@ -105,7 +106,10 @@ struct AtomicEventState {
   ThreadState *threadState;
   ShadowCell *cells[kMaxAtomicShadowCells];
   uint8_t numCells;
+  uint8_t masks[kMaxAtomicShadowCells];
 };
+static_assert(sizeof(AtomicEventState) == 40,
+              "atomic access masks must fit the LLVM event state's padding");
 
 // Place the thread state for each device at a fixed stride for ease of
 // address calculation.
@@ -120,7 +124,7 @@ inline GSAN_HOST_DEVICE GlobalState *getGlobalState(ThreadState *threadState) {
 }
 
 inline GSAN_HOST_DEVICE uintptr_t getRealBaseAddress(uintptr_t reserveBase) {
-  return reserveBase + kReserveSize / 2;
+  return reserveBase + 3 * kReserveSize / 4;
 }
 
 inline GSAN_HOST_DEVICE uintptr_t getReserveBaseFromAddress(uintptr_t addr) {

--- a/python/triton/experimental/gsan/src/GSanAllocator.cc
+++ b/python/triton/experimental/gsan/src/GSanAllocator.cc
@@ -355,12 +355,12 @@ int gsanEnsureInit() {
   auto *root = &alloc->treeRoot;
   root->virtualAddress = gsan::getRealBaseAddress(reserveBase);
 
-  // Choose size so that both shadow memory and real memory definitely fit in
-  // the address reservation
-  auto shadowSize = gsan::kReserveSize / 2;
-  auto realSize = gsan::kShadowMemGranularityBytes *
-                  (shadowSize / sizeof(gsan::ShadowCell));
-  realSize = std::min(gsan::kReserveSize / 2, realSize);
+  // Fit both real memory and its corresponding shadow in the reservation.
+  auto shadowSize = root->virtualAddress - reserveBase;
+  auto realRegionSize = gsan::kReserveSize - shadowSize;
+  auto realSize =
+      std::min(realRegionSize, gsan::kShadowMemGranularityBytes *
+                                   (shadowSize / sizeof(gsan::ShadowCell)));
   realSize = roundDownToPowerOfTwo(realSize);
   root->size = realSize;
   root->maxFreeBlockSize = realSize;

--- a/python/triton/experimental/gsan/src/GSanLibrary.cu
+++ b/python/triton/experimental/gsan/src/GSanLibrary.cu
@@ -355,6 +355,19 @@ GSAN_DEVICE Range roundRange(Range x) {
   return x;
 }
 
+GSAN_DEVICE uint8_t getAccessMask(Range access, uintptr_t cellAddress) {
+  uintptr_t cellEnd = cellAddress + kShadowMemGranularityBytes;
+  uint32_t firstByte =
+      access.start > cellAddress ? access.start - cellAddress : 0;
+  uint32_t lastByte = access.end < cellEnd ? access.end - cellAddress
+                                           : kShadowMemGranularityBytes;
+  return static_cast<uint8_t>((1u << lastByte) - (1u << firstByte));
+}
+
+GSAN_DEVICE bool maskIncludesByte(uint8_t mask, int byte) {
+  return (mask & (1u << byte)) != 0;
+}
+
 GSAN_DEVICE ShadowCell *acquireShadow(uintptr_t shadowAddr) {
   auto cell = reinterpret_cast<ShadowCell *>(shadowAddr);
   uint16_t actual = 0;
@@ -512,19 +525,67 @@ GSAN_DEVICE ScalarClock makePublishedClock(ThreadState *state,
   return ScalarClock{token, state->threadId, scope, true};
 }
 
+GSAN_DEVICE bool clocksEqual(const ScalarClock &lhs, const ScalarClock &rhs) {
+  return lhs.epoch == rhs.epoch && lhs.threadId == rhs.threadId &&
+         lhs.scope == rhs.scope && lhs.isRelease == rhs.isRelease;
+}
+
+GSAN_DEVICE bool isFirstWriteClock(const ShadowCell *cell, uint8_t mask,
+                                   int byte) {
+  for (int previousByte = 0; previousByte < byte; ++previousByte) {
+    if (maskIncludesByte(mask, previousByte) &&
+        clocksEqual(cell->writeClocks[byte], cell->writeClocks[previousByte]))
+      return false;
+  }
+  return true;
+}
+
+GSAN_DEVICE void replaceReadClock(ThreadState *state, ShadowCell *cell,
+                                  int index, ScalarClock clock, uint8_t mask) {
+  for (int i = 0; i < ShadowCell::kReadClockSize; ++i) {
+    if (i == index)
+      continue;
+    auto &prior = cell->readClocks[i];
+    if (prior.threadId == state->threadId && prior.scope == clock.scope) {
+      cell->readMasks[i] &= static_cast<uint8_t>(~mask);
+      if (cell->readMasks[i] == 0)
+        prior = ScalarClock{};
+    }
+  }
+  cell->readClocks[index] = clock;
+  cell->readMasks[index] = mask;
+}
+
 GSAN_DEVICE void recordRead(ThreadState *state, ShadowCell *cell,
-                            AtomicScope scope) {
+                            AtomicScope scope, uint8_t mask) {
   auto numReads = cell->numReads;
   if (numReads < kMaxUint16)
     ++cell->numReads;
 
   auto scalarClock = makeScalarClock(state, scope);
+  int reusableIndex = -1;
+  int emptyIndex = -1;
   for (int iRead = 0; iRead < ShadowCell::kReadClockSize; ++iRead) {
     auto readClock = cell->readClocks[iRead];
-    if (readClock.threadId == state->threadId || readClock.epoch == 0) {
-      cell->readClocks[iRead] = scalarClock;
+    auto readMask = cell->readMasks[iRead];
+    if (readClock.epoch == 0 || readMask == 0) {
+      if (emptyIndex == -1)
+        emptyIndex = iRead;
+      continue;
+    }
+    if (clocksEqual(readClock, scalarClock)) {
+      replaceReadClock(state, cell, iRead, scalarClock, readMask | mask);
       return;
     }
+    if (readClock.threadId == state->threadId && readClock.scope == scope &&
+        (readMask & static_cast<uint8_t>(~mask)) == 0)
+      reusableIndex = iRead;
+  }
+
+  if (reusableIndex != -1 || emptyIndex != -1) {
+    auto index = reusableIndex != -1 ? reusableIndex : emptyIndex;
+    replaceReadClock(state, cell, index, scalarClock, mask);
+    return;
   }
 
   auto threadNumReads = __scoped_atomic_fetch_add(
@@ -532,28 +593,40 @@ GSAN_DEVICE void recordRead(ThreadState *state, ShadowCell *cell,
   auto seed = getGlobalState(state)->rngSeed;
   uint32_t rand = hash2x32(threadNumReads, state->threadId, seed);
   rand = rand % numReads;
-  if (rand < ShadowCell::kReadClockSize) {
-    cell->readClocks[rand] = scalarClock;
-  }
+  if (rand < ShadowCell::kReadClockSize)
+    replaceReadClock(state, cell, rand, scalarClock, mask);
 }
 
-GSAN_DEVICE void doWrite(ThreadState *state, ShadowCell *cell, Location loc) {
+GSAN_DEVICE void doWrite(ThreadState *state, ShadowCell *cell, uint8_t mask,
+                         Location loc) {
   // Check WAR
   for (int iRead = 0; iRead < ShadowCell::kReadClockSize; ++iRead) {
+    if ((cell->readMasks[iRead] & mask) == 0)
+      continue;
     assertOrderedOrCompatible(state, AtomicScope::NonAtomic,
                               cell->readClocks[iRead], loc,
                               "Write after read race detected");
   }
   // Check WAW
-  assertOrderedOrCompatible(state, AtomicScope::NonAtomic, cell->writeClock,
-                            loc, "Write after write race detected");
+  for (int byte = 0; byte < kShadowMemGranularityBytes; ++byte) {
+    if (maskIncludesByte(mask, byte) && isFirstWriteClock(cell, mask, byte)) {
+      assertOrderedOrCompatible(state, AtomicScope::NonAtomic,
+                                cell->writeClocks[byte], loc,
+                                "Write after write race detected");
+    }
+  }
   // Update write
-  cell->writeClock = makeScalarClock(state, AtomicScope::NonAtomic);
+  auto clock = makeScalarClock(state, AtomicScope::NonAtomic);
+  for (int byte = 0; byte < kShadowMemGranularityBytes; ++byte) {
+    if (maskIncludesByte(mask, byte))
+      cell->writeClocks[byte] = clock;
+  }
 }
 
 GSAN_DEVICE void writeRange(ThreadState *state, uintptr_t write_addr,
                             int nBytes, Location loc) {
-  auto range = roundRange(Range{write_addr, write_addr + nBytes});
+  Range access{write_addr, write_addr + nBytes};
+  auto range = roundRange(access);
 
   auto reserveBase = state->reserveBase;
 
@@ -563,7 +636,7 @@ GSAN_DEVICE void writeRange(ThreadState *state, uintptr_t write_addr,
       continue;
     auto shadowAddr = getShadowAddress(addr);
     auto cell = acquireShadow(shadowAddr);
-    doWrite(state, cell, loc);
+    doWrite(state, cell, getAccessMask(access, addr), loc);
     releaseShadow(cell);
   }
 }
@@ -589,15 +662,22 @@ GSAN_DEVICE void tensorStore(ThreadState *state, const char *stackPtr,
     rwLockReleaseRead(state->lock);
 }
 
-GSAN_DEVICE void doRead(ThreadState *state, ShadowCell *cell, Location loc) {
-  assertOrderedOrCompatible(state, AtomicScope::NonAtomic, cell->writeClock,
-                            loc, "Read after write race detected");
-  recordRead(state, cell, AtomicScope::NonAtomic);
+GSAN_DEVICE void doRead(ThreadState *state, ShadowCell *cell, uint8_t mask,
+                        Location loc) {
+  for (int byte = 0; byte < kShadowMemGranularityBytes; ++byte) {
+    if (maskIncludesByte(mask, byte) && isFirstWriteClock(cell, mask, byte)) {
+      assertOrderedOrCompatible(state, AtomicScope::NonAtomic,
+                                cell->writeClocks[byte], loc,
+                                "Read after write race detected");
+    }
+  }
+  recordRead(state, cell, AtomicScope::NonAtomic, mask);
 }
 
 GSAN_DEVICE void readRange(ThreadState *state, uintptr_t read_addr, int nBytes,
                            Location loc) {
-  auto range = roundRange(Range{read_addr, read_addr + nBytes});
+  Range access{read_addr, read_addr + nBytes};
+  auto range = roundRange(access);
 
   auto reserveBase = state->reserveBase;
   if (range.start >= reserveBase + kReserveSize || reserveBase >= range.end)
@@ -609,7 +689,7 @@ GSAN_DEVICE void readRange(ThreadState *state, uintptr_t read_addr, int nBytes,
       continue;
     auto shadowAddr = getShadowAddress(addr);
     auto cell = acquireShadow(shadowAddr);
-    doRead(state, cell, loc);
+    doRead(state, cell, getAccessMask(access, addr), loc);
     releaseShadow(cell);
   }
 }
@@ -638,15 +718,18 @@ GSAN_DEVICE void tensorLoad(ThreadState *state, const char *stackPtr,
 GSAN_DEVICE void initAtomicEventState(AtomicEventState *event) {
   event->threadState = nullptr;
   event->numCells = 0;
-  for (auto &cell : event->cells)
-    cell = nullptr;
+  for (int i = 0; i < kMaxAtomicShadowCells; ++i) {
+    event->cells[i] = nullptr;
+    event->masks[i] = 0;
+  }
 }
 
 GSAN_DEVICE void acquireAtomicShadowRange(ThreadState *state,
                                           AtomicEventState *event,
                                           uintptr_t address, int nBytes,
                                           Location loc) {
-  auto range = roundRange(Range{address, address + nBytes});
+  Range access{address, address + nBytes};
+  auto range = roundRange(access);
   auto reserveBase = state->reserveBase;
   uint8_t numCells = 0;
   for (uintptr_t addr = range.start; addr < range.end;
@@ -669,7 +752,9 @@ GSAN_DEVICE void acquireAtomicShadowRange(ThreadState *state,
        addr += kShadowMemGranularityBytes) {
     if (!isGsanManaged(addr, reserveBase))
       continue;
-    event->cells[event->numCells++] = acquireShadow(getShadowAddress(addr));
+    auto index = event->numCells++;
+    event->cells[index] = acquireShadow(getShadowAddress(addr));
+    event->masks[index] = getAccessMask(access, addr);
   }
 }
 
@@ -680,6 +765,103 @@ GSAN_DEVICE void releaseAtomicShadowRange(AtomicEventState *event) {
     releaseShadow(event->cells[i]);
   rwLockReleaseWrite(event->threadState->lock);
   initAtomicEventState(event);
+}
+
+GSAN_DEVICE bool isFirstAtomicWriteClock(const AtomicEventState *event,
+                                         uint8_t cellIndex, int byteIndex) {
+  auto clock = event->cells[cellIndex]->writeClocks[byteIndex];
+  for (uint8_t previousCell = 0; previousCell <= cellIndex; ++previousCell) {
+    int byteLimit =
+        previousCell == cellIndex ? byteIndex : kShadowMemGranularityBytes;
+    for (int previousByte = 0; previousByte < byteLimit; ++previousByte) {
+      if (maskIncludesByte(event->masks[previousCell], previousByte) &&
+          clocksEqual(clock,
+                      event->cells[previousCell]->writeClocks[previousByte]))
+        return false;
+    }
+  }
+  return true;
+}
+
+GSAN_DEVICE epoch_t publishMixedAtomicReleaseSnapshots(
+    ThreadState *state, const AtomicEventState *event, bool includeCurrent,
+    Location loc) {
+  auto *globals = getGlobalState(state);
+  assert_msg(loc, globals->clockBufferSize != 0,
+             "GSan clock buffer size must be non-zero");
+  uint32_t nextHead = state->clockBufferHead + 1;
+  assert_msg(loc, nextHead <= kMaxEpoch, "GSan clock buffer token overflowed");
+  auto *slot = getClockBufferBase(state) +
+               (nextHead % globals->clockBufferSize) * globals->numThreads;
+  for (int i = 0; i < globals->numThreads; ++i) {
+    epoch_t epoch = includeCurrent ? state->vectorClock[i] : 0;
+    for (uint8_t cellIndex = 0; cellIndex < event->numCells; ++cellIndex) {
+      auto *cell = event->cells[cellIndex];
+      for (int byte = 0; byte < kShadowMemGranularityBytes; ++byte) {
+        if (!maskIncludesByte(event->masks[cellIndex], byte) ||
+            !isFirstAtomicWriteClock(event, cellIndex, byte))
+          continue;
+        auto write = cell->writeClocks[byte];
+        if (!write.isRelease)
+          continue;
+        auto *snapshot = getSnapshotForWrite(state, write, loc);
+        if (epoch < snapshot[i])
+          epoch = snapshot[i];
+      }
+    }
+    slot[i] = epoch;
+  }
+  state->clockBufferHead = nextHead;
+  // The propagated snapshot must not become this thread's acquired clock.
+  state->clockBufferDirty = 1;
+  return static_cast<epoch_t>(nextHead);
+}
+
+GSAN_DEVICE ScalarClock makeAtomicWriteClock(ThreadState *state,
+                                             const AtomicEventState *event,
+                                             AtomicSem sem, AtomicScope scope,
+                                             Location loc) {
+  bool isRelease = hasRelease(sem);
+  bool canAccumulate = false;
+  int numReleases = 0;
+  ScalarClock previousRelease{};
+  for (uint8_t cellIndex = 0; cellIndex < event->numCells; ++cellIndex) {
+    auto *cell = event->cells[cellIndex];
+    for (int byte = 0; byte < kShadowMemGranularityBytes; ++byte) {
+      if (!maskIncludesByte(event->masks[cellIndex], byte) ||
+          !isFirstAtomicWriteClock(event, cellIndex, byte))
+        continue;
+      auto write = cell->writeClocks[byte];
+      if (!write.isRelease)
+        continue;
+      if (numReleases++ == 0)
+        previousRelease = write;
+      if (isRelease && canAccumulateReleaseRmw(state, scope, write)) {
+        canAccumulate = true;
+      } else if (isRelease) {
+        auto *snapshot = getSnapshotForWrite(state, write, loc);
+        assert_msg(loc, dominatesSnapshot(state, snapshot),
+                   "GSan detected atomic release accumulation with mixed "
+                   "scopes, which is not supported.");
+      }
+    }
+  }
+
+  if (!isRelease && numReleases == 0)
+    return makeScalarClock(state, scope);
+
+  epoch_t token;
+  if (isRelease && !canAccumulate) {
+    token = publishCurrentVectorClock(state, loc);
+  } else if (numReleases == 1) {
+    token = isRelease
+                ? publishCurrentVectorClockWithPriorRelease(
+                      state, previousRelease, loc)
+                : propagateClockBufferSnapshot(state, previousRelease, loc);
+  } else {
+    token = publishMixedAtomicReleaseSnapshots(state, event, isRelease, loc);
+  }
+  return makePublishedClock(state, scope, token);
 }
 
 GSAN_DEVICE void beginAtomicAccess(GlobalState *globals,
@@ -700,15 +882,24 @@ GSAN_DEVICE void beginAtomicAccess(GlobalState *globals,
   auto scope = decodeAtomicScope(scopeRaw);
   for (uint8_t i = 0; i < event->numCells; ++i) {
     auto *cell = event->cells[i];
-    auto write = cell->writeClock;
-    assertOrderedOrCompatible(state, scope, write, loc,
-                              "Read after write race detected");
-    recordRead(state, cell, scope);
+    for (int byte = 0; byte < kShadowMemGranularityBytes; ++byte) {
+      if (maskIncludesByte(event->masks[i], byte) &&
+          isFirstAtomicWriteClock(event, i, byte)) {
+        assertOrderedOrCompatible(state, scope, cell->writeClocks[byte], loc,
+                                  "Read after write race detected");
+      }
+    }
+    recordRead(state, cell, scope, event->masks[i]);
   }
   if (hasAcquire(sem)) {
     for (uint8_t i = 0; i < event->numCells; ++i) {
-      auto write = event->cells[i]->writeClock;
-      maybeMergeAcquire(state, scope, write, loc);
+      auto *cell = event->cells[i];
+      for (int byte = 0; byte < kShadowMemGranularityBytes; ++byte) {
+        if (maskIncludesByte(event->masks[i], byte) &&
+            isFirstAtomicWriteClock(event, i, byte)) {
+          maybeMergeAcquire(state, scope, cell->writeClocks[byte], loc);
+        }
+      }
     }
   }
 }
@@ -727,42 +918,28 @@ GSAN_DEVICE void endAtomicAccess(AtomicEventState *event, bool pred,
     for (uint8_t i = 0; i < event->numCells; ++i) {
       auto *cell = event->cells[i];
       for (int iRead = 0; iRead < ShadowCell::kReadClockSize; ++iRead) {
-        assertOrderedOrCompatible(state, scope, cell->readClocks[iRead], loc,
-                                  "Write after read race detected");
+        if ((cell->readMasks[iRead] & event->masks[i]) != 0) {
+          assertOrderedOrCompatible(state, scope, cell->readClocks[iRead], loc,
+                                    "Write after read race detected");
+        }
       }
-      assertOrderedOrCompatible(state, scope, cell->writeClock, loc,
-                                "Write after write race detected");
-    }
-
-    auto previousWrite = event->cells[0]->writeClock;
-    ScalarClock newWriteClock;
-    if (hasRelease(sem)) {
-      epoch_t token;
-      if (canAccumulateReleaseRmw(state, scope, previousWrite))
-        token = publishCurrentVectorClockWithPriorRelease(state, previousWrite,
-                                                          loc);
-      else if (previousWrite.isRelease) {
-        const auto *previousSnapshot =
-            getSnapshotForWrite(state, previousWrite, loc);
-        assert_msg(loc, dominatesSnapshot(state, previousSnapshot),
-                   "GSan detected atomic release accumulation with mixed "
-                   "scopes, which is not supported.");
-        token = publishCurrentVectorClock(state, loc);
-      } else {
-        token = publishCurrentVectorClock(state, loc);
-      }
-      newWriteClock = makePublishedClock(state, scope, token);
-    } else {
-      if (previousWrite.isRelease) {
-        auto token = propagateClockBufferSnapshot(state, previousWrite, loc);
-        newWriteClock = makePublishedClock(state, scope, token);
-      } else {
-        newWriteClock = makeScalarClock(state, scope);
+      for (int byte = 0; byte < kShadowMemGranularityBytes; ++byte) {
+        if (maskIncludesByte(event->masks[i], byte) &&
+            isFirstAtomicWriteClock(event, i, byte)) {
+          assertOrderedOrCompatible(state, scope, cell->writeClocks[byte], loc,
+                                    "Write after write race detected");
+        }
       }
     }
 
-    for (uint8_t i = 0; i < event->numCells; ++i)
-      event->cells[i]->writeClock = newWriteClock;
+    auto newWriteClock = makeAtomicWriteClock(state, event, sem, scope, loc);
+    for (uint8_t i = 0; i < event->numCells; ++i) {
+      auto *cell = event->cells[i];
+      for (int byte = 0; byte < kShadowMemGranularityBytes; ++byte) {
+        if (maskIncludesByte(event->masks[i], byte))
+          cell->writeClocks[byte] = newWriteClock;
+      }
+    }
 
     if (hasRelease(sem))
       incrementThreadEpoch(state, loc);

--- a/python/triton/experimental/gsan/src/gsan_testing.cc
+++ b/python/triton/experimental/gsan/src/gsan_testing.cc
@@ -25,7 +25,8 @@ struct PyScalarClock {
 
 struct PyShadowCell {
   std::array<PyScalarClock, gsan::ShadowCell::kReadClockSize> readClocks;
-  PyScalarClock writeClock;
+  std::array<uint8_t, gsan::ShadowCell::kReadClockSize> readMasks;
+  std::array<PyScalarClock, gsan::kShadowMemGranularityBytes> writeClocks;
   uint32_t numReads = 0;
 };
 
@@ -35,12 +36,14 @@ bool scalarClockEquals(const PyScalarClock &lhs, const PyScalarClock &rhs) {
 }
 
 bool shadowCellEquals(const PyShadowCell &lhs, const PyShadowCell &rhs) {
-  if (lhs.numReads != rhs.numReads ||
-      !scalarClockEquals(lhs.writeClock, rhs.writeClock)) {
+  if (lhs.numReads != rhs.numReads || lhs.readMasks != rhs.readMasks)
     return false;
-  }
   for (size_t i = 0; i < lhs.readClocks.size(); ++i) {
     if (!scalarClockEquals(lhs.readClocks[i], rhs.readClocks[i]))
+      return false;
+  }
+  for (size_t i = 0; i < lhs.writeClocks.size(); ++i) {
+    if (!scalarClockEquals(lhs.writeClocks[i], rhs.writeClocks[i]))
       return false;
   }
   return true;
@@ -135,8 +138,19 @@ std::string shadowCellStr(const PyShadowCell &cell) {
       oss << ", ";
     oss << scalarClockStr(cell.readClocks[i]);
   }
-  oss << "], write_clock=" << scalarClockStr(cell.writeClock)
-      << ", num_reads=" << static_cast<uint64_t>(cell.numReads) << ")";
+  oss << "], read_masks=[";
+  for (size_t i = 0; i < cell.readMasks.size(); ++i) {
+    if (i != 0)
+      oss << ", ";
+    oss << static_cast<uint32_t>(cell.readMasks[i]);
+  }
+  oss << "], write_clocks=[";
+  for (size_t i = 0; i < cell.writeClocks.size(); ++i) {
+    if (i != 0)
+      oss << ", ";
+    oss << scalarClockStr(cell.writeClocks[i]);
+  }
+  oss << "], num_reads=" << static_cast<uint64_t>(cell.numReads) << ")";
   return oss.str();
 }
 
@@ -178,9 +192,12 @@ PyScalarClock toPyScalarClock(const gsan::ScalarClock &clock) {
 
 PyShadowCell toPyShadowCell(const gsan::ShadowCell &cell) {
   PyShadowCell out;
-  for (size_t i = 0; i < gsan::ShadowCell::kReadClockSize; ++i)
+  for (size_t i = 0; i < gsan::ShadowCell::kReadClockSize; ++i) {
     out.readClocks[i] = toPyScalarClock(cell.readClocks[i]);
-  out.writeClock = toPyScalarClock(cell.writeClock);
+    out.readMasks[i] = cell.readMasks[i];
+  }
+  for (size_t i = 0; i < out.writeClocks.size(); ++i)
+    out.writeClocks[i] = toPyScalarClock(cell.writeClocks[i]);
   out.numReads = cell.numReads;
   return out;
 }
@@ -302,8 +319,12 @@ void init_gsan_testing(py::module_ &m) {
   py::class_<PyShadowCell>(m, "ShadowCell")
       .def_prop_ro("read_clocks",
                    [](const PyShadowCell &cell) { return cell.readClocks; })
+      .def_prop_ro("read_masks",
+                   [](const PyShadowCell &cell) { return cell.readMasks; })
+      .def_prop_ro("write_clocks",
+                   [](const PyShadowCell &cell) { return cell.writeClocks; })
       .def_prop_ro("write_clock",
-                   [](const PyShadowCell &cell) { return cell.writeClock; })
+                   [](const PyShadowCell &cell) { return cell.writeClocks[0]; })
       .def_prop_ro("num_reads",
                    [](const PyShadowCell &cell) {
                      return static_cast<uint64_t>(cell.numReads);

--- a/test/Conversion/tritongpu_to_llvm_gsan.mlir
+++ b/test/Conversion/tritongpu_to_llvm_gsan.mlir
@@ -59,9 +59,9 @@ module attributes {"ttg.instrumentation_mode" = "gsan", "ttg.num-ctas" = 1 : i32
     %c0_i32 = arith.constant 0 : i32
     %buf = ttg.local_alloc {allocation.offset = 0 : i32} : () -> !ttg.memdesc<32x64xf16, #shared_f16, #smem, mutable>
     %barrier = ttg.local_alloc {allocation.offset = 4096 : i32} : () -> !ttg.memdesc<1xi64, #bar, #smem, mutable>
-    // CHECK: llvm.alloca %{{.*}} x !llvm.struct<(array<32 x i64>, array<32 x i8>)>
-    // CHECK: %[[COUNT:.*]] = llvm.mlir.constant(32 : i32) : i32
-    // CHECK: %[[BYTES:.*]] = llvm.mlir.constant(4 : i32) : i32
+    // CHECK: llvm.alloca %{{.*}} x !llvm.struct<(array<64 x i64>, array<64 x i8>)>
+    // CHECK: %[[COUNT:.*]] = llvm.mlir.constant(64 : i32) : i32
+    // CHECK: %[[BYTES:.*]] = llvm.mlir.constant(2 : i32) : i32
     // CHECK: llvm.call @__triton_gsan_load_tensor(%{{.*}}, %{{.*}}, %[[COUNT]], %[[BYTES]], %{{.*}}, %{{.*}})
     ttng.async_tma_copy_global_to_local %desc[%c0_i32, %c0_i32] %buf, %barrier, %true : !tt.tensordesc<32x64xf16, #shared_f16>, !ttg.memdesc<1xi64, #bar, #smem, mutable> -> !ttg.memdesc<32x64xf16, #shared_f16, #smem, mutable>
     tt.return
@@ -81,9 +81,9 @@ module attributes {"ttg.instrumentation_mode" = "gsan", "ttg.num-ctas" = 1 : i32
     %c0_i32 = arith.constant 0 : i32
     %buf = ttg.local_alloc {allocation.offset = 0 : i32} : () -> !ttg.memdesc<128x64xf16, #shared_f16, #smem, mutable>
     %barrier = ttg.local_alloc {allocation.offset = 16384 : i32} : () -> !ttg.memdesc<1xi64, #bar, #smem, mutable>
-    // CHECK: llvm.alloca %{{.*}} x !llvm.struct<(array<32 x i64>, array<32 x i8>)>
-    // CHECK: %[[COUNT_4W:.*]] = llvm.mlir.constant(32 : i32) : i32
-    // CHECK: %[[BYTES_4W:.*]] = llvm.mlir.constant(4 : i32) : i32
+    // CHECK: llvm.alloca %{{.*}} x !llvm.struct<(array<64 x i64>, array<64 x i8>)>
+    // CHECK: %[[COUNT_4W:.*]] = llvm.mlir.constant(64 : i32) : i32
+    // CHECK: %[[BYTES_4W:.*]] = llvm.mlir.constant(2 : i32) : i32
     // CHECK: llvm.call @__triton_gsan_load_tensor(%{{.*}}, %{{.*}}, %[[COUNT_4W]], %[[BYTES_4W]], %{{.*}}, %{{.*}})
     ttng.async_tma_copy_global_to_local %desc[%c0_i32, %c0_i32] %buf, %barrier, %true : !tt.tensordesc<128x64xf16, #shared_f16>, !ttg.memdesc<1xi64, #bar, #smem, mutable> -> !ttg.memdesc<128x64xf16, #shared_f16, #smem, mutable>
     tt.return
@@ -134,6 +134,29 @@ module attributes {"ttg.instrumentation_mode" = "gsan", "ttg.num-ctas" = 2 : i32
     %c0 = arith.constant 0 : i32
     %rmw = tt.atomic_rmw add, acq_rel, gpu, %ptr, %val, %mask : (!tt.ptr<i32>, i32, i1) -> i32
     %cas = tt.atomic_cas acq_rel, gpu, %ptr, %c0, %val : (!tt.ptr<i32>, i32, i32) -> i32
+    tt.return
+  }
+}
+
+// -----
+
+#masked_f16 = #ttg.blocked<{sizePerThread = [4], threadsPerWarp = [32], warpsPerCTA = [1], order = [0]}>
+
+module attributes {"ttg.instrumentation_mode" = "gsan", "ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 1 : i32, "ttg.threads-per-warp" = 32 : i32} {
+  // CHECK-LABEL: llvm.func @gsan_masked_f16_preserves_lane_masks
+  // CHECK: llvm.alloca %{{.*}} x !llvm.struct<(array<4 x i64>, array<4 x i8>)>
+  // CHECK: %[[MASKED_COUNT:.*]] = llvm.mlir.constant(4 : i32) : i32
+  // CHECK: %[[MASKED_BYTES:.*]] = llvm.mlir.constant(2 : i32) : i32
+  // CHECK: llvm.call @__triton_gsan_store_tensor(%{{.*}}, %{{.*}}, %[[MASKED_COUNT]], %[[MASKED_BYTES]], %{{.*}}, %{{.*}})
+  tt.func @gsan_masked_f16_preserves_lane_masks(%base: !tt.ptr<f16> {tt.divisibility = 8 : i32}, %size: i32) {
+    %offsets = tt.make_range {end = 128 : i32, start = 0 : i32} : tensor<128xi32, #masked_f16>
+    %bound = tt.splat %size : i32 -> tensor<128xi32, #masked_f16>
+    %mask = arith.cmpi slt, %offsets, %bound : tensor<128xi32, #masked_f16>
+    %base_ptr = tt.splat %base : !tt.ptr<f16> -> tensor<128x!tt.ptr<f16>, #masked_f16>
+    %ptrs = tt.addptr %base_ptr, %offsets : tensor<128x!tt.ptr<f16>, #masked_f16>, tensor<128xi32, #masked_f16>
+    %values = tt.splat %size : i32 -> tensor<128xi32, #masked_f16>
+    %values_f16 = arith.sitofp %values : tensor<128xi32, #masked_f16> to tensor<128xf16, #masked_f16>
+    tt.store %ptrs, %values_f16, %mask : tensor<128x!tt.ptr<f16>, #masked_f16>
     tt.return
   }
 }


### PR DESCRIPTION
## Summary

- Track read and write races per byte within four-byte GSan shadow cells, eliminating false FP8/FP16 races without hiding overlapping accesses.
- Preserve masked lanes through LLVM/TMA lowering, propagate mixed-width atomic release histories, and retain the existing 64 GiB allocator capacity.

## Validation

- H100: `python -m triton._test_runner suite gsan --num-gpus 1 --num-procs 8` — **159 passed, 13 skipped**.
- LLVM: `lit -v test/Conversion/tritongpu_to_llvm_gsan.mlir`.
- H100: original odd-width translated matmul (`K=7`) passes with the patched Triton runtime.

## LoC

| Files | Added | Removed | Net |
| --- | ---: | ---: | ---: |
| Tests | +251 | -10 | +241 |
| Non-tests | +280 | -82 | +198 |
| All | +531 | -92 | +439 |

## Reviewer's guide

- `python/triton/experimental/gsan/src/`: byte-accurate histories, atomic synchronization, testing bindings, and allocator layout.
- `lib/Conversion/TritonInstrumentToLLVM/` and `test/Conversion/`: exact subword masks and descriptor-boundary coverage.
- `python/test/gsan/`: FP8/FP16 races, masked accesses, mixed-width atomics, read epochs, and allocator regressions.