### PR TITLE
[Frontend] Quadratic loop carry discovery

### DIFF
--- a/python/test/unit/language/test_frontend.py
+++ b/python/test/unit/language/test_frontend.py
@@ -1,7 +1,9 @@
+import collections
 import functools
 import triton
 import triton.language as tl
 from triton._filecheck import filecheck_test, run_filecheck_test, run_parser
+from triton.compiler.code_generator import CodeGenerator
 from triton.compiler.errors import CompilationError
 import pytest
 from typing import NamedTuple
@@ -1268,3 +1270,178 @@ def test_dot_fp16_accumulator():
         tl.dot(a, b, c)
 
     run_parser(fp16_acc_kernel)
+
+
+# ===-----------------------------------------------------------------------===#
+# Loop-carried variable lowering
+# ===-----------------------------------------------------------------------===#
+
+
+@filecheck_test
+@triton.jit
+def test_loop_carry_readonly_alias():
+    # CHECK-LABEL: test_loop_carry_readonly_alias
+    # CHECK: %[[SEED:.*]] = arith.constant 1 : i32
+    seed = 1
+    acc = seed
+    # CHECK: scf.for {{.*}} iter_args(%[[ACC:.*]] = %[[SEED]]) -> (i32)
+    for i in range(3):
+        # CHECK: %[[SUM:.*]] = arith.addi %[[ACC]], %[[SEED]] : i32
+        acc = acc + seed
+        # CHECK: scf.yield %[[SUM]] : i32
+    anchor(acc)
+
+
+@filecheck_test
+@triton.jit
+def test_loop_carry_shared_initial_value():
+    # CHECK-LABEL: test_loop_carry_shared_initial_value
+    # CHECK: %[[SEED:.*]] = arith.constant 1 : i32
+    seed = 1
+    a = seed
+    b = seed
+    # CHECK: scf.for {{.*}} iter_args(%[[A:.*]] = %[[SEED]], %[[B:.*]] = %[[SEED]])
+    for i in range(3):
+        # CHECK: %[[NEXT_A:.*]] = arith.addi %[[A]],
+        a = a + 1
+        # CHECK: %[[NEXT_B:.*]] = arith.addi %[[B]],
+        b = b + 2
+        # CHECK: scf.yield %[[NEXT_A]], %[[NEXT_B]] : i32, i32
+    anchor(a)
+    anchor(b)
+
+
+@filecheck_test
+@triton.jit
+def test_loop_carry_while_shared_initial_value():
+    # CHECK-LABEL: test_loop_carry_while_shared_initial_value
+    # CHECK: %[[SEED:.*]] = arith.constant 1 : i32
+    seed = 1
+    a = seed
+    b = seed
+    # CHECK: scf.while
+    while a < 4:
+        # CHECK: } do {
+        # CHECK-NEXT: ^bb0(%[[A:.*]]: i32, %[[B:.*]]: i32):
+        # CHECK: %[[NEXT_A:.*]] = arith.addi %[[A]], %[[SEED]] : i32
+        a = a + seed
+        # CHECK: %[[NEXT_B:.*]] = arith.addi %[[B]],
+        b = b + 2
+        # CHECK: scf.yield %[[NEXT_A]], %[[NEXT_B]] : i32, i32
+    anchor(a)
+    anchor(b)
+
+
+@filecheck_test
+@triton.jit
+def test_loop_carry_tuple_shared_initial_value():
+    # CHECK-LABEL: test_loop_carry_tuple_shared_initial_value
+    # CHECK: %[[SEED:.*]] = arith.constant 1 : i32
+    seed = 1
+    pair = (seed, seed)
+    # CHECK: scf.for {{.*}} iter_args(%[[A:.*]] = %[[SEED]], %[[B:.*]] = %[[SEED]])
+    for i in range(3):
+        # CHECK: %[[NEXT_A:.*]] = arith.addi %[[A]],
+        # CHECK: %[[NEXT_B:.*]] = arith.addi %[[B]],
+        pair = (pair[0] + 1, pair[1] + 2)
+        # CHECK: scf.yield %[[NEXT_A]], %[[NEXT_B]] : i32, i32
+    anchor(pair[0])
+    anchor(pair[1])
+
+
+@filecheck_test
+@triton.jit
+def test_loop_carry_swap():
+    # CHECK-LABEL: test_loop_carry_swap
+    a = 0
+    b = 1
+    # CHECK: scf.for {{.*}} iter_args(%[[A:.*]] = {{.*}}, %[[B:.*]] = {{.*}})
+    for i in range(3):
+        a, b = b, a
+        # CHECK: scf.yield %[[B]], %[[A]] : i32, i32
+    anchor(a)
+    anchor(b)
+
+
+@filecheck_test
+@triton.jit
+def test_loop_carry_invariant_identity():
+    # CHECK-LABEL: test_loop_carry_invariant_identity
+    seed = 1
+    alias = seed
+    acc = 0
+    # CHECK: scf.for {{.*}} iter_args({{.*}}) -> (i32)
+    for i in range(3):
+        tl.static_assert(alias is seed)
+        acc = acc + alias
+    anchor(acc)
+
+
+@filecheck_test
+@triton.jit
+def test_loop_carry_empty_nested():
+    # CHECK-LABEL: test_loop_carry_empty_nested
+    # CHECK: %[[SEED:.*]] = arith.constant 1 : i32
+    seed = 1
+    # CHECK: scf.for
+    # CHECK-NOT: iter_args
+    for i in range(2):
+        # CHECK: scf.while : () -> ()
+        while seed < 0:
+            # CHECK: } do {
+            # CHECK: tt.call @{{.*}}anchor{{.*}}(%[[SEED]])
+            anchor(seed)
+            # CHECK: scf.yield
+
+
+@triton.jit
+def _loop_carry_nest_depth_3(KIND: tl.constexpr):
+    acc = 0
+    if KIND == 0:
+        for i in range(2):
+            for j in range(2):
+                for k in range(2):
+                    acc += 1
+    elif KIND == 1:
+        i = 0
+        while i < 2:
+            j = 0
+            while j < 2:
+                k = 0
+                while k < 2:
+                    acc += 1
+                    k += 1
+                j += 1
+            i += 1
+    elif KIND == 2:
+        for i in range(2):
+            j = 0
+            while j < 2:
+                for k in range(2):
+                    acc += 1
+                j += 1
+    else:
+        i = 0
+        while i < 2:
+            for j in range(2):
+                k = 0
+                while k < 2:
+                    acc += 1
+                    k += 1
+            i += 1
+    anchor(acc)
+
+
+@pytest.mark.parametrize("kind", range(4), ids=["for", "while", "for-while-for", "while-for-while"])
+def test_loop_carry_discovery_avoids_exponential_revisits(monkeypatch, kind):
+    """A depth-three body is generated four times, rather than eight."""
+    per_body = collections.Counter()
+    visit = CodeGenerator.visit_compound_statement
+
+    def counted(self, stmts):
+        per_body[id(stmts)] += 1
+        return visit(self, stmts)
+
+    monkeypatch.setattr(CodeGenerator, "visit_compound_statement", counted)
+    run_parser(_loop_carry_nest_depth_3, args=(kind, ))
+    assert max(per_body.values()) == 4

