### PR TITLE
[PROTON] Support `cuGraphAddKernelNode` created graph nodes

### DIFF
--- a/third_party/proton/csrc/include/Driver/GPU/CudaApi.h
+++ b/third_party/proton/csrc/include/Driver/GPU/CudaApi.h
@@ -64,7 +64,7 @@ CUresult launchKernel(CUfunction f, unsigned int gridDimX,
                       CUstream hStream, void **kernelParams, void **extra);
 
 template <bool CheckSuccess>
-CUresult funcGetName(const char** name, CUfunction hfunc);
+CUresult funcGetName(const char **name, CUfunction hfunc);
 
 Device getDevice(uint64_t index);
 

--- a/third_party/proton/csrc/include/Driver/GPU/CudaApi.h
+++ b/third_party/proton/csrc/include/Driver/GPU/CudaApi.h
@@ -63,6 +63,9 @@ CUresult launchKernel(CUfunction f, unsigned int gridDimX,
                       unsigned int blockDimZ, unsigned int sharedMemBytes,
                       CUstream hStream, void **kernelParams, void **extra);
 
+template <bool CheckSuccess>
+CUresult funcGetName(const char** name, CUfunction hfunc);
+
 Device getDevice(uint64_t index);
 
 } // namespace cuda

--- a/third_party/proton/csrc/lib/Driver/GPU/CudaApi.cpp
+++ b/third_party/proton/csrc/lib/Driver/GPU/CudaApi.cpp
@@ -66,6 +66,9 @@ DEFINE_DISPATCH(ExternLibCuda, launchKernel, cuLaunchKernel, CUfunction,
                 unsigned int, unsigned int, unsigned int, CUstream, void **,
                 void **)
 
+DEFINE_DISPATCH(ExternLibCuda, funcGetName, cuFuncGetName, const char **,
+                CUfunction)
+
 Device getDevice(uint64_t index) {
   CUdevice device;
   cuda::deviceGet<true>(&device, index);

--- a/third_party/proton/csrc/lib/Profiler/Cupti/CuptiProfiler.cpp
+++ b/third_party/proton/csrc/lib/Profiler/Cupti/CuptiProfiler.cpp
@@ -265,14 +265,9 @@ constexpr std::array<CUpti_CallbackId, 11> kGraphCallbacks = {
     CUPTI_DRIVER_TRACE_CBID_cuStreamBeginCaptureToGraph_ptsz,
     CUPTI_DRIVER_TRACE_CBID_cuStreamEndCapture};
 
-#define PROTON_GRAPH_KERNEL_NODE_CALLBACK_LIST(X)                              \
-  X(CUPTI_DRIVER_TRACE_CBID_cuGraphAddKernelNode)                              \
-  X(CUPTI_DRIVER_TRACE_CBID_cuGraphAddKernelNode_v2)
-
-#define PROTON_GRAPH_KERNEL_NODE_CB_AS_ID(cbId) cbId,
 constexpr std::array<CUpti_CallbackId, 2> kGraphKernelNodeCallbacks = {
-    PROTON_GRAPH_KERNEL_NODE_CALLBACK_LIST(PROTON_GRAPH_KERNEL_NODE_CB_AS_ID)};
-#undef PROTON_GRAPH_KERNEL_NODE_CB_AS_ID
+    CUPTI_DRIVER_TRACE_CBID_cuGraphAddKernelNode,
+    CUPTI_DRIVER_TRACE_CBID_cuGraphAddKernelNode_v2};
 
 #define PROTON_KERNEL_CALLBACK_LIST(X)                                         \
   X(CUPTI_DRIVER_TRACE_CBID_cuLaunch)                                          \
