### PR TITLE
[TEST] Handle missing active Triton driver

### DIFF
--- a/python/test/unit/cuda/test_tensor_descriptor_cuda.py
+++ b/python/test/unit/cuda/test_tensor_descriptor_cuda.py
@@ -1,11 +1,8 @@
-import pytest
 import torch
 
 import triton
-from triton._internal_testing import supports_tma, tma_skip_msg
+from triton._internal_testing import requires_tma
 from triton.tools.tensor_descriptor import TensorDescriptor
-
-requires_tma = pytest.mark.skipif(not supports_tma(), reason=tma_skip_msg())
 
 
 @requires_tma

--- a/python/test/unit/cuda/test_tensor_descriptor_cuda.py
+++ b/python/test/unit/cuda/test_tensor_descriptor_cuda.py
@@ -1,8 +1,11 @@
+import pytest
 import torch
 
 import triton
-from triton._internal_testing import requires_tma
+from triton._internal_testing import supports_tma, tma_skip_msg
 from triton.tools.tensor_descriptor import TensorDescriptor
+
+requires_tma = pytest.mark.skipif(not supports_tma(), reason=tma_skip_msg())
 
 
 @requires_tma

--- a/python/triton/_internal_testing.py
+++ b/python/triton/_internal_testing.py
@@ -260,6 +260,9 @@ def tma_skip_msg(byval_only=False):
         return "Requires advanced TMA support (NVIDIA Hopper or higher, CUDA 12.3 or higher)"
 
 
+requires_tma = pytest.mark.skipif(not supports_tma(), reason=tma_skip_msg())
+
+
 def default_alloc_fn(size: int, align: int, _):
     return torch.empty(size, dtype=torch.int8, device="cuda")
 

--- a/python/triton/_internal_testing.py
+++ b/python/triton/_internal_testing.py
@@ -15,6 +15,7 @@ from contextvars import ContextVar
 import pytest
 
 from numpy.random import RandomState
+from triton.backends import backends
 from triton.runtime.jit import TensorWrapper, reinterpret, type_canonicalisation_dict
 
 int_dtypes = ['int8', 'int16', 'int32', 'int64']
@@ -52,6 +53,8 @@ def random_float(*, warmup_value=0.5, **kwargs):
 
 def get_current_target():
     if is_interpreter():
+        return None
+    if not any(backend.driver.is_active() for backend in backends.values()):
         return None
     return triton.runtime.driver.active.get_current_target()
 
@@ -255,9 +258,6 @@ def tma_skip_msg(byval_only=False):
         return "Requires __grid_constant__ TMA support (NVIDIA Hopper or higher, CUDA 12.0 or higher)"
     else:
         return "Requires advanced TMA support (NVIDIA Hopper or higher, CUDA 12.3 or higher)"
-
-
-requires_tma = pytest.mark.skipif(not supports_tma(), reason=tma_skip_msg())
 
 
 def default_alloc_fn(size: int, align: int, _):


### PR DESCRIPTION
Return `None` from internal test target detection when no backend is active, rather than forcing driver creation.

This allows module-level capability checks such as `requires_tma` to evaluate safely and fixes `triton_kernels.testing` imports on CPU-only CI workers.

Validated with an isolated zero-active-driver import reproduction and file-scoped pre-commit checks.
