### PR TITLE
[TRITONGPU] Avoid selecting lane-degenerate layouts in conflict resolution

### DIFF
--- a/lib/Dialect/TritonGPU/Transforms/RemoveLayoutConversions.cpp
+++ b/lib/Dialect/TritonGPU/Transforms/RemoveLayoutConversions.cpp
@@ -383,11 +383,29 @@ void LayoutPropagation::resolveConflicts() {
     Attribute encoding = *info.encodings.begin();
     bool isLoadOrStore =
         op && isa<LoadOp, StoreOp, AtomicRMWOp, AtomicCASOp>(op);
+    bool foundPreferred = false;
     for (Attribute e : info.encodings) {
       if ((isLoadOrStore && isa<BlockedEncodingAttr>(e)) ||
           (!isLoadOrStore && isa<MmaEncodingTrait>(e))) {
         encoding = e;
+        foundPreferred = true;
         break;
+      }
+    }
+    // Otherwise the choice above is just insertion order. Prefer the candidate
+    // needing the fewest registers per thread: a layout degenerate along lane
+    // or warp replicates elements and multiplies the instructions emitted.
+    if (!foundPreferred) {
+      if (auto tensorType = dyn_cast<RankedTensorType>(it.first.getType())) {
+        ArrayRef<int64_t> shape = tensorType.getShape();
+        unsigned bestElems = getTotalElemsPerThread(encoding, shape);
+        for (Attribute e : info.encodings) {
+          unsigned elems = getTotalElemsPerThread(e, shape);
+          if (elems < bestElems) {
+            bestElems = elems;
+            encoding = e;
+          }
+        }
       }
     }
     info.encodings.clear();

--- a/test/TritonGPU/combine.mlir
+++ b/test/TritonGPU/combine.mlir
@@ -4524,3 +4524,60 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.targ
     tt.return
   }
 }
