### PR TITLE
[Triton] Preserve volatile loads in select combining

### DIFF
--- a/lib/Dialect/Triton/Transforms/Combine.cpp
+++ b/lib/Dialect/Triton/Transforms/Combine.cpp
@@ -1,4 +1,5 @@
 #include "mlir/IR/BuiltinAttributes.h"
+#include "mlir/IR/Dominance.h"
 #include "mlir/IR/Matchers.h"
 #include "mlir/IR/PatternMatch.h"
 #include "mlir/Pass/Pass.h"
@@ -100,9 +101,21 @@ public:
     if (splatCond != condSelect)
       return failure();
 
-    rewriter.replaceOpWithNewOp<LoadOp>(
-        op, loadOp.getPtr(), loadOp.getMask(), /*other=*/falseValue,
-        loadOp.getCache(), loadOp.getEvict(), loadOp.getIsVolatile());
+    // Fold the select into the load's `other` by updating the load in place:
+    // replace its `other` operand with the select's false value and drop the
+    // select. Only do this when the load feeds only this select, so we never
+    // create a second load -- building a fresh load would duplicate the memory
+    // access (illegal for a volatile load, and redundant when the load has
+    // other users, e.g. the false value depends on the load). The update also
+    // requires the false value to dominate the load, since it becomes one of
+    // the load's operands.
+    if (!loadOp.getResult().hasOneUse() ||
+        !DominanceInfo().properlyDominates(falseValue, loadOp))
+      return failure();
+
+    rewriter.modifyOpInPlace(
+        loadOp, [&] { loadOp.getOtherMutable().assign(falseValue); });
+    rewriter.replaceOp(op, loadOp.getResult());
     return success();
   }
 };

--- a/test/Triton/combine.mlir
+++ b/test/Triton/combine.mlir
@@ -233,6 +233,82 @@ tt.func @test_combine_select_masked_load_pattern(%ptr: tensor<8x!tt.ptr<f32>>, %
     tt.return %0, %1 : tensor<8xf32>, tensor<8xf32>
 }
 
