### PR TITLE
[GSan] Add gsan.reset()

### DIFF
--- a/python/test/gsan/test_allocator.py
+++ b/python/test/gsan/test_allocator.py
@@ -4,15 +4,18 @@ import os
 
 import pytest
 import torch
+import triton
 
 from triton._internal_testing import is_cuda, run_in_process
-from triton.experimental.gsan import ShareableHandleType, configure, create_mem_pool, freeze_config
+from triton.experimental.gsan import ShareableHandleType, configure, create_mem_pool, freeze_config, reset
+from triton.experimental.gsan import _stream_sync
 from triton.experimental.gsan._allocator import (
     export_allocation_handles,
     export_allocation_memhandle_regions,
     export_runtime_state_handle,
     free_allocation,
     get_device_rank,
+    get_global_state_pointer,
     get_reserve_pointer,
     get_reserve_size,
     gsan_free,
@@ -20,7 +23,8 @@ from triton.experimental.gsan._allocator import (
     import_allocation_handles,
     import_runtime_state_handle,
 )
-from triton.experimental.gsan._testing_utils import global_state, shadow_tensor_for
+from triton.experimental.gsan._testing_utils import (global_state, shadow_cell_from_address, shadow_tensor_for,
+                                                     store_one_i32, thread_state_from_smid)
 from triton.experimental.gsan._utils import uint8_cuda_tensor_from_ptr
 
 # With 2 MiB pages, this rounds to a 6 MiB allocation inside an 8 MiB tree node.
@@ -71,6 +75,102 @@ def _run_allocator_freezes_config_check() -> None:
             raise AssertionError("expected allocator initialization to freeze config")
     finally:
         gsan_free(ptr, device, 0, 0)
+
+
+def _run_reset_rejects_live_allocations_check() -> None:
+    device = torch.cuda.current_device()
+    ptr = gsan_malloc(1, device)
+    try:
+        with pytest.raises(AssertionError, match="GSan allocations are still live"):
+            reset()
+    finally:
+        gsan_free(ptr, device)
+
+    reset()
+
+
+def _run_reset_collects_unreachable_allocations_check() -> None:
+    device = torch.cuda.current_device()
+
+    class CyclicAllocation:
+
+        def __init__(self):
+            self.ptr = gsan_malloc(1, device)
+            self.cycle = self
+
+        def __del__(self):
+            gsan_free(self.ptr, device)
+
+    allocation = CyclicAllocation()
+    del allocation
+    reset()
+
+
+def _run_reset_reinitializes_runtime_state_check() -> None:
+    device = torch.cuda.current_device()
+    configure(rng_seed=12345, clock_buffer_size=17)
+    original_state_pointer = get_global_state_pointer()
+
+    ptr = gsan_malloc(4, device)
+    target = uint8_cuda_tensor_from_ptr(ptr, 4, device).view(torch.int32)
+    with triton.knobs.compilation.scope():
+        triton.knobs.compilation.instrumentation_mode = "gsan"
+        store_one_i32[(1, )](target, num_warps=1)
+    torch.cuda.synchronize()
+
+    thread_id = shadow_cell_from_address(ptr).write_clock.thread_id
+    old_thread_state = thread_state_from_smid(thread_id)
+    assert old_thread_state.globals_ptr != 0
+    assert old_thread_state.vector_clock[thread_id] != 0
+    assert _stream_sync._launch_stream_state.cache_info().currsize == 1
+    assert _stream_sync._runtime_state_layout.cache_info().currsize == 1
+
+    del target
+    gsan_free(ptr, device)
+    reset()
+
+    assert get_global_state_pointer() == original_state_pointer
+    assert _stream_sync._launch_stream_state.cache_info().currsize == 0
+    assert _stream_sync._runtime_state_layout.cache_info().currsize == 0
+
+    state = global_state(device_index=device)
+    assert state.rng_seed == 12345
+    assert state.clock_buffer_size == 17
+    with pytest.raises(RuntimeError, match="configuration is already frozen"):
+        configure(rng_seed=12345)
+
+    new_thread_state = thread_state_from_smid(thread_id)
+    assert new_thread_state.globals_ptr == 0
+    assert all(epoch == 0 for epoch in new_thread_state.vector_clock)
+
+    ptr = gsan_malloc(4, device)
+    target = uint8_cuda_tensor_from_ptr(ptr, 4, device).view(torch.int32)
+    try:
+        with triton.knobs.compilation.scope():
+            triton.knobs.compilation.instrumentation_mode = "gsan"
+            store_one_i32[(1, )](target, num_warps=1)
+        torch.cuda.synchronize()
+        stream = torch.cuda.current_stream().cuda_stream
+        assert _stream_sync._launch_stream_state(device, stream).next_kernel_id == 1
+    finally:
+        del target
+        gsan_free(ptr, device)
+
+
+def _run_reset_releases_cached_pool_clocks_check(num_pools: int) -> None:
+    pools = [create_mem_pool() for _ in range(num_pools)]
+    streams = [torch.cuda.Stream() for _ in pools]
+    for pool, stream in zip(pools, streams):
+        with torch.cuda.stream(stream), torch.cuda.use_mem_pool(pool), triton.knobs.compilation.scope():
+            triton.knobs.compilation.instrumentation_mode = "gsan"
+            target = torch.zeros(1, dtype=torch.int32, device="cuda")
+            store_one_i32[(1, )](target, num_warps=1)
+        del target
+    torch.cuda.synchronize()
+
+    del pool
+    del pools
+    reset()
 
 
 def _run_export_import_fabric_handles_check(explicit_config: bool) -> None:
@@ -200,6 +300,31 @@ def test_freeze_config_rejects_later_changes():
 @pytest.mark.skipif(not is_cuda(), reason="requires CUDA backend")
 def test_allocator_initialization_rejects_later_config():
     result = run_in_process(_run_allocator_freezes_config_check)
+    assert result.exc is None
+
+
+@pytest.mark.skipif(not is_cuda(), reason="requires CUDA backend")
+def test_reset_rejects_live_allocations():
+    result = run_in_process(_run_reset_rejects_live_allocations_check)
+    assert result.exc is None
+
+
+@pytest.mark.skipif(not is_cuda(), reason="requires CUDA backend")
+def test_reset_collects_unreachable_allocations():
+    result = run_in_process(_run_reset_collects_unreachable_allocations_check)
+    assert result.exc is None
+
+
+@pytest.mark.skipif(not is_cuda(), reason="requires CUDA backend")
+def test_reset_reinitializes_runtime_state():
+    result = run_in_process(_run_reset_reinitializes_runtime_state_check)
+    assert result.exc is None
+
+
+@pytest.mark.skipif(not is_cuda(), reason="requires CUDA backend")
+@pytest.mark.parametrize("num_pools", [1, 2])
+def test_reset_releases_cached_pool_clocks(num_pools):
+    result = run_in_process(_run_reset_releases_cached_pool_clocks_check, args=(num_pools, ))
     assert result.exc is None
 
 

--- a/python/test/gsan/test_allocator.py
+++ b/python/test/gsan/test_allocator.py
@@ -7,7 +7,7 @@ import torch
 import triton
 
 from triton._internal_testing import is_cuda, run_in_process
-from triton.experimental.gsan import ShareableHandleType, configure, create_mem_pool, freeze_config, reset
+from triton.experimental.gsan import ShareableHandleType, configure, create_mem_pool, freeze_config, has_live_allocations, reset
 from triton.experimental.gsan import _stream_sync
 from triton.experimental.gsan._allocator import (
     export_allocation_handles,
@@ -77,13 +77,53 @@ def _run_allocator_freezes_config_check() -> None:
         gsan_free(ptr, device, 0, 0)
 
 
-def _run_reset_rejects_live_allocations_check() -> None:
+def _run_has_live_allocations_check() -> None:
+    assert has_live_allocations() is False
+    configure(rng_seed=12345)
     device = torch.cuda.current_device()
     ptr = gsan_malloc(1, device)
     try:
-        with pytest.raises(AssertionError, match="GSan allocations are still live"):
-            reset()
+        assert has_live_allocations() is True
     finally:
+        gsan_free(ptr, device)
+    assert has_live_allocations() is False
+
+
+def _run_reset_rejects_live_allocations_check() -> None:
+    device = torch.cuda.current_device()
+    stream = torch.cuda.current_stream().cuda_stream
+    ptr = gsan_malloc(4, device)
+    target = uint8_cuda_tensor_from_ptr(ptr, 4, device).view(torch.int32)
+    try:
+        with triton.knobs.compilation.scope():
+            triton.knobs.compilation.instrumentation_mode = "gsan"
+            store_one_i32[(1, )](target, num_warps=1)
+            torch.cuda.synchronize()
+
+            stream_state = _stream_sync._launch_stream_state(device, stream)
+            runtime_layout = _stream_sync._runtime_state_layout(get_device_rank(device), device)
+            clocks_before = stream_state.clocks.cpu()
+            shadow_before = shadow_tensor_for(target).cpu()
+            thread_id = shadow_cell_from_address(ptr).write_clock.thread_id
+            thread_state_before = thread_state_from_smid(thread_id)
+            assert stream_state.next_kernel_id == 1
+
+            with pytest.raises(AssertionError, match="GSan allocations are still live"):
+                reset()
+
+            assert has_live_allocations() is True
+            assert _stream_sync._launch_stream_state(device, stream) is stream_state
+            assert _stream_sync._runtime_state_layout(get_device_rank(device), device) is runtime_layout
+            assert stream_state.next_kernel_id == 1
+            assert torch.equal(stream_state.clocks.cpu(), clocks_before)
+            assert torch.equal(shadow_tensor_for(target).cpu(), shadow_before)
+            assert thread_state_from_smid(thread_id).vector_clock == thread_state_before.vector_clock
+
+            store_one_i32[(1, )](target, num_warps=1)
+            torch.cuda.synchronize()
+            assert stream_state.next_kernel_id == 2
+    finally:
+        del target
         gsan_free(ptr, device)
 
     reset()
@@ -322,6 +362,12 @@ def test_freeze_config_rejects_later_changes():
 @pytest.mark.skipif(not is_cuda(), reason="requires CUDA backend")
 def test_allocator_initialization_rejects_later_config():
     result = run_in_process(_run_allocator_freezes_config_check)
+    assert result.exc is None
+
+
+@pytest.mark.skipif(not is_cuda(), reason="requires CUDA backend")
+def test_has_live_allocations():
+    result = run_in_process(_run_has_live_allocations_check)
     assert result.exc is None
 
 

--- a/python/test/gsan/test_allocator.py
+++ b/python/test/gsan/test_allocator.py
@@ -173,6 +173,28 @@ def _run_reset_releases_cached_pool_clocks_check(num_pools: int) -> None:
     reset()
 
 
+def _run_launch_stream_clocks_use_private_pool_check() -> None:
+    device = torch.cuda.current_device()
+    pool = create_mem_pool()
+    stream = torch.cuda.Stream()
+    with torch.cuda.stream(stream), torch.cuda.use_mem_pool(pool):
+        before = torch.empty(1, device=device)
+        clocks, kernel_id = _stream_sync.get_launch_stream_clock(device, stream.cuda_stream)
+        after = torch.empty(1, device=device)
+    stream.synchronize()
+
+    reserve_begin = get_reserve_pointer()
+    reserve_end = reserve_begin + get_reserve_size()
+    assert reserve_begin <= before.data_ptr() < reserve_end
+    assert not reserve_begin <= clocks.data_ptr() < reserve_end
+    assert reserve_begin <= after.data_ptr() < reserve_end
+    assert kernel_id == 0
+    assert torch.count_nonzero(clocks).item() == 0
+
+    del before, after, clocks, pool
+    reset()
+
+
 def _run_export_import_fabric_handles_check(explicit_config: bool) -> None:
     device = torch.cuda.current_device()
     configure(
@@ -325,6 +347,12 @@ def test_reset_reinitializes_runtime_state():
 @pytest.mark.parametrize("num_pools", [1, 2])
 def test_reset_releases_cached_pool_clocks(num_pools):
     result = run_in_process(_run_reset_releases_cached_pool_clocks_check, args=(num_pools, ))
+    assert result.exc is None
+
+
+@pytest.mark.skipif(not is_cuda(), reason="requires CUDA backend")
+def test_launch_stream_clocks_use_private_pool():
+    result = run_in_process(_run_launch_stream_clocks_use_private_pool_check)
     assert result.exc is None
 
 

--- a/python/triton/experimental/gsan/__init__.py
+++ b/python/triton/experimental/gsan/__init__.py
@@ -1,4 +1,4 @@
-from ._allocator import ShareableHandleType, configure, create_mem_pool, freeze_config, get_allocator
+from ._allocator import ShareableHandleType, configure, create_mem_pool, freeze_config, get_allocator, reset
 
 __all__ = [
     "ShareableHandleType",
@@ -6,6 +6,7 @@ __all__ = [
     "create_mem_pool",
     "freeze_config",
     "get_allocator",
+    "reset",
 ]
 
 _LAZY_LOAD_MODULES = {"symmetric_memory"}

--- a/python/triton/experimental/gsan/__init__.py
+++ b/python/triton/experimental/gsan/__init__.py
@@ -1,4 +1,4 @@
-from ._allocator import ShareableHandleType, configure, create_mem_pool, freeze_config, get_allocator, reset
+from ._allocator import ShareableHandleType, configure, create_mem_pool, freeze_config, get_allocator, has_live_allocations, reset
 
 __all__ = [
     "ShareableHandleType",
@@ -6,6 +6,7 @@ __all__ = [
     "create_mem_pool",
     "freeze_config",
     "get_allocator",
+    "has_live_allocations",
     "reset",
 ]
 

--- a/python/triton/experimental/gsan/_allocator.py
+++ b/python/triton/experimental/gsan/_allocator.py
@@ -91,17 +91,28 @@ def freeze_config() -> None:
     _load_gsan_module().freeze_config()
 
 
+def has_live_allocations() -> bool:
+    """Return whether the GSan allocation reserve has outstanding allocations.
+
+    This includes memory retained by caching allocators. The query does not
+    initialize GSan runtime state or freeze its configuration.
+    """
+    return _load_gsan_module().has_live_allocations()
+
+
 def reset() -> None:
-    """Reset GSan runtime state after all GSan allocations have been released."""
+    """Reset GSan runtime state after all GSan allocations have been released.
+
+    Runs garbage collection if allocations remain. If any are still live,
+    raises ``AssertionError`` without resetting the runtime or stream clocks.
+    """
     from . import _stream_sync
 
     module = _load_gsan_module()
-    _stream_sync._reset_caches()
-    try:
-        module.reset()
-    except AssertionError:
+    if module.has_live_allocations():
         gc.collect()
-        module.reset()
+    module.reset()
+    _stream_sync._reset_caches()
 
 
 def create_mem_pool():

--- a/python/triton/experimental/gsan/_allocator.py
+++ b/python/triton/experimental/gsan/_allocator.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import functools
+import gc
 from enum import IntEnum
 from pathlib import Path
 from types import ModuleType
@@ -88,6 +89,19 @@ def configure(
 def freeze_config() -> None:
     """Prevents later `configure(...)` calls from changing allocator configuration."""
     _load_gsan_module().freeze_config()
+
+
+def reset() -> None:
+    """Reset GSan runtime state after all GSan allocations have been released."""
+    from . import _stream_sync
+
+    module = _load_gsan_module()
+    _stream_sync._reset_caches()
+    try:
+        module.reset()
+    except AssertionError:
+        gc.collect()
+        module.reset()
 
 
 def create_mem_pool():

--- a/python/triton/experimental/gsan/_stream_sync.py
+++ b/python/triton/experimental/gsan/_stream_sync.py
@@ -58,6 +58,11 @@ def get_launch_stream_clock(device: int, stream: int):
     return state.clocks, kernel_id
 
 
+def _reset_caches() -> None:
+    _launch_stream_state.cache_clear()
+    _runtime_state_layout.cache_clear()
+
+
 @triton.jit(do_not_specialize=["rank", "epoch"])
 def _synchronize_process_group_barrier_kernel(counters, rank, epoch, WORLD_SIZE: tl.constexpr):
     tl.atomic_xchg(counters + rank, epoch, sem="release", scope="sys")

--- a/python/triton/experimental/gsan/_stream_sync.py
+++ b/python/triton/experimental/gsan/_stream_sync.py
@@ -39,6 +39,14 @@ def _runtime_state_layout(runtime_state_device: int, access_device: int) -> _Run
     )
 
 
+@functools.cache
+def _clock_mem_pool(device: int):
+    import torch
+
+    with torch.cuda.device(device):
+        return torch.cuda.MemPool()
+
+
 @functools.lru_cache()
 def _launch_stream_state(device: int, stream: int) -> _LaunchStreamState:
     import torch
@@ -46,7 +54,8 @@ def _launch_stream_state(device: int, stream: int) -> _LaunchStreamState:
     layout = _runtime_state_layout(get_device_rank(device), device)
     cuda_stream = torch.cuda.ExternalStream(stream, device=device) if stream else torch.cuda.default_stream(device)
     with torch.cuda.device(device), torch.cuda.stream(cuda_stream):
-        clocks = torch.zeros((3, layout.num_threads), dtype=torch.int32, device=device)
+        with torch.cuda.use_mem_pool(_clock_mem_pool(device)):
+            clocks = torch.zeros((3, layout.num_threads), dtype=torch.int32, device=device)
     return _LaunchStreamState(clocks=clocks)
 
 

--- a/python/triton/experimental/gsan/src/GSanAllocator.cc
+++ b/python/triton/experimental/gsan/src/GSanAllocator.cc
@@ -125,6 +125,11 @@ static AllocatorState *alloc = nullptr;
 static GSanConfig config;
 static std::mutex mut;
 
+bool hasLiveAllocations() {
+  return alloc != nullptr &&
+         alloc->treeRoot.maxFreeBlockSize != alloc->treeRoot.size;
+}
+
 CUmemAllocationHandleType getRequestedShareableHandleType() {
   if (config.shareableHandleTypeConfigured)
     return config.shareableHandleType;
@@ -1306,6 +1311,12 @@ PyObject *pyFreezeConfig([[maybe_unused]] PyObject *self, PyObject *const *args,
   Py_RETURN_NONE;
 }
 
+PyObject *pyHasLiveAllocations([[maybe_unused]] PyObject *self,
+                               [[maybe_unused]] PyObject *args) {
+  std::lock_guard lg(mut);
+  return PyBool_FromLong(hasLiveAllocations());
+}
+
 PyObject *pyReset([[maybe_unused]] PyObject *self, PyObject *const *args,
                   Py_ssize_t nargs) {
   if (nargs != 0) {
@@ -1319,7 +1330,7 @@ PyObject *pyReset([[maybe_unused]] PyObject *self, PyObject *const *args,
   if (alloc == nullptr)
     Py_RETURN_NONE;
 
-  if (alloc->treeRoot.maxFreeBlockSize != alloc->treeRoot.size) {
+  if (hasLiveAllocations()) {
     PyErr_SetString(PyExc_AssertionError,
                     "cannot reset GSan while GSan allocations are still live");
     return nullptr;
@@ -1676,6 +1687,9 @@ PyMethodDef kGSanAllocatorMethods[] = {
      "Configure GSan topology and runtime tuning fields."},
     {"freeze_config", reinterpret_cast<PyCFunction>(pyFreezeConfig),
      METH_FASTCALL, "Prevent later changes to the GSan allocator config."},
+    {"has_live_allocations",
+     reinterpret_cast<PyCFunction>(pyHasLiveAllocations), METH_NOARGS,
+     "Return whether the GSan allocation reserve has live allocations."},
     {"reset", reinterpret_cast<PyCFunction>(pyReset), METH_FASTCALL,
      "Reset GSan runtime state when there are no live allocations."},
     {"get_reserve_pointer", reinterpret_cast<PyCFunction>(pyGetReservePointer),

--- a/python/triton/experimental/gsan/src/GSanAllocator.cc
+++ b/python/triton/experimental/gsan/src/GSanAllocator.cc
@@ -460,6 +460,22 @@ CUresult refreshConfigForDevice(int device) {
   return CUDA_SUCCESS;
 }
 
+CUresult initializeRuntimeState(CUdeviceptr deviceAddr, size_t allocSize) {
+  CUresult err = cuMemsetD8(deviceAddr, 0, allocSize);
+  if (err != CUDA_SUCCESS)
+    return err;
+
+  gsan::GlobalState globals = {};
+  globals.reserveBase = static_cast<uintptr_t>(alloc->reserveBaseAddress);
+  globals.globalsBase = static_cast<uintptr_t>(alloc->globalStateAddress);
+  globals.rngSeed = config.rngSeed;
+  globals.numSms = static_cast<gsan::thread_id_t>(config.numSMs);
+  globals.numDevices = static_cast<gsan::thread_id_t>(config.numGPUs);
+  globals.numThreads = static_cast<gsan::thread_id_t>(config.numThreads);
+  globals.clockBufferSize = config.clockBufferSize;
+  return cuMemcpyHtoD(deviceAddr, &globals, sizeof(globals));
+}
+
 CUresult ensureRuntimeStateMapped(int device) {
   if (alloc == nullptr)
     return CUDA_ERROR_NOT_INITIALIZED;
@@ -503,7 +519,6 @@ CUresult ensureRuntimeStateMapped(int device) {
   CUmemGenericAllocationHandle allocHandle = 0;
   bool mapped = false;
   CUmemAccessDesc accessDesc = {};
-  gsan::GlobalState globals = {};
   CUdeviceptr deviceAddr =
       alloc->globalStateAddress + deviceRank * gsan::kPerDeviceStateStride;
 
@@ -523,18 +538,7 @@ CUresult ensureRuntimeStateMapped(int device) {
   if (err != CUDA_SUCCESS)
     goto error;
 
-  err = cuMemsetD8(deviceAddr, 0, allocSize);
-  if (err != CUDA_SUCCESS)
-    goto error;
-
-  globals.reserveBase = static_cast<uintptr_t>(alloc->reserveBaseAddress);
-  globals.globalsBase = static_cast<uintptr_t>(alloc->globalStateAddress);
-  globals.rngSeed = config.rngSeed;
-  globals.numSms = static_cast<gsan::thread_id_t>(config.numSMs);
-  globals.numDevices = static_cast<gsan::thread_id_t>(config.numGPUs);
-  globals.numThreads = static_cast<gsan::thread_id_t>(config.numThreads);
-  globals.clockBufferSize = config.clockBufferSize;
-  err = cuMemcpyHtoD(deviceAddr, &globals, sizeof(globals));
+  err = initializeRuntimeState(deviceAddr, allocSize);
   if (err != CUDA_SUCCESS)
     goto error;
 
@@ -1302,6 +1306,74 @@ PyObject *pyFreezeConfig([[maybe_unused]] PyObject *self, PyObject *const *args,
   Py_RETURN_NONE;
 }
 
+PyObject *pyReset([[maybe_unused]] PyObject *self, PyObject *const *args,
+                  Py_ssize_t nargs) {
+  if (nargs != 0) {
+    PyErr_Format(PyExc_TypeError,
+                 "%s.reset expected 0 positional arguments, got %zd",
+                 kModuleName, nargs);
+    return nullptr;
+  }
+
+  std::lock_guard lg(mut);
+  if (alloc == nullptr)
+    Py_RETURN_NONE;
+
+  if (alloc->treeRoot.maxFreeBlockSize != alloc->treeRoot.size) {
+    PyErr_SetString(PyExc_AssertionError,
+                    "cannot reset GSan while GSan allocations are still live");
+    return nullptr;
+  }
+
+  CUcontext originalContext = nullptr;
+  CUresult err = cuCtxGetCurrent(&originalContext);
+  if (err != CUDA_SUCCESS) {
+    printCUDAError(err);
+    PyErr_SetString(PyExc_RuntimeError,
+                    "failed to get the current CUDA context for GSan reset");
+    return nullptr;
+  }
+
+  for (int device = 0; device < static_cast<int>(gsan::kMaxGPUs); ++device) {
+    if (!config.configuredDeviceRanks[device])
+      continue;
+
+    int deviceRank = config.deviceRanks[device];
+    if (alloc->perDeviceHandles[deviceRank] == 0)
+      continue;
+
+    CUcontext deviceContext = nullptr;
+    err = cuDevicePrimaryCtxRetain(&deviceContext, device);
+    if (err == CUDA_SUCCESS)
+      err = cuCtxSetCurrent(deviceContext);
+    if (err == CUDA_SUCCESS)
+      err = cuCtxSynchronize();
+    if (err == CUDA_SUCCESS) {
+      CUdeviceptr deviceAddr =
+          alloc->globalStateAddress + deviceRank * gsan::kPerDeviceStateStride;
+      err = initializeRuntimeState(deviceAddr, alloc->perDeviceStateSize);
+    }
+
+    CUresult restoreErr = cuCtxSetCurrent(originalContext);
+    if (err == CUDA_SUCCESS)
+      err = restoreErr;
+    if (deviceContext != nullptr) {
+      CUresult releaseErr = cuDevicePrimaryCtxRelease(device);
+      if (err == CUDA_SUCCESS)
+        err = releaseErr;
+    }
+
+    if (err != CUDA_SUCCESS) {
+      printCUDAError(err);
+      PyErr_SetString(PyExc_RuntimeError,
+                      "failed to reinitialize GSan runtime state");
+      return nullptr;
+    }
+  }
+
+  Py_RETURN_NONE;
+}
+
 PyObject *pyGetReservePointer([[maybe_unused]] PyObject *self,
                               PyObject *const *args, Py_ssize_t nargs) {
   if (nargs != 0) {
@@ -1604,6 +1676,8 @@ PyMethodDef kGSanAllocatorMethods[] = {
      "Configure GSan topology and runtime tuning fields."},
     {"freeze_config", reinterpret_cast<PyCFunction>(pyFreezeConfig),
      METH_FASTCALL, "Prevent later changes to the GSan allocator config."},
+    {"reset", reinterpret_cast<PyCFunction>(pyReset), METH_FASTCALL,
+     "Reset GSan runtime state when there are no live allocations."},
     {"get_reserve_pointer", reinterpret_cast<PyCFunction>(pyGetReservePointer),
      METH_FASTCALL, "Return the reserve base pointer as an integer."},
     {"get_reserve_size", reinterpret_cast<PyCFunction>(pyGetReserveSize),


### PR DESCRIPTION
This adds a `gsan.reset()` method which resets all the device-side global state back to the initial value. Crucially, this means the epoch counters are reset and so you don't need your entire test suite to run without overflowing the counters, only each test individually.

For this to be safe, we enforce that there are no live gsan allocations at the time of the reset. Otherwise, you could have bogus false results after calling reset due to the pytorch allocator reusing memory across reset calls.