### PR TITLE
[AMD] Optimize software E4M3FN to FP16 conversion

### DIFF
--- a/python/test/unit/language/test_conversions.py
+++ b/python/test/unit/language/test_conversions.py
@@ -286,9 +286,12 @@ def test_typeconvert_upcast(src_dtype, dst_dtype, device):
                 launch_exhaustive_populate(getattr(tl, src_dtype), 0, 65536, False, 8, 0x7f, device=device)
             return
     elif is_hip():
-        if src_dtype in FP8_DTYPES and is_hip_rdna3():
+        if (src_dtype in FP8_DTYPES and is_hip_rdna3()
+                and (src_dtype, dst_dtype) != ('float8e4nv', 'float16')):
             pytest.skip(f"{src_dtype} is not supported on AMDGPU RDNA3")
-        if  (src_dtype == 'float8e4nv' and not (is_hip_cdna3() or is_hip_cdna4())):
+        if (src_dtype == 'float8e4nv'
+                and not (is_hip_cdna3() or is_hip_cdna4()
+                         or (is_hip_rdna3() and dst_dtype == 'float16'))):
             pytest.skip(f"upcasting {src_dtype} to {dst_dtype} not supported in this architecture")
         if  src_dtype == 'float8e4b15':
             # If the dtype should error out in the given device, we assert that and return
@@ -310,6 +313,19 @@ def test_typeconvert_upcast(src_dtype, dst_dtype, device):
     }[src_dtype]
 
     upcast_test(getattr(tl, src_dtype), getattr(tl, dst_dtype), *stuff, device=device)
