### PR TITLE
Update the lowering semantics of `//` to match the python semantics

### DIFF
--- a/python/src/ir.cc
+++ b/python/src/ir.cc
@@ -1321,7 +1321,7 @@ void init_triton_ir(py::module_ &m) {
            })
       .def("create_sdiv",
            [](TritonOpBuilder &self, Value &lhs, Value &rhs) -> Value {
-             return self.create<arith::DivSIOp>(lhs, rhs);
+             return self.create<arith::FloorDivSIOp>(lhs, rhs);
            })
       .def("create_udiv",
            [](TritonOpBuilder &self, Value &lhs, Value &rhs) -> Value {


### PR DESCRIPTION
Currently, the `//` operator lowers to DivSI rounding towards 0. This doesn't match python semantics and could lead to misleading compilation for users. This PR updates the lowering to round towards -infinity matching the python semantics.

Note on testing. I don't have easy access to a GPU for testing but it looks like floor_divsi is already correctly lowered by these backends. I was hoping to run this in your test suite to see what need fixing. Also I have haven't added a specific test for this case I wanted your input on what that would look like (or if you thing existing tests will cover this once they're fixed). (I will update/remove this section of the comment based on feedback before the PR is landed to get nicer message for the git history.)