### PR TITLE
[TRITONGPU] Use real loop-carried distance in the pipelining precondition

### DIFF
--- a/lib/Dialect/TritonGPU/Transforms/Pipeliner/PipeliningUtility.cpp
+++ b/lib/Dialect/TritonGPU/Transforms/Pipeliner/PipeliningUtility.cpp
@@ -154,11 +154,18 @@ Value triton::sinkValueRedefinition(RewriterBase &rewriter, Value in, Value out,
 //===----------------------------------------------------------------------===//
 
 bool mlir::triton::loopHasDistGreaterThanOne(scf::ForOp forOp) {
-  return llvm::any_of(forOp.getBody()->getTerminator()->getOperands(),
-                      [](Value operand) {
-                        Operation *def = operand.getDefiningOp();
-                        return !def;
-                      });
+  // A yielded value has a loop-carried distance greater than one when tracing
+  // it back through the block-argument chain crosses more than one iteration
+  // boundary before reaching a real definition. `getDefinitionAndDistance`
+  // performs that walk and returns a null definition for values that carry no
+  // meaningful distance: the induction variable, implicit captures, and
+  // self-cycles such as a pass-through iter-arg yielded unchanged. Those must
+  // not disqualify the loop from pipelining, so only consider yielded values
+  // that resolve to an actual definition.
+  return llvm::any_of(forOp.getYieldedValues(), [&](Value operand) {
+    auto [def, distance] = getDefinitionAndDistance(forOp, operand);
+    return def && distance > 1;
+  });
 }
 
 bool mlir::triton::isOuterLoop(scf::ForOp forOp) {

--- a/test/TritonGPU/loop-pipeline.mlir
+++ b/test/TritonGPU/loop-pipeline.mlir
@@ -1799,3 +1799,64 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32} {
     tt.return
   }
 }
