### PR TITLE
[release/3.8] Cherry-pick #9035: Force disable slp-copyable-elements

### DIFF
--- a/python/src/llvm.cc
+++ b/python/src/llvm.cc
@@ -666,6 +666,15 @@ void init_triton_llvm(py::module &&m) {
          bool disable_vector_combine) {
         if (mlir::triton::tools::getBoolEnv("DISABLE_LLVM_OPT"))
           return;
+        auto options = llvm::cl::getRegisteredOptions();
+        // Hack for the 3.6 release only. Vectorization of copyable elements
+        // exposed a bug in ptxas. Manually disable it by modifying the command
+        // line option for it. Note that we can abuse DISABLE_LLVM_OPT to
+        // override this, since setting it to slp-copyable-elements will set the
+        // flag back to true.
+        auto it = options.find("slp-copyable-elements");
+        if (it != options.end())
+          *static_cast<llvm::cl::opt<bool> *>(it->second) = false;
         // Check to see if we are passing a list of flags to disable
         // optimizations.
         auto flagList = mlir::triton::tools::getStrEnv("DISABLE_LLVM_OPT");

--- a/python/src/llvm.cc
+++ b/python/src/llvm.cc
@@ -667,7 +667,7 @@ void init_triton_llvm(py::module &&m) {
         if (mlir::triton::tools::getBoolEnv("DISABLE_LLVM_OPT"))
           return;
         auto options = llvm::cl::getRegisteredOptions();
-        // Hack for the 3.6 release only. Vectorization of copyable elements
+        // Hack for the 3.8 release only. Vectorization of copyable elements
         // exposed a bug in ptxas. Manually disable it by modifying the command
         // line option for it. Note that we can abuse DISABLE_LLVM_OPT to
         // override this, since setting it to slp-copyable-elements will set the


### PR DESCRIPTION
## Summary

Backports [#9035](https://github.com/triton-lang/triton/pull/9035) onto `release/3.8.x`.

## Problem

[PyTorch #193183](https://github.com/pytorch/pytorch/issues/193183) is a correctness issue in which PTXAS 12.9 miscompiles a PTX pattern produced after LLVM SLP vectorization. The affected kernels compile successfully but perform incorrect indexing and return wrong results.

## Why this helps

This backport disables `slp-copyable-elements`, removing one SLP vectorization path implicated in producing the problematic code shape. On Triton 3.8, that change is needed alongside [triton-lang/llvm-project#3](https://github.com/triton-lang/llvm-project/pull/3), which gives the relevant division and remainder calculations a different vectorization path. Together they produce PTX that avoids triggering the PTXAS 12.9 bug.

## Validation

This backport alone still failed at `XBLOCK=512` and `1024`. Combining both backports passed every tested `XBLOCK` value from `128` through `4096`.