### PR TITLE
[AMD][GLUON][BACKEND] Fix and simplify CGA layout handling of scaled_dot scales

### DIFF
--- a/include/triton/Dialect/Triton/IR/Dialect.h
+++ b/include/triton/Dialect/Triton/IR/Dialect.h
@@ -92,6 +92,15 @@ public:
   verifyDotOpEncodingCompatibility(Operation *op, Attribute operandEncodingA,
                                    Attribute operandEncodingB) const = 0;
 
+  // Verify that the operand and scale encodings are compatible to be used
+  // together in a scaled dot operation. The scale encodings may be null, as
+  // scales are optional.
+  virtual LogicalResult verifyDotScaledOpEncodingCompatibility(
+      Operation *op, Attribute operandEncodingA, Attribute operandEncodingB,
+      Attribute scaleEncodingA, Attribute scaleEncodingB) const {
+    return success();
+  }
+
   virtual LogicalResult
   inferFp4ToFpOpEncoding(ArrayRef<int64_t> shape, int axis, Attribute inEnc,
                          Attribute &outEnc, bool fwdInference,

--- a/include/triton/Dialect/TritonGPU/IR/Dialect.h
+++ b/include/triton/Dialect/TritonGPU/IR/Dialect.h
@@ -289,6 +289,16 @@ void printCGAAttr(AsmPrinter &printer, CGAEncodingAttr layout);
 
 CGAEncodingAttr getCGALayout(Attribute layout);
 
+// Projects the CGA layout of a dot accumulator onto operand `opIdx`.
+CGAEncodingAttr inferDotOperandCGALayout(CGAEncodingAttr accCGALayout,
+                                         int opIdx);
+
+// Derives the CGA layout of the scale for dot operand `opIdx`. For operand A,
+// the scale shares the same CGA layout. For operand B, the last two dimensions
+// are swapped.
+CGAEncodingAttr
+inferDotScaleCGALayoutFromOperand(CGAEncodingAttr operandCGALayout, int opIdx);
+
 SmallVector<unsigned> getCTAsPerCGA(Attribute layout);
 
 SmallVector<unsigned> getCTASplitNum(Attribute layout);

--- a/include/triton/Dialect/TritonGPU/IR/LinearLayoutConversions.h
+++ b/include/triton/Dialect/TritonGPU/IR/LinearLayoutConversions.h
@@ -140,6 +140,9 @@ LinearLayout chooseScaledMfmaScaleLayout(MLIRContext *ctx, int dotOperandIdx,
                                          ArrayRef<unsigned> tilesPerWarp,
                                          ArrayRef<unsigned> warpsPerCTA);
 
+// Create LinearLayout for scale in scaled wmma. `ctaLayout` and `cgaLayout`
+// describe the dot operand itself, i.e. they are given in the operand's
+// dimension order (will be transposed for scale b)
 LinearLayout chooseScaledWmmaScaleLayout(
     MLIRContext *ctx, int dotOperandIdx, ArrayRef<int64_t> dotOperandShape,
     unsigned wmmaMDim, unsigned wmmaNDim, bool isTransposed,

--- a/lib/Dialect/Triton/IR/Ops.cpp
+++ b/lib/Dialect/Triton/IR/Ops.cpp
@@ -373,7 +373,18 @@ LogicalResult DotScaledOp::verify() {
       return this->emitError("scales K dimension must match the operand K "
                              "divided by the scale factor");
   }
-  return success();
+
+  auto retEnc = getC().getType().getEncoding();
+  if (!retEnc)
+    return success();
+  auto scaleEncoding = [](TypedValue<RankedTensorType> scale) -> Attribute {
+    return scale ? scale.getType().getEncoding() : Attribute();
+  };
+  auto interface = cast<DialectInferLayoutInterface>(&retEnc.getDialect());
+  return interface->verifyDotScaledOpEncodingCompatibility(
+      getOperation(), getA().getType().getEncoding(),
+      getB().getType().getEncoding(), scaleEncoding(getAScale()),
+      scaleEncoding(getBScale()));
 }
 
 LogicalResult deduceScaleFactor(ArrayRef<int64_t> lhsShape,

--- a/lib/Dialect/TritonGPU/IR/Dialect.cpp
+++ b/lib/Dialect/TritonGPU/IR/Dialect.cpp
@@ -374,6 +374,57 @@ CGAEncodingAttr getCGALayout(Attribute layout) {
   llvm_unreachable("Unimplemented usage of getCGALayout");
 }
 
+CGAEncodingAttr inferDotOperandCGALayout(CGAEncodingAttr accCGALayout,
+                                         int opIdx) {
+  assert((opIdx == 0 || opIdx == 1) && "unknown dot operand index");
+  const auto &layout = accCGALayout.getLinearLayout();
+  auto rank = layout.getNumOutDims();
+  // Operand A does not carry N and operand B does not carry M.
+  auto broadcastDim = opIdx == 0 ? rank - 1 : rank - 2;
+  auto dims = layout.getOutDims();
+  return CGAEncodingAttr::get(accCGALayout.getContext(),
+                              layout.resizeOutDim(dims[broadcastDim].first, 1));
+}
+
+CGAEncodingAttr
+inferDotScaleCGALayoutFromOperand(CGAEncodingAttr operandCGALayout, int opIdx) {
+  assert((opIdx == 0 || opIdx == 1) && "unknown dot operand index");
+  if (opIdx == 0)
+    return operandCGALayout;
+
+  auto rank = operandCGALayout.getRank();
+  auto order = to_vector(llvm::seq<int>(rank));
+  std::swap(order[rank - 2], order[rank - 1]);
+  auto layout =
+      transposeLinearLayout(operandCGALayout.getLinearLayout(), order);
+  return CGAEncodingAttr::get(operandCGALayout.getContext(), std::move(layout));
+}
+
+static bool isDotOperandCGALayoutCompatible(CGAEncodingAttr expected,
+                                            CGAEncodingAttr actual) {
+  auto expectedLayout = expected.getLinearLayout();
+  const auto &actualLayout = actual.getLinearLayout();
+  auto expectedDims = expectedLayout.getOutDims();
+  auto actualDims = actualLayout.getOutDims();
+  if (expectedDims.size() != actualDims.size())
+    return false;
+
+  // A batched dot may explicitly broadcast an operand across a subset of the
+  // batch CTAs. Permit that by shrinking only leading batch dimensions in the
+  // expected layout. The trailing M/N dimensions must still match exactly.
+  int rank = expectedDims.size();
+  for (int dimIdx = 0; dimIdx < rank - 2; ++dimIdx) {
+    auto expectedDim = expectedDims[dimIdx].first;
+    if (expectedDim != actualDims[dimIdx].first)
+      return false;
+    int actualSize = actualLayout.getOutDimSize(expectedDim);
+    if (actualSize > expectedLayout.getOutDimSize(expectedDim))
+      return false;
+    expectedLayout = expectedLayout.resizeOutDim(expectedDim, actualSize);
+  }
+  return actualLayout == expectedLayout;
+}
+
 static LinearEncodingAttr
 getSlicedLinearEncoding(SliceEncodingAttr sliceLayout) {
   SmallVector<unsigned> slices = {sliceLayout.getDim()};
@@ -2874,12 +2925,7 @@ SmallVector<unsigned> DotOperandEncodingAttr::getRepOrder() const {
 }
 
 CGAEncodingAttr DotOperandEncodingAttr::getCGALayout() const {
-  const auto &layout = ::getCGALayout(getParent()).getLinearLayout();
-  auto rank = layout.getNumOutDims();
-  auto kDim = getOpIdx() == 0 ? rank - 1 : rank - 2;
-  auto dims = layout.getOutDims();
-  return CGAEncodingAttr::get(getContext(),
-                              layout.resizeOutDim(dims[kDim].first, 1));
+  return inferDotOperandCGALayout(::getCGALayout(getParent()), getOpIdx());
 }
 LogicalResult DotOperandEncodingAttr::verify(
     function_ref<::mlir::InFlightDiagnostic()> emitError, unsigned opIdx,
@@ -3235,31 +3281,62 @@ struct TritonGPUInferLayoutInterface
         return op->emitError("unsupported MMA version");
     }
 
-    // For AMDWmmaEncodingAttr verify multi-cta CGA layout compatibility
+    return verifyWmmaCGACompatibility(op, aEncoding, bEncoding,
+                                      /*scaleEncodingA=*/{},
+                                      /*scaleEncodingB=*/{}, resEnc);
+  }
+
+  LogicalResult verifyDotScaledOpEncodingCompatibility(
+      Operation *op, Attribute operandEncodingA, Attribute operandEncodingB,
+      Attribute scaleEncodingA, Attribute scaleEncodingB) const override {
+    auto aEncoding = dyn_cast<DotOperandEncodingAttr>(operandEncodingA);
+    auto bEncoding = dyn_cast<DotOperandEncodingAttr>(operandEncodingB);
+    if (!aEncoding || !bEncoding)
+      return success();
+    auto resEnc =
+        cast<RankedTensorType>(cast<DotOpInterface>(op).getD().getType())
+            .getEncoding();
+    return verifyWmmaCGACompatibility(op, aEncoding, bEncoding, scaleEncodingA,
+                                      scaleEncodingB, resEnc);
+  }
+
+  // For AMDWmmaEncodingAttr verify multi-cta CGA layout compatibility. The
+  // scale encodings are optional and only present for scaled dots.
+  LogicalResult verifyWmmaCGACompatibility(Operation *op,
+                                           DotOperandEncodingAttr aEncoding,
+                                           DotOperandEncodingAttr bEncoding,
+                                           Attribute scaleEncodingA,
+                                           Attribute scaleEncodingB,
+                                           Attribute resEnc) const {
     auto wmmaAParentEnc = dyn_cast<AMDWmmaEncodingAttr>(aEncoding.getParent());
     auto wmmaBParentEnc = dyn_cast<AMDWmmaEncodingAttr>(bEncoding.getParent());
     auto wmmaResEncoding = dyn_cast<AMDWmmaEncodingAttr>(resEnc);
-    if (wmmaAParentEnc && wmmaBParentEnc && wmmaResEncoding) {
-      auto resLL = wmmaResEncoding.getCGALayout().getLinearLayout();
+    if (!wmmaAParentEnc || !wmmaBParentEnc || !wmmaResEncoding)
+      return success();
 
-      if (!resLL.isInvertible())
-        return op->emitError("Accumulator CGA layout should not broadcast or "
-                             "have repeated rows");
+    auto accCGALayout = wmmaResEncoding.getCGALayout();
+    if (!accCGALayout.getLinearLayout().isInvertible())
+      return op->emitError("Accumulator CGA layout should not broadcast or "
+                           "have repeated rows");
 
-      auto aLL = aEncoding.getCGALayout().getLinearLayout();
-      auto bLL = bEncoding.getCGALayout().getLinearLayout();
-      // A broadcasts over N, B over M (the trailing two result dims). Batch
-      // dims (rank > 2) are shared across A/B/result, not broadcast.
-      auto ctx = op->getContext();
-      int rank = cast<RankedTensorType>(dotOp.getD().getType()).getRank();
-      auto mDim = StringAttr::get(ctx, "dim" + std::to_string(rank - 2));
-      auto nDim = StringAttr::get(ctx, "dim" + std::to_string(rank - 1));
-      // resizeOutDim(d, 1) makes d broadcast-only.
-      if (aLL != resLL.resizeOutDim(nDim, 1))
-        return op->emitError("Incompatible CGA layout for operand 0");
+    // A is multicast over N and B over M. Leading batch dimensions may also
+    // broadcast when the same operand is intentionally reused by multiple CTAs.
+    for (int opIdx : {0, 1}) {
+      auto expectedOperandCGALayout =
+          inferDotOperandCGALayout(accCGALayout, opIdx);
+      auto encoding = opIdx == 0 ? aEncoding : bEncoding;
+      auto operandCGALayout = encoding.getCGALayout();
+      if (!isDotOperandCGALayoutCompatible(expectedOperandCGALayout,
+                                           operandCGALayout))
+        return op->emitError("Incompatible CGA layout for operand ") << opIdx;
 
-      if (bLL != resLL.resizeOutDim(mDim, 1))
-        return op->emitError("Incompatible CGA layout for operand 1");
+      auto scaleEncoding = opIdx == 0 ? scaleEncodingA : scaleEncodingB;
+      if (scaleEncoding &&
+          getCGALayout(scaleEncoding) !=
+              inferDotScaleCGALayoutFromOperand(operandCGALayout, opIdx))
+        return op->emitError(
+                   "Incompatible CGA layout for the scale of operand ")
+               << opIdx;
     }
     return success();
   }

--- a/lib/Dialect/TritonGPU/IR/LinearLayoutConversions.cpp
+++ b/lib/Dialect/TritonGPU/IR/LinearLayoutConversions.cpp
@@ -1475,14 +1475,15 @@ LinearLayout chooseScaledWmmaScaleLayout(
   }
 
   if (dotOperandIdx == 1) {
-    // ctaLayout comes from the dot operand. For B in scaled dot,
+    // ctaLayout and cgaLayout come from the dot operand. For B in scaled dot,
     // - the operand is ordered as [K, N]
     // - the scale is ordered as [N, K / 32 or 16].
-    // Swap the last two dims of ctaLayout to match the tileLayout
+    // Swap the last two dims of both to match the tileLayout
     SmallVector<int32_t> order = {1, 0};
     if (hasBatchDim)
       order = {0, 2, 1};
     ctaLayout = transposeLinearLayout(ctaLayout, order);
+    cgaLayout = inferDotScaleCGALayoutFromOperand(cgaLayout, dotOperandIdx);
   }
 
   // Zero out M or N dim based on opIdx

--- a/python/test/gluon/test_frontend.py
+++ b/python/test/gluon/test_frontend.py
@@ -4159,7 +4159,7 @@ def test_amd_wmma_scale_layout_for_multicta(target):
         a_layout: ttgl.constexpr = ttgl.DotOperandLayout(
             operand_index=0,  #
             parent=ttgl.amd.AMDWMMALayout(version=3, transposed=True, warp_bases=[[0, 1], [1, 0]],
-                                          instr_shape=[16, 16, 64], cga_layout=[[0, 0], [1, 0]]),  #
+                                          instr_shape=[16, 16, 64], cga_layout=[[0, 1], [1, 0]]),  #
             k_width=16)
         a_scale_layout: ttgl.constexpr = ttgl.amd.cdna5.get_wmma_scale_layout(a_layout, [64, 4])
         ttgl.full([64, 4], 0x02, ttgl.uint8, a_scale_layout)
@@ -4167,7 +4167,7 @@ def test_amd_wmma_scale_layout_for_multicta(target):
         b_layout: ttgl.constexpr = ttgl.DotOperandLayout(
             operand_index=1,  #
             parent=ttgl.amd.AMDWMMALayout(version=3, transposed=True, warp_bases=[[0, 1], [1, 0]],
-                                          instr_shape=[16, 16, 64], cga_layout=[[1, 0], [0, 0]]),  #
+                                          instr_shape=[16, 16, 64], cga_layout=[[0, 1], [1, 0]]),  #
             k_width=16,
         )
         b_scale_layout: ttgl.constexpr = ttgl.amd.cdna5.get_wmma_scale_layout(b_layout, [64, 4])

--- a/python/triton/experimental/gluon/language/amd/cdna5/__init__.py
+++ b/python/triton/experimental/gluon/language/amd/cdna5/__init__.py
@@ -184,6 +184,6 @@ def get_wmma_scale_layout(dot_operand_layout, shape, scale_factor=32):
     transposed = parent.transposed
     reg_bases = parent.reg_bases
     warp_bases = parent.warp_bases
-    cga_bases = parent.cga_layout
+    cga_bases = [list(basis) for basis in dot_operand_layout.cga_layout]
     return _get_wmma_scale_layout_impl(op_idx, shape, mdim, ndim, transposed, scale_factor, reg_bases, warp_bases,
                                        cga_bases)

--- a/test/TritonGPU/amd/invalid.mlir
+++ b/test/TritonGPU/amd/invalid.mlir
@@ -204,6 +204,62 @@ module attributes {"ttg.num-ctas" = 4 : i32, "ttg.num-warps" = 4 : i32, "ttg.thr
 
 // -----
 
+#wmma_acc = #ttg.amd_wmma<{version = 3, isTranspose = true, ctaLayout = {warp = [[0, 1], [1, 0]]}, CGALayout = [[1, 0], [0, 1]], instrShape = [16, 16, 32]}>
+#wmma_a = #ttg.amd_wmma<{version = 3, isTranspose = true, ctaLayout = {warp = [[0, 1], [1, 0]]}, CGALayout = [[1, 0], [0, 0]], instrShape = [16, 16, 32]}>
+#wmma_b = #ttg.amd_wmma<{version = 3, isTranspose = true, ctaLayout = {warp = [[0, 1], [1, 0]]}, CGALayout = [[0, 0], [0, 1]], instrShape = [16, 16, 32]}>
+#a_scale = #ttg.blocked<{sizePerThread = [1, 1], threadsPerWarp = [32, 1], warpsPerCTA = [4, 1], order = [1, 0], CGALayout = [[1, 0], [0, 0]]}>
+#b_scale = #ttg.blocked<{sizePerThread = [1, 1], threadsPerWarp = [32, 1], warpsPerCTA = [4, 1], order = [1, 0], CGALayout = [[0, 0], [1, 0]]}>
+module attributes {"ttg.num-ctas" = 4 : i32, "ttg.num-warps" = 4 : i32, "ttg.threads-per-warp" = 32 : i32} {
+  tt.func @wmma_invalid_cga_split_a_scale(
+              %a: tensor<32x32xf8E4M3FN, #ttg.dot_op<{opIdx = 0, parent = #wmma_a, kWidth = 8}>>,
+              %b: tensor<32x32xf8E4M3FN, #ttg.dot_op<{opIdx = 1, parent = #wmma_b, kWidth = 8}>>,
+              %a_scale: tensor<32x1xi8, #b_scale>,
+              %b_scale: tensor<32x1xi8, #b_scale>,
+              %dst: tensor<32x32xf32, #wmma_acc>
+  ) {
+    // expected-error @+1 {{Incompatible CGA layout for the scale of operand 0}}
+    %0 = tt.dot_scaled %a scale %a_scale, %b scale %b_scale, %dst lhs = e4m3 rhs = e4m3 {fastMath = false} : tensor<32x32xf8E4M3FN, #ttg.dot_op<{opIdx = 0, parent = #wmma_a, kWidth = 8}>>, tensor<32x1xi8, #b_scale> * tensor<32x32xf8E4M3FN, #ttg.dot_op<{opIdx = 1, parent = #wmma_b, kWidth = 8}>>, tensor<32x1xi8, #b_scale> -> tensor<32x32xf32, #wmma_acc>
+    tt.return
+  }
+
+  tt.func @wmma_invalid_cga_split_b_scale(
+              %a: tensor<32x32xf8E4M3FN, #ttg.dot_op<{opIdx = 0, parent = #wmma_a, kWidth = 8}>>,
+              %b: tensor<32x32xf8E4M3FN, #ttg.dot_op<{opIdx = 1, parent = #wmma_b, kWidth = 8}>>,
+              %a_scale: tensor<32x1xi8, #a_scale>,
+              %b_scale: tensor<32x1xi8, #a_scale>,
+              %dst: tensor<32x32xf32, #wmma_acc>
+  ) {
+    // expected-error @+1 {{Incompatible CGA layout for the scale of operand 1}}
+    %0 = tt.dot_scaled %a scale %a_scale, %b scale %b_scale, %dst lhs = e4m3 rhs = e4m3 {fastMath = false} : tensor<32x32xf8E4M3FN, #ttg.dot_op<{opIdx = 0, parent = #wmma_a, kWidth = 8}>>, tensor<32x1xi8, #a_scale> * tensor<32x32xf8E4M3FN, #ttg.dot_op<{opIdx = 1, parent = #wmma_b, kWidth = 8}>>, tensor<32x1xi8, #a_scale> -> tensor<32x32xf32, #wmma_acc>
+    tt.return
+  }
+
+  tt.func @wmma_invalid_cga_split_scaled_operand_1(
+              %a: tensor<32x32xf8E4M3FN, #ttg.dot_op<{opIdx = 0, parent = #wmma_a, kWidth = 8}>>,
+              %b: tensor<32x32xf8E4M3FN, #ttg.dot_op<{opIdx = 1, parent = #wmma_a, kWidth = 8}>>,
+              %a_scale: tensor<32x1xi8, #a_scale>,
+              %b_scale: tensor<32x1xi8, #b_scale>,
+              %dst: tensor<32x32xf32, #wmma_acc>
+  ) {
+    // expected-error @+1 {{Incompatible CGA layout for operand 1}}
+    %0 = tt.dot_scaled %a scale %a_scale, %b scale %b_scale, %dst lhs = e4m3 rhs = e4m3 {fastMath = false} : tensor<32x32xf8E4M3FN, #ttg.dot_op<{opIdx = 0, parent = #wmma_a, kWidth = 8}>>, tensor<32x1xi8, #a_scale> * tensor<32x32xf8E4M3FN, #ttg.dot_op<{opIdx = 1, parent = #wmma_a, kWidth = 8}>>, tensor<32x1xi8, #b_scale> -> tensor<32x32xf32, #wmma_acc>
+    tt.return
+  }
+
+  tt.func @wmma_valid_cga_split_scaled(
+              %a: tensor<32x32xf8E4M3FN, #ttg.dot_op<{opIdx = 0, parent = #wmma_a, kWidth = 8}>>,
+              %b: tensor<32x32xf8E4M3FN, #ttg.dot_op<{opIdx = 1, parent = #wmma_b, kWidth = 8}>>,
+              %a_scale: tensor<32x1xi8, #a_scale>,
+              %b_scale: tensor<32x1xi8, #b_scale>,
+              %dst: tensor<32x32xf32, #wmma_acc>
+  ) {
+    %0 = tt.dot_scaled %a scale %a_scale, %b scale %b_scale, %dst lhs = e4m3 rhs = e4m3 {fastMath = false} : tensor<32x32xf8E4M3FN, #ttg.dot_op<{opIdx = 0, parent = #wmma_a, kWidth = 8}>>, tensor<32x1xi8, #a_scale> * tensor<32x32xf8E4M3FN, #ttg.dot_op<{opIdx = 1, parent = #wmma_b, kWidth = 8}>>, tensor<32x1xi8, #b_scale> -> tensor<32x32xf32, #wmma_acc>
+    tt.return
+  }
+}
+
+// -----
+
 #shared_32 = #ttg.padded_shared<[32:+4] {order = [1, 0], shape = [128, 64]}>
 #shared_2_intervals = #ttg.padded_shared<[64:+4, 128:+4] {order = [1, 0], shape = [128, 64]}>
 #smem = #ttg.shared_memory

--- a/third_party/amd/lib/TritonAMDGPUTransforms/AccelerateAMDMatmul.cpp
+++ b/third_party/amd/lib/TritonAMDGPUTransforms/AccelerateAMDMatmul.cpp
@@ -1276,10 +1276,10 @@ public:
       return {i8_ty, rewriter.getIntegerAttr(i8_ty, 0x7F)};
     };
 
-    auto convertScaleLayout = [&](TensorValue scale,
-                                  llvm::ArrayRef<int64_t> valShape,
-                                  LinearLayout dotLL, int idx,
-                                  ttg::CGAEncodingAttr cgaLayout) -> Value {
+    auto convertScaleLayout =
+        [&](TensorValue scale, llvm::ArrayRef<int64_t> valShape,
+            LinearLayout dotLL, int idx,
+            ttg::CGAEncodingAttr operandCgaLayout) -> Value {
       SmallVector<int64_t> shape;
       Type scaleType;
       // 0x7F is 1.0 in E8M0
@@ -1298,7 +1298,7 @@ public:
 
       LinearLayout newLL = ttg::chooseScaledWmmaScaleLayout(
           ctx, idx, shape, mDim, nDim, wmmaEnc.getIsTransposed(), scaleFactor,
-          ctaLayout, cgaLayout);
+          ctaLayout, operandCgaLayout);
       Attribute newScaleEncoding = ttg::LinearEncodingAttr::get(ctx, newLL);
       auto newScaleType =
           RankedTensorType::get(shape, scaleType, newScaleEncoding);
@@ -1322,11 +1322,13 @@ public:
     auto newAScale = convertScaleLayout(aScale, aShape, aEncLL,
                                         /*dotOperandIdx=*/0, aScaleCgaLayout);
 
-    auto bScaleCgaLayout = inferBScaleCgaLayout(ctx, cgaLayout);
+    auto bOperandCgaLayout =
+        ttg::inferDotOperandCGALayout(cgaLayout, /*opIdx=*/1);
     assert(!bScale || (ttg::getCGALayout(bScale.getType().getEncoding()) ==
-                       bScaleCgaLayout));
+                       ttg::inferDotScaleCGALayoutFromOperand(bOperandCgaLayout,
+                                                              /*opIdx=*/1)));
     auto newBScale = convertScaleLayout(bScale, bShape, bEncLL,
-                                        /*dotOperandIdx=*/1, bScaleCgaLayout);
+                                        /*dotOperandIdx=*/1, bOperandCgaLayout);
 
     auto newDot = triton::DotScaledOp::create(
         rewriter, dotOp.getLoc(), newRetType, a, b, newAcc, newAScale,
@@ -1336,31 +1338,6 @@ public:
                                                       newDot);
 
     return success();
