### PR TITLE
[TTIR] Add loop unswitching for loop-invariant scf.if

### DIFF
--- a/include/triton/Dialect/Triton/Transforms/Passes.td
+++ b/include/triton/Dialect/Triton/Transforms/Passes.td
@@ -56,6 +56,22 @@ def TritonLoopUnroll : Pass</*cli-arg*/"triton-loop-unroll", /*Op*/"mlir::Module
   let dependentDialects = ["mlir::triton::TritonDialect"];
 }
 
+def TritonLoopUnswitch : Pass</*cli-arg*/"triton-loop-unswitch", /*Op*/"mlir::ModuleOp"> {
+  let summary = "Hoist loop-invariant if out of for";
+  let description = [{
+    Moves a loop-invariant `scf.if` out of an `scf.for` by creating one copy
+    of the loop per branch.
+  }];
+
+  let options = [
+    Option<"maxBodySize", "max-body-size", "unsigned", /*default=*/"256",
+           "Maximum number of operations in a loop body to duplicate; larger "
+           "loops are not unswitched to bound compile time and code size.">
+  ];
+
+  let dependentDialects = ["mlir::triton::TritonDialect"];
+}
+
 def TritonLoopInvariantCodeMotion : Pass</*cli-arg*/"triton-licm", /*Op*/"mlir::ModuleOp"> {
   let summary = "MLIR's LICM plus hoist load ops out of loops with masks.";
   let description = [{

--- a/lib/Dialect/Triton/Transforms/CMakeLists.txt
+++ b/lib/Dialect/Triton/Transforms/CMakeLists.txt
@@ -8,6 +8,7 @@ add_triton_library(TritonTransforms
   LoopInvariantCodeMotion.cpp
   LoopPeeling.cpp
   LoopUnroll.cpp
+  LoopUnswitch.cpp
   ReorderBroadcast.cpp
   RewriteTensorDescriptorToPointer.cpp
   ArithTypeConversion.cpp

--- a/lib/Dialect/Triton/Transforms/LoopUnswitch.cpp
+++ b/lib/Dialect/Triton/Transforms/LoopUnswitch.cpp
@@ -1,0 +1,133 @@
+#include "mlir/Dialect/SCF/IR/SCF.h"
+#include "mlir/IR/IRMapping.h"
+#include "mlir/Interfaces/SideEffectInterfaces.h"
+#include "mlir/Pass/Pass.h"
+#include "triton/Dialect/Triton/IR/Dialect.h"
+#include "triton/Dialect/Triton/Transforms/Passes.h"
+#include "llvm/Support/Debug.h"
+
+namespace mlir::triton {
+
+#define GEN_PASS_DEF_TRITONLOOPUNSWITCH
+#include "triton/Dialect/Triton/Transforms/Passes.h.inc"
+
+#define DEBUG_TYPE "triton-loop-unswitch"
+#define DBGS() (llvm::dbgs() << "[" DEBUG_TYPE "]: ")
+#define LDBG(X) LLVM_DEBUG(DBGS() << X << "\n")
+
+namespace {
+
+
+void inlineResolvedIf(scf::IfOp ifOp, Region &region) {
+  if (region.empty()) {
+    ifOp.erase();
+    return;
+  }
+  Block &block = region.front();
+  auto yield = cast<scf::YieldOp>(block.getTerminator());
+  ifOp.replaceAllUsesWith(yield.getOperands());
+  ifOp->getBlock()->getOperations().splice(ifOp->getIterator(),
+                                           block.getOperations(), block.begin(),
+                                           std::prev(block.end()));
+  ifOp.erase();
+}
+
+
+bool isInvariant(scf::ForOp forOp, Value value,
+                 SmallVectorImpl<Operation *> &toHoist) {
+  if (!forOp.getBodyRegion().isAncestor(value.getParentRegion()))
+    return true;
+  // Induction variable or iter_args.
+  if (isa<BlockArgument>(value))
+    return false;
+  Operation *def = value.getDefiningOp();
+  if (def->getBlock() != forOp.getBody())
+    return false;
+  if (!isMemoryEffectFree(def) || !isSpeculatable(def))
+    return false;
+  for (Value operand : def->getOperands())
+    if (!isInvariant(forOp, operand, toHoist))
+      return false;
+  if (!llvm::is_contained(toHoist, def))
+    toHoist.push_back(def);
+  return true;
+}
+
+// Return the first scf.if directly in the body of \p forOp whose condition is
+// loop-invariant, hoisting the condition computation out of the loop if
+// needed.
+scf::IfOp findUnswitchCandidate(scf::ForOp forOp) {
+  for (Operation &op : forOp.getBody()->without_terminator()) {
+    auto ifOp = dyn_cast<scf::IfOp>(&op);
+    if (!ifOp)
+      continue;
+    SmallVector<Operation *> toHoist;
+    if (!isInvariant(forOp, ifOp.getCondition(), toHoist))
+      continue;
+    for (Operation *def : toHoist)
+      def->moveBefore(forOp);
+    return ifOp;
+  }
+  return nullptr;
+}
+
+bool tryUnswitch(scf::ForOp forOp, unsigned maxBodySize) {
+  unsigned bodySize = 0;
+  forOp.getBody()->walk([&](Operation *) { ++bodySize; });
+  if (bodySize > maxBodySize) {
+    LDBG("skipping loop with body size " << bodySize);
+    return false;
+  }
+
+  scf::IfOp candidate = findUnswitchCandidate(forOp);
+  if (!candidate)
+    return false;
+
+  OpBuilder b(forOp);
+  Location loc = forOp.getLoc();
+  auto newIf = scf::IfOp::create(b, loc, forOp.getResultTypes(),
+                                 candidate.getCondition(),
+                                 /*withElseRegion=*/true);
+
+  // Clone the loop into one branch of the new if and resolve the candidate to
+  // the corresponding region.
+  auto specialize = [&](Block *dest, bool takeThen) {
+    // Builders of scf.if may add a terminator for ifs with no results , the clone
+    // supplies its own yield below.
+    if (!dest->empty() && dest->back().hasTrait<OpTrait::IsTerminator>())
+      dest->back().erase();
+    OpBuilder bb = OpBuilder::atBlockEnd(dest);
+    IRMapping map;
+    auto clonedFor = cast<scf::ForOp>(bb.clone(*forOp.getOperation(), map));
+    auto clonedIf = cast<scf::IfOp>(map.lookup(candidate.getOperation()));
+    inlineResolvedIf(clonedIf, takeThen ? clonedIf.getThenRegion()
+                                        : clonedIf.getElseRegion());
+    scf::YieldOp::create(bb, loc, clonedFor.getResults());
+  };
+  specialize(newIf.thenBlock(), /*takeThen=*/true);
+  specialize(newIf.elseBlock(), /*takeThen=*/false);
+
+  forOp.replaceAllUsesWith(newIf.getResults());
+  forOp.erase();
+  return true;
+}
+
+} // anonymous namespace
+
+class LoopUnswitchPass : public impl::TritonLoopUnswitchBase<LoopUnswitchPass> {
+public:
+  using TritonLoopUnswitchBase::TritonLoopUnswitchBase;
+
+  void runOnOperation() override {
+    // Collect loops post-order so that unswitching an inner
+    // loop is visible to the size check of its enclosing loops, and process
+    // each loop at most once to bound duplication.
+    SmallVector<scf::ForOp> loops;
+    getOperation()->walk([&](scf::ForOp forOp) { loops.push_back(forOp); });
+    for (scf::ForOp forOp : loops)
+      if (tryUnswitch(forOp, maxBodySize))
+        LDBG("unswitched loop");
+  }
+};
+
+} // namespace mlir::triton

--- a/python/src/passes.cc
+++ b/python/src/passes.cc
@@ -49,6 +49,7 @@ void init_triton_passes_ttir(py::module_ &m) {
   ADD_PASS_WRAPPER_0("add_rewrite_tensor_descriptor_to_pointer",
                      createTritonRewriteTensorDescriptorToPointer);
   ADD_PASS_WRAPPER_0("add_loop_unroll", createTritonLoopUnroll);
+  ADD_PASS_WRAPPER_0("add_loop_unswitch", createTritonLoopUnswitch);
   ADD_PASS_WRAPPER_0("add_triton_licm", createTritonLoopInvariantCodeMotion);
   ADD_PASS_WRAPPER_0("add_loop_aware_cse", createTritonLoopAwareCSE);
   ADD_PASS_OPTION_WRAPPER_4("add_convert_to_ttgpuir",

--- a/test/Triton/loop-unswitch.mlir
+++ b/test/Triton/loop-unswitch.mlir
@@ -1,0 +1,66 @@
+// RUN: triton-opt %s -triton-loop-unswitch | FileCheck %s
+
+// The condition is computed inside the loop from loop-invariant values: the
+// computation is hoisted and the loop is unswitched.
+// CHECK-LABEL: @unswitch_cond_computed_in_loop
+tt.func @unswitch_cond_computed_in_loop(%lb: index, %ub: index, %step: index, %flag: i32, %x: f32, %y: f32) -> f32 {
+  %init = arith.constant 0.0 : f32
+  // CHECK: %[[C3:.*]] = arith.constant 3 : i32
+  // CHECK: %[[COND:.*]] = arith.cmpi eq, %{{.*}}, %[[C3]]
+  // CHECK: scf.if %[[COND]]
+  // CHECK: scf.for
+  // CHECK-NOT: scf.if
+  %r = scf.for %i = %lb to %ub step %step iter_args(%acc = %init) -> (f32) {
+    %c3 = arith.constant 3 : i32
+    %c = arith.cmpi eq, %flag, %c3 : i32
+    %v = scf.if %c -> (f32) {
+      %a = arith.addf %acc, %x : f32
+      scf.yield %a : f32
+    } else {
+      %m = arith.mulf %acc, %y : f32
+      scf.yield %m : f32
+    }
+    scf.yield %v : f32
+  }
+  tt.return %r : f32
+}
+
+// The condition depends on the induction variable: must not unswitch.
+// CHECK-LABEL: @variant_condition_not_unswitched
+tt.func @variant_condition_not_unswitched(%lb: index, %ub: index, %step: index, %n: index, %x: f32) -> f32 {
+  %init = arith.constant 0.0 : f32
+  // CHECK: scf.for
+  // CHECK: scf.if
+  %r = scf.for %i = %lb to %ub step %step iter_args(%acc = %init) -> (f32) {
+    %c = arith.cmpi slt, %i, %n : index
+    %v = scf.if %c -> (f32) {
+      %a = arith.addf %acc, %x : f32
+      scf.yield %a : f32
+    } else {
+      scf.yield %acc : f32
+    }
+    scf.yield %v : f32
+  }
+  tt.return %r : f32
+}
+
+// If without results or else region: the then"copy" inlines the body, the
+// else"copy" simply drops it.
+// CHECK-LABEL: @unswitch_if_without_else
+tt.func @unswitch_if_without_else(%lb: index, %ub: index, %step: index, %flag: i1, %ptr: !tt.ptr<f32>, %x: f32) {
+  // CHECK: scf.if %{{.*}}
+  // CHECK: scf.for
+  // CHECK-NOT: scf.if
+  // CHECK: tt.store
+  // CHECK: else
+  // CHECK: scf.for
+  // CHECK-NOT: tt.store
+  scf.for %i = %lb to %ub step %step {
+    scf.if %flag {
+      tt.store %ptr, %x : !tt.ptr<f32>
+      scf.yield
+    }
+    scf.yield
+  }
+  tt.return
+}

--- a/third_party/amd/backend/compiler.py
+++ b/third_party/amd/backend/compiler.py
@@ -249,6 +249,7 @@ class HIPBackend(BaseBackend):
         passes.common.add_cse(pm)
         passes.ttir.add_triton_licm(pm)
         passes.common.add_symbol_dce(pm)
+        passes.ttir.add_loop_unswitch(pm)
         passes.ttir.add_loop_unroll(pm)
         pm.run(mod, 'make_ttir')
         return mod

--- a/third_party/nvidia/backend/compiler.py
+++ b/third_party/nvidia/backend/compiler.py
@@ -257,6 +257,7 @@ class CUDABackend(BaseBackend):
         passes.ttir.add_reorder_broadcast(pm)
         passes.common.add_cse(pm)
         passes.common.add_symbol_dce(pm)
+        passes.ttir.add_loop_unswitch(pm)
         passes.ttir.add_loop_unroll(pm)
         pm.run(mod, 'make_ttir')
         return mod


### PR DESCRIPTION
A loop invariant `if` inside a loop silently disables software pipelining: the pipeliner won't issue async copies for loads nested in control flow, so the loop falls back to synchronous loads. For example:

```python
for k in tl.range(0, K, BK, num_stages=3):
    if flag == 3:                      # same on every iteration
        a = tl.load(a_ptr + offs_a)
        b = tl.load(b_ptr + offs_b)
    else:
        a = tl.load(b_ptr + offs_a)
        b = tl.load(a_ptr + offs_b)
    acc = tl.dot(a, b, acc)
```

compiles with zero cp.async (24 without the branch). In pipelined kernels with big tiles or persistent/stream-K launches, prefetching is the only latency hiding, there in my test case im seeing that the loop runs up to 1.76x slower. At high occupancy the cost shrinks to ~10%.

### Fix

Add a `TritonLoopUnswitch` pass that hoists the invariant `if` out of the loop by versioning it:

```python
if flag == 3:
    for k in ...:   # branch-free -> pipelines normally
else:
    for k in ...:   # branch-free -> pipelines normally
```

Conditions computed inside the loop from invariant values are hoisted first. 
Loops bigger than `max-body-size` (pass option, default 256 ops) are skipped.

