### PR TITLE
[AMD] Carry buffer-op base address space in the op format

### DIFF
--- a/include/triton/Dialect/Triton/IR/Types.h
+++ b/include/triton/Dialect/Triton/IR/Types.h
@@ -29,7 +29,7 @@ Type getI32SameShape(Type type);
 
 Type getPointerTypeSameShape(Type type);
 
-Type getPointerTypeToElement(Type type);
+bool elementTypeMatchesPointee(Type valueTy, Type ptrTy);
 
 } // namespace triton
 

--- a/lib/Dialect/Triton/IR/Types.cpp
+++ b/lib/Dialect/Triton/IR/Types.cpp
@@ -160,10 +160,9 @@ Type getPointerTypeSameShape(Type type) {
   }
 }
 
-Type getPointerTypeToElement(Type type) {
-  Type elementType = getElementTypeOrSelf(type);
-  PointerType ptrType = PointerType::get(elementType, 1);
-  return ptrType;
+bool elementTypeMatchesPointee(Type valueTy, Type ptrTy) {
+  auto ptrType = dyn_cast<PointerType>(ptrTy);
+  return ptrType && getElementTypeOrSelf(valueTy) == ptrType.getPointeeType();
 }
 
 // upstream Triton only uses address space 1 for Pointer Type

--- a/python/test/gluon/test_frontend.py
+++ b/python/test/gluon/test_frontend.py
@@ -3488,20 +3488,20 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.targ
     %cst = arith.constant dense<true> : tensor<64x64xi1, #blocked>
     %cst_0 = arith.constant 1.000000e+00 : f32
     %cst_1 = arith.constant dense<1.000000e+00> : tensor<64x64xf32, #blocked>
-    %3 = amdg.buffer_load %arg0[%2], %cst, %cst_1 cacheModifier = ca : tensor<64x64xf32, #blocked>
-    amdg.buffer_store %3, %arg1[%2], %cst cacheModifier = cs : tensor<64x64xf32, #blocked>
-    %4 = amdg.buffer_load %arg0[%2], %cst, %cst_1 cacheModifier = ca : tensor<64x64xf32, #blocked>
-    amdg.buffer_store %4, %arg1[%2], %cst cacheModifier = cs : tensor<64x64xf32, #blocked>
+    %3 = amdg.buffer_load %arg0[%2], %cst, %cst_1 cacheModifier = ca : <f32> -> tensor<64x64xf32, #blocked>
+    amdg.buffer_store %3, %arg1[%2], %cst cacheModifier = cs : <f32> -> tensor<64x64xf32, #blocked>
+    %4 = amdg.buffer_load %arg0[%2], %cst, %cst_1 cacheModifier = ca : <f32> -> tensor<64x64xf32, #blocked>
+    amdg.buffer_store %4, %arg1[%2], %cst cacheModifier = cs : <f32> -> tensor<64x64xf32, #blocked>
     %true_2 = arith.constant true
     %cst_3 = arith.constant dense<true> : tensor<64x64xi1, #gluon.auto_encoding>
     %cst_4 = arith.constant 1.000000e+00 : f32
     %cst_5 = arith.constant dense<1.000000e+00> : tensor<64x64xf32, #gluon.auto_encoding>
     %5 = gluon.set_auto_layout %cst_3 : tensor<64x64xi1, #gluon.auto_encoding> -> tensor<64x64xi1, #blocked>
     %6 = gluon.set_auto_layout %cst_5 : tensor<64x64xf32, #gluon.auto_encoding> -> tensor<64x64xf32, #blocked>
-    %7 = amdg.buffer_load %arg0[%2], %5, %6 : tensor<64x64xf32, #blocked>
+    %7 = amdg.buffer_load %arg0[%2], %5, %6 : <f32> -> tensor<64x64xf32, #blocked>
     %8 = gluon.set_auto_layout %1 : tensor<64x64xi32, #gluon.auto_encoding> -> tensor<64x64xi32, #blocked>
     %9 = gluon.set_auto_layout %cst_3 : tensor<64x64xi1, #gluon.auto_encoding> -> tensor<64x64xi1, #blocked>
-    amdg.buffer_store %7, %arg1[%8], %9 : tensor<64x64xf32, #blocked>
+    amdg.buffer_store %7, %arg1[%8], %9 : <f32> -> tensor<64x64xf32, #blocked>
     tt.return
   }
 }
@@ -3548,23 +3548,23 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.targ
     %cst_1 = arith.constant dense<true> : tensor<64x1xi1, #blocked>
     %3 = tt.broadcast %cst_1 : tensor<64x1xi1, #blocked> -> tensor<64x64xi1, #blocked>
     %4 = arith.truncf %cst_0 : tensor<64x64xf32, #blocked> to tensor<64x64xf16, #blocked>
-    %5 = amdg.buffer_load %arg0[%2], %3, %4 cacheModifier = ca : tensor<64x64xf16, #blocked>
+    %5 = amdg.buffer_load %arg0[%2], %3, %4 cacheModifier = ca : <f16> -> tensor<64x64xf16, #blocked>
     %6 = tt.broadcast %cst_1 : tensor<64x1xi1, #blocked> -> tensor<64x64xi1, #blocked>
-    amdg.buffer_store %5, %arg1[%2], %6 cacheModifier = cs : tensor<64x64xf16, #blocked>
+    amdg.buffer_store %5, %arg1[%2], %6 cacheModifier = cs : <f16> -> tensor<64x64xf16, #blocked>
     %true_2 = arith.constant true
     %cst_3 = arith.constant dense<true> : tensor<1x64xi1, #blocked>
     %7 = tt.broadcast %cst_3 : tensor<1x64xi1, #blocked> -> tensor<64x64xi1, #blocked>
     %8 = arith.truncf %cst_0 : tensor<64x64xf32, #blocked> to tensor<64x64xf16, #blocked>
-    %9 = amdg.buffer_load %arg0[%2], %7, %8 cacheModifier = ca : tensor<64x64xf16, #blocked>
+    %9 = amdg.buffer_load %arg0[%2], %7, %8 cacheModifier = ca : <f16> -> tensor<64x64xf16, #blocked>
     %10 = tt.broadcast %cst_3 : tensor<1x64xi1, #blocked> -> tensor<64x64xi1, #blocked>
-    amdg.buffer_store %9, %arg1[%2], %10 cacheModifier = cs : tensor<64x64xf16, #blocked>
+    amdg.buffer_store %9, %arg1[%2], %10 cacheModifier = cs : <f16> -> tensor<64x64xf16, #blocked>
     %11 = tt.broadcast %cst_3 : tensor<1x64xi1, #blocked> -> tensor<64x64xi1, #blocked>
     %cst_4 = arith.constant 1.000000e+00 : f32
     %12 = arith.truncf %cst_4 : f32 to f16
     %13 = tt.splat %12 : f16 -> tensor<64x64xf16, #blocked>
-    %14 = amdg.buffer_load %arg0[%2], %11, %13 cacheModifier = ca : tensor<64x64xf16, #blocked>
+    %14 = amdg.buffer_load %arg0[%2], %11, %13 cacheModifier = ca : <f16> -> tensor<64x64xf16, #blocked>
     %15 = tt.broadcast %cst_3 : tensor<1x64xi1, #blocked> -> tensor<64x64xi1, #blocked>
-    amdg.buffer_store %14, %arg1[%2], %15 cacheModifier = cs : tensor<64x64xf16, #blocked>
+    amdg.buffer_store %14, %arg1[%2], %15 cacheModifier = cs : <f16> -> tensor<64x64xf16, #blocked>
     tt.return
   }
 }
@@ -4301,52 +4301,52 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.targ
     %0 = tt.make_range {end = 1 : i32, start = 0 : i32} : tensor<1xi32, #gluon.auto_encoding>
     %c1_i32 = arith.constant 1 : i32
     %cst = arith.constant dense<1> : tensor<1xi32, #gluon.auto_encoding>
-    %1 = amdg.buffer_atomic_rmw max, acq_rel, gpu, %cst, %arg0[%0] : tensor<1xi32, #gluon.auto_encoding>
-    %2 = amdg.buffer_atomic_rmw min, acq_rel, gpu, %cst, %arg0[%0] : tensor<1xi32, #gluon.auto_encoding>
-    %3 = amdg.buffer_atomic_rmw and, acq_rel, gpu, %cst, %arg0[%0] : tensor<1xi32, #gluon.auto_encoding>
-    %4 = amdg.buffer_atomic_rmw or, acq_rel, gpu, %cst, %arg0[%0] : tensor<1xi32, #gluon.auto_encoding>
+    %1 = amdg.buffer_atomic_rmw max, acq_rel, gpu, %cst, %arg0[%0] : <i32> -> tensor<1xi32, #gluon.auto_encoding>
+    %2 = amdg.buffer_atomic_rmw min, acq_rel, gpu, %cst, %arg0[%0] : <i32> -> tensor<1xi32, #gluon.auto_encoding>
+    %3 = amdg.buffer_atomic_rmw and, acq_rel, gpu, %cst, %arg0[%0] : <i32> -> tensor<1xi32, #gluon.auto_encoding>
+    %4 = amdg.buffer_atomic_rmw or, acq_rel, gpu, %cst, %arg0[%0] : <i32> -> tensor<1xi32, #gluon.auto_encoding>
     %c1_i32_0 = arith.constant 1 : i32
     %cst_1 = arith.constant dense<1> : tensor<1xi32, #gluon.auto_encoding>
-    %5 = amdg.buffer_atomic_rmw xor, acq_rel, gpu, %cst_1, %arg0[%0] : tensor<1xi32, #gluon.auto_encoding>
+    %5 = amdg.buffer_atomic_rmw xor, acq_rel, gpu, %cst_1, %arg0[%0] : <i32> -> tensor<1xi32, #gluon.auto_encoding>
     %c1_i32_2 = arith.constant 1 : i32
     %cst_3 = arith.constant dense<1> : tensor<1xi32, #gluon.auto_encoding>
-    %6 = amdg.buffer_atomic_rmw umax, acq_rel, gpu, %cst_3, %arg1[%0] : tensor<1xi32, #gluon.auto_encoding>
-    %7 = amdg.buffer_atomic_rmw umin, acq_rel, gpu, %cst_3, %arg1[%0] : tensor<1xi32, #gluon.auto_encoding>
-    %8 = amdg.buffer_atomic_rmw add, acq_rel, gpu, %cst_3, %arg1[%0] : tensor<1xi32, #gluon.auto_encoding>
+    %6 = amdg.buffer_atomic_rmw umax, acq_rel, gpu, %cst_3, %arg1[%0] : <i32> -> tensor<1xi32, #gluon.auto_encoding>
+    %7 = amdg.buffer_atomic_rmw umin, acq_rel, gpu, %cst_3, %arg1[%0] : <i32> -> tensor<1xi32, #gluon.auto_encoding>
+    %8 = amdg.buffer_atomic_rmw add, acq_rel, gpu, %cst_3, %arg1[%0] : <i32> -> tensor<1xi32, #gluon.auto_encoding>
     %9 = arith.extui %cst_3 : tensor<1xi32, #gluon.auto_encoding> to tensor<1xi64, #gluon.auto_encoding>
     %c0_i32 = arith.constant 0 : i32
     %c0_i32_4 = arith.constant 0 : i32
     %10 = arith.cmpi ne, %c0_i32, %c0_i32_4 : i32
     %11 = tt.splat %10 : i1 -> tensor<1xi1, #gluon.auto_encoding>
-    %12 = amdg.buffer_atomic_rmw exch, acq_rel, gpu, %9, %arg2[%0], %11 : tensor<1xi64, #gluon.auto_encoding>
+    %12 = amdg.buffer_atomic_rmw exch, acq_rel, gpu, %9, %arg2[%0], %11 : <i64> -> tensor<1xi64, #gluon.auto_encoding>
     %c1_i32_5 = arith.constant 1 : i32
     %cst_6 = arith.constant dense<1> : tensor<1xi32, #gluon.auto_encoding>
     %13 = tt.call @triton.experimental.gluon.language._standard.zeros__Tc1T_cfp16_cAL() : () -> tensor<1xf16, #gluon.auto_encoding>
     %c0_i32_7 = arith.constant 0 : i32
     %cst_8 = arith.constant dense<0> : tensor<1xi32, #gluon.auto_encoding>
     %14 = arith.cmpi ne, %cst_6, %cst_8 : tensor<1xi32, #gluon.auto_encoding>
-    %15 = amdg.buffer_atomic_rmw fadd, acq_rel, gpu, %13, %arg3[%0], %14 : tensor<1xf16, #gluon.auto_encoding>
+    %15 = amdg.buffer_atomic_rmw fadd, acq_rel, gpu, %13, %arg3[%0], %14 : <f16> -> tensor<1xf16, #gluon.auto_encoding>
     %c0_i32_9 = arith.constant 0 : i32
     %cst_10 = arith.constant dense<0> : tensor<1xi32, #gluon.auto_encoding>
     %16 = arith.cmpi ne, %cst_6, %cst_10 : tensor<1xi32, #gluon.auto_encoding>
-    %17 = amdg.buffer_atomic_rmw fadd, acq_rel, sys, %13, %arg3[%0], %16 : tensor<1xf16, #gluon.auto_encoding>
+    %17 = amdg.buffer_atomic_rmw fadd, acq_rel, sys, %13, %arg3[%0], %16 : <f16> -> tensor<1xf16, #gluon.auto_encoding>
     %c0_i32_11 = arith.constant 0 : i32
     %cst_12 = arith.constant dense<0> : tensor<1xi32, #gluon.auto_encoding>
     %18 = arith.cmpi ne, %cst_6, %cst_12 : tensor<1xi32, #gluon.auto_encoding>
-    %19 = amdg.buffer_atomic_rmw fadd, relaxed, cta, %13, %arg3[%0], %18 : tensor<1xf16, #gluon.auto_encoding>
+    %19 = amdg.buffer_atomic_rmw fadd, relaxed, cta, %13, %arg3[%0], %18 : <f16> -> tensor<1xf16, #gluon.auto_encoding>
     %20 = arith.extf %13 : tensor<1xf16, #gluon.auto_encoding> to tensor<1xf32, #gluon.auto_encoding>
     %c0_i32_13 = arith.constant 0 : i32
     %cst_14 = arith.constant dense<0> : tensor<1xi32, #gluon.auto_encoding>
     %21 = arith.cmpi ne, %cst_6, %cst_14 : tensor<1xi32, #gluon.auto_encoding>
-    %22 = amdg.buffer_atomic_rmw fadd, acq_rel, gpu, %20, %arg4[%0], %21 : tensor<1xf32, #gluon.auto_encoding>
+    %22 = amdg.buffer_atomic_rmw fadd, acq_rel, gpu, %20, %arg4[%0], %21 : <f32> -> tensor<1xf32, #gluon.auto_encoding>
     %c0_i32_15 = arith.constant 0 : i32
     %cst_16 = arith.constant dense<0> : tensor<1xi32, #gluon.auto_encoding>
     %23 = arith.cmpi ne, %cst_6, %cst_16 : tensor<1xi32, #gluon.auto_encoding>
-    %24 = amdg.buffer_atomic_rmw fadd, acq_rel, sys, %20, %arg4[%0], %23 : tensor<1xf32, #gluon.auto_encoding>
+    %24 = amdg.buffer_atomic_rmw fadd, acq_rel, sys, %20, %arg4[%0], %23 : <f32> -> tensor<1xf32, #gluon.auto_encoding>
     %c0_i32_17 = arith.constant 0 : i32
     %cst_18 = arith.constant dense<0> : tensor<1xi32, #gluon.auto_encoding>
     %25 = arith.cmpi ne, %cst_6, %cst_18 : tensor<1xi32, #gluon.auto_encoding>
-    %26 = amdg.buffer_atomic_rmw fadd, relaxed, cta, %20, %arg4[%0], %25 : tensor<1xf32, #gluon.auto_encoding>
+    %26 = amdg.buffer_atomic_rmw fadd, relaxed, cta, %20, %arg4[%0], %25 : <f32> -> tensor<1xf32, #gluon.auto_encoding>
     tt.return
   }
   tt.func private @triton.experimental.gluon.language._standard.zeros__Tc1T_cfp16_cAL() -> tensor<1xf16, #gluon.auto_encoding> attributes {noinline = false} {
@@ -4385,17 +4385,17 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.targ
     %c0_i32_0 = arith.constant 0 : i32
     %2 = arith.cmpi ne, %c0_i32, %c0_i32_0 : i32
     %3 = tt.splat %2 : i1 -> tensor<1xi1, #gluon.auto_encoding>
-    %4 = amdg.buffer_atomic_rmw fadd, acq_rel, gpu, %1, %arg0[%0], %3 : tensor<1xbf16, #gluon.auto_encoding>
+    %4 = amdg.buffer_atomic_rmw fadd, acq_rel, gpu, %1, %arg0[%0], %3 : <bf16> -> tensor<1xbf16, #gluon.auto_encoding>
     %c1_i32 = arith.constant 1 : i32
     %cst = arith.constant dense<1> : tensor<1xi32, #gluon.auto_encoding>
     %c0_i32_1 = arith.constant 0 : i32
     %cst_2 = arith.constant dense<0> : tensor<1xi32, #gluon.auto_encoding>
     %5 = arith.cmpi ne, %cst, %cst_2 : tensor<1xi32, #gluon.auto_encoding>
-    %6 = amdg.buffer_atomic_rmw fadd, acq_rel, sys, %1, %arg0[%0], %5 : tensor<1xbf16, #gluon.auto_encoding>
+    %6 = amdg.buffer_atomic_rmw fadd, acq_rel, sys, %1, %arg0[%0], %5 : <bf16> -> tensor<1xbf16, #gluon.auto_encoding>
     %c0_i32_3 = arith.constant 0 : i32
     %cst_4 = arith.constant dense<0> : tensor<1xi32, #gluon.auto_encoding>
     %7 = arith.cmpi ne, %cst, %cst_4 : tensor<1xi32, #gluon.auto_encoding>
-    %8 = amdg.buffer_atomic_rmw fadd, relaxed, cta, %1, %arg0[%0], %7 : tensor<1xbf16, #gluon.auto_encoding>
+    %8 = amdg.buffer_atomic_rmw fadd, relaxed, cta, %1, %arg0[%0], %7 : <bf16> -> tensor<1xbf16, #gluon.auto_encoding>
     tt.return
   }
   tt.func private @triton.experimental.gluon.language._standard.zeros__Tc1T_cbf16_cAL() -> tensor<1xbf16, #gluon.auto_encoding> attributes {noinline = false} {

--- a/python/test/gluon/test_frontend.py
+++ b/python/test/gluon/test_frontend.py
@@ -3421,10 +3421,10 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.targ
     %6 = tt.broadcast %4 : tensor<128x1xi32, #blocked> -> tensor<128x16xi32, #blocked>
     %7 = tt.broadcast %5 : tensor<1x16xi32, #blocked> -> tensor<128x16xi32, #blocked>
     %8 = arith.addi %6, %7 : tensor<128x16xi32, #blocked>
