### PR TITLE
[Analysis] Reuse BufferRegion analysis in Membar

### DIFF
--- a/include/triton/Analysis/Allocation.h
+++ b/include/triton/Analysis/Allocation.h
@@ -9,6 +9,7 @@
 #include "llvm/ADT/SetVector.h"
 
 #include <limits>
+#include <optional>
 
 namespace mlir {
 
@@ -23,6 +24,11 @@ unsigned defaultAllocationAnalysisScratchSizeFn(Operation *op);
 
 /// Returns whether an operation uses scratch memory across CTAs.
 bool hasCrossCTAScratch(Operation *op);
+
+/// For allocated atomic-result scratch, returns the CTA bits broadcast from
+/// each group leader. Physical scratch owners have these bits clear.
+/// Scalar results are broadcast from CTA0 across all CTAs.
+std::optional<uint16_t> getAtomicScratchBroadcastMask(Operation *op);
 
 unsigned getNumScratchElemsSwizzledCvt(const LinearLayout &srcLayout,
                                        const LinearLayout &dstLayout,

--- a/include/triton/Analysis/Allocation.h
+++ b/include/triton/Analysis/Allocation.h
@@ -25,9 +25,10 @@ unsigned defaultAllocationAnalysisScratchSizeFn(Operation *op);
 /// Returns whether an operation uses scratch memory across CTAs.
 bool hasCrossCTAScratch(Operation *op);
 
-/// For allocated atomic-result scratch, returns the CTA bits broadcast from
+/// For atomic-result scratch, returns the CTA bits broadcast from
 /// each group leader. Physical scratch owners have these bits clear.
 /// Scalar results are broadcast from CTA0 across all CTAs.
+/// Callers check whether scratch has been allocated.
 std::optional<uint16_t> getAtomicScratchBroadcastMask(Operation *op);
 
 unsigned getNumScratchElemsSwizzledCvt(const LinearLayout &srcLayout,

--- a/include/triton/Analysis/BufferRegion.h
+++ b/include/triton/Analysis/BufferRegion.h
@@ -20,6 +20,11 @@
 #include "llvm/ADT/SparseBitVector.h"
 #include "llvm/ADT/UniqueVector.h"
 
+namespace mlir {
+class Allocation;
+class ModuleAllocation;
+} // namespace mlir
+
 namespace mlir::triton::gpu {
 enum class SharedKind : uint32_t;
 }
@@ -122,6 +127,8 @@ struct BufferRegionView {
   uint32_t affineCTAOffset = 0;
   /// Deterministically interned identity of the owning allocation frame.
   uint32_t allocationFrame = 0;
+  /// Descriptor allocation supplying these views; null for implicit scratch.
+  Operation *allocation = nullptr;
 
   bool contains(const BufferRegionView &other) const {
     return allocationFrame == other.allocationFrame &&
@@ -134,7 +141,8 @@ struct BufferRegionView {
 private:
   auto key() const {
     return std::tie(allocationFrame, region, storageBase, affineOffset,
-                    affinePartitionOffset, affineCTAOffset, partitionBases);
+                    affinePartitionOffset, affineCTAOffset, partitionBases,
+                    allocation);
   }
 
 public:
@@ -257,7 +265,7 @@ bool hasSharedAccess(Operation *op,
 //
 // Produces a RegionInfo lattice for each MemDesc/ptr-like SSA value,
 // and also collects a global list of all discovered BufferRegions.
-// Requires offsets from the shared- and tensor-memory allocation passes.
+// Requires completed allocation analyses or their materialized offsets.
 //
 class BufferRegionAnalysis : public dataflow::SparseForwardDataFlowAnalysis<
                                  dataflow::Lattice<RegionInfo>> {
@@ -269,8 +277,9 @@ public:
   enum class Mode { AllMemory, TensorMemoryOnly };
 
   explicit BufferRegionAnalysis(DataFlowSolver &solver,
-                                Mode mode = Mode::AllMemory)
-      : Base(solver), mode(mode) {}
+                                Mode mode = Mode::AllMemory,
+                                ModuleAllocation *allocation = nullptr)
+      : Base(solver), mode(mode), moduleAllocation(allocation) {}
 
   enum RegionType { SHARED_MEMORY, TENSOR_MEMORY, BARRIER, NUM_REGION_TYPES };
 
@@ -293,6 +302,9 @@ public:
   const BufferRegionFootprint *
   translateToCallsite(const BufferRegionFootprint *footprint,
                       CallOpInterface call, FunctionOpInterface callee);
+
+  /// Shared-memory offset of the callee frame in the caller's allocation.
+  uint32_t getCallOffset(CallOpInterface call) const;
 
   uint32_t getOperationId(Operation *operation) const {
     return operationInterner.idFor(operation);
@@ -332,6 +344,9 @@ public:
 
 private:
   const Mode mode;
+  ModuleAllocation *moduleAllocation;
+
+  Allocation *getAllocation(Operation *op) const;
 
   BufferRegionView getAllocView(Value allocation, uint32_t storageBase,
                                 llvm::ArrayRef<uint32_t> partitionBases = {});

--- a/include/triton/Analysis/BufferRegion.h
+++ b/include/triton/Analysis/BufferRegion.h
@@ -2,6 +2,7 @@
 #define TRITON_ANALYSIS_BUFFER_REGION_H
 
 #include <cstdint>
+#include <memory>
 #include <optional>
 #include <set>
 #include <tuple>
@@ -122,11 +123,6 @@ struct BufferRegionView {
   /// Deterministically interned identity of the owning allocation frame.
   uint32_t allocationFrame = 0;
 
-  bool intersects(const BufferRegionView &other) const {
-    return allocationFrame == other.allocationFrame &&
-           region.intersects(other.region);
-  }
-
   bool contains(const BufferRegionView &other) const {
     return allocationFrame == other.allocationFrame &&
            region.contains(other.region);
@@ -150,9 +146,6 @@ public:
     return key() < other.key();
   }
 };
-
-/// An exact access view, or no view when the physical region is unknown.
-using BufferRegionAccess = std::optional<BufferRegionView>;
 
 //===----------------------------------------------------------------------===//
 // Buffer state planning
@@ -223,6 +216,20 @@ struct RegionInfo {
   }
 };
 
+/// Complete MAY-views of a descriptor, shared by all of its memory effects.
+/// Runtime indices may select several physical views across loop iterations.
+/// Addresses, rather than runtime descriptor keys, define the geometry; the
+/// memory space distinguishes shared bytes from TMEM's 32-bit storage words.
+struct BufferRegionFootprint {
+  Attribute memorySpace;
+  RegionInfo regionInfo;
+};
+
+/// Prove disjointness only if every candidate pair is disjoint. Missing views
+/// and unnormalized allocation frames may overlap, never denote empty storage.
+bool mayOverlap(const BufferRegionFootprint *lhs,
+                const BufferRegionFootprint *rhs);
+
 enum class RW { Read, Write };
 
 struct MemoryAccess {
@@ -250,6 +257,7 @@ bool hasSharedAccess(Operation *op,
 //
 // Produces a RegionInfo lattice for each MemDesc/ptr-like SSA value,
 // and also collects a global list of all discovered BufferRegions.
+// Requires offsets from the shared- and tensor-memory allocation passes.
 //
 class BufferRegionAnalysis : public dataflow::SparseForwardDataFlowAnalysis<
                                  dataflow::Lattice<RegionInfo>> {
@@ -258,7 +266,11 @@ public:
   using Base =
       dataflow::SparseForwardDataFlowAnalysis<dataflow::Lattice<RegionInfo>>;
   using Base::getLatticeElement;
-  using Base::SparseForwardDataFlowAnalysis;
+  enum class Mode { AllMemory, TensorMemoryOnly };
+
+  explicit BufferRegionAnalysis(DataFlowSolver &solver,
+                                Mode mode = Mode::AllMemory)
+      : Base(solver), mode(mode) {}
 
   enum RegionType { SHARED_MEMORY, TENSOR_MEMORY, BARRIER, NUM_REGION_TYPES };
 
@@ -266,15 +278,21 @@ public:
     return getLatticeElement(value)->getValue();
   }
 
-  /// Return every exact view an access may reference. A null view represents
-  /// an unknown region and therefore may alias any other view.
-  llvm::SmallVector<BufferRegionAccess> getAccessRegions(Value value);
+  /// Return an immutable footprint covering every possible view, owned by this
+  /// analysis. Call after solver convergence. Return null for unknown geometry
+  /// or views outside allocationFrame, when set.
+  const BufferRegionFootprint *
+  getFootprint(Value value, FunctionOpInterface allocationFrame = {});
 
-  /// Translate a callee-local view into the caller's allocation frame.
-  BufferRegionAccess translateToCallsite(BufferRegionAccess view,
-                                         CallOpInterface call,
-                                         FunctionOpInterface caller,
-                                         FunctionOpInterface callee) const;
+  /// Describe an operation's allocated shared scratch, including cross-CTA
+  /// accesses.
+  const BufferRegionFootprint *getScratchFootprint(Operation *op);
+
+  /// Translate callee-local views into the caller's allocation frame, caching
+  /// the complete footprint and preserving views already in other frames.
+  const BufferRegionFootprint *
+  translateToCallsite(const BufferRegionFootprint *footprint,
+                      CallOpInterface call, FunctionOpInterface callee);
 
   uint32_t getOperationId(Operation *operation) const {
     return operationInterner.idFor(operation);
@@ -313,6 +331,8 @@ public:
   LogicalResult initialize(Operation *top) override;
 
 private:
+  const Mode mode;
+
   BufferRegionView getAllocView(Value allocation, uint32_t storageBase,
                                 llvm::ArrayRef<uint32_t> partitionBases = {});
   BufferRegionView getSubView(Type type, const BufferRegionView &view,
@@ -323,7 +343,15 @@ private:
   // Global registry of all regions
   std::set<BufferRegion> usedBufferRegions[NUM_REGION_TYPES];
   bool usedUnknownBufferRegions[NUM_REGION_TYPES] = {};
-  llvm::DenseMap<std::pair<Type, uint32_t>, AddressSet> footprintCache;
+  llvm::DenseMap<std::pair<Type, uint32_t>,
+                 llvm::SmallVector<BufferRegion::CTAAddresses, 2>>
+      footprintCache;
+  llvm::DenseMap<Value, std::unique_ptr<BufferRegionFootprint>> valueFootprints;
+  llvm::DenseMap<Operation *, std::unique_ptr<BufferRegionFootprint>>
+      scratchFootprints;
+  llvm::DenseMap<std::pair<const BufferRegionFootprint *, Operation *>,
+                 std::unique_ptr<BufferRegionFootprint>>
+      callsiteFootprints;
   llvm::UniqueVector<Operation *> operationInterner;
 };
 

--- a/include/triton/Analysis/Function.h
+++ b/include/triton/Analysis/Function.h
@@ -1,6 +1,8 @@
 #ifndef TRITON_ANALYSIS_FUNCTION_H
 #define TRITON_ANALYSIS_FUNCTION_H
 
+#include "triton/Analysis/CallGraph.h"
+
 #include "mlir/IR/Builders.h"
 #include "mlir/Interfaces/ControlFlowInterfaces.h"
 #include "mlir/Interfaces/FunctionInterfaces.h"
@@ -53,7 +55,33 @@ public:
     resolve(function, &funcMap, &builder);
   }
 
+  template <typename Factory>
+  static void runModule(ModuleOp module, Factory makeAnalysis) {
+    CallGraph<StateT> callGraph(module);
+    FuncMapT summaries;
+    callGraph.template walk<WalkOrder::PreOrder, WalkOrder::PostOrder>(
+        [](CallOpInterface, FunctionOpInterface) {},
+        [&](FunctionOpInterface function) {
+          if (summaries.try_emplace(function).second)
+            makeAnalysis(function).run(function, summaries);
+        });
+  }
+
 protected:
+  /// Copy the callee summary before mapping its accesses into the caller.
+  static std::optional<StateT> getCallSummary(
+      CallOpInterface call, const FuncMapT &summaries,
+      llvm::function_ref<void(StateT &, FunctionOpInterface)> translate = {}) {
+    auto callee = dyn_cast_or_null<FunctionOpInterface>(call.resolveCallable());
+    auto it = summaries.find(callee);
+    if (it == summaries.end())
+      return std::nullopt;
+    StateT summary = it->second;
+    if (translate)
+      translate(summary, callee);
+    return summary;
+  }
+
   virtual void update(Operation *operation, StateT *state, FuncMapT *funcMap,
                       OpBuilder *builder) = 0;
 

--- a/include/triton/Analysis/Function.h
+++ b/include/triton/Analysis/Function.h
@@ -2,6 +2,7 @@
 #define TRITON_ANALYSIS_FUNCTION_H
 
 #include "triton/Analysis/CallGraph.h"
+#include "triton/Dialect/TritonGPU/IR/Dialect.h"
 
 #include "mlir/IR/Builders.h"
 #include "mlir/Interfaces/ControlFlowInterfaces.h"
@@ -184,6 +185,14 @@ private:
 
   static void visitTerminator(Operation *operation,
                               SmallVector<VirtualBlock> &successors) {
+    // The parent continuation must retain worker memory effects even though
+    // the region value-flow interface has no successor for worker returns.
+    if (isa<gpu::WarpReturnOp>(operation)) {
+      auto ws = operation->getParentOfType<gpu::WarpSpecializeOp>();
+      successors.emplace_back(ws->getBlock(), ws->getIterator());
+      return;
+    }
+
     if (isa<BranchOpInterface>(operation)) {
       // Collect the block successors of the branch.
       for (Block *successor : operation->getSuccessors())

--- a/include/triton/Analysis/Membar.h
+++ b/include/triton/Analysis/Membar.h
@@ -9,6 +9,7 @@
 
 #include "llvm/Support/raw_ostream.h"
 #include <functional>
+#include <optional>
 #include <set>
 #include <tuple>
 #include <utility>
@@ -86,10 +87,14 @@ public:
   // BlockInfo::invalidateIterationInfo does.
   const BufferIndexExpr *bufferIndexExpr = nullptr;
 
+  // Parameters have no callee buffer ID. Bind this argument's effects to the
+  // caller's allocation when importing the function summary.
+  std::optional<unsigned> argumentIndex;
+
 private:
   std::tuple<Interval<size_t>, Allocation::BufferId, const void *,
              llvm::ArrayRef<int32_t>, const BufferIndexExpr *, const void *,
-             const void *>
+             const void *, std::optional<unsigned>>
   asTuple() const {
     return {allocationInterval,
             bufferId,
@@ -97,7 +102,8 @@ private:
             subsliceOffsets,
             bufferIndexExpr,
             subsliceSource.getAsOpaquePointer(),
-            physicalFootprint};
+            physicalFootprint,
+            argumentIndex};
   }
   // Offsets from subslice, borrowed from its immutable context-owned attribute.
   // Empty when offsets are unknown.
@@ -135,10 +141,11 @@ struct BlockInfo {
   template <typename Transform> void transformSlices(Transform transform) {
     for (auto *slices : {&syncReadSlices, &syncWriteSlices}) {
       SliceMapT transformed;
-      for (const auto &[slice, ops] : *slices) {
-        auto &dst = transformed[transform(slice)];
-        dst.insert(ops.begin(), ops.end());
-      }
+      for (const auto &[slice, ops] : *slices)
+        for (const AllocationSlice &mapped : transform(slice)) {
+          auto &dst = transformed[mapped];
+          dst.insert(ops.begin(), ops.end());
+        }
       *slices = std::move(transformed);
     }
   }
@@ -336,6 +343,8 @@ protected:
   triton::BufferRegionAnalysis &regions;
 
 private:
+  SmallVector<AllocationSlice> getAllocationSlices(Value value);
+
   MembarSliceFilterFn sliceFilter;
   AccessMode accessMode;
   BufferIndexAnalysis bufferIndexAnalysis;

--- a/include/triton/Analysis/Membar.h
+++ b/include/triton/Analysis/Membar.h
@@ -62,19 +62,10 @@ public:
 
   Allocation::BufferId getBufferId() const { return bufferId; }
 
-  AllocationSlice translated(size_t offset,
-                             bool invalidateBufferId = false) const {
-    AllocationSlice shifted = *this;
-    // TODO: Translate physical footprints into the caller's allocation frame.
-    shifted.physicalFootprint = nullptr;
-    shifted.allocationInterval = Interval<size_t>(
-        allocationInterval.start() + offset, allocationInterval.end() + offset);
-    if (invalidateBufferId) {
-      shifted.bufferId = Allocation::InvalidBufferId;
-      shifted.invalidateIterationInfo();
-    }
-    return shifted;
-  }
+  /// Translate shared-memory geometry and discard callee-local index facts.
+  AllocationSlice
+  translateToCallsite(CallOpInterface call, FunctionOpInterface callee,
+                      triton::BufferRegionAnalysis &regions) const;
 
   void print(raw_ostream &os) const;
 
@@ -139,6 +130,17 @@ struct BlockInfo {
       syncWriteSlices[slice.first].insert(slice.second.begin(),
                                           slice.second.end());
     return *this;
+  }
+
+  template <typename Transform> void transformSlices(Transform transform) {
+    for (auto *slices : {&syncReadSlices, &syncWriteSlices}) {
+      SliceMapT transformed;
+      for (const auto &[slice, ops] : *slices) {
+        auto &dst = transformed[transform(slice)];
+        dst.insert(ops.begin(), ops.end());
+      }
+      *slices = std::move(transformed);
+    }
   }
 
   /// Clears the buffer index and access origin of every slice, rebuilding both
@@ -262,31 +264,16 @@ struct MembarInfo {
     pending.join(callee.pending);
   }
 
+  template <typename Transform> void transformSlices(Transform transform) {
+    pending.transformSlices(transform);
+    entryBlockInfo.transformSlices(transform);
+  }
+
   bool operator==(const MembarInfo &other) const {
     return pending == other.pending && entryBlockInfo == other.entryBlockInfo &&
            allPathsFromEntrySynced == other.allPathsFromEntrySynced;
   }
 };
-
-inline BlockInfo translateBlockInfoToCallsite(const BlockInfo &calleeBlockInfo,
-                                              size_t callOffset) {
-  BlockInfo translatedBlockInfo;
-  auto translateSlices = [&](const BlockInfo::SliceMapT &srcSlices,
-                             BlockInfo::SliceMapT &dstSlices) {
-    for (const auto &[slice, ops] : srcSlices) {
-      auto translatedSlice =
-          slice.translated(callOffset, /*invalidateBufferId=*/true);
-      auto &dstOps = dstSlices[translatedSlice];
-      dstOps.insert(ops.begin(), ops.end());
-    }
-  };
-
-  translateSlices(calleeBlockInfo.syncReadSlices,
-                  translatedBlockInfo.syncReadSlices);
-  translateSlices(calleeBlockInfo.syncWriteSlices,
-                  translatedBlockInfo.syncWriteSlices);
-  return translatedBlockInfo;
-}
 
 /// Classify the barriers that synchronize local memory accesses in `op`
 /// relative to its memory effects.
@@ -299,6 +286,8 @@ triton::BarrierStages getLocalBarrierStages(Operation *op,
 
 class MembarAnalysis : public triton::PostOrderFunctionAnalysis<MembarInfo> {
 public:
+  enum class AccessMode { AllSharedAccesses, AllocatorAliasesOnly };
+
   /// Creates a new Membar analysis that generates the shared memory barrier
   /// in the following circumstances:
   /// - RAW: If a shared memory write is followed by a shared memory read, and
@@ -313,8 +302,11 @@ public:
   /// it is considered as the problem of the operation itself but not the membar
   /// analysis.
   MembarAnalysis(Allocation &allocation, MembarFilterFn filter,
-                 triton::BufferRegionAnalysis *regions = nullptr)
+                 triton::BufferRegionAnalysis &regions,
+                 MembarSliceFilterFn sliceFilter = nullptr,
+                 AccessMode accessMode = AccessMode::AllSharedAccesses)
       : allocation(allocation), filter(std::move(filter)), regions(regions),
+        sliceFilter(std::move(sliceFilter)), accessMode(accessMode),
         bufferIndexAnalysis(
             cast<FunctionOpInterface>(allocation.getOperation())) {}
 
@@ -329,13 +321,20 @@ private:
   void updateExitState(MembarInfo *membarInfo) override;
 
 protected:
-  void insertBarrier(Operation *operation, OpBuilder *builder);
+  void updateMemoryEffects(Operation *operation, MembarInfo *membarInfo,
+                           FuncMapT *funcMap, OpBuilder *builder);
+  void syncIfNeeded(Operation *operation, const BlockInfo &effects,
+                    MembarInfo *membarInfo, OpBuilder *builder);
+  virtual void insertBarrier(Operation *operation, OpBuilder *builder);
+  virtual triton::BarrierStages getBarrierStages(Operation *operation);
 
   Allocation &allocation;
   MembarFilterFn filter;
-  triton::BufferRegionAnalysis *regions;
+  triton::BufferRegionAnalysis &regions;
 
 private:
+  MembarSliceFilterFn sliceFilter;
+  AccessMode accessMode;
   BufferIndexAnalysis bufferIndexAnalysis;
 };
 
@@ -347,19 +346,23 @@ public:
                        MembarFilterFn filter = nullptr)
       : moduleAllocation(moduleAllocation), filter(std::move(filter)) {}
 
-  void run();
+  template <typename AnalysisT = MembarAnalysis> void run() {
+    // Geometry and interval slices use the same completed allocation, including
+    // backend scratch sizes and shared-memory partition offsets.
+    auto solver = createDataFlowSolver();
+    auto *regions = solver->load<triton::BufferRegionAnalysis>(
+        triton::BufferRegionAnalysis::Mode::AllMemory, &moduleAllocation);
+    if (failed(solver->initializeAndRun(moduleAllocation.getModuleOp())))
+      llvm::report_fatal_error("failed to analyze allocated buffer regions");
+    runAnalysis<AnalysisT>(*regions);
+  }
 
   template <typename AnalysisT>
-  void runAnalysis(triton::BufferRegionAnalysis *regions = nullptr) {
-    triton::CallGraph<MembarInfo> callGraph(moduleAllocation.getModuleOp());
-    triton::CallGraph<MembarInfo>::FuncDataMapT summaries;
-    callGraph.walk<WalkOrder::PreOrder, WalkOrder::PostOrder>(
-        [](CallOpInterface, FunctionOpInterface) {},
-        [&](FunctionOpInterface function) {
-          if (!summaries.try_emplace(function).second)
-            return;
+  void runAnalysis(triton::BufferRegionAnalysis &regions) {
+    AnalysisT::runModule(
+        moduleAllocation.getModuleOp(), [&](FunctionOpInterface function) {
           auto &allocation = *moduleAllocation.getFuncData(function);
-          AnalysisT(allocation, filter, regions).run(function, summaries);
+          return AnalysisT(allocation, filter, regions);
         });
   }
 

--- a/include/triton/Analysis/Membar.h
+++ b/include/triton/Analysis/Membar.h
@@ -18,9 +18,6 @@ namespace mlir {
 class OpBuilder;
 struct AllocationSlice;
 
-// Complete MAY-addresses in a known kernel allocation frame.
-using SharedMemoryFootprints = DenseMap<Value, triton::AddressSet>;
-
 /// Callback to allow backend to provide more information on whether a barrier
 /// is needed between two operations. Even though two operations access the same
 /// shared memory they may not require a barrier in between them.
@@ -86,10 +83,10 @@ public:
     subsliceSource = {};
   }
 
-  // Immutable geometry covering every dynamic instance of this access. It
-  // remains valid across backedges, unlike the epoch-relative facts above.
-  // The owning module analysis outlives every slice using this pointer.
-  const triton::AddressSet *physicalFootprint = nullptr;
+  // Immutable MAY-addresses covering every dynamic instance of this access.
+  // They remain valid across backedges, unlike the epoch-relative facts above.
+  // The owning BufferRegionAnalysis outlives every slice using this pointer.
+  const triton::BufferRegionFootprint *physicalFootprint = nullptr;
 
   // Buffer-index expression attached by BufferIndexAnalysis. It participates
   // in ordering/equality so accesses to different slots remain separate.
@@ -316,9 +313,8 @@ public:
   /// it is considered as the problem of the operation itself but not the membar
   /// analysis.
   MembarAnalysis(Allocation &allocation, MembarFilterFn filter,
-                 const SharedMemoryFootprints &physicalFootprints)
-      : allocation(allocation), filter(std::move(filter)),
-        physicalFootprints(physicalFootprints),
+                 triton::BufferRegionAnalysis *regions = nullptr)
+      : allocation(allocation), filter(std::move(filter)), regions(regions),
         bufferIndexAnalysis(
             cast<FunctionOpInterface>(allocation.getOperation())) {}
 
@@ -337,9 +333,9 @@ protected:
 
   Allocation &allocation;
   MembarFilterFn filter;
+  triton::BufferRegionAnalysis *regions;
 
 private:
-  const SharedMemoryFootprints &physicalFootprints;
   BufferIndexAnalysis bufferIndexAnalysis;
 };
 
@@ -354,8 +350,7 @@ public:
   void run();
 
   template <typename AnalysisT>
-  void runAnalysis(const SharedMemoryFootprints &physicalFootprints =
-                       SharedMemoryFootprints{}) {
+  void runAnalysis(triton::BufferRegionAnalysis *regions = nullptr) {
     triton::CallGraph<MembarInfo> callGraph(moduleAllocation.getModuleOp());
     triton::CallGraph<MembarInfo>::FuncDataMapT summaries;
     callGraph.walk<WalkOrder::PreOrder, WalkOrder::PostOrder>(
@@ -364,14 +359,11 @@ public:
           if (!summaries.try_emplace(function).second)
             return;
           auto &allocation = *moduleAllocation.getFuncData(function);
-          AnalysisT(allocation, filter, physicalFootprints)
-              .run(function, summaries);
+          AnalysisT(allocation, filter, regions).run(function, summaries);
         });
   }
 
 private:
-  SharedMemoryFootprints getSharedMemoryFootprints();
-
   ModuleAllocation &moduleAllocation;
   MembarFilterFn filter;
 };

--- a/include/triton/Analysis/Membar.h
+++ b/include/triton/Analysis/Membar.h
@@ -322,10 +322,13 @@ private:
 
 protected:
   void updateMemoryEffects(Operation *operation, MembarInfo *membarInfo,
-                           FuncMapT *funcMap, OpBuilder *builder);
+                           FuncMapT *funcMap, OpBuilder *builder,
+                           bool cluster = false);
   void syncIfNeeded(Operation *operation, const BlockInfo &effects,
-                    MembarInfo *membarInfo, OpBuilder *builder);
-  virtual void insertBarrier(Operation *operation, OpBuilder *builder);
+                    MembarInfo *membarInfo, OpBuilder *builder,
+                    bool cluster = false);
+  void insertBarrier(Operation *operation, OpBuilder *builder,
+                     bool cluster = false);
   virtual triton::BarrierStages getBarrierStages(Operation *operation);
 
   Allocation &allocation;

--- a/include/triton/Analysis/MemoryFrontier.h
+++ b/include/triton/Analysis/MemoryFrontier.h
@@ -9,18 +9,18 @@
 
 namespace mlir::triton {
 
-/// Read and write frontiers keyed by exact physical buffer regions. Each access
-/// is associated with the scopes in which it remains live.
+/// Read and write frontiers keyed by cached physical buffer footprints. Each
+/// access is associated with the scopes in which it remains live.
 template <typename ScopeMaskT> class ScopedMemoryFrontier {
 public:
-  using AccessT = BufferRegionAccess;
+  using AccessT = const BufferRegionFootprint *;
   using AccessMap = std::map<AccessT, ScopeMaskT>;
 
   void addRead(AccessT access, ScopeMaskT scopes) {
-    add(/*isWrite=*/false, std::move(access), scopes);
+    add(/*isWrite=*/false, access, scopes);
   }
   void addWrite(AccessT access, ScopeMaskT scopes) {
-    add(/*isWrite=*/true, std::move(access), scopes);
+    add(/*isWrite=*/true, access, scopes);
   }
 
   ScopedMemoryFrontier &join(const ScopedMemoryFrontier &other) {
@@ -67,7 +67,7 @@ public:
 
 private:
   void add(bool isWrite, AccessT access, ScopeMaskT scopes) {
-    accesses[isWrite][std::move(access)] |= scopes;
+    accesses[isWrite][access] |= scopes;
   }
 
   bool intersects(const ScopedMemoryFrontier &other, bool lhsWrite,
@@ -76,8 +76,7 @@ private:
       if (!(leftScopes & scope))
         continue;
       for (const auto &[right, rightScopes] : other.accesses[rhsWrite])
-        if ((rightScopes & scope) &&
-            (!left || !right || left->intersects(*right)))
+        if ((rightScopes & scope) && mayOverlap(left, right))
           return true;
     }
     return false;

--- a/lib/Analysis/Allocation.cpp
+++ b/lib/Analysis/Allocation.cpp
@@ -147,8 +147,7 @@ unsigned defaultAllocationAnalysisScratchSizeFn(Operation *op) {
 }
 
 std::optional<uint16_t> getAtomicScratchBroadcastMask(Operation *op) {
-  if (!op->hasAttr("allocation.size") ||
-      !isa<AtomicOpInterface, AtomicPollOp, gpu::LocalAtomicScatterRMWOp>(op))
+  if (!isa<AtomicOpInterface, AtomicPollOp, gpu::LocalAtomicScatterRMWOp>(op))
     return std::nullopt;
 
   Type resultTy = op->getResult(0).getType();

--- a/lib/Analysis/Allocation.cpp
+++ b/lib/Analysis/Allocation.cpp
@@ -319,7 +319,8 @@ private:
       AliasInfo &info = latticeElement->getValue();
       if (!info.getAllocs().empty()) {
         for (auto alloc : info.getAllocs()) {
-          allocation->addAlias(value, alloc);
+          if (allocation->valueBuffer.count(alloc))
+            allocation->addAlias(value, alloc);
         }
       }
     }
@@ -336,7 +337,11 @@ private:
     std::unique_ptr<DataFlowSolver> solver = createDataFlowSolver();
     SharedMemoryAliasAnalysis *aliasAnalysis =
         solver->load<SharedMemoryAliasAnalysis>();
-    if (failed(solver->initializeAndRun(operation))) {
+    // Returned descriptors must keep their caller-owned allocations live.
+    Operation *analysisRoot = operation;
+    if (auto module = operation->getParentOfType<ModuleOp>())
+      analysisRoot = module;
+    if (failed(solver->initializeAndRun(analysisRoot))) {
       llvm_unreachable("failed to run SharedMemoryAliasAnalysis");
     }
     operation->walk<WalkOrder::PreOrder>([&](Operation *op) {

--- a/lib/Analysis/Allocation.cpp
+++ b/lib/Analysis/Allocation.cpp
@@ -146,6 +146,19 @@ unsigned defaultAllocationAnalysisScratchSizeFn(Operation *op) {
   return 0;
 }
 
+std::optional<uint16_t> getAtomicScratchBroadcastMask(Operation *op) {
+  if (!op->hasAttr("allocation.size") ||
+      !isa<AtomicOpInterface, AtomicPollOp, gpu::LocalAtomicScatterRMWOp>(op))
+    return std::nullopt;
+
+  Type resultTy = op->getResult(0).getType();
+  if (auto tensorTy = dyn_cast<RankedTensorType>(resultTy)) {
+    auto block = StringAttr::get(op->getContext(), "block");
+    return gpu::toLinearLayout(tensorTy).getFreeVariableMasks().lookup(block);
+  }
+  return static_cast<uint16_t>(gpu::lookupNumCTAs(op) - 1);
+}
+
 bool hasCrossCTAScratch(Operation *op) {
   if (gpu::lookupNumCTAs(op) == 1)
     return false;

--- a/lib/Analysis/BufferRegion.cpp
+++ b/lib/Analysis/BufferRegion.cpp
@@ -6,6 +6,7 @@
 #include "mlir/Interfaces/CallInterfaces.h"
 #include "mlir/Interfaces/FunctionInterfaces.h"
 #include "mlir/Interfaces/SideEffectInterfaces.h"
+#include "triton/Analysis/Allocation.h"
 #include "triton/Dialect/Triton/IR/Utility.h"
 #include "triton/Dialect/TritonGPU/IR/Dialect.h"
 #include "triton/Dialect/TritonGPU/IR/LinearLayoutConversions.h"
@@ -92,7 +93,7 @@ triton::AddressSet &getAddressesForCTA(MemDescFootprint &footprint,
 
 MemDescFootprint getMemDescAddresses(
     uint32_t storageBase, uint32_t affineOffset, ttg::MemDescType ty,
-    llvm::DenseMap<std::pair<Type, uint32_t>, triton::AddressSet> *cache =
+    llvm::DenseMap<std::pair<Type, uint32_t>, MemDescFootprint> *cache =
         nullptr,
     ArrayRef<uint32_t> partitionBases = {}, uint32_t affinePartitionOffset = 0,
     uint32_t affineCTAOffset = 0) {
@@ -111,6 +112,17 @@ MemDescFootprint getMemDescAddresses(
                affinePartitionOffset, affineCTAOffset))
         getAddressesForCTA(footprint, cta).insert(addresses);
     }
+    return footprint;
+  }
+  if (cache && partitionBases.empty()) {
+    auto [found, inserted] =
+        cache->try_emplace(std::make_pair(Type(ty), affineOffset));
+    if (inserted)
+      found->second = getMemDescAddresses(0, affineOffset, ty);
+    MemDescFootprint footprint;
+    for (const auto &[cta, addresses] : found->second)
+      getAddressesForCTA(footprint, cta ^ affineCTAOffset) =
+          addresses.translated(storageBase);
     return footprint;
   }
   triton::LinearLayout layout = ttg::toLinearLayoutIgnoringPadding(ty);
@@ -160,7 +172,6 @@ MemDescFootprint getMemDescAddresses(
     uint32_t block = 0;
   };
   SmallVector<PhysicalBasis> bases;
-  bool hasCTAAddressVariation = false;
   for (auto [dim, dimSize] : llvm::zip_equal(dims, shape)) {
     unsigned numBits = llvm::Log2_64(dimSize);
     for (unsigned bit = 0; bit < numBits; ++bit) {
@@ -170,21 +181,35 @@ MemDescFootprint getMemDescAddresses(
                    : 0;
       };
       uint32_t block = basis(blockName);
-      hasCTAAddressVariation |= block != 0;
       bases.push_back({basis(offsetName), basis(rowName), basis(colName),
                        basis(partitionName), block});
     }
   }
-
-  if (cache && partitionBases.empty() && !hasCTAAddressVariation) {
-    auto [found, inserted] =
-        cache->try_emplace(std::make_pair(Type(ty), affineOffset));
-    if (inserted)
-      found->second =
-          std::move(getMemDescAddresses(0, affineOffset, ty).front().second);
-    footprint.emplace_back(affineCTAOffset,
-                           found->second.translated(storageBase));
-    return footprint;
+  // The pseudoinverse selects one representative of replicated storage. Zero
+  // block bases in the allocation layout denote a local copy in every replica
+  // CTA. A nonzero block basis excluded by a subview is not a replica.
+  uint32_t broadcastBits = layout.getFreeVariableMasks().lookup(blockName);
+  for (unsigned bit = 0; bit < layout.getInDimSizeLog2(blockName); ++bit) {
+    if (!(broadcastBits & (uint32_t{1} << bit)))
+      continue;
+    PhysicalBasis replica;
+    replica.block = uint32_t{1} << bit;
+    bases.push_back(replica);
+    numPoints *= 2;
+  }
+  if (isTmem) {
+    // Zero row bases at 32 and 64 broadcast across warp-addressable storage;
+    // loads/stores still access every replica. The pseudoinverse chooses only
+    // one. Other zero row/column bases denote undefined storage, not replicas.
+    uint64_t rowBasisMask = triton::getInputBasisMask(layout, rowName, dims);
+    for (unsigned bit : {5, 6}) {
+      if (!(rowBasisMask & (uint64_t{1} << bit))) {
+        PhysicalBasis replica;
+        replica.row = uint32_t{1} << bit;
+        bases.push_back(replica);
+        numPoints *= 2;
+      }
+    }
   }
 
   PhysicalBasis physical;
@@ -447,8 +472,14 @@ BufferRegionAnalysis::getAllocView(Value allocation, uint32_t storageBase,
   BufferRegionView view;
   view.storageBase = storageBase;
   view.partitionBases = llvm::to_vector<2>(partitionBases);
-  view.allocationFrame = getOperationId(
-      allocation.getDefiningOp()->getParentOfType<FunctionOpInterface>());
+  Operation *op = allocation.getDefiningOp();
+  // TMEM allocation assigns module-wide addresses; only shared allocations
+  // need a per-function frame and translation by a call's shared-memory offset.
+  auto memory = cast<ttg::MemDescType>(allocation.getType());
+  view.allocationFrame =
+      isa<ttng::TensorMemorySpaceAttr>(memory.getMemorySpace())
+          ? getOperationId(op->getParentOfType<ModuleOp>())
+          : getOperationId(op->getParentOfType<FunctionOpInterface>());
   return getSubView(allocation.getType(), view);
 }
 
@@ -487,7 +518,7 @@ BufferRegionAnalysis::getSubView(Type type, const BufferRegionView &view,
 
 LogicalResult BufferRegionAnalysis::initialize(Operation *top) {
   top->walk([&](Operation *operation) {
-    if (isa<FunctionOpInterface, CallOpInterface>(operation))
+    if (isa<ModuleOp, FunctionOpInterface, CallOpInterface>(operation))
       operationInterner.insert(operation);
   });
 
@@ -508,26 +539,102 @@ LogicalResult BufferRegionAnalysis::initialize(Operation *top) {
   return success();
 }
 
-SmallVector<BufferRegionAccess>
-BufferRegionAnalysis::getAccessRegions(Value value) {
-  const RegionInfo &info = getRegionInfo(value);
-  if (info.kind != RegionInfo::Kind::Exact || info.views.empty())
-    return {std::nullopt};
-  SmallVector<BufferRegionAccess> accesses;
-  for (const BufferRegionView &view : info.views)
-    accesses.push_back(view);
-  return accesses;
+bool mayOverlap(const BufferRegionFootprint *lhs,
+                const BufferRegionFootprint *rhs) {
+  if (!lhs || !rhs || !lhs->memorySpace || !rhs->memorySpace)
+    return true;
+  if (lhs->memorySpace != rhs->memorySpace)
+    return false;
+  const RegionInfo &left = lhs->regionInfo;
+  const RegionInfo &right = rhs->regionInfo;
+  if (left.kind != RegionInfo::Kind::Exact || left.views.empty() ||
+      right.kind != RegionInfo::Kind::Exact || right.views.empty())
+    return true;
+  return llvm::any_of(left.views, [&](const BufferRegionView &a) {
+    return llvm::any_of(right.views, [&](const BufferRegionView &b) {
+      bool sameFrame =
+          a.allocationFrame && a.allocationFrame == b.allocationFrame;
+      return !sameFrame || a.region.intersects(b.region);
+    });
+  });
 }
 
-BufferRegionAccess BufferRegionAnalysis::translateToCallsite(
-    BufferRegionAccess view, CallOpInterface call, FunctionOpInterface caller,
-    FunctionOpInterface callee) const {
-  uint32_t calleeFrame = getOperationId(callee.getOperation());
-  if (!view || view->allocationFrame != calleeFrame)
-    return view;
-  auto offset = call->getAttrOfType<IntegerAttr>("allocation.offset");
-  return view->translated(offset ? offset.getInt() : 0,
-                          getOperationId(caller.getOperation()));
+const BufferRegionFootprint *
+BufferRegionAnalysis::getFootprint(Value value,
+                                   FunctionOpInterface allocationFrame) {
+  auto memory = dyn_cast<ttg::MemDescType>(value.getType());
+  if (!memory)
+    return nullptr;
+  auto [it, inserted] = valueFootprints.try_emplace(value);
+  if (inserted) {
+    const RegionInfo &info = getRegionInfo(value);
+    if (info.kind == RegionInfo::Kind::Exact && !info.views.empty())
+      it->second = std::make_unique<BufferRegionFootprint>(
+          BufferRegionFootprint{memory.getMemorySpace(), info});
+  }
+  const auto *footprint = it->second.get();
+  if (footprint && allocationFrame &&
+      llvm::any_of(footprint->regionInfo.views, [&](const auto &view) {
+        return view.allocationFrame != getOperationId(allocationFrame);
+      }))
+    return nullptr;
+  return footprint;
+}
+
+const BufferRegionFootprint *
+BufferRegionAnalysis::getScratchFootprint(Operation *op) {
+  auto [it, inserted] = scratchFootprints.try_emplace(op);
+  if (!inserted)
+    return it->second.get();
+
+  auto offset = op->getAttrOfType<IntegerAttr>("allocation.offset");
+  auto size = op->getAttrOfType<IntegerAttr>("allocation.size");
+  if (!offset || !size)
+    return nullptr;
+
+  uint32_t base = offset.getInt();
+  uint32_t length = size.getInt();
+  BufferRegionView view{{base, length}, /*storageBase=*/base};
+  view.allocationFrame =
+      getOperationId(op->getParentOfType<FunctionOpInterface>());
+  AddressSet addresses = AddressSet::fromRange(base, length);
+  unsigned numCTAs = ttg::lookupNumCTAs(op);
+  uint32_t broadcastMask = getAtomicScratchBroadcastMask(op).value_or(0);
+  for (unsigned cta = 0; cta < numCTAs; ++cta)
+    if (!(cta & broadcastMask))
+      view.region.ctaAddresses.emplace_back(cta, addresses);
+  it->second = std::make_unique<BufferRegionFootprint>(
+      BufferRegionFootprint{ttg::SharedMemorySpaceAttr::get(op->getContext()),
+                            RegionInfo({std::move(view)})});
+  return it->second.get();
+}
+
+const BufferRegionFootprint *BufferRegionAnalysis::translateToCallsite(
+    const BufferRegionFootprint *footprint, CallOpInterface call,
+    FunctionOpInterface callee) {
+  if (!footprint)
+    return nullptr;
+  uint32_t calleeFrame = getOperationId(callee);
+  if (llvm::none_of(footprint->regionInfo.views, [&](const auto &view) {
+        return view.allocationFrame == calleeFrame;
+      }))
+    return footprint;
+  auto [it, inserted] =
+      callsiteFootprints.try_emplace({footprint, call.getOperation()});
+  if (inserted) {
+    uint32_t callerFrame =
+        getOperationId(call->getParentOfType<FunctionOpInterface>());
+    auto offset = call->getAttrOfType<IntegerAttr>("allocation.offset");
+    RegionInfo info(RegionInfo::ViewList{});
+    for (const BufferRegionView &view : footprint->regionInfo.views)
+      info.views.insert(
+          view.allocationFrame == calleeFrame
+              ? view.translated(offset ? offset.getInt() : 0, callerFrame)
+              : view);
+    it->second = std::make_unique<BufferRegionFootprint>(
+        BufferRegionFootprint{footprint->memorySpace, std::move(info)});
+  }
+  return it->second.get();
 }
 
 LogicalResult BufferRegionAnalysis::visitOperation(
@@ -553,6 +660,10 @@ LogicalResult BufferRegionAnalysis::visitOperation(
     return success();
   }
   if (auto localAllocOp = dyn_cast<ttg::LocalAllocOp>(op)) {
+    // Descriptor views preserve memory space, so shared origins cannot
+    // contribute to a tensor-memory footprint.
+    if (mode == Mode::TensorMemoryOnly)
+      return propagateRegions(RegionInfo::getPessimisticValueState());
     FailureOr<SmallVector<uint32_t, 2>> offsets =
         getAllocationOffsets(localAllocOp);
     if (failed(offsets))

--- a/lib/Analysis/BufferRegion.cpp
+++ b/lib/Analysis/BufferRegion.cpp
@@ -21,7 +21,15 @@ using namespace mlir;
 
 namespace {
 // TODO: move to Utility.cpp/unify with TritonInstrument/Utility.cpp
-FailureOr<SmallVector<uint32_t, 2>> getAllocationOffsets(ttg::LocalAllocOp op) {
+FailureOr<SmallVector<uint32_t, 2>>
+getAllocationOffsets(ttg::LocalAllocOp op, Allocation *allocation) {
+  if (allocation) {
+    SmallVector<uint32_t, 2> offsets;
+    for (auto id : allocation->getBufferIds(op.getResult()))
+      offsets.push_back(allocation->getOffset(id));
+    assert(!offsets.empty() && "shared allocation must have allocated buffers");
+    return offsets;
+  }
   auto offsetAttr = op->getAttr("allocation.offset");
   if (!offsetAttr) {
     op.emitError("ConcurrencySanitizer should run after "
@@ -473,6 +481,7 @@ BufferRegionAnalysis::getAllocView(Value allocation, uint32_t storageBase,
   view.storageBase = storageBase;
   view.partitionBases = llvm::to_vector<2>(partitionBases);
   Operation *op = allocation.getDefiningOp();
+  view.allocation = op;
   // TMEM allocation assigns module-wide addresses; only shared allocations
   // need a per-function frame and translation by a call's shared-memory offset.
   auto memory = cast<ttg::MemDescType>(allocation.getType());
@@ -587,13 +596,21 @@ BufferRegionAnalysis::getScratchFootprint(Operation *op) {
   if (!inserted)
     return it->second.get();
 
-  auto offset = op->getAttrOfType<IntegerAttr>("allocation.offset");
-  auto size = op->getAttrOfType<IntegerAttr>("allocation.size");
-  if (!offset || !size)
-    return nullptr;
-
-  uint32_t base = offset.getInt();
-  uint32_t length = size.getInt();
+  uint32_t base, length;
+  if (auto *allocation = getAllocation(op)) {
+    auto id = allocation->getBufferId(op);
+    if (id == Allocation::InvalidBufferId)
+      return nullptr;
+    base = allocation->getOffset(id);
+    length = allocation->getAllocatedSize(id);
+  } else {
+    auto offset = op->getAttrOfType<IntegerAttr>("allocation.offset");
+    auto size = op->getAttrOfType<IntegerAttr>("allocation.size");
+    if (!offset || !size)
+      return nullptr;
+    base = offset.getInt();
+    length = size.getInt();
+  }
   BufferRegionView view{{base, length}, /*storageBase=*/base};
   view.allocationFrame =
       getOperationId(op->getParentOfType<FunctionOpInterface>());
@@ -624,17 +641,34 @@ const BufferRegionFootprint *BufferRegionAnalysis::translateToCallsite(
   if (inserted) {
     uint32_t callerFrame =
         getOperationId(call->getParentOfType<FunctionOpInterface>());
-    auto offset = call->getAttrOfType<IntegerAttr>("allocation.offset");
+    uint32_t offset = getCallOffset(call);
     RegionInfo info(RegionInfo::ViewList{});
     for (const BufferRegionView &view : footprint->regionInfo.views)
-      info.views.insert(
-          view.allocationFrame == calleeFrame
-              ? view.translated(offset ? offset.getInt() : 0, callerFrame)
-              : view);
+      info.views.insert(view.allocationFrame == calleeFrame
+                            ? view.translated(offset, callerFrame)
+                            : view);
     it->second = std::make_unique<BufferRegionFootprint>(
         BufferRegionFootprint{footprint->memorySpace, std::move(info)});
   }
   return it->second.get();
+}
+
+Allocation *BufferRegionAnalysis::getAllocation(Operation *op) const {
+  if (!moduleAllocation)
+    return nullptr;
+  auto *allocation =
+      moduleAllocation->getFuncData(op->getParentOfType<FunctionOpInterface>());
+  assert(allocation && "function allocation must be available");
+  return allocation;
+}
+
+uint32_t BufferRegionAnalysis::getCallOffset(CallOpInterface call) const {
+  if (auto *allocation = getAllocation(call)) {
+    auto id = allocation->getBufferId(call);
+    return id == Allocation::InvalidBufferId ? 0 : allocation->getOffset(id);
+  }
+  auto offset = call->getAttrOfType<IntegerAttr>("allocation.offset");
+  return offset ? offset.getInt() : 0;
 }
 
 LogicalResult BufferRegionAnalysis::visitOperation(
@@ -665,7 +699,7 @@ LogicalResult BufferRegionAnalysis::visitOperation(
     if (mode == Mode::TensorMemoryOnly)
       return propagateRegions(RegionInfo::getPessimisticValueState());
     FailureOr<SmallVector<uint32_t, 2>> offsets =
-        getAllocationOffsets(localAllocOp);
+        getAllocationOffsets(localAllocOp, getAllocation(op));
     if (failed(offsets))
       return failure();
     ArrayRef<uint32_t> partitionBases = offsets->size() > 1

--- a/lib/Analysis/Membar.cpp
+++ b/lib/Analysis/Membar.cpp
@@ -93,17 +93,39 @@ void AllocationSlice::print(raw_ostream &os) const {
 }
 
 void BlockInfo::invalidateIterationInfo() {
-  auto rebuild = [](SliceMapT &slices) {
-    SliceMapT rebuilt;
-    for (const auto &[slice, ops] : slices) {
-      AllocationSlice key = slice;
-      key.invalidateIterationInfo();
-      rebuilt[key].insert(ops.begin(), ops.end());
-    }
-    slices = std::move(rebuilt);
-  };
-  rebuild(syncReadSlices);
-  rebuild(syncWriteSlices);
+  transformSlices([](AllocationSlice slice) {
+    slice.invalidateIterationInfo();
+    return slice;
+  });
+}
+
+AllocationSlice AllocationSlice::translateToCallsite(
+    CallOpInterface call, FunctionOpInterface callee,
+    triton::BufferRegionAnalysis &regions) const {
+  AllocationSlice shifted = *this;
+  // Unknown accesses span the whole frame; shifting their endpoint overflows.
+  if (allocationInterval != Interval<size_t>{}) {
+    size_t offset = regions.getCallOffset(call);
+    shifted.allocationInterval = Interval<size_t>(
+        allocationInterval.start() + offset, allocationInterval.end() + offset);
+  }
+  shifted.physicalFootprint =
+      regions.translateToCallsite(physicalFootprint, call, callee);
+  shifted.bufferId = Allocation::InvalidBufferId;
+  shifted.invalidateIterationInfo();
+  return shifted;
+}
+
+void MembarAnalysis::syncIfNeeded(Operation *op, const BlockInfo &effects,
+                                  MembarInfo *membarInfo, OpBuilder *builder) {
+  if (!membarInfo->pending.isIntersected(effects, filter, &allocation,
+                                         sliceFilter))
+    return;
+  // The barrier clears incoming state. The operation's own effects still
+  // follow it, including a scratch write that conflicts with a pending read.
+  builder->setInsertionPoint(op);
+  insertBarrier(op, builder);
+  membarInfo->sync();
 }
 
 void MembarAnalysis::insertBarrier(Operation *op, OpBuilder *builder) {
@@ -230,6 +252,10 @@ void MembarAnalysis::updateExitState(MembarInfo *membarInfo) {
   membarInfo->entryBlockInfo.invalidateIterationInfo();
 }
 
+triton::BarrierStages MembarAnalysis::getBarrierStages(Operation *op) {
+  return getLocalBarrierStages(op, &allocation);
+}
+
 void MembarAnalysis::update(Operation *op, MembarInfo *membarInfo,
                             FuncMapT *funcMap, OpBuilder *builder) {
   // A later CTA-wide synchronization can also synchronize this wait, provided
@@ -242,12 +268,6 @@ void MembarAnalysis::update(Operation *op, MembarInfo *membarInfo,
     }
   }
 
-  auto barrierStages = getLocalBarrierStages(op, &allocation);
-  if (barrierStages.beforeMemoryEffects) {
-    // Model a leading local barrier before handling the operation's effects.
-    membarInfo->sync();
-  }
-
   // If the current op is an (async) memory wait and there is no later sync
   // point before memory is accessed, insert a barrier op and sync. This avoids
   // redundant barriers by deferring the barrier to the later sync point.
@@ -258,56 +278,81 @@ void MembarAnalysis::update(Operation *op, MembarInfo *membarInfo,
     membarInfo->sync();
     return;
   }
+  updateMemoryEffects(op, membarInfo, funcMap, builder);
+}
 
-  BlockInfo curBlockInfo;
-  auto scratchBufferId = getScratchBufferId(op, &allocation);
-  if (isa<triton::CallOp>(op)) {
-    auto call = cast<CallOpInterface>(op);
-    if (auto callee = dyn_cast<FunctionOpInterface>(call.resolveCallable())) {
-      MembarInfo calleeMembarInfo = funcMap->lookup(callee);
-      auto callBufferId = allocation.getBufferId(op);
-      size_t callOffset = 0;
-      if (callBufferId != Allocation::InvalidBufferId)
-        callOffset = allocation.getAllocatedInterval(callBufferId).start();
-      calleeMembarInfo.pending =
-          translateBlockInfoToCallsite(calleeMembarInfo.pending, callOffset);
-      calleeMembarInfo.entryBlockInfo = translateBlockInfoToCallsite(
-          calleeMembarInfo.entryBlockInfo, callOffset);
-      if (membarInfo->pending.isIntersected(calleeMembarInfo.entryBlockInfo,
-                                            filter, &allocation)) {
-        builder->setInsertionPoint(op);
-        insertBarrier(op, builder);
-        membarInfo->sync();
-      }
-      membarInfo->applyCallSummary(calleeMembarInfo);
+void MembarAnalysis::updateMemoryEffects(Operation *op, MembarInfo *membarInfo,
+                                         FuncMapT *funcMap,
+                                         OpBuilder *builder) {
+  auto barrierStages = getBarrierStages(op);
+  if (barrierStages.beforeMemoryEffects) {
+    // Model a leading barrier before handling the operation's effects.
+    membarInfo->sync();
+  }
+
+  if (auto call = dyn_cast<CallOpInterface>(op)) {
+    auto summary = getCallSummary(
+        call, *funcMap, [&](MembarInfo &summary, FunctionOpInterface callee) {
+          summary.transformSlices([&](const AllocationSlice &slice) {
+            return slice.translateToCallsite(call, callee, regions);
+          });
+        });
+    if (summary) {
+      syncIfNeeded(op, summary->entryBlockInfo, membarInfo, builder);
+      membarInfo->applyCallSummary(*summary);
     }
     return;
   }
 
   // Intra-function dependencies
   // Explicit buffer
+  BlockInfo curBlockInfo;
   auto function = cast<FunctionOpInterface>(allocation.getOperation());
   for (const auto &access : triton::getMemoryAccesses(op)) {
     Value value = access.value;
-    const triton::BufferRegionFootprint *footprint = nullptr;
     auto memory = cast<triton::gpu::MemDescType>(value.getType());
-    // Physical offsets must use the current kernel's allocation frame.
-    // Device-function allocations need their callsite offsets before
-    // comparison. Returned descriptors may include views from another caller's
-    // frame.
-    if (regions && triton::isKernel(function) &&
-        isa<triton::gpu::SharedMemorySpaceAttr>(memory.getMemorySpace()))
-      footprint = regions->getFootprint(value, function);
-    for (auto bufferId : allocation.getAllBufferIdsWithAliases(value)) {
-      if (bufferId == Allocation::InvalidBufferId)
-        continue;
-      auto interval = allocation.getAllocatedInterval(bufferId);
-      auto slice = bufferIndexAnalysis.makeSlice(value, interval, bufferId);
+    if (!isa<triton::gpu::SharedMemorySpaceAttr>(memory.getMemorySpace()))
+      continue;
+    // Shared effects cover only descriptor elements, including gather/scatter
+    // and async copies. Footprints retain padding, partitions and CTA identity.
+    // Device-function views use their own frame until imported at a call;
+    // foreign or mixed frames, including returned descriptors, stay unknown.
+    auto *footprint = regions.getFootprint(value, function);
+    auto addSlice = [&](AllocationSlice slice) {
       slice.physicalFootprint = footprint;
       if (access.isWrite)
         curBlockInfo.syncWriteSlices[slice].insert(op);
       if (access.isRead)
         curBlockInfo.syncReadSlices[slice].insert(op);
+    };
+    Allocation::BufferIdSetT bufferIds;
+    if (accessMode == AccessMode::AllocatorAliasesOnly) {
+      // Allocation identity survives unknown geometry. Argument-only effects
+      // have no local IDs and cannot introduce aliases in this allocation.
+      bufferIds = allocation.getAllBufferIdsWithAliases(value);
+    } else if (footprint) {
+      // Use every lattice origin: function-local alias analysis can miss roots
+      // returned through calls or joined with descriptor arguments.
+      for (const auto &view : footprint->regionInfo.views) {
+        auto ids = view.allocation
+                       ? allocation.getBufferIds(view.allocation->getResult(0))
+                       : SmallVector<Allocation::BufferId>{};
+        if (ids.empty()) {
+          bufferIds.clear();
+          break;
+        }
+        bufferIds.insert(ids.begin(), ids.end());
+      }
+    }
+    if (bufferIds.empty()) {
+      if (accessMode == AccessMode::AllSharedAccesses)
+        addSlice(bufferIndexAnalysis.makeSlice(value, Interval<size_t>{},
+                                               Allocation::InvalidBufferId));
+      continue;
+    }
+    for (auto bufferId : bufferIds) {
+      auto interval = allocation.getAllocatedInterval(bufferId);
+      addSlice(bufferIndexAnalysis.makeSlice(value, interval, bufferId));
     }
   }
 
@@ -315,6 +360,8 @@ void MembarAnalysis::update(Operation *op, MembarInfo *membarInfo,
   // starting from a shared memory write, followed by a series of shared memory
   // read/write operations, and ending with a shared memory read, i.e., shared
   // memory write -> ... -> shared memory read.
+  auto scratchBufferId = getScratchBufferId(op, &allocation);
+  std::optional<AllocationSlice> scratchSlice;
   if (scratchBufferId != Allocation::InvalidBufferId) {
     bool hasExplicitSharedDeps = !curBlockInfo.syncReadSlices.empty() ||
                                  !curBlockInfo.syncWriteSlices.empty();
@@ -325,19 +372,14 @@ void MembarAnalysis::update(Operation *op, MembarInfo *membarInfo,
           "dependencies");
     }
     auto interval = allocation.getAllocatedInterval(scratchBufferId);
-    auto scratchSlice = AllocationSlice(interval);
-    scratchSlice.physicalFootprint =
-        regions ? regions->getScratchFootprint(op) : nullptr;
-    curBlockInfo.syncWriteSlices[scratchSlice].insert(op);
-    auto insertCTABarrier =
-        membarInfo->pending.isIntersected(curBlockInfo, filter, &allocation);
-    if (insertCTABarrier) {
-      builder->setInsertionPoint(op);
-      insertBarrier(op, builder);
-    }
-    if (insertCTABarrier)
-      membarInfo->sync();
+    scratchSlice.emplace(interval);
+    scratchSlice->physicalFootprint = regions.getScratchFootprint(op);
+    curBlockInfo.syncWriteSlices[*scratchSlice].insert(op);
+  }
 
+  syncIfNeeded(op, curBlockInfo, membarInfo, builder);
+
+  if (scratchSlice) {
     if (barrierStages.betweenMemoryEffects) {
       // The internal barrier synchronizes all incoming effects. Do not carry
       // them past the operation; only effects after the barrier are outgoing.
@@ -345,32 +387,16 @@ void MembarAnalysis::update(Operation *op, MembarInfo *membarInfo,
       membarInfo->sync();
       curBlockInfo.sync();
     }
-    curBlockInfo.syncReadSlices[scratchSlice].insert(op);
-  } else if (membarInfo->pending.isIntersected(curBlockInfo, filter,
-                                               &allocation)) {
-    builder->setInsertionPoint(op);
-    insertBarrier(op, builder);
-    membarInfo->sync();
+    curBlockInfo.syncReadSlices[*scratchSlice].insert(op);
   }
   // Update the region info, even if barrier is inserted, we have to maintain
   // the current op's read/write buffers.
   membarInfo->addBlockInfo(curBlockInfo);
 
   if (barrierStages.afterMemoryEffects) {
-    // Model a trailing local barrier after handling the operation's effects.
+    // Model a trailing barrier after handling the operation's effects.
     membarInfo->sync();
   }
 }
 
-void ModuleMembarAnalysis::run() {
-  ModuleOp module = moduleAllocation.getModuleOp();
-  // Footprints use allocated addresses and retain CTA identity. MembarAnalysis
-  // checks allocation frames and conservatively translates call summaries.
-  // Shared effects cover only descriptor elements, including gather/scatter
-  // and async copies; BufferRegion maps them through padding and partitions.
-  auto solver = createDataFlowSolver();
-  auto *regions = solver->load<triton::BufferRegionAnalysis>();
-  runAnalysis<MembarAnalysis>(
-      succeeded(solver->initializeAndRun(module)) ? regions : nullptr);
-}
 } // namespace mlir

--- a/lib/Analysis/Membar.cpp
+++ b/lib/Analysis/Membar.cpp
@@ -74,6 +74,8 @@ void AllocationSlice::print(raw_ostream &os) const {
 
   if (bufferId != Allocation::InvalidBufferId)
     os << " buffer=" << bufferId;
+  if (argumentIndex)
+    os << " argument=" << *argumentIndex;
 
   os << " offsets=[";
   if (!subsliceOffsets.empty()) {
@@ -95,13 +97,14 @@ void AllocationSlice::print(raw_ostream &os) const {
 void BlockInfo::invalidateIterationInfo() {
   transformSlices([](AllocationSlice slice) {
     slice.invalidateIterationInfo();
-    return slice;
+    return SmallVector<AllocationSlice>{std::move(slice)};
   });
 }
 
 AllocationSlice AllocationSlice::translateToCallsite(
     CallOpInterface call, FunctionOpInterface callee,
     triton::BufferRegionAnalysis &regions) const {
+  assert(!argumentIndex && "argument effects must be bound to call operands");
   AllocationSlice shifted = *this;
   // Unknown accesses span the whole frame; shifting their endpoint overflows.
   if (allocationInterval != Interval<size_t>{}) {
@@ -286,6 +289,52 @@ void MembarAnalysis::update(Operation *op, MembarInfo *membarInfo,
   updateMemoryEffects(op, membarInfo, funcMap, builder);
 }
 
+SmallVector<AllocationSlice> MembarAnalysis::getAllocationSlices(Value value) {
+  auto function = cast<FunctionOpInterface>(allocation.getOperation());
+  // Device-function views use their own frame until imported at a call;
+  // foreign or mixed frames, including returned descriptors, stay unknown.
+  auto *footprint = regions.getFootprint(value, function);
+  SmallVector<AllocationSlice> slices;
+  auto addSlice = [&](Interval<size_t> interval,
+                      Allocation::BufferId bufferId) {
+    auto slice = bufferIndexAnalysis.makeSlice(value, interval, bufferId);
+    slice.physicalFootprint = footprint;
+    slices.push_back(std::move(slice));
+  };
+  Allocation::BufferIdSetT bufferIds;
+  if (accessMode == AccessMode::AllocatorAliasesOnly) {
+    // Allocation identity survives unknown geometry. Direct argument effects
+    // have no local IDs; retain them until a caller binds their allocation.
+    bufferIds = allocation.getAllBufferIdsWithAliases(value);
+    auto argument = dyn_cast<BlockArgument>(value);
+    if (argument && argument.getOwner() == &function.getBlocks().front()) {
+      AllocationSlice slice(Interval<size_t>{});
+      slice.argumentIndex = argument.getArgNumber();
+      slices.push_back(std::move(slice));
+    }
+  } else if (footprint) {
+    // Use every lattice origin: function-local alias analysis can miss roots
+    // returned through calls or joined with descriptor arguments.
+    for (const auto &view : footprint->regionInfo.views) {
+      auto ids = view.allocation
+                     ? allocation.getBufferIds(view.allocation->getResult(0))
+                     : SmallVector<Allocation::BufferId>{};
+      if (ids.empty()) {
+        bufferIds.clear();
+        break;
+      }
+      bufferIds.insert(ids.begin(), ids.end());
+    }
+  }
+  // Unknown allocations use an unbounded interval. View disjointness and
+  // RAW/WAR/WAW checks still determine whether a barrier is needed.
+  if (accessMode == AccessMode::AllSharedAccesses && bufferIds.empty())
+    addSlice(Interval<size_t>{}, Allocation::InvalidBufferId);
+  for (auto bufferId : bufferIds)
+    addSlice(allocation.getAllocatedInterval(bufferId), bufferId);
+  return slices;
+}
+
 void MembarAnalysis::updateMemoryEffects(Operation *op, MembarInfo *membarInfo,
                                          FuncMapT *funcMap, OpBuilder *builder,
                                          bool cluster) {
@@ -299,7 +348,23 @@ void MembarAnalysis::updateMemoryEffects(Operation *op, MembarInfo *membarInfo,
     auto summary = getCallSummary(
         call, *funcMap, [&](MembarInfo &summary, FunctionOpInterface callee) {
           summary.transformSlices([&](const AllocationSlice &slice) {
-            return slice.translateToCallsite(call, callee, regions);
+            if (!slice.argumentIndex)
+              return SmallVector<AllocationSlice>{
+                  slice.translateToCallsite(call, callee, regions)};
+            Value actual = call.getArgOperands()[*slice.argumentIndex];
+            auto slices = getAllocationSlices(actual);
+            if (!actual.getDefiningOp<triton::gpu::LocalAllocOp>() &&
+                llvm::none_of(slices, [](const AllocationSlice &bound) {
+                  return bound.argumentIndex.has_value();
+                }))
+              return SmallVector<AllocationSlice>{};
+            // A callee can reinterpret the argument's view. Retain the caller's
+            // allocation IDs, but cover each whole allocation without shifting.
+            for (AllocationSlice &bound : slices) {
+              bound.physicalFootprint = nullptr;
+              bound.invalidateIterationInfo();
+            }
+            return slices;
           });
         });
     if (summary) {
@@ -312,7 +377,6 @@ void MembarAnalysis::updateMemoryEffects(Operation *op, MembarInfo *membarInfo,
   // Intra-function dependencies
   // Explicit buffer
   BlockInfo curBlockInfo;
-  auto function = cast<FunctionOpInterface>(allocation.getOperation());
   for (const auto &access : triton::getMemoryAccesses(op)) {
     Value value = access.value;
     auto memory = cast<triton::gpu::MemDescType>(value.getType());
@@ -320,44 +384,11 @@ void MembarAnalysis::updateMemoryEffects(Operation *op, MembarInfo *membarInfo,
       continue;
     // Shared effects cover only descriptor elements, including gather/scatter
     // and async copies. Footprints retain padding, partitions and CTA identity.
-    // Device-function views use their own frame until imported at a call;
-    // foreign or mixed frames, including returned descriptors, stay unknown.
-    auto *footprint = regions.getFootprint(value, function);
-    auto addSlice = [&](AllocationSlice slice) {
-      slice.physicalFootprint = footprint;
+    for (const AllocationSlice &slice : getAllocationSlices(value)) {
       if (access.isWrite)
         curBlockInfo.syncWriteSlices[slice].insert(op);
       if (access.isRead)
         curBlockInfo.syncReadSlices[slice].insert(op);
-    };
-    Allocation::BufferIdSetT bufferIds;
-    if (accessMode == AccessMode::AllocatorAliasesOnly) {
-      // Allocation identity survives unknown geometry. Argument-only effects
-      // have no local IDs and cannot introduce aliases in this allocation.
-      bufferIds = allocation.getAllBufferIdsWithAliases(value);
-    } else if (footprint) {
-      // Use every lattice origin: function-local alias analysis can miss roots
-      // returned through calls or joined with descriptor arguments.
-      for (const auto &view : footprint->regionInfo.views) {
-        auto ids = view.allocation
-                       ? allocation.getBufferIds(view.allocation->getResult(0))
-                       : SmallVector<Allocation::BufferId>{};
-        if (ids.empty()) {
-          bufferIds.clear();
-          break;
-        }
-        bufferIds.insert(ids.begin(), ids.end());
-      }
-    }
-    if (bufferIds.empty()) {
-      if (accessMode == AccessMode::AllSharedAccesses)
-        addSlice(bufferIndexAnalysis.makeSlice(value, Interval<size_t>{},
-                                               Allocation::InvalidBufferId));
-      continue;
-    }
-    for (auto bufferId : bufferIds) {
-      auto interval = allocation.getAllocatedInterval(bufferId);
-      addSlice(bufferIndexAnalysis.makeSlice(value, interval, bufferId));
     }
   }
 

--- a/lib/Analysis/Membar.cpp
+++ b/lib/Analysis/Membar.cpp
@@ -38,9 +38,9 @@ bool AllocationSlice::intersects(const AllocationSlice &other) const {
   if (!triton::mayOverlap(physicalFootprint, other.physicalFootprint))
     return false;
 
-  // For slices of the same allocation, compare dynamic buffer indices to prove
-  // that different slots do not overlap.
-  if (bufferId == other.bufferId && bufferId != Allocation::InvalidBufferId &&
+  // Compare indices of the same source descriptor to prove disjoint slots,
+  // including arguments without allocator IDs.
+  if (bufferId == other.bufferId &&
       areBufferIndicesProvablyDifferent(*this, other))
     return false;
 

--- a/lib/Analysis/Membar.cpp
+++ b/lib/Analysis/Membar.cpp
@@ -33,9 +33,9 @@ bool AllocationSlice::intersects(const AllocationSlice &other) const {
   if (!allocationInterval.intersects(other.allocationInterval))
     return false;
 
-  // Physical footprints include every possible origin across loop iterations.
-  if (physicalFootprint && other.physicalFootprint &&
-      !physicalFootprint->intersects(*other.physicalFootprint))
+  // Physical footprints include every possible origin across loop iterations,
+  // retaining CTA and memory-space identity.
+  if (!triton::mayOverlap(physicalFootprint, other.physicalFootprint))
     return false;
 
   // For slices of the same allocation, compare dynamic buffer indices to prove
@@ -286,12 +286,18 @@ void MembarAnalysis::update(Operation *op, MembarInfo *membarInfo,
 
   // Intra-function dependencies
   // Explicit buffer
+  auto function = cast<FunctionOpInterface>(allocation.getOperation());
   for (const auto &access : triton::getMemoryAccesses(op)) {
     Value value = access.value;
-    const triton::AddressSet *footprint = nullptr;
-    auto found = physicalFootprints.find(value);
-    if (found != physicalFootprints.end())
-      footprint = &found->second;
+    const triton::BufferRegionFootprint *footprint = nullptr;
+    auto memory = cast<triton::gpu::MemDescType>(value.getType());
+    // Physical offsets must use the current kernel's allocation frame.
+    // Device-function allocations need their callsite offsets before
+    // comparison. Returned descriptors may include views from another caller's
+    // frame.
+    if (regions && triton::isKernel(function) &&
+        isa<triton::gpu::SharedMemorySpaceAttr>(memory.getMemorySpace()))
+      footprint = regions->getFootprint(value, function);
     for (auto bufferId : allocation.getAllBufferIdsWithAliases(value)) {
       if (bufferId == Allocation::InvalidBufferId)
         continue;
@@ -320,6 +326,8 @@ void MembarAnalysis::update(Operation *op, MembarInfo *membarInfo,
     }
     auto interval = allocation.getAllocatedInterval(scratchBufferId);
     auto scratchSlice = AllocationSlice(interval);
+    scratchSlice.physicalFootprint =
+        regions ? regions->getScratchFootprint(op) : nullptr;
     curBlockInfo.syncWriteSlices[scratchSlice].insert(op);
     auto insertCTABarrier =
         membarInfo->pending.isIntersected(curBlockInfo, filter, &allocation);
@@ -354,49 +362,15 @@ void MembarAnalysis::update(Operation *op, MembarInfo *membarInfo,
   }
 }
 
-SharedMemoryFootprints ModuleMembarAnalysis::getSharedMemoryFootprints() {
+void ModuleMembarAnalysis::run() {
   ModuleOp module = moduleAllocation.getModuleOp();
-  SharedMemoryFootprints footprints;
-
-  // Physical footprints use the addresses assigned by the allocation passes.
+  // Footprints use allocated addresses and retain CTA identity. MembarAnalysis
+  // checks allocation frames and conservatively translates call summaries.
+  // Shared effects cover only descriptor elements, including gather/scatter
+  // and async copies; BufferRegion maps them through padding and partitions.
   auto solver = createDataFlowSolver();
   auto *regions = solver->load<triton::BufferRegionAnalysis>();
-  if (failed(solver->initializeAndRun(module)))
-    return footprints;
-  // Device-function allocations need their callsite offsets before comparison.
-  for (auto function : module.getOps<FunctionOpInterface>()) {
-    if (!triton::isKernel(function))
-      continue;
-    uint32_t frame = regions->getOperationId(function.getOperation());
-
-    function.walk([&](Operation *op) {
-      for (const auto &access : triton::getMemoryAccesses(op)) {
-        Value value = access.value;
-        if (!access.isShared() || footprints.contains(value))
-          continue;
-        const auto &info = regions->getRegionInfo(value);
-        // BufferRegion joins callee arguments across call sites, so a returned
-        // descriptor can include views from another caller's allocation frame.
-        if (info.kind != triton::RegionInfo::Kind::Exact ||
-            info.views.empty() ||
-            llvm::any_of(info.views, [&](const auto &view) {
-              return view.allocationFrame != frame;
-            }))
-          continue;
-        // Union all possible origins. Merging CTA address sets only adds
-        // aliases.
-        auto &footprint = footprints[value];
-        for (const auto &view : info.views)
-          for (const auto &entry : view.region.ctaAddresses)
-            footprint.insert(entry.second);
-      }
-    });
-  }
-  return footprints;
-}
-
-void ModuleMembarAnalysis::run() {
-  auto physicalFootprints = getSharedMemoryFootprints();
-  runAnalysis<MembarAnalysis>(physicalFootprints);
+  runAnalysis<MembarAnalysis>(
+      succeeded(solver->initializeAndRun(module)) ? regions : nullptr);
 }
 } // namespace mlir

--- a/lib/Analysis/Membar.cpp
+++ b/lib/Analysis/Membar.cpp
@@ -117,21 +117,26 @@ AllocationSlice AllocationSlice::translateToCallsite(
 }
 
 void MembarAnalysis::syncIfNeeded(Operation *op, const BlockInfo &effects,
-                                  MembarInfo *membarInfo, OpBuilder *builder) {
+                                  MembarInfo *membarInfo, OpBuilder *builder,
+                                  bool cluster) {
   if (!membarInfo->pending.isIntersected(effects, filter, &allocation,
                                          sliceFilter))
     return;
   // The barrier clears incoming state. The operation's own effects still
   // follow it, including a scratch write that conflicts with a pending read.
   builder->setInsertionPoint(op);
-  insertBarrier(op, builder);
+  insertBarrier(op, builder, cluster);
   membarInfo->sync();
 }
 
-void MembarAnalysis::insertBarrier(Operation *op, OpBuilder *builder) {
+void MembarAnalysis::insertBarrier(Operation *op, OpBuilder *builder,
+                                   bool cluster) {
   OpBuilder::InsertionGuard g(*builder);
-  triton::gpu::BarrierOp::create(*builder, op->getLoc(),
-                                 triton::gpu::AddrSpace::Local);
+  if (cluster)
+    ttng::ClusterBarrierOp::create(*builder, op->getLoc());
+  else
+    triton::gpu::BarrierOp::create(*builder, op->getLoc(),
+                                   triton::gpu::AddrSpace::Local);
 }
 
 static Allocation::BufferId getScratchBufferId(Operation *op,
@@ -282,8 +287,8 @@ void MembarAnalysis::update(Operation *op, MembarInfo *membarInfo,
 }
 
 void MembarAnalysis::updateMemoryEffects(Operation *op, MembarInfo *membarInfo,
-                                         FuncMapT *funcMap,
-                                         OpBuilder *builder) {
+                                         FuncMapT *funcMap, OpBuilder *builder,
+                                         bool cluster) {
   auto barrierStages = getBarrierStages(op);
   if (barrierStages.beforeMemoryEffects) {
     // Model a leading barrier before handling the operation's effects.
@@ -298,7 +303,7 @@ void MembarAnalysis::updateMemoryEffects(Operation *op, MembarInfo *membarInfo,
           });
         });
     if (summary) {
-      syncIfNeeded(op, summary->entryBlockInfo, membarInfo, builder);
+      syncIfNeeded(op, summary->entryBlockInfo, membarInfo, builder, cluster);
       membarInfo->applyCallSummary(*summary);
     }
     return;
@@ -377,7 +382,7 @@ void MembarAnalysis::updateMemoryEffects(Operation *op, MembarInfo *membarInfo,
     curBlockInfo.syncWriteSlices[*scratchSlice].insert(op);
   }
 
-  syncIfNeeded(op, curBlockInfo, membarInfo, builder);
+  syncIfNeeded(op, curBlockInfo, membarInfo, builder, cluster);
 
   if (scratchSlice) {
     if (barrierStages.betweenMemoryEffects) {

--- a/lib/Dialect/TritonNvidiaGPU/Transforms/ClusterBarrierInsertion.cpp
+++ b/lib/Dialect/TritonNvidiaGPU/Transforms/ClusterBarrierInsertion.cpp
@@ -268,139 +268,43 @@ insertCrossCTAMBarrierInitSyncForFunction(FunctionOpInterface funcOp,
 
 class ClusterBarrierAnalysis : public MembarAnalysis {
 public:
-  using MembarAnalysis::MembarAnalysis;
+  ClusterBarrierAnalysis(Allocation &allocation, MembarFilterFn filter,
+                         BufferRegionAnalysis &regions)
+      : MembarAnalysis(allocation, std::move(filter), regions,
+                       isPreAllocAliasSliceFilter,
+                       AccessMode::AllocatorAliasesOnly) {}
 
 private:
+  void insertBarrier(Operation *op, OpBuilder *builder) override {
+    ttng::ClusterBarrierOp::create(*builder, op->getLoc());
+  }
+
+  BarrierStages getBarrierStages(Operation *op) override {
+    BarrierStages stages;
+    if (auto barrier = dyn_cast<ttng::ClusterBarrierOp>(op))
+      stages.beforeMemoryEffects = !barrier.getRelaxed();
+    // Distributed scratch synchronizes between its write and read phases.
+    stages.betweenMemoryEffects = isDistributedMultiCTAOp(op, /*isRead=*/true);
+    return stages;
+  }
+
   void update(Operation *op, MembarInfo *membarInfo, FuncMapT *funcMap,
-              OpBuilder *builder) override;
-};
-
-void ClusterBarrierAnalysis::update(Operation *op, MembarInfo *membarInfo,
-                                    FuncMapT *funcMap, OpBuilder *builder) {
-  if (auto clusterBarrier = dyn_cast<ttng::ClusterBarrierOp>(op)) {
-    if (!clusterBarrier.getRelaxed())
-      membarInfo->sync();
-    return;
-  }
-
-  // Any path from distributed shared memory use to kernel exit must include a
-  // cluster barrier. Conservatively insert the barrier since we can't analyze
-  // memory effects properly in warp specialized kernels.
-  if (op->hasTrait<OpTrait::ReturnLike>() &&
-      isa<FunctionOpInterface>(op->getParentOp())) {
-    auto funcOp = cast<FunctionOpInterface>(op->getParentOp());
-    if (isKernel(funcOp)) {
-      builder->setInsertionPoint(op);
-      ttng::ClusterBarrierOp::create(*builder, op->getLoc());
-      membarInfo->sync();
-    }
-    return;
-  }
-
-  BlockInfo curBlockInfo;
-  auto scratchBufferId = Allocation::InvalidBufferId;
-  if (isa<triton::CallOp>(op)) {
-    auto call = cast<CallOpInterface>(op);
-    if (auto callee = dyn_cast<FunctionOpInterface>(call.resolveCallable())) {
-      MembarInfo calleeMembarInfo = funcMap->lookup(callee);
-      auto callBufferId = allocation.getBufferId(op);
-      size_t callOffset = 0;
-      if (callBufferId != Allocation::InvalidBufferId)
-        callOffset = allocation.getAllocatedInterval(callBufferId).start();
-      calleeMembarInfo.pending =
-          translateBlockInfoToCallsite(calleeMembarInfo.pending, callOffset);
-      calleeMembarInfo.entryBlockInfo = translateBlockInfoToCallsite(
-          calleeMembarInfo.entryBlockInfo, callOffset);
-      if (membarInfo->pending.isIntersected(calleeMembarInfo.entryBlockInfo,
-                                            filter, &allocation,
-                                            isPreAllocAliasSliceFilter)) {
+              OpBuilder *builder) override {
+    if (op->hasTrait<OpTrait::ReturnLike>() &&
+        isa<FunctionOpInterface>(op->getParentOp())) {
+      // Any path from distributed shared memory use to kernel exit must include
+      // a cluster barrier. Conservatively insert it because warp-specialized
+      // memory effects are not fully modeled.
+      if (isKernel(cast<FunctionOpInterface>(op->getParentOp()))) {
         builder->setInsertionPoint(op);
-        ttng::ClusterBarrierOp::create(*builder, op->getLoc());
+        insertBarrier(op, builder);
         membarInfo->sync();
       }
-      membarInfo->applyCallSummary(calleeMembarInfo);
+      return;
     }
-    return;
-  } else {
-    if (auto memEffects = dyn_cast<MemoryEffectOpInterface>(op)) {
-      SmallVector<SideEffects::EffectInstance<MemoryEffects::Effect>>
-          effectInstances;
-      memEffects.getEffects(effectInstances);
-      for (auto effectInstance : effectInstances) {
-        if (auto value = effectInstance.getValue()) {
-          for (auto bufferId : allocation.getAllBufferIdsWithAliases(value)) {
-            if (bufferId != Allocation::InvalidBufferId) {
-              auto interval = allocation.getAllocatedInterval(bufferId);
-              auto slice = AllocationSlice(value, interval, bufferId);
-              if (isa<MemoryEffects::Write>(effectInstance.getEffect()))
-                curBlockInfo.syncWriteSlices[slice].insert(op);
-              else if (isa<MemoryEffects::Read>(effectInstance.getEffect()))
-                curBlockInfo.syncReadSlices[slice].insert(op);
-            }
-          }
-        }
-      }
-    }
-    scratchBufferId = allocation.getBufferId(op);
+    updateMemoryEffects(op, membarInfo, funcMap, builder);
   }
-
-  // Scratch buffer operations consist of a series of shared memory operations
-  // starting from a shared memory write, followed by a series of shared memory
-  // read/write operations, and ending with a shared memory read, i.e., shared
-  // memory write -> ... -> shared memory read.
-  if (scratchBufferId != Allocation::InvalidBufferId) {
-    if ((!curBlockInfo.syncReadSlices.empty() ||
-         !curBlockInfo.syncWriteSlices.empty()) &&
-        !isa<ttg::LocalAtomicScatterRMWOp>(op)) {
-      llvm::report_fatal_error(
-          "scratch buffer operations should not have any shared memory "
-          "dependencies except for local_atomic_scatter_rmw");
-    }
-
-    auto interval = allocation.getAllocatedInterval(scratchBufferId);
-    auto scratchSlice = AllocationSlice(interval);
-    curBlockInfo.syncWriteSlices[scratchSlice].insert(op);
-
-    auto insertClusterBarrierNeeded = membarInfo->pending.isIntersected(
-        curBlockInfo, filter, &allocation, isPreAllocAliasSliceFilter);
-    if (insertClusterBarrierNeeded) {
-      // The inserted barrier precedes the current operation, so it clears only
-      // incoming state. Keep curBlockInfo because all of the operation's
-      // scratch effects occur after the barrier.
-      // For example:
-      //   pending = R(scratch), curBlockInfo = W(scratch)
-      //   cluster_barrier
-      //   pending = {},         curBlockInfo = W(scratch)
-      builder->setInsertionPoint(op);
-      ttng::ClusterBarrierOp::create(*builder, op->getLoc());
-      membarInfo->sync();
-    }
-
-    bool hasClusterSync = isDistributedMultiCTAOp(op, /*isRead=*/true);
-    if (hasClusterSync) {
-      // A distributed scratch operation synchronizes between its write and
-      // read phases. Record the write before clearing the state, then retain
-      // only the read as an outgoing effect.
-      // For example:
-      //   pending = {},          curBlockInfo = W(scratch)
-      //   cluster_barrier
-      //   pending = {},          curBlockInfo = R(scratch)
-      membarInfo->addBlockInfo(curBlockInfo);
-      membarInfo->sync();
-      curBlockInfo.sync();
-    }
-
-    curBlockInfo.syncReadSlices[scratchSlice].insert(op);
-  } else if (membarInfo->pending.isIntersected(curBlockInfo, filter,
-                                               &allocation,
-                                               isPreAllocAliasSliceFilter)) {
-    builder->setInsertionPoint(op);
-    ttng::ClusterBarrierOp::create(*builder, op->getLoc());
-    membarInfo->sync();
-  }
-
-  membarInfo->addBlockInfo(curBlockInfo);
-}
+};
 
 } // namespace
 
@@ -422,7 +326,7 @@ void runClusterBarrierInsertion(ModuleAllocation &moduleAllocation,
   };
 
   ModuleMembarAnalysis analysis(moduleAllocation, filterFn);
-  analysis.runAnalysis<ClusterBarrierAnalysis>();
+  analysis.run<ClusterBarrierAnalysis>();
 }
 
 LogicalResult

--- a/lib/Dialect/TritonNvidiaGPU/Transforms/ClusterBarrierInsertion.cpp
+++ b/lib/Dialect/TritonNvidiaGPU/Transforms/ClusterBarrierInsertion.cpp
@@ -275,6 +275,8 @@ public:
                        AccessMode::AllocatorAliasesOnly) {}
 
 private:
+  llvm::SmallPtrSet<Operation *, 4> returnsWithExitBarrier;
+
   void insertBarrier(Operation *op, OpBuilder *builder) override {
     ttng::ClusterBarrierOp::create(*builder, op->getLoc());
   }
@@ -296,8 +298,11 @@ private:
       // a cluster barrier. Conservatively insert it because warp-specialized
       // memory effects are not fully modeled.
       if (isKernel(cast<FunctionOpInterface>(op->getParentOp()))) {
-        builder->setInsertionPoint(op);
-        insertBarrier(op, builder);
+        // The solver may revisit this return before convergence.
+        if (returnsWithExitBarrier.insert(op).second) {
+          builder->setInsertionPoint(op);
+          insertBarrier(op, builder);
+        }
         membarInfo->sync();
       }
       return;

--- a/lib/Dialect/TritonNvidiaGPU/Transforms/ClusterBarrierInsertion.cpp
+++ b/lib/Dialect/TritonNvidiaGPU/Transforms/ClusterBarrierInsertion.cpp
@@ -50,6 +50,9 @@ bool isPreAllocAliasSliceFilter(const AllocationSlice &lhsSlice,
                                 const AllocationSlice &rhsSlice,
                                 bool /*lhsIsRead*/, bool /*rhsIsRead*/,
                                 Allocation *allocation) {
+  // Argument effects are checked after binding to the caller's allocation.
+  if (lhsSlice.argumentIndex || rhsSlice.argumentIndex)
+    return true;
   auto bufferId = lhsSlice.getBufferId();
   return bufferId != Allocation::InvalidBufferId &&
          bufferId == rhsSlice.getBufferId() &&

--- a/lib/Dialect/TritonNvidiaGPU/Transforms/ClusterBarrierInsertion.cpp
+++ b/lib/Dialect/TritonNvidiaGPU/Transforms/ClusterBarrierInsertion.cpp
@@ -277,10 +277,6 @@ public:
 private:
   llvm::SmallPtrSet<Operation *, 4> returnsWithExitBarrier;
 
-  void insertBarrier(Operation *op, OpBuilder *builder) override {
-    ttng::ClusterBarrierOp::create(*builder, op->getLoc());
-  }
-
   BarrierStages getBarrierStages(Operation *op) override {
     BarrierStages stages;
     if (auto barrier = dyn_cast<ttng::ClusterBarrierOp>(op))
@@ -301,13 +297,13 @@ private:
         // The solver may revisit this return before convergence.
         if (returnsWithExitBarrier.insert(op).second) {
           builder->setInsertionPoint(op);
-          insertBarrier(op, builder);
+          insertBarrier(op, builder, /*cluster=*/true);
         }
         membarInfo->sync();
       }
       return;
     }
-    updateMemoryEffects(op, membarInfo, funcMap, builder);
+    updateMemoryEffects(op, membarInfo, funcMap, builder, /*cluster=*/true);
   }
 };
 

--- a/lib/Dialect/TritonNvidiaGPU/Transforms/ConSanNVIDIA.cpp
+++ b/lib/Dialect/TritonNvidiaGPU/Transforms/ConSanNVIDIA.cpp
@@ -1,3 +1,4 @@
+#include "triton/Analysis/Allocation.h"
 #include "triton/Dialect/TritonGPU/IR/Dialect.h"
 #include "triton/Dialect/TritonInstrument/Transforms/ConSanTargetHooks.h"
 #include "triton/Dialect/TritonNvidiaGPU/IR/Dialect.h"
@@ -33,21 +34,6 @@ uint32_t getBlockBroadcastMask(Type type) {
   auto memDescTy = cast<ttg::MemDescType>(type);
   auto kBlock = StringAttr::get(type.getContext(), "block");
   return toLinearLayout(memDescTy).getFreeVariableMasks().lookup(kBlock);
-}
-
-std::optional<uint16_t> getAtomicScratchBroadcastMask(Operation *op) {
-  if (!op->hasAttr("allocation.size") ||
-      !isa<AtomicPollOp, AtomicRMWOp, AtomicCASOp, ttg::LocalAtomicScatterRMWOp,
-           tti::ExperimentalGSanAtomicRMWOp, tti::ExperimentalGSanAtomicCASOp>(
-          op))
-    return std::nullopt;
-
-  Type resultTy = op->getResult(0).getType();
-  if (auto tensorTy = dyn_cast<RankedTensorType>(resultTy)) {
-    auto kBlock = StringAttr::get(op->getContext(), "block");
-    return ttg::toLinearLayout(tensorTy).getFreeVariableMasks().lookup(kBlock);
-  }
-  return static_cast<uint16_t>(ttg::lookupNumCTAs(op) - 1);
 }
 
 } // namespace
@@ -118,17 +104,12 @@ public:
                          Operation *op) const override {
     // mask = 0 means no CTA predication.
     uint32_t mask = 0;
-    auto getBarrierMask = [&](Value barrier) {
-      auto barrierTy = cast<ttg::MemDescType>(barrier.getType());
-      auto kBlock = StringAttr::get(op->getContext(), "block");
-      return toLinearLayout(barrierTy).getFreeVariableMasks().lookup(kBlock);
-    };
     if (auto initOp = dyn_cast<ttng::InitBarrierOp>(op))
-      mask = getBarrierMask(initOp.getAlloc());
+      mask = getBlockBroadcastMask(initOp.getAlloc().getType());
     if (auto waitOp = dyn_cast<ttng::WaitBarrierOp>(op))
-      mask = getBarrierMask(waitOp.getAlloc());
+      mask = getBlockBroadcastMask(waitOp.getAlloc().getType());
     if (auto invalOp = dyn_cast<ttng::InvalBarrierOp>(op))
-      mask = getBarrierMask(invalOp.getAlloc());
+      mask = getBlockBroadcastMask(invalOp.getAlloc().getType());
     if (isa<ttng::BarrierExpectOp, ttng::ArriveBarrierOp>(op)) {
       std::optional<uint32_t> fromCTA;
       if (auto expectOp = dyn_cast<ttng::BarrierExpectOp>(op))

--- a/lib/Dialect/TritonNvidiaGPU/Transforms/ConSanNVIDIA.cpp
+++ b/lib/Dialect/TritonNvidiaGPU/Transforms/ConSanNVIDIA.cpp
@@ -125,8 +125,9 @@ public:
     }
     if (auto storeOp = dyn_cast<ttng::TMAStoreLikeOpInterface>(op))
       mask = getBlockBroadcastMask(storeOp.getSrc().getType());
-    if (auto scratchMask = getAtomicScratchBroadcastMask(op))
-      mask = *scratchMask;
+    if (op->hasAttr("allocation.size"))
+      if (auto scratchMask = getAtomicScratchBroadcastMask(op))
+        mask = *scratchMask;
     if (isa<ttng::CLCTryCancelOp>(op) && ttg::lookupNumCTAs(op) > 1) {
       Value ctaId = tti::ExperimentalClusterCTAIdOp::create(b, b.getLoc());
       return arith::CmpIOp::create(b, arith::CmpIPredicate::eq, ctaId,
@@ -152,7 +153,8 @@ public:
   bool hasUnsummarizableCalleeState(Operation *op) const override {
     if (isa<ClusterBarrierOp>(op))
       return true;
-    return getAtomicScratchBroadcastMask(op).value_or(0) != 0;
+    return op->hasAttr("allocation.size") &&
+           getAtomicScratchBroadcastMask(op).value_or(0) != 0;
   }
 
   std::optional<MemEffectsOpInfo>

--- a/lib/Dialect/TritonNvidiaGPU/Transforms/ProxyFenceInsertion.cpp
+++ b/lib/Dialect/TritonNvidiaGPU/Transforms/ProxyFenceInsertion.cpp
@@ -1,8 +1,8 @@
-#include "triton/Analysis/Allocation.h"
 #include "triton/Analysis/BufferRegion.h"
 #include "triton/Analysis/CallGraph.h"
 #include "triton/Analysis/Function.h"
 #include "triton/Analysis/MemoryFrontier.h"
+#include "triton/Analysis/Utility.h"
 #include "triton/Dialect/TritonGPU/IR/Dialect.h"
 #include "triton/Dialect/TritonNvidiaGPU/IR/Dialect.h"
 #include "triton/Dialect/TritonNvidiaGPU/Transforms/Passes.h"
@@ -31,7 +31,7 @@ uint8_t getProxyFenceScope(Operation *op) {
   return cluster ? kClusterScope : kCTAScope;
 }
 
-using BufferAccess = BufferRegionAccess;
+using BufferAccess = const BufferRegionFootprint *;
 
 struct ProxyBlockInfo {
   using Frontier = ScopedMemoryFrontier<uint8_t>;
@@ -68,9 +68,8 @@ struct ProxyFenceFunctionAnalysis
     : public PostOrderFunctionAnalysis<ProxyBlockInfo> {
   using FuncMapT = PostOrderFunctionAnalysis<ProxyBlockInfo>::FuncMapT;
 
-  ProxyFenceFunctionAnalysis(FunctionOpInterface function,
-                             BufferRegionAnalysis &regions, uint8_t scopes)
-      : function(function), regions(regions), scopes(scopes) {}
+  ProxyFenceFunctionAnalysis(BufferRegionAnalysis &regions, uint8_t scopes)
+      : regions(regions), scopes(scopes) {}
 
   void applyEffects(Operation *op, const ProxyBlockInfo &effects,
                     ProxyBlockInfo &state, OpBuilder &builder) {
@@ -102,8 +101,7 @@ struct ProxyFenceFunctionAnalysis
       ProxyBlockInfo effects = funcMap->lookup(callee);
       for (auto *frontier : {&effects.generic, &effects.async})
         frontier->transformAccesses([&](BufferAccess access) {
-          return regions.translateToCallsite(std::move(access), call, function,
-                                             callee);
+          return regions.translateToCallsite(access, call, callee);
         });
       applyEffects(op, effects, *state, *builder);
       return;
@@ -118,31 +116,21 @@ struct ProxyFenceFunctionAnalysis
       uint8_t accessScopes = async ? getProxyFenceScope(op) : scopes;
       ProxyBlockInfo::Frontier &frontier =
           async ? effects.async : effects.generic;
-      for (BufferAccess region : regions.getAccessRegions(access.value)) {
-        if (access.isRead)
-          frontier.addRead(region, accessScopes);
-        if (access.isWrite)
-          frontier.addWrite(std::move(region), accessScopes);
-      }
+      BufferAccess footprint = regions.getFootprint(access.value);
+      if (access.isRead)
+        frontier.addRead(footprint, accessScopes);
+      if (access.isWrite)
+        frontier.addWrite(footprint, accessScopes);
     }
 
-    if (auto sizeAttr = op->getAttrOfType<IntegerAttr>("allocation.size")) {
-      uint32_t base =
-          op->getAttrOfType<IntegerAttr>("allocation.offset").getInt();
-      uint32_t size = sizeAttr.getInt();
-      BufferRegionView scratch{{base, size, {}}, base};
-      scratch.allocationFrame = regions.getOperationId(function.getOperation());
-      AddressSet addresses = AddressSet::fromRange(base, size);
-      unsigned numCTAs = hasCrossCTAScratch(op) ? gpu::lookupNumCTAs(op) : 1;
-      for (unsigned cta = 0; cta < numCTAs; ++cta)
-        scratch.region.ctaAddresses.emplace_back(cta, addresses);
+    if (op->hasAttr("allocation.size")) {
+      BufferAccess scratch = regions.getScratchFootprint(op);
       effects.generic.addRead(scratch, scopes);
-      effects.generic.addWrite(std::move(scratch), scopes);
+      effects.generic.addWrite(scratch, scopes);
     }
     applyEffects(op, effects, *state, *builder);
   }
 
-  FunctionOpInterface function;
   BufferRegionAnalysis &regions;
   uint8_t scopes;
 };
@@ -180,7 +168,7 @@ struct ProxyFenceInsertionPass
         [](CallOpInterface, FunctionOpInterface) {},
         [&](FunctionOpInterface function) {
           if (summaries.try_emplace(function).second)
-            ProxyFenceFunctionAnalysis(function, *regions, scopes)
+            ProxyFenceFunctionAnalysis(*regions, scopes)
                 .run(function, summaries);
         });
   }

--- a/lib/Dialect/TritonNvidiaGPU/Transforms/ProxyFenceInsertion.cpp
+++ b/lib/Dialect/TritonNvidiaGPU/Transforms/ProxyFenceInsertion.cpp
@@ -1,5 +1,4 @@
 #include "triton/Analysis/BufferRegion.h"
-#include "triton/Analysis/CallGraph.h"
 #include "triton/Analysis/Function.h"
 #include "triton/Analysis/MemoryFrontier.h"
 #include "triton/Analysis/Utility.h"
@@ -97,13 +96,16 @@ struct ProxyFenceFunctionAnalysis
     }
 
     if (auto call = dyn_cast<CallOpInterface>(op)) {
-      auto callee = cast<FunctionOpInterface>(call.resolveCallable());
-      ProxyBlockInfo effects = funcMap->lookup(callee);
-      for (auto *frontier : {&effects.generic, &effects.async})
-        frontier->transformAccesses([&](BufferAccess access) {
-          return regions.translateToCallsite(access, call, callee);
-        });
-      applyEffects(op, effects, *state, *builder);
+      auto effects = getCallSummary(
+          call, *funcMap,
+          [&](ProxyBlockInfo &effects, FunctionOpInterface callee) {
+            for (auto *frontier : {&effects.generic, &effects.async})
+              frontier->transformAccesses([&](BufferAccess access) {
+                return regions.translateToCallsite(access, call, callee);
+              });
+          });
+      if (effects)
+        applyEffects(op, *effects, *state, *builder);
       return;
     }
 
@@ -162,15 +164,9 @@ struct ProxyFenceInsertionPass
     if (failed(solver->initializeAndRun(module)))
       return signalPassFailure();
 
-    CallGraph<ProxyBlockInfo> callGraph(module);
-    CallGraph<ProxyBlockInfo>::FuncDataMapT summaries;
-    callGraph.walk<WalkOrder::PreOrder, WalkOrder::PostOrder>(
-        [](CallOpInterface, FunctionOpInterface) {},
-        [&](FunctionOpInterface function) {
-          if (summaries.try_emplace(function).second)
-            ProxyFenceFunctionAnalysis(*regions, scopes)
-                .run(function, summaries);
-        });
+    ProxyFenceFunctionAnalysis::runModule(module, [&](FunctionOpInterface) {
+      return ProxyFenceFunctionAnalysis(*regions, scopes);
+    });
   }
 };
 

--- a/lib/Dialect/TritonNvidiaGPU/Transforms/TMemBarrierInsertion.cpp
+++ b/lib/Dialect/TritonNvidiaGPU/Transforms/TMemBarrierInsertion.cpp
@@ -71,7 +71,7 @@ static bool isTensorMemory(Value value) {
          isa<TensorMemorySpaceAttr>(memDescType.getMemorySpace());
 }
 
-static BlockInfo getTMemAccesses(Operation *op, BufferRegionAnalysis *regions) {
+static BlockInfo getTMemAccesses(Operation *op, BufferRegionAnalysis &regions) {
   BlockInfo accesses;
   for (const MemoryAccess &access : getMemoryAccesses(op)) {
     if (!isTensorMemory(access.value))
@@ -79,7 +79,7 @@ static BlockInfo getTMemAccesses(Operation *op, BufferRegionAnalysis *regions) {
     // Footprints preserve TMEM rows and columns; a full interval makes unknown
     // footprints alias all TMEM.
     AllocationSlice slice(Interval<size_t>{});
-    slice.physicalFootprint = regions->getFootprint(access.value);
+    slice.physicalFootprint = regions.getFootprint(access.value);
     if (access.isRead)
       accesses.syncReadSlices[slice].insert(op);
     if (access.isWrite)
@@ -103,29 +103,18 @@ void TMemBarrierAnalysis::update(Operation *op, MembarInfo *membarInfo,
   if (stages.beforeMemoryEffects)
     membarInfo->sync();
 
-  if (isa<triton::CallOp>(op)) {
-    auto call = cast<CallOpInterface>(op);
-    if (auto callee = dyn_cast<FunctionOpInterface>(call.resolveCallable())) {
+  if (auto call = dyn_cast<CallOpInterface>(op)) {
+    if (auto summary = getCallSummary(call, *funcMap)) {
       // Tensor-memory allocation attributes are physical addresses assigned
       // across the whole module, so callee slices need no call-frame offset.
-      MembarInfo calleeMembarInfo = funcMap->lookup(callee);
-      if (membarInfo->pending.isIntersected(calleeMembarInfo.entryBlockInfo,
-                                            filter, &allocation)) {
-        builder->setInsertionPoint(op);
-        insertBarrier(op, builder);
-        membarInfo->sync();
-      }
-      membarInfo->applyCallSummary(calleeMembarInfo);
+      syncIfNeeded(op, summary->entryBlockInfo, membarInfo, builder);
+      membarInfo->applyCallSummary(*summary);
     }
     return;
   }
 
   BlockInfo curBlockInfo = getTMemAccesses(op, regions);
-  if (membarInfo->pending.isIntersected(curBlockInfo, filter, &allocation)) {
-    builder->setInsertionPoint(op);
-    insertBarrier(op, builder);
-    membarInfo->sync();
-  }
+  syncIfNeeded(op, curBlockInfo, membarInfo, builder);
 
   membarInfo->addBlockInfo(curBlockInfo);
   // A leading or interior rendezvous must preserve the operation's own effects.
@@ -338,7 +327,7 @@ LogicalResult runTMemAnalysis(ModuleOp mod, MembarFilterFn filter = nullptr) {
     return failure();
   ModuleAllocation allocation(mod);
   ModuleMembarAnalysis analysis(allocation, std::move(filter));
-  analysis.runAnalysis<AnalysisT>(regions);
+  analysis.runAnalysis<AnalysisT>(*regions);
   return success();
 }
 

--- a/lib/Dialect/TritonNvidiaGPU/Transforms/TMemBarrierInsertion.cpp
+++ b/lib/Dialect/TritonNvidiaGPU/Transforms/TMemBarrierInsertion.cpp
@@ -1,15 +1,11 @@
 #include "triton/Analysis/Allocation.h"
 #include "triton/Analysis/Membar.h"
+#include "triton/Analysis/Utility.h"
 #include "triton/Dialect/TritonGPU/IR/Dialect.h"
 #include "triton/Dialect/TritonNvidiaGPU/IR/Dialect.h"
 #include "triton/Dialect/TritonNvidiaGPU/Transforms/Passes.h"
 
-#include "mlir/Dialect/Arith/IR/Arith.h"
-#include "mlir/Dialect/SCF/IR/SCF.h"
 #include "mlir/Interfaces/ControlFlowInterfaces.h"
-#include "llvm/ADT/DenseSet.h"
-
-#include <limits>
 
 namespace mlir {
 namespace triton {
@@ -21,15 +17,7 @@ namespace nvidia_gpu {
 
 namespace {
 
-namespace ttg = triton::gpu;
-
 enum class TMemAccessKind { None, Load, Store, MMA };
-
-// Keep row groups far apart so per-row column intervals do not alias after
-// flattening the physical 2D tensor-memory address space into 1D intervals.
-static constexpr size_t kFlattenedRowStride = size_t{1} << 32;
-static constexpr int kAllocRowGranularity = 64;
-static constexpr int kRowOffsetGranularity = 16;
 
 // Fine grain modeling of TMEM ops as pipelining behavior is not fully
 // represented in ops attributes.
@@ -78,162 +66,24 @@ static bool filterFn(Operation *lhs, Operation *rhs, bool /*lhsIsRead*/,
 }
 
 static bool isTensorMemory(Value value) {
-  auto memDescType = dyn_cast<ttg::MemDescType>(value.getType());
+  auto memDescType = dyn_cast<gpu::MemDescType>(value.getType());
   return memDescType &&
          isa<TensorMemorySpaceAttr>(memDescType.getMemorySpace());
 }
 
-static void appendRootAllocs(Value value, SmallVectorImpl<TMEMAllocOp> &allocs,
-                             bool &unknown) {
-  DenseSet<Value> seen;
-  SmallVector<Value> worklist{value};
-
-  while (!worklist.empty()) {
-    Value current = worklist.pop_back_val();
-    if (!seen.insert(current).second)
-      continue;
-
-    if (auto arg = dyn_cast<BlockArgument>(current)) {
-      Block *block = arg.getOwner();
-      Operation *parentOp = block->getParentOp();
-
-      if (!block->isEntryBlock()) {
-        for (Block *pred : block->getPredecessors()) {
-          auto branch = dyn_cast<BranchOpInterface>(pred->getTerminator());
-          if (!branch) {
-            unknown = true;
-            continue;
-          }
-          auto it = llvm::find(branch->getSuccessors(), block);
-          unsigned successorIndex =
-              std::distance(branch->getSuccessors().begin(), it);
-          SuccessorOperands args = branch.getSuccessorOperands(successorIndex);
-          worklist.push_back(
-              args.getForwardedOperands()[arg.getArgNumber() -
-                                          args.getProducedOperandCount()]);
-        }
-        continue;
-      }
-
-      if (auto ws = dyn_cast<ttg::WarpSpecializePartitionsOp>(parentOp)) {
-        worklist.push_back(ws.getExplicitCaptures()[arg.getArgNumber()]);
-      } else if (auto forOp = dyn_cast<scf::ForOp>(parentOp)) {
-        unsigned idx = arg.getArgNumber() - 1;
-        worklist.push_back(forOp.getYieldedValues()[idx]);
-        worklist.push_back(forOp.getInits()[idx]);
-      } else if (auto whileOp = dyn_cast<scf::WhileOp>(parentOp)) {
-        unsigned idx = arg.getArgNumber();
-        if (arg.getParentRegion() == &whileOp.getAfter()) {
-          worklist.push_back(whileOp.getConditionOp().getArgs()[idx]);
-        } else {
-          worklist.push_back(whileOp.getYieldedValues()[idx]);
-          worklist.push_back(whileOp.getInits()[idx]);
-        }
-      } else {
-        unknown = true;
-      }
-      continue;
-    }
-
-    Operation *defOp = current.getDefiningOp();
-    if (!defOp) {
-      unknown = true;
-      continue;
-    }
-
-    unsigned resultIndex = cast<OpResult>(current).getResultNumber();
-    if (auto alloc = dyn_cast<TMEMAllocOp>(defOp)) {
-      allocs.push_back(alloc);
-    } else if (defOp->hasTrait<OpTrait::MemDescViewTrait>()) {
-      worklist.push_back(defOp->getOperand(0));
-    } else if (auto slice = dyn_cast<TMEMSubSliceOp>(defOp)) {
-      worklist.push_back(slice.getSrc());
-    } else if (auto selectOp = dyn_cast<arith::SelectOp>(defOp)) {
-      worklist.push_back(selectOp.getTrueValue());
-      worklist.push_back(selectOp.getFalseValue());
-    } else if (auto ifOp = dyn_cast<scf::IfOp>(defOp)) {
-      worklist.push_back(ifOp.thenYield().getOperand(resultIndex));
-      worklist.push_back(ifOp.elseYield().getOperand(resultIndex));
-    } else if (auto forOp = dyn_cast<scf::ForOp>(defOp)) {
-      worklist.push_back(forOp.getYieldedValues()[resultIndex]);
-      worklist.push_back(forOp.getInits()[resultIndex]);
-    } else if (auto whileOp = dyn_cast<scf::WhileOp>(defOp)) {
-      worklist.push_back(whileOp.getConditionOp().getArgs()[resultIndex]);
-    } else {
-      unknown = true;
-    }
-  }
-}
-
-static SmallVector<AllocationSlice> getTMemSlices(Value value) {
-  SmallVector<TMEMAllocOp> allocs;
-  bool unknown = false;
-  appendRootAllocs(value, allocs, unknown);
-
-  SmallVector<AllocationSlice> slices;
-  if (unknown || allocs.empty()) {
-    slices.emplace_back(
-        Interval<size_t>(0, std::numeric_limits<size_t>::max()));
-    return slices;
-  }
-
-  for (TMEMAllocOp alloc : allocs) {
-    auto colAttr =
-        alloc->getAttrOfType<IntegerAttr>("tensor_memory_col_offset");
-    auto rowAttr =
-        alloc->getAttrOfType<IntegerAttr>("tensor_memory_row_offset");
-    if (!colAttr || !rowAttr) {
-      slices.clear();
-      slices.emplace_back(
-          Interval<size_t>(0, std::numeric_limits<size_t>::max()));
-      return slices;
-    }
-
-    int64_t colOffset = colAttr.getInt();
-    int64_t rowOffset = rowAttr.getInt();
-    TMemAllocation allocSize = getTmemAllocSizes(alloc.getType());
-    if (rowOffset % kRowOffsetGranularity != 0 ||
-        allocSize.numRows % kAllocRowGranularity != 0) {
-      slices.clear();
-      slices.emplace_back(
-          Interval<size_t>(0, std::numeric_limits<size_t>::max()));
-      return slices;
-    }
-
-    int64_t rowGroup = rowOffset / kRowOffsetGranularity;
-    int64_t numRowGroups = allocSize.numRows / kAllocRowGranularity;
-    for (int64_t row = 0; row < numRowGroups; ++row) {
-      size_t start = static_cast<size_t>(rowGroup + row) * kFlattenedRowStride +
-                     static_cast<size_t>(colOffset);
-      slices.emplace_back(Interval<size_t>(start, start + allocSize.numCols));
-    }
-  }
-  return slices;
-}
-
-static void appendReadSlices(Value value, Operation *op, BlockInfo *blockInfo) {
-  if (!isTensorMemory(value))
-    return;
-  for (AllocationSlice slice : getTMemSlices(value))
-    blockInfo->syncReadSlices[slice].insert(op);
-}
-
-static void appendWriteSlices(Value value, Operation *op,
-                              BlockInfo *blockInfo) {
-  if (!isTensorMemory(value))
-    return;
-  for (AllocationSlice slice : getTMemSlices(value))
-    blockInfo->syncWriteSlices[slice].insert(op);
-}
-
-static BlockInfo getTMemAccesses(Operation *op) {
-  // Use physical TMEM allocation slices; unknown origins alias all TMEM.
+static BlockInfo getTMemAccesses(Operation *op, BufferRegionAnalysis *regions) {
   BlockInfo accesses;
   for (const MemoryAccess &access : getMemoryAccesses(op)) {
+    if (!isTensorMemory(access.value))
+      continue;
+    // Footprints preserve TMEM rows and columns; a full interval makes unknown
+    // footprints alias all TMEM.
+    AllocationSlice slice(Interval<size_t>{});
+    slice.physicalFootprint = regions->getFootprint(access.value);
     if (access.isRead)
-      appendReadSlices(access.value, op, &accesses);
+      accesses.syncReadSlices[slice].insert(op);
     if (access.isWrite)
-      appendWriteSlices(access.value, op, &accesses);
+      accesses.syncWriteSlices[slice].insert(op);
   }
   return accesses;
 }
@@ -270,7 +120,7 @@ void TMemBarrierAnalysis::update(Operation *op, MembarInfo *membarInfo,
     return;
   }
 
-  BlockInfo curBlockInfo = getTMemAccesses(op);
+  BlockInfo curBlockInfo = getTMemAccesses(op, regions);
   if (membarInfo->pending.isIntersected(curBlockInfo, filter, &allocation)) {
     builder->setInsertionPoint(op);
     insertBarrier(op, builder);
@@ -411,7 +261,7 @@ private:
       return;
     }
 
-    BlockInfo effects = getTMemAccesses(op);
+    BlockInfo effects = getTMemAccesses(op, regions);
     // Include internal scratch barriers even without descriptor memory effects.
     auto stages = getLocalBarrierStages(op, &allocation);
     // Reuse this barrier for incoming hazards only if it precedes the op's TMEM
@@ -479,6 +329,19 @@ private:
   BlockInfo afterBarrier;
 };
 
+template <typename AnalysisT>
+LogicalResult runTMemAnalysis(ModuleOp mod, MembarFilterFn filter = nullptr) {
+  auto solver = createDataFlowSolver();
+  auto *regions = solver->load<BufferRegionAnalysis>(
+      BufferRegionAnalysis::Mode::TensorMemoryOnly);
+  if (failed(solver->initializeAndRun(mod)))
+    return failure();
+  ModuleAllocation allocation(mod);
+  ModuleMembarAnalysis analysis(allocation, std::move(filter));
+  analysis.runAnalysis<AnalysisT>(regions);
+  return success();
+}
+
 } // namespace
 
 struct TMemWaitInsertionPass
@@ -500,9 +363,8 @@ struct TMemWaitInsertionPass
       return;
     // Run after TMEM and shared-memory barrier insertion. Calls and returns
     // complete pending accesses, so this pass needs no call summaries.
-    ModuleAllocation allocation(mod);
-    ModuleMembarAnalysis analysis(allocation);
-    analysis.runAnalysis<TMemWaitAnalysis>();
+    if (failed(runTMemAnalysis<TMemWaitAnalysis>(mod)))
+      return signalPassFailure();
   }
 };
 
@@ -514,9 +376,15 @@ struct TMemBarrierInsertionPass
 
   void runOnOperation() override {
     ModuleOp mod = getOperation();
-    ModuleAllocation allocation(mod);
-    ModuleMembarAnalysis analysis(allocation, filterFn);
-    analysis.runAnalysis<TMemBarrierAnalysis>();
+    if (!mod.walk([](Operation *op) {
+              return getTMemAccessKind(op) == TMemAccessKind::None
+                         ? WalkResult::advance()
+                         : WalkResult::interrupt();
+            })
+             .wasInterrupted())
+      return;
+    if (failed(runTMemAnalysis<TMemBarrierAnalysis>(mod, filterFn)))
+      return signalPassFailure();
   }
 };
 

--- a/python/src/passes.cc
+++ b/python/src/passes.cc
@@ -28,7 +28,7 @@ void init_triton_analysis(py::module_ &m) {
       .def(py::init<mlir::ModuleOp>());
   py::class_<mlir::ModuleMembarAnalysis>(m, "membar")
       .def(py::init<mlir::ModuleAllocation &>())
-      .def("run", &mlir::ModuleMembarAnalysis::run);
+      .def("run", &mlir::ModuleMembarAnalysis::run<>);
 }
 
 void init_triton_passes_common(py::module_ &m) {

--- a/test/Analysis/test-allocation.mlir
+++ b/test/Analysis/test-allocation.mlir
@@ -1098,4 +1098,81 @@ tt.func @partitioned_shared_padded_alloc() {
   %alloc = ttg.local_alloc : () -> !ttg.memdesc<64x32xf16, #PARTITIONED_SHARED_PADDED, #ttg.shared_memory, mutable>
   tt.return
 }
+
+// Returned descriptors retain their caller-owned shared allocation.
+// expected-remark @below {{returned_alias_identity}}
+// expected-remark @below {{size = 0}}
+tt.func private @returned_alias_identity(%arg: !ttg.memdesc<16x16xf16, #A_SHARED, #smem, mutable>) -> !ttg.memdesc<16x16xf16, #A_SHARED, #smem, mutable> {
+  tt.return %arg : !ttg.memdesc<16x16xf16, #A_SHARED, #smem, mutable>
+}
+
+// expected-remark @below {{returned_alias_forward}}
+// expected-remark @below {{size = 0}}
+tt.func private @returned_alias_forward(%arg: !ttg.memdesc<16x16xf16, #A_SHARED, #smem, mutable>) -> !ttg.memdesc<16x16xf16, #A_SHARED, #smem, mutable> {
+  %result = tt.call @returned_alias_identity(%arg) : (!ttg.memdesc<16x16xf16, #A_SHARED, #smem, mutable>) -> !ttg.memdesc<16x16xf16, #A_SHARED, #smem, mutable>
+  tt.return %result : !ttg.memdesc<16x16xf16, #A_SHARED, #smem, mutable>
+}
+
+// expected-remark @below {{returned_alias_direct}}
+// expected-remark @below {{size = 1024}}
+tt.func @returned_alias_direct() -> (tensor<16x16xf16, #AL>, tensor<16x16xf16, #AL>) {
+  %zeros = arith.constant dense<0.0> : tensor<16x16xf16, #AL>
+  %ones = arith.constant dense<1.0> : tensor<16x16xf16, #AL>
+  // expected-remark @below {{offset = 0, size = 512}}
+  %a = ttg.local_alloc %zeros : (tensor<16x16xf16, #AL>) -> !ttg.memdesc<16x16xf16, #A_SHARED, #smem, mutable>
+  // The call forwards %a without allocating a new buffer.
+  %returned = tt.call @returned_alias_identity(%a) : (!ttg.memdesc<16x16xf16, #A_SHARED, #smem, mutable>) -> !ttg.memdesc<16x16xf16, #A_SHARED, #smem, mutable>
+  // expected-remark @below {{offset = 512, size = 512}}
+  %b = ttg.local_alloc %ones : (tensor<16x16xf16, #AL>) -> !ttg.memdesc<16x16xf16, #A_SHARED, #smem, mutable>
+  %a_value = ttg.local_load %returned : !ttg.memdesc<16x16xf16, #A_SHARED, #smem, mutable> -> tensor<16x16xf16, #AL>
+  %b_value = ttg.local_load %b : !ttg.memdesc<16x16xf16, #A_SHARED, #smem, mutable> -> tensor<16x16xf16, #AL>
+  tt.return %a_value, %b_value : tensor<16x16xf16, #AL>, tensor<16x16xf16, #AL>
+}
+
+// expected-remark @below {{returned_alias_nested}}
+// expected-remark @below {{size = 1024}}
+tt.func @returned_alias_nested() -> (tensor<16x16xf16, #AL>, tensor<16x16xf16, #AL>) {
+  %zeros = arith.constant dense<0.0> : tensor<16x16xf16, #AL>
+  %ones = arith.constant dense<1.0> : tensor<16x16xf16, #AL>
+  // expected-remark @below {{offset = 0, size = 512}}
+  %a = ttg.local_alloc %zeros : (tensor<16x16xf16, #AL>) -> !ttg.memdesc<16x16xf16, #A_SHARED, #smem, mutable>
+  // The call forwards %a without allocating a new buffer.
+  %returned = tt.call @returned_alias_forward(%a) : (!ttg.memdesc<16x16xf16, #A_SHARED, #smem, mutable>) -> !ttg.memdesc<16x16xf16, #A_SHARED, #smem, mutable>
+  // expected-remark @below {{offset = 512, size = 512}}
+  %b = ttg.local_alloc %ones : (tensor<16x16xf16, #AL>) -> !ttg.memdesc<16x16xf16, #A_SHARED, #smem, mutable>
+  %a_value = ttg.local_load %returned : !ttg.memdesc<16x16xf16, #A_SHARED, #smem, mutable> -> tensor<16x16xf16, #AL>
+  %b_value = ttg.local_load %b : !ttg.memdesc<16x16xf16, #A_SHARED, #smem, mutable> -> tensor<16x16xf16, #AL>
+  tt.return %a_value, %b_value : tensor<16x16xf16, #AL>, tensor<16x16xf16, #AL>
+}
+
+// expected-remark @below {{returned_alias_choose}}
+// expected-remark @below {{size = 0}}
+tt.func private @returned_alias_choose(%a: !ttg.memdesc<16x16xf16, #A_SHARED, #smem, mutable>, %b: !ttg.memdesc<16x16xf16, #A_SHARED, #smem, mutable>, %take_first: i1) -> !ttg.memdesc<16x16xf16, #A_SHARED, #smem, mutable> {
+  cf.cond_br %take_first, ^first, ^second
+^first:
+  tt.return %a : !ttg.memdesc<16x16xf16, #A_SHARED, #smem, mutable>
+^second:
+  tt.return %b : !ttg.memdesc<16x16xf16, #A_SHARED, #smem, mutable>
+}
+
+// Either returned root must remain live across the third allocation.
+// expected-remark @below {{returned_alias_branch}}
+// expected-remark @below {{size = 1536}}
+tt.func @returned_alias_branch(%take_first: i1) -> (tensor<16x16xf16, #AL>, tensor<16x16xf16, #AL>) {
+  %zeros = arith.constant dense<0.0> : tensor<16x16xf16, #AL>
+  %ones = arith.constant dense<1.0> : tensor<16x16xf16, #AL>
+  %twos = arith.constant dense<2.0> : tensor<16x16xf16, #AL>
+  // expected-remark @below {{offset = 0, size = 512}}
+  %a = ttg.local_alloc %zeros : (tensor<16x16xf16, #AL>) -> !ttg.memdesc<16x16xf16, #A_SHARED, #smem, mutable>
+  // expected-remark @below {{offset = 512, size = 512}}
+  %b = ttg.local_alloc %ones : (tensor<16x16xf16, #AL>) -> !ttg.memdesc<16x16xf16, #A_SHARED, #smem, mutable>
+  %returned = tt.call @returned_alias_choose(%a, %b, %take_first) : (!ttg.memdesc<16x16xf16, #A_SHARED, #smem, mutable>, !ttg.memdesc<16x16xf16, #A_SHARED, #smem, mutable>, i1) -> !ttg.memdesc<16x16xf16, #A_SHARED, #smem, mutable>
+  // expected-remark @below {{offset = 1024, size = 512}}
+  %third = ttg.local_alloc %twos : (tensor<16x16xf16, #AL>) -> !ttg.memdesc<16x16xf16, #A_SHARED, #smem, mutable>
+  %selected_value = ttg.local_load %returned : !ttg.memdesc<16x16xf16, #A_SHARED, #smem, mutable> -> tensor<16x16xf16, #AL>
+  %third_value = ttg.local_load %third : !ttg.memdesc<16x16xf16, #A_SHARED, #smem, mutable> -> tensor<16x16xf16, #AL>
+  tt.return %selected_value, %third_value : tensor<16x16xf16, #AL>, tensor<16x16xf16, #AL>
+}
+
+
 }

--- a/test/Analysis/test-buffer-region-layout-alias.mlir
+++ b/test/Analysis/test-buffer-region-layout-alias.mlir
@@ -470,6 +470,9 @@ module attributes {"ttg.num-ctas" = 2 : i32, "ttg.num-warps" = 1 : i32, ttg.shar
 
 // Peer-CTA views can share local byte offsets while selecting different
 // recipient CTAs. Runtime selection must preserve both candidates.
+// A replicated root covers both CTAs and is physically identical to the
+// sharded parent, including its CTA1 slice.
+#replicated = #ttg.swizzled_shared<{vec = 1, perPhase = 1, maxPhase = 1, order = [1, 0], CGALayout = [[0, 0]]}>
 #shared = #ttg.swizzled_shared<{vec = 1, perPhase = 1, maxPhase = 1, order = [1, 0], CGALayout = [[1, 0]]}>
 #blocked_sharded = #ttg.blocked<{sizePerThread = [1, 1], threadsPerWarp = [1, 32], warpsPerCTA = [1, 4], order = [1, 0], CGALayout = [[1, 0]]}>
 #smem = #ttg.shared_memory
@@ -479,12 +482,16 @@ module attributes {"ttg.num-ctas" = 2 : i32, "ttg.num-warps" = 1 : i32, ttg.shar
 // CHECK: cta_affine_a_parent vs cta_affine_c_remote: alias=true
 // CHECK: cta_affine_a_parent vs cta_affine_d_disjoint: alias=false
 // CHECK: cta_affine_a_parent vs cta_affine_e_selected: alias=true
+// CHECK: cta_affine_a_parent vs cta_affine_f_replicated: alias=true, lhs_contains_rhs=true, rhs_contains_lhs=true
+// CHECK: cta_affine_b_local vs cta_affine_c_remote: alias=false
 // CHECK: cta_affine_b_local vs cta_affine_d_disjoint: alias=false
 // CHECK: cta_affine_c_remote vs cta_affine_d_disjoint: alias=false
+// CHECK: cta_affine_c_remote vs cta_affine_f_replicated: alias=true
 // CHECK: cta_affine_d_disjoint vs cta_affine_e_selected: alias=false
 module attributes {"ttg.num-ctas" = 2 : i32, "ttg.num-warps" = 4 : i32, ttg.shared = 1024 : i32, ttg.target = "cuda:90", ttg.tensor_memory_size = 0 : i32, "ttg.threads-per-warp" = 32 : i32, "ttg.total-num-warps" = 4 : i32} {
   tt.func public @cross_cta_affine_physical_alias(%choose: i1) {
-    %parent = ttg.local_alloc {allocation.offset = 0 : i32} : () -> !ttg.memdesc<4x32xi32, #shared, #smem, mutable>
+    %replica = ttg.local_alloc {allocation.offset = 0 : i32, test.region_name = "cta_affine_f_replicated"} : () -> !ttg.memdesc<2x32xi32, #replicated, #smem, mutable>
+    %parent = ttg.memdesc_reinterpret %replica : !ttg.memdesc<2x32xi32, #replicated, #smem, mutable> -> !ttg.memdesc<4x32xi32, #shared, #smem, mutable>
     %local = ttg.memdesc_subslice %parent [0, 0] : !ttg.memdesc<4x32xi32, #shared, #smem, mutable> -> !ttg.memdesc<2x32xi32, #shared, #smem, mutable, 4x32>
     %remote = ttg.memdesc_subslice %parent [2, 0] : !ttg.memdesc<4x32xi32, #shared, #smem, mutable> -> !ttg.memdesc<2x32xi32, #shared, #smem, mutable, 4x32>
     %selected = arith.select %choose, %local, %remote : !ttg.memdesc<2x32xi32, #shared, #smem, mutable, 4x32>
@@ -500,13 +507,14 @@ module attributes {"ttg.num-ctas" = 2 : i32, "ttg.num-warps" = 4 : i32, ttg.shar
 
 // -----
 
-// Callee allocations are relative to their own frame. Incoming descriptors
-// remain disjoint from callee-local storage across direct and indirect callers.
+// Callee allocations are relative to their own frame. A physical overlap query
+// cannot compare them with incoming caller-frame descriptors before their
+// origins are normalized, even when the program's buffers are disjoint.
 #shared = #ttg.swizzled_shared<{vec = 1, perPhase = 1, maxPhase = 1, order = [0]}>
 #smem = #ttg.shared_memory
 
 // CHECK-LABEL: frame_a_argument vs frame_a_argument: alias=true
-// CHECK: frame_a_argument vs frame_b_local: alias=false
+// CHECK: frame_a_argument vs frame_b_local: alias=true, lhs_contains_rhs=false, rhs_contains_lhs=false
 // CHECK: frame_b_local vs frame_b_local: alias=true
 module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 1 : i32, ttg.shared = 256 : i32, ttg.target = "cuda:90", ttg.tensor_memory_size = 0 : i32, "ttg.threads-per-warp" = 32 : i32, "ttg.total-num-warps" = 1 : i32} {
   tt.func private @callee_local_is_disjoint_from_argument(
@@ -541,13 +549,14 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 1 : i32, ttg.shar
 // -----
 
 // A descriptor returned through a callee retains its caller allocation frame.
+// Its physical offsets cannot be compared with the callee-local frame yet.
 #shared = #ttg.swizzled_shared<{vec = 1, perPhase = 1, maxPhase = 1, order = [0]}>
 #smem = #ttg.shared_memory
 
 // CHECK-LABEL: return_frame_a_direct vs return_frame_a_direct: alias=true
 // CHECK: return_frame_a_direct vs return_frame_a_returned: alias=true, lhs_contains_rhs=true, rhs_contains_lhs=true
-// CHECK: return_frame_a_direct vs return_frame_b_local: alias=false
-// CHECK: return_frame_a_returned vs return_frame_b_local: alias=false
+// CHECK: return_frame_a_direct vs return_frame_b_local: alias=true, lhs_contains_rhs=false, rhs_contains_lhs=false
+// CHECK: return_frame_a_returned vs return_frame_b_local: alias=true, lhs_contains_rhs=false, rhs_contains_lhs=false
 module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 1 : i32, ttg.shared = 64 : i32, ttg.target = "cuda:90", ttg.tensor_memory_size = 0 : i32, "ttg.threads-per-warp" = 32 : i32, "ttg.total-num-warps" = 1 : i32} {
   tt.func private @return_argument(
       %incoming: !ttg.memdesc<16xi32, #shared, #smem, mutable>)
@@ -780,6 +789,48 @@ module attributes {test.print_state_plan, "ttg.num-ctas" = 2 : i32, "ttg.num-war
     %remote = ttg.memdesc_subslice %parent [2, 0] : !ttg.memdesc<4x32xi32, #shared, #smem, mutable> -> !ttg.memdesc<2x32xi32, #shared, #smem, mutable, 4x32>
     %0 = ttg.local_load %local {test.region_name = "cta_state_a_local"} : !ttg.memdesc<2x32xi32, #shared, #smem, mutable, 4x32> -> tensor<2x32xi32, #blocked>
     %1 = ttg.local_load %remote {test.region_name = "cta_state_b_remote"} : !ttg.memdesc<2x32xi32, #shared, #smem, mutable, 4x32> -> tensor<2x32xi32, #blocked>
+    tt.return
+  }
+}
+
+// -----
+
+// Scale elements are broadcast into all four warp-addressable TMEM blocks.
+// The complete footprint equals two full columns of 32-bit words, not just
+// the representative rows chosen by the layout's pseudoinverse.
+// The scales are replicated across CTAs too; sharding the word view must not
+// change its physical coverage.
+#scales = #ttng.tensor_memory_scales_encoding<CGALayout = [[0, 0]]>
+#tmem = #ttng.tensor_memory_encoding<blockM = 128, blockN = 128, colStride = 1, CGALayout = [[1, 0]]>
+
+// CHECK-LABEL: broadcast_a_scales vs broadcast_a_scales: alias=true
+// CHECK: broadcast_a_scales vs broadcast_b_words: alias=true, lhs_contains_rhs=true, rhs_contains_lhs=true
+// CHECK: broadcast_a_scales vs broadcast_c_disjoint: alias=false
+// CHECK: broadcast_b_words vs broadcast_c_disjoint: alias=false
+module attributes {"ttg.num-ctas" = 2 : i32, "ttg.num-warps" = 4 : i32, ttg.target = "cuda:100", ttg.tensor_memory_size = 8 : i32, "ttg.threads-per-warp" = 32 : i32} {
+  tt.func public @tmem_broadcast_rows_are_physical_replicas() {
+    %scales = ttng.tmem_alloc {tensor_memory_col_offset = 0 : i32, tensor_memory_row_offset = 0 : i32, test.region_name = "broadcast_a_scales"} : () -> !ttg.memdesc<64x4xi8, #scales, #ttng.tensor_memory, mutable>
+    %words = ttng.tmem_alloc {tensor_memory_col_offset = 0 : i32, tensor_memory_row_offset = 0 : i32, test.region_name = "broadcast_b_words"} : () -> !ttg.memdesc<256x2xi32, #tmem, #ttng.tensor_memory, mutable>
+    %disjoint = ttng.tmem_alloc {tensor_memory_col_offset = 4 : i32, tensor_memory_row_offset = 0 : i32, test.region_name = "broadcast_c_disjoint"} : () -> !ttg.memdesc<256x2xi32, #tmem, #ttng.tensor_memory, mutable>
+    tt.return
+  }
+}
+
+// -----
+
+// Shared bytes and TMEM words are different address spaces, even when their
+// numerical addresses coincide.
+#shared = #ttg.swizzled_shared<{vec = 1, perPhase = 1, maxPhase = 1, order = [0]}>
+#tmem = #ttng.tensor_memory_encoding<blockM = 128, blockN = 128, colStride = 1>
+#smem = #ttg.shared_memory
+
+// CHECK-LABEL: spaces_a_shared vs spaces_a_shared: alias=true
+// CHECK: spaces_a_shared vs spaces_b_tensor: alias=false, lhs_contains_rhs=false, rhs_contains_lhs=false
+// CHECK: spaces_b_tensor vs spaces_b_tensor: alias=true
+module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.shared = 512 : i32, ttg.target = "cuda:100", ttg.tensor_memory_size = 128 : i32, "ttg.threads-per-warp" = 32 : i32} {
+  tt.func public @different_memory_spaces_do_not_alias() {
+    %shared = ttg.local_alloc {allocation.offset = 0 : i32, test.region_name = "spaces_a_shared"} : () -> !ttg.memdesc<128xi32, #shared, #smem, mutable>
+    %tensor = ttng.tmem_alloc {tensor_memory_col_offset = 0 : i32, tensor_memory_row_offset = 0 : i32, test.region_name = "spaces_b_tensor"} : () -> !ttg.memdesc<128x1xf32, #tmem, #ttng.tensor_memory, mutable>
     tt.return
   }
 }

--- a/test/Analysis/test-membar.mlir
+++ b/test/Analysis/test-membar.mlir
@@ -2022,6 +2022,29 @@ tt.func @must_barrier_nonzero_wrap_arm(%cst: tensor<128x128xf16>, %phase: i32) {
 
 module attributes {"ttg.num-warps" = 4 : i32, "ttg.threads-per-warp" = 32 : i32, "ttg.num-ctas" = 1 : i32} {
 
+// Argument descriptors have no allocation IDs. Different slots are disjoint
+// only when their indexed source is the same.
+// CHECK-LABEL: @shared_argument_buffer_indices
+tt.func @shared_argument_buffer_indices(%first: !ttg.memdesc<2x128xi32, #shared, #smem, mutable>, %second: !ttg.memdesc<2x128xi32, #shared, #smem, mutable>) -> (tensor<128xi32, #reader>, tensor<128xi32, #reader>) {
+  %c0 = arith.constant 0 : i32
+  %c1 = arith.constant 1 : i32
+  %input = arith.constant dense<1> : tensor<128xi32, #writer>
+  %first0 = ttg.memdesc_index %first[%c0] : !ttg.memdesc<2x128xi32, #shared, #smem, mutable> -> !ttg.memdesc<128xi32, #shared, #smem, mutable>
+  %first1 = ttg.memdesc_index %first[%c1] : !ttg.memdesc<2x128xi32, #shared, #smem, mutable> -> !ttg.memdesc<128xi32, #shared, #smem, mutable>
+  %second1 = ttg.memdesc_index %second[%c1] : !ttg.memdesc<2x128xi32, #shared, #smem, mutable> -> !ttg.memdesc<128xi32, #shared, #smem, mutable>
+  // CHECK: ttg.local_store
+  // CHECK-NEXT: {{.*}} = ttg.local_load
+  // CHECK-NEXT: ttg.barrier local{{$}}
+  // CHECK-NEXT: {{.*}} = ttg.local_load
+  // CHECK-NEXT: ttg.barrier local{{$}}
+  // CHECK-NEXT: ttg.local_store
+  ttg.local_store %input, %first0 : tensor<128xi32, #writer> -> !ttg.memdesc<128xi32, #shared, #smem, mutable>
+  %disjoint = ttg.local_load %first1 : !ttg.memdesc<128xi32, #shared, #smem, mutable> -> tensor<128xi32, #reader>
+  %overlapping = ttg.local_load %first0 : !ttg.memdesc<128xi32, #shared, #smem, mutable> -> tensor<128xi32, #reader>
+  ttg.local_store %input, %second1 : tensor<128xi32, #writer> -> !ttg.memdesc<128xi32, #shared, #smem, mutable>
+  tt.return %disjoint, %overlapping : tensor<128xi32, #reader>, tensor<128xi32, #reader>
+}
+
 // Different constant indices can name the same slot when their indexed
 // sources have different origins: allocation[1] equals prefix[0].
 // CHECK-LABEL: @shared_buffer_index_shifted_source

--- a/test/Analysis/test-membar.mlir
+++ b/test/Analysis/test-membar.mlir
@@ -2217,12 +2217,11 @@ tt.func @shared_async_disjoint_footprints(%input: tensor<128xi32, #writer>, %ptr
   tt.return %output : tensor<128xi32, #reader>
 }
 
-// An immediate common source supplies relative coordinates even when it is
-// itself a subslice. A private function keeps physical-footprint refinement
-// disabled, so both the disjoint and overlapping cases use that relative proof.
+// Caller-owned descriptors have unknown footprints in the callee's frame.
+// Nested subslices still share relative coordinates; only the overlapping
+// load needs a barrier.
 // CHECK-LABEL: @nested_subslices_same_source
-tt.func private @nested_subslices_same_source(%initial: tensor<512xi32, #writer>, %input: tensor<128xi32, #writer>) -> (tensor<128xi32, #reader>, tensor<128xi32, #reader>) {
-  %allocation = ttg.local_alloc %initial : (tensor<512xi32, #writer>) -> !ttg.memdesc<512xi32, #shared, #smem, mutable>
+tt.func private @nested_subslices_same_source(%allocation: !ttg.memdesc<512xi32, #shared, #smem, mutable>, %input: tensor<128xi32, #writer>) -> (tensor<128xi32, #reader>, tensor<128xi32, #reader>) attributes {noinline = true} {
   %source = ttg.memdesc_subslice %allocation [0] : !ttg.memdesc<512xi32, #shared, #smem, mutable> -> !ttg.memdesc<256xi32, #shared, #smem, mutable, 512>
   %low = ttg.memdesc_subslice %source [0] : !ttg.memdesc<256xi32, #shared, #smem, mutable, 512> -> !ttg.memdesc<128xi32, #shared, #smem, mutable, 512>
   %high = ttg.memdesc_subslice %source [128] : !ttg.memdesc<256xi32, #shared, #smem, mutable, 512> -> !ttg.memdesc<128xi32, #shared, #smem, mutable, 512>
@@ -2234,6 +2233,12 @@ tt.func private @nested_subslices_same_source(%initial: tensor<512xi32, #writer>
   ttg.local_store %input, %low : tensor<128xi32, #writer> -> !ttg.memdesc<128xi32, #shared, #smem, mutable, 512>
   %disjoint = ttg.local_load %high : !ttg.memdesc<128xi32, #shared, #smem, mutable, 512> -> tensor<128xi32, #reader>
   %overlapping = ttg.local_load %low : !ttg.memdesc<128xi32, #shared, #smem, mutable, 512> -> tensor<128xi32, #reader>
+  tt.return %disjoint, %overlapping : tensor<128xi32, #reader>, tensor<128xi32, #reader>
+}
+
+tt.func @call_nested_subslices_same_source(%initial: tensor<512xi32, #writer>, %input: tensor<128xi32, #writer>) -> (tensor<128xi32, #reader>, tensor<128xi32, #reader>) {
+  %allocation = ttg.local_alloc %initial : (tensor<512xi32, #writer>) -> !ttg.memdesc<512xi32, #shared, #smem, mutable>
+  %disjoint, %overlapping = tt.call @nested_subslices_same_source(%allocation, %input) : (!ttg.memdesc<512xi32, #shared, #smem, mutable>, tensor<128xi32, #writer>) -> (tensor<128xi32, #reader>, tensor<128xi32, #reader>)
   tt.return %disjoint, %overlapping : tensor<128xi32, #reader>, tensor<128xi32, #reader>
 }
 
@@ -2269,6 +2274,92 @@ tt.func @shared_pointer_storage(%input: tensor<128x!tt.ptr<i32>, #writer>) -> te
   tt.return %output : tensor<128x!tt.ptr<i32>, #reader>
 }
 
+tt.func private @read_first_call_slot(%input: tensor<128xi32, #writer>) -> tensor<128xi32, #reader> {
+  %c0 = arith.constant 0 : i32
+  %allocation = ttg.local_alloc : () -> !ttg.memdesc<2x128xi32, #shared, #smem, mutable>
+  %first = ttg.memdesc_index %allocation[%c0] : !ttg.memdesc<2x128xi32, #shared, #smem, mutable> -> !ttg.memdesc<128xi32, #shared, #smem, mutable>
+  ttg.local_store %input, %first : tensor<128xi32, #writer> -> !ttg.memdesc<128xi32, #shared, #smem, mutable>
+  %output = ttg.local_load %first : !ttg.memdesc<128xi32, #shared, #smem, mutable> -> tensor<128xi32, #reader>
+  tt.return %output : tensor<128xi32, #reader>
+}
+
+// The live buffer forces a nonzero call frame. Reused storage in the second
+// slot is disjoint from both the callee's entry write and its pending read.
+// CHECK-LABEL: @call_footprints_preserve_slots
+tt.func @call_footprints_preserve_slots(%input: tensor<128xi32, #writer>) -> (tensor<128xi32, #reader>, tensor<1024xi32, #writer>) {
+  %c0 = arith.constant 0 : i32
+  %c1 = arith.constant 1 : i32
+  %zeros = arith.constant dense<0> : tensor<1024xi32, #writer>
+  %live = ttg.local_alloc %zeros : (tensor<1024xi32, #writer>) -> !ttg.memdesc<1024xi32, #shared, #smem, mutable>
+  %before = ttg.local_alloc : () -> !ttg.memdesc<2x128xi32, #shared, #smem, mutable>
+  %before_second = ttg.memdesc_index %before[%c1] : !ttg.memdesc<2x128xi32, #shared, #smem, mutable> -> !ttg.memdesc<128xi32, #shared, #smem, mutable>
+  // CHECK: ttg.local_store
+  // CHECK-NEXT: ttg.local_dealloc
+  // CHECK-NEXT: {{.*}} = tt.call @read_first_call_slot{{.*}}allocation.offset = [[FRAME:[1-9][0-9]*]]
+  ttg.local_store %input, %before_second : tensor<128xi32, #writer> -> !ttg.memdesc<128xi32, #shared, #smem, mutable>
+  ttg.local_dealloc %before : !ttg.memdesc<2x128xi32, #shared, #smem, mutable>
+  %output = tt.call @read_first_call_slot(%input) : (tensor<128xi32, #writer>) -> tensor<128xi32, #reader>
+  // CHECK-NEXT: {{.*}} = ttg.local_alloc {allocation.offset = [[FRAME]]
+  %after = ttg.local_alloc : () -> !ttg.memdesc<2x128xi32, #shared, #smem, mutable>
+  %after_first = ttg.memdesc_index %after[%c0] : !ttg.memdesc<2x128xi32, #shared, #smem, mutable> -> !ttg.memdesc<128xi32, #shared, #smem, mutable>
+  %after_second = ttg.memdesc_index %after[%c1] : !ttg.memdesc<2x128xi32, #shared, #smem, mutable> -> !ttg.memdesc<128xi32, #shared, #smem, mutable>
+  // CHECK: ttg.memdesc_index
+  // CHECK-NEXT: {{.*}} = ttg.memdesc_index
+  // CHECK-NEXT: ttg.local_store
+  // CHECK-NEXT: ttg.barrier local
+  // CHECK-NEXT: ttg.local_store
+  ttg.local_store %input, %after_second : tensor<128xi32, #writer> -> !ttg.memdesc<128xi32, #shared, #smem, mutable>
+  ttg.local_store %input, %after_first : tensor<128xi32, #writer> -> !ttg.memdesc<128xi32, #shared, #smem, mutable>
+  %kept = ttg.local_load %live : !ttg.memdesc<1024xi32, #shared, #smem, mutable> -> tensor<1024xi32, #writer>
+  tt.return %output, %kept : tensor<128xi32, #reader>, tensor<1024xi32, #writer>
+}
+
+tt.func private @return_shared_argument(%value: !ttg.memdesc<128xi32, #shared, #smem, mutable>) -> !ttg.memdesc<128xi32, #shared, #smem, mutable> {
+  tt.return %value : !ttg.memdesc<128xi32, #shared, #smem, mutable>
+}
+
+// The selected descriptor retains both origins even when one returns through
+// a call that the function-local allocation alias analysis cannot follow.
+// CHECK-LABEL: @returned_origin_in_selected_access
+tt.func @returned_origin_in_selected_access(%condition: i1, %input: tensor<128xi32, #writer>) -> tensor<128xi32, #reader> {
+  %first = ttg.local_alloc %input : (tensor<128xi32, #writer>) -> !ttg.memdesc<128xi32, #shared, #smem, mutable>
+  %second = ttg.local_alloc %input : (tensor<128xi32, #writer>) -> !ttg.memdesc<128xi32, #shared, #smem, mutable>
+  %returned = tt.call @return_shared_argument(%second) : (!ttg.memdesc<128xi32, #shared, #smem, mutable>) -> !ttg.memdesc<128xi32, #shared, #smem, mutable>
+  %selected = arith.select %condition, %first, %returned : !ttg.memdesc<128xi32, #shared, #smem, mutable>
+  ttg.barrier local
+  // CHECK: ttg.local_store
+  // CHECK-NEXT: ttg.barrier local
+  // CHECK-NEXT: {{.*}} = ttg.local_load
+  ttg.local_store %input, %selected : tensor<128xi32, #writer> -> !ttg.memdesc<128xi32, #shared, #smem, mutable>
+  %output = ttg.local_load %second : !ttg.memdesc<128xi32, #shared, #smem, mutable> -> tensor<128xi32, #reader>
+  tt.return %output : tensor<128xi32, #reader>
+}
+
+tt.func private @write_local_or_argument(%condition: i1, %input: tensor<128xi32, #writer>, %incoming: !ttg.memdesc<128xi32, #shared, #smem, mutable>) {
+  %local = ttg.local_alloc : () -> !ttg.memdesc<128xi32, #shared, #smem, mutable>
+  %selected = arith.select %condition, %local, %incoming : !ttg.memdesc<128xi32, #shared, #smem, mutable>
+  ttg.local_store %input, %selected : tensor<128xi32, #writer> -> !ttg.memdesc<128xi32, #shared, #smem, mutable>
+  tt.return
+}
+
+// A partial local-ID set must not drop the argument access. Its unknown range
+// remains unbounded when imported at the nonzero call offset.
+// CHECK-LABEL: @call_with_mixed_allocation_frames
+tt.func @call_with_mixed_allocation_frames(%condition: i1, %input: tensor<128xi32, #writer>) -> tensor<128xi32, #reader> {
+  %c0 = arith.constant 0 : i32
+  %allocation = ttg.local_alloc : () -> !ttg.memdesc<8x128xi32, #shared, #smem, mutable>
+  %incoming = ttg.memdesc_index %allocation[%c0] : !ttg.memdesc<8x128xi32, #shared, #smem, mutable> -> !ttg.memdesc<128xi32, #shared, #smem, mutable>
+  // CHECK: ttg.local_store
+  // CHECK-NEXT: ttg.barrier local
+  // CHECK-NEXT: tt.call @write_local_or_argument{{.*}}allocation.offset = {{[1-9][0-9]*}}
+  // CHECK-NEXT: ttg.barrier local
+  // CHECK-NEXT: {{.*}} = ttg.local_load
+  ttg.local_store %input, %incoming : tensor<128xi32, #writer> -> !ttg.memdesc<128xi32, #shared, #smem, mutable>
+  tt.call @write_local_or_argument(%condition, %input, %incoming) : (i1, tensor<128xi32, #writer>, !ttg.memdesc<128xi32, #shared, #smem, mutable>) -> ()
+  %output = ttg.local_load %incoming : !ttg.memdesc<128xi32, #shared, #smem, mutable> -> tensor<128xi32, #reader>
+  tt.return %output : tensor<128xi32, #reader>
+}
+
 }
 
 // -----
@@ -2278,10 +2369,10 @@ tt.func @shared_pointer_storage(%input: tensor<128x!tt.ptr<i32>, #writer>) -> te
 #smem = #ttg.shared_memory
 
 module attributes {"ttg.num-warps" = 4 : i32, "ttg.num-ctas" = 1 : i32} {
-// Block arguments hide the immediate subslices. Physical footprints still
-// distinguish the padded partitions and retain the overlapping dependency.
+// Block arguments hide the immediate subslices. Device-function footprints
+// still distinguish padded partitions and retain the overlapping dependency.
 // CHECK-LABEL: @shared_partitioned_padded_footprints
-tt.func @shared_partitioned_padded_footprints(%initial: tensor<8x16xf16>, %input: tensor<4x16xf16>) -> (tensor<4x16xf16>, tensor<4x16xf16>) {
+tt.func private @shared_partitioned_padded_footprints(%initial: tensor<8x16xf16>, %input: tensor<4x16xf16>) -> (tensor<4x16xf16>, tensor<4x16xf16>) {
   %allocation = ttg.local_alloc %initial : (tensor<8x16xf16>) -> !ttg.memdesc<8x16xf16, #shared, #smem, mutable>
   %first = ttg.memdesc_subslice %allocation [0, 0] : !ttg.memdesc<8x16xf16, #shared, #smem, mutable> -> !ttg.memdesc<4x16xf16, #shared, #smem, mutable, 8x16>
   %second = ttg.memdesc_subslice %allocation [4, 0] : !ttg.memdesc<8x16xf16, #shared, #smem, mutable> -> !ttg.memdesc<4x16xf16, #shared, #smem, mutable, 8x16>
@@ -2296,5 +2387,10 @@ tt.func @shared_partitioned_padded_footprints(%initial: tensor<8x16xf16>, %input
   %disjoint = ttg.local_load %right : !ttg.memdesc<4x16xf16, #shared, #smem, mutable, 8x16> -> tensor<4x16xf16>
   %overlapping = ttg.local_load %left : !ttg.memdesc<4x16xf16, #shared, #smem, mutable, 8x16> -> tensor<4x16xf16>
   tt.return %disjoint, %overlapping : tensor<4x16xf16>, tensor<4x16xf16>
+}
+
+tt.func @call_partitioned_padded_footprints(%initial: tensor<8x16xf16>, %input: tensor<4x16xf16>) -> (tensor<4x16xf16>, tensor<4x16xf16>) {
+  %result:2 = tt.call @shared_partitioned_padded_footprints(%initial, %input) : (tensor<8x16xf16>, tensor<4x16xf16>) -> (tensor<4x16xf16>, tensor<4x16xf16>)
+  tt.return %result#0, %result#1 : tensor<4x16xf16>, tensor<4x16xf16>
 }
 }

--- a/test/Analysis/test-membar.mlir
+++ b/test/Analysis/test-membar.mlir
@@ -2087,6 +2087,7 @@ tt.func @shared_subslice_shifted_source(%input: tensor<64xi32, #writer>) -> tens
 #writer = #ttg.blocked<{sizePerThread = [1], threadsPerWarp = [32], warpsPerCTA = [4], order = [0], CGALayout = [[0]]}>
 #reader = #ttg.linear<{register = [], lane = [[1], [2], [4], [8], [16]], warp = [[64], [32]], block = [[0]]}>
 #shared = #ttg.swizzled_shared<{vec = 1, perPhase = 1, maxPhase = 1, order = [0], CGALayout = [[0]]}>
+#split = #ttg.swizzled_shared<{vec = 1, perPhase = 1, maxPhase = 1, order = [0], CGALayout = [[1]]}>
 #smem = #ttg.shared_memory
 
 module attributes {"ttg.num-warps" = 4 : i32, "ttg.threads-per-warp" = 32 : i32, "ttg.num-ctas" = 2 : i32} {
@@ -2233,6 +2234,26 @@ tt.func private @nested_subslices_same_source(%initial: tensor<512xi32, #writer>
   ttg.local_store %input, %low : tensor<128xi32, #writer> -> !ttg.memdesc<128xi32, #shared, #smem, mutable, 512>
   %disjoint = ttg.local_load %high : !ttg.memdesc<128xi32, #shared, #smem, mutable, 512> -> tensor<128xi32, #reader>
   %overlapping = ttg.local_load %low : !ttg.memdesc<128xi32, #shared, #smem, mutable, 512> -> tensor<128xi32, #reader>
+  tt.return %disjoint, %overlapping : tensor<128xi32, #reader>, tensor<128xi32, #reader>
+}
+
+// Block arguments hide the immediate subslices. Equal offsets in different
+// physical CTAs remain disjoint; an overlapping access still needs a barrier.
+// CHECK-LABEL: @shared_distinct_cta_footprints
+tt.func @shared_distinct_cta_footprints(%initial: tensor<256xi32, #writer>, %input: tensor<128xi32, #writer>) -> (tensor<128xi32, #reader>, tensor<128xi32, #reader>) {
+  %allocation = ttg.local_alloc %initial : (tensor<256xi32, #writer>) -> !ttg.memdesc<256xi32, #split, #smem, mutable>
+  %first = ttg.memdesc_subslice %allocation [0] : !ttg.memdesc<256xi32, #split, #smem, mutable> -> !ttg.memdesc<128xi32, #split, #smem, mutable, 256>
+  %second = ttg.memdesc_subslice %allocation [128] : !ttg.memdesc<256xi32, #split, #smem, mutable> -> !ttg.memdesc<128xi32, #split, #smem, mutable, 256>
+  ttng.cluster_barrier
+  cf.br ^access(%first, %second : !ttg.memdesc<128xi32, #split, #smem, mutable, 256>, !ttg.memdesc<128xi32, #split, #smem, mutable, 256>)
+^access(%left: !ttg.memdesc<128xi32, #split, #smem, mutable, 256>, %right: !ttg.memdesc<128xi32, #split, #smem, mutable, 256>):
+  // CHECK: ttg.local_store
+  // CHECK-NEXT: {{.*}} = ttg.local_load
+  // CHECK-NEXT: ttg.barrier local
+  // CHECK-NEXT: {{.*}} = ttg.local_load
+  ttg.local_store %input, %left : tensor<128xi32, #writer> -> !ttg.memdesc<128xi32, #split, #smem, mutable, 256>
+  %disjoint = ttg.local_load %right : !ttg.memdesc<128xi32, #split, #smem, mutable, 256> -> tensor<128xi32, #reader>
+  %overlapping = ttg.local_load %left : !ttg.memdesc<128xi32, #split, #smem, mutable, 256> -> tensor<128xi32, #reader>
   tt.return %disjoint, %overlapping : tensor<128xi32, #reader>, tensor<128xi32, #reader>
 }
 

--- a/test/TritonGPU/proxy_fence_insertion.mlir
+++ b/test/TritonGPU/proxy_fence_insertion.mlir
@@ -335,17 +335,14 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32} {
 // -----
 
 #src = #ttg.blocked<{sizePerThread = [1, 1], threadsPerWarp = [1, 32], warpsPerCTA = [1, 4], order = [1, 0], CGALayout = [[1, 0]]}>
-#dst = #ttg.blocked<{sizePerThread = [1, 1], threadsPerWarp = [32, 1], warpsPerCTA = [4, 1], order = [0, 1], CGALayout = [[0, 1]]}>
 #local = #ttg.blocked<{sizePerThread = [1, 1], threadsPerWarp = [32, 1], warpsPerCTA = [4, 1], order = [0, 1], CGALayout = [[1, 0]]}>
-#reduce = #ttg.blocked<{sizePerThread = [1, 32], threadsPerWarp = [8, 4], warpsPerCTA = [4, 1], order = [0, 1], CGALayout = [[0, 1]]}>
-#reduce_result = #ttg.slice<{dim = 1, parent = #reduce}>
 #replicated = #ttg.blocked<{sizePerThread = [1, 1], threadsPerWarp = [1, 32], warpsPerCTA = [1, 4], order = [1, 0], CGALayout = [[0, 0]]}>
 #shared = #ttg.nvmma_shared<{swizzlingByteWidth = 128, transposed = false, elementBitWidth = 32, CGALayout = [[1, 0]]}>
 #barrier = #ttg.swizzled_shared<{vec = 1, perPhase = 1, maxPhase = 1, order = [0], CGALayout = [[0]]}>
 #smem = #ttg.shared_memory
 module attributes {"ttg.num-ctas" = 2 : i32, "ttg.num-warps" = 4 : i32, ttg.target = "cuda:90", "ttg.threads-per-warp" = 32 : i32} {
-  // CHECK-LABEL: cta_local_scratch_does_not_alias_remote_cta
-  tt.func @cta_local_scratch_does_not_alias_remote_cta(
+  // CHECK-LABEL: cta_local_scratch_requires_remote_proxy_fence
+  tt.func @cta_local_scratch_requires_remote_proxy_fence(
       %source: tensor<16x32xi32, #src>,
       %desc: !tt.tensordesc<8x32xi32, #shared>) {
     %c0 = arith.constant 0 : i32
@@ -356,54 +353,16 @@ module attributes {"ttg.num-ctas" = 2 : i32, "ttg.num-warps" = 4 : i32, ttg.targ
     %parent = ttg.local_alloc {allocation.offset = 0 : i32} : () -> !ttg.memdesc<16x32xi32, #shared, #smem, mutable>
     %remote = ttg.memdesc_subslice %parent [8, 0] : !ttg.memdesc<16x32xi32, #shared, #smem, mutable> -> !ttg.memdesc<8x32xi32, #shared, #smem, mutable, 16x32>
     %bar = ttg.local_alloc {allocation.offset = 2048 : i32} : () -> !ttg.memdesc<1xi64, #barrier, #smem, mutable>
-    // CHECK-NOT: ttng.fence_async_shared
-    // CHECK: ttng.async_tma_copy_global_to_local
-    ttng.async_tma_copy_global_to_local %desc[%c0, %c0] %remote, %bar, %true : !tt.tensordesc<8x32xi32, #shared>, !ttg.memdesc<1xi64, #barrier, #smem, mutable> -> !ttg.memdesc<8x32xi32, #shared, #smem, mutable, 16x32>
-    tt.return
-  }
-
-  // CHECK-LABEL: cross_cta_scratch_requires_remote_proxy_fence
-  tt.func @cross_cta_scratch_requires_remote_proxy_fence(
-      %source: tensor<16x32xi32, #src>,
-      %desc: !tt.tensordesc<8x32xi32, #shared>) {
-    %c0 = arith.constant 0 : i32
-    %true = arith.constant true
-    // CHECK: ttg.convert_layout
-    %converted = ttg.convert_layout %source {allocation.offset = 0 : i32, allocation.size = 1024 : i32} : tensor<16x32xi32, #src> -> tensor<16x32xi32, #dst>
-    "test.keep"(%converted) : (tensor<16x32xi32, #dst>) -> ()
-    %parent = ttg.local_alloc {allocation.offset = 0 : i32} : () -> !ttg.memdesc<16x32xi32, #shared, #smem, mutable>
-    %remote = ttg.memdesc_subslice %parent [8, 0] : !ttg.memdesc<16x32xi32, #shared, #smem, mutable> -> !ttg.memdesc<8x32xi32, #shared, #smem, mutable, 16x32>
-    %bar = ttg.local_alloc {allocation.offset = 2048 : i32} : () -> !ttg.memdesc<1xi64, #barrier, #smem, mutable>
     // CHECK: ttng.fence_async_shared {bCluster = false}
     // CHECK-NEXT: ttng.async_tma_copy_global_to_local
     ttng.async_tma_copy_global_to_local %desc[%c0, %c0] %remote, %bar, %true : !tt.tensordesc<8x32xi32, #shared>, !ttg.memdesc<1xi64, #barrier, #smem, mutable> -> !ttg.memdesc<8x32xi32, #shared, #smem, mutable, 16x32>
     tt.return
   }
 
-  // CHECK-LABEL: cross_cta_reduce_scratch_requires_remote_proxy_fence
-  tt.func @cross_cta_reduce_scratch_requires_remote_proxy_fence(
-      %source: tensor<256x128xf16, #reduce>,
-      %desc: !tt.tensordesc<8x32xi32, #shared>) {
-    %c0 = arith.constant 0 : i32
-    %true = arith.constant true
-    // CHECK: "tt.reduce"
-    %reduced = "tt.reduce"(%source) ({
-    ^bb0(%lhs: f16, %rhs: f16):
-      %sum = arith.addf %lhs, %rhs : f16
-      tt.reduce.return %sum : f16
-    }) {allocation.offset = 0 : i32, allocation.size = 512 : i32, axis = 1 : i32} : (tensor<256x128xf16, #reduce>) -> tensor<256xf16, #reduce_result>
-    "test.keep"(%reduced) : (tensor<256xf16, #reduce_result>) -> ()
-    %parent = ttg.local_alloc {allocation.offset = 0 : i32} : () -> !ttg.memdesc<16x32xi32, #shared, #smem, mutable>
-    %remote = ttg.memdesc_subslice %parent [8, 0] : !ttg.memdesc<16x32xi32, #shared, #smem, mutable> -> !ttg.memdesc<8x32xi32, #shared, #smem, mutable, 16x32>
-    %bar = ttg.local_alloc {allocation.offset = 2048 : i32} : () -> !ttg.memdesc<1xi64, #barrier, #smem, mutable>
-    // CHECK: ttng.fence_async_shared {bCluster = false}
-    // CHECK-NEXT: ttng.async_tma_copy_global_to_local
-    ttng.async_tma_copy_global_to_local %desc[%c0, %c0] %remote, %bar, %true : !tt.tensordesc<8x32xi32, #shared>, !ttg.memdesc<1xi64, #barrier, #smem, mutable> -> !ttg.memdesc<8x32xi32, #shared, #smem, mutable, 16x32>
-    tt.return
-  }
-
-  // CHECK-LABEL: cross_cta_atomic_scratch_requires_remote_proxy_fences
-  tt.func @cross_cta_atomic_scratch_requires_remote_proxy_fences(
+  // Scalar scratch is owned by CTA 0. The tensor layout broadcasts bit 0,
+  // so its scratch is also owned by CTA 0, never CTA 1.
+  // CHECK-LABEL: atomic_scratch_uses_cta_owners
+  tt.func @atomic_scratch_uses_cta_owners(
       %ptr: !tt.ptr<i32>,
       %ptrs: tensor<8x32x!tt.ptr<i32>, #replicated>,
       %cmp: tensor<8x32xi32, #replicated>,
@@ -414,7 +373,8 @@ module attributes {"ttg.num-ctas" = 2 : i32, "ttg.num-warps" = 4 : i32, ttg.targ
     %timeout = arith.constant 1 : i64
     %true = arith.constant true
     %parent = ttg.local_alloc {allocation.offset = 0 : i32} : () -> !ttg.memdesc<16x32xi32, #shared, #smem, mutable>
-    %remote = ttg.memdesc_subslice %parent [8, 0] : !ttg.memdesc<16x32xi32, #shared, #smem, mutable> -> !ttg.memdesc<8x32xi32, #shared, #smem, mutable, 16x32>
+    %owner0 = ttg.memdesc_subslice %parent [0, 0] : !ttg.memdesc<16x32xi32, #shared, #smem, mutable> -> !ttg.memdesc<8x32xi32, #shared, #smem, mutable, 16x32>
+    %nonowner1 = ttg.memdesc_subslice %parent [8, 0] : !ttg.memdesc<16x32xi32, #shared, #smem, mutable> -> !ttg.memdesc<8x32xi32, #shared, #smem, mutable, 16x32>
     %bar = ttg.local_alloc {allocation.offset = 2048 : i32} : () -> !ttg.memdesc<1xi64, #barrier, #smem, mutable>
     %atomic_parent = ttg.local_alloc {allocation.offset = 4096 : i32} : () -> !ttg.memdesc<16x32xi32, #shared, #smem, mutable>
     %atomic_dst = ttg.memdesc_subslice %atomic_parent [0, 0] : !ttg.memdesc<16x32xi32, #shared, #smem, mutable> -> !ttg.memdesc<8x32xi32, #shared, #smem, mutable, 16x32>
@@ -422,30 +382,42 @@ module attributes {"ttg.num-ctas" = 2 : i32, "ttg.num-warps" = 4 : i32, ttg.targ
     %scalar = tt.atomic_cas relaxed, gpu, %ptr, %c0, %c0 {allocation.offset = 0 : i32, allocation.size = 4 : i32} : (!tt.ptr<i32>, i32, i32) -> i32
     "test.keep"(%scalar) : (i32) -> ()
     // CHECK: tt.atomic_cas
-    // CHECK: ttng.fence_async_shared {bCluster = false}
+    // CHECK-NOT: ttng.fence_async_shared
+    // CHECK: ttng.async_tma_copy_global_to_local
+    ttng.async_tma_copy_global_to_local %desc[%c0, %c0] %nonowner1, %bar, %true : !tt.tensordesc<8x32xi32, #shared>, !ttg.memdesc<1xi64, #barrier, #smem, mutable> -> !ttg.memdesc<8x32xi32, #shared, #smem, mutable, 16x32>
+    // CHECK-NEXT: ttng.fence_async_shared {bCluster = false}
     // CHECK-NEXT: ttng.async_tma_copy_global_to_local
-    ttng.async_tma_copy_global_to_local %desc[%c0, %c0] %remote, %bar, %true : !tt.tensordesc<8x32xi32, #shared>, !ttg.memdesc<1xi64, #barrier, #smem, mutable> -> !ttg.memdesc<8x32xi32, #shared, #smem, mutable, 16x32>
+    ttng.async_tma_copy_global_to_local %desc[%c0, %c0] %owner0, %bar, %true : !tt.tensordesc<8x32xi32, #shared>, !ttg.memdesc<1xi64, #barrier, #smem, mutable> -> !ttg.memdesc<8x32xi32, #shared, #smem, mutable, 16x32>
 
     %matched = tt.atomic_poll relaxed, gpu, %ptr, %c0 timeout %timeout {allocation.offset = 0 : i32, allocation.size = 4 : i32} : !tt.ptr<i32>, i32 -> i1
     "test.keep"(%matched) : (i1) -> ()
     // CHECK: tt.atomic_poll
-    // CHECK: ttng.fence_async_shared {bCluster = false}
+    // CHECK-NOT: ttng.fence_async_shared
+    // CHECK: ttng.async_tma_copy_global_to_local
+    ttng.async_tma_copy_global_to_local %desc[%c0, %c0] %nonowner1, %bar, %true : !tt.tensordesc<8x32xi32, #shared>, !ttg.memdesc<1xi64, #barrier, #smem, mutable> -> !ttg.memdesc<8x32xi32, #shared, #smem, mutable, 16x32>
+    // CHECK-NEXT: ttng.fence_async_shared {bCluster = false}
     // CHECK-NEXT: ttng.async_tma_copy_global_to_local
-    ttng.async_tma_copy_global_to_local %desc[%c0, %c0] %remote, %bar, %true : !tt.tensordesc<8x32xi32, #shared>, !ttg.memdesc<1xi64, #barrier, #smem, mutable> -> !ttg.memdesc<8x32xi32, #shared, #smem, mutable, 16x32>
+    ttng.async_tma_copy_global_to_local %desc[%c0, %c0] %owner0, %bar, %true : !tt.tensordesc<8x32xi32, #shared>, !ttg.memdesc<1xi64, #barrier, #smem, mutable> -> !ttg.memdesc<8x32xi32, #shared, #smem, mutable, 16x32>
 
     %tensor = tt.atomic_cas relaxed, gpu, %ptrs, %cmp, %values {allocation.offset = 0 : i32, allocation.size = 1024 : i32} : (tensor<8x32x!tt.ptr<i32>, #replicated>, tensor<8x32xi32, #replicated>, tensor<8x32xi32, #replicated>) -> tensor<8x32xi32, #replicated>
     "test.keep"(%tensor) : (tensor<8x32xi32, #replicated>) -> ()
     // CHECK: tt.atomic_cas
-    // CHECK: ttng.fence_async_shared {bCluster = false}
+    // CHECK-NOT: ttng.fence_async_shared
+    // CHECK: ttng.async_tma_copy_global_to_local
+    ttng.async_tma_copy_global_to_local %desc[%c0, %c0] %nonowner1, %bar, %true : !tt.tensordesc<8x32xi32, #shared>, !ttg.memdesc<1xi64, #barrier, #smem, mutable> -> !ttg.memdesc<8x32xi32, #shared, #smem, mutable, 16x32>
+    // CHECK-NEXT: ttng.fence_async_shared {bCluster = false}
     // CHECK-NEXT: ttng.async_tma_copy_global_to_local
-    ttng.async_tma_copy_global_to_local %desc[%c0, %c0] %remote, %bar, %true : !tt.tensordesc<8x32xi32, #shared>, !ttg.memdesc<1xi64, #barrier, #smem, mutable> -> !ttg.memdesc<8x32xi32, #shared, #smem, mutable, 16x32>
+    ttng.async_tma_copy_global_to_local %desc[%c0, %c0] %owner0, %bar, %true : !tt.tensordesc<8x32xi32, #shared>, !ttg.memdesc<1xi64, #barrier, #smem, mutable> -> !ttg.memdesc<8x32xi32, #shared, #smem, mutable, 16x32>
 
     %old = ttg.local_atomic_scatter_rmw add, %atomic_dst[%indices], %values {allocation.offset = 0 : i32, allocation.size = 1024 : i32, axis = 0 : i32} : (!ttg.memdesc<8x32xi32, #shared, #smem, mutable, 16x32>, tensor<8x32xi32, #replicated>, tensor<8x32xi32, #replicated>) -> tensor<8x32xi32, #replicated>
     "test.keep"(%old) : (tensor<8x32xi32, #replicated>) -> ()
     // CHECK: ttg.local_atomic_scatter_rmw
-    // CHECK: ttng.fence_async_shared {bCluster = false}
+    // CHECK-NOT: ttng.fence_async_shared
+    // CHECK: ttng.async_tma_copy_global_to_local
+    ttng.async_tma_copy_global_to_local %desc[%c0, %c0] %nonowner1, %bar, %true : !tt.tensordesc<8x32xi32, #shared>, !ttg.memdesc<1xi64, #barrier, #smem, mutable> -> !ttg.memdesc<8x32xi32, #shared, #smem, mutable, 16x32>
+    // CHECK-NEXT: ttng.fence_async_shared {bCluster = false}
     // CHECK-NEXT: ttng.async_tma_copy_global_to_local
-    ttng.async_tma_copy_global_to_local %desc[%c0, %c0] %remote, %bar, %true : !tt.tensordesc<8x32xi32, #shared>, !ttg.memdesc<1xi64, #barrier, #smem, mutable> -> !ttg.memdesc<8x32xi32, #shared, #smem, mutable, 16x32>
+    ttng.async_tma_copy_global_to_local %desc[%c0, %c0] %owner0, %bar, %true : !tt.tensordesc<8x32xi32, #shared>, !ttg.memdesc<1xi64, #barrier, #smem, mutable> -> !ttg.memdesc<8x32xi32, #shared, #smem, mutable, 16x32>
     tt.return
   }
 }
@@ -1194,6 +1166,8 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32} {
 
 #shared = #ttg.nvmma_shared<{swizzlingByteWidth = 128, transposed = false, elementBitWidth = 32, CGALayout = [[1, 0]]}>
 #blocked = #ttg.blocked<{sizePerThread = [1, 1], threadsPerWarp = [1, 32], warpsPerCTA = [1, 4], order = [1, 0], CGALayout = [[1, 0]]}>
+#shared_replicated = #ttg.nvmma_shared<{swizzlingByteWidth = 128, transposed = false, elementBitWidth = 32, CGALayout = [[0, 0]]}>
+#replicated = #ttg.blocked<{sizePerThread = [1, 1], threadsPerWarp = [1, 32], warpsPerCTA = [1, 4], order = [1, 0], CGALayout = [[0, 0]]}>
 #barrier = #ttg.swizzled_shared<{vec = 1, perPhase = 1, maxPhase = 1, order = [0], CGALayout = [[0]]}>
 #smem = #ttg.shared_memory
 module attributes {"ttg.num-ctas" = 2 : i32, "ttg.num-warps" = 4 : i32, ttg.target = "cuda:90", "ttg.threads-per-warp" = 32 : i32} {
@@ -1212,6 +1186,25 @@ module attributes {"ttg.num-ctas" = 2 : i32, "ttg.num-warps" = 4 : i32, ttg.targ
     %value = ttg.local_load %local : !ttg.memdesc<8x32xi32, #shared, #smem, mutable, 16x32> -> tensor<8x32xi32, #blocked>
     "test.keep"(%value) : (tensor<8x32xi32, #blocked>) -> ()
     ttng.async_tma_copy_global_to_local %desc[%c0, %c0] %selected, %bar, %true : !tt.tensordesc<8x32xi32, #shared>, !ttg.memdesc<1xi64, #barrier, #smem, mutable> -> !ttg.memdesc<8x32xi32, #shared, #smem, mutable, 16x32>
+    tt.return
+  }
+
+  // A replicated allocation includes CTA 1's storage, unlike the fixed
+  // CTA 0 view above. Reinterpretation preserves its per-CTA allocation size.
+  // CHECK-LABEL: replicated_shared_aliases_remote_cta
+  tt.func @replicated_shared_aliases_remote_cta(%desc: !tt.tensordesc<8x32xi32, #shared>) {
+    %c0 = arith.constant 0 : i32
+    %true = arith.constant true
+    %replicated = ttg.local_alloc {allocation.offset = 0 : i32} : () -> !ttg.memdesc<8x32xi32, #shared_replicated, #smem, mutable>
+    %parent = ttg.memdesc_reinterpret %replicated : !ttg.memdesc<8x32xi32, #shared_replicated, #smem, mutable> -> !ttg.memdesc<16x32xi32, #shared, #smem, mutable>
+    %remote = ttg.memdesc_subslice %parent [8, 0] : !ttg.memdesc<16x32xi32, #shared, #smem, mutable> -> !ttg.memdesc<8x32xi32, #shared, #smem, mutable, 16x32>
+    %bar = ttg.local_alloc {allocation.offset = 2048 : i32} : () -> !ttg.memdesc<1xi64, #barrier, #smem, mutable>
+    // CHECK: ttg.local_load
+    %value = ttg.local_load %replicated : !ttg.memdesc<8x32xi32, #shared_replicated, #smem, mutable> -> tensor<8x32xi32, #replicated>
+    "test.keep"(%value) : (tensor<8x32xi32, #replicated>) -> ()
+    // CHECK: ttng.fence_async_shared {bCluster = false}
+    // CHECK-NEXT: ttng.async_tma_copy_global_to_local
+    ttng.async_tma_copy_global_to_local %desc[%c0, %c0] %remote, %bar, %true : !tt.tensordesc<8x32xi32, #shared>, !ttg.memdesc<1xi64, #barrier, #smem, mutable> -> !ttg.memdesc<8x32xi32, #shared, #smem, mutable, 16x32>
     tt.return
   }
 }

--- a/test/TritonGPU/proxy_fence_insertion.mlir
+++ b/test/TritonGPU/proxy_fence_insertion.mlir
@@ -1750,3 +1750,43 @@ module attributes {"ttg.num-ctas" = 2 : i32, "ttg.num-warps" = 4 : i32, ttg.targ
     tt.return
   }
 }
+
+// -----
+
+#src = #ttg.blocked<{sizePerThread = [1], threadsPerWarp = [32], warpsPerCTA = [4], order = [0]}>
+#dst = #ttg.slice<{dim = 1, parent = #ttg.blocked<{sizePerThread = [1, 1], threadsPerWarp = [1, 32], warpsPerCTA = [1, 4], order = [1, 0]}>}>
+#shared = #ttg.nvmma_shared<{swizzlingByteWidth = 0, transposed = false, elementBitWidth = 32, rank = 1}>
+#barrier = #ttg.swizzled_shared<{vec = 1, perPhase = 1, maxPhase = 1, order = [0]}>
+#smem = #ttg.shared_memory
+module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, "ttg.total-num-warps" = 8 : i32, ttg.target = "cuda:90", "ttg.threads-per-warp" = 32 : i32} {
+  // The TMA page reuses worker scratch but does not overlap the captures.
+  // CHECK-LABEL: @worker_scratch_reuse_requires_proxy_fence
+  tt.func @worker_scratch_reuse_requires_proxy_fence(%input: !tt.ptr<i32>, %desc: !tt.tensordesc<64xi32, #shared>) {
+    %c0 = arith.constant 0 : i32
+    %c1 = arith.constant 1 : i32
+    %true = arith.constant true
+    ttg.warp_specialize(%input) attributes {allocation.offset = 0 : i32, allocation.size = 8 : i32, warpGroupStartIds = array<i32: 4>}
+    default {
+      ttg.warp_yield
+    }
+    partition0(%in: !tt.ptr<i32>) num_warps(4) {
+      %ptrs = tt.splat %in : !tt.ptr<i32> -> tensor<128x!tt.ptr<i32>, #src>
+      %value = tt.load %ptrs : tensor<128x!tt.ptr<i32>, #src>
+      %converted = ttg.convert_layout %value {allocation.offset = 0 : i32, allocation.size = 512 : i32} : tensor<128xi32, #src> -> tensor<128xi32, #dst>
+      tt.print "converted" {hex = false, isSigned = array<i32: 1>} : %converted : tensor<128xi32, #dst>
+      // CHECK: ttg.warp_return
+      ttg.warp_return
+    } : (!tt.ptr<i32>) -> ()
+    %buffer = ttg.local_alloc {allocation.offset = 0 : i32} : () -> !ttg.memdesc<2x64xi32, #shared, #smem, mutable>
+    %page = ttg.memdesc_index %buffer[%c1] : !ttg.memdesc<2x64xi32, #shared, #smem, mutable> -> !ttg.memdesc<64xi32, #shared, #smem, mutable>
+    %bar = ttg.local_alloc {allocation.offset = 512 : i32} : () -> !ttg.memdesc<1xi64, #barrier, #smem, mutable>
+    ttng.init_barrier %bar, 1 : !ttg.memdesc<1xi64, #barrier, #smem, mutable>
+    ttng.barrier_expect %bar, 256, %true : !ttg.memdesc<1xi64, #barrier, #smem, mutable>
+    // CHECK: ttng.fence_async_shared {bCluster = false}
+    // CHECK-NEXT: ttng.async_tma_copy_global_to_local
+    ttng.async_tma_copy_global_to_local %desc[%c0] %page, %bar, %true : !tt.tensordesc<64xi32, #shared>, !ttg.memdesc<1xi64, #barrier, #smem, mutable> -> !ttg.memdesc<64xi32, #shared, #smem, mutable>
+    ttng.wait_barrier %bar, %c0, %true deps %page : !ttg.memdesc<1xi64, #barrier, #smem, mutable>, !ttg.memdesc<64xi32, #shared, #smem, mutable>
+    ttng.inval_barrier %bar : !ttg.memdesc<1xi64, #barrier, #smem, mutable>
+    tt.return
+  }
+}

--- a/test/TritonNvidiaGPU/membar-cluster.mlir
+++ b/test/TritonNvidiaGPU/membar-cluster.mlir
@@ -43,6 +43,7 @@ module attributes {"ttg.num-ctas" = 2 : i32, "ttg.num-warps" = 4 : i32, ttg.targ
 
 #blockedCallSrc = #ttg.blocked<{sizePerThread = [1, 32], threadsPerWarp = [32, 1], warpsPerCTA = [4, 1], order = [0, 1], CGALayout = [[1, 0]]}>
 #blockedCallDst = #ttg.blocked<{sizePerThread = [1, 32], threadsPerWarp = [32, 1], warpsPerCTA = [4, 1], order = [0, 1], CGALayout = [[0, 1]]}>
+#sharedCall = #ttg.swizzled_shared<{vec = 1, perPhase = 1, maxPhase = 1, order = [1, 0], CGALayout = [[0, 1]]}>
 #keepLayout = #ttg.blocked<{sizePerThread = [1], threadsPerWarp = [32], warpsPerCTA = [4], order = [0], CGALayout = [[0]]}>
 #keepShared = #ttg.swizzled_shared<{vec = 1, perPhase = 1, maxPhase = 1, order = [0], CGALayout = [[0]]}>
 
@@ -82,6 +83,37 @@ module attributes {"ttg.num-ctas" = 2 : i32, "ttg.num-warps" = 4 : i32, ttg.targ
     tt.call @cluster_entry_b() : () -> ()
     %kept = ttg.local_load %keep : !ttg.memdesc<65536xi8, #keepShared, #ttg.shared_memory, mutable> -> tensor<65536xi8, #keepLayout>
     tt.return %kept : tensor<65536xi8, #keepLayout>
+  }
+
+  tt.func private @store_argument(%dst: !ttg.memdesc<256x128xf16, #sharedCall, #ttg.shared_memory, mutable>) attributes {noinline = true} {
+    %value = arith.constant dense<3.0> : tensor<256x128xf16, #blockedCallDst>
+    %staging = ttg.local_alloc %value : (tensor<256x128xf16, #blockedCallDst>) -> !ttg.memdesc<256x128xf16, #sharedCall, #ttg.shared_memory, mutable>
+    %loaded = ttg.local_load %staging : !ttg.memdesc<256x128xf16, #sharedCall, #ttg.shared_memory, mutable> -> tensor<256x128xf16, #blockedCallDst>
+    ttg.local_store %loaded, %dst : tensor<256x128xf16, #blockedCallDst> -> !ttg.memdesc<256x128xf16, #sharedCall, #ttg.shared_memory, mutable>
+    tt.return
+  }
+
+  tt.func private @forward_store_argument(%dst: !ttg.memdesc<256x128xf16, #sharedCall, #ttg.shared_memory, mutable>) attributes {noinline = true} {
+    tt.call @store_argument(%dst) : (!ttg.memdesc<256x128xf16, #sharedCall, #ttg.shared_memory, mutable>) -> ()
+    tt.return
+  }
+
+  // The nested call writes through an argument into the conversion's reused
+  // scratch, so it must wait for the conversion's cross-CTA read.
+  // The callee's local allocation puts its frame at a nonzero offset, but the
+  // argument still refers to the caller's allocation.
+  // CHECK-LABEL: @cluster_call_argument_reuses_scratch
+  // CHECK: ttg.convert_layout
+  // CHECK-NEXT: ttg.local_alloc
+  // CHECK-NEXT: ttng.cluster_barrier
+  // CHECK-NEXT: tt.call @forward_store_argument{{.*}}allocation.offset = {{[1-9][0-9]*}}
+  tt.func @cluster_call_argument_reuses_scratch() -> (tensor<256x128xf16, #blockedCallDst>, tensor<256x128xf16, #blockedCallDst>) {
+    %value = arith.constant dense<0.0> : tensor<256x128xf16, #blockedCallSrc>
+    %cvt = ttg.convert_layout %value : tensor<256x128xf16, #blockedCallSrc> -> tensor<256x128xf16, #blockedCallDst>
+    %dst = ttg.local_alloc : () -> !ttg.memdesc<256x128xf16, #sharedCall, #ttg.shared_memory, mutable>
+    tt.call @forward_store_argument(%dst) : (!ttg.memdesc<256x128xf16, #sharedCall, #ttg.shared_memory, mutable>) -> ()
+    %result = ttg.local_load %dst : !ttg.memdesc<256x128xf16, #sharedCall, #ttg.shared_memory, mutable> -> tensor<256x128xf16, #blockedCallDst>
+    tt.return %cvt, %result : tensor<256x128xf16, #blockedCallDst>, tensor<256x128xf16, #blockedCallDst>
   }
 }
 

--- a/test/TritonNvidiaGPU/membar-cluster.mlir
+++ b/test/TritonNvidiaGPU/membar-cluster.mlir
@@ -43,6 +43,8 @@ module attributes {"ttg.num-ctas" = 2 : i32, "ttg.num-warps" = 4 : i32, ttg.targ
 
 #blockedCallSrc = #ttg.blocked<{sizePerThread = [1, 32], threadsPerWarp = [32, 1], warpsPerCTA = [4, 1], order = [0, 1], CGALayout = [[1, 0]]}>
 #blockedCallDst = #ttg.blocked<{sizePerThread = [1, 32], threadsPerWarp = [32, 1], warpsPerCTA = [4, 1], order = [0, 1], CGALayout = [[0, 1]]}>
+#keepLayout = #ttg.blocked<{sizePerThread = [1], threadsPerWarp = [32], warpsPerCTA = [4], order = [0], CGALayout = [[0]]}>
+#keepShared = #ttg.swizzled_shared<{vec = 1, perPhase = 1, maxPhase = 1, order = [0], CGALayout = [[0]]}>
 
 module attributes {"ttg.num-ctas" = 2 : i32, "ttg.num-warps" = 4 : i32, ttg.target = "cuda:90", "ttg.threads-per-warp" = 32 : i32} {
   // CHECK-LABEL: @cluster_entry_c
@@ -65,16 +67,21 @@ module attributes {"ttg.num-ctas" = 2 : i32, "ttg.num-warps" = 4 : i32, ttg.targ
 
   // CHECK-LABEL: @cluster_entry_a
   // CHECK-NOT: ttng.cluster_barrier
-  // CHECK: tt.call @cluster_entry_b
+  // CHECK: tt.call @cluster_entry_b{{.*}}allocation.offset = [[CLUSTER_FRAME:[1-9][0-9]*]]
   // CHECK: ttg.convert_layout
   // CHECK-NEXT: ttng.cluster_barrier
-  // CHECK-NEXT: tt.call @cluster_entry_b
-  tt.func @cluster_entry_a() {
+  // CHECK-NEXT: tt.call @cluster_entry_b{{.*}}allocation.offset = [[CLUSTER_FRAME]]
+  tt.func @cluster_entry_a() -> tensor<65536xi8, #keepLayout> {
+    // Keep a larger allocation live to exercise nested frame translation at
+    // a nonzero offset, while both calls reuse the conversion's scratch.
+    %zeros = arith.constant dense<0> : tensor<65536xi8, #keepLayout>
+    %keep = ttg.local_alloc %zeros : (tensor<65536xi8, #keepLayout>) -> !ttg.memdesc<65536xi8, #keepShared, #ttg.shared_memory, mutable>
     tt.call @cluster_entry_b() : () -> ()
     %cst = arith.constant dense<0.0> : tensor<256x128xf16, #blockedCallSrc>
     %cvt = ttg.convert_layout %cst : tensor<256x128xf16, #blockedCallSrc> -> tensor<256x128xf16, #blockedCallDst>
     tt.call @cluster_entry_b() : () -> ()
-    tt.return
+    %kept = ttg.local_load %keep : !ttg.memdesc<65536xi8, #keepShared, #ttg.shared_memory, mutable> -> tensor<65536xi8, #keepLayout>
+    tt.return %kept : tensor<65536xi8, #keepLayout>
   }
 }
 
@@ -823,6 +830,34 @@ module attributes {"ttg.num-ctas" = 2 : i32, "ttg.num-warps" = 4 : i32, ttg.targ
     ttng.init_barrier %barrier, 1 : !ttg.memdesc<2xi64, #barrierStore, #smem, mutable>
     ttng.async_shared_store %src, %dst, %barrier : tensor<128xi32, #blockedStore> -> !ttg.memdesc<128xi32, #sharedStore, #smem, mutable>, !ttg.memdesc<2xi64, #barrierStore, #smem, mutable>
     tt.return
+  }
+
+  tt.func private @async_store_arguments(%src: tensor<128xi32, #blockedStore>, %dst: !ttg.memdesc<128xi32, #sharedStore, #smem, mutable>, %barrier: !ttg.memdesc<2xi64, #barrierStore, #smem, mutable>) attributes {noinline = true} {
+    ttng.async_shared_store %src, %dst, %barrier : tensor<128xi32, #blockedStore> -> !ttg.memdesc<128xi32, #sharedStore, #smem, mutable>, !ttg.memdesc<2xi64, #barrierStore, #smem, mutable>
+    tt.return
+  }
+
+  // The helper only accesses caller-owned buffers. Their dependencies do not
+  // involve allocator reuse and need no additional cluster barriers.
+  // CHECK-LABEL: @cluster_call_without_allocator_reuse
+  // CHECK: ttng.barrier_expect
+  // CHECK-NOT: ttng.cluster_barrier
+  // CHECK: tt.call @async_store_arguments
+  // CHECK-NOT: ttng.cluster_barrier
+  // CHECK: ttng.wait_barrier
+  // CHECK: tt.return
+  tt.func @cluster_call_without_allocator_reuse(%src: tensor<128xi32, #blockedStore>) -> tensor<128xi32, #blockedStore> {
+    %c0 = arith.constant 0 : i32
+    %true = arith.constant true
+    %dst = ttg.local_alloc : () -> !ttg.memdesc<128xi32, #sharedStore, #smem, mutable>
+    %barrier = ttg.local_alloc : () -> !ttg.memdesc<2xi64, #barrierStore, #smem, mutable>
+    ttng.init_barrier %barrier, 1 : !ttg.memdesc<2xi64, #barrierStore, #smem, mutable>
+    ttng.barrier_expect %barrier, 512 {fromCTA = 0 : i32}, %true : !ttg.memdesc<2xi64, #barrierStore, #smem, mutable>
+    tt.call @async_store_arguments(%src, %dst, %barrier) : (tensor<128xi32, #blockedStore>, !ttg.memdesc<128xi32, #sharedStore, #smem, mutable>, !ttg.memdesc<2xi64, #barrierStore, #smem, mutable>) -> ()
+    ttng.wait_barrier %barrier, %c0, %true deps %dst : !ttg.memdesc<2xi64, #barrierStore, #smem, mutable>, !ttg.memdesc<128xi32, #sharedStore, #smem, mutable>
+    %result = ttg.local_load %dst : !ttg.memdesc<128xi32, #sharedStore, #smem, mutable> -> tensor<128xi32, #blockedStore>
+    ttng.inval_barrier %barrier : !ttg.memdesc<2xi64, #barrierStore, #smem, mutable>
+    tt.return %result : tensor<128xi32, #blockedStore>
   }
 }
 

--- a/test/TritonNvidiaGPU/membar-cluster.mlir
+++ b/test/TritonNvidiaGPU/membar-cluster.mlir
@@ -1302,3 +1302,47 @@ module attributes {"ttg.num-ctas" = 2 : i32, "ttg.num-warps" = 4 : i32, ttg.targ
     tt.return
   }
 }
+
+// -----
+
+#src = #ttg.blocked<{sizePerThread = [1, 1], threadsPerWarp = [1, 32], warpsPerCTA = [4, 1], order = [1, 0], CGALayout = [[1, 0]]}>
+#dst = #ttg.blocked<{sizePerThread = [1, 1], threadsPerWarp = [1, 32], warpsPerCTA = [4, 1], order = [1, 0], CGALayout = [[0, 1]]}>
+#shared = #ttg.nvmma_shared<{swizzlingByteWidth = 0, transposed = false, elementBitWidth = 32, rank = 1, CGALayout = [[0]]}>
+#barrier = #ttg.swizzled_shared<{vec = 1, perPhase = 1, maxPhase = 1, order = [0], CGALayout = [[1]]}>
+#smem = #ttg.shared_memory
+module attributes {"ttg.num-ctas" = 2 : i32, "ttg.num-warps" = 4 : i32, "ttg.total-num-warps" = 8 : i32, ttg.target = "cuda:90", "ttg.threads-per-warp" = 32 : i32} {
+  // Worker remote reads must finish before the parent reuses their scratch.
+  // CHECK-LABEL: @worker_scratch_reuse_requires_cluster_barrier
+  tt.func @worker_scratch_reuse_requires_cluster_barrier(%input: !tt.ptr<i32>, %desc: !tt.tensordesc<64xi32, #shared>) {
+    %c0 = arith.constant 0 : i32
+    %c1 = arith.constant 1 : i32
+    %true = arith.constant true
+    %bar = ttg.local_alloc : () -> !ttg.memdesc<2xi64, #barrier, #smem, mutable>
+    ttng.init_barrier %bar, 1 : !ttg.memdesc<2xi64, #barrier, #smem, mutable>
+    ttng.arrive_barrier %bar, 1, %true : !ttg.memdesc<2xi64, #barrier, #smem, mutable>
+    ttng.wait_barrier %bar, %c0 : !ttg.memdesc<2xi64, #barrier, #smem, mutable>
+    ttg.warp_specialize(%input) attributes {warpGroupStartIds = array<i32: 4>}
+    default {
+      ttg.warp_yield
+    }
+    partition0(%in: !tt.ptr<i32>) num_warps(4) {
+      %ptrs = tt.splat %in : !tt.ptr<i32> -> tensor<16x16x!tt.ptr<i32>, #src>
+      %value = tt.load %ptrs : tensor<16x16x!tt.ptr<i32>, #src>
+      %converted = ttg.convert_layout %value : tensor<16x16xi32, #src> -> tensor<16x16xi32, #dst>
+      tt.print "converted" {hex = false, isSigned = array<i32: 1>} : %converted : tensor<16x16xi32, #dst>
+      // CHECK: ttg.warp_return
+      ttg.warp_return
+    } : (!tt.ptr<i32>) -> ()
+    %buffer = ttg.local_alloc : () -> !ttg.memdesc<2x64xi32, #shared, #smem, mutable>
+    %page = ttg.memdesc_index %buffer[%c1] : !ttg.memdesc<2x64xi32, #shared, #smem, mutable> -> !ttg.memdesc<64xi32, #shared, #smem, mutable>
+    ttng.barrier_expect %bar, 256, %true : !ttg.memdesc<2xi64, #barrier, #smem, mutable>
+    ttng.fence_async_shared {bCluster = true}
+    // CHECK: ttng.fence_async_shared
+    // CHECK-NEXT: ttng.cluster_barrier
+    // CHECK-NEXT: ttng.async_tma_copy_global_to_local
+    ttng.async_tma_copy_global_to_local %desc[%c0] %page, %bar, %true {multicast} : !tt.tensordesc<64xi32, #shared>, !ttg.memdesc<2xi64, #barrier, #smem, mutable> -> !ttg.memdesc<64xi32, #shared, #smem, mutable>
+    ttng.wait_barrier %bar, %c1, %true deps %page : !ttg.memdesc<2xi64, #barrier, #smem, mutable>, !ttg.memdesc<64xi32, #shared, #smem, mutable>
+    ttng.inval_barrier %bar : !ttg.memdesc<2xi64, #barrier, #smem, mutable>
+    tt.return
+  }
+}

--- a/test/TritonNvidiaGPU/tmem_barrier_insertion.mlir
+++ b/test/TritonNvidiaGPU/tmem_barrier_insertion.mlir
@@ -529,7 +529,7 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32} {
   // CHECK: ttng.tmem_store
   // CHECK-NEXT: ttng.tmem_wait store
   // CHECK-NEXT: ttng.tc_gen5_mma
-  // CHECK-NEXT: ttng.wait_barrier
+  // CHECK: ttng.wait_barrier
   // CHECK-NEXT: tt.return
   tt.func @wait_disjoint_mma_publication(
       %data: tensor<128x128xf32, #blocked>,

--- a/test/TritonNvidiaGPU/tmem_barrier_insertion.mlir
+++ b/test/TritonNvidiaGPU/tmem_barrier_insertion.mlir
@@ -5,6 +5,8 @@
 #shared_b = #ttg.nvmma_shared<{swizzlingByteWidth = 32, transposed = true, elementBitWidth = 16}>
 #shared_copy = #ttg.nvmma_shared<{swizzlingByteWidth = 128, transposed = false, elementBitWidth = 32}>
 #barrier = #ttg.swizzled_shared<{vec = 1, perPhase = 1, maxPhase = 1, order = [0]}>
+#shared_fp8 = #ttg.nvmma_shared<{swizzlingByteWidth = 32, transposed = false, elementBitWidth = 8}>
+#shared_scales = #ttg.nvmma_shared<{swizzlingByteWidth = 0, transposed = false, elementBitWidth = 8}>
 #blocked = #ttg.blocked<{sizePerThread = [1, 128], threadsPerWarp = [32, 1], warpsPerCTA = [4, 1], order = [0, 1]}>
 #blocked_scales = #ttg.blocked<{sizePerThread = [1, 4], threadsPerWarp = [32, 1], warpsPerCTA = [1, 4], order = [1, 0]}>
 #linear64 = #ttg.linear<{register = [[0, 1], [0, 2], [0, 4], [0, 8], [0, 16], [0, 32]], lane = [[1, 0], [2, 0], [4, 0], [8, 0], [0, 64]], warp = [[16, 0], [32, 0]], block = []}>
@@ -287,6 +289,95 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32} {
     tt.return
   }
 
+  // Slices of one allocation can be physically disjoint even though their
+  // root allocation is the same.
+  // CHECK-LABEL: @ld_then_st_disjoint_slices
+  // CHECK: ttng.tmem_load
+  // CHECK-NEXT: ttng.tmem_store
+  tt.func @ld_then_st_disjoint_slices(%data: tensor<128x64xf32, #blocked>) {
+    %true = arith.constant true
+    %parent = ttng.tmem_alloc {tensor_memory_col_offset = 0 : i32, tensor_memory_row_offset = 0 : i32} : () -> !ttg.memdesc<128x128xf32, #tmem128, #ttng.tensor_memory, mutable>
+    %low = ttng.tmem_subslice %parent {offset = 0 : i32, dim = 1 : i32} : !ttg.memdesc<128x128xf32, #tmem128, #ttng.tensor_memory, mutable> -> !ttg.memdesc<128x64xf32, #tmem128, #ttng.tensor_memory, mutable, 128x128>
+    %high = ttng.tmem_subslice %parent {offset = 64 : i32, dim = 1 : i32} : !ttg.memdesc<128x128xf32, #tmem128, #ttng.tensor_memory, mutable> -> !ttg.memdesc<128x64xf32, #tmem128, #ttng.tensor_memory, mutable, 128x128>
+    %loaded = ttng.tmem_load %low : !ttg.memdesc<128x64xf32, #tmem128, #ttng.tensor_memory, mutable, 128x128> -> tensor<128x64xf32, #blocked>
+    ttng.tmem_store %data, %high, %true : tensor<128x64xf32, #blocked> -> !ttg.memdesc<128x64xf32, #tmem128, #ttng.tensor_memory, mutable, 128x128>
+    tt.return
+  }
+
+  // Both possible descriptors of arith.select must be included in the access.
+  // CHECK-LABEL: @ld_selected_then_st
+  // CHECK: ttng.tmem_load
+  // CHECK-NEXT: ttng.tmem_wait load
+  // CHECK-NEXT: ttg.barrier local
+  // CHECK-NEXT: ttng.tmem_store
+  tt.func @ld_selected_then_st(%condition: i1, %data: tensor<128x64xf32, #blocked>) {
+    %true = arith.constant true
+    %parent = ttng.tmem_alloc {tensor_memory_col_offset = 0 : i32, tensor_memory_row_offset = 0 : i32} : () -> !ttg.memdesc<128x128xf32, #tmem128, #ttng.tensor_memory, mutable>
+    %low = ttng.tmem_subslice %parent {offset = 0 : i32, dim = 1 : i32} : !ttg.memdesc<128x128xf32, #tmem128, #ttng.tensor_memory, mutable> -> !ttg.memdesc<128x64xf32, #tmem128, #ttng.tensor_memory, mutable, 128x128>
+    %high = ttng.tmem_subslice %parent {offset = 64 : i32, dim = 1 : i32} : !ttg.memdesc<128x128xf32, #tmem128, #ttng.tensor_memory, mutable> -> !ttg.memdesc<128x64xf32, #tmem128, #ttng.tensor_memory, mutable, 128x128>
+    %selected = arith.select %condition, %low, %high : !ttg.memdesc<128x64xf32, #tmem128, #ttng.tensor_memory, mutable, 128x128>
+    %loaded = ttng.tmem_load %selected : !ttg.memdesc<128x64xf32, #tmem128, #ttng.tensor_memory, mutable, 128x128> -> tensor<128x64xf32, #blocked>
+    ttng.tmem_store %data, %high, %true : tensor<128x64xf32, #blocked> -> !ttg.memdesc<128x64xf32, #tmem128, #ttng.tensor_memory, mutable, 128x128>
+    tt.return
+  }
+
+  // Unknown descriptor origins must not become empty footprints.
+  // CHECK-LABEL: @ld_unknown_then_st
+  // CHECK: ttng.tmem_load
+  // CHECK-NEXT: ttng.tmem_wait load
+  // CHECK-NEXT: ttg.barrier local
+  // CHECK-NEXT: ttng.tmem_store
+  tt.func @ld_unknown_then_st(%unknown: !ttg.memdesc<128x128xf32, #tmem128, #ttng.tensor_memory>, %data: tensor<128x128xf32, #blocked>) {
+    %true = arith.constant true
+    %known = ttng.tmem_alloc {tensor_memory_col_offset = 0 : i32, tensor_memory_row_offset = 0 : i32} : () -> !ttg.memdesc<128x128xf32, #tmem128, #ttng.tensor_memory, mutable>
+    %loaded = ttng.tmem_load %unknown : !ttg.memdesc<128x128xf32, #tmem128, #ttng.tensor_memory> -> tensor<128x128xf32, #blocked>
+    ttng.tmem_store %data, %known, %true : tensor<128x128xf32, #blocked> -> !ttg.memdesc<128x128xf32, #tmem128, #ttng.tensor_memory, mutable>
+    tt.return
+  }
+
+  // Packed f16 elements occupy half as many physical columns as f32 elements.
+  // Allocation reuse must compare those columns, not logical element indices.
+  // CHECK-LABEL: @ld_packed_then_st_disjoint
+  // CHECK: ttng.tmem_load
+  // CHECK-NEXT: ttng.tmem_alloc
+  // CHECK-NEXT: ttng.tmem_store
+  tt.func @ld_packed_then_st_disjoint(%data: tensor<128x64xf32, #blocked>) {
+    %true = arith.constant true
+    %packed = ttng.tmem_alloc {tensor_memory_col_offset = 0 : i32, tensor_memory_row_offset = 0 : i32} : () -> !ttg.memdesc<128x128xf16, #tmem128, #ttng.tensor_memory, mutable>
+    %loaded = ttng.tmem_load %packed : !ttg.memdesc<128x128xf16, #tmem128, #ttng.tensor_memory, mutable> -> tensor<128x128xf16, #blocked>
+    %other = ttng.tmem_alloc {tensor_memory_col_offset = 64 : i32, tensor_memory_row_offset = 0 : i32} : () -> !ttg.memdesc<128x64xf32, #tmem128, #ttng.tensor_memory, mutable>
+    ttng.tmem_store %data, %other, %true : tensor<128x64xf32, #blocked> -> !ttg.memdesc<128x64xf32, #tmem128, #ttng.tensor_memory, mutable>
+    tt.return
+  }
+
+  // CHECK-LABEL: @ld_packed_then_st_overlap
+  // CHECK: ttng.tmem_load
+  // CHECK-NEXT: ttng.tmem_alloc
+  // CHECK-NEXT: ttng.tmem_wait load
+  // CHECK-NEXT: ttg.barrier local
+  // CHECK-NEXT: ttng.tmem_store
+  tt.func @ld_packed_then_st_overlap(%data: tensor<128x64xf32, #blocked>) {
+    %true = arith.constant true
+    %packed = ttng.tmem_alloc {tensor_memory_col_offset = 0 : i32, tensor_memory_row_offset = 0 : i32} : () -> !ttg.memdesc<128x128xf16, #tmem128, #ttng.tensor_memory, mutable>
+    %loaded = ttng.tmem_load %packed : !ttg.memdesc<128x128xf16, #tmem128, #ttng.tensor_memory, mutable> -> tensor<128x128xf16, #blocked>
+    %other = ttng.tmem_alloc {tensor_memory_col_offset = 32 : i32, tensor_memory_row_offset = 0 : i32} : () -> !ttg.memdesc<128x64xf32, #tmem128, #ttng.tensor_memory, mutable>
+    ttng.tmem_store %data, %other, %true : tensor<128x64xf32, #blocked> -> !ttg.memdesc<128x64xf32, #tmem128, #ttng.tensor_memory, mutable>
+    tt.return
+  }
+
+  // A 64-row allocation uses one 16-row half of every warp's TMEM rows.
+  // CHECK-LABEL: @ld_then_st_disjoint_row_groups
+  // CHECK: ttng.tmem_load
+  // CHECK-NEXT: ttng.tmem_store
+  tt.func @ld_then_st_disjoint_row_groups(%data: tensor<64x128xf32, #linear64>) {
+    %true = arith.constant true
+    %low = ttng.tmem_alloc {tensor_memory_col_offset = 0 : i32, tensor_memory_row_offset = 0 : i32} : () -> !ttg.memdesc<64x128xf32, #tmem64, #ttng.tensor_memory, mutable>
+    %high = ttng.tmem_alloc {tensor_memory_col_offset = 0 : i32, tensor_memory_row_offset = 16 : i32} : () -> !ttg.memdesc<64x128xf32, #tmem64, #ttng.tensor_memory, mutable>
+    %loaded = ttng.tmem_load %low : !ttg.memdesc<64x128xf32, #tmem64, #ttng.tensor_memory, mutable> -> tensor<64x128xf32, #linear64>
+    ttng.tmem_store %data, %high, %true : tensor<64x128xf32, #linear64> -> !ttg.memdesc<64x128xf32, #tmem64, #ttng.tensor_memory, mutable>
+    tt.return
+  }
+
   // CHECK-LABEL: @ld_then_alloc_then_st_aliases_second_row
   // CHECK: ttng.tmem_load
   // CHECK-NEXT: ttng.tmem_alloc
@@ -335,6 +426,30 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32} {
       !ttg.memdesc<128x128xf32, #tmem128, #ttng.tensor_memory, mutable>,
       !ttg.memdesc<128x1xi8, #tmem_scales, #ttng.tensor_memory, mutable>,
       !ttg.memdesc<64x1xi8, #tmem_scales, #ttng.tensor_memory>
+    tt.return
+  }
+
+  // Shared scale arguments have unknown addresses, but cannot alias TMEM.
+  // CHECK-LABEL: @st_then_mma_scaled_shared_scales
+  // CHECK: ttng.tmem_store
+  // CHECK-NEXT: ttng.tc_gen5_mma_scaled
+  tt.func @st_then_mma_scaled_shared_scales(
+      %data: tensor<128x128xf32, #blocked>,
+      %a: !ttg.memdesc<128x128xf8E5M2, #shared_fp8, #ttg.shared_memory>,
+      %b: !ttg.memdesc<128x128xf8E5M2, #shared_fp8, #ttg.shared_memory>,
+      %a_scale: !ttg.memdesc<128x4xi8, #shared_scales, #ttg.shared_memory>,
+      %b_scale: !ttg.memdesc<128x4xi8, #shared_scales, #ttg.shared_memory>) {
+    %false = arith.constant false
+    %true = arith.constant true
+    %d = ttng.tmem_alloc {tensor_memory_col_offset = 0 : i32, tensor_memory_row_offset = 0 : i32} : () -> !ttg.memdesc<128x128xf32, #tmem128, #ttng.tensor_memory, mutable>
+    %other = ttng.tmem_alloc {tensor_memory_col_offset = 128 : i32, tensor_memory_row_offset = 0 : i32} : () -> !ttg.memdesc<128x128xf32, #tmem128, #ttng.tensor_memory, mutable>
+    ttng.tmem_store %data, %other, %true : tensor<128x128xf32, #blocked> -> !ttg.memdesc<128x128xf32, #tmem128, #ttng.tensor_memory, mutable>
+    ttng.tc_gen5_mma_scaled %a, %b, %d, %a_scale, %b_scale, %false, %true lhs = e5m2 rhs = e5m2 :
+      !ttg.memdesc<128x128xf8E5M2, #shared_fp8, #ttg.shared_memory>,
+      !ttg.memdesc<128x128xf8E5M2, #shared_fp8, #ttg.shared_memory>,
+      !ttg.memdesc<128x128xf32, #tmem128, #ttng.tensor_memory, mutable>,
+      !ttg.memdesc<128x4xi8, #shared_scales, #ttg.shared_memory>,
+      !ttg.memdesc<128x4xi8, #shared_scales, #ttg.shared_memory>
     tt.return
   }
 
@@ -675,6 +790,19 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32} {
     ttng.async_tma_copy_local_to_global %desc[%c0, %c0] %smem : !tt.tensordesc<128x128xf32, #shared_copy>, !ttg.memdesc<128x128xf32, #shared_copy, #ttg.shared_memory, mutable>
     ttng.async_tma_store_wait {pendings = 0 : i32, read_only}
     ttg.local_dealloc %smem : !ttg.memdesc<128x128xf32, #shared_copy, #ttg.shared_memory, mutable>
+    tt.return
+  }
+
+  // Tensor-memory offsets share one physical frame across functions. Calls
+  // still complete loads even when the callee's footprint is disjoint.
+  // CHECK-LABEL: @tmem_call_disjoint
+  // CHECK: ttng.tmem_load
+  // CHECK-NEXT: ttng.tmem_wait load
+  // CHECK-NEXT: tt.call @tmem_entry_b
+  tt.func @tmem_call_disjoint() {
+    %alloc = ttng.tmem_alloc {tensor_memory_col_offset = 128 : i32, tensor_memory_row_offset = 0 : i32} : () -> !ttg.memdesc<128x128xf32, #tmem128, #ttng.tensor_memory, mutable>
+    %loaded = ttng.tmem_load %alloc : !ttg.memdesc<128x128xf32, #tmem128, #ttng.tensor_memory, mutable> -> tensor<128x128xf32, #blocked>
+    tt.call @tmem_entry_b() : () -> ()
     tt.return
   }
 }

--- a/test/lib/Analysis/TestBufferRegion.cpp
+++ b/test/lib/Analysis/TestBufferRegion.cpp
@@ -91,23 +91,26 @@ struct TestBufferRegionAliasPass
     : public PassWrapper<TestBufferRegionAliasPass, OperationPass<ModuleOp>> {
   MLIR_DEFINE_EXPLICIT_INTERNAL_INLINE_TYPE_ID(TestBufferRegionAliasPass);
 
+  using NamedRegion = std::pair<std::string, tt::BufferRegionFootprint>;
+
   StringRef getArgument() const final { return "test-buffer-region-alias"; }
   StringRef getDescription() const final {
     return "test exact buffer-region alias and containment analysis";
   }
 
-  static std::optional<Value> getTaggedMemDesc(Operation *op) {
-    for (Value operand : op->getOperands())
-      if (isa<ttg::MemDescType>(operand.getType()))
-        return operand;
-    for (Value result : op->getResults())
-      if (isa<ttg::MemDescType>(result.getType()))
-        return result;
-    return std::nullopt;
+  void getDependentDialects(DialectRegistry &registry) const override {
+    registry.insert<ttg::TritonGPUDialect>();
   }
 
-  static FailureOr<tt::RegionInfo>
-  getTaggedRegionInfo(Operation *op, tt::BufferRegionAnalysis *analysis) {
+  static Value getTaggedMemDesc(Operation *op) {
+    for (Value value : llvm::concat<Value>(op->getOperands(), op->getResults()))
+      if (isa<ttg::MemDescType>(value.getType()))
+        return value;
+    return {};
+  }
+
+  static FailureOr<tt::BufferRegionFootprint>
+  getTaggedFootprint(Operation *op, tt::BufferRegionAnalysis *analysis) {
     if (auto addressesAttr =
             op->getAttrOfType<DenseI32ArrayAttr>("test.region_addresses")) {
       SmallVector<uint32_t> addresses;
@@ -133,75 +136,64 @@ struct TestBufferRegionAliasPass
           addressSet.set(address);
         region.ctaAddresses.emplace_back(0, std::move(addressSet));
       }
-      tt::RegionInfo info(tt::RegionInfo::ViewList{});
-      info.views.insert(
-          {std::move(region), /*storageBase=*/base, /*affineOffset=*/0});
-      return info;
+      tt::BufferRegionView view{std::move(region), /*storageBase=*/base,
+                                /*affineOffset=*/0};
+      // Explicit address sets share one synthetic allocation frame.
+      view.allocationFrame =
+          analysis->getOperationId(op->getParentOfType<ModuleOp>());
+      return tt::BufferRegionFootprint{
+          ttg::SharedMemorySpaceAttr::get(op->getContext()),
+          tt::RegionInfo({std::move(view)})};
     }
 
-    std::optional<Value> memdesc = getTaggedMemDesc(op);
+    Value memdesc = getTaggedMemDesc(op);
     if (!memdesc) {
       op->emitError("test.region_name requires test.region_addresses or a "
                     "memdesc operand/result");
       return failure();
     }
-    return analysis->getLatticeElement(*memdesc)->getValue();
+    if (const auto *footprint = analysis->getFootprint(memdesc))
+      return *footprint;
+    return tt::BufferRegionFootprint{{}, analysis->getRegionInfo(memdesc)};
   }
 
-  static bool mayAlias(const tt::RegionInfo &lhs, const tt::RegionInfo &rhs) {
-    if (lhs.isUnknown() || rhs.isUnknown())
-      return true;
-    return llvm::any_of(lhs.views, [&](const tt::BufferRegionView &a) {
-      return llvm::any_of(rhs.views, [&](const tt::BufferRegionView &b) {
-        return a.intersects(b);
-      });
-    });
-  }
-
-  static bool contains(const tt::RegionInfo &container,
-                       const tt::RegionInfo &contained) {
-    if (container.isUnknown() || contained.isUnknown())
+  static bool contains(const tt::BufferRegionFootprint &container,
+                       const tt::BufferRegionFootprint &contained) {
+    if (!container.memorySpace ||
+        container.memorySpace != contained.memorySpace ||
+        container.regionInfo.isUnknown() || contained.regionInfo.isUnknown())
       return false;
-    return llvm::all_of(contained.views, [&](const tt::BufferRegionView &b) {
-      return llvm::any_of(container.views, [&](const tt::BufferRegionView &a) {
-        return a.contains(b);
-      });
+    return llvm::all_of(contained.regionInfo.views, [&](const auto &b) {
+      return llvm::any_of(container.regionInfo.views,
+                          [&](const auto &a) { return a.contains(b); });
     });
   }
 
   static void printMask(InFlightDiagnostic &diag,
                         const llvm::SmallBitVector &mask) {
     diag << "{";
-    bool first = true;
-    for (unsigned bit = 0; bit < mask.size(); ++bit) {
-      if (!mask.test(bit))
-        continue;
-      if (!first)
-        diag << ",";
-      diag << bit;
-      first = false;
-    }
+    llvm::interleave(mask.set_bits(), diag, ",");
     diag << "}";
   }
 
-  static void
-  emitStatePlan(ModuleOp module,
-                ArrayRef<std::pair<std::string, tt::RegionInfo>> namedRegions) {
+  static void emitStatePlan(ModuleOp module,
+                            ArrayRef<NamedRegion> namedRegions) {
     SmallVector<tt::BufferRegion> regions;
-    for (const auto &[name, info] : namedRegions)
-      for (const tt::BufferRegionView &view : info.views)
+    for (const auto &[name, footprint] : namedRegions)
+      for (const tt::BufferRegionView &view : footprint.regionInfo.views)
         regions.push_back(view.region);
     llvm::sort(regions);
     regions.erase(std::unique(regions.begin(), regions.end()), regions.end());
 
     bool hasUnknown = llvm::any_of(namedRegions, [](const auto &named) {
-      return named.second.isUnknown();
+      return named.second.regionInfo.isUnknown();
     });
     tt::BufferStatePlan plan = tt::createBufferStatePlan(regions, hasUnknown);
     InFlightDiagnostic summary = module.emitRemark();
     summary << "state-plan: lanes=" << plan.numLanes;
 
-    for (const auto &[name, info] : namedRegions) {
+    for (const auto &[name, footprint] : namedRegions) {
+      const tt::RegionInfo &info = footprint.regionInfo;
       if (info.isUnknown()) {
         InFlightDiagnostic diag = module.emitRemark();
         diag << name << " case unknown: mask=";
@@ -234,16 +226,16 @@ struct TestBufferRegionAliasPass
     if (failed(solver->initializeAndRun(module)))
       return signalPassFailure();
 
-    SmallVector<std::pair<std::string, tt::RegionInfo>> namedRegions;
+    SmallVector<NamedRegion> namedRegions;
     module.walk([&](Operation *op) {
       auto name = op->getAttrOfType<StringAttr>("test.region_name");
       if (!name)
         return;
-      FailureOr<tt::RegionInfo> regionInfo = getTaggedRegionInfo(op, analysis);
-      if (failed(regionInfo)) {
+      auto footprint = getTaggedFootprint(op, analysis);
+      if (failed(footprint)) {
         return signalPassFailure();
       }
-      namedRegions.push_back({name.str(), std::move(*regionInfo)});
+      namedRegions.push_back({name.str(), std::move(*footprint)});
     });
     llvm::sort(namedRegions, [](const auto &lhs, const auto &rhs) {
       return lhs.first < rhs.first;
@@ -256,7 +248,7 @@ struct TestBufferRegionAliasPass
           const auto &[rhsName, rhs] = namedRegions[j];
           module.emitRemark()
               << lhsName << " vs " << rhsName
-              << ": alias=" << (mayAlias(lhs, rhs) ? "true" : "false")
+              << ": alias=" << (tt::mayOverlap(&lhs, &rhs) ? "true" : "false")
               << ", lhs_contains_rhs="
               << (contains(lhs, rhs) ? "true" : "false")
               << ", rhs_contains_lhs="

--- a/unittest/Analysis/UtilityTest.cpp
+++ b/unittest/Analysis/UtilityTest.cpp
@@ -142,6 +142,34 @@ TEST(Analysis, BufferRegionViewPreservesSubviewProvenance) {
   EXPECT_EQ(physicalRegions.size(), 1);
 }
 
+TEST(Analysis, BufferRegionFootprintUnknownIsNotEmpty) {
+  MLIRContext context;
+  context.getOrLoadDialect<triton::gpu::TritonGPUDialect>();
+  Attribute space = triton::gpu::SharedMemorySpaceAttr::get(&context);
+  triton::BufferRegionView view{
+      {0, 8, {{0, triton::AddressSet::fromRange(0, 8)}}}};
+  view.allocationFrame = 1;
+  triton::BufferRegionFootprint known{space, triton::RegionInfo({view})};
+  triton::BufferRegionFootprint uninitialized{space, {}};
+  triton::BufferRegionFootprint unknown{
+      space, triton::RegionInfo::getPessimisticValueState()};
+  triton::BufferRegionFootprint noCandidates{
+      space, triton::RegionInfo(triton::RegionInfo::ViewList{})};
+
+  const triton::BufferRegionFootprint *incomplete[] = {nullptr, &uninitialized,
+                                                       &unknown, &noCandidates};
+  for (const auto *footprint : incomplete) {
+    EXPECT_TRUE(triton::mayOverlap(footprint, &known));
+    EXPECT_TRUE(triton::mayOverlap(&known, footprint));
+  }
+
+  view.region = {};
+  triton::BufferRegionFootprint empty{space, triton::RegionInfo({view})};
+  EXPECT_FALSE(triton::mayOverlap(&empty, &known));
+  EXPECT_FALSE(triton::mayOverlap(&known, &empty));
+  EXPECT_TRUE(triton::mayOverlap(&empty, &unknown));
+}
+
 namespace {
 
 uint64_t toBits(const llvm::SmallBitVector &mask) {


### PR DESCRIPTION
Reuse `BufferRegionAnalysis` footprints across Membar, cluster barriers, TMEM synchronization, and proxy fences. Share call-summary handling while preserving allocation frames, CTA identity, and descriptor views when checking aliases.

The diff looks massive, but the non-test code is +565  −608
