### PR TITLE
[ConSan] Track mbarrier publications by phase

### DIFF
--- a/include/triton/Dialect/TritonInstrument/IR/FunctionBuilder.h
+++ b/include/triton/Dialect/TritonInstrument/IR/FunctionBuilder.h
@@ -165,24 +165,26 @@ public:
                                    Value pred, MemType memType,
                                    Operation *insertPoint, Value effectCTAs);
   // trackVisibleAccesses: snapshot the available read and write visibility
-  // frontiers into their independent barrier tracking tables.
+  // frontiers into their independent tracking tables for the barrier's current
+  // phase.
   void createTrackVisibleAccessesCall(ImplicitLocOpBuilder &b, Value mbar,
                                       int thread, Value pred, MemType memType,
                                       Operation *insertPoint, Value barrierCTAs,
                                       Value readBufferMask = nullptr);
-  // trackBarrierWriteForBuffer: mark a specific buffer as tracked by a
-  // barrier in the write-tracking table.
+  // trackBarrierWriteForBuffer: mark a specific buffer as tracked by the
+  // barrier's current phase in the write-tracking table.
   void createTrackBarrierWriteForBufferCall(ImplicitLocOpBuilder &b, Value mbar,
                                             Value bufferMask, Value pred,
                                             MemType memType,
                                             Operation *insertPoint,
                                             Value barrierCTAs,
                                             Value effectCTAs);
-  // transferVisibleAccesses: transfer the barrier's independently tracked
-  // write and read visibility to all threads in threadMask.
+  // transferVisibleAccesses: transfer the requested barrier phase's
+  // independently tracked write and read visibility to all threads in
+  // threadMask.
   void createTransferVisibleAccessesCall(ImplicitLocOpBuilder &b, Value mbar,
-                                         uint64_t threadMask, Value pred,
-                                         MemType memType,
+                                         Value phase, uint64_t threadMask,
+                                         Value pred, MemType memType,
                                          Operation *insertPoint);
   // verifyWriteVisibility: ensure the thread either sees the latest write or no
   // other thread is writing the buffer.
@@ -232,7 +234,7 @@ public:
                                     bool cluster, Value pred,
                                     Operation *insertPoint);
   // trackProxyAccesses: snapshot the current base thread's packed generic
-  // access/fence frontier into a barrier tracking row.
+  // access/fence frontier into the barrier's current phase tracking row.
   void createTrackProxyAccessesCall(ImplicitLocOpBuilder &b, Value mbar,
                                     int thread, Value pred,
                                     Operation *insertPoint, Value barrierCTAs);
@@ -243,10 +245,10 @@ public:
   void createTrackProxyAccessesForBufferCall(
       ImplicitLocOpBuilder &b, Value mbar, Value bufferMask, int thread,
       Value pred, Operation *insertPoint, Value barrierCTAs, Value effectCTAs);
-  // completeBarrierWait: merge the barrier's available proxy frontier and
-  // clear the issuing base thread's waiting flag and phase.
+  // completeBarrierWait: merge the requested barrier phase's proxy frontier
+  // and clear the issuing base thread's waiting flag and phase.
   void createCompleteBarrierWaitCall(ImplicitLocOpBuilder &b, Value mbar,
-                                     int thread, Value pred,
+                                     Value phase, int thread, Value pred,
                                      Operation *insertPoint);
   // verifyProxyAccess: assert that every generic-proxy access visible to the
   // issuing base thread has crossed fence.proxy.async.

--- a/include/triton/Dialect/TritonInstrument/IR/TritonInstrument.md
+++ b/include/triton/Dialect/TritonInstrument/IR/TritonInstrument.md
@@ -94,7 +94,8 @@ At a high level, the pass maintains:
 - A compact state-lane plan and read/write visibility frontiers for those
   lanes.
 - Optional generic-to-async proxy-fence frontiers for shared-memory lanes.
-- Barrier lifecycle, waiting, and barrier-to-buffer tracking state.
+- Barrier lifecycle, waiting, and phase-indexed barrier-to-buffer tracking
+  state.
 - Outstanding commit counters for commit-count-ordered asynchronous flows.
 - A shared-cluster lock that serializes instrumentation updates.
 
@@ -164,18 +165,19 @@ Synchronization transports the packed access-and-fence frontier in the same
 places that ordinary read visibility is transported:
 
 - A frontier-tracked mbarrier arrive copies the issuing base thread's current
-  proxy frontier into the barrier tracking row. The local copy remains live, so
-  an arrive does not make a later async access by the arriving thread legal.
+  proxy frontier into the barrier tracking row for its current phase. The local
+  copy remains live, so an arrive does not make a later async access by the
+  arriving thread legal.
 - An async-proxy write that signals an mbarrier snapshots the issuing base
   thread's frontier at launch time, after its proxy-ordering check, but only for
   physical membership atoms in the write destination. This lets the completion
   wait transport a fence immediately preceding a TMA load without publishing
   bytes outside its destination, including when the destination only partially
   overlaps another logical view.
-- A successful mbarrier wait merges the selected barrier row into the waiting
-  base thread's row. A fence before the wait cannot cover accesses learned only
-  by that wait; a fence after the wait can.
-- Barrier invalidation clears the barrier's proxy tracking row.
+- A successful mbarrier wait merges the tracking row for the requested barrier
+  phase into the waiting base thread's row. A fence before the wait cannot
+  cover accesses learned only by that wait; a fence after the wait can.
+- Barrier invalidation clears both phases of the barrier's proxy tracking row.
 - A non-relaxed publishing cluster barrier transports the proxy frontier across
   CTAs. At top level it publishes to every base-thread row; inside warp
   specialization it publishes only from and to the participating partition's
@@ -241,8 +243,14 @@ operations follow the live-row rule from the CTA model above: all participating
 CTAs address the lead barrier row, and only the lead CTA performs the wait.
 
 For frontier-tracked barriers, an arrive or commit snapshots the current
-thread's visible writes and reads into the barrier's tracking state. A later
-wait transfers that tracked visibility to the waiting thread's peer class.
+thread's visible writes and reads into the tracking slot for the barrier's
+current phase. A later wait transfers visibility from the requested phase to
+the waiting thread's peer class.
+
+Barrier write, read, and generic-to-async proxy publications each have two
+slots indexed by phase parity. Keeping the current and immediately preceding
+phases separate lets a late wait acquire the preceding phase's publications
+without also acquiring publications that already belong to the current phase.
 
 Some effects use precise write tracking instead of frontier tracking. For
 example, NVIDIA TMA and CLC operations can attach only the buffers written by
@@ -258,10 +266,10 @@ On a barrier wait, ConSan:
    phases.
 5. Releases the lock and lets the real wait execute.
 6. Re-acquires the lock after the wait.
-7. Transfers tracked write and read visibility from the barrier to the current
-   thread's peer mask for shared memory and tensor memory.
-8. Transfers the tracked generic-to-async proxy frontier to the current base
-   thread.
+7. Transfers write and read visibility from the requested barrier phase to the
+   current thread's peer mask for shared memory and tensor memory.
+8. Transfers the requested phase's tracked generic-to-async proxy frontier to
+   the current base thread.
 9. Clears the current base thread's waiting bits.
 
 Write transfers also consult the recorded effect-recipient CTA rows, which lets
@@ -289,8 +297,10 @@ ConSan asserts that barriers are initialized before use and not reinitialized
 without invalidation. Arrivals are checked for count underflow and tx-count
 range violations before the shadow barrier state is updated. When both the
 current arrival count and tx-count reach zero, the shadow state flips phase and
-reloads the current count from the initial count. Invalidation clears the
-barrier lifecycle, waiting, read/write tracking, and proxy-fence tracking state.
+reloads the current count from the initial count. The newly current phase's
+recycled publication slot is cleared, while the preceding phase's publications
+remain available to late waiters. Invalidation clears the barrier lifecycle,
+waiting, read/write tracking, and proxy-fence tracking state for both phases.
 
 Deadlock detection records the phase each base thread is waiting on. The check
 aligns those stored phases with each barrier's current phase, filters to active

