### PR TITLE
[RUNTIME] Publish kernel cache groups atomically via per-writer staging

### DIFF
--- a/python/test/unit/runtime/test_cache.py
+++ b/python/test/unit/runtime/test_cache.py
@@ -37,6 +37,24 @@ def test_file_cache_manager_get_group_rejects_missing_child(fresh_knobs, tmp_pat
     assert manager.get_group("kernel.json") is None
 
 
+def test_file_cache_manager_concurrent_group_publish_stays_coherent(fresh_knobs, tmp_path):
+    # A reader must never see a group mixing files from concurrent same-key writers, however the writes interleave.
+    fresh_knobs.cache.dir = str(tmp_path)
+    writer_a = FileCacheManager("key")
+    writer_b = FileCacheManager("key")
+
+    group_a = {"kernel.cubin": writer_a.put("A cubin", "kernel.cubin", binary=False, grouped=True)}
+    group_b = {"kernel.cubin": writer_b.put("B cubin", "kernel.cubin", binary=False, grouped=True)}
+    group_b["kernel.json"] = writer_b.put("B json", "kernel.json", binary=False, grouped=True)
+    group_a["kernel.json"] = writer_a.put("A json", "kernel.json", binary=False, grouped=True)
+
+    for writer, group in ((writer_a, group_a), (writer_b, group_b)):
+        writer.put_group("kernel.json", group)
+        published = FileCacheManager("key").get_group("kernel.json")
+        contents = {pathlib.Path(path).read_text() for path in published.values()}
+        assert contents in ({"A cubin", "A json"}, {"B cubin", "B json"})
+
+
 def test_remote_cache_manager_get_group_rejects_missing_child(fresh_knobs, tmp_path):
 
     class DictRemoteCacheBackend:

--- a/python/triton/compiler/compiler.py
+++ b/python/triton/compiler/compiler.py
@@ -311,10 +311,10 @@ def compile(src, target=None, options=None, _env_vars=None):
 
     if ir_source:
         ir_filename = f"{file_name}.{src.ext}"
-        metadata_group[ir_filename] = fn_cache_manager.put(module, ir_filename)
+        metadata_group[ir_filename] = fn_cache_manager.put(module, ir_filename, grouped=True)
     else:
         ir_filename = f"{file_name}.source"
-        metadata_group[ir_filename] = fn_cache_manager.put(module, ir_filename)
+        metadata_group[ir_filename] = fn_cache_manager.put(module, ir_filename, grouped=True)
 
     use_ir_loc = knobs.compilation.use_ir_loc
     if ir_source and use_ir_loc:
@@ -336,7 +336,7 @@ def compile(src, target=None, options=None, _env_vars=None):
             next_module = parse(full_name, ext, context)
         # If TRITON_STORE_BINARY_ONLY is 1, only store cubin/hsaco/json
         if (not store_only_binary) or (ext in ("cubin", "hsaco", "json")):
-            metadata_group[ir_filename] = fn_cache_manager.put(next_module, ir_filename)
+            metadata_group[ir_filename] = fn_cache_manager.put(next_module, ir_filename, grouped=True)
         if fn_dump_manager is not None:
             fn_dump_manager.put(next_module, ir_filename)
             if ext == "cubin":
@@ -344,7 +344,7 @@ def compile(src, target=None, options=None, _env_vars=None):
                 fn_dump_manager.put(sass, file_name + ".sass")
         # use an env variable to parse ir from file
         if use_ir_loc == ext:
-            ir_full_name = fn_cache_manager.get_file(ir_filename)
+            ir_full_name = metadata_group[ir_filename]
             next_module.create_location_snapshot(ir_full_name)
             print(f"Creating new locations for {ir_full_name}")
         module = next_module
@@ -352,7 +352,7 @@ def compile(src, target=None, options=None, _env_vars=None):
             timer.stage_finished(ext)
     # write-back metadata
     metadata_group[metadata_filename] = fn_cache_manager.put(json.dumps(metadata, default=vars), metadata_filename,
-                                                             binary=False)
+                                                             binary=False, grouped=True)
     fn_cache_manager.put_group(metadata_filename, metadata_group)
 
     # notify any listener

--- a/python/triton/runtime/cache.py
+++ b/python/triton/runtime/cache.py
@@ -21,7 +21,7 @@ class CacheManager(ABC):
         pass
 
     @abstractmethod
