### PR TITLE
[FRONTEND] Reject zero step in tl.range

### DIFF
--- a/python/test/unit/language/test_compile_errors.py
+++ b/python/test/unit/language/test_compile_errors.py
@@ -602,3 +602,20 @@ def test_err_histogram_non_32bit_int(ptr_ty):
             triton.compiler.ASTSource(fn=kernel, signature={"x_ptr": ptr_ty, "z_ptr": "*i32", "N": "constexpr"},
                                       constexprs={"N": 4}))
     assert "histogram only supports 32-bit integer input" in str(e.value.__cause__)
+
+
+def test_err_range_zero_step():
+
+    @triton.jit
+    def kernel(ptr, STEP: tl.constexpr):
+        acc = 0
+        for i in tl.range(0, 10, STEP):
+            acc += 1
+        tl.store(ptr, acc)
+
+    with pytest.raises(CompilationError) as e:
+        triton.compile(
+            triton.compiler.ASTSource(fn=kernel, signature={"ptr": "*i32"}, constexprs={"STEP": 0}))
+
+    err_msg = format_exception(e.type, value=e.value, tb=e.tb)
+    assert "must not be zero" in err_msg, "error should explain the zero step"

--- a/python/triton/compiler/code_generator.py
+++ b/python/triton/compiler/code_generator.py
@@ -1298,7 +1298,7 @@ class CodeGenerator(ast.NodeVisitor):
             raise RuntimeError('Only `range` and `static_range` iterators are currently supported')
 
         if _is_constexpr(step) and step.value == 0:
-            raise ValueError("tl.range() arg 3 (step) must not be zero")
+            raise ValueError("range() arg 3 (step) must not be zero")
         # handle negative constant step (not supported by scf.for in MLIR).
         # Only a constexpr step can be normalized here; a runtime step must be positive.
         negative_step = False

--- a/python/triton/compiler/code_generator.py
+++ b/python/triton/compiler/code_generator.py
@@ -1296,6 +1296,9 @@ class CodeGenerator(ast.NodeVisitor):
             step = iter_args[2] if len(iter_args) > 2 else self.visit(ast.Constant(1))
         else:
             raise RuntimeError('Only `range` and `static_range` iterators are currently supported')
+
+        if _is_constexpr(step) and step.value == 0:
+            raise ValueError("tl.range() arg 3 (step) must not be zero")
         # handle negative constant step (not supported by scf.for in MLIR).
         # Only a constexpr step can be normalized here; a runtime step must be positive.
         negative_step = False


### PR DESCRIPTION
 `tl.range` with 0 step lowers to an `scf.for`, an infinite loop that hangs the GPU with no error.