+
+// -----
+
+// A pass-through iter-arg (%scale, yielded unchanged) has loop-carried distance
+// 1, not greater than one, so the loop must still be pipelined. The precondition
+// used to disqualify any loop that yielded a block argument, which also covered
+// the induction variable and implicit captures.
+// CHECK-LABEL: tt.func @matmul_loop_passthrough_iterarg
+// CHECK: ttg.async_copy_global_to_local
+// CHECK: ttg.async_copy_global_to_local
+#AL = #ttg.blocked<{sizePerThread = [1, 4], threadsPerWarp = [4, 8], warpsPerCTA = [4, 1], order = [1, 0]}>
+#BL = #ttg.blocked<{sizePerThread = [1, 4], threadsPerWarp = [1, 32], warpsPerCTA = [4, 1], order = [1, 0]}>
+#ALs0 = #ttg.slice<{parent=#AL, dim=0}>
+#BLs0 = #ttg.slice<{parent=#BL, dim=0}>
+#C = #ttg.nvidia_mma<{versionMajor = 2, warpsPerCTA = [4, 1], instrShape = [16, 8]}>
+#A = #ttg.dot_op<{opIdx = 0, parent = #C, kWidth=2}>
+#B = #ttg.dot_op<{opIdx = 1, parent = #C, kWidth=2}>
+#smem = #ttg.shared_memory
+module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, "ttg.threads-per-warp" = 32 : i32} {
+tt.func @matmul_loop_passthrough_iterarg(%lb : index, %ub : index, %step : index,
+                  %A : !tt.ptr<f16> {tt.divisibility = 16 : i32},
+                  %B : !tt.ptr<f16> {tt.divisibility = 16 : i32}) -> tensor<128x128xf32, #C> {
+  %a_ptr_splat = tt.splat %A : !tt.ptr<f16> -> tensor<128x32x!tt.ptr<f16>, #AL>
+  %a_tmp0 = tt.make_range {end = 32: i32, start = 0: i32} : tensor<32xi32, #ALs0>
+  %a_tmp1 = tt.expand_dims %a_tmp0 {axis = 0 : i32} : tensor<32xi32, #ALs0> -> tensor<1x32xi32, #AL>
+  %a_offs = tt.broadcast %a_tmp1 : tensor<1x32xi32, #AL> -> tensor<128x32xi32, #AL>
+  %a_ptr_init = tt.addptr %a_ptr_splat, %a_offs : tensor<128x32x!tt.ptr<f16>, #AL>, tensor<128x32xi32, #AL>
+  %b_ptr_splat = tt.splat %B : !tt.ptr<f16> -> tensor<32x128x!tt.ptr<f16>, #BL>
+  %b_tmp0 = tt.make_range {end = 128: i32, start = 0: i32} : tensor<128xi32, #BLs0>
+  %b_tmp1 = tt.expand_dims %b_tmp0 {axis = 0 : i32} : tensor<128xi32, #BLs0> -> tensor<1x128xi32, #BL>
+  %b_offs = tt.broadcast %b_tmp1 : tensor<1x128xi32, #BL> -> tensor<32x128xi32, #BL>
+  %b_ptr_init = tt.addptr %b_ptr_splat, %b_offs : tensor<32x128x!tt.ptr<f16>, #BL>, tensor<32x128xi32, #BL>
+
+
+  %a_mask = arith.constant dense<true> : tensor<128x32xi1, #AL>
+  %a_other = arith.constant dense<0.00e+00> : tensor<128x32xf16, #AL>
+  %b_mask = arith.constant dense<true> : tensor<32x128xi1, #BL>
+  %b_other = arith.constant dense<0.00e+00> : tensor<32x128xf16, #BL>
+  %c_init = arith.constant dense<0.00e+00> : tensor<128x128xf32, #C>
+
+  %a_off = arith.constant dense<4> : tensor<128x32xi32, #AL>
+  %b_off = arith.constant dense<4> : tensor<32x128xi32, #BL>
+
+  %b_scale = arith.constant dense<4.> : tensor<32x128xf16, #B>
+
+  %loop:4 = scf.for %iv = %lb to %ub step %step iter_args(%a_ptr = %a_ptr_init, %b_ptr = %b_ptr_init, %prev_c = %c_init, %scale = %b_scale) -> (tensor<128x32x!tt.ptr<f16>, #AL>, tensor<32x128x!tt.ptr<f16>, #BL>, tensor<128x128xf32, #C>, tensor<32x128xf16, #B>) {
+    %a_ = tt.load %a_ptr : tensor<128x32x!tt.ptr<f16>, #AL>
+    %a = ttg.convert_layout %a_ : tensor<128x32xf16, #AL> -> tensor<128x32xf16, #A>
+    %b__ = tt.load %b_ptr, %b_mask, %b_other : tensor<32x128x!tt.ptr<f16>, #BL>
+    %b_ = ttg.convert_layout %b__ : tensor<32x128xf16, #BL> -> tensor<32x128xf16, #B>
+    %b = arith.mulf %b_, %scale: tensor<32x128xf16, #B>
+
+    %c = tt.dot %a, %b, %prev_c : tensor<128x32xf16, #A> * tensor<32x128xf16, #B> -> tensor<128x128xf32, #C>
+
+    %next_a_ptr = tt.addptr %a_ptr, %a_off : tensor<128x32x!tt.ptr<f16>, #AL>, tensor<128x32xi32, #AL>
+    %next_b_ptr = tt.addptr %b_ptr, %b_off : tensor<32x128x!tt.ptr<f16>, #BL>, tensor<32x128xi32, #BL>
+    scf.yield %next_a_ptr, %next_b_ptr, %c, %scale : tensor<128x32x!tt.ptr<f16>, #AL>, tensor<32x128x!tt.ptr<f16>, #BL>, tensor<128x128xf32, #C>, tensor<32x128xf16, #B>
+  }
+  tt.return %loop#2: tensor<128x128xf32, #C>
+}
+}


### PR DESCRIPTION
`loopHasDistGreaterThanOne` returns true if the loop yields **any** `BlockArgument`:

```cpp
return llvm::any_of(forOp.getBody()->getTerminator()->getOperands(),
                    [](Value operand) { return !operand.getDefiningOp(); });
```

That also covers a pass-through iter-arg (distance 1), the induction variable and implicit captures. `preCondition` then rejects the whole loop from pipelining.

`getDefinitionAndDistance`, 100 lines below in the same file and already used by the expander, walks the block argument chain and returns the real distance. The precondition was strictly more conservative than the transform it guards.

**Impact.** Adding a single pass-through iter-arg (a loop-invariant scale, yielded unchanged) to `matmul_loop` from `test/TritonGPU/loop-pipeline.mlir`:

| | `ttg.async_copy_global_to_local` |
|---|---:|
| unchanged | 6 |
| + pass-through iter-arg, before | 0 |
| + pass-through iter-arg, after | 6 |

**Testing.** Existing `loop-pipeline.mlir` and `pipeline-*.mlir` pass unchanged; added a regression test for the pass-through case.
