### PR TITLE
[MEMBAR] Handle cross-call TMem and cluster barriers

### DIFF
--- a/include/triton/Analysis/Membar.h
+++ b/include/triton/Analysis/Membar.h
@@ -269,18 +269,6 @@ bool containsLocalBarrier(Operation *op);
 // Shared Memory Barrier Analysis
 //===----------------------------------------------------------------------===//
 
-// Common class to analyze membar and fence placement.
-class MembarOrFenceAnalysis
-    : public triton::PostOrderFunctionAnalysis<BlockInfo> {
-public:
-  MembarOrFenceAnalysis(Allocation &allocation, MembarFilterFn filter)
-      : allocation(allocation), filter(std::move(filter)) {}
-
-protected:
-  Allocation &allocation;
-  MembarFilterFn filter;
-};
-
 class MembarAnalysis : public triton::PostOrderFunctionAnalysis<MembarInfo> {
 public:
   /// Creates a new Membar analysis that generates the shared memory barrier
@@ -313,40 +301,12 @@ private:
 
   void insertBarrier(Operation *operation, OpBuilder *builder);
 
+protected:
   Allocation &allocation;
   MembarFilterFn filter;
-  BufferIndexAnalysis bufferIndexAnalysis;
-};
-
-/// Postorder traversal on the callgraph to insert membar instructions
-/// of each function.
-/// Each function maintains a BlockInfo map that includes all potential buffers
-/// after returning. This way users do not have to explicitly insert membars
-/// before and after function calls, but might be a bit conservative.
-template <typename AnalysisT>
-class ModuleMembarOrFenceAnalysis : public triton::CallGraph<BlockInfo> {
-public:
-  ModuleMembarOrFenceAnalysis(ModuleAllocation &moduleAllocation,
-                              MembarFilterFn filter = nullptr)
-      : triton::CallGraph<BlockInfo>(moduleAllocation.getModuleOp()),
-        moduleAllocation(moduleAllocation), filter(std::move(filter)) {}
-
-  void run() {
-    walk<WalkOrder::PreOrder, WalkOrder::PostOrder>(
-        // Pre-order walk callback
-        [](CallOpInterface callOp, FunctionOpInterface funcOp) {},
-        // Post-order walk callback
-        [&](FunctionOpInterface funcOp) {
-          auto &allocation = *moduleAllocation.getFuncData(funcOp);
-          if (!funcMap.try_emplace(funcOp).second)
-            return;
-          AnalysisT(allocation, filter).run(funcOp, funcMap);
-        });
-  }
 
 private:
-  ModuleAllocation &moduleAllocation;
-  MembarFilterFn filter;
+  BufferIndexAnalysis bufferIndexAnalysis;
 };
 
 /// Inserts shared-memory barriers across a module. Function summaries retain
@@ -358,6 +318,19 @@ public:
       : moduleAllocation(moduleAllocation), filter(std::move(filter)) {}
 
   void run();
+
+  template <typename AnalysisT> void runAnalysis() {
+    triton::CallGraph<MembarInfo> callGraph(moduleAllocation.getModuleOp());
+    triton::CallGraph<MembarInfo>::FuncDataMapT summaries;
+    callGraph.walk<WalkOrder::PreOrder, WalkOrder::PostOrder>(
+        [](CallOpInterface, FunctionOpInterface) {},
+        [&](FunctionOpInterface function) {
+          if (!summaries.try_emplace(function).second)
+            return;
+          auto &allocation = *moduleAllocation.getFuncData(function);
+          AnalysisT(allocation, filter).run(function, summaries);
+        });
+  }
 
 private:
   ModuleAllocation &moduleAllocation;

--- a/lib/Analysis/Membar.cpp
+++ b/lib/Analysis/Membar.cpp
@@ -349,16 +349,5 @@ void MembarAnalysis::update(Operation *op, MembarInfo *membarInfo,
   }
 }
 
