### PR TITLE
[AMD] Preserve dominance when preparing if combining

### DIFF
--- a/test/TritonGPU/amd/amd-prepare-if-combining.mlir
+++ b/test/TritonGPU/amd/amd-prepare-if-combining.mlir
@@ -122,6 +122,44 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.targ
 
 // -----
 
+// CHECK-LABEL: region_capture_between_ifs
+//       CHECK: %[[FIRST:.+]] = scf.if
+//       CHECK: %[[LOOP:.+]] = scf.for
+//       CHECK: %[[SECOND:.+]] = scf.if
+// CANON-LABEL: region_capture_between_ifs
+//       CANON: %[[FIRST:.+]] = scf.if
+//       CANON: %[[LOOP:.+]] = scf.for
+//       CANON: %[[SECOND:.+]] = scf.if
+module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.target = "hip:gfx942", "ttg.threads-per-warp" = 64 : i32} {
+  tt.func public @region_capture_between_ifs(%cond: i1, %a: i32) -> i32 {
+    %c0 = arith.constant 0 : index
+    %c1 = arith.constant 1 : index
+    %c4 = arith.constant 4 : index
+    %first = scf.if %cond -> i32 {
+      %add = arith.addi %a, %a : i32
+      scf.yield %add : i32
+    } else {
+      %sub = arith.subi %a, %a : i32
+      scf.yield %sub : i32
+    }
+    %loop = scf.for %i = %c0 to %c4 step %c1 iter_args(%acc = %a) -> i32 {
+      %add = arith.addi %acc, %first : i32
+      scf.yield %add : i32
+    }
+    %second = scf.if %cond -> i32 {
+      %add = arith.addi %loop, %a : i32
+      scf.yield %add : i32
+    } else {
+      %sub = arith.subi %loop, %a : i32
+      scf.yield %sub : i32
+    }
+    %result = arith.addi %first, %second : i32
+    tt.return %result : i32
+  }
+}
+
+// -----
+
 // CHECK-LABEL: sibling_ifs_with_nested_if
 //       CHECK: %[[LOAD:.+]] = ttg.local_load
 //  CHECK-NEXT: tt.trans %[[LOAD]]

--- a/third_party/amd/lib/TritonAMDGPUTransforms/PrepareIfCombining.cpp
+++ b/third_party/amd/lib/TritonAMDGPUTransforms/PrepareIfCombining.cpp
@@ -15,6 +15,7 @@
 #include "mlir/IR/Dominance.h"
 #include "mlir/Interfaces/SideEffectInterfaces.h"
 #include "mlir/Pass/PassManager.h"
+#include "mlir/Transforms/RegionUtils.h"
 #include "triton/Dialect/Triton/IR/Dialect.h"
 
 namespace mlir {
@@ -51,6 +52,15 @@ static void handleIfPair(scf::IfOp currentIf, scf::IfOp nextIf,
       if (!domInfo.properlyDominates(defOp, currentIf))
         return;
     }
+    bool capturesAvailable = true;
+    visitUsedValuesDefinedAbove(op->getRegions(), [&](OpOperand *operand) {
+      auto *defOp = operand->get().getDefiningOp();
+      if (defOp && !opsBetween.contains(defOp) &&
+          !domInfo.properlyDominates(defOp, currentIf))
+        capturesAvailable = false;
+    });
+    if (!capturesAvailable)
+      return;
   }
 
   // Move all ops before the current if.


### PR DESCRIPTION
## Summary

`PrepareIfCombining` checked only direct operands before moving pure operations
across an `scf.if`. This missed values captured inside nested regions and could
move an `scf.for` before the `scf.if` defining one of its captured values.

Check nested-region captures before moving the operation and add a pass-level
regression test.

Fixes #11327.

## Testing

- Exact reduced kernel: gfx942 with `num_stages=1/2/3/4`.
- Neighbor controls: gfx1100, gfx950, and CUDA sm80.
- `amd-prepare-if-combining.mlir` focused lit test.
- `pre-commit run --from-ref origin/main --to-ref HEAD`.

# New contributor declaration
- [x] I am not making a trivial change, such as fixing a typo in a comment.
- [x] I have written a PR description following these
  [rules](https://cbea.ms/git-commit/#why-not-how).
- [x] I have run `pre-commit run --from-ref origin/main --to-ref HEAD`.
- [x] I have added tests under `/test`.
- [x] The added lit test is minimal and follows FileCheck best practices.
