### PR TITLE
[Gluon] Expose rich cache policies

### DIFF
--- a/include/triton/Dialect/Triton/IR/CMakeLists.txt
+++ b/include/triton/Dialect/Triton/IR/CMakeLists.txt
@@ -7,6 +7,10 @@ mlir_tablegen(OpsEnums.h.inc -gen-enum-decls)
 mlir_tablegen(OpsEnums.cpp.inc -gen-enum-defs)
 add_mlir_doc(TritonOps TritonOps dialects/ -gen-op-doc -dialect=tt)
 
+set(LLVM_TARGET_DEFINITIONS TritonAttrDefs.td)
+mlir_tablegen(AttrDefs.h.inc -gen-attrdef-decls)
+mlir_tablegen(AttrDefs.cpp.inc -gen-attrdef-defs)
+
 set(LLVM_TARGET_DEFINITIONS TritonDialect.td)
 mlir_tablegen(Dialect.h.inc -gen-dialect-decls)
 mlir_tablegen(Dialect.cpp.inc -gen-dialect-defs)

--- a/include/triton/Dialect/Triton/IR/Dialect.h
+++ b/include/triton/Dialect/Triton/IR/Dialect.h
@@ -15,6 +15,10 @@
 #include "triton/Dialect/Triton/IR/Dialect.h.inc"
 #include "triton/Dialect/Triton/IR/OpInterfaces.h"
 #include "triton/Dialect/Triton/IR/OpsEnums.h.inc"
+
+#define GET_ATTRDEF_CLASSES
+#include "triton/Dialect/Triton/IR/AttrDefs.h.inc"
+
 #include "triton/Dialect/Triton/IR/Traits.h"
 #include "triton/Dialect/Triton/IR/Types.h"
 

--- a/include/triton/Dialect/Triton/IR/Dialect.h
+++ b/include/triton/Dialect/Triton/IR/Dialect.h
@@ -33,6 +33,24 @@ struct GlobalMemory : public SideEffects::Resource::Base<GlobalMemory> {
   SideEffects::Resource *getParent() const override { return nullptr; }
 };
 
+enum class CachePolicyOperation { Load, Store };
+
+// Allows memory operations to validate cache policy attributes without
+// depending on the dialect that defines the policy.
+class DialectCachePolicyInterface
+    : public DialectInterface::Base<DialectCachePolicyInterface> {
+public:
+  DialectCachePolicyInterface(Dialect *dialect) : Base(dialect) {}
+
+  virtual LogicalResult
+  verifyCachePolicy(Attribute cachePolicy, CachePolicyOperation operation,
+                    function_ref<InFlightDiagnostic()> emitError) const = 0;
+};
+
+LogicalResult verifyCacheModifier(CacheModifier modifier,
+                                  CachePolicyOperation operation,
+                                  function_ref<InFlightDiagnostic()> emitError);
+
 class DialectInferLayoutInterface
     : public DialectInterface::Base<DialectInferLayoutInterface> {
 public:

--- a/include/triton/Dialect/Triton/IR/Dialect.h
+++ b/include/triton/Dialect/Triton/IR/Dialect.h
@@ -50,6 +50,8 @@ public:
 LogicalResult verifyCacheModifier(CacheModifier modifier,
                                   CachePolicyOperation operation,
                                   function_ref<InFlightDiagnostic()> emitError);
+LogicalResult verifyCachePolicy(Operation *op, Attribute cachePolicy,
+                                CachePolicyOperation operation);
 
 class DialectInferLayoutInterface
     : public DialectInterface::Base<DialectInferLayoutInterface> {

--- a/include/triton/Dialect/Triton/IR/TritonAttrDefs.td
+++ b/include/triton/Dialect/Triton/IR/TritonAttrDefs.td
@@ -1,23 +1,12 @@
 #ifndef TRITON_ATTR_DEFS
 #define TRITON_ATTR_DEFS
 
+include "mlir/IR/AttrTypeBase.td"
 include "mlir/IR/EnumAttr.td"
+include "triton/Dialect/Triton/IR/TritonAttrEnums.td"
+include "triton/Dialect/Triton/IR/TritonDialect.td"
 
 // Attributes for LoadOp and StoreOp
-def TT_CacheModifierAttr : I32EnumAttr<
-    "CacheModifier", "",
-    [
-        I32EnumAttrCase<"NONE", 1, "none">,
-        I32EnumAttrCase<"CA", 2, "ca">,
-        I32EnumAttrCase<"CG", 3, "cg">,
-        I32EnumAttrCase<"WB", 4, "wb">,
-        I32EnumAttrCase<"CS", 5, "cs">,
-        I32EnumAttrCase<"WT", 6, "wt">,
-        I32EnumAttrCase<"CV", 7, "cv">,
-    ]> {
-    let cppNamespace = "::mlir::triton";
-}
-
 def TT_MemSemanticAttr : I32EnumAttr<
     "MemSemantic", "",
     [
@@ -37,6 +26,23 @@ def TT_EvictionPolicyAttr : I32EnumAttr<
         I32EnumAttrCase<"EVICT_LAST", 3, "evict_last">
     ]> {
     let cppNamespace = "::mlir::triton";
+}
+
+def TT_CachePolicyAttr : AttrDef<Triton_Dialect, "CachePolicy"> {
+    let mnemonic = "cache_policy";
+    let description = [{
+      Target-neutral cache hints used by Triton memory operations.
+
+      Target dialects may define richer cache policy attributes. This
+      attribute represents the cache modifier and eviction policy exposed by
+      the common Triton language API. Cache policies are performance hints and
+      have no memory-ordering semantics.
+    }];
+    let parameters = (ins
+      EnumParameter<TT_CacheModifierAttr>:$cache_modifier,
+      EnumParameter<TT_EvictionPolicyAttr>:$eviction_policy
+    );
+    let assemblyFormat = "`<` struct(params) `>`";
 }
 
 def TT_PaddingOptionAttr : I32EnumAttr<

--- a/include/triton/Dialect/Triton/IR/TritonAttrEnums.td
+++ b/include/triton/Dialect/Triton/IR/TritonAttrEnums.td
@@ -1,0 +1,20 @@
+#ifndef TRITON_ATTR_ENUMS
+#define TRITON_ATTR_ENUMS
+
+include "mlir/IR/EnumAttr.td"
+
+def TT_CacheModifierAttr : I32EnumAttr<
+    "CacheModifier", "",
+    [
+        I32EnumAttrCase<"NONE", 1, "none">,
+        I32EnumAttrCase<"CA", 2, "ca">,
+        I32EnumAttrCase<"CG", 3, "cg">,
+        I32EnumAttrCase<"WB", 4, "wb">,
+        I32EnumAttrCase<"CS", 5, "cs">,
+        I32EnumAttrCase<"WT", 6, "wt">,
+        I32EnumAttrCase<"CV", 7, "cv">,
+    ]> {
+  let cppNamespace = "::mlir::triton";
+}
+
+#endif // TRITON_ATTR_ENUMS

--- a/include/triton/Dialect/Triton/IR/TritonDialect.td
+++ b/include/triton/Dialect/Triton/IR/TritonDialect.td
@@ -50,6 +50,7 @@ def Triton_Dialect : Dialect {
   );
 
   let hasConstantMaterializer = 1;
+  let useDefaultAttributePrinterParser = 1;
   let useDefaultTypePrinterParser = 1;
 }
 

--- a/include/triton/Dialect/Triton/IR/TritonOps.td
+++ b/include/triton/Dialect/Triton/IR/TritonOps.td
@@ -254,6 +254,7 @@ def TT_LoadOp : TT_Op<"load", [
       attr-dict `:` type($ptr)
     }];
 
+    let hasVerifier = 1;
     let hasCanonicalizer = 1;
 }
 
@@ -290,6 +291,7 @@ def TT_StoreOp : TT_Op<"store", [
       attr-dict `:` type($ptr)
     }];
 
+    let hasVerifier = 1;
     let hasCanonicalizer = 1;
 }
 

--- a/include/triton/Dialect/Triton/IR/TritonOps.td
+++ b/include/triton/Dialect/Triton/IR/TritonOps.td
@@ -231,8 +231,7 @@ def TT_LoadOp : TT_Op<"load", [
       TT_PtrLike:$ptr,
       Optional<TT_BoolLike>:$mask,
       Optional<TT_Type>:$other,
-      DefaultValuedAttr<TT_CacheModifierAttr, "::mlir::triton::CacheModifier::NONE">:$cache,
-      DefaultValuedAttr<TT_EvictionPolicyAttr, "::mlir::triton::EvictionPolicy::NORMAL">:$evict,
+      OptionalAttr<AnyAttr>:$cachePolicy,
       DefaultValuedAttr<BoolAttr, "false">:$isVolatile
     );
 
@@ -240,32 +239,18 @@ def TT_LoadOp : TT_Op<"load", [
 
     let builders = [
         // A tensor of pointers or a pointer to a scalar
-        OpBuilder<(ins "Value":$ptr, "triton::CacheModifier":$cache,
-                       "triton::EvictionPolicy":$evict, "bool":$isVolatile)>,
+        OpBuilder<(ins "Value":$ptr,
+                       CArg<"bool", "false">:$isVolatile)>,
         // A tensor of pointers or a pointer to a scalar with mask
-        OpBuilder<(ins "Value":$ptr, "Value":$mask, "triton::CacheModifier":$cache,
-                       "triton::EvictionPolicy":$evict, "bool":$isVolatile)>
+        OpBuilder<(ins "Value":$ptr, "Value":$mask,
+                       CArg<"bool", "false">:$isVolatile)>,
+        // A tensor of pointers or a pointer to a scalar with mask and other
+        OpBuilder<(ins "Value":$ptr, "Value":$mask, "Value":$other,
+                       CArg<"bool", "false">:$isVolatile)>
     ];
 
-    // Specify `cacheModifier` and `evictionPolicy` explicitly in the
-    // assemblyFormat instead of as part of attr-dict so that they get printed
-    // as strings rather than opaque integers.
-    //
-    // Note there's no comma between `other` and `cacheModifier` and between
-    // `cacheModifier` and `evictionPolicy`.  This is due to an apparent
-    // limitation in the MLIR custom-format parser.  In oilist, the initial
-    // keywords of each clause have to be unique, so they can't be `,`.
-    //
-    // Even if we gave up on order-independence and used vanilla optional
-    // clauses, the format (`,` `foo` `=` $foo^)? (`,` `bar` `=` $bar^)?  will
-    // not match the string ", bar = 0" because after the initial comma (first
-    // token of the first optional clause) we expect to see "foo".
     let assemblyFormat = [{
       $ptr (`,` $mask^)? (`,` $other^)?
-      oilist(
-        `cacheModifier` `=` $cache |
-        `evictionPolicy` `=` $evict
-      )
       attr-dict `:` type($ptr)
     }];
 
@@ -288,25 +273,20 @@ def TT_StoreOp : TT_Op<"store", [
       Arg<TT_PtrLike, "", [MemWrite<GlobalMemory>]>:$ptr,
       TT_Type:$value,
       Optional<TT_BoolLike>:$mask,
-      DefaultValuedAttr<TT_CacheModifierAttr, "triton::CacheModifier::NONE">:$cache,
-      DefaultValuedAttr<TT_EvictionPolicyAttr, "triton::EvictionPolicy::NORMAL">:$evict,
+      OptionalAttr<AnyAttr>:$cachePolicy,
       UnitAttr:$ignore_cta
     );
 
     let builders = [
         // A tensor of pointers or a pointer to a scalar
-        OpBuilder<(ins "Value":$ptr, "Value":$value, "triton::CacheModifier":$cache, "triton::EvictionPolicy":$evict)>
+        OpBuilder<(ins "Value":$ptr, "Value":$value)>,
+        // A tensor of pointers or a pointer to a scalar with mask
+        OpBuilder<(ins "Value":$ptr, "Value":$value, "Value":$mask,
+                       CArg<"bool", "false">:$ignore_cta)>
     ];
 
-    // Specify cacheModifier and evictionPolicy explicitly, instead of leaving
-    // them in attr-dict, because this way their values get printed as strings,
-    // rather than as opaque integers.
-    //
-    // Note there are no commas between mask, cacheModifier, and evictionPolicy,
-    // due to limitations in MLIR's asm parser.
     let assemblyFormat = [{
       $ptr `,` $value (`,` $mask^)?
-      oilist(`cacheModifier` `=` $cache | `evictionPolicy` `=` $evict)
       attr-dict `:` type($ptr)
     }];
 
@@ -1276,18 +1256,13 @@ def TT_DescriptorLoadOp : TT_Op<"descriptor_load", [TT_DescriptorLoadLikeOpInter
   let arguments = (ins
     Arg<TT_TensorDescType, "", [MemRead<GlobalMemory>]>:$desc,
     Variadic<I32>:$indices,
-    DefaultValuedAttr<TT_CacheModifierAttr, "::mlir::triton::CacheModifier::NONE">:$cache,
-    DefaultValuedAttr<TT_EvictionPolicyAttr, "::mlir::triton::EvictionPolicy::NORMAL">:$evict
+    OptionalAttr<AnyAttr>:$cachePolicy
   );
 
   let results = (outs TT_Tensor:$result);
 
   let assemblyFormat = [{
     $desc `[` $indices `]`
-    oilist(
-      `cacheModifier` `=` $cache |
-      `evictionPolicy` `=` $evict
-    )
     attr-dict `:` qualified(type($desc)) `->` type($result)
   }];
 

--- a/include/triton/Dialect/TritonGPU/IR/TritonGPUOps.td
+++ b/include/triton/Dialect/TritonGPU/IR/TritonGPUOps.td
@@ -119,8 +119,7 @@ def TTG_AsyncCopyGlobalToLocalOp : TTG_Op<"async_copy_global_to_local", [
     Arg<TTG_MemDescType, "", GenericSharedWrite>:$result,
     Optional<I1Tensor>:$mask,
     Optional<TT_Type>:$other,
-    DefaultValuedAttr<TT_CacheModifierAttr, "triton::CacheModifier::NONE">:$cache,
-    DefaultValuedAttr<TT_EvictionPolicyAttr, "triton::EvictionPolicy::NORMAL">:$evict,
+    OptionalAttr<AnyAttr>:$cachePolicy,
     DefaultValuedAttr<BoolAttr, "false">:$isVolatile,
     DefaultValuedAttr<I32Attr, "1">:$contiguity
   );
@@ -137,15 +136,8 @@ def TTG_AsyncCopyGlobalToLocalOp : TTG_Op<"async_copy_global_to_local", [
     }
   }];
 
-  // Specify cacheModifier and evictionPolicy explicitly, instead of leaving
-  // them in attr-dict, because this way their values get printed as strings,
-  // rather than as opaque integers.
-  //
-  // Note there are no commas between other, cacheModifier, and evictionPolicy,
-  // due to limitations in MLIR's asm parser.
   let assemblyFormat = [{
     $src `,` $result (`mask` $mask^)? (`other` $other^)?
-    oilist(`cacheModifier` `=` $cache | `evictionPolicy` `=` $evict)
     attr-dict `:` type($src) `->` type($result)
   }];
 }

--- a/include/triton/Dialect/TritonNvidiaGPU/IR/CMakeLists.txt
+++ b/include/triton/Dialect/TritonNvidiaGPU/IR/CMakeLists.txt
@@ -17,6 +17,8 @@ add_public_tablegen_target(TritonNvidiaGPUTypesIncGen)
 set(LLVM_TARGET_DEFINITIONS TritonNvidiaGPUAttrDefs.td)
 mlir_tablegen(TritonNvidiaGPUAttrDefs.h.inc -gen-attrdef-decls)
 mlir_tablegen(TritonNvidiaGPUAttrDefs.cpp.inc -gen-attrdef-defs)
+
+set(LLVM_TARGET_DEFINITIONS TritonNvidiaGPUEnums.td)
 mlir_tablegen(OpsEnums.h.inc -gen-enum-decls)
 mlir_tablegen(OpsEnums.cpp.inc -gen-enum-defs)
 add_public_tablegen_target(TritonNvidiaGPUAttrDefsIncGen)

--- a/include/triton/Dialect/TritonNvidiaGPU/IR/TritonNvidiaGPUAttrDefs.td
+++ b/include/triton/Dialect/TritonNvidiaGPU/IR/TritonNvidiaGPUAttrDefs.td
@@ -3,10 +3,44 @@
 
 include "mlir/IR/AttrTypeBase.td"
 include "mlir/IR/EnumAttr.td"
+include "triton/Dialect/Triton/IR/TritonAttrEnums.td"
+include "triton/Dialect/TritonNvidiaGPU/IR/TritonNvidiaGPUEnums.td"
 include "triton/Dialect/TritonNvidiaGPU/IR/TritonNvidiaGPUDialect.td"
 include "triton/Dialect/Triton/IR/TritonInterfaces.td"
 include "triton/Dialect/TritonGPU/IR/TritonGPUAttrInterfaces.td"
-include "mlir/IR/EnumAttr.td"
+
+class TTNG_DefaultCacheModifierParameter
+    : EnumParameter<TT_CacheModifierAttr> {
+  let defaultValue = "::mlir::triton::CacheModifier::NONE";
+}
+
+class TTNG_DefaultCacheEvictionPriorityParameter
+    : EnumParameter<TTNG_CacheEvictionPriorityAttr> {
+  let defaultValue =
+      "::mlir::triton::nvidia_gpu::CacheEvictionPriority::NONE";
+}
+
+def TTNG_CachePolicyAttr
+    : AttrDef<TritonNvidiaGPU_Dialect, "CachePolicy"> {
+  let mnemonic = "cache_policy";
+  let description = [{
+    NVIDIA global-memory cache hints.
+
+    The attribute can contain a cache modifier, an L1 eviction priority, an L2
+    fractional eviction policy, and an L2 prefetch size. This attribute is a
+    performance hint and has no memory-ordering semantics.
+  }];
+  let parameters = (ins
+    TTNG_DefaultCacheModifierParameter<>:$cache_modifier,
+    TTNG_DefaultCacheEvictionPriorityParameter<>:$l1,
+    TTNG_DefaultCacheEvictionPriorityParameter<>:$l2_primary,
+    TTNG_DefaultCacheEvictionPriorityParameter<>:$l2_secondary,
+    OptionalParameter<"FloatAttr">:$l2_fraction,
+    OptionalParameter<"IntegerAttr">:$l2_prefetch_size
+  );
+  let assemblyFormat = "`<` struct(params) `>`";
+  let genVerifyDecl = 1;
+}
 
 def TTG_TensorMemorySpace : AttrDef<TritonNvidiaGPU_Dialect, "TensorMemorySpace"> {
   let mnemonic = "tensor_memory";
@@ -34,50 +68,10 @@ def TTG_TensorMemorySpace : AttrDef<TritonNvidiaGPU_Dialect, "TensorMemorySpace"
   }];
 }
 
-def TTNG_TMEMWaitKindAttr : I32EnumAttr<
-    "TMEMWaitKind", "tensor memory wait kind",
-    [
-        I32EnumAttrCase<"LOAD", 0, "load">,
-        I32EnumAttrCase<"STORE", 1, "store">,
-    ]> {
-  let cppNamespace = "::mlir::triton::nvidia_gpu";
-}
-
-def TTNG_TMEMLoadReduceModifierAttr : I32EnumAttr<
-    "TMEMLoadReduceModifier", "",
-    [
-        I32EnumAttrCase<"MIN", 1, "min">,
-        I32EnumAttrCase<"MAX", 2, "max">,
-    ]> {
-    let cppNamespace = "::mlir::triton::nvidia_gpu";
-    let genSpecializedAttr = 0;
-}
 def TTNG_TMEMLoadReduceModifierEnum : EnumAttr<TritonNvidiaGPU_Dialect, TTNG_TMEMLoadReduceModifierAttr, "redOp"> {
   let assemblyFormat = "`<` $value `>`";
 }
 