-  }
-
-  // If Bscale were present, we could directly grab the CGA layout from it.
-  // Unfortunately, it is optional; on top of that, sometime we need to know
-  // its CGA layout even if it's not present.
-  //
-  // Note that split only take place along M and N dimension. For A and Ascale,
-  // their shapes are MxK and Mx(K/grp), respectively. Hence, A and A-scale can
-  // share the CGA layout. For B and Bscale, their shapes are KxN and Nx(K/grp),
-  // respectively. Since N shows up on different positions, we cannot "reuse"
-  // B's CGA layout for B-scale.
-  //
-  // We can grab N's split number from D's CGA layout, and construct Bscale's
-  // using that info.
-  //
-  static ttg::CGAEncodingAttr
-  inferBScaleCgaLayout(MLIRContext *ctx, ttg::CGAEncodingAttr dCgaLayout) {
-    auto resultSplit = dCgaLayout.getCTASplitNum();
-    unsigned nSplit = resultSplit[1];
-    unsigned numCtas = mlir::product(dCgaLayout.getCTAsPerCGA());
-
-    return ttg::CGAEncodingAttr::fromSplitParams(
-        ctx,
-        /*CTAsPerCGA=*/{nSplit, numCtas / nSplit},
-        /*CTASplitNum=*/{nSplit, 1}, /*CTAOrder*/ {0, 1});
   }
 };
 

