### PR TITLE
[NVIDIA] Derive NVMMA SMEM attributes instead of scanning for them

### DIFF
--- a/lib/Dialect/TritonNvidiaGPU/IR/NvmmaSmemAttrs.cpp
+++ b/lib/Dialect/TritonNvidiaGPU/IR/NvmmaSmemAttrs.cpp
@@ -8,49 +8,123 @@ namespace ttg = mlir::triton::gpu;
 
 namespace mlir::triton::nvidia_gpu {
 
+namespace {
+
+// Builds the core matrix implied by `attrs` and checks that it tiles
+// `nvmmaSmemLL`. Returns the core matrix, as a map from the two logical dims to
+// offsets, when it does.
+std::optional<LinearLayout> matchCoreMatrix(const LinearLayout &nvmmaSmemLL,
+                                            unsigned bitwidth,
+                                            NvmmaSmemAttrs attrs) {
+  auto dims = llvm::to_vector<2>(nvmmaSmemLL.getInDimNames());
+  auto *ctx = dims[0].getContext();
+  auto offset = StringAttr::get(ctx, "offset");
+  auto block = StringAttr::get(ctx, "block");
+
+  auto enc = ttg::NVMMASharedEncodingAttr::get(
+      ctx, attrs.swizzlingByteWidth, attrs.transposed, std::max(8u, bitwidth),
+      attrs.fp4Padded, ttg::CGAEncodingAttr::get1CTALayout(ctx, /*rank=*/2));
+  auto coreMatrixLL =
+      ttg::getCoreMatrixLinearLayout(enc, /*disableSwizzle=*/false);
+  auto outDims = llvm::to_vector(coreMatrixLL.getOutDims());
+  outDims[0].first = dims[0];
+  outDims[1].first = dims[1];
+  coreMatrixLL = LinearLayout(coreMatrixLL.getBases(), outDims,
+                              /*requireSurjective=*/false);
+  if (bitwidth == 4)
+    coreMatrixLL = LinearLayout::identity1D(2, offset, dims[1]) * coreMatrixLL;
+  if (attrs.transposed)
+    coreMatrixLL = transposeLinearLayout(coreMatrixLL, {1, 0});
+  auto candidateLL = coreMatrixLL.pseudoinvert();
+  // Add a trivial block dimension as getReps expects both layouts to
+  // have the same outdims
+  auto matchLL = candidateLL * LinearLayout::identity1D(1, dims[0], block);
+  if (!getReps(nvmmaSmemLL, matchLL).has_value())
+    return std::nullopt;
+  return candidateLL;
+}
+
+struct CoreMatrixGeometry {
+  unsigned swizzlingByteWidth;
+  bool transposed;
+};
+
+// Recovers the core matrix geometry from the two lowest bases of
+// `nvmmaSmemLL`, so that only the implied core matrix has to be matched.
+//
+// getReps compares a tile's leading bases exactly, so those bases are the core
+// matrix's own. Inverting getCoreMatrixLinearLayout, the contiguous axis maps
+// col 2^k to offset 2^k, and the strided axis maps row 1 to
+// tileCols + swizzle(1), which is distinct for every swizzling mode. fp4Padded
+// only halves swizzle(1), and only for sw=128, so it is left to matching.
+std::optional<CoreMatrixGeometry>
+deriveCoreMatrixGeometry(const LinearLayout &nvmmaSmemLL, unsigned bitwidth) {
+  auto dims = llvm::to_vector<2>(nvmmaSmemLL.getInDimNames());
+  auto *ctx = dims[0].getContext();
+  auto offset = StringAttr::get(ctx, "offset");
+
+  auto lowestBasisIsOne = [&](StringAttr dim) {
+    return nvmmaSmemLL.getInDimSizeLog2(dim) > 0 &&
+           nvmmaSmemLL.getBasis(dim, 0, offset) == 1;
+  };
+  // Only a degenerate layout lets both axes claim offset 1; prefer the
+  // untransposed reading, which matchCoreMatrix then has to confirm.
+  int contig =
+      lowestBasisIsOne(dims[1]) ? 1 : (lowestBasisIsOne(dims[0]) ? 0 : -1);
+  if (contig < 0)
+    return std::nullopt;
+  auto strided = dims[1 - contig];
+  if (nvmmaSmemLL.getInDimSizeLog2(strided) == 0)
+    return std::nullopt;
+
+  int64_t stridedBasis = nvmmaSmemLL.getBasis(strided, 0, offset);
+  // A 4-bit element type is stored as packed pairs, doubling every offset.
+  if (bitwidth == 4) {
+    if (stridedBasis % 2 != 0)
+      return std::nullopt;
+    stridedBasis /= 2;
+  }
+  bool transposed = contig == 0;
+  // In bit units the basis is tileCols * ebw, which is 8 * max(16, swizzling),
+  // plus swizzle(1) * ebw, which is zero below sw=128.
+  switch (stridedBasis * std::max(8u, bitwidth)) {
+  case 8 * 16:
+    return CoreMatrixGeometry{0u, transposed};
+  case 8 * 32:
+    return CoreMatrixGeometry{32u, transposed};
+  case 8 * 64:
+    return CoreMatrixGeometry{64u, transposed};
+  case 8 * 128 + 128: // swizzle(1) is one full vec of 128 bits
+  case 8 * 128 + 64:  // ... which the fp4Padded column packing halves
+    return CoreMatrixGeometry{128u, transposed};
+  default:
+    return std::nullopt;
+  }
+}
+
+} // namespace
+
 std::optional<std::pair<NvmmaSmemAttrs, LinearLayout>>
 getNvmmaSmemAttrs(const LinearLayout &nvmmaSmemLL, unsigned bitwidth) {
   assert(nvmmaSmemLL.getNumInDims() == 2);
   assert(nvmmaSmemLL.getNumOutDims() == 2);
 
-  auto dims = llvm::to_vector<2>(nvmmaSmemLL.getInDimNames());
-  auto *ctx = dims[0].getContext();
-  auto offset = StringAttr::get(ctx, "offset");
-  auto block = StringAttr::get(ctx, "block");
-  assert(nvmmaSmemLL.hasOutDim(offset) && nvmmaSmemLL.hasOutDim(block));
+  [[maybe_unused]] auto dims = llvm::to_vector<2>(nvmmaSmemLL.getInDimNames());
+  [[maybe_unused]] auto *ctx = dims[0].getContext();
+  assert(nvmmaSmemLL.hasOutDim(StringAttr::get(ctx, "offset")) &&
+         nvmmaSmemLL.hasOutDim(StringAttr::get(ctx, "block")));
 
   // TODO: sw=0 is only matched for the MMA "core-matrices" operand form. The
   // other sw=0 interpretation (nvmma_shared<sw=0> as a flat TMA destination) is
   // not supported here.
+  auto geometry = deriveCoreMatrixGeometry(nvmmaSmemLL, bitwidth);
+  if (!geometry)
+    return std::nullopt;
   for (bool fp4Padded : {false, true}) {
-    for (unsigned swizzling : {0u, 32u, 64u, 128u}) {
-      for (bool transposed : {false, true}) {
-        auto enc = ttg::NVMMASharedEncodingAttr::get(
-            ctx, swizzling, transposed, std::max(8u, bitwidth), fp4Padded,
-            ttg::CGAEncodingAttr::get1CTALayout(ctx, /*rank=*/2));
-        auto coreMatrixLL =
-            ttg::getCoreMatrixLinearLayout(enc, /*disableSwizzle=*/false);
-        auto outDims = llvm::to_vector(coreMatrixLL.getOutDims());
-        outDims[0].first = dims[0];
-        outDims[1].first = dims[1];
-        coreMatrixLL = LinearLayout(coreMatrixLL.getBases(), outDims,
-                                    /*requireSurjective=*/false);
-        if (bitwidth == 4)
-          coreMatrixLL =
-              LinearLayout::identity1D(2, offset, dims[1]) * coreMatrixLL;
-        if (transposed)
-          coreMatrixLL = transposeLinearLayout(coreMatrixLL, {1, 0});
-        auto candidateLL = coreMatrixLL.pseudoinvert();
-        // Add a trivial block dimension as getReps expects both layouts to
-        // have the same outdims
-        auto matchLL =
-            candidateLL * LinearLayout::identity1D(1, dims[0], block);
-        if (getReps(nvmmaSmemLL, matchLL).has_value())
-          return std::make_pair(
-              NvmmaSmemAttrs{swizzling, transposed, fp4Padded},
-              std::move(candidateLL));
-      }
-    }
+    NvmmaSmemAttrs attrs{geometry->swizzlingByteWidth, geometry->transposed,
+                         fp4Padded};
+    if (auto coreMatrix = matchCoreMatrix(nvmmaSmemLL, bitwidth, attrs))
+      return std::make_pair(attrs, std::move(*coreMatrix));
   }
   return std::nullopt;
 }

--- a/unittest/Dialect/TritonNvidiaGPU/NvmmaSmemAttrsTest.cpp
+++ b/unittest/Dialect/TritonNvidiaGPU/NvmmaSmemAttrsTest.cpp
@@ -226,5 +226,42 @@ TEST_F(NvmmaSmemAttrsTest, InferNvmmaSmemAttrsRejectsNearMisses) {
   EXPECT_FALSE(inferSharedLinearInfo(std::move(earlyRowInterleave)));
 }
 
+TEST_F(NvmmaSmemAttrsTest, InferNvmmaSmemAttrsFromLinearLayout) {
+  // 256 columns hold a swizzle period for every mode below, so all the
+  // (bitwidth, swizzling) combinations here are representable.
+  SmallVector<int64_t> shape = {256, 256};
+  for (unsigned ebw : {8u, 16u, 32u, 64u}) {
+    for (unsigned sw : {32u, 64u, 128u}) {
+      for (bool transposed : {false, true}) {
+        auto nvmma =
+            nvmmaShared(sw, transposed, ebw, {1, 1}, {1, 1}, {1, 0}, {1, 0});
+        auto inferred =
+            getNvmmaSmemAttrs(toLinearLayout(shape, nvmma).pseudoinvert(), ebw);
+        ASSERT_TRUE(inferred)
+            << "sw=" << sw << " ebw=" << ebw << " transposed=" << transposed;
+        EXPECT_EQ(inferred->first.swizzlingByteWidth, sw);
+        EXPECT_EQ(inferred->first.transposed, transposed);
+        EXPECT_FALSE(inferred->first.fp4Padded);
+      }
+    }
+  }
+
+  // The fp4 operand form, where MMAHelpers halves the bitwidth and prepends a
+  // packing factor along the contiguous dim before matching.
+  for (bool transposed : {false, true}) {
+    auto nvmma = nvmmaShared(128, transposed, /*elementBitWidth=*/8, {1, 1},
+                             {1, 1}, {1, 0}, {1, 0}, /*fp4Padded=*/true);
+    auto ll = toLinearLayout(shape, nvmma).pseudoinvert();
+    auto dims = llvm::to_vector<2>(ll.getInDimNames());
+    auto packed =
+        LinearLayout::identity1D(2, dims[transposed ? 0 : 1], S("offset")) * ll;
+    auto inferred = getNvmmaSmemAttrs(packed, /*bitwidth=*/4);
+    ASSERT_TRUE(inferred) << "transposed=" << transposed;
+    EXPECT_EQ(inferred->first.swizzlingByteWidth, 128u);
+    EXPECT_EQ(inferred->first.transposed, transposed);
+    EXPECT_TRUE(inferred->first.fp4Padded);
+  }
+}
+
 } // namespace
 } // namespace mlir::triton::gpu


