### PR TITLE
[AxisAnalysis] Perform constant propagation using APInt

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -13,4 +13,5 @@
 - In C++, never put side-effecting code in `assert`. Assertions may be compiled out, so perform mutations and other required computation before the assertion and assert only the resulting condition. This guideline does not apply to Python `assert` statements.
 
 ## Lowering Guidelines
+- Triton IR uses fixed-width integer types, not MLIR's `index` type. Do not report missing `index` support as a Triton bug.
 - Lowerings must inspect only the operation they lower. Do not inspect other operations or follow loop-carried values; perform cross-operation reasoning in a separate analysis or transformation pass.

--- a/include/triton/Analysis/AxisInfo.h
+++ b/include/triton/Analysis/AxisInfo.h
@@ -2,6 +2,7 @@
 #define TRITON_ANALYSIS_AXISINFO_H
 
 #include "mlir/Analysis/DataFlow/SparseAnalysis.h"
+#include "llvm/ADT/APInt.h"
 #include "llvm/Support/raw_ostream.h"
 
 #include "mlir/Support/LLVM.h"
@@ -10,6 +11,7 @@
 
 #include <algorithm>
 #include <optional>
+#include <utility>
 
 namespace mlir::triton {
 
@@ -30,9 +32,9 @@ public:
       : AxisInfo(contiguity, divisibility, constancy, std::nullopt) {}
 
   AxisInfo(ArrayRef<int64_t> contiguity, ArrayRef<int64_t> divisibility,
-           ArrayRef<int64_t> constancy, std::optional<int64_t> constantValue)
+           ArrayRef<int64_t> constancy, std::optional<APInt> constantValue)
       : contiguity(contiguity), divisibility(divisibility),
-        constancy(constancy), constantValue(constantValue) {
+        constancy(constancy), constantValue(std::move(constantValue)) {
     assert(divisibility.size() == contiguity.size());
     assert(constancy.size() == contiguity.size());
     int64_t globalDivisibility = getGlobalDivisibility();
@@ -121,7 +123,7 @@ public:
 
   int getRank() const { return contiguity.size(); }
 
-  std::optional<int64_t> getConstantValue() const { return constantValue; }
+  const std::optional<APInt> &getConstantValue() const { return constantValue; }
 
   static void initPessimisticStateFromFunc(int argNumber,
                                            FunctionOpInterface funcOp,
@@ -134,10 +136,15 @@ public:
   bool operator==(const AxisInfo &other) const {
     return contiguity == other.contiguity &&
            divisibility == other.divisibility && constancy == other.constancy &&
-           constantValue == other.constantValue;
+           ((!constantValue && !other.constantValue) ||
+            (constantValue && other.constantValue &&
+             constantValue->getBitWidth() ==
+                 other.constantValue->getBitWidth() &&
+             *constantValue == *other.constantValue));
   }
 
   static AxisInfo getPessimisticValueState(Value value);
+  static AxisInfo getConstantValueState(Type type, APInt value);
 
   // The gcd of both arguments for each dimension
   static AxisInfo join(const AxisInfo &lhs, const AxisInfo &rhs);
@@ -163,8 +170,8 @@ private:
   DimVectorT divisibility;
   DimVectorT constancy;
 
-  // The constant value of the lattice if we can infer it.
-  std::optional<int64_t> constantValue;
+  // Exact fixed-width integer scalar or splat bits, if known.
+  std::optional<APInt> constantValue;
 };
 
 class AxisInfoVisitor {
@@ -274,8 +281,6 @@ public:
     }
   }
 
-  // Integer/index constant values returned here are exact scalar or splat
-  // constants representable as a signed int64_t.
   AxisInfo *getAxisInfo(Value value) {
     auto funcOp =
         value.getParentRegion()->getParentOfType<FunctionOpInterface>();

--- a/include/triton/Analysis/AxisInfo.h
+++ b/include/triton/Analysis/AxisInfo.h
@@ -274,6 +274,8 @@ public:
     }
   }
 
