### PR TITLE
Support Python 3.15 and build 3.15t wheels

### DIFF
--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -112,6 +112,15 @@ jobs:
           export CIBW_ENVIRONMENT="MAX_JOBS=4 TRITON_EXT_ENABLED=ON TRITON_BUILD_WITH_CLANG_LLD=1 TRITON_STABLE_ABI=ON"
           python3 -m cibuildwheel . --output-dir wheelhouse
 
+          # Free-threaded builds do not support the limited API, so the cp312
+          # abi3 wheel above does not cover them: 3.15t needs its own wheel.
+          # cpython-prerelease is required while manylinux ships 3.15.0rc1;
+          # drop it once 3.15.0 final is in the image.
+          export CIBW_ENABLE="cpython-prerelease"
+          export CIBW_BUILD="cp315t-manylinux_${{ matrix.config.arch }}"
+          export CIBW_ENVIRONMENT="MAX_JOBS=4 TRITON_EXT_ENABLED=ON TRITON_BUILD_WITH_CLANG_LLD=1"
+          python3 -m cibuildwheel . --output-dir wheelhouse
+
       - uses: actions/upload-artifact@v7
         with:
           name: cibw-wheels-manylinux_2_28_${{ matrix.config.arch }}-wheels-upload

--- a/setup.py
+++ b/setup.py
@@ -589,7 +589,7 @@ TRITON_VERSION = "3.8.0" + get_triton_version_suffix()
 
 # Dynamically define supported Python versions and classifiers
 MIN_PYTHON = (3, 10)
-MAX_PYTHON = (3, 14)
+MAX_PYTHON = (3, 15)
 
 PYTHON_REQUIRES = f">={MIN_PYTHON[0]}.{MIN_PYTHON[1]},<{MAX_PYTHON[0]}.{MAX_PYTHON[1] + 1}"
 BASE_CLASSIFIERS = [


### PR DESCRIPTION
Adds Python 3.15 support so downstream projects that follow CPython releases (PyTorch is already building 3.15 / 3.15t wheels) are not blocked on Triton.

Two changes, for two different reasons.

## 1. `setup.py`: allow 3.15 to install

```diff
 MIN_PYTHON = (3, 10)
-MAX_PYTHON = (3, 14)
+MAX_PYTHON = (3, 15)
```

This is the actual blocker for 3.15-with-GIL. The existing `cp312-abi3` wheel already runs on 3.15 — `TRITON_STABLE_ABI` sets `Py_LIMITED_API=0x030C0000` and tags the wheel `cp312-abi3`, which is forward compatible — but `python_requires` was `>=3.10,<3.15`, so pip refuses to install it on 3.15. Bumping `MAX_PYTHON` makes it `>=3.10,<3.16` and adds the 3.15 classifier.

**No new non-free-threaded wheel is needed**, and none is added here: the abi3 wheel covers 3.12 through 3.15.

## 2. `wheels.yml`: build a free-threaded 3.15t wheel

Free-threaded builds do not support the limited API, so the cp312 abi3 wheel cannot cover `3.15t` — it needs a version-specific wheel, like the existing cp310/cp311 pass:

```yaml
export CIBW_ENABLE="cpython-prerelease"
export CIBW_BUILD="cp315t-manylinux_${{ matrix.config.arch }}"
export CIBW_ENVIRONMENT="MAX_JOBS=4 TRITON_EXT_ENABLED=ON TRITON_BUILD_WITH_CLANG_LLD=1"
python3 -m cibuildwheel . --output-dir wheelhouse
```

Note `TRITON_STABLE_ABI` is deliberately **not** set for this pass.

### Why `cpython-prerelease`

`manylinux_2_28` currently ships **3.15.0rc1** (`build_cpython315` / `build_cpython315_nogil` stages in pypa/manylinux's Dockerfile), and cibuildwheel gates prerelease CPython behind `CIBW_ENABLE=cpython-prerelease`. The flag can be dropped once the image carries 3.15.0 final. cibuildwheel already knows the identifiers:

```
{ identifier = "cp315t-manylinux_x86_64",  version = "3.15", path_str = "/opt/python/cp315-cp315t" }
{ identifier = "cp315t-manylinux_aarch64", version = "3.15", path_str = "/opt/python/cp315-cp315t" }
```

cibuildwheel's docs caution against publishing prerelease-built wheels to **PyPI**; this workflow publishes to the Triton-Nightly Azure feed, which is the intended consumer for pre-GA testing.

## Scope / follow-ups

- Only `3.15t` is added. `3.13t` and `3.14t` are also uncovered by the abi3 wheel today; adding them is the same one-block change if wanted, but I kept this PR to 3.15.
- The workflow only runs on `schedule`, `workflow_dispatch`, and PRs touching `wheels.yml` — so this PR exercises the new build path in CI.