@@ -361,15 +356,12 @@ bool isGraphLaunch(CUpti_CallbackId cbId) {
 }
 
 bool isGraphKernelNode(CUpti_CallbackId cbId) {
-  switch (cbId) {
-#define PROTON_GRAPH_KERNEL_NODE_CB_AS_CASE(cbId)                              \
-  case cbId:                                                                   \
-    return true;
-    PROTON_GRAPH_KERNEL_NODE_CALLBACK_LIST(PROTON_GRAPH_KERNEL_NODE_CB_AS_CASE)
-#undef PROTON_GRAPH_KERNEL_NODE_CB_AS_CASE
-  default:
-    return false;
+  for (auto graphKernelCbId : kGraphKernelNodeCallbacks) {
+    if (cbId == graphKernelCbId) {
+      return true;
+    }
   }
+  return false;
 }
 
 CUfunction getGraphKernelFunction(CUpti_CallbackId cbId,
@@ -405,7 +397,6 @@ bool isStreamCaptureEnd(CUpti_CallbackId cbId) {
 }
 
 #undef PROTON_KERNEL_CALLBACK_LIST
-#undef PROTON_GRAPH_KERNEL_NODE_CALLBACK_LIST
 
 } // namespace
 
@@ -688,13 +679,15 @@ void CuptiProfiler::CuptiProfilerPimpl::handleGraphKernelNodeCallbacks(
     return;
 
   if (callbackData->callbackSite == CUPTI_API_ENTER) {
-    auto function = getGraphKernelFunction(cbId, callbackData->functionParams);
-    const char *name = function ? cuda::getFunctionName(function) : nullptr;
-    // symbolName is only reliable for launch callbacks, but retaining it as a
-    // fallback avoids making graph construction fail on older drivers without
-    // cuFuncGetName.
-    if (!name)
-      name = callbackData->symbolName;
+    const auto getFunc = [&](auto *p) { return p->nodeParams->func; };
+    CUfunction function =
+        (cbId == CUPTI_DRIVER_TRACE_CBID_cuGraphAddKernelNode)
+            ? getFunc(static_cast<const cuGraphAddKernelNode_params *>(
+                  callbackData->functionParams))
+            : getFunc(static_cast<const cuGraphAddKernelNode_v2_params *>(
+                  callbackData->functionParams));
+    const char *name = nullptr;
+    cuda::funcGetName<true>(&name, function);
     threadState.enterOp(Scope(name ? name : ""));
   } else if (callbackData->callbackSite == CUPTI_API_EXIT) {
     threadState.exitOp();

--- a/third_party/proton/csrc/lib/Profiler/Cupti/CuptiProfiler.cpp
+++ b/third_party/proton/csrc/lib/Profiler/Cupti/CuptiProfiler.cpp
@@ -265,6 +265,15 @@ constexpr std::array<CUpti_CallbackId, 11> kGraphCallbacks = {
     CUPTI_DRIVER_TRACE_CBID_cuStreamBeginCaptureToGraph_ptsz,
     CUPTI_DRIVER_TRACE_CBID_cuStreamEndCapture};
 
+#define PROTON_GRAPH_KERNEL_NODE_CALLBACK_LIST(X)                              \
+  X(CUPTI_DRIVER_TRACE_CBID_cuGraphAddKernelNode)                              \
+  X(CUPTI_DRIVER_TRACE_CBID_cuGraphAddKernelNode_v2)
+
+#define PROTON_GRAPH_KERNEL_NODE_CB_AS_ID(cbId) cbId,
+constexpr std::array<CUpti_CallbackId, 2> kGraphKernelNodeCallbacks = {
+    PROTON_GRAPH_KERNEL_NODE_CALLBACK_LIST(PROTON_GRAPH_KERNEL_NODE_CB_AS_ID)};
+#undef PROTON_GRAPH_KERNEL_NODE_CB_AS_ID
+
 #define PROTON_KERNEL_CALLBACK_LIST(X)                                         \
   X(CUPTI_DRIVER_TRACE_CBID_cuLaunch)                                          \
   X(CUPTI_DRIVER_TRACE_CBID_cuLaunchGrid)                                      \
@@ -310,6 +319,10 @@ void setGraphCallbacks(CUpti_SubscriberHandle subscriber, bool enable) {
     cupti::enableCallback<true>(static_cast<uint32_t>(enable), subscriber,
                                 CUPTI_CB_DOMAIN_DRIVER_API, cbId);
   }
+  for (auto cbId : kGraphKernelNodeCallbacks) {
+    cupti::enableCallback<true>(static_cast<uint32_t>(enable), subscriber,
+                                CUPTI_CB_DOMAIN_DRIVER_API, cbId);
+  }
   for (auto cbId : kGraphResourceCallbacks) {
     cupti::enableCallback<true>(static_cast<uint32_t>(enable), subscriber,
                                 CUPTI_CB_DOMAIN_RESOURCE, cbId);
@@ -347,6 +360,32 @@ bool isGraphLaunch(CUpti_CallbackId cbId) {
          cbId == CUPTI_DRIVER_TRACE_CBID_cuGraphLaunch_ptsz;
 }
 
+bool isGraphKernelNode(CUpti_CallbackId cbId) {
+  switch (cbId) {
+#define PROTON_GRAPH_KERNEL_NODE_CB_AS_CASE(cbId)                              \
+  case cbId:                                                                   \
+    return true;
+    PROTON_GRAPH_KERNEL_NODE_CALLBACK_LIST(PROTON_GRAPH_KERNEL_NODE_CB_AS_CASE)
+#undef PROTON_GRAPH_KERNEL_NODE_CB_AS_CASE
+  default:
+    return false;
+  }
+}
+
+CUfunction getGraphKernelFunction(CUpti_CallbackId cbId,
+                                  const void *functionParams) {
+  if (!functionParams)
+    return nullptr;
+  if (cbId == CUPTI_DRIVER_TRACE_CBID_cuGraphAddKernelNode) {
+    const auto *params =
+        static_cast<const cuGraphAddKernelNode_params *>(functionParams);
+    return params->nodeParams ? params->nodeParams->func : nullptr;
+  }
+  const auto *params =
+      static_cast<const cuGraphAddKernelNode_v2_params *>(functionParams);
+  return params->nodeParams ? params->nodeParams->func : nullptr;
+}
+
 bool isLaunch(CUpti_CallbackId cbId) {
   return isKernel(cbId) || isGraphLaunch(cbId);
 }
@@ -366,6 +405,7 @@ bool isStreamCaptureEnd(CUpti_CallbackId cbId) {
 }
 
 #undef PROTON_KERNEL_CALLBACK_LIST
+#undef PROTON_GRAPH_KERNEL_NODE_CALLBACK_LIST
 
 } // namespace
 
@@ -412,6 +452,8 @@ private:
 
   void handleStreamCaptureCallbacks(CUpti_CallbackId cbId,
                                     const CUpti_CallbackData *callbackData);
+  void handleGraphKernelNodeCallbacks(CUpti_CallbackId cbId,
+                                      const CUpti_CallbackData *callbackData);
   void handleApiEnterLaunchCallbacks(CuptiProfiler &profiler,
                                      CUpti_CallbackId cbId,
                                      const CUpti_CallbackData *callbackData);
@@ -640,6 +682,25 @@ void CuptiProfiler::CuptiProfilerPimpl::handleStreamCaptureCallbacks(
   }
 }
 
+void CuptiProfiler::CuptiProfilerPimpl::handleGraphKernelNodeCallbacks(
+    CUpti_CallbackId cbId, const CUpti_CallbackData *callbackData) {
+  if (!isGraphKernelNode(cbId))
+    return;
+
+  if (callbackData->callbackSite == CUPTI_API_ENTER) {
+    auto function = getGraphKernelFunction(cbId, callbackData->functionParams);
+    const char *name = function ? cuda::getFunctionName(function) : nullptr;
+    // symbolName is only reliable for launch callbacks, but retaining it as a
+    // fallback avoids making graph construction fail on older drivers without
+    // cuFuncGetName.
+    if (!name)
+      name = callbackData->symbolName;
+    threadState.enterOp(Scope(name ? name : ""));
+  } else if (callbackData->callbackSite == CUPTI_API_EXIT) {
+    threadState.exitOp();
+  }
+}
+
 void CuptiProfiler::CuptiProfilerPimpl::handleApiEnterLaunchCallbacks(
     CuptiProfiler &profiler, CUpti_CallbackId cbId,
     const CUpti_CallbackData *callbackData) {
@@ -743,6 +804,7 @@ void CuptiProfiler::CuptiProfilerPimpl::handleApiCallbacks(
   const CUpti_CallbackData *callbackData =
       static_cast<const CUpti_CallbackData *>(cbData);
   handleStreamCaptureCallbacks(cbId, callbackData);
+  handleGraphKernelNodeCallbacks(cbId, callbackData);
   if (isLaunch(cbId)) {
     if (callbackData->callbackSite == CUPTI_API_ENTER) {
       handleApiEnterLaunchCallbacks(profiler, cbId, callbackData);

--- a/third_party/proton/test/cuda_graph_helper.py
+++ b/third_party/proton/test/cuda_graph_helper.py
@@ -55,16 +55,16 @@ C_SOURCE = r"""
 #include <string.h>
 
 enum {
-    PDL = 0,
-    EVENT = 1,
-    NO_PDL = 2,
-    KERNELS_PER_GRAPH = 4,
-    CONSUMERS_PER_GRAPH = 3,
-    BLOCK_SIZE = 256,
-    COUNT = 4096,
+    Pdl = 0,
+    Event = 1,
+    NoPdl = 2,
+    KernelsPerGraph = 4,
+    ConsumersPerGraph = 3,
+    BlockSize = 256,
+    Count = 4096,
 };
 
-static void check_cuda(CUresult result, const char *operation) {
+static void checkCuda(CUresult result, const char *operation) {
     if (result == CUDA_SUCCESS)
         return;
     const char *description = NULL;
@@ -74,81 +74,81 @@ static void check_cuda(CUresult result, const char *operation) {
     exit(2);
 }
 
-#define CUDA(call) check_cuda((call), #call)
+#define CUDA(call) checkCuda((call), #call)
 
-struct runtime {
+struct Runtime {
     int mode;
     CUdevice device;
     CUcontext context;
-    CUmodule producer_module;
-    CUmodule consumer_module;
+    CUmodule producerModule;
+    CUmodule consumerModule;
     CUfunction producer;
     CUfunction consumer;
     CUstream stream;
     CUgraph graph;
     CUgraphExec executable;
-    CUevent graph_start;
-    CUevent graph_end;
-    CUgraphNode kernels[KERNELS_PER_GRAPH];
+    CUevent graphStart;
+    CUevent graphEnd;
+    CUgraphNode kernels[KernelsPerGraph];
     CUdeviceptr output;
-    CUdeviceptr null_scratch;
+    CUdeviceptr nullScratch;
     uint32_t count;
-    uint32_t iterations[KERNELS_PER_GRAPH];
-    uint32_t tags[KERNELS_PER_GRAPH];
-    void *parameters[KERNELS_PER_GRAPH][6];
+    uint32_t iterations[KernelsPerGraph];
+    uint32_t tags[KernelsPerGraph];
+    void *parameters[KernelsPerGraph][6];
 };
 
-static void add_kernel(struct runtime *runtime, int index, CUfunction function,
-                       const CUgraphNode *dependencies,
-                       size_t dependency_count) {
+static void addKernel(struct Runtime *runtime, int index, CUfunction function,
+                      const CUgraphNode *dependencies,
+                      size_t dependencyCount) {
     runtime->parameters[index][0] = &runtime->output;
     runtime->parameters[index][1] = &runtime->count;
     runtime->parameters[index][2] = &runtime->iterations[index];
     runtime->parameters[index][3] = &runtime->tags[index];
-    runtime->parameters[index][4] = &runtime->null_scratch;
-    runtime->parameters[index][5] = &runtime->null_scratch;
+    runtime->parameters[index][4] = &runtime->nullScratch;
+    runtime->parameters[index][5] = &runtime->nullScratch;
 
     CUDA_KERNEL_NODE_PARAMS params;
     memset(&params, 0, sizeof(params));
     params.func = function;
-    params.gridDimX = (runtime->count + BLOCK_SIZE - 1) / BLOCK_SIZE;
+    params.gridDimX = (runtime->count + BlockSize - 1) / BlockSize;
     params.gridDimY = 1;
     params.gridDimZ = 1;
-    params.blockDimX = BLOCK_SIZE;
+    params.blockDimX = BlockSize;
     params.blockDimY = 1;
     params.blockDimZ = 1;
     params.kernelParams = runtime->parameters[index];
     CUDA(cuGraphAddKernelNode(&runtime->kernels[index], runtime->graph,
-                              dependencies, dependency_count, &params));
+                              dependencies, dependencyCount, &params));
 }
 
-static void build_graph(struct runtime *runtime) {
+static void buildGraph(struct Runtime *runtime) {
     CUDA(cuGraphCreate(&runtime->graph, 0));
-    runtime->count = COUNT;
-    for (int index = 0; index < KERNELS_PER_GRAPH; ++index) {
+    runtime->count = Count;
+    for (int index = 0; index < KernelsPerGraph; ++index) {
         runtime->tags[index] = (uint32_t)index;
         runtime->iterations[index] = 10000;
     }
 
-    if (runtime->mode == EVENT) {
+    if (runtime->mode == Event) {
         CUgraphNode dependency;
-        CUDA(cuEventCreate(&runtime->graph_start, CU_EVENT_DEFAULT));
-        CUDA(cuEventCreate(&runtime->graph_end, CU_EVENT_DEFAULT));
+        CUDA(cuEventCreate(&runtime->graphStart, CU_EVENT_DEFAULT));
+        CUDA(cuEventCreate(&runtime->graphEnd, CU_EVENT_DEFAULT));
         CUDA(cuGraphAddEventRecordNode(&dependency, runtime->graph, NULL, 0,
-                                       runtime->graph_start));
-        for (int index = 0; index < KERNELS_PER_GRAPH; ++index) {
-            add_kernel(runtime, index, runtime->consumer, &dependency, 1);
+                                       runtime->graphStart));
+        for (int index = 0; index < KernelsPerGraph; ++index) {
+            addKernel(runtime, index, runtime->consumer, &dependency, 1);
             dependency = runtime->kernels[index];
         }
         CUDA(cuGraphAddEventRecordNode(&dependency, runtime->graph,
-                                       &runtime->kernels[KERNELS_PER_GRAPH - 1],
-                                       1, runtime->graph_end));
+                                       &runtime->kernels[KernelsPerGraph - 1],
+                                       1, runtime->graphEnd));
     } else {
         runtime->iterations[0] = 25000;
-        add_kernel(runtime, 0, runtime->producer, NULL, 0);
-        for (int index = 1; index < KERNELS_PER_GRAPH; ++index) {
-            if (runtime->mode == PDL) {
-                add_kernel(runtime, index, runtime->consumer, NULL, 0);
+        addKernel(runtime, 0, runtime->producer, NULL, 0);
+        for (int index = 1; index < KernelsPerGraph; ++index) {
+            if (runtime->mode == Pdl) {
+                addKernel(runtime, index, runtime->consumer, NULL, 0);
                 CUgraphEdgeData edge;
                 memset(&edge, 0, sizeof(edge));
                 edge.from_port = CU_GRAPH_KERNEL_NODE_PORT_PROGRAMMATIC;
@@ -157,8 +157,8 @@ static void build_graph(struct runtime *runtime) {
                     runtime->graph, &runtime->kernels[0],
                     &runtime->kernels[index], &edge, 1));
             } else {
-                add_kernel(runtime, index, runtime->consumer,
-                           &runtime->kernels[0], 1);
+                addKernel(runtime, index, runtime->consumer,
+                          &runtime->kernels[0], 1);
             }
         }
     }
@@ -166,11 +166,11 @@ static void build_graph(struct runtime *runtime) {
 }
 
 __attribute__((visibility("default")))
-void *graph_runtime_create(int mode, const char *producer_path,
-                           const char *consumer_path,
-                           const char *producer_name,
-                           const char *consumer_name) {
-    struct runtime *runtime = calloc(1, sizeof(*runtime));
+void *graphRuntimeCreate(int mode, const char *producerPath,
+                         const char *consumerPath,
+                         const char *producerName,
+                         const char *consumerName) {
+    struct Runtime *runtime = calloc(1, sizeof(*runtime));
     if (!runtime)
         return NULL;
     runtime->mode = mode;
@@ -179,45 +179,45 @@ void *graph_runtime_create(int mode, const char *producer_path,
     CUDA(cuDeviceGet(&runtime->device, 0));
     CUDA(cuDevicePrimaryCtxRetain(&runtime->context, runtime->device));
     CUDA(cuCtxSetCurrent(runtime->context));
-    CUDA(cuModuleLoad(&runtime->producer_module, producer_path));
-    CUDA(cuModuleLoad(&runtime->consumer_module, consumer_path));
-    CUDA(cuModuleGetFunction(&runtime->producer, runtime->producer_module,
-                             producer_name));
-    CUDA(cuModuleGetFunction(&runtime->consumer, runtime->consumer_module,
-                             consumer_name));
+    CUDA(cuModuleLoad(&runtime->producerModule, producerPath));
+    CUDA(cuModuleLoad(&runtime->consumerModule, consumerPath));
+    CUDA(cuModuleGetFunction(&runtime->producer, runtime->producerModule,
+                             producerName));
+    CUDA(cuModuleGetFunction(&runtime->consumer, runtime->consumerModule,
+                             consumerName));
     CUDA(cuMemAlloc(&runtime->output,
-                    KERNELS_PER_GRAPH * COUNT * sizeof(float)));
+                    KernelsPerGraph * Count * sizeof(float)));
     CUDA(cuStreamCreate(&runtime->stream, CU_STREAM_NON_BLOCKING));
-    build_graph(runtime);
+    buildGraph(runtime);
     return runtime;
 }
 
 __attribute__((visibility("default")))
-void graph_runtime_launch(void *handle) {
-    struct runtime *runtime = handle;
+void graphRuntimeLaunch(void *handle) {
+    struct Runtime *runtime = handle;
     CUDA(cuGraphLaunch(runtime->executable, runtime->stream));
-    if (runtime->mode == EVENT)
-        CUDA(cuEventSynchronize(runtime->graph_end));
+    if (runtime->mode == Event)
+        CUDA(cuEventSynchronize(runtime->graphEnd));
     else
         CUDA(cuStreamSynchronize(runtime->stream));
 }
 
 __attribute__((visibility("default")))
-void graph_runtime_destroy(void *handle) {
-    struct runtime *runtime = handle;
+void graphRuntimeDestroy(void *handle) {
+    struct Runtime *runtime = handle;
     if (!runtime)
         return;
     CUDA(cuCtxSetCurrent(runtime->context));
     CUDA(cuGraphExecDestroy(runtime->executable));
     CUDA(cuGraphDestroy(runtime->graph));
-    if (runtime->graph_start)
-        CUDA(cuEventDestroy(runtime->graph_start));
-    if (runtime->graph_end)
-        CUDA(cuEventDestroy(runtime->graph_end));
+    if (runtime->graphStart)
+        CUDA(cuEventDestroy(runtime->graphStart));
+    if (runtime->graphEnd)
+        CUDA(cuEventDestroy(runtime->graphEnd));
     CUDA(cuStreamDestroy(runtime->stream));
     CUDA(cuMemFree(runtime->output));
-    CUDA(cuModuleUnload(runtime->consumer_module));
-    CUDA(cuModuleUnload(runtime->producer_module));
+    CUDA(cuModuleUnload(runtime->consumerModule));
+    CUDA(cuModuleUnload(runtime->producerModule));
     CUDA(cuDevicePrimaryCtxRelease(runtime->device));
     free(runtime);
 }
@@ -237,17 +237,17 @@ class GraphRuntime:
 
     def __init__(self, build: RuntimeBuild, case: str) -> None:
         self.library = ctypes.CDLL(str(build.library_path))
-        self.library.graph_runtime_create.argtypes = [
+        self.library.graphRuntimeCreate.argtypes = [
             ctypes.c_int,
             ctypes.c_char_p,
             ctypes.c_char_p,
             ctypes.c_char_p,
             ctypes.c_char_p,
         ]
-        self.library.graph_runtime_create.restype = ctypes.c_void_p
-        self.library.graph_runtime_launch.argtypes = [ctypes.c_void_p]
-        self.library.graph_runtime_destroy.argtypes = [ctypes.c_void_p]
-        self.handle = self.library.graph_runtime_create(
+        self.library.graphRuntimeCreate.restype = ctypes.c_void_p
+        self.library.graphRuntimeLaunch.argtypes = [ctypes.c_void_p]
+        self.library.graphRuntimeDestroy.argtypes = [ctypes.c_void_p]
+        self.handle = self.library.graphRuntimeCreate(
             CASE_IDS[case],
             os.fsencode(build.producer_path),
             os.fsencode(build.consumer_path),
@@ -258,11 +258,11 @@ class GraphRuntime:
             raise RuntimeError("C graph runtime creation failed")
 
     def launch(self) -> None:
-        self.library.graph_runtime_launch(self.handle)
+        self.library.graphRuntimeLaunch(self.handle)
 
     def close(self) -> None:
         if self.handle:
-            self.library.graph_runtime_destroy(self.handle)
+            self.library.graphRuntimeDestroy(self.handle)
             self.handle = None
 
 
@@ -334,11 +334,11 @@ def main() -> None:
     triton.knobs.proton.cupti_lib_dir = triton.knobs.proton.cupti_lib_blackwell_dir
     triton.knobs.proton.enable_hw_trace = True
 
-    from triton._C.libproton import proton as libproton
+    import triton.profiler as proton
 
     case = sys.argv[1]
     replays = int(sys.argv[2])
-    trace_path = Path(sys.argv[3])
+    profile_path = Path(sys.argv[3])
     build = RuntimeBuild(
         library_path=Path(sys.argv[4]),
         producer_path=Path(sys.argv[5]),
@@ -347,44 +347,29 @@ def main() -> None:
         consumer_name=sys.argv[8],
     )
 
-    # cuInit initializes the driver, not a CUDA context. Start Proton through
-    # the low-level entry point next so HES is enabled before GraphRuntime
-    # retains and sets the primary context.
+    # cuInit initializes the driver, not a CUDA context. Start Proton next so
+    # HES is enabled before GraphRuntime retains and sets the primary context.
     cuda = ctypes.CDLL("libcuda.so.1")
     cuda.cuInit.argtypes = [ctypes.c_uint]
     cuda.cuInit.restype = ctypes.c_int
     if status := cuda.cuInit(0):
         raise RuntimeError(f"cuInit failed with status {status}")
 
-    session = libproton.start(
-        str(trace_path.with_suffix("")),
-        "shadow",
-        "trace",
-        "cupti",
-        "",
+    session = proton.start(
+        str(profile_path.with_suffix("")),
+        context="shadow",
+        data="tree",
+        backend="cupti",
     )
     runtime = GraphRuntime(build, case)
-    finalized = False
-    try:
-        libproton.deactivate(session, False)
-        runtime.launch()
-        libproton.activate(session)
-        for replay in range(replays):
-            scope_name = f"{case}_{replay}"
-            scope_id = libproton.record_scope()
-            libproton.enter_scope(scope_id, scope_name)
-            try:
-                runtime.launch()
-            finally:
-                libproton.exit_scope(scope_id, scope_name)
-        libproton.finalize(session, "")
-        finalized = True
-    finally:
-        try:
-            if not finalized:
-                libproton.finalize(session, "")
-        finally:
-            runtime.close()
+    proton.deactivate(session, flushing=False)
+    runtime.launch()
+    proton.activate(session)
+    for replay in range(replays):
+        with proton.scope(f"{case}_{replay}"):
+            runtime.launch()
+    proton.finalize(session, "")
+    runtime.close()
 
 
 if __name__ == "__main__":

--- a/third_party/proton/test/cuda_graph_helper.py
+++ b/third_party/proton/test/cuda_graph_helper.py
@@ -1,0 +1,391 @@
+"""Triton kernels and a C-built CUDA graph runtime for Proton tests."""
+
+from __future__ import annotations
+
+import ctypes
+import dataclasses
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+import triton
+import triton.language as tl
+from triton.compiler import ASTSource
+from triton.runtime import driver
+
+CASES = ("pdl", "event", "no-pdl")
+CASE_IDS = {case: index for index, case in enumerate(CASES)}
+BLOCK_SIZE = 256
+KERNELS_PER_GRAPH = 4
+CONSUMERS_PER_GRAPH = 3
+
+
+@triton.jit(do_not_specialize=["count", "iterations", "tag"])
+def pdl_producer(output, count, iterations, tag, BLOCK_SIZE: tl.constexpr):
+    offset = tl.program_id(0) * BLOCK_SIZE + tl.arange(0, BLOCK_SIZE)
+    active = offset < count
+    tl.extra.cuda.gdc_launch_dependents()
+    value = offset.to(tl.float32) + tag.to(tl.float32)
+    iteration = 0
+    while iteration < iterations:
+        value = value * 1.0000001192092896 + 0.0000001192092896
+        iteration += 1
+    tl.store(output + tag * count + offset, value, mask=active)
+
+
+@triton.jit(do_not_specialize=["count", "iterations", "tag"])
+def pdl_consumer(output, count, iterations, tag, BLOCK_SIZE: tl.constexpr):
+    offset = tl.program_id(0) * BLOCK_SIZE + tl.arange(0, BLOCK_SIZE)
+    active = offset < count
+    value = offset.to(tl.float32) + tag.to(tl.float32)
+    iteration = 0
+    while iteration < iterations:
+        value = value * 1.0000001192092896 + 0.0000001192092896
+        iteration += 1
+    tl.store(output + tag * count + offset, value, mask=active)
+
+
+C_SOURCE = r"""
+#include <cuda.h>
+
+#include <stdint.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+enum {
+    PDL = 0,
+    EVENT = 1,
+    NO_PDL = 2,
+    KERNELS_PER_GRAPH = 4,
+    CONSUMERS_PER_GRAPH = 3,
+    BLOCK_SIZE = 256,
+    COUNT = 4096,
+};
+
+static void check_cuda(CUresult result, const char *operation) {
+    if (result == CUDA_SUCCESS)
+        return;
+    const char *description = NULL;
+    cuGetErrorString(result, &description);
+    fprintf(stderr, "%s failed: %s\n", operation,
+            description ? description : "unknown CUDA error");
+    exit(2);
+}
+
+#define CUDA(call) check_cuda((call), #call)
+
+struct runtime {
+    int mode;
+    CUdevice device;
+    CUcontext context;
+    CUmodule producer_module;
+    CUmodule consumer_module;
+    CUfunction producer;
+    CUfunction consumer;
+    CUstream stream;
+    CUgraph graph;
+    CUgraphExec executable;
+    CUevent graph_start;
+    CUevent graph_end;
+    CUgraphNode kernels[KERNELS_PER_GRAPH];
+    CUdeviceptr output;
+    CUdeviceptr null_scratch;
+    uint32_t count;
+    uint32_t iterations[KERNELS_PER_GRAPH];
+    uint32_t tags[KERNELS_PER_GRAPH];
+    void *parameters[KERNELS_PER_GRAPH][6];
+};
+
+static void add_kernel(struct runtime *runtime, int index, CUfunction function,
+                       const CUgraphNode *dependencies,
+                       size_t dependency_count) {
+    runtime->parameters[index][0] = &runtime->output;
+    runtime->parameters[index][1] = &runtime->count;
+    runtime->parameters[index][2] = &runtime->iterations[index];
+    runtime->parameters[index][3] = &runtime->tags[index];
+    runtime->parameters[index][4] = &runtime->null_scratch;
+    runtime->parameters[index][5] = &runtime->null_scratch;
+
+    CUDA_KERNEL_NODE_PARAMS params;
+    memset(&params, 0, sizeof(params));
+    params.func = function;
+    params.gridDimX = (runtime->count + BLOCK_SIZE - 1) / BLOCK_SIZE;
+    params.gridDimY = 1;
+    params.gridDimZ = 1;
+    params.blockDimX = BLOCK_SIZE;
+    params.blockDimY = 1;
+    params.blockDimZ = 1;
+    params.kernelParams = runtime->parameters[index];
+    CUDA(cuGraphAddKernelNode(&runtime->kernels[index], runtime->graph,
+                              dependencies, dependency_count, &params));
+}
+
+static void build_graph(struct runtime *runtime) {
+    CUDA(cuGraphCreate(&runtime->graph, 0));
+    runtime->count = COUNT;
+    for (int index = 0; index < KERNELS_PER_GRAPH; ++index) {
+        runtime->tags[index] = (uint32_t)index;
+        runtime->iterations[index] = 10000;
+    }
+
+    if (runtime->mode == EVENT) {
+        CUgraphNode dependency;
+        CUDA(cuEventCreate(&runtime->graph_start, CU_EVENT_DEFAULT));
+        CUDA(cuEventCreate(&runtime->graph_end, CU_EVENT_DEFAULT));
+        CUDA(cuGraphAddEventRecordNode(&dependency, runtime->graph, NULL, 0,
+                                       runtime->graph_start));
+        for (int index = 0; index < KERNELS_PER_GRAPH; ++index) {
+            add_kernel(runtime, index, runtime->consumer, &dependency, 1);
+            dependency = runtime->kernels[index];
+        }
+        CUDA(cuGraphAddEventRecordNode(&dependency, runtime->graph,
+                                       &runtime->kernels[KERNELS_PER_GRAPH - 1],
+                                       1, runtime->graph_end));
+    } else {
+        runtime->iterations[0] = 25000;
+        add_kernel(runtime, 0, runtime->producer, NULL, 0);
+        for (int index = 1; index < KERNELS_PER_GRAPH; ++index) {
+            if (runtime->mode == PDL) {
+                add_kernel(runtime, index, runtime->consumer, NULL, 0);
+                CUgraphEdgeData edge;
+                memset(&edge, 0, sizeof(edge));
+                edge.from_port = CU_GRAPH_KERNEL_NODE_PORT_PROGRAMMATIC;
+                edge.type = CU_GRAPH_DEPENDENCY_TYPE_PROGRAMMATIC;
+                CUDA(cuGraphAddDependencies_v2(
+                    runtime->graph, &runtime->kernels[0],
+                    &runtime->kernels[index], &edge, 1));
+            } else {
+                add_kernel(runtime, index, runtime->consumer,
+                           &runtime->kernels[0], 1);
+            }
+        }
+    }
+    CUDA(cuGraphInstantiateWithFlags(&runtime->executable, runtime->graph, 0));
+}
+
+__attribute__((visibility("default")))
+void *graph_runtime_create(int mode, const char *producer_path,
+                           const char *consumer_path,
+                           const char *producer_name,
+                           const char *consumer_name) {
+    struct runtime *runtime = calloc(1, sizeof(*runtime));
+    if (!runtime)
+        return NULL;
+    runtime->mode = mode;
+
+    CUDA(cuInit(0));
+    CUDA(cuDeviceGet(&runtime->device, 0));
+    CUDA(cuDevicePrimaryCtxRetain(&runtime->context, runtime->device));
+    CUDA(cuCtxSetCurrent(runtime->context));
+    CUDA(cuModuleLoad(&runtime->producer_module, producer_path));
+    CUDA(cuModuleLoad(&runtime->consumer_module, consumer_path));
+    CUDA(cuModuleGetFunction(&runtime->producer, runtime->producer_module,
+                             producer_name));
+    CUDA(cuModuleGetFunction(&runtime->consumer, runtime->consumer_module,
+                             consumer_name));
+    CUDA(cuMemAlloc(&runtime->output,
+                    KERNELS_PER_GRAPH * COUNT * sizeof(float)));
+    CUDA(cuStreamCreate(&runtime->stream, CU_STREAM_NON_BLOCKING));
+    build_graph(runtime);
+    return runtime;
+}
+
+__attribute__((visibility("default")))
+void graph_runtime_launch(void *handle) {
+    struct runtime *runtime = handle;
+    CUDA(cuGraphLaunch(runtime->executable, runtime->stream));
+    if (runtime->mode == EVENT)
+        CUDA(cuEventSynchronize(runtime->graph_end));
+    else
+        CUDA(cuStreamSynchronize(runtime->stream));
+}
+
+__attribute__((visibility("default")))
+void graph_runtime_destroy(void *handle) {
+    struct runtime *runtime = handle;
+    if (!runtime)
+        return;
+    CUDA(cuCtxSetCurrent(runtime->context));
+    CUDA(cuGraphExecDestroy(runtime->executable));
+    CUDA(cuGraphDestroy(runtime->graph));
+    if (runtime->graph_start)
+        CUDA(cuEventDestroy(runtime->graph_start));
+    if (runtime->graph_end)
+        CUDA(cuEventDestroy(runtime->graph_end));
+    CUDA(cuStreamDestroy(runtime->stream));
+    CUDA(cuMemFree(runtime->output));
+    CUDA(cuModuleUnload(runtime->consumer_module));
+    CUDA(cuModuleUnload(runtime->producer_module));
+    CUDA(cuDevicePrimaryCtxRelease(runtime->device));
+    free(runtime);
+}
+"""
+
+
+@dataclasses.dataclass(frozen=True)
+class RuntimeBuild:
+    library_path: Path
+    producer_path: Path
+    consumer_path: Path
+    producer_name: str
+    consumer_name: str
+
+
+class GraphRuntime:
+
+    def __init__(self, build: RuntimeBuild, case: str) -> None:
+        self.library = ctypes.CDLL(str(build.library_path))
+        self.library.graph_runtime_create.argtypes = [
+            ctypes.c_int,
+            ctypes.c_char_p,
+            ctypes.c_char_p,
+            ctypes.c_char_p,
+            ctypes.c_char_p,
+        ]
+        self.library.graph_runtime_create.restype = ctypes.c_void_p
+        self.library.graph_runtime_launch.argtypes = [ctypes.c_void_p]
+        self.library.graph_runtime_destroy.argtypes = [ctypes.c_void_p]
+        self.handle = self.library.graph_runtime_create(
+            CASE_IDS[case],
+            os.fsencode(build.producer_path),
+            os.fsencode(build.consumer_path),
+            os.fsencode(build.producer_name),
+            os.fsencode(build.consumer_name),
+        )
+        if not self.handle:
+            raise RuntimeError("C graph runtime creation failed")
+
+    def launch(self) -> None:
+        self.library.graph_runtime_launch(self.handle)
+
+    def close(self) -> None:
+        if self.handle:
+            self.library.graph_runtime_destroy(self.handle)
+            self.handle = None
+
+
+def _compile_kernel(kernel, target) -> tuple[bytes, str]:
+    source = ASTSource(
+        kernel,
+        {
+            "output": "*fp32",
+            "count": "u32",
+            "iterations": "u32",
+            "tag": "u32",
+        },
+        constexprs={"BLOCK_SIZE": BLOCK_SIZE},
+    )
+    compiled = triton.compile(
+        source,
+        target=target,
+        options={"num_warps": 8, "num_stages": 1},
+    )
+    if compiled.metadata.global_scratch_size or compiled.metadata.profile_scratch_size:
+        raise RuntimeError(f"{compiled.name} unexpectedly requires scratch storage")
+    return compiled.asm["cubin"], compiled.name
+
+
+def build_runtime(build_dir: Path, cuda_home: Path) -> RuntimeBuild:
+    target = driver.active.get_current_target()
+    if target.backend != "cuda" or int(target.arch) < 100:
+        raise RuntimeError(f"CUDA Blackwell is required, got {target}")
+
+    producer_cubin, producer_name = _compile_kernel(pdl_producer, target)
+    consumer_cubin, consumer_name = _compile_kernel(pdl_consumer, target)
+    producer_path = build_dir / "pdl_producer.cubin"
+    consumer_path = build_dir / "pdl_consumer.cubin"
+    producer_path.write_bytes(producer_cubin)
+    consumer_path.write_bytes(consumer_cubin)
+
+    source_path = build_dir / "cuda_graph_runtime.c"
+    source_path.write_text(C_SOURCE)
+    library_path = build_dir / "cuda_graph_runtime.so"
+    subprocess.run(
+        [
+            "gcc",
+            "-O2",
+            "-std=c11",
+            "-Wall",
+            "-Wextra",
+            "-Werror",
+            "-fPIC",
+            "-shared",
+            f"-I{cuda_home / 'include'}",
+            str(source_path),
+            f"-L{cuda_home / 'lib64'}",
+            "-lcuda",
+            "-o",
+            str(library_path),
+        ],
+        check=True,
+    )
+    return RuntimeBuild(
+        library_path=library_path,
+        producer_path=producer_path,
+        consumer_path=consumer_path,
+        producer_name=producer_name,
+        consumer_name=consumer_name,
+    )
+
+
+def main() -> None:
+    triton.knobs.proton.cupti_lib_dir = triton.knobs.proton.cupti_lib_blackwell_dir
+    triton.knobs.proton.enable_hw_trace = True
+
+    from triton._C.libproton import proton as libproton
+
+    case = sys.argv[1]
+    replays = int(sys.argv[2])
+    trace_path = Path(sys.argv[3])
+    build = RuntimeBuild(
+        library_path=Path(sys.argv[4]),
+        producer_path=Path(sys.argv[5]),
+        consumer_path=Path(sys.argv[6]),
+        producer_name=sys.argv[7],
+        consumer_name=sys.argv[8],
+    )
+
+    # cuInit initializes the driver, not a CUDA context. Start Proton through
+    # the low-level entry point next so HES is enabled before GraphRuntime
+    # retains and sets the primary context.
+    cuda = ctypes.CDLL("libcuda.so.1")
+    cuda.cuInit.argtypes = [ctypes.c_uint]
+    cuda.cuInit.restype = ctypes.c_int
+    if status := cuda.cuInit(0):
+        raise RuntimeError(f"cuInit failed with status {status}")
+
+    session = libproton.start(
+        str(trace_path.with_suffix("")),
+        "shadow",
+        "trace",
+        "cupti",
+        "",
+    )
+    runtime = GraphRuntime(build, case)
+    finalized = False
+    try:
+        libproton.deactivate(session, False)
+        runtime.launch()
+        libproton.activate(session)
+        for replay in range(replays):
+            scope_name = f"{case}_{replay}"
+            scope_id = libproton.record_scope()
+            libproton.enter_scope(scope_id, scope_name)
+            try:
+                runtime.launch()
+            finally:
+                libproton.exit_scope(scope_id, scope_name)
+        libproton.finalize(session, "")
+        finalized = True
+    finally:
+        try:
+            if not finalized:
+                libproton.finalize(session, "")
+        finally:
+            runtime.close()
+
+
+if __name__ == "__main__":
+    main()

--- a/third_party/proton/test/cuda_graph_helper.py
+++ b/third_party/proton/test/cuda_graph_helper.py
@@ -29,7 +29,7 @@ def pdl_producer(output, count, iterations, tag, BLOCK_SIZE: tl.constexpr):
     value = offset.to(tl.float32) + tag.to(tl.float32)
     iteration = 0
     while iteration < iterations:
-        value = value * 1.0000001192092896 + 0.0000001192092896
+        value = value * 1.02 + 1.02
         iteration += 1
     tl.store(output + tag * count + offset, value, mask=active)
 
@@ -41,7 +41,7 @@ def pdl_consumer(output, count, iterations, tag, BLOCK_SIZE: tl.constexpr):
     value = offset.to(tl.float32) + tag.to(tl.float32)
     iteration = 0
     while iteration < iterations:
-        value = value * 1.0000001192092896 + 0.0000001192092896
+        value = value * 1.02 + 1.02
         iteration += 1
     tl.store(output + tag * count + offset, value, mask=active)
 

--- a/third_party/proton/test/test_profile.py
+++ b/third_party/proton/test/test_profile.py
@@ -5,6 +5,11 @@ Each test should invoke one or more GPU kernels and check the validity of their 
 
 import os
 import pathlib
+import shutil
+import subprocess
+import sys
+
+import cuda_graph_helper
 
 import triton
 import triton.profiler as proton
@@ -1974,3 +1979,100 @@ def test_hw_trace(fresh_knobs, tmp_path: pathlib.Path, device: str):
     kernel_frame = data[0]["children"][0]["children"][0]
     assert "elementwise" in kernel_frame["frame"]["name"]
     assert kernel_frame["metrics"]["time (ns)"] > 0
+
+
+@pytest.fixture(scope="module")
+def cupti_graph_construction_runtime(tmp_path_factory: pytest.TempPathFactory):
+    if not is_blackwell():
+        pytest.skip("CUPTI HES graph construction tests require a Blackwell GPU")
+    if shutil.which("gcc") is None:
+        pytest.skip("gcc is required to build the CUDA graph test runtime")
+
+    cuda_home = pathlib.Path(os.environ.get("CUDA_HOME", "/usr/local/cuda"))
+    if not (cuda_home / "include" / "cuda.h").is_file():
+        pytest.skip(f"CUDA headers are unavailable under {cuda_home}")
+    build_dir = tmp_path_factory.mktemp("cupti-graph-construction")
+    return cuda_graph_helper.build_runtime(build_dir, cuda_home)
+
+
+@pytest.mark.skipif(not is_blackwell(), reason="HW trace is only supported on Blackwell GPUs")
+@pytest.mark.parametrize("case", cuda_graph_helper.CASES)
+def test_cupti_hes_graph_construction_launch(
+    case: str,
+    cupti_graph_construction_runtime: cuda_graph_helper.RuntimeBuild,
+    tmp_path: pathlib.Path,
+):
+    replays = 3
+    helper_path = pathlib.Path(cuda_graph_helper.__file__).resolve()
+
+    trace_path = tmp_path / f"{case}.chrome_trace"
+    try:
+        result = subprocess.run(
+            [
+                sys.executable,
+                str(helper_path),
+                case,
+                str(replays),
+                str(trace_path),
+                str(cupti_graph_construction_runtime.library_path),
+                str(cupti_graph_construction_runtime.producer_path),
+                str(cupti_graph_construction_runtime.consumer_path),
+                cupti_graph_construction_runtime.producer_name,
+                cupti_graph_construction_runtime.consumer_name,
+            ],
+            capture_output=True,
+            text=True,
+            timeout=30,
+        )
+    except subprocess.TimeoutExpired as error:
+        pytest.fail(f"{case}: timed out after {error.timeout}s\n"
+                    f"stdout:\n{error.stdout}\nstderr:\n{error.stderr}")
+
+    assert result.returncode == 0, (f"{case}: child exited with status {result.returncode}\n"
+                                    f"stdout:\n{result.stdout}\nstderr:\n{result.stderr}")
+
+    with trace_path.open() as trace_file:
+        trace_events = json.load(trace_file)["traceEvents"]
+    build = cupti_graph_construction_runtime
+    kernel_names = {build.producer_name, build.consumer_name}
+    kernel_events = [
+        event for event in trace_events if event.get("cat") == "kernel" and event.get("name") in kernel_names
+    ]
+    expected_kernel_count = replays * cuda_graph_helper.KERNELS_PER_GRAPH
+    assert len(kernel_events) == expected_kernel_count, (
+        f"{case}: found {len(kernel_events)} kernel events, expected {expected_kernel_count}")
+
+    for replay in range(replays):
+        scope_name = f"{case}_{replay}"
+        replay_events = [
+            event for event in kernel_events if event.get("args", {}).get("call_stack", [])[:2] == ["ROOT", scope_name]
+        ]
+        assert len(replay_events) == cuda_graph_helper.KERNELS_PER_GRAPH, (
+            f"{scope_name}: found {len(replay_events)} kernel events")
+        for event in replay_events:
+            assert event["args"]["call_stack"] == [
+                "ROOT",
+                scope_name,
+                "<captured_at>",
+                event["name"],
+            ]
+            assert event["dur"] > 0
+
+        producers = [event for event in replay_events if event["name"] == build.producer_name]
+        consumers = [event for event in replay_events if event["name"] == build.consumer_name]
+        if case in ("pdl", "no-pdl"):
+            assert len(producers) == 1
+            assert len(consumers) == cuda_graph_helper.CONSUMERS_PER_GRAPH
+            producer = producers[0]
+            producer_end = producer["ts"] + producer["dur"]
+            overlaps = [
+                consumer["ts"] < producer_end and producer["ts"] < consumer["ts"] + consumer["dur"]
+                for consumer in consumers
+            ]
+            if case == "pdl":
+                assert all(overlaps)
+            else:
+                assert not any(overlaps)
+        else:
+            assert not producers
+            assert len(consumers) == cuda_graph_helper.KERNELS_PER_GRAPH

--- a/third_party/proton/test/test_profile.py
+++ b/third_party/proton/test/test_profile.py
@@ -2005,7 +2005,7 @@ def test_cupti_hes_graph_construction_launch(
     replays = 3
     helper_path = pathlib.Path(cuda_graph_helper.__file__).resolve()
 
-    trace_path = tmp_path / f"{case}.chrome_trace"
+    profile_path = tmp_path / f"{case}.hatchet"
     try:
         result = subprocess.run(
             [
@@ -2013,7 +2013,7 @@ def test_cupti_hes_graph_construction_launch(
                 str(helper_path),
                 case,
                 str(replays),
-                str(trace_path),
+                str(profile_path),
                 str(cupti_graph_construction_runtime.library_path),
                 str(cupti_graph_construction_runtime.producer_path),
                 str(cupti_graph_construction_runtime.consumer_path),
@@ -2031,48 +2031,30 @@ def test_cupti_hes_graph_construction_launch(
     assert result.returncode == 0, (f"{case}: child exited with status {result.returncode}\n"
                                     f"stdout:\n{result.stdout}\nstderr:\n{result.stderr}")
 
-    with trace_path.open() as trace_file:
-        trace_events = json.load(trace_file)["traceEvents"]
+    with profile_path.open() as profile_file:
+        profile = json.load(profile_file)
     build = cupti_graph_construction_runtime
     kernel_names = {build.producer_name, build.consumer_name}
-    kernel_events = [
-        event for event in trace_events if event.get("cat") == "kernel" and event.get("name") in kernel_names
-    ]
-    expected_kernel_count = replays * cuda_graph_helper.KERNELS_PER_GRAPH
-    assert len(kernel_events) == expected_kernel_count, (
-        f"{case}: found {len(kernel_events)} kernel events, expected {expected_kernel_count}")
 
     for replay in range(replays):
         scope_name = f"{case}_{replay}"
-        replay_events = [
-            event for event in kernel_events if event.get("args", {}).get("call_stack", [])[:2] == ["ROOT", scope_name]
-        ]
-        assert len(replay_events) == cuda_graph_helper.KERNELS_PER_GRAPH, (
-            f"{scope_name}: found {len(replay_events)} kernel events")
-        for event in replay_events:
-            assert event["args"]["call_stack"] == [
-                "ROOT",
-                scope_name,
-                "<captured_at>",
-                event["name"],
-            ]
-            assert event["dur"] > 0
+        replay_frame = _find_frame_by_name(profile[0], scope_name)
+        assert replay_frame is not None
+        capture_frame = _find_frame_by_name(replay_frame, "<captured_at>")
+        assert capture_frame is not None
+        kernel_frames = [child for child in capture_frame["children"] if child["frame"]["name"] in kernel_names]
+        assert sum(frame["metrics"]["count"] for frame in kernel_frames) == cuda_graph_helper.KERNELS_PER_GRAPH
+        assert all(frame["metrics"]["time (ns)"] > 0 for frame in kernel_frames)
 
-        producers = [event for event in replay_events if event["name"] == build.producer_name]
-        consumers = [event for event in replay_events if event["name"] == build.consumer_name]
+        producer_count = sum(frame["metrics"]["count"]
+                             for frame in kernel_frames
+                             if frame["frame"]["name"] == build.producer_name)
+        consumer_count = sum(frame["metrics"]["count"]
+                             for frame in kernel_frames
+                             if frame["frame"]["name"] == build.consumer_name)
         if case in ("pdl", "no-pdl"):
-            assert len(producers) == 1
-            assert len(consumers) == cuda_graph_helper.CONSUMERS_PER_GRAPH
-            producer = producers[0]
-            producer_end = producer["ts"] + producer["dur"]
-            overlaps = [
-                consumer["ts"] < producer_end and producer["ts"] < consumer["ts"] + consumer["dur"]
-                for consumer in consumers
-            ]
-            if case == "pdl":
-                assert all(overlaps)
-            else:
-                assert not any(overlaps)
+            assert producer_count == 1
+            assert consumer_count == cuda_graph_helper.CONSUMERS_PER_GRAPH
         else:
-            assert not producers
-            assert len(consumers) == cuda_graph_helper.KERNELS_PER_GRAPH
+            assert producer_count == 0
+            assert consumer_count == cuda_graph_helper.KERNELS_PER_GRAPH


### PR DESCRIPTION
- Cuda graph call path reconstruction is not supported yet
- Metadata profiling is not supported in cuda graph

These features require proton C/C++ apis