### PR TITLE
[triton_kernels] Support arbitrary top-k widths

### DIFF
--- a/python/triton_kernels/tests/test_tensor.py
+++ b/python/triton_kernels/tests/test_tensor.py
@@ -313,9 +313,9 @@ def test_remap_ragged_tensor_metadata(n_slices):
     assert_equal(tri_metadata.block_schedule_data, ref_metadata.block_schedule_data)
 
 
-@pytest.mark.parametrize("n_rows", [7, 256, 17111])
+@pytest.mark.parametrize("n_rows", [0, 7, 256, 17111])
 @pytest.mark.parametrize("n_cols", [13, 32, 128, 811])
-@pytest.mark.parametrize("k", [1, 4, 8])
+@pytest.mark.parametrize("k", [1, 3, 4, 7, 8, 12, 18, 33, 63])
 def test_make_bitmatrix_metadata(n_rows, n_cols, k):
     if k > n_cols:
         pytest.skip("k must be <= n_cols")

--- a/python/triton_kernels/tests/test_topk.py
+++ b/python/triton_kernels/tests/test_topk.py
@@ -1,5 +1,8 @@
+from types import SimpleNamespace
+
 import pytest
 import torch
+import triton
 import triton.profiler as proton
 from triton.testing import cuda_graph_without_gc
 from triton_kernels.topk import topk, topk_torch
@@ -10,7 +13,7 @@ import torch.distributed as dist
 
 @pytest.mark.parametrize("n_rows", [1, 7, 256, 300])
 @pytest.mark.parametrize("n_cols", [13, 32, 128, 200])
-@pytest.mark.parametrize("k", [8])
+@pytest.mark.parametrize("k", [3, 7, 8, 12])
 @pytest.mark.parametrize("apply_softmax", [True, False])
 @pytest.mark.parametrize("dtype", ["float16", "bfloat16", "float32"])
 @pytest.mark.enable_warmup(min_capability=9)
@@ -29,18 +32,81 @@ def test_topk(n_rows, n_cols, k, apply_softmax, dtype):
     assert sparse_x_tri.mask.storage.data.shape == sparse_x_ref.mask.storage.data.shape
 
 
+@pytest.mark.parametrize("k", [1, 3, 5, 6, 7, 8, 12, 14, 15, 18, 31, 33, 63, 64])
+@pytest.mark.parametrize("apply_softmax", [True, False])
+@pytest.mark.parametrize("use_provided_indices", [True, False])
+@pytest.mark.parametrize("dtype", [torch.float16, torch.bfloat16, torch.float32])
+def test_topk_arbitrary_k_forward_backward(k, apply_softmax, use_provided_indices, dtype):
+    torch.manual_seed(0)
+    n_rows, n_experts = 7, 67
+    x = torch.randn((n_rows, n_experts), device="cuda", dtype=dtype, requires_grad=True)
+    x_ref = x.detach().clone().requires_grad_()
+
+    provided_indices = None
+    if use_provided_indices:
+        provided_indices = torch.argsort(x.detach(), dim=1, descending=True)[:, :k]
+        provided_indices = provided_indices.flip(1).contiguous().to(torch.int16)
+
+    actual = topk(x, k, apply_softmax=apply_softmax, y_indx=provided_indices)
+    expected = topk_torch(x_ref, k, apply_softmax=apply_softmax, y_indx=provided_indices)
+
+    assert actual.vals.shape == (n_rows, k)
+    assert actual.indx.shape == (n_rows, k)
+    assert actual.mask.storage.data.shape == (n_rows, triton.cdiv(n_experts, 32))
+    assert_close(expected.vals, actual.vals)
+    assert_equal(expected.indx, actual.indx)
+    assert_equal(expected.mask.storage.data, actual.mask.storage.data)
+
+    output_gradient = torch.randn_like(actual.vals)
+    actual.vals.backward(output_gradient)
+    expected.vals.backward(output_gradient.to(expected.vals.dtype))
+    assert_close(x_ref.grad, x.grad)
+
+
+@pytest.mark.parametrize("use_provided_indices", [False, True])
+@pytest.mark.parametrize("n_rows", [1, 7, 16, 31, 32, 128])
+@pytest.mark.parametrize("k", [8, 18, 33, 63, 64])
+def test_topk_all_gather_uses_reserved_bitmap_size(n_rows, k, use_provided_indices):
+    torch.manual_seed(0)
+    n_experts = 67
+    x = torch.randn((n_rows, n_experts), device="cuda", dtype=torch.float32)
+    mesh = SimpleNamespace(world_size=1, local_rank=0)
+    symm_mem_pool = SymmetricMemoryPool(mesh)
+    symm_mem_pool.initialize_matmul(
+        n_tokens_global=n_rows,
+        d_input=1,
+        d_model=1,
+        n_expts_act=k,
+        n_expts_tot=n_experts,
+        dtype=x.dtype,
+        device=x.device,
+    )
+
+    provided_indices = None
+    if use_provided_indices:
+        provided_indices = torch.argsort(x, dim=1, descending=True)[:, :k].contiguous().to(torch.int16)
+
+    actual = topk(x, k, apply_softmax=False, y_indx=provided_indices, all_gather=True, symm_mem_pool=symm_mem_pool)
+    expected = topk_torch(x, k, apply_softmax=False, y_indx=provided_indices)
+
+    assert actual.mask.storage.data.shape == expected.mask.storage.data.shape
+    assert_close(expected.vals, actual.vals)
+    assert_equal(expected.indx, actual.indx)
+    assert_equal(expected.mask.storage.data, actual.mask.storage.data)
+
+
 @pytest.mark.parametrize("n_experts", [13, 33])
