### PR TITLE
[FRONTEND] Restore tl.softmax keep_dims argument for BC

### DIFF
--- a/python/test/unit/language/test_standard.py
+++ b/python/test/unit/language/test_standard.py
@@ -184,15 +184,15 @@ def test_softmax(shape, dim, ieee_rounding, device):
 
 @pytest.mark.interpreter
 @pytest.mark.parametrize("member", [False, True])
-def test_softmax_rejects_positional_ieee_rounding(member):
+def test_softmax_rejects_positional_keep_dims(member):
 
     @triton.jit
     def kernel(member: tl.constexpr):
         x = tl.full((2, 2), 1.0, tl.float32)
         if member:
-            x.softmax(1, None, True)
+            x.softmax(1, True)
         else:
-            tl.softmax(x, 1, None, True)
+            tl.softmax(x, 1, True)
 
     error = InterpreterError if is_interpreter() else triton.CompilationError
     with pytest.raises(error, match="positional argument"):
@@ -201,21 +201,17 @@ def test_softmax_rejects_positional_ieee_rounding(member):
 
 @pytest.mark.interpreter
 @pytest.mark.parametrize("keep_dims", [None, False, True])
-@pytest.mark.parametrize("call_style", ["keyword", "positional", "member_keyword", "member_positional"])
-def test_softmax_keep_dims_deprecated(keep_dims, call_style, device, fresh_triton_cache):
+@pytest.mark.parametrize("member", [False, True])
+def test_softmax_keep_dims_deprecated(keep_dims, member, device, fresh_triton_cache):
 
     @triton.jit
-    def kernel(X, Z, keep_dims: tl.constexpr, call_style: tl.constexpr):
+    def kernel(X, Z, keep_dims: tl.constexpr, member: tl.constexpr):
         offs = tl.arange(0, 32).reshape((8, 4))
         x = tl.load(X + offs)
-        if call_style == "keyword":
-            z = tl.softmax(x, dim=1, keep_dims=keep_dims, ieee_rounding=True)
-        elif call_style == "positional":
-            z = tl.softmax(x, 1, keep_dims, ieee_rounding=True)
-        elif call_style == "member_keyword":
+        if member:
             z = x.softmax(dim=1, keep_dims=keep_dims, ieee_rounding=True)
         else:
-            z = x.softmax(1, keep_dims, ieee_rounding=True)
+            z = tl.softmax(x, dim=1, keep_dims=keep_dims, ieee_rounding=True)
         tl.static_assert(z.shape == x.shape, "softmax must preserve the input shape")
         tl.store(Z + offs, z)
 
