### PR TITLE
handle missing ldconfig/cache

### DIFF
--- a/third_party/nvidia/backend/driver.py
+++ b/third_party/nvidia/backend/driver.py
@@ -27,9 +27,13 @@ def libcuda_dirs():
     if env_libcuda_path := knobs.nvidia.libcuda_path:
         return [env_libcuda_path]
 
-    libs = subprocess.check_output(["/sbin/ldconfig", "-p"]).decode(errors="ignore")
-    # each line looks like the following:
-    # libcuda.so.1 (libc6,x86-64) => /lib/x86_64-linux-gnu/libcuda.so.1
+    # The program should not crash in the case of a failure to retrieve the ld cache
+    try:
+        # each line looks like the following:
+        # libcuda.so.1 (libc6,x86-64) => /lib/x86_64-linux-gnu/libcuda.so.1
+        libs = subprocess.check_output(["ldconfig", "-p"]).decode(errors="ignore")
+    except (subprocess.CalledProcessError, FileNotFoundError, OSError):
+        libs = ""
     locs = [line.split()[-1] for line in libs.splitlines() if "libcuda.so.1" in line]
     dirs = [os.path.dirname(loc) for loc in locs]
     env_ld_library_path = os.getenv("LD_LIBRARY_PATH")


### PR DESCRIPTION
`ldconfig` can raise an error if the cache is not present, or the ldconfig is not located in /sbin/. Wrapped the subprocess call of ld cache in a try-except block. This prevents a crash on FHS non-compliant such as on NixOS.

Using `shutil` to get the proper path to ldconfig is more robust, but I have refrained from this to keep the changes minimal.

<!---
The core Triton is a small number of people, and we receive many PRs (thank
you!).  To help us review your code more quickly, **if you are a new
contributor (less than 3 PRs merged) we ask that you complete the following
tasks and include the filled-out checklist in your PR description.**

Complete the following tasks before sending your PR, and replace `[ ]` with
`[x]` to indicate you have done them.
-->

# New contributor declaration
- [X] I am not making a trivial change, such as fixing a typo in a comment.

- [X] I have written a PR description following these
  [rules](https://cbea.ms/git-commit/#why-not-how).

- [X] I have run `pre-commit run --from-ref origin/main --to-ref HEAD`.

- Select one of the following.
  - [ ] I have added tests.
    - `/test` for `lit` tests
    - `/unittest` for C++ tests
    - `/python/test` for end-to-end tests
  - [X] This PR does not need a test because `the locs variable was already allowed to be empty, the change only catches a crash`.

- Select one of the following.
  - [X] I have not added any `lit` tests.
  - [ ] The `lit` tests I have added follow these [best practices](https://mlir.llvm.org/getting_started/TestingGuide/#filecheck-best-practices),
    including the "tests should be minimal" section. (Usually running Python code
    and using the instructions it generates is not minimal.)
