### PR TITLE
[NVIDIA] Use block-scaled MMA with unit scales for fp8 dot on sm120

### DIFF
--- a/lib/Dialect/TritonGPU/Transforms/AccelerateMatmul.cpp
+++ b/lib/Dialect/TritonGPU/Transforms/AccelerateMatmul.cpp
@@ -707,6 +707,101 @@ public:
   }
 };
 
+// Whether the native sm120 block-scaled MMA path implemented by
+// ScaledBlockedToMMA is available. Shared by ScaledBlockedToMMA and
+// SM120FP8DotToDotScaled so that their applicability cannot drift apart: if
+// the former stopped matching while the latter still fired, the created
+// tt.dot_scaled would be decomposed into an upcast + f16 dot, which is slower
+// than the plain fp8 MMA.
+static bool sm120SupportsNativeScaledDot(int computeCapability,
+                                         PatternRewriter &rewriter) {
+  return computeCapability / 10 == 12 && lookupNumCTAs(rewriter) == 1;
+}
+
+// On consumer Blackwell (sm120), the plain fp8 MMA (kind::f8f6f4) runs at
+// half the throughput of the block-scaled MXFP8 MMA
+// (kind::mxf8f6f4.block_scale). Rewrite fp8 tt.dot into tt.dot_scaled with
+// all scales set to 1.0 (E8M0 value 127) so that ScaledBlockedToMMA lowers it
+// to the full-rate instruction. Scaling by 1.0 is exact, so the result is
+// bit-identical to the plain fp8 MMA.
+class SM120FP8DotToDotScaled : public mlir::OpRewritePattern<triton::DotOp> {
+  int computeCapability;
+
+public:
+  SM120FP8DotToDotScaled(mlir::MLIRContext *context, int computeCapability,
+                         int benefit)
+      : mlir::OpRewritePattern<triton::DotOp>(context, benefit),
+        computeCapability(computeCapability) {}
+
+  mlir::LogicalResult
+  matchAndRewrite(triton::DotOp dotOp,
+                  mlir::PatternRewriter &rewriter) const override {
+    if (computeCapability / 10 != 12)
+      return failure();
+    RankedTensorType retType = dotOp.getType();
+    if (!retType.getEncoding() ||
+        mlir::isa<NvidiaMmaEncodingAttr>(retType.getEncoding()))
+      return failure();
+    // The sm120 block-scaled MMA lowering only supports rank-2 dots with an
+    // f32 accumulator.
+    if (retType.getRank() != 2 || !retType.getElementType().isF32())
+      return failure();
+    auto toScaleDotElemType = [](Type type) -> std::optional<ScaleDotElemType> {
+      if (llvm::isa<Float8E4M3FNType>(type))
+        return ScaleDotElemType::E4M3;
+      if (llvm::isa<Float8E5M2Type>(type))
+        return ScaleDotElemType::E5M2;
+      return std::nullopt;
+    };
+    auto aElemType =
+        toScaleDotElemType(dotOp.getA().getType().getElementType());
+    auto bElemType =
+        toScaleDotElemType(dotOp.getB().getType().getElementType());
+    if (!aElemType || !bElemType)
+      return failure();
+    // Each E8M0 scale covers 32 fp8 elements along K, and the scale layout
+    // assumes full m16n8k32 tiles. Smaller dots keep the plain fp8 MMA.
+    constexpr int64_t kScaleGroupSize = 32;
+    int64_t kDim = dotOp.getA().getType().getShape().back();
+    if (retType.getShape()[0] % 16 != 0 || retType.getShape()[1] % 8 != 0 ||
+        kDim % kScaleGroupSize != 0)
+      return failure();
+    if (!sm120SupportsNativeScaledDot(computeCapability, rewriter))
+      return failure();
+    // BlockedToMMA picks the dot operand kWidth from the width of the
+    // originating loads; ScaledBlockedToMMA always uses the fp8 element
+    // width. Keep dots whose operands come from narrower (packed) loads on
+    // the plain path so they do not lose the wider kWidth.
+    if (std::min(computeOrigBitWidth(dotOp.getA()),
+                 computeOrigBitWidth(dotOp.getB())) < 8)
+      return failure();
+
+    MLIRContext *ctx = dotOp.getContext();
+    Location loc = dotOp.getLoc();
+    int numWarps = lookupNumWarps(dotOp);
+    int threadsPerWarp = lookupThreadsPerWarp(rewriter);
+    // E8M0 encodes 2^(x - 127), so 127 is exactly 1.0.
+    auto createUnitScale = [&](int64_t mnDim) -> Value {
+      SmallVector<int64_t> scaleShape{mnDim, kDim / kScaleGroupSize};
+      auto encoding = getDefaultBlockedEncoding(ctx, scaleShape, numWarps,
+                                                threadsPerWarp, /*numCTAs=*/1);
+      auto scaleType =
+          RankedTensorType::get(scaleShape, rewriter.getI8Type(), encoding);
+      return arith::ConstantOp::create(
+          rewriter, loc, scaleType,
+          DenseElementsAttr::get(scaleType, APInt(8, 127)));
+    };
+    Value aScale = createUnitScale(retType.getShape()[0]);
+    Value bScale = createUnitScale(retType.getShape()[1]);
+    // The scales are finite constants, so NaN propagation is irrelevant and
+    // fastMath is safe.
+    rewriter.replaceOpWithNewOp<DotScaledOp>(
+        dotOp, retType, dotOp.getA(), dotOp.getB(), dotOp.getC(), aScale,
+        bScale, *aElemType, *bElemType, /*fastMath=*/true);
+    return success();
+  }
+};
+
 class ScaledBlockedToMMA : public mlir::OpRewritePattern<triton::DotScaledOp> {
   int computeCapability;
 
@@ -719,13 +814,8 @@ public:
   mlir::LogicalResult
   matchAndRewrite(triton::DotScaledOp dotOp,
                   mlir::PatternRewriter &rewriter) const override {
-    if (computeCapability / 10 != 12)
+    if (!sm120SupportsNativeScaledDot(computeCapability, rewriter))
       return failure();
-
-    auto numCTAs = lookupNumCTAs(rewriter);
-    if (numCTAs != 1) {
-      return failure();
-    }
     // Skip if any scale is missing. This pattern requires both scales.
     if (!dotOp.getAScale() || !dotOp.getBScale())
       return failure();
@@ -1100,6 +1190,8 @@ public:
     constexpr int benefitSM120 = 10;
 
     patterns.add<BlockedToMMA>(context, computeCapability, benefitDefault);
+    patterns.add<SM120FP8DotToDotScaled>(context, computeCapability,
+                                         benefitSM120);
     patterns.add<ScaledBlockedToMMA>(context, computeCapability, benefitSM120);
     populateDecomposeScaledBlockedPatterns(patterns, benefitDefault);
     patterns.add<BlockedToMMAv5, ScaledBlockedToMMAv5>(

--- a/python/test/unit/language/test_core.py
+++ b/python/test/unit/language/test_core.py
@@ -4094,7 +4094,10 @@ def test_dot(M, N, K, num_warps, col_a, col_b, epilogue, input_precision, in_dty
             assert 'wgmma.mma_async.sync.aligned' in ptx or\
                 'mma.sync.aligned.m16n8k32.row.col.satfinite.s32.s8.s8.s32' in ptx
     elif in_dtype == "float8e5" and out_dtype == tl.float32:
-        if capability[0] == 9 and M >= 64 and N >= 8:
+        if capability[0] == 12 and M % 16 == 0 and N % 8 == 0 and K % 32 == 0:
+            # sm120 fp8 dots use the full-rate block-scaled MMA with unit scales
+            assert 'mma.sync.aligned.m16n8k32.row.col.kind::mxf8f6f4.block_scale.scale_vec::1X' in ptx
+        elif capability[0] == 9 and M >= 64 and N >= 8:
             assert 'wgmma.mma_async.sync.aligned.m64n128k32.f32.e5m2.e5m2' in ptx
         elif capability[0] >= 8 and M < 64:
             if capability == (8, 9) or capability[0] == 12:
@@ -4102,7 +4105,10 @@ def test_dot(M, N, K, num_warps, col_a, col_b, epilogue, input_precision, in_dty
             else:
                 assert 'mma.sync.aligned.m16n8k16.row.col.f32.f16.f16.f32' in ptx
     elif in_dtype == "float8e4nv" and out_dtype == tl.float32:
-        if capability[0] == 9 and M >= 64 and N >= 8:
+        if capability[0] == 12 and M % 16 == 0 and N % 8 == 0 and K % 32 == 0:
+            # sm120 fp8 dots use the full-rate block-scaled MMA with unit scales
+            assert 'mma.sync.aligned.m16n8k32.row.col.kind::mxf8f6f4.block_scale.scale_vec::1X' in ptx
+        elif capability[0] == 9 and M >= 64 and N >= 8:
             assert 'wgmma.mma_async.sync.aligned.m64n128k32.f32.e4m3.e4m3' in ptx
     if is_tcgen5 and epilogue == 'softmax' and M >= 128:
         # check that there is no shared memory exchange in the softmax

--- a/test/Conversion/tritongpu_to_llvm_sm120.mlir
+++ b/test/Conversion/tritongpu_to_llvm_sm120.mlir
@@ -27,4 +27,25 @@ module attributes {"ttg.target" = "cuda:120", "ttg.num-ctas" = 1 : i32, "ttg.num
     tt.store %out_ptrs, %d, %zero : tensor<128x128x!tt.ptr<f32>, #blocked>
     tt.return
   }
+
+  // A plain fp8 tt.dot must be rewritten to use the full-rate block-scaled
+  // MMA with unit scales instead of the half-rate plain fp8 MMA.
+  // CHECK-LABEL: @sm120_fp8_dot_block_scaled
+  // CHECK: mma.sync.aligned.m16n8k32.row.col.kind::mxf8f6f4.block_scale.scale_vec::1X
+  // CHECK-NOT: mma.sync.aligned.m16n8k32.row.col.f32.e4m3.e4m3.f32
+  tt.func public @sm120_fp8_dot_block_scaled(
+    %a: tensor<128x32xf8E4M3FN, #blocked_k>,
+    %b: tensor<32x128xf8E4M3FN, #blocked>,
+    %out: !tt.ptr<f32>
+  ){
+    %c = arith.constant dense<0.000000e+00> : tensor<128x128xf32, #blocked>
+    %a_d = ttg.convert_layout %a : tensor<128x32xf8E4M3FN, #blocked_k> -> tensor<128x32xf8E4M3FN, #ttg.dot_op<{opIdx = 0, parent = #blocked}>>
+    %b_d = ttg.convert_layout %b : tensor<32x128xf8E4M3FN, #blocked> -> tensor<32x128xf8E4M3FN, #ttg.dot_op<{opIdx = 1, parent = #blocked}>>
+    %d = tt.dot %a_d, %b_d, %c : tensor<128x32xf8E4M3FN, #ttg.dot_op<{opIdx = 0, parent = #blocked}>> * tensor<32x128xf8E4M3FN, #ttg.dot_op<{opIdx = 1, parent = #blocked}>> -> tensor<128x128xf32, #blocked>
+    %out_splat = tt.splat %out : !tt.ptr<f32> -> tensor<128x1x!tt.ptr<f32>, #blocked>
+    %out_ptrs = tt.broadcast %out_splat : tensor<128x1x!tt.ptr<f32>, #blocked> -> tensor<128x128x!tt.ptr<f32>, #blocked>
+    %zero = arith.constant dense<0> : tensor<128x128xi1, #blocked>
+    tt.store %out_ptrs, %d, %zero : tensor<128x128x!tt.ptr<f32>, #blocked>
+    tt.return
+  }
 }

--- a/test/TritonGPU/accelerate-matmul.mlir
+++ b/test/TritonGPU/accelerate-matmul.mlir
@@ -765,6 +765,9 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.targ
 #blocked1 = #ttg.blocked<{sizePerThread = [1, 16], threadsPerWarp = [4, 8], warpsPerCTA = [8, 1], order = [1, 0]}>
 #blocked2 = #ttg.blocked<{sizePerThread = [16, 1], threadsPerWarp = [8, 4], warpsPerCTA = [1, 8], order = [0, 1]}>
 module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 8 : i32, ttg.target = "cuda:120", "ttg.threads-per-warp" = 32 : i32} {
+  // Verify that on SM_120 a plain fp8 tt.dot is rewritten into tt.dot_scaled
+  // with unit scales (E8M0 127 == 1.0) so it uses the full-rate block-scaled
+  // MMA instead of the half-rate plain fp8 MMA.
   // CHECK-LABEL: sm120_fp8_dot
   tt.func public @sm120_fp8_dot(%arg0: tensor<128x256xf32, #blocked>, %arg1: tensor<128x128x!tt.ptr<f8E4M3FN>, #blocked1>, %arg2: tensor<128x256x!tt.ptr<f8E4M3FN>, #blocked2>, %arg3: tensor<128x128xi1, #blocked1>, %arg4: tensor<128x256xi1, #blocked2>) -> tensor<128x256xf32, #blocked> {
     %cst = arith.constant dense<0.000000e+00> : tensor<128x256xf8E4M3FN, #blocked2>
@@ -773,9 +776,130 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 8 : i32, ttg.targ
     %1 = tt.load %arg2, %arg4, %cst : tensor<128x256x!tt.ptr<f8E4M3FN>, #blocked2>
     %2 = ttg.convert_layout %0 : tensor<128x128xf8E4M3FN, #blocked1> -> tensor<128x128xf8E4M3FN, #ttg.dot_op<{opIdx = 0, parent = #blocked}>>
     %3 = ttg.convert_layout %1 : tensor<128x256xf8E4M3FN, #blocked2> -> tensor<128x256xf8E4M3FN, #ttg.dot_op<{opIdx = 1, parent = #blocked}>>
-    // CHECK: {{.*}} = tt.dot {{.*}} tensor<128x128xf8E4M3FN
+    // CHECK-DAG: arith.constant dense<127> : tensor<128x4xi8
+    // CHECK-DAG: arith.constant dense<127> : tensor<256x4xi8
+    // CHECK: tt.dot_scaled {{.*}} lhs = e4m3 rhs = e4m3
+    // CHECK-NOT: tt.dot %
     %4 = tt.dot %2, %3, %arg0, inputPrecision = tf32 : tensor<128x128xf8E4M3FN, #ttg.dot_op<{opIdx = 0, parent = #blocked}>> * tensor<128x256xf8E4M3FN, #ttg.dot_op<{opIdx = 1, parent = #blocked}>> -> tensor<128x256xf32, #blocked>
     tt.return %4 : tensor<128x256xf32, #blocked>
+  }
+}
+
+// -----
+
+// Verify that on SM_120 an fp8 tt.dot with mixed fp8 element types is also
+// rewritten into a unit-scale tt.dot_scaled.
+
+#blocked = #ttg.blocked<{sizePerThread = [4, 4], threadsPerWarp = [1, 32], warpsPerCTA = [4, 2], order = [1, 0]}>
+module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 8 : i32, ttg.target = "cuda:120", "ttg.threads-per-warp" = 32 : i32} {
+  // CHECK-LABEL: sm120_fp8_dot_mixed
+  tt.func public @sm120_fp8_dot_mixed(%arg0: tensor<128x128xf8E5M2, #ttg.dot_op<{opIdx = 0, parent = #blocked}>>, %arg1: tensor<128x256xf8E4M3FN, #ttg.dot_op<{opIdx = 1, parent = #blocked}>>) -> tensor<128x256xf32, #blocked> {
+    %cst = arith.constant dense<0.000000e+00> : tensor<128x256xf32, #blocked>
+    // CHECK: tt.dot_scaled {{.*}} lhs = e5m2 rhs = e4m3
+    %0 = tt.dot %arg0, %arg1, %cst : tensor<128x128xf8E5M2, #ttg.dot_op<{opIdx = 0, parent = #blocked}>> * tensor<128x256xf8E4M3FN, #ttg.dot_op<{opIdx = 1, parent = #blocked}>> -> tensor<128x256xf32, #blocked>
+    tt.return %0 : tensor<128x256xf32, #blocked>
+  }
+}
+
+// -----
+
+// Verify that on SM_120 an fp8 tt.dot with an f16 accumulator keeps the plain
+// fp8 MMA path; the block-scaled MMA only supports f32 accumulators.
+
+#blocked = #ttg.blocked<{sizePerThread = [4, 4], threadsPerWarp = [1, 32], warpsPerCTA = [4, 2], order = [1, 0]}>
+module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 8 : i32, ttg.target = "cuda:120", "ttg.threads-per-warp" = 32 : i32} {
+  // CHECK-LABEL: sm120_fp8_dot_f16_acc
+  tt.func public @sm120_fp8_dot_f16_acc(%arg0: tensor<128x128xf8E4M3FN, #ttg.dot_op<{opIdx = 0, parent = #blocked}>>, %arg1: tensor<128x256xf8E4M3FN, #ttg.dot_op<{opIdx = 1, parent = #blocked}>>) -> tensor<128x256xf16, #blocked> {
+    %cst = arith.constant dense<0.000000e+00> : tensor<128x256xf16, #blocked>
+    // CHECK-NOT: tt.dot_scaled
+    // CHECK: tt.dot %
+    %0 = tt.dot %arg0, %arg1, %cst : tensor<128x128xf8E4M3FN, #ttg.dot_op<{opIdx = 0, parent = #blocked}>> * tensor<128x256xf8E4M3FN, #ttg.dot_op<{opIdx = 1, parent = #blocked}>> -> tensor<128x256xf16, #blocked>
+    tt.return %0 : tensor<128x256xf16, #blocked>
+  }
+}
+
+// -----
+
+// Verify that on SM_120 an fp8 tt.dot with K smaller than the 32-element
+// scale group keeps the plain fp8 MMA path.
+
+#blocked = #ttg.blocked<{sizePerThread = [4, 4], threadsPerWarp = [1, 32], warpsPerCTA = [4, 2], order = [1, 0]}>
+module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 8 : i32, ttg.target = "cuda:120", "ttg.threads-per-warp" = 32 : i32} {
+  // CHECK-LABEL: sm120_fp8_dot_small_k
+  tt.func public @sm120_fp8_dot_small_k(%arg0: tensor<128x16xf8E4M3FN, #ttg.dot_op<{opIdx = 0, parent = #blocked}>>, %arg1: tensor<16x256xf8E4M3FN, #ttg.dot_op<{opIdx = 1, parent = #blocked}>>) -> tensor<128x256xf32, #blocked> {
+    %cst = arith.constant dense<0.000000e+00> : tensor<128x256xf32, #blocked>
+    // CHECK-NOT: tt.dot_scaled
+    // CHECK: tt.dot %
+    %0 = tt.dot %arg0, %arg1, %cst : tensor<128x16xf8E4M3FN, #ttg.dot_op<{opIdx = 0, parent = #blocked}>> * tensor<16x256xf8E4M3FN, #ttg.dot_op<{opIdx = 1, parent = #blocked}>> -> tensor<128x256xf32, #blocked>
+    tt.return %0 : tensor<128x256xf32, #blocked>
+  }
+}
+
+// -----
+
+// Verify that on SM_120 an fp8 tt.dot whose M dimension is not a multiple of
+// the m16n8k32 tile keeps the plain fp8 MMA path.
+
+#blocked = #ttg.blocked<{sizePerThread = [4, 4], threadsPerWarp = [1, 32], warpsPerCTA = [4, 2], order = [1, 0]}>
+module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 8 : i32, ttg.target = "cuda:120", "ttg.threads-per-warp" = 32 : i32} {
+  // CHECK-LABEL: sm120_fp8_dot_unaligned_m
+  tt.func public @sm120_fp8_dot_unaligned_m(%arg0: tensor<8x64xf8E4M3FN, #ttg.dot_op<{opIdx = 0, parent = #blocked}>>, %arg1: tensor<64x128xf8E4M3FN, #ttg.dot_op<{opIdx = 1, parent = #blocked}>>) -> tensor<8x128xf32, #blocked> {
+    %cst = arith.constant dense<0.000000e+00> : tensor<8x128xf32, #blocked>
+    // CHECK-NOT: tt.dot_scaled
+    // CHECK: tt.dot %
+    %0 = tt.dot %arg0, %arg1, %cst : tensor<8x64xf8E4M3FN, #ttg.dot_op<{opIdx = 0, parent = #blocked}>> * tensor<64x128xf8E4M3FN, #ttg.dot_op<{opIdx = 1, parent = #blocked}>> -> tensor<8x128xf32, #blocked>
+    tt.return %0 : tensor<8x128xf32, #blocked>
+  }
+}
+
+// -----
+
+// Verify that on SM_120 an fp8 tt.dot whose operand is unpacked from fp4 data
+// keeps the plain fp8 MMA path: BlockedToMMA picks a wider kWidth for such
+// operands (via computeOrigBitWidth), which the block-scaled path would lose.
+
+#blocked = #ttg.blocked<{sizePerThread = [4, 4], threadsPerWarp = [1, 32], warpsPerCTA = [4, 2], order = [1, 0]}>
+#blocked_pack = #ttg.blocked<{sizePerThread = [1, 4], threadsPerWarp = [32, 1], warpsPerCTA = [8, 1], order = [1, 0]}>
+module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 8 : i32, ttg.target = "cuda:120", "ttg.threads-per-warp" = 32 : i32} {
+  // CHECK-LABEL: sm120_fp8_dot_packed_operand
+  tt.func public @sm120_fp8_dot_packed_operand(%arg0: tensor<128x32xi8, #blocked_pack>, %arg1: tensor<64x128xf8E4M3FN, #ttg.dot_op<{opIdx = 1, parent = #blocked}>>) -> tensor<128x128xf32, #blocked> {
+    %cst = arith.constant dense<0.000000e+00> : tensor<128x128xf32, #blocked>
+    %0 = ttg.fp4_to_fp %arg0 {axis = 1 : i32} : tensor<128x32xi8, #blocked_pack> -> tensor<128x64xbf16, #blocked_pack>
+    %1 = tt.fp_to_fp %0, rounding = rtne : tensor<128x64xbf16, #blocked_pack> -> tensor<128x64xf8E4M3FN, #blocked_pack>
+    %2 = ttg.convert_layout %1 : tensor<128x64xf8E4M3FN, #blocked_pack> -> tensor<128x64xf8E4M3FN, #ttg.dot_op<{opIdx = 0, parent = #blocked}>>
+    // CHECK-NOT: tt.dot_scaled
+    // CHECK: tt.dot {{.*}} kWidth = 8
+    %3 = tt.dot %2, %arg1, %cst : tensor<128x64xf8E4M3FN, #ttg.dot_op<{opIdx = 0, parent = #blocked}>> * tensor<64x128xf8E4M3FN, #ttg.dot_op<{opIdx = 1, parent = #blocked}>> -> tensor<128x128xf32, #blocked>
+    tt.return %3 : tensor<128x128xf32, #blocked>
+  }
+}
+
+// -----
+
+// The packed-operand walk stops at block arguments (computeOrigBitWidth uses
+// omitBlockArguments), so a loop-carried fp8 operand takes the block-scaled
+// path. This matches BlockedToMMA, which uses the same walk and would pick
+// the same kWidth = 4 for this dot. If computeOrigBitWidth learns to look
+// through block arguments, both paths change together and this test should be
+// updated.
+
+#blocked = #ttg.blocked<{sizePerThread = [4, 4], threadsPerWarp = [1, 32], warpsPerCTA = [4, 2], order = [1, 0]}>
+#blocked_pack = #ttg.blocked<{sizePerThread = [1, 4], threadsPerWarp = [32, 1], warpsPerCTA = [8, 1], order = [1, 0]}>
+module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 8 : i32, ttg.target = "cuda:120", "ttg.threads-per-warp" = 32 : i32} {
+  // CHECK-LABEL: sm120_fp8_dot_packed_operand_loop
+  tt.func public @sm120_fp8_dot_packed_operand_loop(%arg0: tensor<128x32xi8, #blocked_pack>, %arg1: tensor<64x128xf8E4M3FN, #ttg.dot_op<{opIdx = 1, parent = #blocked}>>, %arg2: i32) -> tensor<128x128xf32, #blocked> {
+    %c0_i32 = arith.constant 0 : i32
+    %c1_i32 = arith.constant 1 : i32
+    %cst = arith.constant dense<0.000000e+00> : tensor<128x128xf32, #blocked>
+    %0 = ttg.fp4_to_fp %arg0 {axis = 1 : i32} : tensor<128x32xi8, #blocked_pack> -> tensor<128x64xbf16, #blocked_pack>
+    %1 = tt.fp_to_fp %0, rounding = rtne : tensor<128x64xbf16, #blocked_pack> -> tensor<128x64xf8E4M3FN, #blocked_pack>
+    // CHECK: tt.dot_scaled
+    %2:2 = scf.for %i = %c0_i32 to %arg2 step %c1_i32 iter_args(%acc = %cst, %a = %1) -> (tensor<128x128xf32, #blocked>, tensor<128x64xf8E4M3FN, #blocked_pack>) : i32 {
+      %3 = ttg.convert_layout %a : tensor<128x64xf8E4M3FN, #blocked_pack> -> tensor<128x64xf8E4M3FN, #ttg.dot_op<{opIdx = 0, parent = #blocked}>>
+      %4 = tt.dot %3, %arg1, %acc : tensor<128x64xf8E4M3FN, #ttg.dot_op<{opIdx = 0, parent = #blocked}>> * tensor<64x128xf8E4M3FN, #ttg.dot_op<{opIdx = 1, parent = #blocked}>> -> tensor<128x128xf32, #blocked>
+      scf.yield %4, %a : tensor<128x128xf32, #blocked>, tensor<128x64xf8E4M3FN, #blocked_pack>
+    }
+    tt.return %2#0 : tensor<128x128xf32, #blocked>
   }
 }
 


