### PR TITLE
[NVIDIA] Reuse TCGen5 A operands across N tiles

### DIFF
--- a/include/triton/Dialect/TritonNvidiaGPU/IR/TargetFeatures.h
+++ b/include/triton/Dialect/TritonNvidiaGPU/IR/TargetFeatures.h
@@ -69,6 +69,10 @@ public:
   }
   bool supports4xFp4Tcgen05MMA() const { return computeCapability == 107; }
   bool supports2xFp8Tcgen05MMA() const { return computeCapability == 107; }
+  bool supportsReuseA() const {
+    // A collectors are part of the baseline tcgen05 ISA (PTX 8.6).
+    return computeCapability >= 100 && computeCapability < 120;
+  }
   bool supportsReuseB() const { return computeCapability == 107; }
   bool supportsMbarMulticast() const { return computeCapability == 107; }
 

--- a/python/test/gluon/test_core.py
+++ b/python/test/gluon/test_core.py
@@ -1153,6 +1153,33 @@ def test_tcgen05_mma_collector_a(M, N):
     torch.testing.assert_close(out, a.float() @ b.float(), atol=0, rtol=0)
 
 
+@pytest.mark.skipif(not is_rubin(), reason="Requires Rubin")
+@pytest.mark.parametrize("N,BLOCK_N,expected", [
+    pytest.param(128, 128, [("", "fill"), ("", "lastuse")], id="b-only"),
+    pytest.param(256, 128, [("", "fill"), ("fill", "lastuse"), ("lastuse", "fill"), ("", "lastuse")], id="b-major"),
+    pytest.param(128, 64, [("fill", ""), ("lastuse", "fill"), ("fill", "lastuse"), ("lastuse", "")], id="a-major"),
+])
+def test_tcgen05_mma_collector_ab(N, BLOCK_N, expected):
+    M, K = 256, 32
+    layout = ttgl.BlockedLayout([1, 4], [4, 8], [4, 1], [1, 0])
+    acc_layout = TensorMemoryLayout([128, BLOCK_N], col_stride=1)
+    shared_a = ttgl.NVMMASharedLayout.get_default_for([M, K], ttgl.float16)
+    shared_b = ttgl.NVMMASharedLayout.get_default_for([K, N], ttgl.float16)
+
+    torch.manual_seed(0)
+    a = torch.randint(-3, 4, (M, K), device="cuda").to(torch.float16)
+    b = torch.randint(-3, 4, (K, N), device="cuda").to(torch.float16)
+    out = torch.empty((M, N), device="cuda", dtype=torch.float32)
+    compiled = mma_kernel[(1, )](a, b, out, M, N, K, layout, layout, (), acc_layout, shared_a, shared_b, ttgl.float32,
+                                 False, True, num_warps=4)
+
+    collectors = re.findall(
+        r"tcgen05\.mma\.cta_group::1\.kind::f16(?:\.collector::a::(\w+))?(?:\.collector::b::(\w+))?\s",
+        compiled.asm["ptx"])
+    assert collectors == expected * (K // 16)
+    torch.testing.assert_close(out, a.float() @ b.float(), atol=0, rtol=0)
+
+
 @gluon.jit
 def warpgroup_mma_wait_multi_warpgroup_kernel(a_ptr, b0_ptr, b1_ptr, out_ptr, D: ttgl.constexpr, NBLK: ttgl.constexpr,
                                               WG: ttgl.constexpr):

--- a/python/test/gluon/test_core.py
+++ b/python/test/gluon/test_core.py
@@ -1128,6 +1128,31 @@ def test_warpgroup_mma(ASYNC):
     torch.testing.assert_close(out, ref, atol=1e-3, rtol=1e-1)
 
 
+@pytest.mark.skipif(not is_blackwell(), reason="Requires Blackwell")
+@pytest.mark.parametrize("M", [64, 128])
+@pytest.mark.parametrize("N", [64, 128, 256])
+def test_tcgen05_mma_collector_a(M, N):
+    K = 32
+    layout = ttgl.BlockedLayout([1, 4], [4, 8], [4, 1], [1, 0])
+    acc_layout = TensorMemoryLayout([M, 64], col_stride=1)
+    shared_a = ttgl.NVMMASharedLayout.get_default_for([M, K], ttgl.float16)
+    shared_b = ttgl.NVMMASharedLayout.get_default_for([K, N], ttgl.float16)
+
+    torch.manual_seed(0)
+    a = torch.randint(-3, 4, (M, K), device="cuda").to(torch.float16)
+    b = torch.randint(-3, 4, (K, N), device="cuda").to(torch.float16)
+    out = torch.empty((M, N), device="cuda", dtype=torch.float32)
+    compiled = mma_kernel[(1, )](a, b, out, M, N, K, layout, layout, (), acc_layout, shared_a, shared_b, ttgl.float32,
+                                 False, True, num_warps=4)
+
+    collectors = re.findall(r"tcgen05\.mma\.cta_group::1\.kind::f16(?:\.collector::a::(\w+))?", compiled.asm["ptx"])
+    n_tiles = N // 64
+    # M=64 can place successive N tiles in different halves of the datapath.
+    expected = [""] * n_tiles if M == 64 or n_tiles == 1 else ["fill"] + ["use"] * (n_tiles - 2) + ["lastuse"]
+    assert collectors == expected * (K // 16)
+    torch.testing.assert_close(out, a.float() @ b.float(), atol=0, rtol=0)
+
+
 @gluon.jit
 def warpgroup_mma_wait_multi_warpgroup_kernel(a_ptr, b0_ptr, b1_ptr, out_ptr, D: ttgl.constexpr, NBLK: ttgl.constexpr,
                                               WG: ttgl.constexpr):
@@ -3178,8 +3203,9 @@ def test_tcgen05_mma_scaled_noncontiguous_accumulator():
     ],
 )
 @pytest.mark.skipif(not is_blackwell(), reason="Requires Blackwell")
+@pytest.mark.parametrize("acc_block_n", [64, 128])
 def test_tcgen05_mma_scaled_lhs_tmem(a_format, a_torch_dtype, b_format, b_torch_dtype, a_is_fp4, b_is_fp4, a_fp4_padded,
-                                     scale_vec_size, nvfp4):
+                                     scale_vec_size, nvfp4, acc_block_n):
     torch.manual_seed(0)
     M = 128
     N = 128
@@ -3189,7 +3215,7 @@ def test_tcgen05_mma_scaled_lhs_tmem(a_format, a_torch_dtype, b_format, b_torch_
     @gluon.jit
     def kernel(out_ptr, M: ttgl.constexpr, N: ttgl.constexpr, K: ttgl.constexpr, a, b, a_scale, b_scale,
                A_FORMAT: ttgl.constexpr, B_FORMAT: ttgl.constexpr, A_IS_FP4: ttgl.constexpr, B_IS_FP4: ttgl.constexpr,
-               A_FP4_PADDED: ttgl.constexpr, SCALE_VEC_SIZE: ttgl.constexpr):
+               A_FP4_PADDED: ttgl.constexpr, SCALE_VEC_SIZE: ttgl.constexpr, ACC_BLOCK_N: ttgl.constexpr):
         store_layout: ttgl.constexpr = ttgl.BlockedLayout([1, 1], [threads_per_warp, 1], [ttgl.num_warps(), 1], [1, 0])
 
         A_K_INPUT: ttgl.constexpr = K // 2 if A_IS_FP4 else K
