### PR TITLE
[MEMBAR] Handle cross call pending memory reads/writes

### DIFF
--- a/include/triton/Analysis/Membar.h
+++ b/include/triton/Analysis/Membar.h
@@ -236,8 +236,7 @@ struct MembarInfo {
   }
 
   bool operator==(const MembarInfo &other) const {
-    return pending == other.pending &&
-           entryBlockInfo == other.entryBlockInfo &&
+    return pending == other.pending && entryBlockInfo == other.entryBlockInfo &&
            allPathsFromEntrySynced == other.allPathsFromEntrySynced;
   }
 };

--- a/include/triton/Analysis/Membar.h
+++ b/include/triton/Analysis/Membar.h
@@ -199,41 +199,46 @@ struct MembarInfo {
   /// Buffers accessed since the most recent synchronization.
   BlockInfo pending;
 
-  /// Buffers reachable from the basic block entry.
-  BlockInfo entry;
+  /// Buffers reachable from the function entry block before the first
+  /// synchronization.
+  /// It keeps incrementing during the iterative algorithm until
+  ///  we note all paths to a basic block has synchronized.
+  BlockInfo entryBlockInfo;
 
-  /// Whether every path to this basic block has synchronized.
-  bool allPathsSynced = false;
+  /// Whether every path from the function entry block to the current program
+  /// point has synchronized.
+  bool allPathsFromEntrySynced = false;
 
   MembarInfo &join(const MembarInfo &other) {
     pending.join(other.pending);
-    entry.join(other.entry);
-    allPathsSynced &= other.allPathsSynced;
+    entryBlockInfo.join(other.entryBlockInfo);
+    allPathsFromEntrySynced &= other.allPathsFromEntrySynced;
     return *this;
   }
 
   void addBlockInfo(const BlockInfo &blockInfo) {
-    if (!allPathsSynced)
-      entry.join(blockInfo);
+    if (!allPathsFromEntrySynced)
+      entryBlockInfo.join(blockInfo);
     pending.join(blockInfo);
   }
 
   void sync() {
     pending.sync();
-    allPathsSynced = true;
+    allPathsFromEntrySynced = true;
   }
 
   void applyCallSummary(const MembarInfo &callee) {
-    if (!allPathsSynced)
-      entry.join(callee.entry);
-    if (callee.allPathsSynced)
+    if (!allPathsFromEntrySynced)
+      entryBlockInfo.join(callee.entryBlockInfo);
+    if (callee.allPathsFromEntrySynced)
       sync();
     pending.join(callee.pending);
   }
 
   bool operator==(const MembarInfo &other) const {
-    return pending == other.pending && entry == other.entry &&
-           allPathsSynced == other.allPathsSynced;
+    return pending == other.pending &&
+           entryBlockInfo == other.entryBlockInfo &&
+           allPathsFromEntrySynced == other.allPathsFromEntrySynced;
   }
 };
 

--- a/include/triton/Analysis/Membar.h
+++ b/include/triton/Analysis/Membar.h
@@ -304,13 +304,13 @@ public:
 
 private:
   /// Updates the BlockInfo operation based on the operation.
-  void update(Operation *operation, MembarInfo *blockInfo, FuncMapT *funcMap,
+  void update(Operation *operation, MembarInfo *membarInfo, FuncMapT *funcMap,
               OpBuilder *builder) override;
 
   void updateSuccessor(Operation *terminator, Block *successor,
-                       MembarInfo *blockInfo) override;
+                       MembarInfo *membarInfo) override;
 
-  void updateExitState(MembarInfo *blockInfo) override;
+  void updateExitState(MembarInfo *membarInfo) override;
 
   void insertBarrier(Operation *operation, OpBuilder *builder);
 

--- a/include/triton/Analysis/Membar.h
+++ b/include/triton/Analysis/Membar.h
@@ -193,6 +193,43 @@ private:
   }
 };
 
