### PR TITLE
[FRONTEND] Make for-loop targets loop-local

### DIFF
--- a/docs/python-api/triton-semantics.rst
+++ b/docs/python-api/triton-semantics.rst
@@ -70,3 +70,25 @@ Assign the variable before the block so that it is defined on all paths:
         for _ in range(0, 1):
             value = 1.0
         tl.store(out_ptr, value)
+
+A name that is already defined cannot be reused as the loop variable of a dynamic loop (``range``/``tl.range``); choose a different name for it. Matching Python here would require the frontend to carry the loop variable's exit value, so Triton keeps the rule simple instead:
+
+.. code-block:: python
+
+    @triton.jit
+    def kernel(out_ptr, n):
+        i = -1
+        for i in range(n):  # error: `i` is already defined
+            pass
+
+The loop variable of a dynamic loop is local to the loop body, so it cannot be used after the loop:
+
+.. code-block:: python
+
+    @triton.jit
+    def kernel(out_ptr, n):
+        for i in range(n):
+            pass
+        tl.store(out_ptr, i)  # `i` is not defined here
+
+``tl.static_range`` loops are unrolled at compile time, so their loop variable stays defined after the loop with its last value.

--- a/python/test/unit/language/test_compile_errors.py
+++ b/python/test/unit/language/test_compile_errors.py
@@ -33,6 +33,110 @@ def test_err_undefined_variable():
         raise assertion_err from e.value
 
 
+def test_err_for_target_after_loop():
+
+    @triton.jit
+    def kernel(out_ptr, n):
+        for i in range(n):
+            pass
+        tl.store(out_ptr, i)  # noqa
+
+    with pytest.raises(CompilationError) as e:
+        triton.compile(triton.compiler.ASTSource(fn=kernel, signature={"out_ptr": "*i32", "n": "i32"}, constexprs={}))
+
+    try:
+        err_msg = format_exception(e.type, value=e.value, tb=e.tb)
+        assert "is not defined" in err_msg, "loop target should be local to the loop body"
+        assert "code_generator.py" not in err_msg
+    except AssertionError as assertion_err:
+        raise assertion_err from e.value
+
+
+def test_err_for_target_shadows_existing_variable():
+
+    @triton.jit
+    def kernel(n):
+        i = -1
+        for i in range(n):
+            pass
+
+    with pytest.raises(CompilationError) as e:
+        triton.compile(triton.compiler.ASTSource(fn=kernel, signature={"n": "i32"}, constexprs={}))
+
+    try:
+        err_msg = format_exception(e.type, value=e.value, tb=e.tb)
+        assert "already defined" in err_msg, "error should reject reusing an assigned name as the loop target"
+        assert "code_generator.py" not in err_msg
+    except AssertionError as assertion_err:
+        raise assertion_err from e.value
+
+
+def test_err_for_target_shadows_nested_loop():
+
+    @triton.jit
+    def kernel(n):
+        for i in range(n):
+            for i in range(n):  # noqa
+                pass
+
+    with pytest.raises(CompilationError) as e:
+        triton.compile(triton.compiler.ASTSource(fn=kernel, signature={"n": "i32"}, constexprs={}))
+
+    try:
+        err_msg = format_exception(e.type, value=e.value, tb=e.tb)
+        assert "already defined" in err_msg, "nested loops may not reuse the enclosing loop's target"
+        assert "code_generator.py" not in err_msg
+    except AssertionError as assertion_err:
+        raise assertion_err from e.value
+
+
+def test_for_other_name_after_loop_no_err():
+
+    @triton.jit
+    def kernel(out_ptr, n):
+        i = -1
+        for j in range(n):
+            pass
+        tl.store(out_ptr, i)
+
+    triton.compile(triton.compiler.ASTSource(fn=kernel, signature={"out_ptr": "*i32", "n": "i32"}, constexprs={}))
+
+
+def test_for_sequential_same_target_no_err():
+
+    @triton.jit
+    def kernel(n):
+        for i in range(n):
+            pass
+        for i in range(2 * n):
+            pass
+
+    triton.compile(triton.compiler.ASTSource(fn=kernel, signature={"n": "i32"}, constexprs={}))
+
+
+def test_for_target_rebound_after_loop_no_err():
+
+    @triton.jit
+    def kernel(out_ptr, n):
+        for i in range(n):
+            pass
+        i = -1
+        tl.store(out_ptr, i)
+
+    triton.compile(triton.compiler.ASTSource(fn=kernel, signature={"out_ptr": "*i32", "n": "i32"}, constexprs={}))
+
+
+def test_static_range_target_after_loop_no_err():
+
+    @triton.jit
+    def kernel(out_ptr):
+        for i in tl.static_range(3):
+            pass
+        tl.store(out_ptr, i)
+
+    triton.compile(triton.compiler.ASTSource(fn=kernel, signature={"out_ptr": "*i32"}, constexprs={}))
+
+
 def test_err_in_binary_operator():
 
     @triton.jit

