### PR TITLE
[Membar] Treat warp_specialize entry as a CTA sync point

### DIFF
--- a/lib/Analysis/Membar.cpp
+++ b/lib/Analysis/Membar.cpp
@@ -175,7 +175,19 @@ static triton::BarrierStages getLocalBarrierStages(Operation *op,
   // write and read phases. Other barrier-like operations behave as a barrier
   // immediately before the operation.
   stages.betweenMemoryEffects = hasScratchBarrier;
-  stages.beforeMemoryEffects = containsLocalBarrier(op);
+
+  // Entering the default region of a `ttg.warp_specialize` goes through the two
+  // CTA-wide barriers `lowerWarpSpecializeCommon` emits between the capture
+  // stores and the branch into the region. This is keyed on the scratch buffer
+  // rather than on `getCaptureSize() == 0` because the capture stores precede
+  // those barriers, backends override the scratch size, and the concurrency
+  // sanitizer reserves capture bytes on every op regardless of its captures.
+  // It cannot live in `containsLocalBarrier`, which has no `Allocation` and so
+  // could only answer unconditionally.
+  if (isa<triton::gpu::WarpSpecializeOp>(op))
+    stages.beforeMemoryEffects = !hasScratchBarrier;
+  else
+    stages.beforeMemoryEffects = containsLocalBarrier(op);
   return stages;
 }
 

--- a/test/Analysis/test-membar-ttng.mlir
+++ b/test/Analysis/test-membar-ttng.mlir
@@ -50,6 +50,21 @@ tt.func @warpgroup_wait_followed_by_barrier_expect(%acc: tensor<256xf32, #blocke
   tt.return
 }
 
