### PR TITLE
[TRITONGPU] Guard local load reordering across effects

### DIFF
--- a/lib/Dialect/TritonGPU/Transforms/ReorderInstructions.cpp
+++ b/lib/Dialect/TritonGPU/Transforms/ReorderInstructions.cpp
@@ -40,27 +40,31 @@ static bool willIncreaseRegisterPressure(Operation *op) {
   return false;
 }
 
-// Return true if it has side effects that are either unknown or writes.
-static bool hasWriteSideEffect(Operation *op) {
+// Return true if an operation may invalidate a shared-memory load moved
+// across it.
+static bool hasUnsafeMemoryEffect(Operation *op) {
   auto effects = getEffectsRecursively(op);
   if (!effects)
-    return false;
+    return true;
   return llvm::any_of(*effects, [](MemoryEffects::EffectInstance effect) {
-    return !isa<MemoryEffects::Read, MemoryEffects::Allocate,
-                MemoryEffects::Free>(effect.getEffect());
+    if (isa<MemoryEffects::Read, MemoryEffects::Allocate>(effect.getEffect()))
+      return false;
+    if (isa<SideEffects::DefaultResource>(effect.getResource()))
+      return true;
+    return !effect.getResource()->isDisjointFrom(SharedMemory::get());
   });
 }
 
-// Return true if there is a write side effect on any path between start and end
-// ops. This assumes start dominates end.
-static bool crossWriteSideEffectingOp(Operation *start, Operation *end) {
+// Return true if there is an unsafe memory effect on any path between start
+// and end. This assumes start dominates end.
+static bool crossesUnsafeMemoryEffect(Operation *start, Operation *end) {
   auto ancestor = start->getBlock()->findAncestorOpInBlock(*end);
   // Couldn't find an ancestor in the same block, conservatively assume true.
   if (!ancestor)
     return true;
   Operation *nextOp = start->getNextNode();
   while (nextOp) {
-    if ((hasWriteSideEffect(nextOp)))
+    if (hasUnsafeMemoryEffect(nextOp))
       return true;
     if (nextOp == ancestor)
       return false;
@@ -117,6 +121,9 @@ public:
       if (user_begin->getParentOfType<scf::ForOp>() ==
           op->getParentOfType<scf::ForOp>())
         return;
+      if (isa<triton::gpu::LocalLoadOp>(op) &&
+          crossesUnsafeMemoryEffect(op, *user_begin))
+        return;
       opToMove.insert({op, *user_begin});
     });
     for (auto &kv : opToMove)
@@ -165,7 +172,7 @@ public:
       // after the conversion to OpIdx=0.
       if (!dom.dominates(op.getOperation(), AOp.getOperation()))
         return;
-      if (crossWriteSideEffectingOp(op, AOp))
+      if (crossesUnsafeMemoryEffect(op, AOp))
         return;
       moveAfter(op, AOp);
     });

--- a/test/TritonGPU/reorder-instructions.mlir
+++ b/test/TritonGPU/reorder-instructions.mlir
@@ -156,3 +156,134 @@ module attributes {"ttg.num-warps" = 4 : i32, "ttg.threads-per-warp" = 32 : i32}
     tt.return
   }
 }