+struct MembarInfo {
+  BlockInfo pending;
+  BlockInfo entry;
+  bool allPathsSynced = false;
+
+  MembarInfo &join(const MembarInfo &other) {
+    pending.join(other.pending);
+    entry.join(other.entry);
+    allPathsSynced &= other.allPathsSynced;
+    return *this;
+  }
+
+  void addEffects(const BlockInfo &effects) {
+    if (!allPathsSynced)
+      entry.join(effects);
+    pending.join(effects);
+  }
+
+  void sync() {
+    pending.sync();
+    allPathsSynced = true;
+  }
+
+  void applyCallSummary(const MembarInfo &callee) {
+    if (!allPathsSynced)
+      entry.join(callee.entry);
+    if (callee.allPathsSynced)
+      sync();
+    pending.join(callee.pending);
+  }
+
+  bool operator==(const MembarInfo &other) const {
+    return pending == other.pending && entry == other.entry &&
+           allPathsSynced == other.allPathsSynced;
+  }
+};
+
 inline BlockInfo translateBlockInfoToCallsite(const BlockInfo &calleeBlockInfo,
                                               size_t callOffset) {
   BlockInfo translatedBlockInfo;
@@ -233,7 +270,7 @@ protected:
   MembarFilterFn filter;
 };
 
-class MembarAnalysis : public MembarOrFenceAnalysis {
+class MembarAnalysis : public triton::PostOrderFunctionAnalysis<MembarInfo> {
 public:
   /// Creates a new Membar analysis that generates the shared memory barrier
   /// in the following circumstances:
@@ -249,22 +286,24 @@ public:
   /// it is considered as the problem of the operation itself but not the membar
   /// analysis.
   MembarAnalysis(Allocation &allocation, MembarFilterFn filter)
-      : MembarOrFenceAnalysis(allocation, std::move(filter)),
+      : allocation(allocation), filter(std::move(filter)),
         bufferIndexAnalysis(
             cast<FunctionOpInterface>(allocation.getOperation())) {}
 
 private:
   /// Updates the BlockInfo operation based on the operation.
-  void update(Operation *operation, BlockInfo *blockInfo, FuncMapT *funcMap,
+  void update(Operation *operation, MembarInfo *blockInfo, FuncMapT *funcMap,
               OpBuilder *builder) override;
 
   void updateSuccessor(Operation *terminator, Block *successor,
-                       BlockInfo *blockInfo) override;
+                       MembarInfo *blockInfo) override;
 
-  void updateExitState(BlockInfo *blockInfo) override;
+  void updateExitState(MembarInfo *blockInfo) override;
 
   void insertBarrier(Operation *operation, OpBuilder *builder);
 
+  Allocation &allocation;
+  MembarFilterFn filter;
   BufferIndexAnalysis bufferIndexAnalysis;
 };
 
@@ -299,7 +338,20 @@ private:
   MembarFilterFn filter;
 };
 
-using ModuleMembarAnalysis = ModuleMembarOrFenceAnalysis<MembarAnalysis>;
+/// Inserts shared-memory barriers across a module. Function summaries retain
+/// entry-prefix and pending exit states for calls.
+class ModuleMembarAnalysis {
+public:
+  ModuleMembarAnalysis(ModuleAllocation &moduleAllocation,
+                       MembarFilterFn filter = nullptr)
+      : moduleAllocation(moduleAllocation), filter(std::move(filter)) {}
+
+  void run();
+
+private:
+  ModuleAllocation &moduleAllocation;
+  MembarFilterFn filter;
+};
 
 } // namespace mlir
 

--- a/include/triton/Analysis/Membar.h
+++ b/include/triton/Analysis/Membar.h
@@ -199,7 +199,7 @@ struct MembarInfo {
   /// Buffers accessed since the most recent synchronization.
   BlockInfo pending;
 
-  /// Buffers reachable from the basic block entry
+  /// Buffers reachable from the basic block entry.
   BlockInfo entry;
 
   /// Whether every path to this basic block has synchronized.

--- a/include/triton/Analysis/Membar.h
+++ b/include/triton/Analysis/Membar.h
@@ -193,11 +193,19 @@ private:
   }
 };
 
