### PR TITLE
[TRITONGPU] Accept any dot-like consumer when folding transposes into shared memory

### DIFF
--- a/lib/Dialect/TritonGPU/Transforms/OptimizeDotOperands.cpp
+++ b/lib/Dialect/TritonGPU/Transforms/OptimizeDotOperands.cpp
@@ -27,8 +27,22 @@ public:
 
   LogicalResult matchAndRewrite(ConvertLayoutOp cvtOp,
                                 PatternRewriter &rewriter) const override {
-    if (!cvtOp->hasOneUse() ||
-        !isa<triton::DotOp>(cvtOp->use_begin()->getOwner()))
+    // The rewrite below only reassigns `cvtOp`'s *source*; the result of
+    // `cvtOp` keeps its type (and its DotOperandEncodingAttr) unchanged, and
+    // none of its users are modified. Correctness therefore rests entirely on
+    // the encoding inference below, which is a pure function of the dot-operand
+    // encoding, the pre-transpose source type and the transpose order -- it
+    // never inspects the consuming op. So we can accept any dot-like consumer
+    // (tt.dot, tt.dot_scaled, ttng.warp_group_dot, ...) rather than only
+    // tt.dot, and we can accept several of them sharing the same convert.
+    //
+    // We still require *every* user to be dot-like: the shared-memory
+    // round-trip we introduce is only a win when the value is consumed as an
+    // MMA operand, and a non-dot user would pay for it without benefiting.
+    if (cvtOp->use_empty() ||
+        !llvm::all_of(cvtOp->getUsers(), [](Operation *user) {
+          return isa<triton::DotOpInterface>(user);
+        }))
       return failure();
     // Match outerCvt(trans(innerCvt(x))).
     auto trans = cvtOp.getSrc().getDefiningOp<TransOp>();

--- a/test/TritonGPU/dot-operands.mlir
+++ b/test/TritonGPU/dot-operands.mlir
@@ -100,6 +100,83 @@ module attributes {"ttg.target" = "cuda:80", "ttg.num-ctas" = 1 : i32, "ttg.num-
 
 // -----
 
+// Flash-attention shape: one transposed K tile feeds TWO dots. The rewrite only
+// reassigns the convert's source and leaves its result type untouched, so both
+// dots keep consuming the exact same value and the swizzled shared round-trip is
+// shared between them.
+
+#blocked = #ttg.blocked<{sizePerThread = [16, 1], threadsPerWarp = [32, 1], warpsPerCTA = [4, 1], order = [1, 0]}>
+#blocked1 = #ttg.blocked<{sizePerThread = [1, 16], threadsPerWarp = [1, 32], warpsPerCTA = [1, 4], order = [0, 1]}>
+#mma = #ttg.nvidia_mma<{versionMajor = 2, versionMinor = 0, warpsPerCTA = [4, 1], instrShape = [16, 8]}>
+#smem = #ttg.shared_memory
+module attributes {"ttg.target" = "cuda:80", "ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, "ttg.threads-per-warp" = 32 : i32} {
+// CHECK-LABEL: mmav2_reorder_transpose_two_dots
+// CHECK: ttg.local_alloc
+// CHECK: ttg.memdesc_trans
+// CHECK: %[[T0:.+]] = ttg.local_load
+// CHECK-NOT: tt.trans
+// CHECK: tt.dot %[[T0]]
+// CHECK: tt.dot %[[T0]]
+  tt.func @mmav2_reorder_transpose_two_dots(%t: tensor<32x128xf16, #blocked1>, %dotb: tensor<32x64xf16, #ttg.dot_op<{opIdx = 1, parent = #mma, kWidth = 2}>>, %dotc: tensor<128x64xf32, #mma>) -> (tensor<128x64xf32, #mma>, tensor<128x64xf32, #mma>){
+    %a = tt.trans %t {order = array<i32: 1, 0>} : tensor<32x128xf16, #blocked1> -> tensor<128x32xf16, #blocked>
+    %cv = ttg.convert_layout %a : tensor<128x32xf16, #blocked> -> tensor<128x32xf16, #ttg.dot_op<{opIdx = 0, parent = #mma, kWidth = 2}>>
+    %r0 = tt.dot %cv, %dotb, %dotc, inputPrecision = tf32 : tensor<128x32xf16, #ttg.dot_op<{opIdx = 0, parent = #mma, kWidth = 2}>> * tensor<32x64xf16, #ttg.dot_op<{opIdx = 1, parent = #mma, kWidth = 2}>> -> tensor<128x64xf32, #mma>
+    %r1 = tt.dot %cv, %dotb, %dotc, inputPrecision = tf32 : tensor<128x32xf16, #ttg.dot_op<{opIdx = 0, parent = #mma, kWidth = 2}>> * tensor<32x64xf16, #ttg.dot_op<{opIdx = 1, parent = #mma, kWidth = 2}>> -> tensor<128x64xf32, #mma>
+    tt.return %r0, %r1 : tensor<128x64xf32, #mma>, tensor<128x64xf32, #mma>
+  }
+}
+
+// -----
+
+// tt.dot_scaled is a DotOpInterface op whose operands are ranked tensors, so it
+// can carry a dot-operand encoding and benefits from the same rewrite.
+
+#blocked = #ttg.blocked<{sizePerThread = [16, 1], threadsPerWarp = [32, 1], warpsPerCTA = [4, 1], order = [1, 0]}>
+#blocked1 = #ttg.blocked<{sizePerThread = [1, 16], threadsPerWarp = [1, 32], warpsPerCTA = [1, 4], order = [0, 1]}>
+#mma = #ttg.nvidia_mma<{versionMajor = 2, versionMinor = 0, warpsPerCTA = [4, 1], instrShape = [16, 8]}>
+#smem = #ttg.shared_memory
+module attributes {"ttg.target" = "cuda:80", "ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, "ttg.threads-per-warp" = 32 : i32} {
+// CHECK-LABEL: mmav2_reorder_transpose_dot_scaled
+// CHECK: ttg.local_alloc
+// CHECK: ttg.memdesc_trans
+// CHECK: %[[T0:.+]] = ttg.local_load
+// CHECK-NOT: tt.trans
+// CHECK: tt.dot_scaled %[[T0]]
+  tt.func @mmav2_reorder_transpose_dot_scaled(%t: tensor<32x128xf16, #blocked1>, %dotb: tensor<32x64xf16, #ttg.dot_op<{opIdx = 1, parent = #mma, kWidth = 2}>>, %dotc: tensor<128x64xf32, #mma>) -> tensor<128x64xf32, #mma>{
+    %a = tt.trans %t {order = array<i32: 1, 0>} : tensor<32x128xf16, #blocked1> -> tensor<128x32xf16, #blocked>
+    %cv = ttg.convert_layout %a : tensor<128x32xf16, #blocked> -> tensor<128x32xf16, #ttg.dot_op<{opIdx = 0, parent = #mma, kWidth = 2}>>
+    %r = tt.dot_scaled %cv, %dotb, %dotc lhs = e5m2 rhs = e5m2 {fastMath = false} : tensor<128x32xf16, #ttg.dot_op<{opIdx = 0, parent = #mma, kWidth = 2}>> * tensor<32x64xf16, #ttg.dot_op<{opIdx = 1, parent = #mma, kWidth = 2}>> -> tensor<128x64xf32, #mma>
+    tt.return %r : tensor<128x64xf32, #mma>
+  }
+}
+
+// -----
+
+// Negative test: the convert is consumed by a dot AND by a non-dot op. We
+// deliberately leave this alone -- the shared-memory round-trip only pays off
+// for MMA operands, and the non-dot user would pay the cost without benefiting.
+
+#blocked = #ttg.blocked<{sizePerThread = [16, 1], threadsPerWarp = [32, 1], warpsPerCTA = [4, 1], order = [1, 0]}>
+#blocked1 = #ttg.blocked<{sizePerThread = [1, 16], threadsPerWarp = [1, 32], warpsPerCTA = [1, 4], order = [0, 1]}>
+#mma = #ttg.nvidia_mma<{versionMajor = 2, versionMinor = 0, warpsPerCTA = [4, 1], instrShape = [16, 8]}>
+#smem = #ttg.shared_memory
+module attributes {"ttg.target" = "cuda:80", "ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, "ttg.threads-per-warp" = 32 : i32} {
+// CHECK-LABEL: mmav2_reorder_transpose_mixed_users
+// CHECK-NOT: ttg.local_alloc
+// CHECK: tt.trans
+// CHECK: ttg.convert_layout
+// CHECK: tt.dot
+  tt.func @mmav2_reorder_transpose_mixed_users(%t: tensor<32x128xf16, #blocked1>, %dotb: tensor<32x64xf16, #ttg.dot_op<{opIdx = 1, parent = #mma, kWidth = 2}>>, %dotc: tensor<128x64xf32, #mma>) -> (tensor<128x64xf32, #mma>, tensor<128x32xf32, #ttg.dot_op<{opIdx = 0, parent = #mma, kWidth = 2}>>){
+    %a = tt.trans %t {order = array<i32: 1, 0>} : tensor<32x128xf16, #blocked1> -> tensor<128x32xf16, #blocked>
+    %cv = ttg.convert_layout %a : tensor<128x32xf16, #blocked> -> tensor<128x32xf16, #ttg.dot_op<{opIdx = 0, parent = #mma, kWidth = 2}>>
+    %r = tt.dot %cv, %dotb, %dotc, inputPrecision = tf32 : tensor<128x32xf16, #ttg.dot_op<{opIdx = 0, parent = #mma, kWidth = 2}>> * tensor<32x64xf16, #ttg.dot_op<{opIdx = 1, parent = #mma, kWidth = 2}>> -> tensor<128x64xf32, #mma>
+    %ext = arith.extf %cv : tensor<128x32xf16, #ttg.dot_op<{opIdx = 0, parent = #mma, kWidth = 2}>> to tensor<128x32xf32, #ttg.dot_op<{opIdx = 0, parent = #mma, kWidth = 2}>>
+    tt.return %r, %ext : tensor<128x64xf32, #mma>, tensor<128x32xf32, #ttg.dot_op<{opIdx = 0, parent = #mma, kWidth = 2}>>
+  }
+}
+
+// -----
+
 #blocked = #ttg.blocked<{sizePerThread = [16, 1], threadsPerWarp = [32, 1], warpsPerCTA = [4, 1], order = [1, 0]}>
 #blocked1 = #ttg.blocked<{sizePerThread = [1, 16], threadsPerWarp = [1, 32], warpsPerCTA = [1, 4], order = [0, 1]}>
 #mma = #ttg.nvidia_mma<{versionMajor = 2, versionMinor = 0, warpsPerCTA = [4, 1], instrShape = [16, 8]}>


### PR DESCRIPTION
The transpose-folding pattern required the convert to have exactly one use and that use to be a `triton::DotOp`:

```cpp
if (!cvtOp->hasOneUse() || !isa<triton::DotOp>(cvtOp->use_begin()->getOwner()))
  return failure();
```

Neither narrowing is load-bearing. The rewrite only reassigns the convert's *source*; the result keeps its type and its `DotOperandEncodingAttr`, and no user is modified. Correctness rests on the encoding inference below, which is a pure function of the dot-operand encoding, the pre-transpose source type and the transpose order — it never inspects the consumer. The next pattern in the same file already matches the other dot flavors.

Now matches `DotOpInterface`, so `dot_scaled` and `warp_group_dot` qualify, and allows several dot users to share one convert — the flash-attention shape where a transposed K tile feeds two dots. Every user must still be dot-like, since the shared-memory round trip only pays off for MMA operands.

**Testing.** Existing `dot-operands.mlir` cases pass; added tests for the two-dot shape and for `dot_scaled`. No regressions in `accelerate-matmul.mlir`, `combine.mlir` or `reduce-data-duplication.mlir`.