### PR DESCRIPTION
Fixes #11320.

On consumer Blackwell (sm120) the plain fp8 MMA (`mma.sync...f32.e4m3.e4m3.f32`) runs at half the 8-bit tensor core rate, while the block-scaled MXFP8 MMA (`kind::mxf8f6f4.block_scale`) runs at full rate. A scale of exactly 1.0 (E8M0 value 127) is exact, so the block-scaled instruction with unit scales produces bit-identical results at up to twice the throughput. QuACK and FlashInfer use the same approach on SM120 (references in the issue).

This adds an `AccelerateMatmul` rewrite that converts fp8 `tt.dot` on sm120 into `tt.dot_scaled` with constant unit scales, reusing the existing sm120 `ScaledBlockedToMMA` lowering (the entry conditions are shared through a common predicate so the two patterns cannot drift apart). It only fires when the native block-scaled path is guaranteed to apply (fp8 x fp8, f32 accumulator, rank 2, single CTA, M % 16 == 0, N % 8 == 0, K % 32 == 0, operands not derived from narrower packed loads); anything else keeps the plain fp8 MMA path. The unit-scale constants fold into linear-layout constants during remove-layout-conversions, so no scale data ever moves at runtime.

Note: like manual `tl.dot_scaled` kernels, rewritten dots are not matched by the `triton::DotOp`-keyed patterns in `OptimizeDotOperands` (SwizzleShmemConvert) and `ReorderInstructions`; widening those to `DotOpInterface` would benefit both and is left as a follow-up.

