### PR TITLE
[ConSan] Slice tracking updates for unique barrier slots

### DIFF
--- a/lib/Dialect/TritonInstrument/IR/FunctionBuilder.cpp
+++ b/lib/Dialect/TritonInstrument/IR/FunctionBuilder.cpp
@@ -3,6 +3,8 @@
 #include <cassert>
 #include <optional>
 
+#include "llvm/ADT/DenseSet.h"
+
 #include "mlir/Dialect/Arith/IR/Arith.h"
 #include "mlir/Dialect/ControlFlow/IR/ControlFlowOps.h"
 #include "mlir/IR/Builders.h"
@@ -2013,9 +2015,10 @@ void FunctionBuilder::createTrackVisibleAccessesCall(
   auto barriersType = cast<RankedTensorType>(barriers.type);
   ValueType barrierStates = auxData.barrierStates.at(insertPoint);
   auto barrierStatesType = cast<RankedTensorType>(barrierStates.type);
+  uint32_t mbarLength = getMemDescLength(mbar);
   SmallVector<Value> args = {
       tti::ExperimentalMemDescToI32Op::create(b, mbar),
-      arith::ConstantIntOp::create(b, getMemDescLength(mbar), 32),
+      arith::ConstantIntOp::create(b, mbarLength, 32),
       pred,
       arith::ConstantIntOp::create(b, thread, 32),
       barriers.value,
@@ -2055,6 +2058,30 @@ void FunctionBuilder::createTrackVisibleAccessesCall(
   if (readBufferMask)
     args.push_back(readBufferMask);
 
+  auto descriptors =
+      barriers.value.getDefiningOp<tti::ExperimentalBufferDescriptorsOp>();
+  bool sliceBarrierTracking = static_cast<bool>(descriptors);
+  if (sliceBarrierTracking) {
+    llvm::SmallDenseSet<uint64_t> keys;
+    // Match BufferDescriptorsOpConversion's address trimming and length
+    // packing. Adding its common base preserves equality modulo this mask.
+    uint64_t addressMask = descriptors.getMemType() == MemType::SHARED_MEM
+                               ? (1ULL << 24) - 1
+                               : 0xffffffffULL;
+    for (auto [offset, length] :
+         llvm::zip_equal(descriptors.getOffsets(), descriptors.getLengths())) {
+      if (static_cast<uint32_t>(length) != mbarLength)
+        continue;
+      uint64_t key = (static_cast<uint64_t>(mbarLength) << 32) |
+                     (static_cast<uint32_t>(offset) & addressMask);
+      if (!keys.insert(key).second) {
+        sliceBarrierTracking = false;
+        break;
+      }
+    }
+  }
+  specializationArgs.append(static_cast<uint64_t>(sliceBarrierTracking));
+
   createCallToCachedFunction(
       b,
       readBufferMask ? "track_barrier_read_for_buffer"
@@ -2062,8 +2089,8 @@ void FunctionBuilder::createTrackVisibleAccessesCall(
       args, /*assertInfo=*/std::nullopt, specializationArgs,
       [trackWrites, trackReads, writeVisibilityType, writeTrackingType,
        readVisibilityType, barrierStatesType,
-       filterBuffer = static_cast<bool>(readBufferMask),
-       readTrackingType](ImplicitLocOpBuilder &fb, Block *entryBlock) {
+       filterBuffer = static_cast<bool>(readBufferMask), readTrackingType,
+       sliceBarrierTracking](ImplicitLocOpBuilder &fb, Block *entryBlock) {
         Value mbarOffset = entryBlock->getArgument(0);
         Value lengthVal = entryBlock->getArgument(1);
         Value pred = entryBlock->getArgument(2);
@@ -2085,27 +2112,88 @@ void FunctionBuilder::createTrackVisibleAccessesCall(
             fb, barrierStates,
             tti::createConstIntTensor(fb, fb.getLoc(), 1, barrierStatesType));
 
-        if (trackWrites) {
-          Value visibilityPtr = entryBlock->getArgument(nextArg++);
-          Value trackingPtr = entryBlock->getArgument(nextArg++);
-          Value visibility = tti::createLoadScratchMemory(
-              fb, fb.getLoc(), visibilityPtr, writeVisibilityType);
-          Value barrierMask =
-              convertAndBroadcast(fb, barriersEqBar, {3}, writeTrackingType);
-          Value barrierCTAMask =
-              createCTASetMask(fb, writeTrackingType, /*dim=*/2, barrierCTAs);
-          barrierMask = arith::AndIOp::create(fb, barrierMask, barrierCTAMask);
+        Value barrierIndex, anyMatch;
+        Value trackingPhases = currentPhases;
+        SmallVector<int> phaseDims{2, 3};
+        if (sliceBarrierTracking) {
+          auto indexType =
+              cast<RankedTensorType>(barriers.getType()).clone(fb.getI32Type());
+          Value indices = triton::MakeRangeOp::create(
+              fb, indexType, 0, indexType.getNumElements());
+          Value selectedIndices = arith::SelectOp::create(
+              fb, barriersEqBar, indices,
+              tti::createConstIntTensor(fb, fb.getLoc(), 0, indexType));
+          barrierIndex = reduceAll<arith::OrIOp>(fb, selectedIndices);
+          anyMatch = reduceAll<arith::OrIOp>(fb, barriersEqBar);
+
+          // Each recipient CTA keeps its own phase. Both phase banks remain
+          // in the viewport; remove only the uniquely selected barrier axis.
+          Value selectedPhases = arith::SelectOp::create(
+              fb,
+              convertAndBroadcast(fb, barriersEqBar, {1}, barrierStatesType),
+              currentPhases,
+              tti::createConstIntTensor(fb, fb.getLoc(), 0, barrierStatesType));
+          trackingPhases = reduceLastDim<arith::OrIOp>(fb, selectedPhases);
+          phaseDims = {2};
+        }
+
+        auto createTrackingView = [&](Value ptr, RankedTensorType type) {
+          SmallVector<int64_t> strides;
+          if (sliceBarrierTracking) {
+            ArrayRef<int64_t> shape = type.getShape();
+            int64_t barrierStride = shape[0] * shape[1] * shape[2];
+            Value offset = arith::MulIOp::create(
+                fb, barrierIndex,
+                arith::ConstantIntOp::create(fb, barrierStride, 32));
+            ptr = triton::AddPtrOp::create(fb, ptr.getType(), ptr, offset);
+            SmallVector<int64_t> compactShape;
+            int64_t stride = 1;
+            for (int dim = 0; dim < type.getRank(); ++dim) {
+              if (dim != 3) {
+                compactShape.push_back(shape[dim]);
+                strides.push_back(stride);
+              }
+              stride *= shape[dim];
+            }
+            type = tti::getIntTensorType(
+                entryBlock->getParent(), compactShape,
+                type.getElementType().getIntOrFloatBitWidth());
+          }
+          return std::make_tuple(ptr, type, std::move(strides));
+        };
+
+        auto createBarrierMask = [&](RankedTensorType type, Value ctaMask) {
+          Value mask;
+          if (sliceBarrierTracking) {
+            mask = triton::SplatOp::create(fb, type.clone(fb.getI1Type()),
+                                           anyMatch);
+          } else {
+            mask = convertAndBroadcast(fb, barriersEqBar, {3}, type);
+          }
+          mask = arith::AndIOp::create(fb, mask, ctaMask);
           Value currentPhase =
-              convertAndBroadcast(fb, currentPhases, {2, 3}, writeTrackingType);
-          Value phaseIndices = createDimIndices(
-              fb, writeTrackingType, /*dim=*/writeTrackingType.getRank() - 1);
+              convertAndBroadcast(fb, trackingPhases, phaseDims, type);
+          Value phaseIndices =
+              createDimIndices(fb, type, /*dim=*/type.getRank() - 1);
           auto phaseIndicesType =
               cast<RankedTensorType>(phaseIndices.getType());
           currentPhase =
               arith::TruncIOp::create(fb, phaseIndicesType, currentPhase);
           Value phaseMask = arith::CmpIOp::create(fb, arith::CmpIPredicate::eq,
                                                   phaseIndices, currentPhase);
-          barrierMask = arith::AndIOp::create(fb, barrierMask, phaseMask);
+          return arith::AndIOp::create(fb, mask, phaseMask).getResult();
+        };
+
+        if (trackWrites) {
+          Value visibilityPtr = entryBlock->getArgument(nextArg++);
+          auto [trackingPtr, trackingType, trackingStrides] =
+              createTrackingView(entryBlock->getArgument(nextArg++),
+                                 writeTrackingType);
+          Value visibility = tti::createLoadScratchMemory(
+              fb, fb.getLoc(), visibilityPtr, writeVisibilityType);
+          Value barrierCTAMask =
+              createCTASetMask(fb, trackingType, /*dim=*/2, barrierCTAs);
+          Value barrierMask = createBarrierMask(trackingType, barrierCTAMask);
           auto elemType =
               cast<IntegerType>(writeVisibilityType.getElementType());
           Value threadElem = adjustIntegerWidth(fb, threadVal, elemType);
@@ -2125,19 +2213,21 @@ void FunctionBuilder::createTrackVisibleAccessesCall(
               arith::AndIOp::create(fb, visibleWrites, sourceCTAMask);
           visibleWrites = reduceLastDim<arith::OrIOp>(fb, visibleWrites);
           visibleWrites =
-              convertAndBroadcast(fb, visibleWrites, {0, 1}, writeTrackingType);
+              convertAndBroadcast(fb, visibleWrites, {0, 1}, trackingType);
           Value barAndVisible =
               arith::AndIOp::create(fb, barrierMask, visibleWrites);
           Value one =
-              tti::createConstIntTensor(fb, fb.getLoc(), 1, writeTrackingType);
+              tti::createConstIntTensor(fb, fb.getLoc(), 1, trackingType);
           tti::createStoreScratchMemory(
-              fb, fb.getLoc(), trackingPtr, one, writeTrackingType,
-              /*currentCTAOnly=*/false, barAndVisible);
+              fb, fb.getLoc(), trackingPtr, one, trackingType,
+              /*currentCTAOnly=*/false, barAndVisible, trackingStrides);
         }
 
         if (trackReads) {
           Value visibilityPtr = entryBlock->getArgument(nextArg++);
-          Value trackingPtr = entryBlock->getArgument(nextArg++);
+          auto [trackingPtr, trackingType, trackingStrides] =
+              createTrackingView(entryBlock->getArgument(nextArg++),
+                                 readTrackingType);
           // Select the issuing observer before loading [Cbuf, B, Creader].
           // The retained reader-CTA dimension keeps its full-table stride.
           ArrayRef<int64_t> visibilityShape = readVisibilityType.getShape();
@@ -2164,37 +2254,25 @@ void FunctionBuilder::createTrackVisibleAccessesCall(
               {1, visibilityShape[0],
                observerThreadStride * visibilityShape[3]});
           Value tracking = tti::createLoadScratchMemory(
-              fb, fb.getLoc(), trackingPtr, readTrackingType);
-          Value barrierMask =
-              convertAndBroadcast(fb, barriersEqBar, {3}, readTrackingType);
+              fb, fb.getLoc(), trackingPtr, trackingType, trackingStrides);
           Value barrierCTAMask =
-              createCTASetMask(fb, readTrackingType, /*dim=*/2, barrierCTAs);
-          barrierMask = arith::AndIOp::create(fb, barrierMask, barrierCTAMask);
+              createCTASetMask(fb, trackingType, /*dim=*/2, barrierCTAs);
+          Value barrierMask = createBarrierMask(trackingType, barrierCTAMask);
           if (filterBuffer) {
             Value bufferMask = convertAndBroadcast(
-                fb, entryBlock->getArguments().back(), {1}, readTrackingType);
+                fb, entryBlock->getArguments().back(), {1}, trackingType);
             Value bufferCTAMask =
-                createCTASetMask(fb, readTrackingType, /*dim=*/0, barrierCTAs);
+                createCTASetMask(fb, trackingType, /*dim=*/0, barrierCTAs);
             barrierMask = arith::AndIOp::create(fb, barrierMask, bufferMask);
             barrierMask = arith::AndIOp::create(fb, barrierMask, bufferCTAMask);
           }
-          Value currentPhase =
-              convertAndBroadcast(fb, currentPhases, {2, 3}, readTrackingType);
-          Value phaseIndices = createDimIndices(
-              fb, readTrackingType, /*dim=*/readTrackingType.getRank() - 1);
-          auto phaseIndicesType =
-              cast<RankedTensorType>(phaseIndices.getType());
-          currentPhase =
-              arith::TruncIOp::create(fb, phaseIndicesType, currentPhase);
-          Value phaseMask = arith::CmpIOp::create(fb, arith::CmpIPredicate::eq,
-                                                  phaseIndices, currentPhase);
-          barrierMask = arith::AndIOp::create(fb, barrierMask, phaseMask);
-          visibleReads = convertAndBroadcast(fb, visibleReads, {0, 1, 4},
-                                             readTrackingType);
+          SmallVector<int> readerDims{0, 1, sliceBarrierTracking ? 3 : 4};
+          visibleReads =
+              convertAndBroadcast(fb, visibleReads, readerDims, trackingType);
           Value withVisible = arith::OrIOp::create(fb, tracking, visibleReads);
-          tti::createStoreScratchMemory(fb, fb.getLoc(), trackingPtr,
-                                        withVisible, readTrackingType,
-                                        /*currentCTAOnly=*/false, barrierMask);
+          tti::createStoreScratchMemory(
+              fb, fb.getLoc(), trackingPtr, withVisible, trackingType,
+              /*currentCTAOnly=*/false, barrierMask, trackingStrides);
         }
 
         fb.setInsertionPointToEnd(thenBlock);

--- a/test/TritonGPU/consan.mlir
+++ b/test/TritonGPU/consan.mlir
@@ -284,6 +284,29 @@ module attributes {"ttg.num-ctas" = 4 : i32, "ttg.num-warps" = 1 : i32, ttg.shar
   // CHECK: tt.load {{.*}} : tensor<4x2x4x!tt.ptr<i32>,
   // CHECK-NOT: ttg.barrier global_read
   // CHECK: tt.load
+  // Selecting K must retain a separate phase for each recipient CTA. Reduce
+  // only K from [Cbar, K] = [4, 2], then broadcast that [4] vector into both
+  // compact tracking masks on Cbar (dimension 2).
+  // CHECK-LABEL: tt.func private @__triton_consan_track_visible_accesses_{{.*}}_I1(
+  // CHECK: %[[MCAST_SELECTED_PHASES:.*]] = arith.select {{.*}}tensor<4x2xi{{32|64}},
+  // CHECK: %[[MCAST_PHASES:.*]] = "tt.reduce"(%[[MCAST_SELECTED_PHASES]]) <{axis = 1 : i32}>
+  // CHECK: }) : (tensor<4x2xi{{32|64}}, {{.*}}>) -> tensor<4xi{{32|64}},
+  // CHECK: %[[MCAST_WRITE_PHASE_LAYOUT:.*]] = ttg.convert_layout %[[MCAST_PHASES]]{{.*}} : tensor<4xi{{32|64}},
+  // CHECK: tt.reshape %[[MCAST_WRITE_PHASE_LAYOUT]]{{.*}} -> tensor<1x1x4x1xi{{32|64}},
+  // CHECK: %[[MCAST_WRITE_PHASE_BCAST:.*]] = tt.broadcast {{.*}} : tensor<1x1x4x1xi{{32|64}}, {{.*}}> -> tensor<4x2x4x2xi{{32|64}},
+  // CHECK: %[[MCAST_WRITE_PHASE:.*]] = arith.trunci %[[MCAST_WRITE_PHASE_BCAST]]
+  // CHECK: %[[MCAST_WRITE_PHASE_MASK:.*]] = arith.cmpi eq, {{.*}}, %[[MCAST_WRITE_PHASE]]
+  // CHECK: %[[MCAST_WRITE_BARRIER_MASK:.*]] = arith.andi {{.*}}, %[[MCAST_WRITE_PHASE_MASK]]
+  // CHECK: %[[MCAST_WRITE_STORE_MASK:.*]] = arith.andi %[[MCAST_WRITE_BARRIER_MASK]],
+  // CHECK: tt.store {{.*}}, %[[MCAST_WRITE_STORE_MASK]]{{.*}} : tensor<4x2x4x2x!tt.ptr<i8>,
+  // CHECK: %[[MCAST_READ_PHASE_LAYOUT:.*]] = ttg.convert_layout %[[MCAST_PHASES]]{{.*}} : tensor<4xi{{32|64}},
+  // CHECK: tt.reshape %[[MCAST_READ_PHASE_LAYOUT]]{{.*}} -> tensor<1x1x4x1x1xi{{32|64}},
+  // CHECK: %[[MCAST_READ_PHASE_BCAST:.*]] = tt.broadcast {{.*}} : tensor<1x1x4x1x1xi{{32|64}}, {{.*}}> -> tensor<4x2x4x4x2xi{{32|64}},
+  // CHECK: %[[MCAST_READ_PHASE:.*]] = arith.trunci %[[MCAST_READ_PHASE_BCAST]]
+  // CHECK: %[[MCAST_READ_PHASE_MASK:.*]] = arith.cmpi eq, {{.*}}, %[[MCAST_READ_PHASE]]
+  // CHECK: %[[MCAST_READ_BARRIER_MASK:.*]] = arith.andi {{.*}}, %[[MCAST_READ_PHASE_MASK]]
+  // CHECK: tt.store {{.*}}, %[[MCAST_READ_BARRIER_MASK]]{{.*}} : tensor<4x2x4x4x2x!tt.ptr<i{{32|64}}>,
+  // CHECK: tt.return
   // CHECK-LABEL: @mbarrier_multicast_four_ctas
   tt.func public @mbarrier_multicast_four_ctas() {
     %bar0 = ttg.local_alloc {allocation.offset = 0 : i32} : () -> !ttg.memdesc<4xi64, #barrier_multicast_four, #smem_multicast_four, mutable>
@@ -311,6 +334,61 @@ module attributes {"ttg.num-ctas" = 4 : i32, "ttg.num-warps" = 1 : i32, ttg.shar
     // CHECK: tt.call @__triton_consan_verify_and_update_barrier_state{{.*}}({{.*}}%[[HIGH_RECIPIENTS]], {{.*}})
     // CHECK: ttng.arrive_barrier {{.*}}multicastCTA = 2 : i32
     ttng.arrive_barrier %bar1, 1 {multicastCTA = 2 : i32} : !ttg.memdesc<4xi64, #barrier_multicast_four, #smem_multicast_four, mutable>
+    tt.return
+  }
+}
+
+// -----
+
+// Different CTA footprints can produce the same packed barrier descriptor.
+// Retain both K entries: choosing one matching index would lose a frontier.
+#duplicate_key_distributed = #ttg.swizzled_shared<{vec = 1, perPhase = 1, maxPhase = 1, order = [0], CGALayout = [[1]]}>
+#duplicate_key_replicated = #ttg.swizzled_shared<{vec = 1, perPhase = 1, maxPhase = 1, order = [0], CGALayout = [[0]]}>
+#duplicate_key_smem = #ttg.shared_memory
+
+module attributes {"ttg.num-ctas" = 2 : i32, "ttg.num-warps" = 1 : i32, "ttg.threads-per-warp" = 32 : i32, "ttg.total-num-warps" = 1 : i32, ttg.shared = 32 : i32, ttg.target = "cuda:100", ttg.tensor_memory_size = 0 : i32} {
+  // CHECK-LABEL: tt.func private @__triton_consan_track_visible_accesses_{{.*}}_I0(
+  // K=4 includes the two real barriers, a cluster rendezvous, and padding.
+  // Full tracking tensors retain every K entry and both phases, despite B=1.
+  // CHECK: tt.store {{.*}} : tensor<2x1x2x4x2x!tt.ptr<i8>,
+  // CHECK: tt.load {{.*}} : tensor<2x1x2x4x2x2x!tt.ptr<i{{32|64}}>,
+  // CHECK: tt.store {{.*}} : tensor<2x1x2x4x2x2x!tt.ptr<i{{32|64}}>,
+  // CHECK: tt.return
+  // CHECK-LABEL: @duplicate_barrier_descriptor_tracking
+  tt.func public @duplicate_barrier_descriptor_tracking() {
+    // The collision is between nonempty descriptors, not the padded entries.
+    // CHECK: tti.experimental_buffer_descriptors [16, 16, 0, 0], [8, 8, 0, 0], shared_mem : tensor<4xi64,
+    // CHECK: %[[DUP_DISTRIBUTED:.*]] = ttg.local_alloc
+    %distributed = ttg.local_alloc {allocation.offset = 16 : i32} : () -> !ttg.memdesc<2xi64, #duplicate_key_distributed, #duplicate_key_smem, mutable>
+    %zero = arith.constant 0 : i32
+    %true = arith.constant true
+    // Both CTAs execute each lifetime; the layouts select the barrier owners.
+    // CHECK: ttng.init_barrier %[[DUP_DISTRIBUTED]]
+    ttng.init_barrier %distributed, 1 : !ttg.memdesc<2xi64, #duplicate_key_distributed, #duplicate_key_smem, mutable>
+    // CHECK: tt.call @__triton_consan_track_visible_accesses_{{.*}}_I0(
+    // CHECK: ttng.arrive_barrier %[[DUP_DISTRIBUTED]]
+    ttng.arrive_barrier %distributed, 1 : !ttg.memdesc<2xi64, #duplicate_key_distributed, #duplicate_key_smem, mutable>
+    ttng.wait_barrier %distributed, %zero, %true : !ttg.memdesc<2xi64, #duplicate_key_distributed, #duplicate_key_smem, mutable>
+    // CHECK: ttng.inval_barrier %[[DUP_DISTRIBUTED]]
+    ttng.inval_barrier %distributed : !ttg.memdesc<2xi64, #duplicate_key_distributed, #duplicate_key_smem, mutable>
+    // End the per-CTA lifetimes before reusing their physical scratch offset.
+    // CHECK: ttng.cluster_barrier
+    ttng.cluster_barrier
+    // CHECK: %[[DUP_REPLICATED:.*]] = ttg.local_alloc
+    %replicated = ttg.local_alloc {allocation.offset = 16 : i32} : () -> !ttg.memdesc<1xi64, #duplicate_key_replicated, #duplicate_key_smem, mutable>
+    // CHECK: ttng.init_barrier %[[DUP_REPLICATED]]
+    ttng.init_barrier %replicated, 1 : !ttg.memdesc<1xi64, #duplicate_key_replicated, #duplicate_key_smem, mutable>
+    // Publish the lead CTA's initialization before either CTA can arrive.
+    // CHECK: ttng.fence_mbarrier_init_release_cluster
+    ttng.fence_mbarrier_init_release_cluster
+    // CHECK: ttng.cluster_barrier {relaxed = true}
+    ttng.cluster_barrier {relaxed = true}
+    // CHECK: tt.call @__triton_consan_track_visible_accesses_{{.*}}_I0(
+    // CHECK: ttng.arrive_barrier %[[DUP_REPLICATED]]
+    ttng.arrive_barrier %replicated, 1 : !ttg.memdesc<1xi64, #duplicate_key_replicated, #duplicate_key_smem, mutable>
+    ttng.wait_barrier %replicated, %zero, %true : !ttg.memdesc<1xi64, #duplicate_key_replicated, #duplicate_key_smem, mutable>
+    // CHECK: ttng.inval_barrier %[[DUP_REPLICATED]]
+    ttng.inval_barrier %replicated : !ttg.memdesc<1xi64, #duplicate_key_replicated, #duplicate_key_smem, mutable>
     tt.return
   }
 }

--- a/test/TritonGPU/consan.mlir
+++ b/test/TritonGPU/consan.mlir
@@ -340,24 +340,24 @@ module attributes {"ttg.num-ctas" = 4 : i32, "ttg.num-warps" = 1 : i32, ttg.shar
 
 // -----
 
-// Different CTA footprints can produce the same packed barrier descriptor.
-// Retain both K entries: choosing one matching index would lose a frontier.
+// Replicated and distributed allocations cover the same physical CTA storage.
+// Deduplicate their barrier descriptor and retain compact tracking views.
 #duplicate_key_distributed = #ttg.swizzled_shared<{vec = 1, perPhase = 1, maxPhase = 1, order = [0], CGALayout = [[1]]}>
 #duplicate_key_replicated = #ttg.swizzled_shared<{vec = 1, perPhase = 1, maxPhase = 1, order = [0], CGALayout = [[0]]}>
 #duplicate_key_smem = #ttg.shared_memory
 
 module attributes {"ttg.num-ctas" = 2 : i32, "ttg.num-warps" = 1 : i32, "ttg.threads-per-warp" = 32 : i32, "ttg.total-num-warps" = 1 : i32, ttg.shared = 32 : i32, ttg.target = "cuda:100", ttg.tensor_memory_size = 0 : i32} {
-  // CHECK-LABEL: tt.func private @__triton_consan_track_visible_accesses_{{.*}}_I0(
-  // K=4 includes the two real barriers, a cluster rendezvous, and padding.
-  // Full tracking tensors retain every K entry and both phases, despite B=1.
-  // CHECK: tt.store {{.*}} : tensor<2x1x2x4x2x!tt.ptr<i8>,
-  // CHECK: tt.load {{.*}} : tensor<2x1x2x4x2x2x!tt.ptr<i{{32|64}}>,
-  // CHECK: tt.store {{.*}} : tensor<2x1x2x4x2x2x!tt.ptr<i{{32|64}}>,
+  // CHECK-LABEL: tt.func private @__triton_consan_track_visible_accesses_{{.*}}_I1(
+  // K=2 includes one real barrier and a cluster rendezvous. The compact views
+  // remove K while retaining both recipient CTAs and both phases.
+  // CHECK: tt.store {{.*}} : tensor<2x1x2x2x!tt.ptr<i8>,
+  // CHECK: tt.load {{.*}} : tensor<2x1x2x2x2x!tt.ptr<i{{32|64}}>,
+  // CHECK: tt.store {{.*}} : tensor<2x1x2x2x2x!tt.ptr<i{{32|64}}>,
   // CHECK: tt.return
-  // CHECK-LABEL: @duplicate_barrier_descriptor_tracking
-  tt.func public @duplicate_barrier_descriptor_tracking() {
-    // The collision is between nonempty descriptors, not the padded entries.
-    // CHECK: tti.experimental_buffer_descriptors [16, 16, 0, 0], [8, 8, 0, 0], shared_mem : tensor<4xi64,
+  // CHECK-LABEL: @equivalent_barrier_descriptor_tracking
+  tt.func public @equivalent_barrier_descriptor_tracking() {
+    // Both lifetimes use the same nonempty descriptor.
+    // CHECK: tti.experimental_buffer_descriptors [16, 0], [8, 0], shared_mem : tensor<2xi64,
     // CHECK: %[[DUP_DISTRIBUTED:.*]] = ttg.local_alloc
     %distributed = ttg.local_alloc {allocation.offset = 16 : i32} : () -> !ttg.memdesc<2xi64, #duplicate_key_distributed, #duplicate_key_smem, mutable>
     %zero = arith.constant 0 : i32
@@ -365,7 +365,7 @@ module attributes {"ttg.num-ctas" = 2 : i32, "ttg.num-warps" = 1 : i32, "ttg.thr
     // Both CTAs execute each lifetime; the layouts select the barrier owners.
     // CHECK: ttng.init_barrier %[[DUP_DISTRIBUTED]]
     ttng.init_barrier %distributed, 1 : !ttg.memdesc<2xi64, #duplicate_key_distributed, #duplicate_key_smem, mutable>
-    // CHECK: tt.call @__triton_consan_track_visible_accesses_{{.*}}_I0(
+    // CHECK: tt.call @__triton_consan_track_visible_accesses_{{.*}}_I1(
     // CHECK: ttng.arrive_barrier %[[DUP_DISTRIBUTED]]
     ttng.arrive_barrier %distributed, 1 : !ttg.memdesc<2xi64, #duplicate_key_distributed, #duplicate_key_smem, mutable>
     ttng.wait_barrier %distributed, %zero, %true : !ttg.memdesc<2xi64, #duplicate_key_distributed, #duplicate_key_smem, mutable>
@@ -383,7 +383,7 @@ module attributes {"ttg.num-ctas" = 2 : i32, "ttg.num-warps" = 1 : i32, "ttg.thr
     ttng.fence_mbarrier_init_release_cluster
     // CHECK: ttng.cluster_barrier {relaxed = true}
     ttng.cluster_barrier {relaxed = true}
-    // CHECK: tt.call @__triton_consan_track_visible_accesses_{{.*}}_I0(
+    // CHECK: tt.call @__triton_consan_track_visible_accesses_{{.*}}_I1(
     // CHECK: ttng.arrive_barrier %[[DUP_REPLICATED]]
     ttng.arrive_barrier %replicated, 1 : !ttg.memdesc<1xi64, #duplicate_key_replicated, #duplicate_key_smem, mutable>
     ttng.wait_barrier %replicated, %zero, %true : !ttg.memdesc<1xi64, #duplicate_key_replicated, #duplicate_key_smem, mutable>


### PR DESCRIPTION
Reduce ConSan compilation and execution time by using one-slot views when descriptors prove unique barrier matching. Preserve buffer masks, recipient phases, and backing strides. Unknown or colliding descriptors retain full-table updates.

## Performance

These measurements use the original stack based on `8ce2ac12`; they have not been repeated on the current main base.

Measured on an internal workload with the same inputs and hardware, compared with [#11449](https://github.com/triton-lang/triton/pull/11449), the preceding PR in this stack:

- Cold compilation: **78.43 s → 59.41 s (24.2% less time)**.
- Instrumented execution: **78.73 s → 63.58 s (19.2% less time)**.

Single-run measurements; small deltas may be noise. Compilation used fresh caches.

## PR stack

Merge order (base → top):

1. [#11446 — Masked scratch stores](https://github.com/triton-lang/triton/pull/11446)
2. [#11447 — Narrow thread masks](https://github.com/triton-lang/triton/pull/11447)
3. [#11448 — Single-buffer row views](https://github.com/triton-lang/triton/pull/11448)
4. [#11449 — Issuing-observer views](https://github.com/triton-lang/triton/pull/11449)
5. [#11450 — Unique-barrier-slot views](https://github.com/triton-lang/triton/pull/11450) **← this PR**
6. [#11451 — Streaming large-table clears](https://github.com/triton-lang/triton/pull/11451)
7. [#11452 — Streaming phase-completion clears](https://github.com/triton-lang/triton/pull/11452)