+/// Tracks the shared-memory state needed at the current program point and at
+/// function boundaries.
 struct MembarInfo {
+  /// Buffers accessed since the most recent synchronization.
   BlockInfo pending;
+
+  /// Buffers reachable from function entry before the first synchronization.
   BlockInfo entry;
+
+  /// Whether every path from function entry has synchronized.
   bool allPathsSynced = false;
 
+  /// Merge states reaching the same control-flow point.
   MembarInfo &join(const MembarInfo &other) {
     pending.join(other.pending);
     entry.join(other.entry);
@@ -205,17 +213,21 @@ struct MembarInfo {
     return *this;
   }
 
-  void addEffects(const BlockInfo &effects) {
+  /// Add a BlockInfo to the pending state and, while an unsynchronized entry
+  /// path remains, to the entry state.
+  void addBlockInfo(const BlockInfo &blockInfo) {
     if (!allPathsSynced)
-      entry.join(effects);
-    pending.join(effects);
+      entry.join(blockInfo);
+    pending.join(blockInfo);
   }
 
+  /// Clear the pending state and close every current entry path.
   void sync() {
     pending.sync();
     allPathsSynced = true;
   }
 
+  /// Compose a callee summary into the caller state.
   void applyCallSummary(const MembarInfo &callee) {
     if (!allPathsSynced)
       entry.join(callee.entry);

--- a/include/triton/Analysis/Membar.h
+++ b/include/triton/Analysis/Membar.h
@@ -199,13 +199,12 @@ struct MembarInfo {
   /// Buffers accessed since the most recent synchronization.
   BlockInfo pending;
 
-  /// Buffers reachable from function entry before the first synchronization.
+  /// Buffers reachable from the basic block entry
   BlockInfo entry;
 
-  /// Whether every path from function entry has synchronized.
+  /// Whether every path to this basic block has synchronized.
   bool allPathsSynced = false;
 
-  /// Merge states reaching the same control-flow point.
   MembarInfo &join(const MembarInfo &other) {
     pending.join(other.pending);
     entry.join(other.entry);
@@ -213,21 +212,17 @@ struct MembarInfo {
     return *this;
   }
 
-  /// Add a BlockInfo to the pending state and, while an unsynchronized entry
-  /// path remains, to the entry state.
   void addBlockInfo(const BlockInfo &blockInfo) {
     if (!allPathsSynced)
       entry.join(blockInfo);
     pending.join(blockInfo);
   }
 
-  /// Clear the pending state and close every current entry path.
   void sync() {
     pending.sync();
     allPathsSynced = true;
   }
 
-  /// Compose a callee summary into the caller state.
   void applyCallSummary(const MembarInfo &callee) {
     if (!allPathsSynced)
       entry.join(callee.entry);

--- a/lib/Analysis/Membar.cpp
+++ b/lib/Analysis/Membar.cpp
@@ -328,7 +328,7 @@ void MembarAnalysis::update(Operation *op, MembarInfo *blockInfo,
     if (barrierStages.betweenMemoryEffects) {
       // The internal barrier synchronizes all incoming effects. Do not carry
       // them past the operation; only effects after the barrier are outgoing.
-      blockInfo->addEffects(curBlockInfo);
+      blockInfo->addBlockInfo(curBlockInfo);
       blockInfo->sync();
       curBlockInfo.sync();
     }
@@ -341,7 +341,7 @@ void MembarAnalysis::update(Operation *op, MembarInfo *blockInfo,
   }
   // Update the region info, even if barrier is inserted, we have to maintain
   // the current op's read/write buffers.
-  blockInfo->addEffects(curBlockInfo);
+  blockInfo->addBlockInfo(curBlockInfo);
 
   if (barrierStages.afterMemoryEffects) {
     // Model a trailing local barrier after handling the operation's effects.

--- a/lib/Analysis/Membar.cpp
+++ b/lib/Analysis/Membar.cpp
@@ -208,18 +208,21 @@ static bool hasSyncPointBeforeMemoryEffect(Operation *op,
 }
 
 void MembarAnalysis::updateSuccessor(Operation *terminator, Block *successor,
-                                     BlockInfo *blockInfo) {
-  if (bufferIndexAnalysis.isBackedgeSuccessor(terminator, successor))
-    bufferIndexAnalysis.invalidateBufferIndices(*blockInfo);
+                                     MembarInfo *blockInfo) {
+  if (bufferIndexAnalysis.isBackedgeSuccessor(terminator, successor)) {
+    bufferIndexAnalysis.invalidateBufferIndices(blockInfo->pending);
+    bufferIndexAnalysis.invalidateBufferIndices(blockInfo->entry);
+  }
 }
 
-void MembarAnalysis::updateExitState(BlockInfo *blockInfo) {
+void MembarAnalysis::updateExitState(MembarInfo *blockInfo) {
   // Function summaries are reused at every call site, so per-function SSA
   // index identity is no longer meaningful.
-  bufferIndexAnalysis.invalidateBufferIndices(*blockInfo);
+  bufferIndexAnalysis.invalidateBufferIndices(blockInfo->pending);
+  bufferIndexAnalysis.invalidateBufferIndices(blockInfo->entry);
 }
 
-void MembarAnalysis::update(Operation *op, BlockInfo *blockInfo,
+void MembarAnalysis::update(Operation *op, MembarInfo *blockInfo,
                             FuncMapT *funcMap, OpBuilder *builder) {
   // A later CTA-wide synchronization can also synchronize this wait, provided
   // no memory is accessed before reaching it.
@@ -251,17 +254,26 @@ void MembarAnalysis::update(Operation *op, BlockInfo *blockInfo,
   BlockInfo curBlockInfo;
   auto scratchBufferId = getScratchBufferId(op, &allocation);
   if (isa<triton::CallOp>(op)) {
-    // Inter-function dependencies
-    auto callOpInterface = dyn_cast<CallOpInterface>(op);
-    if (auto callee =
-            dyn_cast<FunctionOpInterface>(callOpInterface.resolveCallable())) {
-      auto calleeBlockInfo = funcMap->lookup(callee);
+    auto call = cast<CallOpInterface>(op);
+    if (auto callee = dyn_cast<FunctionOpInterface>(call.resolveCallable())) {
+      MembarInfo calleeInfo = funcMap->lookup(callee);
       auto callBufferId = allocation.getBufferId(op);
       size_t callOffset = 0;
       if (callBufferId != Allocation::InvalidBufferId)
         callOffset = allocation.getAllocatedInterval(callBufferId).start();
-      curBlockInfo = translateBlockInfoToCallsite(calleeBlockInfo, callOffset);
+      calleeInfo.pending =
+          translateBlockInfoToCallsite(calleeInfo.pending, callOffset);
+      calleeInfo.entry =
+          translateBlockInfoToCallsite(calleeInfo.entry, callOffset);
+      if (blockInfo->pending.isIntersected(calleeInfo.entry, filter,
+                                           &allocation)) {
+        builder->setInsertionPoint(op);
+        insertBarrier(op, builder);
+        blockInfo->sync();
+      }
+      blockInfo->applyCallSummary(calleeInfo);
     }
+    return;
   } else {
     // Intra-function dependencies
     if (auto memoryEffectOpInterface = dyn_cast<MemoryEffectOpInterface>(op)) {
@@ -305,7 +317,7 @@ void MembarAnalysis::update(Operation *op, BlockInfo *blockInfo,
     auto scratchSlice = AllocationSlice(interval);
     curBlockInfo.syncWriteSlices[scratchSlice].insert(op);
     auto insertCTABarrier =
-        blockInfo->isIntersected(curBlockInfo, filter, &allocation);
+        blockInfo->pending.isIntersected(curBlockInfo, filter, &allocation);
     if (insertCTABarrier) {
       builder->setInsertionPoint(op);
       insertBarrier(op, builder);
@@ -316,23 +328,37 @@ void MembarAnalysis::update(Operation *op, BlockInfo *blockInfo,
     if (barrierStages.betweenMemoryEffects) {
       // The internal barrier synchronizes all incoming effects. Do not carry
       // them past the operation; only effects after the barrier are outgoing.
-      blockInfo->join(curBlockInfo);
+      blockInfo->addEffects(curBlockInfo);
       blockInfo->sync();
       curBlockInfo.sync();
     }
     curBlockInfo.syncReadSlices[scratchSlice].insert(op);
-  } else if (blockInfo->isIntersected(curBlockInfo, filter, &allocation)) {
+  } else if (blockInfo->pending.isIntersected(curBlockInfo, filter,
+                                              &allocation)) {
     builder->setInsertionPoint(op);
     insertBarrier(op, builder);
     blockInfo->sync();
   }
   // Update the region info, even if barrier is inserted, we have to maintain
   // the current op's read/write buffers.
-  blockInfo->join(curBlockInfo);
+  blockInfo->addEffects(curBlockInfo);
 
   if (barrierStages.afterMemoryEffects) {
     // Model a trailing local barrier after handling the operation's effects.
     blockInfo->sync();
   }
+}
+
+void ModuleMembarAnalysis::run() {
+  triton::CallGraph<MembarInfo> callGraph(moduleAllocation.getModuleOp());
+  triton::CallGraph<MembarInfo>::FuncDataMapT summaries;
+  callGraph.walk<WalkOrder::PreOrder, WalkOrder::PostOrder>(
+      [](CallOpInterface, FunctionOpInterface) {},
+      [&](FunctionOpInterface function) {
+        if (!summaries.try_emplace(function).second)
+          return;
+        auto &allocation = *moduleAllocation.getFuncData(function);
+        MembarAnalysis(allocation, filter).run(function, summaries);
+      });
 }
 } // namespace mlir

--- a/lib/Analysis/Membar.cpp
+++ b/lib/Analysis/Membar.cpp
@@ -211,7 +211,7 @@ void MembarAnalysis::updateSuccessor(Operation *terminator, Block *successor,
                                      MembarInfo *membarInfo) {
   if (bufferIndexAnalysis.isBackedgeSuccessor(terminator, successor)) {
     bufferIndexAnalysis.invalidateBufferIndices(membarInfo->pending);
-    bufferIndexAnalysis.invalidateBufferIndices(membarInfo->entry);
+    bufferIndexAnalysis.invalidateBufferIndices(membarInfo->entryBlockInfo);
   }
 }
 
@@ -219,7 +219,7 @@ void MembarAnalysis::updateExitState(MembarInfo *membarInfo) {
   // Function summaries are reused at every call site, so per-function SSA
   // index identity is no longer meaningful.
   bufferIndexAnalysis.invalidateBufferIndices(membarInfo->pending);
-  bufferIndexAnalysis.invalidateBufferIndices(membarInfo->entry);
+  bufferIndexAnalysis.invalidateBufferIndices(membarInfo->entryBlockInfo);
 }
 
 void MembarAnalysis::update(Operation *op, MembarInfo *membarInfo,
@@ -263,10 +263,10 @@ void MembarAnalysis::update(Operation *op, MembarInfo *membarInfo,
         callOffset = allocation.getAllocatedInterval(callBufferId).start();
       calleeMembarInfo.pending =
           translateBlockInfoToCallsite(calleeMembarInfo.pending, callOffset);
-      calleeMembarInfo.entry =
-          translateBlockInfoToCallsite(calleeMembarInfo.entry, callOffset);
-      if (membarInfo->pending.isIntersected(calleeMembarInfo.entry, filter,
-                                            &allocation)) {
+      calleeMembarInfo.entryBlockInfo = translateBlockInfoToCallsite(
+          calleeMembarInfo.entryBlockInfo, callOffset);
+      if (membarInfo->pending.isIntersected(calleeMembarInfo.entryBlockInfo,
+                                            filter, &allocation)) {
         builder->setInsertionPoint(op);
         insertBarrier(op, builder);
         membarInfo->sync();

--- a/lib/Analysis/Membar.cpp
+++ b/lib/Analysis/Membar.cpp
@@ -208,21 +208,21 @@ static bool hasSyncPointBeforeMemoryEffect(Operation *op,
 }
 
 void MembarAnalysis::updateSuccessor(Operation *terminator, Block *successor,
-                                     MembarInfo *blockInfo) {
+                                     MembarInfo *membarInfo) {
   if (bufferIndexAnalysis.isBackedgeSuccessor(terminator, successor)) {
-    bufferIndexAnalysis.invalidateBufferIndices(blockInfo->pending);
-    bufferIndexAnalysis.invalidateBufferIndices(blockInfo->entry);
+    bufferIndexAnalysis.invalidateBufferIndices(membarInfo->pending);
+    bufferIndexAnalysis.invalidateBufferIndices(membarInfo->entry);
   }
 }
 
-void MembarAnalysis::updateExitState(MembarInfo *blockInfo) {
+void MembarAnalysis::updateExitState(MembarInfo *membarInfo) {
   // Function summaries are reused at every call site, so per-function SSA
   // index identity is no longer meaningful.
-  bufferIndexAnalysis.invalidateBufferIndices(blockInfo->pending);
-  bufferIndexAnalysis.invalidateBufferIndices(blockInfo->entry);
+  bufferIndexAnalysis.invalidateBufferIndices(membarInfo->pending);
+  bufferIndexAnalysis.invalidateBufferIndices(membarInfo->entry);
 }
 
-void MembarAnalysis::update(Operation *op, MembarInfo *blockInfo,
+void MembarAnalysis::update(Operation *op, MembarInfo *membarInfo,
                             FuncMapT *funcMap, OpBuilder *builder) {
   // A later CTA-wide synchronization can also synchronize this wait, provided
   // no memory is accessed before reaching it.
@@ -237,7 +237,7 @@ void MembarAnalysis::update(Operation *op, MembarInfo *blockInfo,
   auto barrierStages = getLocalBarrierStages(op, &allocation);
   if (barrierStages.beforeMemoryEffects) {
     // Model a leading local barrier before handling the operation's effects.
-    blockInfo->sync();
+    membarInfo->sync();
   }
 
   // If the current op is an (async) memory wait and there is no later sync
@@ -247,7 +247,7 @@ void MembarAnalysis::update(Operation *op, MembarInfo *blockInfo,
       !hasSyncPointBeforeMemoryEffect(op, &allocation)) {
     builder->setInsertionPointAfter(op);
     insertBarrier(op, builder);
-    blockInfo->sync();
+    membarInfo->sync();
     return;
   }
 
@@ -256,22 +256,22 @@ void MembarAnalysis::update(Operation *op, MembarInfo *blockInfo,
   if (isa<triton::CallOp>(op)) {
     auto call = cast<CallOpInterface>(op);
     if (auto callee = dyn_cast<FunctionOpInterface>(call.resolveCallable())) {
-      MembarInfo calleeInfo = funcMap->lookup(callee);
+      MembarInfo calleeMembarInfo = funcMap->lookup(callee);
       auto callBufferId = allocation.getBufferId(op);
       size_t callOffset = 0;
       if (callBufferId != Allocation::InvalidBufferId)
         callOffset = allocation.getAllocatedInterval(callBufferId).start();
-      calleeInfo.pending =
-          translateBlockInfoToCallsite(calleeInfo.pending, callOffset);
-      calleeInfo.entry =
-          translateBlockInfoToCallsite(calleeInfo.entry, callOffset);
-      if (blockInfo->pending.isIntersected(calleeInfo.entry, filter,
-                                           &allocation)) {
+      calleeMembarInfo.pending =
+          translateBlockInfoToCallsite(calleeMembarInfo.pending, callOffset);
+      calleeMembarInfo.entry =
+          translateBlockInfoToCallsite(calleeMembarInfo.entry, callOffset);
+      if (membarInfo->pending.isIntersected(calleeMembarInfo.entry, filter,
+                                            &allocation)) {
         builder->setInsertionPoint(op);
         insertBarrier(op, builder);
-        blockInfo->sync();
+        membarInfo->sync();
       }
-      blockInfo->applyCallSummary(calleeInfo);
+      membarInfo->applyCallSummary(calleeMembarInfo);
     }
     return;
   } else {
@@ -317,35 +317,35 @@ void MembarAnalysis::update(Operation *op, MembarInfo *blockInfo,
     auto scratchSlice = AllocationSlice(interval);
     curBlockInfo.syncWriteSlices[scratchSlice].insert(op);
     auto insertCTABarrier =
-        blockInfo->pending.isIntersected(curBlockInfo, filter, &allocation);
+        membarInfo->pending.isIntersected(curBlockInfo, filter, &allocation);
     if (insertCTABarrier) {
       builder->setInsertionPoint(op);
       insertBarrier(op, builder);
     }
     if (insertCTABarrier)
-      blockInfo->sync();
+      membarInfo->sync();
 
     if (barrierStages.betweenMemoryEffects) {
       // The internal barrier synchronizes all incoming effects. Do not carry
       // them past the operation; only effects after the barrier are outgoing.
-      blockInfo->addBlockInfo(curBlockInfo);
-      blockInfo->sync();
+      membarInfo->addBlockInfo(curBlockInfo);
+      membarInfo->sync();
       curBlockInfo.sync();
     }
     curBlockInfo.syncReadSlices[scratchSlice].insert(op);
-  } else if (blockInfo->pending.isIntersected(curBlockInfo, filter,
-                                              &allocation)) {
+  } else if (membarInfo->pending.isIntersected(curBlockInfo, filter,
+                                               &allocation)) {
     builder->setInsertionPoint(op);
     insertBarrier(op, builder);
-    blockInfo->sync();
+    membarInfo->sync();
   }
   // Update the region info, even if barrier is inserted, we have to maintain
   // the current op's read/write buffers.
-  blockInfo->addBlockInfo(curBlockInfo);
+  membarInfo->addBlockInfo(curBlockInfo);
 
   if (barrierStages.afterMemoryEffects) {
     // Model a trailing local barrier after handling the operation's effects.
-    blockInfo->sync();
+    membarInfo->sync();
   }
 }
 

--- a/test/Analysis/test-membar.mlir
+++ b/test/Analysis/test-membar.mlir
@@ -1595,6 +1595,39 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32} {
     %sum = arith.addf %call, %cvt : tensor<128x32xf16, #blockedCallDst>
     tt.return %sum : tensor<128x32xf16, #blockedCallDst>
   }
+
+  tt.func private @nested_entry_c() -> tensor<128x32xf16, #blockedCallDst> {
+    %cst = arith.constant dense<0.0> : tensor<128x32xf16, #blockedCallSrc>
+    %cvt = ttg.convert_layout %cst : tensor<128x32xf16, #blockedCallSrc> -> tensor<128x32xf16, #blockedCallDst>
+    tt.return %cvt : tensor<128x32xf16, #blockedCallDst>
+  }
+
+  // CHECK-LABEL: @nested_entry_b
+  // CHECK-NOT: ttg.barrier local
+  // CHECK: tt.call @nested_entry_c
+  tt.func private @nested_entry_b() -> tensor<128x32xf16, #blockedCallDst> {
+    %call = tt.call @nested_entry_c() : () -> tensor<128x32xf16, #blockedCallDst>
+    tt.return %call : tensor<128x32xf16, #blockedCallDst>
+  }
+
+  // The first call has no pending shared-memory accesses and needs no barrier.
+  // The conversion before the second call conflicts with the entry state
+  // propagated through B from C.
+  // CHECK-LABEL: @nested_entry_a
+  // CHECK-NOT: ttg.barrier local
+  // CHECK: %[[FIRST:.*]] = tt.call @nested_entry_b
+  // CHECK: ttg.convert_layout
+  // CHECK-NEXT: ttg.barrier local
+  // CHECK-NEXT: %[[SECOND:.*]] = tt.call @nested_entry_b
+  tt.func @nested_entry_a() -> tensor<128x32xf16, #blockedCallDst> {
+    %first = tt.call @nested_entry_b() : () -> tensor<128x32xf16, #blockedCallDst>
+    %cst = arith.constant dense<0.0> : tensor<128x32xf16, #blockedCallSrc>
+    %cvt = ttg.convert_layout %cst : tensor<128x32xf16, #blockedCallSrc> -> tensor<128x32xf16, #blockedCallDst>
+    %second = tt.call @nested_entry_b() : () -> tensor<128x32xf16, #blockedCallDst>
+    %sum0 = arith.addf %first, %cvt : tensor<128x32xf16, #blockedCallDst>
+    %sum1 = arith.addf %sum0, %second : tensor<128x32xf16, #blockedCallDst>
+    tt.return %sum1 : tensor<128x32xf16, #blockedCallDst>
+  }
 }
 
 // -----

--- a/test/Analysis/test-membar.mlir
+++ b/test/Analysis/test-membar.mlir
@@ -1534,6 +1534,67 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32} {
     ttg.local_dealloc %buf : !ttg.memdesc<65536xi8, #sharedLarge, #smem, mutable>
     tt.return %sum : tensor<128x32xf16, #blockedCallDst>
   }
+
+  tt.func private @callee_writes_first() -> tensor<128x32xf16, #blockedCallDst> {
+    %cst = arith.constant dense<0.0> : tensor<128x32xf16, #blockedCallSrc>
+    %cvt = ttg.convert_layout %cst : tensor<128x32xf16, #blockedCallSrc> -> tensor<128x32xf16, #blockedCallDst>
+    tt.return %cvt : tensor<128x32xf16, #blockedCallDst>
+  }
+
+  // The caller's conversion leaves a pending shared-memory read. The callee
+  // starts with a conversion that writes the same call frame, so a barrier is
+  // required immediately before the call.
+  // CHECK-LABEL: @caller_pending_read_then_call
+  // CHECK: ttg.convert_layout
+  // CHECK-NEXT: ttg.barrier local
+  // CHECK-NEXT: tt.call @callee_writes_first
+  tt.func @caller_pending_read_then_call() -> tensor<128x32xf16, #blockedCallDst> {
+    %cst = arith.constant dense<0.0> : tensor<128x32xf16, #blockedCallSrc>
+    %cvt = ttg.convert_layout %cst : tensor<128x32xf16, #blockedCallSrc> -> tensor<128x32xf16, #blockedCallDst>
+    %call = tt.call @callee_writes_first() : () -> tensor<128x32xf16, #blockedCallDst>
+    %sum = arith.addf %call, %cvt : tensor<128x32xf16, #blockedCallDst>
+    tt.return %sum : tensor<128x32xf16, #blockedCallDst>
+  }
+
+  tt.func private @callee_writes_then_barrier() -> tensor<128x32xf16, #blockedCallDst> {
+    %cst = arith.constant dense<0.0> : tensor<128x32xf16, #blockedCallSrc>
+    %cvt = ttg.convert_layout %cst : tensor<128x32xf16, #blockedCallSrc> -> tensor<128x32xf16, #blockedCallDst>
+    ttg.barrier local
+    tt.return %cvt : tensor<128x32xf16, #blockedCallDst>
+  }
+
+  // A trailing callee barrier cannot order the callee's first write against
+  // the caller's access before the call.
+  // CHECK-LABEL: @caller_pending_read_then_callee_trailing_barrier
+  // CHECK: ttg.convert_layout
+  // CHECK-NEXT: ttg.barrier local
+  // CHECK-NEXT: tt.call @callee_writes_then_barrier
+  tt.func @caller_pending_read_then_callee_trailing_barrier() -> tensor<128x32xf16, #blockedCallDst> {
+    %cst = arith.constant dense<0.0> : tensor<128x32xf16, #blockedCallSrc>
+    %cvt = ttg.convert_layout %cst : tensor<128x32xf16, #blockedCallSrc> -> tensor<128x32xf16, #blockedCallDst>
+    %call = tt.call @callee_writes_then_barrier() : () -> tensor<128x32xf16, #blockedCallDst>
+    %sum = arith.addf %call, %cvt : tensor<128x32xf16, #blockedCallDst>
+    tt.return %sum : tensor<128x32xf16, #blockedCallDst>
+  }
+
+  tt.func private @callee_barrier_then_writes() -> tensor<128x32xf16, #blockedCallDst> {
+    ttg.barrier local
+    %cst = arith.constant dense<0.0> : tensor<128x32xf16, #blockedCallSrc>
+    %cvt = ttg.convert_layout %cst : tensor<128x32xf16, #blockedCallSrc> -> tensor<128x32xf16, #blockedCallDst>
+    tt.return %cvt : tensor<128x32xf16, #blockedCallDst>
+  }
+
+  // A leading callee barrier synchronizes the caller's pending access.
+  // CHECK-LABEL: @callee_entry_barrier_covers_caller
+  // CHECK: ttg.convert_layout
+  // CHECK-NEXT: tt.call @callee_barrier_then_writes
+  tt.func @callee_entry_barrier_covers_caller() -> tensor<128x32xf16, #blockedCallDst> {
+    %cst = arith.constant dense<0.0> : tensor<128x32xf16, #blockedCallSrc>
+    %cvt = ttg.convert_layout %cst : tensor<128x32xf16, #blockedCallSrc> -> tensor<128x32xf16, #blockedCallDst>
+    %call = tt.call @callee_barrier_then_writes() : () -> tensor<128x32xf16, #blockedCallDst>
+    %sum = arith.addf %call, %cvt : tensor<128x32xf16, #blockedCallDst>
+    tt.return %sum : tensor<128x32xf16, #blockedCallDst>
+  }
 }
 
 // -----


### PR DESCRIPTION
close https://github.com/triton-lang/triton/pull/11384

Similar to ProxyFenceInsertion.cpp, we analyze the data flow in a call graph (DAG).

For each basic block, we keep it's outgoing buffers and the buffers accumulated from the function `entry` basic block. The later is incrementally added, so a function's exit block has the largest number of buffers in the `entry` field. Utilizing this, which was previously missing, we can check whether a caller's pending buffers overlap with all buffers reachable from a callee's function entry.

`MembarOrFenceAnalysis` has not been removed since it's still being used by other passes such as `ClusterBarrierAnalysis` and `TMemBarrierAnalysis`. Maybe these passes have to be cleaned up as well.