### PR TITLE
[NVIDIA] Use native packed BF16/FP8 conversions

### DIFF
--- a/test/Conversion/tritongpu_to_llvm_blackwell_256bit.mlir
+++ b/test/Conversion/tritongpu_to_llvm_blackwell_256bit.mlir
@@ -1,6 +1,7 @@
-// RUN: triton-opt %s -split-input-file --convert-triton-gpu-to-llvm='compute-capability=100 ptx-version=88' -cse | FileCheck --check-prefix=BW256 %s
+// RUN: triton-opt %s -split-input-file --convert-triton-gpu-to-llvm='compute-capability=100 ptx-version=88' -cse | FileCheck --check-prefixes=BW256,FP8,LEGACY %s
 // RUN: triton-opt %s -split-input-file --convert-triton-gpu-to-llvm='compute-capability=103 ptx-version=88' -cse | FileCheck --check-prefix=SM103 %s
 // RUN: triton-opt %s -split-input-file --convert-triton-gpu-to-llvm='compute-capability=90 ptx-version=83' -cse | FileCheck --check-prefixes=PRE_BW,FP8,LEGACY %s
+// RUN: triton-opt %s -split-input-file --convert-triton-gpu-to-llvm='compute-capability=100 ptx-version=91' -cse | FileCheck --check-prefixes=FP8,LEGACY %s
 // RUN: triton-opt %s -split-input-file --convert-triton-gpu-to-llvm='compute-capability=100 ptx-version=92' -cse | FileCheck --check-prefixes=FP8,PACKED %s
 
 // Test 256-bit global load with 8x f32 (v8.b32) on Blackwell
