### PR TITLE
[FRONTEND] Normalize while conditions to i1

### DIFF
--- a/python/test/unit/language/test_frontend.py
+++ b/python/test/unit/language/test_frontend.py
@@ -624,6 +624,19 @@ def test_call_in_while():
             trivial_return()
 
 
+@filecheck_test
+@triton.jit
+def test_while_integer_condition():
+    # CHECK-LABEL: test_while_integer_condition
+    i = tl.program_id(0)
+    # CHECK: scf.while
+    # CHECK: [[COND:%.*]] = arith.cmpi ne, %{{.*}}, %{{.*}} : i32
+    # CHECK: scf.condition([[COND]])
+    while i:
+        i -= 1
+    anchor(i)
+
+
 def test_return_in_while():
 
     @triton.jit

--- a/python/triton/compiler/code_generator.py
+++ b/python/triton/compiler/code_generator.py
@@ -1202,6 +1202,8 @@ class CodeGenerator(ast.NodeVisitor):
                 if cond.disable_licm:
                     while_op.set_attr("llvm.loop_annotation", self.builder.get_disable_loop_licm_attr())
                 cond = cond.condition
+            if _is_triton_tensor(cond):
+                cond = cond.to(language.int1, _semantic=self.semantic)
             self.builder.set_insertion_point_to_end(before_block)
             # create ConditionOp: e.g., scf.condition(%cond) %arg0, %arg1, ...
             self.builder.create_condition_op(cond.handle, block_args)


### PR DESCRIPTION
## Summary

Convert dynamic Triton `while` conditions to scalar `i1` values before creating `scf.condition`.

## Why

A numeric condition written through ordinary Triton Python could produce invalid SCF IR:

```python
i = tl.program_id(0)
while i:
    i -= 1
```

Previously, the `i32` value was passed directly to `scf.condition`, which requires a scalar `i1`. This change applies Python truthiness as `i != 0` before creating the condition operation.

## Tests

- `python/test/unit/language/test_frontend.py::test_while_integer_condition`
