### PR TITLE
[AMD] Fix address space of barriers that carry atomic memory ordering

### DIFF
--- a/include/triton/Conversion/TritonGPUToLLVM/Utility.h
+++ b/include/triton/Conversion/TritonGPUToLLVM/Utility.h
@@ -740,6 +740,16 @@ emitPredicated(RewriterBase &rewriter, Location loc, Value pred,
                ValueRange falseValues,
                llvm::function_ref<SmallVector<Value>()> bodyBuilder);
 
+/// Address spaces a CTA barrier must order to stand in for `memOrdering`.
+/// Only a subset of the threads runs the atomic, so the barrier has to carry
+/// its cache maintenance for the rest; a local-only annotation drops that.
+triton::gpu::AddrSpace atomicOrderingBarrierAddrSpace(MemSemantic memOrdering);
+
+/// Same, for the result-broadcast barrier. It sits after the atomic, so it
+/// only stands in for the acquire side; release-only stays local.
+triton::gpu::AddrSpace
+atomicResultBroadcastBarrierAddrSpace(MemSemantic memOrdering);
+
 /// Insert CTA or cluster barriers around an atomic operation according to its
 /// acquire/release semantics. `emitBarrierAfter` may be false when result
 /// staging already emits the required barrier after the atomic instruction.

--- a/lib/Conversion/TritonGPUToLLVM/MemoryOpToLLVM.cpp
+++ b/lib/Conversion/TritonGPUToLLVM/MemoryOpToLLVM.cpp
@@ -399,9 +399,12 @@ struct AtomicPollOpConversion
       results.push_back(emitPoll(op, ptr, value, start, adaptor.getTimeout(),
                                  threadPred, rewriter));
 
+    // Only the polling threads run the acquire fence in emitPoll; the
+    // rendezvous carries that ordering for the rest of the CTA.
     auto rendezvous = [&] {
       if (numCTAs == 1)
-        targetInfo.barrier(loc, rewriter, AddrSpace::Local);
+        targetInfo.barrier(loc, rewriter,
+                           atomicOrderingBarrierAddrSpace(op.getSem()));
       else
         targetInfo.clusterBarrier(loc, rewriter, op);
     };

--- a/lib/Conversion/TritonGPUToLLVM/Utility.cpp
+++ b/lib/Conversion/TritonGPUToLLVM/Utility.cpp
@@ -1229,12 +1229,28 @@ emitPredicated(RewriterBase &rewriter, Location loc, Value pred,
   return results;
 }
 
