### PR TITLE
[FRONTEND] Require identical operand shapes in `tl.cat`

### DIFF
--- a/python/test/unit/language/test_core.py
+++ b/python/test/unit/language/test_core.py
@@ -2327,6 +2327,26 @@ def test_cat_nd(shape, dim, device):
     torch.testing.assert_close(z, z_ref, atol=0, rtol=0)
 
 
+@pytest.mark.parametrize("m1, m2", [
+    pytest.param(16, 8, id="non_broadcastable"),
+    pytest.param(1, 8, id="broadcastable"),
+])
+def test_cat_shape_mismatch(m1, m2, device):
+
+    @triton.jit
+    def kernel(X, Y, M1: tl.constexpr, M2: tl.constexpr):
+        x = tl.load(X + tl.arange(0, M1))
+        y = tl.load(Y + tl.arange(0, M2))
+        z = tl.cat(x, y, dim=0)
+        tl.store(X + tl.arange(0, 1), tl.sum(z))
+
+    x = torch.zeros(m1, device=device, dtype=torch.float32)
+    y = torch.zeros(m2, device=device, dtype=torch.float32)
+    with pytest.raises(triton.CompilationError) as exc_info:
+        kernel[(1, )](x, y, M1=m1, M2=m2)
+    assert "tl.cat requires tensors of the same shape" in str(exc_info.value)
+
+
 @pytest.mark.interpreter
 @pytest.mark.parametrize("dtype_str", list(torch_dtypes))
 @pytest.mark.parametrize("constant_field", ["value", "mask"])

--- a/python/triton/language/core.py
+++ b/python/triton/language/core.py
@@ -2005,8 +2005,9 @@ def cat(input, other, can_reorder=False, dim=0, _semantic=None):
     rank = len(input.shape)
     assert rank == len(other.shape), f"tensors must have the same rank, got {rank} and {len(other.shape)}"
     dim = _wrap_axis(_unwrap_if_constexpr(dim), rank)
-    assert all(input.shape[i] == other.shape[i] for i in builtins.range(rank) if i !=
-               dim), f"tensor dims must match except in the concat dimension {dim}, got {input.shape} and {other.shape}"
+    assert all(input.shape[i] == other.shape[i] for i in builtins.range(rank)), (
+        f"tl.cat requires tensors of the same shape, got "
+        f"{[_unwrap_if_constexpr(s) for s in input.shape]} and {[_unwrap_if_constexpr(s) for s in other.shape]}")
 
     # Join introduces a new minor dim; move it before the concat dim and merge.
     c = join(input, other, _semantic=_semantic)


### PR DESCRIPTION
## Summary

The precondition assertion of `tl.cat` follows the input contract of `torch.cat` — all dims except `dim` must match, and `dim` itself is allowed to differ. However, any input that differs along `dim` always fails to compile under the current implementation (the `join → permute → reshape` decomposition), and the error comes from the broadcast inside `join` or from the shape check inside `reshape` — it never mentions `cat`, so nothing points back to the call site. This PR tightens the assertion to require identical shapes and makes the error state the reason directly.

## Background

The first step of the decomposition, `join`, requires both operands to have the same shape at the IR level (`SameTypeOperands`). The frontend aligns the shapes with `broadcast_impl_value` — that is broadcast semantics, not concat semantics — so inputs that differ along `dim` fail in one of two ways:

- Not broadcastable (e.g. `16 vs 8`): `join` raises `Cannot make_shape_compatible: incompatible dimensions at index 0: 16 and 8`.
- Broadcastable (e.g. `1 vs 8`): `join` broadcasts silently, then `reshape` raises `Shape element 0 must be a power of 2`.

This cannot be fixed by a better implementation: the sum of two distinct powers of two is never a power of two, so with different sizes along `dim` the output shape is itself not a legal Triton block shape, and no implementation that returns a block tensor can produce it. Tightening the assertion is the only correct fix.

## Changes

- `python/triton/language/core.py`: the assertion in `cat` no longer exempts the concat dim (`if i != dim`) and now requires equal shapes on all dims; the message becomes `tl.cat requires tensors of the same shape, got [16] and [8]` (shapes rendered through `_unwrap_if_constexpr`).
- `python/test/unit/language/test_core.py`: add `test_cat_shape_mismatch`, parametrized over both failure modes (`non_broadcastable`: `(16,) + (8,)`; `broadcastable`: `(1,) + (8,)`), asserting the new message.

## Behavior impact

- No input that compiled before breaks: inputs that differ along `dim` already failed to compile (in `join` or in `reshape`). This PR only moves the failure to the entry of `cat`, with an error that points to the call site.
- Inputs with identical shapes behave exactly as before.

## Testing

- The new `test_cat_shape_mismatch` (both `non_broadcastable` / `broadcastable` cases) passes.
- The existing `test_cat` / `test_cat_nd` cover the identical-shape correctness path and are unaffected.

Fixes #11352 