### PR TITLE
[AMD][BACKEND Allow compact scales in scaled_upcast on CDNA4

### DIFF
--- a/test/TritonGPU/amd/amd-scaled-upcast-gfx1250.mlir
+++ b/test/TritonGPU/amd/amd-scaled-upcast-gfx1250.mlir
@@ -1,4 +1,5 @@
 // RUN: triton-opt %s -split-input-file --allocate-amdgpu-shared-memory --convert-triton-amdgpu-to-llvm="gfx-arch=gfx1250" --canonicalize --cse | FileCheck %s
+// RUN: triton-opt %s -split-input-file --allocate-amdgpu-shared-memory --convert-triton-amdgpu-to-llvm="gfx-arch=gfx950" --canonicalize --cse | FileCheck %s --check-prefix=CDNA4
 
 // -----
 
@@ -95,6 +96,21 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 1 : i32, ttg.targ
     // CHECK: rocdl.cvt.scale.pk8.bf16.fp4 {{.*}}, %[[SI1]][0] : vector<8xbf16>
     %up = amdg.scaled_upcast_fp4 %x scale %scale {axis = 1 : i32} : tensor<32x16xi8, #packed>, tensor<32x2xi8, #scale> -> tensor<32x32xbf16, #unpacked>
     tt.store %output, %up : tensor<32x32x!tt.ptr<bf16>, #unpacked>
+    tt.return
+  }
+}
+
+// -----
+
+#packed = #ttg.blocked<{sizePerThread = [1, 16], threadsPerWarp = [8, 8], warpsPerCTA = [1, 1], order = [1, 0]}>
+#unpacked = #ttg.blocked<{sizePerThread = [1, 32], threadsPerWarp = [8, 8], warpsPerCTA = [1, 1], order = [1, 0]}>
+#scale = #ttg.blocked<{sizePerThread = [1, 1], threadsPerWarp = [8, 8], warpsPerCTA = [1, 1], order = [1, 0]}>
+module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 1 : i32, ttg.target = "hip:gfx950", "ttg.threads-per-warp" = 64 : i32} {
+  // CDNA4-LABEL: llvm.func @cvt_scalef32_bf16_fp4_compact
+  // CDNA4: rocdl.cvt
+  tt.func public @cvt_scalef32_bf16_fp4_compact(%output: tensor<8x256x!tt.ptr<bf16>, #unpacked>, %x: tensor<8x128xi8, #packed>, %scale: tensor<8x8xi8, #scale>) {
+    %up = amdg.scaled_upcast_fp4 %x scale %scale {axis = 1 : i32} : tensor<8x128xi8, #packed>, tensor<8x8xi8, #scale> -> tensor<8x256xbf16, #unpacked>
+    tt.store %output, %up : tensor<8x256x!tt.ptr<bf16>, #unpacked>
     tt.return
   }
 }

--- a/test/TritonGPU/amd/amd-scaled-upcast-gfx1250.mlir
+++ b/test/TritonGPU/amd/amd-scaled-upcast-gfx1250.mlir
@@ -1,5 +1,4 @@
 // RUN: triton-opt %s -split-input-file --allocate-amdgpu-shared-memory --convert-triton-amdgpu-to-llvm="gfx-arch=gfx1250" --canonicalize --cse | FileCheck %s
-// RUN: triton-opt %s -split-input-file --allocate-amdgpu-shared-memory --convert-triton-amdgpu-to-llvm="gfx-arch=gfx950" --canonicalize --cse | FileCheck %s --check-prefix=CDNA4
 
 // -----
 
@@ -96,21 +95,6 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 1 : i32, ttg.targ
     // CHECK: rocdl.cvt.scale.pk8.bf16.fp4 {{.*}}, %[[SI1]][0] : vector<8xbf16>
     %up = amdg.scaled_upcast_fp4 %x scale %scale {axis = 1 : i32} : tensor<32x16xi8, #packed>, tensor<32x2xi8, #scale> -> tensor<32x32xbf16, #unpacked>
     tt.store %output, %up : tensor<32x32x!tt.ptr<bf16>, #unpacked>
-    tt.return
-  }
-}
-
-// -----
-
-#packed = #ttg.blocked<{sizePerThread = [1, 16], threadsPerWarp = [8, 8], warpsPerCTA = [1, 1], order = [1, 0]}>
-#unpacked = #ttg.blocked<{sizePerThread = [1, 32], threadsPerWarp = [8, 8], warpsPerCTA = [1, 1], order = [1, 0]}>
-#scale = #ttg.blocked<{sizePerThread = [1, 1], threadsPerWarp = [8, 8], warpsPerCTA = [1, 1], order = [1, 0]}>
-module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 1 : i32, ttg.target = "hip:gfx950", "ttg.threads-per-warp" = 64 : i32} {
-  // CDNA4-LABEL: llvm.func @cvt_scalef32_bf16_fp4_compact
-  // CDNA4: rocdl.cvt
-  tt.func public @cvt_scalef32_bf16_fp4_compact(%output: tensor<8x256x!tt.ptr<bf16>, #unpacked>, %x: tensor<8x128xi8, #packed>, %scale: tensor<8x8xi8, #scale>) {
-    %up = amdg.scaled_upcast_fp4 %x scale %scale {axis = 1 : i32} : tensor<8x128xi8, #packed>, tensor<8x8xi8, #scale> -> tensor<8x256xbf16, #unpacked>
-    tt.store %output, %up : tensor<8x256x!tt.ptr<bf16>, #unpacked>
     tt.return
   }
 }

