### PR TITLE
[Blackwell] Fix NVFP4 MMA with MN-major packed operand

### DIFF
--- a/lib/Dialect/TritonGPU/Transforms/AccelerateMatmul.cpp
+++ b/lib/Dialect/TritonGPU/Transforms/AccelerateMatmul.cpp
@@ -874,12 +874,29 @@ public:
     // MMA_K = 64 is also not supported when BLOCK_M = 64.
     auto blockK = dotOp.getA().getType().getShape().back() * (isAFP4 ? 2 : 1);
     auto blockM = dotOp.getA().getType().getShape()[0];
+    bool hasMNMajorFp4Operand =
+        isFp4MMA && (!dotOp.getLhsKPack() || !dotOp.getRhsKPack());
+    auto aScaleType = dotOp.getAScale().getType();
+    auto bScaleType = dotOp.getBScale().getType();
+    auto aScaleElemType = aScaleType.getElementType();
+    auto bScaleElemType = bScaleType.getElementType();
+    auto isBlock16Scale = [blockK](RankedTensorType scaleType) {
+      return scaleType.getShape().back() * 16 == blockK;
+    };
+    bool hasUE4M3Scale = isa<Float8E4M3FNType>(aScaleElemType) ||
+                         isa<Float8E4M3FNType>(bScaleElemType);
+    bool hasUE5M3Scale =
+        (aScaleElemType.isInteger(8) && isBlock16Scale(aScaleType)) ||
+        (bScaleElemType.isInteger(8) && isBlock16Scale(bScaleType));
+    // mxf4nvf4 supports UE4M3/UE5M3 scales but not MN-major operands, while
+    // the mxf8f6f4 fallback for MN-major FP4 only supports E8M0 scales.
+    if (hasMNMajorFp4Operand && (hasUE4M3Scale || hasUE5M3Scale))
+      return failure();
     // mxf4/mxf4nvf4 do not support MN-major operands, so fp4 x fp4 falls
     // back to mxf8f6f4 if either operand is not K-packed. The mxf8f6f4
     // shared-memory packing format requires padding for every fp4 operand,
     // even if the operand is K packed.
