### PR TITLE
[ConSan] Stream tracking clears after barrier phase completion

### DIFF
--- a/lib/Dialect/TritonInstrument/IR/FunctionBuilder.cpp
+++ b/lib/Dialect/TritonInstrument/IR/FunctionBuilder.cpp
@@ -1624,21 +1624,70 @@ void FunctionBuilder::createVerifyAndUpdateBarrierStateCall(
               arith::TruncIOp::create(fb, phaseStateType, newPhase);
           for (auto [index, trackingType] : llvm::enumerate(trackingTypes)) {
             Value trackingPtr = entryBlock->getArgument(8 + index);
+            SmallVector<int64_t> shape(trackingType.getShape());
+            SmallVector<int64_t> strides(shape.size(), 1);
+            for (unsigned dim = 1; dim < shape.size(); ++dim)
+              strides[dim] = strides[dim - 1] * shape[dim - 1];
+            int64_t extent = shape[1];
+            // Stream buffer rows with a warp-sized contiguous prefix. The
+            // completion and phase masks depend only on [barrier CTA, K].
+            int64_t chunk = std::min<int64_t>(
+                extent, std::max<int64_t>(1, ttg::lookupThreadsPerWarp(fb) /
+                                                 strides[1]));
+            RankedTensorType storeType = trackingType;
+            if (chunk < extent) {
+              shape[1] = chunk;
+              storeType = tti::getIntTensorType(
+                  fb.getInsertionBlock()->getParent(), shape,
+                  trackingType.getElementType().getIntOrFloatBitWidth());
+            }
             Value completedMask =
-                convertAndBroadcast(fb, completed, {2, 3}, trackingType);
+                convertAndBroadcast(fb, completed, {2, 3}, storeType);
             Value nextPhase =
-                convertAndBroadcast(fb, nextPhases, {2, 3}, trackingType);
+                convertAndBroadcast(fb, nextPhases, {2, 3}, storeType);
             Value phaseIndices =
-                createDimIndices(fb, trackingType, trackingType.getRank() - 1);
+                createDimIndices(fb, storeType, storeType.getRank() - 1);
             Value phaseMask = arith::CmpIOp::create(
                 fb, arith::CmpIPredicate::eq, phaseIndices, nextPhase);
             Value clearMask =
                 arith::AndIOp::create(fb, completedMask, phaseMask);
             Value zero =
-                tti::createConstIntTensor(fb, fb.getLoc(), 0, trackingType);
-            tti::createStoreScratchMemory(fb, fb.getLoc(), trackingPtr, zero,
-                                          trackingType,
-                                          /*currentCTAOnly=*/false, clearMask);
+                tti::createConstIntTensor(fb, fb.getLoc(), 0, storeType);
+            if (chunk == extent) {
+              tti::createStoreScratchMemory(
+                  fb, fb.getLoc(), trackingPtr, zero, trackingType,
+                  /*currentCTAOnly=*/false, clearMask);
+              continue;
+            }
+
+            Value first = arith::ConstantIntOp::create(fb, 0, 32);
+            Value step = arith::ConstantIntOp::create(fb, chunk, 32);
+            Value limit = arith::ConstantIntOp::create(fb, extent, 32);
+            Value stride = arith::ConstantIntOp::create(fb, strides[1], 32);
+            Block *preheader = fb.getInsertionBlock();
+            Block *continueBlock =
+                preheader->splitBlock(fb.getInsertionPoint());
+            Block *loopBlock = fb.createBlock(continueBlock);
+            loopBlock->addArgument(fb.getI32Type(), fb.getLoc());
+            fb.setInsertionPointToEnd(preheader);
+            cf::BranchOp::create(fb, loopBlock, ValueRange{first});
+
+            fb.setInsertionPointToStart(loopBlock);
+            Value row = loopBlock->getArgument(0);
+            Value offset = arith::MulIOp::create(fb, row, stride);
+            Value viewPtr = triton::AddPtrOp::create(fb, trackingPtr.getType(),
+                                                     trackingPtr, offset);
+            // Keep full backing strides for every CTA, barrier, origin and
+            // phase. Only the B coordinate advances between iterations.
+            tti::createStoreScratchMemory(
+                fb, fb.getLoc(), viewPtr, zero, storeType,
+                /*currentCTAOnly=*/false, clearMask, strides);
+            Value next = arith::AddIOp::create(fb, row, step);
+            Value more = arith::CmpIOp::create(fb, arith::CmpIPredicate::ult,
+                                               next, limit);
+            cf::CondBranchOp::create(fb, more, loopBlock, ValueRange{next},
+                                     continueBlock, ValueRange{});
+            fb.setInsertionPointToStart(continueBlock);
           }
         }
 

