### PR TITLE
[Triton] Preserve load/store attributes when folding masks

### DIFF
--- a/lib/Dialect/Triton/IR/Ops.cpp
+++ b/lib/Dialect/Triton/IR/Ops.cpp
@@ -81,9 +81,10 @@ struct CanonicalizeMaskedLoadPattern : public OpRewritePattern<LoadOp> {
 
     if (splatMask.getSplatValue<IntegerAttr>().getValue() == true) {
       // mask = splat(1)
-      rewriter.replaceOpWithNewOp<LoadOp>(
-          loadOp, loadOp.getType(), loadOp.getPtr(), Value(), Value(),
-          loadOp.getCache(), loadOp.getEvict(), loadOp.getIsVolatile());
+      rewriter.modifyOpInPlace(loadOp, [&] {
+        loadOp.getMaskMutable().clear();
+        loadOp.getOtherMutable().clear();
+      });
     } else {
       // mask = splat(0)
 
@@ -137,9 +138,8 @@ struct CanonicalizeMaskedStorePattern : public OpRewritePattern<StoreOp> {
 
     if (splatMask.getSplatValue<IntegerAttr>().getValue() == true) {
       // mask = splat(1)
-      rewriter.replaceOpWithNewOp<StoreOp>(
-          storeOp, storeOp.getPtr(), storeOp.getValue(), storeOp.getCache(),
-          storeOp.getEvict());
+      rewriter.modifyOpInPlace(storeOp,
+                               [&] { storeOp.getMaskMutable().clear(); });
     } else {
       // mask = splat(0)
       rewriter.eraseOp(storeOp);

--- a/test/Triton/combine.mlir
+++ b/test/Triton/combine.mlir
@@ -261,13 +261,13 @@ tt.func @test_canonicalize_masked_load_pattern(%ptr: tensor<8x!tt.ptr<f32>>) -> 
     %false_mask = arith.constant dense<false> : tensor<8xi1>
     %other_val = arith.constant dense<0.0> : tensor<8xf32>
 
-    // true_mask with other
+    // true_mask without other
     // CHECK: %[[res1:.*]] = tt.load %{{.*}} : tensor<8x!tt.ptr<f32>>
     %x = tt.load %ptr, %true_mask : tensor<8x!tt.ptr<f32>>
 
-    // true_mask without other
-    // CHECK: %[[res2:.*]] = tt.load %{{.*}} : tensor<8x!tt.ptr<f32>>
-    %y = tt.load %ptr, %true_mask, %other_val : tensor<8x!tt.ptr<f32>>
+    // true_mask with other
+    // CHECK: %[[res2:.*]] = tt.load %{{.*}} {loop.cluster = 2 : i32, loop.stage = 0 : i32} : tensor<8x!tt.ptr<f32>>
+    %y = tt.load %ptr, %true_mask, %other_val {loop.cluster = 2 : i32, loop.stage = 0 : i32} : tensor<8x!tt.ptr<f32>>
 
     // false_mask with other. It should become "other" (i.e., %y)
     %z = tt.load %ptr, %false_mask, %y : tensor<8x!tt.ptr<f32>>
@@ -294,8 +294,8 @@ tt.func @test_canonicalize_masked_store_pattern(%ptr: tensor<8x!tt.ptr<f32>>, %v
     %true_mask = arith.constant dense<true> : tensor<8xi1>
     %false_mask = arith.constant dense<false> : tensor<8xi1>
 
-    // CHECK: tt.store %{{.*}}, %{{.*}} : tensor<8x!tt.ptr<f32>>
-    tt.store %ptr, %val, %true_mask : tensor<8x!tt.ptr<f32>>
+    // CHECK: tt.store %{{.*}}, %{{.*}} {ignore_cta} : tensor<8x!tt.ptr<f32>>
+    tt.store %ptr, %val, %true_mask {ignore_cta} : tensor<8x!tt.ptr<f32>>
 
     // The following store should disappear.
     // CHECK-NEXT: tt.return


### PR DESCRIPTION
## Summary

- Fold all-true load/store masks by clearing optional operands in place.
- Preserve operation attributes such as load scheduling metadata and store `ignore_cta`.

## Why

Rebuilding the memory operation during canonicalization silently dropped non-builder attributes.

## Tests

- `MAX_JOBS=2 make`
- `lit -v test/Triton/combine.mlir`
- `lit -v test/Triton/canonicalize.mlir`
- The load/store attribute checks fail on the parent revision and pass with this change.
