### PR TITLE
[AMD] Swizzle clamping for the direct-to-lds path

### DIFF
--- a/test/TritonGPU/amd/amd-pipeline-shared-layout-async-copy-gfx9.mlir
+++ b/test/TritonGPU/amd/amd-pipeline-shared-layout-async-copy-gfx9.mlir
@@ -151,6 +151,40 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.targ
 
 // -----
 
+// The same unsafe swizzle candidate must remain unchanged when pointer
+// contiguity makes the load ineligible for async copy.
+#blocked = #ttg.blocked<{sizePerThread = [8, 1], threadsPerWarp = [8, 8], warpsPerCTA = [1, 4], order = [0, 1]}>
+// CHECK: #shared = #ttg.swizzled_shared<{vec = 2, perPhase = 2, maxPhase = 8, order = [0, 1]}>
+#mma = #ttg.amd_mfma<{version = 4, warpsPerCTA = [4, 1], instrShape = [32, 32, 16], isTransposed = true}>
+module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.target = "hip:gfx950", "ttg.threads-per-warp" = 64 : i32} {
+  // CHECK-LABEL: stream_copy_does_not_clamp_swizzle
+  tt.func @stream_copy_does_not_clamp_swizzle(
+              %arg0: !tt.ptr<f16> {tt.divisibility = 16 : i32},
+              %arg1: tensor<128x64xf16, #ttg.dot_op<{opIdx = 0, parent = #mma, kWidth = 2}>>,
+              %lb: i32, %ub: i32, %step: i32) -> tensor<128x16xf32, #mma> {
+    // CHECK-NOT: ttg.async_copy_global_to_local
+    // CHECK: ttg.local_store
+    %cst_acc = arith.constant dense<0.000000e+00> : tensor<128x16xf32, #mma>
+    %c2 = arith.constant dense<2> : tensor<64x16xi32, #blocked>
+    %0 = tt.splat %arg0 : !tt.ptr<f16> -> tensor<1x16x!tt.ptr<f16>, #blocked>
+    %1 = tt.make_range {end = 64 : i32, start = 0 : i32} : tensor<64xi32, #ttg.slice<{dim = 1, parent = #blocked}>>
+    %2 = tt.expand_dims %1 {axis = 1 : i32} : tensor<64xi32, #ttg.slice<{dim = 1, parent = #blocked}>> -> tensor<64x1xi32, #blocked>
+    %3 = tt.broadcast %0 : tensor<1x16x!tt.ptr<f16>, #blocked> -> tensor<64x16x!tt.ptr<f16>, #blocked>
+    %4 = tt.broadcast %2 : tensor<64x1xi32, #blocked> -> tensor<64x16xi32, #blocked>
+    %5 = arith.muli %4, %c2 : tensor<64x16xi32, #blocked>
+    %6 = tt.addptr %3, %5 : tensor<64x16x!tt.ptr<f16>, #blocked>, tensor<64x16xi32, #blocked>
+    %result = scf.for %iv = %lb to %ub step %step iter_args(%acc = %cst_acc) -> (tensor<128x16xf32, #mma>) : i32 {
+      %b = tt.load %6 : tensor<64x16x!tt.ptr<f16>, #blocked>
+      %b_dot = ttg.convert_layout %b : tensor<64x16xf16, #blocked> -> tensor<64x16xf16, #ttg.dot_op<{opIdx = 1, parent = #mma, kWidth = 2}>>
+      %c = tt.dot %arg1, %b_dot, %acc : tensor<128x64xf16, #ttg.dot_op<{opIdx = 0, parent = #mma, kWidth = 2}>> * tensor<64x16xf16, #ttg.dot_op<{opIdx = 1, parent = #mma, kWidth = 2}>> -> tensor<128x16xf32, #mma>
+      scf.yield %c : tensor<128x16xf32, #mma>
+    }
+    tt.return %result : tensor<128x16xf32, #mma>
+  }
+}
+
+// -----
+
 // Same deduced swizzle as above, but each thread holds exactly one vec block
 // so the shuffle stays inside the warp and maxPhase must be preserved.
 #blocked = #ttg.blocked<{sizePerThread = [2, 1], threadsPerWarp = [32, 2], warpsPerCTA = [1, 4], order = [0, 1]}>