+
+
+def test_fp8e4nv_to_fp16_nan(device):
+    if not (is_hip() and (is_hip_rdna3() or is_hip_cdna3())):
+        pytest.skip("AMD software conversion test")
+
+    src = torch.tensor([0x7f, -1], dtype=torch.int8, device=device)
+    dst = launch_type_convert_triton(
+        src, tl.float8e4nv, tl.float16, device=device, BLOCK_SIZE=2
+    )
+    bits = [value & 0xffff for value in dst.cpu().tolist()]
+    assert bits == [0x7e00, 0xfe00]
+
 
 @pytest.mark.parametrize("src_dtype, dst_dtype, rounding, max_repr", [
     ('float32', 'float16', 'rtne', 0x477fe000),

--- a/test/Conversion/amd/fp8e4m3fn_to_fp16.mlir
+++ b/test/Conversion/amd/fp8e4m3fn_to_fp16.mlir
@@ -1,0 +1,25 @@
+// RUN: triton-opt %s --convert-triton-amdgpu-to-llvm=gfx-arch=gfx1100 | FileCheck --check-prefix=SELECT %s
+// RUN: triton-opt %s --convert-triton-amdgpu-to-llvm=gfx-arch=gfx1100 | FileCheck --check-prefix=ARITH %s
+// RUN: triton-opt %s --convert-triton-amdgpu-to-llvm=gfx-arch=gfx942 | FileCheck --check-prefix=SELECT %s
+// RUN: triton-opt %s --convert-triton-amdgpu-to-llvm=gfx-arch=gfx942 | FileCheck --check-prefix=ARITH %s
+
+#blocked = #ttg.blocked<{sizePerThread = [1, 8], threadsPerWarp = [4, 8], warpsPerCTA = [4, 1], order = [1, 0]}>
+
+module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, "ttg.threads-per-warp" = 32 : i32} {
+  // SELECT-LABEL: llvm.func @fp8e4m3fn_to_fp16
+  // ARITH-LABEL: llvm.func @fp8e4m3fn_to_fp16
+  tt.func @fp8e4m3fn_to_fp16(%arg0: tensor<8x8xf8E4M3FN, #ttg.dot_op<{opIdx = 0, parent = #blocked}>>) {
+    // The fixture converts eight elements per thread. Each value
+    // uses one branchless magnitude conversion and one select for signed NaN,
+    // rather than an eight-entry denormal lookup chain.
+    // SELECT-COUNT-8: llvm.select
+    // SELECT-NOT: llvm.select
+    // ARITH: llvm.fmul
+    // ARITH: llvm.fptrunc
+    // ARITH: llvm.mlir.constant(32256 : i16)
+    // ARITH: llvm.icmp "eq"
+    // ARITH: llvm.select
+    %0 = tt.fp_to_fp %arg0 : tensor<8x8xf8E4M3FN, #ttg.dot_op<{opIdx = 0, parent = #blocked}>> -> tensor<8x8xf16, #ttg.dot_op<{opIdx = 0, parent = #blocked}>>
+    tt.return
+  }
+}

--- a/third_party/amd/lib/TritonAMDGPUToLLVM/ConvertFpCastOpToLLVM.cpp
+++ b/third_party/amd/lib/TritonAMDGPUToLLVM/ConvertFpCastOpToLLVM.cpp
@@ -19,6 +19,7 @@
 #include "mlir/Dialect/LLVMIR/ROCDLDialect.h"
 #include "mlir/IR/BuiltinTypes.h"
 #include "mlir/IR/TypeUtilities.h"
+#include "third_party/amd/lib/TritonAMDGPUToLLVM/Utility.h"
 #include "triton/Analysis/Allocation.h"
 #include "triton/Conversion/TritonGPUToLLVM/ElementwiseOpToLLVMBase.h"
 #include "triton/Conversion/TritonGPUToLLVM/PatternTritonGPUOpToLLVM.h"
@@ -975,43 +976,19 @@ public:
   Value Fp8E4M3fnToFp16OneValue(Location loc,
                                 ConversionPatternRewriter &rewriter, Value v) {
     auto b = TritonLLVMOpBuilder(loc, rewriter);
-    auto fp8x2VecTy = vec_ty(i8_ty, 2);
-    Value a = b.undef(fp8x2VecTy);
-    a = b.insert_element(fp8x2VecTy, a, b.i8_val(0), b.i32_val(0));
-    a = b.insert_element(fp8x2VecTy, a, v, b.i32_val(1));
-    a = b.bitcast(a, i16_ty);
+    Value v8 = b.bitcast(v, i8_ty);
+    Value vAbs = b.and_(v8, b.i8_val(0x7F));
+    Value fp32 = mlir::LLVM::AMD::convertF8ToF32_SW(rewriter, loc, v8,
+                                                    /*isE4M3FN=*/true);
+    Value fp16 = b.fptrunc(f16_ty, fp32);
 
-    // Get sign and absolute value
-    Value sign = b.and_(a, b.i16_val(0x8000));
-    a = b.and_(a, b.i16_val(0x7FFF));
-
-    // Right shift 1 bit to adjust the positions of exponent and mantissa
-    a = b.lshr(a, b.i16_val(1));
-
-    // Adjust exponent, (15 - 7) << 10 === 0x2000
-    a = b.add(a, b.i16_val(0x2000));
-
-    // Check NaN
-    Value vAbs = b.and_(b.bitcast(v, i8_ty), b.i8_val(0x7F));
-    a = b.select(b.icmp_eq(vAbs, b.i8_val(0x7F)), b.i16_val(0x7E00), a);
-
-    // Check denorms and zero
-    // Here we use a LUT to map S.0000.000 ~ S.0000.111 to its corresponding
-    // fp16 value
-    constexpr size_t lutSize = 8;
-    static constexpr int denormsAndZeroLut[lutSize] = {
-        0x0000, 0x1800, 0x1C00, 0x1E00, 0x2000, 0x2100, 0x2200, 0x2300};
-
-    for (int i = 0; i < lutSize; i++) {
-      a = b.select(b.icmp_eq(vAbs, b.i8_val(i)),
-                   b.i16_val(denormsAndZeroLut[i]), a);
-    }
-
-    // Set sign
-    a = b.or_(a, sign);
-    a = b.bitcast(a, f16_ty);
-
-    return a;
+    // E4M3FN reserves magnitude 0x7f for NaN. The arithmetic conversion
+    // treats it as 480, so restore a signed canonical half NaN explicitly.
+    Value sign =
+        b.shl(b.zext(i16_ty, b.and_(v8, b.i8_val(0x80))), b.i16_val(8));
+    Value nanBits = b.or_(sign, b.i16_val(0x7E00));
+    Value nan = b.bitcast(nanBits, f16_ty);
+    return b.select(b.icmp_eq(vAbs, b.i8_val(0x7F)), nan, fp16);
   }
 
   // Ocp Fp8->Fp16


### PR DESCRIPTION
## Summary

Replace the AMD software E4M3FN-to-FP16 denormal lookup chain with the existing
arithmetic E4M3FN-to-FP32 helper followed by `fptrunc`. Preserve signed
canonical FP16 NaNs with one explicit select.

The old lowering emits one NaN select plus an eight-entry denormal LUT for each
scalar conversion. On targets without a native conversion path, that expands
into thousands of compares and conditional masks in FP8-storage / FP16-compute
kernels.

## What changed

- Reuse `convertF8ToF32_SW(..., isE4M3FN=true)` and truncate to FP16.
- Restore `+NaN=0x7e00` and `-NaN=0xfe00` explicitly because the arithmetic
  finite conversion maps magnitude `0x7f` to 480 before the fixup.
- Enable the existing exhaustive `float8e4nv -> float16` conversion test on
  RDNA3 and add a signed-NaN regression for AMD software paths.
- Add an AMD conversion lit test for gfx1100 and gfx942. It checks that eight
  values use eight NaN selects rather than eight LUT chains per value.

## Correctness

On a physical gfx1100 device with no architecture override:

- all 256 E4M3FN input bit patterns match the previous FP16 bit contract;
- the output-byte SHA-256 is identical between baseline and candidate:
  `26f6424f23eb8c679a0602789b1c0a77d61cd603245d021dd64cc7a38e7c3ed2`;
- the two exact upstream conversion tests pass;
- a non-divisible downstream `M1/N128/K384` block-FP8 GEMM tail is bitwise
  identical.

Full lit result: 293 discovered, 291 passed, 2 unsupported, 0 failed. The two
new architecture runs pass for gfx1100 and gfx942. I only have physical gfx1100
coverage; gfx942 coverage here is compile/lit coverage.

## Downstream performance

Hardware/software: Radeon PRO W7900D (`gfx1100`, 48 WGP), ROCm/HIP
7.2.53211, PyTorch 2.9.1 development build, Triton 3.8.0, no
`HSA_OVERRIDE_GFX_VERSION`.

The workload is a block-scaled E4M3FN GEMM with BF16 output at
`MxN1536xK4096`, using BM16/BN16/BK128, four warps and two stages. Each result
is an A/B/A/B cache-hit run with 20 warmups and 301 samples per run.

| M | baseline pooled p50 | candidate pooled p50 | speedup |
|---:|---:|---:|---:|
| 1 | 0.985734 ms | 0.258860 ms | 3.807979x |
| 8 | 0.979159 ms | 0.224160 ms | 4.368135x |
| 16 | 0.974818 ms | 0.223010 ms | 4.371187x |

The `M1/N128/K384` tail improves from 0.784929 ms to 0.355949 ms (2.205172x).
Fresh first-call speedups for M1/M8/M16 are 1.450028x/1.923388x/1.914407x.

M1 compiler output changes as follows:

| Metric | baseline | candidate |
|---|---:|---:|
| LLVM IR bytes | 796,325 | 223,843 |
| AMDGCN bytes | 786,187 | 369,439 |
| scalar selects | 4,636 | 28 |
| `v_cmp*` / `v_cndmask*` | 4,625 / 4,640 | 529 / 544 |
| SGPR / VGPR | 104 / 109 | 46 / 114 |
| native FP16 WMMA | 16 | 16 |
| private / scratch | 0 / 0 | 0 / 0 |

This does not add native FP8 matrix support to gfx1100. It makes the required
software upcast substantially cheaper before the unchanged FP16 WMMA body.

## Checks

- rebased on `triton-lang/triton@5df3c0406af851b23e203bb7bed6efa09b43da54`
- full wheel/C++ build: pass
- exact upstream pytest: 2 passed
- Triton lit: 291 passed, 2 unsupported
- Ruff, YAPF, clang-format and the other file hooks: pass
- mypy 1.15.0 under Python 3.12: no issues in 7 source files
- DCO sign-off: present

The complete pre-commit hook set was covered in two environments: all
file-oriented hooks via `pre-commit run --from-ref origin/main --to-ref HEAD`,
and the repository-pinned mypy 1.15.0 hook under the same Python 3.12 version
used by Triton's pre-commit CI. This avoids a Python 3.9-only typeshed error
that reproduces unchanged on both clean base and candidate.

# New contributor declaration

- [x] I am not making a trivial change, such as fixing a typo in a comment.

- [x] I have written a PR description following these
  [rules](https://cbea.ms/git-commit/#why-not-how).

- [x] I have run `pre-commit run --from-ref origin/main --to-ref HEAD`.

- Select one of the following.
  - [x] I have added tests.
    - `/test` for `lit` tests
    - `/unittest` for C++ tests
    - `/python/test` for end-to-end tests
  - [ ] This PR does not need a test because `FILL THIS IN`.

- Select one of the following.
  - [ ] I have not added any `lit` tests.
  - [x] The `lit` tests I have added follow these [best practices](https://mlir.llvm.org/getting_started/TestingGuide/#filecheck-best-practices),
    including the "tests should be minimal" section. (Usually running Python code
    and using the instructions it generates is not minimal.)
