### PR TITLE
[NVIDIA] Enable FP32 warp reductions on datacenter Blackwell and Rubin

### DIFF
--- a/test/Conversion/tritongpu_to_llvm_blackwell_256bit.mlir
+++ b/test/Conversion/tritongpu_to_llvm_blackwell_256bit.mlir
@@ -1,4 +1,5 @@
 // RUN: triton-opt %s -split-input-file --convert-triton-gpu-to-llvm='compute-capability=100 ptx-version=88' -cse | FileCheck --check-prefix=BW256 %s
+// RUN: triton-opt %s -split-input-file --convert-triton-gpu-to-llvm='compute-capability=103 ptx-version=88' -cse | FileCheck --check-prefix=SM103 %s
 // RUN: triton-opt %s -split-input-file --convert-triton-gpu-to-llvm='compute-capability=90 ptx-version=83' -cse | FileCheck --check-prefix=PRE_BW %s
 
 // Test 256-bit global load with 8x f32 (v8.b32) on Blackwell
@@ -68,6 +69,22 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 1 : i32} {
     %5 = tt.splat %arg0 : !tt.ptr<f64> -> tensor<128x!tt.ptr<f64>, #blocked_4xf64>
     %6 = tt.addptr %5, %4 : tensor<128x!tt.ptr<f64>, #blocked_4xf64>, tensor<128xi32, #blocked_4xf64>
     %7 = tt.load %6 : tensor<128x!tt.ptr<f64>, #blocked_4xf64>
+    tt.return
+  }
+}
+
+// -----
+
+#blocked_redux_103 = #ttg.blocked<{sizePerThread = [1, 4], threadsPerWarp = [1, 32], warpsPerCTA = [1, 4], order = [1, 0]}>
+module attributes {"ttg.target" = "cuda:103", "ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, "ttg.threads-per-warp" = 32 : i32} {
+  // SM103-LABEL: @maxnum_reduction_sm103
+  // SM103: nvvm.redux.sync fmax
+  tt.func public @maxnum_reduction_sm103(%arg0: tensor<1x1024xf32, #blocked_redux_103>) {
+    %0 = "tt.reduce"(%arg0) <{axis = 1 : i32}> ({
+    ^bb0(%lhs: f32, %rhs: f32):
+      %1 = arith.maxnumf %lhs, %rhs : f32
+      tt.reduce.return %1 : f32
+    }) {allocation.offset = 0 : i32} : (tensor<1x1024xf32, #blocked_redux_103>) -> tensor<1xf32, #ttg.slice<{dim = 1, parent = #blocked_redux_103}>>
     tt.return
   }
 }

--- a/third_party/nvidia/lib/TritonNVIDIAGPUToLLVM/TargetInfo.cpp
+++ b/third_party/nvidia/lib/TritonNVIDIAGPUToLLVM/TargetInfo.cpp
@@ -97,7 +97,7 @@ matchReduxKind(triton::ReduceOp op, int computeCapability,
   Operation *reduceOp = op.getSingleCombiner();
   if (!reduceOp)
     return std::nullopt;
-  if (computeCapability == 100 && reduceOp->getResultTypes()[0].isF32()) {
+  if (computeCapability / 10 == 10 && reduceOp->getResultTypes()[0].isF32()) {
     if (isa<arith::MinimumFOp, arith::MaximumFOp>(reduceOp))
       useNanQualifier = true;
     if (isa<arith::MaxNumFOp, arith::MaximumFOp>(reduceOp))


### PR DESCRIPTION
Enable native FP32 min/max reductions on GB300 and Rubin
