### PR TITLE
Add matmul tuning constraints for swap_xw, group_m and use_output_tma

### DIFF
--- a/python/triton_kernels/tests/test_matmul_details/test_opt_flags_split_k.py
+++ b/python/triton_kernels/tests/test_matmul_details/test_opt_flags_split_k.py
@@ -6,7 +6,7 @@ import types
 import torch
 
 import triton_kernels.matmul_details.opt_flags as opt_flags
-from triton_kernels.matmul import FusedActivation, PrecisionConfig, init_allocation, _resolve_tma_override
+from triton_kernels.matmul import FusedActivation, PrecisionConfig, init_allocation
 from triton_kernels.tensor_details.dtype import BF16, FP16, FP32
 
 class _DummyPrecisionConfig:
@@ -216,14 +216,6 @@ def test_make_default_opt_flags_nvidia_output_tma_constraint(monkeypatch):
     )
 
     assert flags.use_output_tma is False
-
-
-def test_resolve_tma_override():
-    assert _resolve_tma_override("use_output_tma", True, None) is True
-    assert _resolve_tma_override("use_output_tma", True, False) is False
-    assert _resolve_tma_override("use_output_tma", True, True) is True
-    with pytest.raises(opt_flags.InapplicableConstraint):
-        _resolve_tma_override("use_output_tma", False, True)
 
 
 def test_split_k_uses_intermediate_out_dtype(monkeypatch):

--- a/python/triton_kernels/tests/test_matmul_details/test_opt_flags_split_k.py
+++ b/python/triton_kernels/tests/test_matmul_details/test_opt_flags_split_k.py
@@ -193,14 +193,8 @@ def test_make_default_opt_flags_nvidia_group_m_constraint(monkeypatch, group_m):
     assert flags.group_m == group_m
 
 
-def test_make_default_opt_flags_nvidia_execution_constraints(monkeypatch):
+def test_make_default_opt_flags_nvidia_output_tma_constraint(monkeypatch):
     setup_nvidia(monkeypatch)
-    constraints = {
-        "use_output_tma": False,
-        "occupancy_target": 2,
-        "flatten_loops": False,
-        "maxnreg": 192,
-    }
     flags = opt_flags.make_default_opt_flags_nvidia(
         torch.float16,
         torch.float16,
@@ -217,16 +211,11 @@ def test_make_default_opt_flags_nvidia_execution_constraints(monkeypatch):
         0,
         False,
         False,
-        constraints,
+        {"use_output_tma": False},
         torch.float32,
     )
 
     assert flags.use_output_tma is False
-    assert flags.occupancy_target == 2
-    assert flags.flatten_loops is False
-    assert flags.maxnreg == 192
-    assert flags.target_kernel_kwargs["FLATTEN_LOOPS"] is False
-    assert flags.target_kernel_kwargs["maxnreg"] == 192
 
 
 def test_resolve_tma_override():

--- a/python/triton_kernels/tests/test_matmul_details/test_opt_flags_split_k.py
+++ b/python/triton_kernels/tests/test_matmul_details/test_opt_flags_split_k.py
@@ -133,8 +133,12 @@ def test_make_default_opt_flags_nvidia_split_k_constraint(monkeypatch):
     assert flags.split_k == 3
 
 
-@pytest.mark.parametrize("swap_xw", [None, False, True])
-def test_make_default_opt_flags_nvidia_swap_xw_constraint(monkeypatch, swap_xw):
+@pytest.mark.parametrize(("constraint", "values"), [
+    ("swap_xw", [None, False, True]),
+    ("group_m", [None, 2, 4, 8, 16, 32, 64]),
+    ("use_output_tma", [None, False, True]),
+])
+def test_make_default_opt_flags_nvidia_tuning_constraints(monkeypatch, constraint, values):
     setup_nvidia(monkeypatch)
     seen = {}
 