-    %9 = amdg.buffer_load_to_local %arg0[%8] into %0 : <f16>[tensor<128x16xi32, #blocked>]  -> <128x16xf16, #shared, #smem, mutable>
-    %10 = amdg.buffer_load_to_local %arg0[%8] cacheModifier = ca into %0 : <f16>[tensor<128x16xi32, #blocked>]  -> <128x16xf16, #shared, #smem, mutable>
-    %11 = amdg.buffer_load_to_local %arg0[%8] cacheModifier = cg into %0 : <f16>[tensor<128x16xi32, #blocked>]  -> <128x16xf16, #shared, #smem, mutable>
-    %12 = amdg.buffer_load_to_local %arg0[%8] cacheModifier = cv into %0 : <f16>[tensor<128x16xi32, #blocked>]  -> <128x16xf16, #shared, #smem, mutable>
+    %9 = amdg.buffer_load_to_local %arg0[%8] into %0 : !tt.ptr<f16>[tensor<128x16xi32, #blocked>]  -> <128x16xf16, #shared, #smem, mutable>
+    %10 = amdg.buffer_load_to_local %arg0[%8] cacheModifier = ca into %0 : !tt.ptr<f16>[tensor<128x16xi32, #blocked>]  -> <128x16xf16, #shared, #smem, mutable>
+    %11 = amdg.buffer_load_to_local %arg0[%8] cacheModifier = cg into %0 : !tt.ptr<f16>[tensor<128x16xi32, #blocked>]  -> <128x16xf16, #shared, #smem, mutable>
+    %12 = amdg.buffer_load_to_local %arg0[%8] cacheModifier = cv into %0 : !tt.ptr<f16>[tensor<128x16xi32, #blocked>]  -> <128x16xf16, #shared, #smem, mutable>
     %c64_i32 = arith.constant 64 : i32
     %cst_1 = arith.constant dense<64> : tensor<128xi32, #ttg.slice<{dim = 1, parent = #blocked}>>
     %13 = arith.cmpi slt, %1, %cst_1 : tensor<128xi32, #ttg.slice<{dim = 1, parent = #blocked}>>
@@ -3432,17 +3432,17 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.targ
     %cst_2 = arith.constant 0.000000e+00 : f16
     %cst_3 = arith.constant dense<0.000000e+00> : tensor<128x16xf16, #blocked>
     %15 = tt.broadcast %14 : tensor<128x1xi1, #blocked> -> tensor<128x16xi1, #blocked>
-    %16 = amdg.buffer_load_to_local %arg0[%8] mask = %15 other = %cst_3 into %0 : <f16>[tensor<128x16xi32, #blocked>] tensor<128x16xf16, #blocked> -> <128x16xf16, #shared, #smem, mutable>
+    %16 = amdg.buffer_load_to_local %arg0[%8] mask = %15 other = %cst_3 into %0 : !tt.ptr<f16>[tensor<128x16xi32, #blocked>] tensor<128x16xf16, #blocked> -> <128x16xf16, #shared, #smem, mutable>
     %cst_4 = arith.constant 0.000000e+00 : f16
     %cst_5 = arith.constant dense<0.000000e+00> : tensor<128x1xf16, #blocked>
     %17 = tt.broadcast %14 : tensor<128x1xi1, #blocked> -> tensor<128x16xi1, #blocked>
     %18 = tt.broadcast %cst_5 : tensor<128x1xf16, #blocked> -> tensor<128x16xf16, #blocked>
-    %19 = amdg.buffer_load_to_local %arg0[%8] mask = %17 other = %18 into %0 : <f16>[tensor<128x16xi32, #blocked>] tensor<128x16xf16, #blocked> -> <128x16xf16, #shared, #smem, mutable>
+    %19 = amdg.buffer_load_to_local %arg0[%8] mask = %17 other = %18 into %0 : !tt.ptr<f16>[tensor<128x16xi32, #blocked>] tensor<128x16xf16, #blocked> -> <128x16xf16, #shared, #smem, mutable>
     %20 = tt.broadcast %14 : tensor<128x1xi1, #blocked> -> tensor<128x16xi1, #blocked>
     %cst_6 = arith.constant 0.000000e+00 : f32
     %21 = arith.truncf %cst_6 : f32 to f16
     %22 = tt.splat %21 : f16 -> tensor<128x16xf16, #blocked>
-    %23 = amdg.buffer_load_to_local %arg0[%8] mask = %20 other = %22 into %0 : <f16>[tensor<128x16xi32, #blocked>] tensor<128x16xf16, #blocked> -> <128x16xf16, #shared, #smem, mutable>
+    %23 = amdg.buffer_load_to_local %arg0[%8] mask = %20 other = %22 into %0 : !tt.ptr<f16>[tensor<128x16xi32, #blocked>] tensor<128x16xf16, #blocked> -> <128x16xf16, #shared, #smem, mutable>
     tt.return
   }
 }
@@ -3488,20 +3488,20 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.targ
     %cst = arith.constant dense<true> : tensor<64x64xi1, #blocked>
     %cst_0 = arith.constant 1.000000e+00 : f32
     %cst_1 = arith.constant dense<1.000000e+00> : tensor<64x64xf32, #blocked>
-    %3 = amdg.buffer_load %arg0[%2], %cst, %cst_1 cacheModifier = ca : <f32> -> tensor<64x64xf32, #blocked>
-    amdg.buffer_store %3, %arg1[%2], %cst cacheModifier = cs : <f32> -> tensor<64x64xf32, #blocked>
-    %4 = amdg.buffer_load %arg0[%2], %cst, %cst_1 cacheModifier = ca : <f32> -> tensor<64x64xf32, #blocked>
-    amdg.buffer_store %4, %arg1[%2], %cst cacheModifier = cs : <f32> -> tensor<64x64xf32, #blocked>
+    %3 = amdg.buffer_load %arg0[%2], %cst, %cst_1 cacheModifier = ca : !tt.ptr<f32> -> tensor<64x64xf32, #blocked>
+    amdg.buffer_store %3, %arg1[%2], %cst cacheModifier = cs : !tt.ptr<f32> -> tensor<64x64xf32, #blocked>
+    %4 = amdg.buffer_load %arg0[%2], %cst, %cst_1 cacheModifier = ca : !tt.ptr<f32> -> tensor<64x64xf32, #blocked>
+    amdg.buffer_store %4, %arg1[%2], %cst cacheModifier = cs : !tt.ptr<f32> -> tensor<64x64xf32, #blocked>
     %true_2 = arith.constant true
     %cst_3 = arith.constant dense<true> : tensor<64x64xi1, #gluon.auto_encoding>
     %cst_4 = arith.constant 1.000000e+00 : f32
     %cst_5 = arith.constant dense<1.000000e+00> : tensor<64x64xf32, #gluon.auto_encoding>
     %5 = gluon.set_auto_layout %cst_3 : tensor<64x64xi1, #gluon.auto_encoding> -> tensor<64x64xi1, #blocked>
     %6 = gluon.set_auto_layout %cst_5 : tensor<64x64xf32, #gluon.auto_encoding> -> tensor<64x64xf32, #blocked>
-    %7 = amdg.buffer_load %arg0[%2], %5, %6 : <f32> -> tensor<64x64xf32, #blocked>
+    %7 = amdg.buffer_load %arg0[%2], %5, %6 : !tt.ptr<f32> -> tensor<64x64xf32, #blocked>
     %8 = gluon.set_auto_layout %1 : tensor<64x64xi32, #gluon.auto_encoding> -> tensor<64x64xi32, #blocked>
     %9 = gluon.set_auto_layout %cst_3 : tensor<64x64xi1, #gluon.auto_encoding> -> tensor<64x64xi1, #blocked>
-    amdg.buffer_store %7, %arg1[%8], %9 : <f32> -> tensor<64x64xf32, #blocked>
+    amdg.buffer_store %7, %arg1[%8], %9 : !tt.ptr<f32> -> tensor<64x64xf32, #blocked>
     tt.return
   }
 }
@@ -3548,23 +3548,23 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.targ
     %cst_1 = arith.constant dense<true> : tensor<64x1xi1, #blocked>
     %3 = tt.broadcast %cst_1 : tensor<64x1xi1, #blocked> -> tensor<64x64xi1, #blocked>
     %4 = arith.truncf %cst_0 : tensor<64x64xf32, #blocked> to tensor<64x64xf16, #blocked>
-    %5 = amdg.buffer_load %arg0[%2], %3, %4 cacheModifier = ca : <f16> -> tensor<64x64xf16, #blocked>
+    %5 = amdg.buffer_load %arg0[%2], %3, %4 cacheModifier = ca : !tt.ptr<f16> -> tensor<64x64xf16, #blocked>
     %6 = tt.broadcast %cst_1 : tensor<64x1xi1, #blocked> -> tensor<64x64xi1, #blocked>
-    amdg.buffer_store %5, %arg1[%2], %6 cacheModifier = cs : <f16> -> tensor<64x64xf16, #blocked>
+    amdg.buffer_store %5, %arg1[%2], %6 cacheModifier = cs : !tt.ptr<f16> -> tensor<64x64xf16, #blocked>
     %true_2 = arith.constant true
     %cst_3 = arith.constant dense<true> : tensor<1x64xi1, #blocked>
     %7 = tt.broadcast %cst_3 : tensor<1x64xi1, #blocked> -> tensor<64x64xi1, #blocked>
     %8 = arith.truncf %cst_0 : tensor<64x64xf32, #blocked> to tensor<64x64xf16, #blocked>
-    %9 = amdg.buffer_load %arg0[%2], %7, %8 cacheModifier = ca : <f16> -> tensor<64x64xf16, #blocked>
+    %9 = amdg.buffer_load %arg0[%2], %7, %8 cacheModifier = ca : !tt.ptr<f16> -> tensor<64x64xf16, #blocked>
     %10 = tt.broadcast %cst_3 : tensor<1x64xi1, #blocked> -> tensor<64x64xi1, #blocked>
-    amdg.buffer_store %9, %arg1[%2], %10 cacheModifier = cs : <f16> -> tensor<64x64xf16, #blocked>
+    amdg.buffer_store %9, %arg1[%2], %10 cacheModifier = cs : !tt.ptr<f16> -> tensor<64x64xf16, #blocked>
     %11 = tt.broadcast %cst_3 : tensor<1x64xi1, #blocked> -> tensor<64x64xi1, #blocked>
     %cst_4 = arith.constant 1.000000e+00 : f32
     %12 = arith.truncf %cst_4 : f32 to f16
     %13 = tt.splat %12 : f16 -> tensor<64x64xf16, #blocked>
-    %14 = amdg.buffer_load %arg0[%2], %11, %13 cacheModifier = ca : <f16> -> tensor<64x64xf16, #blocked>
+    %14 = amdg.buffer_load %arg0[%2], %11, %13 cacheModifier = ca : !tt.ptr<f16> -> tensor<64x64xf16, #blocked>
     %15 = tt.broadcast %cst_3 : tensor<1x64xi1, #blocked> -> tensor<64x64xi1, #blocked>
-    amdg.buffer_store %14, %arg1[%2], %15 cacheModifier = cs : <f16> -> tensor<64x64xf16, #blocked>
+    amdg.buffer_store %14, %arg1[%2], %15 cacheModifier = cs : !tt.ptr<f16> -> tensor<64x64xf16, #blocked>
     tt.return
   }
 }
@@ -4301,52 +4301,52 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.targ
     %0 = tt.make_range {end = 1 : i32, start = 0 : i32} : tensor<1xi32, #gluon.auto_encoding>
     %c1_i32 = arith.constant 1 : i32
     %cst = arith.constant dense<1> : tensor<1xi32, #gluon.auto_encoding>
-    %1 = amdg.buffer_atomic_rmw max, acq_rel, gpu, %cst, %arg0[%0] : <i32> -> tensor<1xi32, #gluon.auto_encoding>
-    %2 = amdg.buffer_atomic_rmw min, acq_rel, gpu, %cst, %arg0[%0] : <i32> -> tensor<1xi32, #gluon.auto_encoding>
-    %3 = amdg.buffer_atomic_rmw and, acq_rel, gpu, %cst, %arg0[%0] : <i32> -> tensor<1xi32, #gluon.auto_encoding>
-    %4 = amdg.buffer_atomic_rmw or, acq_rel, gpu, %cst, %arg0[%0] : <i32> -> tensor<1xi32, #gluon.auto_encoding>
+    %1 = amdg.buffer_atomic_rmw max, acq_rel, gpu, %cst, %arg0[%0] : !tt.ptr<i32> -> tensor<1xi32, #gluon.auto_encoding>
+    %2 = amdg.buffer_atomic_rmw min, acq_rel, gpu, %cst, %arg0[%0] : !tt.ptr<i32> -> tensor<1xi32, #gluon.auto_encoding>
+    %3 = amdg.buffer_atomic_rmw and, acq_rel, gpu, %cst, %arg0[%0] : !tt.ptr<i32> -> tensor<1xi32, #gluon.auto_encoding>
+    %4 = amdg.buffer_atomic_rmw or, acq_rel, gpu, %cst, %arg0[%0] : !tt.ptr<i32> -> tensor<1xi32, #gluon.auto_encoding>
     %c1_i32_0 = arith.constant 1 : i32
     %cst_1 = arith.constant dense<1> : tensor<1xi32, #gluon.auto_encoding>
-    %5 = amdg.buffer_atomic_rmw xor, acq_rel, gpu, %cst_1, %arg0[%0] : <i32> -> tensor<1xi32, #gluon.auto_encoding>
+    %5 = amdg.buffer_atomic_rmw xor, acq_rel, gpu, %cst_1, %arg0[%0] : !tt.ptr<i32> -> tensor<1xi32, #gluon.auto_encoding>
     %c1_i32_2 = arith.constant 1 : i32
     %cst_3 = arith.constant dense<1> : tensor<1xi32, #gluon.auto_encoding>
-    %6 = amdg.buffer_atomic_rmw umax, acq_rel, gpu, %cst_3, %arg1[%0] : <i32> -> tensor<1xi32, #gluon.auto_encoding>
-    %7 = amdg.buffer_atomic_rmw umin, acq_rel, gpu, %cst_3, %arg1[%0] : <i32> -> tensor<1xi32, #gluon.auto_encoding>
-    %8 = amdg.buffer_atomic_rmw add, acq_rel, gpu, %cst_3, %arg1[%0] : <i32> -> tensor<1xi32, #gluon.auto_encoding>
+    %6 = amdg.buffer_atomic_rmw umax, acq_rel, gpu, %cst_3, %arg1[%0] : !tt.ptr<i32> -> tensor<1xi32, #gluon.auto_encoding>
+    %7 = amdg.buffer_atomic_rmw umin, acq_rel, gpu, %cst_3, %arg1[%0] : !tt.ptr<i32> -> tensor<1xi32, #gluon.auto_encoding>
+    %8 = amdg.buffer_atomic_rmw add, acq_rel, gpu, %cst_3, %arg1[%0] : !tt.ptr<i32> -> tensor<1xi32, #gluon.auto_encoding>
     %9 = arith.extui %cst_3 : tensor<1xi32, #gluon.auto_encoding> to tensor<1xi64, #gluon.auto_encoding>
     %c0_i32 = arith.constant 0 : i32
     %c0_i32_4 = arith.constant 0 : i32
     %10 = arith.cmpi ne, %c0_i32, %c0_i32_4 : i32
     %11 = tt.splat %10 : i1 -> tensor<1xi1, #gluon.auto_encoding>
-    %12 = amdg.buffer_atomic_rmw exch, acq_rel, gpu, %9, %arg2[%0], %11 : <i64> -> tensor<1xi64, #gluon.auto_encoding>
+    %12 = amdg.buffer_atomic_rmw exch, acq_rel, gpu, %9, %arg2[%0], %11 : !tt.ptr<i64> -> tensor<1xi64, #gluon.auto_encoding>
     %c1_i32_5 = arith.constant 1 : i32
     %cst_6 = arith.constant dense<1> : tensor<1xi32, #gluon.auto_encoding>
     %13 = tt.call @triton.experimental.gluon.language._standard.zeros__Tc1T_cfp16_cAL() : () -> tensor<1xf16, #gluon.auto_encoding>
     %c0_i32_7 = arith.constant 0 : i32
     %cst_8 = arith.constant dense<0> : tensor<1xi32, #gluon.auto_encoding>
     %14 = arith.cmpi ne, %cst_6, %cst_8 : tensor<1xi32, #gluon.auto_encoding>
-    %15 = amdg.buffer_atomic_rmw fadd, acq_rel, gpu, %13, %arg3[%0], %14 : <f16> -> tensor<1xf16, #gluon.auto_encoding>
+    %15 = amdg.buffer_atomic_rmw fadd, acq_rel, gpu, %13, %arg3[%0], %14 : !tt.ptr<f16> -> tensor<1xf16, #gluon.auto_encoding>
     %c0_i32_9 = arith.constant 0 : i32
     %cst_10 = arith.constant dense<0> : tensor<1xi32, #gluon.auto_encoding>
     %16 = arith.cmpi ne, %cst_6, %cst_10 : tensor<1xi32, #gluon.auto_encoding>
-    %17 = amdg.buffer_atomic_rmw fadd, acq_rel, sys, %13, %arg3[%0], %16 : <f16> -> tensor<1xf16, #gluon.auto_encoding>
+    %17 = amdg.buffer_atomic_rmw fadd, acq_rel, sys, %13, %arg3[%0], %16 : !tt.ptr<f16> -> tensor<1xf16, #gluon.auto_encoding>
     %c0_i32_11 = arith.constant 0 : i32
     %cst_12 = arith.constant dense<0> : tensor<1xi32, #gluon.auto_encoding>
     %18 = arith.cmpi ne, %cst_6, %cst_12 : tensor<1xi32, #gluon.auto_encoding>
-    %19 = amdg.buffer_atomic_rmw fadd, relaxed, cta, %13, %arg3[%0], %18 : <f16> -> tensor<1xf16, #gluon.auto_encoding>
+    %19 = amdg.buffer_atomic_rmw fadd, relaxed, cta, %13, %arg3[%0], %18 : !tt.ptr<f16> -> tensor<1xf16, #gluon.auto_encoding>
     %20 = arith.extf %13 : tensor<1xf16, #gluon.auto_encoding> to tensor<1xf32, #gluon.auto_encoding>
     %c0_i32_13 = arith.constant 0 : i32
     %cst_14 = arith.constant dense<0> : tensor<1xi32, #gluon.auto_encoding>
     %21 = arith.cmpi ne, %cst_6, %cst_14 : tensor<1xi32, #gluon.auto_encoding>
-    %22 = amdg.buffer_atomic_rmw fadd, acq_rel, gpu, %20, %arg4[%0], %21 : <f32> -> tensor<1xf32, #gluon.auto_encoding>
+    %22 = amdg.buffer_atomic_rmw fadd, acq_rel, gpu, %20, %arg4[%0], %21 : !tt.ptr<f32> -> tensor<1xf32, #gluon.auto_encoding>
     %c0_i32_15 = arith.constant 0 : i32
     %cst_16 = arith.constant dense<0> : tensor<1xi32, #gluon.auto_encoding>
     %23 = arith.cmpi ne, %cst_6, %cst_16 : tensor<1xi32, #gluon.auto_encoding>
-    %24 = amdg.buffer_atomic_rmw fadd, acq_rel, sys, %20, %arg4[%0], %23 : <f32> -> tensor<1xf32, #gluon.auto_encoding>
+    %24 = amdg.buffer_atomic_rmw fadd, acq_rel, sys, %20, %arg4[%0], %23 : !tt.ptr<f32> -> tensor<1xf32, #gluon.auto_encoding>
     %c0_i32_17 = arith.constant 0 : i32
     %cst_18 = arith.constant dense<0> : tensor<1xi32, #gluon.auto_encoding>
     %25 = arith.cmpi ne, %cst_6, %cst_18 : tensor<1xi32, #gluon.auto_encoding>
-    %26 = amdg.buffer_atomic_rmw fadd, relaxed, cta, %20, %arg4[%0], %25 : <f32> -> tensor<1xf32, #gluon.auto_encoding>
+    %26 = amdg.buffer_atomic_rmw fadd, relaxed, cta, %20, %arg4[%0], %25 : !tt.ptr<f32> -> tensor<1xf32, #gluon.auto_encoding>
     tt.return
   }
   tt.func private @triton.experimental.gluon.language._standard.zeros__Tc1T_cfp16_cAL() -> tensor<1xf16, #gluon.auto_encoding> attributes {noinline = false} {
@@ -4385,17 +4385,17 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.targ
     %c0_i32_0 = arith.constant 0 : i32
     %2 = arith.cmpi ne, %c0_i32, %c0_i32_0 : i32
     %3 = tt.splat %2 : i1 -> tensor<1xi1, #gluon.auto_encoding>
-    %4 = amdg.buffer_atomic_rmw fadd, acq_rel, gpu, %1, %arg0[%0], %3 : <bf16> -> tensor<1xbf16, #gluon.auto_encoding>
+    %4 = amdg.buffer_atomic_rmw fadd, acq_rel, gpu, %1, %arg0[%0], %3 : !tt.ptr<bf16> -> tensor<1xbf16, #gluon.auto_encoding>
     %c1_i32 = arith.constant 1 : i32
     %cst = arith.constant dense<1> : tensor<1xi32, #gluon.auto_encoding>
     %c0_i32_1 = arith.constant 0 : i32
     %cst_2 = arith.constant dense<0> : tensor<1xi32, #gluon.auto_encoding>
     %5 = arith.cmpi ne, %cst, %cst_2 : tensor<1xi32, #gluon.auto_encoding>
-    %6 = amdg.buffer_atomic_rmw fadd, acq_rel, sys, %1, %arg0[%0], %5 : <bf16> -> tensor<1xbf16, #gluon.auto_encoding>
+    %6 = amdg.buffer_atomic_rmw fadd, acq_rel, sys, %1, %arg0[%0], %5 : !tt.ptr<bf16> -> tensor<1xbf16, #gluon.auto_encoding>
     %c0_i32_3 = arith.constant 0 : i32
     %cst_4 = arith.constant dense<0> : tensor<1xi32, #gluon.auto_encoding>
     %7 = arith.cmpi ne, %cst, %cst_4 : tensor<1xi32, #gluon.auto_encoding>
-    %8 = amdg.buffer_atomic_rmw fadd, relaxed, cta, %1, %arg0[%0], %7 : <bf16> -> tensor<1xbf16, #gluon.auto_encoding>
+    %8 = amdg.buffer_atomic_rmw fadd, relaxed, cta, %1, %arg0[%0], %7 : !tt.ptr<bf16> -> tensor<1xbf16, #gluon.auto_encoding>
     tt.return
   }
   tt.func private @triton.experimental.gluon.language._standard.zeros__Tc1T_cbf16_cAL() -> tensor<1xbf16, #gluon.auto_encoding> attributes {noinline = false} {

--- a/test/Analysis/test-buffer-region-layout-alias.mlir
+++ b/test/Analysis/test-buffer-region-layout-alias.mlir
@@ -604,7 +604,7 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 1 : i32, ttg.shar
 module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.shared = 8192 : i32, ttg.target = "hip:gfx950", "ttg.threads-per-warp" = 64 : i32, "ttg.total-num-warps" = 4 : i32} {
   tt.func public @amd_buffer_load_to_local_alias(%ptr: !tt.ptr<f32>, %offsets: tensor<32x64xi32, #blocked>) {
     %buffer = ttg.local_alloc {allocation.offset = 0 : i32} : () -> !ttg.memdesc<32x64xf32, #shared, #smem, mutable>
-    %token = amdg.buffer_load_to_local %ptr[%offsets] into %buffer {test.region_name = "amd_direct_a_buffer_load"} : <f32>[tensor<32x64xi32, #blocked>] -> <32x64xf32, #shared, #smem, mutable>
+    %token = amdg.buffer_load_to_local %ptr[%offsets] into %buffer {test.region_name = "amd_direct_a_buffer_load"} : !tt.ptr<f32>[tensor<32x64xi32, #blocked>] -> <32x64xf32, #shared, #smem, mutable>
     %value = ttg.local_load %buffer {test.region_name = "amd_direct_b_local_load"} : !ttg.memdesc<32x64xf32, #shared, #smem, mutable> -> tensor<32x64xf32, #blocked>
     tt.return
   }

--- a/test/Conversion/amd/amdgpu_membar.mlir
+++ b/test/Conversion/amd/amdgpu_membar.mlir
@@ -259,7 +259,7 @@ tt.func @missing_barrier_reused_allocation(%A: !tt.ptr<f16>, %B: !tt.ptr<f16>) {
   %offset = arith.constant dense<0> : tensor<128x32xi32, #AL>
 
   %slice1_0 = ttg.memdesc_index %alloc1[%c0_i32] : !ttg.memdesc<2x128x32xf16, #A_SHARED, #ttg.shared_memory, mutable> -> !ttg.memdesc<128x32xf16, #A_SHARED, #ttg.shared_memory, mutable>
-  %async1 = amdg.buffer_load_to_local %A[%offset] into %slice1_0 : <f16>[tensor<128x32xi32, #AL>] -> <128x32xf16, #A_SHARED, #ttg.shared_memory, mutable>
+  %async1 = amdg.buffer_load_to_local %A[%offset] into %slice1_0 : !tt.ptr<f16>[tensor<128x32xi32, #AL>] -> <128x32xf16, #A_SHARED, #ttg.shared_memory, mutable>
   %token1 = ttg.async_commit_group tokens %async1
   %wait1 = amdg.async_wait %token1 {num_inst = 0 : i32}
   // CHECK: ttg.barrier local
@@ -271,7 +271,7 @@ tt.func @missing_barrier_reused_allocation(%A: !tt.ptr<f16>, %B: !tt.ptr<f16>) {
   // op2: Async load into alloc2 (overlapping with the dealloc'd alloc1 that is still being local_load'd from)
   // CHECK: ttg.barrier local
   // CHECK-NEXT: amdg.buffer_load_to_local
-  %async2 = amdg.buffer_load_to_local %B[%offset] into %slice2_0 : <f16>[tensor<128x32xi32, #AL>] -> <128x32xf16, #A_SHARED, #ttg.shared_memory, mutable>
+  %async2 = amdg.buffer_load_to_local %B[%offset] into %slice2_0 : !tt.ptr<f16>[tensor<128x32xi32, #AL>] -> <128x32xf16, #A_SHARED, #ttg.shared_memory, mutable>
   %token2 = ttg.async_commit_group tokens %async2
   %wait2 = amdg.async_wait %token2 {num_inst = 0 : i32}
   // CHECK: ttg.barrier local

--- a/test/Conversion/amd/async-ops-alias-scopes.mlir
+++ b/test/Conversion/amd/async-ops-alias-scopes.mlir
@@ -44,7 +44,7 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.shar
     // COMMON: rocdl.raw.ptr.buffer.load.async.lds {{.*}} {alias_scopes = [[[$ASYNC_COPY_SCOPE]]]
     // Check that store for 'other' has alias information set
     // COMMON: llvm.store {{.*}} {alias_scopes = [[[$LOCAL_LOAD_SCOPE]]], {{.*}}, noalias_scopes = [[[$ASYNC_COPY_SCOPE]]]
-    %65 = amdg.buffer_load_to_local %arg1[%arg2] mask=%mask other=%other into %arg3 : <f32>[tensor<8x64xi32, #blocked>] tensor<8x64xf32, #blocked> -> <8x64xf32, #shared, #smem, mutable>
+    %65 = amdg.buffer_load_to_local %arg1[%arg2] mask=%mask other=%other into %arg3 : !tt.ptr<f32>[tensor<8x64xi32, #blocked>] tensor<8x64xf32, #blocked> -> <8x64xf32, #shared, #smem, mutable>
 
     // COMMON: llvm.return
     tt.return

--- a/test/Conversion/amd/buffer_atomic_cas.mlir
+++ b/test/Conversion/amd/buffer_atomic_cas.mlir
@@ -32,10 +32,10 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.targ
     // CHECK: %[[dst:.*]] = rocdl.raw.ptr.buffer.atomic.cmpswap %{{.*}}, %{{.*}}, %[[resource]], %{{.*}}, %{{.*}}, {{.*}} : i64
     // CHECK: llvm.fence syncscope("agent") acquire
     // CHECK: rocdl.s.barrier
-    %4 = amdg.buffer_atomic_cas acq_rel, gpu, %cmp, %val, %scalar_ptr[%offsets] : tensor<512xi64, #blocked>
+    %4 = amdg.buffer_atomic_cas acq_rel, gpu, %cmp, %val, %scalar_ptr[%offsets] : <i64> -> tensor<512xi64, #blocked>
 
     %5 = tt.addptr %arg1, %1 : !tt.ptr<i64>, i32
-    amdg.buffer_store %4, %5[%offsets] : tensor<512xi64, #blocked>
+    amdg.buffer_store %4, %5[%offsets] : <i64> -> tensor<512xi64, #blocked>
     tt.return
   }
 }

--- a/test/Conversion/amd/buffer_atomic_cas.mlir
+++ b/test/Conversion/amd/buffer_atomic_cas.mlir
@@ -32,10 +32,10 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.targ
     // CHECK: %[[dst:.*]] = rocdl.raw.ptr.buffer.atomic.cmpswap %{{.*}}, %{{.*}}, %[[resource]], %{{.*}}, %{{.*}}, {{.*}} : i64
     // CHECK: llvm.fence syncscope("agent") acquire
     // CHECK: rocdl.s.barrier
-    %4 = amdg.buffer_atomic_cas acq_rel, gpu, %cmp, %val, %scalar_ptr[%offsets] : <i64> -> tensor<512xi64, #blocked>
+    %4 = amdg.buffer_atomic_cas acq_rel, gpu, %cmp, %val, %scalar_ptr[%offsets] : !tt.ptr<i64> -> tensor<512xi64, #blocked>
 
     %5 = tt.addptr %arg1, %1 : !tt.ptr<i64>, i32
-    amdg.buffer_store %4, %5[%offsets] : <i64> -> tensor<512xi64, #blocked>
+    amdg.buffer_store %4, %5[%offsets] : !tt.ptr<i64> -> tensor<512xi64, #blocked>
     tt.return
   }
 }

--- a/test/Conversion/amd/buffer_atomic_rmw_barrier.mlir
+++ b/test/Conversion/amd/buffer_atomic_rmw_barrier.mlir
@@ -24,8 +24,8 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.targ
       tt.reduce.return %4 : i64
     }) : (tensor<2x64xi64, #blocked1>) -> tensor<64xi64, #ttg.slice<{dim = 0, parent = #blocked1}>>
     %2 = ttg.convert_layout %1 : tensor<64xi64, #ttg.slice<{dim = 0, parent = #blocked1}>> -> tensor<64xi64, #blocked>
-    %3 = amdg.buffer_atomic_rmw add, acq_rel, gpu, %2, %arg0[%0] : <i64> -> tensor<64xi64, #blocked>
-    amdg.buffer_store %3, %arg1[%0] : <i64> -> tensor<64xi64, #blocked>
+    %3 = amdg.buffer_atomic_rmw add, acq_rel, gpu, %2, %arg0[%0] : !tt.ptr<i64> -> tensor<64xi64, #blocked>
+    amdg.buffer_store %3, %arg1[%0] : !tt.ptr<i64> -> tensor<64xi64, #blocked>
     tt.return
   }
 }

--- a/test/Conversion/amd/buffer_atomic_rmw_barrier.mlir
+++ b/test/Conversion/amd/buffer_atomic_rmw_barrier.mlir
@@ -24,8 +24,8 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.targ
       tt.reduce.return %4 : i64
     }) : (tensor<2x64xi64, #blocked1>) -> tensor<64xi64, #ttg.slice<{dim = 0, parent = #blocked1}>>
     %2 = ttg.convert_layout %1 : tensor<64xi64, #ttg.slice<{dim = 0, parent = #blocked1}>> -> tensor<64xi64, #blocked>
-    %3 = amdg.buffer_atomic_rmw add, acq_rel, gpu, %2, %arg0[%0] : tensor<64xi64, #blocked>
-    amdg.buffer_store %3, %arg1[%0] : tensor<64xi64, #blocked>
+    %3 = amdg.buffer_atomic_rmw add, acq_rel, gpu, %2, %arg0[%0] : <i64> -> tensor<64xi64, #blocked>
+    amdg.buffer_store %3, %arg1[%0] : <i64> -> tensor<64xi64, #blocked>
     tt.return
   }
 }

--- a/test/Conversion/amd/buffer_load_store.mlir
+++ b/test/Conversion/amd/buffer_load_store.mlir
@@ -8,7 +8,7 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 1 : i32} {
         // CHECK: %[[c_mask:.*]] = llvm.mlir.constant(true) : i1
         // CHECK: %[[offset:.*]] = llvm.select %[[c_mask]]
         // CHECK: rocdl.raw.ptr.buffer.load {{.*}}, %[[offset]], {{.*}}, {{.*}}
-        %ret = amdg.buffer_load %arg0[%offset] cacheModifier = cs : <f32> -> tensor<128xf32, #blocked0>
+        %ret = amdg.buffer_load %arg0[%offset] cacheModifier = cs : !tt.ptr<f32> -> tensor<128xf32, #blocked0>
         tt.return
   }
 }
@@ -30,7 +30,7 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 1 : i32} {
         // CHECK: %[[mask:.*]] = llvm.extractvalue %{{.*}} : !llvm.struct<(i1, i1, i1, i1)>
         // CHECK: %[[offset:.*]] = llvm.select %[[mask]]
         // CHECK: rocdl.raw.ptr.buffer.load {{.*}}, %[[offset]]
-        %ret = amdg.buffer_load %arg0[%offset], %7 stride = %c256_i32 : <f32> -> tensor<128xf32, #blocked0>
+        %ret = amdg.buffer_load %arg0[%offset], %7 stride = %c256_i32 : !tt.ptr<f32> -> tensor<128xf32, #blocked0>
         tt.return
   }
 }
@@ -54,7 +54,7 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 1 : i32} {
         // CHECK: %[[offset:.*]] = llvm.select %[[mask]]
         // CHECK: rocdl.raw.ptr.buffer.load {{.*}}, %[[offset]]
         // CHECK: llvm.select
-        %ret = amdg.buffer_load %arg0[%offset], %7, %other stride = %c256_i32: <f32> -> tensor<128xf32, #blocked0>
+        %ret = amdg.buffer_load %arg0[%offset], %7, %other stride = %c256_i32: !tt.ptr<f32> -> tensor<128xf32, #blocked0>
         tt.return
   }
 }
@@ -69,7 +69,7 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 1 : i32} {
         // CHECK: %[[offset:.*]] = llvm.select %[[mask]]
         // CHECK: rocdl.raw.ptr.buffer.store {{.*}}, {{.*}}, %[[offset]], {{.*}}, {{.*}}
         %c256_i32 = arith.constant 256 : i32
-        amdg.buffer_store %value, %arg0[%offset] cacheModifier = cs stride = %c256_i32 : <f32> -> tensor<128xf32, #blocked0>
+        amdg.buffer_store %value, %arg0[%offset] cacheModifier = cs stride = %c256_i32 : !tt.ptr<f32> -> tensor<128xf32, #blocked0>
         tt.return
   }
 }
@@ -93,7 +93,7 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 1 : i32} {
         // CHECK: %[[mask2:.*]] = llvm.and %[[mask1]], %[[mask0]]
         // CHECK: %[[offset:.*]] = llvm.select %[[mask2]]
         // CHECK: rocdl.raw.ptr.buffer.store {{.*}}, {{.*}}, %[[offset]]
-        amdg.buffer_store %value, %arg0[%offset], %7 stride = %N : <f32> -> tensor<128xf32, #blocked0>
+        amdg.buffer_store %value, %arg0[%offset], %7 stride = %N : !tt.ptr<f32> -> tensor<128xf32, #blocked0>
         tt.return
   }
 }
@@ -112,14 +112,14 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 1 : i32} {
         %4 = arith.addi %3, %2 : tensor<256xi32, #blocked0>
         // Load 8 elements from A with two vectorized load instructions
         // CHECK-COUNT-2: rocdl.raw.ptr.buffer.load {{.*}} : vector<4xf32>
-        %9 = amdg.buffer_load %arg0[%4] stride = %arg3 : <f32> -> tensor<256xf32, #blocked0>
+        %9 = amdg.buffer_load %arg0[%4] stride = %arg3 : !tt.ptr<f32> -> tensor<256xf32, #blocked0>
         // Load 8 elements from B with two vectorized load instructions
         // CHECK-COUNT-2: rocdl.raw.ptr.buffer.load {{.*}} : vector<4xf32>
-        %10 = amdg.buffer_load %arg1[%4] stride = %arg3 : <f32> -> tensor<256xf32, #blocked0>
+        %10 = amdg.buffer_load %arg1[%4] stride = %arg3 : !tt.ptr<f32> -> tensor<256xf32, #blocked0>
         %11 = arith.addf %9, %10 : tensor<256xf32, #blocked0>
         // Store 8 elements into C with two vectorized store instructions
         // CHECK-COUNT-2: rocdl.raw.ptr.buffer.store {{.*}} : vector<4xf32>
-        amdg.buffer_store %11, %arg2[%4] stride = %arg3 : <f32> -> tensor<256xf32, #blocked0>
+        amdg.buffer_store %11, %arg2[%4] stride = %arg3 : !tt.ptr<f32> -> tensor<256xf32, #blocked0>
         tt.return
   }
 }
@@ -137,9 +137,9 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 8 : i32, "ttg.thr
     %4 = arith.addi %3, %1 : tensor<256x64xi32, #blocked>
     // Load 16 f16 elements check for correct vector size of instruction (4xi32 = 8xf16)
     // CHECK-COUNT-4: rocdl.raw.ptr.buffer.load {{.*}} : vector<4xi32>
-    %5 = amdg.buffer_load %arg0[%4] : <f16> -> tensor<256x64xf16, #blocked>
+    %5 = amdg.buffer_load %arg0[%4] : !tt.ptr<f16> -> tensor<256x64xf16, #blocked>
     // CHECK-COUNT-4: rocdl.raw.ptr.buffer.store {{.*}} : vector<4xi32>
-    amdg.buffer_store %5, %arg0[%4] : <f16> -> tensor<256x64xf16, #blocked>
+    amdg.buffer_store %5, %arg0[%4] : !tt.ptr<f16> -> tensor<256x64xf16, #blocked>
     tt.return
   }
 }
@@ -160,14 +160,14 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 1 : i32} {
         %7 = arith.cmpi slt, %4, %5: tensor<256xi32, #blocked0>
         // Load 8 elements from A with eight scalar load instructions
         // CHECK-COUNT-8: rocdl.raw.ptr.buffer.load {{.*}} : f32
-        %9 = amdg.buffer_load %arg0[%4], %7 stride = %arg3 : <f32> -> tensor<256xf32, #blocked0>
+        %9 = amdg.buffer_load %arg0[%4], %7 stride = %arg3 : !tt.ptr<f32> -> tensor<256xf32, #blocked0>
         // Load 8 elements from B with two scalar load instructions
         // CHECK-COUNT-8: rocdl.raw.ptr.buffer.load {{.*}} : f32
-        %10 = amdg.buffer_load %arg1[%4], %7 stride = %arg3 : <f32> -> tensor<256xf32, #blocked0>
+        %10 = amdg.buffer_load %arg1[%4], %7 stride = %arg3 : !tt.ptr<f32> -> tensor<256xf32, #blocked0>
         %11 = arith.addf %9, %10 : tensor<256xf32, #blocked0>
         // Store 8 elements into C with two scalar store instructions
         // CHECK-COUNT-8: rocdl.raw.ptr.buffer.store {{.*}} : f32
-        amdg.buffer_store %11, %arg2[%4], %7 stride = %arg3 : <f32> -> tensor<256xf32, #blocked0>
+        amdg.buffer_store %11, %arg2[%4], %7 stride = %arg3 : !tt.ptr<f32> -> tensor<256xf32, #blocked0>
         tt.return
   }
 }
@@ -188,14 +188,14 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 1 : i32} {
         %7 = arith.cmpi slt, %4, %5: tensor<256xi32, #blocked0>
         // Load 8 fp16 elements from A with four i32 scalar load instructions
         // CHECK-COUNT-4: rocdl.raw.ptr.buffer.load {{.*}} : i32
-        %9 = amdg.buffer_load %arg0[%4], %7 stride = %arg3 : <f16> -> tensor<256xf16, #blocked0>
+        %9 = amdg.buffer_load %arg0[%4], %7 stride = %arg3 : !tt.ptr<f16> -> tensor<256xf16, #blocked0>
         // Load 8 fp16 elements from B with four i32 scalar load instructions
         // CHECK-COUNT-4: rocdl.raw.ptr.buffer.load {{.*}} : i32
-        %10 = amdg.buffer_load %arg1[%4], %7 stride = %arg3 : <f16> -> tensor<256xf16, #blocked0>
+        %10 = amdg.buffer_load %arg1[%4], %7 stride = %arg3 : !tt.ptr<f16> -> tensor<256xf16, #blocked0>
         %11 = arith.addf %9, %10 : tensor<256xf16, #blocked0>
         // Store 8 fp16 elements into C with four i32 scalar store instructionss
         // CHECK-COUNT-4: rocdl.raw.ptr.buffer.store {{.*}} : i32
-        amdg.buffer_store %11, %arg2[%4], %7 stride = %arg3 : <f16> -> tensor<256xf16, #blocked0>
+        amdg.buffer_store %11, %arg2[%4], %7 stride = %arg3 : !tt.ptr<f16> -> tensor<256xf16, #blocked0>
         tt.return
   }
 }
@@ -223,7 +223,7 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 1 : i32} {
 
         // We will have 4 calls to fadd, since the sizePerThread is 4. Scope/ordering instructions will be
         // generated by the lowering of llvm.fence
-        %ret = amdg.buffer_atomic_rmw fadd, acq_rel, gpu, %values, %arg0[%offset], %mask stride = %stride : <f32> -> tensor<128xf32, #blocked0>
+        %ret = amdg.buffer_atomic_rmw fadd, acq_rel, gpu, %values, %arg0[%offset], %mask stride = %stride : !tt.ptr<f32> -> tensor<128xf32, #blocked0>
 
         // CHECK: %[[result:.*]] = llvm.call_intrinsic "llvm.amdgcn.raw.ptr.buffer.atomic.fadd"({{.*}}, {{.*}}, %[[mask1:.*]], {{.*}}, {{.*}}) : (f32, !llvm.ptr<8>, i32, i32, i32) -> f32
         // CHECK: %[[result:.*]] = llvm.call_intrinsic "llvm.amdgcn.raw.ptr.buffer.atomic.fadd"({{.*}}, {{.*}}, %[[mask1:.*]], {{.*}}, {{.*}}) : (f32, !llvm.ptr<8>, i32, i32, i32) -> f32
@@ -246,7 +246,7 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 1 : i32, "ttg.thr
     // CHECK: llvm.call_intrinsic "llvm.amdgcn.raw.ptr.buffer.atomic.fadd"({{.*}}) : (f32, !llvm.ptr<8>, i32, i32, i32) -> f32
     // CHECK: llvm.fence syncscope("agent") acquire
     tt.func public @buffer_atomic_rmw_fadd_acquire(%arg0: !tt.ptr<f32> {tt.divisibility = 16 : i32}, %offsets : tensor<64xi32, #blocked0>{tt.divisibility=16:i32}, %values : tensor<64xf32, #blocked0>) {
-        %ret = amdg.buffer_atomic_rmw fadd, acquire, gpu, %values, %arg0[%offsets] : <f32> -> tensor<64xf32, #blocked0>
+        %ret = amdg.buffer_atomic_rmw fadd, acquire, gpu, %values, %arg0[%offsets] : !tt.ptr<f32> -> tensor<64xf32, #blocked0>
         tt.return
     }
 }
@@ -261,7 +261,7 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 1 : i32, "ttg.thr
     // No acquire fence after the atomic for release ordering
     // CHECK-NOT: llvm.fence syncscope("agent") acquire
     tt.func public @buffer_atomic_rmw_fadd_release(%arg0: !tt.ptr<f32> {tt.divisibility = 16 : i32}, %offsets : tensor<64xi32, #blocked0>{tt.divisibility=16:i32}, %values : tensor<64xf32, #blocked0>) {
-        %ret = amdg.buffer_atomic_rmw fadd, release, gpu, %values, %arg0[%offsets] : <f32> -> tensor<64xf32, #blocked0>
+        %ret = amdg.buffer_atomic_rmw fadd, release, gpu, %values, %arg0[%offsets] : !tt.ptr<f32> -> tensor<64xf32, #blocked0>
         tt.return
     }
 }
@@ -273,7 +273,7 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, "ttg.thr
     // CHECK-LABEL: buffer_atomic_rmw_xchg_i32
     // CHECK: llvm.call_intrinsic "llvm.amdgcn.raw.ptr.buffer.atomic.swap"({{.*}}) : (i32, !llvm.ptr<8>, i32, i32, i32) -> i32
     tt.func public @buffer_atomic_rmw_xchg_i32(%arg0: !tt.ptr<i32> {tt.divisibility = 16 : i32}, %offsets : tensor<256xi32, #blocked0>{tt.divisibility=16:i32}, %values : tensor<256xi32, #blocked0>) {
-        %ret = amdg.buffer_atomic_rmw exch, acq_rel, gpu, %values, %arg0[%offsets] : <i32> -> tensor<256xi32, #blocked0>
+        %ret = amdg.buffer_atomic_rmw exch, acq_rel, gpu, %values, %arg0[%offsets] : !tt.ptr<i32> -> tensor<256xi32, #blocked0>
         tt.return
     }
 }
