### PR TITLE
[FRONTEND] Fix int-to-bool conversion in tl.store

### DIFF
--- a/python/test/unit/language/test_core.py
+++ b/python/test/unit/language/test_core.py
@@ -2322,6 +2322,60 @@ def test_store_constant(num_ctas, dtype_str, constant_field, device):
         assert torch.all(output == 0)
 
 
+@pytest.mark.interpreter
+@pytest.mark.parametrize("value", [0, 1, 2, 127, 128, 255, 256, 257, 512, 65536, -1, -256])
+def test_store_int_to_bool(value, device):
+    # Storing an integer through a `bool` pointer must convert with `value != 0`.
+    # Previously the value was truncated to the i8 storage type, so any value
+    # whose low byte was zero (e.g. 256) was silently stored as `False`.
+    # See https://github.com/triton-lang/triton/issues/9991
+
+    @triton.jit
+    def kernel(output_ptr, value):
+        tl.store(output_ptr, value)
+
+    output = torch.zeros([1], dtype=torch.bool, device=device)
+    kernel[(1, )](output, value)
+    assert output[0].item() == (value != 0)
+
+
+@pytest.mark.interpreter
+def test_store_bool_reduction(device):
+    # `tl.sum` over a bool tensor reduces in int32; storing that result into a
+    # bool output must not truncate. 256 `True` values used to yield `False`.
+    # See https://github.com/triton-lang/triton/issues/9991
+
+    @triton.jit
+    def kernel(input_ptr, output_ptr, BLOCK_SIZE: tl.constexpr):
+        offsets = tl.arange(0, BLOCK_SIZE)
+        x = tl.load(input_ptr + offsets)
+        tl.store(output_ptr, tl.sum(x, 0))
+
+    for block_size in [1, 2, 128, 256, 512]:
+        x = torch.ones([block_size], dtype=torch.bool, device=device)
+        output = torch.zeros([1], dtype=torch.bool, device=device)
+        kernel[(1, )](x, output, BLOCK_SIZE=block_size)
+        assert output[0].item() is True
+
+
+@pytest.mark.interpreter
+@pytest.mark.parametrize("dtype_str", ["int8", "int16"])
+@pytest.mark.parametrize("value", [0, 1, 127, 256, 257, 300, 65536, 65537, -1])
+def test_store_int_truncates(dtype_str, value, device):
+    # Narrowing stores to non-bool integer types must keep truncating; only a
+    # `bool` destination compares against zero.
+
+    @triton.jit
+    def kernel(output_ptr, value):
+        tl.store(output_ptr, value)
+
+    dtype = getattr(torch, dtype_str)
+    output = torch.zeros([1], dtype=dtype, device=device)
+    kernel[(1, )](output, value)
+    ref = torch.tensor([value], dtype=torch.int32, device=device).to(dtype)
+    assert output[0].item() == ref[0].item()
+
+
 def test_load_store_same_ptr(device):
 
     @triton.jit()

--- a/python/triton/language/semantic.py
+++ b/python/triton/language/semantic.py
@@ -1212,12 +1212,18 @@ class TritonSemantic(Generic[TensorTy]):
         elt_ty = ptr_ty.element_ty
 
         # Treat `pointer_type<tl.int1>` as `pointer_type<tl.int8>`
-        if elt_ty == tl.int1:
+        is_bool = elt_ty == tl.int1
+        if is_bool:
             elt_ty = tl.int8
             ptr_ty = tl.pointer_type(elt_ty, ptr_ty.address_space)
             ptr = self.cast(ptr, ptr_ty)
 
-        # Cast to target data type
+        # Cast to target data type. For a bool destination the conversion must go
+        # through `tl.int1` first (i.e. `val != 0`) so that values whose low byte
+        # is zero -- e.g. 256 -- do not silently become `False`. Casting straight
+        # to the `tl.int8` storage type would truncate instead of comparing.
+        if is_bool:
+            val = self.cast(val, tl.int1)
         val = self.cast(val, elt_ty)
 
         # Build IR


### PR DESCRIPTION
Fixes #9991 — `tl.sum` over a bool tensor of 256 `True` values stores `False`.

`TritonSemantic.store` rewrites a `pointer_type<int1>` to `pointer_type<int8>` because i1 is stored as a byte, but it does so **before** coercing the value. The following `cast(val, elt_ty)` therefore sees an `int8` destination rather than a boolean one, never reaches the `is_bool` branch that emits `val != 0`, and emits `arith.trunci i32 -> i8`. 256 truncates to 0.

The `load` path already handles this correctly via an `is_bool` flag; the store path lacked the symmetric handling. Float-to-bool stores were already correct.

```
- %1 = arith.trunci %ret : i32 to i8
+ %3 = arith.cmpi ne, %1, %c0_i32 : i32
+ %4 = arith.extui %3 : i1 to i8
```

**Verification** (sm_120). Before: `n=128 -> True`, `n=256 -> False`, `n=512 -> False`. After: all `True`. Integer narrowing is unchanged: `256 -> 0`, `257 -> 1`, `300 -> 44`, `-1 -> -1`, identical before and after.

**Testing.** Three tests added after `test_store_constant`: int-to-bool with values whose low byte is zero, the issue's reduction scenario at sizes 1–512, and 18 guard cases for legitimate narrowing. Without the fix exactly 5 of the 31 new cases fail — the ones with a zero low byte. 501 existing store/cast/load and 740 reduce/sum/bool tests pass, including under `TRITON_INTERPRET=1`.
