### PR TITLE
[MEMBAR] Schedule`tcgen05_wait::{ld,st}`

### DIFF
--- a/include/triton/Analysis/Membar.h
+++ b/include/triton/Analysis/Membar.h
@@ -332,9 +332,9 @@ private:
 
   void updateExitState(MembarInfo *membarInfo) override;
 
+protected:
   void insertBarrier(Operation *operation, OpBuilder *builder);
 
-protected:
   Allocation &allocation;
   MembarFilterFn filter;
 

--- a/include/triton/Analysis/Utility.h
+++ b/include/triton/Analysis/Utility.h
@@ -287,6 +287,10 @@ struct BarrierStages {
   bool beforeMemoryEffects = false;
   bool afterMemoryEffects = false;
   bool betweenMemoryEffects = false;
+
+  bool hasBarrier() const {
+    return beforeMemoryEffects || betweenMemoryEffects || afterMemoryEffects;
+  }
 };
 
 // Classify the barriers required by an atomic at a chosen scope. A result

--- a/include/triton/Dialect/TritonNvidiaGPU/IR/TritonNvidiaGPUAttrDefs.td
+++ b/include/triton/Dialect/TritonNvidiaGPU/IR/TritonNvidiaGPUAttrDefs.td
@@ -34,6 +34,15 @@ def TTG_TensorMemorySpace : AttrDef<TritonNvidiaGPU_Dialect, "TensorMemorySpace"
   }];
 }
 
+def TTNG_TMEMWaitKindAttr : I32EnumAttr<
+    "TMEMWaitKind", "tensor memory wait kind",
+    [
+        I32EnumAttrCase<"LOAD", 0, "load">,
+        I32EnumAttrCase<"STORE", 1, "store">,
+    ]> {
+  let cppNamespace = "::mlir::triton::nvidia_gpu";
+}
+
 def TTNG_TMEMLoadReduceModifierAttr : I32EnumAttr<
     "TMEMLoadReduceModifier", "",
     [

--- a/include/triton/Dialect/TritonNvidiaGPU/IR/TritonNvidiaGPUOps.td
+++ b/include/triton/Dialect/TritonNvidiaGPU/IR/TritonNvidiaGPUOps.td
@@ -883,6 +883,22 @@ def TTNG_TCGen5CommitOp : TTNG_Op<"tc_gen5_commit", [AttrSizedOperandSegments,
   let hasVerifier = 1;
 }
 
+// Inserted by TMEM synchronization and instrumentation before lowering.
+def TTNG_TMEMWaitOp : TTNG_Op<"tmem_wait"> {
+  let summary = "Wait for tensor memory loads or stores to complete";
+  let description = [{
+    Waits for all prior tensor memory loads or stores issued by the executing
+    threads, as selected by `kind`. All threads in each executing warp must
+    execute this operation. It does not synchronize different warps or wait for
+    asynchronous MMA or tensor memory copy operations.
+
+    Lowers to `tcgen05.wait::ld.sync.aligned` or
+    `tcgen05.wait::st.sync.aligned`.
+  }];
+  let arguments = (ins TTNG_TMEMWaitKindAttr:$kind);
+  let assemblyFormat = "$kind attr-dict";
+}
+
 def TTNG_TMEMLoadOp : TTNG_Op<"tmem_load", [AttrSizedResultSegments]> {
   let summary = "Load a buffer from tensor memory into a distributed tensor";
 

--- a/include/triton/Dialect/TritonNvidiaGPU/Transforms/Passes.td
+++ b/include/triton/Dialect/TritonNvidiaGPU/Transforms/Passes.td
@@ -156,6 +156,21 @@ def TritonNvidiaGPUTMemBarrierInsertionPass : Pass<"triton-nvidia-gpu-tmem-barri
   ];
 }
 
