### PR TITLE
[ConSan] Stream large visibility and tracking clears

### DIFF
--- a/lib/Dialect/TritonInstrument/IR/FunctionBuilder.cpp
+++ b/lib/Dialect/TritonInstrument/IR/FunctionBuilder.cpp
@@ -1,5 +1,6 @@
 #include "triton/Dialect/TritonInstrument/IR/FunctionBuilder.h"
 
+#include <algorithm>
 #include <cassert>
 #include <optional>
 
@@ -1766,14 +1767,63 @@ void FunctionBuilder::createPublishWriteVisibilityCall(
 
         auto clearTable = [&](RankedTensorType tableType) {
           Value tablePtr = entryBlock->getArgument(nextArg++);
-          Value tableMask = convertAndBroadcast(fb, bufferMask, {1}, tableType);
+          SmallVector<int64_t> shape(tableType.getShape());
+          SmallVector<int64_t> strides(shape.size(), 1);
+          for (unsigned dim = 1; dim < shape.size(); ++dim)
+            strides[dim] = strides[dim - 1] * shape[dim - 1];
+          int64_t extent = shape[3];
+          unsigned bitWidth =
+              tableType.getElementType().getIntOrFloatBitWidth();
+          int64_t threadsPerWarp = ttg::lookupThreadsPerWarp(fb);
+          // Keep a warp's 128-bit vector span while streaming the K/T axis.
+          int64_t chunk = std::min<int64_t>(
+              extent, std::max<int64_t>(1, threadsPerWarp * (128 / bitWidth) /
+                                               strides[3]));
+          RankedTensorType storeType = tableType;
+          if (chunk < extent) {
+            shape[3] = chunk;
+            storeType = tti::getIntTensorType(
+                fb.getInsertionBlock()->getParent(), shape, bitWidth);
+          }
+          Value tableMask = convertAndBroadcast(fb, bufferMask, {1}, storeType);
           Value ctaMask =
-              createCTASetMask(fb, tableType, /*dim=*/0, effectCTAs);
+              createCTASetMask(fb, storeType, /*dim=*/0, effectCTAs);
           tableMask = arith::AndIOp::create(fb, tableMask, ctaMask);
-          Value zero = tti::createConstIntTensor(fb, fb.getLoc(), 0, tableType);
-          tti::createStoreScratchMemory(fb, fb.getLoc(), tablePtr, zero,
-                                        tableType, /*currentCTAOnly=*/false,
-                                        tableMask);
+          Value zero = tti::createConstIntTensor(fb, fb.getLoc(), 0, storeType);
+          if (chunk == extent) {
+            tti::createStoreScratchMemory(fb, fb.getLoc(), tablePtr, zero,
+                                          tableType, /*currentCTAOnly=*/false,
+                                          tableMask);
+            return;
+          }
+
+          Value first = arith::ConstantIntOp::create(fb, 0, 32);
+          Value step = arith::ConstantIntOp::create(fb, chunk, 32);
+          Value limit = arith::ConstantIntOp::create(fb, extent, 32);
+          Value stride = arith::ConstantIntOp::create(fb, strides[3], 32);
+          Block *preheader = fb.getInsertionBlock();
+          Block *continueBlock = preheader->splitBlock(fb.getInsertionPoint());
+          Block *loopBlock = fb.createBlock(continueBlock);
+          loopBlock->addArgument(fb.getI32Type(), fb.getLoc());
+          fb.setInsertionPointToEnd(preheader);
+          cf::BranchOp::create(fb, loopBlock, ValueRange{first});
+
+          fb.setInsertionPointToStart(loopBlock);
+          Value index = loopBlock->getArgument(0);
+          Value offset = arith::MulIOp::create(fb, index, stride);
+          Value viewPtr = triton::AddPtrOp::create(fb, tablePtr.getType(),
+                                                   tablePtr, offset);
+          // K/T is chunked, but every CTA, origin and phase retains its
+          // original physical stride in the backing table.
+          tti::createStoreScratchMemory(
+              fb, fb.getLoc(), viewPtr, zero, storeType,
+              /*currentCTAOnly=*/false, tableMask, strides);
+          Value next = arith::AddIOp::create(fb, index, step);
+          Value more =
+              arith::CmpIOp::create(fb, arith::CmpIPredicate::ult, next, limit);
+          cf::CondBranchOp::create(fb, more, loopBlock, ValueRange{next},
+                                   continueBlock, ValueRange{});
+          fb.setInsertionPointToStart(continueBlock);
         };
 
         if (clearWrites)

--- a/lib/Dialect/TritonInstrument/IR/FunctionBuilder.cpp
+++ b/lib/Dialect/TritonInstrument/IR/FunctionBuilder.cpp
@@ -1832,8 +1832,20 @@ void FunctionBuilder::createPublishWriteVisibilityCall(
           clearTable(readVisibilityType);
         if (clearReadTracking)
           clearTable(readTrackingType);
-        if (clearCopies)
-          clearTable(copiesType);
+        if (clearCopies) {
+          // Copy counters have no K/T axis to stream.
+          Value copiesPtr = entryBlock->getArgument(nextArg++);
+          Value copiesMask =
+              convertAndBroadcast(fb, bufferMask, {1}, copiesType);
+          Value ctaMask =
+              createCTASetMask(fb, copiesType, /*dim=*/0, effectCTAs);
+          copiesMask = arith::AndIOp::create(fb, copiesMask, ctaMask);
+          Value zero =
+              tti::createConstIntTensor(fb, fb.getLoc(), 0, copiesType);
+          tti::createStoreScratchMemory(fb, fb.getLoc(), copiesPtr, zero,
+                                        copiesType, /*currentCTAOnly=*/false,
+                                        copiesMask);
+        }
 
         fb.setInsertionPointToEnd(thenBlock);
         triton::ReturnOp::create(fb);

--- a/test/TritonGPU/consan.mlir
+++ b/test/TritonGPU/consan.mlir
@@ -307,6 +307,17 @@ module attributes {"ttg.num-ctas" = 4 : i32, "ttg.num-warps" = 1 : i32, ttg.shar
   // CHECK: %[[MCAST_READ_BARRIER_MASK:.*]] = arith.andi {{.*}}, %[[MCAST_READ_PHASE_MASK]]
   // CHECK: tt.store {{.*}}, %[[MCAST_READ_BARRIER_MASK]]{{.*}} : tensor<4x2x4x4x2x!tt.ptr<i{{32|64}}>,
   // CHECK: tt.return
+  // Small clear tables retain direct stores after the predicate branch.
+  // CHECK-LABEL: tt.func private @__triton_consan_publish_write_visibility_
+  // CHECK: cf.cond_br
+  // CHECK-NOT: cf.cond_br
+  // CHECK: tt.store {{.*}} : tensor<4x2x4x2x2x!tt.ptr<i8>,
+  // CHECK-NOT: cf.cond_br
+  // CHECK: tt.store {{.*}} : tensor<4x2x4x1x4x!tt.ptr<i{{32|64}}>,
+  // CHECK-NOT: cf.cond_br
+  // CHECK: tt.store {{.*}} : tensor<4x2x4x2x4x2x!tt.ptr<i{{32|64}}>,
+  // CHECK-NOT: cf.cond_br
+  // CHECK: tt.return
   // CHECK-LABEL: @mbarrier_multicast_four_ctas
   tt.func public @mbarrier_multicast_four_ctas() {
     %bar0 = ttg.local_alloc {allocation.offset = 0 : i32} : () -> !ttg.memdesc<4xi64, #barrier_multicast_four, #smem_multicast_four, mutable>
@@ -389,6 +400,80 @@ module attributes {"ttg.num-ctas" = 2 : i32, "ttg.num-warps" = 1 : i32, "ttg.thr
     ttng.wait_barrier %replicated, %zero, %true : !ttg.memdesc<1xi64, #duplicate_key_replicated, #duplicate_key_smem, mutable>
     // CHECK: ttng.inval_barrier %[[DUP_REPLICATED]]
     ttng.inval_barrier %replicated : !ttg.memdesc<1xi64, #duplicate_key_replicated, #duplicate_key_smem, mutable>
+    tt.return
+  }
+}
+
+// -----
+
+// Eight possible barrier entries give B=K=8; TCGen adds a second logical
+// thread. Clearing a write streams K/T while retaining every origin and phase.
+#stream_barrier = #ttg.swizzled_shared<{vec = 1, perPhase = 1, maxPhase = 1, order = [0], CGALayout = [[1], [2]]}>
+#stream_smem = #ttg.shared_memory
+
+module attributes {"ttg.num-ctas" = 4 : i32, "ttg.num-warps" = 1 : i32, "ttg.threads-per-warp" = 32 : i32, "ttg.total-num-warps" = 1 : i32, ttg.shared = 64 : i32, ttg.target = "cuda:100", ttg.tensor_memory_size = 0 : i32} {
+  // CHECK-LABEL: tt.func private @__triton_consan_publish_write_visibility_
+  // Write tracking streams K in groups of four, preserving the full phase stride.
+  // CHECK: %[[STREAM_W_MASK:.*]] = arith.andi {{.*}} : tensor<4x8x4x4x2xi1,
+  // CHECK-NEXT: %[[STREAM_W_ZERO:.*]] = arith.constant dense<0> : tensor<4x8x4x4x2xi8,
+  // CHECK: %[[STREAM_W_FIRST:.*]] = arith.constant 0 : i32
+  // CHECK: %[[STREAM_W_STEP:.*]] = arith.constant 4 : i32
+  // CHECK: %[[STREAM_W_LIMIT:.*]] = arith.constant 8 : i32
+  // CHECK: %[[STREAM_W_STRIDE:.*]] = arith.constant 128 : i32
+  // CHECK: cf.br ^[[STREAM_W_LOOP:bb[0-9]+]](%[[STREAM_W_FIRST]] : i32)
+  // CHECK: ^[[STREAM_W_LOOP]](%[[STREAM_W_IV:[^:]+]]: i32):
+  // CHECK: %[[STREAM_W_OFFSET:.*]] = arith.muli %[[STREAM_W_IV]], %[[STREAM_W_STRIDE]] : i32
+  // CHECK: tt.addptr {{.*}}, %[[STREAM_W_OFFSET]] : !tt.ptr<i8>, i32
+  // CHECK: arith.constant dense<1024> : tensor<2xi32,
+  // CHECK: tt.store {{.*}}, %[[STREAM_W_ZERO]], %[[STREAM_W_MASK]]{{.*}} : tensor<4x8x4x4x2x!tt.ptr<i8>,
+  // CHECK: %[[STREAM_W_NEXT:.*]] = arith.addi %[[STREAM_W_IV]], %[[STREAM_W_STEP]] : i32
+  // CHECK: %[[STREAM_W_MORE:.*]] = arith.cmpi ult, %[[STREAM_W_NEXT]], %[[STREAM_W_LIMIT]] : i32
+  // CHECK: cf.cond_br %[[STREAM_W_MORE]], ^[[STREAM_W_LOOP]](%[[STREAM_W_NEXT]] : i32),
+  // Read visibility streams T, without compressing the reader-origin stride.
+  // CHECK: %[[STREAM_T_MASK:.*]] = arith.andi {{.*}} : tensor<4x8x4x1x4xi1,
+  // CHECK-NEXT: %[[STREAM_T_ZERO:.*]] = arith.constant dense<0> : tensor<4x8x4x1x4xi{{32|64}},
+  // CHECK: %[[STREAM_T_FIRST:.*]] = arith.constant 0 : i32
+  // CHECK: %[[STREAM_T_STEP:.*]] = arith.constant 1 : i32
+  // CHECK: %[[STREAM_T_LIMIT:.*]] = arith.constant 2 : i32
+  // CHECK: %[[STREAM_T_STRIDE:.*]] = arith.constant 128 : i32
+  // CHECK: cf.br ^[[STREAM_T_LOOP:bb[0-9]+]](%[[STREAM_T_FIRST]] : i32)
+  // CHECK: ^[[STREAM_T_LOOP]](%[[STREAM_T_IV:[^:]+]]: i32):
+  // CHECK: %[[STREAM_T_OFFSET:.*]] = arith.muli %[[STREAM_T_IV]], %[[STREAM_T_STRIDE]] : i32
+  // CHECK: tt.addptr {{.*}}, %[[STREAM_T_OFFSET]] : !tt.ptr<i{{32|64}}>, i32
+  // CHECK: arith.constant dense<256> : tensor<4xi32,
+  // CHECK: tt.store {{.*}}, %[[STREAM_T_ZERO]], %[[STREAM_T_MASK]]{{.*}} : tensor<4x8x4x1x4x!tt.ptr<i{{32|64}}>,
+  // CHECK: %[[STREAM_T_NEXT:.*]] = arith.addi %[[STREAM_T_IV]], %[[STREAM_T_STEP]] : i32
+  // CHECK: %[[STREAM_T_MORE:.*]] = arith.cmpi ult, %[[STREAM_T_NEXT]], %[[STREAM_T_LIMIT]] : i32
+  // CHECK: cf.cond_br %[[STREAM_T_MORE]], ^[[STREAM_T_LOOP]](%[[STREAM_T_NEXT]] : i32),
+  // Read tracking streams K, retaining full origin and phase bank strides.
+  // CHECK: %[[STREAM_R_MASK:.*]] = arith.andi {{.*}} : tensor<4x8x4x1x4x2xi1,
+  // CHECK-NEXT: %[[STREAM_R_ZERO:.*]] = arith.constant dense<0> : tensor<4x8x4x1x4x2xi{{32|64}},
+  // CHECK: %[[STREAM_R_FIRST:.*]] = arith.constant 0 : i32
+  // CHECK: %[[STREAM_R_STEP:.*]] = arith.constant 1 : i32
+  // CHECK: %[[STREAM_R_LIMIT:.*]] = arith.constant 8 : i32
+  // CHECK: %[[STREAM_R_STRIDE:.*]] = arith.constant 128 : i32
+  // CHECK: cf.br ^[[STREAM_R_LOOP:bb[0-9]+]](%[[STREAM_R_FIRST]] : i32)
+  // CHECK: ^[[STREAM_R_LOOP]](%[[STREAM_R_IV:[^:]+]]: i32):
+  // CHECK: %[[STREAM_R_OFFSET:.*]] = arith.muli %[[STREAM_R_IV]], %[[STREAM_R_STRIDE]] : i32
+  // CHECK: tt.addptr {{.*}}, %[[STREAM_R_OFFSET]] : !tt.ptr<i{{32|64}}>, i32
+  // CHECK: arith.constant dense<1024> : tensor<4xi32,
+  // CHECK: arith.constant dense<4096> : tensor<2xi32,
+  // CHECK: tt.store {{.*}}, %[[STREAM_R_ZERO]], %[[STREAM_R_MASK]]{{.*}} : tensor<4x8x4x1x4x2x!tt.ptr<i{{32|64}}>,
+  // CHECK: %[[STREAM_R_NEXT:.*]] = arith.addi %[[STREAM_R_IV]], %[[STREAM_R_STEP]] : i32
+  // CHECK: %[[STREAM_R_MORE:.*]] = arith.cmpi ult, %[[STREAM_R_NEXT]], %[[STREAM_R_LIMIT]] : i32
+  // CHECK: cf.cond_br %[[STREAM_R_MORE]], ^[[STREAM_R_LOOP]](%[[STREAM_R_NEXT]] : i32),
+  // CHECK: tt.return
+  // CHECK-LABEL: @streamed_frontier_clear
+  tt.func public @streamed_frontier_clear(%idx: i32) {
+    // CHECK: tti.experimental_buffer_descriptors [0, 8, 16, 24, 32, 40, 48, 56], [8, 8, 8, 8, 8, 8, 8, 8], shared_mem
+    %zero = arith.constant 0 : i32
+    %true = arith.constant true
+    %ring = ttg.local_alloc {allocation.offset = 0 : i32} : () -> !ttg.memdesc<8x4xi64, #stream_barrier, #stream_smem, mutable>
+    %bar = ttg.memdesc_index %ring[%idx] : !ttg.memdesc<8x4xi64, #stream_barrier, #stream_smem, mutable> -> !ttg.memdesc<4xi64, #stream_barrier, #stream_smem, mutable>
+    ttng.init_barrier %bar, 1 : !ttg.memdesc<4xi64, #stream_barrier, #stream_smem, mutable>
+    ttng.tc_gen5_commit %bar : !ttg.memdesc<4xi64, #stream_barrier, #stream_smem, mutable>
+    ttng.wait_barrier %bar, %zero, %true : !ttg.memdesc<4xi64, #stream_barrier, #stream_smem, mutable>
+    ttng.inval_barrier %bar : !ttg.memdesc<4xi64, #stream_barrier, #stream_smem, mutable>
     tt.return
   }
 }


### PR DESCRIPTION
Reduce ConSan compilation and execution time by clearing large tables through bounded slices of the barrier/thread axis. Preserve masks, backing strides, and all origin/phase banks. Small tables retain direct stores; allocation and locking are unchanged.

## Performance

These measurements use the original stack based on `8ce2ac12`; they have not been repeated on the current main base.

Measured on an internal workload with the same inputs and hardware, compared with [#11450](https://github.com/triton-lang/triton/pull/11450), the preceding PR in this stack:

- Cold compilation: **59.41 s → 49.20 s (17.2% less time)**.
- Instrumented execution: **63.58 s → 59.44 s (6.5% less time)**.

Single-run measurements; small deltas may be noise. Compilation used fresh caches.

## PR stack

Merge order (base → top):

1. [#11446 — Masked scratch stores](https://github.com/triton-lang/triton/pull/11446)
2. [#11447 — Narrow thread masks](https://github.com/triton-lang/triton/pull/11447)
3. [#11448 — Single-buffer row views](https://github.com/triton-lang/triton/pull/11448)
4. [#11449 — Issuing-observer views](https://github.com/triton-lang/triton/pull/11449)
5. [#11450 — Unique-barrier-slot views](https://github.com/triton-lang/triton/pull/11450)
6. [#11451 — Streaming large-table clears](https://github.com/triton-lang/triton/pull/11451) **← this PR**
7. [#11452 — Streaming phase-completion clears](https://github.com/triton-lang/triton/pull/11452)

