### PR TITLE
[ConSan] Track compiler-owned scratch across function calls

### DIFF
--- a/include/triton/Dialect/TritonInstrument/IR/TritonInstrument.md
+++ b/include/triton/Dialect/TritonInstrument/IR/TritonInstrument.md
@@ -337,10 +337,10 @@ The common hook implementation covers these TritonGPU operations:
   descriptors because their indices are runtime values.
 - `ttg.local_alloc` with a source: barrier-tracked shared-memory write.
 - Any operation with allocator-provided operation-local shared scratch: a
-  synchronous generic-proxy write over its allocated byte interval. The
-  affected CTAs are derived from the operation's layout and target-specific
-  broadcast behavior. Forced warp-shuffle conversions publish no scratch
-  metadata because allocation reserves no scratch for them.
+  synchronous generic-proxy write over its allocated byte interval in its owning
+  CTA. Cross-CTA scratch reads follow intrinsic synchronization, and atomic
+  writes are issued only by producer CTAs. Forced warp-shuffle conversions
+  publish no scratch metadata because allocation reserves no scratch for them.
 - Function calls with allocator-provided virtual shared-memory frames: a
   synchronous generic-proxy write over the whole callee frame in the current
   CTA. This includes nested callees because each virtual frame is sized from

--- a/include/triton/Dialect/TritonInstrument/IR/TritonInstrument.md
+++ b/include/triton/Dialect/TritonInstrument/IR/TritonInstrument.md
@@ -15,11 +15,15 @@ implementation:
 - `cuda:*` uses the NVIDIA hooks.
 - `hip:*` uses the AMD hooks.
 
-ConSan currently supports one public entry point in the module. It uses
-BufferRegion analysis to collect exact shared-memory and tensor-memory address
-sets plus barrier allocations, then creates auxiliary state in distributed
-tensors and shared-cluster global scratch memory. Most scratch state is
-CTA-qualified so cluster and multicast effects can be modeled explicitly.
+ConSan instruments the module's one public entry point. It uses BufferRegion
+analysis to collect exact shared-memory and tensor-memory address sets plus
+barrier allocations, then creates auxiliary state in distributed tensors and
+shared-cluster global scratch memory. Calls from the entry point are summarized
+as accesses to their allocator-provided shared-memory frames; ConSan does not
+instrument non-entry function bodies. A non-entry function that contains
+effects outside this call-frame model is rejected with a diagnostic asking the
+compiler to inline it. Most scratch state is CTA-qualified so cluster and
+multicast effects can be modeled explicitly.
 
 ## Visibility Model
 
@@ -333,10 +337,15 @@ The common hook implementation covers these TritonGPU operations:
   descriptors because their indices are runtime values.
 - `ttg.local_alloc` with a source: barrier-tracked shared-memory write.
 - Any operation with allocator-provided operation-local shared scratch: a
-  synchronous generic-proxy write over its allocated byte interval. Forced
-  warp-shuffle conversions publish no scratch metadata because allocation
-  reserves no scratch for them; convert, reduce, and scratch-backed atomic
-  broadcasts use CTA-aware routing.
+  synchronous generic-proxy write over its allocated byte interval. The
+  affected CTAs are derived from the operation's layout and target-specific
+  broadcast behavior. Forced warp-shuffle conversions publish no scratch
+  metadata because allocation reserves no scratch for them.
+- Function calls with allocator-provided virtual shared-memory frames: a
+  synchronous generic-proxy write over the whole callee frame in the current
+  CTA. This includes nested callees because each virtual frame is sized from
+  the callee's peak shared-memory allocation. Callees requiring cross-CTA
+  scratch accesses must be inlined.
 
 These shared-memory effects are generic-proxy accesses for the proxy-ordering
 model.
@@ -385,4 +394,9 @@ AMD hooks additionally cover:
   commit flows where possible.
 - Global-memory race checking is handled by the separate global sanitizer, not
   by ConSan.
-- The pass expects exactly one public entry point in the module.
+- The pass expects exactly one public entry point in the module. Non-entry
+  functions may contain register and global-memory operations, calls, and
+  CTA-local compiler-owned shared scratch. Explicit shared/tensor-memory
+  allocations or accesses, cross-CTA scratch effects, barrier or asynchronous
+  state, warp specialization, and cluster barriers require inlining before
+  ConSan.

