### PR TITLE
[Membar] Key subslice offset comparison on the value they came from

### DIFF
--- a/include/triton/Analysis/Membar.h
+++ b/include/triton/Analysis/Membar.h
@@ -91,15 +91,16 @@ private:
             bufferId,
             accessTy.getAsOpaquePointer(),
             subsliceOffsets,
-            subsliceSrc.getAsOpaquePointer(),
+            subsliceSrcTy.getAsOpaquePointer(),
             bufferIndexExpr};
   }
   // Offsets from subslice. Empty when offsets are unknown
   SmallVector<int64_t> subsliceOffsets;
-  // The value the subslice was taken from. Offsets are logical coordinates in
-  // that value's shape, so they are only comparable between slices that share
-  // it. Null when there are no offsets.
-  Value subsliceSrc;
+  // Type of the value the subslice was taken from. Offsets are logical
+  // coordinates in that type's shape and element type, so they are only
+  // comparable between slices whose sources agree on it. Null when there are
+  // no offsets.
+  triton::gpu::MemDescType subsliceSrcTy;
   // The allocated interval for this buffer
   Interval<size_t> allocationInterval;
   // Type of the memory descriptor for this access

--- a/include/triton/Analysis/Membar.h
+++ b/include/triton/Analysis/Membar.h
@@ -85,13 +85,21 @@ public:
 
 private:
   std::tuple<Interval<size_t>, Allocation::BufferId, const void *,
-             llvm::ArrayRef<int64_t>, const BufferIndexExpr *>
+             llvm::ArrayRef<int64_t>, const void *, const BufferIndexExpr *>
   asTuple() const {
-    return {allocationInterval, bufferId, accessTy.getAsOpaquePointer(),
-            subsliceOffsets, bufferIndexExpr};
+    return {allocationInterval,
+            bufferId,
+            accessTy.getAsOpaquePointer(),
+            subsliceOffsets,
+            subsliceSrc.getAsOpaquePointer(),
+            bufferIndexExpr};
   }
   // Offsets from subslice. Empty when offsets are unknown
   SmallVector<int64_t> subsliceOffsets;
+  // The value the subslice was taken from. Offsets are logical coordinates in
+  // that value's shape, so they are only comparable between slices that share
+  // it. Null when there are no offsets.
+  Value subsliceSrc;
   // The allocated interval for this buffer
   Interval<size_t> allocationInterval;
   // Type of the memory descriptor for this access

--- a/lib/Analysis/Membar.cpp
+++ b/lib/Analysis/Membar.cpp
@@ -49,6 +49,18 @@ bool AllocationSlice::intersects(const AllocationSlice &other) const {
   if (subsliceOffsets.empty() || other.subsliceOffsets.empty())
     return true;
 
+  // The offsets below are logical coordinates in the shape the subslice was
+  // taken from, so they are only comparable when both slices index the same
+  // allocation under the same shape. Two things break that: a
+  // `memdesc_reinterpret` changes the shape, and hence how many bytes a row
+  // spans, before the subslice is taken; and two distinct allocations can cover
+  // the same bytes, because the allocator reuses memory across disjoint
+  // lifetimes. In either case equal row indices denote different bytes, and
+  // different row indices can denote the same bytes.
+  if (bufferId != other.bufferId || bufferId == Allocation::InvalidBufferId ||
+      accessTy.getAllocShape() != other.accessTy.getAllocShape())
+    return true;
+
   // If layouts differ, we assume intersection as we currently only work on
   // logical elements
   if (accessTy.getEncoding() != other.accessTy.getEncoding())

--- a/lib/Analysis/Membar.cpp
+++ b/lib/Analysis/Membar.cpp
@@ -26,7 +26,7 @@ AllocationSlice::AllocationSlice(Value value,
     // and when a subslice is carried in a loop
     if (accessTy.getAllocShape() == subslice.getSrc().getType().getShape()) {
       subsliceOffsets = SmallVector<int64_t>(subslice.getOffsets());
-      subsliceSrc = subslice.getSrc();
+      subsliceSrcTy = subslice.getSrc().getType();
     }
   }
 }