+  // Integer/index constant values returned here are exact scalar or splat
+  // constants representable as a signed int64_t.
   AxisInfo *getAxisInfo(Value value) {
     auto funcOp =
         value.getParentRegion()->getParentOfType<FunctionOpInterface>();

--- a/lib/Analysis/AxisInfo.cpp
+++ b/lib/Analysis/AxisInfo.cpp
@@ -36,35 +36,57 @@ unsigned getIntegerBitWidth(Type type) {
 
 // Keep constants exact on defined executions. Generic operation folders can
 // refine poison, so check the integer operations' poison-producing flags here.
-ConstantInt
-evaluateConstant(Operation *operation,
-                 ArrayRef<const dataflow::Lattice<AxisInfo> *> operands) {
-  if (operation->getNumResults() != 1)
-    return std::nullopt;
-  unsigned resultWidth = getIntegerBitWidth(operation->getResult(0).getType());
-  if (!resultWidth)
-    return std::nullopt;
-  auto getOperand = [&](unsigned i) -> const APInt * {
-    if (i >= operands.size())
-      return nullptr;
-    const auto &constant = operands[i]->getValue().getConstantValue();
+class ConstantEvaluator {
+public:
+  ConstantEvaluator(Operation *operation,
+                    ArrayRef<const dataflow::Lattice<AxisInfo> *> operands)
+      : operation(operation), operands(operands),
+        resultWidth(operation->getNumResults() == 1
+                        ? getIntegerBitWidth(operation->getResult(0).getType())
+                        : 0) {
+    assert(operands.size() == operation->getNumOperands());
+  }
+
+  ConstantInt run() const {
+    if (!resultWidth)
+      return std::nullopt;
+
+    return llvm::TypeSwitch<Operation *, ConstantInt>(operation)
+        .Case<arith::ConstantOp, arith::ExtSIOp, arith::ExtUIOp,
+              arith::TruncIOp, arith::AddIOp, arith::SubIOp, arith::MulIOp,
+              arith::DivSIOp, arith::DivUIOp, arith::RemSIOp, arith::RemUIOp,
+              arith::AndIOp, arith::OrIOp, arith::XOrIOp, arith::ShLIOp,
+              arith::ShRSIOp, arith::ShRUIOp, arith::MinSIOp, arith::MaxSIOp,
+              arith::MinUIOp, arith::MaxUIOp, arith::CmpIOp, arith::SelectOp>(
+            [&](auto op) { return evaluate(op); })
+        .Default([](Operation *) -> ConstantInt { return std::nullopt; });
+  }
+
+private:
+  const APInt *constantOperand(unsigned index) const {
+    assert(index < operands.size());
+    const auto &constant = operands[index]->getValue().getConstantValue();
     assert((!constant ||
             constant->getBitWidth() ==
-                getIntegerBitWidth(operation->getOperand(i).getType())) &&
+                getIntegerBitWidth(operation->getOperand(index).getType())) &&
            "constant width must match the operand type");
     return constant ? &*constant : nullptr;
-  };
-  const APInt *lhs = getOperand(0);
-  const APInt *rhs = getOperand(1);
-  auto binary = [&](auto &&evaluate) -> ConstantInt {
+  }
+
+  template <typename Fn> ConstantInt evaluateBinary(Fn &&fn) const {
+    const APInt *lhs = constantOperand(0);
+    const APInt *rhs = constantOperand(1);
     if (!lhs || !rhs || lhs->getBitWidth() != rhs->getBitWidth())
       return std::nullopt;
-    return evaluate(*lhs, *rhs);
-  };
+    return fn(*lhs, *rhs);
+  }
+
   using OverflowOp = APInt (APInt::*)(const APInt &, bool &) const;
-  auto overflowing = [&](auto op, OverflowOp signedOp,
-                         OverflowOp unsignedOp) -> ConstantInt {
-    return binary([&](const APInt &a, const APInt &b) -> ConstantInt {
+
+  template <typename OpTy>
+  ConstantInt evaluateOverflowing(OpTy op, OverflowOp signedOp,
+                                  OverflowOp unsignedOp) const {
+    return evaluateBinary([&](const APInt &a, const APInt &b) -> ConstantInt {
       bool overflow;
       APInt result = (a.*unsignedOp)(b, overflow);
       if (op.hasNoUnsignedWrap() && overflow)
@@ -76,121 +98,179 @@ evaluateConstant(Operation *operation,
       }
       return result;
     });
-  };
+  }
 
-  return llvm::TypeSwitch<Operation *, ConstantInt>(operation)
-      .Case<arith::ConstantOp>([](auto op) -> ConstantInt {
-        APInt value;
-        if (matchPattern(op.getValue(), m_ConstantInt(&value)))
-          return value;
+  template <typename OpTy> ConstantInt evaluateDivision(OpTy op) const {
+    return evaluateBinary([&](const APInt &a, const APInt &b) -> ConstantInt {
+      if (b.isZero())
         return std::nullopt;
-      })
-      .Case<arith::AddIOp>([&](auto op) {
-        return overflowing(op, &APInt::sadd_ov, &APInt::uadd_ov);
-      })
-      .Case<arith::SubIOp>([&](auto op) {
-        return overflowing(op, &APInt::ssub_ov, &APInt::usub_ov);
-      })
-      .Case<arith::MulIOp>([&](auto op) -> ConstantInt {
-        if ((lhs && lhs->isZero()) || (rhs && rhs->isZero()))
-          return APInt(resultWidth, 0);
-        return overflowing(op, &APInt::smul_ov, &APInt::umul_ov);
-      })
-      .Case<arith::DivSIOp, arith::DivUIOp>([&](auto op) {
-        return binary([&](const APInt &a, const APInt &b) -> ConstantInt {
-          if (b.isZero())
-            return std::nullopt;
-          if constexpr (std::is_same_v<decltype(op), arith::DivSIOp>) {
-            bool overflow;
-            APInt result = a.sdiv_ov(b, overflow);
-            if (overflow || (op.getIsExact() && !a.srem(b).isZero()))
-              return std::nullopt;
-            return result;
-          } else {
-            if (op.getIsExact() && !a.urem(b).isZero())
-              return std::nullopt;
-            return a.udiv(b);
-          }
-        });
-      })
-      .Case<arith::RemSIOp, arith::RemUIOp>([&](auto op) -> ConstantInt {
-        // lhs % 1 = 0; signed remainder by -1 is also zero.
-        if (rhs &&
-            (rhs->isOne() || (isa<arith::RemSIOp>(op) && rhs->isAllOnes())))
-          return APInt(resultWidth, 0);
-        return binary([&](const APInt &a, const APInt &b) -> ConstantInt {
-          if (b.isZero())
-            return std::nullopt;
-          if constexpr (std::is_same_v<decltype(op), arith::RemSIOp>)
-            return a.srem(b);
-          else
-            return a.urem(b);
-        });
-      })
-      .Case<arith::AndIOp>([&](auto) {
-        return binary([](const APInt &a, const APInt &b) { return a & b; });
-      })
-      .Case<arith::OrIOp>([&](auto) {
-        return binary([](const APInt &a, const APInt &b) { return a | b; });
-      })
-      .Case<arith::XOrIOp>([&](auto) {
-        return binary([](const APInt &a, const APInt &b) { return a ^ b; });
-      })
-      .Case<arith::ShLIOp>([&](auto op) -> ConstantInt {
-        if (!lhs || !rhs || rhs->uge(lhs->getBitWidth()))
+      if constexpr (std::is_same_v<OpTy, arith::DivSIOp>) {
+        bool overflow;
+        APInt result = a.sdiv_ov(b, overflow);
+        if (overflow || (op.getIsExact() && !a.srem(b).isZero()))
           return std::nullopt;
-        return overflowing(op, &APInt::sshl_ov, &APInt::ushl_ov);
-      })
-      .Case<arith::ShRSIOp, arith::ShRUIOp>([&](auto op) {
-        return binary([&](const APInt &a, const APInt &b) -> ConstantInt {
-          if (b.uge(a.getBitWidth()))
-            return std::nullopt;
-          unsigned shift = b.getZExtValue();
-          if (op.getIsExact() && a.countr_zero() < shift)
-            return std::nullopt;
-          if constexpr (std::is_same_v<decltype(op), arith::ShRSIOp>)
-            return a.ashr(shift);
-          else
-            return a.lshr(shift);
-        });
-      })
-      .Case<arith::MinSIOp>([&](auto) { return binary(llvm::APIntOps::smin); })
-      .Case<arith::MaxSIOp>([&](auto) { return binary(llvm::APIntOps::smax); })
-      .Case<arith::MinUIOp>([&](auto) { return binary(llvm::APIntOps::umin); })
-      .Case<arith::MaxUIOp>([&](auto) { return binary(llvm::APIntOps::umax); })
-      .Case<arith::CmpIOp>([&](auto op) {
-        return binary([&](const APInt &a, const APInt &b) {
-          return APInt(1, arith::applyCmpPredicate(op.getPredicate(), a, b));
-        });
-      })
-      .Case<arith::ExtSIOp>([&](auto) -> ConstantInt {
-        return lhs ? ConstantInt(lhs->sext(resultWidth)) : std::nullopt;
-      })
-      .Case<arith::ExtUIOp>([&](auto op) -> ConstantInt {
-        if (!lhs || (op.getNonNeg() && lhs->isNegative()))
+        return result;
+      } else {
+        if (op.getIsExact() && !a.urem(b).isZero())
           return std::nullopt;
-        return lhs->zext(resultWidth);
-      })
-      .Case<arith::TruncIOp>([&](auto op) -> ConstantInt {
-        if (!lhs || (op.hasNoUnsignedWrap() && !lhs->isIntN(resultWidth)) ||
-            (op.hasNoSignedWrap() && !lhs->isSignedIntN(resultWidth)))
-          return std::nullopt;
-        return lhs->trunc(resultWidth);
-      })
-      .Case<arith::SelectOp>([&](auto) -> ConstantInt {
-        const APInt *falseValue = getOperand(2);
-        if (lhs) {
-          const APInt *selected = lhs->isZero() ? falseValue : rhs;
-          return selected ? ConstantInt(*selected) : std::nullopt;
-        }
-        if (rhs && falseValue &&
-            rhs->getBitWidth() == falseValue->getBitWidth() &&
-            *rhs == *falseValue)
-          return *rhs;
+        return a.udiv(b);
+      }
+    });
+  }
+
+  template <typename OpTy> ConstantInt evaluateRemainder(OpTy op) const {
+    const APInt *rhs = constantOperand(1);
+    // lhs % 1 = 0; signed remainder by -1 is also zero.
+    if (rhs && (rhs->isOne() || (isa<arith::RemSIOp>(op) && rhs->isAllOnes())))
+      return APInt(resultWidth, 0);
+    return evaluateBinary([&](const APInt &a, const APInt &b) -> ConstantInt {
+      if (b.isZero())
         return std::nullopt;
-      })
-      .Default([](Operation *) -> ConstantInt { return std::nullopt; });
-}
+      if constexpr (std::is_same_v<OpTy, arith::RemSIOp>)
+        return a.srem(b);
+      else
+        return a.urem(b);
+    });
+  }
+
+  template <typename OpTy> ConstantInt evaluateRightShift(OpTy op) const {
+    return evaluateBinary([&](const APInt &a, const APInt &b) -> ConstantInt {
+      if (b.uge(a.getBitWidth()))
+        return std::nullopt;
+      unsigned shift = b.getZExtValue();
+      if (op.getIsExact() && a.countr_zero() < shift)
+        return std::nullopt;
+      if constexpr (std::is_same_v<OpTy, arith::ShRSIOp>)
+        return a.ashr(shift);
+      else
+        return a.lshr(shift);
+    });
+  }
+
+  ConstantInt evaluate(arith::ConstantOp op) const {
+    APInt value;
+    if (matchPattern(op.getValue(), m_ConstantInt(&value)))
+      return value;
+    return std::nullopt;
+  }
+
+  ConstantInt evaluate(arith::ExtSIOp) const {
+    const APInt *value = constantOperand(0);
+    return value ? ConstantInt(value->sext(resultWidth)) : std::nullopt;
+  }
+
+  ConstantInt evaluate(arith::ExtUIOp op) const {
+    const APInt *value = constantOperand(0);
+    if (!value || (op.getNonNeg() && value->isNegative()))
+      return std::nullopt;
+    return value->zext(resultWidth);
+  }
+
+  ConstantInt evaluate(arith::TruncIOp op) const {
+    const APInt *value = constantOperand(0);
+    if (!value || (op.hasNoUnsignedWrap() && !value->isIntN(resultWidth)) ||
+        (op.hasNoSignedWrap() && !value->isSignedIntN(resultWidth)))
+      return std::nullopt;
+    return value->trunc(resultWidth);
+  }
+
+  ConstantInt evaluate(arith::AddIOp op) const {
+    return evaluateOverflowing(op, &APInt::sadd_ov, &APInt::uadd_ov);
+  }
+
+  ConstantInt evaluate(arith::SubIOp op) const {
+    return evaluateOverflowing(op, &APInt::ssub_ov, &APInt::usub_ov);
+  }
+
+  ConstantInt evaluate(arith::MulIOp op) const {
+    const APInt *lhs = constantOperand(0);
+    const APInt *rhs = constantOperand(1);
+    if ((lhs && lhs->isZero()) || (rhs && rhs->isZero()))
+      return APInt(resultWidth, 0);
+    return evaluateOverflowing(op, &APInt::smul_ov, &APInt::umul_ov);
+  }
+
+  ConstantInt evaluate(arith::DivSIOp op) const { return evaluateDivision(op); }
+
+  ConstantInt evaluate(arith::DivUIOp op) const { return evaluateDivision(op); }
+
+  ConstantInt evaluate(arith::RemSIOp op) const {
+    return evaluateRemainder(op);
+  }
+
+  ConstantInt evaluate(arith::RemUIOp op) const {
+    return evaluateRemainder(op);
+  }
+
+  ConstantInt evaluate(arith::AndIOp) const {
+    return evaluateBinary([](const APInt &a, const APInt &b) { return a & b; });
+  }
+
+  ConstantInt evaluate(arith::OrIOp) const {
+    return evaluateBinary([](const APInt &a, const APInt &b) { return a | b; });
+  }
+
+  ConstantInt evaluate(arith::XOrIOp) const {
+    return evaluateBinary([](const APInt &a, const APInt &b) { return a ^ b; });
+  }
+
+  ConstantInt evaluate(arith::ShLIOp op) const {
+    const APInt *lhs = constantOperand(0);
+    const APInt *rhs = constantOperand(1);
+    if (!lhs || !rhs || rhs->uge(lhs->getBitWidth()))
+      return std::nullopt;
+    return evaluateOverflowing(op, &APInt::sshl_ov, &APInt::ushl_ov);
+  }
+
+  ConstantInt evaluate(arith::ShRSIOp op) const {
+    return evaluateRightShift(op);
+  }
+
+  ConstantInt evaluate(arith::ShRUIOp op) const {
+    return evaluateRightShift(op);
+  }
+
+  ConstantInt evaluate(arith::MinSIOp) const {
+    return evaluateBinary(llvm::APIntOps::smin);
+  }
+
+  ConstantInt evaluate(arith::MaxSIOp) const {
+    return evaluateBinary(llvm::APIntOps::smax);
+  }
+
+  ConstantInt evaluate(arith::MinUIOp) const {
+    return evaluateBinary(llvm::APIntOps::umin);
+  }
+
+  ConstantInt evaluate(arith::MaxUIOp) const {
+    return evaluateBinary(llvm::APIntOps::umax);
+  }
+
+  ConstantInt evaluate(arith::CmpIOp op) const {
+    return evaluateBinary([&](const APInt &a, const APInt &b) {
+      return APInt(1, arith::applyCmpPredicate(op.getPredicate(), a, b));
+    });
+  }
+
+  ConstantInt evaluate(arith::SelectOp) const {
+    const APInt *condition = constantOperand(0);
+    const APInt *trueValue = constantOperand(1);
+    const APInt *falseValue = constantOperand(2);
+    if (condition) {
+      const APInt *selected = condition->isZero() ? falseValue : trueValue;
+      return selected ? ConstantInt(*selected) : std::nullopt;
+    }
+    if (trueValue && falseValue &&
+        trueValue->getBitWidth() == falseValue->getBitWidth() &&
+        *trueValue == *falseValue)
+      return *trueValue;
+    return std::nullopt;
+  }
+
+  Operation *operation;
+  ArrayRef<const dataflow::Lattice<AxisInfo> *> operands;
+  unsigned resultWidth;
+};
 
 template <typename... Args> int64_t gcd(int64_t a, int64_t b, Args... args) {
   if (a == 0)
@@ -1196,7 +1276,7 @@ LogicalResult AxisInfoAnalysis::visitOperation(
     if (op->getValue().getRank() == 0)
       return success();
   AxisInfo curr;
-  if (ConstantInt constant = evaluateConstant(op, operands))
+  if (ConstantInt constant = ConstantEvaluator(op, operands).run())
     curr = AxisInfo::getConstantValueState(op->getResult(0).getType(),
                                            std::move(*constant));
   else {

--- a/lib/Analysis/AxisInfo.cpp
+++ b/lib/Analysis/AxisInfo.cpp
@@ -70,7 +70,7 @@ evaluateConstant(Operation *operation,
       if (op.hasNoUnsignedWrap() && overflow)
         return std::nullopt;
       if (op.hasNoSignedWrap()) {
-        (a.*signedOp)(b, overflow);
+        (void)(a.*signedOp)(b, overflow);
         if (overflow)
           return std::nullopt;
       }

--- a/lib/Analysis/AxisInfo.cpp
+++ b/lib/Analysis/AxisInfo.cpp
@@ -1,6 +1,6 @@
 #include "triton/Analysis/AxisInfo.h"
-#include "mlir/Analysis/DataFlow/ConstantPropagationAnalysis.h"
 #include "mlir/Analysis/DataFlowFramework.h"
+#include "mlir/Dialect/Arith/IR/Arith.h"
 #include "mlir/Dialect/UB/IR/UBOps.h"
 #include "mlir/IR/Matchers.h"
 #include "triton/Dialect/Gluon/IR/Dialect.h"
@@ -8,10 +8,12 @@
 #include "triton/Dialect/Triton/IR/Utility.h"
 #include "triton/Dialect/TritonGPU/IR/Dialect.h"
 #include "llvm/ADT/APInt.h"
+#include "llvm/ADT/TypeSwitch.h"
 #include "llvm/ADT/bit.h"
 #include "llvm/Support/Debug.h"
 #include "llvm/Support/raw_ostream.h"
 
+#include <limits>
 #include <numeric>
 
 #define DEBUG_TYPE "axis-info"
@@ -22,6 +24,173 @@ namespace mlir::triton {
 namespace {
 
 constexpr int64_t kMaxDivisor = highestPowOf2Divisor<int64_t>(0);
+constexpr unsigned kMaxDivisorLog2 = std::numeric_limits<int64_t>::digits - 1;
+
+using ConstantInt = std::optional<APInt>;
+
+unsigned getIntegerBitWidth(Type type) {
+  if (auto intType = dyn_cast<IntegerType>(getElementTypeOrSelf(type)))
+    return intType.getWidth();
+  return 0;
+}
+
+// Keep constants exact on defined executions. Generic operation folders can
+// refine poison, so check the integer operations' poison-producing flags here.
+ConstantInt
+evaluateConstant(Operation *operation,
+                 ArrayRef<const dataflow::Lattice<AxisInfo> *> operands) {
+  if (operation->getNumResults() != 1)
+    return std::nullopt;
+  unsigned resultWidth = getIntegerBitWidth(operation->getResult(0).getType());
+  if (!resultWidth)
+    return std::nullopt;
+  auto getOperand = [&](unsigned i) -> const APInt * {
+    if (i >= operands.size())
+      return nullptr;
+    const auto &constant = operands[i]->getValue().getConstantValue();
+    assert((!constant ||
+            constant->getBitWidth() ==
+                getIntegerBitWidth(operation->getOperand(i).getType())) &&
+           "constant width must match the operand type");
+    return constant ? &*constant : nullptr;
+  };
+  const APInt *lhs = getOperand(0);
+  const APInt *rhs = getOperand(1);
+  auto binary = [&](auto &&evaluate) -> ConstantInt {
+    if (!lhs || !rhs || lhs->getBitWidth() != rhs->getBitWidth())
+      return std::nullopt;
+    return evaluate(*lhs, *rhs);
+  };
+  using OverflowOp = APInt (APInt::*)(const APInt &, bool &) const;
+  auto overflowing = [&](auto op, OverflowOp signedOp,
+                         OverflowOp unsignedOp) -> ConstantInt {
+    return binary([&](const APInt &a, const APInt &b) -> ConstantInt {
+      bool overflow;
+      APInt result = (a.*unsignedOp)(b, overflow);
+      if (op.hasNoUnsignedWrap() && overflow)
+        return std::nullopt;
+      if (op.hasNoSignedWrap()) {
+        (a.*signedOp)(b, overflow);
+        if (overflow)
+          return std::nullopt;
+      }
+      return result;
+    });
+  };
+
+  return llvm::TypeSwitch<Operation *, ConstantInt>(operation)
+      .Case<arith::ConstantOp>([](auto op) -> ConstantInt {
+        APInt value;
+        if (matchPattern(op.getValue(), m_ConstantInt(&value)))
+          return value;
+        return std::nullopt;
+      })
+      .Case<arith::AddIOp>([&](auto op) {
+        return overflowing(op, &APInt::sadd_ov, &APInt::uadd_ov);
+      })
+      .Case<arith::SubIOp>([&](auto op) {
+        return overflowing(op, &APInt::ssub_ov, &APInt::usub_ov);
+      })
+      .Case<arith::MulIOp>([&](auto op) -> ConstantInt {
+        if ((lhs && lhs->isZero()) || (rhs && rhs->isZero()))
+          return APInt(resultWidth, 0);
+        return overflowing(op, &APInt::smul_ov, &APInt::umul_ov);
+      })
+      .Case<arith::DivSIOp, arith::DivUIOp>([&](auto op) {
+        return binary([&](const APInt &a, const APInt &b) -> ConstantInt {
+          if (b.isZero())
+            return std::nullopt;
+          if constexpr (std::is_same_v<decltype(op), arith::DivSIOp>) {
+            bool overflow;
+            APInt result = a.sdiv_ov(b, overflow);
+            if (overflow || (op.getIsExact() && !a.srem(b).isZero()))
+              return std::nullopt;
+            return result;
+          } else {
+            if (op.getIsExact() && !a.urem(b).isZero())
+              return std::nullopt;
+            return a.udiv(b);
+          }
+        });
+      })
+      .Case<arith::RemSIOp, arith::RemUIOp>([&](auto op) -> ConstantInt {
+        // lhs % 1 = 0; signed remainder by -1 is also zero.
+        if (rhs &&
+            (rhs->isOne() || (isa<arith::RemSIOp>(op) && rhs->isAllOnes())))
+          return APInt(resultWidth, 0);
+        return binary([&](const APInt &a, const APInt &b) -> ConstantInt {
+          if (b.isZero())
+            return std::nullopt;
+          if constexpr (std::is_same_v<decltype(op), arith::RemSIOp>)
+            return a.srem(b);
+          else
+            return a.urem(b);
+        });
+      })
+      .Case<arith::AndIOp>([&](auto) {
+        return binary([](const APInt &a, const APInt &b) { return a & b; });
+      })
+      .Case<arith::OrIOp>([&](auto) {
+        return binary([](const APInt &a, const APInt &b) { return a | b; });
+      })
+      .Case<arith::XOrIOp>([&](auto) {
+        return binary([](const APInt &a, const APInt &b) { return a ^ b; });
+      })
+      .Case<arith::ShLIOp>([&](auto op) -> ConstantInt {
+        if (!lhs || !rhs || rhs->uge(lhs->getBitWidth()))
+          return std::nullopt;
+        return overflowing(op, &APInt::sshl_ov, &APInt::ushl_ov);
+      })
+      .Case<arith::ShRSIOp, arith::ShRUIOp>([&](auto op) {
+        return binary([&](const APInt &a, const APInt &b) -> ConstantInt {
+          if (b.uge(a.getBitWidth()))
+            return std::nullopt;
+          unsigned shift = b.getZExtValue();
+          if (op.getIsExact() && a.countr_zero() < shift)
+            return std::nullopt;
+          if constexpr (std::is_same_v<decltype(op), arith::ShRSIOp>)
+            return a.ashr(shift);
+          else
+            return a.lshr(shift);
+        });
+      })
+      .Case<arith::MinSIOp>([&](auto) { return binary(llvm::APIntOps::smin); })
+      .Case<arith::MaxSIOp>([&](auto) { return binary(llvm::APIntOps::smax); })
+      .Case<arith::MinUIOp>([&](auto) { return binary(llvm::APIntOps::umin); })
+      .Case<arith::MaxUIOp>([&](auto) { return binary(llvm::APIntOps::umax); })
+      .Case<arith::CmpIOp>([&](auto op) {
+        return binary([&](const APInt &a, const APInt &b) {
+          return APInt(1, arith::applyCmpPredicate(op.getPredicate(), a, b));
+        });
+      })
+      .Case<arith::ExtSIOp>([&](auto) -> ConstantInt {
+        return lhs ? ConstantInt(lhs->sext(resultWidth)) : std::nullopt;
+      })
+      .Case<arith::ExtUIOp>([&](auto op) -> ConstantInt {
+        if (!lhs || (op.getNonNeg() && lhs->isNegative()))
+          return std::nullopt;
+        return lhs->zext(resultWidth);
+      })
+      .Case<arith::TruncIOp>([&](auto op) -> ConstantInt {
+        if (!lhs || (op.hasNoUnsignedWrap() && !lhs->isIntN(resultWidth)) ||
+            (op.hasNoSignedWrap() && !lhs->isSignedIntN(resultWidth)))
+          return std::nullopt;
+        return lhs->trunc(resultWidth);
+      })
+      .Case<arith::SelectOp>([&](auto) -> ConstantInt {
+        const APInt *falseValue = getOperand(2);
+        if (lhs) {
+          const APInt *selected = lhs->isZero() ? falseValue : rhs;
+          return selected ? ConstantInt(*selected) : std::nullopt;
+        }
+        if (rhs && falseValue &&
+            rhs->getBitWidth() == falseValue->getBitWidth() &&
+            *rhs == *falseValue)
+          return *rhs;
+        return std::nullopt;
+      })
+      .Default([](Operation *) -> ConstantInt { return std::nullopt; });
+}
 
 template <typename... Args> int64_t gcd(int64_t a, int64_t b, Args... args) {
   if (a == 0)
@@ -89,22 +258,12 @@ public:
   AxisInfo
   getAxisInfo(OpTy op,
               ArrayRef<const dataflow::Lattice<AxisInfo> *> operands) override {
-    auto lhsInfo = operands[0]->getValue();
-    auto rhsInfo = operands[1]->getValue();
+    const AxisInfo &lhsInfo = operands[0]->getValue();
+    const AxisInfo &rhsInfo = operands[1]->getValue();
     auto rank = lhsInfo.getRank();
     assert(isa<RankedTensorType>(op.getType()) ||
            rank == 1 && "Expected ranked tensor or scalar");
     assert(operands.size() == 2 && "Expected two operands");
-    auto constantValue = getConstantValue(op, lhsInfo, rhsInfo);
-    if (constantValue.has_value()) {
-      auto resTy = dyn_cast<RankedTensorType>(op.getType());
-      AxisInfo::DimVectorT constancy =
-          resTy ? to_vector(resTy.getShape()) : AxisInfo::DimVectorT(rank, 1);
-      AxisInfo::DimVectorT contiguity(rank, 1);
-      AxisInfo::DimVectorT divisibility(
-          rank, highestPowOf2Divisor<int64_t>(constantValue.value()));
-      return AxisInfo(contiguity, divisibility, constancy, constantValue);
-    }
     AxisInfo::DimVectorT contiguity;
     AxisInfo::DimVectorT divisibility;
     AxisInfo::DimVectorT constancy;
@@ -113,7 +272,7 @@ public:
       constancy.push_back(getConstancy(op, lhsInfo, rhsInfo, d));
       divisibility.push_back(getDivisibility(op, lhsInfo, rhsInfo, d));
     }
-    return AxisInfo(contiguity, divisibility, constancy, constantValue);
+    return AxisInfo(contiguity, divisibility, constancy);
   }
 
 protected:
@@ -131,10 +290,6 @@ protected:
                                const AxisInfo &rhs, int dim) {
     return gcd(lhs.getConstancy(dim), rhs.getConstancy(dim));
   }
-  virtual std::optional<int64_t> getConstantValue(OpTy op, const AxisInfo &lhs,
-                                                  const AxisInfo &rhs) {
-    return {};
-  }
 };
 
 template <typename OpTy>
@@ -145,35 +300,11 @@ public:
   AxisInfo
   getAxisInfo(OpTy op,
               ArrayRef<const dataflow::Lattice<AxisInfo> *> operands) override {
-    AxisInfo info = operands[0]->getValue();
-    auto constant = info.getConstantValue();
-    if (!constant)
-      return info;
-
-    unsigned srcWidth =
-        getElementTypeOrSelf(op.getIn().getType()).getIntOrFloatBitWidth();
-    unsigned dstWidth =
-        getElementTypeOrSelf(op.getType()).getIntOrFloatBitWidth();
-    // Recover the source bits before applying the cast's signedness.
-    APInt value =
-        APInt(64, static_cast<uint64_t>(*constant)).sextOrTrunc(srcWidth);
-    if constexpr (std::is_same_v<OpTy, arith::ExtUIOp>)
-      value = value.zext(dstWidth);
-    else if constexpr (std::is_same_v<OpTy, arith::ExtSIOp>)
-      value = value.sext(dstWidth);
-    else {
-      static_assert(std::is_same_v<OpTy, arith::TruncIOp>);
-      value = value.trunc(dstWidth);
-    }
-
-    // Divisibility is capped at kMaxDivisor, so the low 64 bits suffice even
-    // when the converted constant does not fit in int64_t.
-    int64_t divisibility =
-        highestPowOf2Divisor(value.sextOrTrunc(64).getSExtValue());
-    // The lattice cannot represent every constant wider than 64 bits.
-    return AxisInfo(info.getContiguity(),
-                    AxisInfo::DimVectorT(info.getRank(), divisibility),
-                    info.getConstancy(), value.trySExtValue());
+    const AxisInfo &info = operands[0]->getValue();
+    // Exact casts are handled before the bound visitors. An unproven or poison
+    // cast must not retain its operand's constant value.
+    return AxisInfo(info.getContiguity(), info.getDivisibility(),
+                    info.getConstancy());
   }
 };
 
@@ -227,6 +358,8 @@ public:
   AxisInfo
   getAxisInfo(mlir::UnrealizedConversionCastOp op,
               ArrayRef<const dataflow::Lattice<AxisInfo> *> operands) override {
+    if (op->getNumOperands() != 1 || op->getNumResults() != 1)
+      return {};
     auto tensorType = dyn_cast<RankedTensorType>(op.getResultTypes()[0]);
     if (tensorType &&
         tensorType.getRank() != operands[0]->getValue().getRank()) {
@@ -234,7 +367,11 @@ public:
       // in future visitor applications.
       return AxisInfo::getPessimisticValueState(op->getResult(0));
     }
-    return operands[0]->getValue();
+    const AxisInfo &info = operands[0]->getValue();
+    if (op.getOperand(0).getType() == op.getResult(0).getType())
+      return info;
+    return AxisInfo(info.getContiguity(), info.getDivisibility(),
+                    info.getConstancy());
   }
 };
 
@@ -251,44 +388,6 @@ public:
     return AxisInfo(/*contiguity=*/{end - start},
                     /*divisibility=*/{highestPowOf2Divisor(start)},
                     /*constancy=*/{1});
-  }
-};
-
-class ConstantOpAxisInfoVisitor final
-    : public AxisInfoVisitorImpl<arith::ConstantOp> {
-public:
-  using AxisInfoVisitorImpl::AxisInfoVisitorImpl;
-
-  AxisInfo
-  getAxisInfo(arith::ConstantOp op,
-              ArrayRef<const dataflow::Lattice<AxisInfo> *> operands) override {
-    auto intAttr = dyn_cast<IntegerAttr>(op.getValue());
-    auto boolAttr = dyn_cast<BoolAttr>(op.getValue());
-    if (intAttr || boolAttr) {
-      int64_t value{};
-      if (intAttr)
-        value = intAttr.getValue().getSExtValue();
-      else
-        value = boolAttr.getValue() ? 1 : 0;
-      return AxisInfo(/*contiguity=*/{1},
-                      /*divisibility=*/{highestPowOf2Divisor(value)},
-                      /*constancy=*/{1},
-                      /*knownConstantValue=*/{value});
-    }
-    // TODO: generalize to dense attr
-    auto splatAttr = dyn_cast<SplatElementsAttr>(op.getValue());
-    if (splatAttr && splatAttr.getElementType().isIntOrIndex()) {
-      int64_t value = splatAttr.template getSplatValue<APInt>().getSExtValue();
-      TensorType ty = cast<TensorType>(splatAttr.getType());
-      return AxisInfo(
-          /*contiguity=*/AxisInfo::DimVectorT(ty.getRank(), 1),
-          /*divisibility=*/
-          AxisInfo::DimVectorT(ty.getRank(), highestPowOf2Divisor(value)),
-          /*constancy=*/
-          AxisInfo::DimVectorT(ty.getShape().begin(), ty.getShape().end()),
-          /*knownConstantValue=*/{value});
-    }
-    return AxisInfo();
   }
 };
 
@@ -407,26 +506,6 @@ private:
       }
     }
   }