-void ModuleMembarAnalysis::run() {
-  triton::CallGraph<MembarInfo> callGraph(moduleAllocation.getModuleOp());
-  triton::CallGraph<MembarInfo>::FuncDataMapT summaries;
-  callGraph.walk<WalkOrder::PreOrder, WalkOrder::PostOrder>(
-      [](CallOpInterface, FunctionOpInterface) {},
-      [&](FunctionOpInterface function) {
-        if (!summaries.try_emplace(function).second)
-          return;
-        auto &allocation = *moduleAllocation.getFuncData(function);
-        MembarAnalysis(allocation, filter).run(function, summaries);
-      });
-}
+void ModuleMembarAnalysis::run() { runAnalysis<MembarAnalysis>(); }
 } // namespace mlir

--- a/lib/Dialect/TritonNvidiaGPU/Transforms/ClusterBarrierInsertion.cpp
+++ b/lib/Dialect/TritonNvidiaGPU/Transforms/ClusterBarrierInsertion.cpp
@@ -375,13 +375,26 @@ void ClusterBarrierAnalysis::update(Operation *op, MembarInfo *membarInfo,
       ttng::ClusterBarrierOp::create(*builder, op->getLoc());
     }
 
-    // Clear prior distributed dependencies if we have inserted a cluster
-    // barrier, or if the scratch op itself performs a cluster-level sync.
     bool hasClusterSync = isDistributedMultiCTAOp(op, /*isRead=*/true);
