### PR TITLE
[INTERPRETER] Fix tl.condition while-loop truth evaluation

### DIFF
--- a/python/test/unit/language/test_core.py
+++ b/python/test/unit/language/test_core.py
@@ -6868,6 +6868,23 @@ def test_disable_licm():
     assert "llvm.licm.disable" in compiled_kernel3.asm["llir"]
 
 
+@pytest.mark.interpreter
+@pytest.mark.parametrize("disable_licm", [False, True])
+@pytest.mark.parametrize("n", [0, 3])
+def test_condition_while_loop(disable_licm, n, device):
+
+    @triton.jit
+    def kernel(output, n, DISABLE_LICM: tl.constexpr):
+        i = 0
+        while tl.condition(i < n, disable_licm=DISABLE_LICM):
+            i += 1
+        tl.store(output, i)
+
+    output = torch.empty(1, dtype=torch.int32, device=device)
+    kernel[(1, )](output, n, disable_licm)
+    assert output.item() == n
+
+
 @triton.jit(noinline=True)
 def maxnreg_noinline1(X):
     tl.store(X, 0)

--- a/python/triton/language/core.py
+++ b/python/triton/language/core.py
@@ -3654,6 +3654,9 @@ class condition(base_value):
         self.condition = arg1
         self.disable_licm = disable_licm
 
+    def __bool__(self):
+        return bool(self.condition)
+
 
 # -----------------------
 # Extern functions


### PR DESCRIPTION
## Why

`tl.condition` is a compiler-only wrapper around a while-loop condition. In interpreter mode, the kernel executes as Python, and the wrapper inherited Python's default object truthiness instead of the truth value of the wrapped scalar tensor. As a result, a loop whose initial condition was false still entered the body, and a loop that should eventually terminate continued indefinitely.

## What changed

- Delegate `tl.condition` boolean evaluation to its wrapped condition.
- Add an end-to-end regression test for both a false initial condition (`n=0`) and a condition that becomes false (`n=3`), with LICM enabled and disabled.

Fixes #11402

## Validation

- Baseline interpreter reproducer: timed out after 5 seconds (`exit 124`).
- Baseline compiled control on RTX 5090: passed.
- Patched interpreter test: 4/4 passed.
- Patched compiled RTX 5090 test: 4/4 passed.
- `pre-commit run --from-ref origin/main --to-ref HEAD`: passed, including ruff, YAPF, and mypy.

# New contributor declaration

- [x] I am not making a trivial change, such as fixing a typo in a comment.

- [x] I have written a PR description following these [rules](https://cbea.ms/git-commit/#why-not-how).

- [x] I have run `pre-commit run --from-ref origin/main --to-ref HEAD`.

- Select one of the following.
  - [x] I have added tests.
    - `/test` for `lit` tests
    - `/unittest` for C++ tests
    - `/python/test` for end-to-end tests
  - [ ] This PR does not need a test because `FILL THIS IN`.

- Select one of the following.
  - [x] I have not added any `lit` tests.
  - [ ] The `lit` tests I have added follow these [best practices](https://mlir.llvm.org/getting_started/TestingGuide/#filecheck-best-practices), including the "tests should be minimal" section.
