### PR TITLE
[AMD][BACKEND][GLUON] Add `scaled_downcast` for MXFP4/MXFP8

### DIFF
--- a/include/triton/Dialect/TritonGPU/IR/Dialect.h
+++ b/include/triton/Dialect/TritonGPU/IR/Dialect.h
@@ -178,6 +178,10 @@ FailureOr<RankedTensorType> inferFp4ToFpResultType(RankedTensorType srcType,
                                                    Type elemType, int32_t axis,
                                                    std::optional<Location> loc);
 
+FailureOr<RankedTensorType> inferFpToFp4ResultType(RankedTensorType srcType,
+                                                   int32_t axis,
+                                                   std::optional<Location> loc);
+
 // Returns the number of warps per CTA that have access to non-replicated
 // elements of the tensor. E.g. for a blocked layout with sizePerThread = [1,
 // 1], threadsPerWarp = [2, 16], warpsPerCTA = [1, 4] and tensor shape = [2, 2],

--- a/include/triton/Dialect/TritonGPU/IR/TritonGPUOpInterfaces.td
+++ b/include/triton/Dialect/TritonGPU/IR/TritonGPUOpInterfaces.td
@@ -4,9 +4,10 @@
 include "mlir/IR/OpBase.td"
 include "mlir/Interfaces/InferTypeOpInterface.td"
 
