### PR TITLE
[AMD] Preserve layout-changing singleton concats

### DIFF
--- a/test/TritonGPU/amd/amd-canonicalize-extract-slice.mlir
+++ b/test/TritonGPU/amd/amd-canonicalize-extract-slice.mlir
@@ -35,3 +35,18 @@ module attributes {"ttg.compute-capability" = 0 : i32, "ttg.num-ctas" = 1 : i32,
     tt.return %1 : tensor<128x128xf32, #blocked>
   }
 }
+
+// -----
+
+#src = #ttg.linear<{register = [[1], [128]], lane = [[2], [4], [8], [16], [32], [64]], warp = [], block = []}>
+#dst = #ttg.linear<{register = [[128], [1]], lane = [[2], [4], [8], [16], [32], [64]], warp = [], block = []}>
+module attributes {"ttg.compute-capability" = 0 : i32, "ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 1 : i32, "ttg.threads-per-warp" = 64 : i32} {
+  tt.func @do_not_canonicalize_singleton_concat_layout_change(%arg0: tensor<256xi32, #src>) -> tensor<256xi32, #dst> {
+    // CHECK-LABEL: tt.func @do_not_canonicalize_singleton_concat_layout_change
+    // CHECK: %[[CONCAT:.*]] = amdg.concat %arg0
+    // CHECK: tt.return %[[CONCAT]]
+
+    %concat = amdg.concat %arg0 : tensor<256xi32, #src> -> tensor<256xi32, #dst>
+    tt.return %concat : tensor<256xi32, #dst>
+  }
+}

--- a/third_party/amd/lib/Dialect/TritonAMDGPU/IR/Dialect.cpp
+++ b/third_party/amd/lib/Dialect/TritonAMDGPU/IR/Dialect.cpp
@@ -798,13 +798,15 @@ LogicalResult LocalLoadPackedTransposedOp::verify() {
 static mlir::LogicalResult
 foldConcatOpFromSingleSource(amdgpu::ConcatOp op, PatternRewriter &rewriter) {
   auto sources = op.getSources();
-  if (sources.size() == 1) {
-    auto source = sources.front();
-    auto result = op.getResult();
-    result.replaceAllUsesWith(source);
-    return success();
-  }
-  return failure();
+  if (sources.size() != 1)
+    return failure();
+
+  auto source = sources.front();
+  if (source.getType() != op.getResult().getType())
+    return failure();
+
+  rewriter.replaceOp(op, source);
+  return success();
 }
 
 void ConcatOp::getCanonicalizationPatterns(mlir::RewritePatternSet &patterns,


### PR DESCRIPTION
## Summary

- Fold a singleton `amdg.concat` only when its source and result tensor types are identical.
- Use the pattern rewriter to replace and erase the identity concat.

## Why

A singleton concat with different register layouts performs a real register permutation. Replacing it directly with the source both loses that permutation and creates type-invalid IR.

## Tests

- `MAX_JOBS=2 make`
- `lit -v test/TritonGPU/amd/amd-canonicalize-extract-slice.mlir`
- The parent revision fails with a source/result layout type mismatch; this change passes.
