### PR TITLE
[BC Breaking][FRONTEND] Support keyword-only args in triton

### DIFF
--- a/python/test/unit/language/test_core.py
+++ b/python/test/unit/language/test_core.py
@@ -5201,6 +5201,16 @@ def _impl(value=10):
     return value
 
 
+@triton.jit
+def _keyword_only_impl(value=3, *, required, optional=5, REQUIRED: tl.constexpr, OPTIONAL: tl.constexpr = 2):
+    return value + required + optional + REQUIRED * OPTIONAL
+
+
+@triton.jit
+def _keyword_only_varargs(value, *values, scale: tl.constexpr = 2):
+    return value + values[0] + values[1] * scale
+
+
 @pytest.mark.interpreter
 def test_default(device):
     value = 5
@@ -5219,6 +5229,36 @@ def test_default(device):
     _kernel[(1, )](ret0, ret1)
     assert ret0.item() == 10
     assert ret1.item() == 3
+
+
+@pytest.mark.interpreter
+@pytest.mark.parametrize("args, kwargs, expected", [((), {}, [37, 37, 20]),
+                                                    ((13, ), {"optional": 17, "OPTIONAL": 19}, [37, 246, 343])])
+def test_keyword_only_arguments(device, args, kwargs, expected):
+
+    @triton.jit
+    def kernel(value=3, *, output, required, optional=5, REQUIRED: tl.constexpr, OPTIONAL: tl.constexpr = 2):
+        tl.store(output, _keyword_only_impl(required=required, REQUIRED=REQUIRED))
+        tl.store(output + 1,
+                 _keyword_only_impl(value, required=required, optional=optional, REQUIRED=REQUIRED, OPTIONAL=OPTIONAL))
+        tl.store(output + 2, _keyword_only_varargs(value, required, optional, scale=OPTIONAL))
+
+    output = torch.empty(3, dtype=torch.int32, device=device)
+    kernel[(1, )](*args, output=output, required=7, REQUIRED=11, **kwargs)
+    assert output.tolist() == expected
+
+
+@pytest.mark.interpreter
+def test_keyword_only_launch_errors():
+
+    @triton.jit
+    def kernel(*, MODE: tl.constexpr):
+        pass
+
+    with pytest.raises(TypeError, match="positional argument"):
+        kernel[(1, )](0)
+    with pytest.raises(TypeError, match="MODE"):
+        kernel[(1, )]()
 
 
 # ---------------

--- a/python/test/unit/language/test_frontend.py
+++ b/python/test/unit/language/test_frontend.py
@@ -2,6 +2,7 @@ import collections
 import functools
 import triton
 import triton.language as tl
+from triton.experimental import gluon
 from triton._filecheck import filecheck_test, run_filecheck_test, run_parser
 from triton.compiler.code_generator import CodeGenerator
 from triton.runtime.jit import MockTensor
@@ -12,6 +13,16 @@ from typing import NamedTuple
 # ===-----------------------------------------------------------------------===#
 # Unit Tests
 # ===-----------------------------------------------------------------------===#
+
+
+@pytest.mark.parametrize("jit", [triton.jit, gluon.jit])
+def test_jit_variadic_keyword_arguments(jit):
+
+    def kernel(**kwargs):
+        pass
+
+    with pytest.raises(TypeError, match=r"JIT functions do not support \*\*kwargs"):
+        jit(kernel)
 
 
 def doesnt_compile(kernel):
@@ -362,6 +373,12 @@ def test_constexpr_function_from_jit():
 
 def test_constexpr_function_from_python():
     assert constexpr_function(7) == 8
+
+    @triton.constexpr_function
+    def with_kwargs(**kwargs):
+        return kwargs["value"] + 1
+
+    assert with_kwargs(value=7) == 8
 
 
 @filecheck_test

--- a/python/test/unit/language/test_standard.py
+++ b/python/test/unit/language/test_standard.py
@@ -4,6 +4,8 @@ import torch
 import triton.language as tl
 
 from test_core import _test_binary, int_dtypes, uint_dtypes, float_dtypes, numpy_random
+from triton._internal_testing import is_interpreter
+from triton.runtime.errors import InterpreterError
 
 # ---------------
 # test maximum/minimum ops
@@ -152,25 +154,45 @@ def test_swizzle2d(size_i, size_j, size_g, device):
 
 
 @pytest.mark.interpreter
