### PR TITLE
[AMD] Map tl.const pointer args to constant address space

### DIFF
--- a/include/triton/Dialect/Triton/IR/TritonTypeEnums.td
+++ b/include/triton/Dialect/Triton/IR/TritonTypeEnums.td
@@ -5,13 +5,15 @@ include "mlir/IR/EnumAttr.td"
 
 // Address space of a Triton pointer type (`!tt.ptr`). Case values mirror the
 // LLVM address spaces:
-//   Global     (1): NVPTXAS ADDRESS_SPACE_GLOBAL  / AMDGPUAS GLOBAL_ADDRESS
-//   Descriptor (0): NVPTXAS ADDRESS_SPACE_GENERIC / AMDGPUAS FLAT_ADDRESS
+//   Global     (1): NVPTXAS ADDRESS_SPACE_GLOBAL   / AMDGPUAS GLOBAL_ADDRESS
+//   Descriptor (0): NVPTXAS ADDRESS_SPACE_GENERIC  / AMDGPUAS FLAT_ADDRESS
+//   Constant   (4): NVPTXAS ADDRESS_SPACE_GLOBAL   / AMDGPUAS CONSTANT_ADDRESS
 def TT_PtrAddrSpaceAttr : I32EnumAttr<
     "PtrAddrSpace", "",
     [
         I32EnumAttrCase<"Global", 1, "global">,
         I32EnumAttrCase<"Descriptor", 0, "descriptor">,
+        I32EnumAttrCase<"Constant", 4, "constant">,
     ]> {
     let cppNamespace = "::mlir::triton";
 }

--- a/include/triton/Dialect/Triton/IR/TritonTypeEnums.td
+++ b/include/triton/Dialect/Triton/IR/TritonTypeEnums.td
@@ -3,11 +3,10 @@
 
 include "mlir/IR/EnumAttr.td"
 
