### PR TITLE
[FRONTEND] Name the parameter when visit_arg cannot find it

### DIFF
--- a/python/test/unit/language/test_compile_errors.py
+++ b/python/test/unit/language/test_compile_errors.py
@@ -589,6 +589,30 @@ def test_err_nested_function_def():
     assert "nested function" in err_msg, "error should mention nested function"
 
 
+def test_err_unknown_parameter():
+    """A parameter present in the source but absent from the signature.
+
+    Reaching this is an internal inconsistency rather than user error, which is
+    exactly why it has to say what it found: the bare next() this replaces
+    surfaced as StopIteration() and named neither the parameter nor the function.
+    """
+
+    @triton.jit
+    def kernel(ptr, n, BLOCK: tl.constexpr):
+        offs = tl.arange(0, BLOCK)
+        tl.store(ptr + offs, tl.load(ptr + offs))
+
+    kernel.params = [p for p in kernel.params if p.name != "n"]
+
+    with pytest.raises(CompilationError) as e:
+        triton.compile(
+            triton.compiler.ASTSource(fn=kernel, signature={"ptr": "*fp32", "n": "i32"}, constexprs={"BLOCK": 128}))
+
+    err_msg = format_exception(e.type, value=e.value, tb=e.tb)
+    assert "StopIteration" not in err_msg, "unknown parameter should not leak StopIteration"
+    assert "'n' is not in the signature" in err_msg, "error should name the missing parameter"
+
+
 @pytest.mark.parametrize("ptr_ty", ["*i8", "*i16", "*i64"])
 def test_err_histogram_non_32bit_int(ptr_ty):
 

--- a/python/triton/compiler/code_generator.py
+++ b/python/triton/compiler/code_generator.py
@@ -707,7 +707,15 @@ class CodeGenerator(ast.NodeVisitor):
 
     def visit_arg(self, node):
         ast.NodeVisitor.generic_visit(self, node)
-        param = next(p for p in self.jit_fn.params if p.name == node.arg)
+        param = next((p for p in self.jit_fn.params if p.name == node.arg), None)
+        if param is None:
+            # Defensive: a bare next() here surfaces as StopIteration(), which the
+            # visitor's handler wraps into a CompilationError whose message names
+            # neither the parameter nor the function.
+            raise CompilationError(
+                self.jit_fn.src, node, f"parameter '{node.arg}' is not in the signature of "
+                f"'{self.jit_fn.__name__}', whose parameters are "
+                f"{[p.name for p in self.jit_fn.params]}.")
         if param.is_constexpr and (param.do_not_specialize or param.do_not_specialize_on_alignment):
             raise CompilationError(
                 self.jit_fn.src, node,


### PR DESCRIPTION
## Problem

`visit_arg` looks the parameter up with a bare `next()`:

```python
param = next(p for p in self.jit_fn.params if p.name == node.arg)
```

A name absent from `jit_fn.params` escapes as `StopIteration`, and the visitor's handler wraps that into a `CompilationError` whose message is the bare repr:

```
triton.compiler.errors.CompilationError: at 1:16:
def kernel(ptr, n, BLOCK: tl.constexpr):
                ^
StopIteration()
```

That names neither the parameter nor the function, so there is nothing to investigate with.

## Relation to #10004

#10004 diagnosed this same lookup and fixed the nested-`def` route into it by moving the `if self.fn:` guard ahead of `self.visit(node.args)`. That works — on 3.8.0 a nested `def` now raises the intended `UnsupportedLanguageConstruct`. It fixed the caller rather than the lookup, though, so any other path that reaches `visit_arg` with an unknown name still produces the uninformative error.

## Fix

Give the lookup a default and report what it found:

```
triton.compiler.errors.CompilationError: at 1:16:
def kernel(ptr, n, BLOCK: tl.constexpr):
                ^
parameter 'n' is not in the signature of 'kernel', whose parameters are ['ptr', 'BLOCK'].
```

Reaching this branch means the source disagrees with the signature it was compiled against, which should not happen. The point is only that when it does, the error says so.

## Motivation

We hit the bare `StopIteration` on 3.8.0 (ROCm 7.2.1, gfx950) while compiling Inductor template kernels in parallel — twice across 62 compiled graphs, in a compile worker, on an ordinary Triton kernel, reported at its signature line. It has not reproduced since across 96 further graphs under deliberately unfavourable conditions, and I cannot attribute the miss to Triton: `JITFunction.params` is eager from the signature while the AST comes from `src`, so a mismatch points at whoever constructed the `JITFunction`. Which is the point — the error gave me no way to tell. Filed as #11454.

## Test

`test_err_unknown_parameter` in `python/test/unit/language/test_compile_errors.py`, alongside the nested-`def` test from #10004 and asserting the same way: no `StopIteration` in the message, and the missing parameter named. It reaches the branch by dropping an entry from `kernel.params`, since the nested-`def` route is now closed. Verified that it fails on the unpatched lookup, on exactly the `StopIteration` assertion.