--- a/include/triton/Dialect/TritonInstrument/IR/Utility.h
+++ b/include/triton/Dialect/TritonInstrument/IR/Utility.h
@@ -238,8 +238,10 @@ struct AuxDataMap {
   RegionToValueMap commits[CommitKind::NumCommitKinds];
 
   // State-lane plans and analysis-derived runtime-base, state-mask, and CTA
-  // cases for each memdesc.
+  // cases for each memdesc. bufferRegions preserves the ordered region list
+  // used to build each plan so static scratch can select its mask directly.
   triton::BufferStatePlan bufferStatePlans[numMemTypes];
+  SmallVector<triton::BufferRegion> bufferRegions[numMemTypes];
   DenseMap<Value, BufferStateCandidates> bufferCandidates[numMemTypes];
 
   // Shared-memory state lanes occupied by each physical mbarrier. Virtual
@@ -278,6 +280,7 @@ struct AuxDataMap {
   bool hasAsyncProxyFenceTracking = false;
 
   LogicalResult populateAndPassToWarpSpecialize(ModuleOp module,
+                                                triton::FuncOp entryPoint,
                                                 FunctionBuilder &funcBuilder,
                                                 const ConSanTargetHooks &hooks);
 
@@ -285,7 +288,7 @@ struct AuxDataMap {
 
 private:
   LogicalResult
-  getBuffersAndBarriers(ModuleOp module,
+  getBuffersAndBarriers(ModuleOp module, triton::FuncOp entryPoint,
                         SmallVector<triton::BufferRegion> &barrierRegions,
                         const ConSanTargetHooks &hooks);
   void passToWarpSpecialize(triton::FuncOp func, ValueType value,

--- a/include/triton/Dialect/TritonInstrument/Transforms/ConSanTargetHooks.h
+++ b/include/triton/Dialect/TritonInstrument/Transforms/ConSanTargetHooks.h
@@ -6,7 +6,6 @@
 #include "triton/Analysis/BufferRegion.h"
 #include "triton/Dialect/TritonGPU/IR/Dialect.h"
 #include "triton/Dialect/TritonInstrument/IR/Utility.h"
-#include "llvm/ADT/APInt.h"
 #include <functional>
 #include <memory>
 #include <optional>
@@ -216,46 +215,13 @@ public:
 inline FailureOr<std::optional<MemEffectsOpInfo>>
 getConSanMemEffectsOpInfo(const ConSanTargetHooks &hooks, Operation *op) {
   std::optional<MemEffectsOpInfo> info = hooks.getMemEffectsOpInfo(op);
-  Attribute rawSize = op->getAttr("allocation.size");
-  if (!rawSize)
+  auto sizeAttr = op->getAttrOfType<IntegerAttr>("allocation.size");
+  if (!sizeAttr)
     return info;
 
-  auto size = dyn_cast<IntegerAttr>(rawSize);
-  auto offset = dyn_cast_or_null<IntegerAttr>(op->getAttr("allocation.offset"));
-  if (!size || !offset || !size.getType().isSignlessInteger() ||
-      !offset.getType().isSignlessInteger()) {
-    op->emitError("compiler scratch metadata requires integer "
-                  "allocation.offset and allocation.size attributes");
-    return failure();
-  }
-
-  constexpr uint64_t maxSharedMemorySize = uint64_t{1} << 24;
-  const llvm::APInt &offsetValue = offset.getValue();
-  const llvm::APInt &sizeValue = size.getValue();
-  bool valid = !offsetValue.isNegative() && !sizeValue.isNegative() &&
-               !sizeValue.isZero() && offsetValue.ule(maxSharedMemorySize) &&
-               sizeValue.ule(maxSharedMemorySize);
-  if (valid) {
-    uint64_t unsignedOffset = offsetValue.getZExtValue();
-    uint64_t unsignedSize = sizeValue.getZExtValue();
-    valid = unsignedSize <= maxSharedMemorySize - unsignedOffset;
-  }
-  if (!valid) {
-    InFlightDiagnostic diagnostic =
-        op->emitError("invalid compiler scratch allocation metadata: offset ");
-    if (offsetValue.getBitWidth() <= 64)
-      diagnostic << offset.getInt();
-    else
-      diagnostic << offset;
-    diagnostic << ", size ";
-    if (sizeValue.getBitWidth() <= 64)
-      diagnostic << size.getInt();
-    else
-      diagnostic << size;
-    diagnostic << "; the interval must be non-empty and fit in the "
-                  "24-bit shared-memory address space";
-    return failure();
-  }
+  uint32_t offset =
+      op->getAttrOfType<IntegerAttr>("allocation.offset").getInt();
+  uint32_t size = sizeAttr.getInt();
 
   if (!info)
     info.emplace();
@@ -271,10 +237,7 @@ getConSanMemEffectsOpInfo(const ConSanTargetHooks &hooks, Operation *op) {
   // conservative read/write summary for compiler-owned scratch.
   StringRef name = isa<CallOpInterface>(op) ? "Callee scratch" : "Scratch";
   info->operandEffects.emplace_back(
-      RW::Write,
-      MemEffectsOpInfo::Effects::StaticSharedBuffer{
-          static_cast<uint32_t>(offsetValue.getZExtValue()),
-          static_cast<uint32_t>(sizeValue.getZExtValue())},
+      RW::Write, MemEffectsOpInfo::Effects::StaticSharedBuffer{offset, size},
       name.str());
   return info;
 }

--- a/include/triton/Dialect/TritonInstrument/Transforms/ConSanTargetHooks.h
+++ b/include/triton/Dialect/TritonInstrument/Transforms/ConSanTargetHooks.h
@@ -212,7 +212,7 @@ public:
   virtual bool barrierWritesInvalidate() const { return false; }
 };
 
-inline FailureOr<std::optional<MemEffectsOpInfo>>
+inline std::optional<MemEffectsOpInfo>
 getConSanMemEffectsOpInfo(const ConSanTargetHooks &hooks, Operation *op) {
   std::optional<MemEffectsOpInfo> info = hooks.getMemEffectsOpInfo(op);
   auto sizeAttr = op->getAttrOfType<IntegerAttr>("allocation.size");
@@ -227,12 +227,10 @@ getConSanMemEffectsOpInfo(const ConSanTargetHooks &hooks, Operation *op) {
     info.emplace();
   if (info->trackingKind == MemEffectsOpInfo::TrackingKind::None)
     info->trackingKind = MemEffectsOpInfo::TrackingKind::Barrier;
-  if (info->trackingKind != MemEffectsOpInfo::TrackingKind::Barrier ||
-      info->implicitCommit) {
-    op->emitError("compiler scratch cannot be combined with "
-                  "asynchronous operation effect tracking");
-    return failure();
-  }
+  assert(info->trackingKind == MemEffectsOpInfo::TrackingKind::Barrier &&
+         !info->implicitCommit &&
+         "compiler scratch cannot be combined with asynchronous operation "
+         "effect tracking");
   // A ConSan write performs both read- and write-conflict checks, so it is the
   // conservative read/write summary for compiler-owned scratch.
   StringRef name = isa<CallOpInterface>(op) ? "Callee scratch" : "Scratch";

--- a/include/triton/Dialect/TritonInstrument/Transforms/ConSanTargetHooks.h
+++ b/include/triton/Dialect/TritonInstrument/Transforms/ConSanTargetHooks.h
@@ -155,13 +155,6 @@ public:
   virtual SmallVector<Operation *>
   createInitClusterBarrier(ImplicitLocOpBuilder &b) const = 0;
 
-  // Scratch-backed atomic results may be produced by one CTA and consumed by
-  // other CTAs in the same broadcast group.
-  virtual std::optional<uint16_t>
-  getScratchCTABroadcastMask(Operation *op) const {
-    return std::nullopt;
-  }
-
   // A call-frame summary cannot represent target-specific synchronization or
   // compiler scratch that crosses CTA boundaries.
   virtual bool hasUnsummarizableCalleeState(Operation *op) const {

--- a/include/triton/Dialect/TritonInstrument/Transforms/ConSanTargetHooks.h
+++ b/include/triton/Dialect/TritonInstrument/Transforms/ConSanTargetHooks.h
@@ -2,12 +2,15 @@
 #define TRITONINSTRUMENT_CONSAN_TARGET_HOOKS_H
 
 #include "mlir/IR/BuiltinOps.h"
+#include "mlir/Interfaces/CallInterfaces.h"
+#include "triton/Analysis/BufferRegion.h"
 #include "triton/Dialect/TritonGPU/IR/Dialect.h"
 #include "triton/Dialect/TritonInstrument/IR/Utility.h"
 #include <functional>
 #include <memory>
 #include <optional>
 #include <string>
+#include <variant>
 
 namespace mlir::triton::instrument {
 
@@ -30,16 +33,36 @@ struct MemEffectsOpInfo {
     EffectWrites,
   };
   struct Effects {
+    struct StaticSharedBuffer {
+      uint32_t offset;
+      uint32_t length;
+
+      triton::BufferRegion getRegion(unsigned numCTAs) const {
+        triton::BufferRegion region;
+        region.baseOffset = offset;
+        region.length = length;
+        for (unsigned cta = 0; cta < numCTAs; ++cta)
+          region.ctaAddresses.push_back(
+              {cta, triton::AddressSet::fromRange(offset, length)});
+        return region;
+      }
+    };
+
     RW rw;
     std::optional<gpu::SharedKind> sharedKind;
-    Value buf;
+    std::variant<Value, StaticSharedBuffer> buffer;
     std::string operandName = "";
     uint32_t length = 0;
 
     Effects(RW rw, Value buf, std::string operandName = "",
             std::optional<gpu::SharedKind> sharedKind = std::nullopt)
-        : rw(rw), sharedKind(sharedKind), buf(buf), operandName(operandName),
+        : rw(rw), sharedKind(sharedKind), buffer(buf), operandName(operandName),
           length(getMemDescLength(buf)) {}
+
+    Effects(RW rw, StaticSharedBuffer buffer,
+            std::string operandName = "Scratch")
+        : rw(rw), sharedKind(gpu::SharedKind::Generic), buffer(buffer),
+          operandName(operandName), length(buffer.length) {}
   };
   struct BarrierInfo {
     Value barrier;
@@ -126,6 +149,24 @@ public:
   virtual Value getIssuerCTAPred(ImplicitLocOpBuilder &b,
                                  Operation *op) const = 0;
 
+  // Publish shared-cluster state initialization through the target's native
+  // cluster rendezvous, which may consist of multiple operations.
+  virtual SmallVector<Operation *>
+  createInitClusterBarrier(ImplicitLocOpBuilder &b) const = 0;
+
+  // Scratch-backed atomic results may be produced by one CTA and consumed by
+  // other CTAs in the same broadcast group.
+  virtual std::optional<uint16_t>
+  getScratchCTABroadcastMask(Operation *op) const {
+    return std::nullopt;
+  }
+
+  // A call-frame summary cannot represent target-specific synchronization or
+  // compiler scratch that crosses CTA boundaries.
+  virtual bool hasUnsummarizableCalleeState(Operation *op) const {
+    return false;
+  }
+
   virtual std::optional<MemEffectsOpInfo>
   getMemEffectsOpInfo(Operation *op) const {
     namespace ttg = triton::gpu;
@@ -177,6 +218,31 @@ public:
   // AMD barriers are ordinary LDS objects and have no invalidate operation.
   virtual bool barrierWritesInvalidate() const { return false; }
 };
+
+inline std::optional<MemEffectsOpInfo>
+getConSanMemEffectsOpInfo(const ConSanTargetHooks &hooks, Operation *op) {
+  std::optional<MemEffectsOpInfo> info = hooks.getMemEffectsOpInfo(op);
+  auto size = op->getAttrOfType<IntegerAttr>("allocation.size");
+  if (!size)
+    return info;
+
+  auto offset = op->getAttrOfType<IntegerAttr>("allocation.offset");
+  assert(offset && "allocation.size requires allocation.offset");
+  if (!info)
+    info.emplace();
+  if (info->trackingKind == MemEffectsOpInfo::TrackingKind::None)
+    info->trackingKind = MemEffectsOpInfo::TrackingKind::Barrier;
+  // A ConSan write performs both read- and write-conflict checks, so it is the
+  // conservative read/write summary for compiler-owned scratch.
+  StringRef name = isa<CallOpInterface>(op) ? "Callee scratch" : "Scratch";
+  info->operandEffects.emplace_back(
+      RW::Write,
+      MemEffectsOpInfo::Effects::StaticSharedBuffer{
+          static_cast<uint32_t>(offset.getInt()),
+          static_cast<uint32_t>(size.getInt())},
+      name.str());
+  return info;
+}
 
 LogicalResult runConcurrencySanitizer(ModuleOp module,
                                       const ConSanTargetHooks &hooks);

--- a/include/triton/Dialect/TritonInstrument/Transforms/ConSanTargetHooks.h
+++ b/include/triton/Dialect/TritonInstrument/Transforms/ConSanTargetHooks.h
@@ -6,6 +6,7 @@
 #include "triton/Analysis/BufferRegion.h"
 #include "triton/Dialect/TritonGPU/IR/Dialect.h"
 #include "triton/Dialect/TritonInstrument/IR/Utility.h"
+#include "llvm/ADT/APInt.h"
 #include <functional>
 #include <memory>
 #include <optional>
@@ -219,27 +220,68 @@ public:
   virtual bool barrierWritesInvalidate() const { return false; }
 };
 
-inline std::optional<MemEffectsOpInfo>
+inline FailureOr<std::optional<MemEffectsOpInfo>>
 getConSanMemEffectsOpInfo(const ConSanTargetHooks &hooks, Operation *op) {
   std::optional<MemEffectsOpInfo> info = hooks.getMemEffectsOpInfo(op);
-  auto size = op->getAttrOfType<IntegerAttr>("allocation.size");
-  if (!size)
+  Attribute rawSize = op->getAttr("allocation.size");
+  if (!rawSize)
     return info;
 
-  auto offset = op->getAttrOfType<IntegerAttr>("allocation.offset");
-  assert(offset && "allocation.size requires allocation.offset");
+  auto size = dyn_cast<IntegerAttr>(rawSize);
+  auto offset = dyn_cast_or_null<IntegerAttr>(op->getAttr("allocation.offset"));
+  if (!size || !offset || !size.getType().isSignlessInteger() ||
+      !offset.getType().isSignlessInteger()) {
+    op->emitError("compiler scratch metadata requires integer "
+                  "allocation.offset and allocation.size attributes");
+    return failure();
+  }
+
+  constexpr uint64_t maxSharedMemorySize = uint64_t{1} << 24;
+  const llvm::APInt &offsetValue = offset.getValue();
+  const llvm::APInt &sizeValue = size.getValue();
+  bool valid = !offsetValue.isNegative() && !sizeValue.isNegative() &&
+               !sizeValue.isZero() && offsetValue.ule(maxSharedMemorySize) &&
+               sizeValue.ule(maxSharedMemorySize);
+  if (valid) {
+    uint64_t unsignedOffset = offsetValue.getZExtValue();
+    uint64_t unsignedSize = sizeValue.getZExtValue();
+    valid = unsignedSize <= maxSharedMemorySize - unsignedOffset;
+  }
+  if (!valid) {
+    InFlightDiagnostic diagnostic =
+        op->emitError("invalid compiler scratch allocation metadata: offset ");
+    if (offsetValue.getBitWidth() <= 64)
+      diagnostic << offset.getInt();
+    else
+      diagnostic << offset;
+    diagnostic << ", size ";
+    if (sizeValue.getBitWidth() <= 64)
+      diagnostic << size.getInt();
+    else
+      diagnostic << size;
+    diagnostic << "; the interval must be non-empty and fit in the "
+                  "24-bit shared-memory address space";
+    return failure();
+  }
+
   if (!info)
     info.emplace();
   if (info->trackingKind == MemEffectsOpInfo::TrackingKind::None)
     info->trackingKind = MemEffectsOpInfo::TrackingKind::Barrier;
+  if (info->trackingKind != MemEffectsOpInfo::TrackingKind::Barrier ||
+      info->implicitCommit) {
+    op->emitError("compiler scratch cannot be combined with "
+                  "asynchronous operation effect tracking");
+    return failure();
+  }
   // A ConSan write performs both read- and write-conflict checks, so it is the
   // conservative read/write summary for compiler-owned scratch.
   StringRef name = isa<CallOpInterface>(op) ? "Callee scratch" : "Scratch";
   info->operandEffects.emplace_back(
       RW::Write,
       MemEffectsOpInfo::Effects::StaticSharedBuffer{
-          static_cast<uint32_t>(offset.getInt()),
-          static_cast<uint32_t>(size.getInt())},
+          static_cast<uint32_t>(offsetValue.getZExtValue()),
+          static_cast<uint32_t>(sizeValue.getZExtValue())},
       name.str());
   return info;
 }

--- a/lib/Conversion/TritonGPUToLLVM/AllocateSharedMemoryUtility.cpp
+++ b/lib/Conversion/TritonGPUToLLVM/AllocateSharedMemoryUtility.cpp
@@ -14,11 +14,10 @@ void attachAllocationSizeAndOffsetAttr(ModuleOp mod,
       // Handle scratch buffers (from operations like convert_layout)
       auto oBufferId = funcAllocation->getBufferId(op);
       if (oBufferId != Allocation::InvalidBufferId) {
-        auto interval = funcAllocation->getAllocatedInterval(oBufferId);
-        int offset = interval.start();
+        int offset = funcAllocation->getOffset(oBufferId);
         op->setAttr("allocation.offset", IntegerAttr::get(i32Ty, offset));
         if (!isa<FunctionOpInterface>(op)) {
-          int size = interval.size();
+          int size = funcAllocation->getAllocatedSize(oBufferId);
           op->setAttr("allocation.size", IntegerAttr::get(i32Ty, size));
         }
         return;

--- a/lib/Conversion/TritonGPUToLLVM/AllocateSharedMemoryUtility.cpp
+++ b/lib/Conversion/TritonGPUToLLVM/AllocateSharedMemoryUtility.cpp
@@ -14,10 +14,11 @@ void attachAllocationSizeAndOffsetAttr(ModuleOp mod,
       // Handle scratch buffers (from operations like convert_layout)
       auto oBufferId = funcAllocation->getBufferId(op);
       if (oBufferId != Allocation::InvalidBufferId) {
-        int offset = funcAllocation->getOffset(oBufferId);
+        auto interval = funcAllocation->getAllocatedInterval(oBufferId);
+        int offset = interval.start();
         op->setAttr("allocation.offset", IntegerAttr::get(i32Ty, offset));
-        if (!funcAllocation->isVirtualBuffer(oBufferId)) {
-          int size = funcAllocation->getAllocatedSize(oBufferId);
+        if (!isa<FunctionOpInterface>(op)) {
+          int size = interval.size();
           op->setAttr("allocation.size", IntegerAttr::get(i32Ty, size));
         }
         return;

--- a/lib/Dialect/TritonInstrument/IR/Utility.cpp
+++ b/lib/Dialect/TritonInstrument/IR/Utility.cpp
@@ -391,14 +391,14 @@ FuncOp getEntryPoint(ModuleOp module) {
   return publicFuncs.front();
 }
 
-AuxDataMap::ThreadLayout getThreadLayout(ModuleOp module,
+AuxDataMap::ThreadLayout getThreadLayout(FuncOp entryPoint,
                                          const ConSanTargetHooks &hooks) {
   AuxDataMap::ThreadLayout layout;
   bool hasTMA = false;
   bool hasTC = false;
   bool hasCLC = false;
 
-  module.walk([&](Operation *op) {
+  entryPoint.walk([&](Operation *op) {
     if (auto wsOp = dyn_cast<WarpSpecializeOp>(op))
       layout.numBaseThreads = std::max<int>(
           layout.numBaseThreads, wsOp.getPartitionRegions().size() + 1);
@@ -471,21 +471,21 @@ Region *AuxDataMap::RegionToValueMap::getEnclosingParitionOrFunctionRegion(
   return nullptr;
 }
 
-LogicalResult AuxDataMap::populateAndPassToWarpSpecialize(
-    ModuleOp module, FunctionBuilder &fb, const ConSanTargetHooks &hooks) {
+LogicalResult
+AuxDataMap::populateAndPassToWarpSpecialize(ModuleOp module, FuncOp entryPoint,
+                                            FunctionBuilder &fb,
+                                            const ConSanTargetHooks &hooks) {
   SmallVector<BufferRegion> barrierRegions;
-  if (failed(getBuffersAndBarriers(module, barrierRegions, hooks)))
+  if (failed(getBuffersAndBarriers(module, entryPoint, barrierRegions, hooks)))
     return failure();
   int numCTAs = lookupNumCTAs(module);
-  threadLayout = getThreadLayout(module, hooks);
+  threadLayout = getThreadLayout(entryPoint, hooks);
   hasAsyncProxyFenceTracking =
       hooks.needsAsyncProxyFenceTracking(module) &&
       bufferStatePlans[(int)MemType::SHARED_MEM].numLanes != 0;
   int captureCounter = 0;
   int64_t captureBytes = 0;
 
-  FuncOp entryPoint = getEntryPoint(module);
-  assert(entryPoint);
   Region *entryRegion = &entryPoint.getBody();
 
   int numMBarriers = barrierRegions.size();
@@ -610,8 +610,11 @@ LogicalResult AuxDataMap::populateAndPassToWarpSpecialize(
       arith::CmpIOp::create(b, arith::CmpIPredicate::eq, ctaId, zero);
   ExperimentalLockReleaseOp::create(b, lockVal, isCTA0);
   if (numCTAs > 1) {
-    auto clusterBarrier = ClusterBarrierOp::create(b, b.getLoc());
-    internalClusterBarriers.push_back(clusterBarrier.getOperation());
+    SmallVector<Operation *> clusterBarriers =
+        hooks.createInitClusterBarrier(b);
+    assert(!clusterBarriers.empty() &&
+           "target must provide a cluster initialization barrier");
+    llvm::append_range(internalClusterBarriers, clusterBarriers);
   } else {
     BarrierOp::create(b, b.getLoc(), AddrSpace::Local);
   }
@@ -663,10 +666,11 @@ LogicalResult AuxDataMap::populateAndPassToWarpSpecialize(
 }
 
 LogicalResult
-AuxDataMap::getBuffersAndBarriers(ModuleOp module,
+AuxDataMap::getBuffersAndBarriers(ModuleOp module, FuncOp entryPoint,
                                   SmallVector<BufferRegion> &barrierRegions,
                                   const ConSanTargetHooks &hooks) {
-  // Collect shared memory buffers allocated in the module
+  // Run dataflow over the module so call edges resolve, then collect only the
+  // entrypoint regions that this ConSan invocation will instrument.
   std::unique_ptr<DataFlowSolver> solver = createDataFlowSolver();
   triton::BufferRegionAnalysis *analysis =
       solver->load<triton::BufferRegionAnalysis>();
@@ -697,11 +701,13 @@ AuxDataMap::getBuffersAndBarriers(ModuleOp module,
         pending.append({select.getTrueValue(), select.getFalseValue()});
     }
   };
-  module.walk([&](Operation *op) {
+  SmallVector<BufferRegion> staticSharedRegions;
+  unsigned numCTAs = lookupNumCTAs(module);
+  entryPoint.walk([&](Operation *op) {
     for (const MemoryAccess &access : getMemoryAccesses(op))
       collectCandidates(access.value);
 
-    auto info = hooks.getMemEffectsOpInfo(op);
+    auto info = getConSanMemEffectsOpInfo(hooks, op);
     if (!info)
       return;
     if (info->trackingKind == MemEffectsOpInfo::TrackingKind::CommitCount &&
@@ -711,9 +717,19 @@ AuxDataMap::getBuffersAndBarriers(ModuleOp module,
           [](const MemEffectsOpInfo::Effects &e) { return e.rw == RW::Read; });
     for (const auto &barrier : info->barriers)
       collectCandidates(barrier.barrier);
+    for (const auto &effect : info->operandEffects) {
+      if (auto *value = std::get_if<Value>(&effect.buffer)) {
+        collectCandidates(*value);
+      } else {
+        staticSharedRegions.push_back(
+            std::get<MemEffectsOpInfo::Effects::StaticSharedBuffer>(
+                effect.buffer)
+                .getRegion(numCTAs));
+      }
+    }
   });
 
-  analysis->calculateUsedBufferRegions(module);
+  analysis->calculateUsedBufferRegions(entryPoint);
   barrierRegions = analysis->getAllUsedBufferRegions(
       BufferRegionAnalysis::RegionType::BARRIER);
 
@@ -724,13 +740,18 @@ AuxDataMap::getBuffersAndBarriers(ModuleOp module,
                           : BufferRegionAnalysis::TENSOR_MEMORY;
     SmallVector<BufferRegion> regions =
         analysis->getAllUsedBufferRegions(regionType);
+    if (memType == MemType::SHARED_MEM)
+      llvm::append_range(regions, staticSharedRegions);
+    llvm::sort(regions);
+    regions.erase(std::unique(regions.begin(), regions.end()), regions.end());
     bool hasUnknown = analysis->hasUnknownUsedBufferRegions(regionType);
 
     if (regions.empty() && !hasUnknown)
       continue;
 
+    bufferRegions[iMemType] = regions;
     bufferStatePlans[iMemType] =
-        triton::createBufferStatePlan(regions, hasUnknown);
+        triton::createBufferStatePlan(bufferRegions[iMemType], hasUnknown);
 
     if (memType == MemType::SHARED_MEM) {
       for (const BufferRegion &barrier : barrierRegions) {

--- a/lib/Dialect/TritonInstrument/IR/Utility.cpp
+++ b/lib/Dialect/TritonInstrument/IR/Utility.cpp
@@ -703,16 +703,13 @@ AuxDataMap::getBuffersAndBarriers(ModuleOp module, FuncOp entryPoint,
   };
   SmallVector<BufferRegion> staticSharedRegions;
   unsigned numCTAs = lookupNumCTAs(module);
-  WalkResult result = entryPoint.walk([&](Operation *op) -> WalkResult {
+  entryPoint.walk([&](Operation *op) {
     for (const MemoryAccess &access : getMemoryAccesses(op))
       collectCandidates(access.value);
 
-    auto infoOr = getConSanMemEffectsOpInfo(hooks, op);
-    if (failed(infoOr))
-      return WalkResult::interrupt();
-    const auto &info = *infoOr;
+    auto info = getConSanMemEffectsOpInfo(hooks, op);
     if (!info)
-      return WalkResult::advance();
+      return;
     if (info->trackingKind == MemEffectsOpInfo::TrackingKind::CommitCount &&
         info->commitKind == CommitKind::AsyncCp)
       hasAsyncCopyReads |= llvm::any_of(
@@ -725,10 +722,7 @@ AuxDataMap::getBuffersAndBarriers(ModuleOp module, FuncOp entryPoint,
               std::get_if<MemEffectsOpInfo::Effects::StaticSharedBuffer>(
                   &effect.buffer))
         staticSharedRegions.push_back(buffer->getRegion(numCTAs));
-    return WalkResult::advance();
   });
-  if (result.wasInterrupted())
-    return failure();
 
   analysis->calculateUsedBufferRegions(entryPoint);
   barrierRegions = analysis->getAllUsedBufferRegions(

--- a/lib/Dialect/TritonInstrument/IR/Utility.cpp
+++ b/lib/Dialect/TritonInstrument/IR/Utility.cpp
@@ -720,16 +720,11 @@ AuxDataMap::getBuffersAndBarriers(ModuleOp module, FuncOp entryPoint,
           [](const MemEffectsOpInfo::Effects &e) { return e.rw == RW::Read; });
     for (const auto &barrier : info->barriers)
       collectCandidates(barrier.barrier);
-    for (const auto &effect : info->operandEffects) {
-      if (auto *value = std::get_if<Value>(&effect.buffer)) {
-        collectCandidates(*value);
-      } else {
-        staticSharedRegions.push_back(
-            std::get<MemEffectsOpInfo::Effects::StaticSharedBuffer>(
-                effect.buffer)
-                .getRegion(numCTAs));
-      }
-    }
+    for (const auto &effect : info->operandEffects)
+      if (auto *buffer =
+              std::get_if<MemEffectsOpInfo::Effects::StaticSharedBuffer>(
+                  &effect.buffer))
+        staticSharedRegions.push_back(buffer->getRegion(numCTAs));
     return WalkResult::advance();
   });
   if (result.wasInterrupted())

--- a/lib/Dialect/TritonInstrument/IR/Utility.cpp
+++ b/lib/Dialect/TritonInstrument/IR/Utility.cpp
@@ -703,13 +703,16 @@ AuxDataMap::getBuffersAndBarriers(ModuleOp module, FuncOp entryPoint,
   };
   SmallVector<BufferRegion> staticSharedRegions;
   unsigned numCTAs = lookupNumCTAs(module);
-  entryPoint.walk([&](Operation *op) {
+  WalkResult result = entryPoint.walk([&](Operation *op) -> WalkResult {
     for (const MemoryAccess &access : getMemoryAccesses(op))
       collectCandidates(access.value);
 
-    auto info = getConSanMemEffectsOpInfo(hooks, op);
+    auto infoOr = getConSanMemEffectsOpInfo(hooks, op);
+    if (failed(infoOr))
+      return WalkResult::interrupt();
+    const auto &info = *infoOr;
     if (!info)
-      return;
+      return WalkResult::advance();
     if (info->trackingKind == MemEffectsOpInfo::TrackingKind::CommitCount &&
         info->commitKind == CommitKind::AsyncCp)
       hasAsyncCopyReads |= llvm::any_of(
@@ -727,7 +730,10 @@ AuxDataMap::getBuffersAndBarriers(ModuleOp module, FuncOp entryPoint,
                 .getRegion(numCTAs));
       }
     }
+    return WalkResult::advance();
   });
+  if (result.wasInterrupted())
+    return failure();
 
   analysis->calculateUsedBufferRegions(entryPoint);
   barrierRegions = analysis->getAllUsedBufferRegions(

--- a/lib/Dialect/TritonInstrument/Transforms/ConcurrencySanitizer.cpp
+++ b/lib/Dialect/TritonInstrument/Transforms/ConcurrencySanitizer.cpp
@@ -248,28 +248,6 @@ FailureOr<Value> createBufferStateMask(ImplicitLocOpBuilder &b,
   return result;
 }
 
-FailureOr<Value> createStaticBufferStateMask(
-    ImplicitLocOpBuilder &b, AuxDataMap &auxData,
-    const MemEffectsOpInfo::Effects::StaticSharedBuffer &buffer,
-    Operation *op) {
-  int index = static_cast<int>(MemType::SHARED_MEM);
-  const auto &regions = auxData.bufferRegions[index];
-  BufferRegion region = buffer.getRegion(ttg::lookupNumCTAs(op));
-  auto it = llvm::lower_bound(regions, region);
-  if (it == regions.end() || !(*it == region)) {
-    op->emitError("static shared-memory region is absent from the ConSan "
-                  "registry");
-    return failure();
-  }
-  unsigned id = std::distance(regions.begin(), it);
-  const BufferStatePlan &plan = auxData.bufferStatePlans[index];
-  auto writeVisibilityType =
-      cast<RankedTensorType>(auxData.writeVisibility[index].at(op).type);
-  RankedTensorType maskType =
-      tti::getSlicedTensorType(writeVisibilityType, {1}, b.getI1Type());
-  return createStateMaskConstant(b, maskType, plan.regionMasks[id]);
-}
-
 Value allCTAsMask(ImplicitLocOpBuilder &b) {
   int numCTAs = ttg::lookupNumCTAs(b);
   assert(numCTAs <= 16 && "ConSan CTA bitsets assume at most 16 CTAs");
@@ -1335,32 +1313,31 @@ private:
     auto materializeStaticBuffer =
         [&](const MemEffectsOpInfo::Effects::StaticSharedBuffer &buffer,
             bool selectBarrierStorage) -> FailureOr<MaterializedEffect> {
+      int index = static_cast<int>(MemType::SHARED_MEM);
+      const auto &regions = auxData.bufferRegions[index];
+      BufferRegion region = buffer.getRegion(ttg::lookupNumCTAs(op));
+      auto it = llvm::lower_bound(regions, region);
+      if (it == regions.end() || !(*it == region)) {
+        op->emitError("static shared-memory region is absent from the ConSan "
+                      "registry");
+        return failure();
+      }
+      unsigned id = std::distance(regions.begin(), it);
+      const llvm::SmallBitVector &stateMask =
+          auxData.bufferStatePlans[index].regionMasks[id];
+      auto writeVisibilityType =
+          cast<RankedTensorType>(auxData.writeVisibility[index].at(op).type);
+      RankedTensorType maskType =
+          tti::getSlicedTensorType(writeVisibilityType, {1}, b.getI1Type());
+
       MaterializedEffect materialized;
       materialized.memType = MemType::SHARED_MEM;
-      FailureOr<Value> stateMask =
-          createStaticBufferStateMask(b, auxData, buffer, op);
-      if (failed(stateMask))
-        return failure();
-      materialized.bufferMask = *stateMask;
+      materialized.bufferMask = createStateMaskConstant(b, maskType, stateMask);
       // Scratch stores target the issuing CTA; cross-CTA consumers read after
       // intrinsic synchronization.
       materialized.effectCTAs = currentCTAMask(b);
-
-      if (selectBarrierStorage && !auxData.barrierBufferMasks.empty()) {
-        int index = static_cast<int>(MemType::SHARED_MEM);
-        const auto &regions = auxData.bufferRegions[index];
-        BufferRegion region = buffer.getRegion(ttg::lookupNumCTAs(op));
-        auto it = llvm::lower_bound(regions, region);
-        if (it == regions.end() || !(*it == region)) {
-          op->emitError("static shared-memory region is absent from the ConSan "
-                        "registry");
-          return failure();
-        }
-        unsigned id = std::distance(regions.begin(), it);
-        addBarrierOwners(materialized,
-                         auxData.bufferStatePlans[index].regionMasks[id],
-                         materialized.effectCTAs, selectBarrierStorage);
-      }
+      addBarrierOwners(materialized, stateMask, materialized.effectCTAs,
+                       selectBarrierStorage);
       return materialized;
     };
 

--- a/lib/Dialect/TritonInstrument/Transforms/ConcurrencySanitizer.cpp
+++ b/lib/Dialect/TritonInstrument/Transforms/ConcurrencySanitizer.cpp
@@ -1262,7 +1262,8 @@ private:
     auto addBarrierOwners = [&](MaterializedEffect &materialized,
                                 const llvm::SmallBitVector &bufferMask,
                                 Value ownerCTAs, bool selectBarrierStorage) {
-      if (!selectBarrierStorage || materialized.memType != MemType::SHARED_MEM ||
+      if (!selectBarrierStorage ||
+          materialized.memType != MemType::SHARED_MEM ||
           auxData.barrierBufferMasks.empty())
         return;
 

--- a/lib/Dialect/TritonInstrument/Transforms/ConcurrencySanitizer.cpp
+++ b/lib/Dialect/TritonInstrument/Transforms/ConcurrencySanitizer.cpp
@@ -1,6 +1,9 @@
 #include "mlir/Analysis/SliceAnalysis.h"
 #include "mlir/IR/ImplicitLocOpBuilder.h"
 #include "mlir/IR/Matchers.h"
+#include "mlir/IR/SymbolTable.h"
+#include "mlir/Interfaces/CallInterfaces.h"
+#include "mlir/Interfaces/SideEffectInterfaces.h"
 #include "mlir/Transforms/Passes.h"
 #include "triton/Dialect/Triton/IR/Utility.h"
 #include "triton/Dialect/TritonGPU/IR/Dialect.h"
@@ -12,6 +15,7 @@
 #include "triton/Dialect/TritonNvidiaGPU/IR/Dialect.h"
 #include "triton/Tools/LayoutUtils.h"
 #include "triton/Tools/Sys/GetEnv.h"
+#include "llvm/ADT/DenseSet.h"
 
 namespace mlir {
 namespace triton {
@@ -242,6 +246,28 @@ FailureOr<Value> createBufferStateMask(ImplicitLocOpBuilder &b,
     result = arith::OrIOp::create(b, result, candidate);
   }
   return result;
+}
+
+FailureOr<Value> createStaticBufferStateMask(
+    ImplicitLocOpBuilder &b, AuxDataMap &auxData,
+    const MemEffectsOpInfo::Effects::StaticSharedBuffer &buffer,
+    Operation *op) {
+  int index = static_cast<int>(MemType::SHARED_MEM);
+  const auto &regions = auxData.bufferRegions[index];
+  BufferRegion region = buffer.getRegion(ttg::lookupNumCTAs(op));
+  auto it = llvm::lower_bound(regions, region);
+  if (it == regions.end() || !(*it == region)) {
+    op->emitError("static shared-memory region is absent from the ConSan "
+                  "registry");
+    return failure();
+  }
+  unsigned id = std::distance(regions.begin(), it);
+  const BufferStatePlan &plan = auxData.bufferStatePlans[index];
+  auto writeVisibilityType =
+      cast<RankedTensorType>(auxData.writeVisibility[index].at(op).type);
+  RankedTensorType maskType =
+      tti::getSlicedTensorType(writeVisibilityType, {1}, b.getI1Type());
+  return createStateMaskConstant(b, maskType, plan.regionMasks[id]);
 }
 
 Value allCTAsMask(ImplicitLocOpBuilder &b) {
@@ -619,6 +645,38 @@ Value getLocalLoadStoreRecipientCTAs(ImplicitLocOpBuilder &b,
       b, getLocalLoadStoreConversion(memDescTy, regTy));
 }
 
+Value getScratchEffectCTAs(ImplicitLocOpBuilder &b, Operation *op,
+                           const ConSanTargetHooks &hooks) {
+  if (isa<CallOpInterface>(op)) {
+    // Non-entry validation ensures every scratch operation in the callee and
+    // its nested callees accesses only the issuing CTA's virtual frame.
+    return currentCTAMask(b);
+  }
+
+  if (auto convert = dyn_cast<ttg::ConvertLayoutOp>(op)) {
+    // Conversion stores remain CTA-local, but the source-owned scratch may be
+    // read by other CTAs when the source and destination block layouts differ.
+    LinearLayout srcLayout = ttg::toLinearLayout(convert.getSrc().getType());
+    LinearLayout dstLayout = ttg::toLinearLayout(convert.getType());
+    Value loadCTAs = getLocalMemoryRecipientCTAs(
+        b, invertAndComposeBlockLocal(srcLayout, dstLayout));
+    return arith::OrIOp::create(b, currentCTAMask(b), loadCTAs);
+  }
+
+  if (auto reduce = dyn_cast<tt::ReduceOp>(op)) {
+    auto srcType = reduce.getInputTypes()[0];
+    if (ttg::getCTASplitNum(srcType.getEncoding())[reduce.getAxis()] != 1)
+      return allCTAsMask(b);
+    return currentCTAMask(b);
+  }
+
+  if (auto broadcastMask = hooks.getScratchCTABroadcastMask(op)) {
+    if (*broadcastMask)
+      return getRecipientCTAsForBroadcastMasks(b, {*broadcastMask});
+  }
+  return currentCTAMask(b);
+}
+
 Value getMemEffectCTAs(ImplicitLocOpBuilder &b, Operation *op) {
   if (auto load = dyn_cast<ttg::LocalLoadOp>(op)) {
     return getLocalLoadStoreRecipientCTAs(b, load.getSrc().getType(),
@@ -740,12 +798,28 @@ public:
       : module(module), hooks(hooks) {}
 
   LogicalResult run() {
-    tti::FunctionBuilder funcBuilder(module, auxData);
-    if (failed(auxData.populateAndPassToWarpSpecialize(module, funcBuilder,
-                                                       hooks)))
+    SmallVector<tt::FuncOp> publicFuncs =
+        llvm::to_vector(llvm::make_filter_range(
+            module.getOps<tt::FuncOp>(),
+            [](tt::FuncOp func) { return func.isPublic(); }));
+    if (publicFuncs.size() != 1) {
+      module.emitError(
+          "ConSan requires exactly one public entrypoint function; "
+          "found ")
+          << publicFuncs.size();
+      return failure();
+    }
+    entryPoint = publicFuncs.front();
+    SmallVector<tt::FuncOp> reachableFunctions;
+    if (failed(collectReachableFunctions(reachableFunctions)) ||
+        failed(validateScratchMetadata(reachableFunctions)) ||
+        failed(validateNonEntryFunctions(reachableFunctions)))
       return failure();
 
-    tt::FuncOp entryPoint = tti::getEntryPoint(module);
+    tti::FunctionBuilder funcBuilder(module, auxData);
+    if (failed(auxData.populateAndPassToWarpSpecialize(module, entryPoint,
+                                                       funcBuilder, hooks)))
+      return failure();
 
     ImplicitLocOpBuilder b(entryPoint.getLoc(), entryPoint);
     b.setInsertionPointToStart(&entryPoint.getBody().front());
@@ -756,12 +830,211 @@ public:
   }
 
 private:
+  LogicalResult
+  collectReachableFunctions(SmallVectorImpl<tt::FuncOp> &reachableFunctions) {
+    if (entryPoint.isExternal()) {
+      entryPoint.emitError("ConSan entrypoint must have a function body");
+      return failure();
+    }
+
+    SymbolTableCollection symbolTable;
+    DenseSet<Operation *> visited;
+    SmallVector<tt::FuncOp> worklist{entryPoint};
+    visited.insert(entryPoint.getOperation());
+
+    while (!worklist.empty()) {
+      tt::FuncOp func = worklist.pop_back_val();
+      reachableFunctions.push_back(func);
+      WalkResult result = func.walk([&](CallOpInterface call) -> WalkResult {
+        Operation *resolved = call.resolveCallableInTable(&symbolTable);
+        tt::FuncOp callee = dyn_cast_or_null<tt::FuncOp>(resolved);
+        if (!callee || callee.isExternal()) {
+          call->emitError("ConSan cannot summarize an unresolved or external "
+                          "callee in function @")
+              << func.getName();
+          return WalkResult::interrupt();
+        }
+        if (visited.insert(callee.getOperation()).second)
+          worklist.push_back(callee);
+        return WalkResult::advance();
+      });
+      if (result.wasInterrupted())
+        return failure();
+    }
+    return success();
+  }
+
+  LogicalResult
+  validateScratchMetadata(ArrayRef<tt::FuncOp> reachableFunctions) {
+    constexpr uint64_t maxSharedMemorySize = uint64_t{1} << 24;
+    for (tt::FuncOp func : reachableFunctions) {
+      WalkResult result = func.walk([&](Operation *op) -> WalkResult {
+        Attribute rawSize = op->getAttr("allocation.size");
+        if (!rawSize)
+          return WalkResult::advance();
+
+        auto size = dyn_cast<IntegerAttr>(rawSize);
+        auto offset =
+            dyn_cast_or_null<IntegerAttr>(op->getAttr("allocation.offset"));
+        if (!size || !offset || !size.getType().isSignlessInteger() ||
+            !offset.getType().isSignlessInteger()) {
+          op->emitError("compiler scratch metadata requires integer "
+                        "allocation.offset and allocation.size attributes");
+          return WalkResult::interrupt();
+        }
+
+        const APInt &offsetValue = offset.getValue();
+        const APInt &sizeValue = size.getValue();
+        bool valid = !offsetValue.isNegative() && !sizeValue.isNegative() &&
+                     !sizeValue.isZero() &&
+                     offsetValue.ule(maxSharedMemorySize) &&
+                     sizeValue.ule(maxSharedMemorySize);
+        if (valid) {
+          uint64_t unsignedOffset = offsetValue.getZExtValue();
+          uint64_t unsignedSize = sizeValue.getZExtValue();
+          valid = unsignedSize <= maxSharedMemorySize - unsignedOffset;
+        }
+        if (!valid) {
+          InFlightDiagnostic diagnostic =
+              op->emitError("invalid compiler scratch allocation metadata: "
+                            "offset ");
+          if (offsetValue.getBitWidth() <= 64)
+            diagnostic << offset.getInt();
+          else
+            diagnostic << offset;
+          diagnostic << ", size ";
+          if (sizeValue.getBitWidth() <= 64)
+            diagnostic << size.getInt();
+          else
+            diagnostic << size;
+          diagnostic << "; the interval must be non-empty and fit in the "
+                        "24-bit shared-memory address space";
+          return WalkResult::interrupt();
+        }
+
+        if (auto info = hooks.getMemEffectsOpInfo(op)) {
+          bool hasSynchronousTracking =
+              info->trackingKind == MemEffectsOpInfo::TrackingKind::None ||
+              info->trackingKind == MemEffectsOpInfo::TrackingKind::Barrier;
+          if (!hasSynchronousTracking || info->implicitCommit) {
+            op->emitError("compiler scratch cannot be combined with "
+                          "asynchronous operation effect tracking");
+            return WalkResult::interrupt();
+          }
+        }
+        return WalkResult::advance();
+      });
+      if (result.wasInterrupted())
+        return failure();
+    }
+    return success();
+  }
+
+  bool isCTALocalScratch(Operation *op) const {
+    if (!op->hasAttr("allocation.size") || ttg::lookupNumCTAs(op) == 1)
+      return true;
+
+    if (auto convert = dyn_cast<ttg::ConvertLayoutOp>(op)) {
+      RankedTensorType srcType = convert.getSrc().getType();
+      RankedTensorType dstType = convert.getType();
+      if (!srcType.getEncoding() || !dstType.getEncoding())
+        return false;
+      StringAttr block = StringAttr::get(op->getContext(), "block");
+      return invertAndComposeBlockLocal(ttg::toLinearLayout(srcType),
+                                        ttg::toLinearLayout(dstType))
+          .isIdentityOnOutDim(block);
+    }
+
+    if (auto reduce = dyn_cast<tt::ReduceOp>(op)) {
+      SmallVector<RankedTensorType> inputs = reduce.getInputTypes();
+      if (inputs.empty() || !inputs.front().getEncoding())
+        return false;
+      SmallVector<unsigned> splits =
+          ttg::getCTASplitNum(inputs.front().getEncoding());
+      unsigned axis = reduce.getAxis();
+      return axis < splits.size() && splits[axis] == 1;
+    }
+
+    return true;
+  }
+
+  // Non-entry bodies are not instrumented. Their compiler-owned shared memory
+  // is covered by the virtual frame on each call, but SSA-visible memory and
+  // sanitizer state transitions cannot be represented by that summary.
+  LogicalResult
+  validateNonEntryFunctions(ArrayRef<tt::FuncOp> reachableFunctions) {
+    AuxDataMap emptyAuxData;
+    for (tt::FuncOp func : reachableFunctions) {
+      if (func == entryPoint)
+        continue;
+      WalkResult result = func.walk([&](Operation *op) -> WalkResult {
+        if (op == func.getOperation() || isa<CallOpInterface>(op))
+          return WalkResult::advance();
+
+        bool hasUnsupportedAllocation =
+            isa<ttg::LocalAllocOp, ttng::TMEMAllocOp>(op);
+        bool hasOpaqueEffects =
+            !isa<ttg::BarrierOp>(op) && hasUnknownEffects(op);
+        bool hasUnsupportedResource = false;
+        if (auto memoryEffects = dyn_cast<MemoryEffectOpInterface>(op)) {
+          SmallVector<MemoryEffects::EffectInstance> effects;
+          memoryEffects.getEffects(effects);
+          hasUnsupportedResource = llvm::any_of(
+              effects, [op](const MemoryEffects::EffectInstance &effect) {
+                if (effect.getResource() == tt::GlobalMemory::get())
+                  return false;
+                // Volatile global loads publish a synthetic default-resource
+                // write only to prevent compiler reordering.
+                auto load = dyn_cast<tt::LoadOp>(op);
+                return !(load && load.getIsVolatile() &&
+                         isa<MemoryEffects::Write>(effect.getEffect()) &&
+                         effect.getResource() ==
+                             SideEffects::DefaultResource::get());
+              });
+        }
+
+        auto info = hooks.getMemEffectsOpInfo(op);
+        bool hasMemoryState =
+            info && (!info->operandEffects.empty() || !info->barriers.empty() ||
+                     info->implicitCommit);
+        bool hasBarrierState = hooks.getBarrierInitInfo(op) ||
+                               hooks.getBarrierWaitInfo(op) ||
+                               hooks.getBarrierInvalidateInfo(op) ||
+                               isa<ttg::MBarrierOpInterface>(op);
+        bool hasAsyncState =
+            hooks.getAsyncProxyFenceInfo(op) ||
+            hooks.getWaitOpInfo(op, emptyAuxData) ||
+            op->hasTrait<OpTrait::MemWaitOpTrait>() ||
+            isa<ttg::AsyncCommitGroupOp, ttng::WarpGroupDotWaitOp,
+                ttg::AsyncWaitOp>(op);
+        bool hasControlState =
+            isa<ttg::WarpSpecializeOp, ttg::WarpSpecializePartitionsOp,
+                ttng::ClusterBarrierOp>(op) ||
+            hooks.hasUnsummarizableCalleeState(op);
+        if (!hasUnsupportedAllocation && !hasOpaqueEffects &&
+            !hasUnsupportedResource && !hasMemoryState && !hasBarrierState &&
+            !hasAsyncState && !hasControlState && isCTALocalScratch(op))
+          return WalkResult::advance();
+
+        op->emitError("ConSan cannot summarize ")
+            << op->getName() << " in non-entry function @" << func.getName()
+            << "; inline the function before ConSan or keep its body limited "
+               "to register/global-memory operations and compiler-owned "
+               "shared scratch";
+        return WalkResult::interrupt();
+      });
+      if (result.wasInterrupted())
+        return failure();
+    }
+    return success();
+  }
+
   void initializeAllocations() {
     if (!shouldInitializeAllocations())
       return;
 
     SmallVector<Operation *> allocationsToInitialize;
-    module.walk([&](Operation *op) {
+    entryPoint.walk([&](Operation *op) {
       if (auto alloc = dyn_cast<ttg::LocalAllocOp>(op)) {
         if (!alloc.getSrc())
           allocationsToInitialize.push_back(op);
@@ -790,7 +1063,7 @@ private:
   LogicalResult instrumentMemoryOperations(ImplicitLocOpBuilder &b,
                                            tti::FunctionBuilder &funcBuilder) {
     SmallVector<ttng::ClusterBarrierOp> clusterBarriers;
-    WalkResult walkResult = module.walk([&](Operation *op) -> WalkResult {
+    WalkResult walkResult = entryPoint.walk([&](Operation *op) -> WalkResult {
       CriticalSectionListener listener;
       b.setListener(&listener);
 
@@ -940,8 +1213,7 @@ private:
           b.setListener(&listener);
         }
       }
-      if (isa<tt::ReturnOp>(op) && !auxData.activeMasks.empty() &&
-          op->getParentOfType<tt::FuncOp>() == tti::getEntryPoint(module)) {
+      if (isa<tt::ReturnOp>(op) && !auxData.activeMasks.empty()) {
         b.setListener(nullptr);
         Value lock = auxData.lock.at(op).value;
         Value trueVal = arith::ConstantIntOp::create(b, 1, 1);
@@ -1013,7 +1285,8 @@ private:
                                      int thread,
                                      tti::FunctionBuilder &funcBuilder) {
     int baseThread = getBaseThread(thread, auxData.threadLayout);
-    std::optional<MemEffectsOpInfo> opInfo = hooks.getMemEffectsOpInfo(op);
+    std::optional<MemEffectsOpInfo> opInfo =
+        getConSanMemEffectsOpInfo(hooks, op);
     for (const MemoryAccess &access :
          getMemoryAccesses(op, ttg::SharedKind::Barrier)) {
       if (opInfo && llvm::any_of(opInfo->barriers, [&](const auto &barrier) {
@@ -1040,6 +1313,38 @@ private:
     };
     SmallVector<MaterializedEffect> materializedEffects;
     materializedEffects.reserve(opInfo->operandEffects.size());
+
+    auto addBarrierOwners = [&](MaterializedEffect &materialized,
+                                const llvm::SmallBitVector &bufferMask,
+                                Value ownerCTAs, bool selectBarrierStorage) {
+      if (!selectBarrierStorage || materialized.memType != MemType::SHARED_MEM ||
+          auxData.barrierBufferMasks.empty())
+        return;
+
+      auto barrierStatesType =
+          cast<RankedTensorType>(auxData.barrierStates.at(op).type);
+      RankedTensorType barrierMaskType =
+          tti::getSlicedTensorType(barrierStatesType, {1}, b.getI1Type());
+      RankedTensorType barrierOwnersType =
+          cast<RankedTensorType>(barrierMaskType.clone(b.getI32Type()));
+      llvm::SmallBitVector overlaps(barrierMaskType.getNumElements());
+      for (auto [index, barrierMask] :
+           llvm::enumerate(auxData.barrierBufferMasks))
+        if (bufferMask.anyCommon(barrierMask))
+          overlaps.set(index);
+      if (overlaps.none())
+        return;
+
+      Value selected = createStateMaskConstant(b, barrierMaskType, overlaps);
+      Value owners = tt::SplatOp::create(b, barrierOwnersType, ownerCTAs);
+      Value zero =
+          tti::createConstIntTensor(b, b.getLoc(), 0, barrierOwnersType);
+      owners = arith::SelectOp::create(b, selected, owners, zero);
+      materialized.barrierCTAs =
+          materialized.barrierCTAs
+              ? arith::OrIOp::create(b, materialized.barrierCTAs, owners)
+              : owners;
+    };
 
     auto materializeBuffer =
         [&](Value buf, Value recipients,
@@ -1068,46 +1373,12 @@ private:
         return failure();
       materialized.bufferMask = *stateMask;
 
-      bool selectBarriers = selectBarrierStorage &&
-                            materialized.memType == MemType::SHARED_MEM &&
-                            !auxData.barrierBufferMasks.empty();
-      RankedTensorType barrierMaskType;
-      RankedTensorType barrierOwnersType;
-      if (selectBarriers) {
-        auto barrierStatesType =
-            cast<RankedTensorType>(auxData.barrierStates.at(op).type);
-        barrierMaskType =
-            tti::getSlicedTensorType(barrierStatesType, {1}, b.getI1Type());
-        barrierOwnersType =
-            cast<RankedTensorType>(barrierMaskType.clone(b.getI32Type()));
-      }
-      auto addBarrierOwners = [&](const llvm::SmallBitVector &bufferMask,
-                                  Value ownerCTAs) {
-        if (!selectBarriers)
-          return;
-        llvm::SmallBitVector overlaps(barrierMaskType.getNumElements());
-        for (auto [index, barrierMask] :
-             llvm::enumerate(auxData.barrierBufferMasks))
-          if (bufferMask.anyCommon(barrierMask))
-            overlaps.set(index);
-        if (overlaps.none())
-          return;
-        Value selected = createStateMaskConstant(b, barrierMaskType, overlaps);
-        Value owners = tt::SplatOp::create(b, barrierOwnersType, ownerCTAs);
-        Value zero =
-            tti::createConstIntTensor(b, b.getLoc(), 0, barrierOwnersType);
-        owners = arith::SelectOp::create(b, selected, owners, zero);
-        materialized.barrierCTAs =
-            materialized.barrierCTAs
-                ? arith::OrIOp::create(b, materialized.barrierCTAs, owners)
-                : owners;
-      };
-
       if (candidates.unknown) {
         materialized.effectCTAs = allCTAsMask(b);
         addBarrierOwners(
+            materialized,
             auxData.bufferStatePlans[(int)materialized.memType].unknownMask,
-            materialized.effectCTAs);
+            materialized.effectCTAs, selectBarrierStorage);
         return materialized;
       }
 
@@ -1121,27 +1392,64 @@ private:
             materialized.effectCTAs
                 ? arith::OrIOp::create(b, materialized.effectCTAs, ownerCTAs)
                 : ownerCTAs;
-        addBarrierOwners(candidate.mask, ownerCTAs);
+        addBarrierOwners(materialized, candidate.mask, ownerCTAs,
+                         selectBarrierStorage);
+      }
+      return materialized;
+    };
+
+    auto materializeStaticBuffer =
+        [&](const MemEffectsOpInfo::Effects::StaticSharedBuffer &buffer,
+            bool selectBarrierStorage) -> FailureOr<MaterializedEffect> {
+      MaterializedEffect materialized;
+      materialized.memType = MemType::SHARED_MEM;
+      FailureOr<Value> stateMask =
+          createStaticBufferStateMask(b, auxData, buffer, op);
+      if (failed(stateMask))
+        return failure();
+      materialized.bufferMask = *stateMask;
+      materialized.effectCTAs = getScratchEffectCTAs(b, op, hooks);
+
+      if (selectBarrierStorage && !auxData.barrierBufferMasks.empty()) {
+        int index = static_cast<int>(MemType::SHARED_MEM);
+        const auto &regions = auxData.bufferRegions[index];
+        BufferRegion region = buffer.getRegion(ttg::lookupNumCTAs(op));
+        auto it = llvm::lower_bound(regions, region);
+        if (it == regions.end() || !(*it == region)) {
+          op->emitError("static shared-memory region is absent from the ConSan "
+                        "registry");
+          return failure();
+        }
+        unsigned id = std::distance(regions.begin(), it);
+        addBarrierOwners(materialized,
+                         auxData.bufferStatePlans[index].regionMasks[id],
+                         materialized.effectCTAs, selectBarrierStorage);
       }
       return materialized;
     };
 
     for (const auto &effect : opInfo->operandEffects) {
-      Value buf = effect.buf;
-      bool isSharedMemory = isa<ttg::SharedMemorySpaceAttr>(
-          cast<ttg::MemDescType>(buf.getType()).getMemorySpace());
+      const auto *buf = std::get_if<Value>(&effect.buffer);
+      bool isSharedMemory =
+          !buf || isa<ttg::SharedMemorySpaceAttr>(
+                      cast<ttg::MemDescType>(buf->getType()).getMemorySpace());
       bool invalidatesBarriers =
-          isSharedMemory && hooks.barrierWritesInvalidate() &&
+          buf && isSharedMemory && hooks.barrierWritesInvalidate() &&
           effect.rw == RW::Write &&
           effect.sharedKind == ttg::SharedKind::Generic &&
           thread == baseThread &&
           opInfo->trackingKind == MemEffectsOpInfo::TrackingKind::Barrier &&
           llvm::none_of(getMemoryAccesses(op), [&](const auto &access) {
-            return access.value == buf &&
+            return access.value == *buf &&
                    access.sharedKind == effect.sharedKind && access.isRead;
           });
-      FailureOr<MaterializedEffect> maybeMaterialized = materializeBuffer(
-          buf, defaultEffectCTAs, !isBarrierLifecycle || invalidatesBarriers);
+      bool selectBarrierStorage = !isBarrierLifecycle || invalidatesBarriers;
+      FailureOr<MaterializedEffect> maybeMaterialized =
+          buf ? materializeBuffer(*buf, defaultEffectCTAs, selectBarrierStorage)
+              : materializeStaticBuffer(
+                    std::get<MemEffectsOpInfo::Effects::StaticSharedBuffer>(
+                        effect.buffer),
+                    selectBarrierStorage);
       if (failed(maybeMaterialized))
         return failure();
       MaterializedEffect materialized = *maybeMaterialized;
@@ -1338,6 +1646,7 @@ private:
   }
 
   ModuleOp module;
+  tt::FuncOp entryPoint;
   AuxDataMap auxData;
   const ConSanTargetHooks &hooks;
 };

--- a/lib/Dialect/TritonInstrument/Transforms/ConcurrencySanitizer.cpp
+++ b/lib/Dialect/TritonInstrument/Transforms/ConcurrencySanitizer.cpp
@@ -664,10 +664,15 @@ Value getScratchEffectCTAs(ImplicitLocOpBuilder &b, Operation *op,
   }
 
   if (auto reduce = dyn_cast<tt::ReduceOp>(op)) {
-    auto srcType = reduce.getInputTypes()[0];
-    if (ttg::getCTASplitNum(srcType.getEncoding())[reduce.getAxis()] != 1)
+    LinearLayout srcLayout = ttg::toLinearLayout(reduce.getInputTypes()[0]);
+    auto block = StringAttr::get(op->getContext(), "block");
+    auto axis = *(srcLayout.getOutDimNames().begin() + reduce.getAxis());
+    uint16_t groupMask = getInputBasisMask(srcLayout, block, {axis});
+    if (!groupMask)
+      return currentCTAMask(b);
+    if (groupMask == ttg::lookupNumCTAs(op) - 1)
       return allCTAsMask(b);
-    return currentCTAMask(b);
+    return getRecipientCTAsForBroadcastMasks(b, {groupMask});
   }
 
   if (auto broadcastMask = hooks.getScratchCTABroadcastMask(op)) {
@@ -812,7 +817,6 @@ public:
     entryPoint = publicFuncs.front();
     SmallVector<tt::FuncOp> reachableFunctions;
     if (failed(collectReachableFunctions(reachableFunctions)) ||
-        failed(validateScratchMetadata(reachableFunctions)) ||
         failed(validateNonEntryFunctions(reachableFunctions)))
       return failure();
 
@@ -864,72 +868,6 @@ private:
     return success();
   }
 
-  LogicalResult
-  validateScratchMetadata(ArrayRef<tt::FuncOp> reachableFunctions) {
-    constexpr uint64_t maxSharedMemorySize = uint64_t{1} << 24;
-    for (tt::FuncOp func : reachableFunctions) {
-      WalkResult result = func.walk([&](Operation *op) -> WalkResult {
-        Attribute rawSize = op->getAttr("allocation.size");
-        if (!rawSize)
-          return WalkResult::advance();
-
-        auto size = dyn_cast<IntegerAttr>(rawSize);
-        auto offset =
-            dyn_cast_or_null<IntegerAttr>(op->getAttr("allocation.offset"));
-        if (!size || !offset || !size.getType().isSignlessInteger() ||
-            !offset.getType().isSignlessInteger()) {
-          op->emitError("compiler scratch metadata requires integer "
-                        "allocation.offset and allocation.size attributes");
-          return WalkResult::interrupt();
-        }
-
-        const APInt &offsetValue = offset.getValue();
-        const APInt &sizeValue = size.getValue();
-        bool valid = !offsetValue.isNegative() && !sizeValue.isNegative() &&
-                     !sizeValue.isZero() &&
-                     offsetValue.ule(maxSharedMemorySize) &&
-                     sizeValue.ule(maxSharedMemorySize);
-        if (valid) {
-          uint64_t unsignedOffset = offsetValue.getZExtValue();
-          uint64_t unsignedSize = sizeValue.getZExtValue();
-          valid = unsignedSize <= maxSharedMemorySize - unsignedOffset;
-        }
-        if (!valid) {
-          InFlightDiagnostic diagnostic =
-              op->emitError("invalid compiler scratch allocation metadata: "
-                            "offset ");
-          if (offsetValue.getBitWidth() <= 64)
-            diagnostic << offset.getInt();
-          else
-            diagnostic << offset;
-          diagnostic << ", size ";
-          if (sizeValue.getBitWidth() <= 64)
-            diagnostic << size.getInt();
-          else
-            diagnostic << size;
-          diagnostic << "; the interval must be non-empty and fit in the "
-                        "24-bit shared-memory address space";
-          return WalkResult::interrupt();
-        }
-
-        if (auto info = hooks.getMemEffectsOpInfo(op)) {
-          bool hasSynchronousTracking =
-              info->trackingKind == MemEffectsOpInfo::TrackingKind::None ||
-              info->trackingKind == MemEffectsOpInfo::TrackingKind::Barrier;
-          if (!hasSynchronousTracking || info->implicitCommit) {
-            op->emitError("compiler scratch cannot be combined with "
-                          "asynchronous operation effect tracking");
-            return WalkResult::interrupt();
-          }
-        }
-        return WalkResult::advance();
-      });
-      if (result.wasInterrupted())
-        return failure();
-    }
-    return success();
-  }
-
   bool isCTALocalScratch(Operation *op) const {
     if (!op->hasAttr("allocation.size") || ttg::lookupNumCTAs(op) == 1)
       return true;
@@ -968,7 +906,12 @@ private:
       if (func == entryPoint)
         continue;
       WalkResult result = func.walk([&](Operation *op) -> WalkResult {
-        if (op == func.getOperation() || isa<CallOpInterface>(op))
+        if (op == func.getOperation())
+          return WalkResult::advance();
+        if (op->hasAttr("allocation.size") &&
+            failed(getConSanMemEffectsOpInfo(hooks, op)))
+          return WalkResult::interrupt();
+        if (isa<CallOpInterface>(op))
           return WalkResult::advance();
 
         bool hasUnsupportedAllocation =
@@ -1285,8 +1228,10 @@ private:
                                      int thread,
                                      tti::FunctionBuilder &funcBuilder) {
     int baseThread = getBaseThread(thread, auxData.threadLayout);
-    std::optional<MemEffectsOpInfo> opInfo =
-        getConSanMemEffectsOpInfo(hooks, op);
+    auto opInfoOr = getConSanMemEffectsOpInfo(hooks, op);
+    if (failed(opInfoOr))
+      return failure();
+    const std::optional<MemEffectsOpInfo> &opInfo = *opInfoOr;
     for (const MemoryAccess &access :
          getMemoryAccesses(op, ttg::SharedKind::Barrier)) {
       if (opInfo && llvm::any_of(opInfo->barriers, [&](const auto &barrier) {

--- a/lib/Dialect/TritonInstrument/Transforms/ConcurrencySanitizer.cpp
+++ b/lib/Dialect/TritonInstrument/Transforms/ConcurrencySanitizer.cpp
@@ -772,7 +772,7 @@ public:
     SmallVector<tt::FuncOp> publicFuncs =
         llvm::to_vector(llvm::make_filter_range(
             module.getOps<tt::FuncOp>(),
-            [](tt::FuncOp func) { return func.isPublic(); }));
+            [](tt::FuncOp func) { return tt::isKernel(func); }));
     if (publicFuncs.size() != 1) {
       module.emitError(
           "ConSan requires exactly one public entrypoint function; "
@@ -803,26 +803,14 @@ public:
 
 private:
   bool isCTALocalScratch(Operation *op) const {
-    if (!op->hasAttr("allocation.size") || ttg::lookupNumCTAs(op) == 1)
+    if (!op->hasAttr("allocation.size"))
       return true;
 
-    if (auto convert = dyn_cast<ttg::ConvertLayoutOp>(op)) {
-      RankedTensorType srcType = convert.getSrc().getType();
-      RankedTensorType dstType = convert.getType();
-      if (!srcType.getEncoding() || !dstType.getEncoding())
-        return false;
-    } else if (auto reduce = dyn_cast<tt::ReduceOp>(op)) {
-      SmallVector<RankedTensorType> inputs = reduce.getInputTypes();
-      if (inputs.empty() || !inputs.front().getEncoding())
-        return false;
-      SmallVector<unsigned> splits =
-          ttg::getCTASplitNum(inputs.front().getEncoding());
-      unsigned axis = reduce.getAxis();
-      if (axis >= splits.size())
-        return false;
-    } else {
-      return true;
-    }
+    // NVIDIA broadcasts scalar atomic results; AMD executes them in each CTA.
+    if (isa<tt::AtomicRMWOp, tt::AtomicCASOp>(op) &&
+        !isa<RankedTensorType>(op->getResult(0).getType()))
+      return !hooks.hasUnsummarizableCalleeState(op);
+
     return !tt::hasCrossCTAScratch(op);
   }
 
@@ -848,9 +836,6 @@ private:
         }
         if (func == entryPoint)
           return WalkResult::advance();
-        if (op->hasAttr("allocation.size") &&
-            failed(getConSanMemEffectsOpInfo(hooks, op)))
-          return WalkResult::interrupt();
         if (isa<CallOpInterface>(op))
           return WalkResult::advance();
 
@@ -1168,10 +1153,8 @@ private:
                                      int thread,
                                      tti::FunctionBuilder &funcBuilder) {
     int baseThread = getBaseThread(thread, auxData.threadLayout);
-    auto opInfoOr = getConSanMemEffectsOpInfo(hooks, op);
-    if (failed(opInfoOr))
-      return failure();
-    const std::optional<MemEffectsOpInfo> &opInfo = *opInfoOr;
+    std::optional<MemEffectsOpInfo> opInfo =
+        getConSanMemEffectsOpInfo(hooks, op);
     for (const MemoryAccess &access :
          getMemoryAccesses(op, ttg::SharedKind::Barrier)) {
       if (opInfo && llvm::any_of(opInfo->barriers, [&](const auto &barrier) {

--- a/lib/Dialect/TritonInstrument/Transforms/ConcurrencySanitizer.cpp
+++ b/lib/Dialect/TritonInstrument/Transforms/ConcurrencySanitizer.cpp
@@ -645,22 +645,14 @@ Value getLocalLoadStoreRecipientCTAs(ImplicitLocOpBuilder &b,
       b, getLocalLoadStoreConversion(memDescTy, regTy));
 }
 
-Value getScratchEffectCTAs(ImplicitLocOpBuilder &b, Operation *op,
-                           const ConSanTargetHooks &hooks) {
-  if (isa<CallOpInterface>(op)) {
-    // Non-entry validation ensures every scratch operation in the callee and
-    // its nested callees accesses only the issuing CTA's virtual frame.
-    return currentCTAMask(b);
-  }
-
+Value getScratchReadCTAs(ImplicitLocOpBuilder &b, Operation *op,
+                         Value ownerCTAs) {
   if (auto convert = dyn_cast<ttg::ConvertLayoutOp>(op)) {
-    // Conversion stores remain CTA-local, but the source-owned scratch may be
-    // read by other CTAs when the source and destination block layouts differ.
     LinearLayout srcLayout = ttg::toLinearLayout(convert.getSrc().getType());
     LinearLayout dstLayout = ttg::toLinearLayout(convert.getType());
     Value loadCTAs = getLocalMemoryRecipientCTAs(
         b, invertAndComposeBlockLocal(srcLayout, dstLayout));
-    return arith::OrIOp::create(b, currentCTAMask(b), loadCTAs);
+    return arith::OrIOp::create(b, ownerCTAs, loadCTAs);
   }
 
   if (auto reduce = dyn_cast<tt::ReduceOp>(op)) {
@@ -669,17 +661,13 @@ Value getScratchEffectCTAs(ImplicitLocOpBuilder &b, Operation *op,
     auto axis = *(srcLayout.getOutDimNames().begin() + reduce.getAxis());
     uint16_t groupMask = getInputBasisMask(srcLayout, block, {axis});
     if (!groupMask)
-      return currentCTAMask(b);
+      return ownerCTAs;
     if (groupMask == ttg::lookupNumCTAs(op) - 1)
       return allCTAsMask(b);
     return getRecipientCTAsForBroadcastMasks(b, {groupMask});
   }
 
-  if (auto broadcastMask = hooks.getScratchCTABroadcastMask(op)) {
-    if (*broadcastMask)
-      return getRecipientCTAsForBroadcastMasks(b, {*broadcastMask});
-  }
-  return currentCTAMask(b);
+  return ownerCTAs;
 }
 
 Value getMemEffectCTAs(ImplicitLocOpBuilder &b, Operation *op) {
@@ -1354,7 +1342,9 @@ private:
       if (failed(stateMask))
         return failure();
       materialized.bufferMask = *stateMask;
-      materialized.effectCTAs = getScratchEffectCTAs(b, op, hooks);
+      // Scratch stores target the issuing CTA; cross-CTA consumers read after
+      // intrinsic synchronization.
+      materialized.effectCTAs = currentCTAMask(b);
 
       if (selectBarrierStorage && !auxData.barrierBufferMasks.empty()) {
         int index = static_cast<int>(MemType::SHARED_MEM);
@@ -1380,15 +1370,16 @@ private:
           !buf || isa<ttg::SharedMemorySpaceAttr>(
                       cast<ttg::MemDescType>(buf->getType()).getMemorySpace());
       bool invalidatesBarriers =
-          buf && isSharedMemory && hooks.barrierWritesInvalidate() &&
+          isSharedMemory && hooks.barrierWritesInvalidate() &&
           effect.rw == RW::Write &&
           effect.sharedKind == ttg::SharedKind::Generic &&
           thread == baseThread &&
           opInfo->trackingKind == MemEffectsOpInfo::TrackingKind::Barrier &&
-          llvm::none_of(getMemoryAccesses(op), [&](const auto &access) {
-            return access.value == *buf &&
-                   access.sharedKind == effect.sharedKind && access.isRead;
-          });
+          (!buf ||
+           llvm::none_of(getMemoryAccesses(op), [&](const auto &access) {
+             return access.value == *buf &&
+                    access.sharedKind == effect.sharedKind && access.isRead;
+           }));
       bool selectBarrierStorage = !isBarrierLifecycle || invalidatesBarriers;
       FailureOr<MaterializedEffect> maybeMaterialized =
           buf ? materializeBuffer(*buf, defaultEffectCTAs, selectBarrierStorage)
@@ -1403,11 +1394,12 @@ private:
 
       Value bufferMask = materialized.bufferMask;
       Value effectCTAs = materialized.effectCTAs;
+      Value readCTAs = buf ? effectCTAs : getScratchReadCTAs(b, op, effectCTAs);
       MemType memType = materialized.memType;
       bool invalidatedBarrier = false;
       auto verifyWrite = [&] {
         addWriteChecks(b, funcBuilder, op, bufferMask, pred, memType, thread,
-                       effect.operandName, effectCTAs, opInfo->commitKind);
+                       effect.operandName, readCTAs, opInfo->commitKind);
         addReadChecks(b, funcBuilder, op, bufferMask, pred, memType, thread,
                       effect.operandName, effectCTAs, opInfo->commitKind);
       };
@@ -1431,7 +1423,7 @@ private:
                                                   effectCTAs);
         } else {
           funcBuilder.createSetProxyAccessCall(b, bufferMask, baseThread, pred,
-                                               op, effectCTAs);
+                                               op, readCTAs);
         }
       }
       if (effect.rw == RW::Read) {

--- a/lib/Dialect/TritonInstrument/Transforms/ConcurrencySanitizer.cpp
+++ b/lib/Dialect/TritonInstrument/Transforms/ConcurrencySanitizer.cpp
@@ -5,6 +5,7 @@
 #include "mlir/Interfaces/CallInterfaces.h"
 #include "mlir/Interfaces/SideEffectInterfaces.h"
 #include "mlir/Transforms/Passes.h"
+#include "triton/Analysis/Allocation.h"
 #include "triton/Dialect/Triton/IR/Utility.h"
 #include "triton/Dialect/TritonGPU/IR/Dialect.h"
 #include "triton/Dialect/TritonGPU/IR/LinearLayoutConversions.h"
@@ -15,7 +16,6 @@
 #include "triton/Dialect/TritonNvidiaGPU/IR/Dialect.h"
 #include "triton/Tools/LayoutUtils.h"
 #include "triton/Tools/Sys/GetEnv.h"
-#include "llvm/ADT/DenseSet.h"
 
 namespace mlir {
 namespace triton {
@@ -781,9 +781,11 @@ public:
       return failure();
     }
     entryPoint = publicFuncs.front();
-    SmallVector<tt::FuncOp> reachableFunctions;
-    if (failed(collectReachableFunctions(reachableFunctions)) ||
-        failed(validateNonEntryFunctions(reachableFunctions)))
+    if (entryPoint.isExternal()) {
+      entryPoint.emitError("ConSan entrypoint must have a function body");
+      return failure();
+    }
+    if (failed(validateNonEntryFunctions()))
       return failure();
 
     tti::FunctionBuilder funcBuilder(module, auxData);
@@ -800,40 +802,6 @@ public:
   }
 
 private:
-  LogicalResult
-  collectReachableFunctions(SmallVectorImpl<tt::FuncOp> &reachableFunctions) {
-    if (entryPoint.isExternal()) {
-      entryPoint.emitError("ConSan entrypoint must have a function body");
-      return failure();
-    }
-
-    SymbolTableCollection symbolTable;
-    DenseSet<Operation *> visited;
-    SmallVector<tt::FuncOp> worklist{entryPoint};
-    visited.insert(entryPoint.getOperation());
-
-    while (!worklist.empty()) {
-      tt::FuncOp func = worklist.pop_back_val();
-      reachableFunctions.push_back(func);
-      WalkResult result = func.walk([&](CallOpInterface call) -> WalkResult {
-        Operation *resolved = call.resolveCallableInTable(&symbolTable);
-        tt::FuncOp callee = dyn_cast_or_null<tt::FuncOp>(resolved);
-        if (!callee || callee.isExternal()) {
-          call->emitError("ConSan cannot summarize an unresolved or external "
-                          "callee in function @")
-              << func.getName();
-          return WalkResult::interrupt();
-        }
-        if (visited.insert(callee.getOperation()).second)
-          worklist.push_back(callee);
-        return WalkResult::advance();
-      });
-      if (result.wasInterrupted())
-        return failure();
-    }
-    return success();
-  }
-
   bool isCTALocalScratch(Operation *op) const {
     if (!op->hasAttr("allocation.size") || ttg::lookupNumCTAs(op) == 1)
       return true;
@@ -843,36 +811,42 @@ private:
       RankedTensorType dstType = convert.getType();
       if (!srcType.getEncoding() || !dstType.getEncoding())
         return false;
-      StringAttr block = StringAttr::get(op->getContext(), "block");
-      return invertAndComposeBlockLocal(ttg::toLinearLayout(srcType),
-                                        ttg::toLinearLayout(dstType))
-          .isIdentityOnOutDim(block);
-    }
-
-    if (auto reduce = dyn_cast<tt::ReduceOp>(op)) {
+    } else if (auto reduce = dyn_cast<tt::ReduceOp>(op)) {
       SmallVector<RankedTensorType> inputs = reduce.getInputTypes();
       if (inputs.empty() || !inputs.front().getEncoding())
         return false;
       SmallVector<unsigned> splits =
           ttg::getCTASplitNum(inputs.front().getEncoding());
       unsigned axis = reduce.getAxis();
-      return axis < splits.size() && splits[axis] == 1;
+      if (axis >= splits.size())
+        return false;
+    } else {
+      return true;
     }
-
-    return true;
+    return !tt::hasCrossCTAScratch(op);
   }
 
   // Non-entry bodies are not instrumented. Their compiler-owned shared memory
   // is covered by the virtual frame on each call, but SSA-visible memory and
   // sanitizer state transitions cannot be represented by that summary.
-  LogicalResult
-  validateNonEntryFunctions(ArrayRef<tt::FuncOp> reachableFunctions) {
+  LogicalResult validateNonEntryFunctions() {
+    SymbolTableCollection symbolTable;
     AuxDataMap emptyAuxData;
-    for (tt::FuncOp func : reachableFunctions) {
-      if (func == entryPoint)
-        continue;
+    for (tt::FuncOp func : module.getOps<tt::FuncOp>()) {
       WalkResult result = func.walk([&](Operation *op) -> WalkResult {
         if (op == func.getOperation())
+          return WalkResult::advance();
+        if (auto call = dyn_cast<CallOpInterface>(op)) {
+          Operation *resolved = call.resolveCallableInTable(&symbolTable);
+          tt::FuncOp callee = dyn_cast_or_null<tt::FuncOp>(resolved);
+          if (!callee || callee.isExternal()) {
+            call->emitError("ConSan cannot summarize an unresolved or external "
+                            "callee in function @")
+                << func.getName();
+            return WalkResult::interrupt();
+          }
+        }
+        if (func == entryPoint)
           return WalkResult::advance();
         if (op->hasAttr("allocation.size") &&
             failed(getConSanMemEffectsOpInfo(hooks, op)))

--- a/lib/Dialect/TritonInstrument/Transforms/PrepareConSanCaptures.cpp
+++ b/lib/Dialect/TritonInstrument/Transforms/PrepareConSanCaptures.cpp
@@ -25,6 +25,10 @@ namespace tti = mlir::triton::instrument;
 bool hasSharedMemoryBuffers(ModuleOp mod) {
   bool result = false;
   mod.walk([&](ttg::LocalAllocOp op) { result |= op.isSharedMemoryAlloc(); });
+  // Warp specialization itself uses compiler-owned shared scratch. ConSan's
+  // lock capture adds another scratch user, so reserve the shared-memory state
+  // captures whenever a warp-specialized region is present.
+  mod.walk([&](ttg::WarpSpecializeOp) { result = true; });
   return result;
 }
 
@@ -94,15 +98,15 @@ public:
       return signalPassFailure();
     }
 
-    int numActiveMemTypes = (hasSharedMemoryBuffers(mod) ? 1 : 0) +
-                            (hasTensorMemoryBuffers(mod) ? 1 : 0);
+    bool hasSharedBuffers = hasSharedMemoryBuffers(mod);
+    int numActiveMemTypes =
+        (hasSharedBuffers ? 1 : 0) + (hasTensorMemoryBuffers(mod) ? 1 : 0);
     // NVIDIA inserts a terminal cluster barrier after this pass.
     bool hasClusterBarriers = target == "nvidia" && ttg::lookupNumCTAs(mod) > 1;
     int totalCaptures = tti::estimateConSanCaptureCount(
         numActiveMemTypes, hasBarriers(mod), hasClusterBarriers,
         getNumCommitKinds(mod, *hooks),
-        hasSharedMemoryBuffers(mod) &&
-            hooks->needsAsyncProxyFenceTracking(mod));
+        hasSharedBuffers && hooks->needsAsyncProxyFenceTracking(mod));
     int extraBytes = totalCaptures * tti::kCaptureSizeBytes;
 
     auto i32Ty = IntegerType::get(mod.getContext(), 32);

--- a/lib/Dialect/TritonNvidiaGPU/Transforms/ConSanNVIDIA.cpp
+++ b/lib/Dialect/TritonNvidiaGPU/Transforms/ConSanNVIDIA.cpp
@@ -35,6 +35,21 @@ uint32_t getBlockBroadcastMask(Type type) {
   return toLinearLayout(memDescTy).getFreeVariableMasks().lookup(kBlock);
 }
 
+std::optional<uint16_t> getAtomicScratchBroadcastMask(Operation *op) {
+  if (!op->hasAttr("allocation.size") ||
+      !isa<AtomicPollOp, AtomicRMWOp, AtomicCASOp, ttg::LocalAtomicScatterRMWOp,
+           tti::ExperimentalGSanAtomicRMWOp, tti::ExperimentalGSanAtomicCASOp>(
+          op))
+    return std::nullopt;
+
+  Type resultTy = op->getResult(0).getType();
+  if (auto tensorTy = dyn_cast<RankedTensorType>(resultTy)) {
+    auto kBlock = StringAttr::get(op->getContext(), "block");
+    return ttg::toLinearLayout(tensorTy).getFreeVariableMasks().lookup(kBlock);
+  }
+  return static_cast<uint16_t>(ttg::lookupNumCTAs(op) - 1);
+}
+
 } // namespace
 
 class NVIDIAConSanHooks : public tti::ConSanTargetHooks {
@@ -129,6 +144,8 @@ public:
     }
     if (auto storeOp = dyn_cast<ttng::TMAStoreLikeOpInterface>(op))
       mask = getBlockBroadcastMask(storeOp.getSrc().getType());
+    if (auto scratchMask = getAtomicScratchBroadcastMask(op))
+      mask = *scratchMask;
     if (isa<ttng::CLCTryCancelOp>(op) && ttg::lookupNumCTAs(op) > 1) {
       Value ctaId = tti::ExperimentalClusterCTAIdOp::create(b, b.getLoc());
       return arith::CmpIOp::create(b, arith::CmpIPredicate::eq, ctaId,
@@ -144,6 +161,22 @@ public:
     if (!mask)
       return nullptr;
     return getLeaderCTAPredicate(b, mask);
+  }
+
+  SmallVector<Operation *>
+  createInitClusterBarrier(ImplicitLocOpBuilder &b) const override {
+    return {ClusterBarrierOp::create(b, b.getLoc()).getOperation()};
+  }
+
+  std::optional<uint16_t>
+  getScratchCTABroadcastMask(Operation *op) const override {
+    return getAtomicScratchBroadcastMask(op);
+  }
+
+  bool hasUnsummarizableCalleeState(Operation *op) const override {
+    if (isa<ClusterBarrierOp>(op))
+      return true;
+    return getAtomicScratchBroadcastMask(op).value_or(0) != 0;
   }
 
   std::optional<MemEffectsOpInfo>
@@ -244,7 +277,8 @@ public:
       for (auto [value, name] : namedOperands)
         for (auto it = info->operandEffects.begin();
              it != info->operandEffects.end(); ++it)
-          if (it->buf == value) {
+          if (auto *buffer = std::get_if<Value>(&it->buffer);
+              buffer && *buffer == value) {
             effects.emplace_back(*it).operandName = name.str();
             break;
           }

--- a/lib/Dialect/TritonNvidiaGPU/Transforms/ConSanNVIDIA.cpp
+++ b/lib/Dialect/TritonNvidiaGPU/Transforms/ConSanNVIDIA.cpp
@@ -168,11 +168,6 @@ public:
     return {ClusterBarrierOp::create(b, b.getLoc()).getOperation()};
   }
 
-  std::optional<uint16_t>
-  getScratchCTABroadcastMask(Operation *op) const override {
-    return getAtomicScratchBroadcastMask(op);
-  }
-
   bool hasUnsummarizableCalleeState(Operation *op) const override {
     if (isa<ClusterBarrierOp>(op))
       return true;

--- a/python/test/gluon/test_consan.py
+++ b/python/test/gluon/test_consan.py
@@ -3825,12 +3825,12 @@ def test_barrier_underflow(device, run_wrapper, monkeypatch, num_ctas):
 
 
 @pytest.mark.skipif(not is_cuda() or torch.cuda.get_device_capability()[0] < 9, reason="Requires hopper")
-@pytest.mark.parametrize("ASYNC", [False, True], ids=["generic", "async-copy"])
+@pytest.mark.parametrize("ACCESS", ["generic", "async-copy", "convert-layout"])
 @pytest.mark.parametrize("INVALIDATE", [False, True], ids=["live", "invalidated"])
-def test_payload_reuse_requires_barrier_invalidation(ASYNC, INVALIDATE, device, run_wrapper, monkeypatch):
+def test_payload_reuse_requires_barrier_invalidation(ACCESS, INVALIDATE, device, run_wrapper, monkeypatch):
     if run_wrapper and not INVALIDATE:
         result = run_in_process(test_payload_reuse_requires_barrier_invalidation,
-                                (ASYNC, INVALIDATE, device, False, monkeypatch))
+                                (ACCESS, INVALIDATE, device, False, monkeypatch))
         assert_expected_cuda_failure(result.exc)
         assert "Shared memory reused before barrier invalidation" in result.driver_stderr_output
         return
@@ -3840,7 +3840,7 @@ def test_payload_reuse_requires_barrier_invalidation(ASYNC, INVALIDATE, device, 
     knobs.refresh_knobs()
 
     @gluon.jit
-    def kernel(source, output, ASYNC: ttgl.constexpr, INVALIDATE: ttgl.constexpr):
+    def kernel(source, output, ACCESS: ttgl.constexpr, INVALIDATE: ttgl.constexpr):
         layout: ttgl.constexpr = ttgl.BlockedLayout([1], [32], [4], [0])
         smem_layout: ttgl.constexpr = ttgl.SwizzledSharedLayout(1, 1, 1, [0])
         barrier = mbarrier.allocate_mbarrier()
@@ -3849,22 +3849,28 @@ def test_payload_reuse_requires_barrier_invalidation(ASYNC, INVALIDATE, device, 
             mbarrier.invalidate(barrier)
 
         offsets = ttgl.arange(0, XBLOCK, layout=layout)
-        if ASYNC:
+        if ACCESS == "async-copy":
             smem = ttgl.allocate_shared_memory(ttgl.int32, [XBLOCK], smem_layout)
             ampere.async_copy.async_load(smem, source + offsets)
             ampere.async_copy.commit_group()
             ampere.async_copy.wait_group(0)
+        elif ACCESS == "convert-layout":
+            dst_layout: ttgl.constexpr = ttgl.SliceLayout(1, ttgl.BlockedLayout([1, 1], [1, 32], [1, 4], [1, 0]))
+            dst_offsets = ttgl.arange(0, XBLOCK, layout=dst_layout)
+            values = ttgl.load(source + offsets)
+            ttgl.store(output + dst_offsets, ttgl.convert_layout(values, dst_layout))
         else:
             values = ttgl.full([XBLOCK], 7, ttgl.int32, layout)
             smem = ttgl.allocate_shared_memory(ttgl.int32, [XBLOCK], smem_layout, values)
-        ttgl.store(output + offsets, smem.load(layout))
+        if ACCESS != "convert-layout":
+            ttgl.store(output + offsets, smem.load(layout))
 
     source = torch.arange(XBLOCK.value, device=device, dtype=torch.int32)
     output = torch.empty_like(source)
-    compiled = kernel.warmup(source, output, ASYNC=ASYNC, INVALIDATE=INVALIDATE, grid=(1, ), num_warps=4, num_ctas=1)
+    compiled = kernel.warmup(source, output, ACCESS=ACCESS, INVALIDATE=INVALIDATE, grid=(1, ), num_warps=4, num_ctas=1)
     assert compiled.metadata.shared == XBLOCK.value * source.element_size()
-    kernel[(1, )](source, output, ASYNC=ASYNC, INVALIDATE=INVALIDATE, num_warps=4, num_ctas=1)
-    expected = source if ASYNC else torch.full_like(source, 7)
+    kernel[(1, )](source, output, ACCESS=ACCESS, INVALIDATE=INVALIDATE, num_warps=4, num_ctas=1)
+    expected = torch.full_like(source, 7) if ACCESS == "generic" else source
     torch.testing.assert_close(output, expected)
 
 

--- a/python/test/gluon/test_consan.py
+++ b/python/test/gluon/test_consan.py
@@ -212,6 +212,8 @@ def test_consan_noinline_convert_layout_scratch(ENABLE_CONSAN, NESTED, device, f
     output = torch.empty_like(values)
     sentinel_output = torch.empty_like(values)
     compiled = _consan_noinline_convert_layout_kernel[(1, )](values, output, sentinel_output, NESTED, num_warps=4)
+    if is_compile_warmup():
+        return
     assert compiled.metadata.shared >= 2 * values.numel() * values.element_size()
     assert compiled.asm["ttgir"].count("noinline = true") >= 1 + int(NESTED)
     torch.testing.assert_close(output, values)

--- a/python/test/gluon/test_consan.py
+++ b/python/test/gluon/test_consan.py
@@ -185,36 +185,28 @@ def _consan_noinline_forward_convert_layout(input, output):
 
 
 @gluon.jit
-def _consan_noinline_convert_layout_kernel(input, output, sentinel_output, NESTED: ttgl.constexpr):
+def _consan_noinline_convert_layout_kernel(input, output, sentinel_output):
     layout: ttgl.constexpr = ttgl.BlockedLayout([1], [32], [4], [0])
     shared_layout: ttgl.constexpr = ttgl.SwizzledSharedLayout(1, 1, 1, [0])
     offsets = ttgl.arange(0, 128, layout=layout)
     sentinel = offsets + 4096
     caller_allocation = ttgl.allocate_shared_memory(ttgl.int32, [128], shared_layout, sentinel)
 
-    if NESTED:
-        _consan_noinline_forward_convert_layout(input, output)
-    else:
-        _consan_noinline_convert_layout(input, output)
-
+    _consan_noinline_forward_convert_layout(input, output)
     ttgl.store(sentinel_output + offsets, caller_allocation.load(layout))
 
 
 @pytest.mark.skipif(not is_cuda() or torch.cuda.get_device_capability()[0] < 9, reason="Requires Hopper or newer")
-@pytest.mark.parametrize("NESTED", [
-    pytest.param(False, id="with-consan"),
-    pytest.param(True, id="with-consan-nested"),
-])
-def test_consan_noinline_convert_layout_scratch(NESTED, device, fresh_knobs):
+def test_consan_noinline_convert_layout_scratch(device, fresh_knobs):
     fresh_knobs.compilation.instrumentation_mode = "consan"
     values = torch.arange(128, device=device, dtype=torch.int32)
     output = torch.empty_like(values)
     sentinel_output = torch.empty_like(values)
-    compiled = _consan_noinline_convert_layout_kernel[(1, )](values, output, sentinel_output, NESTED, num_warps=4)
+    compiled = _consan_noinline_convert_layout_kernel[(1, )](values, output, sentinel_output, num_warps=4)
     if is_compile_warmup():
         return
     assert compiled.metadata.shared >= 2 * values.numel() * values.element_size()
-    assert compiled.asm["ttgir"].count("noinline = true") >= 1 + int(NESTED)
+    assert compiled.asm["ttgir"].count("noinline = true") >= 2
     torch.testing.assert_close(output, values)
     torch.testing.assert_close(sentinel_output, values + 4096)
 

--- a/python/test/gluon/test_consan.py
+++ b/python/test/gluon/test_consan.py
@@ -169,6 +169,55 @@ def test_consan_uses_profile_scratch(device, fresh_knobs, num_ctas):
         assert compiled.metadata.global_scratch_size == 0
 
 
+@gluon.jit(noinline=True)
+def _consan_noinline_convert_layout(input, output):
+    src_layout: ttgl.constexpr = ttgl.BlockedLayout([1], [32], [4], [0])
+    dst_layout: ttgl.constexpr = ttgl.SliceLayout(1, ttgl.BlockedLayout([1, 1], [1, 32], [1, 4], [1, 0]))
+    src_offsets = ttgl.arange(0, 128, layout=src_layout)
+    dst_offsets = ttgl.arange(0, 128, layout=dst_layout)
+    values = ttgl.load(input + src_offsets)
+    ttgl.store(output + dst_offsets, ttgl.convert_layout(values, dst_layout))
+
+
+@gluon.jit(noinline=True)
+def _consan_noinline_forward_convert_layout(input, output):
+    _consan_noinline_convert_layout(input, output)
+
+
+@gluon.jit
+def _consan_noinline_convert_layout_kernel(input, output, sentinel_output, NESTED: ttgl.constexpr):
+    layout: ttgl.constexpr = ttgl.BlockedLayout([1], [32], [4], [0])
+    shared_layout: ttgl.constexpr = ttgl.SwizzledSharedLayout(1, 1, 1, [0])
+    offsets = ttgl.arange(0, 128, layout=layout)
+    sentinel = offsets + 4096
+    caller_allocation = ttgl.allocate_shared_memory(ttgl.int32, [128], shared_layout, sentinel)
+
+    if NESTED:
+        _consan_noinline_forward_convert_layout(input, output)
+    else:
+        _consan_noinline_convert_layout(input, output)
+
+    ttgl.store(sentinel_output + offsets, caller_allocation.load(layout))
+
+
+@pytest.mark.skipif(not is_cuda(), reason="Requires CUDA")
+@pytest.mark.parametrize("ENABLE_CONSAN,NESTED", [
+    pytest.param(False, False, id="without-consan"),
+    pytest.param(True, False, id="with-consan"),
+    pytest.param(True, True, id="with-consan-nested"),
+])
+def test_consan_noinline_convert_layout_scratch(ENABLE_CONSAN, NESTED, device, fresh_knobs):
+    fresh_knobs.compilation.instrumentation_mode = "consan" if ENABLE_CONSAN else ""
+    values = torch.arange(128, device=device, dtype=torch.int32)
+    output = torch.empty_like(values)
+    sentinel_output = torch.empty_like(values)
+    compiled = _consan_noinline_convert_layout_kernel[(1, )](values, output, sentinel_output, NESTED, num_warps=4)
+    assert compiled.metadata.shared >= 2 * values.numel() * values.element_size()
+    assert compiled.asm["ttgir"].count("noinline = true") >= 1 + int(NESTED)
+    torch.testing.assert_close(output, values)
+    torch.testing.assert_close(sentinel_output, values + 4096)
+
+
 @pytest.mark.skipif(not is_cuda() or torch.cuda.get_device_capability()[0] < 10, reason="Requires blackwell or newer")
 @pytest.mark.parametrize("MEMORY_KIND", ["shared", "tensor"])
 def test_consan_initializes_allocations_with_nan(MEMORY_KIND, device, num_ctas):
@@ -1413,6 +1462,78 @@ def test_tma_store(FAILURE, device, run_wrapper, monkeypatch, num_ctas):
                                            cga_layout=default_cga_layout(num_ctas, 2))
     output_desc = gluon.nvidia.hopper.TensorDescriptor.from_tensor(output, [block_m, XBLOCK.value], shared_layout)
     kernel[(1, )](output_desc, FAILURE=FAILURE, num_warps=4, num_ctas=num_ctas)
+
+
+@pytest.mark.skipif(not is_cuda() or torch.cuda.get_device_capability()[0] < 9, reason="Requires Hopper or newer")
+@pytest.mark.parametrize("FAILURE", [
+    pytest.param(True, id="reused-pending-source"),
+    pytest.param(False, id="stable-source"),
+])
+def test_tma_store_convert_layout_scratch(FAILURE, device, run_wrapper, monkeypatch):
+    if run_wrapper:
+        result = run_in_process(test_tma_store_convert_layout_scratch, (FAILURE, device, False, monkeypatch))
+        if FAILURE:
+            assert_expected_cuda_failure(result.exc)
+            expected_error = "Accessing buffer with pending access. Pending access type: async_copy_shared_to_global"
+            assert expected_error in result.driver_stderr_output
+        else:
+            assert result.exc is None
+            assert result.driver_stderr_output == ""
+        return
+
+    monkeypatch.setenv("TRITON_INSTRUMENTATION_MODE", "consan")
+    monkeypatch.setenv("CUDA_LAUNCH_BLOCKING", "1")
+    knobs.refresh_knobs()
+
+    @gluon.jit
+    def kernel(output_desc, input, sink, iterations, FAILURE: ttgl.constexpr):
+        src_layout: ttgl.constexpr = ttgl.BlockedLayout([1], [32], [4], [0])
+        dst_layout: ttgl.constexpr = ttgl.SliceLayout(1, ttgl.BlockedLayout([1, 1], [1, 32], [1, 4], [1, 0]))
+        src_offsets = ttgl.arange(0, 128, layout=src_layout)
+        dst_offsets = ttgl.arange(0, 128, layout=dst_layout)
+        persistent_page = ttgl.allocate_shared_memory(ttgl.int32, [128], output_desc.layout)
+        if not FAILURE:
+            stable_source_page = ttgl.allocate_shared_memory(ttgl.int32, [128], output_desc.layout)
+
+        for iteration in range(iterations):
+            base = iteration * 128
+
+            # On iteration 1, scratch aliases iteration 0's deallocated source
+            # while its asynchronous TMA read can still be pending.
+            value = ttgl.load(input + base + src_offsets)
+            converted = ttgl.convert_layout(value, dst_layout)
+            ttgl.store(sink + base + dst_offsets, converted)
+
+            # Keep an unrelated store pending so wait(1) does not complete the
+            # source transfer below.
+            tma.store_wait(1)
+            persistent_page.store(value)
+            hopper.fence_async_shared()
+            tma.async_store(output_desc, [2 * base], persistent_page)
+
+            tma.store_wait(1)
+            if FAILURE:
+                source_page = ttgl.allocate_shared_memory(ttgl.int32, [128], output_desc.layout, value)
+            else:
+                stable_source_page.store(value)
+                source_page = stable_source_page
+            hopper.fence_async_shared()
+            tma.async_store(output_desc, [2 * base + 128], source_page)
+            if FAILURE:
+                source_page._keep_alive()
+
+        tma.store_wait(0)
+        persistent_page._keep_alive()
+        if not FAILURE:
+            stable_source_page._keep_alive()
+
+    iterations = 2
+    output = torch.empty(iterations * 2 * 128, dtype=torch.int32, device=device)
+    input = torch.arange(iterations * 128, dtype=torch.int32, device=device)
+    sink = torch.empty_like(input)
+    shared_layout = ttgl.NVMMASharedLayout.get_default_for([128], ttgl.int32)
+    output_desc = gluon.nvidia.hopper.TensorDescriptor.from_tensor(output, [128], shared_layout)
+    kernel[(1, )](output_desc, input, sink, iterations, FAILURE=FAILURE, num_warps=4)
 
 
 @pytest.mark.skipif(not is_cuda() or torch.cuda.get_device_capability()[0] < 10, reason="Requires blackwell or newer")

--- a/python/test/gluon/test_consan.py
+++ b/python/test/gluon/test_consan.py
@@ -200,7 +200,7 @@ def _consan_noinline_convert_layout_kernel(input, output, sentinel_output, NESTE
     ttgl.store(sentinel_output + offsets, caller_allocation.load(layout))
 
 
-@pytest.mark.skipif(not is_cuda(), reason="Requires CUDA")
+@pytest.mark.skipif(not is_cuda() or torch.cuda.get_device_capability()[0] < 9, reason="Requires Hopper or newer")
 @pytest.mark.parametrize("ENABLE_CONSAN,NESTED", [
     pytest.param(False, False, id="without-consan"),
     pytest.param(True, False, id="with-consan"),

--- a/python/test/gluon/test_consan.py
+++ b/python/test/gluon/test_consan.py
@@ -201,13 +201,12 @@ def _consan_noinline_convert_layout_kernel(input, output, sentinel_output, NESTE
 
 
 @pytest.mark.skipif(not is_cuda() or torch.cuda.get_device_capability()[0] < 9, reason="Requires Hopper or newer")
-@pytest.mark.parametrize("ENABLE_CONSAN,NESTED", [
-    pytest.param(False, False, id="without-consan"),
-    pytest.param(True, False, id="with-consan"),
-    pytest.param(True, True, id="with-consan-nested"),
+@pytest.mark.parametrize("NESTED", [
+    pytest.param(False, id="with-consan"),
+    pytest.param(True, id="with-consan-nested"),
 ])
-def test_consan_noinline_convert_layout_scratch(ENABLE_CONSAN, NESTED, device, fresh_knobs):
-    fresh_knobs.compilation.instrumentation_mode = "consan" if ENABLE_CONSAN else ""
+def test_consan_noinline_convert_layout_scratch(NESTED, device, fresh_knobs):
+    fresh_knobs.compilation.instrumentation_mode = "consan"
     values = torch.arange(128, device=device, dtype=torch.int32)
     output = torch.empty_like(values)
     sentinel_output = torch.empty_like(values)

--- a/test/Conversion/allocate_shared_memory.mlir
+++ b/test/Conversion/allocate_shared_memory.mlir
@@ -1,4 +1,4 @@
-// RUN: triton-opt %s --allocate-shared-memory | FileCheck %s
+// RUN: triton-opt %s -split-input-file --allocate-shared-memory | FileCheck %s
 
 #blocked = #ttg.blocked<{sizePerThread = [1, 1], threadsPerWarp = [32, 1], warpsPerCTA = [2, 2], order = [1, 0]}>
 
@@ -14,5 +14,137 @@ tt.func @gather_op(%arg0: tensor<1024x256xi32, #blocked>, %arg1: tensor<128x256x
   %0 = tt.gather %arg1[%arg0] {axis = 0 : i32} : (tensor<128x256xf32, #blocked>, tensor<1024x256xi32, #blocked>) -> tensor<1024x256xf32, #blocked>
   tt.return
 }
+}
 
+// -----
+
+#blocked = #ttg.blocked<{sizePerThread = [1, 1], threadsPerWarp = [32, 1], warpsPerCTA = [2, 2], order = [1, 0]}>
+
+module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32} {
+  tt.func private @scratch_callee(%arg0: tensor<1024x256xi32, #blocked>, %arg1: tensor<128x256xf32, #blocked>) {
+    // CHECK-LABEL: @scratch_callee
+    // CHECK: tt.gather {{.*}}allocation.offset = 0 : i32, allocation.size = 131072 : i32
+    %0 = tt.gather %arg1[%arg0] {axis = 0 : i32} : (tensor<128x256xf32, #blocked>, tensor<1024x256xi32, #blocked>) -> tensor<1024x256xf32, #blocked>
+    tt.return
+  }
+
+  tt.func public @scratch_caller(%arg0: tensor<1024x256xi32, #blocked>, %arg1: tensor<128x256xf32, #blocked>) {
+    // CHECK-LABEL: @scratch_caller
+    // CHECK: tt.call @scratch_callee{{.*}}allocation.offset = 0 : i32, allocation.size = 131072 : i32
+    tt.call @scratch_callee(%arg0, %arg1) : (tensor<1024x256xi32, #blocked>, tensor<128x256xf32, #blocked>) -> ()
+    tt.return
+  }
+}
+
+// -----
+
+#atomic_blocked = #ttg.blocked<{sizePerThread = [1], threadsPerWarp = [32], warpsPerCTA = [4], order = [0]}>
+#atomic_shared = #ttg.swizzled_shared<{vec = 1, perPhase = 1, maxPhase = 1, order = [0]}>
+#atomic_smem = #ttg.shared_memory
+
+module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32} {
+  // CHECK-LABEL: @local_atomic_scratch_size
+  tt.func @local_atomic_scratch_size(
+      %indices: tensor<1xi32, #atomic_blocked>,
+      %values: tensor<1xi32, #atomic_blocked>,
+      %out: tensor<1x!tt.ptr<i32>, #atomic_blocked>) {
+    // Explicit allocations do not acquire scratch-size metadata.
+    // CHECK: %[[ATOMIC_DST:.*]] = ttg.local_alloc {allocation.offset = 0 : i32}
+    %dst = ttg.local_alloc
+        : () -> !ttg.memdesc<1xi32, #atomic_shared, #atomic_smem, mutable>
+    // CHECK: ttg.local_atomic_scatter_rmw {{.*}} {allocation.offset = 128 : i32, allocation.size = 4 : i32, axis = 0 : i32}
+    %old = ttg.local_atomic_scatter_rmw add, %dst[%indices], %values {axis = 0 : i32}
+        : (!ttg.memdesc<1xi32, #atomic_shared, #atomic_smem, mutable>,
+           tensor<1xi32, #atomic_blocked>, tensor<1xi32, #atomic_blocked>)
+        -> tensor<1xi32, #atomic_blocked>
+    tt.store %out, %old : tensor<1x!tt.ptr<i32>, #atomic_blocked>
+    tt.return
+  }
+}
+
+// -----
+
+#reduce = #ttg.blocked<{sizePerThread = [1, 2], threadsPerWarp = [1, 32], warpsPerCTA = [1, 4], order = [1, 0]}>
+
+module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32} {
+  // CHECK-LABEL: @reduce_scratch_size
+  tt.func @reduce_scratch_size(%arg0: tensor<1x256xf32, #reduce>) {
+    // CHECK: "tt.reduce"
+    // CHECK: }) {allocation.offset = 0 : i32, allocation.size = 16 : i32}
+    %0 = "tt.reduce"(%arg0) <{axis = 1 : i32}> ({
+    ^bb0(%lhs: f32, %rhs: f32):
+      %sum = arith.addf %lhs, %rhs : f32
+      tt.reduce.return %sum : f32
+    }) : (tensor<1x256xf32, #reduce>) -> tensor<1xf32, #ttg.slice<{dim = 1, parent = #reduce}>>
+    tt.return
+  }
+}
+
+// -----
+
+#src = #ttg.blocked<{sizePerThread = [1], threadsPerWarp = [32], warpsPerCTA = [4], order = [0]}>
+#dst_parent = #ttg.blocked<{sizePerThread = [1, 1], threadsPerWarp = [1, 32], warpsPerCTA = [1, 4], order = [1, 0]}>
+#dst = #ttg.slice<{dim = 1, parent = #dst_parent}>
+
+module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32} {
+  // CHECK-LABEL: @convert_layout_scratch_size
+  tt.func @convert_layout_scratch_size(%arg0: tensor<128xi32, #src>) {
+    // CHECK: ttg.convert_layout {{.*}} {allocation.offset = 0 : i32, allocation.size = 512 : i32}
+    %0 = ttg.convert_layout %arg0 : tensor<128xi32, #src> -> tensor<128xi32, #dst>
+    tt.return
+  }
+}
+
+// -----
+
+#nested_src = #ttg.blocked<{sizePerThread = [1], threadsPerWarp = [32], warpsPerCTA = [4], order = [0]}>
+#nested_dst_parent = #ttg.blocked<{sizePerThread = [1, 1], threadsPerWarp = [1, 32], warpsPerCTA = [1, 4], order = [1, 0]}>
+#nested_dst = #ttg.slice<{dim = 1, parent = #nested_dst_parent}>
+#nested_shared = #ttg.swizzled_shared<{vec = 1, perPhase = 1, maxPhase = 1, order = [0]}>
+#nested_smem = #ttg.shared_memory
+
+module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32} {
+  // CHECK-LABEL: @nested_scratch_leaf
+  tt.func private @nested_scratch_leaf(%value: tensor<128xi32, #nested_src>) {
+    // CHECK: ttg.convert_layout {{.*}}allocation.offset = 0 : i32, allocation.size = 512 : i32
+    %converted = ttg.convert_layout %value
+        : tensor<128xi32, #nested_src> -> tensor<128xi32, #nested_dst>
+    tt.return
+  }
+
+  // CHECK-LABEL: @nested_scratch_middle
+  tt.func private @nested_scratch_middle(%value: tensor<128xi32, #nested_src>) {
+    // CHECK: tt.call @nested_scratch_leaf{{.*}}allocation.offset = 0 : i32, allocation.size = 512 : i32
+    tt.call @nested_scratch_leaf(%value) : (tensor<128xi32, #nested_src>) -> ()
+    tt.return
+  }
+
+  // CHECK-LABEL: @nested_scratch_caller
+  tt.func public @nested_scratch_caller(%value: tensor<128xi32, #nested_src>) {
+    // CHECK: %[[LIVE_BUFFER:.*]] = ttg.local_alloc {allocation.offset = 0 : i32}
+    %live = ttg.local_alloc : () -> !ttg.memdesc<128xi32, #nested_shared, #nested_smem, mutable>
+    // CHECK: tt.call @nested_scratch_middle{{.*}}allocation.offset = 512 : i32, allocation.size = 512 : i32
+    tt.call @nested_scratch_middle(%value) : (tensor<128xi32, #nested_src>) -> ()
+    %preserved = ttg.local_load %live
+        : !ttg.memdesc<128xi32, #nested_shared, #nested_smem, mutable>
+        -> tensor<128xi32, #nested_src>
+    tt.return
+  }
+}
+
+// -----
+
+module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 1 : i32} {
+  tt.func private @forward_without_scratch(%value: i32) -> i32 {
+    tt.return %value : i32
+  }
+
+  // CHECK-LABEL: @call_without_scratch
+  tt.func public @call_without_scratch(%value: i32) {
+    // CHECK: tt.call @forward_without_scratch(%arg0) : (i32) -> i32
+    // CHECK-NOT: allocation.size
+    // CHECK: tt.return
+    %forwarded = tt.call @forward_without_scratch(%value) : (i32) -> i32
+    tt.return
+  }
 }

--- a/test/Conversion/allocate_shared_memory.mlir
+++ b/test/Conversion/allocate_shared_memory.mlir
@@ -18,85 +18,6 @@ tt.func @gather_op(%arg0: tensor<1024x256xi32, #blocked>, %arg1: tensor<128x256x
 
 // -----
 
-#blocked = #ttg.blocked<{sizePerThread = [1, 1], threadsPerWarp = [32, 1], warpsPerCTA = [2, 2], order = [1, 0]}>
-
-module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32} {
-  tt.func private @scratch_callee(%arg0: tensor<1024x256xi32, #blocked>, %arg1: tensor<128x256xf32, #blocked>) {
-    // CHECK-LABEL: @scratch_callee
-    // CHECK: tt.gather {{.*}}allocation.offset = 0 : i32, allocation.size = 131072 : i32
-    %0 = tt.gather %arg1[%arg0] {axis = 0 : i32} : (tensor<128x256xf32, #blocked>, tensor<1024x256xi32, #blocked>) -> tensor<1024x256xf32, #blocked>
-    tt.return
-  }
-
-  tt.func public @scratch_caller(%arg0: tensor<1024x256xi32, #blocked>, %arg1: tensor<128x256xf32, #blocked>) {
-    // CHECK-LABEL: @scratch_caller
-    // CHECK: tt.call @scratch_callee{{.*}}allocation.offset = 0 : i32, allocation.size = 131072 : i32
-    tt.call @scratch_callee(%arg0, %arg1) : (tensor<1024x256xi32, #blocked>, tensor<128x256xf32, #blocked>) -> ()
-    tt.return
-  }
-}
-
-// -----
-
-#atomic_blocked = #ttg.blocked<{sizePerThread = [1], threadsPerWarp = [32], warpsPerCTA = [4], order = [0]}>
-#atomic_shared = #ttg.swizzled_shared<{vec = 1, perPhase = 1, maxPhase = 1, order = [0]}>
-#atomic_smem = #ttg.shared_memory
-
-module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32} {
-  // CHECK-LABEL: @local_atomic_scratch_size
-  tt.func @local_atomic_scratch_size(
-      %indices: tensor<1xi32, #atomic_blocked>,
-      %values: tensor<1xi32, #atomic_blocked>,
-      %out: tensor<1x!tt.ptr<i32>, #atomic_blocked>) {
-    // Explicit allocations do not acquire scratch-size metadata.
-    // CHECK: %[[ATOMIC_DST:.*]] = ttg.local_alloc {allocation.offset = 0 : i32}
-    %dst = ttg.local_alloc
-        : () -> !ttg.memdesc<1xi32, #atomic_shared, #atomic_smem, mutable>
-    // CHECK: ttg.local_atomic_scatter_rmw {{.*}} {allocation.offset = 128 : i32, allocation.size = 4 : i32, axis = 0 : i32}
-    %old = ttg.local_atomic_scatter_rmw add, %dst[%indices], %values {axis = 0 : i32}
-        : (!ttg.memdesc<1xi32, #atomic_shared, #atomic_smem, mutable>,
-           tensor<1xi32, #atomic_blocked>, tensor<1xi32, #atomic_blocked>)
-        -> tensor<1xi32, #atomic_blocked>
-    tt.store %out, %old : tensor<1x!tt.ptr<i32>, #atomic_blocked>
-    tt.return
-  }
-}
-
-// -----
-
-#reduce = #ttg.blocked<{sizePerThread = [1, 2], threadsPerWarp = [1, 32], warpsPerCTA = [1, 4], order = [1, 0]}>
-
-module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32} {
-  // CHECK-LABEL: @reduce_scratch_size
-  tt.func @reduce_scratch_size(%arg0: tensor<1x256xf32, #reduce>) {
-    // CHECK: "tt.reduce"
-    // CHECK: }) {allocation.offset = 0 : i32, allocation.size = 16 : i32}
-    %0 = "tt.reduce"(%arg0) <{axis = 1 : i32}> ({
-    ^bb0(%lhs: f32, %rhs: f32):
-      %sum = arith.addf %lhs, %rhs : f32
-      tt.reduce.return %sum : f32
-    }) : (tensor<1x256xf32, #reduce>) -> tensor<1xf32, #ttg.slice<{dim = 1, parent = #reduce}>>
-    tt.return
-  }
-}
-
-// -----
-
-#src = #ttg.blocked<{sizePerThread = [1], threadsPerWarp = [32], warpsPerCTA = [4], order = [0]}>
-#dst_parent = #ttg.blocked<{sizePerThread = [1, 1], threadsPerWarp = [1, 32], warpsPerCTA = [1, 4], order = [1, 0]}>
-#dst = #ttg.slice<{dim = 1, parent = #dst_parent}>
-
-module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32} {
-  // CHECK-LABEL: @convert_layout_scratch_size
-  tt.func @convert_layout_scratch_size(%arg0: tensor<128xi32, #src>) {
-    // CHECK: ttg.convert_layout {{.*}} {allocation.offset = 0 : i32, allocation.size = 512 : i32}
-    %0 = ttg.convert_layout %arg0 : tensor<128xi32, #src> -> tensor<128xi32, #dst>
-    tt.return
-  }
-}
-
-// -----
-
 #nested_src = #ttg.blocked<{sizePerThread = [1], threadsPerWarp = [32], warpsPerCTA = [4], order = [0]}>
 #nested_dst_parent = #ttg.blocked<{sizePerThread = [1, 1], threadsPerWarp = [1, 32], warpsPerCTA = [1, 4], order = [1, 0]}>
 #nested_dst = #ttg.slice<{dim = 1, parent = #nested_dst_parent}>
@@ -128,23 +49,6 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32} {
     %preserved = ttg.local_load %live
         : !ttg.memdesc<128xi32, #nested_shared, #nested_smem, mutable>
         -> tensor<128xi32, #nested_src>
-    tt.return
-  }
-}
-
-// -----
-
-module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 1 : i32} {
-  tt.func private @forward_without_scratch(%value: i32) -> i32 {
-    tt.return %value : i32
-  }
-
-  // CHECK-LABEL: @call_without_scratch
-  tt.func public @call_without_scratch(%value: i32) {
-    // CHECK: tt.call @forward_without_scratch(%arg0) : (i32) -> i32
-    // CHECK-NOT: allocation.size
-    // CHECK: tt.return
-    %forwarded = tt.call @forward_without_scratch(%value) : (i32) -> i32
     tt.return
   }
 }

--- a/test/TritonGPU/amd/amd-consan.mlir
+++ b/test/TritonGPU/amd/amd-consan.mlir
@@ -1311,49 +1311,33 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.shar
 #amd_convert_src = #ttg.blocked<{sizePerThread = [1], threadsPerWarp = [32], warpsPerCTA = [4], order = [0]}>
 #amd_convert_parent = #ttg.blocked<{sizePerThread = [1, 1], threadsPerWarp = [1, 32], warpsPerCTA = [1, 4], order = [1, 0]}>
 #amd_convert_dst = #ttg.slice<{dim = 1, parent = #amd_convert_parent}>
+#amd_convert_barrier = #ttg.swizzled_shared<{vec = 1, perPhase = 1, maxPhase = 1, order = [0]}>
 
 module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, "ttg.threads-per-warp" = 32 : i32, "ttg.total-num-warps" = 4 : i32, ttg.shared = 512 : i32, ttg.target = "hip:gfx1250", ttg.tensor_memory_size = 0 : i32} {
   // CHECK-LABEL: @amd_convert_layout_shared_scratch
   tt.func public @amd_convert_layout_shared_scratch(
       %value: tensor<128xi32, #amd_convert_src>) {
+    %barrier = ttg.local_alloc {allocation.offset = 0 : i32}
+        : () -> !ttg.memdesc<1xi64, #amd_convert_barrier, #ttg.shared_memory, mutable>
+    amdg.init_barrier %barrier, 128
+        : !ttg.memdesc<1xi64, #amd_convert_barrier, #ttg.shared_memory, mutable>
+    %phase = amdg.arrive_barrier %barrier, 1
+        : !ttg.memdesc<1xi64, #amd_convert_barrier, #ttg.shared_memory, mutable> -> i32
+    amdg.wait_barrier %barrier, %phase
+        : !ttg.memdesc<1xi64, #amd_convert_barrier, #ttg.shared_memory, mutable>
+    // CHECK: ttg.local_dealloc
+    ttg.local_dealloc %barrier
+        : !ttg.memdesc<1xi64, #amd_convert_barrier, #ttg.shared_memory, mutable>
+    // CHECK-NOT: tt.call @__triton_consan_verify_barrier_can_init
     // CHECK: tt.call @__triton_consan_verify_write_visibility
     // CHECK: tt.call @__triton_consan_verify_read_visibility
+    // CHECK: tt.call @__triton_consan_invalidate_barrier_storage
     // CHECK: tt.call @__triton_consan_publish_write_visibility
     // CHECK: ttg.convert_layout
     %converted = ttg.convert_layout %value
         {allocation.offset = 0 : i32, allocation.size = 512 : i32}
         : tensor<128xi32, #amd_convert_src>
         -> tensor<128xi32, #amd_convert_dst>
-    tt.return
-  }
-}
-
-// -----
-
-#amd_atomic_broadcast = #ttg.blocked<{sizePerThread = [1], threadsPerWarp = [32], warpsPerCTA = [4], order = [0], CGALayout = [[0]]}>
-
-module attributes {"ttg.num-ctas" = 2 : i32, "ttg.num-warps" = 4 : i32, "ttg.threads-per-warp" = 32 : i32, "ttg.total-num-warps" = 4 : i32, ttg.shared = 64 : i32, ttg.target = "hip:gfx1250", ttg.tensor_memory_size = 0 : i32} {
-  // CHECK-LABEL: @amd_buffer_atomic_broadcast_scratch
-  tt.func public @amd_buffer_atomic_broadcast_scratch(
-      %base: !tt.ptr<i32>,
-      %offsets: tensor<16xi32, #amd_atomic_broadcast>,
-      %values: tensor<16xi32, #amd_atomic_broadcast>,
-      %out: tensor<16x!tt.ptr<i32>, #amd_atomic_broadcast>) {
-    // AMD initializes cluster-wide ConSan state with its own barrier dialect.
-    // CHECK: amdg.cluster_barrier_arrive
-    // CHECK-NEXT: amdg.cluster_barrier_wait
-    // CHECK: %[[AMD_PRODUCER:.*]] = arith.cmpi eq, {{.*}} : i32
-    // CHECK: %[[AMD_ALL_ROWS:.*]] = arith.constant 3 : i32
-    // CHECK: %[[AMD_GROUP_ROWS:.*]] = arith.shli %[[AMD_ALL_ROWS]], {{.*}} : i32
-    // CHECK: %[[AMD_RECIPIENTS:.*]] = arith.ori {{.*}}, %[[AMD_GROUP_ROWS]] : i32
-    // CHECK: tt.call @__triton_consan_verify_write_visibility{{.*}}%[[AMD_PRODUCER]]{{.*}}%[[AMD_RECIPIENTS]]
-    // CHECK: tt.call @__triton_consan_verify_read_visibility{{.*}}%[[AMD_PRODUCER]]{{.*}}%[[AMD_RECIPIENTS]]
-    // CHECK: tt.call @__triton_consan_publish_write_visibility{{.*}}%[[AMD_PRODUCER]]{{.*}}%[[AMD_RECIPIENTS]]
-    // CHECK: amdg.buffer_atomic_rmw
-    %old = amdg.buffer_atomic_rmw add, acq_rel, gpu, %values, %base[%offsets]
-        {allocation.offset = 0 : i32, allocation.size = 64 : i32}
-        : tensor<16xi32, #amd_atomic_broadcast>
-    tt.store %out, %old : tensor<16x!tt.ptr<i32>, #amd_atomic_broadcast>
     tt.return
   }
 }

--- a/test/TritonGPU/amd/amd-consan.mlir
+++ b/test/TritonGPU/amd/amd-consan.mlir
@@ -1305,3 +1305,84 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.shar
     tt.return
   }
 }
+
+// -----
+
+#amd_convert_src = #ttg.blocked<{sizePerThread = [1], threadsPerWarp = [32], warpsPerCTA = [4], order = [0]}>
+#amd_convert_parent = #ttg.blocked<{sizePerThread = [1, 1], threadsPerWarp = [1, 32], warpsPerCTA = [1, 4], order = [1, 0]}>
+#amd_convert_dst = #ttg.slice<{dim = 1, parent = #amd_convert_parent}>
+
+module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, "ttg.threads-per-warp" = 32 : i32, "ttg.total-num-warps" = 4 : i32, ttg.shared = 512 : i32, ttg.target = "hip:gfx1250", ttg.tensor_memory_size = 0 : i32} {
+  // CHECK-LABEL: @amd_convert_layout_shared_scratch
+  tt.func public @amd_convert_layout_shared_scratch(
+      %value: tensor<128xi32, #amd_convert_src>) {
+    // CHECK: tt.call @__triton_consan_verify_write_visibility
+    // CHECK: tt.call @__triton_consan_verify_read_visibility
+    // CHECK: tt.call @__triton_consan_publish_write_visibility
+    // CHECK: ttg.convert_layout
+    %converted = ttg.convert_layout %value
+        {allocation.offset = 0 : i32, allocation.size = 512 : i32}
+        : tensor<128xi32, #amd_convert_src>
+        -> tensor<128xi32, #amd_convert_dst>
+    tt.return
+  }
+}
+
+// -----
+
+#amd_atomic_broadcast = #ttg.blocked<{sizePerThread = [1], threadsPerWarp = [32], warpsPerCTA = [4], order = [0], CGALayout = [[0]]}>
+
+module attributes {"ttg.num-ctas" = 2 : i32, "ttg.num-warps" = 4 : i32, "ttg.threads-per-warp" = 32 : i32, "ttg.total-num-warps" = 4 : i32, ttg.shared = 64 : i32, ttg.target = "hip:gfx1250", ttg.tensor_memory_size = 0 : i32} {
+  // CHECK-LABEL: @amd_buffer_atomic_broadcast_scratch
+  tt.func public @amd_buffer_atomic_broadcast_scratch(
+      %base: !tt.ptr<i32>,
+      %offsets: tensor<16xi32, #amd_atomic_broadcast>,
+      %values: tensor<16xi32, #amd_atomic_broadcast>,
+      %out: tensor<16x!tt.ptr<i32>, #amd_atomic_broadcast>) {
+    // AMD initializes cluster-wide ConSan state with its own barrier dialect.
+    // CHECK: amdg.cluster_barrier_arrive
+    // CHECK-NEXT: amdg.cluster_barrier_wait
+    // CHECK: %[[AMD_PRODUCER:.*]] = arith.cmpi eq, {{.*}} : i32
+    // CHECK: %[[AMD_ALL_ROWS:.*]] = arith.constant 3 : i32
+    // CHECK: %[[AMD_GROUP_ROWS:.*]] = arith.shli %[[AMD_ALL_ROWS]], {{.*}} : i32
+    // CHECK: %[[AMD_RECIPIENTS:.*]] = arith.ori {{.*}}, %[[AMD_GROUP_ROWS]] : i32
+    // CHECK: tt.call @__triton_consan_verify_write_visibility{{.*}}%[[AMD_PRODUCER]]{{.*}}%[[AMD_RECIPIENTS]]
+    // CHECK: tt.call @__triton_consan_verify_read_visibility{{.*}}%[[AMD_PRODUCER]]{{.*}}%[[AMD_RECIPIENTS]]
+    // CHECK: tt.call @__triton_consan_publish_write_visibility{{.*}}%[[AMD_PRODUCER]]{{.*}}%[[AMD_RECIPIENTS]]
+    // CHECK: amdg.buffer_atomic_rmw
+    %old = amdg.buffer_atomic_rmw add, acq_rel, gpu, %values, %base[%offsets]
+        {allocation.offset = 0 : i32, allocation.size = 64 : i32}
+        : tensor<16xi32, #amd_atomic_broadcast>
+    tt.store %out, %old : tensor<16x!tt.ptr<i32>, #amd_atomic_broadcast>
+    tt.return
+  }
+}
+
+// -----
+
+module attributes {"ttg.num-ctas" = 2 : i32, "ttg.num-warps" = 1 : i32, "ttg.threads-per-warp" = 32 : i32, "ttg.total-num-warps" = 1 : i32, ttg.shared = 4 : i32, ttg.target = "hip:gfx1250", ttg.tensor_memory_size = 0 : i32} {
+  // CHECK-LABEL: @amd_scalar_atomic_scratch_stays_cta_local
+  tt.func public @amd_scalar_atomic_scratch_stays_cta_local(
+      %ptr: !tt.ptr<i32>, %out: !tt.ptr<i32>) {
+    %one = arith.constant 1 : i32
+    // Skip cluster-state initialization and the unrelated default effect mask.
+    // CHECK: tti.experimental_lock_acquire
+    // CHECK-NOT: arith.cmpi eq
+    // CHECK: tti.experimental_cluster_cta_id
+    // CHECK: arith.shli
+    // CHECK: %[[AMD_SCALAR_CTA:.*]] = tti.experimental_cluster_cta_id
+    // CHECK: %[[AMD_SCALAR_RECIPIENT:.*]] = arith.shli {{.*}}, %[[AMD_SCALAR_CTA]] : i32
+    // CHECK-NOT: arith.cmpi eq
+    // CHECK: tt.call @__triton_consan_verify_write_visibility{{.*}}%[[AMD_SCALAR_RECIPIENT]]
+    // CHECK: tt.call @__triton_consan_verify_read_visibility{{.*}}%[[AMD_SCALAR_RECIPIENT]]
+    // CHECK: tt.call @__triton_consan_publish_write_visibility{{.*}}%[[AMD_SCALAR_RECIPIENT]]
+    // CHECK: tt.atomic_rmw
+    %old = tt.atomic_rmw add, relaxed, gpu, %ptr, %one
+        {allocation.offset = 0 : i32, allocation.size = 4 : i32}
+        : (!tt.ptr<i32>, i32) -> i32
+    tt.store %out, %old : !tt.ptr<i32>
+    amdg.cluster_barrier_arrive
+    amdg.cluster_barrier_wait
+    tt.return
+  }
+}

--- a/test/TritonGPU/amd/amd-consan.mlir
+++ b/test/TritonGPU/amd/amd-consan.mlir
@@ -1345,6 +1345,16 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, "ttg.thr
 // -----
 
 module attributes {"ttg.num-ctas" = 2 : i32, "ttg.num-warps" = 1 : i32, "ttg.threads-per-warp" = 32 : i32, "ttg.total-num-warps" = 1 : i32, ttg.shared = 4 : i32, ttg.target = "hip:gfx1250", ttg.tensor_memory_size = 0 : i32} {
+  // CHECK-LABEL: tt.func private @amd_scalar_atomic_callee
+  // CHECK: tt.atomic_rmw
+  tt.func private @amd_scalar_atomic_callee(%ptr: !tt.ptr<i32>) -> i32 {
+    %one = arith.constant 1 : i32
+    %old = tt.atomic_rmw add, relaxed, gpu, %ptr, %one
+        {allocation.offset = 0 : i32, allocation.size = 4 : i32}
+        : (!tt.ptr<i32>, i32) -> i32
+    tt.return %old : i32
+  }
+
   // CHECK-LABEL: @amd_scalar_atomic_scratch_stays_cta_local
   tt.func public @amd_scalar_atomic_scratch_stays_cta_local(
       %ptr: !tt.ptr<i32>, %out: !tt.ptr<i32>) {
@@ -1365,6 +1375,10 @@ module attributes {"ttg.num-ctas" = 2 : i32, "ttg.num-warps" = 1 : i32, "ttg.thr
         {allocation.offset = 0 : i32, allocation.size = 4 : i32}
         : (!tt.ptr<i32>, i32) -> i32
     tt.store %out, %old : !tt.ptr<i32>
+    // CHECK: tt.call @amd_scalar_atomic_callee
+    %callee = tt.call @amd_scalar_atomic_callee(%ptr)
+        {allocation.offset = 0 : i32, allocation.size = 4 : i32}
+        : (!tt.ptr<i32>) -> i32
     amdg.cluster_barrier_arrive
     amdg.cluster_barrier_wait
     tt.return

--- a/test/TritonGPU/consan-capture-reservation.mlir
+++ b/test/TritonGPU/consan-capture-reservation.mlir
@@ -7,8 +7,6 @@
 // RUN: not triton-opt %t/private-amd-cluster-arrive.mlir -allow-unregistered-dialect -tritoninstrument-concurrency-sanitizer 2>&1 | FileCheck %t/private-amd-cluster-arrive.mlir --check-prefix=AMD-ARRIVE
 // RUN: not triton-opt %t/private-amd-cluster-wait.mlir -allow-unregistered-dialect -tritoninstrument-concurrency-sanitizer 2>&1 | FileCheck %t/private-amd-cluster-wait.mlir --check-prefix=AMD-WAIT
 // RUN: not triton-opt %t/private-cross-cta-scratch.mlir -allow-unregistered-dialect -tritoninstrument-concurrency-sanitizer 2>&1 | FileCheck %t/private-cross-cta-scratch.mlir --check-prefix=CROSS-CTA
-// RUN: not triton-opt %t/scratch-missing-offset.mlir -allow-unregistered-dialect -tritoninstrument-concurrency-sanitizer 2>&1 | FileCheck %t/scratch-missing-offset.mlir --check-prefix=SCRATCH-MISSING-OFFSET
-// RUN: not triton-opt %t/scratch-invalid.mlir -allow-unregistered-dialect -tritoninstrument-concurrency-sanitizer 2>&1 | FileCheck %t/scratch-invalid.mlir --check-prefix=SCRATCH-INVALID
 
 //--- missing.mlir
 
@@ -130,36 +128,6 @@ module attributes {"ttg.num-ctas" = 2 : i32, "ttg.num-warps" = 4 : i32, "ttg.thr
   tt.func public @entry(%value: tensor<8x32xi32, #cross_src>) {
     tt.call @private_cross_cta_conversion(%value) {allocation.offset = 0 : i32, allocation.size = 512 : i32}
         : (tensor<8x32xi32, #cross_src>) -> ()
-    tt.return
-  }
-}
-
-//--- scratch-missing-offset.mlir
-
-#src = #ttg.blocked<{sizePerThread = [1], threadsPerWarp = [32], warpsPerCTA = [4], order = [0]}>
-#dst_parent = #ttg.blocked<{sizePerThread = [1, 1], threadsPerWarp = [1, 32], warpsPerCTA = [1, 4], order = [1, 0]}>
-#dst = #ttg.slice<{dim = 1, parent = #dst_parent}>
-
-module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, "ttg.threads-per-warp" = 32 : i32, "ttg.total-num-warps" = 4 : i32, ttg.shared = 512 : i32, ttg.target = "cuda:90", ttg.tensor_memory_size = 0 : i32} {
-  tt.func public @scratch_missing_offset(%value: tensor<128xi32, #src>) {
-    // SCRATCH-MISSING-OFFSET: compiler scratch metadata requires integer allocation.offset and allocation.size attributes
-    %converted = ttg.convert_layout %value {allocation.size = 512 : i32}
-        : tensor<128xi32, #src> -> tensor<128xi32, #dst>
-    tt.return
-  }
-}
-
-//--- scratch-invalid.mlir
-
-#src = #ttg.blocked<{sizePerThread = [1], threadsPerWarp = [32], warpsPerCTA = [4], order = [0]}>
-#dst_parent = #ttg.blocked<{sizePerThread = [1, 1], threadsPerWarp = [1, 32], warpsPerCTA = [1, 4], order = [1, 0]}>
-#dst = #ttg.slice<{dim = 1, parent = #dst_parent}>
-
-module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, "ttg.threads-per-warp" = 32 : i32, "ttg.total-num-warps" = 4 : i32, ttg.shared = 512 : i32, ttg.target = "cuda:90", ttg.tensor_memory_size = 0 : i32} {
-  tt.func public @scratch_invalid(%value: tensor<128xi32, #src>) {
-    // SCRATCH-INVALID: invalid compiler scratch allocation metadata: offset 16777215, size 2
-    %converted = ttg.convert_layout %value {allocation.offset = 16777215 : i32, allocation.size = 2 : i32}
-        : tensor<128xi32, #src> -> tensor<128xi32, #dst>
     tt.return
   }
 }

--- a/test/TritonGPU/consan-capture-reservation.mlir
+++ b/test/TritonGPU/consan-capture-reservation.mlir
@@ -1,6 +1,14 @@
 // RUN: split-file %s %t
 // RUN: not triton-opt %t/missing.mlir -allow-unregistered-dialect -tritoninstrument-concurrency-sanitizer 2>&1 | FileCheck %t/missing.mlir --check-prefix=MISSING
 // RUN: not triton-opt %t/too-small.mlir -allow-unregistered-dialect -tritoninstrument-concurrency-sanitizer 2>&1 | FileCheck %t/too-small.mlir --check-prefix=SMALL
+// RUN: not triton-opt %t/unsupported-callee.mlir -allow-unregistered-dialect -tritoninstrument-concurrency-sanitizer 2>&1 | FileCheck %t/unsupported-callee.mlir --check-prefix=CALLEE
+// RUN: not triton-opt %t/private-shared-access.mlir -allow-unregistered-dialect -tritoninstrument-concurrency-sanitizer 2>&1 | FileCheck %t/private-shared-access.mlir --check-prefix=PRIVATE-ACCESS
+// RUN: not triton-opt %t/private-mbarrier.mlir -allow-unregistered-dialect -tritoninstrument-concurrency-sanitizer 2>&1 | FileCheck %t/private-mbarrier.mlir --check-prefix=PRIVATE-MBARRIER
+// RUN: not triton-opt %t/private-amd-cluster-arrive.mlir -allow-unregistered-dialect -tritoninstrument-concurrency-sanitizer 2>&1 | FileCheck %t/private-amd-cluster-arrive.mlir --check-prefix=AMD-ARRIVE
+// RUN: not triton-opt %t/private-amd-cluster-wait.mlir -allow-unregistered-dialect -tritoninstrument-concurrency-sanitizer 2>&1 | FileCheck %t/private-amd-cluster-wait.mlir --check-prefix=AMD-WAIT
+// RUN: not triton-opt %t/private-cross-cta-scratch.mlir -allow-unregistered-dialect -tritoninstrument-concurrency-sanitizer 2>&1 | FileCheck %t/private-cross-cta-scratch.mlir --check-prefix=CROSS-CTA
+// RUN: not triton-opt %t/scratch-missing-offset.mlir -allow-unregistered-dialect -tritoninstrument-concurrency-sanitizer 2>&1 | FileCheck %t/scratch-missing-offset.mlir --check-prefix=SCRATCH-MISSING-OFFSET
+// RUN: not triton-opt %t/scratch-invalid.mlir -allow-unregistered-dialect -tritoninstrument-concurrency-sanitizer 2>&1 | FileCheck %t/scratch-invalid.mlir --check-prefix=SCRATCH-INVALID
 
 //--- missing.mlir
 
@@ -14,6 +22,144 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, "ttg.thr
     partition0() num_warps(4) {
       ttg.warp_return
     } : () -> ()
+    tt.return
+  }
+}
+
+//--- unsupported-callee.mlir
+
+#shared = #ttg.swizzled_shared<{vec = 1, perPhase = 1, maxPhase = 1, order = [0]}>
+#smem = #ttg.shared_memory
+
+module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 1 : i32, "ttg.threads-per-warp" = 32 : i32, "ttg.total-num-warps" = 1 : i32, ttg.shared = 64 : i32, ttg.target = "cuda:90", ttg.tensor_memory_size = 0 : i32} {
+  tt.func private @unsupported_callee() {
+    // CALLEE: ConSan cannot summarize ttg.local_alloc in non-entry function @unsupported_callee
+    // CALLEE-SAME: inline the function before ConSan or keep its body limited to register/global-memory operations and compiler-owned shared scratch
+    %buf = ttg.local_alloc {allocation.offset = 0 : i32} : () -> !ttg.memdesc<16xi32, #shared, #smem, mutable>
+    %0 = ttg.local_load %buf : !ttg.memdesc<16xi32, #shared, #smem, mutable> -> tensor<16xi32>
+    tt.return
+  }
+
+  tt.func public @entry() {
+    tt.call @unsupported_callee() {allocation.offset = 0 : i32, allocation.size = 64 : i32} : () -> ()
+    tt.return
+  }
+}
+
+//--- private-shared-access.mlir
+
+#shared = #ttg.swizzled_shared<{vec = 1, perPhase = 1, maxPhase = 1, order = [0]}>
+#smem = #ttg.shared_memory
+
+module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 1 : i32, "ttg.threads-per-warp" = 32 : i32, "ttg.total-num-warps" = 1 : i32, ttg.shared = 64 : i32, ttg.target = "cuda:90", ttg.tensor_memory_size = 0 : i32} {
+  tt.func private @read_caller_descriptor(%incoming: !ttg.memdesc<16xi32, #shared, #smem, mutable>) {
+    // PRIVATE-ACCESS: ConSan cannot summarize ttg.local_load in non-entry function @read_caller_descriptor
+    %value = ttg.local_load %incoming : !ttg.memdesc<16xi32, #shared, #smem, mutable> -> tensor<16xi32>
+    tt.return
+  }
+
+  tt.func public @entry() {
+    %buffer = ttg.local_alloc {allocation.offset = 0 : i32} : () -> !ttg.memdesc<16xi32, #shared, #smem, mutable>
+    tt.call @read_caller_descriptor(%buffer) : (!ttg.memdesc<16xi32, #shared, #smem, mutable>) -> ()
+    tt.return
+  }
+}
+
+//--- private-mbarrier.mlir
+
+#shared = #ttg.swizzled_shared<{vec = 1, perPhase = 1, maxPhase = 1, order = [0]}>
+#smem = #ttg.shared_memory
+
+module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 1 : i32, "ttg.threads-per-warp" = 32 : i32, "ttg.total-num-warps" = 1 : i32, ttg.shared = 8 : i32, ttg.target = "cuda:90", ttg.tensor_memory_size = 0 : i32} {
+  tt.func private @initialize_caller_barrier(%barrier: !ttg.memdesc<1xi64, #shared, #smem, mutable>) {
+    // PRIVATE-MBARRIER: ConSan cannot summarize ttng.init_barrier in non-entry function @initialize_caller_barrier
+    ttng.init_barrier %barrier, 1 : !ttg.memdesc<1xi64, #shared, #smem, mutable>
+    tt.return
+  }
+
+  tt.func public @entry() {
+    %barrier = ttg.local_alloc {allocation.offset = 0 : i32} : () -> !ttg.memdesc<1xi64, #shared, #smem, mutable>
+    tt.call @initialize_caller_barrier(%barrier) : (!ttg.memdesc<1xi64, #shared, #smem, mutable>) -> ()
+    tt.return
+  }
+}
+
+//--- private-amd-cluster-arrive.mlir
+
+module attributes {"ttg.num-ctas" = 2 : i32, "ttg.num-warps" = 1 : i32, "ttg.threads-per-warp" = 32 : i32, "ttg.total-num-warps" = 1 : i32, ttg.shared = 0 : i32, ttg.target = "hip:gfx1250"} {
+  tt.func private @private_cluster_arrive() {
+    // AMD-ARRIVE: ConSan cannot summarize amdg.cluster_barrier_arrive in non-entry function @private_cluster_arrive
+    amdg.cluster_barrier_arrive
+    tt.return
+  }
+
+  tt.func public @entry() {
+    tt.call @private_cluster_arrive() : () -> ()
+    tt.return
+  }
+}
+
+//--- private-amd-cluster-wait.mlir
+
+module attributes {"ttg.num-ctas" = 2 : i32, "ttg.num-warps" = 1 : i32, "ttg.threads-per-warp" = 32 : i32, "ttg.total-num-warps" = 1 : i32, ttg.shared = 0 : i32, ttg.target = "hip:gfx1250"} {
+  tt.func private @private_cluster_wait() {
+    // AMD-WAIT: ConSan cannot summarize amdg.cluster_barrier_wait in non-entry function @private_cluster_wait
+    amdg.cluster_barrier_wait
+    tt.return
+  }
+
+  tt.func public @entry() {
+    tt.call @private_cluster_wait() : () -> ()
+    tt.return
+  }
+}
+
+//--- private-cross-cta-scratch.mlir
+
+#cross_src = #ttg.blocked<{sizePerThread = [1, 1], threadsPerWarp = [1, 32], warpsPerCTA = [1, 4], order = [1, 0], CGALayout = [[1, 0]]}>
+#cross_dst = #ttg.blocked<{sizePerThread = [1, 1], threadsPerWarp = [1, 32], warpsPerCTA = [1, 4], order = [1, 0], CGALayout = [[0, 1]]}>
+
+module attributes {"ttg.num-ctas" = 2 : i32, "ttg.num-warps" = 4 : i32, "ttg.threads-per-warp" = 32 : i32, "ttg.total-num-warps" = 4 : i32, ttg.shared = 512 : i32, ttg.target = "cuda:90", ttg.tensor_memory_size = 0 : i32} {
+  tt.func private @private_cross_cta_conversion(%value: tensor<8x32xi32, #cross_src>) {
+    // CROSS-CTA: ConSan cannot summarize ttg.convert_layout in non-entry function @private_cross_cta_conversion
+    %converted = ttg.convert_layout %value {allocation.offset = 0 : i32, allocation.size = 512 : i32}
+        : tensor<8x32xi32, #cross_src> -> tensor<8x32xi32, #cross_dst>
+    tt.return
+  }
+
+  tt.func public @entry(%value: tensor<8x32xi32, #cross_src>) {
+    tt.call @private_cross_cta_conversion(%value) {allocation.offset = 0 : i32, allocation.size = 512 : i32}
+        : (tensor<8x32xi32, #cross_src>) -> ()
+    tt.return
+  }
+}
+
+//--- scratch-missing-offset.mlir
+
+#src = #ttg.blocked<{sizePerThread = [1], threadsPerWarp = [32], warpsPerCTA = [4], order = [0]}>
+#dst_parent = #ttg.blocked<{sizePerThread = [1, 1], threadsPerWarp = [1, 32], warpsPerCTA = [1, 4], order = [1, 0]}>
+#dst = #ttg.slice<{dim = 1, parent = #dst_parent}>
+
+module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, "ttg.threads-per-warp" = 32 : i32, "ttg.total-num-warps" = 4 : i32, ttg.shared = 512 : i32, ttg.target = "cuda:90", ttg.tensor_memory_size = 0 : i32} {
+  tt.func public @scratch_missing_offset(%value: tensor<128xi32, #src>) {
+    // SCRATCH-MISSING-OFFSET: compiler scratch metadata requires integer allocation.offset and allocation.size attributes
+    %converted = ttg.convert_layout %value {allocation.size = 512 : i32}
+        : tensor<128xi32, #src> -> tensor<128xi32, #dst>
+    tt.return
+  }
+}
+
+//--- scratch-invalid.mlir
+
+#src = #ttg.blocked<{sizePerThread = [1], threadsPerWarp = [32], warpsPerCTA = [4], order = [0]}>
+#dst_parent = #ttg.blocked<{sizePerThread = [1, 1], threadsPerWarp = [1, 32], warpsPerCTA = [1, 4], order = [1, 0]}>
+#dst = #ttg.slice<{dim = 1, parent = #dst_parent}>
+
+module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, "ttg.threads-per-warp" = 32 : i32, "ttg.total-num-warps" = 4 : i32, ttg.shared = 512 : i32, ttg.target = "cuda:90", ttg.tensor_memory_size = 0 : i32} {
+  tt.func public @scratch_invalid(%value: tensor<128xi32, #src>) {
+    // SCRATCH-INVALID: invalid compiler scratch allocation metadata: offset 16777215, size 2
+    %converted = ttg.convert_layout %value {allocation.offset = 16777215 : i32, allocation.size = 2 : i32}
+        : tensor<128xi32, #src> -> tensor<128xi32, #dst>
     tt.return
   }
 }

--- a/test/TritonGPU/consan.mlir
+++ b/test/TritonGPU/consan.mlir
@@ -38,6 +38,53 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 1 : i32, ttg.shar
 
 // -----
 
+#call_blocked = #ttg.blocked<{sizePerThread = [1, 1], threadsPerWarp = [32, 1], warpsPerCTA = [2, 2], order = [1, 0], CGALayout = [[1, 0]]}>
+#call_shared = #ttg.swizzled_shared<{vec = 1, perPhase = 1, maxPhase = 1, order = [0], CGALayout = [[1]]}>
+#call_smem = #ttg.shared_memory
+#call_load_blocked = #ttg.blocked<{sizePerThread = [4], threadsPerWarp = [32], warpsPerCTA = [4], order = [0], CGALayout = [[1]]}>
+
+module attributes {"ttg.num-ctas" = 2 : i32, "ttg.num-warps" = 4 : i32, "ttg.threads-per-warp" = 32 : i32, "ttg.total-num-warps" = 4 : i32, ttg.shared = 1024 : i32, ttg.target = "cuda:90", ttg.tensor_memory_size = 0 : i32} {
+  // Scratch in a non-entry function is summarized by the call's virtual
+  // shared-memory frame. The callee body itself is not instrumented.
+  // CHECK-LABEL: tt.func private @scratch_only_callee
+  // CHECK-NOT: tt.call @__triton_consan
+  // CHECK: tt.gather
+  tt.func private @scratch_only_callee(
+      %indices: tensor<1024x256xi32, #call_blocked>,
+      %values: tensor<128x256xf32, #call_blocked>) {
+    %0 = tt.gather %values[%indices] {axis = 0 : i32, allocation.offset = 0 : i32, allocation.size = 512 : i32}
+        : (tensor<128x256xf32, #call_blocked>, tensor<1024x256xi32, #call_blocked>) -> tensor<1024x256xf32, #call_blocked>
+    tt.return
+  }
+
+  // CHECK-LABEL: tt.func public @summarize_scratch_call
+  // The explicit buffer and call frame partially overlap, so both masks select
+  // the shared state lane.
+  // CHECK: arith.constant dense<[true, true, false, false]> : tensor<4xi1
+  // CHECK: ttg.local_load
+  // CHECK: arith.constant dense<[false, true, true, false]> : tensor<4xi1
+  // A valid private callee only touches the caller's CTA-local frame.
+  // CHECK: %[[CALL_CTA_ID:.*]] = tti.experimental_cluster_cta_id
+  // CHECK: %[[CALL_CTA:.*]] = arith.shli {{.*}}, %[[CALL_CTA_ID]] : i32
+  // CHECK: tt.call @__triton_consan_verify_write_visibility{{.*}}%[[CALL_CTA]]
+  // CHECK: tt.call @__triton_consan_verify_read_visibility{{.*}}%[[CALL_CTA]]
+  // CHECK: tt.call @__triton_consan_publish_write_visibility{{.*}}%[[CALL_CTA]]
+  // CHECK: tt.call @scratch_only_callee
+  tt.func public @summarize_scratch_call(
+      %indices: tensor<1024x256xi32, #call_blocked>,
+      %values: tensor<128x256xf32, #call_blocked>) {
+    %buf = ttg.local_alloc {allocation.offset = 0 : i32} : () -> !ttg.memdesc<256xi32, #call_shared, #call_smem, mutable>
+    %loaded = ttg.local_load %buf : !ttg.memdesc<256xi32, #call_shared, #call_smem, mutable> -> tensor<256xi32, #call_load_blocked>
+    tt.call @scratch_only_callee(%indices, %values) {allocation.offset = 128 : i32, allocation.size = 512 : i32}
+        : (tensor<1024x256xi32, #call_blocked>, tensor<128x256xf32, #call_blocked>) -> ()
+    // Keep the NVIDIA dialect loaded in this standalone split module.
+    ttng.cluster_barrier {relaxed = true}
+    tt.return
+  }
+}
+
+// -----
+
 #shared = #ttg.swizzled_shared<{vec = 1, perPhase = 1, maxPhase = 1, order = [1, 0], CGALayout = [[1, 0]]}>
 #shared1 = #ttg.swizzled_shared<{vec = 1, perPhase = 1, maxPhase = 1, order = [0], CGALayout = [[0]]}>
 #smem = #ttg.shared_memory
@@ -341,11 +388,12 @@ module attributes {"ttg.num-ctas" = 2 : i32, "ttg.num-warps" = 4 : i32, ttg.shar
 #local_atomic_shared = #ttg.swizzled_shared<{vec = 1, perPhase = 1, maxPhase = 1, order = [1, 0], CGALayout = [[0, 1]]}>
 #local_atomic_tma_shared = #ttg.nvmma_shared<{swizzlingByteWidth = 64, transposed = false, elementBitWidth = 32, CGALayout = [[0, 1]]}>
 #local_atomic_smem = #ttg.shared_memory
-#local_atomic_blocked = #ttg.blocked<{sizePerThread = [1, 1], threadsPerWarp = [1, 32], warpsPerCTA = [1, 4], order = [1, 0], CGALayout = [[0, 1]]}>
-module attributes {"ttg.num-ctas" = 2 : i32, "ttg.num-warps" = 4 : i32, ttg.shared = 1024 : i32, ttg.target = "cuda:90", ttg.tensor_memory_size = 0 : i32, "ttg.threads-per-warp" = 32 : i32, "ttg.total-num-warps" = 4 : i32} {
+#local_atomic_blocked = #ttg.blocked<{sizePerThread = [1, 1], threadsPerWarp = [1, 32], warpsPerCTA = [2, 4], order = [1, 0], CGALayout = [[0, 1]]}>
+module attributes {"ttg.num-ctas" = 2 : i32, "ttg.num-warps" = 8 : i32, ttg.shared = 1536 : i32, ttg.target = "cuda:90", ttg.tensor_memory_size = 0 : i32, "ttg.threads-per-warp" = 32 : i32, "ttg.total-num-warps" = 8 : i32} {
   // CHECK-LABEL: @local_atomic_scatter_rmw_effects
   tt.func public @local_atomic_scatter_rmw_effects(
-      %out: !tt.tensordesc<8x32xi32, #local_atomic_tma_shared>) {
+      %out: !tt.tensordesc<8x32xi32, #local_atomic_tma_shared>,
+      %result: tensor<8x32x!tt.ptr<i32>, #local_atomic_blocked>) {
     // The atomic is the allocation's only user, so its state mask proves
     // BufferRegion discovers the full destination.
     %c0 = arith.constant 0 : i32
@@ -357,13 +405,22 @@ module attributes {"ttg.num-ctas" = 2 : i32, "ttg.num-warps" = 4 : i32, ttg.shar
 
     // Runtime indices along the sharded axis can target either CTA row.
     // CHECK: %[[ATOMIC_CTAS:.*]] = arith.constant 3 : i32
-    // CHECK: arith.constant dense<[true, false]> : tensor<2xi1
+    // CHECK: arith.constant dense<[true, false, false, false]> : tensor<4xi1
     // CHECK: tt.call @__triton_consan_set_proxy_access{{.*}}({{.*}}%[[ATOMIC_CTAS]])
     // CHECK: tt.call @__triton_consan_verify_write_visibility{{.*}}({{.*}}%[[ATOMIC_CTAS]]{{.*}})
     // CHECK: tt.call @__triton_consan_verify_read_visibility{{.*}}({{.*}}%[[ATOMIC_CTAS]]{{.*}})
     // CHECK: tt.call @__triton_consan_publish_write_visibility{{.*}}({{.*}}%[[ATOMIC_CTAS]]{{.*}})
+    // The existing destination reaches both CTAs, while independent result
+    // staging remains private to the issuer's shared-memory frame.
+    // CHECK: arith.constant dense<[false, false, true, false]> : tensor<4xi1
+    // CHECK: %[[ATOMIC_SCRATCH_CTA_ID:.*]] = tti.experimental_cluster_cta_id
+    // CHECK: %[[ATOMIC_SCRATCH_CTA:.*]] = arith.shli {{.*}}, %[[ATOMIC_SCRATCH_CTA_ID]] : i32
+    // CHECK: tt.call @__triton_consan_verify_write_visibility{{.*}}%[[ATOMIC_SCRATCH_CTA]]
+    // CHECK: tt.call @__triton_consan_verify_read_visibility{{.*}}%[[ATOMIC_SCRATCH_CTA]]
+    // CHECK: tt.call @__triton_consan_publish_write_visibility{{.*}}%[[ATOMIC_SCRATCH_CTA]]
     // CHECK: ttg.local_atomic_scatter_rmw
-    %old = ttg.local_atomic_scatter_rmw add, %dst[%indices], %values {axis = 1 : i32} : (!ttg.memdesc<8x32xi32, #local_atomic_shared, #local_atomic_smem, mutable>, tensor<8x32xi32, #local_atomic_blocked>, tensor<8x32xi32, #local_atomic_blocked>) -> tensor<8x32xi32, #local_atomic_blocked>
+    %old = ttg.local_atomic_scatter_rmw add, %dst[%indices], %values {allocation.offset = 1024 : i32, allocation.size = 512 : i32, axis = 1 : i32} : (!ttg.memdesc<8x32xi32, #local_atomic_shared, #local_atomic_smem, mutable>, tensor<8x32xi32, #local_atomic_blocked>, tensor<8x32xi32, #local_atomic_blocked>) -> tensor<8x32xi32, #local_atomic_blocked>
+    tt.store %result, %old : tensor<8x32x!tt.ptr<i32>, #local_atomic_blocked>
     // Enable proxy tracking without giving the atomic destination another user.
     ttng.async_tma_copy_local_to_global %out[%c0, %c0] %proxy : !tt.tensordesc<8x32xi32, #local_atomic_tma_shared>, !ttg.memdesc<8x32xi32, #local_atomic_tma_shared, #local_atomic_smem, mutable>
     tt.return
@@ -2405,6 +2462,177 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 1 : i32, ttg.shar
     // CHECK: ttng.async_copy_mbarrier_arrive
     ttng.async_copy_mbarrier_arrive %uninitialized
         : !ttg.memdesc<1xi64, #lifetime_shared, #lifetime_smem, mutable>
+    tt.return
+  }
+}
+
+// -----
+
+#nested_src = #ttg.blocked<{sizePerThread = [1], threadsPerWarp = [32], warpsPerCTA = [4], order = [0]}>
+#nested_dst_parent = #ttg.blocked<{sizePerThread = [1, 1], threadsPerWarp = [1, 32], warpsPerCTA = [1, 4], order = [1, 0]}>
+#nested_dst = #ttg.slice<{dim = 1, parent = #nested_dst_parent}>
+#nested_shared = #ttg.swizzled_shared<{vec = 1, perPhase = 1, maxPhase = 1, order = [0]}>
+#nested_smem = #ttg.shared_memory
+
+module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, "ttg.threads-per-warp" = 32 : i32, "ttg.total-num-warps" = 4 : i32, ttg.shared = 640 : i32, ttg.target = "cuda:90", ttg.tensor_memory_size = 0 : i32} {
+  // Reachable private functions can combine register-only compiler scratch,
+  // volatile global accesses, and nested calls without instrumentation.
+  // CHECK-LABEL: tt.func private @nested_scratch_leaf
+  // CHECK-NOT: tt.call @__triton_consan
+  // CHECK: tt.load {{.*}}isVolatile = true
+  // CHECK: ttg.convert_layout
+  tt.func private @nested_scratch_leaf(
+      %value: tensor<128xi32, #nested_src>, %global: !tt.ptr<i32>) {
+    %loaded = tt.load %global {isVolatile = true} : !tt.ptr<i32>
+    %converted = ttg.convert_layout %value {allocation.offset = 0 : i32, allocation.size = 512 : i32}
+        : tensor<128xi32, #nested_src> -> tensor<128xi32, #nested_dst>
+    tt.return
+  }
+
+  tt.func private @nested_scratch_middle(
+      %value: tensor<128xi32, #nested_src>, %global: !tt.ptr<i32>) {
+    tt.call @nested_scratch_leaf(%value, %global) {allocation.offset = 0 : i32, allocation.size = 512 : i32}
+        : (tensor<128xi32, #nested_src>, !tt.ptr<i32>) -> ()
+    tt.return
+  }
+
+  tt.func private @forward_shared_descriptor(
+      %incoming: !ttg.memdesc<16xi32, #nested_shared, #nested_smem, mutable>)
+      -> !ttg.memdesc<16xi32, #nested_shared, #nested_smem, mutable> {
+    tt.return %incoming : !ttg.memdesc<16xi32, #nested_shared, #nested_smem, mutable>
+  }
+
+  // An otherwise unsupported function that is unreachable from the public
+  // entrypoint does not constrain the entrypoint's call summary.
+  tt.func private @unreachable_unsupported_callee() {
+    %unused = ttg.local_alloc {allocation.offset = 0 : i32}
+        : () -> !ttg.memdesc<16xi32, #nested_shared, #nested_smem, mutable>
+    tt.return
+  }
+
+  // CHECK-LABEL: tt.func public @nested_scratch_and_descriptor_forwarding
+  tt.func public @nested_scratch_and_descriptor_forwarding(
+      %value: tensor<128xi32, #nested_src>, %global: !tt.ptr<i32>) {
+    %buffer = ttg.local_alloc {allocation.offset = 0 : i32}
+        : () -> !ttg.memdesc<16xi32, #nested_shared, #nested_smem, mutable>
+    %live_barrier = ttg.local_alloc {allocation.offset = 128 : i32}
+        : () -> !ttg.memdesc<1xi64, #nested_shared, #nested_smem, mutable>
+    // A summarized call cannot reuse storage occupied by a live barrier.
+    // CHECK: ttng.init_barrier
+    ttng.init_barrier %live_barrier, 1
+        : !ttg.memdesc<1xi64, #nested_shared, #nested_smem, mutable>
+    // CHECK: tt.call @__triton_consan_verify_barrier_can_init
+    // CHECK: tt.call @__triton_consan_verify_write_visibility
+    // CHECK: tt.call @__triton_consan_verify_read_visibility
+    // CHECK: tt.call @__triton_consan_publish_write_visibility
+    // CHECK: tt.call @nested_scratch_middle
+    tt.call @nested_scratch_middle(%value, %global) {allocation.offset = 128 : i32, allocation.size = 512 : i32}
+        : (tensor<128xi32, #nested_src>, !tt.ptr<i32>) -> ()
+    // CHECK: %[[FORWARDED:.*]] = tt.call @forward_shared_descriptor
+    %forwarded = tt.call @forward_shared_descriptor(%buffer)
+        : (!ttg.memdesc<16xi32, #nested_shared, #nested_smem, mutable>)
+        -> !ttg.memdesc<16xi32, #nested_shared, #nested_smem, mutable>
+    // CHECK: tt.call @__triton_consan_verify_write_visibility
+    // CHECK: ttg.local_load %[[FORWARDED]]
+    %loaded = ttg.local_load %forwarded
+        : !ttg.memdesc<16xi32, #nested_shared, #nested_smem, mutable>
+        -> tensor<16xi32>
+    tt.return
+  }
+}
+
+// -----
+
+#direct_shared = #ttg.nvmma_shared<{swizzlingByteWidth = 0, transposed = false, elementBitWidth = 32, rank = 1}>
+#direct_smem = #ttg.shared_memory
+#direct_src = #ttg.blocked<{sizePerThread = [1], threadsPerWarp = [32], warpsPerCTA = [4], order = [0]}>
+#direct_dst_parent = #ttg.blocked<{sizePerThread = [1, 1], threadsPerWarp = [1, 32], warpsPerCTA = [1, 4], order = [1, 0]}>
+#direct_dst = #ttg.slice<{dim = 1, parent = #direct_dst_parent}>
+#direct_reduce = #ttg.blocked<{sizePerThread = [1, 2], threadsPerWarp = [1, 32], warpsPerCTA = [1, 4], order = [1, 0]}>
+
+module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, "ttg.threads-per-warp" = 32 : i32, "ttg.total-num-warps" = 4 : i32, ttg.shared = 1024 : i32, ttg.target = "cuda:90", ttg.tensor_memory_size = 0 : i32} {
+  // CHECK-LABEL: @conversion_and_reduction_detect_outstanding_tma
+  tt.func public @conversion_and_reduction_detect_outstanding_tma(
+      %desc: !tt.tensordesc<256xi32, #direct_shared>,
+      %value: tensor<128xi32, #direct_src>,
+      %reduce: tensor<1x256xf32, #direct_reduce>) {
+    %zero = arith.constant 0 : i32
+    %buffer = ttg.local_alloc {allocation.offset = 0 : i32}
+        : () -> !ttg.memdesc<256xi32, #direct_shared, #direct_smem, mutable>
+    ttng.async_tma_copy_local_to_global %desc[%zero] %buffer
+        : !tt.tensordesc<256xi32, #direct_shared>,
+          !ttg.memdesc<256xi32, #direct_shared, #direct_smem, mutable>
+    ttg.local_dealloc %buffer
+        : !ttg.memdesc<256xi32, #direct_shared, #direct_smem, mutable>
+
+    // CHECK: tt.call @__triton_consan_verify_read_visibility
+    // CHECK: tt.call @__triton_consan_check_outstanding_commits
+    // CHECK: tt.call @__triton_consan_publish_write_visibility
+    // CHECK: ttg.convert_layout
+    %converted = ttg.convert_layout %value {allocation.offset = 0 : i32, allocation.size = 512 : i32}
+        : tensor<128xi32, #direct_src> -> tensor<128xi32, #direct_dst>
+
+    // CHECK: tt.call @__triton_consan_verify_read_visibility
+    // CHECK: tt.call @__triton_consan_check_outstanding_commits
+    // CHECK: tt.call @__triton_consan_publish_write_visibility
+    // CHECK: "tt.reduce"
+    %reduced = "tt.reduce"(%reduce) <{axis = 1 : i32}> ({
+    ^bb0(%lhs: f32, %rhs: f32):
+      %sum = arith.addf %lhs, %rhs : f32
+      tt.reduce.return %sum : f32
+    }) {allocation.offset = 256 : i32, allocation.size = 16 : i32}
+        : (tensor<1x256xf32, #direct_reduce>)
+        -> tensor<1xf32, #ttg.slice<{dim = 1, parent = #direct_reduce}>>
+    ttng.async_tma_store_wait {pendings = 0 : i32}
+    tt.return
+  }
+}
+
+// -----
+
+#cross_src = #ttg.blocked<{sizePerThread = [1, 1], threadsPerWarp = [1, 32], warpsPerCTA = [1, 4], order = [1, 0], CGALayout = [[1, 0]]}>
+#cross_dst = #ttg.blocked<{sizePerThread = [1, 1], threadsPerWarp = [1, 32], warpsPerCTA = [1, 4], order = [1, 0], CGALayout = [[0, 1]]}>
+
+module attributes {"ttg.num-ctas" = 2 : i32, "ttg.num-warps" = 4 : i32, "ttg.threads-per-warp" = 32 : i32, "ttg.total-num-warps" = 4 : i32, ttg.shared = 512 : i32, ttg.target = "cuda:90", ttg.tensor_memory_size = 0 : i32} {
+  // CHECK-LABEL: @convert_layout_cross_cta_scratch
+  tt.func public @convert_layout_cross_cta_scratch(
+      %value: tensor<8x32xi32, #cross_src>) {
+    // The entrypoint conversion can read scratch owned by either CTA.
+    // CHECK: %[[PEER_CTAS:.*]] = arith.constant 3 : i32
+    // CHECK: %[[CONVERT_CTAS:.*]] = arith.ori {{.*}}, %[[PEER_CTAS]] : i32
+    // CHECK: tt.call @__triton_consan_verify_write_visibility{{.*}}%[[CONVERT_CTAS]]
+    // CHECK: tt.call @__triton_consan_verify_read_visibility{{.*}}%[[CONVERT_CTAS]]
+    // CHECK: tt.call @__triton_consan_publish_write_visibility{{.*}}%[[CONVERT_CTAS]]
+    // CHECK: ttg.convert_layout
+    %converted = ttg.convert_layout %value {allocation.offset = 0 : i32, allocation.size = 512 : i32}
+        : tensor<8x32xi32, #cross_src> -> tensor<8x32xi32, #cross_dst>
+    ttng.cluster_barrier {relaxed = true}
+    tt.return
+  }
+}
+
+// -----
+
+module attributes {"ttg.num-ctas" = 2 : i32, "ttg.num-warps" = 1 : i32, "ttg.threads-per-warp" = 32 : i32, "ttg.total-num-warps" = 1 : i32, ttg.shared = 4 : i32, ttg.target = "cuda:90", ttg.tensor_memory_size = 0 : i32} {
+  // CHECK-LABEL: @scalar_atomic_scratch_broadcast
+  tt.func public @scalar_atomic_scratch_broadcast(
+      %ptr: !tt.ptr<i32>, %out: !tt.ptr<i32>) {
+    %one = arith.constant 1 : i32
+    // Only CTA zero issues the atomic, but both consume its broadcast result.
+    // CHECK: tti.experimental_lock_acquire
+    // CHECK: %[[SCALAR_PRODUCER:.*]] = arith.cmpi eq, {{.*}} : i32
+    // CHECK: %[[SCALAR_ALL_CTAS:.*]] = arith.constant 3 : i32
+    // CHECK: %[[SCALAR_SHIFTED:.*]] = arith.shli %[[SCALAR_ALL_CTAS]], {{.*}} : i32
+    // CHECK: %[[SCALAR_RECIPIENTS:.*]] = arith.ori {{.*}}, %[[SCALAR_SHIFTED]] : i32
+    // CHECK: tt.call @__triton_consan_verify_write_visibility{{.*}}%[[SCALAR_PRODUCER]]{{.*}}%[[SCALAR_RECIPIENTS]]
+    // CHECK: tt.call @__triton_consan_verify_read_visibility{{.*}}%[[SCALAR_PRODUCER]]{{.*}}%[[SCALAR_RECIPIENTS]]
+    // CHECK: tt.call @__triton_consan_publish_write_visibility{{.*}}%[[SCALAR_PRODUCER]]{{.*}}%[[SCALAR_RECIPIENTS]]
+    // CHECK: tt.atomic_rmw
+    %old = tt.atomic_rmw add, relaxed, gpu, %ptr, %one
+        {allocation.offset = 0 : i32, allocation.size = 4 : i32}
+        : (!tt.ptr<i32>, i32) -> i32
+    tt.store %out, %old : !tt.ptr<i32>
+    ttng.cluster_barrier {relaxed = true}
     tt.return
   }
 }

--- a/test/TritonGPU/consan.mlir
+++ b/test/TritonGPU/consan.mlir
@@ -2593,22 +2593,25 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, "ttg.thr
 #reduce_groups = #ttg.blocked<{sizePerThread = [1, 2], threadsPerWarp = [1, 32], warpsPerCTA = [1, 4], order = [1, 0], CGALayout = [[1, 0], [0, 1]]}>
 
 module attributes {"ttg.num-ctas" = 4 : i32, "ttg.num-warps" = 4 : i32, "ttg.threads-per-warp" = 32 : i32, "ttg.total-num-warps" = 4 : i32, ttg.shared = 32 : i32, ttg.target = "cuda:90", ttg.tensor_memory_size = 0 : i32} {
-  // CHECK-LABEL: @reduce_independent_noncontiguous_cta_groups
-  tt.func public @reduce_independent_noncontiguous_cta_groups(
+  // CHECK-LABEL: @reduce_cross_cta_scratch_is_cta_local
+  tt.func public @reduce_cross_cta_scratch_is_cta_local(
       %value: tensor<8x256xf32, #reduce_groups>) {
-    // Reducing axis 1 groups CTA {0,2} and {1,3}, without crossing into
-    // the other independent reduction. The recipient masks are 5 or 10.
+    // Reduction groups {0,2} and {1,3} read peers only after their intrinsic
+    // cluster barrier; scratch writes touch the current CTA alone.
     // CHECK: tti.experimental_lock_acquire
-    // CHECK: arith.shli
+    // CHECK: arith.constant dense<true> : tensor<1xi1
+    // CHECK: %[[REDUCE_CTA:.*]] = tti.experimental_cluster_cta_id
+    // CHECK: %[[REDUCE_ONE:.*]] = arith.constant 1 : i32
+    // CHECK: %[[REDUCE_OWNER:.*]] = arith.shli %[[REDUCE_ONE]], %[[REDUCE_CTA]] : i32
     // CHECK: %[[REDUCE_GROUP_CTA:.*]] = tti.experimental_cluster_cta_id
     // CHECK: %[[REDUCE_GROUP_FIXED:.*]] = arith.constant 1 : i32
     // CHECK: %[[REDUCE_GROUP_BASE:.*]] = arith.andi %[[REDUCE_GROUP_CTA]], %[[REDUCE_GROUP_FIXED]] : i32
     // CHECK: %[[REDUCE_GROUP_PATTERN:.*]] = arith.constant 5 : i32
     // CHECK: %[[REDUCE_GROUP_SHIFT:.*]] = arith.shli %[[REDUCE_GROUP_PATTERN]], %[[REDUCE_GROUP_BASE]] : i32
-    // CHECK: %[[REDUCE_GROUP_RECIPIENTS:.*]] = arith.ori {{.*}}, %[[REDUCE_GROUP_SHIFT]] : i32
-    // CHECK: tt.call @__triton_consan_verify_write_visibility{{.*}}%[[REDUCE_GROUP_RECIPIENTS]]
-    // CHECK: tt.call @__triton_consan_verify_read_visibility{{.*}}%[[REDUCE_GROUP_RECIPIENTS]]
-    // CHECK: tt.call @__triton_consan_publish_write_visibility{{.*}}%[[REDUCE_GROUP_RECIPIENTS]]
+    // CHECK: %[[REDUCE_READERS:.*]] = arith.ori {{.*}}, %[[REDUCE_GROUP_SHIFT]] : i32
+    // CHECK: tt.call @__triton_consan_verify_write_visibility{{.*}}%[[REDUCE_READERS]]
+    // CHECK: tt.call @__triton_consan_verify_read_visibility{{.*}}%[[REDUCE_OWNER]]
+    // CHECK: tt.call @__triton_consan_publish_write_visibility{{.*}}%[[REDUCE_OWNER]]
     // CHECK: "tt.reduce"
     %reduced = "tt.reduce"(%value) <{axis = 1 : i32}> ({
     ^bb0(%lhs: f32, %rhs: f32):
@@ -2626,19 +2629,36 @@ module attributes {"ttg.num-ctas" = 4 : i32, "ttg.num-warps" = 4 : i32, "ttg.thr
 
 #cross_src = #ttg.blocked<{sizePerThread = [1, 1], threadsPerWarp = [1, 32], warpsPerCTA = [1, 4], order = [1, 0], CGALayout = [[1, 0]]}>
 #cross_dst = #ttg.blocked<{sizePerThread = [1, 1], threadsPerWarp = [1, 32], warpsPerCTA = [1, 4], order = [1, 0], CGALayout = [[0, 1]]}>
+#cross_shared = #ttg.swizzled_shared<{vec = 1, perPhase = 1, maxPhase = 1, order = [1, 0], CGALayout = [[1, 0]]}>
+#cross_smem = #ttg.shared_memory
 
 module attributes {"ttg.num-ctas" = 2 : i32, "ttg.num-warps" = 4 : i32, "ttg.threads-per-warp" = 32 : i32, "ttg.total-num-warps" = 4 : i32, ttg.shared = 512 : i32, ttg.target = "cuda:90", ttg.tensor_memory_size = 0 : i32} {
   // CHECK-LABEL: @convert_layout_cross_cta_scratch
   tt.func public @convert_layout_cross_cta_scratch(
       %value: tensor<8x32xi32, #cross_src>) {
-    // The entrypoint conversion can read scratch owned by either CTA.
-    // CHECK: %[[PEER_CTAS:.*]] = arith.constant 3 : i32
-    // CHECK: %[[CONVERT_CTAS:.*]] = arith.ori {{.*}}, %[[PEER_CTAS]] : i32
-    // CHECK: tt.call @__triton_consan_verify_write_visibility{{.*}}%[[CONVERT_CTAS]]
-    // CHECK: tt.call @__triton_consan_verify_read_visibility{{.*}}%[[CONVERT_CTAS]]
-    // CHECK: tt.call @__triton_consan_publish_write_visibility{{.*}}%[[CONVERT_CTAS]]
+    %buffer = ttg.local_alloc %value {allocation.offset = 0 : i32}
+        : (tensor<8x32xi32, #cross_src>) -> !ttg.memdesc<8x32xi32, #cross_shared, #cross_smem, mutable>
+    // CHECK: ttg.local_load
+    %loaded = ttg.local_load %buffer
+        : !ttg.memdesc<8x32xi32, #cross_shared, #cross_smem, mutable> -> tensor<8x32xi32, #cross_src>
+    // CHECK: ttg.local_dealloc
+    ttg.local_dealloc %buffer : !ttg.memdesc<8x32xi32, #cross_shared, #cross_smem, mutable>
+    // CHECK: ttng.cluster_barrier {relaxed = true}
+    ttng.cluster_barrier {relaxed = true}
+    // Peer reads follow the conversion's intrinsic cluster barrier; the
+    // compiler-owned scratch write belongs only to its issuing CTA.
+    // CHECK: tti.experimental_lock_acquire
+    // CHECK: arith.constant dense<true> : tensor<1xi1
+    // CHECK: %[[CONVERT_CTA:.*]] = tti.experimental_cluster_cta_id
+    // CHECK: %[[CONVERT_ONE:.*]] = arith.constant 1 : i32
+    // CHECK: %[[CONVERT_OWNER:.*]] = arith.shli %[[CONVERT_ONE]], %[[CONVERT_CTA]] : i32
+    // CHECK: %[[CONVERT_PEERS:.*]] = arith.constant 3 : i32
+    // CHECK: %[[CONVERT_READERS:.*]] = arith.ori {{.*}}, %[[CONVERT_PEERS]] : i32
+    // CHECK: tt.call @__triton_consan_verify_write_visibility{{.*}}%[[CONVERT_READERS]]
+    // CHECK: tt.call @__triton_consan_verify_read_visibility{{.*}}%[[CONVERT_OWNER]]
+    // CHECK: tt.call @__triton_consan_publish_write_visibility{{.*}}%[[CONVERT_OWNER]]
     // CHECK: ttg.convert_layout
-    %converted = ttg.convert_layout %value {allocation.offset = 0 : i32, allocation.size = 512 : i32}
+    %converted = ttg.convert_layout %loaded {allocation.offset = 0 : i32, allocation.size = 512 : i32}
         : tensor<8x32xi32, #cross_src> -> tensor<8x32xi32, #cross_dst>
     ttng.cluster_barrier {relaxed = true}
     tt.return
@@ -2647,26 +2667,83 @@ module attributes {"ttg.num-ctas" = 2 : i32, "ttg.num-warps" = 4 : i32, "ttg.thr
 
 // -----
 
-module attributes {"ttg.num-ctas" = 2 : i32, "ttg.num-warps" = 1 : i32, "ttg.threads-per-warp" = 32 : i32, "ttg.total-num-warps" = 1 : i32, ttg.shared = 4 : i32, ttg.target = "cuda:90", ttg.tensor_memory_size = 0 : i32} {
+#atomic_barrier = #ttg.swizzled_shared<{vec = 1, perPhase = 1, maxPhase = 1, order = [0], CGALayout = [[1]]}>
+#atomic_smem = #ttg.shared_memory
+
+module attributes {"ttg.num-ctas" = 2 : i32, "ttg.num-warps" = 1 : i32, "ttg.threads-per-warp" = 32 : i32, "ttg.total-num-warps" = 1 : i32, ttg.shared = 8 : i32, ttg.target = "cuda:90", ttg.tensor_memory_size = 0 : i32} {
   // CHECK-LABEL: @scalar_atomic_scratch_broadcast
   tt.func public @scalar_atomic_scratch_broadcast(
       %ptr: !tt.ptr<i32>, %out: !tt.ptr<i32>) {
     %one = arith.constant 1 : i32
-    // Only CTA zero issues the atomic, but both consume its broadcast result.
+    %barrier = ttg.local_alloc {allocation.offset = 0 : i32}
+        : () -> !ttg.memdesc<2xi64, #atomic_barrier, #atomic_smem, mutable>
+    %cta = tti.experimental_cluster_cta_id : i32
+    %is_cta_one = arith.cmpi eq, %cta, %one : i32
+    scf.if %is_cta_one {
+      ttng.init_barrier %barrier, 1 : !ttg.memdesc<2xi64, #atomic_barrier, #atomic_smem, mutable>
+    }
+    // CHECK: ttng.cluster_barrier {relaxed = true}
+    ttng.cluster_barrier {relaxed = true}
+    // Both CTAs consume the result, but only CTA zero owns the scratch. The
+    // live barrier in CTA one does not overlap the atomic's physical storage.
     // CHECK: tti.experimental_lock_acquire
     // CHECK: %[[SCALAR_PRODUCER:.*]] = arith.cmpi eq, {{.*}} : i32
-    // CHECK: %[[SCALAR_ALL_CTAS:.*]] = arith.constant 3 : i32
-    // CHECK: %[[SCALAR_SHIFTED:.*]] = arith.shli %[[SCALAR_ALL_CTAS]], {{.*}} : i32
-    // CHECK: %[[SCALAR_RECIPIENTS:.*]] = arith.ori {{.*}}, %[[SCALAR_SHIFTED]] : i32
-    // CHECK: tt.call @__triton_consan_verify_write_visibility{{.*}}%[[SCALAR_PRODUCER]]{{.*}}%[[SCALAR_RECIPIENTS]]
-    // CHECK: tt.call @__triton_consan_verify_read_visibility{{.*}}%[[SCALAR_PRODUCER]]{{.*}}%[[SCALAR_RECIPIENTS]]
-    // CHECK: tt.call @__triton_consan_publish_write_visibility{{.*}}%[[SCALAR_PRODUCER]]{{.*}}%[[SCALAR_RECIPIENTS]]
+    // CHECK: arith.constant dense<[true, false]> : tensor<2xi1
+    // CHECK: %[[SCALAR_CTA:.*]] = tti.experimental_cluster_cta_id
+    // CHECK: %[[SCALAR_ONE:.*]] = arith.constant 1 : i32
+    // CHECK: %[[SCALAR_OWNER:.*]] = arith.shli %[[SCALAR_ONE]], %[[SCALAR_CTA]] : i32
+    // CHECK: tt.call @__triton_consan_verify_write_visibility{{.*}}%[[SCALAR_PRODUCER]]{{.*}}%[[SCALAR_OWNER]]
+    // CHECK: tt.call @__triton_consan_verify_read_visibility{{.*}}%[[SCALAR_PRODUCER]]{{.*}}%[[SCALAR_OWNER]]
+    // CHECK: tt.call @__triton_consan_publish_write_visibility{{.*}}%[[SCALAR_PRODUCER]]{{.*}}%[[SCALAR_OWNER]]
     // CHECK: tt.atomic_rmw
     %old = tt.atomic_rmw add, relaxed, gpu, %ptr, %one
         {allocation.offset = 0 : i32, allocation.size = 4 : i32}
         : (!tt.ptr<i32>, i32) -> i32
     tt.store %out, %old : !tt.ptr<i32>
     ttng.cluster_barrier {relaxed = true}
+    tt.return
+  }
+}
+
+// -----
+
+#tma_src = #ttg.blocked<{sizePerThread = [1, 1], threadsPerWarp = [1, 32], warpsPerCTA = [1, 4], order = [1, 0], CGALayout = [[1, 0]]}>
+#tma_dst = #ttg.blocked<{sizePerThread = [1, 1], threadsPerWarp = [32, 1], warpsPerCTA = [4, 1], order = [0, 1], CGALayout = [[0, 1]]}>
+#tma_shared = #ttg.nvmma_shared<{swizzlingByteWidth = 128, transposed = false, elementBitWidth = 32, CGALayout = [[1, 0]]}>
+#tma_barrier = #ttg.swizzled_shared<{vec = 1, perPhase = 1, maxPhase = 1, order = [0], CGALayout = [[1]]}>
+#tma_smem = #ttg.shared_memory
+
+module attributes {"ttg.num-ctas" = 2 : i32, "ttg.num-warps" = 4 : i32, "ttg.threads-per-warp" = 32 : i32, "ttg.total-num-warps" = 4 : i32, "ttng.two-ctas" = true, ttg.shared = 8192 : i32, ttg.target = "cuda:100", ttg.tensor_memory_size = 0 : i32} {
+  // CHECK-LABEL: @remote_tma_cross_cta_conversion_scratch
+  tt.func public @remote_tma_cross_cta_conversion_scratch(
+      %desc: !tt.tensordesc<8x32xi32, #tma_shared>, %value: tensor<16x32xi32, #tma_src>) {
+    %zero = arith.constant 0 : i32
+    %cta = tti.experimental_cluster_cta_id : i32
+    %lead = arith.cmpi eq, %cta, %zero : i32
+    %parent = ttg.local_alloc {allocation.offset = 0 : i32} : () -> !ttg.memdesc<16x32xi32, #tma_shared, #tma_smem, mutable>
+    %remote = ttg.memdesc_subslice %parent [8, 0] : !ttg.memdesc<16x32xi32, #tma_shared, #tma_smem, mutable> -> !ttg.memdesc<8x32xi32, #tma_shared, #tma_smem, mutable, 16x32>
+    %bar = ttg.local_alloc {allocation.offset = 4096 : i32} : () -> !ttg.memdesc<2xi64, #tma_barrier, #tma_smem, mutable>
+    ttng.init_barrier %bar, 1 : !ttg.memdesc<2xi64, #tma_barrier, #tma_smem, mutable>
+    ttng.barrier_expect %bar, 1024, %lead : !ttg.memdesc<2xi64, #tma_barrier, #tma_smem, mutable>
+    // CHECK: ttng.async_tma_copy_global_to_local
+    ttng.async_tma_copy_global_to_local %desc[%zero, %zero] %remote, %bar, %lead : !tt.tensordesc<8x32xi32, #tma_shared>, !ttg.memdesc<2xi64, #tma_barrier, #tma_smem, mutable> -> !ttg.memdesc<8x32xi32, #tma_shared, #tma_smem, mutable, 16x32>
+    // CHECK: ttg.local_dealloc
+    ttg.local_dealloc %parent : !ttg.memdesc<16x32xi32, #tma_shared, #tma_smem, mutable>
+    // CTA zero's pending async write targets CTA one. Conversion must check
+    // that remote owner but publish its own CTA-local scratch write only.
+    // CHECK: tti.experimental_lock_acquire
+    // CHECK: arith.constant dense<[true, false]> : tensor<2xi1
+    // CHECK: %[[TMA_OWNER_CTA:.*]] = tti.experimental_cluster_cta_id
+    // CHECK: %[[TMA_OWNER_ONE:.*]] = arith.constant 1 : i32
+    // CHECK: %[[TMA_OWNER:.*]] = arith.shli %[[TMA_OWNER_ONE]], %[[TMA_OWNER_CTA]] : i32
+    // CHECK: %[[TMA_PEERS:.*]] = arith.constant 3 : i32
+    // CHECK: %[[TMA_READERS:.*]] = arith.ori {{.*}}, %[[TMA_PEERS]] : i32
+    // CHECK: tt.call @__triton_consan_set_proxy_access{{.*}}%[[TMA_READERS]]
+    // CHECK: tt.call @__triton_consan_verify_write_visibility{{.*}}%[[TMA_READERS]]
+    // CHECK: tt.call @__triton_consan_verify_read_visibility{{.*}}%[[TMA_OWNER]]
+    // CHECK: tt.call @__triton_consan_publish_write_visibility{{.*}}%[[TMA_OWNER]]
+    // CHECK: ttg.convert_layout
+    %converted = ttg.convert_layout %value {allocation.offset = 0 : i32, allocation.size = 1024 : i32} : tensor<16x32xi32, #tma_src> -> tensor<16x32xi32, #tma_dst>
     tt.return
   }
 }

--- a/test/TritonGPU/consan.mlir
+++ b/test/TritonGPU/consan.mlir
@@ -2590,6 +2590,39 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, "ttg.thr
 
 // -----
 
+#reduce_groups = #ttg.blocked<{sizePerThread = [1, 2], threadsPerWarp = [1, 32], warpsPerCTA = [1, 4], order = [1, 0], CGALayout = [[1, 0], [0, 1]]}>
+
+module attributes {"ttg.num-ctas" = 4 : i32, "ttg.num-warps" = 4 : i32, "ttg.threads-per-warp" = 32 : i32, "ttg.total-num-warps" = 4 : i32, ttg.shared = 32 : i32, ttg.target = "cuda:90", ttg.tensor_memory_size = 0 : i32} {
+  // CHECK-LABEL: @reduce_independent_noncontiguous_cta_groups
+  tt.func public @reduce_independent_noncontiguous_cta_groups(
+      %value: tensor<8x256xf32, #reduce_groups>) {
+    // Reducing axis 1 groups CTA {0,2} and {1,3}, without crossing into
+    // the other independent reduction. The recipient masks are 5 or 10.
+    // CHECK: tti.experimental_lock_acquire
+    // CHECK: %[[REDUCE_GROUP_CTA:.*]] = tti.experimental_cluster_cta_id
+    // CHECK: %[[REDUCE_GROUP_FIXED:.*]] = arith.constant 1 : i32
+    // CHECK: %[[REDUCE_GROUP_BASE:.*]] = arith.andi %[[REDUCE_GROUP_CTA]], %[[REDUCE_GROUP_FIXED]] : i32
+    // CHECK: %[[REDUCE_GROUP_PATTERN:.*]] = arith.constant 5 : i32
+    // CHECK: %[[REDUCE_GROUP_SHIFT:.*]] = arith.shli %[[REDUCE_GROUP_PATTERN]], %[[REDUCE_GROUP_BASE]] : i32
+    // CHECK: %[[REDUCE_GROUP_RECIPIENTS:.*]] = arith.ori {{.*}}, %[[REDUCE_GROUP_SHIFT]] : i32
+    // CHECK: tt.call @__triton_consan_verify_write_visibility{{.*}}%[[REDUCE_GROUP_RECIPIENTS]]
+    // CHECK: tt.call @__triton_consan_verify_read_visibility{{.*}}%[[REDUCE_GROUP_RECIPIENTS]]
+    // CHECK: tt.call @__triton_consan_publish_write_visibility{{.*}}%[[REDUCE_GROUP_RECIPIENTS]]
+    // CHECK: "tt.reduce"
+    %reduced = "tt.reduce"(%value) <{axis = 1 : i32}> ({
+    ^bb0(%lhs: f32, %rhs: f32):
+      %sum = arith.addf %lhs, %rhs : f32
+      tt.reduce.return %sum : f32
+    }) {allocation.offset = 0 : i32, allocation.size = 32 : i32}
+        : (tensor<8x256xf32, #reduce_groups>)
+        -> tensor<8xf32, #ttg.slice<{dim = 1, parent = #reduce_groups}>>
+    ttng.cluster_barrier {relaxed = true}
+    tt.return
+  }
+}
+
+// -----
+
 #cross_src = #ttg.blocked<{sizePerThread = [1, 1], threadsPerWarp = [1, 32], warpsPerCTA = [1, 4], order = [1, 0], CGALayout = [[1, 0]]}>
 #cross_dst = #ttg.blocked<{sizePerThread = [1, 1], threadsPerWarp = [1, 32], warpsPerCTA = [1, 4], order = [1, 0], CGALayout = [[0, 1]]}>
 

--- a/test/TritonGPU/consan.mlir
+++ b/test/TritonGPU/consan.mlir
@@ -2502,14 +2502,6 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, "ttg.thr
     tt.return %incoming : !ttg.memdesc<16xi32, #nested_shared, #nested_smem, mutable>
   }
 
-  // An otherwise unsupported function that is unreachable from the public
-  // entrypoint does not constrain the entrypoint's call summary.
-  tt.func private @unreachable_unsupported_callee() {
-    %unused = ttg.local_alloc {allocation.offset = 0 : i32}
-        : () -> !ttg.memdesc<16xi32, #nested_shared, #nested_smem, mutable>
-    tt.return
-  }
-
   // CHECK-LABEL: tt.func public @nested_scratch_and_descriptor_forwarding
   tt.func public @nested_scratch_and_descriptor_forwarding(
       %value: tensor<128xi32, #nested_src>, %global: !tt.ptr<i32>) {

--- a/test/TritonGPU/consan.mlir
+++ b/test/TritonGPU/consan.mlir
@@ -2599,6 +2599,7 @@ module attributes {"ttg.num-ctas" = 4 : i32, "ttg.num-warps" = 4 : i32, "ttg.thr
     // Reducing axis 1 groups CTA {0,2} and {1,3}, without crossing into
     // the other independent reduction. The recipient masks are 5 or 10.
     // CHECK: tti.experimental_lock_acquire
+    // CHECK: arith.shli
     // CHECK: %[[REDUCE_GROUP_CTA:.*]] = tti.experimental_cluster_cta_id
     // CHECK: %[[REDUCE_GROUP_FIXED:.*]] = arith.constant 1 : i32
     // CHECK: %[[REDUCE_GROUP_BASE:.*]] = arith.andi %[[REDUCE_GROUP_CTA]], %[[REDUCE_GROUP_FIXED]] : i32

--- a/third_party/amd/lib/TritonAMDGPUTransforms/ConSanAMD.cpp
+++ b/third_party/amd/lib/TritonAMDGPUTransforms/ConSanAMD.cpp
@@ -16,6 +16,34 @@ using tti::WaitOpInfo;
 
 namespace mlir {
 
+namespace {
+
+Value getLeaderCTAPredicate(ImplicitLocOpBuilder &b, uint32_t broadcastMask) {
+  Value ctaId = tti::ExperimentalClusterCTAIdOp::create(b, b.getLoc());
+  Value ctaIdInGroup = arith::AndIOp::create(
+      b, ctaId, arith::ConstantIntOp::create(b, broadcastMask, 32));
+  return arith::CmpIOp::create(b, arith::CmpIPredicate::eq, ctaIdInGroup,
+                               arith::ConstantIntOp::create(b, 0, 32));
+}
+
+std::optional<uint16_t> getAtomicScratchBroadcastMask(Operation *op) {
+  if (!op->hasAttr("allocation.size") ||
+      !isa<ttag::BufferAtomicCASOp, ttag::BufferAtomicRMWOp,
+           triton::AtomicRMWOp, triton::AtomicCASOp,
+           ttg::LocalAtomicScatterRMWOp>(op))
+    return std::nullopt;
+
+  // Tensor-result atomics broadcast through shared memory from the canonical
+  // producer CTA. Scalar atomics stage and reload their result within one CTA.
+  auto tensorTy = dyn_cast<RankedTensorType>(op->getResult(0).getType());
+  if (!tensorTy)
+    return std::nullopt;
+  auto kBlock = StringAttr::get(op->getContext(), "block");
+  return ttg::toLinearLayout(tensorTy).getFreeVariableMasks().lookup(kBlock);
+}
+
+} // namespace
+
 class AMDConSanHooks : public tti::ConSanTargetHooks {
 public:
   bool isTMAOp(Operation *op) const override {
@@ -89,9 +117,30 @@ public:
     return std::nullopt;
   }
 
-  Value getIssuerCTAPred(ImplicitLocOpBuilder & /*b*/,
-                         Operation * /*op*/) const override {
+  Value getIssuerCTAPred(ImplicitLocOpBuilder &b,
+                         Operation *op) const override {
+    if (auto scratchMask = getAtomicScratchBroadcastMask(op);
+        scratchMask && *scratchMask)
+      return getLeaderCTAPredicate(b, *scratchMask);
     return nullptr;
+  }
+
+  SmallVector<Operation *>
+  createInitClusterBarrier(ImplicitLocOpBuilder &b) const override {
+    auto arrive = ttag::ClusterBarrierArriveOp::create(b, b.getLoc());
+    auto wait = ttag::ClusterBarrierWaitOp::create(b, b.getLoc());
+    return {arrive.getOperation(), wait.getOperation()};
+  }
+
+  std::optional<uint16_t>
+  getScratchCTABroadcastMask(Operation *op) const override {
+    return getAtomicScratchBroadcastMask(op);
+  }
+
+  bool hasUnsummarizableCalleeState(Operation *op) const override {
+    if (isa<ttag::ClusterBarrierArriveOp, ttag::ClusterBarrierWaitOp>(op))
+      return true;
+    return getAtomicScratchBroadcastMask(op).value_or(0) != 0;
   }
 
   std::optional<MemEffectsOpInfo>

--- a/third_party/amd/lib/TritonAMDGPUTransforms/ConSanAMD.cpp
+++ b/third_party/amd/lib/TritonAMDGPUTransforms/ConSanAMD.cpp
@@ -16,34 +16,6 @@ using tti::WaitOpInfo;
 
 namespace mlir {
 
-namespace {
-
-Value getLeaderCTAPredicate(ImplicitLocOpBuilder &b, uint32_t broadcastMask) {
-  Value ctaId = tti::ExperimentalClusterCTAIdOp::create(b, b.getLoc());
-  Value ctaIdInGroup = arith::AndIOp::create(
-      b, ctaId, arith::ConstantIntOp::create(b, broadcastMask, 32));
-  return arith::CmpIOp::create(b, arith::CmpIPredicate::eq, ctaIdInGroup,
-                               arith::ConstantIntOp::create(b, 0, 32));
-}
-
-std::optional<uint16_t> getAtomicScratchBroadcastMask(Operation *op) {
-  if (!op->hasAttr("allocation.size") ||
-      !isa<ttag::BufferAtomicCASOp, ttag::BufferAtomicRMWOp,
-           triton::AtomicRMWOp, triton::AtomicCASOp,
-           ttg::LocalAtomicScatterRMWOp>(op))
-    return std::nullopt;
-
-  // Tensor-result atomics broadcast through shared memory from the canonical
-  // producer CTA. Scalar atomics stage and reload their result within one CTA.
-  auto tensorTy = dyn_cast<RankedTensorType>(op->getResult(0).getType());
-  if (!tensorTy)
-    return std::nullopt;
-  auto kBlock = StringAttr::get(op->getContext(), "block");
-  return ttg::toLinearLayout(tensorTy).getFreeVariableMasks().lookup(kBlock);
-}
-
-} // namespace
-
 class AMDConSanHooks : public tti::ConSanTargetHooks {
 public:
   bool isTMAOp(Operation *op) const override {
@@ -117,11 +89,8 @@ public:
     return std::nullopt;
   }
 
-  Value getIssuerCTAPred(ImplicitLocOpBuilder &b,
-                         Operation *op) const override {
-    if (auto scratchMask = getAtomicScratchBroadcastMask(op);
-        scratchMask && *scratchMask)
-      return getLeaderCTAPredicate(b, *scratchMask);
+  Value getIssuerCTAPred(ImplicitLocOpBuilder & /*b*/,
+                         Operation * /*op*/) const override {
     return nullptr;
   }
 
@@ -132,15 +101,8 @@ public:
     return {arrive.getOperation(), wait.getOperation()};
   }
 
-  std::optional<uint16_t>
-  getScratchCTABroadcastMask(Operation *op) const override {
-    return getAtomicScratchBroadcastMask(op);
-  }
-
   bool hasUnsummarizableCalleeState(Operation *op) const override {
-    if (isa<ttag::ClusterBarrierArriveOp, ttag::ClusterBarrierWaitOp>(op))
-      return true;
-    return getAtomicScratchBroadcastMask(op).value_or(0) != 0;
+    return isa<ttag::ClusterBarrierArriveOp, ttag::ClusterBarrierWaitOp>(op);
   }
 
   std::optional<MemEffectsOpInfo>


### PR DESCRIPTION
Track compiler-owned shared-memory scratch and summarize CTA-local non-inlined callee frames at their call sites. Preserve operation-specific CTA ownership and reject callee effects that cannot be summarized safely.

Co-authored by <jeffniu@openai.com>