--- a/test/TritonGPU/amd/amd-pipeline-shared-layout-async-copy-gfx9.mlir
+++ b/test/TritonGPU/amd/amd-pipeline-shared-layout-async-copy-gfx9.mlir
@@ -118,3 +118,63 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 1 : i32, ttg.targ
     tt.return %result : tensor<16x16xf32, #mma>
   }
 }
+
+// -----
+
+// On GFX9 the swizzle is realized as a lane shuffle. Lanes are 4 vec blocks
+// apart here, so the maxPhase=8 XOR leaves the warp and must be clamped.
+#blocked = #ttg.blocked<{sizePerThread = [8, 1], threadsPerWarp = [8, 8], warpsPerCTA = [1, 4], order = [0, 1]}>
+// CHECK: #shared = #ttg.swizzled_shared<{vec = 2, perPhase = 2, maxPhase = 1, order = [0, 1]}>
+#mma = #ttg.amd_mfma<{version = 4, warpsPerCTA = [4, 1], instrShape = [32, 32, 16], isTransposed = true}>
+module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.target = "hip:gfx950", "ttg.threads-per-warp" = 64 : i32} {
+  // CHECK-LABEL: async_copy_swizzle_clamped_to_warp
+  tt.func @async_copy_swizzle_clamped_to_warp(%arg0: !tt.ptr<f16> {tt.divisibility = 16 : i32},
+              %arg1: tensor<128x64xf16, #ttg.dot_op<{opIdx = 0, parent = #mma, kWidth = 2}>>,
+              %lb: i32, %ub: i32, %step: i32) -> tensor<128x16xf32, #mma> {
+    // CHECK: ttg.async_copy_global_to_local {{.*}} -> <64x16xf16, #shared, #smem, mutable>
+    %cst_acc = arith.constant dense<0.000000e+00> : tensor<128x16xf32, #mma>
+    %0 = tt.splat %arg0 : !tt.ptr<f16> -> tensor<1x16x!tt.ptr<f16>, #blocked>
+    %1 = tt.make_range {end = 64 : i32, start = 0 : i32} : tensor<64xi32, #ttg.slice<{dim = 1, parent = #blocked}>>
+    %2 = tt.expand_dims %1 {axis = 1 : i32} : tensor<64xi32, #ttg.slice<{dim = 1, parent = #blocked}>> -> tensor<64x1xi32, #blocked>
+    %3 = tt.broadcast %0 : tensor<1x16x!tt.ptr<f16>, #blocked> -> tensor<64x16x!tt.ptr<f16>, #blocked>
+    %4 = tt.broadcast %2 : tensor<64x1xi32, #blocked> -> tensor<64x16xi32, #blocked>
+    %5 = tt.addptr %3, %4 : tensor<64x16x!tt.ptr<f16>, #blocked>, tensor<64x16xi32, #blocked>
+    %result = scf.for %iv = %lb to %ub step %step iter_args(%acc = %cst_acc) -> (tensor<128x16xf32, #mma>) : i32 {
+      %b = tt.load %5 : tensor<64x16x!tt.ptr<f16>, #blocked>
+      %b_dot = ttg.convert_layout %b : tensor<64x16xf16, #blocked> -> tensor<64x16xf16, #ttg.dot_op<{opIdx = 1, parent = #mma, kWidth = 2}>>
+      %c = tt.dot %arg1, %b_dot, %acc : tensor<128x64xf16, #ttg.dot_op<{opIdx = 0, parent = #mma, kWidth = 2}>> * tensor<64x16xf16, #ttg.dot_op<{opIdx = 1, parent = #mma, kWidth = 2}>> -> tensor<128x16xf32, #mma>
+      scf.yield %c : tensor<128x16xf32, #mma>
+    }
+    tt.return %result : tensor<128x16xf32, #mma>
+  }
+}
+
+// -----
+
+// Same deduced swizzle as above, but each thread holds exactly one vec block
+// so the shuffle stays inside the warp and maxPhase must be preserved.
+#blocked = #ttg.blocked<{sizePerThread = [2, 1], threadsPerWarp = [32, 2], warpsPerCTA = [1, 4], order = [0, 1]}>
+// CHECK: #shared = #ttg.swizzled_shared<{vec = 2, perPhase = 2, maxPhase = 8, order = [0, 1]}>
+#mma = #ttg.amd_mfma<{version = 4, warpsPerCTA = [4, 1], instrShape = [32, 32, 16], isTransposed = true}>
+module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.target = "hip:gfx950", "ttg.threads-per-warp" = 64 : i32} {
+  // CHECK-LABEL: async_copy_swizzle_stays_in_warp
+  tt.func @async_copy_swizzle_stays_in_warp(%arg0: !tt.ptr<f16> {tt.divisibility = 16 : i32},
+              %arg1: tensor<128x64xf16, #ttg.dot_op<{opIdx = 0, parent = #mma, kWidth = 2}>>,
+              %lb: i32, %ub: i32, %step: i32) -> tensor<128x16xf32, #mma> {
+    // CHECK: ttg.async_copy_global_to_local {{.*}} -> <64x16xf16, #shared, #smem, mutable>
+    %cst_acc = arith.constant dense<0.000000e+00> : tensor<128x16xf32, #mma>
+    %0 = tt.splat %arg0 : !tt.ptr<f16> -> tensor<1x16x!tt.ptr<f16>, #blocked>
+    %1 = tt.make_range {end = 64 : i32, start = 0 : i32} : tensor<64xi32, #ttg.slice<{dim = 1, parent = #blocked}>>
+    %2 = tt.expand_dims %1 {axis = 1 : i32} : tensor<64xi32, #ttg.slice<{dim = 1, parent = #blocked}>> -> tensor<64x1xi32, #blocked>
+    %3 = tt.broadcast %0 : tensor<1x16x!tt.ptr<f16>, #blocked> -> tensor<64x16x!tt.ptr<f16>, #blocked>
+    %4 = tt.broadcast %2 : tensor<64x1xi32, #blocked> -> tensor<64x16xi32, #blocked>
+    %5 = tt.addptr %3, %4 : tensor<64x16x!tt.ptr<f16>, #blocked>, tensor<64x16xi32, #blocked>
+    %result = scf.for %iv = %lb to %ub step %step iter_args(%acc = %cst_acc) -> (tensor<128x16xf32, #mma>) : i32 {
+      %b = tt.load %5 : tensor<64x16x!tt.ptr<f16>, #blocked>
+      %b_dot = ttg.convert_layout %b : tensor<64x16xf16, #blocked> -> tensor<64x16xf16, #ttg.dot_op<{opIdx = 1, parent = #mma, kWidth = 2}>>
+      %c = tt.dot %arg1, %b_dot, %acc : tensor<128x64xf16, #ttg.dot_op<{opIdx = 0, parent = #mma, kWidth = 2}>> * tensor<64x16xf16, #ttg.dot_op<{opIdx = 1, parent = #mma, kWidth = 2}>> -> tensor<128x16xf32, #mma>
+      scf.yield %c : tensor<128x16xf32, #mma>
+    }
+    tt.return %result : tensor<128x16xf32, #mma>
+  }
+}

