### PR TITLE
[MEMBAR] Improve cross CTA membar handling missing ops

### DIFF
--- a/lib/Dialect/TritonNvidiaGPU/Transforms/ClusterBarrierInsertion.cpp
+++ b/lib/Dialect/TritonNvidiaGPU/Transforms/ClusterBarrierInsertion.cpp
@@ -1,7 +1,6 @@
 #include "triton/Dialect/TritonNvidiaGPU/Transforms/ClusterBarrierInsertion.h"
 #include "triton/Analysis/Allocation.h"
 #include "triton/Analysis/Membar.h"
-#include "triton/Analysis/Utility.h"
 #include "triton/Dialect/Triton/IR/Utility.h"
 #include "triton/Dialect/TritonGPU/IR/Dialect.h"
 #include "triton/Dialect/TritonNvidiaGPU/IR/Dialect.h"
@@ -26,22 +25,10 @@ namespace ttg = mlir::triton::gpu;
 namespace ttng = mlir::triton::nvidia_gpu;
 
 static bool isDistributedMultiCTAOp(Operation *op, bool isRead) {
-  if (auto cvt = dyn_cast<ttg::ConvertLayoutOp>(op)) {
-    if (!isRead)
-      return false;
-    auto srcTy = cvt.getSrc().getType();
-    auto dstTy = cvt.getType();
-    auto kBlock = StringAttr::get(op->getContext(), "block");
-    return !isCvtDimSync(ttg::toLinearLayout(srcTy), ttg::toLinearLayout(dstTy),
-                         kBlock);
-  }
-  if (auto reduce = dyn_cast<triton::ReduceOp>(op)) {
-    if (!isRead)
-      return false;
-    auto srcTy = reduce.getInputTypes()[0];
-    auto splitNum = ttg::getCTASplitNum(srcTy.getEncoding());
-    return splitNum[reduce.getAxis()] > 1;
-  }
+  // Scratch writes are CTA-local. When the scratch spans CTAs, only its read
+  // phase accesses another CTA's shared memory.
+  if (hasCrossCTAScratch(op))
+    return isRead;
   if (isa<ttng::CLCTryCancelOp, ttng::AsyncSharedStoreOp>(op)) {
     return ttg::lookupNumCTAs(op) > 1;
   } else if (isa<ttng::TMEMCopyOp>(op)) {
@@ -362,13 +349,19 @@ void ClusterBarrierAnalysis::update(Operation *op, BlockInfo *blockInfo,
     if (insertClusterBarrierNeeded) {
       builder->setInsertionPoint(op);
       ttng::ClusterBarrierOp::create(*builder, op->getLoc());
+      blockInfo->sync();
     }
 
-    // Clear prior distributed dependencies if we have inserted a cluster
-    // barrier, or if the scratch op itself performs a cluster-level sync.
-    bool hasClusterSync = isDistributedMultiCTAOp(op, /*isRead=*/true);
-    if (insertClusterBarrierNeeded || hasClusterSync)
+    // A scratch operation that crosses CTAs synchronizes internally between
+    // its write and read phases. Keep its write before that synchronization
+    // and only its read afterward:
+    //   write scratch -> cluster barrier -> read scratch
+    bool hasInternalClusterSync = hasCrossCTAScratch(op);
+    if (hasInternalClusterSync) {
+      blockInfo->join(curBlockInfo);
       blockInfo->sync();
+      curBlockInfo.sync();
+    }
 
     curBlockInfo.syncReadSlices[scratchSlice].insert(op);
   } else if (blockInfo->isIntersected(curBlockInfo, filter, &allocation,

--- a/lib/Dialect/TritonNvidiaGPU/Transforms/ClusterBarrierInsertion.cpp
+++ b/lib/Dialect/TritonNvidiaGPU/Transforms/ClusterBarrierInsertion.cpp
@@ -360,8 +360,8 @@ void ClusterBarrierAnalysis::update(Operation *op, BlockInfo *blockInfo,
     // its write and read phases. Keep its write before that synchronization
     // and only its read afterward:
     //   write scratch -> cluster barrier -> read scratch
-    bool hasInternalClusterSync = hasCrossCTAScratch(op);
-    if (hasInternalClusterSync) {
+    bool hasClusterSync = isDistributedMultiCTAOp(op, /*isRead=*/true);
+    if (hasClusterSync) {
       blockInfo->join(curBlockInfo);
       blockInfo->sync();
       curBlockInfo.sync();

--- a/lib/Dialect/TritonNvidiaGPU/Transforms/ClusterBarrierInsertion.cpp
+++ b/lib/Dialect/TritonNvidiaGPU/Transforms/ClusterBarrierInsertion.cpp
@@ -1,6 +1,7 @@
 #include "triton/Dialect/TritonNvidiaGPU/Transforms/ClusterBarrierInsertion.h"
 #include "triton/Analysis/Allocation.h"
 #include "triton/Analysis/Membar.h"
+#include "triton/Analysis/Utility.h"
 #include "triton/Dialect/Triton/IR/Utility.h"
 #include "triton/Dialect/TritonGPU/IR/Dialect.h"
 #include "triton/Dialect/TritonNvidiaGPU/IR/Dialect.h"
@@ -25,10 +26,22 @@ namespace ttg = mlir::triton::gpu;
 namespace ttng = mlir::triton::nvidia_gpu;
 
 static bool isDistributedMultiCTAOp(Operation *op, bool isRead) {
-  // Scratch writes are CTA-local. When the scratch spans CTAs, only its read
-  // phase accesses another CTA's shared memory.
-  if (hasCrossCTAScratch(op))
-    return isRead;
+  if (auto cvt = dyn_cast<ttg::ConvertLayoutOp>(op)) {
+    if (!isRead)
+      return false;
+    auto srcTy = cvt.getSrc().getType();
+    auto dstTy = cvt.getType();
+    auto kBlock = StringAttr::get(op->getContext(), "block");
+    return !isCvtDimSync(ttg::toLinearLayout(srcTy), ttg::toLinearLayout(dstTy),
+                         kBlock);
+  }
+  if (auto reduce = dyn_cast<triton::ReduceOp>(op)) {
+    if (!isRead)
+      return false;
+    auto srcTy = reduce.getInputTypes()[0];
+    auto splitNum = ttg::getCTASplitNum(srcTy.getEncoding());
+    return splitNum[reduce.getAxis()] > 1;
+  }
   if (isa<ttng::CLCTryCancelOp, ttng::AsyncSharedStoreOp>(op)) {
     return ttg::lookupNumCTAs(op) > 1;
   } else if (isa<ttng::TMEMCopyOp>(op)) {

--- a/lib/Dialect/TritonNvidiaGPU/Transforms/ClusterBarrierInsertion.cpp
+++ b/lib/Dialect/TritonNvidiaGPU/Transforms/ClusterBarrierInsertion.cpp
@@ -1,7 +1,6 @@
 #include "triton/Dialect/TritonNvidiaGPU/Transforms/ClusterBarrierInsertion.h"
 #include "triton/Analysis/Allocation.h"
 #include "triton/Analysis/Membar.h"
-#include "triton/Analysis/Utility.h"
 #include "triton/Dialect/Triton/IR/Utility.h"
 #include "triton/Dialect/TritonGPU/IR/Dialect.h"
 #include "triton/Dialect/TritonNvidiaGPU/IR/Dialect.h"
@@ -25,23 +24,14 @@ namespace {
 namespace ttg = mlir::triton::gpu;
 namespace ttng = mlir::triton::nvidia_gpu;
 
-static bool isDistributedMultiCTAOp(Operation *op, bool isRead) {
-  if (auto cvt = dyn_cast<ttg::ConvertLayoutOp>(op)) {
-    if (!isRead)
-      return false;
-    auto srcTy = cvt.getSrc().getType();
-    auto dstTy = cvt.getType();
-    auto kBlock = StringAttr::get(op->getContext(), "block");
-    return !isCvtDimSync(ttg::toLinearLayout(srcTy), ttg::toLinearLayout(dstTy),
-                         kBlock);
-  }
-  if (auto reduce = dyn_cast<triton::ReduceOp>(op)) {
-    if (!isRead)
-      return false;
-    auto srcTy = reduce.getInputTypes()[0];
-    auto splitNum = ttg::getCTASplitNum(srcTy.getEncoding());
-    return splitNum[reduce.getAxis()] > 1;
-  }
+// `isRead` identifies whether `op` is being classified for an entry in
+// BlockInfo::syncReadSlices or BlockInfo::syncWriteSlices. It does not describe
+// all memory effects of the operation.
+bool isDistributedMultiCTAOp(Operation *op, bool isRead) {
+  // Scratch writes are CTA-local. When the scratch spans CTAs, only its read
+  // phase accesses another CTA's shared memory.
+  if (hasCrossCTAScratch(op))
+    return isRead;
   if (isa<ttng::CLCTryCancelOp, ttng::AsyncSharedStoreOp>(op)) {
     return ttg::lookupNumCTAs(op) > 1;
   } else if (isa<ttng::TMEMCopyOp>(op)) {
@@ -54,17 +44,17 @@ static bool isDistributedMultiCTAOp(Operation *op, bool isRead) {
   return hasTCGen5CommitCrossCTA(op);
 }
 
-static bool isPreAllocAliasSliceFilter(const AllocationSlice &lhsSlice,
-                                       const AllocationSlice &rhsSlice,
-                                       bool /*lhsIsRead*/, bool /*rhsIsRead*/,
-                                       Allocation *allocation) {
+bool isPreAllocAliasSliceFilter(const AllocationSlice &lhsSlice,
+                                const AllocationSlice &rhsSlice,
+                                bool /*lhsIsRead*/, bool /*rhsIsRead*/,
+                                Allocation *allocation) {
   auto bufferId = lhsSlice.getBufferId();
   return bufferId != Allocation::InvalidBufferId &&
          bufferId == rhsSlice.getBufferId() &&
          allocation->isExplicitBuffer(bufferId);
 }
 
-static bool hasUnresolvedCrossClusterDependency(const BlockInfo &blockInfo) {
+bool hasUnresolvedCrossClusterDependency(const BlockInfo &blockInfo) {
   auto hasDistributedDependency = [](const BlockInfo::SliceMapT &slices,
                                      bool isRead) {
     for (const auto &sliceAndOps : slices)
@@ -78,9 +68,9 @@ static bool hasUnresolvedCrossClusterDependency(const BlockInfo &blockInfo) {
          hasDistributedDependency(blockInfo.syncWriteSlices, /*isRead=*/false);
 }
 
-static bool valueAliasesTrackedBuffers(Value value,
-                                       const Allocation::BufferIdSetT &tracked,
-                                       Allocation *allocation) {
+bool valueAliasesTrackedBuffers(Value value,
+                                const Allocation::BufferIdSetT &tracked,
+                                Allocation *allocation) {
   for (auto bufferId : allocation->getAllBufferIdsWithAliases(value)) {
     if (bufferId != Allocation::InvalidBufferId && tracked.contains(bufferId))
       return true;
@@ -88,10 +78,9 @@ static bool valueAliasesTrackedBuffers(Value value,
   return false;
 }
 
-static bool requiresCrossCTAMBarrierInitSync(ttng::InitBarrierOp initBarrierOp,
-                                             FunctionOpInterface funcOp,
-                                             Allocation *allocation,
-                                             int numCTAs) {
+bool requiresCrossCTAMBarrierInitSync(ttng::InitBarrierOp initBarrierOp,
+                                      FunctionOpInterface funcOp,
+                                      Allocation *allocation, int numCTAs) {
   Allocation::BufferIdSetT initBarrierBuffers;
   for (auto bufferId :
        allocation->getAllBufferIdsWithAliases(initBarrierOp.getBarrier())) {
@@ -106,9 +95,9 @@ static bool requiresCrossCTAMBarrierInitSync(ttng::InitBarrierOp initBarrierOp,
       });
 }
 
-static bool nestedOpUsesTrackedMBarrier(Operation *op,
-                                        const Allocation::BufferIdSetT &tracked,
-                                        Allocation *allocation) {
+bool nestedOpUsesTrackedMBarrier(Operation *op,
+                                 const Allocation::BufferIdSetT &tracked,
+                                 Allocation *allocation) {
   if (isa<ttng::InitBarrierOp, ttg::LocalAllocOp>(op))
     return false;
 
@@ -124,9 +113,9 @@ static bool nestedOpUsesTrackedMBarrier(Operation *op,
   return false;
 }
 
-static bool opUsesTrackedMBarrier(Operation *op,
-                                  const Allocation::BufferIdSetT &tracked,
-                                  Allocation *allocation) {
+bool opUsesTrackedMBarrier(Operation *op,
+                           const Allocation::BufferIdSetT &tracked,
+                           Allocation *allocation) {
   return op
       ->walk<WalkOrder::PreOrder>([&](Operation *nestedOp) {
         if (nestedOpUsesTrackedMBarrier(nestedOp, tracked, allocation))
@@ -136,7 +125,7 @@ static bool opUsesTrackedMBarrier(Operation *op,
       .wasInterrupted();
 }
 
-static LogicalResult
+LogicalResult
 insertCrossCTAMBarrierInitSyncForFunction(FunctionOpInterface funcOp,
                                           Allocation *allocation, int numCTAs,
                                           OpBuilder &builder) {

--- a/lib/Dialect/TritonNvidiaGPU/Transforms/ClusterBarrierInsertion.cpp
+++ b/lib/Dialect/TritonNvidiaGPU/Transforms/ClusterBarrierInsertion.cpp
@@ -24,9 +24,11 @@ namespace {
 namespace ttg = mlir::triton::gpu;
 namespace ttng = mlir::triton::nvidia_gpu;
 
-// `isRead` identifies whether `op` is being classified for an entry in
-// BlockInfo::syncReadSlices or BlockInfo::syncWriteSlices. It does not describe
-// all memory effects of the operation.
+// Returns whether an operation's tracked access touches distributed shared
+// memory across CTAs.
+// op: The operation associated with the tracked access.
+// isRead: Whether the access is recorded in BlockInfo::syncReadSlices rather
+// than BlockInfo::syncWriteSlices.
 bool isDistributedMultiCTAOp(Operation *op, bool isRead) {
   // Scratch writes are CTA-local. When the scratch spans CTAs, only its read
   // phase accesses another CTA's shared memory.

--- a/test/TritonNvidiaGPU/membar-cluster.mlir
+++ b/test/TritonNvidiaGPU/membar-cluster.mlir
@@ -233,6 +233,51 @@ module attributes {"ttg.num-ctas" = 2 : i32, "ttg.num-warps" = 4 : i32, ttg.targ
 
 // -----
 
+#sharedAtomic = #ttg.nvmma_shared<{swizzlingByteWidth = 128, transposed = false, elementBitWidth = 32, CGALayout = [[0, 0]]}>
+#tmemAtomic = #ttng.tensor_memory_encoding<blockM = 128, blockN = 128, colStride = 1, CGALayout = [[0, 0]]>
+#blockedAtomic = #ttg.blocked<{sizePerThread = [1, 32], threadsPerWarp = [8, 4], warpsPerCTA = [4, 1], order = [0, 1], CGALayout = [[0, 1]]}>
+#sliceAtomic = #ttg.slice<{dim = 0, parent = #blockedAtomic}>
+#smem = #ttg.shared_memory
+
+module attributes {"ttg.num-ctas" = 2 : i32, "ttg.num-warps" = 4 : i32, "ttng.two-ctas" = true, ttg.target = "cuda:100", "ttg.threads-per-warp" = 32 : i32} {
+  // A cross-CTA scalar atomic broadcasts its result through scratch memory as:
+  //   write scratch -> cluster barrier -> read scratch
+  // The following two-CTA tmem_copy only reads the reused scratch allocation,
+  // so the atomic's internal barrier makes another cluster barrier unnecessary.
+  // CHECK-LABEL: @cross_cta_atomic_then_tmem_copy
+  // CHECK: tt.atomic_cas
+  // CHECK-NOT: ttng.cluster_barrier
+  // CHECK: ttng.tmem_copy
+  tt.func @cross_cta_atomic_then_tmem_copy(%ptr: !tt.ptr<i32>) -> i32 {
+    %c0 = arith.constant 0 : i32
+    %result = tt.atomic_cas relaxed, gpu, %ptr, %c0, %c0 : (!tt.ptr<i32>, i32, i32) -> i32
+    %src = ttg.local_alloc : () -> !ttg.memdesc<128x128xf32, #sharedAtomic, #smem, mutable>
+    %dst = ttng.tmem_alloc : () -> !ttg.memdesc<128x128xf32, #tmemAtomic, #ttng.tensor_memory, mutable>
+    ttng.tmem_copy %src, %dst : !ttg.memdesc<128x128xf32, #sharedAtomic, #smem, mutable>, !ttg.memdesc<128x128xf32, #tmemAtomic, #ttng.tensor_memory, mutable>
+    tt.return %result : i32
+  }
+
+  // The read phase of a cross-CTA atomic accesses distributed scratch. A
+  // following CTA-local reduction reuses that allocation for a write, so it
+  // must wait until every CTA has finished reading the atomic result.
+  // CHECK-LABEL: @cross_cta_atomic_then_local_reduce
+  // CHECK: tt.atomic_cas
+  // CHECK-NEXT: ttng.cluster_barrier
+  // CHECK-NEXT: "tt.reduce"
+  tt.func @cross_cta_atomic_then_local_reduce(%ptr: !tt.ptr<i32>, %input: tensor<256x128xf16, #blockedAtomic>) -> (i32, tensor<128xf16, #sliceAtomic>) {
+    %c0 = arith.constant 0 : i32
+    %result = tt.atomic_cas relaxed, gpu, %ptr, %c0, %c0 : (!tt.ptr<i32>, i32, i32) -> i32
+    %reduced = "tt.reduce"(%input) ({
+    ^bb0(%lhs: f16, %rhs: f16):
+      %sum = arith.addf %lhs, %rhs : f16
+      tt.reduce.return %sum : f16
+    }) {axis = 0 : i32} : (tensor<256x128xf16, #blockedAtomic>) -> tensor<128xf16, #sliceAtomic>
+    tt.return %result, %reduced : i32, tensor<128xf16, #sliceAtomic>
+  }
+}
+
+// -----
+
 #blockedSplitM = #ttg.blocked<{sizePerThread = [1, 32], threadsPerWarp = [32, 1], warpsPerCTA = [4, 1], order = [0, 1], CGALayout = [[1, 0]]}>
 #slice0 = #ttg.slice<{dim = 0, parent = #blockedSplitM}>
 #shared = #ttg.swizzled_shared<{vec = 1, perPhase = 1, maxPhase = 1, order = [1, 0], CGALayout = [[1, 0]]}>

--- a/test/TritonNvidiaGPU/membar-cluster.mlir
+++ b/test/TritonNvidiaGPU/membar-cluster.mlir
@@ -233,26 +233,31 @@ module attributes {"ttg.num-ctas" = 2 : i32, "ttg.num-warps" = 4 : i32, ttg.targ
 
 // -----
 
-#sharedAtomic = #ttg.nvmma_shared<{swizzlingByteWidth = 128, transposed = false, elementBitWidth = 32, CGALayout = [[0, 0]]}>
-#tmemAtomic = #ttng.tensor_memory_encoding<blockM = 128, blockN = 128, colStride = 1, CGALayout = [[0, 0]]>
+#blockedScratch = #ttg.blocked<{sizePerThread = [1, 32], threadsPerWarp = [8, 4], warpsPerCTA = [4, 1], order = [0, 1], CGALayout = [[0, 1]]}>
+#sliceScratch1 = #ttg.slice<{dim = 1, parent = #blockedScratch}>
+#sharedScratch = #ttg.nvmma_shared<{swizzlingByteWidth = 128, transposed = false, elementBitWidth = 32, CGALayout = [[0, 0]]}>
+#tmemScratch = #ttng.tensor_memory_encoding<blockM = 128, blockN = 128, colStride = 1, CGALayout = [[0, 0]]>
 #smem = #ttg.shared_memory
 
 module attributes {"ttg.num-ctas" = 2 : i32, "ttg.num-warps" = 4 : i32, "ttng.two-ctas" = true, ttg.target = "cuda:100", "ttg.threads-per-warp" = 32 : i32} {
-  // A cross-CTA scalar atomic broadcasts its result through scratch memory as:
+  // A cross-CTA reduction accesses scratch memory as:
   //   write scratch -> cluster barrier -> read scratch
   // The following two-CTA tmem_copy only reads the reused scratch allocation,
-  // so the atomic's internal barrier makes another cluster barrier unnecessary.
-  // CHECK-LABEL: @cross_cta_atomic_then_tmem_copy
-  // CHECK: tt.atomic_cas
+  // so the reduction's internal barrier makes another barrier unnecessary.
+  // CHECK-LABEL: @cross_cta_reduce_then_tmem_copy
+  // CHECK: "tt.reduce"{{.*}}axis = 1
   // CHECK-NOT: ttng.cluster_barrier
   // CHECK: ttng.tmem_copy
-  tt.func @cross_cta_atomic_then_tmem_copy(%ptr: !tt.ptr<i32>) -> i32 {
-    %c0 = arith.constant 0 : i32
-    %result = tt.atomic_cas relaxed, gpu, %ptr, %c0, %c0 : (!tt.ptr<i32>, i32, i32) -> i32
-    %src = ttg.local_alloc : () -> !ttg.memdesc<128x128xf32, #sharedAtomic, #smem, mutable>
-    %dst = ttng.tmem_alloc : () -> !ttg.memdesc<128x128xf32, #tmemAtomic, #ttng.tensor_memory, mutable>
-    ttng.tmem_copy %src, %dst : !ttg.memdesc<128x128xf32, #sharedAtomic, #smem, mutable>, !ttg.memdesc<128x128xf32, #tmemAtomic, #ttng.tensor_memory, mutable>
-    tt.return %result : i32
+  tt.func @cross_cta_reduce_then_tmem_copy(%input: tensor<256x128xf16, #blockedScratch>) -> tensor<256xf16, #sliceScratch1> {
+    %reduced = "tt.reduce"(%input) ({
+    ^bb0(%lhs: f16, %rhs: f16):
+      %sum = arith.addf %lhs, %rhs : f16
+      tt.reduce.return %sum : f16
+    }) {axis = 1 : i32} : (tensor<256x128xf16, #blockedScratch>) -> tensor<256xf16, #sliceScratch1>
+    %src = ttg.local_alloc : () -> !ttg.memdesc<128x128xf32, #sharedScratch, #smem, mutable>
+    %dst = ttng.tmem_alloc : () -> !ttg.memdesc<128x128xf32, #tmemScratch, #ttng.tensor_memory, mutable>
+    ttng.tmem_copy %src, %dst : !ttg.memdesc<128x128xf32, #sharedScratch, #smem, mutable>, !ttg.memdesc<128x128xf32, #tmemScratch, #ttng.tensor_memory, mutable>
+    tt.return %reduced : tensor<256xf16, #sliceScratch1>
   }
 }
 

--- a/test/TritonNvidiaGPU/membar-cluster.mlir
+++ b/test/TritonNvidiaGPU/membar-cluster.mlir
@@ -235,8 +235,6 @@ module attributes {"ttg.num-ctas" = 2 : i32, "ttg.num-warps" = 4 : i32, ttg.targ
 
 #sharedAtomic = #ttg.nvmma_shared<{swizzlingByteWidth = 128, transposed = false, elementBitWidth = 32, CGALayout = [[0, 0]]}>
 #tmemAtomic = #ttng.tensor_memory_encoding<blockM = 128, blockN = 128, colStride = 1, CGALayout = [[0, 0]]>
-#blockedAtomic = #ttg.blocked<{sizePerThread = [1, 32], threadsPerWarp = [8, 4], warpsPerCTA = [4, 1], order = [0, 1], CGALayout = [[0, 1]]}>
-#sliceAtomic = #ttg.slice<{dim = 0, parent = #blockedAtomic}>
 #smem = #ttg.shared_memory
 
 module attributes {"ttg.num-ctas" = 2 : i32, "ttg.num-warps" = 4 : i32, "ttng.two-ctas" = true, ttg.target = "cuda:100", "ttg.threads-per-warp" = 32 : i32} {
@@ -255,24 +253,6 @@ module attributes {"ttg.num-ctas" = 2 : i32, "ttg.num-warps" = 4 : i32, "ttng.tw
     %dst = ttng.tmem_alloc : () -> !ttg.memdesc<128x128xf32, #tmemAtomic, #ttng.tensor_memory, mutable>
     ttng.tmem_copy %src, %dst : !ttg.memdesc<128x128xf32, #sharedAtomic, #smem, mutable>, !ttg.memdesc<128x128xf32, #tmemAtomic, #ttng.tensor_memory, mutable>
     tt.return %result : i32
-  }
-
-  // The read phase of a cross-CTA atomic accesses distributed scratch. A
-  // following CTA-local reduction reuses that allocation for a write, so it
-  // must wait until every CTA has finished reading the atomic result.
-  // CHECK-LABEL: @cross_cta_atomic_then_local_reduce
-  // CHECK: tt.atomic_cas
-  // CHECK-NEXT: ttng.cluster_barrier
-  // CHECK-NEXT: "tt.reduce"
-  tt.func @cross_cta_atomic_then_local_reduce(%ptr: !tt.ptr<i32>, %input: tensor<256x128xf16, #blockedAtomic>) -> (i32, tensor<128xf16, #sliceAtomic>) {
-    %c0 = arith.constant 0 : i32
-    %result = tt.atomic_cas relaxed, gpu, %ptr, %c0, %c0 : (!tt.ptr<i32>, i32, i32) -> i32
-    %reduced = "tt.reduce"(%input) ({
-    ^bb0(%lhs: f16, %rhs: f16):
-      %sum = arith.addf %lhs, %rhs : f16
-      tt.reduce.return %sum : f16
-    }) {axis = 0 : i32} : (tensor<256x128xf16, #blockedAtomic>) -> tensor<128xf16, #sliceAtomic>
-    tt.return %result, %reduced : i32, tensor<128xf16, #sliceAtomic>
   }
 }
 

--- a/test/TritonNvidiaGPU/membar-cluster.mlir
+++ b/test/TritonNvidiaGPU/membar-cluster.mlir
@@ -234,6 +234,7 @@ module attributes {"ttg.num-ctas" = 2 : i32, "ttg.num-warps" = 4 : i32, ttg.targ
 // -----
 
 #blockedScratch = #ttg.blocked<{sizePerThread = [1, 32], threadsPerWarp = [8, 4], warpsPerCTA = [4, 1], order = [0, 1], CGALayout = [[0, 1]]}>
+#sliceScratch0 = #ttg.slice<{dim = 0, parent = #blockedScratch}>
 #sliceScratch1 = #ttg.slice<{dim = 1, parent = #blockedScratch}>
 #sharedScratch = #ttg.nvmma_shared<{swizzlingByteWidth = 128, transposed = false, elementBitWidth = 32, CGALayout = [[0, 0]]}>
 #tmemScratch = #ttng.tensor_memory_encoding<blockM = 128, blockN = 128, colStride = 1, CGALayout = [[0, 0]]>
@@ -258,6 +259,103 @@ module attributes {"ttg.num-ctas" = 2 : i32, "ttg.num-warps" = 4 : i32, "ttng.tw
     %dst = ttng.tmem_alloc : () -> !ttg.memdesc<128x128xf32, #tmemScratch, #ttng.tensor_memory, mutable>
     ttng.tmem_copy %src, %dst : !ttg.memdesc<128x128xf32, #sharedScratch, #smem, mutable>, !ttg.memdesc<128x128xf32, #tmemScratch, #ttng.tensor_memory, mutable>
     tt.return %reduced : tensor<256xf16, #sliceScratch1>
+  }
+
+  // A scalar atomic CAS broadcasts its result through scratch memory as:
+  //   write scratch -> cluster barrier -> read scratch
+  // The following two-CTA tmem_copy only reads the reused scratch allocation,
+  // so the atomic's internal barrier makes another barrier unnecessary.
+  // CHECK-LABEL: @cross_cta_atomic_cas_then_tmem_copy
+  // CHECK: tt.atomic_cas
+  // CHECK-NOT: ttng.cluster_barrier
+  // CHECK: ttng.tmem_copy
+  tt.func @cross_cta_atomic_cas_then_tmem_copy(%ptr: !tt.ptr<i32>) -> i32 {
+    %c0 = arith.constant 0 : i32
+    %result = tt.atomic_cas relaxed, gpu, %ptr, %c0, %c0 : (!tt.ptr<i32>, i32, i32) -> i32
+    %src = ttg.local_alloc : () -> !ttg.memdesc<128x128xf32, #sharedScratch, #smem, mutable>
+    %dst = ttng.tmem_alloc : () -> !ttg.memdesc<128x128xf32, #tmemScratch, #ttng.tensor_memory, mutable>
+    ttng.tmem_copy %src, %dst : !ttg.memdesc<128x128xf32, #sharedScratch, #smem, mutable>, !ttg.memdesc<128x128xf32, #tmemScratch, #ttng.tensor_memory, mutable>
+    tt.return %result : i32
+  }
+
+  // After the atomic's internal barrier, its cross-CTA scratch read remains
+  // pending. A CTA-local reduction then reuses that allocation for a scratch
+  // write, so the read must be classified as distributed and synchronized.
+  // CHECK-LABEL: @cross_cta_atomic_cas_then_local_reduce
+  // CHECK: tt.atomic_cas
+  // CHECK-NEXT: ttng.cluster_barrier
+  // CHECK-NEXT: "tt.reduce"{{.*}}axis = 0
+  tt.func @cross_cta_atomic_cas_then_local_reduce(%ptr: !tt.ptr<i32>, %input: tensor<256x128xf16, #blockedScratch>) -> (i32, tensor<128xf16, #sliceScratch0>) {
+    %c0 = arith.constant 0 : i32
+    %result = tt.atomic_cas relaxed, gpu, %ptr, %c0, %c0 : (!tt.ptr<i32>, i32, i32) -> i32
+    %reduced = "tt.reduce"(%input) ({
+    ^bb0(%lhs: f16, %rhs: f16):
+      %sum = arith.addf %lhs, %rhs : f16
+      tt.reduce.return %sum : f16
+    }) {axis = 0 : i32} : (tensor<256x128xf16, #blockedScratch>) -> tensor<128xf16, #sliceScratch0>
+    tt.return %result, %reduced : i32, tensor<128xf16, #sliceScratch0>
+  }
+
+  // A scalar atomic RMW has the same scratch broadcast sequence as atomic CAS.
+  // Its internal barrier also leaves only a read before the following
+  // read-only reuse.
+  // CHECK-LABEL: @cross_cta_atomic_rmw_then_tmem_copy
+  // CHECK: tt.atomic_rmw
+  // CHECK-NOT: ttng.cluster_barrier
+  // CHECK: ttng.tmem_copy
+  tt.func @cross_cta_atomic_rmw_then_tmem_copy(%ptr: !tt.ptr<i32>) -> i32 {
+    %c1 = arith.constant 1 : i32
+    %result = tt.atomic_rmw add, relaxed, gpu, %ptr, %c1 : (!tt.ptr<i32>, i32) -> i32
+    %src = ttg.local_alloc : () -> !ttg.memdesc<128x128xf32, #sharedScratch, #smem, mutable>
+    %dst = ttng.tmem_alloc : () -> !ttg.memdesc<128x128xf32, #tmemScratch, #ttng.tensor_memory, mutable>
+    ttng.tmem_copy %src, %dst : !ttg.memdesc<128x128xf32, #sharedScratch, #smem, mutable>, !ttg.memdesc<128x128xf32, #tmemScratch, #ttng.tensor_memory, mutable>
+    tt.return %result : i32
+  }
+
+  // A timed atomic poll broadcasts its result through cross-CTA scratch. The
+  // rendezvous between the scratch write and read makes another barrier before
+  // the following read-only reuse unnecessary.
+  // CHECK-LABEL: @cross_cta_atomic_poll_then_tmem_copy
+  // CHECK: tt.atomic_poll
+  // CHECK-NOT: ttng.cluster_barrier
+  // CHECK: ttng.tmem_copy
+  tt.func @cross_cta_atomic_poll_then_tmem_copy(%ptr: !tt.ptr<i32>, %expected: i32, %timeout: i64) -> i1 {
+    %matched = tt.atomic_poll acquire, gpu, %ptr, %expected timeout %timeout : !tt.ptr<i32>, i32 -> i1
+    %src = ttg.local_alloc : () -> !ttg.memdesc<128x128xf32, #sharedScratch, #smem, mutable>
+    %dst = ttng.tmem_alloc : () -> !ttg.memdesc<128x128xf32, #tmemScratch, #ttng.tensor_memory, mutable>
+    ttng.tmem_copy %src, %dst : !ttg.memdesc<128x128xf32, #sharedScratch, #smem, mutable>, !ttg.memdesc<128x128xf32, #tmemScratch, #ttng.tensor_memory, mutable>
+    tt.return %matched : i1
+  }
+}
+
+// -----
+
+#replicatedAtomicScratch = #ttg.blocked<{sizePerThread = [1, 1], threadsPerWarp = [1, 32], warpsPerCTA = [1, 4], order = [1, 0], CGALayout = [[0, 0]]}>
+#sharedAtomicDst = #ttg.swizzled_shared<{vec = 1, perPhase = 1, maxPhase = 1, order = [1, 0], CGALayout = [[1, 0]]}>
+#sharedAtomicReuse = #ttg.nvmma_shared<{swizzlingByteWidth = 128, transposed = false, elementBitWidth = 32, CGALayout = [[0, 0]]}>
+#tmemAtomicReuse = #ttng.tensor_memory_encoding<blockM = 128, blockN = 128, colStride = 1, CGALayout = [[0, 0]]>
+#smem = #ttg.shared_memory
+
+module attributes {"ttg.num-ctas" = 2 : i32, "ttg.num-warps" = 4 : i32, "ttng.two-ctas" = true, ttg.target = "cuda:100", "ttg.threads-per-warp" = 32 : i32} {
+  // A cross-CTA local atomic scatter broadcasts its result through scratch
+  // while separately accessing its explicit shared-memory destination. Its
+  // internal barrier leaves only a scratch read before the following read-only
+  // reuse, so another cluster barrier is unnecessary.
+  // CHECK-LABEL: @cross_cta_local_atomic_scatter_then_tmem_copy
+  // CHECK: ttg.local_atomic_scatter_rmw
+  // CHECK-NOT: ttng.cluster_barrier
+  // CHECK: ttng.tmem_copy
+  tt.func @cross_cta_local_atomic_scatter_then_tmem_copy(
+      %indices: tensor<8x32xi32, #replicatedAtomicScratch>,
+      %values: tensor<8x32xi32, #replicatedAtomicScratch>) -> tensor<8x32xi32, #replicatedAtomicScratch> {
+    %parent = ttg.local_alloc : () -> !ttg.memdesc<16x32xi32, #sharedAtomicDst, #smem, mutable>
+    %dst = ttg.memdesc_subslice %parent [0, 0] : !ttg.memdesc<16x32xi32, #sharedAtomicDst, #smem, mutable> -> !ttg.memdesc<8x32xi32, #sharedAtomicDst, #smem, mutable, 16x32>
+    %old = ttg.local_atomic_scatter_rmw add, %dst[%indices], %values {axis = 0 : i32} : (!ttg.memdesc<8x32xi32, #sharedAtomicDst, #smem, mutable, 16x32>, tensor<8x32xi32, #replicatedAtomicScratch>, tensor<8x32xi32, #replicatedAtomicScratch>) -> tensor<8x32xi32, #replicatedAtomicScratch>
+    %src = ttg.local_alloc : () -> !ttg.memdesc<128x32xi32, #sharedAtomicReuse, #smem, mutable>
+    %tmem = ttng.tmem_alloc : () -> !ttg.memdesc<128x32xi32, #tmemAtomicReuse, #ttng.tensor_memory, mutable>
+    ttng.tmem_copy %src, %tmem : !ttg.memdesc<128x32xi32, #sharedAtomicReuse, #smem, mutable>, !ttg.memdesc<128x32xi32, #tmemAtomicReuse, #ttng.tensor_memory, mutable>
+    ttg.local_dealloc %parent : !ttg.memdesc<16x32xi32, #sharedAtomicDst, #smem, mutable>
+    tt.return %old : tensor<8x32xi32, #replicatedAtomicScratch>
   }
 }
 

--- a/test/TritonNvidiaGPU/membar-cluster.mlir
+++ b/test/TritonNvidiaGPU/membar-cluster.mlir
@@ -312,6 +312,25 @@ module attributes {"ttg.num-ctas" = 2 : i32, "ttg.num-warps" = 4 : i32, "ttng.tw
     tt.return %result : i32
   }
 
+  // The atomic RMW's scratch access is:
+  //   write scratch -> cluster barrier -> read scratch
+  // A CTA-local reduction then writes the reused scratch allocation, so it
+  // must wait for the pending cross-CTA read.
+  // CHECK-LABEL: @cross_cta_atomic_rmw_then_local_reduce
+  // CHECK: tt.atomic_rmw
+  // CHECK-NEXT: ttng.cluster_barrier
+  // CHECK-NEXT: "tt.reduce"{{.*}}axis = 0
+  tt.func @cross_cta_atomic_rmw_then_local_reduce(%ptr: !tt.ptr<i32>, %input: tensor<256x128xf16, #blockedScratch>) -> (i32, tensor<128xf16, #sliceScratch0>) {
+    %c1 = arith.constant 1 : i32
+    %result = tt.atomic_rmw add, relaxed, gpu, %ptr, %c1 : (!tt.ptr<i32>, i32) -> i32
+    %reduced = "tt.reduce"(%input) ({
+    ^bb0(%lhs: f16, %rhs: f16):
+      %sum = arith.addf %lhs, %rhs : f16
+      tt.reduce.return %sum : f16
+    }) {axis = 0 : i32} : (tensor<256x128xf16, #blockedScratch>) -> tensor<128xf16, #sliceScratch0>
+    tt.return %result, %reduced : i32, tensor<128xf16, #sliceScratch0>
+  }
+
   // A timed atomic poll broadcasts its result through cross-CTA scratch. The
   // rendezvous between the scratch write and read makes another barrier before
   // the following read-only reuse unnecessary.
@@ -326,6 +345,24 @@ module attributes {"ttg.num-ctas" = 2 : i32, "ttg.num-warps" = 4 : i32, "ttng.tw
     ttng.tmem_copy %src, %dst : !ttg.memdesc<128x128xf32, #sharedScratch, #smem, mutable>, !ttg.memdesc<128x128xf32, #tmemScratch, #ttng.tensor_memory, mutable>
     tt.return %matched : i1
   }
+
+  // The atomic poll's scratch access is:
+  //   write scratch -> cluster barrier -> read scratch
+  // A CTA-local reduction then writes the reused scratch allocation, so it
+  // must wait for the pending cross-CTA read.
+  // CHECK-LABEL: @cross_cta_atomic_poll_then_local_reduce
+  // CHECK: tt.atomic_poll
+  // CHECK-NEXT: ttng.cluster_barrier
+  // CHECK-NEXT: "tt.reduce"{{.*}}axis = 0
+  tt.func @cross_cta_atomic_poll_then_local_reduce(%ptr: !tt.ptr<i32>, %expected: i32, %timeout: i64, %input: tensor<256x128xf16, #blockedScratch>) -> (i1, tensor<128xf16, #sliceScratch0>) {
+    %matched = tt.atomic_poll acquire, gpu, %ptr, %expected timeout %timeout : !tt.ptr<i32>, i32 -> i1
+    %reduced = "tt.reduce"(%input) ({
+    ^bb0(%lhs: f16, %rhs: f16):
+      %sum = arith.addf %lhs, %rhs : f16
+      tt.reduce.return %sum : f16
+    }) {axis = 0 : i32} : (tensor<256x128xf16, #blockedScratch>) -> tensor<128xf16, #sliceScratch0>
+    tt.return %matched, %reduced : i1, tensor<128xf16, #sliceScratch0>
+  }
 }
 
 // -----
@@ -334,6 +371,8 @@ module attributes {"ttg.num-ctas" = 2 : i32, "ttg.num-warps" = 4 : i32, "ttng.tw
 #sharedAtomicDst = #ttg.swizzled_shared<{vec = 1, perPhase = 1, maxPhase = 1, order = [1, 0], CGALayout = [[1, 0]]}>
 #sharedAtomicReuse = #ttg.nvmma_shared<{swizzlingByteWidth = 128, transposed = false, elementBitWidth = 32, CGALayout = [[0, 0]]}>
 #tmemAtomicReuse = #ttng.tensor_memory_encoding<blockM = 128, blockN = 128, colStride = 1, CGALayout = [[0, 0]]>
+#blockedAtomicReduce = #ttg.blocked<{sizePerThread = [1, 32], threadsPerWarp = [8, 4], warpsPerCTA = [4, 1], order = [0, 1], CGALayout = [[0, 1]]}>
+#sliceAtomicReduce0 = #ttg.slice<{dim = 0, parent = #blockedAtomicReduce}>
 #smem = #ttg.shared_memory
 
 module attributes {"ttg.num-ctas" = 2 : i32, "ttg.num-warps" = 4 : i32, "ttng.two-ctas" = true, ttg.target = "cuda:100", "ttg.threads-per-warp" = 32 : i32} {
@@ -356,6 +395,30 @@ module attributes {"ttg.num-ctas" = 2 : i32, "ttg.num-warps" = 4 : i32, "ttng.tw
     ttng.tmem_copy %src, %tmem : !ttg.memdesc<128x32xi32, #sharedAtomicReuse, #smem, mutable>, !ttg.memdesc<128x32xi32, #tmemAtomicReuse, #ttng.tensor_memory, mutable>
     ttg.local_dealloc %parent : !ttg.memdesc<16x32xi32, #sharedAtomicDst, #smem, mutable>
     tt.return %old : tensor<8x32xi32, #replicatedAtomicScratch>
+  }
+
+  // The local atomic scatter RMW's scratch access is:
+  //   write scratch -> cluster barrier -> read scratch
+  // A CTA-local reduction then writes the reused scratch allocation, so it
+  // must wait for the pending cross-CTA read.
+  // CHECK-LABEL: @cross_cta_local_atomic_scatter_then_local_reduce
+  // CHECK: ttg.local_atomic_scatter_rmw
+  // CHECK-NEXT: ttng.cluster_barrier
+  // CHECK-NEXT: "tt.reduce"{{.*}}axis = 0
+  tt.func @cross_cta_local_atomic_scatter_then_local_reduce(
+      %indices: tensor<8x32xi32, #replicatedAtomicScratch>,
+      %values: tensor<8x32xi32, #replicatedAtomicScratch>,
+      %input: tensor<256x128xi32, #blockedAtomicReduce>) -> (tensor<8x32xi32, #replicatedAtomicScratch>, tensor<128xi32, #sliceAtomicReduce0>) {
+    %parent = ttg.local_alloc : () -> !ttg.memdesc<16x32xi32, #sharedAtomicDst, #smem, mutable>
+    %dst = ttg.memdesc_subslice %parent [0, 0] : !ttg.memdesc<16x32xi32, #sharedAtomicDst, #smem, mutable> -> !ttg.memdesc<8x32xi32, #sharedAtomicDst, #smem, mutable, 16x32>
+    %old = ttg.local_atomic_scatter_rmw add, %dst[%indices], %values {axis = 0 : i32} : (!ttg.memdesc<8x32xi32, #sharedAtomicDst, #smem, mutable, 16x32>, tensor<8x32xi32, #replicatedAtomicScratch>, tensor<8x32xi32, #replicatedAtomicScratch>) -> tensor<8x32xi32, #replicatedAtomicScratch>
+    %reduced = "tt.reduce"(%input) ({
+    ^bb0(%lhs: i32, %rhs: i32):
+      %sum = arith.addi %lhs, %rhs : i32
+      tt.reduce.return %sum : i32
+    }) {axis = 0 : i32} : (tensor<256x128xi32, #blockedAtomicReduce>) -> tensor<128xi32, #sliceAtomicReduce0>
+    ttg.local_dealloc %parent : !ttg.memdesc<16x32xi32, #sharedAtomicDst, #smem, mutable>
+    tt.return %old, %reduced : tensor<8x32xi32, #replicatedAtomicScratch>, tensor<128xi32, #sliceAtomicReduce0>
   }
 }
 


### PR DESCRIPTION
- Model cross-cta operations with scratch memory as write scratch -> internal cluster barrier -> read scratch and sync blockInfo properly.
- Add missing ops `isDistributedMultiCTAOp` by invoking `hasCrossCTAScratch`.
- Add MLIR coverage for reductions, atomic CAS, atomic RMW, atomic poll, and local atomic scatter RMW, covering both:
    - read followed by read: no additional cluster barrier.
    - cross-CTA read followed by (local) scratch write: cluster barrier required.
- Remove `static` qualifier for functions in anonymous namespace.