-
-  std::optional<int64_t> getConstantValue(OpTy op, const AxisInfo &lhs,
-                                          const AxisInfo &rhs) override {
-    if (lhs.getConstantValue().has_value() &&
-        rhs.getConstantValue().has_value()) {
-      if constexpr (std::is_same_v<OpTy, arith::AddIOp>) {
-        return {lhs.getConstantValue().value() +
-                rhs.getConstantValue().value()};
-      } else if constexpr (std::is_same_v<OpTy, arith::SubIOp>) {
-        return {lhs.getConstantValue().value() -
-                rhs.getConstantValue().value()};
-      } else if constexpr (std::is_same_v<OpTy, triton::AddPtrOp>) {
-        auto elemSize = std::max<int64_t>(
-            1, triton::getPointeeBitWidth(op.getPtr().getType()) / 8);
-        auto rhsValue = rhs.getConstantValue().value() * elemSize;
-        return {lhs.getConstantValue().value() + rhsValue};
-      }
-    }
-    return {};
-  }
 };
 
 class MulIOpAxisInfoVisitor final : public BinaryOpVisitorImpl<arith::MulIOp> {
@@ -438,12 +517,12 @@ private:
                         const AxisInfo &rhs, int dim) override {
     // lhs * 1 = lhs
     auto lhsContiguity =
-        rhs.getConstantValue().has_value() && rhs.getConstantValue() == 1
+        rhs.getConstantValue() && rhs.getConstantValue()->isOne()
             ? lhs.getContiguity(dim)
             : 1;
     // 1 * rhs = rhs
     auto rhsContiguity =
-        lhs.getConstantValue().has_value() && lhs.getConstantValue() == 1
+        lhs.getConstantValue() && lhs.getConstantValue()->isOne()
             ? rhs.getContiguity(dim)
             : 1;
     return std::max(lhsContiguity, rhsContiguity);
@@ -452,7 +531,8 @@ private:
   int64_t getDivisibility(arith::MulIOp op, const AxisInfo &lhs,
                           const AxisInfo &rhs, int dim) override {
     auto lhsDivisibility = lhs.getDivisibility(dim);
-    if (lhs.getContiguity(dim) > 1 && rhs.getConstantValue() != 1) {
+    if (lhs.getContiguity(dim) > 1 &&
+        (!rhs.getConstantValue() || !rhs.getConstantValue()->isOne())) {
       // If the operand is contiguous, the divisibility of the
       // sequence drops to 1.
       // Example: [4, 5, 6, 7] (base 4 divisible by 4).
@@ -461,23 +541,12 @@ private:
       lhsDivisibility = 1;
     }
     auto rhsDivisibility = rhs.getDivisibility(dim);
-    if (rhs.getContiguity(dim) > 1 && lhs.getConstantValue() != 1) {
+    if (rhs.getContiguity(dim) > 1 &&
+        (!lhs.getConstantValue() || !lhs.getConstantValue()->isOne())) {
       // Treat [2^n,2^n+1,...]'s divisibility as 1 instead of 2^n
       rhsDivisibility = 1;
     }
     return multiplyDivisor(lhsDivisibility, rhsDivisibility);
-  }
-
-  std::optional<int64_t> getConstantValue(arith::MulIOp op, const AxisInfo &lhs,
-                                          const AxisInfo &rhs) override {
-    auto lhsConst = lhs.getConstantValue();
-    auto rhsConst = rhs.getConstantValue();
-    if (lhsConst.has_value() && rhsConst.has_value())
-      return {lhsConst.value() * rhsConst.value()};
-    if ((lhsConst.has_value() && lhsConst.value() == 0) ||
-        (rhsConst.has_value() && rhsConst.value() == 0))
-      return 0;
-    return {};
   }
 };
 
@@ -490,8 +559,7 @@ private:
   int64_t getContiguity(OpTy op, const AxisInfo &lhs, const AxisInfo &rhs,
                         int dim) override {
     // lhs / 1 = lhs
-    return rhs.getConstantValue().has_value() &&
-                   rhs.getConstantValue().value() == 1
+    return rhs.getConstantValue() && rhs.getConstantValue()->isOne()
                ? lhs.getContiguity(dim)
                : 1;
   }
@@ -524,30 +592,24 @@ private:
   int64_t getDivisibility(OpTy op, const AxisInfo &lhs, const AxisInfo &rhs,
                           int dim) override {
     // Case 1: lhs is 0
-    if (lhs.getConstantValue().has_value() &&
-        lhs.getConstantValue().value() == 0)
+    if (lhs.getConstantValue() && lhs.getConstantValue()->isZero())
       return lhs.getDivisibility(dim);
     // Case 2: rhs is 1
-    if (rhs.getConstantValue().has_value() &&
-        rhs.getConstantValue().value() == 1)
+    if (rhs.getConstantValue() && rhs.getConstantValue()->isOne())
       return lhs.getDivisibility(dim);
     // Case 3: lhs has contiguity of 1 in this dimension and rhs is a power of 2
-    if (rhs.getConstantValue().has_value() &&
-        llvm::isPowerOf2_64(std::abs(rhs.getConstantValue().value())) &&
-        lhs.getContiguity(dim) == 1) {
-      int64_t absRhs = std::abs(rhs.getConstantValue().value());
-      return std::max<int64_t>(1, lhs.getDivisibility(dim) / absRhs);
+    if (rhs.getConstantValue() && lhs.getContiguity(dim) == 1) {
+      APInt divisor = *rhs.getConstantValue();
+      if constexpr (std::is_same_v<OpTy, arith::DivSIOp>)
+        if (divisor.isNegative())
+          divisor = -divisor;
+      if (divisor.isPowerOf2()) {
+        unsigned shift = std::min(divisor.countr_zero(), kMaxDivisorLog2);
+        return std::max<int64_t>(1, lhs.getDivisibility(dim) >> shift);
+      }
     }
     // otherwise: return 1
     return 1;
-  }
-
-  std::optional<int64_t> getConstantValue(OpTy op, const AxisInfo &lhs,
-                                          const AxisInfo &rhs) override {
-    if (lhs.getConstantValue().has_value() &&
-        rhs.getConstantValue().has_value())
-      return {lhs.getConstantValue().value() / rhs.getConstantValue().value()};
-    return {};
   }
 };
 
@@ -596,30 +658,6 @@ private:
     // lhs % rhs = [0, 0, 0, 1]
     return 1;
   };
-
-  int64_t getConstancy(OpTy op, const AxisInfo &lhs, const AxisInfo &rhs,
-                       int dim) override {
-    auto constancy = BinaryOpVisitorImpl<OpTy>::getConstancy(op, lhs, rhs, dim);
-    auto resTy = dyn_cast<RankedTensorType>(op.getType());
-    if (!resTy)
-      return constancy;
-    // Case: lhs % 1 = 0
-    if (rhs.getConstantValue().has_value() &&
-        rhs.getConstantValue().value() == 1)
-      return resTy.getDimSize(dim);
-    return constancy;
-  }
-
-  std::optional<int64_t> getConstantValue(OpTy op, const AxisInfo &lhs,
-                                          const AxisInfo &rhs) override {
-    if (lhs.getConstantValue().has_value() &&
-        rhs.getConstantValue().has_value())
-      return {lhs.getConstantValue().value() % rhs.getConstantValue().value()};
-    else if (rhs.getConstantValue().has_value() &&
-             rhs.getConstantValue().value() == 1)
-      return {0};
-    return {};
-  }
 };
 
 class SplatOpAxisInfoVisitor final
