### PR TITLE
[Membar] Fix shared alias reasoning and recover physical footprints

### DIFF
--- a/include/triton/Analysis/BufferIndexAnalysis.h
+++ b/include/triton/Analysis/BufferIndexAnalysis.h
@@ -14,7 +14,6 @@ namespace mlir {
 class Block;
 class Operation;
 struct AllocationSlice;
-struct BlockInfo;
 struct BufferIndexExpr;
 
 /// Extends membar's slice disjointness check for multi-buffered shared-memory
@@ -24,6 +23,9 @@ struct BufferIndexExpr;
 /// into `base + constantOffset`, optionally under a positive constant modulus,
 /// and proves two accesses disjoint only when the expressions have the same
 /// base and different offsets modulo the same modulus.
+/// Scalar indices follow Triton's block-programming semantics. Comparisons
+/// also require the same indexed source in the same dynamic iteration:
+/// a source change can change both the origin and the byte stride of a slot.
 ///
 /// Recognized index shapes:
 ///   1. integer constants,
@@ -62,15 +64,11 @@ public:
   AllocationSlice makeSlice(Value value, Interval<size_t> allocationInterval,
                             Allocation::BufferId bufferId);
 
-  /// Returns true if `successor` is reached by a cf-form loop backedge from
-  /// `terminator`, using the standard dominance rule.
+  /// Returns true if `successor` may revisit definitions from `terminator`'s
+  /// dynamic iteration. Uses dominance for reducible cf-form loops and
+  /// conservatively invalidates region-to-region, nested and irreducible CFG
+  /// edges, whose reducibility is not established by this analysis.
   bool isBackedgeSuccessor(Operation *terminator, Block *successor) const;
-
-  /// Clears the buffer index of every slice in `info`, rebuilding both maps.
-  /// Used at loop backedges where the same SSA value can denote a value from a
-  /// different dynamic iteration, and before storing function summaries where
-  /// per-function SSA index identity is no longer meaningful.
-  void invalidateBufferIndices(BlockInfo &info) const;
 
 private:
   void attachBufferIndex(AllocationSlice &slice, Value value);

--- a/include/triton/Analysis/Membar.h
+++ b/include/triton/Analysis/Membar.h
@@ -3,6 +3,7 @@
 
 #include "Allocation.h"
 #include "BufferIndexAnalysis.h"
+#include "BufferRegion.h"
 #include "CallGraph.h"
 #include "Function.h"
 
@@ -16,6 +17,12 @@ namespace mlir {
 
 class OpBuilder;
 struct AllocationSlice;
+
+// Complete MAY-addresses in a known single-CTA kernel allocation frame. Runtime
+// indices may select several possible physical views across loop iterations.
+// Only the byte addresses are needed, not a runtime descriptor key.
+// Share geometry per descriptor across all of its read and write effects.
+using SharedMemoryFootprints = DenseMap<Value, triton::AddressSet>;
 
 /// Callback to allow backend to provide more information on whether a barrier
 /// is needed between two operations. Even though two operations access the same
@@ -64,34 +71,58 @@ public:
   AllocationSlice translated(size_t offset,
                              bool invalidateBufferId = false) const {
     AllocationSlice shifted = *this;
+    // Calls retain the coarse translated interval until frame translation of
+    // these physical views is supported.
+    shifted.physicalFootprint = nullptr;
     shifted.allocationInterval = Interval<size_t>(
         allocationInterval.start() + offset, allocationInterval.end() + offset);
-    if (invalidateBufferId)
+    if (invalidateBufferId) {
       shifted.bufferId = Allocation::InvalidBufferId;
-    // This preserves analysis payloads such as bufferIndexExpr. Callers that
-    // translate slices across function boundaries must clear per-function
-    // payloads before translating.
+      shifted.invalidateIterationInfo();
+    }
+    // Translations within a function preserve analysis payloads such as
+    // bufferIndexExpr. Cross-function translations invalidate both buffer IDs
+    // and iteration-relative payloads above.
     return shifted;
   }
 
   void print(raw_ostream &os) const;
 
+  void invalidateIterationInfo() {
+    bufferIndexExpr = nullptr;
+    subsliceSource = {};
+  }
+
+  // Immutable geometry covering every dynamic instance of this access. It
+  // remains valid across backedges, unlike the epoch-relative facts above.
+  // The owning module analysis outlives every slice using this pointer.
+  const triton::AddressSet *physicalFootprint = nullptr;
+
   // Buffer-index expression attached by BufferIndexAnalysis. It participates
   // in ordering/equality so accesses to different slots remain separate.
   // Must not be mutated after the slice is inserted into a sorted container
   // (e.g. BlockInfo::SliceMapT); rebuild the container instead, as
-  // BufferIndexAnalysis::invalidateBufferIndices does.
+  // BlockInfo::invalidateIterationInfo does.
   const BufferIndexExpr *bufferIndexExpr = nullptr;
 
 private:
   std::tuple<Interval<size_t>, Allocation::BufferId, const void *,
-             llvm::ArrayRef<int64_t>, const BufferIndexExpr *>
+             llvm::ArrayRef<int32_t>, const BufferIndexExpr *, const void *,
+             const void *>
   asTuple() const {
-    return {allocationInterval, bufferId, accessTy.getAsOpaquePointer(),
-            subsliceOffsets, bufferIndexExpr};
+    return {allocationInterval,
+            bufferId,
+            accessTy.getAsOpaquePointer(),
+            subsliceOffsets,
+            bufferIndexExpr,
+            subsliceSource.getAsOpaquePointer(),
+            physicalFootprint};
   }
-  // Offsets from subslice. Empty when offsets are unknown
-  SmallVector<int64_t> subsliceOffsets;
+  // Offsets from subslice, borrowed from its immutable context-owned attribute.
+  // Empty when offsets are unknown.
+  llvm::ArrayRef<int32_t> subsliceOffsets;
+  // The source descriptor supplying the coordinates for subslice offsets.
+  Value subsliceSource;
   // The allocated interval for this buffer
   Interval<size_t> allocationInterval;
   // Type of the memory descriptor for this access
@@ -119,6 +150,12 @@ struct BlockInfo {
                                           slice.second.end());
     return *this;
   }
+
+  /// Clears the buffer index and access origin of every slice, rebuilding both
+  /// maps. Used at loop backedges where the same SSA value can denote a value
+  /// from a different dynamic iteration, and before storing function summaries
+  /// where per-function SSA identity is no longer meaningful.
+  void invalidateIterationInfo();
 
   void dump() {
     auto &err = llvm::errs();
@@ -284,8 +321,10 @@ public:
   /// a shared memory read. If the temporary storage is written but not read,
   /// it is considered as the problem of the operation itself but not the membar
   /// analysis.
-  MembarAnalysis(Allocation &allocation, MembarFilterFn filter)
+  MembarAnalysis(Allocation &allocation, MembarFilterFn filter,
+                 const SharedMemoryFootprints &physicalFootprints)
       : allocation(allocation), filter(std::move(filter)),
+        physicalFootprints(physicalFootprints),
         bufferIndexAnalysis(
             cast<FunctionOpInterface>(allocation.getOperation())) {}
 
@@ -306,6 +345,7 @@ protected:
   MembarFilterFn filter;
 
 private:
+  const SharedMemoryFootprints &physicalFootprints;
   BufferIndexAnalysis bufferIndexAnalysis;
 };
 
@@ -319,7 +359,9 @@ public:
 
   void run();
 
-  template <typename AnalysisT> void runAnalysis() {
+  template <typename AnalysisT>
+  void runAnalysis(const SharedMemoryFootprints &physicalFootprints =
+                       SharedMemoryFootprints{}) {
     triton::CallGraph<MembarInfo> callGraph(moduleAllocation.getModuleOp());
     triton::CallGraph<MembarInfo>::FuncDataMapT summaries;
     callGraph.walk<WalkOrder::PreOrder, WalkOrder::PostOrder>(
@@ -328,11 +370,14 @@ public:
           if (!summaries.try_emplace(function).second)
             return;
           auto &allocation = *moduleAllocation.getFuncData(function);
-          AnalysisT(allocation, filter).run(function, summaries);
+          AnalysisT(allocation, filter, physicalFootprints)
+              .run(function, summaries);
         });
   }
 
 private:
+  SharedMemoryFootprints getSharedMemoryFootprints();
+
   ModuleAllocation &moduleAllocation;
   MembarFilterFn filter;
 };

--- a/include/triton/Analysis/Membar.h
+++ b/include/triton/Analysis/Membar.h
@@ -18,10 +18,7 @@ namespace mlir {
 class OpBuilder;
 struct AllocationSlice;
 
-// Complete MAY-addresses in a known kernel allocation frame. Runtime
-// indices may select several possible physical views across loop iterations.
-// Only the byte addresses are needed, not a runtime descriptor key.
-// Share geometry per descriptor across all of its read and write effects.
+// Complete MAY-addresses in a known kernel allocation frame.
 using SharedMemoryFootprints = DenseMap<Value, triton::AddressSet>;
 
 /// Callback to allow backend to provide more information on whether a barrier
@@ -71,8 +68,7 @@ public:
   AllocationSlice translated(size_t offset,
                              bool invalidateBufferId = false) const {
     AllocationSlice shifted = *this;
-    // Calls retain the coarse translated interval until frame translation of
-    // these physical views is supported.
+    // TODO: Translate physical footprints into the caller's allocation frame.
     shifted.physicalFootprint = nullptr;
     shifted.allocationInterval = Interval<size_t>(
         allocationInterval.start() + offset, allocationInterval.end() + offset);
@@ -80,9 +76,6 @@ public:
       shifted.bufferId = Allocation::InvalidBufferId;
       shifted.invalidateIterationInfo();
     }
-    // Translations within a function preserve analysis payloads such as
-    // bufferIndexExpr. Cross-function translations invalidate both buffer IDs
-    // and iteration-relative payloads above.
     return shifted;
   }
 