@@ -50,12 +50,15 @@ bool AllocationSlice::intersects(const AllocationSlice &other) const {
   if (subsliceOffsets.empty() || other.subsliceOffsets.empty())
     return true;
 
-  // The offsets below are logical coordinates in the shape of the value the
-  // subslice was taken from, so they only mean the same thing when both slices
-  // were taken from the same value. A `memdesc_reinterpret` in between changes
-  // the shape or the element type, and hence how many bytes a row spans, so the
-  // same row index denotes different bytes on either side.
-  if (subsliceSrc != other.subsliceSrc)
+  // The offsets below are logical coordinates in the shape and element type of
+  // the value the subslice was taken from, so they only denote the same bytes
+  // when both sources agree on both, within the same buffer. A
+  // `memdesc_reinterpret` in between changes how many bytes a row spans, so the
+  // same row index means something else on either side. Comparing the source
+  // types rather than the source values keeps the disjointness proof for two
+  // separate but identical views of one buffer.
+  if (bufferId != other.bufferId || bufferId == Allocation::InvalidBufferId ||
+      subsliceSrcTy != other.subsliceSrcTy)
     return true;
 
   // If layouts differ, we assume intersection as we currently only work on

--- a/lib/Analysis/Membar.cpp
+++ b/lib/Analysis/Membar.cpp
@@ -26,6 +26,7 @@ AllocationSlice::AllocationSlice(Value value,
     // and when a subslice is carried in a loop
     if (accessTy.getAllocShape() == subslice.getSrc().getType().getShape()) {
       subsliceOffsets = SmallVector<int64_t>(subslice.getOffsets());
+      subsliceSrc = subslice.getSrc();
     }
   }
 }
@@ -49,16 +50,12 @@ bool AllocationSlice::intersects(const AllocationSlice &other) const {
   if (subsliceOffsets.empty() || other.subsliceOffsets.empty())
     return true;
 
-  // The offsets below are logical coordinates in the shape the subslice was
-  // taken from, so they are only comparable when both slices index the same
-  // allocation under the same shape. Two things break that: a
-  // `memdesc_reinterpret` changes the shape, and hence how many bytes a row
-  // spans, before the subslice is taken; and two distinct allocations can cover
-  // the same bytes, because the allocator reuses memory across disjoint
-  // lifetimes. In either case equal row indices denote different bytes, and
-  // different row indices can denote the same bytes.
-  if (bufferId != other.bufferId || bufferId == Allocation::InvalidBufferId ||
-      accessTy.getAllocShape() != other.accessTy.getAllocShape())
+  // The offsets below are logical coordinates in the shape of the value the
+  // subslice was taken from, so they only mean the same thing when both slices
+  // were taken from the same value. A `memdesc_reinterpret` in between changes
+  // the shape or the element type, and hence how many bytes a row spans, so the
+  // same row index denotes different bytes on either side.
+  if (subsliceSrc != other.subsliceSrc)
     return true;
 
   // If layouts differ, we assume intersection as we currently only work on

--- a/test/Analysis/test-membar.mlir
+++ b/test/Analysis/test-membar.mlir
@@ -1941,3 +1941,26 @@ tt.func public @subslice_offsets_after_reinterpret_element_type(%data: tensor<16
   %read = ttg.local_load %same : !ttg.memdesc<16x16xf16, #shared, #smem, mutable, 32x16> -> tensor<16x16xf16>
   tt.return
 }
+
+// -----
+
+#shared = #ttg.swizzled_shared<{vec = 1, perPhase = 1, maxPhase = 1, order = [1, 0]}>
+#smem = #ttg.shared_memory
+
+// Two separate but identical views of one buffer still describe the same
+// coordinates, so disjoint rows taken through them stay provably disjoint.
+// CHECK-LABEL: @subslice_offsets_through_identical_views
+tt.func public @subslice_offsets_through_identical_views(%data: tensor<16x16xf16>) {
+  // CHECK: ttg.local_alloc
+  %alloc = ttg.local_alloc : () -> !ttg.memdesc<32x16xf16, #shared, #smem, mutable>
+  %v0 = ttg.memdesc_reinterpret %alloc : !ttg.memdesc<32x16xf16, #shared, #smem, mutable> -> !ttg.memdesc<32x16xf16, #shared, #smem, mutable>
+  %lo = ttg.memdesc_subslice %v0[0, 0] : !ttg.memdesc<32x16xf16, #shared, #smem, mutable> -> !ttg.memdesc<16x16xf16, #shared, #smem, mutable, 32x16>
+  // CHECK: ttg.local_store
+  ttg.local_store %data, %lo : tensor<16x16xf16> -> !ttg.memdesc<16x16xf16, #shared, #smem, mutable, 32x16>
+  %v1 = ttg.memdesc_reinterpret %alloc : !ttg.memdesc<32x16xf16, #shared, #smem, mutable> -> !ttg.memdesc<32x16xf16, #shared, #smem, mutable>
+  %hi = ttg.memdesc_subslice %v1[16, 0] : !ttg.memdesc<32x16xf16, #shared, #smem, mutable> -> !ttg.memdesc<16x16xf16, #shared, #smem, mutable, 32x16>
+  // CHECK-NOT: ttg.barrier local
+  // CHECK: ttg.local_load
+  %read = ttg.local_load %hi : !ttg.memdesc<16x16xf16, #shared, #smem, mutable, 32x16> -> tensor<16x16xf16>
+  tt.return
+}

--- a/test/Analysis/test-membar.mlir
+++ b/test/Analysis/test-membar.mlir
@@ -1873,3 +1873,48 @@ tt.func @must_barrier_nonzero_wrap_arm(%cst: tensor<128x128xf16>, %phase: i32) {
 }
 
 }
