### PR TITLE
[TRITONGPU] Keep FMA dot K values contiguous in registers

### DIFF
--- a/lib/Conversion/TritonGPUToLLVM/DotOpToLLVM/FMADotUtility.cpp
+++ b/lib/Conversion/TritonGPUToLLVM/DotOpToLLVM/FMADotUtility.cpp
@@ -96,8 +96,9 @@ LogicalResult parametricConvertFMADot(DotOp op, DotOp::Adaptor adaptor,
 
   BlockedEncodingAttr dLayout =
       cast<BlockedEncodingAttr>(dTensorTy.getEncoding());
-  // TODO process A and B operand separately
-  auto inRepOrder = expandMatrixOrderWithBatch(dLayout.getOrder());
+  auto aInRepOrder = expandMatrixOrderWithBatch(getOrder(aTensorTy));
+  auto bInRepOrder = expandMatrixOrderWithBatch(getOrder(bTensorTy));
+  auto dInRepOrder = expandMatrixOrderWithBatch(dLayout.getOrder());
   auto repOrder = expandMatrixOrderWithBatch(dLayout.getRepOrder());
   auto cc = unpackTensorElements(loc, adaptor.getC(), rewriter, dTensorTy);
 
@@ -126,11 +127,11 @@ LogicalResult parametricConvertFMADot(DotOp op, DotOp::Adaptor adaptor,
   auto has = getValueTableFromStructFMA(
       llA, aTensorTy, {sizePerThread[0], sizePerThread[1], K},
       {repetitions[0], repetitions[1], 1},
-      /*kDim*/ 2, /*nonKDim*/ 1, rewriter, loc, inRepOrder, repOrder);
+      /*kDim*/ 2, /*nonKDim*/ 1, rewriter, loc, aInRepOrder, repOrder);
   auto hbs = getValueTableFromStructFMA(
       llB, bTensorTy, {sizePerThread[0], K, sizePerThread[2]},
       {repetitions[0], 1, repetitions[2]},
-      /*kDim*/ 1, /*nonKDim*/ 2, rewriter, loc, inRepOrder, repOrder);
+      /*kDim*/ 1, /*nonKDim*/ 2, rewriter, loc, bInRepOrder, repOrder);
 
   SmallVector<Value> acc = cc;
 
