### PR TITLE
Represent tt.ptr address space as a named enum

### DIFF
--- a/include/triton/Dialect/Triton/IR/CMakeLists.txt
+++ b/include/triton/Dialect/Triton/IR/CMakeLists.txt
@@ -16,6 +16,10 @@ set(LLVM_TARGET_DEFINITIONS TritonTypes.td)
 mlir_tablegen(Types.h.inc -gen-typedef-decls)
 mlir_tablegen(Types.cpp.inc -gen-typedef-defs)
 
+set(LLVM_TARGET_DEFINITIONS TritonTypeEnums.td)
+mlir_tablegen(TypesEnums.h.inc -gen-enum-decls)
+mlir_tablegen(TypesEnums.cpp.inc -gen-enum-defs)
+
 set(LLVM_TARGET_DEFINITIONS TritonInterfaces.td)
 mlir_tablegen(AttrInterfaces.h.inc -gen-attr-interface-decls)
 mlir_tablegen(AttrInterfaces.cpp.inc -gen-attr-interface-defs)

--- a/include/triton/Dialect/Triton/IR/Dialect.h
+++ b/include/triton/Dialect/Triton/IR/Dialect.h
@@ -14,6 +14,7 @@
 #include "mlir/Interfaces/SideEffectInterfaces.h"
 #include "triton/Dialect/Triton/IR/Dialect.h.inc"
 #include "triton/Dialect/Triton/IR/OpInterfaces.h"
+#include "triton/Dialect/Triton/IR/OpsEnums.h.inc"
 #include "triton/Dialect/Triton/IR/Traits.h"
 #include "triton/Dialect/Triton/IR/Types.h"
 

--- a/include/triton/Dialect/Triton/IR/Dialect.h
+++ b/include/triton/Dialect/Triton/IR/Dialect.h
@@ -14,7 +14,6 @@
 #include "mlir/Interfaces/SideEffectInterfaces.h"
 #include "triton/Dialect/Triton/IR/Dialect.h.inc"
 #include "triton/Dialect/Triton/IR/OpInterfaces.h"
-#include "triton/Dialect/Triton/IR/OpsEnums.h.inc"
 #include "triton/Dialect/Triton/IR/Traits.h"
 #include "triton/Dialect/Triton/IR/Types.h"
 

--- a/include/triton/Dialect/Triton/IR/TritonAttrDefs.td
+++ b/include/triton/Dialect/Triton/IR/TritonAttrDefs.td
@@ -49,18 +49,6 @@ def TT_PaddingOptionAttr : I32EnumAttr<
     let cppNamespace = "::mlir::triton";
 }
 
-// Case values mirror the LLVM address spaces:
-//   Global (1): NVPTXAS ADDRESS_SPACE_GLOBAL  / AMDGPUAS GLOBAL_ADDRESS
-//   Flat   (0): NVPTXAS ADDRESS_SPACE_GENERIC / AMDGPUAS FLAT_ADDRESS
-def TT_PtrAddrSpaceAttr : I32EnumAttr<
-    "PtrAddrSpace", "",
-    [
-        I32EnumAttrCase<"Global", 1, "global">,
-        I32EnumAttrCase<"Flat", 0, "flat">,
-    ]> {
-    let cppNamespace = "::mlir::triton";
-}
-
 // atomic
 def TT_AtomicRMWAttr : I32EnumAttr<
     "RMWOp", "",

--- a/include/triton/Dialect/Triton/IR/TritonAttrDefs.td
+++ b/include/triton/Dialect/Triton/IR/TritonAttrDefs.td
@@ -49,6 +49,18 @@ def TT_PaddingOptionAttr : I32EnumAttr<
     let cppNamespace = "::mlir::triton";
 }
 
+// Case values mirror the LLVM address spaces:
+//   Global (1): NVPTXAS ADDRESS_SPACE_GLOBAL  / AMDGPUAS GLOBAL_ADDRESS
+//   Flat   (0): NVPTXAS ADDRESS_SPACE_GENERIC / AMDGPUAS FLAT_ADDRESS
+def TT_PtrAddrSpaceAttr : I32EnumAttr<
+    "PtrAddrSpace", "",
+    [
+        I32EnumAttrCase<"Global", 1, "global">,
+        I32EnumAttrCase<"Flat", 0, "flat">,
+    ]> {
+    let cppNamespace = "::mlir::triton";
+}
+
 // atomic
 def TT_AtomicRMWAttr : I32EnumAttr<
     "RMWOp", "",

--- a/include/triton/Dialect/Triton/IR/TritonTypeEnums.td
+++ b/include/triton/Dialect/Triton/IR/TritonTypeEnums.td
@@ -1,0 +1,19 @@
+#ifndef TRITON_TYPE_ENUMS
+#define TRITON_TYPE_ENUMS
+
+include "mlir/IR/EnumAttr.td"
+
+// Address space of a Triton pointer type (`!tt.ptr`). Case values mirror the
+// LLVM address spaces:
+//   Global     (1): NVPTXAS ADDRESS_SPACE_GLOBAL  / AMDGPUAS GLOBAL_ADDRESS
+//   Flat       (0): NVPTXAS ADDRESS_SPACE_GENERIC / AMDGPUAS FLAT_ADDRESS
+def TT_PtrAddrSpaceAttr : I32EnumAttr<
+    "PtrAddrSpace", "",
+    [
+        I32EnumAttrCase<"Global", 1, "global">,
+        I32EnumAttrCase<"Flat", 0, "flat">,
+    ]> {
+    let cppNamespace = "::mlir::triton";
+}
+
+#endif // TRITON_TYPE_ENUMS

--- a/include/triton/Dialect/Triton/IR/TritonTypeEnums.td
+++ b/include/triton/Dialect/Triton/IR/TritonTypeEnums.td
@@ -6,12 +6,12 @@ include "mlir/IR/EnumAttr.td"
 // Address space of a Triton pointer type (`!tt.ptr`). Case values mirror the
 // LLVM address spaces:
 //   Global     (1): NVPTXAS ADDRESS_SPACE_GLOBAL  / AMDGPUAS GLOBAL_ADDRESS
-//   Flat       (0): NVPTXAS ADDRESS_SPACE_GENERIC / AMDGPUAS FLAT_ADDRESS
+//   Descriptor (0): NVPTXAS ADDRESS_SPACE_GENERIC / AMDGPUAS FLAT_ADDRESS
 def TT_PtrAddrSpaceAttr : I32EnumAttr<
     "PtrAddrSpace", "",
     [
         I32EnumAttrCase<"Global", 1, "global">,
-        I32EnumAttrCase<"Flat", 0, "flat">,
+        I32EnumAttrCase<"Descriptor", 0, "descriptor">,
     ]> {
     let cppNamespace = "::mlir::triton";
 }

--- a/include/triton/Dialect/Triton/IR/TritonTypes.td
+++ b/include/triton/Dialect/Triton/IR/TritonTypes.td
@@ -58,14 +58,19 @@ def TT_PtrType : TritonTypeDef<"Pointer", "ptr"> {
         Pointer type in Triton IR type system. Pointer types may only point to scalar element types.
     }];
 
-    let parameters = (ins "Type":$pointeeType, "int":$addressSpace);
+    let parameters = (ins "Type":$pointeeType, "PtrAddrSpace":$addressSpace);
 
     let builders = [
         TypeBuilderWithInferredContext<(ins
             "Type":$pointeeType,
-            "int":$addressSpace
+            "PtrAddrSpace":$addressSpace
         ), [{
             return $_get(pointeeType.getContext(), pointeeType, addressSpace);
+        }]>,
+        TypeBuilderWithInferredContext<(ins
+            "Type":$pointeeType
+        ), [{
+            return $_get(pointeeType.getContext(), pointeeType, PtrAddrSpace::Global);
         }]>
     ];
 

--- a/include/triton/Dialect/Triton/IR/Types.h
+++ b/include/triton/Dialect/Triton/IR/Types.h
@@ -9,8 +9,12 @@
 #define GET_TYPEDEF_CLASSES
 #include "triton/Dialect/Triton/IR/TypeInterfaces.h.inc"
 
-#include "triton/Dialect/Triton/IR/OpsEnums.h.inc" // required by `Types.h.inc`
+// clang-format off
+// TypesEnums.h.inc must precede Types.h.inc: the generated PointerType
+// declarations reference PtrAddrSpace.
+#include "triton/Dialect/Triton/IR/TypesEnums.h.inc"
 #include "triton/Dialect/Triton/IR/Types.h.inc"