+
+// -----
+
+// CHECK-LABEL: do_not_sink_local_load_into_writing_loop
+//       CHECK: %[[LOADED:.*]] = ttg.local_load
+//       CHECK: scf.for
+#blocked = #ttg.blocked<{sizePerThread = [1], threadsPerWarp = [32], warpsPerCTA = [4], order = [0]}>
+#shared = #ttg.swizzled_shared<{vec = 1, perPhase = 1, maxPhase = 1, order = [0]}>
+#smem = #ttg.shared_memory
+module attributes {"ttg.num-warps" = 4 : i32, "ttg.threads-per-warp" = 32 : i32} {
+  tt.func public @do_not_sink_local_load_into_writing_loop(
+      %buffer: !ttg.memdesc<128xf32, #shared, #smem, mutable>,
+      %value: tensor<128xf32, #blocked>) {
+    %c0 = arith.constant 0 : index
+    %c1 = arith.constant 1 : index
+    %c2 = arith.constant 2 : index
+    %loaded = ttg.local_load %buffer : !ttg.memdesc<128xf32, #shared, #smem, mutable> -> tensor<128xf32, #blocked>
+    scf.for %i = %c0 to %c2 step %c1 {
+      %updated = arith.addf %loaded, %value : tensor<128xf32, #blocked>
+      ttg.local_store %updated, %buffer : tensor<128xf32, #blocked> -> !ttg.memdesc<128xf32, #shared, #smem, mutable>
+    }
+    tt.return
+  }
+}
+
+// -----
+
+// CHECK-LABEL: sink_local_load_into_loop_with_global_store
+//       CHECK: scf.for
+//       CHECK:   %[[LOADED:.*]] = ttg.local_load
+//       CHECK:   tt.store
+#blocked = #ttg.blocked<{sizePerThread = [1], threadsPerWarp = [32], warpsPerCTA = [4], order = [0]}>
+#shared = #ttg.swizzled_shared<{vec = 1, perPhase = 1, maxPhase = 1, order = [0]}>
+#smem = #ttg.shared_memory
+module attributes {"ttg.num-warps" = 4 : i32, "ttg.threads-per-warp" = 32 : i32} {
+  tt.func public @sink_local_load_into_loop_with_global_store(
+      %buffer: !ttg.memdesc<128xf32, #shared, #smem>,
+      %ptrs: tensor<128x!tt.ptr<f32>, #blocked>,
+      %value: tensor<128xf32, #blocked>) {
+    %c0 = arith.constant 0 : index
+    %c1 = arith.constant 1 : index
+    %c2 = arith.constant 2 : index
+    %loaded = ttg.local_load %buffer : !ttg.memdesc<128xf32, #shared, #smem> -> tensor<128xf32, #blocked>
+    scf.for %i = %c0 to %c2 step %c1 {
+      %sum = arith.addf %loaded, %value : tensor<128xf32, #blocked>
+      tt.store %ptrs, %sum : tensor<128x!tt.ptr<f32>, #blocked>
+    }
+    tt.return
+  }
+}
+
+// -----
+
+// CHECK-LABEL: do_not_reorder_local_load_across_dealloc
+//       CHECK: %[[B:.*]] = ttg.local_load
+//       CHECK: ttg.local_dealloc
+//       CHECK: %[[A:.*]] = ttg.local_load
+//       CHECK: tt.dot %[[A]], %[[B]]
+#blocked = #ttg.blocked<{sizePerThread = [1, 1], threadsPerWarp = [32, 1], warpsPerCTA = [1, 4], order = [0, 1]}>
+#mma = #ttg.nvidia_mma<{versionMajor = 2, versionMinor = 0, warpsPerCTA = [2, 2], instrShape = [16, 8]}>
+#shared = #ttg.swizzled_shared<{vec = 8, perPhase = 1, maxPhase = 4, order = [0, 1]}>
+#smem = #ttg.shared_memory
+module attributes {"ttg.num-warps" = 4 : i32, "ttg.threads-per-warp" = 32 : i32} {
+  tt.func public @do_not_reorder_local_load_across_dealloc(
+      %a: !ttg.memdesc<32x32xf32, #shared, #smem>,
+      %b: !ttg.memdesc<32x32xf32, #shared, #smem, mutable>) {
+    %zero = arith.constant dense<0.000000e+00> : tensor<32x32xf32, #mma>
+    %B = ttg.local_load %b : !ttg.memdesc<32x32xf32, #shared, #smem, mutable> -> tensor<32x32xf32, #ttg.dot_op<{opIdx = 1, parent = #mma, kWidth = 1}>>
+    ttg.local_dealloc %b : !ttg.memdesc<32x32xf32, #shared, #smem, mutable>
+    %A = ttg.local_load %a : !ttg.memdesc<32x32xf32, #shared, #smem> -> tensor<32x32xf32, #ttg.dot_op<{opIdx = 0, parent = #mma, kWidth = 1}>>
+    %result = tt.dot %A, %B, %zero, inputPrecision = tf32 : tensor<32x32xf32, #ttg.dot_op<{opIdx = 0, parent = #mma, kWidth = 1}>> * tensor<32x32xf32, #ttg.dot_op<{opIdx = 1, parent = #mma, kWidth = 1}>> -> tensor<32x32xf32, #mma>
+    tt.return
+  }
+}
+
+// -----
+
+// CHECK-LABEL: do_not_reorder_local_load_across_default_resource
+//       CHECK: %[[B:.*]] = ttg.local_load
+//       CHECK: tt.elementwise_inline_asm
+//       CHECK: %[[A:.*]] = ttg.local_load
+//       CHECK: tt.dot %[[A]], %[[B]]
+#blocked = #ttg.blocked<{sizePerThread = [1, 1], threadsPerWarp = [32, 1], warpsPerCTA = [1, 4], order = [0, 1]}>
+#mma = #ttg.nvidia_mma<{versionMajor = 2, versionMinor = 0, warpsPerCTA = [2, 2], instrShape = [16, 8]}>
+#shared = #ttg.swizzled_shared<{vec = 8, perPhase = 1, maxPhase = 4, order = [0, 1]}>
+#smem = #ttg.shared_memory
+module attributes {"ttg.num-warps" = 4 : i32, "ttg.threads-per-warp" = 32 : i32} {
+  tt.func public @do_not_reorder_local_load_across_default_resource(
+      %a: !ttg.memdesc<32x32xf32, #shared, #smem>,
+      %b: !ttg.memdesc<32x32xf32, #shared, #smem>,
+      %value: i32) {
+    %zero = arith.constant dense<0.000000e+00> : tensor<32x32xf32, #mma>
+    %B = ttg.local_load %b : !ttg.memdesc<32x32xf32, #shared, #smem> -> tensor<32x32xf32, #ttg.dot_op<{opIdx = 1, parent = #mma, kWidth = 1}>>
+    %asm = tt.elementwise_inline_asm "mov.b32 $0, $1;" {constraints = "=r,r", packed_element = 1 : i32, pure = false} %value : i32 -> i32
+    %A = ttg.local_load %a : !ttg.memdesc<32x32xf32, #shared, #smem> -> tensor<32x32xf32, #ttg.dot_op<{opIdx = 0, parent = #mma, kWidth = 1}>>
+    %result = tt.dot %A, %B, %zero, inputPrecision = tf32 : tensor<32x32xf32, #ttg.dot_op<{opIdx = 0, parent = #mma, kWidth = 1}>> * tensor<32x32xf32, #ttg.dot_op<{opIdx = 1, parent = #mma, kWidth = 1}>> -> tensor<32x32xf32, #mma>
+    tt.return
+  }
+}
+
+// -----
+
+// CHECK-LABEL: do_not_reorder_local_load_across_unknown_effect
+//       CHECK: %[[B:.*]] = ttg.local_load
+//       CHECK: tt.call @overwrite
+//       CHECK: %[[A:.*]] = ttg.local_load
+//       CHECK: tt.dot %[[A]], %[[B]]
+#blocked = #ttg.blocked<{sizePerThread = [1, 1], threadsPerWarp = [32, 1], warpsPerCTA = [1, 4], order = [0, 1]}>
+#mma = #ttg.nvidia_mma<{versionMajor = 2, versionMinor = 0, warpsPerCTA = [2, 2], instrShape = [16, 8]}>
+#shared = #ttg.swizzled_shared<{vec = 8, perPhase = 1, maxPhase = 4, order = [0, 1]}>
+#smem = #ttg.shared_memory
+module attributes {"ttg.num-warps" = 4 : i32, "ttg.threads-per-warp" = 32 : i32} {
+  tt.func private @overwrite(
+      %buffer: !ttg.memdesc<32x32xf32, #shared, #smem, mutable>,
+      %value: tensor<32x32xf32, #blocked>) {
+    ttg.local_store %value, %buffer : tensor<32x32xf32, #blocked> -> !ttg.memdesc<32x32xf32, #shared, #smem, mutable>
+    tt.return
+  }
+
+  tt.func public @do_not_reorder_local_load_across_unknown_effect(
+      %a: !ttg.memdesc<32x32xf32, #shared, #smem>,
+      %b: !ttg.memdesc<32x32xf32, #shared, #smem, mutable>,
+      %value: tensor<32x32xf32, #blocked>) {
+    %zero = arith.constant dense<0.000000e+00> : tensor<32x32xf32, #mma>
+    %B = ttg.local_load %b : !ttg.memdesc<32x32xf32, #shared, #smem, mutable> -> tensor<32x32xf32, #ttg.dot_op<{opIdx = 1, parent = #mma, kWidth = 1}>>
+    tt.call @overwrite(%b, %value) : (!ttg.memdesc<32x32xf32, #shared, #smem, mutable>, tensor<32x32xf32, #blocked>) -> ()
+    %A = ttg.local_load %a : !ttg.memdesc<32x32xf32, #shared, #smem> -> tensor<32x32xf32, #ttg.dot_op<{opIdx = 0, parent = #mma, kWidth = 1}>>
+    %result = tt.dot %A, %B, %zero, inputPrecision = tf32 : tensor<32x32xf32, #ttg.dot_op<{opIdx = 0, parent = #mma, kWidth = 1}>> * tensor<32x32xf32, #ttg.dot_op<{opIdx = 1, parent = #mma, kWidth = 1}>> -> tensor<32x32xf32, #mma>
+    tt.return
+  }
+}


### PR DESCRIPTION
## Summary

- Prevent local loads from moving across loops or operations that may write, deallocate, or have unknown effects on the relevant memory.
- Preserve reordering across effects proven safe or disjoint.

## Why

The old ordering logic could move a local load across a write or deallocation and make it observe the wrong shared-memory state.

## Tests

- `MAX_JOBS=2 make`
- `lit -v test/TritonGPU/reorder-instructions.mlir`
- The effect-ordering regressions fail on the parent revision and pass with this change.