+
+// -----
+
+#shared = #ttg.swizzled_shared<{vec = 1, perPhase = 1, maxPhase = 1, order = [1, 0]}>
+#smem = #ttg.shared_memory
+
+// A `memdesc_reinterpret` between the allocation and the subslice changes the
+// shape the offsets are measured in: row 16 of a 32x16 buffer and row 8 of the
+// same buffer viewed as 16x32 are the same 512 bytes. The offsets must not be
+// compared across the two shapes.
+// CHECK-LABEL: @subslice_offsets_after_reinterpret
+tt.func public @subslice_offsets_after_reinterpret(%data: tensor<16x16xf16>) {
+  // CHECK: ttg.local_alloc
+  %alloc = ttg.local_alloc : () -> !ttg.memdesc<32x16xf16, #shared, #smem, mutable>
+  %lo = ttg.memdesc_subslice %alloc[16, 0] : !ttg.memdesc<32x16xf16, #shared, #smem, mutable> -> !ttg.memdesc<16x16xf16, #shared, #smem, mutable, 32x16>
+  // CHECK: ttg.local_store
+  ttg.local_store %data, %lo : tensor<16x16xf16> -> !ttg.memdesc<16x16xf16, #shared, #smem, mutable, 32x16>
+  %view = ttg.memdesc_reinterpret %alloc : !ttg.memdesc<32x16xf16, #shared, #smem, mutable> -> !ttg.memdesc<16x32xf16, #shared, #smem, mutable>
+  %same = ttg.memdesc_subslice %view[8, 0] : !ttg.memdesc<16x32xf16, #shared, #smem, mutable> -> !ttg.memdesc<8x32xf16, #shared, #smem, mutable, 16x32>
+  // CHECK: ttg.barrier local
+  // CHECK-NEXT: ttg.local_load
+  %read = ttg.local_load %same : !ttg.memdesc<8x32xf16, #shared, #smem, mutable, 16x32> -> tensor<8x32xf16>
+  tt.return
+}
+
+// -----
+
+#shared = #ttg.swizzled_shared<{vec = 1, perPhase = 1, maxPhase = 1, order = [1, 0]}>
+#smem = #ttg.shared_memory
+
+// Same allocation and same shape: the offsets are comparable, and genuinely
+// disjoint rows still need no barrier.
+// CHECK-LABEL: @subslice_offsets_same_shape_stay_disjoint
+tt.func public @subslice_offsets_same_shape_stay_disjoint(%data: tensor<16x16xf16>) {
+  // CHECK: ttg.local_alloc
+  %alloc = ttg.local_alloc : () -> !ttg.memdesc<32x16xf16, #shared, #smem, mutable>
+  %lo = ttg.memdesc_subslice %alloc[16, 0] : !ttg.memdesc<32x16xf16, #shared, #smem, mutable> -> !ttg.memdesc<16x16xf16, #shared, #smem, mutable, 32x16>
+  // CHECK: ttg.local_store
+  ttg.local_store %data, %lo : tensor<16x16xf16> -> !ttg.memdesc<16x16xf16, #shared, #smem, mutable, 32x16>
+  %hi = ttg.memdesc_subslice %alloc[0, 0] : !ttg.memdesc<32x16xf16, #shared, #smem, mutable> -> !ttg.memdesc<16x16xf16, #shared, #smem, mutable, 32x16>
+  // CHECK-NOT: ttg.barrier local
+  // CHECK: ttg.local_load
+  %read = ttg.local_load %hi : !ttg.memdesc<16x16xf16, #shared, #smem, mutable, 32x16> -> tensor<16x16xf16>
+  tt.return
+}

