### PR TITLE
[CI] Fix lit configuration for LLVM 23

### DIFF
--- a/test/LLVMIR/di-local-variable-with-callsite-loc.mlir
+++ b/test/LLVMIR/di-local-variable-with-callsite-loc.mlir
@@ -1,4 +1,4 @@
-// RUN: LLVM_EXTRACT_DI_LOCAL_VARIABLES=1 triton-opt %s -o - --mlir-print-debuginfo --mlir-use-nameloc-as-prefix --enable-line-info --extract-variable-info | \
+// RUN: env LLVM_EXTRACT_DI_LOCAL_VARIABLES=1 triton-opt %s -o - --mlir-print-debuginfo --mlir-use-nameloc-as-prefix --enable-line-info --extract-variable-info | \
 // RUN: mlir-translate --mlir-to-llvmir | FileCheck %s
 
 // Regression test for a crash when CallSiteLoc operations coexist with

--- a/test/Plugins/test-dialect-plugin.mlir
+++ b/test/Plugins/test-dialect-plugin.mlir
@@ -1,4 +1,4 @@
-// RUN: LD_PRELOAD=%shlibdir/../plugins/libtriton.so \
+// RUN: env LD_PRELOAD=%shlibdir/../plugins/libtriton.so \
 // RUN: TRITON_PLUGIN_PATHS=%shlibdir/../plugins/libMLIRDialectPlugin.so \
 // RUN: triton-opt \
 // RUN: -split-input-file --convert-plugin-gpu-to-llvm --convert-triton-gpu-to-llvm %s | \

--- a/test/Plugins/test-plugin.mlir
+++ b/test/Plugins/test-plugin.mlir
@@ -1,9 +1,9 @@
-// RUN: LD_PRELOAD=%shlibdir/../plugins/libtriton.so \
+// RUN: env LD_PRELOAD=%shlibdir/../plugins/libtriton.so \
 // RUN: TRITON_PLUGIN_PATHS=%shlibdir/../plugins/libTritonPluginsTestLib.so \
 // RUN: triton-opt \
 // RUN: -split-input-file -tritongpu-plugin %s | FileCheck %s --check-prefix=CHECK-PLUGIN
 
-// RUN: LD_PRELOAD=%shlibdir/../plugins/libtriton.so \
+// RUN: env LD_PRELOAD=%shlibdir/../plugins/libtriton.so \
 // RUN: TRITON_PLUGIN_PATHS=%shlibdir/../plugins/libTritonPluginsTestLib.so \
 // RUN: triton-opt \
 // RUN: -split-input-file %s | FileCheck %s -allow-unused-prefixes --check-prefix=CHECK-NOFLAG

--- a/test/lit.cfg.py
+++ b/test/lit.cfg.py
@@ -14,7 +14,7 @@ from lit.llvm.subst import ToolSubst
 # name: The name of this test suite
 config.name = 'TRITON'
 
-config.test_format = lit.formats.ShTest(not llvm_config.use_lit_shell)
+config.test_format = lit.formats.ShTest(execute_external=False)
 
 # suffixes: A list of file extensions to treat as test files.
 config.suffixes = ['.mlir', '.ll']


### PR DESCRIPTION
Lit 23 rejects ShTest configurations that enable the external shell by default. CI runners using lit 23 therefore fail while parsing lit.cfg.py.

This commit selects internal shell explicitly, and updates RUN lines that use leading environment assignments to invoke them through env, which is supported by lit's internal shell.

<!---
The core Triton is a small number of people, and we receive many PRs (thank
you!).  To help us review your code more quickly, **if you are a new
contributor (less than 3 PRs merged) we ask that you complete the following
tasks and include the filled-out checklist in your PR description.**

Complete the following tasks before sending your PR, and replace `[ ]` with
`[x]` to indicate you have done them.
-->

# New contributor declaration
- [x] I am not making a trivial change, such as fixing a typo in a comment.

- [x] I have written a PR description following these
  [rules](https://cbea.ms/git-commit/#why-not-how).

- [x] I have run `pre-commit run --from-ref origin/main --to-ref HEAD`.

- Select one of the following.
  - [ ] I have added tests.
    - `/test` for `lit` tests
    - `/unittest` for C++ tests
    - `/python/test` for end-to-end tests
  - [x] This PR does not need a test because it fixes test configuration that should allow current tests to pass.

- Select one of the following.
  - [x] I have not added any `lit` tests.
  - [ ] The `lit` tests I have added follow these [best practices](https://mlir.llvm.org/getting_started/TestingGuide/#filecheck-best-practices),
    including the "tests should be minimal" section. (Usually running Python code
    and using the instructions it generates is not minimal.)
