### PR TITLE
[INTERPRETER] Fix double rounding in tl.fma

### DIFF
--- a/python/test/unit/language/test_core.py
+++ b/python/test/unit/language/test_core.py
@@ -5,6 +5,7 @@ import re
 from typing import Optional
 import math
 import textwrap
+from fractions import Fraction
 
 import numpy as np
 import pytest
@@ -1136,7 +1137,7 @@ def test_math_erf_op(dtype, member_fn, device):
 
 
 @pytest.mark.interpreter
-@pytest.mark.parametrize("dtype", [dtype for dtype in ["float32", "float64"]])
+@pytest.mark.parametrize("dtype", ["float16", "float32", "float64"])
 def test_math_fma_op(dtype, device):
     check_type_supported(dtype, device)
     SIZE = 128
@@ -1150,14 +1151,67 @@ def test_math_fma_op(dtype, device):
         z = tl.math.fma(x, y, w)
         tl.store(Z + off, z)
 
-    torch_dtype = torch.float32 if dtype == "float32" else torch.float64
-    x = torch.randn(SIZE, dtype=torch_dtype, device=device)
-    y = torch.randn(SIZE, dtype=torch_dtype, device=device)
-    w = torch.randn(SIZE, dtype=torch_dtype, device=device)
-    z_ref = x * y + w
-    z_tri = torch.zeros_like(x)
-    kernel[(1, )](z_tri, x, y, w, SIZE=SIZE, num_warps=4)
-    torch.testing.assert_close(z_tri, z_ref)
+    def fma_ref(x, y, w):
+        # Rational arithmetic keeps the product exact, so the result is rounded
+        # once as an fma requires.
+        exact = [Fraction(float(a)) * Fraction(float(b)) + Fraction(float(c)) for a, b, c in zip(x, y, w)]
+        return np.array([float(e) for e in exact], dtype=x.dtype)
+
+    rs = RandomState(17)
+    x = numpy_random((SIZE, ), dtype_str=dtype, rs=rs)
+    y = numpy_random((SIZE, ), dtype_str=dtype, rs=rs)
+    w = numpy_random((SIZE, ), dtype_str=dtype, rs=rs)
+    # Let half of the addends cancel the rounded product, the sharpest case.
+    w[SIZE // 2:] = -(x[SIZE // 2:] * y[SIZE // 2:])
+
+    x_tri = to_triton(x, device=device, dst_type=dtype)
+    y_tri = to_triton(y, device=device, dst_type=dtype)
+    w_tri = to_triton(w, device=device, dst_type=dtype)
+    z_tri = to_triton(np.zeros_like(x), device=device, dst_type=dtype)
+    kernel[(1, )](z_tri, x_tri, y_tri, w_tri, SIZE=SIZE, num_warps=4)
+
+    np.testing.assert_equal(fma_ref(x, y, w), to_numpy(z_tri))
+
+
+@pytest.mark.interpreter
+def test_math_fma_op_special_values(device):
+    check_type_supported('float64', device)
+
+    @triton.jit
+    def kernel(Z, X, Y, W, SIZE: tl.constexpr):
+        off = tl.arange(0, SIZE)
+        x = tl.load(X + off)
+        y = tl.load(Y + off)
+        w = tl.load(W + off)
+        z = tl.math.fma(x, y, w)
+        tl.store(Z + off, z)
+
+    finfo = np.finfo(np.float64)
+    inf, nan = float('inf'), float('nan')
+    cases = [
+        # x, y, w, expected
+        (nan, 1.0, 1.0, nan),
+        (inf, 0.0, 1.0, nan),
+        (2.0, 3.0, inf, inf),
+        (-finfo.max, finfo.max, inf, inf),
+        (-0.0, 1.0, -0.0, -0.0),
+        (1.0, 1.0, -1.0, 0.0),
+        (finfo.max, 2.0, finfo.max, inf),
+        (-finfo.smallest_subnormal, 0.5, 0.0, -0.0),
+    ]
+    x, y, w, expected = (np.array(column, dtype=np.float64) for column in zip(*cases))
+
+    x_tri = to_triton(x, device=device, dst_type='float64')
+    y_tri = to_triton(y, device=device, dst_type='float64')
+    w_tri = to_triton(w, device=device, dst_type='float64')
+    z_tri = to_triton(np.zeros_like(x), device=device, dst_type='float64')
+    kernel[(1, )](z_tri, x_tri, y_tri, w_tri, SIZE=len(cases))
+
+    z = to_numpy(z_tri)
+    np.testing.assert_equal(z, expected)
+    # assert_equal treats -0.0 and 0.0 as equal; NaN signs are unspecified.
+    finite = ~np.isnan(expected)
+    np.testing.assert_equal(np.signbit(z[finite]), np.signbit(expected[finite]))
 
 
 @pytest.mark.interpreter

--- a/python/triton/runtime/interpreter.py
+++ b/python/triton/runtime/interpreter.py
@@ -712,11 +712,9 @@ class InterpreterBuilder:
         dtype = z.data.dtype
         if dtype == np.float64:
             ret = np_fma_fp64(x.data, y.data, z.data)
-        elif dtype == np.float32 or dtype == np.float16:
+        else:
             product = np.multiply(x.data, y.data, dtype=np.float64)
             ret = np.add(product, z.data, dtype=np.float64).astype(dtype)
-        else:
-            ret = x.data * y.data + z.data
         return TensorHandle(ret, z.dtype.scalar)
 
     # unary functions

--- a/python/triton/runtime/interpreter.py
+++ b/python/triton/runtime/interpreter.py
@@ -7,6 +7,7 @@ from typing import Tuple, List, Dict, Callable, TypeVar, Optional
 import math
 import numpy as np
 import time
+from fractions import Fraction
 
 import triton
 import triton.language as tl
@@ -257,6 +258,25 @@ def _umulhi_64(a, b):
     return ((int(a) & mask) * (int(b) & mask)) >> 64
 
 
+def _fma_fp64(a, b, c):
+    # Numpy has no fused multiply-add, and float64 has no wider type to hold the
+    # product exactly, so round the exact rational value instead.
+    if math.isnan(a) or math.isnan(b) or math.isnan(c) or math.isinf(a) or math.isinf(b):
+        return a * b + c
+    if math.isinf(c):
+        return c
+    exact = Fraction(a) * Fraction(b) + Fraction(c)
+    if exact == 0:
+        # Only zero operands can make this a negative zero.
+        return a * b + c if a * b == 0.0 and c == 0.0 else 0.0
+    sign = 1.0 if exact > 0 else -1.0
+    try:
+        ret = float(exact)
+    except OverflowError:
+        return math.copysign(math.inf, sign)
+    return ret if ret != 0.0 else math.copysign(0.0, sign)
+
+
 def _e8m0_to_f32(scale):
     assert scale.dtype in (np.uint8, np.int8)
     scale = scale.astype(np.uint8)
@@ -352,6 +372,7 @@ def _prepare_dot_scaled_operand(value_handle, scale_handle, format_enum, k_pack,
 np_erf_fp32 = np.vectorize(_erf, otypes=[np.float32])
 np_erf_fp64 = np.vectorize(_erf, otypes=[np.float64])
 np_umulhi_u64 = np.vectorize(_umulhi_64, otypes=[np.uint64])
+np_fma_fp64 = np.vectorize(_fma_fp64, otypes=[np.float64])
 
 
 class ExtraFunctions:
@@ -686,7 +707,17 @@ class InterpreterBuilder:
     create_select = lambda self, cond, lhs, rhs: self.ternary_op(cond, lhs, rhs, np.where)
 
     def create_fma(self, x, y, z):
-        return TensorHandle(x.data * y.data + z.data, z.dtype.scalar)
+        # An fma rounds once, but multiplying and then adding rounds twice.
+        # float64 has the precision to round the narrower types correctly.
+        dtype = z.data.dtype
+        if dtype == np.float64:
+            ret = np_fma_fp64(x.data, y.data, z.data)
+        elif dtype == np.float32 or dtype == np.float16:
+            product = np.multiply(x.data, y.data, dtype=np.float64)
+            ret = np.add(product, z.data, dtype=np.float64).astype(dtype)
+        else:
+            ret = x.data * y.data + z.data
+        return TensorHandle(ret, z.dtype.scalar)
 
     # unary functions
     def unary_op(self, arg, op):


### PR DESCRIPTION
`tl.fma(x, y, z)` performs a fused multiply-add, so the exact product and addend must be rounded together once. The interpreter instead evaluated it as `x * y + z`, rounding the product before the addition.

This can produce different results from the compiled kernel. In particular, if `z` cancels the already-rounded product, the interpreter returns zero while a fused operation retains the rounding residual:

```python
x = 1.4142135    # float32
y = 1.7320508
z = -(x * y)     # cancels the rounded product
result = tl.fma(x, y, z)
```

Produced:

```text
interpreter (before)   0.0            0x00000000
compiled kernel        6.339208e-08   0x3388222a
```

Compute float16 and float32 operations through a float64 intermediate, which has enough precision to produce the correctly rounded target result. Since no NumPy type is wide enough to hold the exact float64 product, compute its exact rational result before converting back to float64. Preserve the expected IEEE behavior for NaN, infinity, overflow, underflow, exact cancellation, and signed zero.

Update `test_math_fma_op` to use an exact reference instead of `x * y + z`, add float16 coverage, and include cancellation inputs that distinguish fused from non-fused evaluation. Also add focused float64 special-value cases.