### PR TITLE
[CI] Bump actions/cache from v4 to v6

### DIFF
--- a/.github/workflows/build-macos.yml
+++ b/.github/workflows/build-macos.yml
@@ -47,7 +47,7 @@ jobs:
           echo "datetime=$(date -u -Iseconds)" >> $GITHUB_OUTPUT
         shell: bash
       - name: Cache build dependencies
-        uses: actions/cache@v4
+        uses: actions/cache@v6
         with:
           # Note that we cannot use environment variables here given there is
           # no shell to interpret them in the paths.
@@ -64,7 +64,7 @@ jobs:
         name: Restore cache of ccache and Triton compilation artifacts
         id: restore-build-cache
         if: github.ref != 'refs/heads/main'
-        uses: actions/cache/restore@v4
+        uses: actions/cache/restore@v6
         with:
           path: |
             ~/.ccache
@@ -128,7 +128,7 @@ jobs:
         # evicts cache entries LRU, but maybe this saves a bit of time in CI.)
         name: Save ccache and Triton compilation artifacts to cache
         if: github.ref == 'refs/heads/main'
-        uses: actions/cache/save@v4
+        uses: actions/cache/save@v6
         with:
           path: |
             ~/.ccache

--- a/.github/workflows/integration-tests-amd.yml
+++ b/.github/workflows/integration-tests-amd.yml
@@ -80,7 +80,7 @@ jobs:
       - name: Restore build dependencies cache
         id: restore-build-deps-cache
         if: ${{ !contains(matrix.runner, 'gfx90a') }}
-        uses: actions/cache/restore@v4
+        uses: actions/cache/restore@v6
         with:
           # Note that we cannot use environment variables here given there is
           # no shell to interpret them in the paths.
@@ -228,7 +228,7 @@ jobs:
           du -h -d 1 ~/.ccache
       - name: Save build dependencies cache
         if: ${{ github.ref == 'refs/heads/main' && !contains(matrix.runner, 'gfx90a') }}
-        uses: actions/cache/save@v4
+        uses: actions/cache/save@v6
         with:
           path: |
             ~/.triton/llvm
@@ -289,7 +289,7 @@ jobs:
         shell: bash
       - name: Restore build dependencies cache
         id: restore-build-deps-cache
-        uses: actions/cache/restore@v4
+        uses: actions/cache/restore@v6
         with:
           path: |
             ~/.triton/llvm
@@ -353,7 +353,7 @@ jobs:
           du -h -d 1 ~/.ccache
       - name: Save build dependencies cache
         if: github.ref == 'refs/heads/main'
-        uses: actions/cache/save@v4
+        uses: actions/cache/save@v6
         with:
           path: |
             ~/.triton/llvm

--- a/.github/workflows/integration-tests-nvidia.yml
+++ b/.github/workflows/integration-tests-nvidia.yml
@@ -54,7 +54,7 @@ jobs:
         shell: bash
       - name: Restore build dependencies cache
         id: restore-build-deps-cache
-        uses: actions/cache/restore@v4
+        uses: actions/cache/restore@v6
         with:
           # Note that we cannot use environment variables here given there is
           # no shell to interpret them in the paths.
@@ -128,7 +128,7 @@ jobs:
           du -h -d 1 ~/.ccache
       - name: Save build dependencies cache
         if: github.ref == 'refs/heads/main'
-        uses: actions/cache/save@v4
+        uses: actions/cache/save@v6
         with:
           path: |
             ~/.triton/llvm

--- a/.github/workflows/llvm-build.yml
+++ b/.github/workflows/llvm-build.yml
@@ -115,7 +115,7 @@ jobs:
         rm -rf ${{ env.SCCACHE_DIR }}/*
 
     - name: Enable Cache
-      uses: actions/cache@v4
+      uses: actions/cache@v6
       with:
         path: ${{ env.SCCACHE_DIR }}
         key: ${{ matrix.config.target-os }}-${{ matrix.config.arch }}-${{ env.short_llvm_commit_hash }}

--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -20,7 +20,7 @@ jobs:
           echo "pre_commit_hash=$(sha256sum .pre-commit-config.yaml | cut -d ' ' -f 1)" >> $GITHUB_OUTPUT
         shell: bash
       - name: Cache pre-commit's cache dir
-        uses: actions/cache@v4
+        uses: actions/cache@v6
         with:
           # Note that we cannot use environment variables here given there is
           # no shell to interpret them in the paths.


### PR DESCRIPTION
`actions/cache@v4` targets Node.js 20, which is deprecated on GitHub Actions runners. Runners currently force these steps onto Node.js 24 and emit a deprecation warning on every job:

    Node.js 20 is deprecated. The following actions target Node.js 20 but
    are being forced to run on Node.js 24: actions/cache/restore@v4,
    actions/cache/save@v4.

This was the last Node 20 action left in .github/.