### PR TITLE
[tritongpu] Deduplicate the three hoistConvert*() driver functions in RemoveLayoutConversions

### DIFF
--- a/lib/Dialect/TritonGPU/Transforms/RemoveLayoutConversions.cpp
+++ b/lib/Dialect/TritonGPU/Transforms/RemoveLayoutConversions.cpp
@@ -1570,7 +1570,6 @@ bool backwardRematerialization(ModuleOp module, bool disableRematSplitting) {
 }
 
 void hoistConvert(ModuleOp module, bool disableRematSplitting) {
-  SmallVector<ConvertLayoutOp> convertOps;
   module.walk([&](FuncOp funcOp) {
     LayoutRematerialization layoutRemat(funcOp);
     layoutRemat.hoistConvertOnTopOfExtOrBroadcast(disableRematSplitting);

--- a/lib/Dialect/TritonGPU/Transforms/RemoveLayoutConversions.cpp
+++ b/lib/Dialect/TritonGPU/Transforms/RemoveLayoutConversions.cpp
@@ -131,7 +131,7 @@ public:
   bool backwardRematerialization(ConvertLayoutOp convertOp,
                                  bool disableRematSplitting);
 
-  // TODO: Merge the three hoistConvert*(); functions as they are duplicate code
+  void runHoistConvertPass(std::function<bool(ConvertLayoutOp)> tryHoist);
   void hoistConvertDotOperand();
   void hoistConvertOnTopOfExtOrBroadcast(bool disableRematSplitting);
   void hoistConvertIntoConditionals();
@@ -961,14 +961,13 @@ bool LayoutRematerialization::backwardRematerialization(
   return changed;
 }
 
-void LayoutRematerialization::hoistConvertOnTopOfExtOrBroadcast(
-    bool disableRematSplitting) {
-  // Go through each ConvertLayoutOp.
+void LayoutRematerialization::runHoistConvertPass(
+    std::function<bool(ConvertLayoutOp)> tryHoist) {
   SmallVector<ConvertLayoutOp> convertOps;
   funcOp.walk(
       [&](ConvertLayoutOp convertOp) { convertOps.push_back(convertOp); });
   for (ConvertLayoutOp convertOp : convertOps) {
-    if (!hoistConvertOnTopOfExtOrBroadcast(convertOp, disableRematSplitting)) {
+    if (!tryHoist(convertOp)) {
       // If the conversion didn't get removed, consider it for reuse in future
       // backward slices.
       addRematValue(convertOp.getSrc(), convertOp.getType().getEncoding(),
@@ -977,19 +976,16 @@ void LayoutRematerialization::hoistConvertOnTopOfExtOrBroadcast(
   }
 }
 
+void LayoutRematerialization::hoistConvertOnTopOfExtOrBroadcast(
+    bool disableRematSplitting) {
+  runHoistConvertPass([&](ConvertLayoutOp convertOp) {
+    return hoistConvertOnTopOfExtOrBroadcast(convertOp, disableRematSplitting);
+  });
+}
+
 void LayoutRematerialization::hoistConvertIntoConditionals() {
-  // Go through each ConvertLayoutOp.
-  SmallVector<ConvertLayoutOp> convertOps;
-  funcOp.walk(
-      [&](ConvertLayoutOp convertOp) { convertOps.push_back(convertOp); });
-  for (ConvertLayoutOp convertOp : convertOps) {
-    if (!hoistConvertIntoConditionals(convertOp)) {
-      // If the conversion didn't get removed, consider it for reuse in future
-      // backward slices.
-      addRematValue(convertOp.getSrc(), convertOp.getType().getEncoding(),
-                    convertOp.getResult());
-    }
-  }
+  runHoistConvertPass(
+      [&](ConvertLayoutOp convertOp) { return hoistConvertIntoConditionals(convertOp); });
 }
 
 static bool isExpensiveMathOp(Operation *op) {
@@ -1243,18 +1239,8 @@ bool LayoutRematerialization::backwardRematerialization(
 }
 
 void LayoutRematerialization::hoistConvertDotOperand() {
-  // Go through each ConvertLayoutOp.
-  SmallVector<ConvertLayoutOp> convertOps;
-  funcOp.walk(
-      [&](ConvertLayoutOp convertOp) { convertOps.push_back(convertOp); });
-  for (ConvertLayoutOp convertOp : convertOps) {
-    if (!hoistConvertDotOperand(convertOp)) {
-      // If the conversion didn't get removed, consider it for reuse in future
-      // backward slices.
-      addRematValue(convertOp.getSrc(), convertOp.getType().getEncoding(),
-                    convertOp.getResult());
-    }
-  }
+  runHoistConvertPass(
+      [&](ConvertLayoutOp convertOp) { return hoistConvertDotOperand(convertOp); });
 }
 
 bool LayoutRematerialization::hoistConvertDotOperand(
@@ -1586,13 +1572,13 @@ bool backwardRematerialization(ModuleOp module, bool disableRematSplitting) {
 void hoistConvert(ModuleOp module, bool disableRematSplitting) {
   SmallVector<ConvertLayoutOp> convertOps;
   module.walk([&](FuncOp funcOp) {
-    LayoutRematerialization(funcOp).hoistConvertOnTopOfExtOrBroadcast(
-        disableRematSplitting);
+    LayoutRematerialization layoutRemat(funcOp);
+    layoutRemat.hoistConvertOnTopOfExtOrBroadcast(disableRematSplitting);
     if (disableRematSplitting)
       return;
 
-    LayoutRematerialization(funcOp).hoistConvertIntoConditionals();
-    LayoutRematerialization(funcOp).hoistConvertDotOperand();
+    layoutRemat.hoistConvertIntoConditionals();
+    layoutRemat.hoistConvertDotOperand();
   });
 }
 } // namespace

--- a/lib/Dialect/TritonGPU/Transforms/RemoveLayoutConversions.cpp
+++ b/lib/Dialect/TritonGPU/Transforms/RemoveLayoutConversions.cpp
@@ -1573,13 +1573,13 @@ bool backwardRematerialization(ModuleOp module, bool disableRematSplitting) {
 
 void hoistConvert(ModuleOp module, bool disableRematSplitting) {
   module.walk([&](FuncOp funcOp) {
-    LayoutRematerialization layoutRemat(funcOp);
-    layoutRemat.hoistConvertOnTopOfExtOrBroadcast(disableRematSplitting);
+    LayoutRematerialization(funcOp).hoistConvertOnTopOfExtOrBroadcast(
+        disableRematSplitting);
     if (disableRematSplitting)
       return;
 
-    layoutRemat.hoistConvertIntoConditionals();
-    layoutRemat.hoistConvertDotOperand();
+    LayoutRematerialization(funcOp).hoistConvertIntoConditionals();
+    LayoutRematerialization(funcOp).hoistConvertDotOperand();
   });
 }
 } // namespace

--- a/lib/Dialect/TritonGPU/Transforms/RemoveLayoutConversions.cpp
+++ b/lib/Dialect/TritonGPU/Transforms/RemoveLayoutConversions.cpp
@@ -984,8 +984,9 @@ void LayoutRematerialization::hoistConvertOnTopOfExtOrBroadcast(
 }
 
 void LayoutRematerialization::hoistConvertIntoConditionals() {
-  runHoistConvertPass(
-      [&](ConvertLayoutOp convertOp) { return hoistConvertIntoConditionals(convertOp); });
+  runHoistConvertPass([&](ConvertLayoutOp convertOp) {
+    return hoistConvertIntoConditionals(convertOp);
+  });
 }
 
 static bool isExpensiveMathOp(Operation *op) {
@@ -1239,8 +1240,9 @@ bool LayoutRematerialization::backwardRematerialization(
 }
 
 void LayoutRematerialization::hoistConvertDotOperand() {
-  runHoistConvertPass(
-      [&](ConvertLayoutOp convertOp) { return hoistConvertDotOperand(convertOp); });
+  runHoistConvertPass([&](ConvertLayoutOp convertOp) {
+    return hoistConvertDotOperand(convertOp);
+  });
 }
 
 bool LayoutRematerialization::hoistConvertDotOperand(


### PR DESCRIPTION
### Description

The `LayoutRematerialization` class in `RemoveLayoutConversions.cpp` had three hoist driver methods — `hoistConvertOnTopOfExtOrBroadcast`, `hoistConvertIntoConditionals`, and `hoistConvertDotOperand` — whose bodies were byte-for-byte identical except for which per-op hoist routine they called. This duplication was flagged by a long standing in-code TODO and made the drivers error-prone to keep in sync.

This PR extracts the shared "walk every `ConvertLayoutOp`, try to hoist it, and record it for reuse on failure" loop into a single `runHoistConvertPass` helper that takes the varying per-op step as a callback, reducing each driver to a thin wrapper. The now-unused `convertOps` local in `hoistConvert` is removed.

Each hoist pass keeps its own `LayoutRematerialization` instance. The issue's third bullet suggested sharing one instance across the three passes so `rematMapping` carries between them; that was tried and reverted, because it is not a safe cleanup. `runHoistConvertPass` records each convert it fails to hoist as `src -> convert result`, a later pass is free to erase that convert, and `updateRematMapping` only fixes up entries whose *key* is in the replacement batch — so a mapped value pointing at erased IR survives and trips the `live.contains(remat)` assertion in `~LayoutRematerialization`. This is exactly the hazard the comment on `rematMapping` warns about: a value is only safe to store if it outlives the map, which held while each pass owned its own map. Making the state shareable needs erase-time bookkeeping (an op-erase listener, or reverse indexing in `updateRematMapping`) and would change pass output, so it belongs in its own PR.

The change is behavior-preserving: with an assertions-enabled build, `tritongpu-remove-layout-conversions` produces byte-for-byte identical output to `main` on every `test/TritonGPU` lit input the pass accepts standalone (128/128), and the lit suite passes (290 passed, 2 unsupported).

Resolves #11290.

# New contributor declaration
- [x] I am not making a trivial change, such as fixing a typo in a comment.

- [x] I have written a PR description following these
  [rules](https://cbea.ms/git-commit/#why-not-how).

- [x] I have run `pre-commit run --from-ref origin/main --to-ref HEAD`.

- Select one of the following.
  - [ ] I have added tests.
  - [x] This PR does not need a test because it is a behavior-preserving
    refactor; the existing `test/TritonGPU/remove-layout-conversions-*.mlir` and
    `combine.mlir` lit tests already exercise all three hoist drivers, and the
    pass output was verified byte-for-byte identical to `main`.

- Select one of the following.
  - [x] I have not added any `lit` tests.
  - [ ] The `lit` tests I have added follow these best practices.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