@@ -223,7 +219,7 @@ def test_softmax_keep_dims_deprecated(keep_dims, call_style, device, fresh_trito
     z = torch.empty_like(x)
     with warnings.catch_warnings(record=True) as caught:
         warnings.simplefilter("always")
-        kernel[(1, )](x, z, keep_dims, call_style)
+        kernel[(1, )](x, z, keep_dims, member)
     if keep_dims is None:
         assert not caught
     else:

--- a/python/test/unit/language/test_standard.py
+++ b/python/test/unit/language/test_standard.py
@@ -1,3 +1,5 @@
+import warnings
+
 import triton
 import pytest
 import torch
@@ -174,25 +176,61 @@ def test_softmax(shape, dim, ieee_rounding, device):
     x = numpy_random(shape, dtype_str='float32')
     x = torch.from_numpy(x).to(device)
     z = torch.empty_like(x)
-    softmax_kernel[(1, )](x, z, x.numel(), shape, dim, ieee_rounding)
+    with warnings.catch_warnings():
+        warnings.filterwarnings("error", message=".*keep_dims.*")
+        softmax_kernel[(1, )](x, z, x.numel(), shape, dim, ieee_rounding)
     torch.testing.assert_close(z, torch.softmax(x, dim=dim), rtol=1e-5, atol=1e-6)
 
 
 @pytest.mark.interpreter
 @pytest.mark.parametrize("member", [False, True])
-def test_softmax_rejects_positional_keep_dims(member):
+def test_softmax_rejects_positional_ieee_rounding(member):
 
     @triton.jit
     def kernel(member: tl.constexpr):
         x = tl.full((2, 2), 1.0, tl.float32)
         if member:
-            x.softmax(1, True)
+            x.softmax(1, None, True)
         else:
-            tl.softmax(x, 1, True)
+            tl.softmax(x, 1, None, True)
 
     error = InterpreterError if is_interpreter() else triton.CompilationError
     with pytest.raises(error, match="positional argument"):
         kernel[(1, )](member)
+
+
+@pytest.mark.interpreter
+@pytest.mark.parametrize("keep_dims", [None, False, True])
+@pytest.mark.parametrize("call_style", ["keyword", "positional", "member_keyword", "member_positional"])
+def test_softmax_keep_dims_deprecated(keep_dims, call_style, device, fresh_triton_cache):
+
+    @triton.jit
+    def kernel(X, Z, keep_dims: tl.constexpr, call_style: tl.constexpr):
+        offs = tl.arange(0, 32).reshape((8, 4))
+        x = tl.load(X + offs)
+        if call_style == "keyword":
+            z = tl.softmax(x, dim=1, keep_dims=keep_dims, ieee_rounding=True)
+        elif call_style == "positional":
+            z = tl.softmax(x, 1, keep_dims, ieee_rounding=True)
+        elif call_style == "member_keyword":
+            z = x.softmax(dim=1, keep_dims=keep_dims, ieee_rounding=True)
+        else:
+            z = x.softmax(1, keep_dims, ieee_rounding=True)
+        tl.static_assert(z.shape == x.shape, "softmax must preserve the input shape")
+        tl.store(Z + offs, z)
+
+    x = torch.from_numpy(numpy_random((8, 4), dtype_str='float32')).to(device)
+    z = torch.empty_like(x)
+    with warnings.catch_warnings(record=True) as caught:
+        warnings.simplefilter("always")
+        kernel[(1, )](x, z, keep_dims, call_style)
+    if keep_dims is None:
+        assert not caught
+    else:
+        assert len(caught) == 1
+        assert caught[0].category is UserWarning
+        assert "keep_dims argument to tl.softmax is deprecated and ignored" in str(caught[0].message)
+    torch.testing.assert_close(z, torch.softmax(x, dim=1), rtol=1e-5, atol=1e-6)
 
 
 @pytest.mark.interpreter

--- a/python/triton/language/core.py
+++ b/python/triton/language/core.py
@@ -1261,7 +1261,7 @@ class tensor(base_value):
     def sigmoid(self) -> tensor:
         ...
 
-    def softmax(self, dim=None, *, ieee_rounding=False) -> tensor:
+    def softmax(self, dim=None, keep_dims=None, *, ieee_rounding=False) -> tensor:
         ...
 
     def ravel(self) -> tensor:

--- a/python/triton/language/core.py
+++ b/python/triton/language/core.py
@@ -1261,7 +1261,7 @@ class tensor(base_value):
     def sigmoid(self) -> tensor:
         ...
 
-    def softmax(self, dim=None, keep_dims=None, *, ieee_rounding=False) -> tensor:
+    def softmax(self, dim=None, *, keep_dims=None, ieee_rounding=False) -> tensor:
         ...
 
     def ravel(self) -> tensor:

--- a/python/triton/language/standard.py
+++ b/python/triton/language/standard.py
@@ -70,6 +70,9 @@ def softmax(x, dim=None, keep_dims=None, *, ieee_rounding=False):
     :param dim: the axis along which to normalize. Defaults to 0 -- note that
         this is *not* the last axis, unlike :code:`torch.softmax`.
     :type dim: int | None
+    :param keep_dims: deprecated and ignored. Softmax always preserves the input shape.
+        Defaults to :code:`None`; any other value emits a warning.
+    :type keep_dims: bool | None
     :param ieee_rounding: whether the final division uses IEEE-compliant rounding.
         Must be passed by keyword.
     :type ieee_rounding: bool

--- a/python/triton/language/standard.py
+++ b/python/triton/language/standard.py
@@ -50,9 +50,18 @@ def sigmoid(x):
     return 1 / (1 + math.exp(-x))
 
 
+@constexpr_function
+def _softmax_keep_dims_warning():
+    import warnings
+
+    warnings.warn(
+        "The keep_dims argument to tl.softmax is deprecated and ignored; softmax always preserves the input shape.",
+        stacklevel=2)
+
+
 @core._tensor_member_fn
 @jit
-def softmax(x, dim=None, *, ieee_rounding=False):
+def softmax(x, dim=None, keep_dims=None, *, ieee_rounding=False):
     """
     Computes the softmax of :code:`x` along the given axis.
 
@@ -65,6 +74,8 @@ def softmax(x, dim=None, *, ieee_rounding=False):
         Must be passed by keyword.
     :type ieee_rounding: bool
     """
+    if keep_dims is not None:
+        _softmax_keep_dims_warning()
     if dim is None:
         _dim: core.constexpr = 0
     else:

--- a/python/triton/language/standard.py
+++ b/python/triton/language/standard.py
@@ -61,7 +61,7 @@ def _softmax_keep_dims_warning():
 
 @core._tensor_member_fn
 @jit
-def softmax(x, dim=None, keep_dims=None, *, ieee_rounding=False):
+def softmax(x, dim=None, *, keep_dims=None, ieee_rounding=False):
     """
     Computes the softmax of :code:`x` along the given axis.
 
@@ -72,6 +72,7 @@ def softmax(x, dim=None, keep_dims=None, *, ieee_rounding=False):
     :type dim: int | None
     :param keep_dims: deprecated and ignored. Softmax always preserves the input shape.
         Defaults to :code:`None`; any other value emits a warning.
+        Must be passed by keyword.
     :type keep_dims: bool | None
     :param ieee_rounding: whether the final division uses IEEE-compliant rounding.
         Must be passed by keyword.


### PR DESCRIPTION
## Summary

#11409 removed `keep_dims`, breaking callers that pass it by keyword.

Restore `keep_dims=None` as a keyword-only argument for `tl.softmax` and `tensor.softmax`, and document its deprecation. Non-`None` values emit a deprecation warning and are ignored; the internal reductions still use `keep_dims=True`, preserving the normalization fix. `ieee_rounding` remains keyword-only, as introduced by #11418.

Add regression coverage for keyword calls, tensor methods, warning/no-warning behavior, and rejection of positional `keep_dims`.

## Validation

- GB300: rebuilt Triton with `make`; all 11 focused cases passed (`test_softmax`, `test_softmax_keep_dims_deprecated`, and `test_softmax_rejects_positional_keep_dims`).
- Interpreter: the same 11 cases passed with `TRITON_INTERPRET=1 --device=cpu`.
- Pre-commit hooks passed, including Ruff, YAPF, and mypy.
