### PR TITLE
[ConSan] Slice proven single-buffer read visibility updates

### DIFF
--- a/include/triton/Dialect/TritonInstrument/IR/FunctionBuilder.h
+++ b/include/triton/Dialect/TritonInstrument/IR/FunctionBuilder.h
@@ -165,10 +165,12 @@ public:
                                         Value effectCTAs);
   // setReadVisibility: record the actual reader in the visibility columns of
   // each observer, including any synthetic peers.
+  // bufferIndex is optional and requires a proven one-hot bufferMask.
   void createSetReadVisibilityCall(ImplicitLocOpBuilder &b, Value bufferMask,
                                    int reader, uint64_t observerMask,
                                    Value pred, MemType memType,
-                                   Operation *insertPoint, Value effectCTAs);
+                                   Operation *insertPoint, Value effectCTAs,
+                                   Value bufferIndex = nullptr);
   // trackVisibleAccesses: snapshot the available read and write visibility
   // frontiers into their independent tracking tables for the barrier's current
   // phase.

--- a/include/triton/Dialect/TritonInstrument/IR/Utility.h
+++ b/include/triton/Dialect/TritonInstrument/IR/Utility.h
@@ -78,12 +78,15 @@ inline int estimateConSanCaptureCount(int numActiveMemTypes, bool hasMBarriers,
 
 void createAssertInThread(ImplicitLocOpBuilder &b, Value condition,
                           StringRef message);
+// Strides are in elements; an empty list uses contiguous column-major storage.
 Operation *createStoreScratchMemory(OpBuilder &b, Location loc, Value alloc,
                                     Value tensor, RankedTensorType tensorType,
                                     bool currentCTAOnly = false,
-                                    Value storeMask = nullptr);
+                                    Value storeMask = nullptr,
+                                    ArrayRef<int64_t> strides = {});
 Value createLoadScratchMemory(OpBuilder &b, Location loc, Value alloc,
-                              RankedTensorType tensorType);
+                              RankedTensorType tensorType,
+                              ArrayRef<int64_t> strides = {});
 gpu::GlobalScratchAllocOp
 createThirdPartyScratchAlloc(OpBuilder &b, Location loc, Type ptrType,
                              int64_t sizeInBytes, int64_t alignment,

--- a/lib/Dialect/TritonInstrument/IR/FunctionBuilder.cpp
+++ b/lib/Dialect/TritonInstrument/IR/FunctionBuilder.cpp
@@ -1788,12 +1788,10 @@ void FunctionBuilder::createPublishWriteVisibilityCall(
       });
 }
 