@@ -685,14 +723,15 @@ public:
   getAxisInfo(triton::ExpandDimsOp op,
               ArrayRef<const dataflow::Lattice<AxisInfo> *> operands) override {
     AxisInfo opInfo = operands[0]->getValue();
+    // The tensor is constant.
+    if (opInfo.getConstantValue())
+      return AxisInfo::getConstantValueState(op.getType(),
+                                             *opInfo.getConstantValue());
     AxisInfo::DimVectorT contiguity = opInfo.getContiguity();
     AxisInfo::DimVectorT divisibility = opInfo.getDivisibility();
     AxisInfo::DimVectorT constancy = opInfo.getConstancy();
     int64_t newDivisibility = 1;
-    if (opInfo.getConstantValue().has_value()) {
-      // The tensor is constant, same as ConstantOpAxisInfoVisitor
-      newDivisibility = highestPowOf2Divisor(opInfo.getConstantValue().value());
-    } else if (opInfo.getRank()) {
+    if (opInfo.getRank()) {
       // Otherwise, calculate the GCD as the new divisibility
       // Treat [2^n,2^n+1,...]'s divisibility as 1 instead of 2^n
       newDivisibility =
@@ -706,8 +745,7 @@ public:
     contiguity.insert(contiguity.begin() + op.getAxis(), 1);
     divisibility.insert(divisibility.begin() + op.getAxis(), newDivisibility);
     constancy.insert(constancy.begin() + op.getAxis(), 1);
-    return AxisInfo(contiguity, divisibility, constancy,
-                    operands[0]->getValue().getConstantValue());
+    return AxisInfo(contiguity, divisibility, constancy);
   }
 };
 
@@ -754,15 +792,9 @@ public:
     auto dstShape = dstTy.getShape();
 
     // Constant tensor stays constant
-    if (srcInfo.getConstantValue().has_value()) {
-      AxisInfo::DimVectorT contiguity(dstTy.getRank(), 1);
-      AxisInfo::DimVectorT divisibility(
-          dstTy.getRank(),
-          highestPowOf2Divisor(srcInfo.getConstantValue().value()));
-      AxisInfo::DimVectorT constancy(dstShape.begin(), dstShape.end());
-      return AxisInfo(contiguity, divisibility, constancy,
-                      srcInfo.getConstantValue());
-    }
+    if (srcInfo.getConstantValue())
+      return AxisInfo::getConstantValueState(dstTy,
+                                             *srcInfo.getConstantValue());
 
     auto srcShape = srcTy.getShape();
     // `suffixProducts[d + 1]` is the flat stride of axis `d` in row-major
@@ -859,8 +891,7 @@ public:
       }
     }
 
-    return AxisInfo(contiguity, divisibility, constancy,
-                    srcInfo.getConstantValue());
+    return AxisInfo(contiguity, divisibility, constancy);
   }
 };
 
@@ -881,52 +912,40 @@ public:
     auto rhsInfo = operands[1]->getValue();
 
     AxisInfo::DimVectorT contiguity, divisibility, constancy;
-    std::optional<int64_t> constantValue;
     for (short d = 0; d < rank; ++d) {
-      int64_t constHint;
-      if (lhsInfo.getConstantValue().has_value() &&
-          rhsInfo.getConstantValue().has_value()) {
-        constHint = shape[d];
-        constantValue =
-            compare(getPredicate(op), lhsInfo.getConstantValue().value(),
-                    rhsInfo.getConstantValue().value())
-                ? 1
-                : 0;
-      } else {
-        // Case 1: lhs and rhs are both partial constants
-        constHint = gcd(lhsInfo.getConstancy(d), rhsInfo.getConstancy(d));
-        if ((gtPredicate(getPredicate(op)) || lePredicate(getPredicate(op))) &&
-            AxisInfoVisitor::isConstantDim(lhsInfo, shape, d)) {
-          // Case 2: lhs all constant, rhs all contiguous
-          // NOTE:
-          // lhs: 4 4 4 4
-          // rhs: 4 5 6 7
-          // lhs eq rhs: 1, 0, 0, 0
-          // lhs ne rhs: 0, 1, 1, 1
-          // lhs lt rhs: 0, 1, 1, 1
-          // lhs le rhs: 1, 1, 1, 1
-          // lhs ge rhs: 1, 0, 0, 0
-          // lhs gt rhs: 0, 0, 0, 0
-          constHint = std::max(constHint, gcd(rhsInfo.getContiguity(d),
-                                              lhsInfo.getDivisibility(d),
-                                              rhsInfo.getDivisibility(d)));
-        } else if ((ltPredicate(getPredicate(op)) ||
-                    gePredicate(getPredicate(op))) &&
-                   AxisInfoVisitor::isConstantDim(rhsInfo, shape, d)) {
-          // Case 3: lhs all contiguous, rhs all constant
-          // NOTE
-          // lhs: 4 5 6 7
-          // rhs: 4 4 4 4
-          // lhs eq rhs: 1, 0, 0, 0
-          // lhs ne rhs: 0, 1, 1, 1
-          // lhs le rhs: 1, 0, 0, 0
-          // lhs lt rhs: 0, 0, 0, 0
-          // lhs gt rhs: 0, 1, 1, 1
-          // lhs ge rhs: 1, 1, 1, 1
-          constHint = std::max(constHint, gcd(lhsInfo.getContiguity(d),
-                                              lhsInfo.getDivisibility(d),
-                                              rhsInfo.getDivisibility(d)));
-        }
+      // Case 1: lhs and rhs are both partial constants
+      int64_t constHint = gcd(lhsInfo.getConstancy(d), rhsInfo.getConstancy(d));
+      if ((gtPredicate(getPredicate(op)) || lePredicate(getPredicate(op))) &&
+          AxisInfoVisitor::isConstantDim(lhsInfo, shape, d)) {
+        // Case 2: lhs all constant, rhs all contiguous
+        // NOTE:
+        // lhs: 4 4 4 4
+        // rhs: 4 5 6 7
+        // lhs eq rhs: 1, 0, 0, 0
+        // lhs ne rhs: 0, 1, 1, 1
+        // lhs lt rhs: 0, 1, 1, 1
+        // lhs le rhs: 1, 1, 1, 1
+        // lhs ge rhs: 1, 0, 0, 0
+        // lhs gt rhs: 0, 0, 0, 0
+        constHint = std::max(constHint, gcd(rhsInfo.getContiguity(d),
+                                            lhsInfo.getDivisibility(d),
+                                            rhsInfo.getDivisibility(d)));
+      } else if ((ltPredicate(getPredicate(op)) ||
+                  gePredicate(getPredicate(op))) &&
+                 AxisInfoVisitor::isConstantDim(rhsInfo, shape, d)) {
+        // Case 3: lhs all contiguous, rhs all constant
+        // NOTE
+        // lhs: 4 5 6 7
+        // rhs: 4 4 4 4
+        // lhs eq rhs: 1, 0, 0, 0
+        // lhs ne rhs: 0, 1, 1, 1
+        // lhs le rhs: 1, 0, 0, 0
+        // lhs lt rhs: 0, 0, 0, 0
+        // lhs gt rhs: 0, 1, 1, 1
+        // lhs ge rhs: 1, 1, 1, 1
+        constHint = std::max(constHint, gcd(lhsInfo.getContiguity(d),
+                                            lhsInfo.getDivisibility(d),
+                                            rhsInfo.getDivisibility(d)));
       }
 
       constancy.push_back(constHint);
@@ -934,7 +953,7 @@ public:
       contiguity.push_back(1);
     }
 
-    return AxisInfo(contiguity, divisibility, constancy, constantValue);
+    return AxisInfo(contiguity, divisibility, constancy);
   }
 
 private:
@@ -961,35 +980,6 @@ private:
     return predicate == arith::CmpIPredicate::sle ||
            predicate == arith::CmpIPredicate::ule;
   }
