### PR TITLE
[AxisAnalysis] Handle pointer element-size bitcasts

### DIFF
--- a/lib/Analysis/AxisInfo.cpp
+++ b/lib/Analysis/AxisInfo.cpp
@@ -146,6 +146,35 @@ public:
   }
 };
 
+class BitcastOpAxisInfoVisitor final
+    : public AxisInfoVisitorImpl<triton::BitcastOp> {
+public:
+  using AxisInfoVisitorImpl<triton::BitcastOp>::AxisInfoVisitorImpl;
+
+  AxisInfo
+  getAxisInfo(triton::BitcastOp op,
+              ArrayRef<const dataflow::Lattice<AxisInfo> *> operands) override {
+    AxisInfo info = operands[0]->getValue();
+    if (!isa<PointerType>(getElementTypeOrSelf(op.getSrc().getType())))
+      return info;
+
+    int64_t srcBytes =
+        std::max<int64_t>(1, getPointeeBitWidth(op.getSrc().getType()) / 8);
+    int64_t dstBytes =
+        std::max<int64_t>(1, getPointeeBitWidth(op.getType()) / 8);
+    if (srcBytes == dstBytes)
+      return info;
+
+    AxisInfo::DimVectorT divisibility = info.getDivisibility();
+    // Every former element becomes a group base after the bitcast.
+    for (unsigned dim = 0; dim < divisibility.size(); ++dim)
+      if (info.getContiguity(dim) > 1)
+        divisibility[dim] = gcd(divisibility[dim], srcBytes);
+    return AxisInfo(AxisInfo::DimVectorT(info.getRank(), 1), divisibility,
+                    info.getConstancy(), info.getConstantValue());
+  }
+};
+
 class UnrealizedConversionCastOpAxisInfoVisitor final
     : public AxisInfoVisitorImpl<mlir::UnrealizedConversionCastOp> {
 public:
@@ -1181,7 +1210,7 @@ AxisInfoAnalysis::AxisInfoAnalysis(DataFlowSolver &solver)
                   CastOpAxisInfoVisitor<arith::ExtUIOp>,
                   CastOpAxisInfoVisitor<arith::TruncIOp>,
                   CastOpAxisInfoVisitor<triton::gpu::ConvertLayoutOp>,
-                  CastOpAxisInfoVisitor<triton::BitcastOp>,
+                  BitcastOpAxisInfoVisitor,
                   CastOpAxisInfoVisitor<triton::gluon::SetAutoLayoutOp>>();
   visitors.append<MakeRangeOpAxisInfoVisitor>();
   visitors.append<PoisonOpAxisInfoVisitor>();

--- a/lib/Dialect/Triton/IR/Types.cpp
+++ b/lib/Dialect/Triton/IR/Types.cpp
@@ -63,6 +63,7 @@ void TensorDescType::print(AsmPrinter &printer) const {
 }
 
 Type PointerType::parse(AsmParser &parser) {
+  Location loc = parser.getEncodedSourceLoc(parser.getCurrentLocation());
   if (parser.parseLess())
     return Type();
 
@@ -79,7 +80,7 @@ Type PointerType::parse(AsmParser &parser) {
   if (parser.parseGreater())
     return Type();
 
-  return PointerType::get(pointeeType, addressSpace);
+  return PointerType::getChecked(loc, pointeeType, addressSpace);
 }
 
 void PointerType::print(AsmPrinter &printer) const {
@@ -104,9 +105,9 @@ TensorDescType::verify(function_ref<InFlightDiagnostic()> emitError,
 
 LogicalResult PointerType::verify(function_ref<InFlightDiagnostic()> emitError,
                                   Type pointeeType, int addressSpace) {
-  if (isa<RankedTensorType>(pointeeType)) {
-    return emitError() << "pointer types cannot point to ranked tensor types";
-  }
+  if (!pointeeType.isIntOrFloat())
+    return emitError()
+           << "pointer types must point to integer or floating-point types";
   return success();
 }
 

--- a/test/Analysis/test-alignment.mlir
+++ b/test/Analysis/test-alignment.mlir
@@ -24,6 +24,8 @@ tt.func @bitcast_pointer_element_width(%arg0: !tt.ptr<f32> {tt.divisibility = 16
   %same_width = tt.bitcast %ptrs : tensor<128x!tt.ptr<f32>> -> tensor<128x!tt.ptr<i32>>
   // expected-remark @below {{contiguity = [1], divisibility = [4], constancy = [1], constant_value = <none>}}
   %cast = tt.bitcast %ptrs : tensor<128x!tt.ptr<f32>> -> tensor<128x!tt.ptr<f16>>
+  // expected-remark @below {{contiguity = [1], divisibility = [4], constancy = [1], constant_value = <none>}}
+  %cast_fp8 = tt.bitcast %cast : tensor<128x!tt.ptr<f16>> -> tensor<128x!tt.ptr<f8E4M3FN>>
   %byte_base = tt.splat %arg1 : !tt.ptr<i1> -> tensor<128x!tt.ptr<i1>>
   %byte_ptrs = tt.addptr %byte_base, %range : tensor<128x!tt.ptr<i1>>, tensor<128xi32>
   // Sub-byte and i8 pointers both use an effective one-byte element size.

--- a/test/Analysis/test-alignment.mlir
+++ b/test/Analysis/test-alignment.mlir
@@ -15,6 +15,25 @@ tt.func @cast() {
 
 // -----
 
+tt.func @bitcast_pointer_element_width(%arg0: !tt.ptr<f32> {tt.divisibility = 16 : i32}, %arg1: !tt.ptr<i1> {tt.divisibility = 16 : i32}) {
+  %range = tt.make_range {end = 128 : i32, start = 0 : i32} : tensor<128xi32>
+  %base = tt.splat %arg0 : !tt.ptr<f32> -> tensor<128x!tt.ptr<f32>>
+  // expected-remark @below {{contiguity = [128], divisibility = [16], constancy = [1], constant_value = <none>}}
+  %ptrs = tt.addptr %base, %range : tensor<128x!tt.ptr<f32>>, tensor<128xi32>
+  // expected-remark @below {{contiguity = [128], divisibility = [16], constancy = [1], constant_value = <none>}}
+  %same_width = tt.bitcast %ptrs : tensor<128x!tt.ptr<f32>> -> tensor<128x!tt.ptr<i32>>
+  // expected-remark @below {{contiguity = [1], divisibility = [4], constancy = [1], constant_value = <none>}}
+  %cast = tt.bitcast %ptrs : tensor<128x!tt.ptr<f32>> -> tensor<128x!tt.ptr<f16>>
+  %byte_base = tt.splat %arg1 : !tt.ptr<i1> -> tensor<128x!tt.ptr<i1>>
+  %byte_ptrs = tt.addptr %byte_base, %range : tensor<128x!tt.ptr<i1>>, tensor<128xi32>
+  // Sub-byte and i8 pointers both use an effective one-byte element size.
+  // expected-remark @below {{contiguity = [128], divisibility = [16], constancy = [1], constant_value = <none>}}
+  %same_storage_width = tt.bitcast %byte_ptrs : tensor<128x!tt.ptr<i1>> -> tensor<128x!tt.ptr<i8>>
+  tt.return
+}
+
+// -----
+
 tt.func @add(%arg0: tensor<128xi32> {tt.contiguity = 1 : i32, tt.divisibility = 4 : i32, tt.constancy = 2: i32}, %arg1: tensor<128xi32> {tt.contiguity = 4 : i32, tt.divisibility = 4 : i32, tt.constancy = 1: i32}) {
   // expected-remark @below {{contiguity = [128], divisibility = [1073741824], constancy = [1], constant_value = <none>}}
   %0 = tt.make_range {end = 128 : i32, start = 0 : i32} : tensor<128xi32>

--- a/test/Triton/invalid.mlir
+++ b/test/Triton/invalid.mlir
@@ -9,6 +9,13 @@ tt.func @fn(%v: i32) {
 
 // -----
 
+// expected-error @+1 {{pointer types must point to integer or floating-point types}}
+tt.func public @invalid_pointer_pointee(%arg0: !tt.ptr<index>) {
+  tt.return
+}
+
+// -----
+
 // Invalid bitcast between types of different bit width.
 tt.func public @fn(%arg0: tensor<128xf32>) {
     // expected-error @+1 {{Cannot bitcast data-type of size}}


### PR DESCRIPTION
Give pointer bitcasts a dedicated axis-info visitor. Reset contiguity
and clamp byte alignment when storage width changes.
In other words, if you want to load just half of the data, this data
surely cannot be contiguous.