-// Address space of a Triton pointer type (`!tt.ptr`). Case values mirror the
-// LLVM address spaces:
-//   Global     (1): NVPTXAS ADDRESS_SPACE_GLOBAL   / AMDGPUAS GLOBAL_ADDRESS
-//   Descriptor (0): NVPTXAS ADDRESS_SPACE_GENERIC  / AMDGPUAS FLAT_ADDRESS
-//   Constant   (4): NVPTXAS ADDRESS_SPACE_GLOBAL   / AMDGPUAS CONSTANT_ADDRESS
+// Address space of a Triton pointer type (`!tt.ptr`):
+//   Global: generic global memory
+//   Descriptor: pointer to tensor descriptor
+//   Constant: read only global memory
 def TT_PtrAddrSpaceAttr : I32EnumAttr<
     "PtrAddrSpace", "",
     [

--- a/lib/Conversion/TritonGPUToLLVM/TypeConverter.cpp
+++ b/lib/Conversion/TritonGPUToLLVM/TypeConverter.cpp
@@ -24,6 +24,8 @@ TritonGPUToLLVMTypeConverter::TritonGPUToLLVMTypeConverter(
   addConversion([ctx](triton::PointerType type) -> std::optional<Type> {
     switch (type.getAddressSpace()) {
     case triton::PtrAddrSpace::Global:
+    // Constant is AMD-specific; map to global here.
+    case triton::PtrAddrSpace::Constant:
       return LLVM::LLVMPointerType::get(ctx,
                                         llvm::NVPTXAS::ADDRESS_SPACE_GLOBAL);
     case triton::PtrAddrSpace::Descriptor:

--- a/python/test/unit/language/test_frontend.py
+++ b/python/test/unit/language/test_frontend.py
@@ -4,6 +4,7 @@ import triton
 import triton.language as tl
 from triton._filecheck import filecheck_test, run_filecheck_test, run_parser
 from triton.compiler.code_generator import CodeGenerator
+from triton.runtime.jit import MockTensor
 from triton.compiler.errors import CompilationError
 import pytest
 from typing import NamedTuple
@@ -1458,3 +1459,19 @@ def test_loop_carry_discovery_avoids_exponential_revisits(monkeypatch, kind):
     monkeypatch.setattr(CodeGenerator, "visit_compound_statement", counted)
     run_parser(_loop_carry_nest_depth_3, args=(kind, ))
     assert max(per_body.values()) == 4
+
+
+def test_const_ptr_is_constant_addrspace():
+
+    @triton.jit
+    def kernel(In: tl.const, Out, N, BLOCK: tl.constexpr):
+        # CHECK-LABEL: tt.func public @kernel
+        # A `tl.const` pointer argument is tagged with Triton's constant address
+        # CHECK-SAME: %arg0: !tt.ptr<f32, "constant">
+        # A plain pointer stays global
+        # CHECK-SAME: %arg1: !tt.ptr<f32> {
+        offs = tl.arange(0, BLOCK)
+        mask = offs < N
+        tl.store(Out + offs, tl.load(In + offs, mask=mask), mask=mask)
+
+    run_filecheck_test(kernel, args=(MockTensor(tl.float32), MockTensor(tl.float32), 8, 128))

--- a/python/triton/_filecheck.py
+++ b/python/triton/_filecheck.py
@@ -77,12 +77,12 @@ def run_parser(kernel_fn, args=(), kwargs={}, target=stub_target):
     return module
 
 
-def run_filecheck_test(kernel_fn):
+def run_filecheck_test(kernel_fn, args=(), kwargs={}):
     assert isinstance(kernel_fn, triton.runtime.JITFunction)
     check_template = inspect.getsource(kernel_fn.fn)
     if check_template is None:
         raise ValueError("kernel function must have a docstring with FileCheck template")
-    mlir_module = run_parser(kernel_fn)
+    mlir_module = run_parser(kernel_fn, args=args, kwargs=kwargs)
 
     run_filecheck("placeholder", mlir_module.str_nodebug(), check_template)
 

--- a/python/triton/language/core.py
+++ b/python/triton/language/core.py
@@ -686,7 +686,9 @@ class pointer_type(dtype):
         self.name = f'pointer<{element_ty}>' if not const else f'const_pointer<{element_ty}>'
 
     def to_ir(self, builder: ir.builder) -> ir.pointer_type:
-        return builder.get_ptr_ty(self.element_ty.to_ir(builder), self.address_space)
+        # const pointers live in the constant address space.
+        address_space = "constant" if self.const else self.address_space
+        return builder.get_ptr_ty(self.element_ty.to_ir(builder), address_space)
 
     def __str__(self):
         return self.name

--- a/test/Conversion/amd/const_addrspace.mlir
+++ b/test/Conversion/amd/const_addrspace.mlir
@@ -1,0 +1,13 @@
+// RUN: triton-opt %s -split-input-file --convert-triton-amdgpu-to-llvm=gfx-arch=gfx942 | FileCheck %s
+
+// A `tl.const` pointer carries Triton's constant address space (4). On AMD it
+// lowers to the AMDGPU constant address space so uniform loads select s_load; a
+// plain pointer stays global (1).
+module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 1 : i32} {
+  // CHECK-LABEL: llvm.func @const_ptr_arg
+  // CHECK-SAME: %arg0: !llvm.ptr<4>
+  // CHECK-SAME: %arg1: !llvm.ptr<1>
+  tt.func @const_ptr_arg(%const: !tt.ptr<f32, "constant">, %global: !tt.ptr<f32>) {
+    tt.return
+  }
+}

--- a/third_party/amd/include/TritonAMDGPUToLLVM/TypeConverter.h
+++ b/third_party/amd/include/TritonAMDGPUToLLVM/TypeConverter.h
@@ -29,6 +29,9 @@ public:
         return LLVM::LLVMPointerType::get(ctx, llvm::AMDGPUAS::GLOBAL_ADDRESS);
       case triton::PtrAddrSpace::Descriptor:
         return LLVM::LLVMPointerType::get(ctx, llvm::AMDGPUAS::FLAT_ADDRESS);
+      case triton::PtrAddrSpace::Constant:
+        return LLVM::LLVMPointerType::get(ctx,
+                                          llvm::AMDGPUAS::CONSTANT_ADDRESS);
       }
       llvm_unreachable("unknown PtrAddrSpace");
     });

--- a/third_party/proton/Dialect/lib/ProtonGPUToLLVM/ProtonAMDGPUToLLVM/TargetInfo.cpp
+++ b/third_party/proton/Dialect/lib/ProtonGPUToLLVM/ProtonAMDGPUToLLVM/TargetInfo.cpp
@@ -222,6 +222,8 @@ unsigned TargetInfo::getPtrAddressSpace(triton::PtrAddrSpace space) const {
     return llvm::AMDGPUAS::GLOBAL_ADDRESS;
   case triton::PtrAddrSpace::Descriptor:
     return llvm::AMDGPUAS::FLAT_ADDRESS;
+  case triton::PtrAddrSpace::Constant:
+    return llvm::AMDGPUAS::CONSTANT_ADDRESS;
   }
   llvm_unreachable("unknown PtrAddrSpace");
 }