--- a/python/triton/compiler/code_generator.py
+++ b/python/triton/compiler/code_generator.py
@@ -1335,6 +1335,9 @@ class CodeGenerator(ast.NodeVisitor):
             raise TypeError(f"For upper bound must be a scalar, got {ub.type}")
         if _is_non_scalar_tensor(step):
             raise TypeError(f"For step must be a scalar, got {step.type}")
+        target_name = node.target.id
+        if target_name in self.lscope:
+            raise NameError(f"loop target '{target_name}' is already defined")
         iv_type = self.semantic.integer_promote_impl(lb.dtype, ub.dtype)
         iv_type = self.semantic.integer_promote_impl(iv_type, step.dtype)
         iv_ir_type = iv_type.to_ir(self.builder)
@@ -1349,7 +1352,7 @@ class CodeGenerator(ast.NodeVisitor):
         step = self.builder.create_int_cast(step, iv_ir_type, iv_is_signed)
         # Create placeholder for the loop induction variable
         iv_placeholder = self.builder.create_poison(iv_ir_type)
-        self.set_value(node.target.id, language.core.tensor(iv_placeholder, iv_type))
+        self.set_value(target_name, language.core.tensor(iv_placeholder, iv_type))
 
         with enter_sub_region(self) as sr:
             liveins, insert_block = sr
@@ -1410,6 +1413,10 @@ class CodeGenerator(ast.NodeVisitor):
         for name, val in zip(names, result_values):
             self.set_value(name, val)
             self._maybe_set_loc_to_name(val, name)
+
+        # The loop target stays local to the loop body.
+        self.lscope.pop(target_name, None)
+        self.local_defs.pop(target_name, None)
 
         for stmt in node.orelse:
             assert False, "Don't know what to do with else after for"