@@ -92,8 +93,8 @@ module attributes {"ttg.target" = "cuda:103", "ttg.num-ctas" = 1 : i32, "ttg.num
 
 // -----
 
-// Blackwell uses native packed BF16/FP8 conversions in both directions.
-// Pre-Blackwell targets retain their existing paths.
+// Blackwell uses native packed BF16/FP8 conversions in both directions with PTX 9.2.
+// Pre-Blackwell targets and older PTX versions retain their existing paths.
 #blocked_fp8 = #ttg.blocked<{sizePerThread = [2], threadsPerWarp = [32], warpsPerCTA = [1], order = [0]}>
 module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 1 : i32} {
   // FP8-LABEL: @bf16_to_fp8e4

--- a/test/Conversion/tritongpu_to_llvm_blackwell_256bit.mlir
+++ b/test/Conversion/tritongpu_to_llvm_blackwell_256bit.mlir
@@ -1,6 +1,7 @@
 // RUN: triton-opt %s -split-input-file --convert-triton-gpu-to-llvm='compute-capability=100 ptx-version=88' -cse | FileCheck --check-prefix=BW256 %s
 // RUN: triton-opt %s -split-input-file --convert-triton-gpu-to-llvm='compute-capability=103 ptx-version=88' -cse | FileCheck --check-prefix=SM103 %s
-// RUN: triton-opt %s -split-input-file --convert-triton-gpu-to-llvm='compute-capability=90 ptx-version=83' -cse | FileCheck --check-prefix=PRE_BW %s
+// RUN: triton-opt %s -split-input-file --convert-triton-gpu-to-llvm='compute-capability=90 ptx-version=83' -cse | FileCheck --check-prefixes=PRE_BW,FP8,LEGACY %s
+// RUN: triton-opt %s -split-input-file --convert-triton-gpu-to-llvm='compute-capability=100 ptx-version=92' -cse | FileCheck --check-prefixes=FP8,PACKED %s
 
 // Test 256-bit global load with 8x f32 (v8.b32) on Blackwell
 #blocked_8xf32 = #ttg.blocked<{sizePerThread = [8], threadsPerWarp = [32], warpsPerCTA = [1], order = [0]}>
@@ -86,5 +87,36 @@ module attributes {"ttg.target" = "cuda:103", "ttg.num-ctas" = 1 : i32, "ttg.num
       tt.reduce.return %1 : f32
     }) {allocation.offset = 0 : i32} : (tensor<1x1024xf32, #blocked_redux_103>) -> tensor<1xf32, #ttg.slice<{dim = 1, parent = #blocked_redux_103}>>
     tt.return
+  }
+}
+
+// -----
+
+// Blackwell uses native packed BF16/FP8 conversions in both directions.
+// Pre-Blackwell targets retain their existing paths.
+#blocked_fp8 = #ttg.blocked<{sizePerThread = [2], threadsPerWarp = [32], warpsPerCTA = [1], order = [0]}>
+module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 1 : i32} {
+  // FP8-LABEL: @bf16_to_fp8e4
+  // PACKED: cvt.rn.satfinite.e4m3x2.bf16x2 $0, $1;", "=h,r"
+  // LEGACY: cvt.rn.satfinite.e4m3x2.f32
+  tt.func private @bf16_to_fp8e4(%in: tensor<64xbf16, #blocked_fp8>) -> tensor<64xf8E4M3FN, #blocked_fp8> {
+    %out = tt.fp_to_fp %in, rounding = rtne : tensor<64xbf16, #blocked_fp8> -> tensor<64xf8E4M3FN, #blocked_fp8>
+    tt.return %out : tensor<64xf8E4M3FN, #blocked_fp8>
+  }
+
+  // FP8-LABEL: @bf16_to_fp8e5
+  // PACKED: cvt.rn.satfinite.e5m2x2.bf16x2 $0, $1;", "=h,r"
+  // LEGACY: cvt.rn.satfinite.e5m2x2.f32
+  tt.func private @bf16_to_fp8e5(%in: tensor<64xbf16, #blocked_fp8>) -> tensor<64xf8E5M2, #blocked_fp8> {
+    %out = tt.fp_to_fp %in, rounding = rtne : tensor<64xbf16, #blocked_fp8> -> tensor<64xf8E5M2, #blocked_fp8>
+    tt.return %out : tensor<64xf8E5M2, #blocked_fp8>
+  }
+
+  // FP8-LABEL: @fp8e4_to_bf16
+  // PACKED: cvt.rn.bf16x2.e4m3x2 $0, $1;", "=r,h"
+  // LEGACY: cvt.rn.f16x2.e4m3x2
+  tt.func private @fp8e4_to_bf16(%in: tensor<64xf8E4M3FN, #blocked_fp8>) -> tensor<64xbf16, #blocked_fp8> {
+    %out = tt.fp_to_fp %in : tensor<64xf8E4M3FN, #blocked_fp8> -> tensor<64xbf16, #blocked_fp8>
+    tt.return %out : tensor<64xbf16, #blocked_fp8>
   }
 }

--- a/third_party/nvidia/lib/TritonNVIDIAGPUToLLVM/ElementwiseOpToLLVM.cpp
+++ b/third_party/nvidia/lib/TritonNVIDIAGPUToLLVM/ElementwiseOpToLLVM.cpp
@@ -348,10 +348,10 @@ struct FpToFpOpConversion
 
   explicit FpToFpOpConversion(LLVMTypeConverter &typeConverter,
                               ModuleAxisInfoAnalysis &axisAnalysisPass,
-                              int computeCapability,
+                              int computeCapability, int ptxVersion,
                               PatternBenefit benefit = patternBenefitDefault)
       : ElementwiseOpConversionBase(typeConverter, axisAnalysisPass, benefit),