-def TTNG_PackedArithOpKindAttr : I32EnumAttr<
-    "PackedArithOpKind", "packed arithmetic operation",
-    [
-        I32EnumAttrCase<"ADD", 0, "add">,
-        I32EnumAttrCase<"SUB", 1, "sub">,
-        I32EnumAttrCase<"MUL", 2, "mul">,
-        I32EnumAttrCase<"FMA", 3, "fma">,
-        I32EnumAttrCase<"MIN", 4, "min">,
-        I32EnumAttrCase<"MAX", 5, "max">,
-    ]> {
-  let cppNamespace = "::mlir::triton::nvidia_gpu";
-}
-
-def TTNG_TensorMemoryScalesBlockRepOrderAttr : I32EnumAttr<
-    "TensorMemoryScalesBlockRepOrder", "",
-    [
-        I32EnumAttrCase<"MN_THEN_K", 0, "mnThenK">,
-        I32EnumAttrCase<"K_THEN_MN", 1, "kThenMn">,
-    ]> {
-    let cppNamespace = "::mlir::triton::nvidia_gpu";
-    let genSpecializedAttr = 0;
-}
 def TTNG_TensorMemoryScalesBlockRepOrderEnum
     : EnumAttr<TritonNvidiaGPU_Dialect,
                TTNG_TensorMemoryScalesBlockRepOrderAttr, "blockRepOrder"> {

--- a/include/triton/Dialect/TritonNvidiaGPU/IR/TritonNvidiaGPUEnums.td
+++ b/include/triton/Dialect/TritonNvidiaGPU/IR/TritonNvidiaGPUEnums.td
@@ -1,0 +1,62 @@
+#ifndef TRITONNVIDIAGPU_ENUMS
+#define TRITONNVIDIAGPU_ENUMS
+
+include "mlir/IR/EnumAttr.td"
+
+def TTNG_CacheEvictionPriorityAttr : I32EnumAttr<
+    "CacheEvictionPriority", "NVIDIA cache eviction priority",
+    [
+      I32EnumAttrCase<"NONE", 0, "none">,
+      I32EnumAttrCase<"EVICT_NORMAL", 1, "evict_normal">,
+      I32EnumAttrCase<"EVICT_UNCHANGED", 2, "evict_unchanged">,
+      I32EnumAttrCase<"EVICT_FIRST", 3, "evict_first">,
+      I32EnumAttrCase<"EVICT_LAST", 4, "evict_last">,
+      I32EnumAttrCase<"NO_ALLOCATE", 5, "no_allocate">
+    ]> {
+  let cppNamespace = "::mlir::triton::nvidia_gpu";
+  let genSpecializedAttr = 0;
+}
+
+def TTNG_TMEMWaitKindAttr : I32EnumAttr<
+    "TMEMWaitKind", "tensor memory wait kind",
+    [
+        I32EnumAttrCase<"LOAD", 0, "load">,
+        I32EnumAttrCase<"STORE", 1, "store">,
+    ]> {
+  let cppNamespace = "::mlir::triton::nvidia_gpu";
+}
+
+def TTNG_TMEMLoadReduceModifierAttr : I32EnumAttr<
+    "TMEMLoadReduceModifier", "",
+    [
+        I32EnumAttrCase<"MIN", 1, "min">,
+        I32EnumAttrCase<"MAX", 2, "max">,
+    ]> {
+  let cppNamespace = "::mlir::triton::nvidia_gpu";
+  let genSpecializedAttr = 0;
+}
+
+def TTNG_PackedArithOpKindAttr : I32EnumAttr<
+    "PackedArithOpKind", "packed arithmetic operation",
+    [
+        I32EnumAttrCase<"ADD", 0, "add">,
+        I32EnumAttrCase<"SUB", 1, "sub">,
+        I32EnumAttrCase<"MUL", 2, "mul">,
+        I32EnumAttrCase<"FMA", 3, "fma">,
+        I32EnumAttrCase<"MIN", 4, "min">,
+        I32EnumAttrCase<"MAX", 5, "max">,
+    ]> {
+  let cppNamespace = "::mlir::triton::nvidia_gpu";
+}
+
+def TTNG_TensorMemoryScalesBlockRepOrderAttr : I32EnumAttr<
+    "TensorMemoryScalesBlockRepOrder", "",
+    [
+        I32EnumAttrCase<"MN_THEN_K", 0, "mnThenK">,
+        I32EnumAttrCase<"K_THEN_MN", 1, "kThenMn">,
+    ]> {
+  let cppNamespace = "::mlir::triton::nvidia_gpu";
+  let genSpecializedAttr = 0;
+}
+
+#endif // TRITONNVIDIAGPU_ENUMS

--- a/lib/Dialect/Triton/IR/Dialect.cpp
+++ b/lib/Dialect/Triton/IR/Dialect.cpp
@@ -21,6 +21,25 @@ using namespace mlir::triton;
 // TritonDialect Dialect Interfaces
 //===----------------------------------------------------------------------===//
 
+namespace {
+
+class TritonCachePolicyInterface : public DialectCachePolicyInterface {
+public:
+  using DialectCachePolicyInterface::DialectCachePolicyInterface;
+
+  LogicalResult verifyCachePolicy(
+      Attribute cachePolicy, CachePolicyOperation operation,
+      function_ref<InFlightDiagnostic()> emitError) const override {
+    auto policy = dyn_cast<CachePolicyAttr>(cachePolicy);
+    if (!policy)
+      return emitError() << "unsupported Triton cache policy attribute "
+                         << cachePolicy;
+    return verifyCacheModifier(policy.getCacheModifier(), operation, emitError);
+  }
+};
+
+} // namespace
+
 bool TritonInlinerInterface::isLegalToInline(Operation *call,
                                              Operation *callable,
                                              bool wouldBeCloned) const {
@@ -91,6 +110,7 @@ void TritonDialect::initialize() {
       >();
 
   // We can also add interface here.
+  addInterfaces<TritonCachePolicyInterface>();
   addInterfaces<TritonInlinerInterface>();
 }
 

--- a/lib/Dialect/Triton/IR/Dialect.cpp
+++ b/lib/Dialect/Triton/IR/Dialect.cpp
@@ -14,6 +14,9 @@
 using namespace mlir;
 using namespace mlir::triton;
 
+#define GET_ATTRDEF_CLASSES
+#include "triton/Dialect/Triton/IR/AttrDefs.cpp.inc"
+
 //===----------------------------------------------------------------------===//
 // TritonDialect Dialect Interfaces
 //===----------------------------------------------------------------------===//
@@ -76,6 +79,11 @@ Value TritonInlinerInterface::handleResult(OpBuilder &, Operation *call,
 
 void TritonDialect::initialize() {
   registerTypes();
+
+  addAttributes<
+#define GET_ATTRDEF_LIST
+#include "triton/Dialect/Triton/IR/AttrDefs.cpp.inc"
+      >();
 
   addOperations<
 #define GET_OP_LIST

--- a/lib/Dialect/Triton/IR/Ops.cpp
+++ b/lib/Dialect/Triton/IR/Ops.cpp
@@ -65,8 +65,8 @@ verifyCacheModifier(CacheModifier modifier, CachePolicyOperation operation,
                                                                  : "stores");
 }
 
-static LogicalResult verifyCachePolicy(Operation *op, Attribute cachePolicy,
-                                       CachePolicyOperation operation) {
+LogicalResult verifyCachePolicy(Operation *op, Attribute cachePolicy,
+                                CachePolicyOperation operation) {
   if (!cachePolicy)
     return success();
   Dialect &dialect = cachePolicy.getDialect();

--- a/lib/Dialect/Triton/IR/Ops.cpp
+++ b/lib/Dialect/Triton/IR/Ops.cpp
@@ -39,6 +39,46 @@ void LoadOp::getEffects(
 namespace mlir {
 namespace triton {
 
+LogicalResult
+verifyCacheModifier(CacheModifier modifier, CachePolicyOperation operation,
+                    function_ref<InFlightDiagnostic()> emitError) {
+  bool isSupported = false;
+  switch (operation) {
+  case CachePolicyOperation::Load:
+    isSupported =
+        modifier == CacheModifier::NONE || modifier == CacheModifier::CA ||
+        modifier == CacheModifier::CG || modifier == CacheModifier::CS ||
+        modifier == CacheModifier::CV;
+    break;
+  case CachePolicyOperation::Store:
+    isSupported =
+        modifier == CacheModifier::NONE || modifier == CacheModifier::WB ||
+        modifier == CacheModifier::CG || modifier == CacheModifier::CS ||
+        modifier == CacheModifier::WT;
+    break;
+  }
+  if (isSupported)
+    return success();
+  return emitError() << "cache modifier '" << stringifyCacheModifier(modifier)
+                     << "' is not supported for "
+                     << (operation == CachePolicyOperation::Load ? "loads"
+                                                                 : "stores");
+}
+
+static LogicalResult verifyCachePolicy(Operation *op, Attribute cachePolicy,
+                                       CachePolicyOperation operation) {
+  if (!cachePolicy)
+    return success();
+  Dialect &dialect = cachePolicy.getDialect();
+  auto *interface = dyn_cast<DialectCachePolicyInterface>(&dialect);
+  if (!interface)
+    return op->emitOpError("unsupported cache policy attribute ")
+           << cachePolicy;
+  return interface->verifyCachePolicy(cachePolicy, operation, [&]() {
+    return op->emitOpError("invalid cache policy: ");
+  });
+}
+
 //-- LoadOp --
 void LoadOp::build(OpBuilder &builder, OperationState &state, Value ptr,
                    bool isVolatile) {
@@ -63,6 +103,11 @@ Value LoadOp::getPredicateOperand() { return getMask(); }
 void LoadOp::setPredicateOperand(Value pred) { getMaskMutable().assign(pred); }
 
 Type LoadOp::getPredicateOperandTypeLike() { return getPtr().getType(); }
+
+LogicalResult LoadOp::verify() {
+  return verifyCachePolicy(*this, getCachePolicyAttr(),
+                           CachePolicyOperation::Load);
+}
 
 // load(ptr, splat(1), ...)        -> load(ptr, ...)
 // load(ptr, splat(0), other, ...) -> other
@@ -126,6 +171,11 @@ Value StoreOp::getPredicateOperand() { return getMask(); }
 void StoreOp::setPredicateOperand(Value pred) { getMaskMutable().assign(pred); }
 
 Type StoreOp::getPredicateOperandTypeLike() { return getPtr().getType(); }
+
+LogicalResult StoreOp::verify() {
+  return verifyCachePolicy(*this, getCachePolicyAttr(),
+                           CachePolicyOperation::Store);
+}
 
 // store(ptr, value, splat(1), ...) -> store(ptr, value, ...)
 // store(ptr, value, splat(0), ...) -> [none]

--- a/lib/Dialect/Triton/IR/Ops.cpp
+++ b/lib/Dialect/Triton/IR/Ops.cpp
@@ -41,15 +41,20 @@ namespace triton {
 
 //-- LoadOp --
 void LoadOp::build(OpBuilder &builder, OperationState &state, Value ptr,
-                   CacheModifier cache, EvictionPolicy evict, bool isVolatile) {
-  LoadOp::build(builder, state, ptr, /*mask=*/{}, /*other=*/{}, cache, evict,
-                isVolatile);
+                   bool isVolatile) {
+  LoadOp::build(builder, state, ptr, /*mask=*/{}, /*other=*/{},
+                /*cachePolicy=*/{}, isVolatile);
 }
 
 void LoadOp::build(OpBuilder &builder, OperationState &state, Value ptr,
-                   Value mask, CacheModifier cache, EvictionPolicy evict,
-                   bool isVolatile) {
-  LoadOp::build(builder, state, ptr, mask, /*other=*/{}, cache, evict,
+                   Value mask, bool isVolatile) {
+  LoadOp::build(builder, state, ptr, mask, /*other=*/{},
+                /*cachePolicy=*/{}, isVolatile);
+}
+
+void LoadOp::build(OpBuilder &builder, OperationState &state, Value ptr,
+                   Value mask, Value other, bool isVolatile) {
+  LoadOp::build(builder, state, ptr, mask, other, /*cachePolicy=*/{},
                 isVolatile);
 }
 
@@ -83,7 +88,7 @@ struct CanonicalizeMaskedLoadPattern : public OpRewritePattern<LoadOp> {
       // mask = splat(1)
       rewriter.replaceOpWithNewOp<LoadOp>(
           loadOp, loadOp.getType(), loadOp.getPtr(), Value(), Value(),
-          loadOp.getCache(), loadOp.getEvict(), loadOp.getIsVolatile());
+          loadOp.getCachePolicyAttr(), loadOp.getIsVolatile());
     } else {
       // mask = splat(0)
 
@@ -105,8 +110,15 @@ void LoadOp::getCanonicalizationPatterns(RewritePatternSet &results,
 
 //-- StoreOp --
 void StoreOp::build(OpBuilder &builder, OperationState &state, Value ptr,
-                    Value value, CacheModifier cache, EvictionPolicy evict) {
-  return StoreOp::build(builder, state, ptr, value, /*mask=*/{}, cache, evict);
+                    Value value) {
+  StoreOp::build(builder, state, ptr, value, /*mask=*/{},
+                 /*cachePolicy=*/{});
+}
+
+void StoreOp::build(OpBuilder &builder, OperationState &state, Value ptr,
+                    Value value, Value mask, bool ignoreCTA) {
+  StoreOp::build(builder, state, ptr, value, mask, /*cachePolicy=*/{},
+                 ignoreCTA);
 }
 
 Value StoreOp::getPredicateOperand() { return getMask(); }
@@ -138,8 +150,8 @@ struct CanonicalizeMaskedStorePattern : public OpRewritePattern<StoreOp> {
     if (splatMask.getSplatValue<IntegerAttr>().getValue() == true) {
       // mask = splat(1)
       rewriter.replaceOpWithNewOp<StoreOp>(
-          storeOp, storeOp.getPtr(), storeOp.getValue(), storeOp.getCache(),
-          storeOp.getEvict());
+          storeOp, storeOp.getPtr(), storeOp.getValue(), Value(),
+          storeOp.getCachePolicyAttr(), storeOp.getIgnoreCta());
     } else {
       // mask = splat(0)
       rewriter.eraseOp(storeOp);

--- a/lib/Dialect/Triton/Transforms/Combine.cpp
+++ b/lib/Dialect/Triton/Transforms/Combine.cpp
@@ -102,7 +102,7 @@ public:
 
     rewriter.replaceOpWithNewOp<LoadOp>(
         op, loadOp.getPtr(), loadOp.getMask(), /*other=*/falseValue,
-        loadOp.getCache(), loadOp.getEvict(), loadOp.getIsVolatile());
+        loadOp.getCachePolicyAttr(), loadOp.getIsVolatile());
     return success();
   }
 };

--- a/lib/Dialect/Triton/Transforms/RewriteTensorDescriptorToPointer.cpp
+++ b/lib/Dialect/Triton/Transforms/RewriteTensorDescriptorToPointer.cpp
@@ -329,8 +329,9 @@ struct RewriteLoadPattern : OpConversionPattern<triton::DescriptorLoadOp> {
     auto newLoad = triton::LoadOp::create(
         rewriter, loc, generatePtr(rewriter, loc, blockShape, desc, offsets),
         generateMask(rewriter, loc, blockShape, desc, offsets), other,
-        triton::CacheModifier::NONE, triton::EvictionPolicy::NORMAL, false);
-    newLoad->setAttrs(filterSegmentSizes(op->getAttrs()));
+        op.getCachePolicyAttr());
+    auto attrs = filterSegmentSizes(op->getAttrs());
+    newLoad->setAttrs(attrs);
 
     Value result = newLoad.getResult();
     if (descTy.getElementType().isF32()) {
@@ -370,8 +371,7 @@ struct RewriteStorePattern : OpConversionPattern<triton::DescriptorStoreOp> {
 
     auto newStore = rewriter.replaceOpWithNewOp<triton::StoreOp>(
         op, generatePtr(rewriter, loc, blockShape, desc, offsets), op.getSrc(),
-        generateMask(rewriter, loc, blockShape, desc, offsets),
-        triton::CacheModifier::NONE, triton::EvictionPolicy::NORMAL);
+        generateMask(rewriter, loc, blockShape, desc, offsets));
     newStore->setAttrs(attrs);
 
     return llvm::success();
@@ -414,9 +414,7 @@ struct RewriteGatherPattern : OpConversionPattern<triton::DescriptorGatherOp> {
     auto other = generateOther(rewriter, loc,
                                descTy.getSignlessBlockType().getElementType(),
                                blockShape, desc.paddingOption);
-    auto newLoad = triton::LoadOp::create(
-        rewriter, loc, ptr, mask, other, triton::CacheModifier::NONE,
-        triton::EvictionPolicy::NORMAL, false);
+    auto newLoad = triton::LoadOp::create(rewriter, loc, ptr, mask, other);
     newLoad->setAttrs(filterSegmentSizes(op->getAttrs()));
 
     Value result = newLoad.getResult();
@@ -450,8 +448,7 @@ struct RewriteScatterPattern
     auto attrs = filterSegmentSizes(op->getAttrs());
 
     auto newStore = rewriter.replaceOpWithNewOp<triton::StoreOp>(
-        op, ptr, op.getSrc(), mask, triton::CacheModifier::NONE,
-        triton::EvictionPolicy::NORMAL);
+        op, ptr, op.getSrc(), mask);
     newStore->setAttrs(attrs);
 
     return llvm::success();

--- a/lib/Dialect/TritonGPU/Transforms/Pipeliner/LowerLoops.cpp
+++ b/lib/Dialect/TritonGPU/Transforms/Pipeliner/LowerLoops.cpp
@@ -169,7 +169,7 @@ void createAsyncCopy(scf::ForOp forOp, tt::LoadOp loadOp, Value alloc,
   // Create async copy
   Value view = createSingleBufferView(builder, alloc, insertIdx);
   Operation *copy = ttg::AsyncCopyGlobalToLocalOp::create(
-      builder, src, view, mask, other, loadOp.getCache(), loadOp.getEvict(),
+      builder, src, view, mask, other, loadOp.getCachePolicyAttr(),
       loadOp.getIsVolatile(), contiguity);
   Operation *commit =
       ttg::AsyncCommitGroupOp::create(builder, copy->getResult(0));

--- a/lib/Dialect/TritonInstrument/IR/Utility.cpp
+++ b/lib/Dialect/TritonInstrument/IR/Utility.cpp
@@ -380,15 +380,13 @@ Operation *createStoreScratchMemory(OpBuilder &b, Location loc, Value alloc,
   }
   auto ptrTensor = createPointerTensor(b, loc, alloc, tensorType);
   return StoreOp::create(b, loc, ptrTensor, tensor, storeMask,
-                         CacheModifier::NONE, EvictionPolicy::NORMAL,
                          /*ignore_cta=*/true);
 }
 
 Value createLoadScratchMemory(OpBuilder &b, Location loc, Value alloc,
                               RankedTensorType tensorType) {
   auto ptrTensor = createPointerTensor(b, loc, alloc, tensorType);
-  Value value = LoadOp::create(b, loc, ptrTensor, CacheModifier::NONE,
-                               EvictionPolicy::NORMAL, false);
+  Value value = LoadOp::create(b, loc, ptrTensor);
   // Finish replicated reads before another thread can update the scratch.
   auto freeVarMasks = toLinearLayout(tensorType).getFreeVariableMasks();
   if (freeVarMasks.lookup(b.getStringAttr("lane")) ||

--- a/lib/Dialect/TritonInstrument/Transforms/FpSanitizer.cpp
+++ b/lib/Dialect/TritonInstrument/Transforms/FpSanitizer.cpp
@@ -1058,9 +1058,7 @@ static Value loadScratchStrided2D(PatternRewriter &rewriter, Location loc,
   auto storageTy = getScratchStorageType(tensorTy);
   auto ptrTensor = createPointerTensorStrided2D(rewriter, loc, base, storageTy,
                                                 stride0, stride1);
-  Value stored =
-      tt::LoadOp::create(rewriter, loc, ptrTensor, CacheModifier::NONE,
-                         EvictionPolicy::NORMAL, false);
+  Value stored = tt::LoadOp::create(rewriter, loc, ptrTensor);
   if (isFloatLike(tensorTy))
     return unembedToFloat(rewriter, loc, stored, tensorTy);
   return stored;
@@ -1085,7 +1083,6 @@ static Operation *storeScratchStrided2D(PatternRewriter &rewriter, Location loc,
   if (isFloatLike(tensorTy))
     stored = embedToInt(rewriter, loc, tensor);
   return tt::StoreOp::create(rewriter, loc, ptrTensor, stored, Value(),
-                             CacheModifier::NONE, EvictionPolicy::NORMAL,
                              ignoreCTA);
 }
 

--- a/lib/Dialect/TritonNvidiaGPU/IR/Dialect.cpp
+++ b/lib/Dialect/TritonNvidiaGPU/IR/Dialect.cpp
@@ -59,6 +59,10 @@ CachePolicyAttr::verify(function_ref<InFlightDiagnostic()> emitError,
                         CacheEvictionPriority secondary, FloatAttr fraction,
                         IntegerAttr prefetchSize) {
   using Priority = CacheEvictionPriority;
+  if (cacheModifier != triton::CacheModifier::NONE && l1 != Priority::NONE)
+    return emitError()
+           << "cache modifier cannot be combined with an L1 eviction priority";
+
   if (primary == Priority::NO_ALLOCATE)
     return emitError() << "invalid L2 primary eviction priority '"
                        << stringifyCacheEvictionPriority(primary) << "'";
@@ -604,6 +608,26 @@ TensorDescIm2ColType::verify(function_ref<InFlightDiagnostic()> emitError,
 
 namespace {
 //===----------------------------------------------------------------------===//
+// Cache Policy Interface
+//===----------------------------------------------------------------------===//
+class TritonNvidiaGPUCachePolicyInterface
+    : public triton::DialectCachePolicyInterface {
+public:
+  using DialectCachePolicyInterface::DialectCachePolicyInterface;
+
+  LogicalResult verifyCachePolicy(
+      Attribute cachePolicy, triton::CachePolicyOperation operation,
+      function_ref<InFlightDiagnostic()> emitError) const override {
+    auto policy = dyn_cast<CachePolicyAttr>(cachePolicy);
+    if (!policy)
+      return emitError() << "unsupported NVIDIA cache policy attribute "
+                         << cachePolicy;
+    return triton::verifyCacheModifier(policy.getCacheModifier(), operation,
+                                       emitError);
+  }
+};
+
+//===----------------------------------------------------------------------===//
 // Verify Tensor/MemDesc Layout Interface
 //===----------------------------------------------------------------------===//
 class TritonNvidiaGPUVerifyTensorLayoutInterface
@@ -674,6 +698,7 @@ void TritonNvidiaGPUDialect::initialize() {
 #define GET_TYPEDEF_LIST
 #include "triton/Dialect/TritonNvidiaGPU/IR/Types.cpp.inc"
       >();
+  addInterfaces<TritonNvidiaGPUCachePolicyInterface>();
   addInterfaces<TritonNvidiaGPUVerifyTensorLayoutInterface>();
   addInterfaces<TritonGPUOpAsmInterface>();
   addInterfaces<TritonInlinerInterface>();

--- a/lib/Dialect/TritonNvidiaGPU/IR/Dialect.cpp
+++ b/lib/Dialect/TritonNvidiaGPU/IR/Dialect.cpp
@@ -40,6 +40,8 @@
 #include "llvm/ADT/TypeSwitch.h"
 #include "llvm/Support/Debug.h"
 
+#include <cmath>
+
 #include "triton/Dialect/TritonNvidiaGPU/IR/Dialect.cpp.inc"
 
 using namespace mlir;
@@ -49,6 +51,41 @@ using namespace mlir::triton::nvidia_gpu;
 namespace mlir {
 namespace triton {
 namespace nvidia_gpu {
+
+LogicalResult
+CachePolicyAttr::verify(function_ref<InFlightDiagnostic()> emitError,
+                        triton::CacheModifier cacheModifier,
+                        CacheEvictionPriority l1, CacheEvictionPriority primary,
+                        CacheEvictionPriority secondary, FloatAttr fraction,
+                        IntegerAttr prefetchSize) {
+  using Priority = CacheEvictionPriority;
+  if (primary == Priority::NO_ALLOCATE)
+    return emitError() << "invalid L2 primary eviction priority '"
+                       << stringifyCacheEvictionPriority(primary) << "'";
+
+  if (primary != Priority::NONE) {
+    if (secondary == Priority::NONE || !fraction)
+      return emitError() << "L2 policy requires l2_secondary and l2_fraction";
+    if (secondary != Priority::EVICT_FIRST &&
+        secondary != Priority::EVICT_UNCHANGED)
+      return emitError() << "invalid L2 secondary eviction priority '"
+                         << stringifyCacheEvictionPriority(secondary) << "'";
+    double value = fraction.getValueAsDouble();
+    if (!fraction.getType().isF32() || !std::isfinite(value) || value <= 0.0 ||
+        value > 1.0)
+      return emitError() << "L2 fraction must be a finite f32 in (0, 1]";
+  } else if (secondary != Priority::NONE || fraction) {
+    return emitError() << "l2_secondary and l2_fraction require l2_primary";
+  }
+
+  if (prefetchSize) {
+    int64_t size = prefetchSize.getInt();
+    if (!prefetchSize.getType().isInteger(32) ||
+        (size != 64 && size != 128 && size != 256))
+      return emitError() << "L2 prefetch size must be 64, 128, or 256";
+  }
+  return success();
+}
 
 namespace {
 

--- a/python/src/gluon_ir.cc
+++ b/python/src/gluon_ir.cc
@@ -365,6 +365,61 @@ void init_gluon_ir(py::module_ &m) {
       .def(py::init<MLIRContext *, std::string>(), py::arg("context"),
            py::arg("arch") = "")
       .def("get_op_builder", &GluonOpBuilder::getBuilder, ret::reference)
+      .def("get_cache_policy",
+           [](GluonOpBuilder &self, const std::string &cacheModifier,
+              const std::string &evictionPolicy) -> Attribute {
+             auto modifier = tt::symbolizeCacheModifier(cacheModifier);
+             if (!modifier)
+               throw std::invalid_argument("invalid cache modifier '" +
+                                           cacheModifier + "'");
+             auto eviction = tt::symbolizeEvictionPolicy(evictionPolicy);
+             if (!eviction)
+               throw std::invalid_argument("invalid eviction policy '" +
+                                           evictionPolicy + "'");
+             return buildCachePolicy(self.getBuilder(), *modifier, *eviction);
+           })
+      .def(
+          "get_nvidia_cache_policy",
+          [](GluonOpBuilder &self, std::optional<std::string> cacheModifier,
+             std::optional<std::string> l1,
+             std::optional<std::string> l2Primary,
+             std::optional<std::string> l2Secondary,
+             std::optional<double> l2Fraction,
+             std::optional<int32_t> l2PrefetchSize) -> Attribute {
+            auto *ctx = self.getContext();
+            auto parseModifier = [](const std::optional<std::string> &value) {
+              if (!value)
+                return tt::CacheModifier::NONE;
+              auto parsed = tt::symbolizeCacheModifier(*value);
+              if (!parsed)
+                throw std::invalid_argument("invalid cache modifier '" +
+                                            *value + "'");
+              return *parsed;
+            };
+            auto parsePriority = [](const std::optional<std::string> &value) {
+              if (!value)
+                return ttng::CacheEvictionPriority::NONE;
+              auto parsed = ttng::symbolizeCacheEvictionPriority(*value);
+              if (!parsed)
+                throw std::invalid_argument(
+                    "invalid cache eviction priority '" + *value + "'");
+              return *parsed;
+            };
+            FloatAttr fractionAttr;
+            if (l2Fraction)
+              fractionAttr = FloatAttr::get(Float32Type::get(ctx), *l2Fraction);
+            IntegerAttr prefetchSizeAttr;
+            if (l2PrefetchSize)
+              prefetchSizeAttr =
+                  IntegerAttr::get(IntegerType::get(ctx, 32), *l2PrefetchSize);
+            return self.getChecked<ttng::CachePolicyAttr>(
+                ctx, parseModifier(cacheModifier), parsePriority(l1),
+                parsePriority(l2Primary), parsePriority(l2Secondary),
+                fractionAttr, prefetchSizeAttr);
+          },
+          py::arg("cacheModifier").none(), py::arg("l1").none(),
+          py::arg("l2Primary").none(), py::arg("l2Secondary").none(),
+          py::arg("l2Fraction").none(), py::arg("l2PrefetchSize").none())
       .def("get_distributed_ty",
            [](GluonOpBuilder &self, Type &elementType,
               std::vector<int64_t> &shape, Attribute layout) -> Type {
@@ -717,21 +772,16 @@ void init_gluon_ir(py::module_ &m) {
              return self.create<ttg::Fp4ToFpOp>(
                  cast<TypedValue<RankedTensorType>>(src), elemType, axis);
            })
-      .def("create_async_copy_global_to_local",
-           [](GluonOpBuilder &self, Value smem, Value pointer, Value mask,
-              Value other, tt::CacheModifier cacheModifier,
-              tt::EvictionPolicy evictionPolicy, bool isVolatile) {
-             self.create<ttg::AsyncCopyGlobalToLocalOp>(
-                 pointer, smem, mask, other, cacheModifier, evictionPolicy,
-                 isVolatile);
-           })
-      .def("create_async_copy_local_to_global",
-           [](GluonOpBuilder &self, Value smem, Value pointer, Value mask,
-              tt::CacheModifier cacheModifier,
-              tt::EvictionPolicy evictionPolicy) {
-             self.create<ttag::AsyncCopyLocalToGlobalOp>(
-                 smem, pointer, mask, cacheModifier, evictionPolicy);
-           })
+      .def(
+          "create_async_copy_global_to_local",
+          [](GluonOpBuilder &self, Value smem, Value pointer, Value mask,
+             Value other, Attribute cachePolicy, bool isVolatile) {
+            self.create<ttg::AsyncCopyGlobalToLocalOp>(
+                pointer, smem, mask, other, cachePolicy, isVolatile,
+                /*contiguity=*/1);
+          },
+          py::arg("smem"), py::arg("pointer"), py::arg("mask"),
+          py::arg("other"), py::arg("cachePolicy"), py::arg("isVolatile"))
       .def("create_async_copy_mbarrier_arrive",
            [](GluonOpBuilder &self, Value mbarrier, bool incrementCount) {
              self.create<ttng::AsyncCopyMbarrierArriveOp>(mbarrier,
@@ -1127,16 +1177,19 @@ void init_gluon_ir(py::module_ &m) {
            })
       .def("create_buffer_load",
            [](GluonOpBuilder &self, Type resultType, Value ptr, Value offsets,
-              Value mask, Value other, tt::CacheModifier cache) -> Value {
-             return self.create<ttag::BufferLoadOp>(resultType, ptr, offsets,
-                                                    Value() /*stride*/, cache,
-                                                    mask, other);
+              Value mask, Value other,
+              tt::CacheModifier cacheModifier) -> Value {
+             return self.create<ttag::BufferLoadOp>(
+                 resultType, ptr, offsets, Value() /*stride*/,
+                 buildCachePolicy(self.getBuilder(), cacheModifier), mask,
+                 other);
            })
       .def("create_buffer_store",
            [](GluonOpBuilder &self, Value storedValue, Value ptr, Value offsets,
-              Value mask, tt::CacheModifier cache) {
-             self.create<ttag::BufferStoreOp>(storedValue, ptr, offsets,
-                                              Value() /*stride*/, cache, mask);
+              Value mask, tt::CacheModifier cacheModifier) {
+             self.create<ttag::BufferStoreOp>(
+                 storedValue, ptr, offsets, Value() /*stride*/,
+                 buildCachePolicy(self.getBuilder(), cacheModifier), mask);
            })
       .def("create_buffer_atomic_rmw",
            [](GluonOpBuilder &self, tt::RMWOp op, Value ptr, Value offsets,
@@ -1151,7 +1204,8 @@ void init_gluon_ir(py::module_ &m) {
               Value mask, Value other, Value stride,
               tt::CacheModifier cacheModifier) {
              self.create<ttag::BufferLoadToLocalOp>(
-                 dest, ptr, offsets, mask, other, stride, cacheModifier);
+                 dest, ptr, offsets, mask, other, stride,
+                 buildCachePolicy(self.getBuilder(), cacheModifier));
            })
       .def("create_local_load_packed_transposed",
            [](GluonOpBuilder &self, Type resultType, Value memDesc) -> Value {

--- a/python/src/gluon_ir.cc
+++ b/python/src/gluon_ir.cc
@@ -782,6 +782,12 @@ void init_gluon_ir(py::module_ &m) {
           },
           py::arg("smem"), py::arg("pointer"), py::arg("mask"),
           py::arg("other"), py::arg("cachePolicy"), py::arg("isVolatile"))
+      .def("create_async_copy_local_to_global",
+           [](GluonOpBuilder &self, Value smem, Value pointer, Value mask,
+              Attribute cachePolicy) {
+             self.create<ttag::AsyncCopyLocalToGlobalOp>(
+                 smem, pointer, mask, cachePolicy, /*contiguity=*/1);
+           })
       .def("create_async_copy_mbarrier_arrive",
            [](GluonOpBuilder &self, Value mbarrier, bool incrementCount) {
              self.create<ttng::AsyncCopyMbarrierArriveOp>(mbarrier,

--- a/python/src/ir.cc
+++ b/python/src/ir.cc
@@ -46,6 +46,7 @@
 #include "triton/Tools/Sys/GetEnv.h"
 #include "llvm/Support/SourceMgr.h"
 #include <memory>
+#include <stdexcept>
 
 namespace {
 
@@ -865,6 +866,19 @@ void init_triton_ir(py::module_ &m) {
       py::class_<TritonOpBuilder>(m, "builder", py::dynamic_attr());
   TritonOpBuilderBinding.def(py::init<MLIRContext *>())
       .def("get_op_builder", &TritonOpBuilder::getBuilder, ret::reference)
+      .def("get_cache_policy",
+           [](TritonOpBuilder &self, const std::string &cacheModifier,
+              const std::string &evictionPolicy) -> Attribute {
+             auto modifier = symbolizeCacheModifier(cacheModifier);
+             if (!modifier)
+               throw std::invalid_argument("invalid cache modifier '" +
+                                           cacheModifier + "'");
+             auto eviction = symbolizeEvictionPolicy(evictionPolicy);
+             if (!eviction)
+               throw std::invalid_argument("invalid eviction policy '" +
+                                           evictionPolicy + "'");
+             return buildCachePolicy(self.getBuilder(), *modifier, *eviction);
+           })
       // getters
       .def("create_module",
            [](TritonOpBuilder &self) -> ModuleOp {
@@ -1550,36 +1564,34 @@ void init_triton_ir(py::module_ &m) {
            })
       // Input/Output
       .def("create_load",
-           [](TritonOpBuilder &self, Value &ptrs, CacheModifier cacheModifier,
-              EvictionPolicy evictionPolicy, bool isVolatile) -> Value {
-             return self.create<LoadOp>(ptrs, cacheModifier, evictionPolicy,
+           [](TritonOpBuilder &self, Value &ptrs, Attribute cachePolicy,
+              bool isVolatile) -> Value {
+             return self.create<LoadOp>(ptrs, Value(), Value(), cachePolicy,
                                         isVolatile);
            })
       .def("create_store",
            [](TritonOpBuilder &self, Value &ptrs, Value &value,
-              CacheModifier cacheModifier,
-              EvictionPolicy evictionPolicy) -> void {
-             self.create<StoreOp>(ptrs, value, cacheModifier, evictionPolicy);
+              Attribute cachePolicy) -> void {
+             self.create<StoreOp>(ptrs, value, Value(), cachePolicy);
            })
       .def(
           "create_masked_load",
           [](TritonOpBuilder &self, Value &ptrs, Value &mask,
-             std::optional<Value> &other, CacheModifier cacheModifier,
-             EvictionPolicy evictionPolicy, bool isVolatile) -> Value {
+             std::optional<Value> &other, Attribute cachePolicy,
+             bool isVolatile) -> Value {
             return self.create<LoadOp>(ptrs, mask, other.value_or(Value()),
-                                       cacheModifier, evictionPolicy,
-                                       isVolatile);
+                                       cachePolicy, isVolatile);
           },
           py::arg("ptrs"), py::arg("mask"), py::arg("other").none(),
-          py::arg("cacheModifier"), py::arg("evictionPolicy"),
-          py::arg("isVolatile"))
-      .def("create_masked_store",
-           [](TritonOpBuilder &self, Value &ptrs, Value &val, Value &mask,
-              CacheModifier cacheModifier,
-              EvictionPolicy evictionPolicy) -> void {
-             self.create<StoreOp>(ptrs, val, mask, cacheModifier,
-                                  evictionPolicy);
-           })
+          py::arg("cachePolicy"), py::arg("isVolatile"))
+      .def(
+          "create_masked_store",
+          [](TritonOpBuilder &self, Value &ptrs, Value &val, Value &mask,
+             Attribute cachePolicy) -> void {
+            self.create<StoreOp>(ptrs, val, mask, cachePolicy);
+          },
+          py::arg("ptrs"), py::arg("val"), py::arg("mask"),
+          py::arg("cachePolicy"))
       .def("create_tensor_descriptor_type",
            [](TritonOpBuilder &self, Type blockTy, bool isSigned) -> Type {
              auto rtt = cast<RankedTensorType>(blockTy);
@@ -1588,12 +1600,11 @@ void init_triton_ir(py::module_ &m) {
            })
       .def("create_descriptor_load",
            [](TritonOpBuilder &self, Value desc, std::vector<Value> &indices,
-              CacheModifier cacheModifier,
-              EvictionPolicy evictionPolicy) -> Value {
+              Attribute cachePolicy) -> Value {
              auto descTy = cast<triton::TensorDescType>(desc.getType());
              auto resTy = descTy.getSignlessBlockType();
-             return self.create<DescriptorLoadOp>(
-                 resTy, desc, indices, cacheModifier, evictionPolicy);
+             return self.create<DescriptorLoadOp>(resTy, desc, indices,
+                                                  cachePolicy);
            })
       .def("create_descriptor_gather",
            [](TritonOpBuilder &self, Value desc, Value x_indices, Value y_index,

--- a/python/src/ir.h
+++ b/python/src/ir.h
@@ -1,9 +1,22 @@
 #pragma once
 #include "mlir/IR/Builders.h"
 #include "mlir/IR/DialectRegistry.h"
+#include "triton/Dialect/Triton/IR/Dialect.h"
 #include "triton/Tools/Sys/GetEnv.h"
 #include <memory>
 #include <string>
+
+inline mlir::Attribute
+buildCachePolicy(mlir::OpBuilder &builder,
+                 mlir::triton::CacheModifier cacheModifier,
+                 mlir::triton::EvictionPolicy evictionPolicy =
+                     mlir::triton::EvictionPolicy::NORMAL) {
+  if (cacheModifier == mlir::triton::CacheModifier::NONE &&
+      evictionPolicy == mlir::triton::EvictionPolicy::NORMAL)
+    return {};
+  return mlir::triton::CachePolicyAttr::get(builder.getContext(), cacheModifier,
+                                            evictionPolicy);
+}
 
 // A custom op builder that keeps track of the last location
 class TritonOpBuilder {

--- a/python/test/gluon/test_frontend.py
+++ b/python/test/gluon/test_frontend.py
@@ -3376,7 +3376,8 @@ def amd_async_copy_shared_to_global(ptr):
 
     # test mask
     mask = (y_offset < 64)[:, None]
-    cdna5_async_copy.shared_to_global(ptr + offsets, smem, mask)
+    # CHECK: amdg.async_copy_local_to_global {{.*}} mask {{.*}} {cachePolicy = #tt.cache_policy<cache_modifier = cg, eviction_policy = evict_normal>}
+    cdna5_async_copy.shared_to_global(ptr + offsets, smem, mask, cache_modifier=".cg")
 
     cdna5_async_copy.commit_group()
 
@@ -3384,6 +3385,7 @@ def amd_async_copy_shared_to_global(ptr):
 @pytest.mark.parametrize("target", [HIP_TARGET_CDNA5])
 def test_amd_async_copy_shared_to_global(target):
     ptr = MockTensor(ttgl.float16)
+    run_filecheck_test(amd_async_copy_shared_to_global, *make_args(ptr), target=target)
     mod = run_parser(amd_async_copy_shared_to_global, *make_args(ptr), target=target)
     expecttest.assert_expected_inline(
         anonymize_ir(mod.str_nodebug()), """\
@@ -3414,7 +3416,7 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.targ
     %14 = tt.splat %arg0 : !tt.ptr<f16> -> tensor<128x16x!tt.ptr<f16>, #blocked>
     %15 = tt.addptr %14, %8 : tensor<128x16x!tt.ptr<f16>, #blocked>, tensor<128x16xi32, #blocked>
     %16 = tt.broadcast %13 : tensor<128x1xi1, #blocked> -> tensor<128x16xi1, #blocked>
-    %17 = amdg.async_copy_local_to_global %0, %15 mask %16 : !ttg.memdesc<128x16xf16, #shared, #smem, mutable> -> tensor<128x16x!tt.ptr<f16>, #blocked>
+    %17 = amdg.async_copy_local_to_global %0, %15 mask %16 {cachePolicy = #tt.cache_policy<cache_modifier = cg, eviction_policy = evict_normal>} : !ttg.memdesc<128x16xf16, #shared, #smem, mutable> -> tensor<128x16x!tt.ptr<f16>, #blocked>
     %18 = ttg.async_commit_group
     tt.return
   }

--- a/python/test/gluon/test_frontend.py
+++ b/python/test/gluon/test_frontend.py
@@ -2610,13 +2610,16 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.targ
 
 
 @gluon.jit
-def detailed_cache_policy_kernel(inp, out, load_policy: ttgl.constexpr, store_policy: ttgl.constexpr):
+def detailed_cache_policy_kernel(inp, out, l1_load_policy: ttgl.constexpr, modifier_load_policy: ttgl.constexpr,
+                                 store_policy: ttgl.constexpr):
     layout: ttgl.constexpr = ttgl.BlockedLayout([1], [32], [4], [0])
     offsets = ttgl.arange(0, 128, layout)
-    # CHECK: %[[VALUE:.*]] = tt.load {{.*}} {cachePolicy = #ttng.cache_policy<cache_modifier = cg, l1 = no_allocate, l2_primary = evict_last, l2_secondary = evict_first, l2_fraction = {{.*}} : f32, l2_prefetch_size = 128 : i32>}
-    value = ttgl.load(inp + offsets, cache_policy=load_policy)
+    # CHECK: %[[L1_VALUE:.*]] = tt.load {{.*}} {cachePolicy = #ttng.cache_policy<l1 = no_allocate, l2_primary = evict_last, l2_secondary = evict_first, l2_fraction = {{.*}} : f32, l2_prefetch_size = 128 : i32>}
+    l1_value = ttgl.load(inp + offsets, cache_policy=l1_load_policy)
+    # CHECK: %[[MODIFIER_VALUE:.*]] = tt.load {{.*}} {cachePolicy = #ttng.cache_policy<cache_modifier = cg, l2_primary = evict_last, l2_secondary = evict_first, l2_fraction = {{.*}} : f32, l2_prefetch_size = 128 : i32>}
+    modifier_value = ttgl.load(inp + offsets, cache_policy=modifier_load_policy)
     # CHECK: tt.store {{.*}} {cachePolicy = #ttng.cache_policy<l1 = no_allocate, l2_primary = evict_last, l2_secondary = evict_first, l2_fraction = {{.*}} : f32>}
-    ttgl.store(out + offsets, value, cache_policy=store_policy)
+    ttgl.store(out + offsets, l1_value + modifier_value, cache_policy=store_policy)
 
 
 @gluon.jit
@@ -2671,17 +2674,46 @@ def test_generic_cache_policy_validation():
 
 def test_detailed_cache_policy_frontend():
     l2_policy = ttgl.nvidia.ampere.FractionalEvictionPolicy("evict_last", 0.33, "evict_first")
-    load_policy = ttgl.nvidia.ampere.CachePolicy(
-        cache_modifier=".cg",
+    l1_load_policy = ttgl.nvidia.ampere.CachePolicy(
         l1="no_allocate",
+        l2=l2_policy,
+        l2_prefetch_size=128,
+    )
+    modifier_load_policy = ttgl.nvidia.ampere.CachePolicy(
+        cache_modifier=".cg",
         l2=l2_policy,
         l2_prefetch_size=128,
     )
     store_policy = ttgl.nvidia.ampere.CachePolicy(l1="no_allocate", l2=l2_policy)
     run_filecheck_test(
         detailed_cache_policy_kernel,
-        *make_args(MockTensor(ttgl.float32), MockTensor(ttgl.float32), load_policy, store_policy),
+        *make_args(
+            MockTensor(ttgl.float32),
+            MockTensor(ttgl.float32),
+            l1_load_policy,
+            modifier_load_policy,
+            store_policy,
+        ),
     )
+
+
+def test_detailed_cache_policy_rejects_cache_modifier_with_l1():
+    invalid_policy = ttgl.nvidia.ampere.CachePolicy(cache_modifier=".cg", l1="no_allocate")
+    valid_policy = ttgl.nvidia.ampere.CachePolicy(l1="no_allocate")
+    with pytest.raises(
+            CompilationError,
+            match="cache modifier cannot be combined with an L1 eviction priority",
+    ):
+        run_parser(
+            detailed_cache_policy_kernel,
+            *make_args(
+                MockTensor(ttgl.float32),
+                MockTensor(ttgl.float32),
+                invalid_policy,
+                valid_policy,
+                valid_policy,
+            ),
+        )
 
 
 def test_detailed_cache_policy_validation():

--- a/python/test/gluon/test_frontend.py
+++ b/python/test/gluon/test_frontend.py
@@ -25,7 +25,7 @@ from triton.experimental.gluon.language.amd.cdna5 import (
 )
 from triton.experimental.gluon.language.extra import libdevice
 
-from triton._filecheck import filecheck_test, run_parser
+from triton._filecheck import filecheck_test, run_filecheck_test, run_parser
 from triton.runtime.jit import MockTensor
 import triton.language as tl
 from triton.compiler.errors import CompilationError, CompileTimeAssertionFailure
@@ -2610,6 +2610,150 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.targ
 
 
 @gluon.jit
+def detailed_cache_policy_kernel(inp, out, load_policy: ttgl.constexpr, store_policy: ttgl.constexpr):
+    layout: ttgl.constexpr = ttgl.BlockedLayout([1], [32], [4], [0])
+    offsets = ttgl.arange(0, 128, layout)
+    # CHECK: %[[VALUE:.*]] = tt.load {{.*}} {cachePolicy = #ttng.cache_policy<cache_modifier = cg, l1 = no_allocate, l2_primary = evict_last, l2_secondary = evict_first, l2_fraction = {{.*}} : f32, l2_prefetch_size = 128 : i32>}
+    value = ttgl.load(inp + offsets, cache_policy=load_policy)
+    # CHECK: tt.store {{.*}} {cachePolicy = #ttng.cache_policy<l1 = no_allocate, l2_primary = evict_last, l2_secondary = evict_first, l2_fraction = {{.*}} : f32>}
+    ttgl.store(out + offsets, value, cache_policy=store_policy)
+
+
+@gluon.jit
+def generic_cache_policy_kernel(inp, out, layout: ttgl.constexpr, load_policy: ttgl.constexpr,
+                                store_policy: ttgl.constexpr):
+    offsets = ttgl.arange(0, 256, layout)
+    # CHECK: %[[VALUE:.*]] = tt.load {{.*}} {cachePolicy = #tt.cache_policy<cache_modifier = cg, eviction_policy = evict_last>}
+    value = ttgl.load(inp + offsets, cache_policy=load_policy)
+    # CHECK: tt.store {{.*}} {cachePolicy = #tt.cache_policy<cache_modifier = cs, eviction_policy = evict_first>}
+    ttgl.store(out + offsets, value, cache_policy=store_policy)
+
+
+@gluon.jit
+def legacy_cache_policy_kernel(inp, out, layout: ttgl.constexpr):
+    offsets = ttgl.arange(0, 256, layout)
+    # CHECK: %[[VALUE:.*]] = tt.load {{.*}} {cachePolicy = #tt.cache_policy<cache_modifier = cg, eviction_policy = evict_last>}
+    value = ttgl.load(inp + offsets, cache_modifier=".cg", eviction_policy="evict_last")
+    # CHECK: tt.store {{.*}} {cachePolicy = #tt.cache_policy<cache_modifier = cs, eviction_policy = evict_first>}
+    ttgl.store(out + offsets, value, cache_modifier=".cs", eviction_policy="evict_first")
+
+
+@pytest.mark.parametrize("target", [HOPPER_TARGET, HIP_TARGET_CDNA4])
+def test_generic_cache_policy_frontend(target):
+    layout = ttgl.BlockedLayout([1], [target.warp_size], [4], [0])
+    load_policy = ttgl.CachePolicy(".cg", "evict_last")
+    store_policy = ttgl.CachePolicy(".cs", "evict_first")
+    run_filecheck_test(
+        generic_cache_policy_kernel,
+        *make_args(MockTensor(ttgl.float32), MockTensor(ttgl.float32), layout, load_policy, store_policy),
+        target=target,
+    )
+
+
+@pytest.mark.parametrize("target", [HOPPER_TARGET, HIP_TARGET_CDNA4])
+def test_legacy_cache_policy_normalization(target):
+    layout = ttgl.BlockedLayout([1], [target.warp_size], [4], [0])
+    run_filecheck_test(
+        legacy_cache_policy_kernel,
+        *make_args(MockTensor(ttgl.float32), MockTensor(ttgl.float32), layout),
+        target=target,
+    )
+
+
+def test_generic_cache_policy_validation():
+    assert ttgl.CachePolicy().cache_modifier == "none"
+    assert ttgl.CachePolicy(".cg").cache_modifier == "cg"
+    with pytest.raises(ValueError, match="Unsupported cache modifier"):
+        ttgl.CachePolicy(".invalid")
+    with pytest.raises(ValueError, match="Unsupported eviction policy"):
+        ttgl.CachePolicy(eviction_policy="evict_unchanged")
+
+
+def test_detailed_cache_policy_frontend():
+    l2_policy = ttgl.nvidia.ampere.FractionalEvictionPolicy("evict_last", 0.33, "evict_first")
+    load_policy = ttgl.nvidia.ampere.CachePolicy(
+        cache_modifier=".cg",
+        l1="no_allocate",
+        l2=l2_policy,
+        l2_prefetch_size=128,
+    )
+    store_policy = ttgl.nvidia.ampere.CachePolicy(l1="no_allocate", l2=l2_policy)
+    run_filecheck_test(
+        detailed_cache_policy_kernel,
+        *make_args(MockTensor(ttgl.float32), MockTensor(ttgl.float32), load_policy, store_policy),
+    )
+
+
+def test_detailed_cache_policy_validation():
+    assert not hasattr(ttgl.nvidia, "CachePolicy")
+    assert not hasattr(ttgl.nvidia, "FractionalEvictionPolicy")
+    assert ttgl.nvidia.hopper.CachePolicy is ttgl.nvidia.ampere.CachePolicy
+    assert ttgl.nvidia.blackwell.CachePolicy is ttgl.nvidia.ampere.CachePolicy
+    assert ttgl.nvidia.rubin.CachePolicy is ttgl.nvidia.ampere.CachePolicy
+    assert ttgl.nvidia.hopper.FractionalEvictionPolicy is ttgl.nvidia.ampere.FractionalEvictionPolicy
+    assert ttgl.nvidia.blackwell.FractionalEvictionPolicy is ttgl.nvidia.ampere.FractionalEvictionPolicy
+    assert ttgl.nvidia.rubin.FractionalEvictionPolicy is ttgl.nvidia.ampere.FractionalEvictionPolicy
+    assert ttgl.nvidia.ampere.CachePolicy(cache_modifier=".cg").cache_modifier == "cg"
+    assert ttgl.nvidia.ampere.CachePolicy(l2_prefetch_size=64).l2_prefetch_size == 64
+    with pytest.raises(ValueError, match="Unsupported cache modifier"):
+        ttgl.nvidia.ampere.CachePolicy(cache_modifier=".invalid")
+    with pytest.raises(ValueError, match="Unsupported L1"):
+        ttgl.nvidia.ampere.CachePolicy(l1="evict_immediately")
+    with pytest.raises(ValueError, match=r"\(0, 1\]"):
+        ttgl.nvidia.ampere.FractionalEvictionPolicy("evict_first", 0.0)
+    with pytest.raises(ValueError, match="Unsupported L2 secondary"):
+        ttgl.nvidia.ampere.FractionalEvictionPolicy("evict_first", 0.5, "evict_last")
+    with pytest.raises(ValueError, match="L2 prefetch size"):
+        ttgl.nvidia.ampere.CachePolicy(l2_prefetch_size=32)
+    with pytest.raises(ValueError, match="L2 prefetch size"):
+        ttgl.nvidia.ampere.CachePolicy(l2_prefetch_size=64.0)
+
+
+@gluon.jit
+def cache_policy_with_cache_modifier_kernel(inp, policy: ttgl.constexpr):
+    layout: ttgl.constexpr = ttgl.BlockedLayout([1], [32], [4], [0])
+    offsets = ttgl.arange(0, 128, layout)
+    ttgl.load(inp + offsets, cache_modifier=".cg", cache_policy=policy)
+
+
+@gluon.jit
+def cache_policy_with_eviction_policy_kernel(inp, policy: ttgl.constexpr):
+    layout: ttgl.constexpr = ttgl.BlockedLayout([1], [32], [4], [0])
+    offsets = ttgl.arange(0, 128, layout)
+    ttgl.load(inp + offsets, eviction_policy="evict_first", cache_policy=policy)
+
+
+@gluon.jit
+def store_cache_policy_with_cache_modifier_kernel(out, policy: ttgl.constexpr):
+    layout: ttgl.constexpr = ttgl.BlockedLayout([1], [32], [4], [0])
+    offsets = ttgl.arange(0, 128, layout)
+    ttgl.store(out + offsets, 0.0, cache_modifier=".cs", cache_policy=policy)
+
+
+@gluon.jit
+def async_cache_policy_with_eviction_policy_kernel(inp, policy: ttgl.constexpr):
+    smem = ttgl.allocate_shared_memory(inp.dtype.element_ty, [128], ttgl.SwizzledSharedLayout(1, 1, 1, order=[0]))
+    layout: ttgl.constexpr = ttgl.BlockedLayout([2], [32], [4], [0])
+    offsets = ttgl.arange(0, 128, layout)
+    async_copy.async_load(smem, inp + offsets, eviction_policy="evict_first", cache_policy=policy)
+
+
+@pytest.mark.parametrize(
+    "kernel, message",
+    [
+        (cache_policy_with_cache_modifier_kernel, "cache_policy and cache_modifier are mutually exclusive"),
+        (cache_policy_with_eviction_policy_kernel, "cache_policy and eviction_policy are mutually exclusive"),
+        (store_cache_policy_with_cache_modifier_kernel, "cache_policy and cache_modifier are mutually exclusive"),
+        (async_cache_policy_with_eviction_policy_kernel, "cache_policy and eviction_policy are mutually exclusive"),
+    ],
+)
+def test_detailed_cache_policy_rejects_legacy_policy_arguments(kernel, message):
+    policy = ttgl.nvidia.ampere.CachePolicy(l1="evict_first")
+    with pytest.raises(CompilationError, match=message):
+        run_parser(kernel, *make_args(MockTensor(ttgl.float32), policy))
+
+
+@gluon.jit
 def async_copy_kernel(inp, xnumel, XBLOCK: ttgl.constexpr):
     smem = ttgl.allocate_shared_memory(inp.dtype.element_ty, [XBLOCK], ttgl.SwizzledSharedLayout(1, 1, 1, order=[0]))
     block_layout: ttgl.constexpr = ttgl.BlockedLayout([2], [32], [4], [0])
@@ -2624,6 +2768,26 @@ def async_copy_kernel(inp, xnumel, XBLOCK: ttgl.constexpr):
     async_copy.mbarrier_arrive(mbar, increment_count=False)
     async_copy.commit_group()
     async_copy.wait_group(0)
+
+
+@gluon.jit
+def detailed_cache_policy_async_copy_kernel(inp, policy: ttgl.constexpr):
+    smem = ttgl.allocate_shared_memory(inp.dtype.element_ty, [128], ttgl.SwizzledSharedLayout(1, 1, 1, order=[0]))
+    layout: ttgl.constexpr = ttgl.BlockedLayout([2], [32], [4], [0])
+    offsets = ttgl.arange(0, 128, layout)
+    # CHECK: ttg.async_copy_global_to_local {{.*}} {cachePolicy = #ttng.cache_policy<l2_primary = evict_last, {{.*}}l2_prefetch_size = 256 : i32>}
+    async_copy.async_load(smem, inp + offsets, cache_policy=policy)
+
+
+def test_detailed_cache_policy_async_copy_frontend():
+    policy = ttgl.nvidia.ampere.CachePolicy(
+        l2=ttgl.nvidia.ampere.FractionalEvictionPolicy("evict_last", 0.82),
+        l2_prefetch_size=256,
+    )
+    run_filecheck_test(
+        detailed_cache_policy_async_copy_kernel,
+        *make_args(MockTensor(ttgl.float16), policy),
+    )
 
 
 @pytest.mark.parametrize("target", [AMPERE_TARGET, HOPPER_TARGET, BLACKWELL_TARGET])
@@ -2649,7 +2813,7 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.targ
     %6 = ttg.async_copy_global_to_local %5, %0 : tensor<128x!tt.ptr<f16>, #blocked> -> <128xf16, #shared, #smem, mutable>
     %7 = tt.splat %arg0 : !tt.ptr<f16> -> tensor<128x!tt.ptr<f16>, #blocked>
     %8 = tt.addptr %7, %1 : tensor<128x!tt.ptr<f16>, #blocked>, tensor<128xi32, #blocked>
-    %9 = ttg.async_copy_global_to_local %8, %0 mask %3 cacheModifier = ca evictionPolicy = evict_last {isVolatile = true} : tensor<128x!tt.ptr<f16>, #blocked> -> <128xf16, #shared, #smem, mutable>
+    %9 = ttg.async_copy_global_to_local %8, %0 mask %3 {cachePolicy = #tt.cache_policy<cache_modifier = ca, eviction_policy = evict_last>, isVolatile = true} : tensor<128x!tt.ptr<f16>, #blocked> -> <128xf16, #shared, #smem, mutable>
     %10 = ttg.local_alloc : () -> !ttg.memdesc<1xi64, #shared, #smem, mutable>
     ttng.async_copy_mbarrier_arrive %10 : !ttg.memdesc<1xi64, #shared, #smem, mutable>
     ttng.async_copy_mbarrier_arrive %10 {noIncrement} : !ttg.memdesc<1xi64, #shared, #smem, mutable>
@@ -3461,9 +3625,9 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.targ
     %7 = tt.broadcast %5 : tensor<1x16xi32, #blocked> -> tensor<128x16xi32, #blocked>
     %8 = arith.addi %6, %7 : tensor<128x16xi32, #blocked>
     %9 = amdg.buffer_load_to_local %arg0[%8] into %0 : !tt.ptr<f16>[tensor<128x16xi32, #blocked>]  -> <128x16xf16, #shared, #smem, mutable>
-    %10 = amdg.buffer_load_to_local %arg0[%8] cacheModifier = ca into %0 : !tt.ptr<f16>[tensor<128x16xi32, #blocked>]  -> <128x16xf16, #shared, #smem, mutable>
-    %11 = amdg.buffer_load_to_local %arg0[%8] cacheModifier = cg into %0 : !tt.ptr<f16>[tensor<128x16xi32, #blocked>]  -> <128x16xf16, #shared, #smem, mutable>
-    %12 = amdg.buffer_load_to_local %arg0[%8] cacheModifier = cv into %0 : !tt.ptr<f16>[tensor<128x16xi32, #blocked>]  -> <128x16xf16, #shared, #smem, mutable>
+    %10 = amdg.buffer_load_to_local %arg0[%8] cachePolicy = #tt.cache_policy<cache_modifier = ca, eviction_policy = evict_normal> into %0 : !tt.ptr<f16>[tensor<128x16xi32, #blocked>]  -> <128x16xf16, #shared, #smem, mutable>
+    %11 = amdg.buffer_load_to_local %arg0[%8] cachePolicy = #tt.cache_policy<cache_modifier = cg, eviction_policy = evict_normal> into %0 : !tt.ptr<f16>[tensor<128x16xi32, #blocked>]  -> <128x16xf16, #shared, #smem, mutable>
+    %12 = amdg.buffer_load_to_local %arg0[%8] cachePolicy = #tt.cache_policy<cache_modifier = cv, eviction_policy = evict_normal> into %0 : !tt.ptr<f16>[tensor<128x16xi32, #blocked>]  -> <128x16xf16, #shared, #smem, mutable>
     %c64_i32 = arith.constant 64 : i32
     %cst_1 = arith.constant dense<64> : tensor<128xi32, #ttg.slice<{dim = 1, parent = #blocked}>>
     %13 = arith.cmpi slt, %1, %cst_1 : tensor<128xi32, #ttg.slice<{dim = 1, parent = #blocked}>>
@@ -3527,10 +3691,10 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.targ
     %cst = arith.constant dense<true> : tensor<64x64xi1, #blocked>
     %cst_0 = arith.constant 1.000000e+00 : f32
     %cst_1 = arith.constant dense<1.000000e+00> : tensor<64x64xf32, #blocked>
-    %3 = amdg.buffer_load %arg0[%2], %cst, %cst_1 cacheModifier = ca : !tt.ptr<f32> -> tensor<64x64xf32, #blocked>
-    amdg.buffer_store %3, %arg1[%2], %cst cacheModifier = cs : !tt.ptr<f32> -> tensor<64x64xf32, #blocked>
-    %4 = amdg.buffer_load %arg0[%2], %cst, %cst_1 cacheModifier = ca : !tt.ptr<f32> -> tensor<64x64xf32, #blocked>
-    amdg.buffer_store %4, %arg1[%2], %cst cacheModifier = cs : !tt.ptr<f32> -> tensor<64x64xf32, #blocked>
+    %3 = amdg.buffer_load %arg0[%2], %cst, %cst_1 {cachePolicy = #tt.cache_policy<cache_modifier = ca, eviction_policy = evict_normal>} : !tt.ptr<f32> -> tensor<64x64xf32, #blocked>
+    amdg.buffer_store %3, %arg1[%2], %cst {cachePolicy = #tt.cache_policy<cache_modifier = cs, eviction_policy = evict_normal>} : !tt.ptr<f32> -> tensor<64x64xf32, #blocked>
+    %4 = amdg.buffer_load %arg0[%2], %cst, %cst_1 {cachePolicy = #tt.cache_policy<cache_modifier = ca, eviction_policy = evict_normal>} : !tt.ptr<f32> -> tensor<64x64xf32, #blocked>
+    amdg.buffer_store %4, %arg1[%2], %cst {cachePolicy = #tt.cache_policy<cache_modifier = cs, eviction_policy = evict_normal>} : !tt.ptr<f32> -> tensor<64x64xf32, #blocked>
     %true_2 = arith.constant true
     %cst_3 = arith.constant dense<true> : tensor<64x64xi1, #gluon.auto_encoding>
     %cst_4 = arith.constant 1.000000e+00 : f32
@@ -3587,23 +3751,23 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.targ
     %cst_1 = arith.constant dense<true> : tensor<64x1xi1, #blocked>
     %3 = tt.broadcast %cst_1 : tensor<64x1xi1, #blocked> -> tensor<64x64xi1, #blocked>
     %4 = arith.truncf %cst_0 : tensor<64x64xf32, #blocked> to tensor<64x64xf16, #blocked>
-    %5 = amdg.buffer_load %arg0[%2], %3, %4 cacheModifier = ca : !tt.ptr<f16> -> tensor<64x64xf16, #blocked>
+    %5 = amdg.buffer_load %arg0[%2], %3, %4 {cachePolicy = #tt.cache_policy<cache_modifier = ca, eviction_policy = evict_normal>} : !tt.ptr<f16> -> tensor<64x64xf16, #blocked>
     %6 = tt.broadcast %cst_1 : tensor<64x1xi1, #blocked> -> tensor<64x64xi1, #blocked>
-    amdg.buffer_store %5, %arg1[%2], %6 cacheModifier = cs : !tt.ptr<f16> -> tensor<64x64xf16, #blocked>
+    amdg.buffer_store %5, %arg1[%2], %6 {cachePolicy = #tt.cache_policy<cache_modifier = cs, eviction_policy = evict_normal>} : !tt.ptr<f16> -> tensor<64x64xf16, #blocked>
     %true_2 = arith.constant true
     %cst_3 = arith.constant dense<true> : tensor<1x64xi1, #blocked>
     %7 = tt.broadcast %cst_3 : tensor<1x64xi1, #blocked> -> tensor<64x64xi1, #blocked>
     %8 = arith.truncf %cst_0 : tensor<64x64xf32, #blocked> to tensor<64x64xf16, #blocked>
-    %9 = amdg.buffer_load %arg0[%2], %7, %8 cacheModifier = ca : !tt.ptr<f16> -> tensor<64x64xf16, #blocked>
+    %9 = amdg.buffer_load %arg0[%2], %7, %8 {cachePolicy = #tt.cache_policy<cache_modifier = ca, eviction_policy = evict_normal>} : !tt.ptr<f16> -> tensor<64x64xf16, #blocked>
     %10 = tt.broadcast %cst_3 : tensor<1x64xi1, #blocked> -> tensor<64x64xi1, #blocked>
-    amdg.buffer_store %9, %arg1[%2], %10 cacheModifier = cs : !tt.ptr<f16> -> tensor<64x64xf16, #blocked>
+    amdg.buffer_store %9, %arg1[%2], %10 {cachePolicy = #tt.cache_policy<cache_modifier = cs, eviction_policy = evict_normal>} : !tt.ptr<f16> -> tensor<64x64xf16, #blocked>
     %11 = tt.broadcast %cst_3 : tensor<1x64xi1, #blocked> -> tensor<64x64xi1, #blocked>
     %cst_4 = arith.constant 1.000000e+00 : f32
     %12 = arith.truncf %cst_4 : f32 to f16
     %13 = tt.splat %12 : f16 -> tensor<64x64xf16, #blocked>
-    %14 = amdg.buffer_load %arg0[%2], %11, %13 cacheModifier = ca : !tt.ptr<f16> -> tensor<64x64xf16, #blocked>
+    %14 = amdg.buffer_load %arg0[%2], %11, %13 {cachePolicy = #tt.cache_policy<cache_modifier = ca, eviction_policy = evict_normal>} : !tt.ptr<f16> -> tensor<64x64xf16, #blocked>
     %15 = tt.broadcast %cst_3 : tensor<1x64xi1, #blocked> -> tensor<64x64xi1, #blocked>
-    amdg.buffer_store %14, %arg1[%2], %15 cacheModifier = cs : !tt.ptr<f16> -> tensor<64x64xf16, #blocked>
+    amdg.buffer_store %14, %arg1[%2], %15 {cachePolicy = #tt.cache_policy<cache_modifier = cs, eviction_policy = evict_normal>} : !tt.ptr<f16> -> tensor<64x64xf16, #blocked>
     tt.return
   }
 }

--- a/python/test/gluon/test_frontend.py
+++ b/python/test/gluon/test_frontend.py
@@ -3376,7 +3376,7 @@ def amd_async_copy_shared_to_global(ptr):
 
     # test mask
     mask = (y_offset < 64)[:, None]
-    # CHECK: amdg.async_copy_local_to_global {{.*}} mask {{.*}} {cachePolicy = #tt.cache_policy<cache_modifier = cg, eviction_policy = evict_normal>}
+    # CHECK: amdg.async_copy_local_to_global {{.*}} mask {{.*}} cachePolicy = #tt.cache_policy<cache_modifier = cg, eviction_policy = evict_normal>
     cdna5_async_copy.shared_to_global(ptr + offsets, smem, mask, cache_modifier=".cg")
 
     cdna5_async_copy.commit_group()
@@ -3416,7 +3416,7 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.targ
     %14 = tt.splat %arg0 : !tt.ptr<f16> -> tensor<128x16x!tt.ptr<f16>, #blocked>
     %15 = tt.addptr %14, %8 : tensor<128x16x!tt.ptr<f16>, #blocked>, tensor<128x16xi32, #blocked>
     %16 = tt.broadcast %13 : tensor<128x1xi1, #blocked> -> tensor<128x16xi1, #blocked>
-    %17 = amdg.async_copy_local_to_global %0, %15 mask %16 {cachePolicy = #tt.cache_policy<cache_modifier = cg, eviction_policy = evict_normal>} : !ttg.memdesc<128x16xf16, #shared, #smem, mutable> -> tensor<128x16x!tt.ptr<f16>, #blocked>
+    %17 = amdg.async_copy_local_to_global %0, %15 mask %16 cachePolicy = #tt.cache_policy<cache_modifier = cg, eviction_policy = evict_normal> : !ttg.memdesc<128x16xf16, #shared, #smem, mutable> -> tensor<128x16x!tt.ptr<f16>, #blocked>
     %18 = ttg.async_commit_group
     tt.return
   }

--- a/python/test/unit/language/test_frontend.py
+++ b/python/test/unit/language/test_frontend.py
@@ -1588,3 +1588,16 @@ def test_const_ptr_is_constant_addrspace():
         tl.store(Out + offs, tl.load(In + offs, mask=mask), mask=mask)
 
     run_filecheck_test(kernel, args=(MockTensor(tl.float32), MockTensor(tl.float32), 8, 128))
+
+
+def test_cache_policy_ir_attrs():
+
+    @triton.jit
+    def kernel(In, Out, BLOCK: tl.constexpr):
+        offsets = tl.arange(0, BLOCK)
+        # CHECK: %[[VALUE:.*]] = tt.load {{.*}} {cachePolicy = #tt.cache_policy<cache_modifier = cg, eviction_policy = evict_first>}
+        value = tl.load(In + offsets, cache_modifier=".cg", eviction_policy="evict_first")
+        # CHECK: tt.store {{.*}} {cachePolicy = #tt.cache_policy<cache_modifier = wt, eviction_policy = evict_last>}
+        tl.store(Out + offsets, value, cache_modifier=".wt", eviction_policy="evict_last")
+
+    run_filecheck_test(kernel, args=(MockTensor(tl.float32), MockTensor(tl.float32), 128))

--- a/python/triton/_filecheck.py
+++ b/python/triton/_filecheck.py
@@ -77,12 +77,12 @@ def run_parser(kernel_fn, args=(), kwargs={}, target=stub_target):
     return module
 
 
-def run_filecheck_test(kernel_fn, args=(), kwargs={}):
+def run_filecheck_test(kernel_fn, args=(), kwargs={}, target=stub_target):
     assert isinstance(kernel_fn, triton.runtime.JITFunction)
     check_template = inspect.getsource(kernel_fn.fn)
     if check_template is None:
         raise ValueError("kernel function must have a docstring with FileCheck template")
-    mlir_module = run_parser(kernel_fn, args=args, kwargs=kwargs)
+    mlir_module = run_parser(kernel_fn, args=args, kwargs=kwargs, target=target)
 
     run_filecheck("placeholder", mlir_module.str_nodebug(), check_template)
 

--- a/python/triton/experimental/gluon/language/__init__.py
+++ b/python/triton/experimental/gluon/language/__init__.py
@@ -1,5 +1,6 @@
 from ._core import (
     aggregate_replace,
+    CachePolicy,
     base_value,
     base_type,
     block_type,

--- a/python/triton/experimental/gluon/language/_core.py
+++ b/python/triton/experimental/gluon/language/_core.py
@@ -14,6 +14,8 @@ from ._layouts import (SharedLayout, DistributedLayout, BlockedLayout, DotOperan
 from triton._C.libtriton import ir
 import triton.language.core as tl_core
 from triton.language.core import (
+    _CachePolicy as CachePolicy,
+    _normalize_cache_policy,
     aggregate_replace,
     base_value,
     base_type,
@@ -52,6 +54,7 @@ from triton.language.core import (
 # this file but we want to import them anyway so they are importable from here.
 __all__ = [
     "aggregate_replace",
+    "CachePolicy",
     "constexpr",
     "pointer_type",
     "void",
@@ -125,7 +128,6 @@ expand_dims = builtin(tl_core.expand_dims)
 gather = builtin(tl_core.gather)
 inline_asm_elementwise = builtin(tl_core.inline_asm_elementwise)
 join = builtin(tl_core.join)
-load = builtin(tl_core.load)
 map_elementwise = builtin(tl_core.map_elementwise)
 max_constancy = builtin(tl_core.max_constancy)
 max_contiguous = builtin(tl_core.max_contiguous)
@@ -141,11 +143,36 @@ reshape = builtin(tl_core.reshape)
 split = builtin(tl_core.split)
 static_assert = builtin(tl_core.static_assert)
 static_print = builtin(tl_core.static_print)
-store = builtin(tl_core.store)
 sub = builtin(tl_core.sub)
 to_tensor = builtin(tl_core.to_tensor)
 expect_zero = builtin(tl_core.expect_zero)
 where = builtin(tl_core.where)
+
+
+@builtin
+def load(pointer, mask=None, other=None, *, cache_modifier=None, eviction_policy=None, volatile=False,
+         cache_policy=None, _semantic=None):
+    """Load from memory, optionally using a cache policy."""
+    mask = _unwrap_if_constexpr(mask)
+    other = _unwrap_if_constexpr(other)
+    if mask is not None:
+        mask = _semantic.to_tensor(mask)
+    if other is not None:
+        other = _semantic.to_tensor(other)
+    volatile = _unwrap_if_constexpr(volatile)
+    cache_policy = _normalize_cache_policy(cache_policy, cache_modifier, eviction_policy)
+    return _semantic.load(pointer, mask, other, cache_policy, volatile)
+
+
+@builtin
+def store(pointer, value, mask=None, *, cache_modifier=None, eviction_policy=None, cache_policy=None, _semantic=None):
+    """Store to memory, optionally using a cache policy."""
+    value = _semantic.to_tensor(value)
+    mask = _unwrap_if_constexpr(mask)
+    if mask is not None:
+        mask = _semantic.to_tensor(mask)
+    cache_policy = _normalize_cache_policy(cache_policy, cache_modifier, eviction_policy)
+    return _semantic.store(pointer, value, mask, cache_policy)
 
 
 class distributed_type(block_type):

--- a/python/triton/experimental/gluon/language/amd/cdna4/async_copy.py
+++ b/python/triton/experimental/gluon/language/amd/cdna4/async_copy.py
@@ -1,4 +1,4 @@
-from ..._core import ir, builtin, _unwrap_if_constexpr
+from ..._core import ir, builtin, _unwrap_if_constexpr, _normalize_cache_policy
 from ..._semantic import _check
 from ..._layouts import DistributedLayout
 from ..cdna3 import _verify_buffer_ops
@@ -64,11 +64,11 @@ def global_load_to_shared(dest, ptr, mask=None, other=None, cache_modifier="", _
         other = _semantic.cast(other, ptr.dtype.element_ty)
         ptr, other = _semantic.broadcast_impl_value(ptr, other)
 
-    cache_modifier = _semantic._str_to_load_cache_modifier(cache_modifier)
     mask_handle = mask.handle if mask is not None else ir.value()
     other_handle = other.handle if other is not None else ir.value()
+    cache_policy = _normalize_cache_policy(None, cache_modifier, None)
     _semantic.builder.create_async_copy_global_to_local(dest.handle, ptr.handle, mask_handle, other_handle,
-                                                        cache_modifier, ir.EVICTION_POLICY.NORMAL, False)
+                                                        cache_policy, False)
 
 
 @builtin

--- a/python/triton/experimental/gluon/language/amd/cdna4/async_copy.py
+++ b/python/triton/experimental/gluon/language/amd/cdna4/async_copy.py
@@ -67,6 +67,7 @@ def global_load_to_shared(dest, ptr, mask=None, other=None, cache_modifier="", _
     mask_handle = mask.handle if mask is not None else ir.value()
     other_handle = other.handle if other is not None else ir.value()
     cache_policy = _normalize_cache_policy(None, cache_modifier, None)
+    cache_policy = cache_policy._to_ir(_semantic.builder)
     _semantic.builder.create_async_copy_global_to_local(dest.handle, ptr.handle, mask_handle, other_handle,
                                                         cache_policy, False)
 

--- a/python/triton/experimental/gluon/language/amd/cdna5/async_copy.py
+++ b/python/triton/experimental/gluon/language/amd/cdna5/async_copy.py
@@ -1,4 +1,4 @@
-from ..._core import ir, builtin, _unwrap_if_constexpr
+from ..._core import ir, builtin, _unwrap_if_constexpr, _normalize_cache_policy
 from ..._semantic import _check
 from triton.experimental.gluon.language._layouts import DistributedLayout
 from ..cdna4.async_copy import commit_group, wait_group
@@ -35,11 +35,11 @@ def global_to_shared(smem, pointer, mask=None, other=None, cache_modifier="", _s
         other = _semantic.to_tensor(other)
         other = _semantic.cast(other, pointer.dtype.element_ty)
         pointer, other = _semantic.broadcast_impl_value(pointer, other)
-    cache_modifier = _semantic._str_to_load_cache_modifier(cache_modifier)
     mask_handle = mask.handle if mask is not None else ir.value()
     other_handle = other.handle if other is not None else ir.value()
+    cache_policy = _normalize_cache_policy(None, cache_modifier, None)
     _semantic.builder.create_async_copy_global_to_local(smem.handle, pointer.handle, mask_handle, other_handle,
-                                                        cache_modifier, ir.EVICTION_POLICY.NORMAL, False)
+                                                        cache_policy, False)
 
 
 @builtin

--- a/python/triton/experimental/gluon/language/amd/cdna5/async_copy.py
+++ b/python/triton/experimental/gluon/language/amd/cdna5/async_copy.py
@@ -66,10 +66,10 @@ def shared_to_global(pointer, smem, mask=None, cache_modifier="", _semantic=None
     mask = _unwrap_if_constexpr(mask)
     if mask is not None:
         pointer, mask = _semantic.broadcast_impl_value(pointer, mask)
-    cache_modifier = _semantic._str_to_store_cache_modifier(cache_modifier)
     mask_handle = mask.handle if mask is not None else ir.value()
-    _semantic.builder.create_async_copy_local_to_global(smem.handle, pointer.handle, mask_handle, cache_modifier,
-                                                        ir.EVICTION_POLICY.NORMAL)
+    cache_policy = _normalize_cache_policy(None, cache_modifier, None)
+    cache_policy = cache_policy._to_ir(_semantic.builder)
+    _semantic.builder.create_async_copy_local_to_global(smem.handle, pointer.handle, mask_handle, cache_policy)
 
 
 @builtin

--- a/python/triton/experimental/gluon/language/amd/cdna5/async_copy.py
+++ b/python/triton/experimental/gluon/language/amd/cdna5/async_copy.py
@@ -38,6 +38,7 @@ def global_to_shared(smem, pointer, mask=None, other=None, cache_modifier="", _s
     mask_handle = mask.handle if mask is not None else ir.value()
     other_handle = other.handle if other is not None else ir.value()
     cache_policy = _normalize_cache_policy(None, cache_modifier, None)
+    cache_policy = cache_policy._to_ir(_semantic.builder)
     _semantic.builder.create_async_copy_global_to_local(smem.handle, pointer.handle, mask_handle, other_handle,
                                                         cache_policy, False)
 

--- a/python/triton/experimental/gluon/language/nvidia/__init__.py
+++ b/python/triton/experimental/gluon/language/nvidia/__init__.py
@@ -1,5 +1,6 @@
-from . import blackwell
+from . import ampere
 from . import hopper
+from . import blackwell
 from . import rubin
 
-__all__ = ["blackwell", "hopper", "rubin"]
+__all__ = ["ampere", "blackwell", "hopper", "rubin"]

--- a/python/triton/experimental/gluon/language/nvidia/ampere/__init__.py
+++ b/python/triton/experimental/gluon/language/nvidia/ampere/__init__.py
@@ -1,12 +1,108 @@
 from __future__ import annotations
 
+from dataclasses import dataclass
+import math
+
 from triton import knobs
+from triton.language.core import constexpr_type
 from triton.experimental.gluon.language import _core as ttgl
 from triton.experimental.gluon.language._layouts import DotOperandLayout, NVMMADistributedLayout
 from ..._core import builtin, _unwrap_if_constexpr
 from . import async_copy, mbarrier
 
-__all__ = ["async_copy", "mbarrier", "mma_v2"]
+__all__ = ["CachePolicy", "FractionalEvictionPolicy", "async_copy", "mbarrier", "mma_v2"]
+
+_EVICTION_PRIORITIES = {
+    "evict_normal",
+    "evict_unchanged",
+    "evict_first",
+    "evict_last",
+}
+_L1_EVICTION_PRIORITIES = _EVICTION_PRIORITIES | {"no_allocate"}
+_L2_SECONDARY_EVICTION_PRIORITIES = {"evict_unchanged", "evict_first"}
+_CACHE_MODIFIERS = {"ca", "cg", "wb", "cs", "wt", "cv"}
+
+
+@dataclass(frozen=True)
+class FractionalEvictionPolicy:
+    """A fractional NVIDIA L2 eviction policy.
+
+    ``fraction`` is the fraction of cache lines assigned ``primary``. Remaining
+    lines receive ``secondary``.
+    """
+
+    primary: str
+    fraction: float
+    secondary: str = "evict_unchanged"
+
+    def __post_init__(self):
+        object.__setattr__(self, "primary", _unwrap_if_constexpr(self.primary))
+        object.__setattr__(self, "fraction", _unwrap_if_constexpr(self.fraction))
+        object.__setattr__(self, "secondary", _unwrap_if_constexpr(self.secondary))
+        if self.primary not in _EVICTION_PRIORITIES:
+            raise ValueError(f"Unsupported L2 primary eviction priority {self.primary!r}")
+        if self.secondary not in _L2_SECONDARY_EVICTION_PRIORITIES:
+            raise ValueError(f"Unsupported L2 secondary eviction priority {self.secondary!r}")
+        if not isinstance(self.fraction, (int, float)) or not math.isfinite(self.fraction):
+            raise ValueError("L2 eviction fraction must be finite")
+        if not 0 < self.fraction <= 1:
+            raise ValueError("L2 eviction fraction must be in (0, 1]")
+
+    @property
+    def type(self):
+        return constexpr_type(self)
+
+    def mangle(self) -> str:
+        fraction = float(self.fraction).hex().replace(".", "d").replace("-", "m").replace("+", "p")
+        return f"FEP_{self.primary}_{fraction}_{self.secondary}_FEP"
+
+
+@dataclass(frozen=True)
+class CachePolicy:
+    """Detailed NVIDIA cache policy for Gluon memory operations."""
+
+    cache_modifier: str | None = None
+    l1: str | None = None
+    l2: FractionalEvictionPolicy | None = None
+    l2_prefetch_size: int | None = None
+
+    def __post_init__(self):
+        cache_modifier = _unwrap_if_constexpr(self.cache_modifier)
+        if cache_modifier is not None:
+            cache_modifier = cache_modifier.removeprefix(".")
+        object.__setattr__(self, "cache_modifier", cache_modifier)
+        object.__setattr__(self, "l1", _unwrap_if_constexpr(self.l1))
+        object.__setattr__(self, "l2", _unwrap_if_constexpr(self.l2))
+        object.__setattr__(self, "l2_prefetch_size", _unwrap_if_constexpr(self.l2_prefetch_size))
+        if self.cache_modifier is not None and self.cache_modifier not in _CACHE_MODIFIERS:
+            raise ValueError(f"Unsupported cache modifier {self.cache_modifier!r}")
+        if self.l1 is not None and self.l1 not in _L1_EVICTION_PRIORITIES:
+            raise ValueError(f"Unsupported L1 eviction priority {self.l1!r}")
+        if self.l2 is not None and not isinstance(self.l2, FractionalEvictionPolicy):
+            raise TypeError("l2 must be a FractionalEvictionPolicy")
+        if self.l2_prefetch_size is not None and (not isinstance(self.l2_prefetch_size, int)
+                                                  or self.l2_prefetch_size not in (64, 128, 256)):
+            raise ValueError("L2 prefetch size must be 64, 128, or 256")
+        if (self.cache_modifier is None and self.l1 is None and self.l2 is None and self.l2_prefetch_size is None):
+            raise ValueError("CachePolicy requires a cache modifier, L1 policy, L2 policy, or L2 prefetch size")
+
+    @property
+    def type(self):
+        return constexpr_type(self)
+
+    def mangle(self) -> str:
+        cache_modifier = self.cache_modifier or "none"
+        l1 = self.l1 or "none"
+        l2 = self.l2.mangle() if self.l2 is not None else "none"
+        l2_prefetch_size = self.l2_prefetch_size or "none"
+        return f"CP_{cache_modifier}_{l1}_{l2}_{l2_prefetch_size}_CP"
+
+    def _to_ir(self, builder):
+        if self.l2 is None:
+            return builder.get_nvidia_cache_policy(self.cache_modifier, self.l1, None, None, None,
+                                                   self.l2_prefetch_size)
+        return builder.get_nvidia_cache_policy(self.cache_modifier, self.l1, self.l2.primary, self.l2.secondary,
+                                               float(self.l2.fraction), self.l2_prefetch_size)
 
 
 @builtin

--- a/python/triton/experimental/gluon/language/nvidia/ampere/async_copy.py
+++ b/python/triton/experimental/gluon/language/nvidia/ampere/async_copy.py
@@ -1,5 +1,5 @@
 from ..._semantic import _check
-from ..._core import _unwrap_if_constexpr, builtin
+from ..._core import _normalize_cache_policy, _unwrap_if_constexpr, builtin
 from triton._C.libtriton import ir
 
 __all__ = [
@@ -12,7 +12,8 @@ __all__ = [
 
 
 @builtin
-def async_load(smem, pointer, mask=None, cache_modifier="", eviction_policy="", volatile=False, _semantic=None):
+def async_load(smem, pointer, mask=None, cache_modifier=None, eviction_policy=None, volatile=False, cache_policy=None,
+               _semantic=None):
     """
     Asynchronously load elements from global memory to shared memory.
 
@@ -20,13 +21,15 @@ def async_load(smem, pointer, mask=None, cache_modifier="", eviction_policy="", 
         smem (shared_memory_descriptor): Destination shared memory descriptor.
         pointer (tensor): Source pointer tensor.
         mask (tensor, optional): Mask tensor for predicated loads. Defaults to None.
-        cache_modifier (str): Cache modifier specifier. Defaults to "".
-        eviction_policy (str): Eviction policy specifier. Defaults to "".
+        cache_modifier (str): Cache modifier specifier. Defaults to None.
+        eviction_policy (str): Eviction policy specifier. Defaults to None.
         volatile (bool): Whether the load is volatile. Defaults to False.
+        cache_policy (CachePolicy): Cache policy. Cannot be combined
+            with ``cache_modifier`` or ``eviction_policy``. Defaults to None.
     """
     mask = _unwrap_if_constexpr(mask)
-    cache_modifier = _semantic._str_to_load_cache_modifier(cache_modifier)
-    eviction_policy = _semantic._str_to_eviction_policy(eviction_policy)
+    cache_policy = _normalize_cache_policy(cache_policy, cache_modifier, eviction_policy)
+    cache_policy = cache_policy._to_ir(_semantic.builder)
     volatile = _unwrap_if_constexpr(volatile)
     if mask is not None:
         pointer, mask = _semantic.broadcast_impl_value(pointer, mask)
@@ -36,7 +39,7 @@ def async_load(smem, pointer, mask=None, cache_modifier="", eviction_policy="", 
     )
     mask_handle = mask.handle if mask is not None else ir.value()
     _semantic.builder.create_async_copy_global_to_local(smem.handle, pointer.handle, mask_handle, ir.value(),
-                                                        cache_modifier, eviction_policy, volatile)
+                                                        cache_policy, volatile)
 
 
 @builtin

--- a/python/triton/experimental/gluon/language/nvidia/blackwell/__init__.py
+++ b/python/triton/experimental/gluon/language/nvidia/blackwell/__init__.py
@@ -10,7 +10,7 @@ from triton.experimental.gluon.language._semantic import _check, _compute_tmem_r
 from . import tma
 from . import clc
 from ..hopper import async_store, cluster, fence_async_shared, mbarrier
-from ..ampere import async_copy, mma_v2
+from ..ampere import CachePolicy, FractionalEvictionPolicy, async_copy, mma_v2
 
 from triton._C.libtriton import ir
 import triton._C.libtriton.gluon_ir as gluon_ir
@@ -19,6 +19,8 @@ if TYPE_CHECKING:
     from ..._semantic import GluonSemantic
 
 __all__ = [
+    "CachePolicy",
+    "FractionalEvictionPolicy",
     "add2",
     "allocate_tensor_memory",
     "async_copy",

--- a/python/triton/experimental/gluon/language/nvidia/hopper/__init__.py
+++ b/python/triton/experimental/gluon/language/nvidia/hopper/__init__.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 from triton.compiler.code_generator import unflatten_ir_values
-from ..ampere import async_copy, mma_v2
+from ..ampere import CachePolicy, FractionalEvictionPolicy, async_copy, mma_v2
 from . import cluster, mbarrier, tma
 from ... import _core
 
@@ -9,6 +9,8 @@ if TYPE_CHECKING:
     from triton._C.libtriton import ir
 
 __all__ = [
+    "CachePolicy",
+    "FractionalEvictionPolicy",
     "async_copy",
     "async_store",
     "cluster",

--- a/python/triton/experimental/gluon/language/nvidia/rubin/__init__.py
+++ b/python/triton/experimental/gluon/language/nvidia/rubin/__init__.py
@@ -5,6 +5,8 @@ from dataclasses import dataclass
 from triton.experimental.gluon.language._core import _unwrap_if_constexpr, builtin
 
 from ..blackwell import (
+    CachePolicy,
+    FractionalEvictionPolicy,
     TensorMemoryLayout,
     _TensorMemoryLinearLayout,
     _packed_arith,
@@ -34,6 +36,8 @@ from ..blackwell import TensorMemoryScalesLayout as _BlackwellTensorMemoryScales
 from . import mbarrier
 
 __all__ = [
+    "CachePolicy",
+    "FractionalEvictionPolicy",
     "add2",
     "add4",
     "allocate_tensor_memory",

--- a/python/triton/language/core.py
+++ b/python/triton/language/core.py
@@ -1460,7 +1460,7 @@ class tensor_descriptor_base(base_value):
 
         :note: Offset must be a multiple of 16-bytes
         """
-        return _semantic.descriptor_load(self, offsets, "", "")
+        return _semantic.descriptor_load(self, offsets, _CachePolicy())
 
     @builtin
     def store(self, offsets: Sequence[constexpr | tensor], value: tensor, _semantic=None) -> tensor:
@@ -2344,6 +2344,50 @@ def dot_scaled(lhs, lhs_scale, lhs_format, rhs, rhs_scale, rhs_format, acc=None,
 # -----------------------
 
 
+@dataclass(frozen=True)
+class _CachePolicy:
+    """Target-neutral cache hints for Triton and Gluon memory operations."""
+
+    cache_modifier: str = "none"
+    eviction_policy: str = "evict_normal"
+
+    def __post_init__(self):
+        cache_modifier = _unwrap_if_constexpr(self.cache_modifier)
+        eviction_policy = _unwrap_if_constexpr(self.eviction_policy)
+        if not isinstance(cache_modifier, str):
+            raise TypeError("cache_modifier must be a string")
+        if not isinstance(eviction_policy, str):
+            raise TypeError("eviction_policy must be a string")
+        cache_modifier = cache_modifier.removeprefix(".")
+        object.__setattr__(self, "cache_modifier", cache_modifier)
+        object.__setattr__(self, "eviction_policy", eviction_policy)
+        if cache_modifier not in {"none", "ca", "cg", "wb", "cs", "wt", "cv"}:
+            raise ValueError(f"Unsupported cache modifier {cache_modifier!r}")
+        if eviction_policy not in {"evict_normal", "evict_first", "evict_last"}:
+            raise ValueError(f"Unsupported eviction policy {eviction_policy!r}")
+
+    @property
+    def type(self):
+        return constexpr_type(self)
+
+    def mangle(self) -> str:
+        return f"CP_{self.cache_modifier}_{self.eviction_policy}_CP"
+
+    def _to_ir(self, builder):
+        return builder.get_cache_policy(self.cache_modifier, self.eviction_policy)
+
+
+def _normalize_cache_policy(cache_policy, cache_modifier, eviction_policy):
+    cache_modifier = _unwrap_if_constexpr(cache_modifier)
+    eviction_policy = _unwrap_if_constexpr(eviction_policy)
+    cache_policy = _unwrap_if_constexpr(cache_policy)
+    if cache_policy is not None:
+        assert eviction_policy is None, "cache_policy and eviction_policy are mutually exclusive"
+        assert cache_modifier is None, "cache_policy and cache_modifier are mutually exclusive"
+        return cache_policy
+    return _CachePolicy(cache_modifier or "none", eviction_policy or "evict_normal")
+
+
 @builtin
 def load(pointer, mask=None, other=None, *, cache_modifier="", eviction_policy="", volatile=False, _semantic=None):
     """
@@ -2384,10 +2428,9 @@ def load(pointer, mask=None, other=None, *, cache_modifier="", eviction_policy="
         mask = _semantic.to_tensor(mask)
     if other is not None:
         other = _semantic.to_tensor(other)
-    cache_modifier = _unwrap_if_constexpr(cache_modifier)
-    eviction_policy = _unwrap_if_constexpr(eviction_policy)
     volatile = _unwrap_if_constexpr(volatile)
-    return _semantic.load(pointer, mask, other, cache_modifier, eviction_policy, volatile)
+    cache_policy = _normalize_cache_policy(None, cache_modifier, eviction_policy)
+    return _semantic.load(pointer, mask, other, cache_policy, volatile)
 
 
 @builtin
@@ -2440,9 +2483,8 @@ def store(pointer, value, mask=None, *, cache_modifier="", eviction_policy="", _
     mask = _unwrap_if_constexpr(mask)
     if mask is not None:
         mask = _semantic.to_tensor(mask)
-    cache_modifier = _unwrap_if_constexpr(cache_modifier)
-    eviction_policy = _unwrap_if_constexpr(eviction_policy)
-    return _semantic.store(pointer, value, mask, cache_modifier, eviction_policy)
+    cache_policy = _normalize_cache_policy(None, cache_modifier, eviction_policy)
+    return _semantic.store(pointer, value, mask, cache_policy)
 
 
 @builtin

--- a/python/triton/language/semantic.py
+++ b/python/triton/language/semantic.py
@@ -995,10 +995,9 @@ class TritonSemantic(Generic[TensorTy]):
                 raise ValueError(f"Memory semantic {scope_option} not supported")
         return scope
 
-    def load(self, ptr: TensorTy, mask: Optional[TensorTy], other: Optional[TensorTy], cache_modifier: str,
-             eviction_policy: str, is_volatile: bool) -> TensorTy:
-        cache = self._str_to_load_cache_modifier(cache_modifier)
-        eviction = self._str_to_eviction_policy(eviction_policy)
+    def load(self, ptr: TensorTy, mask: Optional[TensorTy], other: Optional[TensorTy], cache_policy,
+             is_volatile: bool) -> TensorTy:
+        cache_policy = cache_policy._to_ir(self.builder)
         if not ptr.type.scalar.is_ptr():
             raise ValueError(f"Unsupported ptr type {ptr.type.__repr__()} in `tl.load`")
 
@@ -1044,25 +1043,23 @@ class TritonSemantic(Generic[TensorTy]):
 
         # Build IR
         if mask is None:
-            ret = self.tensor(self.builder.create_load(ptr.handle, cache, eviction, is_volatile), dst_ty)
+            ret = self.tensor(self.builder.create_load(ptr.handle, cache_policy, is_volatile), dst_ty)
         else:
             ret = self.tensor(
-                self.builder.create_masked_load(ptr.handle, mask.handle, other.handle if other else None, cache,
-                                                eviction, is_volatile), dst_ty)
+                self.builder.create_masked_load(ptr.handle, mask.handle, other.handle if other else None, cache_policy,
+                                                is_volatile), dst_ty)
         if is_bool:
             ret = self.cast(ret, tl.int1)
         return ret
 
-    def descriptor_load(self, desc: tl.tensor_descriptor_base, offsets, cache_modifier: str,
-                        eviction_policy: str) -> TensorTy:
+    def descriptor_load(self, desc: tl.tensor_descriptor_base, offsets, cache_policy) -> TensorTy:
         assert isinstance(desc, tl.tensor_descriptor_base), \
             f"expected a tensor descriptor, got {type(desc).__name__}"
         ndim = len(desc.block_shape)
         assert len(offsets) == ndim, f"expected {ndim} offsets, but got {len(offsets)}"
 
         offsets = self._convert_to_ir_values(offsets, require_i64=False)
-        x = self.builder.create_descriptor_load(desc.handle, offsets, self._str_to_load_cache_modifier(cache_modifier),
-                                                self._str_to_eviction_policy(eviction_policy))
+        x = self.builder.create_descriptor_load(desc.handle, offsets, cache_policy._to_ir(self.builder))
         return self.tensor(x, desc.block_type)
 
     def validate_store_like(self, desc: tl.tensor_descriptor_base, value: TensorTy, offsets) -> None:
@@ -1193,10 +1190,8 @@ class TritonSemantic(Generic[TensorTy]):
             raise ValueError(f"Expected pointer argument to have shape {ptr.shape} but got {ptr_shape}")
         return ptr, val, mask
 
-    def store(self, ptr: TensorTy, val: TensorTy, mask: Optional[TensorTy], cache_modifier: str,
-              eviction_policy: str) -> TensorTy:
-        cache = self._str_to_store_cache_modifier(cache_modifier)
-        eviction = self._str_to_eviction_policy(eviction_policy)
+    def store(self, ptr: TensorTy, val: TensorTy, mask: Optional[TensorTy], cache_policy) -> TensorTy:
+        cache_policy = cache_policy._to_ir(self.builder)
         if ptr.type.is_const() or ptr.type.scalar.is_const():
             raise ValueError("Cannot store to a constant pointer")
 
@@ -1229,11 +1224,10 @@ class TritonSemantic(Generic[TensorTy]):
 
         # Build IR
         if mask is None:
-            return self.tensor(self.builder.create_store(ptr.handle, val.handle, cache, eviction), tl.void)
+            return self.tensor(self.builder.create_store(ptr.handle, val.handle, cache_policy), tl.void)
         if not mask.type.scalar.is_bool():
             raise ValueError("Mask must have boolean scalar type")
-        return self.tensor(self.builder.create_masked_store(ptr.handle, val.handle, mask.handle, cache, eviction),
-                           tl.void)
+        return self.tensor(self.builder.create_masked_store(ptr.handle, val.handle, mask.handle, cache_policy), tl.void)
 
 #########
 # atomic

--- a/python/triton/runtime/interpreter.py
+++ b/python/triton/runtime/interpreter.py
@@ -536,16 +536,19 @@ class InterpreterBuilder:
         return TensorHandle(np.array([self.grid_dim[axis]], dtype=np.int32), tl.int32)
 
     # memory ops
-    def create_load(self, ptr, _0, _1, is_volatile):
+    def get_cache_policy(self, cache_modifier, eviction_policy):
+        return None
+
+    def create_load(self, ptr, cache_policy, is_volatile):
         mask = TensorHandle(np.ones_like(ptr.data, dtype=bool), tl.int1)
         other = None
-        return self.create_masked_load(ptr, mask, other, _0, _1, is_volatile)
+        return self.create_masked_load(ptr, mask, other, cache_policy, is_volatile)
 
-    def create_store(self, ptr, val, _0, _1):
+    def create_store(self, ptr, val, cache_policy):
         mask = TensorHandle(np.ones_like(ptr.data, dtype=bool), tl.int1)
-        return self.create_masked_store(ptr, val, mask, None, None)
+        return self.create_masked_store(ptr, val, mask, cache_policy)
 
-    def create_masked_load(self, ptrs, mask, other, cache_modifier, eviction_policy, is_volatile):
+    def create_masked_load(self, ptrs, mask, other, cache_policy, is_volatile):
         dtype_tt = ptrs.get_element_ty()
         dtype_np = _get_np_dtype(dtype_tt)
         if other is None:
@@ -553,7 +556,7 @@ class InterpreterBuilder:
         ret = _interpreter.load(ptrs.data, mask.data, other.data, dtype_np)
         return TensorHandle(ret, dtype_tt)
 
-    def create_masked_store(self, ptrs, value, mask, cache_modifier, eviction_policy):
+    def create_masked_store(self, ptrs, value, mask, cache_policy):
         return _interpreter.store(ptrs.data, value.data, mask.data)
 
     # casting ops
@@ -839,7 +842,7 @@ class InterpreterBuilder:
         for index in np.ndindex(ptr.data.shape):
             element_ptr = TensorHandle(np.asarray(ptr.data[index]), ptr.dtype)
             while True:
-                value = self.create_load(element_ptr, None, None, True)
+                value = self.create_load(element_ptr, None, True)
                 if value.data.item() == expected.data[index]:
                     matched[index] = True
                     break
@@ -901,8 +904,7 @@ class InterpreterBuilder:
         desc.validate()
         return desc
 
-    def create_descriptor_load(self, desc: TensorDescHandle, indices: List[TensorHandle], cache_modifier,
-                               eviction_policy):
+    def create_descriptor_load(self, desc: TensorDescHandle, indices: List[TensorHandle], cache_policy):
         ptrs, mask = desc.materialize_pointers(indices)
         dtype_tt = ptrs.get_element_ty()
         dtype_np = _get_np_dtype(dtype_tt)
@@ -913,22 +915,20 @@ class InterpreterBuilder:
             other = TensorHandle(np.full_like(ptrs.data, float('nan'), dtype=dtype_np), dtype_tt)
         else:
             raise ValueError(f"unsupported padding {padding}")
-        return self.create_masked_load(ptrs, mask, other, cache_modifier=cache_modifier,
-                                       eviction_policy=eviction_policy, is_volatile=False)
+        return self.create_masked_load(ptrs, mask, other, cache_policy=cache_policy, is_volatile=False)
 
     def create_descriptor_store(self, desc: TensorDescHandle, value: TensorHandle, indices: List[TensorHandle]):
         ptrs, mask = desc.materialize_pointers(indices)
-        return self.create_masked_store(ptrs, value, mask, None, None)
+        return self.create_masked_store(ptrs, value, mask, None)
 
     def create_descriptor_gather(self, desc: TensorDescHandle, x_offsets: TensorHandle, y_offset: TensorHandle, type):
         dtype = desc.base.dtype.element_ty
         np_dtype = _get_np_dtype(dtype)
         result = np.zeros([x_offsets.data.shape[0], desc.block_shape[-1]], dtype=np_dtype)
-        cache_modifier = None
-        eviction_policy = None
+        cache_policy = None
         for i, x_offset in enumerate(x_offsets.data):
             indices = [TensorHandle(x_offset, tl.int32), y_offset]
-            result[i, :] = self.create_descriptor_load(desc, indices, cache_modifier, eviction_policy).data
+            result[i, :] = self.create_descriptor_load(desc, indices, cache_policy).data
         return TensorHandle(result, dtype)
 
     def create_descriptor_scatter(self, desc: TensorDescHandle, value: TensorHandle, x_offsets: TensorHandle,

--- a/python/triton/tools/triton_to_gluon_translator/translator.py
+++ b/python/triton/tools/triton_to_gluon_translator/translator.py
@@ -104,6 +104,8 @@ def add_expr_rewrites(rewrites: list[RewriteFn]) -> None:
 
     rewrites.append(expr_rewrite(triton.jit, "gluon.jit"))
     rewrites.append(expr_rewrite(tl.debug_barrier, "gl.barrier"))
+    rewrites.append(expr_rewrite(tl.load, "gl.load"))
+    rewrites.append(expr_rewrite(tl.store, "gl.store"))
 
 
 @dataclass

--- a/test/Conversion/amd/async_ops_to_llvm.mlir
+++ b/test/Conversion/amd/async_ops_to_llvm.mlir
@@ -270,13 +270,13 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 16 : i32, ttg.sha
 
     // CHECK: llvm.getelementptr
     // CHECK: rocdl.global.load.async.lds {{.*}}, {{.*}}, 4, 0, 0
-    %2 = ttg.async_copy_global_to_local %1, %arg2 cacheModifier = ca: tensor<32x32x!tt.ptr<f32>, #blocked> -> <32x32xf32, #shared, #smem, mutable>
+    %2 = ttg.async_copy_global_to_local %1, %arg2 {cachePolicy = #tt.cache_policy<cache_modifier = ca, eviction_policy = evict_normal>}: tensor<32x32x!tt.ptr<f32>, #blocked> -> <32x32xf32, #shared, #smem, mutable>
     // CHECK: llvm.getelementptr
     // CHECK: rocdl.global.load.async.lds {{.*}}, {{.*}}, 4, 0, 3
-    %3 = ttg.async_copy_global_to_local %1, %arg2 cacheModifier = cg: tensor<32x32x!tt.ptr<f32>, #blocked> -> <32x32xf32, #shared, #smem, mutable>
+    %3 = ttg.async_copy_global_to_local %1, %arg2 {cachePolicy = #tt.cache_policy<cache_modifier = cg, eviction_policy = evict_normal>}: tensor<32x32x!tt.ptr<f32>, #blocked> -> <32x32xf32, #shared, #smem, mutable>
     // CHECK: llvm.getelementptr
     // CHECK: rocdl.global.load.async.lds {{.*}}, {{.*}}, 4, 0, 17
-    %4 = ttg.async_copy_global_to_local %1, %arg2 cacheModifier = cv: tensor<32x32x!tt.ptr<f32>, #blocked> -> <32x32xf32, #shared, #smem, mutable>
+    %4 = ttg.async_copy_global_to_local %1, %arg2 {cachePolicy = #tt.cache_policy<cache_modifier = cv, eviction_policy = evict_normal>}: tensor<32x32x!tt.ptr<f32>, #blocked> -> <32x32xf32, #shared, #smem, mutable>
     tt.return
   }
 }

--- a/test/Conversion/amd/buffer_load_store.mlir
+++ b/test/Conversion/amd/buffer_load_store.mlir
@@ -10,7 +10,7 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 1 : i32} {
         // CHECK: %[[c_mask:.*]] = llvm.mlir.constant(true) : i1
         // CHECK: %[[offset:.*]] = llvm.select %[[c_mask]]
         // CHECK: rocdl.raw.ptr.buffer.load {{.*}}, %[[offset]], {{.*}}, {{.*}}
-        %ret = amdg.buffer_load %arg0[%offset] cacheModifier = cs : !tt.ptr<f32> -> tensor<128xf32, #blocked0>
+        %ret = amdg.buffer_load %arg0[%offset] {cachePolicy = #tt.cache_policy<cache_modifier = cs, eviction_policy = evict_normal>} : !tt.ptr<f32> -> tensor<128xf32, #blocked0>
         tt.return
   }
 }
@@ -71,7 +71,7 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 1 : i32} {
         // CHECK: %[[offset:.*]] = llvm.select %[[mask]]
         // CHECK: rocdl.raw.ptr.buffer.store {{.*}}, {{.*}}, %[[offset]], {{.*}}, {{.*}}
         %c256_i32 = arith.constant 256 : i32
-        amdg.buffer_store %value, %arg0[%offset] cacheModifier = cs stride = %c256_i32 : !tt.ptr<f32> -> tensor<128xf32, #blocked0>
+        amdg.buffer_store %value, %arg0[%offset] stride = %c256_i32 {cachePolicy = #tt.cache_policy<cache_modifier = cs, eviction_policy = evict_normal>} : !tt.ptr<f32> -> tensor<128xf32, #blocked0>
         tt.return
   }
 }

--- a/test/Conversion/amd/buffer_load_to_local_to_llvm.mlir
+++ b/test/Conversion/amd/buffer_load_to_local_to_llvm.mlir
@@ -192,13 +192,13 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 1 : i32, "ttg.thr
     // COMMON: %[[IMM0:.*]] = llvm.mlir.constant(0 : i32) : i32
     // COMMON: %[[IMM1:.*]] = llvm.mlir.constant(0 : i32) : i32
     // COMMON: rocdl.raw.ptr.buffer.load.async.lds {{.*}}, {{.*}}, {{.*}}, %[[VOFFSET]], %[[IMM0]], %[[IMM1]], 0
-    %1 = amdg.buffer_load_to_local %arg0[%0] cacheModifier = ca into %arg2: !tt.ptr<f32>[tensor<64xi32, #blocked>] -> <64xf32, #shared, #smem, mutable>
+    %1 = amdg.buffer_load_to_local %arg0[%0] cachePolicy = #tt.cache_policy<cache_modifier = ca, eviction_policy = evict_normal> into %arg2: !tt.ptr<f32>[tensor<64xi32, #blocked>] -> <64xf32, #shared, #smem, mutable>
     // COMMON: llvm.getelementptr
     // COMMON: rocdl.raw.ptr.buffer.load.async.lds {{.*}}, {{.*}}, {{.*}}, {{.*}}, {{.*}}, {{.*}}, 3
-    %2 = amdg.buffer_load_to_local %arg0[%0] cacheModifier = cg into %arg2: !tt.ptr<f32>[tensor<64xi32, #blocked>] -> <64xf32, #shared, #smem, mutable>
+    %2 = amdg.buffer_load_to_local %arg0[%0] cachePolicy = #tt.cache_policy<cache_modifier = cg, eviction_policy = evict_normal> into %arg2: !tt.ptr<f32>[tensor<64xi32, #blocked>] -> <64xf32, #shared, #smem, mutable>
     // COMMON: llvm.getelementptr
     // COMMON: rocdl.raw.ptr.buffer.load.async.lds {{.*}}, {{.*}}, {{.*}}, {{.*}}, {{.*}}, {{.*}}, 17
-    %3 = amdg.buffer_load_to_local %arg0[%0] cacheModifier = cv into %arg2: !tt.ptr<f32>[tensor<64xi32, #blocked>] -> <64xf32, #shared, #smem, mutable>
+    %3 = amdg.buffer_load_to_local %arg0[%0] cachePolicy = #tt.cache_policy<cache_modifier = cv, eviction_policy = evict_normal> into %arg2: !tt.ptr<f32>[tensor<64xi32, #blocked>] -> <64xf32, #shared, #smem, mutable>
 
     tt.return
   }

--- a/test/Conversion/amd/load_store.mlir
+++ b/test/Conversion/amd/load_store.mlir
@@ -16,10 +16,10 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 1 : i32} {
     %8 = tt.addptr %7, %4 : tensor<256x!tt.ptr<f32>, #blocked0>, tensor<256xi32, #blocked0>
     // Load 8 elements from A with two vectorized load instruction
     // CHECK-COUNT-2: llvm.load {{.*}} : !llvm.ptr<1> -> vector<4xf32>
-    %9 = tt.load %6 {cache = 1 : i32, evict = 1 : i32, isVolatile = false} : tensor<256x!tt.ptr<f32>, #blocked0>
+    %9 = tt.load %6 : tensor<256x!tt.ptr<f32>, #blocked0>
     // Load 8 elements from B with two vectorized load instruction
     // CHECK-COUNT-2: llvm.load {{.*}} : !llvm.ptr<1> -> vector<4xf32>
-    %10 = tt.load %8 {cache = 1 : i32, evict = 1 : i32, isVolatile = false} : tensor<256x!tt.ptr<f32>, #blocked0>
+    %10 = tt.load %8 : tensor<256x!tt.ptr<f32>, #blocked0>
     %11 = arith.addf %9, %10 : tensor<256xf32, #blocked0>
     %12 = tt.splat %arg2 : !tt.ptr<f32> -> tensor<256x!tt.ptr<f32>, #blocked0>
     %13 = tt.addptr %12, %4 : tensor<256x!tt.ptr<f32>, #blocked0>, tensor<256xi32, #blocked0>

--- a/test/Conversion/tritongpu_to_llvm.mlir
+++ b/test/Conversion/tritongpu_to_llvm.mlir
@@ -175,7 +175,7 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32} {
     // CHECK: llvm.inline_asm has_side_effects asm_dialect = att {{.*}} "@$3 st.global.L1::evict_last.L2::cache_hint.b32 [ $1 + 0 ], { $0 }, $2;"
     // CHECK-NOT: createpolicy
     // CHECK: llvm.inline_asm has_side_effects asm_dialect = att {{.*}} "@$3 st.global.L1::evict_last.L2::cache_hint.b32 [ $1 + 0 ], { $0 }, $2;"
-    tt.store %a_ptr_init, %cst_0, %cst {cachePolicy = #tt.cache_policy<cache_modifier = ca, eviction_policy = evict_last>} : tensor<256x!tt.ptr<f32>, #blocked0>
+    tt.store %a_ptr_init, %cst_0, %cst {cachePolicy = #tt.cache_policy<cache_modifier = none, eviction_policy = evict_last>} : tensor<256x!tt.ptr<f32>, #blocked0>
     tt.return
   }
 }

--- a/test/Conversion/tritongpu_to_llvm.mlir
+++ b/test/Conversion/tritongpu_to_llvm.mlir
@@ -134,6 +134,38 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 8 : i32} {
 
 // -----
 
+#detailed_cache_policy = #ttng.cache_policy<l1 = evict_last, l2_primary = evict_first, l2_secondary = evict_unchanged, l2_fraction = 3.300000e-01 : f32, l2_prefetch_size = 128 : i32>
+#store_detailed_cache_policy = #ttng.cache_policy<l1 = evict_last, l2_primary = evict_first, l2_secondary = evict_unchanged, l2_fraction = 3.300000e-01 : f32>
+#modifier_l2_cache_policy = #ttng.cache_policy<cache_modifier = cg, l2_primary = evict_last, l2_secondary = evict_unchanged, l2_fraction = 5.000000e-01 : f32>
+#blocked0 = #ttg.blocked<{sizePerThread = [1], threadsPerWarp = [32], warpsPerCTA = [4], order = [0]}>
+module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.target = "cuda:80", "ttg.threads-per-warp" = 32 : i32} {
+  // CHECK-LABEL: load_with_detailed_cache_policy
+  tt.func @load_with_detailed_cache_policy(%ptrs : tensor<128x!tt.ptr<f32>, #blocked0>) {
+    // CHECK: createpolicy.fractional.L2::evict_first.b64 $0, {{0\.33.*}};
+    // CHECK: ld.global.L1::evict_last.L2::128B.L2::cache_hint.b32
+    %value = tt.load %ptrs {cachePolicy = #detailed_cache_policy} : tensor<128x!tt.ptr<f32>, #blocked0>
+    tt.return
+  }
+
+  // CHECK-LABEL: store_with_detailed_cache_policy
+  tt.func @store_with_detailed_cache_policy(%ptrs : tensor<128x!tt.ptr<f32>, #blocked0>, %value : tensor<128xf32, #blocked0>) {
+    // CHECK: createpolicy.fractional.L2::evict_first.b64 $0, {{0\.33.*}};
+    // CHECK: st.global.L1::evict_last.L2::cache_hint.b32
+    tt.store %ptrs, %value {cachePolicy = #store_detailed_cache_policy} : tensor<128x!tt.ptr<f32>, #blocked0>
+    tt.return
+  }
+
+  // CHECK-LABEL: load_with_cache_modifier_in_policy
+  tt.func @load_with_cache_modifier_in_policy(%ptrs : tensor<128x!tt.ptr<f32>, #blocked0>) {
+    // CHECK: createpolicy.fractional.L2::evict_last.b64 $0, 0.5;
+    // CHECK: ld.global.cg.L2::cache_hint.b32
+    %value = tt.load %ptrs {cachePolicy = #modifier_l2_cache_policy} : tensor<128x!tt.ptr<f32>, #blocked0>
+    tt.return
+  }
+}
+
+// -----
+
 #blocked0 = #ttg.blocked<{sizePerThread = [1], threadsPerWarp = [32], warpsPerCTA = [4], order = [0]}>
 module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32} {
   // CHECK-LABEL: store_with_cache_attr
@@ -143,7 +175,7 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32} {
     // CHECK: llvm.inline_asm has_side_effects asm_dialect = att {{.*}} "@$3 st.global.L1::evict_last.L2::cache_hint.b32 [ $1 + 0 ], { $0 }, $2;"
     // CHECK-NOT: createpolicy
     // CHECK: llvm.inline_asm has_side_effects asm_dialect = att {{.*}} "@$3 st.global.L1::evict_last.L2::cache_hint.b32 [ $1 + 0 ], { $0 }, $2;"
-    tt.store %a_ptr_init, %cst_0, %cst evictionPolicy = evict_last cacheModifier = ca : tensor<256x!tt.ptr<f32>, #blocked0>
+    tt.store %a_ptr_init, %cst_0, %cst {cachePolicy = #tt.cache_policy<cache_modifier = ca, eviction_policy = evict_last>} : tensor<256x!tt.ptr<f32>, #blocked0>
     tt.return
   }
 }
@@ -159,7 +191,7 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32} {
     // CHECK: llvm.inline_asm has_side_effects asm_dialect = att {{.*}} "mov.u32 $0, $1;\0A\09@$4 ld.global.L1::evict_first.L2::cache_hint.b32 { $0 }, [ $2 + 0 ], $3;"
     // CHECK-NOT: createpolicy
     // CHECK: llvm.inline_asm has_side_effects asm_dialect = att {{.*}} "mov.u32 $0, $1;\0A\09@$4 ld.global.L1::evict_first.L2::cache_hint.b32 { $0 }, [ $2 + 0 ], $3;"
-      %1 = tt.load %a_ptr_init, %cst, %cst_0 evictionPolicy = evict_first : tensor<256x!tt.ptr<f32>, #blocked0>
+      %1 = tt.load %a_ptr_init, %cst, %cst_0 {cachePolicy = #tt.cache_policy<cache_modifier = none, eviction_policy = evict_first>} : tensor<256x!tt.ptr<f32>, #blocked0>
       tt.return
   }
 }
@@ -174,7 +206,7 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32} {
     // CHECK: llvm.inline_asm has_side_effects asm_dialect = att {{.*}} "@$3 st.global.L1::evict_last.L2::cache_hint.b32 [ $1 + 0 ], { $0 }, $2;"
     // CHECK-NOT: createpolicy
     // CHECK: llvm.inline_asm has_side_effects asm_dialect = att {{.*}} "@$3 st.global.L1::evict_last.L2::cache_hint.b32 [ $1 + 0 ], { $0 }, $2;"
-      tt.store %a_ptr_init, %cst_0, %cst evictionPolicy = evict_last : tensor<256x!tt.ptr<f32>, #blocked0>
+      tt.store %a_ptr_init, %cst_0, %cst {cachePolicy = #tt.cache_policy<cache_modifier = none, eviction_policy = evict_last>} : tensor<256x!tt.ptr<f32>, #blocked0>
       tt.return
   }
 }
@@ -796,11 +828,21 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 8 : i32} {
 #blocked = #ttg.blocked<{sizePerThread = [4], threadsPerWarp = [32], warpsPerCTA = [4], order = [0]}>
 #shared1D = #ttg.swizzled_shared<{vec = 2, perPhase = 1, maxPhase = 8, order = [0]}>
 #smem = #ttg.shared_memory
-module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32} {
+#async_l2_policy = #ttng.cache_policy<l1 = evict_last, l2_primary = evict_last, l2_secondary = evict_unchanged, l2_fraction = 8.200000e-01 : f32, l2_prefetch_size = 256 : i32>
+module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.target = "cuda:80", "ttg.threads-per-warp" = 32 : i32} {
   // CHECK-LABEL: async_cp_contiguity_hint
   tt.func @async_cp_contiguity_hint(%v: tensor<256x!tt.ptr<f16>, #blocked>, %smem: !ttg.memdesc<256xf16, #shared1D, #smem, mutable>) {
     // CHECK: cp.async.ca.shared.global [ ${{.*}} + 0 ], [ ${{.*}} + 0 ], 0x8, 0x8
     %0 = ttg.async_copy_global_to_local %v, %smem {contiguity = 4 : i32} : tensor<256x!tt.ptr<f16>, #blocked> -> !ttg.memdesc<256xf16, #shared1D, #smem, mutable>
+    tt.return
+  }
+
+  // CHECK-LABEL: async_cp_detailed_cache_policy
+  tt.func @async_cp_detailed_cache_policy(%v: tensor<256x!tt.ptr<f16>, #blocked>, %smem: !ttg.memdesc<256xf16, #shared1D, #smem, mutable>) {
+    // CHECK: createpolicy.fractional.L2::evict_last.b64 $0, {{0\.8.*}};
+    // CHECK-NOT: L1::evict_last
+    // CHECK: cp.async.ca.shared.global.L2::256B.L2::cache_hint
+    %0 = ttg.async_copy_global_to_local %v, %smem {cachePolicy = #async_l2_policy, contiguity = 4 : i32} : tensor<256x!tt.ptr<f16>, #blocked> -> !ttg.memdesc<256xf16, #shared1D, #smem, mutable>
     tt.return
   }
 }

--- a/test/Conversion/tritongpu_to_llvm_volta.mlir
+++ b/test/Conversion/tritongpu_to_llvm_volta.mlir
@@ -25,7 +25,7 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32} {
   tt.func @store_with_cache_attr(%a_ptr_init : tensor<256x!tt.ptr<f32>, #blocked0>, %cst : tensor<256xi1, #blocked0>, %cst_0 : tensor<256xf32, #blocked0>) {
     // CHECK-NOT: createpolicy.fractional
     // CHECK: st.global.L1::evict_last.b32
-    tt.store %a_ptr_init, %cst_0, %cst evictionPolicy = evict_last cacheModifier = ca : tensor<256x!tt.ptr<f32>, #blocked0>
+    tt.store %a_ptr_init, %cst_0, %cst {cachePolicy = #tt.cache_policy<cache_modifier = ca, eviction_policy = evict_last>} : tensor<256x!tt.ptr<f32>, #blocked0>
     tt.return
   }
 }

--- a/test/Conversion/tritongpu_to_llvm_volta.mlir
+++ b/test/Conversion/tritongpu_to_llvm_volta.mlir
@@ -25,7 +25,7 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32} {
   tt.func @store_with_cache_attr(%a_ptr_init : tensor<256x!tt.ptr<f32>, #blocked0>, %cst : tensor<256xi1, #blocked0>, %cst_0 : tensor<256xf32, #blocked0>) {
     // CHECK-NOT: createpolicy.fractional
     // CHECK: st.global.L1::evict_last.b32
-    tt.store %a_ptr_init, %cst_0, %cst {cachePolicy = #tt.cache_policy<cache_modifier = ca, eviction_policy = evict_last>} : tensor<256x!tt.ptr<f32>, #blocked0>
+    tt.store %a_ptr_init, %cst_0, %cst {cachePolicy = #tt.cache_policy<cache_modifier = none, eviction_policy = evict_last>} : tensor<256x!tt.ptr<f32>, #blocked0>
     tt.return
   }
 }

--- a/test/Hopper/WarpSpecialization/ws_task_partition.mlir
+++ b/test/Hopper/WarpSpecialization/ws_task_partition.mlir
@@ -37,4 +37,23 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.targ
     }
     tt.return
   }
+
+// CHECK-LABEL: @load_with_cache_policy
+// CHECK: %[[#LOAD:]] = tt.load {{.*}} {async_task_id = array<i32: 0>, cachePolicy = #ttng.cache_policy<l1 = evict_last>}
+// CHECK: %[[#LOCAL:]] = ttg.local_alloc %[[#LOAD]]
+// CHECK: ttng.warp_group_dot %[[#LOCAL]], {{.*}} {async_task_id = array<i32: 1, 2>
+  tt.func @load_with_cache_policy(%arg0: tensor<128x64x!tt.ptr<f16>, #blocked>, %arg1: !tt.tensordesc<64x256xf16>, %arg2: i32) {
+    %c0_i32 = arith.constant 0 : i32
+    %c1_i32 = arith.constant 1 : i32
+    %cst = arith.constant dense<0.000000e+00> : tensor<128x256xf32, #mma>
+    %0 = scf.for %arg3 = %c0_i32 to %arg2 step %c1_i32 iter_args(%arg4 = %cst) -> tensor<128x256xf32, #mma> : i32 {
+      %1 = tt.load %arg0 {cachePolicy = #ttng.cache_policy<l1 = evict_last>} : tensor<128x64x!tt.ptr<f16>, #blocked>
+      %2 = ttg.local_alloc %1 : (tensor<128x64xf16, #blocked>) -> !ttg.memdesc<128x64xf16, #shared, #smem>
+      %3 = tt.descriptor_load %arg1[%arg3, %arg3] : !tt.tensordesc<64x256xf16> -> tensor<64x256xf16, #blocked1>
+      %4 = ttg.local_alloc %3 : (tensor<64x256xf16, #blocked1>) -> !ttg.memdesc<64x256xf16, #shared, #smem>
+      %5 = ttng.warp_group_dot %2, %4, %arg4 {inputPrecision = 0 : i32} : !ttg.memdesc<128x64xf16, #shared, #smem> * !ttg.memdesc<64x256xf16, #shared, #smem> -> tensor<128x256xf32, #mma>
+      scf.yield %5 : tensor<128x256xf32, #mma>
+    }
+    tt.return
+  }
 }

--- a/test/NVWS/insert_aref.mlir
+++ b/test/NVWS/insert_aref.mlir
@@ -32,9 +32,9 @@ module attributes {"ttg.num-warps" = 4 : i32, ttg.target = "cuda:100"} {
     %1 = scf.for %arg5 = %c0_i32 to %arg0 step %c1_i32 iter_args(%arg6 = %0) -> (!ttg.async.token)  : i32 {
       %2 = arith.muli %arg5, %c64_i32 {ttg.partition = array<i32: 2>, loop.cluster = 1 : i32, loop.stage = 0 : i32} : i32
       // CHECK: [[PUT_BUF1:%.*]], [[TOKEN1:%.*]] = nvws.aref.put.enter [[AREF1]] {loop.cluster = 1 : i32, loop.stage = 0 : i32, ttg.partition = array<i32: 2>}
-      // CHECK-NEXT: nvws.descriptor_load {{.*}} 16384 [[PUT_BUF1]]
+      // CHECK-NEXT: nvws.descriptor_load {{.*}} 16384 [[PUT_BUF1]] {{.*}}cachePolicy = #tt.cache_policy<cache_modifier = cg, eviction_policy = evict_last>
       // CHECK: nvws.aref.put.exit [[AREF1]], [[TOKEN1]] [#nvws.async_op<tma_load>] {loop.cluster = 1 : i32, loop.stage = 0 : i32, ttg.partition = array<i32: 2>}
-      %3 = tt.descriptor_load %arg3[%arg1, %2] {loop.cluster = 1 : i32, loop.stage = 0 : i32, ttg.partition = array<i32: 2>} : !tt.tensordesc<128x64xf16, #shared> -> tensor<128x64xf16, #blocked1>
+      %3 = tt.descriptor_load %arg3[%arg1, %2] {cachePolicy = #tt.cache_policy<cache_modifier = cg, eviction_policy = evict_last>, loop.cluster = 1 : i32, loop.stage = 0 : i32, ttg.partition = array<i32: 2>} : !tt.tensordesc<128x64xf16, #shared> -> tensor<128x64xf16, #blocked1>
       // CHECK: [[PUT_BUF2:%.*]], [[TOKEN2:%.*]] = nvws.aref.put.enter [[AREF2]]
       // CHECK-NEXT: nvws.descriptor_load {{.*}} 16384 [[PUT_BUF2]]
       // CHECK: nvws.aref.put.exit [[AREF2]]

--- a/test/Triton/invalid.mlir
+++ b/test/Triton/invalid.mlir
@@ -16,6 +16,38 @@ tt.func @atomic_poll_invalid_width(%ptr: tensor<32x!tt.ptr<i8>>, %expected: tens
 
 // -----
 
+tt.func @load_with_store_cache_modifier(%ptr: !tt.ptr<f32>) {
+  // expected-error @+1 {{'tt.load' op invalid cache policy: cache modifier 'wb' is not supported for loads}}
+  %value = tt.load %ptr {cachePolicy = #tt.cache_policy<cache_modifier = wb, eviction_policy = evict_normal>} : !tt.ptr<f32>
+  tt.return
+}
+
+// -----
+
+tt.func @store_with_load_cache_modifier(%ptr: !tt.ptr<f32>, %value: f32) {
+  // expected-error @+1 {{'tt.store' op invalid cache policy: cache modifier 'ca' is not supported for stores}}
+  tt.store %ptr, %value {cachePolicy = #tt.cache_policy<cache_modifier = ca, eviction_policy = evict_normal>} : !tt.ptr<f32>
+  tt.return
+}
+
+// -----
+
+tt.func @load_with_nvidia_store_cache_modifier(%ptr: !tt.ptr<f32>) {
+  // expected-error @+1 {{'tt.load' op invalid cache policy: cache modifier 'wt' is not supported for loads}}
+  %value = tt.load %ptr {cachePolicy = #ttng.cache_policy<cache_modifier = wt>} : !tt.ptr<f32>
+  tt.return
+}
+
+// -----
+
+tt.func @store_with_nvidia_load_cache_modifier(%ptr: !tt.ptr<f32>, %value: f32) {
+  // expected-error @+1 {{'tt.store' op invalid cache policy: cache modifier 'cv' is not supported for stores}}
+  tt.store %ptr, %value {cachePolicy = #ttng.cache_policy<cache_modifier = cv>} : !tt.ptr<f32>
+  tt.return
+}
+
+// -----
+
 tt.func @fn(%v: i32) {
   %b = tt.splat %v : i32 -> tensor<128xi32>
   // expected-error @+1 {{rank of source must be same as rank of result}}

--- a/test/Triton/rewrite-tensor-descriptor-to-pointer.mlir
+++ b/test/Triton/rewrite-tensor-descriptor-to-pointer.mlir
@@ -8,7 +8,7 @@ module {
     %c128_i32 = arith.constant 128 : i32
     %c256_i32 = arith.constant 256 : i32
     %0 = tt.make_tensor_descriptor %arg0, [%c256_i32, %c256_i32], [%c1_i64, %c256_i64] {order = array<i32: 0>} : <f32>, <128x128xf32>
-    %3 = tt.descriptor_load %0[%arg1, %arg2] : !tt.tensordesc<128x128xf32> -> tensor<128x128xf32>
+    %3 = tt.descriptor_load %0[%arg1, %arg2] {cachePolicy = #tt.cache_policy<cache_modifier = cg, eviction_policy = evict_last>} : !tt.tensordesc<128x128xf32> -> tensor<128x128xf32>
     tt.return %3 : tensor<128x128xf32>
   }
 }
@@ -50,7 +50,7 @@ module {
 // CHECK-DAG: %[[VAL23:.*]] = tt.broadcast %[[VAL22]] : tensor<1x128xi1> -> tensor<128x128xi1>
 // CHECK-DAG: %[[VAL24:.*]] = arith.andi %[[VAL19]], %[[VAL23]]
 
-// CHECK-DAG: %[[VAL25:.*]] = tt.load %[[VAL15]], %[[VAL24]], %[[CST]]
+// CHECK-DAG: %[[VAL25:.*]] = tt.load %[[VAL15]], %[[VAL24]], %[[CST]] {cachePolicy = #tt.cache_policy<cache_modifier = cg, eviction_policy = evict_last>}
 // CHECK: tt.return %[[VAL25]] :
 
 // -----

--- a/test/TritonGPU/amd/amd-buffer-cache-modifiers-rdna3.mlir
+++ b/test/TritonGPU/amd/amd-buffer-cache-modifiers-rdna3.mlir
@@ -19,7 +19,7 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 1 : i32, "ttg.thr
   tt.func @buffer_load_cg(%arg0: !tt.ptr<f32> {tt.divisibility = 16 : i32}, %offset: tensor<128xi32, #blocked> {tt.divisibility = 16 : i32}) {
     // .cg load on RDNA3.5: aux = 1 (GLC)
     // CHECK: rocdl.raw.ptr.buffer.load {{.*}}, {{.*}}, {{.*}}, 1
-    %ret = amdg.buffer_load %arg0[%offset] cacheModifier = cg : !tt.ptr<f32> -> tensor<128xf32, #blocked>
+    %ret = amdg.buffer_load %arg0[%offset] {cachePolicy = #tt.cache_policy<cache_modifier = cg, eviction_policy = evict_normal>} : !tt.ptr<f32> -> tensor<128xf32, #blocked>
     tt.return
   }
 }
@@ -33,7 +33,7 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 1 : i32, "ttg.thr
   tt.func @buffer_load_cs(%arg0: !tt.ptr<f32> {tt.divisibility = 16 : i32}, %offset: tensor<128xi32, #blocked> {tt.divisibility = 16 : i32}) {
     // .cs load on RDNA3.5: aux = 7 (GLC|SLC|DLC)
     // CHECK: rocdl.raw.ptr.buffer.load {{.*}}, {{.*}}, {{.*}}, 7
-    %ret = amdg.buffer_load %arg0[%offset] cacheModifier = cs : !tt.ptr<f32> -> tensor<128xf32, #blocked>
+    %ret = amdg.buffer_load %arg0[%offset] {cachePolicy = #tt.cache_policy<cache_modifier = cs, eviction_policy = evict_normal>} : !tt.ptr<f32> -> tensor<128xf32, #blocked>
     tt.return
   }
 }
@@ -47,7 +47,7 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 1 : i32, "ttg.thr
   tt.func @buffer_load_cv(%arg0: !tt.ptr<f32> {tt.divisibility = 16 : i32}, %offset: tensor<128xi32, #blocked> {tt.divisibility = 16 : i32}) {
     // .cv load on RDNA3.5: aux = 7 (GLC|SLC|DLC)
     // CHECK: rocdl.raw.ptr.buffer.load {{.*}}, {{.*}}, {{.*}}, 7
-    %ret = amdg.buffer_load %arg0[%offset] cacheModifier = cv : !tt.ptr<f32> -> tensor<128xf32, #blocked>
+    %ret = amdg.buffer_load %arg0[%offset] {cachePolicy = #tt.cache_policy<cache_modifier = cv, eviction_policy = evict_normal>} : !tt.ptr<f32> -> tensor<128xf32, #blocked>
     tt.return
   }
 }
@@ -62,7 +62,7 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 1 : i32, "ttg.thr
     %c256_i32 = arith.constant 256 : i32
     // .cs store on RDNA3.5: aux = 7 (GLC|SLC|DLC)
     // CHECK: rocdl.raw.ptr.buffer.store {{.*}}, {{.*}}, {{.*}}, {{.*}}, 7
-    amdg.buffer_store %value, %arg0[%offset] cacheModifier = cs stride = %c256_i32 : !tt.ptr<f32> -> tensor<128xf32, #blocked>
+    amdg.buffer_store %value, %arg0[%offset] stride = %c256_i32 {cachePolicy = #tt.cache_policy<cache_modifier = cs, eviction_policy = evict_normal>} : !tt.ptr<f32> -> tensor<128xf32, #blocked>
     tt.return
   }
 }
@@ -77,7 +77,7 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 1 : i32, "ttg.thr
     %c256_i32 = arith.constant 256 : i32
     // .wt store on RDNA3.5: aux = 7 (GLC|SLC|DLC)
     // CHECK: rocdl.raw.ptr.buffer.store {{.*}}, {{.*}}, {{.*}}, {{.*}}, 7
-    amdg.buffer_store %value, %arg0[%offset] cacheModifier = wt stride = %c256_i32 : !tt.ptr<f32> -> tensor<128xf32, #blocked>
+    amdg.buffer_store %value, %arg0[%offset] stride = %c256_i32 {cachePolicy = #tt.cache_policy<cache_modifier = wt, eviction_policy = evict_normal>} : !tt.ptr<f32> -> tensor<128xf32, #blocked>
     tt.return
   }
 }

--- a/test/TritonGPU/amd/amd-convert-buffer-ops.mlir
+++ b/test/TritonGPU/amd/amd-convert-buffer-ops.mlir
@@ -215,10 +215,10 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32} {
     %4 = tt.addptr %3, %1 : tensor<16x!tt.ptr<bf16>, #blocked>, tensor<16xi32, #blocked>
     %5 = tt.splat %arg1 : !tt.ptr<bf16> -> tensor<16x!tt.ptr<bf16>, #blocked>
     %6 = tt.addptr %5, %1 : tensor<16x!tt.ptr<bf16>, #blocked>, tensor<16xi32, #blocked>
-    // COMMON: %[[loaded:.*]] = amdg.buffer_load %arg1[%1]
-    %7 = tt.load %6 : tensor<16x!tt.ptr<bf16>, #blocked>
-    // COMMON: amdg.buffer_store %[[loaded]], %[[ptr]][%[[range]]]
-    tt.store %4, %7 : tensor<16x!tt.ptr<bf16>, #blocked>
+    // COMMON: %[[loaded:.*]] = amdg.buffer_load %arg1[%1] {cachePolicy = #ttng.cache_policy<l1 = evict_last>}
+    %7 = tt.load %6 {cachePolicy = #ttng.cache_policy<l1 = evict_last>} : tensor<16x!tt.ptr<bf16>, #blocked>
+    // COMMON: amdg.buffer_store %[[loaded]], %[[ptr]][%[[range]]] {cachePolicy = #ttng.cache_policy<l1 = evict_last>}
+    tt.store %4, %7 {cachePolicy = #ttng.cache_policy<l1 = evict_last>} : tensor<16x!tt.ptr<bf16>, #blocked>
     tt.return
   }
 }
@@ -791,17 +791,20 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 8 : i32, ttg.targ
     // CDNA: %[[buffer:.*]] = amdg.buffer_load_to_local %[[ptr]][%[[offset]]] mask = %arg11 other = %arg12 stride = %arg[[#stride]] into %arg10
     %15 = ttg.async_copy_global_to_local %11, %arg10 mask %arg11 other %arg12 : tensor<256x64x!tt.ptr<f16>, #blocked> -> <256x64xf16, #shared, #smem, mutable>
 
-    // CDNA: %[[buffer:.*]] = amdg.buffer_load_to_local %[[ptr]][%[[offset]]] mask = %arg11 other = %arg12 stride = %arg[[#stride]] cacheModifier = ca into %arg10
-    %16 = ttg.async_copy_global_to_local %11, %arg10 mask %arg11 other %arg12 cacheModifier = ca: tensor<256x64x!tt.ptr<f16>, #blocked> -> <256x64xf16, #shared, #smem, mutable>
+    // CDNA: %[[buffer:.*]] = amdg.buffer_load_to_local %[[ptr]][%[[offset]]] mask = %arg11 other = %arg12 stride = %arg[[#stride]] cachePolicy = #tt.cache_policy<cache_modifier = ca, eviction_policy = evict_normal> into %arg10
+    %16 = ttg.async_copy_global_to_local %11, %arg10 mask %arg11 other %arg12 {cachePolicy = #tt.cache_policy<cache_modifier = ca, eviction_policy = evict_normal>}: tensor<256x64x!tt.ptr<f16>, #blocked> -> <256x64xf16, #shared, #smem, mutable>
 
-    // CDNA: %[[buffer:.*]] = amdg.buffer_load_to_local %[[ptr]][%[[offset]]] mask = %arg11 other = %arg12 stride = %arg[[#stride]] cacheModifier = cg into %arg10
-    %17 = ttg.async_copy_global_to_local %11, %arg10 mask %arg11 other %arg12 cacheModifier = cg: tensor<256x64x!tt.ptr<f16>, #blocked> -> <256x64xf16, #shared, #smem, mutable>
+    // CDNA: %[[buffer:.*]] = amdg.buffer_load_to_local %[[ptr]][%[[offset]]] mask = %arg11 other = %arg12 stride = %arg[[#stride]] cachePolicy = #tt.cache_policy<cache_modifier = cg, eviction_policy = evict_normal> into %arg10
+    %17 = ttg.async_copy_global_to_local %11, %arg10 mask %arg11 other %arg12 {cachePolicy = #tt.cache_policy<cache_modifier = cg, eviction_policy = evict_normal>}: tensor<256x64x!tt.ptr<f16>, #blocked> -> <256x64xf16, #shared, #smem, mutable>
 
-    // CDNA: %[[buffer:.*]] = amdg.buffer_load_to_local %[[ptr]][%[[offset]]] mask = %arg11 other = %arg12 stride = %arg[[#stride]] cacheModifier = cv into %arg10
-    %18 = ttg.async_copy_global_to_local %11, %arg10 mask %arg11 other %arg12 cacheModifier = cv: tensor<256x64x!tt.ptr<f16>, #blocked> -> <256x64xf16, #shared, #smem, mutable>
+    // CDNA: %[[buffer:.*]] = amdg.buffer_load_to_local %[[ptr]][%[[offset]]] mask = %arg11 other = %arg12 stride = %arg[[#stride]] cachePolicy = #tt.cache_policy<cache_modifier = cv, eviction_policy = evict_normal> into %arg10
+    %18 = ttg.async_copy_global_to_local %11, %arg10 mask %arg11 other %arg12 {cachePolicy = #tt.cache_policy<cache_modifier = cv, eviction_policy = evict_normal>}: tensor<256x64x!tt.ptr<f16>, #blocked> -> <256x64xf16, #shared, #smem, mutable>
+
+    // CDNA: %[[buffer:.*]] = amdg.buffer_load_to_local %[[ptr]][%[[offset]]] stride = %arg[[#stride]] cachePolicy = #ttng.cache_policy<l1 = evict_last> into %arg10
+    %19 = ttg.async_copy_global_to_local %11, %arg10 {cachePolicy = #ttng.cache_policy<l1 = evict_last>} : tensor<256x64x!tt.ptr<f16>, #blocked> -> <256x64xf16, #shared, #smem, mutable>
 
     // CDNA: %[[buffer:.*]] = amdg.buffer_load_to_local %[[ptr]][%[[offset]]] stride = %arg[[#stride]] into %arg10 {contiguity = 8 : i32
-    %19 = ttg.async_copy_global_to_local %11, %arg10 {contiguity = 8 : i32} : tensor<256x64x!tt.ptr<f16>, #blocked> -> <256x64xf16, #shared, #smem, mutable>
+    %20 = ttg.async_copy_global_to_local %11, %arg10 {contiguity = 8 : i32} : tensor<256x64x!tt.ptr<f16>, #blocked> -> <256x64xf16, #shared, #smem, mutable>
     tt.return
   }
 }

--- a/test/TritonGPU/amd/amd-optimize-buffer-ops-base-ptr-increment.mlir
+++ b/test/TritonGPU/amd/amd-optimize-buffer-ops-base-ptr-increment.mlir
@@ -5,7 +5,7 @@
 // CHECK-DAG: [[Y_OFFSET_CST:%.*]] = arith.constant dense<321>
 // CHECK: scf.for {{.*}} iter_args({{.*}}, {{.*}}, [[X_BASE:%.*]] = {{.*}}, [[Y_BASE:%.*]] = {{.*}})
 // CHECK:   amdg.buffer_load [[X_BASE]]{{\[}}[[X_OFFSET_CST]]{{\]}} :
-// CHECK:   amdg.buffer_load [[Y_BASE]]{{\[}}[[Y_OFFSET_CST]]{{\]}} cacheModifier = cg :
+// CHECK:   amdg.buffer_load [[Y_BASE]]{{\[}}[[Y_OFFSET_CST]]{{\]}} {cachePolicy = #tt.cache_policy<cache_modifier = cg, eviction_policy = evict_normal>} :
 // CHECK:   [[NEXT_X_BASE:%.*]] = tt.addptr [[X_BASE]], %c64_i32
 // CHECK:   [[NEXT_Y_BASE:%.*]] = tt.addptr [[Y_BASE]]
 // CHECK:   scf.yield {{.*}}, [[NEXT_X_BASE]], [[NEXT_Y_BASE]]
@@ -38,7 +38,7 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 1 : i32, "ttg.thr
     %step = tt.splat %tmp : i32 -> tensor<64x32xi32, #blocked>
     %for:2 = scf.for %idx = %c0 to %c128 step %c1 iter_args(%Xoffset = %Xoffset_init, %Yoffset = %Yoffset_init) -> (tensor<16x64xi32, #blocked>, tensor<64x32xi32, #blocked>) {
       %x = amdg.buffer_load %X[%Xoffset] : !tt.ptr<f16> -> tensor<16x64xf16, #blocked>
-      %y = amdg.buffer_load %Y[%Yoffset] cacheModifier = cg : !tt.ptr<f16> -> tensor<64x32xf16, #blocked>
+      %y = amdg.buffer_load %Y[%Yoffset] {cachePolicy = #tt.cache_policy<cache_modifier = cg, eviction_policy = evict_normal>} : !tt.ptr<f16> -> tensor<64x32xf16, #blocked>
 
       ttg.local_store %x, %x_dummy_buffer : tensor<16x64xf16, #blocked> -> !ttg.memdesc<16x64xf16, #shared, #smem, mutable, 16x64>
       ttg.local_store %y, %y_dummy_buffer : tensor<64x32xf16, #blocked> -> !ttg.memdesc<64x32xf16, #shared, #smem, mutable, 64x32>
@@ -336,8 +336,8 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 1 : i32, "ttg.thr
 // CHECK-DAG: [[Z_OFFSET:%.*]] = arith.constant dense<789> : tensor<32x32xi32, #blocked>
 // CHECK: scf.for {{.*}} iter_args({{%.*}}[[Y_OFFSET:%.*]] = [[Y_OFFSET_INIT]]
 // CHECK-DAG: amdg.buffer_load {{%.*\[}}[[X_OFFSET]]{{\]}} : !tt.ptr<f16> -> tensor<16x64xf16, #blocked>
-// CHECK-DAG: amdg.buffer_load {{%.*\[}}[[Y_OFFSET]]{{\]}} cacheModifier = cg : !tt.ptr<f16> -> tensor<64x32xf16, #blocked>
-// CHECK-DAG: amdg.buffer_load {{%.*\[}}[[Z_OFFSET]]{{\]}} cacheModifier = cg : !tt.ptr<f16> -> tensor<32x32xf16, #blocked>
+// CHECK-DAG: amdg.buffer_load {{%.*\[}}[[Y_OFFSET]]{{\]}} {cachePolicy = #tt.cache_policy<cache_modifier = cg, eviction_policy = evict_normal>} : !tt.ptr<f16> -> tensor<64x32xf16, #blocked>
+// CHECK-DAG: amdg.buffer_load {{%.*\[}}[[Z_OFFSET]]{{\]}} {cachePolicy = #tt.cache_policy<cache_modifier = cg, eviction_policy = evict_normal>} : !tt.ptr<f16> -> tensor<32x32xf16, #blocked>
 
 #blocked = #ttg.blocked<{sizePerThread = [1, 1], threadsPerWarp = [8, 8], warpsPerCTA = [1, 1], order = [1, 0]}>
 #shared = #ttg.swizzled_shared<{vec = 1, perPhase = 1, maxPhase = 1, order = [1, 0]}>
@@ -367,8 +367,8 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 1 : i32, "ttg.thr
 
     %for:3 = scf.for %iter = %iter_first to %iter_last step %iter_step iter_args(%Xoffset = %Xoffset_init, %Yoffset = %Yoffset_init, %Zoffset = %Zoffset_init) -> (tensor<16x64xi32, #blocked>, tensor<64x32xi32, #blocked>, tensor<32x32xi32, #blocked>) {
       %x = amdg.buffer_load %X[%Xoffset] : !tt.ptr<f16> -> tensor<16x64xf16, #blocked>
-      %y = amdg.buffer_load %Y[%Yoffset] cacheModifier = cg : !tt.ptr<f16> -> tensor<64x32xf16, #blocked>
-      %z = amdg.buffer_load %Z[%Zoffset] cacheModifier = cg : !tt.ptr<f16> -> tensor<32x32xf16, #blocked>
+      %y = amdg.buffer_load %Y[%Yoffset] {cachePolicy = #tt.cache_policy<cache_modifier = cg, eviction_policy = evict_normal>} : !tt.ptr<f16> -> tensor<64x32xf16, #blocked>
+      %z = amdg.buffer_load %Z[%Zoffset] {cachePolicy = #tt.cache_policy<cache_modifier = cg, eviction_policy = evict_normal>} : !tt.ptr<f16> -> tensor<32x32xf16, #blocked>
 
       ttg.local_store %x, %x_dummy_buffer : tensor<16x64xf16, #blocked> -> !ttg.memdesc<16x64xf16, #shared, #smem, mutable, 16x64>
       ttg.local_store %y, %y_dummy_buffer : tensor<64x32xf16, #blocked> -> !ttg.memdesc<64x32xf16, #shared, #smem, mutable, 64x32>
@@ -392,8 +392,8 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 1 : i32, "ttg.thr
 // CHECK-DAG: [[Z_OFFSET_INIT:%.*]] = arith.constant dense<789> : tensor<32x32xi32, #blocked>
 // CHECK: scf.for {{.*}} iter_args([[X_OFFSET:%.*]] = [[X_OFFSET_INIT]], {{.*}}[[Z_OFFSET:%.*]] = [[Z_OFFSET_INIT]]
 // CHECK-DAG: amdg.buffer_load {{%.*\[}}[[X_OFFSET]]{{\]}} : !tt.ptr<f16> -> tensor<16x64xf16, #blocked>
-// CHECK-DAG: amdg.buffer_load {{%.*\[}}[[Y_OFFSET]]{{\]}} cacheModifier = cg : !tt.ptr<f16> -> tensor<64x32xf16, #blocked>
-// CHECK-DAG: amdg.buffer_load {{%.*\[}}[[Z_OFFSET]]{{\]}} cacheModifier = cg : !tt.ptr<f16> -> tensor<32x32xf16, #blocked>
+// CHECK-DAG: amdg.buffer_load {{%.*\[}}[[Y_OFFSET]]{{\]}} {cachePolicy = #tt.cache_policy<cache_modifier = cg, eviction_policy = evict_normal>} : !tt.ptr<f16> -> tensor<64x32xf16, #blocked>
+// CHECK-DAG: amdg.buffer_load {{%.*\[}}[[Z_OFFSET]]{{\]}} {cachePolicy = #tt.cache_policy<cache_modifier = cg, eviction_policy = evict_normal>} : !tt.ptr<f16> -> tensor<32x32xf16, #blocked>
 
 #blocked = #ttg.blocked<{sizePerThread = [1, 1], threadsPerWarp = [8, 8], warpsPerCTA = [1, 1], order = [1, 0]}>
 #shared = #ttg.swizzled_shared<{vec = 1, perPhase = 1, maxPhase = 1, order = [1, 0]}>
@@ -423,8 +423,8 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 1 : i32, "ttg.thr
 
     %for:3 = scf.for %iter = %iter_first to %iter_last step %iter_step iter_args(%Xoffset = %Xoffset_init, %Yoffset = %Yoffset_init, %Zoffset = %Zoffset_init) -> (tensor<16x64xi32, #blocked>, tensor<64x32xi32, #blocked>, tensor<32x32xi32, #blocked>) {
       %x = amdg.buffer_load %X[%Xoffset] : !tt.ptr<f16> -> tensor<16x64xf16, #blocked>
-      %y = amdg.buffer_load %Y[%Yoffset] cacheModifier = cg : !tt.ptr<f16> -> tensor<64x32xf16, #blocked>
-      %z = amdg.buffer_load %Z[%Zoffset] cacheModifier = cg : !tt.ptr<f16> -> tensor<32x32xf16, #blocked>
+      %y = amdg.buffer_load %Y[%Yoffset] {cachePolicy = #tt.cache_policy<cache_modifier = cg, eviction_policy = evict_normal>} : !tt.ptr<f16> -> tensor<64x32xf16, #blocked>
+      %z = amdg.buffer_load %Z[%Zoffset] {cachePolicy = #tt.cache_policy<cache_modifier = cg, eviction_policy = evict_normal>} : !tt.ptr<f16> -> tensor<32x32xf16, #blocked>
 
       ttg.local_store %x, %x_dummy_buffer : tensor<16x64xf16, #blocked> -> !ttg.memdesc<16x64xf16, #shared, #smem, mutable, 16x64>
       ttg.local_store %y, %y_dummy_buffer : tensor<64x32xf16, #blocked> -> !ttg.memdesc<64x32xf16, #shared, #smem, mutable, 64x32>

--- a/test/TritonGPU/loop-pipeline-hip.mlir
+++ b/test/TritonGPU/loop-pipeline-hip.mlir
@@ -44,6 +44,7 @@ module attributes {"ttg.target" = "hip:gfx942", "ttg.num-ctas" = 1 : i32, "ttg.n
     // SYNC:   scf.yield
 
     // ASYNC: ttg.async_copy_global_to_local
+    // ASYNC-SAME: cachePolicy = #tt.cache_policy<cache_modifier = ca
     // ASYNC: scf.for
     // ASYNC:  ttg.async_wait
     // ASYNC:  ttg.async_copy_global_to_local
@@ -51,7 +52,7 @@ module attributes {"ttg.target" = "hip:gfx942", "ttg.num-ctas" = 1 : i32, "ttg.n
     // ASYNC:  tt.dot
     // ASYNC:  scf.yield
     %17:2 = scf.for %arg2 = %c0_i32 to %c8_i32 step %c1_i32 iter_args(%arg3 = %cst_1, %arg4 = %cst_2) -> (tensor<128x16xf32, #mma>, tensor<128x64xf32, #mma>)  : i32 {
-      %18 = tt.load %16 : tensor<64x16x!tt.ptr<f16>, #blocked>
+      %18 = tt.load %16 {cachePolicy = #tt.cache_policy<cache_modifier = ca, eviction_policy = evict_normal>} : tensor<64x16x!tt.ptr<f16>, #blocked>
       %19 = ttg.convert_layout %9 : tensor<128x64xf16, #blocked1> -> tensor<128x64xf16, #ttg.dot_op<{opIdx = 0, parent = #mma, kWidth = 2}>>
       %20 = ttg.convert_layout %18 : tensor<64x16xf16, #blocked> -> tensor<64x16xf16, #ttg.dot_op<{opIdx = 1, parent = #mma, kWidth = 2}>>
       %21 = tt.dot %19, %20, %cst_1 : tensor<128x64xf16, #ttg.dot_op<{opIdx = 0, parent = #mma, kWidth = 2}>> * tensor<64x16xf16, #ttg.dot_op<{opIdx = 1, parent = #mma, kWidth = 2}>> -> tensor<128x16xf32, #mma>

--- a/test/TritonGPU/loop-pipeline-hopper.mlir
+++ b/test/TritonGPU/loop-pipeline-hopper.mlir
@@ -22,7 +22,9 @@
 // CHECK-DAG: %[[LOOP_COND_0:.*]] = arith.cmpi slt, %[[LB:.*]], %[[UB:.*]]
 // CHECK-DAG: %[[LOOP_COND_0_SPLAT_A:.*]] = tt.splat %[[LOOP_COND_0]]
 // CHECK-DAG: %[[ASUB:.*]] = ttg.memdesc_index %[[ABUFFER]]{{\[}}%[[CONSTANT_0]]{{\]}} : !ttg.memdesc<2x128x32xf16, #shared, #smem, mutable> -> !ttg.memdesc<128x32xf16, #shared, #smem, mutable>
-// CHECK: %[[T_A0:.*]] = ttg.async_copy_global_to_local %{{.*}}, %[[ASUB]] mask %[[LOOP_COND_0_SPLAT_A]] {contiguity = 4 : i32} : tensor<128x32x!tt.ptr<f16>, #blocked1> -> <128x32xf16, #shared, #smem, mutable>
+// CHECK: %[[T_A0:.*]] = ttg.async_copy_global_to_local %{{.*}}, %[[ASUB]] mask %[[LOOP_COND_0_SPLAT_A]]
+// CHECK-SAME: cachePolicy = #ttng.cache_policy<l1 = evict_last>
+// CHECK-SAME: contiguity = 4 : i32
 // CHECK-DAG: %[[LOOP_COND_0_SPLAT_B:.*]] = tt.splat %[[LOOP_COND_0]]
 // CHECK-DAG: %[[BSUB:.*]] = ttg.memdesc_index %[[BBUFFER]]{{\[}}%[[CONSTANT_0]]{{\]}}
 // CHECK: %[[T_B0:.*]] = ttg.async_copy_global_to_local %{{.*}}, %[[BSUB]] mask %[[LOOP_COND_0_SPLAT_B]] other %{{.*}} {contiguity = 4 : i32} : tensor<32x128x!tt.ptr<f16>, #blocked> -> <32x128xf16, #shared1, #smem, mutable>
@@ -80,7 +82,7 @@ tt.func @matmul_loop(%lb : index, %ub : index, %step : index,
   %b_off = arith.constant dense<4> : tensor<32x128xi32, #BL>
 
   scf.for %iv = %lb to %ub step %step iter_args(%a_ptr = %a_ptr_init, %b_ptr = %b_ptr_init, %prev_c = %c_init) -> (tensor<128x32x!tt.ptr<f16>, #AL>, tensor<32x128x!tt.ptr<f16>, #BL>, tensor<128x128xf32, #C>) {
-    %a_ = tt.load %a_ptr : tensor<128x32x!tt.ptr<f16>, #AL>
+    %a_ = tt.load %a_ptr {cachePolicy = #ttng.cache_policy<l1 = evict_last>} : tensor<128x32x!tt.ptr<f16>, #AL>
     %a = ttg.convert_layout %a_ : tensor<128x32xf16, #AL> -> tensor<128x32xf16, #A>
     %b_ = tt.load %b_ptr, %b_mask, %b_other : tensor<32x128x!tt.ptr<f16>, #BL>
     %b = ttg.convert_layout %b_ : tensor<32x128xf16, #BL> -> tensor<32x128xf16, #B>

--- a/test/TritonNvidiaGPU/invalid.mlir
+++ b/test/TritonNvidiaGPU/invalid.mlir
@@ -37,6 +37,11 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.targ
 
 // -----
 
+// expected-error @below {{cache modifier cannot be combined with an L1 eviction priority}}
+#invalid_cache_policy = #ttng.cache_policy<cache_modifier = cg, l1 = no_allocate>
+
+// -----
+
 // expected-error @below {{fp4Padded tensor memory layout requires colStride 1 but got 2}}
 #bad_fp4_padded_tmem = #ttng.tensor_memory_encoding<blockM = 128, blockN = 64, colStride = 2, fp4Padded = true>
 

--- a/third_party/amd/include/Dialect/TritonAMDGPU/IR/TritonAMDGPUOps.td
+++ b/third_party/amd/include/Dialect/TritonAMDGPU/IR/TritonAMDGPUOps.td
@@ -831,8 +831,7 @@ def AsyncCopyLocalToGlobalOp : TT_AMDGPU_Op<"async_copy_local_to_global", [
     Arg<TTG_MemDescType, "", GenericSharedRead>:$src,
     Arg<TT_PtrTensor, "", [MemWrite<GlobalMemory>]>:$dst,
     Optional<I1Tensor>:$mask,
-    DefaultValuedAttr<TT_CacheModifierAttr, "triton::CacheModifier::NONE">:$cache,
-    DefaultValuedAttr<TT_EvictionPolicyAttr, "triton::EvictionPolicy::NORMAL">:$evict,
+    OptionalAttr<AnyAttr>:$cachePolicy,
     DefaultValuedAttr<I32Attr, "1">:$contiguity
   );
 
@@ -840,7 +839,7 @@ def AsyncCopyLocalToGlobalOp : TT_AMDGPU_Op<"async_copy_local_to_global", [
 
   let assemblyFormat = [{
     $src `,` $dst (`mask` $mask^)?
-    oilist(`cacheModifier` `=` $cache | `evictionPolicy` `=` $evict)
+    oilist(`cachePolicy` `=` $cachePolicy)
     attr-dict `:` qualified(type($src)) `->` type($dst)
   }];
 }

--- a/third_party/amd/include/Dialect/TritonAMDGPU/IR/TritonAMDGPUOps.td
+++ b/third_party/amd/include/Dialect/TritonAMDGPU/IR/TritonAMDGPUOps.td
@@ -293,7 +293,7 @@ def BufferLoadOp : TT_AMDGPU_Op<"buffer_load", [
       Arg<TT_Ptr, "Global memory scalar base pointer to load from", [MemRead<GlobalMemory>]>:$ptr,
       I32Tensor:$offsets,
       Optional<I32>:$stride,
-      DefaultValuedAttr<TT_CacheModifierAttr, "::mlir::triton::CacheModifier::NONE">:$cache,
+      OptionalAttr<AnyAttr>:$cachePolicy,
       Optional<TT_BoolTensor>:$mask,
       Optional<TT_Tensor>:$other,
       DefaultValuedAttr<I32Attr, "1">:$contiguity
@@ -302,7 +302,6 @@ def BufferLoadOp : TT_AMDGPU_Op<"buffer_load", [
 
     let assemblyFormat = [{
       $ptr `[` $offsets `]` (`,` $mask^)? (`,` $other^)?
-      oilist(`cacheModifier` `=` $cache)
       (`stride` `=` $stride^)?
       attr-dict `:` qualified(type($ptr)) `->` type($result)
     }];
@@ -338,7 +337,7 @@ def BufferLoadToLocalOp : TT_AMDGPU_Op<"buffer_load_to_local", [
       Optional<TT_BoolTensor>:$mask,
       Optional<TT_Tensor>:$other,
       Optional<I32>:$stride,
-      DefaultValuedAttr<TT_CacheModifierAttr, "::mlir::triton::CacheModifier::NONE">:$cache,
+      OptionalAttr<AnyAttr>:$cachePolicy,
       DefaultValuedAttr<I32Attr, "1">:$contiguity
     );
     let results = (outs TTG_AsyncToken:$token);
@@ -347,7 +346,7 @@ def BufferLoadToLocalOp : TT_AMDGPU_Op<"buffer_load_to_local", [
 
     let assemblyFormat = [{
       $ptr `[` $offsets `]` (`mask` `=` $mask^)? (`other` `=` $other^)? (`stride` `=` $stride^)?
-      oilist(`cacheModifier` `=` $cache) `into` $dest
+      oilist(`cachePolicy` `=` $cachePolicy) `into` $dest
       attr-dict `:` qualified(type($ptr)) `[` type($offsets) `]` type($other) `->` type($dest)
     }];
 }
@@ -483,7 +482,7 @@ def BufferStoreOp : TT_AMDGPU_Op<"buffer_store", [
       Arg<TT_Ptr, "Global memory scalar base pointer to write to", [MemWrite<GlobalMemory>]>:$ptr,
       I32Tensor:$offsets,
       Optional<I32>:$stride,
-      DefaultValuedAttr<TT_CacheModifierAttr, "mlir::triton::CacheModifier::NONE">:$cache,
+      OptionalAttr<AnyAttr>:$cachePolicy,
       Optional<TT_BoolTensor>:$mask,
       DefaultValuedAttr<I32Attr, "1">:$contiguity
     );
@@ -492,7 +491,6 @@ def BufferStoreOp : TT_AMDGPU_Op<"buffer_store", [
 
     let assemblyFormat = [{
       $value `,` $ptr `[` $offsets `]` (`,` $mask^)?
-      oilist(`cacheModifier` `=` $cache)
       (`stride` `=` $stride^)?
       attr-dict `:` qualified(type($ptr)) `->` type($value)
     }];

--- a/third_party/amd/lib/Dialect/TritonAMDGPU/IR/Dialect.cpp
+++ b/third_party/amd/lib/Dialect/TritonAMDGPU/IR/Dialect.cpp
@@ -1273,7 +1273,8 @@ LogicalResult AsyncCopyLocalToGlobalOp::verify() {
   if (!isa<gpu::SharedMemorySpaceAttr>(srcTy.getMemorySpace()))
     return emitOpError("source must be in shared memory");
 
-  return success();
+  return triton::verifyCachePolicy(getOperation(), getCachePolicyAttr(),
+                                   triton::CachePolicyOperation::Store);
 }
 
 LogicalResult AsyncTDMFusedCopyGlobalToLocalOp::verify() {

--- a/third_party/amd/lib/TritonAMDGPUToLLVM/LoadStoreOpToLLVM.cpp
+++ b/third_party/amd/lib/TritonAMDGPUToLLVM/LoadStoreOpToLLVM.cpp
@@ -1137,6 +1137,12 @@ struct AsyncCopyLocalToGlobalOpConversion
   matchAndRewrite(triton::amdgpu::AsyncCopyLocalToGlobalOp op,
                   OpAdaptor adaptor,
                   ConversionPatternRewriter &rewriter) const override {
+    auto cacheModifier = LLVM::AMD::getCacheModifier(op.getCachePolicyAttr());
+    if (failed(cacheModifier)) {
+      op.emitOpError("target cache policy is not supported on AMD targets");
+      return failure();
+    }
+
     // Only supported on GFX1250
     if (targetInfo.getISAFamily() != ISAFamily::GFX1250) {
       return rewriter.notifyMatchFailure(
@@ -1181,7 +1187,7 @@ struct AsyncCopyLocalToGlobalOpConversion
         freeVarMasks, rewriter, loc, targetInfo);
 
     auto emitGlobalStoreLds =
-        [this, &op, &b, threadPred, dstPtrTy](
+        [this, &op, &b, threadPred, dstPtrTy, cacheModifier = *cacheModifier](
             RewriterBase &rewriter, Location loc, ArrayRef<Value> storeValues,
             Value shmemAddr, int startIdx, VectorType vecTy,
             Value /*multicastMask*/) -> SmallVector<Value> {
@@ -1195,7 +1201,7 @@ struct AsyncCopyLocalToGlobalOpConversion
       auto [storeBlock, afterStoreBlock] = emitBranch(rewriter, loc, cond);
 
       emitAsyncStore(rewriter, loc, targetInfo, vecBits, dstElem, shmemAddr,
-                     op.getCache());
+                     cacheModifier);
 
       rewriter.setInsertionPointToStart(afterStoreBlock);
 

--- a/third_party/amd/lib/TritonAMDGPUToLLVM/LoadStoreOpToLLVM.cpp
+++ b/third_party/amd/lib/TritonAMDGPUToLLVM/LoadStoreOpToLLVM.cpp
@@ -551,6 +551,11 @@ struct LoadOpConversion : public ConvertOpToLLVMPattern<triton::LoadOp>,
   LogicalResult
   matchAndRewrite(triton::LoadOp op, OpAdaptor adaptor,
                   ConversionPatternRewriter &rewriter) const override {
+    auto cacheModifier = LLVM::AMD::getCacheModifier(op.getCachePolicyAttr());
+    if (failed(cacheModifier)) {
+      op.emitOpError("target cache policy is not supported on AMD targets");
+      return failure();
+    }
     auto loc = op->getLoc();
     auto b = TritonLLVMOpBuilder(loc, rewriter);
     // original values
@@ -599,7 +604,7 @@ struct LoadOpConversion : public ConvertOpToLLVMPattern<triton::LoadOp>,
         std::max(8u, valueElemTy.getIntOrFloatBitWidth());
     const int numVecs = numElems / vec;
 
-    auto cacheMod = op.getCache();
+    auto cacheMod = *cacheModifier;
     SmallVector<Value> loadedVals;
     Type vecTy = LLVM::getVectorType(valueElemTy, vec);
     for (size_t vecStart = 0; vecStart < numElems; vecStart += vec) {
@@ -651,6 +656,11 @@ struct BufferLoadOpConversion
   LogicalResult
   matchAndRewrite(triton::amdgpu::BufferLoadOp op, OpAdaptor adaptor,
                   ConversionPatternRewriter &rewriter) const override {
+    auto cacheModifier = LLVM::AMD::getCacheModifier(op.getCachePolicyAttr());
+    if (failed(cacheModifier)) {
+      op.emitOpError("target cache policy is not supported on AMD targets");
+      return failure();
+    }
     auto loc = op->getLoc();
     auto b = TritonLLVMOpBuilder(loc, rewriter);
     LLVM::AMD::BufferEmitter bufferEmitter(rewriter, loc, targetInfo);
@@ -659,7 +669,7 @@ struct BufferLoadOpConversion
     Value ptr = op.getPtr();
     Value offset = op.getOffsets();
     Value mask = op.getMask();
-    auto cacheMod = op.getCache();
+    auto cacheMod = *cacheModifier;
 
     // Converted values
     Value llPtr = adaptor.getPtr();
@@ -735,6 +745,12 @@ struct BufferLoadToLocalOpConversion
   LogicalResult
   matchAndRewrite(triton::amdgpu::BufferLoadToLocalOp op, OpAdaptor adaptor,
                   ConversionPatternRewriter &rewriter) const override {
+    auto cacheModifier = LLVM::AMD::getCacheModifier(op.getCachePolicyAttr());
+    if (failed(cacheModifier)) {
+      op.emitOpError("target cache policy is not supported on AMD targets");
+      return failure();
+    }
+    auto cacheMod = *cacheModifier;
     auto loc = op->getLoc();
     auto b = TritonLLVMOpBuilder(loc, rewriter);
     LLVM::AMD::BufferEmitter bufferEmitter(rewriter, loc, targetInfo);
@@ -854,7 +870,7 @@ struct BufferLoadToLocalOpConversion
             selectLdsAddressForPredicate(b, threadPred, shmemAddr);
         auto bufferLoadToLds = bufferEmitter.emitLoadToLds(
             vecTy, vecBytesVal, rsrcDesc, offsetElem, predicatedAddress,
-            maybeSwizzledMaskElem, op.getCache());
+            maybeSwizzledMaskElem, cacheMod);
         if (targetInfo.requiresAliasInfoForAsyncOps())
           AMD::addAsyncCopyAliasScope(bufferLoadToLds);
       } else {
@@ -864,7 +880,7 @@ struct BufferLoadToLocalOpConversion
 
         auto bufferLoadToLds = bufferEmitter.emitLoadToLds(
             vecTy, vecBytesVal, rsrcDesc, offsetElem, shmemAddr,
-            hasOther ? b.true_val() : maybeSwizzledMaskElem, op.getCache());
+            hasOther ? b.true_val() : maybeSwizzledMaskElem, cacheMod);
         if (targetInfo.requiresAliasInfoForAsyncOps())
           AMD::addAsyncCopyAliasScope(bufferLoadToLds);
 
@@ -909,6 +925,11 @@ struct AsyncCopyGlobalToLocalOpConversion
   LogicalResult
   matchAndRewrite(triton::gpu::AsyncCopyGlobalToLocalOp op, OpAdaptor adaptor,
                   ConversionPatternRewriter &rewriter) const override {
+    auto cacheModifier = LLVM::AMD::getCacheModifier(op.getCachePolicyAttr());
+    if (failed(cacheModifier)) {
+      op.emitOpError("target cache policy is not supported on AMD targets");
+      return failure();
+    }
     auto loc = op.getLoc();
     auto b = TritonLLVMOpBuilder(loc, rewriter);
 
@@ -1010,14 +1031,14 @@ struct AsyncCopyGlobalToLocalOpConversion
             selectLdsAddressForPredicate(b, cond, shmemAddr);
 
         emitAsyncLoad(rewriter, loc, targetInfo, vecBits, srcElem,
-                      predicatedAddress, op.getCache(), multicastMask);
+                      predicatedAddress, *cacheModifier, multicastMask);
       } else {
         // For architectures not supporting per lane LDS addresses we need to
         // emit a branch.
         auto [loadBlock, afterLoadBlock] = emitBranch(rewriter, loc, cond);
 
         emitAsyncLoad(rewriter, loc, targetInfo, vecBits, srcElem, shmemAddr,
-                      op.getCache(), multicastMask);
+                      *cacheModifier, multicastMask);
 
         rewriter.setInsertionPointToStart(afterLoadBlock);
       }
@@ -1684,6 +1705,11 @@ struct StoreOpConversion : public ConvertOpToLLVMPattern<triton::StoreOp>,
   LogicalResult
   matchAndRewrite(triton::StoreOp op, OpAdaptor adaptor,
                   ConversionPatternRewriter &rewriter) const override {
+    auto cacheModifier = LLVM::AMD::getCacheModifier(op.getCachePolicyAttr());
+    if (failed(cacheModifier)) {
+      op.emitOpError("target cache policy is not supported on AMD targets");
+      return failure();
+    }
     Value ptr = op.getPtr();
     Value value = op.getValue();
     Value mask = op.getMask();
@@ -1715,7 +1741,7 @@ struct StoreOpConversion : public ConvertOpToLLVMPattern<triton::StoreOp>,
     const size_t valueElemNBits =
         std::max<int>(8, valueElemTy.getIntOrFloatBitWidth());
 
-    auto cacheMod = op.getCache();
+    auto cacheMod = *cacheModifier;
     const int numVecs = elemsPerThread / vec;
     auto freeVarMasks = getFreeVariableMasks(valueTy);
     Value threadPred = emitRedundantThreadPredicateNonNull(
@@ -2015,6 +2041,11 @@ struct BufferStoreOpConversion
   LogicalResult
   matchAndRewrite(triton::amdgpu::BufferStoreOp op, OpAdaptor adaptor,
                   ConversionPatternRewriter &rewriter) const override {
+    auto cacheModifier = LLVM::AMD::getCacheModifier(op.getCachePolicyAttr());
+    if (failed(cacheModifier)) {
+      op.emitOpError("target cache policy is not supported on AMD targets");
+      return failure();
+    }
     auto loc = op->getLoc();
     auto b = TritonLLVMOpBuilder(loc, rewriter);
     LLVM::AMD::BufferEmitter bufferEmitter(rewriter, loc, targetInfo);
@@ -2024,7 +2055,7 @@ struct BufferStoreOpConversion
     Value offset = op.getOffsets();
     Value mask = op.getMask();
     Value data = op.getValue();
-    auto cacheMod = op.getCache();
+    auto cacheMod = *cacheModifier;
 
     Value llPtr = adaptor.getPtr();
     Value llOffset = adaptor.getOffsets();

--- a/third_party/amd/lib/TritonAMDGPUToLLVM/Utility.cpp
+++ b/third_party/amd/lib/TritonAMDGPUToLLVM/Utility.cpp
@@ -16,6 +16,16 @@ using mlir::triton::amdgpu::ISAFamily;
 using mlir::triton::gpu::appendOrGetExternFuncOp;
 
 namespace mlir::LLVM::AMD {
+
+FailureOr<triton::CacheModifier> getCacheModifier(Attribute cachePolicy) {
+  if (!cachePolicy)
+    return triton::CacheModifier::NONE;
+  auto policy = dyn_cast<triton::CachePolicyAttr>(cachePolicy);
+  if (!policy)
+    return failure();
+  return policy.getCacheModifier();
+}
+
 namespace {
 
 enum class ShflKind : uint32_t {

--- a/third_party/amd/lib/TritonAMDGPUToLLVM/Utility.h
+++ b/third_party/amd/lib/TritonAMDGPUToLLVM/Utility.h
@@ -14,6 +14,10 @@
 
 namespace mlir::LLVM::AMD {
 
+// Decode the target-independent compatibility payload accepted by Triton
+// memory operations. Target-specific cache policy attributes are rejected.
+FailureOr<triton::CacheModifier> getCacheModifier(Attribute cachePolicy);
+
 // Here is a partial definition of DppCtrl enums. For the complete definition,
 // please check:
 // https://github.com/llvm/llvm-project/blob/8c75290/llvm/lib/Target/AMDGPU/SIDefines.h#L939

--- a/third_party/amd/lib/TritonAMDGPUTransforms/ConvertToBufferOps.cpp
+++ b/third_party/amd/lib/TritonAMDGPUTransforms/ConvertToBufferOps.cpp
@@ -547,14 +547,15 @@ struct ConvertTritonLoadToBufferLoad : public mlir::OpRewritePattern<SourceOp> {
                 contig, axisAnalysisPass.getMaskAlignment(maybeMask));
           return triton::amdgpu::BufferLoadOp::create(
               rewriter, op->getLoc(), op.getType(), basePtr, tensorOffset,
-              blockStride, op.getCache(), maybeMask, maybeOther, contig);
+              blockStride, op.getCachePolicyAttr(), maybeMask, maybeOther,
+              contig);
         } else if constexpr (std::is_same_v<
                                  SourceOp,
                                  triton::gpu::AsyncCopyGlobalToLocalOp>) {
           return triton::amdgpu::BufferLoadToLocalOp::create(
               rewriter, op->getLoc(), op.getType(), op.getResult(), basePtr,
-              tensorOffset, maybeMask, maybeOther, blockStride, op.getCache(),
-              op.getContiguity());
+              tensorOffset, maybeMask, maybeOther, blockStride,
+              op.getCachePolicyAttr(), op.getContiguity());
         } else {
           static_assert(always_false<SourceOp>::value,
                         "Unsupported type in ConvertTritonLoadToBufferLoad");
@@ -619,8 +620,8 @@ struct ConvertTritonStoreToBufferStore
           op->getLoc(), op);
 
       rewriter.replaceOpWithNewOp<triton::amdgpu::BufferStoreOp>(
-          op, op.getValue(), basePtr, tensorOffset, blockStride, op.getCache(),
-          maybeMask, contig);
+          op, op.getValue(), basePtr, tensorOffset, blockStride,
+          op.getCachePolicyAttr(), maybeMask, contig);
       return success();
     }
     LDBG("Failed to convert: " << op);

--- a/third_party/amd/lib/TritonAMDGPUTransforms/LowerLoops.cpp
+++ b/third_party/amd/lib/TritonAMDGPUTransforms/LowerLoops.cpp
@@ -138,8 +138,8 @@ AsyncCopyChainOps createAsyncCopy(tt::LoadOp loadOp, Value alloc,
 
   auto copyOp = ttg::AsyncCopyGlobalToLocalOp::create(
       builder, loc, loadOp.getPtr(), viewLoad, loadOp.getMask(),
-      loadOp.getOther(), loadOp.getCache(), loadOp.getEvict(),
-      loadOp.getIsVolatile(), contiguity);
+      loadOp.getOther(), loadOp.getCachePolicyAttr(), loadOp.getIsVolatile(),
+      contiguity);
   auto commitOp =
       ttg::AsyncCommitGroupOp::create(builder, loc, copyOp->getResult(0));
   ttg::AsyncWaitOp waitOp =

--- a/third_party/amd/lib/TritonAMDGPUTransforms/OptimizeEpilogue.cpp
+++ b/third_party/amd/lib/TritonAMDGPUTransforms/OptimizeEpilogue.cpp
@@ -91,9 +91,10 @@ usePermlaneSwapToOptimizeStore(PatternRewriter &rewriter, Value ptr, Value val,
                                                    newMaskType, mask);
   }
 
-  return triton::StoreOp::create(rewriter, oldStoreOp.getLoc(), newPtr, newVal,
-                                 newMask, oldStoreOp.getCache(),
-                                 oldStoreOp.getEvict());
+  auto newStore = triton::StoreOp::create(
+      rewriter, oldStoreOp.getLoc(), newPtr, newVal, newMask,
+      oldStoreOp.getCachePolicyAttr(), oldStoreOp.getIgnoreCta());
+  return newStore;
 }
 
 // convert(val) : xmma -> blocked
@@ -187,9 +188,9 @@ public:
     triton::StoreOp newStoreOp =
         usePermlaneSwapToOptimizeStore(rewriter, newPtr, newVal, newMask, stOp);
     if (!newStoreOp) {
-      newStoreOp =
-          triton::StoreOp::create(rewriter, stOp.getLoc(), newPtr, newVal,
-                                  newMask, stOp.getCache(), stOp.getEvict());
+      newStoreOp = triton::StoreOp::create(
+          rewriter, stOp.getLoc(), newPtr, newVal, newMask,
+          stOp.getCachePolicyAttr(), stOp.getIgnoreCta());
     }
 
     rewriter.replaceOp(stOp, newStoreOp);

--- a/third_party/amd/python/test/test_extract_slice_concat_op.py
+++ b/third_party/amd/python/test/test_extract_slice_concat_op.py
@@ -142,7 +142,7 @@ def test_extract_slice(dtype, M, N, M_tile_size, N_tile_size, M_tile_offset, N_t
         %39 = tt.broadcast %44 : tensor<{M_tile_size}x1xi32, #blocked> -> tensor<{M_tile_size}x{N_tile_size}xi32, #blocked>
         %40 = arith.addi %38, %39 : tensor<{M_tile_size}x{N_tile_size}xi32, #blocked>
         %10 = tt.addptr %2, %9 : tensor<{M}x{N}x!tt.ptr<f16>, #blocked>, tensor<{M}x{N}xi32, #blocked>
-        %11 = tt.load %10 {{cache = 1 : i32, evict = 1 : i32, isVolatile = false}} : tensor<{M}x{N}x!tt.ptr<f16>, #blocked>
+        %11 = tt.load %10 : tensor<{M}x{N}x!tt.ptr<f16>, #blocked>
         %12 = ttg.convert_layout %11 : tensor<{M}x{N}xf16, #blocked> -> tensor<{M}x{N}xf16, #src_extract_layout>
         %13 = amdg.extract_slice %12 [{M_tile_offset}, {N_tile_offset}] : tensor<{M}x{N}xf16, #src_extract_layout> to tensor<{M_tile_size}x{N_tile_size}xf16, #dst_extract_layout>
         %14 = ttg.convert_layout %13 : tensor<{M_tile_size}x{N_tile_size}xf16, #dst_extract_layout> -> tensor<{M_tile_size}x{N_tile_size}xf16, #blocked>
@@ -298,10 +298,10 @@ def test_concat_op(dtype, M, N, M_tile_size, N_tile_size, src_layout, dst_layout
         %200 = tt.addptr %100, %9 : tensor<{M}x{N}x!tt.ptr<f16>, #blocked>, tensor<{M}x{N}xi32, #blocked>
         %201 = tt.addptr %101, %9 : tensor<{M}x{N}x!tt.ptr<f16>, #blocked>, tensor<{M}x{N}xi32, #blocked>
         %202 = tt.addptr %102, %9 : tensor<{M}x{N}x!tt.ptr<f16>, #blocked>, tensor<{M}x{N}xi32, #blocked>
-        %11 = tt.load %10 {{cache = 1 : i32, evict = 1 : i32, isVolatile = false}} : tensor<{M}x{N}x!tt.ptr<f16>, #blocked>
-        %300 = tt.load %200 {{cache = 1 : i32, evict = 1 : i32, isVolatile = false}} : tensor<{M}x{N}x!tt.ptr<f16>, #blocked>
-        %301 = tt.load %201 {{cache = 1 : i32, evict = 1 : i32, isVolatile = false}} : tensor<{M}x{N}x!tt.ptr<f16>, #blocked>
-        %302 = tt.load %202 {{cache = 1 : i32, evict = 1 : i32, isVolatile = false}} : tensor<{M}x{N}x!tt.ptr<f16>, #blocked>
+        %11 = tt.load %10 : tensor<{M}x{N}x!tt.ptr<f16>, #blocked>
+        %300 = tt.load %200 : tensor<{M}x{N}x!tt.ptr<f16>, #blocked>
+        %301 = tt.load %201 : tensor<{M}x{N}x!tt.ptr<f16>, #blocked>
+        %302 = tt.load %202 : tensor<{M}x{N}x!tt.ptr<f16>, #blocked>
 
         %12 = ttg.convert_layout %11 : tensor<{M}x{N}xf16, #blocked> -> tensor<{M}x{N}xf16, #src_layout>
         %400 = ttg.convert_layout %300 : tensor<{M}x{N}xf16, #blocked> -> tensor<{M}x{N}xf16, #src_layout>

--- a/third_party/nvidia/hopper/lib/Transforms/WarpSpecialization/WSLowerMem.cpp
+++ b/third_party/nvidia/hopper/lib/Transforms/WarpSpecialization/WSLowerMem.cpp
@@ -76,7 +76,7 @@ createAsyncCopy(const DenseMap<Channel *, Value> &bufferMap, Channel *c,
   Operation *copy =
       builder.createWithAsyncTaskIds<ttg::AsyncCopyGlobalToLocalOp>(
           loadOp.getLoc(), loadOp.getPtr(), view, loadOp.getMask(),
-          loadOp.getOther(), loadOp.getCache(), loadOp.getEvict(),
+          loadOp.getOther(), loadOp.getCachePolicyAttr(),
           loadOp.getIsVolatile());
 
   // Extract part.

--- a/third_party/nvidia/include/Dialect/NVWS/IR/NVWSOps.td
+++ b/third_party/nvidia/include/Dialect/NVWS/IR/NVWSOps.td
@@ -335,16 +335,11 @@ def NVWS_DescriptorLoadOp : NVWS_Op<"descriptor_load", [NVWS_DescriptorLoadOpInt
     Variadic<I32>:$indices,
     I32Attr:$txCount,
     Arg<TTG_MemDescType, "", GenericSharedWrite>:$result,
-    DefaultValuedAttr<TT_CacheModifierAttr, "::mlir::triton::CacheModifier::NONE">:$cache,
-    DefaultValuedAttr<TT_EvictionPolicyAttr, "::mlir::triton::EvictionPolicy::NORMAL">:$evict
+    OptionalAttr<AnyAttr>:$cachePolicy
   );
 
   let assemblyFormat = [{
     $desc `[` $indices `]` $txCount $result
-    oilist(
-      `cacheModifier` `=` $cache |
-      `evictionPolicy` `=` $evict
-    )
     attr-dict `:` type(operands)
   }];
 }

--- a/third_party/nvidia/lib/Dialect/NVWS/Transforms/InsertAref.cpp
+++ b/third_party/nvidia/lib/Dialect/NVWS/Transforms/InsertAref.cpp
@@ -183,7 +183,7 @@ void createNVWSDescriptorLoadOp(OpBuilder &builder, Operation *ttDescLoadOp,
   if (auto descLoad = dyn_cast<triton::DescriptorLoadOp>(ttDescLoadOp)) {
     auto newDescLoad = triton::nvws::DescriptorLoadOp::create(
         builder, loc, descLoad.getDesc(), descLoad.getIndices(), txCount,
-        dataBuf, descLoad.getCache(), descLoad.getEvict());
+        dataBuf, descLoad.getCachePolicyAttr());
     newDescLoad->setAttrs(descLoad->getAttrs());
     setPartition(newDescLoad, producerPartitions);
   } else if (auto descGather =

--- a/third_party/nvidia/lib/TritonNVIDIAGPUToLLVM/LoadStoreOpToLLVM.cpp
+++ b/third_party/nvidia/lib/TritonNVIDIAGPUToLLVM/LoadStoreOpToLLVM.cpp
@@ -155,9 +155,6 @@ LogicalResult verifyDetailedCachePolicySupport(Operation *op,
   const bool hasDetailedL1 =
       policy.detailed &&
       policy.detailed.getL1() != ttng::CacheEvictionPriority::NONE;
-  if (hasDetailedL1 && policy.modifier != CacheModifier::NONE)
-    return op->emitOpError(
-        "an L1 cache policy cannot be combined with cacheModifier");
   if (hasDetailedL1 && computeCapability < 70)
     return op->emitOpError(
         "L1 eviction priority requires compute capability 70 or newer");

--- a/third_party/nvidia/lib/TritonNVIDIAGPUToLLVM/LoadStoreOpToLLVM.cpp
+++ b/third_party/nvidia/lib/TritonNVIDIAGPUToLLVM/LoadStoreOpToLLVM.cpp
@@ -19,9 +19,11 @@
 #include "triton/Dialect/TritonGPU/IR/Dialect.h"
 #include "triton/Dialect/TritonGPU/IR/LinearLayoutConversions.h"
 #include "triton/Dialect/TritonGPU/Transforms/Utility.h"
+#include "triton/Dialect/TritonNvidiaGPU/IR/Dialect.h"
 #include "triton/Dialect/TritonNvidiaGPU/Transforms/TMAUtilities.h"
 #include "triton/Tools/LayoutUtils.h"
 #include "llvm/ADT/APInt.h"
+#include "llvm/ADT/SmallString.h"
 
 #include <cassert>
 
@@ -43,30 +45,66 @@ static constexpr bool disableLDAcquireLowering = false;
 
 namespace {
 
-Value createCachePolicy(triton::EvictionPolicy opEvict,
-                        ConversionPatternRewriter &rewriter, Location loc,
-                        int computeCapability) {
+struct CachePolicy {
+  triton::CacheModifier modifier = triton::CacheModifier::NONE;
+  triton::EvictionPolicy legacy = triton::EvictionPolicy::NORMAL;
+  ttng::CachePolicyAttr detailed;
+};
+
+FailureOr<Value> createCachePolicy(CachePolicy cachePolicy,
+                                   ConversionPatternRewriter &rewriter,
+                                   Location loc, int computeCapability,
+                                   Operation *op) {
   // Emit createpolicy.fractional.L2::policy.b64 xx 1.0
   PTXBuilder ptxBuilder;
-  const bool hasL2EvictPolicy =
-      opEvict == triton::EvictionPolicy::EVICT_FIRST ||
-      opEvict == triton::EvictionPolicy::EVICT_LAST;
+  const bool hasLegacyL2EvictPolicy =
+      cachePolicy.legacy == triton::EvictionPolicy::EVICT_FIRST ||
+      cachePolicy.legacy == triton::EvictionPolicy::EVICT_LAST;
+  StringRef primary;
+  StringRef secondary;
+  FloatAttr fraction;
+  if (cachePolicy.detailed) {
+    auto primaryPriority = cachePolicy.detailed.getL2Primary();
+    if (primaryPriority != ttng::CacheEvictionPriority::NONE)
+      primary = ttng::stringifyCacheEvictionPriority(primaryPriority);
+    auto secondaryPriority = cachePolicy.detailed.getL2Secondary();
+    if (secondaryPriority != ttng::CacheEvictionPriority::NONE)
+      secondary = ttng::stringifyCacheEvictionPriority(secondaryPriority);
+    fraction = cachePolicy.detailed.getL2Fraction();
+  }
+  const bool hasDetailedL2Policy = !primary.empty();
   Value policyRet;
 
   const bool hardwareSupport = computeCapability >= 80;
+  if (hasDetailedL2Policy && !hardwareSupport) {
+    op->emitOpError("fractional L2 cache policy requires compute capability "
+                    "80 or newer");
+    return failure();
+  }
 
-  if (hasL2EvictPolicy && hardwareSupport) {
-    auto &policy =
-        ptxBuilder.create("createpolicy.fractional")
-            ->o("L2::evict_first",
-                opEvict == triton::EvictionPolicy::EVICT_FIRST)
-            .o("L2::evict_last", opEvict == triton::EvictionPolicy::EVICT_LAST)
-            .b(64);
+  if ((hasLegacyL2EvictPolicy || hasDetailedL2Policy) && hardwareSupport) {
+    if (!hasDetailedL2Policy) {
+      primary = cachePolicy.legacy == triton::EvictionPolicy::EVICT_FIRST
+                    ? "evict_first"
+                    : "evict_last";
+    }
+    auto &policy = ptxBuilder.create("createpolicy.fractional")
+                       ->o("L2::evict_normal", primary == "evict_normal")
+                       .o("L2::evict_unchanged", primary == "evict_unchanged")
+                       .o("L2::evict_first", primary == "evict_first")
+                       .o("L2::evict_last", primary == "evict_last")
+                       .o("L2::evict_first", secondary == "evict_first")
+                       .b(64);
 
     const std::string writeConstraint = "=l";
     // prepare asm operands
     auto *dstOpr = ptxBuilder.newOperand(writeConstraint, /*init=*/true);
-    std::string fractionStr = "1.0";
+    SmallString<16> fractionBuffer;
+    if (fraction)
+      fraction.getValue().toString(fractionBuffer);
+    else
+      fractionBuffer = "1.0";
+    std::string fractionStr = fractionBuffer.str().str();
     auto *fractionOpr = ptxBuilder.newConstantOperand(fractionStr);
     policy(dstOpr, fractionOpr);
 
@@ -76,6 +114,61 @@ Value createCachePolicy(triton::EvictionPolicy opEvict,
   }
 
   return policyRet;
+}
+
+StringRef getL1EvictionPriority(CachePolicy cachePolicy) {
+  if (cachePolicy.detailed) {
+    auto l1 = cachePolicy.detailed.getL1();
+    if (l1 != ttng::CacheEvictionPriority::NONE)
+      return ttng::stringifyCacheEvictionPriority(l1);
+    return {};
+  }
+  if (cachePolicy.legacy == triton::EvictionPolicy::EVICT_FIRST)
+    return "evict_first";
+  if (cachePolicy.legacy == triton::EvictionPolicy::EVICT_LAST)
+    return "evict_last";
+  return {};
+}
+
+FailureOr<CachePolicy> getCachePolicy(Operation *op, Attribute attr) {
+  CachePolicy cachePolicy;
+  if (!attr)
+    return cachePolicy;
+  if (auto policy = dyn_cast<ttng::CachePolicyAttr>(attr)) {
+    cachePolicy.detailed = policy;
+    cachePolicy.modifier = policy.getCacheModifier();
+    return cachePolicy;
+  }
+  if (auto policy = dyn_cast<triton::CachePolicyAttr>(attr)) {
+    cachePolicy.modifier = policy.getCacheModifier();
+    cachePolicy.legacy = policy.getEvictionPolicy();
+    return cachePolicy;
+  }
+  op->emitOpError("unsupported NVIDIA cache policy attribute ") << attr;
+  return failure();
+}
+
+LogicalResult verifyDetailedCachePolicySupport(Operation *op,
+                                               CachePolicy policy,
+                                               int computeCapability,
+                                               bool supportsPrefetch = true) {
+  const bool hasDetailedL1 =
+      policy.detailed &&
+      policy.detailed.getL1() != ttng::CacheEvictionPriority::NONE;
+  if (hasDetailedL1 && policy.modifier != CacheModifier::NONE)
+    return op->emitOpError(
+        "an L1 cache policy cannot be combined with cacheModifier");
+  if (hasDetailedL1 && computeCapability < 70)
+    return op->emitOpError(
+        "L1 eviction priority requires compute capability 70 or newer");
+  IntegerAttr l2PrefetchSize =
+      policy.detailed ? policy.detailed.getL2PrefetchSize() : IntegerAttr();
+  if (!supportsPrefetch && l2PrefetchSize)
+    return op->emitOpError("L2 prefetch size is only supported on loads");
+  if (l2PrefetchSize && computeCapability < 75)
+    return op->emitOpError(
+        "L2 prefetch size requires compute capability 75 or newer");
+  return success();
 }
 
 // Contains some helper functions for both Load and Store conversions.
@@ -142,6 +235,12 @@ struct LoadOpConversion : public ConvertOpToLLVMPattern<triton::LoadOp>,
   LogicalResult
   matchAndRewrite(triton::LoadOp op, OpAdaptor adaptor,
                   ConversionPatternRewriter &rewriter) const override {
+    auto cachePolicy = getCachePolicy(op, op.getCachePolicyAttr());
+    if (failed(cachePolicy))
+      return failure();
+    if (failed(verifyDetailedCachePolicySupport(op, *cachePolicy,
+                                                computeCapability)))
+      return failure();
     auto ctx = getContext();
     auto loc = op->getLoc();
     auto b = TritonLLVMOpBuilder(loc, rewriter);
@@ -217,8 +316,17 @@ struct LoadOpConversion : public ConvertOpToLLVMPattern<triton::LoadOp>,
     SmallVector<Value> loadedVals;
     // The L2 cache policy register is loop-invariant; create it once instead of
     // re-emitting an identical createpolicy per vectorized load.
-    Value l2PolicyReg =
-        createCachePolicy(op.getEvict(), rewriter, loc, computeCapability);
+    FailureOr<Value> l2Policy =
+        createCachePolicy(*cachePolicy, rewriter, loc, computeCapability, op);
+    if (failed(l2Policy))
+      return failure();
+    Value l2PolicyReg = *l2Policy;
+    StringRef l1Policy = getL1EvictionPriority(*cachePolicy);
+    auto l2PrefetchSizeAttr = cachePolicy->detailed
+                                  ? cachePolicy->detailed.getL2PrefetchSize()
+                                  : IntegerAttr();
+    int64_t l2PrefetchSize =
+        l2PrefetchSizeAttr ? l2PrefetchSizeAttr.getInt() : 0;
     for (size_t vecStart = 0; vecStart < numElems; vecStart += vec) {
       // TODO: optimization when ptr is GEP with constant offset
       const size_t runStart = vecStart - vecStart % scalarizedContiguousRun;
@@ -292,20 +400,25 @@ struct LoadOpConversion : public ConvertOpToLLVMPattern<triton::LoadOp>,
           ptxBuilder.newAddrOperand(ptrElems[runStart], "l", in_off);
 
       // Define the instruction opcode
-      auto &ld = ptxBuilder.create("ld")
-                     ->o("volatile", op.getIsVolatile())
-                     .global()
-                     .o("ca", op.getCache() == triton::CacheModifier::CA)
-                     .o("cg", op.getCache() == triton::CacheModifier::CG)
-                     .o("cs", op.getCache() == triton::CacheModifier::CS)
-                     .o("cv", op.getCache() == triton::CacheModifier::CV)
-                     .o("L1::evict_first",
-                        op.getEvict() == triton::EvictionPolicy::EVICT_FIRST)
-                     .o("L1::evict_last",
-                        op.getEvict() == triton::EvictionPolicy::EVICT_LAST)
-                     .o("L2::cache_hint", l2PolicyReg != Value())
-                     .v(nWords)
-                     .b(width);
+      auto &ld =
+          ptxBuilder.create("ld")
+              ->o("volatile", op.getIsVolatile())
+              .global()
+              .o("ca", cachePolicy->modifier == triton::CacheModifier::CA)
+              .o("cg", cachePolicy->modifier == triton::CacheModifier::CG)
+              .o("cs", cachePolicy->modifier == triton::CacheModifier::CS)
+              .o("cv", cachePolicy->modifier == triton::CacheModifier::CV)
+              .o("L1::evict_normal", l1Policy == "evict_normal")
+              .o("L1::evict_unchanged", l1Policy == "evict_unchanged")
+              .o("L1::evict_first", l1Policy == "evict_first")
+              .o("L1::evict_last", l1Policy == "evict_last")
+              .o("L1::no_allocate", l1Policy == "no_allocate")
+              .o("L2::64B", l2PrefetchSize == 64)
+              .o("L2::128B", l2PrefetchSize == 128)
+              .o("L2::256B", l2PrefetchSize == 256)
+              .o("L2::cache_hint", l2PolicyReg != Value())
+              .v(nWords)
+              .b(width);
 
       PTXBuilder::Operand *evictOpr = nullptr;
       if (l2PolicyReg)
@@ -368,6 +481,13 @@ struct StoreOpConversion : public ConvertOpToLLVMPattern<triton::StoreOp>,
   LogicalResult
   matchAndRewrite(triton::StoreOp op, OpAdaptor adaptor,
                   ConversionPatternRewriter &rewriter) const override {
+    auto cachePolicy = getCachePolicy(op, op.getCachePolicyAttr());
+    if (failed(cachePolicy))
+      return failure();
+    if (failed(verifyDetailedCachePolicySupport(op, *cachePolicy,
+                                                computeCapability,
+                                                /*supportsPrefetch=*/false)))
+      return failure();
     Value ptr = op.getPtr();
     Value value = op.getValue();
 
@@ -426,8 +546,12 @@ struct StoreOpConversion : public ConvertOpToLLVMPattern<triton::StoreOp>,
     const int numVecs = elemsPerThread / vec;
     // The L2 cache policy register is loop-invariant; create it once instead of
     // re-emitting an identical createpolicy per vectorized store.
-    Value l2PolicyReg =
-        createCachePolicy(op.getEvict(), rewriter, loc, computeCapability);
+    FailureOr<Value> l2Policy =
+        createCachePolicy(*cachePolicy, rewriter, loc, computeCapability, op);
+    if (failed(l2Policy))
+      return failure();
+    Value l2PolicyReg = *l2Policy;
+    StringRef l1Policy = getL1EvictionPriority(*cachePolicy);
     for (size_t vecStart = 0; vecStart < elemsPerThread; vecStart += vec) {
       // TODO: optimization when ptr is AddPtr with constant offset
       const size_t runStart = vecStart - vecStart % scalarizedContiguousRun;
@@ -439,9 +563,6 @@ struct StoreOpConversion : public ConvertOpToLLVMPattern<triton::StoreOp>,
       const size_t nWords = std::max<size_t>(1, totalWidth / width);
       const size_t wordNElems = width / valueElemNBits;
       assert(wordNElems * nWords * numVecs == elemsPerThread);
-
-      // TODO(Superjomn) Add cache policy fields to StoreOp.
-      // TODO(Superjomn) Deal with cache policy here.
 
       Type valArgTy = IntegerType::get(ctx, width);
       auto wordTy = vec_ty(valueElemTy, wordNElems);
@@ -483,14 +604,15 @@ struct StoreOpConversion : public ConvertOpToLLVMPattern<triton::StoreOp>,
       auto &ptxStoreInstr =
           ptxBuilder.create("st")
               ->global()
-              .o("wb", op.getCache() == triton::CacheModifier::WB)
-              .o("cg", op.getCache() == triton::CacheModifier::CG)
-              .o("cs", op.getCache() == triton::CacheModifier::CS)
-              .o("wt", op.getCache() == triton::CacheModifier::WT)
-              .o("L1::evict_first",
-                 op.getEvict() == triton::EvictionPolicy::EVICT_FIRST)
-              .o("L1::evict_last",
-                 op.getEvict() == triton::EvictionPolicy::EVICT_LAST)
+              .o("wb", cachePolicy->modifier == triton::CacheModifier::WB)
+              .o("cg", cachePolicy->modifier == triton::CacheModifier::CG)
+              .o("cs", cachePolicy->modifier == triton::CacheModifier::CS)
+              .o("wt", cachePolicy->modifier == triton::CacheModifier::WT)
+              .o("L1::evict_normal", l1Policy == "evict_normal")
+              .o("L1::evict_unchanged", l1Policy == "evict_unchanged")
+              .o("L1::evict_first", l1Policy == "evict_first")
+              .o("L1::evict_last", l1Policy == "evict_last")
+              .o("L1::no_allocate", l1Policy == "no_allocate")
               .o("L2::cache_hint", l2PolicyReg != Value())
               .v(nWords)
               .b(width);
@@ -916,6 +1038,13 @@ struct AsyncCopyGlobalToLocalOpConversion
   LogicalResult
   matchAndRewrite(triton::gpu::AsyncCopyGlobalToLocalOp op, OpAdaptor adaptor,
                   ConversionPatternRewriter &rewriter) const override {
+    int computeCapability = targetInfo.getComputeCapability();
+    auto cachePolicy = getCachePolicy(op, op.getCachePolicyAttr());
+    if (failed(cachePolicy))
+      return failure();
+    if (failed(verifyDetailedCachePolicySupport(op, *cachePolicy,
+                                                computeCapability)))
+      return failure();
     auto ctx = getContext();
     auto loc = op.getLoc();
     auto b = TritonLLVMOpBuilder(loc, rewriter);
@@ -995,11 +1124,23 @@ struct AsyncCopyGlobalToLocalOpConversion
     Value threadPred = ttg::emitRedundantThreadPredicate(freeVarMasks, rewriter,
                                                          loc, targetInfo);
 
-    auto emitCpAsync = [&b, threadPred, ptrTy, hasMask = bool(llMask)](
-                           RewriterBase &rewriter, Location loc,
-                           ArrayRef<Value> vals, Value shmemAddr, int startIdx,
-                           VectorType vecTy,
-                           Value ctaId) -> SmallVector<Value> {
+    FailureOr<Value> l2Policy =
+        createCachePolicy(*cachePolicy, rewriter, loc, computeCapability, op);
+    if (failed(l2Policy))
+      return failure();
+    Value l2PolicyReg = *l2Policy;
+    auto l2PrefetchSizeAttr = cachePolicy->detailed
+                                  ? cachePolicy->detailed.getL2PrefetchSize()
+                                  : IntegerAttr();
+    int64_t l2PrefetchSize =
+        l2PrefetchSizeAttr ? l2PrefetchSizeAttr.getInt() : 0;
+
+    auto emitCpAsync = [&b, threadPred, ptrTy, l2PolicyReg, l2PrefetchSize,
+                        hasMask =
+                            bool(llMask)](RewriterBase &rewriter, Location loc,
+                                          ArrayRef<Value> vals, Value shmemAddr,
+                                          int startIdx, VectorType vecTy,
+                                          Value ctaId) -> SmallVector<Value> {
       assert(!ctaId && "cp.async does not support cross-cta loads");
       assert(isa<VectorType>(vecTy));
       auto *ctx = rewriter.getContext();
@@ -1017,6 +1158,10 @@ struct AsyncCopyGlobalToLocalOpConversion
       PTXBuilder ptxBuilder;
       auto &copyAsyncOp =
           *ptxBuilder.create<PTXCpAsyncLoadInstr>(srcCacheModifier);
+      copyAsyncOp.o("L2::64B", l2PrefetchSize == 64)
+          .o("L2::128B", l2PrefetchSize == 128)
+          .o("L2::256B", l2PrefetchSize == 256)
+          .o("L2::cache_hint", l2PolicyReg != Value());
       auto *dstOperand = ptxBuilder.newAddrOperand(shmemAddr, "r");
       auto *srcOperand = ptxBuilder.newAddrOperand(srcElem, "l");
       auto *copySize = ptxBuilder.newConstantOperand(nBytes);
@@ -1032,8 +1177,14 @@ struct AsyncCopyGlobalToLocalOpConversion
         auto selectOp = b.select(maskElem, b.i32_val(nBytes), b.i32_val(0));
         srcSize = ptxBuilder.newOperand(selectOp, "r");
       }
-      copyAsyncOp(dstOperand, srcOperand, copySize, srcSize)
-          .maybePredicate(threadPred);
+      if (l2PolicyReg) {
+        auto *policyOperand = ptxBuilder.newOperand(l2PolicyReg, "l");
+        copyAsyncOp(dstOperand, srcOperand, copySize, srcSize, policyOperand)
+            .maybePredicate(threadPred);
+      } else {
+        copyAsyncOp(dstOperand, srcOperand, copySize, srcSize)
+            .maybePredicate(threadPred);
+      }
       ptxBuilder.launch(rewriter, loc, void_ty(ctx));
       return {};
     };


### PR DESCRIPTION
This makes a few changes:
- In the backed, I refactor the `cache_modifier, eviction_policy` pair into a `TT_CachePolicyAttr` and plumb it throughout the code base
- I also add a `TTNG_CachePolicyAttr` which has additional fields including separate L1 and L2 policies, support for fractional policies, and configurable L2 prefetch size.
- In gluon I expose a `cache_policy` argument to load and store, and allow the user to construct either generic or nvidia-specific cache policies.