### PR TITLE
[TRITONGPU] Skip thread-local rewrite for mismatched operators

### DIFF
--- a/lib/Dialect/TritonGPU/Transforms/OptimizeThreadLocality.cpp
+++ b/lib/Dialect/TritonGPU/Transforms/OptimizeThreadLocality.cpp
@@ -1,6 +1,7 @@
 #include <memory>
 #include <numeric>
 
+#include "llvm/ADT/TypeSwitch.h"
 #include "mlir/IR/ImplicitLocOpBuilder.h"
 #include "mlir/Pass/Pass.h"
 #include "mlir/Pass/PassManager.h"
@@ -239,6 +240,20 @@ struct OptimizeGatherLayoutPattern : public mlir::OpRewritePattern<GatherOp> {
 } // namespace
 
 namespace {
+static bool hasSameReductionSemantics(Operation *reductionOp,
+                                      Operation *updateOp) {
+  auto match = [updateOp](auto typedReductionOp) {
+    using OpTy = decltype(typedReductionOp);
+    auto typedUpdateOp = dyn_cast<OpTy>(updateOp);
+    return typedUpdateOp &&
+           typedReductionOp.getProperties() == typedUpdateOp.getProperties();
+  };
+  return llvm::TypeSwitch<Operation *, bool>(reductionOp)
+      .Case<arith::AddFOp, arith::MulFOp, arith::MaximumFOp,
+            arith::MaxNumFOp, arith::MinimumFOp, arith::MinNumFOp>(match)
+      .Default(false);
+}
+
 class TritonGPUOptimizeThreadLocalityPass
     : public impl::TritonGPUOptimizeThreadLocalityBase<
           TritonGPUOptimizeThreadLocalityPass> {
@@ -259,10 +274,7 @@ class TritonGPUOptimizeThreadLocalityPass
       auto rank = srcType.getShape().size();
       auto srcEncoding = srcType.getEncoding();
       auto reductionOp = getReductionOp(reduce);
-      if (!reductionOp ||
-          !isa<arith::AddFOp, arith::MulFOp, arith::MaximumFOp,
-               arith::MaxNumFOp, arith::MinimumFOp, arith::MinNumFOp>(
-              reductionOp.value()))
+      if (!reductionOp)
         return;
       // TODO: relax this restriction
       if (!(isa<triton::gpu::BlockedEncodingAttr>(srcEncoding) && rank > 1))
@@ -284,7 +296,7 @@ class TritonGPUOptimizeThreadLocalityPass
       if (!reduce->hasOneUse())
         return;
       Operation *user = *(reduce->getUsers().begin());
-      if (user->getName() != reductionOp.value()->getName() ||
+      if (!hasSameReductionSemantics(reductionOp.value(), user) ||
           !user->hasOneUse())
         return;
       OpOperand &yieldOpOperand = *(user->getUses().begin());

--- a/lib/Dialect/TritonGPU/Transforms/OptimizeThreadLocality.cpp
+++ b/lib/Dialect/TritonGPU/Transforms/OptimizeThreadLocality.cpp
@@ -284,7 +284,8 @@ class TritonGPUOptimizeThreadLocalityPass
       if (!reduce->hasOneUse())
         return;
       Operation *user = *(reduce->getUsers().begin());
-      if (!user->hasOneUse())
+      if (user->getName() != reductionOp.value()->getName() ||
+          !user->hasOneUse())
         return;
       OpOperand &yieldOpOperand = *(user->getUses().begin());
       auto yieldOp = dyn_cast<scf::YieldOp>(yieldOpOperand.getOwner());

--- a/test/TritonGPU/optimize-locality.mlir
+++ b/test/TritonGPU/optimize-locality.mlir
@@ -593,6 +593,44 @@ module attributes {"ttg.target" = "cuda:80", "ttg.num-ctas" = 1 : i32, "ttg.num-
 
 // -----
 
+// CHECK-LABEL: mismatched_reduce_update
+// CHECK: %[[INIT_ARG:.*]] = arith.constant dense<2.000000e+00>
+// CHECK: %[[LOOP_OUTPUT:.*]] = scf.for {{.*}} iter_args(%[[FOR_ARG:.*]] = %[[INIT_ARG]]) -> {{.*}}
+// CHECK: %[[LOAD:.*]] = tt.load
+// CHECK-NOT: tt.reshape
+// CHECK: %[[REDUCE:.*]] = "tt.reduce"(%[[LOAD]]) <{axis = 1 : i32}>
+// CHECK: arith.addf
+// CHECK: %[[UPDATE:.*]] = arith.mulf %[[FOR_ARG]], %[[REDUCE]]
+// CHECK-NEXT: scf.yield %[[UPDATE]]
+// CHECK-NOT: "tt.reduce"
+// CHECK: tt.store {{.*}}, %[[LOOP_OUTPUT]]
+#blocked = #ttg.blocked<{sizePerThread = [1, 2], threadsPerWarp = [1, 32], warpsPerCTA = [4, 1], order = [1, 0]}>
+#slice = #ttg.slice<{dim = 1, parent = #blocked}>
+module attributes {"ttg.target" = "cuda:80", "ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, "ttg.threads-per-warp" = 32 : i32} {
+  tt.func public @mismatched_reduce_update(
+      %input: tensor<32x128x!tt.ptr<f32>, #blocked>,
+      %output: tensor<32x!tt.ptr<f32>, #slice>, %count: i32) {
+    %two = arith.constant dense<2.000000e+00> : tensor<32xf32, #slice>
+    %start = arith.constant 0 : i32
+    %step = arith.constant 1 : i32
+    %result = scf.for %i = %start to %count step %step
+        iter_args(%acc = %two) -> (tensor<32xf32, #slice>) : i32 {
+      %values = tt.load %input : tensor<32x128x!tt.ptr<f32>, #blocked>
+      %sum = "tt.reduce"(%values) <{axis = 1 : i32}> ({
+      ^bb0(%lhs: f32, %rhs: f32):
+        %pair = arith.addf %lhs, %rhs : f32
+        tt.reduce.return %pair : f32
+      }) : (tensor<32x128xf32, #blocked>) -> tensor<32xf32, #slice>
+      %updated = arith.mulf %acc, %sum : tensor<32xf32, #slice>
+      scf.yield %updated : tensor<32xf32, #slice>
+    }
+    tt.store %output, %result : tensor<32x!tt.ptr<f32>, #slice>
+    tt.return
+  }
+}
+
+// -----
+
 // CHECK-LABEL: remains_unchanged
 // CHECK: %[[CST:.*]] = arith.constant dense
 // CHECK: %[[LOOP_OUTPUT:.*]] = scf.for {{.*}} iter_args(%[[FOR_ARG:.*]] = %[[CST]]) -> {{.*}}

--- a/test/TritonGPU/optimize-locality.mlir
+++ b/test/TritonGPU/optimize-locality.mlir
@@ -627,6 +627,39 @@ module attributes {"ttg.target" = "cuda:80", "ttg.num-ctas" = 1 : i32, "ttg.num-
     tt.store %output, %result : tensor<32x!tt.ptr<f32>, #slice>
     tt.return
   }
+
+  // The combiner and update are both addf, but have different rounding modes.
+  // CHECK-LABEL: mismatched_reduce_properties
+  // CHECK: %[[INIT_ARG:.*]] = arith.constant dense<0.000000e+00>
+  // CHECK: %[[LOOP_OUTPUT:.*]] = scf.for {{.*}} iter_args(%[[FOR_ARG:.*]] = %[[INIT_ARG]]) -> {{.*}}
+  // CHECK: %[[LOAD:.*]] = tt.load
+  // CHECK-NOT: tt.reshape
+  // CHECK: %[[REDUCE:.*]] = "tt.reduce"(%[[LOAD]]) <{axis = 1 : i32}>
+  // CHECK: arith.addf {{.*}} downward
+  // CHECK: %[[UPDATE:.*]] = arith.addf %[[FOR_ARG]], %[[REDUCE]]
+  // CHECK-NEXT: scf.yield %[[UPDATE]]
+  // CHECK-NOT: "tt.reduce"
+  // CHECK: tt.store {{.*}}, %[[LOOP_OUTPUT]]
+  tt.func public @mismatched_reduce_properties(
+      %input: tensor<32x128x!tt.ptr<f32>, #blocked>,
+      %output: tensor<32x!tt.ptr<f32>, #slice>, %count: i32) {
+    %zero = arith.constant dense<0.000000e+00> : tensor<32xf32, #slice>
+    %start = arith.constant 0 : i32
+    %step = arith.constant 1 : i32
+    %result = scf.for %i = %start to %count step %step
+        iter_args(%acc = %zero) -> (tensor<32xf32, #slice>) : i32 {
+      %values = tt.load %input : tensor<32x128x!tt.ptr<f32>, #blocked>
+      %sum = "tt.reduce"(%values) <{axis = 1 : i32}> ({
+      ^bb0(%lhs: f32, %rhs: f32):
+        %pair = arith.addf %lhs, %rhs downward : f32
+        tt.reduce.return %pair : f32
+      }) : (tensor<32x128xf32, #blocked>) -> tensor<32xf32, #slice>
+      %updated = arith.addf %acc, %sum : tensor<32xf32, #slice>
+      scf.yield %updated : tensor<32xf32, #slice>
+    }
+    tt.store %output, %result : tensor<32x!tt.ptr<f32>, #slice>
+    tt.return
+  }
 }
 
 // -----


### PR DESCRIPTION
Only apply the thread-locality reduction rewrite when the loop update and the reduction combiner use the same operation.



The pass exchanges the loop-accumulation and cross-thread reduction order. This is valid for matching operations such as add/add or mul/mul, but not for a pattern such as:

acc = acc * reduce_add(values)