@@ -3226,7 +3252,7 @@ def test_tcgen05_mma_scaled_lhs_tmem(a_format, a_torch_dtype, b_format, b_torch_
             b_smem = ttgl.allocate_shared_memory(b.dtype.element_ty, [K, N], b_layout,
                                                  ttgl.load(b + b_offs_k * N + b_offs_n))
 
-        acc_layout: ttgl.constexpr = TensorMemoryLayout([M, N], col_stride=1)
+        acc_layout: ttgl.constexpr = TensorMemoryLayout([M, ACC_BLOCK_N], col_stride=1)
         acc_tmem = allocate_tensor_memory(ttgl.float32, [M, N], acc_layout)
         acc_reg_layout: ttgl.constexpr = acc_tmem.get_reg_layout()
         acc_tmem.store(ttgl.zeros([M, N], ttgl.float32, layout=acc_reg_layout))
@@ -3302,8 +3328,14 @@ def test_tcgen05_mma_scaled_lhs_tmem(a_format, a_torch_dtype, b_format, b_torch_
     ref = torch.matmul(a_ref, b_ref)
     atol, rtol = (1e-3, 1e-3) if a_is_fp4 or b_is_fp4 else (1e-6, 1e-6)
 
-    kernel[(1, )](out, M, N, K, a, b, a_scale, b_scale, a_format, b_format, a_is_fp4, b_is_fp4, a_fp4_padded,
-                  scale_vec_size)
+    compiled = kernel[(1, )](out, M, N, K, a, b, a_scale, b_scale, a_format, b_format, a_is_fp4, b_is_fp4, a_fp4_padded,
+                             scale_vec_size, acc_block_n)
+    # Both D and A must use TMEM address operands in the collector sequence.
+    collectors = re.findall(r"tcgen05\.mma\.[^\s;]+\.collector::a::(\w+)\s+\[[^]]+\],\s*\[", compiled.asm["ptx"])
+    if acc_block_n < N:
+        assert collectors and collectors == ["fill", "lastuse"] * (len(collectors) // 2)
+    else:
+        assert not collectors
     torch.testing.assert_close(out, ref, atol=atol, rtol=rtol)
 
 

--- a/test/Conversion/tritongpu_to_llvm_blackwell.mlir
+++ b/test/Conversion/tritongpu_to_llvm_blackwell.mlir
@@ -580,7 +580,7 @@ module attributes {"ttg.num-ctas" = 2 : i32, "ttg.num-warps" = 4 : i32, "ttng.tw
 #tmem_scales = #ttng.tensor_memory_scales_encoding<>
 module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32} {
   // CHECK-LABEL: @tc_gen5_mma_block_scale_nvfp4
-  // CHECK: %[[TMEM_BASE:.+]] = llvm.ptrtoint %{{.*}} : !llvm.ptr<3> to i32
+  // CHECK: %[[TMEM_BASE:.+]] = llvm.ptrtoint %arg2 : !llvm.ptr<3> to i32
   // CHECK: %[[DESC0:.+]] = llvm.mlir.constant(138413184 : i32) : i32
   // CHECK: @$7 tcgen05.mma.cta_group::1.kind::mxf4nvf4.block_scale.block16 [ $0 + 0 ], $1, $2, $3, [ $4 + 0 ], [ $5 + 0 ], $6;", "r,l,l,r,r,r,b,b" %[[TMEM_BASE]], %{{.+}}, %{{.+}}, %[[DESC0]]
   // CHECK: @$7 tcgen05.mma.cta_group::1.kind::mxf4nvf4.block_scale.block16 [ $0 + 0 ], $1, $2, $3, [ $4 + 0 ], [ $5 + 0 ], $6;", "r,l,l,r,r,r,b,b" %[[TMEM_BASE]], %{{.+}}, %{{.+}}, %[[DESC0]]
@@ -613,7 +613,7 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32} {
 #tmem_scales = #ttng.tensor_memory_scales_encoding<>
 module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32} {
   // CHECK-LABEL: @tc_gen5_mma_block_scale_mxfp4
-  // CHECK-DAG: %[[TMEM_BASE:.+]] = llvm.ptrtoint %{{.*}} : !llvm.ptr<3> to i32
+  // CHECK-DAG: %[[TMEM_BASE:.+]] = llvm.ptrtoint %arg2 : !llvm.ptr<3> to i32
   // CHECK: %[[DESC0:.+]] = llvm.mlir.constant(146801792 : i32) : i32
   // CHECK: @$7 tcgen05.mma.cta_group::1.kind::mxf4.block_scale.block32 [ $0 + 0 ], $1, $2, $3, [ $4 + 0 ], [ $5 + 0 ], $6;", "r,l,l,r,r,r,b,b" %[[TMEM_BASE]], %{{.+}}, %{{.+}}, %[[DESC0]]
   // CHECK: %[[DESC1:.+]] = llvm.mlir.constant(1220543648 : i32) : i32

--- a/test/Conversion/tritongpu_to_llvm_blackwell.mlir
+++ b/test/Conversion/tritongpu_to_llvm_blackwell.mlir
@@ -150,6 +150,39 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 8 : i32} {
 
 // -----
 
+#shared = #ttg.nvmma_shared<{swizzlingByteWidth = 64, transposed = false, elementBitWidth = 16}>
+#shared1 = #ttg.nvmma_shared<{swizzlingByteWidth = 64, transposed = true, elementBitWidth = 16}>
+#tmem = #ttng.tensor_memory_encoding<blockM = 128, blockN = 64, colStride = 1>
+module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32} {
+  // CHECK-LABEL: @tc_gen5_mma_a_reuse
+  // CHECK: %[[TMEM_BASE:.+]] = llvm.ptrtoint %arg2 : !llvm.ptr<3> to i32
+  // CHECK: %[[E:.+]] = nvvm.elect.sync -> i1
+  // Each K step visits all four N tiles, with the same A descriptor. All four
+  // accumulators use the caller's flag at K=0 and accumulate thereafter.
+  // CHECK: kind::f16.collector::a::fill [ $0 + 0 ], $1, $2, $3, $4;", "r,l,l,r,b,b" %[[TMEM_BASE]], %[[A0:[^,]+]], %{{[^,]+}}, %{{[^,]+}}, %arg3, %[[E]]
+  // CHECK: kind::f16.collector::a::use [ $0 + 64 ], $1, $2, $3, $4;", "r,l,l,r,b,b" %[[TMEM_BASE]], %[[A0]], %{{[^,]+}}, %{{[^,]+}}, %arg3, %[[E]]
+  // CHECK: kind::f16.collector::a::use [ $0 + 128 ], $1, $2, $3, $4;", "r,l,l,r,b,b" %[[TMEM_BASE]], %[[A0]], %{{[^,]+}}, %{{[^,]+}}, %arg3, %[[E]]
+  // CHECK: kind::f16.collector::a::lastuse [ $0 + 192 ], $1, $2, $3, $4;", "r,l,l,r,b,b" %[[TMEM_BASE]], %[[A0]], %{{[^,]+}}, %{{[^,]+}}, %arg3, %[[E]]
+  // CHECK: %[[TRUE:.+]] = llvm.mlir.constant(true) : i1
+  // CHECK: kind::f16.collector::a::fill [ $0 + 0 ], $1, $2, $3, $4;", "r,l,l,r,b,b" %[[TMEM_BASE]], %[[A1:[^,]+]], %{{[^,]+}}, %{{[^,]+}}, %[[TRUE]], %[[E]]
+  // CHECK: kind::f16.collector::a::use [ $0 + 64 ], $1, $2, $3, $4;", "r,l,l,r,b,b" %[[TMEM_BASE]], %[[A1]], %{{[^,]+}}, %{{[^,]+}}, %[[TRUE]], %[[E]]
+  // CHECK: kind::f16.collector::a::use [ $0 + 128 ], $1, $2, $3, $4;", "r,l,l,r,b,b" %[[TMEM_BASE]], %[[A1]], %{{[^,]+}}, %{{[^,]+}}, %[[TRUE]], %[[E]]
+  // CHECK: kind::f16.collector::a::lastuse [ $0 + 192 ], $1, $2, $3, $4;", "r,l,l,r,b,b" %[[TMEM_BASE]], %[[A1]], %{{[^,]+}}, %{{[^,]+}}, %[[TRUE]], %[[E]]
+  // CHECK-NOT: tcgen05.mma
+  tt.func @tc_gen5_mma_a_reuse(%a: !ttg.memdesc<128x32xf16, #shared, #ttg.shared_memory>,
+                              %b: !ttg.memdesc<32x256xf16, #shared1, #ttg.shared_memory>,
+                              %c: !ttg.memdesc<128x256xf32, #tmem, #ttng.tensor_memory, mutable>,
+                              %useAcc: i1, %pred: i1) {
+    ttng.tc_gen5_mma %a, %b, %c, %useAcc, %pred :
+      !ttg.memdesc<128x32xf16, #shared, #ttg.shared_memory>,
+      !ttg.memdesc<32x256xf16, #shared1, #ttg.shared_memory>,
+      !ttg.memdesc<128x256xf32, #tmem, #ttng.tensor_memory, mutable>
+    tt.return
+  }
+}
+
+// -----
+
 #mma = #ttg.nvidia_mma<{versionMajor = 3, versionMinor = 0, warpsPerCTA = [8, 1], CGALayout = [[0, 0]], instrShape = [16, 256, 32]}>
 #shared = #ttg.nvmma_shared<{swizzlingByteWidth = 32, transposed = true, elementBitWidth = 16, CGALayout = [[0, 0]]}>
 #shared1 = #ttg.nvmma_shared<{swizzlingByteWidth = 32, transposed = true, elementBitWidth = 16, CGALayout = [[0, 1]]}>
@@ -308,21 +341,24 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32} {
   // CHECK-LABEL: @tc_gen5_mma_scaled_a_tmem
   // CHECK: %[[TMEM_BASE:.+]] = llvm.ptrtoint %arg2 : !llvm.ptr<3> to i32
   // CHECK: %[[A_BASE:.+]] = llvm.ptrtoint %arg0 : !llvm.ptr<3> to i32
-  // CHECK: @$7 tcgen05.mma.cta_group::1.kind::mxf8f6f4.block_scale.block32 [ $0 + 0 ], [ $1 + 0 ], $2, $3, [ $4 + 0 ], [ $5 + 0 ], $6;", "r,r,l,r,r,r,b,b" %[[TMEM_BASE]], %[[A_BASE]]
+  // CHECK: @$7 tcgen05.mma.cta_group::1.kind::mxf8f6f4.block_scale.block32.collector::a::fill [ $0 + 0 ], [ $1 + 0 ], $2, $3, [ $4 + 0 ], [ $5 + 0 ], $6;", "r,r,l,r,r,r,b,b" %[[TMEM_BASE]], %[[A_BASE]], %{{[^,]+}}, %{{[^,]+}}, %[[SCALE_A:[^,]+]]
+  // CHECK: @$7 tcgen05.mma.cta_group::1.kind::mxf8f6f4.block_scale.block32.collector::a::lastuse [ $0 + 64 ], [ $1 + 0 ], $2, $3, [ $4 + 0 ], [ $5 + 0 ], $6;", "r,r,l,r,r,r,b,b" %[[TMEM_BASE]], %[[A_BASE]], %{{[^,]+}}, %{{[^,]+}}, %[[SCALE_A]]
+  // CHECK: kind::mxf8f6f4.block_scale.block32.collector::a::fill [ $0 + 0 ], [ $1 + 8 ]
+  // CHECK: kind::mxf8f6f4.block_scale.block32.collector::a::lastuse [ $0 + 64 ], [ $1 + 8 ]
   tt.func @tc_gen5_mma_scaled_a_tmem(
       %a: !ttg.memdesc<128x256xf8E5M2, #tmem, #ttng.tensor_memory>,
-      %b: !ttg.memdesc<256x64xf8E5M2, #shared, #ttg.shared_memory>,
-      %c: !ttg.memdesc<128x64xf32, #tmem, #ttng.tensor_memory, mutable>,
+      %b: !ttg.memdesc<256x128xf8E5M2, #shared, #ttg.shared_memory>,
+      %c: !ttg.memdesc<128x128xf32, #tmem, #ttng.tensor_memory, mutable>,
       %scale_a: !ttg.memdesc<128x8xi8, #tmem_scales, #ttng.tensor_memory>,
-      %scale_b: !ttg.memdesc<64x8xi8, #tmem_scales, #ttng.tensor_memory>,
+      %scale_b: !ttg.memdesc<128x8xi8, #tmem_scales, #ttng.tensor_memory>,
       %useAcc: i1,
       %pred: i1) {
     ttng.tc_gen5_mma_scaled %a, %b, %c, %scale_a, %scale_b, %useAcc, %pred lhs = e5m2 rhs = e5m2 :
       !ttg.memdesc<128x256xf8E5M2, #tmem, #ttng.tensor_memory>,
-      !ttg.memdesc<256x64xf8E5M2, #shared, #ttg.shared_memory>,
-      !ttg.memdesc<128x64xf32, #tmem, #ttng.tensor_memory, mutable>,
+      !ttg.memdesc<256x128xf8E5M2, #shared, #ttg.shared_memory>,
+      !ttg.memdesc<128x128xf32, #tmem, #ttng.tensor_memory, mutable>,
       !ttg.memdesc<128x8xi8, #tmem_scales, #ttng.tensor_memory>,
-      !ttg.memdesc<64x8xi8, #tmem_scales, #ttng.tensor_memory>
+      !ttg.memdesc<128x8xi8, #tmem_scales, #ttng.tensor_memory>
     tt.return
   }
 }

--- a/test/Conversion/tritongpu_to_llvm_rubin.mlir
+++ b/test/Conversion/tritongpu_to_llvm_rubin.mlir
@@ -130,25 +130,93 @@ module attributes {"ttg.num-ctas" = 2 : i32, "ttg.num-warps" = 4 : i32, ttg.targ
 #shared1 = #ttg.nvmma_shared<{swizzlingByteWidth = 32, transposed = true, elementBitWidth = 16}>
 #shared2 = #ttg.swizzled_shared<{vec = 1, perPhase = 1, maxPhase = 1, order = [0]}>
 #tmem = #ttng.tensor_memory_encoding<blockM = 128, blockN = 128, colStride = 1>
+#tmem_n64 = #ttng.tensor_memory_encoding<blockM = 128, blockN = 64, colStride = 1>
+#tmem_m64 = #ttng.tensor_memory_encoding<blockM = 64, blockN = 64, colStride = 1>
 module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 8 : i32, ttg.target = "cuda:107"} {
   // CHECK-LABEL: @tc_gen5_mma_breuse
-  // Both operands can be reused; retain the Rubin B-reuse schedule.
+  // Only B can be reused; retain the Rubin B-reuse schedule.
   // CHECK-NOT: collector::a
   // CHECK: tcgen05.mma.cta_group::1.kind::f16.collector::b::fill
   // CHECK: tcgen05.mma.cta_group::1.kind::f16.collector::b::lastuse
-  // CHECK-NOT: collector::a
-  tt.func @tc_gen5_mma_breuse(%a: !ttg.memdesc<256x128xf16, #shared, #ttg.shared_memory>,
-                       %b: !ttg.memdesc<128x256xf16, #shared1, #ttg.shared_memory>,
-                       %c: !ttg.memdesc<256x256xf32, #tmem, #ttng.tensor_memory, mutable>,
+  // CHECK-NOT: tcgen05.mma
+  tt.func @tc_gen5_mma_breuse(%a: !ttg.memdesc<256x16xf16, #shared, #ttg.shared_memory>,
+                       %b: !ttg.memdesc<16x128xf16, #shared1, #ttg.shared_memory>,
+                       %c: !ttg.memdesc<256x128xf32, #tmem, #ttng.tensor_memory, mutable>,
                        %useAcc: i1,
                        %pred: i1,
                        %barrier: !ttg.memdesc<1xi64, #shared2, #ttg.shared_memory>,
                        %barrierPred: i1) {
     ttng.tc_gen5_mma %a, %b, %c, %useAcc, %pred, %barrier[%barrierPred] {is_async} :
-       !ttg.memdesc<256x128xf16, #shared, #ttg.shared_memory>,
-       !ttg.memdesc<128x256xf16, #shared1, #ttg.shared_memory>,
-       !ttg.memdesc<256x256xf32, #tmem, #ttng.tensor_memory, mutable>,
+       !ttg.memdesc<256x16xf16, #shared, #ttg.shared_memory>,
+       !ttg.memdesc<16x128xf16, #shared1, #ttg.shared_memory>,
+       !ttg.memdesc<256x128xf32, #tmem, #ttng.tensor_memory, mutable>,
        !ttg.memdesc<1xi64, #shared2, #ttg.shared_memory>
+    tt.return
+  }
+
+  // CHECK-LABEL: @tc_gen5_mma_ab_reuse_b_major
+  // Equal-sized A and B tiles retain B-major traversal. Reverse M at the N
+  // boundary to keep A as well, without changing any accumulator's K order.
+  // CHECK: %[[BM_BASE:.+]] = llvm.ptrtoint %arg2 : !llvm.ptr<3> to i32
+  // CHECK: %[[BM_E:.+]] = nvvm.elect.sync -> i1
+  // CHECK: kind::f16.collector::b::fill [ $0 + 0 ], $1, $2, $3, $4;", "r,l,l,r,b,b" %[[BM_BASE]], %[[BM_A0:[^,]+]], %[[BM_B0:[^,]+]], %{{[^,]+}}, %arg3, %[[BM_E]]
+  // CHECK: kind::f16.collector::a::fill.collector::b::lastuse [ $0 + 128 ], $1, $2, $3, $4;", "r,l,l,r,b,b" %[[BM_BASE]], %[[BM_A1:[^,]+]], %[[BM_B0]], %{{[^,]+}}, %arg3, %[[BM_E]]
+  // CHECK: kind::f16.collector::a::lastuse.collector::b::fill [ $0 + 384 ], $1, $2, $3, $4;", "r,l,l,r,b,b" %[[BM_BASE]], %[[BM_A1]], %[[BM_B1:[^,]+]], %{{[^,]+}}, %arg3, %[[BM_E]]
+  // CHECK: kind::f16.collector::b::lastuse [ $0 + 256 ], $1, $2, $3, $4;", "r,l,l,r,b,b" %[[BM_BASE]], %[[BM_A0]], %[[BM_B1]], %{{[^,]+}}, %arg3, %[[BM_E]]
+  // CHECK: %[[BM_TRUE:.+]] = llvm.mlir.constant(true) : i1
+  // CHECK: kind::f16.collector::b::fill [ $0 + 0 ], $1, $2, $3, $4;", "r,l,l,r,b,b" %[[BM_BASE]], %[[BM_A2:[^,]+]], %[[BM_B2:[^,]+]], %{{[^,]+}}, %[[BM_TRUE]], %[[BM_E]]
+  // CHECK: kind::f16.collector::a::fill.collector::b::lastuse [ $0 + 128 ], $1, $2, $3, $4;", "r,l,l,r,b,b" %[[BM_BASE]], %[[BM_A3:[^,]+]], %[[BM_B2]], %{{[^,]+}}, %[[BM_TRUE]], %[[BM_E]]
+  // CHECK: kind::f16.collector::a::lastuse.collector::b::fill [ $0 + 384 ], $1, $2, $3, $4;", "r,l,l,r,b,b" %[[BM_BASE]], %[[BM_A3]], %[[BM_B3:[^,]+]], %{{[^,]+}}, %[[BM_TRUE]], %[[BM_E]]
+  // CHECK: kind::f16.collector::b::lastuse [ $0 + 256 ], $1, $2, $3, $4;", "r,l,l,r,b,b" %[[BM_BASE]], %[[BM_A2]], %[[BM_B3]], %{{[^,]+}}, %[[BM_TRUE]], %[[BM_E]]
+  // CHECK-NOT: tcgen05.mma
+  tt.func @tc_gen5_mma_ab_reuse_b_major(
+      %a: !ttg.memdesc<256x32xf16, #shared, #ttg.shared_memory>,
+      %b: !ttg.memdesc<32x256xf16, #shared1, #ttg.shared_memory>,
+      %c: !ttg.memdesc<256x256xf32, #tmem, #ttng.tensor_memory, mutable>,
+      %useAcc: i1, %pred: i1) {
+    ttng.tc_gen5_mma %a, %b, %c, %useAcc, %pred :
+      !ttg.memdesc<256x32xf16, #shared, #ttg.shared_memory>,
+      !ttg.memdesc<32x256xf16, #shared1, #ttg.shared_memory>,
+      !ttg.memdesc<256x256xf32, #tmem, #ttng.tensor_memory, mutable>
+    tt.return
+  }
+
+  // CHECK-LABEL: @tc_gen5_mma_ab_reuse_a_major
+  // A is twice as large as B, so traverse N first and reuse B at the turn.
+  // CHECK: %[[AM_BASE:.+]] = llvm.ptrtoint %arg2 : !llvm.ptr<3> to i32
+  // CHECK: kind::f16.collector::a::fill [ $0 + 0 ], $1, $2, $3, $4;", "r,l,l,r,b,b" %[[AM_BASE]], %[[AM_A0:[^,]+]], %{{[^,]+}},
+  // CHECK: kind::f16.collector::a::lastuse.collector::b::fill [ $0 + 128 ], $1, $2, $3, $4;", "r,l,l,r,b,b" %[[AM_BASE]], %[[AM_A0]], %[[AM_B1:[^,]+]],
+  // CHECK: kind::f16.collector::a::fill.collector::b::lastuse [ $0 + 192 ], $1, $2, $3, $4;", "r,l,l,r,b,b" %[[AM_BASE]], %[[AM_A1:[^,]+]], %[[AM_B1]],
+  // CHECK: kind::f16.collector::a::lastuse [ $0 + 64 ], $1, $2, $3, $4;", "r,l,l,r,b,b" %[[AM_BASE]], %[[AM_A1]],
+  // CHECK-NOT: tcgen05.mma
+  tt.func @tc_gen5_mma_ab_reuse_a_major(
+      %a: !ttg.memdesc<256x16xf16, #shared, #ttg.shared_memory>,
+      %b: !ttg.memdesc<16x128xf16, #shared1, #ttg.shared_memory>,
+      %c: !ttg.memdesc<256x128xf32, #tmem_n64, #ttng.tensor_memory, mutable>,
+      %useAcc: i1, %pred: i1) {
+    ttng.tc_gen5_mma %a, %b, %c, %useAcc, %pred :
+      !ttg.memdesc<256x16xf16, #shared, #ttg.shared_memory>,
+      !ttg.memdesc<16x128xf16, #shared1, #ttg.shared_memory>,
+      !ttg.memdesc<256x128xf32, #tmem_n64, #ttng.tensor_memory, mutable>
+    tt.return
+  }
+
+  // CHECK-LABEL: @tc_gen5_mma_m64_no_reuse
+  // Neither collector is eligible across the half-datapath M=64 tiles.
+  // CHECK: kind::f16 [ $0 + 0 ]
+  // CHECK: kind::f16 [ $0 + 64 ]
+  // CHECK: kind::f16 [ $0 + 1048576 ]
+  // CHECK: kind::f16 [ $0 + 1048640 ]
+  // CHECK-NOT: tcgen05.mma
+  tt.func @tc_gen5_mma_m64_no_reuse(
+      %a: !ttg.memdesc<128x16xf16, #shared, #ttg.shared_memory>,
+      %b: !ttg.memdesc<16x128xf16, #shared1, #ttg.shared_memory>,
+      %c: !ttg.memdesc<128x128xf32, #tmem_m64, #ttng.tensor_memory, mutable>,
+      %useAcc: i1, %pred: i1) {
+    ttng.tc_gen5_mma %a, %b, %c, %useAcc, %pred :
+      !ttg.memdesc<128x16xf16, #shared, #ttg.shared_memory>,
+      !ttg.memdesc<16x128xf16, #shared1, #ttg.shared_memory>,
+      !ttg.memdesc<128x128xf32, #tmem_m64, #ttng.tensor_memory, mutable>
     tt.return
   }
 }
@@ -205,24 +273,32 @@ module attributes {"ttg.num-ctas" = 8 : i32, "ttg.num-warps" = 4 : i32, ttg.targ
 #tmem = #ttng.tensor_memory_encoding<blockM = 128, blockN = 128, colStride = 1>
 #tmem_scales = #ttng.tensor_memory_scales_encoding<>
 module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.target = "cuda:107"} {
-  // CHECK-LABEL: @tc_gen5_mma_block_scale_breuse
-  // CHECK: tcgen05.mma.cta_group::1.kind::mxf8f6f4.block_scale.block32.collector::b::fill
-  // CHECK: tcgen05.mma.cta_group::1.kind::mxf8f6f4.block_scale.block32.collector::b::lastuse
-  tt.func @tc_gen5_mma_block_scale_breuse(%a: !ttg.memdesc<256x64xf8E4M3FN, #shared, #ttg.shared_memory>,
-                       %b: !ttg.memdesc<32x128xi8, #shared1, #ttg.shared_memory>,
-                       %c: !ttg.memdesc<256x128xf32, #tmem, #ttng.tensor_memory, mutable>,
+  // CHECK-LABEL: @tc_gen5_mma_block_scale_ab_reuse
+  // FP8 A takes twice the bytes of packed FP4 B, despite equal M/N tile sizes.
+  // CHECK: kind::mxf8f6f4.block_scale.block32.collector::a::fill [ $0 + 0 ]
+  // CHECK-SAME: "r,l,l,r,r,r,b,b" %{{[^,]+}}, %{{[^,]+}}, %{{[^,]+}}, %[[SC_ID:[^,]+]], %[[SC_A0:[^,]+]], %[[SC_B0:[^,]+]],
+  // CHECK: kind::mxf8f6f4.block_scale.block32.collector::a::lastuse.collector::b::fill [ $0 + 256 ]
+  // CHECK-SAME: "r,l,l,r,r,r,b,b" %{{[^,]+}}, %{{[^,]+}}, %{{[^,]+}}, %[[SC_ID]], %[[SC_A0]], %[[SC_B1:[^,]+]],
+  // CHECK: kind::mxf8f6f4.block_scale.block32.collector::a::fill.collector::b::lastuse [ $0 + 384 ]
+  // CHECK-SAME: "r,l,l,r,r,r,b,b" %{{[^,]+}}, %{{[^,]+}}, %{{[^,]+}}, %[[SC_ID]], %[[SC_A1:[^,]+]], %[[SC_B1]],
+  // CHECK: kind::mxf8f6f4.block_scale.block32.collector::a::lastuse [ $0 + 128 ]
+  // CHECK-SAME: "r,l,l,r,r,r,b,b" %{{[^,]+}}, %{{[^,]+}}, %{{[^,]+}}, %[[SC_ID]], %[[SC_A1]], %[[SC_B0]],
+  // CHECK-NOT: tcgen05.mma
+  tt.func @tc_gen5_mma_block_scale_ab_reuse(%a: !ttg.memdesc<256x64xf8E4M3FN, #shared, #ttg.shared_memory>,
+                       %b: !ttg.memdesc<32x256xi8, #shared1, #ttg.shared_memory>,
+                       %c: !ttg.memdesc<256x256xf32, #tmem, #ttng.tensor_memory, mutable>,
                        %scale_a: !ttg.memdesc<256x2xi8, #tmem_scales, #ttng.tensor_memory>,
-                       %scale_b: !ttg.memdesc<128x2xi8, #tmem_scales, #ttng.tensor_memory>,
+                       %scale_b: !ttg.memdesc<256x2xi8, #tmem_scales, #ttng.tensor_memory>,
                        %useAcc: i1,
                        %pred: i1,
                        %barrier: !ttg.memdesc<1xi64, #shared2, #ttg.shared_memory, mutable>,
                        %barrierPred: i1) {
     ttng.tc_gen5_mma_scaled %a, %b, %c, %scale_a, %scale_b, %useAcc, %pred lhs = e4m3 rhs = e2m1, %barrier[%barrierPred] {is_async} :
     !ttg.memdesc<256x64xf8E4M3FN, #shared, #ttg.shared_memory>,
-    !ttg.memdesc<32x128xi8, #shared1, #ttg.shared_memory>,
-    !ttg.memdesc<256x128xf32, #tmem, #ttng.tensor_memory, mutable>,
+    !ttg.memdesc<32x256xi8, #shared1, #ttg.shared_memory>,
+    !ttg.memdesc<256x256xf32, #tmem, #ttng.tensor_memory, mutable>,
     !ttg.memdesc<256x2xi8, #tmem_scales, #ttng.tensor_memory>,
-    !ttg.memdesc<128x2xi8, #tmem_scales, #ttng.tensor_memory>,
+    !ttg.memdesc<256x2xi8, #tmem_scales, #ttng.tensor_memory>,
     !ttg.memdesc<1xi64, #shared2, #ttg.shared_memory, mutable>
     tt.return
   }

--- a/test/Conversion/tritongpu_to_llvm_rubin.mlir
+++ b/test/Conversion/tritongpu_to_llvm_rubin.mlir
@@ -132,19 +132,22 @@ module attributes {"ttg.num-ctas" = 2 : i32, "ttg.num-warps" = 4 : i32, ttg.targ
 #tmem = #ttng.tensor_memory_encoding<blockM = 128, blockN = 128, colStride = 1>
 module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 8 : i32, ttg.target = "cuda:107"} {
   // CHECK-LABEL: @tc_gen5_mma_breuse
+  // Both operands can be reused; retain the Rubin B-reuse schedule.
+  // CHECK-NOT: collector::a
   // CHECK: tcgen05.mma.cta_group::1.kind::f16.collector::b::fill
   // CHECK: tcgen05.mma.cta_group::1.kind::f16.collector::b::lastuse
+  // CHECK-NOT: collector::a
   tt.func @tc_gen5_mma_breuse(%a: !ttg.memdesc<256x128xf16, #shared, #ttg.shared_memory>,
-                       %b: !ttg.memdesc<128x128xf16, #shared1, #ttg.shared_memory>,
-                       %c: !ttg.memdesc<256x128xf32, #tmem, #ttng.tensor_memory, mutable>,
+                       %b: !ttg.memdesc<128x256xf16, #shared1, #ttg.shared_memory>,
+                       %c: !ttg.memdesc<256x256xf32, #tmem, #ttng.tensor_memory, mutable>,
                        %useAcc: i1,
                        %pred: i1,
                        %barrier: !ttg.memdesc<1xi64, #shared2, #ttg.shared_memory>,
                        %barrierPred: i1) {
     ttng.tc_gen5_mma %a, %b, %c, %useAcc, %pred, %barrier[%barrierPred] {is_async} :
        !ttg.memdesc<256x128xf16, #shared, #ttg.shared_memory>,
-       !ttg.memdesc<128x128xf16, #shared1, #ttg.shared_memory>,
-       !ttg.memdesc<256x128xf32, #tmem, #ttng.tensor_memory, mutable>,
+       !ttg.memdesc<128x256xf16, #shared1, #ttg.shared_memory>,
+       !ttg.memdesc<256x256xf32, #tmem, #ttng.tensor_memory, mutable>,
        !ttg.memdesc<1xi64, #shared2, #ttg.shared_memory>
     tt.return
   }

--- a/third_party/nvidia/lib/TritonNVIDIAGPUToLLVM/DotOpToLLVM/MMAv5.cpp
+++ b/third_party/nvidia/lib/TritonNVIDIAGPUToLLVM/DotOpToLLVM/MMAv5.cpp
@@ -357,7 +357,7 @@ void createGen5MMA(ConversionPatternRewriter &rewriter, Location loc,
                    ttng::TCGen5MMAOp op, MemDescOperand a, Value b,
                    MemDescOperand d, Value pred, Value instDescriptor,
                    Value useInitAcc, bool aInTMem, bool twoCTAs,
-                   std::string collectorB) {
+                   std::string collector) {
   PTXBuilder ptxBuilder;
   std::string opcode =
       "tcgen05.mma.cta_group::" + std::to_string(twoCTAs ? 2 : 1) + ".kind::";
@@ -375,7 +375,7 @@ void createGen5MMA(ConversionPatternRewriter &rewriter, Location loc,
   } else {
     assert(0 && "Unsupported type.");
   }
-  opcode += collectorB;
+  opcode += collector;
   auto *accOp = ptxBuilder.newAddrOperand(d.base, "r", *d.offset);
   assert(a.offset.has_value() == aInTMem);
   auto *aOp = aInTMem ? ptxBuilder.newAddrOperand(a.base, "r", *a.offset)
@@ -393,7 +393,7 @@ void createScaledGen5MMA(ConversionPatternRewriter &rewriter, Location loc,
                          MemDescOperand d, Value scaleA, Value scaleB,
                          Value pred, Value instDescriptor, Value useInitAcc,
                          bool aInTmem, mxfpKind mxfpInstKind, bool twoCTAs,
-                         std::string collectorB) {
+                         std::string collector) {
   PTXBuilder ptxBuilder;
   std::string opcode =
       "tcgen05.mma.cta_group::" + std::to_string(twoCTAs ? 2 : 1) + ".kind::";
@@ -407,7 +407,7 @@ void createScaledGen5MMA(ConversionPatternRewriter &rewriter, Location loc,
   } else {
     assert(0 && "Unsupported mxfp kind.");
   }
-  opcode += collectorB;
+  opcode += collector;
   auto *accOp = ptxBuilder.newAddrOperand(d.base, "r", *d.offset);
   assert(aInTmem == a.offset.has_value());
   auto *aOp = aInTmem ? ptxBuilder.newAddrOperand(a.base, "r", *a.offset)
@@ -462,11 +462,14 @@ void createMMACommit(ConversionPatternRewriter &rewriter, Location loc,
 // MMAv5 Conversion
 //===----------------------------------------------------------------------===//
 
-enum class ReuseB {
+enum class OperandReuse {
   None,
-  Keep,
-  Use,
-  Lastuse,
+  AFill,
+  AUse,
+  ALastuse,
+  BFill,
+  BUse,
+  BLastuse,
 };
 
 // Information about how to lower a dot operation, shared between regular and
@@ -489,7 +492,7 @@ struct DotConversion {
       ConversionPatternRewriter &, Location, int, int, const InstDesc &)>;
   using CreateMMAInstFn = std::function<void(
       ConversionPatternRewriter &, Location, MemDescOperand, MemDescOperand,
-      Value, Value, Value, const InstDesc &, int, int, int, ReuseB)>;
+      Value, Value, Value, const InstDesc &, int, int, int, OperandReuse)>;
 
   struct {
     unsigned M;
@@ -629,9 +632,37 @@ LogicalResult convertDotImpl(const LLVMTypeConverter &typeConverter,
               op.getAccAddress(rewriter, loc, m, n, desc);
           MemDescOperand a =
               aLoader->memLoad(m * mmaSizeM, k * mmaSizeK, rewriter, loc);
-          ReuseB reuseB = m == 0 ? ReuseB::Keep : ReuseB::Lastuse;
+          OperandReuse reuse =
+              m == 0 ? OperandReuse::BFill : OperandReuse::BLastuse;
           op.createMMAInst(rewriter, loc, accAddress, a, b, elect, useInitAcc,
-                           desc, m, n, k, reuseB);
+                           desc, m, n, k, reuse);
+        }
+        useInitAcc = tb.i1_val(1);
+      }
+    }
+  } else if (mmaSizeM == 128 && numRepN > 1 &&
+             targetFeatures.supportsReuseA()) {
+    // Keep one A tile in the collector across the N tiles. Interleaving N
+    // inside K preserves the accumulation order and the first-K useD flag for
+    // every destination tile. Reuse is opportunistic, so A remains live until
+    // the whole MMA operation completes, just as on the non-reuse path.
+    // M=64 uses half the datapath and can interleave N tiles across TMEM lane
+    // alignments 0 and 16. A collector cannot be reused across that change.
+    for (int m = 0; m < numRepM; m++) {
+      Value useInitAcc = useDFlag;
+      for (int k = 0; k < numRepK; k++) {
+        MemDescOperand a = aLoader->memLoad(
+            m * aOperandShape[0], k * aOperandShape[1], rewriter, loc);
+        for (int n = 0; n < numRepN; n++) {
+          MemDescOperand accAddress =
+              op.getAccAddress(rewriter, loc, m, n, desc);
+          Value b = bLoader->smemLoad(k * bOperandShape[0],
+                                      n * bOperandShape[1], rewriter, loc);
+          OperandReuse reuse = n == 0             ? OperandReuse::AFill
+                               : n == numRepN - 1 ? OperandReuse::ALastuse
+                                                  : OperandReuse::AUse;
+          op.createMMAInst(rewriter, loc, accAddress, a, b, elect, useInitAcc,
+                           desc, m, n, k, reuse);
         }
         useInitAcc = tb.i1_val(1);
       }
@@ -647,7 +678,7 @@ LogicalResult convertDotImpl(const LLVMTypeConverter &typeConverter,
           Value b = bLoader->smemLoad(k * bOperandShape[0],
                                       n * bOperandShape[1], rewriter, loc);
           op.createMMAInst(rewriter, loc, accAddress, a, b, elect, useInitAcc,
-                           desc, m, n, k, ReuseB::None);
+                           desc, m, n, k, OperandReuse::None);
           useInitAcc = tb.i1_val(1);
         }
       }
@@ -665,15 +696,24 @@ LogicalResult convertDotImpl(const LLVMTypeConverter &typeConverter,
   return success();
 }
 
-std::string getCollectorBModifer(ReuseB reuseB) {
-  if (reuseB == ReuseB::Keep) {
+std::string getCollectorModifier(OperandReuse reuse) {
+  switch (reuse) {
+  case OperandReuse::AFill:
+    return ".collector::a::fill";
+  case OperandReuse::AUse:
+    return ".collector::a::use";
+  case OperandReuse::ALastuse:
+    return ".collector::a::lastuse";
+  case OperandReuse::BFill:
     return ".collector::b::fill";
-  } else if (reuseB == ReuseB::Use) {
+  case OperandReuse::BUse:
     return ".collector::b::use";
-  } else if (reuseB == ReuseB::Lastuse) {
+  case OperandReuse::BLastuse:
     return ".collector::b::lastuse";
+  case OperandReuse::None:
+    return "";
   }
-  return "";
+  llvm_unreachable("unsupported collector operation");
 }
 
 LogicalResult convertDot(const LLVMTypeConverter &typeConverter,
@@ -724,7 +764,7 @@ LogicalResult convertDot(const LLVMTypeConverter &typeConverter,
                           MemDescOperand accAddress, MemDescOperand a, Value b,
                           Value pred, Value useInitAcc,
                           const DotConversion::InstDesc &desc, int m, int n,
-                          int k, ReuseB reuseB) {
+                          int k, OperandReuse reuse) {
     // mmaSizeM/N is the per-cta size M/N, while the 2CTA instruction expects
     // the 2CTA size mmaSize is always 64 / 128 so we double it for 2CTA
     auto mmaSizeM = twoCTAs ? desc.mmaSizeM * 2 : desc.mmaSizeM;
@@ -733,9 +773,9 @@ LogicalResult convertDot(const LLVMTypeConverter &typeConverter,
     Value instDescriptor =
         createInstDescriptor(rewriter, op, mmaSizeM, mmaSizeN, desc.transA,
                              desc.transB, dot.mmaSizeK);
-    auto collectorB = getCollectorBModifer(reuseB);
+    auto collector = getCollectorModifier(reuse);
     createGen5MMA(rewriter, loc, op, a, b, accAddress, pred, instDescriptor,
-                  useInitAcc, desc.aInTmem, twoCTAs, collectorB);
+                  useInitAcc, desc.aInTmem, twoCTAs, collector);
   };
 
   return convertDotImpl(
@@ -866,7 +906,7 @@ LogicalResult convertScaledDot(const LLVMTypeConverter &typeConverter,
                           MemDescOperand accAddress, MemDescOperand a, Value b,
                           Value pred, Value useInitAcc,
                           const DotConversion::InstDesc &desc, int m, int n,
-                          int k, ReuseB reuseB) {
+                          int k, OperandReuse reuse) {
     auto [numRepM, numRepN, numRepK] = desc.repShape;
     int scaleFactorColsPerSet =
         getScaleFactorColsPerSet(mxfpInstKind, op, dot.mmaSizeK);
@@ -904,10 +944,10 @@ LogicalResult convertScaledDot(const LLVMTypeConverter &typeConverter,
           subWordIdx, subWordIdx, mxfpInstKind, blockK, dot.mmaSizeK);
     }
 
-    auto collectorB = getCollectorBModifer(reuseB);
+    auto collector = getCollectorModifier(reuse);
     createScaledGen5MMA(rewriter, loc, op, a, b, accAddress, scaleA, scaleB,
                         pred, instDescriptor, useInitAcc, desc.aInTmem,
-                        mxfpInstKind, twoCTAs, collectorB);
+                        mxfpInstKind, twoCTAs, collector);
   };
 
   return convertDotImpl(

--- a/third_party/nvidia/lib/TritonNVIDIAGPUToLLVM/DotOpToLLVM/MMAv5.cpp
+++ b/third_party/nvidia/lib/TritonNVIDIAGPUToLLVM/DotOpToLLVM/MMAv5.cpp
@@ -6,6 +6,8 @@
 #include "triton/Conversion/TritonGPUToLLVM/PatternTritonGPUOpToLLVM.h"
 #include "triton/Dialect/TritonNvidiaGPU/IR/NvmmaSmemAttrs.h"
 
+#include <array>
+
 using namespace mlir;
 using namespace mlir::triton;
 using namespace mlir::triton::gpu;
@@ -353,73 +355,60 @@ static Value createScaleInstDescriptorFp4(
 // tcgen05 instructions
 //===----------------------------------------------------------------------===//
 
-void createGen5MMA(ConversionPatternRewriter &rewriter, Location loc,
-                   ttng::TCGen5MMAOp op, MemDescOperand a, Value b,
-                   MemDescOperand d, Value pred, Value instDescriptor,
-                   Value useInitAcc, bool aInTMem, bool twoCTAs,
-                   std::string collector) {
-  PTXBuilder ptxBuilder;
-  std::string opcode =
-      "tcgen05.mma.cta_group::" + std::to_string(twoCTAs ? 2 : 1) + ".kind::";
-  Type srcElementTy = op.getA().getType().getElementType();
-  if (srcElementTy.isF16() || srcElementTy.isBF16()) {
-    opcode += "f16";
-  } else if (srcElementTy.isF32()) {
-    opcode += "tf32";
-  } else if (llvm::isa<Float8E4M3FNType, Float8E5M2Type>(srcElementTy)) {
-    opcode += "f8f6f4";
-  } else if (op.getD().getType().getElementType().isInteger(32)) {
-    // PTX uses "i8" for integer operations (both signed and unsigned)
-    // The signed/unsigned distinction is encoded in the instruction descriptor
-    opcode += "i8";
-  } else {
-    assert(0 && "Unsupported type.");
+enum class CollectorAction { None, Fill, Use, Lastuse };
+
+struct OperandReuse {
+  CollectorAction a = CollectorAction::None;
+  CollectorAction b = CollectorAction::None;
+};
+
+struct MMAInstOperands {
+  Value descriptor;
+  Value scaleA;
+  Value scaleB;
+};
+
+std::string getCollectorModifier(CollectorAction reuse, StringRef operand) {
+  StringRef action;
+  switch (reuse) {
+  case CollectorAction::None:
+    return "";
+  case CollectorAction::Fill:
+    action = "fill";
+    break;
+  case CollectorAction::Use:
+    action = "use";
+    break;
+  case CollectorAction::Lastuse:
+    action = "lastuse";
+    break;
   }
-  opcode += collector;
-  auto *accOp = ptxBuilder.newAddrOperand(d.base, "r", *d.offset);
-  assert(a.offset.has_value() == aInTMem);
-  auto *aOp = aInTMem ? ptxBuilder.newAddrOperand(a.base, "r", *a.offset)
-                      : ptxBuilder.newOperand(a.base, "l");
-  auto *bOp = ptxBuilder.newOperand(b, "l");
-  auto *instDescOp = ptxBuilder.newOperand(instDescriptor, "r");
-  auto *useInitAccOp = ptxBuilder.newOperand(useInitAcc, "b");
-  auto &mmaOp = *ptxBuilder.create(opcode);
-  mmaOp({accOp, aOp, bOp, instDescOp, useInitAccOp}).predicate(pred);
-  ptxBuilder.launch(rewriter, loc, void_ty(rewriter.getContext()));
+  return ".collector::" + operand.str() + "::" + action.str();
 }
 
-void createScaledGen5MMA(ConversionPatternRewriter &rewriter, Location loc,
-                         ttng::TCGen5MMAScaledOp op, MemDescOperand a, Value b,
-                         MemDescOperand d, Value scaleA, Value scaleB,
-                         Value pred, Value instDescriptor, Value useInitAcc,
-                         bool aInTmem, mxfpKind mxfpInstKind, bool twoCTAs,
-                         std::string collector) {
+void createGen5MMA(ConversionPatternRewriter &rewriter, Location loc,
+                   StringRef kind, MemDescOperand a, Value b, MemDescOperand d,
+                   Value pred, const MMAInstOperands &inst, Value useInitAcc,
+                   bool twoCTAs, OperandReuse reuse) {
   PTXBuilder ptxBuilder;
   std::string opcode =
-      "tcgen05.mma.cta_group::" + std::to_string(twoCTAs ? 2 : 1) + ".kind::";
-  if (mxfpInstKind == mxfpKind::mxf8f6f4) {
-    opcode += "mxf8f6f4.block_scale.block32";
-  } else if (mxfpInstKind == mxfpKind::mxf4) {
-    opcode += "mxf4.block_scale.block32";
-  } else if (mxfpInstKind == mxfpKind::mxf4nvf4) {
-    opcode += getScaleVecSize(op) == 32 ? "mxf4nvf4.block_scale.block32"
-                                        : "mxf4nvf4.block_scale.block16";
-  } else {
-    assert(0 && "Unsupported mxfp kind.");
-  }
-  opcode += collector;
+      "tcgen05.mma.cta_group::" + std::to_string(twoCTAs ? 2 : 1) +
+      ".kind::" + kind.str() + getCollectorModifier(reuse.a, "a") +
+      getCollectorModifier(reuse.b, "b");
   auto *accOp = ptxBuilder.newAddrOperand(d.base, "r", *d.offset);
-  assert(aInTmem == a.offset.has_value());
-  auto *aOp = aInTmem ? ptxBuilder.newAddrOperand(a.base, "r", *a.offset)
-                      : ptxBuilder.newOperand(a.base, "l");
+  auto *aOp = a.offset ? ptxBuilder.newAddrOperand(a.base, "r", *a.offset)
+                       : ptxBuilder.newOperand(a.base, "l");
   auto *bOp = ptxBuilder.newOperand(b, "l");
-  auto *instDescOp = ptxBuilder.newOperand(instDescriptor, "r");
-  auto *scaleAOp = ptxBuilder.newAddrOperand(scaleA, "r");
-  auto *scaleBOp = ptxBuilder.newAddrOperand(scaleB, "r");
-  auto *useInitAccOp = ptxBuilder.newOperand(useInitAcc, "b");
+  auto *instDescOp = ptxBuilder.newOperand(inst.descriptor, "r");
+  SmallVector<PTXBuilder::Operand *> operands{accOp, aOp, bOp, instDescOp};
+  assert(bool(inst.scaleA) == bool(inst.scaleB));
+  if (inst.scaleA) {
+    operands.push_back(ptxBuilder.newAddrOperand(inst.scaleA, "r"));
+    operands.push_back(ptxBuilder.newAddrOperand(inst.scaleB, "r"));
+  }
+  operands.push_back(ptxBuilder.newOperand(useInitAcc, "b"));
   auto &mmaOp = *ptxBuilder.create(opcode);
-  mmaOp({accOp, aOp, bOp, instDescOp, scaleAOp, scaleBOp, useInitAccOp})
-      .predicate(pred);
+  mmaOp(operands).predicate(pred);
   ptxBuilder.launch(rewriter, loc, void_ty(rewriter.getContext()));
 }
 
@@ -462,16 +451,6 @@ void createMMACommit(ConversionPatternRewriter &rewriter, Location loc,
 // MMAv5 Conversion
 //===----------------------------------------------------------------------===//
 
-enum class OperandReuse {
-  None,
-  AFill,
-  AUse,
-  ALastuse,
-  BFill,
-  BUse,
-  BLastuse,
-};
-
 // Information about how to lower a dot operation, shared between regular and
 // scaled dot.
 struct DotConversion {
@@ -485,14 +464,10 @@ struct DotConversion {
     } repShape;
     bool transA;
     bool transB;
-    bool aInTmem;
   };
 
-  using GetAccAddressFn = std::function<MemDescOperand(
-      ConversionPatternRewriter &, Location, int, int, const InstDesc &)>;
-  using CreateMMAInstFn = std::function<void(
-      ConversionPatternRewriter &, Location, MemDescOperand, MemDescOperand,
-      Value, Value, Value, const InstDesc &, int, int, int, OperandReuse)>;
+  using GetInstOperandsFn =
+      std::function<MMAInstOperands(const InstDesc &, int, int, int)>;
 
   struct {
     unsigned M;
@@ -502,20 +477,22 @@ struct DotConversion {
   int mmaSizeK;
   int numBitsPerElementA;
   int numBitsPerElementB;
-  GetAccAddressFn getAccAddress;
-  CreateMMAInstFn createMMAInst;
+  StringRef kind;
+  GetInstOperandsFn getInstOperands;
 };
 
 LogicalResult convertDotImpl(const LLVMTypeConverter &typeConverter,
                              ConversionPatternRewriter &rewriter, Location loc,
                              Value a, Value b, Value loadedA, Value loadedB,
-                             MemDescType dTensorTy, Value useDFlag, Value pred,
-                             ValueRange barriers, ValueRange barrierPreds,
-                             bool twoCTAs, ValueRange commitDescs,
-                             bool opKindIsMXFP4,
+                             MemDescType dTensorTy, Value loadedD,
+                             Value useDFlag, Value pred, ValueRange barriers,
+                             ValueRange barrierPreds, bool twoCTAs,
+                             ValueRange commitDescs,
                              const ttng::TargetFeatures &targetFeatures,
                              const DotConversion &op) {
   auto tb = TritonLLVMOpBuilder(loc, rewriter);
+  auto dLoader = DotOpMmaV5TmemLoader::build(
+      loc, rewriter, dTensorTy, loadedD, dTensorTy.getElementTypeBitWidth());
 
   // Only run mma on one thread. We currently use elect as ptxas is not able to
   // detect that tid.x == 0 is true only for 1 thread.
@@ -616,73 +593,68 @@ LogicalResult convertDotImpl(const LLVMTypeConverter &typeConverter,
                                 "float32 operands in shared memory");
   }
 
-  DotConversion::InstDesc desc{mmaSizeM, mmaSizeN, {numRepM, numRepN, numRepK},
-                               transA,   transB,   aInTmem};
+  DotConversion::InstDesc desc{
+      mmaSizeM, mmaSizeN, {numRepM, numRepN, numRepK}, transA, transB};
 
   // B reuse requires M = 128 for 1CTA or 256 for 2CTA, which corresponds to
   // the condition mmaSizeM == 128 here
-  if (numRepM == 2 && mmaSizeM == 128 && targetFeatures.supportsReuseB()) {
-    for (int n = 0; n < numRepN; n++) {
-      Value useInitAcc = useDFlag;
-      for (int k = 0; k < numRepK; k++) {
-        Value b = bLoader->smemLoad(k * bOperandShape[0], n * bOperandShape[1],
-                                    rewriter, loc);
-        for (int m = 0; m < 2; m++) {
-          MemDescOperand accAddress =
-              op.getAccAddress(rewriter, loc, m, n, desc);
-          MemDescOperand a =
-              aLoader->memLoad(m * mmaSizeM, k * mmaSizeK, rewriter, loc);
-          OperandReuse reuse =
-              m == 0 ? OperandReuse::BFill : OperandReuse::BLastuse;
-          op.createMMAInst(rewriter, loc, accAddress, a, b, elect, useInitAcc,
-                           desc, m, n, k, reuse);
-        }
-        useInitAcc = tb.i1_val(1);
-      }
+  bool reuseB =
+      numRepM == 2 && mmaSizeM == 128 && targetFeatures.supportsReuseB();
+  // Keep one A tile in the collector across the N tiles. Interleaving N
+  // inside K preserves the accumulation order and the first-K useD flag for
+  // every destination tile. Reuse is opportunistic, so A remains live until
+  // the whole MMA operation completes, just as on the non-reuse path.
+  // M=64 uses half the datapath and can interleave N tiles across TMEM lane
+  // alignments 0 and 16. A collector cannot be reused across that change.
+  bool reuseA = !reuseB && mmaSizeM == 128 && numRepN > 1 &&
+                targetFeatures.supportsReuseA();
+
+  // Dimensions are M, N, K. Keep the original traversal when neither
+  // collector is used, and put the reused operand's other dimension innermost.
+  std::array<int, 3> numReps{numRepM, numRepN, numRepK};
+  std::array<int, 3> order = reuseB   ? std::array{1, 2, 0}
+                             : reuseA ? std::array{0, 2, 1}
+                                      : std::array{0, 1, 2};
+  auto getIndices = [&](int64_t index) {
+    std::array<int, 3> indices;
+    for (int dim : llvm::reverse(order)) {
+      indices[dim] = index % numReps[dim];
+      index /= numReps[dim];
     }
-  } else if (mmaSizeM == 128 && numRepN > 1 &&
-             targetFeatures.supportsReuseA()) {
-    // Keep one A tile in the collector across the N tiles. Interleaving N
-    // inside K preserves the accumulation order and the first-K useD flag for
-    // every destination tile. Reuse is opportunistic, so A remains live until
-    // the whole MMA operation completes, just as on the non-reuse path.
-    // M=64 uses half the datapath and can interleave N tiles across TMEM lane
-    // alignments 0 and 16. A collector cannot be reused across that change.
-    for (int m = 0; m < numRepM; m++) {
-      Value useInitAcc = useDFlag;
-      for (int k = 0; k < numRepK; k++) {
-        MemDescOperand a = aLoader->memLoad(
-            m * aOperandShape[0], k * aOperandShape[1], rewriter, loc);
-        for (int n = 0; n < numRepN; n++) {
-          MemDescOperand accAddress =
-              op.getAccAddress(rewriter, loc, m, n, desc);
-          Value b = bLoader->smemLoad(k * bOperandShape[0],
-                                      n * bOperandShape[1], rewriter, loc);
-          OperandReuse reuse = n == 0             ? OperandReuse::AFill
-                               : n == numRepN - 1 ? OperandReuse::ALastuse
-                                                  : OperandReuse::AUse;
-          op.createMMAInst(rewriter, loc, accAddress, a, b, elect, useInitAcc,
-                           desc, m, n, k, reuse);
-        }
-        useInitAcc = tb.i1_val(1);
-      }
-    }
-  } else {
-    for (int m = 0; m < numRepM; m++) {
-      for (int n = 0; n < numRepN; n++) {
-        Value useInitAcc = useDFlag;
-        MemDescOperand accAddress = op.getAccAddress(rewriter, loc, m, n, desc);
-        for (int k = 0; k < numRepK; k++) {
-          MemDescOperand a = aLoader->memLoad(
-              m * aOperandShape[0], k * aOperandShape[1], rewriter, loc);
-          Value b = bLoader->smemLoad(k * bOperandShape[0],
-                                      n * bOperandShape[1], rewriter, loc);
-          op.createMMAInst(rewriter, loc, accAddress, a, b, elect, useInitAcc,
-                           desc, m, n, k, OperandReuse::None);
-          useInitAcc = tb.i1_val(1);
-        }
-      }
-    }
+    return indices;
+  };
+
+  // A is identified by (m, k), and B by (n, k). Derive each collector action
+  // from adjacent instructions so every reuse chain has a fill and a lastuse.
+  const std::array<int, 3> noIndices{-1, -1, -1};
+  auto previous = noIndices;
+  int64_t numMmas = int64_t(numRepM) * numRepN * numRepK;
+  for (int64_t i = 0; i < numMmas; ++i) {
+    auto indices = getIndices(i);
+    auto next = i + 1 < numMmas ? getIndices(i + 1) : noIndices;
+    auto getReuse = [&](bool enabled, int dim) {
+      if (!enabled)
+        return CollectorAction::None;
+      bool prevMatch =
+          indices[dim] == previous[dim] && indices[2] == previous[2];
+      bool nextMatch = indices[dim] == next[dim] && indices[2] == next[2];
+      return prevMatch
+                 ? (nextMatch ? CollectorAction::Use : CollectorAction::Lastuse)
+                 : (nextMatch ? CollectorAction::Fill : CollectorAction::None);
+    };
+    OperandReuse reuse{getReuse(reuseA, 0), getReuse(reuseB, 1)};
+    auto [m, n, k] = indices;
+    MemDescOperand accAddress =
+        dLoader.tmemLoad(m * mmaSizeM, n * mmaSizeN, rewriter, loc);
+    MemDescOperand a = aLoader->memLoad(m * aOperandShape[0],
+                                        k * aOperandShape[1], rewriter, loc);
+    Value b = bLoader->smemLoad(k * bOperandShape[0], n * bOperandShape[1],
+                                rewriter, loc);
+    Value useInitAcc = k == 0 ? useDFlag : tb.i1_val(1);
+    createGen5MMA(rewriter, loc, op.kind, a, b, accAddress, elect,
+                  op.getInstOperands(desc, m, n, k), useInitAcc, twoCTAs,
+                  reuse);
+    previous = indices;
   }
 
   for (auto [barrier, barrierPred] : llvm::zip(barriers, barrierPreds)) {
@@ -694,26 +666,6 @@ LogicalResult convertDotImpl(const LLVMTypeConverter &typeConverter,
   }
   LLVM::BrOp::create(rewriter, loc, endBlock);
   return success();
-}
-
-std::string getCollectorModifier(OperandReuse reuse) {
-  switch (reuse) {
-  case OperandReuse::AFill:
-    return ".collector::a::fill";
-  case OperandReuse::AUse:
-    return ".collector::a::use";
-  case OperandReuse::ALastuse:
-    return ".collector::a::lastuse";
-  case OperandReuse::BFill:
-    return ".collector::b::fill";
-  case OperandReuse::BUse:
-    return ".collector::b::use";
-  case OperandReuse::BLastuse:
-    return ".collector::b::lastuse";
-  case OperandReuse::None:
-    return "";
-  }
-  llvm_unreachable("unsupported collector operation");
 }
 
 LogicalResult convertDot(const LLVMTypeConverter &typeConverter,
@@ -729,6 +681,20 @@ LogicalResult convertDot(const LLVMTypeConverter &typeConverter,
   SmallVector<Value> commitDescs = op.getCompletionDescs();
 
   DotConversion dot;
+  Type srcElementTy = aTensorTy.getElementType();
+  if (srcElementTy.isF16() || srcElementTy.isBF16()) {
+    dot.kind = "f16";
+  } else if (srcElementTy.isF32()) {
+    dot.kind = "tf32";
+  } else if (llvm::isa<Float8E4M3FNType, Float8E5M2Type>(srcElementTy)) {
+    dot.kind = "f8f6f4";
+  } else if (dTensorTy.getElementType().isInteger(32)) {
+    // PTX uses "i8" for integer operations (both signed and unsigned)
+    // The signed/unsigned distinction is encoded in the instruction descriptor
+    dot.kind = "i8";
+  } else {
+    llvm_unreachable("Unsupported type.");
+  }
 
   SmallVector<int64_t> dstPerCTA = triton::gpu::getShapePerCTA(dTensorTy);
   dot.shape.M = dstPerCTA[0];
@@ -751,38 +717,24 @@ LogicalResult convertDot(const LLVMTypeConverter &typeConverter,
   dot.numBitsPerElementA = aTensorTy.getElementTypeBitWidth();
   dot.numBitsPerElementB = bTensorTy.getElementTypeBitWidth();
 
-  DotOpMmaV5TmemLoader dLoader =
-      DotOpMmaV5TmemLoader::build(loc, rewriter, dTensorTy, adaptor.getD(),
-                                  dTensorTy.getElementTypeBitWidth());
-  dot.getAccAddress = [&](ConversionPatternRewriter &rewriter, Location loc,
-                          int m, int n, const DotConversion::InstDesc &desc) {
-    return dLoader.tmemLoad(m * desc.mmaSizeM, n * desc.mmaSizeN, rewriter,
-                            loc);
-  };
-
-  dot.createMMAInst = [&](ConversionPatternRewriter &rewriter, Location loc,
-                          MemDescOperand accAddress, MemDescOperand a, Value b,
-                          Value pred, Value useInitAcc,
-                          const DotConversion::InstDesc &desc, int m, int n,
-                          int k, OperandReuse reuse) {
+  dot.getInstOperands = [&](const DotConversion::InstDesc &desc, int, int,
+                            int) -> MMAInstOperands {
     // mmaSizeM/N is the per-cta size M/N, while the 2CTA instruction expects
     // the 2CTA size mmaSize is always 64 / 128 so we double it for 2CTA
     auto mmaSizeM = twoCTAs ? desc.mmaSizeM * 2 : desc.mmaSizeM;
     auto mmaSizeN = desc.mmaSizeN;
     assert(desc.mmaSizeM == 64 || desc.mmaSizeM == 128);
-    Value instDescriptor =
-        createInstDescriptor(rewriter, op, mmaSizeM, mmaSizeN, desc.transA,
-                             desc.transB, dot.mmaSizeK);
-    auto collector = getCollectorModifier(reuse);
-    createGen5MMA(rewriter, loc, op, a, b, accAddress, pred, instDescriptor,
-                  useInitAcc, desc.aInTmem, twoCTAs, collector);
+    return {createInstDescriptor(rewriter, op, mmaSizeM, mmaSizeN, desc.transA,
+                                 desc.transB, dot.mmaSizeK),
+            {},
+            {}};
   };
 
-  return convertDotImpl(
-      typeConverter, rewriter, loc, op.getA(), op.getB(), adaptor.getA(),
-      adaptor.getB(), dTensorTy, adaptor.getUseD(), adaptor.getPred(),
-      adaptor.getBarriers(), adaptor.getBarrierPreds(), twoCTAs, commitDescs,
-      /*opKindIsMXFP4=*/false, targetFeatures, dot);
+  return convertDotImpl(typeConverter, rewriter, loc, op.getA(), op.getB(),
+                        adaptor.getA(), adaptor.getB(), dTensorTy,
+                        adaptor.getD(), adaptor.getUseD(), adaptor.getPred(),
+                        adaptor.getBarriers(), adaptor.getBarrierPreds(),
+                        twoCTAs, commitDescs, targetFeatures, dot);
 }
 
 int64_t getFormatBitSize(ScaleDotElemType type) {
@@ -855,6 +807,18 @@ LogicalResult convertScaledDot(const LLVMTypeConverter &typeConverter,
   bool opKindIsMXFP4 = mxfpInstKind != mxfpKind::mxf8f6f4;
 
   DotConversion dot;
+  switch (mxfpInstKind) {
+  case mxfpKind::mxf8f6f4:
+    dot.kind = "mxf8f6f4.block_scale.block32";
+    break;
+  case mxfpKind::mxf4:
+    dot.kind = "mxf4.block_scale.block32";
+    break;
+  case mxfpKind::mxf4nvf4:
+    dot.kind = getScaleVecSize(op) == 32 ? "mxf4nvf4.block_scale.block32"
+                                         : "mxf4nvf4.block_scale.block16";
+    break;
+  }
 
   auto tensorMemAttr =
       cast<ttng::TensorMemoryEncodingAttr>(dTensorTy.getEncoding());
@@ -888,25 +852,13 @@ LogicalResult convertScaledDot(const LLVMTypeConverter &typeConverter,
   dot.numBitsPerElementB = getFormatBitSize(op.getBType());
 
   TritonLLVMOpBuilder tb(loc, rewriter);
-  DotOpMmaV5TmemLoader dLoader =
-      DotOpMmaV5TmemLoader::build(loc, rewriter, dTensorTy, adaptor.getD(),
-                                  dTensorTy.getElementTypeBitWidth());
   Value baseScaleA = tb.ptrtoint(i32_ty, adaptor.getAScale());
   Value baseScaleB = tb.ptrtoint(i32_ty, adaptor.getBScale());
   bool twoCTAs = ttng::getModuleTwoCTAs(op);
   SmallVector<Value> commitDescs = op.getCompletionDescs();
 
-  dot.getAccAddress = [&](ConversionPatternRewriter &rewriter, Location loc,
-                          int m, int n, const DotConversion::InstDesc &desc) {
-    return dLoader.tmemLoad(m * desc.mmaSizeM, n * desc.mmaSizeN, rewriter,
-                            loc);
-  };
-
-  dot.createMMAInst = [&](ConversionPatternRewriter &rewriter, Location loc,
-                          MemDescOperand accAddress, MemDescOperand a, Value b,
-                          Value pred, Value useInitAcc,
-                          const DotConversion::InstDesc &desc, int m, int n,
-                          int k, OperandReuse reuse) {
+  dot.getInstOperands = [&](const DotConversion::InstDesc &desc, int m, int n,
+                            int k) -> MMAInstOperands {
     auto [numRepM, numRepN, numRepK] = desc.repShape;
     int scaleFactorColsPerSet =
         getScaleFactorColsPerSet(mxfpInstKind, op, dot.mmaSizeK);
@@ -944,17 +896,14 @@ LogicalResult convertScaledDot(const LLVMTypeConverter &typeConverter,
           subWordIdx, subWordIdx, mxfpInstKind, blockK, dot.mmaSizeK);
     }
 
-    auto collector = getCollectorModifier(reuse);
-    createScaledGen5MMA(rewriter, loc, op, a, b, accAddress, scaleA, scaleB,
-                        pred, instDescriptor, useInitAcc, desc.aInTmem,
-                        mxfpInstKind, twoCTAs, collector);
+    return {instDescriptor, scaleA, scaleB};
   };
 
-  return convertDotImpl(
-      typeConverter, rewriter, loc, op.getA(), op.getB(), adaptor.getA(),
-      adaptor.getB(), dTensorTy, adaptor.getUseD(), adaptor.getPred(),
-      adaptor.getBarriers(), adaptor.getBarrierPreds(), twoCTAs, commitDescs,
-      opKindIsMXFP4, targetFeatures, dot);
+  return convertDotImpl(typeConverter, rewriter, loc, op.getA(), op.getB(),
+                        adaptor.getA(), adaptor.getB(), dTensorTy,
+                        adaptor.getD(), adaptor.getUseD(), adaptor.getPred(),
+                        adaptor.getBarriers(), adaptor.getBarrierPreds(),
+                        twoCTAs, commitDescs, targetFeatures, dot);
 }
 
 //===----------------------------------------------------------------------===//

--- a/third_party/nvidia/lib/TritonNVIDIAGPUToLLVM/DotOpToLLVM/MMAv5.cpp
+++ b/third_party/nvidia/lib/TritonNVIDIAGPUToLLVM/DotOpToLLVM/MMAv5.cpp
@@ -89,6 +89,18 @@ bool isTransposed(Value operand) {
   return attrs->transposed;
 }
 
+bool isFp4Padded(MemDescType operand) {
+  // An fp4Padded TMEM descriptor keeps the packed Mx(K/2)xi8 shape. Allocate
+  // two physical columns per packed K coordinate so each logical FP4 element
+  // occupies one byte in TMEM.
+  if (auto tmemLayout =
+          dyn_cast<ttng::TensorMemoryEncodingAttr>(operand.getEncoding()))
+    return tmemLayout.getFp4Padded();
+  auto attrs = ttng::getNvmmaSmemAttrs(operand);
+  assert(attrs && "expected MMAv5 shared operand to have NVMMA SMEM attrs");
+  return attrs->fp4Padded;
+}
+
 static int getScaleFactor(Type scaleType, int blockK) {
   auto shapedType = cast<ShapedType>(scaleType);
   int64_t scaleCols = shapedType.getShape().back();
@@ -455,6 +467,8 @@ void createMMACommit(ConversionPatternRewriter &rewriter, Location loc,
 // scaled dot.
 struct DotConversion {
   struct InstDesc {
+    // For 2CTA mode, the M dimension in the instruction descriptor must be
+    // doubled to match the hardware's expectation for cta_group::2 operations.
     unsigned mmaSizeM;
     unsigned mmaSizeN;
     struct {
@@ -469,11 +483,7 @@ struct DotConversion {
   using GetInstOperandsFn =
       std::function<MMAInstOperands(const InstDesc &, int, int, int)>;
 
-  struct {
-    unsigned M;
-    unsigned N;
-    unsigned K;
-  } shape;
+  unsigned blockK;
   int mmaSizeK;
   int numBitsPerElementA;
   int numBitsPerElementB;
@@ -531,7 +541,13 @@ LogicalResult convertDotImpl(const LLVMTypeConverter &typeConverter,
   Value baseB =
       getOffsetedBase(loadedB, bTensorTy, &typeConverter, rewriter, loc);
 
-  auto [M, N, K] = op.shape;
+  // Use per-CTA shape to correctly handle 2-CTA mode. getBlockM/N() returns
+  // the full block shape (e.g., 256 for 2-CTA), but we need the per-CTA shape
+  // (e.g., 128) to compute the correct number of MMA repetitions.
+  SmallVector<int64_t> dstPerCTA = triton::gpu::getShapePerCTA(dTensorTy);
+  unsigned M = dstPerCTA[0];
+  unsigned N = dstPerCTA[1];
+  unsigned K = op.blockK;
 
   auto tensorMemAttr =
       cast<ttng::TensorMemoryEncodingAttr>(dTensorTy.getEncoding());
@@ -593,21 +609,29 @@ LogicalResult convertDotImpl(const LLVMTypeConverter &typeConverter,
                                 "float32 operands in shared memory");
   }
 
-  DotConversion::InstDesc desc{
-      mmaSizeM, mmaSizeN, {numRepM, numRepN, numRepK}, transA, transB};
+  // mmaSizeM/N is the per-cta size M/N, while the 2CTA instruction expects
+  // the 2CTA size mmaSize is always 64 / 128 so we double it for 2CTA
+  assert(mmaSizeM == 64 || mmaSizeM == 128);
+  DotConversion::InstDesc desc{twoCTAs ? mmaSizeM * 2 : mmaSizeM,
+                               mmaSizeN,
+                               {numRepM, numRepN, numRepK},
+                               transA,
+                               transB};
 
   // B reuse requires M = 128 for 1CTA or 256 for 2CTA, which corresponds to
   // the condition mmaSizeM == 128 here
   bool reuseB =
       numRepM == 2 && mmaSizeM == 128 && targetFeatures.supportsReuseB();
-  // Keep one A tile in the collector across the N tiles. Interleaving N
-  // inside K preserves the accumulation order and the first-K useD flag for
-  // every destination tile. Reuse is opportunistic, so A remains live until
-  // the whole MMA operation completes, just as on the non-reuse path.
+  // With A-only reuse, keep one A tile in the collector across the N tiles.
+  // Interleaving N inside K preserves the accumulation order and the first-K
+  // useD flag for every destination tile. Reuse is opportunistic, so A remains
+  // live until the whole MMA operation completes, just as on the non-reuse
+  // path. The same lifetime rule applies to B when both collectors are used.
   // M=64 uses half the datapath and can interleave N tiles across TMEM lane
   // alignments 0 and 16. A collector cannot be reused across that change.
-  bool reuseA = !reuseB && mmaSizeM == 128 && numRepN > 1 &&
-                targetFeatures.supportsReuseA();
+  bool reuseA =
+      mmaSizeM == 128 && numRepN > 1 && targetFeatures.supportsReuseA();
+  bool reuseBoth = reuseA && reuseB;
 
   // Dimensions are M, N, K. Keep the original traversal when neither
   // collector is used, and put the reused operand's other dimension innermost.
@@ -615,12 +639,32 @@ LogicalResult convertDotImpl(const LLVMTypeConverter &typeConverter,
   std::array<int, 3> order = reuseB   ? std::array{1, 2, 0}
                              : reuseA ? std::array{0, 2, 1}
                                       : std::array{0, 1, 2};
+  if (reuseBoth) {
+    // Keep the more expensive source tile across the inner sweep, and reuse
+    // the other source at each turn. Count physical storage: FP4 can be packed
+    // or byte-padded, and FP6 also occupies byte-sized containers. There is no
+    // measured SMEM-versus-TMEM weighting here; equal sizes retain B priority.
+    auto storageBits = [](MemDescType ty, int logicalBits) {
+      return logicalBits == 4 && !isFp4Padded(ty)
+                 ? 4u
+                 : std::max<unsigned>(8, ty.getElementTypeBitWidth());
+    };
+    uint64_t aTileBits = uint64_t(aOperandShape[0]) * aOperandShape[1] *
+                         storageBits(aTensorTy, op.numBitsPerElementA);
+    uint64_t bTileBits = uint64_t(bOperandShape[0]) * bOperandShape[1] *
+                         storageBits(bTensorTy, op.numBitsPerElementB);
+    order = aTileBits > bTileBits ? std::array{2, 0, 1} : std::array{2, 1, 0};
+  }
   auto getIndices = [&](int64_t index) {
     std::array<int, 3> indices;
     for (int dim : llvm::reverse(order)) {
       indices[dim] = index % numReps[dim];
       index /= numReps[dim];
     }
+    // With both collectors, K is outermost and each M/N sweep reverses
+    // direction. Adjacent sweeps then share one operand at their boundary.
+    if (reuseBoth && indices[order[1]] % 2)
+      indices[order[2]] = numReps[order[2]] - 1 - indices[order[2]];
     return indices;
   };
 
@@ -696,10 +740,7 @@ LogicalResult convertDot(const LLVMTypeConverter &typeConverter,
     llvm_unreachable("Unsupported type.");
   }
 
-  SmallVector<int64_t> dstPerCTA = triton::gpu::getShapePerCTA(dTensorTy);
-  dot.shape.M = dstPerCTA[0];
-  dot.shape.N = dstPerCTA[1];
-  dot.shape.K = aTensorTy.getDimSize(1);
+  dot.blockK = aTensorTy.getDimSize(1);
   dot.mmaSizeK = 256 / aTensorTy.getElementTypeBitWidth();
 
   auto tensorMemAttr =
@@ -719,13 +760,8 @@ LogicalResult convertDot(const LLVMTypeConverter &typeConverter,
 
   dot.getInstOperands = [&](const DotConversion::InstDesc &desc, int, int,
                             int) -> MMAInstOperands {
-    // mmaSizeM/N is the per-cta size M/N, while the 2CTA instruction expects
-    // the 2CTA size mmaSize is always 64 / 128 so we double it for 2CTA
-    auto mmaSizeM = twoCTAs ? desc.mmaSizeM * 2 : desc.mmaSizeM;
-    auto mmaSizeN = desc.mmaSizeN;
-    assert(desc.mmaSizeM == 64 || desc.mmaSizeM == 128);
-    return {createInstDescriptor(rewriter, op, mmaSizeM, mmaSizeN, desc.transA,
-                                 desc.transB, dot.mmaSizeK),
+    return {createInstDescriptor(rewriter, op, desc.mmaSizeM, desc.mmaSizeN,
+                                 desc.transA, desc.transB, dot.mmaSizeK),
             {},
             {}};
   };
@@ -767,18 +803,6 @@ int getScaleFactorColsPerSet(mxfpKind kind, ttng::TCGen5MMAScaledOp op,
     llvm_unreachable("Unsupported mxfp kind.");
   }
 };
-
-bool isFp4Padded(MemDescType operand) {
-  // An fp4Padded TMEM descriptor keeps the packed Mx(K/2)xi8 shape. Allocate
-  // two physical columns per packed K coordinate so each logical FP4 element
-  // occupies one byte in TMEM.
-  if (auto tmemLayout =
-          dyn_cast<ttng::TensorMemoryEncodingAttr>(operand.getEncoding()))
-    return tmemLayout.getFp4Padded();
-  auto attrs = ttng::getNvmmaSmemAttrs(operand);
-  assert(attrs && "expected MMAv5 shared operand to have NVMMA SMEM attrs");
-  return attrs->fp4Padded;
-}
 
 int linearizeScaleBlockIdx(Value scale, int mnIdx, int wordIdx, int numRepMn,
                            int numRepKWords) {
@@ -825,13 +849,7 @@ LogicalResult convertScaledDot(const LLVMTypeConverter &typeConverter,
   unsigned mmaSizeM = tensorMemAttr.getBlockM();
   unsigned mmaSizeN = tensorMemAttr.getBlockN();
 
-  // Use per-CTA shape to correctly handle 2-CTA mode. getBlockM/N() returns
-  // the full block shape (e.g., 256 for 2-CTA), but we need the per-CTA shape
-  // (e.g., 128) to compute the correct number of MMA repetitions.
-  SmallVector<int64_t> dstPerCTA = triton::gpu::getShapePerCTA(dTensorTy);
-  dot.shape.M = dstPerCTA[0];
-  dot.shape.N = dstPerCTA[1];
-  dot.shape.K = blockK; // K is not split across CTAs
+  dot.blockK = blockK; // K is not split across CTAs
 
   bool hasFp4PaddedOperand = isFp4Padded(aTensorTy) || isFp4Padded(bTensorTy);
 
@@ -856,13 +874,13 @@ LogicalResult convertScaledDot(const LLVMTypeConverter &typeConverter,
   Value baseScaleB = tb.ptrtoint(i32_ty, adaptor.getBScale());
   bool twoCTAs = ttng::getModuleTwoCTAs(op);
   SmallVector<Value> commitDescs = op.getCompletionDescs();
+  int mmasPerScaleWord =
+      4 / getScaleFactorColsPerSet(mxfpInstKind, op, dot.mmaSizeK);
 
   dot.getInstOperands = [&](const DotConversion::InstDesc &desc, int m, int n,
                             int k) -> MMAInstOperands {
     auto [numRepM, numRepN, numRepK] = desc.repShape;
-    int scaleFactorColsPerSet =
-        getScaleFactorColsPerSet(mxfpInstKind, op, dot.mmaSizeK);
-    int numRepKWords = ceil<int>(numRepK, 4 / scaleFactorColsPerSet);
+    int numRepKWords = ceil<int>(numRepK, mmasPerScaleWord);
     int numColPerScaleBlockA = ceil<int>(
         ttng::getTmemAllocSizes(cast<MemDescType>(op.getAScale().getType()))
             .numCols,
@@ -872,8 +890,8 @@ LogicalResult convertScaledDot(const LLVMTypeConverter &typeConverter,
             .numCols,
         numRepN * numRepKWords);
     numColPerScaleBlockB = std::max(numColPerScaleBlockB, 2);
-    int subWordIdx = k % (4 / scaleFactorColsPerSet);
-    int wordIdx = k / (4 / scaleFactorColsPerSet);
+    int subWordIdx = k % mmasPerScaleWord;
+    int wordIdx = k / mmasPerScaleWord;
     int scaleIdxA = linearizeScaleBlockIdx(op.getAScale(), m, wordIdx, numRepM,
                                            numRepKWords);
     int scaleIdxB = linearizeScaleBlockIdx(op.getBScale(), n, wordIdx, numRepN,
@@ -883,16 +901,13 @@ LogicalResult convertScaledDot(const LLVMTypeConverter &typeConverter,
     Value scaleB =
         tb.add(baseScaleB, tb.i32_val(scaleIdxB * numColPerScaleBlockB));
     Value instDescriptor;
-    // For 2CTA mode, the M dimension in the instruction descriptor must be
-    // doubled to match the hardware's expectation for cta_group::2 operations.
-    int mmaM = twoCTAs ? desc.mmaSizeM * 2 : desc.mmaSizeM;
     if (mxfpInstKind == mxfpKind::mxf8f6f4) {
       instDescriptor = createScaleInstDescriptorFp8(
-          rewriter, op, mmaM, desc.mmaSizeN, desc.transA, desc.transB,
+          rewriter, op, desc.mmaSizeM, desc.mmaSizeN, desc.transA, desc.transB,
           subWordIdx, subWordIdx, dot.mmaSizeK);
     } else {
       instDescriptor = createScaleInstDescriptorFp4(
-          rewriter, op, mmaM, desc.mmaSizeN, desc.transA, desc.transB,
+          rewriter, op, desc.mmaSizeM, desc.mmaSizeN, desc.transA, desc.transB,
           subWordIdx, subWordIdx, mxfpInstKind, blockK, dot.mmaSizeK);
     }
 


### PR DESCRIPTION
This may trigger just on 1CTA mode for now as we support nRep > 1 on
2CTA mode. That being said, when it triggers it gives pretty nice
speed-ups
