### PR TITLE
Fix autotuner to validate prune_configs_by["top_k"] values

### DIFF
--- a/python/test/unit/runtime/test_autotuner.py
+++ b/python/test/unit/runtime/test_autotuner.py
@@ -1,3 +1,4 @@
+import math
 import torch
 
 import triton
@@ -235,6 +236,51 @@ def test_prune_configs(with_perf_model: bool, device: str):
         assert records['run_early_config_prune']
         assert records['capture_kwargs']
         assert records['capture_named_args']
+
+
+@pytest.mark.parametrize("top_k", [True, False, 0, -1, 1.0, 0.0, 1.1, -0.1, math.nan, math.inf, -math.inf, "2", object()])
+def test_top_k_invalid_values_rejected(top_k):
+    class Kernel:
+
+        def __init__(self):
+            self.fn = lambda: None
+
+        def run(self, **kwargs):
+            return None
+
+    with pytest.raises((TypeError, ValueError)):
+        triton.runtime.Autotuner(
+            Kernel(),
+            arg_names=[],
+            configs=[triton.Config(kwargs={"BLOCK_SIZE": 32})],
+            key=[],
+            reset_to_zero=None,
+            restore_value=None,
+            prune_configs_by={"top_k": top_k},
+        )
+
+
+@pytest.mark.parametrize("top_k", [1, 2, 0.5, 1.0, 0.3])
+def test_top_k_valid_values_accepted(top_k):
+    class Kernel:
+
+        def __init__(self):
+            self.fn = lambda: None
+
+        def run(self, **kwargs):
+            return None
+
+    tuner = triton.runtime.Autotuner(
+        Kernel(),
+        arg_names=[],
+        configs=[triton.Config(kwargs={"BLOCK_SIZE": 32})],
+        key=[],
+        reset_to_zero=None,
+        restore_value=None,
+        prune_configs_by={"top_k": top_k},
+    )
+
+    assert tuner.configs_top_k == top_k
 
 
 def test_prune_configs_fractional_top_k_keeps_one(device: str):

--- a/python/triton/runtime/autotuner.py
+++ b/python/triton/runtime/autotuner.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import builtins
+import math
 import time
 import inspect
 import hashlib
@@ -88,6 +89,7 @@ class Autotuner(KernelInterface):
             self.perf_model = prune_configs_by.get("perf_model", self.perf_model)
             self.configs_top_k = prune_configs_by.get("top_k", self.configs_top_k)
             self.early_config_prune = prune_configs_by.get("early_config_prune", self.early_config_prune)
+            self._validate_top_k(self.configs_top_k)
 
         self.fn = fn
         self.base_fn = fn
@@ -123,6 +125,20 @@ class Autotuner(KernelInterface):
                 quantiles=quantiles,
             )
             return
+
+    @staticmethod
+    def _validate_top_k(top_k):
+        if isinstance(top_k, bool):
+            raise TypeError("top_k must be a positive integer or a float in the interval (0.0, 1.0]")
+        if isinstance(top_k, int):
+            if top_k <= 0:
+                raise ValueError("top_k must be a positive integer")
+            return
+        if isinstance(top_k, float):
+            if not math.isfinite(top_k) or top_k <= 0.0 or top_k > 1.0:
+                raise ValueError("top_k must be a finite float in the interval (0.0, 1.0]")
+            return
+        raise TypeError("top_k must be a positive integer or a float in the interval (0.0, 1.0]")
 
     @cached_property
     def do_bench(self):
@@ -290,15 +306,12 @@ class Autotuner(KernelInterface):
                     "No valid autotuner configs after pruning. `early_config_prune` should return at least one config.")
         if self.perf_model:
             top_k = self.configs_top_k
-            if isinstance(top_k, float) and top_k <= 1.0:
+            if isinstance(top_k, float):
                 # Keep at least one config: a small fraction over a small config
                 # set rounds down to zero, which would prune everything and crash
                 # the later min() on an empty set. early_config_prune already
                 # guarantees at least one config; mirror that here.
                 top_k = max(1, int(len(pruned_configs) * top_k))
-            elif not isinstance(top_k, int):
-                # Slice index must be an integer
-                raise TypeError("Error while pruning configs, top_k must be either 1) a float <= 1.0 or 2) an int")
 
             if len(pruned_configs) > top_k:
                 est_timing = {


### PR DESCRIPTION
# Summary

Fixes #11072

This patch adds validation for `prune_configs_by["top_k"]` when the `Autotuner` is created.

Previously, invalid `top_k` values were allowed through and could cause errors later in the config-pruning logic. This made it harder to understand what went wrong. With this change, invalid values are rejected immediately with a clear error during `Autotuner` initialization.

## What changed

### Validate `top_k` early

`Autotuner.__init__` now validates the value of `top_k`.

The following values are accepted:

- Positive integers
- Finite floats in the range `(0.0, 1.0]`

The following values are rejected:

- `True` / `False`
- Zero or negative integers
- Floats `<= 0.0`
- Floats `> 1.0`
- `NaN`
- `inf` / `-inf`
- Non-numeric values

This makes the expected behavior of `top_k` explicit and prevents invalid values from reaching the pruning logic.

### Simplify pruning logic

Since `top_k` is now validated when the `Autotuner` is created, the extra validation checks in `prune_configs()` are no longer needed.

Fractional `top_k` values continue to behave as before. For example, `top_k=0.3` still keeps at least one config even when the calculated number of configs rounds down to zero.

## Tests

Added regression tests covering:

- Invalid integer values
- Invalid floating-point values
- `NaN` and infinite values
- Boolean values
- Non-numeric values
- Valid positive integer values
- Valid fractional values
- Fractional values that round down to zero

The tests only exercise autotuner initialization and pruning behavior, so they do not require GPU execution.

## Why

The main goal is to fail early and make invalid `top_k` values easier to diagnose.

Instead of allowing an invalid value to reach the pruning logic and fail later with a less useful error, the autotuner now rejects it during construction with a clear exception.