### PR TITLE
[AMD][BACKEND][GFX9] Enable amdgpu-use-amdgpu-trackers LLVM flag

### DIFF
--- a/third_party/amd/backend/compiler.py
+++ b/third_party/amd/backend/compiler.py
@@ -537,6 +537,8 @@ class HIPBackend(BaseBackend):
         metadata["name"] = names[0]
         # llvm -> hsaco
         flags = []
+        if options.arch in ["gfx942", "gfx950"]:
+            flags.append("amdgpu-use-amdgpu-trackers")
         if is_expert_scheduling_enabled(options.arch):
             flags.append("amdgpu-expert-scheduling-mode")
         features = ''


### PR DESCRIPTION
Enable LLVM's AMDGPU-specific register-pressure trackers when compiling for gfx942 and gfx950. This allows the scheduler to make better-informed SGPR/VGPR/AGPR pressure and occupancy decisions.

This flag can be removed once the trackers are enabled by default: https://github.com/llvm/llvm-project/pull/184400
