### PR TITLE
[FRONTEND][NVIDIA] Reject TMA scatter on consumer Blackwell (sm_12x) at compile time

### DIFF
--- a/python/test/gluon/test_frontend.py
+++ b/python/test/gluon/test_frontend.py
@@ -1777,6 +1777,25 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.targ
 """)
 
 
+@pytest.mark.parametrize("arch", [120, 121], ids=["sm120", "sm121"])
+def test_async_tma_scatter_rejects_consumer_blackwell(arch):
+    input = MockTensor(ttgl.float16, (1024, 1024))
+    XBLOCK = 128
+    shared_layout = ttgl.NVMMASharedLayout(swizzle_byte_width=128, element_bitwidth=16, rank=2)
+    input_desc = TensorDescriptor.from_tensor(input, [1, XBLOCK], shared_layout)
+    expected = ("TMA scatter is not supported on consumer Blackwell (sm_12x). "
+                "TMA gather is supported on this architecture; use regular stores instead.")
+
+    with pytest.raises(CompilationError) as error:
+        run_parser(
+            async_tma_blackwell_kernel,
+            *make_args(input_desc, XBLOCK, num_warps=4),
+            target=GPUTarget("cuda", arch, 32),
+        )
+    assert expected in str(error.value)
+    assert "tma.async_scatter(input_desc, x_offsets, 0, smem)" in str(error.value)
+
+
 def test_mlir_attr_error():
 
     @gluon.jit

--- a/python/test/unit/language/test_tensor_descriptor.py
+++ b/python/test/unit/language/test_tensor_descriptor.py
@@ -4,11 +4,14 @@ import numpy as np
 
 import triton
 import triton.language as tl
+from triton.backends.compiler import GPUTarget
+from triton._filecheck import run_parser
 from triton._internal_testing import is_hopper, is_sm12x, is_interpreter, numpy_random, to_triton, unwrap_tensor, tma_dtypes, to_numpy
 from triton.tools.mxfp import MXFP4Tensor, MXScaleTensor
 from typing import Optional
 from triton._internal_testing import is_compile_warmup, is_cuda, is_hip, is_hip_cdna3
 from triton.tools.tensor_descriptor import TensorDescriptor
+from triton.runtime.jit import MockTensor
 from triton import CompilationError
 
 
@@ -1383,7 +1386,7 @@ def torch_gather_rows(input, idx, y, block_y):
 @pytest.mark.parametrize("dtype", [torch.float32, torch.float16, torch.int8])
 @pytest.mark.parametrize("y", [0, 32, 48])
 @pytest.mark.parametrize("idx_dtype", [torch.int32, torch.int16])
-@pytest.mark.skipif(is_hopper(), reason="TMA Scatter is not supported on hopper")
+@pytest.mark.skipif(is_hopper(), reason="TMA Gather is not supported on hopper")
 def test_tma_gather(X, Y, BLOCK_X, BLOCK_Y, dtype, y, idx_dtype, device):
     if BLOCK_X > X or y + BLOCK_Y > Y:
         pytest.skip()
@@ -1435,7 +1438,7 @@ def tma_gather_dot_pipeline(  #
 @pytest.mark.interpreter
 @pytest.mark.parametrize("BLOCK_M, BLOCK_N, BLOCK_K", [(16, 16, 16)])
 @pytest.mark.parametrize("K", [128])
-@pytest.mark.skipif(is_hopper(), reason="TMA Scatter is not supported on hopper")
+@pytest.mark.skipif(is_hopper(), reason="TMA Gather is not supported on hopper")
 def test_tma_gather_dot_pipeline(BLOCK_M, BLOCK_N, BLOCK_K, K, device):
 
     def alloc_fn(size: int, align: int, steam):
@@ -1477,6 +1480,59 @@ def tma_scatter_rows_kernel(out_ptr, in_ptr, idx_ptr, y, X: tl.constexpr, Y: tl.
     desc.scatter(data, idx, y)
 
 
+def tma_gather_scatter_parser_args():
+    return (
+        MockTensor(tl.float32),
+        MockTensor(tl.float32),
+        MockTensor(tl.int32),
+        0,
+        128,
+        128,
+        32,
+        32,
+    )
+
+
+@pytest.mark.parametrize("arch", [120, 121], ids=["sm120", "sm121"])
+def test_tma_gather_accepts_consumer_blackwell(arch):
+    module = run_parser(
+        tma_gather_rows_kernel,
+        args=tma_gather_scatter_parser_args(),
+        target=GPUTarget("cuda", arch, 32),
+    )
+    assert "tt.descriptor_gather" in str(module)
+
+
+@pytest.mark.parametrize("arch", [120, 121], ids=["sm120", "sm121"])
+def test_tma_scatter_rejects_consumer_blackwell(arch):
+    expected = ("TMA scatter is not supported on consumer Blackwell (sm_12x). "
+                "TMA gather is supported on this architecture; use regular stores instead.")
+    with pytest.raises(CompilationError) as error:
+        run_parser(
+            tma_scatter_rows_kernel,
+            args=tma_gather_scatter_parser_args(),
+            target=GPUTarget("cuda", arch, 32),
+        )
+    assert expected in str(error.value)
+    assert "desc.scatter(data, idx, y)" in str(error.value)
+
+
+@pytest.mark.parametrize(
+    "target",
+    [
+        pytest.param(GPUTarget("cuda", 89, 32), id="sm89"),
+        pytest.param(GPUTarget("hip", "gfx942", 64), id="gfx942"),
+    ],
+)
+def test_tma_scatter_accepts_fallback_target(target):
+    module = run_parser(
+        tma_scatter_rows_kernel,
+        args=tma_gather_scatter_parser_args(),
+        target=target,
+    )
+    assert "tt.descriptor_scatter" in str(module)
+
+
 @pytest.mark.interpreter
 @pytest.mark.parametrize("X, Y", [(128, 128), (64, 256)])
 @pytest.mark.parametrize("BLOCK_X, BLOCK_Y", [(32, 32), (64, 128), (16, 128), (512, 16)])
@@ -1484,7 +1540,7 @@ def tma_scatter_rows_kernel(out_ptr, in_ptr, idx_ptr, y, X: tl.constexpr, Y: tl.
 @pytest.mark.parametrize("y", [0, 32, 48])
 @pytest.mark.parametrize("idx_dtype", [torch.int32, torch.int16])
 @pytest.mark.skipif(is_hopper(), reason="TMA Scatter is not supported on hopper")
-@pytest.mark.skipif(is_sm12x(), reason="TMA Scatter is not supported on sm120")
+@pytest.mark.skipif(is_sm12x(), reason="TMA Scatter is not supported on consumer Blackwell")
 def test_tma_scatter(X, Y, BLOCK_X, BLOCK_Y, dtype, y, idx_dtype, device):
     if BLOCK_X > X or y + BLOCK_Y > Y:
         pytest.skip()

--- a/python/triton/experimental/gluon/language/nvidia/blackwell/tma.py
+++ b/python/triton/experimental/gluon/language/nvidia/blackwell/tma.py
@@ -54,6 +54,9 @@ def async_gather(tensor_desc, x_offsets, y_offset, barrier, result, pred=True, m
         pred (bool): Scalar predicate. Operation is skipped if predicate is False. Defaults to True.
         multicast (bool): Enable multicast.
     """