-@pytest.mark.parametrize("shape, dim", [((2, 2), 1), ((8, 64), -1), ((128, ), 0)])
-def test_softmax(shape, dim, device):
+@pytest.mark.parametrize("shape, dim, ieee_rounding", [((2, 2), 1, False), ((8, 64), -1, True), ((128, ), 0, False)])
+def test_softmax(shape, dim, ieee_rounding, device):
     # Reproducer for https://github.com/triton-lang/triton/issues/11406, where
     # softmax normalized along the wrong axis for every dim but the default.
 
     @triton.jit
-    def softmax_kernel(X, Z, numel: tl.constexpr, shape: tl.constexpr, dim: tl.constexpr):
+    def softmax_kernel(X, Z, numel: tl.constexpr, shape: tl.constexpr, dim: tl.constexpr, ieee_rounding: tl.constexpr):
         # X is contiguous, so its row-major flat offsets are just an arange.
         offs = tl.arange(0, numel).reshape(shape)
         x = tl.load(X + offs)
-        z = tl.softmax(x, dim=dim)
+        if ieee_rounding:
+            z = x.softmax(dim=dim, ieee_rounding=True)
+        else:
+            z = tl.softmax(x, dim=dim)
         tl.static_assert(z.shape == x.shape, "softmax must preserve the input shape")
         tl.store(Z + offs, z)
 
     x = numpy_random(shape, dtype_str='float32')
     x = torch.from_numpy(x).to(device)
     z = torch.empty_like(x)
-    softmax_kernel[(1, )](x, z, x.numel(), shape, dim)
+    softmax_kernel[(1, )](x, z, x.numel(), shape, dim, ieee_rounding)
     torch.testing.assert_close(z, torch.softmax(x, dim=dim), rtol=1e-5, atol=1e-6)
+
+
+@pytest.mark.interpreter
+@pytest.mark.parametrize("member", [False, True])
+def test_softmax_rejects_positional_keep_dims(member):
+
+    @triton.jit
+    def kernel(member: tl.constexpr):
+        x = tl.full((2, 2), 1.0, tl.float32)
+        if member:
+            x.softmax(1, True)
+        else:
+            tl.softmax(x, 1, True)
+
+    error = InterpreterError if is_interpreter() else triton.CompilationError
+    with pytest.raises(error, match="positional argument"):
+        kernel[(1, )](member)
 
 
 @pytest.mark.interpreter

--- a/python/test/unit/runtime/test_cache.py
+++ b/python/test/unit/runtime/test_cache.py
@@ -149,6 +149,18 @@ def test_toplevel_change():
     assert baseline != updated
 
 
+def test_keyword_only_default_dependency_change():
+
+    @triton.jit
+    def with_default(i, *, function_1: tl.constexpr = function_1):
+        return function_1(i)
+
+    baseline = with_default.cache_key
+    with_default.hash = None
+    updated = apply_src_change(with_default, 'i + 1', 'i + 2', function_1)
+    assert baseline != updated
+
+
 def test_nested1_change():
     baseline = kernel.cache_key
     updated = apply_src_change(kernel, 'i + 1', 'i + 2', function_2)
@@ -418,6 +430,18 @@ def test_local_shadows_global():
     kernel[(1, )]()
     GLOBAL = 43
     kernel[(1, )]()
+
+
+def test_keyword_only_shadows_global(monkeypatch):
+    monkeypatch.setitem(globals(), "GLOBAL", 42)
+
+    @triton.jit
+    def kernel(*, GLOBAL: tl.constexpr):
+        tl.static_assert(GLOBAL == 1)
+
+    kernel[(1, )](GLOBAL=1)
+    monkeypatch.setitem(globals(), "GLOBAL", 43)
+    kernel[(1, )](GLOBAL=1)
 
 
 CONSTEXPR_GLOBAL = tl.constexpr(42)

--- a/python/triton/compiler/code_generator.py
+++ b/python/triton/compiler/code_generator.py
@@ -703,7 +703,6 @@ class CodeGenerator(ast.NodeVisitor):
             arg_names += [self.visit(node.vararg)]
         # Keyword-only parameters use the same ordered IR argument list.
         arg_names += [self.visit(arg) for arg in node.kwonlyargs]
-        self.visit(node.kwarg)
         return arg_names
 
     def visit_arg(self, node):

