### PR TITLE
[AMD][IMP][Launch Latency] read use_buffer_ops once at import time

### DIFF
--- a/python/test/unit/runtime/test_cache.py
+++ b/python/test/unit/runtime/test_cache.py
@@ -838,6 +838,7 @@ def test_within_2gb(device, fresh_triton_cache) -> None:
         for use_buffer_ops, pointer_range in zip(use_buffer_ops_opts, pointer_ranges):
             # Set AMDGCN_USE_BUFFER_OPS
             os.environ["AMDGCN_USE_BUFFER_OPS"] = use_buffer_ops
+            triton.knobs.refresh_knobs()
 
             @triton.jit
             def kernel_add(a):
@@ -864,6 +865,7 @@ def test_within_2gb(device, fresh_triton_cache) -> None:
             assert pointer_range_32 == pointer_range
     finally:
         os.environ["AMDGCN_USE_BUFFER_OPS"] = default_buffer_ops
+        triton.knobs.refresh_knobs()
 
 
 def test_function_arguments(device):

--- a/python/test/unit/test_knobs.py
+++ b/python/test/unit/test_knobs.py
@@ -76,11 +76,11 @@ def test_knobs_scope(fresh_knobs, monkeypatch):
 
     assert fresh_knobs.amd.use_buffer_atomics
 
-    # Just to prove that use_buffer_ops is coming from env
-    monkeypatch.setenv("AMDGCN_USE_BUFFER_OPS", "0")
-    assert not fresh_knobs.amd.use_buffer_ops
-    monkeypatch.delenv("AMDGCN_USE_BUFFER_OPS")
-    assert fresh_knobs.amd.use_buffer_ops
+    # Just to prove that buffer_ops_analyze_small_tensor_range is coming from env
+    monkeypatch.setenv("AMDGCN_ANALYZE_SMALL_TENSOR_RANGE", "1")
+    assert fresh_knobs.amd.buffer_ops_analyze_small_tensor_range
+    monkeypatch.delenv("AMDGCN_ANALYZE_SMALL_TENSOR_RANGE")
+    assert not fresh_knobs.amd.buffer_ops_analyze_small_tensor_range
 
     with fresh_knobs.amd.scope():
         # Use the environment
@@ -93,18 +93,36 @@ def test_knobs_scope(fresh_knobs, monkeypatch):
     assert fresh_knobs.amd.use_buffer_atomics
     assert fresh_knobs.amd.use_buffer_ops
 
-    # Just to prove that use_buffer_ops is coming from env
-    monkeypatch.setenv("AMDGCN_USE_BUFFER_OPS", "0")
-    assert not fresh_knobs.amd.use_buffer_ops
-    monkeypatch.delenv("AMDGCN_USE_BUFFER_OPS")
+    # Just to prove that buffer_ops_analyze_small_tensor_range is coming from env
+    monkeypatch.setenv("AMDGCN_ANALYZE_SMALL_TENSOR_RANGE", "1")
+    assert fresh_knobs.amd.buffer_ops_analyze_small_tensor_range
+    monkeypatch.delenv("AMDGCN_ANALYZE_SMALL_TENSOR_RANGE")
+    assert not fresh_knobs.amd.buffer_ops_analyze_small_tensor_range
+
+
+def test_use_buffer_ops_is_read_once(fresh_knobs, monkeypatch):
+    # use_buffer_ops is read at import time, only refresh_knobs() re-reads it
     assert fresh_knobs.amd.use_buffer_ops
+
+    monkeypatch.setenv("AMDGCN_USE_BUFFER_OPS", "0")
+    assert fresh_knobs.amd.use_buffer_ops
+    triton.knobs.refresh_knobs()
+    assert not fresh_knobs.amd.use_buffer_ops
+
+    monkeypatch.delenv("AMDGCN_USE_BUFFER_OPS")
+    triton.knobs.refresh_knobs()
+    assert fresh_knobs.amd.use_buffer_ops
+
+    # Explicit assignment still wins
+    fresh_knobs.amd.use_buffer_ops = False
+    assert not fresh_knobs.amd.use_buffer_ops
 
 
 def test_env_updated(fresh_knobs, monkeypatch):
-    fresh_knobs.amd.use_buffer_ops = False
-    assert os.getenv("AMDGCN_USE_BUFFER_OPS") == "0"
+    fresh_knobs.amd.use_buffer_atomics = False
+    assert os.getenv("AMDGCN_USE_BUFFER_ATOMICS") == "0"
     # Just triple checking both APIs give us what we expect