@@ -285,7 +285,7 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, "ttg.thr
     // CHECK-LABEL: buffer_atomic_rmw_fmax_f32
     // CHECK: llvm.call_intrinsic "llvm.amdgcn.raw.ptr.buffer.atomic.fmax"({{.*}}) : (f32, !llvm.ptr<8>, i32, i32, i32) -> f32
     tt.func public @buffer_atomic_rmw_fmax_f32(%arg0: !tt.ptr<f32> {tt.divisibility = 16 : i32}, %offsets : tensor<256xi32, #blocked0>{tt.divisibility=16:i32}, %values : tensor<256xf32, #blocked0>) {
-        %ret = amdg.buffer_atomic_rmw max, acq_rel, gpu, %values, %arg0[%offsets] : <f32> -> tensor<256xf32, #blocked0>
+        %ret = amdg.buffer_atomic_rmw max, acq_rel, gpu, %values, %arg0[%offsets] : !tt.ptr<f32> -> tensor<256xf32, #blocked0>
         tt.return
     }
 }
@@ -297,7 +297,7 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, "ttg.thr
     // CHECK-LABEL: buffer_atomic_rmw_fmin_f32
     // CHECK: llvm.call_intrinsic "llvm.amdgcn.raw.ptr.buffer.atomic.fmin"({{.*}}) : (f32, !llvm.ptr<8>, i32, i32, i32) -> f32
     tt.func public @buffer_atomic_rmw_fmin_f32(%arg0: !tt.ptr<f32> {tt.divisibility = 16 : i32}, %offsets : tensor<256xi32, #blocked0>{tt.divisibility=16:i32}, %values : tensor<256xf32, #blocked0>) {
-        %ret = amdg.buffer_atomic_rmw min, acq_rel, gpu, %values, %arg0[%offsets] : <f32> -> tensor<256xf32, #blocked0>
+        %ret = amdg.buffer_atomic_rmw min, acq_rel, gpu, %values, %arg0[%offsets] : !tt.ptr<f32> -> tensor<256xf32, #blocked0>
         tt.return
     }
 }
@@ -309,7 +309,7 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, "ttg.thr
     // CHECK-LABEL: buffer_atomic_rmw_smax_i32
     // CHECK: llvm.call_intrinsic "llvm.amdgcn.raw.ptr.buffer.atomic.smax"({{.*}}) : (i32, !llvm.ptr<8>, i32, i32, i32) -> i32
     tt.func public @buffer_atomic_rmw_smax_i32(%arg0: !tt.ptr<i32> {tt.divisibility = 16 : i32}, %offsets : tensor<256xi32, #blocked0>{tt.divisibility=16:i32}, %values : tensor<256xi32, #blocked0>) {
-        %ret = amdg.buffer_atomic_rmw max, acq_rel, gpu, %values, %arg0[%offsets] : <i32> -> tensor<256xi32, #blocked0>
+        %ret = amdg.buffer_atomic_rmw max, acq_rel, gpu, %values, %arg0[%offsets] : !tt.ptr<i32> -> tensor<256xi32, #blocked0>
         tt.return
     }
 }
@@ -321,7 +321,7 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, "ttg.thr
     // CHECK-LABEL: buffer_atomic_rmw_smin_i32
     // CHECK: llvm.call_intrinsic "llvm.amdgcn.raw.ptr.buffer.atomic.smin"({{.*}}) : (i32, !llvm.ptr<8>, i32, i32, i32) -> i32
     tt.func public @buffer_atomic_rmw_smin_i32(%arg0: !tt.ptr<i32> {tt.divisibility = 16 : i32}, %offsets : tensor<256xi32, #blocked0>{tt.divisibility=16:i32}, %values : tensor<256xi32, #blocked0>) {
-        %ret = amdg.buffer_atomic_rmw min, acq_rel, gpu, %values, %arg0[%offsets] : <i32> -> tensor<256xi32, #blocked0>
+        %ret = amdg.buffer_atomic_rmw min, acq_rel, gpu, %values, %arg0[%offsets] : !tt.ptr<i32> -> tensor<256xi32, #blocked0>
         tt.return
     }
 }
@@ -333,7 +333,7 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, "ttg.thr
     // CHECK-LABEL: buffer_atomic_rmw_umax_i32
     // CHECK: llvm.call_intrinsic "llvm.amdgcn.raw.ptr.buffer.atomic.umax"({{.*}}) : (i32, !llvm.ptr<8>, i32, i32, i32) -> i32
     tt.func public @buffer_atomic_rmw_umax_i32(%arg0: !tt.ptr<i32> {tt.divisibility = 16 : i32}, %offsets : tensor<256xi32, #blocked0>{tt.divisibility=16:i32}, %values : tensor<256xi32, #blocked0>) {
-        %ret = amdg.buffer_atomic_rmw umax, acq_rel, gpu, %values, %arg0[%offsets] : <i32> -> tensor<256xi32, #blocked0>
+        %ret = amdg.buffer_atomic_rmw umax, acq_rel, gpu, %values, %arg0[%offsets] : !tt.ptr<i32> -> tensor<256xi32, #blocked0>
         tt.return
     }
 }
@@ -345,7 +345,7 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, "ttg.thr
     // CHECK-LABEL: buffer_atomic_rmw_umin_i32
     // CHECK: llvm.call_intrinsic "llvm.amdgcn.raw.ptr.buffer.atomic.umin"({{.*}}) : (i32, !llvm.ptr<8>, i32, i32, i32) -> i32
     tt.func public @buffer_atomic_rmw_umin_i32(%arg0: !tt.ptr<i32> {tt.divisibility = 16 : i32}, %offsets : tensor<256xi32, #blocked0>{tt.divisibility=16:i32}, %values : tensor<256xi32, #blocked0>) {
-        %ret = amdg.buffer_atomic_rmw umin, acq_rel, gpu, %values, %arg0[%offsets] : <i32> -> tensor<256xi32, #blocked0>
+        %ret = amdg.buffer_atomic_rmw umin, acq_rel, gpu, %values, %arg0[%offsets] : !tt.ptr<i32> -> tensor<256xi32, #blocked0>
         tt.return
     }
 }
@@ -364,7 +364,7 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, "ttg.thr
         // We expect vector size == 1 (i16) for the generated loads as sizePerThread = [1, 1]
         // CHECK-COUNT-8: rocdl.raw.ptr.buffer.load {{.*}}, {{.*}}, {{.*}}, {{.*}} : i16
         // CHECK-NOT: rocdl.raw.ptr.buffer.load
-        %24 = amdg.buffer_load %arg0[%23] : <f16> -> tensor<8x16xf16, #blocked>
+        %24 = amdg.buffer_load %arg0[%23] : !tt.ptr<f16> -> tensor<8x16xf16, #blocked>
         tt.return
   }
 }
@@ -380,10 +380,10 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, "ttg.thr
     %1 = arith.muli %0, %cst : tensor<1024xi32, #blocked>
     // CHECK-COUNT-4: rocdl.raw.ptr.buffer.load {{.*}}, {{.*}}, {{.*}}, {{.*}} : f32
     // CHECK-NOT: rocdl.raw.ptr.buffer.load
-    %2 = amdg.buffer_load %arg0[%1] : <f32> -> tensor<1024xf32, #blocked>
+    %2 = amdg.buffer_load %arg0[%1] : !tt.ptr<f32> -> tensor<1024xf32, #blocked>
     // CHECK-COUNT-4: rocdl.raw.ptr.buffer.store {{.*}}, {{.*}}, {{.*}}, {{.*}}, {{.*}} : f32
     // CHECK-NOT: rocdl.raw.ptr.buffer.store
-    amdg.buffer_store %2, %arg1[%1] : <f32> -> tensor<1024xf32, #blocked>
+    amdg.buffer_store %2, %arg1[%1] : !tt.ptr<f32> -> tensor<1024xf32, #blocked>
     tt.return
   }
 }

--- a/test/Conversion/amd/buffer_load_store.mlir
+++ b/test/Conversion/amd/buffer_load_store.mlir
@@ -8,7 +8,7 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 1 : i32} {
         // CHECK: %[[c_mask:.*]] = llvm.mlir.constant(true) : i1
         // CHECK: %[[offset:.*]] = llvm.select %[[c_mask]]
         // CHECK: rocdl.raw.ptr.buffer.load {{.*}}, %[[offset]], {{.*}}, {{.*}}
-        %ret = amdg.buffer_load %arg0[%offset] cacheModifier = cs : tensor<128xf32, #blocked0>
+        %ret = amdg.buffer_load %arg0[%offset] cacheModifier = cs : <f32> -> tensor<128xf32, #blocked0>
         tt.return
   }
 }
@@ -30,7 +30,7 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 1 : i32} {
         // CHECK: %[[mask:.*]] = llvm.extractvalue %{{.*}} : !llvm.struct<(i1, i1, i1, i1)>
         // CHECK: %[[offset:.*]] = llvm.select %[[mask]]
         // CHECK: rocdl.raw.ptr.buffer.load {{.*}}, %[[offset]]
-        %ret = amdg.buffer_load %arg0[%offset], %7 stride = %c256_i32 : tensor<128xf32, #blocked0>
+        %ret = amdg.buffer_load %arg0[%offset], %7 stride = %c256_i32 : <f32> -> tensor<128xf32, #blocked0>
         tt.return
   }
 }
@@ -54,7 +54,7 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 1 : i32} {
         // CHECK: %[[offset:.*]] = llvm.select %[[mask]]
         // CHECK: rocdl.raw.ptr.buffer.load {{.*}}, %[[offset]]
         // CHECK: llvm.select
-        %ret = amdg.buffer_load %arg0[%offset], %7, %other stride = %c256_i32: tensor<128xf32, #blocked0>
+        %ret = amdg.buffer_load %arg0[%offset], %7, %other stride = %c256_i32: <f32> -> tensor<128xf32, #blocked0>
         tt.return
   }
 }
@@ -69,7 +69,7 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 1 : i32} {
         // CHECK: %[[offset:.*]] = llvm.select %[[mask]]
         // CHECK: rocdl.raw.ptr.buffer.store {{.*}}, {{.*}}, %[[offset]], {{.*}}, {{.*}}
         %c256_i32 = arith.constant 256 : i32
-        amdg.buffer_store %value, %arg0[%offset] cacheModifier = cs stride = %c256_i32 : tensor<128xf32, #blocked0>
+        amdg.buffer_store %value, %arg0[%offset] cacheModifier = cs stride = %c256_i32 : <f32> -> tensor<128xf32, #blocked0>
         tt.return
   }
 }
@@ -93,7 +93,7 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 1 : i32} {
         // CHECK: %[[mask2:.*]] = llvm.and %[[mask1]], %[[mask0]]
         // CHECK: %[[offset:.*]] = llvm.select %[[mask2]]
         // CHECK: rocdl.raw.ptr.buffer.store {{.*}}, {{.*}}, %[[offset]]
-        amdg.buffer_store %value, %arg0[%offset], %7 stride = %N : tensor<128xf32, #blocked0>
+        amdg.buffer_store %value, %arg0[%offset], %7 stride = %N : <f32> -> tensor<128xf32, #blocked0>
         tt.return
   }
 }
@@ -112,14 +112,14 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 1 : i32} {
         %4 = arith.addi %3, %2 : tensor<256xi32, #blocked0>
         // Load 8 elements from A with two vectorized load instructions
         // CHECK-COUNT-2: rocdl.raw.ptr.buffer.load {{.*}} : vector<4xf32>
-        %9 = amdg.buffer_load %arg0[%4] stride = %arg3 : tensor<256xf32, #blocked0>
+        %9 = amdg.buffer_load %arg0[%4] stride = %arg3 : <f32> -> tensor<256xf32, #blocked0>
         // Load 8 elements from B with two vectorized load instructions
         // CHECK-COUNT-2: rocdl.raw.ptr.buffer.load {{.*}} : vector<4xf32>
-        %10 = amdg.buffer_load %arg1[%4] stride = %arg3 : tensor<256xf32, #blocked0>
+        %10 = amdg.buffer_load %arg1[%4] stride = %arg3 : <f32> -> tensor<256xf32, #blocked0>
         %11 = arith.addf %9, %10 : tensor<256xf32, #blocked0>
         // Store 8 elements into C with two vectorized store instructions
         // CHECK-COUNT-2: rocdl.raw.ptr.buffer.store {{.*}} : vector<4xf32>
-        amdg.buffer_store %11, %arg2[%4] stride = %arg3 : tensor<256xf32, #blocked0>
+        amdg.buffer_store %11, %arg2[%4] stride = %arg3 : <f32> -> tensor<256xf32, #blocked0>
         tt.return
   }
 }
@@ -137,9 +137,9 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 8 : i32, "ttg.thr
     %4 = arith.addi %3, %1 : tensor<256x64xi32, #blocked>
     // Load 16 f16 elements check for correct vector size of instruction (4xi32 = 8xf16)
     // CHECK-COUNT-4: rocdl.raw.ptr.buffer.load {{.*}} : vector<4xi32>
-    %5 = amdg.buffer_load %arg0[%4] : tensor<256x64xf16, #blocked>
+    %5 = amdg.buffer_load %arg0[%4] : <f16> -> tensor<256x64xf16, #blocked>
     // CHECK-COUNT-4: rocdl.raw.ptr.buffer.store {{.*}} : vector<4xi32>
-    amdg.buffer_store %5, %arg0[%4] : tensor<256x64xf16, #blocked>
+    amdg.buffer_store %5, %arg0[%4] : <f16> -> tensor<256x64xf16, #blocked>
     tt.return
   }
 }
@@ -160,14 +160,14 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 1 : i32} {
         %7 = arith.cmpi slt, %4, %5: tensor<256xi32, #blocked0>
         // Load 8 elements from A with eight scalar load instructions
         // CHECK-COUNT-8: rocdl.raw.ptr.buffer.load {{.*}} : f32
-        %9 = amdg.buffer_load %arg0[%4], %7 stride = %arg3 : tensor<256xf32, #blocked0>
+        %9 = amdg.buffer_load %arg0[%4], %7 stride = %arg3 : <f32> -> tensor<256xf32, #blocked0>
         // Load 8 elements from B with two scalar load instructions
         // CHECK-COUNT-8: rocdl.raw.ptr.buffer.load {{.*}} : f32
-        %10 = amdg.buffer_load %arg1[%4], %7 stride = %arg3 : tensor<256xf32, #blocked0>
+        %10 = amdg.buffer_load %arg1[%4], %7 stride = %arg3 : <f32> -> tensor<256xf32, #blocked0>
         %11 = arith.addf %9, %10 : tensor<256xf32, #blocked0>
         // Store 8 elements into C with two scalar store instructions
         // CHECK-COUNT-8: rocdl.raw.ptr.buffer.store {{.*}} : f32
-        amdg.buffer_store %11, %arg2[%4], %7 stride = %arg3 : tensor<256xf32, #blocked0>
+        amdg.buffer_store %11, %arg2[%4], %7 stride = %arg3 : <f32> -> tensor<256xf32, #blocked0>
         tt.return
   }
 }
@@ -188,14 +188,14 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 1 : i32} {
         %7 = arith.cmpi slt, %4, %5: tensor<256xi32, #blocked0>
         // Load 8 fp16 elements from A with four i32 scalar load instructions
         // CHECK-COUNT-4: rocdl.raw.ptr.buffer.load {{.*}} : i32
-        %9 = amdg.buffer_load %arg0[%4], %7 stride = %arg3 : tensor<256xf16, #blocked0>
+        %9 = amdg.buffer_load %arg0[%4], %7 stride = %arg3 : <f16> -> tensor<256xf16, #blocked0>
         // Load 8 fp16 elements from B with four i32 scalar load instructions
         // CHECK-COUNT-4: rocdl.raw.ptr.buffer.load {{.*}} : i32
-        %10 = amdg.buffer_load %arg1[%4], %7 stride = %arg3 : tensor<256xf16, #blocked0>
+        %10 = amdg.buffer_load %arg1[%4], %7 stride = %arg3 : <f16> -> tensor<256xf16, #blocked0>
         %11 = arith.addf %9, %10 : tensor<256xf16, #blocked0>
         // Store 8 fp16 elements into C with four i32 scalar store instructionss
         // CHECK-COUNT-4: rocdl.raw.ptr.buffer.store {{.*}} : i32
-        amdg.buffer_store %11, %arg2[%4], %7 stride = %arg3 : tensor<256xf16, #blocked0>
+        amdg.buffer_store %11, %arg2[%4], %7 stride = %arg3 : <f16> -> tensor<256xf16, #blocked0>
         tt.return
   }
 }
@@ -223,7 +223,7 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 1 : i32} {
 
         // We will have 4 calls to fadd, since the sizePerThread is 4. Scope/ordering instructions will be
         // generated by the lowering of llvm.fence
-        %ret = amdg.buffer_atomic_rmw fadd, acq_rel, gpu, %values, %arg0[%offset], %mask stride = %stride : tensor<128xf32, #blocked0>
+        %ret = amdg.buffer_atomic_rmw fadd, acq_rel, gpu, %values, %arg0[%offset], %mask stride = %stride : <f32> -> tensor<128xf32, #blocked0>
 
         // CHECK: %[[result:.*]] = llvm.call_intrinsic "llvm.amdgcn.raw.ptr.buffer.atomic.fadd"({{.*}}, {{.*}}, %[[mask1:.*]], {{.*}}, {{.*}}) : (f32, !llvm.ptr<8>, i32, i32, i32) -> f32
         // CHECK: %[[result:.*]] = llvm.call_intrinsic "llvm.amdgcn.raw.ptr.buffer.atomic.fadd"({{.*}}, {{.*}}, %[[mask1:.*]], {{.*}}, {{.*}}) : (f32, !llvm.ptr<8>, i32, i32, i32) -> f32
@@ -246,7 +246,7 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 1 : i32, "ttg.thr
     // CHECK: llvm.call_intrinsic "llvm.amdgcn.raw.ptr.buffer.atomic.fadd"({{.*}}) : (f32, !llvm.ptr<8>, i32, i32, i32) -> f32
     // CHECK: llvm.fence syncscope("agent") acquire
     tt.func public @buffer_atomic_rmw_fadd_acquire(%arg0: !tt.ptr<f32> {tt.divisibility = 16 : i32}, %offsets : tensor<64xi32, #blocked0>{tt.divisibility=16:i32}, %values : tensor<64xf32, #blocked0>) {
-        %ret = amdg.buffer_atomic_rmw fadd, acquire, gpu, %values, %arg0[%offsets] : tensor<64xf32, #blocked0>
+        %ret = amdg.buffer_atomic_rmw fadd, acquire, gpu, %values, %arg0[%offsets] : <f32> -> tensor<64xf32, #blocked0>
         tt.return
     }
 }
@@ -261,7 +261,7 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 1 : i32, "ttg.thr
     // No acquire fence after the atomic for release ordering
     // CHECK-NOT: llvm.fence syncscope("agent") acquire
     tt.func public @buffer_atomic_rmw_fadd_release(%arg0: !tt.ptr<f32> {tt.divisibility = 16 : i32}, %offsets : tensor<64xi32, #blocked0>{tt.divisibility=16:i32}, %values : tensor<64xf32, #blocked0>) {
-        %ret = amdg.buffer_atomic_rmw fadd, release, gpu, %values, %arg0[%offsets] : tensor<64xf32, #blocked0>
+        %ret = amdg.buffer_atomic_rmw fadd, release, gpu, %values, %arg0[%offsets] : <f32> -> tensor<64xf32, #blocked0>
         tt.return
     }
 }
@@ -273,7 +273,7 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, "ttg.thr
     // CHECK-LABEL: buffer_atomic_rmw_xchg_i32
     // CHECK: llvm.call_intrinsic "llvm.amdgcn.raw.ptr.buffer.atomic.swap"({{.*}}) : (i32, !llvm.ptr<8>, i32, i32, i32) -> i32
     tt.func public @buffer_atomic_rmw_xchg_i32(%arg0: !tt.ptr<i32> {tt.divisibility = 16 : i32}, %offsets : tensor<256xi32, #blocked0>{tt.divisibility=16:i32}, %values : tensor<256xi32, #blocked0>) {
-        %ret = amdg.buffer_atomic_rmw exch, acq_rel, gpu, %values, %arg0[%offsets] : tensor<256xi32, #blocked0>
+        %ret = amdg.buffer_atomic_rmw exch, acq_rel, gpu, %values, %arg0[%offsets] : <i32> -> tensor<256xi32, #blocked0>
         tt.return
     }
 }
@@ -285,7 +285,7 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, "ttg.thr
     // CHECK-LABEL: buffer_atomic_rmw_fmax_f32
     // CHECK: llvm.call_intrinsic "llvm.amdgcn.raw.ptr.buffer.atomic.fmax"({{.*}}) : (f32, !llvm.ptr<8>, i32, i32, i32) -> f32
     tt.func public @buffer_atomic_rmw_fmax_f32(%arg0: !tt.ptr<f32> {tt.divisibility = 16 : i32}, %offsets : tensor<256xi32, #blocked0>{tt.divisibility=16:i32}, %values : tensor<256xf32, #blocked0>) {
-        %ret = amdg.buffer_atomic_rmw max, acq_rel, gpu, %values, %arg0[%offsets] : tensor<256xf32, #blocked0>
+        %ret = amdg.buffer_atomic_rmw max, acq_rel, gpu, %values, %arg0[%offsets] : <f32> -> tensor<256xf32, #blocked0>
         tt.return
     }
 }
@@ -297,7 +297,7 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, "ttg.thr
     // CHECK-LABEL: buffer_atomic_rmw_fmin_f32
     // CHECK: llvm.call_intrinsic "llvm.amdgcn.raw.ptr.buffer.atomic.fmin"({{.*}}) : (f32, !llvm.ptr<8>, i32, i32, i32) -> f32
     tt.func public @buffer_atomic_rmw_fmin_f32(%arg0: !tt.ptr<f32> {tt.divisibility = 16 : i32}, %offsets : tensor<256xi32, #blocked0>{tt.divisibility=16:i32}, %values : tensor<256xf32, #blocked0>) {
-        %ret = amdg.buffer_atomic_rmw min, acq_rel, gpu, %values, %arg0[%offsets] : tensor<256xf32, #blocked0>
+        %ret = amdg.buffer_atomic_rmw min, acq_rel, gpu, %values, %arg0[%offsets] : <f32> -> tensor<256xf32, #blocked0>
         tt.return
     }
 }
@@ -309,7 +309,7 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, "ttg.thr
     // CHECK-LABEL: buffer_atomic_rmw_smax_i32
     // CHECK: llvm.call_intrinsic "llvm.amdgcn.raw.ptr.buffer.atomic.smax"({{.*}}) : (i32, !llvm.ptr<8>, i32, i32, i32) -> i32
     tt.func public @buffer_atomic_rmw_smax_i32(%arg0: !tt.ptr<i32> {tt.divisibility = 16 : i32}, %offsets : tensor<256xi32, #blocked0>{tt.divisibility=16:i32}, %values : tensor<256xi32, #blocked0>) {
-        %ret = amdg.buffer_atomic_rmw max, acq_rel, gpu, %values, %arg0[%offsets] : tensor<256xi32, #blocked0>
+        %ret = amdg.buffer_atomic_rmw max, acq_rel, gpu, %values, %arg0[%offsets] : <i32> -> tensor<256xi32, #blocked0>
         tt.return
     }
 }
@@ -321,7 +321,7 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, "ttg.thr
     // CHECK-LABEL: buffer_atomic_rmw_smin_i32
     // CHECK: llvm.call_intrinsic "llvm.amdgcn.raw.ptr.buffer.atomic.smin"({{.*}}) : (i32, !llvm.ptr<8>, i32, i32, i32) -> i32
     tt.func public @buffer_atomic_rmw_smin_i32(%arg0: !tt.ptr<i32> {tt.divisibility = 16 : i32}, %offsets : tensor<256xi32, #blocked0>{tt.divisibility=16:i32}, %values : tensor<256xi32, #blocked0>) {
-        %ret = amdg.buffer_atomic_rmw min, acq_rel, gpu, %values, %arg0[%offsets] : tensor<256xi32, #blocked0>
+        %ret = amdg.buffer_atomic_rmw min, acq_rel, gpu, %values, %arg0[%offsets] : <i32> -> tensor<256xi32, #blocked0>
         tt.return
     }
 }
@@ -333,7 +333,7 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, "ttg.thr
     // CHECK-LABEL: buffer_atomic_rmw_umax_i32
     // CHECK: llvm.call_intrinsic "llvm.amdgcn.raw.ptr.buffer.atomic.umax"({{.*}}) : (i32, !llvm.ptr<8>, i32, i32, i32) -> i32
     tt.func public @buffer_atomic_rmw_umax_i32(%arg0: !tt.ptr<i32> {tt.divisibility = 16 : i32}, %offsets : tensor<256xi32, #blocked0>{tt.divisibility=16:i32}, %values : tensor<256xi32, #blocked0>) {
-        %ret = amdg.buffer_atomic_rmw umax, acq_rel, gpu, %values, %arg0[%offsets] : tensor<256xi32, #blocked0>
+        %ret = amdg.buffer_atomic_rmw umax, acq_rel, gpu, %values, %arg0[%offsets] : <i32> -> tensor<256xi32, #blocked0>
         tt.return
     }
 }
@@ -345,7 +345,7 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, "ttg.thr
     // CHECK-LABEL: buffer_atomic_rmw_umin_i32
     // CHECK: llvm.call_intrinsic "llvm.amdgcn.raw.ptr.buffer.atomic.umin"({{.*}}) : (i32, !llvm.ptr<8>, i32, i32, i32) -> i32
     tt.func public @buffer_atomic_rmw_umin_i32(%arg0: !tt.ptr<i32> {tt.divisibility = 16 : i32}, %offsets : tensor<256xi32, #blocked0>{tt.divisibility=16:i32}, %values : tensor<256xi32, #blocked0>) {
-        %ret = amdg.buffer_atomic_rmw umin, acq_rel, gpu, %values, %arg0[%offsets] : tensor<256xi32, #blocked0>
+        %ret = amdg.buffer_atomic_rmw umin, acq_rel, gpu, %values, %arg0[%offsets] : <i32> -> tensor<256xi32, #blocked0>
         tt.return
     }
 }
@@ -364,7 +364,7 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, "ttg.thr
         // We expect vector size == 1 (i16) for the generated loads as sizePerThread = [1, 1]
         // CHECK-COUNT-8: rocdl.raw.ptr.buffer.load {{.*}}, {{.*}}, {{.*}}, {{.*}} : i16
         // CHECK-NOT: rocdl.raw.ptr.buffer.load
-        %24 = amdg.buffer_load %arg0[%23] : tensor<8x16xf16, #blocked>
+        %24 = amdg.buffer_load %arg0[%23] : <f16> -> tensor<8x16xf16, #blocked>
         tt.return
   }
 }
@@ -380,10 +380,10 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, "ttg.thr
     %1 = arith.muli %0, %cst : tensor<1024xi32, #blocked>
     // CHECK-COUNT-4: rocdl.raw.ptr.buffer.load {{.*}}, {{.*}}, {{.*}}, {{.*}} : f32
     // CHECK-NOT: rocdl.raw.ptr.buffer.load
-    %2 = amdg.buffer_load %arg0[%1] : tensor<1024xf32, #blocked>
+    %2 = amdg.buffer_load %arg0[%1] : <f32> -> tensor<1024xf32, #blocked>
     // CHECK-COUNT-4: rocdl.raw.ptr.buffer.store {{.*}}, {{.*}}, {{.*}}, {{.*}}, {{.*}} : f32
     // CHECK-NOT: rocdl.raw.ptr.buffer.store
-    amdg.buffer_store %2, %arg1[%1] : tensor<1024xf32, #blocked>
+    amdg.buffer_store %2, %arg1[%1] : <f32> -> tensor<1024xf32, #blocked>
     tt.return
   }
 }

--- a/test/Conversion/amd/buffer_load_to_local_to_llvm.mlir
+++ b/test/Conversion/amd/buffer_load_to_local_to_llvm.mlir
@@ -15,7 +15,7 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.shar
     // COMMON-NOT: rocdl.make.buffer.rsrc
     // COMMON-COUNT-8: rocdl.raw.ptr.buffer.load.async.lds
     // COMMON-NOT: rocdl.raw.ptr.buffer.load.async.lds
-    %65 = amdg.buffer_load_to_local %arg1[%arg2] into %arg3 : <f32>[tensor<32x64xi32, #blocked>] -> <32x64xf32, #shared, #smem, mutable>
+    %65 = amdg.buffer_load_to_local %arg1[%arg2] into %arg3 : !tt.ptr<f32>[tensor<32x64xi32, #blocked>] -> <32x64xf32, #shared, #smem, mutable>
     tt.return
   }
 }
@@ -43,7 +43,7 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 32 : i32, ttg.sha
     // COMMON-NOT: rocdl.make.buffer.rsrc
     // COMMON: rocdl.raw.ptr.buffer.load.async.lds
     // COMMON-NOT: rocdl.raw.ptr.buffer.load.async.lds
-    %8 = amdg.buffer_load_to_local %arg1[%7] into %arg2 : <f16>[tensor<64x64xi32, #blocked>]  -> <64x64xf16, #shared, #smem, mutable>
+    %8 = amdg.buffer_load_to_local %arg1[%7] into %arg2 : !tt.ptr<f16>[tensor<64x64xi32, #blocked>]  -> <64x64xf16, #shared, #smem, mutable>
     tt.return
   }
 }
@@ -75,7 +75,7 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 32 : i32, ttg.sha
     // GFX942 does not support vectorization > 4bytes so we cannot lower it
     // GFX942-NOT: rocdl.raw.ptr.buffer.load.async.lds
     // GFX942: amdg.buffer_load_to_local
-    %8 = amdg.buffer_load_to_local %arg1[%7] into %arg2 : <f16>[tensor<64x64xi32, #blocked>]  -> <64x64xf16, #shared, #smem, mutable>
+    %8 = amdg.buffer_load_to_local %arg1[%7] into %arg2 : !tt.ptr<f16>[tensor<64x64xi32, #blocked>]  -> <64x64xf16, #shared, #smem, mutable>
     tt.return
   }
 }
@@ -107,7 +107,7 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.shar
     // GFX942 does not support vectorization > 4bytes so we cannot lower it
     // GFX942-NOT: rocdl.raw.ptr.buffer.load.async.lds
     // GFX942: amdg.buffer_load_to_local
-    %8 = amdg.buffer_load_to_local %arg1[%7] into %arg2 : <f16>[tensor<256x8xi32, #blocked>]  -> <256x8xf16, #shared, #smem, mutable>
+    %8 = amdg.buffer_load_to_local %arg1[%7] into %arg2 : !tt.ptr<f16>[tensor<256x8xi32, #blocked>]  -> <256x8xf16, #shared, #smem, mutable>
     tt.return
   }
 }
@@ -171,7 +171,7 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.shar
     // COMMON-NOT: llvm.cond_br
     // COMMON-NOT: llvm.store
 
-    amdg.buffer_load_to_local %arg1[%arg2] mask=%67 other=%cst_0 into %arg3 : <f32>[tensor<32x32xi32, #blocked>] tensor<32x32xf32, #blocked>  -> <32x32xf32, #shared, #smem, mutable>
+    amdg.buffer_load_to_local %arg1[%arg2] mask=%67 other=%cst_0 into %arg3 : !tt.ptr<f32>[tensor<32x32xi32, #blocked>] tensor<32x32xf32, #blocked>  -> <32x32xf32, #shared, #smem, mutable>
     tt.return
   }
 }
@@ -192,13 +192,13 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 1 : i32, "ttg.thr
     // COMMON: %[[IMM0:.*]] = llvm.mlir.constant(0 : i32) : i32
     // COMMON: %[[IMM1:.*]] = llvm.mlir.constant(0 : i32) : i32
     // COMMON: rocdl.raw.ptr.buffer.load.async.lds {{.*}}, {{.*}}, {{.*}}, %[[VOFFSET]], %[[IMM0]], %[[IMM1]], 0
