### PR TITLE
Add descriptor-load reduction regression reproducer

### DIFF
--- a/python/test/microbenchmark/tma_descriptor_load_reduce/README.md
+++ b/python/test/microbenchmark/tma_descriptor_load_reduce/README.md
@@ -1,0 +1,88 @@
+# Descriptor-load partial-reduction microbenchmark
+
+This standalone microbenchmark measures a descriptor/TMA load immediately followed by a partial max reduction:
+
+```text
+[1, BLOCK_M, BLOCK_N] descriptor load
+    -> convert to fp32
+    -> tl.max(axis=1)
+    -> BLOCK_N fp32 results
+```
+
+It compares the same kernel under the Triton 3.5.1 and 3.6.0 PyPI packages. The motivating cases use a small reduction axis, BF16 or FP16 inputs, and four warps. This is a performance reproducer and evidence-gathering tool, not a regression test with a timing threshold.
+
+## Run
+
+The runner reinstalls each requested Triton wheel in the selected Python environment. Use a disposable environment rather than a development environment whose Triton installation must be preserved.
+
+Minimal affected case:
+
+```bash
+cd python/test/microbenchmark/tma_descriptor_load_reduce
+GPU_LABEL=h100_sxm \
+VERSIONS="3.5.1 3.6.0" \
+SHAPES="32x128" \
+DTYPES="bf16" \
+WARPS="4" \
+REPEAT=5 \
+WARMUP=5 \
+bash run_triton_versions.sh
+```
+
+Full comparison grid:
+
+```bash
+GPU_LABEL=h100_sxm \
+VERSIONS="3.5.1 3.6.0" \
+SHAPES="16x128,32x128,64x128,32x64,32x256" \
+DTYPES="bf16,fp16,fp32" \
+WARPS="4" \
+M=8192 \
+N=8192 \
+REPEAT=5 \
+WARMUP=5 \
+bash run_triton_versions.sh
+```
+
+The script performs sampled exact correctness checks before timing and emits one JSON object per line under `results/`. A complete full-grid run contains an environment record followed by 15 records with `status="ok"` for each Triton version.
+
+Tensor descriptors use TMA on supported NVIDIA GPUs. An A100 run is useful as a negative architecture control, but the descriptor kernel may be rejected or lower through a different path because Ampere does not have Hopper TMA.
+
+## Reproducible environment
+
+The measurements below used:
+
+- PyTorch 2.8.0+cu128;
+- matrix size `M=N=8192`;
+- five shapes, three dtypes, and `num_warps=4`;
+- five warmup launches;
+- three timed samples per RTX 5090 case and five per H100/B300 case.
+
+For B300, the public image `northcapitalca/triton-b300-cuda13:0.2` supplies CUDA/PTXAS 13.3 and sets `TRITON_PTXAS_PATH` so Triton 3.5.1 can assemble `sm_103a`. The benchmark is already available at `/workspace/triton_tma_reduction_bench` in that image.
+
+## Initial results
+
+Each cell is `3.5.1 median -> 3.6.0 median (3.6.0 / 3.5.1)`. All displayed cases passed `--check` and have `status="ok"`.
+
+| Case | RTX 5090 | H100 SXM | B300 SXM6 AC |
+|---|---:|---:|---:|
+| 16x128 BF16 | 0.084439 -> 0.093082 ms (1.10x) | 0.050487 -> 0.167688 ms (3.32x) | 0.024827 -> 0.147604 ms (5.95x) |
+| 32x128 BF16 | 0.083704 -> 0.084772 ms (1.01x) | 0.048684 -> 0.088257 ms (1.81x) | 0.022414 -> 0.077734 ms (3.47x) |
+| 64x128 BF16 | 0.083125 -> 0.084059 ms (1.01x) | 0.048195 -> 0.052110 ms (1.08x) | 0.022045 -> 0.042958 ms (1.95x) |
+| 32x128 FP32 | 0.164173 -> 0.164387 ms (1.00x) | 0.093879 -> 0.096339 ms (1.03x) | 0.041646 -> 0.051404 ms (1.23x) |
+
+The regression is therefore not B300-only: it is large on H100 and B300 for short BF16/FP16 reductions, while this RTX 5090 grid is mostly flat. Increasing `BLOCK_M` reduces the slowdown, and FP32 is affected much less.
+
+Timings alone do not prove a compiler root cause. In particular, the results do not yet establish that Triton 3.6.0 selected a layout that changed a thread-local reduction into a cross-thread or cross-warp reduction.
+
+## Planned compiler analysis
+
+For the affected `32x128 BF16` case and the `64x128 BF16` and `32x128 FP32` controls, the next step is to compare Triton 3.5.1 and 3.6.0 at each relevant stage:
+
+- TTIR and TritonGPU IR before and after `OptimizeThreadLocality`;
+- selected load and `SliceEncoding` layouts, including `sizePerThread`, `threadsPerWarp`, `warpsPerCTA`, order, and vector width;
+- inserted `convert_layout` operations and whether the reduction is thread-, warp-, or CTA-local;
+- LLVM IR, PTX, cubin/SASS, register count, and shared-memory allocation;
+- shared-memory traffic, barriers, shuffles, barrier stalls, occupancy, and achieved bandwidth.
+
+Additional H200, B200, and A100 measurements can localize the architecture/path boundary, but layout and lowering evidence is required before proposing a compiler or cost-model change.