--- a/test/TritonGPU/amd/amd-scaled-upcast-gfx950.mlir
+++ b/test/TritonGPU/amd/amd-scaled-upcast-gfx950.mlir
@@ -1,0 +1,14 @@
+// RUN: triton-opt %s -split-input-file --allocate-amdgpu-shared-memory --convert-triton-amdgpu-to-llvm="gfx-arch=gfx950" --canonicalize --cse | FileCheck %s
+
+#packed = #ttg.blocked<{sizePerThread = [1, 16], threadsPerWarp = [8, 8], warpsPerCTA = [1, 1], order = [1, 0]}>
+#unpacked = #ttg.blocked<{sizePerThread = [1, 32], threadsPerWarp = [8, 8], warpsPerCTA = [1, 1], order = [1, 0]}>
+#scale = #ttg.blocked<{sizePerThread = [1, 1], threadsPerWarp = [8, 8], warpsPerCTA = [1, 1], order = [1, 0]}>
+module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 1 : i32, ttg.target = "hip:gfx950", "ttg.threads-per-warp" = 64 : i32} {
+  // CHECK-LABEL: llvm.func @cvt_scalef32_bf16_fp4_compact
+  // CHECK: rocdl.cvt
+  tt.func public @cvt_scalef32_bf16_fp4_compact(%output: tensor<8x256x!tt.ptr<bf16>, #unpacked>, %x: tensor<8x128xi8, #packed>, %scale: tensor<8x8xi8, #scale>) {
+    %up = amdg.scaled_upcast_fp4 %x scale %scale {axis = 1 : i32} : tensor<8x128xi8, #packed>, tensor<8x8xi8, #scale> -> tensor<8x256xbf16, #unpacked>
+    tt.store %output, %up : tensor<8x256x!tt.ptr<bf16>, #unpacked>
+    tt.return
+  }
+}

--- a/test/TritonGPU/amd/amd-scaled-upcast-gfx950.mlir
+++ b/test/TritonGPU/amd/amd-scaled-upcast-gfx950.mlir
@@ -1,12 +1,93 @@
 // RUN: triton-opt %s -split-input-file --allocate-amdgpu-shared-memory --convert-triton-amdgpu-to-llvm="gfx-arch=gfx950" --canonicalize --cse | FileCheck %s
 
