### PR TITLE
[BC-breaking][Frontend] Remove outdated bfloat16 promotion rules

### DIFF
--- a/python/test/unit/language/test_core.py
+++ b/python/test/unit/language/test_core.py
@@ -2841,7 +2841,9 @@ def test_max_min_with_nan(device):
 
 
 @pytest.mark.interpreter
-def test_argmax_argmin_with_nan(device):
+@pytest.mark.parametrize("dtype", [torch.float32, torch.bfloat16])
+def test_argmax_argmin_with_nan(dtype, device):
+    check_type_supported(dtype, device)
     # In triton, argmax/argmin should also follow the "nan ignore" style,
     # consistent with tl.max/tl.min. NaN should be skipped, returning the
     # index of the largest/smallest finite value.
@@ -2866,8 +2868,8 @@ def test_argmax_argmin_with_nan(device):
         tl.store(idx_ptr, idx)
 
     # argmax: [nan, 6, 8] -> max=8.0, argmax=2
-    x = torch.tensor([float("nan"), 6.0, 8.0], dtype=torch.float32, device=device)
-    val = torch.empty((), dtype=torch.float32, device=device)
+    x = torch.tensor([float("nan"), 6.0, 8.0], dtype=dtype, device=device)
+    val = torch.empty((), dtype=dtype, device=device)
     idx = torch.empty((), dtype=torch.int32, device=device)
     argmax_kernel[(1, )](x, val, idx, N=3, BLOCK=4)
     assert val.item() == 8.0, f"expected 8.0, got {val.item()}"
@@ -2881,7 +2883,7 @@ def test_argmax_argmin_with_nan(device):
     assert idx.item() == 1, f"expected 1, got {idx.item()}"
 
     # argmax: NaN at end [3, 5, nan] -> max=5.0, argmax=1
-    x_nan_end = torch.tensor([3.0, 5.0, float("nan")], dtype=torch.float32, device=device)
+    x_nan_end = torch.tensor([3.0, 5.0, float("nan")], dtype=dtype, device=device)
     val.zero_()
     idx.zero_()
     argmax_kernel[(1, )](x_nan_end, val, idx, N=3, BLOCK=4)
@@ -2890,7 +2892,9 @@ def test_argmax_argmin_with_nan(device):
 
 
 @pytest.mark.interpreter
-def test_argmax_argmin_tie_break_fast_with_nan(device):
+@pytest.mark.parametrize("dtype", [torch.float32, torch.bfloat16])
+def test_argmax_argmin_tie_break_fast_with_nan(dtype, device):
+    check_type_supported(dtype, device)
     # tl.argmax/argmin with tie_break_left=False should also ignore NaN,
     # consistent with the tie_break_left=True behaviour and JIT hardware
     # semantics (fmaxf/fminf treat NaN as missing values).
@@ -2915,11 +2919,11 @@ def test_argmax_argmin_tie_break_fast_with_nan(device):
         tl.store(val_ptr, val)
         tl.store(idx_ptr, idx)
 
-    val = torch.empty((), dtype=torch.float32, device=device)
+    val = torch.empty((), dtype=dtype, device=device)
     idx = torch.empty((), dtype=torch.int32, device=device)
 
     # argmax: [nan, 6, 8] -> max=8.0, argmax=2
-    x = torch.tensor([float("nan"), 6.0, 8.0], dtype=torch.float32, device=device)
+    x = torch.tensor([float("nan"), 6.0, 8.0], dtype=dtype, device=device)
     argmax_fast_kernel[(1, )](x, val, idx, N=3, BLOCK=4)
     assert val.item() == 8.0, f"expected 8.0, got {val.item()}"
     assert idx.item() == 2, f"expected 2, got {idx.item()}"
@@ -2932,7 +2936,7 @@ def test_argmax_argmin_tie_break_fast_with_nan(device):
     assert idx.item() == 1, f"expected 1, got {idx.item()}"
 
     # argmax: NaN at end [3, 5, nan] -> max=5.0, argmax=1
-    x_nan_end = torch.tensor([3.0, 5.0, float("nan")], dtype=torch.float32, device=device)
+    x_nan_end = torch.tensor([3.0, 5.0, float("nan")], dtype=dtype, device=device)
     val.zero_()
     idx.zero_()
     argmax_fast_kernel[(1, )](x_nan_end, val, idx, N=3, BLOCK=4)