-
-  static bool compare(arith::CmpIPredicate predicate, int64_t lhs,
-                      int64_t rhs) {
-    switch (predicate) {
-    case arith::CmpIPredicate::eq:
-      return lhs == rhs;
-    case arith::CmpIPredicate::ne:
-      return lhs != rhs;
-    case arith::CmpIPredicate::slt:
-      return lhs < rhs;
-    case arith::CmpIPredicate::sle:
-      return lhs <= rhs;
-    case arith::CmpIPredicate::sgt:
-      return lhs > rhs;
-    case arith::CmpIPredicate::sge:
-      return lhs >= rhs;
-    case arith::CmpIPredicate::ult:
-      return (uint64_t)lhs < (uint64_t)rhs;
-    case arith::CmpIPredicate::ule:
-      return (uint64_t)lhs <= (uint64_t)rhs;
-    case arith::CmpIPredicate::ugt:
-      return (uint64_t)lhs > (uint64_t)rhs;
-    case arith::CmpIPredicate::uge:
-      return (uint64_t)lhs >= (uint64_t)rhs;
-    default:
-      break;
-    }
-    llvm_unreachable("unknown comparison predicate");
-  }
 };
 
 template <typename OpTy>
@@ -1000,90 +990,34 @@ public:
   AxisInfo
   getAxisInfo(OpTy op,
               ArrayRef<const dataflow::Lattice<AxisInfo> *> operands) override {
-    auto condConstancy = operands[0]->getValue().getConstancy();
-    auto lhsInfo = operands[1]->getValue();
-    auto rhsInfo = operands[2]->getValue();
-    auto rank = lhsInfo.getRank();
+    const AxisInfo &condInfo = operands[0]->getValue();
+    const AxisInfo &lhsInfo = operands[1]->getValue();
+    const AxisInfo &rhsInfo = operands[2]->getValue();
+    if (const auto &condition = condInfo.getConstantValue())
+      return condition->isZero() ? rhsInfo : lhsInfo;
+
+    // The condition can be either a tensor or i1.
+    // If i1 is used as the condition, the entire tensor of either
+    // lhs or rhs is selected.
+    if (isa<IntegerType>(op.getOperand(0).getType()))
+      return AxisInfo::join(lhsInfo, rhsInfo);
 
     AxisInfo::DimVectorT contiguity, divisibility, constancy;
-    std::optional<int64_t> constantValue;
-    if (operands[0]->getValue().getConstantValue().has_value()) {
-      if (operands[0]->getValue().getConstantValue() == 0) {
-        contiguity = rhsInfo.getContiguity();
-        divisibility = rhsInfo.getDivisibility();
-        constancy = rhsInfo.getConstancy();
-        constantValue = rhsInfo.getConstantValue();
-      } else {
-        contiguity = lhsInfo.getContiguity();
-        divisibility = lhsInfo.getDivisibility();
-        constancy = lhsInfo.getConstancy();
-        constantValue = lhsInfo.getConstantValue();
-      }
-    } else {
-      // The condition can be either a tensor or i1.
-      // If i1 is used as the condition, the entire tensor of either
-      // lhs or rhs is selected.
-      bool i1Cond = isa<IntegerType>(op.getOperand(0).getType());
-      for (auto d = 0; d < rank; ++d) {
-        if (i1Cond) {
-          constancy.push_back(
-              gcd(lhsInfo.getConstancy(d), rhsInfo.getConstancy(d)));
-          divisibility.push_back(
-              getDivisibilityFromContiguity(lhsInfo, rhsInfo, d));
-          contiguity.push_back(
-              gcd(lhsInfo.getContiguity(d), rhsInfo.getContiguity(d)));
-        } else {
-          constancy.push_back(gcd(lhsInfo.getConstancy(d),
-                                  rhsInfo.getConstancy(d), condConstancy[d]));
-          contiguity.push_back(gcd(lhsInfo.getContiguity(d),
-                                   rhsInfo.getContiguity(d), condConstancy[d]));
-          // getDivisibilityFromContiguity does not see condConstancy; clamp
-          // by the just-computed output contiguity so the result remains
-          // sound when condConstancy reduces it below the input contiguities.
-          divisibility.push_back(
-              gcd(getDivisibilityFromContiguity(lhsInfo, rhsInfo, d),
-                  contiguity.back()));
-        }
-      }
-      if (lhsInfo.getConstantValue().has_value() &&
-          rhsInfo.getConstantValue().has_value() &&
-          lhsInfo.getConstantValue() == rhsInfo.getConstantValue())
-        constantValue = lhsInfo.getConstantValue();
-
-      if (constantValue.has_value()) {
-        auto resTy = dyn_cast<RankedTensorType>(op.getType());
-        assert(resTy || rank == 1);
-        constancy =
-            resTy ? to_vector(resTy.getShape()) : AxisInfo::DimVectorT(rank, 1);
-      }
+    for (int d = 0; d < lhsInfo.getRank(); ++d) {
+      constancy.push_back(gcd(lhsInfo.getConstancy(d), rhsInfo.getConstancy(d),
+                              condInfo.getConstancy(d)));
+      contiguity.push_back(gcd(lhsInfo.getContiguity(d),
+                               rhsInfo.getContiguity(d),
+                               condInfo.getConstancy(d)));
+      // getDivisibilityFromContiguity does not see condConstancy; clamp
+      // by the just-computed output contiguity so the result remains
+      // sound when condConstancy reduces it below the input contiguities.
+      divisibility.push_back(
+          gcd(getDivisibilityFromContiguity(lhsInfo, rhsInfo, d),
+              contiguity.back()));
     }
 
-    return AxisInfo(contiguity, divisibility, constancy, constantValue);
-  }
-};
-
-template <typename OpTy>
-class LogicalOpAxisInfoVisitor final : public BinaryOpVisitorImpl<OpTy> {
-public:
-  using BinaryOpVisitorImpl<OpTy>::BinaryOpVisitorImpl;
-
-private:
-  std::optional<int64_t> getConstantValue(OpTy op, const AxisInfo &lhs,
-                                          const AxisInfo &rhs) override {
-    if (lhs.getConstantValue().has_value() &&
-        rhs.getConstantValue().has_value()) {
-      if constexpr (std::is_same_v<OpTy, arith::AndIOp>) {
-        return {lhs.getConstantValue().value() &
-                rhs.getConstantValue().value()};
-      } else if constexpr (std::is_same_v<OpTy, arith::OrIOp>) {
-        return {lhs.getConstantValue().value() |
-                rhs.getConstantValue().value()};
-      } else if constexpr (std::is_same_v<OpTy, arith::XOrIOp>) {
-        return {lhs.getConstantValue().value() ^
-                rhs.getConstantValue().value()};
-      }
-    }
-    return {};
+    return AxisInfo(contiguity, divisibility, constancy);
   }
 };
 