-    %1 = amdg.buffer_load_to_local %arg0[%0] cacheModifier = ca into %arg2: <f32>[tensor<64xi32, #blocked>] -> <64xf32, #shared, #smem, mutable>
+    %1 = amdg.buffer_load_to_local %arg0[%0] cacheModifier = ca into %arg2: !tt.ptr<f32>[tensor<64xi32, #blocked>] -> <64xf32, #shared, #smem, mutable>
     // COMMON: llvm.getelementptr
     // COMMON: rocdl.raw.ptr.buffer.load.async.lds {{.*}}, {{.*}}, {{.*}}, {{.*}}, {{.*}}, {{.*}}, 3
-    %2 = amdg.buffer_load_to_local %arg0[%0] cacheModifier = cg into %arg2: <f32>[tensor<64xi32, #blocked>] -> <64xf32, #shared, #smem, mutable>
+    %2 = amdg.buffer_load_to_local %arg0[%0] cacheModifier = cg into %arg2: !tt.ptr<f32>[tensor<64xi32, #blocked>] -> <64xf32, #shared, #smem, mutable>
     // COMMON: llvm.getelementptr
     // COMMON: rocdl.raw.ptr.buffer.load.async.lds {{.*}}, {{.*}}, {{.*}}, {{.*}}, {{.*}}, {{.*}}, 17
-    %3 = amdg.buffer_load_to_local %arg0[%0] cacheModifier = cv into %arg2: <f32>[tensor<64xi32, #blocked>] -> <64xf32, #shared, #smem, mutable>
+    %3 = amdg.buffer_load_to_local %arg0[%0] cacheModifier = cv into %arg2: !tt.ptr<f32>[tensor<64xi32, #blocked>] -> <64xf32, #shared, #smem, mutable>
 
     tt.return
   }
@@ -223,7 +223,7 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 8 : i32, ttg.shar
     // COMMON: rocdl.ds_bpermute
     // COMMON: rocdl.raw.ptr.buffer.load.async.lds
     // COMMON-NOT: rocdl.raw.ptr.buffer.load.async.lds
-    %65 = amdg.buffer_load_to_local %arg1[%arg2] into %arg3 : <f32>[tensor<16x64xi32, #blocked>] -> <16x64xf32, #shared, #smem, mutable>
+    %65 = amdg.buffer_load_to_local %arg1[%arg2] into %arg3 : !tt.ptr<f32>[tensor<16x64xi32, #blocked>] -> <16x64xf32, #shared, #smem, mutable>
     tt.return
   }
 }
@@ -291,7 +291,7 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.shar
     // COMMON-NOT: rocdl.raw.ptr.buffer.load.async.lds
     // COMMON-NOT: _predicated_store
 
-    amdg.buffer_load_to_local %arg1[%arg2] mask=%67 other=%cst_0 into %arg3 : <f32>[tensor<32x32xi32, #blocked>] tensor<32x32xf32, #blocked>  -> <32x32xf32, #shared, #smem, mutable>
+    amdg.buffer_load_to_local %arg1[%arg2] mask=%67 other=%cst_0 into %arg3 : !tt.ptr<f32>[tensor<32x32xi32, #blocked>] tensor<32x32xf32, #blocked>  -> <32x32xf32, #shared, #smem, mutable>
     tt.return
   }
 }
@@ -322,7 +322,7 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 32 : i32, ttg.sha
     // GFX942 does not support vectorization > 4bytes so we cannot lower it
     // GFX942-NOT: rocdl.raw.ptr.buffer.load.async.lds
     // GFX942: amdg.buffer_load_to_local
-    %8 = amdg.buffer_load_to_local %arg1[%7] into %arg2 : <f16>[tensor<64x64xi32, #blocked>]  -> <64x64xf16, #shared, #smem, mutable>
+    %8 = amdg.buffer_load_to_local %arg1[%7] into %arg2 : !tt.ptr<f16>[tensor<64x64xi32, #blocked>]  -> <64x64xf16, #shared, #smem, mutable>
     tt.return
   }
 }
@@ -338,7 +338,7 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, "ttg.thr
     // Check we load 4 bytes
     // COMMON: %[[LOAD_BYTES:.*]] = llvm.mlir.constant(4 : i32) : i32
     // COMMON: rocdl.raw.ptr.buffer.load.async.lds %{{.*}}, %{{.*}}, %[[LOAD_BYTES]]
-    %0 = amdg.buffer_load_to_local %ptr[%off] into %lds {contiguity = 2 : i32} : <f16>[tensor<256xi32, #blocked>] -> <256xf16, #shared1D, #smem, mutable>
+    %0 = amdg.buffer_load_to_local %ptr[%off] into %lds {contiguity = 2 : i32} : !tt.ptr<f16>[tensor<256xi32, #blocked>] -> <256xf16, #shared1D, #smem, mutable>
     tt.return
   }
 }
@@ -357,7 +357,7 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, "ttg.thr
     // CHECK: %[[OOB_PTR:.*]] = llvm.inttoptr %[[OOB_I32]] : i32 to !llvm.ptr<3>
     // CHECK: %[[PRED_ADDR:.*]] = llvm.select {{.*}}, {{.*}}, %[[OOB_PTR]] : i1, !llvm.ptr<3>
     // CHECK: rocdl.raw.ptr.buffer.load.async.lds {{.*}}, %[[PRED_ADDR]], {{.*}}
-    %0 = amdg.buffer_load_to_local %ptr[%off] into %lds : <f32>[tensor<64xi32, #blocked>] -> <64xf32, #shared, #smem, mutable>
+    %0 = amdg.buffer_load_to_local %ptr[%off] into %lds : !tt.ptr<f32>[tensor<64xi32, #blocked>] -> <64xf32, #shared, #smem, mutable>
     tt.return
   }
 }
@@ -378,7 +378,7 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, "ttg.thr
     // CHECK: llvm.cond_br %[[PRED]], ^[[LOAD_BLOCK:bb[0-9]+]]
     // CHECK-NEXT: ^[[LOAD_BLOCK]]:
     // CHECK: rocdl.raw.ptr.buffer.load.async.lds
-    %0 = amdg.buffer_load_to_local %ptr[%off] mask=%mask other=%other into %lds : <f32>[tensor<64xi32, #blocked>] tensor<64xf32, #blocked> -> <64xf32, #shared, #smem, mutable>
+    %0 = amdg.buffer_load_to_local %ptr[%off] mask=%mask other=%other into %lds : !tt.ptr<f32>[tensor<64xi32, #blocked>] tensor<64xf32, #blocked> -> <64xf32, #shared, #smem, mutable>
     tt.return
   }
 }
@@ -402,7 +402,7 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, "ttg.thr
     // regardless of whether the load branch was taken (i.e., for masked-out lanes).
     // COMMON-NEXT: ^[[AFTER_BB]]:
     // COMMON: llvm.store
-    amdg.buffer_load_to_local %ptr[%off] mask=%mask other=%other into %lds : <f32>[tensor<64xi32, #blocked>] tensor<64xf32, #blocked> -> <64xf32, #shared, #smem, mutable>
+    amdg.buffer_load_to_local %ptr[%off] mask=%mask other=%other into %lds : !tt.ptr<f32>[tensor<64xi32, #blocked>] tensor<64xf32, #blocked> -> <64xf32, #shared, #smem, mutable>
     tt.return
   }
 }
@@ -431,7 +431,7 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 1 : i32, ttg.targ
     // COMMON: rocdl.raw.ptr.buffer.load.async.lds
     // COMMON: rocdl.raw.ptr.buffer.load.async.lds
     // COMMON-NOT: rocdl.raw.ptr.buffer.load.async.lds
-    %8 = amdg.buffer_load_to_local %arg0[%7] into %arg1 : <f32>[tensor<64x2xi32, #blocked>] -> <64x2xf32, #shared, #smem, mutable>
+    %8 = amdg.buffer_load_to_local %arg0[%7] into %arg1 : !tt.ptr<f32>[tensor<64x2xi32, #blocked>] -> <64x2xf32, #shared, #smem, mutable>
     tt.return
   }
 }

--- a/test/Conversion/amd/buffer_ops_gfx1250.mlir
+++ b/test/Conversion/amd/buffer_ops_gfx1250.mlir
@@ -21,7 +21,7 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 1 : i32, "ttg.thr
 
     // There should be a single acquire fence after all of the atomics
     // CHECK: llvm.fence syncscope("agent") acquire
-    %ret = amdg.buffer_atomic_rmw fadd, acq_rel, gpu, %values, %arg0[%offset] : <f32> -> tensor<128xf32, #blocked>
+    %ret = amdg.buffer_atomic_rmw fadd, acq_rel, gpu, %values, %arg0[%offset] : !tt.ptr<f32> -> tensor<128xf32, #blocked>
     tt.return
   }
 }
@@ -50,10 +50,10 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, "ttg.thr
     // CHECK: rocdl.raw.ptr.buffer.atomic.cmpswap {{.*}}, 17 : i32
     // CHECK: rocdl.raw.ptr.buffer.atomic.cmpswap {{.*}}, 17 : i32
     // CHECK: llvm.fence syncscope("agent") acquire
-    %4 = amdg.buffer_atomic_cas acq_rel, gpu, %cmp, %val, %scalar_ptr[%offsets] : <i32> -> tensor<256xi32, #blocked>
+    %4 = amdg.buffer_atomic_cas acq_rel, gpu, %cmp, %val, %scalar_ptr[%offsets] : !tt.ptr<i32> -> tensor<256xi32, #blocked>
 
     %5 = tt.addptr %arg1, %1 : !tt.ptr<i32>, i32
-    amdg.buffer_store %4, %5[%offsets] : <i32> -> tensor<256xi32, #blocked>
+    amdg.buffer_store %4, %5[%offsets] : !tt.ptr<i32> -> tensor<256xi32, #blocked>
     tt.return
   }
 }
@@ -79,7 +79,7 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 1 : i32, "ttg.thr
     // CHECK: llvm.call_intrinsic "llvm.amdgcn.raw.ptr.buffer.atomic.fadd"({{.*}}) : (vector<2xbf16>, !llvm.ptr<8>, i32, i32, i32) -> vector<2xbf16>
 
     // CHECK: llvm.fence syncscope("agent") acquire
-    %ret = amdg.buffer_atomic_rmw fadd, acq_rel, gpu, %values, %arg0[%offsets] : <bf16> -> tensor<64xbf16, #blocked>
+    %ret = amdg.buffer_atomic_rmw fadd, acq_rel, gpu, %values, %arg0[%offsets] : !tt.ptr<bf16> -> tensor<64xbf16, #blocked>
     tt.return
   }
 }

--- a/test/Conversion/amd/buffer_ops_gfx1250.mlir
+++ b/test/Conversion/amd/buffer_ops_gfx1250.mlir
@@ -21,7 +21,7 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 1 : i32, "ttg.thr
 
     // There should be a single acquire fence after all of the atomics
     // CHECK: llvm.fence syncscope("agent") acquire
-    %ret = amdg.buffer_atomic_rmw fadd, acq_rel, gpu, %values, %arg0[%offset] : tensor<128xf32, #blocked>
+    %ret = amdg.buffer_atomic_rmw fadd, acq_rel, gpu, %values, %arg0[%offset] : <f32> -> tensor<128xf32, #blocked>
     tt.return
   }
 }
@@ -50,10 +50,10 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, "ttg.thr
     // CHECK: rocdl.raw.ptr.buffer.atomic.cmpswap {{.*}}, 17 : i32
     // CHECK: rocdl.raw.ptr.buffer.atomic.cmpswap {{.*}}, 17 : i32
     // CHECK: llvm.fence syncscope("agent") acquire
-    %4 = amdg.buffer_atomic_cas acq_rel, gpu, %cmp, %val, %scalar_ptr[%offsets] : tensor<256xi32, #blocked>
+    %4 = amdg.buffer_atomic_cas acq_rel, gpu, %cmp, %val, %scalar_ptr[%offsets] : <i32> -> tensor<256xi32, #blocked>
 
     %5 = tt.addptr %arg1, %1 : !tt.ptr<i32>, i32
-    amdg.buffer_store %4, %5[%offsets] : tensor<256xi32, #blocked>
+    amdg.buffer_store %4, %5[%offsets] : <i32> -> tensor<256xi32, #blocked>
     tt.return
   }
 }
@@ -79,7 +79,7 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 1 : i32, "ttg.thr
     // CHECK: llvm.call_intrinsic "llvm.amdgcn.raw.ptr.buffer.atomic.fadd"({{.*}}) : (vector<2xbf16>, !llvm.ptr<8>, i32, i32, i32) -> vector<2xbf16>
 
     // CHECK: llvm.fence syncscope("agent") acquire
-    %ret = amdg.buffer_atomic_rmw fadd, acq_rel, gpu, %values, %arg0[%offsets] : tensor<64xbf16, #blocked>
+    %ret = amdg.buffer_atomic_rmw fadd, acq_rel, gpu, %values, %arg0[%offsets] : <bf16> -> tensor<64xbf16, #blocked>
     tt.return
   }
 }

--- a/test/Conversion/amd/cluster_load.mlir
+++ b/test/Conversion/amd/cluster_load.mlir
@@ -177,11 +177,11 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.targ
     // Scalar load should produce a regular llvm.load, not a cluster load
     // CHECK: llvm.load %{{.*}} : !llvm.ptr<1> -> vector<1xi16>
     %1 = tt.load %arg1 : !tt.ptr<i16>
-    %2 = amdg.buffer_load %arg2[%0] : tensor<128xi32, #blocked>
+    %2 = amdg.buffer_load %arg2[%0] : <i32> -> tensor<128xi32, #blocked>
     %3 = arith.extsi %1 : i16 to i32
     %4 = tt.splat %3 : i32 -> tensor<128xi32, #blocked>
     %5 = arith.ori %4, %2 : tensor<128xi32, #blocked>
-    amdg.buffer_store %5, %arg0[%0] : tensor<128xi32, #blocked>
+    amdg.buffer_store %5, %arg0[%0] : <i32> -> tensor<128xi32, #blocked>
     tt.return
   }
 }

--- a/test/Conversion/amd/cluster_load.mlir
+++ b/test/Conversion/amd/cluster_load.mlir
@@ -177,11 +177,11 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.targ
     // Scalar load should produce a regular llvm.load, not a cluster load
     // CHECK: llvm.load %{{.*}} : !llvm.ptr<1> -> vector<1xi16>
     %1 = tt.load %arg1 : !tt.ptr<i16>
-    %2 = amdg.buffer_load %arg2[%0] : <i32> -> tensor<128xi32, #blocked>
+    %2 = amdg.buffer_load %arg2[%0] : !tt.ptr<i32> -> tensor<128xi32, #blocked>
     %3 = arith.extsi %1 : i16 to i32
     %4 = tt.splat %3 : i32 -> tensor<128xi32, #blocked>
     %5 = arith.ori %4, %2 : tensor<128xi32, #blocked>
-    amdg.buffer_store %5, %arg0[%0] : <i32> -> tensor<128xi32, #blocked>
+    amdg.buffer_store %5, %arg0[%0] : !tt.ptr<i32> -> tensor<128xi32, #blocked>
     tt.return
   }
 }

--- a/test/TritonGPU/amd/amd-buffer-cache-modifiers-rdna3.mlir
+++ b/test/TritonGPU/amd/amd-buffer-cache-modifiers-rdna3.mlir
@@ -19,7 +19,7 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 1 : i32, "ttg.thr
   tt.func @buffer_load_cg(%arg0: !tt.ptr<f32> {tt.divisibility = 16 : i32}, %offset: tensor<128xi32, #blocked> {tt.divisibility = 16 : i32}) {
     // .cg load on RDNA3.5: aux = 1 (GLC)
     // CHECK: rocdl.raw.ptr.buffer.load {{.*}}, {{.*}}, {{.*}}, 1
-    %ret = amdg.buffer_load %arg0[%offset] cacheModifier = cg : tensor<128xf32, #blocked>
+    %ret = amdg.buffer_load %arg0[%offset] cacheModifier = cg : <f32> -> tensor<128xf32, #blocked>
     tt.return
   }
 }
@@ -33,7 +33,7 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 1 : i32, "ttg.thr
   tt.func @buffer_load_cs(%arg0: !tt.ptr<f32> {tt.divisibility = 16 : i32}, %offset: tensor<128xi32, #blocked> {tt.divisibility = 16 : i32}) {
     // .cs load on RDNA3.5: aux = 7 (GLC|SLC|DLC)
     // CHECK: rocdl.raw.ptr.buffer.load {{.*}}, {{.*}}, {{.*}}, 7
-    %ret = amdg.buffer_load %arg0[%offset] cacheModifier = cs : tensor<128xf32, #blocked>
+    %ret = amdg.buffer_load %arg0[%offset] cacheModifier = cs : <f32> -> tensor<128xf32, #blocked>
     tt.return
   }
 }
@@ -47,7 +47,7 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 1 : i32, "ttg.thr
   tt.func @buffer_load_cv(%arg0: !tt.ptr<f32> {tt.divisibility = 16 : i32}, %offset: tensor<128xi32, #blocked> {tt.divisibility = 16 : i32}) {
     // .cv load on RDNA3.5: aux = 7 (GLC|SLC|DLC)
     // CHECK: rocdl.raw.ptr.buffer.load {{.*}}, {{.*}}, {{.*}}, 7
-    %ret = amdg.buffer_load %arg0[%offset] cacheModifier = cv : tensor<128xf32, #blocked>
+    %ret = amdg.buffer_load %arg0[%offset] cacheModifier = cv : <f32> -> tensor<128xf32, #blocked>
     tt.return
   }
 }
@@ -62,7 +62,7 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 1 : i32, "ttg.thr
     %c256_i32 = arith.constant 256 : i32
     // .cs store on RDNA3.5: aux = 7 (GLC|SLC|DLC)
     // CHECK: rocdl.raw.ptr.buffer.store {{.*}}, {{.*}}, {{.*}}, {{.*}}, 7
-    amdg.buffer_store %value, %arg0[%offset] cacheModifier = cs stride = %c256_i32 : tensor<128xf32, #blocked>
+    amdg.buffer_store %value, %arg0[%offset] cacheModifier = cs stride = %c256_i32 : <f32> -> tensor<128xf32, #blocked>
     tt.return
   }
 }
@@ -77,7 +77,7 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 1 : i32, "ttg.thr
     %c256_i32 = arith.constant 256 : i32
     // .wt store on RDNA3.5: aux = 7 (GLC|SLC|DLC)
     // CHECK: rocdl.raw.ptr.buffer.store {{.*}}, {{.*}}, {{.*}}, {{.*}}, 7
-    amdg.buffer_store %value, %arg0[%offset] cacheModifier = wt stride = %c256_i32 : tensor<128xf32, #blocked>
+    amdg.buffer_store %value, %arg0[%offset] cacheModifier = wt stride = %c256_i32 : <f32> -> tensor<128xf32, #blocked>
     tt.return
   }
 }

--- a/test/TritonGPU/amd/amd-buffer-cache-modifiers-rdna3.mlir
+++ b/test/TritonGPU/amd/amd-buffer-cache-modifiers-rdna3.mlir
@@ -19,7 +19,7 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 1 : i32, "ttg.thr
   tt.func @buffer_load_cg(%arg0: !tt.ptr<f32> {tt.divisibility = 16 : i32}, %offset: tensor<128xi32, #blocked> {tt.divisibility = 16 : i32}) {
     // .cg load on RDNA3.5: aux = 1 (GLC)
     // CHECK: rocdl.raw.ptr.buffer.load {{.*}}, {{.*}}, {{.*}}, 1
-    %ret = amdg.buffer_load %arg0[%offset] cacheModifier = cg : <f32> -> tensor<128xf32, #blocked>
+    %ret = amdg.buffer_load %arg0[%offset] cacheModifier = cg : !tt.ptr<f32> -> tensor<128xf32, #blocked>
     tt.return
   }
 }
@@ -33,7 +33,7 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 1 : i32, "ttg.thr
   tt.func @buffer_load_cs(%arg0: !tt.ptr<f32> {tt.divisibility = 16 : i32}, %offset: tensor<128xi32, #blocked> {tt.divisibility = 16 : i32}) {
     // .cs load on RDNA3.5: aux = 7 (GLC|SLC|DLC)
     // CHECK: rocdl.raw.ptr.buffer.load {{.*}}, {{.*}}, {{.*}}, 7
-    %ret = amdg.buffer_load %arg0[%offset] cacheModifier = cs : <f32> -> tensor<128xf32, #blocked>
+    %ret = amdg.buffer_load %arg0[%offset] cacheModifier = cs : !tt.ptr<f32> -> tensor<128xf32, #blocked>
     tt.return
   }
 }
@@ -47,7 +47,7 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 1 : i32, "ttg.thr
   tt.func @buffer_load_cv(%arg0: !tt.ptr<f32> {tt.divisibility = 16 : i32}, %offset: tensor<128xi32, #blocked> {tt.divisibility = 16 : i32}) {
     // .cv load on RDNA3.5: aux = 7 (GLC|SLC|DLC)
     // CHECK: rocdl.raw.ptr.buffer.load {{.*}}, {{.*}}, {{.*}}, 7
-    %ret = amdg.buffer_load %arg0[%offset] cacheModifier = cv : <f32> -> tensor<128xf32, #blocked>
+    %ret = amdg.buffer_load %arg0[%offset] cacheModifier = cv : !tt.ptr<f32> -> tensor<128xf32, #blocked>
     tt.return
   }
 }
@@ -62,7 +62,7 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 1 : i32, "ttg.thr
     %c256_i32 = arith.constant 256 : i32
     // .cs store on RDNA3.5: aux = 7 (GLC|SLC|DLC)
     // CHECK: rocdl.raw.ptr.buffer.store {{.*}}, {{.*}}, {{.*}}, {{.*}}, 7
-    amdg.buffer_store %value, %arg0[%offset] cacheModifier = cs stride = %c256_i32 : <f32> -> tensor<128xf32, #blocked>
+    amdg.buffer_store %value, %arg0[%offset] cacheModifier = cs stride = %c256_i32 : !tt.ptr<f32> -> tensor<128xf32, #blocked>
     tt.return
   }
 }
@@ -77,7 +77,7 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 1 : i32, "ttg.thr
     %c256_i32 = arith.constant 256 : i32
     // .wt store on RDNA3.5: aux = 7 (GLC|SLC|DLC)
     // CHECK: rocdl.raw.ptr.buffer.store {{.*}}, {{.*}}, {{.*}}, {{.*}}, 7
-    amdg.buffer_store %value, %arg0[%offset] cacheModifier = wt stride = %c256_i32 : <f32> -> tensor<128xf32, #blocked>
+    amdg.buffer_store %value, %arg0[%offset] cacheModifier = wt stride = %c256_i32 : !tt.ptr<f32> -> tensor<128xf32, #blocked>
     tt.return
   }
 }

--- a/test/TritonGPU/amd/amd-consan.mlir
+++ b/test/TritonGPU/amd/amd-consan.mlir
@@ -1160,7 +1160,7 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.shar
     // CHECK: tt.call @__triton_consan_verify_read_visibility
     // CHECK: tt.call @__triton_consan_stage_access_for_commit
     // CHECK: amdg.buffer_load_to_local