--- a/third_party/amd/python/test/test_gluon_cdna5.py
+++ b/third_party/amd/python/test/test_gluon_cdna5.py
@@ -1273,43 +1273,35 @@ def test_amd_wmma_scaled(wmma_shape, transposed, M, N, K, a_type, b_type, a_scal
 @pytest.mark.parametrize("a_type, b_type", get_test_mxfp_variants())
 @pytest.mark.parametrize("a_scale_type, b_scale_type", itertools.product(["e8m0", "e4m3"], repeat=2))
 @pytest.mark.parametrize("scale_factor", [16, 32])
-def test_amd_wmma_scaled_multi_cta(M, N, K, a_type, b_type, a_scale_type, b_scale_type, scale_factor):
+@pytest.mark.parametrize("ctas_per_cga", [(2, 1), (1, 2), (2, 2), (4, 1), (2, 4)])
+def test_amd_wmma_scaled_multi_cta(M, N, K, a_type, b_type, a_scale_type, b_scale_type, scale_factor, ctas_per_cga):
 
     @gluon.constexpr_function
-    def _get_wmma_layout(cga_layout=[[0, 1], [1, 0]], packed=False):
+    def _get_wmma_layout(cga_layout, packed=False):
         instr_shape = [16, 16, 64] if packed else [16, 16, 128]
         return ttgl.amd.AMDWMMALayout(version=3, transposed=True, warp_bases=[[0, 1], [1, 0]], instr_shape=instr_shape,
-                                      cga_layout=cga_layout)
+                                      cga_layout=[list(basis) for basis in cga_layout])
 
     @gluon.constexpr_function