-    def put(self, data, filename, binary=True) -> str:
+    def put(self, data, filename, binary=True, grouped=False) -> str:
         pass
 
     @abstractmethod
@@ -38,6 +38,7 @@ class FileCacheManager(CacheManager):
     def __init__(self, key, override=False, dump=False):
         self.key = key
         self.lock_path = None
+        self._staging_dir = None
         if dump:
             self.cache_dir = knobs.cache.dump_dir
             self.cache_dir = os.path.join(self.cache_dir, self.key)
@@ -100,14 +101,23 @@ class FileCacheManager(CacheManager):
         grp_filename = f"__grp__{filename}"
         return self.put(grp_contents, grp_filename, binary=False)
 
-    def put(self, data, filename, binary=True) -> str:
+    def _group_staging_dir(self) -> str:
+        # Per-writer staging, published atomically by put_group's manifest replace, so groups never mix writers.
+        if self._staging_dir is None:
+            staging_dir = os.path.join(self.cache_dir, f"grp.{uuid.uuid4().hex[:16]}")
+            os.makedirs(staging_dir, exist_ok=True)
+            self._staging_dir = staging_dir
+        return self._staging_dir
+
+    def put(self, data, filename, binary=True, grouped=False) -> str:
         if not self.cache_dir:
             raise RuntimeError("Could not create or locate cache dir")
         binary = isinstance(data, bytes)
         if not binary:
             data = str(data)
         assert self.lock_path is not None
-        filepath = self._make_path(filename)
+        target_dir = self._group_staging_dir() if grouped else self.cache_dir
+        filepath = os.path.join(target_dir, filename)
         # Random ID to avoid any collisions
         rnd_id = str(uuid.uuid4())
         # we use the PID in case a bunch of these around so we can see what PID made it
@@ -200,10 +210,10 @@ class RemoteCacheManager(CacheManager):
         (_, data), = results.items()
         return self._materialize(filename, data)
 
-    def put(self, data, filename: str, binary=True) -> str:
+    def put(self, data, filename: str, binary=True, grouped=False) -> str:
         # We don't handle the dump/override cases.
         if self._dump or self._override:
-            return self._file_cache_manager.put(data, filename, binary=binary)
+            return self._file_cache_manager.put(data, filename, binary=binary, grouped=grouped)
 
         if not isinstance(data, bytes):
             data = str(data).encode("utf-8")


### PR DESCRIPTION
## Problem

A kernel's cache entry is a group of files (IR stages, cubin, metadata JSON, plus a `__grp__` manifest). Each individual write is atomic (`os.replace`), but concurrent compilations of the same key — separate processes or hosts sharing one cache dir — write the same file names into the same directory. A reader can then load a **mixed group**: one writer's cubin paired with another writer's metadata JSON. If the two compilations are not byte-identical, launch metadata no longer matches the binary and the kernel silently misbehaves.

Not theoretical: in a multi-node deployment sharing `TRITON_CACHE_DIR` on Lustre, concurrent first-compiles of two alignment specializations of vLLM's causal-conv1d kernels corrupted the cache and produced silent all-NaN model outputs. Forensics in vllm-project/vllm#52413.

## Fix

Make group publication transactional, using only the atomicity the cache already has:

- grouped files are staged in a per-writer directory `<key>/grp.<uuid>/` (`put(..., grouped=True)`);
- `put_group`'s manifest replace — already atomic — becomes the single publication point.

The manifest always references one writer's complete set, so torn/mixed groups become unobservable. A compilation's returned `CompiledKernel` also now always points at its own files — they can no longer be overwritten in place by a concurrent same-key writer. No locks (unreliable on NFS/Lustre anyway); works on any POSIX filesystem. Old caches remain readable (manifests store absolute paths). A losing writer's staging dir is left orphaned inside the key dir — bounded by the number of concurrent same-key compiles, i.e. the same duplicated work that exists today.

## Test

`test_file_cache_manager_concurrent_group_publish_stays_coherent` interleaves two writers' child writes in the worst order and asserts every published group is single-origin. On current main the reader observes `{A json, B cubin}`; with this change both publications are coherent.

Also verified end-to-end on GPU (GB200): fresh cache dir → compile → run OK, manifest children all live in the writer's staging dir; a second process gets a clean cache hit through the manifest.