--- a/python/triton/compiler/code_generator.py
+++ b/python/triton/compiler/code_generator.py
@@ -350,6 +350,7 @@ class CodeGenerator(ast.NodeVisitor):
         self.noinline = noinline
         self.caller_context = caller_context
         self.scf_stack = []
+        self._loop_carry_discovery_depth = 0
         self.ret_type = None
         # SSA-construction
         # name => language.tensor
@@ -470,13 +471,25 @@ class CodeGenerator(ast.NodeVisitor):
         self.builder.restore_insertion_point(ip)
         self.builder.set_loc(loc)
 
+    @contextlib.contextmanager
+    def _discovering_loop_carries(self):
+        # Nested loops need result placeholders, not a second complete body,
+        # while generating IR that an enclosing _find_carries will discard.
+        # This gives depth + 1 innermost-body visits instead of 2**depth.
+        self._loop_carry_discovery_depth += 1
+        try:
+            yield
+        finally:
+            self._loop_carry_discovery_depth -= 1
+
     def _find_carries(self, node, liveins, ignore: set[str] = set()):
         # create loop body block
         block = self.builder.create_block()
         self.builder.set_insertion_point_to_start(block)
         # dry visit loop body
         self.scf_stack.append(node)
-        self.visit_compound_statement(node.body)
+        with self._discovering_loop_carries():
+            self.visit_compound_statement(node.body)
         self.scf_stack.pop()
         block.erase()
 
@@ -1219,7 +1232,11 @@ class CodeGenerator(ast.NodeVisitor):
                 self.local_defs[name] = val
                 self._maybe_set_loc_to_name(val, name)
             self.scf_stack.append(node)
-            self.visit_compound_statement(node.body)
+            # An enclosing carry-discovery pass discards this loop. Its result
+            # types and identities suffice; yield the body arguments instead
+            # of recursively generating the body a second time.
+            if not self._loop_carry_discovery_depth:
+                self.visit_compound_statement(node.body)
             self.scf_stack.pop()
 
             yield_handles = flatten_values_to_ir(self.lscope[name] for name in names)
@@ -1361,7 +1378,10 @@ class CodeGenerator(ast.NodeVisitor):
             for name, val in zip(names, block_args):
                 self._maybe_set_loc_to_name(val, name)
                 self.set_value(name, val)
-            self.visit_compound_statement(node.body)
+            # See visit_While: only the enclosing dry run observes this loop's
+            # results. The final lowering still generates the real body.
+            if not self._loop_carry_discovery_depth:
+                self.visit_compound_statement(node.body)
             self.scf_stack.pop()
             yield_handles = flatten_values_to_ir(self.lscope[name] for name in names)
 


### PR DESCRIPTION
Closes #11147, Fixes #11146

This reduces the complexity of nested loop carry discovery from O(2^depth) to O(depth^2) and is around 10x faster at a loop depth of 8. I also prototyped an O(depth) version but it was only 1.5x faster at a depth of 8 and this didn't seem worth the added complexity and risk.