### PR TITLE
Fix register allocation for padded warp groups

### DIFF
--- a/lib/Conversion/TritonGPUToLLVM/AllocateWarpGroups.cpp
+++ b/lib/Conversion/TritonGPUToLLVM/AllocateWarpGroups.cpp
@@ -12,6 +12,7 @@ using namespace mlir;
 using namespace mlir::triton;
 using namespace mlir::triton::gpu;
 
+constexpr int32_t kMinRegisters = 24;
 constexpr int32_t kMinRegistersForAssertOrPrint = 32;
 
 static bool regionUsesAssertOrPrint(Region &region) {
@@ -182,8 +183,8 @@ struct AllocateWarpGroups
       SmallVector<WarpGroupPartition> orderedPartitions;
       for (auto [startId, partition, estRegs, numWarps] :
            llvm::zip(startIds, op.getPartitionRegions(), *regsAttr, arr)) {
-        int minRegs =
-            minRegistersForRegion(*partition, laterInstrumentation, estRegs);
+        int minRegs = minRegistersForRegion(*partition, laterInstrumentation,
+                                            std::max(estRegs, kMinRegisters));
         orderedPartitions.push_back({startId, partition, minRegs, numWarps});
       }
       llvm::sort(orderedPartitions,
@@ -220,8 +221,7 @@ struct AllocateWarpGroups
       // Round down to the nearest multiple of 8.
       leftover = leftover / 8 * 8;
       if (leftover < minRegistersForRegion(op.getDefaultRegion(),
-                                           laterInstrumentation,
-                                           /*minRegisters=*/24))
+                                           laterInstrumentation, kMinRegisters))
         return; // too few registers
 
       // Generate setmaxnreg in each partition according to its warp group.

--- a/test/Conversion/allocate_warp_groups_then_lower.mlir
+++ b/test/Conversion/allocate_warp_groups_then_lower.mlir
@@ -1,0 +1,46 @@
+// RUN: triton-opt %s --tritongpu-allocate-warp-groups | FileCheck %s --check-prefix=ALLOC
+// RUN: triton-opt %s --tritongpu-allocate-warp-groups --convert-warp-specialize-to-llvm | FileCheck %s --check-prefix=LOWER
+
+module attributes {
+  ttg.maxnreg = 80 : i32,
+  "ttg.num-warps" = 4 : i32,
+  ttg.target = "cuda:100"
+} {
+  llvm.mlir.global external @global_smem()
+      {addr_space = 3 : i32, alignment = 16 : i64} : !llvm.array<0 x i8>
+
+  // ALLOC-LABEL: llvm.func @padding_uses_legal_register_minimum
+  // LOWER-LABEL: llvm.func @padding_uses_legal_register_minimum
+  llvm.func @padding_uses_legal_register_minimum()
+      attributes {allocation.offset = 0 : i32} {
+    // ALLOC: actualRegisters = array<i32: 80, 80>
+    ttg.warp_specialize() attributes {
+      allocation.offset = 0 : i32,
+      requestedRegisters = array<i32: 80>
+    }
+    default {
+      ttg.warp_yield
+    }
+    partition0() num_warps(8) {
+      ttg.warp_return
+    } : () -> ()
+
+    // ALLOC: actualRegisters = array<i32: 136, 80, 24>
+    // ALLOC-SAME: requestedRegisters = array<i32: 80, 16>
+    ttg.warp_specialize() attributes {
+      allocation.offset = 0 : i32,
+      requestedRegisters = array<i32: 80>
+    }
+    default {
+      ttg.warp_yield
+    }
+    partition0() num_warps(4) {
+      ttg.warp_return
+    } : () -> ()
+
+    // LOWER-NOT: nvvm.setmaxregister {{.*}} 16
+    // LOWER: nvvm.setmaxregister increase 24
+    // LOWER: llvm.return
+    llvm.return
+  }
+}


### PR DESCRIPTION
## Summary

- Clamp per-partition register allocations to NVVM's minimum of 24 registers.
- Reuse the same minimum for the default warp group.
- Add an end-to-end regression test from warp-group allocation through NVIDIA lowering.

## Problem

`AllocateWarpGroups::padToMaxWarpGroups` pads smaller `ttg.warp_specialize` operations to the largest worker footprint in the module. Those synthetic no-op partitions request 16 registers. The allocator could copy that value into `actualRegisters`, so `ConvertWarpSpecializeToLLVM` generated `nvvm.setmaxregister ... 16`. NVVM only accepts register targets from 24 through 256.

A valid source-level kernel with sequential handoffs using different worker-warp counts can therefore fail during compilation.

## Fix

Clamp each partition estimate to 24 before computing warp-group budgets. This both keeps the lowered `nvvm.setmaxregister` legal and accounts for the padding warp group's real register consumption when distributing the remaining budget to the default warp group.

## Validation

- New allocation-only regression check.
- New allocation-to-NVVM lowering regression check.
- Existing `allocate_warp_groups.mlir` checks in normal and instrumented modes.
- Existing NVIDIA `warp_specialize_to_llvm.mlir` checks.
- Source-level Gluon reproducer compiled to PTX and cubin and launched on B200.
- `pre-commit run --from-ref origin/main --to-ref HEAD`.

## New contributor declaration

- [x] I am not making a trivial change, such as fixing a typo in a comment.
- [x] I have written a PR description following these [rules](https://cbea.ms/git-commit/#why-not-how).
- [x] I have run `pre-commit run --from-ref origin/main --to-ref HEAD`.
- [x] I have added tests.
  - `/test` for `lit` tests
- [x] The `lit` tests I have added follow these [best practices](https://mlir.llvm.org/getting_started/TestingGuide/#filecheck-best-practices), including the "tests should be minimal" section.