-    bool isFp4MMAUsingMxf8f6f4 =
-        isFp4MMA && (!dotOp.getLhsKPack() || !dotOp.getRhsKPack());
+    bool isFp4MMAUsingMxf8f6f4 = hasMNMajorFp4Operand;
     bool isMMAv5Fp4PaddedLhs =
         isFp4MMAUsingMxf8f6f4 ||
         (IsAMixedPrecFp4 && (requiresFp4Padding || blockM == 64 ||

--- a/lib/Dialect/TritonGPU/Transforms/AccelerateMatmul.cpp
+++ b/lib/Dialect/TritonGPU/Transforms/AccelerateMatmul.cpp
@@ -896,13 +896,12 @@ public:
     // back to mxf8f6f4 if either operand is not K-packed. The mxf8f6f4
     // shared-memory packing format requires padding for every fp4 operand,
     // even if the operand is K packed.
-    bool isFp4MMAUsingMxf8f6f4 = hasMNMajorFp4Operand;
     bool isMMAv5Fp4PaddedLhs =
-        isFp4MMAUsingMxf8f6f4 ||
+        hasMNMajorFp4Operand ||
         (IsAMixedPrecFp4 && (requiresFp4Padding || blockM == 64 ||
                              blockK == 32 || !dotOp.getLhsKPack()));
     bool isMMAv5Fp4PaddedRhs =
-        isFp4MMAUsingMxf8f6f4 ||
+        hasMNMajorFp4Operand ||
         (IsBMixedPrecFp4 &&
          (requiresFp4Padding || blockK == 32 || !dotOp.getRhsKPack()));
 

--- a/lib/Dialect/TritonGPU/Transforms/AccelerateMatmul.cpp
+++ b/lib/Dialect/TritonGPU/Transforms/AccelerateMatmul.cpp
@@ -892,10 +892,10 @@ public:
     // the mxf8f6f4 fallback for MN-major FP4 only supports E8M0 scales.
     if (hasMNMajorFp4Operand && (hasUE4M3Scale || hasUE5M3Scale))
       return failure();
-    // mxf4/mxf4nvf4 do not support MN-major operands, so fp4 x fp4 falls
-    // back to mxf8f6f4 if either operand is not K-packed. The mxf8f6f4
-    // shared-memory packing format requires padding for every fp4 operand,
-    // even if the operand is K packed.
+    // mxf4 does not support MN-major operands, so mxfp4 x mxfp4 falls back to
+    // mxf8f6f4 if either operand is not K-packed. The mxf8f6f4 shared-memory
+    // packing format requires padding for every fp4 operand, even if the
+    // operand is K packed.
     bool isMMAv5Fp4PaddedLhs =
         hasMNMajorFp4Operand ||
         (IsAMixedPrecFp4 && (requiresFp4Padding || blockM == 64 ||

--- a/test/TritonGPU/accelerate-matmul.mlir
+++ b/test/TritonGPU/accelerate-matmul.mlir
@@ -250,6 +250,31 @@ module attributes {"ttg.target" = "cuda:90", "ttg.num-ctas" = 1 : i32, "ttg.num-
 
 // -----
 
+// mxf8f6f4 only supports E8M0 scales, so an MN-major NVFP4 operand with
+// UE4M3 scales must decompose instead of using the mxf8f6f4 fallback.
+
+#blocked = #ttg.blocked<{sizePerThread = [1, 1], threadsPerWarp = [1, 32], warpsPerCTA = [1, 4], order = [1, 0]}>
+#blocked_k = #ttg.blocked<{sizePerThread = [1, 1], threadsPerWarp = [1, 32], warpsPerCTA = [4, 1], order = [0, 1]}>
+module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.target = "cuda:100", "ttg.threads-per-warp" = 32 : i32} {
+  // CHECK-LABEL: nvfp4_rhs_mn_packed_decomposes
+  tt.func public @nvfp4_rhs_mn_packed_decomposes(
+      %a: tensor<128x32xi8, #blocked_k>,
+      %scale_a: tensor<128x4xf8E4M3FN, #blocked>,
+      %b: tensor<64x64xi8, #blocked>,
+      %scale_b: tensor<128x4xf8E4M3FN, #blocked>) -> tensor<128x128xf32, #blocked> {
+    // CHECK-NOT: tt.dot_scaled
+    // CHECK-COUNT-2: ttg.fp4_to_fp
+    // CHECK-NOT: tt.dot_scaled
+    // CHECK: ttng.tc_gen5_mma
+    // CHECK-NOT: ttng.tc_gen5_mma_scaled
+    %cst = arith.constant dense<0.000000e+00> : tensor<128x128xf32, #blocked>
+    %d = tt.dot_scaled %a scale %scale_a, %b scale %scale_b, %cst lhs = e2m1 rhs = e2m1 {fastMath = false, rhs_k_pack = false} : tensor<128x32xi8, #blocked_k>, tensor<128x4xf8E4M3FN, #blocked> * tensor<64x64xi8, #blocked>, tensor<128x4xf8E4M3FN, #blocked> -> tensor<128x128xf32, #blocked>
+    tt.return %d : tensor<128x128xf32, #blocked>
+  }
+}
+
+// -----
+
 #blocked = #ttg.blocked<{sizePerThread = [1, 1], threadsPerWarp = [1, 32], warpsPerCTA = [1, 4], order = [1, 0]}>
 #blocked1 = #ttg.blocked<{sizePerThread = [1, 1], threadsPerWarp = [1, 32], warpsPerCTA = [1, 4], order = [1, 0]}>
 #blocked2 = #ttg.blocked<{sizePerThread = [1, 1], threadsPerWarp = [1, 32], warpsPerCTA = [1, 4], order = [1, 0]}>


### PR DESCRIPTION
Hopefully the final MN-packed related fix.

Currently, the decision to use NVFP4 vs MXFP4 is based on the scale dtype. If scales are e4m3 but an operand is MN-packed, we get an error.
```
third_party/nvidia/lib/TritonNVIDIAGPUToLLVM/DotOpToLLVM/MMAv5.cpp:120: {anonymous}::mxfpKind {anonymous}::getMXFPKind(mlir::triton::ScaleDotElemType, mlir::triton::ScaleDotElemType, mlir::Type, mlir::Type, int, bool): Assertion `!transpose && "MMAv5 with kind=mxf4nvf4 does not support transpose"' failed.
``` 

For mxfp4, we can fallback to `mxf8f6f4` for MN-packed case. But since `mxf8f6f4` requires e8m0 scales, it cannot be used as a fallback for NVFP4. We need to use the dequantized path in this case.