### PR TITLE
[Frontend] Restore arith.truncf for most fp8 constants

### DIFF
--- a/python/test/gluon/test_frontend.py
+++ b/python/test/gluon/test_frontend.py
@@ -3918,7 +3918,7 @@ def test_amd_scaled_upcast_fp8_cdna(target):
 module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 1 : i32, ttg.target = "...", "ttg.threads-per-warp" = 64 : i32} {
   tt.func public @kernel() attributes {noinline = false} {
     %cst = arith.constant 1.000000e+00 : f32
-    %0 = tt.fp_to_fp %cst, rounding = rtne : f32 -> f8E4M3FN
+    %0 = arith.truncf %cst : f32 to f8E4M3FN
     %1 = tt.splat %0 : f8E4M3FN -> tensor<16x64xf8E4M3FN, #blocked>
     %c2_i8 = arith.constant 2 : i8
     %cst_0 = arith.constant dense<2> : tensor<16x64xi8, #blocked>

--- a/python/triton/language/semantic.py
+++ b/python/triton/language/semantic.py
@@ -601,11 +601,14 @@ class TritonSemantic(Generic[TensorTy]):
             # For BC, we explicitly allow e.g. tl.full((), 0.0, tl.int32)
             # which raises a type error for non-zero values.
             value = 0
-        if dtype.is_fp8():
+        if dtype.name == "fp8e4b15":
             # Validate target support
             dtype.to_ir(self.builder)
             value = self.tensor(self.builder.get_fp32(value), tl.float32)
             return self.cast(value, dtype)
+        elif dtype.is_fp8():
+            value = self.builder.get_fp32(value)
+            value = self.builder.create_fp_trunc(value, dtype.to_ir(self.builder))
         else:
             get_value_fn = getattr(self.builder, f"get_{dtype.name}")
             value = get_value_fn(value)


### PR DESCRIPTION
In #11426 I changed the scalar_constant lowering to use the same logic as `cast`, which for fp8 dtypes lowers to `tt.fp_to_fp`. Apparently this op only has constant folding for zero, so we lost constant folding for other values.

To fix, I make the change more limited and only use cast for `fp8e4b15` which was otherwise problematic because it is represented in IR as an integer type so fp_trunc doesn't work.