### PR TITLE
[ANALYSIS] Fix AxisInfo constancy for signed div/rem with negative inputs

### DIFF
--- a/lib/Analysis/AxisInfo.cpp
+++ b/lib/Analysis/AxisInfo.cpp
@@ -59,6 +59,162 @@ int64_t getDivisibilityFromContiguity(const AxisInfo &lhs, const AxisInfo &rhs,
   }
 }
 
+// Returns true if `v` is provably nonnegative for every element.
+//
+// This is a deliberately cheap, purely local syntactic check: AxisInfo runs as
+// part of the `to-llvm` lowering, i.e. after `scf-to-cf`, so a general
+// SCF-oriented integer-range analysis is not available to us here.  We only
+// need soundness plus enough coverage to keep the common indexing idioms
+// (`tt.make_range`, program ids, and the affine expressions built on top of
+// them) out of the pessimistic path.
+//
+// Any value we cannot classify is treated as possibly negative.
+static bool isProvablyNonNegative(Value v, int depth = 0) {
+  // Bound the recursion so pathological expression trees cannot blow up
+  // compile time.
+  constexpr int kMaxDepth = 6;
+  if (depth > kMaxDepth)
+    return false;
+
+  // An unsigned-typed value is nonnegative by construction. Note Triton/MLIR
+  // integers are signless, so this only fires for genuinely unsigned types.
+  if (auto intTy = dyn_cast<IntegerType>(getElementTypeOrSelf(v.getType())))
+    if (intTy.isUnsigned())
+      return true;
+
+  // An `llvm.intr.assume` of `v >= 0` / `v > 0` anywhere in the same function
+  // lets us treat `v` as nonnegative. Scanning the users of `v` keeps this
+  // cheap, and covers the idiom kernels use to declare that a size or an
+  // index base is nonnegative. This works for block arguments too, which is
+  // why it runs before the defining-op checks below.
+  for (Operation *user : v.getUsers()) {
+    auto cmpOp = dyn_cast<arith::CmpIOp>(user);
+    if (!cmpOp || cmpOp.getLhs() != v)
+      continue;
+    auto pred = cmpOp.getPredicate();
+    if (pred != arith::CmpIPredicate::sge && pred != arith::CmpIPredicate::sgt)
+      continue;
+    // The bound must itself be nonnegative for the assumption to imply
+    // nonnegativity (`v >= -5` says nothing useful). `sgt` against 0 or more
+    // is fine; `sge` needs a nonnegative bound as well.
+    auto boundOp = cmpOp.getRhs().getDefiningOp<arith::ConstantOp>();
+    if (!boundOp)
+      continue;
+    auto boundAttr = dyn_cast<IntegerAttr>(boundOp.getValue());
+    if (!boundAttr)
+      continue;
+    bool boundImpliesNonNegative = pred == arith::CmpIPredicate::sge
+                                       ? boundAttr.getValue().isNonNegative()
+                                       : boundAttr.getValue().sge(-1);
+    if (!boundImpliesNonNegative)
+      continue;
+    // Only trust the comparison if it actually feeds an assume. Require the
+    // assume to sit in the entry block of the enclosing function so that it is
+    // unconditionally executed; an assume nested inside control flow only
+    // holds on the paths that reach it.
+    for (Operation *cmpUser : cmpOp.getResult().getUsers()) {
+      if (cmpUser->getName().getStringRef() != "llvm.intr.assume")
+        continue;
+      auto funcOp = cmpUser->getParentOfType<FunctionOpInterface>();
+      if (funcOp && !funcOp.getFunctionBody().empty() &&
+          cmpUser->getBlock() == &funcOp.getFunctionBody().front())
+        return true;
+    }
+  }
+
+  Operation *defOp = v.getDefiningOp();
+  if (!defOp)
+    return false;
+
+  // Splat/broadcast/reshape/expand_dims and friends are element-preserving, so
+  // nonnegativity passes straight through.
+  if (isa<triton::SplatOp, triton::BroadcastOp, triton::ExpandDimsOp,
+          triton::ReshapeOp, triton::TransOp>(defOp))
+    return isProvablyNonNegative(defOp->getOperand(0), depth + 1);
+
+  // `tt.make_range` has a statically known start, and is ascending, so the
+  // whole range is nonnegative exactly when the start is.  Note getStart()
+  // returns uint32_t even though the attribute is signed, so go through the
+  // attribute to get the correctly-signed value.
+  if (auto rangeOp = dyn_cast<triton::MakeRangeOp>(defOp))
+    return rangeOp.getStartAttr().getInt() >= 0;
+
+  // Program ids and the number of programs are nonnegative by definition.
+  if (isa<triton::GetProgramIdOp, triton::GetNumProgramsOp>(defOp))
+    return true;
+
+  // Constants: check the actual value(s).
+  if (auto constOp = dyn_cast<arith::ConstantOp>(defOp)) {
+    Attribute value = constOp.getValue();
+    if (auto intAttr = dyn_cast<IntegerAttr>(value))
+      return intAttr.getValue().isNonNegative();
+    if (auto denseAttr = dyn_cast<DenseIntElementsAttr>(value)) {
+      return llvm::all_of(denseAttr.getValues<APInt>(),
+                          [](const APInt &v) { return v.isNonNegative(); });
+    }
+    return false;
+  }
+
+  // Closure properties. Addition and multiplication preserve nonnegativity
+  // only in the absence of signed wraparound, so require the `nsw` flag; the
+  // index arithmetic Triton generates carries it.
+  if (isa<arith::AddIOp, arith::MulIOp>(defOp)) {
+    auto iface = dyn_cast<arith::ArithIntegerOverflowFlagsInterface>(defOp);
+    if (!iface || !iface.hasNoSignedWrap())
+      return false;
+    return isProvablyNonNegative(defOp->getOperand(0), depth + 1) &&
+           isProvablyNonNegative(defOp->getOperand(1), depth + 1);
+  }
+
+  // Truncating division and remainder of nonnegative operands stay
+  // nonnegative, as do the unsigned variants (whose results are nonnegative
+  // whenever they fit in the signed range -- which the operands being
+  // nonnegative guarantees).
+  if (isa<arith::DivSIOp, arith::RemSIOp, arith::DivUIOp, arith::RemUIOp>(
+          defOp))
+    return isProvablyNonNegative(defOp->getOperand(0), depth + 1) &&
+           isProvablyNonNegative(defOp->getOperand(1), depth + 1);
+
+  // max(a, b) is nonnegative as soon as either side is; min(a, b) needs both.
+  if (isa<arith::MaxSIOp>(defOp))
+    return isProvablyNonNegative(defOp->getOperand(0), depth + 1) ||
+           isProvablyNonNegative(defOp->getOperand(1), depth + 1);
+  if (isa<arith::MinSIOp>(defOp))
+    return isProvablyNonNegative(defOp->getOperand(0), depth + 1) &&
+           isProvablyNonNegative(defOp->getOperand(1), depth + 1);
+
+  // Unsigned max/min return one of their operands unchanged, so the result is
+  // nonnegative when both inputs are.
+  if (isa<arith::MaxUIOp, arith::MinUIOp>(defOp))
+    return isProvablyNonNegative(defOp->getOperand(0), depth + 1) &&
+           isProvablyNonNegative(defOp->getOperand(1), depth + 1);
+
+  // A logical shift right by a nonzero amount clears the sign bit, so the
+  // result is nonnegative regardless of the input's sign.
+  if (auto shrOp = dyn_cast<arith::ShRUIOp>(defOp)) {
+    if (auto rhsConst = shrOp.getRhs().getDefiningOp<arith::ConstantOp>()) {
+      if (auto intAttr = dyn_cast<IntegerAttr>(rhsConst.getValue()))
+        if (intAttr.getValue().isStrictlyPositive())
+          return true;
+      if (auto denseAttr =
+              dyn_cast<DenseIntElementsAttr>(rhsConst.getValue())) {
+        if (llvm::all_of(denseAttr.getValues<APInt>(), [](const APInt &v) {
+              return v.isStrictlyPositive();
+            }))
+          return true;
+      }
+    }
+    return isProvablyNonNegative(shrOp.getLhs(), depth + 1);
+  }
+
+  // `select` is nonnegative when both arms are.
+  if (auto selOp = dyn_cast<arith::SelectOp>(defOp))
+    return isProvablyNonNegative(selOp.getTrueValue(), depth + 1) &&
+           isProvablyNonNegative(selOp.getFalseValue(), depth + 1);
+
+  return false;
+}
+
 // Base class for all operations
 template <typename OpTy> class AxisInfoVisitorImpl : public AxisInfoVisitor {
 public:
@@ -440,8 +596,25 @@ private:
     // the minimal constancy is gcd(d_lhs, d_rhs).
     // Since gcd(d_lhs, d_rhs) maybe > len(lhs),
     // we need to use another gcd to get the actual constancy.
+    //
+    // This plateau argument relies on the quotient being constant on aligned
+    // blocks of `gcd(...)` elements, which only holds when the numerator is
+    // nonnegative.  `arith.divsi` truncates toward zero, so on the negative
+    // side the plateaus are shifted by one and are no longer aligned to
+    // multiples of the divisor:
+    //
+    //   a    : ... -17 -16 -15 ...  -9  -8  -7 ...  -1   0   1 ...   7   8
+    //   a / 8: ...  -2  -2  -1 ...  -1  -1   0 ...   0   0   0 ...   0   1
+    //
+    // The plateaus on the negative side start at -7, -15, -23, ... rather than
+    // at multiples of 8, so no nontrivial constancy is guaranteed. Note that
+    // this is about the *numerator* only: a negative divisor is harmless
+    // because the quotient's plateau structure depends solely on the sign of
+    // the numerator.
     if (AxisInfoVisitor::isContiguousDim(lhs, shape, dim) &&
-        AxisInfoVisitor::isConstantDim(rhs, shape, dim)) {
+        AxisInfoVisitor::isConstantDim(rhs, shape, dim) &&
+        (!std::is_same_v<OpTy, arith::DivSIOp> ||
+         isProvablyNonNegative(op.getLhs()))) {
       constancy = std::max(constancy,
                            gcd(lhs.getContiguity(dim), lhs.getDivisibility(dim),
                                rhs.getDivisibility(dim)));
@@ -501,8 +674,21 @@ private:
     // The minimal contiguity is gcd(d_lhs, d_rhs).
     // Since gcd(d_lhs, d_rhs) maybe > len(lhs),
     // we need to use another gcd to get the actual contiguity.
+    //
+    // As with `divsi`, the run-of-consecutive-values argument requires a
+    // nonnegative numerator. `arith.remsi` takes the sign of the dividend, so
+    // a contiguous negative input wraps at zero rather than at a multiple of
+    // the divisor:
+    //
+    //   a      : -64 -63 -62 ... -33  -32 -31 ...  -1   0   1
+    //   a % 32 :   0 -31 -30 ...  -1    0 -31 ...  -1   0   1
+    //
+    // The run restarts at a = -64 (giving 0, -31, -30, ...), which is not a
+    // contiguous ascending run, so no nontrivial contiguity is guaranteed.
     if (AxisInfoVisitor::isContiguousDim(lhs, shape, dim) &&
-        AxisInfoVisitor::isConstantDim(rhs, shape, dim)) {
+        AxisInfoVisitor::isConstantDim(rhs, shape, dim) &&
+        (!std::is_same_v<OpTy, arith::RemSIOp> ||
+         isProvablyNonNegative(op.getLhs()))) {
       contiguity = gcd(lhs.getContiguity(dim), lhs.getDivisibility(dim),
                        rhs.getDivisibility(dim));
     }
@@ -516,6 +702,11 @@ private:
       // rhs: d_rhs * p = gcd(d_lhs, d_rhs) * p' * p = gcd(d_lhs, d_rhs) * p''
       // lhs = gcd(d_lhs, d_rhs) * k'' = gcd(d_lhs, d_rhs) * d + r
       // r must be divisible by gcd(d_lhs, d_rhs)
+      //
+      // Unlike the contiguity rule above, this stays valid for negative
+      // operands: r = lhs - (lhs / rhs) * rhs is an integer combination of lhs
+      // and rhs, so it is divisible by gcd(d_lhs, d_rhs) whatever the signs
+      // and whichever way the division rounds.
       return gcd(lhs.getDivisibility(dim), rhs.getDivisibility(dim));
     }
     // Otherwise we shouldn't assume any divisibility.

--- a/test/Analysis/test-alignment.mlir
+++ b/test/Analysis/test-alignment.mlir
@@ -275,6 +275,134 @@ tt.func @rem() {
 
 // -----
 
+// `arith.divsi` truncates toward zero, so the plateaus of the quotient are
+// only aligned to multiples of the divisor when the numerator is nonnegative.
+tt.func @divsi_negative() {
+  // A range that is entirely negative: [-128, -1].
+  // expected-remark @below {{contiguity = [128], divisibility = [128], constancy = [1], constant_value = <none>}}
+  %0 = tt.make_range {end = 0 : i32, start = -128 : i32} : tensor<128xi32>
+  // expected-remark @below {{contiguity = [1], divisibility = [64], constancy = [128], constant_value = 64}}
+  %1 = arith.constant dense<64> : tensor<128xi32>
+  // Truncation toward zero makes the negative plateaus start at -63, -127, ...
+  // rather than at multiples of 64, so no constancy can be claimed.
+  // expected-remark @below {{contiguity = [1], divisibility = [1], constancy = [1], constant_value = <none>}}
+  %2 = arith.divsi %0, %1 : tensor<128xi32>
+
+  // A range straddling zero: [-64, 63]. Same conclusion.
+  // expected-remark @below {{contiguity = [128], divisibility = [64], constancy = [1], constant_value = <none>}}
+  %3 = tt.make_range {end = 64 : i32, start = -64 : i32} : tensor<128xi32>
+  // expected-remark @below {{contiguity = [1], divisibility = [1], constancy = [1], constant_value = <none>}}
+  %4 = arith.divsi %3, %1 : tensor<128xi32>
+
+  // A nonnegative range keeps the original, still-sound constancy.
+  // expected-remark @below {{contiguity = [128], divisibility = [1073741824], constancy = [1], constant_value = <none>}}
+  %5 = tt.make_range {end = 128 : i32, start = 0 : i32} : tensor<128xi32>
+  // expected-remark @below {{contiguity = [1], divisibility = [1], constancy = [64], constant_value = <none>}}
+  %6 = arith.divsi %5, %1 : tensor<128xi32>
+
+  // The sign of the *divisor* does not matter: with a nonnegative numerator
+  // the plateau structure is unchanged, so constancy is still provable.
+  // expected-remark @below {{contiguity = [1], divisibility = [64], constancy = [128], constant_value = -64}}
+  %7 = arith.constant dense<-64> : tensor<128xi32>
+  // expected-remark @below {{contiguity = [1], divisibility = [1], constancy = [64], constant_value = <none>}}
+  %8 = arith.divsi %5, %7 : tensor<128xi32>
+
+  // ... but a negative numerator with a negative divisor is still unprovable.
+  // expected-remark @below {{contiguity = [1], divisibility = [1], constancy = [1], constant_value = <none>}}
+  %9 = arith.divsi %0, %7 : tensor<128xi32>
+
+  // `divui` is unaffected: the operands are unsigned bit patterns.
+  // expected-remark @below {{contiguity = [1], divisibility = [1], constancy = [64], constant_value = <none>}}
+  %10 = arith.divui %0, %1 : tensor<128xi32>
+  tt.return
+}
+
+// -----
+
+// `arith.remsi` takes the sign of the dividend, so a contiguous negative input
+// wraps at zero instead of at a multiple of the divisor.
+tt.func @remsi_negative() {
+  // expected-remark @below {{contiguity = [128], divisibility = [128], constancy = [1], constant_value = <none>}}
+  %0 = tt.make_range {end = 0 : i32, start = -128 : i32} : tensor<128xi32>
+  // expected-remark @below {{contiguity = [1], divisibility = [64], constancy = [128], constant_value = 64}}
+  %1 = arith.constant dense<64> : tensor<128xi32>
+  // [-128, -127, ...] % 64 = [0, -63, -62, ...], which is not a contiguous
+  // ascending run, so no contiguity can be claimed. Divisibility survives:
+  // the remainder is still an integer combination of the two operands.
+  // expected-remark @below {{contiguity = [1], divisibility = [64], constancy = [1], constant_value = <none>}}
+  %2 = arith.remsi %0, %1 : tensor<128xi32>
+
+  // A range straddling zero: [-64, 63]. Same conclusion.
+  // expected-remark @below {{contiguity = [128], divisibility = [64], constancy = [1], constant_value = <none>}}
+  %3 = tt.make_range {end = 64 : i32, start = -64 : i32} : tensor<128xi32>
+  // expected-remark @below {{contiguity = [1], divisibility = [64], constancy = [1], constant_value = <none>}}
+  %4 = arith.remsi %3, %1 : tensor<128xi32>
+
+  // A nonnegative range keeps the original contiguity.
+  // expected-remark @below {{contiguity = [128], divisibility = [1073741824], constancy = [1], constant_value = <none>}}
+  %5 = tt.make_range {end = 128 : i32, start = 0 : i32} : tensor<128xi32>
+  // expected-remark @below {{contiguity = [64], divisibility = [64], constancy = [1], constant_value = <none>}}
+  %6 = arith.remsi %5, %1 : tensor<128xi32>
+
+  // A negative divisor is harmless when the numerator is nonnegative.
+  // expected-remark @below {{contiguity = [1], divisibility = [64], constancy = [128], constant_value = -64}}
+  %7 = arith.constant dense<-64> : tensor<128xi32>
+  // expected-remark @below {{contiguity = [64], divisibility = [64], constancy = [1], constant_value = <none>}}
+  %8 = arith.remsi %5, %7 : tensor<128xi32>
+
+  // `remui` is unaffected.
+  // expected-remark @below {{contiguity = [64], divisibility = [64], constancy = [1], constant_value = <none>}}
+  %9 = arith.remui %0, %1 : tensor<128xi32>
+  tt.return
+}
+
+// -----
+
+// Nonnegativity is propagated through the affine index arithmetic Triton
+// generates, so the common addressing idioms keep their constancy/contiguity.
+tt.func @divsi_remsi_nonneg_propagation(%arg0: i32) {
+  // expected-remark @below {{contiguity = [1], divisibility = [1], constancy = [1], constant_value = <none>}}
+  %pid = tt.get_program_id x : i32
+  // expected-remark @below {{contiguity = [1], divisibility = [128], constancy = [1], constant_value = 128}}
+  %c128 = arith.constant 128 : i32
+  // expected-remark @below {{contiguity = [1], divisibility = [128], constancy = [1], constant_value = <none>}}
+  %off = arith.muli %pid, %c128 overflow<nsw> : i32
+  // expected-remark @below {{contiguity = [128], divisibility = [1073741824], constancy = [1], constant_value = <none>}}
+  %range = tt.make_range {end = 128 : i32, start = 0 : i32} : tensor<128xi32>
+  // expected-remark @below {{contiguity = [1], divisibility = [128], constancy = [128], constant_value = <none>}}
+  %splat = tt.splat %off : i32 -> tensor<128xi32>
+  // pid * 128 + [0, 128) is provably nonnegative.
+  // expected-remark @below {{contiguity = [128], divisibility = [128], constancy = [1], constant_value = <none>}}
+  %idx = arith.addi %splat, %range overflow<nsw> : tensor<128xi32>
+  // expected-remark @below {{contiguity = [1], divisibility = [64], constancy = [128], constant_value = 64}}
+  %c64 = arith.constant dense<64> : tensor<128xi32>
+  // expected-remark @below {{contiguity = [1], divisibility = [1], constancy = [64], constant_value = <none>}}
+  %div = arith.divsi %idx, %c64 : tensor<128xi32>
+  // expected-remark @below {{contiguity = [64], divisibility = [64], constancy = [1], constant_value = <none>}}
+  %rem = arith.remsi %idx, %c64 : tensor<128xi32>
+
+  // Without `nsw` the sum could wrap into the negatives, so we must be
+  // conservative.
+  // expected-remark @below {{contiguity = [128], divisibility = [128], constancy = [1], constant_value = <none>}}
+  %idx_wrap = arith.addi %splat, %range : tensor<128xi32>
+  // expected-remark @below {{contiguity = [1], divisibility = [1], constancy = [1], constant_value = <none>}}
+  %div_wrap = arith.divsi %idx_wrap, %c64 : tensor<128xi32>
+  // expected-remark @below {{contiguity = [1], divisibility = [64], constancy = [1], constant_value = <none>}}
+  %rem_wrap = arith.remsi %idx_wrap, %c64 : tensor<128xi32>
+
+  // An opaque function argument is not provably nonnegative, so the plateau
+  // rule is skipped. The constancy of 128 that remains comes from both
+  // operands being constant along the dimension, which is sound regardless of
+  // sign.
+  // expected-remark @below {{contiguity = [1], divisibility = [1], constancy = [128], constant_value = <none>}}
+  %opaque = tt.splat %arg0 : i32 -> tensor<128xi32>
+  // expected-remark @below {{contiguity = [1], divisibility = [1], constancy = [128], constant_value = <none>}}
+  %div_opaque = arith.divsi %opaque, %c64 : tensor<128xi32>
+  tt.return
+}
+
+// -----
+
 tt.func @expanddims() {
   // expected-remark @below {{contiguity = [128], divisibility = [1073741824], constancy = [1], constant_value = <none>}}
   %0 = tt.make_range {end = 128 : i32, start = 0 : i32} : tensor<128xi32>

--- a/test/Conversion/dedup-by-constancy.mlir
+++ b/test/Conversion/dedup-by-constancy.mlir
@@ -16,10 +16,10 @@ module attributes {"ttg.target" = "cuda:80", "ttg.num-ctas" = 1 : i32, "ttg.num-
     %cst = arith.constant dense<256> : tensor<1024xi32, #blocked>
     %c1024_i32 = arith.constant 1024 : i32
     %0 = tt.get_program_id x : i32
-    %1 = arith.muli %0, %c1024_i32 : i32
+    %1 = arith.muli %0, %c1024_i32 overflow<nsw> : i32
     %2 = tt.make_range {end = 1024 : i32, start = 0 : i32} : tensor<1024xi32, #blocked>
     %3 = tt.splat %1 : i32 -> tensor<1024xi32, #blocked>
-    %4 = arith.addi %3, %2 : tensor<1024xi32, #blocked>
+    %4 = arith.addi %3, %2 overflow<nsw> : tensor<1024xi32, #blocked>
     %5 = tt.splat %arg2 : i32 -> tensor<1024xi32, #blocked>
     %6 = arith.cmpi slt, %4, %5 : tensor<1024xi32, #blocked>
     %7 = arith.divsi %4, %cst : tensor<1024xi32, #blocked>
@@ -54,10 +54,10 @@ module attributes {"ttg.target" = "cuda:80", "ttg.num-ctas" = 1 : i32, "ttg.num-
     %cst = arith.constant dense<4> : tensor<1024xi32, #blocked>
     %c1024_i32 = arith.constant 1024 : i32
     %0 = tt.get_program_id x : i32
-    %1 = arith.muli %0, %c1024_i32 : i32
+    %1 = arith.muli %0, %c1024_i32 overflow<nsw> : i32
     %2 = tt.make_range {end = 1024 : i32, start = 0 : i32} : tensor<1024xi32, #blocked>
     %3 = tt.splat %1 : i32 -> tensor<1024xi32, #blocked>
-    %4 = arith.addi %3, %2 : tensor<1024xi32, #blocked>
+    %4 = arith.addi %3, %2 overflow<nsw> : tensor<1024xi32, #blocked>
     %5 = tt.splat %arg2 : i32 -> tensor<1024xi32, #blocked>
     %6 = arith.cmpi slt, %4, %5 : tensor<1024xi32, #blocked>
     %7 = arith.divsi %4, %cst : tensor<1024xi32, #blocked>

--- a/test/TritonGPU/loop-pipeline-hip.mlir
+++ b/test/TritonGPU/loop-pipeline-hip.mlir
@@ -485,10 +485,14 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 8 : i32, ttg.targ
     %c1_i32 = arith.constant 1 : i32
     %c0_i32 = arith.constant 0 : i32
     %cst_1 = arith.constant dense<0.000000e+00> : tensor<64x64xf32, #mma>
+    // The pid-like argument is nonnegative; `arith.remsi` only keeps its
+    // contiguity for nonnegative numerators.
+    %arg1_nonneg = arith.cmpi sge, %arg1, %c0_i32 : i32
+    llvm.intr.assume %arg1_nonneg : i1
     %0 = tt.make_range {end = 64 : i32, start = 0 : i32} : tensor<64xi32, #ttg.slice<{dim = 0, parent = #blocked1}>>
-    %1 = arith.muli %arg1, %c64_i32 : i32
+    %1 = arith.muli %arg1, %c64_i32 overflow<nsw> : i32
     %2 = tt.splat %1 : i32 -> tensor<64xi32, #ttg.slice<{dim = 0, parent = #blocked1}>>
-    %3 = arith.addi %2, %0 : tensor<64xi32, #ttg.slice<{dim = 0, parent = #blocked1}>>
+    %3 = arith.addi %2, %0 overflow<nsw> : tensor<64xi32, #ttg.slice<{dim = 0, parent = #blocked1}>>
     %4 = tt.splat %arg6 : i32 -> tensor<64xi32, #ttg.slice<{dim = 0, parent = #blocked1}>>
     %5 = arith.remsi %3, %4 : tensor<64xi32, #ttg.slice<{dim = 0, parent = #blocked1}>>
     %6 = tt.make_range {end = 32 : i32, start = 0 : i32} : tensor<32xi32, #ttg.slice<{dim = 0, parent = #blocked}>>


### PR DESCRIPTION
Fixes #7749. `DivOpAxisInfoVisitor` and `RemOpAxisInfoVisitor` compute over-optimistic `constancy` for `arith.divsi` / `arith.remsi` when the numerator can be negative, because signed division truncates toward zero. Over-claimed constancy can drive unsound vectorization.

**Two points beyond the issue report.**

The bug is broader than "ranges straddling zero": an entirely negative range is equally wrong, since truncation shifts the negative-side plateaus by one — they start at -7, -15, -23 rather than at multiples of 8. Verified against an independent model of truncating div/rem.

Only the *numerator's* sign matters. `|a/b|` depends on magnitudes alone, so plateau structure is fixed by the numerator's sign; a negative divisor with a non-negative numerator keeps full constancy and is preserved rather than pessimized. `divui`/`remui` are unaffected.

**Relation to #9802.** That PR diagnosed this correctly but has been stalled since March on a blocker its author identified: it depends on `TritonIntegerRangeAnalysis`, which is SCF-based, while AxisInfo runs after `scf-to-cf`. This keeps its diagnosis and its `overflow<nsw>` / `llvm.intr.assume` test strategy but replaces the analysis port with a local check, so there is no SCF dependency. If maintainers prefer #9802's generality, these guards and test cases drop into it directly.

It also keeps `remsi`'s divisibility rule, which #9802 guards as well. That rule is sign-independent — `r = lhs - (lhs/rhs)*rhs` is an integer combination of two multiples of the gcd — so constancy is recovered there rather than given up, which addresses the performance concern raised on the issue.

**Testing.** 3 new functions / 40 expectations in `test/Analysis/test-alignment.mlir` covering entirely-negative ranges, ranges straddling zero, negative divisors, `nsw` propagation and the `remsi` analogues. Full `test/Analysis` passes (9/9). Two files needed `nsw` added (`dedup-by-constancy.mlir`, `loop-pipeline-hip.mlir`) — the same two #9802 had to touch — since they compute `pid*N + range` without it, which can wrap negative.

Note for reviewers: `MakeRangeOp::getStart()` returns `uint32_t` despite the attribute being signed (`TritonOps.td:881` warns about this), so a naive `>= 0` check is vacuously true; this uses `getStartAttr().getInt()`.