-    def _get_wmma_operand_layout(operand_index, dtype, transposed=False):
-        cga_layout = [[0, 0], [1, 0]] if operand_index == 0 else [[0, 1], [0, 0]]
-        if transposed:
-            cga_layout = [list(reversed(row)) for row in cga_layout]
+    def _get_wmma_operand_layout(cga_layout, operand_index, dtype):
         wmma_layout = _get_wmma_layout(cga_layout, packed=(dtype == "e2m1"))
         return ttgl.DotOperandLayout(operand_index, wmma_layout, k_width=16)
-
-    @gluon.constexpr_function
-    def _get_wmma_scale_layout(operand_index, dtype, shape, scale_factor):
-        transposed = True if operand_index == 1 else False
-        operand_layout = _get_wmma_operand_layout(operand_index, dtype, transposed)
-        return get_wmma_scale_layout(operand_layout, shape, scale_factor)
 
     @gluon.jit
     def kernel(c_ptr, a_ptr, a_scale_ptr, b_ptr, b_scale_ptr,  #
                a_type: ttgl.constexpr, b_type: ttgl.constexpr,  #
                BLOCK_M: ttgl.constexpr, BLOCK_N: ttgl.constexpr, BLOCK_K: ttgl.constexpr,  #
-               SCALE_FACTOR: ttgl.constexpr):
+               SCALE_FACTOR: ttgl.constexpr, CGA_LAYOUT: ttgl.constexpr):
         DIV_FACTOR_A: ttgl.constexpr = 2 if a_type == "e2m1" else 1
         DIV_FACTOR_B: ttgl.constexpr = 2 if b_type == "e2m1" else 1
 