--- a/python/triton/compiler/code_generator.py
+++ b/python/triton/compiler/code_generator.py
@@ -653,7 +653,7 @@ class CodeGenerator(ast.NodeVisitor):
             raise self._unsupported(
                 node, "nested function definitions are not allowed inside a @triton.jit kernel. "
                 "Move the helper function to module level and decorate it with @triton.jit.")
-        arg_names, kwarg_names = self.visit(node.args)
+        arg_names = self.visit(node.args)
         # initialize defaults
         for i, default_value in enumerate(node.args.defaults[::-1]):
             arg_node = node.args.args[-i - 1]
@@ -701,9 +701,10 @@ class CodeGenerator(ast.NodeVisitor):
             arg_names += [self.visit(arg)]
         if node.vararg is not None:
             arg_names += [self.visit(node.vararg)]
+        # Keyword-only parameters use the same ordered IR argument list.
         arg_names += [self.visit(arg) for arg in node.kwonlyargs]
-        kwarg_names = self.visit(node.kwarg)
-        return arg_names, kwarg_names
+        self.visit(node.kwarg)
+        return arg_names
 
     def visit_arg(self, node):
         ast.NodeVisitor.generic_visit(self, node)

--- a/python/triton/compiler/code_generator.py
+++ b/python/triton/compiler/code_generator.py
@@ -701,6 +701,7 @@ class CodeGenerator(ast.NodeVisitor):
             arg_names += [self.visit(arg)]
         if node.vararg is not None:
             arg_names += [self.visit(node.vararg)]
+        arg_names += [self.visit(arg) for arg in node.kwonlyargs]
         kwarg_names = self.visit(node.kwarg)
         return arg_names, kwarg_names
 

--- a/python/triton/language/core.py
+++ b/python/triton/language/core.py
@@ -1261,7 +1261,7 @@ class tensor(base_value):
     def sigmoid(self) -> tensor:
         ...
 
-    def softmax(self, dim=None, ieee_rounding=False) -> tensor:
+    def softmax(self, dim=None, *, ieee_rounding=False) -> tensor:
         ...
 
     def ravel(self) -> tensor:

--- a/python/triton/language/standard.py
+++ b/python/triton/language/standard.py
@@ -52,7 +52,7 @@ def sigmoid(x):
 
 @core._tensor_member_fn
 @jit
-def softmax(x, dim=None, ieee_rounding=False):
+def softmax(x, dim=None, *, ieee_rounding=False):
     """
     Computes the softmax of :code:`x` along the given axis.
 
@@ -61,7 +61,8 @@ def softmax(x, dim=None, ieee_rounding=False):
     :param dim: the axis along which to normalize. Defaults to 0 -- note that
         this is *not* the last axis, unlike :code:`torch.softmax`.
     :type dim: int | None
-    :param ieee_rounding: whether the final division uses IEEE-compliant rounding
+    :param ieee_rounding: whether the final division uses IEEE-compliant rounding.
+        Must be passed by keyword.
     :type ieee_rounding: bool
     """
     if dim is None:

--- a/python/triton/runtime/interpreter.py
+++ b/python/triton/runtime/interpreter.py
@@ -1419,10 +1419,10 @@ class GridExecutor:
 
     def __call__(self, *args_dev, **kwargs):
         # Removes not used reserved keywords from kwargs
-        # Triton doesn't support keyword-only, variable positional or variable keyword arguments
-        # It's safe to inspect only positional or keyword arguments (i.e., argspec.args)
+        # Triton doesn't support variable positional or variable keyword arguments
+        # Keep both positional-or-keyword and keyword-only arguments.
         argspec = inspect.getfullargspec(self.fn)
-        kwargs = {k: v for k, v in kwargs.items() if k in argspec.args}
+        kwargs = {k: v for k, v in kwargs.items() if k in argspec.args or k in argspec.kwonlyargs}
         # copy arguments to the host
         args_hst, kwargs_hst = self._init_args_hst(args_dev, kwargs)
         # run pre-run hooks

--- a/python/triton/runtime/jit.py
+++ b/python/triton/runtime/jit.py
@@ -193,6 +193,7 @@ class DependenciesFinder(ast.NodeVisitor):
     def visit_FunctionDef(self, node):
         # Save the local name, which may hide the global name.
         self.local_names = {arg.arg for arg in node.args.args}
+        self.function_args = node.args
         self.generic_visit(node)
 
     def visit_arguments(self, node):
@@ -226,6 +227,10 @@ class DependenciesFinder(ast.NodeVisitor):
             self.visit(node.kwarg)
 
         visit_defaults(node.defaults)
