### PR TITLE
[Membar] Treat the warp_specialize terminators as CTA sync points

### DIFF
--- a/lib/Analysis/Membar.cpp
+++ b/lib/Analysis/Membar.cpp
@@ -177,7 +177,6 @@ static triton::BarrierStages getLocalBarrierStages(Operation *op,
   // write and read phases. Other barrier-like operations behave as a barrier
   // immediately before the operation.
   stages.betweenMemoryEffects = hasScratchBarrier;
-
   stages.beforeMemoryEffects = containsLocalBarrier(op);
   return stages;
 }

--- a/lib/Analysis/Membar.cpp
+++ b/lib/Analysis/Membar.cpp
@@ -175,7 +175,16 @@ static triton::BarrierStages getLocalBarrierStages(Operation *op,
   // write and read phases. Other barrier-like operations behave as a barrier
   // immediately before the operation.
   stages.betweenMemoryEffects = hasScratchBarrier;
-  stages.beforeMemoryEffects = containsLocalBarrier(op);
+
+  // Leaving the default region of a `ttg.warp_specialize` goes through the
+  // CTA-wide barrier `lowerWarpSpecializeCommon` emits at every
+  // `ttg.warp_yield`, which is the rendezvous with the barrier each partition
+  // executes on `ttg.warp_return`, so shared memory effects inside the region
+  // are synchronized before the code after the op runs.
+  if (isa<triton::gpu::WarpYieldOp>(op))
+    stages.beforeMemoryEffects = true;
+  else
+    stages.beforeMemoryEffects = containsLocalBarrier(op);
   return stages;
 }
 

