### PR TITLE
[NVIDIA] Fix phase race in cluster_barrier

### DIFF
--- a/python/test/gluon/test_lowerings.py
+++ b/python/test/gluon/test_lowerings.py
@@ -1,11 +1,13 @@
 import math
+import os
+import re
 import torch
 import pytest
 
 import triton
 from triton.experimental import gluon
 from triton.experimental.gluon import language as ttgl
-from triton._internal_testing import is_blackwell, is_compile_warmup, is_cuda, is_hip, is_hopper_or_newer, get_hip_lds_size
+from triton._internal_testing import is_blackwell, is_compile_warmup, is_cuda, is_hip, is_hopper_or_newer, get_hip_lds_size, run_in_process
 from triton._C.libtriton.gluon_ir import make_cga_layout
 from triton.experimental.gluon.language.amd.cdna5 import PartitionedSharedLayout
 from triton.experimental.gluon.language.nvidia.blackwell import TensorMemoryLayout, allocate_tensor_memory
@@ -214,33 +216,88 @@ def test_atomic_poll_two_ctas(warp_specialize, device):
     assert out.item() == 42
 
 
+@gluon.jit
+def _cluster_barrier_partition(out, offset: ttgl.constexpr, BLOCK: ttgl.constexpr):
+    layout: ttgl.constexpr = ttgl.BlockedLayout([1], [32], [4], [0], cga_layout=_make_cga_broadcast(1, ttgl.num_ctas()))
+    offs = offset + ttgl.arange(0, BLOCK, layout=layout)
+    ttgl.barrier(cluster=True)
+    ttgl.store(out + offs, offs)
+
+
+@gluon.jit
+def _cluster_barrier_kernel(out, BLOCK: ttgl.constexpr):
+    ttgl.warp_specialize([
+        (_cluster_barrier_partition, (out, 0, BLOCK)),
+        (_cluster_barrier_partition, (out, BLOCK, BLOCK)),
+    ], [4])
+
+
 @pytest.mark.skipif(not is_hopper_or_newer(), reason="Requires NVIDIA Hopper or newer")
 @pytest.mark.parametrize("num_ctas", [2, 4])
 def test_cluster_barrier_in_warp_specialize(device, num_ctas):
-    BLOCK = ttgl.constexpr(128)
-
-    @gluon.jit
-    def partition(out, offset: ttgl.constexpr):
-        layout: ttgl.constexpr = ttgl.BlockedLayout([1], [32], [4], [0],
-                                                    cga_layout=_make_cga_broadcast(1, ttgl.num_ctas()))
-        offs = offset + ttgl.arange(0, BLOCK, layout=layout)
-        ttgl.barrier(cluster=True)
-        ttgl.store(out + offs, offs)
-
-    @gluon.jit
-    def kernel(out):
-        ttgl.warp_specialize([
-            (partition, (out, 0)),
-            (partition, (out, BLOCK)),
-        ], [4])
-
-    out = torch.empty((2 * BLOCK.value, ), device=device, dtype=torch.int32)
-    compiled = kernel[(1, )](out, num_warps=4, num_ctas=num_ctas)
+    BLOCK = 128
+    out = torch.empty((2 * BLOCK, ), device=device, dtype=torch.int32)
+    compiled = _cluster_barrier_kernel[(1, )](out, BLOCK, num_warps=4, num_ctas=num_ctas)
 
     ptx = compiled.asm["ptx"]
     assert ptx.count("mbarrier.arrive.release.cluster.shared::cluster") == 2
     assert "mapa" not in ptx
