### PR TITLE
[FRONTEND] Fix decorator order for tensor math member functions

### DIFF
--- a/python/test/unit/language/test_core.py
+++ b/python/test/unit/language/test_core.py
@@ -1052,24 +1052,50 @@ def test_math_op(dtype_x, expr, x, device):
     _test_unary(dtype_x, f'tl.{expr}({x})', np_expr, device=device)
 
 
+# Interpreter only patches tensor members marked as builtins.
+# Use float32 because `sqrt_rn` only accepts fp32 tensors.
 @pytest.mark.interpreter
+@pytest.mark.parametrize(
+    "expr", ['abs', 'exp', 'exp2', 'log', 'log2', 'cos', 'sin', 'sqrt', 'sqrt_rn', 'rsqrt', 'floor', 'ceil'])
+def test_math_member_fn(expr, device):
+    np_expr = {'rsqrt': "1.0 / np.sqrt(x)", 'sqrt_rn': "np.sqrt(x)"}.get(expr, f"np.{expr}(x)")
+    _test_unary('float32', f'x.{expr}()', np_expr, device=device)
+
+
+@pytest.mark.interpreter
+@pytest.mark.parametrize("expr", ['tl.exp(x)', 'x.exp()'])
+def test_math_member_fn_rejects_fp16(expr, device):
+
+    @triton.jit
+    def kernel(X):
+        x = tl.load(X + tl.arange(0, 4))
+        y = GENERATE_TEST_HERE  # noqa: F841
+
+    kernel = patch_kernel(kernel, {'GENERATE_TEST_HERE': expr})
+    x = to_triton(numpy_random(4, dtype_str='float16'), device=device, dst_type='float16')
+    with pytest.raises(triton.TritonError, match="Expected dtype"):
+        kernel[(1, )](x)
+
+
+@pytest.mark.interpreter
+@pytest.mark.parametrize("member_fn", [False, True])
 @pytest.mark.parametrize("dtype", [dtype for dtype in ["float32", "float64"]])
-def test_math_erf_op(dtype, device):
+def test_math_erf_op(dtype, member_fn, device):
     check_type_supported(dtype, device)
     SIZE = 128
 
     @triton.jit
-    def kernel(Z, X, SIZE: tl.constexpr):
+    def kernel(Z, X, SIZE: tl.constexpr, MEMBER_FN: tl.constexpr):
         off = tl.arange(0, SIZE)
         x = tl.load(X + off)
-        z = tl.math.erf(x)
+        z = x.erf() if MEMBER_FN else tl.math.erf(x)
         tl.store(Z + off, z)
 
     torch_dtype = torch.float32 if dtype == "float32" else torch.float64
     x = torch.randn(SIZE, dtype=torch_dtype, device=device)
     z_ref = torch.erf(x)
     z_tri = torch.zeros_like(x)
-    kernel[(1, )](z_tri, x, SIZE=SIZE, num_warps=4)
+    kernel[(1, )](z_tri, x, SIZE=SIZE, MEMBER_FN=member_fn, num_warps=4)
     torch.testing.assert_close(z_tri, z_ref)
 
 

--- a/python/triton/language/core.py
+++ b/python/triton/language/core.py
@@ -1205,7 +1205,13 @@ class tensor(base_value):
     def exp(self) -> tensor:
         ...
 
+    def exp2(self) -> tensor:
+        ...
+
     def log(self) -> tensor:
+        ...
+
+    def log2(self) -> tensor:
         ...
 
     def cos(self) -> tensor:
@@ -1217,10 +1223,22 @@ class tensor(base_value):
     def sqrt(self) -> tensor:
         ...
 
+    def sqrt_rn(self) -> tensor:
+        ...
+
     def rsqrt(self) -> tensor:
         ...
 
     def abs(self) -> tensor:
+        ...
+
+    def erf(self) -> tensor:
+        ...
+
+    def floor(self) -> tensor:
+        ...
+
+    def ceil(self) -> tensor:
         ...
 
     def reduce(self, axis, combine_fn, keep_dims=False) -> tensor:

--- a/python/triton/language/math.py
+++ b/python/triton/language/math.py
@@ -91,82 +91,82 @@ def umulhi(x, y, _semantic=None):
     return core.tensor(_semantic.builder.create_umulhi(x.handle, y.handle), x.type)
 
 
+@core._tensor_member_fn
 @core.builtin
 @_check_dtype(dtypes=["fp32", "fp64"])
 @_add_math_1arg_docstr("exponential")
-@core._tensor_member_fn
 def exp(x, _semantic=None):
     x = _semantic.to_tensor(x)
     return core.tensor(_semantic.builder.create_exp(x.handle), x.type)
 
 
+@core._tensor_member_fn
 @core.builtin
 @_check_dtype(dtypes=["fp32", "fp64"])
 @_add_math_1arg_docstr("exponential (base 2)")
-@core._tensor_member_fn
 def exp2(x, _semantic=None):
     x = _semantic.to_tensor(x)
     return core.tensor(_semantic.builder.create_exp2(x.handle), x.type)
 
 