+
+// -----
+
+// Layout conflict resolution must not pick a candidate that is degenerate along
+// the lane dimension. Here `#linear` has all-zero lane bases, so every lane of a
+// warp holds the same element and each thread would have to execute the divide
+// on 32x more registers than in `#blocked`. Both divides must stay in
+// `#blocked`, and no convert may be introduced to push data into `#linear`.
+
+// CHECK-LABEL: @lane_degenerate_layout_not_selected
+// CHECK-NOT: ttg.convert_layout {{.*}} -> tensor<16x256xf32, #linear>
+// CHECK-COUNT-2: arith.divf {{.*}} : tensor<16x256xf32, #blocked>
+// CHECK-NOT: arith.divf {{.*}} : tensor<16x256xf32, #linear>
+// CHECK: tt.return
+#blocked = #ttg.blocked<{sizePerThread = [1, 8], threadsPerWarp = [1, 32], warpsPerCTA = [4, 1], order = [1, 0]}>
+#linear = #ttg.linear<{register = [[4, 0], [8, 0]], lane = [[0, 0], [0, 0], [0, 0], [0, 0], [0, 0]], warp = [[1, 0], [2, 0]], block = []}>
+module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.target = "cuda:120", "ttg.threads-per-warp" = 32 : i32} {
+  tt.func public @lane_degenerate_layout_not_selected(%a: !tt.ptr<f32>, %out: !tt.ptr<f32>) {
+    %cst = arith.constant dense<256> : tensor<16x1xi32, #blocked>
+    %i0 = tt.make_range {end = 16 : i32, start = 0 : i32} : tensor<16xi32, #ttg.slice<{dim = 1, parent = #blocked}>>
+    %i0_0 = tt.expand_dims %i0 {axis = 1 : i32} : tensor<16xi32, #ttg.slice<{dim = 1, parent = #blocked}>> -> tensor<16x1xi32, #blocked>
+    %i1 = tt.make_range {end = 256 : i32, start = 0 : i32} : tensor<256xi32, #ttg.slice<{dim = 0, parent = #blocked}>>
+    %i1_1 = tt.expand_dims %i1 {axis = 0 : i32} : tensor<256xi32, #ttg.slice<{dim = 0, parent = #blocked}>> -> tensor<1x256xi32, #blocked>
+    %x = arith.muli %i0_0, %cst : tensor<16x1xi32, #blocked>
+    %x_2 = tt.splat %a : !tt.ptr<f32> -> tensor<16x1x!tt.ptr<f32>, #blocked>
+    %x_3 = tt.addptr %x_2, %x : tensor<16x1x!tt.ptr<f32>, #blocked>, tensor<16x1xi32, #blocked>
+    %x_4 = tt.broadcast %x_3 : tensor<16x1x!tt.ptr<f32>, #blocked> -> tensor<16x256x!tt.ptr<f32>, #blocked>
+    %x_5 = tt.broadcast %i1_1 : tensor<1x256xi32, #blocked> -> tensor<16x256xi32, #blocked>
+    %x_6 = tt.addptr %x_4, %x_5 : tensor<16x256x!tt.ptr<f32>, #blocked>, tensor<16x256xi32, #blocked>
+    %x_7 = tt.load %x_6 : tensor<16x256x!tt.ptr<f32>, #blocked>
+    %s = "tt.reduce"(%x_7) <{axis = 1 : i32}> ({
+    ^bb0(%s_17: f32, %s_18: f32):
+      %s_19 = arith.addf %s_17, %s_18 : f32
+      tt.reduce.return %s_19 : f32
+    }) : (tensor<16x256xf32, #blocked>) -> tensor<16xf32, #ttg.slice<{dim = 1, parent = #blocked}>>
+    %s_8 = tt.reshape %s : tensor<16xf32, #ttg.slice<{dim = 1, parent = #blocked}>> -> tensor<16x1xf32, #linear>
+    %y = ttg.convert_layout %s_8 : tensor<16x1xf32, #linear> -> tensor<16x1xf32, #blocked>
+    %y_9 = tt.broadcast %y : tensor<16x1xf32, #blocked> -> tensor<16x256xf32, #blocked>
+    %y_10 = arith.divf %x_7, %y_9 : tensor<16x256xf32, #blocked>
+    %w = arith.divf %y_10, %y_9 : tensor<16x256xf32, #blocked>
+    %z = "tt.reduce"(%w) <{axis = 1 : i32}> ({
+    ^bb0(%z_17: f32, %z_18: f32):
+      %z_19 = arith.addf %z_17, %z_18 : f32
+      tt.reduce.return %z_19 : f32
+    }) : (tensor<16x256xf32, #blocked>) -> tensor<16xf32, #ttg.slice<{dim = 1, parent = #blocked}>>
+    %z_11 = tt.reshape %z : tensor<16xf32, #ttg.slice<{dim = 1, parent = #blocked}>> -> tensor<16x1xf32, #linear>
+    %z_12 = ttg.convert_layout %z_11 : tensor<16x1xf32, #linear> -> tensor<16x1xf32, #blocked>
+    %z_13 = tt.broadcast %z_12 : tensor<16x1xf32, #blocked> -> tensor<16x256xf32, #blocked>
+    %z_15 = arith.addf %z_13, %w : tensor<16x256xf32, #blocked>
+    %0 = tt.splat %out : !tt.ptr<f32> -> tensor<16x1x!tt.ptr<f32>, #blocked>
+    %1 = tt.addptr %0, %x : tensor<16x1x!tt.ptr<f32>, #blocked>, tensor<16x1xi32, #blocked>
+    %2 = tt.broadcast %1 : tensor<16x1x!tt.ptr<f32>, #blocked> -> tensor<16x256x!tt.ptr<f32>, #blocked>
+    %3 = tt.addptr %2, %x_5 : tensor<16x256x!tt.ptr<f32>, #blocked>, tensor<16x256xi32, #blocked>
+    tt.store %3, %z_15 : tensor<16x256x!tt.ptr<f32>, #blocked>
+    tt.return
+  }
+}


### PR DESCRIPTION
Fixes #10987.

`LayoutPropagation::resolveConflicts` prefers blocked encodings for memory ops and MMA encodings otherwise; when neither applies it falls back to `*info.encodings.begin()` — the first candidate that happened to be inserted, which is arbitrary.

That fallback can pick a layout whose lane bases are all zero, so every lane of a warp holds the same element:

```
#linear = #ttg.linear<{register = [[4,0],[8,0]],
                       lane = [[0,0],[0,0],[0,0],[0,0],[0,0]],
                       warp = [[1,0],[2,0]], block = []}>
```

Each thread then materialises 32x more registers than an alternative candidate needs, and every elementwise op placed in that layout is emitted once per duplicated register. In the issue's kernel two sibling divisions get different insertion orders: one resolves to blocked (32 instructions, correct), the other to the degenerate layout (1024 instructions).

`getUniqueElemsPerThread` cannot detect this — it calls `removeZeroBasesAlongDim(kReg)`, register dimension only, so the degenerate layout scores as free. Lane replication also cannot be deduplicated after the fact, since lanes are separate threads executing SIMT; the layout has to be avoided at selection time.

**Change:** when neither existing preference applies, break the tie on `getTotalElemsPerThread` and keep the cheapest candidate. Total rather than unique, for the reason above. No op or shape is named.

**Results** (sm_120):

| | before | after |
|---|---:|---:|
| fp32 divisions | 1056 | 64 |
| PTX lines | 4308 | 3469 |
| compile time | 24.2s | 2s |

Numerics validated against PyTorch: max abs err 6.3e-05.

**Testing:** `@lane_degenerate_layout_not_selected` added to `test/TritonGPU/combine.mlir`; it fails without the patch. `test/TritonGPU/` + `test/Conversion/` sweep matches baseline (75 pass / 1 fail, the failure reproducing unpatched).

The primary branches of `resolveConflicts` remain order-dependent — this only makes the fallback principled.
