### PR TITLE
[LLVM] Build LLVM with SLP vectorizer backports for 3.8 release

### DIFF
--- a/cmake/llvm-build-info.json
+++ b/cmake/llvm-build-info.json
@@ -1,5 +1,5 @@
 {
-  "llvm_hash": "2449c0e3a0a5ff2ec9d70efb9afb95e6e8fe8abd",
+  "llvm_hash": "5f07f818b51b786b0a87b4e514882600ecba112f",
   "repository": "triton-lang/llvm-project",
   "build_number": 1
 }


### PR DESCRIPTION
## Summary
Cherry pick `triton-lang/llvm-project@5f07f818`, which contains SLP vectorizer backports from [triton-lang/llvm-project#3](https://github.com/triton-lang/llvm-project/pull/3), to build LLVM package that will be used in Triton 3.8 release branch. Fixes issue described in https://github.com/pytorch/pytorch/issues/193183