### PR TITLE
[Release][Cherry-Pick] [AMD] Support blocked/shared order mismatch for direct-to-LDS (#10928)

### DIFF
--- a/test/Conversion/amd/buffer_load_to_local_to_llvm.mlir
+++ b/test/Conversion/amd/buffer_load_to_local_to_llvm.mlir
@@ -385,3 +385,32 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, "ttg.thr
     tt.return
   }
 }
+
+// -----
+
+// The blocked layout will return contiguity of 2 because the repeat pattern to cover the full tensor.
+// Check that we lower it to 2 separate instructions because the order of blocked layout and shared layout disagree.
+#blocked = #ttg.blocked<{sizePerThread = [1, 1], threadsPerWarp = [64, 1], warpsPerCTA = [1, 1], order = [1, 0]}>
+#shared = #ttg.swizzled_shared<{vec = 1, perPhase = 1, maxPhase = 1, order = [0, 1]}>
+#smem = #ttg.shared_memory
+module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 1 : i32, ttg.target = "hip:gfx942", "ttg.threads-per-warp" = 64 : i32} {
+  // COMMON-LABEL: buffer_load_to_local_order_mismatch_clamped_vec
+  tt.func public @buffer_load_to_local_order_mismatch_clamped_vec(%arg0: !tt.ptr<f32> {tt.divisibility = 16 : i32, tt.pointer_range = 32 : i32},
+                                %arg1: !ttg.memdesc<64x2xf32, #shared, #smem, mutable>) {
+    %cst = arith.constant dense<2> : tensor<64x1xi32, #blocked>
+    %0 = tt.make_range {end = 64 : i32, start = 0 : i32} : tensor<64xi32, #ttg.slice<{dim = 1, parent = #blocked}>>
+    %1 = tt.make_range {end = 2 : i32, start = 0 : i32} : tensor<2xi32, #ttg.slice<{dim = 0, parent = #blocked}>>
+    %2 = tt.expand_dims %0 {axis = 1 : i32} : tensor<64xi32, #ttg.slice<{dim = 1, parent = #blocked}>> -> tensor<64x1xi32, #blocked>
+    %3 = arith.muli %2, %cst : tensor<64x1xi32, #blocked>
+    %4 = tt.broadcast %3 : tensor<64x1xi32, #blocked> -> tensor<64x2xi32, #blocked>
+    %5 = tt.expand_dims %1 {axis = 0 : i32} : tensor<2xi32, #ttg.slice<{dim = 0, parent = #blocked}>> -> tensor<1x2xi32, #blocked>
+    %6 = tt.broadcast %5 : tensor<1x2xi32, #blocked> -> tensor<64x2xi32, #blocked>
+    %7 = arith.addi %4, %6 : tensor<64x2xi32, #blocked>
+
+    // COMMON: rocdl.raw.ptr.buffer.load.async.lds
+    // COMMON: rocdl.raw.ptr.buffer.load.async.lds
+    // COMMON-NOT: rocdl.raw.ptr.buffer.load.async.lds
+    %8 = amdg.buffer_load_to_local %arg0[%7] into %arg1 : <f32>[tensor<64x2xi32, #blocked>] -> <64x2xf32, #shared, #smem, mutable>
+    tt.return
+  }
+}

--- a/test/TritonGPU/amd/amd-coalesce-async-copy.mlir
+++ b/test/TritonGPU/amd/amd-coalesce-async-copy.mlir
@@ -149,8 +149,7 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.shar
 #shared = #ttg.swizzled_shared<{vec = 1, perPhase = 1, maxPhase = 1, order = [0, 1]}>
 #smem = #ttg.shared_memory
 module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.shared = 8192 : i32, ttg.target = "hip:gfx942", "ttg.threads-per-warp" = 64 : i32} {
-  // The order of #blocked and #shared are different so we need to clip to 1 element
-  // CHECK: #[[$NEW_BLOCKED:.*]] = #ttg.blocked<{sizePerThread = [1, 1], threadsPerWarp = [1, 64], warpsPerCTA = [4, 1], order = [1, 0]}>
+  // CHECK: #[[$NEW_BLOCKED:.*]] = #ttg.blocked<{sizePerThread = [1, 1], threadsPerWarp = [32, 2], warpsPerCTA = [1, 4], order = [1, 0]}>
   // CHECK-LABEL: async_copy_different_order
   tt.func public @async_copy_different_order(%arg0: !tt.ptr<f32> {tt.divisibility = 16 : i32, tt.pointer_range = 32 : i32},
                                 %arg1: i32 {tt.divisibility = 16 : i32},
@@ -272,6 +271,23 @@ tt.func @async_copy_with_padding_different_vec(%input: tensor<256x!tt.ptr<f32>, 
     %view: !ttg.memdesc<256xf32, #shared, #smem, mutable>) {
   // CHECK: %{{.*}} = ttg.async_copy_global_to_local %{{.*}}: tensor<256x!tt.ptr<f32>, #[[$NEW_BLOCKED]]>
   %token = ttg.async_copy_global_to_local %input, %view: tensor<256x!tt.ptr<f32>, #blocked> -> <256xf32, #shared, #smem, mutable>
+  tt.return
+}
+}
+
+// -----
+
+#blocked = #ttg.blocked<{sizePerThread = [1, 2], threadsPerWarp = [64, 1], warpsPerCTA = [1, 1], order = [1, 0]}>
+#shared = #ttg.swizzled_shared<{vec = 1, perPhase = 1, maxPhase = 1, order = [0, 1]}>
+#smem = #ttg.shared_memory
+module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 1 : i32, "ttg.target" = "hip:gfx950", "ttg.threads-per-warp" = 64 : i32} {
+// CHECK: #[[$NEW_BLOCKED:.*]] = #ttg.blocked<{sizePerThread = [1, 1], threadsPerWarp = [64, 1], warpsPerCTA = [1, 1], order = [1, 0]}>
+// CHECK-LABEL: async_copy_with_mismatching_order_and_unsupported_vec_width
+tt.func @async_copy_with_mismatching_order_and_unsupported_vec_width(%input: tensor<64x2x!tt.ptr<f32>, #blocked> {tt.contiguity = dense<[1, 2]> : tensor<2xi32>, tt.divisibility = dense<[4, 8]> : tensor<2xi32>, tt.constancy = dense<[1, 1]> : tensor<2xi32>},
+    %view: !ttg.memdesc<64x2xf32, #shared, #smem, mutable>) {
+  // CHECK: %[[CVT:.*]] = ttg.convert_layout %{{.*}} : {{.*}} -> tensor<64x2x!tt.ptr<f32>, #[[$NEW_BLOCKED]]>
+  // CHECK: %{{.*}} = ttg.async_copy_global_to_local %[[CVT]], %{{.*}} : tensor<64x2x!tt.ptr<f32>, #[[$NEW_BLOCKED]]>
+  %token = ttg.async_copy_global_to_local %input, %view {contiguity = 2 : i32} : tensor<64x2x!tt.ptr<f32>, #blocked> -> <64x2xf32, #shared, #smem, mutable>
   tt.return
 }
 }