+@pytest.mark.parametrize("k", [3, 7, 8, 12])
 @pytest.mark.parametrize("apply_softmax", [False, True])
 @pytest.mark.parametrize("dtype,storage_dtype", [
     (torch.float16, torch.int16),
     (torch.bfloat16, torch.int16),
     (torch.float32, torch.int32),
 ])
-def test_topk_fpsan_masks_padded_experts(fresh_knobs, n_experts, apply_softmax, dtype, storage_dtype):
+def test_topk_fpsan_masks_padded_experts(fresh_knobs, n_experts, k, apply_softmax, dtype, storage_dtype):
     fresh_knobs.compilation.instrumentation_mode = "fpsan"
 
     n_rows = 2
-    k = 8
     # Negative NaNs sort below -inf as floating-point keys. Under FPSan these
     # bit patterns are valid payload carriers, so -inf cannot mask padding.
     logits = torch.full((n_rows, n_experts), -1, dtype=storage_dtype, device="cuda").view(dtype)

--- a/python/triton_kernels/triton_kernels/distributed_details/mesh.py
+++ b/python/triton_kernels/triton_kernels/distributed_details/mesh.py
@@ -150,8 +150,9 @@ class SymmetricMemoryPool:
 
         BLOCK_N = 32
         BLOCK_M = 32
-        n_bytes_topk = n_tokens_global * n_expts_act * 4  # topk logits (float32): pessimistic estimate
-        n_bytes_topk += n_tokens_global * n_expts_act * 2  # topk indx (int16)
+        TOPK_ALIGNMENT = 128
+        n_bytes_topk = self.align_up(n_tokens_global * n_expts_act * 4, TOPK_ALIGNMENT)  # topk logits (float32)
+        n_bytes_topk += self.align_up(n_tokens_global * n_expts_act * 2, TOPK_ALIGNMENT)  # topk indx (int16)
         cdiv = lambda x, y: (x + y - 1) // y
         num_blocks_m = cdiv(n_tokens_global, BLOCK_M)
         num_blocks_n = cdiv(n_expts_tot, BLOCK_N)