--- a/third_party/proton/Dialect/lib/ProtonGPUToLLVM/ProtonNvidiaGPUToLLVM/TargetInfo.cpp
+++ b/third_party/proton/Dialect/lib/ProtonGPUToLLVM/ProtonNvidiaGPUToLLVM/TargetInfo.cpp
@@ -72,6 +72,8 @@ int TargetInfo::getAddressSpace(Attribute addressSpace) const {
 unsigned TargetInfo::getPtrAddressSpace(triton::PtrAddrSpace space) const {
   switch (space) {
   case triton::PtrAddrSpace::Global:
+  // Constant is AMD-specific; map to global here.
+  case triton::PtrAddrSpace::Constant:
     return llvm::NVPTXAS::ADDRESS_SPACE_GLOBAL;
   case triton::PtrAddrSpace::Descriptor:
     return llvm::NVPTXAS::ADDRESS_SPACE_GENERIC;

--- a/third_party/proton/Dialect/lib/ProtonGPUToLLVM/ProtonNvidiaGPUToLLVM/TargetInfo.cpp
+++ b/third_party/proton/Dialect/lib/ProtonGPUToLLVM/ProtonNvidiaGPUToLLVM/TargetInfo.cpp
@@ -72,7 +72,8 @@ int TargetInfo::getAddressSpace(Attribute addressSpace) const {
 unsigned TargetInfo::getPtrAddressSpace(triton::PtrAddrSpace space) const {
   switch (space) {
   case triton::PtrAddrSpace::Global:
-  // Constant is AMD-specific; map to global here.
+  // Global memory read-only marking is not carried via a different LLVM
+  // address space. We channel it through other mechanisms.
   case triton::PtrAddrSpace::Constant:
     return llvm::NVPTXAS::ADDRESS_SPACE_GLOBAL;
   case triton::PtrAddrSpace::Descriptor:


### PR DESCRIPTION
## Summary

  Lower a tl.const kernel pointer argument to the AMDGPU constant address space (4) on the HIP backend, so uniform, read-only loads through it select scalar s_load and remove the in-loop v_readfirstlane churn.

## Motivation

The motivating case is the gfx1250 MoE gather-index load: it's wave-uniform and read-only, but because other pointer args are written in the kernel, ISel can't prove the gather buffer is un-clobbered and falls back to vector loads + v_readfirstlane. Marking the pointer tl.const lets the compiler treat it as invariant and issue s_load.

## Implementation

  - Named pointer address space triton::PtrAddrSpace { Global, Constant } (dialect), mirrored by PointerAddressSpace in the frontend.
  - ast_to_ttir (all targets): tag tl.const pointer args with Constant; addptr/splat/broadcast propagate it down the load chain.
  - TypeConverter: common maps Constant → target global; AMD overrides it to `AMDGPUAS::CONSTANT_ADDRESS` so uniform loads select scalar s_load.
  - ConvertToBufferOps: only convert Global-base accesses.



##  Results

Byte identical with https://github.com/triton-lang/triton/pull/11092, in loop readfirstlane replaced with out-of-loop s_load.

----

 ## Alternatives considered

1. noalias param attribute (prior attempt): https://github.com/triton-lang/triton/pull/11092
2. !invariant.load on the loads: mark loads through a tl.const pointer invariant. This keeps the pointer in addrspace 1 (no ABI/allocation issue), both reading the actual global buffer, and least exposure to LLVM internals (standard IR metadata, not alias-analysis inference)
   - lowers to `s_load … nv` on AMD
   - lowers to `ld.global.nc` on NVIDIA
