### PR TITLE
[TritonGPU] Validate partition capture operand types in WarpSpecializeOp::verify

### DIFF
--- a/lib/Dialect/TritonGPU/IR/Ops.cpp
+++ b/lib/Dialect/TritonGPU/IR/Ops.cpp
@@ -1361,6 +1361,23 @@ LogicalResult WarpSpecializeOp::verify() {
         "its second region");
   }
 
+  // Verify that captures can be marshaled through shared memory.
+  for (auto [i, val] :
+       llvm::enumerate(getPartitionOp().getExplicitCaptures())) {
+    Type type = val.getType();
+    if (isa<RankedTensorType>(type)) {
+      return emitOpError("cannot capture ranked tensor operand '")
+             << val
+             << "' directly into warp_specialize; operands must be scalars, "
+                "pointers, tensor descriptors, or memdescs";
+    }
+    if (!isa<IntegerType, FloatType, PointerType, TensorDescInterface,
+             MemDescType>(type)) {
+      return emitOpError("unsupported capture operand type ")
+             << type << " for operand '" << val << "'";
+    }
+  }
+
   // Verify the partitions.
   if (getPartitionRegions().size() != getPartitionNumWarps().size()) {
     return emitOpError("has ") << getPartitionRegions().size()
@@ -1598,7 +1615,7 @@ LogicalResult WarpYieldOp::verify() {
   return success();
 }
 
-// Get the size of a scalar type when stored in shared memory.
+// Get the size of a type when stored in shared memory.
 // TODO: Generalize this as needed.
 size_t getSharedMemorySize(Type type) {
   if (isa<IntegerType, FloatType>(type))
@@ -1611,7 +1628,7 @@ size_t getSharedMemorySize(Type type) {
     return 8 + desc.getRank() * 4;
   }
   llvm::report_fatal_error(
-      Twine("shared memory size for scalar type is unspecified: ") +
+      Twine("shared memory size for type is unspecified: ") +
       mlir::debugString(type));
 }
 

--- a/test/TritonGPU/invalid.mlir
+++ b/test/TritonGPU/invalid.mlir
@@ -663,6 +663,23 @@ tt.func @bad_argument_type(%arg0: i32) {
 
 // -----
 
+#blocked = #ttg.blocked<{sizePerThread = [1], threadsPerWarp = [32], warpsPerCTA = [4], order = [0]}>
+module attributes {"ttg.num-warps" = 4 : i32, "ttg.threads-per-warp" = 32 : i32} {
+  tt.func @warp_specialize_tensor_capture(%arg0: tensor<128xf32, #blocked>) {
+    // expected-error @below {{'ttg.warp_specialize' op cannot capture ranked tensor operand}}
+    ttg.warp_specialize(%arg0)
+    default {
+      ttg.warp_yield
+    }
+    partition0(%arg1: tensor<128xf32, #blocked>) num_warps(2) {
+      ttg.warp_return
+    } : (tensor<128xf32, #blocked>) -> ()
+    tt.return
+  }
+}
+
+// -----
+
 tt.func @bad_default_yields(%arg0: i32) {
   ttg.warp_specialize()
   default {

--- a/third_party/nvidia/hopper/lib/Transforms/WarpSpecialization.cpp
+++ b/third_party/nvidia/hopper/lib/Transforms/WarpSpecialization.cpp
@@ -18,7 +18,7 @@ namespace mlir {
 void doTaskPartition(triton::FuncOp &funcOp, unsigned numWarpGroups);
 int doTaskIdPropagate(triton::FuncOp &funcOp);
 bool doDataPartition(triton::FuncOp &funcOp, unsigned numConsumerGroups);
-void doCodePartition(triton::FuncOp &funcOp, unsigned numBuffers);
+LogicalResult doCodePartition(triton::FuncOp &funcOp, unsigned numBuffers);
 void doTokenLowering(triton::FuncOp &funcOp, unsigned numConsumerGroups);
 
 #define GEN_PASS_DEF_NVGPUWARPSPECIALIZATION
@@ -97,7 +97,9 @@ public:
       return signalPassFailure();
     }
 
-    doCodePartition(funcOp, numStages);
+    if (failed(doCodePartition(funcOp, numStages)))
+      return signalPassFailure();
+
     if (dumpIntermediateSteps) {
       ::mlir::triton::tools::mlirDumpsOrDbgs()
           << "// -----// WarpSpec internal IR Dump After: doCodePartition\n"

--- a/third_party/nvidia/hopper/lib/Transforms/WarpSpecialization/CodePartitionUtility.h
+++ b/third_party/nvidia/hopper/lib/Transforms/WarpSpecialization/CodePartitionUtility.h
@@ -1,6 +1,7 @@
 #ifndef NV_DIALECT_HOPPER_TRANSFORMS_CODEPARTITIONUTILITY_H_
 #define NV_DIALECT_HOPPER_TRANSFORMS_CODEPARTITIONUTILITY_H_
 
+#include "mlir/Support/LogicalResult.h"
 #include "triton/Dialect/Triton/IR/Dialect.h"
 #include "triton/Dialect/TritonGPU/IR/Dialect.h"
 #include "triton/Dialect/TritonGPU/Transforms/Utility.h"
@@ -130,7 +131,7 @@ Operation *optimizeTMALoads(OpBuilderWithAsyncTaskIds &builder,
                             Value bufferIdx, Value bufferIdxExtract,
                             Value phase, Operation *headProducer,
                             Operation *headConsumer);
-void specializeRegion(triton::FuncOp funcOp, unsigned requestedRegisters);
+LogicalResult specializeRegion(triton::FuncOp funcOp, unsigned requestedRegisters);
 void invalidateWarpSpecializeBarriers(triton::FuncOp funcOp);
 
 } // namespace mlir

--- a/third_party/nvidia/hopper/lib/Transforms/WarpSpecialization/CodePartitionUtility.h
+++ b/third_party/nvidia/hopper/lib/Transforms/WarpSpecialization/CodePartitionUtility.h
@@ -131,7 +131,8 @@ Operation *optimizeTMALoads(OpBuilderWithAsyncTaskIds &builder,
                             Value bufferIdx, Value bufferIdxExtract,
                             Value phase, Operation *headProducer,
                             Operation *headConsumer);
-LogicalResult specializeRegion(triton::FuncOp funcOp, unsigned requestedRegisters);
+LogicalResult specializeRegion(triton::FuncOp funcOp,
+                               unsigned requestedRegisters);
 void invalidateWarpSpecializeBarriers(triton::FuncOp funcOp);
 
 } // namespace mlir

--- a/third_party/nvidia/hopper/lib/Transforms/WarpSpecialization/WSCodePartition.cpp
+++ b/third_party/nvidia/hopper/lib/Transforms/WarpSpecialization/WSCodePartition.cpp
@@ -1225,7 +1225,7 @@ void foldLocalLoads(triton::FuncOp funcOp) {
 
 } // namespace
 
-void doCodePartition(triton::FuncOp &funcOp, unsigned numBuffers) {
+LogicalResult doCodePartition(triton::FuncOp &funcOp, unsigned numBuffers) {
   // Step 1: collect all communications between producers and consumers.
   SmallVector<std::unique_ptr<Channel>> channelsOrigin;
   collectAsyncChannels(channelsOrigin, funcOp, numBuffers);
@@ -1234,7 +1234,7 @@ void doCodePartition(triton::FuncOp &funcOp, unsigned numBuffers) {
     channels.push_back(c.get());
   }
   if (channels.empty()) {
-    return;
+    return success();
   }
 
   // Step 2: group channels
@@ -1315,11 +1315,15 @@ void doCodePartition(triton::FuncOp &funcOp, unsigned numBuffers) {
     funcOp.dump();
   });
 
-  specializeRegion(funcOp, 0 /*requestedRegisters*/);
+  if (failed(specializeRegion(funcOp, 0 /*requestedRegisters*/)))
+    return failure();
+
   LLVM_DEBUG({
     LDBG("\n\nwith specializeRegion");
     funcOp.dump();
   });
+
+  return success();
 }
 
 #define GEN_PASS_DEF_NVGPUTESTWSCODEPARTITION
@@ -1331,18 +1335,27 @@ public:
   using impl::NVGPUTestWSCodePartitionBase<
       NVGPUTestWSCodePartitionPass>::NVGPUTestWSCodePartitionBase;
 
-  void runOnFuncOp(triton::FuncOp funcOp) {
+  LogicalResult runOnFuncOp(triton::FuncOp funcOp) {
     // Disable code partitioning when numBuffers is 0.
     if (numBuffers > 0)
-      doCodePartition(funcOp, numBuffers);
+      return doCodePartition(funcOp, numBuffers);
+    return success();
   }
+
   void runOnOperation() override {
-    getOperation()->walk([&](triton::FuncOp funcOp) { runOnFuncOp(funcOp); });
+    WalkResult result = getOperation()->walk([&](triton::FuncOp funcOp) {
+      if (failed(runOnFuncOp(funcOp)))
+        return WalkResult::interrupt();
+      return WalkResult::advance();
+    });
+
+    if (result.wasInterrupted())
+      return signalPassFailure();
+
     LLVM_DEBUG({
       LDBG("post pass");
       getOperation()->dump();
     });
-    return;
   }
 };
 

--- a/third_party/nvidia/hopper/lib/Transforms/WarpSpecialization/WSSpecialize.cpp
+++ b/third_party/nvidia/hopper/lib/Transforms/WarpSpecialization/WSSpecialize.cpp
@@ -372,7 +372,7 @@ Operation *SpecializeOp(Operation *op, IRMapping &mapping,
 
 } // namespace
 
-void specializeRegion(triton::FuncOp funcOp, unsigned requestedRegisters) {
+LogicalResult specializeRegion(triton::FuncOp funcOp, unsigned requestedRegisters) {
 
   LLVM_DEBUG({
     LDBG("\n\n");
@@ -479,9 +479,8 @@ void specializeRegion(triton::FuncOp funcOp, unsigned requestedRegisters) {
     }
 
     if (isa<RankedTensorType>(capture.getType())) {
-      mlir::emitWarning(capture.getLoc(),
-                        "FIXME: capturing tensor values into warp "
-                        "partitions is not supported");
+      return mlir::emitError(capture.getLoc(),
+                             "capturing tensor values into warp partitions is not supported");
     }
     auto partOp = wsOp.getPartitionOp();
     partOp->insertOperands(partOp.getNumOperands(), capture);
@@ -516,6 +515,7 @@ void specializeRegion(triton::FuncOp funcOp, unsigned requestedRegisters) {
     });
     op->erase();
   }
+  return mlir::success();
 }
 
 void invalidateWarpSpecializeBarriers(triton::FuncOp funcOp) {

--- a/third_party/nvidia/hopper/lib/Transforms/WarpSpecialization/WSSpecialize.cpp
+++ b/third_party/nvidia/hopper/lib/Transforms/WarpSpecialization/WSSpecialize.cpp
@@ -372,7 +372,8 @@ Operation *SpecializeOp(Operation *op, IRMapping &mapping,
 
 } // namespace
 
-LogicalResult specializeRegion(triton::FuncOp funcOp, unsigned requestedRegisters) {
+LogicalResult specializeRegion(triton::FuncOp funcOp,
+                               unsigned requestedRegisters) {
 
   LLVM_DEBUG({
     LDBG("\n\n");
@@ -479,8 +480,9 @@ LogicalResult specializeRegion(triton::FuncOp funcOp, unsigned requestedRegister
     }
 
     if (isa<RankedTensorType>(capture.getType())) {
-      return mlir::emitError(capture.getLoc(),
-                             "capturing tensor values into warp partitions is not supported");
+      return mlir::emitError(
+          capture.getLoc(),
+          "capturing tensor values into warp partitions is not supported");
     }
     auto partOp = wsOp.getPartitionOp();
     partOp->insertOperands(partOp.getNumOperands(), capture);


### PR DESCRIPTION
Fixes #11405

### Description

`ttg.warp_specialize` marshals explicit captures through shared memory to communicate operands across partition regions. Capturing `RankedTensorType` values directly aborts the compiler via `llvm::report_fatal_error` without source location info or diagnostics during downstream shared memory allocation (`Allocation.cpp` / `getCaptureSize`).

Because shared memory allocation unconditionally inspects all `ttg.warp_specialize` ops, any pipeline that leaves a tensor capture unlowered crashes the compiler. This PR resolves the issue end-to-end:

1. **Dialect Verification:** Adds capture operand type validation in `WarpSpecializeOp::verify()` to reject `RankedTensorType` captures and restrict operands to marshalable types (integers, floats, pointers, tensor descriptors, and memdescs).
2. **Pass Pipeline Error Propagation:** Upgrades unsupported tensor capture handling from a passive warning to an explicit `mlir::emitError` in `WSSpecialize.cpp`, returning `LogicalResult` across `doCodePartition` and halting pass execution via `signalPassFailure()` in both `NVGPUWarpSpecializationPass` and `NVGPUTestWSCodePartitionPass` before downstreams (token lowering, barrier invalidation) run.

---

### Changes

* **`lib/Dialect/TritonGPU/IR/Ops.cpp`**: Added explicit operand type validation in `WarpSpecializeOp::verify()`.
* **`third_party/nvidia/hopper/lib/Transforms/WarpSpecialization/CodePartitionUtility.h`**: Updated `specializeRegion` signature to return `mlir::LogicalResult`.
* **`third_party/nvidia/hopper/lib/Transforms/WarpSpecialization/WSSpecialize.cpp`**: Emitted error on unsupported tensor captures and returned `mlir::LogicalResult` from `specializeRegion`.
* **`third_party/nvidia/hopper/lib/Transforms/WarpSpecialization/WSCodePartition.cpp`**: Updated `doCodePartition` to return `LogicalResult` and propagated failure in `NVGPUTestWSCodePartitionPass`.
* **`third_party/nvidia/hopper/lib/Transforms/WarpSpecialization.cpp`**: Synced `doCodePartition` forward declaration to return `LogicalResult` and halted execution via `signalPassFailure()` on failure.
* **`test/TritonGPU/invalid.mlir`**: Added negative diagnostic test case (`@warp_specialize_tensor_capture`) verifying proper error emission.

---

### Validation

* Ran `triton-opt --split-input-file test/TritonGPU/invalid.mlir --verify-diagnostics` (passed).
* Verified dialect and Hopper transform pass test suites pass cleanly.