-        computeCapability(computeCapability) {}
+        computeCapability(computeCapability), ptxVersion(ptxVersion) {}
 
   static Value convertFp16ToFp32(Location loc,
                                  ConversionPatternRewriter &rewriter,
@@ -419,7 +419,8 @@ struct FpToFpOpConversion
     auto undefRounding = static_cast<RoundingMode>(-1);
 
     // Blackwell and newer can convert packed BF16/FP8 values directly.
-    bool hasPackedBf16 = computeCapability >= 100;
+    // Require PTX 9.2 to support both directions.
+    bool hasPackedBf16 = computeCapability >= 100 && ptxVersion >= 92;
 
     DenseMap<std::tuple<TypeID, TypeID, RoundingMode>, Fp8ConversionDesc>
         srcMap = {
@@ -560,6 +561,7 @@ struct FpToFpOpConversion
 
 private:
   int computeCapability;
+  int ptxVersion;
 };
 
 struct FDivOpConversion
@@ -921,7 +923,8 @@ void mlir::triton::NVIDIA::populateElementwiseOpToLLVMPatterns(
   patterns.add<SIToFPOpConversion>(typeConverter, axisInfoAnalysis,
                                    computeCapability, benefit);
   patterns.add<FpToFpOpConversion>(typeConverter, axisInfoAnalysis,
-                                   computeCapability, benefit);
+                                   computeCapability,
+                                   targetInfo.getPtxVersion(), benefit);
   patterns.add<PackedArithOpConversion>(typeConverter, benefit);
 
   // ExpOpConversionApprox will try using ex2.approx if the input type is

--- a/third_party/nvidia/lib/TritonNVIDIAGPUToLLVM/ElementwiseOpToLLVM.cpp
+++ b/third_party/nvidia/lib/TritonNVIDIAGPUToLLVM/ElementwiseOpToLLVM.cpp
@@ -418,6 +418,9 @@ struct FpToFpOpConversion
 
     auto undefRounding = static_cast<RoundingMode>(-1);
 
+    // Blackwell and newer can convert packed BF16/FP8 values directly.
+    bool hasPackedBf16 = computeCapability >= 100;
+
     DenseMap<std::tuple<TypeID, TypeID, RoundingMode>, Fp8ConversionDesc>
         srcMap = {
             // F8 -> F16
@@ -434,11 +437,20 @@ struct FpToFpOpConversion
              Fp8E5M2_to_Bf16(computeCapability >= 90)},
             // cvt with .bf16.f16' requires .target sm_90 or higher
             {{F8E4M3TyID, BF16TyID, undefRounding},
-             Fp8E4M3Nv_to_Bf16(computeCapability >= 90)},
+             hasPackedBf16
+                 ? Fp8ConversionDesc{"cvt.rn.bf16x2.e4m3x2 $0, $1;", 16, 32, 2}
+                 : Fp8E4M3Nv_to_Bf16(computeCapability >= 90)},
             // BF16 -> F8
             {{BF16TyID, F8E5M2TyID, RoundingMode::RTNE},
-             Bf16_to_Fp8E5M2(computeCapability >= 89)},
-            {{BF16TyID, F8E4M3TyID, RoundingMode::RTNE}, Bf16_to_Fp8E4M3Nv},
+             hasPackedBf16
+                 ? Fp8ConversionDesc{"cvt.rn.satfinite.e5m2x2.bf16x2 $0, $1;",
+                                     32, 16, 2}
+                 : Bf16_to_Fp8E5M2(computeCapability >= 89)},
+            {{BF16TyID, F8E4M3TyID, RoundingMode::RTNE},
+             hasPackedBf16
+                 ? Fp8ConversionDesc{"cvt.rn.satfinite.e4m3x2.bf16x2 $0, $1;",
+                                     32, 16, 2}
+                 : Bf16_to_Fp8E4M3Nv},
             // F32 -> F8
             {{F32TyID, F8E4M3TyID, RoundingMode::RTNE}, Fp32_to_Fp8E4M3Nv},
             {{F32TyID, F8E5M2TyID, RoundingMode::RTNE}, Fp32_to_Fp8E5M2},


### PR DESCRIPTION
Use the packed BF16-to-E4M3/E5M2 and E4M3-to-BF16 instructions on
Blackwell and newer targets.
