### PR TITLE
[DOCS] examples/plugins: make the Example 4 python block parse

### DIFF
--- a/examples/plugins/README.md
+++ b/examples/plugins/README.md
@@ -103,6 +103,8 @@ Finally, if we both load the plugin at runtime and insert the pass pipeline hook
 ``` python
 import torch
 import os
+import hashlib
+import pathlib
 
 import triton
 import triton.language as tl
@@ -236,6 +238,8 @@ inserted pass.
 ``` python
 import torch
 import os
+import hashlib
+import pathlib
 import sys
 
 import triton
@@ -263,8 +267,8 @@ def get_hash():
     return hashlib.sha256(get_key().encode('utf-8')).hexdigest()
 
 def dump_stages_hook(self=None, stages=None, options=None, language=None, capability=None):
-  if all(arg is None for arg in (stages, options, language, capability)):
-      return get_key(), get_hash()
+    if all(arg is None for arg in (stages, options, language, capability)):
+        return get_key(), get_hash()
     source_code = "# This is generated from Triton compiler.py"
     source_code = (
         source_code
@@ -277,10 +281,10 @@ def dump_stages_hook(self=None, stages=None, options=None, language=None, capabi
 
     with open("compiler_override.py", "w") as file:
         file.write(source_code)
-  return get_key(), get_hash()
+    return get_key(), get_hash()
 def override_stages(self=None, stages=None, options=None, language=None, capability=None):
-  if all(arg is None for arg in (stages, options, language, capability)):
-      return get_key(), get_hash()
+    if all(arg is None for arg in (stages, options, language, capability)):
+        return get_key(), get_hash()
     if language != Language.TRITON:
         return
     full_name = "compiler_override.py"


### PR DESCRIPTION
## What

The Example 4 python block in `examples/plugins/README.md` is not valid Python and never has been. The early-return guards in `dump_stages_hook` and `override_stages` are indented two spaces while the rest of each body is four:

```
IndentationError: unindent does not match any outer indentation level
```

The same two blocks (Example 2 and Example 4) also use `pathlib` and `hashlib` without importing them. Those imports were lost when the helpers were copied from `python/test/unit/plugins/custom_stages.py`, which does import them.

## Repro

From the repo root, on `main`:

```
python - <<'PY'
import re, pathlib
md = pathlib.Path("examples/plugins/README.md").read_text()
for i, b in enumerate(re.findall(r"```\s*python\n(.*?)```", md, re.S), 1):
    try: compile(b, f"block{i}", "exec"); print(i, "ok")
    except SyntaxError as e: print(i, type(e).__name__ + ":", e.msg, "at block line", e.lineno)
PY
1 ok
2 ok
3 ok
4 IndentationError: unindent does not match any outer indentation level at block line 32
```

With this PR the same script reports `1 ok / 2 ok / 3 ok / 4 ok`.

## Why it went unnoticed

The indentation came in with #8401 and was carried over by the move to `examples/plugins/`, and nothing checks these blocks: `.pre-commit-config.yaml` scopes ruff to `^python|^third_party/...|^test`, and `check-ast` only sees `.py` files, of which `examples/plugins/` has none.

## Test

Extracted every fenced python block and ran it. The Example 2 block runs to completion (exit 0) both before and after this change, so the added imports do not disturb it. The Example 4 block dies immediately on `main` with the `IndentationError` above; with this change it parses and executes into the plugin setup. I could not run it all the way through here because my local Triton predates `knobs.runtime.add_stages_inspection_hook`, so the dump hook never fires.

Docs only, no code changes.
