### PR TITLE
[BACKEND] Canonicalize redundant full-cluster CTA-rank masks

### DIFF
--- a/lib/Conversion/TritonGPUToLLVM/CMakeLists.txt
+++ b/lib/Conversion/TritonGPUToLLVM/CMakeLists.txt
@@ -35,6 +35,7 @@ add_triton_library(TritonGPUToLLVM
     MLIRGPUToNVVMTransforms
     MLIRGPUToROCDLTransforms
     MLIRGPUTransforms
+    NVGPUIR
     TritonAnalysis
     TritonIR
     TritonGPUIR

--- a/lib/Conversion/TritonGPUToLLVM/CanonicalizeLLVMIR.cpp
+++ b/lib/Conversion/TritonGPUToLLVM/CanonicalizeLLVMIR.cpp
@@ -3,6 +3,9 @@
 #include "mlir/IR/PatternMatch.h"
 #include "mlir/Pass/Pass.h"
 #include "mlir/Transforms/GreedyPatternRewriteDriver.h"
+#include "third_party/nvidia/include/Dialect/NVGPU/IR/Dialect.h"
+#include "triton/Dialect/TritonGPU/IR/Dialect.h"
+#include "llvm/Support/MathExtras.h"
 
 using namespace mlir;
 
@@ -25,6 +28,31 @@ class SelectConstantConditionPattern : public OpRewritePattern<LLVM::SelectOp> {
     return success();
   }
 };
+
+class ElideFullClusterRankMaskPattern : public OpRewritePattern<LLVM::AndOp> {
+  using OpRewritePattern::OpRewritePattern;
+
+  LogicalResult matchAndRewrite(LLVM::AndOp op,
+                                PatternRewriter &rewriter) const override {
+    APInt mask;
+    Value rank = op.getLhs();
+    if (!matchPattern(op.getRhs(), m_ConstantInt(&mask))) {
+      if (!matchPattern(op.getLhs(), m_ConstantInt(&mask)))
+        return failure();
+      rank = op.getRhs();
+    }
+
+    if (!rank.getDefiningOp<triton::nvgpu::ClusterCTAIdOp>())
+      return failure();
+
+    unsigned numCTAs = triton::gpu::lookupNumCTAs(op);
+    if (mask.countr_one() < llvm::Log2_32_Ceil(numCTAs))
+      return failure();
+
+    rewriter.replaceOp(op, rank);
+    return success();
+  }
+};
 } // namespace
 
 namespace {
@@ -34,7 +62,9 @@ struct CanonicalizeLLVMIR
   void runOnOperation() override {
     LLVM::LLVMFuncOp func = getOperation();
     RewritePatternSet patterns(&getContext());
-    patterns.add<SelectConstantConditionPattern>(&getContext());
+    patterns
+        .add<SelectConstantConditionPattern, ElideFullClusterRankMaskPattern>(
+            &getContext());
 
     getContext()
         .getLoadedDialect<LLVM::LLVMDialect>()

--- a/test/Conversion/tritonnvidiagpu_to_llvm.mlir
+++ b/test/Conversion/tritonnvidiagpu_to_llvm.mlir
@@ -2,6 +2,7 @@
 // RUN: triton-opt %s -split-input-file --convert-triton-gpu-to-llvm='compute-capability=90 ptx-version=85' --initialize-ws-cluster-barriers='compute-capability=90 ptx-version=85' -reconcile-unrealized-casts | FileCheck --check-prefix=PTX85 %s
 // RUN: triton-opt %s -split-input-file --convert-triton-gpu-to-llvm='compute-capability=90 ptx-version=86' --initialize-ws-cluster-barriers='compute-capability=90 ptx-version=86' -reconcile-unrealized-casts | FileCheck --check-prefix=PTX86 %s
 // RUN: triton-opt %s -split-input-file --convert-triton-gpu-to-llvm='compute-capability=107 ptx-version=94' --initialize-ws-cluster-barriers='compute-capability=107 ptx-version=94' -reconcile-unrealized-casts | FileCheck --check-prefix=RUBIN %s
+// RUN: triton-opt %s -split-input-file --convert-triton-gpu-to-llvm=compute-capability=90 --initialize-ws-cluster-barriers=compute-capability=90 --canonicalize-llvm-ir -reconcile-unrealized-casts | FileCheck --check-prefix=CLUSTER-MASK %s
 
 #shared0 = #ttg.swizzled_shared<{vec = 1, perPhase = 1, maxPhase = 1, order = [0]}>
 #smem = #ttg.shared_memory
@@ -20,9 +21,13 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32} {
 #smem = #ttg.shared_memory
 module attributes {"ttg.num-ctas" = 2 : i32, "ttg.num-warps" = 4 : i32} {
   // CHECK-LABEL: init_barrier_cluster_broadcast
+  // CLUSTER-MASK-LABEL: init_barrier_cluster_broadcast
   tt.func @init_barrier_cluster_broadcast() {
     %alloc = ttg.local_alloc {allocation.offset = 0 : i32} : () -> !ttg.memdesc<1xi64, #shared0, #smem, mutable>
     // CHECK: nvg.cluster_id
+    // CLUSTER-MASK: [[CTA:%.*]] = nvg.cluster_id
+    // CLUSTER-MASK-NOT: llvm.and [[CTA]], {{.*}} : i32
+    // CLUSTER-MASK: llvm.icmp "eq" [[CTA]], {{.*}} : i32
     // CHECK: @$0 mbarrier.init.shared::cta.b64 [$1], 2;
     ttng.init_barrier %alloc, 1 : !ttg.memdesc<1xi64, #shared0, #smem, mutable>
     ttng.inval_barrier %alloc : !ttg.memdesc<1xi64, #shared0, #smem, mutable>


### PR DESCRIPTION
Remove redundant CTA masks. LLVM and ptxas do not seem to be able to
remove these, which is surprising.

We do so by adding a pass that runs on the LLVM we generate.