-    assert os.environ["AMDGCN_USE_BUFFER_OPS"] == "0"
+    assert os.environ["AMDGCN_USE_BUFFER_ATOMICS"] == "0"
 
     fresh_knobs.cache.home_dir = "/foo/bar"
     assert os.getenv("TRITON_HOME") == "/foo/bar"

--- a/python/triton/knobs.py
+++ b/python/triton/knobs.py
@@ -515,7 +515,9 @@ class nvidia_knobs(base_knobs):
 
 
 class amd_knobs(base_knobs):
-    use_buffer_ops: env_bool = env_bool("AMDGCN_USE_BUFFER_OPS", True)
+    # use_buffer_ops is read once per tensor arg on the kernel launch critical path
+    # avoid repeated reads from env-var by calling get directly
+    use_buffer_ops: bool = env_bool("AMDGCN_USE_BUFFER_OPS", True).get()
     # Note: This requires use_buffer_ops be true to have any effect
     use_buffer_atomics: env_bool = env_bool("AMDGCN_USE_BUFFER_ATOMICS", True)
     # Note: This requires use_buffer_ops be true to have any effect
@@ -595,3 +597,4 @@ proton = proton_knobs()
 def refresh_knobs():
     runtime.debug = env_bool("TRITON_DEBUG").get()
     compilation.instrumentation_mode = env_str("TRITON_INSTRUMENTATION_MODE", "").get()
+    amd.use_buffer_ops = env_bool("AMDGCN_USE_BUFFER_OPS", True).get()


### PR DESCRIPTION
# New contributor declaration
- [x] I am not making a trivial change, such as fixing a typo in a comment.

- [x] I have written a PR description following these
  [rules](https://cbea.ms/git-commit/#why-not-how).

- [x] I have run `pre-commit run --from-ref origin/main --to-ref HEAD`.

- Select one of the following.
  - [x] I have added tests.
    - `/test` for `lit` tests
    - `/unittest` for C++ tests
    - `/python/test` for end-to-end tests
  - [ ] This PR does not need a test because `FILL THIS IN`.

- Select one of the following.
  - [x] I have not added any `lit` tests.
  - [ ] The `lit` tests I have added follow these [best practices](https://mlir.llvm.org/getting_started/TestingGuide/#filecheck-best-practices),
    including the "tests should be minimal" section. (Usually running Python code
    and using the instructions it generates is not minimal.)

---

Continuing the `[IMP][Launch Latency]` work (#7767, #7841).

`HIPBackend.get_tensor_specialization` runs once per tensor argument of every launch and reads `knobs.amd.use_buffer_ops`. Since the knob is never assigned explicitly, `env_base.__get__` falls through to `getenv_bool` each time, so a kernel with N tensor arguments performs N environment lookups per launch for a value that cannot change between them.

This gives `use_buffer_ops` the same treatment `TRITON_DEBUG` got in #7767: resolve it at import time, re-read it in `refresh_knobs()`.

`get_tensor_specialization` drops from 2.98us to 1.24us per tensor argument. Empty-kernel launch, gfx1100 (RX 7900 XTX):

| kernel args | before | after | speedup |
|---|---|---|---|
| 1 tensor | 14.63us | 12.58us | 1.16x |
| 2 tensors | 18.86us | 15.25us | 1.24x |
| 4 tensors | 26.96us | 19.32us | 1.40x |
| 8 tensors | 43.79us | 26.89us | 1.63x |

Integer arguments are unaffected (+0.26us each), which is the tell: they go through `BaseBackend.get_int_specialization`, which never touches `knobs`.

Measured on Windows, where `getenv` is comparatively expensive (~1.8us vs ~0.8us for Python's cached `os.environ`). The absolute win on Linux will be smaller, but the lookup is redundant on every platform.

## Tests

`test_knobs_scope` and `test_env_updated` used `use_buffer_ops` as their example of an env-driven knob, so they now use `buffer_ops_analyze_small_tensor_range` and `use_buffer_atomics`, which stay dynamic. `test_within_2gb` toggles the env var at runtime and now calls `refresh_knobs()` after doing so.

New `test_use_buffer_ops_is_read_once` covers the three behaviours: the env is read at import time, `refresh_knobs()` re-reads it, and explicit assignment still wins.