@@ -143,79 +147,31 @@ def test_make_default_opt_flags_nvidia_swap_xw_constraint(monkeypatch, swap_xw):
         return 2
 
     monkeypatch.setattr(opt_flags.opt_flags_nvidia, "compute_num_stages", capture_num_stages)
-    flags = opt_flags.make_default_opt_flags_nvidia(
-        torch.float16,
-        torch.float16,
-        torch.float16,
-        _DummyPrecisionConfig(),
-        4,
-        256,
-        128,
-        64,
-        None,
-        False,
-        False,
-        False,
-        0,
-        False,
-        False,
-        {"swap_xw": swap_xw},
-        torch.float32,
-    )
+    for value in values:
+        flags = opt_flags.make_default_opt_flags_nvidia(
+            torch.float16,
+            torch.float16,
+            torch.float16,
+            _DummyPrecisionConfig(),
+            4,
+            256,
+            128,
+            64,
+            None,
+            False,
+            False,
+            False,
+            0,
+            False,
+            False,
+            {constraint: value},
+            torch.float32,
+        )
 
-    assert flags.swap_xw is swap_xw
-    assert seen["swap_xw"] is swap_xw
-
-
-@pytest.mark.parametrize("group_m", [None, 2, 4, 8, 16, 32, 64])
-def test_make_default_opt_flags_nvidia_group_m_constraint(monkeypatch, group_m):
-    setup_nvidia(monkeypatch)
-    flags = opt_flags.make_default_opt_flags_nvidia(
-        torch.float16,
-        torch.float16,
-        torch.float16,
-        _DummyPrecisionConfig(),
-        4,
-        256,
-        128,
-        64,
-        None,
-        False,
-        False,
-        False,
-        0,
-        False,
-        False,
-        {"group_m": group_m},
-        torch.float32,
-    )
-
-    assert flags.group_m == (8 if group_m is None else group_m)
-
-
-def test_make_default_opt_flags_nvidia_output_tma_constraint(monkeypatch):
-    setup_nvidia(monkeypatch)
-    flags = opt_flags.make_default_opt_flags_nvidia(
-        torch.float16,
-        torch.float16,
-        torch.float16,
-        _DummyPrecisionConfig(),
-        4,
-        256,
-        128,
-        64,
-        None,
-        False,
-        False,
-        False,
-        0,
-        False,
-        False,
-        {"use_output_tma": False},
-        torch.float32,
-    )
-
-    assert flags.use_output_tma is False
+        expected = 8 if constraint == "group_m" and value is None else value
+        expected_swap_xw = value if constraint == "swap_xw" else None
+        assert getattr(flags, constraint) == expected
+        assert seen["swap_xw"] is expected_swap_xw
 
 
 def test_split_k_uses_intermediate_out_dtype(monkeypatch):

--- a/python/triton_kernels/tests/test_matmul_details/test_opt_flags_split_k.py
+++ b/python/triton_kernels/tests/test_matmul_details/test_opt_flags_split_k.py
@@ -6,7 +6,7 @@ import types
 import torch
 
 import triton_kernels.matmul_details.opt_flags as opt_flags
-from triton_kernels.matmul import FusedActivation, PrecisionConfig, init_allocation
+from triton_kernels.matmul import FusedActivation, PrecisionConfig, init_allocation, _resolve_tma_override
 from triton_kernels.tensor_details.dtype import BF16, FP16, FP32
 
 class _DummyPrecisionConfig:
@@ -131,6 +131,110 @@ def test_make_default_opt_flags_nvidia_split_k_constraint(monkeypatch):
     )
 
     assert flags.split_k == 3
