### PR TITLE
Skip warp specialization for non-TMA loads instead of aborting

### DIFF
--- a/third_party/nvidia/hopper/lib/Transforms/WarpSpecialization.cpp
+++ b/third_party/nvidia/hopper/lib/Transforms/WarpSpecialization.cpp
@@ -44,6 +44,21 @@ public:
     if (numWarps != 4)
       return;
 
+    // Producer can only be lowered for TMA loads today, see
+    // processProducerCommitOp() in WSLowerToken.cpp, which reports a fatal
+    // error for any other token load type.
+    // so bail out here and let the regular software pipeliner handle the loop
+    // instead of aborting the compiler.
+    bool hasNonTMATensorLoad = false;
+    for (scf::ForOp forOp : loops) {
+      forOp.walk([&](triton::LoadOp loadOp) {
+        if (isa<RankedTensorType>(loadOp.getType()))
+          hasNonTMATensorLoad = true;
+      });
+    }
+    if (hasNonTMATensorLoad)
+      return;
+
     // FIXME: skip warpspec if there is else block. Need to improve
     // CodePartitioning to correctly handle channels in else block.
     bool hasElse = false;


### PR DESCRIPTION

`processProducerCommitOp()` only handles TMA loads and calls
`report_fatal_error()` for anything else. A tensor `tt.load` becomes a
cp.async channel and hits that path.
## Fix
Bail out before rewriting any IR when a loop has a tensor-producing
`tt.load`, and let the normal software pipeliner handle it. Descriptor-load
kernels are unaffected.
## Repro
```python
for k in tl.range(0, K, BK, warp_specialize=True):
    acc += tl.dot(tl.load(ap), tl.load(bp))