### PR TITLE
[OptimizeThreadLocality] Fix crash on multi-operand reduce & cleanup

### DIFF
--- a/lib/Dialect/TritonGPU/Transforms/OptimizeThreadLocality.cpp
+++ b/lib/Dialect/TritonGPU/Transforms/OptimizeThreadLocality.cpp
@@ -258,11 +258,11 @@ class TritonGPUOptimizeThreadLocalityPass
       auto srcType = cast<RankedTensorType>(reduce.getOperands()[0].getType());
       auto rank = srcType.getShape().size();
       auto srcEncoding = srcType.getEncoding();
-      auto reductionOp = getReductionOp(reduce);
+      Operation *reductionOp = reduce.getSingleCombiner();
       if (!reductionOp ||
           !isa<arith::AddFOp, arith::MulFOp, arith::MaximumFOp,
                arith::MaxNumFOp, arith::MinimumFOp, arith::MinNumFOp>(
-              reductionOp.value()))
+              reductionOp))
         return;
       // TODO: relax this restriction
       if (!(isa<triton::gpu::BlockedEncodingAttr>(srcEncoding) && rank > 1))
@@ -271,10 +271,8 @@ class TritonGPUOptimizeThreadLocalityPass
       // inner dim.
       if (reduce.getAxis() != rank - 1)
         return;
-      for (auto operand : reduce->getOperands()) {
-        if (!operand.getDefiningOp<triton::LoadOp>())
-          return;
-      }
+      if (!reduce.getOperands()[0].getDefiningOp<triton::LoadOp>())
+        return;
       auto elemsPerThread =
           triton::gpu::getElemsPerThread(srcType)[reduce.getAxis()];
       // Not worth applying this optimization if there is only one element per
@@ -378,23 +376,6 @@ class TritonGPUOptimizeThreadLocalityPass
   };
 
 private:
-  std::optional<Operation *> getReductionOp(triton::ReduceOp reduce) const {
-    auto numRegions = reduce->getNumRegions();
-    if (numRegions != 1)
-      return std::nullopt;
-    Region &region = reduce->getRegion(0);
-    auto numBlocks = region.getBlocks().size();
-    if (numBlocks != 1)
-      return std::nullopt;
-    Block &block = region.front();
-    auto blockWithoutTerminator = block.without_terminator();
-    auto blockSizeWithoutTerminator = std::distance(
-        blockWithoutTerminator.begin(), blockWithoutTerminator.end());
-    if (blockSizeWithoutTerminator != 1)
-      return std::nullopt;
-    Operation *op = &block.front();
-    return std::optional<Operation *>(op);
-  }
   Operation *incorporateOriginalAccumulatorValue(OpBuilder &builder,
                                                  Operation *oldUpdate,
                                                  Operation *cvtLayout,
@@ -421,7 +402,7 @@ private:
     auto newLoopResult = loop.getResult(resultIndex);
     builder.setInsertionPointAfter(loop);
     IRMapping mapping;
-    mapping.map(*(reduce.getOperands().begin()), newLoopResult);
+    mapping.map(reduce.getOperands()[0], newLoopResult);
     auto newReduce2 = cloneWithInferType(builder, &(*reduce), mapping);
     return newReduce2;
   }
@@ -474,22 +455,21 @@ private:
     std::swap(transposeOrder[rank - 1], transposeOrder[rank]);
 
     builder.setInsertionPointAfter(reduce);
+    Value operand = reduce.getOperands()[0];
+    auto factored = triton::ReshapeOp::create(builder, reduce.getLoc(),
+                                              factorShape, operand);
+    auto transposed = triton::TransOp::create(builder, reduce.getLoc(),
+                                              factored, transposeOrder);
+    auto viewOp = triton::ReshapeOp::create(builder, reduce.getLoc(), dstShape,
+                                            transposed);
+    viewOp.setEfficientLayout(true);
+    auto converted =
+        ConvertLayoutOp::create(builder, reduce.getLoc(), dstType, viewOp);
+    assert(cvtReordersRegisters(viewOp.getType(), converted.getType()) &&
+           "thread locality optimization requires a register-only layout "
+           "conversion");
     IRMapping mapping;
-    for (auto operand : reduce.getOperands()) {
-      auto factored = triton::ReshapeOp::create(builder, reduce.getLoc(),
-                                                factorShape, operand);
-      auto transposed = triton::TransOp::create(builder, reduce.getLoc(),
-                                                factored, transposeOrder);
-      auto viewOp = triton::ReshapeOp::create(builder, reduce.getLoc(),
-                                              dstShape, transposed);
-      viewOp.setEfficientLayout(true);
-      auto converted =
-          ConvertLayoutOp::create(builder, reduce.getLoc(), dstType, viewOp);
-      assert(cvtReordersRegisters(viewOp.getType(), converted.getType()) &&
-             "thread locality optimization requires a register-only layout "
-             "conversion");
-      mapping.map(operand, converted);
-    }
+    mapping.map(operand, converted);
 
     auto newReduce = cloneWithInferType(builder, &(*reduce), mapping);
     newReduce->setAttr("axis", builder.getI32IntegerAttr(rank));
