### PR TITLE
[LLVM] Build llvm/llvm-project@ce3529423abd

### DIFF
--- a/cmake/llvm-build-info.json
+++ b/cmake/llvm-build-info.json
@@ -1,5 +1,5 @@
 {
-  "llvm_hash": "2b1d88ec90a9d3a495baf6f3210cf7b55326bf4a",
-  "repository": "triton-lang/llvm-project",
+  "llvm_hash": "ce3529423abda3fc4ad0b542daa50af21e539a29",
+  "repository": "llvm/llvm-project",
   "build_number": 1
 }


### PR DESCRIPTION
PR description written by Codex

The current LLVM packages predate llvm/llvm-project@ce3529423abda3fc4ad0b542daa50af21e539a29, which fixes the MLIR symbol verifier performance regression. Schedule persistent packages from that upstream revision so Triton can consume the fix.

Production code diff: none. Other code diff: updates only the LLVM build metadata. The target commit resolves upstream and all eight expected build artifacts are currently absent.