### PR TITLE
[AMD] Preserve volatile loads during LLVM lowering

### DIFF
--- a/test/Conversion/amd/cluster_load.mlir
+++ b/test/Conversion/amd/cluster_load.mlir
@@ -35,6 +35,21 @@ module attributes {"ttg.num-ctas" = 8 : i32, "ttg.num-warps" = 4 : i32, ttg.shar
 
 // -----
 
+// Volatile semantics cannot be represented by the cluster load intrinsic, so
+// volatile loads must use regular LLVM loads instead.
+#blocked = #ttg.blocked<{sizePerThread = [1, 8], threadsPerWarp = [8, 4], warpsPerCTA = [4, 1], order = [1, 0], CGALayout = [[1, 0], [0, 0], [0, 0]]}>
+module attributes {"ttg.num-ctas" = 8 : i32, "ttg.num-warps" = 4 : i32, ttg.shared = 8192 : i32} {
+  // CHECK-LABEL: volatile_load_no_cluster
+  tt.func public @volatile_load_no_cluster(%arg0: tensor<32x32x!tt.ptr<f16>, #blocked> {tt.divisibility = dense<[16, 16]> : tensor<2xi32>, tt.contiguity = dense<[16, 16]> : tensor<2xi32>, tt.constancy = dense<[1, 1]> : tensor<2xi32>}) {
+    // CHECK-NOT: llvm.amdgcn.cluster.load
+    // CHECK: llvm.load volatile
+    %6 = tt.load %arg0 {isVolatile = true} : tensor<32x32x!tt.ptr<f16>, #blocked>
+    tt.return
+  }
+}
+
+// -----
+
 // 16 CTAs with communication groups {0,1,4,5,8,9,12,13} and
 // {2,3,6,7,10,11,14,15}. The eight-bit masks exceed gfx1250's limit of five
 // bits, so split each group into four-CTA subgroups selected by CTA id bit 3.

--- a/test/Conversion/amd/load_store.mlir
+++ b/test/Conversion/amd/load_store.mlir
@@ -30,6 +30,25 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 1 : i32} {
 
 // -----
 
+module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 1 : i32} {
+  // CHECK-LABEL: volatile_load_in_loop
+  tt.func @volatile_load_in_loop(%flag: !tt.ptr<i32>) {
+    %c0_i32 = arith.constant 0 : i32
+    scf.while : () -> () {
+      // CHECK: scf.while
+      // CHECK: llvm.load volatile
+      %0 = tt.load %flag {isVolatile = true} : !tt.ptr<i32>
+      %1 = arith.cmpi eq, %0, %c0_i32 : i32
+      scf.condition(%1)
+    } do {
+      scf.yield
+    }
+    tt.return
+  }
+}
+
+// -----
+
 #mma = #ttg.amd_mfma<{version = 3, warpsPerCTA = [1, 1], instrShape = [16, 16, 4], isTransposed = true}>
 module attributes {"ttg.num-warps" = 1 : i32, "ttg.threads-per-warp" = 64 : i32} {
   // CHECK-LABEL: global_store_mfma_vec16

--- a/third_party/amd/include/Dialect/TritonAMDGPU/IR/TritonAMDGPUOps.td
+++ b/third_party/amd/include/Dialect/TritonAMDGPU/IR/TritonAMDGPUOps.td
@@ -507,6 +507,7 @@ def MaskedLoadOp : TT_AMDGPU_Op<"masked_load", []> {
     LLVM_Type:$falseVal,
     Optional<I32>:$multicastMask,
     DefaultValuedAttr<TT_CacheModifierAttr, "::mlir::triton::CacheModifier::NONE">:$cache,
+    DefaultValuedAttr<BoolAttr, "false">:$isVolatile,
     DefaultValuedAttr<BoolAttr, "false">:$forceNoAlias
   );
 
@@ -515,6 +516,7 @@ def MaskedLoadOp : TT_AMDGPU_Op<"masked_load", []> {
   let assemblyFormat = [{
     $ptr `,` $mask `,` $falseVal (`,` $multicastMask^)?
     oilist(`cacheModifier` `=` $cache)
+    (`volatile` $isVolatile^)?
     (`forceNoAlias` $forceNoAlias^)?
     attr-dict `:` functional-type(operands, results)
   }];

--- a/third_party/amd/lib/TritonAMDGPUToLLVM/LoadStoreOpToLLVM.cpp
+++ b/third_party/amd/lib/TritonAMDGPUToLLVM/LoadStoreOpToLLVM.cpp
@@ -621,7 +621,7 @@ struct LoadOpConversion : public ConvertOpToLLVMPattern<triton::LoadOp>,
             otherElems, vecStart);
 
       Value loadVal = llLoad(rewriter, loc, ptr, vecTy, pred, falseVal,
-                             multicastMask, cacheMod);
+                             multicastMask, cacheMod, op.getIsVolatile());
       for (size_t ii = 0; ii < vec; ++ii) {
         Value vecIdx = createIndexAttrConstant(
             rewriter, loc, getTypeConverter()->getIndexType(), ii);

--- a/third_party/amd/lib/TritonAMDGPUToLLVM/MaskedOpsToLLVM.cpp
+++ b/third_party/amd/lib/TritonAMDGPUToLLVM/MaskedOpsToLLVM.cpp
@@ -39,6 +39,7 @@ public:
     std::tie(volatileFlag, nonTmpFlag) =
         mlir::LLVM::AMD::getCacheModifierFlagsForLoadStore(
             cacheMod, mlir::LLVM::AMD::MemoryOp::Load);
+    volatileFlag |= loadOp.getIsVolatile();
 
     auto createLoadWithAttrs = [&](Location loadLoc) -> Value {
       int vecBits = 0;
@@ -48,8 +49,12 @@ public:
         vecBits = elemTy.getIntOrFloatBitWidth();
       }
       assert(vecBits != 0);
-      // We can only multicast for 32, 64, 128 bit load size (hw limitation)
-      if (multicastMask && targetInfo.supportsClusterLoadBitWidth(vecBits)) {
+      bool supportsClusterLoad =
+          targetInfo.supportsClusterLoadBitWidth(vecBits);
+      // The cluster load intrinsic cannot represent LLVM volatile semantics,
+      // so use a regular load for volatile accesses.
+      if (multicastMask && supportsClusterLoad &&
+          !loadOp.getIsVolatile()) {
         std::string intrinsic =
             "llvm.amdgcn.cluster.load.b" + std::to_string(vecBits);
         auto cacheModBits = LLVM::AMD::getCtrlBitsForCacheModifierOnTarget(
@@ -63,7 +68,7 @@ public:
             rewriter, loc, intrinsic, {resTy},
             {ptr, b.i32_val(cacheModBits), multicastMask});
         return b.bitcast(clusterLoadOp->getResult(0), elemTy);
-      } else if (multicastMask) {
+      } else if (multicastMask && !supportsClusterLoad) {
         loadOp.emitRemark()
             << "Multicast with bit width " << vecBits << " is not supported on "
             << targetInfo.getArch() << " falling back to regular load";

--- a/third_party/amd/lib/TritonAMDGPUToLLVM/MaskedOpsToLLVM.cpp
+++ b/third_party/amd/lib/TritonAMDGPUToLLVM/MaskedOpsToLLVM.cpp
@@ -53,8 +53,7 @@ public:
           targetInfo.supportsClusterLoadBitWidth(vecBits);
       // The cluster load intrinsic cannot represent LLVM volatile semantics,
       // so use a regular load for volatile accesses.
-      if (multicastMask && supportsClusterLoad &&
-          !loadOp.getIsVolatile()) {
+      if (multicastMask && supportsClusterLoad && !loadOp.getIsVolatile()) {
         std::string intrinsic =
             "llvm.amdgcn.cluster.load.b" + std::to_string(vecBits);
         auto cacheModBits = LLVM::AMD::getCtrlBitsForCacheModifierOnTarget(

--- a/third_party/amd/lib/TritonAMDGPUToLLVM/TargetInfo.cpp
+++ b/third_party/amd/lib/TritonAMDGPUToLLVM/TargetInfo.cpp
@@ -247,7 +247,8 @@ Value TargetInfo::loadDShared(RewriterBase &rewriter, Location loc, Value ptr,
   bool addAliasGroup = localLoadOp && requiresAliasInfoForAsyncOps() &&
                        isSyncedViaAsyncWait(localLoadOp);
   return mlir::LLVM::AMD::llLoad(rewriter, loc, ptr, elemTy, pred, falseVal, {},
-                                 triton::CacheModifier::NONE, addAliasGroup);
+                                 triton::CacheModifier::NONE,
+                                 /*isVolatile=*/false, addAliasGroup);
 }
 
 Value TargetInfo::shuffleXor(RewriterBase &rewriter, Location loc, Value val,

--- a/third_party/amd/lib/TritonAMDGPUToLLVM/Utility.cpp
+++ b/third_party/amd/lib/TritonAMDGPUToLLVM/Utility.cpp
@@ -470,10 +470,9 @@ Value llLoad(RewriterBase &rewriter, Location loc, Value ptr, Type elemTy,
              Value pred, Value falseVal, Value multicastMask,
              triton::CacheModifier cm, bool isVolatile,
              bool forceNoAliasAsyncLoads) {
-  return triton::amdgpu::MaskedLoadOp::create(rewriter, loc, elemTy, ptr, pred,
-                                              falseVal, multicastMask, cm,
-                                              isVolatile,
-                                              forceNoAliasAsyncLoads)
+  return triton::amdgpu::MaskedLoadOp::create(
+             rewriter, loc, elemTy, ptr, pred, falseVal, multicastMask, cm,
+             isVolatile, forceNoAliasAsyncLoads)
       .getResult();
 }
 

--- a/third_party/amd/lib/TritonAMDGPUToLLVM/Utility.cpp
+++ b/third_party/amd/lib/TritonAMDGPUToLLVM/Utility.cpp
@@ -468,9 +468,11 @@ Value emitCtaMulticastMask(RewriterBase &rewriter, Location loc, Value groupId,
 
 Value llLoad(RewriterBase &rewriter, Location loc, Value ptr, Type elemTy,
              Value pred, Value falseVal, Value multicastMask,
-             triton::CacheModifier cm, bool forceNoAliasAsyncLoads) {
+             triton::CacheModifier cm, bool isVolatile,
+             bool forceNoAliasAsyncLoads) {
   return triton::amdgpu::MaskedLoadOp::create(rewriter, loc, elemTy, ptr, pred,
                                               falseVal, multicastMask, cm,
+                                              isVolatile,
                                               forceNoAliasAsyncLoads)
       .getResult();
 }

--- a/third_party/amd/lib/TritonAMDGPUToLLVM/Utility.h
+++ b/third_party/amd/lib/TritonAMDGPUToLLVM/Utility.h
@@ -67,8 +67,7 @@ getCacheModifierFlagsForLoadStore(const triton::CacheModifier &cm, MemoryOp op);
 Value llLoad(RewriterBase &rewriter, Location loc, Value ptr, Type elemTy,
              Value pred, Value falseVal, Value multicastMask,
              triton::CacheModifier cm = triton::CacheModifier::NONE,
-             bool isVolatile = false,
-             bool forceNoAliasAsyncLoads = false);
+             bool isVolatile = false, bool forceNoAliasAsyncLoads = false);
 
 // Stores to shared or global memory with predication.
 // forceNoAliasAsyncLoads=true adds alias information to the llvm.store to

--- a/third_party/amd/lib/TritonAMDGPUToLLVM/Utility.h
+++ b/third_party/amd/lib/TritonAMDGPUToLLVM/Utility.h
@@ -67,6 +67,7 @@ getCacheModifierFlagsForLoadStore(const triton::CacheModifier &cm, MemoryOp op);
 Value llLoad(RewriterBase &rewriter, Location loc, Value ptr, Type elemTy,
              Value pred, Value falseVal, Value multicastMask,
              triton::CacheModifier cm = triton::CacheModifier::NONE,
+             bool isVolatile = false,
              bool forceNoAliasAsyncLoads = false);
 
 // Stores to shared or global memory with predication.


### PR DESCRIPTION
Preserve `tl.load(..., volatile=True)` through AMD LLVM lowering.
Previously, volatility was dropped, allowing polling-loop loads to
be hoisted and causing HIP kernels to hang.