### PR TITLE
[LANG] Keep bitonic compare-and-swap conditions in predicate form

### DIFF
--- a/python/test/unit/language/test_compile_only.py
+++ b/python/test/unit/language/test_compile_only.py
@@ -40,6 +40,20 @@ def test_topk_valid_k(k):
     triton.compile(src, target=GPUTarget("cuda", 90, 32))
 
 
+def test_compile_only_sort_keeps_comparisons_boolean() -> None:
+
+    @triton.jit
+    def sort_kernel(values, result):
+        offsets = tl.arange(0, 128)
+        loaded = tl.load(values + offsets)
+        sorted_values = tl.sort(loaded, descending=False)
+        tl.store(result + offsets, sorted_values)
+
+    source = ASTSource(fn=sort_kernel, signature={"values": "*i32", "result": "*i32"})
+    compiled = triton.compile(source, target=GPUTarget("cuda", 100, 32))
+    assert "arith.extui" not in compiled.asm["ttgir"]
+
+
 def test_compile_only_sm100() -> None:
 
     @triton.jit

--- a/python/triton/language/standard.py
+++ b/python/triton/language/standard.py
@@ -379,7 +379,7 @@ def _compare_and_swap(x, flip, i: core.constexpr):
     is_right = _indicator(n_dims, i)
 
     # conditional swap:
-    ret = core.where((x > y) != (flip ^ is_right), y, x)
+    ret = core.where((x > y) != (flip ^ is_right).to(core.int1), y, x)
     return ret
 
 


### PR DESCRIPTION
Cast the bitonic direction indicator to int1 before comparing it with the existing floating-point or integer comparison predicate. Both direction inputs are already restricted to zero or one, so this is semantically exact while preventing promotion of every predicate to a 32-bit integer. NVIDIA can then combine the comparison and direction with ISETP.XOR instead of materializing separate SEL/LOP3 sequences.
