### PR TITLE
[AMD] Guard extract-slice concat canonicalization

### DIFF
--- a/test/Conversion/amd/invalid_extractslice_to_llvm.mlir
+++ b/test/Conversion/amd/invalid_extractslice_to_llvm.mlir
@@ -35,6 +35,18 @@ module attributes {"ttg.compute-capability" = 0 : i32, "ttg.num-ctas" = 1 : i32,
 
 // -----
 
+// Invalid negative offset
+#blocked1 = #ttg.blocked<{sizePerThread = [8, 1], threadsPerWarp = [4, 16], warpsPerCTA = [8, 1], order = [1, 0]}>
+module attributes {"ttg.compute-capability" = 0 : i32, "ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 8 : i32, "ttg.threads-per-warp" = 64 : i32} {
+  tt.func @negative_offset(%arg0: tensor<256x128xi32, #blocked1> {tt.divisibility = 16 : i32}) {
+    // expected-error @+1 {{offset must be non-negative at dimension 0}}
+    %1 = amdg.extract_slice %arg0 [-1,0] : tensor<256x128xi32, #blocked1> to tensor<256x16xi32, #blocked1>
+    tt.return
+  }
+}
+
+// -----
+
 // Invalid result layout
 #blocked1 = #ttg.blocked<{sizePerThread = [8, 1], threadsPerWarp = [4, 16], warpsPerCTA = [8, 1], order = [1, 0]}>
 #blocked2 = #ttg.blocked<{sizePerThread = [4, 1], threadsPerWarp = [4, 16], warpsPerCTA = [8, 1], order = [1, 0]}>

--- a/test/TritonGPU/amd/amd-canonicalize-extract-slice.mlir
+++ b/test/TritonGPU/amd/amd-canonicalize-extract-slice.mlir
@@ -27,6 +27,24 @@ module attributes {"ttg.compute-capability" = 0 : i32, "ttg.num-ctas" = 1 : i32,
 
 #blocked = #ttg.blocked<{sizePerThread = [1, 8], threadsPerWarp = [8, 8], warpsPerCTA = [4, 1], order = [1, 0]}>
 module attributes {"ttg.compute-capability" = 0 : i32, "ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, "ttg.threads-per-warp" = 64 : i32} {
+  tt.func @do_not_canonicalize_cross_operand_slice(
+    %arg0: tensor<64x64xf32, #blocked>,
+    %arg1: tensor<64x64xf32, #blocked>) -> tensor<64x64xf32, #blocked> {
+    // CHECK-LABEL: tt.func @do_not_canonicalize_cross_operand_slice
+    // CHECK: %[[CONCAT:.*]] = amdg.concat %arg0, %arg1
+    // CHECK: %[[SLICE:.*]] = amdg.extract_slice %[[CONCAT]] [32, 0]
+    // CHECK: tt.return %[[SLICE]] : tensor<64x64xf32, #blocked>
+
+    %concat = amdg.concat %arg0, %arg1 : tensor<64x64xf32, #blocked>, tensor<64x64xf32, #blocked> -> tensor<128x64xf32, #blocked>
+    %slice = amdg.extract_slice %concat [32, 0] : tensor<128x64xf32, #blocked> to tensor<64x64xf32, #blocked>
+    tt.return %slice : tensor<64x64xf32, #blocked>
+  }
+}
+
+// -----
+
+#blocked = #ttg.blocked<{sizePerThread = [1, 8], threadsPerWarp = [8, 8], warpsPerCTA = [4, 1], order = [1, 0]}>
+module attributes {"ttg.compute-capability" = 0 : i32, "ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, "ttg.threads-per-warp" = 64 : i32} {
   tt.func @canonicalize_singleton_concat(%arg0: tensor<128x128xf32, #blocked>) -> tensor<128x128xf32, #blocked> {
     // CHECK-LABEL: tt.func @canonicalize_singleton_concat
 

--- a/third_party/amd/lib/Dialect/TritonAMDGPU/IR/Dialect.cpp
+++ b/third_party/amd/lib/Dialect/TritonAMDGPU/IR/Dialect.cpp
@@ -438,6 +438,10 @@ struct CanonicalizeExtractSliceAndConcat
     // Calculate which concat operand contains our slice
     auto srcShape = concatItemType.getShape();
     auto rank = srcShape.size();
+    for (auto [dimOffset, dimSize] : llvm::zip_equal(offset, srcShape)) {
+      if (dimOffset < 0 || dimOffset % dimSize != 0)
+        return failure();
+    }
     std::vector<unsigned> defaultOrder(rank);
     std::iota(defaultOrder.rbegin(), defaultOrder.rend(), 0);
 

--- a/third_party/amd/lib/Dialect/TritonAMDGPU/IR/Dialect.cpp
+++ b/third_party/amd/lib/Dialect/TritonAMDGPU/IR/Dialect.cpp
@@ -343,6 +343,8 @@ LogicalResult ExtractSliceOp::verify() {
   };
 
   for (size_t i = 0; i < rank; ++i) {
+    if (offsets[i] < 0)
+      return failDim("offset must be non-negative", i);
     if (dstShape[i] > srcShape[i])
       return failDim("result shape cannot exceed source shape", i);
     if (offsets[i] + dstShape[i] > srcShape[i])
@@ -439,7 +441,7 @@ struct CanonicalizeExtractSliceAndConcat
     auto srcShape = concatItemType.getShape();
     auto rank = srcShape.size();
     for (auto [dimOffset, dimSize] : llvm::zip_equal(offset, srcShape)) {
-      if (dimOffset < 0 || dimOffset % dimSize != 0)
+      if (dimOffset % dimSize != 0)
         return failure();
     }
     std::vector<unsigned> defaultOrder(rank);


### PR DESCRIPTION
## Summary

- Fold `amdg.extract_slice(amdg.concat(...))` only when every offset is aligned to a complete concat operand.
- Reject negative `amdg.extract_slice` offsets in the operation verifier.

## Why

The previous canonicalization floor-divided offsets without checking alignment, so a slice spanning two operands could be incorrectly replaced with one whole input tensor.

Negative offsets are invalid for every `amdg.extract_slice`, so they are rejected by the verifier rather than handled only by this canonicalization pattern.

## Tests

- `lit -v test/TritonGPU/amd/amd-canonicalize-extract-slice.mlir`
- `lit -v test/Conversion/amd/invalid_extractslice_to_llvm.mlir`