--- a/python/triton_kernels/triton_kernels/tensor_details/ragged_tensor.py
+++ b/python/triton_kernels/triton_kernels/tensor_details/ragged_tensor.py
@@ -172,8 +172,8 @@ def _ragged_tensor_metadata_compute(SliceSizes,  #
     block_size_log2 = first_block_size_log2 + block_size_id
     n_blocks = _cdiv_pow2(slice_sizes, block_size_log2)
     # compute block schedule
-    block_off = tl.load(BlockOffs + slice_id)
-    BlockSchedule += block_off
+    block_base = tl.load(BlockOffs + slice_id)
+    BlockSchedule += block_base
     for block_off in range(0, n_blocks, BLOCK):
         block_offs = block_off + tl.arange(0, BLOCK)
         data = (block_offs << 16) + slice_id

--- a/python/tutorials/gluon/07-persistence.py
+++ b/python/tutorials/gluon/07-persistence.py
@@ -661,8 +661,9 @@ def persistent_matmul_pipelined_kernel(a_desc, b_desc, c_desc, c_half_desc, MMAI
     for ki in gl.static_range(0, BLOCK_K * (num_buffers - 2), BLOCK_K):
         producer = issue_loads_stealb(producer, a_desc, b_desc, off_m, off_n, ki, bars, a_bufs, b_bufs, STEALB,
                                       num_buffers)
-    k = BLOCK_K * (num_buffers - 2)
-    producer = issue_loads_stealb(producer, a_desc, b_desc, off_m, off_n, k, bars, a_bufs, b_bufs, STEALB, num_buffers)
+    k_peel = BLOCK_K * (num_buffers - 2)
+    producer = issue_loads_stealb(producer, a_desc, b_desc, off_m, off_n, k_peel, bars, a_bufs, b_bufs, STEALB,
+                                  num_buffers)
 
     for _ in range(num_tiles):
         consumer, mma = issue_mma_stealb(consumer, mma, bars, a_bufs, b_bufs, STEALB, num_buffers)

--- a/python/tutorials/gluon/09-tma-gather-scatter.py
+++ b/python/tutorials/gluon/09-tma-gather-scatter.py
@@ -523,9 +523,9 @@ def matmul_fused_gather_scatter_kernel(X_desc, W_desc, out_desc, X_gather_indx_p
     for ki in gl.static_range(0, BLOCK_K * (num_buffers - 2), BLOCK_K):
         producer = issue_loads(producer, X_desc, W_desc, X_gather_indx_ptr, off_m, off_n, ki, bars, x_bufs, w_bufs,
                                BLOCK_M, num_buffers)
-    k = BLOCK_K * (num_buffers - 2)
-    producer = issue_loads(producer, X_desc, W_desc, X_gather_indx_ptr, off_m, off_n, k, bars, x_bufs, w_bufs, BLOCK_M,
-                           num_buffers)
+    k_peel = BLOCK_K * (num_buffers - 2)
+    producer = issue_loads(producer, X_desc, W_desc, X_gather_indx_ptr, off_m, off_n, k_peel, bars, x_bufs, w_bufs,
+                           BLOCK_M, num_buffers)
 
     for _ in range(num_tiles):
         consumer, mma = issue_mma(consumer, mma, bars, x_bufs, w_bufs, num_buffers)

--- a/python/tutorials/gluon/11-tcgen05-mma-scaled.py
+++ b/python/tutorials/gluon/11-tcgen05-mma-scaled.py
@@ -1254,9 +1254,9 @@ def mma_scaled_pipelined_kernel(a_desc, b_desc, c_desc, a_scale_desc, b_scale_de
     for ki in gl.static_range(0, BLOCK_K * (num_buffers - 2), BLOCK_K):
         load_producer = issue_loads(load_producer, pid_m, pid_n, ki, a_desc, b_desc, a_scale_desc, b_scale_desc, a_bufs,
                                     b_bufs, a_scale_bufs, b_scale_bufs, load_bars, pred=ki < K)
-    k = BLOCK_K * (num_buffers - 2)
-    load_producer = issue_loads(load_producer, pid_m, pid_n, k, a_desc, b_desc, a_scale_desc, b_scale_desc, a_bufs,
-                                b_bufs, a_scale_bufs, b_scale_bufs, load_bars, pred=k < K)
+    k_peel = BLOCK_K * (num_buffers - 2)
+    load_producer = issue_loads(load_producer, pid_m, pid_n, k_peel, a_desc, b_desc, a_scale_desc, b_scale_desc, a_bufs,
+                                b_bufs, a_scale_bufs, b_scale_bufs, load_bars, pred=k_peel < K)
 
     load_consumer, mma_producer = issue_mma(load_consumer, load_bars, a_bufs, b_bufs, a_scale_bufs, b_scale_bufs,
                                             mma_producer, mma_bars, acc_bufs.index(acc_idx), use_acc=False, pred=True)


### PR DESCRIPTION
After a dynamic `for` loop, any use of the loop target silently read poison — whether the target was only bound by the loop or carried a value from before the loop. No `NameError`, no warning, just a silent miscompile.

Following the review discussion, this PR makes the loop variable local to the loop body:

- Reusing an already-defined name as the loop variable is rejected at the `for` statement.
- An unbound loop variable raises `NameError` if used after the loop.
- Valid loops generate identical IR, and `tl.static_range` is untouched.

The shadow check also rejects a pre-bound name reused as the loop variable even when it is never read after the loop (telling that case apart would need liveness analysis). The in-repo impact is 4 spots, renamed here: one in `triton_kernels/tensor_details/ragged_tensor.py` and three Gluon tutorials with the peel-then-loop pattern.

Tests: compile-error tests for both rules, plus coverage for nested loops, sequential reuse, rebinding after the loop, `tl.static_range`, and pre-bound non-target names staying usable. triton-semantics documents both rules.

# New contributor declaration
- [x] I am not making a trivial change, such as fixing a typo in a comment.

- [x] I have written a PR description following these
  [rules](https://cbea.ms/git-commit/#why-not-how).

- [x] I have run `pre-commit run --from-ref origin/main --to-ref HEAD`.

- Select one of the following.
  - [x] I have added tests.
    - `/python/test` for end-to-end tests
  - [ ] This PR does not need a test because `FILL THIS IN`.

- Select one of the following.
  - [x] I have not added any `lit` tests.
  - [ ] The `lit` tests I have added follow these [best practices](https://mlir.llvm.org/getting_started/TestingGuide/#filecheck-best-practices).