--- a/test/TritonGPU/consan.mlir
+++ b/test/TritonGPU/consan.mlir
@@ -3088,3 +3088,83 @@ module attributes {"ttg.num-ctas" = 2 : i32, "ttg.num-warps" = 1 : i32, "ttg.thr
     tt.return
   }
 }
+
+// -----
+
+// B=K=16 with four CTAs clears B in two chunks of eight, retaining the
+// completed-recipient and next-phase masks and the full backing strides.
+#phase_clear_barrier = #ttg.swizzled_shared<{vec = 1, perPhase = 1, maxPhase = 1, order = [0], CGALayout = [[1], [2]]}>
+#phase_clear_smem = #ttg.shared_memory
+
+module attributes {"ttg.num-ctas" = 4 : i32, "ttg.num-warps" = 1 : i32, "ttg.threads-per-warp" = 32 : i32, "ttg.total-num-warps" = 1 : i32, ttg.shared = 128 : i32, ttg.target = "cuda:90", ttg.tensor_memory_size = 0 : i32} {
+  // CHECK-LABEL: tt.func private @__triton_consan_verify_and_update_barrier_state_
+  // CHECK: %[[PC_DONE_WIDE:.*]] = arith.extui %[[PC_ZERO_COUNTS:[^ ]+]] : tensor<4x16xi1, {{.*}}> to tensor<4x16xi64,
+  // CHECK: %[[PC_NEW_PHASES:.*]] = arith.xori {{.*}}, %[[PC_DONE_WIDE]] : tensor<4x16xi64,
+  // CHECK: %[[PC_COMPLETED:.*]] = arith.andi %[[PC_ZERO_COUNTS]], {{.*}} : tensor<4x16xi1,
+  // CHECK: %[[PC_ANY_COMPLETED:.*]] = "tt.reduce"
+  // CHECK: cf.cond_br %[[PC_ANY_COMPLETED]],
+  // CHECK: %[[PC_NEXT_PHASES:.*]] = arith.trunci %[[PC_NEW_PHASES]] : tensor<4x16xi64, {{.*}}> to tensor<4x16xi32,
+  // Write tracking keeps Cbar/K in dimensions 2/3 and both phase banks.
+  // CHECK: ttg.convert_layout %[[PC_COMPLETED]]
+  // CHECK: %[[PC_W_DONE:.*]] = tt.broadcast {{.*}} : tensor<1x1x4x16x1xi1, {{.*}}> -> tensor<4x8x4x16x2xi1,
+  // CHECK: ttg.convert_layout %[[PC_NEXT_PHASES]]
+  // CHECK: %[[PC_W_PHASE:.*]] = tt.broadcast {{.*}} : tensor<1x1x4x16x1xi32, {{.*}}> -> tensor<4x8x4x16x2xi32,
+  // CHECK: %[[PC_W_PHASE_MASK:.*]] = arith.cmpi eq, {{.*}}, %[[PC_W_PHASE]]
+  // CHECK-NEXT: %[[PC_W_MASK:.*]] = arith.andi %[[PC_W_DONE]], %[[PC_W_PHASE_MASK]]
+  // CHECK-NEXT: %[[PC_W_ZERO:.*]] = arith.constant dense<0> : tensor<4x8x4x16x2xi8,
+  // CHECK: %[[PC_W_FIRST:.*]] = arith.constant 0 : i32
+  // CHECK: %[[PC_W_STEP:.*]] = arith.constant 8 : i32
+  // CHECK: %[[PC_W_LIMIT:.*]] = arith.constant 16 : i32
+  // CHECK: %[[PC_W_STRIDE:.*]] = arith.constant 4 : i32
+  // CHECK: cf.br ^[[PC_W_LOOP:bb[0-9]+]](%[[PC_W_FIRST]] : i32)
+  // CHECK: ^[[PC_W_LOOP]](%[[PC_W_ROW:[^:]+]]: i32):
+  // CHECK: %[[PC_W_OFFSET:.*]] = arith.muli %[[PC_W_ROW]], %[[PC_W_STRIDE]] : i32
+  // CHECK-NEXT: tt.addptr {{.*}}, %[[PC_W_OFFSET]] : !tt.ptr<i8>, i32
+  // CHECK: arith.constant dense<64> : tensor<4xi32,
+  // CHECK: arith.constant dense<256> : tensor<16xi32,
+  // CHECK: arith.constant dense<4096> : tensor<2xi32,
+  // CHECK: tt.store {{.*}}, %[[PC_W_ZERO]], %[[PC_W_MASK]]{{.*}} : tensor<4x8x4x16x2x!tt.ptr<i8>,
+  // CHECK-NEXT: %[[PC_W_NEXT:.*]] = arith.addi %[[PC_W_ROW]], %[[PC_W_STEP]] : i32
+  // CHECK-NEXT: %[[PC_W_MORE:.*]] = arith.cmpi ult, %[[PC_W_NEXT]], %[[PC_W_LIMIT]] : i32
+  // CHECK-NEXT: cf.cond_br %[[PC_W_MORE]], ^[[PC_W_LOOP]](%[[PC_W_NEXT]] : i32),
+  // Read tracking also keeps all reader origins and the full phase stride.
+  // CHECK: ttg.convert_layout %[[PC_COMPLETED]]
+  // CHECK: %[[PC_R_DONE:.*]] = tt.broadcast {{.*}} : tensor<1x1x4x16x1x1xi1, {{.*}}> -> tensor<4x8x4x16x4x2xi1,
+  // CHECK: ttg.convert_layout %[[PC_NEXT_PHASES]]
+  // CHECK: %[[PC_R_PHASE:.*]] = tt.broadcast {{.*}} : tensor<1x1x4x16x1x1xi32, {{.*}}> -> tensor<4x8x4x16x4x2xi32,
+  // CHECK: %[[PC_R_PHASE_MASK:.*]] = arith.cmpi eq, {{.*}}, %[[PC_R_PHASE]]
+  // CHECK-NEXT: %[[PC_R_MASK:.*]] = arith.andi %[[PC_R_DONE]], %[[PC_R_PHASE_MASK]]
+  // CHECK-NEXT: %[[PC_R_ZERO:.*]] = arith.constant dense<0> : tensor<4x8x4x16x4x2xi{{32|64}},
+  // CHECK: %[[PC_R_FIRST:.*]] = arith.constant 0 : i32
+  // CHECK: %[[PC_R_STEP:.*]] = arith.constant 8 : i32
+  // CHECK: %[[PC_R_LIMIT:.*]] = arith.constant 16 : i32
+  // CHECK: %[[PC_R_STRIDE:.*]] = arith.constant 4 : i32
+  // CHECK: cf.br ^[[PC_R_LOOP:bb[0-9]+]](%[[PC_R_FIRST]] : i32)
+  // CHECK: ^[[PC_R_LOOP]](%[[PC_R_ROW:[^:]+]]: i32):
+  // CHECK: %[[PC_R_OFFSET:.*]] = arith.muli %[[PC_R_ROW]], %[[PC_R_STRIDE]] : i32
+  // CHECK-NEXT: tt.addptr {{.*}}, %[[PC_R_OFFSET]] : !tt.ptr<i{{32|64}}>, i32
+  // CHECK: arith.constant dense<64> : tensor<4xi32,
+  // CHECK: arith.constant dense<256> : tensor<16xi32,
+  // CHECK: arith.constant dense<4096> : tensor<4xi32,
+  // CHECK: arith.constant dense<16384> : tensor<2xi32,
+  // CHECK: tt.store {{.*}}, %[[PC_R_ZERO]], %[[PC_R_MASK]]{{.*}} : tensor<4x8x4x16x4x2x!tt.ptr<i{{32|64}}>,
+  // CHECK-NEXT: %[[PC_R_NEXT:.*]] = arith.addi %[[PC_R_ROW]], %[[PC_R_STEP]] : i32
+  // CHECK-NEXT: %[[PC_R_MORE:.*]] = arith.cmpi ult, %[[PC_R_NEXT]], %[[PC_R_LIMIT]] : i32
+  // CHECK-NEXT: cf.cond_br %[[PC_R_MORE]], ^[[PC_R_LOOP]](%[[PC_R_NEXT]] : i32),
+  // CHECK: tt.return
+  // CHECK-LABEL: @streamed_barrier_phase_clear
+  tt.func public @streamed_barrier_phase_clear(%idx: i32) {
+    // CHECK: tti.experimental_buffer_descriptors [0, 8, 16, 24, 32, 40, 48, 56, 64, 72, 80, 88, 96, 104, 112, 120], [8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8], shared_mem
+    %zero = arith.constant 0 : i32
+    %fifteen = arith.constant 15 : i32
+    %true = arith.constant true
+    %slot = arith.andi %idx, %fifteen : i32
+    %ring = ttg.local_alloc {allocation.offset = 0 : i32} : () -> !ttg.memdesc<16x4xi64, #phase_clear_barrier, #phase_clear_smem, mutable>
+    %bar = ttg.memdesc_index %ring[%slot] : !ttg.memdesc<16x4xi64, #phase_clear_barrier, #phase_clear_smem, mutable> -> !ttg.memdesc<4xi64, #phase_clear_barrier, #phase_clear_smem, mutable>
+    ttng.init_barrier %bar, 1 : !ttg.memdesc<4xi64, #phase_clear_barrier, #phase_clear_smem, mutable>
+    ttng.arrive_barrier %bar, 1 : !ttg.memdesc<4xi64, #phase_clear_barrier, #phase_clear_smem, mutable>
+    ttng.wait_barrier %bar, %zero, %true : !ttg.memdesc<4xi64, #phase_clear_barrier, #phase_clear_smem, mutable>
+    ttng.inval_barrier %bar : !ttg.memdesc<4xi64, #phase_clear_barrier, #phase_clear_smem, mutable>
+    tt.return
+  }
+}


