### PR TITLE
Validate Autotuner prune_configs_by["top_k"] values

### DIFF
--- a/python/test/unit/runtime/test_autotuner.py
+++ b/python/test/unit/runtime/test_autotuner.py
@@ -309,6 +309,61 @@ def test_prune_configs_fractional_top_k_after_early_prune():
     assert benchmarked == [1, 2, 3]
 
 
+def _autotuner_for_top_k(top_k, n_configs=4):
+    class Kernel:
+
+        def __init__(self):
+            self.fn = lambda: None
+
+    configs = [triton.Config(kwargs={'BLOCK_SIZE': 16 * (i + 1)}) for i in range(n_configs)]
+
+    def perf_model(*args, **kwargs):
+        return kwargs['BLOCK_SIZE']
+
+    return triton.runtime.Autotuner(
+        Kernel(),
+        arg_names=[],
+        configs=configs,
+        key=[],
+        reset_to_zero=None,
+        restore_value=None,
+        prune_configs_by={
+            'perf_model': perf_model,
+            'top_k': top_k,
+        },
+    )
+
+
+@pytest.mark.parametrize("top_k,exc", [
+    (0, ValueError),
+    (-1, ValueError),
+    (0.0, ValueError),
+    (-0.25, ValueError),
+    (1.5, ValueError),
+    (float("nan"), ValueError),
+    (float("inf"), ValueError),
+    (float("-inf"), ValueError),
+    (True, TypeError),
+    (False, TypeError),
+])
+def test_prune_configs_rejects_invalid_top_k(top_k, exc):
+    with pytest.raises(exc, match="top_k"):
+        _autotuner_for_top_k(top_k)
+
+
+@pytest.mark.parametrize("top_k,expected", [
+    (2, [16, 32]),
+    (0.5, [16, 32]),
+    (1.0, [16, 32, 48, 64]),
+    (0.1, [16]),
+])
+def test_prune_configs_accepts_valid_top_k(top_k, expected):
+    tuner = _autotuner_for_top_k(top_k)
+    tuner.nargs = {}
+    pruned = tuner.prune_configs({})
+    assert [config.kwargs['BLOCK_SIZE'] for config in pruned] == expected
+
+
 def test_config_ir_override_changes_disk_cache_key():
     # Autotuner derives persisted result-cache keys from Config.__str__().
     first = triton.Config(kwargs={"BLOCK_SIZE": 32}, ir_override="first.ttir")

--- a/python/test/unit/runtime/test_autotuner.py
+++ b/python/test/unit/runtime/test_autotuner.py
@@ -310,6 +310,7 @@ def test_prune_configs_fractional_top_k_after_early_prune():
 
 
 def _autotuner_for_top_k(top_k, n_configs=4):
+
     class Kernel:
 
         def __init__(self):

--- a/python/triton/runtime/autotuner.py
+++ b/python/triton/runtime/autotuner.py
@@ -16,6 +16,21 @@ from .cache import get_cache_manager, triton_key
 from triton._C.libtriton import get_cache_invalidating_env_vars
 
 
