### PR TITLE
[OptimizeThreadLocality] Handle reduce op outside accumulator loop

### DIFF
--- a/lib/Dialect/TritonGPU/Transforms/OptimizeThreadLocality.cpp
+++ b/lib/Dialect/TritonGPU/Transforms/OptimizeThreadLocality.cpp
@@ -290,10 +290,12 @@ class TritonGPUOptimizeThreadLocalityPass
       auto yieldOp = dyn_cast<scf::YieldOp>(yieldOpOperand.getOwner());
       if (!yieldOp)
         return;
-      Block *block = reduce->getBlock();
-      Operation *parentOp = block->getParentOp();
-      auto forOp = dyn_cast<scf::ForOp>(parentOp);
+      // Get the parent forOp for the yield and ensure the reduce is inside the
+      // forOp block
+      auto forOp = dyn_cast<scf::ForOp>(yieldOp->getParentOp());
       if (!forOp)
+        return;
+      if (reduce->getBlock() != forOp.getBody())
         return;
       auto argNum = yieldOpOperand.getOperandNumber();
       auto oldAccum = forOp.getInitArgs()[argNum];

--- a/test/TritonGPU/optimize-locality.mlir
+++ b/test/TritonGPU/optimize-locality.mlir
@@ -170,6 +170,35 @@ module attributes {"ttg.target" = "cuda:80", "ttg.num-ctas" = 1 : i32, "ttg.num-
 
 // -----
 
+// The yielded accumulator belongs to a different loop than the one enclosing the reduce.
+// CHECK-LABEL: @reduce_outside_accumulator_loop
+// CHECK: "tt.reduce"({{.*}}) <{axis = 1 : i32}>
+#blocked = #ttg.blocked<{sizePerThread = [1, 2], threadsPerWarp = [32, 1], warpsPerCTA = [1, 1], order = [1, 0]}>
+#slice = #ttg.slice<{dim = 1, parent = #blocked}>
+module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 1 : i32, "ttg.threads-per-warp" = 32 : i32} {
+  tt.func public @reduce_outside_accumulator_loop(%input: tensor<32x2x!tt.ptr<f32>, #blocked>, %output: tensor<32x!tt.ptr<f32>, #slice>, %count: i32) {
+    %zero = arith.constant dense<0.000000e+00> : tensor<32xf32, #slice>
+    %start = arith.constant 0 : i32
+    %step = arith.constant 1 : i32
+    scf.for %index = %start to %count step %step : i32 {
+      %values = tt.load %input : tensor<32x2x!tt.ptr<f32>, #blocked>
+      %reduced = "tt.reduce"(%values) <{axis = 1 : i32}> ({
+      ^bb0(%left: f32, %right: f32):
+        %sum = arith.addf %left, %right : f32
+        tt.reduce.return %sum : f32
+      }) : (tensor<32x2xf32, #blocked>) -> tensor<32xf32, #slice>
+      %result = scf.for %inner = %start to %count step %step iter_args(%accumulator = %zero) -> (tensor<32xf32, #slice>) : i32 {
+        %updated = arith.addf %accumulator, %reduced : tensor<32xf32, #slice>
+        scf.yield %updated : tensor<32xf32, #slice>
+      }
+      tt.store %output, %result : tensor<32x!tt.ptr<f32>, #slice>
+    }
+    tt.return
+  }
+}
+
+// -----
+
 // CHECK-LABEL: slice_layout
 // CHECK: %[[LOOP_OUTPUT:.*]] = scf.for
 // CHECK: %[[LOAD:.*]] = tt.load


### PR DESCRIPTION
The reduce op walk in OptimizeThreadLocality does not ensure that the YieldOp user of the candidate ReduceOp is associated with the ReduceOp's parent ForOp (if one exists). If the accumulator loop is separate from the Reduce but the Reduce is contained inside its own loop then the arg num index from the yield will be incorrect. To resolve this, get the ForLoop from the yield instead and ensure it matches the ReduceOp's parent block. 

@neildhar this was uncovered by the test you added in #11186 but I think it is otherwise unrelated to those changes. 