### PR TITLE
[IR] Model speculation for immutable shared and tensor allocations

### DIFF
--- a/include/triton/Dialect/TritonGPU/IR/TritonGPUOps.td
+++ b/include/triton/Dialect/TritonGPU/IR/TritonGPUOps.td
@@ -150,7 +150,10 @@ def TTG_AsyncCopyGlobalToLocalOp : TTG_Op<"async_copy_global_to_local", [
 }
 
 // Allocate shared memory
-def TTG_LocalAllocOp : TTG_Op<"local_alloc", [DeclareOpInterfaceMethods<MemoryEffectsOpInterface>]> {
+def TTG_LocalAllocOp : TTG_Op<"local_alloc", [
+  DeclareOpInterfaceMethods<MemoryEffectsOpInterface>,
+  DeclareOpInterfaceMethods<ConditionallySpeculatable>
+]> {
   let summary = "allocate tensor";
   let description = [{
     This operation allocates buffer in shared memory and return a descriptor

--- a/include/triton/Dialect/TritonNvidiaGPU/IR/TritonNvidiaGPUOps.td
+++ b/include/triton/Dialect/TritonNvidiaGPU/IR/TritonNvidiaGPUOps.td
@@ -1017,7 +1017,10 @@ def TTNG_TMEMStoreOp : TTNG_Op<"tmem_store", [
   let hasVerifier = 1;
 }
 
-def TTNG_TMEMAllocOp : TTNG_Op<"tmem_alloc", [DeclareOpInterfaceMethods<MemoryEffectsOpInterface>]> {
+def TTNG_TMEMAllocOp : TTNG_Op<"tmem_alloc", [
+  DeclareOpInterfaceMethods<MemoryEffectsOpInterface>,
+  DeclareOpInterfaceMethods<ConditionallySpeculatable>
+]> {
   let summary = "allocate tensor memory";
   let description = [{
     This operation allocates a buffer in tensor memory and returns a descriptor

--- a/lib/Dialect/TritonGPU/IR/Ops.cpp
+++ b/lib/Dialect/TritonGPU/IR/Ops.cpp
@@ -1,5 +1,6 @@
 #include "mlir/IR/BuiltinTypes.h"
 #include "mlir/IR/Diagnostics.h"
+#include "mlir/Interfaces/SideEffectInterfaces.h"
 #include "mlir/Support/DebugStringHelper.h"
 #include "triton/Dialect/Triton/IR/Dialect.h"
 #include "triton/Dialect/Triton/IR/Utility.h"
@@ -844,6 +845,14 @@ void LocalAllocOp::getEffects(
   if (getSrc())
     effects.push_back(
         makeShared<MemoryEffects::Write>(alloc, SharedKind::Generic));
+}
+
+Speculation::Speculatability LocalAllocOp::getSpeculatability() {
+  // Immutable local allocations are safe to speculate before physical storage
+  // is assigned.
+  return mlir::isMemoryEffectFree(getOperation())
+             ? Speculation::Speculatable
+             : Speculation::NotSpeculatable;
 }
 
 OpFoldResult LocalAllocOp::fold(FoldAdaptor adaptor) {

--- a/lib/Dialect/TritonNvidiaGPU/IR/Ops.cpp
+++ b/lib/Dialect/TritonNvidiaGPU/IR/Ops.cpp
@@ -24,6 +24,7 @@
 #include "mlir/IR/Builders.h"
 #include "mlir/IR/BuiltinTypes.h"
 #include "mlir/IR/Diagnostics.h"
+#include "mlir/Interfaces/SideEffectInterfaces.h"
 #include "mlir/Support/LLVM.h"
 #include "triton/Analysis/Utility.h"
 #include "triton/Dialect/Triton/IR/Dialect.h"
@@ -1782,6 +1783,12 @@ void TMEMAllocOp::getEffects(
   if (getSrc())
     effects.emplace_back(MemoryEffects::Write::get(), alloc,
                          TensorMemory::get());
+}
+
+Speculation::Speculatability TMEMAllocOp::getSpeculatability() {
+  return mlir::isMemoryEffectFree(getOperation())
+             ? Speculation::Speculatable
+             : Speculation::NotSpeculatable;
 }
 
 // -- TMEMCopyOp --

--- a/test/Triton/loop-invariant-code-motion.mlir
+++ b/test/Triton/loop-invariant-code-motion.mlir
@@ -167,3 +167,70 @@ tt.func @hoist_cond_no_hoist_load_from_scf_while(%ptr: tensor<1024x!tt.ptr<f32>>
   tt.store %ptr, %1 : tensor<1024x!tt.ptr<f32>>
   tt.return
 }
+
+// -----
+
+#blocked = #ttg.blocked<{sizePerThread = [1], threadsPerWarp = [32], warpsPerCTA = [4], order = [0]}>
+#shared = #ttg.swizzled_shared<{vec = 1, perPhase = 1, maxPhase = 1, order = [0]}>
+#smem = #ttg.shared_memory
+module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, "ttg.threads-per-warp" = 32 : i32} {
+  // CHECK-LABEL: @local_alloc_speculation
+  // CHECK: ttg.local_alloc {{.*}} -> !ttg.memdesc<128xf32, #shared, #smem>
+  // CHECK-NOT: ttg.local_alloc
+  // CHECK: scf.for
+  // CHECK: ttg.local_alloc {{.*}} -> !ttg.memdesc<128xf32, #shared, #smem, mutable>
+  // CHECK: ttg.local_alloc {{.*}} {allocation.offset = 0 : i32}
+  // CHECK-NOT: ttg.local_alloc
+  // CHECK: scf.yield
+  tt.func @local_alloc_speculation(%src: tensor<128xf32, #blocked>, %n: i32) -> tensor<128xf32, #blocked> {
+    %c0 = arith.constant 0 : i32
+    %c1 = arith.constant 1 : i32
+    %result = scf.for %i = %c0 to %n step %c1 iter_args(%sum = %src) -> tensor<128xf32, #blocked> : i32 {
+      %immutable = ttg.local_alloc %src : (tensor<128xf32, #blocked>) -> !ttg.memdesc<128xf32, #shared, #smem>
+      %mutable = ttg.local_alloc %src : (tensor<128xf32, #blocked>) -> !ttg.memdesc<128xf32, #shared, #smem, mutable>
+      %allocated = ttg.local_alloc %src {allocation.offset = 0 : i32} : (tensor<128xf32, #blocked>) -> !ttg.memdesc<128xf32, #shared, #smem>
+      %a = ttg.local_load %immutable : !ttg.memdesc<128xf32, #shared, #smem> -> tensor<128xf32, #blocked>
+      %b = ttg.local_load %mutable : !ttg.memdesc<128xf32, #shared, #smem, mutable> -> tensor<128xf32, #blocked>
+      %c = ttg.local_load %allocated : !ttg.memdesc<128xf32, #shared, #smem> -> tensor<128xf32, #blocked>
+      %sum_a = arith.addf %sum, %a : tensor<128xf32, #blocked>
+      %sum_b = arith.addf %sum_a, %b : tensor<128xf32, #blocked>
+      %sum_c = arith.addf %sum_b, %c : tensor<128xf32, #blocked>
+      scf.yield %sum_c : tensor<128xf32, #blocked>
+    }
+    tt.return %result : tensor<128xf32, #blocked>
+  }
+}
+
+// -----
+
+#blocked = #ttg.blocked<{sizePerThread = [1, 1], threadsPerWarp = [32, 1], warpsPerCTA = [4, 1], order = [0, 1]}>
+#tmem = #ttng.tensor_memory_encoding<blockM = 128, blockN = 64, colStride = 1>
+#tmem_space = #ttng.tensor_memory
+module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, "ttg.threads-per-warp" = 32 : i32} {
+  // CHECK-LABEL: @tmem_alloc_speculation
+  // CHECK: %[[ALLOC:.*]], %[[TOKEN:.*]] = ttng.tmem_alloc
+  // CHECK-NOT: ttng.tmem_alloc
+  // CHECK: scf.for
+  // CHECK: ttng.tmem_alloc {{.*}} -> !ttg.memdesc<128x64xf32, #tmem, #ttng.tensor_memory, mutable>
+  // CHECK: ttng.tmem_alloc {{.*}} {tensor_memory_col_offset = 0 : i32
+  // CHECK-NOT: ttng.tmem_alloc
+  // CHECK: ttng.tmem_load %[[ALLOC]][%[[TOKEN]]]
+  // CHECK: scf.yield
+  tt.func @tmem_alloc_speculation(%src: tensor<128x64xf32, #blocked>, %n: i32) -> tensor<128x64xf32, #blocked> {
+    %c0 = arith.constant 0 : i32
+    %c1 = arith.constant 1 : i32
+    %result = scf.for %i = %c0 to %n step %c1 iter_args(%sum = %src) -> tensor<128x64xf32, #blocked> : i32 {
+      %immutable, %token = ttng.tmem_alloc %src : (tensor<128x64xf32, #blocked>) -> (!ttg.memdesc<128x64xf32, #tmem, #tmem_space>, !ttg.async.token)
+      %mutable = ttng.tmem_alloc %src : (tensor<128x64xf32, #blocked>) -> !ttg.memdesc<128x64xf32, #tmem, #tmem_space, mutable>
+      %allocated = ttng.tmem_alloc %src {tensor_memory_col_offset = 0 : i32, tensor_memory_row_offset = 0 : i32} : (tensor<128x64xf32, #blocked>) -> !ttg.memdesc<128x64xf32, #tmem, #tmem_space>
+      %a, %load_token = ttng.tmem_load %immutable[%token] : !ttg.memdesc<128x64xf32, #tmem, #tmem_space> -> tensor<128x64xf32, #blocked>
+      %b = ttng.tmem_load %mutable : !ttg.memdesc<128x64xf32, #tmem, #tmem_space, mutable> -> tensor<128x64xf32, #blocked>
+      %c = ttng.tmem_load %allocated : !ttg.memdesc<128x64xf32, #tmem, #tmem_space> -> tensor<128x64xf32, #blocked>
+      %sum_a = arith.addf %sum, %a : tensor<128x64xf32, #blocked>
+      %sum_b = arith.addf %sum_a, %b : tensor<128x64xf32, #blocked>
+      %sum_c = arith.addf %sum_b, %c : tensor<128x64xf32, #blocked>
+      scf.yield %sum_c : tensor<128x64xf32, #blocked>
+    }
+    tt.return %result : tensor<128x64xf32, #blocked>
+  }
+}

--- a/test/TritonGPU/loop-pipeline-expand.mlir
+++ b/test/TritonGPU/loop-pipeline-expand.mlir
@@ -1,4 +1,5 @@
 // RUN: triton-opt %s -split-input-file -tritongpu-pipeline | FileCheck %s --check-prefixes=CHECK
+// RUN: triton-opt %s -split-input-file -tritongpu-pipeline -triton-nvidia-tma-lowering | FileCheck %s --check-prefix=TMA
 
 #blocked = #ttg.blocked<{sizePerThread = [1, 4], threadsPerWarp = [4, 8], warpsPerCTA = [4, 1], order = [1, 0]}>
 #blocked1 = #ttg.blocked<{sizePerThread = [1, 4], threadsPerWarp = [1, 32], warpsPerCTA = [4, 1], order = [1, 0]}>
@@ -85,6 +86,35 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.targ
       scf.yield %next : i32
     } {tt.num_stages = 2 : i32, tt.scheduled_max_stage = 1 : i32}
     tt.return %result : i32
+  }
+}
+
+// -----
+
+#blocked = #ttg.blocked<{sizePerThread = [1, 1], threadsPerWarp = [1, 32], warpsPerCTA = [1, 4], order = [1, 0]}>
+#shared = #ttg.nvmma_shared<{swizzlingByteWidth = 32, transposed = false, elementBitWidth = 16}>
+#smem = #ttg.shared_memory
+module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.target = "cuda:90", "ttg.threads-per-warp" = 32 : i32} {
+  // The invariant TMA load is lowered after the loop is pipelined. Its storage
+  // must still forward into the loop without yielding a different memdesc type.
+  // TMA-LABEL: @pipeline_invariant_tma_load
+  // TMA: %[[ALLOC:.*]] = ttg.local_alloc : () -> !ttg.memdesc<16x16xf16
+  // TMA: ttng.async_tma_copy_global_to_local {{.*}} %[[ALLOC]],
+  // TMA: scf.for
+  // TMA: ttg.local_load %[[ALLOC]]
+  // TMA: tt.return
+  tt.func @pipeline_invariant_tma_load(%desc: !tt.tensordesc<16x16xf16, #shared>, %n: i32) -> tensor<16x16xf16, #blocked> {
+    %c0 = arith.constant 0 : i32
+    %c1 = arith.constant 1 : i32
+    %zero = arith.constant dense<0.0> : tensor<16x16xf16, #blocked>
+    %tile = tt.descriptor_load %desc[%c0, %c0] : !tt.tensordesc<16x16xf16, #shared> -> tensor<16x16xf16, #blocked>
+    %result = scf.for %i = %c0 to %n step %c1 iter_args(%sum = %zero) -> tensor<16x16xf16, #blocked> : i32 {
+      %view = ttg.local_alloc %tile {loop.cluster = 0 : i32, loop.stage = 0 : i32} : (tensor<16x16xf16, #blocked>) -> !ttg.memdesc<16x16xf16, #shared, #smem>
+      %loaded = ttg.local_load %view {loop.cluster = 0 : i32, loop.stage = 0 : i32} : !ttg.memdesc<16x16xf16, #shared, #smem> -> tensor<16x16xf16, #blocked>
+      %next = arith.addf %sum, %loaded {loop.cluster = 1 : i32, loop.stage = 1 : i32} : tensor<16x16xf16, #blocked>
+      scf.yield %next : tensor<16x16xf16, #blocked>
+    } {tt.num_stages = 2 : i32, tt.scheduled_max_stage = 1 : i32}
+    tt.return %result : tensor<16x16xf16, #blocked>
   }
 }
 


### PR DESCRIPTION
Implement ConditionallySpeculatable for local_alloc and tmem_alloc using their
existing memory-effect contracts. Immutable allocations without assigned
physical offsets can be speculated; mutable or physically assigned storage
remains non-speculatable.

This lets the pipeliner leave immutable shared allocations unpredicated,
avoiding descriptor-valued conditionals whose result types become inconsistent
when late TMA lowering forwards mutable storage into their yields. It also
allows generic LICM to hoist invariant immutable allocations.

The TMA was failing in some internal kernel after https://github.com/triton-lang/triton/pull/11410

Cover pipeline-to-TMA forwarding and the LICM boundaries for both memory spaces,
including an immutable tensor allocation with a dependency-token result.