+
+        # Keyword-only parameters shadow globals in the body, but not in defaults.
+        if node.kwonlyargs and node is self.function_args:
+            self.local_names.update(arg.arg for arg in node.kwonlyargs)
 
     def visitAssnTarget(self, node):
         # Target is either a single string, or a (possibly nested) list of strings if the assign target is a tuple.
@@ -422,15 +427,21 @@ def create_function_from_signature(sig, kparams, backend):
             else:
                 specialization.append(f"{ret}")
 
-    # compute argument string for a given parameter
-    def arg(name_param):
-        name, param = name_param
+    # compute argument strings, preserving the keyword-only separator
+    arg_list = []
+    has_star = False
+    for name, param in sig.parameters.items():
         if param.kind == inspect.Parameter.VAR_POSITIONAL:
-            return f"*{name}"
-        return name if param.default is inspect.Parameter.empty else f"{name}=default_{name}"
+            arg_list.append(f"*{name}")
+            has_star = True
+            continue
+        if param.kind == inspect.Parameter.KEYWORD_ONLY and not has_star:
+            arg_list.append("*")
+            has_star = True
+        arg_list.append(name if param.default is inspect.Parameter.empty else f"{name}=default_{name}")
 
     func_body = f"""
-def dynamic_func({", ".join(list(map(arg, sig.parameters.items())) + ["**options"])}):
+def dynamic_func({", ".join(arg_list + ["**options"])}):
     params = {{{', '.join([f"'{name}': {name}" for name in sig.parameters.keys()])}}}
     specialization = [{','.join(specialization)}]
     return params, specialization, options

--- a/python/triton/runtime/jit.py
+++ b/python/triton/runtime/jit.py
@@ -193,8 +193,11 @@ class DependenciesFinder(ast.NodeVisitor):
     def visit_FunctionDef(self, node):
         # Save the local name, which may hide the global name.
         self.local_names = {arg.arg for arg in node.args.args}
-        self.function_args = node.args
-        self.generic_visit(node)
+        for child in ast.iter_child_nodes(node):
+            self.visit(child)
+            # Keyword-only parameters shadow globals in the body, but not in defaults.
+            if child is node.args and node.args.kwonlyargs:
+                self.local_names.update(arg.arg for arg in node.args.kwonlyargs)
 
     def visit_arguments(self, node):
         # The purpose of this function is to visit everything in `arguments`
@@ -227,10 +230,6 @@ class DependenciesFinder(ast.NodeVisitor):
             self.visit(node.kwarg)
 
         visit_defaults(node.defaults)
-
-        # Keyword-only parameters shadow globals in the body, but not in defaults.
-        if node.kwonlyargs and node is self.function_args:
-            self.local_names.update(arg.arg for arg in node.kwonlyargs)
 
     def visitAssnTarget(self, node):
         # Target is either a single string, or a (possibly nested) list of strings if the assign target is a tuple.

--- a/python/triton/runtime/jit.py
+++ b/python/triton/runtime/jit.py
@@ -802,14 +802,17 @@ class JITFunction(JITCallable, KernelInterface[T]):
         self.do_not_specialize_on_alignment = do_not_specialize_on_alignment
         self._repr = repr
         self.launch_metadata = launch_metadata
-        # Register for simple deserialization of JITFunction constants
-        _triton_jit_function_registry[f"{self.module}:{self.fn.__qualname__}"] = self
 
         self.params = []
         for i, param in enumerate(self.signature.parameters.values()):
+            if param.kind == inspect.Parameter.VAR_KEYWORD:
+                raise TypeError(f"JIT functions do not support **{param.name} parameters")
             dns = i in do_not_specialize or param.name in do_not_specialize
             dns_oa = i in do_not_specialize_on_alignment or param.name in do_not_specialize_on_alignment
             self.params.append(KernelParam(i, param, dns, dns_oa))
+
+        # Register for simple deserialization of JITFunction constants
+        _triton_jit_function_registry[f"{self.module}:{self.fn.__qualname__}"] = self
 
         # cache of just-in-time compiled kernels
         self.device_caches = defaultdict(self.create_binder)


### PR DESCRIPTION
Add keyword-only argument support to the frontend and interpreter, and make `softmax`'s `ieee_rounding` keyword-only.

This preserves the `keep_dims` removal from #11409 while rejecting old positional calls instead of silently changing their meaning.