@@ -1094,8 +1028,7 @@ public:
 private:
   int64_t getContiguity(arith::ShLIOp op, const AxisInfo &lhs,
                         const AxisInfo &rhs, int dim) override {
-    if (rhs.getConstantValue().has_value() &&
-        rhs.getConstantValue().value() == 0)
+    if (rhs.getConstantValue() && rhs.getConstantValue()->isZero())
       return lhs.getContiguity(dim);
     else
       return 1;
@@ -1103,21 +1036,18 @@ private:
 
   int64_t getDivisibility(arith::ShLIOp op, const AxisInfo &lhs,
                           const AxisInfo &rhs, int dim) override {
-    auto shift = rhs.getConstantValue().value_or(0);
+    const auto &amount = rhs.getConstantValue();
     auto lhsDivisibility = lhs.getDivisibility(dim);
-    if (lhs.getContiguity(dim) > 1 && shift) {
+    if (lhs.getContiguity(dim) > 1 && (!amount || !amount->isZero())) {
       // Treat [2^n,2^n+1,...]'s divisibility as 1 instead of 2^n
       lhsDivisibility = 1;
     }
-    return multiplyDivisor(lhsDivisibility, 1ll << shift);
-  }
-
-  std::optional<int64_t> getConstantValue(arith::ShLIOp op, const AxisInfo &lhs,
-                                          const AxisInfo &rhs) override {
-    if (lhs.getConstantValue().has_value() &&
-        rhs.getConstantValue().has_value())
-      return {lhs.getConstantValue().value() << rhs.getConstantValue().value()};
-    return {};
+    if (!amount)
+      return lhsDivisibility;
+    if (amount->uge(getIntegerBitWidth(op.getType())))
+      return 1;
+    unsigned shift = amount->getLimitedValue(kMaxDivisorLog2);
+    return multiplyDivisor(lhsDivisibility, int64_t{1} << shift);
   }
 };
 
@@ -1129,8 +1059,7 @@ public:
 private:
   int64_t getContiguity(OpTy op, const AxisInfo &lhs, const AxisInfo &rhs,
                         int dim) override {
-    if (rhs.getConstantValue().has_value() &&
-        rhs.getConstantValue().value() == 0)
+    if (rhs.getConstantValue() && rhs.getConstantValue()->isZero())
       return lhs.getContiguity(dim);
     else
       return 1;
@@ -1138,23 +1067,16 @@ private:
 
   int64_t getDivisibility(OpTy op, const AxisInfo &lhs, const AxisInfo &rhs,
                           int dim) override {
-    if (!rhs.getConstantValue().has_value())
+    const auto &amount = rhs.getConstantValue();
+    if (!amount || amount->uge(getIntegerBitWidth(op.getType())))
       return 1;
-    auto shift = rhs.getConstantValue().value();
     auto lhsDivisibility = lhs.getDivisibility(dim);
-    if (lhs.getContiguity(dim) > 1 && shift) {
+    if (lhs.getContiguity(dim) > 1 && !amount->isZero()) {
       // Treat [2^n,2^n+1,...]'s divisibility as 1 instead of 2^n
       lhsDivisibility = 1;
     }
-    return std::max<int64_t>(1, lhsDivisibility / (int64_t(1) << shift));
-  }
-
-  std::optional<int64_t> getConstantValue(OpTy op, const AxisInfo &lhs,
-                                          const AxisInfo &rhs) override {
-    if (lhs.getConstantValue().has_value() &&
-        rhs.getConstantValue().has_value())
-      return {lhs.getConstantValue().value() >> rhs.getConstantValue().value()};
-    return {};
+    unsigned shift = amount->getLimitedValue(kMaxDivisorLog2);
+    return std::max<int64_t>(1, lhsDivisibility >> shift);
   }
 };
 
@@ -1166,43 +1088,7 @@ public:
   AxisInfo
   getAxisInfo(OpTy op,
               ArrayRef<const dataflow::Lattice<AxisInfo> *> operands) override {
-    auto lhsInfo = operands[0]->getValue();
-    auto rhsInfo = operands[1]->getValue();
-    auto rank = lhsInfo.getRank();
-    std::optional<int64_t> constantValue;
-    if (lhsInfo.getConstantValue().has_value() &&
-        rhsInfo.getConstantValue().has_value()) {
-      if constexpr (std::is_same_v<OpTy, arith::MaxSIOp> ||
-                    std::is_same_v<OpTy, arith::MaxUIOp>) {
-        constantValue = {std::max(lhsInfo.getConstantValue().value(),
-                                  rhsInfo.getConstantValue().value())};
-      } else if constexpr (std::is_same_v<OpTy, arith::MinSIOp> ||
-                           std::is_same_v<OpTy, arith::MinUIOp>) {
-        constantValue = {std::min(lhsInfo.getConstantValue().value(),
-                                  rhsInfo.getConstantValue().value())};
-      }
-      auto resTy = dyn_cast<RankedTensorType>(op.getType());
-      assert(resTy || rank == 1);
-      AxisInfo::DimVectorT constancy =
-          resTy ? to_vector(resTy.getShape()) : AxisInfo::DimVectorT(rank, 1);
-      AxisInfo::DimVectorT divisibility(
-          rank, highestPowOf2Divisor<int64_t>(constantValue.value()));
-      return AxisInfo(/*knownContiguity=*/AxisInfo::DimVectorT(rank, 1),
-                      /*knownDivisibility=*/divisibility,
-                      /*knownConstancy=*/constancy,
-                      /*constantValue=*/constantValue);
-    } else {
-      AxisInfo::DimVectorT contiguity, divisibility, constancy;
-      for (auto d = 0; d < rank; ++d) {
-        constancy.push_back(
-            gcd(lhsInfo.getConstancy(d), rhsInfo.getConstancy(d)));
-        divisibility.push_back(
-            getDivisibilityFromContiguity(lhsInfo, rhsInfo, d));
-        contiguity.push_back(
-            gcd(lhsInfo.getContiguity(d), rhsInfo.getContiguity(d)));
-      }
-      return AxisInfo(contiguity, divisibility, constancy, std::nullopt);
-    }
+    return AxisInfo::join(operands[0]->getValue(), operands[1]->getValue());
   }
 };
 
@@ -1257,7 +1143,6 @@ AxisInfoAnalysis::AxisInfoAnalysis(DataFlowSolver &solver)
                   IdentityOpAxisInfoVisitor<triton::gluon::SetAutoLayoutOp>>();
   visitors.append<MakeRangeOpAxisInfoVisitor>();
   visitors.append<PoisonOpAxisInfoVisitor>();
-  visitors.append<ConstantOpAxisInfoVisitor>();
   visitors.append<AddSubOpAxisInfoVisitor<triton::AddPtrOp>,
                   AddSubOpAxisInfoVisitor<arith::AddIOp>,
                   AddSubOpAxisInfoVisitor<arith::SubIOp>>();
@@ -1271,9 +1156,9 @@ AxisInfoAnalysis::AxisInfoAnalysis(DataFlowSolver &solver)
   visitors.append<ExpandDimsOpAxisInfoVisitor>();
   visitors.append<ReshapeOpAxisInfoVisitor>();
   visitors.append<CmpOpAxisInfoVisitor<arith::CmpIOp>>();
-  visitors.append<LogicalOpAxisInfoVisitor<arith::AndIOp>,
-                  LogicalOpAxisInfoVisitor<arith::OrIOp>,
-                  LogicalOpAxisInfoVisitor<arith::XOrIOp>>();
+  visitors.append<BinaryOpVisitorImpl<arith::AndIOp>,
+                  BinaryOpVisitorImpl<arith::OrIOp>,
+                  BinaryOpVisitorImpl<arith::XOrIOp>>();
   visitors.append<SelectOpAxisInfoVisitor<mlir::arith::SelectOp>>();
   visitors.append<ShLIOpAxisInfoVisitor, ShROpAxisInfoVisitor<arith::ShRUIOp>,
                   ShROpAxisInfoVisitor<arith::ShRSIOp>>();
@@ -1304,11 +1189,32 @@ void AxisInfoAnalysis::visitNonControlFlowArguments(
 LogicalResult AxisInfoAnalysis::visitOperation(
     Operation *op, ArrayRef<const dataflow::Lattice<AxisInfo> *> operands,
     ArrayRef<dataflow::Lattice<AxisInfo> *> results) {
+  if (results.empty())
+    return success();
   // If any operands are not yet ready, skip this operation for now.
   for (auto op : operands)
     if (op->getValue().getRank() == 0)
       return success();
-  AxisInfo curr = visitors.apply(op, operands);
+  AxisInfo curr;
+  if (ConstantInt constant = evaluateConstant(op, operands))
+    curr = AxisInfo::getConstantValueState(op->getResult(0).getType(),
+                                           std::move(*constant));
+  else {
+    curr = visitors.apply(op, operands);
+    if (const auto &constant = curr.getConstantValue()) {
+      if (op->getNumResults() == 1 &&
+          getIntegerBitWidth(op->getResult(0).getType()) ==
+              constant->getBitWidth()) {
+        // Shape and layout operations can forward a known splat. Recover its
+        // strongest bounds for the result shape.
+        curr = AxisInfo::getConstantValueState(op->getResult(0).getType(),
+                                               *constant);
+      } else {
+        curr = AxisInfo(curr.getContiguity(), curr.getDivisibility(),
+                        curr.getConstancy());
+      }
+    }
+  }
   if (curr.getRank() == 0) {
     setAllToEntryStates(results);
     return success();
@@ -1413,6 +1319,22 @@ void AxisInfo::initDimVectorFromHint(Attribute attr, DimVectorT *vec) {
   return AxisInfo(knownContiguity, knownDivisibility, knownConstancy);
 }
 
+/*static*/ AxisInfo AxisInfo::getConstantValueState(Type type, APInt value) {
+  assert(cast<IntegerType>(getElementTypeOrSelf(type)).getWidth() ==
+             value.getBitWidth() &&
+         "constant width must match the result type");
+  auto tensorType = dyn_cast<RankedTensorType>(type);
+  DimVectorT constancy =
+      tensorType ? to_vector(tensorType.getShape()) : DimVectorT(1, 1);
+  unsigned rank = constancy.size();
+  int64_t divisibility =
+      value.isZero()
+          ? kMaxDivisor
+          : int64_t{1} << std::min(value.countr_zero(), kMaxDivisorLog2);
+  return AxisInfo(DimVectorT(rank, 1), DimVectorT(rank, divisibility),
+                  constancy, std::move(value));
+}
+
 /*static*/ AxisInfo AxisInfo::join(const AxisInfo &lhs, const AxisInfo &rhs) {
   // If one argument is not initialized, return the other.
   if (lhs.getRank() == 0)
@@ -1428,12 +1350,15 @@ void AxisInfo::initDimVectorFromHint(Attribute attr, DimVectorT *vec) {
     divisibility.push_back(getDivisibilityFromContiguity(lhs, rhs, d));
     constancy.push_back(gcd(lhs.getConstancy(d), rhs.getConstancy(d)));
   }
-  std::optional<int64_t> constantValue;
-  if (lhs.getConstantValue().has_value() &&
-      rhs.getConstantValue().has_value() &&
-      lhs.getConstantValue() == rhs.getConstantValue())
-    constantValue = lhs.getConstantValue();
-  return AxisInfo(contiguity, divisibility, constancy, constantValue);
+  ConstantInt constantValue;
+  const auto &lhsConstant = lhs.getConstantValue();
+  const auto &rhsConstant = rhs.getConstantValue();
+  if (lhsConstant && rhsConstant &&
+      lhsConstant->getBitWidth() == rhsConstant->getBitWidth() &&
+      *lhsConstant == *rhsConstant)
+    constantValue = lhsConstant;
+  return AxisInfo(contiguity, divisibility, constancy,
+                  std::move(constantValue));
 }
 
 AxisInfoAnalysis *
@@ -1551,24 +1476,6 @@ void ModuleAxisInfoAnalysis::initialize(
       axisInfo = AxisInfo::getPessimisticValueState(value);
     auto &valInfo = (*axisInfoMap)[value];
     valInfo = AxisInfo::join(axisInfo, valInfo);
-
-    // The axis visitors' integer arithmetic is not always width-aware. Expose
-    // only exact integer/index constants from SCCP to clients that materialize
-    // them. Keep the axis bounds and noninteger values unchanged.
-    if (getElementTypeOrSelf(value.getType()).isIntOrIndex()) {
-      std::optional<int64_t> constantValue;
-      auto *constant =
-          solver->lookupState<dataflow::Lattice<dataflow::ConstantValue>>(
-              value);
-      if (constant && !constant->getValue().isUninitialized()) {
-        APInt intValue;
-        if (matchPattern(constant->getValue().getConstantValue(),
-                         m_ConstantInt(&intValue)))
-          constantValue = intValue.trySExtValue();
-      }
-      valInfo = AxisInfo(valInfo.getContiguity(), valInfo.getDivisibility(),
-                         valInfo.getConstancy(), constantValue);
-    }
   };
   funcOp.walk([&](Operation *op) {
     for (auto value : op->getResults()) {

--- a/lib/Analysis/AxisInfo.cpp
+++ b/lib/Analysis/AxisInfo.cpp
@@ -1,6 +1,8 @@
 #include "triton/Analysis/AxisInfo.h"
+#include "mlir/Analysis/DataFlow/ConstantPropagationAnalysis.h"
 #include "mlir/Analysis/DataFlowFramework.h"
 #include "mlir/Dialect/UB/IR/UBOps.h"
+#include "mlir/IR/Matchers.h"
 #include "triton/Dialect/Gluon/IR/Dialect.h"
 #include "triton/Dialect/Triton/IR/Dialect.h"
 #include "triton/Dialect/Triton/IR/Utility.h"
@@ -1549,6 +1551,24 @@ void ModuleAxisInfoAnalysis::initialize(
       axisInfo = AxisInfo::getPessimisticValueState(value);
     auto &valInfo = (*axisInfoMap)[value];
     valInfo = AxisInfo::join(axisInfo, valInfo);
+
+    // The axis visitors' integer arithmetic is not always width-aware. Expose
+    // only exact integer/index constants from SCCP to clients that materialize
+    // them. Keep the axis bounds and noninteger values unchanged.
+    if (getElementTypeOrSelf(value.getType()).isIntOrIndex()) {
+      std::optional<int64_t> constantValue;
+      auto *constant =
+          solver->lookupState<dataflow::Lattice<dataflow::ConstantValue>>(
+              value);
+      if (constant && !constant->getValue().isUninitialized()) {
+        APInt intValue;
+        if (matchPattern(constant->getValue().getConstantValue(),
+                         m_ConstantInt(&intValue)))
+          constantValue = intValue.trySExtValue();
+      }
+      valInfo = AxisInfo(valInfo.getContiguity(), valInfo.getDivisibility(),
+                         valInfo.getConstancy(), constantValue);
+    }
   };
   funcOp.walk([&](Operation *op) {
     for (auto value : op->getResults()) {

--- a/lib/Analysis/AxisInfo.cpp
+++ b/lib/Analysis/AxisInfo.cpp
@@ -5,6 +5,7 @@
 #include "triton/Dialect/Triton/IR/Dialect.h"
 #include "triton/Dialect/Triton/IR/Utility.h"
 #include "triton/Dialect/TritonGPU/IR/Dialect.h"
+#include "llvm/ADT/APInt.h"
 #include "llvm/ADT/bit.h"
 #include "llvm/Support/Debug.h"
 #include "llvm/Support/raw_ostream.h"
@@ -135,7 +136,47 @@ protected:
 };
 
 template <typename OpTy>
-class CastOpAxisInfoVisitor final : public AxisInfoVisitorImpl<OpTy> {
+class IntegerCastOpAxisInfoVisitor final : public AxisInfoVisitorImpl<OpTy> {
+public:
+  using AxisInfoVisitorImpl<OpTy>::AxisInfoVisitorImpl;
+
+  AxisInfo
+  getAxisInfo(OpTy op,
+              ArrayRef<const dataflow::Lattice<AxisInfo> *> operands) override {
+    AxisInfo info = operands[0]->getValue();
+    auto constant = info.getConstantValue();
+    if (!constant)
+      return info;
+
+    unsigned srcWidth =
+        getElementTypeOrSelf(op.getIn().getType()).getIntOrFloatBitWidth();
+    unsigned dstWidth =
+        getElementTypeOrSelf(op.getType()).getIntOrFloatBitWidth();
+    // Recover the source bits before applying the cast's signedness.
+    APInt value =
+        APInt(64, static_cast<uint64_t>(*constant)).sextOrTrunc(srcWidth);
+    if constexpr (std::is_same_v<OpTy, arith::ExtUIOp>)
+      value = value.zext(dstWidth);
+    else if constexpr (std::is_same_v<OpTy, arith::ExtSIOp>)
+      value = value.sext(dstWidth);
+    else {
+      static_assert(std::is_same_v<OpTy, arith::TruncIOp>);
+      value = value.trunc(dstWidth);
+    }
+
+    // Divisibility is capped at kMaxDivisor, so the low 64 bits suffice even
+    // when the converted constant does not fit in int64_t.
+    int64_t divisibility =
+        highestPowOf2Divisor(value.sextOrTrunc(64).getSExtValue());
+    // The lattice cannot represent every constant wider than 64 bits.
+    return AxisInfo(info.getContiguity(),
+                    AxisInfo::DimVectorT(info.getRank(), divisibility),
+                    info.getConstancy(), value.trySExtValue());
+  }
+};
+
+template <typename OpTy>
+class IdentityOpAxisInfoVisitor final : public AxisInfoVisitorImpl<OpTy> {
 public:
   using AxisInfoVisitorImpl<OpTy>::AxisInfoVisitorImpl;
 
@@ -1206,12 +1247,12 @@ AxisInfoAnalysis::AxisInfoAnalysis(DataFlowSolver &solver)
   // in the process of a PartialConversion, where UnrealizedConversionCast
   // may exist
   visitors.append<UnrealizedConversionCastOpAxisInfoVisitor>();
-  visitors.append<CastOpAxisInfoVisitor<arith::ExtSIOp>,
-                  CastOpAxisInfoVisitor<arith::ExtUIOp>,
-                  CastOpAxisInfoVisitor<arith::TruncIOp>,
-                  CastOpAxisInfoVisitor<triton::gpu::ConvertLayoutOp>,
+  visitors.append<IntegerCastOpAxisInfoVisitor<arith::ExtSIOp>,
+                  IntegerCastOpAxisInfoVisitor<arith::ExtUIOp>,
+                  IntegerCastOpAxisInfoVisitor<arith::TruncIOp>,
+                  IdentityOpAxisInfoVisitor<triton::gpu::ConvertLayoutOp>,
                   BitcastOpAxisInfoVisitor,
-                  CastOpAxisInfoVisitor<triton::gluon::SetAutoLayoutOp>>();
+                  IdentityOpAxisInfoVisitor<triton::gluon::SetAutoLayoutOp>>();
   visitors.append<MakeRangeOpAxisInfoVisitor>();
   visitors.append<PoisonOpAxisInfoVisitor>();
   visitors.append<ConstantOpAxisInfoVisitor>();

--- a/test/Analysis/test-alignment.mlir
+++ b/test/Analysis/test-alignment.mlir
@@ -15,6 +15,42 @@ tt.func @cast() {
 
 // -----
 
+tt.func @integer_cast_constants() {
+  %minus_one = arith.constant -1 : i8
+  // expected-remark @below {{contiguity = [1], divisibility = [1], constancy = [1], constant_value = 255}}
+  %unsigned = arith.extui %minus_one : i8 to i32
+  // expected-remark @below {{contiguity = [1], divisibility = [1], constancy = [1], constant_value = -1}}
+  %signed = arith.extsi %minus_one : i8 to i32
+  // expected-remark @below {{contiguity = [1], divisibility = [1], constancy = [1], constant_value = -1}}
+  %narrow = arith.trunci %unsigned : i32 to i8
+  %true = arith.constant true
+  // expected-remark @below {{constant_value = 1}}
+  %unsigned_bool = arith.extui %true : i1 to i32
+  // expected-remark @below {{constant_value = -1}}
+  %signed_bool = arith.extsi %true : i1 to i32
+  %splat = arith.constant dense<256> : tensor<4xi16>
+  // Truncation to zero improves the known divisibility.
+  // expected-remark @below {{contiguity = [1], divisibility = [4611686018427387904], constancy = [4], constant_value = 0}}
+  %zero = arith.trunci %splat : tensor<4xi16> to tensor<4xi8>
+  tt.return
+}
+
+// -----
+
+tt.func @wide_integer_cast_constants() {
+  %minus_one = arith.constant -1 : i64
+  // expected-remark @below {{constant_value = -1}}
+  %signed = arith.extsi %minus_one : i64 to i128
+  // A positive 2^64 - 1 does not fit AxisInfo's signed constant field.
+  // expected-remark @below {{contiguity = [1], divisibility = [1], constancy = [1], constant_value = <none>}}
+  %unsigned = arith.extui %minus_one : i64 to i128
+  // expected-remark @below {{constant_value = -1}}
+  %narrow = arith.trunci %signed : i128 to i8
+  tt.return
+}
+
+// -----
+
 tt.func @bitcast_pointer_element_width(%arg0: !tt.ptr<f32> {tt.divisibility = 16 : i32}, %arg1: !tt.ptr<i1> {tt.divisibility = 16 : i32}) {
   %range = tt.make_range {end = 128 : i32, start = 0 : i32} : tensor<128xi32>
   %base = tt.splat %arg0 : !tt.ptr<f32> -> tensor<128x!tt.ptr<f32>>

--- a/test/Analysis/test-alignment.mlir
+++ b/test/Analysis/test-alignment.mlir
@@ -7,8 +7,9 @@ tt.func @cast() {
   %0 = arith.extsi %cst : i32 to i64
   // expected-remark @below {{contiguity = [1], divisibility = [1], constancy = [128], constant_value = 1}}
   %cst_tensor = arith.constant dense<1> : tensor<128xi32>
-  // Bitcast preserves axis info for same-width types.
-  // expected-remark @below {{contiguity = [1], divisibility = [1], constancy = [128], constant_value = 1}}
+  // Bitcast preserves axis bounds for same-width types, but float results have
+  // no integer constant.
+  // expected-remark @below {{contiguity = [1], divisibility = [1], constancy = [128], constant_value = <none>}}
   %1 = tt.bitcast %cst_tensor : tensor<128xi32> -> tensor<128xf32>
   tt.return
 }
@@ -41,11 +42,157 @@ tt.func @wide_integer_cast_constants() {
   %minus_one = arith.constant -1 : i64
   // expected-remark @below {{constant_value = -1}}
   %signed = arith.extsi %minus_one : i64 to i128
-  // A positive 2^64 - 1 does not fit AxisInfo's signed constant field.
-  // expected-remark @below {{contiguity = [1], divisibility = [1], constancy = [1], constant_value = <none>}}
+  // The positive 2^64 - 1 remains exact in the wider constant field.
+  // expected-remark @below {{constant_value = 18446744073709551615}}
   %unsigned = arith.extui %minus_one : i64 to i128
   // expected-remark @below {{constant_value = -1}}
+  %round_trip = arith.trunci %unsigned : i128 to i64
+  // expected-remark @below {{constant_value = -1}}
   %narrow = arith.trunci %signed : i128 to i8
+  tt.return
+}
+
+// -----
+
+tt.func @narrow_integer_arithmetic_constants() {
+  %min = arith.constant -128 : i8
+  %one = arith.constant 1 : i8
+  // Wrapping to zero recovers the strongest divisibility.
+  // expected-remark @below {{divisibility = [4611686018427387904], constancy = [1], constant_value = 0}}
+  %sum = arith.addi %min, %min : i8
+  // expected-remark @below {{constant_value = 127}}
+  %difference = arith.subi %min, %one : i8
+  %sixteen = arith.constant dense<16> : tensor<4xi8>
+  // expected-remark @below {{divisibility = [4611686018427387904], constancy = [4], constant_value = 0}}
+  %product = arith.muli %sixteen, %sixteen : tensor<4xi8>
+  // expected-remark @below {{constant_value = 0}}
+  %shift = arith.shli %min, %one : i8
+  tt.return
+}
+
+// -----
+
+tt.func @signed_unsigned_integer_constants() {
+  %negative = arith.constant -7 : i8
+  %one = arith.constant 1 : i8
+  %two = arith.constant 2 : i8
+  // The same i8 bits represent either -7 or 249.
+  // expected-remark @below {{constant_value = -3}}
+  %signed_div = arith.divsi %negative, %two : i8
+  // expected-remark @below {{constant_value = 124}}
+  %unsigned_div = arith.divui %negative, %two : i8
+  // expected-remark @below {{constant_value = -1}}
+  %signed_rem = arith.remsi %negative, %two : i8
+  // expected-remark @below {{constant_value = 1}}
+  %unsigned_rem = arith.remui %negative, %two : i8
+  // expected-remark @below {{constant_value = -4}}
+  %signed_shift = arith.shrsi %negative, %one : i8
+  // expected-remark @below {{constant_value = 124}}
+  %unsigned_shift = arith.shrui %negative, %one : i8
+  // expected-remark @below {{constant_value = -7}}
+  %signed_min = arith.minsi %negative, %two : i8
+  // expected-remark @below {{constant_value = 2}}
+  %unsigned_min = arith.minui %negative, %two : i8
+  // expected-remark @below {{constant_value = 2}}
+  %signed_max = arith.maxsi %negative, %two : i8
+  // expected-remark @below {{constant_value = -7}}
+  %unsigned_max = arith.maxui %negative, %two : i8
+  // expected-remark @below {{constant_value = -1}}
+  %signed_cmp = arith.cmpi slt, %negative, %two : i8
+  // expected-remark @below {{constant_value = 0}}
+  %unsigned_cmp = arith.cmpi ult, %negative, %two : i8
+  tt.return
+}
+
+// -----
+
+tt.func @invalid_integer_constants() {
+  %zero = arith.constant 0 : i8
+  %one = arith.constant 1 : i8
+  %min = arith.constant -128 : i8
+  %minus_one = arith.constant -1 : i8
+  %width = arith.constant 8 : i8
+  // Undefined division and remainder must not produce exact constants.
+  // expected-remark @below {{constant_value = <none>}}
+  %div_zero = arith.divsi %one, %zero : i8
+  // expected-remark @below {{constant_value = <none>}}
+  %rem_zero = arith.remui %one, %zero : i8
+  // expected-remark @below {{constant_value = <none>}}
+  %div_overflow = arith.divsi %min, %minus_one : i8
+  // Unlike signed division, this remainder is defined.
+  // expected-remark @below {{constant_value = 0}}
+  %rem_min = arith.remsi %min, %minus_one : i8
+  // A shift by the element width produces poison.
+  // expected-remark @below {{constant_value = <none>}}
+  %left_overshift = arith.shli %one, %width : i8
+  // expected-remark @below {{constant_value = <none>}}
+  %right_overshift = arith.shrui %one, %width : i8
+  tt.return
+}
+
+// -----
+
+tt.func @integer_overflow_flags() {
+  %zero = arith.constant 0 : i8
+  %one = arith.constant 1 : i8
+  %two = arith.constant 2 : i8
+  %min = arith.constant -128 : i8
+  %max = arith.constant 127 : i8
+  // Each flagged operation rejects the corresponding kind of wrap.
+  // expected-remark @below {{constant_value = <none>}}
+  %signed_add = arith.addi %max, %one overflow<nsw> : i8
+  // expected-remark @below {{constant_value = <none>}}
+  %unsigned_sub = arith.subi %zero, %one overflow<nuw> : i8
+  // expected-remark @below {{constant_value = <none>}}
+  %unsigned_mul = arith.muli %min, %two overflow<nuw> : i8
+  // expected-remark @below {{constant_value = <none>}}
+  %signed_shift = arith.shli %max, %one overflow<nsw> : i8
+  // expected-remark @below {{constant_value = 3}}
+  %valid = arith.addi %one, %two overflow<nsw, nuw> : i8
+  tt.return
+}
+
+// -----
+
+tt.func @integer_exact_flags() {
+  %odd = arith.constant -7 : i8
+  %even = arith.constant -8 : i8
+  %one = arith.constant 1 : i8
+  %two = arith.constant 2 : i8
+  // Exact division and shifts cannot discard nonzero bits.
+  // expected-remark @below {{constant_value = <none>}}
+  %signed_div = arith.divsi %odd, %two exact : i8
+  // expected-remark @below {{constant_value = <none>}}
+  %unsigned_div = arith.divui %odd, %two exact : i8
+  // expected-remark @below {{constant_value = <none>}}
+  %inexact_shift = arith.shrui %odd, %one exact : i8
+  // expected-remark @below {{constant_value = 124}}
+  %valid_div = arith.divui %even, %two exact : i8
+  // expected-remark @below {{constant_value = -4}}
+  %valid_shift = arith.shrsi %even, %one exact : i8
+  tt.return
+}
+
+// -----
+
+tt.func @integer_cast_flags() {
+  %negative = arith.constant -1 : i8
+  %positive = arith.constant 1 : i8
+  %unsigned_byte = arith.constant 255 : i16
+  %signed_byte = arith.constant -1 : i16
+  // expected-remark @below {{constant_value = <none>}}
+  %negative_ext = arith.extui %negative nneg : i8 to i16
+  // expected-remark @below {{constant_value = 1}}
+  %positive_ext = arith.extui %positive nneg : i8 to i16
+  // 255 fits unsigned i8, while -1 fits signed i8.
+  // expected-remark @below {{constant_value = <none>}}
+  %signed_trunc_overflow = arith.trunci %unsigned_byte overflow<nsw> : i16 to i8
+  // expected-remark @below {{constant_value = -1}}
+  %unsigned_trunc = arith.trunci %unsigned_byte overflow<nuw> : i16 to i8
+  // expected-remark @below {{constant_value = <none>}}
+  %unsigned_trunc_overflow = arith.trunci %signed_byte overflow<nuw> : i16 to i8
+  // expected-remark @below {{constant_value = -1}}
+  %signed_trunc = arith.trunci %signed_byte overflow<nsw> : i16 to i8
   tt.return
 }
 
@@ -656,6 +803,9 @@ tt.func @shift(%arg0: i32 {tt.divisibility = 4 : i32}) {
   %5 = arith.shli %1, %2 : tensor<128xi32>
   // expected-remark @below {{contiguity = [1], divisibility = [8], constancy = [128], constant_value = <none>}}
   %6 = arith.shli %1, %s : tensor<128xi32>
+  // Unknown shifts make every range element a group base, including odd ones.
+  // expected-remark @below {{contiguity = [1], divisibility = [1], constancy = [1], constant_value = <none>}}
+  %unknown_left = arith.shli %0, %s : tensor<128xi32>
   // expected-remark @below {{contiguity = [1], divisibility = [1], constancy = [1], constant_value = <none>}}
   %7 = arith.shrsi %0, %s : tensor<128xi32>
   tt.return

--- a/test/Analysis/test-alignment.mlir
+++ b/test/Analysis/test-alignment.mlir
@@ -502,7 +502,7 @@ tt.func @cmp_all_contiguous() {
   %14 = arith.constant dense<8> : tensor<128xi32>
   // expected-remark @below {{contiguity = [1], divisibility = [1], constancy = [8], constant_value = <none>}}
   %15 = arith.cmpi sgt, %14, %0 : tensor<128xi32>
-  // expected-remark @below {{contiguity = [1], divisibility = [1], constancy = [128], constant_value = 1}}
+  // expected-remark @below {{contiguity = [1], divisibility = [1], constancy = [128], constant_value = -1}}
   %16 = arith.cmpi sgt, %14, %1 : tensor<128xi32>
   tt.return
 }
@@ -1280,7 +1280,7 @@ tt.func @cmp_after_max_constancy() {
   %c5 = arith.constant dense<5> : tensor<4xi32>
   %c7 = arith.constant dense<7> : tensor<4xi32>
   %max = arith.maxsi %c5, %c7 : tensor<4xi32>
-  // expected-remark @below {{constancy = [4], constant_value = 1}}
+  // expected-remark @below {{constancy = [4], constant_value = -1}}
   %cmp = arith.cmpi sgt, %max, %c5 : tensor<4xi32>
   tt.return
 }
@@ -1298,7 +1298,7 @@ tt.func public @test_inductor_for() {
   %c1_i32 = arith.constant 1 : i32
   // expected-remark @below {{contiguity = [1], divisibility = [64], constancy = [1], constant_value = 64}}
   %c64_i64 = arith.constant 64 : i64
-  // expected-remark @below {{contiguity = [1], divisibility = [1], constancy = [1], constant_value = <none>}}
+  // expected-remark @below {{contiguity = [1], divisibility = [1], constancy = [1], constant_value = -1}}
   %0 = arith.cmpi slt, %c0_i32, %c1_i32 : i32
 
   // expected-remark @below {{contiguity = [1], divisibility = [64], constancy = [1], constant_value = 64}}

--- a/test/Conversion/tritongpu_to_llvm.mlir
+++ b/test/Conversion/tritongpu_to_llvm.mlir
@@ -27,20 +27,25 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32} {
   tt.func @masked_scalar_i32_constant_fallbacks(%ptr: !tt.ptr<i32>, %out: !tt.ptr<i32>, %mask: i1, %fallback: i32) {
     %zero = arith.constant 0 : i32
     %one = arith.constant 1 : i32
+    %minus_one = arith.constant -1 : i32
     %byte = arith.constant -1 : i8
     %extended = arith.extui %byte : i8 to i32
-    %max = arith.maxui %extended, %one : i32
+    %max = arith.maxui %minus_one, %one : i32
     // CHECK: llvm.inline_asm
-    // CHECK-SAME: mov.u32 $0, $1;\0A\09@$3 ld.global.b32 { $0 }, [ $2 + 0 ];", "=r,r,l,b"
+    // CHECK-SAME: mov.u32 $0, 0x0;\0A\09@$2 ld.global.b32 { $0 }, [ $1 + 0 ];", "=r,l,b"
     %literal = tt.load %ptr, %mask, %zero : !tt.ptr<i32>
     // CHECK: llvm.inline_asm
-    // CHECK-SAME: mov.u32 $0, $1;\0A\09@$3 ld.global.b32 { $0 }, [ $2 + 0 ];", "=r,r,l,b"
+    // CHECK-SAME: mov.u32 $0, 0xff;\0A\09@$2 ld.global.b32 { $0 }, [ $1 + 0 ];", "=r,l,b"
+    %casted = tt.load %ptr, %mask, %extended : !tt.ptr<i32>
+    // CHECK: llvm.inline_asm
+    // CHECK-SAME: mov.u32 $0, 0xffffffff;\0A\09@$2 ld.global.b32 { $0 }, [ $1 + 0 ];", "=r,l,b"
     %computed = tt.load %ptr, %mask, %max : !tt.ptr<i32>
     // CHECK: llvm.inline_asm
     // CHECK-SAME: @$3 ld.global.b32 { $0 }, [ $2 + 0 ];", "=r,0,l,b"
     %dynamic = tt.load %ptr, %mask, %fallback : !tt.ptr<i32>
-    %xor = arith.xori %literal, %computed : i32
-    %value = arith.xori %xor, %dynamic : i32
+    %xor = arith.xori %literal, %casted : i32
+    %xor2 = arith.xori %xor, %computed : i32
+    %value = arith.xori %xor2, %dynamic : i32
     tt.store %out, %value : !tt.ptr<i32>
     tt.return
   }
@@ -274,9 +279,11 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 1 : i32} {
     // CHECK: llvm.inline_asm
     // CHECK-SAME: @$3 ld.global.b32 { $0 }, [ $2 + 0 ];", "=r,0,l,b"
     %dynamic = tt.load %ptrs, %mask, %other : tensor<128x!tt.ptr<i8>, #blocked0>
-    %splat = arith.constant dense<7> : tensor<128xi8, #blocked0>
+    %negative = arith.constant dense<-128> : tensor<128xi8, #blocked0>
+    %one = arith.constant dense<1> : tensor<128xi8, #blocked0>
+    %splat = arith.maxui %negative, %one : tensor<128xi8, #blocked0>
     // CHECK: llvm.inline_asm
-    // CHECK-SAME: mov.u32 $0, 0x7070707;\0A\09@$2 ld.global.b32 { $0 }, [ $1 + 0 ];", "=r,l,b"
+    // CHECK-SAME: mov.u32 $0, 0x80808080;\0A\09@$2 ld.global.b32 { $0 }, [ $1 + 0 ];", "=r,l,b"
     %constant = tt.load %ptrs, %mask, %splat : tensor<128x!tt.ptr<i8>, #blocked0>
     %values = arith.xori %dynamic, %constant : tensor<128xi8, #blocked0>
     tt.store %ptrs, %values, %mask : tensor<128x!tt.ptr<i8>, #blocked0>

--- a/third_party/nvidia/lib/TritonNVIDIAGPUToLLVM/LoadStoreOpToLLVM.cpp
+++ b/third_party/nvidia/lib/TritonNVIDIAGPUToLLVM/LoadStoreOpToLLVM.cpp
@@ -229,6 +229,7 @@ struct LoadOpConversion : public ConvertOpToLLVMPattern<triton::LoadOp>,
       const size_t nWords = std::max<size_t>(1, totalWidth / width);
       const size_t wordNElems = width / valueElemNBits;
       const size_t movWidth = width < 16 ? 16 : width;
+      assert(movWidth <= 64 && "load words must be at most 64 bits");
       assert(wordNElems * nWords * numVecs == numElems);
 
       PTXBuilder ptxBuilder;
@@ -253,7 +254,7 @@ struct LoadOpConversion : public ConvertOpToLLVMPattern<triton::LoadOp>,
       if (other) {
         for (size_t ii = 0; ii < nWords; ++ii) {
           PTXInstr::Operand *opr{};
-          if (otherConstInt && movWidth <= 64) {
+          if (otherConstInt) {
             // Pack the declared element bits into their physical slots.
             APInt bits = otherConstInt->zextOrTrunc(valueElemNBits);
             APInt packed = APInt::getSplat(movWidth, bits);

--- a/third_party/nvidia/lib/TritonNVIDIAGPUToLLVM/LoadStoreOpToLLVM.cpp
+++ b/third_party/nvidia/lib/TritonNVIDIAGPUToLLVM/LoadStoreOpToLLVM.cpp
@@ -21,6 +21,7 @@
 #include "triton/Dialect/TritonGPU/Transforms/Utility.h"
 #include "triton/Dialect/TritonNvidiaGPU/Transforms/TMAUtilities.h"
 #include "triton/Tools/LayoutUtils.h"
+#include "llvm/ADT/APInt.h"
 
 #include <cassert>
 
@@ -158,8 +159,8 @@ struct LoadOpConversion : public ConvertOpToLLVMPattern<triton::LoadOp>,
     Value llOther = adaptor.getOther();
 
     // Determine the vectorization size
-    Type valueElemTy =
-        typeConverter->convertType(getElementTypeOrSelf(op.getType()));
+    Type elemTy = getElementTypeOrSelf(op.getType());
+    Type valueElemTy = typeConverter->convertType(elemTy);
     unsigned vec = getVectorSize(ptr);
     unsigned numElems = getUniqueElemsPerThread(ptr.getType());
     unsigned vecOrig = vec;
@@ -190,24 +191,15 @@ struct LoadOpConversion : public ConvertOpToLLVMPattern<triton::LoadOp>,
     }
 
     // Get the LLVM values for `other`
-    // TODO: (goostavz) handle when other is const but not splat, which
-    //       should be rarely seen
-    bool otherIsSplatConstInt = false;
-    DenseElementsAttr constAttr;
-    int64_t splatVal = 0;
-    if (other && isa<IntegerType>(valueElemTy) &&
-        matchPattern(other, m_Constant(&constAttr)) && constAttr.isSplat() &&
-        isa<IntegerType>(constAttr.getElementType())) {
-      otherIsSplatConstInt = true;
-      splatVal = constAttr.getSplatValue<APInt>().getSExtValue();
-    }
-    // Preserve the existing initialization of proven integer constants.
-    // Tying them can add a dependency on a materialized constant register.
-    auto *otherInfo = other ? axisAnalysisPass.getAxisInfo(other) : nullptr;
-    bool otherIsConstInt = otherInfo && isa<IntegerType>(valueElemTy) &&
-                           otherInfo->getConstantValue().has_value();
+    std::optional<int64_t> otherConstInt;
     SmallVector<Value> otherElems;
     if (other) {
+      // Use immediates for proven integer constants.
+      // Tying them can add a dependency on a materialized constant register.
+      // Check the original type because FP8 can lower to i8.
+      if (isa<IntegerType>(elemTy))
+        if (auto *otherInfo = axisAnalysisPass.getAxisInfo(other))
+          otherConstInt = otherInfo->getConstantValue();
       otherElems = unpackUniqueTensorElements(loc, llOther, rewriter);
     }
 
@@ -272,7 +264,7 @@ struct LoadOpConversion : public ConvertOpToLLVMPattern<triton::LoadOp>,
           }
           v = b.bitcast(v, IntegerType::get(getContext(), width));
 
-          if (!otherIsConstInt && (width == 32 || width == 64)) {
+          if (!otherConstInt && (width == 32 || width == 64)) {
             // Match each fallback to its destination instead of moving it.
             // The packed value and destination have the same register width.
             ptxBuilder.newOperand(v, std::to_string(dstsOpr->listGet(ii)->idx));
@@ -285,12 +277,14 @@ struct LoadOpConversion : public ConvertOpToLLVMPattern<triton::LoadOp>,
 
           PTXInstr::Operand *opr{};
 
-          if (otherIsSplatConstInt) {
-            int64_t replicatedSplatVal = 0;
-            for (size_t s = 0; s < movWidth; s += valueElemNBits) {
-              replicatedSplatVal |= splatVal << s;
-            }
-            opr = ptxBuilder.newConstantOperand(replicatedSplatVal);
+          if (otherConstInt && movWidth <= 64) {
+            // Pack the declared element bits, not a sign-extended int64_t.
+            APInt bits = APInt(64, static_cast<uint64_t>(*otherConstInt))
+                             .sextOrTrunc(elemTy.getIntOrFloatBitWidth())
+                             .zextOrTrunc(valueElemNBits);
+            APInt packed = APInt::getSplat(movWidth, bits);
+            opr = ptxBuilder.newConstantOperand(
+                packed.zextOrTrunc(64).getSExtValue());
           } else
             opr = ptxBuilder.newOperand(v, readConstraint);
 

--- a/third_party/nvidia/lib/TritonNVIDIAGPUToLLVM/LoadStoreOpToLLVM.cpp
+++ b/third_party/nvidia/lib/TritonNVIDIAGPUToLLVM/LoadStoreOpToLLVM.cpp
@@ -191,7 +191,7 @@ struct LoadOpConversion : public ConvertOpToLLVMPattern<triton::LoadOp>,
     }
 
     // Get the LLVM values for `other`
-    std::optional<int64_t> otherConstInt;
+    std::optional<APInt> otherConstInt;
     SmallVector<Value> otherElems;
     if (other) {
       // Use immediates for proven integer constants.
@@ -252,42 +252,31 @@ struct LoadOpConversion : public ConvertOpToLLVMPattern<triton::LoadOp>,
 
       if (other) {
         for (size_t ii = 0; ii < nWords; ++ii) {
-          size_t size = width / valueElemNBits;
-
-          auto vecTy = LLVM::getVectorType(valueElemTy, size);
-          Value v = b.undef(vecTy);
-          for (size_t s = 0; s < size; ++s) {
-            Value falseVal = otherElems[vecStart + ii * size + s];
-            Value sVal = createIndexAttrConstant(
-                rewriter, loc, typeConverter->getIndexType(), s);
-            v = b.insert_element(vecTy, v, falseVal, sVal);
-          }
-          v = b.bitcast(v, IntegerType::get(getContext(), width));
-
-          if (!otherConstInt && (width == 32 || width == 64)) {
-            // Match each fallback to its destination instead of moving it.
-            // The packed value and destination have the same register width.
-            ptxBuilder.newOperand(v, std::to_string(dstsOpr->listGet(ii)->idx));
-            continue;
+          PTXInstr::Operand *opr{};
+          if (otherConstInt && movWidth <= 64) {
+            // Pack the declared element bits into their physical slots.
+            APInt bits = otherConstInt->zextOrTrunc(valueElemNBits);
+            APInt packed = APInt::getSplat(movWidth, bits);
+            opr = ptxBuilder.newConstantOperand(
+                packed.zextOrTrunc(64).getSExtValue());
+          } else {
+            auto elems = ArrayRef<Value>(otherElems)
+                             .slice(vecStart + ii * wordNElems, wordNElems);
+            Value v = b.bitcast(packLLVector(loc, elems, rewriter),
+                                IntegerType::get(getContext(), width));
+            if (width == 32 || width == 64) {
+              // Match each fallback to its destination instead of moving it.
+              // The packed value and destination have the same register width.
+              ptxBuilder.newOperand(v,
+                                    std::to_string(dstsOpr->listGet(ii)->idx));
+              continue;
+            }
+            opr = ptxBuilder.newOperand(v, readConstraint);
           }
 
           // PTX doesn't support mov.u8, so we need to use mov.u16
           PTXInstr &mov =
               ptxBuilder.create("mov")->o("u" + std::to_string(movWidth));
-
-          PTXInstr::Operand *opr{};
-
-          if (otherConstInt && movWidth <= 64) {
-            // Pack the declared element bits, not a sign-extended int64_t.
-            APInt bits = APInt(64, static_cast<uint64_t>(*otherConstInt))
-                             .sextOrTrunc(elemTy.getIntOrFloatBitWidth())
-                             .zextOrTrunc(valueElemNBits);
-            APInt packed = APInt::getSplat(movWidth, bits);
-            opr = ptxBuilder.newConstantOperand(
-                packed.zextOrTrunc(64).getSExtValue());
-          } else
-            opr = ptxBuilder.newOperand(v, readConstraint);
-
           mov(dstsOpr->listGet(ii), opr);
         }
       }


### PR DESCRIPTION
The previous implementation used `int64_t` which was quite loose at times.
We move to APInt to get a correct propagation. We then use this result in the
`load/store` lowering to generalise it and simplify it.
