### PR TITLE
Document cubin mtime sensitivity, test the reproducible path

### DIFF
--- a/README.md
+++ b/README.md
@@ -242,6 +242,11 @@ See [`python/triton/knobs.py`](python/triton/knobs.py) for the full list of conf
 - `TRITON_F32_DEFAULT` sets the default input precision of `tl.dot` when using 32-bit floats, which can be either `ieee`, `tf32`, or `tf32x3`.
 - `TRITON_FRONT_END_DEBUGGING=1` disables exception wrapping when an error occurs in the compiler frontend, allowing the full stack trace to be seen.
 - `TRITON_DISABLE_LINE_INFO=1` removes all line information from the module.
+  Line information is kept by default, and `ptxas` then records the path and the
+  modification time of the referenced source file in the cubin's `.debug_line`
+  section. Raw cubin bytes are therefore not reproducible across changes to the
+  source file's mtime, even when the PTX and the SASS are unchanged. Set this to
+  `1` if you need bit-reproducible cubins.
 - `PTXAS_OPTIONS` passes additional command-line options to the PTX assembler `ptxas` (only on NVIDIA).
 - `LLVM_EXTRACT_DI_LOCAL_VARIABLES` emit full debug info, allowing for eval of values in gpu debuggers (ie cuda-gdb, rocm-gdb etc)
 - `TRITON_DEFAULT_BACKEND=<backend>` optionally sets the default backend used by Triton when

--- a/python/test/unit/language/test_line_info.py
+++ b/python/test/unit/language/test_line_info.py
@@ -1,4 +1,5 @@
 import inspect
+import os
 import subprocess
 import tempfile
 
@@ -7,7 +8,7 @@ import torch
 
 import triton
 import triton.language as tl
-from triton._internal_testing import is_hopper_or_newer, is_interpreter
+from triton._internal_testing import is_cuda, is_hopper_or_newer, is_interpreter
 from triton._filecheck import run_filecheck
 
 
@@ -244,6 +245,38 @@ def test_line_info_env(monkeypatch, status: str):
     kernel_info = kernel_single.warmup(torch.float32, torch.float32, BLOCK=shape[0], grid=(1, ))
     file_lines = extract_file_lines(command, anchor, separator, kernel_info.asm[obj_kind])
     assert len(file_lines) == 0 if status == "1" else len(file_lines) > 0
+
+
+def test_cubin_reproducible_without_line_info(fresh_knobs, tmp_path, fresh_triton_cache):
+    if not is_cuda():
+        pytest.skip("cubin debug info is NVIDIA-specific")
+
+    # ptxas records the mtime of the file named by `.file` in the cubin's
+    # .debug_line section, so raw cubins are only reproducible across mtime
+    # changes once that section is suppressed.
+    fresh_knobs.compilation.disable_line_info = True
+    fresh_knobs.compilation.always_compile = True
+
+    temp_file = tmp_path / "test.ttir"
+    temp_file.write_text(f"""
+    #loc = loc("{temp_file}":7:0)
+    module {{
+    tt.func public @test(%arg0: !tt.ptr<f32> {{tt.divisibility = 16 : i32}} loc("{temp_file}":7:0), %arg1: !tt.ptr<f32> {{tt.divisibility = 16 : i32}} loc("{temp_file}":7:0)) attributes {{noinline = false}} {{
+        %0 = tt.load %arg0 : !tt.ptr<f32> loc(#loc1)
+        tt.store %arg1, %0 : !tt.ptr<f32> loc(#loc2)
+        tt.return loc(#loc3)
+    }} loc(#loc)
+    }} loc(#loc)
+    #loc1 = loc("{temp_file}":8:16)
+    #loc2 = loc("{temp_file}":9:20)
+    #loc3 = loc("{temp_file}":9:4)
+    """)
+
+    cubins = []
+    for mtime in (1785147297, 1785210547):
+        os.utime(temp_file, (mtime, mtime))
+        cubins.append(triton.compile(str(temp_file)).asm["cubin"])
+    assert cubins[0] == cubins[1]
 
 
 @pytest.mark.parametrize("status", ["ttir", ""])


### PR DESCRIPTION
Fixes #11091

We pass `-lineinfo` to `ptxas` by default, so `ptxas` stats the file named by the PTX `.file`
directive and writes its mtime into the cubin's `.debug_line` file table. That mtime is not part
of the PTX or of the cache key, so two builds of byte-identical PTX produce different raw cubin
bytes after nothing but a source-file `touch`. Nothing in the tree said so.

Two changes, no behavior change:

- README: the `TRITON_DISABLE_LINE_INFO=1` bullet now says that raw cubins are not
  bit-reproducible across source mtime changes with line info on, and that this knob is what you
  set if you need them to be.
- New `test_cubin_reproducible_without_line_info` in `python/test/unit/language/test_line_info.py`:
  compiles the same TTIR twice across an mtime change with `disable_line_info` set and asserts
  the cubin bytes match, so the `-lineinfo -suppress-debug-info` reproducibility path stays
  covered.

Verified on an A40 (sm_86, driver 560.35.03) with CUDA 12.6 ptxas. The reporter's raw-ptxas
reproducer gives exactly three adjacent differing cubin bytes and identical SASS, and an
end-to-end Triton compile of one kernel across an mtime change gives identical PTX and cubins
differing in three bytes. With `TRITON_DISABLE_LINE_INFO=1` both are byte-identical. Flipping the
new test's `disable_line_info` to `False` makes it fail on the timestamp bytes, so the assertion
is not vacuous.

Not verified: I could not build this tree on the machine I had (g++ 9.4, cmake 3.16), so the new
test was exercised against the released 3.7.1 wheel using this repo's `conftest.py` fixtures and
the test body verbatim, not by an in-tree pytest run. Only CUDA 12.6 and sm_86 were covered. The
reporter separately confirmed the same pattern on CUDA 12.9 and 13.3.

Thanks to the reporter of #11091 for the minimal causal reproducer and the byte-level analysis.