+    # Gluon bypasses TritonSemantic.descriptor_gather, so the check has to live here too.
+    _semantic._check_supports_tma_gather()
+
     if _semantic.builder.options.enable_iisan:
         _emit_alignment_check(tensor_desc, (y_offset, ), "async_gather", "y_offset", _semantic=_semantic)
 
@@ -86,6 +89,9 @@ def async_scatter(tensor_desc, x_offsets, y_offset, src, _semantic=None):
         y_offset (int): Scalar Y offset.
         src (tensor_memory_descriptor): The source data, must be in NVMMASharedLayout.
     """
+    # Gluon bypasses TritonSemantic.descriptor_scatter, so the check has to live here too.
+    _semantic._check_supports_tma_scatter()
+
     if _semantic.builder.options.enable_iisan:
         _emit_alignment_check(tensor_desc, (y_offset, ), "async_scatter", "y_offset", _semantic=_semantic)
         _emit_scatter_nonnegative_check(x_offsets, y_offset, _semantic=_semantic)

--- a/python/triton/language/semantic.py
+++ b/python/triton/language/semantic.py
@@ -1091,6 +1091,32 @@ class TritonSemantic(Generic[TensorTy]):
         target = driver.active.get_current_target()
         return (target.backend == "cuda" and target.arch >= 90)
 
+    def _tma_target(self):
+        options = self.builder.options
+        backend = options.backend_name
+        return backend, int(options.arch.removeprefix("sm")) if backend == "cuda" else None
+
+    def _check_supports_tma_gather(self, allow_fallback=False):
+        backend, capability = self._tma_target()
+        if backend == "interpreter":
+            return
+        if allow_fallback and (backend != "cuda" or capability < 90):
+            return
+        assert backend == "cuda" and capability >= 100, \
+            "TMA gather requires NVIDIA Blackwell (sm_100) or newer"
+
+    def _check_supports_tma_scatter(self, allow_fallback=False):
+        backend, capability = self._tma_target()
+        if backend == "interpreter":
+            return
+        if allow_fallback and (backend != "cuda" or capability < 90):
+            return
+        assert backend == "cuda" and capability >= 100, \
+            "TMA scatter requires NVIDIA Blackwell (sm_100) or newer"
+        assert capability // 10 != 12, \
+            "TMA scatter is not supported on consumer Blackwell (sm_12x). " \
+            "TMA gather is supported on this architecture; use regular stores instead."
+
     def _descriptor_atomic_min_max_supported(self, dtype):
         assert dtype in {tl.uint32, tl.int32, tl.uint64, tl.int64, tl.float16, tl.bfloat16}, "Unsupported dtype"
         if dtype in {tl.float16, tl.bfloat16}:
@@ -1134,6 +1160,7 @@ class TritonSemantic(Generic[TensorTy]):
     def descriptor_gather(self, desc, x_offsets, y_offset, cache_modifier: str, eviction_policy: str) -> TensorTy:
         assert isinstance(desc, tl.tensor_descriptor_base), \
             f"expected a tensor descriptor, got {desc.__class__.__name__}"
+        self._check_supports_tma_gather(allow_fallback=True)
         assert cache_modifier == "", "cache modifier is not supported yet"
         assert eviction_policy == "", "eviction policy is not supported yet"
 
@@ -1161,6 +1188,8 @@ class TritonSemantic(Generic[TensorTy]):
     def descriptor_scatter(self, desc, value: TensorTy, x_offsets, y_offset) -> TensorTy:
         assert isinstance(desc, tl.tensor_descriptor_base), \
             f"expected a tensor descriptor, got {type(desc).__name__}"
+
+        self._check_supports_tma_scatter(allow_fallback=True)
 
         # Validate descriptor.
         assert len(desc.block_shape) == 2, f"descriptor must be 2D, but got {desc.block_shape}"

--- a/python/triton_kernels/tests/test_matmul_details/test_opt_flags_nvidia.py
+++ b/python/triton_kernels/tests/test_matmul_details/test_opt_flags_nvidia.py
@@ -2,8 +2,10 @@ import pytest
 import torch
 import triton
 import triton.language as tl
+from triton.backends.compiler import GPUTarget
 from triton._internal_testing import is_cuda
 
+from triton_kernels import target_info
 from triton_kernels.matmul import matmul, matmul_torch, PrecisionConfig
 from triton_kernels.matmul_details._matmul import _compute_packed_n_w
 from triton_kernels.matmul_details.opt_flags import InapplicableConstraint, scoped_opt_flags_constraints
@@ -15,6 +17,80 @@ from triton_kernels.tensor_details.layout import BlackwellMX4ValueShuffledLayout
 from triton_kernels.tensor_details.layout_details.blackwell_scale import BlackwellMXScaleLayout
 from triton_kernels.tensor_details.ragged_tensor import make_ragged_tensor_metadata_torch
 from triton_kernels.testing import assert_close
+
+
+@pytest.mark.parametrize(
+    "target, expected_gather, expected_scatter",
+    [
+        pytest.param(None, False, False, id="no-target"),
+        pytest.param(GPUTarget("cuda", 80, 32), False, False, id="sm80"),
+        pytest.param(GPUTarget("cuda", 90, 32), False, False, id="sm90"),
+        pytest.param(GPUTarget("cuda", 100, 32), True, True, id="sm100"),
+        pytest.param(GPUTarget("cuda", 103, 32), True, True, id="sm103"),
+        pytest.param(GPUTarget("cuda", 107, 32), True, True, id="sm107"),
+        pytest.param(GPUTarget("cuda", 110, 32), True, True, id="sm110"),
+        pytest.param(GPUTarget("cuda", 120, 32), True, False, id="sm120"),
+        pytest.param(GPUTarget("cuda", 121, 32), True, False, id="sm121"),
+        pytest.param(GPUTarget("hip", "gfx942", 64), False, False, id="gfx942"),
+    ],
+)
+def test_tma_gather_scatter_support(monkeypatch, target, expected_gather, expected_scatter):
+    monkeypatch.setattr(tl.target_info, "current_target", lambda: target)
+    assert target_info.has_tma_gather() == expected_gather
+    assert target_info.has_tma_scatter() == expected_scatter
+
+
+def test_matmul_scatter_falls_back_on_consumer_blackwell(device):
+    if device != "cuda" or not torch.cuda.is_available() or not is_cuda():
+        pytest.skip("requires CUDA")
+    if torch.cuda.get_device_capability()[0] != 12:
+        pytest.skip("requires consumer Blackwell")
+
+    torch.manual_seed(0)
+    m = n = k = 128
+    a = torch.randn((m, k), device=device, dtype=torch.float16)
+    b = torch.randn((k, n), device=device, dtype=torch.float16)
+    scatter_indx = torch.randperm(m, device=device, dtype=torch.int32)
+    precision_config = PrecisionConfig()
+    constraints = {
+        "is_persistent": True,
+        "block_m": 128,
+        "split_k": 1,
+        "epilogue_subtile": 1,
+        "num_warps": 4,
+    }
+
+    reference = matmul_torch(a, b, None, scatter_indx=scatter_indx, precision_config=precision_config)
+    with scoped_opt_flags_constraints(constraints):
+        actual = matmul(a, b, None, scatter_indx=scatter_indx, precision_config=precision_config)
+
+    assert_close(reference, actual)
+
+
+def test_matmul_scatter_rejects_forced_output_tma_on_consumer_blackwell(device):
+    if device != "cuda" or not torch.cuda.is_available() or not is_cuda():
+        pytest.skip("requires CUDA")
+    if torch.cuda.get_device_capability()[0] != 12:
+        pytest.skip("requires consumer Blackwell")
+
+    a = torch.empty((128, 128), device=device, dtype=torch.float16)
+    b = torch.empty((128, 128), device=device, dtype=torch.float16)
+    scatter_indx = torch.arange(128, device=device, dtype=torch.int32)
+    constraints = {
+        "is_persistent": True,
+        "block_m": 128,
+        "split_k": 1,
+        "epilogue_subtile": 1,
+        "num_warps": 4,
+        "use_output_tma": True,
+    }
+
+    with scoped_opt_flags_constraints(constraints):
+        with pytest.raises(
+                InapplicableConstraint,
+                match=r"cannot enforce `use_output_tma=True` because TMA scatter is unavailable",
+        ):
+            matmul(a, b, None, scatter_indx=scatter_indx, precision_config=PrecisionConfig())
 
 
 def _make_blackwell_scale_tensor():

--- a/python/triton_kernels/triton_kernels/matmul.py
+++ b/python/triton_kernels/triton_kernels/matmul.py
@@ -519,7 +519,7 @@ def matmul(a, b, bias,
         available_sms = target_info.num_sms() - opt_flags.idle_sms
         grid = min(opt_flags.occupancy_target * available_sms, grid)
     # canonicalize storage
-    has_scatter_tma = has_scatter and out_matmul.element_size() <= 4 and target_info.has_tma_gather()
+    has_scatter_tma = has_scatter and out_matmul.element_size() <= 4 and target_info.has_tma_scatter()
     c = wrap_torch_tensor(out_matmul.view(math.prod(out_matmul.shape[:-1]), out_matmul.shape[-1]) if has_scatter else out_matmul.view(math.prod(out_matmul.shape[:-2]), *out_matmul.shape[-2:]))
     a = Tensor(_canonicalize_storage(a.storage, 2 if has_gather_tma else 3, flex.lhs_data), dtype=a.dtype, shape=a.shape, shape_max=a.shape_max)
     b_storage_ndim = 5 if b_is_shuffled else 3
@@ -560,6 +560,10 @@ def matmul(a, b, bias,
         )
     )
     if opt_flags.use_output_tma is not None:
+        if opt_flags.use_output_tma and has_scatter and not has_scatter_tma:
+            raise InapplicableConstraint(
+                "cannot enforce `use_output_tma=True` because TMA scatter is unavailable for this output or target"
+            )
         c_has_tma = opt_flags.use_output_tma
     c_logical_block_n = opt_flags.block_n // opt_flags.epilogue_subtile // matmul_fused_activation.specs.reduction_n
     c_tma_block_n = c_logical_block_n // precision_config.c_value_pack_factor

--- a/python/triton_kernels/triton_kernels/target_info.py
+++ b/python/triton_kernels/triton_kernels/target_info.py
@@ -16,6 +16,7 @@ __all__ = [
     "get_cdna_version",
     "get_rdna_version",
     "has_tma_gather",
+    "has_tma_scatter",
     "has_native_mxfp",
     "is_cuda",
     "is_hip",
@@ -63,6 +64,15 @@ def get_rdna_version():
 @triton.constexpr_function
 def has_tma_gather():
     return cuda_capability_geq(10, 0)
+
+
+@triton.constexpr_function
+def has_tma_scatter():
+    target = tl.target_info.current_target()
+    if target is None or target.backend != "cuda":
+        return False
+    assert isinstance(target.arch, int)
+    return target.arch >= 100 and target.arch // 10 != 12
 
 
 @triton.constexpr_function

--- a/test/Conversion/tma_to_llvm.mlir
+++ b/test/Conversion/tma_to_llvm.mlir
@@ -1,4 +1,6 @@
 // RUN: triton-opt %s --convert-triton-gpu-to-llvm --convert-nv-gpu-to-llvm | mlir-translate -mlir-to-llvmir | opt -S -O1 | FileCheck %s
+// RUN: not triton-opt %s --convert-triton-gpu-to-llvm=compute-capability=120 2>&1 | FileCheck %s --check-prefix=SM12X-ERROR
+// RUN: not triton-opt %s --convert-triton-gpu-to-llvm=compute-capability=121 2>&1 | FileCheck %s --check-prefix=SM12X-ERROR
 
 #blocked = #ttg.blocked<{sizePerThread = [1, 4], threadsPerWarp = [32, 1], warpsPerCTA = [1, 4], order = [1, 0]}>
 #blocked1 = #ttg.blocked<{sizePerThread = [1, 8], threadsPerWarp = [32, 1], warpsPerCTA = [1, 4], order = [1, 0]}>
@@ -146,6 +148,7 @@ tt.func @tma_gather_redundant_warps(%arg0: !tt.tensordesc<1x128xbf16, #shared1>,
   tt.return
 }
 
+// SM12X-ERROR: error: TMA scatter is not supported on consumer Blackwell (sm_12x)
 // CHECK-LABEL: @tma_scatter
 tt.func @tma_scatter(%arg0: !tt.tensordesc<1x128xbf16, #shared1>, %arg1: tensor<32xi32, #ttg.slice<{dim = 0, parent = #blocked}>>, %arg2: i32, %arg3: !ttg.memdesc<32x128xbf16, #shared1, #smem, mutable>) {
   // The lowering for `async_tma_scatter` shares practically all of its logic

--- a/third_party/nvidia/lib/TritonNVIDIAGPUToLLVM/LoadStoreOpToLLVM.cpp
+++ b/third_party/nvidia/lib/TritonNVIDIAGPUToLLVM/LoadStoreOpToLLVM.cpp
@@ -1688,16 +1688,28 @@ LogicalResult AsyncTMAGatherOpConversion::matchAndRewrite(
 
 struct AsyncTMAScatterOpConversion
     : public ConvertOpToLLVMPattern<triton::nvidia_gpu::AsyncTMAScatterOp> {
-  using ConvertOpToLLVMPattern::ConvertOpToLLVMPattern;
+  AsyncTMAScatterOpConversion(LLVMTypeConverter &typeConverter,
+                              int computeCapability, PatternBenefit benefit)
+      : ConvertOpToLLVMPattern<triton::nvidia_gpu::AsyncTMAScatterOp>(
+            typeConverter, benefit),
+        computeCapability(computeCapability) {}
 
   LogicalResult
   matchAndRewrite(triton::nvidia_gpu::AsyncTMAScatterOp op, OpAdaptor adaptor,
                   ConversionPatternRewriter &rewriter) const override;
+
+  int computeCapability;
 };
 
 LogicalResult AsyncTMAScatterOpConversion::matchAndRewrite(
     triton::nvidia_gpu::AsyncTMAScatterOp op, OpAdaptor adaptor,
     ConversionPatternRewriter &rewriter) const {
+  if (computeCapability / 10 == 12)
+    return op.emitError(
+        "TMA scatter is not supported on consumer Blackwell (sm_12x). TMA "
+        "gather is supported on this architecture; use regular stores "
+        "instead.");
+
   Location loc = op.getLoc();
   auto b = TritonLLVMOpBuilder(loc, rewriter);
   LLVM::LLVMVoidType voidTy = void_ty(op->getContext());
@@ -1836,9 +1848,11 @@ void mlir::triton::NVIDIA::populateLoadStoreOpToLLVMPatterns(
       typeConverter, targetInfo, computeCapability, axisInfoAnalysis, benefit);
   patterns.add<AsyncCommitGroupOpConversion, AsyncWaitOpConversion,
                AsyncCopyMbarrierArriveOpConversion>(typeConverter, benefit);
-  patterns.add<AsyncTMACopyGlobalToLocalOpConversion,
-               AsyncTMACopyLocalToGlobalOpConversion,
-               AsyncTMAReduceOpConversion, AsyncTMAGatherOpConversion,
-               AsyncTMAScatterOpConversion, TMAStoreWaitOpConversion>(
-      typeConverter, benefit);
+  patterns
+      .add<AsyncTMACopyGlobalToLocalOpConversion,
+           AsyncTMACopyLocalToGlobalOpConversion, AsyncTMAReduceOpConversion,
+           AsyncTMAGatherOpConversion, TMAStoreWaitOpConversion>(typeConverter,
+                                                                 benefit);
+  patterns.add<AsyncTMAScatterOpConversion>(typeConverter, computeCapability,
+                                            benefit);
 }


### PR DESCRIPTION
# [FRONTEND][NVIDIA] Reject TMA scatter on consumer Blackwell (sm_12x) at compile time

Addresses https://github.com/triton-lang/triton/issues/11344.

Consumer Blackwell (sm_120 / sm_121) implements the TMA `tile::gather4` instruction but not `tile::scatter4`. Triton has no target check for this, so `desc.scatter(...)` compiles all the way down and dies inside ptxas as an "Internal Triton PTX codegen error" — a message that points at nothing the user wrote and gives no hint that the operation is simply unavailable on the hardware. A user hitting this has no way to tell an unsupported feature apart from a compiler bug.

This PR turns that into a compile-time rejection that names the architecture and the reason.

## What changed

**1. `[FRONTEND] Reject TMA scatter on consumer Blackwell instead of failing in ptxas`**

Adds `_has_tma_scatter()` next to the existing `_has_native_tma()` in `python/triton/language/semantic.py`, and one assert at the top of `TritonSemantic.descriptor_scatter`, worded like the shape/dtype validation immediately below it. The backend check short-circuits before the arch comparison, so non-CUDA targets (whose `arch` is a string) are unaffected.

The payoff is a source-located `CompilationError` pointing at the user's `.scatter(...)` call.

**2. `[Gluon] Reject TMA scatter on consumer Blackwell in async_scatter`**

Gluon calls `create_async_tma_scatter` directly (`gluon/language/nvidia/blackwell/tma.py`) and never passes through `descriptor_scatter`, so the semantic-layer check does not cover it. On stock 3.7.1 on sm_121a, Gluon `async_scatter` still dies in ptxas with `Feature '.tile::scatter4' not supported on .target 'sm_121a'`. The same assert now sits at the top of Gluon's `async_scatter` (GluonSemantic inherits `_has_tma_scatter` from TritonSemantic), turning that into the same source-located compile-time error.

## Test

Reproducers run on a GB10 (sm_121a): both the `tl` descriptor path and the Gluon path now fail at compile time with the message above instead of the ptxas internal error. The existing suite already skips TMA scatter on sm_12x (`test_tensor_descriptor.py:1487`), so no test changes were needed.
