### PR TITLE
Reject tensor operations in reduce and scan regions

### DIFF
--- a/lib/Dialect/Triton/IR/Ops.cpp
+++ b/lib/Dialect/Triton/IR/Ops.cpp
@@ -619,6 +619,22 @@ template <class ReturnOp, class Op> LogicalResult verifyRegionsImpl(Op &op) {
              << " to have type " << argElemTy << " but got " << resultTy;
     }
   }
+
+  auto walkRes = op.getCombineOp().walk([&](Operation *nestedOp) -> WalkResult {
+    auto hasTensorType = [](auto types) {
+      return llvm::any_of(
+          types, [](Type type) { return isa<RankedTensorType>(type); });
+    };
+    if (hasTensorType(nestedOp->getOperandTypes()) ||
+        hasTensorType(nestedOp->getResultTypes())) {
+      nestedOp->emitOpError() << "tensor operations are not allowed inside '"
+                              << op->getName() << "' combine region";
+      return WalkResult::interrupt();
+    }
+    return WalkResult::advance();
+  });
+  if (walkRes.wasInterrupted())
+    return failure();
   return success();
 }
 

--- a/test/Triton/invalid.mlir
+++ b/test/Triton/invalid.mlir
@@ -204,6 +204,36 @@ tt.func public @fn(%v1: tensor<4x128xf32>, %v2: tensor<4x128xi64>) {
 
 // -----
 
+tt.func public @reduce_with_tensor_op(%v: tensor<4x128xi32>) {
+    %a = "tt.reduce" (%v) ({
+    ^bb0(%arg0: i32, %arg1: i32):
+      %condition = arith.cmpi sgt, %arg0, %arg1 : i32
+      // expected-error @+1 {{tensor operations are not allowed inside 'tt.reduce' combine region}}
+      %tensor_condition = tt.splat %condition : i1 -> tensor<1xi1>
+      tt.assert %tensor_condition, "unexpected value" : tensor<1xi1>
+      %add = arith.addi %arg0, %arg1 : i32
+      tt.reduce.return %add : i32
+    }) {axis = 1 : i32} : (tensor<4x128xi32>) -> tensor<4xi32>
+    tt.return
+}
+
+// -----
+
+tt.func public @scan_with_tensor_op(%v: tensor<4x128xi32>) {
+    %a = "tt.scan" (%v) ({
+    ^bb0(%arg0: i32, %arg1: i32):
+      %condition = arith.cmpi sgt, %arg0, %arg1 : i32
+      // expected-error @+1 {{tensor operations are not allowed inside 'tt.scan' combine region}}
+      %tensor_condition = tt.splat %condition : i1 -> tensor<1xi1>
+      tt.assert %tensor_condition, "unexpected value" : tensor<1xi1>
+      %add = arith.addi %arg0, %arg1 : i32
+      tt.scan.return %add : i32
+    }) {axis = 1 : i32, reverse = false} : (tensor<4x128xi32>) -> tensor<4x128xi32>
+    tt.return
+}
+
+// -----
+
 #blocked = #ttg.blocked<{sizePerThread = [1], threadsPerWarp = [32], warpsPerCTA = [1], order = [0]}>
 module attributes {"ttg.target" = "cuda:80", "ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 1 : i32, "ttg.threads-per-warp" = 32 : i32} {
 tt.func public @fn(%arg0: tensor<32xf32, #blocked>) {


### PR DESCRIPTION
## Why

Reduce and scan combine regions operate on scalar block arguments, but their verifier currently allows nested operations with tensor operands or results. Such unsupported IR can reach lowering and introduce invalid control flow around operations such as `tt.assert`, including divergent barriers.

Rejecting tensor-typed operations during IR verification makes the restriction explicit and reports the offending operation before backend lowering.

Fixes #5632.

## What changed

- Recursively verify the combine regions of both `tt.reduce` and `tt.scan`.
- Reject an operation when any operand or result has a ranked tensor type.
- Add minimal invalid-IR coverage for reduce and scan.

## Validation

- Baseline at `0c91a25bf19d2a5d07d33e556956f30850d5a966`: `TRITON :: Triton/invalid.mlir` failed because both new expected diagnostics were not produced.
- Patched focused test: `TRITON :: Triton/invalid.mlir` passed.
- Full lit suite: 297 passed, 2 unsupported, 0 failed.
- `make -j16 all PYTHON=.venv/bin/python` completed successfully.
- `pre-commit run --from-ref origin/main --to-ref HEAD` passed.
- `git diff --check origin/main...HEAD` passed.

# New contributor declaration
- [x] I am not making a trivial change, such as fixing a typo in a comment.

- [x] I have written a PR description following these
  [rules](https://cbea.ms/git-commit/#why-not-how).

- [x] I have run `pre-commit run --from-ref origin/main --to-ref HEAD`.

- Select one of the following.
  - [x] I have added tests.
    - `/test` for `lit` tests
    - `/unittest` for C++ tests
    - `/python/test` for end-to-end tests
  - [ ] This PR does not need a test because `FILL THIS IN`.

- Select one of the following.
  - [ ] I have not added any `lit` tests.
  - [x] The `lit` tests I have added follow these [best practices](https://mlir.llvm.org/getting_started/TestingGuide/#filecheck-best-practices),
    including the "tests should be minimal" section.