### PR TITLE
[Membar] Preserve memory state across relaxed cluster barriers

### DIFF
--- a/lib/Dialect/TritonNvidiaGPU/Transforms/ClusterBarrierInsertion.cpp
+++ b/lib/Dialect/TritonNvidiaGPU/Transforms/ClusterBarrierInsertion.cpp
@@ -277,8 +277,9 @@ private:
 
 void ClusterBarrierAnalysis::update(Operation *op, MembarInfo *membarInfo,
                                     FuncMapT *funcMap, OpBuilder *builder) {
-  if (isa<ttng::ClusterBarrierOp>(op)) {
-    membarInfo->sync();
+  if (auto clusterBarrier = dyn_cast<ttng::ClusterBarrierOp>(op)) {
+    if (!clusterBarrier.getRelaxed())
+      membarInfo->sync();
     return;
   }
 

--- a/test/TritonNvidiaGPU/membar-cluster.mlir
+++ b/test/TritonNvidiaGPU/membar-cluster.mlir
@@ -20,6 +20,23 @@ module attributes {"ttg.num-ctas" = 2 : i32, "ttg.num-warps" = 4 : i32, ttg.targ
     %ld = ttg.local_load %buf : !ttg.memdesc<256x128xf16, #shared, #smem, mutable> -> tensor<256x128xf16, #blockedSplitM>
     tt.return %ld : tensor<256x128xf16, #blockedSplitM>
   }
+
+  // A relaxed cluster barrier does not synchronize memory. A strong barrier
+  // is still required before reusing shared memory touched by convert_layout.
+  // CHECK-LABEL: @relaxed_cluster_barrier_does_not_sync_memory
+  // CHECK: ttg.convert_layout
+  // CHECK-NEXT: ttng.cluster_barrier {relaxed = true}
+  // CHECK-NEXT: ttng.cluster_barrier{{$}}
+  // CHECK-NEXT: ttg.local_alloc
+  tt.func @relaxed_cluster_barrier_does_not_sync_memory() -> tensor<256x128xf16, #blockedSplitM> {
+    %cst = arith.constant dense<0.000000e+00> : tensor<256x128xf16, #blockedSplitM>
+    %cvt = ttg.convert_layout %cst : tensor<256x128xf16, #blockedSplitM> -> tensor<256x128xf16, #blockedSplitN>
+    ttng.cluster_barrier {relaxed = true}
+    %buf = ttg.local_alloc %cvt : (tensor<256x128xf16, #blockedSplitN>) -> !ttg.memdesc<256x128xf16, #shared, #smem, mutable>
+    ttg.local_store %cvt, %buf : tensor<256x128xf16, #blockedSplitN> -> !ttg.memdesc<256x128xf16, #shared, #smem, mutable>
+    %ld = ttg.local_load %buf : !ttg.memdesc<256x128xf16, #shared, #smem, mutable> -> tensor<256x128xf16, #blockedSplitM>
+    tt.return %ld : tensor<256x128xf16, #blockedSplitM>
+  }
 }
 
 // -----


### PR DESCRIPTION
## Summary

A relaxed cluster barrier synchronizes execution but does not provide memory ordering or visibility. Treating it as a full memory sync clears the analysis's pending distributed shared-memory accesses and can suppress a required strong cluster barrier before scratch memory is reused.

This change keeps pending memory state across relaxed cluster barriers. Non-relaxed cluster barriers continue to clear it as before.

The regression test models a distributed `convert_layout`, followed by a relaxed barrier and shared-memory reuse. It verifies that the pass inserts a strong barrier between the relaxed barrier and `local_alloc`.

Fixes #11404.

## Validation

- Baseline regression: failed because `local_alloc` immediately followed the relaxed barrier.
- Patched regression: `membar-cluster.mlir` passed (1/1).
- Incremental native build: passed (`make`, 16 targets rebuilt/linked).
- RTX 5090 (SM 12.0): a two-CTA Gluon cluster-barrier kernel compiled and ran successfully with both `relaxed=false` and `relaxed=true` (`payload=1`, `out=1`).
- `pre-commit run --from-ref origin/main --to-ref HEAD`: passed.
- `git diff --check`: passed.

# New contributor declaration
- [x] I am not making a trivial change, such as fixing a typo in a comment.

- [x] I have written a PR description following these
  [rules](https://cbea.ms/git-commit/#why-not-how).

- [x] I have run `pre-commit run --from-ref origin/main --to-ref HEAD`.

- [x] I have added tests.
  - `/test` for `lit` tests
  - `/unittest` for C++ tests
  - `/python/test` for end-to-end tests

- [ ] I have not added any `lit` tests.
- [x] The `lit` tests I have added follow these [best practices](https://mlir.llvm.org/getting_started/TestingGuide/#filecheck-best-practices),
  including the "tests should be minimal" section.