-    if (insertClusterBarrierNeeded)
+    if (insertClusterBarrierNeeded) {
+      // The inserted barrier precedes the current operation, so it clears only
+      // incoming state. Keep curBlockInfo because all of the operation's
+      // scratch effects occur after the barrier.
+      // For example:
+      //   pending = R(scratch), curBlockInfo = W(scratch)
+      //   cluster_barrier
+      //   pending = {},          curBlockInfo = W(scratch)
       membarInfo->sync();
+    }
 
     if (hasClusterSync) {
+      // A distributed scratch operation synchronizes between its write and
+      // read phases. Record the write before clearing the state, then retain
+      // only the read as an outgoing effect.
+      // For example:
+      //   addBlockInfo records W(scratch)
+      //   internal cluster sync clears W(scratch)
+      //   the insertion below records R(scratch)
       membarInfo->addBlockInfo(curBlockInfo);
       membarInfo->sync();
       curBlockInfo.sync();

--- a/lib/Dialect/TritonNvidiaGPU/Transforms/ClusterBarrierInsertion.cpp
+++ b/lib/Dialect/TritonNvidiaGPU/Transforms/ClusterBarrierInsertion.cpp
@@ -392,9 +392,9 @@ void ClusterBarrierAnalysis::update(Operation *op, MembarInfo *membarInfo,
       // read phases. Record the write before clearing the state, then retain
       // only the read as an outgoing effect.
       // For example:
-      //   addBlockInfo records W(scratch)
-      //   internal cluster sync clears W(scratch)
-      //   the insertion below records R(scratch)
+      //   pending = {},          curBlockInfo = W(scratch)
+      //   cluster_barrier
+      //   pending = {},          curBlockInfo = R(scratch)
       membarInfo->addBlockInfo(curBlockInfo);
       membarInfo->sync();
       curBlockInfo.sync();

--- a/lib/Dialect/TritonNvidiaGPU/Transforms/ClusterBarrierInsertion.cpp
+++ b/lib/Dialect/TritonNvidiaGPU/Transforms/ClusterBarrierInsertion.cpp
@@ -275,19 +275,19 @@ insertCrossCTAMBarrierInitSyncForFunction(FunctionOpInterface funcOp,
   return success();
 }
 
-class ClusterBarrierAnalysis : public MembarOrFenceAnalysis {
+class ClusterBarrierAnalysis : public MembarAnalysis {
 public:
-  using MembarOrFenceAnalysis::MembarOrFenceAnalysis;
+  using MembarAnalysis::MembarAnalysis;
 
 private:
-  void update(Operation *op, BlockInfo *blockInfo, FuncMapT *funcMap,
+  void update(Operation *op, MembarInfo *membarInfo, FuncMapT *funcMap,
               OpBuilder *builder) override;
 };
 
-void ClusterBarrierAnalysis::update(Operation *op, BlockInfo *blockInfo,
+void ClusterBarrierAnalysis::update(Operation *op, MembarInfo *membarInfo,
                                     FuncMapT *funcMap, OpBuilder *builder) {
   if (isa<ttng::ClusterBarrierOp>(op)) {
-    blockInfo->sync();
+    membarInfo->sync();
     return;
   }
 
@@ -300,7 +300,7 @@ void ClusterBarrierAnalysis::update(Operation *op, BlockInfo *blockInfo,
     if (isKernel(funcOp)) {
       builder->setInsertionPoint(op);
       ttng::ClusterBarrierOp::create(*builder, op->getLoc());
-      blockInfo->sync();
+      membarInfo->sync();
     }
     return;
   }
@@ -308,16 +308,27 @@ void ClusterBarrierAnalysis::update(Operation *op, BlockInfo *blockInfo,
   BlockInfo curBlockInfo;
   auto scratchBufferId = Allocation::InvalidBufferId;
   if (isa<triton::CallOp>(op)) {
-    auto callOpInterface = dyn_cast<CallOpInterface>(op);
-    if (auto callee =
-            dyn_cast<FunctionOpInterface>(callOpInterface.resolveCallable())) {
-      auto calleeBlockInfo = funcMap->lookup(callee);
+    auto call = cast<CallOpInterface>(op);
+    if (auto callee = dyn_cast<FunctionOpInterface>(call.resolveCallable())) {
+      MembarInfo calleeMembarInfo = funcMap->lookup(callee);
       auto callBufferId = allocation.getBufferId(op);
       size_t callOffset = 0;
       if (callBufferId != Allocation::InvalidBufferId)
         callOffset = allocation.getAllocatedInterval(callBufferId).start();
-      curBlockInfo = translateBlockInfoToCallsite(calleeBlockInfo, callOffset);
+      calleeMembarInfo.pending =
+          translateBlockInfoToCallsite(calleeMembarInfo.pending, callOffset);
+      calleeMembarInfo.entryBlockInfo = translateBlockInfoToCallsite(
+          calleeMembarInfo.entryBlockInfo, callOffset);
+      if (membarInfo->pending.isIntersected(calleeMembarInfo.entryBlockInfo,
+                                            filter, &allocation,
+                                            isPreAllocAliasSliceFilter)) {
+        builder->setInsertionPoint(op);
+        ttng::ClusterBarrierOp::create(*builder, op->getLoc());
+        membarInfo->sync();
+      }
+      membarInfo->applyCallSummary(calleeMembarInfo);
     }
+    return;
   } else {
     if (auto memEffects = dyn_cast<MemoryEffectOpInterface>(op)) {
       SmallVector<SideEffects::EffectInstance<MemoryEffects::Effect>>
@@ -357,7 +368,7 @@ void ClusterBarrierAnalysis::update(Operation *op, BlockInfo *blockInfo,
     auto scratchSlice = AllocationSlice(interval);
     curBlockInfo.syncWriteSlices[scratchSlice].insert(op);
 
-    auto insertClusterBarrierNeeded = blockInfo->isIntersected(
+    auto insertClusterBarrierNeeded = membarInfo->pending.isIntersected(
         curBlockInfo, filter, &allocation, isPreAllocAliasSliceFilter);
     if (insertClusterBarrierNeeded) {
       builder->setInsertionPoint(op);
@@ -367,18 +378,25 @@ void ClusterBarrierAnalysis::update(Operation *op, BlockInfo *blockInfo,
     // Clear prior distributed dependencies if we have inserted a cluster
     // barrier, or if the scratch op itself performs a cluster-level sync.
     bool hasClusterSync = isDistributedMultiCTAOp(op, /*isRead=*/true);
-    if (insertClusterBarrierNeeded || hasClusterSync)
-      blockInfo->sync();
+    if (insertClusterBarrierNeeded)
+      membarInfo->sync();
+
+    if (hasClusterSync) {
+      membarInfo->addBlockInfo(curBlockInfo);
+      membarInfo->sync();
+      curBlockInfo.sync();
+    }
 
     curBlockInfo.syncReadSlices[scratchSlice].insert(op);
-  } else if (blockInfo->isIntersected(curBlockInfo, filter, &allocation,
-                                      isPreAllocAliasSliceFilter)) {
+  } else if (membarInfo->pending.isIntersected(curBlockInfo, filter,
+                                               &allocation,
+                                               isPreAllocAliasSliceFilter)) {
     builder->setInsertionPoint(op);
     ttng::ClusterBarrierOp::create(*builder, op->getLoc());
-    blockInfo->sync();
+    membarInfo->sync();
   }
 
-  blockInfo->join(curBlockInfo);
+  membarInfo->addBlockInfo(curBlockInfo);
 }
 
 } // namespace
@@ -400,9 +418,8 @@ void runClusterBarrierInsertion(ModuleAllocation &moduleAllocation,
     return !lhsDist && !rhsDist;
   };
 
-  ModuleMembarOrFenceAnalysis<ClusterBarrierAnalysis> analysis(moduleAllocation,
-                                                               filterFn);
-  analysis.run();
+  ModuleMembarAnalysis analysis(moduleAllocation, filterFn);
+  analysis.runAnalysis<ClusterBarrierAnalysis>();
 }
 
 LogicalResult

--- a/lib/Dialect/TritonNvidiaGPU/Transforms/TMemBarrierInsertion.cpp
+++ b/lib/Dialect/TritonNvidiaGPU/Transforms/TMemBarrierInsertion.cpp
@@ -225,12 +225,12 @@ static void appendWriteSlices(Value value, Operation *op,
     blockInfo->syncWriteSlices[slice].insert(op);
 }
 
-class TMemBarrierAnalysis : public MembarOrFenceAnalysis {
+class TMemBarrierAnalysis : public MembarAnalysis {
 public:
-  using MembarOrFenceAnalysis::MembarOrFenceAnalysis;
+  using MembarAnalysis::MembarAnalysis;
 
 private:
-  void update(Operation *operation, BlockInfo *blockInfo, FuncMapT *funcMap,
+  void update(Operation *operation, MembarInfo *membarInfo, FuncMapT *funcMap,
               OpBuilder *builder) override;
 
   void insertBarrier(Operation *operation, OpBuilder *builder);
@@ -242,18 +242,29 @@ void TMemBarrierAnalysis::insertBarrier(Operation *op, OpBuilder *builder) {
                                  triton::gpu::AddrSpace::Local);
 }
 
-void TMemBarrierAnalysis::update(Operation *op, BlockInfo *blockInfo,
+void TMemBarrierAnalysis::update(Operation *op, MembarInfo *membarInfo,
                                  FuncMapT *funcMap, OpBuilder *builder) {
   if (mlir::containsLocalBarrier(op)) {
-    blockInfo->sync();
+    membarInfo->sync();
     return;
   }
 
   BlockInfo curBlockInfo;
   if (isa<triton::CallOp>(op)) {
-    auto call = dyn_cast<CallOpInterface>(op);
-    if (auto callee = dyn_cast<FunctionOpInterface>(call.resolveCallable()))
-      curBlockInfo = funcMap->lookup(callee);
+    auto call = cast<CallOpInterface>(op);
+    if (auto callee = dyn_cast<FunctionOpInterface>(call.resolveCallable())) {
+      // Tensor-memory allocation attributes are physical addresses assigned
+      // across the whole module, so callee slices need no call-frame offset.
+      MembarInfo calleeMembarInfo = funcMap->lookup(callee);
+      if (membarInfo->pending.isIntersected(calleeMembarInfo.entryBlockInfo,
+                                            filter, &allocation)) {
+        builder->setInsertionPoint(op);
+        insertBarrier(op, builder);
+        membarInfo->sync();
+      }
+      membarInfo->applyCallSummary(calleeMembarInfo);
+    }
+    return;
   } else if (auto load = dyn_cast<TMEMLoadOp>(op)) {
     appendReadSlices(load.getSrc(), op, &curBlockInfo);
   } else if (auto store = dyn_cast<TMEMStoreOp>(op)) {
@@ -272,13 +283,13 @@ void TMemBarrierAnalysis::update(Operation *op, BlockInfo *blockInfo,
     appendWriteSlices(copy.getDst(), op, &curBlockInfo);
   }
 
-  if (blockInfo->isIntersected(curBlockInfo, filter, &allocation)) {
+  if (membarInfo->pending.isIntersected(curBlockInfo, filter, &allocation)) {
     builder->setInsertionPoint(op);
     insertBarrier(op, builder);
-    blockInfo->sync();
+    membarInfo->sync();
   }
 
-  blockInfo->join(curBlockInfo);
+  membarInfo->addBlockInfo(curBlockInfo);
 }
 
 } // namespace
@@ -292,9 +303,8 @@ struct TMemBarrierInsertionPass
   void runOnOperation() override {
     ModuleOp mod = getOperation();
     ModuleAllocation allocation(mod);
-    ModuleMembarOrFenceAnalysis<TMemBarrierAnalysis> analysis(allocation,
-                                                              filterFn);
-    analysis.run();
+    ModuleMembarAnalysis analysis(allocation, filterFn);
+    analysis.runAnalysis<TMemBarrierAnalysis>();
   }
 };
 

--- a/test/TritonNvidiaGPU/membar-cluster.mlir
+++ b/test/TritonNvidiaGPU/membar-cluster.mlir
@@ -24,6 +24,45 @@ module attributes {"ttg.num-ctas" = 2 : i32, "ttg.num-warps" = 4 : i32, ttg.targ
 
 // -----
 
+#blockedCallSrc = #ttg.blocked<{sizePerThread = [1, 32], threadsPerWarp = [32, 1], warpsPerCTA = [4, 1], order = [0, 1], CGALayout = [[1, 0]]}>
+#blockedCallDst = #ttg.blocked<{sizePerThread = [1, 32], threadsPerWarp = [32, 1], warpsPerCTA = [4, 1], order = [0, 1], CGALayout = [[0, 1]]}>
+
+module attributes {"ttg.num-ctas" = 2 : i32, "ttg.num-warps" = 4 : i32, ttg.target = "cuda:90", "ttg.threads-per-warp" = 32 : i32} {
+  // CHECK-LABEL: @cluster_entry_c
+  // CHECK: ttg.convert_layout
+  // CHECK-NEXT: ttng.cluster_barrier
+  tt.func private @cluster_entry_c() {
+    %cst = arith.constant dense<0.0> : tensor<256x128xf16, #blockedCallSrc>
+    %cvt = ttg.convert_layout %cst : tensor<256x128xf16, #blockedCallSrc> -> tensor<256x128xf16, #blockedCallDst>
+    ttng.cluster_barrier
+    tt.return
+  }
+
+  // CHECK-LABEL: @cluster_entry_b
+  // CHECK-NOT: ttng.cluster_barrier
+  // CHECK: tt.call @cluster_entry_c
+  tt.func private @cluster_entry_b() {
+    tt.call @cluster_entry_c() : () -> ()
+    tt.return
+  }
+
+  // CHECK-LABEL: @cluster_entry_a
+  // CHECK-NOT: ttng.cluster_barrier
+  // CHECK: tt.call @cluster_entry_b
+  // CHECK: ttg.convert_layout
+  // CHECK-NEXT: ttng.cluster_barrier
+  // CHECK-NEXT: tt.call @cluster_entry_b
+  tt.func @cluster_entry_a() {
+    tt.call @cluster_entry_b() : () -> ()
+    %cst = arith.constant dense<0.0> : tensor<256x128xf16, #blockedCallSrc>
+    %cvt = ttg.convert_layout %cst : tensor<256x128xf16, #blockedCallSrc> -> tensor<256x128xf16, #blockedCallDst>
+    tt.call @cluster_entry_b() : () -> ()
+    tt.return
+  }
+}
+
+// -----
+
 #barrierEncPartial = #ttg.swizzled_shared<{vec = 1, perPhase = 1, maxPhase = 1, order = [0], CGALayout = [[0]]}>
 #smem = #ttg.shared_memory
 

--- a/test/TritonNvidiaGPU/membar-cluster.mlir
+++ b/test/TritonNvidiaGPU/membar-cluster.mlir
@@ -269,6 +269,46 @@ module attributes {"ttg.num-ctas" = 2 : i32, "ttg.num-warps" = 4 : i32, ttg.targ
   }
 }
 
+// -----
+
+#blockedRetain = #ttg.blocked<{sizePerThread = [1, 32], threadsPerWarp = [8, 4], warpsPerCTA = [4, 1], order = [0, 1], CGALayout = [[0, 1]]}>
+#sliceRetain0 = #ttg.slice<{dim = 0, parent = #blockedRetain}>
+#sliceRetain1 = #ttg.slice<{dim = 1, parent = #blockedRetain}>
+#sharedRetain = #ttg.nvmma_shared<{swizzlingByteWidth = 128, transposed = false, elementBitWidth = 32, CGALayout = [[0, 0]]}>
+#tmemRetain = #ttng.tensor_memory_encoding<blockM = 128, blockN = 128, colStride = 1, CGALayout = [[0, 0]]>
+#smem = #ttg.shared_memory
+
+module attributes {"ttg.num-ctas" = 2 : i32, "ttg.num-warps" = 4 : i32, "ttng.two-ctas" = true, ttg.target = "cuda:100", "ttg.threads-per-warp" = 32 : i32} {
+  // The cross-CTA reduction leaves a distributed scratch read pending and
+  // forces a cluster barrier before the non-cross-CTA reduction. That barrier
+  // is before the second reduction, so its scratch effects must remain pending
+  // and force another cluster barrier before the two-CTA tmem copy that reuses
+  // the same shared-memory offset.
+  // CHECK-LABEL: @retain_scratch_effects_after_inserted_cluster_barrier
+  // CHECK: "tt.reduce"{{.*}}axis = 1
+  // CHECK: ttng.cluster_barrier
+  // CHECK: "tt.reduce"{{.*}}axis = 0
+  // CHECK: ttng.cluster_barrier
+  // CHECK-NEXT: ttng.tmem_copy
+  tt.func @retain_scratch_effects_after_inserted_cluster_barrier(%input: tensor<256x128xf16, #blockedRetain>) {
+    %cross = "tt.reduce"(%input) ({
+    ^bb0(%lhs: f16, %rhs: f16):
+      %add = arith.addf %lhs, %rhs : f16
+      tt.reduce.return %add : f16
+    }) {axis = 1 : i32} : (tensor<256x128xf16, #blockedRetain>) -> tensor<256xf16, #sliceRetain1>
+
+    %local = "tt.reduce"(%input) ({
+    ^bb0(%lhs: f16, %rhs: f16):
+      %add = arith.addf %lhs, %rhs : f16
+      tt.reduce.return %add : f16
+    }) {axis = 0 : i32} : (tensor<256x128xf16, #blockedRetain>) -> tensor<128xf16, #sliceRetain0>
+
+    %src = ttg.local_alloc : () -> !ttg.memdesc<128x128xf32, #sharedRetain, #smem, mutable>
+    %dst = ttng.tmem_alloc : () -> !ttg.memdesc<128x128xf32, #tmemRetain, #ttng.tensor_memory, mutable>
+    ttng.tmem_copy %src, %dst : !ttg.memdesc<128x128xf32, #sharedRetain, #smem, mutable>, !ttg.memdesc<128x128xf32, #tmemRetain, #ttng.tensor_memory, mutable>
+    tt.return
+  }
+}
 
 // -----
 

--- a/test/TritonNvidiaGPU/tmem_barrier_insertion.mlir
+++ b/test/TritonNvidiaGPU/tmem_barrier_insertion.mlir
@@ -330,4 +330,37 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32} {
     ttng.tmem_copy %arg1, %0 : !ttg.memdesc<128x128xf32, #shared_copy, #ttg.shared_memory>, !ttg.memdesc<128x128xf32, #tmem128, #ttng.tensor_memory, mutable>
     tt.return
   }
+
+  // CHECK-LABEL: @tmem_entry_c
+  // CHECK: ttng.tmem_alloc
+  // CHECK-NEXT: ttg.barrier local
+  tt.func private @tmem_entry_c() {
+    %cst = arith.constant dense<0.0> : tensor<128x128xf32, #blocked>
+    %alloc = ttng.tmem_alloc %cst {tensor_memory_col_offset = 0 : i32, tensor_memory_row_offset = 0 : i32} : (tensor<128x128xf32, #blocked>) -> !ttg.memdesc<128x128xf32, #tmem128, #ttng.tensor_memory, mutable>
+    ttg.barrier local
+    tt.return
+  }
+
+  // CHECK-LABEL: @tmem_entry_b
+  // CHECK-NOT: ttg.barrier local
+  // CHECK: tt.call @tmem_entry_c
+  tt.func private @tmem_entry_b() {
+    tt.call @tmem_entry_c() : () -> ()
+    tt.return
+  }
+
+  // CHECK-LABEL: @tmem_entry_a
+  // CHECK-NOT: ttg.barrier local
+  // CHECK: tt.call @tmem_entry_b
+  // CHECK: ttng.tmem_load
+  // CHECK-NEXT: ttg.barrier local
+  // CHECK-NEXT: tt.call @tmem_entry_b
+  tt.func @tmem_entry_a() {
+    tt.call @tmem_entry_b() : () -> ()
+    %alloc = ttng.tmem_alloc {tensor_memory_col_offset = 0 : i32, tensor_memory_row_offset = 0 : i32} : () -> !ttg.memdesc<128x128xf32, #tmem128, #ttng.tensor_memory, mutable>
+    ttg.barrier local
+    %loaded = ttng.tmem_load %alloc : !ttg.memdesc<128x128xf32, #tmem128, #ttng.tensor_memory, mutable> -> tensor<128x128xf32, #blocked>
+    tt.call @tmem_entry_b() : () -> ()
+    tt.return
+  }
 }


### PR DESCRIPTION
Builds on #11389.

- Reuse MembarInfo summaries for TMem and cluster barrier analyses and remove the old MembarOrFenceAnalysis path.
- Insert a barrier before a call when caller-pending accesses conflict with the callee entry state.
- Translate shared-memory call-frame offsets for cluster barriers; keep TMEM physical addresses unchanged because tensor-memory allocation assigns module-wide row and column offsets.
- Add nested A-to-B-to-C MLIR regressions for both analyses.

Tests:
- make
- lit -v test/TritonNvidiaGPU/tmem_barrier_insertion.mlir test/TritonNvidiaGPU/membar-cluster.mlir test/Analysis/test-membar.mlir
- pre-commit run over all changed files