Measured on RTX 5070 Ti (e4m3 x e4m3 -> f32, BLOCK 128x128x128, interleaved A/B, medians). Before, `tl.dot` uses the plain fp8 MMA; after, it matches `tl.dot_scaled` with unit scales at every shape (ratio 0.99-1.02):

| M x N x K | `tl.dot` before | `tl.dot` after | speedup |
|-----------|----------------|----------------|---------|
| 1024 x 1024 x 1024 | 71.3 TFLOP/s | 104.2 TFLOP/s | 1.46x |
| 2048 x 2048 x 2048 | 95.5 TFLOP/s | 135.7 TFLOP/s | 1.42x |
| 4096 x 4096 x 4096 | 109.7 TFLOP/s | 156.8 TFLOP/s | 1.43x |
| 8192 x 4096 x 8192 | 114.9 TFLOP/s | 162.4 TFLOP/s | 1.41x |

Output is bit-identical before vs after the change and vs `tl.dot_scaled` with unit scales.

Testing:
- lit: updated `sm120_fp8_dot` and added mixed-fp8-type, f16-accumulator, small-K, unaligned-M and packed-fp4-operand fallback cases (plus a loop-carried packed-operand case documenting the kWidth alignment with BlockedToMMA) in `accelerate-matmul.mlir`; `tritongpu_to_llvm_sm120.mlir` now checks that a plain fp8 `tt.dot` emits `kind::mxf8f6f4.block_scale.scale_vec::1X`.
- `test_core.py::test_dot` asserts the block-scaled instruction for aligned fp8 dots on sm120.
- Ran on RTX 5070 Ti: `test_core.py -k test_dot` (724 passed), `test_scaled_dot` (1728 passed), mxfp matmul suites (115 passed), full lit suite and C++ unit tests.

Generated with [Claude Code](https://claude.com/claude-code)
