### PR TITLE
[AMD] Do not insert barriers between two async loads for Membar

### DIFF
--- a/include/triton/Dialect/TritonGPU/IR/Traits.h
+++ b/include/triton/Dialect/TritonGPU/IR/Traits.h
@@ -44,6 +44,14 @@ class MemWaitOpTrait
   // Optional: Add methods or verification logic here
 };
 
+// Copies from global memory into local memory. Such copies are asynchronous:
+// their completion is ordered by an async wait, not by a barrier.
+template <typename ConcreteType>
+class GlobalToLocalCopyTrait
+    : public mlir::OpTrait::TraitBase<ConcreteType, GlobalToLocalCopyTrait> {
+  // Optional: Add methods or verification logic here
+};
+
 } // namespace OpTrait
 } // namespace mlir
 

--- a/include/triton/Dialect/TritonGPU/IR/Traits.h
+++ b/include/triton/Dialect/TritonGPU/IR/Traits.h
@@ -44,8 +44,7 @@ class MemWaitOpTrait
   // Optional: Add methods or verification logic here
 };
 
-// Copies from global memory into local memory. Such copies are asynchronous:
-// their completion is ordered by an async wait, not by a barrier.
+// Copies from global memory into local memory. Such copies are asynchronous
 template <typename ConcreteType>
 class GlobalToLocalCopyTrait
     : public mlir::OpTrait::TraitBase<ConcreteType, GlobalToLocalCopyTrait> {

--- a/include/triton/Dialect/TritonGPU/IR/TritonGPUAttrBase.td
+++ b/include/triton/Dialect/TritonGPU/IR/TritonGPUAttrBase.td
@@ -15,6 +15,7 @@ include "triton/Dialect/TritonGPU/IR/TritonGPUDialect.td"
 def MemDescViewTrait : NativeOpTrait<"MemDescViewTrait">;
 def LocalLoadTrait : NativeOpTrait<"LocalLoadTrait">;
 def MemWaitOpTrait : NativeOpTrait<"MemWaitOpTrait">;
+def GlobalToLocalCopyTrait : NativeOpTrait<"GlobalToLocalCopyTrait">;
 
 // Common parameter helpers.
 def LinearLayoutParam : AttrOrTypeParameter<"LinearLayout",

--- a/include/triton/Dialect/TritonGPU/IR/TritonGPUOps.td
+++ b/include/triton/Dialect/TritonGPU/IR/TritonGPUOps.td
@@ -89,6 +89,7 @@ def TTG_AsyncCommitGroupOp : TTG_Op<"async_commit_group"> {
 }
 
 def TTG_AsyncCopyGlobalToLocalOp : TTG_Op<"async_copy_global_to_local", [
+  GlobalToLocalCopyTrait,
   AttrSizedOperandSegments,
   DeclareOpInterfaceMethods<PredicatedOpInterface>,
   OptionalTypesMatchWith<"infer mask type from src type",

--- a/test/Conversion/amd/amdgpu_membar.mlir
+++ b/test/Conversion/amd/amdgpu_membar.mlir
@@ -459,8 +459,6 @@ tt.func @must_barrier_remsi_loop_carried_future_disjoint_cf(%cst: tensor<128x128
 #smem = #ttg.shared_memory
 
 module attributes {"ttg.num-warps" = 4 : i32, "ttg.num-ctas" = 1 : i32} {
-// Two async loads need no barrier between them. Dynamic slice indices, so
-// membar cannot prove the tiles disjoint and only the filter applies.
 // CHECK-LABEL: no_barrier_between_async_loads
 tt.func @no_barrier_between_async_loads(%A: !tt.ptr<f16>, %i: i32, %j: i32) {
   %offset = arith.constant dense<0> : tensor<128x32xi32, #AL>
@@ -484,38 +482,12 @@ tt.func @no_barrier_between_async_loads(%A: !tt.ptr<f16>, %i: i32, %j: i32) {
 #smem = #ttg.shared_memory
 
 module attributes {"ttg.num-warps" = 4 : i32, "ttg.num-ctas" = 1 : i32} {
-// Same for ttg.async_copy_global_to_local.
-// CHECK-LABEL: no_barrier_between_async_copies
-tt.func @no_barrier_between_async_copies(%A: !tt.ptr<f16>, %i: i32, %j: i32) {
-  %a_ptr = tt.splat %A : !tt.ptr<f16> -> tensor<128x32x!tt.ptr<f16>, #AL>
-  %alloc = ttg.local_alloc : () -> !ttg.memdesc<2x128x32xf16, #shared, #smem, mutable>
-  %tile_a = ttg.memdesc_index %alloc[%i] : !ttg.memdesc<2x128x32xf16, #shared, #smem, mutable> -> !ttg.memdesc<128x32xf16, #shared, #smem, mutable>
-  %tile_b = ttg.memdesc_index %alloc[%j] : !ttg.memdesc<2x128x32xf16, #shared, #smem, mutable> -> !ttg.memdesc<128x32xf16, #shared, #smem, mutable>
-  // CHECK: ttg.async_copy_global_to_local
-  // CHECK-NOT: ttg.barrier local
-  // CHECK: ttg.async_copy_global_to_local
-  %async_a = ttg.async_copy_global_to_local %a_ptr, %tile_a : tensor<128x32x!tt.ptr<f16>, #AL> -> !ttg.memdesc<128x32xf16, #shared, #smem, mutable>
-  %async_b = ttg.async_copy_global_to_local %a_ptr, %tile_b : tensor<128x32x!tt.ptr<f16>, #AL> -> !ttg.memdesc<128x32xf16, #shared, #smem, mutable>
-  // CHECK: tt.return
-  tt.return
-}
-}
-
-// -----
-
-#AL = #ttg.blocked<{sizePerThread = [1, 4], threadsPerWarp = [4, 8], warpsPerCTA = [4, 1], order = [1, 0]}>
-#shared = #ttg.swizzled_shared<{vec = 2, perPhase = 2, maxPhase = 4, order = [1, 0]}>
-#smem = #ttg.shared_memory
-
-module attributes {"ttg.num-warps" = 4 : i32, "ttg.num-ctas" = 1 : i32} {
-// Three-buffer pipelined loop without async tokens:
+// Three-buffer pipelined loop
 //   prologue: load buf[0]; load buf[1]
 //   loop i:   load buf[i]; wait(2); j = (i+1)%3; read buf[j]; load buf[j]
-// None of the load/load pairs can be proven disjoint (the prologue indices have
-// a different SSA base than the loop index, and (i+0) vs (i+1)%3 have
-// mismatched moduli), so all of them rely on the filter. What remains is the
-// barrier owned by the async_wait and the WAR barrier before the refill of
-// buf[j], which stays because the LocalLoad is not synced via an async wait.
+// no barrier between async loads
+// barrier after the async_wait
+// barrier before the refill of the same buf
 // CHECK-LABEL: no_barrier_between_async_loads_in_pipelined_loop
 tt.func @no_barrier_between_async_loads_in_pipelined_loop(%A: !tt.ptr<f16>, %ub: i32) {
   %c0_i32 = arith.constant 0 : i32
@@ -552,7 +524,6 @@ tt.func @no_barrier_between_async_loads_in_pipelined_loop(%A: !tt.ptr<f16>, %ub:
     %ip1 = arith.addi %i, %c1_i32 : i32
     %j = arith.remsi %ip1, %c3_i32 : i32
     %sj = ttg.memdesc_index %alloc[%j] : !ttg.memdesc<3x128x32xf16, #shared, #smem, mutable> -> !ttg.memdesc<128x32xf16, #shared, #smem, mutable>
-    // CHECK-NOT: ttg.barrier local
     // CHECK: ttg.local_load
     // CHECK-NEXT: ttg.barrier local
     // CHECK-NEXT: amdg.buffer_load_to_local
@@ -562,83 +533,6 @@ tt.func @no_barrier_between_async_loads_in_pipelined_loop(%A: !tt.ptr<f16>, %ub:
 
     scf.yield %j : i32
   }
-  tt.return
-}
-}
-
-// -----
-
-#blocked = #ttg.blocked<{sizePerThread = [1, 8], threadsPerWarp = [4, 8], warpsPerCTA = [4, 1], order = [1, 0]}>
-#shared = #ttg.swizzled_shared<{vec = 1, perPhase = 1, maxPhase = 1, order = [1, 0]}>
-#smem = #ttg.shared_memory
-
-module attributes {"ttg.num-warps" = 4 : i32, "ttg.num-ctas" = 1 : i32, "ttg.threads-per-warp" = 32 : i32} {
-// A TDM copy is an async load too, so the LocalLoad synced via async_tdm_wait
-// does not need a barrier against the following copy into the same buffer.
-// Only the barrier belonging to the wait remains.
-// CHECK-LABEL: tdm_copy_after_synced_local_load
-tt.func @tdm_copy_after_synced_local_load(%desc: !tt.tensordesc<64x64xf16, #shared>) {
-  %buf = ttg.local_alloc : () -> !ttg.memdesc<64x64xf16, #shared, #smem, mutable>
-  %tok_a = amdg.async_tdm_copy_global_to_local %desc into %buf : !tt.tensordesc<64x64xf16, #shared> -> !ttg.memdesc<64x64xf16, #shared, #smem, mutable>
-  // CHECK-NOT: ttg.barrier local
-  // CHECK: amdg.async_tdm_wait
-  // CHECK-NEXT: ttg.barrier local
-  // CHECK-NOT: ttg.barrier local
-  %wait = amdg.async_tdm_wait %tok_a {num = 0 : i32}
-  %val = ttg.local_load %buf token %wait : !ttg.memdesc<64x64xf16, #shared, #smem, mutable> -> tensor<64x64xf16, #blocked>
-  %tok_b = amdg.async_tdm_copy_global_to_local %desc into %buf : !tt.tensordesc<64x64xf16, #shared> -> !ttg.memdesc<64x64xf16, #shared, #smem, mutable>
-  // CHECK: tt.return
-  tt.return
-}
-}
-
-// -----
-
-#blocked = #ttg.blocked<{sizePerThread = [1, 8], threadsPerWarp = [4, 8], warpsPerCTA = [4, 1], order = [1, 0]}>
-#shared = #ttg.swizzled_shared<{vec = 1, perPhase = 1, maxPhase = 1, order = [1, 0]}>
-#smem = #ttg.shared_memory
-
-module attributes {"ttg.num-warps" = 4 : i32, "ttg.num-ctas" = 1 : i32, "ttg.threads-per-warp" = 32 : i32} {
-// Same for a fused TDM copy. It writes to several destinations and the
-// LocalLoad reads the second one, so all of them have to be considered.
-// CHECK-LABEL: tdm_fused_copy_after_synced_local_load
-tt.func @tdm_fused_copy_after_synced_local_load(%desc0: !tt.tensordesc<64x64xf16, #shared>, %desc1: !tt.tensordesc<64x64xf16, #shared>) {
-  %dst0 = ttg.local_alloc : () -> !ttg.memdesc<64x64xf16, #shared, #smem, mutable>
-  %dst1 = ttg.local_alloc : () -> !ttg.memdesc<64x64xf16, #shared, #smem, mutable>
-  %tok_a = amdg.async_tdm_fused_copy_global_to_local %desc0, %desc1 into %dst0, %dst1 {warp_used_hints = array<i32: 3, 12>} : !tt.tensordesc<64x64xf16, #shared>, !tt.tensordesc<64x64xf16, #shared> -> !ttg.memdesc<64x64xf16, #shared, #smem, mutable>, !ttg.memdesc<64x64xf16, #shared, #smem, mutable>
-  // CHECK-NOT: ttg.barrier local
-  // CHECK: amdg.async_tdm_wait
-  // CHECK-NEXT: ttg.barrier local
-  // CHECK-NOT: ttg.barrier local
-  %wait = amdg.async_tdm_wait %tok_a {num = 0 : i32}
-  %val = ttg.local_load %dst1 token %wait : !ttg.memdesc<64x64xf16, #shared, #smem, mutable> -> tensor<64x64xf16, #blocked>
-  %tok_b = amdg.async_tdm_fused_copy_global_to_local %desc0, %desc1 into %dst0, %dst1 {warp_used_hints = array<i32: 3, 12>} : !tt.tensordesc<64x64xf16, #shared>, !tt.tensordesc<64x64xf16, #shared> -> !ttg.memdesc<64x64xf16, #shared, #smem, mutable>, !ttg.memdesc<64x64xf16, #shared, #smem, mutable>
-  // CHECK: tt.return
-  tt.return
-}
-}
-
-// -----
-
-#blocked = #ttg.blocked<{sizePerThread = [1, 8], threadsPerWarp = [4, 8], warpsPerCTA = [4, 1], order = [1, 0]}>
-#idx_parent = #ttg.blocked<{sizePerThread = [1, 16], threadsPerWarp = [32, 1], warpsPerCTA = [1, 4], order = [0, 1]}>
-#shared = #ttg.swizzled_shared<{vec = 1, perPhase = 1, maxPhase = 1, order = [1, 0]}>
-#smem = #ttg.shared_memory
-
-module attributes {"ttg.num-warps" = 4 : i32, "ttg.num-ctas" = 1 : i32, "ttg.threads-per-warp" = 32 : i32} {
-// Same for a TDM gather.
-// CHECK-LABEL: tdm_gather_after_synced_local_load
-tt.func @tdm_gather_after_synced_local_load(%desc: !tt.tensordesc<64x128xf16>, %rows: tensor<64xi32, #ttg.slice<{dim = 0, parent = #idx_parent}>>) {
-  %buf = ttg.local_alloc : () -> !ttg.memdesc<256x128xf16, #shared, #smem, mutable>
-  %tok_a = amdg.async_tdm_gather %desc[%rows] to %buf : tensor<64xi32, #ttg.slice<{dim = 0, parent = #idx_parent}>>, !ttg.memdesc<256x128xf16, #shared, #smem, mutable> -> !tt.tensordesc<64x128xf16>
-  // CHECK-NOT: ttg.barrier local
-  // CHECK: amdg.async_tdm_wait
-  // CHECK-NEXT: ttg.barrier local
-  // CHECK-NOT: ttg.barrier local
-  %wait = amdg.async_tdm_wait %tok_a {num = 0 : i32}
-  %val = ttg.local_load %buf token %wait : !ttg.memdesc<256x128xf16, #shared, #smem, mutable> -> tensor<256x128xf16, #blocked>
-  %tok_b = amdg.async_tdm_gather %desc[%rows] to %buf : tensor<64xi32, #ttg.slice<{dim = 0, parent = #idx_parent}>>, !ttg.memdesc<256x128xf16, #shared, #smem, mutable> -> !tt.tensordesc<64x128xf16>
-  // CHECK: tt.return
   tt.return
 }
 }

--- a/test/Conversion/amd/amdgpu_membar.mlir
+++ b/test/Conversion/amd/amdgpu_membar.mlir
@@ -500,3 +500,80 @@ tt.func @no_barrier_between_async_copies(%A: !tt.ptr<f16>, %i: i32, %j: i32) {
   tt.return
 }
 }
+
+// -----
+
+#blocked = #ttg.blocked<{sizePerThread = [1, 8], threadsPerWarp = [4, 8], warpsPerCTA = [4, 1], order = [1, 0]}>
+#shared = #ttg.swizzled_shared<{vec = 1, perPhase = 1, maxPhase = 1, order = [1, 0]}>
+#smem = #ttg.shared_memory
+
+module attributes {"ttg.num-warps" = 4 : i32, "ttg.num-ctas" = 1 : i32, "ttg.threads-per-warp" = 32 : i32} {
+// A TDM copy is an async load too, so the LocalLoad synced via async_tdm_wait
+// does not need a barrier against the following copy into the same buffer.
+// Only the barrier belonging to the wait remains.
+// CHECK-LABEL: tdm_copy_after_synced_local_load
+tt.func @tdm_copy_after_synced_local_load(%desc: !tt.tensordesc<64x64xf16, #shared>) {
+  %buf = ttg.local_alloc : () -> !ttg.memdesc<64x64xf16, #shared, #smem, mutable>
+  %tok_a = amdg.async_tdm_copy_global_to_local %desc into %buf : !tt.tensordesc<64x64xf16, #shared> -> !ttg.memdesc<64x64xf16, #shared, #smem, mutable>
+  // CHECK-NOT: ttg.barrier local
+  // CHECK: amdg.async_tdm_wait
+  // CHECK-NEXT: ttg.barrier local
+  // CHECK-NOT: ttg.barrier local
+  %wait = amdg.async_tdm_wait %tok_a {num = 0 : i32}
+  %val = ttg.local_load %buf token %wait : !ttg.memdesc<64x64xf16, #shared, #smem, mutable> -> tensor<64x64xf16, #blocked>
+  %tok_b = amdg.async_tdm_copy_global_to_local %desc into %buf : !tt.tensordesc<64x64xf16, #shared> -> !ttg.memdesc<64x64xf16, #shared, #smem, mutable>
+  // CHECK: tt.return
+  tt.return
+}
+}
+
+// -----
+
+#blocked = #ttg.blocked<{sizePerThread = [1, 8], threadsPerWarp = [4, 8], warpsPerCTA = [4, 1], order = [1, 0]}>
+#shared = #ttg.swizzled_shared<{vec = 1, perPhase = 1, maxPhase = 1, order = [1, 0]}>
+#smem = #ttg.shared_memory
+
+module attributes {"ttg.num-warps" = 4 : i32, "ttg.num-ctas" = 1 : i32, "ttg.threads-per-warp" = 32 : i32} {
+// Same for a fused TDM copy. It writes to several destinations and the
+// LocalLoad reads the second one, so all of them have to be considered.
+// CHECK-LABEL: tdm_fused_copy_after_synced_local_load
+tt.func @tdm_fused_copy_after_synced_local_load(%desc0: !tt.tensordesc<64x64xf16, #shared>, %desc1: !tt.tensordesc<64x64xf16, #shared>) {
+  %dst0 = ttg.local_alloc : () -> !ttg.memdesc<64x64xf16, #shared, #smem, mutable>
+  %dst1 = ttg.local_alloc : () -> !ttg.memdesc<64x64xf16, #shared, #smem, mutable>
+  %tok_a = amdg.async_tdm_fused_copy_global_to_local %desc0, %desc1 into %dst0, %dst1 {warp_used_hints = array<i32: 3, 12>} : !tt.tensordesc<64x64xf16, #shared>, !tt.tensordesc<64x64xf16, #shared> -> !ttg.memdesc<64x64xf16, #shared, #smem, mutable>, !ttg.memdesc<64x64xf16, #shared, #smem, mutable>
+  // CHECK-NOT: ttg.barrier local
+  // CHECK: amdg.async_tdm_wait
+  // CHECK-NEXT: ttg.barrier local
+  // CHECK-NOT: ttg.barrier local
+  %wait = amdg.async_tdm_wait %tok_a {num = 0 : i32}
+  %val = ttg.local_load %dst1 token %wait : !ttg.memdesc<64x64xf16, #shared, #smem, mutable> -> tensor<64x64xf16, #blocked>
+  %tok_b = amdg.async_tdm_fused_copy_global_to_local %desc0, %desc1 into %dst0, %dst1 {warp_used_hints = array<i32: 3, 12>} : !tt.tensordesc<64x64xf16, #shared>, !tt.tensordesc<64x64xf16, #shared> -> !ttg.memdesc<64x64xf16, #shared, #smem, mutable>, !ttg.memdesc<64x64xf16, #shared, #smem, mutable>
+  // CHECK: tt.return
+  tt.return
+}
+}
+
+// -----
+
+#blocked = #ttg.blocked<{sizePerThread = [1, 8], threadsPerWarp = [4, 8], warpsPerCTA = [4, 1], order = [1, 0]}>
+#idx_parent = #ttg.blocked<{sizePerThread = [1, 16], threadsPerWarp = [32, 1], warpsPerCTA = [1, 4], order = [0, 1]}>
+#shared = #ttg.swizzled_shared<{vec = 1, perPhase = 1, maxPhase = 1, order = [1, 0]}>
+#smem = #ttg.shared_memory
+
+module attributes {"ttg.num-warps" = 4 : i32, "ttg.num-ctas" = 1 : i32, "ttg.threads-per-warp" = 32 : i32} {
+// Same for a TDM gather.
+// CHECK-LABEL: tdm_gather_after_synced_local_load
+tt.func @tdm_gather_after_synced_local_load(%desc: !tt.tensordesc<64x128xf16>, %rows: tensor<64xi32, #ttg.slice<{dim = 0, parent = #idx_parent}>>) {
+  %buf = ttg.local_alloc : () -> !ttg.memdesc<256x128xf16, #shared, #smem, mutable>
+  %tok_a = amdg.async_tdm_gather %desc[%rows] to %buf : tensor<64xi32, #ttg.slice<{dim = 0, parent = #idx_parent}>>, !ttg.memdesc<256x128xf16, #shared, #smem, mutable> -> !tt.tensordesc<64x128xf16>
+  // CHECK-NOT: ttg.barrier local
+  // CHECK: amdg.async_tdm_wait
+  // CHECK-NEXT: ttg.barrier local
+  // CHECK-NOT: ttg.barrier local
+  %wait = amdg.async_tdm_wait %tok_a {num = 0 : i32}
+  %val = ttg.local_load %buf token %wait : !ttg.memdesc<256x128xf16, #shared, #smem, mutable> -> tensor<256x128xf16, #blocked>
+  %tok_b = amdg.async_tdm_gather %desc[%rows] to %buf : tensor<64xi32, #ttg.slice<{dim = 0, parent = #idx_parent}>>, !ttg.memdesc<256x128xf16, #shared, #smem, mutable> -> !tt.tensordesc<64x128xf16>
+  // CHECK: tt.return
+  tt.return
+}
+}

--- a/test/Conversion/amd/amdgpu_membar.mlir
+++ b/test/Conversion/amd/amdgpu_membar.mlir
@@ -451,3 +451,52 @@ tt.func @must_barrier_remsi_loop_carried_future_disjoint_cf(%cst: tensor<128x128
   tt.return
 }
 }
+
+// -----
+
+#AL = #ttg.blocked<{sizePerThread = [1, 4], threadsPerWarp = [4, 8], warpsPerCTA = [4, 1], order = [1, 0]}>
+#shared = #ttg.swizzled_shared<{vec = 2, perPhase = 2, maxPhase = 4, order = [1, 0]}>
+#smem = #ttg.shared_memory
+
+module attributes {"ttg.num-warps" = 4 : i32, "ttg.num-ctas" = 1 : i32} {
+// Two async loads need no barrier between them. Dynamic slice indices, so
+// membar cannot prove the tiles disjoint and only the filter applies.
+// CHECK-LABEL: no_barrier_between_async_loads
+tt.func @no_barrier_between_async_loads(%A: !tt.ptr<f16>, %i: i32, %j: i32) {
+  %offset = arith.constant dense<0> : tensor<128x32xi32, #AL>
+  %alloc = ttg.local_alloc : () -> !ttg.memdesc<2x128x32xf16, #shared, #smem, mutable>
+  %tile_a = ttg.memdesc_index %alloc[%i] : !ttg.memdesc<2x128x32xf16, #shared, #smem, mutable> -> !ttg.memdesc<128x32xf16, #shared, #smem, mutable>
+  %tile_b = ttg.memdesc_index %alloc[%j] : !ttg.memdesc<2x128x32xf16, #shared, #smem, mutable> -> !ttg.memdesc<128x32xf16, #shared, #smem, mutable>
+  // CHECK: amdg.buffer_load_to_local
+  // CHECK-NOT: ttg.barrier local
+  // CHECK: amdg.buffer_load_to_local
+  %async_a = amdg.buffer_load_to_local %A[%offset] into %tile_a : !tt.ptr<f16>[tensor<128x32xi32, #AL>] -> <128x32xf16, #shared, #smem, mutable>
+  %async_b = amdg.buffer_load_to_local %A[%offset] into %tile_b : !tt.ptr<f16>[tensor<128x32xi32, #AL>] -> <128x32xf16, #shared, #smem, mutable>
+  // CHECK: tt.return
+  tt.return
+}
+}
+
+// -----
+
+#AL = #ttg.blocked<{sizePerThread = [1, 4], threadsPerWarp = [4, 8], warpsPerCTA = [4, 1], order = [1, 0]}>
+#shared = #ttg.swizzled_shared<{vec = 2, perPhase = 2, maxPhase = 4, order = [1, 0]}>
+#smem = #ttg.shared_memory
+
+module attributes {"ttg.num-warps" = 4 : i32, "ttg.num-ctas" = 1 : i32} {
+// Same for ttg.async_copy_global_to_local.
+// CHECK-LABEL: no_barrier_between_async_copies
+tt.func @no_barrier_between_async_copies(%A: !tt.ptr<f16>, %i: i32, %j: i32) {
+  %a_ptr = tt.splat %A : !tt.ptr<f16> -> tensor<128x32x!tt.ptr<f16>, #AL>
+  %alloc = ttg.local_alloc : () -> !ttg.memdesc<2x128x32xf16, #shared, #smem, mutable>
+  %tile_a = ttg.memdesc_index %alloc[%i] : !ttg.memdesc<2x128x32xf16, #shared, #smem, mutable> -> !ttg.memdesc<128x32xf16, #shared, #smem, mutable>
+  %tile_b = ttg.memdesc_index %alloc[%j] : !ttg.memdesc<2x128x32xf16, #shared, #smem, mutable> -> !ttg.memdesc<128x32xf16, #shared, #smem, mutable>
+  // CHECK: ttg.async_copy_global_to_local
+  // CHECK-NOT: ttg.barrier local
+  // CHECK: ttg.async_copy_global_to_local
+  %async_a = ttg.async_copy_global_to_local %a_ptr, %tile_a : tensor<128x32x!tt.ptr<f16>, #AL> -> !ttg.memdesc<128x32xf16, #shared, #smem, mutable>
+  %async_b = ttg.async_copy_global_to_local %a_ptr, %tile_b : tensor<128x32x!tt.ptr<f16>, #AL> -> !ttg.memdesc<128x32xf16, #shared, #smem, mutable>
+  // CHECK: tt.return
+  tt.return
+}
+}

--- a/test/Conversion/amd/amdgpu_membar.mlir
+++ b/test/Conversion/amd/amdgpu_membar.mlir
@@ -503,6 +503,71 @@ tt.func @no_barrier_between_async_copies(%A: !tt.ptr<f16>, %i: i32, %j: i32) {
 
 // -----
 
+#AL = #ttg.blocked<{sizePerThread = [1, 4], threadsPerWarp = [4, 8], warpsPerCTA = [4, 1], order = [1, 0]}>
+#shared = #ttg.swizzled_shared<{vec = 2, perPhase = 2, maxPhase = 4, order = [1, 0]}>
+#smem = #ttg.shared_memory
+
+module attributes {"ttg.num-warps" = 4 : i32, "ttg.num-ctas" = 1 : i32} {
+// Three-buffer pipelined loop without async tokens:
+//   prologue: load buf[0]; load buf[1]
+//   loop i:   load buf[i]; wait(2); j = (i+1)%3; read buf[j]; load buf[j]
+// None of the load/load pairs can be proven disjoint (the prologue indices have
+// a different SSA base than the loop index, and (i+0) vs (i+1)%3 have
+// mismatched moduli), so all of them rely on the filter. What remains is the
+// barrier owned by the async_wait and the WAR barrier before the refill of
+// buf[j], which stays because the LocalLoad is not synced via an async wait.
+// CHECK-LABEL: no_barrier_between_async_loads_in_pipelined_loop
+tt.func @no_barrier_between_async_loads_in_pipelined_loop(%A: !tt.ptr<f16>, %ub: i32) {
+  %c0_i32 = arith.constant 0 : i32
+  %c1_i32 = arith.constant 1 : i32
+  %c2_i32 = arith.constant 2 : i32
+  %c3_i32 = arith.constant 3 : i32
+  %offset = arith.constant dense<0> : tensor<128x32xi32, #AL>
+  %alloc = ttg.local_alloc : () -> !ttg.memdesc<3x128x32xf16, #shared, #smem, mutable>
+
+  %s0 = ttg.memdesc_index %alloc[%c0_i32] : !ttg.memdesc<3x128x32xf16, #shared, #smem, mutable> -> !ttg.memdesc<128x32xf16, #shared, #smem, mutable>
+  // CHECK: amdg.buffer_load_to_local
+  // CHECK-NOT: ttg.barrier local
+  %ld0 = amdg.buffer_load_to_local %A[%offset] into %s0 : !tt.ptr<f16>[tensor<128x32xi32, #AL>] -> <128x32xf16, #shared, #smem, mutable>
+  ttg.async_commit_group
+
+  %s1 = ttg.memdesc_index %alloc[%c1_i32] : !ttg.memdesc<3x128x32xf16, #shared, #smem, mutable> -> !ttg.memdesc<128x32xf16, #shared, #smem, mutable>
+  // CHECK: amdg.buffer_load_to_local
+  // CHECK-NOT: ttg.barrier local
+  %ld1 = amdg.buffer_load_to_local %A[%offset] into %s1 : !tt.ptr<f16>[tensor<128x32xi32, #AL>] -> <128x32xf16, #shared, #smem, mutable>
+  ttg.async_commit_group
+
+  // CHECK: cf.br
+  %res = scf.for %iv = %c0_i32 to %ub step %c1_i32 iter_args(%i = %c2_i32) -> (i32) : i32 {
+    %si = ttg.memdesc_index %alloc[%i] : !ttg.memdesc<3x128x32xf16, #shared, #smem, mutable> -> !ttg.memdesc<128x32xf16, #shared, #smem, mutable>
+    // CHECK-NOT: ttg.barrier local
+    // CHECK: amdg.buffer_load_to_local
+    %ldi = amdg.buffer_load_to_local %A[%offset] into %si : !tt.ptr<f16>[tensor<128x32xi32, #AL>] -> <128x32xf16, #shared, #smem, mutable>
+    ttg.async_commit_group
+
+    // CHECK: ttg.async_wait
+    // CHECK-NEXT: ttg.barrier local
+    ttg.async_wait {num = 2 : i32}
+
+    %ip1 = arith.addi %i, %c1_i32 : i32
+    %j = arith.remsi %ip1, %c3_i32 : i32
+    %sj = ttg.memdesc_index %alloc[%j] : !ttg.memdesc<3x128x32xf16, #shared, #smem, mutable> -> !ttg.memdesc<128x32xf16, #shared, #smem, mutable>
+    // CHECK-NOT: ttg.barrier local
+    // CHECK: ttg.local_load
+    // CHECK-NEXT: ttg.barrier local
+    // CHECK-NEXT: amdg.buffer_load_to_local
+    %v = ttg.local_load %sj : !ttg.memdesc<128x32xf16, #shared, #smem, mutable> -> tensor<128x32xf16, #AL>
+    %ldj = amdg.buffer_load_to_local %A[%offset] into %sj : !tt.ptr<f16>[tensor<128x32xi32, #AL>] -> <128x32xf16, #shared, #smem, mutable>
+    ttg.async_commit_group
+
+    scf.yield %j : i32
+  }
+  tt.return
+}
+}
+
+// -----
+
 #blocked = #ttg.blocked<{sizePerThread = [1, 8], threadsPerWarp = [4, 8], warpsPerCTA = [4, 1], order = [1, 0]}>
 #shared = #ttg.swizzled_shared<{vec = 1, perPhase = 1, maxPhase = 1, order = [1, 0]}>
 #smem = #ttg.shared_memory

--- a/third_party/amd/include/Dialect/TritonAMDGPU/IR/TritonAMDGPUOps.td
+++ b/third_party/amd/include/Dialect/TritonAMDGPU/IR/TritonAMDGPUOps.td
@@ -313,6 +313,7 @@ def BufferLoadOp : TT_AMDGPU_Op<"buffer_load", [
 //===----------------------------------------------------------------------===//
 
 def BufferLoadToLocalOp : TT_AMDGPU_Op<"buffer_load_to_local", [
+  GlobalToLocalCopyTrait,
   AttrSizedOperandSegments,
   BufferOpInterface,
   DeclareOpInterfaceMethods<PredicatedOpInterface>,
@@ -739,6 +740,7 @@ def AsyncCopyLocalToGlobalOp : TT_AMDGPU_Op<"async_copy_local_to_global", [
 //===----------------------------------------------------------------------===//
 
 def AsyncTDMCopyGlobalToLocalOp : TT_AMDGPU_Op<"async_tdm_copy_global_to_local", [
+    GlobalToLocalCopyTrait,
     DeclareOpInterfaceMethods<MBarrierOpInterface>,
     DeclareOpInterfaceMethods<TDMOpInterface>]> {
   let summary = "Copy data based on descriptor from global memory to local memory asynchronously";
@@ -818,6 +820,7 @@ def AsyncTDMCopyGlobalToLocalOp : TT_AMDGPU_Op<"async_tdm_copy_global_to_local",
 }
 
 def AsyncTDMFusedCopyGlobalToLocalOp : TT_AMDGPU_Op<"async_tdm_fused_copy_global_to_local", [
+    GlobalToLocalCopyTrait,
     SameVariadicOperandSize]> {
   let summary = "Fuse multiple TDM global-to-local copies into one async operation";
 
@@ -931,6 +934,7 @@ def AsyncTDMScatterOp : TT_AMDGPU_Op<"async_tdm_scatter", [
 //===----------------------------------------------------------------------===//
 
 def AsyncTDMGatherOp : TT_AMDGPU_Op<"async_tdm_gather", [
+    GlobalToLocalCopyTrait,
     DeclareOpInterfaceMethods<MBarrierOpInterface>,
     DeclareOpInterfaceMethods<TDMOpInterface>]> {
   let summary = "Gather data from non-contiguous global memory rows to local memory asynchronously";

--- a/third_party/amd/include/TritonAMDGPUToLLVM/MembarUtility.h
+++ b/third_party/amd/include/TritonAMDGPUToLLVM/MembarUtility.h
@@ -27,7 +27,7 @@ namespace mlir::triton::AMD {
 //     %4 = AsyncCopyGlobalToLocal %ptr_2 %tile_a
 //     scf.yield
 // 2) Do not create barriers between two async loads. They are ordered by
-// ttg.async_wait, not by barriers, so the barrier membar requests when it
+// async counter wait, not by barriers, so the barrier membar requests when it
 // cannot prove their destination slices disjoint (e.g. dynamically indexed
 // tiles in a pipelined loop) synchronizes nothing.
 bool membarFilter(Operation *op1, Operation *op2, bool op1IsRead,

--- a/third_party/amd/include/TritonAMDGPUToLLVM/MembarUtility.h
+++ b/third_party/amd/include/TritonAMDGPUToLLVM/MembarUtility.h
@@ -26,10 +26,8 @@ namespace mlir::triton::AMD {
 //      # Requires ttg.barrier but filter will prevent it
 //     %4 = AsyncCopyGlobalToLocal %ptr_2 %tile_a
 //     scf.yield
-// 2) Do not create barriers between two async loads. They are ordered by
-// async counter wait, not by barriers, so the barrier membar requests when it
-// cannot prove their destination slices disjoint (e.g. dynamically indexed
-// tiles in a pipelined loop) synchronizes nothing.
+// 2) Do not create barriers between two async loads. The synchronization
+// between them do not make sense.
 bool membarFilter(Operation *op1, Operation *op2, bool op1IsRead,
                   bool op2IsRead, Allocation *allocation);
 } // namespace mlir::triton::AMD

--- a/third_party/amd/include/TritonAMDGPUToLLVM/MembarUtility.h
+++ b/third_party/amd/include/TritonAMDGPUToLLVM/MembarUtility.h
@@ -26,6 +26,10 @@ namespace mlir::triton::AMD {
 //      # Requires ttg.barrier but filter will prevent it
 //     %4 = AsyncCopyGlobalToLocal %ptr_2 %tile_a
 //     scf.yield
+// 2) Do not create barriers between two async loads. They are ordered by
+// ttg.async_wait, not by barriers, so the barrier membar requests when it
+// cannot prove their destination slices disjoint (e.g. dynamically indexed
+// tiles in a pipelined loop) synchronizes nothing.
 bool membarFilter(Operation *op1, Operation *op2, bool op1IsRead,
                   bool op2IsRead, Allocation *allocation);
 } // namespace mlir::triton::AMD

--- a/third_party/amd/lib/TritonAMDGPUToLLVM/MembarUtility.cpp
+++ b/third_party/amd/lib/TritonAMDGPUToLLVM/MembarUtility.cpp
@@ -7,26 +7,36 @@
 
 namespace mlir::triton::AMD {
 namespace {
-// Returns true if one of the operands is a LocalLoad synced via AsyncWait.
+// Returns true if
+// 1) one is LocalLoad synced via AsyncWait.
+// 2) both are AsyncLoad
 bool filterAsyncLocalLoadsDependencies(Operation *op1, Operation *op2,
                                        Allocation *allocation) {
   auto isAsyncLoad = [](Operation *op) {
-    return llvm::isa<triton::gpu::AsyncCopyGlobalToLocalOp,
-                     triton::amdgpu::BufferLoadToLocalOp,
-                     triton::amdgpu::AsyncTDMCopyGlobalToLocalOp>(op);
+    return op->hasTrait<mlir::OpTrait::GlobalToLocalCopyTrait>();
   };
   auto isLocalLoadWithAsyncWaitToken = [](Operation *op) {
     auto localLoad = llvm::dyn_cast<triton::gpu::LocalLoadOp>(op);
     return localLoad && isSyncedViaAsyncWait(localLoad);
   };
-  auto getMemdescValue = [](Operation *op) -> Value {
-    return llvm::TypeSwitch<Operation *, Value>(op)
+  // Returns the local memory operands an op reads from or writes to. Fused TDM
+  // copies write to several destinations, hence the vector.
+  auto getMemdescValues = [](Operation *op) -> SmallVector<Value> {
+    return llvm::TypeSwitch<Operation *, SmallVector<Value>>(op)
         .Case<triton::amdgpu::BufferLoadToLocalOp>(
-            [](auto op) { return op.getDest(); })
-        .Case<triton::gpu::AsyncCopyGlobalToLocalOp>(
-            [](auto op) { return op.getResult(); })
-        .Case<triton::gpu::LocalLoadOp>([](auto op) { return op.getSrc(); })
-        .Default([](Operation *) { return Value(); });
+            [](auto op) -> SmallVector<Value> { return {op.getDest()}; })
+        .Case<triton::gpu::AsyncCopyGlobalToLocalOp,
+              triton::amdgpu::AsyncTDMCopyGlobalToLocalOp>(
+            [](auto op) -> SmallVector<Value> { return {op.getResult()}; })
+        .Case<triton::amdgpu::AsyncTDMFusedCopyGlobalToLocalOp>(
+            [](auto op) -> SmallVector<Value> {
+              return llvm::to_vector(op.getDests());
+            })
+        .Case<triton::amdgpu::AsyncTDMGatherOp>(
+            [](auto op) -> SmallVector<Value> { return {op.getDst()}; })
+        .Case<triton::gpu::LocalLoadOp>(
+            [](auto op) -> SmallVector<Value> { return {op.getSrc()}; })
+        .Default([](Operation *) { return SmallVector<Value>{}; });
   };
 
   // Early return if neither operands are an AsyncLoad
@@ -38,12 +48,21 @@ bool filterAsyncLocalLoadsDependencies(Operation *op1, Operation *op2,
     return true;
   }
 
-  Value op1Memdesc = getMemdescValue(op1);
-  Value op2Memdesc = getMemdescValue(op2);
-  if (!op1Memdesc || !op2Memdesc)
+  SmallVector<Value> op1Memdescs = getMemdescValues(op1);
+  SmallVector<Value> op2Memdescs = getMemdescValues(op2);
+  if (op1Memdescs.empty() || op2Memdescs.empty())
     return false;
-  auto op1BufferIds = allocation->getAllBufferIdsWithAliases(op1Memdesc);
-  auto op2BufferIds = allocation->getAllBufferIdsWithAliases(op2Memdesc);
+
+  auto collectBufferIds = [&](ArrayRef<Value> memdescs) {
+    Allocation::BufferIdSetT bufferIds;
+    for (Value memdesc : memdescs) {
+      auto ids = allocation->getAllBufferIdsWithAliases(memdesc);
+      bufferIds.insert(ids.begin(), ids.end());
+    }
+    return bufferIds;
+  };
+  auto op1BufferIds = collectBufferIds(op1Memdescs);
+  auto op2BufferIds = collectBufferIds(op2Memdescs);
 
   // Check if operations access the same buffer
   bool sameBuffer = llvm::any_of(

--- a/third_party/amd/lib/TritonAMDGPUToLLVM/MembarUtility.cpp
+++ b/third_party/amd/lib/TritonAMDGPUToLLVM/MembarUtility.cpp
@@ -13,7 +13,7 @@ bool filterAsyncLocalLoadsDependencies(Operation *op1, Operation *op2,
   auto isAsyncLoad = [](Operation *op) {
     return llvm::isa<triton::gpu::AsyncCopyGlobalToLocalOp,
                      triton::amdgpu::BufferLoadToLocalOp,
-                     triton::amdgpu::AsyncTDMCopyLocalToGlobalOp>(op);
+                     triton::amdgpu::AsyncTDMCopyGlobalToLocalOp>(op);
   };
   auto isLocalLoadWithAsyncWaitToken = [](Operation *op) {
     auto localLoad = llvm::dyn_cast<triton::gpu::LocalLoadOp>(op);
@@ -29,9 +29,13 @@ bool filterAsyncLocalLoadsDependencies(Operation *op1, Operation *op2,
         .Default([](Operation *) { return Value(); });
   };
 
-  // Early return if neither or both operands are an AsyncLoad
-  if (isAsyncLoad(op1) == isAsyncLoad(op2)) {
+  // Early return if neither operands are an AsyncLoad
+  if (!isAsyncLoad(op1) && !isAsyncLoad(op2)) {
     return false;
+  }
+  // Filter if both operands are an AsyncLoad
+  if (isAsyncLoad(op1) && isAsyncLoad(op2)) {
+    return true;
   }
 
   Value op1Memdesc = getMemdescValue(op1);

--- a/third_party/amd/lib/TritonAMDGPUTransforms/InThreadTranspose.cpp
+++ b/third_party/amd/lib/TritonAMDGPUTransforms/InThreadTranspose.cpp
@@ -513,8 +513,7 @@ findReachableSMemOps(ttg::LocalLoadOp root) {
         smemOperand = candidate->getOperand(0);
       } else if (isa<ttg::LocalLoadOp, ttg::LocalDeallocOp>(candidate)) {
         smemOperand = candidate->getOperand(0);
-      } else if (isa<ttg::AsyncCopyGlobalToLocalOp,
-                     tt::amdgpu::BufferLoadToLocalOp>(candidate)) {
+      } else if (candidate->hasTrait<mlir::OpTrait::GlobalToLocalCopyTrait>()) {
         // InTheadTranspose cannot be used with direct-to-lds loads
         LDBG(" skip because of direct-to-lds load");
         return failure();


### PR DESCRIPTION
Membar emits a ttg.barrier between two async loads when it cannot prove their destination slices disjoint, e.g. dynamically indexed tiles of one allocation in a pipelined loop. 
Async loads are ordered by ttg.async_wait, not by barriers, so that barrier synchronizes nothing. 
we set the Async programming model for Async load as below
1)  user need to handle RAW dependency using async_wait, while all others are handled by compiler
2) no barrier between async loads

add GlobalToLocalCopyTrait to group all the async load. 

Closes https://github.com/triton-lang/triton/pull/10626
