### PR TITLE
Fix NVFP4 matmul profiler names

### DIFF
--- a/python/triton_kernels/tests/test_matmul_metadata.py
+++ b/python/triton_kernels/tests/test_matmul_metadata.py
@@ -1,13 +1,56 @@
+from types import SimpleNamespace
+
 import pytest
 import torch
 
 from triton_kernels.matmul_details._common import _matmul_flops_and_bytes_from_slices, matmul_launch_metadata
+from triton_kernels.matmul_details._common import make_matmul_repr
 from triton_kernels.proton_opts import launch_metadata_allow_sync, set_launch_metadata_allow_sync
 
 
 class _Kernel:
     name = "_p_matmul_test"
     num_stages = 4
+
+
+def _matmul_name(signature):
+    constants = {
+        "stride_y_n": 1,
+        "stride_x_k": 1,
+        "stride_w_n": 1,
+        "BLOCK_M": 128,
+        "BLOCK_N": 256,
+        "BLOCK_K": 128,
+        "SPLIT_K": 1,
+    }
+    specialization = SimpleNamespace(signature=signature, constants=constants)
+    return make_matmul_repr("_matmul", [0, 1, 2])(specialization)
+
+
+@pytest.mark.parametrize(
+    ("signature", "expected_dtypes"),
+    [
+        ({"Y": "*bf16", "X": "*u8", "W": "*bf16", "XMxScale": "*u8"}, "bf16xmxfp4xbf16"),
+        (
+            {"Y": "*bf16", "X": "*u8", "W": "*bf16", "XMxScale": "tensordesc<u8[128,4]>"},
+            "bf16xmxfp4xbf16",
+        ),
+        ({"Y": "*bf16", "X": "*u8", "W": "*bf16", "XMxScale": "*fp8e4nv"}, "bf16xnvfp4xbf16"),
+        (
+            {"Y": "*bf16", "X": "*u8", "W": "*bf16", "XMxScale": "tensordesc<fp8e4nv[128,4]>"},
+            "bf16xnvfp4xbf16",
+        ),
+        (
+            {"Y": "*bf16", "X": "*u8", "W": "*u8", "XMxScale": "*fp8e4nv", "WMxScale": "*fp8e4nv"},
+            "bf16xnvfp4xnvfp4",
+        ),
+        ({"Y": "*u8", "X": "*bf16", "W": "*bf16", "YActualScale": "*fp8e4nv"}, "nvfp4xbf16xbf16"),
+        ({"Y": "*bf16", "X": "*fp8e4nv", "W": "*fp16"}, "bf16xfp8e4nvxfp16"),
+    ],
+)
+def test_matmul_repr_names_operand_dtypes(signature, expected_dtypes):
+    name = _matmul_name(signature)
+    assert name == f"_matmul_NNN_{expected_dtypes}_128x256x128x1"
 
 
 def _old_flops_and_bytes(args, M, N, K, X, Y, W, slice_sizes, nbits, batch_size):

--- a/python/triton_kernels/triton_kernels/matmul_details/_common.py
+++ b/python/triton_kernels/triton_kernels/matmul_details/_common.py
@@ -231,18 +231,20 @@ def make_matmul_repr(base_name, order):
         reorder = lambda L: [L[i] for i in order]
         layout = lambda stride: "N" if stride in constants else "T"
 
-        def convert_dtype(dtype):
+        def convert_dtype(i):
+            dtype = signature[i]
             if "tensordesc" in dtype:
-                ret = convert_dtype(dtype.split("<")[1].split("[")[0])
-                return ret
-            elif "u8" in dtype:
-                return "mxfp4"
+                dtype = dtype.split("<")[1].split("[")[0]
             elif dtype[0] == "*":
-                return dtype[1:]
-            else:
-                return dtype
+                dtype = dtype[1:]
 
-        dtypes = "x".join([convert_dtype(f"{signature[i]}") for i in reorder(["Y", "X", "W"])])
+            if "u8" in dtype:
+                scale_name = "YActualScale" if i == "Y" else f"{i}MxScale"
+                scale = signature[scale_name]
+                return "nvfp4" if "fp8e4nv" in scale else "mxfp4"
+            return dtype
+
+        dtypes = "x".join([convert_dtype(i) for i in reorder(["Y", "X", "W"])])
         layouts = "".join([f"{layout(i)}" for i in reorder(["stride_y_n", "stride_x_k", "stride_w_n"])])
         blocks = "x".join([f"{constants[i]}" for i in ["BLOCK_M", "BLOCK_N", "BLOCK_K", "SPLIT_K"]])
         suffix = "_acc" if "OutAcc" in signature and "OutAcc" not in constants else ""


### PR DESCRIPTION
## Summary

TritonKernels currently labels every packed uint8 matmul operand as MXFP4 when generating profiler names. This produces misleading names for real NVFP4 kernels. For example, a kernel with E4M3 block scales can appear as:

`_p_matmul_NNT_fp8e4nvxmxfp4xmxfp4_...`

even though both packed operands are NVFP4. The expected name is:

`_p_matmul_NNT_fp8e4nvxnvfp4xnvfp4_...`

Both formats pack two E2M1 values into each uint8, so the value dtype alone cannot distinguish them. This change also inspects each operand's block-scale dtype:

- uint8/E8M0 scale → MXFP4
- float8e4nv/E4M3 scale → NVFP4

A uint8 matmul operand is treated as packed FP4 and must have its associated microscale argument. The change only affects generated profiler names, not kernel execution.

## Validation

Not run per request.

Device: Not tested.

## Lines Changed

| Type | Added | Removed | Net |
| --- | ---: | ---: | ---: |
| Tests | 43 | 0 | +43 |
| Core Logic | 11 | 9 | +2 |
| AutoGenerated | 0 | 0 | 0 |
| Total | 54 | 9 | +45 |

## Reviewers Guide

- Critical logic: `python/triton_kernels/triton_kernels/matmul_details/_common.py`
- Focused naming coverage: `python/triton_kernels/tests/test_matmul_metadata.py`
- No files are primarily code movements.