### PR DESCRIPTION
Optimize ConSan compilation time by streaming buffer rows during completed-phase clears. Preserve completion and next-phase masks, backing strides, and all reader origins and phase banks. Small tables retain direct stores; lifecycle checks and locking are unchanged.

## Performance

These measurements use the original stack based on `8ce2ac12`; they have not been repeated on the current main base.

Measured on an internal workload with the same inputs and hardware, compared with [#11451](https://github.com/triton-lang/triton/pull/11451), the preceding PR in this stack:

- Cold compilation: **49.20 s → 43.44 s (11.7% less time)**.
- Instrumented execution: **59.44 s → 59.66 s (0.4% more time)**.

Single-run measurements; small deltas may be noise. Compilation used fresh caches. No execution-time improvement is demonstrated by this layer.

## PR stack

Merge order (base → top):

1. [#11446 — Masked scratch stores](https://github.com/triton-lang/triton/pull/11446)
2. [#11447 — Narrow thread masks](https://github.com/triton-lang/triton/pull/11447)
3. [#11448 — Single-buffer row views](https://github.com/triton-lang/triton/pull/11448)
4. [#11449 — Issuing-observer views](https://github.com/triton-lang/triton/pull/11449)
5. [#11450 — Unique-barrier-slot views](https://github.com/triton-lang/triton/pull/11450)
6. [#11451 — Streaming large-table clears](https://github.com/triton-lang/triton/pull/11451)
7. [#11452 — Streaming phase-completion clears](https://github.com/triton-lang/triton/pull/11452) **← this PR**