@@ -160,7 +161,7 @@ class SymmetricMemoryPool:
         n_bytes_dp_to_ep = n_tokens_global * n_expts_act * d_input * elem_size
         n_bytes_ep_to_dp = (n_tokens_global // self.mesh.world_size) * n_expts_act * d_model * elem_size
 
-        offset = self._reserve_region("topk", n_bytes_topk, 128, 0)
+        offset = self._reserve_region("topk", n_bytes_topk, TOPK_ALIGNMENT, 0)
         offset = self._reserve_region("ep_to_dp", n_bytes_ep_to_dp, 128, offset)
         offset = self._reserve_region("dp_to_ep", n_bytes_dp_to_ep, 128, offset)
         self._initialize(device=device)

--- a/python/triton_kernels/triton_kernels/tensor_details/bitmatrix.py
+++ b/python/triton_kernels/triton_kernels/tensor_details/bitmatrix.py
@@ -43,7 +43,8 @@ def _keyed_add(x, y):
 @triton.jit
 def _bitmatrix_metadata_compute_stage2(ColSortedIndx, RowSortedIndx, NonzeroIndx, n_tokens, ColPartialSum, stride_pm,
                                        stride_pn, ColOffs, TOKS_PER_ROW: tl.constexpr, BLOCK_PER_TOK: tl.constexpr):
-    BLOCK_SIZE: tl.constexpr = BLOCK_PER_TOK * TOKS_PER_ROW
+    BLOCK_SIZE_ACT: tl.constexpr = BLOCK_PER_TOK * TOKS_PER_ROW
+    BLOCK_SIZE: tl.constexpr = triton.next_power_of_2(BLOCK_SIZE_ACT)
     tl.static_assert(BLOCK_SIZE <= 32768)
     if isinstance(n_tokens, tl.tensor) and n_tokens.dtype.is_ptr():
         n_tokens = tl.load(n_tokens)
@@ -51,14 +52,14 @@ def _bitmatrix_metadata_compute_stage2(ColSortedIndx, RowSortedIndx, NonzeroIndx
     pid_m = tl.program_id(0)
     # load column indices
     offs_local = tl.arange(0, BLOCK_SIZE)
-    offs_global = pid_m * BLOCK_SIZE + offs_local
-    mask = offs_global < nonzero_indx_size
+    offs_global = pid_m * BLOCK_SIZE_ACT + offs_local
+    mask = (offs_local < BLOCK_SIZE_ACT) & (offs_global < nonzero_indx_size)
     col_indx = tl.load(NonzeroIndx + offs_global, mask=mask, other=-1).to(tl.uint32)
     # stable-sort by columns index
     kv_pairs = ((col_indx << 16) | offs_local).to(tl.uint32)
     kv_pairs = tl.sort(kv_pairs, 0)
     col_indx = kv_pairs >> 16
-    offs_global = pid_m * BLOCK_SIZE + (kv_pairs & 0xffff)
+    offs_global = pid_m * BLOCK_SIZE_ACT + (kv_pairs & 0xffff)
     mask = col_indx != 0xffff
     # compute run lengths in column-sorted order:
     x = (kv_pairs & 0xffff0000 | 0x00000001)

--- a/python/triton_kernels/triton_kernels/topk.py
+++ b/python/triton_kernels/triton_kernels/topk.py
@@ -28,14 +28,16 @@ def topk_forward(x, k, apply_softmax=True, dim=1, y_indx=None, n_rows=None, all_
         x_shape_max = [x.shape[0], x.shape[1]]
         x = wrap_torch_tensor(x, shape=x_shape, shape_max=x_shape_max)
     cdiv = lambda a, b: (a + b - 1) // b
-    BLOCK_M = 32
-    BLOCK_N = 32
     use_provided_indx = y_indx is not None
     assert symm_mem_pool is not None or not all_gather
     assert len(x.shape) == 2
     assert x.shape_max[-1] < 32768
     assert dim == 1
     n_rows, n_cols = x.shape
+    assert 0 < k <= n_cols
+    k_pad = triton.next_power_of_2(k)
+    BLOCK_M = 32
+    BLOCK_N = max(32, k_pad)
     n_rows_max, _ = x.shape_max
     dev = x.device
     n_rows_out_max = n_rows_max * symm_mem_pool.mesh.world_size if all_gather else n_rows_max
@@ -50,7 +52,7 @@ def topk_forward(x, k, apply_softmax=True, dim=1, y_indx=None, n_rows=None, all_
         y_indx_bufs = (y_indx, )
     # create bitmatrix in transposed memory layout:
     n_cols_pad = cdiv(n_cols, BLOCK_N) * BLOCK_N
-    n_cols_words = n_cols_pad // 32
+    n_cols_words = cdiv(n_cols, 32)
     bitmatrix_bufs, bitmatrix_data, offset = make_empty(offset, (n_cols_words, cdiv(n_rows_out_max, 32) * 32),
                                                         torch.uint32, dev, all_gather=all_gather,
                                                         symm_mem_pool=symm_mem_pool)

--- a/python/triton_kernels/triton_kernels/topk_details/_topk_backward.py
+++ b/python/triton_kernels/triton_kernels/topk_details/_topk_backward.py
@@ -19,6 +19,7 @@ def _topk_backward(
     N_EXPTS_ACT: tl.constexpr,
     N_EXPTS_PAD: tl.constexpr,
 ):
+    N_EXPTS_ACT_PAD: tl.constexpr = triton.next_power_of_2(N_EXPTS_ACT)
     pid_m = tl.program_id(0)
     if NRows is not None:
         n_rows = tl.load(NRows)
@@ -30,15 +31,16 @@ def _topk_backward(
     DX += pid_m * stride_dxm
     # --
     offs_xn = tl.arange(0, N_EXPTS_PAD)
-    offs_yn = tl.arange(0, N_EXPTS_ACT)
+    offs_yn = tl.arange(0, N_EXPTS_ACT_PAD)
+    mask_yn = offs_yn < N_EXPTS_ACT
     mask_xn = offs_xn < n_expts_tot
     # recompute softmax
-    y_indx = tl.load(Yi + offs_yn)
-    x = tl.load(X + y_indx)
+    y_indx = tl.load(Yi + offs_yn, mask=mask_yn, other=0)
+    x = tl.load(X + y_indx, mask=mask_yn, other=float("-inf"))
     x = x.to(tl.float32)
     y = tl.softmax(x)
     # compute input-gradient
-    dy = tl.load(DY + offs_yn)
+    dy = tl.load(DY + offs_yn, mask=mask_yn, other=0.0)
     dy = dy.to(tl.float32)
     s = tl.sum(y * dy, 0)
     # write-back input gradient
@@ -48,4 +50,4 @@ def _topk_backward(
         dx = y * (dy - s)
     else:
         dx = dy
-    tl.store(DX + y_indx, dx)
+    tl.store(DX + y_indx, dx, mask=mask_yn)

--- a/python/triton_kernels/triton_kernels/topk_details/_topk_forward.py
+++ b/python/triton_kernels/triton_kernels/topk_details/_topk_forward.py
@@ -38,6 +38,7 @@ def key_to_indx(indx, N_EXPTS_PAD: tl.constexpr):
 @triton.jit
 def streaming_topk(X, stride_xm, n_expts_tot, offs_m, mask_m, N_EXPTS_PAD: tl.constexpr, N_EXPTS_ACT: tl.constexpr,
                    BLOCK_N: tl.constexpr):
+    N_EXPTS_ACT_PAD: tl.constexpr = triton.next_power_of_2(N_EXPTS_ACT)
     x_nbits: tl.constexpr = X.dtype.element_ty.primitive_bitwidth
     x_utype: tl.constexpr = tl.dtype(f"uint{x_nbits}")
     if x_nbits < 16:
@@ -63,7 +64,7 @@ def streaming_topk(X, stride_xm, n_expts_tot, offs_m, mask_m, N_EXPTS_PAD: tl.co
     # padding to zero so it cannot be selected when FPSan payloads sort below
     # the floating-point -inf sentinel.
     x = tl.where(mask_n, x, 0)
-    acc = tl.topk(x, N_EXPTS_ACT, dim=1)
+    acc = tl.topk(x, N_EXPTS_ACT_PAD, dim=1)
 
     # subsequent iterations:
     for _i in (tl.static_range if loop_iterations <= 4 else range)(loop_iterations):
@@ -73,7 +74,7 @@ def streaming_topk(X, stride_xm, n_expts_tot, offs_m, mask_m, N_EXPTS_PAD: tl.co
         x = tl.load(X_ptrs, mask=mask_m, other=float("-inf"))
         x = fpval_to_key(x.to(x_utype, bitcast=True))
         x = (x.to(x_ultype) << 16) | indx_to_key(offs_x_n, N_EXPTS_PAD)[None, :]
-        acc = tl.maximum(acc, tl.topk(x, N_EXPTS_ACT, dim=1))
+        acc = tl.maximum(acc, tl.topk(x, N_EXPTS_ACT_PAD, dim=1))
 
     # sort packed (value_key, index_key) descending:
     # this keeps outputs ordered by gate value and uses smaller expert index for ties
@@ -97,6 +98,7 @@ def _topk_forward(X, stride_xm,  # inputs
                   BLOCK_M: tl.constexpr, N_EXPTS_PAD: tl.constexpr, N_EXPTS_ACT: tl.constexpr, BLOCK_N: tl.constexpr):
 
     N_PEERS: tl.constexpr = len(PeerYvs)
+    N_EXPTS_ACT_PAD: tl.constexpr = triton.next_power_of_2(N_EXPTS_ACT)
 
     pid = tl.program_id(0)
     if isinstance(n_rows, tl.tensor) and n_rows.dtype.is_ptr():
@@ -112,39 +114,39 @@ def _topk_forward(X, stride_xm,  # inputs
 
     # load logits
     offs_m = pid * BLOCK_M + tl.arange(0, BLOCK_M)
-    offs_y_n = tl.arange(0, N_EXPTS_ACT)
+    offs_y_n = tl.arange(0, N_EXPTS_ACT_PAD)
+    mask_y_n = offs_y_n < N_EXPTS_ACT
     mask_m = offs_m[:, None] < n_rows
     if USE_PROVIDED_INDX:
         tl.static_assert(len(PeerYis) == 1)
         Yi_ptrs = PeerYis[0] + (dst_offs_m + offs_m[:, None]) * stride_ym + offs_y_n[None, :]
-        y_indices = tl.load(Yi_ptrs, mask=mask_m)
+        y_indices = tl.load(Yi_ptrs, mask=mask_m & mask_y_n[None, :], other=0)
         Xv_ptrs = X + offs_m[:, None] * stride_xm + y_indices
-        y_values = tl.load(Xv_ptrs, mask=mask_m)
+        y_values = tl.load(Xv_ptrs, mask=mask_m & mask_y_n[None, :], other=float("-inf"))
     else:
         y_values, y_indices = streaming_topk(X, stride_xm, n_expts_tot, offs_m, mask_m,  #
                                              N_EXPTS_PAD, N_EXPTS_ACT, BLOCK_N)
 
     # normalize selected values
     if APPLY_SOFTMAX:
+        y_values = tl.where(mask_y_n[None, :], y_values, float("-inf"))
         y_values = tl.softmax(y_values.to(tl.float32), dim=1).to(x_dtype)
 
     # write back
     for rank in tl.static_range(N_PEERS):
         Yv_ptrs = PeerYvs[rank] + (dst_offs_m + offs_m[:, None]) * stride_ym + offs_y_n[None, :]
-        tl.store(Yv_ptrs, y_values, mask=mask_m)
+        tl.store(Yv_ptrs, y_values, mask=mask_m & mask_y_n[None, :])
     if not USE_PROVIDED_INDX:
         for rank in tl.static_range(N_PEERS):
             Yi_ptrs = PeerYis[rank] + (dst_offs_m + offs_m[:, None]) * stride_ym + offs_y_n[None, :]
-            tl.store(Yi_ptrs, y_indices, mask=mask_m)
+            tl.store(Yi_ptrs, y_indices, mask=mask_m & mask_y_n[None, :])
 
     # pack into bitmatrix
     y_div = y_indices // 32
-    y_rem = y_indices % 32
-    loop_iterations = N_EXPTS_PAD // BLOCK_N
-    for i in range(loop_iterations):
-        offs_r_n = tl.arange(0, BLOCK_N // 32) + i * (BLOCK_N // 32)
-        y2 = tl.where(y_div[:, :, None] == offs_r_n[None, None, :], (1 << y_rem)[:, :, None], 0)
+    y_rem = (y_indices % 32).to(tl.uint32)
+    for word_idx in range(tl.cdiv(n_expts_tot, 32)):
+        y2 = tl.where(mask_y_n[None, :] & (y_div == word_idx), 1 << y_rem, 0)
         r = tl.reduce_or(y2, axis=1)
         for rank in tl.static_range(N_PEERS):
-            BitsPtrs = PeerBits[rank] + (dst_offs_m + offs_m[:, None]) * stride_rm + offs_r_n[None, :] * stride_rn
-            tl.store(BitsPtrs, r, mask=mask_m)
+            BitsPtrs = PeerBits[rank] + (dst_offs_m + offs_m) * stride_rm + word_idx * stride_rn
+            tl.store(BitsPtrs, r, mask=offs_m < n_rows)


### PR DESCRIPTION
## Summary

- Support non-power-of-two top-k widths and widths above 32, including automatic and caller-provided indices, without changing the existing Triton kernel interfaces.
- Preserve the upstream 32-row tile, canonical 32-bit bitmap storage, FPSan behavior, empty-batch handling, and forward/backward correctness.
- Round bitmap-metadata sort blocks to a valid power of two and account for 128-byte alignment between symmetric-memory buffers so small-batch all-gather allocations remain valid.

## Validation

- NVIDIA GB200, four GPUs:

  ```bash
  python -m pytest \
    python/triton_kernels/tests/test_topk.py \
    python/triton_kernels/tests/test_tensor.py::test_make_bitmatrix_metadata \
    -n 4 -s --tb=short
  ```

  Result: **784 passed, 20 skipped**. The skips are parameter combinations where `k` exceeds the expert count.

- Real two-GPU symmetric-memory all-gather passed for `k=8, 18, 33, 64`, both with automatically selected indices and with caller-provided indices.
- Ruff checks and `git diff --check` pass.
