### PR TITLE
[BufferRegion] Add pipeline-prefix displacements to storage bases

### DIFF
--- a/lib/Analysis/BufferRegion.cpp
+++ b/lib/Analysis/BufferRegion.cpp
@@ -216,6 +216,7 @@ uint32_t getMemDescStorageOffset(ttg::MemDescType ty, unsigned index) {
 }
 
 struct MemDescSubsliceOffsets {
+  uint32_t storageOffset = 0;
   uint32_t byteOffset = 0;
   uint32_t partitionOffset = 0;
   uint32_t ctaOffset = 0;
@@ -257,19 +258,24 @@ getMemDescSubsliceUnpaddedOffsets(ttg::MemDescSubsliceOp op) {
     else if (dim == partitionDim)
       partitionOffset = static_cast<uint32_t>(offset);
   }
+  uint32_t storageElementOffset = 0;
   if (offsets.size() != layoutRank) {
     uint32_t stride = ttg::getAllocationElems(
         encoding, ttg::dropPipeliningDim(srcTy.getAllocShape(), encoding));
     if (auto partitioned =
             dyn_cast<ttg::PartitionedSharedEncodingAttr>(encoding))
       stride /= partitioned.getNumPartitions();
-    elementOffset += offsets.front() * stride;
+    // The pipeline prefix advances every base pointer by addition. Only the
+    // layout-ranked suffix composes by XOR; nested prefix offsets may carry.
+    // Padded pipeline subslices are rejected by the verifier.
+    storageElementOffset = offsets.front() * stride;
   }
 
   uint32_t elementSizeBytes =
       srcTy.getElementType().getIntOrFloatBitWidth() / 8;
   assert(elementSizeBytes > 0 && "element size must be non-zero");
-  return MemDescSubsliceOffsets{elementOffset * elementSizeBytes,
+  return MemDescSubsliceOffsets{storageElementOffset * elementSizeBytes,
+                                elementOffset * elementSizeBytes,
                                 partitionOffset, blockOffset};
 }
 
@@ -597,9 +603,9 @@ LogicalResult BufferRegionAnalysis::visitOperation(
         getMemDescSubsliceUnpaddedOffsets(memdescSubsliceOp);
     for (const BufferRegionView &view : in.views)
       regionInfo.views.insert(
-          getSubView(memdescSubsliceOp.getType(), view, /*storageOffset=*/0,
-                     relativeOffset.byteOffset, relativeOffset.partitionOffset,
-                     relativeOffset.ctaOffset));
+          getSubView(memdescSubsliceOp.getType(), view,
+                     relativeOffset.storageOffset, relativeOffset.byteOffset,
+                     relativeOffset.partitionOffset, relativeOffset.ctaOffset));
     return propagateRegions(regionInfo);
   }
   if (auto tmemSubsliceOp = dyn_cast<ttng::TMEMSubSliceOp>(op)) {

--- a/python/test/gluon/test_core.py
+++ b/python/test/gluon/test_core.py
@@ -2495,6 +2495,40 @@ def test_multibuffer_prefix_subslice():
     torch.testing.assert_close(out3, torch.full_like(out3, 3), atol=0, rtol=0)
 
 
+@pytest.mark.skipif(not is_hopper_or_newer(), reason="Requires Hopper")
+def test_proxy_fence_nested_multibuffer_prefix(fresh_knobs):
+    fresh_knobs.compilation.instrumentation_mode = ""
+
+    @gluon.jit(do_not_specialize=["choose"])
+    def kernel(desc, inp, choose):
+        layout: ttgl.constexpr = ttgl.BlockedLayout([1, 1], [1, 32], [4, 1], [1, 0])
+        parent = ttgl.allocate_shared_memory(ttgl.float32, [4, 32, 32], desc.layout)
+        if choose:
+            first = parent.slice(1, 3, dim=0)
+        else:
+            first = parent.slice(0, 3, dim=0)
+        nested = first.slice(1, 2, dim=0).index(0)
+        rows = ttgl.arange(0, 32, layout=ttgl.SliceLayout(1, layout))[:, None]
+        cols = ttgl.arange(0, 32, layout=ttgl.SliceLayout(0, layout))[None, :]
+        nested.store(ttgl.load(inp + rows * 32 + cols))
+        # The runtime merge prevents folding the nested slices. With choose=1,
+        # their offsets add to stage 2, whose TMA read needs a proxy fence.
+        tma.async_store(desc, [0, 0], parent.index(2))
+        tma.store_wait(0)
+        parent._keep_alive()
+
+    values = torch.arange(1024, device="cuda", dtype=torch.float32).reshape(32, 32)
+    output = torch.empty_like(values)
+    desc = TensorDescriptor.from_tensor(output, [32, 32], ttgl.NVMMASharedLayout(128, 32, rank=2))
+    compiled = kernel[(1, )](desc, values, 1, num_warps=4)
+    ptx = compiled.asm["ptx"]
+    stores = list(re.finditer(r"\b(?:st\.shared|stmatrix\.)", ptx))
+    tma_store = re.search(r"\bcp\.async\.bulk\.tensor\.2d\.global\.shared::cta\b", ptx)
+    assert stores and tma_store
+    assert "fence.proxy.async.shared::cta" in ptx[stores[-1].end():tma_store.start()]
+    torch.testing.assert_close(output, values, atol=0, rtol=0)
+
+
 def test_slice_reinterpret():
     BLOCK = ttgl.constexpr(2048)
     SPLIT_BLOCK = ttgl.constexpr(BLOCK // 2)

--- a/test/Analysis/test-buffer-region-layout-alias.mlir
+++ b/test/Analysis/test-buffer-region-layout-alias.mlir
@@ -339,6 +339,10 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 2 : i32, ttg.shar
 // CHECK: stage_partition_b_second vs stage_partition_d_second_first: alias=true
 // CHECK: stage_partition_b_second vs stage_partition_e_second_peer: alias=true
 // CHECK: stage_partition_d_second_first vs stage_partition_e_second_peer: alias=false
+// CHECK: stage_partition_f_prefix_first vs stage_partition_g_prefix_nested: alias=false
+// CHECK: stage_partition_f_prefix_first vs stage_partition_i_prefix_merged: alias=true, lhs_contains_rhs=false, rhs_contains_lhs=true
+// CHECK: stage_partition_g_prefix_nested vs stage_partition_h_prefix_direct: alias=true, lhs_contains_rhs=true, rhs_contains_lhs=true
+// CHECK: stage_partition_g_prefix_nested vs stage_partition_i_prefix_merged: alias=true, lhs_contains_rhs=false, rhs_contains_lhs=true
 module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 2 : i32, ttg.shared = 4096 : i32, ttg.target = "hip:gfx1250", "ttg.threads-per-warp" = 32 : i32, "ttg.total-num-warps" = 2 : i32} {
   tt.func public @partitioned_multibuffer_physical_alias(%index: i32) {
     %c0 = arith.constant 0 : i32
@@ -354,6 +358,31 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 2 : i32, ttg.shar
     %2 = ttg.local_load %dynamic {test.region_name = "stage_partition_c_dynamic"} : !ttg.memdesc<16x16xf16, #partitioned, #smem, mutable> -> tensor<16x16xf16>
     %3 = ttg.local_load %second_first {test.region_name = "stage_partition_d_second_first"} : !ttg.memdesc<4x16xf16, #partitioned, #smem, mutable, 16x16> -> tensor<4x16xf16>
     %4 = ttg.local_load %second_peer {test.region_name = "stage_partition_e_second_peer"} : !ttg.memdesc<4x16xf16, #partitioned, #smem, mutable, 16x16> -> tensor<4x16xf16>
+    tt.return
+  }
+
+  // Prefix slices add to every partition base, even across a CFG edge. Two
+  // offsets of one stage must become stage two, not XOR back to stage zero;
+  // merging those distinct origins must retain both physical footprints.
+  tt.func public @nested_pipeline_prefix_cfg(%choose: i1) {
+    %c0 = arith.constant 0 : i32
+    %c2 = arith.constant 2 : i32
+    %parent = ttg.local_alloc {allocation.offset = [0 : i32, 2048 : i32]} : () -> !ttg.memdesc<4x16x16xf16, #partitioned, #smem, mutable>
+    %prefix = ttg.memdesc_subslice %parent [1, 0, 0] : !ttg.memdesc<4x16x16xf16, #partitioned, #smem, mutable> -> !ttg.memdesc<3x16x16xf16, #partitioned, #smem, mutable, 4x16x16>
+    cf.br ^slice(%prefix : !ttg.memdesc<3x16x16xf16, #partitioned, #smem, mutable, 4x16x16>)
+  ^slice(%stage: !ttg.memdesc<3x16x16xf16, #partitioned, #smem, mutable, 4x16x16>):
+    %nested = ttg.memdesc_subslice %stage [1, 0, 0] : !ttg.memdesc<3x16x16xf16, #partitioned, #smem, mutable, 4x16x16> -> !ttg.memdesc<2x16x16xf16, #partitioned, #smem, mutable, 4x16x16>
+    %low = ttg.memdesc_subslice %parent [0, 0, 0] : !ttg.memdesc<4x16x16xf16, #partitioned, #smem, mutable> -> !ttg.memdesc<2x16x16xf16, #partitioned, #smem, mutable, 4x16x16>
+    %first = ttg.memdesc_index %parent[%c0] : !ttg.memdesc<4x16x16xf16, #partitioned, #smem, mutable> -> !ttg.memdesc<16x16xf16, #partitioned, #smem, mutable>
+    %nested_stage = ttg.memdesc_index %nested[%c0] : !ttg.memdesc<2x16x16xf16, #partitioned, #smem, mutable, 4x16x16> -> !ttg.memdesc<16x16xf16, #partitioned, #smem, mutable>
+    %direct = ttg.memdesc_index %parent[%c2] : !ttg.memdesc<4x16x16xf16, #partitioned, #smem, mutable> -> !ttg.memdesc<16x16xf16, #partitioned, #smem, mutable>
+    %0 = ttg.local_load %first {test.region_name = "stage_partition_f_prefix_first"} : !ttg.memdesc<16x16xf16, #partitioned, #smem, mutable> -> tensor<16x16xf16>
+    %1 = ttg.local_load %nested_stage {test.region_name = "stage_partition_g_prefix_nested"} : !ttg.memdesc<16x16xf16, #partitioned, #smem, mutable> -> tensor<16x16xf16>
+    %2 = ttg.local_load %direct {test.region_name = "stage_partition_h_prefix_direct"} : !ttg.memdesc<16x16xf16, #partitioned, #smem, mutable> -> tensor<16x16xf16>
+    cf.cond_br %choose, ^merge(%nested : !ttg.memdesc<2x16x16xf16, #partitioned, #smem, mutable, 4x16x16>), ^merge(%low : !ttg.memdesc<2x16x16xf16, #partitioned, #smem, mutable, 4x16x16>)
+  ^merge(%selected: !ttg.memdesc<2x16x16xf16, #partitioned, #smem, mutable, 4x16x16>):
+    %selected_stage = ttg.memdesc_index %selected[%c0] : !ttg.memdesc<2x16x16xf16, #partitioned, #smem, mutable, 4x16x16> -> !ttg.memdesc<16x16xf16, #partitioned, #smem, mutable>
+    %3 = ttg.local_load %selected_stage {test.region_name = "stage_partition_i_prefix_merged"} : !ttg.memdesc<16x16xf16, #partitioned, #smem, mutable> -> tensor<16x16xf16>
     tt.return
   }
 }


### PR DESCRIPTION
Pipeline-prefix offsets advance shared-memory storage bases by addition, but BufferRegion currently composes them through the XOR-based layout offset. Nested prefix slices can therefore resolve to the wrong stage and cause a required generic-to-async proxy fence to be omitted.

Keep prefix displacements in the additive storage-base offset.