--- a/python/test/microbenchmark/tma_descriptor_load_reduce/bench_desc_load_reduce.py
+++ b/python/test/microbenchmark/tma_descriptor_load_reduce/bench_desc_load_reduce.py
@@ -1,0 +1,195 @@
+#!/usr/bin/env python3
+import argparse
+import json
+import platform
+import statistics
+import time
+
+import torch
+import triton
+import triton.language as tl
+from triton.tools.tensor_descriptor import TensorDescriptor
+
+
+@triton.jit
+def desc_load_reduce_kernel(
+    x_desc,
+    out_ptr,
+    stride_out_0,
+    stride_out_1,
+    BLOCK_M: tl.constexpr,
+    BLOCK_N: tl.constexpr,
+    NUM_BLOCKS_N: tl.constexpr,
+):
+    pid = tl.program_id(0)
+    pid_m = pid // NUM_BLOCKS_N
+    pid_n = pid % NUM_BLOCKS_N
+
+    off_m = pid_m * BLOCK_M
+    off_n = pid_n * BLOCK_N
+
+    # Descriptor/TMA load -> [1, BLOCK_M, BLOCK_N].
+    x = x_desc.load([0, off_m, off_n])
+    x = x.to(tl.float32)
+
+    # Collapse BLOCK_M rows and leave BLOCK_N partial-reduction results.
+    x_max = tl.max(x, axis=1)
+
+    offs_n = off_n + tl.arange(0, BLOCK_N)
+    out_ptrs = out_ptr + pid_m * stride_out_0 + offs_n * stride_out_1
+    tl.store(out_ptrs, tl.reshape(x_max, [BLOCK_N]))
+
+
+def parse_dtype(name: str):
+    if name == "bf16":
+        return torch.bfloat16
+    if name == "fp16":
+        return torch.float16
+    if name == "fp32":
+        return torch.float32
+    raise ValueError(f"unsupported dtype: {name}")
+
+
+def check_output(x, out, block_m: int, block_n: int):
+    num_blocks_m = x.shape[1] // block_m
+    num_blocks_n = x.shape[2] // block_n
+    tiles = {
+        (0, 0),
+        (num_blocks_m // 2, num_blocks_n // 2),
+        (num_blocks_m - 1, num_blocks_n - 1),
+    }
+    for tile_m, tile_n in tiles:
+        off_m = tile_m * block_m
+        off_n = tile_n * block_n
+        ref = x[0, off_m : off_m + block_m, off_n : off_n + block_n].to(torch.float32).amax(dim=0)
+        actual = out[tile_m, off_n : off_n + block_n]
+        torch.testing.assert_close(actual, ref, rtol=0, atol=0)
+
+
+def bench_case(args, block_m: int, block_n: int, dtype_name: str, num_warps: int):
+    dtype = parse_dtype(dtype_name)
+    m = args.m
+    n = args.n
+
+    if m % block_m != 0 or n % block_n != 0:
+        return {
+            "status": "skipped",
+            "reason": "M/N not divisible by BLOCK_M/BLOCK_N",
+            "M": m,
+            "N": n,
+            "BLOCK_M": block_m,
+            "BLOCK_N": block_n,
+            "dtype": dtype_name,
+            "num_warps": num_warps,
+        }
+
+    torch.manual_seed(args.seed)
+    x = torch.randn(1, m, n, dtype=dtype, device="cuda")
+    out = torch.empty(m // block_m, n, dtype=torch.float32, device="cuda")
+    x_desc = TensorDescriptor(x, list(x.shape), list(x.stride()), [1, block_m, block_n])
+
+    grid = ((m // block_m) * (n // block_n),)
+    num_blocks_n = n // block_n
+
+    def fn():
+        desc_load_reduce_kernel[grid](
+            x_desc,
+            out,
+            out.stride(0),
+            out.stride(1),
+            BLOCK_M=block_m,
+            BLOCK_N=block_n,
+            NUM_BLOCKS_N=num_blocks_n,
+            num_warps=num_warps,
+        )
+
+    for _ in range(args.warmup):
+        fn()
+    torch.cuda.synchronize()
+
+    if args.check:
+        check_output(x, out, block_m, block_n)
+
+    samples = [float(triton.testing.do_bench_cudagraph(fn)) for _ in range(args.repeat)]
+    median_ms = statistics.median(samples)
+    bytes_moved = x.numel() * x.element_size() + out.numel() * out.element_size()
+    bw_gbs = bytes_moved / 1e9 / (median_ms / 1e3)
+
+    return {
+        "status": "ok",
+        "triton": triton.__version__,
+        "torch": torch.__version__,
+        "cuda_runtime": torch.version.cuda,
+        "gpu": torch.cuda.get_device_name(0),
+        "capability": torch.cuda.get_device_capability(0),
+        "python": platform.python_version(),
+        "M": m,
+        "N": n,
+        "BLOCK_M": block_m,
+        "BLOCK_N": block_n,
+        "dtype": dtype_name,
+        "num_warps": num_warps,
+        "warmup": args.warmup,
+        "repeat": args.repeat,
+        "check": args.check,
+        "median_ms": median_ms,
+        "samples_ms": samples,
+        "bw_gbs": bw_gbs,
+    }
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Benchmark descriptor load followed by a partial max reduction")
+    parser.add_argument("--m", type=int, default=8192)
+    parser.add_argument("--n", type=int, default=8192)
+    parser.add_argument("--shapes", default="32x128")
+    parser.add_argument("--dtypes", default="bf16")
+    parser.add_argument("--warps", default="4")
+    parser.add_argument("--warmup", type=int, default=5)
+    parser.add_argument("--repeat", type=int, default=5)
+    parser.add_argument("--seed", type=int, default=0)
+    parser.add_argument("--check", action="store_true")
+    args = parser.parse_args()
+
+    if not torch.cuda.is_available():
+        raise SystemExit("CUDA is not available")
+
+    print(
+        json.dumps(
+            {
+                "event": "env",
+                "triton": triton.__version__,
+                "torch": torch.__version__,
+                "cuda_runtime": torch.version.cuda,
+                "gpu": torch.cuda.get_device_name(0),
+                "capability": torch.cuda.get_device_capability(0),
+                "M": args.m,
+                "N": args.n,
+                "warmup": args.warmup,
+                "repeat": args.repeat,
+                "check": args.check,
+            },
+            sort_keys=True,
+        ),
+        flush=True,
+    )
+
+    shapes = []
+    for item in args.shapes.split(","):
+        block_m, block_n = item.lower().split("x", 1)
+        shapes.append((int(block_m), int(block_n)))
+
+    dtypes = [item.strip() for item in args.dtypes.split(",") if item.strip()]
+    warps = [int(item.strip()) for item in args.warps.split(",") if item.strip()]
+
+    started = time.time()
+    for block_m, block_n in shapes:
+        for dtype_name in dtypes:
+            for num_warps in warps:
+                result = bench_case(args, block_m, block_n, dtype_name, num_warps)
+                result["elapsed_s"] = round(time.time() - started, 3)
+                print(json.dumps(result, sort_keys=True), flush=True)
+
+
+if __name__ == "__main__":
+    main()

--- a/python/test/microbenchmark/tma_descriptor_load_reduce/run_triton_versions.sh
+++ b/python/test/microbenchmark/tma_descriptor_load_reduce/run_triton_versions.sh
@@ -1,0 +1,49 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)"
+
+VERSIONS="${VERSIONS:-3.5.1 3.6.0}"
+SHAPES="${SHAPES:-32x128}"
+DTYPES="${DTYPES:-bf16}"
+WARPS="${WARPS:-4}"
+M="${M:-8192}"
+N="${N:-8192}"
+REPEAT="${REPEAT:-5}"
+WARMUP="${WARMUP:-5}"
+GPU_LABEL="${GPU_LABEL:-gpu}"
+PYTHON_BIN="${PYTHON_BIN:-}"
+RESULTS_DIR="${RESULTS_DIR:-${SCRIPT_DIR}/results}"
+
+if [ -z "${PYTHON_BIN}" ]; then
+  if [ -x /opt/venv/bin/python ]; then
+    PYTHON_BIN=/opt/venv/bin/python
+  else
+    PYTHON_BIN=python3
+  fi
+fi
+
+mkdir -p "${RESULTS_DIR}"
+
+echo "python=${PYTHON_BIN}"
+"${PYTHON_BIN}" - <<'PY'
+import torch
+print("torch", torch.__version__)
+PY
+
+for version in ${VERSIONS}; do
+  "${PYTHON_BIN}" -m pip install -q --disable-pip-version-check --no-cache-dir --no-deps --force-reinstall \
+    "triton==${version}"
+
+  out="${RESULTS_DIR}/${GPU_LABEL}_triton_${version}_$(date -u +%Y%m%dT%H%M%SZ).jsonl"
+  echo "running Triton ${version}; output=${out}"
+  "${PYTHON_BIN}" "${SCRIPT_DIR}/bench_desc_load_reduce.py" \
+    --m "${M}" \
+    --n "${N}" \
+    --shapes "${SHAPES}" \
+    --dtypes "${DTYPES}" \
+    --warps "${WARPS}" \
+    --warmup "${WARMUP}" \
+    --repeat "${REPEAT}" \
+    --check | tee "${out}"
+done


### PR DESCRIPTION
Draft PR for reproducer/evidence only. This does not propose a compiler fix yet.

This adds:
- a standalone microbenchmark for a descriptor-load followed by max reduction;
- a wrapper to compare Triton 3.5.1 and 3.6.0 and emit JSONL;
- initial RunPod measurements on RTX 5090, H100 SXM, and B300 SXM6 AC.

Initial observation:
- H100 and B300 show large BF16/FP16 slowdowns on small reduction-axis shapes.
- RTX 5090 is mostly flat on the same script.
- FP32 is much less affected.

I am not claiming root cause from timing alone. Planned next steps:
- add H200, B200, and A100 measurements;
- capture optimized MLIR/TritonGPU IR and PTX/SASS for affected shapes;
- map the regression to the selected layout / cross-warp reduction path before proposing cost-model changes.

Validation:
- `python3 -m py_compile python/test/microbenchmark/tma_descriptor_load_reduce/bench_desc_load_reduce.py`
- `bash -n python/test/microbenchmark/tma_descriptor_load_reduce/run_triton_versions.sh`
- `git diff --cached --check`
- all 90 canonical archived measurement records have `status="ok"`.


<!---
The core Triton is a small number of people, and we receive many PRs (thank
you!).  To help us review your code more quickly, **if you are a new
contributor (less than 3 PRs merged) we ask that you complete the following
tasks and include the filled-out checklist in your PR description.**

Complete the following tasks before sending your PR, and replace `[ ]` with
`[x]` to indicate you have done them.
-->

# New contributor declaration
- [x] I am not making a trivial change

- [x] I have written a PR description...
  [rules](https://cbea.ms/git-commit/#why-not-how).

- [ ] I have run `pre-commit run --from-ref origin/main --to-ref HEAD`.

- Select one of the following.
  - [ ] I have added tests.
    - `/test` for `lit` tests
    - `/unittest` for C++ tests
    - `/python/test` for end-to-end tests
  - [x] This PR does not need a test because this draft adds a standalone benchmark/reproducer with exact correctness checks before timing.

- Select one of the following.
  - [x] I have not added any `lit` tests.
  - [ ] The `lit` tests I have added follow these [best practices](https://mlir.llvm.org/getting_started/TestingGuide/#filecheck-best-practices),
    including the "tests should be minimal" section. (Usually running Python code
    and using the instructions it generates is not minimal.)
