### PR TITLE
[TEST] Handle alternate CUDA errors in integer overflow checks

### DIFF
--- a/python/test/unit/test_debug.py
+++ b/python/test/unit/test_debug.py
@@ -127,10 +127,14 @@ def _run_overflow(x, y, x_dtype, y_dtype, debug, op, device):
     assert int(z) == int(ref_func(x, y))
 
 
-def _assert_overflow_result(result, debug, should_overflow):
+def _assert_overflow_result(result, debug, should_overflow, dtype, op):
     if should_overflow and debug:
         assert isinstance(result.exc, RuntimeError)
-        assert "device-side assert" in str(result.exc)
+        # CUDA can report a device assertion as an unspecified launch failure.
+        # Check the diagnostic as well so unrelated launch failures cannot pass.
+        assert any(msg in str(result.exc)
+                   for msg in ["device-side assert", "unspecified launch failure"]), str(result.exc)
+        assert f"{dtype} overflow detected for operation {op}" in result.driver_stderr_output, result.driver_stderr_output
         return
 
     assert result.exc is None, result.exc
@@ -152,7 +156,7 @@ def _assert_overflow_result(result, debug, should_overflow):
 ])
 def test_sanitize_int_add_overflow(x, y, x_dtype, y_dtype, debug, should_overflow, device):
     result = run_in_process(_run_overflow, (x, y, x_dtype, y_dtype, debug, "add", device))
-    _assert_overflow_result(result, debug, should_overflow)
+    _assert_overflow_result(result, debug, should_overflow, x_dtype, "add")
 
 
 # mul overflow
@@ -168,7 +172,7 @@ def test_sanitize_int_add_overflow(x, y, x_dtype, y_dtype, debug, should_overflo
 ])
 def test_sanitize_int_mul_overflow(x, y, x_dtype, y_dtype, debug, should_overflow, device):
     result = run_in_process(_run_overflow, (x, y, x_dtype, y_dtype, debug, "mul", device))
-    _assert_overflow_result(result, debug, should_overflow)
+    _assert_overflow_result(result, debug, should_overflow, x_dtype, "mul")
 
 
 # sub overflow
@@ -183,4 +187,4 @@ def test_sanitize_int_mul_overflow(x, y, x_dtype, y_dtype, debug, should_overflo
 ])
 def test_sanitize_int_sub_overflow(x, y, x_dtype, y_dtype, debug, should_overflow, device):
     result = run_in_process(_run_overflow, (x, y, x_dtype, y_dtype, debug, "sub", device))
-    _assert_overflow_result(result, debug, should_overflow)
+    _assert_overflow_result(result, debug, should_overflow, x_dtype, "sub")


### PR DESCRIPTION
## Summary

The [H100 run for #11340](https://github.com/triton-lang/triton/actions/runs/32122194361/job/95664986315) correctly detected an int32 subtraction overflow, but CUDA reported `unspecified launch failure` instead of `device-side assert`. The existing test rejected that error despite the correct diagnostic in driver stderr.