### PR TITLE
[KERNELS] Fix Blackwell MXFP fused-output tile selection

### DIFF
--- a/python/triton_kernels/tests/test_matmul.py
+++ b/python/triton_kernels/tests/test_matmul.py
@@ -279,6 +279,13 @@ def _build_test_op_cases():
         Case(*shape, mode, "mxfloat8_e4m3fn", "mxfloat4_e2m1", a_hbm_swizzling=True, b_hbm_swizzling=True, split_k=split_k, swiglu_opts=(1.1, 7))
      for shape in [odd_shape2, even_shape] for mode in ["ragged", "batched"] for split_k in [1, 5]
     ])
+    # MXFP8 lhs x dense rhs needs TMEM headroom even with fused MX output.
+    test_cases.extend([
+        Case(32, 256, 128, "plain", "mxfloat8_e4m3fn", rhs_dtype, "mxfloat8_e4m3fn",
+             a_hbm_swizzling=True, c_hbm_swizzling=c_hbm_swizzling, swiglu_opts=(1.702, 7.0))
+        for rhs_dtype in ["bfloat16", "float16"]
+        for c_hbm_swizzling in [False, True]
+    ])
     # swiglu together with nvfp4 downcast epilogue
     test_cases.extend([
         Case(*shape, mode, "bfloat16", "bfloat16", "nvfp4_e2m1", swiglu_opts=(1.1, 7.0))

--- a/python/triton_kernels/triton_kernels/matmul_details/opt_flags.py
+++ b/python/triton_kernels/triton_kernels/matmul_details/opt_flags.py
@@ -331,7 +331,7 @@ def make_default_opt_flags_nvidia(
             and opt_flags_nvidia.is_blackwell_mx_lhs_dense_rhs(precision_config, lhs_dtype, rhs_dtype)):
         # Native Blackwell MX lhs + dense rhs persistent dots also stage an
         # expanded operand in TMEM, so keep the accumulator tile below the
-        # 512-column budget.
+        # 512-column budget, including when the epilogue produces MX output.
         block_n = min(block_n, 128)
     # adjust block_m based on is_persistent signal
     if is_persistent and opt_flags_nvidia.is_x_scale_swizzled(precision_config):
@@ -385,7 +385,8 @@ def make_default_opt_flags_nvidia(
             and is_persistent
             and block_n <= 128
             and block_k >= 256
-            and opt_flags_nvidia.is_blackwell_mx_lhs_dense_rhs(precision_config, lhs_dtype, rhs_dtype)):
+            and opt_flags_nvidia.is_blackwell_mx_lhs_dense_rhs(precision_config, lhs_dtype, rhs_dtype)
+            and precision_config.c_mx_scale is None):
         num_warps = max(num_warps, 8)
 
     # Occupancy target and maxnreg (for Hopper)

--- a/python/triton_kernels/triton_kernels/matmul_details/opt_flags_details/opt_flags_nvidia.py
+++ b/python/triton_kernels/triton_kernels/matmul_details/opt_flags_details/opt_flags_nvidia.py
@@ -16,8 +16,7 @@ def is_x_scale_swizzled(precision_config):
 def is_blackwell_mx_lhs_dense_rhs(precision_config, lhs_dtype, rhs_dtype):
     return (target_info.cuda_capability_geq(10, 0) and precision_config is not None
             and precision_config.a_mx_scale is not None and precision_config.a_microblock_size == int(MXFP_BLOCK_SIZE)
-            and precision_config.b_mx_scale is None and lhs_dtype.bitwidth <= 8
-            and rhs_dtype in [FP16, BF16])
+            and precision_config.b_mx_scale is None and lhs_dtype.bitwidth <= 8 and rhs_dtype in [FP16, BF16])
 
 
 def compute_swap_xw(precision_config, block_m, is_persistent, lhs_dtype, rhs_dtype):

--- a/python/triton_kernels/triton_kernels/matmul_details/opt_flags_details/opt_flags_nvidia.py
+++ b/python/triton_kernels/triton_kernels/matmul_details/opt_flags_details/opt_flags_nvidia.py
@@ -16,7 +16,7 @@ def is_x_scale_swizzled(precision_config):
 def is_blackwell_mx_lhs_dense_rhs(precision_config, lhs_dtype, rhs_dtype):
     return (target_info.cuda_capability_geq(10, 0) and precision_config is not None
             and precision_config.a_mx_scale is not None and precision_config.a_microblock_size == int(MXFP_BLOCK_SIZE)
-            and precision_config.b_mx_scale is None and precision_config.c_mx_scale is None and lhs_dtype.bitwidth <= 8
+            and precision_config.b_mx_scale is None and lhs_dtype.bitwidth <= 8
             and rhs_dtype in [FP16, BF16])
 
 
@@ -79,7 +79,8 @@ def compute_block_k(m: int, k: int | None, is_persistent: bool, lhs_dtype, rhs_d
         min_block_k = 32 if is_persistent or lhs_width != 16 or rhs_width != 16 else 16
         block_k = max(min_block_k, min(triton.next_power_of_2(k), block_k))
     if (is_persistent and k is not None and k >= 256
-            and is_blackwell_mx_lhs_dense_rhs(precision_config, lhs_dtype, rhs_dtype)):
+            and is_blackwell_mx_lhs_dense_rhs(precision_config, lhs_dtype, rhs_dtype)
+            and precision_config.c_mx_scale is None):
         block_k = max(block_k, 256)
     if precision_config is not None and precision_config.b_mx_scale is not None:
         if has_native_mxfp and is_persistent:


### PR DESCRIPTION
## Summary

Blackwell's persistent MXFP × dense BF16/FP16 matmul expands the MXFP operand into tensor memory alongside the accumulator. The existing `block_n <= 128` safeguard only applies when the output is dense. With fused SwiGLU and MXFP8 output, `(M, N, K) = (32, 256, 128)` therefore selects a tile requiring 576 columns and exceeds the [512-column TMEM limit](https://docs.nvidia.com/cuda/archive/12.8.0/parallel-thread-execution/index.html#tensor-memory).

Apply the existing column limit to microscaled outputs too. Keep dense-output block-K and warp tuning unchanged, and continue honoring explicit planner constraints. Extend the real matmul tests across BF16/FP16 RHS and canonical/swizzled MXFP8 output.

## Validation

On NVIDIA GB300 with Triton `3.8.0+git.b3762cc612` ([\[NVIDIA\] Snapshot synthetic cluster-barrier counters before rendezvous](https://github.com/triton-lang/triton/commit/b3762cc612ff2925d9a81308513b91ff89bac636)), all four focused cases failed with `OutOfResources(576, 512, 'tensor memory')` before the fix and passed afterward. The expanded regression cases passed (6 passed, 186 skipped), as did the existing planner tests (13 passed, 4 skipped). An explicit `block_n=256` constraint remained intact. The exact current-main compiler was not rerun.

## Diff size

| Area | Added | Removed | Net |
| --- | ---: | ---: | ---: |
| Test | +7 | -0 | +7 |
| Non-test | +6 | -5 | +1 |
| All | +13 | -5 | +8 |

## Reviewer's guide

- `python/triton_kernels/triton_kernels/matmul_details/`: extend the column safety limit without broadening the other tuning rules.
- `python/triton_kernels/tests/test_matmul.py`: exercise the failing fused-output operation against the existing numerical reference.
