### PR TITLE
[NVIDIA] Read PTXAS_OPTIONS live so it works after importing triton

### DIFF
--- a/python/test/unit/language/test_core.py
+++ b/python/test/unit/language/test_core.py
@@ -6549,6 +6549,29 @@ def test_enable_reflect_ftz(enable_reflect_ftz, device, fresh_knobs):
 
 
 # -----------------------
+# test ptx_options
+# -----------------------
+
+
+@pytest.mark.skipif(not is_cuda(), reason="Requires CUDA")
+@pytest.mark.parametrize("default_override", [False, True])
+def test_ptxas_options(default_override, device, fresh_knobs):
+    # PTXAS_OPTIONS must be read at compile time, not frozen at import.
+    @triton.jit
+    def copy(data):
+        ptrs = data + tl.arange(0, 128)
+        tl.store(ptrs, tl.load(ptrs))
+
+    data = torch.randn((128, ), device=device, dtype=torch.float32)
+    if default_override:
+        fresh_knobs.nvidia.ptxas_options = "-v"
+        h = copy.warmup(data, grid=(1, ))
+    else:
+        h = copy.warmup(data, grid=(1, ), ptx_options="-v")
+    assert h.metadata.ptx_options == "-v"
+
+
+# -----------------------
 # test override_arch
 # -----------------------
 

--- a/python/test/unit/language/test_core.py
+++ b/python/test/unit/language/test_core.py
@@ -6555,7 +6555,7 @@ def test_enable_reflect_ftz(enable_reflect_ftz, device, fresh_knobs):
 
 @pytest.mark.skipif(not is_cuda(), reason="Requires CUDA")
 @pytest.mark.parametrize("default_override", [False, True])
-def test_ptxas_options(default_override, device, fresh_knobs):
+def test_ptxas_options(default_override, device, fresh_knobs_including_libraries):
     # PTXAS_OPTIONS must be read at compile time, not frozen at import.
     @triton.jit
     def copy(data):
@@ -6564,7 +6564,7 @@ def test_ptxas_options(default_override, device, fresh_knobs):
 
     data = torch.randn((128, ), device=device, dtype=torch.float32)
     if default_override:
-        fresh_knobs.nvidia.ptxas_options = "-v"
+        fresh_knobs_including_libraries.nvidia.ptxas_options = "-v"
         h = copy.warmup(data, grid=(1, ))
     else:
         h = copy.warmup(data, grid=(1, ), ptx_options="-v")

--- a/third_party/nvidia/backend/compiler.py
+++ b/third_party/nvidia/backend/compiler.py
@@ -115,7 +115,7 @@ class CUDAOptions:
     # maximum number of 32-bit registers used by one thread.
     maxnreg: Optional[int] = None
     ptx_version: int = None
-    ptx_options: Optional[str] = knobs.nvidia.ptxas_options
+    ptx_options: Optional[str] = None
     ir_override: Optional[str] = None  # filename of a user-defined IR (*.{ttir|ttgir|llir|ptx})
     enable_fp_fusion: bool = True
     enable_reflect_ftz: bool = True  # ftz in libdevice
@@ -235,6 +235,9 @@ class CUDABackend(BaseBackend):
 
         if "enable_fp_fusion" not in args:
             args["enable_fp_fusion"] = knobs.language.default_fp_fusion
+
+        if "ptx_options" not in args:
+            args["ptx_options"] = knobs.nvidia.ptxas_options
 
         if "gsan" in args.get("instrumentation_mode", ""):
             from triton.runtime.driver import driver


### PR DESCRIPTION
`CUDAOptions.ptx_options` defaulted to `knobs.nvidia.ptxas_options`, a dataclass field default evaluated once at import so setting `PTXAS_OPTIONS` after `import triton` was silently ignored.

this now works : 
```python
import os, torch, triton, triton.language as tl
os.environ["PTXAS_OPTIONS"] =  "--allow-expensive-optimizations=true"   # set AFTER import

```