### PR TITLE
[Release] Fix padding for block pointer zeros in release branch

### DIFF
--- a/python/triton/language/core.py
+++ b/python/triton/language/core.py
@@ -1909,7 +1909,9 @@ class _block_ptr:
         if padding_option == "":
             generated_other = None
         elif padding_option == "zero":
-            generated_other = 0
+            # Use a float literal for float element types: `cast` cannot take an
+            # integer to a non-standard float (e.g. fp8e4nv), but fp32 -> fp8 is fine.
+            generated_other = 0.0 if self.base.dtype.element_ty.is_floating() else 0
         elif padding_option == "nan":
             if self.base.dtype.element_ty.is_int():
                 raise ValueError("Padding option `nan` is not supported for integer block pointers")


### PR DESCRIPTION
Fixes a block pointer bug reported in https://github.com/pytorch/pytorch/issues/192063 by ensuring all floating types get 0.0 instead of 0.