### PR TITLE
[GSan] Fix initial mbarrier phase state

### DIFF
--- a/python/test/gsan/test_gsan.py
+++ b/python/test/gsan/test_gsan.py
@@ -458,11 +458,34 @@ def test_gluon_cluster_barriers_in_warp_specialize_synchronize_vector_clocks(wit
 
 
 @gluon.jit
+def _gluon_mbarrier_initial_empty_phase_kernel(out_ptr):
+    data_layout: gl.constexpr = gl.BlockedLayout([1], [32], [4], [0], cga_layout=[[1]])
+    barrier = hopper.mbarrier.allocate_mbarrier(two_ctas=True)
+    hopper.mbarrier.init(barrier, count=1)
+    hopper.mbarrier.wait(barrier, phase=1)
+    offsets = gl.arange(0, 256, data_layout)
+    gl.store(out_ptr + offsets * 0, 1, mask=offsets == 0)
+    hopper.mbarrier.invalidate(barrier)
+
+
+@pytest.mark.skipif(not is_hopper_or_newer(), reason="requires Hopper or newer")
+def test_gluon_mbarrier_initial_empty_phase_is_ready(with_gsan):
+    out = torch.zeros(1, dtype=torch.int32, device="cuda")
+
+    compiled = _gluon_mbarrier_initial_empty_phase_kernel[(1, )](out, num_warps=4, num_ctas=2)
+    assert "__triton_gsan_mbarrier_wait" in compiled.asm["llir"]
+    torch.cuda.synchronize()
+
+    assert out.item() == 1
+
+
+@gluon.jit
 def _gluon_mbarrier_sync_kernel(payload_ptr, out_ptr):
     data_layout: gl.constexpr = gl.BlockedLayout([1], [32], [4], [0], cga_layout=[[1]])
 
     barrier = hopper.mbarrier.allocate_mbarrier(two_ctas=True)
     hopper.mbarrier.init(barrier, count=1)
+    hopper.mbarrier.wait(barrier, phase=1)
     offsets = gl.arange(0, 256, data_layout)
     for iteration in range(4):
         payload_ptrs = payload_ptr + iteration + offsets * 0

--- a/python/triton/experimental/gsan/src/GSan.h
+++ b/python/triton/experimental/gsan/src/GSan.h
@@ -128,7 +128,7 @@ struct MBarrierPublishedClock {
 static_assert(sizeof(MBarrierPublishedClock) == 4);
 
 struct MBarrierPhaseState {
-  // One-based generation tag. Zero denotes an unused phase slot.
+  // One-based generation tag. The initially completed phase 1 has tag zero.
   uint32_t generation;
   uint32_t complete;
   MBarrierPublishedClock clocks[kMaxClusterCTAs];

--- a/python/triton/experimental/gsan/src/GSanLibrary.cu
+++ b/python/triton/experimental/gsan/src/GSanLibrary.cu
@@ -664,7 +664,7 @@ GSAN_DEVICE void initMBarrier(void *scratch, uint32_t offset,
   barrier->generation = 0;
   for (int bank = 0; bank < 2; ++bank) {
     barrier->phases[bank].generation = 0;
-    barrier->phases[bank].complete = 0;
+    barrier->phases[bank].complete = bank;
     for (int source = 0; source < kMaxClusterCTAs; ++source)
       barrier->phases[bank].clocks[source] = {};
   }
@@ -724,8 +724,7 @@ GSAN_DEVICE void acquireMBarrierPhase(GlobalState *globals, void *scratch,
   MBarrierPublishedClock clocks[kMaxClusterCTAs] = {};
   clusterLockAcquire(barrier->lock);
   const auto &phase = barrier->phases[waitPhase];
-  assert_msg(loc,
-             phase.generation != 0 && ((phase.generation - 1) & 1) == waitPhase,
+  assert_msg(loc, ((phase.generation - 1) & 1) == waitPhase,
              "Invalid GSan mbarrier phase state");
   assert_msg(loc, phase.complete,
              "GSan mbarrier wait observed an incomplete phase");


### PR DESCRIPTION
A newly initialized mbarrier starts in phase 0, so waits for phase 1 should succeed immediately. GSan currently marks both phase slots as incomplete and rejects the initial phase-1 generation, causing valid waits to fail.