### PR TITLE
[CI][AMD] Clear compile traces before warmup

### DIFF
--- a/.github/workflows/integration-tests-amd.yml
+++ b/.github/workflows/integration-tests-amd.yml
@@ -125,6 +125,7 @@ jobs:
         shell: bash
         run: |
           trace_dir="$RUNNER_TEMP/triton-ci-compile-trace"
+          rm -rf "$trace_dir"
           echo "TRITON_CI_COMPILE_TRACE_DIR=$trace_dir" >> "$GITHUB_ENV"
           export TRITON_CI_COMPILE_TRACE_DIR="$trace_dir"
           warmup_procs=$(nproc)


### PR DESCRIPTION
## Summary

- clear the AMD compile-trace directory before cache warmup

## Context

The persistent gfx90a runner executes tests in a root container with the host runner's temporary directory mounted into it. Compile traces can therefore survive across jobs when the host runner cannot remove the root-owned files. If a job completes warmup but fails before a runtime suite, those stale warmup hashes make later `report --require-complete` invocations fail with unused specializations.

Clearing the fixed directory before warmup establishes a clean trace boundary for every job and recovers from abandoned or interrupted jobs without depending on an end-of-job cleanup.

## Validation

- `pre-commit run --files .github/workflows/integration-tests-amd.yml`
- YAML parsed with `yaml.safe_load`
- `git diff --check`