--- a/test/Analysis/test-membar.mlir
+++ b/test/Analysis/test-membar.mlir
@@ -1879,10 +1879,9 @@ tt.func @must_barrier_nonzero_wrap_arm(%cst: tensor<128x128xf16>, %phase: i32) {
 #shared = #ttg.swizzled_shared<{vec = 1, perPhase = 1, maxPhase = 1, order = [1, 0]}>
 #smem = #ttg.shared_memory
 
-// A `memdesc_reinterpret` between the allocation and the subslice changes the
-// shape the offsets are measured in: row 16 of a 32x16 buffer and row 8 of the
-// same buffer viewed as 16x32 are the same 512 bytes. The offsets must not be
-// compared across the two shapes.
+// A `memdesc_reinterpret` between the allocation and the subslice changes what
+// the offsets mean: row 16 of a 32x16 buffer and row 8 of the same buffer
+// viewed as 16x32 are the same 512 bytes.
 // CHECK-LABEL: @subslice_offsets_after_reinterpret
 tt.func public @subslice_offsets_after_reinterpret(%data: tensor<16x16xf16>) {
   // CHECK: ttg.local_alloc
@@ -1916,5 +1915,29 @@ tt.func public @subslice_offsets_same_shape_stay_disjoint(%data: tensor<16x16xf1
   // CHECK-NOT: ttg.barrier local
   // CHECK: ttg.local_load
   %read = ttg.local_load %hi : !ttg.memdesc<16x16xf16, #shared, #smem, mutable, 32x16> -> tensor<16x16xf16>
+  tt.return
+}
+
+// -----
+
+#shared = #ttg.swizzled_shared<{vec = 1, perPhase = 1, maxPhase = 1, order = [1, 0]}>
+#smem = #ttg.shared_memory
+
+// The reinterpret changes only the element type here, so the shapes match on
+// both sides and only the source of the subslice tells them apart: rows 0..15
+// of 32x16xf32 and rows 16..31 of the same buffer as 32x16xf16 both end at byte
+// 1024.
+// CHECK-LABEL: @subslice_offsets_after_reinterpret_element_type
+tt.func public @subslice_offsets_after_reinterpret_element_type(%data: tensor<16x16xf32>) {
+  // CHECK: ttg.local_alloc
+  %alloc = ttg.local_alloc : () -> !ttg.memdesc<32x16xf32, #shared, #smem, mutable>
+  %lo = ttg.memdesc_subslice %alloc[0, 0] : !ttg.memdesc<32x16xf32, #shared, #smem, mutable> -> !ttg.memdesc<16x16xf32, #shared, #smem, mutable, 32x16>
+  // CHECK: ttg.local_store
+  ttg.local_store %data, %lo : tensor<16x16xf32> -> !ttg.memdesc<16x16xf32, #shared, #smem, mutable, 32x16>
+  %view = ttg.memdesc_reinterpret %alloc : !ttg.memdesc<32x16xf32, #shared, #smem, mutable> -> !ttg.memdesc<32x16xf16, #shared, #smem, mutable>
+  %same = ttg.memdesc_subslice %view[16, 0] : !ttg.memdesc<32x16xf16, #shared, #smem, mutable> -> !ttg.memdesc<16x16xf16, #shared, #smem, mutable, 32x16>
+  // CHECK: ttg.barrier local
+  // CHECK-NEXT: ttg.local_load
+  %read = ttg.local_load %same : !ttg.memdesc<16x16xf16, #shared, #smem, mutable, 32x16> -> tensor<16x16xf16>
   tt.return
 }


### PR DESCRIPTION
Note up front: @peterbell10's #9241 "[MemBar] Improve slice analysis" rewrites this same function and has been open since June. This change is deliberately the small soundness fix for `main` as it stands today, not a competing rewrite. #9241 predates `bufferId` and `BufferIndexExpr`, so it needs a rebase either way, and the predicate below survives that rebase: it is the same "are these two slices in the same frame" question, answered by identity of the value the subslice came from.

## The bug

`AllocationSlice::subsliceOffsets` holds the offsets of a `memdesc_subslice`, recorded in the shape of the value the subslice was taken from (`Membar.cpp:23-30`). `intersects` then compares the offsets of two slices directly (`Membar.cpp:62-71`) without checking that the two were recorded against the same value. A `memdesc_reinterpret` in between changes how many bytes a row spans, so equal row indices stop denoting equal bytes.

Two variants, both of which produce no `ttg.barrier local` on `main`:

```mlir
// shape changes: rows 16..31 of 32x16xf16 and rows 8..15 of the same buffer as
// 16x32xf16 are both bytes [512, 1024)
%alloc = ttg.local_alloc : () -> !ttg.memdesc<32x16xf16, #shared, #smem, mutable>
%lo    = ttg.memdesc_subslice %alloc[16, 0] : ... -> !ttg.memdesc<16x16xf16, ..., 32x16>
ttg.local_store %data, %lo
%view  = ttg.memdesc_reinterpret %alloc : ... -> !ttg.memdesc<16x32xf16, #shared, #smem, mutable>
%same  = ttg.memdesc_subslice %view[8, 0] : ... -> !ttg.memdesc<8x32xf16, ..., 16x32>
%read  = ttg.local_load %same
```

```mlir
// only the element type changes, so the shapes still match: rows 0..15 of
// 32x16xf32 and rows 16..31 of the same buffer as 32x16xf16 both end at byte 1024
%alloc = ttg.local_alloc : () -> !ttg.memdesc<32x16xf32, #shared, #smem, mutable>
%lo    = ttg.memdesc_subslice %alloc[0, 0] : ... -> !ttg.memdesc<16x16xf32, ..., 32x16>
ttg.local_store %data, %lo
%view  = ttg.memdesc_reinterpret %alloc : ... -> !ttg.memdesc<32x16xf16, #shared, #smem, mutable>
%same  = ttg.memdesc_subslice %view[16, 0] : ... -> !ttg.memdesc<16x16xf16, ..., 32x16>
%read  = ttg.local_load %same
```

Both are reachable from Gluon, which exposes `reinterpret` and `slice` on a shared memory descriptor (`_core.py:446` and `:507`):

```python
buf = ttgl.allocate_shared_memory(ttgl.float16, [32, 16], SH)
buf.slice(16, 16, dim=0).store(value)
same = buf.reinterpret(shape=[16, 32]).slice(8, 8, dim=0)
v = same.load(layout=BL)
```

## The fix

Record the *type* of the value the subslice was taken from, and only compare offsets when both slices agree on it, within the same buffer. That type carries the shape and the element type, which together decide how many bytes a row spans, so it is the frame the offsets are expressed in.

Comparing types rather than values matters: two separate `memdesc_reinterpret` results describing the same view are different values, and requiring the same value would give up the disjointness proof for subslices taken through them. There is a lit test for that case as well.

## What it costs

Nothing measurable. Compiling `test_warp_specialization.py` and `test_pipeliner.py` on an H100, fresh cache per build, 107 kernels and 181 passed / 1433 skipped either way: **2203 `bar.sync` on `main`, 2203 with this patch**. `test/Analysis`, `test/TritonGPU`, `test/Conversion`, `test/TritonNvidiaGPU` and `test/NVWS` have the same set of failures before and after. The two new lit tests fail on `main` and pass with the change.

## Honest scope

This is a latent race, not an observed miscompile. I could not make it corrupt data: 2000 launches of the Gluon kernel above on an H100 give the right answer on `main`, because in a kernel that small the warps stay close enough together that the store lands first. The concurrency sanitizer does not cover it either, by design, since it models partitions and CTAs rather than warps within one partition.

What makes the barrier necessary is the analysis being inconsistent with itself: for the identical program with the `memdesc_reinterpret` removed, membar emits the barrier. Nothing orders two warps of a CTA except `bar.sync`, and the current code drops it based on a comparison that is not meaningful across the reinterpret.

# New contributor declaration
- [x] I am not making a trivial change, such as fixing a typo in a comment.

- [x] I have written a PR description following these
  [rules](https://cbea.ms/git-commit/#why-not-how).

- [x] I have run `pre-commit run --from-ref origin/main --to-ref HEAD`.

- Select one of the following.
  - [x] I have added tests.
    - `/test` for `lit` tests
    - `/unittest` for C++ tests
    - `/python/test` for end-to-end tests
  - [ ] This PR does not need a test because `FILL THIS IN`.

- Select one of the following.
  - [ ] I have not added any `lit` tests.
  - [x] The `lit` tests I have added follow these [best practices](https://mlir.llvm.org/getting_started/TestingGuide/#filecheck-best-practices),
    including the "tests should be minimal" section. (Usually running Python code
    and using the instructions it generates is not minimal.)