### PR TITLE
[NVIDIA] Optimize scalarized masked loads, stores, and cache policies

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -11,3 +11,6 @@
 
 ## C++ Guidelines
 - In C++, never put side-effecting code in `assert`. Assertions may be compiled out, so perform mutations and other required computation before the assertion and assert only the resulting condition. This guideline does not apply to Python `assert` statements.
+
+## Lowering Guidelines
+- Lowerings must inspect only the operation they lower. Do not inspect other operations or follow loop-carried values; perform cross-operation reasoning in a separate analysis or transformation pass.

--- a/test/Conversion/tritongpu_to_llvm.mlir
+++ b/test/Conversion/tritongpu_to_llvm.mlir
@@ -256,6 +256,22 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 1 : i32} {
     tt.return
   }
 
+  // CHECK-LABEL: masked_scalarized_pointer_argument
+  tt.func @masked_scalarized_pointer_argument(%ptrs: tensor<128x!tt.ptr<f32>, #blocked0> {tt.contiguity = 4 : i32, tt.divisibility = 4 : i32}, %mask: tensor<128xi1, #blocked0>) {
+    %other = arith.constant dense<0.0> : tensor<128xf32, #blocked0>
+    // CHECK: ld.global.b32 { ${{.*}} }, [ ${{.*}} + 0 ];
+    // CHECK: ld.global.b32 { ${{.*}} }, [ ${{.*}} + 4 ];
+    // CHECK: ld.global.b32 { ${{.*}} }, [ ${{.*}} + 8 ];
+    // CHECK: ld.global.b32 { ${{.*}} }, [ ${{.*}} + 12 ];
+    %values = tt.load %ptrs, %mask, %other : tensor<128x!tt.ptr<f32>, #blocked0>
+    // CHECK: st.global.b32 [ ${{.*}} + 0 ]
+    // CHECK: st.global.b32 [ ${{.*}} + 4 ]
+    // CHECK: st.global.b32 [ ${{.*}} + 8 ]
+    // CHECK: st.global.b32 [ ${{.*}} + 12 ]
+    tt.store %ptrs, %values, %mask : tensor<128x!tt.ptr<f32>, #blocked0>
+    tt.return
+  }
+
   // CHECK-LABEL: masked_scalarized_bitcast_load
   tt.func @masked_scalarized_bitcast_load(%arg0: !tt.ptr<f32> {tt.divisibility = 16 : i32}, %arg1: i32) {
     %range = tt.make_range {end = 128 : i32, start = 0 : i32} : tensor<128xi32, #blocked0>

--- a/test/Conversion/tritongpu_to_llvm.mlir
+++ b/test/Conversion/tritongpu_to_llvm.mlir
@@ -198,7 +198,42 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 2 : i32} {
 // -----
 
 #blocked0 = #ttg.blocked<{sizePerThread = [4], threadsPerWarp = [32], warpsPerCTA = [1], order = [0]}>
+#blocked2d = #ttg.blocked<{sizePerThread = [1, 4], threadsPerWarp = [1, 32], warpsPerCTA = [1, 1], order = [1, 0]}>
+#slice = #ttg.slice<{dim = 0, parent = #blocked2d}>
 module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 1 : i32} {
+
+  // CHECK-LABEL: masked_four_byte_fp8
+  tt.func @masked_four_byte_fp8(%ptr: !tt.ptr<f8E4M3FN> {tt.divisibility = 16 : i32}, %bound: i32 {tt.divisibility = 4 : i32}, %fallback: f8E4M3FN) {
+    %offsets = tt.make_range {end = 128 : i32, start = 0 : i32} : tensor<128xi32, #blocked0>
+    %base = tt.splat %ptr : !tt.ptr<f8E4M3FN> -> tensor<128x!tt.ptr<f8E4M3FN>, #blocked0>
+    %ptrs = tt.addptr %base, %offsets : tensor<128x!tt.ptr<f8E4M3FN>, #blocked0>, tensor<128xi32, #blocked0>
+    %bounds = tt.splat %bound : i32 -> tensor<128xi32, #blocked0>
+    %mask = arith.cmpi slt, %offsets, %bounds : tensor<128xi32, #blocked0>
+    %other = tt.splat %fallback : f8E4M3FN -> tensor<128xf8E4M3FN, #blocked0>
+    // CHECK: llvm.inline_asm
+    // CHECK-SAME: @$3 ld.global.b32 { $0 }, [ $2 + 0 ];", "=r,0,l,b"
+    %values = tt.load %ptrs, %mask, %other : tensor<128x!tt.ptr<f8E4M3FN>, #blocked0>
+    tt.store %ptrs, %values, %mask : tensor<128x!tt.ptr<f8E4M3FN>, #blocked0>
+    tt.return
+  }
+
+  // CHECK-LABEL: masked_rank_two_fp8
+  tt.func @masked_rank_two_fp8(%ptr: !tt.ptr<f8E4M3FN> {tt.divisibility = 16 : i32}, %bound: i32 {tt.divisibility = 4 : i32}, %fallback: f8E4M3FN) {
+    %columns = tt.make_range {end = 128 : i32, start = 0 : i32} : tensor<128xi32, #slice>
+    %offsets = tt.expand_dims %columns {axis = 0 : i32} : tensor<128xi32, #slice> -> tensor<1x128xi32, #blocked2d>
+    %base = tt.splat %ptr : !tt.ptr<f8E4M3FN> -> tensor<1x128x!tt.ptr<f8E4M3FN>, #blocked2d>
+    %ptrs = tt.addptr %base, %offsets : tensor<1x128x!tt.ptr<f8E4M3FN>, #blocked2d>, tensor<1x128xi32, #blocked2d>
+    %bounds = tt.splat %bound : i32 -> tensor<1x128xi32, #blocked2d>
+    %mask = arith.cmpi slt, %offsets, %bounds : tensor<1x128xi32, #blocked2d>
+    %other = tt.splat %fallback : f8E4M3FN -> tensor<1x128xf8E4M3FN, #blocked2d>
+    // CHECK: llvm.inline_asm
+    // CHECK-SAME: mov.u32 $0, $1;
+    // CHECK-SAME: ld.global.b32
+    %values = tt.load %ptrs, %mask, %other : tensor<1x128x!tt.ptr<f8E4M3FN>, #blocked2d>
+    tt.store %ptrs, %values, %mask : tensor<1x128x!tt.ptr<f8E4M3FN>, #blocked2d>
+    tt.return
+  }
+
   // CHECK-LABEL: masked_scalarized_contiguous_load
   tt.func @masked_scalarized_contiguous_load(%arg0: !tt.ptr<f32> {tt.divisibility = 4 : i32}, %arg1: i32) {
     %range = tt.make_range {end = 128 : i32, start = 0 : i32} : tensor<128xi32, #blocked0>

--- a/test/Conversion/tritongpu_to_llvm.mlir
+++ b/test/Conversion/tritongpu_to_llvm.mlir
@@ -47,10 +47,25 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 1 : i32} {
   // CHECK-LABEL: vectorized_load_f16
   tt.func @vectorized_load_f16(%a_ptr_init: tensor<256x!tt.ptr<f16>, #blocked0>, %cst : tensor<256xi1, #blocked0>, %cst_0 : tensor<256xf16, #blocked0>) {
     // CHECK: llvm.inline_asm
-    // CHECK-SAME: ld.global.b16
+    // CHECK-SAME: mov.u16 $0, $1;\0A\09@$3 ld.global.b16 { $0 }, [ $2 + 0 ];", "=c,c,l,b"
     // CHECK: llvm.inline_asm
     // CHECK-SAME: ld.global.b16
     %1 = tt.load %a_ptr_init, %cst, %cst_0 : tensor<256x!tt.ptr<f16>, #blocked0>
+    tt.return
+  }
+
+  // CHECK-LABEL: masked_multiword_f16
+  tt.func @masked_multiword_f16(%ptr: !tt.ptr<f16> {tt.divisibility = 16 : i32}, %bound: i32 {tt.divisibility = 8 : i32}, %fallback: f16) {
+    %offsets = tt.make_range {end = 256 : i32, start = 0 : i32} : tensor<256xi32, #blocked0>
+    %base = tt.splat %ptr : !tt.ptr<f16> -> tensor<256x!tt.ptr<f16>, #blocked0>
+    %ptrs = tt.addptr %base, %offsets : tensor<256x!tt.ptr<f16>, #blocked0>, tensor<256xi32, #blocked0>
+    %bounds = tt.splat %bound : i32 -> tensor<256xi32, #blocked0>
+    %mask = arith.cmpi slt, %offsets, %bounds : tensor<256xi32, #blocked0>
+    %other = tt.splat %fallback : f16 -> tensor<256xf16, #blocked0>
+    // CHECK: llvm.inline_asm
+    // CHECK-SAME: @$9 ld.global.v4.b32 { $0, $1, $2, $3 }, [ $8 + 0 ];", "=r,=r,=r,=r,0,1,2,3,l,b"
+    %values = tt.load %ptrs, %mask, %other : tensor<256x!tt.ptr<f16>, #blocked0>
+    tt.store %ptrs, %values, %mask : tensor<256x!tt.ptr<f16>, #blocked0>
     tt.return
   }
 }

--- a/test/Conversion/tritongpu_to_llvm.mlir
+++ b/test/Conversion/tritongpu_to_llvm.mlir
@@ -88,7 +88,7 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32} {
   // CHECK-LABEL: store_with_cache_attr
   tt.func @store_with_cache_attr(%a_ptr_init : tensor<256x!tt.ptr<f32>, #blocked0>, %cst : tensor<256xi1, #blocked0>, %cst_0 : tensor<256xf32, #blocked0>) {
     // The cache policy register is created once (hoisted out of the vectorization loop).
-    // CHECK: llvm.inline_asm has_side_effects asm_dialect = att {{.*}} "mov.u64 $0, 0x0;\0A\09createpolicy.fractional.L2::evict_last.b64 $0, 1.0;"
+    // CHECK: llvm.inline_asm asm_dialect = att {{.*}} "mov.u64 $0, 0x0;\0A\09createpolicy.fractional.L2::evict_last.b64 $0, 1.0;"
     // CHECK: llvm.inline_asm has_side_effects asm_dialect = att {{.*}} "@$3 st.global.L1::evict_last.L2::cache_hint.b32 [ $1 + 0 ], { $0 }, $2;"
     // CHECK-NOT: createpolicy
     // CHECK: llvm.inline_asm has_side_effects asm_dialect = att {{.*}} "@$3 st.global.L1::evict_last.L2::cache_hint.b32 [ $1 + 0 ], { $0 }, $2;"
@@ -104,7 +104,7 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32} {
   // CHECK-LABEL: load_with_l2_cache_hint
   tt.func @load_with_l2_cache_hint(%a_ptr_init : tensor<256x!tt.ptr<f32>, #blocked0>, %cst : tensor<256xi1, #blocked0>, %cst_0 : tensor<256xf32, #blocked0>) {
     // The cache policy register is created once (hoisted out of the vectorization loop).
-    // CHECK: llvm.inline_asm has_side_effects asm_dialect = att {{.*}} "mov.u64 $0, 0x0;\0A\09createpolicy.fractional.L2::evict_first.b64 $0, 1.0;"
+    // CHECK: llvm.inline_asm asm_dialect = att {{.*}} "mov.u64 $0, 0x0;\0A\09createpolicy.fractional.L2::evict_first.b64 $0, 1.0;"
     // CHECK: llvm.inline_asm has_side_effects asm_dialect = att {{.*}} "mov.u32 $0, $1;\0A\09@$4 ld.global.L1::evict_first.L2::cache_hint.b32 { $0 }, [ $2 + 0 ], $3;"
     // CHECK-NOT: createpolicy
     // CHECK: llvm.inline_asm has_side_effects asm_dialect = att {{.*}} "mov.u32 $0, $1;\0A\09@$4 ld.global.L1::evict_first.L2::cache_hint.b32 { $0 }, [ $2 + 0 ], $3;"
@@ -119,7 +119,7 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32} {
   // CHECK-LABEL: store_with_l2_cache_hint
   tt.func @store_with_l2_cache_hint(%a_ptr_init : tensor<256x!tt.ptr<f32>, #blocked0>, %cst : tensor<256xi1, #blocked0>, %cst_0 : tensor<256xf32, #blocked0>) {
     // The cache policy register is created once (hoisted out of the vectorization loop).
-    // CHECK: llvm.inline_asm has_side_effects asm_dialect = att {{.*}} "mov.u64 $0, 0x0;\0A\09createpolicy.fractional.L2::evict_last.b64 $0, 1.0;"
+    // CHECK: llvm.inline_asm asm_dialect = att {{.*}} "mov.u64 $0, 0x0;\0A\09createpolicy.fractional.L2::evict_last.b64 $0, 1.0;"
     // CHECK: llvm.inline_asm has_side_effects asm_dialect = att {{.*}} "@$3 st.global.L1::evict_last.L2::cache_hint.b32 [ $1 + 0 ], { $0 }, $2;"
     // CHECK-NOT: createpolicy
     // CHECK: llvm.inline_asm has_side_effects asm_dialect = att {{.*}} "@$3 st.global.L1::evict_last.L2::cache_hint.b32 [ $1 + 0 ], { $0 }, $2;"

--- a/test/Conversion/tritongpu_to_llvm.mlir
+++ b/test/Conversion/tritongpu_to_llvm.mlir
@@ -182,6 +182,56 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 2 : i32} {
 
 // -----
 
+#blocked0 = #ttg.blocked<{sizePerThread = [4], threadsPerWarp = [32], warpsPerCTA = [1], order = [0]}>
+module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 1 : i32} {
+  // CHECK-LABEL: masked_scalarized_contiguous_load
+  tt.func @masked_scalarized_contiguous_load(%arg0: !tt.ptr<f32> {tt.divisibility = 4 : i32}, %arg1: i32) {
+    %range = tt.make_range {end = 128 : i32, start = 0 : i32} : tensor<128xi32, #blocked0>
+    %base = tt.splat %arg0 : !tt.ptr<f32> -> tensor<128x!tt.ptr<f32>, #blocked0>
+    %ptrs = tt.addptr %base, %range : tensor<128x!tt.ptr<f32>, #blocked0>, tensor<128xi32, #blocked0>
+    %limit = tt.splat %arg1 : i32 -> tensor<128xi32, #blocked0>
+    %mask = arith.cmpi slt, %range, %limit : tensor<128xi32, #blocked0>
+    %other = arith.constant dense<0.0> : tensor<128xf32, #blocked0>
+
+    // CHECK: ld.global.b32 { ${{.*}} }, [ ${{.*}} + 0 ];
+    // CHECK: ld.global.b32 { ${{.*}} }, [ ${{.*}} + 4 ];
+    // CHECK: ld.global.b32 { ${{.*}} }, [ ${{.*}} + 8 ];
+    // CHECK: ld.global.b32 { ${{.*}} }, [ ${{.*}} + 12 ];
+    %0 = tt.load %ptrs, %mask, %other : tensor<128x!tt.ptr<f32>, #blocked0>
+    // CHECK: st.global.b32 [ ${{.*}} + 0 ]
+    // CHECK: st.global.b32 [ ${{.*}} + 4 ]
+    // CHECK: st.global.b32 [ ${{.*}} + 8 ]
+    // CHECK: st.global.b32 [ ${{.*}} + 12 ]
+    tt.store %ptrs, %0, %mask : tensor<128x!tt.ptr<f32>, #blocked0>
+    tt.return
+  }
+
+  // CHECK-LABEL: masked_scalarized_bitcast_load
+  tt.func @masked_scalarized_bitcast_load(%arg0: !tt.ptr<f32> {tt.divisibility = 16 : i32}, %arg1: i32) {
+    %range = tt.make_range {end = 128 : i32, start = 0 : i32} : tensor<128xi32, #blocked0>
+    %base = tt.splat %arg0 : !tt.ptr<f32> -> tensor<128x!tt.ptr<f32>, #blocked0>
+    %ptrs = tt.addptr %base, %range : tensor<128x!tt.ptr<f32>, #blocked0>, tensor<128xi32, #blocked0>
+    %cast = tt.bitcast %ptrs : tensor<128x!tt.ptr<f32>, #blocked0> -> tensor<128x!tt.ptr<f16>, #blocked0>
+    %limit = tt.splat %arg1 : i32 -> tensor<128xi32, #blocked0>
+    %mask = arith.cmpi slt, %range, %limit : tensor<128xi32, #blocked0>
+    %other = arith.constant dense<0.0> : tensor<128xf16, #blocked0>
+
+    // CHECK: ld.global.b16 { ${{.*}} }, [ ${{.*}} + 0 ];
+    // CHECK: ld.global.b16 { ${{.*}} }, [ ${{.*}} + 0 ];
+    // CHECK: ld.global.b16 { ${{.*}} }, [ ${{.*}} + 0 ];
+    // CHECK: ld.global.b16 { ${{.*}} }, [ ${{.*}} + 0 ];
+    %0 = tt.load %cast, %mask, %other : tensor<128x!tt.ptr<f16>, #blocked0>
+    // CHECK: st.global.b16 [ ${{.*}} + 0 ]
+    // CHECK: st.global.b16 [ ${{.*}} + 0 ]
+    // CHECK: st.global.b16 [ ${{.*}} + 0 ]
+    // CHECK: st.global.b16 [ ${{.*}} + 0 ]
+    tt.store %cast, %0, %mask : tensor<128x!tt.ptr<f16>, #blocked0>
+    tt.return
+  }
+}
+
+// -----
+
 #blocked0 = #ttg.blocked<{sizePerThread = [4], threadsPerWarp = [32], warpsPerCTA = [2], order = [0]}>
 module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 2 : i32} {
   // CHECK-LABEL: global_load_store_vec4

--- a/third_party/nvidia/lib/TritonNVIDIAGPUToLLVM/LoadStoreOpToLLVM.cpp
+++ b/third_party/nvidia/lib/TritonNVIDIAGPUToLLVM/LoadStoreOpToLLVM.cpp
@@ -271,9 +271,14 @@ struct LoadOpConversion : public ConvertOpToLLVMPattern<triton::LoadOp>,
           }
           v = b.bitcast(v, IntegerType::get(getContext(), width));
 
-          if (!otherIsSplatConstInt && valueElemNBits == 16 && nWords > 1 &&
-              isa<RankedTensorType>(op.getType())) {
+          auto tensorType = dyn_cast<RankedTensorType>(op.getType());
+          if (!otherIsSplatConstInt && tensorType &&
+              ((valueElemNBits == 16 && nWords > 1) ||
+               (valueElemNBits == 8 && width == 32 && nWords == 1 && vec == 4 &&
+                tensorType.getRank() == 1 &&
+                isa<FloatType>(tensorType.getElementType())))) {
             // Match each fallback to its destination instead of moving it.
+            // Match the packed FP8 fallback to its 32-bit destination.
             ptxBuilder.newOperand(v, std::to_string(dstsOpr->listGet(ii)->idx));
             continue;
           }

--- a/third_party/nvidia/lib/TritonNVIDIAGPUToLLVM/LoadStoreOpToLLVM.cpp
+++ b/third_party/nvidia/lib/TritonNVIDIAGPUToLLVM/LoadStoreOpToLLVM.cpp
@@ -70,7 +70,8 @@ Value createCachePolicy(triton::EvictionPolicy opEvict,
     policy(dstOpr, fractionOpr);
 
     Type policyRetTy = rewriter.getI64Type();
-    policyRet = ptxBuilder.launch(rewriter, loc, policyRetTy);
+    policyRet = ptxBuilder.launch(rewriter, loc, policyRetTy,
+                                  /*hasSideEffect=*/false);
   }
 
   return policyRet;

--- a/third_party/nvidia/lib/TritonNVIDIAGPUToLLVM/LoadStoreOpToLLVM.cpp
+++ b/third_party/nvidia/lib/TritonNVIDIAGPUToLLVM/LoadStoreOpToLLVM.cpp
@@ -259,10 +259,6 @@ struct LoadOpConversion : public ConvertOpToLLVMPattern<triton::LoadOp>,
 
       if (other) {
         for (size_t ii = 0; ii < nWords; ++ii) {
-          // PTX doesn't support mov.u8, so we need to use mov.u16
-          PTXInstr &mov =
-              ptxBuilder.create("mov")->o("u" + std::to_string(movWidth));
-
           size_t size = width / valueElemNBits;
 
           auto vecTy = LLVM::getVectorType(valueElemTy, size);
@@ -274,6 +270,17 @@ struct LoadOpConversion : public ConvertOpToLLVMPattern<triton::LoadOp>,
             v = b.insert_element(vecTy, v, falseVal, sVal);
           }
           v = b.bitcast(v, IntegerType::get(getContext(), width));
+
+          if (!otherIsSplatConstInt && valueElemNBits == 16 && nWords > 1 &&
+              isa<RankedTensorType>(op.getType())) {
+            // Match each fallback to its destination instead of moving it.
+            ptxBuilder.newOperand(v, std::to_string(dstsOpr->listGet(ii)->idx));
+            continue;
+          }
+
+          // PTX doesn't support mov.u8, so we need to use mov.u16
+          PTXInstr &mov =
+              ptxBuilder.create("mov")->o("u" + std::to_string(movWidth));
 
           PTXInstr::Operand *opr{};
 

--- a/third_party/nvidia/lib/TritonNVIDIAGPUToLLVM/LoadStoreOpToLLVM.cpp
+++ b/third_party/nvidia/lib/TritonNVIDIAGPUToLLVM/LoadStoreOpToLLVM.cpp
@@ -110,20 +110,17 @@ struct LoadStoreConversionBase {
 
   unsigned getScalarizedContiguousRun(Value ptr) const {
     auto type = dyn_cast<RankedTensorType>(ptr.getType());
-    auto addPtr = ptr.getDefiningOp<triton::AddPtrOp>();
-    if (!type || !addPtr)
+    if (!type)
       return 1;
 
-    AxisInfo *baseInfo = axisAnalysisPass.getAxisInfo(addPtr.getPtr());
-    AxisInfo *offsetInfo = axisAnalysisPass.getAxisInfo(addPtr.getOffset());
-    if (!baseInfo || !offsetInfo)
+    AxisInfo *ptrInfo = axisAnalysisPass.getAxisInfo(ptr);
+    if (!ptrInfo)
       return 1;
 
     unsigned dim = ttg::getOrder(type)[0];
-    // A constant base and consecutive offsets prove the actual byte stride.
-    return std::min<int64_t>({baseInfo->getConstancy(dim),
-                              offsetInfo->getContiguity(dim),
-                              ttg::getContigPerThread(type)[dim]});
+    // Scalar accesses need a consecutive element stride, not vector alignment.
+    return std::min<int64_t>(ptrInfo->getContiguity(dim),
+                             ttg::getContigPerThread(type)[dim]);
   }
 
 protected:

--- a/third_party/nvidia/lib/TritonNVIDIAGPUToLLVM/LoadStoreOpToLLVM.cpp
+++ b/third_party/nvidia/lib/TritonNVIDIAGPUToLLVM/LoadStoreOpToLLVM.cpp
@@ -107,6 +107,24 @@ struct LoadStoreConversionBase {
     return axisAnalysisPass.getMaskAlignment(mask);
   }
 
+  unsigned getScalarizedContiguousRun(Value ptr) const {
+    auto type = dyn_cast<RankedTensorType>(ptr.getType());
+    auto addPtr = ptr.getDefiningOp<triton::AddPtrOp>();
+    if (!type || !addPtr)
+      return 1;
+
+    AxisInfo *baseInfo = axisAnalysisPass.getAxisInfo(addPtr.getPtr());
+    AxisInfo *offsetInfo = axisAnalysisPass.getAxisInfo(addPtr.getOffset());
+    if (!baseInfo || !offsetInfo)
+      return 1;
+
+    unsigned dim = ttg::getOrder(type)[0];
+    // A constant base and consecutive offsets prove the actual byte stride.
+    return std::min<int64_t>({baseInfo->getConstancy(dim),
+                              offsetInfo->getContiguity(dim),
+                              ttg::getContigPerThread(type)[dim]});
+  }
+
 protected:
   const NVIDIA::TargetInfo &targetInfo;
   ModuleAxisInfoAnalysis &axisAnalysisPass;
@@ -195,6 +213,9 @@ struct LoadOpConversion : public ConvertOpToLLVMPattern<triton::LoadOp>,
         std::max(8u, valueElemTy.getIntOrFloatBitWidth());
     const int numVecs = numElems / vec;
 
+    const size_t scalarizedContiguousRun =
+        llMask && vec == 1 ? getScalarizedContiguousRun(ptr) : 1;
+
     LDBG("LoadOp numElems = " << numElems << " vec = " << vec
                               << " valueElemNBits = " << valueElemNBits << " "
                               << op.getType());
@@ -205,7 +226,8 @@ struct LoadOpConversion : public ConvertOpToLLVMPattern<triton::LoadOp>,
         createCachePolicy(op.getEvict(), rewriter, loc, computeCapability);
     for (size_t vecStart = 0; vecStart < numElems; vecStart += vec) {
       // TODO: optimization when ptr is GEP with constant offset
-      size_t in_off = 0;
+      const size_t runStart = vecStart - vecStart % scalarizedContiguousRun;
+      const size_t in_off = (vecStart - runStart) * valueElemNBits / 8;
 
       const size_t maxWordWidth = std::max<size_t>(32, valueElemNBits);
       const size_t totalWidth = valueElemNBits * vec;
@@ -268,7 +290,7 @@ struct LoadOpConversion : public ConvertOpToLLVMPattern<triton::LoadOp>,
       }
 
       auto *addrOpr =
-          ptxBuilder.newAddrOperand(ptrElems[vecStart], "l", in_off);
+          ptxBuilder.newAddrOperand(ptrElems[runStart], "l", in_off);
 
       // Define the instruction opcode
       auto &ld = ptxBuilder.create("ld")
@@ -394,6 +416,9 @@ struct StoreOpConversion : public ConvertOpToLLVMPattern<triton::StoreOp>,
         std::max<int>(1, valueElemTy.getIntOrFloatBitWidth() / 8);
     const size_t valueElemNBits = dtsize * 8;
 
+    const size_t scalarizedContiguousRun =
+        llMask && vec == 1 ? getScalarizedContiguousRun(ptr) : 1;
+
     auto freeVarMasks = getFreeVariableMasks(ptr.getType());
     if (op.getIgnoreCta())
       freeVarMasks[str_attr("block")] = 0;
@@ -406,7 +431,8 @@ struct StoreOpConversion : public ConvertOpToLLVMPattern<triton::StoreOp>,
         createCachePolicy(op.getEvict(), rewriter, loc, computeCapability);
     for (size_t vecStart = 0; vecStart < elemsPerThread; vecStart += vec) {
       // TODO: optimization when ptr is AddPtr with constant offset
-      size_t in_off = 0;
+      const size_t runStart = vecStart - vecStart % scalarizedContiguousRun;
+      const size_t in_off = (vecStart - runStart) * valueElemNBits / 8;
 
       const size_t maxWordWidth = std::max<size_t>(32, valueElemNBits);
       const size_t totalWidth = valueElemNBits * vec;
@@ -453,7 +479,7 @@ struct StoreOpConversion : public ConvertOpToLLVMPattern<triton::StoreOp>,
       }
 
       auto *asmAddr =
-          ptxBuilder.newAddrOperand(ptrElems[vecStart], "l", in_off);
+          ptxBuilder.newAddrOperand(ptrElems[runStart], "l", in_off);
 
       auto &ptxStoreInstr =
           ptxBuilder.create("st")


### PR DESCRIPTION
- Reuse a proven contiguous base plus immediate byte offsets for independently masked scalar loads and stores, while respecting per-thread layout boundaries. For other types of loads this is already done by ptxas.
- Mark deterministic L2 cache-policy construction as side-effect-free so LLVM can eliminate duplicate policy descriptors.
- Reuse inline-assembly destination registers for masked multiword 16-bit fallbacks and tightly restricted rank-one packed FP8 fallbacks. For integer types we still use immediates.
- Document that lowerings should inspect only the operation they lower; leave cross-operation reasoning to separate analyses or passes.

All this (other than the docs lol) improves the generated SASS of the associated instructions.