-    %token = amdg.buffer_load_to_local %ptr[%offsets] into %buffer : <f32>[tensor<32x64xi32, #blocked>] -> <32x64xf32, #shared, #smem, mutable>
+    %token = amdg.buffer_load_to_local %ptr[%offsets] into %buffer : !tt.ptr<f32>[tensor<32x64xi32, #blocked>] -> <32x64xf32, #shared, #smem, mutable>
     // CHECK: tt.call @__triton_consan_commit_accesses
     // CHECK: ttg.async_commit_group
     %group = ttg.async_commit_group tokens %token

--- a/test/TritonGPU/amd/amd-convert-buffer-ops-range-analysis.mlir
+++ b/test/TritonGPU/amd/amd-convert-buffer-ops-range-analysis.mlir
@@ -36,7 +36,7 @@ module attributes {"ttg.num-warps" = 4 : i32, "ttg.threads-per-warp" = 64 : i32}
 // CHECK:           %[[VAL_4:.*]] = arith.muli %[[VAL_3]], %[[VAL_2]] : i32
 // CHECK:           %[[VAL_5:.*]] = tt.make_range {end = 1024 : i32, start = 0 : i32} : tensor<1024xi32, #blocked>
 // CHECK:           %[[VAL_6:.*]] = tt.addptr %[[VAL_0]], %[[VAL_4]] : !tt.ptr<f32>, i32
-// CHECK:           %[[VAL_7:.*]] = amdg.buffer_load %[[VAL_6]]{{\[}}%[[VAL_5]]] : <f32> -> tensor<1024xf32, #blocked>
+// CHECK:           %[[VAL_7:.*]] = amdg.buffer_load %[[VAL_6]]{{\[}}%[[VAL_5]]] : !tt.ptr<f32> -> tensor<1024xf32, #blocked>
 // CHECK:           tt.return %[[VAL_7]] : tensor<1024xf32, #blocked>
 // CHECK:         }
 
@@ -70,7 +70,7 @@ module attributes {"ttg.num-warps" = 4 : i32, "ttg.threads-per-warp" = 64 : i32}
 // CHECK:           %[[VAL_8:.*]] = arith.extsi %[[VAL_4]] : tensor<1024xi32, #blocked> to tensor<1024xi64, #blocked>
 // CHECK:           %[[VAL_9:.*]] = arith.addi %[[VAL_8]], %[[VAL_6]] : tensor<1024xi64, #blocked>
 // CHECK:           %[[VAL_10:.*]] = arith.trunci %[[VAL_9]] : tensor<1024xi64, #blocked> to tensor<1024xi32, #blocked>
-// CHECK:           %[[VAL_11:.*]] = amdg.buffer_load %[[VAL_7]][%[[VAL_10]]] : <f32> -> tensor<1024xf32, #blocked>
+// CHECK:           %[[VAL_11:.*]] = amdg.buffer_load %[[VAL_7]][%[[VAL_10]]] : !tt.ptr<f32> -> tensor<1024xf32, #blocked>
 // CHECK:           tt.return %[[VAL_11]] : tensor<1024xf32, #blocked>
 // CHECK:         }
 
@@ -105,7 +105,7 @@ module attributes {"ttg.num-warps" = 4 : i32, "ttg.threads-per-warp" = 64 : i32}
 // CHECK:           %[[VAL_6:.*]] = tt.addptr %[[VAL_0]], %[[VAL_4]] : !tt.ptr<f32>, i32
 // CHECK:           %[[VAL_7:.*]] = tt.addptr %[[VAL_6]], %[[VAL_4]] : !tt.ptr<f32>, i32
 // CHECK:           %[[VAL_8:.*]] = arith.addi %[[VAL_5]], %[[VAL_5]] : tensor<1024xi32, #blocked>
-// CHECK:           %[[VAL_9:.*]] = amdg.buffer_load %[[VAL_7]]{{\[}}%[[VAL_8]]] : <f32> -> tensor<1024xf32, #blocked>
+// CHECK:           %[[VAL_9:.*]] = amdg.buffer_load %[[VAL_7]]{{\[}}%[[VAL_8]]] : !tt.ptr<f32> -> tensor<1024xf32, #blocked>
 // CHECK:           tt.return %[[VAL_9]] : tensor<1024xf32, #blocked>
 // CHECK:         }
 
@@ -145,7 +145,7 @@ module attributes {"ttg.num-warps" = 4 : i32, "ttg.threads-per-warp" = 64 : i32}
 // CHECK:             %[[VAL_17:.*]] = arith.extsi %[[VAL_8]] : tensor<1024xi32, #blocked> to tensor<1024xi64, #blocked>
 // CHECK:             %[[VAL_18:.*]] = arith.addi %[[VAL_17]], %[[VAL_14]] : tensor<1024xi64, #blocked>
 // CHECK:             %[[VAL_19:.*]] = arith.trunci %[[VAL_18]] : tensor<1024xi64, #blocked> to tensor<1024xi32, #blocked>
-// CHECK:             %[[VAL_20:.*]] = amdg.buffer_load %[[VAL_16]][%[[VAL_19]]] : <f32> -> tensor<1024xf32, #blocked>
+// CHECK:             %[[VAL_20:.*]] = amdg.buffer_load %[[VAL_16]][%[[VAL_19]]] : !tt.ptr<f32> -> tensor<1024xf32, #blocked>
 // CHECK:             %[[VAL_21:.*]] = arith.addf %[[VAL_20]], %[[VAL_15]] : tensor<1024xf32, #blocked>
 // CHECK:             scf.yield %[[VAL_16]], %[[VAL_18]], %[[VAL_21]] : !tt.ptr<f32>, tensor<1024xi64, #blocked>, tensor<1024xf32, #blocked>
 // CHECK:           }
@@ -153,7 +153,7 @@ module attributes {"ttg.num-warps" = 4 : i32, "ttg.threads-per-warp" = 64 : i32}
 // CHECK:           %[[VAL_24:.*]] = arith.extsi %[[VAL_8]] : tensor<1024xi32, #blocked> to tensor<1024xi64, #blocked>
 // CHECK:           %[[VAL_25:.*]] = arith.addi %[[VAL_24]], %[[VAL_23]]#1 : tensor<1024xi64, #blocked>
 // CHECK:           %[[VAL_26:.*]] = arith.trunci %[[VAL_25]] : tensor<1024xi64, #blocked> to tensor<1024xi32, #blocked>
-// CHECK:           %[[VAL_27:.*]] = amdg.buffer_load %[[VAL_22]][%[[VAL_26]]] : <f32> -> tensor<1024xf32, #blocked>
+// CHECK:           %[[VAL_27:.*]] = amdg.buffer_load %[[VAL_22]][%[[VAL_26]]] : !tt.ptr<f32> -> tensor<1024xf32, #blocked>
 // CHECK:           tt.return %[[VAL_27]] : tensor<1024xf32, #blocked>
 // CHECK:         }
 
@@ -207,7 +207,7 @@ module attributes {"ttg.num-warps" = 4 : i32, "ttg.threads-per-warp" = 64 : i32}
 // CHECK:             %[[VAL_16:.*]] = arith.extsi %[[VAL_9]] : tensor<1024xi32, #blocked> to tensor<1024xi64, #blocked>
 // CHECK:             %[[VAL_17:.*]] = arith.addi %[[VAL_16]], %[[VAL_13]] : tensor<1024xi64, #blocked>
 // CHECK:             %[[VAL_18:.*]] = arith.trunci %[[VAL_17]] : tensor<1024xi64, #blocked> to tensor<1024xi32, #blocked>
-// CHECK:             %[[VAL_19:.*]] = amdg.buffer_load %[[VAL_15]][%[[VAL_18]]] : <f32> -> tensor<1024xf32, #blocked>
+// CHECK:             %[[VAL_19:.*]] = amdg.buffer_load %[[VAL_15]][%[[VAL_18]]] : !tt.ptr<f32> -> tensor<1024xf32, #blocked>
 // CHECK:             %[[VAL_20:.*]] = arith.addf %[[VAL_19]], %[[VAL_14]] : tensor<1024xf32, #blocked>
 // CHECK:             scf.yield %[[VAL_15]], %[[VAL_17]], %[[VAL_20]] : !tt.ptr<f32>, tensor<1024xi64, #blocked>, tensor<1024xf32, #blocked>
 // CHECK:           }
@@ -215,7 +215,7 @@ module attributes {"ttg.num-warps" = 4 : i32, "ttg.threads-per-warp" = 64 : i32}
 // CHECK:           %[[VAL_23:.*]] = arith.extsi %[[VAL_9]] : tensor<1024xi32, #blocked> to tensor<1024xi64, #blocked>
 // CHECK:           %[[VAL_24:.*]] = arith.addi %[[VAL_23]], %[[VAL_22]]#1 : tensor<1024xi64, #blocked>
 // CHECK:           %[[VAL_25:.*]] = arith.trunci %[[VAL_24]] : tensor<1024xi64, #blocked> to tensor<1024xi32, #blocked>
-// CHECK:           %[[VAL_26:.*]] = amdg.buffer_load %[[VAL_21]][%[[VAL_25]]] : <f32> -> tensor<1024xf32, #blocked>
+// CHECK:           %[[VAL_26:.*]] = amdg.buffer_load %[[VAL_21]][%[[VAL_25]]] : !tt.ptr<f32> -> tensor<1024xf32, #blocked>
 // CHECK:           tt.return %[[VAL_26]] : tensor<1024xf32, #blocked>
 // CHECK:         }
 
@@ -269,7 +269,7 @@ module attributes {"ttg.num-warps" = 4 : i32, "ttg.threads-per-warp" = 64 : i32}
 // CHECK:               %[[VAL_21:.*]] = arith.extsi %[[VAL_9]] : tensor<1024xi32, #blocked> to tensor<1024xi64, #blocked>
 // CHECK:               %[[VAL_22:.*]] = arith.addi %[[VAL_21]], %[[VAL_18]] : tensor<1024xi64, #blocked>
 // CHECK:               %[[VAL_23:.*]] = arith.trunci %[[VAL_22]] : tensor<1024xi64, #blocked> to tensor<1024xi32, #blocked>
-// CHECK:               %[[VAL_24:.*]] = amdg.buffer_load %[[VAL_20]][%[[VAL_23]]] : <f32> -> tensor<1024xf32, #blocked>
+// CHECK:               %[[VAL_24:.*]] = amdg.buffer_load %[[VAL_20]][%[[VAL_23]]] : !tt.ptr<f32> -> tensor<1024xf32, #blocked>
 // CHECK:               %[[VAL_25:.*]] = arith.addf %[[VAL_24]], %[[VAL_19]] : tensor<1024xf32, #blocked>
 // CHECK:               scf.yield %[[VAL_20]], %[[VAL_22]], %[[VAL_25]] : !tt.ptr<f32>, tensor<1024xi64, #blocked>, tensor<1024xf32, #blocked>
 // CHECK:             }
@@ -279,7 +279,7 @@ module attributes {"ttg.num-warps" = 4 : i32, "ttg.threads-per-warp" = 64 : i32}
 // CHECK:           %[[VAL_29:.*]] = arith.extsi %[[VAL_9]] : tensor<1024xi32, #blocked> to tensor<1024xi64, #blocked>
 // CHECK:           %[[VAL_30:.*]] = arith.addi %[[VAL_29]], %[[VAL_28]]#1 : tensor<1024xi64, #blocked>
 // CHECK:           %[[VAL_31:.*]] = arith.trunci %[[VAL_30]] : tensor<1024xi64, #blocked> to tensor<1024xi32, #blocked>
-// CHECK:           %[[VAL_32:.*]] = amdg.buffer_load %[[VAL_27]][%[[VAL_31]]] : <f32> -> tensor<1024xf32, #blocked>
+// CHECK:           %[[VAL_32:.*]] = amdg.buffer_load %[[VAL_27]][%[[VAL_31]]] : !tt.ptr<f32> -> tensor<1024xf32, #blocked>
 // CHECK:           tt.return %[[VAL_32]] : tensor<1024xf32, #blocked>
 // CHECK:         }
 
@@ -405,7 +405,7 @@ module attributes {"ttg.num-warps" = 4 : i32, "ttg.threads-per-warp" = 64 : i32}
 // CHECK:             scf.yield %[[VAL_12]], %[[VAL_4]] : !tt.ptr<f32>, tensor<1024xi64, #blocked>
 // CHECK:           }
 // CHECK:           %[[VAL_13:.*]] = arith.trunci %[[VAL_14:.*]]#1 : tensor<1024xi64, #blocked> to tensor<1024xi32, #blocked>
-// CHECK:           %[[VAL_15:.*]] = amdg.buffer_load %[[VAL_14]]#0{{\[}}%[[VAL_13]]] : <f32> -> tensor<1024xf32, #blocked>
+// CHECK:           %[[VAL_15:.*]] = amdg.buffer_load %[[VAL_14]]#0{{\[}}%[[VAL_13]]] : !tt.ptr<f32> -> tensor<1024xf32, #blocked>
 // CHECK:           tt.return %[[VAL_15]] : tensor<1024xf32, #blocked>
 // CHECK:         }
 
@@ -448,7 +448,7 @@ module attributes {"ttg.num-warps" = 4 : i32, "ttg.threads-per-warp" = 64 : i32}
 // CHECK:           cf.cond_br %[[VAL_1]], ^bb1(%[[VAL_0]], %[[VAL_2]] : !tt.ptr<f32>, tensor<1024xi64, #blocked>), ^bb1(%[[VAL_8]], %[[VAL_9]] : !tt.ptr<f32>, tensor<1024xi64, #blocked>)
 // CHECK:         ^bb1(%[[VAL_9:.*]]: !tt.ptr<f32>, %[[VAL_11:.*]]: tensor<1024xi64, #blocked>):
 // CHECK:           %[[VAL_12:.*]] = arith.trunci %[[VAL_11]] : tensor<1024xi64, #blocked> to tensor<1024xi32, #blocked>
-// CHECK:           %[[VAL_13:.*]] = amdg.buffer_load %[[VAL_9]]{{\[}}%[[VAL_12]]] : <f32> -> tensor<1024xf32, #blocked>
+// CHECK:           %[[VAL_13:.*]] = amdg.buffer_load %[[VAL_9]]{{\[}}%[[VAL_12]]] : !tt.ptr<f32> -> tensor<1024xf32, #blocked>
 // CHECK:           tt.return %[[VAL_13]] : tensor<1024xf32, #blocked>
 // CHECK:         }
 
@@ -488,7 +488,7 @@ module attributes {"ttg.num-warps" = 4 : i32, "ttg.threads-per-warp" = 64 : i32}
 // CHECK:           %[[VAL_5:.*]] = arith.muli %[[VAL_4]], %[[VAL_3]] : i32
 // CHECK:           %[[VAL_6:.*]] = tt.make_range {end = 1024 : i32, start = 0 : i32} : tensor<1024xi32, #blocked>
 // CHECK:           %[[VAL_7:.*]] = tt.addptr %[[VAL_0]], %[[VAL_5]] : !tt.ptr<f32>, i32
-// CHECK:           %[[VAL_8:.*]] = amdg.buffer_load %[[VAL_7]]{{\[}}%[[VAL_6]]] : <f32> -> tensor<1024xf32, #blocked>
+// CHECK:           %[[VAL_8:.*]] = amdg.buffer_load %[[VAL_7]]{{\[}}%[[VAL_6]]] : !tt.ptr<f32> -> tensor<1024xf32, #blocked>
 // CHECK:           tt.return %[[VAL_8]] : tensor<1024xf32, #blocked>
 // CHECK:         }
 
@@ -618,7 +618,7 @@ module attributes {"ttg.num-warps" = 4 : i32, "ttg.threads-per-warp" = 64 : i32}
 // CHECK:           %[[VAL_10:.*]] = arith.select %[[VAL_1]], %[[VAL_0]], %[[VAL_8]] : !tt.ptr<f32>
 // CHECK:           %[[VAL_11:.*]] = arith.select %[[VAL_1]], %[[VAL_3]], %[[VAL_9]] : tensor<1024xi64, #blocked>
 // CHECK:           %[[VAL_12:.*]] = arith.trunci %[[VAL_11]] : tensor<1024xi64, #blocked> to tensor<1024xi32, #blocked>
-// CHECK:           %[[VAL_13:.*]] = amdg.buffer_load %[[VAL_10]]{{\[}}%[[VAL_12]]] : <f32> -> tensor<1024xf32, #blocked>
+// CHECK:           %[[VAL_13:.*]] = amdg.buffer_load %[[VAL_10]]{{\[}}%[[VAL_12]]] : !tt.ptr<f32> -> tensor<1024xf32, #blocked>
 // CHECK:           tt.return %[[VAL_13]] : tensor<1024xf32, #blocked>
 // CHECK:         }
 
@@ -655,7 +655,7 @@ module attributes {"ttg.num-warps" = 4 : i32, "ttg.threads-per-warp" = 64 : i32}
 // CHECK:           %[[VAL_9:.*]] = arith.cmpi ne, %[[VAL_2]], %[[VAL_4]] : i8
 // CHECK:           %[[VAL_10:.*]] = arith.select %[[VAL_9]], %[[VAL_0]], %[[VAL_1]] : !tt.ptr<i64>
 // CHECK:           %[[VAL_11:.*]] = tt.addptr %[[VAL_10]], %[[VAL_7]] : !tt.ptr<i64>, i32
-// CHECK:           %[[VAL_12:.*]] = amdg.buffer_load %[[VAL_11]]{{\[}}%[[VAL_8]]] : <i64> -> tensor<1024xi64, #blocked>
+// CHECK:           %[[VAL_12:.*]] = amdg.buffer_load %[[VAL_11]]{{\[}}%[[VAL_8]]] : !tt.ptr<i64> -> tensor<1024xi64, #blocked>
 // CHECK:           tt.return %[[VAL_12]] : tensor<1024xi64, #blocked>
 // CHECK:         }
 
@@ -691,7 +691,7 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, "ttg.thr
 // CHECK:           %[[VAL_9:.*]] = arith.extsi %[[VAL_7]] : tensor<1024xi32, #blocked> to tensor<1024xi64, #blocked>
 // CHECK:           %[[VAL_10:.*]]:3 = scf.for %[[VAL_11:.*]] = %[[VAL_3]] to %[[VAL_5]] step %[[VAL_4]] iter_args(%[[VAL_12:.*]] = %[[VAL_8]], %[[VAL_13:.*]] = %[[VAL_9]], %[[VAL_14:.*]] = %[[VAL_1]]) -> (!tt.ptr<f32>, tensor<1024xi64, #blocked>, tensor<1024xf32, #blocked>) {
 // CHECK:             %[[VAL_15:.*]] = arith.trunci %[[VAL_13]] : tensor<1024xi64, #blocked> to tensor<1024xi32, #blocked>
-// CHECK:             %[[VAL_16:.*]] = amdg.buffer_load %[[VAL_12]]{{\[}}%[[VAL_15]]] : <f32> -> tensor<1024xf32, #blocked>
+// CHECK:             %[[VAL_16:.*]] = amdg.buffer_load %[[VAL_12]]{{\[}}%[[VAL_15]]] : !tt.ptr<f32> -> tensor<1024xf32, #blocked>
 // CHECK:             %[[VAL_17:.*]] = tt.addptr %[[VAL_12]], %[[VAL_6]] : !tt.ptr<f32>, i32
 // CHECK:             %[[VAL_18:.*]] = arith.extsi %[[VAL_7]] : tensor<1024xi32, #blocked> to tensor<1024xi64, #blocked>
 // CHECK:             %[[VAL_19:.*]] = arith.addi %[[VAL_18]], %[[VAL_13]] : tensor<1024xi64, #blocked>
@@ -703,7 +703,7 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, "ttg.thr
 // CHECK:           %[[VAL_24:.*]] = arith.extsi %[[VAL_7]] : tensor<1024xi32, #blocked> to tensor<1024xi64, #blocked>
 // CHECK:           %[[VAL_25:.*]] = arith.addi %[[VAL_24]], %[[VAL_23]]#1 : tensor<1024xi64, #blocked>
 // CHECK:           %[[VAL_26:.*]] = arith.trunci %[[VAL_25]] : tensor<1024xi64, #blocked> to tensor<1024xi32, #blocked>
-// CHECK:           %[[VAL_27:.*]] = amdg.buffer_load %[[VAL_22]][%[[VAL_26]]] : <f32> -> tensor<1024xf32, #blocked>
+// CHECK:           %[[VAL_27:.*]] = amdg.buffer_load %[[VAL_22]][%[[VAL_26]]] : !tt.ptr<f32> -> tensor<1024xf32, #blocked>
 // CHECK:           tt.return %[[VAL_27]] : tensor<1024xf32, #blocked>
 // CHECK:         }
 
@@ -854,7 +854,7 @@ module attributes {"ttg.num-warps" = 4 : i32, "ttg.threads-per-warp" = 64 : i32}
 // CHECK:             %[[VAL_21:.*]] = arith.extsi %[[VAL_8]] : tensor<1024xi32, #blocked> to tensor<1024xi64, #blocked>
 // CHECK:             %[[VAL_22:.*]] = arith.addi %[[VAL_21]], %[[VAL_18]] : tensor<1024xi64, #blocked>
 // CHECK:             %[[VAL_23:.*]] = arith.trunci %[[VAL_22]] : tensor<1024xi64, #blocked> to tensor<1024xi32, #blocked>
-// CHECK:             %[[VAL_24:.*]] = amdg.buffer_load %[[VAL_20]][%[[VAL_23]]] : <f32> -> tensor<1024xf32, #blocked>
+// CHECK:             %[[VAL_24:.*]] = amdg.buffer_load %[[VAL_20]][%[[VAL_23]]] : !tt.ptr<f32> -> tensor<1024xf32, #blocked>
 // CHECK:             %[[VAL_25:.*]] = arith.addf %[[VAL_24]], %[[VAL_19]] : tensor<1024xf32, #blocked>
 // CHECK:             scf.yield %[[VAL_20]], %[[VAL_22]], %[[VAL_15]], %[[VAL_16]], %[[VAL_25]] : !tt.ptr<f32>, tensor<1024xi64, #blocked>, !tt.ptr<f32>, tensor<1024xi64, #blocked>, tensor<1024xf32, #blocked>
 // CHECK:           }
@@ -862,7 +862,7 @@ module attributes {"ttg.num-warps" = 4 : i32, "ttg.threads-per-warp" = 64 : i32}
 // CHECK:           %[[VAL_28:.*]] = arith.extsi %[[VAL_8]] : tensor<1024xi32, #blocked> to tensor<1024xi64, #blocked>
 // CHECK:           %[[VAL_29:.*]] = arith.addi %[[VAL_28]], %[[VAL_27]]#1 : tensor<1024xi64, #blocked>
 // CHECK:           %[[VAL_30:.*]] = arith.trunci %[[VAL_29]] : tensor<1024xi64, #blocked> to tensor<1024xi32, #blocked>
-// CHECK:           %[[VAL_31:.*]] = amdg.buffer_load %[[VAL_26]][%[[VAL_30]]] : <f32> -> tensor<1024xf32, #blocked>
+// CHECK:           %[[VAL_31:.*]] = amdg.buffer_load %[[VAL_26]][%[[VAL_30]]] : !tt.ptr<f32> -> tensor<1024xf32, #blocked>
 // CHECK:           tt.return %[[VAL_31]] : tensor<1024xf32, #blocked>
 // CHECK:         }
 
@@ -921,13 +921,13 @@ module attributes {"ttg.num-warps" = 4 : i32, "ttg.threads-per-warp" = 64 : i32}
 // CHECK:             %[[VAL_23:.*]] = arith.extsi %[[VAL_9]] : tensor<1024xi32, #blocked> to tensor<1024xi64, #blocked>
 // CHECK:             %[[VAL_24:.*]] = arith.addi %[[VAL_23]], %[[VAL_17]] : tensor<1024xi64, #blocked>
 // CHECK:             %[[VAL_25:.*]] = arith.trunci %[[VAL_24]] : tensor<1024xi64, #blocked> to tensor<1024xi32, #blocked>
-// CHECK:             %[[VAL_26:.*]] = amdg.buffer_load %[[VAL_22]][%[[VAL_25]]] : <f32> -> tensor<1024xf32, #blocked>
+// CHECK:             %[[VAL_26:.*]] = amdg.buffer_load %[[VAL_22]][%[[VAL_25]]] : !tt.ptr<f32> -> tensor<1024xf32, #blocked>
 // CHECK:             %[[VAL_27:.*]] = arith.addf %[[VAL_26]], %[[VAL_18]] : tensor<1024xf32, #blocked>
 // CHECK:             %[[VAL_28:.*]] = tt.addptr %[[VAL_19]], %[[VAL_8]] : !tt.ptr<f32>, i32
 // CHECK:             %[[VAL_29:.*]] = arith.extsi %[[VAL_9]] : tensor<1024xi32, #blocked> to tensor<1024xi64, #blocked>
 // CHECK:             %[[VAL_30:.*]] = arith.addi %[[VAL_29]], %[[VAL_20]] : tensor<1024xi64, #blocked>
 // CHECK:             %[[VAL_31:.*]] = arith.trunci %[[VAL_30]] : tensor<1024xi64, #blocked> to tensor<1024xi32, #blocked>
-// CHECK:             %[[VAL_32:.*]] = amdg.buffer_load %[[VAL_28]][%[[VAL_31]]] : <f32> -> tensor<1024xf32, #blocked>
+// CHECK:             %[[VAL_32:.*]] = amdg.buffer_load %[[VAL_28]][%[[VAL_31]]] : !tt.ptr<f32> -> tensor<1024xf32, #blocked>
 // CHECK:             %[[VAL_33:.*]] = arith.addf %[[VAL_32]], %[[VAL_21]] : tensor<1024xf32, #blocked>
 // CHECK:             scf.yield %[[VAL_28]], %[[VAL_30]], %[[VAL_33]], %[[VAL_22]], %[[VAL_24]], %[[VAL_27]] : !tt.ptr<f32>, tensor<1024xi64, #blocked>, tensor<1024xf32, #blocked>, !tt.ptr<f32>, tensor<1024xi64, #blocked>, tensor<1024xf32, #blocked>
 // CHECK:           }
@@ -935,12 +935,12 @@ module attributes {"ttg.num-warps" = 4 : i32, "ttg.threads-per-warp" = 64 : i32}
 // CHECK:           %[[VAL_36:.*]] = arith.extsi %[[VAL_9]] : tensor<1024xi32, #blocked> to tensor<1024xi64, #blocked>
 // CHECK:           %[[VAL_37:.*]] = arith.addi %[[VAL_36]], %[[VAL_35]]#1 : tensor<1024xi64, #blocked>
 // CHECK:           %[[VAL_38:.*]] = arith.trunci %[[VAL_37]] : tensor<1024xi64, #blocked> to tensor<1024xi32, #blocked>
-// CHECK:           %[[VAL_39:.*]] = amdg.buffer_load %[[VAL_34]][%[[VAL_38]]] : <f32> -> tensor<1024xf32, #blocked>
+// CHECK:           %[[VAL_39:.*]] = amdg.buffer_load %[[VAL_34]][%[[VAL_38]]] : !tt.ptr<f32> -> tensor<1024xf32, #blocked>
 // CHECK:           %[[VAL_40:.*]] = tt.addptr %[[VAL_35]]#3, %[[VAL_8]] : !tt.ptr<f32>, i32
 // CHECK:           %[[VAL_41:.*]] = arith.extsi %[[VAL_9]] : tensor<1024xi32, #blocked> to tensor<1024xi64, #blocked>
 // CHECK:           %[[VAL_42:.*]] = arith.addi %[[VAL_41]], %[[VAL_35]]#4 : tensor<1024xi64, #blocked>
 // CHECK:           %[[VAL_43:.*]] = arith.trunci %[[VAL_42]] : tensor<1024xi64, #blocked> to tensor<1024xi32, #blocked>
-// CHECK:           %[[VAL_44:.*]] = amdg.buffer_load %[[VAL_40]][%[[VAL_43]]] : <f32> -> tensor<1024xf32, #blocked>
+// CHECK:           %[[VAL_44:.*]] = amdg.buffer_load %[[VAL_40]][%[[VAL_43]]] : !tt.ptr<f32> -> tensor<1024xf32, #blocked>
 // CHECK:           tt.return %[[VAL_39]], %[[VAL_44]] : tensor<1024xf32, #blocked>, tensor<1024xf32, #blocked>
 // CHECK:         }
 

--- a/test/TritonGPU/amd/amd-convert-buffer-ops-range-analysis.mlir
+++ b/test/TritonGPU/amd/amd-convert-buffer-ops-range-analysis.mlir
@@ -36,7 +36,7 @@ module attributes {"ttg.num-warps" = 4 : i32, "ttg.threads-per-warp" = 64 : i32}
 // CHECK:           %[[VAL_4:.*]] = arith.muli %[[VAL_3]], %[[VAL_2]] : i32
 // CHECK:           %[[VAL_5:.*]] = tt.make_range {end = 1024 : i32, start = 0 : i32} : tensor<1024xi32, #blocked>
 // CHECK:           %[[VAL_6:.*]] = tt.addptr %[[VAL_0]], %[[VAL_4]] : !tt.ptr<f32>, i32
-// CHECK:           %[[VAL_7:.*]] = amdg.buffer_load %[[VAL_6]]{{\[}}%[[VAL_5]]] : tensor<1024xf32, #blocked>
+// CHECK:           %[[VAL_7:.*]] = amdg.buffer_load %[[VAL_6]]{{\[}}%[[VAL_5]]] : <f32> -> tensor<1024xf32, #blocked>
 // CHECK:           tt.return %[[VAL_7]] : tensor<1024xf32, #blocked>
 // CHECK:         }
 
@@ -70,7 +70,7 @@ module attributes {"ttg.num-warps" = 4 : i32, "ttg.threads-per-warp" = 64 : i32}
 // CHECK:           %[[VAL_8:.*]] = arith.extsi %[[VAL_4]] : tensor<1024xi32, #blocked> to tensor<1024xi64, #blocked>
 // CHECK:           %[[VAL_9:.*]] = arith.addi %[[VAL_8]], %[[VAL_6]] : tensor<1024xi64, #blocked>
 // CHECK:           %[[VAL_10:.*]] = arith.trunci %[[VAL_9]] : tensor<1024xi64, #blocked> to tensor<1024xi32, #blocked>
-// CHECK:           %[[VAL_11:.*]] = amdg.buffer_load %[[VAL_7]][%[[VAL_10]]] : tensor<1024xf32, #blocked>
+// CHECK:           %[[VAL_11:.*]] = amdg.buffer_load %[[VAL_7]][%[[VAL_10]]] : <f32> -> tensor<1024xf32, #blocked>
 // CHECK:           tt.return %[[VAL_11]] : tensor<1024xf32, #blocked>
 // CHECK:         }
 
@@ -105,7 +105,7 @@ module attributes {"ttg.num-warps" = 4 : i32, "ttg.threads-per-warp" = 64 : i32}
 // CHECK:           %[[VAL_6:.*]] = tt.addptr %[[VAL_0]], %[[VAL_4]] : !tt.ptr<f32>, i32
 // CHECK:           %[[VAL_7:.*]] = tt.addptr %[[VAL_6]], %[[VAL_4]] : !tt.ptr<f32>, i32
 // CHECK:           %[[VAL_8:.*]] = arith.addi %[[VAL_5]], %[[VAL_5]] : tensor<1024xi32, #blocked>
-// CHECK:           %[[VAL_9:.*]] = amdg.buffer_load %[[VAL_7]]{{\[}}%[[VAL_8]]] : tensor<1024xf32, #blocked>
+// CHECK:           %[[VAL_9:.*]] = amdg.buffer_load %[[VAL_7]]{{\[}}%[[VAL_8]]] : <f32> -> tensor<1024xf32, #blocked>
 // CHECK:           tt.return %[[VAL_9]] : tensor<1024xf32, #blocked>
 // CHECK:         }
 
@@ -145,7 +145,7 @@ module attributes {"ttg.num-warps" = 4 : i32, "ttg.threads-per-warp" = 64 : i32}
 // CHECK:             %[[VAL_17:.*]] = arith.extsi %[[VAL_8]] : tensor<1024xi32, #blocked> to tensor<1024xi64, #blocked>
 // CHECK:             %[[VAL_18:.*]] = arith.addi %[[VAL_17]], %[[VAL_14]] : tensor<1024xi64, #blocked>
 // CHECK:             %[[VAL_19:.*]] = arith.trunci %[[VAL_18]] : tensor<1024xi64, #blocked> to tensor<1024xi32, #blocked>
-// CHECK:             %[[VAL_20:.*]] = amdg.buffer_load %[[VAL_16]][%[[VAL_19]]] : tensor<1024xf32, #blocked>
+// CHECK:             %[[VAL_20:.*]] = amdg.buffer_load %[[VAL_16]][%[[VAL_19]]] : <f32> -> tensor<1024xf32, #blocked>
 // CHECK:             %[[VAL_21:.*]] = arith.addf %[[VAL_20]], %[[VAL_15]] : tensor<1024xf32, #blocked>
 // CHECK:             scf.yield %[[VAL_16]], %[[VAL_18]], %[[VAL_21]] : !tt.ptr<f32>, tensor<1024xi64, #blocked>, tensor<1024xf32, #blocked>
 // CHECK:           }
@@ -153,7 +153,7 @@ module attributes {"ttg.num-warps" = 4 : i32, "ttg.threads-per-warp" = 64 : i32}
 // CHECK:           %[[VAL_24:.*]] = arith.extsi %[[VAL_8]] : tensor<1024xi32, #blocked> to tensor<1024xi64, #blocked>
 // CHECK:           %[[VAL_25:.*]] = arith.addi %[[VAL_24]], %[[VAL_23]]#1 : tensor<1024xi64, #blocked>
 // CHECK:           %[[VAL_26:.*]] = arith.trunci %[[VAL_25]] : tensor<1024xi64, #blocked> to tensor<1024xi32, #blocked>
-// CHECK:           %[[VAL_27:.*]] = amdg.buffer_load %[[VAL_22]][%[[VAL_26]]] : tensor<1024xf32, #blocked>
+// CHECK:           %[[VAL_27:.*]] = amdg.buffer_load %[[VAL_22]][%[[VAL_26]]] : <f32> -> tensor<1024xf32, #blocked>
 // CHECK:           tt.return %[[VAL_27]] : tensor<1024xf32, #blocked>
 // CHECK:         }
 
@@ -207,7 +207,7 @@ module attributes {"ttg.num-warps" = 4 : i32, "ttg.threads-per-warp" = 64 : i32}
 // CHECK:             %[[VAL_16:.*]] = arith.extsi %[[VAL_9]] : tensor<1024xi32, #blocked> to tensor<1024xi64, #blocked>
 // CHECK:             %[[VAL_17:.*]] = arith.addi %[[VAL_16]], %[[VAL_13]] : tensor<1024xi64, #blocked>
 // CHECK:             %[[VAL_18:.*]] = arith.trunci %[[VAL_17]] : tensor<1024xi64, #blocked> to tensor<1024xi32, #blocked>
-// CHECK:             %[[VAL_19:.*]] = amdg.buffer_load %[[VAL_15]][%[[VAL_18]]] : tensor<1024xf32, #blocked>
+// CHECK:             %[[VAL_19:.*]] = amdg.buffer_load %[[VAL_15]][%[[VAL_18]]] : <f32> -> tensor<1024xf32, #blocked>
 // CHECK:             %[[VAL_20:.*]] = arith.addf %[[VAL_19]], %[[VAL_14]] : tensor<1024xf32, #blocked>
 // CHECK:             scf.yield %[[VAL_15]], %[[VAL_17]], %[[VAL_20]] : !tt.ptr<f32>, tensor<1024xi64, #blocked>, tensor<1024xf32, #blocked>
 // CHECK:           }
@@ -215,7 +215,7 @@ module attributes {"ttg.num-warps" = 4 : i32, "ttg.threads-per-warp" = 64 : i32}
 // CHECK:           %[[VAL_23:.*]] = arith.extsi %[[VAL_9]] : tensor<1024xi32, #blocked> to tensor<1024xi64, #blocked>
 // CHECK:           %[[VAL_24:.*]] = arith.addi %[[VAL_23]], %[[VAL_22]]#1 : tensor<1024xi64, #blocked>
 // CHECK:           %[[VAL_25:.*]] = arith.trunci %[[VAL_24]] : tensor<1024xi64, #blocked> to tensor<1024xi32, #blocked>
-// CHECK:           %[[VAL_26:.*]] = amdg.buffer_load %[[VAL_21]][%[[VAL_25]]] : tensor<1024xf32, #blocked>
+// CHECK:           %[[VAL_26:.*]] = amdg.buffer_load %[[VAL_21]][%[[VAL_25]]] : <f32> -> tensor<1024xf32, #blocked>
 // CHECK:           tt.return %[[VAL_26]] : tensor<1024xf32, #blocked>
 // CHECK:         }
 
@@ -269,7 +269,7 @@ module attributes {"ttg.num-warps" = 4 : i32, "ttg.threads-per-warp" = 64 : i32}
 // CHECK:               %[[VAL_21:.*]] = arith.extsi %[[VAL_9]] : tensor<1024xi32, #blocked> to tensor<1024xi64, #blocked>
 // CHECK:               %[[VAL_22:.*]] = arith.addi %[[VAL_21]], %[[VAL_18]] : tensor<1024xi64, #blocked>
 // CHECK:               %[[VAL_23:.*]] = arith.trunci %[[VAL_22]] : tensor<1024xi64, #blocked> to tensor<1024xi32, #blocked>
-// CHECK:               %[[VAL_24:.*]] = amdg.buffer_load %[[VAL_20]][%[[VAL_23]]] : tensor<1024xf32, #blocked>
+// CHECK:               %[[VAL_24:.*]] = amdg.buffer_load %[[VAL_20]][%[[VAL_23]]] : <f32> -> tensor<1024xf32, #blocked>
 // CHECK:               %[[VAL_25:.*]] = arith.addf %[[VAL_24]], %[[VAL_19]] : tensor<1024xf32, #blocked>
 // CHECK:               scf.yield %[[VAL_20]], %[[VAL_22]], %[[VAL_25]] : !tt.ptr<f32>, tensor<1024xi64, #blocked>, tensor<1024xf32, #blocked>
 // CHECK:             }
@@ -279,7 +279,7 @@ module attributes {"ttg.num-warps" = 4 : i32, "ttg.threads-per-warp" = 64 : i32}
 // CHECK:           %[[VAL_29:.*]] = arith.extsi %[[VAL_9]] : tensor<1024xi32, #blocked> to tensor<1024xi64, #blocked>
 // CHECK:           %[[VAL_30:.*]] = arith.addi %[[VAL_29]], %[[VAL_28]]#1 : tensor<1024xi64, #blocked>
 // CHECK:           %[[VAL_31:.*]] = arith.trunci %[[VAL_30]] : tensor<1024xi64, #blocked> to tensor<1024xi32, #blocked>
-// CHECK:           %[[VAL_32:.*]] = amdg.buffer_load %[[VAL_27]][%[[VAL_31]]] : tensor<1024xf32, #blocked>
+// CHECK:           %[[VAL_32:.*]] = amdg.buffer_load %[[VAL_27]][%[[VAL_31]]] : <f32> -> tensor<1024xf32, #blocked>
 // CHECK:           tt.return %[[VAL_32]] : tensor<1024xf32, #blocked>
 // CHECK:         }
 
@@ -405,7 +405,7 @@ module attributes {"ttg.num-warps" = 4 : i32, "ttg.threads-per-warp" = 64 : i32}
 // CHECK:             scf.yield %[[VAL_12]], %[[VAL_4]] : !tt.ptr<f32>, tensor<1024xi64, #blocked>
 // CHECK:           }
 // CHECK:           %[[VAL_13:.*]] = arith.trunci %[[VAL_14:.*]]#1 : tensor<1024xi64, #blocked> to tensor<1024xi32, #blocked>
-// CHECK:           %[[VAL_15:.*]] = amdg.buffer_load %[[VAL_14]]#0{{\[}}%[[VAL_13]]] : tensor<1024xf32, #blocked>
+// CHECK:           %[[VAL_15:.*]] = amdg.buffer_load %[[VAL_14]]#0{{\[}}%[[VAL_13]]] : <f32> -> tensor<1024xf32, #blocked>
 // CHECK:           tt.return %[[VAL_15]] : tensor<1024xf32, #blocked>
 // CHECK:         }
 
@@ -448,7 +448,7 @@ module attributes {"ttg.num-warps" = 4 : i32, "ttg.threads-per-warp" = 64 : i32}
 // CHECK:           cf.cond_br %[[VAL_1]], ^bb1(%[[VAL_0]], %[[VAL_2]] : !tt.ptr<f32>, tensor<1024xi64, #blocked>), ^bb1(%[[VAL_8]], %[[VAL_9]] : !tt.ptr<f32>, tensor<1024xi64, #blocked>)
 // CHECK:         ^bb1(%[[VAL_9:.*]]: !tt.ptr<f32>, %[[VAL_11:.*]]: tensor<1024xi64, #blocked>):
 // CHECK:           %[[VAL_12:.*]] = arith.trunci %[[VAL_11]] : tensor<1024xi64, #blocked> to tensor<1024xi32, #blocked>
-// CHECK:           %[[VAL_13:.*]] = amdg.buffer_load %[[VAL_9]]{{\[}}%[[VAL_12]]] : tensor<1024xf32, #blocked>
+// CHECK:           %[[VAL_13:.*]] = amdg.buffer_load %[[VAL_9]]{{\[}}%[[VAL_12]]] : <f32> -> tensor<1024xf32, #blocked>
 // CHECK:           tt.return %[[VAL_13]] : tensor<1024xf32, #blocked>
 // CHECK:         }
 
@@ -488,7 +488,7 @@ module attributes {"ttg.num-warps" = 4 : i32, "ttg.threads-per-warp" = 64 : i32}
 // CHECK:           %[[VAL_5:.*]] = arith.muli %[[VAL_4]], %[[VAL_3]] : i32
 // CHECK:           %[[VAL_6:.*]] = tt.make_range {end = 1024 : i32, start = 0 : i32} : tensor<1024xi32, #blocked>
 // CHECK:           %[[VAL_7:.*]] = tt.addptr %[[VAL_0]], %[[VAL_5]] : !tt.ptr<f32>, i32
-// CHECK:           %[[VAL_8:.*]] = amdg.buffer_load %[[VAL_7]]{{\[}}%[[VAL_6]]] : tensor<1024xf32, #blocked>
+// CHECK:           %[[VAL_8:.*]] = amdg.buffer_load %[[VAL_7]]{{\[}}%[[VAL_6]]] : <f32> -> tensor<1024xf32, #blocked>
 // CHECK:           tt.return %[[VAL_8]] : tensor<1024xf32, #blocked>
 // CHECK:         }
 
@@ -618,7 +618,7 @@ module attributes {"ttg.num-warps" = 4 : i32, "ttg.threads-per-warp" = 64 : i32}
 // CHECK:           %[[VAL_10:.*]] = arith.select %[[VAL_1]], %[[VAL_0]], %[[VAL_8]] : !tt.ptr<f32>
 // CHECK:           %[[VAL_11:.*]] = arith.select %[[VAL_1]], %[[VAL_3]], %[[VAL_9]] : tensor<1024xi64, #blocked>
 // CHECK:           %[[VAL_12:.*]] = arith.trunci %[[VAL_11]] : tensor<1024xi64, #blocked> to tensor<1024xi32, #blocked>
-// CHECK:           %[[VAL_13:.*]] = amdg.buffer_load %[[VAL_10]]{{\[}}%[[VAL_12]]] : tensor<1024xf32, #blocked>
+// CHECK:           %[[VAL_13:.*]] = amdg.buffer_load %[[VAL_10]]{{\[}}%[[VAL_12]]] : <f32> -> tensor<1024xf32, #blocked>
 // CHECK:           tt.return %[[VAL_13]] : tensor<1024xf32, #blocked>
 // CHECK:         }
 
@@ -655,7 +655,7 @@ module attributes {"ttg.num-warps" = 4 : i32, "ttg.threads-per-warp" = 64 : i32}
 // CHECK:           %[[VAL_9:.*]] = arith.cmpi ne, %[[VAL_2]], %[[VAL_4]] : i8
 // CHECK:           %[[VAL_10:.*]] = arith.select %[[VAL_9]], %[[VAL_0]], %[[VAL_1]] : !tt.ptr<i64>
 // CHECK:           %[[VAL_11:.*]] = tt.addptr %[[VAL_10]], %[[VAL_7]] : !tt.ptr<i64>, i32
-// CHECK:           %[[VAL_12:.*]] = amdg.buffer_load %[[VAL_11]]{{\[}}%[[VAL_8]]] : tensor<1024xi64, #blocked>
+// CHECK:           %[[VAL_12:.*]] = amdg.buffer_load %[[VAL_11]]{{\[}}%[[VAL_8]]] : <i64> -> tensor<1024xi64, #blocked>
 // CHECK:           tt.return %[[VAL_12]] : tensor<1024xi64, #blocked>
 // CHECK:         }
 
@@ -691,7 +691,7 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, "ttg.thr
 // CHECK:           %[[VAL_9:.*]] = arith.extsi %[[VAL_7]] : tensor<1024xi32, #blocked> to tensor<1024xi64, #blocked>
 // CHECK:           %[[VAL_10:.*]]:3 = scf.for %[[VAL_11:.*]] = %[[VAL_3]] to %[[VAL_5]] step %[[VAL_4]] iter_args(%[[VAL_12:.*]] = %[[VAL_8]], %[[VAL_13:.*]] = %[[VAL_9]], %[[VAL_14:.*]] = %[[VAL_1]]) -> (!tt.ptr<f32>, tensor<1024xi64, #blocked>, tensor<1024xf32, #blocked>) {
 // CHECK:             %[[VAL_15:.*]] = arith.trunci %[[VAL_13]] : tensor<1024xi64, #blocked> to tensor<1024xi32, #blocked>
-// CHECK:             %[[VAL_16:.*]] = amdg.buffer_load %[[VAL_12]]{{\[}}%[[VAL_15]]] : tensor<1024xf32, #blocked>
+// CHECK:             %[[VAL_16:.*]] = amdg.buffer_load %[[VAL_12]]{{\[}}%[[VAL_15]]] : <f32> -> tensor<1024xf32, #blocked>
 // CHECK:             %[[VAL_17:.*]] = tt.addptr %[[VAL_12]], %[[VAL_6]] : !tt.ptr<f32>, i32
 // CHECK:             %[[VAL_18:.*]] = arith.extsi %[[VAL_7]] : tensor<1024xi32, #blocked> to tensor<1024xi64, #blocked>
 // CHECK:             %[[VAL_19:.*]] = arith.addi %[[VAL_18]], %[[VAL_13]] : tensor<1024xi64, #blocked>
@@ -703,7 +703,7 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, "ttg.thr
 // CHECK:           %[[VAL_24:.*]] = arith.extsi %[[VAL_7]] : tensor<1024xi32, #blocked> to tensor<1024xi64, #blocked>
 // CHECK:           %[[VAL_25:.*]] = arith.addi %[[VAL_24]], %[[VAL_23]]#1 : tensor<1024xi64, #blocked>
 // CHECK:           %[[VAL_26:.*]] = arith.trunci %[[VAL_25]] : tensor<1024xi64, #blocked> to tensor<1024xi32, #blocked>
-// CHECK:           %[[VAL_27:.*]] = amdg.buffer_load %[[VAL_22]][%[[VAL_26]]] : tensor<1024xf32, #blocked>
+// CHECK:           %[[VAL_27:.*]] = amdg.buffer_load %[[VAL_22]][%[[VAL_26]]] : <f32> -> tensor<1024xf32, #blocked>
 // CHECK:           tt.return %[[VAL_27]] : tensor<1024xf32, #blocked>
 // CHECK:         }
 
@@ -854,7 +854,7 @@ module attributes {"ttg.num-warps" = 4 : i32, "ttg.threads-per-warp" = 64 : i32}
 // CHECK:             %[[VAL_21:.*]] = arith.extsi %[[VAL_8]] : tensor<1024xi32, #blocked> to tensor<1024xi64, #blocked>
 // CHECK:             %[[VAL_22:.*]] = arith.addi %[[VAL_21]], %[[VAL_18]] : tensor<1024xi64, #blocked>
 // CHECK:             %[[VAL_23:.*]] = arith.trunci %[[VAL_22]] : tensor<1024xi64, #blocked> to tensor<1024xi32, #blocked>
-// CHECK:             %[[VAL_24:.*]] = amdg.buffer_load %[[VAL_20]][%[[VAL_23]]] : tensor<1024xf32, #blocked>
+// CHECK:             %[[VAL_24:.*]] = amdg.buffer_load %[[VAL_20]][%[[VAL_23]]] : <f32> -> tensor<1024xf32, #blocked>
 // CHECK:             %[[VAL_25:.*]] = arith.addf %[[VAL_24]], %[[VAL_19]] : tensor<1024xf32, #blocked>
 // CHECK:             scf.yield %[[VAL_20]], %[[VAL_22]], %[[VAL_15]], %[[VAL_16]], %[[VAL_25]] : !tt.ptr<f32>, tensor<1024xi64, #blocked>, !tt.ptr<f32>, tensor<1024xi64, #blocked>, tensor<1024xf32, #blocked>
 // CHECK:           }
@@ -862,7 +862,7 @@ module attributes {"ttg.num-warps" = 4 : i32, "ttg.threads-per-warp" = 64 : i32}
 // CHECK:           %[[VAL_28:.*]] = arith.extsi %[[VAL_8]] : tensor<1024xi32, #blocked> to tensor<1024xi64, #blocked>
 // CHECK:           %[[VAL_29:.*]] = arith.addi %[[VAL_28]], %[[VAL_27]]#1 : tensor<1024xi64, #blocked>
 // CHECK:           %[[VAL_30:.*]] = arith.trunci %[[VAL_29]] : tensor<1024xi64, #blocked> to tensor<1024xi32, #blocked>
-// CHECK:           %[[VAL_31:.*]] = amdg.buffer_load %[[VAL_26]][%[[VAL_30]]] : tensor<1024xf32, #blocked>
+// CHECK:           %[[VAL_31:.*]] = amdg.buffer_load %[[VAL_26]][%[[VAL_30]]] : <f32> -> tensor<1024xf32, #blocked>
 // CHECK:           tt.return %[[VAL_31]] : tensor<1024xf32, #blocked>
 // CHECK:         }
 
@@ -921,13 +921,13 @@ module attributes {"ttg.num-warps" = 4 : i32, "ttg.threads-per-warp" = 64 : i32}
 // CHECK:             %[[VAL_23:.*]] = arith.extsi %[[VAL_9]] : tensor<1024xi32, #blocked> to tensor<1024xi64, #blocked>
 // CHECK:             %[[VAL_24:.*]] = arith.addi %[[VAL_23]], %[[VAL_17]] : tensor<1024xi64, #blocked>
 // CHECK:             %[[VAL_25:.*]] = arith.trunci %[[VAL_24]] : tensor<1024xi64, #blocked> to tensor<1024xi32, #blocked>
-// CHECK:             %[[VAL_26:.*]] = amdg.buffer_load %[[VAL_22]][%[[VAL_25]]] : tensor<1024xf32, #blocked>
+// CHECK:             %[[VAL_26:.*]] = amdg.buffer_load %[[VAL_22]][%[[VAL_25]]] : <f32> -> tensor<1024xf32, #blocked>
 // CHECK:             %[[VAL_27:.*]] = arith.addf %[[VAL_26]], %[[VAL_18]] : tensor<1024xf32, #blocked>
 // CHECK:             %[[VAL_28:.*]] = tt.addptr %[[VAL_19]], %[[VAL_8]] : !tt.ptr<f32>, i32
 // CHECK:             %[[VAL_29:.*]] = arith.extsi %[[VAL_9]] : tensor<1024xi32, #blocked> to tensor<1024xi64, #blocked>
 // CHECK:             %[[VAL_30:.*]] = arith.addi %[[VAL_29]], %[[VAL_20]] : tensor<1024xi64, #blocked>
 // CHECK:             %[[VAL_31:.*]] = arith.trunci %[[VAL_30]] : tensor<1024xi64, #blocked> to tensor<1024xi32, #blocked>
-// CHECK:             %[[VAL_32:.*]] = amdg.buffer_load %[[VAL_28]][%[[VAL_31]]] : tensor<1024xf32, #blocked>
+// CHECK:             %[[VAL_32:.*]] = amdg.buffer_load %[[VAL_28]][%[[VAL_31]]] : <f32> -> tensor<1024xf32, #blocked>
 // CHECK:             %[[VAL_33:.*]] = arith.addf %[[VAL_32]], %[[VAL_21]] : tensor<1024xf32, #blocked>
 // CHECK:             scf.yield %[[VAL_28]], %[[VAL_30]], %[[VAL_33]], %[[VAL_22]], %[[VAL_24]], %[[VAL_27]] : !tt.ptr<f32>, tensor<1024xi64, #blocked>, tensor<1024xf32, #blocked>, !tt.ptr<f32>, tensor<1024xi64, #blocked>, tensor<1024xf32, #blocked>
 // CHECK:           }
@@ -935,12 +935,12 @@ module attributes {"ttg.num-warps" = 4 : i32, "ttg.threads-per-warp" = 64 : i32}
 // CHECK:           %[[VAL_36:.*]] = arith.extsi %[[VAL_9]] : tensor<1024xi32, #blocked> to tensor<1024xi64, #blocked>
 // CHECK:           %[[VAL_37:.*]] = arith.addi %[[VAL_36]], %[[VAL_35]]#1 : tensor<1024xi64, #blocked>
 // CHECK:           %[[VAL_38:.*]] = arith.trunci %[[VAL_37]] : tensor<1024xi64, #blocked> to tensor<1024xi32, #blocked>
-// CHECK:           %[[VAL_39:.*]] = amdg.buffer_load %[[VAL_34]][%[[VAL_38]]] : tensor<1024xf32, #blocked>
+// CHECK:           %[[VAL_39:.*]] = amdg.buffer_load %[[VAL_34]][%[[VAL_38]]] : <f32> -> tensor<1024xf32, #blocked>
 // CHECK:           %[[VAL_40:.*]] = tt.addptr %[[VAL_35]]#3, %[[VAL_8]] : !tt.ptr<f32>, i32
 // CHECK:           %[[VAL_41:.*]] = arith.extsi %[[VAL_9]] : tensor<1024xi32, #blocked> to tensor<1024xi64, #blocked>
 // CHECK:           %[[VAL_42:.*]] = arith.addi %[[VAL_41]], %[[VAL_35]]#4 : tensor<1024xi64, #blocked>
 // CHECK:           %[[VAL_43:.*]] = arith.trunci %[[VAL_42]] : tensor<1024xi64, #blocked> to tensor<1024xi32, #blocked>
-// CHECK:           %[[VAL_44:.*]] = amdg.buffer_load %[[VAL_40]][%[[VAL_43]]] : tensor<1024xf32, #blocked>
+// CHECK:           %[[VAL_44:.*]] = amdg.buffer_load %[[VAL_40]][%[[VAL_43]]] : <f32> -> tensor<1024xf32, #blocked>
 // CHECK:           tt.return %[[VAL_39]], %[[VAL_44]] : tensor<1024xf32, #blocked>, tensor<1024xf32, #blocked>
 // CHECK:         }
 

--- a/test/TritonGPU/amd/amd-convert-buffer-ops-small-tensor.mlir
+++ b/test/TritonGPU/amd/amd-convert-buffer-ops-small-tensor.mlir
@@ -589,7 +589,7 @@ module attributes {"ttg.compute-capability" = 0 : i32, "ttg.num-ctas" = 1 : i32,
 // COMMON:    %[[VAR_0:.*]] = arith.constant dense<0> : tensor<256x256xi64, #blocked>
 // COMMON:    %[[VAR_1:.*]] = amdg.extract_slice %[[VAR_0]] [0, 0] : tensor<256x256xi64, #blocked> to tensor<128x256xi64, #blocked>
 // COMMON:    %[[VAR_2:.*]] = arith.trunci %[[VAR_1]] : tensor<128x256xi64, #blocked> to tensor<128x256xi32, #blocked>
-// COMMON:    %[[VAR_3:.*]] = amdg.buffer_load %[[ARG_0]][%[[VAR_2]]] : <f32> -> tensor<128x256xf32, #blocked>
+// COMMON:    %[[VAR_3:.*]] = amdg.buffer_load %[[ARG_0]][%[[VAR_2]]] : !tt.ptr<f32> -> tensor<128x256xf32, #blocked>
 // COMMON:    tt.return %[[VAR_3]] : tensor<128x256xf32, #blocked>
 // COMMON:  }
 
@@ -627,8 +627,8 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.targ
 // COMMON: test_contiguity_set
 // COMMON: scf.for
 // COMMON: %[[OFFSET:.*]] = arith.addi
-// COMMON: amdg.buffer_load %{{.*}}[%[[OFFSET]]] {contiguity = 8 : i32} : <f16> -> tensor<128x64xf16, #blocked>
-// COMMON: amdg.buffer_store %{{.*}}[%[[OFFSET]]] {contiguity = 8 : i32} : <f16> -> tensor<128x64xf16, #blocked>
+// COMMON: amdg.buffer_load %{{.*}}[%[[OFFSET]]] {contiguity = 8 : i32} : !tt.ptr<f16> -> tensor<128x64xf16, #blocked>
+// COMMON: amdg.buffer_store %{{.*}}[%[[OFFSET]]] {contiguity = 8 : i32} : !tt.ptr<f16> -> tensor<128x64xf16, #blocked>
 
 #blocked = #ttg.blocked<{sizePerThread = [1, 8], threadsPerWarp = [8, 8], warpsPerCTA = [8, 1], order = [1, 0]}>
 

--- a/test/TritonGPU/amd/amd-convert-buffer-ops-small-tensor.mlir
+++ b/test/TritonGPU/amd/amd-convert-buffer-ops-small-tensor.mlir
@@ -589,7 +589,7 @@ module attributes {"ttg.compute-capability" = 0 : i32, "ttg.num-ctas" = 1 : i32,
 // COMMON:    %[[VAR_0:.*]] = arith.constant dense<0> : tensor<256x256xi64, #blocked>
 // COMMON:    %[[VAR_1:.*]] = amdg.extract_slice %[[VAR_0]] [0, 0] : tensor<256x256xi64, #blocked> to tensor<128x256xi64, #blocked>
 // COMMON:    %[[VAR_2:.*]] = arith.trunci %[[VAR_1]] : tensor<128x256xi64, #blocked> to tensor<128x256xi32, #blocked>
-// COMMON:    %[[VAR_3:.*]] = amdg.buffer_load %[[ARG_0]][%[[VAR_2]]] : tensor<128x256xf32, #blocked>
+// COMMON:    %[[VAR_3:.*]] = amdg.buffer_load %[[ARG_0]][%[[VAR_2]]] : <f32> -> tensor<128x256xf32, #blocked>
 // COMMON:    tt.return %[[VAR_3]] : tensor<128x256xf32, #blocked>
 // COMMON:  }
 
@@ -627,8 +627,8 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.targ
 // COMMON: test_contiguity_set
 // COMMON: scf.for
 // COMMON: %[[OFFSET:.*]] = arith.addi
-// COMMON: amdg.buffer_load %{{.*}}[%[[OFFSET]]] {contiguity = 8 : i32} : tensor<128x64xf16, #blocked>
-// COMMON: amdg.buffer_store %{{.*}}[%[[OFFSET]]] {contiguity = 8 : i32} : tensor<128x64xf16, #blocked>
+// COMMON: amdg.buffer_load %{{.*}}[%[[OFFSET]]] {contiguity = 8 : i32} : <f16> -> tensor<128x64xf16, #blocked>
+// COMMON: amdg.buffer_store %{{.*}}[%[[OFFSET]]] {contiguity = 8 : i32} : <f16> -> tensor<128x64xf16, #blocked>
 
 #blocked = #ttg.blocked<{sizePerThread = [1, 8], threadsPerWarp = [8, 8], warpsPerCTA = [8, 1], order = [1, 0]}>
 

--- a/test/TritonGPU/amd/amd-convert-buffer-ops.mlir
+++ b/test/TritonGPU/amd/amd-convert-buffer-ops.mlir
@@ -827,7 +827,7 @@ module attributes {"ttg.compute-capability" = 0 : i32, "ttg.num-ctas" = 1 : i32,
 // COMMON:    %[[VAR_0:.*]] = arith.constant dense<0> : tensor<256x256xi64, #blocked>
 // COMMON:    %[[VAR_1:.*]] = amdg.extract_slice %[[VAR_0]] [0, 0] : tensor<256x256xi64, #blocked> to tensor<128x256xi64, #blocked>
 // COMMON:    %[[VAR_2:.*]] = arith.trunci %[[VAR_1]] : tensor<128x256xi64, #blocked> to tensor<128x256xi32, #blocked>
-// COMMON:    %[[VAR_3:.*]] = amdg.buffer_load %[[ARG_0]][%[[VAR_2]]] : tensor<128x256xf32, #blocked>
+// COMMON:    %[[VAR_3:.*]] = amdg.buffer_load %[[ARG_0]][%[[VAR_2]]] : <f32> -> tensor<128x256xf32, #blocked>
 // COMMON:    tt.return %[[VAR_3]] : tensor<128x256xf32, #blocked>
 // COMMON:  }
 
@@ -887,12 +887,12 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.targ
     %9 = tt.splat %8 : !tt.ptr<i64> -> tensor<64x!tt.ptr<i64>, #blocked>
     %10 = tt.addptr %9, %2 : tensor<64x!tt.ptr<i64>, #blocked>, tensor<64xi32, #blocked>
     %11 = tt.load %10, %cst : tensor<64x!tt.ptr<i64>, #blocked>
-    // COMMON: amdg.buffer_load %[[ptr1:.*]][%[[ofst1:.*]]], %[[mask1:.*]] : tensor<64xi64, #blocked>
+    // COMMON: amdg.buffer_load %[[ptr1:.*]][%[[ofst1:.*]]], %[[mask1:.*]] : <i64> -> tensor<64xi64, #blocked>
     %12 = tt.addptr %in_ptr, %1 : !tt.ptr<f32>, i32
     %13 = tt.splat %12 : !tt.ptr<f32> -> tensor<64x!tt.ptr<f32>, #blocked>
     %14 = tt.addptr %13, %2 : tensor<64x!tt.ptr<f32>, #blocked>, tensor<64xi32, #blocked>
     %15 = tt.load %14, %cst : tensor<64x!tt.ptr<f32>, #blocked>
-    // COMMON: amdg.buffer_load %[[ptr2:.*]][%[[ofst2:.*]]], %[[mask2:.*]] : tensor<64xf32, #blocked>
+    // COMMON: amdg.buffer_load %[[ptr2:.*]][%[[ofst2:.*]]], %[[mask2:.*]] : <f32> -> tensor<64xf32, #blocked>
     %16 = arith.extsi %7 : tensor<64xi32, #blocked> to tensor<64xi64, #blocked>
     %17 = arith.addi %11, %16 : tensor<64xi64, #blocked>
     %18 = arith.trunci %17 : tensor<64xi64, #blocked> to tensor<64xi32, #blocked>
@@ -926,12 +926,12 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.targ
     %9 = tt.splat %8 : !tt.ptr<i64> -> tensor<64x!tt.ptr<i64>, #blocked>
     %10 = tt.addptr %9, %2 : tensor<64x!tt.ptr<i64>, #blocked>, tensor<64xi32, #blocked>
     %11 = tt.load %10, %cst : tensor<64x!tt.ptr<i64>, #blocked>
-    // COMMON: amdg.buffer_load %[[ptr1:.*]][%[[ofst1:.*]]] : tensor<64xi64, #blocked>
+    // COMMON: amdg.buffer_load %[[ptr1:.*]][%[[ofst1:.*]]] : <i64> -> tensor<64xi64, #blocked>
     %12 = tt.addptr %in_ptr, %1 : !tt.ptr<f32>, i32
     %13 = tt.splat %12 : !tt.ptr<f32> -> tensor<64x!tt.ptr<f32>, #blocked>
     %14 = tt.addptr %13, %2 : tensor<64x!tt.ptr<f32>, #blocked>, tensor<64xi32, #blocked>
     %15 = tt.load %14, %cst : tensor<64x!tt.ptr<f32>, #blocked>
-    // COMMON: amdg.buffer_load %[[ptr2:.*]][%[[ofst2:.*]]] : tensor<64xf32, #blocked>
+    // COMMON: amdg.buffer_load %[[ptr2:.*]][%[[ofst2:.*]]] : <f32> -> tensor<64xf32, #blocked>
     %16 = arith.extsi %7 : tensor<64xi32, #blocked> to tensor<64xi64, #blocked>
     %17 = arith.addi %11, %16 : tensor<64xi64, #blocked>
     %18 = arith.trunci %17 : tensor<64xi64, #blocked> to tensor<64xi32, #blocked>

--- a/test/TritonGPU/amd/amd-convert-buffer-ops.mlir
+++ b/test/TritonGPU/amd/amd-convert-buffer-ops.mlir
@@ -827,7 +827,7 @@ module attributes {"ttg.compute-capability" = 0 : i32, "ttg.num-ctas" = 1 : i32,
 // COMMON:    %[[VAR_0:.*]] = arith.constant dense<0> : tensor<256x256xi64, #blocked>
 // COMMON:    %[[VAR_1:.*]] = amdg.extract_slice %[[VAR_0]] [0, 0] : tensor<256x256xi64, #blocked> to tensor<128x256xi64, #blocked>
 // COMMON:    %[[VAR_2:.*]] = arith.trunci %[[VAR_1]] : tensor<128x256xi64, #blocked> to tensor<128x256xi32, #blocked>
-// COMMON:    %[[VAR_3:.*]] = amdg.buffer_load %[[ARG_0]][%[[VAR_2]]] : <f32> -> tensor<128x256xf32, #blocked>
+// COMMON:    %[[VAR_3:.*]] = amdg.buffer_load %[[ARG_0]][%[[VAR_2]]] : !tt.ptr<f32> -> tensor<128x256xf32, #blocked>
 // COMMON:    tt.return %[[VAR_3]] : tensor<128x256xf32, #blocked>
 // COMMON:  }
 
@@ -887,12 +887,12 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.targ
     %9 = tt.splat %8 : !tt.ptr<i64> -> tensor<64x!tt.ptr<i64>, #blocked>
     %10 = tt.addptr %9, %2 : tensor<64x!tt.ptr<i64>, #blocked>, tensor<64xi32, #blocked>
     %11 = tt.load %10, %cst : tensor<64x!tt.ptr<i64>, #blocked>
-    // COMMON: amdg.buffer_load %[[ptr1:.*]][%[[ofst1:.*]]], %[[mask1:.*]] : <i64> -> tensor<64xi64, #blocked>
+    // COMMON: amdg.buffer_load %[[ptr1:.*]][%[[ofst1:.*]]], %[[mask1:.*]] : !tt.ptr<i64> -> tensor<64xi64, #blocked>
     %12 = tt.addptr %in_ptr, %1 : !tt.ptr<f32>, i32
     %13 = tt.splat %12 : !tt.ptr<f32> -> tensor<64x!tt.ptr<f32>, #blocked>
     %14 = tt.addptr %13, %2 : tensor<64x!tt.ptr<f32>, #blocked>, tensor<64xi32, #blocked>
     %15 = tt.load %14, %cst : tensor<64x!tt.ptr<f32>, #blocked>
-    // COMMON: amdg.buffer_load %[[ptr2:.*]][%[[ofst2:.*]]], %[[mask2:.*]] : <f32> -> tensor<64xf32, #blocked>
+    // COMMON: amdg.buffer_load %[[ptr2:.*]][%[[ofst2:.*]]], %[[mask2:.*]] : !tt.ptr<f32> -> tensor<64xf32, #blocked>
     %16 = arith.extsi %7 : tensor<64xi32, #blocked> to tensor<64xi64, #blocked>
     %17 = arith.addi %11, %16 : tensor<64xi64, #blocked>
     %18 = arith.trunci %17 : tensor<64xi64, #blocked> to tensor<64xi32, #blocked>
@@ -926,12 +926,12 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.targ
     %9 = tt.splat %8 : !tt.ptr<i64> -> tensor<64x!tt.ptr<i64>, #blocked>
     %10 = tt.addptr %9, %2 : tensor<64x!tt.ptr<i64>, #blocked>, tensor<64xi32, #blocked>
     %11 = tt.load %10, %cst : tensor<64x!tt.ptr<i64>, #blocked>
-    // COMMON: amdg.buffer_load %[[ptr1:.*]][%[[ofst1:.*]]] : <i64> -> tensor<64xi64, #blocked>
+    // COMMON: amdg.buffer_load %[[ptr1:.*]][%[[ofst1:.*]]] : !tt.ptr<i64> -> tensor<64xi64, #blocked>
     %12 = tt.addptr %in_ptr, %1 : !tt.ptr<f32>, i32
     %13 = tt.splat %12 : !tt.ptr<f32> -> tensor<64x!tt.ptr<f32>, #blocked>
     %14 = tt.addptr %13, %2 : tensor<64x!tt.ptr<f32>, #blocked>, tensor<64xi32, #blocked>
     %15 = tt.load %14, %cst : tensor<64x!tt.ptr<f32>, #blocked>
-    // COMMON: amdg.buffer_load %[[ptr2:.*]][%[[ofst2:.*]]] : <f32> -> tensor<64xf32, #blocked>
+    // COMMON: amdg.buffer_load %[[ptr2:.*]][%[[ofst2:.*]]] : !tt.ptr<f32> -> tensor<64xf32, #blocked>
     %16 = arith.extsi %7 : tensor<64xi32, #blocked> to tensor<64xi64, #blocked>
     %17 = arith.addi %11, %16 : tensor<64xi64, #blocked>
     %18 = arith.trunci %17 : tensor<64xi64, #blocked> to tensor<64xi32, #blocked>

--- a/test/TritonGPU/amd/amd-optimize-buffer-ops-base-ptr-increment.mlir
+++ b/test/TritonGPU/amd/amd-optimize-buffer-ops-base-ptr-increment.mlir
@@ -37,8 +37,8 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 1 : i32, "ttg.thr
     %tmp = arith.muli %stride, %c64_i32 : i32
     %step = tt.splat %tmp : i32 -> tensor<64x32xi32, #blocked>
     %for:2 = scf.for %idx = %c0 to %c128 step %c1 iter_args(%Xoffset = %Xoffset_init, %Yoffset = %Yoffset_init) -> (tensor<16x64xi32, #blocked>, tensor<64x32xi32, #blocked>) {
-      %x = amdg.buffer_load %X[%Xoffset] : <f16> -> tensor<16x64xf16, #blocked>
-      %y = amdg.buffer_load %Y[%Yoffset] cacheModifier = cg : <f16> -> tensor<64x32xf16, #blocked>
+      %x = amdg.buffer_load %X[%Xoffset] : !tt.ptr<f16> -> tensor<16x64xf16, #blocked>
+      %y = amdg.buffer_load %Y[%Yoffset] cacheModifier = cg : !tt.ptr<f16> -> tensor<64x32xf16, #blocked>
 
       ttg.local_store %x, %x_dummy_buffer : tensor<16x64xf16, #blocked> -> !ttg.memdesc<16x64xf16, #shared, #smem, mutable, 16x64>
       ttg.local_store %y, %y_dummy_buffer : tensor<64x32xf16, #blocked> -> !ttg.memdesc<64x32xf16, #shared, #smem, mutable, 64x32>
@@ -75,7 +75,7 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 1 : i32, "ttg.thr
     %x_dummy_buffer = ttg.local_alloc : () -> !ttg.memdesc<16x64xf16, #shared, #smem, mutable, 16x64>
 
     %for = scf.for %idx = %c0 to %c128 step %c1 iter_args(%Xoffset = %Xoffset_init) -> (tensor<16x64xi32, #blocked>) {
-      %x = amdg.buffer_load_to_local %X[%Xoffset] into %x_dummy_buffer : <f16>[tensor<16x64xi32, #blocked>] -> !ttg.memdesc<16x64xf16, #shared, #smem, mutable, 16x64>
+      %x = amdg.buffer_load_to_local %X[%Xoffset] into %x_dummy_buffer : !tt.ptr<f16>[tensor<16x64xi32, #blocked>] -> !ttg.memdesc<16x64xf16, #shared, #smem, mutable, 16x64>
 
       %Xoffset_next = arith.addi %Xoffset, %cst : tensor<16x64xi32, #blocked>
       scf.yield %Xoffset_next : tensor<16x64xi32, #blocked>
@@ -106,7 +106,7 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 1 : i32, "ttg.thr
     %x_dummy_buffer = ttg.local_alloc : () -> !ttg.memdesc<16x64xf16, #shared, #smem, mutable, 16x64>
     %for = scf.for %idx = %c0 to %c128 step %c1 iter_args(%Xoffset = %Xoffset_init) -> (tensor<16x64xi32, #blocked>) {
       %Xoffset_next = arith.addi %Xoffset, %cst : tensor<16x64xi32, #blocked>
-      %x = amdg.buffer_load %X[%Xoffset_next] : <f16> -> tensor<16x64xf16, #blocked>
+      %x = amdg.buffer_load %X[%Xoffset_next] : !tt.ptr<f16> -> tensor<16x64xf16, #blocked>
       ttg.local_store %x, %x_dummy_buffer : tensor<16x64xf16, #blocked> -> !ttg.memdesc<16x64xf16, #shared, #smem, mutable, 16x64>
       scf.yield %Xoffset_next : tensor<16x64xi32, #blocked>
     }
@@ -138,7 +138,7 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 1 : i32, "ttg.thr
     %x_dummy_buffer = ttg.local_alloc : () -> !ttg.memdesc<16x64xf16, #shared, #smem, mutable, 16x64>
     scf.for %idx_outer = %c0 to %c32 step %c1 iter_args() -> () {
       %for_inner = scf.for %idx_innter = %c0 to %c32 step %c1 iter_args(%Xoffset = %Xoffset_init) -> (tensor<16x64xi32, #blocked>) {
-        %x = amdg.buffer_load %X[%Xoffset] : <f16> -> tensor<16x64xf16, #blocked>
+        %x = amdg.buffer_load %X[%Xoffset] : !tt.ptr<f16> -> tensor<16x64xf16, #blocked>
         ttg.local_store %x, %x_dummy_buffer : tensor<16x64xf16, #blocked> -> !ttg.memdesc<16x64xf16, #shared, #smem, mutable, 16x64>
         %Xoffset_next = arith.addi %Xoffset, %cst : tensor<16x64xi32, #blocked>
         scf.yield %Xoffset_next : tensor<16x64xi32, #blocked>
@@ -173,7 +173,7 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 1 : i32, "ttg.thr
     %x_dummy_buffer = ttg.local_alloc : () -> !ttg.memdesc<16x64xf16, #shared, #smem, mutable, 16x64>
     %for_outer = scf.for %idx_outer = %c0 to %c128 step %c1 iter_args(%Xoffset = %Xoffset_init) -> (tensor<16x64xi32, #blocked>) {
       scf.for %idx_inner = %c0 to %c128 step %c1 iter_args() -> () {
-        %x = amdg.buffer_load %X[%Xoffset] : <f16> -> tensor<16x64xf16, #blocked>
+        %x = amdg.buffer_load %X[%Xoffset] : !tt.ptr<f16> -> tensor<16x64xf16, #blocked>
         ttg.local_store %x, %x_dummy_buffer : tensor<16x64xf16, #blocked> -> !ttg.memdesc<16x64xf16, #shared, #smem, mutable, 16x64>
         scf.yield
       }
@@ -237,7 +237,7 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 1 : i32, "ttg.thr
     %x_dummy_buffer = ttg.local_alloc : () -> !ttg.memdesc<16x64xf16, #shared, #smem, mutable, 16x64>
     %for = scf.for %idx = %c0 to %c128 step %c1 iter_args(%Xoffset = %Xoffset_init) -> (tensor<16x64xi32, #blocked>) : i32 {
       %x_base = tt.addptr %X, %idx : !tt.ptr<f16>, i32
-      %x = amdg.buffer_load %x_base[%Xoffset] : <f16> -> tensor<16x64xf16, #blocked>
+      %x = amdg.buffer_load %x_base[%Xoffset] : !tt.ptr<f16> -> tensor<16x64xf16, #blocked>
       ttg.local_store %x, %x_dummy_buffer : tensor<16x64xf16, #blocked> -> !ttg.memdesc<16x64xf16, #shared, #smem, mutable, 16x64>
       %Xoffset_next = arith.addi %Xoffset, %cst : tensor<16x64xi32, #blocked>
       scf.yield %Xoffset_next : tensor<16x64xi32, #blocked>
@@ -263,7 +263,7 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 1 : i32, "ttg.thr
     %Xoffset_init = arith.constant dense<123> : tensor<16x64xi32, #blocked>
     %x_dummy_buffer = ttg.local_alloc : () -> !ttg.memdesc<16x64xf16, #shared, #smem, mutable, 16x64>
     %for = scf.for %idx = %c0 to %c128 step %c1 iter_args(%Xoffset = %Xoffset_init) -> (tensor<16x64xi32, #blocked>) : i32 {
-      %x = amdg.buffer_load %X[%Xoffset] : <f16> -> tensor<16x64xf16, #blocked>
+      %x = amdg.buffer_load %X[%Xoffset] : !tt.ptr<f16> -> tensor<16x64xf16, #blocked>
       ttg.local_store %x, %x_dummy_buffer : tensor<16x64xf16, #blocked> -> !ttg.memdesc<16x64xf16, #shared, #smem, mutable, 16x64>
       %Xoffset_next = arith.addi %Xoffset, %step : tensor<16x64xi32, #blocked>
       scf.yield %Xoffset_next : tensor<16x64xi32, #blocked>
@@ -290,7 +290,7 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 1 : i32, "ttg.thr
     %x_dummy_buffer = ttg.local_alloc : () -> !ttg.memdesc<16x64xf16, #shared, #smem, mutable, 16x64>
     %step = tt.splat %step_scalar: i32 -> tensor<16x64xi32, #blocked>
     %for = scf.for %idx = %c0 to %c128 step %c1 iter_args(%Xoffset = %Xoffset_init) -> (tensor<16x64xi32, #blocked>) : i32 {
-      %x = amdg.buffer_load %X[%Xoffset] : <f16> -> tensor<16x64xf16, #blocked>
+      %x = amdg.buffer_load %X[%Xoffset] : !tt.ptr<f16> -> tensor<16x64xf16, #blocked>
       ttg.local_store %x, %x_dummy_buffer : tensor<16x64xf16, #blocked> -> !ttg.memdesc<16x64xf16, #shared, #smem, mutable, 16x64>
       %Xoffset_next = arith.addi %Xoffset, %step : tensor<16x64xi32, #blocked>
       scf.yield %Xoffset_next : tensor<16x64xi32, #blocked>
@@ -318,7 +318,7 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 1 : i32, "ttg.thr
     %step = arith.constant dense<64> : tensor<16x64xi32, #blocked>
     %for:2 = scf.for %idx = %c0 to %c128 step %c1 iter_args(%Xoffset = %Xoffset_init, %Xoffset_dummy = %Xoffset_init) -> (tensor<16x64xi32, #blocked>, tensor<16x64xi32, #blocked>) : i32 {
       %Xoffset_decoy = arith.addi %Xoffset, %step : tensor<16x64xi32, #blocked>
-      %x = amdg.buffer_load %X[%Xoffset_decoy] : <f16> -> tensor<16x64xf16, #blocked>
+      %x = amdg.buffer_load %X[%Xoffset_decoy] : !tt.ptr<f16> -> tensor<16x64xf16, #blocked>
       ttg.local_store %x, %x_dummy_buffer : tensor<16x64xf16, #blocked> -> !ttg.memdesc<16x64xf16, #shared, #smem, mutable, 16x64>
       %Xoffset_next = arith.addi %Xoffset, %step : tensor<16x64xi32, #blocked>
       scf.yield %Xoffset_next, %Xoffset_decoy : tensor<16x64xi32, #blocked>, tensor<16x64xi32, #blocked>
@@ -335,9 +335,9 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 1 : i32, "ttg.thr
 // CHECK-DAG: [[Y_OFFSET_INIT:%.*]] = arith.constant dense<456> : tensor<64x32xi32, #blocked>
 // CHECK-DAG: [[Z_OFFSET:%.*]] = arith.constant dense<789> : tensor<32x32xi32, #blocked>
 // CHECK: scf.for {{.*}} iter_args({{%.*}}[[Y_OFFSET:%.*]] = [[Y_OFFSET_INIT]]
-// CHECK-DAG: amdg.buffer_load {{%.*\[}}[[X_OFFSET]]{{\]}} : <f16> -> tensor<16x64xf16, #blocked>
-// CHECK-DAG: amdg.buffer_load {{%.*\[}}[[Y_OFFSET]]{{\]}} cacheModifier = cg : <f16> -> tensor<64x32xf16, #blocked>
-// CHECK-DAG: amdg.buffer_load {{%.*\[}}[[Z_OFFSET]]{{\]}} cacheModifier = cg : <f16> -> tensor<32x32xf16, #blocked>
+// CHECK-DAG: amdg.buffer_load {{%.*\[}}[[X_OFFSET]]{{\]}} : !tt.ptr<f16> -> tensor<16x64xf16, #blocked>
+// CHECK-DAG: amdg.buffer_load {{%.*\[}}[[Y_OFFSET]]{{\]}} cacheModifier = cg : !tt.ptr<f16> -> tensor<64x32xf16, #blocked>
+// CHECK-DAG: amdg.buffer_load {{%.*\[}}[[Z_OFFSET]]{{\]}} cacheModifier = cg : !tt.ptr<f16> -> tensor<32x32xf16, #blocked>
 
 #blocked = #ttg.blocked<{sizePerThread = [1, 1], threadsPerWarp = [8, 8], warpsPerCTA = [1, 1], order = [1, 0]}>
 #shared = #ttg.swizzled_shared<{vec = 1, perPhase = 1, maxPhase = 1, order = [1, 0]}>
@@ -366,9 +366,9 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 1 : i32, "ttg.thr
     %z_dummy_buffer = ttg.local_alloc : () -> !ttg.memdesc<32x32xf16, #shared, #smem, mutable, 32x32>
 
     %for:3 = scf.for %iter = %iter_first to %iter_last step %iter_step iter_args(%Xoffset = %Xoffset_init, %Yoffset = %Yoffset_init, %Zoffset = %Zoffset_init) -> (tensor<16x64xi32, #blocked>, tensor<64x32xi32, #blocked>, tensor<32x32xi32, #blocked>) {
-      %x = amdg.buffer_load %X[%Xoffset] : <f16> -> tensor<16x64xf16, #blocked>
-      %y = amdg.buffer_load %Y[%Yoffset] cacheModifier = cg : <f16> -> tensor<64x32xf16, #blocked>
-      %z = amdg.buffer_load %Z[%Zoffset] cacheModifier = cg : <f16> -> tensor<32x32xf16, #blocked>
+      %x = amdg.buffer_load %X[%Xoffset] : !tt.ptr<f16> -> tensor<16x64xf16, #blocked>
+      %y = amdg.buffer_load %Y[%Yoffset] cacheModifier = cg : !tt.ptr<f16> -> tensor<64x32xf16, #blocked>
+      %z = amdg.buffer_load %Z[%Zoffset] cacheModifier = cg : !tt.ptr<f16> -> tensor<32x32xf16, #blocked>
 
       ttg.local_store %x, %x_dummy_buffer : tensor<16x64xf16, #blocked> -> !ttg.memdesc<16x64xf16, #shared, #smem, mutable, 16x64>
       ttg.local_store %y, %y_dummy_buffer : tensor<64x32xf16, #blocked> -> !ttg.memdesc<64x32xf16, #shared, #smem, mutable, 64x32>
@@ -391,9 +391,9 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 1 : i32, "ttg.thr
 // CHECK-DAG: [[Y_OFFSET:%.*]] = arith.constant dense<456> : tensor<64x32xi32, #blocked>
 // CHECK-DAG: [[Z_OFFSET_INIT:%.*]] = arith.constant dense<789> : tensor<32x32xi32, #blocked>
 // CHECK: scf.for {{.*}} iter_args([[X_OFFSET:%.*]] = [[X_OFFSET_INIT]], {{.*}}[[Z_OFFSET:%.*]] = [[Z_OFFSET_INIT]]
-// CHECK-DAG: amdg.buffer_load {{%.*\[}}[[X_OFFSET]]{{\]}} : <f16> -> tensor<16x64xf16, #blocked>
-// CHECK-DAG: amdg.buffer_load {{%.*\[}}[[Y_OFFSET]]{{\]}} cacheModifier = cg : <f16> -> tensor<64x32xf16, #blocked>
-// CHECK-DAG: amdg.buffer_load {{%.*\[}}[[Z_OFFSET]]{{\]}} cacheModifier = cg : <f16> -> tensor<32x32xf16, #blocked>
+// CHECK-DAG: amdg.buffer_load {{%.*\[}}[[X_OFFSET]]{{\]}} : !tt.ptr<f16> -> tensor<16x64xf16, #blocked>
+// CHECK-DAG: amdg.buffer_load {{%.*\[}}[[Y_OFFSET]]{{\]}} cacheModifier = cg : !tt.ptr<f16> -> tensor<64x32xf16, #blocked>
+// CHECK-DAG: amdg.buffer_load {{%.*\[}}[[Z_OFFSET]]{{\]}} cacheModifier = cg : !tt.ptr<f16> -> tensor<32x32xf16, #blocked>
 
 #blocked = #ttg.blocked<{sizePerThread = [1, 1], threadsPerWarp = [8, 8], warpsPerCTA = [1, 1], order = [1, 0]}>
 #shared = #ttg.swizzled_shared<{vec = 1, perPhase = 1, maxPhase = 1, order = [1, 0]}>
@@ -422,9 +422,9 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 1 : i32, "ttg.thr
     %z_dummy_buffer = ttg.local_alloc : () -> !ttg.memdesc<32x32xf16, #shared, #smem, mutable, 32x32>
 
     %for:3 = scf.for %iter = %iter_first to %iter_last step %iter_step iter_args(%Xoffset = %Xoffset_init, %Yoffset = %Yoffset_init, %Zoffset = %Zoffset_init) -> (tensor<16x64xi32, #blocked>, tensor<64x32xi32, #blocked>, tensor<32x32xi32, #blocked>) {
-      %x = amdg.buffer_load %X[%Xoffset] : <f16> -> tensor<16x64xf16, #blocked>
-      %y = amdg.buffer_load %Y[%Yoffset] cacheModifier = cg : <f16> -> tensor<64x32xf16, #blocked>
-      %z = amdg.buffer_load %Z[%Zoffset] cacheModifier = cg : <f16> -> tensor<32x32xf16, #blocked>
+      %x = amdg.buffer_load %X[%Xoffset] : !tt.ptr<f16> -> tensor<16x64xf16, #blocked>
+      %y = amdg.buffer_load %Y[%Yoffset] cacheModifier = cg : !tt.ptr<f16> -> tensor<64x32xf16, #blocked>
+      %z = amdg.buffer_load %Z[%Zoffset] cacheModifier = cg : !tt.ptr<f16> -> tensor<32x32xf16, #blocked>
 
       ttg.local_store %x, %x_dummy_buffer : tensor<16x64xf16, #blocked> -> !ttg.memdesc<16x64xf16, #shared, #smem, mutable, 16x64>
       ttg.local_store %y, %y_dummy_buffer : tensor<64x32xf16, #blocked> -> !ttg.memdesc<64x32xf16, #shared, #smem, mutable, 64x32>
@@ -459,7 +459,7 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 1 : i32, "ttg.thr
     %for = scf.for %idx = %iter_first to %iter_last step %iter_step iter_args(%Xoffset = %Xoffset_init) -> (tensor<16x64xi32, #blocked>) {
       ttg.local_store %Xoffset, %offset_buffer : tensor<16x64xi32, #blocked> -> !ttg.memdesc<16x64xi32, #shared, #smem, mutable, 16x64>
       %Xoffset_next = arith.addi %Xoffset, %offset_step : tensor<16x64xi32, #blocked>
-      %x = amdg.buffer_load %X[%Xoffset_next] : <f16> -> tensor<16x64xf16, #blocked>
+      %x = amdg.buffer_load %X[%Xoffset_next] : !tt.ptr<f16> -> tensor<16x64xf16, #blocked>
       ttg.local_store %x, %x_dummy_buffer : tensor<16x64xf16, #blocked> -> !ttg.memdesc<16x64xf16, #shared, #smem, mutable, 16x64>
       ttg.local_store %Xoffset_next, %offset_buffer : tensor<16x64xi32, #blocked> -> !ttg.memdesc<16x64xi32, #shared, #smem, mutable, 16x64>
       scf.yield %Xoffset_next : tensor<16x64xi32, #blocked>
@@ -494,12 +494,12 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 1 : i32, "ttg.thr
 
       %for2 = scf.for %idx2 = %iter_first to %iter_last step %iter_step iter_args(%Xoffset2 = %Xoffset_next1) -> (tensor<16x64xi32, #blocked>) {
         %Xoffset_next2 = arith.addi %Xoffset2, %offset_step : tensor<16x64xi32, #blocked>
-        %x2 = amdg.buffer_load %X[%Xoffset_next2] : <f16> -> tensor<16x64xf16, #blocked>
+        %x2 = amdg.buffer_load %X[%Xoffset_next2] : !tt.ptr<f16> -> tensor<16x64xf16, #blocked>
         ttg.local_store %x2, %x_dummy_buffer : tensor<16x64xf16, #blocked> -> !ttg.memdesc<16x64xf16, #shared, #smem, mutable, 16x64>
         scf.yield %Xoffset_next2 : tensor<16x64xi32, #blocked>
       }
 
-      %x1 = amdg.buffer_load %X[%Xoffset_next1] : <f16> -> tensor<16x64xf16, #blocked>
+      %x1 = amdg.buffer_load %X[%Xoffset_next1] : !tt.ptr<f16> -> tensor<16x64xf16, #blocked>
       ttg.local_store %x1, %x_dummy_buffer : tensor<16x64xf16, #blocked> -> !ttg.memdesc<16x64xf16, #shared, #smem, mutable, 16x64>
       scf.yield %Xoffset_next1 : tensor<16x64xi32, #blocked>
     }
@@ -528,7 +528,7 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 1 : i32, "ttg.thr
     %x_dummy_buffer = ttg.local_alloc : () -> !ttg.memdesc<16x64xf16, #shared, #smem, mutable, 16x64>
 
     %for = scf.for %idx = %iter_first to %iter_last step %iter_step iter_args(%Xoffset = %Xoffset_init) -> (tensor<16x64xi32, #blocked>) {
-      %x = amdg.buffer_load_to_local %X[%Xoffset] into %x_dummy_buffer : <f16>[tensor<16x64xi32, #blocked>] -> !ttg.memdesc<16x64xf16, #shared, #smem, mutable, 16x64>
+      %x = amdg.buffer_load_to_local %X[%Xoffset] into %x_dummy_buffer : !tt.ptr<f16>[tensor<16x64xi32, #blocked>] -> !ttg.memdesc<16x64xf16, #shared, #smem, mutable, 16x64>
 
       %Xoffset_tmp = arith.addi %Xoffset, %cst1 : tensor<16x64xi32, #blocked>
       %Xoffset_next = arith.addi %Xoffset_tmp, %cst2 : tensor<16x64xi32, #blocked>
@@ -558,9 +558,9 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 1 : i32, "ttg.thr
     %x_dummy_buffer = ttg.local_alloc : () -> !ttg.memdesc<16x64xf16, #shared, #smem, mutable, 16x64>
 
     %for = scf.for %idx = %iter_first to %iter_last step %iter_step iter_args(%Xoffset = %Xoffset_init) -> (tensor<16x64xi32, #blocked>) {
-      %x1 = amdg.buffer_load_to_local %X[%Xoffset] into %x_dummy_buffer : <f16>[tensor<16x64xi32, #blocked>] -> !ttg.memdesc<16x64xf16, #shared, #smem, mutable, 16x64>
+      %x1 = amdg.buffer_load_to_local %X[%Xoffset] into %x_dummy_buffer : !tt.ptr<f16>[tensor<16x64xi32, #blocked>] -> !ttg.memdesc<16x64xf16, #shared, #smem, mutable, 16x64>
       %Xoffset_next = arith.addi %Xoffset, %cst : tensor<16x64xi32, #blocked>
-      %x2 = amdg.buffer_load_to_local %X[%Xoffset_next] into %x_dummy_buffer : <f16>[tensor<16x64xi32, #blocked>] -> !ttg.memdesc<16x64xf16, #shared, #smem, mutable, 16x64>
+      %x2 = amdg.buffer_load_to_local %X[%Xoffset_next] into %x_dummy_buffer : !tt.ptr<f16>[tensor<16x64xi32, #blocked>] -> !ttg.memdesc<16x64xf16, #shared, #smem, mutable, 16x64>
       scf.yield %Xoffset_next : tensor<16x64xi32, #blocked>
     }
     tt.return
@@ -581,7 +581,7 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, "ttg.thr
     %iter_step = arith.constant 1 : i32
 
     %for:2 = scf.for %iter = %iter_first to %iter_last step %iter_step iter_args(%arg1 = %zero, %arg2 = %zero) -> (tensor<256xi32, #blocked>, tensor<256xi32, #blocked>) : i32 {
-      %data = amdg.buffer_load %arg0[%arg1] : <i32> -> tensor<256xi32, #blocked>
+      %data = amdg.buffer_load %arg0[%arg1] : !tt.ptr<i32> -> tensor<256xi32, #blocked>
       scf.yield %arg2, %data : tensor<256xi32, #blocked>, tensor<256xi32, #blocked>
     }
     tt.return %for#1 : tensor<256xi32, #blocked>

--- a/test/TritonGPU/amd/amd-optimize-buffer-ops-base-ptr-increment.mlir
+++ b/test/TritonGPU/amd/amd-optimize-buffer-ops-base-ptr-increment.mlir
@@ -37,8 +37,8 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 1 : i32, "ttg.thr
     %tmp = arith.muli %stride, %c64_i32 : i32
     %step = tt.splat %tmp : i32 -> tensor<64x32xi32, #blocked>
     %for:2 = scf.for %idx = %c0 to %c128 step %c1 iter_args(%Xoffset = %Xoffset_init, %Yoffset = %Yoffset_init) -> (tensor<16x64xi32, #blocked>, tensor<64x32xi32, #blocked>) {
-      %x = amdg.buffer_load %X[%Xoffset] : tensor<16x64xf16, #blocked>
-      %y = amdg.buffer_load %Y[%Yoffset] cacheModifier = cg : tensor<64x32xf16, #blocked>
+      %x = amdg.buffer_load %X[%Xoffset] : <f16> -> tensor<16x64xf16, #blocked>
+      %y = amdg.buffer_load %Y[%Yoffset] cacheModifier = cg : <f16> -> tensor<64x32xf16, #blocked>
 
       ttg.local_store %x, %x_dummy_buffer : tensor<16x64xf16, #blocked> -> !ttg.memdesc<16x64xf16, #shared, #smem, mutable, 16x64>
       ttg.local_store %y, %y_dummy_buffer : tensor<64x32xf16, #blocked> -> !ttg.memdesc<64x32xf16, #shared, #smem, mutable, 64x32>
@@ -106,7 +106,7 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 1 : i32, "ttg.thr
     %x_dummy_buffer = ttg.local_alloc : () -> !ttg.memdesc<16x64xf16, #shared, #smem, mutable, 16x64>
     %for = scf.for %idx = %c0 to %c128 step %c1 iter_args(%Xoffset = %Xoffset_init) -> (tensor<16x64xi32, #blocked>) {
       %Xoffset_next = arith.addi %Xoffset, %cst : tensor<16x64xi32, #blocked>
-      %x = amdg.buffer_load %X[%Xoffset_next] : tensor<16x64xf16, #blocked>
+      %x = amdg.buffer_load %X[%Xoffset_next] : <f16> -> tensor<16x64xf16, #blocked>
       ttg.local_store %x, %x_dummy_buffer : tensor<16x64xf16, #blocked> -> !ttg.memdesc<16x64xf16, #shared, #smem, mutable, 16x64>
       scf.yield %Xoffset_next : tensor<16x64xi32, #blocked>
     }
@@ -138,7 +138,7 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 1 : i32, "ttg.thr
     %x_dummy_buffer = ttg.local_alloc : () -> !ttg.memdesc<16x64xf16, #shared, #smem, mutable, 16x64>
     scf.for %idx_outer = %c0 to %c32 step %c1 iter_args() -> () {
       %for_inner = scf.for %idx_innter = %c0 to %c32 step %c1 iter_args(%Xoffset = %Xoffset_init) -> (tensor<16x64xi32, #blocked>) {
-        %x = amdg.buffer_load %X[%Xoffset] : tensor<16x64xf16, #blocked>
+        %x = amdg.buffer_load %X[%Xoffset] : <f16> -> tensor<16x64xf16, #blocked>
         ttg.local_store %x, %x_dummy_buffer : tensor<16x64xf16, #blocked> -> !ttg.memdesc<16x64xf16, #shared, #smem, mutable, 16x64>
         %Xoffset_next = arith.addi %Xoffset, %cst : tensor<16x64xi32, #blocked>
         scf.yield %Xoffset_next : tensor<16x64xi32, #blocked>
@@ -173,7 +173,7 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 1 : i32, "ttg.thr
     %x_dummy_buffer = ttg.local_alloc : () -> !ttg.memdesc<16x64xf16, #shared, #smem, mutable, 16x64>
     %for_outer = scf.for %idx_outer = %c0 to %c128 step %c1 iter_args(%Xoffset = %Xoffset_init) -> (tensor<16x64xi32, #blocked>) {
       scf.for %idx_inner = %c0 to %c128 step %c1 iter_args() -> () {
-        %x = amdg.buffer_load %X[%Xoffset] : tensor<16x64xf16, #blocked>
+        %x = amdg.buffer_load %X[%Xoffset] : <f16> -> tensor<16x64xf16, #blocked>
         ttg.local_store %x, %x_dummy_buffer : tensor<16x64xf16, #blocked> -> !ttg.memdesc<16x64xf16, #shared, #smem, mutable, 16x64>
         scf.yield
       }
@@ -237,7 +237,7 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 1 : i32, "ttg.thr
     %x_dummy_buffer = ttg.local_alloc : () -> !ttg.memdesc<16x64xf16, #shared, #smem, mutable, 16x64>
     %for = scf.for %idx = %c0 to %c128 step %c1 iter_args(%Xoffset = %Xoffset_init) -> (tensor<16x64xi32, #blocked>) : i32 {
       %x_base = tt.addptr %X, %idx : !tt.ptr<f16>, i32
-      %x = amdg.buffer_load %x_base[%Xoffset] : tensor<16x64xf16, #blocked>
+      %x = amdg.buffer_load %x_base[%Xoffset] : <f16> -> tensor<16x64xf16, #blocked>
       ttg.local_store %x, %x_dummy_buffer : tensor<16x64xf16, #blocked> -> !ttg.memdesc<16x64xf16, #shared, #smem, mutable, 16x64>
       %Xoffset_next = arith.addi %Xoffset, %cst : tensor<16x64xi32, #blocked>
       scf.yield %Xoffset_next : tensor<16x64xi32, #blocked>
@@ -263,7 +263,7 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 1 : i32, "ttg.thr
     %Xoffset_init = arith.constant dense<123> : tensor<16x64xi32, #blocked>
     %x_dummy_buffer = ttg.local_alloc : () -> !ttg.memdesc<16x64xf16, #shared, #smem, mutable, 16x64>
     %for = scf.for %idx = %c0 to %c128 step %c1 iter_args(%Xoffset = %Xoffset_init) -> (tensor<16x64xi32, #blocked>) : i32 {
-      %x = amdg.buffer_load %X[%Xoffset] : tensor<16x64xf16, #blocked>
+      %x = amdg.buffer_load %X[%Xoffset] : <f16> -> tensor<16x64xf16, #blocked>
       ttg.local_store %x, %x_dummy_buffer : tensor<16x64xf16, #blocked> -> !ttg.memdesc<16x64xf16, #shared, #smem, mutable, 16x64>
       %Xoffset_next = arith.addi %Xoffset, %step : tensor<16x64xi32, #blocked>
       scf.yield %Xoffset_next : tensor<16x64xi32, #blocked>
@@ -290,7 +290,7 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 1 : i32, "ttg.thr
     %x_dummy_buffer = ttg.local_alloc : () -> !ttg.memdesc<16x64xf16, #shared, #smem, mutable, 16x64>
     %step = tt.splat %step_scalar: i32 -> tensor<16x64xi32, #blocked>
     %for = scf.for %idx = %c0 to %c128 step %c1 iter_args(%Xoffset = %Xoffset_init) -> (tensor<16x64xi32, #blocked>) : i32 {
-      %x = amdg.buffer_load %X[%Xoffset] : tensor<16x64xf16, #blocked>
+      %x = amdg.buffer_load %X[%Xoffset] : <f16> -> tensor<16x64xf16, #blocked>
       ttg.local_store %x, %x_dummy_buffer : tensor<16x64xf16, #blocked> -> !ttg.memdesc<16x64xf16, #shared, #smem, mutable, 16x64>
       %Xoffset_next = arith.addi %Xoffset, %step : tensor<16x64xi32, #blocked>
       scf.yield %Xoffset_next : tensor<16x64xi32, #blocked>
@@ -318,7 +318,7 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 1 : i32, "ttg.thr
     %step = arith.constant dense<64> : tensor<16x64xi32, #blocked>
     %for:2 = scf.for %idx = %c0 to %c128 step %c1 iter_args(%Xoffset = %Xoffset_init, %Xoffset_dummy = %Xoffset_init) -> (tensor<16x64xi32, #blocked>, tensor<16x64xi32, #blocked>) : i32 {
       %Xoffset_decoy = arith.addi %Xoffset, %step : tensor<16x64xi32, #blocked>
-      %x = amdg.buffer_load %X[%Xoffset_decoy] : tensor<16x64xf16, #blocked>
+      %x = amdg.buffer_load %X[%Xoffset_decoy] : <f16> -> tensor<16x64xf16, #blocked>
       ttg.local_store %x, %x_dummy_buffer : tensor<16x64xf16, #blocked> -> !ttg.memdesc<16x64xf16, #shared, #smem, mutable, 16x64>
       %Xoffset_next = arith.addi %Xoffset, %step : tensor<16x64xi32, #blocked>
       scf.yield %Xoffset_next, %Xoffset_decoy : tensor<16x64xi32, #blocked>, tensor<16x64xi32, #blocked>
@@ -335,9 +335,9 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 1 : i32, "ttg.thr
 // CHECK-DAG: [[Y_OFFSET_INIT:%.*]] = arith.constant dense<456> : tensor<64x32xi32, #blocked>
 // CHECK-DAG: [[Z_OFFSET:%.*]] = arith.constant dense<789> : tensor<32x32xi32, #blocked>
 // CHECK: scf.for {{.*}} iter_args({{%.*}}[[Y_OFFSET:%.*]] = [[Y_OFFSET_INIT]]
-// CHECK-DAG: amdg.buffer_load {{%.*\[}}[[X_OFFSET]]{{\]}} : tensor<16x64xf16, #blocked>
-// CHECK-DAG: amdg.buffer_load {{%.*\[}}[[Y_OFFSET]]{{\]}} cacheModifier = cg : tensor<64x32xf16, #blocked>
-// CHECK-DAG: amdg.buffer_load {{%.*\[}}[[Z_OFFSET]]{{\]}} cacheModifier = cg : tensor<32x32xf16, #blocked>
+// CHECK-DAG: amdg.buffer_load {{%.*\[}}[[X_OFFSET]]{{\]}} : <f16> -> tensor<16x64xf16, #blocked>
+// CHECK-DAG: amdg.buffer_load {{%.*\[}}[[Y_OFFSET]]{{\]}} cacheModifier = cg : <f16> -> tensor<64x32xf16, #blocked>
+// CHECK-DAG: amdg.buffer_load {{%.*\[}}[[Z_OFFSET]]{{\]}} cacheModifier = cg : <f16> -> tensor<32x32xf16, #blocked>
 
 #blocked = #ttg.blocked<{sizePerThread = [1, 1], threadsPerWarp = [8, 8], warpsPerCTA = [1, 1], order = [1, 0]}>
 #shared = #ttg.swizzled_shared<{vec = 1, perPhase = 1, maxPhase = 1, order = [1, 0]}>
@@ -366,9 +366,9 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 1 : i32, "ttg.thr
     %z_dummy_buffer = ttg.local_alloc : () -> !ttg.memdesc<32x32xf16, #shared, #smem, mutable, 32x32>
 
     %for:3 = scf.for %iter = %iter_first to %iter_last step %iter_step iter_args(%Xoffset = %Xoffset_init, %Yoffset = %Yoffset_init, %Zoffset = %Zoffset_init) -> (tensor<16x64xi32, #blocked>, tensor<64x32xi32, #blocked>, tensor<32x32xi32, #blocked>) {
-      %x = amdg.buffer_load %X[%Xoffset] : tensor<16x64xf16, #blocked>
-      %y = amdg.buffer_load %Y[%Yoffset] cacheModifier = cg : tensor<64x32xf16, #blocked>
-      %z = amdg.buffer_load %Z[%Zoffset] cacheModifier = cg : tensor<32x32xf16, #blocked>
+      %x = amdg.buffer_load %X[%Xoffset] : <f16> -> tensor<16x64xf16, #blocked>
+      %y = amdg.buffer_load %Y[%Yoffset] cacheModifier = cg : <f16> -> tensor<64x32xf16, #blocked>
+      %z = amdg.buffer_load %Z[%Zoffset] cacheModifier = cg : <f16> -> tensor<32x32xf16, #blocked>
 
       ttg.local_store %x, %x_dummy_buffer : tensor<16x64xf16, #blocked> -> !ttg.memdesc<16x64xf16, #shared, #smem, mutable, 16x64>
       ttg.local_store %y, %y_dummy_buffer : tensor<64x32xf16, #blocked> -> !ttg.memdesc<64x32xf16, #shared, #smem, mutable, 64x32>
@@ -391,9 +391,9 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 1 : i32, "ttg.thr
 // CHECK-DAG: [[Y_OFFSET:%.*]] = arith.constant dense<456> : tensor<64x32xi32, #blocked>
 // CHECK-DAG: [[Z_OFFSET_INIT:%.*]] = arith.constant dense<789> : tensor<32x32xi32, #blocked>
 // CHECK: scf.for {{.*}} iter_args([[X_OFFSET:%.*]] = [[X_OFFSET_INIT]], {{.*}}[[Z_OFFSET:%.*]] = [[Z_OFFSET_INIT]]
-// CHECK-DAG: amdg.buffer_load {{%.*\[}}[[X_OFFSET]]{{\]}} : tensor<16x64xf16, #blocked>
-// CHECK-DAG: amdg.buffer_load {{%.*\[}}[[Y_OFFSET]]{{\]}} cacheModifier = cg : tensor<64x32xf16, #blocked>
-// CHECK-DAG: amdg.buffer_load {{%.*\[}}[[Z_OFFSET]]{{\]}} cacheModifier = cg : tensor<32x32xf16, #blocked>
+// CHECK-DAG: amdg.buffer_load {{%.*\[}}[[X_OFFSET]]{{\]}} : <f16> -> tensor<16x64xf16, #blocked>
+// CHECK-DAG: amdg.buffer_load {{%.*\[}}[[Y_OFFSET]]{{\]}} cacheModifier = cg : <f16> -> tensor<64x32xf16, #blocked>
+// CHECK-DAG: amdg.buffer_load {{%.*\[}}[[Z_OFFSET]]{{\]}} cacheModifier = cg : <f16> -> tensor<32x32xf16, #blocked>
 
 #blocked = #ttg.blocked<{sizePerThread = [1, 1], threadsPerWarp = [8, 8], warpsPerCTA = [1, 1], order = [1, 0]}>
 #shared = #ttg.swizzled_shared<{vec = 1, perPhase = 1, maxPhase = 1, order = [1, 0]}>
@@ -422,9 +422,9 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 1 : i32, "ttg.thr
     %z_dummy_buffer = ttg.local_alloc : () -> !ttg.memdesc<32x32xf16, #shared, #smem, mutable, 32x32>
 
     %for:3 = scf.for %iter = %iter_first to %iter_last step %iter_step iter_args(%Xoffset = %Xoffset_init, %Yoffset = %Yoffset_init, %Zoffset = %Zoffset_init) -> (tensor<16x64xi32, #blocked>, tensor<64x32xi32, #blocked>, tensor<32x32xi32, #blocked>) {
-      %x = amdg.buffer_load %X[%Xoffset] : tensor<16x64xf16, #blocked>
-      %y = amdg.buffer_load %Y[%Yoffset] cacheModifier = cg : tensor<64x32xf16, #blocked>
-      %z = amdg.buffer_load %Z[%Zoffset] cacheModifier = cg : tensor<32x32xf16, #blocked>
+      %x = amdg.buffer_load %X[%Xoffset] : <f16> -> tensor<16x64xf16, #blocked>
+      %y = amdg.buffer_load %Y[%Yoffset] cacheModifier = cg : <f16> -> tensor<64x32xf16, #blocked>
+      %z = amdg.buffer_load %Z[%Zoffset] cacheModifier = cg : <f16> -> tensor<32x32xf16, #blocked>
 
       ttg.local_store %x, %x_dummy_buffer : tensor<16x64xf16, #blocked> -> !ttg.memdesc<16x64xf16, #shared, #smem, mutable, 16x64>
       ttg.local_store %y, %y_dummy_buffer : tensor<64x32xf16, #blocked> -> !ttg.memdesc<64x32xf16, #shared, #smem, mutable, 64x32>
@@ -459,7 +459,7 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 1 : i32, "ttg.thr
     %for = scf.for %idx = %iter_first to %iter_last step %iter_step iter_args(%Xoffset = %Xoffset_init) -> (tensor<16x64xi32, #blocked>) {
       ttg.local_store %Xoffset, %offset_buffer : tensor<16x64xi32, #blocked> -> !ttg.memdesc<16x64xi32, #shared, #smem, mutable, 16x64>
       %Xoffset_next = arith.addi %Xoffset, %offset_step : tensor<16x64xi32, #blocked>
-      %x = amdg.buffer_load %X[%Xoffset_next] : tensor<16x64xf16, #blocked>
+      %x = amdg.buffer_load %X[%Xoffset_next] : <f16> -> tensor<16x64xf16, #blocked>
       ttg.local_store %x, %x_dummy_buffer : tensor<16x64xf16, #blocked> -> !ttg.memdesc<16x64xf16, #shared, #smem, mutable, 16x64>
       ttg.local_store %Xoffset_next, %offset_buffer : tensor<16x64xi32, #blocked> -> !ttg.memdesc<16x64xi32, #shared, #smem, mutable, 16x64>
       scf.yield %Xoffset_next : tensor<16x64xi32, #blocked>
@@ -494,12 +494,12 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 1 : i32, "ttg.thr
 
       %for2 = scf.for %idx2 = %iter_first to %iter_last step %iter_step iter_args(%Xoffset2 = %Xoffset_next1) -> (tensor<16x64xi32, #blocked>) {
         %Xoffset_next2 = arith.addi %Xoffset2, %offset_step : tensor<16x64xi32, #blocked>
-        %x2 = amdg.buffer_load %X[%Xoffset_next2] : tensor<16x64xf16, #blocked>
+        %x2 = amdg.buffer_load %X[%Xoffset_next2] : <f16> -> tensor<16x64xf16, #blocked>
         ttg.local_store %x2, %x_dummy_buffer : tensor<16x64xf16, #blocked> -> !ttg.memdesc<16x64xf16, #shared, #smem, mutable, 16x64>
         scf.yield %Xoffset_next2 : tensor<16x64xi32, #blocked>
       }
 
-      %x1 = amdg.buffer_load %X[%Xoffset_next1] : tensor<16x64xf16, #blocked>
+      %x1 = amdg.buffer_load %X[%Xoffset_next1] : <f16> -> tensor<16x64xf16, #blocked>
       ttg.local_store %x1, %x_dummy_buffer : tensor<16x64xf16, #blocked> -> !ttg.memdesc<16x64xf16, #shared, #smem, mutable, 16x64>
       scf.yield %Xoffset_next1 : tensor<16x64xi32, #blocked>
     }
@@ -581,7 +581,7 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, "ttg.thr
     %iter_step = arith.constant 1 : i32
 
     %for:2 = scf.for %iter = %iter_first to %iter_last step %iter_step iter_args(%arg1 = %zero, %arg2 = %zero) -> (tensor<256xi32, #blocked>, tensor<256xi32, #blocked>) : i32 {
-      %data = amdg.buffer_load %arg0[%arg1] : tensor<256xi32, #blocked>
+      %data = amdg.buffer_load %arg0[%arg1] : <i32> -> tensor<256xi32, #blocked>
       scf.yield %arg2, %data : tensor<256xi32, #blocked>, tensor<256xi32, #blocked>
     }
     tt.return %for#1 : tensor<256xi32, #blocked>

--- a/test/TritonGPU/amd/amd-update-async-wait-count.mlir
+++ b/test/TritonGPU/amd/amd-update-async-wait-count.mlir
@@ -40,10 +40,10 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.targ
   // CHECK-LABEL: simple_buffer_load_to_local_waitcnt
   tt.func public @simple_buffer_load_to_local_waitcnt(%arg0: !tt.ptr<f16> {tt.divisibility = 16 : i32, tt.pointer_range = 32 : i32}, %arg1: tensor<128x16xi32, #blocked> {tt.contiguity = dense<16> : tensor<2xi32>, tt.divisibility = dense<16> : tensor<2xi32>}, %arg2: !tt.ptr<f16> {tt.divisibility = 16 : i32, tt.pointer_range = 32 : i32}, %arg3: tensor<16x256xi32, #blocked1> {tt.contiguity = dense<16> : tensor<2xi32>, tt.divisibility = dense<16> : tensor<2xi32>}, %arg4: !ttg.memdesc<128x16xf16, #shared, #smem, mutable>, %arg5: !ttg.memdesc<16x256xf16, #shared1, #smem, mutable>) {
     // Emits 1 direct to lds instruction
-    %0 = amdg.buffer_load_to_local %arg0[%arg1] into %arg4 : <f16>[tensor<128x16xi32, #blocked>]  -> <128x16xf16, #shared, #smem, mutable>
+    %0 = amdg.buffer_load_to_local %arg0[%arg1] into %arg4 : !tt.ptr<f16>[tensor<128x16xi32, #blocked>]  -> <128x16xf16, #shared, #smem, mutable>
     %1 = ttg.async_commit_group tokens %0
     // Emits 2 direct to lds instructions
-    %2 = amdg.buffer_load_to_local %arg2[%arg3] into %arg5 : <f16>[tensor<16x256xi32, #blocked1>]  -> <16x256xf16, #shared1, #smem, mutable>
+    %2 = amdg.buffer_load_to_local %arg2[%arg3] into %arg5 : !tt.ptr<f16>[tensor<16x256xi32, #blocked1>]  -> <16x256xf16, #shared1, #smem, mutable>
     %3 = ttg.async_commit_group tokens %2
     // Wait on token %1: 2 instructions outstanding (second buffer_load emits 2)
     // CHECK: amdg.async_wait {{.*}} {num_inst = 2
@@ -654,7 +654,7 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.targ
       %ptr: !tt.ptr<i32> {tt.divisibility = 16 : i32, tt.pointer_range = 32 : i32},
       %offsets: tensor<64xi32, #linear_warp_free>,
       %dest: !ttg.memdesc<64xi32, #shared_simple, #smem, mutable>) {
-    %0 = amdg.buffer_load_to_local %ptr[%offsets] into %dest : <i32>[tensor<64xi32, #linear_warp_free>]  -> <64xi32, #shared_simple, #smem, mutable>
+    %0 = amdg.buffer_load_to_local %ptr[%offsets] into %dest : !tt.ptr<i32>[tensor<64xi32, #linear_warp_free>]  -> <64xi32, #shared_simple, #smem, mutable>
     %1 = ttg.async_commit_group
 
     // Warp free variable means 0 instructions emitted for this warp config
@@ -677,7 +677,7 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.targ
       %ptr: !tt.ptr<i32> {tt.divisibility = 16 : i32, tt.pointer_range = 32 : i32},
       %offsets: tensor<256xi32, #linear_reg_zero>,
       %dest: !ttg.memdesc<256xi32, #shared_simple2, #smem, mutable>) {
-    %0 = amdg.buffer_load_to_local %ptr[%offsets] into %dest : <i32>[tensor<256xi32, #linear_reg_zero>]  -> <256xi32, #shared_simple2, #smem, mutable>
+    %0 = amdg.buffer_load_to_local %ptr[%offsets] into %dest : !tt.ptr<i32>[tensor<256xi32, #linear_reg_zero>]  -> <256xi32, #shared_simple2, #smem, mutable>
     %1 = ttg.async_commit_group
     // Register zero bases should not inflate count: 1 instruction
     // CHECK: amdg.async_wait {num_inst = 1

--- a/test/TritonGPU/amd/in-thread-transpose.mlir
+++ b/test/TritonGPU/amd/in-thread-transpose.mlir
@@ -540,7 +540,7 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 8 : i32, ttg.targ
     %2 = ttg.async_copy_global_to_local %0, %1 : tensor<256x32x!tt.ptr<f16>, #blocked1> -> <256x32xf16, #shared, #smem, mutable>
     %3 = ttg.local_load %1 : !ttg.memdesc<256x32xf16, #shared, #smem, mutable> -> tensor<256x32xf16, #ttg.dot_op<{opIdx = 0, parent = #mma, kWidth = 4}>>
     %4 = ttg.local_alloc : () -> !ttg.memdesc<32x128xf16, #shared, #smem, mutable>
-    %5 = amdg.buffer_load_to_local %arg1[%cst_0] into %4 : <f16>[tensor<32x128xi32, #blocked>]  -> <32x128xf16, #shared, #smem, mutable>
+    %5 = amdg.buffer_load_to_local %arg1[%cst_0] into %4 : !tt.ptr<f16>[tensor<32x128xi32, #blocked>]  -> <32x128xf16, #shared, #smem, mutable>
     %6 = ttg.local_load %4 : !ttg.memdesc<32x128xf16, #shared, #smem, mutable> -> tensor<32x128xf16, #ttg.dot_op<{opIdx = 1, parent = #mma, kWidth = 4}>>
     %7 = tt.dot %3, %6, %cst : tensor<256x32xf16, #ttg.dot_op<{opIdx = 0, parent = #mma, kWidth = 4}>> * tensor<32x128xf16, #ttg.dot_op<{opIdx = 1, parent = #mma, kWidth = 4}>> -> tensor<256x128xf32, #mma>
     tt.return

--- a/test/TritonGPU/amd/invalid.mlir
+++ b/test/TritonGPU/amd/invalid.mlir
@@ -717,3 +717,38 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 1 : i32, ttg.targ
     tt.return
   }
 }
+
+// -----
+
+// A buffer write's scalar base must be global memory; a non-global (generic,
+// address space 0) base is rejected -- for stores, atomic RMWs, and atomic CAS.
+#blocked = #ttg.blocked<{sizePerThread = [1], threadsPerWarp = [64], warpsPerCTA = [4], order = [0]}>
+module attributes {"ttg.num-warps" = 4 : i32, "ttg.threads-per-warp" = 64 : i32} {
+  tt.func @buffer_store_nonglobal_base(%arg0: !tt.ptr<f32, 0>, %arg1: tensor<256xi32, #blocked>, %arg2: tensor<256xf32, #blocked>) {
+    // expected-error @+1 {{buffer writes require a global address space base}}
+    amdg.buffer_store %arg2, %arg0[%arg1] : <f32, 0> -> tensor<256xf32, #blocked>
+    tt.return
+  }
+}
+
+// -----
+
+#blocked = #ttg.blocked<{sizePerThread = [1], threadsPerWarp = [64], warpsPerCTA = [4], order = [0]}>
+module attributes {"ttg.num-warps" = 4 : i32, "ttg.threads-per-warp" = 64 : i32} {
+  tt.func @buffer_atomic_rmw_nonglobal_base(%arg0: !tt.ptr<f32, 0>, %arg1: tensor<256xi32, #blocked>, %arg2: tensor<256xf32, #blocked>) {
+    // expected-error @+1 {{buffer writes require a global address space base}}
+    %0 = amdg.buffer_atomic_rmw fadd, acq_rel, gpu, %arg2, %arg0[%arg1] : <f32, 0> -> tensor<256xf32, #blocked>
+    tt.return
+  }
+}
+
+// -----
+
+#blocked = #ttg.blocked<{sizePerThread = [1], threadsPerWarp = [64], warpsPerCTA = [4], order = [0]}>
+module attributes {"ttg.num-warps" = 4 : i32, "ttg.threads-per-warp" = 64 : i32} {
+  tt.func @buffer_atomic_cas_nonglobal_base(%arg0: !tt.ptr<i32, 0>, %arg1: tensor<256xi32, #blocked>, %arg2: tensor<256xi32, #blocked>, %arg3: tensor<256xi32, #blocked>) {
+    // expected-error @+1 {{buffer writes require a global address space base}}
+    %0 = amdg.buffer_atomic_cas acq_rel, gpu, %arg2, %arg3, %arg0[%arg1] : <i32, 0> -> tensor<256xi32, #blocked>
+    tt.return
+  }
+}

--- a/test/TritonGPU/amd/invalid.mlir
+++ b/test/TritonGPU/amd/invalid.mlir
@@ -726,7 +726,7 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 1 : i32, ttg.targ
 module attributes {"ttg.num-warps" = 4 : i32, "ttg.threads-per-warp" = 64 : i32} {
   tt.func @buffer_store_nonglobal_base(%arg0: !tt.ptr<f32, 0>, %arg1: tensor<256xi32, #blocked>, %arg2: tensor<256xf32, #blocked>) {
     // expected-error @+1 {{buffer writes require a global address space base}}
-    amdg.buffer_store %arg2, %arg0[%arg1] : <f32, 0> -> tensor<256xf32, #blocked>
+    amdg.buffer_store %arg2, %arg0[%arg1] : !tt.ptr<f32, 0> -> tensor<256xf32, #blocked>
     tt.return
   }
 }
@@ -737,7 +737,7 @@ module attributes {"ttg.num-warps" = 4 : i32, "ttg.threads-per-warp" = 64 : i32}
 module attributes {"ttg.num-warps" = 4 : i32, "ttg.threads-per-warp" = 64 : i32} {
   tt.func @buffer_atomic_rmw_nonglobal_base(%arg0: !tt.ptr<f32, 0>, %arg1: tensor<256xi32, #blocked>, %arg2: tensor<256xf32, #blocked>) {
     // expected-error @+1 {{buffer writes require a global address space base}}
-    %0 = amdg.buffer_atomic_rmw fadd, acq_rel, gpu, %arg2, %arg0[%arg1] : <f32, 0> -> tensor<256xf32, #blocked>
+    %0 = amdg.buffer_atomic_rmw fadd, acq_rel, gpu, %arg2, %arg0[%arg1] : !tt.ptr<f32, 0> -> tensor<256xf32, #blocked>
     tt.return
   }
 }
@@ -748,7 +748,7 @@ module attributes {"ttg.num-warps" = 4 : i32, "ttg.threads-per-warp" = 64 : i32}
 module attributes {"ttg.num-warps" = 4 : i32, "ttg.threads-per-warp" = 64 : i32} {
   tt.func @buffer_atomic_cas_nonglobal_base(%arg0: !tt.ptr<i32, 0>, %arg1: tensor<256xi32, #blocked>, %arg2: tensor<256xi32, #blocked>, %arg3: tensor<256xi32, #blocked>) {
     // expected-error @+1 {{buffer writes require a global address space base}}
-    %0 = amdg.buffer_atomic_cas acq_rel, gpu, %arg2, %arg3, %arg0[%arg1] : <i32, 0> -> tensor<256xi32, #blocked>
+    %0 = amdg.buffer_atomic_cas acq_rel, gpu, %arg2, %arg3, %arg0[%arg1] : !tt.ptr<i32, 0> -> tensor<256xi32, #blocked>
     tt.return
   }
 }

--- a/third_party/amd/include/Dialect/TritonAMDGPU/IR/TritonAMDGPUOps.td
+++ b/third_party/amd/include/Dialect/TritonAMDGPU/IR/TritonAMDGPUOps.td
@@ -304,7 +304,7 @@ def BufferLoadOp : TT_AMDGPU_Op<"buffer_load", [
       $ptr `[` $offsets `]` (`,` $mask^)? (`,` $other^)?
       oilist(`cacheModifier` `=` $cache)
       (`stride` `=` $stride^)?
-      attr-dict `:` type($ptr) `->` type($result)
+      attr-dict `:` qualified(type($ptr)) `->` type($result)
     }];
 }
 
@@ -347,7 +347,7 @@ def BufferLoadToLocalOp : TT_AMDGPU_Op<"buffer_load_to_local", [
     let assemblyFormat = [{
       $ptr `[` $offsets `]` (`mask` `=` $mask^)? (`other` `=` $other^)? (`stride` `=` $stride^)?
       oilist(`cacheModifier` `=` $cache) `into` $dest
-      attr-dict `:` type($ptr) `[` type($offsets) `]` type($other) `->` type($dest)
+      attr-dict `:` qualified(type($ptr)) `[` type($offsets) `]` type($other) `->` type($dest)
     }];
 }
 
@@ -399,7 +399,7 @@ def BufferAtomicRMWOp : TT_AMDGPU_Op<"buffer_atomic_rmw", [
     let assemblyFormat = [{
         $atomic_rmw_op `,` $sem `,` $scope `,` $value `,` $ptr `[` $offsets `]` (`,` $mask^)?
         (`stride` `=` $stride^)?
-        attr-dict `:` type($ptr) `->` type($result)
+        attr-dict `:` qualified(type($ptr)) `->` type($result)
     }];
 }
 
@@ -442,7 +442,7 @@ def BufferAtomicCASOp : TT_AMDGPU_Op<"buffer_atomic_cas", [
     let assemblyFormat = [{
         $sem `,` $scope `,` $cmp `,` $val `,` $ptr `[` $offsets `]`
         (`stride` `=` $stride^)?
-        attr-dict `:` type($ptr) `->` type($result)
+        attr-dict `:` qualified(type($ptr)) `->` type($result)
     }];
 }
 
@@ -493,7 +493,7 @@ def BufferStoreOp : TT_AMDGPU_Op<"buffer_store", [
       $value `,` $ptr `[` $offsets `]` (`,` $mask^)?
       oilist(`cacheModifier` `=` $cache)
       (`stride` `=` $stride^)?
-      attr-dict `:` type($ptr) `->` type($value)
+      attr-dict `:` qualified(type($ptr)) `->` type($value)
     }];
 }
 

--- a/third_party/amd/include/Dialect/TritonAMDGPU/IR/TritonAMDGPUOps.td
+++ b/third_party/amd/include/Dialect/TritonAMDGPU/IR/TritonAMDGPUOps.td
@@ -265,7 +265,7 @@ def BufferLoadOp : TT_AMDGPU_Op<"buffer_load", [
   AttrSizedOperandSegments,
   BufferOpInterface,
   DeclareOpInterfaceMethods<PredicatedOpInterface>,
-  TypesMatchWith<"result element type matches the pointed type of ptr", "result", "ptr", "getPointerTypeToElement($_self)">,
+  TypesMatchWith<"result element type matches the pointed type of ptr", "result", "ptr", "$_self", "::mlir::triton::elementTypeMatchesPointee">,
   TypesMatchWith<"result and offsets have the same shape", "result", "offsets", "getI32SameShape($_self)">,
   TypesMatchWith<"result and mask have the same shape", "result", "mask", "getI1SameShape($_self)",
                  "(cast<BufferLoadOp>($_op).getMask() == nullptr) || std::equal_to<>()">,
@@ -304,7 +304,7 @@ def BufferLoadOp : TT_AMDGPU_Op<"buffer_load", [
       $ptr `[` $offsets `]` (`,` $mask^)? (`,` $other^)?
       oilist(`cacheModifier` `=` $cache)
       (`stride` `=` $stride^)?
-      attr-dict `:` type($result)
+      attr-dict `:` type($ptr) `->` type($result)
     }];
 }
 
@@ -316,7 +316,7 @@ def BufferLoadToLocalOp : TT_AMDGPU_Op<"buffer_load_to_local", [
   AttrSizedOperandSegments,
   BufferOpInterface,
   DeclareOpInterfaceMethods<PredicatedOpInterface>,
-  TypesMatchWith<"dest element type matches pointee type of ptr", "dest", "ptr", "getPointerTypeToElement($_self)">,
+  TypesMatchWith<"dest element type matches pointee type of ptr", "dest", "ptr", "$_self", "::mlir::triton::elementTypeMatchesPointee">,
   TypesMatchWith<"infer mask shape from offsets",
                  "offsets", "mask", "getI1SameShape($_self)",
                  "(cast<BufferLoadToLocalOp>($_op).getMask() == nullptr) || std::equal_to<>()">,
@@ -361,11 +361,11 @@ def BufferAtomicRMWOp : TT_AMDGPU_Op<"buffer_atomic_rmw", [
   BufferOpInterface,
   DeclareOpInterfaceMethods<PredicatedOpInterface>,
   TypesMatchWith<"result element type matches the value type", "result", "value", "$_self">,
-  TypesMatchWith<"result element type matches the pointed type of ptr", "result", "ptr", "getPointerTypeToElement($_self)">,
+  TypesMatchWith<"result element type matches the pointed type of ptr", "result", "ptr", "$_self", "::mlir::triton::elementTypeMatchesPointee">,
   TypesMatchWith<"result and offsets have the same shape", "result", "offsets", "getI32SameShape($_self)">,
   TypesMatchWith<"result and mask have the same shape", "result", "mask", "getI1SameShape($_self)",
                  "(cast<BufferAtomicRMWOp>($_op).getMask() == nullptr) || std::equal_to<>()">,
-  TypesMatchWith<"value element type matches the pointed type of ptr", "value", "ptr", "getPointerTypeToElement($_self)">,
+  TypesMatchWith<"value element type matches the pointed type of ptr", "value", "ptr", "$_self", "::mlir::triton::elementTypeMatchesPointee">,
   TypesMatchWith<"value and offsets have the same shape", "value", "offsets", "getI32SameShape($_self)">,
   TypesMatchWith<"value and mask have the same shape", "value", "mask", "getI1SameShape($_self)",
                  "(cast<BufferAtomicRMWOp>($_op).getMask() == nullptr) || std::equal_to<>()">,
@@ -394,10 +394,12 @@ def BufferAtomicRMWOp : TT_AMDGPU_Op<"buffer_atomic_rmw", [
     );
     let results = (outs TT_Tensor:$result);
 
+    let hasVerifier = 1;
+
     let assemblyFormat = [{
         $atomic_rmw_op `,` $sem `,` $scope `,` $value `,` $ptr `[` $offsets `]` (`,` $mask^)?
         (`stride` `=` $stride^)?
-        attr-dict `:` type($result)
+        attr-dict `:` type($ptr) `->` type($result)
     }];
 }
 
@@ -409,7 +411,7 @@ def BufferAtomicCASOp : TT_AMDGPU_Op<"buffer_atomic_cas", [
   BufferOpInterface,
   TypesMatchWith<"result element type matches the val type", "result", "val", "$_self">,
   TypesMatchWith<"result element type matches the cmp type", "result", "cmp", "$_self">,
-  TypesMatchWith<"result element type matches the pointed type of ptr", "result", "ptr", "getPointerTypeToElement($_self)">,
+  TypesMatchWith<"result element type matches the pointed type of ptr", "result", "ptr", "$_self", "::mlir::triton::elementTypeMatchesPointee">,
   TypesMatchWith<"result and offsets have the same shape", "result", "offsets", "getI32SameShape($_self)">,
   TypesMatchWith<"val and offsets have the same shape", "val", "offsets", "getI32SameShape($_self)">,
   TypesMatchWith<"val and cmp have the same shape", "val", "cmp", "$_self">,
@@ -435,10 +437,12 @@ def BufferAtomicCASOp : TT_AMDGPU_Op<"buffer_atomic_cas", [
     );
     let results = (outs TT_Tensor:$result);
 
+    let hasVerifier = 1;
+
     let assemblyFormat = [{
         $sem `,` $scope `,` $cmp `,` $val `,` $ptr `[` $offsets `]`
         (`stride` `=` $stride^)?
-        attr-dict `:` type($result)
+        attr-dict `:` type($ptr) `->` type($result)
     }];
 }
 
@@ -451,7 +455,7 @@ def BufferStoreOp : TT_AMDGPU_Op<"buffer_store", [
   SameLoadStoreOperandsEncoding,
   BufferOpInterface,
   DeclareOpInterfaceMethods<PredicatedOpInterface>,
-  TypesMatchWith<"value element type matches the pointed type of ptr", "value", "ptr", "getPointerTypeToElement($_self)">,
+  TypesMatchWith<"value element type matches the pointed type of ptr", "value", "ptr", "$_self", "::mlir::triton::elementTypeMatchesPointee">,
   TypesMatchWith<"value and offsets have the same shape", "value", "offsets", "getI32SameShape($_self)">,
   TypesMatchWith<"value and mask have the same shape", "value", "mask", "getI1SameShape($_self)",
                  "(cast<BufferStoreOp>($_op).getMask() == nullptr) || std::equal_to<>()">,
@@ -483,11 +487,13 @@ def BufferStoreOp : TT_AMDGPU_Op<"buffer_store", [
       DefaultValuedAttr<I32Attr, "1">:$contiguity
     );
 
+    let hasVerifier = 1;
+
     let assemblyFormat = [{
       $value `,` $ptr `[` $offsets `]` (`,` $mask^)?
       oilist(`cacheModifier` `=` $cache)
       (`stride` `=` $stride^)?
-      attr-dict `:` type($value)
+      attr-dict `:` type($ptr) `->` type($value)
     }];
 }
 

--- a/third_party/amd/lib/Dialect/TritonAMDGPU/IR/Dialect.cpp
+++ b/third_party/amd/lib/Dialect/TritonAMDGPU/IR/Dialect.cpp
@@ -749,8 +749,7 @@ LogicalResult BufferLoadToLocalOp::verify() {
   return emitError() << "BufferLoadToLocal unsupported on target architecture";
 }
 
-// A buffer write's scalar base must be global memory (address space 1). This
-// invariant was previously enforced implicitly by base-type inference.
+// A buffer write's scalar base must be global memory (address space 1).
 static LogicalResult verifyBufferWriteBase(Operation *op, Value ptr) {
   constexpr int kGlobalAddressSpace = 1;
   if (triton::getAddressSpace(ptr.getType()) != kGlobalAddressSpace)

--- a/third_party/amd/lib/Dialect/TritonAMDGPU/IR/Dialect.cpp
+++ b/third_party/amd/lib/Dialect/TritonAMDGPU/IR/Dialect.cpp
@@ -749,6 +749,27 @@ LogicalResult BufferLoadToLocalOp::verify() {
   return emitError() << "BufferLoadToLocal unsupported on target architecture";
 }
 
+// A buffer write's scalar base must be global memory (address space 1). This
+// invariant was previously enforced implicitly by base-type inference.
+static LogicalResult verifyBufferWriteBase(Operation *op, Value ptr) {
+  constexpr int kGlobalAddressSpace = 1;
+  if (triton::getAddressSpace(ptr.getType()) != kGlobalAddressSpace)
+    return op->emitOpError("buffer writes require a global address space base");
+  return success();
+}
+
+LogicalResult BufferStoreOp::verify() {
+  return verifyBufferWriteBase(getOperation(), getPtr());
+}
+
+LogicalResult BufferAtomicRMWOp::verify() {
+  return verifyBufferWriteBase(getOperation(), getPtr());
+}
+
+LogicalResult BufferAtomicCASOp::verify() {
+  return verifyBufferWriteBase(getOperation(), getPtr());
+}
+
 LogicalResult LocalLoadPackedTransposedOp::verify() {
   auto srcTy = getSrc().getType();
   auto dstTy = getType();


### PR DESCRIPTION
### Context

Motivated by https://github.com/triton-lang/triton/pull/11294#discussion_r3816009720

The AMD buffer ops (`buffer_load, buffer_store`, `buffer_atomic_rmw/cas`) spelled only the result/value type and inferred the scalar base pointer type via `getPointerTypeToElement()`, which fabricated a global address space. Two consequences: 
 - the base's address space was invisible in the printed op
 - a non-global base could not round-trip (the parser re-inferred global and clashed with the declared base type).

### Implementation

This PR spells `type($ptr)` directly in the buffer-op assembly format, so the base pointer type is carried on the op itself. With inference gone:
  - getPointerTypeToElement is deleted (it was used only by these verifiers) and replaced by the address-space-agnostic elementTypeMatchesPointee.
  - the "buffer writes require a global-memory base" invariant — previously enforced only as a side effect of the fabricated global type is re-expressed explicitly via verifyBufferWriteBase.

  ```mlir
  // before: base address space invisible; global and non-global look identical
  %0 = amdg.buffer_load %arg0[%arg1] : tensor<256xf32, #blocked>
  // after: base type (and its address space) spelled on the op
  %0 = amdg.buffer_load %arg0[%arg1] : <f32> -> tensor<256xf32, #blocked>
  ```

### Review

Please review by commit:

1. [AMD] Carry buffer-op base address space in the op format, this is the meat.
2. [AMD] Migrate buffer-op lit tests to the spelled base type, mostly mechanical changes.

CC: @ThomasRaoux @antiagainst 