### PR TITLE
[ConSan] Track barrier storage lifetimes

### DIFF
--- a/include/triton/Dialect/TritonInstrument/IR/FunctionBuilder.h
+++ b/include/triton/Dialect/TritonInstrument/IR/FunctionBuilder.h
@@ -221,8 +221,8 @@ public:
   void createCopyReadVisibilityCall(ImplicitLocOpBuilder &b, int sourceThread,
                                     uint64_t destMask, Value pred,
                                     MemType memType, Operation *insertPoint);
-  // publishCTAVisibility: make the read and write visibility observed by
-  // sourceMask visible to destMask in the current CTA.
+  // publishCTAVisibility: make read, write, and shared-memory proxy visibility
+  // observed by sourceMask visible to destMask in the current CTA.
   void createPublishCTAVisibilityCall(ImplicitLocOpBuilder &b,
                                       uint64_t sourceMask, uint64_t destMask,
                                       MemType memType, Operation *insertPoint);

--- a/include/triton/Dialect/TritonInstrument/IR/FunctionBuilder.h
+++ b/include/triton/Dialect/TritonInstrument/IR/FunctionBuilder.h
@@ -136,15 +136,14 @@ public:
                                   int count, Value pred,
                                   Operation *insertPoint);
   // invalidateBarrierState: verify the barrier is initialized with no active
-  // waiters, then clear its lifecycle state and waiting bits.
+  // waiters, then clear its lifecycle state, waiting bits, and saved frontiers.
   void createInvalidateBarrierStateCall(ImplicitLocOpBuilder &b, Value mbar,
                                         Value pred, Operation *insertPoint);
   // invalidateBarrierStorage: clear an active barrier overwritten by an
   // ordinary store, including its saved visibility frontiers.
   void createInvalidateBarrierStorageCall(ImplicitLocOpBuilder &b, Value offset,
                                           uint32_t length, Value pred,
-                                          Operation *insertPoint,
-                                          Value recipientCTAs);
+                                          Operation *insertPoint);
   // verifyAndUpdateBarrierState: Validate barrier initialization, an arrive
   // count, and a tx-count delta using one snapshot of the tracked barrier
   // state. Preserve independent initialization and underflow assertions and
@@ -181,16 +180,6 @@ public:
                                             Operation *insertPoint,
                                             Value barrierCTAs,
                                             Value effectCTAs);
-  // clearBarrierWriteTracking: clear all write tracking associated with the
-  // given barrier row.
-  void createClearBarrierWriteTrackingCall(ImplicitLocOpBuilder &b, Value mbar,
-                                           Value pred, MemType memType,
-                                           Operation *insertPoint);
-  // clearBarrierReadTracking: clear all read tracking associated with the
-  // given barrier row.
-  void createClearBarrierReadTrackingCall(ImplicitLocOpBuilder &b, Value mbar,
-                                          Value pred, MemType memType,
-                                          Operation *insertPoint);
   // transferVisibleAccesses: transfer the barrier's independently tracked
   // write and read visibility to all threads in threadMask.
   void createTransferVisibleAccessesCall(ImplicitLocOpBuilder &b, Value mbar,
@@ -261,11 +250,6 @@ public:
   void createCompleteBarrierWaitCall(ImplicitLocOpBuilder &b, Value mbar,
                                      int thread, Value pred,
                                      Operation *insertPoint);
-  // clearBarrierProxyAccessTracking: clear packed proxy state associated with
-  // an invalidated barrier.
-  void createClearBarrierProxyAccessTrackingCall(ImplicitLocOpBuilder &b,
-                                                 Value mbar, Value pred,
-                                                 Operation *insertPoint);
   // verifyProxyAccess: assert that every generic-proxy access visible to the
   // issuing base thread has crossed fence.proxy.async.
   void createVerifyProxyAccessCall(ImplicitLocOpBuilder &b, Value bufferMask,
@@ -329,16 +313,15 @@ public:
       bool excludeSelf = false);
 
 private:
-  Value createInvalidateBarrierStateCallImpl(ImplicitLocOpBuilder &b,
-                                             Value offset, Value length,
-                                             Value pred, Operation *insertPoint,
-                                             Value recipientCTAs,
-                                             bool allowUninitialized);
+  void createInvalidateBarrierStateCallImpl(ImplicitLocOpBuilder &b,
+                                            Value offset, Value length,
+                                            Value pred, Operation *insertPoint,
+                                            bool allowUninitialized);
 
   void createClearBarrierStorageTrackingCall(ImplicitLocOpBuilder &b,
                                              Value offset, Value length,
-                                             Value pred, Operation *insertPoint,
-                                             Value recipientCTAs);
+                                             Value pred,
+                                             Operation *insertPoint);
 
   void createClearOutstandingCommitsTransferCall(
       ImplicitLocOpBuilder &b, int thread, uint64_t transferThreadMask,

--- a/include/triton/Dialect/TritonInstrument/IR/FunctionBuilder.h
+++ b/include/triton/Dialect/TritonInstrument/IR/FunctionBuilder.h
@@ -125,10 +125,8 @@ public:
   // verifyBarrierMemoryAvailable: reject ordinary shared-memory accesses that
   // overlap initialized barrier storage.
   void createVerifyBarrierMemoryAvailableCall(ImplicitLocOpBuilder &b,
-                                              Value offset, uint32_t length,
-                                              Value pred,
-                                              Operation *insertPoint,
-                                              Value recipientCTAs);
+                                              Value barrierCTAs, Value pred,
+                                              Operation *insertPoint);
   // initBarrierState: Initialize the tracked barrier state to phase 0 and set
   // both the initial and current arrival counts. A zero state denotes an
   // invalidated/uninitialized barrier.
@@ -141,8 +139,8 @@ public:
                                         Value pred, Operation *insertPoint);
   // invalidateBarrierStorage: clear an active barrier overwritten by an
   // ordinary store, including its saved visibility frontiers.
-  void createInvalidateBarrierStorageCall(ImplicitLocOpBuilder &b, Value offset,
-                                          uint32_t length, Value pred,
+  void createInvalidateBarrierStorageCall(ImplicitLocOpBuilder &b,
+                                          Value barrierCTAs, Value pred,
                                           Operation *insertPoint);
   // verifyAndUpdateBarrierState: Validate barrier initialization, an arrive
   // count, and a tx-count delta using one snapshot of the tracked barrier
@@ -314,13 +312,12 @@ public:
 
 private:
   void createInvalidateBarrierStateCallImpl(ImplicitLocOpBuilder &b,
-                                            Value offset, Value length,
-                                            Value pred, Operation *insertPoint,
+                                            Value selectedBarriers, Value pred,
+                                            Operation *insertPoint,
                                             bool allowUninitialized);
 
   void createClearBarrierStorageTrackingCall(ImplicitLocOpBuilder &b,
-                                             Value offset, Value length,
-                                             Value pred,
+                                             Value selectedBarriers, Value pred,
                                              Operation *insertPoint);
 
   void createClearOutstandingCommitsTransferCall(

--- a/include/triton/Dialect/TritonInstrument/IR/FunctionBuilder.h
+++ b/include/triton/Dialect/TritonInstrument/IR/FunctionBuilder.h
@@ -129,19 +129,14 @@ public:
                                               Value pred,
                                               Operation *insertPoint,
                                               Value recipientCTAs);
-  // verifyBarrierHasNoWaiters: reject invalidation while any thread is waiting
-  // on the barrier.
-  void createVerifyBarrierHasNoWaitersCall(ImplicitLocOpBuilder &b, Value mbar,
-                                           Value pred, Operation *insertPoint,
-                                           Value recipientCTAs);
   // initBarrierState: Initialize the tracked barrier state to phase 0 and set
   // both the initial and current arrival counts. A zero state denotes an
   // invalidated/uninitialized barrier.
   void createInitBarrierStateCall(ImplicitLocOpBuilder &b, Value mbar,
                                   int count, Value pred,
                                   Operation *insertPoint);
-  // invalidateBarrierState: clear the tracked barrier lifecycle state and any
-  // waiting bits for the barrier.
+  // invalidateBarrierState: verify the barrier is initialized with no active
+  // waiters, then clear its lifecycle state and waiting bits.
   void createInvalidateBarrierStateCall(ImplicitLocOpBuilder &b, Value mbar,
                                         Value pred, Operation *insertPoint);
   // verifyAndUpdateBarrierState: Validate barrier initialization, an arrive

--- a/include/triton/Dialect/TritonInstrument/IR/FunctionBuilder.h
+++ b/include/triton/Dialect/TritonInstrument/IR/FunctionBuilder.h
@@ -217,10 +217,12 @@ public:
                                      uint64_t destMask, Value pred,
                                      MemType memType, Operation *insertPoint);
   // copyReadVisibility: replicate the read visibility row of sourceThread to
-  // every destination thread in destMask.
+  // every destination thread in destMask. Preserve existing destination rows
+  // when merge is true.
   void createCopyReadVisibilityCall(ImplicitLocOpBuilder &b, int sourceThread,
                                     uint64_t destMask, Value pred,
-                                    MemType memType, Operation *insertPoint);
+                                    MemType memType, Operation *insertPoint,
+                                    bool merge = false);
   // publishClusterVisibility: after a non-relaxed cluster barrier, make the
   // participating threads' synchronous facts visible across the cluster. A
   // top-level barrier includes every thread; a warp-specialized barrier is

--- a/include/triton/Dialect/TritonInstrument/IR/FunctionBuilder.h
+++ b/include/triton/Dialect/TritonInstrument/IR/FunctionBuilder.h
@@ -139,6 +139,12 @@ public:
   // waiters, then clear its lifecycle state and waiting bits.
   void createInvalidateBarrierStateCall(ImplicitLocOpBuilder &b, Value mbar,
                                         Value pred, Operation *insertPoint);
+  // invalidateBarrierStorage: clear an active barrier overwritten by an
+  // ordinary store, including its saved visibility frontiers.
+  void createInvalidateBarrierStorageCall(ImplicitLocOpBuilder &b, Value offset,
+                                          uint32_t length, Value pred,
+                                          Operation *insertPoint,
+                                          Value recipientCTAs);
   // verifyAndUpdateBarrierState: Validate barrier initialization, an arrive
   // count, and a tx-count delta using one snapshot of the tracked barrier
   // state. Preserve independent initialization and underflow assertions and
@@ -323,6 +329,17 @@ public:
       bool excludeSelf = false);
 
 private:
+  Value createInvalidateBarrierStateCallImpl(ImplicitLocOpBuilder &b,
+                                             Value offset, Value length,
+                                             Value pred, Operation *insertPoint,
+                                             Value recipientCTAs,
+                                             bool allowUninitialized);
+
+  void createClearBarrierStorageTrackingCall(ImplicitLocOpBuilder &b,
+                                             Value offset, Value length,
+                                             Value pred, Operation *insertPoint,
+                                             Value recipientCTAs);
+
   void createClearOutstandingCommitsTransferCall(
       ImplicitLocOpBuilder &b, int thread, uint64_t transferThreadMask,
       int outstandingNum, Value pred, CommitKind::Kind commitKind,

--- a/include/triton/Dialect/TritonInstrument/IR/FunctionBuilder.h
+++ b/include/triton/Dialect/TritonInstrument/IR/FunctionBuilder.h
@@ -165,8 +165,8 @@ public:
   // frontiers into their independent barrier tracking tables.
   void createTrackVisibleAccessesCall(ImplicitLocOpBuilder &b, Value mbar,
                                       int thread, Value pred, MemType memType,
-                                      Operation *insertPoint,
-                                      Value barrierCTAs);
+                                      Operation *insertPoint, Value barrierCTAs,
+                                      Value readBufferMask = nullptr);
   // trackBarrierWriteForBuffer: mark a specific buffer as tracked by a
   // barrier in the write-tracking table.
   void createTrackBarrierWriteForBufferCall(ImplicitLocOpBuilder &b, Value mbar,
@@ -175,13 +175,6 @@ public:
                                             Operation *insertPoint,
                                             Value barrierCTAs,
                                             Value effectCTAs);
-  // trackBarrierReadForBuffer: snapshot one buffer's current reader frontier
-  // into the barrier read-tracking table.
-  void createTrackBarrierReadForBufferCall(ImplicitLocOpBuilder &b, Value mbar,
-                                           Value bufferMask, int thread,
-                                           Value pred, MemType memType,
-                                           Operation *insertPoint,
-                                           Value barrierCTAs, Value effectCTAs);
   // clearBarrierWriteTracking: clear all write tracking associated with the
   // given barrier row.
   void createClearBarrierWriteTrackingCall(ImplicitLocOpBuilder &b, Value mbar,

--- a/include/triton/Dialect/TritonInstrument/IR/FunctionBuilder.h
+++ b/include/triton/Dialect/TritonInstrument/IR/FunctionBuilder.h
@@ -122,6 +122,18 @@ public:
   void createVerifyBarrierInitializedCall(ImplicitLocOpBuilder &b, Value mbar,
                                           Value pred, Operation *insertPoint,
                                           Value recipientCTAs);
+  // verifyBarrierMemoryAvailable: reject ordinary shared-memory accesses that
+  // overlap initialized barrier storage.
+  void createVerifyBarrierMemoryAvailableCall(ImplicitLocOpBuilder &b,
+                                              Value offset, uint32_t length,
+                                              Value pred,
+                                              Operation *insertPoint,
+                                              Value recipientCTAs);
+  // verifyBarrierHasNoWaiters: reject invalidation while any thread is waiting
+  // on the barrier.
+  void createVerifyBarrierHasNoWaitersCall(ImplicitLocOpBuilder &b, Value mbar,
+                                           Value pred, Operation *insertPoint,
+                                           Value recipientCTAs);
   // initBarrierState: Initialize the tracked barrier state to phase 0 and set
   // both the initial and current arrival counts. A zero state denotes an
   // invalidated/uninitialized barrier.
@@ -168,6 +180,13 @@ public:
                                             Operation *insertPoint,
                                             Value barrierCTAs,
                                             Value effectCTAs);
+  // trackBarrierReadForBuffer: snapshot one buffer's current reader frontier
+  // into the barrier read-tracking table.
+  void createTrackBarrierReadForBufferCall(ImplicitLocOpBuilder &b, Value mbar,
+                                           Value bufferMask, int thread,
+                                           Value pred, MemType memType,
+                                           Operation *insertPoint,
+                                           Value barrierCTAs, Value effectCTAs);
   // clearBarrierWriteTracking: clear all write tracking associated with the
   // given barrier row.
   void createClearBarrierWriteTrackingCall(ImplicitLocOpBuilder &b, Value mbar,

--- a/include/triton/Dialect/TritonInstrument/IR/FunctionBuilder.h
+++ b/include/triton/Dialect/TritonInstrument/IR/FunctionBuilder.h
@@ -217,12 +217,15 @@ public:
                                      uint64_t destMask, Value pred,
                                      MemType memType, Operation *insertPoint);
   // copyReadVisibility: replicate the read visibility row of sourceThread to
-  // every destination thread in destMask. Preserve existing destination rows
-  // when merge is true.
+  // every destination thread in destMask.
   void createCopyReadVisibilityCall(ImplicitLocOpBuilder &b, int sourceThread,
                                     uint64_t destMask, Value pred,
-                                    MemType memType, Operation *insertPoint,
-                                    bool merge = false);
+                                    MemType memType, Operation *insertPoint);
+  // publishCTAVisibility: make the read and write visibility observed by
+  // sourceMask visible to destMask in the current CTA.
+  void createPublishCTAVisibilityCall(ImplicitLocOpBuilder &b,
+                                      uint64_t sourceMask, uint64_t destMask,
+                                      MemType memType, Operation *insertPoint);
   // publishClusterVisibility: after a non-relaxed cluster barrier, make the
   // participating threads' synchronous facts visible across the cluster. A
   // top-level barrier includes every thread; a warp-specialized barrier is

--- a/include/triton/Dialect/TritonInstrument/IR/Utility.h
+++ b/include/triton/Dialect/TritonInstrument/IR/Utility.h
@@ -241,10 +241,9 @@ struct AuxDataMap {
   triton::BufferStatePlan bufferStatePlans[numMemTypes];
   DenseMap<Value, BufferStateCandidates> bufferCandidates[numMemTypes];
 
-  // Barrier footprints that may alias ordinary shared-memory effects. Their
-  // masks use the same physical state lanes as the overlapping payloads.
-  SmallVector<std::pair<triton::BufferRegion, llvm::SmallBitVector>>
-      sharedBarrierMasks;
+  // Shared-memory state lanes occupied by each physical mbarrier. Virtual
+  // cluster barriers have no storage and therefore do not appear here.
+  SmallVector<llvm::SmallBitVector> barrierBufferMasks;
 
   // scratch pointer, i32
   // Shared-cluster lock used to serialize ConSan instrumentation updates.

--- a/include/triton/Dialect/TritonInstrument/IR/Utility.h
+++ b/include/triton/Dialect/TritonInstrument/IR/Utility.h
@@ -241,6 +241,11 @@ struct AuxDataMap {
   triton::BufferStatePlan bufferStatePlans[numMemTypes];
   DenseMap<Value, BufferStateCandidates> bufferCandidates[numMemTypes];
 
+  // Barrier footprints that may alias ordinary shared-memory effects. Their
+  // masks use the same physical state lanes as the overlapping payloads.
+  SmallVector<std::pair<triton::BufferRegion, llvm::SmallBitVector>>
+      sharedBarrierMasks;
+
   // scratch pointer, i32
   // Shared-cluster lock used to serialize ConSan instrumentation updates.
   RegionToValueMap lock;

--- a/include/triton/Dialect/TritonInstrument/Transforms/ConSanTargetHooks.h
+++ b/include/triton/Dialect/TritonInstrument/Transforms/ConSanTargetHooks.h
@@ -129,8 +129,6 @@ public:
   virtual std::optional<MemEffectsOpInfo>
   getMemEffectsOpInfo(Operation *op) const {
     namespace ttg = triton::gpu;
-    if (getBarrierInitInfo(op) || getBarrierInvalidateInfo(op))
-      return std::nullopt;
     MemEffectsOpInfo info;
     if (isa<ttg::AsyncCopyGlobalToLocalOp>(op)) {
       info.trackingKind = MemEffectsOpInfo::TrackingKind::CommitCount;

--- a/include/triton/Dialect/TritonInstrument/Transforms/ConSanTargetHooks.h
+++ b/include/triton/Dialect/TritonInstrument/Transforms/ConSanTargetHooks.h
@@ -173,6 +173,9 @@ public:
 
   virtual SmallVector<CommitKind::Kind>
   getRequiredCommitKinds(ModuleOp module) const = 0;
+
+  // AMD barriers are ordinary LDS objects and have no invalidate operation.
+  virtual bool barrierWritesInvalidate() const { return false; }
 };
 
 LogicalResult runConcurrencySanitizer(ModuleOp module,

--- a/lib/Analysis/BufferRegion.cpp
+++ b/lib/Analysis/BufferRegion.cpp
@@ -215,13 +215,6 @@ uint32_t getMemDescStorageOffset(ttg::MemDescType ty, unsigned index) {
                             ty);
 }
 
-bool isUsedAsBarrier(Value v) {
-  return llvm::any_of(v.getUsers(), [&](Operation *user) {
-    auto barrierOp = dyn_cast<ttg::MBarrierOpInterface>(user);
-    return barrierOp && llvm::is_contained(barrierOp.getBarriers(), v);
-  });
-}
-
 struct MemDescSubsliceOffsets {
   uint32_t byteOffset = 0;
   uint32_t partitionOffset = 0;
@@ -278,15 +271,6 @@ getMemDescSubsliceUnpaddedOffsets(ttg::MemDescSubsliceOp op) {
   assert(elementSizeBytes > 0 && "element size must be non-zero");
   return MemDescSubsliceOffsets{elementOffset * elementSizeBytes,
                                 partitionOffset, blockOffset};
-}
-
-triton::BufferRegionAnalysis::RegionType getRegionType(Value v) {
-  if (isUsedAsBarrier(v))
-    return triton::BufferRegionAnalysis::RegionType::BARRIER;
-  return isa<ttng::TensorMemorySpaceAttr>(
-             cast<ttg::MemDescType>(v.getType()).getMemorySpace())
-             ? triton::BufferRegionAnalysis::RegionType::TENSOR_MEMORY
-             : triton::BufferRegionAnalysis::RegionType::SHARED_MEMORY;
 }
 
 } // namespace
@@ -627,13 +611,21 @@ LogicalResult BufferRegionAnalysis::visitOperation(
 void BufferRegionAnalysis::calculateUsedBufferRegions(Operation *op) {
   op->walk([&](Operation *op) {
     for (const MemoryAccess &access : getMemoryAccesses(op)) {
-      RegionType regionType = getRegionType(access.value);
       const RegionInfo &regionInfo =
           getLatticeElement(access.value)->getValue();
-      if (regionInfo.isUnknown())
-        usedUnknownBufferRegions[regionType] = true;
-      for (const BufferRegionView &view : regionInfo.views)
-        usedBufferRegions[regionType].insert(view.region);
+      auto addRegions = [&](RegionType regionType) {
+        if (regionInfo.isUnknown())
+          usedUnknownBufferRegions[regionType] = true;
+        for (const BufferRegionView &view : regionInfo.views)
+          usedBufferRegions[regionType].insert(view.region);
+      };
+
+      bool isTensorMemory = isa<ttng::TensorMemorySpaceAttr>(
+          cast<ttg::MemDescType>(access.value.getType()).getMemorySpace());
+      addRegions(isTensorMemory ? TENSOR_MEMORY : SHARED_MEMORY);
+      if (auto barrierOp = dyn_cast<ttg::MBarrierOpInterface>(op))
+        if (llvm::is_contained(barrierOp.getBarriers(), access.value))
+          addRegions(BARRIER);
     }
   });
 }

--- a/lib/Dialect/TritonInstrument/IR/FunctionBuilder.cpp
+++ b/lib/Dialect/TritonInstrument/IR/FunctionBuilder.cpp
@@ -2520,11 +2520,20 @@ void FunctionBuilder::createPublishCTAVisibilityCall(ImplicitLocOpBuilder &b,
   SmallVector<Value> args = {arith::ConstantIntOp::create(b, sourceMask, 64),
                              arith::ConstantIntOp::create(b, destMask, 64),
                              writeVis.value, readVis.value};
+  ManglingArgs specializationArgs{writeVisibilityType, readVisibilityType};
+  RankedTensorType proxyVisibilityType;
+  if (memType == MemType::SHARED_MEM &&
+      !auxData.proxyAccessVisibility.empty()) {
+    auto proxyVis = auxData.proxyAccessVisibility.at(insertPoint);
+    proxyVisibilityType = cast<RankedTensorType>(proxyVis.type);
+    args.push_back(proxyVis.value);
+    specializationArgs.append(proxyVisibilityType);
+  }
   createCallToCachedFunction(
       b, "publish_cta_visibility", args,
-      /*assertInfo=*/std::nullopt, {writeVisibilityType, readVisibilityType},
-      [writeVisibilityType, readVisibilityType](ImplicitLocOpBuilder &fb,
-                                                Block *entryBlock) {
+      /*assertInfo=*/std::nullopt, specializationArgs,
+      [writeVisibilityType, readVisibilityType,
+       proxyVisibilityType](ImplicitLocOpBuilder &fb, Block *entryBlock) {
         Value sourceMask = entryBlock->getArgument(0);
         Value destMask = entryBlock->getArgument(1);
         Value writeVisibilityPtr = entryBlock->getArgument(2);
@@ -2556,28 +2565,33 @@ void FunctionBuilder::createPublishCTAVisibilityCall(ImplicitLocOpBuilder &b,
                                        newWriteVisibility, writeVisibilityType,
                                        writeCTAMask);
 
-        Value readVisibility = tti::createLoadScratchMemory(
-            fb, fb.getLoc(), readVisibilityPtr, readVisibilityType);
-        Value zeroReads =
-            tti::createConstIntTensor(fb, fb.getLoc(), 0, readVisibilityType);
-        Value sourceColumns = createThreadColumnMask(
-            fb, sourceMask, readVisibilityType, /*columnDim=*/3);
-        Value sourceReads = arith::SelectOp::create(fb, sourceColumns,
-                                                    readVisibility, zeroReads);
-        sourceReads = reduce<arith::OrIOp>(fb, sourceReads, {3});
-        sourceReads = convertAndBroadcast(fb, sourceReads, {0, 1, 2, 4},
-                                          readVisibilityType);
-        Value destColumns = createThreadColumnMask(
-            fb, destMask, readVisibilityType, /*columnDim=*/3);
-        Value publishedReads =
-            arith::SelectOp::create(fb, destColumns, sourceReads, zeroReads);
-        Value newReadVisibility =
-            arith::OrIOp::create(fb, readVisibility, publishedReads);
-        Value readCTAMask =
-            createCTASetMask(fb, readVisibilityType, /*dim=*/2, currentCTA);
-        createMaskedStoreScratchMemory(fb, fb.getLoc(), readVisibilityPtr,
-                                       newReadVisibility, readVisibilityType,
-                                       readCTAMask);
+        auto publishObserverVisibility = [&](Value visibilityPtr,
+                                             RankedTensorType visibilityType) {
+          Value visibility = tti::createLoadScratchMemory(
+              fb, fb.getLoc(), visibilityPtr, visibilityType);
+          Value zero =
+              tti::createConstIntTensor(fb, fb.getLoc(), 0, visibilityType);
+          Value sourceColumns = createThreadColumnMask(
+              fb, sourceMask, visibilityType, /*columnDim=*/3);
+          Value source =
+              arith::SelectOp::create(fb, sourceColumns, visibility, zero);
+          source = reduce<arith::OrIOp>(fb, source, {3});
+          source =
+              convertAndBroadcast(fb, source, {0, 1, 2, 4}, visibilityType);
+          Value destColumns = createThreadColumnMask(
+              fb, destMask, visibilityType, /*columnDim=*/3);
+          Value published =
+              arith::SelectOp::create(fb, destColumns, source, zero);
+          Value updated = arith::OrIOp::create(fb, visibility, published);
+          Value ctaMask =
+              createCTASetMask(fb, visibilityType, /*dim=*/2, currentCTA);
+          createMaskedStoreScratchMemory(fb, fb.getLoc(), visibilityPtr,
+                                         updated, visibilityType, ctaMask);
+        };
+        publishObserverVisibility(readVisibilityPtr, readVisibilityType);
+        if (proxyVisibilityType)
+          publishObserverVisibility(entryBlock->getArgument(4),
+                                    proxyVisibilityType);
 
         triton::ReturnOp::create(fb);
       });

--- a/lib/Dialect/TritonInstrument/IR/FunctionBuilder.cpp
+++ b/lib/Dialect/TritonInstrument/IR/FunctionBuilder.cpp
@@ -2446,9 +2446,11 @@ void FunctionBuilder::createCopyWriteVisibilityCall(ImplicitLocOpBuilder &b,
       });
 }
 
-void FunctionBuilder::createCopyReadVisibilityCall(
-    ImplicitLocOpBuilder &b, int sourceThread, uint64_t destMask, Value pred,
-    MemType memType, Operation *insertPoint, bool merge) {
+void FunctionBuilder::createCopyReadVisibilityCall(ImplicitLocOpBuilder &b,
+                                                   int sourceThread,
+                                                   uint64_t destMask,
+                                                   Value pred, MemType memType,
+                                                   Operation *insertPoint) {
 
   if (auxData.readVisibility[(int)memType].empty()) {
     return;
@@ -2462,8 +2464,8 @@ void FunctionBuilder::createCopyReadVisibilityCall(
   SmallVector<Value> args = {sourceThreadVal, destMaskVal, pred, readVis.value};
   createCallToCachedFunction(
       b, "copy_read_visibility", args,
-      /*assertInfo=*/std::nullopt, {readVisibilityType, (uint64_t)merge},
-      [readVisibilityType, merge](ImplicitLocOpBuilder &fb, Block *entryBlock) {
+      /*assertInfo=*/std::nullopt, {readVisibilityType},
+      [readVisibilityType](ImplicitLocOpBuilder &fb, Block *entryBlock) {
         Value sourceThread = entryBlock->getArgument(0);
         Value destMaskVal = entryBlock->getArgument(1);
         Value pred = entryBlock->getArgument(2);
@@ -2491,8 +2493,7 @@ void FunctionBuilder::createCopyReadVisibilityCall(
         Value replicated = arith::SelectOp::create(fb, destMaskTensor,
                                                    broadcastRow, zeroTensor);
 
-        Value retained = merge ? readVisibility : cleared;
-        Value updated = arith::OrIOp::create(fb, retained, replicated);
+        Value updated = arith::OrIOp::create(fb, cleared, replicated);
         Value currentCTAMask = createCTASetMask(
             fb, readVisibilityType, /*dim=*/2, createCurrentCTAMask(fb));
         createMaskedStoreScratchMemory(fb, fb.getLoc(), readVisibilityPtr,
@@ -2500,6 +2501,84 @@ void FunctionBuilder::createCopyReadVisibilityCall(
                                        currentCTAMask);
 
         fb.setInsertionPointToEnd(thenBlock);
+        triton::ReturnOp::create(fb);
+      });
+}
+
+void FunctionBuilder::createPublishCTAVisibilityCall(ImplicitLocOpBuilder &b,
+                                                     uint64_t sourceMask,
+                                                     uint64_t destMask,
+                                                     MemType memType,
+                                                     Operation *insertPoint) {
+  if (auxData.writeVisibility[(int)memType].empty())
+    return;
+
+  auto writeVis = auxData.writeVisibility[(int)memType].at(insertPoint);
+  auto readVis = auxData.readVisibility[(int)memType].at(insertPoint);
+  auto writeVisibilityType = cast<RankedTensorType>(writeVis.type);
+  auto readVisibilityType = cast<RankedTensorType>(readVis.type);
+  SmallVector<Value> args = {arith::ConstantIntOp::create(b, sourceMask, 64),
+                             arith::ConstantIntOp::create(b, destMask, 64),
+                             writeVis.value, readVis.value};
+  createCallToCachedFunction(
+      b, "publish_cta_visibility", args,
+      /*assertInfo=*/std::nullopt, {writeVisibilityType, readVisibilityType},
+      [writeVisibilityType, readVisibilityType](ImplicitLocOpBuilder &fb,
+                                                Block *entryBlock) {
+        Value sourceMask = entryBlock->getArgument(0);
+        Value destMask = entryBlock->getArgument(1);
+        Value writeVisibilityPtr = entryBlock->getArgument(2);
+        Value readVisibilityPtr = entryBlock->getArgument(3);
+        Value currentCTA = createCurrentCTAMask(fb);
+
+        Value writeVisibility = tti::createLoadScratchMemory(
+            fb, fb.getLoc(), writeVisibilityPtr, writeVisibilityType);
+        Value zeroWrites =
+            tti::createConstIntTensor(fb, fb.getLoc(), 0, writeVisibilityType);
+        auto writeElemType =
+            cast<IntegerType>(writeVisibilityType.getElementType());
+        Value sourceBits = triton::SplatOp::create(
+            fb, writeVisibilityType,
+            adjustIntegerWidth(fb, sourceMask, writeElemType));
+        Value destBits = triton::SplatOp::create(
+            fb, writeVisibilityType,
+            adjustIntegerWidth(fb, destMask, writeElemType));
+        Value sourceVisible = arith::CmpIOp::create(
+            fb, arith::CmpIPredicate::ne,
+            arith::AndIOp::create(fb, writeVisibility, sourceBits), zeroWrites);
+        Value publishedWrites =
+            arith::SelectOp::create(fb, sourceVisible, destBits, zeroWrites);
+        Value newWriteVisibility =
+            arith::OrIOp::create(fb, writeVisibility, publishedWrites);
+        Value writeCTAMask =
+            createCTASetMask(fb, writeVisibilityType, /*dim=*/2, currentCTA);
+        createMaskedStoreScratchMemory(fb, fb.getLoc(), writeVisibilityPtr,
+                                       newWriteVisibility, writeVisibilityType,
+                                       writeCTAMask);
+
+        Value readVisibility = tti::createLoadScratchMemory(
+            fb, fb.getLoc(), readVisibilityPtr, readVisibilityType);
+        Value zeroReads =
+            tti::createConstIntTensor(fb, fb.getLoc(), 0, readVisibilityType);
+        Value sourceColumns = createThreadColumnMask(
+            fb, sourceMask, readVisibilityType, /*columnDim=*/3);
+        Value sourceReads = arith::SelectOp::create(fb, sourceColumns,
+                                                    readVisibility, zeroReads);
+        sourceReads = reduce<arith::OrIOp>(fb, sourceReads, {3});
+        sourceReads = convertAndBroadcast(fb, sourceReads, {0, 1, 2, 4},
+                                          readVisibilityType);
+        Value destColumns = createThreadColumnMask(
+            fb, destMask, readVisibilityType, /*columnDim=*/3);
+        Value publishedReads =
+            arith::SelectOp::create(fb, destColumns, sourceReads, zeroReads);
+        Value newReadVisibility =
+            arith::OrIOp::create(fb, readVisibility, publishedReads);
+        Value readCTAMask =
+            createCTASetMask(fb, readVisibilityType, /*dim=*/2, currentCTA);
+        createMaskedStoreScratchMemory(fb, fb.getLoc(), readVisibilityPtr,
+                                       newReadVisibility, readVisibilityType,
+                                       readCTAMask);
+
         triton::ReturnOp::create(fb);
       });
 }

--- a/lib/Dialect/TritonInstrument/IR/FunctionBuilder.cpp
+++ b/lib/Dialect/TritonInstrument/IR/FunctionBuilder.cpp
@@ -398,13 +398,10 @@ Value createCTASetMask(ImplicitLocOpBuilder &b, RankedTensorType tensorType,
   return arith::CmpIOp::create(b, arith::CmpIPredicate::ne, selectedBit, zero);
 }
 
-static void createVerifyBarrierStateCall(ImplicitLocOpBuilder &b,
-                                         StringRef functionName,
-                                         StringRef message, Value offset,
-                                         Value length, Value pred,
-                                         ValueType barriers, ValueType states,
-                                         Value recipientCTAs, bool matchOverlap,
-                                         bool requireInitialized) {
+static void createVerifyBarrierAvailableCall(
+    ImplicitLocOpBuilder &b, StringRef functionName, StringRef message,
+    Value offset, Value length, Value pred, ValueType barriers,
+    ValueType states, Value recipientCTAs) {
   if (!pred)
     pred = arith::ConstantIntOp::create(b, 1, 1);
   auto barriersType = cast<RankedTensorType>(barriers.type);
@@ -414,8 +411,7 @@ static void createVerifyBarrierStateCall(ImplicitLocOpBuilder &b,
   AssertInfo assertInfo{message, b.getI1Type()};
   createCallToCachedFunction(
       b, functionName.str(), args, assertInfo, {barriersType, statesType},
-      [statesType, matchOverlap, requireInitialized](ImplicitLocOpBuilder &fb,
-                                                     Block *entryBlock) {
+      [statesType](ImplicitLocOpBuilder &fb, Block *entryBlock) {
         Value offset = entryBlock->getArgument(0);
         Value length = entryBlock->getArgument(1);
         Value pred = entryBlock->getArgument(2);
@@ -423,21 +419,14 @@ static void createVerifyBarrierStateCall(ImplicitLocOpBuilder &b,
         Value statesPtr = entryBlock->getArgument(4);
         Value recipientCTAs = entryBlock->getArgument(5);
 
-        Value selected;
-        if (matchOverlap) {
-          selected = createBufferOverlapMask(fb, barriers, offset, length);
-        } else {
-          Value descriptor = createBufferDescriptor(fb, offset, length);
-          selected = createCmpIntTensorScalar(fb, barriers, descriptor);
-        }
+        Value selected = createBufferOverlapMask(fb, barriers, offset, length);
         selected = convertAndBroadcast(fb, selected, {1}, statesType);
 
         Value states = tti::createLoadScratchMemory(fb, fb.getLoc(), statesPtr,
                                                     statesType);
         Value zero = tti::createConstIntTensor(fb, fb.getLoc(), 0, statesType);
-        auto predicate = requireInitialized ? arith::CmpIPredicate::ne
-                                            : arith::CmpIPredicate::eq;
-        Value valid = arith::CmpIOp::create(fb, predicate, states, zero);
+        Value valid =
+            arith::CmpIOp::create(fb, arith::CmpIPredicate::eq, states, zero);
         auto condType = cast<RankedTensorType>(valid.getType());
         Value vTrue = tti::createConstIntTensor(fb, fb.getLoc(), 1, condType);
         valid = arith::SelectOp::create(fb, selected, valid, vTrue);
@@ -1036,14 +1025,13 @@ void FunctionBuilder::createVerifyBarrierCanInitCall(ImplicitLocOpBuilder &b,
          "barrier descriptors must exist when verifying barrier init");
   assert(!auxData.barrierStates.empty() &&
          "barrier states must exist when verifying barrier init");
-  createVerifyBarrierStateCall(
+  createVerifyBarrierAvailableCall(
       b, "verify_barrier_can_init",
       "Barrier re-initialized without prior invalidation",
       tti::ExperimentalMemDescToI32Op::create(b, mbar),
       arith::ConstantIntOp::create(b, getMemDescLength(mbar), 32), pred,
       auxData.barriers.at(insertPoint), auxData.barrierStates.at(insertPoint),
-      recipientCTAs,
-      /*matchOverlap=*/true, /*requireInitialized=*/false);
+      recipientCTAs);
 }
 
 void FunctionBuilder::createVerifyBarrierInitializedCall(
@@ -1053,26 +1041,66 @@ void FunctionBuilder::createVerifyBarrierInitializedCall(
          "barrier descriptors must exist when verifying barrier use");
   assert(!auxData.barrierStates.empty() &&
          "barrier states must exist when verifying barrier use");
-  createVerifyBarrierStateCall(
-      b, "verify_barrier_initialized",
+  if (!pred) {
+    pred = arith::ConstantIntOp::create(b, 1, 1);
+  }
+  Value barriersVal = auxData.barriers.at(insertPoint).value;
+  auto barriersType =
+      cast<RankedTensorType>(auxData.barriers.at(insertPoint).type);
+  Value barrierStatesVal = auxData.barrierStates.at(insertPoint).value;
+  auto barrierStatesType =
+      cast<RankedTensorType>(auxData.barrierStates.at(insertPoint).type);
+  uint32_t length = getMemDescLength(mbar);
+  Value mbarOffset = tti::ExperimentalMemDescToI32Op::create(b, mbar);
+  Value lengthVal = arith::ConstantIntOp::create(b, length, 32);
+  SmallVector<Value> args = {mbarOffset,  lengthVal,        pred,
+                             barriersVal, barrierStatesVal, recipientCTAs};
+  AssertInfo assertInfo{
       "Barrier used before initialization or after invalidation",
-      tti::ExperimentalMemDescToI32Op::create(b, mbar),
-      arith::ConstantIntOp::create(b, getMemDescLength(mbar), 32), pred,
-      auxData.barriers.at(insertPoint), auxData.barrierStates.at(insertPoint),
-      recipientCTAs,
-      /*matchOverlap=*/false, /*requireInitialized=*/true);
+      b.getI1Type()};
+  createCallToCachedFunction(
+      b, "verify_barrier_initialized", args, assertInfo,
+      {barriersType, barrierStatesType},
+      [barrierStatesType](ImplicitLocOpBuilder &fb, Block *entryBlock) {
+        Value mbarOffset = entryBlock->getArgument(0);
+        Value lengthVal = entryBlock->getArgument(1);
+        Value pred = entryBlock->getArgument(2);
+        Value barriers = entryBlock->getArgument(3);
+        Value statesPtr = entryBlock->getArgument(4);
+        Value recipientCTAs = entryBlock->getArgument(5);
+
+        Value states = tti::createLoadScratchMemory(fb, fb.getLoc(), statesPtr,
+                                                    barrierStatesType);
+        Value descriptor = createBufferDescriptor(fb, mbarOffset, lengthVal);
+        Value mask = createCmpIntTensorScalar(fb, barriers, descriptor);
+        mask = convertAndBroadcast(fb, mask, {1}, barrierStatesType);
+        Value zero =
+            tti::createConstIntTensor(fb, fb.getLoc(), 0, barrierStatesType);
+        Value initialized =
+            arith::CmpIOp::create(fb, arith::CmpIPredicate::ne, states, zero);
+        auto condType = cast<RankedTensorType>(initialized.getType());
+        Value vTrue = tti::createConstIntTensor(fb, fb.getLoc(), 1, condType);
+        initialized = arith::SelectOp::create(fb, mask, initialized, vTrue);
+        Value ctaMask =
+            createCTASetMask(fb, condType, /*dim=*/0, recipientCTAs);
+        initialized = arith::SelectOp::create(fb, ctaMask, initialized, vTrue);
+        Value predTensor = triton::SplatOp::create(fb, condType, pred);
+        Value predicatedInitialized =
+            arith::SelectOp::create(fb, predTensor, initialized, vTrue);
+        triton::ReturnOp::create(
+            fb, reduceAll<arith::AndIOp>(fb, predicatedInitialized));
+      });
 }
 
 void FunctionBuilder::createVerifyBarrierMemoryAvailableCall(
     ImplicitLocOpBuilder &b, Value offset, uint32_t length, Value pred,
     Operation *insertPoint, Value recipientCTAs) {
-  createVerifyBarrierStateCall(
+  createVerifyBarrierAvailableCall(
       b, "verify_barrier_memory_available",
       "Shared memory reused before barrier invalidation", offset,
       arith::ConstantIntOp::create(b, length, 32), pred,
       auxData.barriers.at(insertPoint), auxData.barrierStates.at(insertPoint),
-      recipientCTAs,
-      /*matchOverlap=*/true, /*requireInitialized=*/false);
+      recipientCTAs);
 }
 
 void FunctionBuilder::createInitBarrierStateCall(ImplicitLocOpBuilder &b,
@@ -1715,11 +1743,13 @@ void FunctionBuilder::createSetReadVisibilityCall(ImplicitLocOpBuilder &b,
 
 void FunctionBuilder::createTrackVisibleAccessesCall(
     ImplicitLocOpBuilder &b, Value mbar, int thread, Value pred,
-    MemType memType, Operation *insertPoint, Value barrierCTAs) {
+    MemType memType, Operation *insertPoint, Value barrierCTAs,
+    Value readBufferMask) {
   if (auxData.barriers.empty())
     return;
 
-  const bool trackWrites = !auxData.writeVisibility[(int)memType].empty() &&
+  const bool trackWrites = !readBufferMask &&
+                           !auxData.writeVisibility[(int)memType].empty() &&
                            !auxData.writeTracking[(int)memType].empty();
   const bool trackReads = !auxData.readVisibility[(int)memType].empty() &&
                           !auxData.readTracking[(int)memType].empty();
@@ -1767,12 +1797,16 @@ void FunctionBuilder::createTrackVisibleAccessesCall(
     specializationArgs.append(readVisibilityType);
     specializationArgs.append(readTrackingType);
   }
+  if (readBufferMask)
+    args.push_back(readBufferMask);
 
   createCallToCachedFunction(
-      b, "track_visible_accesses", args, /*assertInfo=*/std::nullopt,
-      specializationArgs,
+      b,
+      readBufferMask ? "track_barrier_read_for_buffer"
+                     : "track_visible_accesses",
+      args, /*assertInfo=*/std::nullopt, specializationArgs,
       [trackWrites, trackReads, writeVisibilityType, writeTrackingType,
-       readVisibilityType,
+       readVisibilityType, filterBuffer = static_cast<bool>(readBufferMask),
        readTrackingType](ImplicitLocOpBuilder &fb, Block *entryBlock) {
         Value mbarOffset = entryBlock->getArgument(0);
         Value lengthVal = entryBlock->getArgument(1);
@@ -1840,120 +1874,42 @@ void FunctionBuilder::createTrackVisibleAccessesCall(
           Value barrierCTAMask =
               createCTASetMask(fb, readTrackingType, /*dim=*/2, barrierCTAs);
           barrierMask = arith::AndIOp::create(fb, barrierMask, barrierCTAMask);
+          if (filterBuffer) {
+            Value bufferMask = convertAndBroadcast(
+                fb, entryBlock->getArguments().back(), {1}, readTrackingType);
+            Value bufferCTAMask =
+                createCTASetMask(fb, readTrackingType, /*dim=*/0, barrierCTAs);
+            barrierMask = arith::AndIOp::create(fb, barrierMask, bufferMask);
+            barrierMask = arith::AndIOp::create(fb, barrierMask, bufferCTAMask);
+          }
           Value threadColumnMask =
               createDimMask(fb, threadVal, readVisibilityType, /*dim=*/3);
           Value zero =
               tti::createConstIntTensor(fb, fb.getLoc(), 0, readVisibilityType);
-          Value visibleReads =
-              arith::SelectOp::create(fb, threadColumnMask, visibility, zero);
           Value sourceCTAMask =
               createCTASetMask(fb, readVisibilityType, /*dim=*/2, currentCTA);
-          visibleReads =
-              arith::SelectOp::create(fb, sourceCTAMask, visibleReads, zero);
+          Value visibleReads;
+          if (filterBuffer) {
+            Value observer =
+                arith::AndIOp::create(fb, threadColumnMask, sourceCTAMask);
+            visibleReads =
+                arith::SelectOp::create(fb, observer, visibility, zero);
+          } else {
+            visibleReads =
+                arith::SelectOp::create(fb, threadColumnMask, visibility, zero);
+            visibleReads =
+                arith::SelectOp::create(fb, sourceCTAMask, visibleReads, zero);
+          }
           visibleReads = reduce<arith::OrIOp>(fb, visibleReads, {2, 3});
           visibleReads = convertAndBroadcast(fb, visibleReads, {0, 1, 4},
                                              readTrackingType);
           Value withVisible = arith::OrIOp::create(fb, tracking, visibleReads);
           Value updated =
               arith::SelectOp::create(fb, barrierMask, withVisible, tracking);
-          createMaskedStoreScratchMemory(fb, fb.getLoc(), trackingPtr, updated,
-                                         readTrackingType, barrierCTAMask);
+          createMaskedStoreScratchMemory(
+              fb, fb.getLoc(), trackingPtr, updated, readTrackingType,
+              filterBuffer ? barrierMask : barrierCTAMask);
         }
-
-        fb.setInsertionPointToEnd(thenBlock);
-        triton::ReturnOp::create(fb);
-      });
-}
-
-static void createTrackBarrierBufferCall(ImplicitLocOpBuilder &b,
-                                         StringRef functionName, Value mbar,
-                                         Value bufferMask, Value pred,
-                                         ValueType barriers, ValueType tracking,
-                                         Value barrierCTAs, Value effectCTAs,
-                                         ValueType visibility, int thread) {
-  bool trackRead = static_cast<bool>(visibility.value);
-  if (!pred)
-    pred = arith::ConstantIntOp::create(b, 1, 1);
-  auto barriersType = cast<RankedTensorType>(barriers.type);
-  auto trackingType = cast<RankedTensorType>(tracking.type);
-  RankedTensorType visibilityType;
-  SmallVector<Value> args = {
-      tti::ExperimentalMemDescToI32Op::create(b, mbar),
-      arith::ConstantIntOp::create(b, getMemDescLength(mbar), 32),
-      pred,
-      bufferMask,
-      barriers.value,
-      tracking.value,
-      barrierCTAs,
-      effectCTAs};
-  ManglingArgs specializationArgs{barriersType, trackingType};
-  if (trackRead) {
-    visibilityType = cast<RankedTensorType>(visibility.type);
-    args.append(
-        {arith::ConstantIntOp::create(b, thread, 32), visibility.value});
-    specializationArgs.append(visibilityType);
-  }
-  createCallToCachedFunction(
-      b, functionName.str(), args, /*assertInfo=*/std::nullopt,
-      specializationArgs,
-      [trackingType, visibilityType, trackRead](ImplicitLocOpBuilder &fb,
-                                                Block *entryBlock) {
-        Value mbarOffset = entryBlock->getArgument(0);
-        Value mbarLength = entryBlock->getArgument(1);
-        Value pred = entryBlock->getArgument(2);
-        Value bufferMask = entryBlock->getArgument(3);
-        Value barriers = entryBlock->getArgument(4);
-        Value trackingPtr = entryBlock->getArgument(5);
-        Value barrierCTAs = entryBlock->getArgument(6);
-        Value effectCTAs = entryBlock->getArgument(7);
-
-        auto [prevBlock, ifBlock, thenBlock] = createIfBlock(fb, pred);
-        fb.setInsertionPointToStart(ifBlock);
-
-        Value tracking = tti::createLoadScratchMemory(
-            fb, fb.getLoc(), trackingPtr, trackingType);
-        Value barrierDescriptor =
-            createBufferDescriptor(fb, mbarOffset, mbarLength);
-        Value trackMask =
-            createCmpIntTensorScalar(fb, barriers, barrierDescriptor);
-        trackMask = convertAndBroadcast(fb, trackMask, {3}, trackingType);
-        bufferMask = convertAndBroadcast(fb, bufferMask, {1}, trackingType);
-        trackMask = arith::AndIOp::create(fb, trackMask, bufferMask);
-        trackMask = arith::AndIOp::create(
-            fb, trackMask,
-            createCTASetMask(fb, trackingType, /*dim=*/0, effectCTAs));
-        Value barrierCTAMask =
-            createCTASetMask(fb, trackingType, /*dim=*/2, barrierCTAs);
-        trackMask = arith::AndIOp::create(fb, trackMask, barrierCTAMask);
-
-        Value updated;
-        if (trackRead) {
-          Value thread = entryBlock->getArgument(8);
-          Value visibilityPtr = entryBlock->getArgument(9);
-          Value visibility = tti::createLoadScratchMemory(
-              fb, fb.getLoc(), visibilityPtr, visibilityType);
-          Value observer = createDimMask(fb, thread, visibilityType, /*dim=*/3);
-          observer = arith::AndIOp::create(
-              fb, observer,
-              createCTASetMask(fb, visibilityType, /*dim=*/2,
-                               createCurrentCTAMask(fb)));
-          Value zero =
-              tti::createConstIntTensor(fb, fb.getLoc(), 0, visibilityType);
-          Value visibleReads =
-              arith::SelectOp::create(fb, observer, visibility, zero);
-          visibleReads = reduce<arith::OrIOp>(fb, visibleReads, {2, 3});
-          visibleReads =
-              convertAndBroadcast(fb, visibleReads, {0, 1, 4}, trackingType);
-          Value withVisible = arith::OrIOp::create(fb, tracking, visibleReads);
-          updated =
-              arith::SelectOp::create(fb, trackMask, withVisible, tracking);
-        } else {
-          Value one =
-              tti::createConstIntTensor(fb, fb.getLoc(), 1, trackingType);
-          updated = arith::SelectOp::create(fb, trackMask, one, tracking);
-        }
-        createMaskedStoreScratchMemory(fb, fb.getLoc(), trackingPtr, updated,
-                                       trackingType, trackMask);
 
         fb.setInsertionPointToEnd(thenBlock);
         triton::ReturnOp::create(fb);
@@ -1964,28 +1920,68 @@ void FunctionBuilder::createTrackBarrierWriteForBufferCall(
     ImplicitLocOpBuilder &b, Value mbar, Value bufferMask, Value pred,
     MemType memType, Operation *insertPoint, Value barrierCTAs,
     Value effectCTAs) {
-  if (auxData.barriers.empty() || auxData.writeTracking[(int)memType].empty())
+  if (auxData.barriers.empty() || auxData.writeTracking[(int)memType].empty()) {
     return;
-  createTrackBarrierBufferCall(
-      b, "track_barrier_write_for_buffer", mbar, bufferMask, pred,
-      auxData.barriers.at(insertPoint),
-      auxData.writeTracking[(int)memType].at(insertPoint), barrierCTAs,
-      effectCTAs, /*visibility=*/{}, /*thread=*/0);
-}
+  }
+  if (!pred)
+    pred = arith::ConstantIntOp::create(b, 1, 1);
+  Value barriersVal = auxData.barriers.at(insertPoint).value;
+  auto barriersType =
+      cast<RankedTensorType>(auxData.barriers.at(insertPoint).type);
+  Value writeTrackingVal =
+      auxData.writeTracking[(int)memType].at(insertPoint).value;
+  auto writeTrackingType = cast<RankedTensorType>(
+      auxData.writeTracking[(int)memType].at(insertPoint).type);
+  uint32_t mbarLength = getMemDescLength(mbar);
+  Value mbarOffset = tti::ExperimentalMemDescToI32Op::create(b, mbar);
+  Value mbarLengthVal = arith::ConstantIntOp::create(b, mbarLength, 32);
+  SmallVector<Value> args = {mbarOffset,  mbarLengthVal, pred,
+                             bufferMask,  barriersVal,   writeTrackingVal,
+                             barrierCTAs, effectCTAs};
+  createCallToCachedFunction(
+      b, "track_barrier_write_for_buffer", args,
+      /*assertInfo=*/std::nullopt, {barriersType, writeTrackingType},
+      [writeTrackingType](ImplicitLocOpBuilder &fb, Block *entryBlock) {
+        Value mbarOffset = entryBlock->getArgument(0);
+        Value mbarLengthVal = entryBlock->getArgument(1);
+        Value pred = entryBlock->getArgument(2);
+        Value bufferMask = entryBlock->getArgument(3);
+        Value barriers = entryBlock->getArgument(4);
+        Value writeTrackingPtr = entryBlock->getArgument(5);
+        Value barrierCTAs = entryBlock->getArgument(6);
+        Value effectCTAs = entryBlock->getArgument(7);
 
-void FunctionBuilder::createTrackBarrierReadForBufferCall(
-    ImplicitLocOpBuilder &b, Value mbar, Value bufferMask, int thread,
-    Value pred, MemType memType, Operation *insertPoint, Value barrierCTAs,
-    Value effectCTAs) {
-  if (auxData.barriers.empty() ||
-      auxData.readVisibility[(int)memType].empty() ||
-      auxData.readTracking[(int)memType].empty())
-    return;
-  createTrackBarrierBufferCall(
-      b, "track_barrier_read_for_buffer", mbar, bufferMask, pred,
-      auxData.barriers.at(insertPoint),
-      auxData.readTracking[(int)memType].at(insertPoint), barrierCTAs,
-      effectCTAs, auxData.readVisibility[(int)memType].at(insertPoint), thread);
+        auto [prevBlock, ifBlock, thenBlock] = createIfBlock(fb, pred);
+        fb.setInsertionPointToStart(ifBlock);
+
+        Value writeTracking = tti::createLoadScratchMemory(
+            fb, fb.getLoc(), writeTrackingPtr, writeTrackingType);
+        Value barrierDescriptor =
+            createBufferDescriptor(fb, mbarOffset, mbarLengthVal);
+        Value barriersEqBar =
+            createCmpIntTensorScalar(fb, barriers, barrierDescriptor);
+        barriersEqBar =
+            convertAndBroadcast(fb, barriersEqBar, {3}, writeTrackingType);
+        bufferMask =
+            convertAndBroadcast(fb, bufferMask, {1}, writeTrackingType);
+        Value bufferCTAMask =
+            createCTASetMask(fb, writeTrackingType, /*dim=*/0, effectCTAs);
+        Value barrierCTAMask =
+            createCTASetMask(fb, writeTrackingType, /*dim=*/2, barrierCTAs);
+        Value trackMask = arith::AndIOp::create(fb, barriersEqBar, bufferMask);
+        trackMask = arith::AndIOp::create(fb, trackMask, bufferCTAMask);
+        trackMask = arith::AndIOp::create(fb, trackMask, barrierCTAMask);
+        Value writeTrackingOne =
+            tti::createConstIntTensor(fb, fb.getLoc(), 1, writeTrackingType);
+        Value newTracking = arith::SelectOp::create(
+            fb, trackMask, writeTrackingOne, writeTracking);
+        createMaskedStoreScratchMemory(fb, fb.getLoc(), writeTrackingPtr,
+                                       newTracking, writeTrackingType,
+                                       trackMask);
+
+        fb.setInsertionPointToEnd(thenBlock);
+        triton::ReturnOp::create(fb);
+      });
 }
 
 static void createClearBarrierTrackingCall(ImplicitLocOpBuilder &b,

--- a/lib/Dialect/TritonInstrument/IR/FunctionBuilder.cpp
+++ b/lib/Dialect/TritonInstrument/IR/FunctionBuilder.cpp
@@ -1269,13 +1269,11 @@ Value FunctionBuilder::createInvalidateBarrierStateCallImpl(
         if (allowUninitialized) {
           Value active = arith::CmpIOp::create(fb, arith::CmpIPredicate::ne,
                                                states, zeroState);
-          selectedStates = arith::AndIOp::create(fb, selectedStates, active);
-          initialized = reduceAll<arith::OrIOp>(fb, selectedStates);
+          initialized = reduceAll<arith::OrIOp>(
+              fb, arith::AndIOp::create(fb, selectedStates, active));
         }
 
-        Value waitingMask =
-            convertAndBroadcast(fb, allowUninitialized ? selectedStates : mask,
-                                {0, 1}, waitingType);
+        Value waitingMask = convertAndBroadcast(fb, mask, {0, 1}, waitingType);
         Value waitingCTAMask =
             createLeadCTAEffectMask(fb, waitingType, currentCTA);
         Value selectedWaiters = arith::AndIOp::create(
@@ -2075,6 +2073,16 @@ static void createClearBarrierTrackingCall(
       });
 }
 
+static void createClearBarrierTrackingCall(ImplicitLocOpBuilder &b,
+                                           StringRef functionName, Value mbar,
+                                           Value pred, ValueType barriers,
+                                           ValueType tracking) {
+  createClearBarrierTrackingCall(
+      b, functionName, tti::ExperimentalMemDescToI32Op::create(b, mbar),
+      arith::ConstantIntOp::create(b, getMemDescLength(mbar), 32), pred,
+      nullptr, barriers, tracking);
+}
+
 void FunctionBuilder::createClearBarrierWriteTrackingCall(
     ImplicitLocOpBuilder &b, Value mbar, Value pred, MemType memType,
     Operation *insertPoint) {
@@ -2083,10 +2091,8 @@ void FunctionBuilder::createClearBarrierWriteTrackingCall(
   assert(!auxData.barriers.empty() &&
          "barrier descriptors must exist when clearing barrier write tracking");
   createClearBarrierTrackingCall(
-      b, "clear_barrier_write_tracking",
-      tti::ExperimentalMemDescToI32Op::create(b, mbar),
-      arith::ConstantIntOp::create(b, getMemDescLength(mbar), 32), pred,
-      nullptr, auxData.barriers.at(insertPoint),
+      b, "clear_barrier_write_tracking", mbar, pred,
+      auxData.barriers.at(insertPoint),
       auxData.writeTracking[(int)memType].at(insertPoint));
 }
 
@@ -2098,10 +2104,8 @@ void FunctionBuilder::createClearBarrierReadTrackingCall(
   assert(!auxData.barriers.empty() &&
          "barrier descriptors must exist when clearing barrier read tracking");
   createClearBarrierTrackingCall(
-      b, "clear_barrier_read_tracking",
-      tti::ExperimentalMemDescToI32Op::create(b, mbar),
-      arith::ConstantIntOp::create(b, getMemDescLength(mbar), 32), pred,
-      nullptr, auxData.barriers.at(insertPoint),
+      b, "clear_barrier_read_tracking", mbar, pred,
+      auxData.barriers.at(insertPoint),
       auxData.readTracking[(int)memType].at(insertPoint));
 }
 
@@ -3213,12 +3217,9 @@ void FunctionBuilder::createClearBarrierProxyAccessTrackingCall(
     return;
   assert(!auxData.barriers.empty() &&
          "barrier descriptors must exist when clearing proxy tracking");
-  createClearBarrierTrackingCall(
-      b, "clear_barrier_proxy_tracking",
-      tti::ExperimentalMemDescToI32Op::create(b, mbar),
-      arith::ConstantIntOp::create(b, getMemDescLength(mbar), 32), pred,
-      nullptr, auxData.barriers.at(insertPoint),
-      auxData.proxyAccessTracking.at(insertPoint));
+  createClearBarrierTrackingCall(b, "clear_barrier_proxy_tracking", mbar, pred,
+                                 auxData.barriers.at(insertPoint),
+                                 auxData.proxyAccessTracking.at(insertPoint));
 }
 
 void FunctionBuilder::createVerifyProxyAccessCall(ImplicitLocOpBuilder &b,

--- a/lib/Dialect/TritonInstrument/IR/FunctionBuilder.cpp
+++ b/lib/Dialect/TritonInstrument/IR/FunctionBuilder.cpp
@@ -251,6 +251,29 @@ Value createBufferDescriptor(ImplicitLocOpBuilder &b, Value offsetI32,
   return arith::OrIOp::create(b, lengthShifted, offsetI64);
 }
 
+Value createBufferOverlapMask(ImplicitLocOpBuilder &b, Value descriptors,
+                              Value offset, Value length) {
+  auto type = cast<RankedTensorType>(descriptors.getType());
+  Value offsetMask = tti::createConstIntTensor(b, b.getLoc(), UINT32_MAX, type);
+  Value shift = tti::createConstIntTensor(b, b.getLoc(), 32, type);
+  Value descriptorOffsets = arith::AndIOp::create(b, descriptors, offsetMask);
+  Value descriptorLengths = arith::ShRUIOp::create(b, descriptors, shift);
+  Value descriptorEnds =
+      arith::AddIOp::create(b, descriptorOffsets, descriptorLengths);
+
+  Value offsetI64 = arith::ExtUIOp::create(b, b.getI64Type(), offset);
+  Value lengthI64 = arith::ExtUIOp::create(b, b.getI64Type(), length);
+  Value endI64 = arith::AddIOp::create(b, offsetI64, lengthI64);
+  Value offsets = triton::SplatOp::create(b, type, offsetI64);
+  Value ends = triton::SplatOp::create(b, type, endI64);
+  return arith::AndIOp::create(
+      b,
+      arith::CmpIOp::create(b, arith::CmpIPredicate::ult, offsets,
+                            descriptorEnds),
+      arith::CmpIOp::create(b, arith::CmpIPredicate::ult, descriptorOffsets,
+                            ends));
+}
+
 std::tuple<Block *, Block *, Block *> createIfBlock(ImplicitLocOpBuilder &b,
                                                     Value cnd) {
   // #prevBlock
@@ -990,8 +1013,8 @@ void FunctionBuilder::createVerifyBarrierCanInitCall(ImplicitLocOpBuilder &b,
 
         Value states = tti::createLoadScratchMemory(fb, fb.getLoc(), statesPtr,
                                                     barrierStatesType);
-        Value descriptor = createBufferDescriptor(fb, mbarOffset, lengthVal);
-        Value mask = createCmpIntTensorScalar(fb, barriers, descriptor);
+        Value mask =
+            createBufferOverlapMask(fb, barriers, mbarOffset, lengthVal);
         mask = convertAndBroadcast(fb, mask, {1}, barrierStatesType);
         Value zero =
             tti::createConstIntTensor(fb, fb.getLoc(), 0, barrierStatesType);
@@ -1064,6 +1087,110 @@ void FunctionBuilder::createVerifyBarrierInitializedCall(
             arith::SelectOp::create(fb, predTensor, initialized, vTrue);
         triton::ReturnOp::create(
             fb, reduceAll<arith::AndIOp>(fb, predicatedInitialized));
+      });
+}
+
+void FunctionBuilder::createVerifyBarrierMemoryAvailableCall(
+    ImplicitLocOpBuilder &b, Value offset, uint32_t length, Value pred,
+    Operation *insertPoint, Value recipientCTAs) {
+  if (!pred)
+    pred = arith::ConstantIntOp::create(b, 1, 1);
+
+  ValueType barriers = auxData.barriers.at(insertPoint);
+  ValueType states = auxData.barrierStates.at(insertPoint);
+  auto barriersType = cast<RankedTensorType>(barriers.type);
+  auto statesType = cast<RankedTensorType>(states.type);
+  SmallVector<Value> args = {
+      offset,       arith::ConstantIntOp::create(b, length, 32),
+      pred,         barriers.value,
+      states.value, recipientCTAs};
+  AssertInfo assertInfo{"Shared memory reused before barrier invalidation",
+                        b.getI1Type()};
+
+  createCallToCachedFunction(
+      b, "verify_barrier_memory_available", args, assertInfo,
+      {barriersType, statesType},
+      [statesType](ImplicitLocOpBuilder &fb, Block *entryBlock) {
+        Value accessOffset = entryBlock->getArgument(0);
+        Value accessLength = entryBlock->getArgument(1);
+        Value pred = entryBlock->getArgument(2);
+        Value barriers = entryBlock->getArgument(3);
+        Value statesPtr = entryBlock->getArgument(4);
+        Value recipientCTAs = entryBlock->getArgument(5);
+
+        Value overlaps =
+            createBufferOverlapMask(fb, barriers, accessOffset, accessLength);
+        overlaps = convertAndBroadcast(fb, overlaps, {1}, statesType);
+
+        Value states = tti::createLoadScratchMemory(fb, fb.getLoc(), statesPtr,
+                                                    statesType);
+        Value zero = tti::createConstIntTensor(fb, fb.getLoc(), 0, statesType);
+        Value inactive =
+            arith::CmpIOp::create(fb, arith::CmpIPredicate::eq, states, zero);
+        auto condType = cast<RankedTensorType>(inactive.getType());
+        Value vTrue = tti::createConstIntTensor(fb, fb.getLoc(), 1, condType);
+        Value available =
+            arith::SelectOp::create(fb, overlaps, inactive, vTrue);
+        Value ctaMask =
+            createCTASetMask(fb, condType, /*dim=*/0, recipientCTAs);
+        available = arith::SelectOp::create(fb, ctaMask, available, vTrue);
+        Value predTensor = triton::SplatOp::create(fb, condType, pred);
+        available = arith::SelectOp::create(fb, predTensor, available, vTrue);
+        triton::ReturnOp::create(fb, reduceAll<arith::AndIOp>(fb, available));
+      });
+}
+
+void FunctionBuilder::createVerifyBarrierHasNoWaitersCall(
+    ImplicitLocOpBuilder &b, Value mbar, Value pred, Operation *insertPoint,
+    Value recipientCTAs) {
+  assert(!auxData.barriers.empty() && !auxData.waiting.empty() &&
+         "barrier and waiting state must exist when invalidating a barrier");
+  if (!pred)
+    pred = arith::ConstantIntOp::create(b, 1, 1);
+
+  ValueType barriers = auxData.barriers.at(insertPoint);
+  ValueType waiting = auxData.waiting.at(insertPoint);
+  auto barriersType = cast<RankedTensorType>(barriers.type);
+  auto waitingType = cast<RankedTensorType>(waiting.type);
+  SmallVector<Value> args = {
+      tti::ExperimentalMemDescToI32Op::create(b, mbar),
+      arith::ConstantIntOp::create(b, getMemDescLength(mbar), 32),
+      pred,
+      barriers.value,
+      waiting.value,
+      recipientCTAs};
+  AssertInfo assertInfo{"Barrier invalidated while a thread is waiting",
+                        b.getI1Type()};
+
+  createCallToCachedFunction(
+      b, "verify_barrier_has_no_waiters", args, assertInfo,
+      {barriersType, waitingType},
+      [waitingType](ImplicitLocOpBuilder &fb, Block *entryBlock) {
+        Value mbarOffset = entryBlock->getArgument(0);
+        Value length = entryBlock->getArgument(1);
+        Value pred = entryBlock->getArgument(2);
+        Value barriers = entryBlock->getArgument(3);
+        Value waitingPtr = entryBlock->getArgument(4);
+        Value recipientCTAs = entryBlock->getArgument(5);
+
+        Value descriptor = createBufferDescriptor(fb, mbarOffset, length);
+        Value selected = createCmpIntTensorScalar(fb, barriers, descriptor);
+        selected = convertAndBroadcast(fb, selected, {1}, waitingType);
+        selected = arith::AndIOp::create(
+            fb, selected,
+            createCTASetMask(fb, waitingType, /*dim=*/0, recipientCTAs));
+
+        Value waiting = tti::createLoadScratchMemory(fb, fb.getLoc(),
+                                                     waitingPtr, waitingType);
+        Value zero = tti::createConstIntTensor(fb, fb.getLoc(), 0, waitingType);
+        Value idle =
+            arith::CmpIOp::create(fb, arith::CmpIPredicate::eq, waiting, zero);
+        auto condType = cast<RankedTensorType>(idle.getType());
+        Value vTrue = tti::createConstIntTensor(fb, fb.getLoc(), 1, condType);
+        idle = arith::SelectOp::create(fb, selected, idle, vTrue);
+        Value predTensor = triton::SplatOp::create(fb, condType, pred);
+        idle = arith::SelectOp::create(fb, predTensor, idle, vTrue);
+        triton::ReturnOp::create(fb, reduceAll<arith::AndIOp>(fb, idle));
       });
 }
 
@@ -1869,6 +1996,93 @@ void FunctionBuilder::createTrackBarrierWriteForBufferCall(
         createMaskedStoreScratchMemory(fb, fb.getLoc(), writeTrackingPtr,
                                        newTracking, writeTrackingType,
                                        trackMask);
+
+        fb.setInsertionPointToEnd(thenBlock);
+        triton::ReturnOp::create(fb);
+      });
+}
+
+void FunctionBuilder::createTrackBarrierReadForBufferCall(
+    ImplicitLocOpBuilder &b, Value mbar, Value bufferMask, int thread,
+    Value pred, MemType memType, Operation *insertPoint, Value barrierCTAs,
+    Value effectCTAs) {
+  if (auxData.barriers.empty() ||
+      auxData.readVisibility[(int)memType].empty() ||
+      auxData.readTracking[(int)memType].empty())
+    return;
+  if (!pred)
+    pred = arith::ConstantIntOp::create(b, 1, 1);
+
+  ValueType barriers = auxData.barriers.at(insertPoint);
+  ValueType visibility = auxData.readVisibility[(int)memType].at(insertPoint);
+  ValueType tracking = auxData.readTracking[(int)memType].at(insertPoint);
+  auto barriersType = cast<RankedTensorType>(barriers.type);
+  auto visibilityType = cast<RankedTensorType>(visibility.type);
+  auto trackingType = cast<RankedTensorType>(tracking.type);
+  SmallVector<Value> args = {
+      tti::ExperimentalMemDescToI32Op::create(b, mbar),
+      arith::ConstantIntOp::create(b, getMemDescLength(mbar), 32),
+      pred,
+      bufferMask,
+      arith::ConstantIntOp::create(b, thread, 32),
+      barriers.value,
+      visibility.value,
+      tracking.value,
+      barrierCTAs,
+      effectCTAs};
+
+  createCallToCachedFunction(
+      b, "track_barrier_read_for_buffer", args,
+      /*assertInfo=*/std::nullopt, {barriersType, visibilityType, trackingType},
+      [visibilityType, trackingType](ImplicitLocOpBuilder &fb,
+                                     Block *entryBlock) {
+        Value mbarOffset = entryBlock->getArgument(0);
+        Value mbarLength = entryBlock->getArgument(1);
+        Value pred = entryBlock->getArgument(2);
+        Value bufferMask = entryBlock->getArgument(3);
+        Value thread = entryBlock->getArgument(4);
+        Value barriers = entryBlock->getArgument(5);
+        Value visibilityPtr = entryBlock->getArgument(6);
+        Value trackingPtr = entryBlock->getArgument(7);
+        Value barrierCTAs = entryBlock->getArgument(8);
+        Value effectCTAs = entryBlock->getArgument(9);
+
+        auto [prevBlock, ifBlock, thenBlock] = createIfBlock(fb, pred);
+        fb.setInsertionPointToStart(ifBlock);
+
+        Value visibility = tti::createLoadScratchMemory(
+            fb, fb.getLoc(), visibilityPtr, visibilityType);
+        Value tracking = tti::createLoadScratchMemory(
+            fb, fb.getLoc(), trackingPtr, trackingType);
+        Value currentCTA = createCurrentCTAMask(fb);
+        Value observer = createDimMask(fb, thread, visibilityType, /*dim=*/3);
+        observer = arith::AndIOp::create(
+            fb, observer,
+            createCTASetMask(fb, visibilityType, /*dim=*/2, currentCTA));
+        Value zero =
+            tti::createConstIntTensor(fb, fb.getLoc(), 0, visibilityType);
+        Value visibleReads =
+            arith::SelectOp::create(fb, observer, visibility, zero);
+        visibleReads = reduce<arith::OrIOp>(fb, visibleReads, {2, 3});
+        visibleReads =
+            convertAndBroadcast(fb, visibleReads, {0, 1, 4}, trackingType);
+
+        Value descriptor = createBufferDescriptor(fb, mbarOffset, mbarLength);
+        Value trackMask = createCmpIntTensorScalar(fb, barriers, descriptor);
+        trackMask = convertAndBroadcast(fb, trackMask, {3}, trackingType);
+        bufferMask = convertAndBroadcast(fb, bufferMask, {1}, trackingType);
+        trackMask = arith::AndIOp::create(fb, trackMask, bufferMask);
+        trackMask = arith::AndIOp::create(
+            fb, trackMask,
+            createCTASetMask(fb, trackingType, /*dim=*/0, effectCTAs));
+        trackMask = arith::AndIOp::create(
+            fb, trackMask,
+            createCTASetMask(fb, trackingType, /*dim=*/2, barrierCTAs));
+        Value withVisible = arith::OrIOp::create(fb, tracking, visibleReads);
+        Value updated =
+            arith::SelectOp::create(fb, trackMask, withVisible, tracking);
+        createMaskedStoreScratchMemory(fb, fb.getLoc(), trackingPtr, updated,
+                                       trackingType, trackMask);
 
         fb.setInsertionPointToEnd(thenBlock);
         triton::ReturnOp::create(fb);

--- a/lib/Dialect/TritonInstrument/IR/FunctionBuilder.cpp
+++ b/lib/Dialect/TritonInstrument/IR/FunctionBuilder.cpp
@@ -375,6 +375,22 @@ Value createCTASetMask(ImplicitLocOpBuilder &b, RankedTensorType tensorType,
   return arith::CmpIOp::create(b, arith::CmpIPredicate::ne, selectedBit, zero);
 }
 
+Value createBarrierOwnerMask(ImplicitLocOpBuilder &b, Value barrierCTAs,
+                             RankedTensorType statesType) {
+  auto indexType = cast<RankedTensorType>(statesType.clone(b.getI32Type()));
+  auto rowType = tti::getSlicedTensorType(indexType, {0}, b.getI32Type());
+  Value row =
+      triton::MakeRangeOp::create(b, rowType, 0, statesType.getShape()[0]);
+  row = convertAndBroadcast(b, row, {0}, indexType);
+  Value owners = convertAndBroadcast(b, barrierCTAs, {1}, indexType);
+  Value bit = arith::AndIOp::create(
+      b, arith::ShRUIOp::create(b, owners, row),
+      tti::createConstIntTensor(b, b.getLoc(), 1, indexType));
+  return arith::CmpIOp::create(
+      b, arith::CmpIPredicate::ne, bit,
+      tti::createConstIntTensor(b, b.getLoc(), 0, indexType));
+}
+
 static void createVerifyBarrierStateCall(ImplicitLocOpBuilder &b,
                                          StringRef message, Value offset,
                                          Value length, Value pred,
@@ -1032,13 +1048,33 @@ void FunctionBuilder::createVerifyBarrierInitializedCall(
 }
 
 void FunctionBuilder::createVerifyBarrierMemoryAvailableCall(
-    ImplicitLocOpBuilder &b, Value offset, uint32_t length, Value pred,
-    Operation *insertPoint, Value recipientCTAs) {
-  createVerifyBarrierStateCall(
-      b, "Shared memory reused before barrier invalidation", offset,
-      arith::ConstantIntOp::create(b, length, 32), pred,
-      auxData.barriers.at(insertPoint), auxData.barrierStates.at(insertPoint),
-      recipientCTAs, /*initialized=*/false);
+    ImplicitLocOpBuilder &b, Value barrierCTAs, Value pred,
+    Operation *insertPoint) {
+  if (!pred)
+    pred = arith::ConstantIntOp::create(b, 1, 1);
+  ValueType states = auxData.barrierStates.at(insertPoint);
+  auto statesType = cast<RankedTensorType>(states.type);
+  SmallVector<Value> args = {barrierCTAs, pred, states.value};
+  AssertInfo assertInfo{"Shared memory reused before barrier invalidation",
+                        b.getI1Type()};
+  createCallToCachedFunction(
+      b, "verify_barrier_can_init", args, assertInfo, {statesType},
+      [statesType](ImplicitLocOpBuilder &fb, Block *entryBlock) {
+        Value barrierCTAs = entryBlock->getArgument(0);
+        Value pred = entryBlock->getArgument(1);
+        Value states = tti::createLoadScratchMemory(
+            fb, fb.getLoc(), entryBlock->getArgument(2), statesType);
+        Value zero = tti::createConstIntTensor(fb, fb.getLoc(), 0, statesType);
+        Value available =
+            arith::CmpIOp::create(fb, arith::CmpIPredicate::eq, states, zero);
+        Value selected = createBarrierOwnerMask(fb, barrierCTAs, statesType);
+        auto maskType = cast<RankedTensorType>(selected.getType());
+        Value vTrue = tti::createConstIntTensor(fb, fb.getLoc(), 1, maskType);
+        available = arith::SelectOp::create(fb, selected, available, vTrue);
+        Value active = triton::SplatOp::create(fb, maskType, pred);
+        available = arith::SelectOp::create(fb, active, available, vTrue);
+        triton::ReturnOp::create(fb, reduceAll<arith::AndIOp>(fb, available));
+      });
 }
 
 void FunctionBuilder::createInitBarrierStateCall(ImplicitLocOpBuilder &b,
@@ -1117,22 +1153,31 @@ void FunctionBuilder::createInitBarrierStateCall(ImplicitLocOpBuilder &b,
 void FunctionBuilder::createInvalidateBarrierStateCall(ImplicitLocOpBuilder &b,
                                                        Value mbar, Value pred,
                                                        Operation *insertPoint) {
-  createInvalidateBarrierStateCallImpl(
+  Value descriptor = createBufferDescriptor(
       b, tti::ExperimentalMemDescToI32Op::create(b, mbar),
-      arith::ConstantIntOp::create(b, getMemDescLength(mbar), 32), pred,
-      insertPoint, /*allowUninitialized=*/false);
+      arith::ConstantIntOp::create(b, getMemDescLength(mbar), 32));
+  Value selectedBarriers = createCmpIntTensorScalar(
+      b, auxData.barriers.at(insertPoint).value, descriptor);
+  createInvalidateBarrierStateCallImpl(b, selectedBarriers, pred, insertPoint,
+                                       /*allowUninitialized=*/false);
 }
 
 void FunctionBuilder::createInvalidateBarrierStorageCall(
-    ImplicitLocOpBuilder &b, Value offset, uint32_t length, Value pred,
+    ImplicitLocOpBuilder &b, Value barrierCTAs, Value pred,
     Operation *insertPoint) {
-  createInvalidateBarrierStateCallImpl(
-      b, offset, arith::ConstantIntOp::create(b, length, 32), pred, insertPoint,
-      /*allowUninitialized=*/true);
+  auto ownersType = cast<RankedTensorType>(barrierCTAs.getType());
+  Value currentCTA =
+      triton::SplatOp::create(b, ownersType, createCurrentCTAMask(b));
+  Value owners = arith::AndIOp::create(b, barrierCTAs, currentCTA);
+  Value selectedBarriers = arith::CmpIOp::create(
+      b, arith::CmpIPredicate::ne, owners,
+      tti::createConstIntTensor(b, b.getLoc(), 0, ownersType));
+  createInvalidateBarrierStateCallImpl(b, selectedBarriers, pred, insertPoint,
+                                       /*allowUninitialized=*/true);
 }
 
 void FunctionBuilder::createInvalidateBarrierStateCallImpl(
-    ImplicitLocOpBuilder &b, Value mbarOffset, Value lengthVal, Value pred,
+    ImplicitLocOpBuilder &b, Value selectedBarriers, Value pred,
     Operation *insertPoint, bool allowUninitialized) {
   assert(!auxData.barriers.empty() &&
          "barrier descriptors must exist when invalidating a barrier");
@@ -1143,39 +1188,38 @@ void FunctionBuilder::createInvalidateBarrierStateCallImpl(
   if (!pred) {
     pred = arith::ConstantIntOp::create(b, 1, 1);
   }
-  Value barriersVal = auxData.barriers.at(insertPoint).value;
-  auto barriersType =
-      cast<RankedTensorType>(auxData.barriers.at(insertPoint).type);
   Value barrierStatesVal = auxData.barrierStates.at(insertPoint).value;
   auto barrierStatesType =
       cast<RankedTensorType>(auxData.barrierStates.at(insertPoint).type);
+  auto selectedType =
+      tti::getSlicedTensorType(barrierStatesType, {1}, b.getI1Type());
+  if (selectedBarriers.getType() != selectedType)
+    selectedBarriers =
+        ttg::ConvertLayoutOp::create(b, selectedType, selectedBarriers);
   Value waitingVal = auxData.waiting.at(insertPoint).value;
   auto waitingType =
       cast<RankedTensorType>(auxData.waiting.at(insertPoint).type);
-  SmallVector<Value> args = {mbarOffset,  lengthVal,        pred,
-                             barriersVal, barrierStatesVal, waitingVal};
+  SmallVector<Value> args = {selectedBarriers, pred, barrierStatesVal,
+                             waitingVal};
   AssertInfo statusInfo{"", b.getI32Type()};
   Value status = createCallToCachedFunction(
       b,
       allowUninitialized ? "invalidate_barrier_storage"
                          : "invalidate_barrier_state",
-      args, statusInfo, {barriersType, barrierStatesType, waitingType},
+      args, statusInfo, {barrierStatesType, waitingType},
       [barrierStatesType, waitingType,
        allowUninitialized](ImplicitLocOpBuilder &fb, Block *entryBlock) {
-        Value mbarOffset = entryBlock->getArgument(0);
-        Value lengthVal = entryBlock->getArgument(1);
-        Value pred = entryBlock->getArgument(2);
-        Value barriers = entryBlock->getArgument(3);
-        Value statesPtr = entryBlock->getArgument(4);
-        Value waitingPtr = entryBlock->getArgument(5);
+        Value selectedBarriers = entryBlock->getArgument(0);
+        Value pred = entryBlock->getArgument(1);
+        Value statesPtr = entryBlock->getArgument(2);
+        Value waitingPtr = entryBlock->getArgument(3);
 
         Value states = tti::createLoadScratchMemory(fb, fb.getLoc(), statesPtr,
                                                     barrierStatesType);
         Value waiting = tti::createLoadScratchMemory(fb, fb.getLoc(),
                                                      waitingPtr, waitingType);
-        Value descriptor = createBufferDescriptor(fb, mbarOffset, lengthVal);
-        Value mask = createCmpIntTensorScalar(fb, barriers, descriptor);
-        mask = convertAndBroadcast(fb, mask, {1}, barrierStatesType);
+        Value mask =
+            convertAndBroadcast(fb, selectedBarriers, {1}, barrierStatesType);
         Value currentCTA = createCurrentCTAMask(fb);
         Value stateCTAMask =
             createCTASetMask(fb, barrierStatesType, /*dim=*/0, currentCTA);
@@ -1271,7 +1315,7 @@ void FunctionBuilder::createInvalidateBarrierStateCallImpl(
   if (allowUninitialized)
     clearPred =
         tti::maybeAnd(b, pred, arith::AndIOp::create(b, initialized, idle));
-  createClearBarrierStorageTrackingCall(b, mbarOffset, lengthVal, clearPred,
+  createClearBarrierStorageTrackingCall(b, selectedBarriers, clearPred,
                                         insertPoint);
 }
 
@@ -1947,37 +1991,29 @@ void FunctionBuilder::createTrackBarrierWriteForBufferCall(
 }
 
 static void createClearBarrierTrackingCall(ImplicitLocOpBuilder &b,
-                                           StringRef functionName, Value offset,
-                                           Value length, Value pred,
-                                           ValueType barriers,
+                                           StringRef functionName,
+                                           Value selectedBarriers, Value pred,
                                            ValueType tracking) {
   if (!pred)
     pred = arith::ConstantIntOp::create(b, 1, 1);
-  auto barriersType = cast<RankedTensorType>(barriers.type);
   auto trackingType = cast<RankedTensorType>(tracking.type);
-  SmallVector<Value> args = {offset, length, pred, barriers.value,
-                             tracking.value};
-  ManglingArgs specializationArgs{barriersType, trackingType};
+  SmallVector<Value> args = {selectedBarriers, pred, tracking.value};
+  ManglingArgs specializationArgs{trackingType};
   createCallToCachedFunction(
       b, functionName.str(), args, /*assertInfo=*/std::nullopt,
       specializationArgs,
       [trackingType](ImplicitLocOpBuilder &fb, Block *entryBlock) {
-        Value mbarOffset = entryBlock->getArgument(0);
-        Value lengthVal = entryBlock->getArgument(1);
-        Value pred = entryBlock->getArgument(2);
-        Value barriers = entryBlock->getArgument(3);
-        Value trackingPtr = entryBlock->getArgument(4);
+        Value selectedBarriers = entryBlock->getArgument(0);
+        Value pred = entryBlock->getArgument(1);
+        Value trackingPtr = entryBlock->getArgument(2);
 
         auto [prevBlock, ifBlock, thenBlock] = createIfBlock(fb, pred);
         fb.setInsertionPointToStart(ifBlock);
 
         Value tracking = tti::createLoadScratchMemory(
             fb, fb.getLoc(), trackingPtr, trackingType);
-        Value descriptor = createBufferDescriptor(fb, mbarOffset, lengthVal);
         Value barriersEqBar =
-            createCmpIntTensorScalar(fb, barriers, descriptor);
-        barriersEqBar =
-            convertAndBroadcast(fb, barriersEqBar, {3}, trackingType);
+            convertAndBroadcast(fb, selectedBarriers, {3}, trackingType);
         Value barrierCTAs = createCurrentCTAMask(fb);
         Value barrierCTAMask =
             createCTASetMask(fb, trackingType, /*dim=*/2, barrierCTAs);
@@ -1996,12 +2032,11 @@ static void createClearBarrierTrackingCall(ImplicitLocOpBuilder &b,
 }
 
 void FunctionBuilder::createClearBarrierStorageTrackingCall(
-    ImplicitLocOpBuilder &b, Value offset, Value length, Value pred,
+    ImplicitLocOpBuilder &b, Value selectedBarriers, Value pred,
     Operation *insertPoint) {
   auto clear = [&](StringRef name, AuxDataMap::RegionToValueMap &tracking) {
     if (!tracking.empty())
-      createClearBarrierTrackingCall(b, name, offset, length, pred,
-                                     auxData.barriers.at(insertPoint),
+      createClearBarrierTrackingCall(b, name, selectedBarriers, pred,
                                      tracking.at(insertPoint));
   };
   for (MemType memType : {MemType::SHARED_MEM, MemType::TENSOR_MEM}) {

--- a/lib/Dialect/TritonInstrument/IR/FunctionBuilder.cpp
+++ b/lib/Dialect/TritonInstrument/IR/FunctionBuilder.cpp
@@ -1177,6 +1177,33 @@ void FunctionBuilder::createInitBarrierStateCall(ImplicitLocOpBuilder &b,
 void FunctionBuilder::createInvalidateBarrierStateCall(ImplicitLocOpBuilder &b,
                                                        Value mbar, Value pred,
                                                        Operation *insertPoint) {
+  createInvalidateBarrierStateCallImpl(
+      b, tti::ExperimentalMemDescToI32Op::create(b, mbar),
+      arith::ConstantIntOp::create(b, getMemDescLength(mbar), 32), pred,
+      insertPoint, nullptr, /*allowUninitialized=*/false);
+}
+
+void FunctionBuilder::createInvalidateBarrierStorageCall(
+    ImplicitLocOpBuilder &b, Value offset, uint32_t length, Value pred,
+    Operation *insertPoint, Value recipientCTAs) {
+  Value lengthVal = arith::ConstantIntOp::create(b, length, 32);
+  Value status = createInvalidateBarrierStateCallImpl(
+      b, offset, lengthVal, pred, insertPoint, recipientCTAs,
+      /*allowUninitialized=*/true);
+  Value initialized = arith::TruncIOp::create(b, b.getI1Type(), status);
+  Value idle = arith::TruncIOp::create(
+      b, b.getI1Type(),
+      arith::ShRUIOp::create(b, status,
+                             arith::ConstantIntOp::create(b, 1, 32)));
+  Value clearPred =
+      tti::maybeAnd(b, pred, arith::AndIOp::create(b, initialized, idle));
+  createClearBarrierStorageTrackingCall(b, offset, lengthVal, clearPred,
+                                        insertPoint, recipientCTAs);
+}
+
+Value FunctionBuilder::createInvalidateBarrierStateCallImpl(
+    ImplicitLocOpBuilder &b, Value mbarOffset, Value lengthVal, Value pred,
+    Operation *insertPoint, Value recipientCTAs, bool allowUninitialized) {
   assert(!auxData.barriers.empty() &&
          "barrier descriptors must exist when invalidating a barrier");
   assert(!auxData.barrierStates.empty() &&
@@ -1195,17 +1222,18 @@ void FunctionBuilder::createInvalidateBarrierStateCall(ImplicitLocOpBuilder &b,
   Value waitingVal = auxData.waiting.at(insertPoint).value;
   auto waitingType =
       cast<RankedTensorType>(auxData.waiting.at(insertPoint).type);
-  uint32_t length = getMemDescLength(mbar);
-  Value mbarOffset = tti::ExperimentalMemDescToI32Op::create(b, mbar);
-  Value lengthVal = arith::ConstantIntOp::create(b, length, 32);
   SmallVector<Value> args = {mbarOffset,  lengthVal,        pred,
                              barriersVal, barrierStatesVal, waitingVal};
+  if (allowUninitialized)
+    args.push_back(recipientCTAs);
   AssertInfo statusInfo{"", b.getI32Type()};
   Value status = createCallToCachedFunction(
-      b, "invalidate_barrier_state", args, statusInfo,
-      {barriersType, barrierStatesType, waitingType},
-      [barrierStatesType, waitingType](ImplicitLocOpBuilder &fb,
-                                       Block *entryBlock) {
+      b,
+      allowUninitialized ? "invalidate_barrier_storage"
+                         : "invalidate_barrier_state",
+      args, statusInfo, {barriersType, barrierStatesType, waitingType},
+      [barrierStatesType, waitingType,
+       allowUninitialized](ImplicitLocOpBuilder &fb, Block *entryBlock) {
         Value mbarOffset = entryBlock->getArgument(0);
         Value lengthVal = entryBlock->getArgument(1);
         Value pred = entryBlock->getArgument(2);
@@ -1220,7 +1248,8 @@ void FunctionBuilder::createInvalidateBarrierStateCall(ImplicitLocOpBuilder &b,
         Value descriptor = createBufferDescriptor(fb, mbarOffset, lengthVal);
         Value mask = createCmpIntTensorScalar(fb, barriers, descriptor);
         mask = convertAndBroadcast(fb, mask, {1}, barrierStatesType);
-        Value currentCTA = createCurrentCTAMask(fb);
+        Value currentCTA = allowUninitialized ? entryBlock->getArgument(6)
+                                              : createCurrentCTAMask(fb);
         Value stateCTAMask =
             createCTASetMask(fb, barrierStatesType, /*dim=*/0, currentCTA);
         Value selectedStates = arith::AndIOp::create(fb, mask, stateCTAMask);
@@ -1237,8 +1266,16 @@ void FunctionBuilder::createInvalidateBarrierStateCall(ImplicitLocOpBuilder &b,
         initialized =
             arith::SelectOp::create(fb, selectedStates, initialized, stateTrue);
         initialized = reduceAll<arith::AndIOp>(fb, initialized);
+        if (allowUninitialized) {
+          Value active = arith::CmpIOp::create(fb, arith::CmpIPredicate::ne,
+                                               states, zeroState);
+          selectedStates = arith::AndIOp::create(fb, selectedStates, active);
+          initialized = reduceAll<arith::OrIOp>(fb, selectedStates);
+        }
 
-        Value waitingMask = convertAndBroadcast(fb, mask, {0, 1}, waitingType);
+        Value waitingMask =
+            convertAndBroadcast(fb, allowUninitialized ? selectedStates : mask,
+                                {0, 1}, waitingType);
         Value waitingCTAMask =
             createLeadCTAEffectMask(fb, waitingType, currentCTA);
         Value selectedWaiters = arith::AndIOp::create(
@@ -1251,7 +1288,9 @@ void FunctionBuilder::createInvalidateBarrierStateCall(ImplicitLocOpBuilder &b,
         idle = arith::SelectOp::create(fb, selectedWaiters, idle, waitingTrue);
         idle = reduceAll<arith::AndIOp>(fb, idle);
 
-        Value valid = arith::AndIOp::create(fb, initialized, idle);
+        Value valid = allowUninitialized
+                          ? idle
+                          : arith::AndIOp::create(fb, initialized, idle);
         Value shouldInvalidate = arith::AndIOp::create(fb, pred, valid);
 
         auto stateCondType = cast<RankedTensorType>(selectedStates.getType());
@@ -1291,16 +1330,19 @@ void FunctionBuilder::createInvalidateBarrierStateCall(ImplicitLocOpBuilder &b,
       },
       /*emitAssert=*/false);
 
-  Value initialized = arith::TruncIOp::create(b, b.getI1Type(), status);
-  tti::createAssertInThread(
-      b, initialized,
-      "Barrier used before initialization or after invalidation");
+  if (!allowUninitialized) {
+    Value initialized = arith::TruncIOp::create(b, b.getI1Type(), status);
+    tti::createAssertInThread(
+        b, initialized,
+        "Barrier used before initialization or after invalidation");
+  }
   Value idle = arith::TruncIOp::create(
       b, b.getI1Type(),
       arith::ShRUIOp::create(b, status,
                              arith::ConstantIntOp::create(b, 1, 32)));
   tti::createAssertInThread(b, idle,
                             "Barrier invalidated while a thread is waiting");
+  return status;
 }
 
 void FunctionBuilder::createVerifyAndUpdateBarrierStateCall(
@@ -1982,23 +2024,23 @@ void FunctionBuilder::createTrackBarrierWriteForBufferCall(
       });
 }
 
-static void createClearBarrierTrackingCall(ImplicitLocOpBuilder &b,
-                                           StringRef functionName, Value mbar,
-                                           Value pred, ValueType barriers,
-                                           ValueType tracking) {
+static void createClearBarrierTrackingCall(
+    ImplicitLocOpBuilder &b, StringRef functionName, Value offset, Value length,
+    Value pred, Value recipientCTAs, ValueType barriers, ValueType tracking) {
   if (!pred)
     pred = arith::ConstantIntOp::create(b, 1, 1);
   auto barriersType = cast<RankedTensorType>(barriers.type);
   auto trackingType = cast<RankedTensorType>(tracking.type);
-  SmallVector<Value> args = {
-      tti::ExperimentalMemDescToI32Op::create(b, mbar),
-      arith::ConstantIntOp::create(b, getMemDescLength(mbar), 32), pred,
-      barriers.value, tracking.value};
+  SmallVector<Value> args = {offset, length, pred, barriers.value,
+                             tracking.value};
+  bool scoped = static_cast<bool>(recipientCTAs);
+  if (scoped)
+    args.push_back(recipientCTAs);
   ManglingArgs specializationArgs{barriersType, trackingType};
   createCallToCachedFunction(
       b, functionName.str(), args, /*assertInfo=*/std::nullopt,
       specializationArgs,
-      [trackingType](ImplicitLocOpBuilder &fb, Block *entryBlock) {
+      [trackingType, scoped](ImplicitLocOpBuilder &fb, Block *entryBlock) {
         Value mbarOffset = entryBlock->getArgument(0);
         Value lengthVal = entryBlock->getArgument(1);
         Value pred = entryBlock->getArgument(2);
@@ -2015,8 +2057,10 @@ static void createClearBarrierTrackingCall(ImplicitLocOpBuilder &b,
             createCmpIntTensorScalar(fb, barriers, descriptor);
         barriersEqBar =
             convertAndBroadcast(fb, barriersEqBar, {3}, trackingType);
-        Value barrierCTAMask = createCTASetMask(fb, trackingType, /*dim=*/2,
-                                                createCurrentCTAMask(fb));
+        Value barrierCTAs =
+            scoped ? entryBlock->getArgument(5) : createCurrentCTAMask(fb);
+        Value barrierCTAMask =
+            createCTASetMask(fb, trackingType, /*dim=*/2, barrierCTAs);
         barriersEqBar =
             arith::AndIOp::create(fb, barriersEqBar, barrierCTAMask);
         Value zero =
@@ -2039,8 +2083,10 @@ void FunctionBuilder::createClearBarrierWriteTrackingCall(
   assert(!auxData.barriers.empty() &&
          "barrier descriptors must exist when clearing barrier write tracking");
   createClearBarrierTrackingCall(
-      b, "clear_barrier_write_tracking", mbar, pred,
-      auxData.barriers.at(insertPoint),
+      b, "clear_barrier_write_tracking",
+      tti::ExperimentalMemDescToI32Op::create(b, mbar),
+      arith::ConstantIntOp::create(b, getMemDescLength(mbar), 32), pred,
+      nullptr, auxData.barriers.at(insertPoint),
       auxData.writeTracking[(int)memType].at(insertPoint));
 }
 
@@ -2052,9 +2098,27 @@ void FunctionBuilder::createClearBarrierReadTrackingCall(
   assert(!auxData.barriers.empty() &&
          "barrier descriptors must exist when clearing barrier read tracking");
   createClearBarrierTrackingCall(
-      b, "clear_barrier_read_tracking", mbar, pred,
-      auxData.barriers.at(insertPoint),
+      b, "clear_barrier_read_tracking",
+      tti::ExperimentalMemDescToI32Op::create(b, mbar),
+      arith::ConstantIntOp::create(b, getMemDescLength(mbar), 32), pred,
+      nullptr, auxData.barriers.at(insertPoint),
       auxData.readTracking[(int)memType].at(insertPoint));
+}
+
+void FunctionBuilder::createClearBarrierStorageTrackingCall(
+    ImplicitLocOpBuilder &b, Value offset, Value length, Value pred,
+    Operation *insertPoint, Value recipientCTAs) {
+  auto clear = [&](StringRef name, AuxDataMap::RegionToValueMap &tracking) {
+    if (!tracking.empty())
+      createClearBarrierTrackingCall(
+          b, name, offset, length, pred, recipientCTAs,
+          auxData.barriers.at(insertPoint), tracking.at(insertPoint));
+  };
+  for (MemType memType : {MemType::SHARED_MEM, MemType::TENSOR_MEM}) {
+    clear("clear_barrier_write_tracking", auxData.writeTracking[(int)memType]);
+    clear("clear_barrier_read_tracking", auxData.readTracking[(int)memType]);
+  }
+  clear("clear_barrier_proxy_tracking", auxData.proxyAccessTracking);
 }
 
 void FunctionBuilder::createTransferVisibleAccessesCall(
@@ -3149,9 +3213,12 @@ void FunctionBuilder::createClearBarrierProxyAccessTrackingCall(
     return;
   assert(!auxData.barriers.empty() &&
          "barrier descriptors must exist when clearing proxy tracking");
-  createClearBarrierTrackingCall(b, "clear_barrier_proxy_tracking", mbar, pred,
-                                 auxData.barriers.at(insertPoint),
-                                 auxData.proxyAccessTracking.at(insertPoint));
+  createClearBarrierTrackingCall(
+      b, "clear_barrier_proxy_tracking",
+      tti::ExperimentalMemDescToI32Op::create(b, mbar),
+      arith::ConstantIntOp::create(b, getMemDescLength(mbar), 32), pred,
+      nullptr, auxData.barriers.at(insertPoint),
+      auxData.proxyAccessTracking.at(insertPoint));
 }
 
 void FunctionBuilder::createVerifyProxyAccessCall(ImplicitLocOpBuilder &b,

--- a/lib/Dialect/TritonInstrument/IR/FunctionBuilder.cpp
+++ b/lib/Dialect/TritonInstrument/IR/FunctionBuilder.cpp
@@ -2446,11 +2446,9 @@ void FunctionBuilder::createCopyWriteVisibilityCall(ImplicitLocOpBuilder &b,
       });
 }
 
-void FunctionBuilder::createCopyReadVisibilityCall(ImplicitLocOpBuilder &b,
-                                                   int sourceThread,
-                                                   uint64_t destMask,
-                                                   Value pred, MemType memType,
-                                                   Operation *insertPoint) {
+void FunctionBuilder::createCopyReadVisibilityCall(
+    ImplicitLocOpBuilder &b, int sourceThread, uint64_t destMask, Value pred,
+    MemType memType, Operation *insertPoint, bool merge) {
 
   if (auxData.readVisibility[(int)memType].empty()) {
     return;
@@ -2464,8 +2462,8 @@ void FunctionBuilder::createCopyReadVisibilityCall(ImplicitLocOpBuilder &b,
   SmallVector<Value> args = {sourceThreadVal, destMaskVal, pred, readVis.value};
   createCallToCachedFunction(
       b, "copy_read_visibility", args,
-      /*assertInfo=*/std::nullopt, {readVisibilityType},
-      [readVisibilityType](ImplicitLocOpBuilder &fb, Block *entryBlock) {
+      /*assertInfo=*/std::nullopt, {readVisibilityType, (uint64_t)merge},
+      [readVisibilityType, merge](ImplicitLocOpBuilder &fb, Block *entryBlock) {
         Value sourceThread = entryBlock->getArgument(0);
         Value destMaskVal = entryBlock->getArgument(1);
         Value pred = entryBlock->getArgument(2);
@@ -2493,7 +2491,8 @@ void FunctionBuilder::createCopyReadVisibilityCall(ImplicitLocOpBuilder &b,
         Value replicated = arith::SelectOp::create(fb, destMaskTensor,
                                                    broadcastRow, zeroTensor);
 
-        Value updated = arith::OrIOp::create(fb, cleared, replicated);
+        Value retained = merge ? readVisibility : cleared;
+        Value updated = arith::OrIOp::create(fb, retained, replicated);
         Value currentCTAMask = createCTASetMask(
             fb, readVisibilityType, /*dim=*/2, createCurrentCTAMask(fb));
         createMaskedStoreScratchMemory(fb, fb.getLoc(), readVisibilityPtr,

--- a/lib/Dialect/TritonInstrument/IR/FunctionBuilder.cpp
+++ b/lib/Dialect/TritonInstrument/IR/FunctionBuilder.cpp
@@ -398,6 +398,58 @@ Value createCTASetMask(ImplicitLocOpBuilder &b, RankedTensorType tensorType,
   return arith::CmpIOp::create(b, arith::CmpIPredicate::ne, selectedBit, zero);
 }
 
+static void createVerifyBarrierStateCall(ImplicitLocOpBuilder &b,
+                                         StringRef functionName,
+                                         StringRef message, Value offset,
+                                         Value length, Value pred,
+                                         ValueType barriers, ValueType states,
+                                         Value recipientCTAs, bool matchOverlap,
+                                         bool requireInitialized) {
+  if (!pred)
+    pred = arith::ConstantIntOp::create(b, 1, 1);
+  auto barriersType = cast<RankedTensorType>(barriers.type);
+  auto statesType = cast<RankedTensorType>(states.type);
+  SmallVector<Value> args = {offset,         length,       pred,
+                             barriers.value, states.value, recipientCTAs};
+  AssertInfo assertInfo{message, b.getI1Type()};
+  createCallToCachedFunction(
+      b, functionName.str(), args, assertInfo, {barriersType, statesType},
+      [statesType, matchOverlap, requireInitialized](ImplicitLocOpBuilder &fb,
+                                                     Block *entryBlock) {
+        Value offset = entryBlock->getArgument(0);
+        Value length = entryBlock->getArgument(1);
+        Value pred = entryBlock->getArgument(2);
+        Value barriers = entryBlock->getArgument(3);
+        Value statesPtr = entryBlock->getArgument(4);
+        Value recipientCTAs = entryBlock->getArgument(5);
+
+        Value selected;
+        if (matchOverlap) {
+          selected = createBufferOverlapMask(fb, barriers, offset, length);
+        } else {
+          Value descriptor = createBufferDescriptor(fb, offset, length);
+          selected = createCmpIntTensorScalar(fb, barriers, descriptor);
+        }
+        selected = convertAndBroadcast(fb, selected, {1}, statesType);
+
+        Value states = tti::createLoadScratchMemory(fb, fb.getLoc(), statesPtr,
+                                                    statesType);
+        Value zero = tti::createConstIntTensor(fb, fb.getLoc(), 0, statesType);
+        auto predicate = requireInitialized ? arith::CmpIPredicate::ne
+                                            : arith::CmpIPredicate::eq;
+        Value valid = arith::CmpIOp::create(fb, predicate, states, zero);
+        auto condType = cast<RankedTensorType>(valid.getType());
+        Value vTrue = tti::createConstIntTensor(fb, fb.getLoc(), 1, condType);
+        valid = arith::SelectOp::create(fb, selected, valid, vTrue);
+        Value ctaMask =
+            createCTASetMask(fb, condType, /*dim=*/0, recipientCTAs);
+        valid = arith::SelectOp::create(fb, ctaMask, valid, vTrue);
+        Value predTensor = triton::SplatOp::create(fb, condType, pred);
+        valid = arith::SelectOp::create(fb, predTensor, valid, vTrue);
+        triton::ReturnOp::create(fb, reduceAll<arith::AndIOp>(fb, valid));
+      });
+}
+
 Value createLeadCTAEffectMask(ImplicitLocOpBuilder &b,
                               RankedTensorType tensorType, Value effectCTAs) {
   Value lhsMask = createCTASetMask(b, tensorType, /*dim=*/0, effectCTAs);
@@ -984,52 +1036,14 @@ void FunctionBuilder::createVerifyBarrierCanInitCall(ImplicitLocOpBuilder &b,
          "barrier descriptors must exist when verifying barrier init");
   assert(!auxData.barrierStates.empty() &&
          "barrier states must exist when verifying barrier init");
-  if (!pred) {
-    pred = arith::ConstantIntOp::create(b, 1, 1);
-  }
-  Value barriersVal = auxData.barriers.at(insertPoint).value;
-  auto barriersType =
-      cast<RankedTensorType>(auxData.barriers.at(insertPoint).type);
-  Value barrierStatesVal = auxData.barrierStates.at(insertPoint).value;
-  auto barrierStatesType =
-      cast<RankedTensorType>(auxData.barrierStates.at(insertPoint).type);
-  uint32_t length = getMemDescLength(mbar);
-  Value mbarOffset = tti::ExperimentalMemDescToI32Op::create(b, mbar);
-  Value lengthVal = arith::ConstantIntOp::create(b, length, 32);
-  SmallVector<Value> args = {mbarOffset,  lengthVal,        pred,
-                             barriersVal, barrierStatesVal, recipientCTAs};
-  AssertInfo assertInfo{"Barrier re-initialized without prior invalidation",
-                        b.getI1Type()};
-  createCallToCachedFunction(
-      b, "verify_barrier_can_init", args, assertInfo,
-      {barriersType, barrierStatesType},
-      [barrierStatesType](ImplicitLocOpBuilder &fb, Block *entryBlock) {
-        Value mbarOffset = entryBlock->getArgument(0);
-        Value lengthVal = entryBlock->getArgument(1);
-        Value pred = entryBlock->getArgument(2);
-        Value barriers = entryBlock->getArgument(3);
-        Value statesPtr = entryBlock->getArgument(4);
-        Value recipientCTAs = entryBlock->getArgument(5);
-
-        Value states = tti::createLoadScratchMemory(fb, fb.getLoc(), statesPtr,
-                                                    barrierStatesType);
-        Value mask =
-            createBufferOverlapMask(fb, barriers, mbarOffset, lengthVal);
-        mask = convertAndBroadcast(fb, mask, {1}, barrierStatesType);
-        Value zero =
-            tti::createConstIntTensor(fb, fb.getLoc(), 0, barrierStatesType);
-        Value canInit =
-            arith::CmpIOp::create(fb, arith::CmpIPredicate::eq, states, zero);
-        auto condType = cast<RankedTensorType>(canInit.getType());
-        Value vTrue = tti::createConstIntTensor(fb, fb.getLoc(), 1, condType);
-        canInit = arith::SelectOp::create(fb, mask, canInit, vTrue);
-        Value ctaMask =
-            createCTASetMask(fb, condType, /*dim=*/0, recipientCTAs);
-        canInit = arith::SelectOp::create(fb, ctaMask, canInit, vTrue);
-        Value predTensor = triton::SplatOp::create(fb, condType, pred);
-        canInit = arith::SelectOp::create(fb, predTensor, canInit, vTrue);
-        triton::ReturnOp::create(fb, reduceAll<arith::AndIOp>(fb, canInit));
-      });
+  createVerifyBarrierStateCall(
+      b, "verify_barrier_can_init",
+      "Barrier re-initialized without prior invalidation",
+      tti::ExperimentalMemDescToI32Op::create(b, mbar),
+      arith::ConstantIntOp::create(b, getMemDescLength(mbar), 32), pred,
+      auxData.barriers.at(insertPoint), auxData.barrierStates.at(insertPoint),
+      recipientCTAs,
+      /*matchOverlap=*/true, /*requireInitialized=*/false);
 }
 
 void FunctionBuilder::createVerifyBarrierInitializedCall(
@@ -1039,159 +1053,26 @@ void FunctionBuilder::createVerifyBarrierInitializedCall(
          "barrier descriptors must exist when verifying barrier use");
   assert(!auxData.barrierStates.empty() &&
          "barrier states must exist when verifying barrier use");
-  if (!pred) {
-    pred = arith::ConstantIntOp::create(b, 1, 1);
-  }
-  Value barriersVal = auxData.barriers.at(insertPoint).value;
-  auto barriersType =
-      cast<RankedTensorType>(auxData.barriers.at(insertPoint).type);
-  Value barrierStatesVal = auxData.barrierStates.at(insertPoint).value;
-  auto barrierStatesType =
-      cast<RankedTensorType>(auxData.barrierStates.at(insertPoint).type);
-  uint32_t length = getMemDescLength(mbar);
-  Value mbarOffset = tti::ExperimentalMemDescToI32Op::create(b, mbar);
-  Value lengthVal = arith::ConstantIntOp::create(b, length, 32);
-  SmallVector<Value> args = {mbarOffset,  lengthVal,        pred,
-                             barriersVal, barrierStatesVal, recipientCTAs};
-  AssertInfo assertInfo{
+  createVerifyBarrierStateCall(
+      b, "verify_barrier_initialized",
       "Barrier used before initialization or after invalidation",
-      b.getI1Type()};
-  createCallToCachedFunction(
-      b, "verify_barrier_initialized", args, assertInfo,
-      {barriersType, barrierStatesType},
-      [barrierStatesType](ImplicitLocOpBuilder &fb, Block *entryBlock) {
-        Value mbarOffset = entryBlock->getArgument(0);
-        Value lengthVal = entryBlock->getArgument(1);
-        Value pred = entryBlock->getArgument(2);
-        Value barriers = entryBlock->getArgument(3);
-        Value statesPtr = entryBlock->getArgument(4);
-        Value recipientCTAs = entryBlock->getArgument(5);
-
-        Value states = tti::createLoadScratchMemory(fb, fb.getLoc(), statesPtr,
-                                                    barrierStatesType);
-        Value descriptor = createBufferDescriptor(fb, mbarOffset, lengthVal);
-        Value mask = createCmpIntTensorScalar(fb, barriers, descriptor);
-        mask = convertAndBroadcast(fb, mask, {1}, barrierStatesType);
-        Value zero =
-            tti::createConstIntTensor(fb, fb.getLoc(), 0, barrierStatesType);
-        Value initialized =
-            arith::CmpIOp::create(fb, arith::CmpIPredicate::ne, states, zero);
-        auto condType = cast<RankedTensorType>(initialized.getType());
-        Value vTrue = tti::createConstIntTensor(fb, fb.getLoc(), 1, condType);
-        initialized = arith::SelectOp::create(fb, mask, initialized, vTrue);
-        Value ctaMask =
-            createCTASetMask(fb, condType, /*dim=*/0, recipientCTAs);
-        initialized = arith::SelectOp::create(fb, ctaMask, initialized, vTrue);
-        Value predTensor = triton::SplatOp::create(fb, condType, pred);
-        Value predicatedInitialized =
-            arith::SelectOp::create(fb, predTensor, initialized, vTrue);
-        triton::ReturnOp::create(
-            fb, reduceAll<arith::AndIOp>(fb, predicatedInitialized));
-      });
+      tti::ExperimentalMemDescToI32Op::create(b, mbar),
+      arith::ConstantIntOp::create(b, getMemDescLength(mbar), 32), pred,
+      auxData.barriers.at(insertPoint), auxData.barrierStates.at(insertPoint),
+      recipientCTAs,
+      /*matchOverlap=*/false, /*requireInitialized=*/true);
 }
 
 void FunctionBuilder::createVerifyBarrierMemoryAvailableCall(
     ImplicitLocOpBuilder &b, Value offset, uint32_t length, Value pred,
     Operation *insertPoint, Value recipientCTAs) {
-  if (!pred)
-    pred = arith::ConstantIntOp::create(b, 1, 1);
-
-  ValueType barriers = auxData.barriers.at(insertPoint);
-  ValueType states = auxData.barrierStates.at(insertPoint);
-  auto barriersType = cast<RankedTensorType>(barriers.type);
-  auto statesType = cast<RankedTensorType>(states.type);
-  SmallVector<Value> args = {
-      offset,       arith::ConstantIntOp::create(b, length, 32),
-      pred,         barriers.value,
-      states.value, recipientCTAs};
-  AssertInfo assertInfo{"Shared memory reused before barrier invalidation",
-                        b.getI1Type()};
-
-  createCallToCachedFunction(
-      b, "verify_barrier_memory_available", args, assertInfo,
-      {barriersType, statesType},
-      [statesType](ImplicitLocOpBuilder &fb, Block *entryBlock) {
-        Value accessOffset = entryBlock->getArgument(0);
-        Value accessLength = entryBlock->getArgument(1);
-        Value pred = entryBlock->getArgument(2);
-        Value barriers = entryBlock->getArgument(3);
-        Value statesPtr = entryBlock->getArgument(4);
-        Value recipientCTAs = entryBlock->getArgument(5);
-
-        Value overlaps =
-            createBufferOverlapMask(fb, barriers, accessOffset, accessLength);
-        overlaps = convertAndBroadcast(fb, overlaps, {1}, statesType);
-
-        Value states = tti::createLoadScratchMemory(fb, fb.getLoc(), statesPtr,
-                                                    statesType);
-        Value zero = tti::createConstIntTensor(fb, fb.getLoc(), 0, statesType);
-        Value inactive =
-            arith::CmpIOp::create(fb, arith::CmpIPredicate::eq, states, zero);
-        auto condType = cast<RankedTensorType>(inactive.getType());
-        Value vTrue = tti::createConstIntTensor(fb, fb.getLoc(), 1, condType);
-        Value available =
-            arith::SelectOp::create(fb, overlaps, inactive, vTrue);
-        Value ctaMask =
-            createCTASetMask(fb, condType, /*dim=*/0, recipientCTAs);
-        available = arith::SelectOp::create(fb, ctaMask, available, vTrue);
-        Value predTensor = triton::SplatOp::create(fb, condType, pred);
-        available = arith::SelectOp::create(fb, predTensor, available, vTrue);
-        triton::ReturnOp::create(fb, reduceAll<arith::AndIOp>(fb, available));
-      });
-}
-
-void FunctionBuilder::createVerifyBarrierHasNoWaitersCall(
-    ImplicitLocOpBuilder &b, Value mbar, Value pred, Operation *insertPoint,
-    Value recipientCTAs) {
-  assert(!auxData.barriers.empty() && !auxData.waiting.empty() &&
-         "barrier and waiting state must exist when invalidating a barrier");
-  if (!pred)
-    pred = arith::ConstantIntOp::create(b, 1, 1);
-
-  ValueType barriers = auxData.barriers.at(insertPoint);
-  ValueType waiting = auxData.waiting.at(insertPoint);
-  auto barriersType = cast<RankedTensorType>(barriers.type);
-  auto waitingType = cast<RankedTensorType>(waiting.type);
-  SmallVector<Value> args = {
-      tti::ExperimentalMemDescToI32Op::create(b, mbar),
-      arith::ConstantIntOp::create(b, getMemDescLength(mbar), 32),
-      pred,
-      barriers.value,
-      waiting.value,
-      recipientCTAs};
-  AssertInfo assertInfo{"Barrier invalidated while a thread is waiting",
-                        b.getI1Type()};
-
-  createCallToCachedFunction(
-      b, "verify_barrier_has_no_waiters", args, assertInfo,
-      {barriersType, waitingType},
-      [waitingType](ImplicitLocOpBuilder &fb, Block *entryBlock) {
-        Value mbarOffset = entryBlock->getArgument(0);
-        Value length = entryBlock->getArgument(1);
-        Value pred = entryBlock->getArgument(2);
-        Value barriers = entryBlock->getArgument(3);
-        Value waitingPtr = entryBlock->getArgument(4);
-        Value recipientCTAs = entryBlock->getArgument(5);
-
-        Value descriptor = createBufferDescriptor(fb, mbarOffset, length);
-        Value selected = createCmpIntTensorScalar(fb, barriers, descriptor);
-        selected = convertAndBroadcast(fb, selected, {1}, waitingType);
-        selected = arith::AndIOp::create(
-            fb, selected,
-            createCTASetMask(fb, waitingType, /*dim=*/0, recipientCTAs));
-
-        Value waiting = tti::createLoadScratchMemory(fb, fb.getLoc(),
-                                                     waitingPtr, waitingType);
-        Value zero = tti::createConstIntTensor(fb, fb.getLoc(), 0, waitingType);
-        Value idle =
-            arith::CmpIOp::create(fb, arith::CmpIPredicate::eq, waiting, zero);
-        auto condType = cast<RankedTensorType>(idle.getType());
-        Value vTrue = tti::createConstIntTensor(fb, fb.getLoc(), 1, condType);
-        idle = arith::SelectOp::create(fb, selected, idle, vTrue);
-        Value predTensor = triton::SplatOp::create(fb, condType, pred);
-        idle = arith::SelectOp::create(fb, predTensor, idle, vTrue);
-        triton::ReturnOp::create(fb, reduceAll<arith::AndIOp>(fb, idle));
-      });
+  createVerifyBarrierStateCall(
+      b, "verify_barrier_memory_available",
+      "Shared memory reused before barrier invalidation", offset,
+      arith::ConstantIntOp::create(b, length, 32), pred,
+      auxData.barriers.at(insertPoint), auxData.barrierStates.at(insertPoint),
+      recipientCTAs,
+      /*matchOverlap=*/true, /*requireInitialized=*/false);
 }
 
 void FunctionBuilder::createInitBarrierStateCall(ImplicitLocOpBuilder &b,
@@ -1293,9 +1174,9 @@ void FunctionBuilder::createInvalidateBarrierStateCall(ImplicitLocOpBuilder &b,
   Value lengthVal = arith::ConstantIntOp::create(b, length, 32);
   SmallVector<Value> args = {mbarOffset,  lengthVal,        pred,
                              barriersVal, barrierStatesVal, waitingVal};
-  createCallToCachedFunction(
-      b, "invalidate_barrier_state", args,
-      /*assertInfo=*/std::nullopt,
+  AssertInfo statusInfo{"", b.getI32Type()};
+  Value status = createCallToCachedFunction(
+      b, "invalidate_barrier_state", args, statusInfo,
       {barriersType, barrierStatesType, waitingType},
       [barrierStatesType, waitingType](ImplicitLocOpBuilder &fb,
                                        Block *entryBlock) {
@@ -1313,37 +1194,87 @@ void FunctionBuilder::createInvalidateBarrierStateCall(ImplicitLocOpBuilder &b,
         Value descriptor = createBufferDescriptor(fb, mbarOffset, lengthVal);
         Value mask = createCmpIntTensorScalar(fb, barriers, descriptor);
         mask = convertAndBroadcast(fb, mask, {1}, barrierStatesType);
+        Value currentCTA = createCurrentCTAMask(fb);
+        Value stateCTAMask =
+            createCTASetMask(fb, barrierStatesType, /*dim=*/0, currentCTA);
+        Value selectedStates = arith::AndIOp::create(fb, mask, stateCTAMask);
 
         Value zeroState =
             tti::createConstIntTensor(fb, fb.getLoc(), 0, barrierStatesType);
         Value zeroWaiting =
             tti::createConstIntTensor(fb, fb.getLoc(), 0, waitingType);
-        Value updatedStates =
-            arith::SelectOp::create(fb, mask, zeroState, states);
-        auto stateCondType = cast<RankedTensorType>(mask.getType());
-        Value statePredTensor =
-            triton::SplatOp::create(fb, stateCondType, pred);
-        updatedStates =
-            arith::SelectOp::create(fb, statePredTensor, updatedStates, states);
+
+        Value initialized = arith::CmpIOp::create(fb, arith::CmpIPredicate::ne,
+                                                  states, zeroState);
+        Value stateTrue = tti::createConstIntTensor(
+            fb, fb.getLoc(), 1, cast<RankedTensorType>(initialized.getType()));
+        initialized =
+            arith::SelectOp::create(fb, selectedStates, initialized, stateTrue);
+        initialized = reduceAll<arith::AndIOp>(fb, initialized);
+
         Value waitingMask = convertAndBroadcast(fb, mask, {0, 1}, waitingType);
         Value waitingCTAMask =
-            createLeadCTAEffectMask(fb, waitingType, createCurrentCTAMask(fb));
-        waitingMask = arith::AndIOp::create(fb, waitingMask, waitingCTAMask);
-        Value updatedWaiting =
-            arith::SelectOp::create(fb, waitingMask, zeroWaiting, waiting);
-        auto waitingCondType = cast<RankedTensorType>(waitingMask.getType());
-        Value waitingPredTensor =
-            triton::SplatOp::create(fb, waitingCondType, pred);
-        updatedWaiting = arith::SelectOp::create(fb, waitingPredTensor,
-                                                 updatedWaiting, waiting);
+            createLeadCTAEffectMask(fb, waitingType, currentCTA);
+        Value selectedWaiters = arith::AndIOp::create(
+            fb, waitingMask,
+            createCTASetMask(fb, waitingType, /*dim=*/0, currentCTA));
+        Value idle = arith::CmpIOp::create(fb, arith::CmpIPredicate::eq,
+                                           waiting, zeroWaiting);
+        Value waitingTrue = tti::createConstIntTensor(
+            fb, fb.getLoc(), 1, cast<RankedTensorType>(idle.getType()));
+        idle = arith::SelectOp::create(fb, selectedWaiters, idle, waitingTrue);
+        idle = reduceAll<arith::AndIOp>(fb, idle);
+
+        Value valid = arith::AndIOp::create(fb, initialized, idle);
+        Value shouldInvalidate = arith::AndIOp::create(fb, pred, valid);
+
+        auto stateCondType = cast<RankedTensorType>(selectedStates.getType());
+        Value stateValid =
+            triton::SplatOp::create(fb, stateCondType, shouldInvalidate);
+        Value stateUpdateMask =
+            arith::AndIOp::create(fb, selectedStates, stateValid);
+        Value updatedStates =
+            arith::SelectOp::create(fb, stateUpdateMask, zeroState, states);
+        Value waitingUpdateMask =
+            arith::AndIOp::create(fb, waitingMask, waitingCTAMask);
+        auto waitingCondType =
+            cast<RankedTensorType>(waitingUpdateMask.getType());
+        Value waitingValid =
+            triton::SplatOp::create(fb, waitingCondType, shouldInvalidate);
+        waitingUpdateMask =
+            arith::AndIOp::create(fb, waitingUpdateMask, waitingValid);
+        Value updatedWaiting = arith::SelectOp::create(fb, waitingUpdateMask,
+                                                       zeroWaiting, waiting);
         createCTAScopedStoreScratchMemory(fb, fb.getLoc(), statesPtr,
                                           updatedStates, barrierStatesType,
-                                          createCurrentCTAMask(fb));
+                                          currentCTA);
         createMaskedStoreScratchMemory(fb, fb.getLoc(), waitingPtr,
                                        updatedWaiting, waitingType,
                                        waitingCTAMask);
-        triton::ReturnOp::create(fb);
-      });
+
+        Value vTrue = arith::ConstantIntOp::create(fb, 1, 1);
+        initialized = arith::SelectOp::create(fb, pred, initialized, vTrue);
+        idle = arith::SelectOp::create(fb, pred, idle, vTrue);
+        Value initializedI32 =
+            arith::ExtUIOp::create(fb, fb.getI32Type(), initialized);
+        Value idleI32 = arith::ExtUIOp::create(fb, fb.getI32Type(), idle);
+        idleI32 = arith::ShLIOp::create(
+            fb, idleI32, arith::ConstantIntOp::create(fb, 1, 32));
+        Value status = arith::OrIOp::create(fb, initializedI32, idleI32);
+        triton::ReturnOp::create(fb, ValueRange{status});
+      },
+      /*emitAssert=*/false);
+
+  Value initialized = arith::TruncIOp::create(b, b.getI1Type(), status);
+  tti::createAssertInThread(
+      b, initialized,
+      "Barrier used before initialization or after invalidation");
+  Value idle = arith::TruncIOp::create(
+      b, b.getI1Type(),
+      arith::ShRUIOp::create(b, status,
+                             arith::ConstantIntOp::create(b, 1, 32)));
+  tti::createAssertInThread(b, idle,
+                            "Barrier invalidated while a thread is waiting");
 }
 
 void FunctionBuilder::createVerifyAndUpdateBarrierStateCall(
@@ -1934,72 +1865,112 @@ void FunctionBuilder::createTrackVisibleAccessesCall(
       });
 }
 
-void FunctionBuilder::createTrackBarrierWriteForBufferCall(
-    ImplicitLocOpBuilder &b, Value mbar, Value bufferMask, Value pred,
-    MemType memType, Operation *insertPoint, Value barrierCTAs,
-    Value effectCTAs) {
-  if (auxData.barriers.empty() || auxData.writeTracking[(int)memType].empty()) {
-    return;
-  }
+static void createTrackBarrierBufferCall(ImplicitLocOpBuilder &b,
+                                         StringRef functionName, Value mbar,
+                                         Value bufferMask, Value pred,
+                                         ValueType barriers, ValueType tracking,
+                                         Value barrierCTAs, Value effectCTAs,
+                                         ValueType visibility, int thread) {
+  bool trackRead = static_cast<bool>(visibility.value);
   if (!pred)
     pred = arith::ConstantIntOp::create(b, 1, 1);
-  Value barriersVal = auxData.barriers.at(insertPoint).value;
-  auto barriersType =
-      cast<RankedTensorType>(auxData.barriers.at(insertPoint).type);
-  Value writeTrackingVal =
-      auxData.writeTracking[(int)memType].at(insertPoint).value;
-  auto writeTrackingType = cast<RankedTensorType>(
-      auxData.writeTracking[(int)memType].at(insertPoint).type);
-  uint32_t mbarLength = getMemDescLength(mbar);
-  Value mbarOffset = tti::ExperimentalMemDescToI32Op::create(b, mbar);
-  Value mbarLengthVal = arith::ConstantIntOp::create(b, mbarLength, 32);
-  SmallVector<Value> args = {mbarOffset,  mbarLengthVal, pred,
-                             bufferMask,  barriersVal,   writeTrackingVal,
-                             barrierCTAs, effectCTAs};
+  auto barriersType = cast<RankedTensorType>(barriers.type);
+  auto trackingType = cast<RankedTensorType>(tracking.type);
+  RankedTensorType visibilityType;
+  SmallVector<Value> args = {
+      tti::ExperimentalMemDescToI32Op::create(b, mbar),
+      arith::ConstantIntOp::create(b, getMemDescLength(mbar), 32),
+      pred,
+      bufferMask,
+      barriers.value,
+      tracking.value,
+      barrierCTAs,
+      effectCTAs};
+  ManglingArgs specializationArgs{barriersType, trackingType};
+  if (trackRead) {
+    visibilityType = cast<RankedTensorType>(visibility.type);
+    args.append(
+        {arith::ConstantIntOp::create(b, thread, 32), visibility.value});
+    specializationArgs.append(visibilityType);
+  }
   createCallToCachedFunction(
-      b, "track_barrier_write_for_buffer", args,
-      /*assertInfo=*/std::nullopt, {barriersType, writeTrackingType},
-      [writeTrackingType](ImplicitLocOpBuilder &fb, Block *entryBlock) {
+      b, functionName.str(), args, /*assertInfo=*/std::nullopt,
+      specializationArgs,
+      [trackingType, visibilityType, trackRead](ImplicitLocOpBuilder &fb,
+                                                Block *entryBlock) {
         Value mbarOffset = entryBlock->getArgument(0);
-        Value mbarLengthVal = entryBlock->getArgument(1);
+        Value mbarLength = entryBlock->getArgument(1);
         Value pred = entryBlock->getArgument(2);
         Value bufferMask = entryBlock->getArgument(3);
         Value barriers = entryBlock->getArgument(4);
-        Value writeTrackingPtr = entryBlock->getArgument(5);
+        Value trackingPtr = entryBlock->getArgument(5);
         Value barrierCTAs = entryBlock->getArgument(6);
         Value effectCTAs = entryBlock->getArgument(7);
 
         auto [prevBlock, ifBlock, thenBlock] = createIfBlock(fb, pred);
         fb.setInsertionPointToStart(ifBlock);
 
-        Value writeTracking = tti::createLoadScratchMemory(
-            fb, fb.getLoc(), writeTrackingPtr, writeTrackingType);
+        Value tracking = tti::createLoadScratchMemory(
+            fb, fb.getLoc(), trackingPtr, trackingType);
         Value barrierDescriptor =
-            createBufferDescriptor(fb, mbarOffset, mbarLengthVal);
-        Value barriersEqBar =
+            createBufferDescriptor(fb, mbarOffset, mbarLength);
+        Value trackMask =
             createCmpIntTensorScalar(fb, barriers, barrierDescriptor);
-        barriersEqBar =
-            convertAndBroadcast(fb, barriersEqBar, {3}, writeTrackingType);
-        bufferMask =
-            convertAndBroadcast(fb, bufferMask, {1}, writeTrackingType);
-        Value bufferCTAMask =
-            createCTASetMask(fb, writeTrackingType, /*dim=*/0, effectCTAs);
+        trackMask = convertAndBroadcast(fb, trackMask, {3}, trackingType);
+        bufferMask = convertAndBroadcast(fb, bufferMask, {1}, trackingType);
+        trackMask = arith::AndIOp::create(fb, trackMask, bufferMask);
+        trackMask = arith::AndIOp::create(
+            fb, trackMask,
+            createCTASetMask(fb, trackingType, /*dim=*/0, effectCTAs));
         Value barrierCTAMask =
-            createCTASetMask(fb, writeTrackingType, /*dim=*/2, barrierCTAs);
-        Value trackMask = arith::AndIOp::create(fb, barriersEqBar, bufferMask);
-        trackMask = arith::AndIOp::create(fb, trackMask, bufferCTAMask);
+            createCTASetMask(fb, trackingType, /*dim=*/2, barrierCTAs);
         trackMask = arith::AndIOp::create(fb, trackMask, barrierCTAMask);
-        Value writeTrackingOne =
-            tti::createConstIntTensor(fb, fb.getLoc(), 1, writeTrackingType);
-        Value newTracking = arith::SelectOp::create(
-            fb, trackMask, writeTrackingOne, writeTracking);
-        createMaskedStoreScratchMemory(fb, fb.getLoc(), writeTrackingPtr,
-                                       newTracking, writeTrackingType,
-                                       trackMask);
+
+        Value updated;
+        if (trackRead) {
+          Value thread = entryBlock->getArgument(8);
+          Value visibilityPtr = entryBlock->getArgument(9);
+          Value visibility = tti::createLoadScratchMemory(
+              fb, fb.getLoc(), visibilityPtr, visibilityType);
+          Value observer = createDimMask(fb, thread, visibilityType, /*dim=*/3);
+          observer = arith::AndIOp::create(
+              fb, observer,
+              createCTASetMask(fb, visibilityType, /*dim=*/2,
+                               createCurrentCTAMask(fb)));
+          Value zero =
+              tti::createConstIntTensor(fb, fb.getLoc(), 0, visibilityType);
+          Value visibleReads =
+              arith::SelectOp::create(fb, observer, visibility, zero);
+          visibleReads = reduce<arith::OrIOp>(fb, visibleReads, {2, 3});
+          visibleReads =
+              convertAndBroadcast(fb, visibleReads, {0, 1, 4}, trackingType);
+          Value withVisible = arith::OrIOp::create(fb, tracking, visibleReads);
+          updated =
+              arith::SelectOp::create(fb, trackMask, withVisible, tracking);
+        } else {
+          Value one =
+              tti::createConstIntTensor(fb, fb.getLoc(), 1, trackingType);
+          updated = arith::SelectOp::create(fb, trackMask, one, tracking);
+        }
+        createMaskedStoreScratchMemory(fb, fb.getLoc(), trackingPtr, updated,
+                                       trackingType, trackMask);
 
         fb.setInsertionPointToEnd(thenBlock);
         triton::ReturnOp::create(fb);
       });
+}
+
+void FunctionBuilder::createTrackBarrierWriteForBufferCall(
+    ImplicitLocOpBuilder &b, Value mbar, Value bufferMask, Value pred,
+    MemType memType, Operation *insertPoint, Value barrierCTAs,
+    Value effectCTAs) {
+  if (auxData.barriers.empty() || auxData.writeTracking[(int)memType].empty())
+    return;
+  createTrackBarrierBufferCall(
+      b, "track_barrier_write_for_buffer", mbar, bufferMask, pred,
+      auxData.barriers.at(insertPoint),
+      auxData.writeTracking[(int)memType].at(insertPoint), barrierCTAs,
+      effectCTAs, /*visibility=*/{}, /*thread=*/0);
 }
 
 void FunctionBuilder::createTrackBarrierReadForBufferCall(
@@ -2010,83 +1981,11 @@ void FunctionBuilder::createTrackBarrierReadForBufferCall(
       auxData.readVisibility[(int)memType].empty() ||
       auxData.readTracking[(int)memType].empty())
     return;
-  if (!pred)
-    pred = arith::ConstantIntOp::create(b, 1, 1);
-
-  ValueType barriers = auxData.barriers.at(insertPoint);
-  ValueType visibility = auxData.readVisibility[(int)memType].at(insertPoint);
-  ValueType tracking = auxData.readTracking[(int)memType].at(insertPoint);
-  auto barriersType = cast<RankedTensorType>(barriers.type);
-  auto visibilityType = cast<RankedTensorType>(visibility.type);
-  auto trackingType = cast<RankedTensorType>(tracking.type);
-  SmallVector<Value> args = {
-      tti::ExperimentalMemDescToI32Op::create(b, mbar),
-      arith::ConstantIntOp::create(b, getMemDescLength(mbar), 32),
-      pred,
-      bufferMask,
-      arith::ConstantIntOp::create(b, thread, 32),
-      barriers.value,
-      visibility.value,
-      tracking.value,
-      barrierCTAs,
-      effectCTAs};
-
-  createCallToCachedFunction(
-      b, "track_barrier_read_for_buffer", args,
-      /*assertInfo=*/std::nullopt, {barriersType, visibilityType, trackingType},
-      [visibilityType, trackingType](ImplicitLocOpBuilder &fb,
-                                     Block *entryBlock) {
-        Value mbarOffset = entryBlock->getArgument(0);
-        Value mbarLength = entryBlock->getArgument(1);
-        Value pred = entryBlock->getArgument(2);
-        Value bufferMask = entryBlock->getArgument(3);
-        Value thread = entryBlock->getArgument(4);
-        Value barriers = entryBlock->getArgument(5);
-        Value visibilityPtr = entryBlock->getArgument(6);
-        Value trackingPtr = entryBlock->getArgument(7);
-        Value barrierCTAs = entryBlock->getArgument(8);
-        Value effectCTAs = entryBlock->getArgument(9);
-
-        auto [prevBlock, ifBlock, thenBlock] = createIfBlock(fb, pred);
-        fb.setInsertionPointToStart(ifBlock);
-
-        Value visibility = tti::createLoadScratchMemory(
-            fb, fb.getLoc(), visibilityPtr, visibilityType);
-        Value tracking = tti::createLoadScratchMemory(
-            fb, fb.getLoc(), trackingPtr, trackingType);
-        Value currentCTA = createCurrentCTAMask(fb);
-        Value observer = createDimMask(fb, thread, visibilityType, /*dim=*/3);
-        observer = arith::AndIOp::create(
-            fb, observer,
-            createCTASetMask(fb, visibilityType, /*dim=*/2, currentCTA));
-        Value zero =
-            tti::createConstIntTensor(fb, fb.getLoc(), 0, visibilityType);
-        Value visibleReads =
-            arith::SelectOp::create(fb, observer, visibility, zero);
-        visibleReads = reduce<arith::OrIOp>(fb, visibleReads, {2, 3});
-        visibleReads =
-            convertAndBroadcast(fb, visibleReads, {0, 1, 4}, trackingType);
-
-        Value descriptor = createBufferDescriptor(fb, mbarOffset, mbarLength);
-        Value trackMask = createCmpIntTensorScalar(fb, barriers, descriptor);
-        trackMask = convertAndBroadcast(fb, trackMask, {3}, trackingType);
-        bufferMask = convertAndBroadcast(fb, bufferMask, {1}, trackingType);
-        trackMask = arith::AndIOp::create(fb, trackMask, bufferMask);
-        trackMask = arith::AndIOp::create(
-            fb, trackMask,
-            createCTASetMask(fb, trackingType, /*dim=*/0, effectCTAs));
-        trackMask = arith::AndIOp::create(
-            fb, trackMask,
-            createCTASetMask(fb, trackingType, /*dim=*/2, barrierCTAs));
-        Value withVisible = arith::OrIOp::create(fb, tracking, visibleReads);
-        Value updated =
-            arith::SelectOp::create(fb, trackMask, withVisible, tracking);
-        createMaskedStoreScratchMemory(fb, fb.getLoc(), trackingPtr, updated,
-                                       trackingType, trackMask);
-
-        fb.setInsertionPointToEnd(thenBlock);
-        triton::ReturnOp::create(fb);
-      });
+  createTrackBarrierBufferCall(
+      b, "track_barrier_read_for_buffer", mbar, bufferMask, pred,
+      auxData.barriers.at(insertPoint),
+      auxData.readTracking[(int)memType].at(insertPoint), barrierCTAs,
+      effectCTAs, auxData.readVisibility[(int)memType].at(insertPoint), thread);
 }
 
 static void createClearBarrierTrackingCall(ImplicitLocOpBuilder &b,

--- a/lib/Dialect/TritonInstrument/IR/FunctionBuilder.cpp
+++ b/lib/Dialect/TritonInstrument/IR/FunctionBuilder.cpp
@@ -251,29 +251,6 @@ Value createBufferDescriptor(ImplicitLocOpBuilder &b, Value offsetI32,
   return arith::OrIOp::create(b, lengthShifted, offsetI64);
 }
 
-Value createBufferOverlapMask(ImplicitLocOpBuilder &b, Value descriptors,
-                              Value offset, Value length) {
-  auto type = cast<RankedTensorType>(descriptors.getType());
-  Value offsetMask = tti::createConstIntTensor(b, b.getLoc(), UINT32_MAX, type);
-  Value shift = tti::createConstIntTensor(b, b.getLoc(), 32, type);
-  Value descriptorOffsets = arith::AndIOp::create(b, descriptors, offsetMask);
-  Value descriptorLengths = arith::ShRUIOp::create(b, descriptors, shift);
-  Value descriptorEnds =
-      arith::AddIOp::create(b, descriptorOffsets, descriptorLengths);
-
-  Value offsetI64 = arith::ExtUIOp::create(b, b.getI64Type(), offset);
-  Value lengthI64 = arith::ExtUIOp::create(b, b.getI64Type(), length);
-  Value endI64 = arith::AddIOp::create(b, offsetI64, lengthI64);
-  Value offsets = triton::SplatOp::create(b, type, offsetI64);
-  Value ends = triton::SplatOp::create(b, type, endI64);
-  return arith::AndIOp::create(
-      b,
-      arith::CmpIOp::create(b, arith::CmpIPredicate::ult, offsets,
-                            descriptorEnds),
-      arith::CmpIOp::create(b, arith::CmpIPredicate::ult, descriptorOffsets,
-                            ends));
-}
-
 std::tuple<Block *, Block *, Block *> createIfBlock(ImplicitLocOpBuilder &b,
                                                     Value cnd) {
   // #prevBlock
@@ -398,9 +375,12 @@ Value createCTASetMask(ImplicitLocOpBuilder &b, RankedTensorType tensorType,
   return arith::CmpIOp::create(b, arith::CmpIPredicate::ne, selectedBit, zero);
 }
 
-static void createVerifyBarrierAvailableCall(
-    ImplicitLocOpBuilder &b, StringRef message, Value offset, Value length,
-    Value pred, ValueType barriers, ValueType states, Value recipientCTAs) {
+static void createVerifyBarrierStateCall(ImplicitLocOpBuilder &b,
+                                         StringRef message, Value offset,
+                                         Value length, Value pred,
+                                         ValueType barriers, ValueType states,
+                                         Value recipientCTAs,
+                                         bool initialized) {
   if (!pred)
     pred = arith::ConstantIntOp::create(b, 1, 1);
   auto barriersType = cast<RankedTensorType>(barriers.type);
@@ -409,9 +389,9 @@ static void createVerifyBarrierAvailableCall(
                              barriers.value, states.value, recipientCTAs};
   AssertInfo assertInfo{message, b.getI1Type()};
   createCallToCachedFunction(
-      b, "verify_barrier_can_init", args, assertInfo,
-      {barriersType, statesType},
-      [statesType](ImplicitLocOpBuilder &fb, Block *entryBlock) {
+      b, initialized ? "verify_barrier_initialized" : "verify_barrier_can_init",
+      args, assertInfo, {barriersType, statesType},
+      [statesType, initialized](ImplicitLocOpBuilder &fb, Block *entryBlock) {
         Value offset = entryBlock->getArgument(0);
         Value length = entryBlock->getArgument(1);
         Value pred = entryBlock->getArgument(2);
@@ -419,14 +399,17 @@ static void createVerifyBarrierAvailableCall(
         Value statesPtr = entryBlock->getArgument(4);
         Value recipientCTAs = entryBlock->getArgument(5);
 
-        Value selected = createBufferOverlapMask(fb, barriers, offset, length);
+        Value descriptor = createBufferDescriptor(fb, offset, length);
+        Value selected = createCmpIntTensorScalar(fb, barriers, descriptor);
         selected = convertAndBroadcast(fb, selected, {1}, statesType);
 
         Value states = tti::createLoadScratchMemory(fb, fb.getLoc(), statesPtr,
                                                     statesType);
         Value zero = tti::createConstIntTensor(fb, fb.getLoc(), 0, statesType);
-        Value valid =
-            arith::CmpIOp::create(fb, arith::CmpIPredicate::eq, states, zero);
+        Value valid = arith::CmpIOp::create(
+            fb,
+            initialized ? arith::CmpIPredicate::ne : arith::CmpIPredicate::eq,
+            states, zero);
         auto condType = cast<RankedTensorType>(valid.getType());
         Value vTrue = tti::createConstIntTensor(fb, fb.getLoc(), 1, condType);
         valid = arith::SelectOp::create(fb, selected, valid, vTrue);
@@ -1025,12 +1008,12 @@ void FunctionBuilder::createVerifyBarrierCanInitCall(ImplicitLocOpBuilder &b,
          "barrier descriptors must exist when verifying barrier init");
   assert(!auxData.barrierStates.empty() &&
          "barrier states must exist when verifying barrier init");
-  createVerifyBarrierAvailableCall(
+  createVerifyBarrierStateCall(
       b, "Barrier re-initialized without prior invalidation",
       tti::ExperimentalMemDescToI32Op::create(b, mbar),
       arith::ConstantIntOp::create(b, getMemDescLength(mbar), 32), pred,
       auxData.barriers.at(insertPoint), auxData.barrierStates.at(insertPoint),
-      recipientCTAs);
+      recipientCTAs, /*initialized=*/false);
 }
 
 void FunctionBuilder::createVerifyBarrierInitializedCall(
@@ -1040,65 +1023,22 @@ void FunctionBuilder::createVerifyBarrierInitializedCall(
          "barrier descriptors must exist when verifying barrier use");
   assert(!auxData.barrierStates.empty() &&
          "barrier states must exist when verifying barrier use");
-  if (!pred) {
-    pred = arith::ConstantIntOp::create(b, 1, 1);
-  }
-  Value barriersVal = auxData.barriers.at(insertPoint).value;
-  auto barriersType =
-      cast<RankedTensorType>(auxData.barriers.at(insertPoint).type);
-  Value barrierStatesVal = auxData.barrierStates.at(insertPoint).value;
-  auto barrierStatesType =
-      cast<RankedTensorType>(auxData.barrierStates.at(insertPoint).type);
-  uint32_t length = getMemDescLength(mbar);
-  Value mbarOffset = tti::ExperimentalMemDescToI32Op::create(b, mbar);
-  Value lengthVal = arith::ConstantIntOp::create(b, length, 32);
-  SmallVector<Value> args = {mbarOffset,  lengthVal,        pred,
-                             barriersVal, barrierStatesVal, recipientCTAs};
-  AssertInfo assertInfo{
-      "Barrier used before initialization or after invalidation",
-      b.getI1Type()};
-  createCallToCachedFunction(
-      b, "verify_barrier_initialized", args, assertInfo,
-      {barriersType, barrierStatesType},
-      [barrierStatesType](ImplicitLocOpBuilder &fb, Block *entryBlock) {
-        Value mbarOffset = entryBlock->getArgument(0);
-        Value lengthVal = entryBlock->getArgument(1);
-        Value pred = entryBlock->getArgument(2);
-        Value barriers = entryBlock->getArgument(3);
-        Value statesPtr = entryBlock->getArgument(4);
-        Value recipientCTAs = entryBlock->getArgument(5);
-
-        Value states = tti::createLoadScratchMemory(fb, fb.getLoc(), statesPtr,
-                                                    barrierStatesType);
-        Value descriptor = createBufferDescriptor(fb, mbarOffset, lengthVal);
-        Value mask = createCmpIntTensorScalar(fb, barriers, descriptor);
-        mask = convertAndBroadcast(fb, mask, {1}, barrierStatesType);
-        Value zero =
-            tti::createConstIntTensor(fb, fb.getLoc(), 0, barrierStatesType);
-        Value initialized =
-            arith::CmpIOp::create(fb, arith::CmpIPredicate::ne, states, zero);
-        auto condType = cast<RankedTensorType>(initialized.getType());
-        Value vTrue = tti::createConstIntTensor(fb, fb.getLoc(), 1, condType);
-        initialized = arith::SelectOp::create(fb, mask, initialized, vTrue);
-        Value ctaMask =
-            createCTASetMask(fb, condType, /*dim=*/0, recipientCTAs);
-        initialized = arith::SelectOp::create(fb, ctaMask, initialized, vTrue);
-        Value predTensor = triton::SplatOp::create(fb, condType, pred);
-        Value predicatedInitialized =
-            arith::SelectOp::create(fb, predTensor, initialized, vTrue);
-        triton::ReturnOp::create(
-            fb, reduceAll<arith::AndIOp>(fb, predicatedInitialized));
-      });
+  createVerifyBarrierStateCall(
+      b, "Barrier used before initialization or after invalidation",
+      tti::ExperimentalMemDescToI32Op::create(b, mbar),
+      arith::ConstantIntOp::create(b, getMemDescLength(mbar), 32), pred,
+      auxData.barriers.at(insertPoint), auxData.barrierStates.at(insertPoint),
+      recipientCTAs, /*initialized=*/true);
 }
 
 void FunctionBuilder::createVerifyBarrierMemoryAvailableCall(
     ImplicitLocOpBuilder &b, Value offset, uint32_t length, Value pred,
     Operation *insertPoint, Value recipientCTAs) {
-  createVerifyBarrierAvailableCall(
+  createVerifyBarrierStateCall(
       b, "Shared memory reused before barrier invalidation", offset,
       arith::ConstantIntOp::create(b, length, 32), pred,
       auxData.barriers.at(insertPoint), auxData.barrierStates.at(insertPoint),
-      recipientCTAs);
+      recipientCTAs, /*initialized=*/false);
 }
 
 void FunctionBuilder::createInitBarrierStateCall(ImplicitLocOpBuilder &b,
@@ -1180,30 +1120,20 @@ void FunctionBuilder::createInvalidateBarrierStateCall(ImplicitLocOpBuilder &b,
   createInvalidateBarrierStateCallImpl(
       b, tti::ExperimentalMemDescToI32Op::create(b, mbar),
       arith::ConstantIntOp::create(b, getMemDescLength(mbar), 32), pred,
-      insertPoint, nullptr, /*allowUninitialized=*/false);
+      insertPoint, /*allowUninitialized=*/false);
 }
 
 void FunctionBuilder::createInvalidateBarrierStorageCall(
     ImplicitLocOpBuilder &b, Value offset, uint32_t length, Value pred,
-    Operation *insertPoint, Value recipientCTAs) {
-  Value lengthVal = arith::ConstantIntOp::create(b, length, 32);
-  Value status = createInvalidateBarrierStateCallImpl(
-      b, offset, lengthVal, pred, insertPoint, recipientCTAs,
+    Operation *insertPoint) {
+  createInvalidateBarrierStateCallImpl(
+      b, offset, arith::ConstantIntOp::create(b, length, 32), pred, insertPoint,
       /*allowUninitialized=*/true);
-  Value initialized = arith::TruncIOp::create(b, b.getI1Type(), status);
-  Value idle = arith::TruncIOp::create(
-      b, b.getI1Type(),
-      arith::ShRUIOp::create(b, status,
-                             arith::ConstantIntOp::create(b, 1, 32)));
-  Value clearPred =
-      tti::maybeAnd(b, pred, arith::AndIOp::create(b, initialized, idle));
-  createClearBarrierStorageTrackingCall(b, offset, lengthVal, clearPred,
-                                        insertPoint, recipientCTAs);
 }
 
-Value FunctionBuilder::createInvalidateBarrierStateCallImpl(
+void FunctionBuilder::createInvalidateBarrierStateCallImpl(
     ImplicitLocOpBuilder &b, Value mbarOffset, Value lengthVal, Value pred,
-    Operation *insertPoint, Value recipientCTAs, bool allowUninitialized) {
+    Operation *insertPoint, bool allowUninitialized) {
   assert(!auxData.barriers.empty() &&
          "barrier descriptors must exist when invalidating a barrier");
   assert(!auxData.barrierStates.empty() &&
@@ -1224,8 +1154,6 @@ Value FunctionBuilder::createInvalidateBarrierStateCallImpl(
       cast<RankedTensorType>(auxData.waiting.at(insertPoint).type);
   SmallVector<Value> args = {mbarOffset,  lengthVal,        pred,
                              barriersVal, barrierStatesVal, waitingVal};
-  if (allowUninitialized)
-    args.push_back(recipientCTAs);
   AssertInfo statusInfo{"", b.getI32Type()};
   Value status = createCallToCachedFunction(
       b,
@@ -1248,8 +1176,7 @@ Value FunctionBuilder::createInvalidateBarrierStateCallImpl(
         Value descriptor = createBufferDescriptor(fb, mbarOffset, lengthVal);
         Value mask = createCmpIntTensorScalar(fb, barriers, descriptor);
         mask = convertAndBroadcast(fb, mask, {1}, barrierStatesType);
-        Value currentCTA = allowUninitialized ? entryBlock->getArgument(6)
-                                              : createCurrentCTAMask(fb);
+        Value currentCTA = createCurrentCTAMask(fb);
         Value stateCTAMask =
             createCTASetMask(fb, barrierStatesType, /*dim=*/0, currentCTA);
         Value selectedStates = arith::AndIOp::create(fb, mask, stateCTAMask);
@@ -1328,8 +1255,8 @@ Value FunctionBuilder::createInvalidateBarrierStateCallImpl(
       },
       /*emitAssert=*/false);
 
+  Value initialized = arith::TruncIOp::create(b, b.getI1Type(), status);
   if (!allowUninitialized) {
-    Value initialized = arith::TruncIOp::create(b, b.getI1Type(), status);
     tti::createAssertInThread(
         b, initialized,
         "Barrier used before initialization or after invalidation");
@@ -1340,7 +1267,12 @@ Value FunctionBuilder::createInvalidateBarrierStateCallImpl(
                              arith::ConstantIntOp::create(b, 1, 32)));
   tti::createAssertInThread(b, idle,
                             "Barrier invalidated while a thread is waiting");
-  return status;
+  Value clearPred = pred;
+  if (allowUninitialized)
+    clearPred =
+        tti::maybeAnd(b, pred, arith::AndIOp::create(b, initialized, idle));
+  createClearBarrierStorageTrackingCall(b, mbarOffset, lengthVal, clearPred,
+                                        insertPoint);
 }
 
 void FunctionBuilder::createVerifyAndUpdateBarrierStateCall(
@@ -1926,18 +1858,10 @@ void FunctionBuilder::createTrackVisibleAccessesCall(
               tti::createConstIntTensor(fb, fb.getLoc(), 0, readVisibilityType);
           Value sourceCTAMask =
               createCTASetMask(fb, readVisibilityType, /*dim=*/2, currentCTA);
-          Value visibleReads;
-          if (filterBuffer) {
-            Value observer =
-                arith::AndIOp::create(fb, threadColumnMask, sourceCTAMask);
-            visibleReads =
-                arith::SelectOp::create(fb, observer, visibility, zero);
-          } else {
-            visibleReads =
-                arith::SelectOp::create(fb, threadColumnMask, visibility, zero);
-            visibleReads =
-                arith::SelectOp::create(fb, sourceCTAMask, visibleReads, zero);
-          }
+          Value observer =
+              arith::AndIOp::create(fb, threadColumnMask, sourceCTAMask);
+          Value visibleReads =
+              arith::SelectOp::create(fb, observer, visibility, zero);
           visibleReads = reduce<arith::OrIOp>(fb, visibleReads, {2, 3});
           visibleReads = convertAndBroadcast(fb, visibleReads, {0, 1, 4},
                                              readTrackingType);
@@ -2022,23 +1946,22 @@ void FunctionBuilder::createTrackBarrierWriteForBufferCall(
       });
 }
 
-static void createClearBarrierTrackingCall(
-    ImplicitLocOpBuilder &b, StringRef functionName, Value offset, Value length,
-    Value pred, Value recipientCTAs, ValueType barriers, ValueType tracking) {
+static void createClearBarrierTrackingCall(ImplicitLocOpBuilder &b,
+                                           StringRef functionName, Value offset,
+                                           Value length, Value pred,
+                                           ValueType barriers,
+                                           ValueType tracking) {
   if (!pred)
     pred = arith::ConstantIntOp::create(b, 1, 1);
   auto barriersType = cast<RankedTensorType>(barriers.type);
   auto trackingType = cast<RankedTensorType>(tracking.type);
   SmallVector<Value> args = {offset, length, pred, barriers.value,
                              tracking.value};
-  bool scoped = static_cast<bool>(recipientCTAs);
-  if (scoped)
-    args.push_back(recipientCTAs);
   ManglingArgs specializationArgs{barriersType, trackingType};
   createCallToCachedFunction(
       b, functionName.str(), args, /*assertInfo=*/std::nullopt,
       specializationArgs,
-      [trackingType, scoped](ImplicitLocOpBuilder &fb, Block *entryBlock) {
+      [trackingType](ImplicitLocOpBuilder &fb, Block *entryBlock) {
         Value mbarOffset = entryBlock->getArgument(0);
         Value lengthVal = entryBlock->getArgument(1);
         Value pred = entryBlock->getArgument(2);
@@ -2055,8 +1978,7 @@ static void createClearBarrierTrackingCall(
             createCmpIntTensorScalar(fb, barriers, descriptor);
         barriersEqBar =
             convertAndBroadcast(fb, barriersEqBar, {3}, trackingType);
-        Value barrierCTAs =
-            scoped ? entryBlock->getArgument(5) : createCurrentCTAMask(fb);
+        Value barrierCTAs = createCurrentCTAMask(fb);
         Value barrierCTAMask =
             createCTASetMask(fb, trackingType, /*dim=*/2, barrierCTAs);
         barriersEqBar =
@@ -2073,50 +1995,14 @@ static void createClearBarrierTrackingCall(
       });
 }
 
-static void createClearBarrierTrackingCall(ImplicitLocOpBuilder &b,
-                                           StringRef functionName, Value mbar,
-                                           Value pred, ValueType barriers,
-                                           ValueType tracking) {
-  createClearBarrierTrackingCall(
-      b, functionName, tti::ExperimentalMemDescToI32Op::create(b, mbar),
-      arith::ConstantIntOp::create(b, getMemDescLength(mbar), 32), pred,
-      nullptr, barriers, tracking);
-}
-
-void FunctionBuilder::createClearBarrierWriteTrackingCall(
-    ImplicitLocOpBuilder &b, Value mbar, Value pred, MemType memType,
-    Operation *insertPoint) {
-  if (auxData.writeTracking[(int)memType].empty())
-    return;
-  assert(!auxData.barriers.empty() &&
-         "barrier descriptors must exist when clearing barrier write tracking");
-  createClearBarrierTrackingCall(
-      b, "clear_barrier_write_tracking", mbar, pred,
-      auxData.barriers.at(insertPoint),
-      auxData.writeTracking[(int)memType].at(insertPoint));
-}
-
-void FunctionBuilder::createClearBarrierReadTrackingCall(
-    ImplicitLocOpBuilder &b, Value mbar, Value pred, MemType memType,
-    Operation *insertPoint) {
-  if (auxData.readTracking[(int)memType].empty())
-    return;
-  assert(!auxData.barriers.empty() &&
-         "barrier descriptors must exist when clearing barrier read tracking");
-  createClearBarrierTrackingCall(
-      b, "clear_barrier_read_tracking", mbar, pred,
-      auxData.barriers.at(insertPoint),
-      auxData.readTracking[(int)memType].at(insertPoint));
-}
-
 void FunctionBuilder::createClearBarrierStorageTrackingCall(
     ImplicitLocOpBuilder &b, Value offset, Value length, Value pred,
-    Operation *insertPoint, Value recipientCTAs) {
+    Operation *insertPoint) {
   auto clear = [&](StringRef name, AuxDataMap::RegionToValueMap &tracking) {
     if (!tracking.empty())
-      createClearBarrierTrackingCall(
-          b, name, offset, length, pred, recipientCTAs,
-          auxData.barriers.at(insertPoint), tracking.at(insertPoint));
+      createClearBarrierTrackingCall(b, name, offset, length, pred,
+                                     auxData.barriers.at(insertPoint),
+                                     tracking.at(insertPoint));
   };
   for (MemType memType : {MemType::SHARED_MEM, MemType::TENSOR_MEM}) {
     clear("clear_barrier_write_tracking", auxData.writeTracking[(int)memType]);
@@ -3209,17 +3095,6 @@ void FunctionBuilder::createCompleteBarrierWaitCall(ImplicitLocOpBuilder &b,
         fb.setInsertionPointToEnd(thenBlock);
         triton::ReturnOp::create(fb);
       });
-}
-
-void FunctionBuilder::createClearBarrierProxyAccessTrackingCall(
-    ImplicitLocOpBuilder &b, Value mbar, Value pred, Operation *insertPoint) {
-  if (auxData.proxyAccessTracking.empty())
-    return;
-  assert(!auxData.barriers.empty() &&
-         "barrier descriptors must exist when clearing proxy tracking");
-  createClearBarrierTrackingCall(b, "clear_barrier_proxy_tracking", mbar, pred,
-                                 auxData.barriers.at(insertPoint),
-                                 auxData.proxyAccessTracking.at(insertPoint));
 }
 
 void FunctionBuilder::createVerifyProxyAccessCall(ImplicitLocOpBuilder &b,

--- a/lib/Dialect/TritonInstrument/IR/FunctionBuilder.cpp
+++ b/lib/Dialect/TritonInstrument/IR/FunctionBuilder.cpp
@@ -399,9 +399,8 @@ Value createCTASetMask(ImplicitLocOpBuilder &b, RankedTensorType tensorType,
 }
 
 static void createVerifyBarrierAvailableCall(
-    ImplicitLocOpBuilder &b, StringRef functionName, StringRef message,
-    Value offset, Value length, Value pred, ValueType barriers,
-    ValueType states, Value recipientCTAs) {
+    ImplicitLocOpBuilder &b, StringRef message, Value offset, Value length,
+    Value pred, ValueType barriers, ValueType states, Value recipientCTAs) {
   if (!pred)
     pred = arith::ConstantIntOp::create(b, 1, 1);
   auto barriersType = cast<RankedTensorType>(barriers.type);
@@ -410,7 +409,8 @@ static void createVerifyBarrierAvailableCall(
                              barriers.value, states.value, recipientCTAs};
   AssertInfo assertInfo{message, b.getI1Type()};
   createCallToCachedFunction(
-      b, functionName.str(), args, assertInfo, {barriersType, statesType},
+      b, "verify_barrier_can_init", args, assertInfo,
+      {barriersType, statesType},
       [statesType](ImplicitLocOpBuilder &fb, Block *entryBlock) {
         Value offset = entryBlock->getArgument(0);
         Value length = entryBlock->getArgument(1);
@@ -1026,8 +1026,7 @@ void FunctionBuilder::createVerifyBarrierCanInitCall(ImplicitLocOpBuilder &b,
   assert(!auxData.barrierStates.empty() &&
          "barrier states must exist when verifying barrier init");
   createVerifyBarrierAvailableCall(
-      b, "verify_barrier_can_init",
-      "Barrier re-initialized without prior invalidation",
+      b, "Barrier re-initialized without prior invalidation",
       tti::ExperimentalMemDescToI32Op::create(b, mbar),
       arith::ConstantIntOp::create(b, getMemDescLength(mbar), 32), pred,
       auxData.barriers.at(insertPoint), auxData.barrierStates.at(insertPoint),
@@ -1096,8 +1095,7 @@ void FunctionBuilder::createVerifyBarrierMemoryAvailableCall(
     ImplicitLocOpBuilder &b, Value offset, uint32_t length, Value pred,
     Operation *insertPoint, Value recipientCTAs) {
   createVerifyBarrierAvailableCall(
-      b, "verify_barrier_memory_available",
-      "Shared memory reused before barrier invalidation", offset,
+      b, "Shared memory reused before barrier invalidation", offset,
       arith::ConstantIntOp::create(b, length, 32), pred,
       auxData.barriers.at(insertPoint), auxData.barrierStates.at(insertPoint),
       recipientCTAs);

--- a/lib/Dialect/TritonInstrument/IR/Utility.cpp
+++ b/lib/Dialect/TritonInstrument/IR/Utility.cpp
@@ -674,7 +674,6 @@ AuxDataMap::getBuffersAndBarriers(ModuleOp module,
 
   SmallVector<std::pair<Value, RegionInfo>> candidates[numMemTypes];
   DenseSet<Value> seenValues;
-  DenseSet<Value> lifecycleValues;
   DenseSet<Value> payloadValues;
   DenseSet<Value> completionBarrierValues;
   auto collectCandidates = [&](Value value) {
@@ -709,9 +708,7 @@ AuxDataMap::getBuffersAndBarriers(ModuleOp module,
           [](const MemEffectsOpInfo::Effects &e) { return e.rw == RW::Read; });
     for (const auto &effect : info->operandEffects) {
       collectCandidates(effect.buf);
-      if (effect.buf == lifecycleValue)
-        lifecycleValues.insert(effect.buf);
-      else
+      if (effect.buf != lifecycleValue)
         payloadValues.insert(effect.buf);
     }
     if (hooks.isTMAOp(op) || hooks.isCLCOp(op) ||
@@ -737,37 +734,38 @@ AuxDataMap::getBuffersAndBarriers(ModuleOp module,
     bool hasUnknown = analysis->hasUnknownUsedBufferRegions(regionType);
 
     if (memType == MemType::SHARED_MEM) {
+      auto appendRegions = [&](const DenseSet<Value> &values) {
+        for (Value value : values) {
+          auto type = dyn_cast<MemDescType>(value.getType());
+          if (!type || !isa<SharedMemorySpaceAttr>(type.getMemorySpace()))
+            continue;
+          const RegionInfo &info =
+              analysis->getLatticeElement(value)->getValue();
+          hasUnknown |= info.isUnknown();
+          for (const BufferRegionView &view : info.views)
+            regions.push_back(view.region);
+        }
+      };
+      auto sortUnique = [](SmallVectorImpl<BufferRegion> &regions) {
+        llvm::sort(regions);
+        regions.erase(std::unique(regions.begin(), regions.end()),
+                      regions.end());
+      };
       // BufferRegionAnalysis classifies a value used as an mbarrier as barrier
       // storage globally. Recover ordinary payload uses here. Barrier bytes use
       // the ordinary reader model only when they can alias payload or receive a
       // deferred engine completion; isolated synchronous barriers stay on the
       // compact barrier-specific state.
-      for (Value value : payloadValues) {
-        auto type = dyn_cast<MemDescType>(value.getType());
-        if (!type || !isa<SharedMemorySpaceAttr>(type.getMemorySpace()))
-          continue;
-        const RegionInfo &info = analysis->getLatticeElement(value)->getValue();
-        hasUnknown |= info.isUnknown();
-        for (const BufferRegionView &view : info.views)
-          regions.push_back(view.region);
-      }
-
-      llvm::sort(regions);
-      regions.erase(std::unique(regions.begin(), regions.end()), regions.end());
+      appendRegions(payloadValues);
+      sortUnique(regions);
       SmallVector<BufferRegion> payloadRegions = regions;
-      for (Value value : completionBarrierValues) {
-        const RegionInfo &info = analysis->getLatticeElement(value)->getValue();
-        hasUnknown |= info.isUnknown();
-        for (const BufferRegionView &view : info.views)
-          regions.push_back(view.region);
-      }
+      appendRegions(completionBarrierValues);
       for (const BufferRegion &barrier : barrierRegions)
         if (hasUnknown || llvm::any_of(payloadRegions, [&](const auto &region) {
               return barrier.intersects(region);
             }))
           regions.push_back(barrier);
-      llvm::sort(regions);
-      regions.erase(std::unique(regions.begin(), regions.end()), regions.end());
+      sortUnique(regions);
     }
 
     if (regions.empty() && !hasUnknown)
@@ -794,7 +792,7 @@ AuxDataMap::getBuffersAndBarriers(ModuleOp module,
         const BufferRegion &candidate = view.region;
         auto it = llvm::lower_bound(regions, candidate);
         if (it == regions.end() || !(*it == candidate)) {
-          if (lifecycleValues.contains(value) && !payloadValues.contains(value))
+          if (!payloadValues.contains(value))
             continue;
           InFlightDiagnostic diag = emitError(
               value.getLoc(),

--- a/lib/Dialect/TritonInstrument/IR/Utility.cpp
+++ b/lib/Dialect/TritonInstrument/IR/Utility.cpp
@@ -696,11 +696,8 @@ AuxDataMap::getBuffersAndBarriers(ModuleOp module,
     auto info = hooks.getMemEffectsOpInfo(op);
     if (!info)
       return;
-    Value lifecycleValue;
-    if (auto init = hooks.getBarrierInitInfo(op))
-      lifecycleValue = init->alloc;
-    if (auto invalidate = hooks.getBarrierInvalidateInfo(op))
-      lifecycleValue = invalidate->alloc;
+    bool isBarrierLifecycle = hooks.getBarrierInitInfo(op).has_value() ||
+                              hooks.getBarrierInvalidateInfo(op).has_value();
     if (info->trackingKind == MemEffectsOpInfo::TrackingKind::CommitCount &&
         info->commitKind == CommitKind::AsyncCp)
       hasAsyncCopyReads |= llvm::any_of(
@@ -708,7 +705,7 @@ AuxDataMap::getBuffersAndBarriers(ModuleOp module,
           [](const MemEffectsOpInfo::Effects &e) { return e.rw == RW::Read; });
     for (const auto &effect : info->operandEffects) {
       collectCandidates(effect.buf);
-      if (effect.buf != lifecycleValue)
+      if (!isBarrierLifecycle)
         payloadValues.insert(effect.buf);
     }
     if (hooks.isTMAOp(op) || hooks.isCLCOp(op) ||

--- a/lib/Dialect/TritonInstrument/IR/Utility.cpp
+++ b/lib/Dialect/TritonInstrument/IR/Utility.cpp
@@ -674,8 +674,6 @@ AuxDataMap::getBuffersAndBarriers(ModuleOp module,
 
   SmallVector<std::pair<Value, RegionInfo>> candidates[numMemTypes];
   DenseSet<Value> seenValues;
-  DenseSet<Value> payloadValues;
-  DenseSet<Value> completionBarrierValues;
   auto collectCandidates = [&](Value value) {
     if (!seenValues.insert(value).second)
       return;
@@ -693,28 +691,19 @@ AuxDataMap::getBuffersAndBarriers(ModuleOp module,
         {value, analysis->getLatticeElement(value)->getValue()});
   };
   module.walk([&](Operation *op) {
+    for (const MemoryAccess &access : getMemoryAccesses(op))
+      collectCandidates(access.value);
+
     auto info = hooks.getMemEffectsOpInfo(op);
     if (!info)
       return;
-    bool isBarrierLifecycle = hooks.getBarrierInitInfo(op).has_value() ||
-                              hooks.getBarrierInvalidateInfo(op).has_value();
     if (info->trackingKind == MemEffectsOpInfo::TrackingKind::CommitCount &&
         info->commitKind == CommitKind::AsyncCp)
       hasAsyncCopyReads |= llvm::any_of(
           info->operandEffects,
           [](const MemEffectsOpInfo::Effects &e) { return e.rw == RW::Read; });
-    for (const auto &effect : info->operandEffects) {
-      collectCandidates(effect.buf);
-      if (!isBarrierLifecycle)
-        payloadValues.insert(effect.buf);
-    }
-    if (hooks.isTMAOp(op) || hooks.isCLCOp(op) ||
-        isa<MMAv5OpInterface, TCGen5CommitOp, TMEMCopyOp>(op)) {
-      for (const auto &barrier : info->barriers) {
-        collectCandidates(barrier.barrier);
-        completionBarrierValues.insert(barrier.barrier);
-      }
-    }
+    for (const auto &barrier : info->barriers)
+      collectCandidates(barrier.barrier);
   });
 
   analysis->calculateUsedBufferRegions(module);
@@ -730,41 +719,6 @@ AuxDataMap::getBuffersAndBarriers(ModuleOp module,
         analysis->getAllUsedBufferRegions(regionType);
     bool hasUnknown = analysis->hasUnknownUsedBufferRegions(regionType);
 
-    if (memType == MemType::SHARED_MEM) {
-      auto appendRegions = [&](const DenseSet<Value> &values) {
-        for (Value value : values) {
-          auto type = dyn_cast<MemDescType>(value.getType());
-          if (!type || !isa<SharedMemorySpaceAttr>(type.getMemorySpace()))
-            continue;
-          const RegionInfo &info =
-              analysis->getLatticeElement(value)->getValue();
-          hasUnknown |= info.isUnknown();
-          for (const BufferRegionView &view : info.views)
-            regions.push_back(view.region);
-        }
-      };
-      auto sortUnique = [](SmallVectorImpl<BufferRegion> &regions) {
-        llvm::sort(regions);
-        regions.erase(std::unique(regions.begin(), regions.end()),
-                      regions.end());
-      };
-      // BufferRegionAnalysis classifies a value used as an mbarrier as barrier
-      // storage globally. Recover ordinary payload uses here. Barrier bytes use
-      // the ordinary reader model only when they can alias payload or receive a
-      // deferred engine completion; isolated synchronous barriers stay on the
-      // compact barrier-specific state.
-      appendRegions(payloadValues);
-      sortUnique(regions);
-      SmallVector<BufferRegion> payloadRegions = regions;
-      appendRegions(completionBarrierValues);
-      for (const BufferRegion &barrier : barrierRegions)
-        if (hasUnknown || llvm::any_of(payloadRegions, [&](const auto &region) {
-              return barrier.intersects(region);
-            }))
-          regions.push_back(barrier);
-      sortUnique(regions);
-    }
-
     if (regions.empty() && !hasUnknown)
       continue;
 
@@ -774,8 +728,6 @@ AuxDataMap::getBuffersAndBarriers(ModuleOp module,
     if (memType == MemType::SHARED_MEM) {
       for (const BufferRegion &barrier : barrierRegions) {
         auto it = llvm::lower_bound(regions, barrier);
-        if (it == regions.end() || !(*it == barrier))
-          continue;
         unsigned id = std::distance(regions.begin(), it);
         sharedBarrierMasks.push_back(
             {barrier, bufferStatePlans[iMemType].regionMasks[id]});
@@ -789,8 +741,6 @@ AuxDataMap::getBuffersAndBarriers(ModuleOp module,
         const BufferRegion &candidate = view.region;
         auto it = llvm::lower_bound(regions, candidate);
         if (it == regions.end() || !(*it == candidate)) {
-          if (!payloadValues.contains(value))
-            continue;
           InFlightDiagnostic diag = emitError(
               value.getLoc(),
               "accessed exact buffer-region candidate is absent from the "
@@ -814,9 +764,7 @@ AuxDataMap::getBuffersAndBarriers(ModuleOp module,
           existing->ctaMask |= ctaMask;
         }
       }
-      if (stateCandidates.unknown || !stateCandidates.cases.empty())
-        bufferCandidates[iMemType].try_emplace(value,
-                                               std::move(stateCandidates));
+      bufferCandidates[iMemType].try_emplace(value, std::move(stateCandidates));
     }
   }
   return success();

--- a/lib/Dialect/TritonInstrument/IR/Utility.cpp
+++ b/lib/Dialect/TritonInstrument/IR/Utility.cpp
@@ -1,5 +1,6 @@
 #include "triton/Dialect/TritonInstrument/IR/Utility.h"
 #include "mlir/Analysis/SliceAnalysis.h"
+#include "mlir/Dialect/Arith/IR/Arith.h"
 #include "mlir/Dialect/ControlFlow/IR/ControlFlowOps.h"
 #include "triton/Analysis/BufferRegion.h"
 #include "triton/Analysis/Utility.h"
@@ -675,20 +676,26 @@ AuxDataMap::getBuffersAndBarriers(ModuleOp module,
   SmallVector<std::pair<Value, RegionInfo>> candidates[numMemTypes];
   DenseSet<Value> seenValues;
   auto collectCandidates = [&](Value value) {
-    if (!seenValues.insert(value).second)
-      return;
-    auto type = dyn_cast<MemDescType>(value.getType());
-    if (!type)
-      return;
-    std::optional<MemType> memType;
-    if (isa<SharedMemorySpaceAttr>(type.getMemorySpace()))
-      memType = MemType::SHARED_MEM;
-    else if (isa<TensorMemorySpaceAttr>(type.getMemorySpace()))
-      memType = MemType::TENSOR_MEM;
-    if (!memType)
-      return;
-    candidates[static_cast<int>(*memType)].push_back(
-        {value, analysis->getLatticeElement(value)->getValue()});
+    SmallVector<Value> pending = {value};
+    while (!pending.empty()) {
+      Value current = pending.pop_back_val();
+      if (!seenValues.insert(current).second)
+        continue;
+      auto type = dyn_cast<MemDescType>(current.getType());
+      if (!type)
+        continue;
+      std::optional<MemType> memType;
+      if (isa<SharedMemorySpaceAttr>(type.getMemorySpace()))
+        memType = MemType::SHARED_MEM;
+      else if (isa<TensorMemorySpaceAttr>(type.getMemorySpace()))
+        memType = MemType::TENSOR_MEM;
+      if (!memType)
+        continue;
+      candidates[static_cast<int>(*memType)].push_back(
+          {current, analysis->getLatticeElement(current)->getValue()});
+      if (auto select = current.getDefiningOp<arith::SelectOp>())
+        pending.append({select.getTrueValue(), select.getFalseValue()});
+    }
   };
   module.walk([&](Operation *op) {
     for (const MemoryAccess &access : getMemoryAccesses(op))
@@ -729,8 +736,8 @@ AuxDataMap::getBuffersAndBarriers(ModuleOp module,
       for (const BufferRegion &barrier : barrierRegions) {
         auto it = llvm::lower_bound(regions, barrier);
         unsigned id = std::distance(regions.begin(), it);
-        sharedBarrierMasks.push_back(
-            {barrier, bufferStatePlans[iMemType].regionMasks[id]});
+        barrierBufferMasks.push_back(
+            bufferStatePlans[iMemType].regionMasks[id]);
       }
     }
 
@@ -753,7 +760,8 @@ AuxDataMap::getBuffersAndBarriers(ModuleOp module,
 
         auto existing = llvm::find_if(
             stateCandidates.cases, [&](const BufferStateCandidate &state) {
-              return state.baseOffset == candidate.baseOffset;
+              return state.baseOffset == candidate.baseOffset &&
+                     state.ctaMask == ctaMask;
             });
         if (existing == stateCandidates.cases.end()) {
           stateCandidates.cases.push_back(
@@ -761,7 +769,6 @@ AuxDataMap::getBuffersAndBarriers(ModuleOp module,
                ctaMask});
         } else {
           existing->mask |= bufferStatePlans[iMemType].regionMasks[id];
-          existing->ctaMask |= ctaMask;
         }
       }
       bufferCandidates[iMemType].try_emplace(value, std::move(stateCandidates));

--- a/lib/Dialect/TritonInstrument/IR/Utility.cpp
+++ b/lib/Dialect/TritonInstrument/IR/Utility.cpp
@@ -674,6 +674,9 @@ AuxDataMap::getBuffersAndBarriers(ModuleOp module,
 
   SmallVector<std::pair<Value, RegionInfo>> candidates[numMemTypes];
   DenseSet<Value> seenValues;
+  DenseSet<Value> lifecycleValues;
+  DenseSet<Value> payloadValues;
+  DenseSet<Value> completionBarrierValues;
   auto collectCandidates = [&](Value value) {
     if (!seenValues.insert(value).second)
       return;
@@ -694,13 +697,30 @@ AuxDataMap::getBuffersAndBarriers(ModuleOp module,
     auto info = hooks.getMemEffectsOpInfo(op);
     if (!info)
       return;
+    Value lifecycleValue;
+    if (auto init = hooks.getBarrierInitInfo(op))
+      lifecycleValue = init->alloc;
+    if (auto invalidate = hooks.getBarrierInvalidateInfo(op))
+      lifecycleValue = invalidate->alloc;
     if (info->trackingKind == MemEffectsOpInfo::TrackingKind::CommitCount &&
         info->commitKind == CommitKind::AsyncCp)
       hasAsyncCopyReads |= llvm::any_of(
           info->operandEffects,
           [](const MemEffectsOpInfo::Effects &e) { return e.rw == RW::Read; });
-    for (const auto &effect : info->operandEffects)
+    for (const auto &effect : info->operandEffects) {
       collectCandidates(effect.buf);
+      if (effect.buf == lifecycleValue)
+        lifecycleValues.insert(effect.buf);
+      else
+        payloadValues.insert(effect.buf);
+    }
+    if (hooks.isTMAOp(op) || hooks.isCLCOp(op) ||
+        isa<MMAv5OpInterface, TCGen5CommitOp, TMEMCopyOp>(op)) {
+      for (const auto &barrier : info->barriers) {
+        collectCandidates(barrier.barrier);
+        completionBarrierValues.insert(barrier.barrier);
+      }
+    }
   });
 
   analysis->calculateUsedBufferRegions(module);
@@ -715,11 +735,57 @@ AuxDataMap::getBuffersAndBarriers(ModuleOp module,
     SmallVector<BufferRegion> regions =
         analysis->getAllUsedBufferRegions(regionType);
     bool hasUnknown = analysis->hasUnknownUsedBufferRegions(regionType);
+
+    if (memType == MemType::SHARED_MEM) {
+      // BufferRegionAnalysis classifies a value used as an mbarrier as barrier
+      // storage globally. Recover ordinary payload uses here. Barrier bytes use
+      // the ordinary reader model only when they can alias payload or receive a
+      // deferred engine completion; isolated synchronous barriers stay on the
+      // compact barrier-specific state.
+      for (Value value : payloadValues) {
+        auto type = dyn_cast<MemDescType>(value.getType());
+        if (!type || !isa<SharedMemorySpaceAttr>(type.getMemorySpace()))
+          continue;
+        const RegionInfo &info = analysis->getLatticeElement(value)->getValue();
+        hasUnknown |= info.isUnknown();
+        for (const BufferRegionView &view : info.views)
+          regions.push_back(view.region);
+      }
+
+      llvm::sort(regions);
+      regions.erase(std::unique(regions.begin(), regions.end()), regions.end());
+      SmallVector<BufferRegion> payloadRegions = regions;
+      for (Value value : completionBarrierValues) {
+        const RegionInfo &info = analysis->getLatticeElement(value)->getValue();
+        hasUnknown |= info.isUnknown();
+        for (const BufferRegionView &view : info.views)
+          regions.push_back(view.region);
+      }
+      for (const BufferRegion &barrier : barrierRegions)
+        if (hasUnknown || llvm::any_of(payloadRegions, [&](const auto &region) {
+              return barrier.intersects(region);
+            }))
+          regions.push_back(barrier);
+      llvm::sort(regions);
+      regions.erase(std::unique(regions.begin(), regions.end()), regions.end());
+    }
+
     if (regions.empty() && !hasUnknown)
       continue;
 
     bufferStatePlans[iMemType] =
         triton::createBufferStatePlan(regions, hasUnknown);
+
+    if (memType == MemType::SHARED_MEM) {
+      for (const BufferRegion &barrier : barrierRegions) {
+        auto it = llvm::lower_bound(regions, barrier);
+        if (it == regions.end() || !(*it == barrier))
+          continue;
+        unsigned id = std::distance(regions.begin(), it);
+        sharedBarrierMasks.push_back(
+            {barrier, bufferStatePlans[iMemType].regionMasks[id]});
+      }
+    }
 
     for (const auto &[value, regionInfo] : candidates[iMemType]) {
       BufferStateCandidates stateCandidates;
@@ -728,6 +794,8 @@ AuxDataMap::getBuffersAndBarriers(ModuleOp module,
         const BufferRegion &candidate = view.region;
         auto it = llvm::lower_bound(regions, candidate);
         if (it == regions.end() || !(*it == candidate)) {
+          if (lifecycleValues.contains(value) && !payloadValues.contains(value))
+            continue;
           InFlightDiagnostic diag = emitError(
               value.getLoc(),
               "accessed exact buffer-region candidate is absent from the "
@@ -751,7 +819,9 @@ AuxDataMap::getBuffersAndBarriers(ModuleOp module,
           existing->ctaMask |= ctaMask;
         }
       }
-      bufferCandidates[iMemType].try_emplace(value, std::move(stateCandidates));
+      if (stateCandidates.unknown || !stateCandidates.cases.empty())
+        bufferCandidates[iMemType].try_emplace(value,
+                                               std::move(stateCandidates));
     }
   }
   return success();

--- a/lib/Dialect/TritonInstrument/Transforms/ConcurrencySanitizer.cpp
+++ b/lib/Dialect/TritonInstrument/Transforms/ConcurrencySanitizer.cpp
@@ -833,9 +833,15 @@ private:
           // effects remain pending until a worker explicitly waits for them.
           b.setListener(nullptr);
           b.setInsertionPointAfter(wsOp);
+          Value lock = auxData.lock.at(op).value;
+          Value trueVal = arith::ConstantIntOp::create(b, 1, 1);
+          tti::ExperimentalLockAcquireOp::create(b, lock, trueVal);
           for (MemType memType : {MemType::SHARED_MEM, MemType::TENSOR_MEM})
             funcBuilder.createPublishCTAVisibilityCall(
-                b, baseDestMask, /*destMask=*/1, memType, op);
+                b, baseDestMask,
+                getThreadPeersMask(baseThread, auxData.threadLayout), memType,
+                op);
+          tti::ExperimentalLockReleaseOp::create(b, lock, trueVal);
           b.setInsertionPoint(wsOp);
           b.setListener(&listener);
         }

--- a/lib/Dialect/TritonInstrument/Transforms/ConcurrencySanitizer.cpp
+++ b/lib/Dialect/TritonInstrument/Transforms/ConcurrencySanitizer.cpp
@@ -828,6 +828,20 @@ private:
           if (baseDestMask)
             funcBuilder.createCopyProxyAccessesCall(b, baseThread, baseDestMask,
                                                     nullptr, op);
+          // Lowering joins the partitions with a CTA barrier. Merge completed
+          // reader observations only after that join so the default partition
+          // cannot observe a worker's state while it is still running.
+          b.setListener(nullptr);
+          b.setInsertionPointAfter(wsOp);
+          for (Region *region : partitionRegions) {
+            int sourceThread = region->getRegionNumber() + 1;
+            for (MemType memType : {MemType::SHARED_MEM, MemType::TENSOR_MEM})
+              funcBuilder.createCopyReadVisibilityCall(
+                  b, sourceThread, /*destMask=*/1, nullptr, memType, op,
+                  /*merge=*/true);
+          }
+          b.setInsertionPoint(wsOp);
+          b.setListener(&listener);
         }
       }
       if (auto info = hooks.getBarrierInitInfo(op)) {

--- a/lib/Dialect/TritonInstrument/Transforms/ConcurrencySanitizer.cpp
+++ b/lib/Dialect/TritonInstrument/Transforms/ConcurrencySanitizer.cpp
@@ -842,6 +842,8 @@ private:
         Value pred = hooks.getIssuerCTAPred(b, op);
         funcBuilder.createVerifyBarrierInitializedCall(b, barrier, pred, op,
                                                        currentCTAMask(b));
+        funcBuilder.createVerifyBarrierHasNoWaitersCall(b, barrier, pred, op,
+                                                        currentCTAMask(b));
         funcBuilder.createInvalidateBarrierStateCall(b, barrier, pred, op);
         for (MemType memType : {MemType::SHARED_MEM, MemType::TENSOR_MEM}) {
           funcBuilder.createClearBarrierWriteTrackingCall(b, barrier, pred,
@@ -988,8 +990,20 @@ private:
                                      tti::FunctionBuilder &funcBuilder) {
     int baseThread = getBaseThread(thread, auxData.threadLayout);
     std::optional<MemEffectsOpInfo> opInfo = hooks.getMemEffectsOpInfo(op);
+    for (const MemoryAccess &access :
+         getMemoryAccesses(op, ttg::SharedKind::Barrier)) {
+      if (opInfo && llvm::any_of(opInfo->barriers, [&](const auto &barrier) {
+            return barrier.barrier == access.value;
+          }))
+        continue;
+      funcBuilder.createVerifyBarrierInitializedCall(
+          b, access.value, hooks.getIssuerCTAPred(b, op), op,
+          getBarrierRecipientCTAs(b, op));
+    }
     if (!opInfo)
       return success();
+    bool isBarrierLifecycle = hooks.getBarrierInitInfo(op).has_value() ||
+                              hooks.getBarrierInvalidateInfo(op).has_value();
     Value pred = opInfo->pred;
     Value issuerCTAPred = hooks.getIssuerCTAPred(b, op);
     pred = tti::maybeAnd(b, pred, issuerCTAPred);
@@ -1013,6 +1027,8 @@ private:
           auxData.bufferCandidates[static_cast<int>(materialized.memType)];
       auto candidateIt = candidateMap.find(buf);
       if (candidateIt == candidateMap.end()) {
+        if (isBarrierLifecycle)
+          continue;
         op->emitError("missing buffer-region candidates for memdesc");
         return failure();
       }
@@ -1032,6 +1048,38 @@ private:
       Value bufferMask = materialized.bufferMask;
       Value effectCTAs = materialized.effectCTAs;
       MemType memType = materialized.memType;
+
+      if (memType == MemType::SHARED_MEM && !isBarrierLifecycle) {
+        const BufferStateCandidates &candidates = candidateIt->second;
+        for (const auto &[barrier, barrierMask] : auxData.sharedBarrierMasks) {
+          Value barrierOffset = tti::ExperimentalMemoryOffsetToI32Op::create(
+              b, barrier.baseOffset, memType);
+          auto verifyAvailable = [&](Value candidatePred) {
+            funcBuilder.createVerifyBarrierMemoryAvailableCall(
+                b, barrierOffset, barrier.length, candidatePred, op,
+                effectCTAs);
+          };
+          if (candidates.unknown) {
+            verifyAvailable(pred);
+            continue;
+          }
+          for (const BufferStateCandidate &candidate : candidates.cases) {
+            if (!candidate.mask.anyCommon(barrierMask))
+              continue;
+            Value candidatePred = pred;
+            if (candidates.cases.size() > 1) {
+              Value candidateBase =
+                  tti::ExperimentalMemoryOffsetToI32Op::create(
+                      b, candidate.baseOffset, memType);
+              Value matchesBase = arith::CmpIOp::create(
+                  b, arith::CmpIPredicate::eq, runtimeBase, candidateBase);
+              candidatePred = tti::maybeAnd(b, candidatePred, matchesBase);
+            }
+            verifyAvailable(candidatePred);
+          }
+        }
+      }
+
       if (memType == MemType::SHARED_MEM) {
         if (effect.sharedKind == ttg::SharedKind::Async) {
           funcBuilder.createVerifyProxyAccessCall(b, bufferMask, baseThread,
@@ -1088,6 +1136,35 @@ private:
               ? getAsyncSharedStoreBarrierRecipientCTAs(
                     b, barrier, materializedEffects.front().effectCTAs)
               : getBarrierRecipientCTAs(b, op);
+      Value completionBufferMask;
+      if (thread != baseThread) {
+        auto &candidateMap = auxData.bufferCandidates[(int)MemType::SHARED_MEM];
+        auto candidateIt = candidateMap.find(barrier);
+        if (candidateIt == candidateMap.end()) {
+          op->emitError(
+              "missing buffer-region candidates for completion barrier");
+          return failure();
+        }
+        Value runtimeBase;
+        if (!candidateIt->second.unknown &&
+            candidateIt->second.cases.size() > 1)
+          runtimeBase = tti::ExperimentalMemDescToI32Op::create(b, barrier);
+        FailureOr<Value> stateMask =
+            createBufferStateMask(b, auxData, MemType::SHARED_MEM, runtimeBase,
+                                  candidateIt->second, op);
+        if (failed(stateMask))
+          return failure();
+        completionBufferMask = *stateMask;
+        // A deferred completion may still touch the barrier after the issuing
+        // thread advances. Model that future touch as a reader owned by the
+        // synthetic engine. Waiting publishes the reader through the existing
+        // barrier frontier; invalidation is a generic write and therefore must
+        // observe it first.
+        funcBuilder.createSetReadVisibilityCall(
+            b, completionBufferMask, thread,
+            getThreadPeersMask(thread, auxData.threadLayout), combinedPred,
+            MemType::SHARED_MEM, op, recipientCTAs);
+      }
       if (barrierInfo.count == 0 && barrierInfo.txCount == 0)
         funcBuilder.createVerifyBarrierInitializedCall(b, barrier, combinedPred,
                                                        op, recipientCTAs);
@@ -1116,6 +1193,10 @@ private:
                 op, recipientCTAs, materialized.effectCTAs);
           }
         }
+        if (completionBufferMask)
+          funcBuilder.createTrackBarrierReadForBufferCall(
+              b, barrier, completionBufferMask, thread, combinedPred,
+              MemType::SHARED_MEM, op, recipientCTAs, recipientCTAs);
       }
       if (barrierInfo.count > 0 || barrierInfo.txCount != 0) {
         funcBuilder.createVerifyAndUpdateBarrierStateCall(

--- a/lib/Dialect/TritonInstrument/Transforms/ConcurrencySanitizer.cpp
+++ b/lib/Dialect/TritonInstrument/Transforms/ConcurrencySanitizer.cpp
@@ -840,10 +840,6 @@ private:
       if (auto info = hooks.getBarrierInvalidateInfo(op)) {
         Value barrier = info->alloc;
         Value pred = hooks.getIssuerCTAPred(b, op);
-        funcBuilder.createVerifyBarrierInitializedCall(b, barrier, pred, op,
-                                                       currentCTAMask(b));
-        funcBuilder.createVerifyBarrierHasNoWaitersCall(b, barrier, pred, op,
-                                                        currentCTAMask(b));
         funcBuilder.createInvalidateBarrierStateCall(b, barrier, pred, op);
         for (MemType memType : {MemType::SHARED_MEM, MemType::TENSOR_MEM}) {
           funcBuilder.createClearBarrierWriteTrackingCall(b, barrier, pred,
@@ -1008,6 +1004,30 @@ private:
     Value issuerCTAPred = hooks.getIssuerCTAPred(b, op);
     pred = tti::maybeAnd(b, pred, issuerCTAPred);
     Value defaultEffectCTAs = getMemEffectCTAs(b, op);
+    struct MaterializedBuffer {
+      Value mask;
+      Value runtimeBase;
+      const BufferStateCandidates *candidates;
+    };
+    auto materializeBuffer =
+        [&](Value buffer, MemType memType,
+            StringRef missingMessage) -> FailureOr<MaterializedBuffer> {
+      auto &candidateMap = auxData.bufferCandidates[(int)memType];
+      auto candidateIt = candidateMap.find(buffer);
+      if (candidateIt == candidateMap.end()) {
+        op->emitError(missingMessage);
+        return failure();
+      }
+      const BufferStateCandidates &candidates = candidateIt->second;
+      Value runtimeBase;
+      if (!candidates.unknown && candidates.cases.size() > 1)
+        runtimeBase = tti::ExperimentalMemDescToI32Op::create(b, buffer);
+      FailureOr<Value> mask = createBufferStateMask(
+          b, auxData, memType, runtimeBase, candidates, op);
+      if (failed(mask))
+        return failure();
+      return MaterializedBuffer{*mask, runtimeBase, &candidates};
+    };
     struct MaterializedEffect {
       Value bufferMask;
       Value effectCTAs;
@@ -1025,24 +1045,16 @@ private:
         materialized.memType = MemType::SHARED_MEM;
       auto &candidateMap =
           auxData.bufferCandidates[static_cast<int>(materialized.memType)];
-      auto candidateIt = candidateMap.find(buf);
-      if (candidateIt == candidateMap.end()) {
-        if (isBarrierLifecycle)
-          continue;
-        op->emitError("missing buffer-region candidates for memdesc");
+      if (isBarrierLifecycle && !candidateMap.contains(buf))
+        continue;
+      FailureOr<MaterializedBuffer> buffer =
+          materializeBuffer(buf, materialized.memType,
+                            "missing buffer-region candidates for memdesc");
+      if (failed(buffer))
         return failure();
-      }
-      Value runtimeBase;
-      if (!candidateIt->second.unknown && candidateIt->second.cases.size() > 1)
-        runtimeBase = tti::ExperimentalMemDescToI32Op::create(b, buf);
-      FailureOr<Value> stateMask =
-          createBufferStateMask(b, auxData, materialized.memType, runtimeBase,
-                                candidateIt->second, op);
-      if (failed(stateMask))
-        return failure();
-      materialized.bufferMask = *stateMask;
+      materialized.bufferMask = buffer->mask;
       materialized.effectCTAs =
-          getMemEffectCTAs(b, defaultEffectCTAs, candidateIt->second);
+          getMemEffectCTAs(b, defaultEffectCTAs, *buffer->candidates);
       materializedEffects.push_back(materialized);
 
       Value bufferMask = materialized.bufferMask;
@@ -1050,7 +1062,7 @@ private:
       MemType memType = materialized.memType;
 
       if (memType == MemType::SHARED_MEM && !isBarrierLifecycle) {
-        const BufferStateCandidates &candidates = candidateIt->second;
+        const BufferStateCandidates &candidates = *buffer->candidates;
         for (const auto &[barrier, barrierMask] : auxData.sharedBarrierMasks) {
           Value barrierOffset = tti::ExperimentalMemoryOffsetToI32Op::create(
               b, barrier.baseOffset, memType);
@@ -1071,8 +1083,9 @@ private:
               Value candidateBase =
                   tti::ExperimentalMemoryOffsetToI32Op::create(
                       b, candidate.baseOffset, memType);
-              Value matchesBase = arith::CmpIOp::create(
-                  b, arith::CmpIPredicate::eq, runtimeBase, candidateBase);
+              Value matchesBase =
+                  arith::CmpIOp::create(b, arith::CmpIPredicate::eq,
+                                        buffer->runtimeBase, candidateBase);
               candidatePred = tti::maybeAnd(b, candidatePred, matchesBase);
             }
             verifyAvailable(candidatePred);
@@ -1138,23 +1151,12 @@ private:
               : getBarrierRecipientCTAs(b, op);
       Value completionBufferMask;
       if (thread != baseThread) {
-        auto &candidateMap = auxData.bufferCandidates[(int)MemType::SHARED_MEM];
-        auto candidateIt = candidateMap.find(barrier);
-        if (candidateIt == candidateMap.end()) {
-          op->emitError(
-              "missing buffer-region candidates for completion barrier");
+        FailureOr<MaterializedBuffer> completionBuffer = materializeBuffer(
+            barrier, MemType::SHARED_MEM,
+            "missing buffer-region candidates for completion barrier");
+        if (failed(completionBuffer))
           return failure();
-        }
-        Value runtimeBase;
-        if (!candidateIt->second.unknown &&
-            candidateIt->second.cases.size() > 1)
-          runtimeBase = tti::ExperimentalMemDescToI32Op::create(b, barrier);
-        FailureOr<Value> stateMask =
-            createBufferStateMask(b, auxData, MemType::SHARED_MEM, runtimeBase,
-                                  candidateIt->second, op);
-        if (failed(stateMask))
-          return failure();
-        completionBufferMask = *stateMask;
+        completionBufferMask = completionBuffer->mask;
         // A deferred completion may still touch the barrier after the issuing
         // thread advances. Model that future touch as a reader owned by the
         // synthetic engine. Waiting publishes the reader through the existing

--- a/lib/Dialect/TritonInstrument/Transforms/ConcurrencySanitizer.cpp
+++ b/lib/Dialect/TritonInstrument/Transforms/ConcurrencySanitizer.cpp
@@ -848,8 +848,16 @@ private:
       }
       if (auto info = hooks.getBarrierInitInfo(op)) {
         Value pred = hooks.getIssuerCTAPred(b, op);
-        funcBuilder.createVerifyBarrierCanInitCall(b, info->alloc, pred, op,
-                                                   currentCTAMask(b));
+        if (!hooks.barrierWritesInvalidate()) {
+          funcBuilder.createVerifyBarrierCanInitCall(b, info->alloc, pred, op,
+                                                     currentCTAMask(b));
+        } else if (!auxData.bufferCandidates[(int)MemType::SHARED_MEM].contains(
+                       info->alloc)) {
+          // Isolated barriers have no buffer lane for instrumentMemEffects.
+          funcBuilder.createInvalidateBarrierStorageCall(
+              b, tti::ExperimentalMemDescToI32Op::create(b, info->alloc),
+              getMemDescLength(info->alloc), pred, op, currentCTAMask(b));
+        }
         funcBuilder.createInitBarrierStateCall(b, info->alloc, info->count,
                                                pred, op);
       }
@@ -1060,19 +1068,36 @@ private:
       Value bufferMask = materialized.bufferMask;
       Value effectCTAs = materialized.effectCTAs;
       MemType memType = materialized.memType;
+      struct PendingBarrierInvalidation {
+        Value offset;
+        uint32_t length;
+        Value pred;
+        Value recipientCTAs;
+      };
+      SmallVector<PendingBarrierInvalidation> pendingInvalidations;
+      bool invalidatesBarriers = false;
+      if (memType == MemType::SHARED_MEM && hooks.barrierWritesInvalidate() &&
+          effect.rw == RW::Write &&
+          effect.sharedKind == ttg::SharedKind::Generic &&
+          thread == baseThread &&
+          opInfo->trackingKind == MemEffectsOpInfo::TrackingKind::Barrier) {
+        invalidatesBarriers =
+            llvm::none_of(getMemoryAccesses(op), [&](const auto &access) {
+              return access.value == buf &&
+                     access.sharedKind == effect.sharedKind && access.isRead;
+            });
+      }
 
-      if (memType == MemType::SHARED_MEM && !isBarrierLifecycle) {
+      if (memType == MemType::SHARED_MEM &&
+          (!isBarrierLifecycle || invalidatesBarriers)) {
         const BufferStateCandidates &candidates = candidateIt->second;
         for (const auto &[barrier, barrierMask] : auxData.sharedBarrierMasks) {
           Value barrierOffset = tti::ExperimentalMemoryOffsetToI32Op::create(
               b, barrier.baseOffset, memType);
           int64_t barrierLength = barrier.length;
-          auto verifyAvailable = [&](Value candidatePred) {
-            funcBuilder.createVerifyBarrierMemoryAvailableCall(
-                b, barrierOffset, barrierLength, candidatePred, op, effectCTAs);
-          };
           if (candidates.unknown) {
-            verifyAvailable(pred);
+            funcBuilder.createVerifyBarrierMemoryAvailableCall(
+                b, barrierOffset, barrierLength, pred, op, effectCTAs);
             continue;
           }
           for (const BufferStateCandidate &candidate : candidates.cases) {
@@ -1087,7 +1112,20 @@ private:
                   b, arith::CmpIPredicate::eq, runtimeBase, candidateBase);
               candidatePred = tti::maybeAnd(b, candidatePred, matchesBase);
             }
-            verifyAvailable(candidatePred);
+            bool singleOwner = candidate.ctaMask &&
+                               !(candidate.ctaMask & (candidate.ctaMask - 1));
+            if (!invalidatesBarriers || !singleOwner) {
+              funcBuilder.createVerifyBarrierMemoryAvailableCall(
+                  b, barrierOffset, barrierLength, candidatePred, op,
+                  effectCTAs);
+              continue;
+            }
+            BufferStateCandidates selected;
+            selected.cases.push_back(candidate);
+            pendingInvalidations.push_back(
+                {barrierOffset, static_cast<uint32_t>(barrierLength),
+                 candidatePred,
+                 getMemEffectCTAs(b, defaultEffectCTAs, selected)});
           }
         }
       }
@@ -1127,6 +1165,11 @@ private:
                        effect.operandName, effectCTAs, opInfo->commitKind);
         addReadChecks(b, funcBuilder, op, bufferMask, pred, memType, thread,
                       effect.operandName, effectCTAs, opInfo->commitKind);
+        for (const PendingBarrierInvalidation &barrier : pendingInvalidations) {
+          funcBuilder.createInvalidateBarrierStorageCall(
+              b, barrier.offset, barrier.length, barrier.pred, op,
+              barrier.recipientCTAs);
+        }
         if (opInfo->trackingKind == MemEffectsOpInfo::TrackingKind::Barrier) {
           funcBuilder.createPublishWriteVisibilityCall(
               b, bufferMask, getThreadPeersMask(thread, auxData.threadLayout),

--- a/lib/Dialect/TritonInstrument/Transforms/ConcurrencySanitizer.cpp
+++ b/lib/Dialect/TritonInstrument/Transforms/ConcurrencySanitizer.cpp
@@ -828,18 +828,14 @@ private:
           if (baseDestMask)
             funcBuilder.createCopyProxyAccessesCall(b, baseThread, baseDestMask,
                                                     nullptr, op);
-          // Lowering joins the partitions with a CTA barrier. Merge completed
-          // reader observations only after that join so the default partition
-          // cannot observe a worker's state while it is still running.
+          // Lowering joins the partitions with a CTA barrier. Publish facts
+          // observed by worker base threads only after that join; async-only
+          // effects remain pending until a worker explicitly waits for them.
           b.setListener(nullptr);
           b.setInsertionPointAfter(wsOp);
-          for (Region *region : partitionRegions) {
-            int sourceThread = region->getRegionNumber() + 1;
-            for (MemType memType : {MemType::SHARED_MEM, MemType::TENSOR_MEM})
-              funcBuilder.createCopyReadVisibilityCall(
-                  b, sourceThread, /*destMask=*/1, nullptr, memType, op,
-                  /*merge=*/true);
-          }
+          for (MemType memType : {MemType::SHARED_MEM, MemType::TENSOR_MEM})
+            funcBuilder.createPublishCTAVisibilityCall(
+                b, baseDestMask, /*destMask=*/1, memType, op);
           b.setInsertionPoint(wsOp);
           b.setListener(&listener);
         }

--- a/lib/Dialect/TritonInstrument/Transforms/ConcurrencySanitizer.cpp
+++ b/lib/Dialect/TritonInstrument/Transforms/ConcurrencySanitizer.cpp
@@ -858,14 +858,6 @@ private:
         Value barrier = info->alloc;
         Value pred = hooks.getIssuerCTAPred(b, op);
         funcBuilder.createInvalidateBarrierStateCall(b, barrier, pred, op);
-        for (MemType memType : {MemType::SHARED_MEM, MemType::TENSOR_MEM}) {
-          funcBuilder.createClearBarrierWriteTrackingCall(b, barrier, pred,
-                                                          memType, op);
-          funcBuilder.createClearBarrierReadTrackingCall(b, barrier, pred,
-                                                         memType, op);
-        }
-        funcBuilder.createClearBarrierProxyAccessTrackingCall(b, barrier, pred,
-                                                              op);
       }
       if (auto asyncCommitGroupOp = dyn_cast<ttg::AsyncCommitGroupOp>(op)) {
         if (!auxData.commits[CommitKind::AsyncCp].empty())
@@ -1117,9 +1109,7 @@ private:
                   candidateBase);
               candidatePred = tti::maybeAnd(b, candidatePred, matchesBase);
             }
-            bool singleOwner = candidate.ctaMask &&
-                               !(candidate.ctaMask & (candidate.ctaMask - 1));
-            if (!invalidatesBarriers || !singleOwner) {
+            if (!invalidatesBarriers) {
               verifyAvailable(candidatePred);
               continue;
             }
@@ -1127,11 +1117,8 @@ private:
               verifyWrite();
               invalidatedBarrier = true;
             }
-            BufferStateCandidates selected;
-            selected.cases.push_back(candidate);
             funcBuilder.createInvalidateBarrierStorageCall(
-                b, barrierOffset, barrierLength, candidatePred, op,
-                getMemEffectCTAs(b, defaultEffectCTAs, selected));
+                b, barrierOffset, barrierLength, candidatePred, op);
           }
         }
       }

--- a/lib/Dialect/TritonInstrument/Transforms/ConcurrencySanitizer.cpp
+++ b/lib/Dialect/TritonInstrument/Transforms/ConcurrencySanitizer.cpp
@@ -1066,10 +1066,10 @@ private:
         for (const auto &[barrier, barrierMask] : auxData.sharedBarrierMasks) {
           Value barrierOffset = tti::ExperimentalMemoryOffsetToI32Op::create(
               b, barrier.baseOffset, memType);
+          int64_t barrierLength = barrier.length;
           auto verifyAvailable = [&](Value candidatePred) {
             funcBuilder.createVerifyBarrierMemoryAvailableCall(
-                b, barrierOffset, barrier.length, candidatePred, op,
-                effectCTAs);
+                b, barrierOffset, barrierLength, candidatePred, op, effectCTAs);
           };
           if (candidates.unknown) {
             verifyAvailable(pred);

--- a/lib/Dialect/TritonInstrument/Transforms/ConcurrencySanitizer.cpp
+++ b/lib/Dialect/TritonInstrument/Transforms/ConcurrencySanitizer.cpp
@@ -162,9 +162,10 @@ Value createStateMaskConstant(ImplicitLocOpBuilder &b,
 
 FailureOr<Value> createBufferStateMask(ImplicitLocOpBuilder &b,
                                        AuxDataMap &auxData, MemType memType,
-                                       Value runtimeBase,
+                                       Value buffer, Value runtimeBase,
                                        const BufferStateCandidates &candidates,
-                                       Operation *op) {
+                                       Operation *op,
+                                       SmallVectorImpl<Value> &predicates) {
   int index = static_cast<int>(memType);
   const BufferStatePlan &plan = auxData.bufferStatePlans[index];
   if (plan.numLanes == 0 || auxData.writeVisibility[index].empty()) {
@@ -184,18 +185,43 @@ FailureOr<Value> createBufferStateMask(ImplicitLocOpBuilder &b,
   if (candidates.unknown)
     return createStateMaskConstant(b, maskType, plan.unknownMask);
 
-  SmallVector<Value> predicates;
   if (candidates.cases.size() > 1) {
     if (!runtimeBase) {
       op->emitError("dynamic buffer-state cases require a runtime base");
       return failure();
     }
     Value resolved = arith::ConstantIntOp::create(b, 0, 1);
+    auto &candidateMap = auxData.bufferCandidates[index];
     for (const BufferStateCandidate &candidate : candidates.cases) {
       Value base = tti::ExperimentalMemoryOffsetToI32Op::create(
           b, candidate.baseOffset, memType);
       Value predicate =
           arith::CmpIOp::create(b, arith::CmpIPredicate::eq, runtimeBase, base);
+      Value selectedValue = buffer;
+      while (auto select = selectedValue.getDefiningOp<arith::SelectOp>()) {
+        auto matchesArm = [&](Value arm) {
+          auto it = candidateMap.find(arm);
+          return it == candidateMap.end() || it->second.unknown ||
+                 llvm::any_of(
+                     it->second.cases,
+                     [&](const BufferStateCandidate &armCandidate) {
+                       return armCandidate.baseOffset == candidate.baseOffset &&
+                              armCandidate.ctaMask == candidate.ctaMask &&
+                              armCandidate.mask.anyCommon(candidate.mask);
+                     });
+        };
+        bool selectedOnTrue = matchesArm(select.getTrueValue());
+        bool selectedOnFalse = matchesArm(select.getFalseValue());
+        if (selectedOnTrue == selectedOnFalse)
+          break;
+        Value selected = select.getCondition();
+        if (!selectedOnTrue)
+          selected = arith::XOrIOp::create(
+              b, selected, arith::ConstantIntOp::create(b, 1, 1));
+        predicate = arith::AndIOp::create(b, predicate, selected);
+        selectedValue =
+            selectedOnTrue ? select.getTrueValue() : select.getFalseValue();
+      }
       predicates.push_back(predicate);
       resolved = arith::OrIOp::create(b, resolved, predicate);
     }
@@ -641,14 +667,7 @@ Value getMemEffectCTAs(ImplicitLocOpBuilder &b, Operation *op) {
 }
 
 Value getMemEffectCTAs(ImplicitLocOpBuilder &b, Value recipients,
-                       const BufferStateCandidates &candidates) {
-  if (candidates.unknown)
-    return allCTAsMask(b);
-
-  uint32_t ownerMask = 0;
-  for (const BufferStateCandidate &candidate : candidates.cases)
-    ownerMask |= candidate.ctaMask;
-
+                       uint32_t ownerMask) {
   if (ownerMask == 1)
     return recipients;
 
@@ -1016,14 +1035,15 @@ private:
     struct MaterializedEffect {
       Value bufferMask;
       Value effectCTAs;
-      Value runtimeBase;
-      const BufferStateCandidates *candidates = nullptr;
+      Value barrierCTAs;
       MemType memType;
     };
     SmallVector<MaterializedEffect> materializedEffects;
     materializedEffects.reserve(opInfo->operandEffects.size());
 
-    auto materializeBuffer = [&](Value buf) -> FailureOr<MaterializedEffect> {
+    auto materializeBuffer =
+        [&](Value buf, Value recipients,
+            bool selectBarrierStorage) -> FailureOr<MaterializedEffect> {
       MaterializedEffect materialized;
       auto bufType = cast<ttg::MemDescType>(buf.getType());
       materialized.memType = MemType::TENSOR_MEM;
@@ -1036,35 +1056,82 @@ private:
         op->emitError("missing buffer-region candidates for memdesc");
         return failure();
       }
-      materialized.candidates = &candidateIt->second;
-      if (!candidateIt->second.unknown && candidateIt->second.cases.size() > 1)
-        materialized.runtimeBase =
-            tti::ExperimentalMemDescToI32Op::create(b, buf);
-      FailureOr<Value> stateMask = createBufferStateMask(
-          b, auxData, materialized.memType, materialized.runtimeBase,
-          candidateIt->second, op);
+      const BufferStateCandidates &candidates = candidateIt->second;
+      Value runtimeBase;
+      if (!candidates.unknown && candidates.cases.size() > 1)
+        runtimeBase = tti::ExperimentalMemDescToI32Op::create(b, buf);
+      SmallVector<Value> predicates;
+      FailureOr<Value> stateMask =
+          createBufferStateMask(b, auxData, materialized.memType, buf,
+                                runtimeBase, candidates, op, predicates);
       if (failed(stateMask))
         return failure();
       materialized.bufferMask = *stateMask;
+
+      bool selectBarriers = selectBarrierStorage &&
+                            materialized.memType == MemType::SHARED_MEM &&
+                            !auxData.barrierBufferMasks.empty();
+      RankedTensorType barrierMaskType;
+      RankedTensorType barrierOwnersType;
+      if (selectBarriers) {
+        auto barrierStatesType =
+            cast<RankedTensorType>(auxData.barrierStates.at(op).type);
+        barrierMaskType =
+            tti::getSlicedTensorType(barrierStatesType, {1}, b.getI1Type());
+        barrierOwnersType =
+            cast<RankedTensorType>(barrierMaskType.clone(b.getI32Type()));
+      }
+      auto addBarrierOwners = [&](const llvm::SmallBitVector &bufferMask,
+                                  Value ownerCTAs) {
+        if (!selectBarriers)
+          return;
+        llvm::SmallBitVector overlaps(barrierMaskType.getNumElements());
+        for (auto [index, barrierMask] :
+             llvm::enumerate(auxData.barrierBufferMasks))
+          if (bufferMask.anyCommon(barrierMask))
+            overlaps.set(index);
+        if (overlaps.none())
+          return;
+        Value selected = createStateMaskConstant(b, barrierMaskType, overlaps);
+        Value owners = tt::SplatOp::create(b, barrierOwnersType, ownerCTAs);
+        Value zero =
+            tti::createConstIntTensor(b, b.getLoc(), 0, barrierOwnersType);
+        owners = arith::SelectOp::create(b, selected, owners, zero);
+        materialized.barrierCTAs =
+            materialized.barrierCTAs
+                ? arith::OrIOp::create(b, materialized.barrierCTAs, owners)
+                : owners;
+      };
+
+      if (candidates.unknown) {
+        materialized.effectCTAs = allCTAsMask(b);
+        addBarrierOwners(
+            auxData.bufferStatePlans[(int)materialized.memType].unknownMask,
+            materialized.effectCTAs);
+        return materialized;
+      }
+
+      for (auto [index, candidate] : llvm::enumerate(candidates.cases)) {
+        Value ownerCTAs = getMemEffectCTAs(b, recipients, candidate.ctaMask);
+        if (!predicates.empty())
+          ownerCTAs =
+              arith::SelectOp::create(b, predicates[index], ownerCTAs,
+                                      arith::ConstantIntOp::create(b, 0, 32));
+        materialized.effectCTAs =
+            materialized.effectCTAs
+                ? arith::OrIOp::create(b, materialized.effectCTAs, ownerCTAs)
+                : ownerCTAs;
+        addBarrierOwners(candidate.mask, ownerCTAs);
+      }
       return materialized;
     };
 
     for (const auto &effect : opInfo->operandEffects) {
-      FailureOr<MaterializedEffect> maybeMaterialized =
-          materializeBuffer(effect.buf);
-      if (failed(maybeMaterialized))
-        return failure();
-      MaterializedEffect materialized = *maybeMaterialized;
-      materialized.effectCTAs =
-          getMemEffectCTAs(b, defaultEffectCTAs, *materialized.candidates);
-      materializedEffects.push_back(materialized);
-
       Value buf = effect.buf;
-      Value bufferMask = materialized.bufferMask;
-      Value effectCTAs = materialized.effectCTAs;
-      MemType memType = materialized.memType;
+      bool isSharedMemory = isa<ttg::SharedMemorySpaceAttr>(
+          cast<ttg::MemDescType>(buf.getType()).getMemorySpace());
       bool invalidatesBarriers =
-          memType == MemType::SHARED_MEM && hooks.barrierWritesInvalidate() &&
+          isSharedMemory && hooks.barrierWritesInvalidate() &&
           effect.rw == RW::Write &&
           effect.sharedKind == ttg::SharedKind::Generic &&
           thread == baseThread &&
@@ -1073,6 +1140,16 @@ private:
             return access.value == buf &&
                    access.sharedKind == effect.sharedKind && access.isRead;
           });
+      FailureOr<MaterializedEffect> maybeMaterialized = materializeBuffer(
+          buf, defaultEffectCTAs, !isBarrierLifecycle || invalidatesBarriers);
+      if (failed(maybeMaterialized))
+        return failure();
+      MaterializedEffect materialized = *maybeMaterialized;
+      materializedEffects.push_back(materialized);
+
+      Value bufferMask = materialized.bufferMask;
+      Value effectCTAs = materialized.effectCTAs;
+      MemType memType = materialized.memType;
       bool invalidatedBarrier = false;
       auto verifyWrite = [&] {
         addWriteChecks(b, funcBuilder, op, bufferMask, pred, memType, thread,
@@ -1081,45 +1158,15 @@ private:
                       effect.operandName, effectCTAs, opInfo->commitKind);
       };
 
-      if (memType == MemType::SHARED_MEM &&
-          (!isBarrierLifecycle || invalidatesBarriers)) {
-        const BufferStateCandidates &candidates = *materialized.candidates;
-        for (const auto &[barrier, barrierMask] : auxData.sharedBarrierMasks) {
-          Value barrierOffset = tti::ExperimentalMemoryOffsetToI32Op::create(
-              b, barrier.baseOffset, memType);
-          int64_t barrierLength = barrier.length;
-          auto verifyAvailable = [&](Value candidatePred) {
-            funcBuilder.createVerifyBarrierMemoryAvailableCall(
-                b, barrierOffset, barrierLength, candidatePred, op, effectCTAs);
-          };
-          if (candidates.unknown) {
-            verifyAvailable(pred);
-            continue;
-          }
-          for (const BufferStateCandidate &candidate : candidates.cases) {
-            if (!candidate.mask.anyCommon(barrierMask))
-              continue;
-            Value candidatePred = pred;
-            if (candidates.cases.size() > 1) {
-              Value candidateBase =
-                  tti::ExperimentalMemoryOffsetToI32Op::create(
-                      b, candidate.baseOffset, memType);
-              Value matchesBase = arith::CmpIOp::create(
-                  b, arith::CmpIPredicate::eq, materialized.runtimeBase,
-                  candidateBase);
-              candidatePred = tti::maybeAnd(b, candidatePred, matchesBase);
-            }
-            if (!invalidatesBarriers) {
-              verifyAvailable(candidatePred);
-              continue;
-            }
-            if (!invalidatedBarrier) {
-              verifyWrite();
-              invalidatedBarrier = true;
-            }
-            funcBuilder.createInvalidateBarrierStorageCall(
-                b, barrierOffset, barrierLength, candidatePred, op);
-          }
+      if (materialized.barrierCTAs) {
+        if (invalidatesBarriers) {
+          verifyWrite();
+          invalidatedBarrier = true;
+          funcBuilder.createInvalidateBarrierStorageCall(
+              b, materialized.barrierCTAs, pred, op);
+        } else {
+          funcBuilder.createVerifyBarrierMemoryAvailableCall(
+              b, materialized.barrierCTAs, pred, op);
         }
       }
 
@@ -1179,7 +1226,9 @@ private:
               : getBarrierRecipientCTAs(b, op);
       Value completionBufferMask;
       if (thread != baseThread) {
-        FailureOr<MaterializedEffect> completion = materializeBuffer(barrier);
+        FailureOr<MaterializedEffect> completion =
+            materializeBuffer(barrier, recipientCTAs,
+                              /*selectBarrierStorage=*/false);
         if (failed(completion))
           return failure();
         completionBufferMask = completion->bufferMask;

--- a/lib/Dialect/TritonInstrument/Transforms/ConcurrencySanitizer.cpp
+++ b/lib/Dialect/TritonInstrument/Transforms/ConcurrencySanitizer.cpp
@@ -1020,30 +1020,6 @@ private:
     Value issuerCTAPred = hooks.getIssuerCTAPred(b, op);
     pred = tti::maybeAnd(b, pred, issuerCTAPred);
     Value defaultEffectCTAs = getMemEffectCTAs(b, op);
-    struct MaterializedBuffer {
-      Value mask;
-      Value runtimeBase;
-      const BufferStateCandidates *candidates;
-    };
-    auto materializeBuffer =
-        [&](Value buffer, MemType memType,
-            StringRef missingMessage) -> FailureOr<MaterializedBuffer> {
-      auto &candidateMap = auxData.bufferCandidates[(int)memType];
-      auto candidateIt = candidateMap.find(buffer);
-      if (candidateIt == candidateMap.end()) {
-        op->emitError(missingMessage);
-        return failure();
-      }
-      const BufferStateCandidates &candidates = candidateIt->second;
-      Value runtimeBase;
-      if (!candidates.unknown && candidates.cases.size() > 1)
-        runtimeBase = tti::ExperimentalMemDescToI32Op::create(b, buffer);
-      FailureOr<Value> mask = createBufferStateMask(
-          b, auxData, memType, runtimeBase, candidates, op);
-      if (failed(mask))
-        return failure();
-      return MaterializedBuffer{*mask, runtimeBase, &candidates};
-    };
     struct MaterializedEffect {
       Value bufferMask;
       Value effectCTAs;
@@ -1061,16 +1037,24 @@ private:
         materialized.memType = MemType::SHARED_MEM;
       auto &candidateMap =
           auxData.bufferCandidates[static_cast<int>(materialized.memType)];
-      if (isBarrierLifecycle && !candidateMap.contains(buf))
-        continue;
-      FailureOr<MaterializedBuffer> buffer =
-          materializeBuffer(buf, materialized.memType,
-                            "missing buffer-region candidates for memdesc");
-      if (failed(buffer))
+      auto candidateIt = candidateMap.find(buf);
+      if (candidateIt == candidateMap.end()) {
+        if (isBarrierLifecycle)
+          continue;
+        op->emitError("missing buffer-region candidates for memdesc");
         return failure();
-      materialized.bufferMask = buffer->mask;
+      }
+      Value runtimeBase;
+      if (!candidateIt->second.unknown && candidateIt->second.cases.size() > 1)
+        runtimeBase = tti::ExperimentalMemDescToI32Op::create(b, buf);
+      FailureOr<Value> stateMask =
+          createBufferStateMask(b, auxData, materialized.memType, runtimeBase,
+                                candidateIt->second, op);
+      if (failed(stateMask))
+        return failure();
+      materialized.bufferMask = *stateMask;
       materialized.effectCTAs =
-          getMemEffectCTAs(b, defaultEffectCTAs, *buffer->candidates);
+          getMemEffectCTAs(b, defaultEffectCTAs, candidateIt->second);
       materializedEffects.push_back(materialized);
 
       Value bufferMask = materialized.bufferMask;
@@ -1078,7 +1062,7 @@ private:
       MemType memType = materialized.memType;
 
       if (memType == MemType::SHARED_MEM && !isBarrierLifecycle) {
-        const BufferStateCandidates &candidates = *buffer->candidates;
+        const BufferStateCandidates &candidates = candidateIt->second;
         for (const auto &[barrier, barrierMask] : auxData.sharedBarrierMasks) {
           Value barrierOffset = tti::ExperimentalMemoryOffsetToI32Op::create(
               b, barrier.baseOffset, memType);
@@ -1099,9 +1083,8 @@ private:
               Value candidateBase =
                   tti::ExperimentalMemoryOffsetToI32Op::create(
                       b, candidate.baseOffset, memType);
-              Value matchesBase =
-                  arith::CmpIOp::create(b, arith::CmpIPredicate::eq,
-                                        buffer->runtimeBase, candidateBase);
+              Value matchesBase = arith::CmpIOp::create(
+                  b, arith::CmpIPredicate::eq, runtimeBase, candidateBase);
               candidatePred = tti::maybeAnd(b, candidatePred, matchesBase);
             }
             verifyAvailable(candidatePred);
@@ -1167,12 +1150,23 @@ private:
               : getBarrierRecipientCTAs(b, op);
       Value completionBufferMask;
       if (thread != baseThread) {
-        FailureOr<MaterializedBuffer> completionBuffer = materializeBuffer(
-            barrier, MemType::SHARED_MEM,
-            "missing buffer-region candidates for completion barrier");
-        if (failed(completionBuffer))
+        auto &candidateMap = auxData.bufferCandidates[(int)MemType::SHARED_MEM];
+        auto candidateIt = candidateMap.find(barrier);
+        if (candidateIt == candidateMap.end()) {
+          op->emitError("missing buffer-region candidates for completion "
+                        "barrier");
           return failure();
-        completionBufferMask = completionBuffer->mask;
+        }
+        Value runtimeBase;
+        if (!candidateIt->second.unknown &&
+            candidateIt->second.cases.size() > 1)
+          runtimeBase = tti::ExperimentalMemDescToI32Op::create(b, barrier);
+        FailureOr<Value> stateMask =
+            createBufferStateMask(b, auxData, MemType::SHARED_MEM, runtimeBase,
+                                  candidateIt->second, op);
+        if (failed(stateMask))
+          return failure();
+        completionBufferMask = *stateMask;
         // A deferred completion may still touch the barrier after the issuing
         // thread advances. Model that future touch as a reader owned by the
         // synthetic engine. Waiting publishes the reader through the existing
@@ -1212,9 +1206,9 @@ private:
           }
         }
         if (completionBufferMask)
-          funcBuilder.createTrackBarrierReadForBufferCall(
-              b, barrier, completionBufferMask, thread, combinedPred,
-              MemType::SHARED_MEM, op, recipientCTAs, recipientCTAs);
+          funcBuilder.createTrackVisibleAccessesCall(
+              b, barrier, thread, combinedPred, MemType::SHARED_MEM, op,
+              recipientCTAs, completionBufferMask);
       }
       if (barrierInfo.count > 0 || barrierInfo.txCount != 0) {
         funcBuilder.createVerifyAndUpdateBarrierStateCall(

--- a/lib/Dialect/TritonInstrument/Transforms/ConcurrencySanitizer.cpp
+++ b/lib/Dialect/TritonInstrument/Transforms/ConcurrencySanitizer.cpp
@@ -1068,25 +1068,23 @@ private:
       Value bufferMask = materialized.bufferMask;
       Value effectCTAs = materialized.effectCTAs;
       MemType memType = materialized.memType;
-      struct PendingBarrierInvalidation {
-        Value offset;
-        uint32_t length;
-        Value pred;
-        Value recipientCTAs;
-      };
-      SmallVector<PendingBarrierInvalidation> pendingInvalidations;
-      bool invalidatesBarriers = false;
-      if (memType == MemType::SHARED_MEM && hooks.barrierWritesInvalidate() &&
+      bool invalidatesBarriers =
+          memType == MemType::SHARED_MEM && hooks.barrierWritesInvalidate() &&
           effect.rw == RW::Write &&
           effect.sharedKind == ttg::SharedKind::Generic &&
           thread == baseThread &&
-          opInfo->trackingKind == MemEffectsOpInfo::TrackingKind::Barrier) {
-        invalidatesBarriers =
-            llvm::none_of(getMemoryAccesses(op), [&](const auto &access) {
-              return access.value == buf &&
-                     access.sharedKind == effect.sharedKind && access.isRead;
-            });
-      }
+          opInfo->trackingKind == MemEffectsOpInfo::TrackingKind::Barrier &&
+          llvm::none_of(getMemoryAccesses(op), [&](const auto &access) {
+            return access.value == buf &&
+                   access.sharedKind == effect.sharedKind && access.isRead;
+          });
+      bool invalidatedBarrier = false;
+      auto verifyWrite = [&] {
+        addWriteChecks(b, funcBuilder, op, bufferMask, pred, memType, thread,
+                       effect.operandName, effectCTAs, opInfo->commitKind);
+        addReadChecks(b, funcBuilder, op, bufferMask, pred, memType, thread,
+                      effect.operandName, effectCTAs, opInfo->commitKind);
+      };
 
       if (memType == MemType::SHARED_MEM &&
           (!isBarrierLifecycle || invalidatesBarriers)) {
@@ -1095,9 +1093,12 @@ private:
           Value barrierOffset = tti::ExperimentalMemoryOffsetToI32Op::create(
               b, barrier.baseOffset, memType);
           int64_t barrierLength = barrier.length;
-          if (candidates.unknown) {
+          auto verifyAvailable = [&](Value candidatePred) {
             funcBuilder.createVerifyBarrierMemoryAvailableCall(
-                b, barrierOffset, barrierLength, pred, op, effectCTAs);
+                b, barrierOffset, barrierLength, candidatePred, op, effectCTAs);
+          };
+          if (candidates.unknown) {
+            verifyAvailable(pred);
             continue;
           }
           for (const BufferStateCandidate &candidate : candidates.cases) {
@@ -1115,17 +1116,18 @@ private:
             bool singleOwner = candidate.ctaMask &&
                                !(candidate.ctaMask & (candidate.ctaMask - 1));
             if (!invalidatesBarriers || !singleOwner) {
-              funcBuilder.createVerifyBarrierMemoryAvailableCall(
-                  b, barrierOffset, barrierLength, candidatePred, op,
-                  effectCTAs);
+              verifyAvailable(candidatePred);
               continue;
+            }
+            if (!invalidatedBarrier) {
+              verifyWrite();
+              invalidatedBarrier = true;
             }
             BufferStateCandidates selected;
             selected.cases.push_back(candidate);
-            pendingInvalidations.push_back(
-                {barrierOffset, static_cast<uint32_t>(barrierLength),
-                 candidatePred,
-                 getMemEffectCTAs(b, defaultEffectCTAs, selected)});
+            funcBuilder.createInvalidateBarrierStorageCall(
+                b, barrierOffset, barrierLength, candidatePred, op,
+                getMemEffectCTAs(b, defaultEffectCTAs, selected));
           }
         }
       }
@@ -1161,15 +1163,8 @@ private:
       if (effect.rw == RW::Write) {
         // Op is writing to the buffer, we need to check if anything else
         // is reading or writing to the same buffer.
-        addWriteChecks(b, funcBuilder, op, bufferMask, pred, memType, thread,
-                       effect.operandName, effectCTAs, opInfo->commitKind);
-        addReadChecks(b, funcBuilder, op, bufferMask, pred, memType, thread,
-                      effect.operandName, effectCTAs, opInfo->commitKind);
-        for (const PendingBarrierInvalidation &barrier : pendingInvalidations) {
-          funcBuilder.createInvalidateBarrierStorageCall(
-              b, barrier.offset, barrier.length, barrier.pred, op,
-              barrier.recipientCTAs);
-        }
+        if (!invalidatedBarrier)
+          verifyWrite();
         if (opInfo->trackingKind == MemEffectsOpInfo::TrackingKind::Barrier) {
           funcBuilder.createPublishWriteVisibilityCall(
               b, bufferMask, getThreadPeersMask(thread, auxData.threadLayout),

--- a/lib/Dialect/TritonInstrument/Transforms/ConcurrencySanitizer.cpp
+++ b/lib/Dialect/TritonInstrument/Transforms/ConcurrencySanitizer.cpp
@@ -848,16 +848,9 @@ private:
       }
       if (auto info = hooks.getBarrierInitInfo(op)) {
         Value pred = hooks.getIssuerCTAPred(b, op);
-        if (!hooks.barrierWritesInvalidate()) {
+        if (!hooks.barrierWritesInvalidate())
           funcBuilder.createVerifyBarrierCanInitCall(b, info->alloc, pred, op,
                                                      currentCTAMask(b));
-        } else if (!auxData.bufferCandidates[(int)MemType::SHARED_MEM].contains(
-                       info->alloc)) {
-          // Isolated barriers have no buffer lane for instrumentMemEffects.
-          funcBuilder.createInvalidateBarrierStorageCall(
-              b, tti::ExperimentalMemDescToI32Op::create(b, info->alloc),
-              getMemDescLength(info->alloc), pred, op, currentCTAMask(b));
-        }
         funcBuilder.createInitBarrierStateCall(b, info->alloc, info->count,
                                                pred, op);
       }
@@ -1031,14 +1024,15 @@ private:
     struct MaterializedEffect {
       Value bufferMask;
       Value effectCTAs;
+      Value runtimeBase;
+      const BufferStateCandidates *candidates = nullptr;
       MemType memType;
     };
     SmallVector<MaterializedEffect> materializedEffects;
     materializedEffects.reserve(opInfo->operandEffects.size());
 
-    for (const auto &effect : opInfo->operandEffects) {
+    auto materializeBuffer = [&](Value buf) -> FailureOr<MaterializedEffect> {
       MaterializedEffect materialized;
-      Value buf = effect.buf;
       auto bufType = cast<ttg::MemDescType>(buf.getType());
       materialized.memType = MemType::TENSOR_MEM;
       if (isa<ttg::SharedMemorySpaceAttr>(bufType.getMemorySpace()))
@@ -1047,24 +1041,33 @@ private:
           auxData.bufferCandidates[static_cast<int>(materialized.memType)];
       auto candidateIt = candidateMap.find(buf);
       if (candidateIt == candidateMap.end()) {
-        if (isBarrierLifecycle)
-          continue;
         op->emitError("missing buffer-region candidates for memdesc");
         return failure();
       }
-      Value runtimeBase;
+      materialized.candidates = &candidateIt->second;
       if (!candidateIt->second.unknown && candidateIt->second.cases.size() > 1)
-        runtimeBase = tti::ExperimentalMemDescToI32Op::create(b, buf);
-      FailureOr<Value> stateMask =
-          createBufferStateMask(b, auxData, materialized.memType, runtimeBase,
-                                candidateIt->second, op);
+        materialized.runtimeBase =
+            tti::ExperimentalMemDescToI32Op::create(b, buf);
+      FailureOr<Value> stateMask = createBufferStateMask(
+          b, auxData, materialized.memType, materialized.runtimeBase,
+          candidateIt->second, op);
       if (failed(stateMask))
         return failure();
       materialized.bufferMask = *stateMask;
+      return materialized;
+    };
+
+    for (const auto &effect : opInfo->operandEffects) {
+      FailureOr<MaterializedEffect> maybeMaterialized =
+          materializeBuffer(effect.buf);
+      if (failed(maybeMaterialized))
+        return failure();
+      MaterializedEffect materialized = *maybeMaterialized;
       materialized.effectCTAs =
-          getMemEffectCTAs(b, defaultEffectCTAs, candidateIt->second);
+          getMemEffectCTAs(b, defaultEffectCTAs, *materialized.candidates);
       materializedEffects.push_back(materialized);
 
+      Value buf = effect.buf;
       Value bufferMask = materialized.bufferMask;
       Value effectCTAs = materialized.effectCTAs;
       MemType memType = materialized.memType;
@@ -1088,7 +1091,7 @@ private:
 
       if (memType == MemType::SHARED_MEM &&
           (!isBarrierLifecycle || invalidatesBarriers)) {
-        const BufferStateCandidates &candidates = candidateIt->second;
+        const BufferStateCandidates &candidates = *materialized.candidates;
         for (const auto &[barrier, barrierMask] : auxData.sharedBarrierMasks) {
           Value barrierOffset = tti::ExperimentalMemoryOffsetToI32Op::create(
               b, barrier.baseOffset, memType);
@@ -1110,7 +1113,8 @@ private:
                   tti::ExperimentalMemoryOffsetToI32Op::create(
                       b, candidate.baseOffset, memType);
               Value matchesBase = arith::CmpIOp::create(
-                  b, arith::CmpIPredicate::eq, runtimeBase, candidateBase);
+                  b, arith::CmpIPredicate::eq, materialized.runtimeBase,
+                  candidateBase);
               candidatePred = tti::maybeAnd(b, candidatePred, matchesBase);
             }
             bool singleOwner = candidate.ctaMask &&
@@ -1188,23 +1192,10 @@ private:
               : getBarrierRecipientCTAs(b, op);
       Value completionBufferMask;
       if (thread != baseThread) {
-        auto &candidateMap = auxData.bufferCandidates[(int)MemType::SHARED_MEM];
-        auto candidateIt = candidateMap.find(barrier);
-        if (candidateIt == candidateMap.end()) {
-          op->emitError("missing buffer-region candidates for completion "
-                        "barrier");
+        FailureOr<MaterializedEffect> completion = materializeBuffer(barrier);
+        if (failed(completion))
           return failure();
-        }
-        Value runtimeBase;
-        if (!candidateIt->second.unknown &&
-            candidateIt->second.cases.size() > 1)
-          runtimeBase = tti::ExperimentalMemDescToI32Op::create(b, barrier);
-        FailureOr<Value> stateMask =
-            createBufferStateMask(b, auxData, MemType::SHARED_MEM, runtimeBase,
-                                  candidateIt->second, op);
-        if (failed(stateMask))
-          return failure();
-        completionBufferMask = *stateMask;
+        completionBufferMask = completion->bufferMask;
         // A deferred completion may still touch the barrier after the issuing
         // thread advances. Model that future touch as a reader owned by the
         // synthetic engine. Waiting publishes the reader through the existing

--- a/python/test/gluon/test_consan.py
+++ b/python/test/gluon/test_consan.py
@@ -1826,7 +1826,10 @@ def test_tcgen5_mma_multibar(BUF_IDX, BAR_IDX, device, run_wrapper, monkeypatch,
         store_shape: ttgl.constexpr = [block_m, block_n]
         acc.index(BUF_IDX).store(ttgl.full(store_shape, 42, ttgl.float32, acc_blocked_layout))
 
-        for i in range(4):
+        # Waiting a completion barrier publishes the tensor-core frontier that
+        # existed when that barrier was attached. Later barriers may still
+        # receive deferred completions and cannot be invalidated yet.
+        for i in range(BAR_IDX + 1):
             mbarrier.invalidate(bar.index(i))
 
     block_m = mma_block_m(num_ctas)
@@ -3536,6 +3539,138 @@ def test_barrier_underflow(device, run_wrapper, monkeypatch, num_ctas):
         ], [4], [32])
 
     kernel[(1, )](num_warps=4, num_ctas=num_ctas)
+
+
+@pytest.mark.skipif(not is_cuda() or torch.cuda.get_device_capability()[0] < 9, reason="Requires hopper")
+@pytest.mark.parametrize("ASYNC", [False, True], ids=["generic", "async-copy"])
+@pytest.mark.parametrize("INVALIDATE", [False, True], ids=["live", "invalidated"])
+def test_payload_reuse_requires_barrier_invalidation(ASYNC, INVALIDATE, device, run_wrapper, monkeypatch):
+    if run_wrapper and not INVALIDATE:
+        result = run_in_process(test_payload_reuse_requires_barrier_invalidation,
+                                (ASYNC, INVALIDATE, device, False, monkeypatch))
+        assert_expected_cuda_failure(result.exc)
+        assert "Shared memory reused before barrier invalidation" in result.driver_stderr_output
+        return
+
+    monkeypatch.setenv("TRITON_INSTRUMENTATION_MODE", "consan")
+    monkeypatch.setenv("CUDA_LAUNCH_BLOCKING", "1")
+    knobs.refresh_knobs()
+
+    @gluon.jit
+    def kernel(source, output, ASYNC: ttgl.constexpr, INVALIDATE: ttgl.constexpr):
+        layout: ttgl.constexpr = ttgl.BlockedLayout([1], [32], [4], [0])
+        smem_layout: ttgl.constexpr = ttgl.SwizzledSharedLayout(1, 1, 1, [0])
+        barrier = mbarrier.allocate_mbarrier()
+        mbarrier.init(barrier, count=1)
+        if INVALIDATE:
+            mbarrier.invalidate(barrier)
+
+        offsets = ttgl.arange(0, XBLOCK, layout=layout)
+        if ASYNC:
+            smem = ttgl.allocate_shared_memory(ttgl.int32, [XBLOCK], smem_layout)
+            ampere.async_copy.async_load(smem, source + offsets)
+            ampere.async_copy.commit_group()
+            ampere.async_copy.wait_group(0)
+        else:
+            values = ttgl.full([XBLOCK], 7, ttgl.int32, layout)
+            smem = ttgl.allocate_shared_memory(ttgl.int32, [XBLOCK], smem_layout, values)
+        ttgl.store(output + offsets, smem.load(layout))
+
+    source = torch.arange(XBLOCK.value, device=device, dtype=torch.int32)
+    output = torch.empty_like(source)
+    compiled = kernel.warmup(source, output, ASYNC=ASYNC, INVALIDATE=INVALIDATE, grid=(1, ), num_warps=4, num_ctas=1)
+    assert compiled.metadata.shared == XBLOCK.value * source.element_size()
+    kernel[(1, )](source, output, ASYNC=ASYNC, INVALIDATE=INVALIDATE, num_warps=4, num_ctas=1)
+    expected = source if ASYNC else torch.full_like(source, 7)
+    torch.testing.assert_close(output, expected)
+
+
+@pytest.mark.skipif(not is_cuda() or torch.cuda.get_device_capability()[0] < 9, reason="Requires hopper")
+@pytest.mark.parametrize("WAIT", [False, True], ids=["outstanding-copy", "waited-copy"])
+def test_barrier_init_is_generic_write(WAIT, device, run_wrapper, monkeypatch):
+    if run_wrapper and not WAIT:
+        result = run_in_process(test_barrier_init_is_generic_write, (WAIT, device, False, monkeypatch))
+        assert_expected_cuda_failure(result.exc)
+        assert "Pending access type: async_copy_global_to_shared" in result.driver_stderr_output
+        return
+
+    monkeypatch.setenv("TRITON_INSTRUMENTATION_MODE", "consan")
+    monkeypatch.setenv("CUDA_LAUNCH_BLOCKING", "1")
+    knobs.refresh_knobs()
+
+    @gluon.jit
+    def kernel(source, WAIT: ttgl.constexpr):
+        layout: ttgl.constexpr = ttgl.BlockedLayout([1], [32], [4], [0])
+        smem_layout: ttgl.constexpr = ttgl.SwizzledSharedLayout(1, 1, 1, [0])
+        offsets = ttgl.arange(0, XBLOCK, layout=layout)
+        smem = ttgl.allocate_shared_memory(ttgl.int32, [XBLOCK], smem_layout)
+        ampere.async_copy.async_load(smem, source + offsets)
+        ampere.async_copy.commit_group()
+        if WAIT:
+            ampere.async_copy.wait_group(0)
+        barrier = mbarrier.allocate_mbarrier()
+        mbarrier.init(barrier, count=1)
+        if not WAIT:
+            ampere.async_copy.wait_group(0)
+        mbarrier.invalidate(barrier)
+
+    source = torch.arange(XBLOCK.value, device=device, dtype=torch.int32)
+    compiled = kernel.warmup(source, WAIT=WAIT, grid=(1, ), num_warps=4, num_ctas=1)
+    assert compiled.metadata.shared == XBLOCK.value * source.element_size()
+    kernel[(1, )](source, WAIT=WAIT, num_warps=4, num_ctas=1)
+
+
+@pytest.mark.skipif(not is_cuda() or torch.cuda.get_device_capability()[0] < 9, reason="Requires hopper")
+@pytest.mark.parametrize("INITIALIZE", [False, True], ids=["uninitialized", "initialized"])
+def test_async_copy_mbarrier_arrive_requires_init(INITIALIZE, device, run_wrapper, monkeypatch):
+    if run_wrapper and not INITIALIZE:
+        result = run_in_process(test_async_copy_mbarrier_arrive_requires_init, (INITIALIZE, device, False, monkeypatch))
+        assert_expected_cuda_failure(result.exc)
+        assert "Barrier used before initialization or after invalidation" in result.driver_stderr_output
+        return
+
+    monkeypatch.setenv("TRITON_INSTRUMENTATION_MODE", "consan")
+    monkeypatch.setenv("CUDA_LAUNCH_BLOCKING", "1")
+    knobs.refresh_knobs()
+
+    @gluon.jit
+    def kernel(INITIALIZE: ttgl.constexpr):
+        barrier = mbarrier.allocate_mbarrier()
+        if INITIALIZE:
+            mbarrier.init(barrier, count=1)
+        ampere.async_copy.mbarrier_arrive(barrier, increment_count=False)
+
+    kernel[(1, )](INITIALIZE=INITIALIZE, num_warps=4, num_ctas=1)
+
+
+@pytest.mark.skipif(not is_cuda() or torch.cuda.get_device_capability()[0] < 9, reason="Requires hopper")
+@pytest.mark.parametrize("WAIT", [False, True], ids=["outstanding-completion", "waited-completion"])
+def test_barrier_invalidate_requires_completion_wait(WAIT, device, run_wrapper, monkeypatch):
+    if run_wrapper and not WAIT:
+        result = run_in_process(test_barrier_invalidate_requires_completion_wait, (WAIT, device, False, monkeypatch))
+        assert_expected_cuda_failure(result.exc)
+        assert "Buffer being accessed has outstanding reads" in result.driver_stderr_output
+        return
+
+    monkeypatch.setenv("TRITON_INSTRUMENTATION_MODE", "consan")
+    monkeypatch.setenv("CUDA_LAUNCH_BLOCKING", "1")
+    knobs.refresh_knobs()
+
+    @gluon.jit
+    def kernel(input_desc, WAIT: ttgl.constexpr):
+        smem = ttgl.allocate_shared_memory(ttgl.float16, [XBLOCK, XBLOCK], input_desc.layout)
+        barrier = mbarrier.allocate_mbarrier()
+        mbarrier.init(barrier, count=1)
+        mbarrier.expect(barrier, input_desc.nbytes_per_cta)
+        tma.async_load(input_desc, [0, 0], barrier, smem)
+        if WAIT:
+            mbarrier.wait(barrier, 0, deps=[smem])
+        mbarrier.invalidate(barrier)
+
+    source = torch.randn((XBLOCK.value, XBLOCK.value), device=device, dtype=torch.float16)
+    smem_layout = ttgl.NVMMASharedLayout(128, 16, rank=2, cga_layout=[])
+    input_desc = gluon.nvidia.hopper.TensorDescriptor.from_tensor(source, [XBLOCK.value, XBLOCK.value], smem_layout)
+    kernel[(1, )](input_desc, WAIT=WAIT, num_warps=4, num_ctas=1)
 
 
 @pytest.mark.skipif(not is_cuda() or torch.cuda.get_device_capability()[0] < 9, reason="Requires hopper or newer")

--- a/python/test/gluon/test_consan.py
+++ b/python/test/gluon/test_consan.py
@@ -1433,8 +1433,10 @@ def test_tcgen5_mma(FAILURE, MEM_ACCESS_KIND, TWO_CTAS, device, run_wrapper, mon
                         (TWO_CTAS
                          and "Barrier used before initialization or after invalidation" in result.driver_stderr_output))
             elif MEM_ACCESS_KIND in ["tmem_load", "tmem_store"]:
-                # tmem is being written by the tcgen05_mma
-                assert (("Buffer being accessed has outstanding writes" in result.driver_stderr_output) or
+                # The tcgen05_mma is writing tmem and its pending completion is
+                # reading the barrier storage. Either conflict may report first.
+                assert (("Buffer being accessed has outstanding writes" in result.driver_stderr_output)
+                        or ("Buffer being accessed has outstanding reads" in result.driver_stderr_output) or
                         (TWO_CTAS
                          and "Barrier used before initialization or after invalidation" in result.driver_stderr_output))
         else:
@@ -1675,6 +1677,88 @@ def test_reader_visibility_across_partitions(TC_COMMIT, device, run_wrapper, mon
         mbarrier.invalidate(barriers.index(1))
 
     kernel[(1, )](TC_COMMIT=TC_COMMIT, num_warps=4)
+
+
+@pytest.mark.skipif(not is_cuda() or torch.cuda.get_device_capability()[0] < 9, reason="Requires hopper or newer")
+def test_ws_join_write_visibility(device, monkeypatch, num_ctas):
+    monkeypatch.setenv("TRITON_INSTRUMENTATION_MODE", "consan")
+    monkeypatch.setenv("CUDA_LAUNCH_BLOCKING", "1")
+    knobs.refresh_knobs()
+
+    @gluon.jit
+    def default_partition():
+        pass
+
+    @gluon.jit
+    def writer(smem, layout: ttgl.constexpr):
+        smem.store(ttgl.full([XBLOCK * ttgl.num_ctas()], 7, ttgl.int32, layout))
+
+    @gluon.jit
+    def kernel(output):
+        block_x: ttgl.constexpr = XBLOCK * ttgl.num_ctas()
+        cga_layout: ttgl.constexpr = default_cga_layout(ttgl.num_ctas(), 1)
+        shared_layout: ttgl.constexpr = ttgl.SwizzledSharedLayout(1, 1, 1, [0], cga_layout)
+        layout: ttgl.constexpr = ttgl.BlockedLayout([1], [32], [4], [0], cga_layout=cga_layout)
+        smem = ttgl.allocate_shared_memory(ttgl.int32, [block_x], shared_layout)
+
+        ttgl.warp_specialize([(default_partition, ()), (writer, (smem, layout))], [4], [32])
+
+        offsets = ttgl.arange(0, block_x, layout)
+        ttgl.store(output + offsets, smem.load(layout))
+
+    output = torch.empty((XBLOCK.value * num_ctas, ), device=device, dtype=torch.int32)
+    kernel[(1, )](output, num_warps=4, num_ctas=num_ctas)
+    torch.testing.assert_close(output, torch.full_like(output, 7))
+
+
+@pytest.mark.skipif(not is_cuda() or torch.cuda.get_device_capability()[0] < 9, reason="Requires hopper or newer")
+@pytest.mark.parametrize("WAIT", [False, True], ids=["pending", "completed"])
+def test_ws_join_async_write_visibility(WAIT, device, run_wrapper, monkeypatch):
+    if not WAIT and run_wrapper:
+        result = run_in_process(test_ws_join_async_write_visibility, (WAIT, device, False, monkeypatch))
+        assert_expected_cuda_failure(result.exc)
+        assert "Buffer being accessed has outstanding writes" in result.driver_stderr_output
+        return
+
+    monkeypatch.setenv("TRITON_INSTRUMENTATION_MODE", "consan")
+    monkeypatch.setenv("CUDA_LAUNCH_BLOCKING", "1")
+    knobs.refresh_knobs()
+
+    @gluon.jit
+    def default_partition():
+        pass
+
+    @gluon.jit
+    def producer(input_desc, smem, bar, WAIT: ttgl.constexpr):
+        mbarrier.expect(bar, input_desc.nbytes_per_cta)
+        tma.async_load(input_desc, [0, 0], bar, smem)
+        if WAIT:
+            mbarrier.wait(bar, phase=0, deps=[smem])
+
+    @gluon.jit
+    def kernel(input_desc, output, WAIT: ttgl.constexpr):
+        block_m: ttgl.constexpr = XBLOCK * ttgl.num_ctas()
+        cga_layout: ttgl.constexpr = default_cga_layout(ttgl.num_ctas(), 2)
+        layout: ttgl.constexpr = ttgl.BlockedLayout([1, 1], [32, 1], [4, 1], [0, 1], cga_layout=cga_layout)
+        smem = ttgl.allocate_shared_memory(ttgl.float16, [block_m, XBLOCK], input_desc.layout)
+        bar = mbarrier.allocate_mbarrier()
+        mbarrier.init(bar, count=1)
+
+        ttgl.warp_specialize([(default_partition, ()), (producer, (input_desc, smem, bar, WAIT))], [4], [32])
+
+        offsets_m = ttgl.arange(0, block_m, ttgl.SliceLayout(1, layout))[:, None]
+        offsets_n = ttgl.arange(0, XBLOCK, ttgl.SliceLayout(0, layout))[None, :]
+        ttgl.store(output + offsets_m * XBLOCK + offsets_n, smem.load(layout))
+        if WAIT:
+            mbarrier.invalidate(bar)
+
+    block_m = XBLOCK.value
+    input = torch.randn((block_m, XBLOCK.value), device=device, dtype=torch.float16)
+    output = torch.empty_like(input)
+    shared_layout = ttgl.NVMMASharedLayout(128, 16, rank=2)
+    input_desc = gluon.nvidia.hopper.TensorDescriptor.from_tensor(input, [block_m, XBLOCK.value], shared_layout)
+    kernel[(1, )](input_desc, output, WAIT=WAIT, num_warps=4, num_ctas=1)
+    torch.testing.assert_close(output, input)
 
 
 @pytest.mark.skipif(not is_cuda() or torch.cuda.get_device_capability()[0] != 9, reason="Requires hopper")

--- a/python/test/gluon/test_consan.py
+++ b/python/test/gluon/test_consan.py
@@ -1712,6 +1712,91 @@ def test_ws_join_write_visibility(device, monkeypatch, num_ctas):
 
 
 @pytest.mark.skipif(not is_cuda() or torch.cuda.get_device_capability()[0] < 9, reason="Requires hopper or newer")
+@pytest.mark.parametrize("FENCE_LOCATION", ["producer", "consumer"])
+def test_ws_join_publishes_to_async_peer(FENCE_LOCATION, device, monkeypatch):
+    monkeypatch.setenv("TRITON_INSTRUMENTATION_MODE", "consan")
+    monkeypatch.setenv("CUDA_LAUNCH_BLOCKING", "1")
+    knobs.refresh_knobs()
+
+    @gluon.jit
+    def default_partition():
+        pass
+
+    @gluon.jit
+    def producer(smem, layout: ttgl.constexpr, FENCE_LOCATION: ttgl.constexpr):
+        smem.store(ttgl.full([XBLOCK, XBLOCK], 42, ttgl.float16, layout))
+        if FENCE_LOCATION == "producer":
+            hopper.fence_async_shared()
+
+    @gluon.jit
+    def kernel(output_desc, FENCE_LOCATION: ttgl.constexpr):
+        layout: ttgl.constexpr = ttgl.BlockedLayout([1, XBLOCK], [32, 1], [4, 1], [0, 1])
+        shared_layout: ttgl.constexpr = ttgl.NVMMASharedLayout(128, 16, rank=2)
+        smem = ttgl.allocate_shared_memory(ttgl.float16, [XBLOCK, XBLOCK], shared_layout)
+        ttgl.warp_specialize([
+            (default_partition, ()),
+            (producer, (smem, layout, FENCE_LOCATION)),
+        ], [4], [32])
+        if FENCE_LOCATION == "consumer":
+            hopper.fence_async_shared()
+        tma.async_store(output_desc, [0, 0], smem)
+        tma.store_wait(0)
+
+    output = torch.empty((XBLOCK.value, XBLOCK.value), device=device, dtype=torch.float16)
+    shared_layout = ttgl.NVMMASharedLayout(128, 16, rank=2)
+    output_desc = gluon.nvidia.hopper.TensorDescriptor.from_tensor(output, [XBLOCK.value, XBLOCK.value], shared_layout)
+    kernel[(1, )](output_desc, FENCE_LOCATION=FENCE_LOCATION, num_warps=4)
+    torch.testing.assert_close(output, torch.full_like(output, 42))
+
+
+@pytest.mark.skipif(not is_cuda() or torch.cuda.get_device_capability()[0] < 9, reason="Requires hopper or newer")
+@pytest.mark.parametrize("FENCE", [False, True], ids=["missing", "present"])
+def test_ws_join_publishes_proxy_generation(FENCE, device, run_wrapper, monkeypatch):
+    if not FENCE and run_wrapper:
+        result = run_in_process(test_ws_join_publishes_proxy_generation, (FENCE, device, False, monkeypatch))
+        assert_expected_cuda_failure(result.exc)
+        assert "Async shared-memory access is missing fence_async_shared" in result.driver_stderr_output
+        return
+
+    monkeypatch.setenv("TRITON_INSTRUMENTATION_MODE", "consan")
+    monkeypatch.setenv("CUDA_LAUNCH_BLOCKING", "1")
+    knobs.refresh_knobs()
+
+    @gluon.jit
+    def default_partition():
+        pass
+
+    @gluon.jit
+    def reader(smem, sink, layout: ttgl.constexpr):
+        offsets_m = ttgl.arange(0, XBLOCK, ttgl.SliceLayout(1, layout))[:, None]
+        offsets_n = ttgl.arange(0, XBLOCK, ttgl.SliceLayout(0, layout))[None, :]
+        ttgl.store(sink + offsets_m * XBLOCK + offsets_n, smem.load(layout))
+
+    @gluon.jit
+    def kernel(output_desc, sink, FENCE: ttgl.constexpr):
+        layout: ttgl.constexpr = ttgl.BlockedLayout([1, XBLOCK], [32, 1], [4, 1], [0, 1])
+        shared_layout: ttgl.constexpr = ttgl.NVMMASharedLayout(128, 16, rank=2)
+        initial = ttgl.full([XBLOCK, XBLOCK], 42, ttgl.float16, layout)
+        smem = ttgl.allocate_shared_memory(ttgl.float16, [XBLOCK, XBLOCK], shared_layout, initial)
+        hopper.fence_async_shared()
+        ttgl.warp_specialize([
+            (default_partition, ()),
+            (reader, (smem, sink, layout)),
+        ], [4], [32])
+        if FENCE:
+            hopper.fence_async_shared()
+        tma.async_store(output_desc, [0, 0], smem)
+        tma.store_wait(0)
+
+    output = torch.empty((XBLOCK.value, XBLOCK.value), device=device, dtype=torch.float16)
+    sink = torch.empty_like(output)
+    shared_layout = ttgl.NVMMASharedLayout(128, 16, rank=2)
+    output_desc = gluon.nvidia.hopper.TensorDescriptor.from_tensor(output, [XBLOCK.value, XBLOCK.value], shared_layout)
+    kernel[(1, )](output_desc, sink, FENCE=FENCE, num_warps=4)
+    torch.testing.assert_close(output, torch.full_like(output, 42))
+
+
+@pytest.mark.skipif(not is_cuda() or torch.cuda.get_device_capability()[0] < 9, reason="Requires hopper or newer")
 @pytest.mark.parametrize("WAIT", [False, True], ids=["pending", "completed"])
 def test_ws_join_async_write_visibility(WAIT, device, run_wrapper, monkeypatch):
     if not WAIT and run_wrapper:

--- a/test/Analysis/test-buffer-region.mlir
+++ b/test/Analysis/test-buffer-region.mlir
@@ -352,6 +352,7 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 1 : i32, ttg.shar
     tt.return
   }
 
+  // expected-remark @below {{All Shared Regions: [8192, 8]}}
   // expected-remark @below {{All Barrier Regions: [8192, 8]}}
   tt.func private @print_all_regions() attributes {test.print_all_used_regions} {
     tt.return
@@ -372,6 +373,7 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 1 : i32, ttg.shar
     tt.return
   }
 
+  // expected-remark @below {{All Shared Regions: [8192, 8], [8200, 8]}}
   // expected-remark @below {{All Barrier Regions: [8192, 8], [8200, 8]}}
   tt.func private @print_all_regions() attributes {test.print_all_used_regions} {
     tt.return
@@ -391,6 +393,7 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 1 : i32, ttg.shar
     tt.return
   }
 
+  // expected-remark @below {{All Shared Regions: [8192, 8]}}
   // expected-remark @below {{All Barrier Regions: [8192, 8]}}
   tt.func private @print_all_regions() attributes {test.print_all_used_regions} {
     tt.return

--- a/test/TritonGPU/amd/amd-consan.mlir
+++ b/test/TritonGPU/amd/amd-consan.mlir
@@ -1036,6 +1036,7 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 1 : i32, ttg.shar
     // CHECK: tti.experimental_assert_uniform {{.*}}, "Barrier invalidated while a thread is waiting"
     // CHECK: tt.call @__triton_consan_clear_barrier_write_tracking
     // CHECK: tt.call @__triton_consan_clear_barrier_read_tracking
+    // CHECK-NOT: tt.call @__triton_consan_invalidate_barrier_storage
     // CHECK: tt.call @__triton_consan_publish_write_visibility
     // CHECK: ttg.local_store
     ttg.local_store %values, %payload : tensor<16xi32, #lifetime_blocked>

--- a/test/TritonGPU/amd/amd-consan.mlir
+++ b/test/TritonGPU/amd/amd-consan.mlir
@@ -1002,6 +1002,8 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 1 : i32, ttg.shar
         : () -> !ttg.memdesc<16xi32, #lifetime_shared, #lifetime_smem, mutable>
     %barrier = ttg.local_alloc {allocation.offset = 0 : i32}
         : () -> !ttg.memdesc<1xi64, #lifetime_shared, #lifetime_smem, mutable>
+    %uninitialized = ttg.local_alloc {allocation.offset = 8 : i32}
+        : () -> !ttg.memdesc<1xi64, #lifetime_shared, #lifetime_smem, mutable>
     amdg.init_barrier %barrier, 1
         : !ttg.memdesc<1xi64, #lifetime_shared, #lifetime_smem, mutable>
     // CHECK: tt.call @__triton_consan_verify_barrier_memory_available
@@ -1009,24 +1011,10 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 1 : i32, ttg.shar
     %value = ttg.local_load %payload
         : !ttg.memdesc<16xi32, #lifetime_shared, #lifetime_smem, mutable>
         -> tensor<16xi32>
-    tt.return
-  }
-}
-
-// -----
-
-#lifetime_barrier = #ttg.swizzled_shared<{vec = 1, perPhase = 1, maxPhase = 1, order = [0]}>
-#lifetime_smem = #ttg.shared_memory
-
-module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 1 : i32, ttg.shared = 8 : i32, ttg.target = "hip:gfx1250", "ttg.threads-per-warp" = 32 : i32, "ttg.total-num-warps" = 1 : i32} {
-  // CHECK-LABEL: @amd_copy_completion_requires_initialized_barrier
-  tt.func public @amd_copy_completion_requires_initialized_barrier() {
-    %barrier = ttg.local_alloc {allocation.offset = 0 : i32}
-        : () -> !ttg.memdesc<1xi64, #lifetime_barrier, #lifetime_smem, mutable>
     // CHECK: tt.call @__triton_consan_verify_barrier_initialized
     // CHECK: amdg.async_copy_mbarrier_arrive
-    amdg.async_copy_mbarrier_arrive %barrier
-        : !ttg.memdesc<1xi64, #lifetime_barrier, #lifetime_smem, mutable>
+    amdg.async_copy_mbarrier_arrive %uninitialized
+        : !ttg.memdesc<1xi64, #lifetime_shared, #lifetime_smem, mutable>
     tt.return
   }
 }

--- a/test/TritonGPU/amd/amd-consan.mlir
+++ b/test/TritonGPU/amd/amd-consan.mlir
@@ -336,7 +336,11 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 1 : i32, ttg.shar
     // CHECK: tt.call @__triton_consan_invalidate_barrier_storage
     amdg.init_barrier %bar, 1 : !ttg.memdesc<1xi64, #shared1, #smem, mutable>
     // CHECK: tt.call @__triton_consan_init_barrier_state
+    // CHECK: ttg.local_load
     ttg.local_load %buf : !ttg.memdesc<32x32xf32, #shared, #smem, mutable> -> tensor<32x32xf32, #blocked>
+    // CHECK: tt.call @__triton_consan_invalidate_barrier_storage
+    // CHECK: tt.call @__triton_consan_init_barrier_state
+    amdg.init_barrier %bar, 2 : !ttg.memdesc<1xi64, #shared1, #smem, mutable>
     tt.return
   }
 }
@@ -1000,7 +1004,8 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 1 : i32, ttg.shar
   // CHECK-LABEL: @amd_payload_rejects_live_barrier_storage
   tt.func public @amd_payload_rejects_live_barrier_storage(
       %indices: tensor<16xi32, #lifetime_blocked>,
-      %values: tensor<16xi32, #lifetime_blocked>) {
+      %values: tensor<16xi32, #lifetime_blocked>,
+      %partial: tensor<1xi32, #lifetime_blocked>) {
     %payload = ttg.local_alloc {allocation.offset = 0 : i32}
         : () -> !ttg.memdesc<16xi32, #lifetime_shared, #lifetime_smem, mutable>
     %barrier = ttg.local_alloc {allocation.offset = 0 : i32}
@@ -1023,30 +1028,6 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 1 : i32, ttg.shar
     // CHECK: tt.call @__triton_consan_verify_barrier_initialized
     // CHECK: amdg.async_copy_mbarrier_arrive
     amdg.async_copy_mbarrier_arrive %uninitialized
-        : !ttg.memdesc<1xi64, #lifetime_shared, #lifetime_smem, mutable>
-    tt.return
-  }
-}
-
-// -----
-
-#lifetime_shared = #ttg.swizzled_shared<{vec = 1, perPhase = 1, maxPhase = 1, order = [0]}>
-#lifetime_smem = #ttg.shared_memory
-#lifetime_blocked = #ttg.blocked<{sizePerThread = [1], threadsPerWarp = [32], warpsPerCTA = [1], order = [0]}>
-
-module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 1 : i32, ttg.shared = 64 : i32, ttg.target = "hip:gfx1250", "ttg.threads-per-warp" = 32 : i32, "ttg.total-num-warps" = 1 : i32} {
-  // CHECK-LABEL: @amd_store_invalidates_barrier_storage
-  tt.func public @amd_store_invalidates_barrier_storage(
-      %values: tensor<16xi32, #lifetime_blocked>,
-      %partial: tensor<1xi32, #lifetime_blocked>) {
-    %payload = ttg.local_alloc {allocation.offset = 0 : i32}
-        : () -> !ttg.memdesc<16xi32, #lifetime_shared, #lifetime_smem, mutable>
-    %barrier = ttg.local_alloc {allocation.offset = 0 : i32}
-        : () -> !ttg.memdesc<1xi64, #lifetime_shared, #lifetime_smem, mutable>
-    // CHECK: tt.call @__triton_consan_invalidate_barrier_storage
-    // CHECK-NOT: tt.call @__triton_consan_verify_barrier_can_init
-    // CHECK: tt.call @__triton_consan_init_barrier_state
-    amdg.init_barrier %barrier, 1
         : !ttg.memdesc<1xi64, #lifetime_shared, #lifetime_smem, mutable>
     // CHECK: tt.call @__triton_consan_verify_write_visibility
     // CHECK: tt.call @__triton_consan_verify_read_visibility
@@ -1072,28 +1053,6 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 1 : i32, ttg.shar
     // CHECK: tt.call @__triton_consan_verify_barrier_initialized
     // CHECK: amdg.async_copy_mbarrier_arrive
     amdg.async_copy_mbarrier_arrive %barrier
-        : !ttg.memdesc<1xi64, #lifetime_shared, #lifetime_smem, mutable>
-    tt.return
-  }
-}
-
-// -----
-
-#lifetime_shared = #ttg.swizzled_shared<{vec = 1, perPhase = 1, maxPhase = 1, order = [0]}>
-#lifetime_smem = #ttg.shared_memory
-
-module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 1 : i32, ttg.shared = 64 : i32, ttg.target = "hip:gfx1250", "ttg.threads-per-warp" = 32 : i32, "ttg.total-num-warps" = 1 : i32} {
-  // CHECK-LABEL: @amd_reinitialize_isolated_barrier
-  tt.func public @amd_reinitialize_isolated_barrier() {
-    %barrier = ttg.local_alloc {allocation.offset = 0 : i32}
-        : () -> !ttg.memdesc<1xi64, #lifetime_shared, #lifetime_smem, mutable>
-    // CHECK: tt.call @__triton_consan_invalidate_barrier_storage
-    // CHECK: tt.call @__triton_consan_init_barrier_state
-    amdg.init_barrier %barrier, 1
-        : !ttg.memdesc<1xi64, #lifetime_shared, #lifetime_smem, mutable>
-    // CHECK: tt.call @__triton_consan_invalidate_barrier_storage
-    // CHECK: tt.call @__triton_consan_init_barrier_state
-    amdg.init_barrier %barrier, 2
         : !ttg.memdesc<1xi64, #lifetime_shared, #lifetime_smem, mutable>
     tt.return
   }

--- a/test/TritonGPU/amd/amd-consan.mlir
+++ b/test/TritonGPU/amd/amd-consan.mlir
@@ -333,7 +333,7 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 1 : i32, ttg.shar
   tt.func public @amdg_init_barrier() {
     %buf = ttg.local_alloc {allocation.offset = 0 : i32} : () -> !ttg.memdesc<32x32xf32, #shared, #smem, mutable>
     %bar = ttg.local_alloc {allocation.offset = 65536 : i32} : () -> !ttg.memdesc<1xi64, #shared1, #smem, mutable>
-    // CHECK: tt.call @__triton_consan_verify_barrier_can_init
+    // CHECK: tt.call @__triton_consan_invalidate_barrier_storage
     amdg.init_barrier %bar, 1 : !ttg.memdesc<1xi64, #shared1, #smem, mutable>
     // CHECK: tt.call @__triton_consan_init_barrier_state
     ttg.local_load %buf : !ttg.memdesc<32x32xf32, #shared, #smem, mutable> -> tensor<32x32xf32, #blocked>
@@ -366,7 +366,7 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 1 : i32, ttg.shar
     %c0_i32 = arith.constant 0 : i32
     %0 = ttg.local_alloc {allocation.offset = 0 : i32} : () -> !ttg.memdesc<32x32xf32, #shared, #smem, mutable>
     %bar = ttg.local_alloc {allocation.offset = 65536 : i32} : () -> !ttg.memdesc<1xi64, #shared1, #smem, mutable>
-    // CHECK: tt.call @__triton_consan_verify_barrier_can_init
+    // CHECK: tt.call @__triton_consan_invalidate_barrier_storage
     amdg.init_barrier %bar, 1 : !ttg.memdesc<1xi64, #shared1, #smem, mutable>
     // CHECK: tt.call @__triton_consan_verify_barrier_initialized
     // CHECK-DAG: tt.call @__triton_consan_set_waiting
@@ -404,7 +404,7 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 1 : i32, ttg.shar
     // CHECK: call {{.*}}fill_global_tensor{{.*}}(%[[BSTATE_GLOB]], %c0_i32
     %0 = ttg.local_alloc {allocation.offset = 0 : i32} : () -> !ttg.memdesc<32x32xf32, #shared, #smem, mutable>
     %bar = ttg.local_alloc {allocation.offset = 65536 : i32} : () -> !ttg.memdesc<1xi64, #shared1, #smem, mutable>
-    // CHECK: tt.call @__triton_consan_verify_barrier_can_init
+    // CHECK: tt.call @__triton_consan_invalidate_barrier_storage
     amdg.init_barrier %bar, 1 : !ttg.memdesc<1xi64, #shared1, #smem, mutable>
     // CHECK: tt.call @__triton_consan_init_barrier_state
     // CHECK: tti.experimental_lock_acquire
@@ -477,7 +477,7 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 8 : i32, ttg.shar
     %pred = arith.constant 1 : i32
     %0 = ttg.local_alloc {allocation.offset = 0 : i32} : () -> !ttg.memdesc<32x32xf32, #shared, #smem, mutable>
     %bar = ttg.local_alloc {allocation.offset = 65536 : i32} : () -> !ttg.memdesc<1xi64, #shared1, #smem, mutable>
-    // CHECK: tt.call @__triton_consan_verify_barrier_can_init
+    // CHECK: tt.call @__triton_consan_invalidate_barrier_storage
     amdg.init_barrier %bar, 8 : !ttg.memdesc<1xi64, #shared1, #smem, mutable>
     // CHECK: tt.call @__triton_consan_init_barrier_state
     // CHECK: tt.call @__triton_consan_verify_write_visibility
@@ -511,7 +511,7 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 8 : i32, ttg.shar
     %a_smem = ttg.local_alloc {allocation.offset = 0 : i32} : () -> !ttg.memdesc<32x32xf32, #shared, #smem, mutable>
     %b_smem = ttg.local_alloc {allocation.offset = 4096 : i32} : () -> !ttg.memdesc<32x32xf32, #shared, #smem, mutable>
     %bar = ttg.local_alloc {allocation.offset = 65536 : i32} : () -> !ttg.memdesc<1xi64, #shared1, #smem, mutable>
-    // CHECK: tt.call @__triton_consan_verify_barrier_can_init
+    // CHECK: tt.call @__triton_consan_invalidate_barrier_storage
     amdg.init_barrier %bar, 16 : !ttg.memdesc<1xi64, #shared1, #smem, mutable>
 
     // CHECK: tt.call @__triton_consan_init_barrier_state
@@ -626,7 +626,7 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 8 : i32, ttg.shar
     %c0_i32 = arith.constant 0 : i32
     %0 = ttg.local_alloc {allocation.offset = 0 : i32} : () -> !ttg.memdesc<32x32xf32, #shared, #smem, mutable>
     %bar = ttg.local_alloc {allocation.offset = 65536 : i32} : () -> !ttg.memdesc<1xi64, #shared1, #smem, mutable>
-    // CHECK: tt.call @__triton_consan_verify_barrier_can_init
+    // CHECK: tt.call @__triton_consan_invalidate_barrier_storage
     amdg.init_barrier %bar, 8 : !ttg.memdesc<1xi64, #shared1, #smem, mutable>
     // CHECK: tt.call @__triton_consan_init_barrier_state
     // CHECK: tt.call @__triton_consan_verify_write_visibility
@@ -994,10 +994,13 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.shar
 
 #lifetime_shared = #ttg.swizzled_shared<{vec = 1, perPhase = 1, maxPhase = 1, order = [0]}>
 #lifetime_smem = #ttg.shared_memory
+#lifetime_blocked = #ttg.blocked<{sizePerThread = [1], threadsPerWarp = [32], warpsPerCTA = [1], order = [0]}>
 
 module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 1 : i32, ttg.shared = 64 : i32, ttg.target = "hip:gfx1250", "ttg.threads-per-warp" = 32 : i32, "ttg.total-num-warps" = 1 : i32} {
   // CHECK-LABEL: @amd_payload_rejects_live_barrier_storage
-  tt.func public @amd_payload_rejects_live_barrier_storage() {
+  tt.func public @amd_payload_rejects_live_barrier_storage(
+      %indices: tensor<16xi32, #lifetime_blocked>,
+      %values: tensor<16xi32, #lifetime_blocked>) {
     %payload = ttg.local_alloc {allocation.offset = 0 : i32}
         : () -> !ttg.memdesc<16xi32, #lifetime_shared, #lifetime_smem, mutable>
     %barrier = ttg.local_alloc {allocation.offset = 0 : i32}
@@ -1011,9 +1014,86 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 1 : i32, ttg.shar
     %value = ttg.local_load %payload
         : !ttg.memdesc<16xi32, #lifetime_shared, #lifetime_smem, mutable>
         -> tensor<16xi32>
+    // CHECK: tt.call @__triton_consan_verify_barrier_can_init
+    // CHECK: ttg.local_atomic_scatter_rmw
+    %old = ttg.local_atomic_scatter_rmw add, %payload[%indices], %values
+        {axis = 0 : i32} : (!ttg.memdesc<16xi32, #lifetime_shared,
+        #lifetime_smem, mutable>, tensor<16xi32, #lifetime_blocked>,
+        tensor<16xi32, #lifetime_blocked>) -> tensor<16xi32, #lifetime_blocked>
     // CHECK: tt.call @__triton_consan_verify_barrier_initialized
     // CHECK: amdg.async_copy_mbarrier_arrive
     amdg.async_copy_mbarrier_arrive %uninitialized
+        : !ttg.memdesc<1xi64, #lifetime_shared, #lifetime_smem, mutable>
+    tt.return
+  }
+}
+
+// -----
+
+#lifetime_shared = #ttg.swizzled_shared<{vec = 1, perPhase = 1, maxPhase = 1, order = [0]}>
+#lifetime_smem = #ttg.shared_memory
+#lifetime_blocked = #ttg.blocked<{sizePerThread = [1], threadsPerWarp = [32], warpsPerCTA = [1], order = [0]}>
+
+module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 1 : i32, ttg.shared = 64 : i32, ttg.target = "hip:gfx1250", "ttg.threads-per-warp" = 32 : i32, "ttg.total-num-warps" = 1 : i32} {
+  // CHECK-LABEL: @amd_store_invalidates_barrier_storage
+  tt.func public @amd_store_invalidates_barrier_storage(
+      %values: tensor<16xi32, #lifetime_blocked>,
+      %partial: tensor<1xi32, #lifetime_blocked>) {
+    %payload = ttg.local_alloc {allocation.offset = 0 : i32}
+        : () -> !ttg.memdesc<16xi32, #lifetime_shared, #lifetime_smem, mutable>
+    %barrier = ttg.local_alloc {allocation.offset = 0 : i32}
+        : () -> !ttg.memdesc<1xi64, #lifetime_shared, #lifetime_smem, mutable>
+    // CHECK: tt.call @__triton_consan_invalidate_barrier_storage
+    // CHECK-NOT: tt.call @__triton_consan_verify_barrier_can_init
+    // CHECK: tt.call @__triton_consan_init_barrier_state
+    amdg.init_barrier %barrier, 1
+        : !ttg.memdesc<1xi64, #lifetime_shared, #lifetime_smem, mutable>
+    // CHECK: tt.call @__triton_consan_verify_write_visibility
+    // CHECK: tt.call @__triton_consan_verify_read_visibility
+    // CHECK: tt.call @__triton_consan_invalidate_barrier_storage
+    // CHECK: tti.experimental_assert_uniform {{.*}}, "Barrier invalidated while a thread is waiting"
+    // CHECK: tt.call @__triton_consan_clear_barrier_write_tracking
+    // CHECK: tt.call @__triton_consan_clear_barrier_read_tracking
+    // CHECK: tt.call @__triton_consan_publish_write_visibility
+    // CHECK: ttg.local_store
+    ttg.local_store %values, %payload : tensor<16xi32, #lifetime_blocked>
+        -> !ttg.memdesc<16xi32, #lifetime_shared, #lifetime_smem, mutable>
+    // CHECK: tt.call @__triton_consan_invalidate_barrier_storage
+    // CHECK: tt.call @__triton_consan_init_barrier_state
+    amdg.init_barrier %barrier, 1
+        : !ttg.memdesc<1xi64, #lifetime_shared, #lifetime_smem, mutable>
+    %slice = ttg.memdesc_subslice %payload [1]
+        : !ttg.memdesc<16xi32, #lifetime_shared, #lifetime_smem, mutable>
+        -> !ttg.memdesc<1xi32, #lifetime_shared, #lifetime_smem, mutable, 16>
+    // CHECK: tt.call @__triton_consan_invalidate_barrier_storage
+    // CHECK: ttg.local_store
+    ttg.local_store %partial, %slice : tensor<1xi32, #lifetime_blocked>
+        -> !ttg.memdesc<1xi32, #lifetime_shared, #lifetime_smem, mutable, 16>
+    // CHECK: tt.call @__triton_consan_verify_barrier_initialized
+    // CHECK: amdg.async_copy_mbarrier_arrive
+    amdg.async_copy_mbarrier_arrive %barrier
+        : !ttg.memdesc<1xi64, #lifetime_shared, #lifetime_smem, mutable>
+    tt.return
+  }
+}
+
+// -----
+
+#lifetime_shared = #ttg.swizzled_shared<{vec = 1, perPhase = 1, maxPhase = 1, order = [0]}>
+#lifetime_smem = #ttg.shared_memory
+
+module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 1 : i32, ttg.shared = 64 : i32, ttg.target = "hip:gfx1250", "ttg.threads-per-warp" = 32 : i32, "ttg.total-num-warps" = 1 : i32} {
+  // CHECK-LABEL: @amd_reinitialize_isolated_barrier
+  tt.func public @amd_reinitialize_isolated_barrier() {
+    %barrier = ttg.local_alloc {allocation.offset = 0 : i32}
+        : () -> !ttg.memdesc<1xi64, #lifetime_shared, #lifetime_smem, mutable>
+    // CHECK: tt.call @__triton_consan_invalidate_barrier_storage
+    // CHECK: tt.call @__triton_consan_init_barrier_state
+    amdg.init_barrier %barrier, 1
+        : !ttg.memdesc<1xi64, #lifetime_shared, #lifetime_smem, mutable>
+    // CHECK: tt.call @__triton_consan_invalidate_barrier_storage
+    // CHECK: tt.call @__triton_consan_init_barrier_state
+    amdg.init_barrier %barrier, 2
         : !ttg.memdesc<1xi64, #lifetime_shared, #lifetime_smem, mutable>
     tt.return
   }

--- a/test/TritonGPU/amd/amd-consan.mlir
+++ b/test/TritonGPU/amd/amd-consan.mlir
@@ -13,16 +13,16 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 1 : i32, ttg.shar
   // CHECK: arith.cmpi eq, %[[VISIBLE_THREAD_BITS]], %[[SELECTED_THREAD_BIT]]
   // CHECK-LABEL: @single_local_alloc
   tt.func public @single_local_alloc() {
-    // CHECK: %[[WRITE_VISIBILITY_GLOB:.*]] = ttg.global_scratch_alloc {alignment = 16 : i32, nbytes = 8 : i32, shared_cluster_state, third_party_allocation, tt.divisibility = 16 : i64} : !tt.ptr<i64>
+    // CHECK: %[[WRITE_VISIBILITY_GLOB:.*]] = ttg.global_scratch_alloc {alignment = 16 : i32, nbytes = 16 : i32, shared_cluster_state, third_party_allocation, tt.divisibility = 16 : i64} : !tt.ptr<i64>
     // CHECK: call {{.*}}fill_global_tensor{{.*}}(%[[WRITE_VISIBILITY_GLOB]], %c0_i64
 
-    // CHECK: %[[READ_VISIBILITY_GLOB:.*]] = ttg.global_scratch_alloc {alignment = 16 : i32, nbytes = 8 : i32, shared_cluster_state, third_party_allocation, tt.divisibility = 16 : i64} : !tt.ptr<i64>
+    // CHECK: %[[READ_VISIBILITY_GLOB:.*]] = ttg.global_scratch_alloc {alignment = 16 : i32, nbytes = 16 : i32, shared_cluster_state, third_party_allocation, tt.divisibility = 16 : i64} : !tt.ptr<i64>
     // CHECK: call {{.*}}fill_global_tensor{{.*}}(%[[READ_VISIBILITY_GLOB]], %c0_i64
 
-    // CHECK: %[[WRITE_TRACKING_GLOB:.*]] = ttg.global_scratch_alloc {alignment = 16 : i32, nbytes = 1 : i32, shared_cluster_state, third_party_allocation, tt.divisibility = 16 : i64} : !tt.ptr<i8>
+    // CHECK: %[[WRITE_TRACKING_GLOB:.*]] = ttg.global_scratch_alloc {alignment = 16 : i32, nbytes = 2 : i32, shared_cluster_state, third_party_allocation, tt.divisibility = 16 : i64} : !tt.ptr<i8>
     // CHECK: call {{.*}}fill_global_tensor{{.*}}(%[[WRITE_TRACKING_GLOB]], %c0_i8
 
-    // CHECK: %[[READ_TRACKING_GLOB:.*]] = ttg.global_scratch_alloc {alignment = 16 : i32, nbytes = 8 : i32, shared_cluster_state, third_party_allocation, tt.divisibility = 16 : i64} : !tt.ptr<i64>
+    // CHECK: %[[READ_TRACKING_GLOB:.*]] = ttg.global_scratch_alloc {alignment = 16 : i32, nbytes = 16 : i32, shared_cluster_state, third_party_allocation, tt.divisibility = 16 : i64} : !tt.ptr<i64>
     // CHECK: call {{.*}}fill_global_tensor{{.*}}(%[[READ_TRACKING_GLOB]], %c0_i64
     %0 = ttg.local_alloc {allocation.offset = 0 : i32} : () -> !ttg.memdesc<32x32xf32, #shared, #smem, mutable>
     %bar = ttg.local_alloc {allocation.offset = 4096 : i32} : () -> !ttg.memdesc<1xi64, #shared1, #smem, mutable>
@@ -41,16 +41,16 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 1 : i32, ttg.shar
 module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 1 : i32, ttg.shared = 65544 : i32, ttg.target = "hip:gfx1250", "ttg.threads-per-warp" = 32 : i32, "ttg.total-num-warps" = 1 : i32} {
   // CHECK-LABEL: @two_local_alloc
   tt.func public @two_local_alloc() {
-    // CHECK: %[[WRITE_VISIBILITY_GLOB:.*]] = ttg.global_scratch_alloc {alignment = 16 : i32, nbytes = 16 : i32, shared_cluster_state, third_party_allocation, tt.divisibility = 16 : i64} : !tt.ptr<i64>
+    // CHECK: %[[WRITE_VISIBILITY_GLOB:.*]] = ttg.global_scratch_alloc {alignment = 16 : i32, nbytes = 32 : i32, shared_cluster_state, third_party_allocation, tt.divisibility = 16 : i64} : !tt.ptr<i64>
     // CHECK: call {{.*}}fill_global_tensor{{.*}}(%[[WRITE_VISIBILITY_GLOB]], %c0_i64
 
-    // CHECK: %[[READ_VISIBILITY_GLOB:.*]] = ttg.global_scratch_alloc {alignment = 16 : i32, nbytes = 16 : i32, shared_cluster_state, third_party_allocation, tt.divisibility = 16 : i64} : !tt.ptr<i64>
+    // CHECK: %[[READ_VISIBILITY_GLOB:.*]] = ttg.global_scratch_alloc {alignment = 16 : i32, nbytes = 32 : i32, shared_cluster_state, third_party_allocation, tt.divisibility = 16 : i64} : !tt.ptr<i64>
     // CHECK: call {{.*}}fill_global_tensor{{.*}}(%[[READ_VISIBILITY_GLOB]], %c0_i64
 
-    // CHECK: %[[WRITE_TRACKING_GLOB:.*]] = ttg.global_scratch_alloc {alignment = 16 : i32, nbytes = 2 : i32, shared_cluster_state, third_party_allocation, tt.divisibility = 16 : i64} : !tt.ptr<i8>
+    // CHECK: %[[WRITE_TRACKING_GLOB:.*]] = ttg.global_scratch_alloc {alignment = 16 : i32, nbytes = 4 : i32, shared_cluster_state, third_party_allocation, tt.divisibility = 16 : i64} : !tt.ptr<i8>
     // CHECK: call {{.*}}fill_global_tensor{{.*}}(%[[WRITE_TRACKING_GLOB]], %c0_i8
 
-    // CHECK: %[[READ_TRACKING_GLOB:.*]] = ttg.global_scratch_alloc {alignment = 16 : i32, nbytes = 16 : i32, shared_cluster_state, third_party_allocation, tt.divisibility = 16 : i64} : !tt.ptr<i64>
+    // CHECK: %[[READ_TRACKING_GLOB:.*]] = ttg.global_scratch_alloc {alignment = 16 : i32, nbytes = 32 : i32, shared_cluster_state, third_party_allocation, tt.divisibility = 16 : i64} : !tt.ptr<i64>
     // CHECK: call {{.*}}fill_global_tensor{{.*}}(%[[READ_TRACKING_GLOB]], %c0_i64
     %0 = ttg.local_alloc {allocation.offset = 0 : i32} : () -> !ttg.memdesc<32x32xf32, #shared, #smem, mutable>
     %1 = ttg.local_alloc {allocation.offset = 4096 : i32} : () -> !ttg.memdesc<32x32xf32, #shared, #smem, mutable>
@@ -103,16 +103,16 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 1 : i32, ttg.shar
 module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 1 : i32, ttg.shared = 65544 : i32, ttg.target = "hip:gfx1250", "ttg.threads-per-warp" = 32 : i32, "ttg.total-num-warps" = 1 : i32} {
   // CHECK-LABEL: @three_sub_bufs
   tt.func public @three_sub_bufs() {
-    // CHECK: %[[WRITE_VISIBILITY_GLOB:.*]] = ttg.global_scratch_alloc {alignment = 16 : i32, nbytes = 8 : i32, shared_cluster_state, third_party_allocation, tt.divisibility = 16 : i64} : !tt.ptr<i64>
+    // CHECK: %[[WRITE_VISIBILITY_GLOB:.*]] = ttg.global_scratch_alloc {alignment = 16 : i32, nbytes = 16 : i32, shared_cluster_state, third_party_allocation, tt.divisibility = 16 : i64} : !tt.ptr<i64>
     // CHECK: call {{.*}}fill_global_tensor{{.*}}(%[[WRITE_VISIBILITY_GLOB]], %c0_i64
 
-    // CHECK: %[[READ_VISIBILITY_GLOB:.*]] = ttg.global_scratch_alloc {alignment = 16 : i32, nbytes = 8 : i32, shared_cluster_state, third_party_allocation, tt.divisibility = 16 : i64} : !tt.ptr<i64>
+    // CHECK: %[[READ_VISIBILITY_GLOB:.*]] = ttg.global_scratch_alloc {alignment = 16 : i32, nbytes = 16 : i32, shared_cluster_state, third_party_allocation, tt.divisibility = 16 : i64} : !tt.ptr<i64>
     // CHECK: call {{.*}}fill_global_tensor{{.*}}(%[[READ_VISIBILITY_GLOB]], %c0_i64
 
-    // CHECK: %[[WRITE_TRACKING_GLOB:.*]] = ttg.global_scratch_alloc {alignment = 16 : i32, nbytes = 1 : i32, shared_cluster_state, third_party_allocation, tt.divisibility = 16 : i64} : !tt.ptr<i8>
+    // CHECK: %[[WRITE_TRACKING_GLOB:.*]] = ttg.global_scratch_alloc {alignment = 16 : i32, nbytes = 2 : i32, shared_cluster_state, third_party_allocation, tt.divisibility = 16 : i64} : !tt.ptr<i8>
     // CHECK: call {{.*}}fill_global_tensor{{.*}}(%[[WRITE_TRACKING_GLOB]], %c0_i8
 
-    // CHECK: %[[READ_TRACKING_GLOB:.*]] = ttg.global_scratch_alloc {alignment = 16 : i32, nbytes = 8 : i32, shared_cluster_state, third_party_allocation, tt.divisibility = 16 : i64} : !tt.ptr<i64>
+    // CHECK: %[[READ_TRACKING_GLOB:.*]] = ttg.global_scratch_alloc {alignment = 16 : i32, nbytes = 16 : i32, shared_cluster_state, third_party_allocation, tt.divisibility = 16 : i64} : !tt.ptr<i64>
     // CHECK: call {{.*}}fill_global_tensor{{.*}}(%[[READ_TRACKING_GLOB]], %c0_i64
     %c0_i32 = arith.constant 0 : i32
     %0 = ttg.local_alloc {allocation.offset = 0 : i32} : () -> !ttg.memdesc<3x32x32xf32, #shared, #smem, mutable>
@@ -131,10 +131,9 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 1 : i32, ttg.shar
 #smem = #ttg.shared_memory
 #blocked = #ttg.blocked<{sizePerThread = [2, 4], threadsPerWarp = [1, 32], warpsPerCTA = [1, 1], order = [0, 1]}>
 module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 1 : i32, ttg.shared = 65544 : i32, ttg.target = "hip:gfx1250", "ttg.threads-per-warp" = 32 : i32, "ttg.total-num-warps" = 1 : i32} {
-  // CHECK: #[[READ_BARS_L:.*]] = #ttg.blocked<{sizePerThread = [2, 4], threadsPerWarp = [1, 32], warpsPerCTA = [1, 1], order = [0, 1]}>
   // CHECK: @read_bars_alloc
   tt.func public @read_bars_alloc() {
-    // CHECK: %[[READ_BARS_G:.*]] = ttg.global_scratch_alloc {alignment = 16 : i32, nbytes = 1 : i32, shared_cluster_state, third_party_allocation, tt.divisibility = 16 : i64} : !tt.ptr<i8>
+    // CHECK: %[[READ_BARS_G:.*]] = ttg.global_scratch_alloc {alignment = 16 : i32, nbytes = 2 : i32, shared_cluster_state, third_party_allocation, tt.divisibility = 16 : i64} : !tt.ptr<i8>
     // CHECK: call {{.*}}fill_global_tensor{{.*}}(%[[READ_BARS_G]], %c0_i8
     %c0 = arith.constant 0 : i32
     %0 = ttg.local_alloc {allocation.offset = 0 : i32} : () -> !ttg.memdesc<2x32x32xf32, #shared, #smem, mutable>
@@ -181,12 +180,12 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 1 : i32, ttg.shar
 module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 1 : i32, ttg.shared = 65544 : i32, ttg.target = "hip:gfx1250", "ttg.threads-per-warp" = 32 : i32, "ttg.total-num-warps" = 1 : i32} {
   // CHECK-LABEL: @async_copy_global_to_local_with_barriers
   tt.func public @async_copy_global_to_local_with_barriers(%ptr: tensor<32x32x!tt.ptr<f16>, #blocked>) {
-    // CHECK-DAG: %[[WRITE_VISIBILITY_GLOB:.*]] = ttg.global_scratch_alloc {alignment = 16 : i32, nbytes = 8 : i32, shared_cluster_state, third_party_allocation, tt.divisibility = 16 : i64} : !tt.ptr<i64>
-    // CHECK-DAG: %[[READ_VISIBILITY_GLOB:.*]] = ttg.global_scratch_alloc {alignment = 16 : i32, nbytes = 8 : i32, shared_cluster_state, third_party_allocation, tt.divisibility = 16 : i64} : !tt.ptr<i64>
-    // CHECK-DAG: %[[WRITE_TRACKING_GLOB:.*]] = ttg.global_scratch_alloc {alignment = 16 : i32, nbytes = 1 : i32, shared_cluster_state, third_party_allocation, tt.divisibility = 16 : i64} : !tt.ptr<i8>
-    // CHECK-DAG: %[[READ_TRACKING_GLOB:.*]] = ttg.global_scratch_alloc {alignment = 16 : i32, nbytes = 8 : i32, shared_cluster_state, third_party_allocation, tt.divisibility = 16 : i64} : !tt.ptr<i64>
+    // CHECK-DAG: %[[WRITE_VISIBILITY_GLOB:.*]] = ttg.global_scratch_alloc {alignment = 16 : i32, nbytes = 16 : i32, shared_cluster_state, third_party_allocation, tt.divisibility = 16 : i64} : !tt.ptr<i64>
+    // CHECK-DAG: %[[READ_VISIBILITY_GLOB:.*]] = ttg.global_scratch_alloc {alignment = 16 : i32, nbytes = 16 : i32, shared_cluster_state, third_party_allocation, tt.divisibility = 16 : i64} : !tt.ptr<i64>
+    // CHECK-DAG: %[[WRITE_TRACKING_GLOB:.*]] = ttg.global_scratch_alloc {alignment = 16 : i32, nbytes = 2 : i32, shared_cluster_state, third_party_allocation, tt.divisibility = 16 : i64} : !tt.ptr<i8>
+    // CHECK-DAG: %[[READ_TRACKING_GLOB:.*]] = ttg.global_scratch_alloc {alignment = 16 : i32, nbytes = 16 : i32, shared_cluster_state, third_party_allocation, tt.divisibility = 16 : i64} : !tt.ptr<i64>
 
-    // CHECK-DAG: %[[WRT_COMMITS_GLOB:.*]] = ttg.global_scratch_alloc {alignment = 16 : i32, nbytes = 1 : i32, shared_cluster_state, third_party_allocation, tt.divisibility = 16 : i64} : !tt.ptr<i8>
+    // CHECK-DAG: %[[WRT_COMMITS_GLOB:.*]] = ttg.global_scratch_alloc {alignment = 16 : i32, nbytes = 2 : i32, shared_cluster_state, third_party_allocation, tt.divisibility = 16 : i64} : !tt.ptr<i8>
 
     // CHECK: tt.call @__triton_consan_init_barrier_state
 
@@ -290,8 +289,8 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 1 : i32, ttg.shar
   tt.func public @alias_matrix_shared_indexed() {
     %c0_i32 = arith.constant 0 : i32
     %c1_i32 = arith.constant 1 : i32
-    // CHECK-DAG: arith.constant dense<[true, false]> : tensor<2xi1
-    // CHECK-DAG: arith.constant dense<[false, true]> : tensor<2xi1
+    // CHECK-DAG: arith.constant dense<[true, false, false, false]> : tensor<4xi1
+    // CHECK-DAG: arith.constant dense<[false, true, false, false]> : tensor<4xi1
     %smem = ttg.local_alloc {allocation.offset = 0 : i32} : () -> !ttg.memdesc<2x32xf32, #shared, #smem, mutable>
     %buf0 = ttg.memdesc_index %smem[%c0_i32] : !ttg.memdesc<2x32xf32, #shared, #smem, mutable> -> !ttg.memdesc<32xf32, #shared, #smem, mutable>
     %buf1 = ttg.memdesc_index %smem[%c1_i32] : !ttg.memdesc<2x32xf32, #shared, #smem, mutable> -> !ttg.memdesc<32xf32, #shared, #smem, mutable>
@@ -310,8 +309,8 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 1 : i32, ttg.shar
 module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 1 : i32, ttg.shared = 65544 : i32, ttg.target = "hip:gfx1250", "ttg.threads-per-warp" = 32 : i32, "ttg.total-num-warps" = 1 : i32} {
   // CHECK-LABEL: @alias_matrix_shared_subslice
   tt.func public @alias_matrix_shared_subslice() {
-    // CHECK-DAG: arith.constant dense<true> : tensor<2xi1
-    // CHECK-DAG: arith.constant dense<[false, true]> : tensor<2xi1
+    // CHECK-DAG: arith.constant dense<[true, true, false, false]> : tensor<4xi1
+    // CHECK-DAG: arith.constant dense<[false, true, false, false]> : tensor<4xi1
     %buf0 = ttg.local_alloc {allocation.offset = 0 : i32} : () -> !ttg.memdesc<64xf32, #shared, #smem, mutable>
     %buf1 = ttg.memdesc_subslice %buf0 [32] : !ttg.memdesc<64xf32, #shared, #smem, mutable> -> !ttg.memdesc<32xf32, #shared, #smem, mutable, 64>
     %bar = ttg.local_alloc {allocation.offset = 4096 : i32} : () -> !ttg.memdesc<1xi64, #shared, #smem, mutable>
@@ -354,18 +353,18 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 1 : i32, ttg.shar
 module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 1 : i32, ttg.shared = 65544 : i32, ttg.target = "hip:gfx1250", "ttg.threads-per-warp" = 32 : i32, "ttg.total-num-warps" = 1 : i32} {
   // CHECK-LABEL: @amdg_wait_barrier
   tt.func public @amdg_wait_barrier() {
-    // CHECK-DAG: %[[WRITE_VISIBILITY_GLOB:.*]] = ttg.global_scratch_alloc {alignment = 16 : i32, nbytes = 8 : i32, shared_cluster_state, third_party_allocation, tt.divisibility = 16 : i64} : !tt.ptr<i64>
+    // CHECK-DAG: %[[WRITE_VISIBILITY_GLOB:.*]] = ttg.global_scratch_alloc {alignment = 16 : i32, nbytes = 16 : i32, shared_cluster_state, third_party_allocation, tt.divisibility = 16 : i64} : !tt.ptr<i64>
     // CHECK: call {{.*}}fill_global_tensor{{.*}}(%[[WRITE_VISIBILITY_GLOB]], %c0_i64
 
-    // CHECK-DAG: %[[READ_VISIBILITY_GLOB:.*]] = ttg.global_scratch_alloc {alignment = 16 : i32, nbytes = 8 : i32, shared_cluster_state, third_party_allocation, tt.divisibility = 16 : i64} : !tt.ptr<i64>
+    // CHECK-DAG: %[[READ_VISIBILITY_GLOB:.*]] = ttg.global_scratch_alloc {alignment = 16 : i32, nbytes = 16 : i32, shared_cluster_state, third_party_allocation, tt.divisibility = 16 : i64} : !tt.ptr<i64>
     // CHECK: call {{.*}}fill_global_tensor{{.*}}(%[[READ_VISIBILITY_GLOB]], %c0_i64
 
     // CHECK-DAG: %[[BARRIERS:.*]] = tti.experimental_buffer_descriptors [65536], [{{.*}}], shared_mem : tensor<1xi64
 
-    // CHECK-DAG: %[[WRITE_TRACKING_GLOB:.*]] = ttg.global_scratch_alloc {alignment = 16 : i32, nbytes = 1 : i32, shared_cluster_state, third_party_allocation, tt.divisibility = 16 : i64} : !tt.ptr<i8>
+    // CHECK-DAG: %[[WRITE_TRACKING_GLOB:.*]] = ttg.global_scratch_alloc {alignment = 16 : i32, nbytes = 2 : i32, shared_cluster_state, third_party_allocation, tt.divisibility = 16 : i64} : !tt.ptr<i8>
     // CHECK: call {{.*}}fill_global_tensor{{.*}}(%[[WRITE_TRACKING_GLOB]], %c0_i8
 
-    // CHECK-DAG: %[[READ_TRACKING_GLOB:.*]] = ttg.global_scratch_alloc {alignment = 16 : i32, nbytes = 8 : i32, shared_cluster_state, third_party_allocation, tt.divisibility = 16 : i64} : !tt.ptr<i64>
+    // CHECK-DAG: %[[READ_TRACKING_GLOB:.*]] = ttg.global_scratch_alloc {alignment = 16 : i32, nbytes = 16 : i32, shared_cluster_state, third_party_allocation, tt.divisibility = 16 : i64} : !tt.ptr<i64>
     // CHECK: call {{.*}}fill_global_tensor{{.*}}(%[[READ_TRACKING_GLOB]], %c0_i64
     %c0_i32 = arith.constant 0 : i32
     %0 = ttg.local_alloc {allocation.offset = 0 : i32} : () -> !ttg.memdesc<32x32xf32, #shared, #smem, mutable>
@@ -821,6 +820,7 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.shar
     %bar = ttg.local_alloc {allocation.offset = 65536 : i32} : () -> !ttg.memdesc<1xi64, #shared1, #smem, mutable>
     amdg.init_barrier %bar, 1 : !ttg.memdesc<1xi64, #shared1, #smem, mutable>
     // CHECK: tti.experimental_lock_acquire
+    // CHECK: tt.call @__triton_consan_set_active_mask
     // CHECK: %[[THREAD_BIT:.*]] = arith.constant 0 : i32
     // CHECK: %[[THREAD_MASK:.*]] = arith.constant 2 : i64
     // CHECK: tt.call @__triton_consan_copy_write_visibility{{.*}}(%[[THREAD_BIT]], %[[THREAD_MASK]]
@@ -892,6 +892,7 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.shar
     %bar = ttg.local_alloc {allocation.offset = 65536 : i32} : () -> !ttg.memdesc<1xi64, #shared1, #smem, mutable>
     amdg.init_barrier %bar, 1 : !ttg.memdesc<1xi64, #shared1, #smem, mutable>
     // CHECK: tti.experimental_lock_acquire
+    // CHECK: tt.call @__triton_consan_set_active_mask
     // CHECK: %[[THREAD_BIT:.*]] = arith.constant 0 : i32
     // CHECK: %[[THREAD_MASK:.*]] = arith.constant 2 : i64
     // CHECK: tt.call @__triton_consan_copy_write_visibility{{.*}}(%[[THREAD_BIT]], %[[THREAD_MASK]]

--- a/test/TritonGPU/amd/amd-consan.mlir
+++ b/test/TritonGPU/amd/amd-consan.mlir
@@ -1006,7 +1006,7 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 1 : i32, ttg.shar
         : () -> !ttg.memdesc<1xi64, #lifetime_shared, #lifetime_smem, mutable>
     amdg.init_barrier %barrier, 1
         : !ttg.memdesc<1xi64, #lifetime_shared, #lifetime_smem, mutable>
-    // CHECK: tt.call @__triton_consan_verify_barrier_memory_available
+    // CHECK: tt.call @__triton_consan_verify_barrier_can_init
     // CHECK: ttg.local_load
     %value = ttg.local_load %payload
         : !ttg.memdesc<16xi32, #lifetime_shared, #lifetime_smem, mutable>

--- a/test/TritonGPU/amd/amd-consan.mlir
+++ b/test/TritonGPU/amd/amd-consan.mlir
@@ -461,17 +461,17 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 1 : i32, ttg.shar
 module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 8 : i32, ttg.shared = 65544 : i32, ttg.target = "hip:gfx1250", "ttg.threads-per-warp" = 32 : i32, "ttg.total-num-warps" = 8 : i32} {
   // CHECK-LABEL: @async_tdm_copy_global_to_local
   tt.func public @async_tdm_copy_global_to_local(%desc: !tt.tensordesc<32x32xf32>) {
-    // CHECK-DAG: %[[WRITE_VISIBILITY_GLOB:.*]] = ttg.global_scratch_alloc {alignment = 16 : i32, nbytes = 8 : i32, shared_cluster_state, third_party_allocation, tt.divisibility = 16 : i64} : !tt.ptr<i64>
+    // CHECK-DAG: %[[WRITE_VISIBILITY_GLOB:.*]] = ttg.global_scratch_alloc {alignment = 16 : i32, nbytes = 16 : i32, shared_cluster_state, third_party_allocation, tt.divisibility = 16 : i64} : !tt.ptr<i64>
     // CHECK: call {{.*}}fill_global_tensor{{.*}}(%[[WRITE_VISIBILITY_GLOB]], %c0_i64
 
-    // CHECK-DAG: %[[READ_VISIBILITY_GLOB:.*]] = ttg.global_scratch_alloc {alignment = 16 : i32, nbytes = 16 : i32, shared_cluster_state, third_party_allocation, tt.divisibility = 16 : i64} : !tt.ptr<i64>
+    // CHECK-DAG: %[[READ_VISIBILITY_GLOB:.*]] = ttg.global_scratch_alloc {alignment = 16 : i32, nbytes = 32 : i32, shared_cluster_state, third_party_allocation, tt.divisibility = 16 : i64} : !tt.ptr<i64>
     // CHECK: call {{.*}}fill_global_tensor{{.*}}(%[[READ_VISIBILITY_GLOB]], %c0_i64
 
     // CHECK-DAG: %[[BARRIERS:.*]] = tti.experimental_buffer_descriptors [65536], [{{.*}}], shared_mem : tensor<1xi64
-    // CHECK-DAG: %[[WRITE_TRACKING_GLOB:.*]] = ttg.global_scratch_alloc {alignment = 16 : i32, nbytes = 1 : i32, shared_cluster_state, third_party_allocation, tt.divisibility = 16 : i64} : !tt.ptr<i8>
+    // CHECK-DAG: %[[WRITE_TRACKING_GLOB:.*]] = ttg.global_scratch_alloc {alignment = 16 : i32, nbytes = 2 : i32, shared_cluster_state, third_party_allocation, tt.divisibility = 16 : i64} : !tt.ptr<i8>
     // CHECK: call {{.*}}fill_global_tensor{{.*}}(%[[WRITE_TRACKING_GLOB]], %c0_i8
 
-    // CHECK-DAG: %[[READ_TRACKING_GLOB:.*]] = ttg.global_scratch_alloc {alignment = 16 : i32, nbytes = 8 : i32, shared_cluster_state, third_party_allocation, tt.divisibility = 16 : i64} : !tt.ptr<i64>
+    // CHECK-DAG: %[[READ_TRACKING_GLOB:.*]] = ttg.global_scratch_alloc {alignment = 16 : i32, nbytes = 16 : i32, shared_cluster_state, third_party_allocation, tt.divisibility = 16 : i64} : !tt.ptr<i64>
     // CHECK: call {{.*}}fill_global_tensor{{.*}}(%[[READ_TRACKING_GLOB]], %c0_i64
     %c0_i32 = arith.constant 0 : i32
     %pred = arith.constant 1 : i32
@@ -483,6 +483,7 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 8 : i32, ttg.shar
     // CHECK: tt.call @__triton_consan_verify_write_visibility
     // CHECK: tt.call @__triton_consan_verify_read_visibility
     // CHECK: tt.call @__triton_consan_publish_write_visibility
+    // CHECK: tt.call @__triton_consan_set_read_visibility
     // CHECK: tt.call @__triton_consan_track_visible_accesses
     // CHECK: tt.call @__triton_consan_verify_and_update_barrier_state
     // CHECK: tti.experimental_assert_uniform {{.*}}, "Barrier used before initialization or after invalidation"
@@ -985,6 +986,47 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.shar
       ttg.local_load %arg1 : !ttg.memdesc<32xf32, #shared, #smem, mutable> -> tensor<32xf32>
       ttg.warp_return
     } : (!ttg.memdesc<32xf32, #shared, #smem, mutable>, !ttg.memdesc<32xf32, #shared, #smem, mutable>, !ttg.memdesc<1xi64, #shared, #smem, mutable>) -> ()
+    tt.return
+  }
+}
+
+// -----
+
+#lifetime_shared = #ttg.swizzled_shared<{vec = 1, perPhase = 1, maxPhase = 1, order = [0]}>
+#lifetime_smem = #ttg.shared_memory
+
+module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 1 : i32, ttg.shared = 64 : i32, ttg.target = "hip:gfx1250", "ttg.threads-per-warp" = 32 : i32, "ttg.total-num-warps" = 1 : i32} {
+  // CHECK-LABEL: @amd_payload_rejects_live_barrier_storage
+  tt.func public @amd_payload_rejects_live_barrier_storage() {
+    %payload = ttg.local_alloc {allocation.offset = 0 : i32}
+        : () -> !ttg.memdesc<16xi32, #lifetime_shared, #lifetime_smem, mutable>
+    %barrier = ttg.local_alloc {allocation.offset = 0 : i32}
+        : () -> !ttg.memdesc<1xi64, #lifetime_shared, #lifetime_smem, mutable>
+    amdg.init_barrier %barrier, 1
+        : !ttg.memdesc<1xi64, #lifetime_shared, #lifetime_smem, mutable>
+    // CHECK: tt.call @__triton_consan_verify_barrier_memory_available
+    // CHECK: ttg.local_load
+    %value = ttg.local_load %payload
+        : !ttg.memdesc<16xi32, #lifetime_shared, #lifetime_smem, mutable>
+        -> tensor<16xi32>
+    tt.return
+  }
+}
+
+// -----
+
+#lifetime_barrier = #ttg.swizzled_shared<{vec = 1, perPhase = 1, maxPhase = 1, order = [0]}>
+#lifetime_smem = #ttg.shared_memory
+
+module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 1 : i32, ttg.shared = 8 : i32, ttg.target = "hip:gfx1250", "ttg.threads-per-warp" = 32 : i32, "ttg.total-num-warps" = 1 : i32} {
+  // CHECK-LABEL: @amd_copy_completion_requires_initialized_barrier
+  tt.func public @amd_copy_completion_requires_initialized_barrier() {
+    %barrier = ttg.local_alloc {allocation.offset = 0 : i32}
+        : () -> !ttg.memdesc<1xi64, #lifetime_barrier, #lifetime_smem, mutable>
+    // CHECK: tt.call @__triton_consan_verify_barrier_initialized
+    // CHECK: amdg.async_copy_mbarrier_arrive
+    amdg.async_copy_mbarrier_arrive %barrier
+        : !ttg.memdesc<1xi64, #lifetime_barrier, #lifetime_smem, mutable>
     tt.return
   }
 }

--- a/test/TritonGPU/consan.mlir
+++ b/test/TritonGPU/consan.mlir
@@ -17,16 +17,16 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 1 : i32, ttg.shar
   // CHECK: arith.cmpi eq, %[[VISIBLE_THREAD_BITS]], %[[SELECTED_THREAD_BIT]]
   // CHECK: @single_local_alloc
   tt.func public @single_local_alloc() {
-    // CHECK: %[[WRITE_VISIBILITY_GLOB:.*]] = ttg.global_scratch_alloc {alignment = 16 : i32, nbytes = 8 : i32, shared_cluster_state, third_party_allocation, tt.divisibility = 16 : i64} : !tt.ptr<i64>
+    // CHECK: %[[WRITE_VISIBILITY_GLOB:.*]] = ttg.global_scratch_alloc {alignment = 16 : i32, nbytes = 16 : i32, shared_cluster_state, third_party_allocation, tt.divisibility = 16 : i64} : !tt.ptr<i64>
     // CHECK: call {{.*}}fill_global_tensor{{.*}}(%[[WRITE_VISIBILITY_GLOB]], %c0_i64
 
-    // CHECK: %[[READ_VISIBILITY_GLOB:.*]] = ttg.global_scratch_alloc {alignment = 16 : i32, nbytes = 8 : i32, shared_cluster_state, third_party_allocation, tt.divisibility = 16 : i64} : !tt.ptr<i64>
+    // CHECK: %[[READ_VISIBILITY_GLOB:.*]] = ttg.global_scratch_alloc {alignment = 16 : i32, nbytes = 16 : i32, shared_cluster_state, third_party_allocation, tt.divisibility = 16 : i64} : !tt.ptr<i64>
     // CHECK: call {{.*}}fill_global_tensor{{.*}}(%[[READ_VISIBILITY_GLOB]], %c0_i64
 
-    // CHECK: %[[WRITE_TRACKING_GLOB:.*]] = ttg.global_scratch_alloc {alignment = 16 : i32, nbytes = 1 : i32, shared_cluster_state, third_party_allocation, tt.divisibility = 16 : i64} : !tt.ptr<i8>
+    // CHECK: %[[WRITE_TRACKING_GLOB:.*]] = ttg.global_scratch_alloc {alignment = 16 : i32, nbytes = 2 : i32, shared_cluster_state, third_party_allocation, tt.divisibility = 16 : i64} : !tt.ptr<i8>
     // CHECK: call {{.*}}fill_global_tensor{{.*}}(%[[WRITE_TRACKING_GLOB]], %c0_i8
 
-    // CHECK: %[[READ_TRACKING_GLOB:.*]] = ttg.global_scratch_alloc {alignment = 16 : i32, nbytes = 8 : i32, shared_cluster_state, third_party_allocation, tt.divisibility = 16 : i64} : !tt.ptr<i64>
+    // CHECK: %[[READ_TRACKING_GLOB:.*]] = ttg.global_scratch_alloc {alignment = 16 : i32, nbytes = 16 : i32, shared_cluster_state, third_party_allocation, tt.divisibility = 16 : i64} : !tt.ptr<i64>
     // CHECK: call {{.*}}fill_global_tensor{{.*}}(%[[READ_TRACKING_GLOB]], %c0_i64
     %0 = ttg.local_alloc {allocation.offset = 0 : i32} : () -> !ttg.memdesc<32x32xf32, #shared, #smem, mutable>
     %bar = ttg.local_alloc {allocation.offset = 4096 : i32} : () -> !ttg.memdesc<1xi64, #shared1, #smem, mutable>
@@ -46,13 +46,13 @@ module attributes {"ttg.num-ctas" = 2 : i32, "ttg.num-warps" = 1 : i32, ttg.shar
   // CHECK: tti.experimental_cluster_cta_id : i32
   // CHECK-LABEL: @single_local_alloc_multi_cta
   tt.func public @single_local_alloc_multi_cta() {
-    // CHECK: %[[WRITE_VISIBILITY_GLOB:.*]] = ttg.global_scratch_alloc {alignment = 16 : i32, nbytes = 32 : i32, shared_cluster_state, third_party_allocation, tt.divisibility = 16 : i64} : !tt.ptr<i64>
+    // CHECK: %[[WRITE_VISIBILITY_GLOB:.*]] = ttg.global_scratch_alloc {alignment = 16 : i32, nbytes = 64 : i32, shared_cluster_state, third_party_allocation, tt.divisibility = 16 : i64} : !tt.ptr<i64>
     // CHECK: call {{.*}}fill_global_tensor{{.*}}(%[[WRITE_VISIBILITY_GLOB]], %c0_i64
-    // CHECK: %[[READ_VISIBILITY_GLOB:.*]] = ttg.global_scratch_alloc {alignment = 16 : i32, nbytes = 64 : i32, shared_cluster_state, third_party_allocation, tt.divisibility = 16 : i64} : !tt.ptr<i64>
+    // CHECK: %[[READ_VISIBILITY_GLOB:.*]] = ttg.global_scratch_alloc {alignment = 16 : i32, nbytes = 128 : i32, shared_cluster_state, third_party_allocation, tt.divisibility = 16 : i64} : !tt.ptr<i64>
     // CHECK: call {{.*}}fill_global_tensor{{.*}}(%[[READ_VISIBILITY_GLOB]], %c0_i64
-    // CHECK: %[[WRITE_TRACKING_GLOB:.*]] = ttg.global_scratch_alloc {alignment = 16 : i32, nbytes = 4 : i32, shared_cluster_state, third_party_allocation, tt.divisibility = 16 : i64} : !tt.ptr<i8>
+    // CHECK: %[[WRITE_TRACKING_GLOB:.*]] = ttg.global_scratch_alloc {alignment = 16 : i32, nbytes = 8 : i32, shared_cluster_state, third_party_allocation, tt.divisibility = 16 : i64} : !tt.ptr<i8>
     // CHECK: call {{.*}}fill_global_tensor{{.*}}(%[[WRITE_TRACKING_GLOB]], %c0_i8
-    // CHECK: %[[READ_TRACKING_GLOB:.*]] = ttg.global_scratch_alloc {alignment = 16 : i32, nbytes = 64 : i32, shared_cluster_state, third_party_allocation, tt.divisibility = 16 : i64} : !tt.ptr<i64>
+    // CHECK: %[[READ_TRACKING_GLOB:.*]] = ttg.global_scratch_alloc {alignment = 16 : i32, nbytes = 128 : i32, shared_cluster_state, third_party_allocation, tt.divisibility = 16 : i64} : !tt.ptr<i64>
     // CHECK: call {{.*}}fill_global_tensor{{.*}}(%[[READ_TRACKING_GLOB]], %c0_i64
     // Matching register and shared ownership keeps an ordinary load local.
     // CHECK: ttng.init_barrier
@@ -465,16 +465,16 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.shar
 module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 1 : i32, ttg.shared = 65544 : i32, ttg.target = "cuda:90", ttg.tensor_memory_size = 0 : i32, "ttg.threads-per-warp" = 32 : i32, "ttg.total-num-warps" = 1 : i32} {
   // CHECK-LABEL: @two_local_alloc
   tt.func public @two_local_alloc() {
-    // CHECK: %[[WRITE_VISIBILITY_GLOB:.*]] = ttg.global_scratch_alloc {alignment = 16 : i32, nbytes = 16 : i32, shared_cluster_state, third_party_allocation, tt.divisibility = 16 : i64} : !tt.ptr<i64>
+    // CHECK: %[[WRITE_VISIBILITY_GLOB:.*]] = ttg.global_scratch_alloc {alignment = 16 : i32, nbytes = 32 : i32, shared_cluster_state, third_party_allocation, tt.divisibility = 16 : i64} : !tt.ptr<i64>
     // CHECK: call {{.*}}fill_global_tensor{{.*}}(%[[WRITE_VISIBILITY_GLOB]], %c0_i64
 
-    // CHECK: %[[READ_VISIBILITY_GLOB:.*]] = ttg.global_scratch_alloc {alignment = 16 : i32, nbytes = 16 : i32, shared_cluster_state, third_party_allocation, tt.divisibility = 16 : i64} : !tt.ptr<i64>
+    // CHECK: %[[READ_VISIBILITY_GLOB:.*]] = ttg.global_scratch_alloc {alignment = 16 : i32, nbytes = 32 : i32, shared_cluster_state, third_party_allocation, tt.divisibility = 16 : i64} : !tt.ptr<i64>
     // CHECK: call {{.*}}fill_global_tensor{{.*}}(%[[READ_VISIBILITY_GLOB]], %c0_i64
 
-    // CHECK: %[[WRITE_TRACKING_GLOB:.*]] = ttg.global_scratch_alloc {alignment = 16 : i32, nbytes = 2 : i32, shared_cluster_state, third_party_allocation, tt.divisibility = 16 : i64} : !tt.ptr<i8>
+    // CHECK: %[[WRITE_TRACKING_GLOB:.*]] = ttg.global_scratch_alloc {alignment = 16 : i32, nbytes = 4 : i32, shared_cluster_state, third_party_allocation, tt.divisibility = 16 : i64} : !tt.ptr<i8>
     // CHECK: call {{.*}}fill_global_tensor{{.*}}(%[[WRITE_TRACKING_GLOB]], %c0_i8
 
-    // CHECK: %[[READ_TRACKING_GLOB:.*]] = ttg.global_scratch_alloc {alignment = 16 : i32, nbytes = 16 : i32, shared_cluster_state, third_party_allocation, tt.divisibility = 16 : i64} : !tt.ptr<i64>
+    // CHECK: %[[READ_TRACKING_GLOB:.*]] = ttg.global_scratch_alloc {alignment = 16 : i32, nbytes = 32 : i32, shared_cluster_state, third_party_allocation, tt.divisibility = 16 : i64} : !tt.ptr<i64>
     // CHECK: call {{.*}}fill_global_tensor{{.*}}(%[[READ_TRACKING_GLOB]], %c0_i64
     %0 = ttg.local_alloc {allocation.offset = 0 : i32} : () -> !ttg.memdesc<32x32xf32, #shared, #smem, mutable>
     %1 = ttg.local_alloc {allocation.offset = 4096 : i32} : () -> !ttg.memdesc<32x32xf32, #shared, #smem, mutable>
@@ -527,16 +527,16 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 1 : i32, ttg.shar
 module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 1 : i32, ttg.shared = 65544 : i32, ttg.target = "cuda:90", ttg.tensor_memory_size = 0 : i32, "ttg.threads-per-warp" = 32 : i32, "ttg.total-num-warps" = 1 : i32} {
   // CHECK-LABEL: @three_sub_bufs
   tt.func public @three_sub_bufs() {
-    // CHECK: %[[WRITE_VISIBILITY_GLOB:.*]] = ttg.global_scratch_alloc {alignment = 16 : i32, nbytes = 8 : i32, shared_cluster_state, third_party_allocation, tt.divisibility = 16 : i64} : !tt.ptr<i64>
+    // CHECK: %[[WRITE_VISIBILITY_GLOB:.*]] = ttg.global_scratch_alloc {alignment = 16 : i32, nbytes = 16 : i32, shared_cluster_state, third_party_allocation, tt.divisibility = 16 : i64} : !tt.ptr<i64>
     // CHECK: call {{.*}}fill_global_tensor{{.*}}(%[[WRITE_VISIBILITY_GLOB]], %c0_i64
 
-    // CHECK: %[[READ_VISIBILITY_GLOB:.*]] = ttg.global_scratch_alloc {alignment = 16 : i32, nbytes = 8 : i32, shared_cluster_state, third_party_allocation, tt.divisibility = 16 : i64} : !tt.ptr<i64>
+    // CHECK: %[[READ_VISIBILITY_GLOB:.*]] = ttg.global_scratch_alloc {alignment = 16 : i32, nbytes = 16 : i32, shared_cluster_state, third_party_allocation, tt.divisibility = 16 : i64} : !tt.ptr<i64>
     // CHECK: call {{.*}}fill_global_tensor{{.*}}(%[[READ_VISIBILITY_GLOB]], %c0_i64
 
-    // CHECK: %[[WRITE_TRACKING_GLOB:.*]] = ttg.global_scratch_alloc {alignment = 16 : i32, nbytes = 1 : i32, shared_cluster_state, third_party_allocation, tt.divisibility = 16 : i64} : !tt.ptr<i8>
+    // CHECK: %[[WRITE_TRACKING_GLOB:.*]] = ttg.global_scratch_alloc {alignment = 16 : i32, nbytes = 2 : i32, shared_cluster_state, third_party_allocation, tt.divisibility = 16 : i64} : !tt.ptr<i8>
     // CHECK: call {{.*}}fill_global_tensor{{.*}}(%[[WRITE_TRACKING_GLOB]], %c0_i8
 
-    // CHECK: %[[READ_TRACKING_GLOB:.*]] = ttg.global_scratch_alloc {alignment = 16 : i32, nbytes = 8 : i32, shared_cluster_state, third_party_allocation, tt.divisibility = 16 : i64} : !tt.ptr<i64>
+    // CHECK: %[[READ_TRACKING_GLOB:.*]] = ttg.global_scratch_alloc {alignment = 16 : i32, nbytes = 16 : i32, shared_cluster_state, third_party_allocation, tt.divisibility = 16 : i64} : !tt.ptr<i64>
     // CHECK: call {{.*}}fill_global_tensor{{.*}}(%[[READ_TRACKING_GLOB]], %c0_i64
     %c0_i32 = arith.constant 0 : i32
     %0 = ttg.local_alloc {allocation.offset = 0 : i32} : () -> !ttg.memdesc<3x32x32xf32, #shared, #smem, mutable>
@@ -555,10 +555,9 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 1 : i32, ttg.shar
 #smem = #ttg.shared_memory
 #blocked = #ttg.blocked<{sizePerThread = [2, 4], threadsPerWarp = [1, 32], warpsPerCTA = [1, 1], order = [0, 1]}>
 module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 1 : i32, ttg.shared = 65544 : i32, ttg.target = "cuda:90", ttg.tensor_memory_size = 0 : i32, "ttg.threads-per-warp" = 32 : i32, "ttg.total-num-warps" = 1 : i32} {
-  // CHECK: #[[READ_BARS_L:.*]] = #ttg.blocked<{sizePerThread = [2, 4], threadsPerWarp = [1, 32], warpsPerCTA = [1, 1], order = [0, 1]}>
   // CHECK: @read_bars_alloc
   tt.func public @read_bars_alloc() {
-    // CHECK: %[[READ_BARS_G:.*]] = ttg.global_scratch_alloc {alignment = 16 : i32, nbytes = 1 : i32, shared_cluster_state, third_party_allocation, tt.divisibility = 16 : i64} : !tt.ptr<i8>
+    // CHECK: %[[READ_BARS_G:.*]] = ttg.global_scratch_alloc {alignment = 16 : i32, nbytes = 2 : i32, shared_cluster_state, third_party_allocation, tt.divisibility = 16 : i64} : !tt.ptr<i8>
     // CHECK: call {{.*}}fill_global_tensor{{.*}}(%[[READ_BARS_G]], %c0_i8
     %c0 = arith.constant 0 : i32
     %0 = ttg.local_alloc {allocation.offset = 0 : i32} : () -> !ttg.memdesc<2x32x32xf32, #shared, #smem, mutable>
@@ -1019,18 +1018,18 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 1 : i32, ttg.shar
 module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 1 : i32, ttg.shared = 65544 : i32, ttg.target = "cuda:90", ttg.tensor_memory_size = 0 : i32, "ttg.threads-per-warp" = 32 : i32, "ttg.total-num-warps" = 1 : i32} {
   // CHECK-LABEL: @wait_barrier
   tt.func public @wait_barrier(%arg0: !tt.tensordesc<32x32xf32, #shared>) {
-    // CHECK-DAG: %[[WRITE_VISIBILITY_GLOB:.*]] = ttg.global_scratch_alloc {alignment = 16 : i32, nbytes = 8 : i32, shared_cluster_state, third_party_allocation, tt.divisibility = 16 : i64} : !tt.ptr<i64>
+    // CHECK-DAG: %[[WRITE_VISIBILITY_GLOB:.*]] = ttg.global_scratch_alloc {alignment = 16 : i32, nbytes = 16 : i32, shared_cluster_state, third_party_allocation, tt.divisibility = 16 : i64} : !tt.ptr<i64>
     // CHECK: call {{.*}}fill_global_tensor{{.*}}(%[[WRITE_VISIBILITY_GLOB]], %c0_i64
 
-    // CHECK-DAG: %[[READ_VISIBILITY_GLOB:.*]] = ttg.global_scratch_alloc {alignment = 16 : i32, nbytes = 8 : i32, shared_cluster_state, third_party_allocation, tt.divisibility = 16 : i64} : !tt.ptr<i64>
+    // CHECK-DAG: %[[READ_VISIBILITY_GLOB:.*]] = ttg.global_scratch_alloc {alignment = 16 : i32, nbytes = 16 : i32, shared_cluster_state, third_party_allocation, tt.divisibility = 16 : i64} : !tt.ptr<i64>
     // CHECK: call {{.*}}fill_global_tensor{{.*}}(%[[READ_VISIBILITY_GLOB]], %c0_i64
 
     // CHECK-DAG: %[[BARRIERS:.*]] = tti.experimental_buffer_descriptors [65536], [{{.*}}], shared_mem : tensor<1xi64, #linear{{[0-9]*}}>
 
-    // CHECK-DAG: %[[WRITE_TRACKING_GLOB:.*]] = ttg.global_scratch_alloc {alignment = 16 : i32, nbytes = 1 : i32, shared_cluster_state, third_party_allocation, tt.divisibility = 16 : i64} : !tt.ptr<i8>
+    // CHECK-DAG: %[[WRITE_TRACKING_GLOB:.*]] = ttg.global_scratch_alloc {alignment = 16 : i32, nbytes = 2 : i32, shared_cluster_state, third_party_allocation, tt.divisibility = 16 : i64} : !tt.ptr<i8>
     // CHECK: call {{.*}}fill_global_tensor{{.*}}(%[[WRITE_TRACKING_GLOB]], %c0_i8
 
-    // CHECK-DAG: %[[READ_TRACKING_GLOB:.*]] = ttg.global_scratch_alloc {alignment = 16 : i32, nbytes = 8 : i32, shared_cluster_state, third_party_allocation, tt.divisibility = 16 : i64} : !tt.ptr<i64>
+    // CHECK-DAG: %[[READ_TRACKING_GLOB:.*]] = ttg.global_scratch_alloc {alignment = 16 : i32, nbytes = 16 : i32, shared_cluster_state, third_party_allocation, tt.divisibility = 16 : i64} : !tt.ptr<i64>
     // CHECK: call {{.*}}fill_global_tensor{{.*}}(%[[READ_TRACKING_GLOB]], %c0_i64
     %true = arith.constant true
     %c0_i32 = arith.constant 0 : i32
@@ -1323,12 +1322,12 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 1 : i32, ttg.shar
 module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 1 : i32, ttg.shared = 65544 : i32, ttg.target = "cuda:90", ttg.tensor_memory_size = 0 : i32, "ttg.threads-per-warp" = 32 : i32, "ttg.total-num-warps" = 1 : i32} {
   // CHECK-LABEL: @async_copy_global_to_local_with_barriers
   tt.func public @async_copy_global_to_local_with_barriers(%ptr: tensor<128x128x!tt.ptr<f16>, #blocked>) {
-    // CHECK-DAG: %[[WRITE_VISIBILITY_GLOB:.*]] = ttg.global_scratch_alloc {alignment = 16 : i32, nbytes = 8 : i32, shared_cluster_state, third_party_allocation, tt.divisibility = 16 : i64} : !tt.ptr<i64>
-    // CHECK-DAG: %[[READ_VISIBILITY_GLOB:.*]] = ttg.global_scratch_alloc {alignment = 16 : i32, nbytes = 8 : i32, shared_cluster_state, third_party_allocation, tt.divisibility = 16 : i64} : !tt.ptr<i64>
-    // CHECK-DAG: %[[WRITE_TRACKING_GLOB:.*]] = ttg.global_scratch_alloc {alignment = 16 : i32, nbytes = 1 : i32, shared_cluster_state, third_party_allocation, tt.divisibility = 16 : i64} : !tt.ptr<i8>
-    // CHECK-DAG: %[[READ_TRACKING_GLOB:.*]] = ttg.global_scratch_alloc {alignment = 16 : i32, nbytes = 8 : i32, shared_cluster_state, third_party_allocation, tt.divisibility = 16 : i64} : !tt.ptr<i64>
+    // CHECK-DAG: %[[WRITE_VISIBILITY_GLOB:.*]] = ttg.global_scratch_alloc {alignment = 16 : i32, nbytes = 16 : i32, shared_cluster_state, third_party_allocation, tt.divisibility = 16 : i64} : !tt.ptr<i64>
+    // CHECK-DAG: %[[READ_VISIBILITY_GLOB:.*]] = ttg.global_scratch_alloc {alignment = 16 : i32, nbytes = 16 : i32, shared_cluster_state, third_party_allocation, tt.divisibility = 16 : i64} : !tt.ptr<i64>
+    // CHECK-DAG: %[[WRITE_TRACKING_GLOB:.*]] = ttg.global_scratch_alloc {alignment = 16 : i32, nbytes = 2 : i32, shared_cluster_state, third_party_allocation, tt.divisibility = 16 : i64} : !tt.ptr<i8>
+    // CHECK-DAG: %[[READ_TRACKING_GLOB:.*]] = ttg.global_scratch_alloc {alignment = 16 : i32, nbytes = 16 : i32, shared_cluster_state, third_party_allocation, tt.divisibility = 16 : i64} : !tt.ptr<i64>
 
-    // CHECK-DAG: %[[WRT_COMMITS_GLOB:.*]] = ttg.global_scratch_alloc {alignment = 16 : i32, nbytes = 1 : i32, shared_cluster_state, third_party_allocation, tt.divisibility = 16 : i64} : !tt.ptr<i8>
+    // CHECK-DAG: %[[WRT_COMMITS_GLOB:.*]] = ttg.global_scratch_alloc {alignment = 16 : i32, nbytes = 2 : i32, shared_cluster_state, third_party_allocation, tt.divisibility = 16 : i64} : !tt.ptr<i8>
 
     // CHECK: tt.call @__triton_consan_init_barrier_state
 
@@ -1367,7 +1366,7 @@ module attributes {"ttg.num-ctas" = 2 : i32, "ttg.num-warps" = 1 : i32, ttg.shar
     // ordinary barrier state, waiting, and active-mask captures.
     // CHECK: tti.experimental_buffer_descriptors [65536, 0], [8, 0], shared_mem
     // CHECK: ttg.global_scratch_alloc
-    // CHECK-COUNT-3: ttg.global_scratch_alloc
+    // CHECK-COUNT-5: ttg.global_scratch_alloc
     // CHECK-NOT: ttg.global_scratch_alloc
     // CHECK: tti.experimental_lock_release
     // CHECK-NEXT: ttng.cluster_barrier
@@ -1588,7 +1587,7 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.shar
     %bar = ttg.local_alloc {allocation.offset = 65536 : i32} : () -> !ttg.memdesc<1xi64, #shared1, #smem, mutable>
     ttng.init_barrier %bar, 1 : !ttg.memdesc<1xi64, #shared1, #smem, mutable>
     // CHECK: tti.experimental_lock_acquire
-    // CHECK: arith.constant dense<true> : tensor<1xi1
+    // CHECK: arith.constant dense<[true, false]> : tensor<2xi1
     // CHECK: tt.call @__triton_consan_verify_write_visibility
     // CHECK: tt.call @__triton_consan_set_read_visibility
     // CHECK: tti.experimental_lock_release
@@ -1670,6 +1669,7 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.shar
     %bar = ttg.local_alloc {allocation.offset = 65536 : i32} : () -> !ttg.memdesc<1xi64, #shared1, #smem, mutable>
     ttng.init_barrier %bar, 1 : !ttg.memdesc<1xi64, #shared1, #smem, mutable>
     // CHECK: tti.experimental_lock_acquire
+    // CHECK: tt.call @__triton_consan_set_active_mask
     // CHECK: %[[THREAD_BIT:.*]] = arith.constant 0 : i32
     // CHECK: %[[THREAD_MASK:.*]] = arith.constant 2 : i64
     // CHECK: tt.call @__triton_consan_copy_write_visibility{{.*}}(%[[THREAD_BIT]], %[[THREAD_MASK]]
@@ -1747,6 +1747,7 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.shar
     %bar = ttg.local_alloc {allocation.offset = 65536 : i32} : () -> !ttg.memdesc<1xi64, #shared1, #smem, mutable>
     ttng.init_barrier %bar, 1 : !ttg.memdesc<1xi64, #shared1, #smem, mutable>
     // CHECK: tti.experimental_lock_acquire
+    // CHECK: tt.call @__triton_consan_set_active_mask
     // CHECK: %[[THREAD_BIT:.*]] = arith.constant 0 : i32
     // CHECK: %[[THREAD_MASK:.*]] = arith.constant 2 : i64
     // CHECK: tt.call @__triton_consan_copy_write_visibility{{.*}}(%[[THREAD_BIT]], %[[THREAD_MASK]]
@@ -1917,8 +1918,8 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 1 : i32, ttg.shar
   tt.func public @alias_matrix_shared_indexed() {
     %c0_i32 = arith.constant 0 : i32
     %c1_i32 = arith.constant 1 : i32
-    // CHECK-DAG: arith.constant dense<[true, false]> : tensor<2xi1
-    // CHECK-DAG: arith.constant dense<[false, true]> : tensor<2xi1
+    // CHECK-DAG: arith.constant dense<[true, false, false, false]> : tensor<4xi1
+    // CHECK-DAG: arith.constant dense<[false, true, false, false]> : tensor<4xi1
     // CHECK: tt.call @__triton_consan_verify_write_visibility
     %smem = ttg.local_alloc {allocation.offset = 0 : i32} : () -> !ttg.memdesc<2x32xf32, #shared, #smem, mutable>
     %buf0 = ttg.memdesc_index %smem[%c0_i32] : !ttg.memdesc<2x32xf32, #shared, #smem, mutable> -> !ttg.memdesc<32xf32, #shared, #smem, mutable>
@@ -1940,8 +1941,8 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 1 : i32, ttg.shar
 module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 1 : i32, ttg.shared = 65544 : i32, ttg.target = "cuda:90", ttg.tensor_memory_size = 0 : i32, "ttg.threads-per-warp" = 32 : i32, "ttg.total-num-warps" = 1 : i32} {
   // CHECK-LABEL: @alias_matrix_shared_subslice
   tt.func public @alias_matrix_shared_subslice() {
-    // CHECK-DAG: arith.constant dense<true> : tensor<2xi1
-    // CHECK-DAG: arith.constant dense<[false, true]> : tensor<2xi1
+    // CHECK-DAG: arith.constant dense<[true, true, false, false]> : tensor<4xi1
+    // CHECK-DAG: arith.constant dense<[false, true, false, false]> : tensor<4xi1
     %buf0 = ttg.local_alloc {allocation.offset = 0 : i32} : () -> !ttg.memdesc<64xf32, #shared, #smem, mutable>
     %buf1 = ttg.memdesc_subslice %buf0 [32] : !ttg.memdesc<64xf32, #shared, #smem, mutable> -> !ttg.memdesc<32xf32, #shared, #smem, mutable, 64>
     %bar = ttg.local_alloc {allocation.offset = 4096 : i32} : () -> !ttg.memdesc<1xi64, #shared, #smem, mutable>

--- a/test/TritonGPU/consan.mlir
+++ b/test/TritonGPU/consan.mlir
@@ -2180,13 +2180,15 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 1 : i32, ttg.shar
 // -----
 
 // Cross-CTA subviews must direct every local memory access to the CTA that
-// owns its physical bytes. Runtime selection conservatively reaches both.
+// owns its physical bytes, including dynamically selected subviews whose
+// physical offsets are equal.
 #shared = #ttg.swizzled_shared<{vec = 1, perPhase = 1, maxPhase = 1, order = [1, 0], CGALayout = [[1, 0]]}>
 #blocked = #ttg.blocked<{sizePerThread = [1, 1], threadsPerWarp = [1, 32], warpsPerCTA = [1, 4], order = [1, 0], CGALayout = [[1, 0]]}>
 #smem = #ttg.shared_memory
 
 module attributes {"ttg.num-ctas" = 2 : i32, "ttg.num-warps" = 4 : i32, "ttg.threads-per-warp" = 32 : i32, "ttg.total-num-warps" = 4 : i32, ttg.shared = 512 : i32, ttg.target = "cuda:90", ttg.tensor_memory_size = 0 : i32} {
   // CHECK-LABEL: @cross_cta_affine_subslice_recipients
+  // CHECK-SAME: (%[[CHOOSE:.*]]: i1)
   tt.func public @cross_cta_affine_subslice_recipients(%choose: i1) {
     // CHECK: %[[AFFINE_PARENT:.*]] = ttg.local_alloc
     %parent = ttg.local_alloc {allocation.offset = 0 : i32} : () -> !ttg.memdesc<4x32xi32, #shared, #smem, mutable>
@@ -2208,7 +2210,12 @@ module attributes {"ttg.num-ctas" = 2 : i32, "ttg.num-warps" = 4 : i32, "ttg.thr
     // CHECK: tt.call @__triton_consan_verify_write_visibility{{.*}}({{.*}}%[[REMOTE_CTAS]])
     // CHECK: ttg.local_load
     %r = ttg.local_load %remote : !ttg.memdesc<2x32xi32, #shared, #smem, mutable, 4x32> -> tensor<2x32xi32, #blocked>
-    // CHECK: %[[SELECTED_CTAS:.*]] = arith.constant 3 : i32
+    // CHECK: %[[LOCAL_SELECTED:.*]] = arith.andi {{.*}}, %[[CHOOSE]] : i1
+    // CHECK: %[[REMOTE_CHOICE:.*]] = arith.xori %[[CHOOSE]], {{.*}} : i1
+    // CHECK: %[[REMOTE_SELECTED:.*]] = arith.andi {{.*}}, %[[REMOTE_CHOICE]] : i1
+    // CHECK: %[[LOCAL_CTA:.*]] = arith.select %[[LOCAL_SELECTED]], {{.*}} : i32
+    // CHECK: %[[REMOTE_CTA:.*]] = arith.select %[[REMOTE_SELECTED]], {{.*}} : i32
+    // CHECK: %[[SELECTED_CTAS:.*]] = arith.ori %[[LOCAL_CTA]], %[[REMOTE_CTA]] : i32
     // CHECK: tt.call @__triton_consan_verify_write_visibility{{.*}}({{.*}}%[[SELECTED_CTAS]])
     // CHECK: ttg.local_load
     %s = ttg.local_load %selected : !ttg.memdesc<2x32xi32, #shared, #smem, mutable, 4x32> -> tensor<2x32xi32, #blocked>
@@ -2231,6 +2238,43 @@ module attributes {"ttg.num-ctas" = 2 : i32, "ttg.num-warps" = 4 : i32, "ttg.thr
     // CHECK: tt.call @__triton_consan_verify_read_visibility{{.*}}({{.*}}%[[ATOMIC_CTAS]])
     // CHECK: ttg.local_atomic_scatter_rmw
     %a = ttg.local_atomic_scatter_rmw add, %remote[%indices], %values {axis = 1 : i32} : (!ttg.memdesc<2x32xi32, #shared, #smem, mutable, 4x32>, tensor<2x32xi32, #blocked>, tensor<2x32xi32, #blocked>) -> tensor<2x32xi32, #blocked>
+    tt.return
+  }
+}
+
+// -----
+
+// Dynamically selected subviews can have the same physical byte offset while
+// belonging to different CTAs. Barrier checks retain the selected owner and
+// verify every overlapping barrier with one call.
+#owner_shared = #ttg.swizzled_shared<{vec = 1, perPhase = 1, maxPhase = 1, order = [1, 0], CGALayout = [[1, 0]]}>
+#owner_barrier = #ttg.swizzled_shared<{vec = 1, perPhase = 1, maxPhase = 1, order = [0], CGALayout = [[1]]}>
+#owner_blocked = #ttg.blocked<{sizePerThread = [1, 1], threadsPerWarp = [1, 32], warpsPerCTA = [1, 4], order = [1, 0], CGALayout = [[1, 0]]}>
+#owner_smem = #ttg.shared_memory
+
+module attributes {"ttg.num-ctas" = 2 : i32, "ttg.num-warps" = 4 : i32, "ttg.threads-per-warp" = 32 : i32, "ttg.total-num-warps" = 4 : i32, ttg.shared = 512 : i32, ttg.target = "cuda:90", ttg.tensor_memory_size = 0 : i32} {
+  // CHECK-LABEL: @dynamic_barrier_owner_selection
+  // CHECK-SAME: (%[[CHOOSE:.*]]: i1)
+  tt.func public @dynamic_barrier_owner_selection(%choose: i1) {
+    %parent = ttg.local_alloc {allocation.offset = 0 : i32} : () -> !ttg.memdesc<4x32xi32, #owner_shared, #owner_smem, mutable>
+    %barrier = ttg.local_alloc {allocation.offset = 0 : i32} : () -> !ttg.memdesc<2xi64, #owner_barrier, #owner_smem, mutable>
+    %other = ttg.local_alloc {allocation.offset = 8 : i32} : () -> !ttg.memdesc<2xi64, #owner_barrier, #owner_smem, mutable>
+    ttng.init_barrier %barrier, 1 : !ttg.memdesc<2xi64, #owner_barrier, #owner_smem, mutable>
+    ttng.init_barrier %other, 1 : !ttg.memdesc<2xi64, #owner_barrier, #owner_smem, mutable>
+    %local = ttg.memdesc_subslice %parent [0, 0] : !ttg.memdesc<4x32xi32, #owner_shared, #owner_smem, mutable> -> !ttg.memdesc<2x32xi32, #owner_shared, #owner_smem, mutable, 4x32>
+    %remote = ttg.memdesc_subslice %parent [2, 0] : !ttg.memdesc<4x32xi32, #owner_shared, #owner_smem, mutable> -> !ttg.memdesc<2x32xi32, #owner_shared, #owner_smem, mutable, 4x32>
+    // CHECK: arith.select %[[CHOOSE]], {{.*}} : !ttg.memdesc
+    %selected = arith.select %choose, %local, %remote : !ttg.memdesc<2x32xi32, #owner_shared, #owner_smem, mutable, 4x32>
+    // CHECK: %[[LOCAL_SELECTED:.*]] = arith.andi {{.*}}, %[[CHOOSE]] : i1
+    // CHECK: %[[REMOTE_CHOICE:.*]] = arith.xori %[[CHOOSE]], {{.*}} : i1
+    // CHECK: %[[REMOTE_SELECTED:.*]] = arith.andi {{.*}}, %[[REMOTE_CHOICE]] : i1
+    // CHECK: arith.select %[[LOCAL_SELECTED]], {{.*}} : i32
+    // CHECK: arith.select %[[REMOTE_SELECTED]], {{.*}} : i32
+    // CHECK: %[[BARRIER_OWNERS:.*]] = arith.ori {{.*}} : tensor<2xi32
+    // CHECK: tt.call @__triton_consan_verify_barrier_can_init{{.*}}(%[[BARRIER_OWNERS]],
+    // CHECK-NOT: tt.call @__triton_consan_verify_barrier_can_init
+    // CHECK: ttg.local_load
+    %value = ttg.local_load %selected : !ttg.memdesc<2x32xi32, #owner_shared, #owner_smem, mutable, 4x32> -> tensor<2x32xi32, #owner_blocked>
     tt.return
   }
 }

--- a/test/TritonGPU/consan.mlir
+++ b/test/TritonGPU/consan.mlir
@@ -1694,6 +1694,9 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.shar
       ttg.local_load %arg1 : !ttg.memdesc<128x128xf16, #shared, #smem, mutable> -> tensor<128x128xf16>
       ttg.warp_return
     } : (!ttg.memdesc<128x128xf16, #shared, #smem, mutable>, !ttg.memdesc<1xi64, #shared1, #smem, mutable>) -> ()
+    // CHECK: tti.experimental_lock_acquire
+    // CHECK: tt.call @__triton_consan_publish_cta_visibility
+    // CHECK: tti.experimental_lock_release
     tt.return
   }
 }

--- a/test/TritonGPU/consan.mlir
+++ b/test/TritonGPU/consan.mlir
@@ -652,7 +652,8 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 1 : i32, ttg.shar
     // synthetic engine's deferred completion use of the barrier bytes.
     // CHECK: tt.call @__triton_consan_set_proxy_access
     // CHECK: tt.call @__triton_consan_verify_read_visibility
-    // CHECK: tt.call @__triton_consan_verify_barrier_has_no_waiters
+    // CHECK: tt.call @__triton_consan_invalidate_barrier_state
+    // CHECK: tti.experimental_assert_uniform {{.*}}, "Barrier invalidated while a thread is waiting"
     // CHECK: ttng.inval_barrier
     ttng.inval_barrier %bar : !ttg.memdesc<1xi64, #shared1, #smem, mutable>
     tt.return
@@ -996,10 +997,10 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 1 : i32, ttg.shar
     ttng.init_barrier %bar, 1 : !ttg.memdesc<1xi64, #shared1, #smem, mutable>
     // CHECK: tt.call @__triton_consan_init_barrier_state
     %tmp = ttg.local_load %buf : !ttg.memdesc<32xi32, #shared1, #smem, mutable> -> tensor<32xi32>
-    // CHECK: tt.call @__triton_consan_verify_barrier_initialized
-    // CHECK: tt.call @__triton_consan_verify_barrier_has_no_waiters
-    ttng.inval_barrier %bar : !ttg.memdesc<1xi64, #shared1, #smem, mutable>
     // CHECK: tt.call @__triton_consan_invalidate_barrier_state
+    // CHECK: tti.experimental_assert_uniform {{.*}}, "Barrier used before initialization or after invalidation"
+    // CHECK: tti.experimental_assert_uniform {{.*}}, "Barrier invalidated while a thread is waiting"
+    ttng.inval_barrier %bar : !ttg.memdesc<1xi64, #shared1, #smem, mutable>
     // CHECK: tt.call @__triton_consan_clear_barrier_write_tracking
     // CHECK: tt.call @__triton_consan_clear_barrier_read_tracking
     // CHECK: tt.call @__triton_consan_verify_barrier_can_init
@@ -2333,6 +2334,8 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 1 : i32, ttg.shar
         : () -> !ttg.memdesc<16xi32, #lifetime_shared, #lifetime_smem, mutable>
     %barrier = ttg.local_alloc {allocation.offset = 0 : i32}
         : () -> !ttg.memdesc<1xi64, #lifetime_shared, #lifetime_smem, mutable>
+    %uninitialized = ttg.local_alloc {allocation.offset = 8 : i32}
+        : () -> !ttg.memdesc<1xi64, #lifetime_shared, #lifetime_smem, mutable>
     // Init and invalidate are generic writes to the barrier bytes.
     // CHECK: tt.call @__triton_consan_verify_write_visibility
     // CHECK: ttng.init_barrier
@@ -2345,28 +2348,15 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 1 : i32, ttg.shar
         : !ttg.memdesc<16xi32, #lifetime_shared, #lifetime_smem, mutable>
         -> tensor<16xi32>
     // CHECK: tt.call @__triton_consan_verify_write_visibility
-    // CHECK: tt.call @__triton_consan_verify_barrier_has_no_waiters
+    // CHECK: tt.call @__triton_consan_invalidate_barrier_state
+    // CHECK: tti.experimental_assert_uniform {{.*}}, "Barrier invalidated while a thread is waiting"
     // CHECK: ttng.inval_barrier
     ttng.inval_barrier %barrier
         : !ttg.memdesc<1xi64, #lifetime_shared, #lifetime_smem, mutable>
-    tt.return
-  }
-}
-
-// -----
-
-#lifetime_barrier = #ttg.swizzled_shared<{vec = 1, perPhase = 1, maxPhase = 1, order = [0]}>
-#lifetime_smem = #ttg.shared_memory
-
-module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 1 : i32, ttg.shared = 8 : i32, ttg.target = "cuda:90", ttg.tensor_memory_size = 0 : i32, "ttg.threads-per-warp" = 32 : i32, "ttg.total-num-warps" = 1 : i32} {
-  // CHECK-LABEL: @copy_completion_requires_initialized_barrier
-  tt.func public @copy_completion_requires_initialized_barrier() {
-    %barrier = ttg.local_alloc {allocation.offset = 0 : i32}
-        : () -> !ttg.memdesc<1xi64, #lifetime_barrier, #lifetime_smem, mutable>
     // CHECK: tt.call @__triton_consan_verify_barrier_initialized
     // CHECK: ttng.async_copy_mbarrier_arrive
-    ttng.async_copy_mbarrier_arrive %barrier
-        : !ttg.memdesc<1xi64, #lifetime_barrier, #lifetime_smem, mutable>
+    ttng.async_copy_mbarrier_arrive %uninitialized
+        : !ttg.memdesc<1xi64, #lifetime_shared, #lifetime_smem, mutable>
     tt.return
   }
 }

--- a/test/TritonGPU/consan.mlir
+++ b/test/TritonGPU/consan.mlir
@@ -2345,7 +2345,7 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 1 : i32, ttg.shar
     ttng.init_barrier %barrier, 1
         : !ttg.memdesc<1xi64, #lifetime_shared, #lifetime_smem, mutable>
     // Ordinary accesses cannot reuse live barrier storage.
-    // CHECK: tt.call @__triton_consan_verify_barrier_memory_available
+    // CHECK: tt.call @__triton_consan_verify_barrier_can_init
     // CHECK: ttg.local_load
     %before = ttg.local_load %payload
         : !ttg.memdesc<16xi32, #lifetime_shared, #lifetime_smem, mutable>

--- a/test/TritonGPU/consan.mlir
+++ b/test/TritonGPU/consan.mlir
@@ -607,22 +607,23 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 1 : i32, ttg.shar
   // CHECK: tt.return %[[BARRIER_PACKED_STATUS]] : i32
   // CHECK-LABEL: @async_tma_copy_global_to_local
   tt.func public @async_tma_copy_global_to_local(%arg0: !tt.tensordesc<32x32xf32, #shared>) {
-    // CHECK-DAG: %[[WRITE_VISIBILITY_GLOB:.*]] = ttg.global_scratch_alloc {alignment = 16 : i32, nbytes = 8 : i32, shared_cluster_state, third_party_allocation, tt.divisibility = 16 : i64} : !tt.ptr<i64>
+    // CHECK-DAG: %[[WRITE_VISIBILITY_GLOB:.*]] = ttg.global_scratch_alloc {alignment = 16 : i32, nbytes = 16 : i32, shared_cluster_state, third_party_allocation, tt.divisibility = 16 : i64} : !tt.ptr<i64>
     // CHECK: call {{.*}}fill_global_tensor{{.*}}(%[[WRITE_VISIBILITY_GLOB]], %c0_i64
 
-    // CHECK-DAG: %[[READ_VISIBILITY_GLOB:.*]] = ttg.global_scratch_alloc {alignment = 16 : i32, nbytes = 16 : i32, shared_cluster_state, third_party_allocation, tt.divisibility = 16 : i64} : !tt.ptr<i64>
+    // CHECK-DAG: %[[READ_VISIBILITY_GLOB:.*]] = ttg.global_scratch_alloc {alignment = 16 : i32, nbytes = 32 : i32, shared_cluster_state, third_party_allocation, tt.divisibility = 16 : i64} : !tt.ptr<i64>
     // CHECK: call {{.*}}fill_global_tensor{{.*}}(%[[READ_VISIBILITY_GLOB]], %c0_i64
 
     // CHECK-DAG: %[[BARRIERS:.*]] = tti.experimental_buffer_descriptors [65536], [{{.*}}], shared_mem : tensor<1xi64
-    // CHECK-DAG: %[[WRITE_TRACKING_GLOB:.*]] = ttg.global_scratch_alloc {alignment = 16 : i32, nbytes = 1 : i32, shared_cluster_state, third_party_allocation, tt.divisibility = 16 : i64} : !tt.ptr<i8>
+    // CHECK-DAG: %[[WRITE_TRACKING_GLOB:.*]] = ttg.global_scratch_alloc {alignment = 16 : i32, nbytes = 2 : i32, shared_cluster_state, third_party_allocation, tt.divisibility = 16 : i64} : !tt.ptr<i8>
     // CHECK: call {{.*}}fill_global_tensor{{.*}}(%[[WRITE_TRACKING_GLOB]], %c0_i8
 
-    // CHECK-DAG: %[[READ_TRACKING_GLOB:.*]] = ttg.global_scratch_alloc {alignment = 16 : i32, nbytes = 8 : i32, shared_cluster_state, third_party_allocation, tt.divisibility = 16 : i64} : !tt.ptr<i64>
+    // CHECK-DAG: %[[READ_TRACKING_GLOB:.*]] = ttg.global_scratch_alloc {alignment = 16 : i32, nbytes = 16 : i32, shared_cluster_state, third_party_allocation, tt.divisibility = 16 : i64} : !tt.ptr<i64>
     // CHECK: call {{.*}}fill_global_tensor{{.*}}(%[[READ_TRACKING_GLOB]], %c0_i64
     %true = arith.constant true
     %c0_i32 = arith.constant 0 : i32
     %0 = ttg.local_alloc {allocation.offset = 0 : i32} : () -> !ttg.memdesc<32x32xf32, #shared, #smem, mutable>
     %bar = ttg.local_alloc {allocation.offset = 65536 : i32} : () -> !ttg.memdesc<1xi64, #shared1, #smem, mutable>
+    // CHECK: tt.call @__triton_consan_set_proxy_access
     // CHECK: tt.call @__triton_consan_verify_barrier_can_init
     ttng.init_barrier %bar, 1 : !ttg.memdesc<1xi64, #shared1, #smem, mutable>
     // Model the async TMA completion mechanism: barrier_expect corresponds to
@@ -638,12 +639,22 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 1 : i32, ttg.shar
     // CHECK: tt.call @__triton_consan_verify_write_visibility
     // CHECK: tt.call @__triton_consan_verify_read_visibility
     // CHECK: tt.call @__triton_consan_publish_write_visibility
+    // CHECK: tt.call @__triton_consan_set_read_visibility
     // CHECK: tt.call @__triton_consan_track_barrier_write_for_buffer
+    // CHECK: tt.call @__triton_consan_track_barrier_read_for_buffer
     // CHECK: tt.call @__triton_consan_verify_and_update_barrier_state
     // CHECK: tti.experimental_assert_uniform {{.*}}, "Barrier used before initialization or after invalidation"
     // CHECK: tti.experimental_assert_uniform {{.*}}, "Barrier arrive underflow: current count or tx-count would become invalid"
     // CHECK-NOT: tt.call @__triton_consan_update_barrier_state
+    // CHECK: ttng.async_tma_copy_global_to_local
     ttng.async_tma_copy_global_to_local %arg0[%c0_i32, %c0_i32] %0, %bar, %true : !tt.tensordesc<32x32xf32, #shared>, !ttg.memdesc<1xi64, #shared1, #smem, mutable> -> !ttg.memdesc<32x32xf32, #shared, #smem, mutable>
+    // Invalidation is another generic-proxy write. It must observe the
+    // synthetic engine's deferred completion use of the barrier bytes.
+    // CHECK: tt.call @__triton_consan_set_proxy_access
+    // CHECK: tt.call @__triton_consan_verify_read_visibility
+    // CHECK: tt.call @__triton_consan_verify_barrier_has_no_waiters
+    // CHECK: ttng.inval_barrier
+    ttng.inval_barrier %bar : !ttg.memdesc<1xi64, #shared1, #smem, mutable>
     tt.return
   }
 }
@@ -685,10 +696,10 @@ module attributes {"ttg.num-ctas" = 2 : i32, "ttg.num-warps" = 1 : i32, ttg.shar
 #smem = #ttg.shared_memory
 #blocked = #ttg.blocked<{sizePerThread = [1, 32], threadsPerWarp = [32, 1], warpsPerCTA = [1, 1], order = [0, 1], CGALayout = [[0, 0]]}>
 module attributes {"ttg.num-ctas" = 2 : i32, "ttg.num-warps" = 1 : i32, ttg.shared = 65544 : i32, ttg.target = "cuda:90", ttg.tensor_memory_size = 0 : i32, "ttg.threads-per-warp" = 32 : i32, "ttg.total-num-warps" = 1 : i32} {
-  // CHECK-LABEL: tt.func private @__triton_consan_check_outstanding_commits{{.*}}T2x1x1xI8
+  // CHECK-LABEL: tt.func private @__triton_consan_check_outstanding_commits{{.*}}T2x2x1xI8
   // CHECK-SAME: %arg4: i32
   // CHECK-NOT: tti.experimental_cluster_cta_id
-  // CHECK: tt.splat %arg4 : i32 -> tensor<2x1x1xi32
+  // CHECK: tt.splat %arg4 : i32 -> tensor<2x2x1xi32
   // CHECK: arith.shrui
   // CHECK-LABEL: @outstanding_commits_multicast_tma_recipients
   tt.func public @outstanding_commits_multicast_tma_recipients(
@@ -986,6 +997,7 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 1 : i32, ttg.shar
     // CHECK: tt.call @__triton_consan_init_barrier_state
     %tmp = ttg.local_load %buf : !ttg.memdesc<32xi32, #shared1, #smem, mutable> -> tensor<32xi32>
     // CHECK: tt.call @__triton_consan_verify_barrier_initialized
+    // CHECK: tt.call @__triton_consan_verify_barrier_has_no_waiters
     ttng.inval_barrier %bar : !ttg.memdesc<1xi64, #shared1, #smem, mutable>
     // CHECK: tt.call @__triton_consan_invalidate_barrier_state
     // CHECK: tt.call @__triton_consan_clear_barrier_write_tracking
@@ -1114,16 +1126,16 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 1 : i32, ttg.shar
 module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 1 : i32, ttg.shared = 65544 : i32, ttg.target = "cuda:90", ttg.tensor_memory_size = 0 : i32, "ttg.threads-per-warp" = 32 : i32, "ttg.total-num-warps" = 1 : i32} {
   // CHECK-LABEL: @tcgen5_mma
   tt.func public @tcgen5_mma(%arg0: !tt.tensordesc<32x32xf32, #shared>) {
-    // CHECK-DAG: %[[SM_WRITE_VISIBILITY_GLOB:.*]] = ttg.global_scratch_alloc {alignment = 16 : i32, nbytes = 16 : i32, shared_cluster_state, third_party_allocation, tt.divisibility = 16 : i64} : !tt.ptr<i64>
-    // CHECK-DAG: tt.call @[[FILL_TWO_I64:__triton_consan_fill_global_tensor[^ (]*T2xI64]](%[[SM_WRITE_VISIBILITY_GLOB]],
-    // CHECK-DAG: %[[SM_READ_VISIBILITY_GLOB:.*]] = ttg.global_scratch_alloc {alignment = 16 : i32, nbytes = 32 : i32, shared_cluster_state, third_party_allocation, tt.divisibility = 16 : i64} : !tt.ptr<i64>
+    // CHECK-DAG: %[[SM_WRITE_VISIBILITY_GLOB:.*]] = ttg.global_scratch_alloc {alignment = 16 : i32, nbytes = 32 : i32, shared_cluster_state, third_party_allocation, tt.divisibility = 16 : i64} : !tt.ptr<i64>
+    // CHECK-DAG: tt.call @[[FILL_FOUR_I64:__triton_consan_fill_global_tensor[^ (]*T4xI64]](%[[SM_WRITE_VISIBILITY_GLOB]],
+    // CHECK-DAG: %[[SM_READ_VISIBILITY_GLOB:.*]] = ttg.global_scratch_alloc {alignment = 16 : i32, nbytes = 64 : i32, shared_cluster_state, third_party_allocation, tt.divisibility = 16 : i64} : !tt.ptr<i64>
     // CHECK-DAG: %[[TM_WRITE_VISIBILITY_GLOB:.*]] = ttg.global_scratch_alloc {alignment = 16 : i32, nbytes = 8 : i32, shared_cluster_state, third_party_allocation, tt.divisibility = 16 : i64} : !tt.ptr<i64>
     // CHECK-DAG: ttg.global_scratch_alloc {alignment = 16 : i32, nbytes = 16 : i32, shared_cluster_state, third_party_allocation, tt.divisibility = 16 : i64} : !tt.ptr<i64>
-    // CHECK-DAG: tt.call @[[FILL_TWO_I64]]
+    // CHECK-DAG: tt.call @[[FILL_TWO_I64:__triton_consan_fill_global_tensor[^ (]*T2xI64]]
     // CHECK-DAG: %[[BARRIERS:.*]] = tti.experimental_buffer_descriptors [65536], [{{.*}}], shared_mem : tensor<1xi64
 
-    // CHECK-DAG: %[[SM_WRITE_TRACKING_GLOB:.*]] = ttg.global_scratch_alloc {alignment = 16 : i32, nbytes = 2 : i32, shared_cluster_state, third_party_allocation, tt.divisibility = 16 : i64} : !tt.ptr<i8>
-    // CHECK-DAG: %[[SM_READ_TRACKING_GLOB:.*]] = ttg.global_scratch_alloc {alignment = 16 : i32, nbytes = 16 : i32, shared_cluster_state, third_party_allocation, tt.divisibility = 16 : i64} : !tt.ptr<i64>
+    // CHECK-DAG: %[[SM_WRITE_TRACKING_GLOB:.*]] = ttg.global_scratch_alloc {alignment = 16 : i32, nbytes = 4 : i32, shared_cluster_state, third_party_allocation, tt.divisibility = 16 : i64} : !tt.ptr<i8>
+    // CHECK-DAG: %[[SM_READ_TRACKING_GLOB:.*]] = ttg.global_scratch_alloc {alignment = 16 : i32, nbytes = 32 : i32, shared_cluster_state, third_party_allocation, tt.divisibility = 16 : i64} : !tt.ptr<i64>
     // CHECK-DAG: %[[TM_WRITE_TRACKING_GLOB:.*]] = ttg.global_scratch_alloc {alignment = 16 : i32, nbytes = 1 : i32, shared_cluster_state, third_party_allocation, tt.divisibility = 16 : i64} : !tt.ptr<i8>
     // CHECK-DAG: %[[TM_READ_TRACKING_GLOB:.*]] = ttg.global_scratch_alloc {alignment = 16 : i32, nbytes = 8 : i32, shared_cluster_state, third_party_allocation, tt.divisibility = 16 : i64} : !tt.ptr<i64>
 
@@ -1177,21 +1189,21 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 1 : i32, ttg.shar
 module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 1 : i32, ttg.shared = 65544 : i32, ttg.target = "cuda:90", ttg.tensor_memory_size = 0 : i32, "ttg.threads-per-warp" = 32 : i32, "ttg.total-num-warps" = 1 : i32} {
   // CHECK-LABEL: @tcgen5_mma_lhs_in_tmem
   tt.func public @tcgen5_mma_lhs_in_tmem(%arg0: !tt.tensordesc<32x32xf32, #shared>) {
-    // CHECK-DAG: %[[SM_WRITE_VISIBILITY_GLOB:.*]] = ttg.global_scratch_alloc {alignment = 16 : i32, nbytes = 8 : i32, shared_cluster_state, third_party_allocation, tt.divisibility = 16 : i64} : !tt.ptr<i64>
-    // CHECK-DAG: %[[SM_READ_VISIBILITY_GLOB:.*]] = ttg.global_scratch_alloc {alignment = 16 : i32, nbytes = 16 : i32, shared_cluster_state, third_party_allocation, tt.divisibility = 16 : i64} : !tt.ptr<i64>
-    // CHECK-DAG: %[[TM_WRITE_VISIBILITY_GLOB:.*]] = ttg.global_scratch_alloc {alignment = 16 : i32, nbytes = 16 : i32, shared_cluster_state, third_party_allocation, tt.divisibility = 16 : i64} : !tt.ptr<i64>
+    // CHECK-DAG: %[[SM_WRITE_VISIBILITY_GLOB:.*]] = ttg.global_scratch_alloc {alignment = 16 : i32, nbytes = 16 : i32, shared_cluster_state, third_party_allocation, tt.divisibility = 16 : i64} : !tt.ptr<i64>
+    // CHECK-DAG: %[[SM_READ_VISIBILITY_GLOB:.*]] = ttg.global_scratch_alloc {alignment = 16 : i32, nbytes = 32 : i32, shared_cluster_state, third_party_allocation, tt.divisibility = 16 : i64} : !tt.ptr<i64>
+    // CHECK-DAG: ttg.global_scratch_alloc {alignment = 16 : i32, nbytes = 16 : i32, shared_cluster_state, third_party_allocation, tt.divisibility = 16 : i64} : !tt.ptr<i64>
     // CHECK-DAG: %[[TM_READ_VISIBILITY_GLOB:.*]] = ttg.global_scratch_alloc {alignment = 16 : i32, nbytes = 32 : i32, shared_cluster_state, third_party_allocation, tt.divisibility = 16 : i64} : !tt.ptr<i64>
     // CHECK-DAG: %[[BARRIERS:.*]] = tti.experimental_buffer_descriptors [65536], [{{.*}}], shared_mem : tensor<1xi64
 
-    // CHECK-DAG: %[[SM_WRITE_TRACKING_GLOB:.*]] = ttg.global_scratch_alloc {alignment = 16 : i32, nbytes = 1 : i32, shared_cluster_state, third_party_allocation, tt.divisibility = 16 : i64} : !tt.ptr<i8>
-    // CHECK-DAG: %[[SM_READ_TRACKING_GLOB:.*]] = ttg.global_scratch_alloc {alignment = 16 : i32, nbytes = 8 : i32, shared_cluster_state, third_party_allocation, tt.divisibility = 16 : i64} : !tt.ptr<i64>
+    // CHECK-DAG: %[[SM_WRITE_TRACKING_GLOB:.*]] = ttg.global_scratch_alloc {alignment = 16 : i32, nbytes = 2 : i32, shared_cluster_state, third_party_allocation, tt.divisibility = 16 : i64} : !tt.ptr<i8>
+    // CHECK-DAG: %[[SM_READ_TRACKING_GLOB:.*]] = ttg.global_scratch_alloc {alignment = 16 : i32, nbytes = 16 : i32, shared_cluster_state, third_party_allocation, tt.divisibility = 16 : i64} : !tt.ptr<i64>
     // CHECK-DAG: %[[TM_WRITE_TRACKING_GLOB:.*]] = ttg.global_scratch_alloc {alignment = 16 : i32, nbytes = 2 : i32, shared_cluster_state, third_party_allocation, tt.divisibility = 16 : i64} : !tt.ptr<i8>
     // CHECK-DAG: %[[TM_READ_TRACKING_GLOB:.*]] = ttg.global_scratch_alloc {alignment = 16 : i32, nbytes = 16 : i32, shared_cluster_state, third_party_allocation, tt.divisibility = 16 : i64} : !tt.ptr<i64>
 
     // CHECK: ttng.init_barrier
     // CHECK: arith.shli
     // CHECK: %[[TC_BIT:.*]] = arith.constant 1 : i32
-    // CHECK: tt.call @__triton_consan_verify_write_visibility{{.*}}%[[TM_WRITE_VISIBILITY_GLOB]]
+    // CHECK: tt.call @__triton_consan_verify_write_visibility{{[^ (]*}}({{[^,]+}}, {{[^,]+}}, {{[^,]+}}, %[[TM_WRITE_VISIBILITY_GLOB:[^,]+]],
     // CHECK: %[[TC_MASK:.*]] = arith.constant 2 : i64
     // CHECK: %[[TC_OBSERVER_MASK:.*]] = arith.constant 2 : i64
     // CHECK: tt.call @__triton_consan_set_read_visibility{{.*}}%[[TC_MASK]], %[[TC_OBSERVER_MASK]], %[[TM_READ_VISIBILITY_GLOB]]
@@ -1244,13 +1256,11 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 1 : i32, ttg.shar
     %c0_i32 = arith.constant 0 : i32
     %0 = ttg.local_alloc {allocation.offset = 0 : i32} : () -> !ttg.memdesc<128x128xf16, #shared, #smem, mutable>
     %result = ttng.tmem_alloc  {tensor_memory_col_offset = 0 : i32, tensor_memory_row_offset = 0 : i32} : () -> !ttg.memdesc<128x128xf16, #tmem, #ttng.tensor_memory, mutable>
-    %bar = ttg.local_alloc {allocation.offset = 0 : i32} : () -> !ttg.memdesc<1xi64, #shared1, #smem, mutable>
+    %bar = ttg.local_alloc {allocation.offset = 65536 : i32} : () -> !ttg.memdesc<1xi64, #shared1, #smem, mutable>
     ttng.init_barrier %bar, 1 : !ttg.memdesc<1xi64, #shared1, #smem, mutable>
     // CHECK: tt.call @__triton_consan_init_barrier_state
     %true = arith.constant true
-    // Identical shared- and tensor-memory tracking layouts reuse one helper.
-    // CHECK: tt.call @[[TRACK_VISIBLE:__triton_consan_track_visible_accesses[^ (]*]]
-    // CHECK: tt.call @[[TRACK_VISIBLE]]
+    // CHECK-COUNT-2: tt.call @__triton_consan_track_visible_accesses
     // CHECK: tt.call @__triton_consan_verify_and_update_barrier_state
     // CHECK-NOT: tt.call @__triton_consan_update_barrier_state
     ttng.tc_gen5_commit %bar : !ttg.memdesc<1xi64, #shared1, #smem, mutable>
@@ -1574,7 +1584,7 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.shar
   // CHECK-LABEL: @local_load_barriers
   tt.func public @local_load_barriers() {
     %buf = ttg.local_alloc {allocation.offset = 0 : i32} : () -> !ttg.memdesc<128x128xf16, #shared, #smem, mutable>
-    %bar = ttg.local_alloc {allocation.offset = 4096 : i32} : () -> !ttg.memdesc<1xi64, #shared1, #smem, mutable>
+    %bar = ttg.local_alloc {allocation.offset = 65536 : i32} : () -> !ttg.memdesc<1xi64, #shared1, #smem, mutable>
     ttng.init_barrier %bar, 1 : !ttg.memdesc<1xi64, #shared1, #smem, mutable>
     // CHECK: tti.experimental_lock_acquire
     // CHECK: arith.constant dense<true> : tensor<1xi1
@@ -2307,6 +2317,56 @@ module attributes {"ttg.num-ctas" = 2 : i32, "ttg.num-warps" = 4 : i32, ttg.shar
     // CHECK: tt.call @__triton_consan_verify_and_update_barrier_state{{.*}}({{.*}}%[[BYTES_PER_CTA]], {{.*}}%[[REMOTE_CTA]])
     // CHECK: ttng.async_shared_store
     ttng.async_shared_store %src, %view, %bar : tensor<128xi32, #async_remote_src> -> !ttg.memdesc<128xi32, #async_remote_dst, #async_remote_smem, mutable, 256>, !ttg.memdesc<2xi64, #async_remote_dst, #async_remote_smem, mutable>
+    tt.return
+  }
+}
+
+// -----
+
+#lifetime_shared = #ttg.swizzled_shared<{vec = 1, perPhase = 1, maxPhase = 1, order = [0]}>
+#lifetime_smem = #ttg.shared_memory
+
+module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 1 : i32, ttg.shared = 64 : i32, ttg.target = "cuda:90", ttg.tensor_memory_size = 0 : i32, "ttg.threads-per-warp" = 32 : i32, "ttg.total-num-warps" = 1 : i32} {
+  // CHECK-LABEL: @barrier_storage_lifetime
+  tt.func public @barrier_storage_lifetime() {
+    %payload = ttg.local_alloc {allocation.offset = 0 : i32}
+        : () -> !ttg.memdesc<16xi32, #lifetime_shared, #lifetime_smem, mutable>
+    %barrier = ttg.local_alloc {allocation.offset = 0 : i32}
+        : () -> !ttg.memdesc<1xi64, #lifetime_shared, #lifetime_smem, mutable>
+    // Init and invalidate are generic writes to the barrier bytes.
+    // CHECK: tt.call @__triton_consan_verify_write_visibility
+    // CHECK: ttng.init_barrier
+    ttng.init_barrier %barrier, 1
+        : !ttg.memdesc<1xi64, #lifetime_shared, #lifetime_smem, mutable>
+    // Ordinary accesses cannot reuse live barrier storage.
+    // CHECK: tt.call @__triton_consan_verify_barrier_memory_available
+    // CHECK: ttg.local_load
+    %before = ttg.local_load %payload
+        : !ttg.memdesc<16xi32, #lifetime_shared, #lifetime_smem, mutable>
+        -> tensor<16xi32>
+    // CHECK: tt.call @__triton_consan_verify_write_visibility
+    // CHECK: tt.call @__triton_consan_verify_barrier_has_no_waiters
+    // CHECK: ttng.inval_barrier
+    ttng.inval_barrier %barrier
+        : !ttg.memdesc<1xi64, #lifetime_shared, #lifetime_smem, mutable>
+    tt.return
+  }
+}
+
+// -----
+
+#lifetime_barrier = #ttg.swizzled_shared<{vec = 1, perPhase = 1, maxPhase = 1, order = [0]}>
+#lifetime_smem = #ttg.shared_memory
+
+module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 1 : i32, ttg.shared = 8 : i32, ttg.target = "cuda:90", ttg.tensor_memory_size = 0 : i32, "ttg.threads-per-warp" = 32 : i32, "ttg.total-num-warps" = 1 : i32} {
+  // CHECK-LABEL: @copy_completion_requires_initialized_barrier
+  tt.func public @copy_completion_requires_initialized_barrier() {
+    %barrier = ttg.local_alloc {allocation.offset = 0 : i32}
+        : () -> !ttg.memdesc<1xi64, #lifetime_barrier, #lifetime_smem, mutable>
+    // CHECK: tt.call @__triton_consan_verify_barrier_initialized
+    // CHECK: ttng.async_copy_mbarrier_arrive
+    ttng.async_copy_mbarrier_arrive %barrier
+        : !ttg.memdesc<1xi64, #lifetime_barrier, #lifetime_smem, mutable>
     tt.return
   }
 }

--- a/third_party/amd/lib/TritonAMDGPUTransforms/ConSanAMD.cpp
+++ b/third_party/amd/lib/TritonAMDGPUTransforms/ConSanAMD.cpp
@@ -51,6 +51,8 @@ public:
     return std::nullopt;
   }
 
+  bool barrierWritesInvalidate() const override { return true; }
+
   std::optional<WaitOpInfo>
   getWaitOpInfo(Operation *op, const tti::AuxDataMap &auxData) const override {
     // On asyncmark targets (CDNA3/CDNA4), ttg::AsyncWaitOp is kept as-is

--- a/third_party/amd/python/test/cdna5_consan_helper.py
+++ b/third_party/amd/python/test/cdna5_consan_helper.py
@@ -24,6 +24,72 @@ def alloc_fn(size, alignment, stream):
 set_profile_allocator(alloc_fn)
 
 
+def barrier_storage_lifetime():
+    mode = sys.argv[2]
+
+    @gluon.jit
+    def kernel(MODE: ttgl.constexpr):
+        layout: ttgl.constexpr = ttgl.BlockedLayout([1], [32], [4], [0])
+        shared_layout: ttgl.constexpr = ttgl.SwizzledSharedLayout(vec=1, per_phase=1, max_phase=1, order=[0])
+        barrier_layout: ttgl.constexpr = ttgl.amd.cdna5.mbarrier.MBarrierLayout()
+        storage = ttgl.allocate_shared_memory(ttgl.int32, [2], shared_layout)
+        barrier = storage.reinterpret(ttgl.int64, [1], barrier_layout)
+        ttgl.amd.cdna5.mbarrier.init(barrier, count=128)
+
+        if MODE == "read":
+            storage.load(layout)
+        elif MODE == "atomic":
+            indices = ttgl.full([2], 0, ttgl.int32, layout)
+            values = ttgl.full([2], 1, ttgl.int32, layout)
+            storage.atomic_scatter_add(values, indices, axis=0)
+        elif MODE == "reinitialize":
+            ttgl.amd.cdna5.mbarrier.init(barrier, count=128)
+            ttgl.amd.cdna5.mbarrier.arrive(barrier, count=1)
+            ttgl.amd.cdna5.mbarrier.wait(barrier, phase=0)
+        else:
+            values = ttgl.full([2], 7, ttgl.int32, layout)
+            if MODE == "partial":
+                storage.slice(1, 1).store(ttgl.full([1], 7, ttgl.int32, layout))
+            else:
+                storage.store(values)
+            if MODE == "use-after-store" or MODE == "partial":
+                ttgl.amd.cdna5.mbarrier.arrive(barrier, count=1)
+            else:
+                storage.load(layout)
+
+    kernel[(1, )](MODE=mode, num_warps=4)
+
+
+def barrier_storage_pending_completion():
+    wait = sys.argv[2] == "True"
+
+    @gluon.jit
+    def kernel(input_ptr, WAIT: ttgl.constexpr):
+        num_warps: ttgl.constexpr = 4
+        block: ttgl.constexpr = 32
+        layout: ttgl.constexpr = ttgl.BlockedLayout([1], [32], [4], [0])
+        shared_layout: ttgl.constexpr = ttgl.SwizzledSharedLayout(vec=1, per_phase=1, max_phase=1, order=[1, 0])
+        barrier_layout: ttgl.constexpr = ttgl.amd.cdna5.mbarrier.MBarrierLayout()
+        desc = ttgl.amd.cdna5.tdm.make_tensor_descriptor(
+            base=input_ptr,
+            shape=(block, block),
+            strides=(block, 1),
+            block_shape=(block, block),
+            layout=shared_layout,
+        )
+        payload = ttgl.allocate_shared_memory(ttgl.float16, [block, block], shared_layout)
+        storage = ttgl.allocate_shared_memory(ttgl.int32, [2], barrier_layout)
+        barrier = storage.reinterpret(ttgl.int64, [1], barrier_layout)
+        ttgl.amd.cdna5.mbarrier.init(barrier, count=num_warps)
+        ttgl.amd.cdna5.tdm.async_load(desc, [0, 0], payload, mbarrier=barrier)
+        if WAIT:
+            ttgl.amd.cdna5.mbarrier.wait(barrier, phase=0)
+        storage.store(ttgl.full([2], 7, ttgl.int32, layout))
+
+    data = torch.randn((32, 32), dtype=torch.float16, device="cuda")
+    kernel[(1, )](data, WAIT=wait, num_warps=4)
+
+
 def deadlock_two_partitions():
 
     @gluon.jit
@@ -906,4 +972,6 @@ if __name__ == "__main__":
         "tdm_two_bufs_one_wait_kernel": tdm_two_bufs_one_wait_kernel, "tdm_cross_partition_kernel":
         tdm_cross_partition_kernel, "tdm_cross_partition_load_store_kernel": tdm_cross_partition_load_store_kernel
     }
+    tests["barrier_storage_lifetime"] = barrier_storage_lifetime
+    tests["barrier_storage_pending_completion"] = barrier_storage_pending_completion
     tests[sys.argv[1]]()

--- a/third_party/amd/python/test/test_gluon_cdna5_consan.py
+++ b/third_party/amd/python/test/test_gluon_cdna5_consan.py
@@ -32,6 +32,36 @@ def _run_consan_subprocess(test_name, *args, timeout=120):
 
 
 @pytest.mark.skipif(not is_hip_gfx1250(), reason="Requires CDNA5")
+@pytest.mark.parametrize(
+    ("mode", "message"),
+    [
+        ("store", None),
+        ("reinitialize", None),
+        ("read", "Shared memory reused before barrier invalidation"),
+        ("atomic", "Shared memory reused before barrier invalidation"),
+        ("use-after-store", "Barrier used before initialization or after invalidation"),
+        ("partial", "Barrier used before initialization or after invalidation"),
+    ],
+)
+def test_barrier_storage_lifetime(mode, message):
+    stderr = _run_consan_subprocess("barrier_storage_lifetime", mode)
+    if message is None:
+        assert not stderr, stderr
+    else:
+        assert message in stderr, stderr
+
+
+@pytest.mark.skipif(not is_hip_gfx1250(), reason="Requires CDNA5")
+@pytest.mark.parametrize("wait", [False, True])
+def test_barrier_storage_pending_completion(wait):
+    stderr = _run_consan_subprocess("barrier_storage_pending_completion", wait)
+    if wait:
+        assert not stderr, stderr
+    else:
+        assert "Buffer being accessed has outstanding reads" in stderr, stderr
+
+
+@pytest.mark.skipif(not is_hip_gfx1250(), reason="Requires CDNA5")
 @pytest.mark.parametrize("FAILURE", [True, False])
 def test_ws_store_wait_load(FAILURE):
     """

--- a/third_party/nvidia/lib/Dialect/NVWS/Transforms/LowerAref.cpp
+++ b/third_party/nvidia/lib/Dialect/NVWS/Transforms/LowerAref.cpp
@@ -250,14 +250,8 @@ ArefValue createAndInitMbar(ArefCreateOp op, PatternRewriter &rewriter) {
       arefTy.getBaseType(), [](Type type) { return cast<MemDescType>(type); }));
   auto depth = getArefDepth(arefBufTypes[0]);
 
-  SetVector<Operation *> arefUsers;
-  for (auto user : op->getUsers())
-    arefUsers.insert(user);
-  auto sorted = topologicalSort(arefUsers);
-
   ImplicitLocOpBuilder b1(op->getLoc(), op), b2(op->getLoc(), op);
-  auto op1 = op->getBlock()->findAncestorOpInBlock(*sorted.back());
-  b2.setInsertionPointAfter(op1);
+  b2.setInsertionPoint(op->getBlock()->getTerminator());
 
   auto emptyMbars = createBarriers(b1, b2, depth, count.consumerPendingCount);
   auto fullMbars = createBarriers(b1, b2, depth, count.producerPendingCount);


### PR DESCRIPTION
PR description written by Codex

ConSan tracks mbarrier protocol state, but it does not protect the shared-memory bytes occupied by a live barrier. Ordinary accesses can therefore reuse initialized barrier storage, and invalidation can race a waiter or deferred TMA/tensor-core completion.

Treat initialization and invalidation as generic writes, reject ordinary accesses while overlapping barrier storage is initialized, and represent deferred completion use as reader visibility transferred by the existing mbarrier frontier. Allocate ordinary buffer-state lanes only for barrier storage that can overlap payload or receive a deferred completion.

Validation includes a native `make -j32` build, NVIDIA/AMD/capture-reservation ConSan compiler tests, pre-commit, and focused GPU coverage with 28 passed and 6 skipped. The full GPU suite's independent `tc-commit` reader-visibility failure reproduces on the parent branch; the barrier-lifecycle cases pass independently.