+// clang-format on
 
 namespace mlir {
 

--- a/include/triton/Dialect/Triton/IR/Types.h
+++ b/include/triton/Dialect/Triton/IR/Types.h
@@ -9,6 +9,7 @@
 #define GET_TYPEDEF_CLASSES
 #include "triton/Dialect/Triton/IR/TypeInterfaces.h.inc"
 
+#include "triton/Dialect/Triton/IR/OpsEnums.h.inc" // required by `Types.h.inc`
 #include "triton/Dialect/Triton/IR/Types.h.inc"
 
 namespace mlir {
@@ -19,9 +20,10 @@ unsigned getPointeeBitWidth(Type type);
 
 Type getPointeeType(Type type);
 
-Type getPointerType(Type type, int addressSpace = 1);
+Type getPointerType(Type type,
+                    PtrAddrSpace addressSpace = PtrAddrSpace::Global);
 
-int getAddressSpace(Type type);
+PtrAddrSpace getAddressSpace(Type type);
 
 Type getI1SameShape(Type type);
 

--- a/lib/Conversion/TritonGPUToLLVM/TypeConverter.cpp
+++ b/lib/Conversion/TritonGPUToLLVM/TypeConverter.cpp
@@ -3,6 +3,7 @@
 #include "mlir/Support/LLVM.h"
 #include "triton/Dialect/TritonGPU/IR/Dialect.h"
 #include "triton/Dialect/TritonNvidiaGPU/IR/Dialect.h"
+#include "llvm/Support/NVPTXAddrSpace.h"
 
 using namespace mlir;
 using namespace mlir::triton;
@@ -21,7 +22,15 @@ TritonGPUToLLVMTypeConverter::TritonGPUToLLVMTypeConverter(
     const TargetInfoBase &targetInfo, const DataLayoutAnalysis *analysis)
     : LLVMTypeConverter(ctx, options, analysis) {
   addConversion([ctx](triton::PointerType type) -> std::optional<Type> {
-    return LLVM::LLVMPointerType::get(ctx, type.getAddressSpace());
+    switch (type.getAddressSpace()) {
+    case triton::PtrAddrSpace::Global:
+      return LLVM::LLVMPointerType::get(ctx,
+                                        llvm::NVPTXAS::ADDRESS_SPACE_GLOBAL);
+    case triton::PtrAddrSpace::Flat:
+      return LLVM::LLVMPointerType::get(ctx,
+                                        llvm::NVPTXAS::ADDRESS_SPACE_GENERIC);
+    }
+    llvm_unreachable("unknown PtrAddrSpace");
   });
   addConversion([ctx](TensorDescType type) -> std::optional<Type> {
     return LLVM::LLVMPointerType::get(ctx, 0);

--- a/lib/Conversion/TritonGPUToLLVM/TypeConverter.cpp
+++ b/lib/Conversion/TritonGPUToLLVM/TypeConverter.cpp
@@ -26,7 +26,7 @@ TritonGPUToLLVMTypeConverter::TritonGPUToLLVMTypeConverter(
     case triton::PtrAddrSpace::Global:
       return LLVM::LLVMPointerType::get(ctx,
                                         llvm::NVPTXAS::ADDRESS_SPACE_GLOBAL);
-    case triton::PtrAddrSpace::Flat:
+    case triton::PtrAddrSpace::Descriptor:
       return LLVM::LLVMPointerType::get(ctx,
                                         llvm::NVPTXAS::ADDRESS_SPACE_GENERIC);
     }

--- a/lib/Dialect/Triton/IR/Types.cpp
+++ b/lib/Dialect/Triton/IR/Types.cpp
@@ -64,7 +64,7 @@ void TensorDescType::print(AsmPrinter &printer) const {
 }
 
 // Format: !tt.ptr<f32>            (defaults to the "global" address space)
-//         !tt.ptr<f32, "flat">
+//         !tt.ptr<f32, "descriptor">
 Type PointerType::parse(AsmParser &parser) {
   Location loc = parser.getEncodedSourceLoc(parser.getCurrentLocation());
   if (parser.parseLess())

--- a/lib/Dialect/Triton/IR/Types.cpp
+++ b/lib/Dialect/Triton/IR/Types.cpp
@@ -10,6 +10,7 @@ using namespace mlir;
 using namespace mlir::triton;
 
 #include "triton/Dialect/Triton/IR/TypeInterfaces.cpp.inc"
+#include "triton/Dialect/Triton/IR/TypesEnums.cpp.inc"
 
 #define GET_TYPEDEF_CLASSES
 #include "triton/Dialect/Triton/IR/Types.cpp.inc"

--- a/lib/Dialect/Triton/IR/Types.cpp
+++ b/lib/Dialect/Triton/IR/Types.cpp
@@ -62,6 +62,8 @@ void TensorDescType::print(AsmPrinter &printer) const {
   printer << ">";
 }
 
+// Format: !tt.ptr<f32>            (defaults to the "global" address space)
+//         !tt.ptr<f32, "flat">
 Type PointerType::parse(AsmParser &parser) {
   Location loc = parser.getEncodedSourceLoc(parser.getCurrentLocation());
   if (parser.parseLess())
@@ -71,10 +73,18 @@ Type PointerType::parse(AsmParser &parser) {
   if (parser.parseType(pointeeType))
     return Type();
 
-  int addressSpace = 1;
+  PtrAddrSpace addressSpace = PtrAddrSpace::Global;
   if (succeeded(parser.parseOptionalComma())) {
-    if (parser.parseInteger(addressSpace))
+    std::string name;
+    if (parser.parseString(&name))
       return Type();
+    std::optional<PtrAddrSpace> symbolized = symbolizePtrAddrSpace(name);
+    if (!symbolized) {
+      parser.emitError(parser.getCurrentLocation())
+          << "invalid pointer address space '" << name << "'";
+      return Type();
+    }
+    addressSpace = *symbolized;
   }
 
   if (parser.parseGreater())
@@ -84,11 +94,10 @@ Type PointerType::parse(AsmParser &parser) {
 }
 
 void PointerType::print(AsmPrinter &printer) const {
-  if (getAddressSpace() == 1) {
-    printer << "<" << getPointeeType() << ">";
-  } else {
-    printer << "<" << getPointeeType() << ", " << getAddressSpace() << ">";
-  }
+  printer << "<" << getPointeeType();
+  if (getAddressSpace() != PtrAddrSpace::Global)
+    printer << ", \"" << stringifyPtrAddrSpace(getAddressSpace()) << "\"";
+  printer << ">";
 }
 
 LogicalResult
@@ -104,7 +113,7 @@ TensorDescType::verify(function_ref<InFlightDiagnostic()> emitError,
 }
 
 LogicalResult PointerType::verify(function_ref<InFlightDiagnostic()> emitError,
-                                  Type pointeeType, int addressSpace) {
+                                  Type pointeeType, PtrAddrSpace addressSpace) {
   if (!pointeeType.isIntOrFloat())
     return emitError()
            << "pointer types must point to integer or floating-point types";
@@ -153,10 +162,10 @@ Type getI32SameShape(Type type) {
 Type getPointerTypeSameShape(Type type) {
   if (auto tensorTy = dyn_cast<RankedTensorType>(type)) {
     Type elementType = tensorTy.getElementType();
-    PointerType ptrType = PointerType::get(elementType, 1);
+    PointerType ptrType = PointerType::get(elementType);
     return tensorTy.clone(ptrType);
   } else {
-    return PointerType::get(type, 1);
+    return PointerType::get(type);
   }
 }
 
@@ -165,15 +174,14 @@ bool elementTypeMatchesPointee(Type valueTy, Type ptrTy) {
   return ptrType && getElementTypeOrSelf(valueTy) == ptrType.getPointeeType();
 }
 
-// upstream Triton only uses address space 1 for Pointer Type
-Type getPointerType(Type type, int addressSpace) {
+Type getPointerType(Type type, PtrAddrSpace addressSpace) {
   return PointerType::get(type, addressSpace);
 }
 
-int getAddressSpace(Type type) {
+PtrAddrSpace getAddressSpace(Type type) {
   if (auto ptrType = dyn_cast<PointerType>(type))
     return ptrType.getAddressSpace();
-  return 1;
+  return PtrAddrSpace::Global;
 }
 
 } // namespace triton

--- a/lib/Dialect/TritonInstrument/Transforms/GlobalSanitizer.cpp
+++ b/lib/Dialect/TritonInstrument/Transforms/GlobalSanitizer.cpp
@@ -346,7 +346,7 @@ static void instrumentClusterBarrierEquivalents(ModuleOp module) {
     Location loc = points.front().op->getLoc();
     Block &entry = group->front();
     OpBuilder initBuilder(&entry, entry.begin());
-    Type ptrTy = tt::PointerType::get(initBuilder.getI8Type(), 1);
+    Type ptrTy = tt::PointerType::get(initBuilder.getI8Type());
     Value scratch = createThirdPartyScratchAlloc(
         initBuilder, loc, ptrTy, kGSanClusterBarrierScratchBytes,
         /*alignment=*/16, /*sharedClusterState=*/true);
@@ -372,8 +372,8 @@ public:
   void runOnOperation() override {
     ModuleOp module = getOperation();
     OpBuilder builder(module);
-    Type gsanStatePtrTy = tt::PointerType::get(builder.getI8Type(), 1);
-    Type streamClockPtrTy = tt::PointerType::get(builder.getI32Type(), 1);
+    Type gsanStatePtrTy = tt::PointerType::get(builder.getI8Type());
+    Type streamClockPtrTy = tt::PointerType::get(builder.getI32Type());
     Type kernelIdTy = builder.getI64Type();
     auto launchPdl = module->getAttrOfType<IntegerAttr>("tti.gsan_launch_pdl");
     bool acquireStreamClock = !launchPdl || launchPdl.getInt() == 0;

--- a/python/src/ir.cc
+++ b/python/src/ir.cc
@@ -1081,8 +1081,14 @@ void init_triton_ir(py::module_ &m) {
              return self.getBuilder().getF64Type();
            })
       .def("get_ptr_ty",
-           [](TritonOpBuilder &self, Type &type, int addrSpace) -> Type {
-             return PointerType::get(type, addrSpace);
+           [](TritonOpBuilder &self, Type &type,
+              const std::string &addrSpace) -> Type {
+             std::optional<PtrAddrSpace> symbolized =
+                 symbolizePtrAddrSpace(addrSpace);
+             if (!symbolized)
+               throw std::invalid_argument("invalid pointer address space '" +
+                                           addrSpace + "'");
+             return PointerType::get(type, *symbolized);
            })
       .def("get_block_ty",
            [](TritonOpBuilder &self, Type &elementType,

--- a/python/test/unit/tools/test_irsource.py
+++ b/python/test/unit/tools/test_irsource.py
@@ -33,7 +33,7 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 8 : i32, ttg.targ
                                 %arg6: i32 {tt.divisibility = 16 : i32},
                                 %arg7: i32 {tt.divisibility = 16 : i32},
                                 %arg8: i32 {tt.divisibility = 16 : i32, tt.nv_tma_desc = 0 : i32},
-                                %desc: !tt.ptr<i8, 0> {tt.nv_tma_desc = 1 : i32}) attributes {noinline = false} {
+                                %desc: !tt.ptr<i8, "flat"> {tt.nv_tma_desc = 1 : i32}) attributes {noinline = false} {
     tt.return
   }
 }

--- a/python/test/unit/tools/test_irsource.py
+++ b/python/test/unit/tools/test_irsource.py
@@ -33,7 +33,7 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 8 : i32, ttg.targ
                                 %arg6: i32 {tt.divisibility = 16 : i32},
                                 %arg7: i32 {tt.divisibility = 16 : i32},
                                 %arg8: i32 {tt.divisibility = 16 : i32, tt.nv_tma_desc = 0 : i32},
-                                %desc: !tt.ptr<i8, "flat"> {tt.nv_tma_desc = 1 : i32}) attributes {noinline = false} {
+                                %desc: !tt.ptr<i8, "descriptor"> {tt.nv_tma_desc = 1 : i32}) attributes {noinline = false} {
     tt.return
   }
 }

--- a/python/triton/language/core.py
+++ b/python/triton/language/core.py
@@ -676,7 +676,7 @@ _DtypeClass = dtype
 
 class pointer_type(dtype):
 
-    def __init__(self, element_ty: dtype, address_space: int = 1, const: bool = False):
+    def __init__(self, element_ty: dtype, address_space: str = "global", const: bool = False):
         element_ty = _unwrap_if_constexpr(element_ty)
         if not isinstance(element_ty, dtype):
             raise TypeError(f'element_ty has type `{type(element_ty).__name__}`; expected `dtype`.')

--- a/python/triton/language/semantic.py
+++ b/python/triton/language/semantic.py
@@ -1332,10 +1332,10 @@ class TritonSemantic(Generic[TensorTy]):
 
         i_type = tl.int32 if sca_ty == tl.float32 else tl.int64
         i_val = self.bitcast(val, i_type)
-        i_ptr = self.bitcast(ptr, tl.pointer_type(i_type, 1))
+        i_ptr = self.bitcast(ptr, tl.pointer_type(i_type))
         ui_type = tl.uint32 if sca_ty == tl.float32 else tl.uint64
         ui_val = self.bitcast(val, ui_type)
-        ui_ptr = self.bitcast(ptr, tl.pointer_type(ui_type, 1))
+        ui_ptr = self.bitcast(ptr, tl.pointer_type(ui_type))
         neg = self._signbit(val)
         pos = self.not_(neg)
         pos_ret = self.tensor(
@@ -1370,10 +1370,10 @@ class TritonSemantic(Generic[TensorTy]):
 
         i_type = tl.int32 if sca_ty == tl.float32 else tl.int64
         i_val = self.bitcast(val, i_type)
-        i_ptr = self.bitcast(ptr, tl.pointer_type(i_type, 1))
+        i_ptr = self.bitcast(ptr, tl.pointer_type(i_type))
         ui_type = tl.uint32 if sca_ty == tl.float32 else tl.uint64
         ui_val = self.bitcast(val, ui_type)
-        ui_ptr = self.bitcast(ptr, tl.pointer_type(ui_type, 1))
+        ui_ptr = self.bitcast(ptr, tl.pointer_type(ui_type))
         neg = self._signbit(val)
         pos = self.not_(neg)
         pos_ret = self.tensor(

--- a/test/Conversion/tritongpu_to_llvm.mlir
+++ b/test/Conversion/tritongpu_to_llvm.mlir
@@ -3025,9 +3025,9 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, "ttg.thr
 module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.target = "cuda:100"} {
 
 // CHECK-LABEL: @reinterpret_tensor_descriptor
-tt.func private @reinterpret_tensor_descriptor(%arg0: !tt.ptr<i8, "flat">) -> !tt.tensordesc<128x64xf16, #shared> {
+tt.func private @reinterpret_tensor_descriptor(%arg0: !tt.ptr<i8, "descriptor">) -> !tt.tensordesc<128x64xf16, #shared> {
   // CHECK-NEXT: llvm.addrspacecast %arg0 : !llvm.ptr to !llvm.ptr
-  %0 = ttng.reinterpret_tensor_descriptor %arg0 : !tt.ptr<i8, "flat"> to !tt.tensordesc<128x64xf16, #shared>
+  %0 = ttng.reinterpret_tensor_descriptor %arg0 : !tt.ptr<i8, "descriptor"> to !tt.tensordesc<128x64xf16, #shared>
   tt.return %0 : !tt.tensordesc<128x64xf16, #shared>
 }
 

--- a/test/Conversion/tritongpu_to_llvm.mlir
+++ b/test/Conversion/tritongpu_to_llvm.mlir
@@ -3025,9 +3025,9 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, "ttg.thr
 module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.target = "cuda:100"} {
 
 // CHECK-LABEL: @reinterpret_tensor_descriptor
-tt.func private @reinterpret_tensor_descriptor(%arg0: !tt.ptr<i8, 0>) -> !tt.tensordesc<128x64xf16, #shared> {
+tt.func private @reinterpret_tensor_descriptor(%arg0: !tt.ptr<i8, "flat">) -> !tt.tensordesc<128x64xf16, #shared> {
   // CHECK-NEXT: llvm.addrspacecast %arg0 : !llvm.ptr to !llvm.ptr
-  %0 = ttng.reinterpret_tensor_descriptor %arg0 : !tt.ptr<i8, 0> to !tt.tensordesc<128x64xf16, #shared>
+  %0 = ttng.reinterpret_tensor_descriptor %arg0 : !tt.ptr<i8, "flat"> to !tt.tensordesc<128x64xf16, #shared>
   tt.return %0 : !tt.tensordesc<128x64xf16, #shared>
 }
 

--- a/test/Conversion/tritonnvidiagpu_to_llvm.mlir
+++ b/test/Conversion/tritonnvidiagpu_to_llvm.mlir
@@ -572,7 +572,7 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 1 : i32} {
   // CHECK: llvm.align = 64
   // CHECK: llvm.byval = !llvm.array<128 x i8>
   // CHECK: nvvm.grid_constant
-  tt.func @byval_tma_desc(%desc: !tt.ptr<i8, 0> {tt.nv_tma_desc = 1 : i32}) {
+  tt.func @byval_tma_desc(%desc: !tt.ptr<i8, "flat"> {tt.nv_tma_desc = 1 : i32}) {
     tt.return
   }
 }

--- a/test/Conversion/tritonnvidiagpu_to_llvm.mlir
+++ b/test/Conversion/tritonnvidiagpu_to_llvm.mlir
@@ -572,7 +572,7 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 1 : i32} {
   // CHECK: llvm.align = 64
   // CHECK: llvm.byval = !llvm.array<128 x i8>
   // CHECK: nvvm.grid_constant
-  tt.func @byval_tma_desc(%desc: !tt.ptr<i8, "flat"> {tt.nv_tma_desc = 1 : i32}) {
+  tt.func @byval_tma_desc(%desc: !tt.ptr<i8, "descriptor"> {tt.nv_tma_desc = 1 : i32}) {
     tt.return
   }
 }

--- a/test/Hopper/WarpSpecialization/ws_code_partition.mlir
+++ b/test/Hopper/WarpSpecialization/ws_code_partition.mlir
@@ -279,15 +279,15 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.targ
 #shared2 = #ttg.nvmma_shared<{swizzlingByteWidth = 64, transposed = true, elementBitWidth = 8}>
 #smem = #ttg.shared_memory
 module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.target = "cuda:90", "ttg.threads-per-warp" = 32 : i32} {
-  tt.func public @_fbgemm_grouped_gemm_fp8_rowwise_ws(%arg0: !tt.ptr<i8, 0> {tt.nv_tma_desc = 1 : i32}, %arg1: i32, %arg2: !tt.ptr<i8, 0> {tt.nv_tma_desc = 1 : i32}, %arg3: !tt.ptr<i8, 0> {tt.nv_tma_desc = 1 : i32}) {
+  tt.func public @_fbgemm_grouped_gemm_fp8_rowwise_ws(%arg0: !tt.ptr<i8, "flat"> {tt.nv_tma_desc = 1 : i32}, %arg1: i32, %arg2: !tt.ptr<i8, "flat"> {tt.nv_tma_desc = 1 : i32}, %arg3: !tt.ptr<i8, "flat"> {tt.nv_tma_desc = 1 : i32}) {
     %c0_i32 = arith.constant {async_task_id = array<i32: 0, 1, 2>} 0 : i32
     %c2048_i32 = arith.constant {async_task_id = array<i32: 0, 1, 2>} 2048 : i32
     %c64_i32 = arith.constant {async_task_id = array<i32: 0, 1, 2>} 64 : i32
     %cst = arith.constant {async_task_id = array<i32: 0, 1, 2>} dense<0.000000e+00> : tensor<64x128xf32, #mma>
     %0 = tt.get_program_id x {async_task_id = array<i32: 0, 1, 2>} : i32
-    %1 = ttng.reinterpret_tensor_descriptor %arg0 {async_task_id = array<i32: 0>} : !tt.ptr<i8, 0> to !tt.tensordesc<64x64xf8E4M3FN, #shared>
-    %2 = ttng.reinterpret_tensor_descriptor %arg2 {async_task_id = array<i32: 0>} : !tt.ptr<i8, 0> to !tt.tensordesc<128x64xf8E4M3FN, #shared>
-    %3 = ttng.reinterpret_tensor_descriptor %arg3 {async_task_id = array<i32: 0>} : !tt.ptr<i8, 0> to !tt.tensordesc<128xf32, #shared1>
+    %1 = ttng.reinterpret_tensor_descriptor %arg0 {async_task_id = array<i32: 0>} : !tt.ptr<i8, "flat"> to !tt.tensordesc<64x64xf8E4M3FN, #shared>
+    %2 = ttng.reinterpret_tensor_descriptor %arg2 {async_task_id = array<i32: 0>} : !tt.ptr<i8, "flat"> to !tt.tensordesc<128x64xf8E4M3FN, #shared>
+    %3 = ttng.reinterpret_tensor_descriptor %arg3 {async_task_id = array<i32: 0>} : !tt.ptr<i8, "flat"> to !tt.tensordesc<128xf32, #shared1>
     scf.for %arg4 = %0 to %arg1 step %c64_i32  : i32 {
       %4 = arith.muli %arg4, %c2048_i32 {async_task_id = array<i32: 0>} : i32
       %5 = scf.for %arg5 = %c0_i32 to %c2048_i32 step %c64_i32 iter_args(%arg6 = %cst) -> (tensor<64x128xf32, #mma>)  : i32 {

--- a/test/Hopper/WarpSpecialization/ws_code_partition.mlir
+++ b/test/Hopper/WarpSpecialization/ws_code_partition.mlir
@@ -279,15 +279,15 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.targ
 #shared2 = #ttg.nvmma_shared<{swizzlingByteWidth = 64, transposed = true, elementBitWidth = 8}>
 #smem = #ttg.shared_memory
 module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.target = "cuda:90", "ttg.threads-per-warp" = 32 : i32} {
-  tt.func public @_fbgemm_grouped_gemm_fp8_rowwise_ws(%arg0: !tt.ptr<i8, "flat"> {tt.nv_tma_desc = 1 : i32}, %arg1: i32, %arg2: !tt.ptr<i8, "flat"> {tt.nv_tma_desc = 1 : i32}, %arg3: !tt.ptr<i8, "flat"> {tt.nv_tma_desc = 1 : i32}) {
+  tt.func public @_fbgemm_grouped_gemm_fp8_rowwise_ws(%arg0: !tt.ptr<i8, "descriptor"> {tt.nv_tma_desc = 1 : i32}, %arg1: i32, %arg2: !tt.ptr<i8, "descriptor"> {tt.nv_tma_desc = 1 : i32}, %arg3: !tt.ptr<i8, "descriptor"> {tt.nv_tma_desc = 1 : i32}) {
     %c0_i32 = arith.constant {async_task_id = array<i32: 0, 1, 2>} 0 : i32
     %c2048_i32 = arith.constant {async_task_id = array<i32: 0, 1, 2>} 2048 : i32
     %c64_i32 = arith.constant {async_task_id = array<i32: 0, 1, 2>} 64 : i32
     %cst = arith.constant {async_task_id = array<i32: 0, 1, 2>} dense<0.000000e+00> : tensor<64x128xf32, #mma>
     %0 = tt.get_program_id x {async_task_id = array<i32: 0, 1, 2>} : i32
-    %1 = ttng.reinterpret_tensor_descriptor %arg0 {async_task_id = array<i32: 0>} : !tt.ptr<i8, "flat"> to !tt.tensordesc<64x64xf8E4M3FN, #shared>
-    %2 = ttng.reinterpret_tensor_descriptor %arg2 {async_task_id = array<i32: 0>} : !tt.ptr<i8, "flat"> to !tt.tensordesc<128x64xf8E4M3FN, #shared>
-    %3 = ttng.reinterpret_tensor_descriptor %arg3 {async_task_id = array<i32: 0>} : !tt.ptr<i8, "flat"> to !tt.tensordesc<128xf32, #shared1>
+    %1 = ttng.reinterpret_tensor_descriptor %arg0 {async_task_id = array<i32: 0>} : !tt.ptr<i8, "descriptor"> to !tt.tensordesc<64x64xf8E4M3FN, #shared>
+    %2 = ttng.reinterpret_tensor_descriptor %arg2 {async_task_id = array<i32: 0>} : !tt.ptr<i8, "descriptor"> to !tt.tensordesc<128x64xf8E4M3FN, #shared>
+    %3 = ttng.reinterpret_tensor_descriptor %arg3 {async_task_id = array<i32: 0>} : !tt.ptr<i8, "descriptor"> to !tt.tensordesc<128xf32, #shared1>
     scf.for %arg4 = %0 to %arg1 step %c64_i32  : i32 {
       %4 = arith.muli %arg4, %c2048_i32 {async_task_id = array<i32: 0>} : i32
       %5 = scf.for %arg5 = %c0_i32 to %c2048_i32 step %c64_i32 iter_args(%arg6 = %cst) -> (tensor<64x128xf32, #mma>)  : i32 {

--- a/test/Triton/invalid.mlir
+++ b/test/Triton/invalid.mlir
@@ -16,6 +16,20 @@ tt.func public @invalid_pointer_pointee(%arg0: !tt.ptr<index>) {
 
 // -----
 
+// expected-error @+1 {{invalid pointer address space 'bogus'}}
+tt.func public @invalid_pointer_address_space(%arg0: !tt.ptr<f32, "bogus">) {
+  tt.return
+}
+
+// -----
+
+// expected-error @+1 {{expected string}}
+tt.func public @invalid_pointer_integer_address_space(%arg0: !tt.ptr<f32, 1>) {
+  tt.return
+}
+
+// -----
+
 // Invalid bitcast between types of different bit width.
 tt.func public @fn(%arg0: tensor<128xf32>) {
     // expected-error @+1 {{Cannot bitcast data-type of size}}

--- a/test/Triton/ops.mlir
+++ b/test/Triton/ops.mlir
@@ -287,8 +287,8 @@ tt.func @unsplat(%arg0: tensor<1x1xf32>) -> f32 {
 }
 
 // CHECK-LABEL: @ptr_addr_space
-tt.func @ptr_addr_space(%arg0: !tt.ptr<i8, "flat">, %arg1: !tt.ptr<f32>) {
-  // CHECK-SAME: %arg0: !tt.ptr<i8, "flat">
+tt.func @ptr_addr_space(%arg0: !tt.ptr<i8, "descriptor">, %arg1: !tt.ptr<f32>) {
+  // CHECK-SAME: %arg0: !tt.ptr<i8, "descriptor">
   // CHECK-SAME: %arg1: !tt.ptr<f32>
   tt.return
 }

--- a/test/Triton/ops.mlir
+++ b/test/Triton/ops.mlir
@@ -285,3 +285,10 @@ tt.func @unsplat(%arg0: tensor<1x1xf32>) -> f32 {
   %0 = tt.unsplat %arg0 : tensor<1x1xf32>
   tt.return %0 : f32
 }
+
+// CHECK-LABEL: @ptr_addr_space
+tt.func @ptr_addr_space(%arg0: !tt.ptr<i8, "flat">, %arg1: !tt.ptr<f32>) {
+  // CHECK-SAME: %arg0: !tt.ptr<i8, "flat">
+  // CHECK-SAME: %arg1: !tt.ptr<f32>
+  tt.return
+}

--- a/test/TritonGPU/amd/invalid.mlir
+++ b/test/TritonGPU/amd/invalid.mlir
@@ -724,9 +724,9 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 1 : i32, ttg.targ
 // address space 0) base is rejected -- for stores, atomic RMWs, and atomic CAS.
 #blocked = #ttg.blocked<{sizePerThread = [1], threadsPerWarp = [64], warpsPerCTA = [4], order = [0]}>
 module attributes {"ttg.num-warps" = 4 : i32, "ttg.threads-per-warp" = 64 : i32} {
-  tt.func @buffer_store_nonglobal_base(%arg0: !tt.ptr<f32, "flat">, %arg1: tensor<256xi32, #blocked>, %arg2: tensor<256xf32, #blocked>) {
+  tt.func @buffer_store_nonglobal_base(%arg0: !tt.ptr<f32, "descriptor">, %arg1: tensor<256xi32, #blocked>, %arg2: tensor<256xf32, #blocked>) {
     // expected-error @+1 {{buffer writes require a global address space base}}
-    amdg.buffer_store %arg2, %arg0[%arg1] : !tt.ptr<f32, "flat"> -> tensor<256xf32, #blocked>
+    amdg.buffer_store %arg2, %arg0[%arg1] : !tt.ptr<f32, "descriptor"> -> tensor<256xf32, #blocked>
     tt.return
   }
 }
@@ -735,9 +735,9 @@ module attributes {"ttg.num-warps" = 4 : i32, "ttg.threads-per-warp" = 64 : i32}
 
 #blocked = #ttg.blocked<{sizePerThread = [1], threadsPerWarp = [64], warpsPerCTA = [4], order = [0]}>
 module attributes {"ttg.num-warps" = 4 : i32, "ttg.threads-per-warp" = 64 : i32} {
-  tt.func @buffer_atomic_rmw_nonglobal_base(%arg0: !tt.ptr<f32, "flat">, %arg1: tensor<256xi32, #blocked>, %arg2: tensor<256xf32, #blocked>) {
+  tt.func @buffer_atomic_rmw_nonglobal_base(%arg0: !tt.ptr<f32, "descriptor">, %arg1: tensor<256xi32, #blocked>, %arg2: tensor<256xf32, #blocked>) {
     // expected-error @+1 {{buffer writes require a global address space base}}
-    %0 = amdg.buffer_atomic_rmw fadd, acq_rel, gpu, %arg2, %arg0[%arg1] : !tt.ptr<f32, "flat"> -> tensor<256xf32, #blocked>
+    %0 = amdg.buffer_atomic_rmw fadd, acq_rel, gpu, %arg2, %arg0[%arg1] : !tt.ptr<f32, "descriptor"> -> tensor<256xf32, #blocked>
     tt.return
   }
 }
@@ -746,9 +746,9 @@ module attributes {"ttg.num-warps" = 4 : i32, "ttg.threads-per-warp" = 64 : i32}
 
 #blocked = #ttg.blocked<{sizePerThread = [1], threadsPerWarp = [64], warpsPerCTA = [4], order = [0]}>
 module attributes {"ttg.num-warps" = 4 : i32, "ttg.threads-per-warp" = 64 : i32} {
-  tt.func @buffer_atomic_cas_nonglobal_base(%arg0: !tt.ptr<i32, "flat">, %arg1: tensor<256xi32, #blocked>, %arg2: tensor<256xi32, #blocked>, %arg3: tensor<256xi32, #blocked>) {
+  tt.func @buffer_atomic_cas_nonglobal_base(%arg0: !tt.ptr<i32, "descriptor">, %arg1: tensor<256xi32, #blocked>, %arg2: tensor<256xi32, #blocked>, %arg3: tensor<256xi32, #blocked>) {
     // expected-error @+1 {{buffer writes require a global address space base}}
-    %0 = amdg.buffer_atomic_cas acq_rel, gpu, %arg2, %arg3, %arg0[%arg1] : !tt.ptr<i32, "flat"> -> tensor<256xi32, #blocked>
+    %0 = amdg.buffer_atomic_cas acq_rel, gpu, %arg2, %arg3, %arg0[%arg1] : !tt.ptr<i32, "descriptor"> -> tensor<256xi32, #blocked>
     tt.return
   }
 }

--- a/test/TritonGPU/amd/invalid.mlir
+++ b/test/TritonGPU/amd/invalid.mlir
@@ -4,7 +4,7 @@
 #wmma = #ttg.amd_wmma<{version = 0, isTranspose = false, ctaLayout = {warp = [[0, 1], [1, 0]]}}>
 module attributes {"ttg.num-warps" = 4 : i32, "ttg.num-ctas" = 1 : i32, "ttg.threads-per-warp" = 32 : i32} {
     tt.func public @fn(%arg0: !tt.ptr<i32>) {
-        %t = tt.splat %arg0 : !tt.ptr<i32,1> -> tensor<32x32x!tt.ptr<i32,1>, #wmma>
+        %t = tt.splat %arg0 : !tt.ptr<i32> -> tensor<32x32x!tt.ptr<i32>, #wmma>
         tt.return
     }
 }
@@ -724,9 +724,9 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 1 : i32, ttg.targ
 // address space 0) base is rejected -- for stores, atomic RMWs, and atomic CAS.
 #blocked = #ttg.blocked<{sizePerThread = [1], threadsPerWarp = [64], warpsPerCTA = [4], order = [0]}>
 module attributes {"ttg.num-warps" = 4 : i32, "ttg.threads-per-warp" = 64 : i32} {
-  tt.func @buffer_store_nonglobal_base(%arg0: !tt.ptr<f32, 0>, %arg1: tensor<256xi32, #blocked>, %arg2: tensor<256xf32, #blocked>) {
+  tt.func @buffer_store_nonglobal_base(%arg0: !tt.ptr<f32, "flat">, %arg1: tensor<256xi32, #blocked>, %arg2: tensor<256xf32, #blocked>) {
     // expected-error @+1 {{buffer writes require a global address space base}}
-    amdg.buffer_store %arg2, %arg0[%arg1] : !tt.ptr<f32, 0> -> tensor<256xf32, #blocked>
+    amdg.buffer_store %arg2, %arg0[%arg1] : !tt.ptr<f32, "flat"> -> tensor<256xf32, #blocked>
     tt.return
   }
 }
@@ -735,9 +735,9 @@ module attributes {"ttg.num-warps" = 4 : i32, "ttg.threads-per-warp" = 64 : i32}
 
 #blocked = #ttg.blocked<{sizePerThread = [1], threadsPerWarp = [64], warpsPerCTA = [4], order = [0]}>
 module attributes {"ttg.num-warps" = 4 : i32, "ttg.threads-per-warp" = 64 : i32} {
-  tt.func @buffer_atomic_rmw_nonglobal_base(%arg0: !tt.ptr<f32, 0>, %arg1: tensor<256xi32, #blocked>, %arg2: tensor<256xf32, #blocked>) {
+  tt.func @buffer_atomic_rmw_nonglobal_base(%arg0: !tt.ptr<f32, "flat">, %arg1: tensor<256xi32, #blocked>, %arg2: tensor<256xf32, #blocked>) {
     // expected-error @+1 {{buffer writes require a global address space base}}
-    %0 = amdg.buffer_atomic_rmw fadd, acq_rel, gpu, %arg2, %arg0[%arg1] : !tt.ptr<f32, 0> -> tensor<256xf32, #blocked>
+    %0 = amdg.buffer_atomic_rmw fadd, acq_rel, gpu, %arg2, %arg0[%arg1] : !tt.ptr<f32, "flat"> -> tensor<256xf32, #blocked>
     tt.return
   }
 }
@@ -746,9 +746,9 @@ module attributes {"ttg.num-warps" = 4 : i32, "ttg.threads-per-warp" = 64 : i32}
 
 #blocked = #ttg.blocked<{sizePerThread = [1], threadsPerWarp = [64], warpsPerCTA = [4], order = [0]}>
 module attributes {"ttg.num-warps" = 4 : i32, "ttg.threads-per-warp" = 64 : i32} {
-  tt.func @buffer_atomic_cas_nonglobal_base(%arg0: !tt.ptr<i32, 0>, %arg1: tensor<256xi32, #blocked>, %arg2: tensor<256xi32, #blocked>, %arg3: tensor<256xi32, #blocked>) {
+  tt.func @buffer_atomic_cas_nonglobal_base(%arg0: !tt.ptr<i32, "flat">, %arg1: tensor<256xi32, #blocked>, %arg2: tensor<256xi32, #blocked>, %arg3: tensor<256xi32, #blocked>) {
     // expected-error @+1 {{buffer writes require a global address space base}}
-    %0 = amdg.buffer_atomic_cas acq_rel, gpu, %arg2, %arg3, %arg0[%arg1] : !tt.ptr<i32, 0> -> tensor<256xi32, #blocked>
+    %0 = amdg.buffer_atomic_cas acq_rel, gpu, %arg2, %arg3, %arg0[%arg1] : !tt.ptr<i32, "flat"> -> tensor<256xi32, #blocked>
     tt.return
   }
 }

--- a/test/TritonGPU/loop-pipeline-hopper.mlir
+++ b/test/TritonGPU/loop-pipeline-hopper.mlir
@@ -1021,7 +1021,7 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 8 : i32, ttg.targ
 #nvmma_64 = #ttg.nvmma_shared<{swizzlingByteWidth = 64, transposed = false, elementBitWidth = 16}>
 #nvmma_128 = #ttg.nvmma_shared<{swizzlingByteWidth = 128, transposed = false, elementBitWidth = 32}>
 module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 8 : i32, ttg.target = "cuda:90", "ttg.threads-per-warp" = 32 : i32} {
-  tt.func public @mmav3_fp8_row_major_rhs(%arg0: !tt.ptr<i8, 0> {tt.nv_tma_desc = 1 : i32}, %arg1: !tt.ptr<i8, 0> {tt.nv_tma_desc = 1 : i32}, %arg2: !tt.ptr<i8, 0> {tt.nv_tma_desc = 1 : i32}, %arg3: i32 {tt.divisibility = 16 : i32}, %arg4: i32 {tt.divisibility = 16 : i32}, %arg5: i32 {tt.divisibility = 16 : i32}) {
+  tt.func public @mmav3_fp8_row_major_rhs(%arg0: !tt.ptr<i8, "flat"> {tt.nv_tma_desc = 1 : i32}, %arg1: !tt.ptr<i8, "flat"> {tt.nv_tma_desc = 1 : i32}, %arg2: !tt.ptr<i8, "flat"> {tt.nv_tma_desc = 1 : i32}, %arg3: i32 {tt.divisibility = 16 : i32}, %arg4: i32 {tt.divisibility = 16 : i32}, %arg5: i32 {tt.divisibility = 16 : i32}) {
     // CHECK-LABEL: mmav3_fp8_row_major_rhs
     // The col-major RHS SMEM encoding in the input, created by accelerate-matmul, should be overwritten by the row-major TMA layout.
     // Note that this "overwriting" makes the program invalid after SWP, since warp_group_dot does not support row-major fp8 RHS.
@@ -1044,8 +1044,8 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 8 : i32, ttg.targ
     %6 = arith.muli %4, %c64_i32 : i32
     %7 = arith.addi %arg5, %c63_i32 : i32
     %8 = arith.divsi %7, %c64_i32 : i32
-    %9 = ttng.reinterpret_tensor_descriptor %arg0 : !tt.ptr<i8, 0> to !tt.tensordesc<128x64xf8E4M3FN, #shared>
-    %10 = ttng.reinterpret_tensor_descriptor %arg1 : !tt.ptr<i8, 0> to !tt.tensordesc<64x64xf8E4M3FN, #shared>
+    %9 = ttng.reinterpret_tensor_descriptor %arg0 : !tt.ptr<i8, "flat"> to !tt.tensordesc<128x64xf8E4M3FN, #shared>
+    %10 = ttng.reinterpret_tensor_descriptor %arg1 : !tt.ptr<i8, "flat"> to !tt.tensordesc<64x64xf8E4M3FN, #shared>
     %true = arith.constant true
     %false = arith.constant false
     %11:2 = scf.for %arg6 = %c0_i32 to %8 step %c1_i32 iter_args(%arg7 = %cst, %arg8 = %c0_i32) -> (tensor<128x64xf32, #ttg.nvidia_mma<{versionMajor = 3, versionMinor = 0, warpsPerCTA = [8, 1], instrShape = [16, 64, 32]}>>, i32)  : i32 {
@@ -1058,7 +1058,7 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 8 : i32, ttg.targ
       scf.yield %18, %19 : tensor<128x64xf32, #mma>, i32
     }
     %12 = ttg.convert_layout %11#0 : tensor<128x64xf32, #mma> -> tensor<128x64xf32, #blocked>
-    %13 = ttng.reinterpret_tensor_descriptor %arg2 : !tt.ptr<i8, 0> to !tt.tensordesc<128x64xf32, #nvmma_128>
+    %13 = ttng.reinterpret_tensor_descriptor %arg2 : !tt.ptr<i8, "flat"> to !tt.tensordesc<128x64xf32, #nvmma_128>
     tt.descriptor_store %13[%5, %6], %12 : !tt.tensordesc<128x64xf32, #nvmma_128>, tensor<128x64xf32, #blocked>
     tt.return
   }

--- a/test/TritonGPU/loop-pipeline-hopper.mlir
+++ b/test/TritonGPU/loop-pipeline-hopper.mlir
@@ -1021,7 +1021,7 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 8 : i32, ttg.targ
 #nvmma_64 = #ttg.nvmma_shared<{swizzlingByteWidth = 64, transposed = false, elementBitWidth = 16}>
 #nvmma_128 = #ttg.nvmma_shared<{swizzlingByteWidth = 128, transposed = false, elementBitWidth = 32}>
 module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 8 : i32, ttg.target = "cuda:90", "ttg.threads-per-warp" = 32 : i32} {
-  tt.func public @mmav3_fp8_row_major_rhs(%arg0: !tt.ptr<i8, "flat"> {tt.nv_tma_desc = 1 : i32}, %arg1: !tt.ptr<i8, "flat"> {tt.nv_tma_desc = 1 : i32}, %arg2: !tt.ptr<i8, "flat"> {tt.nv_tma_desc = 1 : i32}, %arg3: i32 {tt.divisibility = 16 : i32}, %arg4: i32 {tt.divisibility = 16 : i32}, %arg5: i32 {tt.divisibility = 16 : i32}) {
+  tt.func public @mmav3_fp8_row_major_rhs(%arg0: !tt.ptr<i8, "descriptor"> {tt.nv_tma_desc = 1 : i32}, %arg1: !tt.ptr<i8, "descriptor"> {tt.nv_tma_desc = 1 : i32}, %arg2: !tt.ptr<i8, "descriptor"> {tt.nv_tma_desc = 1 : i32}, %arg3: i32 {tt.divisibility = 16 : i32}, %arg4: i32 {tt.divisibility = 16 : i32}, %arg5: i32 {tt.divisibility = 16 : i32}) {
     // CHECK-LABEL: mmav3_fp8_row_major_rhs
     // The col-major RHS SMEM encoding in the input, created by accelerate-matmul, should be overwritten by the row-major TMA layout.
     // Note that this "overwriting" makes the program invalid after SWP, since warp_group_dot does not support row-major fp8 RHS.
@@ -1044,8 +1044,8 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 8 : i32, ttg.targ
     %6 = arith.muli %4, %c64_i32 : i32
     %7 = arith.addi %arg5, %c63_i32 : i32
     %8 = arith.divsi %7, %c64_i32 : i32
-    %9 = ttng.reinterpret_tensor_descriptor %arg0 : !tt.ptr<i8, "flat"> to !tt.tensordesc<128x64xf8E4M3FN, #shared>
-    %10 = ttng.reinterpret_tensor_descriptor %arg1 : !tt.ptr<i8, "flat"> to !tt.tensordesc<64x64xf8E4M3FN, #shared>
+    %9 = ttng.reinterpret_tensor_descriptor %arg0 : !tt.ptr<i8, "descriptor"> to !tt.tensordesc<128x64xf8E4M3FN, #shared>
+    %10 = ttng.reinterpret_tensor_descriptor %arg1 : !tt.ptr<i8, "descriptor"> to !tt.tensordesc<64x64xf8E4M3FN, #shared>
     %true = arith.constant true
     %false = arith.constant false
     %11:2 = scf.for %arg6 = %c0_i32 to %8 step %c1_i32 iter_args(%arg7 = %cst, %arg8 = %c0_i32) -> (tensor<128x64xf32, #ttg.nvidia_mma<{versionMajor = 3, versionMinor = 0, warpsPerCTA = [8, 1], instrShape = [16, 64, 32]}>>, i32)  : i32 {
@@ -1058,7 +1058,7 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 8 : i32, ttg.targ
       scf.yield %18, %19 : tensor<128x64xf32, #mma>, i32
     }
     %12 = ttg.convert_layout %11#0 : tensor<128x64xf32, #mma> -> tensor<128x64xf32, #blocked>
-    %13 = ttng.reinterpret_tensor_descriptor %arg2 : !tt.ptr<i8, "flat"> to !tt.tensordesc<128x64xf32, #nvmma_128>
+    %13 = ttng.reinterpret_tensor_descriptor %arg2 : !tt.ptr<i8, "descriptor"> to !tt.tensordesc<128x64xf32, #nvmma_128>
     tt.descriptor_store %13[%5, %6], %12 : !tt.tensordesc<128x64xf32, #nvmma_128>, tensor<128x64xf32, #blocked>
     tt.return
   }

--- a/test/TritonGPU/pipeline-loop-nest.mlir
+++ b/test/TritonGPU/pipeline-loop-nest.mlir
@@ -5,7 +5,7 @@
 
 // BLACKWELL-LABEL: @matmul_kernel_tma_persistent
 // HOPPER-LABEL: @matmul_kernel_tma_persistent
-tt.func public @matmul_kernel_tma_persistent(%arg0: !tt.ptr<i8, 0>, %arg1: !tt.ptr<i8, 0>, %arg2: !tt.ptr<i8, 0>, %arg3: i32 {tt.divisibility = 16 : i32}, %arg4: i32 {tt.divisibility = 16 : i32}, %arg5: i32 {tt.divisibility = 16 : i32}) {
+tt.func public @matmul_kernel_tma_persistent(%arg0: !tt.ptr<i8, "flat">, %arg1: !tt.ptr<i8, "flat">, %arg2: !tt.ptr<i8, "flat">, %arg3: i32 {tt.divisibility = 16 : i32}, %arg4: i32 {tt.divisibility = 16 : i32}, %arg5: i32 {tt.divisibility = 16 : i32}) {
   %cst = arith.constant dense<0.000000e+00> : tensor<128x128xf32>
   %c63_i32 = arith.constant 63 : i32
   %c127_i32 = arith.constant 127 : i32
@@ -45,9 +45,9 @@ tt.func public @matmul_kernel_tma_persistent(%arg0: !tt.ptr<i8, 0>, %arg1: !tt.p
     %20 = arith.muli %18, %c128_i32 : i32
     %21 = scf.for %arg8 = %c0_i32 to %6 step %c1_i32 iter_args(%arg9 = %cst) -> (tensor<128x128xf32>)  : i32 {
       %35 = arith.muli %arg8, %c64_i32 : i32
-      %36 = ttng.reinterpret_tensor_descriptor %arg0 : !tt.ptr<i8, 0> to !tt.tensordesc<128x64xf16, #shared>
+      %36 = ttng.reinterpret_tensor_descriptor %arg0 : !tt.ptr<i8, "flat"> to !tt.tensordesc<128x64xf16, #shared>
       %37 = tt.descriptor_load %36[%19, %35] : !tt.tensordesc<128x64xf16, #shared> -> tensor<128x64xf16>
-      %38 = ttng.reinterpret_tensor_descriptor %arg1 : !tt.ptr<i8, 0> to !tt.tensordesc<128x64xf16, #shared>
+      %38 = ttng.reinterpret_tensor_descriptor %arg1 : !tt.ptr<i8, "flat"> to !tt.tensordesc<128x64xf16, #shared>
       %39 = tt.descriptor_load %38[%20, %35] : !tt.tensordesc<128x64xf16, #shared> -> tensor<128x64xf16>
       // BLACKWELL: ttg.memdesc_trans
       // BLACKWELL: [[ACC_BUF:%.*]] = ttg.memdesc_index [[ACC_BUFS]]
@@ -76,7 +76,7 @@ tt.func public @matmul_kernel_tma_persistent(%arg0: !tt.ptr<i8, 0>, %arg1: !tt.p
     %31 = arith.muli %28, %c128_i32 : i32
     %32 = arith.muli %30, %c128_i32 : i32
     %33 = arith.truncf %21 : tensor<128x128xf32> to tensor<128x128xf16>
-    %34 = ttng.reinterpret_tensor_descriptor %arg2 : !tt.ptr<i8, 0> to !tt.tensordesc<128x128xf16, #shared>
+    %34 = ttng.reinterpret_tensor_descriptor %arg2 : !tt.ptr<i8, "flat"> to !tt.tensordesc<128x128xf16, #shared>
     tt.descriptor_store %34[%31, %32], %33 : !tt.tensordesc<128x128xf16, #shared>, tensor<128x128xf16>
     scf.yield %22 : i32
   } {tt.flatten}

--- a/test/TritonGPU/pipeline-loop-nest.mlir
+++ b/test/TritonGPU/pipeline-loop-nest.mlir
@@ -5,7 +5,7 @@
 
 // BLACKWELL-LABEL: @matmul_kernel_tma_persistent
 // HOPPER-LABEL: @matmul_kernel_tma_persistent
-tt.func public @matmul_kernel_tma_persistent(%arg0: !tt.ptr<i8, "flat">, %arg1: !tt.ptr<i8, "flat">, %arg2: !tt.ptr<i8, "flat">, %arg3: i32 {tt.divisibility = 16 : i32}, %arg4: i32 {tt.divisibility = 16 : i32}, %arg5: i32 {tt.divisibility = 16 : i32}) {
+tt.func public @matmul_kernel_tma_persistent(%arg0: !tt.ptr<i8, "descriptor">, %arg1: !tt.ptr<i8, "descriptor">, %arg2: !tt.ptr<i8, "descriptor">, %arg3: i32 {tt.divisibility = 16 : i32}, %arg4: i32 {tt.divisibility = 16 : i32}, %arg5: i32 {tt.divisibility = 16 : i32}) {
   %cst = arith.constant dense<0.000000e+00> : tensor<128x128xf32>
   %c63_i32 = arith.constant 63 : i32
   %c127_i32 = arith.constant 127 : i32
@@ -45,9 +45,9 @@ tt.func public @matmul_kernel_tma_persistent(%arg0: !tt.ptr<i8, "flat">, %arg1: 
     %20 = arith.muli %18, %c128_i32 : i32
     %21 = scf.for %arg8 = %c0_i32 to %6 step %c1_i32 iter_args(%arg9 = %cst) -> (tensor<128x128xf32>)  : i32 {
       %35 = arith.muli %arg8, %c64_i32 : i32
-      %36 = ttng.reinterpret_tensor_descriptor %arg0 : !tt.ptr<i8, "flat"> to !tt.tensordesc<128x64xf16, #shared>
+      %36 = ttng.reinterpret_tensor_descriptor %arg0 : !tt.ptr<i8, "descriptor"> to !tt.tensordesc<128x64xf16, #shared>
       %37 = tt.descriptor_load %36[%19, %35] : !tt.tensordesc<128x64xf16, #shared> -> tensor<128x64xf16>
-      %38 = ttng.reinterpret_tensor_descriptor %arg1 : !tt.ptr<i8, "flat"> to !tt.tensordesc<128x64xf16, #shared>
+      %38 = ttng.reinterpret_tensor_descriptor %arg1 : !tt.ptr<i8, "descriptor"> to !tt.tensordesc<128x64xf16, #shared>
       %39 = tt.descriptor_load %38[%20, %35] : !tt.tensordesc<128x64xf16, #shared> -> tensor<128x64xf16>
       // BLACKWELL: ttg.memdesc_trans
       // BLACKWELL: [[ACC_BUF:%.*]] = ttg.memdesc_index [[ACC_BUFS]]
@@ -76,7 +76,7 @@ tt.func public @matmul_kernel_tma_persistent(%arg0: !tt.ptr<i8, "flat">, %arg1: 
     %31 = arith.muli %28, %c128_i32 : i32
     %32 = arith.muli %30, %c128_i32 : i32
     %33 = arith.truncf %21 : tensor<128x128xf32> to tensor<128x128xf16>
-    %34 = ttng.reinterpret_tensor_descriptor %arg2 : !tt.ptr<i8, "flat"> to !tt.tensordesc<128x128xf16, #shared>
+    %34 = ttng.reinterpret_tensor_descriptor %arg2 : !tt.ptr<i8, "descriptor"> to !tt.tensordesc<128x128xf16, #shared>
     tt.descriptor_store %34[%31, %32], %33 : !tt.tensordesc<128x128xf16, #shared>, tensor<128x128xf16>
     scf.yield %22 : i32
   } {tt.flatten}

--- a/test/TritonGPU/verify-blocked-layout.mlir
+++ b/test/TritonGPU/verify-blocked-layout.mlir
@@ -13,7 +13,7 @@ module attributes {
 } {
     tt.func public @fn(%arg0: !tt.ptr<i32>) {
         // expected-error @+1 {{threads per warp}}
-        %t = tt.splat %arg0 : !tt.ptr<i32,1> -> tensor<8x1x!tt.ptr<i32,1>, #blocked>
+        %t = tt.splat %arg0 : !tt.ptr<i32> -> tensor<8x1x!tt.ptr<i32>, #blocked>
         tt.return
     }
 }
@@ -33,7 +33,7 @@ module attributes {
 } {
     tt.func public @fn(%arg0: !tt.ptr<i32>) {
         // expected-error @+1 {{warps per CTA}}
-        %t = tt.splat %arg0 : !tt.ptr<i32,1> -> tensor<8x1x!tt.ptr<i32,1>, #blocked>
+        %t = tt.splat %arg0 : !tt.ptr<i32> -> tensor<8x1x!tt.ptr<i32>, #blocked>
         tt.return
     }
 }
@@ -53,7 +53,7 @@ module attributes {
 } {
     tt.func public @fn(%arg0: !tt.ptr<i32>) {
         // expected-error @+1 {{CTAs per CGA}}
-        %t = tt.splat %arg0 : !tt.ptr<i32,1> -> tensor<8x1x!tt.ptr<i32,1>, #blocked>
+        %t = tt.splat %arg0 : !tt.ptr<i32> -> tensor<8x1x!tt.ptr<i32>, #blocked>
         tt.return
     }
 }
@@ -74,7 +74,7 @@ module attributes {
     tt.func public @fn(%arg0: !tt.ptr<i32>) {
         // Note it's a 3d tensor here, but #blocked is 2D.
         // expected-error @+1 {{rank}}
-        %t = tt.splat %arg0 : !tt.ptr<i32,1> -> tensor<8x1x1x!tt.ptr<i32,1>, #blocked>
+        %t = tt.splat %arg0 : !tt.ptr<i32> -> tensor<8x1x1x!tt.ptr<i32>, #blocked>
         tt.return
     }
 }

--- a/third_party/amd/include/TritonAMDGPUToLLVM/TypeConverter.h
+++ b/third_party/amd/include/TritonAMDGPUToLLVM/TypeConverter.h
@@ -9,6 +9,7 @@
 #include "triton/Conversion/TritonGPUToLLVM/TypeConverter.h"
 #include "triton/Dialect/Triton/IR/Types.h"
 #include "triton/Dialect/TritonGPU/IR/Types.h"
+#include "llvm/Support/AMDGPUAddrSpace.h"
 
 using namespace mlir;
 using namespace mlir::triton;
@@ -20,6 +21,17 @@ public:
                                   const TargetInfoBase &targetInfo,
                                   const DataLayoutAnalysis *analysis = nullptr)
       : TritonGPUToLLVMTypeConverter(ctx, options, targetInfo, analysis) {
+    // Override the base conversion (last registration wins) with the AMDGPU
+    // address spaces.
+    addConversion([ctx](triton::PointerType type) -> std::optional<Type> {
+      switch (type.getAddressSpace()) {
+      case triton::PtrAddrSpace::Global:
+        return LLVM::LLVMPointerType::get(ctx, llvm::AMDGPUAS::GLOBAL_ADDRESS);
+      case triton::PtrAddrSpace::Flat:
+        return LLVM::LLVMPointerType::get(ctx, llvm::AMDGPUAS::FLAT_ADDRESS);
+      }
+      llvm_unreachable("unknown PtrAddrSpace");
+    });
     addConversion([&](TensorDescType type) -> std::optional<Type> {
       return convertTensorDescType(type);
     });

--- a/third_party/amd/include/TritonAMDGPUToLLVM/TypeConverter.h
+++ b/third_party/amd/include/TritonAMDGPUToLLVM/TypeConverter.h
@@ -27,7 +27,7 @@ public:
       switch (type.getAddressSpace()) {
       case triton::PtrAddrSpace::Global:
         return LLVM::LLVMPointerType::get(ctx, llvm::AMDGPUAS::GLOBAL_ADDRESS);
-      case triton::PtrAddrSpace::Flat:
+      case triton::PtrAddrSpace::Descriptor:
         return LLVM::LLVMPointerType::get(ctx, llvm::AMDGPUAS::FLAT_ADDRESS);
       }
       llvm_unreachable("unknown PtrAddrSpace");

--- a/third_party/amd/lib/Dialect/TritonAMDGPU/IR/Dialect.cpp
+++ b/third_party/amd/lib/Dialect/TritonAMDGPU/IR/Dialect.cpp
@@ -751,8 +751,7 @@ LogicalResult BufferLoadToLocalOp::verify() {
 
 // A buffer write's scalar base must be global memory (address space 1).
 static LogicalResult verifyBufferWriteBase(Operation *op, Value ptr) {
-  constexpr int kGlobalAddressSpace = 1;
-  if (triton::getAddressSpace(ptr.getType()) != kGlobalAddressSpace)
+  if (triton::getAddressSpace(ptr.getType()) != triton::PtrAddrSpace::Global)
     return op->emitOpError("buffer writes require a global address space base");
   return success();
 }

--- a/third_party/proton/Dialect/include/Conversion/ProtonGPUToLLVM/ProtonAMDGPUToLLVM/TargetInfo.h
+++ b/third_party/proton/Dialect/include/Conversion/ProtonGPUToLLVM/ProtonAMDGPUToLLVM/TargetInfo.h
@@ -25,6 +25,8 @@ public:
 
   int getAddressSpace(Attribute addressSpace) const override;
 
+  unsigned getPtrAddressSpace(triton::PtrAddrSpace space) const override;
+
   int getIndexPtrAddrSpace() const override;
 
   ~TargetInfo() = default;

--- a/third_party/proton/Dialect/include/Conversion/ProtonGPUToLLVM/ProtonNvidiaGPUToLLVM/TargetInfo.h
+++ b/third_party/proton/Dialect/include/Conversion/ProtonGPUToLLVM/ProtonNvidiaGPUToLLVM/TargetInfo.h
@@ -25,6 +25,8 @@ public:
 
   int getAddressSpace(Attribute addressSpace) const override;
 
+  unsigned getPtrAddressSpace(triton::PtrAddrSpace space) const override;
+
   int getIndexPtrAddrSpace() const override;
 
   ~TargetInfo() {}

--- a/third_party/proton/Dialect/include/Conversion/ProtonGPUToLLVM/TargetInfoBase.h
+++ b/third_party/proton/Dialect/include/Conversion/ProtonGPUToLLVM/TargetInfoBase.h
@@ -31,6 +31,9 @@ public:
 
   virtual int getAddressSpace(Attribute addressSpace) const = 0;
 
+  // Map a `!tt.ptr` address space to this backend's LLVM address space.
+  virtual unsigned getPtrAddressSpace(triton::PtrAddrSpace space) const = 0;
+
   virtual int getIndexPtrAddrSpace() const = 0;
 
   virtual ~TargetInfoBase() = default;

--- a/third_party/proton/Dialect/lib/ProtonGPUToLLVM/PatternProtonGPUOpToLLVM.cpp
+++ b/third_party/proton/Dialect/lib/ProtonGPUToLLVM/PatternProtonGPUOpToLLVM.cpp
@@ -751,7 +751,8 @@ void populateTypeConversions(LLVMTypeConverter &typeConverter,
   typeConverter.addConversion(
       [&](triton::PointerType type) -> std::optional<Type> {
         auto ctx = type.getContext();
-        return LLVM::LLVMPointerType::get(ctx, type.getAddressSpace());
+        return LLVM::LLVMPointerType::get(
+            ctx, targetInfo.getPtrAddressSpace(type.getAddressSpace()));
       });
 }
 

--- a/third_party/proton/Dialect/lib/ProtonGPUToLLVM/ProtonAMDGPUToLLVM/TargetInfo.cpp
+++ b/third_party/proton/Dialect/lib/ProtonGPUToLLVM/ProtonAMDGPUToLLVM/TargetInfo.cpp
@@ -220,7 +220,7 @@ unsigned TargetInfo::getPtrAddressSpace(triton::PtrAddrSpace space) const {
   switch (space) {
   case triton::PtrAddrSpace::Global:
     return llvm::AMDGPUAS::GLOBAL_ADDRESS;
-  case triton::PtrAddrSpace::Flat:
+  case triton::PtrAddrSpace::Descriptor:
     return llvm::AMDGPUAS::FLAT_ADDRESS;
   }
   llvm_unreachable("unknown PtrAddrSpace");

--- a/third_party/proton/Dialect/lib/ProtonGPUToLLVM/ProtonAMDGPUToLLVM/TargetInfo.cpp
+++ b/third_party/proton/Dialect/lib/ProtonGPUToLLVM/ProtonAMDGPUToLLVM/TargetInfo.cpp
@@ -4,6 +4,7 @@
 #include "mlir/Dialect/LLVMIR/LLVMTypes.h"
 #include "third_party/amd/include/TritonAMDGPUToLLVM/GCNAsmFormat.h"
 #include "triton/Conversion/TritonGPUToLLVM/Utility.h"
+#include "llvm/Support/AMDGPUAddrSpace.h"
 #include "llvm/Support/MathExtras.h"
 
 namespace mlir::triton::proton::gpu::AMD {
@@ -213,6 +214,16 @@ int TargetInfo::getAddressSpace(Attribute addressSpace) const {
                              "and GlobalMemorySpace for now");
   }
   return spaceId;
+}
+
+unsigned TargetInfo::getPtrAddressSpace(triton::PtrAddrSpace space) const {
+  switch (space) {
+  case triton::PtrAddrSpace::Global:
+    return llvm::AMDGPUAS::GLOBAL_ADDRESS;
+  case triton::PtrAddrSpace::Flat:
+    return llvm::AMDGPUAS::FLAT_ADDRESS;
+  }
+  llvm_unreachable("unknown PtrAddrSpace");
 }
 
 int TargetInfo::getIndexPtrAddrSpace() const {

--- a/third_party/proton/Dialect/lib/ProtonGPUToLLVM/ProtonNvidiaGPUToLLVM/TargetInfo.cpp
+++ b/third_party/proton/Dialect/lib/ProtonGPUToLLVM/ProtonNvidiaGPUToLLVM/TargetInfo.cpp
@@ -73,7 +73,7 @@ unsigned TargetInfo::getPtrAddressSpace(triton::PtrAddrSpace space) const {
   switch (space) {
   case triton::PtrAddrSpace::Global:
     return llvm::NVPTXAS::ADDRESS_SPACE_GLOBAL;
-  case triton::PtrAddrSpace::Flat:
+  case triton::PtrAddrSpace::Descriptor:
     return llvm::NVPTXAS::ADDRESS_SPACE_GENERIC;
   }
   llvm_unreachable("unknown PtrAddrSpace");

--- a/third_party/proton/Dialect/lib/ProtonGPUToLLVM/ProtonNvidiaGPUToLLVM/TargetInfo.cpp
+++ b/third_party/proton/Dialect/lib/ProtonGPUToLLVM/ProtonNvidiaGPUToLLVM/TargetInfo.cpp
@@ -6,6 +6,7 @@
 #include "third_party/nvidia/include/TritonNVIDIAGPUToLLVM/PTXAsmFormat.h"
 #include "third_party/nvidia/lib/TritonNVIDIAGPUToLLVM/Utility.h" // TODO(fywkevin): move Utility.h to include/
 #include "llvm/Support/MathExtras.h"
+#include "llvm/Support/NVPTXAddrSpace.h"
 
 namespace mlir::triton::proton::gpu::NVIDIA {
 
@@ -66,6 +67,16 @@ int TargetInfo::getAddressSpace(Attribute addressSpace) const {
                              "and GlobalMemorySpace for now");
   }
   return spaceId;
+}
+
+unsigned TargetInfo::getPtrAddressSpace(triton::PtrAddrSpace space) const {
+  switch (space) {
+  case triton::PtrAddrSpace::Global:
+    return llvm::NVPTXAS::ADDRESS_SPACE_GLOBAL;
+  case triton::PtrAddrSpace::Flat:
+    return llvm::NVPTXAS::ADDRESS_SPACE_GENERIC;
+  }
+  llvm_unreachable("unknown PtrAddrSpace");
 }
 
 int TargetInfo::getIndexPtrAddrSpace() const {


### PR DESCRIPTION
### Context

Motivated by https://github.com/triton-lang/triton/pull/11294#discussion_r3815478213. This only touches the address spaces already present (`global`, and `flat` = the LLVM flat/generic space, used today only for NV TMA descriptors).

tt.ptr's address space was a bare integer (!tt.ptr<i8, 0>), so a reader had to know that 0 means the flat/generic space and 1 means global. This makes the address space a named enum that prints as a keyword in the IR: !tt.ptr<i8,"flat">, with the default "global" elided. This is so that the IR is self-describing and the keyword vocabulary has a single source of truth.

### Implementation

  - Single source of truth: a TableGen `I32EnumAttr (PtrAddrSpace)` defines the vocabulary once, and get symbolize/stringify for free.
  - IR spelling: PointerType stores the enum; the custom parser/printer spell it as a quoted keyword and elide the default "global".
  - Per-backend lowering: each backend maps the enum to its own LLVM address space in the type converter

### Review

  1. [Triton] Represent tt.ptr address space as a named enum:
     - the implementation: the enum.
     - the PointerType storage + parser/printer.
     - the per-backend converters.
     - the frontend binding.
  2. [Triton] Update tests for the named tt.ptr address space.

