### PR TITLE
Add SM120/SM121 Gluon translation support.

### DIFF
--- a/lib/Dialect/TritonGPU/IR/LinearLayoutConversions.cpp
+++ b/lib/Dialect/TritonGPU/IR/LinearLayoutConversions.cpp
@@ -1539,6 +1539,8 @@ LinearLayout getSM120DotScaledScaleLayout(MLIRContext *ctx,
                                           ArrayRef<unsigned> warpsPerCTA,
                                           CGAEncodingAttr cgaLayout) {
   unsigned rank = shape.size();
+  assert((rank == 2 || rank == 3) && "scaled dot expects rank-2 or rank-3");
+  assert(warpsPerCTA.size() == rank && "warp layout must match operand rank");
   auto outDims = standardOutDimNames(ctx, rank);
   StringAttr kRegister = StringAttr::get(ctx, "register");
   StringAttr kLane = StringAttr::get(ctx, "lane");
@@ -1547,25 +1549,34 @@ LinearLayout getSM120DotScaledScaleLayout(MLIRContext *ctx,
   // - B: [K, N]
   // - aScale: [M, K / K_GROUP_SIZE]
   // - bScale: [N, K / K_GROUP_SIZE]
-  const unsigned kIdx = 1;
-  const unsigned mnIdx = 0;
+  const unsigned kIdx = rank - 1;
+  const unsigned mnIdx = rank - 2;
 
-  std::vector<std::vector<int32_t>> laneBase;
-  SmallVector<unsigned> order;
-  SmallVector<unsigned> mmaWarpsPerCTA;
-  if (opIdx == 0) {
-    laneBase = {{8, 0}, {0, 0}, {1, 0}, {2, 0}, {4, 0}};
-    order = SmallVector<unsigned>{1u, 0u};
-    mmaWarpsPerCTA = SmallVector<unsigned>{warpsPerCTA[0], warpsPerCTA[1]};
-  } else {
-    laneBase = {{0, 0}, {0, 0}, {1, 0}, {2, 0}, {4, 0}};
-    order = SmallVector<unsigned>{0u, 1u};
-    mmaWarpsPerCTA = SmallVector<unsigned>{warpsPerCTA[1], warpsPerCTA[0]};
+  std::vector<std::vector<int32_t>> laneBase(
+      5, std::vector<int32_t>(rank, 0));
+  laneBase[2][mnIdx] = 1;
+  laneBase[3][mnIdx] = 2;
+  laneBase[4][mnIdx] = 4;
+  if (opIdx == 0)
+    laneBase[0][mnIdx] = 8;
+
+  SmallVector<unsigned> order =
+      getMatrixOrder(rank, /*rowMajor=*/true);
+  SmallVector<unsigned> mmaWarpsPerCTA(warpsPerCTA.begin(),
+                                       warpsPerCTA.end());
+  if (opIdx == 1) {
+    std::swap(mmaWarpsPerCTA[mnIdx], mmaWarpsPerCTA[kIdx]);
+    for (unsigned &dim : order) {
+      if (dim == mnIdx)
+        dim = kIdx;
+      else if (dim == kIdx)
+        dim = mnIdx;
+    }
   }
   LinearLayout LL =
-      LinearLayout::identity1D(shape[1], kRegister, outDims[kIdx]) *
-      LinearLayout({{kLane, laneBase}}, {outDims[mnIdx], outDims[kIdx]}) *
-      broadcastedDotOperandLayout(ctx, mmaWarpsPerCTA, order, 1u, kWarp);
+      LinearLayout::identity1D(shape[kIdx], kRegister, outDims[kIdx]) *
+      LinearLayout({{kLane, laneBase}}, outDims) *
+      broadcastedDotOperandLayout(ctx, mmaWarpsPerCTA, order, kIdx, kWarp);
   return combineCtaCgaWithShape(LL, cgaLayout, shape);
 }
 

--- a/lib/Dialect/TritonGPU/IR/LinearLayoutConversions.cpp
+++ b/lib/Dialect/TritonGPU/IR/LinearLayoutConversions.cpp
@@ -1552,18 +1552,15 @@ LinearLayout getSM120DotScaledScaleLayout(MLIRContext *ctx,
   const unsigned kIdx = rank - 1;
   const unsigned mnIdx = rank - 2;
 
-  std::vector<std::vector<int32_t>> laneBase(
-      5, std::vector<int32_t>(rank, 0));
+  std::vector<std::vector<int32_t>> laneBase(5, std::vector<int32_t>(rank, 0));
   laneBase[2][mnIdx] = 1;
   laneBase[3][mnIdx] = 2;
   laneBase[4][mnIdx] = 4;
   if (opIdx == 0)
     laneBase[0][mnIdx] = 8;
 
-  SmallVector<unsigned> order =
-      getMatrixOrder(rank, /*rowMajor=*/true);
-  SmallVector<unsigned> mmaWarpsPerCTA(warpsPerCTA.begin(),
-                                       warpsPerCTA.end());
+  SmallVector<unsigned> order = getMatrixOrder(rank, /*rowMajor=*/true);
+  SmallVector<unsigned> mmaWarpsPerCTA(warpsPerCTA.begin(), warpsPerCTA.end());
   if (opIdx == 1) {
     std::swap(mmaWarpsPerCTA[mnIdx], mmaWarpsPerCTA[kIdx]);
     for (unsigned &dim : order) {

--- a/lib/Dialect/TritonGPU/Transforms/OptimizeThreadLocality.cpp
+++ b/lib/Dialect/TritonGPU/Transforms/OptimizeThreadLocality.cpp
@@ -134,6 +134,11 @@ static LogicalResult setOptimizedGatherLayout(GatherOp op, RewriterBase &b) {
   unsigned rank = srcType.getRank();
   if (rank == 1)
     return failure();
+  // This branch's generic convert-layout lowering materializes the full index
+  // tensor in shared memory when its gather dimension is larger than the
+  // source. Fall back to gather's source-only shared-memory lowering instead.
+  if (idxType.getDimSize(axis) > srcType.getDimSize(axis))
+    return failure();
   SmallVector<unsigned> threadsPerWarp(rank);
   SmallVector<unsigned> warpsPerCTA(rank);
   SmallVector<unsigned> order;

--- a/python/test/unit/language/print_helper.py
+++ b/python/test/unit/language/print_helper.py
@@ -129,7 +129,9 @@ def test_print(func: str, data_type: str, device: str):
     elif func == "print":
         kernel_print[(1, )](x, y, num_warps=num_warps, BLOCK=N)
     elif func == "device_print_large":
-        kernel_device_print_large[(1, 2)](BLOCK_M=64, num_warps=num_warps, BLOCK_N=N)
+        # Each thread still prints 64 values, exercising the >32 argument case
+        # without overflowing CUDA's process-wide printf FIFO.
+        kernel_device_print_large[(1, )](BLOCK_M=64, num_warps=num_warps, BLOCK_N=N)
     elif func == "print_multiple_args":
         kernel_print_multiple_args[(1, )](x, y, num_warps=num_warps, BLOCK=N)
     elif func == "device_print_multiple_args":

--- a/python/test/unit/language/test_core.py
+++ b/python/test/unit/language/test_core.py
@@ -4063,7 +4063,10 @@ def test_dot(M, N, K, num_warps, col_a, col_b, epilogue, input_precision, in_dty
         if capability[0] == 9 and M >= 64 and N >= 8:
             assert 'wgmma.mma_async.sync.aligned.m64n128k32.f32.e5m2.e5m2' in ptx
         elif capability[0] >= 8 and M < 64:
-            assert 'mma.sync.aligned.m16n8k16.row.col.f32.f16.f16.f32' in ptx
+            if capability == (8, 9) or capability[0] == 12:
+                assert 'mma.sync.aligned.m16n8k32.row.col.f32.e5m2.e5m2.f32' in ptx
+            else:
+                assert 'mma.sync.aligned.m16n8k16.row.col.f32.f16.f16.f32' in ptx
     elif in_dtype == "float8e4nv" and out_dtype == tl.float32:
         if capability[0] == 9 and M >= 64 and N >= 8:
             assert 'wgmma.mma_async.sync.aligned.m64n128k32.f32.e4m3.e4m3' in ptx

--- a/python/test/unit/language/test_core.py
+++ b/python/test/unit/language/test_core.py
@@ -1953,7 +1953,7 @@ def test_atomic_cas(sem, num_ctas, dtype_str, device):
 
 @pytest.mark.skipif(not is_cuda() or torch.cuda.get_device_capability()[0] < 9,
                     reason="num_ctas > 1 requires NVIDIA SM90+ (Hopper)")
-@pytest.mark.skipif(is_sm12x(), reason="scalar multi-CTA atomic_cas is not supported on sm120 (consumer Blackwell)")
+@pytest.mark.skipif(is_sm12x(), reason="scalar multi-CTA atomic_cas is not supported on sm12x (consumer Blackwell)")
 def test_scalar_atomic_cas_multicta_result(device):
 
     @triton.jit

--- a/python/test/unit/language/test_matmul.py
+++ b/python/test/unit/language/test_matmul.py
@@ -1061,8 +1061,7 @@ def test_block_scale_fp4(M, N, K, BLOCK_M, BLOCK_N, BLOCK_K, VEC_SIZE, with_a_sc
             pytest.skip("fp8e4nv not supported on Ampere or older")
         if BLOCK_N == 256 and BLOCK_K == 256 and torch.cuda.get_device_capability()[0] < 9:
             pytest.skip("Insufficient SMEM Ampere or older")
-        if (torch.cuda.get_device_capability()[0] == 12 and not pack_along_k and BLOCK_N == 256
-                and BLOCK_K == 256):
+        if (torch.cuda.get_device_capability()[0] == 12 and not pack_along_k and BLOCK_N == 256 and BLOCK_K == 256):
             pytest.skip("Decomposed SM12 MN-packed config requires too much shared memory")
         if not (with_a_scale and with_b_scale):
             pytest.skip("None aScale/bScale is only tested on AMD backend for now")

--- a/python/test/unit/language/test_matmul.py
+++ b/python/test/unit/language/test_matmul.py
@@ -1061,6 +1061,9 @@ def test_block_scale_fp4(M, N, K, BLOCK_M, BLOCK_N, BLOCK_K, VEC_SIZE, with_a_sc
             pytest.skip("fp8e4nv not supported on Ampere or older")
         if BLOCK_N == 256 and BLOCK_K == 256 and torch.cuda.get_device_capability()[0] < 9:
             pytest.skip("Insufficient SMEM Ampere or older")
+        if (torch.cuda.get_device_capability()[0] == 12 and not pack_along_k and BLOCK_N == 256
+                and BLOCK_K == 256):
+            pytest.skip("Decomposed SM12 MN-packed config requires too much shared memory")
         if not (with_a_scale and with_b_scale):
             pytest.skip("None aScale/bScale is only tested on AMD backend for now")
     elif is_hip():
@@ -1122,7 +1125,8 @@ def test_block_scale_fp4(M, N, K, BLOCK_M, BLOCK_N, BLOCK_K, VEC_SIZE, with_a_sc
     if is_hip_gfx1250() and not pack_along_k:
         assert "ds_load_tr4_b64" in k.asm["amdgcn"]
     torch.testing.assert_close(ref_out, output, atol=1e-3, rtol=1e-3)
-    nvfp4_fallback = BLOCK_M < 128
+    sm12_mn_packed_fallback = (is_cuda() and torch.cuda.get_device_capability()[0] == 12 and not pack_along_k)
+    nvfp4_fallback = BLOCK_M < 128 or sm12_mn_packed_fallback
     if is_cuda() and torch.cuda.get_device_capability()[0] in (10, 12) and not nvfp4_fallback:
         ptx = k.asm["ptx"]
         if pack_along_k:
@@ -1386,8 +1390,11 @@ def test_batched_mxfp(BATCH_SIZE, BLOCK_BATCH_SIZE, BLOCK_M, BLOCK_N, BLOCK_K, N
 
     if K % BLOCK_K != 0:
         pytest.skip("Kernel requires shapes aligned by K dimension")
-    if is_cuda() and torch.cuda.get_device_capability()[0] < 10:
-        pytest.skip("Requires compute capability >= 10")
+    if is_cuda():
+        if torch.cuda.get_device_capability()[0] < 10:
+            pytest.skip("Requires compute capability >= 10")
+        if torch.cuda.get_device_capability()[0] == 12 and BLOCK_BATCH_SIZE > 1 and NUM_STAGES > 1:
+            pytest.skip("Config requires too much shared memory")
     elif is_hip():
         if not (is_hip_cdna4() or is_hip_gfx1250()):
             pytest.skip("Scaled mxfp8 matmul is only natively supported on CDNA4 and above")

--- a/python/test/unit/language/test_subprocess.py
+++ b/python/test/unit/language/test_subprocess.py
@@ -125,8 +125,8 @@ def test_print(func_type: str, data_type: str, device: str, capfd):
     elif func_type == "print_no_arg":
         expected_lines["pid (0, 0, 0) no arg"] = N
     elif func_type == "device_print_large":
-        for i, j, k in itertools.product(range(2), range(64), range(N)):
-            expected_lines[f"pid (0, {i}, 0) idx ({j:2}, {k:3}) x: 1"] = 1
+        for j, k in itertools.product(range(64), range(N)):
+            expected_lines[f"pid (0, 0, 0) idx ({j:2}, {k:3}) x: 1"] = 1
     elif func_type == "print_multiple_args" or func_type == "device_print_multiple_args":
         for i in range(N):
             expected_lines[f"pid (0, 0, 0) idx ({i:3}): (operand 0) {i}"] = 1

--- a/python/test/unit/runtime/test_autotuner.py
+++ b/python/test/unit/runtime/test_autotuner.py
@@ -5,7 +5,6 @@ import triton.language as tl
 import pytest
 
 import pathlib
-import uuid
 from triton._internal_testing import is_cuda, is_hip_cdna2, is_rubin
 
 
@@ -365,7 +364,7 @@ def test_pruned_single_config_skips_benchmark(prune_kind: str, device: str, fres
 
 @pytest.mark.skipif(not is_cuda() or torch.cuda.get_device_capability()[0] < 9,
                     reason="Requires compute capability >= 9 for NV")
-def test_override_ttir(device):
+def test_override_ttir(device, tmp_path: pathlib.Path):
     N = 1024
     src = torch.randn(N, device=device)
     dst = torch.empty(N, device=device)
@@ -393,7 +392,7 @@ module {
   }
 }
     """
-    temp_file = pathlib.Path(f"/tmp/test_override_{str(uuid.uuid4())}.ttir")
+    temp_file = tmp_path / "test_override.ttir"
     temp_file.write_text(ir_src)
 
     configs = [triton.Config(kwargs={'BLOCK_SIZE': 32, 'ir_override': str(temp_file)})]
@@ -414,7 +413,7 @@ module {
 
 @pytest.mark.skipif(not is_cuda() or torch.cuda.get_device_capability()[0] < 9,
                     reason="Requires compute capability >= 9 for NV")
-def test_override_ttgir(device):
+def test_override_ttgir(device, tmp_path: pathlib.Path):
     N = 1024
     src = torch.randn(N, device=device)
     dst = torch.empty(N, device=device)
@@ -443,7 +442,7 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.targ
   }
 }
     """
-    temp_file = pathlib.Path(f"/tmp/test_override_{str(uuid.uuid4())}.ttgir")
+    temp_file = tmp_path / "test_override.ttgir"
     temp_file.write_text(ir_src)
 
     configs = [triton.Config(kwargs={'BLOCK_SIZE': 32, 'ir_override': str(temp_file)})]
@@ -464,7 +463,7 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.targ
 
 @pytest.mark.skipif(not is_cuda() or torch.cuda.get_device_capability()[0] != 9,
                     reason="PTX file in this unit test is only for SM90")
-def test_override_ptx(device):
+def test_override_ptx(device, tmp_path: pathlib.Path):
     N = 1024
     src = torch.randn(N, device=device)
     dst = torch.empty(N, device=device)
@@ -540,7 +539,7 @@ $L__func_end0:
                                         // -- End function
 }
     """
-    temp_file = pathlib.Path(f"/tmp/test_override_{str(uuid.uuid4())}.ptx")
+    temp_file = tmp_path / "test_override.ptx"
     temp_file.write_text(ir_src)
 
     configs = [triton.Config(kwargs={'BLOCK_SIZE': 32, 'ir_override': str(temp_file)})]

--- a/python/triton/tools/triton_to_gluon_translator/nvidia_helpers.py
+++ b/python/triton/tools/triton_to_gluon_translator/nvidia_helpers.py
@@ -7,7 +7,9 @@ from triton.experimental.gluon.language.nvidia.hopper import fence_async_shared,
 
 from triton.tools.triton_to_gluon_translator.common_helpers import *  # noqa: F401,F403
 from triton.tools.triton_to_gluon_translator.common_helpers import (
-    default_blocked_layout, )
+    default_blocked_layout,
+    tl_dot_decomposed_block_scales_impl,
+)
 
 # ---- NVIDIA MMA sync (Ampere) ----
 
@@ -32,6 +34,15 @@ def tl_dot_mma_sync_k_width(a_ty, b_ty):
     return max(32 // min_bitwidth, 1)
 
 
+@gluon.constexpr_function
+def tl_dot_mma_sync_input_precision(input_precision, allow_tf32):
+    assert input_precision is None or allow_tf32 is None, (
+        "Only one of input_precision and allow_tf32 can be specified")
+    if input_precision is not None:
+        return input_precision
+    return "ieee" if allow_tf32 is False else "tf32"
+
+
 @gluon.jit
 def tl_dot_mma_sync(a, b, acc_init=None, input_precision=None, out_dtype=ttgl.float32):
     mma_layout: ttgl.constexpr = tl_dot_mma_sync_layout(a.type.shape, ttgl.num_warps())
@@ -43,7 +54,9 @@ def tl_dot_mma_sync(a, b, acc_init=None, input_precision=None, out_dtype=ttgl.fl
     if acc_init is not None:
         acc = ttgl.convert_layout(acc_init, mma_layout)
     else:
-        acc = ttgl.full([a.shape[0], a.shape[1], b.shape[2]], 0.0, out_dtype, layout=mma_layout)
+        shape: ttgl.constexpr = ([a.shape[0], b.shape[1]] if len(a.shape) == 2 else
+                                [a.shape[0], a.shape[1], b.shape[2]])
+        acc = ttgl.full(shape, 0.0, out_dtype, layout=mma_layout)
     result = mma_v2(a, b, acc, input_precision)
     if acc_init is not None:
         layout: ttgl.constexpr = acc_init.type.layout
@@ -51,6 +64,53 @@ def tl_dot_mma_sync(a, b, acc_init=None, input_precision=None, out_dtype=ttgl.fl
         layout: ttgl.constexpr = default_blocked_layout(result.type.shape, ttgl.num_warps())
     result = ttgl.convert_layout(result, layout)
     return result
+
+
+@gluon.jit
+def tl_dot(
+    a,
+    b,
+    acc=None,
+    input_precision=None,
+    allow_tf32=None,
+    max_num_imprecise_acc=None,
+    out_dtype=ttgl.float32,
+):
+    ttgl.static_assert(max_num_imprecise_acc == 0 or max_num_imprecise_acc is None,
+                       "max_num_imprecise_acc only applies to Hopper warp_group_dot")
+    input_prec: ttgl.constexpr = tl_dot_mma_sync_input_precision(input_precision, allow_tf32)
+    return tl_dot_mma_sync(a, b, acc, input_prec, out_dtype)
+
+
+@gluon.jit
+def tl_dot_scaled(
+    lhs,
+    lhs_scale,
+    lhs_format,
+    rhs,
+    rhs_scale,
+    rhs_format,
+    acc=None,
+    fast_math=False,
+    lhs_k_pack=True,
+    rhs_k_pack=True,
+    out_dtype=ttgl.float32,
+):
+    return tl_dot_decomposed_block_scales_impl(
+        tl_dot_scaled,
+        tl_dot,
+        lhs,
+        lhs_scale,
+        lhs_format,
+        rhs,
+        rhs_scale,
+        rhs_format,
+        acc=acc,
+        fast_math=fast_math,
+        lhs_k_pack=lhs_k_pack,
+        rhs_k_pack=rhs_k_pack,
+        out_dtype=out_dtype,
+    )
 
 
 @gluon.constexpr_function

--- a/python/triton/tools/triton_to_gluon_translator/nvidia_helpers.py
+++ b/python/triton/tools/triton_to_gluon_translator/nvidia_helpers.py
@@ -54,8 +54,8 @@ def tl_dot_mma_sync(a, b, acc_init=None, input_precision=None, out_dtype=ttgl.fl
     if acc_init is not None:
         acc = ttgl.convert_layout(acc_init, mma_layout)
     else:
-        shape: ttgl.constexpr = ([a.shape[0], b.shape[1]] if len(a.shape) == 2 else
-                                [a.shape[0], a.shape[1], b.shape[2]])
+        shape: ttgl.constexpr = ([a.shape[0], b.shape[1]]
+                                 if len(a.shape) == 2 else [a.shape[0], a.shape[1], b.shape[2]])
         acc = ttgl.full(shape, 0.0, out_dtype, layout=mma_layout)
     result = mma_v2(a, b, acc, input_precision)
     if acc_init is not None:

--- a/python/triton/tools/triton_to_gluon_translator/target.py
+++ b/python/triton/tools/triton_to_gluon_translator/target.py
@@ -17,6 +17,8 @@ class TranslatorTarget(str, Enum):
     SM100 = "sm100"
     SM103 = "sm103"
     SM107 = "sm107"
+    SM120 = "sm120"
+    SM121 = "sm121"
     # AMD targets currently exercised by the translator test suite:
     GFX90A = "gfx90a"
     GFX1250 = "gfx1250"
@@ -48,6 +50,8 @@ class TranslatorTarget(str, Enum):
             TranslatorTarget.SM100,
             TranslatorTarget.SM103,
             TranslatorTarget.SM107,
+            TranslatorTarget.SM120,
+            TranslatorTarget.SM121,
         )
 
     @property
@@ -63,11 +67,19 @@ class TranslatorTarget(str, Enum):
             return f"{base}.amd_helpers"
 
         if self.is_nvidia:
-            if self in (TranslatorTarget.SM100, TranslatorTarget.SM103, TranslatorTarget.SM107):
+            if self in (
+                    TranslatorTarget.SM100,
+                    TranslatorTarget.SM103,
+                    TranslatorTarget.SM107,
+            ):
                 return f"{base}.blackwell_helpers"
             if self in (TranslatorTarget.SM90):
                 return f"{base}.hopper_helpers"
-            if self in (TranslatorTarget.SM80):
+            if self in (
+                    TranslatorTarget.SM80,
+                    TranslatorTarget.SM120,
+                    TranslatorTarget.SM121,
+            ):
                 return f"{base}.nvidia_helpers"
 
         return f"{base}.common_helpers"

--- a/third_party/nvidia/include/cublas_instance.h
+++ b/third_party/nvidia/include/cublas_instance.h
@@ -3,6 +3,9 @@
 
 #include "cublas_types.h"
 #include <dlfcn.h>
+#ifdef __linux__
+#include <link.h>
+#endif
 #include <stdexcept>
 #include <string>
 
@@ -64,19 +67,48 @@ private:
 
   cublasLtMatmulPreference_t preference = NULL;
 
+#ifdef __linux__
+  // PyTorch may preload a versioned cuBLAS from its wheel. Reuse that exact
+  // library so it remains paired with the compatible cuBLASLt already loaded.
+  static int findLoadedCublas(struct dl_phdr_info *info, size_t, void *data) {
+    if (!info->dlpi_name || !*info->dlpi_name)
+      return 0;
+    std::string path = info->dlpi_name;
+    size_t slash = path.find_last_of('/');
+    std::string basename =
+        slash == std::string::npos ? path : path.substr(slash + 1);
+    if (basename == name ||
+        basename.rfind(std::string(name) + ".", /*pos=*/0) == 0) {
+      *static_cast<std::string *>(data) = path;
+      return 1;
+    }
+    return 0;
+  }
+#endif
+
   void loadCublasDylib() {
+#ifdef __linux__
+    // dlopen("libcublas.so", RTLD_NOLOAD) does not find a library loaded under
+    // a versioned SONAME, so recover its path from the loaded ELF objects.
+    std::string loadedCublas;
+    dl_iterate_phdr(findLoadedCublas, &loadedCublas);
+    if (!loadedCublas.empty()) {
+      dylibHandle =
+          dlopen(loadedCublas.c_str(), RTLD_NOLOAD | RTLD_LOCAL | RTLD_LAZY);
+    }
+#endif
     if (dylibHandle == nullptr) {
       // First reuse the existing handle
-      dylibHandle = dlopen(name, RTLD_NOLOAD);
+      dylibHandle = dlopen(name, RTLD_NOLOAD | RTLD_LOCAL | RTLD_LAZY);
     }
     if (dylibHandle == nullptr) {
       // If not found, try to load it
       dylibHandle = dlopen(name, RTLD_LOCAL | RTLD_LAZY);
     }
     if (dylibHandle == nullptr) {
-      throw std::runtime_error("Could not find `" + std::string(name) +
-                               "`. Make sure it is in your "
-                               "LD_LIBRARY_PATH.");
+      const char *error = dlerror();
+      throw std::runtime_error("Could not load `" + std::string(name) +
+                               "`: " + (error ? error : "unknown error"));
     }
     dlerror(); // Clear any existing error
 

--- a/unittest/Dialect/TritonGPU/LinearLayoutConversionsTest.cpp
+++ b/unittest/Dialect/TritonGPU/LinearLayoutConversionsTest.cpp
@@ -3476,6 +3476,38 @@ TEST_F(LinearLayoutConversionsTest, SM120DotScaledScaleLayout) {
   EXPECT_EQ(ll, layout);
 }
 
+TEST_F(LinearLayoutConversionsTest, SM120BatchedDotScaledScaleLayout) {
+  auto cgaLayout =
+      CGAEncodingAttr::fromSplitParams(&ctx, {1, 1, 1}, {1, 1, 1},
+                                       {2, 1, 0});
+
+  auto layout = getSM120DotScaledScaleLayout(
+      &ctx, /*shape=*/{4, 128, 2}, /*opIdx=*/0,
+      /*warpsPerCTA=*/{4, 1, 1}, cgaLayout);
+  auto expected = LinearLayout(
+      {{S("register"),
+        {{0, 0, 1}, {0, 16, 0}, {0, 32, 0}, {0, 64, 0}}},
+       {S("lane"),
+        {{0, 8, 0}, {0, 0, 0}, {0, 1, 0}, {0, 2, 0}, {0, 4, 0}}},
+       {S("warp"), {{1, 0, 0}, {2, 0, 0}}},
+       {S("block"), {}}},
+      {S("dim0"), S("dim1"), S("dim2")});
+  EXPECT_EQ(expected, layout);
+
+  layout = getSM120DotScaledScaleLayout(
+      &ctx, /*shape=*/{4, 128, 2}, /*opIdx=*/1,
+      /*warpsPerCTA=*/{4, 1, 1}, cgaLayout);
+  expected = LinearLayout(
+      {{S("register"),
+        {{0, 0, 1}, {0, 8, 0}, {0, 16, 0}, {0, 32, 0}, {0, 64, 0}}},
+       {S("lane"),
+        {{0, 0, 0}, {0, 0, 0}, {0, 1, 0}, {0, 2, 0}, {0, 4, 0}}},
+       {S("warp"), {{1, 0, 0}, {2, 0, 0}}},
+       {S("block"), {}}},
+      {S("dim0"), S("dim1"), S("dim2")});
+  EXPECT_EQ(expected, layout);
+}
+
 //===----------------------------------------------------------------------===//
 // nvmmaSharedToLinearLayout TMA Mode Independence Tests
 //

--- a/unittest/Dialect/TritonGPU/LinearLayoutConversionsTest.cpp
+++ b/unittest/Dialect/TritonGPU/LinearLayoutConversionsTest.cpp
@@ -3478,30 +3478,26 @@ TEST_F(LinearLayoutConversionsTest, SM120DotScaledScaleLayout) {
 
 TEST_F(LinearLayoutConversionsTest, SM120BatchedDotScaledScaleLayout) {
   auto cgaLayout =
-      CGAEncodingAttr::fromSplitParams(&ctx, {1, 1, 1}, {1, 1, 1},
-                                       {2, 1, 0});
+      CGAEncodingAttr::fromSplitParams(&ctx, {1, 1, 1}, {1, 1, 1}, {2, 1, 0});
 
-  auto layout = getSM120DotScaledScaleLayout(
-      &ctx, /*shape=*/{4, 128, 2}, /*opIdx=*/0,
-      /*warpsPerCTA=*/{4, 1, 1}, cgaLayout);
+  auto layout =
+      getSM120DotScaledScaleLayout(&ctx, /*shape=*/{4, 128, 2}, /*opIdx=*/0,
+                                   /*warpsPerCTA=*/{4, 1, 1}, cgaLayout);
   auto expected = LinearLayout(
-      {{S("register"),
-        {{0, 0, 1}, {0, 16, 0}, {0, 32, 0}, {0, 64, 0}}},
-       {S("lane"),
-        {{0, 8, 0}, {0, 0, 0}, {0, 1, 0}, {0, 2, 0}, {0, 4, 0}}},
+      {{S("register"), {{0, 0, 1}, {0, 16, 0}, {0, 32, 0}, {0, 64, 0}}},
+       {S("lane"), {{0, 8, 0}, {0, 0, 0}, {0, 1, 0}, {0, 2, 0}, {0, 4, 0}}},
        {S("warp"), {{1, 0, 0}, {2, 0, 0}}},
        {S("block"), {}}},
       {S("dim0"), S("dim1"), S("dim2")});
   EXPECT_EQ(expected, layout);
 
-  layout = getSM120DotScaledScaleLayout(
-      &ctx, /*shape=*/{4, 128, 2}, /*opIdx=*/1,
-      /*warpsPerCTA=*/{4, 1, 1}, cgaLayout);
+  layout =
+      getSM120DotScaledScaleLayout(&ctx, /*shape=*/{4, 128, 2}, /*opIdx=*/1,
+                                   /*warpsPerCTA=*/{4, 1, 1}, cgaLayout);
   expected = LinearLayout(
       {{S("register"),
         {{0, 0, 1}, {0, 8, 0}, {0, 16, 0}, {0, 32, 0}, {0, 64, 0}}},
-       {S("lane"),
-        {{0, 0, 0}, {0, 0, 0}, {0, 1, 0}, {0, 2, 0}, {0, 4, 0}}},
+       {S("lane"), {{0, 0, 0}, {0, 0, 0}, {0, 1, 0}, {0, 2, 0}, {0, 4, 0}}},
        {S("warp"), {{1, 0, 0}, {2, 0, 0}}},
        {S("block"), {}}},
       {S("dim0"), S("dim1"), S("dim2")});


### PR DESCRIPTION
## Summary

This PR adds NVIDIA SM120/SM121 support to the Triton-to-Gluon translator and fixes several issues exposed when running Triton tests on Blackwell GPUs.

The translator now supports SM120 and SM121 targets, including the corresponding dot and scaled-dot operations. Scaled-dot scale layouts are generalized to support both regular and batched operands, preserving the correct operand
dimensions and warp layout for batched matmul.

This PR also avoids excessive shared-memory materialization for gather operations whose index tensor is larger than the source dimension. The cuBLAS loader now reuses versioned cuBLAS libraries already loaded by PyTorch, keeping cuBLAS and cuBLASLt compatible when they originate from the same wheel.

## Testing

- Added unit coverage for batched SM120 scaled-dot scale layouts.
- Updated CUDA tests for SM120/SM121 PTX expectations.
- Added SM12x shared-memory guards for scaled FP4 and mxfp configurations.
- Updated device-print tests to avoid overflowing CUDA's process-wide printf FIFO.
- Updated autotuner tests to use pytest's cross-platform `tmp_path` fixture instead of hard-coded `/tmp` paths.
- Ran `pre-commit run --from-ref origin/main --to-ref HEAD`.
- Run unit test on WSL arm64 with Blackwell GPU.
```
cd python/test/unit
pytest
...
11618 passed, 7190 skipped, 2 xfailed, 41 warnings in 445.74s (0:07:25)
```

# New contributor declaration

- [x] I am not making a trivial change, such as fixing a typo in a comment.
- [x] I have written a PR description following these [rules](https://cbea.ms/git-commit/#why-not-how).
- [x] I have run `pre-commit run --from-ref origin/main --to-ref HEAD`.

- Select one of the following.
  - [x] I have added tests.
    - `/test` for `lit` tests
    - `/unittest` for C++ tests
    - `/python/test` for end-to-end tests
  - [ ] This PR does not need a test because `FILL THIS IN`.

- Select one of the following.
  - [x] I have not added any `lit` tests.
  - [ ] The `lit` tests I have added follow these [best practices](https://mlir.llvm.org/getting_started/TestingGuide/#filecheck-best-practices), including the "tests should be minimal" section. (Usually running Python code and using the instructions it generates is not minimal.)