+// CHECK-LABEL: @warpgroup_wait_followed_by_warp_specialize
+tt.func @warpgroup_wait_followed_by_warp_specialize(%acc: tensor<256xf32, #blocked>, %value: i32) {
+  %c1 = arith.constant 1 : i32
+  // CHECK: ttng.warp_group_dot_wait {{.*}} {pendings = 0 : i32, warpGroupLocal}
+  // CHECK-NEXT: arith.addi
+  // CHECK-NEXT: ttg.warp_specialize
+  %wait = ttng.warp_group_dot_wait %acc {pendings = 0 : i32} : tensor<256xf32, #blocked>
+  %next = arith.addi %value, %c1 : i32
+  ttg.warp_specialize()
+  default {
+    ttg.warp_yield
+  } : () -> ()
+  tt.return
+}
+
 // CHECK-LABEL: @warpgroup_wait_before_memory_effect
 tt.func @warpgroup_wait_before_memory_effect(%acc: tensor<256xf32, #blocked>) {
   %allocation = ttg.local_alloc : () -> !ttg.memdesc<256xf32, #shared, #smem, mutable>

--- a/test/Analysis/test-membar.mlir
+++ b/test/Analysis/test-membar.mlir
@@ -1040,7 +1040,6 @@ tt.func @warp_specialize_into_default(%arg0: tensor<1xi64>) {
   ttg.warp_specialize()
   // CHECK-NEXT: default
   default {
-    // CHECK-NEXT: ttg.barrier local
     // CHECK-NEXT: local_load
     ttg.local_load %0 : !ttg.memdesc<1xi64, #layout, #smem, mutable> -> tensor<1xi64>
     // CHECK-NEXT: ttg.barrier local
@@ -1064,7 +1063,6 @@ tt.func @default_region_cfg(%arg0: tensor<1xi64>, %arg1: i1) {
   ttg.warp_specialize()
   // CHECK-NEXT: default
   default {
-    // CHECK-NEXT: ttg.barrier local
     // CHECK-NEXT: local_load
     ttg.local_load %0 : !ttg.memdesc<1xi64, #layout, #smem, mutable> -> tensor<1xi64>
     cf.cond_br %arg1, ^bb1, ^bb2
@@ -1084,6 +1082,59 @@ tt.func @default_region_cfg(%arg0: tensor<1xi64>, %arg1: i1) {
   // CHECK-NEXT: ttg.barrier local
   // CHECK-NEXT: local_store
   ttg.local_store %arg0, %0 : tensor<1xi64> -> !ttg.memdesc<1xi64, #layout, #smem, mutable>
+  tt.return
+}
+
+// -----
+
+#layout = #ttg.swizzled_shared<{vec = 2, perPhase = 2, maxPhase = 4, order = [0]}>
+#smem = #ttg.shared_memory
+
+// A memory wait can defer its barrier onto a following sync point, and the
+// entry into a captureless warp_specialize is one.
+// CHECK-LABEL: @async_wait_before_warp_specialize
+tt.func @async_wait_before_warp_specialize(%arg0: tensor<1xi64>) {
+  // CHECK-NEXT: local_alloc
+  %0 = ttg.local_alloc : () -> !ttg.memdesc<1xi64, #layout, #smem, mutable>
+  // CHECK-NEXT: local_store
+  ttg.local_store %arg0, %0 : tensor<1xi64> -> !ttg.memdesc<1xi64, #layout, #smem, mutable>
+  // CHECK-NEXT: async_wait
+  ttg.async_wait {num = 4 : i32}
+  // CHECK-NEXT: warp_specialize
+  ttg.warp_specialize()
+  // CHECK-NEXT: default
+  default {
+    // CHECK-NEXT: local_load
+    ttg.local_load %0 : !ttg.memdesc<1xi64, #layout, #smem, mutable> -> tensor<1xi64>
+    // CHECK-NEXT: warp_yield
+    ttg.warp_yield
+  // CHECK-NEXT: () -> ()
+  } : () -> ()
+  tt.return
+}
+
+// The same wait keeps its barrier when the op owns a scratch buffer.
+// CHECK-LABEL: @async_wait_before_warp_specialize_with_captures
+tt.func @async_wait_before_warp_specialize_with_captures(%arg0: tensor<1xi64>) {
+  // CHECK-NEXT: local_alloc
+  %0 = ttg.local_alloc : () -> !ttg.memdesc<1xi64, #layout, #smem, mutable>
+  // CHECK-NEXT: local_store
+  ttg.local_store %arg0, %0 : tensor<1xi64> -> !ttg.memdesc<1xi64, #layout, #smem, mutable>
+  // CHECK-NEXT: async_wait
+  ttg.async_wait {num = 4 : i32}
+  // CHECK-NEXT: ttg.barrier local
+  // CHECK-NEXT: warp_specialize
+  ttg.warp_specialize(%0)
+  // CHECK-NEXT: default
+  default {
+    // CHECK-NEXT: warp_yield
+    ttg.warp_yield
+  }
+  // CHECK: partition0
+  partition0(%arg1: !ttg.memdesc<1xi64, #layout, #smem, mutable>) num_warps(1) {
+    // CHECK-NEXT: warp_return
+    ttg.warp_return
+  } : (!ttg.memdesc<1xi64, #layout, #smem, mutable>) -> ()
   tt.return
 }
 
@@ -1185,7 +1236,6 @@ tt.func @check_barrier_no_duplication(%arg0: tensor<1xi64>) {
   ttg.warp_specialize()
   // CHECK-NEXT: default
   default {
-    // CHECK-NEXT: ttg.barrier local
     // CHECK-NEXT: local_load
     ttg.local_load %0 : !ttg.memdesc<1xi64, #layout, #smem, mutable> -> tensor<1xi64>
     // CHECK-NEXT: ttg.barrier


### PR DESCRIPTION
Entering the default region of a `ttg.warp_specialize` already goes through the two CTA-wide barriers `lowerWarpSpecializeCommon` emits between the capture stores and the branch into the region, so shared memory effects that happen before the op are synchronized by the time the region starts. Membar did not model that, so it inserted a redundant `ttg.barrier` at the top of the default region whenever a shared memory access preceded the op.

This follows what the analysis already does elsewhere: `WarpSpecializePartitionsOp` is modelled the same way for the partition entry barrier, and #10035 added `ArriveBarrierOp`, `BarrierExpectOp` and `TCGen5CommitOp` after making their lowerings emit one.

The rule is keyed on the op having no scratch buffer rather than on `getCaptureSize() == 0`. When the op owns a scratch buffer the capture stores into it happen before those barriers, so the rendezvous that matters is the `betweenMemoryEffects` one the scratch path already models. The two predicates are not interchangeable: backends override the scratch size, and `PrepareConSanCaptures` reserves capture bytes on every `warp_specialize` regardless of its captures, so keying on the capture size would drop a barrier that is still needed under `--instrumentation-mode=consan`.

There is a second effect worth calling out, because it is not obvious from the diff: `hasSyncPointBeforeMemoryEffect` also reads `beforeMemoryEffects`, so a memory wait sitting directly before a capture-free `warp_specialize` now defers its barrier onto the region entry, and a `warp_group_dot_wait` in that position gets marked `warpGroupLocal`. That is the same deferral #10675 introduced, onto a barrier that is a real CTA-wide `bar.sync`, and the three new tests cover both directions of it.

Scope, measured rather than assumed: on the membar corpus this removes 3 barriers (`test/Analysis/test-membar.mlir` goes from 127 to 124 emitted `ttg.barrier`, `test/Analysis/test-membar-ttng.mlir` and `test/TritonNvidiaGPU/membar-cluster.mlir` are unchanged). It does **not** change generated code: partitions are `IsolatedFromAbove`, so a `warp_specialize` produced by the pipeliner carries captures and already got this through the scratch path. I compiled `python/test/unit/language/test_warp_specialization.py` on an H100 with and without the patch and the generated PTX has the same 2356 barriers across the same 75 kernels, with 145 passed / 1432 skipped either way. So this is a modelling gap being closed, not a speedup, and it shows up for the capture-free shape that hand-written and Gluon kernels use.

`lit` over `test/Analysis`, `test/TritonGPU`, `test/Conversion`, `test/TritonNvidiaGPU` and `test/NVWS` gives the same result before and after: the same 14 pre-existing failures in both runs, none of them a membar test, and both RUN lines of `test-membar.mlir` (including the AMD one) pass.

`ttg.warp_yield` lowers to a CTA-wide barrier too and modelling it removes one more barrier in the corpus, but it needs the region-exit state modelled and its own tests, so I left it for a follow-up rather than bundling it here.

# New contributor declaration
- [x] I am not making a trivial change, such as fixing a typo in a comment.

- [x] I have written a PR description following these
  [rules](https://cbea.ms/git-commit/#why-not-how).

- [x] I have run `pre-commit run --from-ref origin/main --to-ref HEAD`.

- Select one of the following.
  - [x] I have added tests.
    - `/test` for `lit` tests
    - `/unittest` for C++ tests
    - `/python/test` for end-to-end tests
  - [ ] This PR does not need a test because `FILL THIS IN`.

- Select one of the following.
  - [ ] I have not added any `lit` tests.
  - [x] The `lit` tests I have added follow these [best practices](https://mlir.llvm.org/getting_started/TestingGuide/#filecheck-best-practices),
    including the "tests should be minimal" section. (Usually running Python code
    and using the instructions it generates is not minimal.)