-        acc_layout: ttgl.constexpr = _get_wmma_layout()
-        a_layout: ttgl.constexpr = _get_wmma_operand_layout(0, a_type)
-        b_layout: ttgl.constexpr = _get_wmma_operand_layout(1, b_type)
-        a_scale_layout: ttgl.constexpr = _get_wmma_scale_layout(0, a_type, [BLOCK_M, BLOCK_K // SCALE_FACTOR],
-                                                                SCALE_FACTOR)
-        b_scale_layout: ttgl.constexpr = _get_wmma_scale_layout(1, b_type, [BLOCK_N, BLOCK_K // SCALE_FACTOR],
-                                                                SCALE_FACTOR)
+        acc_layout: ttgl.constexpr = _get_wmma_layout(CGA_LAYOUT)
+        a_layout: ttgl.constexpr = _get_wmma_operand_layout(CGA_LAYOUT, 0, a_type)
+        b_layout: ttgl.constexpr = _get_wmma_operand_layout(CGA_LAYOUT, 1, b_type)
+        a_scale_layout: ttgl.constexpr = get_wmma_scale_layout(a_layout, [BLOCK_M, BLOCK_K // SCALE_FACTOR],
+                                                               SCALE_FACTOR)
+        b_scale_layout: ttgl.constexpr = get_wmma_scale_layout(b_layout, [BLOCK_N, BLOCK_K // SCALE_FACTOR],
+                                                               SCALE_FACTOR)
 
         a_offs = ttgl.arange(0, BLOCK_M, layout=ttgl.SliceLayout(1, a_layout))[:, None] * (BLOCK_K // DIV_FACTOR_A) + \
                  ttgl.arange(0, BLOCK_K // DIV_FACTOR_A, layout=ttgl.SliceLayout(0, a_layout))[None, :]
@@ -1341,7 +1333,11 @@ def test_amd_wmma_scaled_multi_cta(M, N, K, a_type, b_type, a_scale_type, b_scal
         pytest.skip(f"Invalid type combination: {a_type}, {a_scale_type}, {b_type}, {b_scale_type}")
 
     torch.manual_seed(42)
-    M, N = M * 2, N * 2
+    num_ctas = math.prod(ctas_per_cga)
+    M *= ctas_per_cga[0]
+    N *= ctas_per_cga[1]
+    # Tuples so that the layout can be passed as a constexpr kernel argument.
+    cga_layout = tuple(map(tuple, make_cga_layout(list(ctas_per_cga), list(ctas_per_cga), [1, 0])))
     a, a_ref = create_mxfp_operand(0, M, K, a_type)
     b, b_ref = create_mxfp_operand(1, K, N, b_type)
     a_scale, a_scale_ref = create_mxfp_scale(0, M, K, a_scale_type, scale_factor)
@@ -1351,7 +1347,8 @@ def test_amd_wmma_scaled_multi_cta(M, N, K, a_type, b_type, a_scale_type, b_scal
     a, a_scale = a.cuda(), a_scale.cuda()
     b, b_scale = b.cuda(), b_scale.cuda()
     c = torch.zeros((M, N), dtype=torch.float32).cuda()
-    pgm = kernel[(1, )](c, a, a_scale, b, b_scale, a_type, b_type, M, N, K, scale_factor, num_warps=4, num_ctas=4)
+    pgm = kernel[(1, )](c, a, a_scale, b, b_scale, a_type, b_type, M, N, K, scale_factor, cga_layout, num_warps=4,
+                        num_ctas=num_ctas)
     if scale_factor == 32:
         assert "v_wmma_scale_f32_16x16x128_f8f6f4" in pgm.asm["amdgcn"]
     else:


### PR DESCRIPTION
For the B operand we need to transpose the last 2 dims in the CGA layout of the scales to account for the difference in dim order compared to the operand B.
Before this PR this was silently miscompiled and we used the wrong scales in case the CGA layout was not explicitly transposed in the kernel. This PR tightens the verifiers and moves the logic into an infer function to share it across multiple callers (deduplicates the logic from the Gluon wrapper and AccelerateMatmul)