--- a/include/triton/Analysis/Membar.h
+++ b/include/triton/Analysis/Membar.h
@@ -18,7 +18,7 @@ namespace mlir {
 class OpBuilder;
 struct AllocationSlice;
 
-// Complete MAY-addresses in a known single-CTA kernel allocation frame. Runtime
+// Complete MAY-addresses in a known kernel allocation frame. Runtime
 // indices may select several possible physical views across loop iterations.
 // Only the byte addresses are needed, not a runtime descriptor key.
 // Share geometry per descriptor across all of its read and write effects.

--- a/lib/Analysis/BufferIndexAnalysis.cpp
+++ b/lib/Analysis/BufferIndexAnalysis.cpp
@@ -23,26 +23,18 @@ struct BufferIndexExpr {
   Value baseValue;
   int64_t constantOffset = 0;
   std::optional<int64_t> modulus;
+  Value indexedSource;
 
   bool operator==(const BufferIndexExpr &other) const {
     return baseValue == other.baseValue &&
-           constantOffset == other.constantOffset && modulus == other.modulus;
+           constantOffset == other.constantOffset && modulus == other.modulus &&
+           indexedSource == other.indexedSource;
   }
 
   bool isProvablyDifferentFrom(const BufferIndexExpr &other) const {
-    if (baseValue != other.baseValue)
-      return false;
-    if (modulus || other.modulus) {
-      if (modulus != other.modulus)
-        return false;
-      int64_t m = *modulus;
-      // Euclidean normalization: make 0 <= offset < m so that
-      // negative constants compare correctly against positive ones.
-      int64_t a = normalizeModuloOffset(constantOffset, m);
-      int64_t b = normalizeModuloOffset(other.constantOffset, m);
-      return a != b;
-    }
-    return constantOffset != other.constantOffset;
+    return baseValue == other.baseValue &&
+           indexedSource == other.indexedSource && modulus == other.modulus &&
+           constantOffset != other.constantOffset;
   }
 };
 
@@ -246,7 +238,7 @@ BufferIndexExpr analyzeBufferIndex(Value indexValue) {
   return BufferIndexExpr{indexValue, 0};
 }
 
-Value extractBufferIndex(Value value) {
+triton::gpu::MemDescIndexOp extractBufferIndex(Value value) {
   // MemDescIndexOp selects a whole slot of a multi-buffered allocation; its
   // index operand identifies the slot. MemDescViewTrait producers (trans,
   // reshape, reinterpret, subslice) are slot-preserving, so we can walk
@@ -254,12 +246,12 @@ Value extractBufferIndex(Value value) {
   Value v = value;
   while (auto *def = v.getDefiningOp()) {
     if (auto indexOp = dyn_cast<triton::gpu::MemDescIndexOp>(def))
-      return indexOp.getIndex();
+      return indexOp;
     if (!def->hasTrait<OpTrait::MemDescViewTrait>())
       break;
     v = def->getOperand(0);
   }
-  return Value();
+  return {};
 }
 
 } // namespace
@@ -280,8 +272,9 @@ bool areBufferIndicesProvablyDifferent(const AllocationSlice &a,
 }
 
 const BufferIndexExpr *BufferIndexAnalysis::intern(BufferIndexExpr expr) {
-  // Canonicalize the modular offset so 0 <= constantOffset < m. Equivalent
-  // expressions (e.g. offset 0 and offset m) share a single interned entry.
+  // Euclidean normalization: make 0 <= constantOffset < m so negative constants
+  // compare correctly against positive ones. Equivalent expressions (e.g.
+  // offset 0 and offset m) share a single interned entry.
   if (expr.modulus) {
     int64_t m = *expr.modulus;
     expr.constantOffset = normalizeModuloOffset(expr.constantOffset, m);
@@ -310,31 +303,25 @@ void BufferIndexAnalysis::attachBufferIndex(AllocationSlice &slice,
   if (!hasReducibleCFG)
     return;
 
-  Value index = extractBufferIndex(value);
-  if (!index)
+  auto index = extractBufferIndex(value);
+  if (!index || triton::gpu::lookupNumCTAs(index) != 1)
     return;
-  slice.bufferIndexExpr = intern(analyzeBufferIndex(index));
+  auto expr = analyzeBufferIndex(index.getIndex());
+  expr.indexedSource = index.getSrc();
+  slice.bufferIndexExpr = intern(std::move(expr));
 }
 
 bool BufferIndexAnalysis::isBackedgeSuccessor(Operation *terminator,
                                               Block *successor) const {
   if (isa<BranchOpInterface>(terminator))
-    return dominanceInfo.dominates(successor, terminator->getBlock());
-  return false;
-}
-
-void BufferIndexAnalysis::invalidateBufferIndices(BlockInfo &info) const {
-  auto rebuild = [](BlockInfo::SliceMapT &m) {
-    BlockInfo::SliceMapT rebuilt;
-    for (const auto &[slice, ops] : m) {
-      AllocationSlice key = slice;
-      key.bufferIndexExpr = nullptr;
-      rebuilt[key].insert(ops.begin(), ops.end());
-    }
-    m = std::move(rebuilt);
-  };
-  rebuild(info.syncReadSlices);
-  rebuild(info.syncWriteSlices);
+    return !hasReducibleCFG ||
+           !isa<FunctionOpInterface>(terminator->getParentOp()) ||
+           dominanceInfo.dominates(successor, terminator->getBlock());
+  // Region-to-region edges can start another dynamic iteration (scf.for and
+  // scf.while). Conservatively invalidate on all such edges; exits to the
+  // parent operation's continuation do not revisit the region's definitions.
+  return isa<RegionBranchTerminatorOpInterface>(terminator) &&
+         successor->getParentOp() == terminator->getParentOp();
 }
 
 } // namespace mlir

--- a/lib/Analysis/BufferIndexAnalysis.cpp
+++ b/lib/Analysis/BufferIndexAnalysis.cpp
@@ -304,7 +304,7 @@ void BufferIndexAnalysis::attachBufferIndex(AllocationSlice &slice,
     return;
 
   auto index = extractBufferIndex(value);
-  if (!index || triton::gpu::lookupNumCTAs(index) != 1)
+  if (!index)
     return;
   auto expr = analyzeBufferIndex(index.getIndex());
   expr.indexedSource = index.getSrc();

--- a/lib/Analysis/BufferRegion.cpp
+++ b/lib/Analysis/BufferRegion.cpp
@@ -64,14 +64,14 @@ unsigned getMemDescSize(ttg::MemDescType ty) {
                                              ty.getAllocShape());
   if (auto padded = ttg::getPaddedEncoding(ty.getEncoding()))
     numElems = padded.getPaddedSize({numElems});
-  return numElems * ty.getElementType().getIntOrFloatBitWidth() / 8;
+  return numElems * getIntOrFloatOrPtrBitWidth(ty.getElementType()) / 8;
 }
 
 uint32_t applySharedPadding(uint32_t byteOffset, ttg::MemDescType ty) {
   auto padded = ttg::getPaddedEncoding(ty.getEncoding());
   if (!padded)
     return byteOffset;
-  uint32_t elementSize = ty.getElementTypeBitWidth() / 8;
+  uint32_t elementSize = getIntOrFloatOrPtrBitWidth(ty.getElementType()) / 8;
   uint32_t elementOffset = byteOffset / elementSize;
   return (padded.getPaddedSize({elementOffset + 1}) - 1) * elementSize +
          byteOffset % elementSize;
@@ -119,7 +119,7 @@ MemDescFootprint getMemDescAddresses(
   SmallVector<StringAttr> dims = triton::standardOutDimNames(ctx, ty.getRank());
   ArrayRef<int64_t> shape = ty.getShape();
   uint64_t numPoints = product(shape);
-  uint32_t bitWidth = ty.getElementTypeBitWidth();
+  uint32_t bitWidth = getIntOrFloatOrPtrBitWidth(ty.getElementType());
 
   StringAttr offsetName = StringAttr::get(ctx, "offset");
   StringAttr blockName = StringAttr::get(ctx, "block");
@@ -211,8 +211,8 @@ uint32_t getMemDescStorageOffset(ttg::MemDescType ty, unsigned index) {
   if (auto partitioned =
           dyn_cast<ttg::PartitionedSharedEncodingAttr>(ty.getEncoding()))
     elems /= partitioned.getNumPartitions();
-  return applySharedPadding(index * elems * (ty.getElementTypeBitWidth() / 8),
-                            ty);
+  uint32_t elementSize = getIntOrFloatOrPtrBitWidth(ty.getElementType()) / 8;
+  return applySharedPadding(index * elems * elementSize, ty);
 }
 
 struct MemDescSubsliceOffsets {
@@ -272,7 +272,7 @@ getMemDescSubsliceUnpaddedOffsets(ttg::MemDescSubsliceOp op) {
   }
 
   uint32_t elementSizeBytes =
-      srcTy.getElementType().getIntOrFloatBitWidth() / 8;
+      getIntOrFloatOrPtrBitWidth(srcTy.getElementType()) / 8;
   assert(elementSizeBytes > 0 && "element size must be non-zero");
   return MemDescSubsliceOffsets{storageElementOffset * elementSizeBytes,
                                 elementOffset * elementSizeBytes,

--- a/lib/Analysis/Membar.cpp
+++ b/lib/Analysis/Membar.cpp
@@ -34,9 +34,10 @@ bool AllocationSlice::intersects(const AllocationSlice &other) const {
     return false;
 
   // A MAY-set covers every runtime origin, including across loop iterations.
-  // The unions are disjoint exactly when every candidate pair is disjoint in
-  // the same physical allocation frame. Collection certifies the current
-  // function's frame, and call translation discards these footprints.
+  // Disjoint byte-address unions prove every candidate pair disjoint in the
+  // same physical allocation frame. Ignoring CTA identity can only add aliases.
+  // Collection certifies the current function's frame, and call translation
+  // discards these footprints.
   if (physicalFootprint && other.physicalFootprint &&
       !physicalFootprint->intersects(*other.physicalFootprint))
     return false;
@@ -364,8 +365,6 @@ void MembarAnalysis::update(Operation *op, MembarInfo *membarInfo,
 SharedMemoryFootprints ModuleMembarAnalysis::getSharedMemoryFootprints() {
   ModuleOp module = moduleAllocation.getModuleOp();
   SharedMemoryFootprints footprints;
-  if (triton::gpu::lookupNumCTAs(module) != 1)
-    return footprints;
 
   // Physical footprints use the addresses assigned by the allocation passes.
   auto solver = createDataFlowSolver();

--- a/lib/Analysis/Membar.cpp
+++ b/lib/Analysis/Membar.cpp
@@ -1,5 +1,6 @@
 #include "triton/Analysis/Membar.h"
 #include "triton/Analysis/Utility.h"
+#include "triton/Dialect/Triton/IR/Utility.h"
 #include "triton/Dialect/TritonGPU/IR/Dialect.h"
 #include "triton/Dialect/TritonGPU/IR/LinearLayoutConversions.h"
 #include "triton/Dialect/TritonNvidiaGPU/IR/Dialect.h"
@@ -14,19 +15,16 @@ namespace mlir {
 AllocationSlice::AllocationSlice(Value value,
                                  Interval<size_t> allocationInterval,
                                  Allocation::BufferId bufferId)
-    : allocationInterval(allocationInterval), bufferId(bufferId) {
-  auto accessTy = cast<triton::gpu::MemDescType>(value.getType());
-  this->accessTy = accessTy;
-
+    : allocationInterval(allocationInterval),
+      accessTy(cast<triton::gpu::MemDescType>(value.getType())),
+      bufferId(bufferId) {
   // Get the memdesc_subslice information if present. If no subslice is
   // present the whole interval is accessed
   if (auto subslice = value.getDefiningOp<triton::gpu::MemDescSubsliceOp>()) {
-    // We know there aren't subslices before the one because of subslice::fold
-    // Still need to check this for where a fold isn't possible (control flow)
-    // and when a subslice is carried in a loop
-    if (accessTy.getAllocShape() == subslice.getSrc().getType().getShape()) {
-      subsliceOffsets = SmallVector<int64_t>(subslice.getOffsets());
-    }
+    // The source supplies coordinates even if a preceding subslice has not
+    // folded, or the descriptor is carried through control flow or a loop.
+    subsliceOffsets = subslice.getOffsets();
+    subsliceSource = subslice.getSrc();
   }
 }
 
@@ -35,27 +33,30 @@ bool AllocationSlice::intersects(const AllocationSlice &other) const {
   if (!allocationInterval.intersects(other.allocationInterval))
     return false;
 
+  // A MAY-set covers every runtime origin, including across loop iterations.
+  // The unions are disjoint exactly when every candidate pair is disjoint in
+  // the same physical allocation frame. Collection certifies the current
+  // function's frame, and call translation discards these footprints.
+  if (physicalFootprint && other.physicalFootprint &&
+      !physicalFootprint->intersects(*other.physicalFootprint))
+    return false;
+
   // For slices of the same allocation, compare dynamic buffer indices to prove
   // that different slots do not overlap.
   if (bufferId == other.bufferId && bufferId != Allocation::InvalidBufferId &&
       areBufferIndicesProvablyDifferent(*this, other))
     return false;
 
-  // If access types are unknown, assume intersection
-  if (!accessTy || !other.accessTy)
+  // Logical offsets share coordinates only for the same source descriptor
+  // in the same dynamic iteration. Matching encodings or allocation IDs
+  // do not establish this after selection, indexing or reinterpretation.
+  // The subslice verifier guarantees known types, offsets and matching layouts
+  // for a common source. Otherwise, conservatively assume intersection.
+  if (!subsliceSource || subsliceSource != other.subsliceSource)
     return true;
 
-  // If offsets are unknown, conservatively assume overlap
-  if (subsliceOffsets.empty() || other.subsliceOffsets.empty())
-    return true;
-
-  // If layouts differ, we assume intersection as we currently only work on
-  // logical elements
-  if (accessTy.getEncoding() != other.accessTy.getEncoding())
-    return true;
-
-  auto shapeA = SmallVector<int64_t>(accessTy.getShape());
-  auto shapeB = SmallVector<int64_t>(other.accessTy.getShape());
+  auto shapeA = accessTy.getShape();
+  auto shapeB = other.accessTy.getShape();
   // Chek if all subslice region dimensions have some intersection
   // [offsetA, offsetA + shape) and [offsetB, offsetB + other.shape)
   // If any dimension doesn't intersect, we are looking at disjoint subslices
@@ -96,6 +97,20 @@ void AllocationSlice::print(raw_ostream &os) const {
   } else {
     os << "? layout=unknown";
   }
+}
+
+void BlockInfo::invalidateIterationInfo() {
+  auto rebuild = [](SliceMapT &slices) {
+    SliceMapT rebuilt;
+    for (const auto &[slice, ops] : slices) {
+      AllocationSlice key = slice;
+      key.invalidateIterationInfo();
+      rebuilt[key].insert(ops.begin(), ops.end());
+    }
+    slices = std::move(rebuilt);
+  };
+  rebuild(syncReadSlices);
+  rebuild(syncWriteSlices);
 }
 
 void MembarAnalysis::insertBarrier(Operation *op, OpBuilder *builder) {
@@ -210,16 +225,16 @@ static bool hasSyncPointBeforeMemoryEffect(Operation *op,
 void MembarAnalysis::updateSuccessor(Operation *terminator, Block *successor,
                                      MembarInfo *membarInfo) {
   if (bufferIndexAnalysis.isBackedgeSuccessor(terminator, successor)) {
-    bufferIndexAnalysis.invalidateBufferIndices(membarInfo->pending);
-    bufferIndexAnalysis.invalidateBufferIndices(membarInfo->entryBlockInfo);
+    membarInfo->pending.invalidateIterationInfo();
+    membarInfo->entryBlockInfo.invalidateIterationInfo();
   }
 }
 
 void MembarAnalysis::updateExitState(MembarInfo *membarInfo) {
   // Function summaries are reused at every call site, so per-function SSA
   // index identity is no longer meaningful.
-  bufferIndexAnalysis.invalidateBufferIndices(membarInfo->pending);
-  bufferIndexAnalysis.invalidateBufferIndices(membarInfo->entryBlockInfo);
+  membarInfo->pending.invalidateIterationInfo();
+  membarInfo->entryBlockInfo.invalidateIterationInfo();
 }
 
 void MembarAnalysis::update(Operation *op, MembarInfo *membarInfo,
@@ -274,29 +289,26 @@ void MembarAnalysis::update(Operation *op, MembarInfo *membarInfo,
       membarInfo->applyCallSummary(calleeMembarInfo);
     }
     return;
-  } else {
-    // Intra-function dependencies
-    if (auto memoryEffectOpInterface = dyn_cast<MemoryEffectOpInterface>(op)) {
-      // Explicit buffer
-      SmallVector<SideEffects::EffectInstance<MemoryEffects::Effect>>
-          effectInstances;
-      memoryEffectOpInterface.getEffects(effectInstances);
-      for (auto effectInstance : effectInstances) {
-        if (auto value = effectInstance.getValue()) {
-          for (auto bufferId : allocation.getAllBufferIdsWithAliases(value)) {
-            if (bufferId != Allocation::InvalidBufferId) {
-              auto interval = allocation.getAllocatedInterval(bufferId);
-              auto slice =
-                  bufferIndexAnalysis.makeSlice(value, interval, bufferId);
+  }
 
-              if (isa<MemoryEffects::Write>(effectInstance.getEffect()))
-                curBlockInfo.syncWriteSlices[slice].insert(op);
-              else if (isa<MemoryEffects::Read>(effectInstance.getEffect()))
-                curBlockInfo.syncReadSlices[slice].insert(op);
-            }
-          }
-        }
-      }
+  // Intra-function dependencies
+  // Explicit buffer
+  for (const auto &access : triton::getMemoryAccesses(op)) {
+    Value value = access.value;
+    const triton::AddressSet *footprint = nullptr;
+    auto found = physicalFootprints.find(value);
+    if (found != physicalFootprints.end())
+      footprint = &found->second;
+    for (auto bufferId : allocation.getAllBufferIdsWithAliases(value)) {
+      if (bufferId == Allocation::InvalidBufferId)
+        continue;
+      auto interval = allocation.getAllocatedInterval(bufferId);
+      auto slice = bufferIndexAnalysis.makeSlice(value, interval, bufferId);
+      slice.physicalFootprint = footprint;
+      if (access.isWrite)
+        curBlockInfo.syncWriteSlices[slice].insert(op);
+      if (access.isRead)
+        curBlockInfo.syncReadSlices[slice].insert(op);
     }
   }
 
@@ -349,5 +361,56 @@ void MembarAnalysis::update(Operation *op, MembarInfo *membarInfo,
   }
 }
 
-void ModuleMembarAnalysis::run() { runAnalysis<MembarAnalysis>(); }
+SharedMemoryFootprints ModuleMembarAnalysis::getSharedMemoryFootprints() {
+  ModuleOp module = moduleAllocation.getModuleOp();
+  SharedMemoryFootprints footprints;
+  if (triton::gpu::lookupNumCTAs(module) != 1)
+    return footprints;
+
+  // Physical footprints use the addresses assigned by the allocation passes.
+  auto solver = createDataFlowSolver();
+  auto *regions = solver->load<triton::BufferRegionAnalysis>();
+  if (failed(solver->initializeAndRun(module)))
+    return footprints;
+  // Physical offsets must use the current kernel's allocation frame. Different
+  // unnormalized frames are unknown, not evidence of disjointness. Device-
+  // function frames and returned descriptors need callsite translation before
+  // comparing their offsets; use coarse intervals until that is supported.
+  for (auto function : module.getOps<FunctionOpInterface>()) {
+    if (!triton::isKernel(function))
+      continue;
+    uint32_t frame = regions->getOperationId(function.getOperation());
+
+    // Shared-memory effects access only their descriptor's logical elements,
+    // including gathers, scatters, and asynchronous copies. BufferRegion maps
+    // those elements through padding and partition bases, so no byte-level
+    // containment solve or register-layout size limit is needed here.
+    function.walk([&](Operation *op) {
+      for (const auto &access : triton::getMemoryAccesses(op)) {
+        Value value = access.value;
+        if (!access.isShared() || footprints.contains(value))
+          continue;
+        const auto &info = regions->getRegionInfo(value);
+        if (info.kind != triton::RegionInfo::Kind::Exact ||
+            info.views.empty() ||
+            llvm::any_of(info.views, [&](const auto &view) {
+              return view.allocationFrame != frame;
+            }))
+          continue;
+        // Preserve every possible runtime stage and origin, not only
+        // singletons.
+        auto &footprint = footprints[value];
+        for (const auto &view : info.views)
+          for (const auto &entry : view.region.ctaAddresses)
+            footprint.insert(entry.second);
+      }
+    });
+  }
+  return footprints;
+}
+
+void ModuleMembarAnalysis::run() {
+  auto physicalFootprints = getSharedMemoryFootprints();
+  runAnalysis<MembarAnalysis>(physicalFootprints);
+}
 } // namespace mlir

--- a/lib/Analysis/Membar.cpp
+++ b/lib/Analysis/Membar.cpp
@@ -33,11 +33,7 @@ bool AllocationSlice::intersects(const AllocationSlice &other) const {
   if (!allocationInterval.intersects(other.allocationInterval))
     return false;
 
-  // A MAY-set covers every runtime origin, including across loop iterations.
-  // Disjoint byte-address unions prove every candidate pair disjoint in the
-  // same physical allocation frame. Ignoring CTA identity can only add aliases.
-  // Collection certifies the current function's frame, and call translation
-  // discards these footprints.
+  // Physical footprints include every possible origin across loop iterations.
   if (physicalFootprint && other.physicalFootprint &&
       !physicalFootprint->intersects(*other.physicalFootprint))
     return false;
@@ -48,11 +44,7 @@ bool AllocationSlice::intersects(const AllocationSlice &other) const {
       areBufferIndicesProvablyDifferent(*this, other))
     return false;
 
-  // Logical offsets share coordinates only for the same source descriptor
-  // in the same dynamic iteration. Matching encodings or allocation IDs
-  // do not establish this after selection, indexing or reinterpretation.
-  // The subslice verifier guarantees known types, offsets and matching layouts
-  // for a common source. Otherwise, conservatively assume intersection.
+  // Compare logical offsets only for subslices of the same source descriptor.
   if (!subsliceSource || subsliceSource != other.subsliceSource)
     return true;
 
@@ -371,33 +363,28 @@ SharedMemoryFootprints ModuleMembarAnalysis::getSharedMemoryFootprints() {
   auto *regions = solver->load<triton::BufferRegionAnalysis>();
   if (failed(solver->initializeAndRun(module)))
     return footprints;
-  // Physical offsets must use the current kernel's allocation frame. Different
-  // unnormalized frames are unknown, not evidence of disjointness. Device-
-  // function frames and returned descriptors need callsite translation before
-  // comparing their offsets; use coarse intervals until that is supported.
+  // Device-function allocations need their callsite offsets before comparison.
   for (auto function : module.getOps<FunctionOpInterface>()) {
     if (!triton::isKernel(function))
       continue;
     uint32_t frame = regions->getOperationId(function.getOperation());
 
-    // Shared-memory effects access only their descriptor's logical elements,
-    // including gathers, scatters, and asynchronous copies. BufferRegion maps
-    // those elements through padding and partition bases, so no byte-level
-    // containment solve or register-layout size limit is needed here.
     function.walk([&](Operation *op) {
       for (const auto &access : triton::getMemoryAccesses(op)) {
         Value value = access.value;
         if (!access.isShared() || footprints.contains(value))
           continue;
         const auto &info = regions->getRegionInfo(value);
+        // BufferRegion joins callee arguments across call sites, so a returned
+        // descriptor can include views from another caller's allocation frame.
         if (info.kind != triton::RegionInfo::Kind::Exact ||
             info.views.empty() ||
             llvm::any_of(info.views, [&](const auto &view) {
               return view.allocationFrame != frame;
             }))
           continue;
-        // Preserve every possible runtime stage and origin, not only
-        // singletons.
+        // Union all possible origins. Merging CTA address sets only adds
+        // aliases.
         auto &footprint = footprints[value];
         for (const auto &view : info.views)
           for (const auto &entry : view.region.ctaAddresses)

--- a/lib/Conversion/TritonInstrumentToLLVM/InstrumentationToLLVM.cpp
+++ b/lib/Conversion/TritonInstrumentToLLVM/InstrumentationToLLVM.cpp
@@ -7,6 +7,7 @@
 #include "triton/Conversion/TritonGPUToLLVM/PatternTritonGPUOpToLLVM.h"
 #include "triton/Conversion/TritonGPUToLLVM/TargetInfoBase.h"
 #include "triton/Conversion/TritonGPUToLLVM/Utility.h"
+#include "triton/Dialect/Triton/IR/Utility.h"
 #include "triton/Dialect/TritonGPU/IR/Dialect.h"
 #include "triton/Dialect/TritonGPU/IR/TritonGPUInterfaces.h"
 #include "triton/Dialect/TritonInstrument/IR/Dialect.h"
@@ -44,7 +45,7 @@ Value createMemDescToI32(RewriterBase &rewriter, Location loc,
   auto smemObj = LLVM::getSharedMemoryObjectFromStruct(loc, sharedMemStruct,
                                                        srcElemTy, rewriter);
   auto offset = smemObj.getShmemOffset(loc, rewriter, memDescTy);
-  auto elemSize = srcElemTy.getIntOrFloatBitWidth() / 8;
+  auto elemSize = getIntOrFloatOrPtrBitWidth(srcElemTy) / 8;
   offset = b.mul(offset, b.i32_val(elemSize));
   return b.and_(b.add(offset, b.ptrtoint(i32Ty, smemObj.getBase())),
                 b.i32_val(kSharedMemoryObjectMask));

--- a/lib/Dialect/TritonInstrument/IR/Utility.cpp
+++ b/lib/Dialect/TritonInstrument/IR/Utility.cpp
@@ -5,6 +5,7 @@
 #include "triton/Analysis/BufferRegion.h"
 #include "triton/Analysis/Utility.h"
 #include "triton/Dialect/Triton/IR/Dialect.h"
+#include "triton/Dialect/Triton/IR/Utility.h"
 #include "triton/Dialect/TritonGPU/IR/Attributes.h"
 #include "triton/Dialect/TritonGPU/IR/Dialect.h"
 #include "triton/Dialect/TritonGPU/IR/TritonGPUInterfaces.h"
@@ -177,7 +178,8 @@ static Value createCurrentCTAMask(OpBuilder &b, Location loc,
 uint32_t getMemDescLength(Value buf) {
   auto memDescType = cast<MemDescType>(buf.getType());
   if (isa<SharedEncodingTrait>(memDescType.getEncoding())) {
-    unsigned elSize = memDescType.getElementType().getIntOrFloatBitWidth() / 8;
+    unsigned elSize =
+        getIntOrFloatOrPtrBitWidth(memDescType.getElementType()) / 8;
     return static_cast<uint32_t>(product(getShapePerCTA(memDescType)) * elSize);
   }
   if (isa<TensorMemorySpaceAttr>(memDescType.getMemorySpace())) {

--- a/python/test/gluon/test_core.py
+++ b/python/test/gluon/test_core.py
@@ -9,6 +9,7 @@ import triton.language as tl
 
 from triton._internal_testing import (
     is_compile_warmup,
+    is_cuda,
     is_ampere_or_newer,
     is_blackwell,
     is_blackwell_ultra,
@@ -2495,6 +2496,56 @@ def test_block_m_64_mma():
 
     d_ref = a @ b + c
     torch.testing.assert_close(d_ref, d_tri, rtol=0.08, atol=0)
+
+
+@pytest.mark.skipif(not is_cuda(), reason="Requires CUDA")
+@pytest.mark.parametrize("high_base", [1, 2])
+def test_shared_dynamic_stage_synchronization(high_base, fresh_knobs):
+    fresh_knobs.compilation.instrumentation_mode = ""
+
+    @gluon.jit(do_not_specialize=["n_iters"])
+    def kernel(out, n_iters, HIGH_BASE: ttgl.constexpr):
+        layout: ttgl.constexpr = ttgl.BlockedLayout([1], [32], [4], [0])
+        read: ttgl.constexpr = ttgl.DistributedLinearLayout([], [[1], [2], [4], [8], [16]], [[64], [32]], [], [128])
+        parent = ttgl.allocate_shared_memory(ttgl.int32, [4, 128], ttgl.SwizzledSharedLayout(1, 1, 1, [0]))
+        for slot in ttgl.static_range(4):
+            parent.index(slot).store(ttgl.full([128], slot, ttgl.int32, layout))
+        ttgl.barrier()
+        total = ttgl.full([128], 0, ttgl.int32, read)
+        last_stage = 0
+        for iteration in range(n_iters):
+            last_stage = iteration % 2
+            # Different parent descriptors each select between two stages.
+            # The groups overlap at stage one only when HIGH_BASE is one.
+            low = parent.slice(0, 2).index(last_stage)
+            high = parent.slice(HIGH_BASE, 2).index(1 - last_stage)
+            low.store(ttgl.full([128], iteration + 1, ttgl.int32, layout))
+            value = high.load(read)
+            total += value
+        latest = parent.slice(0, 2).index(last_stage).load(read)
+        ttgl.store(out + ttgl.arange(0, 128, layout=read), total + latest)
+
+    out = torch.empty(128, device="cuda", dtype=torch.int32)
+    n_iters = 7
+    compiled = kernel[(1, )](out, n_iters, high_base, num_warps=4)
+    stages = list(range(4))
+    total = 0
+    for iteration in range(n_iters):
+        low = iteration % 2
+        high = high_base + 1 - low
+        stages[low] = iteration + 1
+        total += stages[high]
+    torch.testing.assert_close(out, torch.full_like(out, total + stages[(n_iters - 1) % 2]))
+
+    ptx = compiled.asm["ptx"]
+    load = re.search(r"\b(?:ld\.shared|ldmatrix\.)", ptx)
+    stores = list(re.finditer(r"\b(?:st\.shared|stmatrix\.)", ptx))
+    assert load and stores
+    before = next(store for store in reversed(stores) if store.start() < load.start())
+    barrier = re.search(r"\b(?:bar\.sync|barrier\.cta\.sync)\b", ptx[before.end():load.start()])
+    # Disjoint physical MAY-sets remove the low-store/high-load barrier.
+    # Overlapping groups require it because the read layout exchanges warps.
+    assert (barrier is not None) == (high_base == 1)
 
 
 @pytest.mark.skipif(not is_hopper_or_newer(), reason="Requires Hopper")

--- a/test/Analysis/test-buffer-region.mlir
+++ b/test/Analysis/test-buffer-region.mlir
@@ -170,7 +170,7 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 1 : i32, ttg.shar
 #padded = #ttg.padded_shared<[4:+2] {order = [1, 0], shape = [4, 4]}>
 #smem = #ttg.shared_memory
 
-module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 1 : i32, ttg.shared = 184 : i32, ttg.target = "cuda:90", ttg.tensor_memory_size = 0 : i32, "ttg.threads-per-warp" = 32 : i32, "ttg.total-num-warps" = 1 : i32} {
+module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 1 : i32, ttg.shared = 368 : i32, ttg.target = "cuda:90", ttg.tensor_memory_size = 0 : i32, "ttg.threads-per-warp" = 32 : i32, "ttg.total-num-warps" = 1 : i32} {
   tt.func public @padded_shared_reinterpret_region() {
     %alloc = ttg.local_alloc {allocation.offset = 0 : i32} : () -> !ttg.memdesc<4x4xf16, #padded, #smem, mutable>
     %view = ttg.memdesc_reinterpret %alloc : !ttg.memdesc<4x4xf16, #padded, #smem, mutable> -> !ttg.memdesc<4x4xbf16, #padded, #smem, mutable>
@@ -197,11 +197,11 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 1 : i32, ttg.shar
     tt.return
   }
 
-  tt.func public @padded_shared_pipeline_stages(%index: i32) {
-    %alloc = ttg.local_alloc {allocation.offset = 0 : i32} : () -> !ttg.memdesc<2x4x4xi32, #padded, #smem, mutable>
-    %view = ttg.memdesc_index %alloc[%index] : !ttg.memdesc<2x4x4xi32, #padded, #smem, mutable> -> !ttg.memdesc<4x4xi32, #padded, #smem, mutable>
-    // expected-remark @below {{Buffers: [0, 88], [96, 88]}}
-    ttg.local_load %view : !ttg.memdesc<4x4xi32, #padded, #smem, mutable> -> tensor<4x4xi32>
+  tt.func public @padded_shared_pointer_pipeline_stages(%index: i32) {
+    %alloc = ttg.local_alloc {allocation.offset = 0 : i32} : () -> !ttg.memdesc<2x4x4x!tt.ptr<i32>, #padded, #smem, mutable>
+    %view = ttg.memdesc_index %alloc[%index] : !ttg.memdesc<2x4x4x!tt.ptr<i32>, #padded, #smem, mutable> -> !ttg.memdesc<4x4x!tt.ptr<i32>, #padded, #smem, mutable>
+    // expected-remark @below {{Buffers: [0, 176], [192, 176]}}
+    ttg.local_load %view : !ttg.memdesc<4x4x!tt.ptr<i32>, #padded, #smem, mutable> -> tensor<4x4x!tt.ptr<i32>>
     tt.return
   }
 }
@@ -655,6 +655,24 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.shar
 
   // expected-remark @below {{All Shared Regions: [49152, 4096]}}
   tt.func private @print_all_regions() attributes {test.print_all_used_regions} {
+    tt.return
+  }
+}
+
+// -----
+
+#shared = #ttg.swizzled_shared<{vec = 1, perPhase = 1, maxPhase = 1, order = [0]}>
+#smem = #ttg.shared_memory
+
+module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 1 : i32} {
+  // Pointer storage and its views have exact byte geometry.
+  tt.func public @shared_pointer_views() {
+    %pointers = ttg.local_alloc {allocation.offset = 128 : i32} : () -> !ttg.memdesc<4x!tt.ptr<i32>, #shared, #smem, mutable>
+    // expected-remark @below {{Buffers: [128, 32]}}
+    ttg.local_load %pointers : !ttg.memdesc<4x!tt.ptr<i32>, #shared, #smem, mutable> -> tensor<4x!tt.ptr<i32>>
+    %view = ttg.memdesc_subslice %pointers [2] : !ttg.memdesc<4x!tt.ptr<i32>, #shared, #smem, mutable> -> !ttg.memdesc<2x!tt.ptr<i32>, #shared, #smem, mutable, 4>
+    // expected-remark @below {{Buffers: [144, 16]}}
+    ttg.local_load %view : !ttg.memdesc<2x!tt.ptr<i32>, #shared, #smem, mutable, 4> -> tensor<2x!tt.ptr<i32>>
     tt.return
   }
 }

--- a/test/Analysis/test-membar-ttng.mlir
+++ b/test/Analysis/test-membar-ttng.mlir
@@ -107,6 +107,30 @@ tt.func @arrive_then_wait_barrier(%phase: i32) {
 #blocked = #ttg.blocked<{sizePerThread = [1, 1], threadsPerWarp = [1, 32], warpsPerCTA = [4, 1], order = [1, 0]}>
 
 module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.shared = 18944 : i32} {
+// An async-proxy read of one stage does not conflict with a generic-proxy write
+// to a disjoint stage. The store wait still synchronizes subsequent accesses.
+// CHECK-LABEL: @tma_store_disjoint_footprints
+tt.func @tma_store_disjoint_footprints(%desc: !tt.tensordesc<64x64xf16, #shared>, %input: tensor<64x64xf16, #blocked>) -> tensor<64x64xf16, #blocked> {
+  %c0 = arith.constant 0 : i32
+  %allocation = ttg.local_alloc : () -> !ttg.memdesc<3x64x64xf16, #shared, #ttg.shared_memory, mutable>
+  %low = ttg.memdesc_index %allocation[%c0] : !ttg.memdesc<3x64x64xf16, #shared, #ttg.shared_memory, mutable> -> !ttg.memdesc<64x64xf16, #shared, #ttg.shared_memory, mutable>
+  %prefix = ttg.memdesc_subslice %allocation [2, 0, 0] : !ttg.memdesc<3x64x64xf16, #shared, #ttg.shared_memory, mutable> -> !ttg.memdesc<1x64x64xf16, #shared, #ttg.shared_memory, mutable, 3x64x64>
+  %high = ttg.memdesc_index %prefix[%c0] : !ttg.memdesc<1x64x64xf16, #shared, #ttg.shared_memory, mutable, 3x64x64> -> !ttg.memdesc<64x64xf16, #shared, #ttg.shared_memory, mutable>
+  ttg.local_store %input, %low : tensor<64x64xf16, #blocked> -> !ttg.memdesc<64x64xf16, #shared, #ttg.shared_memory, mutable>
+  ttg.barrier local
+  ttng.fence_async_shared {bCluster = false}
+  // CHECK: ttng.async_tma_copy_local_to_global
+  // CHECK-NEXT: ttg.local_store
+  // CHECK-NEXT: ttng.async_tma_store_wait
+  // CHECK-NEXT: ttg.barrier local
+  // CHECK-NEXT: {{.*}} = ttg.local_load
+  ttng.async_tma_copy_local_to_global %desc[%c0, %c0] %low : !tt.tensordesc<64x64xf16, #shared>, !ttg.memdesc<64x64xf16, #shared, #ttg.shared_memory, mutable>
+  ttg.local_store %input, %high : tensor<64x64xf16, #blocked> -> !ttg.memdesc<64x64xf16, #shared, #ttg.shared_memory, mutable>
+  ttng.async_tma_store_wait {pendings = 0 : i32}
+  %output = ttg.local_load %high : !ttg.memdesc<64x64xf16, #shared, #ttg.shared_memory, mutable> -> tensor<64x64xf16, #blocked>
+  tt.return %output : tensor<64x64xf16, #blocked>
+}
+
 // CHECK-LABEL: tma_special_cases
 tt.func @tma_special_cases(%arg1: !tt.tensordesc<256x64xf16, #shared>, %arg2: !tt.tensordesc<1x64xf16, #shared>) -> (tensor<256x64xf16, #blocked>){
   %true = arith.constant 1 : i1

--- a/test/Analysis/test-membar.mlir
+++ b/test/Analysis/test-membar.mlir
@@ -1454,9 +1454,12 @@ tt.func @loop_memindex_subslice(%arg0: tensor<2x128x128xf16>) {
     %top_left = ttg.memdesc_subslice %cur[0, 0] : !ttg.memdesc<128x128xf16, #shared, #smem, mutable> -> !ttg.memdesc<64x64xf16, #shared, #smem, mutable, 128x128>
     // CHECK: ttg.memdesc_subslice
     %bottom_right = ttg.memdesc_subslice %cur[64, 64] : !ttg.memdesc<128x128xf16, #shared, #smem, mutable> -> !ttg.memdesc<64x64xf16, #shared, #smem, mutable, 128x128>
+    // Physical footprints keep reads disjoint from writes across the backedge.
+    // The next write must still synchronize with pending writes.
+    // CHECK-NOT: ttg.barrier local
     // CHECK-NEXT: ttg.local_load
     %tile = ttg.local_load %top_left : !ttg.memdesc<64x64xf16, #shared, #smem, mutable, 128x128> -> tensor<64x64xf16>
-    // CHECK: ttg.barrier local
+    // CHECK-NEXT: ttg.barrier local
     // CHECK-NEXT: ttg.local_store
     ttg.local_store %tile, %bottom_right : tensor<64x64xf16> -> !ttg.memdesc<64x64xf16, #shared, #smem, mutable, 128x128>
     %iv_i32 = arith.index_cast %iv : index to i32
@@ -1805,21 +1808,22 @@ tt.func @disjoint_constant_indices(%cst: tensor<128x128xf16>) {
 // CHECK-LABEL: must_barrier_different_buffer_ids
 // Dynamic slot indices are only comparable within the same allocation. These
 // buffers reuse the same physical interval but have different buffer ids, so
-// the disjoint-looking indices must not remove the barrier.
+// the disjoint-looking indices must not remove the barrier: slot one of the
+// larger pages overlaps slot two of the smaller pages.
 tt.func @must_barrier_different_buffer_ids(%cst: tensor<128x128xf16>) {
-  %c0_i32 = arith.constant 0 : i32
   %c1_i32 = arith.constant 1 : i32
+  %c2_i32 = arith.constant 2 : i32
   %alloc0 = ttg.local_alloc {allocation.offset = 0 : i32} : () -> !ttg.memdesc<2x128x128xf16, #shared, #smem, mutable>
 
-  %w_view = ttg.memdesc_index %alloc0[%c0_i32] : !ttg.memdesc<2x128x128xf16, #shared, #smem, mutable> -> !ttg.memdesc<128x128xf16, #shared, #smem, mutable>
+  %w_view = ttg.memdesc_index %alloc0[%c1_i32] : !ttg.memdesc<2x128x128xf16, #shared, #smem, mutable> -> !ttg.memdesc<128x128xf16, #shared, #smem, mutable>
   // CHECK: ttg.local_store
   ttg.local_store %cst, %w_view : tensor<128x128xf16> -> !ttg.memdesc<128x128xf16, #shared, #smem, mutable>
 
-  %alloc1 = ttg.local_alloc {allocation.offset = 0 : i32} : () -> !ttg.memdesc<2x128x128xf16, #shared, #smem, mutable>
-  %r_view = ttg.memdesc_index %alloc1[%c1_i32] : !ttg.memdesc<2x128x128xf16, #shared, #smem, mutable> -> !ttg.memdesc<128x128xf16, #shared, #smem, mutable>
+  %alloc1 = ttg.local_alloc {allocation.offset = 0 : i32} : () -> !ttg.memdesc<3x64x128xf16, #shared, #smem, mutable>
+  %r_view = ttg.memdesc_index %alloc1[%c2_i32] : !ttg.memdesc<3x64x128xf16, #shared, #smem, mutable> -> !ttg.memdesc<64x128xf16, #shared, #smem, mutable>
   // CHECK: ttg.barrier local
   // CHECK-NEXT: ttg.local_load
-  %load = ttg.local_load %r_view : !ttg.memdesc<128x128xf16, #shared, #smem, mutable> -> tensor<128x128xf16>
+  %load = ttg.local_load %r_view : !ttg.memdesc<64x128xf16, #shared, #smem, mutable> -> tensor<64x128xf16>
   tt.return
 }
 
@@ -1985,4 +1989,270 @@ tt.func @must_barrier_nonzero_wrap_arm(%cst: tensor<128x128xf16>, %phase: i32) {
   tt.return
 }
 
+}
+
+// -----
+
+#writer = #ttg.blocked<{sizePerThread = [1], threadsPerWarp = [32], warpsPerCTA = [4], order = [0]}>
+#reader = #ttg.linear<{register = [], lane = [[1], [2], [4], [8], [16]], warp = [[64], [32]], block = []}>
+#reader256 = #ttg.linear<{register = [[128]], lane = [[1], [2], [4], [8], [16]], warp = [[64], [32]], block = []}>
+#reader64 = #ttg.linear<{register = [], lane = [[1], [2], [4], [8], [0]], warp = [[32], [16]], block = []}>
+#shared = #ttg.swizzled_shared<{vec = 1, perPhase = 1, maxPhase = 1, order = [0]}>
+#smem = #ttg.shared_memory
+
+module attributes {"ttg.num-warps" = 4 : i32, "ttg.threads-per-warp" = 32 : i32, "ttg.num-ctas" = 1 : i32} {
+
+// Different constant indices can name the same slot when their indexed
+// sources have different origins: allocation[1] equals prefix[0].
+// CHECK-LABEL: @shared_buffer_index_shifted_source
+tt.func @shared_buffer_index_shifted_source(%input: tensor<128xi32, #writer>) -> tensor<128xi32, #reader> {
+  %c0 = arith.constant 0 : i32
+  %c1 = arith.constant 1 : i32
+  %allocation = ttg.local_alloc : () -> !ttg.memdesc<4x128xi32, #shared, #smem, mutable>
+  %write_view = ttg.memdesc_index %allocation[%c1] : !ttg.memdesc<4x128xi32, #shared, #smem, mutable> -> !ttg.memdesc<128xi32, #shared, #smem, mutable>
+  // CHECK: ttg.local_store
+  // CHECK: ttg.barrier local{{$}}
+  // CHECK-NEXT: {{.*}} = ttg.local_load
+  ttg.local_store %input, %write_view : tensor<128xi32, #writer> -> !ttg.memdesc<128xi32, #shared, #smem, mutable>
+  %prefix = ttg.memdesc_subslice %allocation [1, 0] : !ttg.memdesc<4x128xi32, #shared, #smem, mutable> -> !ttg.memdesc<3x128xi32, #shared, #smem, mutable, 4x128>
+  %read_view = ttg.memdesc_index %prefix[%c0] : !ttg.memdesc<3x128xi32, #shared, #smem, mutable, 4x128> -> !ttg.memdesc<128xi32, #shared, #smem, mutable>
+  %output = ttg.local_load %read_view : !ttg.memdesc<128xi32, #shared, #smem, mutable> -> tensor<128xi32, #reader>
+  tt.return %output : tensor<128xi32, #reader>
+}
+
+// Equal allocation roots do not imply equal slot strides. Both indexed views
+// start at byte 1024, although their constant indices are 2 and 1.
+// CHECK-LABEL: @shared_buffer_index_changed_stride
+tt.func @shared_buffer_index_changed_stride(%input: tensor<128xi32, #writer>) -> tensor<256xi32, #reader256> {
+  %c1 = arith.constant 1 : i32
+  %c2 = arith.constant 2 : i32
+  %allocation = ttg.local_alloc : () -> !ttg.memdesc<4x128xi32, #shared, #smem, mutable>
+  %write_view = ttg.memdesc_index %allocation[%c2] : !ttg.memdesc<4x128xi32, #shared, #smem, mutable> -> !ttg.memdesc<128xi32, #shared, #smem, mutable>
+  // CHECK: ttg.local_store
+  // CHECK: ttg.barrier local{{$}}
+  // CHECK-NEXT: {{.*}} = ttg.local_load
+  ttg.local_store %input, %write_view : tensor<128xi32, #writer> -> !ttg.memdesc<128xi32, #shared, #smem, mutable>
+  %reinterpret = ttg.memdesc_reinterpret %allocation : !ttg.memdesc<4x128xi32, #shared, #smem, mutable> -> !ttg.memdesc<2x256xi32, #shared, #smem, mutable>
+  %read_view = ttg.memdesc_index %reinterpret[%c1] : !ttg.memdesc<2x256xi32, #shared, #smem, mutable> -> !ttg.memdesc<256xi32, #shared, #smem, mutable>
+  %output = ttg.local_load %read_view : !ttg.memdesc<256xi32, #shared, #smem, mutable> -> tensor<256xi32, #reader256>
+  tt.return %output : tensor<256xi32, #reader256>
+}
+
+// Both indices are zero, isolating the relative-subslice check from the index
+// shortcut. Different parent origins make offsets 0 and 128 refer to the same
+// physical bytes 512..767; the matching shared encoding is not enough.
+// CHECK-LABEL: @shared_subslice_shifted_source
+tt.func @shared_subslice_shifted_source(%input: tensor<64xi32, #writer>) -> tensor<64xi32, #reader64> {
+  %c0 = arith.constant 0 : i32
+  %allocation = ttg.local_alloc : () -> !ttg.memdesc<4x128xi32, #shared, #smem, mutable>
+  %prefix = ttg.memdesc_subslice %allocation [1, 0] : !ttg.memdesc<4x128xi32, #shared, #smem, mutable> -> !ttg.memdesc<3x128xi32, #shared, #smem, mutable, 4x128>
+  %left_slot = ttg.memdesc_index %prefix[%c0] : !ttg.memdesc<3x128xi32, #shared, #smem, mutable, 4x128> -> !ttg.memdesc<128xi32, #shared, #smem, mutable>
+  %left = ttg.memdesc_subslice %left_slot [0] : !ttg.memdesc<128xi32, #shared, #smem, mutable> -> !ttg.memdesc<64xi32, #shared, #smem, mutable, 128>
+  // CHECK: ttg.local_store
+  // CHECK: ttg.barrier local{{$}}
+  // CHECK-NEXT: {{.*}} = ttg.local_load
+  ttg.local_store %input, %left : tensor<64xi32, #writer> -> !ttg.memdesc<64xi32, #shared, #smem, mutable, 128>
+  %reinterpret = ttg.memdesc_reinterpret %allocation : !ttg.memdesc<4x128xi32, #shared, #smem, mutable> -> !ttg.memdesc<2x256xi32, #shared, #smem, mutable>
+  %right_slot = ttg.memdesc_index %reinterpret[%c0] : !ttg.memdesc<2x256xi32, #shared, #smem, mutable> -> !ttg.memdesc<256xi32, #shared, #smem, mutable>
+  %right = ttg.memdesc_subslice %right_slot [128] : !ttg.memdesc<256xi32, #shared, #smem, mutable> -> !ttg.memdesc<64xi32, #shared, #smem, mutable, 256>
+  %output = ttg.local_load %right : !ttg.memdesc<64xi32, #shared, #smem, mutable, 256> -> tensor<64xi32, #reader64>
+  tt.return %output : tensor<64xi32, #reader64>
+}
+
+}
+
+// -----
+
+#writer = #ttg.blocked<{sizePerThread = [1], threadsPerWarp = [32], warpsPerCTA = [4], order = [0]}>
+#reader = #ttg.linear<{register = [], lane = [[1], [2], [4], [8], [16]], warp = [[64], [32]], block = []}>
+#shared = #ttg.swizzled_shared<{vec = 1, perPhase = 1, maxPhase = 1, order = [0]}>
+#smem = #ttg.shared_memory
+
+module attributes {"ttg.num-warps" = 4 : i32, "ttg.threads-per-warp" = 32 : i32, "ttg.num-ctas" = 1 : i32} {
+
+// Different descriptor SSA values select disjoint groups of physical stages.
+// Their complete MAY-sets remain disjoint across the loop backedge, even
+// though the scalar stage and relative source identities change epochs.
+// CHECK-LABEL: @shared_dynamic_disjoint_stage_groups
+tt.func @shared_dynamic_disjoint_stage_groups(%input: tensor<128xi32, #writer>, %ub: i32) -> tensor<128xi32, #writer> {
+  %c0 = arith.constant 0 : i32
+  %c1 = arith.constant 1 : i32
+  %c2 = arith.constant 2 : i32
+  %allocation = ttg.local_alloc : () -> !ttg.memdesc<4x128xi32, #shared, #smem, mutable>
+  %low_group = ttg.memdesc_subslice %allocation [0, 0] : !ttg.memdesc<4x128xi32, #shared, #smem, mutable> -> !ttg.memdesc<2x128xi32, #shared, #smem, mutable, 4x128>
+  %high_group = ttg.memdesc_subslice %allocation [2, 0] : !ttg.memdesc<4x128xi32, #shared, #smem, mutable> -> !ttg.memdesc<2x128xi32, #shared, #smem, mutable, 4x128>
+  // CHECK: scf.for
+  %result = scf.for %i = %c0 to %ub step %c1 iter_args(%last = %input) -> (tensor<128xi32, #writer>) : i32 {
+    %stage = arith.remui %i, %c2 : i32
+    %low = ttg.memdesc_index %low_group[%stage] : !ttg.memdesc<2x128xi32, #shared, #smem, mutable, 4x128> -> !ttg.memdesc<128xi32, #shared, #smem, mutable>
+    %high = ttg.memdesc_index %high_group[%stage] : !ttg.memdesc<2x128xi32, #shared, #smem, mutable, 4x128> -> !ttg.memdesc<128xi32, #shared, #smem, mutable>
+    // CHECK: ttg.memdesc_index
+    // CHECK: ttg.memdesc_index
+    // CHECK-NEXT: {{.*}} = ttg.local_load
+    %loaded = ttg.local_load %low : !ttg.memdesc<128xi32, #shared, #smem, mutable> -> tensor<128xi32, #writer>
+    // The high group can still alias across iterations; only the low load
+    // is proved disjoint here.
+    // CHECK: ttg.local_store
+    ttg.local_store %input, %high : tensor<128xi32, #writer> -> !ttg.memdesc<128xi32, #shared, #smem, mutable>
+    scf.yield %loaded : tensor<128xi32, #writer>
+  }
+  tt.return %result : tensor<128xi32, #writer>
+}
+
+// One overlapping candidate pair is enough to retain the barrier. For
+// stage=1, both accesses select physical stage one through different parents
+// and exchange values between warps.
+// CHECK-LABEL: @shared_dynamic_overlapping_stage_groups
+tt.func @shared_dynamic_overlapping_stage_groups(%input: tensor<128xi32, #writer>, %phase: i32) -> tensor<128xi32, #reader> {
+  %c1 = arith.constant 1 : i32
+  %c2 = arith.constant 2 : i32
+  %allocation = ttg.local_alloc : () -> !ttg.memdesc<4x128xi32, #shared, #smem, mutable>
+  %stage = arith.remui %phase, %c2 : i32
+  %other_stage = arith.subi %c1, %stage : i32
+  %low_group = ttg.memdesc_subslice %allocation [0, 0] : !ttg.memdesc<4x128xi32, #shared, #smem, mutable> -> !ttg.memdesc<2x128xi32, #shared, #smem, mutable, 4x128>
+  %high_group = ttg.memdesc_subslice %allocation [1, 0] : !ttg.memdesc<4x128xi32, #shared, #smem, mutable> -> !ttg.memdesc<2x128xi32, #shared, #smem, mutable, 4x128>
+  %low = ttg.memdesc_index %low_group[%stage] : !ttg.memdesc<2x128xi32, #shared, #smem, mutable, 4x128> -> !ttg.memdesc<128xi32, #shared, #smem, mutable>
+  %high = ttg.memdesc_index %high_group[%other_stage] : !ttg.memdesc<2x128xi32, #shared, #smem, mutable, 4x128> -> !ttg.memdesc<128xi32, #shared, #smem, mutable>
+  // CHECK: ttg.local_store
+  // CHECK-NEXT: ttg.barrier local{{$}}
+  // CHECK-NEXT: {{.*}} = ttg.local_load
+  ttg.local_store %input, %low : tensor<128xi32, #writer> -> !ttg.memdesc<128xi32, #shared, #smem, mutable>
+  %loaded = ttg.local_load %high : !ttg.memdesc<128xi32, #shared, #smem, mutable> -> tensor<128xi32, #reader>
+  tt.return %loaded : tensor<128xi32, #reader>
+}
+
+// The preceding iteration writes the slot read by this iteration. The
+// same-source indices are disjoint only within one dynamic iteration.
+// CHECK-LABEL: @shared_buffer_index_structured_backedge
+tt.func @shared_buffer_index_structured_backedge(%input: tensor<128xi32, #writer>, %ub: i32) {
+  %c0 = arith.constant 0 : i32
+  %c1 = arith.constant 1 : i32
+  %c2 = arith.constant 2 : i32
+  %allocation = ttg.local_alloc : () -> !ttg.memdesc<2x128xi32, #shared, #smem, mutable>
+  // CHECK: scf.for
+  scf.for %i = %c0 to %ub step %c1 : i32 {
+    %next = arith.addi %i, %c1 : i32
+    %read_index = arith.remsi %i, %c2 : i32
+    %write_index = arith.remsi %next, %c2 : i32
+    // CHECK: ttg.memdesc_index
+    // CHECK: ttg.memdesc_index
+    %read_view = ttg.memdesc_index %allocation[%read_index] : !ttg.memdesc<2x128xi32, #shared, #smem, mutable> -> !ttg.memdesc<128xi32, #shared, #smem, mutable>
+    %write_view = ttg.memdesc_index %allocation[%write_index] : !ttg.memdesc<2x128xi32, #shared, #smem, mutable> -> !ttg.memdesc<128xi32, #shared, #smem, mutable>
+    // CHECK-NEXT: ttg.barrier local
+    // CHECK-NEXT: {{.*}} = ttg.local_load
+    %loaded = ttg.local_load %read_view : !ttg.memdesc<128xi32, #shared, #smem, mutable> -> tensor<128xi32, #reader>
+    // CHECK-NEXT: ttg.local_store
+    ttg.local_store %input, %write_view : tensor<128xi32, #writer> -> !ttg.memdesc<128xi32, #shared, #smem, mutable>
+    scf.yield
+  }
+  tt.return
+}
+
+// Gather and scatter access their descriptor's logical elements. The disjoint
+// gather needs no barrier, while the overlapping gather exchanges data across
+// warps and must synchronize with the scatter.
+// CHECK-LABEL: @shared_gather_scatter_footprints
+tt.func @shared_gather_scatter_footprints(%input: tensor<128xi32, #writer>) -> (tensor<128xi32, #reader>, tensor<128xi32, #reader>) {
+  %c0 = arith.constant 0 : i32
+  %write_indices = tt.make_range {start = 0 : i32, end = 128 : i32} : tensor<128xi32, #writer>
+  %read_indices = tt.make_range {start = 0 : i32, end = 128 : i32} : tensor<128xi32, #reader>
+  %allocation = ttg.local_alloc : () -> !ttg.memdesc<3x128xi32, #shared, #smem, mutable>
+  %low = ttg.memdesc_index %allocation[%c0] : !ttg.memdesc<3x128xi32, #shared, #smem, mutable> -> !ttg.memdesc<128xi32, #shared, #smem, mutable>
+  %prefix = ttg.memdesc_subslice %allocation [2, 0] : !ttg.memdesc<3x128xi32, #shared, #smem, mutable> -> !ttg.memdesc<1x128xi32, #shared, #smem, mutable, 3x128>
+  %high = ttg.memdesc_index %prefix[%c0] : !ttg.memdesc<1x128xi32, #shared, #smem, mutable, 3x128> -> !ttg.memdesc<128xi32, #shared, #smem, mutable>
+  ttg.local_store %input, %low : tensor<128xi32, #writer> -> !ttg.memdesc<128xi32, #shared, #smem, mutable>
+  ttg.barrier local
+  // CHECK: ttg.local_scatter
+  // CHECK-NEXT: {{.*}} = ttg.local_gather
+  // CHECK-NEXT: ttg.barrier local
+  // CHECK-NEXT: {{.*}} = ttg.local_gather
+  ttg.local_scatter %high[%write_indices], %input {axis = 0 : i32} : !ttg.memdesc<128xi32, #shared, #smem, mutable>, tensor<128xi32, #writer>, tensor<128xi32, #writer>
+  %disjoint = ttg.local_gather %low[%read_indices] {axis = 0 : i32} : !ttg.memdesc<128xi32, #shared, #smem, mutable>, tensor<128xi32, #reader> -> tensor<128xi32, #reader>
+  %overlapping = ttg.local_gather %high[%read_indices] {axis = 0 : i32} : !ttg.memdesc<128xi32, #shared, #smem, mutable>, tensor<128xi32, #reader> -> tensor<128xi32, #reader>
+  tt.return %disjoint, %overlapping : tensor<128xi32, #reader>, tensor<128xi32, #reader>
+}
+
+// Async copies use descriptor footprints too. Disjoint writes need no barrier;
+// the async wait still synchronizes the following load.
+// CHECK-LABEL: @shared_async_disjoint_footprints
+tt.func @shared_async_disjoint_footprints(%input: tensor<128xi32, #writer>, %ptrs: tensor<128x!tt.ptr<i32>, #writer>) -> tensor<128xi32, #reader> {
+  %c0 = arith.constant 0 : i32
+  %allocation = ttg.local_alloc : () -> !ttg.memdesc<3x128xi32, #shared, #smem, mutable>
+  %low = ttg.memdesc_index %allocation[%c0] : !ttg.memdesc<3x128xi32, #shared, #smem, mutable> -> !ttg.memdesc<128xi32, #shared, #smem, mutable>
+  %prefix = ttg.memdesc_subslice %allocation [2, 0] : !ttg.memdesc<3x128xi32, #shared, #smem, mutable> -> !ttg.memdesc<1x128xi32, #shared, #smem, mutable, 3x128>
+  %high = ttg.memdesc_index %prefix[%c0] : !ttg.memdesc<1x128xi32, #shared, #smem, mutable, 3x128> -> !ttg.memdesc<128xi32, #shared, #smem, mutable>
+  // CHECK: ttg.local_store
+  // CHECK-NEXT: {{.*}} = ttg.async_copy_global_to_local
+  // CHECK-NEXT: {{.*}} = ttg.async_commit_group
+  // CHECK-NEXT: ttg.async_wait
+  // CHECK-NEXT: ttg.barrier local
+  // CHECK-NEXT: {{.*}} = ttg.local_load
+  ttg.local_store %input, %low : tensor<128xi32, #writer> -> !ttg.memdesc<128xi32, #shared, #smem, mutable>
+  %token = ttg.async_copy_global_to_local %ptrs, %high : tensor<128x!tt.ptr<i32>, #writer> -> !ttg.memdesc<128xi32, #shared, #smem, mutable>
+  %group = ttg.async_commit_group tokens %token
+  ttg.async_wait %group {num = 0 : i32}
+  %output = ttg.local_load %high : !ttg.memdesc<128xi32, #shared, #smem, mutable> -> tensor<128xi32, #reader>
+  tt.return %output : tensor<128xi32, #reader>
+}
+
+// An immediate common source supplies relative coordinates even when it is
+// itself a subslice. A private function keeps physical-footprint refinement
+// disabled, so both the disjoint and overlapping cases use that relative proof.
+// CHECK-LABEL: @nested_subslices_same_source
+tt.func private @nested_subslices_same_source(%initial: tensor<512xi32, #writer>, %input: tensor<128xi32, #writer>) -> (tensor<128xi32, #reader>, tensor<128xi32, #reader>) {
+  %allocation = ttg.local_alloc %initial : (tensor<512xi32, #writer>) -> !ttg.memdesc<512xi32, #shared, #smem, mutable>
+  %source = ttg.memdesc_subslice %allocation [0] : !ttg.memdesc<512xi32, #shared, #smem, mutable> -> !ttg.memdesc<256xi32, #shared, #smem, mutable, 512>
+  %low = ttg.memdesc_subslice %source [0] : !ttg.memdesc<256xi32, #shared, #smem, mutable, 512> -> !ttg.memdesc<128xi32, #shared, #smem, mutable, 512>
+  %high = ttg.memdesc_subslice %source [128] : !ttg.memdesc<256xi32, #shared, #smem, mutable, 512> -> !ttg.memdesc<128xi32, #shared, #smem, mutable, 512>
+  ttg.barrier local
+  // CHECK: ttg.local_store
+  // CHECK-NEXT: {{.*}} = ttg.local_load
+  // CHECK-NEXT: ttg.barrier local
+  // CHECK-NEXT: {{.*}} = ttg.local_load
+  ttg.local_store %input, %low : tensor<128xi32, #writer> -> !ttg.memdesc<128xi32, #shared, #smem, mutable, 512>
+  %disjoint = ttg.local_load %high : !ttg.memdesc<128xi32, #shared, #smem, mutable, 512> -> tensor<128xi32, #reader>
+  %overlapping = ttg.local_load %low : !ttg.memdesc<128xi32, #shared, #smem, mutable, 512> -> tensor<128xi32, #reader>
+  tt.return %disjoint, %overlapping : tensor<128xi32, #reader>, tensor<128xi32, #reader>
+}
+
+// Overlapping pointer storage needs a barrier without disabling the disjoint
+// footprint optimizations in the other functions of this module.
+// CHECK-LABEL: @shared_pointer_storage
+tt.func @shared_pointer_storage(%input: tensor<128x!tt.ptr<i32>, #writer>) -> tensor<128x!tt.ptr<i32>, #reader> {
+  // CHECK: ttg.local_alloc
+  // CHECK-NEXT: ttg.barrier local
+  // CHECK-NEXT: {{.*}} = ttg.local_load
+  %allocation = ttg.local_alloc %input : (tensor<128x!tt.ptr<i32>, #writer>) -> !ttg.memdesc<128x!tt.ptr<i32>, #shared, #smem, mutable>
+  %output = ttg.local_load %allocation : !ttg.memdesc<128x!tt.ptr<i32>, #shared, #smem, mutable> -> tensor<128x!tt.ptr<i32>, #reader>
+  tt.return %output : tensor<128x!tt.ptr<i32>, #reader>
+}
+
+}
+
+// -----
+
+#piece = #ttg.padded_shared<[16:+4] {order = [1, 0], shape = [4, 16]}>
+#shared = #ttg.partitioned_shared<{numPartitions = 2, numGroups = 1, partitionDim = 0, partitionLayout = #piece}>
+#smem = #ttg.shared_memory
+
+module attributes {"ttg.num-warps" = 4 : i32, "ttg.num-ctas" = 1 : i32} {
+// Block arguments hide the immediate subslices. Physical footprints still
+// distinguish the padded partitions and retain the overlapping dependency.
+// CHECK-LABEL: @shared_partitioned_padded_footprints
+tt.func @shared_partitioned_padded_footprints(%initial: tensor<8x16xf16>, %input: tensor<4x16xf16>) -> (tensor<4x16xf16>, tensor<4x16xf16>) {
+  %allocation = ttg.local_alloc %initial : (tensor<8x16xf16>) -> !ttg.memdesc<8x16xf16, #shared, #smem, mutable>
+  %first = ttg.memdesc_subslice %allocation [0, 0] : !ttg.memdesc<8x16xf16, #shared, #smem, mutable> -> !ttg.memdesc<4x16xf16, #shared, #smem, mutable, 8x16>
+  %second = ttg.memdesc_subslice %allocation [4, 0] : !ttg.memdesc<8x16xf16, #shared, #smem, mutable> -> !ttg.memdesc<4x16xf16, #shared, #smem, mutable, 8x16>
+  ttg.barrier local
+  cf.br ^access(%first, %second : !ttg.memdesc<4x16xf16, #shared, #smem, mutable, 8x16>, !ttg.memdesc<4x16xf16, #shared, #smem, mutable, 8x16>)
+^access(%left: !ttg.memdesc<4x16xf16, #shared, #smem, mutable, 8x16>, %right: !ttg.memdesc<4x16xf16, #shared, #smem, mutable, 8x16>):
+  // CHECK: ttg.local_store
+  // CHECK-NEXT: {{.*}} = ttg.local_load
+  // CHECK-NEXT: ttg.barrier local
+  // CHECK-NEXT: {{.*}} = ttg.local_load
+  ttg.local_store %input, %left : tensor<4x16xf16> -> !ttg.memdesc<4x16xf16, #shared, #smem, mutable, 8x16>
+  %disjoint = ttg.local_load %right : !ttg.memdesc<4x16xf16, #shared, #smem, mutable, 8x16> -> tensor<4x16xf16>
+  %overlapping = ttg.local_load %left : !ttg.memdesc<4x16xf16, #shared, #smem, mutable, 8x16> -> tensor<4x16xf16>
+  tt.return %disjoint, %overlapping : tensor<4x16xf16>, tensor<4x16xf16>
+}
 }

--- a/test/Analysis/test-membar.mlir
+++ b/test/Analysis/test-membar.mlir
@@ -2063,12 +2063,13 @@ tt.func @shared_subslice_shifted_source(%input: tensor<64xi32, #writer>) -> tens
 
 // -----
 
-#writer = #ttg.blocked<{sizePerThread = [1], threadsPerWarp = [32], warpsPerCTA = [4], order = [0]}>
-#reader = #ttg.linear<{register = [], lane = [[1], [2], [4], [8], [16]], warp = [[64], [32]], block = []}>
-#shared = #ttg.swizzled_shared<{vec = 1, perPhase = 1, maxPhase = 1, order = [0]}>
+// Exercise both index and physical-footprint proofs with replicated CTAs.
+#writer = #ttg.blocked<{sizePerThread = [1], threadsPerWarp = [32], warpsPerCTA = [4], order = [0], CGALayout = [[0]]}>
+#reader = #ttg.linear<{register = [], lane = [[1], [2], [4], [8], [16]], warp = [[64], [32]], block = [[0]]}>
+#shared = #ttg.swizzled_shared<{vec = 1, perPhase = 1, maxPhase = 1, order = [0], CGALayout = [[0]]}>
 #smem = #ttg.shared_memory
 
-module attributes {"ttg.num-warps" = 4 : i32, "ttg.threads-per-warp" = 32 : i32, "ttg.num-ctas" = 1 : i32} {
+module attributes {"ttg.num-warps" = 4 : i32, "ttg.threads-per-warp" = 32 : i32, "ttg.num-ctas" = 2 : i32} {
 
 // Different descriptor SSA values select disjoint groups of physical stages.
 // Their complete MAY-sets remain disjoint across the loop backedge, even

--- a/test/Conversion/tritoninstrument_to_llvm.mlir
+++ b/test/Conversion/tritoninstrument_to_llvm.mlir
@@ -103,6 +103,22 @@ tt.func private @experimental_memdesc_to_i32(
 
 // -----
 
+#shared = #ttg.swizzled_shared<{vec = 1, perPhase = 1, maxPhase = 1, order = [0]}>
+#smem = #ttg.shared_memory
+module attributes {"ttg.num-warps" = 4 : i32, ttg.target = "cuda:90"} {
+// CHECK-LABEL: @experimental_pointer_memdesc_to_i32
+// CHECK: %[[POINTER_BYTES:.*]] = llvm.mlir.constant(8 : i32) : i32
+// CHECK: llvm.mul {{.*}}, %[[POINTER_BYTES]] : i32
+tt.func private @experimental_pointer_memdesc_to_i32(
+  %memdesc: !ttg.memdesc<4x!tt.ptr<i32>, #shared, #smem, mutable>
+) {
+  tti.experimental_memdesc_to_i32 %memdesc : !ttg.memdesc<4x!tt.ptr<i32>, #shared, #smem, mutable>
+  tt.return
+}
+}
+
+// -----
+
 #blocked = #ttg.blocked<{sizePerThread = [2], threadsPerWarp = [32], warpsPerCTA = [4], order = [0]}>
 module attributes {"ttg.num-warps" = 4 : i32, ttg.target = "cuda:100"} {
 // CHECK-LABEL: @experimental_memory_offset_to_i32_shared

--- a/test/TritonGPU/amd/amd-convert-warp-pipeline.mlir
+++ b/test/TritonGPU/amd/amd-convert-warp-pipeline.mlir
@@ -1446,3 +1446,58 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 8 : i32, ttg.targ
 // CHECK-NEXT: ttg.barrier local
 // CHECK-NEXT: rocdl.sched.barrier none
 // CHECK: scf.yield
+
+// -----
+
+#blocked = #ttg.blocked<{sizePerThread = [1], threadsPerWarp = [64], warpsPerCTA = [8], order = [0]}>
+#shared = #ttg.swizzled_shared<{vec = 1, perPhase = 1, maxPhase = 1, order = [0]}>
+#smem = #ttg.shared_memory
+!root = !ttg.memdesc<512xi32, #shared, #smem, mutable>
+!stages = !ttg.memdesc<8x64xi32, #shared, #smem, mutable>
+!group = !ttg.memdesc<4x64xi32, #shared, #smem, mutable, 8x64>
+!source = !ttg.memdesc<256xi32, #shared, #smem, mutable>
+!tile = !ttg.memdesc<128xi32, #shared, #smem, mutable, 256>
+
+module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 8 : i32, ttg.target = "hip:gfx942", "ttg.threads-per-warp" = 64 : i32} {
+// The halves of %source are disjoint within an iteration, but its origin
+// shifts by 64 elements between iterations. The high write [128, 256) then
+// overlaps the next low read [64, 192), requiring a barrier at the loop tail,
+// not between the read and write. Three stages distinguish those placements.
+// CHECK-LABEL: tt.func @loop_varying_subslice_origin
+// CHECK: scf.for
+// CHECK: ttg.local_load
+// CHECK-NOT: ttg.barrier local
+// CHECK: ttg.local_store
+// CHECK-NOT: scf.yield
+// CHECK: ttg.barrier local
+// CHECK: scf.yield
+tt.func @loop_varying_subslice_origin(%n: i32, %initial: tensor<512xi32, #blocked>, %input: tensor<128xi32, #blocked>) -> tensor<128xi32, #blocked> {
+  %c0 = arith.constant 0 : i32
+  %c1 = arith.constant 1 : i32
+  %allocation = ttg.local_alloc %initial : (tensor<512xi32, #blocked>) -> !root
+  %parent = ttg.memdesc_reinterpret %allocation : !root -> !stages
+  %group0 = ttg.memdesc_subslice %parent [0, 0] : !stages -> !group
+  %group1 = ttg.memdesc_subslice %parent [1, 0] : !stages -> !group
+  %source0 = ttg.memdesc_reinterpret %group0 : !group -> !source
+  %source1 = ttg.memdesc_reinterpret %group1 : !group -> !source
+  %result:2 = scf.for %i = %c0 to %n step %c1 iter_args(%source = %source0, %last = %input) -> (!source, tensor<128xi32, #blocked>) : i32 {
+    %loaded = scf.execute_region -> tensor<128xi32, #blocked> no_inline {
+      %low = ttg.memdesc_subslice %source [0] : !source -> !tile
+      %value = ttg.local_load %low : !tile -> tensor<128xi32, #blocked>
+      scf.yield %value : tensor<128xi32, #blocked>
+    } {triton.warp_pipeline.stage = "read"}
+    %next = scf.execute_region -> !source no_inline {
+      %first = arith.cmpi eq, %i, %c0 : i32
+      %selected = arith.select %first, %source1, %source0 : !source
+      scf.yield %selected : !source
+    } {triton.warp_pipeline.stage = "advance"}
+    scf.execute_region no_inline {
+      %high = ttg.memdesc_subslice %source [128] : !source -> !tile
+      ttg.local_store %input, %high : tensor<128xi32, #blocked> -> !tile
+      scf.yield
+    } {triton.warp_pipeline.stage = "write"}
+    scf.yield %next, %loaded : !source, tensor<128xi32, #blocked>
+  } {triton.warp_pipeline.pipelined_for}
+  tt.return %result#1 : tensor<128xi32, #blocked>
+}
+}

--- a/test/TritonGPU/consan.mlir
+++ b/test/TritonGPU/consan.mlir
@@ -1595,17 +1595,16 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.shar
 
 // -----
 
-#shared = #ttg.nvmma_shared<{swizzlingByteWidth = 128, transposed = false, elementBitWidth = 32}>
 #shared1 = #ttg.swizzled_shared<{vec = 1, perPhase = 1, maxPhase = 1, order = [0]}>
 #smem = #ttg.shared_memory
-#mma = #ttg.nvidia_mma<{versionMajor = 3, versionMinor = 0, warpsPerCTA = [4, 1], instrShape = [16, 32, 16]}>
 module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.shared = 65544 : i32, ttg.target = "cuda:90", ttg.tensor_memory_size = 0 : i32, "ttg.threads-per-warp" = 32 : i32, "ttg.total-num-warps" = 1 : i32} {
+  // Pointer-valued storage is tracked by its bytes, not its pointee type.
   // CHECK-LABEL: @local_alloc_with_src
-  tt.func public @local_alloc_with_src(%acc: tensor<128x128xf16, #mma>) {
+  tt.func public @local_alloc_with_src(%src: tensor<16x!tt.ptr<i32>>) {
     // CHECK: %[[BUF:.*]] = ttg.local_alloc
     // CHECK: tt.call @__triton_consan_verify_write_visibility{{.*}}({{[^,]+}}
     // CHECK: tt.call @__triton_consan_verify_read_visibility{{.*}}({{[^,]+}}
-    %buf = ttg.local_alloc %acc {allocation.offset = 0 : i32} : (tensor<128x128xf16, #mma>) -> !ttg.memdesc<128x128xf16, #shared, #smem, mutable>
+    %buf = ttg.local_alloc %src {allocation.offset = 0 : i32} : (tensor<16x!tt.ptr<i32>>) -> !ttg.memdesc<16x!tt.ptr<i32>, #shared1, #smem, mutable>
     %bar = ttg.local_alloc {allocation.offset = 4096 : i32} : () -> !ttg.memdesc<1xi64, #shared1, #smem, mutable>
     ttng.init_barrier %bar, 1 : !ttg.memdesc<1xi64, #shared1, #smem, mutable>
     tt.return

--- a/test/TritonNvidiaGPU/membar-cluster.mlir
+++ b/test/TritonNvidiaGPU/membar-cluster.mlir
@@ -1,4 +1,4 @@
-// RUN: triton-opt %s -split-input-file --allocate-shared-memory -test-print-membar | FileCheck --dump-input=fail --dump-input-context=30 %s
+// RUN: triton-opt %s -split-input-file --allocate-shared-memory --triton-tensor-memory-allocation -test-print-membar | FileCheck --dump-input=fail --dump-input-context=30 %s
 
 // -----
 

--- a/third_party/amd/lib/TritonAMDGPUToLLVM/ConvertWarpPipeline.cpp
+++ b/third_party/amd/lib/TritonAMDGPUToLLVM/ConvertWarpPipeline.cpp
@@ -210,6 +210,15 @@ static void analyzePipelineDependencies(ArrayRef<BlockInfo> clusterInfo,
   const int N = clusterInfo.size();
   const int maxDist = circular ? N : N - 1;
 
+  // A descriptor can change between iterations. Preserve same-iteration
+  // disjointness proofs only for pairs that do not wrap around the loop.
+  SmallVector<BlockInfo> previousIterationInfo;
+  if (circular) {
+    previousIterationInfo.assign(clusterInfo.begin(), clusterInfo.end());
+    for (BlockInfo &info : previousIterationInfo)
+      info.invalidateIterationInfo();
+  }
+
   // Modular wrap; a no-op in linear mode where indices stay in range.
   auto wrap = [&](int i) -> int { return circular ? (i % N + N) % N : i; };
 
@@ -236,7 +245,9 @@ static void analyzePipelineDependencies(ArrayRef<BlockInfo> clusterInfo,
       const int barrierLoc = (dist == 1) ? dst : wrap(dst - 1);
       if (isCovered(src, barrierLoc))
         continue;
-      if (!clusterInfo[src].isIntersected(
+      const BlockInfo &sourceInfo =
+          src + dist >= N ? previousIterationInfo[src] : clusterInfo[src];
+      if (!sourceInfo.isIntersected(
               clusterInfo[dst], mlir::triton::AMD::membarFilter, allocation))
         continue;
       bars[barrierLoc] = true;


### PR DESCRIPTION
We mix a few bugfixes and optimisations to avoid regressing due to
the bug fixes in real workloads. This PR does not materially change
the barriers emitted in most kernels.

There will be a follow up where we use BufferIndex and BufferRegion
to actually materially improve the intersection analysis.

[BUGFIX] Compare indices only within the same source
--------------------------------------------------
Different indices can alias after shifting or reinterpreting the source:

    slots = gl.allocate_shared_memory(gl.int32, [4, 128], ...)
    slots.index(1).store(x128)
    y = slots.slice(1, 2).index(0).load(R)  # Same slot.

    wide = slots.reinterpret(shape=[2, 256])
    slots.index(2).store(x128)  # [256, 384)
    y = wide.index(1).load(R)   # [256, 512)

Require the same indexed descriptor, not just a common allocation root,
before using index differences to prove disjointness.

[BUGFIX] Compare subslices in common coordinates
----------------------------------------------
Different local offsets can identify the same physical region:

    a = slots.slice(1, 2).index(0).slice(0, 64)
    b = slots.reinterpret(shape=[2, 256]).index(0).slice(128, 64)
    a.store(x64)
    y = b.load(R)

Both cover [128, 192), despite final offsets of 0 and 128. Require a common
immediate source; matching encodings and allocation IDs are insufficient.

[OPTIM] Allow subslice proofs for nested views
--------------------------------------------
In a non-inlined helper with a 512-element shared allocation:

    if choose:
        middle = arena.slice(0, 256)
    else:
        middle = arena.slice(256, 256)
    middle.slice(0, 128).store(x128)
    y = middle.slice(128, 128).load(R)

The halves are disjoint even though middle does not cover its allocation.

[BUGFIX] Expire iteration-relative source and index facts
-------------------------------------------------------
Different slots within one iteration can overlap across iterations:

    for i in range(n_iters):
        total += slots.index(i % 2).load(R)
        slots.index((i + 1) % 2).store(x128)

Iteration i writes the slot read by i+1. Clear index/source facts at loop
backedges and function boundaries, including structured, nested and
irreducible CFGs. Complete physical footprints remain valid within their
allocation frame.

[BUGFIX] Invalidate wrapping AMD pipeline dependencies
----------------------------------------------------
Reuse BlockInfo's invalidation for dependencies crossing the loop tail:

    pages = arena.reinterpret(shape=[8, 64])
    first = pages.slice(0, 4).reinterpret(shape=[256])
    shifted = pages.slice(1, 4).reinterpret(shape=[256])
    source = first
    for i in range(n_iters):
        with gl.amd.warp_pipeline_stage("read"):
            last = source.slice(0, 128).load(W)
        with gl.amd.warp_pipeline_stage("advance"):
            next_source = shifted if i == 0 else first
        with gl.amd.warp_pipeline_stage("write"):
            source.slice(128, 128).store(x128)
            source = next_source

The first write [128, 256) overlaps the next read [64, 192). Keep the
loop-tail barrier, including self-dependencies across iterations, while
retaining relative proofs for nonwrapping pairs.

[OPTIM] Refine aliases using complete physical footprints
--------------------------------------------------------
Different parents can select disjoint or overlapping sets of slots:

    stage = i % 2
    low = slots.slice(0, 2).index(stage)
    high = slots.slice(HIGH_BASE, 2).index(1 - stage)
    low.store(x128)
    y = high.load(R)

HIGH_BASE=2 gives disjoint unions {0,1} and {2,3}: no barrier is needed,
even across iterations. HIGH_BASE=1 overlaps at slot one when stage=1.
Cache BufferRegion's complete address union per descriptor in single-CTA
kernel frames; unknown or untranslated origins retain the coarse fallback.

BufferRegion also accounts for padding and partition bases:

    piece = gl.PaddedSharedLayout.with_identity_for(
        [[16, 4]], [4, 16], [1, 0])
    layout = PartitionedSharedLayout(2, 1, 0, piece)
    buf = gl.allocate_shared_memory(gl.float16, [8, 16], layout)
    left, right = buf.slice(0, 4), buf.slice(4, 4)

These views remain physically disjoint when forwarding hides their direct
subslice relationship, which the containing allocation interval cannot prove.

[NFC] Reuse canonical indices and immutable slice metadata
--------------------------------------------------------
Interning already normalizes modular offsets:

    a = slots.index((i + 1) % 4)
    b = slots.index((i + 5) % 4)  # Same canonical offset as a.
    c = slots.index((i + 2) % 4)  # Different slot in this iteration.

Compare those offsets directly and borrow immutable offset/shape arrays
instead of copying them.
