### PR TITLE
[INTERPRETER] Fix tl.condition truthiness in while loops

### DIFF
--- a/python/test/unit/language/test_core.py
+++ b/python/test/unit/language/test_core.py
@@ -6828,6 +6828,25 @@ def test_disable_licm():
     assert "llvm.licm.disable" in compiled_kernel3.asm["llir"]
 
 
+@pytest.mark.interpreter
+@pytest.mark.parametrize("n", [0, 1, 5])
+def test_while_condition(n, device):
+    # A `while tl.condition(c)` loop must run exactly as many iterations as the
+    # condition allows, including zero when the initial condition is false. In
+    # the interpreter the wrapper's own truth value drives the Python loop, so a
+    # missing __bool__ made a false condition loop forever (issue #11402).
+    @triton.jit
+    def kernel(out_ptr, n):
+        i = 0
+        while tl.condition(i < n):
+            i += 1
+        tl.store(out_ptr, i)
+
+    out = torch.zeros(1, dtype=torch.int32, device=device)
+    kernel[(1, )](out, n)
+    assert int(out.cpu().item()) == n
+
+
 @triton.jit(noinline=True)
 def maxnreg_noinline1(X):
     tl.store(X, 0)

--- a/python/triton/language/core.py
+++ b/python/triton/language/core.py
@@ -3654,6 +3654,14 @@ class condition(base_value):
         self.condition = arg1
         self.disable_licm = disable_licm
 
+    def __bool__(self):
+        # In the interpreter, `while tl.condition(c)` is a plain Python loop, so
+        # its truth value comes from here. Without this, the wrapper object is
+        # always truthy and a false condition loops forever. Defer to the wrapped
+        # condition's truth value (a tensor in the interpreter). In @triton.jit
+        # code the compiler handles the wrapper directly and never calls this.
+        return bool(self.condition)
+
 
 # -----------------------
 # Extern functions


### PR DESCRIPTION
## Summary

Fixes #11402.

In interpreter mode, `while tl.condition(c)` uses Python truth-value testing on the `condition` wrapper. Because the wrapper did not define `__bool__`, Python treated it as true even when the wrapped condition was false, causing the loop to run forever.

Forwarding truth-value testing to the wrapped condition makes interpreter behavior match compiled mode. The compiled path is unchanged: `visit_While` recognizes the wrapper and reads its `.condition` field directly.

## Testing

- `TRITON_INTERPRET=1 python3 -m pytest -s --tb=short python/test/unit/language/test_core.py::test_while_condition --device=cpu` — `3 passed` (`n=0, 1, 5`)
- `TRITON_INTERPRET=0 python3 -m pytest -s --tb=short python/test/unit/language/test_core.py::test_while_condition --device=cuda` — `3 passed` on CUDA (`n=0, 1, 5`)
- `pre-commit run --from-ref origin/main --to-ref HEAD` — passed

# New contributor declaration

- [x] I am not making a trivial change, such as fixing a typo in a comment.
- [x] I have written a PR description following these [rules](https://cbea.ms/git-commit/#why-not-how).
- [x] I have run `pre-commit run --from-ref origin/main --to-ref HEAD`.
- [x] I have added tests.
  - `/test` for `lit` tests
  - `/unittest` for C++ tests
  - `/python/test` for end-to-end tests
- [x] I have not added any `lit` tests.