-void FunctionBuilder::createSetReadVisibilityCall(ImplicitLocOpBuilder &b,
-                                                  Value bufferMask, int reader,
-                                                  uint64_t observerMask,
-                                                  Value pred, MemType memType,
-                                                  Operation *insertPoint,
-                                                  Value effectCTAs) {
+void FunctionBuilder::createSetReadVisibilityCall(
+    ImplicitLocOpBuilder &b, Value bufferMask, int reader,
+    uint64_t observerMask, Value pred, MemType memType, Operation *insertPoint,
+    Value effectCTAs, Value bufferIndex) {
 
   if (auxData.readVisibility[(int)memType].empty()) {
     return;
@@ -1807,12 +1805,18 @@ void FunctionBuilder::createSetReadVisibilityCall(ImplicitLocOpBuilder &b,
   auto readVisibilityType = cast<RankedTensorType>(
       auxData.readVisibility[(int)memType].at(insertPoint).type);
   bool hasReadTracking = !auxData.readTracking[(int)memType].empty();
-  SmallVector<Value> args = {bufferMask,        pred,
-                             readerMaskVal,     observerMaskVal,
-                             readVisibilityVal, effectCTAs};
+  bool singleBuffer = static_cast<bool>(bufferIndex);
+  SmallVector<Value> args = {singleBuffer ? bufferIndex : bufferMask,
+                             pred,
+                             readerMaskVal,
+                             observerMaskVal,
+                             readVisibilityVal,
+                             effectCTAs};
   RankedTensorType readTrackingType;
-  ManglingArgs specializationArgs{readVisibilityType,
-                                  (uint64_t)hasReadTracking};
+  // Keep the full backing types in the cache key: equal one-buffer view shapes
+  // can have different physical strides and origin/phase bank offsets.
+  ManglingArgs specializationArgs{readVisibilityType, (uint64_t)hasReadTracking,
+                                  (uint64_t)singleBuffer};
   if (hasReadTracking) {
     ValueType tracking = auxData.readTracking[(int)memType].at(insertPoint);
     readTrackingType = cast<RankedTensorType>(tracking.type);
@@ -1822,9 +1826,9 @@ void FunctionBuilder::createSetReadVisibilityCall(ImplicitLocOpBuilder &b,
   createCallToCachedFunction(
       b, "set_read_visibility", args,
       /*assertInfo=*/std::nullopt, specializationArgs,
-      [readVisibilityType, readTrackingType,
-       hasReadTracking](ImplicitLocOpBuilder &fb, Block *entryBlock) {
-        Value bufferMask = entryBlock->getArgument(0);
+      [readVisibilityType, readTrackingType, hasReadTracking,
+       singleBuffer](ImplicitLocOpBuilder &fb, Block *entryBlock) {
+        Value bufferSelection = entryBlock->getArgument(0);
         Value pred = entryBlock->getArgument(1);
         Value readerMaskVal = entryBlock->getArgument(2);
         Value observerMaskVal = entryBlock->getArgument(3);
@@ -1837,9 +1841,54 @@ void FunctionBuilder::createSetReadVisibilityCall(ImplicitLocOpBuilder &b,
         auto [prevBlock, ifBlock, thenBlock] = createIfBlock(fb, pred);
         fb.setInsertionPointToStart(ifBlock);
 
+        SmallVector<int64_t> visibilityStrides, trackingStrides;
+        auto createBufferView = [&](RankedTensorType type,
+                                    SmallVectorImpl<int64_t> &strides) {
+          if (!singleBuffer)
+            return type;
+          SmallVector<int64_t> shape(type.getShape());
+          strides.resize(shape.size(), 1);
+          for (unsigned dim = 1; dim < shape.size(); ++dim)
+            strides[dim] = strides[dim - 1] * shape[dim - 1];
+          shape[1] = 1;
+          // Distribute lanes over the narrowed shape to avoid redundant loads.
+          return tti::getIntTensorType(
+              fb.getInsertionBlock()->getParent(), shape,
+              type.getElementType().getIntOrFloatBitWidth());
+        };
+        RankedTensorType visibilityType =
+            createBufferView(readVisibilityType, visibilityStrides);
+        RankedTensorType trackingType;
+        if (hasReadTracking)
+          trackingType = createBufferView(readTrackingType, trackingStrides);
+
+        auto selectBufferPointer = [&](Value ptr,
+                                       RankedTensorType type) -> Value {
+          if (!singleBuffer)
+            return ptr;
+          Value stride =
+              arith::ConstantIntOp::create(fb, type.getShape()[0], 32);
+          Value offset = arith::MulIOp::create(fb, bufferSelection, stride);
+          return triton::AddPtrOp::create(fb, ptr.getType(), ptr, offset)
+              .getResult();
+        };
+        readVisibilityPtr =
+            selectBufferPointer(readVisibilityPtr, readVisibilityType);
+        if (hasReadTracking)
+          readTrackingPtr =
+              selectBufferPointer(readTrackingPtr, readTrackingType);
+
         Value currentCTA = createCurrentCTAMask(fb);
+        auto createBufferRows = [&](RankedTensorType tableType) -> Value {
+          if (singleBuffer) {
+            auto maskType =
+                cast<RankedTensorType>(tableType.clone(fb.getI1Type()));
+            return tti::createConstIntTensor(fb, fb.getLoc(), 1, maskType);
+          }
+          return convertAndBroadcast(fb, bufferSelection, {1}, tableType);
+        };
         auto createReaderRows = [&](RankedTensorType tableType) {
-          Value rows = convertAndBroadcast(fb, bufferMask, {1}, tableType);
+          Value rows = createBufferRows(tableType);
           Value ownerMask =
               createCTASetMask(fb, tableType, /*dim=*/0, effectCTAs);
           Value readerCTAMask =
@@ -1863,23 +1912,24 @@ void FunctionBuilder::createSetReadVisibilityCall(ImplicitLocOpBuilder &b,
               .getResult();
         };
 
-        Value readVisibility = tti::createLoadScratchMemory(
-            fb, fb.getLoc(), readVisibilityPtr, readVisibilityType);
-        Value visibilityRows = createReaderRows(readVisibilityType);
+        Value readVisibility =
+            tti::createLoadScratchMemory(fb, fb.getLoc(), readVisibilityPtr,
+                                         visibilityType, visibilityStrides);
+        Value visibilityRows = createReaderRows(visibilityType);
         // A logical reader reuses one bit for every read. Remove the previous
         // generation before publishing the current one so an old observer or
         // barrier snapshot cannot license a later unfinished read.
         Value newVisibility =
-            clearReader(readVisibility, readVisibilityType, visibilityRows);
-        auto elemType = cast<IntegerType>(readVisibilityType.getElementType());
+            clearReader(readVisibility, visibilityType, visibilityRows);
+        auto elemType = cast<IntegerType>(visibilityType.getElementType());
         Value readerMaskElem = adjustIntegerWidth(fb, readerMaskVal, elemType);
         Value readerBit =
-            triton::SplatOp::create(fb, readVisibilityType, readerMaskElem);
+            triton::SplatOp::create(fb, visibilityType, readerMaskElem);
         Value observerColumnMask =
-            createThreadColumnMask(fb, observerMaskVal, readVisibilityType,
+            createThreadColumnMask(fb, observerMaskVal, visibilityType,
                                    /*columnDim=*/3);
         Value observerCTAMask =
-            createCTASetMask(fb, readVisibilityType, /*dim=*/2, currentCTA);
+            createCTASetMask(fb, visibilityType, /*dim=*/2, currentCTA);
         Value observerRows =
             arith::AndIOp::create(fb, visibilityRows, observerCTAMask);
         observerRows =
@@ -1888,40 +1938,51 @@ void FunctionBuilder::createSetReadVisibilityCall(ImplicitLocOpBuilder &b,
         newVisibility = arith::SelectOp::create(fb, observerRows, withReader,
                                                 newVisibility);
         tti::createStoreScratchMemory(fb, fb.getLoc(), readVisibilityPtr,
-                                      newVisibility, readVisibilityType,
-                                      /*currentCTAOnly=*/false);
+                                      newVisibility, visibilityType,
+                                      /*currentCTAOnly=*/false,
+                                      /*storeMask=*/nullptr, visibilityStrides);
 
         if (hasReadTracking) {
           if (readTrackingType.getShape()[4] == 1) {
-            Value readTracking = tti::createLoadScratchMemory(
-                fb, fb.getLoc(), readTrackingPtr, readTrackingType);
-            Value trackingRows = createReaderRows(readTrackingType);
+            Value readTracking =
+                tti::createLoadScratchMemory(fb, fb.getLoc(), readTrackingPtr,
+                                             trackingType, trackingStrides);
+            Value trackingRows = createReaderRows(trackingType);
             Value newTracking =
-                clearReader(readTracking, readTrackingType, trackingRows);
-            tti::createStoreScratchMemory(fb, fb.getLoc(), readTrackingPtr,
-                                          newTracking, readTrackingType,
-                                          /*currentCTAOnly=*/false);
+                clearReader(readTracking, trackingType, trackingRows);
+            tti::createStoreScratchMemory(
+                fb, fb.getLoc(), readTrackingPtr, newTracking, trackingType,
+                /*currentCTAOnly=*/false,
+                /*storeMask=*/nullptr, trackingStrides);
           } else {
-            RankedTensorType bankType =
+            RankedTensorType fullBankType =
                 tti::getSlicedTensorType(readTrackingType, {0, 1, 2, 3},
                                          readTrackingType.getElementType());
-            Value trackingRows =
-                convertAndBroadcast(fb, bufferMask, {1}, bankType);
+            RankedTensorType bankType = tti::getSlicedTensorType(
+                trackingType, {0, 1, 2, 3}, trackingType.getElementType());
+            SmallVector<int64_t> bankStrides;
+            if (singleBuffer)
+              bankStrides.assign(trackingStrides.begin(),
+                                 trackingStrides.begin() + 4);
+            Value trackingRows = createBufferRows(bankType);
             Value ownerMask =
                 createCTASetMask(fb, bankType, /*dim=*/0, effectCTAs);
             trackingRows = arith::AndIOp::create(fb, trackingRows, ownerMask);
             Value originId =
                 tti::ExperimentalClusterCTAIdOp::create(fb, fb.getLoc());
             for (int phase = 0; phase < 2; ++phase) {
+              // The pointer is a B=1 view into the original allocation. Origin
+              // and phase banks are still separated by the full table stride.
               Value bankPtr = createTrackingOriginPhasePointer(
-                  fb, readTrackingPtr, readTrackingType, bankType, originId,
+                  fb, readTrackingPtr, readTrackingType, fullBankType, originId,
                   phase);
-              Value tracking = tti::createLoadScratchMemory(fb, fb.getLoc(),
-                                                            bankPtr, bankType);
+              Value tracking = tti::createLoadScratchMemory(
+                  fb, fb.getLoc(), bankPtr, bankType, bankStrides);
               Value updated = clearReader(tracking, bankType, trackingRows);
               tti::createStoreScratchMemory(fb, fb.getLoc(), bankPtr, updated,
                                             bankType,
-                                            /*currentCTAOnly=*/false);
+                                            /*currentCTAOnly=*/false,
+                                            /*storeMask=*/nullptr, bankStrides);
             }
           }
         }

--- a/lib/Dialect/TritonInstrument/IR/Utility.cpp
+++ b/lib/Dialect/TritonInstrument/IR/Utility.cpp
@@ -314,7 +314,8 @@ Value reshapeAndBroadcast(OpBuilder &b, Location loc, Value tensor,
 }
 
 static Value createPointerTensor(OpBuilder &b, Location loc, Value base,
-                                 RankedTensorType tensorType) {
+                                 RankedTensorType tensorType,
+                                 ArrayRef<int64_t> explicitStrides = {}) {
   auto encoding = cast<DistributedEncodingTrait>(tensorType.getEncoding());
   Value ptrTensor = SplatOp::create(
       b, loc,
@@ -322,10 +323,16 @@ static Value createPointerTensor(OpBuilder &b, Location loc, Value base,
       base);
   auto offsetsType =
       RankedTensorType::get(tensorType.getShape(), b.getI32Type(), encoding);
-  SmallVector<int> strides(tensorType.getRank());
-  strides[0] = 1;
-  for (int i = 1; i < tensorType.getRank(); ++i) {
-    strides[i] = strides[i - 1] * tensorType.getShape()[i - 1];
+  assert(
+      (explicitStrides.empty() ||
+       explicitStrides.size() == static_cast<size_t>(tensorType.getRank())) &&
+      "expected one stride per scratch tensor dimension");
+  SmallVector<int64_t> strides(explicitStrides.begin(), explicitStrides.end());
+  if (strides.empty()) {
+    strides.resize(tensorType.getRank());
+    strides[0] = 1;
+    for (int i = 1; i < tensorType.getRank(); ++i)
+      strides[i] = strides[i - 1] * tensorType.getShape()[i - 1];
   }
   for (int i = 0; i < tensorType.getRank(); ++i) {
     auto arangeType = getSlicedTensorType(tensorType, {i}, b.getI32Type());
@@ -360,7 +367,8 @@ static Value createCurrentCTAMask(OpBuilder &b, Location loc,
 
 Operation *createStoreScratchMemory(OpBuilder &b, Location loc, Value alloc,
                                     Value tensor, RankedTensorType tensorType,
-                                    bool currentCTAOnly, Value storeMask) {
+                                    bool currentCTAOnly, Value storeMask,
+                                    ArrayRef<int64_t> strides) {
   if (currentCTAOnly) {
     assert(tensorType.getRank() >= 1 &&
            "expected currentCTAOnly tensor to have a leading CTA dimension");
@@ -376,14 +384,15 @@ Operation *createStoreScratchMemory(OpBuilder &b, Location loc, Value alloc,
       }
     }
   }
-  auto ptrTensor = createPointerTensor(b, loc, alloc, tensorType);
+  auto ptrTensor = createPointerTensor(b, loc, alloc, tensorType, strides);
   return StoreOp::create(b, loc, ptrTensor, tensor, storeMask,
                          /*ignore_cta=*/true);
 }
 
 Value createLoadScratchMemory(OpBuilder &b, Location loc, Value alloc,
-                              RankedTensorType tensorType) {
-  auto ptrTensor = createPointerTensor(b, loc, alloc, tensorType);
+                              RankedTensorType tensorType,
+                              ArrayRef<int64_t> strides) {
+  auto ptrTensor = createPointerTensor(b, loc, alloc, tensorType, strides);
   Value value = LoadOp::create(b, loc, ptrTensor);
   // Finish replicated reads before another thread can update the scratch.
   auto freeVarMasks = toLinearLayout(tensorType).getFreeVariableMasks();

--- a/lib/Dialect/TritonInstrument/Transforms/ConcurrencySanitizer.cpp
+++ b/lib/Dialect/TritonInstrument/Transforms/ConcurrencySanitizer.cpp
@@ -248,6 +248,33 @@ FailureOr<Value> createBufferStateMask(ImplicitLocOpBuilder &b,
   return result;
 }
 
+Value createSingleBufferStateIndex(ImplicitLocOpBuilder &b,
+                                   const BufferStateCandidates &candidates,
+                                   ArrayRef<Value> predicates) {
+  if (candidates.unknown)
+    return {};
+
+  // Every candidate contains its physical base atom, so one-hot candidates
+  // sharing a runtime base select the same lane even with different CTA masks.
+  for (const BufferStateCandidate &candidate : candidates.cases) {
+    if (candidate.mask.count() != 1)
+      return {};
+  }
+
+  if (candidates.cases.size() == 1)
+    return arith::ConstantIntOp::create(
+        b, candidates.cases.front().mask.find_first(), 32);
+
+  assert(predicates.size() == candidates.cases.size());
+  Value index = arith::ConstantIntOp::create(b, 0, 32);
+  for (auto [candidate, predicate] : llvm::zip(candidates.cases, predicates)) {
+    Value lane =
+        arith::ConstantIntOp::create(b, candidate.mask.find_first(), 32);
+    index = arith::SelectOp::create(b, predicate, lane, index);
+  }
+  return index;
+}
+
 Value allCTAsMask(ImplicitLocOpBuilder &b) {
   int numCTAs = ttg::lookupNumCTAs(b);
   assert(numCTAs <= 16 && "ConSan CTA bitsets assume at most 16 CTAs");
@@ -1211,6 +1238,7 @@ private:
     Value defaultEffectCTAs = getMemEffectCTAs(b, op);
     struct MaterializedEffect {
       Value bufferMask;
+      Value bufferIndex;
       Value effectCTAs;
       Value barrierCTAs;
       MemType memType;
@@ -1277,6 +1305,8 @@ private:
       if (failed(stateMask))
         return failure();
       materialized.bufferMask = *stateMask;
+      materialized.bufferIndex =
+          createSingleBufferStateIndex(b, candidates, predicates);
 
       if (candidates.unknown) {
         materialized.effectCTAs = allCTAsMask(b);
@@ -1405,7 +1435,7 @@ private:
           funcBuilder.createSetReadVisibilityCall(
               b, bufferMask, thread,
               getThreadPeersMask(thread, auxData.threadLayout), pred, memType,
-              op, effectCTAs);
+              op, effectCTAs, materialized.bufferIndex);
         }
         if (opInfo->trackingKind ==
             MemEffectsOpInfo::TrackingKind::CommitCount) {
@@ -1460,7 +1490,7 @@ private:
         funcBuilder.createSetReadVisibilityCall(
             b, completionBufferMask, thread,
             getThreadPeersMask(thread, auxData.threadLayout), combinedPred,
-            MemType::SHARED_MEM, op, recipientCTAs);
+            MemType::SHARED_MEM, op, recipientCTAs, completion->bufferIndex);
       }
       if (barrierInfo.count == 0 && barrierInfo.txCount == 0)
         funcBuilder.createVerifyBarrierInitializedCall(b, barrier, combinedPred,

--- a/test/TritonGPU/consan.mlir
+++ b/test/TritonGPU/consan.mlir
@@ -2142,14 +2142,22 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 1 : i32, ttg.shar
 module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 1 : i32, ttg.shared = 65544 : i32, ttg.target = "cuda:90", ttg.tensor_memory_size = 0 : i32, "ttg.threads-per-warp" = 32 : i32, "ttg.total-num-warps" = 1 : i32} {
   // CHECK-LABEL: @alias_matrix_mixed
   tt.func public @alias_matrix_mixed() {
-    // CHECK-DAG: arith.constant dense<true> : tensor<1xi1
-    // CHECK-DAG: arith.constant dense<[true, true, false, false]> : tensor<4xi1
-    // CHECK-DAG: arith.constant dense<[false, true, true, false]> : tensor<4xi1
     %smem0 = ttg.local_alloc {allocation.offset = 0 : i32} : () -> !ttg.memdesc<32xf32, #shared, #smem, mutable>
     %smem1 = ttg.local_alloc {allocation.offset = 16 : i32} : () -> !ttg.memdesc<32xf32, #shared, #smem, mutable>
     %tmem0 = ttng.tmem_alloc {tensor_memory_col_offset = 0 : i32, tensor_memory_row_offset = 0 : i32} : () -> !ttg.memdesc<64x64xf32, #tmem, #ttng.tensor_memory, mutable>
+    // The tensor-memory read has one atom; each overlapping shared-memory
+    // read spans two atoms and must keep the full state-mask path.
+    // CHECK: arith.constant dense<true> : tensor<1xi1
+    // CHECK: tt.call @__triton_consan_set_read_visibility_nw1_I32_
+    // CHECK: ttng.tmem_load
     ttng.tmem_load %tmem0 : !ttg.memdesc<64x64xf32, #tmem, #ttng.tensor_memory, mutable> -> tensor<64x64xf32>
+    // CHECK: arith.constant dense<[true, true, false, false]> : tensor<4xi1
+    // CHECK: tt.call @__triton_consan_set_read_visibility_nw1_T4xI1_
+    // CHECK: ttg.local_load
     ttg.local_load %smem0 : !ttg.memdesc<32xf32, #shared, #smem, mutable> -> tensor<32xf32>
+    // CHECK: arith.constant dense<[false, true, true, false]> : tensor<4xi1
+    // CHECK: tt.call @__triton_consan_set_read_visibility_nw1_T4xI1_
+    // CHECK: ttg.local_load
     ttg.local_load %smem1 : !ttg.memdesc<32xf32, #shared, #smem, mutable> -> tensor<32xf32>
     tt.return
   }
@@ -2377,13 +2385,17 @@ module attributes {"ttg.num-ctas" = 2 : i32, "ttg.num-warps" = 4 : i32, "ttg.thr
     // CHECK: tt.call @__triton_consan_verify_write_visibility{{.*}}({{.*}}%[[REMOTE_CTAS]])
     // CHECK: ttg.local_load
     %r = ttg.local_load %remote : !ttg.memdesc<2x32xi32, #shared, #smem, mutable, 4x32> -> tensor<2x32xi32, #blocked>
+    // CHECK: %[[SELECTED_LOCAL_CTA_BIT:.*]] = arith.constant 1 : i32
     // CHECK: %[[LOCAL_SELECTED:.*]] = arith.andi {{.*}}, %[[CHOOSE]] : i1
     // CHECK: %[[REMOTE_CHOICE:.*]] = arith.xori %[[CHOOSE]], {{.*}} : i1
     // CHECK: %[[REMOTE_SELECTED:.*]] = arith.andi {{.*}}, %[[REMOTE_CHOICE]] : i1
-    // CHECK: %[[LOCAL_CTA:.*]] = arith.select %[[LOCAL_SELECTED]], {{.*}} : i32
-    // CHECK: %[[REMOTE_CTA:.*]] = arith.select %[[REMOTE_SELECTED]], {{.*}} : i32
+    // CHECK: %[[LOCAL_CTA:.*]] = arith.select %[[LOCAL_SELECTED]], %[[SELECTED_LOCAL_CTA_BIT]], {{.*}} : i32
+    // CHECK: %[[SELECTED_REMOTE_CTA_BIT:.*]] = arith.constant 2 : i32
+    // CHECK: %[[REMOTE_CTA:.*]] = arith.select %[[REMOTE_SELECTED]], %[[SELECTED_REMOTE_CTA_BIT]], {{.*}} : i32
     // CHECK: %[[SELECTED_CTAS:.*]] = arith.ori %[[LOCAL_CTA]], %[[REMOTE_CTA]] : i32
     // CHECK: tt.call @__triton_consan_verify_write_visibility{{.*}}({{.*}}%[[SELECTED_CTAS]])
+    // Same-base candidates with different CTA masks share one physical atom.
+    // CHECK: tt.call @__triton_consan_set_read_visibility_nw4_I32_
     // CHECK: ttg.local_load
     %s = ttg.local_load %selected : !ttg.memdesc<2x32xi32, #shared, #smem, mutable, 4x32> -> tensor<2x32xi32, #blocked>
     // CHECK: %[[STORE_CTAS:.*]] = arith.constant 2 : i32
@@ -2466,10 +2478,12 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 1 : i32, ttg.shar
     %known = ttg.local_alloc {allocation.offset = 0 : i32} : () -> !ttg.memdesc<16xi32, #shared, #smem, mutable>
     // CHECK: arith.constant dense<[true, false]> : tensor<2xi1
     // CHECK: tt.call @__triton_consan_verify_write_visibility
+    // CHECK: tt.call @__triton_consan_set_read_visibility_nw1_I32_
     // CHECK: ttg.local_load %[[KNOWN]]
     %0 = ttg.local_load %known : !ttg.memdesc<16xi32, #shared, #smem, mutable> -> tensor<16xi32>
     // CHECK: arith.constant dense<true> : tensor<2xi1
     // CHECK: tt.call @__triton_consan_verify_write_visibility
+    // CHECK: tt.call @__triton_consan_set_read_visibility_nw1_T2xI1_
     // CHECK: ttg.local_load %arg0
     %1 = ttg.local_load %incoming : !ttg.memdesc<16xi32, #shared, #smem, mutable> -> tensor<16xi32>
     tt.return
@@ -2488,6 +2502,9 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 1 : i32, ttg.shar
   tt.func public @unknown_only_descriptor_state(%incoming: !ttg.memdesc<16xi32, #shared, #smem, mutable>) {
     // CHECK: arith.constant dense<true> : tensor<1xi1
     // CHECK: tt.call @__triton_consan_verify_write_visibility
+    // CHECK-NOT: tti.experimental_memdesc_to_i32
+    // An unknown descriptor stays on the mask path even when B is one.
+    // CHECK: tt.call @__triton_consan_set_read_visibility_nw1_T1xI1_
     // CHECK-NOT: tti.experimental_memdesc_to_i32
     // CHECK: ttg.local_load %arg0
     %0 = ttg.local_load %incoming : !ttg.memdesc<16xi32, #shared, #smem, mutable> -> tensor<16xi32>
@@ -2813,6 +2830,70 @@ module attributes {"ttg.num-ctas" = 2 : i32, "ttg.num-warps" = 4 : i32, "ttg.thr
     // CHECK-NOT: tti.experimental_lock_acquire
     // CHECK: ttg.convert_layout
     %converted = ttg.convert_layout %value {allocation.offset = 0 : i32, allocation.size = 1024 : i32} : tensor<16x32xi32, #tma_src> -> tensor<16x32xi32, #tma_dst>
+    tt.return
+  }
+}
+
+// -----
+
+// Selecting a barrier from a ring selects exactly one state atom at runtime.
+// The B=1 viewport must retain the original B=2 strides, every observer and
+// barrier column, and both origin/phase banks.
+#row_barrier = #ttg.swizzled_shared<{vec = 1, perPhase = 1, maxPhase = 1, order = [0], CGALayout = [[1]]}>
+#row_smem = #ttg.shared_memory
+
+module attributes {"ttg.num-ctas" = 2 : i32, "ttg.num-warps" = 1 : i32, "ttg.threads-per-warp" = 32 : i32, "ttg.total-num-warps" = 1 : i32, ttg.shared = 16 : i32, ttg.target = "cuda:100", ttg.tensor_memory_size = 0 : i32} {
+  // CHECK-LABEL: tt.func private @__triton_consan_set_read_visibility_nw1_I32_
+  // CHECK-SAME: (%[[ROW_INDEX:[^:]+]]: i32,
+  // CHECK: %[[ROW_STRIDE:.*]] = arith.constant 2 : i32
+  // CHECK-NEXT: %[[ROW_OFFSET:.*]] = arith.muli %[[ROW_INDEX]], %[[ROW_STRIDE]] : i32
+  // CHECK-NEXT: tt.addptr {{.*}}, %[[ROW_OFFSET]] : !tt.ptr<i{{32|64}}>, i32
+  // The last visibility axis retains stride 16, not the viewport's stride 8.
+  // CHECK: arith.constant dense<16> : tensor<2xi32
+  // CHECK: tt.load {{.*}} : tensor<2x1x2x2x2x!tt.ptr<i{{32|64}}>
+  // CHECK: arith.constant dense<16> : tensor<2xi32
+  // CHECK: tt.store {{.*}} : tensor<2x1x2x2x2x!tt.ptr<i{{32|64}}>
+  // Each origin/phase bank spans 16 backing elements, not 8 viewport elements.
+  // CHECK: %[[ROW_ORIGIN:.*]] = tti.experimental_cluster_cta_id
+  // CHECK-NEXT: %[[ROW_BANK_SIZE:.*]] = arith.constant 16 : i32
+  // CHECK-NEXT: %[[ROW_BANK_OFFSET:.*]] = arith.muli %[[ROW_ORIGIN]], %[[ROW_BANK_SIZE]] : i32
+  // CHECK-NEXT: tt.addptr {{.*}}, %[[ROW_BANK_OFFSET]] : !tt.ptr<i{{32|64}}>, i32
+  // CHECK: arith.constant dense<8> : tensor<2xi32
+  // CHECK: tt.load {{.*}} : tensor<2x1x2x2x!tt.ptr<i{{32|64}}>
+  // CHECK: arith.constant dense<8> : tensor<2xi32
+  // CHECK: tt.store {{.*}} : tensor<2x1x2x2x!tt.ptr<i{{32|64}}>
+  // CHECK: %[[ROW_PHASE_STRIDE:.*]] = arith.constant 2 : i32
+  // CHECK-NEXT: %[[ROW_PHASE_ORIGIN:.*]] = arith.addi %[[ROW_ORIGIN]], %[[ROW_PHASE_STRIDE]] : i32
+  // CHECK-NEXT: %[[ROW_NEXT_BANK_SIZE:.*]] = arith.constant 16 : i32
+  // CHECK-NEXT: arith.muli %[[ROW_PHASE_ORIGIN]], %[[ROW_NEXT_BANK_SIZE]] : i32
+  // CHECK: tt.load {{.*}} : tensor<2x1x2x2x!tt.ptr<i{{32|64}}>
+  // CHECK: tt.store {{.*}} : tensor<2x1x2x2x!tt.ptr<i{{32|64}}>
+  // CHECK: tt.return
+  // CHECK-LABEL: @single_buffer_dynamic_barrier_ring
+  // CHECK-SAME: (%[[ROW_DYNAMIC_INDEX:[^:]+]]: i32,
+  tt.func public @single_buffer_dynamic_barrier_ring(%idx: i32, %phase: i32) {
+    // Each entry has one eight-byte barrier per CTA.
+    // CHECK: tti.experimental_buffer_descriptors [0, 8], [8, 8], shared_mem : tensor<2xi64,
+    %c0 = arith.constant 0 : i32
+    %c1 = arith.constant 1 : i32
+    %true = arith.constant true
+    %ring = ttg.local_alloc {allocation.offset = 0 : i32} : () -> !ttg.memdesc<2x2xi64, #row_barrier, #row_smem, mutable>
+    %bar0 = ttg.memdesc_index %ring[%c0] : !ttg.memdesc<2x2xi64, #row_barrier, #row_smem, mutable> -> !ttg.memdesc<2xi64, #row_barrier, #row_smem, mutable>
+    %bar1 = ttg.memdesc_index %ring[%c1] : !ttg.memdesc<2x2xi64, #row_barrier, #row_smem, mutable> -> !ttg.memdesc<2xi64, #row_barrier, #row_smem, mutable>
+    ttng.init_barrier %bar0, 1 : !ttg.memdesc<2xi64, #row_barrier, #row_smem, mutable>
+    ttng.init_barrier %bar1, 1 : !ttg.memdesc<2xi64, #row_barrier, #row_smem, mutable>
+    // CHECK: %[[ROW_DYNAMIC:.*]] = ttg.memdesc_index {{.*}}[%[[ROW_DYNAMIC_INDEX]]]
+    %dynamic = ttg.memdesc_index %ring[%idx] : !ttg.memdesc<2x2xi64, #row_barrier, #row_smem, mutable> -> !ttg.memdesc<2xi64, #row_barrier, #row_smem, mutable>
+    // CHECK: tti.experimental_memdesc_to_i32 %[[ROW_DYNAMIC]]
+    // CHECK: internal ConSan error: active memdesc resolved to no buffer state
+    // CHECK: arith.select {{.*}} : i32
+    // CHECK: %[[ROW_SELECTED:.*]] = arith.select {{.*}} : i32
+    // CHECK: tt.call @__triton_consan_set_read_visibility_nw1_I32_{{.*}}(%[[ROW_SELECTED]],
+    // CHECK: ttng.tc_gen5_commit %[[ROW_DYNAMIC]]
+    ttng.tc_gen5_commit %dynamic : !ttg.memdesc<2xi64, #row_barrier, #row_smem, mutable>
+    ttng.wait_barrier %dynamic, %phase, %true : !ttg.memdesc<2xi64, #row_barrier, #row_smem, mutable>
+    ttng.inval_barrier %bar0 : !ttg.memdesc<2xi64, #row_barrier, #row_smem, mutable>
+    ttng.inval_barrier %bar1 : !ttg.memdesc<2xi64, #row_barrier, #row_smem, mutable>
     tt.return
   }
 }


### PR DESCRIPTION
Optimize ConSan execution time with compact strided views when buffer analysis proves a single state row. Preserve reader-generation retirement, CTA masks, and original origin/phase-bank strides. Unknown or multi-row candidates retain the full-table path.

## Performance

These measurements use the original stack based on `8ce2ac12`; they have not been repeated on the current main base.

Measured on an internal workload with the same inputs and hardware, compared with [#11447](https://github.com/triton-lang/triton/pull/11447), the preceding PR in this stack:

- Cold compilation: **80.15 s → 83.02 s (3.6% more time)**.
- Instrumented execution: **86.15 s → 80.02 s (7.1% less time)**.

Single-run measurements; small deltas may be noise. Compilation used fresh caches. This layer improves execution time but increases compilation time in this measurement.

## PR stack

Merge order (base → top):

1. [#11446 — Masked scratch stores](https://github.com/triton-lang/triton/pull/11446)
2. [#11447 — Narrow thread masks](https://github.com/triton-lang/triton/pull/11447)
3. [#11448 — Single-buffer row views](https://github.com/triton-lang/triton/pull/11448) **← this PR**
4. [#11449 — Issuing-observer views](https://github.com/triton-lang/triton/pull/11449)
5. [#11450 — Unique-barrier-slot views](https://github.com/triton-lang/triton/pull/11450)
6. [#11451 — Streaming large-table clears](https://github.com/triton-lang/triton/pull/11451)
7. [#11452 — Streaming phase-completion clears](https://github.com/triton-lang/triton/pull/11452)

