### PR TITLE
[RFC][AMD][Gluon] Require other for masked buffer-to-shared loads

### DIFF
--- a/python/test/gluon/test_frontend.py
+++ b/python/test/gluon/test_frontend.py
@@ -3450,6 +3450,42 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.targ
 
 
 @gluon.jit
+def masked_buffer_load_to_shared_without_other(ptr):
+    blocked: ttgl.constexpr = ttgl.BlockedLayout([1, 8], [32, 2], [4, 1], [1, 0])
+    shared: ttgl.constexpr = ttgl.SwizzledSharedLayout(1, 1, 1, order=[1, 0])
+    smem = ttgl.allocate_shared_memory(ptr.dtype.element_ty, [128, 16], shared)
+    y_offset = ttgl.arange(0, 128, layout=ttgl.SliceLayout(1, blocked))
+    x_offset = ttgl.arange(0, 16, layout=ttgl.SliceLayout(0, blocked))
+    offsets = y_offset[:, None] * 16 + x_offset[None, :]
+    mask = (y_offset < 64)[:, None]
+    cdna4_async_copy.buffer_load_to_shared(smem, ptr, offsets, mask=mask)
+
+
+@gluon.jit
+def masked_global_load_to_shared_without_other(ptr):
+    blocked: ttgl.constexpr = ttgl.BlockedLayout([1, 8], [32, 2], [4, 1], [1, 0])
+    shared: ttgl.constexpr = ttgl.SwizzledSharedLayout(1, 1, 1, order=[1, 0])
+    smem = ttgl.allocate_shared_memory(ptr.dtype.element_ty, [128, 16], shared)
+    y_offset = ttgl.arange(0, 128, layout=ttgl.SliceLayout(1, blocked))
+    x_offset = ttgl.arange(0, 16, layout=ttgl.SliceLayout(0, blocked))
+    offsets = y_offset[:, None] * 16 + x_offset[None, :]
+    mask = (y_offset < 64)[:, None]
+    cdna4_async_copy.global_load_to_shared(smem, ptr + offsets, mask=mask)
+
+
+def test_masked_buffer_load_to_shared_requires_other():
+    ptr = MockTensor(ttgl.float16)
+    with pytest.raises(CompilationError) as exc:
+        run_parser(masked_buffer_load_to_shared_without_other, *make_args(ptr), target=HIP_TARGET_CDNA4)
+    assert "other is required for a masked buffer_load_to_shared" in str(exc.value.__cause__)
+
+
+def test_masked_global_load_to_shared_without_other_preserves_dest():
+    ptr = MockTensor(ttgl.float16)
+    run_parser(masked_global_load_to_shared_without_other, *make_args(ptr), target=HIP_TARGET_CDNA4)
+
+
+@gluon.jit
 def buffer_load_store_kernel(x, y):
     layout: ttgl.constexpr = ttgl.BlockedLayout(size_per_thread=[1, 1], threads_per_warp=[1, 64], warps_per_cta=[4, 1],
                                                 order=[1, 0])

