### PR TITLE
[BACKEND] Pass target information to LLVM optimization

### DIFF
--- a/python/src/llvm.cc
+++ b/python/src/llvm.cc
@@ -720,6 +720,11 @@ void init_triton_llvm(py::module_ &m) {
 #endif
   });
 
+  m.def("attach_target_triple",
+        [](llvm::Module *mod, const std::string triple) {
+          mod->setTargetTriple(llvm::Triple(triple));
+        });
+
   m.def("attach_datalayout", [](llvm::Module *mod, const std::string triple,
                                 const std::string proc,
                                 const std::string features) {
@@ -797,12 +802,6 @@ void init_triton_llvm(py::module_ &m) {
         tuningOptions.LoopUnrolling = true;
         tuningOptions.LoopInterleaving = true;
         tuningOptions.LoopVectorization = true;
-        // TODO: currently we run SLP vectorizer with an empty target machine.
-        // This cause the vectorizer to create larger vector which could be bad.
-        // Disabling it would currently cause regressions as this pass also
-        // applies some scheduling that helps performance in some cases. We
-        // should work on using NVPTX target instead and address the performance
-        // regressions with some scheduling solution.
         tuningOptions.SLPVectorization = !disable_slp_vectorizer;
 
         std::string pluginFile =

--- a/python/test/unit/language/test_compile_only.py
+++ b/python/test/unit/language/test_compile_only.py
@@ -3,9 +3,14 @@ import re
 
 import triton
 import triton.language as tl
+from triton._C.libtriton import llvm
 from triton.backends.compiler import GPUTarget
 from triton.compiler import ASTSource
 from triton.compiler.errors import CompileTimeAssertionFailure
+
+
+class StopAfterOptimizeModuleCall(Exception):
+    pass
 
 
 @triton.jit
@@ -369,3 +374,43 @@ def test_fp8_compiles_for_multiple_architectures_cuda():
     src = ASTSource(fn=fp8_convert, signature={"src": "*fp32", "dst": "*fp8e5"}, constexprs={})
     triton.compile(src, target=GPUTarget("cuda", 90, 32))
     triton.compile(src, target=GPUTarget("cuda", 80, 32))
+
+
+@pytest.mark.parametrize(
+    "target, options, enable_asan, expected",
+    [
+        (GPUTarget("cuda", 90, 32), {"ptx_version": 83, "enable_fp_fusion": True}, False,
+         ("nvptx64-nvidia-cuda", "sm_90a", "+ptx83")),
+        (GPUTarget("hip", "gfx942", 64), {"enable_fp_fusion": True}, True, ("amdgcn-amd-amdhsa", "gfx942", "+xnack")),
+    ],
+)
+def test_optimize_module_target_info(monkeypatch, target, options, enable_asan, expected):
+
+    @triton.jit
+    def copy_kernel(src, dst):
+        value = tl.load(src)
+        tl.store(dst, value)
+
+    captured = {}
+
+    def optimize_module_wrapper(mod, opt, **kwargs):
+        captured["module"] = str(mod)
+        captured["kwargs"] = kwargs
+        raise StopAfterOptimizeModuleCall
+
+    monkeypatch.setattr(llvm, "optimize_module", optimize_module_wrapper)
+    # ASan bitcode is immaterial to this call-boundary test.
+    monkeypatch.setattr(llvm, "link_extern_libs", lambda mod, paths: None)
+
+    src = ASTSource(fn=copy_kernel, signature={"src": "*fp32", "dst": "*fp32"}, constexprs={})
+    with triton.knobs.compilation.scope():
+        triton.knobs.compilation.always_compile = True
+        triton.knobs.compilation.enable_asan = enable_asan
+        with pytest.raises(StopAfterOptimizeModuleCall):
+            triton.compile(src, target=target, options=options)
+
+    triple, arch, features = expected
+    assert f'target triple = "{triple}"' in captured["module"]
+    assert captured["kwargs"]["arch"] == arch
+    assert captured["kwargs"]["features"] == features
+    assert captured["kwargs"]["enable_fp_fusion"]

--- a/third_party/amd/backend/compiler.py
+++ b/third_party/amd/backend/compiler.py
@@ -419,7 +419,7 @@ class HIPBackend(BaseBackend):
         llvm.init_targets()
         context = llvm.context()
         llvm_mod = llvm.to_module(mod, context)
-        amd.attach_target_triple(llvm_mod)
+        llvm.attach_target_triple(llvm_mod, amd.TARGET_TRIPLE)
         target_features = ''
         if knobs.compilation.enable_asan:
             target_features = '+xnack'
@@ -495,8 +495,8 @@ class HIPBackend(BaseBackend):
             if len(paths) > 0:
                 llvm.link_extern_libs(llvm_mod, paths)
 
-        llvm.optimize_module(llvm_mod, llvm.OPTIMIZE_O3, options.arch, '', [], options.enable_fp_fusion,
-                             disable_vector_combine=True)
+        llvm.optimize_module(llvm_mod, llvm.OPTIMIZE_O3, arch=options.arch, features=target_features,
+                             enable_fp_fusion=options.enable_fp_fusion, disable_vector_combine=True)
 
         # Architectures with architected SGPRs store the workgroup id in ttmp9 (X) and ttmp7 (Y[15:0], Z[31:16]).
         # These attributes are used to determine if Z should be masked out when loading Y. They are inferred during

--- a/third_party/amd/python/triton_amd.cc
+++ b/third_party/amd/python/triton_amd.cc
@@ -362,10 +362,6 @@ void init_triton_amd(py::module_ &m) {
     context.loadAllAvailableDialects();
   });
 
-  m.def("attach_target_triple", [](llvm::Module *module) {
-    module->setTargetTriple(llvm::Triple(amdTargetTriple));
-  });
-
   // Set target architecture ISA version
   m.def("set_isa_version", [](llvm::Module *module, const std::string &arch) {
     llvm::AMDGPU::IsaVersion version = llvm::AMDGPU::getIsaVersion(arch);

--- a/third_party/nvidia/backend/compiler.py
+++ b/third_party/nvidia/backend/compiler.py
@@ -461,6 +461,7 @@ class CUDABackend(BaseBackend):
         proc = sm_arch_from_capability(cap_llvm)
         features = get_features(options, cap_llvm)
         triple = 'nvptx64-nvidia-cuda'
+        llvm.attach_target_triple(llvm_mod, triple)
         nvidia.set_short_ptr()
         llvm.attach_datalayout(llvm_mod, triple, proc, features)
         if options.enable_reflect_ftz:
@@ -474,6 +475,9 @@ class CUDABackend(BaseBackend):
         llvm.optimize_module(
             llvm_mod,
             llvm.OPTIMIZE_O3,
+            arch=proc,
+            features=features,
+            enable_fp_fusion=options.enable_fp_fusion,
             disable_slp_vectorizer=capability == 80,
             expand_masked_div_rem=True,
         )


### PR DESCRIPTION
We have been investigating performance regressions on the 3.8 release candidate on internal workloads. Many of these regressions relate to LLVM features. During the investigation Codex pointed me to poor cost modeling choices in LLVM that are likely due to selecting a "generic" rather than architecture specific cost model.

This change adds to proper machine target to the LLVM optimize calls to inform the proper cost models.

Full disclosure, we haven't finished testing if this resolves the regressions we are seeing, but we wanted to open it up to initial feedback regardless.