### PR TITLE
[TritonGPU] Require byte-addressable shared-memory descriptors

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -7,7 +7,7 @@
 - Regression tests must be expressible as valid Triton/Gluon block programs. Targeted PTX delays may expose an existing race, but must not change values, memory effects, synchronization, or thread participation, or introduce divergence.
 
 ## Descriptor Memory Effects
-- Shared-memory read/write effects access only the logical elements of their attached memory descriptor's view. This also applies to gathers, scatters, and asynchronous copies; these operations do not access memory outside their descriptors.
+- Shared-memory read/write effects access only the logical elements of their attached memory descriptor's view. This also applies to gathers, scatters, shared-memory atomic operations, and asynchronous copies; these operations do not access memory outside their descriptors.
 - FP4 tensor copies do not touch the padding bytes introduced by their shared-memory layout. Padding affects the physical addresses of logical elements, not which elements an operation accesses.
 
 ## Build and Testing Guidelines

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,5 +1,15 @@
 # Working on Triton
 
+## Block Programming Model
+- Triton and Gluon programs operate on logical blocks, not independent hardware threads. Scalar values, scalar control flow, and memory descriptor origins are uniform within a logical block or warp-specialized execution region. Per-element variation must be represented by tensors with valid layouts. Membar inserts the required intra-CTA barriers so shared-memory operations obey this block-level model from the user's perspective.
+- Do not introduce hidden lane- or warp-varying scalars through inline assembly, hardware IDs, or other backdoors. Such programs violate the programming model and must not be used as reproducers or as justification for compiler guards. Hardware IDs used by compiler lowerings to implement layouts are different from source-level scalar values.
+- Block-uniform does not mean loop-invariant or identical across warp-specialized regions. Preserve physical alias, execution-region, and iteration-boundary checks when reasoning about synchronization, as well as the documented waits for asynchronous operations.
+- Regression tests must be expressible as valid Triton/Gluon block programs. Targeted PTX delays may expose an existing race, but must not change values, memory effects, synchronization, or thread participation, or introduce divergence.
+
+## Descriptor Memory Effects
+- Shared-memory read/write effects access only the logical elements of their attached memory descriptor's view. This also applies to gathers, scatters, and asynchronous copies; these operations do not access memory outside their descriptors.
+- FP4 tensor copies do not touch the padding bytes introduced by their shared-memory layout. Padding affects the physical addresses of logical elements, not which elements an operation accesses.
+
 ## Build and Testing Guidelines
 - Before running tests for native/compiler changes, run `make` in the triton directory to rebuild triton. DO NOT RUN `make` if you only changed Python code or code in `python/triton_kernels`.
 - For compiler changes, add tests in `python/test/` (pytest) or test (lit). Keep GPU-only tests in `python/test/unit/` or `python/test/gluon/`, name them `test_<feature>_<condition>`, and avoid creating new test files unless requested.