--- a/python/triton/experimental/gluon/language/amd/cdna4/async_copy.py
+++ b/python/triton/experimental/gluon/language/amd/cdna4/async_copy.py
@@ -32,6 +32,10 @@ def global_load_to_shared(dest, ptr, mask=None, other=None, cache_modifier="", _
     out-of-bound masking support. Prefer :func:`buffer_load_to_shared` when
     possible for better performance.
 
+    When ``mask`` is provided without ``other``, masked elements in ``dest``
+    are left unchanged. Providing ``other`` writes that value to masked
+    elements instead.
+
     The underlying hardware instruction uses separate registers for global
     memory address for each thread but the same register for local memory
     address for the whole warp. Therefore, while using this operation
@@ -46,7 +50,8 @@ def global_load_to_shared(dest, ptr, mask=None, other=None, cache_modifier="", _
         dest (shared_memory_descriptor): Destination shared memory descriptor.
         ptr (pointer tensor): Tensor of pointers to global memory to load from.
         mask (tensor, optional): Mask tensor for predicated loads. Defaults to None.
-        other (tensor or scalar, optional): Tensor or scalar providing default values for masked elements. Defaults to None.
+        other (tensor or scalar, optional): Tensor or scalar providing values for masked elements. When omitted, masked
+            elements in ``dest`` are left unchanged. Defaults to None.
         cache_modifier (str): Cache modifier specifier. Defaults to "".
     """
     _check(ptr.type.is_block(), lambda: "expected ptr to be a tensor")
@@ -106,18 +111,23 @@ def buffer_load_to_shared(dest, ptr, offsets, mask=None, other=None, cache_modif
         dest (shared_memory_descriptor): Destination shared memory descriptor.
         ptr (pointer to scalar): Global memory scalar base pointer to load from.
         offsets (tensor): Offsets tensor for the load operation.
-        mask (tensor, optional): Mask tensor for predicated loads. Defaults to None.
-        other (tensor or scalar, optional): Tensor or scalar providing default values for masked elements. Defaults to None.
+        mask (tensor, optional): Mask tensor for predicated loads. Requires ``other`` when specified. Defaults to None.
+        other (tensor or scalar, optional): Tensor or scalar providing values for masked elements. Buffer loads cannot
+            preserve masked destination elements, so this is required when ``mask`` is specified. Defaults to None.
         cache_modifier (str): Cache modifier specifier. Defaults to "".
     """
     _check(isinstance(offsets.type.layout, DistributedLayout),
            lambda: "expected offsets type layout to be a DistributedLayout")
+    mask = _unwrap_if_constexpr(mask)
+    other = _unwrap_if_constexpr(other)
+    _check(
+        mask is None or other is not None, lambda:
+        "other is required for a masked buffer_load_to_shared because masked buffer loads cannot preserve destination shared memory"
+    )
     _verify_buffer_ops(ptr, offsets, mask, other)
 
-    mask = _unwrap_if_constexpr(mask)
     if mask is not None:
         offsets, mask = _semantic.broadcast_impl_value(offsets, mask)
-    other = _unwrap_if_constexpr(other)
     if other is not None:
         other = _semantic.to_tensor(other)
         other = _semantic.cast(other, ptr.type.scalar.element_ty)

--- a/test/TritonGPU/amd/amd-buffer-load-to-local-canonicalize.mlir
+++ b/test/TritonGPU/amd/amd-buffer-load-to-local-canonicalize.mlir
@@ -1,0 +1,40 @@
+// RUN: triton-opt %s --canonicalize | FileCheck %s
+// RUN: triton-opt %s --canonicalize --allocate-shared-memory --convert-triton-amdgpu-to-llvm=gfx-arch=gfx950 | FileCheck %s --check-prefix=LLVM
+
+#blocked = #ttg.blocked<{sizePerThread = [1], threadsPerWarp = [64], warpsPerCTA = [1], order = [0]}>
+#shared = #ttg.swizzled_shared<{vec = 1, perPhase = 1, maxPhase = 1, order = [0]}>
+#smem = #ttg.shared_memory
+
+module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 1 : i32, ttg.target = "hip:gfx950", "ttg.threads-per-warp" = 64 : i32} {
+  // CHECK-LABEL: tt.func @drop_zero_other(
+  // LLVM-LABEL: llvm.func @drop_zero_other(
+  // LLVM-NOT: llvm.cond_br
+  // LLVM: rocdl.raw.ptr.buffer.load.async.lds
+  // LLVM-NOT: llvm.cond_br
+  // LLVM-NOT: llvm.store
+  tt.func @drop_zero_other(%ptr: !tt.ptr<f32>, %offsets: tensor<64xi32, #blocked>,
+                           %mask: tensor<64xi1, #blocked>,
+                           %dest: !ttg.memdesc<64xf32, #shared, #smem, mutable>) {
+    // CHECK-NOT: arith.constant dense<0.000000e+00>
+    // CHECK: amdg.buffer_load_to_local %{{.*}}[%{{.*}}] mask = %{{.*}} into %{{.*}}
+    // CHECK-NOT: other
+    %zero = arith.constant dense<0.000000e+00> : tensor<64xf32, #blocked>
+    %token = amdg.buffer_load_to_local %ptr[%offsets] mask = %mask other = %zero into %dest : !tt.ptr<f32>[tensor<64xi32, #blocked>] tensor<64xf32, #blocked> -> <64xf32, #shared, #smem, mutable>
+    tt.return
+  }
+
+  // CHECK-LABEL: tt.func @keep_nonzero_other(
+  // LLVM-LABEL: llvm.func @keep_nonzero_other(
+  // LLVM: llvm.cond_br
+  // LLVM: rocdl.raw.ptr.buffer.load.async.lds
+  // LLVM: llvm.store
+  tt.func @keep_nonzero_other(%ptr: !tt.ptr<f32>, %offsets: tensor<64xi32, #blocked>,
+                              %mask: tensor<64xi1, #blocked>,
+                              %dest: !ttg.memdesc<64xf32, #shared, #smem, mutable>) {
+    // CHECK: %[[ONE:.*]] = arith.constant dense<1.000000e+00>
+    // CHECK: amdg.buffer_load_to_local %{{.*}}[%{{.*}}] mask = %{{.*}} other = %[[ONE]] into %{{.*}}
+    %one = arith.constant dense<1.000000e+00> : tensor<64xf32, #blocked>
+    %token = amdg.buffer_load_to_local %ptr[%offsets] mask = %mask other = %one into %dest : !tt.ptr<f32>[tensor<64xi32, #blocked>] tensor<64xf32, #blocked> -> <64xf32, #shared, #smem, mutable>
+    tt.return
+  }
+}

--- a/third_party/amd/include/Dialect/TritonAMDGPU/IR/TritonAMDGPUOps.td
+++ b/third_party/amd/include/Dialect/TritonAMDGPU/IR/TritonAMDGPUOps.td
@@ -344,6 +344,7 @@ def BufferLoadToLocalOp : TT_AMDGPU_Op<"buffer_load_to_local", [
     let results = (outs TTG_AsyncToken:$token);
 
     let hasVerifier = 1;
+    let hasCanonicalizer = 1;
 
     let assemblyFormat = [{
       $ptr `[` $offsets `]` (`mask` `=` $mask^)? (`other` `=` $other^)? (`stride` `=` $stride^)?

--- a/third_party/amd/lib/Dialect/TritonAMDGPU/IR/Dialect.cpp
+++ b/third_party/amd/lib/Dialect/TritonAMDGPU/IR/Dialect.cpp
@@ -26,6 +26,7 @@
 #include "mlir/IR/DialectImplementation.h"
 #include "mlir/IR/OpImplementation.h"
 #include "third_party/amd/include/Utils/Utility.h"
+#include "triton/Analysis/Utility.h"
 #include "triton/Conversion/TritonGPUToLLVM/Utility.h"
 #include "triton/Dialect/Triton/IR/Interfaces.h"
 #include "triton/Dialect/TritonGPU/IR/Dialect.h"
@@ -1007,6 +1008,29 @@ LogicalResult BufferLoadToLocalOp::verify() {
   if (features.getArch().empty() || features.supportsBufferLoadToLocal())
     return success();
   return emitError() << "BufferLoadToLocal unsupported on target architecture";
+}
+
+namespace {
+// Masked buffer loads natively zero-fill LDS, so an explicit zero does not
+// require the software fallback-store path.
+struct DropZeroOtherFromBufferLoadToLocal
+    : OpRewritePattern<BufferLoadToLocalOp> {
+  using OpRewritePattern::OpRewritePattern;
+
+  LogicalResult matchAndRewrite(BufferLoadToLocalOp op,
+                                PatternRewriter &rewriter) const override {
+    if (!op.getOther() || !isZeroConst(op.getOther()))
+      return failure();
+
+    rewriter.modifyOpInPlace(op, [&] { op.getOtherMutable().clear(); });
+    return success();
+  }
+};
+} // namespace
+
+void BufferLoadToLocalOp::getCanonicalizationPatterns(
+    RewritePatternSet &patterns, MLIRContext *context) {
+  patterns.add<DropZeroOtherFromBufferLoadToLocal>(context);
 }
 
 // A buffer write's scalar base must be global memory (address space 1).


### PR DESCRIPTION
## Summary

Require callers of the CDNA4 Gluon `buffer_load_to_shared` API to provide an explicit `other` value whenever they provide a mask.

Keep mask-only `global_load_to_shared` valid and document that its masked destination elements remain unchanged. Canonicalize a zero `other` from `amdg.buffer_load_to_local` so explicit `other=0` still uses native hardware zero fill.

## Concrete example

Assume LDS already contains `[10, 20, 30, 40]`, the valid global values are `[1, 2, X, X]`, and the mask is `[true, true, false, false]`.

| Operation | Call | LDS after the load |
|---|---|---|
| Global, preserve | `global_load_to_shared(..., mask=mask)` | `[1, 2, 30, 40]` |
| Global, fill | `global_load_to_shared(..., mask=mask, other=0)` | `[1, 2, 0, 0]` |
| Buffer, ambiguous old call | `buffer_load_to_shared(..., mask=mask)` | `[1, 2, 0, 0]`, not preserved |
| Buffer, explicit new call | `buffer_load_to_shared(..., mask=mask, other=0)` | `[1, 2, 0, 0]` |

```text
                       mask = false

global_load_lds   -> instruction is predicated off -> no LDS write -> preserve 30/40
buffer_load_lds   -> source offset is made OOB     -> hardware zero -> write 0/0
```

The new buffer API makes that unavoidable write behavior explicit. It does not emulate preserve semantics that the buffer path cannot provide.

Explicit zero also remains the fast path:

```mlir
// Frontend: caller explicitly requests zero fill.
ttg.buffer_load_to_local ... mask %mask other %zero

// Canonicalized: zero is the native masked-buffer result.
ttg.buffer_load_to_local ... mask %mask

// LLVM lowering: one native direct-to-LDS load.
rocdl.raw.ptr.buffer.load.async.lds ...
// No llvm.cond_br and no fallback llvm.store.
```

For a nonzero `other`, the operand is retained and lowering emits the conditional fallback LDS store required to produce that value.

## Motivation

The two direct-to-LDS paths have different masking capabilities:

- `global_load_to_shared(..., mask=mask)` predicates `global_load_lds`. A masked lane performs neither a global read nor an LDS write, so preserving existing LDS contents is a valid and useful operation.
- `buffer_load_to_shared(..., mask=mask)` represents false lanes as OOB buffer accesses. The hardware writes zero to LDS; it cannot express per-lane preserve semantics through this path.

Silently accepting omitted `other` on the buffer API makes it look like the global and buffer masks have the same contract. Requiring an explicit buffer fallback makes the write semantics visible without removing the global operation's preserve capability.

Explicit `other=0` previously selected the generic fallback path, adding conditional branches and LDS stores. Since zero is exactly the native masked/OOB buffer result, the new AMDGPU canonicalization removes a constant-zero `other` before LLVM conversion.

This is limited to the experimental CDNA4 Gluon direct-to-LDS API and the corresponding AMDGPU buffer-to-local optimization. It does not change `tl.load` or ordinary register buffer loads.

## Tests

- Frontend error coverage for masked `buffer_load_to_shared` without `other`.
- Frontend success coverage for mask-only `global_load_to_shared` preserve semantics.
- MLIR canonicalization coverage showing zero `other` is removed while nonzero `other` is retained.
- gfx950 LLVM checks showing the zero case has native `buffer.load.async.lds` without fallback branches or LDS stores.
- Focused frontend result: `4 passed`.
- New and existing focused AMD LIT result: `7 passed`.
- `yapf`, `clang-format`, and `git diff --check` are clean.