+#packed = #ttg.blocked<{sizePerThread = [1, 32], threadsPerWarp = [8, 8], warpsPerCTA = [1, 1], order = [1, 0]}>
+#unpacked = #ttg.blocked<{sizePerThread = [1, 64], threadsPerWarp = [8, 8], warpsPerCTA = [1, 1], order = [1, 0]}>
+#scale = #ttg.blocked<{sizePerThread = [1, 2], threadsPerWarp = [8, 8], warpsPerCTA = [1, 1], order = [1, 0]}>
+module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 1 : i32, ttg.target = "hip:gfx950", "ttg.threads-per-warp" = 64 : i32} {
+  // CHECK-LABEL: llvm.func @cvt_scalef32_bf16_fp4_compact_e8m0
+  tt.func public @cvt_scalef32_bf16_fp4_compact_e8m0(%output: tensor<8x512x!tt.ptr<bf16>, #unpacked>, %x: tensor<8x256xi8, #packed>, %scale: tensor<8x16xi8, #scale>) {
+    // A raw E8M0 payload is shifted into the f32 exponent by 23.
+    // CHECK-DAG: %[[C23:.+]] = llvm.mlir.constant(23 : i32) : i32
+    // The 8 pk groups a thread holds span 2 scale blocks: groups 0-3 (16
+    // intrinsics) take scale register 0, groups 4-7 take scale register 1.
+    // CHECK: %[[R0:.+]] = llvm.extractvalue %{{.+}}[0] : !llvm.struct<(i8, i8)>
+    // CHECK: %[[R1:.+]] = llvm.extractvalue %{{.+}}[1] : !llvm.struct<(i8, i8)>
+    // CHECK: %[[Z0:.+]] = llvm.zext %[[R0]] : i8 to i32
+    // CHECK: %[[H0:.+]] = llvm.shl %[[Z0]], %[[C23]] : i32
+    // CHECK: %[[S0:.+]] = llvm.bitcast %[[H0]] : i32 to f32
+    // CHECK-COUNT-16: rocdl.cvt.scalef32.pk.bf16.fp4 %{{.+}}, %[[S0]] : vector<2xbf16>
+    // CHECK: %[[Z1:.+]] = llvm.zext %[[R1]] : i8 to i32
+    // CHECK: %[[H1:.+]] = llvm.shl %[[Z1]], %[[C23]] : i32
+    // CHECK: %[[S1:.+]] = llvm.bitcast %[[H1]] : i32 to f32
+    // CHECK-COUNT-16: rocdl.cvt.scalef32.pk.bf16.fp4 %{{.+}}, %[[S1]] : vector<2xbf16>
+    // CHECK-NOT: rocdl.cvt.scalef32.pk.bf16.fp4
+    %up = amdg.scaled_upcast_fp4 %x scale %scale {axis = 1 : i32} : tensor<8x256xi8, #packed>, tensor<8x16xi8, #scale> -> tensor<8x512xbf16, #unpacked>
+    tt.store %output, %up : tensor<8x512x!tt.ptr<bf16>, #unpacked>
+    tt.return
+  }
+}
+
+// -----
+
+#packed = #ttg.blocked<{sizePerThread = [1, 32], threadsPerWarp = [8, 8], warpsPerCTA = [1, 1], order = [1, 0]}>
+#unpacked = #ttg.blocked<{sizePerThread = [1, 64], threadsPerWarp = [8, 8], warpsPerCTA = [1, 1], order = [1, 0]}>
+#scale = #ttg.blocked<{sizePerThread = [1, 2], threadsPerWarp = [8, 8], warpsPerCTA = [1, 1], order = [1, 0]}>
+module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 1 : i32, ttg.target = "hip:gfx950", "ttg.threads-per-warp" = 64 : i32} {
+  // CHECK-LABEL: llvm.func @cvt_scalef32_bf16_fp4_compact_bf16
+  tt.func public @cvt_scalef32_bf16_fp4_compact_bf16(%output: tensor<8x512x!tt.ptr<bf16>, #unpacked>, %x: tensor<8x256xi8, #packed>, %scale: tensor<8x16xbf16, #scale>) {
+    // A bf16 scale is pre-shifted by 7, so it only needs 16 more bits.
+    // CHECK-DAG: %[[C16:.+]] = llvm.mlir.constant(16 : i32) : i32
+    // CHECK: %[[R0:.+]] = llvm.extractvalue %{{.+}}[0] : !llvm.struct<(bf16, bf16)>
+    // CHECK: %[[R1:.+]] = llvm.extractvalue %{{.+}}[1] : !llvm.struct<(bf16, bf16)>
+    // CHECK: %[[B0:.+]] = llvm.bitcast %[[R0]] : bf16 to i16
+    // CHECK: %[[Z0:.+]] = llvm.zext %[[B0]] : i16 to i32
+    // CHECK: %[[H0:.+]] = llvm.shl %[[Z0]], %[[C16]] : i32
+    // CHECK: %[[S0:.+]] = llvm.bitcast %[[H0]] : i32 to f32
+    // CHECK-COUNT-16: rocdl.cvt.scalef32.pk.bf16.fp4 %{{.+}}, %[[S0]] : vector<2xbf16>
+    // CHECK: %[[B1:.+]] = llvm.bitcast %[[R1]] : bf16 to i16
+    // CHECK: %[[Z1:.+]] = llvm.zext %[[B1]] : i16 to i32
+    // CHECK: %[[H1:.+]] = llvm.shl %[[Z1]], %[[C16]] : i32
+    // CHECK: %[[S1:.+]] = llvm.bitcast %[[H1]] : i32 to f32
+    // CHECK-COUNT-16: rocdl.cvt.scalef32.pk.bf16.fp4 %{{.+}}, %[[S1]] : vector<2xbf16>
+    // CHECK-NOT: rocdl.cvt.scalef32.pk.bf16.fp4
+    %up = amdg.scaled_upcast_fp4 %x scale %scale {axis = 1 : i32} : tensor<8x256xi8, #packed>, tensor<8x16xbf16, #scale> -> tensor<8x512xbf16, #unpacked>
+    tt.store %output, %up : tensor<8x512x!tt.ptr<bf16>, #unpacked>
+    tt.return
+  }
+}
+
+// -----
+
+#packed = #ttg.blocked<{sizePerThread = [1, 32], threadsPerWarp = [8, 8], warpsPerCTA = [1, 1], order = [1, 0]}>
+#unpacked = #ttg.blocked<{sizePerThread = [1, 64], threadsPerWarp = [8, 8], warpsPerCTA = [1, 1], order = [1, 0]}>
+#scale = #ttg.blocked<{sizePerThread = [1, 2], threadsPerWarp = [8, 8], warpsPerCTA = [1, 1], order = [1, 0]}>
+module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 1 : i32, ttg.target = "hip:gfx950", "ttg.threads-per-warp" = 64 : i32} {
+  // CHECK-LABEL: llvm.func @cvt_scalef32_f16_fp4_compact
+  tt.func public @cvt_scalef32_f16_fp4_compact(%output: tensor<8x512x!tt.ptr<f16>, #unpacked>, %x: tensor<8x256xi8, #packed>, %scale: tensor<8x16xi8, #scale>) {
+    // CHECK: %[[S0:.+]] = llvm.bitcast %{{.+}} : i32 to f32
+    // CHECK-COUNT-16: rocdl.cvt.scalef32.pk.f16.fp4 %{{.+}}, %[[S0]] : vector<2xf16>
+    // CHECK: %[[S1:.+]] = llvm.bitcast %{{.+}} : i32 to f32
+    // CHECK-COUNT-16: rocdl.cvt.scalef32.pk.f16.fp4 %{{.+}}, %[[S1]] : vector<2xf16>
+    // CHECK-NOT: rocdl.cvt.scalef32.pk.f16.fp4
+    %up = amdg.scaled_upcast_fp4 %x scale %scale {axis = 1 : i32} : tensor<8x256xi8, #packed>, tensor<8x16xi8, #scale> -> tensor<8x512xf16, #unpacked>
+    tt.store %output, %up : tensor<8x512x!tt.ptr<f16>, #unpacked>
+    tt.return
+  }
+}
+
+// -----
+
 #packed = #ttg.blocked<{sizePerThread = [1, 16], threadsPerWarp = [8, 8], warpsPerCTA = [1, 1], order = [1, 0]}>
 #unpacked = #ttg.blocked<{sizePerThread = [1, 32], threadsPerWarp = [8, 8], warpsPerCTA = [1, 1], order = [1, 0]}>
 #scale = #ttg.blocked<{sizePerThread = [1, 1], threadsPerWarp = [8, 8], warpsPerCTA = [1, 1], order = [1, 0]}>
 module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 1 : i32, ttg.target = "hip:gfx950", "ttg.threads-per-warp" = 64 : i32} {
-  // CHECK-LABEL: llvm.func @cvt_scalef32_bf16_fp4_compact
-  // CHECK: rocdl.cvt
-  tt.func public @cvt_scalef32_bf16_fp4_compact(%output: tensor<8x256x!tt.ptr<bf16>, #unpacked>, %x: tensor<8x128xi8, #packed>, %scale: tensor<8x8xi8, #scale>) {
+  // CHECK-LABEL: llvm.func @cvt_scalef32_bf16_fp4_compact_single_reg
+  tt.func public @cvt_scalef32_bf16_fp4_compact_single_reg(%output: tensor<8x256x!tt.ptr<bf16>, #unpacked>, %x: tensor<8x128xi8, #packed>, %scale: tensor<8x8xi8, #scale>) {
+    // CHECK: %[[R0:.+]] = llvm.extractvalue %{{.+}}[0] : !llvm.struct<(i8)>
+    // CHECK: %[[Z0:.+]] = llvm.zext %[[R0]] : i8 to i32
+    // CHECK: %[[S0:.+]] = llvm.bitcast %{{.+}} : i32 to f32
+    // CHECK-COUNT-16: rocdl.cvt.scalef32.pk.bf16.fp4 %{{.+}}, %[[S0]] : vector<2xbf16>
+    // CHECK-NOT: rocdl.cvt.scalef32.pk.bf16.fp4
     %up = amdg.scaled_upcast_fp4 %x scale %scale {axis = 1 : i32} : tensor<8x128xi8, #packed>, tensor<8x8xi8, #scale> -> tensor<8x256xbf16, #unpacked>
     tt.store %output, %up : tensor<8x256x!tt.ptr<bf16>, #unpacked>
     tt.return

--- a/third_party/amd/lib/TritonAMDGPUDialectToLLVM/ScaledUpcastToLLVM.cpp
+++ b/third_party/amd/lib/TritonAMDGPUDialectToLLVM/ScaledUpcastToLLVM.cpp
@@ -2,6 +2,7 @@
 #include "TritonAMDGPUToLLVM/PatternTritonAMDGPUToLLVM.h"
 #include "mlir/Conversion/LLVMCommon/Pattern.h"
 #include "mlir/Dialect/LLVMIR/ROCDLDialect.h"
+#include "third_party/amd/include/Dialect/TritonAMDGPU/Utility/CommonUtils.h"
 #include "third_party/amd/lib/TritonAMDGPUToLLVM/Utility.h"
 #include "triton/Conversion/TritonGPUToLLVM/Utility.h"
 
@@ -37,22 +38,20 @@ SmallVector<int> computeFp4GroupScaleRegisters(amdgpu::ScaledUpcastFp4Op op,
   auto outToScaleLL = amdgpu::ScaledUpcastFp4Op::computeScaleLayout(
       outLL, axis, elementsPerScale);
   assert(outToScaleLL && "expected valid scale layout after verifier");
-  LinearLayout outRegToScaleReg = outToScaleLL->invertAndCompose(scaleLL);
+  scaleLL = scaleLL.removeZeroBasesAlongDim(kReg);
 
   // One intrinsic spans 8 fp4 values
   int64_t numGroups = (2 * numInputBytes) / 8;
   SmallVector<int> groupScaleReg;
   groupScaleReg.reserve(numGroups);
   for (int g = 0; g < numGroups; ++g) {
-    auto scaleCoord =
-        outRegToScaleReg.apply({{kReg, static_cast<int32_t>(8 * g)},
-                                {kLane, 0},
-                                {kWarp, 0},
-                                {kBlock, 0}});
-    auto regIt = llvm::find_if(
-        scaleCoord, [&](const auto &dimVal) { return dimVal.first == kReg; });
-    assert(regIt != scaleCoord.end() && "scale register mapping missing");
-    groupScaleReg.push_back(regIt->second);
+    auto scaleCoord = outToScaleLL->apply({{kReg, static_cast<int32_t>(8 * g)},
+                                           {kLane, 0},
+                                           {kWarp, 0},
+                                           {kBlock, 0}});
+    auto scaleReg = AMD::getRegFromCoordinates(scaleLL, scaleCoord, ctx);
+    assert(scaleReg && "scale register mapping missing");
+    groupScaleReg.push_back(*scaleReg);
   }
   return groupScaleReg;
 }
@@ -139,17 +138,19 @@ struct ScaledUpcastFp4OpPattern
         results.append(converted.begin(), converted.end());
       }
     } else if (targetInfo.supportsHwScaledUpcast()) {
-      assert(scaleVals.size() == 2 * inputVals.size() &&
-             "compact fp4 scales are only supported on pk scale path");
+      auto groupScaleReg =
+          computeFp4GroupScaleRegisters(upcastOp, inputVals.size());
+      bool useShiftedScale =
+          upcastOp.getScale().getType().getElementType().isBF16();
       for (int i = 0; i < inputVals.size(); i += 4) {
+        int scaleIdx = groupScaleReg[i / 4];
         SmallVector<Value, 4> v4i32 =
-            elemType.isF16()
-                ? upcast8xMxfp4_HW<ROCDL::CvtScaleF32PkF16Fp4Op>(
-                      rewriter, loc, inputVals, i, scaleVals[i * 2],
-                      /*useShiftedScale=*/true)
-                : upcast8xMxfp4_HW<ROCDL::CvtScaleF32PkBf16Fp4Op>(
-                      rewriter, loc, inputVals, i, scaleVals[i * 2],
-                      /*useShiftedScale=*/true);
+            elemType.isF16() ? upcast8xMxfp4_HW<ROCDL::CvtScaleF32PkF16Fp4Op>(
+                                   rewriter, loc, inputVals, i,
+                                   scaleVals[scaleIdx], useShiftedScale)
+                             : upcast8xMxfp4_HW<ROCDL::CvtScaleF32PkBf16Fp4Op>(
+                                   rewriter, loc, inputVals, i,
+                                   scaleVals[scaleIdx], useShiftedScale);
         for (int j = 0; j < 4; j++) {
           Value elements = b.bitcast(v4i32[j], vec_ty(elemType, 2));
           results.push_back(b.extract_element(elements, b.i32_val(0)));
@@ -157,8 +158,8 @@ struct ScaledUpcastFp4OpPattern
         }
       }
     } else {
-      assert(scaleVals.size() == 2 * inputVals.size() &&
-             "compact fp4 scales are only supported on pk scale path");
+      auto groupScaleReg =
+          computeFp4GroupScaleRegisters(upcastOp, inputVals.size());
       // Software emulation: upcast fp4 via LUT, then multiply by scale.
       bool toFp16 = elemType.isF16();
       auto isaFamily = targetInfo.getISAFamily();
@@ -173,7 +174,7 @@ struct ScaledUpcastFp4OpPattern
 
         // The bf16 scale was left-shifted by 7 (scaleTo16); shift by 16 more
         // to get f32.
-        Value scaleBf16 = scaleVals[i * 2];
+        Value scaleBf16 = scaleVals[groupScaleReg[i / 4]];
         Value scaleF32 = b.bitcast(
             b.shl(b.zext(i32_ty, b.bitcast(scaleBf16, i16_ty)), b.i32_val(16)),
             f32_ty);

--- a/third_party/amd/lib/TritonAMDGPUDialectToLLVM/ScaledUpcastToLLVM.cpp
+++ b/third_party/amd/lib/TritonAMDGPUDialectToLLVM/ScaledUpcastToLLVM.cpp
@@ -56,6 +56,29 @@ SmallVector<int> computeFp4GroupScaleRegisters(amdgpu::ScaledUpcastFp4Op op,
   return groupScaleReg;
 }
 
+bool scaleIsPreShifted(RankedTensorType scaleTy) {
+  return scaleTy.getElementType().isBF16();
+}
+
+LogicalResult checkPk8ScaleType(Operation *op, RankedTensorType scaleTy) {
+  Type elemTy = scaleTy.getElementType();
+  if (elemTy.isInteger(8))
+    return success();
+  return op->emitOpError("v_cvt_scale_pk8 lowering requires a raw E8M0 scale "
+                         "in i8, but got ")
+         << elemTy;
+}
+
+// Materialize an E8M0 scale register as the f32 value 2^scale.
+Value scaleToF32(RewriterBase &rewriter, Location loc, Value scale,
+                 bool preShifted) {
+  auto b = TritonLLVMOpBuilder(loc, rewriter);
+  if (preShifted)
+    return b.bitcast(
+        b.shl(b.zext(i32_ty, b.bitcast(scale, i16_ty)), b.i32_val(16)), f32_ty);
+  return b.bitcast(b.shl(b.zext(i32_ty, scale), b.i32_val(23)), f32_ty);
+}
+
 // Returns true if the scale layout gives lane `j` and lane `j^16` the same
 // scale value (i.e. the lane basis for the value-16 bit is all zeros). In that
 // case both output-lane halves of a v_cvt_scale_pk8 already share a scale.
@@ -95,9 +118,13 @@ struct ScaledUpcastFp4OpPattern
     results.reserve(inputVals.size() * 2);
 
     auto b = TritonLLVMOpBuilder(loc, rewriter);
+    bool preShifted = scaleIsPreShifted(upcastOp.getScale().getType());
+    auto groupScaleReg =
+        computeFp4GroupScaleRegisters(upcastOp, inputVals.size());
+
     if (targetInfo.supportsCvtPkScalePk8()) {
-      auto groupScaleReg =
-          computeFp4GroupScaleRegisters(upcastOp, inputVals.size());
+      if (failed(checkPk8ScaleType(upcastOp, upcastOp.getScale().getType())))
+        return failure();
 
       // FP4/FP6 v_cvt_scale_pk8 with opSel=0 sources the scale for output
       // lanes 16..31 from byte 1 of the *lower* 16 lanes' Vscale while output
@@ -138,19 +165,15 @@ struct ScaledUpcastFp4OpPattern
         results.append(converted.begin(), converted.end());
       }
     } else if (targetInfo.supportsHwScaledUpcast()) {
-      auto groupScaleReg =
-          computeFp4GroupScaleRegisters(upcastOp, inputVals.size());
-      bool useShiftedScale =
-          upcastOp.getScale().getType().getElementType().isBF16();
       for (int i = 0; i < inputVals.size(); i += 4) {
         int scaleIdx = groupScaleReg[i / 4];
         SmallVector<Value, 4> v4i32 =
             elemType.isF16() ? upcast8xMxfp4_HW<ROCDL::CvtScaleF32PkF16Fp4Op>(
                                    rewriter, loc, inputVals, i,
-                                   scaleVals[scaleIdx], useShiftedScale)
+                                   scaleVals[scaleIdx], preShifted)
                              : upcast8xMxfp4_HW<ROCDL::CvtScaleF32PkBf16Fp4Op>(
                                    rewriter, loc, inputVals, i,
-                                   scaleVals[scaleIdx], useShiftedScale);
+                                   scaleVals[scaleIdx], preShifted);
         for (int j = 0; j < 4; j++) {
           Value elements = b.bitcast(v4i32[j], vec_ty(elemType, 2));
           results.push_back(b.extract_element(elements, b.i32_val(0)));
@@ -158,11 +181,6 @@ struct ScaledUpcastFp4OpPattern
         }
       }
     } else {
-      if (!upcastOp.getScale().getType().getElementType().isBF16())
-        return upcastOp.emitOpError("software lowering requires a BF16 scale");
-
-      auto groupScaleReg =
-          computeFp4GroupScaleRegisters(upcastOp, inputVals.size());
       // Software emulation: upcast fp4 via LUT, then multiply by scale.
       bool toFp16 = elemType.isF16();
       auto isaFamily = targetInfo.getISAFamily();
@@ -175,12 +193,8 @@ struct ScaledUpcastFp4OpPattern
         SmallVector<Value> v8vals =
             upcast8xMxfp4_SW(rewriter, upcastOp, toFp16, packedVec, isaFamily);
 
-        // The bf16 scale was left-shifted by 7 (scaleTo16); shift by 16 more
-        // to get f32.
-        Value scaleBf16 = scaleVals[groupScaleReg[i / 4]];
-        Value scaleF32 = b.bitcast(
-            b.shl(b.zext(i32_ty, b.bitcast(scaleBf16, i16_ty)), b.i32_val(16)),
-            f32_ty);
+        Value scaleF32 = scaleToF32(
+            rewriter, loc, scaleVals[groupScaleReg[i / 4]], preShifted);
 
         for (int j : llvm::seq(8)) {
           Value vF32;
@@ -237,9 +251,13 @@ struct ScaledUpcastFp8OpPattern
     assert(inputVals.size() == scaleVals.size());
 
     auto b = TritonLLVMOpBuilder(loc, rewriter);
+    bool preShifted = scaleIsPreShifted(upcastOp.getScale().getType());
     SmallVector<Value> results;
     results.reserve(inputVals.size());
     if (targetInfo.supportsCvtPkScalePk8()) {
+      if (failed(checkPk8ScaleType(upcastOp, upcastOp.getScale().getType())))
+        return failure();
+
       // Broadcast layouts can use FP8 Block32 (opSel=0). Otherwise use Block16
       // (opSel=8) and pack lane j^16's scale into byte 1.
       bool broadcast = isScaleLane16Broadcast(upcastOp.getScale().getType());
@@ -282,17 +300,17 @@ struct ScaledUpcastFp8OpPattern
                 ? (isa<Float8E4M3FNType>(fp8ElemType)
                        ? upcast4xMxfp8_HW<ROCDL::CvtScaleF32PkF16Fp8Op>(
                              rewriter, loc, inputVals, i, scaleVals[i],
-                             /*useShiftedScale=*/true)
+                             preShifted)
                        : upcast4xMxfp8_HW<ROCDL::CvtScaleF32PkF16Bf8Op>(
                              rewriter, loc, inputVals, i, scaleVals[i],
-                             /*useShiftedScale=*/true))
+                             preShifted))
                 : (isa<Float8E4M3FNType>(fp8ElemType)
                        ? upcast4xMxfp8_HW<ROCDL::CvtScaleF32PkBf16Fp8Op>(
                              rewriter, loc, inputVals, i, scaleVals[i],
-                             /*useShiftedScale=*/true)
+                             preShifted)
                        : upcast4xMxfp8_HW<ROCDL::CvtScaleF32PkBf16Bf8Op>(
                              rewriter, loc, inputVals, i, scaleVals[i],
-                             /*useShiftedScale=*/true));
+                             preShifted));
         for (int j = 0; j < 2; j++) {
           Value elements = b.bitcast(v2i32[j], vec_ty(elemType, 2));
           results.push_back(b.extract_element(elements, b.i32_val(0)));
@@ -304,12 +322,7 @@ struct ScaledUpcastFp8OpPattern
       bool isE4M3FN = isa<Float8E4M3FNType>(fp8ElemType);
       bool toFp16 = elemType.isF16();
       for (size_t i = 0; i < inputVals.size(); i += 4) {
-        // The bf16 scale was left-shifted by 7 (scaleTo16); shift by 16 more
-        // to get f32.
-        Value scaleBf16 = scaleVals[i];
-        Value scaleF32 = b.bitcast(
-            b.shl(b.zext(i32_ty, b.bitcast(scaleBf16, i16_ty)), b.i32_val(16)),
-            f32_ty);
+        Value scaleF32 = scaleToF32(rewriter, loc, scaleVals[i], preShifted);
 
         for (int j : llvm::seq(4)) {
           Value f32Val =

--- a/third_party/amd/lib/TritonAMDGPUDialectToLLVM/ScaledUpcastToLLVM.cpp
+++ b/third_party/amd/lib/TritonAMDGPUDialectToLLVM/ScaledUpcastToLLVM.cpp
@@ -158,6 +158,9 @@ struct ScaledUpcastFp4OpPattern
         }
       }
     } else {
+      if (!upcastOp.getScale().getType().getElementType().isBF16())
+        return upcastOp.emitOpError("software lowering requires a BF16 scale");
+
       auto groupScaleReg =
           computeFp4GroupScaleRegisters(upcastOp, inputVals.size());
       // Software emulation: upcast fp4 via LUT, then multiply by scale.

--- a/third_party/amd/python/test/test_gluon_scaled_upcast.py
+++ b/third_party/amd/python/test/test_gluon_scaled_upcast.py
@@ -9,18 +9,20 @@ IS_CDNA3_OR_CDNA4 = is_hip_cdna3() or is_hip_cdna4()
 
 
 @gluon.jit
-def _compact_scaled_upcast_fp4_kernel(x_ptr, scale_ptr, out_ptr, USE_CDNA4: ttgl.constexpr):
-    packed_layout: ttgl.constexpr = ttgl.BlockedLayout([1, 16], [8, 8], [1, 1], [1, 0])
-    compact_scale_layout: ttgl.constexpr = ttgl.BlockedLayout([1, 1], [8, 8], [1, 1], [1, 0])
+def _compact_scaled_upcast_fp4_kernel(x_ptr, scale_ptr, out_ptr, M: ttgl.constexpr, K_PACKED: ttgl.constexpr,
+                                      OUT_K: ttgl.constexpr, SCALE_K: ttgl.constexpr, SPT_PACKED: ttgl.constexpr,
+                                      SPT_SCALE: ttgl.constexpr, USE_CDNA4: ttgl.constexpr):
+    packed_layout: ttgl.constexpr = ttgl.BlockedLayout([1, SPT_PACKED], [8, 8], [1, 1], [1, 0])
+    compact_scale_layout: ttgl.constexpr = ttgl.BlockedLayout([1, SPT_SCALE], [8, 8], [1, 1], [1, 0])
 
-    offs_m = ttgl.arange(0, 8, layout=ttgl.SliceLayout(1, packed_layout))
-    offs_k_packed = ttgl.arange(0, 128, layout=ttgl.SliceLayout(0, packed_layout))
-    x_offsets = offs_m[:, None] * 128 + offs_k_packed[None, :]
+    offs_m = ttgl.arange(0, M, layout=ttgl.SliceLayout(1, packed_layout))
+    offs_k_packed = ttgl.arange(0, K_PACKED, layout=ttgl.SliceLayout(0, packed_layout))
+    x_offsets = offs_m[:, None] * K_PACKED + offs_k_packed[None, :]
     x = ttgl.load(x_ptr + x_offsets)
 
-    offs_scale_m = ttgl.arange(0, 8, layout=ttgl.SliceLayout(1, compact_scale_layout))
-    offs_scale_k = ttgl.arange(0, 8, layout=ttgl.SliceLayout(0, compact_scale_layout))
-    scale_offsets = offs_scale_m[:, None] * 8 + offs_scale_k[None, :]
+    offs_scale_m = ttgl.arange(0, M, layout=ttgl.SliceLayout(1, compact_scale_layout))
+    offs_scale_k = ttgl.arange(0, SCALE_K, layout=ttgl.SliceLayout(0, compact_scale_layout))
+    scale_offsets = offs_scale_m[:, None] * SCALE_K + offs_scale_k[None, :]
     scale = ttgl.load(scale_ptr + scale_offsets)
 
     if USE_CDNA4:
@@ -29,26 +31,33 @@ def _compact_scaled_upcast_fp4_kernel(x_ptr, scale_ptr, out_ptr, USE_CDNA4: ttgl
         out = ttgl.amd.cdna3.scaled_upcast(x, scale, ttgl.bfloat16, axis=1)
 
     out_layout: ttgl.constexpr = out.type.layout
-    offs_out_m = ttgl.arange(0, 8, layout=ttgl.SliceLayout(1, out_layout))
-    offs_out_k = ttgl.arange(0, 256, layout=ttgl.SliceLayout(0, out_layout))
-    out_offsets = offs_out_m[:, None] * 256 + offs_out_k[None, :]
+    offs_out_m = ttgl.arange(0, M, layout=ttgl.SliceLayout(1, out_layout))
+    offs_out_k = ttgl.arange(0, OUT_K, layout=ttgl.SliceLayout(0, out_layout))
+    out_offsets = offs_out_m[:, None] * OUT_K + offs_out_k[None, :]
     ttgl.store(out_ptr + out_offsets, out)
 
 
 @pytest.mark.skipif(not IS_CDNA3_OR_CDNA4, reason="Requires CDNA3 or CDNA4")
-def test_runtime_scaled_upcast_fp4_compact_scale():
+@pytest.mark.parametrize("k_packed, scale_k, spt_packed, spt_scale", [(128, 8, 16, 1), (256, 16, 32, 2)],
+                         ids=["one_scale_register", "two_scale_registers"])
+def test_runtime_scaled_upcast_fp4_compact_scale(k_packed, scale_k, spt_packed, spt_scale):
+    M = 8
+    out_k = 2 * k_packed
+    elements_per_scale = out_k // scale_k
+
     # Packed 0x1 E2M1 values are 0.5. Use a different E8M0 exponent for
     # every compact scale block to exercise the scale-register mapping.
-    x = torch.full((8, 128), 0x11, dtype=torch.uint8, device="cuda")
-    scale_exponents = torch.arange(64, device="cuda").reshape(8, 8) % 7 - 3
+    x = torch.full((M, k_packed), 0x11, dtype=torch.uint8, device="cuda")
+    scale_exponents = torch.arange(M * scale_k, device="cuda").reshape(M, scale_k) % 7 - 3
     scale = (scale_exponents + 0x7f).to(torch.uint8)
-    out = torch.empty((8, 256), dtype=torch.bfloat16, device="cuda")
+    out = torch.empty((M, out_k), dtype=torch.bfloat16, device="cuda")
 
     use_cdna4 = is_hip_cdna4()
-    program = _compact_scaled_upcast_fp4_kernel[(1, )](x, scale, out, use_cdna4, num_warps=1)
+    program = _compact_scaled_upcast_fp4_kernel[(1, )](x, scale, out, M, k_packed, out_k, scale_k, spt_packed,
+                                                       spt_scale, use_cdna4, num_warps=1)
 
     expected = torch.ldexp(torch.full_like(scale_exponents, 0.5, dtype=torch.float32),
-                           scale_exponents).repeat_interleave(32, dim=1).to(torch.bfloat16)
+                           scale_exponents).repeat_interleave(elements_per_scale, dim=1).to(torch.bfloat16)
     torch.testing.assert_close(out, expected, rtol=0, atol=0)
     if use_cdna4:
         assert "v_cvt_scalef32_pk_bf16_fp4" in program.asm["amdgcn"]

--- a/third_party/amd/python/test/test_gluon_scaled_upcast.py
+++ b/third_party/amd/python/test/test_gluon_scaled_upcast.py
@@ -1,0 +1,56 @@
+import pytest
+import torch
+
+from triton._internal_testing import is_hip_cdna3, is_hip_cdna4
+from triton.experimental import gluon
+import triton.experimental.gluon.language as ttgl
+
+IS_CDNA3_OR_CDNA4 = is_hip_cdna3() or is_hip_cdna4()
+
+
+@gluon.jit
+def _compact_scaled_upcast_fp4_kernel(x_ptr, scale_ptr, out_ptr, USE_CDNA4: ttgl.constexpr):
+    packed_layout: ttgl.constexpr = ttgl.BlockedLayout([1, 16], [8, 8], [1, 1], [1, 0])
+    compact_scale_layout: ttgl.constexpr = ttgl.BlockedLayout([1, 1], [8, 8], [1, 1], [1, 0])
+
+    offs_m = ttgl.arange(0, 8, layout=ttgl.SliceLayout(1, packed_layout))
+    offs_k_packed = ttgl.arange(0, 128, layout=ttgl.SliceLayout(0, packed_layout))
+    x_offsets = offs_m[:, None] * 128 + offs_k_packed[None, :]
+    x = ttgl.load(x_ptr + x_offsets)
+
+    offs_scale_m = ttgl.arange(0, 8, layout=ttgl.SliceLayout(1, compact_scale_layout))
+    offs_scale_k = ttgl.arange(0, 8, layout=ttgl.SliceLayout(0, compact_scale_layout))
+    scale_offsets = offs_scale_m[:, None] * 8 + offs_scale_k[None, :]
+    scale = ttgl.load(scale_ptr + scale_offsets)
+
+    if USE_CDNA4:
+        out = ttgl.amd.cdna4.scaled_upcast(x, scale, ttgl.bfloat16, axis=1)
+    else:
+        out = ttgl.amd.cdna3.scaled_upcast(x, scale, ttgl.bfloat16, axis=1)
+
+    out_layout: ttgl.constexpr = out.type.layout
+    offs_out_m = ttgl.arange(0, 8, layout=ttgl.SliceLayout(1, out_layout))
+    offs_out_k = ttgl.arange(0, 256, layout=ttgl.SliceLayout(0, out_layout))
+    out_offsets = offs_out_m[:, None] * 256 + offs_out_k[None, :]
+    ttgl.store(out_ptr + out_offsets, out)
+
+
+@pytest.mark.skipif(not IS_CDNA3_OR_CDNA4, reason="Requires CDNA3 or CDNA4")
+def test_runtime_scaled_upcast_fp4_compact_scale():
+    # Packed 0x1 E2M1 values are 0.5. Use a different E8M0 exponent for
+    # every compact scale block to exercise the scale-register mapping.
+    x = torch.full((8, 128), 0x11, dtype=torch.uint8, device="cuda")
+    scale_exponents = torch.arange(64, device="cuda").reshape(8, 8) % 7 - 3
+    scale = (scale_exponents + 0x7f).to(torch.uint8)
+    out = torch.empty((8, 256), dtype=torch.bfloat16, device="cuda")
+
+    use_cdna4 = is_hip_cdna4()
+    program = _compact_scaled_upcast_fp4_kernel[(1, )](x, scale, out, use_cdna4, num_warps=1)
+
+    expected = torch.ldexp(torch.full_like(scale_exponents, 0.5, dtype=torch.float32),
+                           scale_exponents).repeat_interleave(32, dim=1).to(torch.bfloat16)
+    torch.testing.assert_close(out, expected, rtol=0, atol=0)
+    if use_cdna4:
+        assert "v_cvt_scalef32_pk_bf16_fp4" in program.asm["amdgcn"]
+    else:
+        assert "v_cvt_scalef32_pk_bf16_fp4" not in program.asm["amdgcn"]


### PR DESCRIPTION
Similar to
- https://github.com/triton-lang/triton/pull/10979

this PR adds support for compact scales on gfx950. This means the scale tensor does not need to be reshaped which allows for more efficient codegen.
This also surfaced an issue in the scale to intrinsic mapping, where we did not correctly ignore zero bases in register dimension and hence indexed out of bounds when accessing the LLVM values for the passed in scales (which are unique values).