--- a/include/triton/Dialect/TritonInstrument/IR/Utility.h
+++ b/include/triton/Dialect/TritonInstrument/IR/Utility.h
@@ -183,6 +183,7 @@ struct AuxDataMap {
   //       padded for the distributed layout.
   //   P = base-thread columns used by commit and proxy state, power-of-two
   //       padded.
+  //   F = mbarrier phase parity slots, with extent 2.
   //
   // Storage notation:
   //   tensor  = distributed tensor value.
@@ -204,8 +205,8 @@ struct AuxDataMap {
   // the latest write to the buffer row.
   RegionToValueMap writeVisibility[numMemTypes];
 
-  // scratch, <Cbuf x B x Cbar x K x i8>
-  // Per-memory-type buffer/barrier map for writes that a barrier tracks.
+  // scratch, <Cbuf x B x Cbar x K x F x i8>
+  // Per-memory-type buffer/barrier/phase map for writes that a barrier tracks.
   RegionToValueMap writeTracking[numMemTypes];
 
   // scratch, <Cbuf x B x Cthr x T x Cmask x i64>
@@ -213,9 +214,9 @@ struct AuxDataMap {
   // i64 value is a bitmask of reads visible to that lane's thread.
   RegionToValueMap readVisibility[numMemTypes];
 
-  // scratch, <Cbuf x B x Cbar x K x Cmask x i64>
-  // Per-memory-type buffer/barrier map for read visibility masks that a barrier
-  // tracks.
+  // scratch, <Cbuf x B x Cbar x K x Cmask x F x i64>
+  // Per-memory-type buffer/barrier/phase map for read visibility masks that a
+  // barrier tracks.
   RegionToValueMap readTracking[numMemTypes];
 
   // scratch, <Cbuf x B x Cthr x P x Cmask x i64>
@@ -225,8 +226,9 @@ struct AuxDataMap {
   // that consumer. CTA dimensions distinguish source and consumer CTAs.
   RegionToValueMap proxyAccessVisibility;
 
-  // scratch, <Cbuf x B x Cbar x K x Cmask x i64>
-  // Barrier publication table for packed proxyAccessVisibility state.
+  // scratch, <Cbuf x B x Cbar x K x Cmask x F x i64>
+  // Phase-specific barrier publication table for packed proxyAccessVisibility
+  // state.
   RegionToValueMap proxyAccessTracking;
 
   // scratch, <C x B x P x i8>

--- a/include/triton/Dialect/TritonInstrument/IR/Utility.h
+++ b/include/triton/Dialect/TritonInstrument/IR/Utility.h
@@ -80,7 +80,8 @@ void createAssertInThread(ImplicitLocOpBuilder &b, Value condition,
                           StringRef message);
 Operation *createStoreScratchMemory(OpBuilder &b, Location loc, Value alloc,
                                     Value tensor, RankedTensorType tensorType,
-                                    bool currentCTAOnly = false);
+                                    bool currentCTAOnly = false,
+                                    Value storeMask = nullptr);
 Value createLoadScratchMemory(OpBuilder &b, Location loc, Value alloc,
                               RankedTensorType tensorType);
 gpu::GlobalScratchAllocOp

--- a/lib/Dialect/TritonInstrument/IR/FunctionBuilder.cpp
+++ b/lib/Dialect/TritonInstrument/IR/FunctionBuilder.cpp
@@ -1348,11 +1348,29 @@ void FunctionBuilder::createVerifyAndUpdateBarrierStateCall(
   SmallVector<Value> args = {mbarOffset,       lengthVal,    countVal,
                              txCountVal,       pred,         barriersVal,
                              barrierStatesVal, recipientCTAs};
+  SmallVector<RankedTensorType> trackingTypes;
+  ManglingArgs specializationArgs{barriersType, barrierStatesType};
+  auto appendTracking = [&](AuxDataMap::RegionToValueMap &tracking) {
+    if (tracking.empty())
+      return;
+    ValueType value = tracking.at(insertPoint);
+    auto type = cast<RankedTensorType>(value.type);
+    args.push_back(value.value);
+    trackingTypes.push_back(type);
+    specializationArgs.append(type);
+  };
+  for (MemType memType : {MemType::SHARED_MEM, MemType::TENSOR_MEM}) {
+    appendTracking(auxData.writeTracking[(int)memType]);
+    appendTracking(auxData.readTracking[(int)memType]);
+  }
+  appendTracking(auxData.proxyAccessTracking);
+
   AssertInfo statusInfo{"", b.getI32Type()};
   Value status = createCallToCachedFunction(
       b, "verify_and_update_barrier_state", args, statusInfo,
-      {barriersType, barrierStatesType},
-      [barrierStatesType](ImplicitLocOpBuilder &fb, Block *entryBlock) {
+      specializationArgs,
+      [barrierStatesType, trackingTypes](ImplicitLocOpBuilder &fb,
+                                         Block *entryBlock) {
         Value mbarOffset = entryBlock->getArgument(0);
         Value lengthVal = entryBlock->getArgument(1);
         Value count = entryBlock->getArgument(2);
@@ -1502,6 +1520,41 @@ void FunctionBuilder::createVerifyAndUpdateBarrierStateCall(
         Value updated = arith::SelectOp::create(fb, mask, newState, states);
         createCTAScopedStoreScratchMemory(fb, fb.getLoc(), statesPtr, updated,
                                           barrierStatesType, recipientCTAs);
+
+        if (!trackingTypes.empty()) {
+          Value recipientMask =
+              createCTASetMask(fb, barrierStatesType, /*dim=*/0, recipientCTAs);
+          Value completed = arith::AndIOp::create(fb, zeroCond, recipientMask);
+          Value anyCompleted = reduceAll<arith::OrIOp>(fb, completed);
+          auto [beforeClear, clearBlock, afterClear] =
+              createIfBlock(fb, anyCompleted);
+          fb.setInsertionPointToStart(clearBlock);
+
+          for (auto [index, trackingType] : llvm::enumerate(trackingTypes)) {
+            Value trackingPtr = entryBlock->getArgument(8 + index);
+            Value tracking = tti::createLoadScratchMemory(
+                fb, fb.getLoc(), trackingPtr, trackingType);
+            Value completedMask =
+                convertAndBroadcast(fb, completed, {2, 3}, trackingType);
+            Value nextPhase =
+                convertAndBroadcast(fb, newPhase, {2, 3}, trackingType);
+            auto phaseType = cast<RankedTensorType>(
+                trackingType.cloneWith(std::nullopt, fb.getI32Type()));
+            nextPhase = arith::TruncIOp::create(fb, phaseType, nextPhase);
+            Value phaseIndices =
+                createDimIndices(fb, trackingType, trackingType.getRank() - 1);
+            Value phaseMask = arith::CmpIOp::create(
+                fb, arith::CmpIPredicate::eq, phaseIndices, nextPhase);
+            Value clearMask =
+                arith::AndIOp::create(fb, completedMask, phaseMask);
+            Value zero =
+                tti::createConstIntTensor(fb, fb.getLoc(), 0, trackingType);
+            Value cleared =
+                arith::SelectOp::create(fb, clearMask, zero, tracking);
+            createMaskedStoreScratchMemory(fb, fb.getLoc(), trackingPtr,
+                                           cleared, trackingType, clearMask);
+          }
+        }
 
         fb.setInsertionPointToEnd(thenBlock);
         triton::ReturnOp::create(fb, packedStatus);
@@ -1759,7 +1812,7 @@ void FunctionBuilder::createTrackVisibleAccessesCall(
     ImplicitLocOpBuilder &b, Value mbar, int thread, Value pred,
     MemType memType, Operation *insertPoint, Value barrierCTAs,
     Value readBufferMask) {
-  if (auxData.barriers.empty())
+  if (auxData.barriers.empty() || auxData.barrierStates.empty())
     return;
 
   const bool trackWrites = !readBufferMask &&
@@ -1774,16 +1827,20 @@ void FunctionBuilder::createTrackVisibleAccessesCall(
     pred = arith::ConstantIntOp::create(b, 1, 1);
   ValueType barriers = auxData.barriers.at(insertPoint);
   auto barriersType = cast<RankedTensorType>(barriers.type);
+  ValueType barrierStates = auxData.barrierStates.at(insertPoint);
+  auto barrierStatesType = cast<RankedTensorType>(barrierStates.type);
   SmallVector<Value> args = {
       tti::ExperimentalMemDescToI32Op::create(b, mbar),
       arith::ConstantIntOp::create(b, getMemDescLength(mbar), 32),
       pred,
       arith::ConstantIntOp::create(b, thread, 32),
       barriers.value,
+      barrierStates.value,
       barrierCTAs,
   };
   ManglingArgs specializationArgs;
   specializationArgs.append(barriersType);
+  specializationArgs.append(barrierStatesType);
   specializationArgs.append(static_cast<uint64_t>(trackWrites));
   specializationArgs.append(static_cast<uint64_t>(trackReads));
 
@@ -1820,15 +1877,17 @@ void FunctionBuilder::createTrackVisibleAccessesCall(
                      : "track_visible_accesses",
       args, /*assertInfo=*/std::nullopt, specializationArgs,
       [trackWrites, trackReads, writeVisibilityType, writeTrackingType,
-       readVisibilityType, filterBuffer = static_cast<bool>(readBufferMask),
+       readVisibilityType, barrierStatesType,
+       filterBuffer = static_cast<bool>(readBufferMask),
        readTrackingType](ImplicitLocOpBuilder &fb, Block *entryBlock) {
         Value mbarOffset = entryBlock->getArgument(0);
         Value lengthVal = entryBlock->getArgument(1);
         Value pred = entryBlock->getArgument(2);
         Value threadVal = entryBlock->getArgument(3);
         Value barriers = entryBlock->getArgument(4);
-        Value barrierCTAs = entryBlock->getArgument(5);
-        unsigned nextArg = 6;
+        Value barrierStatesPtr = entryBlock->getArgument(5);
+        Value barrierCTAs = entryBlock->getArgument(6);
+        unsigned nextArg = 7;
 
         auto [prevBlock, ifBlock, thenBlock] = createIfBlock(fb, pred);
         fb.setInsertionPointToStart(ifBlock);
@@ -1836,6 +1895,11 @@ void FunctionBuilder::createTrackVisibleAccessesCall(
         Value barriersEqBar =
             createCmpIntTensorScalar(fb, barriers, descriptor);
         Value currentCTA = createCurrentCTAMask(fb);
+        Value barrierStates = tti::createLoadScratchMemory(
+            fb, fb.getLoc(), barrierStatesPtr, barrierStatesType);
+        Value currentPhases = arith::AndIOp::create(
+            fb, barrierStates,
+            tti::createConstIntTensor(fb, fb.getLoc(), 1, barrierStatesType));
 
         if (trackWrites) {
           Value visibilityPtr = entryBlock->getArgument(nextArg++);
@@ -1849,6 +1913,17 @@ void FunctionBuilder::createTrackVisibleAccessesCall(
           Value barrierCTAMask =
               createCTASetMask(fb, writeTrackingType, /*dim=*/2, barrierCTAs);
           barrierMask = arith::AndIOp::create(fb, barrierMask, barrierCTAMask);
+          Value currentPhase =
+              convertAndBroadcast(fb, currentPhases, {2, 3}, writeTrackingType);
+          Value phaseIndices = createDimIndices(
+              fb, writeTrackingType, /*dim=*/writeTrackingType.getRank() - 1);
+          auto phaseIndicesType =
+              cast<RankedTensorType>(phaseIndices.getType());
+          currentPhase =
+              arith::TruncIOp::create(fb, phaseIndicesType, currentPhase);
+          Value phaseMask = arith::CmpIOp::create(fb, arith::CmpIPredicate::eq,
+                                                  phaseIndices, currentPhase);
+          barrierMask = arith::AndIOp::create(fb, barrierMask, phaseMask);
           Value threadI64 =
               arith::ExtUIOp::create(fb, fb.getI64Type(), threadVal);
           Value one64 = arith::ConstantIntOp::create(fb, 1, 64);
@@ -1896,6 +1971,17 @@ void FunctionBuilder::createTrackVisibleAccessesCall(
             barrierMask = arith::AndIOp::create(fb, barrierMask, bufferMask);
             barrierMask = arith::AndIOp::create(fb, barrierMask, bufferCTAMask);
           }
+          Value currentPhase =
+              convertAndBroadcast(fb, currentPhases, {2, 3}, readTrackingType);
+          Value phaseIndices = createDimIndices(
+              fb, readTrackingType, /*dim=*/readTrackingType.getRank() - 1);
+          auto phaseIndicesType =
+              cast<RankedTensorType>(phaseIndices.getType());
+          currentPhase =
+              arith::TruncIOp::create(fb, phaseIndicesType, currentPhase);
+          Value phaseMask = arith::CmpIOp::create(fb, arith::CmpIPredicate::eq,
+                                                  phaseIndices, currentPhase);
+          barrierMask = arith::AndIOp::create(fb, barrierMask, phaseMask);
           Value threadColumnMask =
               createDimMask(fb, threadVal, readVisibilityType, /*dim=*/3);
           Value zero =
@@ -1926,7 +2012,8 @@ void FunctionBuilder::createTrackBarrierWriteForBufferCall(
     ImplicitLocOpBuilder &b, Value mbar, Value bufferMask, Value pred,
     MemType memType, Operation *insertPoint, Value barrierCTAs,
     Value effectCTAs) {
-  if (auxData.barriers.empty() || auxData.writeTracking[(int)memType].empty()) {
+  if (auxData.barriers.empty() || auxData.barrierStates.empty() ||
+      auxData.writeTracking[(int)memType].empty()) {
     return;
   }
   if (!pred)
@@ -1938,30 +2025,38 @@ void FunctionBuilder::createTrackBarrierWriteForBufferCall(
       auxData.writeTracking[(int)memType].at(insertPoint).value;
   auto writeTrackingType = cast<RankedTensorType>(
       auxData.writeTracking[(int)memType].at(insertPoint).type);
+  Value barrierStatesVal = auxData.barrierStates.at(insertPoint).value;
+  auto barrierStatesType =
+      cast<RankedTensorType>(auxData.barrierStates.at(insertPoint).type);
   uint32_t mbarLength = getMemDescLength(mbar);
   Value mbarOffset = tti::ExperimentalMemDescToI32Op::create(b, mbar);
   Value mbarLengthVal = arith::ConstantIntOp::create(b, mbarLength, 32);
-  SmallVector<Value> args = {mbarOffset,  mbarLengthVal, pred,
-                             bufferMask,  barriersVal,   writeTrackingVal,
-                             barrierCTAs, effectCTAs};
+  SmallVector<Value> args = {mbarOffset,       mbarLengthVal, pred,
+                             bufferMask,       barriersVal,   writeTrackingVal,
+                             barrierStatesVal, barrierCTAs,   effectCTAs};
   createCallToCachedFunction(
       b, "track_barrier_write_for_buffer", args,
-      /*assertInfo=*/std::nullopt, {barriersType, writeTrackingType},
-      [writeTrackingType](ImplicitLocOpBuilder &fb, Block *entryBlock) {
+      /*assertInfo=*/std::nullopt,
+      {barriersType, writeTrackingType, barrierStatesType},
+      [writeTrackingType, barrierStatesType](ImplicitLocOpBuilder &fb,
+                                             Block *entryBlock) {
         Value mbarOffset = entryBlock->getArgument(0);
         Value mbarLengthVal = entryBlock->getArgument(1);
         Value pred = entryBlock->getArgument(2);
         Value bufferMask = entryBlock->getArgument(3);
         Value barriers = entryBlock->getArgument(4);
         Value writeTrackingPtr = entryBlock->getArgument(5);
-        Value barrierCTAs = entryBlock->getArgument(6);
-        Value effectCTAs = entryBlock->getArgument(7);
+        Value barrierStatesPtr = entryBlock->getArgument(6);
+        Value barrierCTAs = entryBlock->getArgument(7);
+        Value effectCTAs = entryBlock->getArgument(8);
 
         auto [prevBlock, ifBlock, thenBlock] = createIfBlock(fb, pred);
         fb.setInsertionPointToStart(ifBlock);
 
         Value writeTracking = tti::createLoadScratchMemory(
             fb, fb.getLoc(), writeTrackingPtr, writeTrackingType);
+        Value barrierStates = tti::createLoadScratchMemory(
+            fb, fb.getLoc(), barrierStatesPtr, barrierStatesType);
         Value barrierDescriptor =
             createBufferDescriptor(fb, mbarOffset, mbarLengthVal);
         Value barriersEqBar =
@@ -1977,6 +2072,19 @@ void FunctionBuilder::createTrackBarrierWriteForBufferCall(
         Value trackMask = arith::AndIOp::create(fb, barriersEqBar, bufferMask);
         trackMask = arith::AndIOp::create(fb, trackMask, bufferCTAMask);
         trackMask = arith::AndIOp::create(fb, trackMask, barrierCTAMask);
+        Value phaseOne =
+            tti::createConstIntTensor(fb, fb.getLoc(), 1, barrierStatesType);
+        Value currentPhase = arith::AndIOp::create(fb, barrierStates, phaseOne);
+        currentPhase =
+            convertAndBroadcast(fb, currentPhase, {2, 3}, writeTrackingType);
+        Value phaseIndices = createDimIndices(
+            fb, writeTrackingType, /*dim=*/writeTrackingType.getRank() - 1);
+        auto phaseIndicesType = cast<RankedTensorType>(phaseIndices.getType());
+        currentPhase =
+            arith::TruncIOp::create(fb, phaseIndicesType, currentPhase);
+        Value phaseMask = arith::CmpIOp::create(fb, arith::CmpIPredicate::eq,
+                                                phaseIndices, currentPhase);
+        trackMask = arith::AndIOp::create(fb, trackMask, phaseMask);
         Value writeTrackingOne =
             tti::createConstIntTensor(fb, fb.getLoc(), 1, writeTrackingType);
         Value newTracking = arith::SelectOp::create(
@@ -2047,8 +2155,8 @@ void FunctionBuilder::createClearBarrierStorageTrackingCall(
 }
 
 void FunctionBuilder::createTransferVisibleAccessesCall(
-    ImplicitLocOpBuilder &b, Value mbar, uint64_t threadMask, Value pred,
-    MemType memType, Operation *insertPoint) {
+    ImplicitLocOpBuilder &b, Value mbar, Value phase, uint64_t threadMask,
+    Value pred, MemType memType, Operation *insertPoint) {
   if (auxData.barriers.empty())
     return;
 
@@ -2067,6 +2175,7 @@ void FunctionBuilder::createTransferVisibleAccessesCall(
   SmallVector<Value> args = {
       tti::ExperimentalMemDescToI32Op::create(b, mbar),
       arith::ConstantIntOp::create(b, getMemDescLength(mbar), 32),
+      phase,
       pred,
       threadMaskVal,
       barriers.value,
@@ -2109,10 +2218,11 @@ void FunctionBuilder::createTransferVisibleAccessesCall(
        readTrackingType](ImplicitLocOpBuilder &fb, Block *entryBlock) {
         Value mbarOffset = entryBlock->getArgument(0);
         Value lengthVal = entryBlock->getArgument(1);
-        Value pred = entryBlock->getArgument(2);
-        Value threadMaskVal = entryBlock->getArgument(3);
-        Value barriers = entryBlock->getArgument(4);
-        unsigned nextArg = 5;
+        Value phase = entryBlock->getArgument(2);
+        Value pred = entryBlock->getArgument(3);
+        Value threadMaskVal = entryBlock->getArgument(4);
+        Value barriers = entryBlock->getArgument(5);
+        unsigned nextArg = 6;
 
         auto [prevBlock, ifBlock, thenBlock] = createIfBlock(fb, pred);
         fb.setInsertionPointToStart(ifBlock);
@@ -2120,6 +2230,9 @@ void FunctionBuilder::createTransferVisibleAccessesCall(
         Value barriersEqBar =
             createCmpIntTensorScalar(fb, barriers, descriptor);
         Value currentCTA = createCurrentCTAMask(fb);
+        Value phaseI32 = adjustIntegerWidth(fb, phase, fb.getI32Type());
+        phaseI32 = arith::AndIOp::create(
+            fb, phaseI32, arith::ConstantIntOp::create(fb, 1, 32));
 
         if (transferWrites) {
           Value visibilityPtr = entryBlock->getArgument(nextArg++);
@@ -2133,11 +2246,16 @@ void FunctionBuilder::createTransferVisibleAccessesCall(
           Value barrierCTAMask =
               createCTASetMask(fb, writeTrackingType, /*dim=*/2, currentCTA);
           barrierMask = arith::AndIOp::create(fb, barrierMask, barrierCTAMask);
+          int phaseDim = writeTrackingType.getRank() - 1;
+          Value phaseMask =
+              createDimMask(fb, phaseI32, writeTrackingType, phaseDim);
+          barrierMask = arith::AndIOp::create(fb, barrierMask, phaseMask);
           Value zeroTracking =
               tti::createConstIntTensor(fb, fb.getLoc(), 0, writeTrackingType);
           Value trackingBuffers =
               arith::SelectOp::create(fb, barrierMask, tracking, zeroTracking);
-          trackingBuffers = reduce<arith::OrIOp>(fb, trackingBuffers, {2, 3});
+          trackingBuffers =
+              reduce<arith::OrIOp>(fb, trackingBuffers, {2, 3, phaseDim});
           trackingBuffers = convertAndBroadcast(fb, trackingBuffers, {0, 1},
                                                 writeVisibilityType);
           auto trackingBuffersType =
@@ -2178,11 +2296,15 @@ void FunctionBuilder::createTransferVisibleAccessesCall(
           Value barrierCTAMask =
               createCTASetMask(fb, readTrackingType, /*dim=*/2, currentCTA);
           barrierMask = arith::AndIOp::create(fb, barrierMask, barrierCTAMask);
+          int phaseDim = readTrackingType.getRank() - 1;
+          Value phaseMask =
+              createDimMask(fb, phaseI32, readTrackingType, phaseDim);
+          barrierMask = arith::AndIOp::create(fb, barrierMask, phaseMask);
           Value zeroTracking =
               tti::createConstIntTensor(fb, fb.getLoc(), 0, readTrackingType);
           Value trackingBar =
               arith::SelectOp::create(fb, barrierMask, tracking, zeroTracking);
-          trackingBar = reduce<arith::OrIOp>(fb, trackingBar, {2, 3});
+          trackingBar = reduce<arith::OrIOp>(fb, trackingBar, {2, 3, phaseDim});
           trackingBar = convertAndBroadcast(fb, trackingBar, {0, 1, 4},
                                             readVisibilityType);
           Value visibilityOrTracking =
@@ -2798,7 +2920,8 @@ void FunctionBuilder::createSetProxyAccessCall(ImplicitLocOpBuilder &b,
 
         // A new generic access supersedes fence coverage for an older access
         // from the same source. Clear that source's fence bit in outstanding
-        // barrier snapshots as well, so an old publication cannot mask it.
+        // barrier snapshots from either phase as well, so an old publication
+        // cannot mask it.
         if (hasTracking) {
           Value tracking = tti::createLoadScratchMemory(
               fb, fb.getLoc(), trackingPtr, trackingType);
@@ -2899,15 +3022,18 @@ void FunctionBuilder::createTrackProxyAccessesCallImpl(
     Operation *insertPoint, Value barrierCTAs, Value bufferMask,
     Value effectCTAs) {
   bool filterByBuffer = static_cast<bool>(bufferMask);
-  if (auxData.barriers.empty() || auxData.proxyAccessVisibility.empty() ||
+  if (auxData.barriers.empty() || auxData.barrierStates.empty() ||
+      auxData.proxyAccessVisibility.empty() ||
       auxData.proxyAccessTracking.empty())
     return;
   if (!pred)
     pred = arith::ConstantIntOp::create(b, 1, 1);
   ValueType barriers = auxData.barriers.at(insertPoint);
+  ValueType barrierStates = auxData.barrierStates.at(insertPoint);
   ValueType visibility = auxData.proxyAccessVisibility.at(insertPoint);
   ValueType tracking = auxData.proxyAccessTracking.at(insertPoint);
   auto barriersType = cast<RankedTensorType>(barriers.type);
+  auto barrierStatesType = cast<RankedTensorType>(barrierStates.type);
   auto visibilityType = cast<RankedTensorType>(visibility.type);
   auto trackingType = cast<RankedTensorType>(tracking.type);
   SmallVector<Value> args = {
@@ -2916,10 +3042,12 @@ void FunctionBuilder::createTrackProxyAccessesCallImpl(
       pred,
       arith::ConstantIntOp::create(b, thread, 32),
       barriers.value,
+      barrierStates.value,
       visibility.value,
       tracking.value,
       barrierCTAs};
-  ManglingArgs specializationArgs{barriersType, visibilityType, trackingType};
+  ManglingArgs specializationArgs{barriersType, barrierStatesType,
+                                  visibilityType, trackingType};
   if (filterByBuffer) {
     args.append({bufferMask, effectCTAs});
   }
@@ -2928,23 +3056,26 @@ void FunctionBuilder::createTrackProxyAccessesCallImpl(
       filterByBuffer ? "track_proxy_accesses_for_buffer"
                      : "track_proxy_accesses",
       args, /*assertInfo=*/std::nullopt, specializationArgs,
-      [visibilityType, trackingType, filterByBuffer](ImplicitLocOpBuilder &fb,
-                                                     Block *entryBlock) {
+      [barrierStatesType, visibilityType, trackingType,
+       filterByBuffer](ImplicitLocOpBuilder &fb, Block *entryBlock) {
         Value mbarOffset = entryBlock->getArgument(0);
         Value lengthVal = entryBlock->getArgument(1);
         Value pred = entryBlock->getArgument(2);
         Value threadVal = entryBlock->getArgument(3);
         Value barriers = entryBlock->getArgument(4);
-        Value visibilityPtr = entryBlock->getArgument(5);
-        Value trackingPtr = entryBlock->getArgument(6);
-        Value barrierCTAs = entryBlock->getArgument(7);
+        Value barrierStatesPtr = entryBlock->getArgument(5);
+        Value visibilityPtr = entryBlock->getArgument(6);
+        Value trackingPtr = entryBlock->getArgument(7);
+        Value barrierCTAs = entryBlock->getArgument(8);
         Value completeMask =
-            filterByBuffer ? entryBlock->getArgument(8) : Value();
-        Value effectCTAs =
             filterByBuffer ? entryBlock->getArgument(9) : Value();
+        Value effectCTAs =
+            filterByBuffer ? entryBlock->getArgument(10) : Value();
 
         auto [prevBlock, ifBlock, thenBlock] = createIfBlock(fb, pred);
         fb.setInsertionPointToStart(ifBlock);
+        Value barrierStates = tti::createLoadScratchMemory(
+            fb, fb.getLoc(), barrierStatesPtr, barrierStatesType);
         Value visibility = tti::createLoadScratchMemory(
             fb, fb.getLoc(), visibilityPtr, visibilityType);
         Value tracking = tti::createLoadScratchMemory(
@@ -2981,6 +3112,19 @@ void FunctionBuilder::createTrackProxyAccessesCallImpl(
             createCTASetMask(fb, trackingType, /*dim=*/2, barrierCTAs);
         Value trackMask =
             arith::AndIOp::create(fb, barriersEqBar, barrierCTAMask);
+        Value currentPhases = arith::AndIOp::create(
+            fb, barrierStates,
+            tti::createConstIntTensor(fb, fb.getLoc(), 1, barrierStatesType));
+        currentPhases =
+            convertAndBroadcast(fb, currentPhases, {2, 3}, trackingType);
+        Value phaseIndices =
+            createDimIndices(fb, trackingType, trackingType.getRank() - 1);
+        auto phaseIndicesType = cast<RankedTensorType>(phaseIndices.getType());
+        currentPhases =
+            arith::TruncIOp::create(fb, phaseIndicesType, currentPhases);
+        Value phaseMask = arith::CmpIOp::create(fb, arith::CmpIPredicate::eq,
+                                                currentPhases, phaseIndices);
+        trackMask = arith::AndIOp::create(fb, trackMask, phaseMask);
         if (filterByBuffer) {
           Value trackingBuffers =
               convertAndBroadcast(fb, containedBuffers, {1}, trackingType);
@@ -2992,9 +3136,8 @@ void FunctionBuilder::createTrackProxyAccessesCallImpl(
         Value withSource = arith::OrIOp::create(fb, tracking, source);
         Value updated =
             arith::SelectOp::create(fb, trackMask, withSource, tracking);
-        Value storeMask = filterByBuffer ? trackMask : barrierCTAMask;
         createMaskedStoreScratchMemory(fb, fb.getLoc(), trackingPtr, updated,
-                                       trackingType, storeMask);
+                                       trackingType, trackMask);
 
         fb.setInsertionPointToEnd(thenBlock);
         triton::ReturnOp::create(fb);
@@ -3002,8 +3145,8 @@ void FunctionBuilder::createTrackProxyAccessesCallImpl(
 }
 
 void FunctionBuilder::createCompleteBarrierWaitCall(ImplicitLocOpBuilder &b,
-                                                    Value mbar, int thread,
-                                                    Value pred,
+                                                    Value mbar, Value phase,
+                                                    int thread, Value pred,
                                                     Operation *insertPoint) {
   if (auxData.barriers.empty())
     return;
@@ -3024,6 +3167,7 @@ void FunctionBuilder::createCompleteBarrierWaitCall(ImplicitLocOpBuilder &b,
   SmallVector<Value> args = {
       tti::ExperimentalMemDescToI32Op::create(b, mbar),
       arith::ConstantIntOp::create(b, getMemDescLength(mbar), 32),
+      phase,
       pred,
       arith::ConstantIntOp::create(b, thread, 32),
       barriers.value,
@@ -3050,11 +3194,12 @@ void FunctionBuilder::createCompleteBarrierWaitCall(ImplicitLocOpBuilder &b,
        waitingType](ImplicitLocOpBuilder &fb, Block *entryBlock) {
         Value mbarOffset = entryBlock->getArgument(0);
         Value lengthVal = entryBlock->getArgument(1);
-        Value pred = entryBlock->getArgument(2);
-        Value threadVal = entryBlock->getArgument(3);
-        Value barriers = entryBlock->getArgument(4);
-        Value visibilityPtr = entryBlock->getArgument(5);
-        Value trackingPtr = entryBlock->getArgument(6);
+        Value phase = entryBlock->getArgument(2);
+        Value pred = entryBlock->getArgument(3);
+        Value threadVal = entryBlock->getArgument(4);
+        Value barriers = entryBlock->getArgument(5);
+        Value visibilityPtr = entryBlock->getArgument(6);
+        Value trackingPtr = entryBlock->getArgument(7);
 
         auto [prevBlock, ifBlock, thenBlock] = createIfBlock(fb, pred);
         fb.setInsertionPointToStart(ifBlock);
@@ -3073,11 +3218,17 @@ void FunctionBuilder::createCompleteBarrierWaitCall(ImplicitLocOpBuilder &b,
             createCTASetMask(fb, trackingType, /*dim=*/2, currentCTA);
         Value selected =
             arith::AndIOp::create(fb, proxyBarrierMask, barrierCTAMask);
+        Value phaseIndex = adjustIntegerWidth(fb, phase, fb.getI32Type());
+        phaseIndex = arith::AndIOp::create(
+            fb, phaseIndex, arith::ConstantIntOp::create(fb, 1, 32));
+        int phaseDim = trackingType.getRank() - 1;
+        Value phaseMask = createDimMask(fb, phaseIndex, trackingType, phaseDim);
+        selected = arith::AndIOp::create(fb, selected, phaseMask);
         Value zeroTracking =
             tti::createConstIntTensor(fb, fb.getLoc(), 0, trackingType);
         Value frontier =
             arith::SelectOp::create(fb, selected, tracking, zeroTracking);
-        frontier = reduce<arith::OrIOp>(fb, frontier, {2, 3});
+        frontier = reduce<arith::OrIOp>(fb, frontier, {2, 3, phaseDim});
         frontier = convertAndBroadcast(fb, frontier, {0, 1, 4}, visibilityType);
 
         Value targetMask =
@@ -3092,7 +3243,7 @@ void FunctionBuilder::createCompleteBarrierWaitCall(ImplicitLocOpBuilder &b,
                                        visibilityType, targetMask);
 
         if (clearWaiting) {
-          Value waitingPtr = entryBlock->getArgument(7);
+          Value waitingPtr = entryBlock->getArgument(8);
           Value waiting = tti::createLoadScratchMemory(fb, fb.getLoc(),
                                                        waitingPtr, waitingType);
           Value waitingBarrierMask =

--- a/lib/Dialect/TritonInstrument/IR/FunctionBuilder.cpp
+++ b/lib/Dialect/TritonInstrument/IR/FunctionBuilder.cpp
@@ -357,6 +357,30 @@ Value createDimIndices(ImplicitLocOpBuilder &b, RankedTensorType tensorType,
   return convertAndBroadcast(b, range, {dim}, fullIndexType);
 }
 
+Value createLoadTrackingPhase(ImplicitLocOpBuilder &b, Value trackingPtr,
+                              RankedTensorType trackingType, Value phase) {
+  int phaseDim = trackingType.getRank() - 1;
+  assert(phaseDim >= 0 && trackingType.getShape()[phaseDim] == 2 &&
+         "expected a trailing barrier phase dimension");
+
+  SmallVector<int> keptDims;
+  keptDims.reserve(phaseDim);
+  for (int dim = 0; dim < phaseDim; ++dim)
+    keptDims.push_back(dim);
+  RankedTensorType bankType = tti::getSlicedTensorType(
+      trackingType, keptDims, trackingType.getElementType());
+
+  Value phaseIndex = adjustIntegerWidth(b, phase, b.getI32Type());
+  phaseIndex = arith::AndIOp::create(b, phaseIndex,
+                                     arith::ConstantIntOp::create(b, 1, 32));
+  Value bankElements =
+      arith::ConstantIntOp::create(b, bankType.getNumElements(), /*width=*/32);
+  Value offset = arith::MulIOp::create(b, phaseIndex, bankElements);
+  Value bankPtr =
+      triton::AddPtrOp::create(b, trackingPtr.getType(), trackingPtr, offset);
+  return tti::createLoadScratchMemory(b, b.getLoc(), bankPtr, bankType);
+}
+
 Value createCurrentCTAMask(ImplicitLocOpBuilder &b) {
   Value ctaId = tti::ExperimentalClusterCTAIdOp::create(b, b.getLoc());
   return arith::ShLIOp::create(b, arith::ConstantIntOp::create(b, 1, 32),
@@ -1541,15 +1565,16 @@ void FunctionBuilder::createVerifyAndUpdateBarrierStateCall(
               createIfBlock(fb, anyCompleted);
           fb.setInsertionPointToStart(clearBlock);
 
+          auto phaseStateType = cast<RankedTensorType>(
+              barrierStatesType.cloneWith(std::nullopt, fb.getI32Type()));
+          Value nextPhases =
+              arith::TruncIOp::create(fb, phaseStateType, newPhase);
           for (auto [index, trackingType] : llvm::enumerate(trackingTypes)) {
             Value trackingPtr = entryBlock->getArgument(8 + index);
             Value completedMask =
                 convertAndBroadcast(fb, completed, {2, 3}, trackingType);
             Value nextPhase =
-                convertAndBroadcast(fb, newPhase, {2, 3}, trackingType);
-            auto phaseType = cast<RankedTensorType>(
-                trackingType.cloneWith(std::nullopt, fb.getI32Type()));
-            nextPhase = arith::TruncIOp::create(fb, phaseType, nextPhase);
+                convertAndBroadcast(fb, nextPhases, {2, 3}, trackingType);
             Value phaseIndices =
                 createDimIndices(fb, trackingType, trackingType.getRank() - 1);
             Value phaseMask = arith::CmpIOp::create(
@@ -2126,8 +2151,6 @@ static void createClearBarrierTrackingCall(ImplicitLocOpBuilder &b,
         auto [prevBlock, ifBlock, thenBlock] = createIfBlock(fb, pred);
         fb.setInsertionPointToStart(ifBlock);
 
-        Value tracking = tti::createLoadScratchMemory(
-            fb, fb.getLoc(), trackingPtr, trackingType);
         Value barriersEqBar =
             convertAndBroadcast(fb, selectedBarriers, {3}, trackingType);
         Value barrierCTAs = createCurrentCTAMask(fb);
@@ -2137,10 +2160,9 @@ static void createClearBarrierTrackingCall(ImplicitLocOpBuilder &b,
             arith::AndIOp::create(fb, barriersEqBar, barrierCTAMask);
         Value zero =
             tti::createConstIntTensor(fb, fb.getLoc(), 0, trackingType);
-        Value updated =
-            arith::SelectOp::create(fb, barriersEqBar, zero, tracking);
-        createMaskedStoreScratchMemory(fb, fb.getLoc(), trackingPtr, updated,
-                                       trackingType, barrierCTAMask);
+        tti::createStoreScratchMemory(fb, fb.getLoc(), trackingPtr, zero,
+                                      trackingType, /*currentCTAOnly=*/false,
+                                      barriersEqBar);
 
         fb.setInsertionPointToEnd(thenBlock);
         triton::ReturnOp::create(fb);
@@ -2238,32 +2260,25 @@ void FunctionBuilder::createTransferVisibleAccessesCall(
         Value barriersEqBar =
             createCmpIntTensorScalar(fb, barriers, descriptor);
         Value currentCTA = createCurrentCTAMask(fb);
-        Value phaseI32 = adjustIntegerWidth(fb, phase, fb.getI32Type());
-        phaseI32 = arith::AndIOp::create(
-            fb, phaseI32, arith::ConstantIntOp::create(fb, 1, 32));
 
         if (transferWrites) {
           Value visibilityPtr = entryBlock->getArgument(nextArg++);
           Value trackingPtr = entryBlock->getArgument(nextArg++);
           Value visibility = tti::createLoadScratchMemory(
               fb, fb.getLoc(), visibilityPtr, writeVisibilityType);
-          Value tracking = tti::createLoadScratchMemory(
-              fb, fb.getLoc(), trackingPtr, writeTrackingType);
+          Value tracking = createLoadTrackingPhase(fb, trackingPtr,
+                                                   writeTrackingType, phase);
+          auto phaseTrackingType = cast<RankedTensorType>(tracking.getType());
           Value barrierMask =
-              convertAndBroadcast(fb, barriersEqBar, {3}, writeTrackingType);
+              convertAndBroadcast(fb, barriersEqBar, {3}, phaseTrackingType);
           Value barrierCTAMask =
-              createCTASetMask(fb, writeTrackingType, /*dim=*/2, currentCTA);
+              createCTASetMask(fb, phaseTrackingType, /*dim=*/2, currentCTA);
           barrierMask = arith::AndIOp::create(fb, barrierMask, barrierCTAMask);
-          int phaseDim = writeTrackingType.getRank() - 1;
-          Value phaseMask =
-              createDimMask(fb, phaseI32, writeTrackingType, phaseDim);
-          barrierMask = arith::AndIOp::create(fb, barrierMask, phaseMask);
           Value zeroTracking =
-              tti::createConstIntTensor(fb, fb.getLoc(), 0, writeTrackingType);
+              tti::createConstIntTensor(fb, fb.getLoc(), 0, phaseTrackingType);
           Value trackingBuffers =
               arith::SelectOp::create(fb, barrierMask, tracking, zeroTracking);
-          trackingBuffers =
-              reduce<arith::OrIOp>(fb, trackingBuffers, {2, 3, phaseDim});
+          trackingBuffers = reduce<arith::OrIOp>(fb, trackingBuffers, {2, 3});
           trackingBuffers = convertAndBroadcast(fb, trackingBuffers, {0, 1},
                                                 writeVisibilityType);
           auto trackingBuffersType =
@@ -2297,22 +2312,19 @@ void FunctionBuilder::createTransferVisibleAccessesCall(
           Value trackingPtr = entryBlock->getArgument(nextArg++);
           Value visibility = tti::createLoadScratchMemory(
               fb, fb.getLoc(), visibilityPtr, readVisibilityType);
-          Value tracking = tti::createLoadScratchMemory(
-              fb, fb.getLoc(), trackingPtr, readTrackingType);
+          Value tracking =
+              createLoadTrackingPhase(fb, trackingPtr, readTrackingType, phase);
+          auto phaseTrackingType = cast<RankedTensorType>(tracking.getType());
           Value barrierMask =
-              convertAndBroadcast(fb, barriersEqBar, {3}, readTrackingType);
+              convertAndBroadcast(fb, barriersEqBar, {3}, phaseTrackingType);
           Value barrierCTAMask =
-              createCTASetMask(fb, readTrackingType, /*dim=*/2, currentCTA);
+              createCTASetMask(fb, phaseTrackingType, /*dim=*/2, currentCTA);
           barrierMask = arith::AndIOp::create(fb, barrierMask, barrierCTAMask);
-          int phaseDim = readTrackingType.getRank() - 1;
-          Value phaseMask =
-              createDimMask(fb, phaseI32, readTrackingType, phaseDim);
-          barrierMask = arith::AndIOp::create(fb, barrierMask, phaseMask);
           Value zeroTracking =
-              tti::createConstIntTensor(fb, fb.getLoc(), 0, readTrackingType);
+              tti::createConstIntTensor(fb, fb.getLoc(), 0, phaseTrackingType);
           Value trackingBar =
               arith::SelectOp::create(fb, barrierMask, tracking, zeroTracking);
-          trackingBar = reduce<arith::OrIOp>(fb, trackingBar, {2, 3, phaseDim});
+          trackingBar = reduce<arith::OrIOp>(fb, trackingBar, {2, 3});
           trackingBar = convertAndBroadcast(fb, trackingBar, {0, 1, 4},
                                             readVisibilityType);
           Value visibilityOrTracking =
@@ -3218,25 +3230,20 @@ void FunctionBuilder::createCompleteBarrierWaitCall(ImplicitLocOpBuilder &b,
 
         Value visibility = tti::createLoadScratchMemory(
             fb, fb.getLoc(), visibilityPtr, visibilityType);
-        Value tracking = tti::createLoadScratchMemory(
-            fb, fb.getLoc(), trackingPtr, trackingType);
+        Value tracking =
+            createLoadTrackingPhase(fb, trackingPtr, trackingType, phase);
+        auto trackingPhaseType = cast<RankedTensorType>(tracking.getType());
         Value proxyBarrierMask =
-            convertAndBroadcast(fb, barriersEqBar, {3}, trackingType);
+            convertAndBroadcast(fb, barriersEqBar, {3}, trackingPhaseType);
         Value barrierCTAMask =
-            createCTASetMask(fb, trackingType, /*dim=*/2, currentCTA);
+            createCTASetMask(fb, trackingPhaseType, /*dim=*/2, currentCTA);
         Value selected =
             arith::AndIOp::create(fb, proxyBarrierMask, barrierCTAMask);
-        Value phaseIndex = adjustIntegerWidth(fb, phase, fb.getI32Type());
-        phaseIndex = arith::AndIOp::create(
-            fb, phaseIndex, arith::ConstantIntOp::create(fb, 1, 32));
-        int phaseDim = trackingType.getRank() - 1;
-        Value phaseMask = createDimMask(fb, phaseIndex, trackingType, phaseDim);
-        selected = arith::AndIOp::create(fb, selected, phaseMask);
         Value zeroTracking =
-            tti::createConstIntTensor(fb, fb.getLoc(), 0, trackingType);
+            tti::createConstIntTensor(fb, fb.getLoc(), 0, trackingPhaseType);
         Value frontier =
             arith::SelectOp::create(fb, selected, tracking, zeroTracking);
-        frontier = reduce<arith::OrIOp>(fb, frontier, {2, 3, phaseDim});
+        frontier = reduce<arith::OrIOp>(fb, frontier, {2, 3});
         frontier = convertAndBroadcast(fb, frontier, {0, 1, 4}, visibilityType);
 
         Value targetMask =

--- a/lib/Dialect/TritonInstrument/IR/FunctionBuilder.cpp
+++ b/lib/Dialect/TritonInstrument/IR/FunctionBuilder.cpp
@@ -2029,11 +2029,17 @@ void FunctionBuilder::createTrackVisibleAccessesCall(
           visibleReads = convertAndBroadcast(fb, visibleReads, {0, 1, 4},
                                              readTrackingType);
           Value withVisible = arith::OrIOp::create(fb, tracking, visibleReads);
-          Value updated =
-              arith::SelectOp::create(fb, barrierMask, withVisible, tracking);
-          createMaskedStoreScratchMemory(
-              fb, fb.getLoc(), trackingPtr, updated, readTrackingType,
-              filterBuffer ? barrierMask : barrierCTAMask);
+          if (filterBuffer) {
+            Value updated =
+                arith::SelectOp::create(fb, barrierMask, withVisible, tracking);
+            createMaskedStoreScratchMemory(fb, fb.getLoc(), trackingPtr,
+                                           updated, readTrackingType,
+                                           barrierMask);
+          } else {
+            tti::createStoreScratchMemory(
+                fb, fb.getLoc(), trackingPtr, withVisible, readTrackingType,
+                /*currentCTAOnly=*/false, barrierMask);
+          }
         }
 
         fb.setInsertionPointToEnd(thenBlock);
@@ -3154,10 +3160,16 @@ void FunctionBuilder::createTrackProxyAccessesCallImpl(
               createCTASetMask(fb, trackingType, /*dim=*/0, effectCTAs));
         }
         Value withSource = arith::OrIOp::create(fb, tracking, source);
-        Value updated =
-            arith::SelectOp::create(fb, trackMask, withSource, tracking);
-        createMaskedStoreScratchMemory(fb, fb.getLoc(), trackingPtr, updated,
-                                       trackingType, trackMask);
+        if (filterByBuffer) {
+          Value updated =
+              arith::SelectOp::create(fb, trackMask, withSource, tracking);
+          createMaskedStoreScratchMemory(fb, fb.getLoc(), trackingPtr, updated,
+                                         trackingType, trackMask);
+        } else {
+          tti::createStoreScratchMemory(fb, fb.getLoc(), trackingPtr,
+                                        withSource, trackingType,
+                                        /*currentCTAOnly=*/false, trackMask);
+        }
 
         fb.setInsertionPointToEnd(thenBlock);
         triton::ReturnOp::create(fb);

--- a/lib/Dialect/TritonInstrument/IR/FunctionBuilder.cpp
+++ b/lib/Dialect/TritonInstrument/IR/FunctionBuilder.cpp
@@ -1543,8 +1543,6 @@ void FunctionBuilder::createVerifyAndUpdateBarrierStateCall(
 
           for (auto [index, trackingType] : llvm::enumerate(trackingTypes)) {
             Value trackingPtr = entryBlock->getArgument(8 + index);
-            Value tracking = tti::createLoadScratchMemory(
-                fb, fb.getLoc(), trackingPtr, trackingType);
             Value completedMask =
                 convertAndBroadcast(fb, completed, {2, 3}, trackingType);
             Value nextPhase =
@@ -1560,10 +1558,9 @@ void FunctionBuilder::createVerifyAndUpdateBarrierStateCall(
                 arith::AndIOp::create(fb, completedMask, phaseMask);
             Value zero =
                 tti::createConstIntTensor(fb, fb.getLoc(), 0, trackingType);
-            Value cleared =
-                arith::SelectOp::create(fb, clearMask, zero, tracking);
-            createMaskedStoreScratchMemory(fb, fb.getLoc(), trackingPtr,
-                                           cleared, trackingType, clearMask);
+            tti::createStoreScratchMemory(fb, fb.getLoc(), trackingPtr, zero,
+                                          trackingType,
+                                          /*currentCTAOnly=*/false, clearMask);
           }
         }
 

--- a/lib/Dialect/TritonInstrument/IR/FunctionBuilder.cpp
+++ b/lib/Dialect/TritonInstrument/IR/FunctionBuilder.cpp
@@ -346,6 +346,17 @@ Value createDimMask(ImplicitLocOpBuilder &b, Value index,
   return convertAndBroadcast(b, mask1D, {dim}, maskType);
 }
 
+Value createDimIndices(ImplicitLocOpBuilder &b, RankedTensorType tensorType,
+                       int dim) {
+  assert(dim >= 0 && dim < tensorType.getRank() && "invalid tensor dimension");
+  auto indexType = tti::getSlicedTensorType(tensorType, {dim}, b.getI32Type());
+  Value range = triton::MakeRangeOp::create(b, indexType, /*start=*/0,
+                                            /*end=*/tensorType.getShape()[dim]);
+  auto fullIndexType = cast<RankedTensorType>(
+      tensorType.cloneWith(std::nullopt, b.getI32Type()));
+  return convertAndBroadcast(b, range, {dim}, fullIndexType);
+}
+
 Value createCurrentCTAMask(ImplicitLocOpBuilder &b) {
   Value ctaId = tti::ExperimentalClusterCTAIdOp::create(b, b.getLoc());
   return arith::ShLIOp::create(b, arith::ConstantIntOp::create(b, 1, 32),

--- a/lib/Dialect/TritonInstrument/IR/FunctionBuilder.cpp
+++ b/lib/Dialect/TritonInstrument/IR/FunctionBuilder.cpp
@@ -1692,9 +1692,9 @@ void FunctionBuilder::createPublishWriteVisibilityCall(
               triton::SplatOp::create(fb, writeVisibilityType, threadMaskElem);
           Value updated = arith::SelectOp::create(fb, visibilityMask,
                                                   threadMaskTensor, visibility);
-          createMaskedStoreScratchMemory(fb, fb.getLoc(), visibilityPtr,
-                                         updated, writeVisibilityType,
-                                         relationMask);
+          tti::createStoreScratchMemory(fb, fb.getLoc(), visibilityPtr, updated,
+                                        writeVisibilityType,
+                                        /*currentCTAOnly=*/false);
         }
 
         auto clearTable = [&](RankedTensorType tableType) {
@@ -1707,8 +1707,8 @@ void FunctionBuilder::createPublishWriteVisibilityCall(
           tableMask = arith::AndIOp::create(fb, tableMask, ctaMask);
           Value zero = tti::createConstIntTensor(fb, fb.getLoc(), 0, tableType);
           Value updated = arith::SelectOp::create(fb, tableMask, zero, table);
-          createMaskedStoreScratchMemory(fb, fb.getLoc(), tablePtr, updated,
-                                         tableType, ctaMask);
+          tti::createStoreScratchMemory(fb, fb.getLoc(), tablePtr, updated,
+                                        tableType, /*currentCTAOnly=*/false);
         };
 
         if (clearWrites)
@@ -1821,9 +1821,9 @@ void FunctionBuilder::createSetReadVisibilityCall(ImplicitLocOpBuilder &b,
         Value withReader = arith::OrIOp::create(fb, newVisibility, readerBit);
         newVisibility = arith::SelectOp::create(fb, observerRows, withReader,
                                                 newVisibility);
-        createMaskedStoreScratchMemory(fb, fb.getLoc(), readVisibilityPtr,
-                                       newVisibility, readVisibilityType,
-                                       visibilityRows);
+        tti::createStoreScratchMemory(fb, fb.getLoc(), readVisibilityPtr,
+                                      newVisibility, readVisibilityType,
+                                      /*currentCTAOnly=*/false);
 
         if (hasReadTracking) {
           Value readTracking = tti::createLoadScratchMemory(
@@ -1831,9 +1831,9 @@ void FunctionBuilder::createSetReadVisibilityCall(ImplicitLocOpBuilder &b,
           Value trackingRows = createReaderRows(readTrackingType);
           Value newTracking =
               clearReader(readTracking, readTrackingType, trackingRows);
-          createMaskedStoreScratchMemory(fb, fb.getLoc(), readTrackingPtr,
-                                         newTracking, readTrackingType,
-                                         trackingRows);
+          tti::createStoreScratchMemory(fb, fb.getLoc(), readTrackingPtr,
+                                        newTracking, readTrackingType,
+                                        /*currentCTAOnly=*/false);
         }
 
         fb.setInsertionPointToEnd(thenBlock);
@@ -2940,9 +2940,9 @@ void FunctionBuilder::createSetProxyAccessCall(ImplicitLocOpBuilder &b,
         Value withSeen = arith::OrIOp::create(fb, clearedVisibility, seenBit);
         Value updatedVisibility =
             arith::SelectOp::create(fb, ownerMask, withSeen, clearedVisibility);
-        createMaskedStoreScratchMemory(fb, fb.getLoc(), visibilityPtr,
-                                       updatedVisibility, visibilityType,
-                                       selectedBuffers);
+        tti::createStoreScratchMemory(fb, fb.getLoc(), visibilityPtr,
+                                      updatedVisibility, visibilityType,
+                                      /*currentCTAOnly=*/false);
 
         // A new generic access supersedes fence coverage for an older access
         // from the same source. Clear that source's fence bit in outstanding
@@ -2967,9 +2967,9 @@ void FunctionBuilder::createSetProxyAccessCall(ImplicitLocOpBuilder &b,
               arith::AndIOp::create(fb, tracking, trackingClear);
           Value updatedTracking = arith::SelectOp::create(
               fb, trackingMask, clearedTracking, tracking);
-          createMaskedStoreScratchMemory(fb, fb.getLoc(), trackingPtr,
-                                         updatedTracking, trackingType,
-                                         trackingMask);
+          tti::createStoreScratchMemory(fb, fb.getLoc(), trackingPtr,
+                                        updatedTracking, trackingType,
+                                        /*currentCTAOnly=*/false);
         }
 
         fb.setInsertionPointToEnd(thenBlock);

--- a/lib/Dialect/TritonInstrument/IR/FunctionBuilder.cpp
+++ b/lib/Dialect/TritonInstrument/IR/FunctionBuilder.cpp
@@ -387,6 +387,27 @@ Value createCurrentCTAMask(ImplicitLocOpBuilder &b) {
                                ctaId);
 }
 
+Value createTrackingOriginPhasePointer(ImplicitLocOpBuilder &b,
+                                       Value trackingPtr,
+                                       RankedTensorType trackingType,
+                                       RankedTensorType bankType,
+                                       Value originId, int phase) {
+  assert(trackingType.getRank() == 6 && trackingType.getShape()[5] == 2 &&
+         "expected origin CTA followed by the two barrier phases");
+  int64_t numOrigins = trackingType.getShape()[4];
+  Value bankIndex = originId;
+  if (phase != 0) {
+    Value phaseOriginOffset =
+        arith::ConstantIntOp::create(b, phase * numOrigins, 32);
+    bankIndex = arith::AddIOp::create(b, bankIndex, phaseOriginOffset);
+  }
+  Value bankElements =
+      arith::ConstantIntOp::create(b, bankType.getNumElements(), 32);
+  Value elementOffset = arith::MulIOp::create(b, bankIndex, bankElements);
+  return triton::AddPtrOp::create(b, trackingPtr.getType(), trackingPtr,
+                                  elementOffset);
+}
+
 Value createCTASetMask(ImplicitLocOpBuilder &b, RankedTensorType tensorType,
                        int dim, Value ctas) {
   int numCTAs = ttg::lookupNumCTAs(b);
@@ -1826,14 +1847,38 @@ void FunctionBuilder::createSetReadVisibilityCall(ImplicitLocOpBuilder &b,
                                       /*currentCTAOnly=*/false);
 
         if (hasReadTracking) {
-          Value readTracking = tti::createLoadScratchMemory(
-              fb, fb.getLoc(), readTrackingPtr, readTrackingType);
-          Value trackingRows = createReaderRows(readTrackingType);
-          Value newTracking =
-              clearReader(readTracking, readTrackingType, trackingRows);
-          tti::createStoreScratchMemory(fb, fb.getLoc(), readTrackingPtr,
-                                        newTracking, readTrackingType,
-                                        /*currentCTAOnly=*/false);
+          if (readTrackingType.getShape()[4] == 1) {
+            Value readTracking = tti::createLoadScratchMemory(
+                fb, fb.getLoc(), readTrackingPtr, readTrackingType);
+            Value trackingRows = createReaderRows(readTrackingType);
+            Value newTracking =
+                clearReader(readTracking, readTrackingType, trackingRows);
+            tti::createStoreScratchMemory(fb, fb.getLoc(), readTrackingPtr,
+                                          newTracking, readTrackingType,
+                                          /*currentCTAOnly=*/false);
+          } else {
+            RankedTensorType bankType =
+                tti::getSlicedTensorType(readTrackingType, {0, 1, 2, 3},
+                                         readTrackingType.getElementType());
+            Value trackingRows =
+                convertAndBroadcast(fb, bufferMask, {1}, bankType);
+            Value ownerMask =
+                createCTASetMask(fb, bankType, /*dim=*/0, effectCTAs);
+            trackingRows = arith::AndIOp::create(fb, trackingRows, ownerMask);
+            Value originId =
+                tti::ExperimentalClusterCTAIdOp::create(fb, fb.getLoc());
+            for (int phase = 0; phase < 2; ++phase) {
+              Value bankPtr = createTrackingOriginPhasePointer(
+                  fb, readTrackingPtr, readTrackingType, bankType, originId,
+                  phase);
+              Value tracking = tti::createLoadScratchMemory(fb, fb.getLoc(),
+                                                            bankPtr, bankType);
+              Value updated = clearReader(tracking, bankType, trackingRows);
+              tti::createStoreScratchMemory(fb, fb.getLoc(), bankPtr, updated,
+                                            bankType,
+                                            /*currentCTAOnly=*/false);
+            }
+          }
         }
 
         fb.setInsertionPointToEnd(thenBlock);
@@ -2949,27 +2994,55 @@ void FunctionBuilder::createSetProxyAccessCall(ImplicitLocOpBuilder &b,
         // barrier snapshots from either phase as well, so an old publication
         // cannot mask it.
         if (hasTracking) {
-          Value tracking = tti::createLoadScratchMemory(
-              fb, fb.getLoc(), trackingPtr, trackingType);
-          Value trackingBuffers =
-              convertAndBroadcast(fb, bufferVector, {1}, trackingType);
-          Value trackingBufferCTAMask =
-              createCTASetMask(fb, trackingType, /*dim=*/0, effectCTAs);
-          Value trackingOriginCTAMask =
-              createCTASetMask(fb, trackingType, /*dim=*/4, currentCTA);
-          Value trackingMask =
-              arith::AndIOp::create(fb, trackingBuffers, trackingBufferCTAMask);
-          trackingMask =
-              arith::AndIOp::create(fb, trackingMask, trackingOriginCTAMask);
-          Value trackingClear =
-              triton::SplatOp::create(fb, trackingType, clearFencedScalar);
-          Value clearedTracking =
-              arith::AndIOp::create(fb, tracking, trackingClear);
-          Value updatedTracking = arith::SelectOp::create(
-              fb, trackingMask, clearedTracking, tracking);
-          tti::createStoreScratchMemory(fb, fb.getLoc(), trackingPtr,
-                                        updatedTracking, trackingType,
-                                        /*currentCTAOnly=*/false);
+          if (trackingType.getShape()[4] == 1) {
+            Value tracking = tti::createLoadScratchMemory(
+                fb, fb.getLoc(), trackingPtr, trackingType);
+            Value trackingBuffers =
+                convertAndBroadcast(fb, bufferVector, {1}, trackingType);
+            Value trackingBufferCTAMask =
+                createCTASetMask(fb, trackingType, /*dim=*/0, effectCTAs);
+            Value trackingOriginCTAMask =
+                createCTASetMask(fb, trackingType, /*dim=*/4, currentCTA);
+            Value trackingMask = arith::AndIOp::create(fb, trackingBuffers,
+                                                       trackingBufferCTAMask);
+            trackingMask =
+                arith::AndIOp::create(fb, trackingMask, trackingOriginCTAMask);
+            Value trackingClear =
+                triton::SplatOp::create(fb, trackingType, clearFencedScalar);
+            Value clearedTracking =
+                arith::AndIOp::create(fb, tracking, trackingClear);
+            Value updatedTracking = arith::SelectOp::create(
+                fb, trackingMask, clearedTracking, tracking);
+            tti::createStoreScratchMemory(fb, fb.getLoc(), trackingPtr,
+                                          updatedTracking, trackingType,
+                                          /*currentCTAOnly=*/false);
+          } else {
+            RankedTensorType bankType = tti::getSlicedTensorType(
+                trackingType, {0, 1, 2, 3}, trackingType.getElementType());
+            Value trackingBuffers =
+                convertAndBroadcast(fb, bufferVector, {1}, bankType);
+            Value ownerMask =
+                createCTASetMask(fb, bankType, /*dim=*/0, effectCTAs);
+            Value trackingMask =
+                arith::AndIOp::create(fb, trackingBuffers, ownerMask);
+            Value trackingClear =
+                triton::SplatOp::create(fb, bankType, clearFencedScalar);
+            Value originId =
+                tti::ExperimentalClusterCTAIdOp::create(fb, fb.getLoc());
+            for (int phase = 0; phase < 2; ++phase) {
+              Value bankPtr = createTrackingOriginPhasePointer(
+                  fb, trackingPtr, trackingType, bankType, originId, phase);
+              Value tracking = tti::createLoadScratchMemory(fb, fb.getLoc(),
+                                                            bankPtr, bankType);
+              Value clearedTracking =
+                  arith::AndIOp::create(fb, tracking, trackingClear);
+              Value updated = arith::SelectOp::create(
+                  fb, trackingMask, clearedTracking, tracking);
+              tti::createStoreScratchMemory(fb, fb.getLoc(), bankPtr, updated,
+                                            bankType,
+                                            /*currentCTAOnly=*/false);
+            }
+          }
         }
 
         fb.setInsertionPointToEnd(thenBlock);

--- a/lib/Dialect/TritonInstrument/IR/Utility.cpp
+++ b/lib/Dialect/TritonInstrument/IR/Utility.cpp
@@ -576,13 +576,14 @@ LogicalResult AuxDataMap::populateAndPassToWarpSpecialize(
         writeTracking[iMemType].insert(
             entryRegion,
             createZeroInitStateTensor(
-                b, {numCTAs, numBufs, numCTAs, numBarriers}, 8, fb));
+                b, {numCTAs, numBufs, numCTAs, numBarriers, 2}, 8, fb));
         passValueToWarpSpecialize(writeTracking[iMemType].at(entryRegion),
                                   writeTracking[iMemType]);
         readTracking[iMemType].insert(
             entryRegion,
             createZeroInitStateTensor(
-                b, {numCTAs, numBufs, numCTAs, numBarriers, numCTAs}, 64, fb));
+                b, {numCTAs, numBufs, numCTAs, numBarriers, numCTAs, 2}, 64,
+                fb));
         passValueToWarpSpecialize(readTracking[iMemType].at(entryRegion),
                                   readTracking[iMemType]);
       }
@@ -594,7 +595,7 @@ LogicalResult AuxDataMap::populateAndPassToWarpSpecialize(
       proxyAccessTracking.insert(
           entryRegion,
           createZeroInitStateTensor(
-              b, {numCTAs, numBufs, numCTAs, numBarriers, numCTAs}, 64, fb));
+              b, {numCTAs, numBufs, numCTAs, numBarriers, numCTAs, 2}, 64, fb));
       passValueToWarpSpecialize(proxyAccessTracking.at(entryRegion),
                                 proxyAccessTracking);
     }

--- a/lib/Dialect/TritonInstrument/IR/Utility.cpp
+++ b/lib/Dialect/TritonInstrument/IR/Utility.cpp
@@ -357,7 +357,7 @@ static Value createCurrentCTAMask(OpBuilder &b, Location loc,
 
 Operation *createStoreScratchMemory(OpBuilder &b, Location loc, Value alloc,
                                     Value tensor, RankedTensorType tensorType,
-                                    bool currentCTAOnly) {
+                                    bool currentCTAOnly, Value storeMask) {
   if (currentCTAOnly) {
     assert(tensorType.getRank() >= 1 &&
            "expected currentCTAOnly tensor to have a leading CTA dimension");
@@ -365,14 +365,18 @@ Operation *createStoreScratchMemory(OpBuilder &b, Location loc, Value alloc,
     assert(tensorType.getShape()[0] == numCTAs &&
            "expected leading dimension to match numCTAs");
     if (numCTAs > 1) {
-      Value oldTensor = createLoadScratchMemory(b, loc, alloc, tensorType);
       Value currentCTAMask = createCurrentCTAMask(b, loc, tensorType);
-      tensor =
-          arith::SelectOp::create(b, loc, currentCTAMask, tensor, oldTensor);
+      if (storeMask) {
+        storeMask = arith::AndIOp::create(b, loc, storeMask, currentCTAMask);
+      } else {
+        Value oldTensor = createLoadScratchMemory(b, loc, alloc, tensorType);
+        tensor =
+            arith::SelectOp::create(b, loc, currentCTAMask, tensor, oldTensor);
+      }
     }
   }
   auto ptrTensor = createPointerTensor(b, loc, alloc, tensorType);
-  return StoreOp::create(b, loc, ptrTensor, tensor, Value(),
+  return StoreOp::create(b, loc, ptrTensor, tensor, storeMask,
                          CacheModifier::NONE, EvictionPolicy::NORMAL,
                          /*ignore_cta=*/true);
 }

--- a/lib/Dialect/TritonInstrument/Transforms/ConcurrencySanitizer.cpp
+++ b/lib/Dialect/TritonInstrument/Transforms/ConcurrencySanitizer.cpp
@@ -994,18 +994,19 @@ private:
     tti::ExperimentalLockReleaseOp::create(wb, lock, pred);
     tti::createAssertInThread(wb, ok,
                               "Deadlock detected while waiting on an mbarrier");
-    // Post-wait: transfer visible writes and reads to all peer threads,
-    // and clear waiting for this barrier.
+    // Post-wait: transfer the waited phase's visible writes and reads to all
+    // peer threads, and clear waiting for this barrier.
     assert(!auxData.barriers.empty() &&
            "barrier descriptors must exist when instrumenting wait");
     wb.setInsertionPointAfter(op);
     tti::ExperimentalLockAcquireOp::create(wb, lock, pred);
     for (MemType memType : {MemType::SHARED_MEM, MemType::TENSOR_MEM}) {
       funcBuilder.createTransferVisibleAccessesCall(
-          wb, alloc, getThreadPeersMask(thread, auxData.threadLayout), pred,
-          memType, op);
+          wb, alloc, phase, getThreadPeersMask(thread, auxData.threadLayout),
+          pred, memType, op);
     }
-    funcBuilder.createCompleteBarrierWaitCall(wb, alloc, baseThread, pred, op);
+    funcBuilder.createCompleteBarrierWaitCall(wb, alloc, phase, baseThread,
+                                              pred, op);
     tti::ExperimentalLockReleaseOp::create(wb, lock, pred);
   }
 

--- a/python/examples/gluon/01-attention-forward.py
+++ b/python/examples/gluon/01-attention-forward.py
@@ -1194,7 +1194,8 @@ def attention_forward(q, k, v, causal, sm_scale, o=None, M=None, *, use_tmem_red
 @pytest.mark.parametrize("use_tmem_red", [False, True] if is_blackwell_ultra() else [False])
 @pytest.mark.parametrize("cga_layout", [(), ((1, 0), ), ((1, 0), (2, 0))], ids=["1cta", "2ctas", "4ctas"])
 @pytest.mark.skipif(not is_blackwell(), reason="Gluon attention is only supported on Blackwell GPUs")
-def test_op(Z, H, N_CTX, HEAD_DIM, causal, dtype, use_tmem_red, cga_layout, profile=False):
+def test_op(Z, H, N_CTX, HEAD_DIM, causal, dtype, use_tmem_red, cga_layout, profile=False,
+            p: KernelConfig | None = None):
     device = "cuda"
 
     def alloc_fn(size: int, alignment: int, stream):
@@ -1211,7 +1212,7 @@ def test_op(Z, H, N_CTX, HEAD_DIM, causal, dtype, use_tmem_red, cga_layout, prof
     v = (torch.empty((Z, H, N_CTX, HEAD_DIM), device=device).normal_(mean=0.0, std=0.5).to(dtype).requires_grad_())
     sm_scale = 0.5
 
-    tri_out, _ = attention_forward(q, k, v, causal, sm_scale, use_tmem_red=use_tmem_red, cga_layout=cga_layout)
+    tri_out, _ = attention_forward(q, k, v, causal, sm_scale, use_tmem_red=use_tmem_red, p=p, cga_layout=cga_layout)
     if dtype == torch.float8_e5m2:
         ref_out = torch.nn.functional.scaled_dot_product_attention(q.float(), k.float(), v.float(), scale=sm_scale,
                                                                    is_causal=causal)
@@ -1226,9 +1227,11 @@ def test_op(Z, H, N_CTX, HEAD_DIM, causal, dtype, use_tmem_red, cga_layout, prof
 @pytest.mark.parametrize("cga_layout", [(), ((1, 0), )], ids=["1cta", "2ctas"])
 @pytest.mark.skipif(not is_blackwell(), reason="Gluon attention is only supported on Blackwell GPUs")
 def test_op_consan(dtype, cga_layout):
+    p = KernelConfig(NUM_KV_BUFFERS=4) if dtype == torch.float16 and cga_layout and not is_blackwell_ultra() else None
     with triton.knobs.compilation.scope():
         triton.knobs.compilation.instrumentation_mode = "consan"
-        test_op(Z=1, H=1, N_CTX=1024, HEAD_DIM=64, causal=False, dtype=dtype, use_tmem_red=False, cga_layout=cga_layout)
+        test_op(Z=1, H=1, N_CTX=1024, HEAD_DIM=64, causal=False, dtype=dtype, use_tmem_red=False, cga_layout=cga_layout,
+                p=p)
 
 
 # ===-----------------------------------------------------------------------===#

--- a/python/test/gluon/test_consan.py
+++ b/python/test/gluon/test_consan.py
@@ -1211,7 +1211,6 @@ def test_tma_wait_tracks_only_waited_barrier(FAILURE, device, run_wrapper, monke
 
 
 @pytest.mark.skipif(not is_cuda() or torch.cuda.get_device_capability()[0] < 9, reason="Requires hopper or newer")
-@pytest.mark.disable_warmup(reason="phase-aware multi-CTA instrumentation exceeds the Blackwell warmup budget")
 @pytest.mark.parametrize("FAILURE", [True, False])
 def test_tma_wait_tracks_only_requested_phase(FAILURE, device, run_wrapper, monkeypatch, num_ctas):
     if run_wrapper:
@@ -1271,7 +1270,7 @@ def test_tma_wait_tracks_only_requested_phase(FAILURE, device, run_wrapper, monk
         ttgl.warp_specialize([
             (producer, (input_desc, smem, bar)),
             (consumer, (smem, bar, out, FAILURE, blocked_layout)),
-        ], [4])
+        ], [4], [32])
 
     block_m = XBLOCK.value * num_ctas
     input = torch.randn((block_m, XBLOCK.value), device=device, dtype=torch.float16)

--- a/python/test/gluon/test_consan.py
+++ b/python/test/gluon/test_consan.py
@@ -1270,7 +1270,7 @@ def test_tma_wait_tracks_only_requested_phase(FAILURE, device, run_wrapper, monk
         ttgl.warp_specialize([
             (producer, (input_desc, smem, bar)),
             (consumer, (smem, bar, out, FAILURE, blocked_layout)),
-        ], [4], [32])
+        ], [4])
 
     block_m = XBLOCK.value * num_ctas
     input = torch.randn((block_m, XBLOCK.value), device=device, dtype=torch.float16)

--- a/python/test/gluon/test_consan.py
+++ b/python/test/gluon/test_consan.py
@@ -1211,6 +1211,7 @@ def test_tma_wait_tracks_only_waited_barrier(FAILURE, device, run_wrapper, monke
 
 
 @pytest.mark.skipif(not is_cuda() or torch.cuda.get_device_capability()[0] < 9, reason="Requires hopper or newer")
+@pytest.mark.disable_warmup(reason="phase-aware multi-CTA instrumentation exceeds the Blackwell warmup budget")
 @pytest.mark.parametrize("FAILURE", [True, False])
 def test_tma_wait_tracks_only_requested_phase(FAILURE, device, run_wrapper, monkeypatch, num_ctas):
     if run_wrapper:

--- a/python/test/gluon/test_consan.py
+++ b/python/test/gluon/test_consan.py
@@ -1211,6 +1211,77 @@ def test_tma_wait_tracks_only_waited_barrier(FAILURE, device, run_wrapper, monke
 
 
 @pytest.mark.skipif(not is_cuda() or torch.cuda.get_device_capability()[0] < 9, reason="Requires hopper or newer")
+@pytest.mark.parametrize("FAILURE", [True, False])
+def test_tma_wait_tracks_only_requested_phase(FAILURE, device, run_wrapper, monkeypatch, num_ctas):
+    if run_wrapper:
+        result = run_in_process(test_tma_wait_tracks_only_requested_phase,
+                                (FAILURE, device, False, monkeypatch, num_ctas))
+        if FAILURE:
+            assert_expected_cuda_failure(result.exc)
+            assert "Buffer being accessed has outstanding writes" in result.driver_stderr_output
+        else:
+            assert result.exc is None
+            assert result.driver_stderr_output == ""
+        return
+
+    monkeypatch.setenv("TRITON_INSTRUMENTATION_MODE", "consan")
+    monkeypatch.setenv("CUDA_LAUNCH_BLOCKING", "1")
+    knobs.refresh_knobs()
+
+    @gluon.jit
+    def producer(input_desc, smem, bar):
+        mbarrier.arrive(bar.index(0), count=1)
+        mbarrier.wait(bar.index(0), phase=0)
+        mbarrier.expect(bar.index(0), input_desc.nbytes_per_cta)
+        tma.async_load(input_desc, [0, 0], bar.index(0), smem)
+        mbarrier.arrive(bar.index(1), count=1)
+        mbarrier.wait(bar.index(0), phase=1, deps=[smem])
+
+    @gluon.jit
+    def consumer(smem, bar, out, FAILURE: ttgl.constexpr, blocked_layout: ttgl.constexpr):
+        mbarrier.arrive(bar.index(0), count=1)
+        mbarrier.wait(bar.index(1), phase=0)
+        mbarrier.wait(bar.index(0), phase=0)
+
+        if not FAILURE:
+            mbarrier.arrive(bar.index(0), count=1)
+            mbarrier.wait(bar.index(0), phase=1, deps=[smem])
+
+        val = smem.load(blocked_layout)
+        block_m: ttgl.constexpr = XBLOCK * ttgl.num_ctas()
+        out_m = ttgl.arange(0, block_m, ttgl.SliceLayout(1, blocked_layout))[:, None]
+        out_n = ttgl.arange(0, XBLOCK, ttgl.SliceLayout(0, blocked_layout))[None, :]
+        ttgl.store(out + out_m * XBLOCK + out_n, val)
+
+        if FAILURE:
+            mbarrier.arrive(bar.index(0), count=1)
+            mbarrier.wait(bar.index(0), phase=1, deps=[smem])
+
+    @gluon.jit
+    def kernel(input_desc, out, FAILURE: ttgl.constexpr):
+        block_m: ttgl.constexpr = XBLOCK * ttgl.num_ctas()
+        cga_layout: ttgl.constexpr = default_cga_layout(ttgl.num_ctas(), 2)
+        blocked_layout: ttgl.constexpr = ttgl.BlockedLayout(size_per_thread=[1, 1], threads_per_warp=[32, 1],
+                                                            warps_per_cta=[4, 1], order=[0, 1], cga_layout=cga_layout)
+        smem = ttgl.allocate_shared_memory(ttgl.float16, [block_m, XBLOCK], input_desc.layout)
+        bar = mbarrier.allocate_mbarrier(batch=2)
+        mbarrier.init(bar.index(0), count=2)
+        mbarrier.init(bar.index(1), count=1)
+        ttgl.warp_specialize([
+            (producer, (input_desc, smem, bar)),
+            (consumer, (smem, bar, out, FAILURE, blocked_layout)),
+        ], [4], [32])
+
+    block_m = XBLOCK.value * num_ctas
+    input = torch.randn((block_m, XBLOCK.value), device=device, dtype=torch.float16)
+    output = torch.empty_like(input)
+    shared_layout = ttgl.NVMMASharedLayout(swizzle_byte_width=128, element_bitwidth=16, rank=2,
+                                           cga_layout=default_cga_layout(num_ctas, 2))
+    input_desc = gluon.nvidia.hopper.TensorDescriptor.from_tensor(input, [block_m, XBLOCK.value], shared_layout)
+    kernel[(1, )](input_desc, output, FAILURE=FAILURE, num_warps=4, num_ctas=num_ctas)
+
+
+@pytest.mark.skipif(not is_cuda() or torch.cuda.get_device_capability()[0] < 9, reason="Requires hopper or newer")
 @pytest.mark.parametrize("WAIT_LATEST", [True, False])
 def test_tma_wait_does_not_publish_overwritten_row(WAIT_LATEST, device, run_wrapper, monkeypatch, num_ctas):
     if run_wrapper:

--- a/test/TritonGPU/amd/amd-consan.mlir
+++ b/test/TritonGPU/amd/amd-consan.mlir
@@ -19,10 +19,10 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 1 : i32, ttg.shar
     // CHECK: %[[READ_VISIBILITY_GLOB:.*]] = ttg.global_scratch_alloc {alignment = 16 : i32, nbytes = 16 : i32, shared_cluster_state, third_party_allocation, tt.divisibility = 16 : i64} : !tt.ptr<i64>
     // CHECK: call {{.*}}fill_global_tensor{{.*}}(%[[READ_VISIBILITY_GLOB]], %c0_i64
 
-    // CHECK: %[[WRITE_TRACKING_GLOB:.*]] = ttg.global_scratch_alloc {alignment = 16 : i32, nbytes = 2 : i32, shared_cluster_state, third_party_allocation, tt.divisibility = 16 : i64} : !tt.ptr<i8>
+    // CHECK: %[[WRITE_TRACKING_GLOB:.*]] = ttg.global_scratch_alloc {alignment = 16 : i32, nbytes = 4 : i32, shared_cluster_state, third_party_allocation, tt.divisibility = 16 : i64} : !tt.ptr<i8>
     // CHECK: call {{.*}}fill_global_tensor{{.*}}(%[[WRITE_TRACKING_GLOB]], %c0_i8
 
-    // CHECK: %[[READ_TRACKING_GLOB:.*]] = ttg.global_scratch_alloc {alignment = 16 : i32, nbytes = 16 : i32, shared_cluster_state, third_party_allocation, tt.divisibility = 16 : i64} : !tt.ptr<i64>
+    // CHECK: %[[READ_TRACKING_GLOB:.*]] = ttg.global_scratch_alloc {alignment = 16 : i32, nbytes = 32 : i32, shared_cluster_state, third_party_allocation, tt.divisibility = 16 : i64} : !tt.ptr<i64>
     // CHECK: call {{.*}}fill_global_tensor{{.*}}(%[[READ_TRACKING_GLOB]], %c0_i64
     %0 = ttg.local_alloc {allocation.offset = 0 : i32} : () -> !ttg.memdesc<32x32xf32, #shared, #smem, mutable>
     %bar = ttg.local_alloc {allocation.offset = 4096 : i32} : () -> !ttg.memdesc<1xi64, #shared1, #smem, mutable>
@@ -47,10 +47,10 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 1 : i32, ttg.shar
     // CHECK: %[[READ_VISIBILITY_GLOB:.*]] = ttg.global_scratch_alloc {alignment = 16 : i32, nbytes = 32 : i32, shared_cluster_state, third_party_allocation, tt.divisibility = 16 : i64} : !tt.ptr<i64>
     // CHECK: call {{.*}}fill_global_tensor{{.*}}(%[[READ_VISIBILITY_GLOB]], %c0_i64
 
-    // CHECK: %[[WRITE_TRACKING_GLOB:.*]] = ttg.global_scratch_alloc {alignment = 16 : i32, nbytes = 4 : i32, shared_cluster_state, third_party_allocation, tt.divisibility = 16 : i64} : !tt.ptr<i8>
+    // CHECK: %[[WRITE_TRACKING_GLOB:.*]] = ttg.global_scratch_alloc {alignment = 16 : i32, nbytes = 8 : i32, shared_cluster_state, third_party_allocation, tt.divisibility = 16 : i64} : !tt.ptr<i8>
     // CHECK: call {{.*}}fill_global_tensor{{.*}}(%[[WRITE_TRACKING_GLOB]], %c0_i8
 
-    // CHECK: %[[READ_TRACKING_GLOB:.*]] = ttg.global_scratch_alloc {alignment = 16 : i32, nbytes = 32 : i32, shared_cluster_state, third_party_allocation, tt.divisibility = 16 : i64} : !tt.ptr<i64>
+    // CHECK: %[[READ_TRACKING_GLOB:.*]] = ttg.global_scratch_alloc {alignment = 16 : i32, nbytes = 64 : i32, shared_cluster_state, third_party_allocation, tt.divisibility = 16 : i64} : !tt.ptr<i64>
     // CHECK: call {{.*}}fill_global_tensor{{.*}}(%[[READ_TRACKING_GLOB]], %c0_i64
     %0 = ttg.local_alloc {allocation.offset = 0 : i32} : () -> !ttg.memdesc<32x32xf32, #shared, #smem, mutable>
     %1 = ttg.local_alloc {allocation.offset = 4096 : i32} : () -> !ttg.memdesc<32x32xf32, #shared, #smem, mutable>
@@ -109,10 +109,10 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 1 : i32, ttg.shar
     // CHECK: %[[READ_VISIBILITY_GLOB:.*]] = ttg.global_scratch_alloc {alignment = 16 : i32, nbytes = 16 : i32, shared_cluster_state, third_party_allocation, tt.divisibility = 16 : i64} : !tt.ptr<i64>
     // CHECK: call {{.*}}fill_global_tensor{{.*}}(%[[READ_VISIBILITY_GLOB]], %c0_i64
 
-    // CHECK: %[[WRITE_TRACKING_GLOB:.*]] = ttg.global_scratch_alloc {alignment = 16 : i32, nbytes = 2 : i32, shared_cluster_state, third_party_allocation, tt.divisibility = 16 : i64} : !tt.ptr<i8>
+    // CHECK: %[[WRITE_TRACKING_GLOB:.*]] = ttg.global_scratch_alloc {alignment = 16 : i32, nbytes = 4 : i32, shared_cluster_state, third_party_allocation, tt.divisibility = 16 : i64} : !tt.ptr<i8>
     // CHECK: call {{.*}}fill_global_tensor{{.*}}(%[[WRITE_TRACKING_GLOB]], %c0_i8
 
-    // CHECK: %[[READ_TRACKING_GLOB:.*]] = ttg.global_scratch_alloc {alignment = 16 : i32, nbytes = 16 : i32, shared_cluster_state, third_party_allocation, tt.divisibility = 16 : i64} : !tt.ptr<i64>
+    // CHECK: %[[READ_TRACKING_GLOB:.*]] = ttg.global_scratch_alloc {alignment = 16 : i32, nbytes = 32 : i32, shared_cluster_state, third_party_allocation, tt.divisibility = 16 : i64} : !tt.ptr<i64>
     // CHECK: call {{.*}}fill_global_tensor{{.*}}(%[[READ_TRACKING_GLOB]], %c0_i64
     %c0_i32 = arith.constant 0 : i32
     %0 = ttg.local_alloc {allocation.offset = 0 : i32} : () -> !ttg.memdesc<3x32x32xf32, #shared, #smem, mutable>
@@ -133,7 +133,7 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 1 : i32, ttg.shar
 module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 1 : i32, ttg.shared = 65544 : i32, ttg.target = "hip:gfx1250", "ttg.threads-per-warp" = 32 : i32, "ttg.total-num-warps" = 1 : i32} {
   // CHECK: @read_bars_alloc
   tt.func public @read_bars_alloc() {
-    // CHECK: %[[READ_BARS_G:.*]] = ttg.global_scratch_alloc {alignment = 16 : i32, nbytes = 2 : i32, shared_cluster_state, third_party_allocation, tt.divisibility = 16 : i64} : !tt.ptr<i8>
+    // CHECK: %[[READ_BARS_G:.*]] = ttg.global_scratch_alloc {alignment = 16 : i32, nbytes = 4 : i32, shared_cluster_state, third_party_allocation, tt.divisibility = 16 : i64} : !tt.ptr<i8>
     // CHECK: call {{.*}}fill_global_tensor{{.*}}(%[[READ_BARS_G]], %c0_i8
     %c0 = arith.constant 0 : i32
     %0 = ttg.local_alloc {allocation.offset = 0 : i32} : () -> !ttg.memdesc<2x32x32xf32, #shared, #smem, mutable>
@@ -182,8 +182,8 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 1 : i32, ttg.shar
   tt.func public @async_copy_global_to_local_with_barriers(%ptr: tensor<32x32x!tt.ptr<f16>, #blocked>) {
     // CHECK-DAG: %[[WRITE_VISIBILITY_GLOB:.*]] = ttg.global_scratch_alloc {alignment = 16 : i32, nbytes = 16 : i32, shared_cluster_state, third_party_allocation, tt.divisibility = 16 : i64} : !tt.ptr<i64>
     // CHECK-DAG: %[[READ_VISIBILITY_GLOB:.*]] = ttg.global_scratch_alloc {alignment = 16 : i32, nbytes = 16 : i32, shared_cluster_state, third_party_allocation, tt.divisibility = 16 : i64} : !tt.ptr<i64>
-    // CHECK-DAG: %[[WRITE_TRACKING_GLOB:.*]] = ttg.global_scratch_alloc {alignment = 16 : i32, nbytes = 2 : i32, shared_cluster_state, third_party_allocation, tt.divisibility = 16 : i64} : !tt.ptr<i8>
-    // CHECK-DAG: %[[READ_TRACKING_GLOB:.*]] = ttg.global_scratch_alloc {alignment = 16 : i32, nbytes = 16 : i32, shared_cluster_state, third_party_allocation, tt.divisibility = 16 : i64} : !tt.ptr<i64>
+    // CHECK-DAG: %[[WRITE_TRACKING_GLOB:.*]] = ttg.global_scratch_alloc {alignment = 16 : i32, nbytes = 4 : i32, shared_cluster_state, third_party_allocation, tt.divisibility = 16 : i64} : !tt.ptr<i8>
+    // CHECK-DAG: %[[READ_TRACKING_GLOB:.*]] = ttg.global_scratch_alloc {alignment = 16 : i32, nbytes = 32 : i32, shared_cluster_state, third_party_allocation, tt.divisibility = 16 : i64} : !tt.ptr<i64>
 
     // CHECK-DAG: %[[WRT_COMMITS_GLOB:.*]] = ttg.global_scratch_alloc {alignment = 16 : i32, nbytes = 2 : i32, shared_cluster_state, third_party_allocation, tt.divisibility = 16 : i64} : !tt.ptr<i8>
 
@@ -361,10 +361,10 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 1 : i32, ttg.shar
 
     // CHECK-DAG: %[[BARRIERS:.*]] = tti.experimental_buffer_descriptors [65536], [{{.*}}], shared_mem : tensor<1xi64
 
-    // CHECK-DAG: %[[WRITE_TRACKING_GLOB:.*]] = ttg.global_scratch_alloc {alignment = 16 : i32, nbytes = 2 : i32, shared_cluster_state, third_party_allocation, tt.divisibility = 16 : i64} : !tt.ptr<i8>
+    // CHECK-DAG: %[[WRITE_TRACKING_GLOB:.*]] = ttg.global_scratch_alloc {alignment = 16 : i32, nbytes = 4 : i32, shared_cluster_state, third_party_allocation, tt.divisibility = 16 : i64} : !tt.ptr<i8>
     // CHECK: call {{.*}}fill_global_tensor{{.*}}(%[[WRITE_TRACKING_GLOB]], %c0_i8
 
-    // CHECK-DAG: %[[READ_TRACKING_GLOB:.*]] = ttg.global_scratch_alloc {alignment = 16 : i32, nbytes = 16 : i32, shared_cluster_state, third_party_allocation, tt.divisibility = 16 : i64} : !tt.ptr<i64>
+    // CHECK-DAG: %[[READ_TRACKING_GLOB:.*]] = ttg.global_scratch_alloc {alignment = 16 : i32, nbytes = 32 : i32, shared_cluster_state, third_party_allocation, tt.divisibility = 16 : i64} : !tt.ptr<i64>
     // CHECK: call {{.*}}fill_global_tensor{{.*}}(%[[READ_TRACKING_GLOB]], %c0_i64
     %c0_i32 = arith.constant 0 : i32
     %0 = ttg.local_alloc {allocation.offset = 0 : i32} : () -> !ttg.memdesc<32x32xf32, #shared, #smem, mutable>
@@ -399,7 +399,7 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 1 : i32, ttg.shar
   // CHECK: %[[BARRIER_STATUS_BITS:.*]] = arith.ori %[[BARRIER_INIT_BITS]], %[[BARRIER_SHIFTED_VALID_BITS]]
   // CHECK: %[[BARRIER_PACKED_STATUS:.*]] = "tt.reduce"(%{{.*}}) <{axis = 0 : i32}>
   // CHECK: arith.andi {{.*}} : i32
-  // CHECK-NOT: "tt.reduce"
+  // CHECK: "tt.reduce"
   // CHECK: tt.return %[[BARRIER_PACKED_STATUS]] : i32
   // CHECK-LABEL: @amdg_arrive_barrier
   tt.func public @amdg_arrive_barrier() {
@@ -471,10 +471,10 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 8 : i32, ttg.shar
     // CHECK: call {{.*}}fill_global_tensor{{.*}}(%[[READ_VISIBILITY_GLOB]], %c0_i64
 
     // CHECK-DAG: %[[BARRIERS:.*]] = tti.experimental_buffer_descriptors [65536], [{{.*}}], shared_mem : tensor<1xi64
-    // CHECK-DAG: %[[WRITE_TRACKING_GLOB:.*]] = ttg.global_scratch_alloc {alignment = 16 : i32, nbytes = 2 : i32, shared_cluster_state, third_party_allocation, tt.divisibility = 16 : i64} : !tt.ptr<i8>
+    // CHECK-DAG: %[[WRITE_TRACKING_GLOB:.*]] = ttg.global_scratch_alloc {alignment = 16 : i32, nbytes = 4 : i32, shared_cluster_state, third_party_allocation, tt.divisibility = 16 : i64} : !tt.ptr<i8>
     // CHECK: call {{.*}}fill_global_tensor{{.*}}(%[[WRITE_TRACKING_GLOB]], %c0_i8
 
-    // CHECK-DAG: %[[READ_TRACKING_GLOB:.*]] = ttg.global_scratch_alloc {alignment = 16 : i32, nbytes = 16 : i32, shared_cluster_state, third_party_allocation, tt.divisibility = 16 : i64} : !tt.ptr<i64>
+    // CHECK-DAG: %[[READ_TRACKING_GLOB:.*]] = ttg.global_scratch_alloc {alignment = 16 : i32, nbytes = 32 : i32, shared_cluster_state, third_party_allocation, tt.divisibility = 16 : i64} : !tt.ptr<i64>
     // CHECK: call {{.*}}fill_global_tensor{{.*}}(%[[READ_TRACKING_GLOB]], %c0_i64
     %c0_i32 = arith.constant 0 : i32
     %pred = arith.constant 1 : i32

--- a/test/TritonGPU/amd/amd-consan.mlir
+++ b/test/TritonGPU/amd/amd-consan.mlir
@@ -77,10 +77,10 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 1 : i32, ttg.shar
     // CHECK: %[[READ_VISIBILITY_GLOB:.*]] = ttg.global_scratch_alloc {alignment = 16 : i32, nbytes = 32 : i32, shared_cluster_state, third_party_allocation, tt.divisibility = 16 : i64} : !tt.ptr<i64>
     // CHECK: call {{.*}}fill_global_tensor{{.*}}(%[[READ_VISIBILITY_GLOB]], %c0_i64
 
-    // CHECK: %[[WRITE_TRACKING_GLOB:.*]] = ttg.global_scratch_alloc {alignment = 16 : i32, nbytes = 4 : i32, shared_cluster_state, third_party_allocation, tt.divisibility = 16 : i64} : !tt.ptr<i8>
+    // CHECK: %[[WRITE_TRACKING_GLOB:.*]] = ttg.global_scratch_alloc {alignment = 16 : i32, nbytes = 8 : i32, shared_cluster_state, third_party_allocation, tt.divisibility = 16 : i64} : !tt.ptr<i8>
     // CHECK: call {{.*}}fill_global_tensor{{.*}}(%[[WRITE_TRACKING_GLOB]], %c0_i8
 
-    // CHECK: %[[READ_TRACKING_GLOB:.*]] = ttg.global_scratch_alloc {alignment = 16 : i32, nbytes = 32 : i32, shared_cluster_state, third_party_allocation, tt.divisibility = 16 : i64} : !tt.ptr<i64>
+    // CHECK: %[[READ_TRACKING_GLOB:.*]] = ttg.global_scratch_alloc {alignment = 16 : i32, nbytes = 64 : i32, shared_cluster_state, third_party_allocation, tt.divisibility = 16 : i64} : !tt.ptr<i64>
     // CHECK: call {{.*}}fill_global_tensor{{.*}}(%[[READ_TRACKING_GLOB]], %c0_i64
     %0 = ttg.local_alloc {allocation.offset = 0 : i32} : () -> !ttg.memdesc<32x32xf32, #shared, #smem, mutable>
     %1 = ttg.local_alloc {allocation.offset = 4096 : i32} : () -> !ttg.memdesc<32x32xf32, #shared, #smem, mutable>
@@ -374,10 +374,10 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 1 : i32, ttg.shar
     // CHECK: tt.call @__triton_consan_verify_barrier_initialized
     // CHECK-DAG: tt.call @__triton_consan_set_waiting
     // CHECK-DAG: tt.call @__triton_consan_check_all_active_waiting
-    // CHECK: amdg.wait_barrier
+    // CHECK: amdg.wait_barrier {{.*}}, %[[WAIT_PHASE:[^ :]+]]
     amdg.wait_barrier %bar, %c0_i32 : !ttg.memdesc<1xi64, #shared1, #smem, mutable>
     // CHECK: tti.experimental_lock_acquire
-    // CHECK: tt.call @__triton_consan_transfer_visible_accesses{{.*}}%[[BARRIERS]], %[[WRITE_VISIBILITY_GLOB]], %[[WRITE_TRACKING_GLOB]], %[[READ_VISIBILITY_GLOB]], %[[READ_TRACKING_GLOB]]) : {{.*}}!tt.ptr<i64>, !tt.ptr<i8>, !tt.ptr<i64>, !tt.ptr<i64>) -> ()
+    // CHECK: tt.call @__triton_consan_transfer_visible_accesses{{.*}}(%{{[^,]+}}, %{{[^,]+}}, %[[WAIT_PHASE]], {{.*}}%[[BARRIERS]], %[[WRITE_VISIBILITY_GLOB]], %[[WRITE_TRACKING_GLOB]], %[[READ_VISIBILITY_GLOB]], %[[READ_TRACKING_GLOB]]) : {{.*}}!tt.ptr<i64>, !tt.ptr<i8>, !tt.ptr<i64>, !tt.ptr<i64>) -> ()
     // CHECK: tt.call @__triton_consan_clear_waiting
     // CHECK: tti.experimental_lock_release
     ttg.local_load %0 : !ttg.memdesc<32x32xf32, #shared, #smem, mutable> -> tensor<32x32xf32, #blocked>

--- a/test/TritonGPU/consan.mlir
+++ b/test/TritonGPU/consan.mlir
@@ -122,7 +122,7 @@ module attributes {"ttg.num-ctas" = 8 : i32, "ttg.num-warps" = 1 : i32, ttg.shar
     // CHECK: %[[EXPECT_BASE:.*]] = arith.andi %[[EXPECT_RECIPIENT_CTA]], %[[EXPECT_FIXED]] : i32
     // CHECK: %[[EXPECT_PATTERN:.*]] = arith.constant 5 : i32
     // CHECK: %[[EXPECT_RECIPIENTS:.*]] = arith.shli %[[EXPECT_PATTERN]], %[[EXPECT_BASE]] : i32
-    // CHECK: tt.call @__triton_consan_verify_and_update_barrier_state{{.*}}({{.*}}%[[EXPECT_PRED]]{{.*}}%[[EXPECT_RECIPIENTS]])
+    // CHECK: tt.call @__triton_consan_verify_and_update_barrier_state{{.*}}({{.*}}%[[EXPECT_PRED]]{{.*}}%[[EXPECT_RECIPIENTS]], {{.*}})
     // CHECK: tti.experimental_assert_uniform {{.*}}, "Barrier used before initialization or after invalidation"
     // CHECK: tti.experimental_assert_uniform {{.*}}, "Barrier arrive underflow: current count or tx-count would become invalid"
     // CHECK: ttng.barrier_expect
@@ -150,7 +150,7 @@ module attributes {"ttg.num-ctas" = 2 : i32, "ttg.num-warps" = 1 : i32, ttg.shar
     // CHECK: %[[TWO_PATTERN:.*]] = arith.constant 3 : i32
     // CHECK: %[[TWO_SHIFT:.*]] = arith.shli %[[TWO_PATTERN]], {{.*}} : i32
     // CHECK: %[[TWO_RECIPIENTS:.*]] = arith.ori {{.*}}, %[[TWO_SHIFT]] : i32
-    // CHECK: tt.call @__triton_consan_verify_and_update_barrier_state{{.*}}({{.*}}%[[TWO_RECIPIENTS]])
+    // CHECK: tt.call @__triton_consan_verify_and_update_barrier_state{{.*}}({{.*}}%[[TWO_RECIPIENTS]], {{.*}})
     // CHECK: ttng.arrive_barrier {{.*}}multicastCTA = 1 : i32
     ttng.arrive_barrier %bar, 1 {multicastCTA = 1 : i32} : !ttg.memdesc<2xi64, #barrier_multicast_two, #smem_multicast_two, mutable>
     tt.return
@@ -176,7 +176,7 @@ module attributes {"ttg.num-ctas" = 4 : i32, "ttg.num-warps" = 1 : i32, ttg.shar
     // CHECK: %[[LOW_PATTERN:.*]] = arith.constant 3 : i32
     // CHECK: %[[LOW_SHIFT:.*]] = arith.shli %[[LOW_PATTERN]], %[[LOW_BASE]] : i32
     // CHECK: %[[LOW_RECIPIENTS:.*]] = arith.ori {{.*}}, %[[LOW_SHIFT]] : i32
-    // CHECK: tt.call @__triton_consan_verify_and_update_barrier_state{{.*}}({{.*}}%[[LOW_RECIPIENTS]])
+    // CHECK: tt.call @__triton_consan_verify_and_update_barrier_state{{.*}}({{.*}}%[[LOW_RECIPIENTS]], {{.*}})
     // CHECK: ttng.arrive_barrier {{.*}}multicastCTA = 1 : i32
     ttng.arrive_barrier %bar0, 1 {multicastCTA = 1 : i32} : !ttg.memdesc<4xi64, #barrier_multicast_four, #smem_multicast_four, mutable>
     // multicastCTA=2 reaches {0,2} or {1,3}.
@@ -186,7 +186,7 @@ module attributes {"ttg.num-ctas" = 4 : i32, "ttg.num-warps" = 1 : i32, ttg.shar
     // CHECK: %[[HIGH_PATTERN:.*]] = arith.constant 5 : i32
     // CHECK: %[[HIGH_SHIFT:.*]] = arith.shli %[[HIGH_PATTERN]], %[[HIGH_BASE]] : i32
     // CHECK: %[[HIGH_RECIPIENTS:.*]] = arith.ori {{.*}}, %[[HIGH_SHIFT]] : i32
-    // CHECK: tt.call @__triton_consan_verify_and_update_barrier_state{{.*}}({{.*}}%[[HIGH_RECIPIENTS]])
+    // CHECK: tt.call @__triton_consan_verify_and_update_barrier_state{{.*}}({{.*}}%[[HIGH_RECIPIENTS]], {{.*}})
     // CHECK: ttng.arrive_barrier {{.*}}multicastCTA = 2 : i32
     ttng.arrive_barrier %bar1, 1 {multicastCTA = 2 : i32} : !ttg.memdesc<4xi64, #barrier_multicast_four, #smem_multicast_four, mutable>
     tt.return
@@ -414,8 +414,8 @@ module attributes {"ttg.num-ctas" = 2 : i32, "ttg.num-warps" = 4 : i32, ttg.shar
 module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.shared = 8200 : i32, ttg.target = "cuda:90", ttg.tensor_memory_size = 0 : i32, "ttg.threads-per-warp" = 32 : i32, "ttg.total-num-warps" = 4 : i32} {
   // The helper consumes the analysis-derived completion mask directly.
   // CHECK-LABEL: tt.func private @__triton_consan_track_proxy_accesses_for_buffer
-  // CHECK-SAME: %arg8: tensor<8xi1{{.*}}, %arg9: i32
-  // CHECK: ttg.convert_layout %arg8 {force_warp_shuffle}
+  // CHECK-SAME: %arg8: i32, %arg9: tensor<8xi1{{.*}}, %arg10: i32
+  // CHECK: ttg.convert_layout %arg9 {force_warp_shuffle}
   // CHECK-LABEL: @tma_completion_tracks_contained_proxy_frontier
   tt.func public @tma_completion_tracks_contained_proxy_frontier(
       %desc: !tt.tensordesc<1024xi32, #frontier_shared>) {
@@ -602,7 +602,7 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 1 : i32, ttg.shar
   // CHECK: %[[BARRIER_STATUS_BITS:.*]] = arith.ori %[[BARRIER_INIT_BITS]], %[[BARRIER_SHIFTED_VALID_BITS]]
   // CHECK: %[[BARRIER_PACKED_STATUS:.*]] = "tt.reduce"(%{{.*}}) <{axis = 0 : i32}>
   // CHECK: arith.andi {{.*}} : i32
-  // CHECK-NOT: "tt.reduce"
+  // CHECK: "tt.reduce"
   // CHECK: tt.return %[[BARRIER_PACKED_STATUS]] : i32
   // CHECK-LABEL: @async_tma_copy_global_to_local
   tt.func public @async_tma_copy_global_to_local(%arg0: !tt.tensordesc<32x32xf32, #shared>) {
@@ -2363,7 +2363,7 @@ module attributes {"ttg.num-ctas" = 2 : i32, "ttg.num-warps" = 4 : i32, ttg.shar
     // CHECK: tt.call @__triton_consan_verify_write_visibility{{.*}}({{.*}}%[[REMOTE_CTA]])
     // CHECK: tt.call @__triton_consan_track_barrier_write_for_buffer{{.*}}({{.*}}%[[REMOTE_CTA]], %[[REMOTE_CTA]])
     // CHECK: %[[BYTES_PER_CTA:.*]] = arith.constant -256 : i64
-    // CHECK: tt.call @__triton_consan_verify_and_update_barrier_state{{.*}}({{.*}}%[[BYTES_PER_CTA]], {{.*}}%[[REMOTE_CTA]])
+    // CHECK: tt.call @__triton_consan_verify_and_update_barrier_state{{.*}}({{.*}}%[[BYTES_PER_CTA]], {{.*}}%[[REMOTE_CTA]], {{.*}})
     // CHECK: ttng.async_shared_store
     ttng.async_shared_store %src, %view, %bar : tensor<128xi32, #async_remote_src> -> !ttg.memdesc<128xi32, #async_remote_dst, #async_remote_smem, mutable, 256>, !ttg.memdesc<2xi64, #async_remote_dst, #async_remote_smem, mutable>
     tt.return

--- a/test/TritonGPU/consan.mlir
+++ b/test/TritonGPU/consan.mlir
@@ -23,10 +23,10 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 1 : i32, ttg.shar
     // CHECK: %[[READ_VISIBILITY_GLOB:.*]] = ttg.global_scratch_alloc {alignment = 16 : i32, nbytes = 16 : i32, shared_cluster_state, third_party_allocation, tt.divisibility = 16 : i64} : !tt.ptr<i64>
     // CHECK: call {{.*}}fill_global_tensor{{.*}}(%[[READ_VISIBILITY_GLOB]], %c0_i64
 
-    // CHECK: %[[WRITE_TRACKING_GLOB:.*]] = ttg.global_scratch_alloc {alignment = 16 : i32, nbytes = 2 : i32, shared_cluster_state, third_party_allocation, tt.divisibility = 16 : i64} : !tt.ptr<i8>
+    // CHECK: %[[WRITE_TRACKING_GLOB:.*]] = ttg.global_scratch_alloc {alignment = 16 : i32, nbytes = 4 : i32, shared_cluster_state, third_party_allocation, tt.divisibility = 16 : i64} : !tt.ptr<i8>
     // CHECK: call {{.*}}fill_global_tensor{{.*}}(%[[WRITE_TRACKING_GLOB]], %c0_i8
 
-    // CHECK: %[[READ_TRACKING_GLOB:.*]] = ttg.global_scratch_alloc {alignment = 16 : i32, nbytes = 16 : i32, shared_cluster_state, third_party_allocation, tt.divisibility = 16 : i64} : !tt.ptr<i64>
+    // CHECK: %[[READ_TRACKING_GLOB:.*]] = ttg.global_scratch_alloc {alignment = 16 : i32, nbytes = 32 : i32, shared_cluster_state, third_party_allocation, tt.divisibility = 16 : i64} : !tt.ptr<i64>
     // CHECK: call {{.*}}fill_global_tensor{{.*}}(%[[READ_TRACKING_GLOB]], %c0_i64
     %0 = ttg.local_alloc {allocation.offset = 0 : i32} : () -> !ttg.memdesc<32x32xf32, #shared, #smem, mutable>
     %bar = ttg.local_alloc {allocation.offset = 4096 : i32} : () -> !ttg.memdesc<1xi64, #shared1, #smem, mutable>
@@ -50,9 +50,9 @@ module attributes {"ttg.num-ctas" = 2 : i32, "ttg.num-warps" = 1 : i32, ttg.shar
     // CHECK: call {{.*}}fill_global_tensor{{.*}}(%[[WRITE_VISIBILITY_GLOB]], %c0_i64
     // CHECK: %[[READ_VISIBILITY_GLOB:.*]] = ttg.global_scratch_alloc {alignment = 16 : i32, nbytes = 128 : i32, shared_cluster_state, third_party_allocation, tt.divisibility = 16 : i64} : !tt.ptr<i64>
     // CHECK: call {{.*}}fill_global_tensor{{.*}}(%[[READ_VISIBILITY_GLOB]], %c0_i64
-    // CHECK: %[[WRITE_TRACKING_GLOB:.*]] = ttg.global_scratch_alloc {alignment = 16 : i32, nbytes = 8 : i32, shared_cluster_state, third_party_allocation, tt.divisibility = 16 : i64} : !tt.ptr<i8>
+    // CHECK: %[[WRITE_TRACKING_GLOB:.*]] = ttg.global_scratch_alloc {alignment = 16 : i32, nbytes = 16 : i32, shared_cluster_state, third_party_allocation, tt.divisibility = 16 : i64} : !tt.ptr<i8>
     // CHECK: call {{.*}}fill_global_tensor{{.*}}(%[[WRITE_TRACKING_GLOB]], %c0_i8
-    // CHECK: %[[READ_TRACKING_GLOB:.*]] = ttg.global_scratch_alloc {alignment = 16 : i32, nbytes = 128 : i32, shared_cluster_state, third_party_allocation, tt.divisibility = 16 : i64} : !tt.ptr<i64>
+    // CHECK: %[[READ_TRACKING_GLOB:.*]] = ttg.global_scratch_alloc {alignment = 16 : i32, nbytes = 256 : i32, shared_cluster_state, third_party_allocation, tt.divisibility = 16 : i64} : !tt.ptr<i64>
     // CHECK: call {{.*}}fill_global_tensor{{.*}}(%[[READ_TRACKING_GLOB]], %c0_i64
     // Matching register and shared ownership keeps an ordinary load local.
     // CHECK: ttng.init_barrier
@@ -261,8 +261,8 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 1 : i32, ttg.shar
     %value = ttg.local_load %buf : !ttg.memdesc<32x32xf32, #proxy_shared, #proxy_smem, mutable> -> tensor<32x32xf32, #proxy_blocked>
     // CHECK: tt.call @__triton_consan_track_proxy_accesses
     ttng.arrive_barrier %bar, 1, %true : !ttg.memdesc<1xi64, #proxy_bar_shared, #proxy_smem, mutable>
-    // CHECK: ttng.wait_barrier
-    // CHECK: tt.call @__triton_consan_complete_barrier_wait
+    // CHECK: ttng.wait_barrier {{.*}}, %[[PROXY_WAIT_PHASE:[^, ]+]],
+    // CHECK: tt.call @__triton_consan_complete_barrier_wait{{.*}}(%{{[^,]+}}, %{{[^,]+}}, %[[PROXY_WAIT_PHASE]],
     ttng.wait_barrier %bar, %c0, %true : !ttg.memdesc<1xi64, #proxy_bar_shared, #proxy_smem, mutable>
     // CHECK: tt.call @__triton_consan_fence_proxy_accesses
     ttng.fence_async_shared {bCluster = false}
@@ -471,10 +471,10 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 1 : i32, ttg.shar
     // CHECK: %[[READ_VISIBILITY_GLOB:.*]] = ttg.global_scratch_alloc {alignment = 16 : i32, nbytes = 32 : i32, shared_cluster_state, third_party_allocation, tt.divisibility = 16 : i64} : !tt.ptr<i64>
     // CHECK: call {{.*}}fill_global_tensor{{.*}}(%[[READ_VISIBILITY_GLOB]], %c0_i64
 
-    // CHECK: %[[WRITE_TRACKING_GLOB:.*]] = ttg.global_scratch_alloc {alignment = 16 : i32, nbytes = 4 : i32, shared_cluster_state, third_party_allocation, tt.divisibility = 16 : i64} : !tt.ptr<i8>
+    // CHECK: %[[WRITE_TRACKING_GLOB:.*]] = ttg.global_scratch_alloc {alignment = 16 : i32, nbytes = 8 : i32, shared_cluster_state, third_party_allocation, tt.divisibility = 16 : i64} : !tt.ptr<i8>
     // CHECK: call {{.*}}fill_global_tensor{{.*}}(%[[WRITE_TRACKING_GLOB]], %c0_i8
 
-    // CHECK: %[[READ_TRACKING_GLOB:.*]] = ttg.global_scratch_alloc {alignment = 16 : i32, nbytes = 32 : i32, shared_cluster_state, third_party_allocation, tt.divisibility = 16 : i64} : !tt.ptr<i64>
+    // CHECK: %[[READ_TRACKING_GLOB:.*]] = ttg.global_scratch_alloc {alignment = 16 : i32, nbytes = 64 : i32, shared_cluster_state, third_party_allocation, tt.divisibility = 16 : i64} : !tt.ptr<i64>
     // CHECK: call {{.*}}fill_global_tensor{{.*}}(%[[READ_TRACKING_GLOB]], %c0_i64
     %0 = ttg.local_alloc {allocation.offset = 0 : i32} : () -> !ttg.memdesc<32x32xf32, #shared, #smem, mutable>
     %1 = ttg.local_alloc {allocation.offset = 4096 : i32} : () -> !ttg.memdesc<32x32xf32, #shared, #smem, mutable>
@@ -501,10 +501,10 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 1 : i32, ttg.shar
     // CHECK: %[[READ_VISIBILITY_GLOB:.*]] = ttg.global_scratch_alloc {alignment = 16 : i32, nbytes = 32 : i32, shared_cluster_state, third_party_allocation, tt.divisibility = 16 : i64} : !tt.ptr<i64>
     // CHECK: call {{.*}}fill_global_tensor{{.*}}(%[[READ_VISIBILITY_GLOB]], %c0_i64
 
-    // CHECK: %[[WRITE_TRACKING_GLOB:.*]] = ttg.global_scratch_alloc {alignment = 16 : i32, nbytes = 4 : i32, shared_cluster_state, third_party_allocation, tt.divisibility = 16 : i64} : !tt.ptr<i8>
+    // CHECK: %[[WRITE_TRACKING_GLOB:.*]] = ttg.global_scratch_alloc {alignment = 16 : i32, nbytes = 8 : i32, shared_cluster_state, third_party_allocation, tt.divisibility = 16 : i64} : !tt.ptr<i8>
     // CHECK: call {{.*}}fill_global_tensor{{.*}}(%[[WRITE_TRACKING_GLOB]], %c0_i8
 
-    // CHECK: %[[READ_TRACKING_GLOB:.*]] = ttg.global_scratch_alloc {alignment = 16 : i32, nbytes = 32 : i32, shared_cluster_state, third_party_allocation, tt.divisibility = 16 : i64} : !tt.ptr<i64>
+    // CHECK: %[[READ_TRACKING_GLOB:.*]] = ttg.global_scratch_alloc {alignment = 16 : i32, nbytes = 64 : i32, shared_cluster_state, third_party_allocation, tt.divisibility = 16 : i64} : !tt.ptr<i64>
     // CHECK: call {{.*}}fill_global_tensor{{.*}}(%[[READ_TRACKING_GLOB]], %c0_i64
     %0 = ttg.local_alloc {allocation.offset = 0 : i32} : () -> !ttg.memdesc<32x32xf32, #shared, #smem, mutable>
     %1 = ttg.local_alloc {allocation.offset = 4096 : i32} : () -> !ttg.memdesc<32x32xf32, #shared, #smem, mutable>
@@ -533,10 +533,10 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 1 : i32, ttg.shar
     // CHECK: %[[READ_VISIBILITY_GLOB:.*]] = ttg.global_scratch_alloc {alignment = 16 : i32, nbytes = 16 : i32, shared_cluster_state, third_party_allocation, tt.divisibility = 16 : i64} : !tt.ptr<i64>
     // CHECK: call {{.*}}fill_global_tensor{{.*}}(%[[READ_VISIBILITY_GLOB]], %c0_i64
 
-    // CHECK: %[[WRITE_TRACKING_GLOB:.*]] = ttg.global_scratch_alloc {alignment = 16 : i32, nbytes = 2 : i32, shared_cluster_state, third_party_allocation, tt.divisibility = 16 : i64} : !tt.ptr<i8>
+    // CHECK: %[[WRITE_TRACKING_GLOB:.*]] = ttg.global_scratch_alloc {alignment = 16 : i32, nbytes = 4 : i32, shared_cluster_state, third_party_allocation, tt.divisibility = 16 : i64} : !tt.ptr<i8>
     // CHECK: call {{.*}}fill_global_tensor{{.*}}(%[[WRITE_TRACKING_GLOB]], %c0_i8
 
-    // CHECK: %[[READ_TRACKING_GLOB:.*]] = ttg.global_scratch_alloc {alignment = 16 : i32, nbytes = 16 : i32, shared_cluster_state, third_party_allocation, tt.divisibility = 16 : i64} : !tt.ptr<i64>
+    // CHECK: %[[READ_TRACKING_GLOB:.*]] = ttg.global_scratch_alloc {alignment = 16 : i32, nbytes = 32 : i32, shared_cluster_state, third_party_allocation, tt.divisibility = 16 : i64} : !tt.ptr<i64>
     // CHECK: call {{.*}}fill_global_tensor{{.*}}(%[[READ_TRACKING_GLOB]], %c0_i64
     %c0_i32 = arith.constant 0 : i32
     %0 = ttg.local_alloc {allocation.offset = 0 : i32} : () -> !ttg.memdesc<3x32x32xf32, #shared, #smem, mutable>
@@ -557,7 +557,7 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 1 : i32, ttg.shar
 module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 1 : i32, ttg.shared = 65544 : i32, ttg.target = "cuda:90", ttg.tensor_memory_size = 0 : i32, "ttg.threads-per-warp" = 32 : i32, "ttg.total-num-warps" = 1 : i32} {
   // CHECK: @read_bars_alloc
   tt.func public @read_bars_alloc() {
-    // CHECK: %[[READ_BARS_G:.*]] = ttg.global_scratch_alloc {alignment = 16 : i32, nbytes = 2 : i32, shared_cluster_state, third_party_allocation, tt.divisibility = 16 : i64} : !tt.ptr<i8>
+    // CHECK: %[[READ_BARS_G:.*]] = ttg.global_scratch_alloc {alignment = 16 : i32, nbytes = 4 : i32, shared_cluster_state, third_party_allocation, tt.divisibility = 16 : i64} : !tt.ptr<i8>
     // CHECK: call {{.*}}fill_global_tensor{{.*}}(%[[READ_BARS_G]], %c0_i8
     %c0 = arith.constant 0 : i32
     %0 = ttg.local_alloc {allocation.offset = 0 : i32} : () -> !ttg.memdesc<2x32x32xf32, #shared, #smem, mutable>
@@ -613,10 +613,10 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 1 : i32, ttg.shar
     // CHECK: call {{.*}}fill_global_tensor{{.*}}(%[[READ_VISIBILITY_GLOB]], %c0_i64
 
     // CHECK-DAG: %[[BARRIERS:.*]] = tti.experimental_buffer_descriptors [65536], [{{.*}}], shared_mem : tensor<1xi64
-    // CHECK-DAG: %[[WRITE_TRACKING_GLOB:.*]] = ttg.global_scratch_alloc {alignment = 16 : i32, nbytes = 2 : i32, shared_cluster_state, third_party_allocation, tt.divisibility = 16 : i64} : !tt.ptr<i8>
+    // CHECK-DAG: %[[WRITE_TRACKING_GLOB:.*]] = ttg.global_scratch_alloc {alignment = 16 : i32, nbytes = 4 : i32, shared_cluster_state, third_party_allocation, tt.divisibility = 16 : i64} : !tt.ptr<i8>
     // CHECK: call {{.*}}fill_global_tensor{{.*}}(%[[WRITE_TRACKING_GLOB]], %c0_i8
 
-    // CHECK-DAG: %[[READ_TRACKING_GLOB:.*]] = ttg.global_scratch_alloc {alignment = 16 : i32, nbytes = 16 : i32, shared_cluster_state, third_party_allocation, tt.divisibility = 16 : i64} : !tt.ptr<i64>
+    // CHECK-DAG: %[[READ_TRACKING_GLOB:.*]] = ttg.global_scratch_alloc {alignment = 16 : i32, nbytes = 32 : i32, shared_cluster_state, third_party_allocation, tt.divisibility = 16 : i64} : !tt.ptr<i64>
     // CHECK: call {{.*}}fill_global_tensor{{.*}}(%[[READ_TRACKING_GLOB]], %c0_i64
     %true = arith.constant true
     %c0_i32 = arith.constant 0 : i32
@@ -1026,10 +1026,10 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 1 : i32, ttg.shar
 
     // CHECK-DAG: %[[BARRIERS:.*]] = tti.experimental_buffer_descriptors [65536], [{{.*}}], shared_mem : tensor<1xi64, #linear{{[0-9]*}}>
 
-    // CHECK-DAG: %[[WRITE_TRACKING_GLOB:.*]] = ttg.global_scratch_alloc {alignment = 16 : i32, nbytes = 2 : i32, shared_cluster_state, third_party_allocation, tt.divisibility = 16 : i64} : !tt.ptr<i8>
+    // CHECK-DAG: %[[WRITE_TRACKING_GLOB:.*]] = ttg.global_scratch_alloc {alignment = 16 : i32, nbytes = 4 : i32, shared_cluster_state, third_party_allocation, tt.divisibility = 16 : i64} : !tt.ptr<i8>
     // CHECK: call {{.*}}fill_global_tensor{{.*}}(%[[WRITE_TRACKING_GLOB]], %c0_i8
 
-    // CHECK-DAG: %[[READ_TRACKING_GLOB:.*]] = ttg.global_scratch_alloc {alignment = 16 : i32, nbytes = 16 : i32, shared_cluster_state, third_party_allocation, tt.divisibility = 16 : i64} : !tt.ptr<i64>
+    // CHECK-DAG: %[[READ_TRACKING_GLOB:.*]] = ttg.global_scratch_alloc {alignment = 16 : i32, nbytes = 32 : i32, shared_cluster_state, third_party_allocation, tt.divisibility = 16 : i64} : !tt.ptr<i64>
     // CHECK: call {{.*}}fill_global_tensor{{.*}}(%[[READ_TRACKING_GLOB]], %c0_i64
     %true = arith.constant true
     %c0_i32 = arith.constant 0 : i32
@@ -1040,10 +1040,10 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 1 : i32, ttg.shar
     // CHECK: tt.call @__triton_consan_verify_barrier_initialized
     // CHECK-DAG: tt.call @__triton_consan_set_waiting
     // CHECK-DAG: tt.call @__triton_consan_check_all_active_waiting
-    // CHECK: ttng.wait_barrier
+    // CHECK: ttng.wait_barrier {{.*}}, %[[WAIT_PHASE:[^, ]+]],
     ttng.wait_barrier %bar, %c0_i32, %true : !ttg.memdesc<1xi64, #shared1, #smem, mutable>
     // CHECK: tti.experimental_lock_acquire
-    // CHECK: tt.call @__triton_consan_transfer_visible_accesses{{.*}}%[[BARRIERS]], %[[WRITE_VISIBILITY_GLOB]], %[[WRITE_TRACKING_GLOB]], %[[READ_VISIBILITY_GLOB]], %[[READ_TRACKING_GLOB]]) : {{.*}}!tt.ptr<i64>, !tt.ptr<i8>, !tt.ptr<i64>, !tt.ptr<i64>) -> ()
+    // CHECK: tt.call @__triton_consan_transfer_visible_accesses{{.*}}(%{{[^,]+}}, %{{[^,]+}}, %[[WAIT_PHASE]], {{.*}}%[[BARRIERS]], %[[WRITE_VISIBILITY_GLOB]], %[[WRITE_TRACKING_GLOB]], %[[READ_VISIBILITY_GLOB]], %[[READ_TRACKING_GLOB]]) : {{.*}}!tt.ptr<i64>, !tt.ptr<i8>, !tt.ptr<i64>, !tt.ptr<i64>) -> ()
     // CHECK: tt.call @__triton_consan_clear_waiting
     // CHECK: tti.experimental_lock_release
     ttg.local_load %0 : !ttg.memdesc<32x32xf32, #shared, #smem, mutable> -> tensor<32x32xf32, #blocked>
@@ -1134,10 +1134,10 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 1 : i32, ttg.shar
     // CHECK-DAG: tt.call @[[FILL_TWO_I64:__triton_consan_fill_global_tensor[^ (]*T2xI64]]
     // CHECK-DAG: %[[BARRIERS:.*]] = tti.experimental_buffer_descriptors [65536], [{{.*}}], shared_mem : tensor<1xi64
 
-    // CHECK-DAG: %[[SM_WRITE_TRACKING_GLOB:.*]] = ttg.global_scratch_alloc {alignment = 16 : i32, nbytes = 4 : i32, shared_cluster_state, third_party_allocation, tt.divisibility = 16 : i64} : !tt.ptr<i8>
-    // CHECK-DAG: %[[SM_READ_TRACKING_GLOB:.*]] = ttg.global_scratch_alloc {alignment = 16 : i32, nbytes = 32 : i32, shared_cluster_state, third_party_allocation, tt.divisibility = 16 : i64} : !tt.ptr<i64>
-    // CHECK-DAG: %[[TM_WRITE_TRACKING_GLOB:.*]] = ttg.global_scratch_alloc {alignment = 16 : i32, nbytes = 1 : i32, shared_cluster_state, third_party_allocation, tt.divisibility = 16 : i64} : !tt.ptr<i8>
-    // CHECK-DAG: %[[TM_READ_TRACKING_GLOB:.*]] = ttg.global_scratch_alloc {alignment = 16 : i32, nbytes = 8 : i32, shared_cluster_state, third_party_allocation, tt.divisibility = 16 : i64} : !tt.ptr<i64>
+    // CHECK-DAG: %[[SM_WRITE_TRACKING_GLOB:.*]] = ttg.global_scratch_alloc {alignment = 16 : i32, nbytes = 8 : i32, shared_cluster_state, third_party_allocation, tt.divisibility = 16 : i64} : !tt.ptr<i8>
+    // CHECK-DAG: %[[SM_READ_TRACKING_GLOB:.*]] = ttg.global_scratch_alloc {alignment = 16 : i32, nbytes = 64 : i32, shared_cluster_state, third_party_allocation, tt.divisibility = 16 : i64} : !tt.ptr<i64>
+    // CHECK-DAG: %[[TM_WRITE_TRACKING_GLOB:.*]] = ttg.global_scratch_alloc {alignment = 16 : i32, nbytes = 2 : i32, shared_cluster_state, third_party_allocation, tt.divisibility = 16 : i64} : !tt.ptr<i8>
+    // CHECK-DAG: %[[TM_READ_TRACKING_GLOB:.*]] = ttg.global_scratch_alloc {alignment = 16 : i32, nbytes = 16 : i32, shared_cluster_state, third_party_allocation, tt.divisibility = 16 : i64} : !tt.ptr<i64>
 
     // CHECK: ttng.init_barrier
     // CHECK: arith.shli
@@ -1195,10 +1195,10 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 1 : i32, ttg.shar
     // CHECK-DAG: %[[TM_READ_VISIBILITY_GLOB:.*]] = ttg.global_scratch_alloc {alignment = 16 : i32, nbytes = 32 : i32, shared_cluster_state, third_party_allocation, tt.divisibility = 16 : i64} : !tt.ptr<i64>
     // CHECK-DAG: %[[BARRIERS:.*]] = tti.experimental_buffer_descriptors [65536], [{{.*}}], shared_mem : tensor<1xi64
 
-    // CHECK-DAG: %[[SM_WRITE_TRACKING_GLOB:.*]] = ttg.global_scratch_alloc {alignment = 16 : i32, nbytes = 2 : i32, shared_cluster_state, third_party_allocation, tt.divisibility = 16 : i64} : !tt.ptr<i8>
-    // CHECK-DAG: %[[SM_READ_TRACKING_GLOB:.*]] = ttg.global_scratch_alloc {alignment = 16 : i32, nbytes = 16 : i32, shared_cluster_state, third_party_allocation, tt.divisibility = 16 : i64} : !tt.ptr<i64>
-    // CHECK-DAG: %[[TM_WRITE_TRACKING_GLOB:.*]] = ttg.global_scratch_alloc {alignment = 16 : i32, nbytes = 2 : i32, shared_cluster_state, third_party_allocation, tt.divisibility = 16 : i64} : !tt.ptr<i8>
-    // CHECK-DAG: %[[TM_READ_TRACKING_GLOB:.*]] = ttg.global_scratch_alloc {alignment = 16 : i32, nbytes = 16 : i32, shared_cluster_state, third_party_allocation, tt.divisibility = 16 : i64} : !tt.ptr<i64>
+    // CHECK-DAG: %[[SM_WRITE_TRACKING_GLOB:.*]] = ttg.global_scratch_alloc {alignment = 16 : i32, nbytes = 4 : i32, shared_cluster_state, third_party_allocation, tt.divisibility = 16 : i64} : !tt.ptr<i8>
+    // CHECK-DAG: %[[SM_READ_TRACKING_GLOB:.*]] = ttg.global_scratch_alloc {alignment = 16 : i32, nbytes = 32 : i32, shared_cluster_state, third_party_allocation, tt.divisibility = 16 : i64} : !tt.ptr<i64>
+    // CHECK-DAG: %[[TM_WRITE_TRACKING_GLOB:.*]] = ttg.global_scratch_alloc {alignment = 16 : i32, nbytes = 4 : i32, shared_cluster_state, third_party_allocation, tt.divisibility = 16 : i64} : !tt.ptr<i8>
+    // CHECK-DAG: %[[TM_READ_TRACKING_GLOB:.*]] = ttg.global_scratch_alloc {alignment = 16 : i32, nbytes = 32 : i32, shared_cluster_state, third_party_allocation, tt.divisibility = 16 : i64} : !tt.ptr<i64>
 
     // CHECK: ttng.init_barrier
     // CHECK: arith.shli
@@ -1324,8 +1324,8 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 1 : i32, ttg.shar
   tt.func public @async_copy_global_to_local_with_barriers(%ptr: tensor<128x128x!tt.ptr<f16>, #blocked>) {
     // CHECK-DAG: %[[WRITE_VISIBILITY_GLOB:.*]] = ttg.global_scratch_alloc {alignment = 16 : i32, nbytes = 16 : i32, shared_cluster_state, third_party_allocation, tt.divisibility = 16 : i64} : !tt.ptr<i64>
     // CHECK-DAG: %[[READ_VISIBILITY_GLOB:.*]] = ttg.global_scratch_alloc {alignment = 16 : i32, nbytes = 16 : i32, shared_cluster_state, third_party_allocation, tt.divisibility = 16 : i64} : !tt.ptr<i64>
-    // CHECK-DAG: %[[WRITE_TRACKING_GLOB:.*]] = ttg.global_scratch_alloc {alignment = 16 : i32, nbytes = 2 : i32, shared_cluster_state, third_party_allocation, tt.divisibility = 16 : i64} : !tt.ptr<i8>
-    // CHECK-DAG: %[[READ_TRACKING_GLOB:.*]] = ttg.global_scratch_alloc {alignment = 16 : i32, nbytes = 16 : i32, shared_cluster_state, third_party_allocation, tt.divisibility = 16 : i64} : !tt.ptr<i64>
+    // CHECK-DAG: %[[WRITE_TRACKING_GLOB:.*]] = ttg.global_scratch_alloc {alignment = 16 : i32, nbytes = 4 : i32, shared_cluster_state, third_party_allocation, tt.divisibility = 16 : i64} : !tt.ptr<i8>
+    // CHECK-DAG: %[[READ_TRACKING_GLOB:.*]] = ttg.global_scratch_alloc {alignment = 16 : i32, nbytes = 32 : i32, shared_cluster_state, third_party_allocation, tt.divisibility = 16 : i64} : !tt.ptr<i64>
 
     // CHECK-DAG: %[[WRT_COMMITS_GLOB:.*]] = ttg.global_scratch_alloc {alignment = 16 : i32, nbytes = 2 : i32, shared_cluster_state, third_party_allocation, tt.divisibility = 16 : i64} : !tt.ptr<i8>
 


### PR DESCRIPTION
Track mbarrier read, write, and async-proxy publications in separate phase-parity slots so waits acquire only the requested phase. Preserve the previous phase for late waiters and clear recycled slots when a barrier advances.
Add a deterministic TMA regression covering cross-phase races and correctly synchronized accesses across one, two, and four CTAs; update NVIDIA and AMD instrumentation checks.