### PR TITLE
[Triton] Preserve packed inline asm in broadcast reordering

### DIFF
--- a/lib/Dialect/Triton/Transforms/ReorderBroadcast.cpp
+++ b/lib/Dialect/Triton/Transforms/ReorderBroadcast.cpp
@@ -35,6 +35,16 @@ bool isSplat(Operation *op) {
   return (matchPattern(op, m_Constant(&constAttr)) && constAttr.isSplat());
 }
 
+bool canShrinkElementwiseOp(Operation *op) {
+  if (!isMemoryEffectFree(op))
+    return false;
+
+  // Packed inline asm consumes elements as a group, so shrinking its operands
+  // changes the inputs to each invocation.
+  auto inlineAsm = dyn_cast<ElementwiseInlineAsmOp>(op);
+  return !inlineAsm || inlineAsm.getPackedElement() == 1;
+}
+
 // elementwise(splat(a), splat(b), ...) => splat(elementwise(a, b, ...))
 struct MoveSplatAfterElementwisePattern
     : public OpTraitRewritePattern<OpTrait::Elementwise> {
@@ -44,7 +54,7 @@ struct MoveSplatAfterElementwisePattern
 
   LogicalResult matchAndRewrite(Operation *op,
                                 PatternRewriter &rewriter) const override {
-    if (!isMemoryEffectFree(op)) {
+    if (!canShrinkElementwiseOp(op)) {
       return failure();
     }
 
@@ -111,7 +121,7 @@ struct MoveBroadcastAfterElementwisePattern
 
   LogicalResult matchAndRewrite(Operation *op,
                                 PatternRewriter &rewriter) const override {
-    if (!isMemoryEffectFree(op)) {
+    if (!canShrinkElementwiseOp(op)) {
       return failure();
     }
 

--- a/test/Triton/reorder-broadcast.mlir
+++ b/test/Triton/reorder-broadcast.mlir
@@ -65,3 +65,33 @@ tt.func @test_broadcast_mix_type_op_pattern(%arg0: tensor<128x1xf32>, %arg1: f32
 
     tt.return %sel : tensor<128x128xf32>
 }
+
+// CHECK-LABEL: @do_not_move_splat_after_packed_inline_asm
+tt.func @do_not_move_splat_after_packed_inline_asm(%arg0: i8) -> tensor<4xi8> {
+    // CHECK: %[[SPLAT:.*]] = tt.splat %arg0 : i8 -> tensor<4xi8>
+    // CHECK-NEXT: %[[ASM:.*]] = tt.elementwise_inline_asm "mov.b32 $0, $1;" {constraints = "=r,r", packed_element = 4 : i32, pure = true} %[[SPLAT]] : tensor<4xi8> -> tensor<4xi8>
+    // CHECK-NEXT: tt.return %[[ASM]] : tensor<4xi8>
+    %splat = tt.splat %arg0 : i8 -> tensor<4xi8>
+    %asm = tt.elementwise_inline_asm "mov.b32 $0, $1;" {constraints = "=r,r", packed_element = 4 : i32, pure = true} %splat : tensor<4xi8> -> tensor<4xi8>
+    tt.return %asm : tensor<4xi8>
+}
+
+// CHECK-LABEL: @do_not_move_broadcast_after_packed_inline_asm
+tt.func @do_not_move_broadcast_after_packed_inline_asm(%arg0: tensor<1xi8>) -> tensor<4xi8> {
+    // CHECK: %[[BROADCAST:.*]] = tt.broadcast %arg0 : tensor<1xi8> -> tensor<4xi8>
+    // CHECK-NEXT: %[[ASM:.*]] = tt.elementwise_inline_asm "mov.b32 $0, $1;" {constraints = "=r,r", packed_element = 4 : i32, pure = true} %[[BROADCAST]] : tensor<4xi8> -> tensor<4xi8>
+    // CHECK-NEXT: tt.return %[[ASM]] : tensor<4xi8>
+    %broadcast = tt.broadcast %arg0 : tensor<1xi8> -> tensor<4xi8>
+    %asm = tt.elementwise_inline_asm "mov.b32 $0, $1;" {constraints = "=r,r", packed_element = 4 : i32, pure = true} %broadcast : tensor<4xi8> -> tensor<4xi8>
+    tt.return %asm : tensor<4xi8>
+}
+
+// CHECK-LABEL: @move_splat_after_unpacked_inline_asm
+tt.func @move_splat_after_unpacked_inline_asm(%arg0: i8) -> tensor<4xi8> {
+    // CHECK: %[[ASM:.*]] = tt.elementwise_inline_asm "mov.b32 $0, $1;" {constraints = "=r,r", packed_element = 1 : i32, pure = true} %arg0 : i8 -> i8
+    // CHECK-NEXT: %[[SPLAT:.*]] = tt.splat %[[ASM]] : i8 -> tensor<4xi8>
+    // CHECK-NEXT: tt.return %[[SPLAT]] : tensor<4xi8>
+    %splat = tt.splat %arg0 : i8 -> tensor<4xi8>
+    %asm = tt.elementwise_inline_asm "mov.b32 $0, $1;" {constraints = "=r,r", packed_element = 1 : i32, pure = true} %splat : tensor<4xi8> -> tensor<4xi8>
+    tt.return %asm : tensor<4xi8>
+}


### PR DESCRIPTION
## Summary

- Do not shrink `tt.elementwise_inline_asm` through splat/broadcast reordering when `packed_element > 1`.
- Preserve the existing optimization for `packed_element = 1`.

## Why

Packed inline asm consumes elements as a group. Shrinking its operands changes invocation semantics and can also create verifier-invalid IR.

## Tests

- `MAX_JOBS=2 make`
- `lit -v test/Triton/reorder-broadcast.mlir`
- The parent revision fails verification because one input element is not a multiple of `packed_element = 4`; this change passes.
