### PR TITLE
[BC-Breaking][Frontend] Fix min/max type promotion

### DIFF
--- a/python/test/unit/language/test_frontend.py
+++ b/python/test/unit/language/test_frontend.py
@@ -69,6 +69,47 @@ def test_scalar_constant_float_zero_to_integer(dtype, value):
     run_filecheck_test(kernel, args=(dtype, value))
 
 
+@pytest.mark.parametrize("op", [tl.minimum, tl.maximum])
+@pytest.mark.parametrize("dtype, value, expected_dtype", [
+    (tl.float16, 0.0, tl.float16),
+    (tl.float16, 0, tl.float16),
+    (tl.float32, 0.0, tl.float32),
+    (tl.float64, 0.0, tl.float64),
+    (tl.bfloat16, 0.0, tl.float32),
+    (tl.int8, False, tl.int8),
+    (tl.int16, 0, tl.int16),
+    (tl.uint16, 0, tl.uint16),
+    (tl.int16, 0.0, tl.float32),
+])
+def test_minimum_maximum_scalar_promotion(op, dtype, value, expected_dtype):
+
+    @triton.jit
+    def kernel(op: tl.constexpr, dtype: tl.constexpr, value: tl.constexpr, expected_dtype: tl.constexpr):
+        x = tl.full((8, ), 1, dtype)
+        lhs = op(x, value)
+        rhs = op(value, x)
+        tl.static_assert(lhs.dtype == expected_dtype)
+        tl.static_assert(rhs.dtype == expected_dtype)
+
+    run_parser(kernel, args=(op, dtype, value, expected_dtype))
+
+
+@pytest.mark.parametrize("op", [tl.minimum, tl.maximum])
+@pytest.mark.parametrize("other_dtype", [tl.float32, tl.bfloat16])
+def test_minimum_maximum_tensor_promotion(op, other_dtype):
+
+    @triton.jit
+    def kernel(op: tl.constexpr, other_dtype: tl.constexpr):
+        x = tl.full((8, ), 1, tl.float16)
+        y = tl.full((), 0.0, other_dtype)
+        lhs = op(x, y)
+        rhs = op(y, x)
+        tl.static_assert(lhs.dtype == tl.float32)
+        tl.static_assert(rhs.dtype == tl.float32)
+
+    run_parser(kernel, args=(op, other_dtype))
+
+
 @triton.aggregate
 class Pair:
     first: tl.tensor

--- a/python/triton/language/core.py
+++ b/python/triton/language/core.py
@@ -2808,8 +2808,8 @@ def minimum(x, y, propagate_nan: constexpr = PropagateNan.NONE, _semantic=None):
 
     .. seealso:: :class:`tl.PropagateNan`
     """
-    x = _semantic.to_tensor(x)
-    y = _semantic.to_tensor(y)
+    x = _unwrap_if_constexpr(x)
+    y = _unwrap_if_constexpr(y)
     x = _promote_bfloat16_to_float32(x, _semantic=_semantic)
     y = _promote_bfloat16_to_float32(y, _semantic=_semantic)
     propagate_nan = _unwrap_if_constexpr(propagate_nan)
@@ -2830,8 +2830,8 @@ def maximum(x, y, propagate_nan: constexpr = PropagateNan.NONE, _semantic=None):
 
     .. seealso:: :class:`tl.PropagateNan`
     """
-    x = _semantic.to_tensor(x)
-    y = _semantic.to_tensor(y)
+    x = _unwrap_if_constexpr(x)
+    y = _unwrap_if_constexpr(y)
     x = _promote_bfloat16_to_float32(x, _semantic=_semantic)
     y = _promote_bfloat16_to_float32(y, _semantic=_semantic)
     propagate_nan = _unwrap_if_constexpr(propagate_nan)
@@ -2967,10 +2967,8 @@ def reduce(input, axis, combine_fn, keep_dims=False, _semantic=None, _generator=
 
 @builtin
 def _promote_bfloat16_to_float32(t, _semantic=None):
-    scalar_ty = t.type.scalar
-
     # hardware doesn't support FMAX, FMIN, CMP for bfloat16
-    if scalar_ty is bfloat16:
+    if isinstance(t, tensor) and t.dtype is bfloat16:
         return t.to(float32, _semantic=_semantic)
     return t
 

--- a/python/triton/language/semantic.py
+++ b/python/triton/language/semantic.py
@@ -358,7 +358,7 @@ class TritonSemantic(Generic[TensorTy]):
 # other arithmetic ops
 ##############
 
-    def minimum(self, x: TensorTy, y: TensorTy, propagate_nan: tl.PropagateNan):
+    def minimum(self, x: TensorTy | numbers.Number, y: TensorTy | numbers.Number, propagate_nan: tl.PropagateNan):
         x, y = self.binary_op_type_checking_impl(x, y)
         dtype = x.dtype
         if dtype.is_floating():
@@ -375,7 +375,7 @@ class TritonSemantic(Generic[TensorTy]):
         else:
             raise TypeError(f"Unexpected dtype {dtype}")
 
-    def maximum(self, x: TensorTy, y: TensorTy, propagate_nan: tl.PropagateNan):
+    def maximum(self, x: TensorTy | numbers.Number, y: TensorTy | numbers.Number, propagate_nan: tl.PropagateNan):
         x, y = self.binary_op_type_checking_impl(x, y)
         dtype = x.dtype
         if dtype.is_floating():


### PR DESCRIPTION
Our type promotion rules state that tensor dtypes take precedence over constexpr types, but the `to_tensor` here materialized a `float32` value before we got to the type promotion logic.

This is a BC-breaking change, but also a bug fix. Lets hold of on merging for now until I can update the internal pin.