+def TritonNvidiaGPUTMemWaitInsertionPass : Pass<"triton-nvidia-gpu-tmem-wait-insertion", "mlir::ModuleOp"> {
+  let summary = "Insert tensor-memory completion waits";
+
+  let description = [{
+    This pass inserts load and store completion waits before dependent accesses
+    or synchronization boundaries, reusing existing CTA barriers where possible.
+    Run after tensor-memory allocation and barrier insertion, before lowering.
+  }];
+
+  let dependentDialects = [
+    "mlir::triton::gpu::TritonGPUDialect",
+    "mlir::triton::nvidia_gpu::TritonNvidiaGPUDialect"
+  ];
+}
+
 def TritonNvidiaGPUClusterBarrierMbarAllocatorPass : Pass<"triton-nvidia-gpu-cluster-barrier-mbar-allocator", "mlir::ModuleOp"> {
   let summary = "Allocate mbarriers for warp-specialized cluster barriers";
 

--- a/lib/Analysis/Membar.cpp
+++ b/lib/Analysis/Membar.cpp
@@ -175,6 +175,9 @@ triton::BarrierStages getLocalBarrierStages(Operation *op,
           triton::gpu::WarpReturnOp, ttng::ArriveBarrierOp,
           ttng::BarrierExpectOp, ttng::TCGen5CommitOp>(op);
 
+  // Tensor-map acquire ends with a CTA barrier after the descriptor fence.
+  stages.afterMemoryEffects = isa<ttng::TensormapFenceproxyAcquireOp>(op);
+
   // Warp specialization writes its captures before the launch rendezvous.
   if (isa<triton::gpu::WarpSpecializeOp>(op))
     stages.beforeMemoryEffects = !hasScratchBarrier;
@@ -202,8 +205,7 @@ static bool hasSyncPointBeforeMemoryEffect(Operation *op,
     if (stages.betweenMemoryEffects)
       return false;
 
-    // Barriers classified as "after" have no shared-memory effects before
-    // them. Currently these are non-scratch atomics and polls.
+    // These trailing barriers have no shared-memory effects before them.
     if (stages.afterMemoryEffects)
       return true;
 

--- a/lib/Analysis/Utility.cpp
+++ b/lib/Analysis/Utility.cpp
@@ -1308,8 +1308,7 @@ static bool atomicNeedsClusterBarrier(Operation *op) {
 
   auto stages = getAtomicBarrierStages(atomic.getMemSemantic(),
                                        atomicResultHasCTABroadcast(op));
-  return stages.beforeMemoryEffects || stages.afterMemoryEffects ||
-         stages.betweenMemoryEffects;
+  return stages.hasBarrier();
 }
 
 bool needsClusterBarrier(Operation *op) {

--- a/lib/Dialect/TritonInstrument/Transforms/ConcurrencySanitizer.cpp
+++ b/lib/Dialect/TritonInstrument/Transforms/ConcurrencySanitizer.cpp
@@ -355,6 +355,10 @@ void initializeAllocation(ImplicitLocOpBuilder &b, Value alloc) {
   // Synchronize warps, so in case of re-used memory we won't start poisoning
   // memory that is still being used, and finish poisoning before the kernel's
   // first real use of the allocation.
+  if (isTensorMemory) {
+    ttng::TMEMWaitOp::create(b, b.getLoc(), ttng::TMEMWaitKind::LOAD);
+    ttng::TMEMWaitOp::create(b, b.getLoc(), ttng::TMEMWaitKind::STORE);
+  }
   ttg::BarrierOp::create(b, b.getLoc(), barrierSpace);
   for (Value leaf : leaves) {
     auto leafType = cast<ttg::MemDescType>(leaf.getType());
@@ -366,6 +370,8 @@ void initializeAllocation(ImplicitLocOpBuilder &b, Value alloc) {
       ttg::LocalStoreOp::create(b, poison, leaf);
     }
   }
+  if (isTensorMemory)
+    ttng::TMEMWaitOp::create(b, b.getLoc(), ttng::TMEMWaitKind::STORE);
   ttg::BarrierOp::create(b, b.getLoc(), barrierSpace);
 }
 

--- a/lib/Dialect/TritonNvidiaGPU/Transforms/TMemBarrierInsertion.cpp
+++ b/lib/Dialect/TritonNvidiaGPU/Transforms/TMemBarrierInsertion.cpp
@@ -295,13 +295,13 @@ bool isWaitBoundary(Operation *op) {
   if (isa<gpu::WarpSpecializeOp, gpu::WarpSpecializePartitionsOp,
           gpu::WarpYieldOp, gpu::WarpReturnOp, CallOpInterface>(op))
     return true;
-  // ClusterBarrier could be followed by a 2CTA MMA, in which
+  // A non-relaxed cluster barrier could be followed by a 2CTA MMA, in which
   // case we need to put the wait before the cluster barrier.
   // We could track barriers and cluster barriers separately
   // and place the wait before the previous relevant op, but
   // I don't think there are many use cases for that.
-  if (isa<ClusterBarrierOp>(op))
-    return true;
+  if (auto barrier = dyn_cast<ClusterBarrierOp>(op))
+    return !barrier.getRelaxed();
   // Atomic ops may synchronise as well
   if (auto atomic = dyn_cast<AtomicOpInterface>(op))
     if (atomic.getMemSemantic() == MemSemantic::RELEASE ||

--- a/lib/Dialect/TritonNvidiaGPU/Transforms/TMemBarrierInsertion.cpp
+++ b/lib/Dialect/TritonNvidiaGPU/Transforms/TMemBarrierInsertion.cpp
@@ -16,6 +16,7 @@ namespace triton {
 namespace nvidia_gpu {
 
 #define GEN_PASS_DEF_TRITONNVIDIAGPUTMEMBARRIERINSERTIONPASS
+#define GEN_PASS_DEF_TRITONNVIDIAGPUTMEMWAITINSERTIONPASS
 #include "triton/Dialect/TritonNvidiaGPU/Transforms/Passes.h.inc"
 
 namespace {
@@ -225,6 +226,18 @@ static void appendWriteSlices(Value value, Operation *op,
     blockInfo->syncWriteSlices[slice].insert(op);
 }
 
+static BlockInfo getTMemAccesses(Operation *op) {
+  // Use physical TMEM allocation slices; unknown origins alias all TMEM.
+  BlockInfo accesses;
+  for (const MemoryAccess &access : getMemoryAccesses(op)) {
+    if (access.isRead)
+      appendReadSlices(access.value, op, &accesses);
+    if (access.isWrite)
+      appendWriteSlices(access.value, op, &accesses);
+  }
+  return accesses;
+}
+
 class TMemBarrierAnalysis : public MembarAnalysis {
 public:
   using MembarAnalysis::MembarAnalysis;
@@ -232,15 +245,7 @@ public:
 private:
   void update(Operation *operation, MembarInfo *membarInfo, FuncMapT *funcMap,
               OpBuilder *builder) override;
-
-  void insertBarrier(Operation *operation, OpBuilder *builder);
 };
-
-void TMemBarrierAnalysis::insertBarrier(Operation *op, OpBuilder *builder) {
-  OpBuilder::InsertionGuard g(*builder);
-  triton::gpu::BarrierOp::create(*builder, op->getLoc(),
-                                 triton::gpu::AddrSpace::Local);
-}
 
 void TMemBarrierAnalysis::update(Operation *op, MembarInfo *membarInfo,
                                  FuncMapT *funcMap, OpBuilder *builder) {
@@ -248,7 +253,6 @@ void TMemBarrierAnalysis::update(Operation *op, MembarInfo *membarInfo,
   if (stages.beforeMemoryEffects)
     membarInfo->sync();
 
-  BlockInfo curBlockInfo;
   if (isa<triton::CallOp>(op)) {
     auto call = cast<CallOpInterface>(op);
     if (auto callee = dyn_cast<FunctionOpInterface>(call.resolveCallable())) {
@@ -264,24 +268,9 @@ void TMemBarrierAnalysis::update(Operation *op, MembarInfo *membarInfo,
       membarInfo->applyCallSummary(calleeMembarInfo);
     }
     return;
-  } else if (auto load = dyn_cast<TMEMLoadOp>(op)) {
-    appendReadSlices(load.getSrc(), op, &curBlockInfo);
-  } else if (auto store = dyn_cast<TMEMStoreOp>(op)) {
-    appendWriteSlices(store.getDst(), op, &curBlockInfo);
-  } else if (auto alloc = dyn_cast<TMEMAllocOp>(op)) {
-    if (alloc.getSrc())
-      appendWriteSlices(alloc.getResult(), op, &curBlockInfo);
-  } else if (auto mma = dyn_cast<MMAv5OpInterface>(op)) {
-    appendWriteSlices(mma.getAccumulator(), op, &curBlockInfo);
-    appendReadSlices(mma.getA(), op, &curBlockInfo);
-    if (auto scaledMma = dyn_cast<TCGen5MMAScaledOp>(op)) {
-      appendReadSlices(scaledMma.getAScale(), op, &curBlockInfo);
-      appendReadSlices(scaledMma.getBScale(), op, &curBlockInfo);
-    }
-  } else if (auto copy = dyn_cast<TMEMCopyOp>(op)) {
-    appendWriteSlices(copy.getDst(), op, &curBlockInfo);
   }
 
+  BlockInfo curBlockInfo = getTMemAccesses(op);
   if (membarInfo->pending.isIntersected(curBlockInfo, filter, &allocation)) {
     builder->setInsertionPoint(op);
     insertBarrier(op, builder);
@@ -296,7 +285,228 @@ void TMemBarrierAnalysis::update(Operation *op, MembarInfo *membarInfo,
     membarInfo->sync();
 }
 
+// Ops before which we 100% need to flush reads and writes
+bool isWaitBoundary(Operation *op) {
+  // Defer waits at CTA barriers until a hazard or boundary requires them.
+  if (isa<gpu::BarrierOp>(op))
+    return false;
+
+  // Flush before starting or ending WS
+  if (isa<gpu::WarpSpecializeOp, gpu::WarpSpecializePartitionsOp,
+          gpu::WarpYieldOp, gpu::WarpReturnOp, CallOpInterface>(op))
+    return true;
+  // ClusterBarrier could be followed by a 2CTA MMA, in which
+  // case we need to put the wait before the cluster barrier.
+  // We could track barriers and cluster barriers separately
+  // and place the wait before the previous relevant op, but
+  // I don't think there are many use cases for that.
+  if (isa<ClusterBarrierOp>(op))
+    return true;
+  // Atomic ops may synchronise as well
+  if (auto atomic = dyn_cast<AtomicOpInterface>(op))
+    if (atomic.getMemSemantic() == MemSemantic::RELEASE ||
+        atomic.getMemSemantic() == MemSemantic::ACQUIRE_RELEASE)
+      return true;
+  // Mbarriers may signal other WS partitions.
+  if (auto barrier = dyn_cast<gpu::MBarrierOpInterface>(op))
+    if (!barrier.getBarriers().empty())
+      return true;
+
+  // Carry pending accesses through control-flow joins and backedges.
+  if (isa<BranchOpInterface, RegionBranchOpInterface>(op) ||
+      (isa<RegionBranchTerminatorOpInterface>(op) &&
+       isa<RegionBranchOpInterface>(op->getParentOp())))
+    return false;
+  if (op->hasTrait<OpTrait::ReturnLike>())
+    return true;
+
+  // Volatile loads add an opaque write effect to prevent optimization, but
+  // still access only global memory.
+  if (isa<triton::LoadOp>(op))
+    return false;
+
+  // Wait if we can't prove that it's memory-effect free
+  auto memory = dyn_cast<MemoryEffectOpInterface>(op);
+  if (!memory)
+    return !isMemoryEffectFree(op);
+  SmallVector<MemoryEffects::EffectInstance> effects;
+  memory.getEffects(effects);
+  return llvm::any_of(effects, [](const auto &effect) {
+    Value value = effect.getValue();
+    // - An unbound DefaultResource effect may hide synchronization
+    //   in impure inline asm or extern calls.
+    if (!value)
+      return isa<SideEffects::DefaultResource>(effect.getResource());
+    assert(!(isTensorMemory(value) &&
+             isa<MemoryEffects::Free>(effect.getEffect())) &&
+           "unexpected TMEM free");
+    return false;
+  });
+}
+
+class TMemWaitAnalysis : public MembarAnalysis {
+public:
+  using MembarAnalysis::MembarAnalysis;
+
+private:
+  static BlockInfo::SliceMapT &accesses(BlockInfo &info, TMEMWaitKind kind) {
+    return kind == TMEMWaitKind::LOAD ? info.syncReadSlices
+                                      : info.syncWriteSlices;
+  }
+
+  bool hasHazard(const BlockInfo &pending, const BlockInfo &effects,
+                 TMEMWaitKind kind) {
+    return pending.isIntersected(
+        effects,
+        [kind](Operation *, Operation *, bool isRead, bool, Allocation *) {
+          return isRead != (kind == TMEMWaitKind::LOAD);
+        },
+        &allocation);
+  }
+
+  void waitBeforeBarrier(TMEMWaitKind kind, BlockInfo &pending,
+                         OpBuilder *builder) {
+    if (accesses(beforeBarrier, kind).empty())
+      return;
+    assert(lastBarrier && "publication needs a remembered rendezvous");
+    builder->setInsertionPoint(lastBarrier);
+    TMEMWaitOp::create(*builder, lastBarrier->getLoc(), kind);
+    // The unconditional wait completes all preceding accesses of this kind.
+    // Preserve later accesses, even if the same operation also has pending
+    // accesses from an earlier loop iteration.
+    accesses(beforeBarrier, kind).clear();
+    accesses(pending, kind).clear();
+    pending.join(afterBarrier);
+  }
+
+  void waitNow(Operation *op, TMEMWaitKind kind, BlockInfo &pending,
+               OpBuilder *builder) {
+    if (accesses(pending, kind).empty())
+      return;
+    builder->setInsertionPoint(op);
+    TMEMWaitOp::create(*builder, op->getLoc(), kind);
+    accesses(pending, kind).clear();
+    accesses(afterBarrier, kind).clear();
+  }
+
+  void rememberBarrier(Operation *op, const BlockInfo &pending) {
+    lastBarrier = op;
+    beforeBarrier = pending;
+    afterBarrier.sync();
+  }
+
+  void finishBlock(BlockInfo &pending, OpBuilder *builder) {
+    // Complete accesses preceding lastBarrier before forgetting it.
+    // Leave later accesses in pending for joins and backedges.
+    for (TMEMWaitKind kind : {TMEMWaitKind::LOAD, TMEMWaitKind::STORE})
+      waitBeforeBarrier(kind, pending, builder);
+    lastBarrier = nullptr;
+    afterBarrier.sync();
+  }
+
+  void update(Operation *op, MembarInfo *membarInfo, FuncMapT *,
+              OpBuilder *builder) override {
+    BlockInfo &pending = membarInfo->pending;
+    if (auto wait = dyn_cast<TMEMWaitOp>(op)) {
+      accesses(pending, wait.getKind()).clear();
+      accesses(afterBarrier, wait.getKind()).clear();
+      return;
+    }
+
+    BlockInfo effects = getTMemAccesses(op);
+    // Include internal scratch barriers even without descriptor memory effects.
+    auto stages = getLocalBarrierStages(op, &allocation);
+    // Reuse this barrier for incoming hazards only if it precedes the op's TMEM
+    // effects, or the op has no TMEM effects.
+    bool beforeEffects =
+        stages.beforeMemoryEffects ||
+        (effects.syncReadSlices.empty() && effects.syncWriteSlices.empty());
+    if (stages.hasBarrier() && beforeEffects)
+      rememberBarrier(op, pending);
+
+    if (isWaitBoundary(op)) {
+      finishBlock(pending, builder);
+      for (TMEMWaitKind kind : {TMEMWaitKind::LOAD, TMEMWaitKind::STORE})
+        waitNow(op, kind, pending, builder);
+    }
+
+    bool loadHazard = hasHazard(pending, effects, TMEMWaitKind::LOAD) ||
+                      hasHazard(beforeBarrier, effects, TMEMWaitKind::LOAD);
+    bool storeHazard = hasHazard(pending, effects, TMEMWaitKind::STORE) ||
+                       hasHazard(beforeBarrier, effects, TMEMWaitKind::STORE);
+    if (loadHazard || storeHazard) {
+      // Reuse the last barrier if no later access conflicts with this
+      // operation. Otherwise, insert a wait and a new barrier before the
+      // operation.
+      if (lastBarrier &&
+          !afterBarrier.isIntersected(effects, nullptr, &allocation)) {
+        if (loadHazard)
+          waitBeforeBarrier(TMEMWaitKind::LOAD, pending, builder);
+        if (storeHazard)
+          waitBeforeBarrier(TMEMWaitKind::STORE, pending, builder);
+      } else {
+        if (loadHazard)
+          waitNow(op, TMEMWaitKind::LOAD, pending, builder);
+        if (storeHazard)
+          waitNow(op, TMEMWaitKind::STORE, pending, builder);
+        builder->setInsertionPoint(op);
+        insertBarrier(op, builder);
+        rememberBarrier(op->getPrevNode(), pending);
+      }
+    }
+
+    // Handle this operation's hazards before recording its internal barrier.
+    // Waits go before the operation, so its own accesses remain in
+    // afterBarrier.
+    if (stages.hasBarrier() && !beforeEffects)
+      rememberBarrier(op, pending);
+
+    // Track loads and stores, including allocation initializers. An allocation
+    // without an initializer preserves pending accesses to reused storage.
+    auto kind = getTMemAccessKind(op);
+    if (kind == TMemAccessKind::Load || kind == TMemAccessKind::Store) {
+      pending.join(effects);
+      afterBarrier.join(effects);
+    }
+
+    if (op->hasTrait<OpTrait::IsTerminator>() ||
+        isa<RegionBranchOpInterface>(op))
+      finishBlock(pending, builder);
+  }
+
+  // These snapshots track accesses before and after lastBarrier within one
+  // virtual block. Only MembarInfo::pending flows through joins and backedges.
+  Operation *lastBarrier = nullptr;
+  BlockInfo beforeBarrier;
+  BlockInfo afterBarrier;
+};
+
 } // namespace
+
+struct TMemWaitInsertionPass
+    : public impl::TritonNvidiaGPUTMemWaitInsertionPassBase<
+          TMemWaitInsertionPass> {
+  using impl::TritonNvidiaGPUTMemWaitInsertionPassBase<
+      TMemWaitInsertionPass>::TritonNvidiaGPUTMemWaitInsertionPassBase;
+
+  void runOnOperation() override {
+    ModuleOp mod = getOperation();
+    if (!mod.walk([](Operation *op) {
+              auto kind = getTMemAccessKind(op);
+              return kind == TMemAccessKind::Load ||
+                             kind == TMemAccessKind::Store
+                         ? WalkResult::interrupt()
+                         : WalkResult::advance();
+            })
+             .wasInterrupted())
+      return;
+    // Run after TMEM and shared-memory barrier insertion. Calls and returns
+    // complete pending accesses, so this pass needs no call summaries.
+    ModuleAllocation allocation(mod);
+    ModuleMembarAnalysis analysis(allocation);
+    analysis.runAnalysis<TMemWaitAnalysis>();
+  }
+};
 
 struct TMemBarrierInsertionPass
     : public impl::TritonNvidiaGPUTMemBarrierInsertionPassBase<

--- a/lib/Dialect/TritonNvidiaGPU/Transforms/TMemBarrierInsertion.cpp
+++ b/lib/Dialect/TritonNvidiaGPU/Transforms/TMemBarrierInsertion.cpp
@@ -337,10 +337,8 @@ bool isWaitBoundary(Operation *op) {
     //   in impure inline asm or extern calls.
     if (!value)
       return isa<SideEffects::DefaultResource>(effect.getResource());
-    assert(!(isTensorMemory(value) &&
-             isa<MemoryEffects::Free>(effect.getEffect())) &&
-           "unexpected TMEM free");
-    return false;
+    return isTensorMemory(value) &&
+           isa<MemoryEffects::Free>(effect.getEffect());
   });
 }
 

--- a/python/test/gluon/test_core.py
+++ b/python/test/gluon/test_core.py
@@ -2328,6 +2328,44 @@ def test_tmem_subslice_unpacked_one_column():
 
 
 @pytest.mark.skipif(not is_blackwell(), reason="Requires Blackwell")
+@pytest.mark.parametrize("pred", [False, True])
+def test_tmem_wait_predicated_store(pred):
+
+    @gluon.jit
+    def kernel(inp, out, pred_ptr):
+        parent = allocate_tensor_memory(ttgl.float32, [128, 64], TensorMemoryLayout([128, 64], col_stride=1))
+        layout: ttgl.constexpr = parent.get_reg_layout()
+        rows = ttgl.arange(0, 128, layout=ttgl.SliceLayout(1, layout))
+        cols = ttgl.arange(0, 64, layout=ttgl.SliceLayout(0, layout))
+        offsets = rows[:, None] * 64 + cols[None, :]
+        pred_value = ttgl.load(pred_ptr)
+        parent.store(ttgl.load(inp + offsets))
+
+        a = parent.slice(0, 16)
+        b = parent.slice(16, 16)
+        c = parent.slice(32, 16)
+        values = a.load()
+        # Register users and disjoint stores need no load wait.
+        b.store(values + 1)
+        c.store(values + 2, pred=pred_value)
+        # Overwriting the loaded source and reading all stores require completion.
+        a.store(ttgl.full([128, 16], -7, ttgl.float32, layout=a.get_reg_layout()))
+        ttgl.store(out + offsets, parent.load())
+
+    inp = torch.arange(128 * 64, dtype=torch.float32, device="cuda").reshape(128, 64)
+    out = torch.empty_like(inp)
+    pred_tensor = torch.tensor(pred, dtype=torch.bool, device="cuda")
+    kernel[(1, )](inp, out, pred_tensor, num_warps=4)
+
+    expected = inp.clone()
+    expected[:, :16] = -7
+    expected[:, 16:32] = inp[:, :16] + 1
+    if pred:
+        expected[:, 32:48] = inp[:, :16] + 2
+    torch.testing.assert_close(out, expected, atol=0, rtol=0)
+
+
+@pytest.mark.skipif(not is_blackwell(), reason="Requires Blackwell")
 def test_tmem_subslice_block_m_64():
 
     @gluon.jit

--- a/test/Conversion/lower_tensor_memory_to_llvm.mlir
+++ b/test/Conversion/lower_tensor_memory_to_llvm.mlir
@@ -1,4 +1,4 @@
-// RUN: triton-opt %s --test-print-membar --convert-triton-gpu-to-llvm --convert-warp-specialize-to-llvm --convert-nv-gpu-to-llvm -allow-unregistered-dialect | FileCheck %s
+// RUN: triton-opt %s -split-input-file --allocate-shared-memory-nv=compute-capability=103 --triton-nvidia-gpu-tmem-barrier-insertion --test-print-membar --triton-nvidia-gpu-tmem-wait-insertion --convert-triton-gpu-to-llvm=compute-capability=103 --convert-warp-specialize-to-llvm --convert-nv-gpu-to-llvm -allow-unregistered-dialect | FileCheck %s
 
 #tmem = #ttng.tensor_memory_encoding<blockM = 128, blockN = 64, colStride = 1, CGALayout = [[0, 0]]>
 
@@ -38,4 +38,153 @@ module attributes {"ttg.target" = "cuda:103", "ttg.num-ctas" = 2 : i32, "ttg.num
     tt.return %view : !ttg.memdesc<128x64xf32, #tmem, #ttng.tensor_memory, mutable>
   }
 
+}
+
+// -----
+
+#blocked = #ttg.blocked<{sizePerThread = [1, 16], threadsPerWarp = [32, 1], warpsPerCTA = [4, 1], order = [0, 1]}>
+#tmem = #ttng.tensor_memory_encoding<blockM = 128, blockN = 64, colStride = 1>
+
+module attributes {"ttg.target" = "cuda:103", "ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.tensor_memory_size = 64 : i32} {
+  // Disjoint stores to %a, %b, and %c share a wait before overwriting %a,
+  // even when %c's predicate is false.
+  // CHECK-LABEL: @tmem_store_wait_chain
+  // CHECK: tcgen05.st.sync.aligned
+  // CHECK-NOT: nvvm.tcgen05.wait <store>
+  // CHECK: tcgen05.st.sync.aligned
+  // CHECK-NOT: nvvm.tcgen05.wait <store>
+  // CHECK: tcgen05.st.sync.aligned
+  // CHECK-NEXT: nvvm.tcgen05.wait <store>
+  // CHECK: tcgen05.st.sync.aligned
+  // CHECK-NEXT: nvvm.tcgen05.wait <store>
+  tt.func @tmem_store_wait_chain() {
+    %true = arith.constant true
+    %false = arith.constant false
+    %data = arith.constant dense<0.0> : tensor<128x16xf32, #blocked>
+    %a = ttng.tmem_alloc {tensor_memory_col_offset = 0 : i32, tensor_memory_row_offset = 0 : i32} : () -> !ttg.memdesc<128x16xf32, #tmem, #ttng.tensor_memory, mutable>
+    %b = ttng.tmem_alloc {tensor_memory_col_offset = 16 : i32, tensor_memory_row_offset = 0 : i32} : () -> !ttg.memdesc<128x16xf32, #tmem, #ttng.tensor_memory, mutable>
+    %c = ttng.tmem_alloc {tensor_memory_col_offset = 32 : i32, tensor_memory_row_offset = 0 : i32} : () -> !ttg.memdesc<128x16xf32, #tmem, #ttng.tensor_memory, mutable>
+    ttng.tmem_store %data, %a, %true : tensor<128x16xf32, #blocked> -> !ttg.memdesc<128x16xf32, #tmem, #ttng.tensor_memory, mutable>
+    ttng.tmem_store %data, %b, %true : tensor<128x16xf32, #blocked> -> !ttg.memdesc<128x16xf32, #tmem, #ttng.tensor_memory, mutable>
+    ttng.tmem_store %data, %c, %false : tensor<128x16xf32, #blocked> -> !ttg.memdesc<128x16xf32, #tmem, #ttng.tensor_memory, mutable>
+    ttng.tmem_store %data, %a, %true : tensor<128x16xf32, #blocked> -> !ttg.memdesc<128x16xf32, #tmem, #ttng.tensor_memory, mutable>
+    tt.return
+  }
+}
+
+// -----
+
+#blocked = #ttg.blocked<{sizePerThread = [1, 16], threadsPerWarp = [32, 1], warpsPerCTA = [4, 1], order = [0, 1]}>
+#tmem = #ttng.tensor_memory_encoding<blockM = 128, blockN = 64, colStride = 1>
+
+module attributes {"ttg.target" = "cuda:103", "ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32} {
+  // %a and %b may alias, so wait before the second store.
+  // CHECK-LABEL: @tmem_store_wait_unknown
+  // CHECK: tcgen05.st.sync.aligned
+  // CHECK-NEXT: nvvm.tcgen05.wait <store>
+  // CHECK: tcgen05.st.sync.aligned
+  // CHECK-NEXT: nvvm.tcgen05.wait <store>
+  tt.func private @tmem_store_wait_unknown(%a: !ttg.memdesc<128x16xf32, #tmem, #ttng.tensor_memory, mutable>, %b: !ttg.memdesc<128x16xf32, #tmem, #ttng.tensor_memory, mutable>, %value: f32) {
+    %true = arith.constant true
+    %data = tt.splat %value : f32 -> tensor<128x16xf32, #blocked>
+    ttng.tmem_store %data, %a, %true : tensor<128x16xf32, #blocked> -> !ttg.memdesc<128x16xf32, #tmem, #ttng.tensor_memory, mutable>
+    ttng.tmem_store %data, %b, %true : tensor<128x16xf32, #blocked> -> !ttg.memdesc<128x16xf32, #tmem, #ttng.tensor_memory, mutable>
+    tt.return
+  }
+}
+
+// -----
+
+#blocked = #ttg.blocked<{sizePerThread = [1, 16], threadsPerWarp = [32, 1], warpsPerCTA = [4, 1], order = [0, 1]}>
+#mixed = #ttg.blocked<{sizePerThread = [1, 1], threadsPerWarp = [4, 8], warpsPerCTA = [4, 1], order = [0, 1]}>
+#tmem = #ttng.tensor_memory_encoding<blockM = 128, blockN = 64, colStride = 1>
+
+module attributes {"ttg.target" = "cuda:103", "ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.tensor_memory_size = 64 : i32} {
+  // Layout conversion and reduction lower to CTA barriers. The stores to
+  // %a and %b share one wait before the last barrier.
+  // CHECK-LABEL: @tmem_store_wait_scratch_boundaries
+  // CHECK: tcgen05.st.sync.aligned
+  // CHECK-NOT: nvvm.tcgen05.wait
+  // CHECK: nvvm.barrier
+  // CHECK-NOT: nvvm.tcgen05.wait
+  // CHECK: tcgen05.st.sync.aligned
+  // CHECK: nvvm.tcgen05.wait <store>
+  // CHECK-NOT: nvvm.tcgen05.wait
+  // CHECK: nvvm.barrier
+  // CHECK-NOT: nvvm.tcgen05.wait
+  // CHECK: tcgen05.st.sync.aligned
+  // CHECK-NEXT: nvvm.tcgen05.wait <store>
+  tt.func @tmem_store_wait_scratch_boundaries(%input: !tt.ptr<f32>) {
+    %true = arith.constant true
+    %rows = tt.make_range {start = 0 : i32, end = 128 : i32} : tensor<128xi32, #ttg.slice<{dim = 1, parent = #blocked}>>
+    %base = tt.splat %input : !tt.ptr<f32> -> tensor<128x!tt.ptr<f32>, #ttg.slice<{dim = 1, parent = #blocked}>>
+    %ptrs = tt.addptr %base, %rows : tensor<128x!tt.ptr<f32>, #ttg.slice<{dim = 1, parent = #blocked}>>, tensor<128xi32, #ttg.slice<{dim = 1, parent = #blocked}>>
+    %values = tt.load %ptrs : tensor<128x!tt.ptr<f32>, #ttg.slice<{dim = 1, parent = #blocked}>>
+    %column = tt.expand_dims %values {axis = 1 : i32} : tensor<128xf32, #ttg.slice<{dim = 1, parent = #blocked}>> -> tensor<128x1xf32, #blocked>
+    %data = tt.broadcast %column : tensor<128x1xf32, #blocked> -> tensor<128x16xf32, #blocked>
+    %a = ttng.tmem_alloc {tensor_memory_col_offset = 0 : i32, tensor_memory_row_offset = 0 : i32} : () -> !ttg.memdesc<128x16xf32, #tmem, #ttng.tensor_memory, mutable>
+    %b = ttng.tmem_alloc {tensor_memory_col_offset = 16 : i32, tensor_memory_row_offset = 0 : i32} : () -> !ttg.memdesc<128x16xf32, #tmem, #ttng.tensor_memory, mutable>
+    %c = ttng.tmem_alloc {tensor_memory_col_offset = 32 : i32, tensor_memory_row_offset = 0 : i32} : () -> !ttg.memdesc<128x16xf32, #tmem, #ttng.tensor_memory, mutable>
+    ttng.tmem_store %data, %a, %true : tensor<128x16xf32, #blocked> -> !ttg.memdesc<128x16xf32, #tmem, #ttng.tensor_memory, mutable>
+    %converted = ttg.convert_layout %data : tensor<128x16xf32, #blocked> -> tensor<128x16xf32, #mixed>
+    ttng.tmem_store %data, %b, %true : tensor<128x16xf32, #blocked> -> !ttg.memdesc<128x16xf32, #tmem, #ttng.tensor_memory, mutable>
+    %sum = "tt.reduce"(%converted) <{axis = 0 : i32}> ({
+    ^bb0(%lhs: f32, %rhs: f32):
+      %add = arith.addf %lhs, %rhs : f32
+      tt.reduce.return %add : f32
+    }) : (tensor<128x16xf32, #mixed>) -> tensor<16xf32, #ttg.slice<{dim = 0, parent = #mixed}>>
+    %sum_layout = ttg.convert_layout %sum : tensor<16xf32, #ttg.slice<{dim = 0, parent = #mixed}>> -> tensor<16xf32, #ttg.slice<{dim = 0, parent = #blocked}>>
+    %sum_row = tt.expand_dims %sum_layout {axis = 0 : i32} : tensor<16xf32, #ttg.slice<{dim = 0, parent = #blocked}>> -> tensor<1x16xf32, #blocked>
+    %sum_data = tt.broadcast %sum_row : tensor<1x16xf32, #blocked> -> tensor<128x16xf32, #blocked>
+    ttng.tmem_store %sum_data, %c, %true : tensor<128x16xf32, #blocked> -> !ttg.memdesc<128x16xf32, #tmem, #ttng.tensor_memory, mutable>
+    tt.return
+  }
+}
+
+// -----
+
+#blocked = #ttg.blocked<{sizePerThread = [1, 16], threadsPerWarp = [32, 1], warpsPerCTA = [4, 1], order = [0, 1]}>
+#shared = #ttg.swizzled_shared<{vec = 1, perPhase = 1, maxPhase = 1, order = [0]}>
+#tmem = #ttng.tensor_memory_encoding<blockM = 128, blockN = 64, colStride = 1>
+
+module attributes {"ttg.target" = "cuda:103", "ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.tensor_memory_size = 64 : i32} {
+  // Stores to %a and %b share one wait before arrive_barrier. The load from %b
+  // needs a store wait, but the disjoint store to %c needs no load wait.
+  // Both outstanding accesses must complete before wait_barrier.
+  // CHECK-LABEL: @tmem_store_wait_publication
+  // CHECK: tcgen05.st.sync.aligned
+  // CHECK-NEXT: nvvm.barrier
+  // CHECK-NOT: nvvm.tcgen05.wait
+  // CHECK: tcgen05.st.sync.aligned
+  // CHECK-NEXT: nvvm.tcgen05.wait <store>
+  // CHECK: nvvm.barrier
+  // CHECK: mbarrier.arrive.shared::cta
+  // CHECK: tcgen05.st.sync.aligned
+  // CHECK-NEXT: nvvm.tcgen05.wait <store>
+  // CHECK: tcgen05.ld.sync.aligned
+  // CHECK-NOT: nvvm.tcgen05.wait
+  // CHECK: tcgen05.st.sync.aligned
+  // CHECK-NEXT: nvvm.tcgen05.wait <load>
+  // CHECK-NEXT: nvvm.tcgen05.wait <store>
+  // CHECK: mbarrier.try_wait.parity.shared::cta
+  tt.func @tmem_store_wait_publication() {
+    %true = arith.constant true
+    %phase = arith.constant 0 : i32
+    %data = arith.constant dense<0.0> : tensor<128x16xf32, #blocked>
+    %bar = ttg.local_alloc : () -> !ttg.memdesc<1xi64, #shared, #ttg.shared_memory, mutable>
+    ttng.init_barrier %bar, 1 : !ttg.memdesc<1xi64, #shared, #ttg.shared_memory, mutable>
+    %a = ttng.tmem_alloc {tensor_memory_col_offset = 0 : i32, tensor_memory_row_offset = 0 : i32} : () -> !ttg.memdesc<128x16xf32, #tmem, #ttng.tensor_memory, mutable>
+    %b = ttng.tmem_alloc {tensor_memory_col_offset = 16 : i32, tensor_memory_row_offset = 0 : i32} : () -> !ttg.memdesc<128x16xf32, #tmem, #ttng.tensor_memory, mutable>
+    %c = ttng.tmem_alloc {tensor_memory_col_offset = 32 : i32, tensor_memory_row_offset = 0 : i32} : () -> !ttg.memdesc<128x16xf32, #tmem, #ttng.tensor_memory, mutable>
+    ttng.tmem_store %data, %a, %true : tensor<128x16xf32, #blocked> -> !ttg.memdesc<128x16xf32, #tmem, #ttng.tensor_memory, mutable>
+    ttg.barrier local
+    ttng.tmem_store %data, %b, %true : tensor<128x16xf32, #blocked> -> !ttg.memdesc<128x16xf32, #tmem, #ttng.tensor_memory, mutable>
+    ttng.arrive_barrier %bar, 1 : !ttg.memdesc<1xi64, #shared, #ttg.shared_memory, mutable>
+    ttng.tmem_store %data, %b, %true : tensor<128x16xf32, #blocked> -> !ttg.memdesc<128x16xf32, #tmem, #ttng.tensor_memory, mutable>
+    %loaded = ttng.tmem_load %b : !ttg.memdesc<128x16xf32, #tmem, #ttng.tensor_memory, mutable> -> tensor<128x16xf32, #blocked>
+    ttng.tmem_store %loaded, %c, %true : tensor<128x16xf32, #blocked> -> !ttg.memdesc<128x16xf32, #tmem, #ttng.tensor_memory, mutable>
+    ttng.wait_barrier %bar, %phase : !ttg.memdesc<1xi64, #shared, #ttg.shared_memory, mutable>
+    ttng.inval_barrier %bar : !ttg.memdesc<1xi64, #shared, #ttg.shared_memory, mutable>
+    tt.return
+  }
 }

--- a/test/Conversion/tritongpu_to_llvm_blackwell.mlir
+++ b/test/Conversion/tritongpu_to_llvm_blackwell.mlir
@@ -1,5 +1,5 @@
-// RUN: triton-opt %s -split-input-file --convert-triton-gpu-to-llvm=compute-capability=100 -cse | FileCheck %s --check-prefixes=CHECK,SM100
-// RUN: triton-opt %s -split-input-file --convert-triton-gpu-to-llvm=compute-capability=103 -cse | FileCheck %s --check-prefixes=CHECK,SM103
+// RUN: triton-opt %s -split-input-file --triton-nvidia-gpu-tmem-barrier-insertion --convert-triton-gpu-to-llvm=compute-capability=100 -cse | FileCheck %s --check-prefixes=CHECK,SM100
+// RUN: triton-opt %s -split-input-file --triton-nvidia-gpu-tmem-barrier-insertion --convert-triton-gpu-to-llvm=compute-capability=103 -cse | FileCheck %s --check-prefixes=CHECK,SM103
 
 #mma = #ttg.nvidia_mma<{versionMajor = 3, versionMinor = 0, warpsPerCTA = [8, 1], instrShape = [16, 256, 32]}>
 #shared = #ttg.nvmma_shared<{swizzlingByteWidth = 32, transposed = false, elementBitWidth = 16}>
@@ -1451,14 +1451,16 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 8 : i32, ttg.shar
 // Test reduction with blockM=128, blockN=256, 4 warps
 // Each thread handles 256 columns -> 4 messages (x64 each) -> 4 partial reductions combined
 // Uses llvm.minnum.f32 to combine partial reductions (ignores NaN)
+// True register dependencies allow combining partials before the completion wait.
 #blocked_256N_4w = #ttg.blocked<{sizePerThread = [1, 256], threadsPerWarp = [32, 1], warpsPerCTA = [4, 1], order = [0, 1]}>
 #blocked_red_256N_4w = #ttg.blocked<{sizePerThread = [1], threadsPerWarp = [32], warpsPerCTA = [4], order = [0]}>
 #tmem_256N = #ttng.tensor_memory_encoding<blockM = 128, blockN = 256, colStride = 1>
 module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.shared = 65544 : i32, ttg.target = "cuda:103", ttg.tensor_memory_size = 128 : i32, "ttg.threads-per-warp" = 32 : i32} {
   // CHECK-LABEL: @tensor_memory_ld_red_min_128x256_4_warps
   // CHECK-COUNT-4: tcgen05.ld.red.sync.aligned.32x32b.x64.min.f32
-  // CHECK: tcgen05.wait <load>
+  // CHECK-NOT: tcgen05.wait <load>
   // CHECK-COUNT-3: llvm.intr.minnum
+  // CHECK: tcgen05.wait <load>
   tt.func public @tensor_memory_ld_red_min_128x256_4_warps() {
     %cst_0 = arith.constant dense<0.000000e+00> : tensor<128x256xf32, #blocked_256N_4w>
     %0 = ttng.tmem_alloc %cst_0 {tensor_memory_col_offset = 0 : i32, tensor_memory_row_offset = 0 : i32} : (tensor<128x256xf32, #blocked_256N_4w>) -> !ttg.memdesc<128x256xf32, #tmem_256N, #ttng.tensor_memory, mutable>
@@ -1468,8 +1470,8 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.shar
 
   // CHECK-LABEL: @tensor_memory_ld_red_max_128x256_4_warps
   // CHECK-COUNT-4: tcgen05.ld.red.sync.aligned.32x32b.x64.max.f32
-  // CHECK: tcgen05.wait <load>
   // CHECK-COUNT-3: llvm.intr.maxnum
+  // CHECK: tcgen05.wait <load>
   tt.func public @tensor_memory_ld_red_max_128x256_4_warps() {
     %cst_0 = arith.constant dense<0.000000e+00> : tensor<128x256xf32, #blocked_256N_4w>
     %0 = ttng.tmem_alloc %cst_0 {tensor_memory_col_offset = 0 : i32, tensor_memory_row_offset = 0 : i32} : (tensor<128x256xf32, #blocked_256N_4w>) -> !ttg.memdesc<128x256xf32, #tmem_256N, #ttng.tensor_memory, mutable>
@@ -1488,8 +1490,8 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.shar
 module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.shared = 65544 : i32, ttg.target = "cuda:103", ttg.tensor_memory_size = 128 : i32, "ttg.threads-per-warp" = 32 : i32} {
   // CHECK-LABEL: @tensor_memory_ld_red_min_128x256_4_warps_nan
   // CHECK-COUNT-4: tcgen05.ld.red.sync.aligned.32x32b.x64.min.NaN.f32
-  // CHECK: tcgen05.wait <load>
   // CHECK-COUNT-3: llvm.intr.minimum
+  // CHECK: tcgen05.wait <load>
   tt.func public @tensor_memory_ld_red_min_128x256_4_warps_nan() {
     %cst_0 = arith.constant dense<0.000000e+00> : tensor<128x256xf32, #blocked_256N_4w_nan>
     %0 = ttng.tmem_alloc %cst_0 {tensor_memory_col_offset = 0 : i32, tensor_memory_row_offset = 0 : i32} : (tensor<128x256xf32, #blocked_256N_4w_nan>) -> !ttg.memdesc<128x256xf32, #tmem_256N_nan, #ttng.tensor_memory, mutable>
@@ -1499,8 +1501,8 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.shar
 
   // CHECK-LABEL: @tensor_memory_ld_red_max_128x256_4_warps_nan
   // CHECK-COUNT-4: tcgen05.ld.red.sync.aligned.32x32b.x64.max.NaN.f32
-  // CHECK: tcgen05.wait <load>
   // CHECK-COUNT-3: llvm.intr.maximum
+  // CHECK: tcgen05.wait <load>
   tt.func public @tensor_memory_ld_red_max_128x256_4_warps_nan() {
     %cst_0 = arith.constant dense<0.000000e+00> : tensor<128x256xf32, #blocked_256N_4w_nan>
     %0 = ttng.tmem_alloc %cst_0 {tensor_memory_col_offset = 0 : i32, tensor_memory_row_offset = 0 : i32} : (tensor<128x256xf32, #blocked_256N_4w_nan>) -> !ttg.memdesc<128x256xf32, #tmem_256N_nan, #ttng.tensor_memory, mutable>

--- a/test/TritonGPU/consan.mlir
+++ b/test/TritonGPU/consan.mlir
@@ -2107,13 +2107,17 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.shar
     // CHECK: ttg.local_store %[[SMEM_POISON]], %[[SMEM]]
     // CHECK: ttg.barrier local
     // CHECK: %[[TMEM:.*]] = ttng.tmem_alloc
-    // CHECK: ttg.barrier tensor_read|tensor_write
+    // CHECK-NEXT: ttng.tmem_wait load
+    // CHECK-NEXT: ttng.tmem_wait store
+    // CHECK-NEXT: ttg.barrier tensor_read|tensor_write
     // CHECK: %[[TMEM_POISON:.*]] = arith.constant dense<0x7FC00000> : tensor<128x128xf32
     // CHECK: %[[TRUE:.*]] = arith.constant true
     // CHECK: ttng.tmem_store %[[TMEM_POISON]], %[[TMEM]], %[[TRUE]]
-    // CHECK: ttg.barrier tensor_read|tensor_write
+    // CHECK-NEXT: ttng.tmem_wait store
+    // CHECK-NEXT: ttg.barrier tensor_read|tensor_write
     // NO-INIT-NOT: ttg.local_store
     // NO-INIT-NOT: ttng.tmem_store
+    // NO-INIT-NOT: ttng.tmem_wait
     %smem = ttg.local_alloc {allocation.offset = 0 : i32} : () -> !ttg.memdesc<128x128xf32, #shared, #smem, mutable>
     %tmem = ttng.tmem_alloc {tensor_memory_col_offset = 0 : i32, tensor_memory_row_offset = 0 : i32} : () -> !ttg.memdesc<128x128xf32, #tmem, #ttng.tensor_memory, mutable>
     // NO-INIT: tt.return
@@ -2140,10 +2144,14 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.shar
     // CHECK: %[[TMEM:.*]] = ttng.tmem_alloc
     // CHECK: %[[TMEM_0:.*]] = ttg.memdesc_index %[[TMEM]]
     // CHECK: %[[TMEM_1:.*]] = ttg.memdesc_index %[[TMEM]]
-    // CHECK: ttg.barrier tensor_read|tensor_write
+    // CHECK-NEXT: ttng.tmem_wait load
+    // CHECK-NEXT: ttng.tmem_wait store
+    // CHECK-NEXT: ttg.barrier tensor_read|tensor_write
     // CHECK: ttng.tmem_store {{.*}}, %[[TMEM_0]],
+    // CHECK-NOT: ttng.tmem_wait
     // CHECK: ttng.tmem_store {{.*}}, %[[TMEM_1]],
-    // CHECK: ttg.barrier tensor_read|tensor_write
+    // CHECK-NEXT: ttng.tmem_wait store
+    // CHECK-NEXT: ttg.barrier tensor_read|tensor_write
     %smem = ttg.local_alloc {allocation.offset = 0 : i32} : () -> !ttg.memdesc<2x128x128xf32, #shared, #smem, mutable>
     %tmem = ttng.tmem_alloc {tensor_memory_col_offset = 0 : i32, tensor_memory_row_offset = 0 : i32} : () -> !ttg.memdesc<2x128x128xf32, #tmem, #ttng.tensor_memory, mutable>
     tt.return

--- a/test/TritonNvidiaGPU/tmem_barrier_insertion.mlir
+++ b/test/TritonNvidiaGPU/tmem_barrier_insertion.mlir
@@ -1,8 +1,10 @@
-// RUN: triton-opt %s -triton-nvidia-gpu-tmem-barrier-insertion | FileCheck %s
+// RUN: triton-opt %s -triton-nvidia-gpu-tmem-barrier-insertion -test-print-membar -triton-nvidia-gpu-tmem-wait-insertion | FileCheck %s --check-prefixes=CHECK,WAIT
+// RUN: triton-opt %s -triton-nvidia-gpu-tmem-wait-insertion | FileCheck %s --check-prefix=WAIT
 
 #shared_a = #ttg.nvmma_shared<{swizzlingByteWidth = 32, transposed = false, elementBitWidth = 16}>
 #shared_b = #ttg.nvmma_shared<{swizzlingByteWidth = 32, transposed = true, elementBitWidth = 16}>
 #shared_copy = #ttg.nvmma_shared<{swizzlingByteWidth = 128, transposed = false, elementBitWidth = 32}>
+#barrier = #ttg.swizzled_shared<{vec = 1, perPhase = 1, maxPhase = 1, order = [0]}>
 #blocked = #ttg.blocked<{sizePerThread = [1, 128], threadsPerWarp = [32, 1], warpsPerCTA = [4, 1], order = [0, 1]}>
 #blocked_scales = #ttg.blocked<{sizePerThread = [1, 4], threadsPerWarp = [32, 1], warpsPerCTA = [1, 4], order = [1, 0]}>
 #linear64 = #ttg.linear<{register = [[0, 1], [0, 2], [0, 4], [0, 8], [0, 16], [0, 32]], lane = [[1, 0], [2, 0], [4, 0], [8, 0], [0, 64]], warp = [[16, 0], [32, 0]], block = []}>
@@ -13,8 +15,11 @@
 module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32} {
   // CHECK-LABEL: @alloc_then_alloc
   // CHECK: ttng.tmem_alloc
+  // CHECK-NEXT: ttng.tmem_wait store
   // CHECK-NEXT: ttg.barrier local
   // CHECK-NEXT: ttng.tmem_alloc
+  // CHECK-NEXT: ttng.tmem_wait store
+  // CHECK-NEXT: tt.return
   tt.func @alloc_then_alloc(%arg0: tensor<128x128xf32, #blocked>) {
     %0 = ttng.tmem_alloc %arg0 {tensor_memory_col_offset = 0 : i32, tensor_memory_row_offset = 0 : i32} : (tensor<128x128xf32, #blocked>) -> !ttg.memdesc<128x128xf32, #tmem128, #ttng.tensor_memory, mutable>
     %1 = ttng.tmem_alloc %arg0 {tensor_memory_col_offset = 0 : i32, tensor_memory_row_offset = 0 : i32} : (tensor<128x128xf32, #blocked>) -> !ttg.memdesc<128x128xf32, #tmem128, #ttng.tensor_memory, mutable>
@@ -23,8 +28,11 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32} {
 
   // CHECK-LABEL: @alloc_then_ld
   // CHECK: ttng.tmem_alloc
+  // CHECK-NEXT: ttng.tmem_wait store
   // CHECK-NEXT: ttg.barrier local
   // CHECK-NEXT: ttng.tmem_load
+  // CHECK-NEXT: ttng.tmem_wait load
+  // CHECK-NEXT: tt.return
   tt.func @alloc_then_ld(%arg0: tensor<128x128xf32, #blocked>) {
     %0 = ttng.tmem_alloc %arg0 {tensor_memory_col_offset = 0 : i32, tensor_memory_row_offset = 0 : i32} : (tensor<128x128xf32, #blocked>) -> !ttg.memdesc<128x128xf32, #tmem128, #ttng.tensor_memory, mutable>
     %1 = ttng.tmem_load %0 : !ttg.memdesc<128x128xf32, #tmem128, #ttng.tensor_memory, mutable> -> tensor<128x128xf32, #blocked>
@@ -33,6 +41,7 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32} {
 
   // CHECK-LABEL: @alloc_then_st
   // CHECK: ttng.tmem_alloc
+  // CHECK-NEXT: ttng.tmem_wait store
   // CHECK-NEXT: ttg.barrier local
   // CHECK-NEXT: ttng.tmem_store
   tt.func @alloc_then_st(%arg0: tensor<128x128xf32, #blocked>) {
@@ -44,6 +53,7 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32} {
 
   // CHECK-LABEL: @alloc_then_mma
   // CHECK: ttng.tmem_alloc
+  // CHECK-NEXT: ttng.tmem_wait store
   // CHECK-NEXT: ttg.barrier local
   // CHECK-NEXT: ttng.tc_gen5_mma
   tt.func @alloc_then_mma(%arg0: tensor<128x128xf32, #blocked>,
@@ -61,6 +71,7 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32} {
 
   // CHECK-LABEL: @ld_then_alloc
   // CHECK: ttng.tmem_load
+  // CHECK-NEXT: ttng.tmem_wait load
   // CHECK-NEXT: ttg.barrier local
   // CHECK-NEXT: ttng.tmem_alloc
   tt.func @ld_then_alloc(%arg0: tensor<128x128xf32, #blocked>) {
@@ -74,6 +85,8 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32} {
   // CHECK-LABEL: @ld_then_ld
   // CHECK: ttng.tmem_load
   // CHECK-NEXT: ttng.tmem_load
+  // CHECK-NEXT: ttng.tmem_wait load
+  // CHECK-NEXT: tt.return
   tt.func @ld_then_ld() {
     %0 = ttng.tmem_alloc {tensor_memory_col_offset = 0 : i32, tensor_memory_row_offset = 0 : i32} : () -> !ttg.memdesc<128x128xf32, #tmem128, #ttng.tensor_memory, mutable>
     ttg.barrier local
@@ -84,8 +97,11 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32} {
 
   // CHECK-LABEL: @ld_then_st
   // CHECK: ttng.tmem_load
+  // CHECK-NEXT: ttng.tmem_wait load
   // CHECK-NEXT: ttg.barrier local
   // CHECK-NEXT: ttng.tmem_store
+  // CHECK-NEXT: ttng.tmem_wait store
+  // CHECK-NEXT: tt.return
   tt.func @ld_then_st(%arg0: tensor<128x128xf32, #blocked>) {
     %true = arith.constant true
     %0 = ttng.tmem_alloc {tensor_memory_col_offset = 0 : i32, tensor_memory_row_offset = 0 : i32} : () -> !ttg.memdesc<128x128xf32, #tmem128, #ttng.tensor_memory, mutable>
@@ -97,6 +113,7 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32} {
 
   // CHECK-LABEL: @ld_then_mma
   // CHECK: ttng.tmem_load
+  // CHECK-NEXT: ttng.tmem_wait load
   // CHECK-NEXT: ttg.barrier local
   // CHECK-NEXT: ttng.tc_gen5_mma
   tt.func @ld_then_mma(%arg0: !ttg.memdesc<128x128xf16, #shared_a, #ttg.shared_memory>,
@@ -113,20 +130,29 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32} {
     tt.return
   }
 
+  // An uninitialized allocation does not access reused storage. Wait only
+  // before its first store.
   // CHECK-LABEL: @st_then_alloc
   // CHECK: ttng.tmem_store
   // CHECK-NEXT: ttng.tmem_alloc
+  // CHECK-NEXT: ttng.tmem_wait store
+  // CHECK-NEXT: ttg.barrier local
+  // CHECK-NEXT: ttng.tmem_store
+  // CHECK-NEXT: ttng.tmem_wait store
+  // CHECK-NEXT: tt.return
   tt.func @st_then_alloc(%arg0: tensor<128x128xf32, #blocked>) {
     %true = arith.constant true
     %0 = ttng.tmem_alloc {tensor_memory_col_offset = 0 : i32, tensor_memory_row_offset = 0 : i32} : () -> !ttg.memdesc<128x128xf32, #tmem128, #ttng.tensor_memory, mutable>
     ttg.barrier local
     ttng.tmem_store %arg0, %0, %true : tensor<128x128xf32, #blocked> -> !ttg.memdesc<128x128xf32, #tmem128, #ttng.tensor_memory, mutable>
     %1 = ttng.tmem_alloc {tensor_memory_col_offset = 0 : i32, tensor_memory_row_offset = 0 : i32} : () -> !ttg.memdesc<128x128xf32, #tmem128, #ttng.tensor_memory, mutable>
+    ttng.tmem_store %arg0, %1, %true : tensor<128x128xf32, #blocked> -> !ttg.memdesc<128x128xf32, #tmem128, #ttng.tensor_memory, mutable>
     tt.return
   }
 
   // CHECK-LABEL: @st_then_ld
   // CHECK: ttng.tmem_store
+  // CHECK-NEXT: ttng.tmem_wait store
   // CHECK-NEXT: ttg.barrier local
   // CHECK-NEXT: ttng.tmem_load
   tt.func @st_then_ld(%arg0: tensor<128x128xf32, #blocked>) {
@@ -140,8 +166,11 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32} {
 
   // CHECK-LABEL: @st_then_st
   // CHECK: ttng.tmem_store
+  // CHECK-NEXT: ttng.tmem_wait store
   // CHECK-NEXT: ttg.barrier local
   // CHECK-NEXT: ttng.tmem_store
+  // CHECK-NEXT: ttng.tmem_wait store
+  // CHECK-NEXT: tt.return
   tt.func @st_then_st(%arg0: tensor<128x128xf32, #blocked>) {
     %true = arith.constant true
     %0 = ttng.tmem_alloc {tensor_memory_col_offset = 0 : i32, tensor_memory_row_offset = 0 : i32} : () -> !ttg.memdesc<128x128xf32, #tmem128, #ttng.tensor_memory, mutable>
@@ -153,8 +182,11 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32} {
 
   // CHECK-LABEL: @st_then_mma
   // CHECK: ttng.tmem_store
+  // CHECK-NEXT: ttng.tmem_wait store
   // CHECK-NEXT: ttg.barrier local
   // CHECK-NEXT: ttng.tc_gen5_mma
+  // CHECK-NOT: ttng.tmem_wait
+  // CHECK: tt.return
   tt.func @st_then_mma(%arg0: tensor<128x128xf32, #blocked>,
                        %arg1: !ttg.memdesc<128x128xf16, #shared_a, #ttg.shared_memory>,
                        %arg2: !ttg.memdesc<128x128xf16, #shared_b, #ttg.shared_memory>) {
@@ -258,6 +290,7 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32} {
   // CHECK-LABEL: @ld_then_alloc_then_st_aliases_second_row
   // CHECK: ttng.tmem_load
   // CHECK-NEXT: ttng.tmem_alloc
+  // CHECK-NEXT: ttng.tmem_wait load
   // CHECK-NEXT: ttg.barrier local
   // CHECK-NEXT: ttng.tmem_store
   tt.func @ld_then_alloc_then_st_aliases_second_row(%arg0: tensor<64x128xf32, #linear64>) {
@@ -272,6 +305,7 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32} {
 
   // CHECK-LABEL: @alloc_then_alloc_partial_overlap
   // CHECK: ttng.tmem_alloc
+  // CHECK-NEXT: ttng.tmem_wait store
   // CHECK-NEXT: ttg.barrier local
   // CHECK-NEXT: ttng.tmem_alloc
   tt.func @alloc_then_alloc_partial_overlap(%arg0: tensor<128x128xf32, #blocked>) {
@@ -282,6 +316,7 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32} {
 
   // CHECK-LABEL: @st_then_mma_scaled_scale_operand
   // CHECK: ttng.tmem_store
+  // CHECK-NEXT: ttng.tmem_wait store
   // CHECK-NEXT: ttg.barrier local
   // CHECK-NEXT: ttng.tc_gen5_mma_scaled
   tt.func @st_then_mma_scaled_scale_operand(
@@ -305,8 +340,11 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32} {
 
   // CHECK-LABEL: @ld_then_tmem_copy
   // CHECK: ttng.tmem_load
+  // CHECK-NEXT: ttng.tmem_wait load
   // CHECK-NEXT: ttg.barrier local
   // CHECK-NEXT: ttng.tmem_copy
+  // CHECK-NOT: ttng.tmem_wait
+  // CHECK: tt.return
   tt.func @ld_then_tmem_copy(
       %arg0: !ttg.memdesc<128x128xf32, #shared_copy, #ttg.shared_memory>) {
     %0 = ttng.tmem_alloc {tensor_memory_col_offset = 0 : i32, tensor_memory_row_offset = 0 : i32} : () -> !ttg.memdesc<128x128xf32, #tmem128, #ttng.tensor_memory, mutable>
@@ -318,8 +356,11 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32} {
 
   // CHECK-LABEL: @st_then_tmem_copy
   // CHECK: ttng.tmem_store
+  // CHECK-NEXT: ttng.tmem_wait store
   // CHECK-NEXT: ttg.barrier local
   // CHECK-NEXT: ttng.tmem_copy
+  // CHECK-NOT: ttng.tmem_wait
+  // CHECK: tt.return
   tt.func @st_then_tmem_copy(
       %arg0: tensor<128x128xf32, #blocked>,
       %arg1: !ttg.memdesc<128x128xf32, #shared_copy, #ttg.shared_memory>) {
@@ -333,7 +374,9 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32} {
 
   // CHECK-LABEL: @tmem_entry_c
   // CHECK: ttng.tmem_alloc
+  // CHECK-NEXT: ttng.tmem_wait store
   // CHECK-NEXT: ttg.barrier local
+  // CHECK-NEXT: tt.return
   tt.func private @tmem_entry_c() {
     %cst = arith.constant dense<0.0> : tensor<128x128xf32, #blocked>
     %alloc = ttng.tmem_alloc %cst {tensor_memory_col_offset = 0 : i32, tensor_memory_row_offset = 0 : i32} : (tensor<128x128xf32, #blocked>) -> !ttg.memdesc<128x128xf32, #tmem128, #ttng.tensor_memory, mutable>
@@ -349,10 +392,12 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32} {
     tt.return
   }
 
+  // The call supplies no entry barrier; wait before the caller's CTA barrier.
   // CHECK-LABEL: @tmem_entry_a
   // CHECK-NOT: ttg.barrier local
   // CHECK: tt.call @tmem_entry_b
   // CHECK: ttng.tmem_load
+  // CHECK-NEXT: ttng.tmem_wait load
   // CHECK-NEXT: ttg.barrier local
   // CHECK-NEXT: tt.call @tmem_entry_b
   tt.func @tmem_entry_a() {
@@ -361,6 +406,275 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32} {
     ttg.barrier local
     %loaded = ttng.tmem_load %alloc : !ttg.memdesc<128x128xf32, #tmem128, #ttng.tensor_memory, mutable> -> tensor<128x128xf32, #blocked>
     tt.call @tmem_entry_b() : () -> ()
+    tt.return
+  }
+
+  // Wait for the disjoint store before the MMA signals its completion barrier.
+  // CHECK-LABEL: @wait_disjoint_mma_publication
+  // CHECK: ttng.tmem_store
+  // CHECK-NEXT: ttng.tmem_wait store
+  // CHECK-NEXT: ttng.tc_gen5_mma
+  // CHECK-NEXT: ttng.wait_barrier
+  // CHECK-NEXT: tt.return
+  tt.func @wait_disjoint_mma_publication(
+      %data: tensor<128x128xf32, #blocked>,
+      %a: !ttg.memdesc<128x128xf16, #shared_a, #ttg.shared_memory, mutable>,
+      %b: !ttg.memdesc<128x128xf16, #shared_b, #ttg.shared_memory, mutable>,
+      %bar: !ttg.memdesc<1xi64, #barrier, #ttg.shared_memory, mutable>) {
+    %false = arith.constant false
+    %true = arith.constant true
+    %phase = arith.constant 0 : i32
+    %d = ttng.tmem_alloc {tensor_memory_col_offset = 0 : i32, tensor_memory_row_offset = 0 : i32} : () -> !ttg.memdesc<128x128xf32, #tmem128, #ttng.tensor_memory, mutable>
+    %other = ttng.tmem_alloc {tensor_memory_col_offset = 128 : i32, tensor_memory_row_offset = 0 : i32} : () -> !ttg.memdesc<128x128xf32, #tmem128, #ttng.tensor_memory, mutable>
+    ttng.tmem_store %data, %other, %true : tensor<128x128xf32, #blocked> -> !ttg.memdesc<128x128xf32, #tmem128, #ttng.tensor_memory, mutable>
+    ttng.tc_gen5_mma %a, %b, %d, %false, %true, %bar[%true] {is_async} :
+      !ttg.memdesc<128x128xf16, #shared_a, #ttg.shared_memory, mutable>,
+      !ttg.memdesc<128x128xf16, #shared_b, #ttg.shared_memory, mutable>,
+      !ttg.memdesc<128x128xf32, #tmem128, #ttng.tensor_memory, mutable>,
+      !ttg.memdesc<1xi64, #barrier, #ttg.shared_memory, mutable>
+    ttng.wait_barrier %bar, %phase deps %a, %b, %d : !ttg.memdesc<1xi64, #barrier, #ttg.shared_memory, mutable>, !ttg.memdesc<128x128xf16, #shared_a, #ttg.shared_memory, mutable>, !ttg.memdesc<128x128xf16, #shared_b, #ttg.shared_memory, mutable>, !ttg.memdesc<128x128xf32, #tmem128, #ttng.tensor_memory, mutable>
+    tt.return
+  }
+
+  // Batch disjoint stores before the local barrier and loads at the return.
+  // CHECK-LABEL: @wait_disjoint_batches
+  // CHECK: ttng.tmem_store
+  // CHECK-NEXT: ttng.tmem_store
+  // CHECK-NEXT: ttng.tmem_wait store
+  // CHECK-NEXT: ttg.barrier local
+  // CHECK-NEXT: ttng.tmem_load
+  // CHECK-NEXT: ttng.tmem_load
+  // CHECK-NEXT: ttng.tmem_wait load
+  // CHECK-NEXT: tt.return
+  tt.func @wait_disjoint_batches(%data: tensor<128x64xf32, #blocked>) -> (tensor<128x64xf32, #blocked>, tensor<128x64xf32, #blocked>) {
+    %true = arith.constant true
+    %low = ttng.tmem_alloc {tensor_memory_col_offset = 0 : i32, tensor_memory_row_offset = 0 : i32} : () -> !ttg.memdesc<128x64xf32, #tmem128, #ttng.tensor_memory, mutable>
+    %high = ttng.tmem_alloc {tensor_memory_col_offset = 64 : i32, tensor_memory_row_offset = 0 : i32} : () -> !ttg.memdesc<128x64xf32, #tmem128, #ttng.tensor_memory, mutable>
+    ttng.tmem_store %data, %low, %true : tensor<128x64xf32, #blocked> -> !ttg.memdesc<128x64xf32, #tmem128, #ttng.tensor_memory, mutable>
+    ttng.tmem_store %data, %high, %true : tensor<128x64xf32, #blocked> -> !ttg.memdesc<128x64xf32, #tmem128, #ttng.tensor_memory, mutable>
+    %a = ttng.tmem_load %low : !ttg.memdesc<128x64xf32, #tmem128, #ttng.tensor_memory, mutable> -> tensor<128x64xf32, #blocked>
+    %b = ttng.tmem_load %high : !ttg.memdesc<128x64xf32, #tmem128, #ttng.tensor_memory, mutable> -> tensor<128x64xf32, #blocked>
+    tt.return %a, %b : tensor<128x64xf32, #blocked>, tensor<128x64xf32, #blocked>
+  }
+
+  // Hoisting the wait for %low must leave %high's later store pending.
+  // WAIT-LABEL: @wait_hoisted_preserves_later_store
+  // WAIT: ttng.tmem_store
+  // WAIT-NEXT: ttng.tmem_wait store
+  // WAIT-NEXT: %{{.*}} = tt.atomic_poll acquire
+  // WAIT-NEXT: ttng.tmem_store
+  // WAIT-NEXT: ttng.tmem_load
+  // WAIT-NEXT: ttng.tmem_wait store
+  // WAIT-NEXT: ttng.tmem_wait load
+  // WAIT-NEXT: ttg.barrier local
+  // WAIT-NEXT: ttng.tmem_load
+  // WAIT-NEXT: ttng.tmem_wait load
+  // WAIT-NEXT: tt.return
+  tt.func @wait_hoisted_preserves_later_store(%data: tensor<128x64xf32, #blocked>, %ptr: !tt.ptr<i32>, %expected: i32) -> (tensor<128x64xf32, #blocked>, tensor<128x64xf32, #blocked>) {
+    %true = arith.constant true
+    %low = ttng.tmem_alloc {tensor_memory_col_offset = 0 : i32, tensor_memory_row_offset = 0 : i32} : () -> !ttg.memdesc<128x64xf32, #tmem128, #ttng.tensor_memory, mutable>
+    %high = ttng.tmem_alloc {tensor_memory_col_offset = 64 : i32, tensor_memory_row_offset = 0 : i32} : () -> !ttg.memdesc<128x64xf32, #tmem128, #ttng.tensor_memory, mutable>
+    ttng.tmem_store %data, %low, %true : tensor<128x64xf32, #blocked> -> !ttg.memdesc<128x64xf32, #tmem128, #ttng.tensor_memory, mutable>
+    %matched = tt.atomic_poll acquire, gpu, %ptr, %expected : !tt.ptr<i32>, i32 -> i1
+    ttng.tmem_store %data, %high, %true : tensor<128x64xf32, #blocked> -> !ttg.memdesc<128x64xf32, #tmem128, #ttng.tensor_memory, mutable>
+    %a = ttng.tmem_load %low : !ttg.memdesc<128x64xf32, #tmem128, #ttng.tensor_memory, mutable> -> tensor<128x64xf32, #blocked>
+    %b = ttng.tmem_load %high : !ttg.memdesc<128x64xf32, #tmem128, #ttng.tensor_memory, mutable> -> tensor<128x64xf32, #blocked>
+    tt.return %a, %b : tensor<128x64xf32, #blocked>, tensor<128x64xf32, #blocked>
+  }
+
+  // Reuse the acquire poll's trailing CTA barrier for the following TMEM load.
+  // WAIT-LABEL: @wait_trailing_atomic_barrier
+  // WAIT: ttng.tmem_store
+  // WAIT-NEXT: ttng.tmem_wait store
+  // WAIT-NEXT: %{{.*}} = tt.atomic_poll acquire
+  // WAIT-NEXT: ttng.tmem_load
+  // WAIT-NEXT: ttng.tmem_wait load
+  // WAIT-NEXT: tt.return
+  tt.func @wait_trailing_atomic_barrier(%ptr: !tt.ptr<i32>, %expected: i32, %data: tensor<128x128xf32, #blocked>) -> tensor<128x128xf32, #blocked> {
+    %true = arith.constant true
+    %mem = ttng.tmem_alloc {tensor_memory_col_offset = 0 : i32, tensor_memory_row_offset = 0 : i32} : () -> !ttg.memdesc<128x128xf32, #tmem128, #ttng.tensor_memory, mutable>
+    ttng.tmem_store %data, %mem, %true : tensor<128x128xf32, #blocked> -> !ttg.memdesc<128x128xf32, #tmem128, #ttng.tensor_memory, mutable>
+    %matched = tt.atomic_poll acquire, gpu, %ptr, %expected : !tt.ptr<i32>, i32 -> i1
+    %loaded = ttng.tmem_load %mem : !ttg.memdesc<128x128xf32, #tmem128, #ttng.tensor_memory, mutable> -> tensor<128x128xf32, #blocked>
+    tt.return %loaded : tensor<128x128xf32, #blocked>
+  }
+
+  // Keep %low's store pending across the barrier between %high's load and store.
+  // Wait for both stores before arrive_barrier.
+  // CHECK-LABEL: @wait_disjoint_corrections
+  // CHECK: ttng.tmem_load
+  // CHECK-NEXT: ttng.tmem_wait load
+  // CHECK-NEXT: ttg.barrier local
+  // CHECK-NEXT: ttng.tmem_store
+  // CHECK-NEXT: ttng.tmem_load
+  // CHECK-NEXT: ttng.tmem_wait load
+  // CHECK-NEXT: ttg.barrier local
+  // CHECK-NEXT: ttng.tmem_store
+  // CHECK-NEXT: ttng.tmem_wait store
+  // CHECK-NEXT: ttng.arrive_barrier
+  tt.func @wait_disjoint_corrections(%data: tensor<128x64xf32, #blocked>, %bar: !ttg.memdesc<1xi64, #barrier, #ttg.shared_memory, mutable>) {
+    %true = arith.constant true
+    %low = ttng.tmem_alloc %data {tensor_memory_col_offset = 0 : i32, tensor_memory_row_offset = 0 : i32} : (tensor<128x64xf32, #blocked>) -> !ttg.memdesc<128x64xf32, #tmem128, #ttng.tensor_memory, mutable>
+    %high = ttng.tmem_alloc %data {tensor_memory_col_offset = 64 : i32, tensor_memory_row_offset = 0 : i32} : (tensor<128x64xf32, #blocked>) -> !ttg.memdesc<128x64xf32, #tmem128, #ttng.tensor_memory, mutable>
+    %a = ttng.tmem_load %low : !ttg.memdesc<128x64xf32, #tmem128, #ttng.tensor_memory, mutable> -> tensor<128x64xf32, #blocked>
+    ttng.tmem_store %a, %low, %true : tensor<128x64xf32, #blocked> -> !ttg.memdesc<128x64xf32, #tmem128, #ttng.tensor_memory, mutable>
+    %b = ttng.tmem_load %high : !ttg.memdesc<128x64xf32, #tmem128, #ttng.tensor_memory, mutable> -> tensor<128x64xf32, #blocked>
+    ttng.tmem_store %b, %high, %true : tensor<128x64xf32, #blocked> -> !ttg.memdesc<128x64xf32, #tmem128, #ttng.tensor_memory, mutable>
+    ttng.arrive_barrier %bar, 1 : !ttg.memdesc<1xi64, #barrier, #ttg.shared_memory, mutable>
+    tt.return
+  }
+
+  // Defer load and store waits to the last poll's trailing barrier, even without
+  // later memory conflicts.
+  // CHECK-LABEL: @wait_last_trailing_barrier
+  // CHECK: ttng.tmem_load
+  // CHECK-NEXT: ttng.tmem_store
+  // CHECK-NEXT: %{{.*}} = tt.atomic_poll acquire
+  // CHECK-NEXT: ttng.tmem_wait load
+  // CHECK-NEXT: ttng.tmem_wait store
+  // CHECK-NEXT: %{{.*}} = tt.atomic_poll acquire
+  // CHECK-NEXT: tt.return
+  tt.func @wait_last_trailing_barrier(%data: tensor<128x64xf32, #blocked>, %ptr: !tt.ptr<i32>, %expected: i32) {
+    %true = arith.constant true
+    %low = ttng.tmem_alloc %data {tensor_memory_col_offset = 0 : i32, tensor_memory_row_offset = 0 : i32} : (tensor<128x64xf32, #blocked>) -> !ttg.memdesc<128x64xf32, #tmem128, #ttng.tensor_memory, mutable>
+    %high = ttng.tmem_alloc {tensor_memory_col_offset = 64 : i32, tensor_memory_row_offset = 0 : i32} : () -> !ttg.memdesc<128x64xf32, #tmem128, #ttng.tensor_memory, mutable>
+    %loaded = ttng.tmem_load %low : !ttg.memdesc<128x64xf32, #tmem128, #ttng.tensor_memory, mutable> -> tensor<128x64xf32, #blocked>
+    ttng.tmem_store %loaded, %high, %true : tensor<128x64xf32, #blocked> -> !ttg.memdesc<128x64xf32, #tmem128, #ttng.tensor_memory, mutable>
+    %first = tt.atomic_poll acquire, gpu, %ptr, %expected : !tt.ptr<i32>, i32 -> i1
+    %last = tt.atomic_poll acquire, gpu, %ptr, %expected : !tt.ptr<i32>, i32 -> i1
+    tt.return
+  }
+
+  // Stores remain pending across branches. At the merge, wait before
+  // overwriting %low, which may have been written by the left branch.
+  // CHECK-LABEL: @wait_cfg_join
+  // CHECK: cf.cond_br
+  // CHECK: ttng.tmem_store
+  // CHECK-NEXT: cf.br
+  // CHECK: ttng.tmem_store
+  // CHECK-NEXT: cf.br
+  // CHECK: ttng.tmem_wait store
+  // CHECK-NEXT: ttg.barrier local
+  // CHECK-NEXT: ttng.tmem_store
+  // CHECK-NEXT: ttng.tmem_wait store
+  // CHECK-NEXT: tt.return
+  tt.func @wait_cfg_join(%condition: i1, %data: tensor<128x64xf32, #blocked>) {
+    %true = arith.constant true
+    %low = ttng.tmem_alloc {tensor_memory_col_offset = 0 : i32, tensor_memory_row_offset = 0 : i32} : () -> !ttg.memdesc<128x64xf32, #tmem128, #ttng.tensor_memory, mutable>
+    %high = ttng.tmem_alloc {tensor_memory_col_offset = 64 : i32, tensor_memory_row_offset = 0 : i32} : () -> !ttg.memdesc<128x64xf32, #tmem128, #ttng.tensor_memory, mutable>
+    cf.cond_br %condition, ^left, ^right
+  ^left:
+    ttng.tmem_store %data, %low, %true : tensor<128x64xf32, #blocked> -> !ttg.memdesc<128x64xf32, #tmem128, #ttng.tensor_memory, mutable>
+    cf.br ^merge
+  ^right:
+    ttng.tmem_store %data, %high, %true : tensor<128x64xf32, #blocked> -> !ttg.memdesc<128x64xf32, #tmem128, #ttng.tensor_memory, mutable>
+    cf.br ^merge
+  ^merge:
+    ttng.tmem_store %data, %low, %true : tensor<128x64xf32, #blocked> -> !ttg.memdesc<128x64xf32, #tmem128, #ttng.tensor_memory, mutable>
+    tt.return
+  }
+
+  // Complete the first store before the poll's trailing barrier, even though
+  // the conflicting store is after the merge.
+  // CHECK-LABEL: @wait_barrier_before_branch
+  // CHECK: cf.cond_br
+  // CHECK: ttng.tmem_store
+  // CHECK-NEXT: ttng.tmem_wait store
+  // CHECK-NEXT: %{{.*}} = tt.atomic_poll acquire
+  // CHECK-NEXT: cf.br
+  // CHECK: ttng.tmem_store
+  // CHECK-NEXT: ttng.tmem_wait store
+  // CHECK-NEXT: tt.return
+  tt.func @wait_barrier_before_branch(%condition: i1, %ptr: !tt.ptr<i32>, %expected: i32, %data: tensor<128x128xf32, #blocked>) {
+    %true = arith.constant true
+    %mem = ttng.tmem_alloc {tensor_memory_col_offset = 0 : i32, tensor_memory_row_offset = 0 : i32} : () -> !ttg.memdesc<128x128xf32, #tmem128, #ttng.tensor_memory, mutable>
+    cf.cond_br %condition, ^left, ^merge
+  ^left:
+    ttng.tmem_store %data, %mem, %true : tensor<128x128xf32, #blocked> -> !ttg.memdesc<128x128xf32, #tmem128, #ttng.tensor_memory, mutable>
+    %matched = tt.atomic_poll acquire, gpu, %ptr, %expected : !tt.ptr<i32>, i32 -> i1
+    cf.br ^merge
+  ^merge:
+    ttng.tmem_store %data, %mem, %true : tensor<128x128xf32, #blocked> -> !ttg.memdesc<128x128xf32, #tmem128, #ttng.tensor_memory, mutable>
+    tt.return
+  }
+
+  // Carry pending stores across the backedge; the next iteration must wait
+  // before writing the same descriptor again.
+  // CHECK-LABEL: @wait_cfg_backedge
+  // CHECK: cf.br
+  // CHECK: cf.cond_br
+  // CHECK: ttng.tmem_wait store
+  // CHECK-NEXT: ttg.barrier local
+  // CHECK-NEXT: ttng.tmem_store
+  // CHECK-NOT: ttng.tmem_wait
+  // CHECK: cf.br
+  // CHECK: ttng.tmem_wait store
+  // CHECK-NEXT: tt.return
+  tt.func @wait_cfg_backedge(%iterations: i32, %data: tensor<128x128xf32, #blocked>) {
+    %true = arith.constant true
+    %zero = arith.constant 0 : i32
+    %one = arith.constant 1 : i32
+    %mem = ttng.tmem_alloc {tensor_memory_col_offset = 0 : i32, tensor_memory_row_offset = 0 : i32} : () -> !ttg.memdesc<128x128xf32, #tmem128, #ttng.tensor_memory, mutable>
+    cf.br ^header(%iterations : i32)
+  ^header(%remaining: i32):
+    %again = arith.cmpi sgt, %remaining, %zero : i32
+    cf.cond_br %again, ^body, ^exit
+  ^body:
+    ttng.tmem_store %data, %mem, %true : tensor<128x128xf32, #blocked> -> !ttg.memdesc<128x128xf32, #tmem128, #ttng.tensor_memory, mutable>
+    %next = arith.subi %remaining, %one : i32
+    cf.br ^header(%next : i32)
+  ^exit:
+    tt.return
+  }
+
+  // Global effects leave stores pending; opaque synchronization completes them.
+  // WAIT-LABEL: @wait_global_effects
+  // WAIT: ttng.tmem_store
+  // WAIT-NEXT: %{{.*}} = tt.load
+  // WAIT-NEXT: tt.print
+  // WAIT-NEXT: ttng.tmem_wait store
+  // WAIT-NEXT: %{{.*}} = tt.elementwise_inline_asm
+  // WAIT-NEXT: tt.return
+  tt.func @wait_global_effects(%ptr: !tt.ptr<i32>, %value: f32) {
+    %true = arith.constant true
+    %data = tt.splat %value : f32 -> tensor<128x128xf32, #blocked>
+    %mem = ttng.tmem_alloc {tensor_memory_col_offset = 0 : i32, tensor_memory_row_offset = 0 : i32} : () -> !ttg.memdesc<128x128xf32, #tmem128, #ttng.tensor_memory, mutable>
+    ttng.tmem_store %data, %mem, %true : tensor<128x128xf32, #blocked> -> !ttg.memdesc<128x128xf32, #tmem128, #ttng.tensor_memory, mutable>
+    %loaded = tt.load %ptr {isVolatile = true} : !tt.ptr<i32>
+    tt.print "loaded" {hex = false, isSigned = array<i32: 1>} : %loaded : i32
+    %opaque = tt.elementwise_inline_asm "bar.sync 0; mov.u32 $0, 0;" {constraints = "=r", packed_element = 1 : i32, pure = false} -> i32
+    tt.return
+  }
+
+  // Reuse the descriptor acquire's trailing barrier for the following load.
+  // WAIT-LABEL: @wait_tensormap_acquire_barrier
+  // WAIT: ttng.tmem_store
+  // WAIT-NEXT: %{{.*}} = ttg.global_scratch_alloc
+  // WAIT-NEXT: ttng.tensormap_create
+  // WAIT-NEXT: ttng.tmem_wait store
+  // WAIT-NEXT: ttng.tensormap_fenceproxy_acquire
+  // WAIT-NEXT: %{{.*}} = ttng.reinterpret_tensor_descriptor
+  // WAIT-NEXT: %{{.*}} = ttng.tmem_load
+  tt.func @wait_tensormap_acquire_barrier(%out: !tt.ptr<f32>, %value: f32) {
+    %true = arith.constant true
+    %c0 = arith.constant 0 : i32
+    %c1 = arith.constant 1 : i32
+    %c32 = arith.constant 32 : i32
+    %c128 = arith.constant 128 : i32
+    %c512 = arith.constant 512 : i64
+    %data = tt.splat %value : f32 -> tensor<128x128xf32, #blocked>
+    %mem = ttng.tmem_alloc {tensor_memory_col_offset = 0 : i32, tensor_memory_row_offset = 0 : i32} : () -> !ttg.memdesc<128x128xf32, #tmem128, #ttng.tensor_memory, mutable>
+    ttng.tmem_store %data, %mem, %true : tensor<128x128xf32, #blocked> -> !ttg.memdesc<128x128xf32, #tmem128, #ttng.tensor_memory, mutable>
+    %raw = ttg.global_scratch_alloc {alignment = 128 : i32, nbytes = 128 : i32} : !tt.ptr<i8>
+    ttng.tensormap_create %raw, %out, [%c32, %c128], [%c128, %c128], [%c512], [%c1, %c1] {elem_type = 7 : i32, fill_mode = 0 : i32, interleave_layout = 0 : i32, swizzle_mode = 3 : i32} : (!tt.ptr<i8>, !tt.ptr<f32>, i32, i32, i32, i32, i64, i32, i32) -> ()
+    ttng.tensormap_fenceproxy_acquire %raw : !tt.ptr<i8>
+    %desc = ttng.reinterpret_tensor_descriptor %raw : !tt.ptr<i8> to !tt.tensordesc<128x128xf32, #shared_copy>
+    %loaded = ttng.tmem_load %mem : !ttg.memdesc<128x128xf32, #tmem128, #ttng.tensor_memory, mutable> -> tensor<128x128xf32, #blocked>
+    %smem = ttg.local_alloc %loaded : (tensor<128x128xf32, #blocked>) -> !ttg.memdesc<128x128xf32, #shared_copy, #ttg.shared_memory, mutable>
+    ttng.fence_async_shared {bCluster = false}
+    ttng.async_tma_copy_local_to_global %desc[%c0, %c0] %smem : !tt.tensordesc<128x128xf32, #shared_copy>, !ttg.memdesc<128x128xf32, #shared_copy, #ttg.shared_memory, mutable>
+    ttng.async_tma_store_wait {pendings = 0 : i32, read_only}
+    ttg.local_dealloc %smem : !ttg.memdesc<128x128xf32, #shared_copy, #ttg.shared_memory, mutable>
     tt.return
   }
 }

--- a/third_party/nvidia/lib/TritonNVIDIAGPUToLLVM/TensorMemoryToLLVM.cpp
+++ b/third_party/nvidia/lib/TritonNVIDIAGPUToLLVM/TensorMemoryToLLVM.cpp
@@ -503,6 +503,21 @@ static void combinePartialReductions(Location loc,
   }
 }
 
+struct TensorMemoryWaitOpConversion
+    : public ConvertOpToLLVMPattern<triton::nvidia_gpu::TMEMWaitOp> {
+  using ConvertOpToLLVMPattern::ConvertOpToLLVMPattern;
+
+  LogicalResult
+  matchAndRewrite(triton::nvidia_gpu::TMEMWaitOp op, OpAdaptor adaptor,
+                  ConversionPatternRewriter &rewriter) const override {
+    auto kind = op.getKind() == TMEMWaitKind::LOAD
+                    ? NVVM::Tcgen05WaitKind::LOAD
+                    : NVVM::Tcgen05WaitKind::STORE;
+    rewriter.replaceOpWithNewOp<NVVM::Tcgen05WaitOp>(op, kind);
+    return success();
+  }
+};
+
 struct TensorMemoryLoadOpConversion
     : public ConvertOpToLLVMPattern<triton::nvidia_gpu::TMEMLoadOp> {
   using ConvertOpToLLVMPattern::ConvertOpToLLVMPattern;
@@ -535,10 +550,9 @@ struct TensorMemoryLoadOpConversion
 
     Value resultStruct = packUniqueTensorElements(
         loc, getTypeConverter(), resultVals, rewriter, op.getType());
-    // Wait insertion could be moved to the TTGIR level if needed.
-    NVVM::Tcgen05WaitOp::create(rewriter, loc, NVVM::Tcgen05WaitKind::LOAD);
+    // TMEM waits are inserted at the TTGIR level for memory ordering.
 
-    // tcgen05.ld.red is async, redval registers aren't valid until the wait
+    // tcgen05.ld.red honors true register dependencies without a wait.
     if (redOp)
       combinePartialReductions(loc, rewriter, redvalVals, *redOp, useNaN);
 
@@ -577,8 +591,6 @@ struct TensorMemoryStoreOpConversion
     auto maxnreg = getContextualMaxNReg(op);
     lowerTMemLdStFromTypes(loc, rewriter, regTy, memTy, tmemBase, maxnreg, pred,
                            llvmElemTy, srcValues);
-    NVVM::Tcgen05WaitOp::create(rewriter, loc, NVVM::Tcgen05WaitKind::STORE);
-
     rewriter.eraseOp(op);
     return success();
   }
@@ -616,7 +628,6 @@ struct TensorMemoryAllocOpConversion
       Value ptr = b.inttoptr(base.getType(), allocAddress);
       lowerTMemLdStFromTypes(loc, rewriter, regTy, memTy, ptr, maxnreg,
                              b.i1_val(true), llvmElemTy, srcValues);
-      NVVM::Tcgen05WaitOp::create(rewriter, loc, NVVM::Tcgen05WaitKind::STORE);
     }
     // Cast to address space 3 as the shared memory object uses 3.
     // TODO: clean this up and use either a int or ptr address space 6
@@ -846,8 +857,8 @@ void mlir::triton::NVIDIA::populateTensorMemoryOpToLLVMPattern(
     LLVMTypeConverter &typeConverter, RewritePatternSet &patterns,
     PatternBenefit benefit) {
   patterns.add<TensorMemoryCopyOpConversion, TensorMemoryLoadOpConversion,
-               TensorMemoryStoreOpConversion, TensorMemoryAllocOpConversion>(
-      typeConverter, benefit);
+               TensorMemoryStoreOpConversion, TensorMemoryAllocOpConversion,
+               TensorMemoryWaitOpConversion>(typeConverter, benefit);
 }
 
 void mlir::triton::NVIDIA::populateTensorMemorySubviewOpToLLVMPattern(

--- a/third_party/nvidia/lib/TritonNVIDIAGPUToLLVM/TritonGPUToLLVM.cpp
+++ b/third_party/nvidia/lib/TritonNVIDIAGPUToLLVM/TritonGPUToLLVM.cpp
@@ -31,6 +31,7 @@
 #include "triton/Dialect/TritonNvidiaGPU/IR/Dialect.h"
 #include "triton/Dialect/TritonNvidiaGPU/Transforms/ClusterBarrierInsertion.h"
 #include "triton/Dialect/TritonNvidiaGPU/Transforms/ClusterBarrierMbarAllocator.h"
+#include "triton/Dialect/TritonNvidiaGPU/Transforms/Passes.h"
 
 namespace ttng = mlir::triton::nvidia_gpu;
 
@@ -172,6 +173,10 @@ LogicalResult ConvertTritonGPUToLLVM::prepareModule(ModuleOp mod,
 
   ModuleMembarAnalysis membarPass(allocation, canSkipBarSync);
   membarPass.run();
+  mlir::PassManager waitPm(mod.getContext());
+  waitPm.addPass(ttng::createTritonNvidiaGPUTMemWaitInsertionPass());
+  if (failed(waitPm.run(mod)))
+    return failure();
 
   if (enableConcurrencySanitizer) {
     auto hooks = mlir::triton::instrument::createConSanHooks("nvidia");


### PR DESCRIPTION
Waits are per-warp and TMEM ops are cross-warp, so we need to follow
these with a barrier. For now, to avoid adding more barriers, we keep
track of the last seen barrier op and place the wait before it.

This reduces these barriers from 14 to 8 in the 01 gluon attention kernel
and enables a better scheduling of the epilogue.