+
+
+@pytest.mark.parametrize("swap_xw", [None, False, True])
+def test_make_default_opt_flags_nvidia_swap_xw_constraint(monkeypatch, swap_xw):
+    setup_nvidia(monkeypatch)
+    seen = {}
+
+    def capture_num_stages(*args, **kwargs):
+        seen["swap_xw"] = kwargs["swap_xw"]
+        return 2
+
+    monkeypatch.setattr(opt_flags.opt_flags_nvidia, "compute_num_stages", capture_num_stages)
+    flags = opt_flags.make_default_opt_flags_nvidia(
+        torch.float16,
+        torch.float16,
+        torch.float16,
+        _DummyPrecisionConfig(),
+        4,
+        256,
+        128,
+        64,
+        None,
+        False,
+        False,
+        False,
+        0,
+        False,
+        False,
+        {"swap_xw": swap_xw},
+        torch.float32,
+    )
+
+    assert flags.swap_xw is swap_xw
+    assert seen["swap_xw"] is swap_xw
+
+
+@pytest.mark.parametrize("group_m", [2, 4, 8, 16, 32, 64])
+def test_make_default_opt_flags_nvidia_group_m_constraint(monkeypatch, group_m):
+    setup_nvidia(monkeypatch)
+    flags = opt_flags.make_default_opt_flags_nvidia(
+        torch.float16,
+        torch.float16,
+        torch.float16,
+        _DummyPrecisionConfig(),
+        4,
+        256,
+        128,
+        64,
+        None,
+        False,
+        False,
+        False,
+        0,
+        False,
+        False,
+        {"group_m": group_m},
+        torch.float32,
+    )
+
+    assert flags.group_m == group_m
+
+
+def test_make_default_opt_flags_nvidia_execution_constraints(monkeypatch):
+    setup_nvidia(monkeypatch)
+    constraints = {
+        "use_output_tma": False,
+        "occupancy_target": 2,
+        "flatten_loops": False,
+        "maxnreg": 192,
+    }
+    flags = opt_flags.make_default_opt_flags_nvidia(
+        torch.float16,
+        torch.float16,
+        torch.float16,
+        _DummyPrecisionConfig(),
+        4,
+        256,
+        128,
+        64,
+        None,
+        False,
+        False,
+        False,
+        0,
+        False,
+        False,
+        constraints,
+        torch.float32,
+    )
+
+    assert flags.use_output_tma is False
+    assert flags.occupancy_target == 2
+    assert flags.flatten_loops is False
+    assert flags.maxnreg == 192
+    assert flags.target_kernel_kwargs["FLATTEN_LOOPS"] is False
+    assert flags.target_kernel_kwargs["maxnreg"] == 192
+
+
+def test_resolve_tma_override():
+    assert _resolve_tma_override("use_output_tma", True, None) is True
+    assert _resolve_tma_override("use_output_tma", True, False) is False
+    assert _resolve_tma_override("use_output_tma", True, True) is True
+    with pytest.raises(opt_flags.InapplicableConstraint):
+        _resolve_tma_override("use_output_tma", False, True)
 
 
 def test_split_k_uses_intermediate_out_dtype(monkeypatch):

--- a/python/triton_kernels/tests/test_matmul_details/test_opt_flags_split_k.py
+++ b/python/triton_kernels/tests/test_matmul_details/test_opt_flags_split_k.py
@@ -167,7 +167,7 @@ def test_make_default_opt_flags_nvidia_swap_xw_constraint(monkeypatch, swap_xw):
     assert seen["swap_xw"] is swap_xw
 
 
-@pytest.mark.parametrize("group_m", [2, 4, 8, 16, 32, 64])
+@pytest.mark.parametrize("group_m", [None, 2, 4, 8, 16, 32, 64])
 def test_make_default_opt_flags_nvidia_group_m_constraint(monkeypatch, group_m):
     setup_nvidia(monkeypatch)
     flags = opt_flags.make_default_opt_flags_nvidia(
@@ -190,7 +190,7 @@ def test_make_default_opt_flags_nvidia_group_m_constraint(monkeypatch, group_m):
         torch.float32,
     )
 
-    assert flags.group_m == group_m
+    assert flags.group_m == (8 if group_m is None else group_m)
 
 
 def test_make_default_opt_flags_nvidia_output_tma_constraint(monkeypatch):

