### PR TITLE
[GSan] Isolate cluster clock publications

### DIFF
--- a/python/test/gsan/test_gsan.py
+++ b/python/test/gsan/test_gsan.py
@@ -519,6 +519,45 @@ def test_gluon_mbarrier_wait_acquires_arrival_vector_clocks(with_gsan):
 
 
 @gluon.jit
+def _gluon_mbarrier_retains_atomic_release_kernel(payload_ptr, flag_ptr, out_ptr, ITERATIONS: gl.constexpr):
+    layout: gl.constexpr = gl.BlockedLayout([1], [32], [4], [0], cga_layout=[[1]])
+    offsets = gl.arange(0, 256, layout)
+    producer = offsets == 128
+    consumer = offsets == 0
+
+    barrier = hopper.mbarrier.allocate_mbarrier(two_ctas=True)
+    hopper.mbarrier.init(barrier, count=1)
+    hopper.mbarrier.wait(barrier, phase=1)
+
+    gl.store(payload_ptr + offsets * 0, 41, mask=producer)
+    gl.atomic_xchg(flag_ptr + offsets * 0, 1, sem="release", scope="gpu", mask=producer)
+    for iteration in range(ITERATIONS):
+        hopper.mbarrier.arrive(barrier, count=1)
+        hopper.mbarrier.wait(barrier, phase=iteration & 1)
+        hopper.cluster.barrier(relaxed=True)
+
+    gl.atomic_add(flag_ptr + offsets * 0, 0, sem="acquire", scope="gpu", mask=consumer)
+    value = gl.load(payload_ptr + offsets * 0, mask=consumer, other=0)
+    gl.store(out_ptr + offsets * 0, value + 1, mask=consumer)
+    hopper.mbarrier.invalidate(barrier)
+
+
+@pytest.mark.skipif(not is_hopper_or_newer(), reason="requires Hopper or newer")
+@pytest.mark.parametrize("iterations", [1025, 65536], ids=["atomic-token-survives", "compact-epoch-wraps"])
+def test_gluon_mbarrier_publications_preserve_atomic_releases(with_gsan, iterations):
+    payload = torch.zeros(1, dtype=torch.int32, device="cuda")
+    flag = torch.zeros(1, dtype=torch.int32, device="cuda")
+    out = torch.zeros(1, dtype=torch.int32, device="cuda")
+
+    _gluon_mbarrier_retains_atomic_release_kernel[(1, )](payload, flag, out, ITERATIONS=iterations, num_warps=4,
+                                                        num_ctas=2)
+    torch.cuda.synchronize()
+
+    assert flag.item() == 1
+    assert out.item() == 42
+
+
+@gluon.jit
 def _gluon_ws_mbarrier_partition(payload_ptr, out_ptr, barrier, index: gl.constexpr):
     data_layout: gl.constexpr = gl.BlockedLayout([1], [32], [4], [0], cga_layout=[[1]])
 

--- a/python/triton/experimental/gsan/src/GSan.h
+++ b/python/triton/experimental/gsan/src/GSan.h
@@ -35,10 +35,11 @@ enum class AtomicScope : uint8_t {
   MAX_VALUE = System,
 };
 
