### PR TITLE
[AMD][BACKEND] Fix range analysis for loops with dynamic trip counts

### DIFF
--- a/test/TritonGPU/amd/amd-fold-true-cmpi.mlir
+++ b/test/TritonGPU/amd/amd-fold-true-cmpi.mlir
@@ -248,3 +248,33 @@ module attributes {"ttg.num-warps" = 4 : i32} {
 // CHECK:           %[[TRUE:.*]] = arith.constant dense<true> : tensor<32xi1>
 // CHECK:           tt.return %[[TRUE]] : tensor<32xi1>
 // CHECK:         }
+
+// -----
+
+// A loop with a runtime trip count in [0, 1] can return either its initial
+// iter_arg or the value yielded by its only iteration.
+module attributes {"ttg.num-warps" = 4 : i32} {
+  tt.func @dontfold_dynamic_one_trip_loop() -> i1 {
+    %c0 = arith.constant 0 : index
+    %c1 = arith.constant 1 : index
+    %c0_i32 = arith.constant 0 : i32
+    %c1_i32 = arith.constant 1 : i32
+    %c4 = arith.constant 4 : i32
+    %pid = tt.get_program_id x : i32
+    %has_work = arith.cmpi slt, %pid, %c4 : i32
+    %upper_i32 = arith.extui %has_work : i1 to i32
+    %upper = arith.index_cast %upper_i32 : i32 to index
+    %result = scf.for %iv = %c0 to %upper step %c1
+        iter_args(%value = %c0_i32) -> (i32) {
+      %next = arith.addi %value, %c1_i32 : i32
+      scf.yield %next : i32
+    }
+    %is_one = arith.cmpi eq, %result, %c1_i32 : i32
+    tt.return %is_one : i1
+  }
+}
+
+// CHECK-LABEL:   tt.func @dontfold_dynamic_one_trip_loop
+// CHECK:           %[[RESULT:.*]] = scf.for
+// CHECK:           %[[IS_ONE:.*]] = arith.cmpi eq, %[[RESULT]],
+// CHECK:           tt.return %[[IS_ONE]] : i1

--- a/third_party/amd/lib/Analysis/RangeAnalysis.cpp
+++ b/third_party/amd/lib/Analysis/RangeAnalysis.cpp
@@ -261,6 +261,7 @@ TritonIntegerRangeAnalysis::maybeGetTripCount(LoopLikeOpInterface loop) {
     return {};
 
   unsigned int width = ConstantIntRanges::getStorageBitwidth(iv->getType());
+  bool hasExactBounds = true;
 
   auto getLoopRangeInfo = [&](std::optional<OpFoldResult> loopBound,
                               Block *block,
@@ -273,12 +274,14 @@ TritonIntegerRangeAnalysis::maybeGetTripCount(LoopLikeOpInterface loop) {
       } else if (auto value = llvm::dyn_cast_if_present<Value>(*loopBound)) {
         const dataflow::IntegerValueRangeLattice *lattice =
             getLatticeElementFor(getProgramPointBefore(block), value);
-        if (lattice != nullptr && !lattice->getValue().isUninitialized())
-          return getUpper.value_or(false)
-                     ? lattice->getValue().getValue().smax()
-                     : lattice->getValue().getValue().smin();
+        if (lattice != nullptr && !lattice->getValue().isUninitialized()) {
+          const ConstantIntRanges &range = lattice->getValue().getValue();
+          hasExactBounds &= range.smin() == range.smax();
+          return getUpper.value_or(false) ? range.smax() : range.smin();
+        }
       }
     }
+    hasExactBounds = false;
     if (defaultVal)
       return *defaultVal;
     return getUpper.value_or(false) ? APInt::getSignedMaxValue(width)
@@ -307,10 +310,14 @@ TritonIntegerRangeAnalysis::maybeGetTripCount(LoopLikeOpInterface loop) {
   //  step = ceildiv(K, k)
   if (stepVal.isZero())
     stepVal = stepValDefault;
-  if (max.sge(min))
-    return llvm::divideCeilSigned(max.getSExtValue() - min.getSExtValue(),
-                                  stepVal.getSExtValue());
-  return {};
+  if (max.slt(min))
+    return {};
+  int64_t tripCount = llvm::divideCeilSigned(
+      max.getSExtValue() - min.getSExtValue(), stepVal.getSExtValue());
+  // We can only simulate a fixed number of backedges if we have exact bounds
+  if (!hasExactBounds && tripCount <= kDefaultMaxTripCount)
+    return {};
+  return tripCount;
 }
 
 bool isEmptyInitializedRange(ConstantIntRanges rv) {


### PR DESCRIPTION
`RangeAnalysis` did simulate an exact `tripCount` for loops which have a runtime dependent (but) bounded `tripCount`. This yielded to incorrect folds of branches by `TritonAMDFoldTrueCmpI` since we only took the result range of the largest possible tripCount ignore all smaller possible tripCounts.

This PR limits the tripCount simulation to exact tripCounts, all other cases will fall back to the conservative unbounded case.

Fixes: AITRICOMP-170