### PR TITLE
[AMD][BACKEND] Fix under-approximated loop-carried ranges in range analysis

### DIFF
--- a/test/TritonGPU/amd/amd-fold-true-cmpi.mlir
+++ b/test/TritonGPU/amd/amd-fold-true-cmpi.mlir
@@ -248,3 +248,33 @@ module attributes {"ttg.num-warps" = 4 : i32} {
 // CHECK:           %[[TRUE:.*]] = arith.constant dense<true> : tensor<32xi1>
 // CHECK:           tt.return %[[TRUE]] : tensor<32xi1>
 // CHECK:         }
+
+// -----
+
+// A loop with a runtime trip count in [0, 1] can return either its initial
+// iter_arg or the value yielded by its only iteration.
+module attributes {"ttg.num-warps" = 4 : i32} {
+  tt.func @dontfold_dynamic_one_trip_loop() -> i1 {
+    %c0 = arith.constant 0 : index
+    %c1 = arith.constant 1 : index
+    %c0_i32 = arith.constant 0 : i32
+    %c1_i32 = arith.constant 1 : i32
+    %c4 = arith.constant 4 : i32
+    %pid = tt.get_program_id x : i32
+    %has_work = arith.cmpi slt, %pid, %c4 : i32
+    %upper_i32 = arith.extui %has_work : i1 to i32
+    %upper = arith.index_cast %upper_i32 : i32 to index
+    %result = scf.for %iv = %c0 to %upper step %c1
+        iter_args(%value = %c0_i32) -> (i32) {
+      %next = arith.addi %value, %c1_i32 : i32
+      scf.yield %next : i32
+    }
+    %is_one = arith.cmpi eq, %result, %c1_i32 : i32
+    tt.return %is_one : i1
+  }
+}
+
+// CHECK-LABEL:   tt.func @dontfold_dynamic_one_trip_loop
+// CHECK:           %[[RESULT:.*]] = scf.for
+// CHECK:           %[[IS_ONE:.*]] = arith.cmpi eq, %[[RESULT]],
+// CHECK:           tt.return %[[IS_ONE]] : i1

--- a/test/TritonGPU/amd/amd-fold-true-cmpi.mlir
+++ b/test/TritonGPU/amd/amd-fold-true-cmpi.mlir
@@ -278,3 +278,33 @@ module attributes {"ttg.num-warps" = 4 : i32} {
 // CHECK:           %[[RESULT:.*]] = scf.for
 // CHECK:           %[[IS_ONE:.*]] = arith.cmpi eq, %[[RESULT]],
 // CHECK:           tt.return %[[IS_ONE]] : i1
+
+// -----
+
+module attributes {"ttg.num-warps" = 4 : i32} {
+  tt.func @dontfold_widening_inner_bound() -> i1 {
+    %c0 = arith.constant 0 : index
+    %c1 = arith.constant 1 : index
+    %c4 = arith.constant 4 : index
+    %c0_i32 = arith.constant 0 : i32
+    %c1_i32 = arith.constant 1 : i32
+    %c4_i32 = arith.constant 4 : i32
+    %outer:2 = scf.for %i = %c0 to %c4 step %c1
+        iter_args(%upper = %c1, %count = %c0_i32) -> (index, i32) {
+      %inner = scf.for %j = %c0 to %upper step %c1
+          iter_args(%value = %c0_i32) -> (i32) {
+        %next = arith.addi %value, %c1_i32 : i32
+        scf.yield %next : i32
+      }
+      %upper_next = arith.addi %upper, %c1 : index
+      scf.yield %upper_next, %inner : index, i32
+    }
+    %is_not_four = arith.cmpi ne, %outer#1, %c4_i32 : i32
+    tt.return %is_not_four : i1
+  }
+}
+
+// CHECK-LABEL:   tt.func @dontfold_widening_inner_bound
+// CHECK:           %[[OUTER:.*]]:2 = scf.for
+// CHECK:           %[[IS_NOT_FOUR:.*]] = arith.cmpi ne, %[[OUTER]]#1,
+// CHECK:           tt.return %[[IS_NOT_FOUR]] : i1

--- a/test/TritonGPU/amd/amd-range-analysis.mlir
+++ b/test/TritonGPU/amd/amd-range-analysis.mlir
@@ -285,7 +285,7 @@ module attributes {"ttg.num-warps" = 4 : i32} {
     // expected-remark@+1 {{non-neg}}
     %1 = arith.muli %0, %c1024_i32 : i32
     %2 = tt.make_range {end = 1024 : i32, start = 0 : i32} : tensor<1024xi32>
-    // expected-remark@+3 {{result 1: unsigned : [0, 17391] signed : [0, 17391]}}
+    // expected-remark@+3 {{result 1: unsigned : [0, 261888] signed : [0, 261888]}}
     // expected-remark@+2 {{result 1: non-neg}}
     // expected-remark@+1 {{inferred total trip count: 16}}
     %3:3 = scf.for %arg2 = %c0 to %c16 step %c1 iter_args(%arg3 = %arg0, %arg4 = %cst, %arg5 = %arg1) -> (!tt.ptr<f32>, tensor<1024xi64>, tensor<1024xf32>) {
@@ -297,7 +297,7 @@ module attributes {"ttg.num-warps" = 4 : i32} {
         // expected-remark@+2 {{unsigned : [0, 1023] signed : [0, 1023]}}
         // expected-remark@+1 {{non-neg}}
         %12 = arith.extsi %2 : tensor<1024xi32> to tensor<1024xi64>
-        // expected-remark@+2 {{unsigned : [0, 261888] signed : [0, 261888]}}
+        // expected-remark@+2 {{unsigned : [0, 262911] signed : [0, 262911]}}
         // expected-remark@+1 {{non-neg}}
         %13 = arith.addi %12, %arg8 : tensor<1024xi64>
         %14 = tt.splat %11 : !tt.ptr<f32> -> tensor<1024x!tt.ptr<f32>>
@@ -312,7 +312,7 @@ module attributes {"ttg.num-warps" = 4 : i32} {
     // expected-remark@+2 {{unsigned : [0, 1023] signed : [0, 1023]}}
     // expected-remark@+1 {{non-neg}}
     %5 = arith.extsi %2 : tensor<1024xi32> to tensor<1024xi64>
-    // expected-remark@+2 {{unsigned : [0, 18414] signed : [0, 18414]}}
+    // expected-remark@+2 {{unsigned : [0, 262911] signed : [0, 262911]}}
     // expected-remark@+1 {{non-neg}}
     %6 = arith.addi %5, %3#1 : tensor<1024xi64>
     %7 = tt.splat %4 : !tt.ptr<f32> -> tensor<1024x!tt.ptr<f32>>
@@ -1991,5 +1991,28 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.targ
     %16 = tt.addptr %15, %12 : tensor<1024x!tt.ptr<f32>, #blocked>, tensor<1024xi32, #blocked>
     tt.store %16, %14, %8 : tensor<1024x!tt.ptr<f32>, #blocked>
     tt.return
+  }
+}
+
+// -----
+
+// CHECK-LABEL:   tt.func @forOpAssumedDynamicBound
+module attributes {"ttg.num-warps" = 4 : i32} {
+  tt.func @forOpAssumedDynamicBound(%K: i32) -> i32 {
+    %c0_i32 = arith.constant 0 : i32
+    %c1_i32 = arith.constant 1 : i32
+    %c64_i32 = arith.constant 64 : i32
+    %lower = arith.cmpi sge, %K, %c1_i32 : i32
+    llvm.intr.assume %lower : i1
+    %upper = arith.cmpi slt, %K, %c64_i32 : i32
+    llvm.intr.assume %upper : i1
+    // expected-remark@+2 {{unsigned : [0, 63] signed : [0, 63]}}
+    // expected-remark@+1 {{inferred total trip count: 63}}
+    %res = scf.for %i = %c0_i32 to %K step %c1_i32 iter_args(%acc = %c0_i32) -> (i32) : i32 {
+      // expected-remark@+1 {{unsigned : [1, 63] signed : [1, 63]}}
+      %next = arith.addi %acc, %c1_i32 : i32
+      scf.yield %next : i32
+    }
+    tt.return %res : i32
   }
 }

--- a/third_party/amd/include/Analysis/RangeAnalysis.h
+++ b/third_party/amd/include/Analysis/RangeAnalysis.h
@@ -79,8 +79,10 @@ struct TritonIntegerRangeAnalysis : dataflow::IntegerRangeAnalysis {
   /// have to actually visit the loop N times for each iter_arg (each argument
   /// lattice) so we actually track visit count for (loop, arg) not just (loop).
   ///
-  /// 2. Before propagating, we check if we have propagated for (loop, arg) >= N
-  /// times. If so, we do not propagate (and thus the traversal converges/ends).
+  /// 2. Before propagating along a backedge, we check if we have propagated for
+  /// (loop, arg) >= N - 1 times. Propagation from the loop op itself (the init
+  /// args) is never blocked: it seeds the first iteration and, for loops which
+  /// may run zero times.
   ///
   /// Note, for loops where the trip count cannot be inferred *and* loops with a
   /// total trip count larger than `kDefaultMaxTripCount`, fallback to
@@ -110,18 +112,22 @@ struct TritonIntegerRangeAnalysis : dataflow::IntegerRangeAnalysis {
 
   int64_t getTotalLoopTripCount(LoopLikeOpInterface loop);
 
-  /// Trip counts of all loops with static loop bounds contained under the root
-  /// operation being analyzed. Note, nested loops have trip counts computed as
-  /// a product of enclosing loops; i.e. for
+  /// The number of times the lattices of `loop` may have to be updated while
+  /// simulating it.
+  int64_t getLoopSimulationSteps(LoopLikeOpInterface loop);
+
+  /// Simulation steps (see getLoopSimulationSteps) of all loops contained under
+  /// the root operation being analyzed. Note, nested loops have trip counts
+  /// computed as a product of enclosing loops; i.e. for
   ///   scf.for i = 1 to 10
   ///     scf.for j = 1 to 10
   /// the trip count of the outer loop (on i) is 10 but the trip count of the
   /// inner loop (on j) is 100.
-  llvm::SmallDenseMap<LoopLikeOpInterface, int64_t> loopTripCounts;
+  llvm::SmallDenseMap<LoopLikeOpInterface, int64_t> loopSimulationSteps;
 
   /// Visit counts tabulating how many times each lattice has been propagated
   /// through each loop. This is used in visitRegionSuccessors to end
-  /// propagation when loopVisits[loop, lattice] reaches loopTripCounts[loop].
+  /// propagation when loopVisits[loop, ...] reaches loopSimulationSteps[loop].
   llvm::SmallDenseMap<
       std::pair<LoopLikeOpInterface, dataflow::IntegerValueRangeLattice *>,
       int64_t>

--- a/third_party/amd/lib/Analysis/RangeAnalysis.cpp
+++ b/third_party/amd/lib/Analysis/RangeAnalysis.cpp
@@ -261,6 +261,7 @@ TritonIntegerRangeAnalysis::maybeGetTripCount(LoopLikeOpInterface loop) {
     return {};
 
   unsigned int width = ConstantIntRanges::getStorageBitwidth(iv->getType());
+  bool hasExactBounds = true;
 
   auto getLoopRangeInfo = [&](std::optional<OpFoldResult> loopBound,
                               Block *block,
@@ -273,12 +274,14 @@ TritonIntegerRangeAnalysis::maybeGetTripCount(LoopLikeOpInterface loop) {
       } else if (auto value = llvm::dyn_cast_if_present<Value>(*loopBound)) {
         const dataflow::IntegerValueRangeLattice *lattice =
             getLatticeElementFor(getProgramPointBefore(block), value);
-        if (lattice != nullptr && !lattice->getValue().isUninitialized())
-          return getUpper.value_or(false)
-                     ? lattice->getValue().getValue().smax()
-                     : lattice->getValue().getValue().smin();
+        if (lattice != nullptr && !lattice->getValue().isUninitialized()) {
+          const ConstantIntRanges &range = lattice->getValue().getValue();
+          hasExactBounds &= range.smin() == range.smax();
+          return getUpper.value_or(false) ? range.smax() : range.smin();
+        }
       }
     }
+    hasExactBounds = false;
     if (defaultVal)
       return *defaultVal;
     return getUpper.value_or(false) ? APInt::getSignedMaxValue(width)
@@ -307,10 +310,14 @@ TritonIntegerRangeAnalysis::maybeGetTripCount(LoopLikeOpInterface loop) {
   //  step = ceildiv(K, k)
   if (stepVal.isZero())
     stepVal = stepValDefault;
-  if (max.sge(min))
-    return llvm::divideCeilSigned(max.getSExtValue() - min.getSExtValue(),
-                                  stepVal.getSExtValue());
-  return {};
+  if (max.slt(min))
+    return {};
+  int64_t tripCount = llvm::divideCeilSigned(
+      max.getSExtValue() - min.getSExtValue(), stepVal.getSExtValue());
+  // We can only simulate a fixed number of backedges if we have exact bounds
+  if (!hasExactBounds && tripCount <= kDefaultMaxTripCount)
+    return {};
+  return tripCount;
 }
 
 bool isEmptyInitializedRange(ConstantIntRanges rv) {

--- a/third_party/amd/lib/Analysis/RangeAnalysis.cpp
+++ b/third_party/amd/lib/Analysis/RangeAnalysis.cpp
@@ -13,6 +13,7 @@
 #include "llvm/ADT/TypeSwitch.h"
 #include "llvm/Support/Debug.h"
 
+#include <algorithm>
 #include <numeric>
 #include <optional>
 
@@ -261,7 +262,6 @@ TritonIntegerRangeAnalysis::maybeGetTripCount(LoopLikeOpInterface loop) {
     return {};
 
   unsigned int width = ConstantIntRanges::getStorageBitwidth(iv->getType());
-  bool hasExactBounds = true;
 
   auto getLoopRangeInfo = [&](std::optional<OpFoldResult> loopBound,
                               Block *block,
@@ -274,14 +274,12 @@ TritonIntegerRangeAnalysis::maybeGetTripCount(LoopLikeOpInterface loop) {
       } else if (auto value = llvm::dyn_cast_if_present<Value>(*loopBound)) {
         const dataflow::IntegerValueRangeLattice *lattice =
             getLatticeElementFor(getProgramPointBefore(block), value);
-        if (lattice != nullptr && !lattice->getValue().isUninitialized()) {
-          const ConstantIntRanges &range = lattice->getValue().getValue();
-          hasExactBounds &= range.smin() == range.smax();
-          return getUpper.value_or(false) ? range.smax() : range.smin();
-        }
+        if (lattice != nullptr && !lattice->getValue().isUninitialized())
+          return getUpper.value_or(false)
+                     ? lattice->getValue().getValue().smax()
+                     : lattice->getValue().getValue().smin();
       }
     }
-    hasExactBounds = false;
     if (defaultVal)
       return *defaultVal;
     return getUpper.value_or(false) ? APInt::getSignedMaxValue(width)
@@ -312,10 +310,15 @@ TritonIntegerRangeAnalysis::maybeGetTripCount(LoopLikeOpInterface loop) {
     stepVal = stepValDefault;
   if (max.slt(min))
     return {};
+  // Widest bounds and smallest step give the largest number of iterations the
+  // loop can run. Over-estimating is safe because extra backedges only widen
+  // loop carried values; under-estimating is not. Loops which may not run at
+  // all are handled by always propagating the init args.
   int64_t tripCount = llvm::divideCeilSigned(
       max.getSExtValue() - min.getSExtValue(), stepVal.getSExtValue());
-  // We can only simulate a fixed number of backedges if we have exact bounds
-  if (!hasExactBounds && tripCount <= kDefaultMaxTripCount)
+  // A negative count means the subtraction above overflowed, i.e. we do not
+  // have a usable bound on the number of iterations.
+  if (tripCount < 0)
     return {};
   return tripCount;
 }
@@ -386,6 +389,22 @@ TritonIntegerRangeAnalysis::getTotalLoopTripCount(LoopLikeOpInterface loop) {
                            return accum * maybeGetTripCount(loop).value_or(
                                               kDefaultMaxTripCount + 1);
                          });
+}
+
+int64_t
+TritonIntegerRangeAnalysis::getLoopSimulationSteps(LoopLikeOpInterface loop) {
+  int64_t steps = getTotalLoopTripCount(loop);
+  // A lattice of this loop changes once per iteration, but also once for every
+  // step a nested loop needs to converge. This keeps the simulation steps
+  // bounded for deeply nested loops.
+  loop->walk([&](LoopLikeOpInterface nested) {
+    if (nested == loop)
+      return;
+    int64_t nestedSteps = getTotalLoopTripCount(nested);
+    if (nestedSteps <= kDefaultMaxTripCount)
+      steps = std::max(steps, nestedSteps);
+  });
+  return steps;
 }
 
 void TritonIntegerRangeAnalysis::setToEntryState(
@@ -656,29 +675,37 @@ void TritonIntegerRangeAnalysis::visitRegionSuccessors(
     lattices.push_back(
         static_cast<dataflow::IntegerValueRangeLattice *>(abstractLat));
   }
-  // Initialize loop trip counts
+  // Initialize the number of simulation steps
   LoopLikeOpInterface loop =
       llvm::dyn_cast<LoopLikeOpInterface>(branch.getOperation());
   if (loop) {
-    if (!loopTripCounts.contains(loop)) {
-      loopTripCounts[loop] = std::numeric_limits<int64_t>::max();
+    if (!loopSimulationSteps.contains(loop)) {
+      loopSimulationSteps[loop] = 0;
       for (auto argLat : lattices)
         loopVisits[{loop, argLat}] = 0;
     }
 
-    int64_t loopTripCount = getTotalLoopTripCount(loop);
+    int64_t steps = getLoopSimulationSteps(loop);
     LLVM_DEBUG({
-      DBGS() << "Trip count for ";
+      DBGS() << "Simulation steps for ";
       OpPrintingFlags flags;
       flags.skipRegions(true);
       loop->print(llvm::dbgs(), flags);
       llvm::dbgs() << "\n";
-      DBGS() << " --> " << loopTripCount << '\n';
+      DBGS() << " --> " << steps << '\n';
     });
-    if (loopTripCount < loopTripCounts[loop]) {
-      loopTripCounts[loop] = loopTripCount;
-    }
+    if (steps < 0)
+      steps = kDefaultMaxTripCount + 1;
+    // We can only widen the simulation steps (conservative).
+    loopSimulationSteps[loop] = std::max(loopSimulationSteps[loop], steps);
   }
+
+  // Loop iter_args need init values plus values from simulated iterations.
+  // Loop results need one extra backedge to observe the final iteration's yield
+  int64_t maxBackedges = 0;
+  if (loop)
+    maxBackedges = successor.isOperation() ? loopSimulationSteps[loop]
+                                           : loopSimulationSteps[loop] - 1;
 
   const auto *predecessors =
       getOrCreateFor<dataflow::PredecessorState>(point, point);
@@ -708,6 +735,8 @@ void TritonIntegerRangeAnalysis::visitRegionSuccessors(
   //
   for (Operation *op : predecessors->getKnownPredecessors()) {
     std::optional<OperandRange> operands;
+    // Loop init args are not backedges and should never be blocked or counted.
+    bool isBackedge = loop && op != branch.getOperation();
     if (op == branch) {
       operands = branch.getEntrySuccessorOperands(successor);
     } else if (auto regionTerminator =
@@ -754,19 +783,12 @@ void TritonIntegerRangeAnalysis::visitRegionSuccessors(
     for (auto [oper, argLat] :
          llvm::zip(*operands, ArrayRef(lattices).drop_front(firstIndex))) {
       std::pair loopArgLat = {loop, argLat};
-      // If we've "run the loop" #tripcount times, stop propagating.
-      bool reachedTripCount =
-          loop && loopVisits[loopArgLat] >= loopTripCounts[loop];
-      // However, if trip count is 0, we still need to initialize loop-carried
-      // values from the initial iter_args (so loop results equal initial
-      // values).
-      bool needsZeroTripInit = loop && loopTripCounts[loop] == 0 &&
-                               argLat->getValue().isUninitialized();
-      if (reachedTripCount && !needsZeroTripInit)
+      // If we've "run the loop" #maxBackedges times, stop propagating.
+      if (isBackedge && loopVisits[loopArgLat] >= maxBackedges)
         continue;
 
       ChangeResult changed;
-      if (loop && loopTripCounts[loop] > kDefaultMaxTripCount) {
+      if (loop && loopSimulationSteps[loop] > kDefaultMaxTripCount) {
         // If the loop's tripcount is too large, infer the maximum range for
         // the arg lattices. This will have the effect that all users will
         // also be inferred to have maximum range and end the analysis will
@@ -793,9 +815,7 @@ void TritonIntegerRangeAnalysis::visitRegionSuccessors(
       // lattice because otherwise we will over count the number of visits
       // (since not all iter_arg lattices are updated/propagated on each
       // visit).
-      // For initial iterations of zero trip count loops we do not increment
-      // the visit count to avoid overcounting.
-      if (loop && changed == ChangeResult::Change && !needsZeroTripInit)
+      if (isBackedge && changed == ChangeResult::Change)
         ++loopVisits[loopArgLat];
     }
   }


### PR DESCRIPTION
`RangeAnalysis` could report loop-carried ranges that were too narrow, which lets `FoldTrueCmpIOp` (and possibly buffer-op conversion) fire on bounds the program can actually exceed.

There were 2 issues in the pass:
- `visitRegionSuccessors` used the *smallest* trip count it ever computed. Bound ranges widen as the analysis progresses, so an early small estimate meant that too few backedges were simulated, which yields are too small range. 
- The per-loop simulation budget was the loop's own trip count, so an outer loop ran out of visits while its inner loop was still converging.

Fixes: AITRICOMP-170