### PR TITLE
[AMD]Fix empty range inference for HistogramOp in RangeAnalysis

### DIFF
--- a/python/test/unit/language/test_core.py
+++ b/python/test/unit/language/test_core.py
@@ -3319,6 +3319,27 @@ def test_histogram_mask(M, N, device):
     assert (z_torch == z).all()
 
 
+@pytest.mark.interpreter
+@pytest.mark.parametrize("M, N", [[1024, 64], [4096, 128]])
+def test_histogram_compare_mask(M, N, device):
+
+    @triton.jit
+    def histogram_kernel(x_ptr, out_ptr, M: tl.constexpr, N: tl.constexpr):
+        offsets = tl.arange(0, M)
+        x = tl.load(x_ptr + offsets)
+        hist = tl.histogram(x, N)
+        bins = tl.arange(0, N)
+        mask = hist > 0
+        tl.store(out_ptr + bins, hist, mask=mask)
+
+    torch.manual_seed(17)
+    x = torch.randint(0, N, (M, ), device=device, dtype=torch.int32)
+    out = torch.zeros(N, dtype=torch.int32, device=device)
+    ref = torch.histc(x.float(), bins=N, min=0, max=N - 1).to(torch.int32)
+    histogram_kernel[(1, )](x, out, M=M, N=N)
+    assert (out == ref).all(), f"expected {ref}, got {out}"
+
+
 @pytest.mark.parametrize("M, N", [(1, 64), (2, 32), (4, 16), (8, 8), (16, 4), (32, 2), (64, 1)])
 def test_scan_1d(M, N, device):
 

--- a/test/TritonGPU/amd/amd-fold-true-cmpi.mlir
+++ b/test/TritonGPU/amd/amd-fold-true-cmpi.mlir
@@ -308,3 +308,23 @@ module attributes {"ttg.num-warps" = 4 : i32} {
 // CHECK:           %[[OUTER:.*]]:2 = scf.for
 // CHECK:           %[[IS_NOT_FOUR:.*]] = arith.cmpi ne, %[[OUTER]]#1,
 // CHECK:           tt.return %[[IS_NOT_FOUR]] : i1
+
+// -----
+
+// Comparison on tt.histogram result should NOT be folded.
+// histogram returns [0, INT_MAX], so sgt against 0 is indeterminate.
+module attributes {"ttg.num-warps" = 4 : i32} {
+  tt.func @dontfoldhistogramcmpi(%arg0: tensor<1024xi32>) -> tensor<64xi1> {
+    %c0 = arith.constant dense<0> : tensor<64xi32>
+    %hist = tt.histogram %arg0 : tensor<1024xi32> -> tensor<64xi32>
+    %cmp = arith.cmpi sgt, %hist, %c0 : tensor<64xi32>
+    tt.return %cmp : tensor<64xi1>
+  }
+}
+
+// CHECK-LABEL:   tt.func @dontfoldhistogramcmpi
+// CHECK-NOT:       arith.constant dense<true>
+// CHECK-NOT:       arith.constant dense<false>
+// CHECK:           tt.histogram
+// CHECK:           arith.cmpi sgt
+// CHECK:         }

--- a/test/TritonGPU/amd/amd-range-analysis.mlir
+++ b/test/TritonGPU/amd/amd-range-analysis.mlir
@@ -1286,7 +1286,7 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32} {
 module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32} {
   // expected-remark@+1 {{arg 2: unsigned : [0, 4294967295] signed : [-2147483648, 2147483647]}}
   tt.func @histo_nonneg(%arg0: !tt.ptr<bf16>, %arg1: !tt.ptr<bf16>, %arg2 : tensor<256xi32>) {
-    // expected-remark@+2 {{unsigned : [0, 4294967295] signed : [0, -1]}}
+    // expected-remark@+2 {{unsigned : [0, 2147483647] signed : [0, 2147483647]}}
     // expected-remark@+1 {{non-neg}}
     %0 = tt.histogram %arg2 : tensor<256xi32> -> tensor<8xi32>
     %1 = tt.make_range {end = 8 : i32, start = 0 : i32} : tensor<8xi32>

--- a/third_party/amd/lib/Analysis/RangeAnalysis.cpp
+++ b/third_party/amd/lib/Analysis/RangeAnalysis.cpp
@@ -161,8 +161,8 @@ void inferResultRangesMaxNonNegSigned(Operation *op,
     auto bitWidth =
         mlir::ConstantIntRanges::getStorageBitwidth(result.getType());
     setResultRange(result, ConstantIntRanges::fromSigned(
-                               APInt::getZero(bitWidth).sext(bitWidth),
-                               APInt::getMaxValue(bitWidth).sext(bitWidth)));
+                               APInt::getZero(bitWidth),
+                               APInt::getSignedMaxValue(bitWidth)));
   }
 }
 


### PR DESCRIPTION
inferResultRangesMaxNonNegSigned used APInt::getMaxValue (unsigned max, 0xFFFFFFFF) as the signed upper bound passed to fromSigned, which is -1 in two's complement. This produced an empty range [0, -1], causing TritonAMDFoldTrueCmpI to constant-fold any comparison on histogram results (e.g. hist > 0) to false.

Fix by using APInt::getSignedMaxValue to produce the intended [0, INT_MAX] range. Also remove redundant same-width .sext() calls.

Add test_histogram_compare_mask to cover comparisons on histogram results in Python, and a MLIR lit test verifying that arith.cmpi on tt.histogram results is not folded by TritonAMDFoldTrueCmpI.

<!---
The core Triton is a small number of people, and we receive many PRs (thank
you!).  To help us review your code more quickly, **if you are a new
contributor (less than 3 PRs merged) we ask that you complete the following
tasks and include the filled-out checklist in your PR description.**

Complete the following tasks before sending your PR, and replace `[ ]` with
`[x]` to indicate you have done them.
-->

# New contributor declaration
- [x] I am not making a trivial change, such as fixing a typo in a comment.

- [x] I have written a PR description following these
  [rules](https://cbea.ms/git-commit/#why-not-how).

- [x] I have run `pre-commit run --from-ref origin/main --to-ref HEAD`.

- Select one of the following.
  - [x] I have added tests.
    - `/test` for `lit` tests
    - `/unittest` for C++ tests
    - `/python/test` for end-to-end tests
  - [ ] This PR does not need a test because `FILL THIS IN`.

- Select one of the following.
  - [ ] I have not added any `lit` tests.
  - [x] The `lit` tests I have added follow these [best practices](https://mlir.llvm.org/getting_started/TestingGuide/#filecheck-best-practices),
    including the "tests should be minimal" section. (Usually running Python code
    and using the instructions it generates is not minimal.)
