### PR TITLE
Fix dot_scaled scale factor validation

### DIFF
--- a/lib/Dialect/Triton/IR/Ops.cpp
+++ b/lib/Dialect/Triton/IR/Ops.cpp
@@ -389,14 +389,21 @@ LogicalResult deduceScaleFactor(ArrayRef<int64_t> lhsShape,
                                  bool kPack) -> int32_t {
     if (!scaleShape)
       return 0;
-    if (llvm::product_of(*scaleShape) == 1)
-      return 0;
 
     int64_t unpackFactor = (format == ScaleDotElemType::E2M1 && kPack) ? 2 : 1;
     int64_t kdim = operandShape[opIdx == 0 ? operandShape.size() - 1
                                            : operandShape.size() - 2] *
                    unpackFactor;
-    int32_t scaleFactor = kdim / (*scaleShape)[scaleShape->size() - 1];
+    int64_t scaleK = scaleShape->back();
+    if (scaleK <= 0 || kdim % scaleK != 0) {
+      std::ostringstream oss;
+      oss << "scale K dimension must be positive and divide operand K "
+             "dimension; got scale K dimension "
+          << scaleK << " and operand K dimension " << kdim;
+      errMsg = oss.str();
+      return 0;
+    }
+    int32_t scaleFactor = kdim / scaleK;
     if (scaleFactor != 16 && scaleFactor != 32) {
       std::ostringstream oss;
       oss << "scale factor must be 16 or 32. Got " << scaleFactor;

--- a/test/Triton/invalid.mlir
+++ b/test/Triton/invalid.mlir
@@ -575,6 +575,50 @@ module {
 
 // -----
 
+module {
+  tt.func @dot_scaled_single_nvfp4_scale(
+    %a: tensor<1x8xi8>,
+    %b: tensor<8x1xi8>,
+    %a_scale: tensor<1x1xf8E4M3FN>,
+    %b_scale: tensor<1x1xf8E4M3FN>) -> tensor<1x1xf32> {
+    %cst = arith.constant dense<0.000000e+00> : tensor<1x1xf32>
+    %result = tt.dot_scaled %a scale %a_scale, %b scale %b_scale, %cst lhs = e2m1 rhs = e2m1 {fastMath = false, lhs_k_pack = true, rhs_k_pack = true} : tensor<1x8xi8>, tensor<1x1xf8E4M3FN> * tensor<8x1xi8>, tensor<1x1xf8E4M3FN> -> tensor<1x1xf32>
+    tt.return %result : tensor<1x1xf32>
+  }
+}
+
+// -----
+
+module {
+  tt.func @dot_scaled_zero_scale_k(
+    %a: tensor<1x8xi8>,
+    %b: tensor<8x1xi8>,
+    %a_scale: tensor<1x0xf8E4M3FN>,
+    %b_scale: tensor<1x1xf8E4M3FN>) -> tensor<1x1xf32> {
+    %cst = arith.constant dense<0.000000e+00> : tensor<1x1xf32>
+    // expected-error @below {{scale K dimension must be positive and divide operand K dimension; got scale K dimension 0 and operand K dimension 16}}
+    %result = tt.dot_scaled %a scale %a_scale, %b scale %b_scale, %cst lhs = e2m1 rhs = e2m1 {fastMath = false, lhs_k_pack = true, rhs_k_pack = true} : tensor<1x8xi8>, tensor<1x0xf8E4M3FN> * tensor<8x1xi8>, tensor<1x1xf8E4M3FN> -> tensor<1x1xf32>
+    tt.return %result : tensor<1x1xf32>
+  }
+}
+
+// -----
+
+module {
+  tt.func @dot_scaled_non_divisible_scale_k(
+    %a: tensor<1x32xf8E4M3FN>,
+    %b: tensor<32x1xf8E4M3FN>,
+    %a_scale: tensor<1x64xi8>,
+    %b_scale: tensor<1x64xi8>) -> tensor<1x1xf32> {
+    %cst = arith.constant dense<0.000000e+00> : tensor<1x1xf32>
+    // expected-error @below {{scale K dimension must be positive and divide operand K dimension; got scale K dimension 64 and operand K dimension 32}}
+    %result = tt.dot_scaled %a scale %a_scale, %b scale %b_scale, %cst lhs = e4m3 rhs = e4m3 {fastMath = false} : tensor<1x32xf8E4M3FN>, tensor<1x64xi8> * tensor<32x1xf8E4M3FN>, tensor<1x64xi8> -> tensor<1x1xf32>
+    tt.return %result : tensor<1x1xf32>
+  }
+}
+
+// -----
+
 tt.func @unsplat_invalid(%arg0: tensor<128xf32>) {
   // expected-error @below {{source tensor must have exactly one element}}
   %0 = tt.unsplat %arg0 : tensor<128xf32>


### PR DESCRIPTION
## Summary

- deduce scale factors from single-element scale tensors instead of treating them as absent
- reject zero or non-divisible scale K dimensions before division
- cover the NVFP4 single-scale case and invalid scale K dimensions

## Testing

- `make` (Triton 3.8 prepared build; 436 build targets and 42 documentation targets passed)
- `triton-opt --split-input-file test/Triton/invalid.mlir --verify-diagnostics` (Triton 3.8 prepared build)
- `pre-commit run --files lib/Dialect/Triton/IR/Ops.cpp test/Triton/invalid.mlir`