+triton::gpu::AddrSpace atomicOrderingBarrierAddrSpace(MemSemantic memOrdering) {
+  if (memOrdering == MemSemantic::RELAXED)
+    return triton::gpu::AddrSpace::Local;
+  return triton::gpu::AddrSpace::Local | triton::gpu::AddrSpace::GlobalRead |
+         triton::gpu::AddrSpace::GlobalWrite;
+}
+
+triton::gpu::AddrSpace
+atomicResultBroadcastBarrierAddrSpace(MemSemantic memOrdering) {
+  bool acquires = memOrdering == MemSemantic::ACQUIRE ||
+                  memOrdering == MemSemantic::ACQUIRE_RELEASE;
+  return atomicOrderingBarrierAddrSpace(acquires ? MemSemantic::ACQUIRE
+                                                 : MemSemantic::RELAXED);
+}
+
 void insertAtomicOrderingBarriers(Operation *op, MemSemantic memOrdering,
                                   bool emitBarrierAfter, RewriterBase &rewriter,
                                   const TargetInfoBase &targetInfo) {
+  auto addrSpace = atomicOrderingBarrierAddrSpace(memOrdering);
   auto emitBarrier = [&] {
     if (triton::gpu::lookupNumCTAs(op) == 1)
-      targetInfo.barrier(op->getLoc(), rewriter, triton::gpu::AddrSpace::Local);
+      targetInfo.barrier(op->getLoc(), rewriter, addrSpace);
     else
       targetInfo.clusterBarrier(op->getLoc(), rewriter, op);
   };
@@ -1272,7 +1288,11 @@ Value broadcastScalarAtomicResult(Operation *op, Type valueElemTy,
   Value smemBase = LLVM::getSharedMemoryBase(loc, rewriter, targetInfo, op);
   targetInfo.storeShared(rewriter, loc, smemBase, resultVal, threadPred);
   if (triton::gpu::lookupNumCTAs(op) == 1) {
-    targetInfo.barrier(loc, rewriter, triton::gpu::AddrSpace::Local);
+    auto atomic = dyn_cast<AtomicOpInterface>(op);
+    // Unknown ordering: assume it acquires rather than under-synchronize.
+    auto sem = atomic ? atomic.getMemSemantic() : MemSemantic::ACQUIRE_RELEASE;
+    targetInfo.barrier(loc, rewriter,
+                       atomicResultBroadcastBarrierAddrSpace(sem));
     return targetInfo.loadShared(rewriter, loc, smemBase, valueElemTy,
                                  b.true_val());
   }

--- a/test/Conversion/amd/barrier_op_to_llvm.mlir
+++ b/test/Conversion/amd/barrier_op_to_llvm.mlir
@@ -1,30 +1,29 @@
-// RUN: triton-opt %s --allocate-shared-memory --convert-triton-amdgpu-to-llvm=gfx-arch=gfx942 --convert-builtin-func-to-llvm | FileCheck %s --check-prefix=TAGGED
-// RUN: triton-opt %s --allocate-shared-memory --convert-triton-amdgpu-to-llvm=gfx-arch=gfx950 --convert-builtin-func-to-llvm | FileCheck %s --check-prefix=TAGGED
-// RUN: triton-opt %s --allocate-shared-memory --convert-triton-amdgpu-to-llvm=gfx-arch=gfx1100 --convert-builtin-func-to-llvm | FileCheck %s --check-prefix=GENERIC
-// RUN: triton-opt %s --allocate-shared-memory --convert-triton-amdgpu-to-llvm=gfx-arch=gfx1200 --convert-builtin-func-to-llvm | FileCheck %s --check-prefix=RDNA4
-// RUN: triton-opt %s --allocate-shared-memory --convert-triton-amdgpu-to-llvm=gfx-arch=gfx1250 --convert-builtin-func-to-llvm | FileCheck %s --check-prefix=TAGGED
+// RUN: triton-opt %s --allocate-shared-memory --convert-triton-amdgpu-to-llvm=gfx-arch=gfx906 --convert-builtin-func-to-llvm | FileCheck %s --check-prefixes=TAGGED,GENERIC
+// RUN: triton-opt %s --allocate-shared-memory --convert-triton-amdgpu-to-llvm=gfx-arch=gfx942 --convert-builtin-func-to-llvm | FileCheck %s --check-prefixes=TAGGED,GENERIC
+// RUN: triton-opt %s --allocate-shared-memory --convert-triton-amdgpu-to-llvm=gfx-arch=gfx950 --convert-builtin-func-to-llvm | FileCheck %s --check-prefixes=TAGGED,GENERIC
+// RUN: triton-opt %s --allocate-shared-memory --convert-triton-amdgpu-to-llvm=gfx-arch=gfx1100 --convert-builtin-func-to-llvm | FileCheck %s --check-prefixes=TAGGED,GENERIC
+// RUN: triton-opt %s --allocate-shared-memory --convert-triton-amdgpu-to-llvm=gfx-arch=gfx1200 --convert-builtin-func-to-llvm | FileCheck %s --check-prefixes=TAGGED,GENERIC
+// RUN: triton-opt %s --allocate-shared-memory --convert-triton-amdgpu-to-llvm=gfx-arch=gfx1250 --convert-builtin-func-to-llvm | FileCheck %s --check-prefixes=TAGGED,GENERIC
 
-// RDNA targets fall back to the generic barrier lowering without MMRA tags.
 // TAGGED-DAG: [[$LOCAL_MMRA_TAG:#[A-Za-z0-9_]+]] = #llvm.mmra_tag<"amdgpu-synchronize-as":"local">
 
 module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32} {
   // TAGGED-LABEL: llvm.func @lower_barrier
-  // GENERIC-LABEL: llvm.func @lower_barrier
-  // RDNA4-LABEL: llvm.func @lower_barrier
   tt.func @lower_barrier() {
     // TAGGED: llvm.fence syncscope("workgroup") release {llvm.mmra = [[$LOCAL_MMRA_TAG]]}
     // TAGGED-NEXT: rocdl.s.barrier
     // TAGGED-NEXT: llvm.fence syncscope("workgroup") acquire {llvm.mmra = [[$LOCAL_MMRA_TAG]]}
+    ttg.barrier local
+    tt.return
+  }
 
+  // Global ordering keeps the fence untagged so LLVM emits wait + invalidate.
+  // GENERIC-LABEL: llvm.func @lower_barrier_local_and_global
+  tt.func @lower_barrier_local_and_global() {
     // GENERIC: llvm.fence syncscope("workgroup") release{{$}}
     // GENERIC-NEXT: rocdl.s.barrier
     // GENERIC-NEXT: llvm.fence syncscope("workgroup") acquire{{$}}
-
-    // RDNA4: llvm.fence syncscope("workgroup") release{{$}}
-    // RDNA4-NEXT: rocdl.s.barrier.signal id = -1
-    // RDNA4-NEXT: rocdl.s.barrier.wait id = -1
-    // RDNA4-NEXT: llvm.fence syncscope("workgroup") acquire{{$}}
-    ttg.barrier local
+    ttg.barrier local|global_read
     tt.return
   }
 }

--- a/test/Conversion/amd/scalar_atomic_ordering_barrier.mlir
+++ b/test/Conversion/amd/scalar_atomic_ordering_barrier.mlir
@@ -1,0 +1,56 @@
+// RUN: triton-opt %s --allocate-shared-memory --convert-triton-amdgpu-to-llvm=gfx-arch=gfx1100 --convert-builtin-func-to-llvm | FileCheck %s
+// RUN: triton-opt %s --allocate-shared-memory --convert-triton-amdgpu-to-llvm=gfx-arch=gfx942 --convert-builtin-func-to-llvm | FileCheck %s
+// RUN: triton-opt %s --allocate-shared-memory --convert-triton-amdgpu-to-llvm=gfx-arch=gfx906 --convert-builtin-func-to-llvm | FileCheck %s
+
+// One elected thread runs the atomic, so the barrier broadcasting its result
+// must carry the acquire for the rest of the CTA. A "local" annotation drops
+// buffer_gl0_inv, and on RDNA the other CU's L0 then serves stale data.
+
+// CHECK-DAG: [[$LOCAL_MMRA_TAG:#[A-Za-z0-9_]+]] = #llvm.mmra_tag<"amdgpu-synchronize-as":"local">
+
+module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.target = "hip:gfx1100", "ttg.threads-per-warp" = 32 : i32} {
+  // CHECK-LABEL: llvm.func @scalar_atomic_acquire
+  tt.func public @scalar_atomic_acquire(%arg0: !tt.ptr<i32>, %arg1: !tt.ptr<i32>) {
+    %true = arith.constant true
+    %c0 = arith.constant 0 : i32
+    // CHECK: llvm.atomicrmw add {{.*}} acquire
+    // CHECK: llvm.fence syncscope("workgroup") release{{$}}
+    // CHECK-NEXT: rocdl.s.barrier
+    // CHECK-NEXT: llvm.fence syncscope("workgroup") acquire{{$}}
+    %0 = tt.atomic_rmw add, acquire, gpu, %arg0, %c0, %true : (!tt.ptr<i32>, i32, i1) -> i32
+    tt.store %arg1, %0 : !tt.ptr<i32>
+    tt.return
+  }
+
+  // Relaxed orders nothing, so the broadcast barrier is LDS staging only.
+  // CHECK-LABEL: llvm.func @scalar_atomic_relaxed
+  tt.func public @scalar_atomic_relaxed(%arg0: !tt.ptr<i32>, %arg1: !tt.ptr<i32>) {
+    %true = arith.constant true
+    %c0 = arith.constant 0 : i32
+    // CHECK: llvm.atomicrmw add {{.*}} monotonic
+    // CHECK: llvm.fence syncscope("workgroup") release {llvm.mmra = [[$LOCAL_MMRA_TAG]]}
+    // CHECK-NEXT: rocdl.s.barrier
+    // CHECK-NEXT: llvm.fence syncscope("workgroup") acquire {llvm.mmra = [[$LOCAL_MMRA_TAG]]}
+    %0 = tt.atomic_rmw add, relaxed, gpu, %arg0, %c0, %true : (!tt.ptr<i32>, i32, i1) -> i32
+    tt.store %arg1, %0 : !tt.ptr<i32>
+    tt.return
+  }
+
+  // Release-only is ordered by the barrier *before* the atomic, so the
+  // broadcast barrier after it stays LDS-only.
+  // CHECK-LABEL: llvm.func @scalar_atomic_release
+  tt.func public @scalar_atomic_release(%arg0: !tt.ptr<i32>, %arg1: !tt.ptr<i32>) {
+    %true = arith.constant true
+    %c1 = arith.constant 1 : i32
+    // CHECK: llvm.fence syncscope("workgroup") release{{$}}
+    // CHECK-NEXT: rocdl.s.barrier
+    // CHECK-NEXT: llvm.fence syncscope("workgroup") acquire{{$}}
+    // CHECK: llvm.atomicrmw xchg {{.*}} release
+    // CHECK: llvm.fence syncscope("workgroup") release {llvm.mmra = [[$LOCAL_MMRA_TAG]]}
+    // CHECK-NEXT: rocdl.s.barrier
+    // CHECK-NEXT: llvm.fence syncscope("workgroup") acquire {llvm.mmra = [[$LOCAL_MMRA_TAG]]}
+    %0 = tt.atomic_rmw exch, release, gpu, %arg0, %c1, %true : (!tt.ptr<i32>, i32, i1) -> i32
+    tt.store %arg1, %0 : !tt.ptr<i32>
+    tt.return
+  }
+}

