### PR TITLE
[ConSan] Disble setmaxnreg in warp specialized regions

### DIFF
--- a/lib/Dialect/TritonInstrument/Transforms/ConcurrencySanitizer.cpp
+++ b/lib/Dialect/TritonInstrument/Transforms/ConcurrencySanitizer.cpp
@@ -826,6 +826,9 @@ private:
             b, baseThread, info->cluster, hooks.getIssuerCTAPred(b, op), op);
       }
       if (auto wsOp = dyn_cast<ttg::WarpSpecializeOp>(op)) {
+        // ConSan helpers can exceed the partition register budgets and make
+        // PTXAS-generated dynamic register allocation deadlock.
+        wsOp->setAttr("tti.disable_setmaxregister", b.getUnitAttr());
         funcBuilder.createSetActiveMaskCall(b, getActiveMask(wsOp), op);
         auto partitionRegions = wsOp.getNonEmptyPartitionRegions();
         if (!partitionRegions.empty()) {

--- a/test/TritonGPU/consan.mlir
+++ b/test/TritonGPU/consan.mlir
@@ -208,6 +208,8 @@ module attributes {"ttg.num-ctas" = 2 : i32, "ttg.num-warps" = 4 : i32, ttg.shar
     // CHECK: tt.call @__triton_consan_publish_cluster_visibility{{.*}}_I0
     ttng.cluster_barrier
 
+    // CHECK: ttg.warp_specialize
+    // CHECK-SAME: tti.disable_setmaxregister
     ttg.warp_specialize(%buf) attributes {actualRegisters = array<i32: 32, 32, 32>, allocation.offset = 4096 : i32, requestedRegisters = array<i32: 32, 32>, warpGroupStartIds = array<i32: 4, 5>}
     default {
       // The default region is thread 0, but its cluster barrier is still


### PR DESCRIPTION
Recent timeouts in CI are caused by the ptxas register allocator struggling with consan in tight-budgeted warp partitions. Lets just disable setmaxnreg, which is what gsan does already.