@@ -500,10 +480,8 @@ private:
           newReduce->getContext(), newReduce->getLoc(),
           newReduce->getOperands(), newReduce->getAttrDictionary(),
           newReduce->getPropertiesStorage(), newReduce->getRegions(), newTypes);
-      if (succeeded(success)) {
-        for (size_t i = 0; i < newTypes.size(); i++)
-          newReduce->getResult(i).setType(newTypes[i]);
-      }
+      if (succeeded(success))
+        newReduce->getResult(0).setType(newTypes[0]);
     }
     return newReduce;
   }
@@ -542,9 +520,9 @@ private:
     auto accumType = RankedTensorType::get(accumShape, elemType, slice2d);
     // Create new accumulator
     builder.setInsertionPointAfter(oldAccum.getDefiningOp());
-    auto reductionOp = getReductionOp(reduce);
+    Operation *reductionOp = reduce.getSingleCombiner();
     assert(reductionOp && "Processing a reduce that is not supported!");
-    auto neutralVal = getNeutralElement(reductionOp.value());
+    auto neutralVal = getNeutralElement(reductionOp);
     assert(neutralVal && "Could not find neutral value for reduction op!");
     auto denseAttr = DenseElementsAttr::get(accumType, neutralVal.value());
     auto newAccum = arith::ConstantOp::create(builder, oldAccum.getLoc(),

--- a/test/TritonGPU/optimize-locality.mlir
+++ b/test/TritonGPU/optimize-locality.mlir
@@ -199,6 +199,63 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 1 : i32, "ttg.thr
 
 // -----
 
+// A multi-operand reduce must be left untouched
+// CHECK-LABEL: @two_operand_reduce
+// CHECK-NOT: tt.reshape
+// CHECK: "tt.reduce"({{.*}}, {{.*}}) <{axis = 1 : i32}>
+#blocked = #ttg.blocked<{sizePerThread = [1, 2], threadsPerWarp = [32, 1], warpsPerCTA = [1, 1], order = [1, 0]}>
+#slice = #ttg.slice<{dim = 1, parent = #blocked}>
+module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 1 : i32, "ttg.threads-per-warp" = 32 : i32} {
+  tt.func public @two_operand_reduce(%values: tensor<32x2x!tt.ptr<f32>, #blocked>, %tags: tensor<32x2x!tt.ptr<f32>, #blocked>, %output: tensor<32x!tt.ptr<f32>, #slice>, %count: i32) {
+    %zero = arith.constant dense<0.000000e+00> : tensor<32xf32, #slice>
+    %start = arith.constant 0 : i32
+    %step = arith.constant 1 : i32
+    %result = scf.for %index = %start to %count step %step iter_args(%accumulator = %zero) -> (tensor<32xf32, #slice>) : i32 {
+      %v = tt.load %values : tensor<32x2x!tt.ptr<f32>, #blocked>
+      %t = tt.load %tags : tensor<32x2x!tt.ptr<f32>, #blocked>
+      %reduced:2 = "tt.reduce"(%v, %t) <{axis = 1 : i32}> ({
+      ^bb0(%a0: f32, %a1: f32, %b0: f32, %b1: f32):
+        %sum = arith.addf %a0, %b0 : f32
+        tt.reduce.return %sum, %a1 : f32, f32
+      }) : (tensor<32x2xf32, #blocked>, tensor<32x2xf32, #blocked>) -> (tensor<32xf32, #slice>, tensor<32xf32, #slice>)
+      %updated = arith.addf %accumulator, %reduced#0 : tensor<32xf32, #slice>
+      scf.yield %updated : tensor<32xf32, #slice>
+    }
+    tt.store %output, %result : tensor<32x!tt.ptr<f32>, #slice>
+    tt.return
+  }
+}
+
+// -----
+
+// A degenerate combiner that could change the result if the optimization is applied
+// CHECK-LABEL: @self_add_combiner
+// CHECK-NOT: tt.reshape
+// CHECK: "tt.reduce"({{.*}}) <{axis = 1 : i32}>
+#blocked = #ttg.blocked<{sizePerThread = [1, 2], threadsPerWarp = [32, 1], warpsPerCTA = [1, 1], order = [1, 0]}>
+#slice = #ttg.slice<{dim = 1, parent = #blocked}>
+module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 1 : i32, "ttg.threads-per-warp" = 32 : i32} {
+  tt.func public @self_add_combiner(%values: tensor<32x2x!tt.ptr<f32>, #blocked>, %output: tensor<32x!tt.ptr<f32>, #slice>, %count: i32) {
+    %zero = arith.constant dense<0.000000e+00> : tensor<32xf32, #slice>
+    %start = arith.constant 0 : i32
+    %step = arith.constant 1 : i32
+    %result = scf.for %index = %start to %count step %step iter_args(%accumulator = %zero) -> (tensor<32xf32, #slice>) : i32 {
+      %v = tt.load %values : tensor<32x2x!tt.ptr<f32>, #blocked>
+      %reduced = "tt.reduce"(%v) <{axis = 1 : i32}> ({
+      ^bb0(%a: f32, %b: f32):
+        %sum = arith.addf %a, %a : f32
+        tt.reduce.return %sum : f32
+      }) : (tensor<32x2xf32, #blocked>) -> tensor<32xf32, #slice>
+      %updated = arith.addf %accumulator, %reduced : tensor<32xf32, #slice>
+      scf.yield %updated : tensor<32xf32, #slice>
+    }
+    tt.store %output, %result : tensor<32x!tt.ptr<f32>, #slice>
+    tt.return
+  }
+}
+
+// -----
+
 // CHECK-LABEL: slice_layout
 // CHECK: %[[LOOP_OUTPUT:.*]] = scf.for
 // CHECK: %[[LOAD:.*]] = tt.load


### PR DESCRIPTION
In the reduction path of `OptimizeThreadLocality`, the code that builds the post loop reduction assumes a single operand reduce without any checks. 

I don’t think actually supporting multi-operand reduce make much sense for the current pattern it tries to match. Notably, the `getReductionOp` helper effectively gates against all realistic multi-operand reductions, but degenerate cases like the following can slip through, crashing the compiler:

```python
# getReductionOp checks there's only 1 non-terminator op in the 
# combiner region and returns it. 
# So at most one operand can actually do any reduce.
@triton.jit
def add_and_pass_through(a0, a1, b0, b1):
    return a0 + b0, a1

@triton.jit
def crash(x_ptr, out_ptr):
    ptrs = x_ptr + tl.arange(0, 32)[:, None] * 64 + tl.arange(0, 64)[None, :]
    acc = tl.zeros((32,), dtype=tl.float32)
    for _ in range(2):
        x = tl.load(ptrs)
        s, t = tl.reduce((x, x), 1, add_and_path_through)
        acc += s
    tl.store(out_ptr + tl.arange(0, 32), acc)

# error: 'tt.reduce' op requires the same shape for all operands
#      %reduced:2 = "tt.reduce"(%v, %t) <{axis = 1 : i32}> ({
#                   ^
# note: see current operation:
# %5:2 = "tt.reduce"(%4#1, %10) <{axis = 1 : i32}> ({
# ^bb0(%arg4: f32, %arg5: f32, %arg6: f32, %arg7: f32):
#  %8 = "arith.addf"(%arg4, %arg6) <{fastmath = #arith.fastmath<none>}> : (f32, f32) -> f32
#  "tt.reduce.return"(%8, %arg5) : (f32, f32) -> ()
# }) : (tensor<32x1xf32, #ttg.slice<{dim = 2, parent = #ttg.blocked<{sizePerThread = [1, 1, 2], threadsPerWarp = [32, 1, 1], warpsPerCTA = [1, 1, 1], order = [2, 1, 0]}>}>>, tensor<32x2xf32, #ttg.blocked<{sizePerThread = [1, 2], threadsPerWarp = [32, 1], warpsPerCTA = [1, 1], order = [1, 0]}>>) -> (tensor<32xf32, #ttg.slice<{dim = 1, parent = #ttg.slice<{dim = 2, parent = #ttg.blocked<{sizePerThread = [1, 1, 2], threadsPerWarp = [32, 1, 1], warpsPerCTA = [1, 1, 1], order = [2, 1, 0]}>}>}>>, tensor<32xf32, #ttg.slice<{dim = 1, parent = #ttg.blocked<{sizePerThread = [1, 2], threadsPerWarp = [32, 1], warpsPerCTA = [1, 1], order = [1, 0]}>}>>)
```

I think the best fix is to replace  `getReductionOp` with `ReduceOp::getSingleCombiner()`. They try to do the same thing, but the latter is the more standard way to express the intent “get the combiner op of a reduce if there’s no other op in combiner region than the return” in the backend. An extra benefit is that degenerate custom combiners like `[a, b] {return a + a; }` are now rejected.

Also removed all misleading loops that could otherwise give the impression that multi-operand reduce is supported.

<!---
The core Triton is a small number of people, and we receive many PRs (thank
you!).  To help us review your code more quickly, **if you are a new
contributor (less than 3 PRs merged) we ask that you complete the following
tasks and include the filled-out checklist in your PR description.**

Complete the following tasks before sending your PR, and replace `[ ]` with
`[x]` to indicate you have done them.
-->

# New contributor declaration
- [x] I am not making a trivial change, such as fixing a typo in a comment.

- [x] I have written a PR description following these
  [rules](https://cbea.ms/git-commit/#why-not-how).

- [x] I have run `pre-commit run --from-ref origin/main --to-ref HEAD`.

- Select one of the following.
  - [x] I have added tests.
    - `/test` for `lit` tests
    - `/unittest` for C++ tests
    - `/python/test` for end-to-end tests
  - [ ] This PR does not need a test because `FILL THIS IN`.

- Select one of the following.
  - [ ] I have not added any `lit` tests.
  - [x] The `lit` tests I have added follow these [best practices](https://mlir.llvm.org/getting_started/TestingGuide/#filecheck-best-practices),
    including the "tests should be minimal" section. (Usually running Python code
    and using the instructions it generates is not minimal.)