--- a/python/triton_kernels/triton_kernels/matmul.py
+++ b/python/triton_kernels/triton_kernels/matmul.py
@@ -145,7 +145,16 @@ class PrecisionConfig:
 def get_swap_xw(precision_config, opt_flags, lhs_dtype, rhs_dtype):
     if triton.runtime.driver.active.get_current_target().backend != "cuda":
         return False
+    if opt_flags.swap_xw is not None:
+        return opt_flags.swap_xw
     return opt_flags_nvidia.compute_swap_xw(precision_config, opt_flags.block_m, opt_flags.is_persistent, lhs_dtype, rhs_dtype)
+
+def _resolve_tma_override(name, can_use_tma, override):
+    if override is None:
+        return can_use_tma
+    if override and not can_use_tma:
+        raise InapplicableConstraint(f"{name}=True is not supported for this matmul")
+    return override
 
 # ---------------------
 # Allocation
@@ -540,7 +549,7 @@ def matmul(a, b, bias,
     if a_has_tma and precision_config.allow_tf32 and a.storage.data.dtype == torch.float32:
         a_tensor_or_tma.round_f32_to_tf32 = True
     # create tma descriptor for y
-    c_has_tma = (
+    can_use_output_tma = (
         opt_flags.is_persistent and (scatter_indx is None or has_scatter_tma)
         and is_tma_compliant(c)
         and (
@@ -557,6 +566,7 @@ def matmul(a, b, bias,
             or matmul_fused_activation.specs.reduction_n == 1
         )
     )
+    c_has_tma = _resolve_tma_override("use_output_tma", can_use_output_tma, opt_flags.use_output_tma)
     c_logical_block_n = opt_flags.block_n // opt_flags.epilogue_subtile // matmul_fused_activation.specs.reduction_n
     c_tma_block_n = c_logical_block_n // precision_config.c_value_pack_factor
     out_tile_n = opt_flags.block_n // matmul_fused_activation.specs.reduction_n

--- a/python/triton_kernels/triton_kernels/matmul.py
+++ b/python/triton_kernels/triton_kernels/matmul.py
@@ -549,7 +549,7 @@ def matmul(a, b, bias,
     if a_has_tma and precision_config.allow_tf32 and a.storage.data.dtype == torch.float32:
         a_tensor_or_tma.round_f32_to_tf32 = True
     # create tma descriptor for y
-    can_use_output_tma = (
+    c_has_tma = (
         opt_flags.is_persistent and (scatter_indx is None or has_scatter_tma)
         and is_tma_compliant(c)
         and (
@@ -566,7 +566,7 @@ def matmul(a, b, bias,
             or matmul_fused_activation.specs.reduction_n == 1
         )
     )
-    c_has_tma = _resolve_tma_override("use_output_tma", can_use_output_tma, opt_flags.use_output_tma)
+    c_has_tma = _resolve_tma_override("use_output_tma", c_has_tma, opt_flags.use_output_tma)
     c_logical_block_n = opt_flags.block_n // opt_flags.epilogue_subtile // matmul_fused_activation.specs.reduction_n
     c_tma_block_n = c_logical_block_n // precision_config.c_value_pack_factor
     out_tile_n = opt_flags.block_n // matmul_fused_activation.specs.reduction_n

--- a/python/triton_kernels/triton_kernels/matmul.py
+++ b/python/triton_kernels/triton_kernels/matmul.py
@@ -149,13 +149,6 @@ def get_swap_xw(precision_config, opt_flags, lhs_dtype, rhs_dtype):
         return opt_flags.swap_xw
     return opt_flags_nvidia.compute_swap_xw(precision_config, opt_flags.block_m, opt_flags.is_persistent, lhs_dtype, rhs_dtype)
 
-def _resolve_tma_override(name, can_use_tma, override):
-    if override is None:
-        return can_use_tma
-    if override and not can_use_tma:
-        raise InapplicableConstraint(f"{name}=True is not supported for this matmul")
-    return override
-
 # ---------------------
 # Allocation
 # ---------------------
@@ -566,7 +559,8 @@ def matmul(a, b, bias,
             or matmul_fused_activation.specs.reduction_n == 1
         )
     )
-    c_has_tma = _resolve_tma_override("use_output_tma", c_has_tma, opt_flags.use_output_tma)
+    if opt_flags.use_output_tma is not None:
+        c_has_tma = opt_flags.use_output_tma
     c_logical_block_n = opt_flags.block_n // opt_flags.epilogue_subtile // matmul_fused_activation.specs.reduction_n
     c_tma_block_n = c_logical_block_n // precision_config.c_value_pack_factor
     out_tile_n = opt_flags.block_n // matmul_fused_activation.specs.reduction_n

--- a/python/triton_kernels/triton_kernels/matmul_details/opt_flags.py
+++ b/python/triton_kernels/triton_kernels/matmul_details/opt_flags.py
@@ -35,6 +35,10 @@ class OptFlags:
     occupancy_target: int
     target_kernel_kwargs: dict
     clc: bool = False
+    swap_xw: bool | None = None
+    use_output_tma: bool | None = None
+    flatten_loops: bool = True
+    maxnreg: int | None = None
 
 
 def max_allowable_mn(
@@ -220,7 +224,7 @@ def make_default_opt_flags_nvidia(
     mx_block_size=None,
     epilogue_reduction_n=1,
 ):
-    constraints_supported = {"block_m", "block_n", "block_k", "split_k", "is_persistent", "clc", "epilogue_subtile", "num_stages", "idle_sms", "max_allowable_mn", "num_warps", "disable_mx4_block_swap"}
+    constraints_supported = {"block_m", "block_n", "block_k", "split_k", "is_persistent", "clc", "epilogue_subtile", "num_stages", "idle_sms", "max_allowable_mn", "num_warps", "disable_mx4_block_swap", "swap_xw", "group_m", "use_output_tma", "occupancy_target", "flatten_loops", "maxnreg"}
     unsupported = set(constraints.keys()) - constraints_supported
     assert not unsupported, f"Given unsupported constraint: {unsupported}"
     is_large_ragged_nvfp4 = (
@@ -243,6 +247,8 @@ def make_default_opt_flags_nvidia(
     group_m = 8
     if lhs_dtype == FP4 and rhs_dtype == FP4:
         group_m = 16
+    if constraints.get("group_m") is not None:
+        group_m = constraints["group_m"]
     xcd_swizzle = 1
     # block_m
     if constraints.get("block_m", None):
@@ -378,6 +384,7 @@ def make_default_opt_flags_nvidia(
     )
 
     num_warps = opt_flags_nvidia.compute_num_warps(block_m, block_n, is_persistent, precision_config, constraints)
+    swap_xw = constraints.get("swap_xw")
     if is_large_ragged_nvfp4 and constraints.get("num_warps", None) is None:
         # Eight warps overrun GB300 TMEM for the large ragged NVFP4 tile.
         num_warps = 4
@@ -389,14 +396,16 @@ def make_default_opt_flags_nvidia(
         num_warps = max(num_warps, 8)
 
     # Occupancy target and maxnreg (for Hopper)
-    occupancy_target = 1
     is_hopper_scale = isinstance(b_mx_scale_layout, HopperMXScaleLayout)
-    if is_hopper_scale:
-        occupancy_target = 16 // num_warps
-        if precision_config.a_mx_scale is not None and precision_config.c_mx_scale is not None:
-            # Hopper MXFP4 RHS plus MX input/output needs more than the
-            # 128-register cap implied by the default occupancy target.
-            occupancy_target = 1
+    occupancy_target = constraints.get("occupancy_target")
+    if occupancy_target is None:
+        occupancy_target = 1
+        if is_hopper_scale:
+            occupancy_target = 16 // num_warps
+            if precision_config.a_mx_scale is not None and precision_config.c_mx_scale is not None:
+                # Hopper MXFP4 RHS plus MX input/output needs more than the
+                # 128-register cap implied by the default occupancy target.
+                occupancy_target = 1
     threads_per_warp = 32
     reg_per_sm = 64 * 1024
     max_reg_per_thread = 256
@@ -406,6 +415,11 @@ def make_default_opt_flags_nvidia(
         maxnreg = min(max_reg_per_thread, maxnreg)
     else:
         maxnreg = None
+    if constraints.get("maxnreg") is not None:
+        maxnreg = constraints["maxnreg"]
+    flatten_loops = constraints.get("flatten_loops")
+    if flatten_loops is None:
+        flatten_loops = not is_hopper_scale
 
     if constraints.get("epilogue_subtile", None) is not None:
         subtiles_to_check = [constraints["epilogue_subtile"]]
@@ -416,7 +430,7 @@ def make_default_opt_flags_nvidia(
     num_stages = -1
     for ep in subtiles_to_check:
         ns = opt_flags_nvidia.compute_num_stages(*compute_num_stages_args, epilogue_subtile=ep,
-                                                 occupancy_target=occupancy_target,
+                                                 occupancy_target=occupancy_target, swap_xw=swap_xw,
                                                  w_transpose=w_transpose)
         if ns > num_stages:
             epilogue_subtile, num_stages = ep, ns
@@ -455,10 +469,14 @@ def make_default_opt_flags_nvidia(
         target_kernel_kwargs=dict(
             maxnreg=maxnreg,
             # For some reason, overlapping the epilogue is slower for hopper bf16 x mxfp4
-            FLATTEN_LOOPS=not is_hopper_scale,
+            FLATTEN_LOOPS=flatten_loops,
         ),
         idle_sms=constraints.get("idle_sms", _get_idle_sms()),
         occupancy_target=occupancy_target,
+        swap_xw=swap_xw,
+        use_output_tma=constraints.get("use_output_tma"),
+        flatten_loops=flatten_loops,
+        maxnreg=maxnreg,
     )
     # check constraints
     all_constraints_satisfied(ret, constraints)
@@ -483,7 +501,7 @@ def _get_opt_flags_constraints() -> dict:
     constraints = _opt_flags_constraints.get()
     return {} if constraints is None else constraints
 
-def update_opt_flags_constraints(constraints: dict[str, int]):
+def update_opt_flags_constraints(constraints: dict[str, int | bool | None]):
     updated = _get_opt_flags_constraints().copy()
     updated.update(constraints)
     _opt_flags_constraints.set(updated)

--- a/python/triton_kernels/triton_kernels/matmul_details/opt_flags.py
+++ b/python/triton_kernels/triton_kernels/matmul_details/opt_flags.py
@@ -37,8 +37,6 @@ class OptFlags:
     clc: bool = False
     swap_xw: bool | None = None
     use_output_tma: bool | None = None
-    flatten_loops: bool = True
-    maxnreg: int | None = None
 
 
 def max_allowable_mn(
@@ -224,7 +222,7 @@ def make_default_opt_flags_nvidia(
     mx_block_size=None,
     epilogue_reduction_n=1,
 ):
-    constraints_supported = {"block_m", "block_n", "block_k", "split_k", "is_persistent", "clc", "epilogue_subtile", "num_stages", "idle_sms", "max_allowable_mn", "num_warps", "disable_mx4_block_swap", "swap_xw", "group_m", "use_output_tma", "occupancy_target", "flatten_loops", "maxnreg"}
+    constraints_supported = {"block_m", "block_n", "block_k", "split_k", "is_persistent", "clc", "epilogue_subtile", "num_stages", "idle_sms", "max_allowable_mn", "num_warps", "disable_mx4_block_swap", "swap_xw", "group_m", "use_output_tma"}
     unsupported = set(constraints.keys()) - constraints_supported
     assert not unsupported, f"Given unsupported constraint: {unsupported}"
     is_large_ragged_nvfp4 = (
@@ -397,15 +395,13 @@ def make_default_opt_flags_nvidia(
 
     # Occupancy target and maxnreg (for Hopper)
     is_hopper_scale = isinstance(b_mx_scale_layout, HopperMXScaleLayout)
-    occupancy_target = constraints.get("occupancy_target")
-    if occupancy_target is None:
-        occupancy_target = 1
-        if is_hopper_scale:
-            occupancy_target = 16 // num_warps
-            if precision_config.a_mx_scale is not None and precision_config.c_mx_scale is not None:
-                # Hopper MXFP4 RHS plus MX input/output needs more than the
-                # 128-register cap implied by the default occupancy target.
-                occupancy_target = 1
+    occupancy_target = 1
+    if is_hopper_scale:
+        occupancy_target = 16 // num_warps
+        if precision_config.a_mx_scale is not None and precision_config.c_mx_scale is not None:
+            # Hopper MXFP4 RHS plus MX input/output needs more than the
+            # 128-register cap implied by the default occupancy target.
+            occupancy_target = 1
     threads_per_warp = 32
     reg_per_sm = 64 * 1024
     max_reg_per_thread = 256
@@ -415,12 +411,6 @@ def make_default_opt_flags_nvidia(
         maxnreg = min(max_reg_per_thread, maxnreg)
     else:
         maxnreg = None
-    if constraints.get("maxnreg") is not None:
-        maxnreg = constraints["maxnreg"]
-    flatten_loops = constraints.get("flatten_loops")
-    if flatten_loops is None:
-        flatten_loops = not is_hopper_scale
-
     if constraints.get("epilogue_subtile", None) is not None:
         subtiles_to_check = [constraints["epilogue_subtile"]]
     elif is_large_ragged_nvfp4:
@@ -469,14 +459,12 @@ def make_default_opt_flags_nvidia(
         target_kernel_kwargs=dict(
             maxnreg=maxnreg,
             # For some reason, overlapping the epilogue is slower for hopper bf16 x mxfp4
-            FLATTEN_LOOPS=flatten_loops,
+            FLATTEN_LOOPS=not is_hopper_scale,
         ),
         idle_sms=constraints.get("idle_sms", _get_idle_sms()),
         occupancy_target=occupancy_target,
         swap_xw=swap_xw,
         use_output_tma=constraints.get("use_output_tma"),
-        flatten_loops=flatten_loops,
-        maxnreg=maxnreg,
     )
     # check constraints
     all_constraints_satisfied(ret, constraints)

--- a/python/triton_kernels/triton_kernels/matmul_details/opt_flags.py
+++ b/python/triton_kernels/triton_kernels/matmul_details/opt_flags.py
@@ -394,8 +394,8 @@ def make_default_opt_flags_nvidia(
         num_warps = max(num_warps, 8)
 
     # Occupancy target and maxnreg (for Hopper)
-    is_hopper_scale = isinstance(b_mx_scale_layout, HopperMXScaleLayout)
     occupancy_target = 1
+    is_hopper_scale = isinstance(b_mx_scale_layout, HopperMXScaleLayout)
     if is_hopper_scale:
         occupancy_target = 16 // num_warps
         if precision_config.a_mx_scale is not None and precision_config.c_mx_scale is not None:
@@ -411,6 +411,7 @@ def make_default_opt_flags_nvidia(
         maxnreg = min(max_reg_per_thread, maxnreg)
     else:
         maxnreg = None
+
     if constraints.get("epilogue_subtile", None) is not None:
         subtiles_to_check = [constraints["epilogue_subtile"]]
     elif is_large_ragged_nvfp4:
@@ -420,7 +421,8 @@ def make_default_opt_flags_nvidia(
     num_stages = -1
     for ep in subtiles_to_check:
         ns = opt_flags_nvidia.compute_num_stages(*compute_num_stages_args, epilogue_subtile=ep,
-                                                 occupancy_target=occupancy_target, swap_xw=swap_xw,
+                                                 occupancy_target=occupancy_target,
+                                                 swap_xw=swap_xw,
                                                  w_transpose=w_transpose)
         if ns > num_stages:
             epilogue_subtile, num_stages = ep, ns

--- a/python/triton_kernels/triton_kernels/matmul_details/opt_flags_details/opt_flags_nvidia.py
+++ b/python/triton_kernels/triton_kernels/matmul_details/opt_flags_details/opt_flags_nvidia.py
@@ -136,6 +136,7 @@ def compute_num_stages(
     *,
     epilogue_subtile,
     occupancy_target,
+    swap_xw=None,
     w_transpose=False,
 ):
     if precision_config.max_num_imprecise_acc is not None:
@@ -193,7 +194,9 @@ def compute_num_stages(
         # pipelined layout conversion before store of the accumulator
         # note: layout conversion has some padding
         epilogue_smem = int((block_m + 4) * acc_block_n * acc_size)
-        if compute_swap_xw(precision_config, block_m, is_persistent, lhs_dtype, rhs_dtype):
+        if swap_xw is None:
+            swap_xw = compute_swap_xw(precision_config, block_m, is_persistent, lhs_dtype, rhs_dtype)
+        if swap_xw:
             # The fp32 accumulator stays in TMEM for the Blackwell SWAP_XW
             # persistent path. Fused reductions such as swiglu still need smem
             # for the unreduced output tile before the narrower TMA-store tile.


### PR DESCRIPTION
## Summary

Expose three Triton matmul tuning constraints:

- `swap_xw: bool | None`
- `group_m: int | None`
- `use_output_tma: bool | None`

`None` preserves the existing heuristic. Explicit values override it. The resolved `group_m` stored in `OptFlags` remains an integer.

An explicit `swap_xw` value is also used during shared-memory stage budgeting, ensuring configuration selection matches the generated kernel.

Synthetic NVFP4 × NVFP4 → BF16 benchmarks on an NVIDIA GB300 demonstrate configurations that are inaccessible through the existing heuristics:

| Constraint | Synthetic workload | Heuristic | Override | Latency reduction |
|---|---|---:|---:|---:|
| `swap_xw=False` | Routed, M=49152, N=K=4608, 16 experts | 0.0910 ms | 0.0811 ms | 10.9% |
| `group_m=2` | 8448³ with fused SwiGLU | 0.2239 ms | 0.1939 ms | 13.4% |
| `use_output_tma=False` | 2560³ | 0.0175 ms | 0.0155 ms | 11.3% |

Each result is the median of 100 samples. L2 was cleared before every timed invocation, including completion of dirty cache-line writeback.

## Validation

- Device: NVIDIA GB300, 152 SMs
- CUDA: 13.0
- Focused opt-flag tests cover:
  - `swap_xw=None/False/True`
  - `group_m=None/2/4/8/16/32/64`
  - `use_output_tma=None/False/True`
  - Propagation of `swap_xw` into shared-memory stage budgeting
- Synthetic benchmark outputs were bitwise identical between heuristic and overridden configurations.

Test command:

`python -m pytest -s --tb=short python/triton_kernels/tests/test_matmul_details/test_opt_flags_split_k.py`

## Lines Changed

| Type | Added | Removed | Net |
|---|---:|---:|---:|
| Tests | 40 | 0 | +40 |
| Core Logic | 18 | 3 | +15 |
| AutoGenerated | 0 | 0 | 0 |
| Total | 58 | 3 | +55 |

## Reviewers Guide

- `matmul_details/opt_flags.py`
  - Accepts the three tuning constraints.
  - Resolves an explicit `group_m`.
  - Passes `swap_xw` into stage-budget calculation.
- `matmul_details/opt_flags_details/opt_flags_nvidia.py`
  - Makes shared-memory accounting respect an explicit `swap_xw`.
- `matmul.py`
  - Applies explicit `swap_xw` and output-TMA overrides.
- `test_opt_flags_split_k.py`
  - Uses a table-driven test for heuristic preservation and explicit values across all three constraints.