--- a/include/triton/Dialect/TritonGPU/IR/TritonGPUTypes.td
+++ b/include/triton/Dialect/TritonGPU/IR/TritonGPUTypes.td
@@ -25,6 +25,7 @@ def TTG_MemDescType : TTG_TypeDef<"MemDesc", "memdesc", [ShapedTypeInterface]> {
 
     let description = [{
         Memory descriptor contains a base pointer (scalar) and a descriptor of the memory.
+        Shared-memory element bit widths must be multiples of eight.
         If mutable memory is false that means the memory is constant and can only be allocated and stored once.
         A constant memory allocation is different than a tensor as it can have multiple views and the descriptor
         can be changed without changing the underlying memory.

--- a/lib/Conversion/TritonGPUToLLVM/Utility.cpp
+++ b/lib/Conversion/TritonGPUToLLVM/Utility.cpp
@@ -710,8 +710,6 @@ getPaddedSharedShifts(Attribute enc, unsigned bitwidth, bool offsetInBytes) {
     return {};
 
   SmallVector<std::pair<unsigned, unsigned>> shifts;
-  assert(bitwidth >= 8 && (bitwidth % 8 == 0) &&
-         "bitwidth must be a positive multiple of 8 for padding");
   uint64_t offScale = offsetInBytes ? (bitwidth / 8) : 1;
   for (auto [interval, padding] :
        llvm::zip_equal(padded.getIntervals(), padded.getPaddings())) {

--- a/lib/Dialect/TritonGPU/IR/Ops.cpp
+++ b/lib/Dialect/TritonGPU/IR/Ops.cpp
@@ -920,8 +920,6 @@ static LogicalResult verifySharedMemoryRank(Operation *op,
 LogicalResult LocalAllocOp::verify() {
   if (!isa<SharedMemorySpaceAttr>(getType().getMemorySpace()))
     return emitOpError("should create a buffer of shared memory");
-  if (getIntOrFloatOrPtrBitWidth(getType().getElementType()) % 8 != 0)
-    return emitOpError("element type bit width must be a multiple of 8");
   if (getSrc() && failed(verifySharedMemoryRank(*this, getSrc().getType(),
                                                 getType(), "source")))
     return failure();

--- a/lib/Dialect/TritonGPU/IR/Types.cpp
+++ b/lib/Dialect/TritonGPU/IR/Types.cpp
@@ -188,6 +188,11 @@ LogicalResult MemDescType::verify(function_ref<InFlightDiagnostic()> emitError,
              << "memorySpace must be SharedMemorySpace for shared encoding. "
              << "Got " << memorySpace;
     }
+    if (bitwidth % 8 != 0)
+      return emitError()
+             << "shared-memory element type bit width must be a multiple of 8; "
+                "got "
+             << bitwidth;
   } else if (auto enc = dyn_cast<nvidia_gpu::TensorMemoryScalesEncodingAttr>(
                  encoding)) {
     if (memorySpace != nvidia_gpu::TensorMemorySpaceAttr::get(ctx)) {

--- a/test/TritonGPU/invalid.mlir
+++ b/test/TritonGPU/invalid.mlir
@@ -56,11 +56,8 @@ tt.func public @memdesc_zero_allocation_dimension(%arg0: !ttg.memdesc<2x4xi32, #
 
 #shared = #ttg.swizzled_shared<{vec = 1, perPhase = 1, maxPhase = 1, order = [0]}>
 #smem = #ttg.shared_memory
-tt.func public @local_alloc_i1() {
-    // expected-error @+1 {{element type bit width must be a multiple of 8}}
-    %0 = ttg.local_alloc : () -> !ttg.memdesc<8xi1, #shared, #smem, mutable>
-    tt.return
-}
+// expected-error @below {{shared-memory element type bit width must be a multiple of 8; got 1}}
+!i1_smem = !ttg.memdesc<8xi1, #shared, #smem>
 
 // -----
 

--- a/third_party/amd/lib/TritonAMDGPUToLLVM/MemoryOpToLLVM.cpp
+++ b/third_party/amd/lib/TritonAMDGPUToLLVM/MemoryOpToLLVM.cpp
@@ -352,7 +352,6 @@ lowerDsReadTr(Operation *op,
   }
 
   // Perform computation in bytes, LLVM optimises this better
-  assert(bitWidth >= 8);
   auto i8Tile =
       zerosLike(LinearLayout::identity1D(bitWidth / 8, kReg, kOffset));
   auto i8AddrLayout = i8Tile * addrLayout;

--- a/third_party/nvidia/lib/TritonNVIDIAGPUToLLVM/DotOpToLLVM/MMAv5.cpp
+++ b/third_party/nvidia/lib/TritonNVIDIAGPUToLLVM/DotOpToLLVM/MMAv5.cpp
@@ -645,9 +645,8 @@ LogicalResult convertDotImpl(const LLVMTypeConverter &typeConverter,
     // or byte-padded, and FP6 also occupies byte-sized containers. There is no
     // measured SMEM-versus-TMEM weighting here; equal sizes retain B priority.
     auto storageBits = [](MemDescType ty, int logicalBits) {
-      return logicalBits == 4 && !isFp4Padded(ty)
-                 ? 4u
-                 : std::max<unsigned>(8, ty.getElementTypeBitWidth());
+      return logicalBits == 4 && !isFp4Padded(ty) ? 4u
+                                                  : ty.getElementTypeBitWidth();
     };
     uint64_t aTileBits = uint64_t(aOperandShape[0]) * aOperandShape[1] *
                          storageBits(aTensorTy, op.numBitsPerElementA);


### PR DESCRIPTION
Require shared-memory descriptor element widths to be multiples of eight at type verification. Remove redundant allocation and descriptor-lowering checks while preserving boolean scratch conversions.

Document the block programming model and descriptor memory effects in AGENTS.md.
