### PR TITLE
[ConSan] Synchronize replicated scratch loads

### DIFF
--- a/lib/Dialect/TritonInstrument/IR/FunctionBuilder.cpp
+++ b/lib/Dialect/TritonInstrument/IR/FunctionBuilder.cpp
@@ -1013,9 +1013,6 @@ void FunctionBuilder::createClusterBarrierRendezvousCall(
         tti::createConstIntTensor(b, b.getLoc(), 0, statesType));
     Value result = arith::TruncIOp::create(b, b.getI1Type(),
                                            reduceAll<arith::OrIOp>(b, phase));
-    // Every warp must sample this phase before the elected warp can advance
-    // it; otherwise sibling warps can wait for opposite rendezvous epochs.
-    ttg::BarrierOp::create(b, b.getLoc(), ttg::AddrSpace::GlobalRead);
     return result;
   };
   auto updateWaiting = [&](Value phase, Value pred, bool markWaiting) {
@@ -1439,9 +1436,6 @@ void FunctionBuilder::createVerifyAndUpdateBarrierStateCall(
 
         Value states = tti::createLoadScratchMemory(fb, fb.getLoc(), statesPtr,
                                                     barrierStatesType);
-        // Finish all replicated reads before any thread updates the state.
-        // Otherwise copies can disagree on entering phase-clearing collectives.
-        ttg::BarrierOp::create(fb, fb.getLoc(), ttg::AddrSpace::GlobalRead);
         Value descriptor = createBufferDescriptor(fb, mbarOffset, lengthVal);
         Value mask = createCmpIntTensorScalar(fb, barriers, descriptor);
         mask = convertAndBroadcast(fb, mask, {1}, barrierStatesType);

--- a/lib/Dialect/TritonInstrument/IR/FunctionBuilder.cpp
+++ b/lib/Dialect/TritonInstrument/IR/FunctionBuilder.cpp
@@ -1439,6 +1439,9 @@ void FunctionBuilder::createVerifyAndUpdateBarrierStateCall(
 
         Value states = tti::createLoadScratchMemory(fb, fb.getLoc(), statesPtr,
                                                     barrierStatesType);
+        // Finish all replicated reads before any thread updates the state.
+        // Otherwise copies can disagree on entering phase-clearing collectives.
+        ttg::BarrierOp::create(fb, fb.getLoc(), ttg::AddrSpace::GlobalRead);
         Value descriptor = createBufferDescriptor(fb, mbarOffset, lengthVal);
         Value mask = createCmpIntTensorScalar(fb, barriers, descriptor);
         mask = convertAndBroadcast(fb, mask, {1}, barrierStatesType);

--- a/lib/Dialect/TritonInstrument/IR/Utility.cpp
+++ b/lib/Dialect/TritonInstrument/IR/Utility.cpp
@@ -8,6 +8,7 @@
 #include "triton/Dialect/Triton/IR/Utility.h"
 #include "triton/Dialect/TritonGPU/IR/Attributes.h"
 #include "triton/Dialect/TritonGPU/IR/Dialect.h"
+#include "triton/Dialect/TritonGPU/IR/LinearLayoutConversions.h"
 #include "triton/Dialect/TritonGPU/IR/TritonGPUInterfaces.h"
 #include "triton/Dialect/TritonInstrument/IR/Dialect.h"
 #include "triton/Dialect/TritonInstrument/IR/FunctionBuilder.h"
@@ -386,8 +387,14 @@ Operation *createStoreScratchMemory(OpBuilder &b, Location loc, Value alloc,
 Value createLoadScratchMemory(OpBuilder &b, Location loc, Value alloc,
                               RankedTensorType tensorType) {
   auto ptrTensor = createPointerTensor(b, loc, alloc, tensorType);
-  return LoadOp::create(b, loc, ptrTensor, CacheModifier::NONE,
-                        EvictionPolicy::NORMAL, false);
+  Value value = LoadOp::create(b, loc, ptrTensor, CacheModifier::NONE,
+                               EvictionPolicy::NORMAL, false);
+  // Finish replicated reads before another thread can update the scratch.
+  auto freeVarMasks = toLinearLayout(tensorType).getFreeVariableMasks();
+  if (freeVarMasks.lookup(b.getStringAttr("lane")) ||
+      freeVarMasks.lookup(b.getStringAttr("warp")))
+    BarrierOp::create(b, loc, AddrSpace::GlobalRead);
+  return value;
 }
 
 FuncOp getEntryPoint(ModuleOp module) {

--- a/python/test/gluon/test_consan.py
+++ b/python/test/gluon/test_consan.py
@@ -1091,6 +1091,51 @@ def test_async_tma_kernel_2bufs_1bar(FAILURE, device, run_wrapper, monkeypatch, 
     kernel[(1, )](a_desc, b_desc, output, FAILURE=FAILURE, num_warps=4, num_ctas=num_ctas)
 
 
+@pytest.mark.skipif(not is_cuda() or torch.cuda.get_device_capability()[0] < 9, reason="Requires Hopper or newer")
+def test_tma_barrier_state_snapshot(device, run_wrapper, monkeypatch):
+    if run_wrapper:
+        result = run_in_process(test_tma_barrier_state_snapshot, (device, False, monkeypatch))
+        assert result.exc is None
+        assert result.driver_stderr_output == ""
+        return
+
+    monkeypatch.setenv("TRITON_INSTRUMENTATION_MODE", "consan")
+    knobs.refresh_knobs()
+
+    @gluon.jit
+    def kernel(input_desc, output, iterations):
+        block: ttgl.constexpr = input_desc.block_type.shape[0]
+        layout: ttgl.constexpr = ttgl.BlockedLayout([1], [32], [8], [0])
+        smem = ttgl.allocate_shared_memory(ttgl.int32, [block], input_desc.layout)
+        bars = mbarrier.allocate_mbarrier(batch=4)
+        for i in ttgl.static_range(4):
+            mbarrier.init(bars.index(i), count=1)
+
+        # Four barrier-state rows are replicated across the eight-warp CTA.
+        # Every copy must agree on which phase to clear after TMA completion.
+        for iteration in range(iterations):
+            for i in ttgl.static_range(4):
+                bar = bars.index(i)
+                mbarrier.expect(bar, input_desc.nbytes_per_cta)
+                tma.async_load(input_desc, [ttgl.program_id(0) * block], bar, smem)
+                mbarrier.wait(bar, iteration & 1, deps=[smem])
+
+        for i in ttgl.static_range(4):
+            mbarrier.invalidate(bars.index(i))
+        offsets = ttgl.program_id(0) * block + ttgl.arange(0, block, layout=layout)
+        ttgl.store(output + offsets, smem.load(layout))
+
+    block, blocks = 128, 32
+    values = torch.arange(block * blocks, device=device, dtype=torch.int32)
+    output = torch.empty_like(values)
+    shared_layout = ttgl.NVMMASharedLayout.get_default_for([block], ttgl.int32)
+    input_desc = gluon.nvidia.hopper.TensorDescriptor.from_tensor(values, [block], shared_layout)
+    kernel[(blocks, )](input_desc, output, 64, num_warps=8, num_ctas=1)
+    if is_compile_warmup():
+        return
+    torch.testing.assert_close(output, values)
+
+
 @pytest.mark.skipif(not is_cuda() or torch.cuda.get_device_capability()[0] < 9, reason="Requires hopper or newer")
 @pytest.mark.parametrize("EXPECT_DELTA", [-16, 16], ids=["under", "over"])
 def test_async_tma_expect_bytes_mismatch(EXPECT_DELTA, device, run_wrapper, monkeypatch, num_ctas):

--- a/python/test/gluon/test_consan.py
+++ b/python/test/gluon/test_consan.py
@@ -1091,51 +1091,6 @@ def test_async_tma_kernel_2bufs_1bar(FAILURE, device, run_wrapper, monkeypatch, 
     kernel[(1, )](a_desc, b_desc, output, FAILURE=FAILURE, num_warps=4, num_ctas=num_ctas)
 
 
-@pytest.mark.skipif(not is_cuda() or torch.cuda.get_device_capability()[0] < 9, reason="Requires Hopper or newer")
-def test_tma_barrier_state_snapshot(device, run_wrapper, monkeypatch):
-    if run_wrapper:
-        result = run_in_process(test_tma_barrier_state_snapshot, (device, False, monkeypatch))
-        assert result.exc is None
-        assert result.driver_stderr_output == ""
-        return
-
-    monkeypatch.setenv("TRITON_INSTRUMENTATION_MODE", "consan")
-    knobs.refresh_knobs()
-
-    @gluon.jit
-    def kernel(input_desc, output, iterations):
-        block: ttgl.constexpr = input_desc.block_type.shape[0]
-        layout: ttgl.constexpr = ttgl.BlockedLayout([1], [32], [8], [0])
-        smem = ttgl.allocate_shared_memory(ttgl.int32, [block], input_desc.layout)
-        bars = mbarrier.allocate_mbarrier(batch=4)
-        for i in ttgl.static_range(4):
-            mbarrier.init(bars.index(i), count=1)
-
-        # Four barrier-state rows are replicated across the eight-warp CTA.
-        # Every copy must agree on which phase to clear after TMA completion.
-        for iteration in range(iterations):
-            for i in ttgl.static_range(4):
-                bar = bars.index(i)
-                mbarrier.expect(bar, input_desc.nbytes_per_cta)
-                tma.async_load(input_desc, [ttgl.program_id(0) * block], bar, smem)
-                mbarrier.wait(bar, iteration & 1, deps=[smem])
-
-        for i in ttgl.static_range(4):
-            mbarrier.invalidate(bars.index(i))
-        offsets = ttgl.program_id(0) * block + ttgl.arange(0, block, layout=layout)
-        ttgl.store(output + offsets, smem.load(layout))
-
-    block, blocks = 128, 32
-    values = torch.arange(block * blocks, device=device, dtype=torch.int32)
-    output = torch.empty_like(values)
-    shared_layout = ttgl.NVMMASharedLayout.get_default_for([block], ttgl.int32)
-    input_desc = gluon.nvidia.hopper.TensorDescriptor.from_tensor(values, [block], shared_layout)
-    kernel[(blocks, )](input_desc, output, 64, num_warps=8, num_ctas=1)
-    if is_compile_warmup():
-        return
-    torch.testing.assert_close(output, values)
-
-
 @pytest.mark.skipif(not is_cuda() or torch.cuda.get_device_capability()[0] < 9, reason="Requires hopper or newer")
 @pytest.mark.parametrize("EXPECT_DELTA", [-16, 16], ids=["under", "over"])
 def test_async_tma_expect_bytes_mismatch(EXPECT_DELTA, device, run_wrapper, monkeypatch, num_ctas):

--- a/test/TritonGPU/consan.mlir
+++ b/test/TritonGPU/consan.mlir
@@ -1117,6 +1117,11 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 1 : i32, ttg.shar
 #smem = #ttg.shared_memory
 #blocked = #ttg.blocked<{sizePerThread = [1, 128], threadsPerWarp = [32, 1], warpsPerCTA = [1, 1], order = [0, 1]}>
 module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 1 : i32, ttg.shared = 65544 : i32, ttg.target = "cuda:90", ttg.tensor_memory_size = 0 : i32, "ttg.threads-per-warp" = 32 : i32, "ttg.total-num-warps" = 1 : i32} {
+  // Replicated state loads must finish before any thread updates the rows.
+  // CHECK-LABEL: tt.func private @__triton_consan_verify_and_update_barrier_state
+  // CHECK: tt.load
+  // CHECK-NEXT: ttg.barrier global_read
+  // CHECK: tt.store
   // CHECK-LABEL: @arrive_barrier
   tt.func public @arrive_barrier(%arg0: !tt.tensordesc<32x32xf32, #shared>) {
     // CHECK-DAG: %[[BSTATE_GLOB:.*]] = ttg.global_scratch_alloc {alignment = 16 : i32, nbytes = 8 : i32, shared_cluster_state, third_party_allocation, tt.divisibility = 16 : i64} : !tt.ptr<i64>

--- a/test/TritonGPU/consan.mlir
+++ b/test/TritonGPU/consan.mlir
@@ -11,6 +11,7 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 1 : i32, ttg.shar
   // CHECK-DAG: #[[BUFS_BARS_L:.*]] = #ttg.linear<{register = [], lane = {{\[}}[0, 0], [0, 0], [0, 0], [0, 0], [0, 0]], warp = [], block = []}>
   // CHECK-LABEL: tt.func private @__triton_consan_verify_write_visibility_
   // CHECK: %[[WRITE_VISIBILITY:.*]] = tt.load
+  // CHECK-NEXT: ttg.barrier global_read
   // CHECK: arith.cmpi eq, %[[WRITE_VISIBILITY]],
   // CHECK: %[[SELECTED_THREAD_BIT:.*]] = arith.shli
   // CHECK: %[[VISIBLE_THREAD_BITS:.*]] = arith.andi %[[WRITE_VISIBILITY]], %[[SELECTED_THREAD_BIT]]
@@ -44,6 +45,10 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 1 : i32, ttg.shar
 #call_load_blocked = #ttg.blocked<{sizePerThread = [4], threadsPerWarp = [32], warpsPerCTA = [4], order = [0], CGALayout = [[1]]}>
 
 module attributes {"ttg.num-ctas" = 2 : i32, "ttg.num-warps" = 4 : i32, "ttg.threads-per-warp" = 32 : i32, "ttg.total-num-warps" = 4 : i32, ttg.shared = 1024 : i32, ttg.target = "cuda:90", ttg.tensor_memory_size = 0 : i32} {
+  // Lanes read distinct entries, but each warp loads its own copy.
+  // CHECK-LABEL: tt.func private @__triton_consan_set_read_visibility_
+  // CHECK: tt.load {{.*}} : tensor<2x4x2x1x2x!tt.ptr<i64>,
+  // CHECK-NEXT: ttg.barrier global_read
   // Scratch in a non-entry function is summarized by the call's virtual
   // shared-memory frame. The callee body itself is not instrumented.
   // CHECK-LABEL: tt.func private @scratch_only_callee
@@ -209,6 +214,11 @@ module attributes {"ttg.num-ctas" = 2 : i32, "ttg.num-warps" = 1 : i32, ttg.shar
 #barrier_multicast_four = #ttg.swizzled_shared<{vec = 1, perPhase = 1, maxPhase = 1, order = [0], CGALayout = [[1], [2]]}>
 #smem_multicast_four = #ttg.shared_memory
 module attributes {"ttg.num-ctas" = 4 : i32, "ttg.num-warps" = 1 : i32, ttg.shared = 64 : i32, ttg.target = "cuda:107", ttg.tensor_memory_size = 0 : i32, "ttg.threads-per-warp" = 32 : i32, "ttg.total-num-warps" = 1 : i32} {
+  // Replication across CTAs alone does not require an intra-CTA barrier.
+  // CHECK-LABEL: tt.func private @__triton_consan_check_all_active_waiting_
+  // CHECK: tt.load {{.*}} : tensor<4x2x4x!tt.ptr<i32>,
+  // CHECK-NOT: ttg.barrier global_read
+  // CHECK: tt.load
   // CHECK-LABEL: @mbarrier_multicast_four_ctas
   tt.func public @mbarrier_multicast_four_ctas() {
     %bar0 = ttg.local_alloc {allocation.offset = 0 : i32} : () -> !ttg.memdesc<4xi64, #barrier_multicast_four, #smem_multicast_four, mutable>


### PR DESCRIPTION
Replicated scratch loads can race with later stores by another thread, giving replicas inconsistent snapshots. In ConSan's barrier-state updates, this can make some lanes return while others enter a phase-clearing collective.

Emit a `GlobalRead` barrier in `createLoadScratchMemory` when the layout broadcasts across lanes or warps, and remove redundant barriers at the callers. Register-only or CTA-only replication does not trigger a barrier. The shared helper also serves FPSan; existing completion and cluster barriers remain intact.

Add IR checks for lane, warp-only, and CTA-only replication using existing test cases.