@@ -142,7 +143,7 @@ LogicalResult parametricConvertFMADot(DotOp op, DotOp::Adaptor adaptor,
             for (unsigned n = 0; n < sizePerThread[2]; ++n) {
               SmallVector<unsigned> multiDimAccumIdx = {b, m, n};
               unsigned linearInRepIdx =
-                  LLVM::linearize(multiDimAccumIdx, sizePerThread, inRepOrder);
+                  LLVM::linearize(multiDimAccumIdx, sizePerThread, dInRepOrder);
               SmallVector<unsigned> multiDimRepIdx = {bRep, mRep, nRep};
               unsigned linearRepIdx =
                   LLVM::linearize(multiDimRepIdx, repetitions, repOrder);

--- a/lib/Dialect/TritonGPU/IR/LinearLayoutConversions.cpp
+++ b/lib/Dialect/TritonGPU/IR/LinearLayoutConversions.cpp
@@ -880,10 +880,11 @@ LinearLayout fmaDotToLinearLayout(DotOperandEncodingAttr operandLayout,
   auto blocked = cast<BlockedEncodingAttr>(operandLayout.getParent());
   MLIRContext *ctx = operandLayout.getContext();
 
-  // TODO: introduce registerOrder or use getDefaultOrder(operandLayout)
-  // Currently this order is used in legacy converter, because we do not
-  // have access to full dot operand layout, only parent part.
-  auto regOrder = blocked.getOrder();
+  // Keep K contiguous in registers for both operands. The thread and warp
+  // orders still come from the result layout because they describe which
+  // thread owns each non-K element.
+  auto regOrder = getOrderForDotOperand(operandLayout.getOpIdx(), rank,
+                                        /*kContig=*/true);
   auto threadOrder = blocked.getOrder();
   auto warpOrder = blocked.getOrder();
   auto repOrder = blocked.getRepOrder();

--- a/test/Conversion/tritongpu_to_llvm.mlir
+++ b/test/Conversion/tritongpu_to_llvm.mlir
@@ -1426,6 +1426,74 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32} {
 
 // -----
 
+#blocked = #ttg.blocked<{sizePerThread = [1, 2], threadsPerWarp = [1, 32], warpsPerCTA = [1, 1], order = [1, 0]}>
+#dot_a = #ttg.dot_op<{opIdx = 0, parent = #blocked}>
+#dot_b = #ttg.dot_op<{opIdx = 1, parent = #blocked}>
+module attributes {"ttg.target" = "cuda:70", "ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 1 : i32, "ttg.threads-per-warp" = 32 : i32} {
+  // CHECK-LABEL: llvm.func @fmadot_rhs_register_order
+  tt.func @fmadot_rhs_register_order(
+      %a: tensor<1x2xf32, #dot_a>,
+      %b: tensor<2x2xf32, #dot_b>,
+      %c: tensor<1x2xf32, #blocked>) {
+    // Each output column consumes adjacent K values from B's LLVM struct.
+    // CHECK-DAG: [[FMA_C0:%.*]] = llvm.extractvalue %arg2[0]
+    // CHECK-DAG: [[FMA_C1:%.*]] = llvm.extractvalue %arg2[1]
+    // CHECK-DAG: [[FMA_A0:%.*]] = llvm.extractvalue %arg0[0]
+    // CHECK-DAG: [[FMA_A1:%.*]] = llvm.extractvalue %arg0[1]
+    // CHECK-DAG: [[FMA_B0:%.*]] = llvm.extractvalue %arg1[0]
+    // CHECK-DAG: [[FMA_B1:%.*]] = llvm.extractvalue %arg1[1]
+    // CHECK-DAG: [[FMA_B2:%.*]] = llvm.extractvalue %arg1[2]
+    // CHECK-DAG: [[FMA_B3:%.*]] = llvm.extractvalue %arg1[3]
+    // CHECK: [[FMA_R0:%.*]] = llvm.intr.fmuladd([[FMA_A0]], [[FMA_B0]], [[FMA_C0]])
+    // CHECK: [[FMA_R1:%.*]] = llvm.intr.fmuladd([[FMA_A1]], [[FMA_B1]], [[FMA_R0]])
+    // CHECK: [[FMA_R2:%.*]] = llvm.intr.fmuladd([[FMA_A0]], [[FMA_B2]], [[FMA_C1]])
+    // CHECK: llvm.intr.fmuladd([[FMA_A1]], [[FMA_B3]], [[FMA_R2]])
+    %d = tt.dot %a, %b, %c, inputPrecision = ieee :
+        tensor<1x2xf32, #dot_a> * tensor<2x2xf32, #dot_b> -> tensor<1x2xf32, #blocked>
+    tt.return
+  }
+}
+
+// -----
+
+#blocked = #ttg.blocked<{sizePerThread = [2, 2], threadsPerWarp = [1, 32], warpsPerCTA = [1, 1], order = [0, 1]}>
+#dot_a = #ttg.dot_op<{opIdx = 0, parent = #blocked}>
+#dot_b = #ttg.dot_op<{opIdx = 1, parent = #blocked}>
+module attributes {"ttg.target" = "cuda:70", "ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 1 : i32, "ttg.threads-per-warp" = 32 : i32} {
+  // CHECK-LABEL: llvm.func @fmadot_lhs_register_order
+  tt.func @fmadot_lhs_register_order(
+      %a: tensor<2x2xf32, #dot_a>,
+      %b: tensor<2x2xf32, #dot_b>,
+      %c: tensor<2x2xf32, #blocked>) {
+    // Each output row consumes adjacent K values from A's LLVM struct.
+    // CHECK-DAG: [[LHS_C0:%.*]] = llvm.extractvalue %arg2[0]
+    // CHECK-DAG: [[LHS_C1:%.*]] = llvm.extractvalue %arg2[1]
+    // CHECK-DAG: [[LHS_C2:%.*]] = llvm.extractvalue %arg2[2]
+    // CHECK-DAG: [[LHS_C3:%.*]] = llvm.extractvalue %arg2[3]
+    // CHECK-DAG: [[LHS_A0:%.*]] = llvm.extractvalue %arg0[0]
+    // CHECK-DAG: [[LHS_A1:%.*]] = llvm.extractvalue %arg0[1]
+    // CHECK-DAG: [[LHS_A2:%.*]] = llvm.extractvalue %arg0[2]
+    // CHECK-DAG: [[LHS_A3:%.*]] = llvm.extractvalue %arg0[3]
+    // CHECK-DAG: [[LHS_B0:%.*]] = llvm.extractvalue %arg1[0]
+    // CHECK-DAG: [[LHS_B1:%.*]] = llvm.extractvalue %arg1[1]
+    // CHECK-DAG: [[LHS_B2:%.*]] = llvm.extractvalue %arg1[2]
+    // CHECK-DAG: [[LHS_B3:%.*]] = llvm.extractvalue %arg1[3]
+    // CHECK: [[LHS_R00:%.*]] = llvm.intr.fmuladd([[LHS_A0]], [[LHS_B0]], [[LHS_C0]])
+    // CHECK: llvm.intr.fmuladd([[LHS_A1]], [[LHS_B1]], [[LHS_R00]])
+    // CHECK: [[LHS_R01:%.*]] = llvm.intr.fmuladd([[LHS_A0]], [[LHS_B2]], [[LHS_C2]])
+    // CHECK: llvm.intr.fmuladd([[LHS_A1]], [[LHS_B3]], [[LHS_R01]])
+    // CHECK: [[LHS_R10:%.*]] = llvm.intr.fmuladd([[LHS_A2]], [[LHS_B0]], [[LHS_C1]])
+    // CHECK: llvm.intr.fmuladd([[LHS_A3]], [[LHS_B1]], [[LHS_R10]])
+    // CHECK: [[LHS_R11:%.*]] = llvm.intr.fmuladd([[LHS_A2]], [[LHS_B2]], [[LHS_C3]])
+    // CHECK: llvm.intr.fmuladd([[LHS_A3]], [[LHS_B3]], [[LHS_R11]])
+    %d = tt.dot %a, %b, %c, inputPrecision = ieee :
+        tensor<2x2xf32, #dot_a> * tensor<2x2xf32, #dot_b> -> tensor<2x2xf32, #blocked>
+    tt.return
+  }
+}
+
+// -----
+
 #blocked = #ttg.blocked<{sizePerThread = [1, 4], threadsPerWarp = [2, 16], warpsPerCTA = [1, 4], order = [1, 0]}>
 #shared = #ttg.swizzled_shared<{vec = 1, perPhase = 1, maxPhase = 1, order = [1, 0]}>
 #dot_operand_a = #ttg.dot_op<{opIdx=0, parent=#blocked}>

--- a/unittest/Dialect/TritonGPU/LinearLayoutConversionsTest.cpp
+++ b/unittest/Dialect/TritonGPU/LinearLayoutConversionsTest.cpp
@@ -394,6 +394,20 @@ TEST_F(LinearLayoutConversionsTest, BlockedDotOperandLhs) {
                    {S("dim0"), S("dim1")}));
 }
 
+TEST_F(LinearLayoutConversionsTest, BlockedDotOperandLhsNonKContiguousParent) {
+  auto parent = blocked(/*size*/ {2, 4}, /*threads*/ {8, 4}, /*warps*/ {2, 4},
+                        /*ctas*/ {1, 1}, /*splits*/ {1, 1}, /*order*/ {0, 1},
+                        /*cta order*/ {1, 0});
+  auto dotOperand = dot(parent, /*idx*/ 0, /*kWidth*/ 0);
+  EXPECT_EQ(
+      toLinearLayout({32, 16}, dotOperand),
+      LinearLayout({{S("register"), {{0, 1}, {0, 2}, {0, 4}, {0, 8}, {1, 0}}},
+                    {S("lane"), {{2, 0}, {4, 0}, {8, 0}, {0, 0}, {0, 0}}},
+                    {S("warp"), {{16, 0}, {0, 0}, {0, 0}}},
+                    {S("block"), {}}},
+                   {S("dim0"), S("dim1")}));
+}
+
 TEST_F(LinearLayoutConversionsTest, BlockedDot3dOperandLhs) {
   auto parent =
       blocked(/*size*/ {2, 2, 4}, /*threads*/ {2, 4, 4}, /*warps*/ {2, 2, 2},
@@ -423,7 +437,7 @@ TEST_F(LinearLayoutConversionsTest, BlockedDotOperandRhs) {
   auto dotOperand = dot(parent, /*idx*/ 1, /*kWidth*/ 0);
   EXPECT_EQ(toLinearLayout({16, 64}, dotOperand),
             LinearLayout({{S("register"),
-                           {{0, 1}, {0, 2}, {1, 0}, {2, 0}, {4, 0}, {8, 0}}},
+                           {{1, 0}, {2, 0}, {4, 0}, {8, 0}, {0, 1}, {0, 2}}},
                           {S("lane"), {{0, 4}, {0, 8}, {0, 0}, {0, 0}, {0, 0}}},
                           {S("warp"), {{0, 16}, {0, 32}, {0, 0}}},
                           {S("block"), {}}},
@@ -440,10 +454,10 @@ TEST_F(LinearLayoutConversionsTest, BlockedDot3dOperandRhs) {
       toLinearLayout({16, 4, 64}, dotOperand),
       LinearLayout(
           {{S("register"),
-            {{0, 0, 1},
-             {0, 0, 2},
-             {0, 1, 0},
+            {{0, 1, 0},
              {0, 2, 0},
+             {0, 0, 1},
+             {0, 0, 2},
              {1, 0, 0},
              {0, 0, 32},
              {8, 0, 0}}},


### PR DESCRIPTION

Use operand-specific register orders for FMA dot operands, keeping K contiguous for both A and B. Update the lowering to decode each operand using its own layout while preserving the existing thread, warp, and result layouts.
