### PR TITLE
[BACKEND] Add per-kernel NVPTX register-pressure scheduling

### DIFF
--- a/python/src/llvm.cc
+++ b/python/src/llvm.cc
@@ -9,6 +9,8 @@
 #include "llvm/CodeGen/MIRParser/MIRParser.h"
 #include "llvm/CodeGen/MachineModuleInfo.h"
 #include "llvm/CodeGen/MachineRegisterInfo.h"
+#include "llvm/CodeGen/SchedulerRegistry.h"
+#include "llvm/CodeGen/SelectionDAGISel.h"
 #include "llvm/Config/llvm-config.h"
 #include "llvm/IR/DebugInfo.h"
 #include "llvm/IR/IRBuilder.h"
@@ -29,6 +31,7 @@
 #include "llvm/Plugins/PassPlugin.h"
 #include "llvm/Support/CodeGen.h"
 #include "llvm/Support/Parallel.h"
+#include "llvm/Support/SaveAndRestore.h"
 #include "llvm/Support/Signals.h"
 #include "llvm/Support/SourceMgr.h"
 #include "llvm/Support/TargetSelect.h"
@@ -42,6 +45,7 @@
 #include <csignal>
 #include <cstdio>
 #include <memory>
+#include <mutex>
 #include <nanobind/make_iterator.h>
 #include <nanobind/nanobind.h>
 #include <nanobind/stl/optional.h>
@@ -186,6 +190,29 @@ public:
   ScopedLLVMOption(const ScopedLLVMOption &) = delete;
   ScopedLLVMOption &operator=(const ScopedLLVMOption &) = delete;
 };