### PR DESCRIPTION
# New contributor declaration
- [x ] I am not making a trivial change, such as fixing a typo in a comment.

- [ x] I have written a PR description following these
  [rules](https://cbea.ms/git-commit/#why-not-how).

- [ x] I have run `pre-commit run --from-ref origin/main --to-ref HEAD`.

- Select one of the following.
  - [ x] I have added tests.
    - `/unittest` for C++ tests

- Select one of the following.
  - [x] I have not added any `lit` tests.


### Why

`getNvmmaSmemAttrs` (added in #10475) test 16 candidates for tiling (fp4padded x swizzle x transpose), building encodings and layouts for each. Because getReps compares each leading basis against hte layouts and checks they are equal, we can just solve the latter two parts of that:

- the contiguous axis is the one whose lowest basis is `1`;
- the lowest basis of the strided axis is `tileCols + swizzle(1)`

We still search fp4padded as it repacks within a swizzle phase. 

The helper appears faster (347µs → 54µs for a 256×256 sw=128 16-bit operand; ~7.3x transposed), but that is pretty small beans in the overall ConvertTritonGPUToLLVM - I think net this is a nicer approach, but also if you'd rather not take the change, I do understand! 

### Why it's safe

The derived mode is the same the scan would have returned. If no valid geometry, it returns the same nullopt.  getReps is used for confirmation on the chosen candidate. 

In testing I kept the original path as an oracle, and got same results on each case. 

Added a unit test that covers the scaled branch. Testing on a B200 and correct and MMAv5 suites matched upstream. 