### PR TITLE
[FRONTEND] Allow mixed inline asm argument types

### DIFF
--- a/python/test/unit/language/test_core.py
+++ b/python/test/unit/language/test_core.py
@@ -5582,7 +5582,7 @@ def test_inline_asm_mixed_pointer_value_args(num_ctas, device):
     def kernel(X, Y, Z, BLOCK: tl.constexpr):
         offsets = tl.arange(0, BLOCK)
         x_ptrs = X + offsets
-        y = tl.load(Y)
+        y = tl.load(Y + offsets)
         z = tl.inline_asm_elementwise(
             "ld.global.f32 $0, [$1]; add.f32 $0, $0, $2;",
             "=f,l,f",
@@ -5596,7 +5596,7 @@ def test_inline_asm_mixed_pointer_value_args(num_ctas, device):
     shape = (128, )
     rs = RandomState(17)
     x = numpy_random(shape, dtype_str="float32", rs=rs)
-    y = numpy_random((1, ), dtype_str="float32", rs=rs)
+    y = numpy_random(shape, dtype_str="float32", rs=rs)
     x_tri = to_triton(x, device=device)
     y_tri = to_triton(y, device=device)
     z_tri = to_triton(numpy_random(shape, dtype_str="float32", rs=rs), device=device)

--- a/python/test/unit/language/test_core.py
+++ b/python/test/unit/language/test_core.py
@@ -5573,6 +5573,38 @@ def test_inline_asm_with_pointers(num_ctas, device):
     np.testing.assert_equal(y_ref, to_numpy(y_tri))
 
 
+@pytest.mark.parametrize("num_ctas", num_ctas_list)
+def test_inline_asm_mixed_pointer_value_args(num_ctas, device):
+    if not is_cuda():
+        pytest.skip("test_inline_asm is only supported in CUDA")
+
+    @triton.jit
+    def kernel(X, Y, Z, BLOCK: tl.constexpr):
+        offsets = tl.arange(0, BLOCK)
+        x_ptrs = X + offsets
+        y = tl.load(Y)
+        z = tl.inline_asm_elementwise(
+            "ld.global.f32 $0, [$1]; add.f32 $0, $0, $2;",
+            "=f,l,f",
+            [x_ptrs, y],
+            dtype=tl.float32,
+            is_pure=False,
+            pack=1,
+        )
+        tl.store(Z + offsets, z)
+
+    shape = (128, )
+    rs = RandomState(17)
+    x = numpy_random(shape, dtype_str="float32", rs=rs)
+    y = numpy_random((1, ), dtype_str="float32", rs=rs)
+    x_tri = to_triton(x, device=device)
+    y_tri = to_triton(y, device=device)
+    z_tri = to_triton(numpy_random(shape, dtype_str="float32", rs=rs), device=device)
+    kernel[(1, )](x_tri, y_tri, z_tri, BLOCK=shape[0], num_ctas=num_ctas)
+
+    np.testing.assert_equal(x + y, to_numpy(z_tri))
+
+
 def test_inline_asm_multiple_outputs(device):
     if not is_cuda():
         pytest.skip('test_inline_asm is only supported in CUDA')

--- a/python/triton/language/core.py
+++ b/python/triton/language/core.py
@@ -4,7 +4,7 @@ import math
 from warnings import warn
 from contextlib import contextmanager
 from enum import Enum
-from functools import partial, wraps, cached_property
+from functools import wraps, cached_property
 import typing
 from typing import Union, Callable, List, Sequence, TypeVar, Optional, Tuple, TYPE_CHECKING
 from dataclasses import dataclass
@@ -3494,20 +3494,14 @@ def inline_asm_elementwise(asm: str, constraints: str, args: Sequence, dtype: Un
 
     res_tys = dtype
     if dispatch_args := [_semantic.to_tensor(arg) for arg in args]:
-        bin_op_type_checking = partial(
-            _semantic.binary_op_type_checking_impl,
-            arithmetic_check=False,
-            allow_lhs_ptr=True,
-            allow_rhs_ptr=True,
-        )
         broadcast_arg = dispatch_args[0]
         # Get the broadcast shape over all the arguments
         for item in dispatch_args:
-            _, broadcast_arg = bin_op_type_checking(item, broadcast_arg)
+            _, broadcast_arg = _semantic.broadcast_impl_value(item, broadcast_arg)
         if broadcast_arg.shape:
             # Change the shape of each argument based on the broadcast shape
             for i, item in enumerate(dispatch_args):
-                dispatch_args[i], _ = bin_op_type_checking(item, broadcast_arg)
+                dispatch_args[i], _ = _semantic.broadcast_impl_value(item, broadcast_arg)
             res_tys = [broadcast_arg.type.with_element_ty(dt) for dt in dtype]
     handles = [t.handle for t in dispatch_args]
     builder = _semantic.builder


### PR DESCRIPTION
Fixes #5054.

`inline_asm_elementwise` accepts operands according to its constraint string, so valid inline assembly can need an address operand alongside a register value. The frontend currently sends every operand pair through binary-operation type checking solely to determine their broadcast shape. That rejects mixed pointer and value operands before the inline assembly constraints are considered.

Use shape-only broadcasting for inline assembly arguments. This preserves each operand's element type while retaining the existing scalar/tensor and tensor/tensor broadcasting behavior. The regression test exercises elementwise pairs of pointer and floating-point value tensors in real PTX.

Validation:

- `python -m pytest -s --tb=short python/test/unit/language/test_core.py -k inline_asm` (6 passed on an NVIDIA RTX 3090, SM86)
- `TestPtxAsmFormat --gtest_brief=1` (4 passed)
- `lit -v test/Conversion/tritongpu_to_llvm.mlir test/Triton/ops.mlir` (2 passed)
- `pre-commit run --from-ref origin/main --to-ref HEAD`

<!---
The core Triton is a small number of people, and we receive many PRs (thank
you!).  To help us review your code more quickly, **if you are a new
contributor (less than 3 PRs merged) we ask that you complete the following
tasks and include the filled-out checklist in your PR description.**

Complete the following tasks before sending your PR, and replace `[ ]` with
`[x]` to indicate you have done them.
-->

# New contributor declaration
- [x] I am not making a trivial change, such as fixing a typo in a comment.

- [x] I have written a PR description following these
  [rules](https://cbea.ms/git-commit/#why-not-how).

- [x] I have run `pre-commit run --from-ref origin/main --to-ref HEAD`.

- Select one of the following.
  - [x] I have added tests.
    - `/test` for `lit` tests
    - `/unittest` for C++ tests
    - `/python/test` for end-to-end tests
  - [ ] This PR does not need a test because `FILL THIS IN`.

- Select one of the following.
  - [x] I have not added any `lit` tests.
  - [ ] The `lit` tests I have added follow these [best practices](https://mlir.llvm.org/getting_started/TestingGuide/#filecheck-best-practices),
    including the "tests should be minimal" section. (Usually running Python code
    and using the instructions it generates is not minimal.)