-def UpcastFpOpInterface : OpInterface<"UpcastFpOpInterface"> {
+def CastFpOpInterface : OpInterface<"CastFpOpInterface"> {
     let description = [{
-        This interface is for operations that upcast floating-point numbers.
+        This interface is for operations that cast floating-point numbers,
+        either upcasting or downcasting.
     }];
 
     let cppNamespace = "::mlir::triton::gpu";

--- a/lib/Dialect/TritonGPU/IR/Dialect.cpp
+++ b/lib/Dialect/TritonGPU/IR/Dialect.cpp
@@ -187,6 +187,34 @@ inferFp4ToFpResultType(RankedTensorType srcType, Type elemType, int32_t axis,
   return RankedTensorType::get(shape, elemType, outEnc);
 }
 
+FailureOr<RankedTensorType>
+inferFpToFp4ResultType(RankedTensorType srcType, int32_t axis,
+                       std::optional<Location> loc) {
+  auto rank = srcType.getRank();
+  if (axis < 0 || axis >= rank)
+    return failure();
+  if (srcType.getShape()[axis] % 2 != 0)
+    return failure();
+
+  // srcType is the unpacked (larger) tensor. Infer the packed encoding from
+  // the unpacked one using backward inference, then halve the axis extent.
+  Attribute inEnc = srcType.getEncoding();
+  assert(inEnc && "expected an encoding on the unpacked source type");
+  Attribute outEnc;
+  auto result =
+      inEnc.getDialect()
+          .getRegisteredInterface<triton::DialectInferLayoutInterface>()
+          ->inferFp4ToFpOpEncoding(srcType.getShape(), axis, inEnc, outEnc,
+                                   /*fwdInference=*/false, loc);
+  if (failed(result))
+    return failure();
+
+  auto shape = llvm::to_vector(srcType.getShape());
+  shape[axis] /= 2;
+  return RankedTensorType::get(shape, IntegerType::get(srcType.getContext(), 8),
+                               outEnc);
+}
+
 SmallVector<unsigned> getThreadsPerWarp(Attribute layout,
                                         ArrayRef<int64_t> shape) {
   return toGenericLinearEncoding(cast<DistributedEncodingTrait>(layout), shape)

--- a/lib/Dialect/TritonGPU/Transforms/RemoveLayoutConversions.cpp
+++ b/lib/Dialect/TritonGPU/Transforms/RemoveLayoutConversions.cpp
@@ -1306,7 +1306,7 @@ bool LayoutRematerialization::hoistConvertDotOperand(
   // threads We do views and elementwise pure ops for now
   auto noDataMovement = [](Operation *op) {
     return (op->hasTrait<OpTrait::Elementwise>() && isMemoryEffectFree(op)) ||
-           isa<BroadcastOp, Fp4ToFpOp, ConvertLayoutOp, UpcastFpOpInterface>(
+           isa<BroadcastOp, Fp4ToFpOp, ConvertLayoutOp, CastFpOpInterface>(
                op) ||
            isView(op);
   };

--- a/lib/Dialect/TritonGPU/Transforms/Utility.cpp
+++ b/lib/Dialect/TritonGPU/Transforms/Utility.cpp
@@ -578,7 +578,7 @@ Attribute inferSrcEncoding(Operation *op, Attribute encoding) {
       return {};
   }
 
-  if (isa<triton::gpu::UpcastFpOpInterface>(op))
+  if (isa<triton::gpu::CastFpOpInterface>(op))
     return {};
 
   if (op->hasTrait<mlir::OpTrait::SameOperandsAndResultEncoding>() ||
@@ -614,7 +614,7 @@ Attribute inferDstEncoding(Operation *op, Attribute encoding) {
     if (!isa<triton::gpu::BlockedEncodingAttr>(encoding))
       return {};
   }
-  if (isa<triton::gpu::UpcastFpOpInterface>(op))
+  if (isa<triton::gpu::CastFpOpInterface>(op))
     return {};
 
   if (op->hasTrait<mlir::OpTrait::SameOperandsAndResultEncoding>() ||
@@ -978,9 +978,8 @@ LogicalResult getConvertBackwardSlice(
       }
       for (auto [i, operand] : llvm::enumerate(definingOp->getOpOperands())) {
         Attribute srcEncoding;
-        if (auto upcast =
-                dyn_cast<triton::gpu::UpcastFpOpInterface>(definingOp)) {
-          srcEncoding = upcast.inferSrcEncoding(i, encoding);
+        if (auto cast = dyn_cast<triton::gpu::CastFpOpInterface>(definingOp)) {
+          srcEncoding = cast.inferSrcEncoding(i, encoding);
         } else {
           srcEncoding = inferSrcEncoding(definingOp, encoding);
         }

--- a/python/src/gluon_ir.cc
+++ b/python/src/gluon_ir.cc
@@ -1170,6 +1170,17 @@ void init_gluon_ir(py::module_ &m) {
              return self.create<ttag::ScaledUpcastFp8Op>(resultType, input,
                                                          scale);
            })
+      .def("create_scaled_downcast_fp4",
+           [](GluonOpBuilder &self, Value input, Value scale,
+              int axis) -> Value {
+             return self.create<ttag::ScaledDowncastFp4Op>(input, scale, axis);
+           })
+      .def("create_scaled_downcast_fp8",
+           [](GluonOpBuilder &self, Value input, Value scale, Type elemType,
+              int axis) -> Value {
+             return self.create<ttag::ScaledDowncastFp8Op>(input, scale,
+                                                           elemType, axis);
+           })
       .def("create_extract_slice",
            [](GluonOpBuilder &self, Type resultType, Value source,
               std::vector<int64_t> &offsets) -> Value {

--- a/python/test/gluon/test_frontend.py
+++ b/python/test/gluon/test_frontend.py
@@ -3858,6 +3858,48 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 1 : i32, ttg.targ
 """)
 
 
+def _get_amd_scaled_downcast(target):
+    return ttgl.amd.cdna4.scaled_downcast if target.arch == "gfx950" else ttgl.amd.cdna5.scaled_downcast
+
+
+@pytest.mark.parametrize("target", [HIP_TARGET_CDNA4, HIP_TARGET_CDNA5], ids=["cdna4", "cdna5"])
+@pytest.mark.parametrize("dtype,ir_dtype", [(ttgl.float16, "f16"), (ttgl.float32, "f32")])
+def test_amd_scaled_downcast_fp4_float_dtypes(target, dtype, ir_dtype):
+    scaled_downcast = _get_amd_scaled_downcast(target)
+
+    @gluon.jit
+    def kernel():
+        unpacked_layout: ttgl.constexpr = ttgl.BlockedLayout([1, 8], [8, 8], [1, 1], [1, 0])
+        scale_layout: ttgl.constexpr = ttgl.BlockedLayout([1, 1], [8, 8], [1, 1], [1, 0])
+        input = ttgl.full([16, 64], 1.0, dtype, unpacked_layout)
+        scale = ttgl.full([16, 8], 0x7F, ttgl.uint8, scale_layout)
+        scaled_downcast(input, scale, "e2m1", axis=1)
+
+    module = run_parser(kernel, *make_args(num_warps=1), target=target)
+    module_text = module.str_nodebug()
+    assert "amdg.scaled_downcast_fp4" in module_text
+    assert f"tensor<16x64x{ir_dtype}" in module_text
+
+
+@pytest.mark.parametrize("target", [HIP_TARGET_CDNA4, HIP_TARGET_CDNA5], ids=["cdna4", "cdna5"])
+@pytest.mark.parametrize("fp8_format,ir_dtype", [("e4m3", "f8E4M3FN"), ("e5m2", "f8E5M2")])
+def test_amd_scaled_downcast_fp8_cdna(target, fp8_format, ir_dtype):
+    scaled_downcast = _get_amd_scaled_downcast(target)
+
+    @gluon.jit
+    def kernel(FORMAT: ttgl.constexpr):
+        layout: ttgl.constexpr = ttgl.BlockedLayout([1, 8], [8, 8], [1, 1], [1, 0])
+        scale_layout: ttgl.constexpr = ttgl.BlockedLayout([1, 1], [8, 8], [1, 1], [1, 0])
+        input = ttgl.full([16, 64], 1.0, ttgl.bfloat16, layout)
+        scale = ttgl.full([16, 8], 0x7F, ttgl.uint8, scale_layout)
+        scaled_downcast(input, scale, FORMAT, axis=1)
+
+    module = run_parser(kernel, *make_args(fp8_format, num_warps=1), target=target)
+    module_text = module.str_nodebug()
+    assert "amdg.scaled_downcast_fp8" in module_text
+    assert f"-> tensor<16x64x{ir_dtype}" in module_text
+
+
 @pytest.mark.parametrize("target", [HIP_TARGET_CDNA3, HIP_TARGET_CDNA4], ids=["cdna3", "cdna4"])
 def test_amd_scaled_upcast_fp8_cdna(target):
     scaled_upcast = _get_amd_scaled_upcast(target)

--- a/python/triton/experimental/gluon/language/amd/_ops.py
+++ b/python/triton/experimental/gluon/language/amd/_ops.py
@@ -4,9 +4,23 @@ from triton import knobs
 from triton.experimental.gluon.language import _core as ttgl
 from triton.experimental.gluon.language._semantic import _check
 
-from .._core import _unwrap_if_constexpr
+from .._core import builtin, _unwrap_if_constexpr
 from .._layouts import DotOperandLayout
 from ._layouts import AMDWMMALayout
+
+_DOWNCAST_FORMAT_TO_ELEM_TYPE = {
+    "e4m3": ttgl.float8e4nv,
+    "e5m2": ttgl.float8e5,
+    "e2m1": ttgl.uint8,
+}
+
+
+def _downcast_format_to_elem_type(format):
+    format = _unwrap_if_constexpr(format)
+    _check(
+        format in _DOWNCAST_FORMAT_TO_ELEM_TYPE, lambda:
+        f"Unsupported scaled_downcast format {format!r}; expected one of {_DOWNCAST_FORMAT_TO_ELEM_TYPE.keys()}")
+    return _DOWNCAST_FORMAT_TO_ELEM_TYPE[format]
 
 
 def _wrap_scaled_upcast_result(handle, elem_type, semantic):
@@ -185,3 +199,98 @@ def _scaled_upcast(src, scale, elem_type, axis, semantic):
     handle = semantic.builder.create_scaled_upcast_fp4(src.handle, scale.handle, elem_type.to_ir(semantic.builder),
                                                        axis)
     return _wrap_scaled_upcast_result(handle, elem_type, semantic)
+
+
+def _normalize_axis(axis, rank, axis_required_message):
+    _check(axis is not None, lambda: axis_required_message)
+    _check(-rank <= axis < rank, lambda: f"axis {axis} out of range for rank {rank}")
+    if axis < 0:
+        axis += rank
+    return axis
+
+
+def _validate_scaled_downcast_common(input, scale):
+    _check(isinstance(input.type, ttgl.distributed_type),
+           lambda: f"Expected input to have a distributed_type but got {input.type}")
+    _check(isinstance(scale.type, ttgl.distributed_type),
+           lambda: f"Expected scale to have a distributed_type but got {scale.type}")
+    supported_dtypes = {ttgl.float16, ttgl.bfloat16, ttgl.float32}
+    _check(input.dtype in supported_dtypes, lambda: f"Expected fp16, bf16, or fp32 input but got {input.dtype}")
+    _check(scale.dtype in {ttgl.int8, ttgl.uint8},
+           lambda: f"Expected raw E8M0 scale in int8/uint8 but got {scale.dtype}")
+    return len(input.type.shape)
+
+
+def _check_scaled_downcast_scale_shape(input_shape, scale_shape, axis, axis_extent, non_axis_error_message):
+    _check(scale_shape[:axis] + scale_shape[axis + 1:] == input_shape[:axis] + input_shape[axis + 1:],
+           lambda: f"{non_axis_error_message}, but got scale {scale_shape} and input {input_shape}")
+    _check(scale_shape[axis] > 0 and axis_extent % scale_shape[axis] == 0,
+           lambda: f"Expected axis extent {axis_extent} to be divisible by scale axis extent "
+           f"{scale_shape[axis]}")
+    _check(
+        scale_shape[axis] < axis_extent, lambda: "scaled_downcast requires compact scales along the scaled axis; "
+        "expanded scales (one scale per output element) are not supported")
+    block_size = input_shape[axis] // scale_shape[axis]
+    _check(
+        block_size % 8 == 0, lambda: f"Expected each scale block to span a multiple of 8 consecutive input elements "
+        f"along axis {axis}, but got {block_size}")
+
+
+def _scaled_downcast(input, scale, elem_type, axis, semantic):
+    rank = _validate_scaled_downcast_common(input, scale)
+    input_shape = input.type.shape
+    scale_shape = scale.type.shape
+
+    # fp8: elementwise downcast; scale axis is based on input shape.
+    if elem_type in {ttgl.float8e4nv, ttgl.float8e5}:
+        axis = _normalize_axis(axis, rank, "axis is required for fp8 scaled_downcast")
+        _check_scaled_downcast_scale_shape(
+            input_shape, scale_shape, axis, input_shape[axis],
+            "Expected scale shape for fp8 scaled_downcast to match the input shape on non-axis dimensions")
+
+        handle = semantic.builder.create_scaled_downcast_fp8(input.handle, scale.handle,
+                                                             elem_type.to_ir(semantic.builder), axis)
+        ret_ty = input.type.with_element_ty(elem_type)
+        return ttgl.tensor(handle, ret_ty)
+
+    _check(elem_type in {ttgl.int8, ttgl.uint8},
+           lambda: f"Expected elem_type to be fp8 (e4m3/e5m2) or packed fp4 (int8/uint8) but got {elem_type}")
+    axis = _normalize_axis(axis, rank, "axis is required for packed fp4 scaled_downcast")
+    _check(input_shape[axis] % 2 == 0, lambda: f"Expected even input axis extent but got {input_shape[axis]}")
+
+    # fp4: packed output halves axis extent; scale axis uses packed output size.
+    packed_output_axis_extent = input_shape[axis] // 2
+    _check_scaled_downcast_scale_shape(
+        input_shape, scale_shape, axis, packed_output_axis_extent,
+        "Expected scale shape for packed fp4 scaled_downcast to match the packed output shape on non-axis dimensions")
+
+    handle = semantic.builder.create_scaled_downcast_fp4(input.handle, scale.handle, axis)
+    shape = semantic.builder.get_shape_from_tensor(handle)
+    layout = semantic.builder.get_gluon_layout_from_tensor(handle)
+    ret_ty = ttgl.distributed_type(elem_type, shape, layout)
+    return ttgl.tensor(handle, ret_ty)
+
+
+@builtin
+def scaled_downcast(input, scale, format, axis=-1, _semantic=None):
+    """
+    Scale and convert FP16, BF16, or FP32 values to a low-precision MX format,
+    dividing by the raw E8M0 ``scale`` payload (``int8`` or ``uint8``).
+
+    ``format`` selects the target type and packing behavior:
+
+    * ``"e4m3"`` / ``"e5m2"`` (fp8): elementwise, so the output keeps the
+      shape and layout of ``input``.
+    * ``"e2m1"`` (packed fp4): consecutive pairs of values along ``axis`` are
+      packed into one output byte (even element -> low nibble, next element ->
+      high nibble), so the result extent along ``axis`` is halved (the inverse
+      of ``scaled_upcast``).
+
+    ``axis`` (default: last dim) selects the dimension along which scales are
+    shared. ``scale`` must be compact along ``axis`` with one E8M0 byte per
+    block of consecutive input elements along ``axis``, and each block must
+    span a multiple of 8 consecutive input elements.
+    """
+    axis = _unwrap_if_constexpr(axis)
+    elem_type = _downcast_format_to_elem_type(format)
+    return _scaled_downcast(input, scale, elem_type, axis, _semantic)

--- a/python/triton/experimental/gluon/language/amd/cdna4/__init__.py
+++ b/python/triton/experimental/gluon/language/amd/cdna4/__init__.py
@@ -7,7 +7,7 @@ from triton._C.libtriton.gluon_ir import (
 from ..._core import builtin, int8, uint8, _unwrap_if_constexpr
 from ..._layouts import DotOperandLayout
 from .._layouts import AMDMFMALayout
-from .._ops import _load_shared_fp4_repacked, _mma_scaled, _scaled_upcast
+from .._ops import _load_shared_fp4_repacked, _mma_scaled, _scaled_upcast, scaled_downcast
 from ..cdna3 import _buffer_atomic_rmw_impl, _convert_e8m0_scale_to_bf16
 from ..cdna3 import *  # NOQA: F403
 from ..cdna3 import __all__ as __cdna3_all
@@ -18,6 +18,7 @@ __all__ = [
     "async_copy",
     "mfma_scaled",
     "scaled_upcast",
+    "scaled_downcast",
     "load_shared_fp4_repacked",
     "get_mfma_scale_layout",
     "compute_efficient_padded_shared_layout",

--- a/python/triton/experimental/gluon/language/amd/cdna5/__init__.py
+++ b/python/triton/experimental/gluon/language/amd/cdna5/__init__.py
@@ -2,7 +2,7 @@ from triton.runtime.jit import constexpr_function
 from triton._C.libtriton.gluon_ir import get_amd_wmma_scale_layout as _get_wmma_scale_layout
 
 from ..._core import builtin, int8, uint8, int32, float8e4nv, tensor, _unwrap_if_constexpr
-from .._ops import _load_shared_fp4_repacked, _wmma, _verify_wmma, _mma_scaled, _scaled_upcast
+from .._ops import _load_shared_fp4_repacked, _wmma, _verify_wmma, _mma_scaled, _scaled_upcast, scaled_downcast
 from .._layouts import AMDWMMALayout
 from ..cdna3 import buffer_load, buffer_store
 from ._layouts import PartitionedSharedLayout, make_partitioned_dot_layouts
@@ -12,8 +12,9 @@ from . import mbarrier
 from . import cluster
 
 __all__ = [
-    "async_copy", "tdm", "mbarrier", "cluster", "wmma", "wmma_scaled", "scaled_upcast", "buffer_load", "buffer_store",
-    "get_wmma_scale_layout", "PartitionedSharedLayout", "make_partitioned_dot_layouts", "load_shared_fp4_repacked"
+    "async_copy", "tdm", "mbarrier", "cluster", "wmma", "wmma_scaled", "scaled_upcast", "scaled_downcast",
+    "buffer_load", "buffer_store", "get_wmma_scale_layout", "PartitionedSharedLayout", "make_partitioned_dot_layouts",
+    "load_shared_fp4_repacked"
 ]
 
 
@@ -130,10 +131,9 @@ def scaled_upcast(src, scale, elem_type, axis=None, _semantic=None):
 
     * **Expanded scale:** one scale per output value. For example, fp4 bytes
       ``[M, K / 2]`` produce output ``[M, K]`` with scale ``[M, K]``.
-    * **Compact scale:** one scale per native scale block. For example, with
+    * **Compact scale:** one scale per scale block. For example, with
       ``axis=1`` and a 32-element scale block, output ``[M, K]`` uses scale
-      ``[M, K / 32]``. CDNA5 preserves those scale bytes in the native
-      ``cvt.scale.pk8`` payload form.
+      ``[M, K / 32]``.
 
     """
     axis = _unwrap_if_constexpr(axis)

--- a/test/TritonGPU/amd/amd-scaled-downcast-gfx1250.mlir
+++ b/test/TritonGPU/amd/amd-scaled-downcast-gfx1250.mlir
@@ -1,0 +1,75 @@
+// RUN: triton-opt %s --convert-triton-amdgpu-to-llvm="gfx-arch=gfx1250" --canonicalize --cse | FileCheck %s
+
+#blocked = #ttg.blocked<{sizePerThread = [1, 4], threadsPerWarp = [1, 32], warpsPerCTA = [1, 1], order = [1, 0]}>
+#unpacked = #ttg.blocked<{sizePerThread = [1, 8], threadsPerWarp = [1, 32], warpsPerCTA = [1, 1], order = [1, 0]}>
+#scale = #ttg.blocked<{sizePerThread = [1, 1], threadsPerWarp = [1, 32], warpsPerCTA = [1, 1], order = [1, 0]}>
+module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 1 : i32, ttg.target = "hip:gfx1250", "ttg.threads-per-warp" = 32 : i32} {
+  tt.func public @scaled_downcast_fp4(
+      %input: tensor<1x256xbf16, #unpacked>,
+      %scale: tensor<1x32xi8, #scale>,
+      %output: tensor<1x128x!tt.ptr<i8>, #blocked>) {
+    // CHECK-LABEL: llvm.func @scaled_downcast_fp4
+    // CHECK: llvm.insertelement {{.*}} : vector<8xbf16>
+    // CHECK: %[[PACKED:.+]] = rocdl.cvt.scalef32.pk8.fp4.bf16
+    // CHECK: llvm.lshr %[[PACKED]]
+    %result = amdg.scaled_downcast_fp4 %input scale %scale {axis = 1 : i32} : tensor<1x256xbf16, #unpacked>, tensor<1x32xi8, #scale> -> tensor<1x128xi8, #blocked>
+    tt.store %output, %result : tensor<1x128x!tt.ptr<i8>, #blocked>
+    tt.return
+  }
+
+  tt.func public @scaled_downcast_fp16(
+      %input: tensor<1x256xf16, #unpacked>,
+      %scale: tensor<1x32xi8, #scale>,
+      %output: tensor<1x128x!tt.ptr<i8>, #blocked>) {
+    // CHECK-LABEL: llvm.func @scaled_downcast_fp16
+    // CHECK: rocdl.cvt.scalef32.pk8.fp4.f16
+    %result = amdg.scaled_downcast_fp4 %input scale %scale {axis = 1 : i32} : tensor<1x256xf16, #unpacked>, tensor<1x32xi8, #scale> -> tensor<1x128xi8, #blocked>
+    tt.store %output, %result : tensor<1x128x!tt.ptr<i8>, #blocked>
+    tt.return
+  }
+
+  tt.func public @scaled_downcast_fp32(
+      %input: tensor<1x256xf32, #unpacked>,
+      %scale: tensor<1x32xi8, #scale>,
+      %output: tensor<1x128x!tt.ptr<i8>, #blocked>) {
+    // CHECK-LABEL: llvm.func @scaled_downcast_fp32
+    // CHECK: rocdl.cvt.scalef32.pk8.fp4.f32
+    %result = amdg.scaled_downcast_fp4 %input scale %scale {axis = 1 : i32} : tensor<1x256xf32, #unpacked>, tensor<1x32xi8, #scale> -> tensor<1x128xi8, #blocked>
+    tt.store %output, %result : tensor<1x128x!tt.ptr<i8>, #blocked>
+    tt.return
+  }
+
+  tt.func public @scaled_downcast_fp8_e4m3_bf16(
+      %input: tensor<1x256xbf16, #unpacked>,
+      %scale: tensor<1x32xi8, #scale>,
+      %output: tensor<1x256x!tt.ptr<f8E4M3FN>, #unpacked>) {
+    // CHECK-LABEL: llvm.func @scaled_downcast_fp8_e4m3_bf16
+    // CHECK: llvm.insertelement {{.*}} : vector<8xbf16>
+    // CHECK: rocdl.cvt.scalef32.pk8.fp8.bf16
+    %result = amdg.scaled_downcast_fp8 %input scale %scale {axis = 1 : i32} : tensor<1x256xbf16, #unpacked>, tensor<1x32xi8, #scale> -> tensor<1x256xf8E4M3FN, #unpacked>
+    tt.store %output, %result : tensor<1x256x!tt.ptr<f8E4M3FN>, #unpacked>
+    tt.return
+  }
+
+  tt.func public @scaled_downcast_fp8_e5m2_f16(
+      %input: tensor<1x256xf16, #unpacked>,
+      %scale: tensor<1x32xi8, #scale>,
+      %output: tensor<1x256x!tt.ptr<f8E5M2>, #unpacked>) {
+    // CHECK-LABEL: llvm.func @scaled_downcast_fp8_e5m2_f16
+    // CHECK: rocdl.cvt.scalef32.pk8.bf8.f16
+    %result = amdg.scaled_downcast_fp8 %input scale %scale {axis = 1 : i32} : tensor<1x256xf16, #unpacked>, tensor<1x32xi8, #scale> -> tensor<1x256xf8E5M2, #unpacked>
+    tt.store %output, %result : tensor<1x256x!tt.ptr<f8E5M2>, #unpacked>
+    tt.return
+  }
+
+  tt.func public @scaled_downcast_fp8_e4m3_f32(
+      %input: tensor<1x256xf32, #unpacked>,
+      %scale: tensor<1x32xi8, #scale>,
+      %output: tensor<1x256x!tt.ptr<f8E4M3FN>, #unpacked>) {
+    // CHECK-LABEL: llvm.func @scaled_downcast_fp8_e4m3_f32
+    // CHECK: rocdl.cvt.scalef32.pk8.fp8.f32
+    %result = amdg.scaled_downcast_fp8 %input scale %scale {axis = 1 : i32} : tensor<1x256xf32, #unpacked>, tensor<1x32xi8, #scale> -> tensor<1x256xf8E4M3FN, #unpacked>
+    tt.store %output, %result : tensor<1x256x!tt.ptr<f8E4M3FN>, #unpacked>
+    tt.return
+  }
+}

--- a/test/TritonGPU/amd/amd-scaled-downcast-gfx950.mlir
+++ b/test/TritonGPU/amd/amd-scaled-downcast-gfx950.mlir
@@ -1,0 +1,77 @@
+// RUN: triton-opt %s --convert-triton-amdgpu-to-llvm="gfx-arch=gfx950" --canonicalize --cse | FileCheck %s
+
+#blocked = #ttg.blocked<{sizePerThread = [1, 4], threadsPerWarp = [1, 64], warpsPerCTA = [1, 1], order = [1, 0]}>
+#unpacked = #ttg.blocked<{sizePerThread = [1, 8], threadsPerWarp = [1, 64], warpsPerCTA = [1, 1], order = [1, 0]}>
+#scale = #ttg.blocked<{sizePerThread = [1, 1], threadsPerWarp = [1, 64], warpsPerCTA = [1, 1], order = [1, 0]}>
+module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 1 : i32, ttg.target = "hip:gfx950", "ttg.threads-per-warp" = 64 : i32} {
+  tt.func public @scaled_downcast_fp4(
+      %input: tensor<1x512xbf16, #unpacked>,
+      %scale: tensor<1x64xi8, #scale>,
+      %output: tensor<1x256x!tt.ptr<i8>, #blocked>) {
+    // CHECK-LABEL: llvm.func @scaled_downcast_fp4
+    // CHECK: %[[CVT0:.+]] = rocdl.cvt.scalef32.pk.fp4.bf16 {{.*}} -> {{.*}}[0] : i32
+    // CHECK: %[[CVT1:.+]] = rocdl.cvt.scalef32.pk.fp4.bf16 {{.*}} -> %[[CVT0]][1] : i32
+    // CHECK: %[[CVT2:.+]] = rocdl.cvt.scalef32.pk.fp4.bf16 {{.*}} -> %[[CVT1]][2] : i32
+    // CHECK: %[[CVT3:.+]] = rocdl.cvt.scalef32.pk.fp4.bf16 {{.*}} -> %[[CVT2]][3] : i32
+    // CHECK: llvm.lshr %[[CVT3]]
+    %result = amdg.scaled_downcast_fp4 %input scale %scale {axis = 1 : i32} : tensor<1x512xbf16, #unpacked>, tensor<1x64xi8, #scale> -> tensor<1x256xi8, #blocked>
+    tt.store %output, %result : tensor<1x256x!tt.ptr<i8>, #blocked>
+    tt.return
+  }
+
+  tt.func public @scaled_downcast_fp16(
+      %input: tensor<1x512xf16, #unpacked>,
+      %scale: tensor<1x64xi8, #scale>,
+      %output: tensor<1x256x!tt.ptr<i8>, #blocked>) {
+    // CHECK-LABEL: llvm.func @scaled_downcast_fp16
+    // CHECK: rocdl.cvt.scalef32.pk.fp4.f16
+    %result = amdg.scaled_downcast_fp4 %input scale %scale {axis = 1 : i32} : tensor<1x512xf16, #unpacked>, tensor<1x64xi8, #scale> -> tensor<1x256xi8, #blocked>
+    tt.store %output, %result : tensor<1x256x!tt.ptr<i8>, #blocked>
+    tt.return
+  }
+
+  tt.func public @scaled_downcast_fp32(
+      %input: tensor<1x512xf32, #unpacked>,
+      %scale: tensor<1x64xi8, #scale>,
+      %output: tensor<1x256x!tt.ptr<i8>, #blocked>) {
+    // CHECK-LABEL: llvm.func @scaled_downcast_fp32
+    // CHECK: rocdl.cvt.scalef32.pk.fp4.f32
+    %result = amdg.scaled_downcast_fp4 %input scale %scale {axis = 1 : i32} : tensor<1x512xf32, #unpacked>, tensor<1x64xi8, #scale> -> tensor<1x256xi8, #blocked>
+    tt.store %output, %result : tensor<1x256x!tt.ptr<i8>, #blocked>
+    tt.return
+  }
+
+  tt.func public @scaled_downcast_fp8_e4m3_bf16(
+      %input: tensor<1x512xbf16, #unpacked>,
+      %scale: tensor<1x64xi8, #scale>,
+      %output: tensor<1x512x!tt.ptr<f8E4M3FN>, #unpacked>) {
+    // CHECK-LABEL: llvm.func @scaled_downcast_fp8_e4m3_bf16
+    // CHECK: %[[CVT0:.+]] = rocdl.cvt.scalef32.pk.fp8.bf16 {{.*}} -> {{.*}}[false] : vector<2xi16>
+    // CHECK: %[[CVT1:.+]] = rocdl.cvt.scalef32.pk.fp8.bf16 {{.*}} -> %[[CVT0]][true] : vector<2xi16>
+    %result = amdg.scaled_downcast_fp8 %input scale %scale {axis = 1 : i32} : tensor<1x512xbf16, #unpacked>, tensor<1x64xi8, #scale> -> tensor<1x512xf8E4M3FN, #unpacked>
+    tt.store %output, %result : tensor<1x512x!tt.ptr<f8E4M3FN>, #unpacked>
+    tt.return
+  }
+
+  tt.func public @scaled_downcast_fp8_e5m2_f16(
+      %input: tensor<1x512xf16, #unpacked>,
+      %scale: tensor<1x64xi8, #scale>,
+      %output: tensor<1x512x!tt.ptr<f8E5M2>, #unpacked>) {
+    // CHECK-LABEL: llvm.func @scaled_downcast_fp8_e5m2_f16
+    // CHECK: rocdl.cvt.scalef32.pk.bf8.f16
+    %result = amdg.scaled_downcast_fp8 %input scale %scale {axis = 1 : i32} : tensor<1x512xf16, #unpacked>, tensor<1x64xi8, #scale> -> tensor<1x512xf8E5M2, #unpacked>
+    tt.store %output, %result : tensor<1x512x!tt.ptr<f8E5M2>, #unpacked>
+    tt.return
+  }
+
+  tt.func public @scaled_downcast_fp8_e4m3_f32(
+      %input: tensor<1x512xf32, #unpacked>,
+      %scale: tensor<1x64xi8, #scale>,
+      %output: tensor<1x512x!tt.ptr<f8E4M3FN>, #unpacked>) {
+    // CHECK-LABEL: llvm.func @scaled_downcast_fp8_e4m3_f32
+    // CHECK: rocdl.cvt.scalef32.pk.fp8.f32
+    %result = amdg.scaled_downcast_fp8 %input scale %scale {axis = 1 : i32} : tensor<1x512xf32, #unpacked>, tensor<1x64xi8, #scale> -> tensor<1x512xf8E4M3FN, #unpacked>
+    tt.store %output, %result : tensor<1x512x!tt.ptr<f8E4M3FN>, #unpacked>
+    tt.return
+  }
+}

--- a/third_party/amd/include/Dialect/TritonAMDGPU/IR/TargetFeatures.h
+++ b/third_party/amd/include/Dialect/TritonAMDGPU/IR/TargetFeatures.h
@@ -87,6 +87,7 @@ public:
   bool supportsPermlaneSwap() const;
   bool supportsCvtPkScalePk8() const;
   bool supportsHwScaledUpcast() const;
+  bool supportsHwScaledDowncast() const;
 
   bool supportBitwidth16Elementwise() const;
   bool supportBitwidth32Elementwise() const;

--- a/third_party/amd/include/Dialect/TritonAMDGPU/IR/TritonAMDGPUOps.td
+++ b/third_party/amd/include/Dialect/TritonAMDGPU/IR/TritonAMDGPUOps.td
@@ -550,7 +550,7 @@ def MaskedStoreOp : TT_AMDGPU_Op<"masked_store", []> {
 // ScaledUpcastFp4Op
 //===----------------------------------------------------------------------===//
 
-def ScaledUpcastFp4Op : TT_AMDGPU_Op<"scaled_upcast_fp4", [Pure, DeclareOpInterfaceMethods<UpcastFpOpInterface>]> {
+def ScaledUpcastFp4Op : TT_AMDGPU_Op<"scaled_upcast_fp4", [Pure, DeclareOpInterfaceMethods<CastFpOpInterface>]> {
   let summary = "Upcast fp4 and then multiply scale";
 
   let description = [{
@@ -604,7 +604,7 @@ def ScaledUpcastFp8Op : TT_AMDGPU_Op<"scaled_upcast_fp8", [
     Elementwise,
     SameOperandsAndResultShape,
     SameOperandsAndResultEncoding,
-    DeclareOpInterfaceMethods<UpcastFpOpInterface>]> {
+    DeclareOpInterfaceMethods<CastFpOpInterface>]> {
   let summary = "Upcast Fp8 and then multiply scale";
 
   let description = [{
@@ -622,6 +622,118 @@ def ScaledUpcastFp8Op : TT_AMDGPU_Op<"scaled_upcast_fp8", [
     $input `scale` $scale attr-dict
         `:` type($input) `,` type($scale) `->` type($output)
   }];
+}
+
+//===----------------------------------------------------------------------===//
+// ScaledDowncastFp4Op
+//===----------------------------------------------------------------------===//
+
+def ScaledDowncastFp4Op : TT_AMDGPU_Op<"scaled_downcast_fp4", [
+    Pure,
+    DeclareOpInterfaceMethods<CastFpOpInterface>]> {
+  let summary = "Scale and downcast floating-point values to packed FP4";
+
+  let description = [{
+    Divide FP16, BF16, or FP32 values by an E8M0 scale and convert them to
+    packed e2m1 values. The result packs two consecutive fp4 values per i8
+    along `axis`: the element at even position provides the low nibble and the
+    following element the high nibble, so the result extent along `axis` is
+    half the input extent (the inverse of `scaled_upcast_fp4`).
+
+    The `axis` attribute identifies the dimension along which the fp4 elements
+    are packed and along which scales are shared. The scale must be compact
+    along `axis`: one raw E8M0 i8 payload covers multiple consecutive packed
+    bytes along that axis (unlike :func:`scaled_upcast_fp4`, expanded scales
+    with one scale per output element are not supported). Each scale block along
+    `axis` must cover a multiple of 8 fp4 values.
+
+    This will be hardware accelerated on architectures supporting
+    `v_cvt_scalef32_pk_*` instructions (e.g. CDNA4 and CDNA5).
+  }];
+
+  let arguments = (ins
+    RankedTensorOf<[F16, BF16, F32]>:$input,
+    RankedTensorOf<[I8]>:$scale,
+    I32Attr:$axis);
+  let results = (outs RankedTensorOf<[I8]>:$output);
+
+  let builders = [
+      OpBuilder<(ins "Value":$input, "Value":$scale, "int32_t":$axis), [{
+        auto inputTy = cast<RankedTensorType>(input.getType());
+        auto resultTy = mlir::triton::gpu::inferFpToFp4ResultType(
+            inputTy, axis, $_state.location);
+        assert(succeeded(resultTy));
+        build($_builder, $_state, *resultTy, input, scale, axis);
+      }]>
+  ];
+
+  let assemblyFormat = [{
+    $input `scale` $scale attr-dict
+        `:` type($input) `,` type($scale) `->` type($output)
+  }];
+
+  let extraClassDeclaration = [{
+    static std::optional<mlir::triton::LinearLayout>
+    computeScaleLayout(const mlir::triton::LinearLayout &outputLayout,
+                       int64_t axis, int64_t pairsPerScale);
+  }];
+
+  let hasVerifier = 1;
+}
+
+//===----------------------------------------------------------------------===//
+// ScaledDowncastFp8Op
+//===----------------------------------------------------------------------===//
+
+def ScaledDowncastFp8Op : TT_AMDGPU_Op<"scaled_downcast_fp8", [
+    Pure,
+    DeclareOpInterfaceMethods<CastFpOpInterface>]> {
+  let summary = "Scale and downcast floating-point values to fp8";
+
+  let description = [{
+    Divide FP16, BF16, or FP32 values by an E8M0 scale and convert them to
+    fp8 (e4m3) or bf8 (e5m2) values. This is the elementwise inverse of
+    `scaled_upcast_fp8`: input and result share the same shape and encoding,
+    and each fp8 result occupies its own byte (no packing).
+
+    The `axis` attribute identifies the dimension along which scales are
+    shared. The scale must be compact along `axis`: one raw E8M0 i8 payload
+    covers multiple consecutive output elements along that axis (unlike
+    :func:`scaled_upcast_fp8`, expanded scales with one scale per output element
+    are not supported). Each scale block along `axis` must cover a multiple of 8
+    output elements.
+
+    This will be hardware accelerated on architectures supporting
+    `v_cvt_scalef32_pk_{fp8,bf8}_*` instructions (e.g. CDNA4 and CDNA5).
+  }];
+
+  let arguments = (ins
+    RankedTensorOf<[F16, BF16, F32]>:$input,
+    RankedTensorOf<[I8]>:$scale,
+    I32Attr:$axis);
+  let results = (outs RankedTensorOf<[AnyTypeOf<[F8E4M3FN, F8E5M2]>]>:$output);
+
+  let builders = [
+      OpBuilder<(ins "Value":$input, "Value":$scale, "Type":$elemType,
+                     "int32_t":$axis), [{
+        auto inputTy = cast<RankedTensorType>(input.getType());
+        auto resultTy = inputTy.clone(elemType);
+        build($_builder, $_state, resultTy, input, scale, axis);
+      }]>
+  ];
+
+  let assemblyFormat = [{
+    $input `scale` $scale attr-dict
+        `:` type($input) `,` type($scale) `->` type($output)
+  }];
+
+  let extraClassDeclaration = [{
+    static std::optional<mlir::triton::LinearLayout>
+    computeScaleLayout(const mlir::triton::LinearLayout &outputLayout,
+                       int64_t axis, int64_t elementsPerScale);
+  }];
+
+  let hasVerifier = 1;
 }
 
 //===----------------------------------------------------------------------===//

--- a/third_party/amd/include/TritonAMDGPUToLLVM/PatternTritonAMDGPUToLLVM.h
+++ b/third_party/amd/include/TritonAMDGPUToLLVM/PatternTritonAMDGPUToLLVM.h
@@ -20,6 +20,10 @@ void populateScaledUpcastOpToLLVMPatterns(
     mlir::LLVMTypeConverter &typeConverter, mlir::RewritePatternSet &patterns,
     const AMD::TargetInfo &targetInfo, mlir::PatternBenefit benefit);
 
+void populateScaledDowncastOpToLLVMPatterns(
+    mlir::LLVMTypeConverter &typeConverter, mlir::RewritePatternSet &patterns,
+    const AMD::TargetInfo &targetInfo, mlir::PatternBenefit benefit);
+
 } // namespace mlir::triton::AMD
 
 #endif // TRITON_THIRD_PARTY_AMD_INCLUDE_TRITONAMDGPUTOLLVM_PATTERNTRITONAMDGPUTOLLVM_H_

--- a/third_party/amd/lib/Dialect/TritonAMDGPU/IR/Dialect.cpp
+++ b/third_party/amd/lib/Dialect/TritonAMDGPU/IR/Dialect.cpp
@@ -156,15 +156,24 @@ LogicalResult verifyTDMCommonLayout(Operation *op,
   return verifyTDMLayoutConsistency(op, descTy, smemTy);
 }
 
+// A v_cvt_scalef32 group applies one scale to `groupSize` register-consecutive
+// output values. Check that the first `groupSize` register in-dims of the scale
+// layout are all broadcast (zero), i.e. the whole group maps to a single scale.
+bool groupSharesSingleScale(const LinearLayout &scaleLL, StringAttr kRegister,
+                            int64_t groupSize) {
+  assert(llvm::isPowerOf2_64(groupSize));
+  if (scaleLL.getInDimSizeLog2(kRegister) < llvm::Log2_64(groupSize))
+    return false;
+  auto outDims = llvm::to_vector(scaleLL.getOutDimNames());
+  return scaleLL.resizeInDim(kRegister, /*newSize=*/groupSize)
+      .sublayoutIsZero({kRegister}, outDims);
+}
+
 // The v_cvt_scale_pk8 lowering upcasts 8 register-consecutive fp4 values with a
 // single scale, check that 8 elements in the scale layout are all broadcasts.
 bool pk8GroupSharesSingleScale(const LinearLayout &scaleLL,
                                StringAttr kRegister) {
-  if (scaleLL.getInDimSizeLog2(kRegister) < 3)
-    return false;
-  auto outDims = llvm::to_vector(scaleLL.getOutDimNames());
-  return scaleLL.resizeInDim(kRegister, /*newSize=*/8)
-      .sublayoutIsZero({kRegister}, outDims);
+  return groupSharesSingleScale(scaleLL, kRegister, /*groupSize=*/8);
 }
 
 // Validates the output/scale shape relationship and returns the number of
@@ -268,10 +277,140 @@ LogicalResult verifyScaledUpcastFp4ScaleLayout(ScaledUpcastFp4Op op) {
   return success();
 }
 
+template <typename OpT>
+std::optional<int64_t> scaledDowncastScaleBlock(OpT op) {
+  auto outputShape = op.getOutput().getType().getShape();
+  auto scaleShape = op.getScale().getType().getShape();
+  int64_t axis = op.getAxis();
+  if (axis < 0 || axis >= static_cast<int64_t>(outputShape.size()) ||
+      outputShape.size() != scaleShape.size())
+    return std::nullopt;
+  for (int64_t dim = 0; dim < static_cast<int64_t>(outputShape.size()); ++dim) {
+    if (dim != axis && outputShape[dim] != scaleShape[dim])
+      return std::nullopt;
+  }
+  if (scaleShape[axis] <= 0 || outputShape[axis] % scaleShape[axis] != 0)
+    return std::nullopt;
+  return outputShape[axis] / scaleShape[axis];
+}
+
+template <typename OpT>
+std::optional<Attribute> inferScaledDowncastScaleEncoding(OpT op,
+                                                          Attribute outputEnc) {
+  auto elementsPerScale = scaledDowncastScaleBlock(op);
+  if (!elementsPerScale || !outputEnc ||
+      !isa<gpu::LayoutEncodingTrait>(outputEnc))
+    return std::nullopt;
+  // Expanded scales have the same axis extent so we can reuse outputEnc
+  if (*elementsPerScale == 1)
+    return outputEnc;
+
+  auto outputLL =
+      gpu::toLinearLayout(op.getOutput().getType().getShape(),
+                          cast<gpu::LayoutEncodingTrait>(outputEnc));
+  auto compact =
+      OpT::computeScaleLayout(outputLL, op.getAxis(), *elementsPerScale);
+  if (!compact)
+    return std::nullopt;
+  auto kRegister = StringAttr::get(op.getContext(), "register");
+  return gpu::LinearEncodingAttr::get(
+      op.getContext(), compact->removeZeroBasesAlongDim(kRegister));
+}
+
+template <typename OpT>
+LogicalResult verifyScaledDowncastScaleLayout(OpT op, int64_t groupSize,
+                                              StringRef groupDescription,
+                                              StringRef blockDescription) {
+  auto scaleTy = op.getScale().getType();
+  auto outputTy = op.getOutput().getType();
+  auto scaleEnc = scaleTy.getEncoding();
+  auto outputEnc = outputTy.getEncoding();
+  if (!scaleEnc != !outputEnc)
+    return op.emitError()
+           << "scale and output must both have an encoding, or neither";
+  if (!scaleEnc)
+    return success();
+
+  auto elementsPerBlock = scaledDowncastScaleBlock(op);
+  if (!elementsPerBlock)
+    return op.emitError() << "scale shape is not compatible with the output "
+                             "shape along the scaled axis";
+  if (*elementsPerBlock == 1)
+    return op.emitError()
+           << "scaled_downcast requires compact scales along the scaled axis; "
+              "expanded scales (one scale per output element) are not "
+              "supported";
+  if (*elementsPerBlock % groupSize != 0)
+    return op.emitError()
+           << "each scale block along the scaled axis must cover "
+           << blockDescription << ", but got " << *elementsPerBlock
+           << " output elements per scale";
+  auto outputLL = gpu::toLinearLayout(
+      outputTy.getShape(), cast<gpu::LayoutEncodingTrait>(outputEnc));
+  auto compact =
+      OpT::computeScaleLayout(outputLL, op.getAxis(), *elementsPerBlock);
+  if (!compact)
+    return op.emitError() << "the scale block along the scaled axis must be a "
+                             "power of two";
+
+  auto kRegister = StringAttr::get(op.getContext(), "register");
+  if (!groupSharesSingleScale(*compact, kRegister, groupSize))
+    return op.emitError()
+           << "each v_cvt_scalef32_pk8 group of " << groupDescription
+           << " must share a single scale; the scale block along the scaled "
+              "axis must be a "
+           << blockDescription;
+
+  auto stripRegisters = [&](RankedTensorType type, Attribute enc) {
+    return gpu::toLinearLayout(type.getShape(),
+                               cast<gpu::LayoutEncodingTrait>(enc))
+        .removeZeroBasesAlongDim(kRegister);
+  };
+  auto actualLayout = stripRegisters(scaleTy, scaleEnc);
+  auto expectedLayout = compact->removeZeroBasesAlongDim(kRegister);
+  if (actualLayout != expectedLayout)
+    return op.emitError()
+           << "scale encoding is not compatible with the inferred scale "
+              "layout\nexpected: "
+           << expectedLayout.toString()
+           << "\nactual: " << actualLayout.toString();
+  return success();
+}
+
+template <typename OpT>
+LogicalResult verifyScaledDowncastScaleShapeAndAxis(OpT op,
+                                                    RankedTensorType outputTy,
+                                                    RankedTensorType scaleTy) {
+  auto outputShape = outputTy.getShape();
+  auto scaleShape = scaleTy.getShape();
+  if (outputShape.size() != scaleShape.size())
+    return op.emitError() << "scale and output must have the same rank";
+
+  int64_t axis = op.getAxis();
+  int64_t rank = outputTy.getRank();
+  if (axis < 0 || axis >= rank)
+    return op.emitError() << "axis out of range: " << axis << " for rank "
+                          << rank;
+
+  for (int64_t dim = 0; dim < rank; ++dim) {
+    if (dim == axis)
+      continue;
+    if (outputShape[dim] != scaleShape[dim])
+      return op.emitError()
+             << "scale and output must match on non-axis dimensions";
+  }
+  if (scaleShape[axis] <= 0 || outputShape[axis] % scaleShape[axis] != 0)
+    return op.emitError() << "expected output.shape[axis] to be divisible by "
+                             "scale.shape[axis], but got output["
+                          << axis << "]=" << outputShape[axis] << ", scale["
+                          << axis << "]=" << scaleShape[axis];
+  return success();
+}
+
 } // namespace
 
-// Derive the layout of a scale tensor from the upcast output layout. A compact
-// scale holds a single value per `elementsPerScale` consecutive output elements
+// Derive the layout of a scale tensor from an output layout. A compact scale
+// holds a single value per `elementsPerScale` consecutive output elements
 // along `axis`, so the scale that an output element at coordinate `k` needs is
 // `scale[..., k / elementsPerScale, ...]`, i.e. the output coordinate with its
 // low `log2(elementsPerScale)` bits dropped (right-shifted). Output positions
@@ -279,8 +418,8 @@ LogicalResult verifyScaledUpcastFp4ScaleLayout(ScaledUpcastFp4Op op) {
 // broadcast (zero) bases along the scaled axis. `elementsPerScale` must be a
 // power of two.
 std::optional<LinearLayout>
-ScaledUpcastFp4Op::computeScaleLayout(const LinearLayout &outputLayout,
-                                      int64_t axis, int64_t elementsPerScale) {
+computeScaledCastScaleLayout(const LinearLayout &outputLayout, int64_t axis,
+                             int64_t elementsPerScale) {
   // For expanded scales the scale layout is the same as the output layout.
   if (elementsPerScale == 1)
     return outputLayout;
@@ -316,6 +455,23 @@ ScaledUpcastFp4Op::computeScaleLayout(const LinearLayout &outputLayout,
   // each input it yields the scale coordinate that the output element at that
   // input needs.
   return outputLayout.compose(scaleDivisor);
+}
+
+std::optional<LinearLayout>
+ScaledUpcastFp4Op::computeScaleLayout(const LinearLayout &outputLayout,
+                                      int64_t axis, int64_t elementsPerScale) {
+  return computeScaledCastScaleLayout(outputLayout, axis, elementsPerScale);
+}
+
+std::optional<LinearLayout>
+ScaledDowncastFp4Op::computeScaleLayout(const LinearLayout &outputLayout,
+                                        int64_t axis, int64_t pairsPerScale) {
+  return computeScaledCastScaleLayout(outputLayout, axis, pairsPerScale);
+}
+
+std::optional<LinearLayout> ScaledDowncastFp8Op::computeScaleLayout(
+    const LinearLayout &outputLayout, int64_t axis, int64_t elementsPerScale) {
+  return computeScaledCastScaleLayout(outputLayout, axis, elementsPerScale);
 }
 
 LogicalResult ExtractSliceOp::verify() {
@@ -624,6 +780,69 @@ Attribute ScaledUpcastFp4Op::inferSrcEncoding(unsigned opIdx,
   return {};
 }
 
+LogicalResult ScaledDowncastFp4Op::verify() {
+  RankedTensorType inputTy = getInput().getType();
+  RankedTensorType outputTy = getOutput().getType();
+  RankedTensorType scaleTy = getScale().getType();
+  if (failed(verifyScaledDowncastScaleShapeAndAxis(*this, outputTy, scaleTy)))
+    return failure();
+
+  if (failed(verifyScaledDowncastScaleLayout(
+          *this, /*groupSize=*/4, /*groupDescription=*/"8 fp4 values",
+          /*blockDescription=*/"a multiple of 8 fp4 values (4 packed bytes)")))
+    return failure();
+
+  // Reuse fp4tofp verifier for packed/unpacked relationship
+  return mlir::triton::gpu::Fp4ToFpOp::verifyFp4ToFp(*this, outputTy, inputTy,
+                                                     getAxis());
+}
+
+Attribute ScaledDowncastFp4Op::inferDstEncoding(unsigned opIdx,
+                                                Attribute srcEnc) {
+  // The scale layout is a quotient of the output along the scaled axis
+  if (opIdx == 1) {
+    if (auto scaleEnc = inferScaledDowncastScaleEncoding(*this, srcEnc))
+      return *scaleEnc;
+    return {};
+  }
+  // opIdx == 0: infer the packed output encoding from the unpacked input.
+  Attribute dstEnc;
+  auto shape = getInput().getType().getShape();
+
+  auto iface =
+      srcEnc.getDialect()
+          .getRegisteredInterface<triton::DialectInferLayoutInterface>();
+  if (succeeded(iface->inferFp4ToFpOpEncoding(shape, getAxis(), srcEnc, dstEnc,
+                                              /*fwdInference=*/false,
+                                              std::nullopt))) {
+    return dstEnc;
+  }
+  return {};
+}
+
+Attribute ScaledDowncastFp4Op::inferSrcEncoding(unsigned opIdx,
+                                                Attribute dstEnc) {
+  // The scale layout is a quotient of the output along the scaled axis
+  if (opIdx == 1) {
+    if (auto scaleEnc = inferScaledDowncastScaleEncoding(*this, dstEnc)) {
+      return *scaleEnc;
+    }
+  }
+  // opIdx == 0: infer the unpacked input encoding from the packed output.
+  Attribute srcEnc;
+  auto shape = getInput().getType().getShape();
+
+  auto iface =
+      dstEnc.getDialect()
+          .getRegisteredInterface<triton::DialectInferLayoutInterface>();
+  if (succeeded(iface->inferFp4ToFpOpEncoding(shape, getAxis(), dstEnc, srcEnc,
+                                              /*fwdInference=*/true,
+                                              std::nullopt))) {
+    return srcEnc;
+  }
+  return {};
+}
+
 Attribute ScaledUpcastFp8Op::inferDstEncoding(unsigned opIdx,
                                               Attribute srcEnc) {
   return srcEnc;
@@ -631,6 +850,47 @@ Attribute ScaledUpcastFp8Op::inferDstEncoding(unsigned opIdx,
 
 Attribute ScaledUpcastFp8Op::inferSrcEncoding(unsigned opIdx,
                                               Attribute dstEnc) {
+  return dstEnc;
+}
+
+LogicalResult ScaledDowncastFp8Op::verify() {
+  RankedTensorType inputTy = getInput().getType();
+  RankedTensorType outputTy = getOutput().getType();
+  RankedTensorType scaleTy = getScale().getType();
+  auto inputShape = inputTy.getShape();
+  auto outputShape = outputTy.getShape();
+
+  // fp8 downcast is elementwise: input and output share shape (and encoding).
+  if (inputShape != outputShape)
+    return emitError() << "input and output must have the same shape";
+  if (inputTy.getEncoding() != outputTy.getEncoding())
+    return emitError() << "input and output must have the same encoding";
+  if (failed(verifyScaledDowncastScaleShapeAndAxis(*this, outputTy, scaleTy)))
+    return failure();
+
+  return verifyScaledDowncastScaleLayout(
+      *this, /*groupSize=*/8,
+      /*groupDescription=*/"8 elements",
+      /*blockDescription=*/"a multiple of 8 elements");
+}
+
+Attribute ScaledDowncastFp8Op::inferDstEncoding(unsigned opIdx,
+                                                Attribute srcEnc) {
+  if (opIdx == 1) {
+    if (auto scaleEnc = inferScaledDowncastScaleEncoding(*this, srcEnc))
+      return *scaleEnc;
+    return {};
+  }
+  return srcEnc;
+}
+
+Attribute ScaledDowncastFp8Op::inferSrcEncoding(unsigned opIdx,
+                                                Attribute dstEnc) {
+  if (opIdx == 1) {
+    if (auto scaleEnc = inferScaledDowncastScaleEncoding(*this, dstEnc)) {
+      return *scaleEnc;
+    }
+  }
   return dstEnc;
 }
 

--- a/third_party/amd/lib/Dialect/TritonAMDGPU/IR/TargetFeatures.cpp
+++ b/third_party/amd/lib/Dialect/TritonAMDGPU/IR/TargetFeatures.cpp
@@ -325,6 +325,11 @@ bool TargetFeatures::supportsHwScaledUpcast() const {
          getISAFamily() == ISAFamily::GFX1250;
 }
 
+bool TargetFeatures::supportsHwScaledDowncast() const {
+  return getISAFamily() == ISAFamily::CDNA4 ||
+         getISAFamily() == ISAFamily::GFX1250;
+}
+
 bool TargetFeatures::supportBitwidth16Elementwise() const { return true; }
 
 bool TargetFeatures::supportBitwidth32Elementwise() const {

--- a/third_party/amd/lib/TritonAMDGPUDialectToLLVM/CMakeLists.txt
+++ b/third_party/amd/lib/TritonAMDGPUDialectToLLVM/CMakeLists.txt
@@ -3,6 +3,7 @@ add_triton_library(TritonAMDGPUDialectToLLVM
     ExtractSliceOpToLLVM.cpp
     InThreadTransposeOpToTTG.cpp
     ConcatOpToLLVM.cpp
+    ScaledDowncastToLLVM.cpp
     ScaledUpcastToLLVM.cpp
 
     DEPENDS

--- a/third_party/amd/lib/TritonAMDGPUDialectToLLVM/ScaledDowncastToLLVM.cpp
+++ b/third_party/amd/lib/TritonAMDGPUDialectToLLVM/ScaledDowncastToLLVM.cpp
@@ -1,0 +1,348 @@
+#include "Dialect/TritonAMDGPU/IR/Dialect.h"
+#include "TritonAMDGPUToLLVM/PatternTritonAMDGPUToLLVM.h"
+#include "mlir/Conversion/LLVMCommon/Pattern.h"
+#include "mlir/Dialect/LLVMIR/ROCDLDialect.h"
+#include "triton/Conversion/TritonGPUToLLVM/Utility.h"
+
+using namespace mlir;
+using namespace mlir::triton;
+
+namespace {
+
+// Convert a raw E8M0 scale byte to an f32 scale. E8M0 stores a biased f32
+// exponent, so we can shift it into the f32 exponent field.
+Value scaleToF32(TritonLLVMOpBuilder &b, Value scaleByte) {
+  MLIRContext *ctx = scaleByte.getContext();
+  return b.bitcast(
+      b.shl(b.zext(IntegerType::get(ctx, 32), scaleByte), b.i32_val(23)),
+      Float32Type::get(ctx));
+}
+
+// Split `count` little-endian bytes out of a packed i32 `word` and append them
+// (as i8) to `results`.
+void appendBytesFromWord(TritonLLVMOpBuilder &b, Value word, int count,
+                         SmallVectorImpl<Value> &results) {
+  Type i8 = IntegerType::get(word.getContext(), 8);
+  for (int i = 0; i < count; ++i) {
+    Value shifted =
+        i == 0 ? word : b.lshr(word, b.i32_val(static_cast<int64_t>(8 * i)));
+    results.push_back(b.trunc(i8, shifted));
+  }
+}
+
+// Map each output byte (register index) to the index of the scale register
+// that applies to it. Compact scales are shared by several output bytes, so the
+// returned vector may repeat scale indices.
+template <typename OpT>
+SmallVector<int> computeScaleRegisters(OpT op, int64_t numOutputValues) {
+  MLIRContext *ctx = op.getContext();
+  auto outputTy = op.getOutput().getType();
+  auto scaleTy = op.getScale().getType();
+  int64_t axis = op.getAxis();
+  int64_t elementsPerScale =
+      outputTy.getShape()[axis] / scaleTy.getShape()[axis];
+
+  LinearLayout outputLL = triton::gpu::toLinearLayout(outputTy);
+  auto kReg = StringAttr::get(ctx, "register");
+  auto kLane = StringAttr::get(ctx, "lane");
+  auto kWarp = StringAttr::get(ctx, "warp");
+  auto kBlock = StringAttr::get(ctx, "block");
+  // unpackUniqueTensorElements drops registers that only broadcast an already
+  // held scale value. Use the same compact register space for scale indexing.
+  LinearLayout scaleLL =
+      triton::gpu::toLinearLayout(scaleTy).removeZeroBasesAlongDim(kReg);
+
+  auto outputToScaleLL =
+      OpT::computeScaleLayout(outputLL, axis, elementsPerScale);
+  assert(outputToScaleLL && "expected valid scale layout after verifier");
+  LinearLayout outputRegToScaleReg = outputToScaleLL->invertAndCompose(scaleLL);
+
+  SmallVector<int> scaleRegisters;
+  scaleRegisters.reserve(numOutputValues);
+  for (int i = 0; i < numOutputValues; ++i) {
+    auto scaleCoord = outputRegToScaleReg.apply(
+        {{kReg, i}, {kLane, 0}, {kWarp, 0}, {kBlock, 0}});
+    auto regIt = llvm::find_if(
+        scaleCoord, [&](const auto &dimVal) { return dimVal.first == kReg; });
+    assert(regIt != scaleCoord.end() && "scale register mapping missing");
+    scaleRegisters.push_back(regIt->second);
+  }
+  return scaleRegisters;
+}
+
+// Check that all values in [groupStart, groupStart + groupSize) map to the same
+// scale register, which is required for each hardware conversion group.
+LogicalResult verifyGroupUsesSingleScale(ConversionPatternRewriter &rewriter,
+                                         Operation *op,
+                                         ArrayRef<int> scaleRegisters,
+                                         int64_t groupStart, int groupSize,
+                                         StringRef failureMessage) {
+  int scaleReg = scaleRegisters[groupStart];
+  for (int j = 1; j < groupSize; ++j) {
+    if (scaleRegisters[groupStart + j] != scaleReg)
+      return rewriter.notifyMatchFailure(op, failureMessage);
+  }
+  return success();
+}
+
+struct ScaledDowncastFp4OpPattern
+    : ConvertOpToLLVMPattern<amdgpu::ScaledDowncastFp4Op> {
+  ScaledDowncastFp4OpPattern(const LLVMTypeConverter &converter,
+                             const AMD::TargetInfo &targetInfo,
+                             PatternBenefit benefit)
+      : ConvertOpToLLVMPattern(converter, benefit), targetInfo(targetInfo) {}
+
+  LogicalResult
+  matchAndRewrite(amdgpu::ScaledDowncastFp4Op downcastOp, OpAdaptor adaptor,
+                  ConversionPatternRewriter &rewriter) const override {
+    if (!targetInfo.supportsHwScaledDowncast())
+      return rewriter.notifyMatchFailure(
+          downcastOp, "scaled FP4 downcast requires CDNA4 or CDNA5");
+
+    auto loc = downcastOp.getLoc();
+    // `input` is the unpacked tensor: two consecutive register elements along
+    // `axis` (positions 2*byte and 2*byte+1) provide the low/high nibble of one
+    // output byte, so there are twice as many input registers as output bytes.
+    auto inputVals =
+        unpackUniqueTensorElements(loc, adaptor.getInput(), rewriter);
+    auto scaleVals =
+        unpackUniqueTensorElements(loc, adaptor.getScale(), rewriter);
+    assert(inputVals.size() % 2 == 0);
+    int64_t numOutputBytes = inputVals.size() / 2;
+
+    auto scaleRegisters = computeScaleRegisters(downcastOp, numOutputBytes);
+    auto b = TritonLLVMOpBuilder(loc, rewriter);
+    SmallVector<Value> results;
+    results.reserve(numOutputBytes);
+    Type inputElemTy = inputVals.front().getType();
+
+    if (targetInfo.supportsCvtPkScalePk8()) {
+      // Work on groups of 4 bytes since each intrinsic packs 8 fp4 values.
+      Value zero = isa<Float32Type>(inputElemTy)
+                       ? b.f32_val(0.0)
+                       : b.bitcast(b.i16_val(0), inputElemTy);
+      for (int i = 0; i < numOutputBytes; i += 4) {
+        // Note that groupSize is in bytes not in fp4 values.
+        int groupSize = std::min<int>(4, numOutputBytes - i);
+        if (failed(verifyGroupUsesSingleScale(
+                rewriter, downcastOp, scaleRegisters, i, groupSize,
+                "each gfx1250 pk8 conversion group must share one scale")))
+          return failure();
+        int scaleReg = scaleRegisters[i];
+
+        // Gather the group's 8 unpacked values (low/high nibble per byte),
+        // zero-padding the tail of an incomplete group.
+        Value src = b.undef(vec_ty(inputElemTy, 8));
+        for (int byte = 0; byte < 4; ++byte) {
+          Value low = byte < groupSize ? inputVals[2 * (i + byte)] : zero;
+          Value high = byte < groupSize ? inputVals[2 * (i + byte) + 1] : zero;
+          src = b.insert_element(src, low, b.i32_val(2 * byte));
+          src = b.insert_element(src, high, b.i32_val(2 * byte + 1));
+        }
+        Value scaleF32 = scaleToF32(b, scaleVals[scaleReg]);
+        Value packed;
+        if (isa<Float32Type>(inputElemTy))
+          packed = ROCDL::CvtScaleF32Pk8Fp4F32Op::create(rewriter, loc, i32_ty,
+                                                         src, scaleF32);
+        else if (isa<Float16Type>(inputElemTy))
+          packed = ROCDL::CvtScaleF32Pk8Fp4F16Op::create(rewriter, loc, i32_ty,
+                                                         src, scaleF32);
+        else
+          packed = ROCDL::CvtScaleF32Pk8Fp4Bf16Op::create(rewriter, loc, i32_ty,
+                                                          src, scaleF32);
+        // Split the packed i32 back into individual output bytes.
+        appendBytesFromWord(b, packed, groupSize, results);
+      }
+    } else {
+      // The pk(2) intrinsic scales and packs one value pair (2 fp inputs) into
+      // one byte of an i32 result. `byteSel` selects the byte to store into.
+      for (int i = 0; i < numOutputBytes; i += 4) {
+        int groupSize = std::min<int>(4, numOutputBytes - i);
+        Value packed = b.i32_val(0);
+        for (int byteSel = 0; byteSel < groupSize; ++byteSel) {
+          int idx = i + byteSel;
+          Value low = inputVals[2 * idx];
+          Value high = inputVals[2 * idx + 1];
+          Value scaleF32 = scaleToF32(b, scaleVals[scaleRegisters[idx]]);
+          if (isa<Float32Type>(inputElemTy)) {
+            packed = ROCDL::CvtScaleF32PkFp4F32Op::create(
+                rewriter, loc, i32_ty, packed, low, high, scaleF32, byteSel);
+          } else {
+            Value src = b.undef(vec_ty(inputElemTy, 2));
+            src = b.insert_element(src, low, b.i32_val(0));
+            src = b.insert_element(src, high, b.i32_val(1));
+            if (isa<Float16Type>(inputElemTy))
+              packed = ROCDL::CvtScaleF32PkFp4F16Op::create(
+                  rewriter, loc, i32_ty, packed, src, scaleF32, byteSel);
+            else
+              packed = ROCDL::CvtScaleF32PkFp4Bf16Op::create(
+                  rewriter, loc, i32_ty, packed, src, scaleF32, byteSel);
+          }
+        }
+        appendBytesFromWord(b, packed, groupSize, results);
+      }
+    }
+
+    Value result = packUniqueTensorElements(loc, getTypeConverter(), results,
+                                            rewriter, downcastOp.getType());
+    rewriter.replaceOp(downcastOp, result);
+    return success();
+  }
+
+  const AMD::TargetInfo &targetInfo;
+};
+
+struct ScaledDowncastFp8OpPattern
+    : ConvertOpToLLVMPattern<amdgpu::ScaledDowncastFp8Op> {
+  ScaledDowncastFp8OpPattern(const LLVMTypeConverter &converter,
+                             const AMD::TargetInfo &targetInfo,
+                             PatternBenefit benefit)
+      : ConvertOpToLLVMPattern(converter, benefit), targetInfo(targetInfo) {}
+
+  LogicalResult
+  matchAndRewrite(amdgpu::ScaledDowncastFp8Op downcastOp, OpAdaptor adaptor,
+                  ConversionPatternRewriter &rewriter) const override {
+    if (!targetInfo.supportsHwScaledDowncast())
+      return rewriter.notifyMatchFailure(
+          downcastOp, "scaled FP8 downcast requires CDNA4 or CDNA5");
+
+    auto loc = downcastOp.getLoc();
+    // fp8 downcast is elementwise: input and output share the same shape and
+    // encoding, so the number of output fp8 bytes equals the number of input
+    // values. The scale may be compact (one raw E8M0 byte shared by several
+    // consecutive values along `axis`), so map each output value to its scale
+    // register.
+    auto inputVals =
+        unpackUniqueTensorElements(loc, adaptor.getInput(), rewriter);
+    auto scaleVals =
+        unpackUniqueTensorElements(loc, adaptor.getScale(), rewriter);
+    int64_t numOutputBytes = inputVals.size();
+    auto scaleRegisters = computeScaleRegisters(downcastOp, numOutputBytes);
+
+    bool isE4M3 = isa<Float8E4M3FNType>(
+        downcastOp.getOutput().getType().getElementType());
+    auto b = TritonLLVMOpBuilder(loc, rewriter);
+    SmallVector<Value> results;
+    results.reserve(numOutputBytes);
+    Type inputElemTy = inputVals.front().getType();
+    Value zero = isa<Float32Type>(inputElemTy)
+                     ? b.f32_val(0.0)
+                     : b.bitcast(b.i16_val(0), inputElemTy);
+
+    if (targetInfo.supportsCvtPkScalePk8()) {
+      // Work on groups of 8 bytes since each intrinsic packs 8 fp8 values.
+      Type v2i32Ty = vec_ty(i32_ty, 2);
+      for (int i = 0; i < numOutputBytes; i += 8) {
+        int groupSize = std::min<int>(8, numOutputBytes - i);
+        if (failed(verifyGroupUsesSingleScale(
+                rewriter, downcastOp, scaleRegisters, i, groupSize,
+                "each gfx1250 pk8 conversion group must share one scale")))
+          return failure();
+        int scaleReg = scaleRegisters[i];
+        // Gather the group's 8 values, zero-padding an incomplete tail.
+        Value src = b.undef(vec_ty(inputElemTy, 8));
+        for (int j = 0; j < 8; ++j) {
+          Value v = j < groupSize ? inputVals[i + j] : zero;
+          src = b.insert_element(src, v, b.i32_val(j));
+        }
+        Value scaleF32 = scaleToF32(b, scaleVals[scaleReg]);
+        Value packed;
+        if (isa<Float32Type>(inputElemTy)) {
+          if (isE4M3)
+            packed = ROCDL::CvtScaleF32Pk8Fp8F32Op::create(
+                rewriter, loc, v2i32Ty, src, scaleF32);
+          else
+            packed = ROCDL::CvtScaleF32Pk8Bf8F32Op::create(
+                rewriter, loc, v2i32Ty, src, scaleF32);
+        } else if (isa<Float16Type>(inputElemTy)) {
+          if (isE4M3)
+            packed = ROCDL::CvtScaleF32Pk8Fp8F16Op::create(
+                rewriter, loc, v2i32Ty, src, scaleF32);
+          else
+            packed = ROCDL::CvtScaleF32Pk8Bf8F16Op::create(
+                rewriter, loc, v2i32Ty, src, scaleF32);
+        } else {
+          if (isE4M3)
+            packed = ROCDL::CvtScaleF32Pk8Fp8Bf16Op::create(
+                rewriter, loc, v2i32Ty, src, scaleF32);
+          else
+            packed = ROCDL::CvtScaleF32Pk8Bf8Bf16Op::create(
+                rewriter, loc, v2i32Ty, src, scaleF32);
+        }
+        // Extract each fp8 byte from the two packed i32 words (4 bytes each).
+        Value lo = b.extract_element(packed, b.i32_val(0));
+        Value hi = b.extract_element(packed, b.i32_val(1));
+        appendBytesFromWord(b, lo, std::min(groupSize, 4), results);
+        if (groupSize > 4)
+          appendBytesFromWord(b, hi, groupSize - 4, results);
+      }
+    } else {
+      // The pk intrinsic scales one value pair and writes the resulting 2 fp8
+      // bytes into one 16-bit lane (`pair`) of a 2xi16 accumulator.
+      Type v2i16Ty = vec_ty(i16_ty, 2);
+      for (int i = 0; i < numOutputBytes; i += 4) {
+        int groupSize = std::min<int>(4, numOutputBytes - i);
+        Value acc = b.undef(v2i16Ty);
+        int numPairs = (groupSize + 1) / 2;
+        for (int pair = 0; pair < numPairs; ++pair) {
+          int base = i + 2 * pair;
+          // The intrinsic applies a single scale to the pair, so both elements
+          // must map to one scale register.
+          int scaleReg = scaleRegisters[base];
+          if (base + 1 < i + groupSize && scaleRegisters[base + 1] != scaleReg)
+            return rewriter.notifyMatchFailure(
+                downcastOp,
+                "each CDNA4 pk conversion pair must share one scale");
+          Value scaleF32 = scaleToF32(b, scaleVals[scaleReg]);
+          Value e0 = inputVals[base];
+          Value e1 = base + 1 < i + groupSize ? inputVals[base + 1] : zero;
+          if (isa<Float32Type>(inputElemTy)) {
+            if (isE4M3)
+              acc = ROCDL::CvtScaleF32PkFp8F32Op::create(
+                  rewriter, loc, v2i16Ty, acc, e0, e1, scaleF32, pair);
+            else
+              acc = ROCDL::CvtScaleF32PkBf8F32Op::create(
+                  rewriter, loc, v2i16Ty, acc, e0, e1, scaleF32, pair);
+          } else {
+            Value s = b.undef(vec_ty(inputElemTy, 2));
+            s = b.insert_element(s, e0, b.i32_val(0));
+            s = b.insert_element(s, e1, b.i32_val(1));
+            if (isa<Float16Type>(inputElemTy)) {
+              if (isE4M3)
+                acc = ROCDL::CvtScaleF32PkFp8F16Op::create(
+                    rewriter, loc, v2i16Ty, acc, s, scaleF32, pair);
+              else
+                acc = ROCDL::CvtScaleF32PkBf8F16Op::create(
+                    rewriter, loc, v2i16Ty, acc, s, scaleF32, pair);
+            } else {
+              if (isE4M3)
+                acc = ROCDL::CvtScaleF32PkFp8Bf16Op::create(
+                    rewriter, loc, v2i16Ty, acc, s, scaleF32, pair);
+              else
+                acc = ROCDL::CvtScaleF32PkBf8Bf16Op::create(
+                    rewriter, loc, v2i16Ty, acc, s, scaleF32, pair);
+            }
+          }
+        }
+        // Extract each fp8 byte from the packed accumulator.
+        appendBytesFromWord(b, b.bitcast(acc, i32_ty), groupSize, results);
+      }
+    }
+
+    Value result = packUniqueTensorElements(loc, getTypeConverter(), results,
+                                            rewriter, downcastOp.getType());
+    rewriter.replaceOp(downcastOp, result);
+    return success();
+  }
+
+  const AMD::TargetInfo &targetInfo;
+};
+
+} // namespace
+
+void mlir::triton::AMD::populateScaledDowncastOpToLLVMPatterns(
+    LLVMTypeConverter &typeConverter, RewritePatternSet &patterns,
+    const AMD::TargetInfo &targetInfo, PatternBenefit benefit) {
+  patterns.add<ScaledDowncastFp4OpPattern>(typeConverter, targetInfo, benefit);
+  patterns.add<ScaledDowncastFp8OpPattern>(typeConverter, targetInfo, benefit);
+}

--- a/third_party/amd/lib/TritonAMDGPUDialectToLLVM/TritonAMDGPUToLLVMPatterns.cpp
+++ b/third_party/amd/lib/TritonAMDGPUDialectToLLVM/TritonAMDGPUToLLVMPatterns.cpp
@@ -11,5 +11,7 @@ void populateTritonAMDGPUToLLVMPatterns(LLVMTypeConverter &typeConverter,
   populateConcatOpToLLVMPatterns(typeConverter, patterns, benefit);
   populateScaledUpcastOpToLLVMPatterns(typeConverter, patterns, targetInfo,
                                        benefit);
+  populateScaledDowncastOpToLLVMPatterns(typeConverter, patterns, targetInfo,
+                                         benefit);
 }
 } // namespace mlir::triton::AMD

--- a/third_party/amd/lib/TritonAMDGPUToLLVM/TargetInfo.cpp
+++ b/third_party/amd/lib/TritonAMDGPUToLLVM/TargetInfo.cpp
@@ -799,6 +799,10 @@ bool TargetInfo::supportsHwScaledUpcast() const {
   return targetFeatures.supportsHwScaledUpcast();
 }
 
+bool TargetInfo::supportsHwScaledDowncast() const {
+  return targetFeatures.supportsHwScaledDowncast();
+}
+
 void TargetInfo::localLoadOpAnnotation(triton::gpu::LocalLoadOp localLoadOp,
                                        Operation *llLoadOp) const {
   if (requiresAliasInfoForAsyncOps())

--- a/third_party/amd/lib/TritonAMDGPUToLLVM/TargetInfo.h
+++ b/third_party/amd/lib/TritonAMDGPUToLLVM/TargetInfo.h
@@ -149,6 +149,7 @@ public:
   bool supportsPermlaneSwap() const;
   bool supportsCvtPkScalePk8() const;
   bool supportsHwScaledUpcast() const;
+  bool supportsHwScaledDowncast() const;
 
   void localLoadOpAnnotation(triton::gpu::LocalLoadOp localLoadOp,
                              Operation *llLoadOp) const override;

--- a/third_party/amd/python/test/test_gluon_cdna4.py
+++ b/third_party/amd/python/test/test_gluon_cdna4.py
@@ -1,0 +1,84 @@
+import pytest
+import torch
+
+from triton.experimental import gluon
+import triton.experimental.gluon.language as ttgl
+from triton._internal_testing import is_hip_cdna4
+
+
+@gluon.jit
+def scaled_downcast_fp4_kernel(
+    input_ptr,
+    scale_ptr,
+    output_ptr,
+    BLOCK_M: ttgl.constexpr,
+    BLOCK_K: ttgl.constexpr,
+):
+    # BLOCK_K is the packed output width along the scaled axis; the unpacked
+    # input is twice as wide.
+    out_layout: ttgl.constexpr = ttgl.BlockedLayout([1, 4], [8, 8], [1, 1], [1, 0])
+    in_layout: ttgl.constexpr = ttgl.BlockedLayout([1, 8], [8, 8], [1, 1], [1, 0])
+    scale_layout: ttgl.constexpr = ttgl.DistributedLinearLayout(
+        reg_bases=[[8, 0]],
+        lane_bases=[
+            [0, 0],
+            [0, 0],
+            [0, 1],
+            [1, 0],
+            [2, 0],
+            [4, 0],
+        ],
+        warp_bases=[],
+        block_bases=[],
+        shape=[BLOCK_M, BLOCK_K // 16],
+    )
+    in_offsets_m = ttgl.arange(0, BLOCK_M, layout=ttgl.SliceLayout(1, in_layout))
+    in_offsets_k = ttgl.arange(0, 2 * BLOCK_K, layout=ttgl.SliceLayout(0, in_layout))
+    in_offsets = in_offsets_m[:, None] * (2 * BLOCK_K) + in_offsets_k[None, :]
+    input = ttgl.load(input_ptr + in_offsets)
+
+    scale_offsets_m = ttgl.arange(0, BLOCK_M, layout=ttgl.SliceLayout(1, scale_layout))
+    scale_offsets_k = ttgl.arange(0, BLOCK_K // 16, layout=ttgl.SliceLayout(0, scale_layout))
+    scale_offsets = (scale_offsets_m[:, None] * (BLOCK_K // 16) + scale_offsets_k[None, :])
+    scale = ttgl.load(scale_ptr + scale_offsets)
+
+    output = ttgl.amd.cdna4.scaled_downcast(input, scale, "e2m1", axis=1)
+
+    out_offsets_m = ttgl.arange(0, BLOCK_M, layout=ttgl.SliceLayout(1, out_layout))
+    out_offsets_k = ttgl.arange(0, BLOCK_K, layout=ttgl.SliceLayout(0, out_layout))
+    out_offsets = out_offsets_m[:, None] * BLOCK_K + out_offsets_k[None, :]
+    ttgl.store(output_ptr + out_offsets, output)
+
+
+@pytest.mark.skipif(not is_hip_cdna4(), reason="Requires CDNA4")
+@pytest.mark.parametrize(
+    "dtype,instruction_suffix",
+    [
+        (torch.float16, "f16"),
+        (torch.bfloat16, "bf16"),
+        (torch.float32, "f32"),
+    ],
+)
+def test_runtime_scaled_downcast_fp4(dtype, instruction_suffix):
+    block_m, block_k = 16, 32
+    # Interleave 1.0 (low nibble) and 2.0 (high nibble) so every packed byte is
+    # e2m1(1.0) | (e2m1(2.0) << 4) == 0x42.
+    input = torch.empty((block_m, 2 * block_k), dtype=dtype)
+    input[:, 0::2] = 1.0
+    input[:, 1::2] = 2.0
+    input = input.cuda()
+    scale = torch.full((block_m, block_k // 16), 127, dtype=torch.uint8).cuda()
+    output = torch.empty((block_m, block_k), dtype=torch.uint8, device="cuda")
+
+    program = scaled_downcast_fp4_kernel[(1, )](
+        input,
+        scale,
+        output,
+        block_m,
+        block_k,
+        num_warps=1,
+    )
+
+    expected = torch.full((block_m, block_k), 0x42, dtype=torch.uint8)
+    torch.testing.assert_close(output.cpu(), expected)
+    assert (f"v_cvt_scalef32_pk_fp4_{instruction_suffix}" in program.asm["amdgcn"])

--- a/third_party/amd/python/test/test_gluon_cdna5.py
+++ b/third_party/amd/python/test/test_gluon_cdna5.py
@@ -343,6 +343,109 @@ def test_runtime_scaled_upcast_fp8_non_broadcast_block16():
     torch.testing.assert_close(y.cpu(), y_ref, atol=0, rtol=0)
 
 
+@pytest.mark.skipif(not is_hip_gfx1250(), reason="Requires CDNA5")
+@pytest.mark.parametrize("dtype,ttgl_dtype,in_suffix", [
+    (torch.float16, ttgl.float16, "f16"),
+    (torch.bfloat16, ttgl.bfloat16, "bf16"),
+    (torch.float32, ttgl.float32, "f32"),
+], ids=lambda v: getattr(v, "__name__", str(v)))
+@pytest.mark.parametrize("BLOCK_K", [64, 128, 256], ids=lambda v: f"BLOCK_K{v}")
+def test_runtime_scaled_downcast_fp4(dtype, ttgl_dtype, in_suffix, BLOCK_K):
+    # Inverse of test_runtime_scaled_upcast_fp4 (compact scale): pack unpacked
+    # high-precision values back to fp4 through the gfx1250 pk8 instruction.
+
+    @gluon.jit
+    def scaled_downcast_fp4_kernel(x_ptr, scale_ptr, y_ptr, BLOCK_M: ttgl.constexpr, BLOCK_K: ttgl.constexpr,
+                                   SCALE_FACTOR: ttgl.constexpr):
+        compact_layout: ttgl.constexpr = ttgl.BlockedLayout([1, BLOCK_K // SCALE_FACTOR], [8, 4], [4, 1], [1, 0])
+        unpacked_layout: ttgl.constexpr = ttgl.BlockedLayout([1, 8], [8, 4], [4, 1], [1, 0])
+
+        # `input` is the unpacked tile (twice as wide as the packed output).
+        offs_m = ttgl.arange(0, BLOCK_M, layout=ttgl.SliceLayout(1, unpacked_layout))
+        offs_k = ttgl.arange(0, BLOCK_K, layout=ttgl.SliceLayout(0, unpacked_layout))
+        x = ttgl.load(x_ptr + offs_m[:, None] * BLOCK_K + offs_k[None, :])
+
+        scale_k: ttgl.constexpr = BLOCK_K // SCALE_FACTOR
+        offs_scale_m = ttgl.arange(0, BLOCK_M, layout=ttgl.SliceLayout(1, compact_layout))
+        offs_scale_k = ttgl.arange(0, scale_k, layout=ttgl.SliceLayout(0, compact_layout))
+        scale = ttgl.load(scale_ptr + offs_scale_m[:, None] * scale_k + offs_scale_k[None, :])
+
+        y = ttgl.amd.cdna5.scaled_downcast(x, scale, "e2m1", axis=1)
+        out_layout: ttgl.constexpr = y.type.layout
+        offs_out_m = ttgl.arange(0, BLOCK_M, layout=ttgl.SliceLayout(1, out_layout))
+        offs_out_k = ttgl.arange(0, BLOCK_K // 2, layout=ttgl.SliceLayout(0, out_layout))
+        ttgl.store(y_ptr + offs_out_m[:, None] * (BLOCK_K // 2) + offs_out_k[None, :], y)
+
+    BLOCK_M = 16
+    SCALE_FACTOR = 32
+    torch.manual_seed(42)
+
+    # `packed` is the fp4 answer; `unpacked_ref` its per-element float values.
+    packed, unpacked_ref = create_mxfp_operand(0, BLOCK_M, BLOCK_K, "e2m1")
+    scale, scale_ref = create_mxfp_scale(0, BLOCK_M, BLOCK_K, "e8m0", SCALE_FACTOR)
+    # input = answer * scale, so downcast(input / scale) recovers the fp4 bytes.
+    x = (unpacked_ref * scale_ref).to(dtype).contiguous()
+    y = torch.empty((BLOCK_M, BLOCK_K // 2), dtype=torch.uint8, device="cuda")
+
+    pgm = scaled_downcast_fp4_kernel[(1, )](x.cuda(), scale.cuda(), y, BLOCK_M, BLOCK_K, SCALE_FACTOR, num_warps=4)
+
+    assert f"v_cvt_scalef32_pk8_fp4_{in_suffix}" in pgm.asm["amdgcn"]
+    torch.testing.assert_close(y.cpu(), packed, atol=0, rtol=0)
+
+
+@pytest.mark.skipif(not is_hip_gfx1250(), reason="Requires CDNA5")
+@pytest.mark.parametrize("fp8_dtype", ["e4m3", "e5m2"])
+@pytest.mark.parametrize("dtype,ttgl_dtype,in_suffix", [
+    (torch.float16, ttgl.float16, "f16"),
+    (torch.bfloat16, ttgl.bfloat16, "bf16"),
+    (torch.float32, ttgl.float32, "f32"),
+], ids=lambda v: getattr(v, "__name__", str(v)))
+def test_runtime_scaled_downcast_fp8(fp8_dtype, dtype, ttgl_dtype, in_suffix):
+    # Cover the eight v_cvt_scalef32_pk8 fp8 downcast instructions:
+    # {f16,bf16,f32} input x {fp8 (e4m3), bf8 (e5m2)} output.
+    # fp8 downcast is elementwise, but the scale is compact along `axis` (one
+    # E8M0 byte per SCALE_FACTOR values), so the 8 values of each pk8 group
+    # share a single scale.
+    torch_fp8 = {"e4m3": torch.float8_e4m3fn, "e5m2": torch.float8_e5m2}[fp8_dtype]
+    out_mnemonic = {"e4m3": "fp8", "e5m2": "bf8"}[fp8_dtype]
+
+    @gluon.jit
+    def scaled_downcast_fp8_kernel(x_ptr, scale_ptr, y_ptr, BLOCK_M: ttgl.constexpr, BLOCK_K: ttgl.constexpr,
+                                   SCALE_FACTOR: ttgl.constexpr, FORMAT: ttgl.constexpr):
+        compact_layout: ttgl.constexpr = ttgl.BlockedLayout([1, BLOCK_K // SCALE_FACTOR], [8, 4], [4, 1], [1, 0])
+        layout: ttgl.constexpr = ttgl.BlockedLayout([1, 8], [8, 4], [4, 1], [1, 0])
+
+        offs_m = ttgl.arange(0, BLOCK_M, layout=ttgl.SliceLayout(1, layout))
+        offs_k = ttgl.arange(0, BLOCK_K, layout=ttgl.SliceLayout(0, layout))
+        x = ttgl.load(x_ptr + offs_m[:, None] * BLOCK_K + offs_k[None, :])
+
+        scale_k: ttgl.constexpr = BLOCK_K // SCALE_FACTOR
+        offs_scale_m = ttgl.arange(0, BLOCK_M, layout=ttgl.SliceLayout(1, compact_layout))
+        offs_scale_k = ttgl.arange(0, scale_k, layout=ttgl.SliceLayout(0, compact_layout))
+        scale = ttgl.load(scale_ptr + offs_scale_m[:, None] * scale_k + offs_scale_k[None, :])
+
+        y = ttgl.amd.cdna5.scaled_downcast(x, scale, FORMAT, axis=1)
+        ttgl.store(y_ptr + offs_m[:, None] * BLOCK_K + offs_k[None, :], y)
+
+    BLOCK_M = 16
+    BLOCK_K = 64
+    SCALE_FACTOR = 32
+    torch.manual_seed(42)
+
+    # `v` is the fp8 answer bytes; `v_ref` its float values.
+    v, v_ref = create_mxfp_operand(0, BLOCK_M, BLOCK_K, fp8_dtype)
+    scale, scale_ref = create_mxfp_scale(0, BLOCK_M, BLOCK_K, "e8m0", SCALE_FACTOR)
+    # input = answer * scale, so downcast(input / scale) recovers the fp8 bytes.
+    x = (v_ref * scale_ref).to(dtype).contiguous()
+    y = torch.empty((BLOCK_M, BLOCK_K), dtype=torch_fp8, device="cuda")
+
+    pgm = scaled_downcast_fp8_kernel[(1, )](x.cuda(), scale.cuda(), y, BLOCK_M, BLOCK_K, SCALE_FACTOR, fp8_dtype,
+                                            num_warps=4)
+
+    assert f"v_cvt_scalef32_pk8_{out_mnemonic}_{in_suffix}" in pgm.asm["amdgcn"]
+    torch.testing.assert_close(y.view(torch.uint8).cpu(), v, atol=0, rtol=0)
+
+
 @pytest.mark.parametrize("a_dtype,b_dtype,k_dim", get_test_gemm_variants())
 @pytest.mark.parametrize("BLOCK_M,BLOCK_N,BLOCK_K", get_test_gemm_block_mnk())
 @pytest.mark.parametrize("M,N,K", get_test_gemm_shapes())


### PR DESCRIPTION
Introduces `amdgpu.scaled_downcast_fp4/8` to convert a tensor of (b)f16/f32 to mxfp4 or mxfp8. One scale element has to be used by 8 or more contiguous input/output elements along `axis` so the scale tensor is expected to be of smaller dimension than the input.
On supported architectures (CDNA4 and CDNA5) this will lower to packed hardware accelerated instructions offering greatly improved throughput compared to the traditional SW path.