### PR TITLE
Revert "[NVIDIA] Generalize masked load fallback register ties (#11335)"

### DIFF
--- a/test/Conversion/tritongpu_to_llvm.mlir
+++ b/test/Conversion/tritongpu_to_llvm.mlir
@@ -17,7 +17,8 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32} {
   // CHECK-LABEL: basic_load
   tt.func @basic_load(%a_ptr_init : tensor<256x!tt.ptr<f32>, #blocked0>, %cst : tensor<256xi1, #blocked0>, %cst_0 : tensor<256xf32, #blocked0>) {
     // CHECK: llvm.inline_asm
-    // CHECK-SAME: @$3 ld.global.b32 { $0 }, [ $2 + 0 ];", "=r,0,l,b"
+    // CHECK-SAME: mov.u32 $0, $1;
+    // CHECK-SAME: @$3 ld.global.b32 { $0 }, [ $2 + 0 ];", "=r,r,l,b"
     // CHECK: llvm.inline_asm
     %1 = tt.load %a_ptr_init, %cst, %cst_0 : tensor<256x!tt.ptr<f32>, #blocked0>
     tt.return
@@ -41,7 +42,7 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32} {
     // CHECK-SAME: mov.u32 $0, 0xffffffff;\0A\09@$2 ld.global.b32 { $0 }, [ $1 + 0 ];", "=r,l,b"
     %computed = tt.load %ptr, %mask, %max : !tt.ptr<i32>
     // CHECK: llvm.inline_asm
-    // CHECK-SAME: @$3 ld.global.b32 { $0 }, [ $2 + 0 ];", "=r,0,l,b"
+    // CHECK-SAME: mov.u32 $0, $1;\0A\09@$3 ld.global.b32 { $0 }, [ $2 + 0 ];", "=r,r,l,b"
     %dynamic = tt.load %ptr, %mask, %fallback : !tt.ptr<i32>
     %xor = arith.xori %literal, %casted : i32
     %xor2 = arith.xori %xor, %computed : i32
@@ -53,7 +54,7 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32} {
   // CHECK-LABEL: masked_scalar_i64
   tt.func @masked_scalar_i64(%ptr: !tt.ptr<i64>, %out: !tt.ptr<i64>, %mask: i1, %fallback: i64) {
     // CHECK: llvm.inline_asm
-    // CHECK-SAME: @$3 ld.global.b64 { $0 }, [ $2 + 0 ];", "=l,0,l,b"
+    // CHECK-SAME: mov.u64 $0, $1;\0A\09@$3 ld.global.b64 { $0 }, [ $2 + 0 ];", "=l,l,l,b"
     %value = tt.load %ptr, %mask, %fallback : !tt.ptr<i64>
     tt.store %out, %value : !tt.ptr<i64>
     tt.return
@@ -155,9 +156,9 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32} {
   tt.func @load_with_l2_cache_hint(%a_ptr_init : tensor<256x!tt.ptr<f32>, #blocked0>, %cst : tensor<256xi1, #blocked0>, %cst_0 : tensor<256xf32, #blocked0>) {
     // The cache policy register is created once (hoisted out of the vectorization loop).
     // CHECK: llvm.inline_asm asm_dialect = att {{.*}} "mov.u64 $0, 0x0;\0A\09createpolicy.fractional.L2::evict_first.b64 $0, 1.0;"
-    // CHECK: llvm.inline_asm has_side_effects asm_dialect = att {{.*}} "@$4 ld.global.L1::evict_first.L2::cache_hint.b32 { $0 }, [ $2 + 0 ], $3;", "=r,0,l,l,b"
+    // CHECK: llvm.inline_asm has_side_effects asm_dialect = att {{.*}} "mov.u32 $0, $1;\0A\09@$4 ld.global.L1::evict_first.L2::cache_hint.b32 { $0 }, [ $2 + 0 ], $3;"
     // CHECK-NOT: createpolicy
-    // CHECK: llvm.inline_asm has_side_effects asm_dialect = att {{.*}} "@$4 ld.global.L1::evict_first.L2::cache_hint.b32 { $0 }, [ $2 + 0 ], $3;", "=r,0,l,l,b"
+    // CHECK: llvm.inline_asm has_side_effects asm_dialect = att {{.*}} "mov.u32 $0, $1;\0A\09@$4 ld.global.L1::evict_first.L2::cache_hint.b32 { $0 }, [ $2 + 0 ], $3;"
       %1 = tt.load %a_ptr_init, %cst, %cst_0 evictionPolicy = evict_first : tensor<256x!tt.ptr<f32>, #blocked0>
       tt.return
   }
@@ -262,7 +263,8 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 1 : i32} {
     %mask = arith.cmpi slt, %offsets, %bounds : tensor<1x128xi32, #blocked2d>
     %other = tt.splat %fallback : f8E4M3FN -> tensor<1x128xf8E4M3FN, #blocked2d>
     // CHECK: llvm.inline_asm
-    // CHECK-SAME: @$3 ld.global.b32 { $0 }, [ $2 + 0 ];", "=r,0,l,b"
+    // CHECK-SAME: mov.u32 $0, $1;
+    // CHECK-SAME: ld.global.b32
     %values = tt.load %ptrs, %mask, %other : tensor<1x128x!tt.ptr<f8E4M3FN>, #blocked2d>
     tt.store %ptrs, %values, %mask : tensor<1x128x!tt.ptr<f8E4M3FN>, #blocked2d>
     tt.return
@@ -277,7 +279,7 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 1 : i32} {
     %mask = arith.cmpi slt, %offsets, %bounds : tensor<128xi32, #blocked0>
     %other = tt.splat %fallback : i8 -> tensor<128xi8, #blocked0>
     // CHECK: llvm.inline_asm
-    // CHECK-SAME: @$3 ld.global.b32 { $0 }, [ $2 + 0 ];", "=r,0,l,b"
+    // CHECK-SAME: mov.u32 $0, $1;\0A\09@$3 ld.global.b32 { $0 }, [ $2 + 0 ];", "=r,r,l,b"
     %dynamic = tt.load %ptrs, %mask, %other : tensor<128x!tt.ptr<i8>, #blocked0>
     %negative = arith.constant dense<-128> : tensor<128xi8, #blocked0>
     %one = arith.constant dense<1> : tensor<128xi8, #blocked0>

--- a/third_party/nvidia/lib/TritonNVIDIAGPUToLLVM/LoadStoreOpToLLVM.cpp
+++ b/third_party/nvidia/lib/TritonNVIDIAGPUToLLVM/LoadStoreOpToLLVM.cpp
@@ -269,8 +269,8 @@ struct LoadOpConversion : public ConvertOpToLLVMPattern<triton::LoadOp>,
             auto tensorType = dyn_cast<RankedTensorType>(op.getType());
             if (tensorType &&
                 ((valueElemNBits == 16 && nWords > 1) ||
-                 (valueElemNBits == 8 && width == 32 && nWords == 1 && vec == 4 &&
-                  tensorType.getRank() == 1 &&
+                 (valueElemNBits == 8 && width == 32 && nWords == 1 &&
+                  vec == 4 && tensorType.getRank() == 1 &&
                   isa<FloatType>(tensorType.getElementType())))) {
               // Match each fallback to its destination instead of moving it.
               // Match the packed FP8 fallback to its 32-bit destination.
@@ -288,7 +288,8 @@ struct LoadOpConversion : public ConvertOpToLLVMPattern<triton::LoadOp>,
         }
       }
 
-      auto *addrOpr = ptxBuilder.newAddrOperand(ptrElems[runStart], "l", in_off);
+      auto *addrOpr =
+          ptxBuilder.newAddrOperand(ptrElems[runStart], "l", in_off);
 
       // Define the instruction opcode
       auto &ld = ptxBuilder.create("ld")
@@ -476,7 +477,8 @@ struct StoreOpConversion : public ConvertOpToLLVMPattern<triton::StoreOp>,
         pred = ttg::maybeAnd(rewriter, loc, pred, mask);
       }
 
-      auto *asmAddr = ptxBuilder.newAddrOperand(ptrElems[runStart], "l", in_off);
+      auto *asmAddr =
+          ptxBuilder.newAddrOperand(ptrElems[runStart], "l", in_off);
 
       auto &ptxStoreInstr =
           ptxBuilder.create("st")

--- a/third_party/nvidia/lib/TritonNVIDIAGPUToLLVM/LoadStoreOpToLLVM.cpp
+++ b/third_party/nvidia/lib/TritonNVIDIAGPUToLLVM/LoadStoreOpToLLVM.cpp
@@ -220,8 +220,9 @@ struct LoadOpConversion : public ConvertOpToLLVMPattern<triton::LoadOp>,
     Value l2PolicyReg =
         createCachePolicy(op.getEvict(), rewriter, loc, computeCapability);
     for (size_t vecStart = 0; vecStart < numElems; vecStart += vec) {
+      // TODO: optimization when ptr is GEP with constant offset
       const size_t runStart = vecStart - vecStart % scalarizedContiguousRun;
-      const size_t inOff = (vecStart - runStart) * valueElemNBits / 8;
+      const size_t in_off = (vecStart - runStart) * valueElemNBits / 8;
 
       const size_t maxWordWidth = std::max<size_t>(32, valueElemNBits);
       const size_t totalWidth = valueElemNBits * vec;
@@ -265,9 +266,14 @@ struct LoadOpConversion : public ConvertOpToLLVMPattern<triton::LoadOp>,
                              .slice(vecStart + ii * wordNElems, wordNElems);
             Value v = b.bitcast(packLLVector(loc, elems, rewriter),
                                 IntegerType::get(getContext(), width));
-            if (width == 32 || width == 64) {
+            auto tensorType = dyn_cast<RankedTensorType>(op.getType());
+            if (tensorType &&
+                ((valueElemNBits == 16 && nWords > 1) ||
+                 (valueElemNBits == 8 && width == 32 && nWords == 1 && vec == 4 &&
+                  tensorType.getRank() == 1 &&
+                  isa<FloatType>(tensorType.getElementType())))) {
               // Match each fallback to its destination instead of moving it.
-              // The packed value and destination have the same register width.
+              // Match the packed FP8 fallback to its 32-bit destination.
               ptxBuilder.newOperand(v,
                                     std::to_string(dstsOpr->listGet(ii)->idx));
               continue;
@@ -282,7 +288,7 @@ struct LoadOpConversion : public ConvertOpToLLVMPattern<triton::LoadOp>,
         }
       }
 
-      auto *addrOpr = ptxBuilder.newAddrOperand(ptrElems[runStart], "l", inOff);
+      auto *addrOpr = ptxBuilder.newAddrOperand(ptrElems[runStart], "l", in_off);
 
       // Define the instruction opcode
       auto &ld = ptxBuilder.create("ld")
@@ -424,7 +430,7 @@ struct StoreOpConversion : public ConvertOpToLLVMPattern<triton::StoreOp>,
     for (size_t vecStart = 0; vecStart < elemsPerThread; vecStart += vec) {
       // TODO: optimization when ptr is AddPtr with constant offset
       const size_t runStart = vecStart - vecStart % scalarizedContiguousRun;
-      const size_t inOff = (vecStart - runStart) * valueElemNBits / 8;
+      const size_t in_off = (vecStart - runStart) * valueElemNBits / 8;
 
       const size_t maxWordWidth = std::max<size_t>(32, valueElemNBits);
       const size_t totalWidth = valueElemNBits * vec;
@@ -470,7 +476,7 @@ struct StoreOpConversion : public ConvertOpToLLVMPattern<triton::StoreOp>,
         pred = ttg::maybeAnd(rewriter, loc, pred, mask);
       }
 
-      auto *asmAddr = ptxBuilder.newAddrOperand(ptrElems[runStart], "l", inOff);
+      auto *asmAddr = ptxBuilder.newAddrOperand(ptrElems[runStart], "l", in_off);
 
       auto &ptxStoreInstr =
           ptxBuilder.create("st")


### PR DESCRIPTION
This reverts commit #11335, which results in worse scheduling and caused regressions in internal workloads.