-    torch.testing.assert_close(out, torch.arange(2 * BLOCK.value, device=device, dtype=torch.int32))
+    torch.testing.assert_close(out, torch.arange(2 * BLOCK, device=device, dtype=torch.int32))
+
+
+def _run_cluster_barrier_delayed_counter(device, delayed_ptx):
+    BLOCK = 128
+    out = torch.empty((2 * BLOCK, ), device=device, dtype=torch.int32)
+    options = dict(num_warps=4, num_ctas=2)
+    with triton.knobs.compilation.scope():
+        # A source-level delay would precede the old entry rendezvous.
+        # Delay the nonleader warps immediately before the generated counter
+        # load instead, leaving the synchronization instructions intact.
+        triton.knobs.compilation.instrumentation_mode = ""
+        original = _cluster_barrier_kernel.warmup(out, BLOCK, grid=(1, ), **options).asm["ptx"]
+        entry = r"\tbar\.sync\s+0,\s*128;"
+        load = r"\tld\.shared\.b32\s+%r\d+,\s*\[global_smem\+\d+\];"
+        # Accept old and fixed ordering so the same test reproduces the bug.
+        sites = list(re.finditer(rf"^(?:{entry}\n(?P<old>{load})|(?P<fixed>{load})\n{entry})", original, re.MULTILINE))
+        assert len(sites) == 1, "Expected one default-partition counter load"
+        site = sites[0]
+        pos = site.start("old" if site.group("old") is not None else "fixed")
+        delay = """\t{
+\t.reg .pred waiting;
+\t.reg .b32 tid;
+\t.reg .b64 start, elapsed;
+\tmov.u32 tid, %tid.x;
+\tsetp.lt.u32 waiting, tid, 32;
+\t@waiting bra.uni counter_delay_done;
+\tmov.u64 start, %clock64;
+counter_delay_loop:
+\tmov.u64 elapsed, %clock64;
+\tsub.u64 elapsed, elapsed, start;
+\tsetp.lt.u64 waiting, elapsed, 10000000;
+\t@waiting bra.uni counter_delay_loop;
+counter_delay_done:
+\t}
+"""
+        delayed = original[:pos] + delay + original[pos:]
+        delayed_ptx.write_text(delayed)
+        compiled = _cluster_barrier_kernel[(1, )](out, BLOCK, ir_override=str(delayed_ptx), **options)
+        assert compiled.asm["ptx"] == delayed
+
+    ptx = compiled.asm["ptx"]
+    assert ptx.count("mbarrier.arrive.release.cluster.shared::cluster") == 2
+    assert "mapa" not in ptx
+    torch.testing.assert_close(out, torch.arange(2 * BLOCK, device=device, dtype=torch.int32))
+
+
+@pytest.mark.skipif(not is_hopper_or_newer(), reason="Requires NVIDIA Hopper or newer")
+def test_cluster_barrier_warp_specialize_delayed_counter(device, tmp_path, monkeypatch):
+    # A regression deadlocks the CUDA context. Reuse the bounded subprocess
+    # helper so the failure cannot leave the rest of the test suite hanging.
+    if is_compile_warmup() or os.environ.get("DISABLE_SUBPROCESS"):
+        pytest.skip("requires a timeout-bounded subprocess")
+    monkeypatch.setenv("TRITON_TEST_PROCESS_TIMEOUT", "15")
+    result = run_in_process(_run_cluster_barrier_delayed_counter, (device, tmp_path / "delayed-counter.ptx"))
+    assert result.exc is None, result.exc
 
 
 @pytest.mark.skipif(not is_hopper_or_newer(), reason="Requires NVIDIA Hopper or newer")