--- a/third_party/amd/lib/TritonAMDGPUToLLVM/LoadStoreOpToLLVM.cpp
+++ b/third_party/amd/lib/TritonAMDGPUToLLVM/LoadStoreOpToLLVM.cpp
@@ -2259,7 +2259,7 @@ struct AtomicCASOpConversion
           return success();
         }
 
-        b.barrier(triton::gpu::AddrSpace::Local);
+        b.barrier(atomicResultBroadcastBarrierAddrSpace(memOrdering));
         Value atomPtr =
             getSharedMemoryBase(loc, rewriter, targetInfo, op.getOperation());
         Value ret = b.load(valueElemTy, atomPtr);
@@ -2474,7 +2474,7 @@ struct AtomicRMWOpConversion
             return success();
           }
           Value atomPtr = *atomicSharedMemBase;
-          b.barrier(triton::gpu::AddrSpace::Local);
+          b.barrier(atomicResultBroadcastBarrierAddrSpace(op.getSem()));
           Value ret = b.load(valueElemTy, atomPtr);
 
           rewriter.replaceOp(op, {ret});

--- a/third_party/amd/lib/TritonAMDGPUToLLVM/MemoryOpToLLVM.cpp
+++ b/third_party/amd/lib/TritonAMDGPUToLLVM/MemoryOpToLLVM.cpp
@@ -630,8 +630,6 @@ public:
   LogicalResult
   matchAndRewrite(triton::gpu::BarrierOp op, OpAdaptor adaptor,
                   ConversionPatternRewriter &rewriter) const override {
-    if (!mlir::triton::amdgpu::isCDNA(targetInfo.getISAFamily()))
-      return failure();
     // Check no other memory addrspaces are selected.
     // TensorRead/Write are allowed but noop.
     auto mask = triton::gpu::AddrSpace::Local |
@@ -653,6 +651,9 @@ public:
       // Local/global barriers use LLVM fences so the AMDGPU memory legalizer
       // selects target-specific waits. Mixed local+global barriers are left
       // untagged so LLVM conservatively synchronizes every relevant space.
+      // The tag is load-bearing: an LDS-only fence drops buffer_gl0_inv, and
+      // on gfx10+ that L0 is per-CU while a work-group spans both CUs of a
+      // WGP. See atomicOrderingBarrierAddrSpace().
       createAMDGPUMemoryFence(rewriter, op->getLoc(),
                               LLVM::AtomicOrdering::release, mmraAddrSpace);
       ROCDL::SBarrierOp::create(rewriter, op->getLoc());


### PR DESCRIPTION
## Problem

Reverts #10906 with a proper fix for RDNA to avoid the performance loss due to over-synchronization caused by #10906 on RDNA when only LDS barriers are needed.

#10906 avoids a miscompile that only happens on RDNA. It happens on RDNA because there waves of the same workgroup can run on different CUs (of the same WGP), and thus have different L0 caches.

The miscompiled kernel, pytorch cumsum kernel, looks like
```
while flag == 0:
      # Performed by a single thread:
      flag = tl.atomic_add(scratch_base + 3 * test_target + 0, 0, sem="acquire")

# Performed by all waves:
value_u64 = tl.load(scratch_base + 3 * test_target + flag.to(tl.int32))   # plain load
```

A scalar `tl.atomic_*` is executed by a single elected thread, and its result is
broadcast to the rest of the CTA through shared memory. The barrier of that
broadcast is *deliberately* reused as the atomic's acquire/release barrier -
`insertAtomicOrderingBarriers(..., emitBarrierAfter=false)` explicitly suppresses
the duplicate. But that barrier was created with `AddrSpace::Local`.

A barrier that only order shared memory is not enough to implement acquire semantics for waves on the other CU; they will still read stale L0 cache.

We need a `AddrSpace::Global` barrier, whose lowering includes a `buffer_gl0_inv` in WGP-mode.

Buggy assembly before #10906:
```asm
.LBB0_16:                                  ; while flag == 0
        s_waitcnt lgkmcnt(0)
        s_barrier                          ; LDS-only tagged -> no buffer_gl0_inv
        s_and_saveexec_b32 s1, s11         ; elect one thread
        s_cbranch_execz .LBB0_15
        ...
        global_load_b64 v[8:9], v7, s[4:5] glc   ; atomic_add(.., 0, sem="acquire")
        s_waitcnt vmcnt(0)
        buffer_gl1_inv
        buffer_gl0_inv                     ; <-- ONLY this wave invalidates its L0
.LBB0_14:
        ds_store_b64 v7, v[8:9]            ; broadcast flag through LDS
.LBB0_15:
        s_waitcnt lgkmcnt(0)
        s_barrier                          ; LDS-only tagged -> no buffer_gl0_inv
        ds_load_b64 v[8:9], v7
        ...
.LBB0_11:
        global_load_b64 v[19:20], v[19:20], off  ; ALL waves, plain load -> stale on the other CU
```

It reproduces as hard miscompares (relative error ~1.0 against a 1e-4 tolerance)
in PyTorch inductor's split-cumsum kernels, whose decoupled-lookback helper reads
a value published by another program with a plain `tl.load` after an acquiring
atomic.

`eaad84b148` ("[AMD] Restrict BarrierOpConversion to CDNA") worked around the
symptom by disabling the shared-memory-only barrier lowering for RDNA. That hid
it because on CDNA a work-group lives on a single CU, so the missing invalidate
is harmless there.

This is too conservative because it causes all barriers to have acquire/release semantics,
even when there are no atomics in the shader and it really only needs a shared-memory barrier.

With this PR, we get the correct acquire/release semantics around atomics,
and avoid synchronizing global loads when we only need a shared-memory barrier.


## Fix

- One new helper, `atomicOrderingBarrierAddrSpace()`: `relaxed → local`,
  everything else → `local|global_read|global_write`. It does not split acquire
  into `global_read` and release into `global_write`, because no backend
  distinguishes them today.
- Applied in `insertAtomicOrderingBarriers()`, `broadcastScalarAtomicResult()`,
  `AtomicPollOpConversion`, and the scalar `AtomicCAS`/`AtomicRMW` result-staging
  paths of the AMD. 
- The ISA-family guard `eaad84b148` added to the AMD `BarrierOpConversion` is
  **removed** rather than widened. The MMRA tag is target-agnostic in LLVM's
  memory legalizer, so the check never described a hardware capability - it only
  encoded where the bug happened. Removing it also restores the
  tagged lowering on gfx906, which `eaad84b148` disabled as collateral even
  though its single-CU work-group was never implicated.

Relaxed atomics keep the cheap barrier - they order nothing, so it only has to
cover the LDS staging. That is why the fp32 split-cumsum path, whose value comes
out of the atomic itself instead of a separate load, was never affected.

## Evidence

| Experiment | Result | Conclusion |
|---|---|---|
| dtype-resolved cumsum repro | every dtype using the 64-bit lookback helper fails; fp32 passes | only the path with a plain `tl.load` after the acquire breaks |
| ISA diff, LDS-only-tagged vs untagged barrier | the *only* difference is removed `buffer_gl0_inv` (plus redundant `s_waitcnt_vscnt`); no `vmcnt` change | the miscompare is a missing L0 invalidate |
| make that `tl.load` `volatile=True` (bypasses L0+GL1) | failures disappear | that load is the stale read |
| same build with `+cumode` | all dtypes pass | one CU, one L0 - confirms the WGP/per-CU-L0 mechanism |

## Testing

On gfx1151 (RDNA3.5):

- `GPUTests.test_split_cumsum_cuda`, `test_consecutive_split_cumsum_cuda`,
  `test_split_cumprod_cuda`, `test_split_cumsum_low_prec_cuda` - pass
- A dtype-resolved standalone cumsum reproducer, 8 dtypes × 2 shapes × 3
  repetitions - pass (previously deterministic failures with ~8% of elements
  wrong)
- `lit` suite (293 tests) - pass
- `pytest python/test/unit/language/test_core.py -k atomic` - 955 passed,
  67 skipped

New regression test `test/Conversion/amd/scalar_atomic_ordering_barrier.mlir`
pins both directions: an acquiring scalar atomic must produce an untagged fence,
a relaxed one must keep the tagged shared-memory-only fence.
`test/Conversion/amd/barrier_op_to_llvm.mlir` is extended with the
`local|global_read` case and now expects the tagged lowering on RDNA too.
Both run over gfx906/gfx942/gfx950/gfx1100/gfx1200/gfx1250.

Only gfx1151 was exercised on hardware; the other targets are covered by
codegen tests.

### Note on the deleted `RDNA4` check prefix

`barrier_op_to_llvm.mlir` had a gfx1200-specific prefix because the generic
fallback emitted `rocdl.s.barrier.signal id = -1` / `rocdl.s.barrier.wait id = -1`
where the AMD pattern emits `rocdl.s.barrier`. Now that gfx1200 no longer falls
back, its output is identical to the other targets and the prefix has nothing
left to distinguish.

That is not a lost split barrier - the AMDGPU backend expands
`llvm.amdgcn.s.barrier` itself on gfx12. Running the test through
`triton-opt | mlir-translate | llc -mcpu=gfx1200`:

```asm
lower_barrier:                          ; ttg.barrier local (tagged)
        s_barrier_signal -1
        s_barrier_wait -1

lower_barrier_local_and_global:         ; ttg.barrier local|global_read (untagged)
        s_barrier_signal -1
        s_barrier_wait -1
        global_inv scope:SCOPE_SE
```

which also shows the fix's mechanism holding on gfx12, where the invalidate is
spelled `global_inv scope:SCOPE_SE`.

### Impact on targets other than RDNA

The annotation change applies to every backend, so the obvious question is what it
costs on CDNA. Compiling a barrier with a global load live across it through
`triton-opt | mlir-translate | llc`, tagged vs untagged:

| Target | ISA delta (untagged vs `local`-tagged) |
|---|---|
| gfx906, gfx908, gfx90a, gfx942, gfx950 | **identical** |
| gfx1250 | `+ s_wait_storecnt 0x0` |
| gfx1100 | `+ buffer_gl0_inv`, `+ s_waitcnt_vscnt null, 0x0` |
| gfx1200 | `+ global_inv scope:SCOPE_SE`, `+ s_wait_storecnt 0x0` |

On gfx9 a work-group runs on one CU sharing one L1, so a workgroup-scope
acquire/release needs no cache maintenance and the legalizer emits the same code
either way — the change is free there. The guard removal likewise does not touch
CDNA1-4 or gfx1250, which `isCDNA()` already covered.

gfx1250 gains one store-counter drain at atomic-ordering barriers. That is the
release side behaving as asked, and it is not avoidable by being more precise:
annotating only `local|global_read` produces identical ISA on gfx1100, gfx1200
and gfx1250, because the MMRA tag is per-address-space rather than per-direction.

## Performance

Re-enabling the shared-memory-only lowering on RDNA is the point of the change:
an LDS-only barrier goes back to `s_waitcnt lgkmcnt(0); s_barrier` instead of
`s_waitcnt vmcnt(0) lgkmcnt(0); s_barrier; buffer_gl0_inv`, which no longer
drains every outstanding global load at each barrier. On a software-pipelined
shared-memory double-buffered fp16 GEMM (gfx1151, 128x64x64 TN) that is
**30.1 → 33.4-33.8 TFLOP/s (+11%)**, with a `buffer_gl0_inv`-free main loop.

**Reproducing (gfx1151, in-tree).** Codegen check — deterministic, no timing:

    TRITON_KERNEL_DUMP=1 TRITON_DUMP_DIR=/tmp/d \
        python python/tutorials/03-matrix-multiplication.py
    grep -c buffer_gl0_inv /tmp/d/*/matmul_kernel.amdgcn   # 0 with this PR, >0 without

Throughput — the same tutorial prints a TFLOP/s table (needs `matplotlib`):

    python python/tutorials/03-matrix-multiplication.py

Against this PR's merge base, back-to-back: **+8% median across the 31 shapes**
(30/31 faster), with the rocBLAS column flat to ~1% as a control.

fyi @k-artem @PMylon 