+def _validate_top_k(top_k):
+    """Accept a positive integer count or a fractional float in (0.0, 1.0].
+
+    ``bool`` is a subclass of ``int`` and must not be treated as a count.
+    """
+    if isinstance(top_k, bool) or not isinstance(top_k, (int, float)):
+        raise TypeError("prune_configs_by['top_k'] must be a positive integer or a float in (0.0, 1.0]")
+    if isinstance(top_k, float):
+        if not 0.0 < top_k <= 1.0:
+            raise ValueError("prune_configs_by['top_k'] must be a positive integer or a float in (0.0, 1.0]")
+    elif top_k <= 0:
+        raise ValueError("prune_configs_by['top_k'] must be a positive integer or a float in (0.0, 1.0]")
+    return top_k
+
+
 class Autotuner(KernelInterface):
 
     def __init__(self, fn, arg_names, configs, key, reset_to_zero, restore_value, pre_hook=None, post_hook=None,
@@ -24,7 +39,7 @@ class Autotuner(KernelInterface):
         """
         :param prune_configs_by: a dict of functions that are used to prune configs, fields:
             'perf_model': performance model used to predicate running time with different configs, returns running time
-            'top_k': number of configs to bench
+            'top_k': number of configs to bench (positive int) or fraction in (0.0, 1.0]
             'early_config_prune': a function used to prune configs. It should have the signature
                 `prune_configs_by( configs: List[triton.Config], named_args: Dict[str, Any], **kwargs: Dict[str, Any]) -> List[triton.Config]:`
                 and return pruned configs. It should return at least one config.
@@ -86,7 +101,8 @@ class Autotuner(KernelInterface):
         self.early_config_prune = None
         if prune_configs_by:
             self.perf_model = prune_configs_by.get("perf_model", self.perf_model)
-            self.configs_top_k = prune_configs_by.get("top_k", self.configs_top_k)
+            if "top_k" in prune_configs_by:
+                self.configs_top_k = _validate_top_k(prune_configs_by["top_k"])
             self.early_config_prune = prune_configs_by.get("early_config_prune", self.early_config_prune)
 
         self.fn = fn
@@ -289,16 +305,13 @@ class Autotuner(KernelInterface):
                 raise AutotunerError(
                     "No valid autotuner configs after pruning. `early_config_prune` should return at least one config.")
         if self.perf_model:
-            top_k = self.configs_top_k
-            if isinstance(top_k, float) and top_k <= 1.0:
+            top_k = _validate_top_k(self.configs_top_k)
+            if isinstance(top_k, float):
                 # Keep at least one config: a small fraction over a small config
                 # set rounds down to zero, which would prune everything and crash
                 # the later min() on an empty set. early_config_prune already
                 # guarantees at least one config; mirror that here.
                 top_k = max(1, int(len(pruned_configs) * top_k))
-            elif not isinstance(top_k, int):
-                # Slice index must be an integer
-                raise TypeError("Error while pruning configs, top_k must be either 1) a float <= 1.0 or 2) an int")
 
             if len(pruned_configs) > top_k:
                 est_timing = {
@@ -439,7 +452,7 @@ def autotune(configs, key, prune_configs_by=None, reset_to_zero=None, restore_va
     :type key: list[str]
     :param prune_configs_by: a dict of functions that are used to prune configs, fields:
         'perf_model': performance model used to predicate running time with different configs, returns running time
-        'top_k': number of configs to bench
+        'top_k': number of configs to bench (positive int) or fraction in (0.0, 1.0]
         'early_config_prune': a function used to prune configs. It should have the signature
                 `prune_configs_by( configs: List[triton.Config], named_args: Dict[str, Any], **kwargs: Dict[str, Any]) -> List[triton.Config]:`
                 and return pruned configs. It should return at least one config.


### PR DESCRIPTION
Fixes https://github.com/triton-lang/triton/issues/11072.

`prune_configs_by["top_k"]` is intended to be a positive integer count or a fractional float in `(0.0, 1.0]`. The autotuner stored the value as-is and applied it as a slice bound, so invalid inputs produced several different failures:

- `0` emptied the candidate set and later failed in `min()`
- negative integers became Python slice bounds and silently changed which configs were benchmarked
- `0.0` and negative floats silently kept one config via `max(1, ...)`
- floats greater than `1.0`, `NaN`, and infinities raised a misleading `TypeError`
- `True` / `False` inherited integer behavior because `bool` is a subclass of `int`

This change rejects those values with a clear `ValueError` or `TypeError` when `top_k` is provided, and again immediately before the candidate set is sliced. Valid positive integers and fractions in `(0.0, 1.0]` keep their existing pruning behavior, including keeping at least one config when a small fraction rounds down to zero.

# New contributor declaration
- [x] I am not making a trivial change, such as fixing a typo in a comment.
- [x] I have written a PR description following these [rules](https://cbea.ms/git-commit/#why-not-how).
- [x] I have run `pre-commit run --from-ref origin/main --to-ref HEAD`.
- [x] I have added tests.
  - `/python/test` for end-to-end tests
- [x] I have not added any `lit` tests.

## Human-in-the-loop

Luis Felipe Abarca personally read and understood the exact patch at `3aa7ef7a5b6b8fc99d0dd1e4d976e5ae3056f294`, reviewed its verification evidence, authorized publication, and remains accountable for it. He directs the workflow and decides which agent-prepared candidates may be submitted or updated publicly.

The implementation and tests originated from Cursor Agent; its model version is not recorded in the commit metadata. Cad on Hermes Agent with GPT-5.6 Sol performed the current source, policy, and edge-case re-review. Agents do not independently decide what is submitted or merged. Upstream maintainers retain review and merge authority.

[Arca](https://arca.computer) · [Luis Felipe](https://felirami.com) · [X](https://x.com/felirami) · [GitHub](https://github.com/felirami)