+
+thread_local bool scheduleForRegisters = false;
+
+ScheduleDAGSDNodes *createTritonDAGScheduler(SelectionDAGISel *selector,
+                                             CodeGenOptLevel optLevel) {
+  // LLVM's scheduler callback has no user-data argument. Keep the requested
+  // policy local to the thread performing this compilation.
+  if (scheduleForRegisters && selector->TM.getTargetTriple().isNVPTX())
+    return createBURRListDAGScheduler(selector, optLevel);
+  return createDefaultScheduler(selector, optLevel);
+}
+
+void installTritonDAGScheduler() {
+  static RegisterScheduler scheduler("triton-nvptx",
+                                     "Triton compilation-local NVPTX scheduler",
+                                     createTritonDAGScheduler);
+  auto options = llvm::cl::getRegisteredOptions();
+  auto option = options.find("pre-RA-sched");
+  if (option == options.end())
+    throw std::runtime_error("LLVM SelectionDAG scheduler option is missing");
+  if (option->second->addOccurrence(1, "pre-RA-sched", "triton-nvptx"))
+    throw std::runtime_error("failed to install Triton's LLVM scheduler");
+}
 
 std::unique_ptr<TargetMachine>
 createTargetMachine(llvm::Module *module, std::string proc,
@@ -876,36 +903,43 @@ void init_triton_llvm(py::module_ &m) {
       py::arg("expand_masked_div_rem") = false,
       py::call_guard<py::gil_scoped_release>());
 
-  m.def("translate_to_asm",
-        [](std::string llvmIR, std::string triple, std::string proc,
-           std::string features, std::vector<std::string> flags,
-           bool enable_fp_fusion, bool isObject,
-           bool canonicalizeGEP) -> py::object {
-          std::string obj;
-          {
-            // when allow_threads goes out of scope, gil will be released
-            py::gil_scoped_release allow_threads;
-            // create LLVM module from C++
-            llvm::LLVMContext context;
-            std::unique_ptr<llvm::MemoryBuffer> buffer =
-                llvm::MemoryBuffer::getMemBuffer(llvmIR.c_str());
-            llvm::SMDiagnostic error;
-            std::unique_ptr<llvm::Module> module =
-                llvm::parseIR(buffer->getMemBufferRef(), error, context);
-            if (!module) {
-              llvm::report_fatal_error(
-                  "failed to parse IR: " + error.getMessage() +
-                  "lineno: " + std::to_string(error.getLineNo()));
-            }
-            obj = translateLLVMIRToASM(*module, triple, proc, features, flags,
-                                       enable_fp_fusion, isObject,
-                                       canonicalizeGEP);
+  m.def(
+      "translate_to_asm",
+      [](std::string llvmIR, std::string triple, std::string proc,
+         std::string features, std::vector<std::string> flags,
+         bool enable_fp_fusion, bool isObject, bool canonicalizeGEP,
+         bool sched4reg) -> py::object {
+        std::string obj;
+        {
+          // when allow_threads goes out of scope, gil will be released
+          py::gil_scoped_release allow_threads;
+          llvm::SaveAndRestore schedulingPolicy(scheduleForRegisters,
+                                                sched4reg);
+          // create LLVM module from C++
+          llvm::LLVMContext context;
+          std::unique_ptr<llvm::MemoryBuffer> buffer =
+              llvm::MemoryBuffer::getMemBuffer(llvmIR.c_str());
+          llvm::SMDiagnostic error;
+          std::unique_ptr<llvm::Module> module =
+              llvm::parseIR(buffer->getMemBufferRef(), error, context);
+          if (!module) {
+            llvm::report_fatal_error(
+                "failed to parse IR: " + error.getMessage() +
+                "lineno: " + std::to_string(error.getLineNo()));
           }
-          if (isObject)
-            return py::object(py::bytes(obj.c_str(), obj.size()));
-          else
-            return py::object(py::str(obj.c_str(), obj.size()));
-        });
+          obj =
+              translateLLVMIRToASM(*module, triple, proc, features, flags,
+                                   enable_fp_fusion, isObject, canonicalizeGEP);
+        }
+        if (isObject)
+          return py::object(py::bytes(obj.c_str(), obj.size()));
+        else
+          return py::object(py::str(obj.c_str(), obj.size()));
+      },
+      py::arg("llvm_ir"), py::arg("triple"), py::arg("proc"),
+      py::arg("features"), py::arg("flags"), py::arg("enable_fp_fusion"),
+      py::arg("is_object"), py::arg("canonicalize_gep"),
+      py::arg("sched4reg") = false);
 
   m.def("dump_sched_dag", [](std::string llvmIR, std::string triple,
                              std::string proc, std::string features,
@@ -990,6 +1024,10 @@ void init_triton_llvm(py::module_ &m) {
       LLVMInitializeAMDGPUTargetMC();
       LLVMInitializeAMDGPUAsmParser();
       LLVMInitializeAMDGPUAsmPrinter();
+
+      // Installed exactly once, before any target compilation. The dispatcher
+      // reads thread-local state and is safe for parallel codegen.
+      installTritonDAGScheduler();
     });
     // Disable LLVM's internal parallelism. Triton kernels produce small LLVM
     // modules where pass-level parallelism is not beneficial, and LLVM's global

--- a/python/test/unit/test_knobs.py
+++ b/python/test/unit/test_knobs.py
@@ -2,6 +2,7 @@ import os
 import pytest
 import shutil
 import triton
+from concurrent.futures import ThreadPoolExecutor
 from triton._internal_testing import is_hip
 
 from pathlib import Path
@@ -66,6 +67,61 @@ def test_knobs_utils(fresh_knobs) -> None:
         "baz": None,
         "quux": True,
     }
+
+
+def _register_pressure_scheduler_kernel():
+    from triton.backends.compiler import GPUTarget
+    from triton.backends.nvidia import compiler
+
+    compiler.llvm.init_targets()
+    backend = compiler.CUDABackend(GPUTarget("cuda", 90, 32))
+    arithmetic = []
+    stores = []
+    for lane in range(32):
+        arithmetic.extend([
+            f"  %seed{lane} = add i32 %seed, {lane + 1}",
+            f"  %high{lane} = call i32 @llvm.nvvm.mulhi.ui(i32 %seed{lane}, i32 -766435501)",
+            f"  %low{lane} = mul i32 %seed{lane}, -845247145",
+            f"  %value{lane} = xor i32 %high{lane}, %low{lane}",
+        ])
+        stores.extend([
+            f"  %out{lane} = getelementptr i32, ptr addrspace(1) %out, i64 {lane}",
+            f"  store i32 %value{lane}, ptr addrspace(1) %out{lane}, align 4",
+        ])
+
+    source = ('target triple = "nvptx64-nvidia-cuda"\n'
+              'declare i32 @llvm.nvvm.mulhi.ui(i32, i32)\n'
+              'define ptx_kernel void @scheduler_kernel(ptr addrspace(1) %out, i32 %seed) {\n' +
+              "\n".join(arithmetic + stores) + "\n  ret void\n}\n")
+    return backend, source
+
+
+@pytest.mark.skipif(is_hip(), reason="NVPTX code generation is unavailable on AMD")
+def test_nvidia_register_pressure_scheduler_hook():
+    backend, source = _register_pressure_scheduler_kernel()
+    default_options = backend.parse_options({"ptx_version": 80, "sched4reg": False})
+    pressure_options = backend.parse_options({"ptx_version": 80, "sched4reg": True})
+
+    assert default_options.hash() != pressure_options.hash()
+    assert backend.make_ptx(source, {}, default_options, 90) != backend.make_ptx(source, {}, pressure_options, 90)
+
+
+@pytest.mark.skipif(is_hip(), reason="NVPTX code generation is unavailable on AMD")
+def test_nvidia_register_pressure_scheduler_concurrent():
+    backend, source = _register_pressure_scheduler_kernel()
+
+    def emit(pressure_sensitive):
+        options = backend.parse_options({"ptx_version": 80, "sched4reg": pressure_sensitive})
+        return backend.make_ptx(source, {}, options, 90)
+
+    expected = {False: emit(False), True: emit(True)}
+    assert expected[False] != expected[True]
+
+    scheduling_policies = [bool(index % 2) for index in range(24)]
+    with ThreadPoolExecutor(max_workers=8) as executor:
+        results = list(executor.map(emit, scheduling_policies))
+
+    assert results == [expected[policy] for policy in scheduling_policies]
 
 
 def test_knobs_scope(fresh_knobs, monkeypatch):

--- a/third_party/nvidia/backend/compiler.py
+++ b/third_party/nvidia/backend/compiler.py
@@ -118,6 +118,7 @@ class CUDAOptions:
     ptx_options: Optional[str] = knobs.nvidia.ptxas_options
     ir_override: Optional[str] = None  # filename of a user-defined IR (*.{ttir|ttgir|llir|ptx})
     enable_fp_fusion: bool = True
+    sched4reg: bool = False
     enable_reflect_ftz: bool = True  # ftz in libdevice
     launch_cooperative_grid: bool = False
     launch_pdl: bool = False
@@ -535,7 +536,8 @@ class CUDABackend(BaseBackend):
         features = get_features(opt, cap_llvm)
         flags = ["nvptx-mad-wide-opt"]
         canonicalize_gep = "fpsan" in opt.instrumentation_mode
-        ret = llvm.translate_to_asm(src, triple, proc, features, flags, opt.enable_fp_fusion, False, canonicalize_gep)
+        ret = llvm.translate_to_asm(src, triple, proc, features, flags, opt.enable_fp_fusion, False, canonicalize_gep,
+                                    sched4reg=opt.sched4reg)
         # Find kernel names (there should only be one)
         names = re.findall(r".visible .entry ([a-zA-Z_][a-zA-Z0-9_]*)", ret)
         assert len(names) == 1


### PR DESCRIPTION
Expose sched4reg as an optional NVIDIA kernel setting and pass it directly to LLVM assembly generation. Select scheduling policy through scoped thread-local state so concurrent compilations remain independent.
