### PR TITLE
[LLVM] Support histogram integer input widths

### DIFF
--- a/lib/Conversion/TritonGPUToLLVM/HistogramOpToLLVM.cpp
+++ b/lib/Conversion/TritonGPUToLLVM/HistogramOpToLLVM.cpp
@@ -38,7 +38,24 @@ static SmallVector<Value> computeHistogram(
   // Apply atomic add to update the histogram in shared memory.
   Value numBinsValue = b.i32_val(numBins);
   for (int i = 0; i < srcValues.size(); ++i) {
-    Value updatePred = b.icmp_ult(srcValues[i], numBinsValue);
+    Value srcValue = srcValues[i];
+    Value histogramIndex = srcValue;
+    Value compareValue = srcValue;
+    Value compareLimit = numBinsValue;
+    unsigned srcWidth = srcValue.getType().getIntOrFloatBitWidth();
+
+    // Histogram storage is indexed with i32. Narrow inputs must be widened
+    // before the comparison/index, while wide inputs must be range-checked at
+    // their original width before truncation so large values cannot alias a
+    // valid bin.
+    if (srcWidth < 32) {
+      histogramIndex = b.zext(i32_ty, srcValue);
+      compareValue = histogramIndex;
+    } else if (srcWidth > 32) {
+      compareLimit = b.zext(srcValue.getType(), numBinsValue);
+    }
+
+    Value updatePred = b.icmp_ult(compareValue, compareLimit);
     if (!maskValues.empty())
       updatePred = b.and_(updatePred, maskValues[i]);
 
@@ -46,8 +63,10 @@ static SmallVector<Value> computeHistogram(
         createIfBlock(rewriter, loc, updatePred);
     (void)prevBlock;
     rewriter.setInsertionPointToStart(ifBlock);
+    if (srcWidth > 32)
+      histogramIndex = b.trunc(i32_ty, srcValue);
     Value sharedMemPtr = b.gep(baseSharedMemPtr.getType(), i32_ty,
-                               baseSharedMemPtr, srcValues[i]);
+                               baseSharedMemPtr, histogramIndex);
     atomicAddOne(sharedMemPtr, loc, rewriter);
     rewriter.setInsertionPointToStart(thenBlock);
   }

--- a/test/Conversion/histogram_integer_widths.mlir
+++ b/test/Conversion/histogram_integer_widths.mlir
@@ -1,0 +1,44 @@
+// RUN: triton-opt %s -split-input-file --allocate-shared-memory-nv --convert-triton-gpu-to-llvm -reconcile-unrealized-casts 2>/dev/null | FileCheck %s --dump-input-context 20
+
+#blocked = #ttg.blocked<{sizePerThread = [1], threadsPerWarp = [32], warpsPerCTA = [4], order = [0]}>
+module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, "ttg.threads-per-warp" = 32 : i32} {
+  // CHECK-LABEL: @histogram_i8
+  // CHECK: llvm.zext {{.*}} : i8 to i32
+  // CHECK: llvm.icmp "ult"
+  // CHECK: llvm.atomicrmw add
+  tt.func @histogram_i8(%src: tensor<256xi8, #blocked>, %mask: tensor<256xi1, #blocked>, %out_ptr: tensor<8x!tt.ptr<i32>, #blocked>) {
+    %hist = tt.histogram %src, %mask : tensor<256xi8, #blocked> -> tensor<8xi32, #blocked>
+    tt.store %out_ptr, %hist : tensor<8x!tt.ptr<i32>, #blocked>
+    tt.return
+  }
+}
+
+// -----
+
+#blocked = #ttg.blocked<{sizePerThread = [1], threadsPerWarp = [32], warpsPerCTA = [4], order = [0]}>
+module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, "ttg.threads-per-warp" = 32 : i32} {
+  // CHECK-LABEL: @histogram_i16
+  // CHECK: llvm.zext {{.*}} : i16 to i32
+  // CHECK: llvm.icmp "ult"
+  // CHECK: llvm.atomicrmw add
+  tt.func @histogram_i16(%src: tensor<256xi16, #blocked>, %mask: tensor<256xi1, #blocked>, %out_ptr: tensor<8x!tt.ptr<i32>, #blocked>) {
+    %hist = tt.histogram %src, %mask : tensor<256xi16, #blocked> -> tensor<8xi32, #blocked>
+    tt.store %out_ptr, %hist : tensor<8x!tt.ptr<i32>, #blocked>
+    tt.return
+  }
+}
+
+// -----
+
+#blocked = #ttg.blocked<{sizePerThread = [1], threadsPerWarp = [32], warpsPerCTA = [4], order = [0]}>
+module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, "ttg.threads-per-warp" = 32 : i32} {
+  // CHECK-LABEL: @histogram_i64
+  // CHECK: llvm.icmp "ult"
+  // CHECK: llvm.trunc {{.*}} : i64 to i32
+  // CHECK: llvm.atomicrmw add
+  tt.func @histogram_i64(%src: tensor<256xi64, #blocked>, %mask: tensor<256xi1, #blocked>, %out_ptr: tensor<8x!tt.ptr<i32>, #blocked>) {
+    %hist = tt.histogram %src, %mask : tensor<256xi64, #blocked> -> tensor<8xi32, #blocked>
+    tt.store %out_ptr, %hist : tensor<8x!tt.ptr<i32>, #blocked>
+    tt.return
+  }
+}


### PR DESCRIPTION
Fixes #10890.

## What changed

`HistogramOpToLLVM` used histogram source elements directly in an `i32` bin-count comparison and an `i32` shared-memory GEP. That produces invalid LLVM IR for frontend-valid narrow integer inputs such as `i8` and `i16`.

This change:

- zero-extends integer inputs narrower than 32 bits before the bin-range comparison and shared-memory index;
- range-checks integer inputs wider than 32 bits at their original width, then truncates only after the value is known to fit a valid bin;
- preserves the existing `i32` behavior;
- adds a compiler-only lit regression covering `i8`, `i16`, and `i64` histogram inputs.

The wide-input ordering is intentional: truncating before the range check could allow a large `i64` value to wrap into a valid 32-bit bin index.

## Validation

Added `test/Conversion/histogram_integer_widths.mlir`, which runs the existing `triton-opt` conversion pipeline and checks the expected widening/truncation plus histogram atomic update for `i8`, `i16`, and `i64` inputs.

`triton-opt` and repository pre-commit checks were not run locally because this environment does not contain a Triton build and cannot clone the repository. No local test result is claimed; CI should execute the new lit regression.

# New contributor declaration

- [x] I am not making a trivial change, such as fixing a typo in a comment.
- [x] I have written a PR description following these [rules](https://cbea.ms/git-commit/#why-not-how).
- [ ] I have run `pre-commit run --from-ref origin/main --to-ref HEAD`.
- [x] I have added tests.
  - `/test` for `lit` tests
  - `/unittest` for C++ tests
  - `/python/test` for end-to-end tests
- [ ] I have not added any `lit` tests.
- [x] The `lit` tests I have added follow these [best practices](https://mlir.llvm.org/getting_started/TestingGuide/#filecheck-best-practices), including the "tests should be minimal" section.