### PR TITLE
[BACKEND] Fix use-after-free in RewriteStore/ScatterPattern

### DIFF
--- a/lib/Dialect/Triton/Transforms/RewriteTensorDescriptorToPointer.cpp
+++ b/lib/Dialect/Triton/Transforms/RewriteTensorDescriptorToPointer.cpp
@@ -364,11 +364,15 @@ struct RewriteStorePattern : OpConversionPattern<triton::DescriptorStoreOp> {
     auto desc = unpackDescriptor(descTy, adaptor.getDesc());
     auto offsets = castToI64(rewriter, op.getIndices());
 
+    // Save attrs before replaceOpWithNewOp, which may erase op immediately
+    // when allowPatternRollback is false.
+    auto attrs = filterSegmentSizes(op->getAttrs());
+
     auto newStore = rewriter.replaceOpWithNewOp<triton::StoreOp>(
         op, generatePtr(rewriter, loc, blockShape, desc, offsets), op.getSrc(),
         generateMask(rewriter, loc, blockShape, desc, offsets),
         triton::CacheModifier::NONE, triton::EvictionPolicy::NORMAL);
-    newStore->setAttrs(filterSegmentSizes(op->getAttrs()));
+    newStore->setAttrs(attrs);
 
     return llvm::success();
   }
@@ -440,10 +444,15 @@ struct RewriteScatterPattern
     auto desc = unpackDescriptor(descTy, adaptor.getDesc());
     auto [ptr, mask] = generateGatherScatterPtrMask(
         rewriter, loc, blockShape, desc, op.getXOffsets(), op.getYOffset());
+
+    // Save attrs before replaceOpWithNewOp, which may erase op immediately
+    // when allowPatternRollback is false.
+    auto attrs = filterSegmentSizes(op->getAttrs());
+
     auto newStore = rewriter.replaceOpWithNewOp<triton::StoreOp>(
         op, ptr, op.getSrc(), mask, triton::CacheModifier::NONE,
         triton::EvictionPolicy::NORMAL);
-    newStore->setAttrs(filterSegmentSizes(op->getAttrs()));
+    newStore->setAttrs(attrs);
 
     return llvm::success();
   }

