### PR TITLE
[ConSan] Load read visibility for the issuing observer

### DIFF
--- a/lib/Dialect/TritonInstrument/IR/FunctionBuilder.cpp
+++ b/lib/Dialect/TritonInstrument/IR/FunctionBuilder.cpp
@@ -2138,8 +2138,31 @@ void FunctionBuilder::createTrackVisibleAccessesCall(
         if (trackReads) {
           Value visibilityPtr = entryBlock->getArgument(nextArg++);
           Value trackingPtr = entryBlock->getArgument(nextArg++);
-          Value visibility = tti::createLoadScratchMemory(
-              fb, fb.getLoc(), visibilityPtr, readVisibilityType);
+          // Select the issuing observer before loading [Cbuf, B, Creader].
+          // The retained reader-CTA dimension keeps its full-table stride.
+          ArrayRef<int64_t> visibilityShape = readVisibilityType.getShape();
+          int64_t observerCTAStride = visibilityShape[0] * visibilityShape[1];
+          int64_t observerThreadStride = observerCTAStride * visibilityShape[2];
+          Value observerCTA =
+              tti::ExperimentalClusterCTAIdOp::create(fb, fb.getLoc());
+          Value observerCTAOffset = arith::MulIOp::create(
+              fb, observerCTA,
+              arith::ConstantIntOp::create(fb, observerCTAStride, 32));
+          Value observerThreadOffset = arith::MulIOp::create(
+              fb, threadVal,
+              arith::ConstantIntOp::create(fb, observerThreadStride, 32));
+          Value observerOffset = arith::AddIOp::create(fb, observerCTAOffset,
+                                                       observerThreadOffset);
+          Value observerPtr = triton::AddPtrOp::create(
+              fb, visibilityPtr.getType(), visibilityPtr, observerOffset);
+          RankedTensorType observerType = tti::getIntTensorType(
+              entryBlock->getParent(),
+              {visibilityShape[0], visibilityShape[1], visibilityShape[4]},
+              readVisibilityType.getElementType().getIntOrFloatBitWidth());
+          Value visibleReads = tti::createLoadScratchMemory(
+              fb, fb.getLoc(), observerPtr, observerType,
+              {1, visibilityShape[0],
+               observerThreadStride * visibilityShape[3]});
           Value tracking = tti::createLoadScratchMemory(
               fb, fb.getLoc(), trackingPtr, readTrackingType);
           Value barrierMask =
@@ -2166,17 +2189,6 @@ void FunctionBuilder::createTrackVisibleAccessesCall(
           Value phaseMask = arith::CmpIOp::create(fb, arith::CmpIPredicate::eq,
                                                   phaseIndices, currentPhase);
           barrierMask = arith::AndIOp::create(fb, barrierMask, phaseMask);
-          Value threadColumnMask =
-              createDimMask(fb, threadVal, readVisibilityType, /*dim=*/3);
-          Value zero =
-              tti::createConstIntTensor(fb, fb.getLoc(), 0, readVisibilityType);
-          Value sourceCTAMask =
-              createCTASetMask(fb, readVisibilityType, /*dim=*/2, currentCTA);
-          Value observer =
-              arith::AndIOp::create(fb, threadColumnMask, sourceCTAMask);
-          Value visibleReads =
-              arith::SelectOp::create(fb, observer, visibility, zero);
-          visibleReads = reduce<arith::OrIOp>(fb, visibleReads, {2, 3});
           visibleReads = convertAndBroadcast(fb, visibleReads, {0, 1, 4},
                                              readTrackingType);
           Value withVisible = arith::OrIOp::create(fb, tracking, visibleReads);

--- a/test/TritonGPU/consan.mlir
+++ b/test/TritonGPU/consan.mlir
@@ -802,6 +802,34 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 1 : i32, ttg.shar
 #barrier = #ttg.swizzled_shared<{vec = 1, perPhase = 1, maxPhase = 1, order = [0], CGALayout = [[1]]}>
 #smem = #ttg.shared_memory
 module attributes {"ttg.num-ctas" = 2 : i32, "ttg.num-warps" = 1 : i32, ttg.shared = 65544 : i32, ttg.target = "cuda:90", ttg.tensor_memory_size = 0 : i32, "ttg.threads-per-warp" = 32 : i32, "ttg.total-num-warps" = 1 : i32} {
+  // Read the issuing observer's [buffer CTA, buffer, reader CTA] view, not
+  // every observer. Reader CTAs retain stride 16 from the 2x2x2x2x2 table.
+  // CHECK-LABEL: tt.func private @__triton_consan_track_visible_accesses_
+  // CHECK-SAME: (%{{[^:]+}}: i32, %{{[^:]+}}: i32, %{{[^:]+}}: i1, %[[OBSERVER_THREAD:[^:]+]]: i32,
+  // CHECK-SAME: !tt.ptr<i8>{{[^,]*}}, %[[OBSERVER_VISIBILITY:[^:]+]]: !tt.ptr<i32>
+  // CHECK: tt.store {{.*}} : tensor<{{.*}}x!tt.ptr<i8>
+  // CHECK-NOT: tt.load
+  // CHECK: %[[OBSERVER_CTA:.*]] = tti.experimental_cluster_cta_id : i32
+  // CHECK-NEXT: %[[OBSERVER_CTA_STRIDE:.*]] = arith.constant 4 : i32
+  // CHECK-NEXT: %[[OBSERVER_CTA_OFFSET:.*]] = arith.muli %[[OBSERVER_CTA]], %[[OBSERVER_CTA_STRIDE]] : i32
+  // CHECK-NEXT: %[[OBSERVER_THREAD_STRIDE:.*]] = arith.constant 8 : i32
+  // CHECK-NEXT: %[[OBSERVER_THREAD_OFFSET:.*]] = arith.muli %[[OBSERVER_THREAD]], %[[OBSERVER_THREAD_STRIDE]] : i32
+  // CHECK-NEXT: %[[OBSERVER_OFFSET:.*]] = arith.addi %[[OBSERVER_CTA_OFFSET]], %[[OBSERVER_THREAD_OFFSET]] : i32
+  // CHECK-NEXT: %[[OBSERVER_PTR:.*]] = tt.addptr %[[OBSERVER_VISIBILITY]], %[[OBSERVER_OFFSET]] : !tt.ptr<i32>, i32
+  // CHECK-NEXT: %[[OBSERVER_PTRS:.*]] = tt.splat %[[OBSERVER_PTR]] : !tt.ptr<i32> -> tensor<2x2x2x!tt.ptr<i32>
+  // CHECK-NOT: tt.load
+  // CHECK: %[[OBSERVER_OWNER_PTRS:.*]] = tt.addptr %[[OBSERVER_PTRS]], {{.*}} : tensor<2x2x2x!tt.ptr<i32>
+  // CHECK-NOT: tt.load
+  // CHECK: %[[OBSERVER_BUFFER_PTRS:.*]] = tt.addptr %[[OBSERVER_OWNER_PTRS]], {{.*}} : tensor<2x2x2x!tt.ptr<i32>
+  // CHECK-NEXT: %[[READER_CTAS:.*]] = tt.make_range {end = 2 : i32, start = 0 : i32}
+  // CHECK-NEXT: %[[READER_CTA_STRIDE:.*]] = arith.constant dense<16> : tensor<2xi32
+  // CHECK-NEXT: %[[READER_CTA_OFFSETS:.*]] = arith.muli %[[READER_CTAS]], %[[READER_CTA_STRIDE]]
+  // CHECK-NEXT: %[[READER_CTA_RESHAPED:.*]] = tt.reshape %[[READER_CTA_OFFSETS]] : {{.*}} -> tensor<1x1x2xi32
+  // CHECK-NEXT: %[[READER_CTA_LAYOUT:.*]] = ttg.convert_layout %[[READER_CTA_RESHAPED]]
+  // CHECK-NEXT: %[[READER_CTA_BROADCAST:.*]] = tt.broadcast %[[READER_CTA_LAYOUT]] : {{.*}} -> tensor<2x2x2xi32
+  // CHECK-NEXT: %[[OBSERVER_READER_PTRS:.*]] = tt.addptr %[[OBSERVER_BUFFER_PTRS]], %[[READER_CTA_BROADCAST]] : tensor<2x2x2x!tt.ptr<i32>
+  // CHECK-NEXT: tt.load %[[OBSERVER_READER_PTRS]] : tensor<2x2x2x!tt.ptr<i32>
+
   // CHECK-LABEL: @clc_try_cancel_diagonal_effect_recipients
   tt.func public @clc_try_cancel_diagonal_effect_recipients() {
     %true = arith.constant true


### PR DESCRIPTION
Reduce ConSan compilation and execution time by selecting the issuing CTA and logical thread before loading read visibility. Preserve reader-CTA strides, per-recipient barrier phases, and accumulation into existing tracking state.

## Performance

These measurements use the original stack based on `8ce2ac12`; they have not been repeated on the current main base.

Measured on an internal workload with the same inputs and hardware, compared with [#11448](https://github.com/triton-lang/triton/pull/11448), the preceding PR in this stack:

- Cold compilation: **83.02 s → 78.43 s (5.5% less time)**.
- Instrumented execution: **80.02 s → 78.73 s (1.6% less time)**.

Single-run measurements; small deltas may be noise. Compilation used fresh caches.

## PR stack

Merge order (base → top):

1. [#11446 — Masked scratch stores](https://github.com/triton-lang/triton/pull/11446)
2. [#11447 — Narrow thread masks](https://github.com/triton-lang/triton/pull/11447)
3. [#11448 — Single-buffer row views](https://github.com/triton-lang/triton/pull/11448)
4. [#11449 — Issuing-observer views](https://github.com/triton-lang/triton/pull/11449) **← this PR**
5. [#11450 — Unique-barrier-slot views](https://github.com/triton-lang/triton/pull/11450)
6. [#11451 — Streaming large-table clears](https://github.com/triton-lang/triton/pull/11451)
7. [#11452 — Streaming phase-completion clears](https://github.com/triton-lang/triton/pull/11452)