--- a/test/Conversion/tritonnvidiagpu_to_llvm.mlir
+++ b/test/Conversion/tritonnvidiagpu_to_llvm.mlir
@@ -909,8 +909,9 @@ module attributes {"ttg.num-ctas" = 2 : i32, "ttg.num-warps" = 4 : i32, ttg.shar
   tt.func @cluster_barrier_inside_warp_specialize() {
     ttg.warp_specialize()
     default {
-      // CHECK: nvvm.barrier
+      // CHECK-NOT: nvvm.barrier
       // CHECK: %[[COUNTER:.*]] = llvm.load
+      // CHECK-NEXT: nvvm.barrier
       // CHECK: %[[BARRIER_IDX:.*]] = llvm.and %[[COUNTER]]
       // CHECK: %[[PARITY:.*]] = llvm.lshr %[[COUNTER]]
       // CHECK: %[[BARRIER:.*]] = llvm.getelementptr %{{.*}}[%[[BARRIER_IDX]]]
@@ -920,10 +921,11 @@ module attributes {"ttg.num-ctas" = 2 : i32, "ttg.num-warps" = 4 : i32, ttg.shar
       // CHECK-NOT: mapa
       // CHECK: mbarrier.arrive.release.cluster.shared::cluster.b64
       // CHECK: mbarrier.try_wait.parity.acquire.cluster.shared::cta.b64
+      // CHECK-NOT: nvvm.barrier
       // CHECK: %[[NEXT_COUNTER:.*]] = llvm.add %[[COUNTER]]
       // CHECK: llvm.and %[[NEXT_COUNTER]]
       // CHECK: st.shared::cta.b32
-      // CHECK: nvvm.barrier
+      // CHECK-NEXT: nvvm.barrier
       ttng.cluster_barrier
       ttg.warp_yield
     }
@@ -972,6 +974,10 @@ module attributes {"ttg.num-ctas" = 4 : i32, "ttg.num-warps" = 4 : i32, ttg.shar
   // CHECK: nvvm.barrier
   // RUBIN-LABEL: @cluster_barrier_inside_warp_specialize_rubin
   // RUBIN-COUNT-2: mbarrier.init.shared::cta.b64 [$1], 3;
+  // RUBIN: nvvm.cluster.wait
+  // RUBIN-NOT: nvvm.barrier
+  // RUBIN: %[[RUBIN_COUNTER:.*]] = llvm.load
+  // RUBIN-NEXT: nvvm.barrier
   // RUBIN: %[[CTA:.*]] = nvvm.read.ptx.sreg.cluster.ctarank
   // RUBIN: %[[ALL_CTAS:.*]] = llvm.mlir.constant(15 : i32) : i32
   // RUBIN: %[[SELF_MASK:.*]] = llvm.shl %{{.*}}, %[[CTA]] : i32
@@ -979,6 +985,11 @@ module attributes {"ttg.num-ctas" = 4 : i32, "ttg.num-warps" = 4 : i32, ttg.shar
   // RUBIN-COUNT-1: mbarrier.arrive.release.cluster.shared::cluster.multicast::cluster::32b.b64 _, [$1], $2;
   // RUBIN-NOT: mbarrier.arrive
   // RUBIN: mbarrier.try_wait.parity.acquire.cluster.shared::cta.b64
+  // RUBIN-NOT: nvvm.barrier
+  // RUBIN: %[[RUBIN_NEXT_COUNTER:.*]] = llvm.add %[[RUBIN_COUNTER]]
+  // RUBIN: llvm.and %[[RUBIN_NEXT_COUNTER]]
+  // RUBIN: st.shared::cta.b32
+  // RUBIN-NEXT: nvvm.barrier
   tt.func @cluster_barrier_inside_warp_specialize_rubin() {
     ttg.warp_specialize()
     default {

--- a/third_party/nvidia/lib/TritonNVIDIAGPUToLLVM/ClusterOpsToLLVM.cpp
+++ b/third_party/nvidia/lib/TritonNVIDIAGPUToLLVM/ClusterOpsToLLVM.cpp
@@ -199,8 +199,10 @@ struct ClusterBarrierOpConversion
     auto ptrTy = cast<LLVM::LLVMPointerType>(barrierPtr0.getType());
     Value counterPtr = b.gep(ptrTy, i8_ty, barrierPtr0, LLVM::GEPArg(8));
 
-    NVVM::BarrierOp::create(rewriter, loc);
+    // The WS entry or previous tail barrier publishes the current counter.
+    // Wait for every local thread to read it before the leader can advance it.
     Value counter = b.load(i32_ty, counterPtr);
+    NVVM::BarrierOp::create(rewriter, loc);
     // A delayed CTA can miss a phase if a peer reuses one mbarrier twice
     // before it starts waiting. Alternate two slots so each slot is reused
     // only after an intervening rendezvous. The low counter bit selects the


### PR DESCRIPTION
Without this, there was a race where a thread could run ahead and
overwrite the phase before a different warp had finished reading it.