-using epoch_t = uint16_t;
+using epoch_t = uint32_t;
+using compact_epoch_t = uint16_t;
 
 struct alignas(4) ScalarClock {
-  epoch_t epoch;
+  compact_epoch_t epoch;
   thread_id_t threadId : 12; // Supports 4096 threads
   AtomicScope scope : 2;
   // For a release write, the epoch is actually an index into the thread's
@@ -92,10 +93,15 @@ struct ThreadState {
   // Reader-writer lock controlling access to the vector clock and clock buffer
   uint32_t lock;
 
+  // Cluster barriers publish frequently, so keep their snapshots separate from
+  // atomic releases that may remain observable for much longer.
+  uint32_t clusterClockBufferHead;
+
   thread_id_t threadId;
 
   // Local vector clock, shape [numThreads]
-  // Followed by the clock buffer, shape [clockBufferSize, numThreads]
+  // Followed by the atomic and cluster clock buffers, each with shape
+  // [clockBufferSize, numThreads].
   epoch_t vectorClock[];
 };
 
@@ -117,13 +123,13 @@ struct alignas(16) ClusterBarrierState {
   uint32_t generation;
   uint32_t registrationGeneration;
   thread_id_t threadIds[kMaxClusterCTAs];
-  epoch_t tokens[kMaxClusterCTAs];
+  compact_epoch_t tokens[kMaxClusterCTAs];
 };
 static_assert(sizeof(ClusterBarrierState) <= kClusterBarrierScratchBytes);
 
 struct MBarrierPublishedClock {
   thread_id_t threadId;
-  epoch_t token;
+  compact_epoch_t token;
 };
 static_assert(sizeof(MBarrierPublishedClock) == 4);
 

--- a/python/triton/experimental/gsan/src/GSanAllocator.cc
+++ b/python/triton/experimental/gsan/src/GSanAllocator.cc
@@ -489,8 +489,8 @@ CUresult ensureRuntimeStateMapped(int device) {
   auto numThreads = config.numThreads;
   assert(numThreads <= gsan::kMaxThreads);
   auto clockSizeBytes = sizeof(gsan::epoch_t) * config.numThreads;
-  // 1 local clock + the circular clock buffer
-  auto clocksPerThread = 1 + config.clockBufferSize;
+  // 1 local clock + separate atomic-release and cluster-barrier buffers.
+  auto clocksPerThread = 1 + 2 * config.clockBufferSize;
   auto perSMStateSize =
       sizeof(gsan::ThreadState) + clockSizeBytes * clocksPerThread;
   perSMStateSize = roundUp(perSMStateSize, alignof(gsan::ThreadState));
@@ -1401,7 +1401,8 @@ PyObject *pyGetRuntimeStateLayout([[maybe_unused]] PyObject *self,
               alignof(gsan::ThreadState));
   size_t threadStateStride =
       sizeof(gsan::ThreadState) +
-      sizeof(gsan::epoch_t) * config.numThreads * (1 + config.clockBufferSize);
+      sizeof(gsan::epoch_t) * config.numThreads *
+          (1 + 2 * config.clockBufferSize);
   threadStateStride = roundUp(threadStateStride, alignof(gsan::ThreadState));
 
   return Py_BuildValue(

--- a/python/triton/experimental/gsan/src/GSanLibrary.cu
+++ b/python/triton/experimental/gsan/src/GSanLibrary.cu
@@ -36,6 +36,8 @@ namespace gsan {
 namespace {
 static constexpr uint32_t kWriterFlag = 1u << 31;
 static constexpr epoch_t kMaxEpoch = static_cast<epoch_t>(~0u);
+static constexpr epoch_t kCompactEpochPeriod =
+    static_cast<compact_epoch_t>(~0u);
 static constexpr uint16_t kMaxUint16 = static_cast<uint16_t>(~0u);
 
 enum class AtomicSem : uint8_t {
@@ -104,7 +106,7 @@ GSAN_DEVICE void syncThreads(uint32_t barrierId, uint32_t numThreads) {
 }
 
 GSAN_DEVICE uintptr_t getThreadStateStrideBytes(GlobalState *globals) {
-  auto clocksPerThread = 1u + globals->clockBufferSize;
+  auto clocksPerThread = 1u + 2u * globals->clockBufferSize;
   return sizeof(ThreadState) +
          sizeof(epoch_t) * globals->numThreads * clocksPerThread;
 }
@@ -146,10 +148,35 @@ GSAN_DEVICE epoch_t *getClockBufferBase(ThreadState *state) {
   return state->vectorClock + globals->numThreads;
 }
 
-GSAN_DEVICE epoch_t *getClockBufferSlot(ThreadState *state, epoch_t token,
+GSAN_DEVICE epoch_t *getClusterClockBufferBase(ThreadState *state) {
+  auto *globals = getGlobalState(state);
+  return getClockBufferBase(state) +
+         globals->clockBufferSize * globals->numThreads;
+}
+
+GSAN_DEVICE compact_epoch_t compactEpoch(epoch_t epoch) {
+  return static_cast<compact_epoch_t>((epoch - 1) % kCompactEpochPeriod + 1);
+}
+
+GSAN_DEVICE epoch_t expandCompactEpoch(compact_epoch_t compact, epoch_t latest,
+                                       Location loc) {
+  assert_msg(loc, compact != 0, "Invalid GSan clock token");
+  assert_msg(loc, latest != 0, "Future GSan clock token");
+  epoch_t generation = (latest - 1) / kCompactEpochPeriod;
+  epoch_t expanded = generation * kCompactEpochPeriod + compact;
+  if (expanded > latest) {
+    assert_msg(loc, generation != 0, "Future GSan clock token");
+    expanded -= kCompactEpochPeriod;
+  }
+  return expanded;
+}
+
+GSAN_DEVICE epoch_t *getClockBufferSlot(ThreadState *state,
+                                        compact_epoch_t compactToken,
                                         Location loc) {
+  epoch_t token =
+      expandCompactEpoch(compactToken, state->clockBufferHead, loc);
   assert_msg(loc, token != 0, "Invalid GSan clock token");
-  assert_msg(loc, token <= state->clockBufferHead, "Future GSan clock token");
   auto *globals = getGlobalState(state);
   assert_msg(loc, state->clockBufferHead - token < globals->clockBufferSize,
              "GSan clock buffer token overwritten");
@@ -157,10 +184,26 @@ GSAN_DEVICE epoch_t *getClockBufferSlot(ThreadState *state, epoch_t token,
   return getClockBufferBase(state) + slot * globals->numThreads;
 }
 
-GSAN_DEVICE epoch_t publishClockBuffer(ThreadState *state, Location loc) {
+GSAN_DEVICE epoch_t *getClusterClockBufferSlot(ThreadState *state,
+                                               compact_epoch_t compactToken,
+                                               Location loc) {
+  epoch_t token =
+      expandCompactEpoch(compactToken, state->clusterClockBufferHead, loc);
+  auto *globals = getGlobalState(state);
+  assert_msg(loc, state->clusterClockBufferHead - token < globals->clockBufferSize,
+             "GSan cluster clock buffer token overwritten");
+  uint32_t slot = token % globals->clockBufferSize;
+  return getClusterClockBufferBase(state) + slot * globals->numThreads;
+}
+
+GSAN_DEVICE compact_epoch_t publishClockBuffer(ThreadState *state,
+                                              Location loc) {
   auto *globals = getGlobalState(state);
   uint32_t nextHead = state->clockBufferHead + 1;
-  assert_msg(loc, nextHead <= kMaxEpoch, "GSan clock buffer token overflowed");
+  // Atomic-release tokens can outlive a compact-token generation. Keep their
+  // identities unambiguous instead of acquiring an unrelated later snapshot.
+  assert_msg(loc, nextHead <= kCompactEpochPeriod,
+             "GSan clock buffer token overflowed");
   epoch_t *slot =
       getClockBufferBase(state) +
       ((nextHead - 1) % globals->clockBufferSize) * globals->numThreads;
@@ -168,7 +211,7 @@ GSAN_DEVICE epoch_t publishClockBuffer(ThreadState *state, Location loc) {
     slot[i] = state->vectorClock[i];
   state->clockBufferHead = nextHead;
   state->clockBufferDirty = 0;
-  return static_cast<epoch_t>(nextHead);
+  return compactEpoch(nextHead);
 }
 
 GSAN_DEVICE AtomicSem decodeAtomicSem(uint32_t sem) {
@@ -317,6 +360,7 @@ GSAN_DEVICE void initThread(GlobalState *globals, uint32_t *streamClocks,
       state->clockBufferDirty = 0;
       state->gdcWaitCalled = 0;
       state->clockBufferHead = 0;
+      state->clusterClockBufferHead = 0;
       state->threadId = getDeviceThreadId(globals, getSmId());
       __scoped_atomic_store_n(&state->globals, globals, __ATOMIC_RELEASE,
                               __MEMORY_SCOPE_DEVICE);
@@ -383,31 +427,32 @@ GSAN_DEVICE void releaseShadow(ShadowCell *cell) {
                           __MEMORY_SCOPE_SYSTEM);
 }
 
-GSAN_DEVICE epoch_t appendClockBufferSnapshot(ThreadState *state,
-                                              const epoch_t *snapshot,
-                                              Location loc) {
+GSAN_DEVICE compact_epoch_t appendClockBufferSnapshot(ThreadState *state,
+                                                      const epoch_t *snapshot,
+                                                      Location loc) {
   auto *globals = getGlobalState(state);
   assert_msg(loc, globals->clockBufferSize != 0,
              "GSan clock buffer size must be non-zero");
   uint32_t curHead = state->clockBufferHead;
   uint32_t nextHead = curHead + 1;
-  assert_msg(loc, nextHead <= kMaxEpoch, "GSan clock buffer token overflowed");
+  assert_msg(loc, nextHead <= kCompactEpochPeriod,
+             "GSan clock buffer token overflowed");
   epoch_t *slot = getClockBufferBase(state) +
                   (nextHead % globals->clockBufferSize) * globals->numThreads;
   for (int i = 0; i < globals->numThreads; ++i)
     slot[i] = snapshot[i];
   state->clockBufferHead = nextHead;
-  return static_cast<epoch_t>(nextHead);
+  return compactEpoch(nextHead);
 }
 
-GSAN_DEVICE epoch_t publishCurrentVectorClock(ThreadState *state,
-                                              Location loc) {
+GSAN_DEVICE compact_epoch_t publishCurrentVectorClock(ThreadState *state,
+                                                       Location loc) {
   if (state->clockBufferDirty) {
     auto token = appendClockBufferSnapshot(state, state->vectorClock, loc);
     state->clockBufferDirty = 0;
     return token;
   }
-  return state->clockBufferHead;
+  return compactEpoch(state->clockBufferHead);
 }
 
 GSAN_DEVICE const epoch_t *getSnapshotForWrite(ThreadState *state,
@@ -419,14 +464,15 @@ GSAN_DEVICE const epoch_t *getSnapshotForWrite(ThreadState *state,
   return getClockBufferSlot(writerState, write.epoch, loc);
 }
 
-GSAN_DEVICE epoch_t publishCurrentVectorClockWithPriorRelease(
+GSAN_DEVICE compact_epoch_t publishCurrentVectorClockWithPriorRelease(
     ThreadState *state, const ScalarClock &previousWrite, Location loc) {
   const auto *previousSnapshot = getSnapshotForWrite(state, previousWrite, loc);
   auto *globals = getGlobalState(state);
   assert_msg(loc, globals->clockBufferSize != 0,
              "GSan clock buffer size must be non-zero");
   uint32_t nextHead = state->clockBufferHead + 1;
-  assert_msg(loc, nextHead <= kMaxEpoch, "GSan clock buffer token overflowed");
+  assert_msg(loc, nextHead <= kCompactEpochPeriod,
+             "GSan clock buffer token overflowed");
   auto *slot = getClockBufferBase(state) +
                (nextHead % globals->clockBufferSize) * globals->numThreads;
   for (int i = 0; i < globals->numThreads; ++i) {
@@ -438,12 +484,11 @@ GSAN_DEVICE epoch_t publishCurrentVectorClockWithPriorRelease(
   // The joined snapshot extends the release sequence without acquiring the
   // prior writer into this thread's vector clock.
   state->clockBufferDirty = 1;
-  return static_cast<epoch_t>(nextHead);
+  return compactEpoch(nextHead);
 }
 
-GSAN_DEVICE epoch_t propagateClockBufferSnapshot(ThreadState *state,
-                                                 const ScalarClock &write,
-                                                 Location loc) {
+GSAN_DEVICE compact_epoch_t propagateClockBufferSnapshot(
+    ThreadState *state, const ScalarClock &write, Location loc) {
   auto *snapshot = getSnapshotForWrite(state, write, loc);
   assert_msg(loc, snapshot != nullptr, "Invalid GSan propagated clock token");
   auto token = appendClockBufferSnapshot(state, snapshot, loc);
@@ -489,7 +534,16 @@ GSAN_DEVICE bool clockHappensBefore(ThreadState *state,
     return true;
   if (const epoch_t *snapshot = getSnapshotForWrite(state, clock, loc))
     return dominatesSnapshot(state, snapshot);
-  return state->vectorClock[clock.threadId] >= clock.epoch;
+  auto *publisher =
+      getThreadStateById(getGlobalState(state), clock.threadId);
+  // The publisher's current epoch is an upper bound on the recorded access.
+  // If an old shadow entry spans multiple compact generations, reconstruction
+  // can report a conservative race but cannot invent a happens-before edge.
+  epoch_t publisherEpoch = __scoped_atomic_load_n(
+      &publisher->vectorClock[clock.threadId], __ATOMIC_RELAXED,
+      __MEMORY_SCOPE_SYSTEM);
+  epoch_t recordedEpoch = expandCompactEpoch(clock.epoch, publisherEpoch, loc);
+  return state->vectorClock[clock.threadId] >= recordedEpoch;
 }
 
 GSAN_DEVICE void assertOrderedOrCompatible(ThreadState *state,
@@ -518,11 +572,21 @@ GSAN_DEVICE void maybeMergeAcquire(ThreadState *state, AtomicScope currentScope,
   mergeVectorClock(state, snapshot);
 }
 
-GSAN_DEVICE epoch_t publishClusterClock(ThreadState *state, Location loc) {
+GSAN_DEVICE compact_epoch_t publishClusterClock(ThreadState *state,
+                                                Location loc) {
   rwLockAcquireWrite(state->lock);
+  auto *globals = getGlobalState(state);
+  epoch_t nextHead = state->clusterClockBufferHead + 1;
+  assert_msg(loc, nextHead != 0,
+             "GSan cluster clock buffer token overflowed");
+  epoch_t *slot = getClusterClockBufferBase(state) +
+                  (nextHead % globals->clockBufferSize) * globals->numThreads;
+  for (int i = 0; i < globals->numThreads; ++i)
+    slot[i] = state->vectorClock[i];
+  state->clusterClockBufferHead = nextHead;
   // Match a release atomic: publish the pre-barrier clock, then advance the
   // local epoch so later accesses are distinct from the published snapshot.
-  epoch_t token = publishCurrentVectorClock(state, loc);
+  compact_epoch_t token = compactEpoch(nextHead);
   incrementThreadEpoch(state, loc);
   rwLockReleaseWrite(state->lock);
   return token;
@@ -539,7 +603,7 @@ GSAN_DEVICE void acquireClusterClocks(const ClusterBarrierState *barrier,
       continue;
     auto *participant = getThreadStateById(globals, threadId);
     const epoch_t *snapshot =
-        getClockBufferSlot(participant, barrier->tokens[ctaRank], loc);
+        getClusterClockBufferSlot(participant, barrier->tokens[ctaRank], loc);
     mergeVectorClock(state, snapshot);
   }
   rwLockReleaseWrite(state->lock);
@@ -585,7 +649,7 @@ GSAN_DEVICE void synchronizeClusterBarrier(GlobalState *globals, void *scratch,
                                 __MEMORY_SCOPE_DEVICE) == generation) {
   }
 
-  epoch_t token = publishClusterClock(state, loc);
+  compact_epoch_t token = publishClusterClock(state, loc);
   clusterLockAcquire(barrier->lock);
   barrier->tokens[ctaRank] = token;
   uint32_t publication = barrier->publicationCount + 1;
@@ -679,6 +743,10 @@ GSAN_DEVICE void recordMBarrierArrival(GlobalState *globals, void *scratch,
              "Invalid GSan mbarrier source CTA rank");
   assert_msg(loc, recipientMask != 0,
              "GSan mbarrier arrival has no recipients");
+  // A CTA already observes its own vector clock. Publishing an arrival that
+  // targets only the issuing CTA consumes an epoch and a snapshot without
+  // establishing any additional happens-before relationship.
+  publishClock = publishClock && (recipientMask & ~(1u << sourceRank)) != 0;
   MBarrierPublishedClock published = {};
   if (publishClock) {
     auto *threadState = getThreadState(globals);
@@ -740,7 +808,7 @@ GSAN_DEVICE void acquireMBarrierPhase(GlobalState *globals, void *scratch,
       continue;
     auto *publisher = getThreadStateById(globals, published.threadId);
     const epoch_t *snapshot =
-        getClockBufferSlot(publisher, published.token, loc);
+        getClusterClockBufferSlot(publisher, published.token, loc);
     mergeVectorClock(threadState, snapshot);
   }
   rwLockReleaseWrite(threadState->lock);
@@ -748,11 +816,12 @@ GSAN_DEVICE void acquireMBarrierPhase(GlobalState *globals, void *scratch,
 
 GSAN_DEVICE ScalarClock makeScalarClock(ThreadState *state, AtomicScope scope) {
   auto tid = state->threadId;
-  return ScalarClock{state->vectorClock[tid], tid, scope, false};
+  return ScalarClock{compactEpoch(state->vectorClock[tid]), tid, scope, false};
 }
 
 GSAN_DEVICE ScalarClock makePublishedClock(ThreadState *state,
-                                           AtomicScope scope, epoch_t token) {
+                                           AtomicScope scope,
+                                           compact_epoch_t token) {
   return ScalarClock{token, state->threadId, scope, true};
 }
 
@@ -981,7 +1050,7 @@ GSAN_DEVICE void endAtomicAccess(AtomicEventState *event, bool pred,
     auto previousWrite = event->cells[0]->writeClock;
     ScalarClock newWriteClock;
     if (hasRelease(sem)) {
-      epoch_t token;
+      compact_epoch_t token;
       if (canAccumulateReleaseRmw(state, scope, previousWrite))
         token = publishCurrentVectorClockWithPriorRelease(state, previousWrite,
                                                           loc);

--- a/python/triton/experimental/gsan/src/gsan_testing.cc
+++ b/python/triton/experimental/gsan/src/gsan_testing.cc
@@ -206,7 +206,7 @@ inline uintptr_t roundUp(uintptr_t ptr, uintptr_t align) {
 }
 
 size_t threadStateStrideBytes(uint16_t numThreads, uint16_t clockBufferSize) {
-  auto clocksPerThread = static_cast<size_t>(1) + clockBufferSize;
+  auto clocksPerThread = static_cast<size_t>(1) + 2 * clockBufferSize;
   auto clockWords = static_cast<size_t>(numThreads) * clocksPerThread;
   return kThreadStateSize + sizeof(gsan::epoch_t) * clockWords;
 }

--- a/test/Conversion/tritonnvidiagpu_to_llvm.mlir
+++ b/test/Conversion/tritonnvidiagpu_to_llvm.mlir
@@ -909,8 +909,9 @@ module attributes {"ttg.num-ctas" = 2 : i32, "ttg.num-warps" = 4 : i32, ttg.shar
   tt.func @cluster_barrier_inside_warp_specialize() {
     ttg.warp_specialize()
     default {
-      // CHECK: nvvm.barrier
+      // CHECK-NOT: nvvm.barrier
       // CHECK: %[[COUNTER:.*]] = llvm.load
+      // CHECK-NEXT: nvvm.barrier
       // CHECK: %[[BARRIER_IDX:.*]] = llvm.and %[[COUNTER]]
       // CHECK: %[[PARITY:.*]] = llvm.lshr %[[COUNTER]]
       // CHECK: %[[BARRIER:.*]] = llvm.getelementptr %{{.*}}[%[[BARRIER_IDX]]]
@@ -920,10 +921,11 @@ module attributes {"ttg.num-ctas" = 2 : i32, "ttg.num-warps" = 4 : i32, ttg.shar
       // CHECK-NOT: mapa
       // CHECK: mbarrier.arrive.release.cluster.shared::cluster.b64
       // CHECK: mbarrier.try_wait.parity.acquire.cluster.shared::cta.b64
+      // CHECK-NOT: nvvm.barrier
       // CHECK: %[[NEXT_COUNTER:.*]] = llvm.add %[[COUNTER]]
       // CHECK: llvm.and %[[NEXT_COUNTER]]
       // CHECK: st.shared::cta.b32
-      // CHECK: nvvm.barrier
+      // CHECK-NEXT: nvvm.barrier
       ttng.cluster_barrier
       ttg.warp_yield
     }
@@ -972,6 +974,10 @@ module attributes {"ttg.num-ctas" = 4 : i32, "ttg.num-warps" = 4 : i32, ttg.shar
   // CHECK: nvvm.barrier
   // RUBIN-LABEL: @cluster_barrier_inside_warp_specialize_rubin
   // RUBIN-COUNT-2: mbarrier.init.shared::cta.b64 [$1], 3;
+  // RUBIN: nvvm.cluster.wait
+  // RUBIN-NOT: nvvm.barrier
+  // RUBIN: %[[RUBIN_COUNTER:.*]] = llvm.load
+  // RUBIN-NEXT: nvvm.barrier
   // RUBIN: %[[CTA:.*]] = nvvm.read.ptx.sreg.cluster.ctarank
   // RUBIN: %[[ALL_CTAS:.*]] = llvm.mlir.constant(15 : i32) : i32
   // RUBIN: %[[SELF_MASK:.*]] = llvm.shl %{{.*}}, %[[CTA]] : i32
@@ -979,6 +985,11 @@ module attributes {"ttg.num-ctas" = 4 : i32, "ttg.num-warps" = 4 : i32, ttg.shar
   // RUBIN-COUNT-1: mbarrier.arrive.release.cluster.shared::cluster.multicast::cluster::32b.b64 _, [$1], $2;
   // RUBIN-NOT: mbarrier.arrive
   // RUBIN: mbarrier.try_wait.parity.acquire.cluster.shared::cta.b64
+  // RUBIN-NOT: nvvm.barrier
+  // RUBIN: %[[RUBIN_NEXT_COUNTER:.*]] = llvm.add %[[RUBIN_COUNTER]]
+  // RUBIN: llvm.and %[[RUBIN_NEXT_COUNTER]]
+  // RUBIN: st.shared::cta.b32
+  // RUBIN-NEXT: nvvm.barrier
   tt.func @cluster_barrier_inside_warp_specialize_rubin() {
     ttg.warp_specialize()
     default {

--- a/third_party/nvidia/lib/TritonNVIDIAGPUToLLVM/ClusterOpsToLLVM.cpp
+++ b/third_party/nvidia/lib/TritonNVIDIAGPUToLLVM/ClusterOpsToLLVM.cpp
@@ -199,8 +199,10 @@ struct ClusterBarrierOpConversion
     auto ptrTy = cast<LLVM::LLVMPointerType>(barrierPtr0.getType());
     Value counterPtr = b.gep(ptrTy, i8_ty, barrierPtr0, LLVM::GEPArg(8));
 
-    NVVM::BarrierOp::create(rewriter, loc);
+    // The WS entry or previous tail barrier publishes the current counter.
+    // Wait for every local thread to read it before the leader can advance it.
     Value counter = b.load(i32_ty, counterPtr);
+    NVVM::BarrierOp::create(rewriter, loc);
     // A delayed CTA can miss a phase if a peer reuses one mbarrier twice
     // before it starts waiting. Alternate two slots so each slot is reused
     // only after an intervening rendezvous. The low counter bit selects the


### PR DESCRIPTION
PR description written by Codex

GSan currently mixes high-frequency cluster and mbarrier snapshots with long-lived atomic-release snapshots, while its 16-bit vector epochs overflow during valid synchronization-heavy kernels. This produces false failures once a live atomic snapshot is displaced or a thread advances beyond 65,535 epochs.

Separate the cluster and atomic snapshot rings, widen internal vector epochs while retaining compact shadow-cell and barrier representations, and omit CTA-local barrier publications that establish no cross-CTA ordering.

The two added regression cases fail on the unmodified runtime after 1,025 and 65,536 barriers and pass with this change. Ten focused GPU tests passed, including genuine RAW, WAR, and WAW race-detection controls; the affected production GB300 kernel also passed.
