### PR TITLE
[PIPELINE] Preserve nested completion waits in buffer sizing

### DIFF
--- a/lib/Dialect/TritonGPU/Transforms/Pipeliner/LowerLoops.cpp
+++ b/lib/Dialect/TritonGPU/Transforms/Pipeliner/LowerLoops.cpp
@@ -103,24 +103,26 @@ int getDefUseStageDiff(Operation *op, scf::ForOp forOp,
       topLevelWaitUsers.insert(topLevelUser);
     }
   }
-  for (Operation *topLevelUser : topLevelUsers) {
-    int _useStage = schedule[topLevelUser].first;
-    CoarseSchedule::Cluster _useCluster = schedule[topLevelUser].second;
-    if (*_useCluster > *defCluster) {
-      // Check if we need extra buffer due to unusual execution order
-      // The issue occurs when users of the load are scheduled in a later
-      // cluster, which happens when conditional code gets moved to epilogue
-      // cluster. This creates a race condition where the local load happens
-      // after the global-to-local copy for the next pipeline stage starts.
-      _useStage++;
+  auto getEffectiveUseStage = [&](Operation *user) {
+    int stage = schedule[user].first;
+    CoarseSchedule::Cluster cluster = schedule[user].second;
+    if (*cluster > *defCluster) {
+      // A later cluster can put the next iteration's producer before this use
+      // in the expanded schedule. Account for that overlap as an extra stage
+      // so their buffers cannot alias.
+      stage++;
     }
+    return stage;
+  };
+  for (Operation *topLevelUser : topLevelUsers) {
+    int _useStage = getEffectiveUseStage(topLevelUser);
     useStage = std::min(_useStage, useStage.value_or(_useStage));
   }
   // Waits tells us the buffer is still in use until the wait completes, we
   // can't simply load from the buffer and replace the uses of the buffer with
   // the load. The stage diff needs to account for the furthest wait.
   for (Operation *topLevelUser : topLevelWaitUsers) {
-    int _useStage = schedule[topLevelUser].first;
+    int _useStage = getEffectiveUseStage(topLevelUser);
     useStage = std::max(_useStage, useStage.value_or(_useStage));
   }
   if (!useStage)

--- a/lib/Dialect/TritonGPU/Transforms/Pipeliner/LowerLoops.cpp
+++ b/lib/Dialect/TritonGPU/Transforms/Pipeliner/LowerLoops.cpp
@@ -81,6 +81,7 @@ int getDefUseStageDiff(Operation *op, scf::ForOp forOp,
   std::optional<int> useStage;
   DenseSet<Operation *> topLevelUsers =
       triton::getTopLevelUsersInLoop(op, forOp);
+  DenseSet<Operation *> topLevelWaitUsers;
   // Special case for loads used by local_alloc:
   // we must consider the uses of the local_alloc, as it may be removed and its
   // uses will become direct uses of the async load.
@@ -88,16 +89,21 @@ int getDefUseStageDiff(Operation *op, scf::ForOp forOp,
   // local_alloc is used by a dot product and has correct encoding.
   if (isa<tt::LoadOp, tt::DescriptorLoadLikeOpInterface>(op)) {
     DenseSet<Operation *> allocUsers;
+    DenseSet<Operation *> allocWaitUsers;
     for (Operation *topLevelUser : topLevelUsers) {
       if (auto localAlloc = dyn_cast<ttg::LocalAllocOp>(topLevelUser)) {
         DenseSet<Operation *> users =
             triton::getTopLevelUsersInLoop(localAlloc, forOp);
         allocUsers.insert(users.begin(), users.end());
+        DenseSet<Operation *> waitUsers = triton::getTopLevelUsersInLoop(
+            localAlloc, forOp,
+            [](Operation *user) { return isa<ttng::WaitBarrierOp>(user); });
+        allocWaitUsers.insert(waitUsers.begin(), waitUsers.end());
       }
     }
     topLevelUsers.insert(allocUsers.begin(), allocUsers.end());
+    topLevelWaitUsers.insert(allocWaitUsers.begin(), allocWaitUsers.end());
   }
-  DenseSet<Operation *> topLevelWaitUsers;
   for (Operation *topLevelUser : topLevelUsers) {
     if (isa<ttng::WaitBarrierOp>(topLevelUser)) {
       topLevelWaitUsers.insert(topLevelUser);

--- a/test/TritonGPU/pipeline-lower-loop.mlir
+++ b/test/TritonGPU/pipeline-lower-loop.mlir
@@ -99,7 +99,9 @@ tt.func @one_dep_async(%lb : index, %ub : index, %step : index,
 
 module attributes {"ttg.num-warps" = 4 : i32, "ttg.num-ctas" = 1 : i32} {
 // CHECK-LABEL: @one_dep_barrier_wait
-// CHECK: ttg.local_alloc : () -> !ttg.memdesc<3x128x64
+// The wait is in a later cluster than the load, so it extends the buffer's
+// effective lifetime by one stage.
+// CHECK: ttg.local_alloc : () -> !ttg.memdesc<4x128x64
 tt.func @one_dep_barrier_wait(%lb : index, %ub : index, %step : index,
                  %a_ptr_init : tensor<128x64x!tt.ptr<f16>, #A> {tt.divisibility = dense<[16, 16]> : tensor<2xi32>, tt.contiguity = dense<[1, 16]> : tensor<2xi32>},
                  %bar : !ttg.memdesc<1xi64, #shared1, #ttg.shared_memory, mutable>,
@@ -123,7 +125,7 @@ tt.func @one_dep_barrier_wait(%lb : index, %ub : index, %step : index,
 
 module attributes {"ttg.num-warps" = 4 : i32, "ttg.num-ctas" = 1 : i32} {
 // CHECK-LABEL: @one_dep_barrier_wait_trans
-// CHECK: ttg.local_alloc : () -> !ttg.memdesc<3x128x64
+// CHECK: ttg.local_alloc : () -> !ttg.memdesc<4x128x64
 tt.func @one_dep_barrier_wait_trans(%lb : index, %ub : index, %step : index,
                  %a_ptr_init : tensor<128x64x!tt.ptr<f16>, #A> {tt.divisibility = dense<[16, 16]> : tensor<2xi32>, tt.contiguity = dense<[1, 16]> : tensor<2xi32>},
                  %bar : !ttg.memdesc<1xi64, #shared1, #ttg.shared_memory, mutable>,

--- a/test/TritonGPU/pipeline-lower-loop.mlir
+++ b/test/TritonGPU/pipeline-lower-loop.mlir
@@ -144,6 +144,32 @@ tt.func @one_dep_barrier_wait_trans(%lb : index, %ub : index, %step : index,
 // -----
 
 #A = #ttg.blocked<{sizePerThread = [1, 8], threadsPerWarp = [2, 16], warpsPerCTA = [4, 1], order = [1, 0]}>
+#shared = #ttg.nvmma_shared<{swizzlingByteWidth = 128, transposed = false, elementBitWidth = 16}>
+#shared1 = #ttg.swizzled_shared<{vec = 1, perPhase = 1, maxPhase = 1, order = [0]}>
+
+module attributes {"ttg.num-warps" = 4 : i32, "ttg.num-ctas" = 1 : i32} {
+// CHECK-LABEL: @nested_barrier_wait
+// A nested completion wait keeps the buffer live through its parent scf.if.
+// CHECK: ttg.local_alloc : () -> !ttg.memdesc<4x128x64
+tt.func @nested_barrier_wait(%lb : index, %ub : index, %step : index,
+                 %a_ptr_init : tensor<128x64x!tt.ptr<f16>, #A> {tt.divisibility = dense<[16, 16]> : tensor<2xi32>, tt.contiguity = dense<[1, 16]> : tensor<2xi32>},
+                 %bar : !ttg.memdesc<1xi64, #shared1, #ttg.shared_memory, mutable>,
+                 %phase : i32, %condition : i1) -> () {
+  scf.for %iv = %lb to %ub step %step : index {
+    %a = tt.load %a_ptr_init {loop.cluster = 2 : i32, loop.stage = 0 : i32} : tensor<128x64x!tt.ptr<f16>, #A>
+    %sh = ttg.local_alloc %a {loop.cluster = 0 : i32, loop.stage = 2 : i32} : (tensor<128x64xf16, #A>) -> !ttg.memdesc<128x64xf16, #shared, #ttg.shared_memory>
+    "use"(%a) {loop.cluster = 0 : i32, loop.stage = 2 : i32} : (tensor<128x64xf16, #A>) -> ()
+    scf.if %condition {
+      ttng.wait_barrier %bar, %phase deps %sh : !ttg.memdesc<1xi64, #shared1, #ttg.shared_memory, mutable>, !ttg.memdesc<128x64xf16, #shared, #ttg.shared_memory>
+    } {loop.cluster = 3 : i32, loop.stage = 3 : i32}
+  } {tt.scheduled_max_stage = 3 : i32}
+  tt.return
+}
+}
+
+// -----
+
+#A = #ttg.blocked<{sizePerThread = [1, 8], threadsPerWarp = [2, 16], warpsPerCTA = [4, 1], order = [1, 0]}>
 
 module attributes {"ttg.num-warps" = 4 : i32, "ttg.num-ctas" = 1 : i32} {
 // CHECK-LABEL: @different_use_stages


### PR DESCRIPTION
Depends on #10976.

#10976 accounts for later-cluster completion waits when the wait is a top-level
loop operation. A completion wait nested inside structured control flow remains
invisible to the lifetime calculation.

`getTopLevelUsersInLoop(localAlloc, forOp)` collapses a nested use to its
scheduled top-level owner, such as `scf.if`. The later
`isa<ttng::WaitBarrierOp>` check therefore sees the `scf.if`, not the wait,
and treats the dependency as an ordinary use. In the regression schedule, that
allocates two shared-memory buffer slots even though the nested wait remains
live through effective stage four.

This change classifies wait dependencies while traversing the local allocation's
uses, before collapsing them to the scheduled top-level owner. The existing
filtered traversal still follows memdesc views, so the recorded owner can then
participate in the same furthest-completion calculation added by #10976.

The regression mirrors a scheduled shape produced from a public Gluon program
with a conditional `mbarrier.wait(..., deps=[shared_allocation])`:

| Operation | Stage | Cluster | Effective completion stage |
|---|---:|---:|---:|
| Load | 0 | 2 | 0 |
| Ordinary use | 2 | 0 | 2 |
| `scf.if` containing the wait | 3 | 3 | 4 |

Without this commit, the test lowers to a two-slot allocation and FileCheck
fails. With this commit, it lowers to the required four-slot allocation.

This PR is stacked on #10976. The first commit is the content of #10976 rebased onto
current main. The new nested-control-flow fix is isolated in commit
`cdcd9e441`. Once #10976 lands, this branch can be rebased and the duplicate
first commit will disappear from the diff.

## Test plan

- Built `triton-opt` from current upstream main plus #10976 and this commit
  using Triton's pinned LLVM toolchain.
- `lit -v test/TritonGPU/pipeline-lower-loop.mlir`
- Negative check: revert only `cdcd9e441`, rebuild, and observe FileCheck fail
  because `@nested_barrier_wait` gets `2x128x64` instead of `4x128x64`.
- `pre-commit run --from-ref origin/main --to-ref HEAD`

# New contributor declaration

- [x] I am not making a trivial change, such as fixing a typo in a comment.

- [x] I have written a PR description following these
  [rules](https://cbea.ms/git-commit/#why-not-how).

- [x] I have run `pre-commit run --from-ref origin/main --to-ref HEAD`.

- [x] I have added tests.
  - `/test` for `lit` tests

- [x] The `lit` tests I have added follow these
  [best practices](https://mlir.llvm.org/getting_started/TestingGuide/#filecheck-best-practices),
  including the "tests should be minimal" section.