@@ -2940,7 +2944,7 @@ def test_argmax_argmin_tie_break_fast_with_nan(device):
     assert idx.item() == 1, f"expected 1, got {idx.item()}"
 
     # argmin: NaN in middle [3, nan, 1] -> min=1.0, argmin=2
-    x_nan_mid = torch.tensor([3.0, float("nan"), 1.0], dtype=torch.float32, device=device)
+    x_nan_mid = torch.tensor([3.0, float("nan"), 1.0], dtype=dtype, device=device)
     val.zero_()
     idx.zero_()
     argmin_fast_kernel[(1, )](x_nan_mid, val, idx, N=3, BLOCK=4)
@@ -3276,7 +3280,11 @@ def test_scan2d(op, dtype_str, shape, axis, reverse, num_warps, device):
         tl.store(Z + range_m[:, None] * BLOCK_N + range_n[None, :], z)
 
     if op == 'cumsum' or op == 'cumprod':
-        kernel = patch_kernel(kernel, {'GENERATE_TEST_HERE': f'z = tl.{op}(x, axis={axis}, reverse={reverse})'})
+        # This test compares against FP32 accumulation for BF16 inputs. Native
+        # BF16 accumulation is covered separately by test_scan_bfloat16.
+        scan_dtype = 'tl.float32' if dtype_str == 'bfloat16' else 'None'
+        kernel = patch_kernel(
+            kernel, {'GENERATE_TEST_HERE': f'z = tl.{op}(x, axis={axis}, reverse={reverse}, dtype={scan_dtype})'})
     elif op == 'get_first_element':
         kernel = patch_kernel(
             kernel,
@@ -3378,7 +3386,7 @@ def test_scan2d(op, dtype_str, shape, axis, reverse, num_warps, device):
                 z_ref[:, 1:] = x[:, 0:1]
 
     # triton result
-    # we don't cast the `fp32 = bf16 op bf16` result to bfloat16 to alleviate accuracy issues
+    # Keep the FP32 accumulation result for BF16 inputs.
     z_tri = to_triton(z, device=device)
     kernel[(1, )](x_tri, y_tri, z_tri, BLOCK_M=shape[0], BLOCK_N=shape[1], AXIS=axis, num_warps=num_warps)
 
@@ -3393,6 +3401,35 @@ def test_scan2d(op, dtype_str, shape, axis, reverse, num_warps, device):
             np.testing.assert_allclose(z_ref, z_tri, rtol=0.01)
     else:
         np.testing.assert_equal(z_ref, z_tri)
+
+
+@pytest.mark.parametrize("op", ["cumsum", "cumprod"])
+@pytest.mark.parametrize("axis", [0, 1])
+@pytest.mark.parametrize("reverse", [False, True])
+@pytest.mark.parametrize("num_warps", [4, 8])
+def test_scan_bfloat16(op, axis, reverse, num_warps, device):
+    check_type_supported("bfloat16", device)
+
+    @triton.jit
+    def kernel(X, Y, OP: tl.constexpr, AXIS: tl.constexpr, REVERSE: tl.constexpr):
+        offsets = tl.arange(0, 32)[:, None] * 32 + tl.arange(0, 32)[None, :]
+        x = tl.load(X + offsets)
+        y = getattr(tl, OP)(x, axis=AXIS, reverse=REVERSE)
+        tl.static_assert(y.dtype == tl.bfloat16)
+        tl.store(Y + offsets, y)
+
+    # Integer sums and products of powers of two are exact in BF16 here, so
+    # the reference does not depend on the scan's association order.
+    rs = RandomState(17)
+    values = [-1.0, 1.0] if op == "cumsum" else [0.5, 1.0, 2.0]
+    x = torch.tensor(rs.choice(values, (32, 32)), dtype=torch.bfloat16, device=device)
+    x_ref = x.float().flip((axis, )) if reverse else x.float()
+    expected = getattr(torch, op)(x_ref, dim=axis)
+    if reverse:
+        expected = expected.flip((axis, ))
+    out = torch.empty_like(x)
+    kernel[(1, )](x, out, op, axis, reverse, num_warps=num_warps)
+    torch.testing.assert_close(out, expected.to(torch.bfloat16), rtol=0, atol=0)
 
 
 # ---------------
@@ -6843,10 +6880,11 @@ def test_num_ctas_pre_sm90(device, fresh_knobs):
 
 
 @pytest.mark.interpreter
-@pytest.mark.parametrize("dtype", ['float16', 'float32'])
+@pytest.mark.parametrize("dtype", ['bfloat16', 'float16', 'float32'])
 @pytest.mark.parametrize("propagate_nan", ['NONE', 'ALL'])
 @pytest.mark.parametrize("func", ['minimum', 'maximum', 'clamp'])
 def test_propagate_nan(dtype, propagate_nan, func, device):
+    check_type_supported(dtype, device)
 
     @triton.jit
     def kernel(A, B, C, propagate_nan: tl.constexpr, func: tl.constexpr):
@@ -6882,8 +6920,9 @@ def test_propagate_nan(dtype, propagate_nan, func, device):
 
 
 @pytest.mark.interpreter
-@pytest.mark.parametrize("dtype", ['float16', 'float32'])
+@pytest.mark.parametrize("dtype", ['bfloat16', 'float16', 'float32'])
 def test_clamp(dtype, device):
+    check_type_supported(dtype, device)
 
     @triton.jit
     def kernel(x_ptr, min_ptr, max_ptr, out_ptr, ref_ptr, N, BLOCK_SIZE: tl.constexpr):
@@ -6919,6 +6958,7 @@ def test_clamp(dtype, device):
 @pytest.mark.interpreter
 @pytest.mark.parametrize("dtype", ['bfloat16', 'float16', 'float32'])
 def test_clamp_symmetric(dtype, device):
+    check_type_supported(dtype, device)
 
     @triton.jit
     def kernel(x_ptr, limit_ptr, out_ptr, ref_ptr, N, BLOCK_SIZE: tl.constexpr):
@@ -7664,18 +7704,37 @@ def test_unsplat(device):
 
 
 @pytest.mark.interpreter
-def test_cumsum_dtype(device):
+@pytest.mark.parametrize("op", ["cumsum", "cumprod"])
+@pytest.mark.parametrize("in_dtype", [tl.int1, tl.int8, tl.uint8], ids=str)
+@pytest.mark.parametrize("dtype", [None, tl.int8, tl.int64], ids=str)
+@pytest.mark.parametrize("member", [False, True])
+def test_scan_dtype(op, in_dtype, dtype, member, device):
 
     @triton.jit
-    def kernel(Z):
-        x = tl.full((4, ), True, dtype=tl.int1)
-        z = tl.cumsum(x, axis=0)
-        tl.store(Z + tl.arange(0, 4), z)
+    def kernel(X, Z, OP: tl.constexpr, DTYPE: tl.constexpr, MEMBER: tl.constexpr, EXPECTED_DTYPE: tl.constexpr):
+        x = tl.load(X + tl.arange(0, 4))
+        if MEMBER:
+            if OP == "cumsum":
+                z = x.cumsum(axis=0, dtype=DTYPE)
+            else:
+                z = x.cumprod(axis=0, dtype=DTYPE)
+        else:
+            z = getattr(tl, OP)(x, axis=0, dtype=DTYPE)
+        tl.static_assert(z.dtype == EXPECTED_DTYPE)
+        tl.store(Z + tl.arange(0, 4), z.to(tl.int64))
 
-    z = torch.zeros(4, dtype=torch.int32, device=device)
-    kernel[(1, )](z)
-    expected = torch.tensor([1, 2, 3, 4], dtype=torch.int32, device=device)
-    assert torch.equal(z, expected)
+    expected_dtype = dtype
+    if expected_dtype is None:
+        expected_dtype = tl.int32 if in_dtype == tl.int8 else tl.uint32
+    value = 1 if in_dtype == tl.int1 else 8
+    torch_dtype = torch.bool if in_dtype == tl.int1 else getattr(torch, in_dtype.name)
+    x = torch.full((4, ), value, dtype=torch_dtype, device=device)
+    z = torch.empty(4, dtype=torch.int64, device=device)
+    kernel[(1, )](x, z, op, dtype, member, expected_dtype)
+    expected = getattr(np, op)(np.full(4, value, dtype=np.int64))
+    if expected_dtype == tl.int8:
+        expected = expected.astype(np.int8).astype(np.int64)
+    np.testing.assert_array_equal(to_numpy(z), expected)
 
 
 @pytest.mark.interpreter

--- a/python/test/unit/language/test_frontend.py
+++ b/python/test/unit/language/test_frontend.py
@@ -75,7 +75,7 @@ def test_scalar_constant_float_zero_to_integer(dtype, value):
     (tl.float16, 0, tl.float16),
     (tl.float32, 0.0, tl.float32),
     (tl.float64, 0.0, tl.float64),
-    (tl.bfloat16, 0.0, tl.float32),
+    (tl.bfloat16, 0.0, tl.bfloat16),
     (tl.int8, False, tl.int8),
     (tl.int16, 0, tl.int16),
     (tl.uint16, 0, tl.uint16),
@@ -95,19 +95,58 @@ def test_minimum_maximum_scalar_promotion(op, dtype, value, expected_dtype):
 
 
 @pytest.mark.parametrize("op", [tl.minimum, tl.maximum])
-@pytest.mark.parametrize("other_dtype", [tl.float32, tl.bfloat16])
-def test_minimum_maximum_tensor_promotion(op, other_dtype):
+@pytest.mark.parametrize("other_dtype, expected_dtype", [(tl.float32, tl.float32), (tl.bfloat16, tl.float16)])
+def test_minimum_maximum_tensor_promotion(op, other_dtype, expected_dtype):
 
     @triton.jit
-    def kernel(op: tl.constexpr, other_dtype: tl.constexpr):
+    def kernel(op: tl.constexpr, other_dtype: tl.constexpr, expected_dtype: tl.constexpr):
         x = tl.full((8, ), 1, tl.float16)
         y = tl.full((), 0.0, other_dtype)
         lhs = op(x, y)
         rhs = op(y, x)
-        tl.static_assert(lhs.dtype == tl.float32)
-        tl.static_assert(rhs.dtype == tl.float32)
+        tl.static_assert(lhs.dtype == expected_dtype)
+        tl.static_assert(rhs.dtype == expected_dtype)
 
-    run_parser(kernel, args=(op, other_dtype))
+    run_parser(kernel, args=(op, other_dtype, expected_dtype))
+
+
+@pytest.mark.parametrize("op", ["minimum", "maximum", "clamp", "cumsum", "cumprod"])
+@pytest.mark.parametrize("dtype", [tl.bfloat16, tl.float16, tl.float32], ids=str)
+def test_bfloat16_promotion_elementwise_and_scan(op, dtype):
+
+    @triton.jit
+    def kernel(op: tl.constexpr, dtype: tl.constexpr):
+        x = tl.full((32, ), 1, tl.bfloat16)
+        y = tl.full((32, ), 2, dtype)
+        if op == "clamp":
+            result = tl.clamp(x, -y, y)
+        elif op == "minimum" or op == "maximum":
+            result = getattr(tl, op)(x, y)
+        else:
+            result = getattr(tl, op)(x, dtype=None if dtype == tl.bfloat16 else dtype)
+        tl.static_assert(result.dtype == dtype)
+
+    run_parser(kernel, args=(op, dtype))
+
+
+@pytest.mark.parametrize("op", ["min", "max"])
+@pytest.mark.parametrize("return_indices", [False, True])
+@pytest.mark.parametrize("tie_break_left", [False, True])
+def test_bfloat16_promotion_reduction(op, return_indices, tie_break_left):
+
+    @triton.jit
+    def kernel(op: tl.constexpr, return_indices: tl.constexpr, tie_break_left: tl.constexpr):
+        x = tl.full((32, ), 1, tl.bfloat16)
+        result = getattr(tl, op)(x, 0, return_indices=return_indices, return_indices_tie_break_left=tie_break_left)
+        if return_indices:
+            value, index = result
+            tl.static_assert(value.dtype == tl.bfloat16)
+            tl.static_assert(index.dtype == tl.int32)
+        else:
+            # Ordinary min/max reductions still widen all small input types.
+            tl.static_assert(result.dtype == tl.float32)
+
+    run_parser(kernel, args=(op, return_indices, tie_break_left))
 
 
 @triton.aggregate

--- a/python/triton/language/core.py
+++ b/python/triton/language/core.py
@@ -2910,8 +2910,6 @@ def minimum(x, y, propagate_nan: constexpr = PropagateNan.NONE, _semantic=None):
     """
     x = _unwrap_if_constexpr(x)
     y = _unwrap_if_constexpr(y)
-    x = _promote_bfloat16_to_float32(x, _semantic=_semantic)
-    y = _promote_bfloat16_to_float32(y, _semantic=_semantic)
     propagate_nan = _unwrap_if_constexpr(propagate_nan)
     return _semantic.minimum(x, y, propagate_nan)
 
@@ -2932,8 +2930,6 @@ def maximum(x, y, propagate_nan: constexpr = PropagateNan.NONE, _semantic=None):
     """
     x = _unwrap_if_constexpr(x)
     y = _unwrap_if_constexpr(y)
-    x = _promote_bfloat16_to_float32(x, _semantic=_semantic)
-    y = _promote_bfloat16_to_float32(y, _semantic=_semantic)
     propagate_nan = _unwrap_if_constexpr(propagate_nan)
     return _semantic.maximum(x, y, propagate_nan)
 
@@ -2959,9 +2955,6 @@ def clamp(x, min, max, propagate_nan: constexpr = PropagateNan.NONE, _semantic=N
     x = _semantic.to_tensor(x)
     min = _semantic.to_tensor(min)
     max = _semantic.to_tensor(max)
-    x = _promote_bfloat16_to_float32(x, _semantic=_semantic)
-    min = _promote_bfloat16_to_float32(min, _semantic=_semantic)
-    max = _promote_bfloat16_to_float32(max, _semantic=_semantic)
 
     propagate_nan = _unwrap_if_constexpr(propagate_nan)
 
@@ -3066,14 +3059,6 @@ def reduce(input, axis, combine_fn, keep_dims=False, _semantic=None, _generator=
 
 
 @builtin
-def _promote_bfloat16_to_float32(t, _semantic=None):
-    # hardware doesn't support FMAX, FMIN, CMP for bfloat16
-    if isinstance(t, tensor) and t.dtype is bfloat16:
-        return t.to(float32, _semantic=_semantic)
-    return t
-
-
-@builtin
 def _reduce_with_indices(input, axis, combine_fn, keep_dims=False, _semantic=None, _generator=None):
     axis = _unwrap_if_constexpr(axis)
     n = input.shape[axis]
@@ -3111,7 +3096,7 @@ def _add_scan_docstr(name: str, dtype_arg: str = None) -> Callable[[T], T]:
 
         if dtype_arg is not None:
             docstr += f"""
-    :param {dtype_arg}: the desired data type of the returned tensor. If specified, the input tensor is casted to :code:`{dtype_arg}` before the operation is performed. If not specified, small integer types (< 32 bits) are upcasted to prevent overflow. Note that :code:`tl.bfloat16` inputs are automatically promoted to :code:`tl.float32`.
+    :param {dtype_arg}: the desired data type of the returned tensor. If specified, the input tensor is casted to :code:`{dtype_arg}` before the operation is performed. If not specified, signed integer dtypes narrower than 32 bits are upcasted to :code:`tl.int32`, while unsigned integer and bool dtypes narrower than 32 bits are upcasted to :code:`tl.uint32`. Other dtypes are kept as-is.
     :type {dtype_arg}: tl.dtype"""
 
         func.__doc__ = docstr.format(name=name)

--- a/python/triton/language/core.py
+++ b/python/triton/language/core.py
@@ -1295,10 +1295,10 @@ class tensor(base_value):
     def reduce_or(self, axis=None, keep_dims=False) -> tensor:
         ...
 
-    def cumsum(self, axis=0, reverse=False) -> tensor:
+    def cumsum(self, axis=0, reverse=False, dtype=None) -> tensor:
         ...
 
-    def cumprod(self, axis=0, reverse=False) -> tensor:
+    def cumprod(self, axis=0, reverse=False, dtype=None) -> tensor:
         ...
 
     def sort(self, dim: constexpr = None, descending: constexpr = CONSTEXPR_0) -> tensor:

--- a/python/triton/language/standard.py
+++ b/python/triton/language/standard.py
@@ -201,7 +201,6 @@ def _elementwise_max(a, b):
 @core._add_reduction_docstr("maximum", return_indices_arg="return_indices",
                             tie_break_arg="return_indices_tie_break_left")
 def max(input, axis=None, return_indices=False, return_indices_tie_break_left=True, keep_dims=False):
-    input = core._promote_bfloat16_to_float32(input)
     if return_indices:
         if return_indices_tie_break_left:
             return core._reduce_with_indices(input, axis, _argmax_combine_tie_break_left, keep_dims=keep_dims)
@@ -260,7 +259,6 @@ def _elementwise_min(a, b):
 @core._add_reduction_docstr("minimum", return_indices_arg="return_indices",
                             tie_break_arg="return_indices_tie_break_left")
 def min(input, axis=None, return_indices=False, return_indices_tie_break_left=True, keep_dims=False):
-    input = core._promote_bfloat16_to_float32(input)
     if return_indices:
         if return_indices_tie_break_left:
             return core._reduce_with_indices(input, axis, _argmin_combine_tie_break_left, keep_dims=keep_dims)
@@ -355,9 +353,6 @@ def reduce_or(input, axis, keep_dims=False):
 @jit
 @core._add_scan_docstr("cumsum", dtype_arg="dtype")
 def cumsum(input, axis=0, reverse=False, dtype: core.constexpr = None):
-    # todo rename this to a generic function name
-
-    input = core._promote_bfloat16_to_float32(input)
     out_dtype: core.constexpr = _pick_sum_dtype(input.dtype, dtype)
     input = input.to(out_dtype)
     return core.associative_scan(input, axis, _sum_combine, reverse)
@@ -373,10 +368,10 @@ def _prod_combine(a, b):
 
 @core._tensor_member_fn
 @jit
-@core._add_scan_docstr("cumprod")
-def cumprod(input, axis=0, reverse=False):
-    # todo rename this to a generic function name
-    input = core._promote_bfloat16_to_float32(input)
+@core._add_scan_docstr("cumprod", dtype_arg="dtype")
+def cumprod(input, axis=0, reverse=False, dtype: core.constexpr = None):
+    out_dtype: core.constexpr = _pick_sum_dtype(input.dtype, dtype)
+    input = input.to(out_dtype)
     return core.associative_scan(input, axis, _prod_combine, reverse)
 
 

--- a/test/Conversion/tritongpu_to_llvm_hopper.mlir
+++ b/test/Conversion/tritongpu_to_llvm_hopper.mlir
@@ -282,6 +282,20 @@ module attributes {"ttg.target" = "cuda:90", "ttg.num-ctas" = 1 : i32, "ttg.num-
 
 // -----
 
+// CHECK-LABEL: clamp_bfloat16
+module attributes {"ttg.target" = "cuda:90", "ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, "ttg.threads-per-warp" = 32 : i32} {
+  tt.func public @clamp_bfloat16(%x : bf16, %limit : bf16) {
+    %neg_limit = arith.negf %limit : bf16
+    // CHECK: nvvm.fmin.xorsign.abs.bf16
+    %0 = tt.clampf %x, %neg_limit, %limit, propagateNan = none : bf16
+    // CHECK: nvvm.fmin.nan.xorsign.abs.bf16
+    %1 = tt.clampf %x, %neg_limit, %limit, propagateNan = all : bf16
+    tt.return
+  }
+}
+
+// -----
+
 // CHECK-LABEL: clamp_scalar
 module attributes {"ttg.target" = "cuda:90", "ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, "ttg.threads-per-warp" = 32 : i32} {
   tt.func public @clamp_scalar(%x : f32, %limit : f32) {

--- a/third_party/nvidia/lib/TritonNVIDIAGPUToLLVM/ElementwiseOpToLLVM.cpp
+++ b/third_party/nvidia/lib/TritonNVIDIAGPUToLLVM/ElementwiseOpToLLVM.cpp
@@ -832,6 +832,8 @@ struct ClampFOpConversion
       name += ".f";
     } else if (elemTy.isF16()) {
       name += ".f16";
+    } else if (elemTy.isBF16()) {
+      name += ".bf16";
     }
 
     Type resultTy = operands[0][0].getType();


### PR DESCRIPTION
These promotion rules are justified by lack of hardware support, but this is not true any more.