### PR TITLE
[Release] [Cherry-Pick] [AMD] Preserve i32 accumulation for small-K int8 dots (#11282)

### DIFF
--- a/third_party/amd/lib/TritonAMDGPUToLLVM/DotOpToLLVM/FMA.cpp
+++ b/third_party/amd/lib/TritonAMDGPUToLLVM/DotOpToLLVM/FMA.cpp
@@ -70,10 +70,17 @@ class AMDFMAVectorMultiplier : public FMAVectorMultiplier {
     auto vecTy = vec_ty(elemTy, vectorSize);
     auto b = TritonLLVMOpBuilder(loc, rewriter);
     Value vec = b.undef(vecTy);
+    Value zero = LLVM::ConstantOp::create(rewriter, loc, elemTy,
+                                          rewriter.getZeroAttr(elemTy));
     for (int elem = 0; elem < vectorSize; ++elem) {
       int elemPos = firstElemPos + elem;
-      vec =
-          b.insert_element(vecTy, vec, scalarValues[elemPos], b.i32_val(elem));
+      Value scalar;
+      if (elemPos < static_cast<int>(scalarValues.size())) {
+        scalar = scalarValues[elemPos];
+      } else {
+        scalar = zero;
+      }
+      vec = b.insert_element(vecTy, vec, scalar, b.i32_val(elem));
     }
     if (elemTy.isInteger(8)) {
       assert(vectorSize == 4);

--- a/third_party/amd/lib/TritonAMDGPUTransforms/AccelerateAMDMatmul.cpp
+++ b/third_party/amd/lib/TritonAMDGPUTransforms/AccelerateAMDMatmul.cpp
@@ -1635,9 +1635,9 @@ public:
     }
 
     // Try I8 x I8 -> I32 v_dot
-    // if k % 4 != 0: can not use integer V_DOT instruction
+    // Partial K groups are zero-padded in the FMA lowering.
     if (dotTypes.a.isInteger(8) && dotTypes.b.isInteger(8) &&
-        dotTypes.c.isInteger(32) && dotTypes.d.isInteger(32) && k % 4 == 0) {
+        dotTypes.c.isInteger(32) && dotTypes.d.isInteger(32)) {
       return true;
     }
 

--- a/third_party/amd/python/test/test_int8_dot_small_block_k.py
+++ b/third_party/amd/python/test/test_int8_dot_small_block_k.py
@@ -1,0 +1,45 @@
+import numpy as np
+import pytest
+import torch
+import triton
+import triton.language as tl
+
+from triton._internal_testing import is_hip, to_numpy
+
+if not is_hip():
+    pytest.skip(allow_module_level=True)
+
+
+@pytest.mark.parametrize("block_k", [1, 2, 3, 4])
+def test_int8_dot_small_block_k(block_k, device):
+
+    @triton.jit
+    def kernel(a, b, c, K, BLOCK_K: tl.constexpr, PAD_K: tl.constexpr):
+        offs_m = tl.arange(0, 32)
+        offs_n = tl.arange(0, 32)
+        offs_k = tl.arange(0, PAD_K)
+        a_ptrs = a + offs_m[:, None] * K + offs_k[None, :]
+        b_ptrs = b + offs_k[:, None] * 32 + offs_n[None, :]
+        k_mask = offs_k < BLOCK_K
+        acc = tl.zeros((32, 32), dtype=tl.int32)
+        for _ in range(0, K, BLOCK_K):
+            acc = tl.dot(tl.load(a_ptrs, mask=k_mask[None, :], other=0), tl.load(b_ptrs, mask=k_mask[:, None], other=0),
+                         acc, out_dtype=tl.int32)
+            a_ptrs += BLOCK_K
+            b_ptrs += BLOCK_K * 32
+        tl.store(c + offs_m[:, None] * 32 + offs_n[None, :], acc)
+
+    # tl.arange requires a power-of-two range; pad so BLOCK_K=3 stays a logical 3-wide K tile.
+    pad_k = triton.next_power_of_2(block_k)
+    K = 2052
+    rng = np.random.default_rng(0)
+    a = rng.integers(120, 128, size=(32, K), dtype=np.int8)
+    b = rng.integers(120, 128, size=(K, 32), dtype=np.int8)
+    expected = a.astype(np.int64) @ b.astype(np.int64)
+    assert np.abs(expected).max() > 2**24
+
+    a = torch.from_numpy(a).to(device)
+    b = torch.from_numpy(b).to(device)
+    actual = torch.empty((32, 32), dtype=torch.int32, device=device)
+    kernel[(1, )](a, b, actual, K, BLOCK_K=block_k, PAD_K=pad_k)
+    np.testing.assert_array_equal(to_numpy(actual), expected)


### PR DESCRIPTION
## Summary

Backport #11282. On this branch an i8 dot whose K tile is not divisible by four is still legalized through fp32, which rounds the loop-carried i32 accumulator once it exceeds 2^24 and returns silently wrong results. Reported in ROCm/triton#958.

The fix keeps these dots on the integer `sdot4` path and zero-pads the incomplete four-element group. K tiles divisible by four are unchanged.

## Cherry-pick conflicts

None. Applied with `git cherry-pick -x`. FMA.cpp is identical to the pre-fix file on main and the AccelerateAMDMatmul.cpp hunk lands unmodified.

## Test plan

- [x] Built `release/3.8.x` with this commit
- [x] `third_party/amd/python/test/test_int8_dot_small_block_k.py`: 4 passed on gfx950
- [x] Reproducer from ROCm/triton#958 (K=2052, accumulator max 3.1e7): BLOCK_K=1 and 2 give 996/1024 wrong elements before, exact after; BLOCK_K=4 unchanged
- [x] `pre-commit run --from-ref origin/release/3.8.x --to-ref HEAD`
- [x] `git diff --check`

# New contributor declaration

- [x] I am not making a trivial change, such as fixing a typo in a comment.

- [x] I have written a PR description following these
  [rules](https://cbea.ms/git-commit/#why-not-how).

- [x] I have run the `release/3.8.x` equivalent of `pre-commit run --from-ref origin/main --to-ref HEAD`.

- Select one of the following.
  - [x] I have added tests.
    - `/python/test` for end-to-end tests (carried over from the trunk PR)

- Select one of the following.
  - [x] I have not added any `lit` tests.