--- a/third_party/amd/lib/TritonAMDGPUToLLVM/Utility.cpp
+++ b/third_party/amd/lib/TritonAMDGPUToLLVM/Utility.cpp
@@ -785,8 +785,7 @@ Type scaleDotElemTypeToMLIRType(MLIRContext *ctx, triton::ScaleDotElemType t) {
 
 bool canCoalesceWriteIntoSharedMemory(MLIRContext *ctx,
                                       const LinearLayout &srcToSharedLayout,
-                                      unsigned threadsPerWarp,
-                                      unsigned vecSize) {
+                                      unsigned threadsPerWarp) {
   auto kReg = StringAttr::get(ctx, "register");
   StringAttr kLane = StringAttr::get(ctx, "lane");
   auto kOffset = StringAttr::get(ctx, "offset");
@@ -842,10 +841,6 @@ bool canLoadDirectToLDS(const triton::AMD::TargetInfo &targetInfo,
   if (targetInfo.supportsDirectToLdsScatter())
     return true;
 
-  // Must support the full vector width; splitting would cause strided writes.
-  if (!targetInfo.supportsDirectToLdsLoadBitWidth(vectorSize * elemBitWidth))
-    return false;
-
   // Compute the blocked -> shared linear layout to check preconditions
   LinearLayout srcLayout = triton::gpu::toLinearLayout(srcTy);
   LinearLayout sharedLayout;
@@ -867,15 +862,28 @@ bool canLoadDirectToLDS(const triton::AMD::TargetInfo &targetInfo,
   LinearLayout srcToSharedLayout = srcLayout.invertAndCompose(sharedLayout);
 
   auto contig = srcToSharedLayout.getNumConsecutiveInOut();
-  if (vectorSize != contig) {
-    LDBG("Load vectorization ("
-         << vectorSize << ") and contiguity (" << contig
-         << ") do not match resulting in strided writes");
+  // The reg->shared layout can only write `contig` consecutive elements
+  // coalesced into LDS. A load narrower than `contig` would leave gaps between
+  // lanes and produce strided writes, so we cannot lower it here.
+  if (vectorSize < contig) {
+    LDBG("Load vectorization (" << vectorSize << ") smaller than contiguity ("
+                                << contig << ") resulting in strided writes");
+    return false;
+  }
+  // If the requested load is wider than what the layout can write coalesced,
+  // reduce it so that each load instruction writes exactly one coalesced chunk.
+  // The lowering then emits multiple (narrower) direct-to-LDS loads.
+  vectorSize = contig;
+
+  // The reduced width must still be a supported direct-to-LDS load width.
+  if (!targetInfo.supportsDirectToLdsLoadBitWidth(vectorSize * elemBitWidth)) {
+    LDBG("coalesced load width (" << vectorSize
+                                  << ") is not a supported direct-to-LDS load");
     return false;
   }
 
   if (!canCoalesceWriteIntoSharedMemory(srcTy.getContext(), srcToSharedLayout,
-                                        targetInfo.getWarpSize(), vectorSize)) {
+                                        targetInfo.getWarpSize())) {
     LDBG("Does not write coalesced into LDS");
     return false;
   }

--- a/third_party/amd/lib/TritonAMDGPUToLLVM/Utility.h
+++ b/third_party/amd/lib/TritonAMDGPUToLLVM/Utility.h
@@ -104,11 +104,10 @@ unsigned getVectorSize(Value ptr, Value offset,
 Type scaleDotElemTypeToMLIRType(MLIRContext *ctx, triton::ScaleDotElemType t);
 
 // Returns true if we can perform coalesced write from the source encoding to
-// the destination encoding for a given vec size.
+// the destination encoding.
 bool canCoalesceWriteIntoSharedMemory(MLIRContext *ctx,
                                       const LinearLayout &srcToSharedLayout,
-                                      unsigned threadsPerWarp,
-                                      unsigned vecSize);
+                                      unsigned threadsPerWarp);
 
 // Returns true if we can load directly from global |srcTy| to shared memory
 // |dstEnc| for the given target.

--- a/third_party/amd/lib/TritonAMDGPUTransforms/CoalesceAsyncCopy.cpp
+++ b/third_party/amd/lib/TritonAMDGPUTransforms/CoalesceAsyncCopy.cpp
@@ -81,8 +81,15 @@ struct CoalesceAsyncCopyWrites
       sharedLayout = triton::gpu::toLinearLayout(dstTy);
     }
     auto regToSharedLayout = regLayout.invertAndCompose(sharedLayout);
-    loadContig = std::min<unsigned>(loadContig,
-                                    regToSharedLayout.getNumConsecutiveInOut());
+    unsigned layoutContig = regToSharedLayout.getNumConsecutiveInOut();
+
+    // The src encoding supports more contiguous elements per thread than the
+    // reg->shared layout can write coalesced (e.g. the blocked and shared
+    // encodings have a different order). In this case the current src encoding
+    // results in strided writes into LDS which the lowering cannot handle, so
+    // we always have to rewrite the src layout.
+    bool layoutRestrictsContig = layoutContig < loadContig;
+    loadContig = std::min<unsigned>(loadContig, layoutContig);
 
     // Select the largest supported load width equal or smaller than loadContig
     auto elemBitWidth = dstTy.getElementTypeBitWidth();
@@ -102,8 +109,11 @@ struct CoalesceAsyncCopyWrites
 
     ttg::DistributedEncodingTrait newDistEnc;
 
-    if (LLVM::AMD::canLoadDirectToLDS(targetInfo, srcTy, dstTy.getEncoding(),
-                                      dstTy.getAllocShape(), loadContig)) {
+    // Do not move canLoadDirectToLDS into the if because it has ref parameters
+    bool alreadyCoalesced =
+        LLVM::AMD::canLoadDirectToLDS(targetInfo, srcTy, dstTy.getEncoding(),
+                                      dstTy.getAllocShape(), loadContig);
+    if (alreadyCoalesced && !layoutRestrictsContig) {
       return rewriter.notifyMatchFailure(copyOp, "already writes coalesced");
     }
     // Check if we support load contig because canLoadDirectToLds can change it
@@ -112,17 +122,30 @@ struct CoalesceAsyncCopyWrites
                                          "unable to find supported vector size "
                                          "based on src and dst encodings");
 
-    if (isa<ttg::SwizzledSharedEncodingAttr>(dstTy.getEncoding())) {
+    if (auto swizzledEnc =
+            dyn_cast<ttg::SwizzledSharedEncodingAttr>(dstTy.getEncoding())) {
       // For swizzled layouts we apply the swizzling during lowering so we only
-      // adjust the sizePerThread of the blocked encoding to avoid strided
-      // writes into LDS
+      // adjust the blocked encoding to avoid strided writes into LDS.
       auto contigPerThread = ttg::getContigPerThread(srcTy);
       auto srcElemContig = contigPerThread[blockedEnc.getOrder()[0]];
       assert(srcElemContig >= loadContig);
       contigPerThread[blockedEnc.getOrder()[0]] = loadContig;
-      newDistEnc = BlockedEncodingAttr::get(
+
+      // The default builder distributes the lanes (and warps) of a blocked
+      // encoding along its own order. When the blocked and shared order
+      // disagree this spreads consecutive lanes along a dimension that is
+      // strided in LDS, resulting in uncoalesced writes. Instead we distribute
+      // the lanes/warps following the shared order so consecutive lanes map to
+      // consecutive LDS offsets, and keep the original blocked order for the
+      // final blocked encoding.
+      auto distEncSharedOrder = BlockedEncodingAttr::get(
           copyOp.getContext(), srcTy.getShape(), contigPerThread,
-          blockedEnc.getOrder(), numWarps, threadsPerWarp,
+          swizzledEnc.getOrder(), numWarps, threadsPerWarp,
+          blockedEnc.getCGALayout());
+      newDistEnc = BlockedEncodingAttr::get(
+          copyOp.getContext(), distEncSharedOrder.getSizePerThread(),
+          distEncSharedOrder.getThreadsPerWarp(),
+          distEncSharedOrder.getWarpsPerCTA(), blockedEnc.getOrder(),
           blockedEnc.getCGALayout());
     } else if (paddedEnc) {
       // For padded layouts the linear_component maps from LDS offsets to n-D


### PR DESCRIPTION
Cherry-pick to fix a compiler crash:
- https://github.com/triton-lang/triton/pull/10928