### PR TITLE
[Gluon] Disable unprofitable gather-index reuse in MXFP4 MoE configs

### DIFF
--- a/python/examples/gluon/05-moe-bmm1-fused-gather.py
+++ b/python/examples/gluon/05-moe-bmm1-fused-gather.py
@@ -991,7 +991,7 @@ def _select_mid64_config(slice_size: int) -> KernelConfig | None:
         OCCUPANCY=2,
     )
     if slice_size == 36:
-        return replace(p, ACC_NUM_BUFS=2, REUSE_GATHER_INDICES=True, INLINE_MMA_INPUT_RELEASE=True)
+        return replace(p, ACC_NUM_BUFS=2, INLINE_MMA_INPUT_RELEASE=True)
     if slice_size == 40:
         return replace(p, BAND_N=22, MAXNREG=56)
     if slice_size == 48:
@@ -999,7 +999,7 @@ def _select_mid64_config(slice_size: int) -> KernelConfig | None:
     if slice_size == 56:
         return replace(p, LOAD_ACTIVATION_REGS=72)
     if slice_size == 64:
-        return replace(p, X_GATHER_MULTICAST=False, W_SCALE_MULTICAST=False, REUSE_GATHER_INDICES=True)
+        return replace(p, X_GATHER_MULTICAST=False, W_SCALE_MULTICAST=False)
     if slice_size == 72:
         return p
     return None
@@ -1034,7 +1034,7 @@ def _select_high128_config(slice_size: int) -> KernelConfig | None:
     if slice_size == 384:
         return replace(p, LOAD_ACTIVATION_REGS=104)
     if slice_size == 416:
-        return replace(p, REUSE_GATHER_INDICES=True)
+        return p
     if slice_size == 448:
         return replace(p, BAND_N=22)
     if slice_size == 736:
@@ -1047,7 +1047,6 @@ def _select_high128_config(slice_size: int) -> KernelConfig | None:
             BAND_N=24,
             FORCE_EPILOGUE_WARPS_N1=False,
             W_SCALE_MULTICAST=False,
-            REUSE_GATHER_INDICES=True,
             INLINE_MMA_INPUT_RELEASE=True,
         )
     if slice_size == 960:


### PR DESCRIPTION
## What changed

Disable `REUSE_GATHER_INDICES` in the four MXFP4 MoE selector entries that explicitly enabled it, for expected slice sizes 36, 64, 416, and 896. All other tuning choices remain unchanged.

## Why

Index reuse avoids repeated gather-index loads, but it also retains the cached slice state and a `BLOCK_M`-element offset vector in the activation producer. On B200, that retained state and control overhead costs more than the saved loads for every selector entry that currently enables reuse.

## B200 results

Fresh run on SM100, 148 SMs, using 11 randomized rounds and 100 ms per variant per round:

| Expected slice | Reuse | No reuse | Speedup |
| ---: | ---: | ---: | ---: |
| 36 | 61.150 us | 60.739 us | 0.67% |
| 64 | 64.424 us | 63.902 us | 0.81% |
| 416 | 120.832 us | 120.123 us | 0.59% |
| 896 | 138.133 us | 134.955 us | 2.30% |

The geometric-mean speedup is 1.09%. No-reuse wins 42 of 44 paired rounds. Every comparison changes only `REUSE_GATHER_INDICES`, and all outputs are bit-identical.

The performance run used public source revision `c849d97684805e9bc4b5eb82f56e902d55c74ffb` with compiler revision `936f1a455de4549fc692d0191796e269034cde5f`. The four selector entries are unchanged in the current-main base of this PR, `58e1098c97a7353e75100e489fa6c8eae813d9b5`.

## Validation

- `pre-commit run --from-ref origin/main --to-ref HEAD`
- Bit-identical old-reuse and no-reuse outputs for all four affected shapes
- Randomized repeated B200 performance comparison with no unrelated GPU processes before or after timing

# New contributor declaration

- [x] I am not making a trivial change, such as fixing a typo in a comment.
- [x] I have written a PR description following the requested rules.
- [x] I have run `pre-commit run --from-ref origin/main --to-ref HEAD`.
- [x] This PR does not need a test because it changes only performance-tuning selections, with correctness and performance validation reported above.
- [x] I have not added any `lit` tests.
