### PR TITLE
[ConSan] Use masked stores for scratch overwrites

### DIFF
--- a/lib/Dialect/TritonInstrument/IR/FunctionBuilder.cpp
+++ b/lib/Dialect/TritonInstrument/IR/FunctionBuilder.cpp
@@ -508,15 +508,9 @@ Operation *createMaskedStoreScratchMemory(ImplicitLocOpBuilder &b, Location loc,
                                           RankedTensorType tensorType,
                                           Value mask) {
   int64_t numCTAs = ttg::lookupNumCTAs(b);
-  if (numCTAs > 1) {
-    // This should hopefully be folded with the previous load in the caller
-    // function
-    Value oldTensor = tti::createLoadScratchMemory(b, loc, alloc, tensorType);
-    // and this with the previous selectOp, if there is any
-    tensor = arith::SelectOp::create(b, loc, mask, tensor, oldTensor);
-  }
   return tti::createStoreScratchMemory(b, loc, alloc, tensor, tensorType,
-                                       /*currentCTAOnly=*/false);
+                                       /*currentCTAOnly=*/false,
+                                       numCTAs > 1 ? mask : Value{});
 }
 
 Operation *createCTAScopedStoreScratchMemory(ImplicitLocOpBuilder &b,
@@ -1747,8 +1741,6 @@ void FunctionBuilder::createPublishWriteVisibilityCall(
 
         if (publishWrite) {
           Value visibilityPtr = entryBlock->getArgument(nextArg++);
-          Value visibility = tti::createLoadScratchMemory(
-              fb, fb.getLoc(), visibilityPtr, writeVisibilityType);
           Value visibilityMask =
               convertAndBroadcast(fb, bufferMask, {1}, writeVisibilityType);
           Value relationMask =
@@ -1764,25 +1756,22 @@ void FunctionBuilder::createPublishWriteVisibilityCall(
               adjustIntegerWidth(fb, threadMaskVal, elemType);
           Value threadMaskTensor =
               triton::SplatOp::create(fb, writeVisibilityType, threadMaskElem);
-          Value updated = arith::SelectOp::create(fb, visibilityMask,
-                                                  threadMaskTensor, visibility);
-          tti::createStoreScratchMemory(fb, fb.getLoc(), visibilityPtr, updated,
-                                        writeVisibilityType,
-                                        /*currentCTAOnly=*/false);
+          tti::createStoreScratchMemory(fb, fb.getLoc(), visibilityPtr,
+                                        threadMaskTensor, writeVisibilityType,
+                                        /*currentCTAOnly=*/false,
+                                        visibilityMask);
         }
 
         auto clearTable = [&](RankedTensorType tableType) {
           Value tablePtr = entryBlock->getArgument(nextArg++);
-          Value table = tti::createLoadScratchMemory(fb, fb.getLoc(), tablePtr,
-                                                     tableType);
           Value tableMask = convertAndBroadcast(fb, bufferMask, {1}, tableType);
           Value ctaMask =
               createCTASetMask(fb, tableType, /*dim=*/0, effectCTAs);
           tableMask = arith::AndIOp::create(fb, tableMask, ctaMask);
           Value zero = tti::createConstIntTensor(fb, fb.getLoc(), 0, tableType);
-          Value updated = arith::SelectOp::create(fb, tableMask, zero, table);
-          tti::createStoreScratchMemory(fb, fb.getLoc(), tablePtr, updated,
-                                        tableType, /*currentCTAOnly=*/false);
+          tti::createStoreScratchMemory(fb, fb.getLoc(), tablePtr, zero,
+                                        tableType, /*currentCTAOnly=*/false,
+                                        tableMask);
         };
 
         if (clearWrites)
@@ -2039,8 +2028,6 @@ void FunctionBuilder::createTrackVisibleAccessesCall(
           Value trackingPtr = entryBlock->getArgument(nextArg++);
           Value visibility = tti::createLoadScratchMemory(
               fb, fb.getLoc(), visibilityPtr, writeVisibilityType);
-          Value tracking = tti::createLoadScratchMemory(
-              fb, fb.getLoc(), trackingPtr, writeTrackingType);
           Value barrierMask =
               convertAndBroadcast(fb, barriersEqBar, {3}, writeTrackingType);
           Value barrierCTAMask =
@@ -2078,10 +2065,9 @@ void FunctionBuilder::createTrackVisibleAccessesCall(
               arith::AndIOp::create(fb, barrierMask, visibleWrites);
           Value one =
               tti::createConstIntTensor(fb, fb.getLoc(), 1, writeTrackingType);
-          Value updated =
-              arith::SelectOp::create(fb, barAndVisible, one, tracking);
-          createMaskedStoreScratchMemory(fb, fb.getLoc(), trackingPtr, updated,
-                                         writeTrackingType, barrierCTAMask);
+          tti::createStoreScratchMemory(
+              fb, fb.getLoc(), trackingPtr, one, writeTrackingType,
+              /*currentCTAOnly=*/false, barAndVisible);
         }
 
         if (trackReads) {
@@ -2129,17 +2115,9 @@ void FunctionBuilder::createTrackVisibleAccessesCall(
           visibleReads = convertAndBroadcast(fb, visibleReads, {0, 1, 4},
                                              readTrackingType);
           Value withVisible = arith::OrIOp::create(fb, tracking, visibleReads);
-          if (filterBuffer) {
-            Value updated =
-                arith::SelectOp::create(fb, barrierMask, withVisible, tracking);
-            createMaskedStoreScratchMemory(fb, fb.getLoc(), trackingPtr,
-                                           updated, readTrackingType,
-                                           barrierMask);
-          } else {
-            tti::createStoreScratchMemory(
-                fb, fb.getLoc(), trackingPtr, withVisible, readTrackingType,
-                /*currentCTAOnly=*/false, barrierMask);
-          }
+          tti::createStoreScratchMemory(fb, fb.getLoc(), trackingPtr,
+                                        withVisible, readTrackingType,
+                                        /*currentCTAOnly=*/false, barrierMask);
         }
 
         fb.setInsertionPointToEnd(thenBlock);

--- a/lib/Dialect/TritonInstrument/IR/Utility.cpp
+++ b/lib/Dialect/TritonInstrument/IR/Utility.cpp
@@ -372,9 +372,7 @@ Operation *createStoreScratchMemory(OpBuilder &b, Location loc, Value alloc,
       if (storeMask) {
         storeMask = arith::AndIOp::create(b, loc, storeMask, currentCTAMask);
       } else {
-        Value oldTensor = createLoadScratchMemory(b, loc, alloc, tensorType);
-        tensor =
-            arith::SelectOp::create(b, loc, currentCTAMask, tensor, oldTensor);
+        storeMask = currentCTAMask;
       }
     }
   }

--- a/test/TritonGPU/consan.mlir
+++ b/test/TritonGPU/consan.mlir
@@ -96,6 +96,71 @@ module attributes {"ttg.num-ctas" = 2 : i32, "ttg.num-warps" = 4 : i32, "ttg.thr
 #blocked = #ttg.blocked<{sizePerThread = [1, 32], threadsPerWarp = [32, 1], warpsPerCTA = [1, 1], order = [0, 1], CGALayout = [[1, 0]]}>
 module attributes {"ttg.num-ctas" = 2 : i32, "ttg.num-warps" = 1 : i32, ttg.shared = 65544 : i32, ttg.target = "cuda:90", ttg.tensor_memory_size = 0 : i32, "ttg.threads-per-warp" = 32 : i32, "ttg.total-num-warps" = 1 : i32} {
   // CHECK: tti.experimental_cluster_cta_id : i32
+  // Updating the active mask must not read or overwrite another CTA's entry.
+  // CHECK-LABEL: tt.func private @__triton_consan_set_active_mask_
+  // CHECK-SAME: (%[[ACTIVE_VALUE:[^:]+]]: i32,
+  // CHECK-NOT: tt.load
+  // CHECK: %[[ACTIVE_VALUES:.*]] = tt.splat %[[ACTIVE_VALUE]] : i32 -> tensor<2xi32
+  // CHECK-NOT: tt.load
+  // CHECK: %[[ACTIVE_CTA:.*]] = tti.experimental_cluster_cta_id : i32
+  // CHECK-NEXT: %[[ACTIVE_CTAS:.*]] = tt.splat %[[ACTIVE_CTA]] : i32 -> tensor<2xi32
+  // CHECK-NEXT: %[[ACTIVE_STORE_MASK:.*]] = arith.cmpi eq, {{.*}}, %[[ACTIVE_CTAS]] : tensor<2xi32
+  // CHECK-NOT: tt.load
+  // CHECK: tt.store %{{[^,]+}}, %[[ACTIVE_VALUES]], %[[ACTIVE_STORE_MASK]] {ignore_cta} : tensor<2x!tt.ptr<i32>
+  // CHECK-NEXT: tt.return
+
+  // Publishing and clearing overwrite selected entries without reading old
+  // values. The buffer and CTA predicates remain masks on all four stores.
+  // CHECK-LABEL: tt.func private @__triton_consan_publish_write_visibility_
+  // CHECK-SAME: (%[[PUBLISH_BUFFERS:[^:]+]]: tensor<2xi1, {{.*}}>, %[[PUBLISH_PRED:[^:]+]]: i1, %{{[^:]+}}: i64, %[[PUBLISH_CTAS:[^:]+]]: i32,
+  // CHECK-NOT: tt.load
+  // CHECK: cf.cond_br %[[PUBLISH_PRED]],
+  // CHECK-NOT: tt.load
+  // CHECK: %[[PUBLISH_RESHAPED:.*]] = tt.reshape %[[PUBLISH_BUFFERS]] : {{.*}} -> tensor<1x2x1xi1
+  // CHECK-NEXT: %[[PUBLISH_LAYOUT:.*]] = ttg.convert_layout %[[PUBLISH_RESHAPED]]
+  // CHECK-NEXT: %[[PUBLISH_BUFFER_MASK:.*]] = tt.broadcast %[[PUBLISH_LAYOUT]] : {{.*}} -> tensor<2x2x2xi1
+  // CHECK-NOT: tt.load
+  // CHECK: %[[PUBLISH_CTA_BITS:.*]] = tt.splat %[[PUBLISH_CTAS]] : i32 -> tensor<2x2x2xi32
+  // CHECK-NOT: tt.load
+  // CHECK: %[[PUBLISH_OWNER_MASK:.*]] = arith.cmpi ne, {{.*}} : tensor<2x2x2xi32
+  // CHECK-NOT: tt.load
+  // CHECK: %[[PUBLISH_RELATION_MASK:.*]] = arith.andi %[[PUBLISH_OWNER_MASK]], {{.*}} : tensor<2x2x2xi1
+  // CHECK-NEXT: %[[PUBLISH_STORE_MASK:.*]] = arith.andi %[[PUBLISH_BUFFER_MASK]], %[[PUBLISH_RELATION_MASK]] : tensor<2x2x2xi1
+  // CHECK-NOT: tt.load
+  // CHECK: tt.store %{{[^,]+}}, %{{[^,]+}}, %[[PUBLISH_STORE_MASK]] {ignore_cta} : tensor<2x2x2x!tt.ptr<i{{32|64}}>
+  // CHECK-NOT: tt.load
+  // CHECK: %[[CLEAR_WRITES_BUFFERS:.*]] = tt.broadcast {{.*}} -> tensor<2x2x2x1x2xi1
+  // CHECK-NOT: tt.load
+  // CHECK: tt.splat %[[PUBLISH_CTAS]] : i32 -> tensor<2x2x2x1x2xi32
+  // CHECK-NOT: tt.load
+  // CHECK: %[[CLEAR_WRITES_CTAS:.*]] = arith.cmpi ne, {{.*}} : tensor<2x2x2x1x2xi32
+  // CHECK-NEXT: %[[CLEAR_WRITES_MASK:.*]] = arith.andi %[[CLEAR_WRITES_BUFFERS]], %[[CLEAR_WRITES_CTAS]] : tensor<2x2x2x1x2xi1
+  // CHECK-NEXT: %[[CLEAR_WRITES_ZERO:.*]] = arith.constant dense<0> : tensor<2x2x2x1x2xi8
+  // CHECK-NOT: tt.load
+  // CHECK: tt.store %{{[^,]+}}, %[[CLEAR_WRITES_ZERO]], %[[CLEAR_WRITES_MASK]] {ignore_cta} : tensor<2x2x2x1x2x!tt.ptr<i8>
+  // CHECK-NOT: tt.load
+  // CHECK: %[[CLEAR_READS_BUFFERS:.*]] = tt.broadcast {{.*}} -> tensor<2x2x2x1x2xi1
+  // CHECK-NOT: tt.load
+  // CHECK: tt.splat %[[PUBLISH_CTAS]] : i32 -> tensor<2x2x2x1x2xi32
+  // CHECK-NOT: tt.load
+  // CHECK: %[[CLEAR_READS_CTAS:.*]] = arith.cmpi ne, {{.*}} : tensor<2x2x2x1x2xi32
+  // CHECK-NEXT: %[[CLEAR_READS_MASK:.*]] = arith.andi %[[CLEAR_READS_BUFFERS]], %[[CLEAR_READS_CTAS]] : tensor<2x2x2x1x2xi1
+  // CHECK-NEXT: %[[CLEAR_READS_ZERO:.*]] = arith.constant dense<0> : tensor<2x2x2x1x2xi{{32|64}}
+  // CHECK-NOT: tt.load
+  // CHECK: tt.store %{{[^,]+}}, %[[CLEAR_READS_ZERO]], %[[CLEAR_READS_MASK]] {ignore_cta} : tensor<2x2x2x1x2x!tt.ptr<i{{32|64}}>
+  // CHECK-NOT: tt.load
+  // CHECK: %[[CLEAR_TRACKING_BUFFERS:.*]] = tt.broadcast {{.*}} -> tensor<2x2x2x1x2x2xi1
+  // CHECK-NOT: tt.load
+  // CHECK: tt.splat %[[PUBLISH_CTAS]] : i32 -> tensor<2x2x2x1x2x2xi32
+  // CHECK-NOT: tt.load
+  // CHECK: %[[CLEAR_TRACKING_CTAS:.*]] = arith.cmpi ne, {{.*}} : tensor<2x2x2x1x2x2xi32
+  // CHECK-NEXT: %[[CLEAR_TRACKING_MASK:.*]] = arith.andi %[[CLEAR_TRACKING_BUFFERS]], %[[CLEAR_TRACKING_CTAS]] : tensor<2x2x2x1x2x2xi1
+  // CHECK-NEXT: %[[CLEAR_TRACKING_ZERO:.*]] = arith.constant dense<0> : tensor<2x2x2x1x2x2xi{{32|64}}
+  // CHECK-NOT: tt.load
+  // CHECK: tt.store %{{[^,]+}}, %[[CLEAR_TRACKING_ZERO]], %[[CLEAR_TRACKING_MASK]] {ignore_cta} : tensor<2x2x2x1x2x2x!tt.ptr<i{{32|64}}>
+  // CHECK-NOT: tt.load
+  // CHECK: tt.return
+
   // CHECK-LABEL: @single_local_alloc_multi_cta
   tt.func public @single_local_alloc_multi_cta() {
     // CHECK: %[[WRITE_VISIBILITY_GLOB:.*]] = ttg.global_scratch_alloc {alignment = 16 : i32, nbytes = 64 : i32, shared_cluster_state, third_party_allocation, tt.divisibility = 16 : i64} : !tt.ptr<i64>


### PR DESCRIPTION
Reduce ConSan compilation and execution time by replacing load/select/store sequences with masked scratch stores for visibility publication, tracking updates, and CTA-local state writes. Existing masks still control which entries change; read-modify-write operations retain their required loads.

## Performance

These measurements use the original stack based on `8ce2ac12`; they have not been repeated on the current main base.

Measured on an internal workload with the same inputs and hardware, compared with the frozen main baseline [8ce2ac12](https://github.com/triton-lang/triton/commit/8ce2ac12d21648f0f787ecc7576a26c4b34be3cd):

- Cold compilation: **109.45 s → 91.31 s (16.6% less time)**.
- Instrumented execution: **153.30 s → 122.80 s (19.9% less time)**.

Single-run measurements; small deltas may be noise. Compilation used fresh caches.

## PR stack

Merge order (base → top):

1. [#11446 — Masked scratch stores](https://github.com/triton-lang/triton/pull/11446) **← this PR**
2. [#11447 — Narrow thread masks](https://github.com/triton-lang/triton/pull/11447)
3. [#11448 — Single-buffer row views](https://github.com/triton-lang/triton/pull/11448)
4. [#11449 — Issuing-observer views](https://github.com/triton-lang/triton/pull/11449)
5. [#11450 — Unique-barrier-slot views](https://github.com/triton-lang/triton/pull/11450)
6. [#11451 — Streaming large-table clears](https://github.com/triton-lang/triton/pull/11451)
7. [#11452 — Streaming phase-completion clears](https://github.com/triton-lang/triton/pull/11452)