--- a/test/Triton/rewrite-tensor-descriptor-to-pointer.mlir
+++ b/test/Triton/rewrite-tensor-descriptor-to-pointer.mlir
@@ -109,6 +109,58 @@ module {
 
 // -----
 
+module {
+  tt.func public @scatter(%arg0: !tt.ptr<bf16> {tt.divisibility = 16 : i32}, %arg1: i32, %arg2: i32, %arg3: tensor<32xi32>, %arg4: tensor<32x128xbf16>) {
+    %c1_i64 = arith.constant 1 : i64
+    %c256_i64 = arith.constant 256 : i64
+    %c256_i32 = arith.constant 256 : i32
+    %c128_i32 = arith.constant 128 : i32
+    %c8_i32 = arith.constant 8 : i32
+    %0 = tt.make_tensor_descriptor %arg0, [%c256_i32, %c128_i32], [%c256_i64, %c1_i64] {order = array<i32: 0>} : <bf16>, <1x128xbf16>
+    tt.descriptor_scatter %0[%arg3, %c8_i32], %arg4 : !tt.tensordesc<1x128xbf16>, tensor<32xi32>, i32, tensor<32x128xbf16>
+    tt.return
+  }
+}
+
+// CHECK-LABEL: @scatter
+// CHECK-SAME: %[[ARG0:[^:]*]]
+// CHECK-SAME: %[[ARG1:[^:]*]]
+// CHECK-SAME: %[[ARG2:[^:]*]]
+// CHECK-SAME: %[[ARG3:[^:]*]]
+// CHECK-SAME: %[[ARG4:[^:]*]]
+// CHECK-DAG: %[[CST:.*]] = arith.constant dense<128> : tensor<1x128xi64>
+// CHECK-DAG: %[[CST0:.*]] = arith.constant dense<0> : tensor<1x128xi64>
+// CHECK-DAG: %[[CST1:.*]] = arith.constant dense<0> : tensor<32x1xi64>
+// CHECK-DAG: %[[CST2:.*]] = arith.constant dense<256> : tensor<32x1xi64>
+// CHECK-DAG: %[[CST3:.*]] = arith.constant dense<8> : tensor<128xi64>
+
+// CHECK-DAG: %[[VAL0:.*]] = tt.reshape %[[ARG3]] : tensor<32xi32> -> tensor<32x1xi32>
+// CHECK-DAG: %[[VAL1:.*]] = arith.extsi %[[VAL0]] : tensor<32x1xi32> to tensor<32x1xi64>
+// CHECK-DAG: %[[VAL2:.*]] = tt.make_range {end = 128 : i32, start = 0 : i32}
+// CHECK-DAG: %[[VAL3:.*]] = arith.extsi %[[VAL2]] :
+// CHECK-DAG: %[[VAL4:.*]] = arith.addi %[[VAL3]], %[[CST3]] : tensor<128xi64>
+// CHECK-DAG: %[[VAL5:.*]] = tt.reshape %[[VAL4]] : tensor<128xi64> -> tensor<1x128xi64>
+// CHECK-DAG: %[[VAL6:.*]] = tt.splat %[[ARG0]] :
+// CHECK-DAG: %[[VAL7:.*]] = arith.muli %[[VAL1]], %[[CST2]] : tensor<32x1xi64>
+// CHECK-DAG: %[[VAL8:.*]] = tt.broadcast %[[VAL7]] : tensor<32x1xi64> -> tensor<32x128xi64>
+// CHECK-DAG: %[[VAL9:.*]] = tt.addptr %[[VAL6]], %[[VAL8]] :
+// CHECK-DAG: %[[VAL10:.*]] = tt.broadcast %[[VAL5]] : tensor<1x128xi64> -> tensor<32x128xi64>
+// CHECK-DAG: %[[VAL11:.*]] = tt.addptr %[[VAL9]], %[[VAL10]] :
+
+// CHECK-DAG: %[[VAL12:.*]] = arith.cmpi sge, %[[VAL1]], %[[CST1]]
+// CHECK-DAG: %[[VAL13:.*]] = arith.cmpi slt, %[[VAL1]], %[[CST2]]
+// CHECK-DAG: %[[VAL14:.*]] = arith.andi %[[VAL12]], %[[VAL13]]
+// CHECK-DAG: %[[VAL15:.*]] = tt.broadcast %[[VAL14]] : tensor<32x1xi1> -> tensor<32x128xi1>
+// CHECK-DAG: %[[VAL16:.*]] = arith.cmpi sge, %[[VAL5]], %[[CST0]]
+// CHECK-DAG: %[[VAL17:.*]] = arith.cmpi slt, %[[VAL5]], %[[CST]]
+// CHECK-DAG: %[[VAL18:.*]] = arith.andi %[[VAL16]], %[[VAL17]]
+// CHECK-DAG: %[[VAL19:.*]] = tt.broadcast %[[VAL18]] : tensor<1x128xi1> -> tensor<32x128xi1>
+// CHECK-DAG: %[[VAL20:.*]] = arith.andi %[[VAL15]], %[[VAL19]]
+
+// CHECK: tt.store %[[VAL11]], %[[ARG4]], %[[VAL20]]
+
+// -----
+
 #loc2 = loc("rewrite-tensor-descriptor-to-pointer.mlir":147:28)
 module {
   tt.func public @callee(%tensordesc: !tt.tensordesc<128x128xf32> loc("tensordesc"(#loc2))) -> !tt.tensordesc<128x128xf32> {


### PR DESCRIPTION
### Problem

`RewriteStorePattern` and `RewriteScatterPattern` in the `--triton-rewrite-tensor-descriptor-to-pointer` pass access `op->getAttrs()` after calling `rewriter.replaceOpWithNewOp(op, ...)`. Because this pass sets `config.allowPatternRollback = false`, `replaceOpWithNewOp` immediately erases and frees the original op's memory. Any subsequent access to `op` is a use-after-free — undefined behavior per the C++ standard.

### Why this wasn't caught before

- On Linux (glibc malloc), freed memory typically remains in a free list with stale data intact, so the read "happens to work" and tests pass silently.
- On macOS (libmalloc), the allocator reclaims or poisons freed pages more aggressively, causing a stable segfault when running `triton-opt` on the existing `@store` test case.

### Behavior after this fix

`op->getAttrs()` is captured into a local variable **before** `replaceOpWithNewOp` is called, ensuring no access to freed memory. The fix is applied to both `RewriteStorePattern` and `RewriteScatterPattern` since they share the identical problematic pattern.

### Testing

- The existing `@store` lit test now passes on macOS without segfault.
- A new `@scatter` lit test is added to provide coverage for `RewriteScatterPattern`, which previously had no test in `rewrite-tensor-descriptor-to-pointer.mlir`.

<!---
The core Triton is a small number of people, and we receive many PRs (thank
you!).  To help us review your code more quickly, **if you are a new
contributor (less than 3 PRs merged) we ask that you complete the following
tasks and include the filled-out checklist in your PR description.**

Complete the following tasks before sending your PR, and replace `[ ]` with
`[x]` to indicate you have done them.
-->

# New contributor declaration
- [x] I am not making a trivial change, such as fixing a typo in a comment.

- [x] I have written a PR description following these
  [rules](https://cbea.ms/git-commit/#why-not-how).

- [x] I have run `pre-commit run --from-ref origin/main --to-ref HEAD`.

- Select one of the following.
  - [x ] I have added tests.
    - `/test` for `lit` tests
    - `/unittest` for C++ tests
    - `/python/test` for end-to-end tests
  - [ ] This PR does not need a test because `FILL THIS IN`.

- Select one of the following.
  - [ ] I have not added any `lit` tests.
  - [x] The `lit` tests I have added follow these [best practices](https://mlir.llvm.org/getting_started/TestingGuide/#filecheck-best-practices),
    including the "tests should be minimal" section. (Usually running Python code
    and using the instructions it generates is not minimal.)