+// A volatile load with a single user is combined in place: the select is
+// removed and the volatile load's `other` is replaced with the false value, so
+// the read still happens exactly once.
+// CHECK-LABEL: @test_combine_select_volatile_masked_load_single_use
+tt.func @test_combine_select_volatile_masked_load_single_use(%ptr: tensor<8x!tt.ptr<f32>>, %cond: i1, %old_other: tensor<8xf32>, %false_value: tensor<8xf32>) -> tensor<8xf32> {
+    // CHECK: %[[MASK:.*]] = tt.splat %{{.*}} : i1 -> tensor<8xi1>
+    // CHECK-NEXT: %[[LOAD:.*]] = tt.load %{{.*}}, %[[MASK]], %arg3 {isVolatile = true} : tensor<8x!tt.ptr<f32>>
+    // CHECK-NOT: arith.select
+    // CHECK-NEXT: tt.return %[[LOAD]] : tensor<8xf32>
+    %mask = tt.splat %cond : i1 -> tensor<8xi1>
+    %load = tt.load %ptr, %mask, %old_other {isVolatile = true} : tensor<8x!tt.ptr<f32>>
+    %select = arith.select %cond, %load, %false_value : tensor<8xf32>
+    tt.return %select : tensor<8xf32>
+}
+
+// A volatile load with more than one user is not combined: rewriting would
+// build a second volatile load and read the memory twice.
+// CHECK-LABEL: @test_not_combine_select_volatile_masked_load_multi_use
+tt.func @test_not_combine_select_volatile_masked_load_multi_use(%ptr: tensor<8x!tt.ptr<f32>>, %cond: i1, %old_other: tensor<8xf32>, %false_value: tensor<8xf32>) -> (tensor<8xf32>, tensor<8xf32>) {
+    // CHECK: %[[LOAD:.*]] = tt.load %{{.*}}, %{{.*}}, %{{.*}} {isVolatile = true} : tensor<8x!tt.ptr<f32>>
+    // CHECK-NEXT: %[[SELECT:.*]] = arith.select %{{.*}}, %[[LOAD]], %{{.*}} : tensor<8xf32>
+    // CHECK-NEXT: tt.return %[[SELECT]], %[[LOAD]] : tensor<8xf32>, tensor<8xf32>
+    %mask = tt.splat %cond : i1 -> tensor<8xi1>
+    %load = tt.load %ptr, %mask, %old_other {isVolatile = true} : tensor<8x!tt.ptr<f32>>
+    %select = arith.select %cond, %load, %false_value : tensor<8xf32>
+    tt.return %select, %load : tensor<8xf32>, tensor<8xf32>
+}
+
+// A volatile load cannot be updated in place when the false value is defined
+// after it (using it as the load's `other` would not dominate the load), and it
+// cannot be duplicated either, so it is left unchanged.
+// CHECK-LABEL: @test_not_combine_select_volatile_masked_load_false_after
+tt.func @test_not_combine_select_volatile_masked_load_false_after(%ptr: tensor<8x!tt.ptr<f32>>, %cond: i1, %old_other: tensor<8xf32>) -> tensor<8xf32> {
+    // CHECK: %[[LOAD:.*]] = tt.load %{{.*}}, %{{.*}}, %{{.*}} {isVolatile = true} : tensor<8x!tt.ptr<f32>>
+    // CHECK-NEXT: %[[FV:.*]] = arith.negf
+    // CHECK-NEXT: %[[SELECT:.*]] = arith.select %{{.*}}, %[[LOAD]], %[[FV]] : tensor<8xf32>
+    // CHECK-NEXT: tt.return %[[SELECT]] : tensor<8xf32>
+    %mask = tt.splat %cond : i1 -> tensor<8xi1>
+    %load = tt.load %ptr, %mask, %old_other {isVolatile = true} : tensor<8x!tt.ptr<f32>>
+    %false_value = arith.negf %old_other : tensor<8xf32>
+    %select = arith.select %cond, %load, %false_value : tensor<8xf32>
+    tt.return %select : tensor<8xf32>
+}
+
+// A load whose false value is defined after it is left unchanged: the false
+// value does not dominate the load, so it cannot become the load's operand, and
+// combining is only done in place (never by creating a second load).
+// CHECK-LABEL: @test_not_combine_select_masked_load_false_after
+tt.func @test_not_combine_select_masked_load_false_after(%ptr: tensor<8x!tt.ptr<f32>>, %cond: i1, %old_other: tensor<8xf32>) -> tensor<8xf32> {
+    // CHECK: %[[LOAD:.*]] = tt.load %{{.*}}, %{{.*}}, %{{.*}} : tensor<8x!tt.ptr<f32>>
+    // CHECK-NEXT: %[[FV:.*]] = arith.negf
+    // CHECK-NEXT: %[[SELECT:.*]] = arith.select %{{.*}}, %[[LOAD]], %[[FV]] : tensor<8xf32>
+    // CHECK-NEXT: tt.return %[[SELECT]] : tensor<8xf32>
+    %mask = tt.splat %cond : i1 -> tensor<8xi1>
+    %load = tt.load %ptr, %mask, %old_other : tensor<8x!tt.ptr<f32>>
+    %false_value = arith.negf %old_other : tensor<8xf32>
+    %select = arith.select %cond, %load, %false_value : tensor<8xf32>
+    tt.return %select : tensor<8xf32>
+}
+
+// When the false value depends on the load, the load necessarily has more than
+// one user, so it is left unchanged: an in-place update is not possible and a
+// fresh load would duplicate the access.
+// CHECK-LABEL: @test_not_combine_select_masked_load_false_depends_on_load
+tt.func @test_not_combine_select_masked_load_false_depends_on_load(%ptr: tensor<8x!tt.ptr<f32>>, %cond: i1, %old_other: tensor<8xf32>) -> tensor<8xf32> {
+    // CHECK: %[[LOAD:.*]] = tt.load %{{.*}}, %{{.*}}, %{{.*}} : tensor<8x!tt.ptr<f32>>
+    // CHECK-NEXT: %[[FV:.*]] = arith.negf %[[LOAD]]
+    // CHECK-NEXT: %[[SELECT:.*]] = arith.select %{{.*}}, %[[LOAD]], %[[FV]] : tensor<8xf32>
+    // CHECK-NEXT: tt.return %[[SELECT]] : tensor<8xf32>
+    %mask = tt.splat %cond : i1 -> tensor<8xi1>
+    %load = tt.load %ptr, %mask, %old_other : tensor<8x!tt.ptr<f32>>
+    %false_value = arith.negf %load : tensor<8xf32>
+    %select = arith.select %cond, %load, %false_value : tensor<8xf32>
+    tt.return %select : tensor<8xf32>
+}
+
 // CHECK-LABEL: @test_combine_select_masked_load_fail_pattern
 tt.func @test_combine_select_masked_load_fail_pattern(%ptr: tensor<8x!tt.ptr<f32>>, %dummy_load: tensor<8xf32>, %dummy_broadcast: tensor<8xi1>, %cond0: i1, %cond1: i1) -> (tensor<8xf32>, tensor<8xf32>, tensor<8xf32>) {
     %false_val = arith.constant dense<0.0> : tensor<8xf32>


### PR DESCRIPTION
A regular unused load can be removed, but a volatile load must remain. As a result, the old code produced two volatile reads instead of one and returned the value from the second read.