### PR TITLE
[AMD] Disable scalar atomics in multicta kernels

### DIFF
--- a/python/test/gluon/test_frontend.py
+++ b/python/test/gluon/test_frontend.py
@@ -2824,6 +2824,26 @@ def test_atomic_cas():
     ttgl.atomic_cas(offset + ptr, old, new)
 
 
+@pytest.mark.parametrize("op", ["CAS", "RMW"])
+def test_amd_multicta_scalar_atomic_unsupported(op):
+
+    @gluon.jit
+    def kernel(ptr, op: ttgl.constexpr):
+        if op == "CAS":
+            ttgl.atomic_cas(ptr, 0, 1)
+        else:
+            ttgl.atomic_add(ptr, 1)
+
+    ptr = MockTensor(ttgl.int32)
+    args = make_args(ptr, op, num_ctas=2)
+    with pytest.raises(CompilationError) as exc:
+        run_parser(kernel, *args, target=HIP_TARGET_CDNA5)
+    assert f"scalar atomic {op} is not supported in multi-CTA kernels on AMD" in str(exc.value.__cause__)
+
+    run_parser(kernel, *args, target=HOPPER_TARGET)
+    run_parser(kernel, *make_args(ptr, op), target=HIP_TARGET_CDNA5)
+
+
 @gluon.jit
 def amd_mfma_layout_kernel():
     ttgl.full([128, 32], 0, ttgl.float32, layout=amd_layouts.AMDMFMALayout(version=3, instr_shape=[32, 32, 8],

--- a/python/triton/language/semantic.py
+++ b/python/triton/language/semantic.py
@@ -1275,6 +1275,9 @@ class TritonSemantic(Generic[TensorTy]):
         return self.tensor(handle, tl.int1)
 
     def atomic_cas(self, ptr: TensorTy, cmp: TensorTy, val: TensorTy, sem: str, scope: str) -> TensorTy:
+        is_hip = self.builder.options.backend_name == "hip"
+        if (is_hip and self.builder.options.num_ctas > 1 and not ptr.type.is_block()):
+            raise ValueError("scalar atomic CAS is not supported in multi-CTA kernels on AMD")
         sem = self._str_to_sem(sem)
         scope = self._str_to_scope(scope)
         element_ty = ptr.type.scalar.element_ty
@@ -1284,6 +1287,9 @@ class TritonSemantic(Generic[TensorTy]):
 
     def atom_red_typechecking_impl(self, ptr: TensorTy, val: TensorTy, mask: TensorTy,
                                    op: str) -> Tuple[TensorTy, TensorTy, TensorTy]:
+        is_hip = self.builder.options.backend_name == "hip"
+        if (is_hip and self.builder.options.num_ctas > 1 and not ptr.type.is_block()):
+            raise ValueError("scalar atomic RMW is not supported in multi-CTA kernels on AMD")
         if not ptr.type.scalar.is_ptr():
             raise ValueError("Pointer argument of store instruction is " + ptr.type.__repr__())
         if ptr.type.is_const() or ptr.type.element_ty.is_const():

--- a/test/Conversion/amd/cluster_barrier_to_llvm.mlir
+++ b/test/Conversion/amd/cluster_barrier_to_llvm.mlir
@@ -1,4 +1,4 @@
-// RUN: triton-opt %s -split-input-file --allocate-shared-memory --convert-triton-amdgpu-to-llvm=gfx-arch=gfx1250 | FileCheck %s
+// RUN: triton-opt %s -split-input-file --allocate-shared-memory --convert-triton-amdgpu-to-llvm=gfx-arch=gfx1250 --verify-diagnostics | FileCheck %s
 
 module attributes {"ttg.num-ctas" = 2 : i32, "ttg.num-warps" = 4 : i32} {
   // CHECK-LABEL: cluster_barrier_arrive
@@ -22,14 +22,21 @@ module attributes {"ttg.num-ctas" = 2 : i32, "ttg.num-warps" = 4 : i32} {
 // -----
 
 module attributes {"ttg.num-ctas" = 2 : i32, "ttg.num-warps" = 4 : i32, "ttg.threads-per-warp" = 32 : i32} {
-  // CHECK-LABEL: atomic_cluster_barrier
-  tt.func @atomic_cluster_barrier(%ptr: !tt.ptr<i32>, %cmp: i32, %val: i32) {
-    // CHECK-NOT: rocdl.s.barrier
-    // CHECK: llvm.cmpxchg {{.*}} syncscope("agent") acquire monotonic
-    // CHECK: rocdl.s.barrier.signal id = -3
-    // CHECK: rocdl.s.barrier.wait id = -3
-    // CHECK-NOT: rocdl.s.barrier
+  tt.func @unsupported_scalar_atomic_cas(%ptr: !tt.ptr<i32>, %cmp: i32, %val: i32) {
+    // expected-error@+2 {{scalar atomic CAS is not supported in multi-CTA kernels on AMD}}
+    // expected-error@+1 {{failed to legalize operation 'tt.atomic_cas' that was explicitly marked illegal}}
     %old = tt.atomic_cas acquire, gpu, %ptr, %cmp, %val : (!tt.ptr<i32>, i32, i32) -> i32
+    tt.return
+  }
+}
+
+// -----
+
+module attributes {"ttg.num-ctas" = 2 : i32, "ttg.num-warps" = 4 : i32, "ttg.threads-per-warp" = 32 : i32} {
+  tt.func @unsupported_scalar_atomic_rmw(%ptr: !tt.ptr<i32>, %val: i32) {
+    // expected-error@+2 {{scalar atomic RMW is not supported in multi-CTA kernels on AMD}}
+    // expected-error@+1 {{failed to legalize operation 'tt.atomic_rmw' that was explicitly marked illegal}}
+    %old = tt.atomic_rmw add, acquire, gpu, %ptr, %val : (!tt.ptr<i32>, i32) -> i32
     tt.return
   }
 }

--- a/third_party/amd/lib/TritonAMDGPUToLLVM/LoadStoreOpToLLVM.cpp
+++ b/third_party/amd/lib/TritonAMDGPUToLLVM/LoadStoreOpToLLVM.cpp
@@ -2095,6 +2095,11 @@ struct AtomicCASOpConversion
   LogicalResult
   matchAndRewrite(triton::AtomicCASOp op, OpAdaptor adaptor,
                   ConversionPatternRewriter &rewriter) const override {
+    if (lookupNumCTAs(op) > 1 &&
+        !isa<RankedTensorType>(op.getResult().getType()))
+      return op.emitError(
+          "scalar atomic CAS is not supported in multi-CTA kernels on AMD");
+
     // extract relevant info from Module
     auto loc = op.getLoc();
     insertAtomicOrderingBarriers(op, op.getSem(),
@@ -2277,6 +2282,11 @@ struct AtomicRMWOpConversion
   LogicalResult
   matchAndRewrite(triton::AtomicRMWOp op, OpAdaptor adaptor,
                   ConversionPatternRewriter &rewriter) const override {
+    if (lookupNumCTAs(op) > 1 &&
+        !isa<RankedTensorType>(op.getResult().getType()))
+      return op.emitError(
+          "scalar atomic RMW is not supported in multi-CTA kernels on AMD");
+
     auto loc = op.getLoc();
     insertAtomicOrderingBarriers(op, op.getSem(),
                                  !op->hasAttr("allocation.offset"), rewriter,


### PR DESCRIPTION
Disable scalar atomics on AMD side for multi-cta kernels. Guard in both compiler and frontend. Update corresponding tests.