### PR TITLE
[TEST] Bound large device-print output

### DIFF
--- a/python/test/unit/language/print_helper.py
+++ b/python/test/unit/language/print_helper.py
@@ -129,7 +129,9 @@ def test_print(func: str, data_type: str, device: str):
     elif func == "print":
         kernel_print[(1, )](x, y, num_warps=num_warps, BLOCK=N)
     elif func == "device_print_large":
-        kernel_device_print_large[(1, 2)](BLOCK_M=64, num_warps=num_warps, BLOCK_N=N)
+        # Each thread still prints 64 values, exercising the >32 argument case
+        # without overflowing CUDA's process-wide printf FIFO.
+        kernel_device_print_large[(1, )](BLOCK_M=64, num_warps=num_warps, BLOCK_N=N)
     elif func == "print_multiple_args":
         kernel_print_multiple_args[(1, )](x, y, num_warps=num_warps, BLOCK=N)
     elif func == "device_print_multiple_args":

--- a/python/test/unit/language/test_subprocess.py
+++ b/python/test/unit/language/test_subprocess.py
@@ -125,8 +125,8 @@ def test_print(func_type: str, data_type: str, device: str, capfd):
     elif func_type == "print_no_arg":
         expected_lines["pid (0, 0, 0) no arg"] = N
     elif func_type == "device_print_large":
-        for i, j, k in itertools.product(range(2), range(64), range(N)):
-            expected_lines[f"pid (0, {i}, 0) idx ({j:2}, {k:3}) x: 1"] = 1
+        for j, k in itertools.product(range(64), range(N)):
+            expected_lines[f"pid (0, 0, 0) idx ({j:2}, {k:3}) x: 1"] = 1
     elif func_type == "print_multiple_args" or func_type == "device_print_multiple_args":
         for i in range(N):
             expected_lines[f"pid (0, 0, 0) idx ({i:3}): (operand 0) {i}"] = 1


### PR DESCRIPTION
## Summary

- run the large CUDA device-print stress case as one program instead of two
- update the expected output for the single program ID
- keep `BLOCK_M=64`, so every thread still prints 64 values and exercises the historical greater-than-32-argument path

CUDA's `cudaLimitPrintfFifoSize` must be configured before any kernel using `printf` is launched. This parameterized test process has already exercised device printing by the time it reaches this case, so resizing the process-wide FIFO in shared test context would be invalid. Bounding the launched program count avoids overflowing the existing FIFO without changing global CUDA state or weakening the intended coverage.

This supersedes the CUDA device-print stress-test portion of #11243; the remaining changes in that PR are intentionally excluded.

## Testing

- `python -m pytest -s --tb=short python/test/unit/language/test_subprocess.py` (35 passed)