### PR TITLE
[AMD] Execute CDNA4 transpose reads in whole-wave mode

### DIFF
--- a/test/Conversion/amd/ds_transpose.mlir
+++ b/test/Conversion/amd/ds_transpose.mlir
@@ -18,7 +18,11 @@
 module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, "ttg.threads-per-warp" = 64 : i32} {
   //  CHECK-LABEL: ds_transpose_n_t_fp16_mfma_16
   tt.func @ds_transpose_n_t_fp16_mfma_16(%arg0: !ttg.memdesc<128x64xf16, #shared, #smem, mutable>, %arg1: !ttg.memdesc<64x128xf16, #shared1, #smem, mutable>, %arg2: !tt.ptr<f16> {tt.divisibility = 16 : i32, tt.pointer_range = 32 : i32}) {
-    // CHECK-COUNT-32: rocdl.ds.read.tr16.b64 %{{.*}} : <3> -> vector<4xf16>
+    // CDNA4 transpose loads require EXEC to be all ones. Check that the
+    // intrinsic result itself is marked as requiring whole-wave execution.
+    // CHECK: [[TR16:%.*]] = rocdl.ds.read.tr16.b64 %{{.*}} : <3> -> vector<4xf16>
+    // CHECK-NEXT: llvm.call_intrinsic "llvm.amdgcn.strict.wwm"([[TR16]]) : (vector<4xf16>) -> vector<4xf16>
+    // CHECK-COUNT-31: rocdl.ds.read.tr16.b64 %{{.*}} : <3> -> vector<4xf16>
     // CHECK-NOT: rocdl.ds.read.tr16.b64
     %1 = ttg.local_load %arg0 : !ttg.memdesc<128x64xf16, #shared, #smem, mutable> -> tensor<128x64xf16, #ttg.dot_op<{opIdx = 0, parent = #mma16, kWidth = 8}>>
     %2 = ttg.local_load %arg1 : !ttg.memdesc<64x128xf16, #shared1, #smem, mutable> -> tensor<64x128xf16, #ttg.dot_op<{opIdx = 1, parent = #mma16, kWidth = 8}>>
@@ -220,7 +224,9 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, "ttg.thr
 
   //  CHECK-LABEL: ds_transpose_n_t_i8_mfma_16
   tt.func @ds_transpose_n_t_i8_mfma_16(%arg0: !ttg.memdesc<128x64xi8, #shared, #smem, mutable>, %arg1: !ttg.memdesc<64x128xi8, #shared1, #smem, mutable>, %arg2: !tt.ptr<i8> {tt.divisibility = 16 : i32, tt.pointer_range = 32 : i32}) {
-    // CHECK-COUNT-16: rocdl.ds.read.tr8.b64 %{{.*}} : <3> -> vector<2xi32>
+    // CHECK: [[TR8:%.*]] = rocdl.ds.read.tr8.b64 %{{.*}} : <3> -> vector<2xi32>
+    // CHECK-NEXT: llvm.call_intrinsic "llvm.amdgcn.strict.wwm"([[TR8]]) : (vector<2xi32>) -> vector<2xi32>
+    // CHECK-COUNT-15: rocdl.ds.read.tr8.b64 %{{.*}} : <3> -> vector<2xi32>
     // CHECK-NOT: rocdl.ds.read.tr8.b64
     %1 = ttg.local_load %arg0 : !ttg.memdesc<128x64xi8, #shared, #smem, mutable> -> tensor<128x64xi8, #ttg.dot_op<{opIdx = 0, parent = #mma16, kWidth = 16}>>
     %2 = ttg.local_load %arg1 : !ttg.memdesc<64x128xi8, #shared1, #smem, mutable> -> tensor<64x128xi8, #ttg.dot_op<{opIdx = 1, parent = #mma16, kWidth = 16}>>
@@ -636,7 +642,9 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, "ttg.thr
 
   //  CHECK-LABEL: ds_transpose_t_fp4_mfma32_small
   tt.func @ds_transpose_t_fp4_mfma32_small(%arg0: !ttg.memdesc<16x64xi8, #shared, #smem, mutable>, %arg1: !ttg.memdesc<64x16xi8, #shared1, #smem, mutable>, %arg2: !tt.ptr<i8> {tt.divisibility = 16 : i32, tt.pointer_range = 32 : i32}) {
-    // CHECK-COUNT-4: rocdl.ds.read.tr4.b64 %{{.*}} : <3> -> vector<2xi32>
+    // CHECK: [[TR4:%.*]] = rocdl.ds.read.tr4.b64 %{{.*}} : <3> -> vector<2xi32>
+    // CHECK-NEXT: llvm.call_intrinsic "llvm.amdgcn.strict.wwm"([[TR4]]) : (vector<2xi32>) -> vector<2xi32>
+    // CHECK-COUNT-3: rocdl.ds.read.tr4.b64 %{{.*}} : <3> -> vector<2xi32>
     // CHECK-NOT: rocdl.ds.read.tr4.b64
     %1 = amdg.local_load_packed_transposed %arg0 : !ttg.memdesc<16x64xi8, #shared, #smem, mutable> -> tensor<32x32xi8, #ttg.dot_op<{opIdx = 0, parent = #mma32, kWidth = 16}>>
     %2 = amdg.local_load_packed_transposed %arg1 : !ttg.memdesc<64x16xi8, #shared1, #smem, mutable> -> tensor<32x32xi8, #ttg.dot_op<{opIdx = 1, parent = #mma32, kWidth = 16}>>

--- a/third_party/amd/lib/TritonAMDGPUToLLVM/MemoryOpToLLVM.cpp
+++ b/third_party/amd/lib/TritonAMDGPUToLLVM/MemoryOpToLLVM.cpp
@@ -72,7 +72,13 @@ static Value createDsReadTr(Operation *op, RewriterBase &rewriter, Location loc,
       return {};
     AMD::addLocalLoadNoAliasScope(
         op, cast<LLVM::AliasAnalysisOpInterface>(dsReadTr.getDefiningOp()));
-    return dsReadTr;
+    // CDNA4 ISA section 11.4 requires EXEC to be all ones for ds_read_tr.
+    // Pull the load into whole-wave mode even when preceding control flow
+    // leaves a partial execution mask.
+    return LLVM::createLLVMIntrinsicCallOp(rewriter, loc,
+                                           "llvm.amdgcn.strict.wwm",
+                                           {dsReadTr.getType()}, {dsReadTr})
+        .getResult(0);
   }
   default:
     return {};


### PR DESCRIPTION
## Summary

CDNA4 requires `EXEC` to be all ones when executing the
`DS_READ_*_TR_*` family (CDNA4 ISA, section 11.4). This draft tests whether
Triton's CDNA4 local-load lowering needs to express that requirement explicitly
to LLVM.

The proposed change wraps each CDNA4 `ds_read_tr16_b64`, `ds_read_tr8_b64`, and
`ds_read_tr4_b64` result in `llvm.amdgcn.strict.wwm`.

## Hypothesis

The reported failure was correlated with non-canonical 64-bit global pointer
arithmetic in a masked global-to-LDS producer. That global address form is
legal. A separate ISA contract exists on the later transposed LDS read: it is a
lane-cooperative CDNA4 operation and requires all lanes active.

If LLVM can reach `ds_read_tr` with a partial `EXEC`, an explicit WWM constraint
would let the AMDGPU backend save, set, and restore `EXEC`. Pointer
canonicalization can change control flow and scheduling, but it is not itself a
correctness guarantee.

CDNA4 ISA reference:
https://www.amd.com/content/dam/amd/en/documents/instinct-tech-docs/instruction-set-architectures/amd-instinct-cdna4-instruction-set-architecture.pdf

Related investigation:
- https://github.com/raikonenfnu/tlx_triton/issues/17
- https://github.com/raikonenfnu/tlx_triton/issues/16#issuecomment-5402521467
- https://github.com/facebookexperimental/triton/pull/2902

## Compiler tests

- Built `triton-opt` and the upstream Python extension in a clean worktree.
- `lit -v test/Conversion/amd/ds_transpose.mlir test/Conversion/amd/ds_transpose_gfx1250.mlir test/Conversion/amd/async-ops-alias-scopes.mlir`
- Added exact SSA checks for the `tr16`, `tr8`, and `tr4` forms. Reverting the
  source change while retaining these checks fails all three; restoring the
  change passes all tests.

## Upstream runtime A/B

A regular `@triton.jit` pipelined fp16 matmul was tested on gfx950. Its TTGIR
contains masked `ttg.async_copy_global_to_local` operations with a GPU-loaded
64-bit row offset, followed by dot-operand `ttg.local_load`. Its final ISA
contains 32 `global_load_lds*` and 64 `ds_read_b64_tr_b16` instructions.

For `M=19`, both patched and unpatched compilers passed 200/200 numerical trials
with the same worst absolute error (`2.6702880859375e-05`). The unpatched
compiler also passed 100/100 trials for each of `M={1,7,19,63,65,127}`.

The unpatched ISA reconverges `EXEC` before the transpose-read region, so these
reads already satisfy the CDNA4 requirement. The patch increases
`s_or_saveexec_b64` occurrences from 2 to 40 and VGPR allocation from 94 to 98
for the `M=19` kernel without an observed correctness improvement.

A separate upstream Gluon reproducer comparing masked `buffer_load_to_shared`
and `global_load_to_shared` does not contain `ds_read_tr` and is unchanged by
this patch. Its `other=None` behavior is undefined by upstream load semantics;
with `other=0.0`, both paths correctly zero masked LDS elements.

Current upstream evidence therefore does not demonstrate that this WWM change
is needed. This remains a draft while determining whether the earlier TLX-only
failure creates a control-flow shape that upstream Triton cannot produce, or
whether its root cause lies elsewhere.
