### PR TITLE
[triton_kernels] add FP4 matmul metadata

### DIFF
--- a/python/triton_kernels/tests/test_matmul_metadata.py
+++ b/python/triton_kernels/tests/test_matmul_metadata.py
@@ -29,7 +29,24 @@ def _old_flops_and_bytes(args, M, N, K, X, Y, W, slice_sizes, nbits, batch_size)
     return {f"flops{nbits}": flops.to(torch.float64), "bytes": n_x_bytes + n_y_bytes + n_w_bytes}
 
 
-def _metadata_args(*, ragged_dimension, M, N, K, X, Y, W, slice_sizes, batch_size=1, out_acc=None):
+def _metadata_args(
+    *,
+    ragged_dimension,
+    M,
+    N,
+    K,
+    X,
+    Y,
+    W,
+    slice_sizes,
+    batch_size=1,
+    out_acc=None,
+    mx_block_size=32,
+    x_mx_scale=None,
+    w_mx_scale=None,
+    x_tensor_scale=None,
+    w_tensor_scale=None,
+):
     return {
         "M": M,
         "N": N,
@@ -43,7 +60,162 @@ def _metadata_args(*, ragged_dimension, M, N, K, X, Y, W, slice_sizes, batch_siz
         "OutAcc": out_acc,
         "batch_size": batch_size,
         "EPILOGUE_SUBTILE": None,
+        "MX_BLOCK_SIZE": mx_block_size,
+        "XMxScale": x_mx_scale,
+        "WMxScale": w_mx_scale,
+        "XTensorScale": x_tensor_scale,
+        "WTensorScale": w_tensor_scale,
     }
+
+
+@pytest.mark.parametrize(
+    ("batch_size", "x_batched", "mx_block_size", "tensor_scale_dtype", "expected_bytes"),
+    [
+        (1, False, 32, None, 664),
+        (1, False, 16, None, 688),
+        (1, False, 16, torch.float32, 784),
+        (2, True, 16, torch.float32, 1568),
+        (2, False, 16, torch.float32, 1392),
+    ],
+)
+def test_matmul_launch_metadata_fp4_x_fp4_uses_flops4_and_logical_bytes(batch_size, x_batched, mx_block_size,
+                                                                        tensor_scale_dtype, expected_bytes):
+    M, N, K = 8, 16, 32
+    X = torch.empty((batch_size, M, K // 2) if x_batched else (M, K // 2), dtype=torch.uint8)
+    Y = torch.empty((batch_size, M, N) if batch_size > 1 else (M, N), dtype=torch.bfloat16)
+    W = torch.empty((batch_size, K // 2, N), dtype=torch.uint8)
+    x_tensor_scale = None if tensor_scale_dtype is None else torch.empty((), dtype=tensor_scale_dtype)
+    w_tensor_scale = None if tensor_scale_dtype is None else torch.empty((), dtype=tensor_scale_dtype)
+    args = _metadata_args(
+        ragged_dimension=None,
+        M=M,
+        N=N,
+        K=K,
+        X=X,
+        Y=Y,
+        W=W,
+        slice_sizes=None,
+        batch_size=batch_size,
+        mx_block_size=mx_block_size,
+        x_mx_scale=torch.empty((), dtype=torch.uint8),
+        w_mx_scale=torch.empty((), dtype=torch.uint8),
+        x_tensor_scale=x_tensor_scale,
+        w_tensor_scale=w_tensor_scale,
+    )
+
+    actual = matmul_launch_metadata(None, _Kernel(), args)
+
+    assert "flops8" not in actual
+    assert actual["flops4"] == 8192 * batch_size
+    assert actual["bytes"] == expected_bytes
+
+
+def test_matmul_launch_metadata_fp4_x_fp4_uses_logical_rows_for_swizzled_storage():
+    M, N, K = 1000, 16, 32
+    X = torch.empty((512, K), dtype=torch.uint8)
+    Y = torch.empty((M, N), dtype=torch.bfloat16)
+    W = torch.empty((K // 2, N), dtype=torch.uint8)
+    args = _metadata_args(
+        ragged_dimension=None,
+        M=M,
+        N=N,
+        K=K,
+        X=X,
+        Y=Y,
+        W=W,
+        slice_sizes=None,
+        mx_block_size=32,
+        x_mx_scale=torch.empty((), dtype=torch.uint8),
+        w_mx_scale=torch.empty((), dtype=torch.uint8),
+    )
+
+    actual = matmul_launch_metadata(None, _Kernel(), args)
+
+    bytes_per_k = 17
+    assert actual["bytes"] == M * bytes_per_k + N * bytes_per_k + Y.numel() * Y.element_size()
+
+
+def test_matmul_launch_metadata_fp4_x_fp4_handles_empty_k():
+    M, N, K = 8, 16, 0
+    X = torch.empty((M, K), dtype=torch.uint8)
+    Y = torch.empty((M, N), dtype=torch.bfloat16)
+    W = torch.empty((K, N), dtype=torch.uint8)
+    args = _metadata_args(
+        ragged_dimension=None,
+        M=M,
+        N=N,
+        K=K,
+        X=X,
+        Y=Y,
+        W=W,
+        slice_sizes=None,
+        mx_block_size=32,
+        x_mx_scale=torch.empty((), dtype=torch.uint8),
+        w_mx_scale=torch.empty((), dtype=torch.uint8),
+    )
+
+    actual = matmul_launch_metadata(None, _Kernel(), args)
+
+    assert actual["flops4"] == 0
+    assert actual["bytes"] == Y.numel() * Y.element_size()
+
+
+def test_matmul_launch_metadata_mixed_fp4_fp8_keeps_legacy_metrics():
+    M, N, K = 8, 16, 32
+    X = torch.empty((M, K), dtype=torch.float8_e4m3fn)
+    Y = torch.empty((M, N), dtype=torch.bfloat16)
+    W = torch.empty((K // 2, N), dtype=torch.uint8)
+    args = _metadata_args(
+        ragged_dimension=None,
+        M=M,
+        N=N,
+        K=K,
+        X=X,
+        Y=Y,
+        W=W,
+        slice_sizes=None,
+    )
+
+    actual = matmul_launch_metadata(None, _Kernel(), args)
+
+    assert actual["flops8"] == 8192
+    assert "flops4" not in actual
+    assert actual["bytes"] == X.numel() + Y.numel() * 2 + W.numel()
+
+
+def test_matmul_launch_metadata_fp4_x_fp4_ragged_m_counts_active_scale_bytes():
+    N, K = 16, 32
+    slice_sizes = torch.tensor([2, 0, 3], dtype=torch.int32)
+    n_tokens = int(slice_sizes.sum())
+    X = torch.empty((n_tokens, K // 2), dtype=torch.uint8)
+    Y = torch.empty((n_tokens, N), dtype=torch.bfloat16)
+    W = torch.empty((slice_sizes.numel(), K // 2, N), dtype=torch.uint8)
+    args = _metadata_args(
+        ragged_dimension="M",
+        M=None,
+        N=N,
+        K=K,
+        X=X,
+        Y=Y,
+        W=W,
+        slice_sizes=slice_sizes,
+        mx_block_size=16,
+        x_mx_scale=torch.empty((), dtype=torch.uint8),
+        w_mx_scale=torch.empty((), dtype=torch.uint8),
+        x_tensor_scale=torch.empty((), dtype=torch.float32),
+        w_tensor_scale=torch.empty((), dtype=torch.float32),
+    )
+
+    previous_allow_sync = launch_metadata_allow_sync()
+    try:
+        set_launch_metadata_allow_sync(True)
+        actual = matmul_launch_metadata(None, _Kernel(), args)
+    finally:
+        set_launch_metadata_allow_sync(previous_allow_sync)
+
+    assert "flops8" not in actual
+    assert actual["flops4"] == 5120
+    assert actual["bytes"] == 974
 
 
 @pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA is required")

--- a/python/triton_kernels/triton_kernels/matmul_details/_common.py
+++ b/python/triton_kernels/triton_kernels/matmul_details/_common.py
@@ -301,6 +301,10 @@ def _matmul_flops_and_bytes_from_slices(
     slice_sizes,
     nbits,
     batch_size,
+    *,
+    flop_metric_name=None,
+    x_bytes_per_token=None,
+    w_bytes_per_active_slice=None,
 ):
     import torch
 
@@ -319,19 +323,22 @@ def _matmul_flops_and_bytes_from_slices(
         static_flops = 2.0 * M * N * K * z
 
     static_bytes = 0
-    x_bytes_per_token = 0
     y_bytes_per_token = 0
     w_bytes_per_token = 0
-    w_bytes_per_active_slice = 0
     if ragged_k:
-        x_bytes_per_token = X.shape[-2] * X.element_size()
+        if x_bytes_per_token is None:
+            x_bytes_per_token = X.shape[-2] * X.element_size()
+        if w_bytes_per_active_slice is None:
+            w_bytes_per_active_slice = 0
         # Here, we're computing dW = X.T@dY, so "W" is actually dY and "Y" is actually dW.
         static_bytes = Y.numel() * Y.element_size() * (2 if args["OutAcc"] is not None else 1)
         w_bytes_per_token = W.shape[-1] * W.element_size()
     else:
-        x_bytes_per_token = X.shape[-1] * X.element_size()
+        if x_bytes_per_token is None:
+            x_bytes_per_token = X.shape[-1] * X.element_size()
         y_bytes_per_token = Y.shape[-1] * Y.element_size()
-        w_bytes_per_active_slice = W.numel() * W.element_size() // slice_sizes.numel()
+        if w_bytes_per_active_slice is None:
+            w_bytes_per_active_slice = W.numel() * W.element_size() // slice_sizes.numel()
 
     flops = torch.empty((), dtype=torch.float64, device=slice_sizes.device)
     total_bytes = torch.empty((), dtype=torch.int64, device=slice_sizes.device)
@@ -350,10 +357,14 @@ def _matmul_flops_and_bytes_from_slices(
         W_BYTES_PER_ACTIVE_SLICE=w_bytes_per_active_slice,
         STATIC_BYTES=static_bytes,
     )
-    return {f"flops{nbits}": flops, "bytes": total_bytes}
+    if flop_metric_name is None:
+        flop_metric_name = f"flops{nbits}"
+    return {flop_metric_name: flops, "bytes": total_bytes}
 
 
 def matmul_launch_metadata(grid, kernel, args):
+    import torch
+
     from ..proton_opts import launch_metadata_allow_sync
 
     ret = dict()
@@ -381,6 +392,23 @@ def matmul_launch_metadata(grid, kernel, args):
 
     repr = lambda s, x: f"{s} = {x}" if x is not None else f"E_{len(slice_sizes)}({s}) = {n_rows}"
     nbits = X.dtype.itemsize * 8
+    flop_metric_name = f"flops{nbits}"
+    x_bytes_per_token = None
+    w_bytes_per_active_slice = None
+    # Ragged-K is the inner-expert dW path; its active-K bytes need a separate model.
+    fp4_x_fp4 = (args["RAGGED_DIMENSION"] != "K" and X.dtype == torch.uint8 and W.dtype == torch.uint8)
+    if fp4_x_fp4:
+        x_bytes_per_token = triton.cdiv(K, 2)
+        w_bytes_per_active_slice = N * triton.cdiv(K, 2)
+        if args["XMxScale"] is not None:
+            x_bytes_per_token += triton.cdiv(K, args["MX_BLOCK_SIZE"])
+        if args["WMxScale"] is not None:
+            w_bytes_per_active_slice += N * triton.cdiv(K, args["MX_BLOCK_SIZE"])
+        if args["XTensorScale"] is not None:
+            x_bytes_per_token += args["XTensorScale"].element_size()
+        if args["WTensorScale"] is not None:
+            w_bytes_per_active_slice += N * args["WTensorScale"].element_size()
+        flop_metric_name = "flops4"
     batch_repr = ""
     if batch_size > 1:
         batch_repr = repr("B", args["batch_size"]) + ", "
@@ -391,18 +419,22 @@ def matmul_launch_metadata(grid, kernel, args):
         ret["name"] += f" ep/{ep_subtile}"
 
     if slice_sizes is not None and not allow_sync:
-        ret.update(_matmul_flops_and_bytes_from_slices(
-            args,
-            M,
-            N,
-            K,
-            X,
-            Y,
-            W,
-            slice_sizes,
-            nbits,
-            batch_size,
-        ))
+        ret.update(
+            _matmul_flops_and_bytes_from_slices(
+                args,
+                M,
+                N,
+                K,
+                X,
+                Y,
+                W,
+                slice_sizes,
+                nbits,
+                batch_size,
+                flop_metric_name=flop_metric_name,
+                x_bytes_per_token=x_bytes_per_token,
+                w_bytes_per_active_slice=w_bytes_per_active_slice,
+            ))
         return ret
 
     if slice_sizes is not None and n_tokens is None:
@@ -410,12 +442,19 @@ def matmul_launch_metadata(grid, kernel, args):
 
     fM = M if M is not None else n_tokens
     Z = 1 if args["RAGGED_DIMENSION"] == "K" else batch_size
-    ret[f"flops{nbits}"] = 2.0 * fM * N * K * Z
+    flops = 2.0 * fM * N * K * Z
+    ret[flop_metric_name] = flops
 
     # sindx = args.get("WriteBackIndx", None)
     n_x_bytes = X.numel() * X.element_size()
     n_y_bytes = Y.numel() * Y.element_size()
     n_w_bytes = W.numel() * W.element_size()
+    if x_bytes_per_token is not None and M is not None:
+        # A 2-D X can be shared across batched W.
+        input_batch_size = batch_size if X.ndim == 3 else 1
+        n_x_bytes = M * input_batch_size * x_bytes_per_token
+    if w_bytes_per_active_slice is not None:
+        n_w_bytes = batch_size * w_bytes_per_active_slice
     if slice_sizes is not None:
         n_read_rows = n_tokens
 
@@ -425,9 +464,11 @@ def matmul_launch_metadata(grid, kernel, args):
             n_y_bytes = Y.numel() * Y.element_size() * (2 if args["OutAcc"] is not None else 1)
             n_w_bytes = n_read_rows * W.shape[-1] * W.element_size()
         else:
-            n_x_bytes = n_read_rows * X.shape[-1] * X.element_size()
+            n_x_bytes = n_read_rows * (x_bytes_per_token if x_bytes_per_token is not None else X.shape[-1] *
+                                       X.element_size())
             n_y_bytes = n_tokens * Y.shape[-1] * Y.element_size()
-            n_w_bytes = (W.numel() * W.element_size() // slice_sizes.numel()) * (slice_sizes > 0).sum()
+            n_w_bytes = (slice_sizes > 0).sum() * (w_bytes_per_active_slice if w_bytes_per_active_slice is not None else
+                                                   W.numel() * W.element_size() // slice_sizes.numel())
 
     ret["bytes"] = n_x_bytes + n_y_bytes + n_w_bytes
     return ret


### PR DESCRIPTION
## Summary

- report packed FP4-by-FP4 matmuls as generic `flops4` from the existing `matmul_launch_metadata()` callback
- derive physical FP4 bytes from packed values, `MX_BLOCK_SIZE`, and actual tensor/fiber scales for dense and ragged-M metadata
- use logical activation rows rather than transformed Blackwell storage rows, while preserving shared 2-D activation accounting with batched weights
- keep mixed FP4-weight-by-FP8-activation matmuls on the existing `flops8` and legacy bytes path
- leave ragged-K on the legacy path because active-K physical bytes need a separate model

## Test plan

- `SKIP=expand-yaml-anchors pre-commit run --files python/triton_kernels/triton_kernels/matmul_details/_common.py python/triton_kernels/tests/test_matmul_metadata.py` (passed; the skipped hook only applies to workflow YAML)
- `python -m pytest python/triton_kernels/tests/test_matmul_metadata.py -q` (`9 passed, 4 skipped`)