### PR TITLE
[GSan] Weaken mbarrier semantics

### DIFF
--- a/include/triton/Dialect/TritonInstrument/IR/TritonInstrumentOps.td
+++ b/include/triton/Dialect/TritonInstrument/IR/TritonInstrumentOps.td
@@ -167,7 +167,7 @@ def TTI_ExperimentalGSanMBarrierTableInitOp
              [MemoryEffects<[MemWrite<GlobalMemory>]>]> {
   let summary = "Initialize GSan mbarrier release state";
   let description = [{
-    Initializes gsan't internal mbarrier table, used to sequence memory accesses
+    Initializes GSan's internal mbarrier table, used to sequence memory accesses
     through cluster mbarriers. This operation is internal to GSan instrumentation.
   }];
   let arguments = (ins TT_Ptr:$scratch, I32Attr:$capacity);
@@ -199,7 +199,9 @@ def TTI_ExperimentalGSanMBarrierArriveOp
   let description = [{
     Records an arrival for every mbarrier targeted by the corresponding
     hardware operation. When `publishClock` is true, the issuing CTA's vector
-    clock is also published as a release. A false value records only phase
+    clock is also published without advancing its local epoch. Waiters acquire
+    the issuing CTA's completed epochs and its imported clocks, but not its
+    current epoch. A false value records only phase
     progress for asynchronous completion signals that provide no generic
     memory ordering. `multicastMasks` contains CTA-id broadcast masks whose
     recipient bitsets are unioned. When `multicast` is false, the arrival
@@ -223,7 +225,9 @@ def TTI_ExperimentalGSanMBarrierWaitOp
                              MemWrite<GlobalMemory>]>]> {
   let summary = "Acquire GSan clocks after an mbarrier wait";
   let description = [{
-    Acquires the release clocks published to the completed mbarrier phase.
+    Acquires the clocks published to the completed mbarrier phase, excluding
+    each publisher's current epoch. Global-memory handoffs that rely solely on
+    an mbarrier may therefore be conservatively reported as races.
     This operation is internal to GSan instrumentation.
   }];
   let arguments = (ins TT_Ptr:$scratch, TTG_MemDescType:$barrier,

--- a/python/test/gsan/test_gsan.py
+++ b/python/test/gsan/test_gsan.py
@@ -480,7 +480,7 @@ def test_gluon_mbarrier_initial_empty_phase_is_ready(with_gsan):
 
 
 @gluon.jit
-def _gluon_mbarrier_sync_kernel(payload_ptr, out_ptr):
+def _gluon_mbarrier_sync_kernel(payload_ptr, counter_ptr, out_ptr):
     data_layout: gl.constexpr = gl.BlockedLayout([1], [32], [4], [0], cga_layout=[[1]])
 
     barrier = hopper.mbarrier.allocate_mbarrier(two_ctas=True)
@@ -491,6 +491,9 @@ def _gluon_mbarrier_sync_kernel(payload_ptr, out_ptr):
         payload_ptrs = payload_ptr + iteration + offsets * 0
         out_ptrs = out_ptr + iteration + offsets * 0
         gl.store(payload_ptrs, iteration + 1, mask=offsets == 128)
+        # Mbarriers only propagate completed epochs. A release closes the
+        # writer's epoch; direct current-epoch handoffs are tested as failures.
+        gl.atomic_add(counter_ptr, 1, sem="release", scope="gpu")
         hopper.mbarrier.arrive(barrier, count=1)
         hopper.mbarrier.wait(barrier, phase=iteration % 2)
         value = gl.load(payload_ptrs, mask=offsets == 0, other=0)
@@ -500,11 +503,12 @@ def _gluon_mbarrier_sync_kernel(payload_ptr, out_ptr):
 
 
 @pytest.mark.skipif(not is_hopper_or_newer(), reason="requires Hopper or newer")
-def test_gluon_mbarrier_wait_acquires_arrival_vector_clocks(with_gsan):
+def test_gluon_mbarrier_wait_preserves_completed_epochs(with_gsan):
     payload = torch.zeros(4, dtype=torch.int32, device="cuda")
+    counter = torch.zeros(1, dtype=torch.int32, device="cuda")
     out = torch.full((4, ), -1, dtype=torch.int32, device="cuda")
 
-    _gluon_mbarrier_sync_kernel[(1, )](payload, out, num_warps=4, num_ctas=2)
+    _gluon_mbarrier_sync_kernel[(1, )](payload, counter, out, num_warps=4, num_ctas=2)
     torch.cuda.synchronize()
 
     torch.testing.assert_close(out, torch.arange(1, 5, dtype=torch.int32, device="cuda"))
@@ -519,13 +523,14 @@ def test_gluon_mbarrier_wait_acquires_arrival_vector_clocks(with_gsan):
 
 
 @gluon.jit
-def _gluon_ws_mbarrier_partition(payload_ptr, out_ptr, barrier, index: gl.constexpr):
+def _gluon_ws_mbarrier_partition(payload_ptr, counter_ptr, out_ptr, barrier, index: gl.constexpr):
     data_layout: gl.constexpr = gl.BlockedLayout([1], [32], [4], [0], cga_layout=[[1]])
 
     offsets = gl.arange(0, 256, data_layout)
     payload_ptrs = payload_ptr + index + offsets * 0
     out_ptrs = out_ptr + index + offsets * 0
     gl.store(payload_ptrs, index + 1, mask=offsets == 128)
+    gl.atomic_add(counter_ptr + index, 1, sem="release", scope="gpu")
     hopper.mbarrier.arrive(barrier, count=1)
     hopper.mbarrier.wait(barrier, phase=0)
     value = gl.load(payload_ptrs, mask=offsets == 0, other=0)
@@ -533,13 +538,13 @@ def _gluon_ws_mbarrier_partition(payload_ptr, out_ptr, barrier, index: gl.conste
 
 
 @gluon.jit
-def _gluon_ws_mbarrier_sync_kernel(payload_ptr, out_ptr):
+def _gluon_ws_mbarrier_sync_kernel(payload_ptr, counter_ptr, out_ptr):
     barriers = hopper.mbarrier.allocate_mbarrier(batch=2, two_ctas=True)
     hopper.mbarrier.init(barriers.index(0), count=1)
     hopper.mbarrier.init(barriers.index(1), count=1)
     gl.warp_specialize([
-        (_gluon_ws_mbarrier_partition, (payload_ptr, out_ptr, barriers.index(0), 0)),
-        (_gluon_ws_mbarrier_partition, (payload_ptr, out_ptr, barriers.index(1), 1)),
+        (_gluon_ws_mbarrier_partition, (payload_ptr, counter_ptr, out_ptr, barriers.index(0), 0)),
+        (_gluon_ws_mbarrier_partition, (payload_ptr, counter_ptr, out_ptr, barriers.index(1), 1)),
     ], [4])
     hopper.mbarrier.invalidate(barriers.index(0))
     hopper.mbarrier.invalidate(barriers.index(1))
@@ -548,9 +553,10 @@ def _gluon_ws_mbarrier_sync_kernel(payload_ptr, out_ptr):
 @pytest.mark.skipif(not is_hopper_or_newer(), reason="requires Hopper or newer")
 def test_gluon_mbarrier_sync_in_warp_specialized_partitions(with_gsan):
     payload = torch.zeros(2, dtype=torch.int32, device="cuda")
+    counter = torch.zeros(2, dtype=torch.int32, device="cuda")
     out = torch.full((2, ), -1, dtype=torch.int32, device="cuda")
 
-    _gluon_ws_mbarrier_sync_kernel[(1, )](payload, out, num_warps=4, num_ctas=2)
+    _gluon_ws_mbarrier_sync_kernel[(1, )](payload, counter, out, num_warps=4, num_ctas=2)
     torch.cuda.synchronize()
 
     torch.testing.assert_close(out, torch.tensor([1, 2], dtype=torch.int32, device="cuda"))
@@ -562,6 +568,117 @@ def test_gluon_mbarrier_sync_in_warp_specialized_partitions(with_gsan):
         assert consumer_tid != producer_tid
         consumer_state = thread_state_from_smid(consumer_tid)
         assert consumer_state.vector_clock[producer_tid] >= producer_epoch
+
+
+@gluon.jit
+def _gluon_mbarrier_repeated_phases_kernel(markers, flags, iterations, EXPECT: gl.constexpr):
+    layout: gl.constexpr = gl.BlockedLayout([1], [32], [4], [0], cga_layout=[[1]])
+    offsets = gl.arange(0, 256, layout)
+    cta = offsets // 128
+    elected = offsets % 128 == 0
+    barrier = hopper.mbarrier.allocate_mbarrier(two_ctas=True)
+    hopper.mbarrier.init(barrier, count=1)
+    # Keep a release snapshot live throughout the loop, as fused-communication
+    # completion flags do in production kernels.
+    gl.atomic_xchg(flags + cta, 1, mask=elected, sem="release", scope="gpu")
+    gl.store(markers + cta, 1, mask=elected)
+    for iteration in range(iterations):
+        if EXPECT:
+            hopper.mbarrier.expect(barrier, 0)
+        else:
+            hopper.mbarrier.arrive(barrier)
+        hopper.mbarrier.wait(barrier, iteration % 2)
+        hopper.cluster.barrier(relaxed=True)
+    gl.store(markers + 2 + cta, 1, mask=elected)
+    hopper.mbarrier.invalidate(barrier)
+
+
+@pytest.mark.skipif(not is_hopper_or_newer(), reason="requires Hopper or newer")
+@pytest.mark.parametrize("expect", [False, True], ids=["arrive", "expect"])
+def test_gluon_mbarrier_repeated_phases_reuse_epochs_and_snapshots(with_gsan, expect):
+    markers = torch.zeros(4, dtype=torch.int32, device="cuda")
+    flags = torch.zeros(2, dtype=torch.int32, device="cuda")
+    _gluon_mbarrier_repeated_phases_kernel[(1, )](markers, flags, 65536, expect, num_warps=4, num_ctas=2)
+    torch.cuda.synchronize()
+
+    clocks = [shadow_cell_from_address(markers.data_ptr() + i * markers.element_size()).write_clock for i in range(4)]
+    assert clocks[0].thread_id != clocks[1].thread_id
+    for cta in range(2):
+        assert clocks[cta] == clocks[cta + 2]
+        state = thread_state_from_smid(clocks[cta].thread_id)
+        release = shadow_cell_from_address(flags.data_ptr() + cta * flags.element_size()).write_clock
+        assert release.is_release
+        assert release.thread_id == state.thread_id
+        # Publishing once and importing the peer's completed epoch can create
+        # a few snapshots, but the phase count must not control buffer usage.
+        assert 0 <= state.clock_buffer_head - release.epoch <= 4
+        assert state.vector_clock[state.thread_id] == clocks[cta].epoch
+    consumer = thread_state_from_smid(clocks[0].thread_id)
+    assert consumer.vector_clock[clocks[1].thread_id] == clocks[1].epoch - 1
+
+
+@triton.jit
+def _gsan_warm_all_sms_kernel(markers, counter, num_sms: tl.constexpr):
+    smid = tl.inline_asm_elementwise("mov.u32 $0, %smid;", "=r", [], tl.int32, is_pure=False, pack=1)
+    tl.store(markers + smid, 1)
+    tl.atomic_add(counter, 1, sem="relaxed", scope="gpu")
+    # GSan reserves all shared memory, so these resident CTAs occupy distinct
+    # SMs. Keep them alive until every SM has advanced its local epoch.
+    atomic_poll(counter, num_sms)
+
+
+@gluon.jit
+def _gluon_mbarrier_transitive_clock_kernel(markers):
+    layout: gl.constexpr = gl.BlockedLayout([1], [32], [4], [0], cga_layout=[[1], [2]])
+    pairs01 = gl.allocate_shared_memory(gl.int64, [2], hopper.mbarrier.MBarrierLayout([[0], [1]]))
+    pairs02 = gl.allocate_shared_memory(gl.int64, [2], hopper.mbarrier.MBarrierLayout([[1], [0]]))
+    hopper.mbarrier.init(pairs01, count=1)
+    hopper.mbarrier.init(pairs02, count=1)
+    offsets = gl.arange(0, 512, layout)
+    gl.store(markers + offsets // 128, 1, mask=offsets % 128 == 0)
+    # CTA 2 first acquires CTA 3's completed epoch, then passes it to CTA 0.
+    hopper.mbarrier.arrive(pairs01)
+    hopper.mbarrier.wait(pairs01, 0)
+    hopper.cluster.barrier(relaxed=True)
+    hopper.mbarrier.arrive(pairs02)
+    hopper.mbarrier.wait(pairs02, 0)
+    hopper.cluster.barrier(relaxed=True)
+    hopper.mbarrier.invalidate(pairs01)
+    hopper.mbarrier.invalidate(pairs02)
+
+
+@pytest.mark.skipif(not is_hopper_or_newer(), reason="requires Hopper or newer")
+def test_gluon_mbarrier_preserves_transitively_imported_clocks(with_gsan):
+    num_sms = torch.cuda.get_device_properties(torch.cuda.current_device()).multi_processor_count
+    warm = torch.zeros(num_sms, dtype=torch.int32, device="cuda")
+    counter = torch.zeros(1, dtype=torch.int32, device="cuda")
+    markers = torch.zeros(4, dtype=torch.int32, device="cuda")
+    stream = torch.cuda.Stream()
+    stream.wait_stream(torch.cuda.current_stream())
+    with torch.cuda.stream(stream):
+        _gsan_warm_all_sms_kernel[(num_sms, )](warm, counter, num_sms, num_warps=1)
+    stream.synchronize()
+    # A host wait does not import this independent stream's GSan clock.
+    _gluon_mbarrier_transitive_clock_kernel[(1, )](markers, num_warps=4, num_ctas=4)
+    torch.cuda.synchronize()
+
+    clocks = [shadow_cell_from_address(markers.data_ptr() + i * markers.element_size()).write_clock for i in range(4)]
+    assert len({clock.thread_id for clock in clocks}) == 4
+    consumer = thread_state_from_smid(clocks[0].thread_id)
+    for clock in clocks[1:]:
+        smid = clock.thread_id % num_sms
+        previous = shadow_cell_from_address(warm.data_ptr() + smid * warm.element_size()).write_clock
+        assert previous.thread_id == clock.thread_id
+        assert previous.epoch + 1 == clock.epoch
+        assert consumer.vector_clock[clock.thread_id] == previous.epoch
+    # The zero CTA-layout bases predicate the waits onto the pair leaders.
+    # CTA 1 acquires CTA 3 in the second phase, but neither CTA 1 nor CTA 3
+    # executes a wait that could acquire CTA 2's newly completed epoch.
+    nonleader = thread_state_from_smid(clocks[1].thread_id)
+    assert nonleader.vector_clock[clocks[3].thread_id] == clocks[3].epoch - 1
+    for cta in (1, 3):
+        state = thread_state_from_smid(clocks[cta].thread_id)
+        assert state.vector_clock[clocks[2].thread_id] < clocks[2].epoch - 1
 
 
 @triton.jit

--- a/python/test/gsan/test_gsan_failures.py
+++ b/python/test/gsan/test_gsan_failures.py
@@ -282,25 +282,23 @@ def _gluon_cluster_barrier_kernel(payload_ptr, out_ptr, RELAXED: gl.constexpr):
 
 
 @gluon.jit
-def _gluon_mbarrier_post_arrival_write_kernel(payload_ptr, out_ptr):
+def _gluon_mbarrier_current_epoch_kernel(payload_ptr, out_ptr, AFTER_ARRIVAL: gl.constexpr):
     data_layout: gl.constexpr = gl.BlockedLayout([1], [32], [4], [0], cga_layout=[[1]])
 
     barrier = hopper.mbarrier.allocate_mbarrier(two_ctas=True)
     hopper.mbarrier.init(barrier, count=1)
     offsets = gl.arange(0, 256, data_layout)
 
-    ordered_ptrs = payload_ptr + offsets * 0
-    gl.store(ordered_ptrs, 1, mask=offsets == 128)
+    payload_ptrs = payload_ptr + offsets * 0
+    if not AFTER_ARRIVAL:
+        gl.store(payload_ptrs, 1, mask=offsets == 128)
     hopper.mbarrier.arrive(barrier, count=1)
     hopper.mbarrier.wait(barrier, phase=0)
-    ordered = gl.load(ordered_ptrs, mask=offsets == 0, other=0)
-    gl.store(out_ptr + offsets * 0, ordered, mask=offsets == 0)
-
-    unordered_ptrs = payload_ptr + 1 + offsets * 0
-    gl.store(unordered_ptrs, 2, mask=offsets == 128)
+    if AFTER_ARRIVAL:
+        gl.store(payload_ptrs, 1, mask=offsets == 128)
     hopper.cluster.barrier(relaxed=True)
-    unordered = gl.load(unordered_ptrs, mask=offsets == 0, other=0)
-    gl.store(out_ptr + 1 + offsets * 0, unordered, mask=offsets == 0)
+    value = gl.load(payload_ptrs, mask=offsets == 0, other=0)
+    gl.store(out_ptr + offsets * 0, value, mask=offsets == 0)
     hopper.mbarrier.invalidate(barrier)
 
 
@@ -444,10 +442,10 @@ def _run_gluon_relaxed_cluster_barrier_case() -> None:
 
 
 @run_with_gsan
-def _run_gluon_mbarrier_post_arrival_write_case() -> None:
-    payload = torch.zeros(2, dtype=torch.int32, device="cuda")
-    out = torch.full((2, ), -1, dtype=torch.int32, device="cuda")
-    _gluon_mbarrier_post_arrival_write_kernel[(1, )](payload, out, num_warps=4, num_ctas=2)
+def _run_gluon_mbarrier_current_epoch_case(after_arrival: bool) -> None:
+    payload = torch.zeros(1, dtype=torch.int32, device="cuda")
+    out = torch.full((1, ), -1, dtype=torch.int32, device="cuda")
+    _gluon_mbarrier_current_epoch_kernel[(1, )](payload, out, after_arrival, num_warps=4, num_ctas=2)
 
 
 @run_with_gsan
@@ -709,12 +707,14 @@ def test_relaxed_cluster_barrier_does_not_synchronize_vector_clocks():
 
 
 @pytest.mark.skipif(not is_hopper_or_newer(), reason="requires Hopper or newer")
-def test_mbarrier_wait_does_not_acquire_post_arrival_writes():
+@pytest.mark.parametrize("after_arrival", [False, True], ids=["before-arrival", "after-arrival"])
+def test_mbarrier_wait_does_not_acquire_current_epoch(after_arrival):
     _run_failure_case(
-        "mbarrier_post_arrival_write",
-        runner=_run_gluon_mbarrier_post_arrival_write_case,
-        source_function=_gluon_mbarrier_post_arrival_write_kernel.fn,
-        marker="unordered = gl.load(unordered_ptrs",
+        f"mbarrier_current_epoch_{after_arrival}",
+        runner=_run_gluon_mbarrier_current_epoch_case,
+        runner_args=(after_arrival, ),
+        source_function=_gluon_mbarrier_current_epoch_kernel.fn,
+        marker="value = gl.load(payload_ptrs",
         error="Read after write race detected",
     )
 

--- a/python/triton/experimental/gsan/src/GSan.h
+++ b/python/triton/experimental/gsan/src/GSan.h
@@ -124,6 +124,8 @@ struct alignas(16) ClusterBarrierState {
 static_assert(sizeof(ClusterBarrierState) <= kClusterBarrierScratchBytes);
 
 struct MBarrierPublishedClock {
+  // An immutable snapshot whose publisher has not advanced its epoch. A wait
+  // must exclude that thread's current epoch when acquiring the snapshot.
   thread_id_t threadId;
   epoch_t token;
 };

--- a/python/triton/experimental/gsan/src/GSanLibrary.cu
+++ b/python/triton/experimental/gsan/src/GSanLibrary.cu
@@ -459,12 +459,18 @@ GSAN_DEVICE void incrementThreadEpoch(ThreadState *state, Location loc) {
   state->clockBufferDirty = 1;
 }
 
-GSAN_DEVICE bool mergeVectorClock(ThreadState *state, const epoch_t *snapshot) {
+// A publisher that has not advanced its local epoch can only transfer its
+// completed epochs. All other entries retain their usual acquire semantics.
+GSAN_DEVICE bool mergeVectorClock(ThreadState *state, const epoch_t *snapshot,
+                                  thread_id_t incompleteThread = kMaxThreads) {
   bool changed = false;
   auto *globals = getGlobalState(state);
   for (int i = 0; i < globals->numThreads; ++i) {
-    if (state->vectorClock[i] < snapshot[i]) {
-      state->vectorClock[i] = snapshot[i];
+    auto epoch = snapshot[i];
+    if (i == incompleteThread && epoch != 0)
+      --epoch;
+    if (state->vectorClock[i] < epoch) {
+      state->vectorClock[i] = epoch;
       changed = true;
     }
   }
@@ -524,6 +530,18 @@ GSAN_DEVICE epoch_t publishClusterClock(ThreadState *state, Location loc) {
   // local epoch so later accesses are distinct from the published snapshot.
   epoch_t token = publishCurrentVectorClock(state, loc);
   incrementThreadEpoch(state, loc);
+  rwLockReleaseWrite(state->lock);
+  return token;
+}
+
+GSAN_DEVICE epoch_t publishMBarrierClock(ThreadState *state, Location loc) {
+  rwLockAcquireWrite(state->lock);
+  // Mbarriers are frequent in shared/TMEM pipelines. Do not consume an epoch
+  // for each arrival: publish an immutable snapshot and let the waiter exclude
+  // this thread's still-open epoch. Imported clocks remain fully transferable.
+  // Reusing the ordinary snapshot cache also avoids filling the clock buffer
+  // when repeated arrivals have no new ordering to publish.
+  epoch_t token = publishCurrentVectorClock(state, loc);
   rwLockReleaseWrite(state->lock);
   return token;
 }
@@ -682,7 +700,7 @@ GSAN_DEVICE void recordMBarrierArrival(GlobalState *globals, void *scratch,
   MBarrierPublishedClock published = {};
   if (publishClock) {
     auto *threadState = getThreadState(globals);
-    published = {threadState->threadId, publishClusterClock(threadState, loc)};
+    published = {threadState->threadId, publishMBarrierClock(threadState, loc)};
   }
   auto *table = reinterpret_cast<MBarrierTable *>(scratch);
   for (uint32_t ownerRank = 0; ownerRank < kMaxClusterCTAs; ++ownerRank) {
@@ -741,7 +759,11 @@ GSAN_DEVICE void acquireMBarrierPhase(GlobalState *globals, void *scratch,
     auto *publisher = getThreadStateById(globals, published.threadId);
     const epoch_t *snapshot =
         getClockBufferSlot(publisher, published.token, loc);
-    mergeVectorClock(threadState, snapshot);
+    // The publisher did not advance its epoch. Acquiring that epoch would
+    // incorrectly order its post-arrival accesses as well as earlier ones.
+    // Only its completed epochs, and ordering imported from other threads,
+    // are covered by this deliberately weaker mbarrier model.
+    mergeVectorClock(threadState, snapshot, published.threadId);
   }
   rwLockReleaseWrite(threadState->lock);
 }


### PR DESCRIPTION
Currently an arrive-wait pair is modelled as a full acquire-release pattern which consumes epoch counter range, and also vector clock buffer space.

This changes it to not advance the epoch counter on mbarrier arrival, and on wait we only acquire `epoch - 1` from the arriving CTA.  Also, since we already reuse the published clock buffer snapshots when they haven't changed, we don't actually use more clock buffer space either.

The trade-off is that you can't use an mbarrier alone to pass messages through global memory between CTAs in the cluster, but usually communication within a cluster happens through dsmem anyway.

In a real 2CTA matmul kernel this changed the final epoch counter from ~16,000 to just 2.