### PR TITLE
[AMD] Preserve i32 accumulation for small-K int8 dots

### DIFF
--- a/python/test/unit/language/test_core.py
+++ b/python/test/unit/language/test_core.py
@@ -4091,6 +4091,39 @@ def test_dot(M, N, K, num_warps, col_a, col_b, epilogue, input_precision, in_dty
         assert re.search(pattern, ptx, flags=re.DOTALL)
 
 
+@pytest.mark.parametrize("block_k", [1, 2, 4])
+def test_int8_dot_small_block_k(block_k, device):
+    if not is_hip():
+        pytest.skip("small-K integer FMA path is AMD-specific")
+
+    @triton.jit
+    def kernel(a, b, c, K, BLOCK_K: tl.constexpr):
+        offs_m = tl.arange(0, 32)
+        offs_n = tl.arange(0, 32)
+        offs_k = tl.arange(0, BLOCK_K)
+        a_ptrs = a + offs_m[:, None] * K + offs_k[None, :]
+        b_ptrs = b + offs_k[:, None] * 32 + offs_n[None, :]
+        acc = tl.zeros((32, 32), dtype=tl.int32)
+        for _ in range(0, K, BLOCK_K):
+            acc = tl.dot(tl.load(a_ptrs), tl.load(b_ptrs), acc, out_dtype=tl.int32)
+            a_ptrs += BLOCK_K
+            b_ptrs += BLOCK_K * 32
+        tl.store(c + offs_m[:, None] * 32 + offs_n[None, :], acc)
+
+    K = 2048
+    rng = np.random.default_rng(0)
+    a = rng.integers(120, 128, size=(32, K), dtype=np.int8)
+    b = rng.integers(120, 128, size=(K, 32), dtype=np.int8)
+    expected = a.astype(np.int64) @ b.astype(np.int64)
+    assert np.abs(expected).max() > 2**24
+
+    a = torch.from_numpy(a).to(device)
+    b = torch.from_numpy(b).to(device)
+    actual = torch.empty((32, 32), dtype=torch.int32, device=device)
+    kernel[(1, )](a, b, actual, K, BLOCK_K=block_k)
+    np.testing.assert_array_equal(to_numpy(actual), expected)
+
+
 @pytest.mark.interpreter
 @pytest.mark.parametrize("M, N, K, col_a, col_b, rhs_scale, mxfp_type, normal_type, num_warps, mma, kpack",
                          [(M, N, K, col_a, col_b, rhs_scale, mxfp_type, normal_type, 4, mma, kpack)

--- a/python/test/unit/language/test_core.py
+++ b/python/test/unit/language/test_core.py
@@ -4091,39 +4091,6 @@ def test_dot(M, N, K, num_warps, col_a, col_b, epilogue, input_precision, in_dty
         assert re.search(pattern, ptx, flags=re.DOTALL)
 
 
-@pytest.mark.parametrize("block_k", [1, 2, 4])
-def test_int8_dot_small_block_k(block_k, device):
-    if not is_hip():
-        pytest.skip("small-K integer FMA path is AMD-specific")
-
-    @triton.jit
-    def kernel(a, b, c, K, BLOCK_K: tl.constexpr):
-        offs_m = tl.arange(0, 32)
-        offs_n = tl.arange(0, 32)
-        offs_k = tl.arange(0, BLOCK_K)
-        a_ptrs = a + offs_m[:, None] * K + offs_k[None, :]
-        b_ptrs = b + offs_k[:, None] * 32 + offs_n[None, :]
-        acc = tl.zeros((32, 32), dtype=tl.int32)
-        for _ in range(0, K, BLOCK_K):
-            acc = tl.dot(tl.load(a_ptrs), tl.load(b_ptrs), acc, out_dtype=tl.int32)
-            a_ptrs += BLOCK_K
-            b_ptrs += BLOCK_K * 32
-        tl.store(c + offs_m[:, None] * 32 + offs_n[None, :], acc)
-
-    K = 2048
-    rng = np.random.default_rng(0)
-    a = rng.integers(120, 128, size=(32, K), dtype=np.int8)
-    b = rng.integers(120, 128, size=(K, 32), dtype=np.int8)
-    expected = a.astype(np.int64) @ b.astype(np.int64)
-    assert np.abs(expected).max() > 2**24
-
-    a = torch.from_numpy(a).to(device)
-    b = torch.from_numpy(b).to(device)
-    actual = torch.empty((32, 32), dtype=torch.int32, device=device)
-    kernel[(1, )](a, b, actual, K, BLOCK_K=block_k)
-    np.testing.assert_array_equal(to_numpy(actual), expected)
-
-
 @pytest.mark.interpreter
 @pytest.mark.parametrize("M, N, K, col_a, col_b, rhs_scale, mxfp_type, normal_type, num_warps, mma, kpack",
                          [(M, N, K, col_a, col_b, rhs_scale, mxfp_type, normal_type, 4, mma, kpack)

--- a/third_party/amd/lib/TritonAMDGPUToLLVM/DotOpToLLVM/FMA.cpp
+++ b/third_party/amd/lib/TritonAMDGPUToLLVM/DotOpToLLVM/FMA.cpp
@@ -70,16 +70,14 @@ class AMDFMAVectorMultiplier : public FMAVectorMultiplier {
     auto vecTy = vec_ty(elemTy, vectorSize);
     auto b = TritonLLVMOpBuilder(loc, rewriter);
     Value vec = b.undef(vecTy);
-    Value zero;
+    Value zero = LLVM::ConstantOp::create(rewriter, loc, elemTy,
+                                          rewriter.getZeroAttr(elemTy));
     for (int elem = 0; elem < vectorSize; ++elem) {
       int elemPos = firstElemPos + elem;
       Value scalar;
       if (elemPos < static_cast<int>(scalarValues.size())) {
         scalar = scalarValues[elemPos];
       } else {
-        if (!zero)
-          zero = LLVM::ConstantOp::create(rewriter, loc, elemTy,
-                                          rewriter.getZeroAttr(elemTy));
         scalar = zero;
       }
       vec = b.insert_element(vecTy, vec, scalar, b.i32_val(elem));

--- a/third_party/amd/lib/TritonAMDGPUToLLVM/DotOpToLLVM/FMA.cpp
+++ b/third_party/amd/lib/TritonAMDGPUToLLVM/DotOpToLLVM/FMA.cpp
@@ -70,10 +70,19 @@ class AMDFMAVectorMultiplier : public FMAVectorMultiplier {
     auto vecTy = vec_ty(elemTy, vectorSize);
     auto b = TritonLLVMOpBuilder(loc, rewriter);
     Value vec = b.undef(vecTy);
+    Value zero;
     for (int elem = 0; elem < vectorSize; ++elem) {
       int elemPos = firstElemPos + elem;
-      vec =
-          b.insert_element(vecTy, vec, scalarValues[elemPos], b.i32_val(elem));
+      Value scalar;
+      if (elemPos < static_cast<int>(scalarValues.size())) {
+        scalar = scalarValues[elemPos];
+      } else {
+        if (!zero)
+          zero = LLVM::ConstantOp::create(rewriter, loc, elemTy,
+                                          rewriter.getZeroAttr(elemTy));
+        scalar = zero;
+      }
+      vec = b.insert_element(vecTy, vec, scalar, b.i32_val(elem));
     }
     if (elemTy.isInteger(8)) {
       assert(vectorSize == 4);

--- a/third_party/amd/lib/TritonAMDGPUTransforms/AccelerateAMDMatmul.cpp
+++ b/third_party/amd/lib/TritonAMDGPUTransforms/AccelerateAMDMatmul.cpp
@@ -1650,7 +1650,8 @@ public:
       return false;
     }
 
-    // The lowering zero-pads a partial final group for I8 x I8 -> I32 v_dot.
+    // Try I8 x I8 -> I32 v_dot
+    // Partial K groups are zero-padded in the FMA lowering.
     if (dotTypes.a.isInteger(8) && dotTypes.b.isInteger(8) &&
         dotTypes.c.isInteger(32) && dotTypes.d.isInteger(32)) {
       return true;

--- a/third_party/amd/lib/TritonAMDGPUTransforms/AccelerateAMDMatmul.cpp
+++ b/third_party/amd/lib/TritonAMDGPUTransforms/AccelerateAMDMatmul.cpp
@@ -1650,10 +1650,9 @@ public:
       return false;
     }
 
-    // Try I8 x I8 -> I32 v_dot
-    // if k % 4 != 0: can not use integer V_DOT instruction
+    // The lowering zero-pads a partial final group for I8 x I8 -> I32 v_dot.
     if (dotTypes.a.isInteger(8) && dotTypes.b.isInteger(8) &&
-        dotTypes.c.isInteger(32) && dotTypes.d.isInteger(32) && k % 4 == 0) {
+        dotTypes.c.isInteger(32) && dotTypes.d.isInteger(32)) {
       return true;
     }
 

--- a/third_party/amd/python/test/test_int8_dot_small_block_k.py
+++ b/third_party/amd/python/test/test_int8_dot_small_block_k.py
@@ -1,0 +1,44 @@
+import numpy as np
+import pytest
+import torch
+import triton
+import triton.language as tl
+
+from triton._internal_testing import is_hip, to_numpy
+
+if not is_hip():
+    pytest.skip(allow_module_level=True)
+
+
+@pytest.mark.parametrize("block_k", [1, 2, 3, 4])
+def test_int8_dot_small_block_k(block_k, device):
+    @triton.jit
+    def kernel(a, b, c, K, BLOCK_K: tl.constexpr, PAD_K: tl.constexpr):
+        offs_m = tl.arange(0, 32)
+        offs_n = tl.arange(0, 32)
+        offs_k = tl.arange(0, PAD_K)
+        a_ptrs = a + offs_m[:, None] * K + offs_k[None, :]
+        b_ptrs = b + offs_k[:, None] * 32 + offs_n[None, :]
+        k_mask = offs_k < BLOCK_K
+        acc = tl.zeros((32, 32), dtype=tl.int32)
+        for _ in range(0, K, BLOCK_K):
+            acc = tl.dot(tl.load(a_ptrs, mask=k_mask[None, :], other=0),
+                         tl.load(b_ptrs, mask=k_mask[:, None], other=0), acc, out_dtype=tl.int32)
+            a_ptrs += BLOCK_K
+            b_ptrs += BLOCK_K * 32
+        tl.store(c + offs_m[:, None] * 32 + offs_n[None, :], acc)
+
+    # tl.arange requires a power-of-two range; pad so BLOCK_K=3 stays a logical 3-wide K tile.
+    pad_k = triton.next_power_of_2(block_k)
+    K = 2052
+    rng = np.random.default_rng(0)
+    a = rng.integers(120, 128, size=(32, K), dtype=np.int8)
+    b = rng.integers(120, 128, size=(K, 32), dtype=np.int8)
+    expected = a.astype(np.int64) @ b.astype(np.int64)
+    assert np.abs(expected).max() > 2**24
+
+    a = torch.from_numpy(a).to(device)
+    b = torch.from_numpy(b).to(device)
+    actual = torch.empty((32, 32), dtype=torch.int32, device=device)
+    kernel[(1, )](a, b, actual, K, BLOCK_K=block_k, PAD_K=pad_k)
+    np.testing.assert_array_equal(to_numpy(actual), expected)

--- a/third_party/amd/python/test/test_int8_dot_small_block_k.py
+++ b/third_party/amd/python/test/test_int8_dot_small_block_k.py
@@ -12,6 +12,7 @@ if not is_hip():
 
 @pytest.mark.parametrize("block_k", [1, 2, 3, 4])
 def test_int8_dot_small_block_k(block_k, device):
+
     @triton.jit
     def kernel(a, b, c, K, BLOCK_K: tl.constexpr, PAD_K: tl.constexpr):
         offs_m = tl.arange(0, 32)
@@ -22,8 +23,8 @@ def test_int8_dot_small_block_k(block_k, device):
         k_mask = offs_k < BLOCK_K
         acc = tl.zeros((32, 32), dtype=tl.int32)
         for _ in range(0, K, BLOCK_K):
-            acc = tl.dot(tl.load(a_ptrs, mask=k_mask[None, :], other=0),
-                         tl.load(b_ptrs, mask=k_mask[:, None], other=0), acc, out_dtype=tl.int32)
+            acc = tl.dot(tl.load(a_ptrs, mask=k_mask[None, :], other=0), tl.load(b_ptrs, mask=k_mask[:, None], other=0),
+                         acc, out_dtype=tl.int32)
             a_ptrs += BLOCK_K
             b_ptrs += BLOCK_K * 32
         tl.store(c + offs_m[:, None] * 32 + offs_n[None, :], acc)


### PR DESCRIPTION
Small-K i8 dots whose K tile is not divisible by four are currently legalized through fp32. This silently rounds loop-carried i32 accumulators once they exceed 2²⁴.

Keep these dots on the integer `sdot4` path and zero-pad incomplete four-element groups. The existing BLOCK_K=4 lowering remains byte-identical.

References: https://github.com/ROCm/triton/issues/958

## Testing

- gfx950 BLOCK_K=1/2: 996/1024 mismatches before, exact after.
- gfx950 BLOCK_K=4: exact before and after; LLVM and ISA unchanged.
- `python3 -m pytest python/test/unit/language/test_core.py -k int8_dot_small_block_k -s --tb=short`: 3 passed.
- Nearby int8 dot tests: 92 passed.
- AMD FMA lit test: passed.
- All applicable pre-commit hooks passed on the exact rebased commit range.

# New contributor declaration

- [x] I am not making a trivial change, such as fixing a typo in a comment.
- [x] I have written a PR description following these [rules](https://cbea.ms/git-commit/#why-not-how).
- [x] I have run the equivalent exact range for `pre-commit run --from-ref origin/main --to-ref HEAD`.
- [x] I have added tests under `/python/test`.
- [x] I have not added any `lit` tests.