--- a/lib/Analysis/Membar.cpp
+++ b/lib/Analysis/Membar.cpp
@@ -115,6 +115,8 @@ bool containsLocalBarrier(Operation *op) {
     return true;
   if (isa<triton::gpu::WarpSpecializePartitionsOp>(op))
     return true;
+  if (isa<triton::gpu::WarpYieldOp, triton::gpu::WarpReturnOp>(op))
+    return true;
   if (isa<ttng::ArriveBarrierOp>(op))
     return true;
   if (isa<ttng::BarrierExpectOp>(op))
@@ -176,15 +178,7 @@ static triton::BarrierStages getLocalBarrierStages(Operation *op,
   // immediately before the operation.
   stages.betweenMemoryEffects = hasScratchBarrier;
 
-  // Leaving the default region of a `ttg.warp_specialize` goes through the
-  // CTA-wide barrier `lowerWarpSpecializeCommon` emits at every
-  // `ttg.warp_yield`, which is the rendezvous with the barrier each partition
-  // executes on `ttg.warp_return`, so shared memory effects inside the region
-  // are synchronized before the code after the op runs.
-  if (isa<triton::gpu::WarpYieldOp>(op))
-    stages.beforeMemoryEffects = true;
-  else
-    stages.beforeMemoryEffects = containsLocalBarrier(op);
+  stages.beforeMemoryEffects = containsLocalBarrier(op);
   return stages;
 }
 

--- a/test/Analysis/test-membar.mlir
+++ b/test/Analysis/test-membar.mlir
@@ -1086,24 +1086,6 @@ tt.func @default_region_cfg(%arg0: tensor<1xi64>, %arg1: i1) {
   tt.return
 }
 
-// A `ttg.warp_return` lowers to the same CTA-wide barrier as `ttg.warp_yield`,
-// so a wait at the end of a partition region does not need one of its own.
-// CHECK-LABEL: @async_wait_before_warp_return
-tt.func @async_wait_before_warp_return() {
-  ttg.warp_specialize()
-  default {
-    ttg.warp_yield
-  }
-  // CHECK: partition0
-  partition0() num_warps(4) {
-    // CHECK: ttg.async_wait
-    // CHECK-NEXT: ttg.warp_return
-    ttg.async_wait {num = 0 : i32}
-    ttg.warp_return
-  } : () -> ()
-  tt.return
-}
-
 // -----
 
 #blocked = #ttg.blocked<{sizePerThread = [1, 4], threadsPerWarp = [4, 8], warpsPerCTA = [4, 1], order = [1, 0]}>

--- a/test/Analysis/test-membar.mlir
+++ b/test/Analysis/test-membar.mlir
@@ -1086,6 +1086,26 @@ tt.func @default_region_cfg(%arg0: tensor<1xi64>, %arg1: i1) {
   tt.return
 }
 
+// `hasSyncPointBeforeMemoryEffect` normally inserts a barrier after a wait, so
+// that the reads it releases are ordered against what follows. Here the wait is
+// the last operation of a partition region, and the `ttg.warp_return` that ends
+// it already lowers to a CTA-wide barrier, so no second one is needed.
+// CHECK-LABEL: @async_wait_before_warp_return
+tt.func @async_wait_before_warp_return() {
+  ttg.warp_specialize()
+  default {
+    ttg.warp_yield
+  }
+  // CHECK: partition0
+  partition0() num_warps(4) {
+    // CHECK: ttg.async_wait
+    // CHECK-NEXT: ttg.warp_return
+    ttg.async_wait {num = 0 : i32}
+    ttg.warp_return
+  } : () -> ()
+  tt.return
+}
+
 // -----
 
 #blocked = #ttg.blocked<{sizePerThread = [1, 4], threadsPerWarp = [4, 8], warpsPerCTA = [4, 1], order = [1, 0]}>

--- a/test/Analysis/test-membar.mlir
+++ b/test/Analysis/test-membar.mlir
@@ -1086,24 +1086,21 @@ tt.func @default_region_cfg(%arg0: tensor<1xi64>, %arg1: i1) {
   tt.return
 }
 
-// The barrier at every warp_yield also covers a write after the op, on the path
-// through the region that has no barrier of its own.
-// CHECK-LABEL: @warp_yield_is_a_sync_point
-tt.func @warp_yield_is_a_sync_point(%arg0: tensor<1xi64>) {
-  // CHECK-NEXT: local_alloc
-  %0 = ttg.local_alloc : () -> !ttg.memdesc<1xi64, #layout, #smem, mutable>
-  // CHECK-NEXT: warp_specialize
+// A `ttg.warp_return` lowers to the same CTA-wide barrier as `ttg.warp_yield`,
+// so a wait at the end of a partition region does not need one of its own.
+// CHECK-LABEL: @async_wait_before_warp_return
+tt.func @async_wait_before_warp_return() {
   ttg.warp_specialize()
-  // CHECK-NEXT: default
   default {
-    // CHECK-NEXT: local_load
-    ttg.local_load %0 : !ttg.memdesc<1xi64, #layout, #smem, mutable> -> tensor<1xi64>
-    // CHECK-NEXT: warp_yield
     ttg.warp_yield
-  // CHECK-NEXT: () -> ()
+  }
+  // CHECK: partition0
+  partition0() num_warps(4) {
+    // CHECK: ttg.async_wait
+    // CHECK-NEXT: ttg.warp_return
+    ttg.async_wait {num = 0 : i32}
+    ttg.warp_return
   } : () -> ()
-  // CHECK-NEXT: local_store
-  ttg.local_store %arg0, %0 : tensor<1xi64> -> !ttg.memdesc<1xi64, #layout, #smem, mutable>
   tt.return
 }
 

--- a/test/Analysis/test-membar.mlir
+++ b/test/Analysis/test-membar.mlir
@@ -1081,7 +1081,27 @@ tt.func @default_region_cfg(%arg0: tensor<1xi64>, %arg1: i1) {
     ttg.warp_yield
   // CHECK-NEXT: () -> ()
   } : () -> ()
-  // CHECK-NEXT: ttg.barrier local
+  // CHECK-NEXT: local_store
+  ttg.local_store %arg0, %0 : tensor<1xi64> -> !ttg.memdesc<1xi64, #layout, #smem, mutable>
+  tt.return
+}
+
+// The barrier at every warp_yield also covers a write after the op, on the path
+// through the region that has no barrier of its own.
+// CHECK-LABEL: @warp_yield_is_a_sync_point
+tt.func @warp_yield_is_a_sync_point(%arg0: tensor<1xi64>) {
+  // CHECK-NEXT: local_alloc
+  %0 = ttg.local_alloc : () -> !ttg.memdesc<1xi64, #layout, #smem, mutable>
+  // CHECK-NEXT: warp_specialize
+  ttg.warp_specialize()
+  // CHECK-NEXT: default
+  default {
+    // CHECK-NEXT: local_load
+    ttg.local_load %0 : !ttg.memdesc<1xi64, #layout, #smem, mutable> -> tensor<1xi64>
+    // CHECK-NEXT: warp_yield
+    ttg.warp_yield
+  // CHECK-NEXT: () -> ()
+  } : () -> ()
   // CHECK-NEXT: local_store
   ttg.local_store %arg0, %0 : tensor<1xi64> -> !ttg.memdesc<1xi64, #layout, #smem, mutable>
   tt.return


### PR DESCRIPTION
`lowerWarpSpecializeCommon` emits a CTA-wide barrier at every `ttg.warp_yield`, and every partition executes one at `ttg.warp_return` with the same barrier id, so the two are a rendezvous: shared memory effects inside the regions are ordered before the code that follows the op. Membar did not model that, so it inserted a redundant `ttg.barrier` after a `warp_specialize` whenever the code after it touched shared memory that the region had touched.

Unlike the entry-side rule in #11323, this one does change generated code. Compiling `python/test/unit/language/test_warp_specialization.py` on an H100, one fresh cache per build, across the same 75 kernels with 145 passed / 1432 skipped every time: 2016 `bar.sync` on `main`, 1956 with this patch. On the membar corpus, `test/Analysis/test-membar.mlir` goes from 127 to 126 emitted `ttg.barrier`.

There is no measurable wall-clock difference: I timed `matmul_tma_ws_kernel` at 4096^3 over seven configurations and the deltas range from -0.38% to +0.25%, which is noise. The case for this change is that the analysis is more conservative than it needs to be, not that kernels get faster.

The barrier is CTA-wide on both in-tree backends (`llvm.nvvm.barrier.cta.sync.all` on NVIDIA, `rocdl.barrier` on AMD) and `lowerWarpSpecializeBarriers` runs before `lowerWarpSpecialize`, so it is not rewritten into a warp-group named barrier. Every path through one `warp_specialize` executes exactly three of these: the default warp group takes the two on entry plus the one at the yield, a warp assigned to a partition takes the switch-loop head, the partition entry, and the one at `warp_return`, and an unassigned warp takes the head plus the two in the idle block. That is what pairs `warp_return` with `warp_yield`.

`lit` over `test/Analysis`, `test/TritonGPU`, `test/Conversion`, `test/TritonNvidiaGPU` and `test/NVWS` gives the same result before and after: the same 14 pre-existing failures in both runs, none of them a membar test.

This overlaps #11323 in the same `if`/`else`, so whichever lands second needs a trivial rebase. They are independent: that one is about entering the default region, this one about leaving it.

# New contributor declaration
- [x] I am not making a trivial change, such as fixing a typo in a comment.

- [x] I have written a PR description following these
  [rules](https://cbea.ms/git-commit/#why-not-how).

- [x] I have run `pre-commit run --from-ref origin/main --to-ref HEAD`.

- Select one of the following.
  - [x] I have added tests.
    - `/test` for `lit` tests
    - `/unittest` for C++ tests
    - `/python/test` for end-to-end tests
  - [ ] This PR does not need a test because `FILL THIS IN`.

- Select one of the following.
  - [ ] I have not added any `lit` tests.
  - [x] The `lit` tests I have added follow these [best practices](https://mlir.llvm.org/getting_started/TestingGuide/#filecheck-best-practices),
    including the "tests should be minimal" section. (Usually running Python code
    and using the instructions it generates is not minimal.)