--- a/third_party/amd/lib/TritonAMDGPUTransforms/LowerLoops.cpp
+++ b/third_party/amd/lib/TritonAMDGPUTransforms/LowerLoops.cpp
@@ -378,9 +378,8 @@ bool hasEnoughCTABytesForDirectToLds(tt::LoadOp loadOp,
 
 // Return whether the shared-memory swizzle maps every register and lane of
 // srcTy to a source lane within the same warp.
-static bool
-swizzlesInsideWarp(RankedTensorType srcTy,
-                   ttg::SwizzledSharedEncodingAttr enc) {
+static bool swizzlesInsideWarp(RankedTensorType srcTy,
+                               ttg::SwizzledSharedEncodingAttr enc) {
   // maxPhase == 1 means no swizzling, so `requiresSrcPtrSwizzling` is false in
   // the lowering and there is no lane shuffle.
   if (!enc || enc.getMaxPhase() == 1)
@@ -583,8 +582,7 @@ createStreamOps(const LoadToInfoMap &loadToInfo, scf::ForOp &forOp,
     // On non-scatter targets, direct-to-LDS realizes the shared-memory swizzle
     // by shuffling source pointers between lanes, which must stay in one warp.
     if (canUseAsyncCopy && !targetInfo.supportsDirectToLdsScatter()) {
-      auto clampedEncoding =
-          clampSwizzleForDirectToLds(ty, sharedEncoding);
+      auto clampedEncoding = clampSwizzleForDirectToLds(ty, sharedEncoding);
       // Clamping changes the shared layout used by the final eligibility
       // check, so verify that the load remains convertible.
       canUseAsyncCopy = canBeConvertedToAsyncLoad(

--- a/third_party/amd/lib/TritonAMDGPUTransforms/LowerLoops.cpp
+++ b/third_party/amd/lib/TritonAMDGPUTransforms/LowerLoops.cpp
@@ -182,10 +182,6 @@ StreamCopyChainOps createStreamCopy(tt::LoadOp loadOp, Value alloc,
   return {newLoadOp, viewLoad, storeOp, maybeLocalLoad};
 }
 
-static ttg::SharedEncodingTrait
-clampSwizzleForDirectToLds(RankedTensorType srcTy, ttg::SharedEncodingTrait enc,
-                           const tt::AMD::TargetInfo &targetInfo);
-
 // Adapted from
 // lib/Dialect/TritonGPU/Transforms/Utility.cpp::getSharedEncIfAllUsersAreDotEnc
 // to support AMDMfmaEncodingAttr.
@@ -357,17 +353,6 @@ std::optional<ttg::SharedEncodingTrait> getSharedEncIfAllUsersAreDotEnc(
   }
 
   LDBG("Deduced shared encoding: " << maxVecSharedEnc);
-
-  // On GFX9 the direct-to-LDS lowering models the shared swizzle as a
-  // within-warp lane shuffle. If the deduced swizzle would shuffle across the
-  // warp boundary (e.g. a bf16 kWidth=8 operand feeding an f32 async copy),
-  // shrink its maxPhase so the shuffle stays valid instead of miscompiling into
-  // an out-of-bounds global read.
-  if (useAsyncCopy && !targetInfo.supportsDirectToLdsScatter())
-    if (auto ld = dyn_cast<tt::LoadOp>(loadOp))
-      if (auto srcTy = dyn_cast<RankedTensorType>(ld.getResult().getType()))
-        maxVecSharedEnc =
-            clampSwizzleForDirectToLds(srcTy, maxVecSharedEnc, targetInfo);
 
   return maxVecSharedEnc;
 }
@@ -597,13 +582,32 @@ createStreamOps(const LoadToInfoMap &loadToInfo, scf::ForOp &forOp,
     if (!loadOp && !descLoadOp && !gatherOp)
       continue;
 
-    // Create an allocation that can hold distance number of loadOp shapes.
     auto ty = cast<RankedTensorType>(op->getResultTypes()[0]);
-    Value alloc = triton::createAlloc(forOp, ty, op->getLoc(),
-                                      info.sharedEncoding, numBuffers);
-    assert(alloc && "Failed to create alloc for the async load.");
     triton::AMD::TargetInfo targetInfo(
         getAMDArch(op->getParentOfType<ModuleOp>()));
+
+    ttg::SharedEncodingTrait sharedEncoding = info.sharedEncoding;
+    bool canUseAsyncCopy =
+        loadOp && useAsyncCopy &&
+        canBeConvertedToAsyncLoad(numBuffers, loadOp, sharedEncoding,
+                                  axisInfoAnalysis, targetInfo);
+    if (canUseAsyncCopy && !targetInfo.supportsDirectToLdsScatter()) {
+      sharedEncoding =
+          clampSwizzleForDirectToLds(ty, sharedEncoding, targetInfo);
+      // Clamping changes the shared layout used by the final eligibility
+      // check, so verify that the load remains convertible.
+      canUseAsyncCopy = canBeConvertedToAsyncLoad(
+          numBuffers, loadOp, sharedEncoding, axisInfoAnalysis, targetInfo);
+    }
+
+    // Create the allocation only after final async-copy eligibility is known.
+    // Stream copies retain the original encoding; only the direct-to-LDS path
+    // uses the clamped encoding.
+    if (!canUseAsyncCopy)
+      sharedEncoding = info.sharedEncoding;
+    Value alloc = triton::createAlloc(forOp, ty, op->getLoc(), sharedEncoding,
+                                      numBuffers);
+    assert(alloc && "Failed to create alloc for the async load.");
 
     // Replace the old load with multi-buffered loads
     if (descLoadOp) {
@@ -615,9 +619,7 @@ createStreamOps(const LoadToInfoMap &loadToInfo, scf::ForOp &forOp,
       continue;
     }
 
-    if (useAsyncCopy &&
-        canBeConvertedToAsyncLoad(numBuffers, loadOp, info.sharedEncoding,
-                                  axisInfoAnalysis, targetInfo)) {
+    if (canUseAsyncCopy) {
       unsigned vec = axisInfoAnalysis.getContiguity(loadOp.getPtr());
       if (auto mask = loadOp.getMask())
         vec = std::min<unsigned>(vec, axisInfoAnalysis.getMaskAlignment(mask));

--- a/third_party/amd/lib/TritonAMDGPUTransforms/LowerLoops.cpp
+++ b/third_party/amd/lib/TritonAMDGPUTransforms/LowerLoops.cpp
@@ -376,20 +376,11 @@ bool hasEnoughCTABytesForDirectToLds(tt::LoadOp loadOp,
   return ctaTileBits >= 32 * targetInfo.getWarpSize();
 }
 
-// The GFX9 direct-to-LDS lowering of a swizzled shared encoding assumes the
-// shuffle stays inside the warp, but a wide operand swizzle (e.g. bf16
-// kWidth=8 feeding an f32 direct-to-LDS load) can have a reach larger than the
-// lanes covering the swizzled dimension. Detect that statically for a
-// candidate shared encoding so the caller can shrink the maxPhase before it is
-// committed.
+// Return whether the shared-memory swizzle maps every register and lane of
+// srcTy to a source lane within the same warp.
 static bool
-directToLdsSwizzleStaysInWarp(RankedTensorType srcTy,
-                              ttg::SwizzledSharedEncodingAttr enc,
-                              const tt::AMD::TargetInfo &targetInfo) {
-  // Scatter-capable targets do not use the lane-shuffle swizzle path.
-  if (targetInfo.supportsDirectToLdsScatter())
-    return true;
-
+swizzlesInsideWarp(RankedTensorType srcTy,
+                   ttg::SwizzledSharedEncodingAttr enc) {
   // maxPhase == 1 means no swizzling, so `requiresSrcPtrSwizzling` is false in
   // the lowering and there is no lane shuffle.
   if (!enc || enc.getMaxPhase() == 1)
@@ -398,8 +389,8 @@ directToLdsSwizzleStaysInWarp(RankedTensorType srcTy,
   MLIRContext *ctx = srcTy.getContext();
   auto shape = srcTy.getShape();
 
-  // Mirror the flat (unswizzled) encoding the lowering builds to compute LDS
-  // addresses when gathering into shared memory.
+  // Compare against an otherwise identical unswizzled layout to isolate the
+  // lane displacement introduced by the candidate swizzle.
   auto flatEnc = ttg::SwizzledSharedEncodingAttr::get(
       ctx, enc.getVec(), /*perPhase=*/1, /*maxPhase=*/1, enc.getOrder(),
       enc.getCGALayout());
@@ -425,7 +416,7 @@ directToLdsSwizzleStaysInWarp(RankedTensorType srcTy,
   int64_t warpSize = regToSharedSwizzled.getInDimSize(kLane);
   int64_t numRegs = regToSharedSwizzled.getInDimSize(kRegister);
 
-  for (int32_t regId = 0; regId < numRegs; ++regId) {
+  for (int32_t regId = 0; regId < numRegs; regId += vec) {
     for (int64_t lane = 0; lane < warpSize; ++lane) {
       int32_t swizzledOff = regToSharedSwizzled
                                 .apply({{kRegister, regId},
@@ -452,28 +443,26 @@ directToLdsSwizzleStaysInWarp(RankedTensorType srcTy,
 // maxPhase monotonically reduces the swizzle reach, and maxPhase == 1 always
 // passes, so the search terminates on the largest safe value.
 static ttg::SharedEncodingTrait
-clampSwizzleForDirectToLds(RankedTensorType srcTy, ttg::SharedEncodingTrait enc,
-                           const tt::AMD::TargetInfo &targetInfo) {
+clampSwizzleForDirectToLds(RankedTensorType srcTy,
+                           ttg::SharedEncodingTrait enc) {
   auto swizz = dyn_cast_or_null<ttg::SwizzledSharedEncodingAttr>(enc);
   if (!swizz)
     return enc;
 
-  for (unsigned maxPhase = swizz.getMaxPhase(); maxPhase >= 1; maxPhase /= 2) {
+  for (unsigned maxPhase = swizz.getMaxPhase(); maxPhase > 1; maxPhase /= 2) {
     auto candidate =
         maxPhase == swizz.getMaxPhase()
             ? swizz
             : ttg::SwizzledSharedEncodingAttr::get(
                   swizz.getContext(), swizz.getVec(), swizz.getPerPhase(),
                   maxPhase, swizz.getOrder(), swizz.getCGALayout());
-    if (directToLdsSwizzleStaysInWarp(srcTy, candidate, targetInfo)) {
+    if (swizzlesInsideWarp(srcTy, candidate)) {
       if (candidate != swizz)
         LDBG("Clamped direct-to-LDS swizzle maxPhase "
              << swizz.getMaxPhase() << " -> " << maxPhase
              << " to keep the lane shuffle inside the warp");
       return candidate;
     }
-    if (maxPhase == 1)
-      break;
   }
   // Unreachable: maxPhase == 1 always stays in warp.
   return ttg::SwizzledSharedEncodingAttr::get(
@@ -591,20 +580,22 @@ createStreamOps(const LoadToInfoMap &loadToInfo, scf::ForOp &forOp,
         loadOp && useAsyncCopy &&
         canBeConvertedToAsyncLoad(numBuffers, loadOp, sharedEncoding,
                                   axisInfoAnalysis, targetInfo);
+    // On non-scatter targets, direct-to-LDS realizes the shared-memory swizzle
+    // by shuffling source pointers between lanes, which must stay in one warp.
     if (canUseAsyncCopy && !targetInfo.supportsDirectToLdsScatter()) {
-      sharedEncoding =
-          clampSwizzleForDirectToLds(ty, sharedEncoding, targetInfo);
+      auto clampedEncoding =
+          clampSwizzleForDirectToLds(ty, sharedEncoding);
       // Clamping changes the shared layout used by the final eligibility
       // check, so verify that the load remains convertible.
       canUseAsyncCopy = canBeConvertedToAsyncLoad(
-          numBuffers, loadOp, sharedEncoding, axisInfoAnalysis, targetInfo);
+          numBuffers, loadOp, clampedEncoding, axisInfoAnalysis, targetInfo);
+      if (canUseAsyncCopy)
+        sharedEncoding = clampedEncoding;
     }
 
     // Create the allocation only after final async-copy eligibility is known.
     // Stream copies retain the original encoding; only the direct-to-LDS path
     // uses the clamped encoding.
-    if (!canUseAsyncCopy)
-      sharedEncoding = info.sharedEncoding;
     Value alloc = triton::createAlloc(forOp, ty, op->getLoc(), sharedEncoding,
                                       numBuffers);
     assert(alloc && "Failed to create alloc for the async load.");

--- a/third_party/amd/lib/TritonAMDGPUTransforms/LowerLoops.cpp
+++ b/third_party/amd/lib/TritonAMDGPUTransforms/LowerLoops.cpp
@@ -182,6 +182,10 @@ StreamCopyChainOps createStreamCopy(tt::LoadOp loadOp, Value alloc,
   return {newLoadOp, viewLoad, storeOp, maybeLocalLoad};
 }
 
+static ttg::SharedEncodingTrait
+clampSwizzleForDirectToLds(RankedTensorType srcTy, ttg::SharedEncodingTrait enc,
+                           const tt::AMD::TargetInfo &targetInfo);
+
 // Adapted from
 // lib/Dialect/TritonGPU/Transforms/Utility.cpp::getSharedEncIfAllUsersAreDotEnc
 // to support AMDMfmaEncodingAttr.
@@ -354,6 +358,17 @@ std::optional<ttg::SharedEncodingTrait> getSharedEncIfAllUsersAreDotEnc(
 
   LDBG("Deduced shared encoding: " << maxVecSharedEnc);
 
+  // On GFX9 the direct-to-LDS lowering models the shared swizzle as a
+  // within-warp lane shuffle. If the deduced swizzle would shuffle across the
+  // warp boundary (e.g. a bf16 kWidth=8 operand feeding an f32 async copy),
+  // shrink its maxPhase so the shuffle stays valid instead of miscompiling into
+  // an out-of-bounds global read.
+  if (useAsyncCopy && !targetInfo.supportsDirectToLdsScatter())
+    if (auto ld = dyn_cast<tt::LoadOp>(loadOp))
+      if (auto srcTy = dyn_cast<RankedTensorType>(ld.getResult().getType()))
+        maxVecSharedEnc =
+            clampSwizzleForDirectToLds(srcTy, maxVecSharedEnc, targetInfo);
+
   return maxVecSharedEnc;
 }
 
@@ -374,6 +389,111 @@ bool hasEnoughCTABytesForDirectToLds(tt::LoadOp loadOp,
   int64_t ctaTileBits = mlir::product(ttg::getShapePerCTA(srcTy)) *
                         srcTy.getElementTypeBitWidth();
   return ctaTileBits >= 32 * targetInfo.getWarpSize();
+}
+
+// The GFX9 direct-to-LDS lowering of a swizzled shared encoding assumes the
+// shuffle stays inside the warp, but a wide operand swizzle (e.g. bf16
+// kWidth=8 feeding an f32 direct-to-LDS load) can have a reach larger than the
+// lanes covering the swizzled dimension. Detect that statically for a
+// candidate shared encoding so the caller can shrink the maxPhase before it is
+// committed.
+static bool
+directToLdsSwizzleStaysInWarp(RankedTensorType srcTy,
+                              ttg::SwizzledSharedEncodingAttr enc,
+                              const tt::AMD::TargetInfo &targetInfo) {
+  // Scatter-capable targets do not use the lane-shuffle swizzle path.
+  if (targetInfo.supportsDirectToLdsScatter())
+    return true;
+
+  // maxPhase == 1 means no swizzling, so `requiresSrcPtrSwizzling` is false in
+  // the lowering and there is no lane shuffle.
+  if (!enc || enc.getMaxPhase() == 1)
+    return true;
+
+  MLIRContext *ctx = srcTy.getContext();
+  auto shape = srcTy.getShape();
+
+  // Mirror the flat (unswizzled) encoding the lowering builds to compute LDS
+  // addresses when gathering into shared memory.
+  auto flatEnc = ttg::SwizzledSharedEncodingAttr::get(
+      ctx, enc.getVec(), /*perPhase=*/1, /*maxPhase=*/1, enc.getOrder(),
+      enc.getCGALayout());
+
+  auto regLayout = triton::gpu::toLinearLayout(srcTy);
+  auto sharedSwizz = triton::gpu::toLinearLayout(shape, enc);
+  auto sharedFlat = triton::gpu::toLinearLayout(shape, flatEnc);
+
+  auto regToSharedSwizzled = regLayout.invertAndCompose(sharedSwizz);
+  auto regToSharedFlat = regLayout.invertAndCompose(sharedFlat);
+
+  auto kRegister = StringAttr::get(ctx, "register");
+  auto kLane = StringAttr::get(ctx, "lane");
+  auto kWarp = StringAttr::get(ctx, "warp");
+  auto kBlock = StringAttr::get(ctx, "block");
+
+  // Mirror emitSwizzledLaneOffsets, which normalizes the swizzled-vs-flat
+  // offset delta by the vector size to turn it into a lane offset.
+  int64_t vec = enc.getVec();
+  // Enumerate lanes over the layout's own lane dimension: apply() silently
+  // ignores index bits above the in-dim size, so an out-of-range lane would
+  // alias onto a smaller one and yield a meaningless offset.
+  int64_t warpSize = regToSharedSwizzled.getInDimSize(kLane);
+  int64_t numRegs = regToSharedSwizzled.getInDimSize(kRegister);
+
+  for (int32_t regId = 0; regId < numRegs; ++regId) {
+    for (int64_t lane = 0; lane < warpSize; ++lane) {
+      int32_t swizzledOff = regToSharedSwizzled
+                                .apply({{kRegister, regId},
+                                        {kLane, static_cast<int32_t>(lane)},
+                                        {kWarp, 0},
+                                        {kBlock, 0}})[0]
+                                .second;
+      int32_t flatOff = regToSharedFlat
+                            .apply({{kRegister, regId},
+                                    {kLane, static_cast<int32_t>(lane)},
+                                    {kWarp, 0},
+                                    {kBlock, 0}})[0]
+                            .second;
+      int64_t shuffledLane = lane + (swizzledOff - flatOff) / vec;
+      if (shuffledLane < 0 || shuffledLane >= warpSize)
+        return false;
+    }
+  }
+  return true;
+}
+
+// If a swizzled shared encoding would make the GFX9 direct-to-LDS lane shuffle
+// leave the warp, shrink its maxPhase until the shuffle is valid. Halving
+// maxPhase monotonically reduces the swizzle reach, and maxPhase == 1 always
+// passes, so the search terminates on the largest safe value.
+static ttg::SharedEncodingTrait
+clampSwizzleForDirectToLds(RankedTensorType srcTy, ttg::SharedEncodingTrait enc,
+                           const tt::AMD::TargetInfo &targetInfo) {
+  auto swizz = dyn_cast_or_null<ttg::SwizzledSharedEncodingAttr>(enc);
+  if (!swizz)
+    return enc;
+
+  for (unsigned maxPhase = swizz.getMaxPhase(); maxPhase >= 1; maxPhase /= 2) {
+    auto candidate =
+        maxPhase == swizz.getMaxPhase()
+            ? swizz
+            : ttg::SwizzledSharedEncodingAttr::get(
+                  swizz.getContext(), swizz.getVec(), swizz.getPerPhase(),
+                  maxPhase, swizz.getOrder(), swizz.getCGALayout());
+    if (directToLdsSwizzleStaysInWarp(srcTy, candidate, targetInfo)) {
+      if (candidate != swizz)
+        LDBG("Clamped direct-to-LDS swizzle maxPhase "
+             << swizz.getMaxPhase() << " -> " << maxPhase
+             << " to keep the lane shuffle inside the warp");
+      return candidate;
+    }
+    if (maxPhase == 1)
+      break;
+  }
+  // Unreachable: maxPhase == 1 always stays in warp.
+  return ttg::SwizzledSharedEncodingAttr::get(
+      swizz.getContext(), swizz.getVec(), swizz.getPerPhase(), /*maxPhase=*/1,
+      swizz.getOrder(), swizz.getCGALayout());
 }
 
 bool canBeConvertedToAsyncLoad(unsigned numBuffers, tt::LoadOp loadOp,


### PR DESCRIPTION
<!---
The core Triton is a small number of people, and we receive many PRs (thank
you!).  To help us review your code more quickly, **if you are a new
contributor (less than 3 PRs merged) we ask that you complete the following
tasks and include the filled-out checklist in your PR description.**

Complete the following tasks before sending your PR, and replace `[ ]` with
`[x]` to indicate you have done them.
-->

On targets without direct-to-LDS scatter, the lowering implements a swizzled shared-memory layout by shuffling source pointers between lanes, rather than assigning each lane an arbitrary LDS address. This requires every computed `laneId + swizzleOffset` to remain within `[0, threadsPerWarp)`. However, the shared encoding is derived from the consuming dot operand while lane coverage is determined by the load’s blocked layout. For some combinations, the resulting swizzle spans more chunks than the warp’s lanes cover, causing the shuffle index to cross the warp boundary and select an invalid source pointer.

This PR validates the deduced swizzle against the load’s actual register layout before using it for async copy. If the implied lane permutation leaves the warp, it repeatedly halves the shared encoding’s `maxPhase`, reducing the swizzle’s reach until every shuffle remains in range. Because `maxPhase == 1` disables swizzling, the process always finds a valid encoding while preserving the widest safe swizzle and leaving already-valid encodings unchanged.

# New contributor declaration
- [x] I am not making a trivial change, such as fixing a typo in a comment.

- [x] I have written a PR description following these
  [rules](https://cbea.ms/git-commit/#why-not-how).

- [x] I have run `pre-commit run --from-ref origin/main --to-ref HEAD`.

- Select one of the following.
  - [x] I have added tests.
    - `/test` for `lit` tests
    - `/unittest` for C++ tests
    - `/python/test` for end-to-end tests
  - [ ] This PR does not need a test because `FILL THIS IN`.

- Select one of the following.
  - [ ] I have not added any `lit` tests.
  - [x] The `lit` tests I have added follow these [best practices](https://mlir.llvm.org/getting_started/TestingGuide/#filecheck-best-practices),
    including the "tests should be minimal" section. (Usually running Python code
    and using the instructions it generates is not minimal.)