+@core._tensor_member_fn
 @core.builtin
 @_check_dtype(dtypes=["fp32", "fp64"])
 @_add_math_1arg_docstr("natural logarithm")
-@core._tensor_member_fn
 def log(x, _semantic=None):
     x = _semantic.to_tensor(x)
     return core.tensor(_semantic.builder.create_log(x.handle), x.type)
 
 
+@core._tensor_member_fn
 @core.builtin
 @_check_dtype(dtypes=["fp32", "fp64"])
 @_add_math_1arg_docstr("logarithm (base 2)")
-@core._tensor_member_fn
 def log2(x, _semantic=None):
     x = _semantic.to_tensor(x)
     return core.tensor(_semantic.builder.create_log2(x.handle), x.type)
 
 
+@core._tensor_member_fn
 @core.builtin
 @_check_dtype(dtypes=["fp32", "fp64"])
 @_add_math_1arg_docstr("cosine")
-@core._tensor_member_fn
 def cos(x, _semantic=None):
     x = _semantic.to_tensor(x)
     return core.tensor(_semantic.builder.create_cos(x.handle), x.type)
 
 
+@core._tensor_member_fn
 @core.builtin
 @_check_dtype(dtypes=["fp32", "fp64"])
 @_add_math_1arg_docstr("sine")
-@core._tensor_member_fn
 def sin(x, _semantic=None):
     x = _semantic.to_tensor(x)
     return core.tensor(_semantic.builder.create_sin(x.handle), x.type)
 
 
+@core._tensor_member_fn
 @core.builtin
 @_check_dtype(dtypes=["fp32", "fp64"])
 @_add_math_1arg_docstr("fast square root")
-@core._tensor_member_fn
 def sqrt(x, _semantic=None):
     x = _semantic.to_tensor(x)
     return core.tensor(_semantic.builder.create_sqrt(x.handle), x.type)
 
 
+@core._tensor_member_fn
 @core.builtin
 @_check_dtype(dtypes=["fp32"])
 @_add_math_1arg_docstr("precise square root (rounding to nearest wrt the IEEE standard)")
-@core._tensor_member_fn
 def sqrt_rn(x, _semantic=None):
     x = _semantic.to_tensor(x)
     return core.tensor(_semantic.builder.create_precise_sqrt(x.handle), x.type)
 
 
+@core._tensor_member_fn
 @core.builtin
 @_check_dtype(dtypes=["fp32", "fp64"])
 @_add_math_1arg_docstr("inverse square root")
-@core._tensor_member_fn
 def rsqrt(x, _semantic=None):
     x = _semantic.to_tensor(x)
     return core.tensor(_semantic.builder.create_rsqrt(x.handle), x.type)
@@ -210,28 +210,28 @@ def div_rn(x, y, _semantic=None):
     return core.tensor(_semantic.builder.create_precise_divf(x.handle, y.handle), x.type)
 
 
+@core._tensor_member_fn
 @core.builtin
 @_check_dtype(dtypes=["fp32", "fp64"])
 @_add_math_1arg_docstr("error function")
-@core._tensor_member_fn
 def erf(x, _semantic=None):
     x = _semantic.to_tensor(x)
     return core.tensor(_semantic.builder.create_erf(x.handle), x.type)
 
 
+@core._tensor_member_fn
 @core.builtin
 @_check_dtype(dtypes=["fp32", "fp64"])
 @_add_math_1arg_docstr("floor")
-@core._tensor_member_fn
 def floor(x, _semantic=None):
     x = _semantic.to_tensor(x)
     return core.tensor(_semantic.builder.create_floor(x.handle), x.type)
 
 
+@core._tensor_member_fn
 @core.builtin
 @_check_dtype(dtypes=["fp32", "fp64"])
 @_add_math_1arg_docstr("ceil")
-@core._tensor_member_fn
 def ceil(x, _semantic=None):
     x = _semantic.to_tensor(x)
     return core.tensor(_semantic.builder.create_ceil(x.handle), x.type)


### PR DESCRIPTION
On twelve math functions, `@core._tensor_member_fn` was applied before `@core.builtin` and `@_check_dtype`. Their registered tensor member wrappers therefore lacked the builtin marker and bypassed the decorators applied afterward.

This made the member and free-function forms behave differently. Under `TRITON_INTERPRET=1`, a valid `x.exp()` call was not patched with `_semantic` and failed with an `AttributeError`, while `tl.exp(x)` worked. In JIT mode, the member form bypassed dtype validation, so `x.exp()` accepted fp16 input that `tl.exp(x)` rejected.

Move `@core._tensor_member_fn` outermost, as its docstring requires, matching the decorator order used by `abs` since #5795. The member forms are now recognized as builtins by the interpreter and enforce the same dtype restrictions as their free-function equivalents. Unsupported narrow inputs can be cast explicitly, for example with `x.to(tl.float32).exp()`.

Adds member-form interpreter coverage, an fp16 dtype-validation test, and the six missing tensor method stubs.