### PR TITLE
[triton_kernels] Raise matmul warp floor

### DIFF
--- a/python/triton_kernels/tests/test_matmul_details/test_opt_flags_nvidia.py
+++ b/python/triton_kernels/tests/test_matmul_details/test_opt_flags_nvidia.py
@@ -161,6 +161,12 @@ def test_compute_block_n_blackwell_scale_aligns_to_128(n, expected):
     assert block_n == block_n_tma == expected
 
 
+def test_compute_num_warps_uses_two_warp_floor():
+    precision_config = PrecisionConfig()
+    assert opt_flags_nvidia.compute_num_warps(16, 256, False, precision_config, {}) == 2
+    assert opt_flags_nvidia.compute_num_warps(16, 256, False, precision_config, {"num_warps": 1}) == 1
+
+
 def test_matmul_blackwell_scale_small_n(device):
     if device != "cuda" or not torch.cuda.is_available():
         pytest.skip("requires CUDA")

--- a/python/triton_kernels/triton_kernels/matmul_details/opt_flags_details/opt_flags_nvidia.py
+++ b/python/triton_kernels/triton_kernels/matmul_details/opt_flags_details/opt_flags_nvidia.py
@@ -116,7 +116,7 @@ def compute_num_warps(block_m, block_n, is_persistent: bool, precision_config, c
     num_warps = constraints.get("num_warps", None)
     if num_warps is not None:
         return num_warps
-    return max(block_m * block_n // 4096, 4 if is_persistent else 1)
+    return max(block_m * block_n // 4096, 4 if is_persistent else 2)
 
 
 def compute_num_stages(


### PR DESCRIPTION
PR description written by Codex

One-warp non-persistent matmuls can spill heavily after the LLVM 24 SLSR correctness fix. This raises the NVIDIA matmul heuristic floor from one to two warps while continuing to honor explicit one-warp constraints.

On GB300, the edited source selected two warps without an override for BF16 x BF16 -> FP32 `[M, 5120] x [5120, 201088]` at M=8/12/16. Full-output correctness passed, runtime was 0.292/0.293/0.294 ms, and the kernels used 237 registers with zero local storage. Across a 24-shape M/K/N sweep, one warp never won and was 2.68x-11.85x slower. The focused selector assertions and the full pre-commit hook suite pass.

## Stack
Merge bottom-up:
- [ ] #11253 (this PR)
