### PR TITLE
[BACKEND] Package separately pinned NVIDIA LLVM codegen

### DIFF
--- a/.github/workflows/build-macos.yml
+++ b/.github/workflows/build-macos.yml
@@ -32,17 +32,18 @@ jobs:
         run: |
           llvm_file="cmake/llvm-info.json"
           nvidia_file="cmake/nvidia-toolchain-version.json"
+          nvidia_llvm_file="cmake/nvidia-llvm-info.json"
           json_file="cmake/json-version.txt"
 
           # Check if files exist before proceeding
-          if [[ ! -f "$llvm_file" || ! -f "$nvidia_file" || ! -f "$json_file" ]]; then
+          if [[ ! -f "$llvm_file" || ! -f "$nvidia_file" || ! -f "$nvidia_llvm_file" || ! -f "$json_file" ]]; then
             echo "Error: Required dependency files are missing."
             exit 1
           fi
 
           # Process the files if they exist
           echo "llvm=$(sha256sum $llvm_file | cut -d ' ' -f 1)" >> $GITHUB_OUTPUT
-          echo "nvidia=$(sha256sum $nvidia_file | cut -d ' ' -f 1)" >> $GITHUB_OUTPUT
+          echo "nvidia=$(cat "$nvidia_file" "$nvidia_llvm_file" | sha256sum | cut -d ' ' -f 1)" >> $GITHUB_OUTPUT
           echo "json=$(cat $json_file)" >> $GITHUB_OUTPUT
           echo "datetime=$(date -u -Iseconds)" >> $GITHUB_OUTPUT
         shell: bash

--- a/.github/workflows/integration-tests-amd.yml
+++ b/.github/workflows/integration-tests-amd.yml
@@ -64,17 +64,18 @@ jobs:
         run: |
           llvm_file="cmake/llvm-info.json"
           nvidia_file="cmake/nvidia-toolchain-version.json"
+          nvidia_llvm_file="cmake/nvidia-llvm-info.json"
           json_file="cmake/json-version.txt"
 
           # Check if files exist before proceeding
-          if [[ ! -f "$llvm_file" || ! -f "$nvidia_file" || ! -f "$json_file" ]]; then
+          if [[ ! -f "$llvm_file" || ! -f "$nvidia_file" || ! -f "$nvidia_llvm_file" || ! -f "$json_file" ]]; then
             echo "Error: Required dependency files are missing."
             exit 1
           fi
 
           # Process the files if they exist
           echo "llvm=$(sha256sum $llvm_file | cut -d ' ' -f 1)" >> $GITHUB_OUTPUT
-          echo "nvidia=$(sha256sum $nvidia_file | cut -d ' ' -f 1)" >> $GITHUB_OUTPUT
+          echo "nvidia=$(cat "$nvidia_file" "$nvidia_llvm_file" | sha256sum | cut -d ' ' -f 1)" >> $GITHUB_OUTPUT
           echo "json=$(cat $json_file)" >> $GITHUB_OUTPUT
         shell: bash
       - name: Restore build dependencies cache
@@ -277,15 +278,16 @@ jobs:
         run: |
           llvm_file="cmake/llvm-info.json"
           nvidia_file="cmake/nvidia-toolchain-version.json"
+          nvidia_llvm_file="cmake/nvidia-llvm-info.json"
           json_file="cmake/json-version.txt"
 
-          if [[ ! -f "$llvm_file" || ! -f "$nvidia_file" || ! -f "$json_file" ]]; then
+          if [[ ! -f "$llvm_file" || ! -f "$nvidia_file" || ! -f "$nvidia_llvm_file" || ! -f "$json_file" ]]; then
             echo "Error: Required dependency files are missing."
             exit 1
           fi
 
           echo "llvm=$(sha256sum $llvm_file | cut -d ' ' -f 1)" >> $GITHUB_OUTPUT
-          echo "nvidia=$(sha256sum $nvidia_file | cut -d ' ' -f 1)" >> $GITHUB_OUTPUT
+          echo "nvidia=$(cat "$nvidia_file" "$nvidia_llvm_file" | sha256sum | cut -d ' ' -f 1)" >> $GITHUB_OUTPUT
           echo "json=$(cat $json_file)" >> $GITHUB_OUTPUT
         shell: bash
       - name: Restore build dependencies cache

--- a/.github/workflows/integration-tests-nvidia.yml
+++ b/.github/workflows/integration-tests-nvidia.yml
@@ -39,17 +39,18 @@ jobs:
         run: |
           llvm_file="cmake/llvm-info.json"
           nvidia_file="cmake/nvidia-toolchain-version.json"
+          nvidia_llvm_file="cmake/nvidia-llvm-info.json"
           json_file="cmake/json-version.txt"
 
           # Check if files exist before proceeding
-          if [[ ! -f "$llvm_file" || ! -f "$nvidia_file" || ! -f "$json_file" ]]; then
+          if [[ ! -f "$llvm_file" || ! -f "$nvidia_file" || ! -f "$nvidia_llvm_file" || ! -f "$json_file" ]]; then
             echo "Error: Required dependency files are missing."
             exit 1
           fi
 
           # Process the files if they exist
           echo "llvm=$(sha256sum $llvm_file | cut -d ' ' -f 1)" >> $GITHUB_OUTPUT
-          echo "nvidia=$(sha256sum $nvidia_file | cut -d ' ' -f 1)" >> $GITHUB_OUTPUT
+          echo "nvidia=$(cat "$nvidia_file" "$nvidia_llvm_file" | sha256sum | cut -d ' ' -f 1)" >> $GITHUB_OUTPUT
           echo "json=$(cat $json_file)" >> $GITHUB_OUTPUT
         shell: bash
       - name: Restore build dependencies cache

--- a/.github/workflows/nvidia-llvm-build.yml
+++ b/.github/workflows/nvidia-llvm-build.yml
@@ -162,7 +162,7 @@ jobs:
         -DCMAKE_BUILD_TYPE=Release
         -DCMAKE_C_COMPILER=clang -DCMAKE_CXX_COMPILER=clang++
         -DLLVM_DIR="${{ github.workspace }}/llvm-project/install/lib/cmake/llvm"
-        -DCMAKE_INSTALL_PREFIX="${{ github.workspace }}/${{ env.llvm_install_dir }}"
+        -DCMAKE_INSTALL_PREFIX="${{ env.llvm_install_dir }}"
         -DTRITON_NVIDIA_LLVM_REVISION="${{ env.llvm_commit_hash }}-${{ env.llvm_build_number }}"
         llvm-build/third_party/nvidia/backend/codegen
 
@@ -194,7 +194,7 @@ jobs:
         -DCMAKE_BUILD_TYPE=Release
         -DCMAKE_C_COMPILER=cl -DCMAKE_CXX_COMPILER=cl
         -DLLVM_DIR="${{ github.workspace }}/llvm-project/install/lib/cmake/llvm"
-        -DCMAKE_INSTALL_PREFIX="${{ github.workspace }}/${{ env.llvm_install_dir }}"
+        -DCMAKE_INSTALL_PREFIX="${{ env.llvm_install_dir }}"
         -DTRITON_NVIDIA_LLVM_REVISION="${{ env.llvm_commit_hash }}-${{ env.llvm_build_number }}"
         llvm-build/third_party/nvidia/backend/codegen
 

--- a/.github/workflows/nvidia-llvm-build.yml
+++ b/.github/workflows/nvidia-llvm-build.yml
@@ -150,6 +150,9 @@ jobs:
         -DLLVM_INCLUDE_BENCHMARKS=OFF
         -DLLVM_INCLUDE_TESTS=OFF
         -DLLVM_ENABLE_PIC=ON
+        -DBUILD_SHARED_LIBS=OFF
+        -DLLVM_BUILD_LLVM_DYLIB=OFF
+        -DLLVM_LINK_LLVM_DYLIB=OFF
         -DLLVM_DISTRIBUTION_COMPONENTS="${{ env.LLVM_DISTRIBUTION_COMPONENTS }}"
         -DLLVM_TARGETS_TO_BUILD="NVPTX"
         -DLLVM_ENABLE_ZSTD=OFF
@@ -184,6 +187,9 @@ jobs:
         -DLLVM_INCLUDE_TESTS=OFF
         -DLLVM_DISTRIBUTION_COMPONENTS="${{ env.LLVM_DISTRIBUTION_COMPONENTS }}"
         -DLLVM_ENABLE_DIA_SDK=OFF
+        -DBUILD_SHARED_LIBS=OFF
+        -DLLVM_BUILD_LLVM_DYLIB=OFF
+        -DLLVM_LINK_LLVM_DYLIB=OFF
         -DLLVM_TARGETS_TO_BUILD="NVPTX"
         -DLLVM_ENABLE_ZSTD=OFF
         llvm-project/llvm
@@ -202,6 +208,27 @@ jobs:
 
         tar czf "${{ env.llvm_install_dir }}.tar.gz" "${{ env.llvm_install_dir }}"
 
+
+    - name: Verify Standalone Library
+      shell: bash
+      run: |
+        python3 - <<'PY'
+        import ctypes
+        import os
+        import pathlib
+        import sys
+
+        filename = {
+            "win32": "triton_nvidia_codegen.dll",
+            "darwin": "libtriton_nvidia_codegen.dylib",
+        }.get(sys.platform, "libtriton_nvidia_codegen.so")
+        path = pathlib.Path(os.environ["llvm_install_dir"]) / "lib" / filename
+        library = ctypes.CDLL(str(path.resolve()))
+        library.triton_nvptx_revision.restype = ctypes.c_char_p
+        expected = os.environ["llvm_commit_hash"] + "-" + os.environ["llvm_build_number"]
+        assert library.triton_nvptx_revision().decode() == expected
+        print("Loaded standalone backend without importing Triton:", path)
+        PY
 
     - name: Upload Build Artifacts
       uses: actions/upload-artifact@v7

--- a/.github/workflows/nvidia-llvm-build.yml
+++ b/.github/workflows/nvidia-llvm-build.yml
@@ -1,0 +1,240 @@
+name: NVIDIA LLVM Build
+
+on:
+  push:
+    branches:
+      - main
+    paths:
+      - cmake/nvidia-llvm-build-info.json
+      - third_party/nvidia/backend/codegen/**
+  pull_request:
+    paths:
+      - .github/workflows/nvidia-llvm-build.yml
+      - cmake/nvidia-llvm-build-info.json
+      - third_party/nvidia/backend/codegen/**
+  workflow_dispatch:
+
+env:
+  SCCACHE_DIR: ${{ github.workspace }}/sccache
+  LLVM_DISTRIBUTION_COMPONENTS: "llvm-headers;llvm-libraries;cmake-exports"
+
+permissions:
+  contents: read
+  id-token: write
+
+jobs:
+
+  build:
+    name: Build on ${{ matrix.config.runner }}
+    runs-on: ${{ matrix.config.runs_on }}
+    container: ${{ matrix.config.container }}
+
+    strategy:
+      fail-fast: true
+      matrix:
+        config:
+        - {runner: 'Ubuntu 22.04', runs_on: 'ubuntu-22.04', target-os: 'ubuntu', arch: 'x64'}
+        - {runner: 'Ubuntu 22.04 ARM64', runs_on: 'ubuntu-22.04-arm', target-os: 'ubuntu', arch: 'arm64'}
+        - {runner: 'AlmaLinux 8', runs_on: 'ubuntu-22.04', target-os: 'almalinux', arch: 'x64', container: 'almalinux:8.10-20250411'}
+        - {runner: 'AlmaLinux 8 ARM64', runs_on: 'ubuntu-22.04-arm', target-os: 'almalinux', arch: 'arm64', container: 'almalinux:8.10-20250411'}
+        - {runner: 'MacOS X64', runs_on: 'macos-15-intel', target-os: 'macos', arch: 'x64'}
+        - {runner: 'MacOS ARM64', runs_on: 'macos-15', target-os: 'macos', arch: 'arm64'}
+        - {runner: 'Windows 2022', runs_on: 'windows-2022', target-os: 'windows', arch: 'x64', msvc_arch: 'amd64'}
+        - {runner: 'Windows 11 ARM64', runs_on: 'windows-11-arm', target-os: 'windows', arch: 'arm64', msvc_arch: 'arm64'}
+
+    steps:
+
+    - name: Checkout Repo
+      uses: actions/checkout@v6
+      with:
+        path: llvm-build
+
+    - name: Install System Prerequisites (AlmaLinux)
+      if: matrix.config.target-os == 'almalinux'
+      run: |
+        rpm --import https://packages.microsoft.com/keys/microsoft.asc
+        dnf install --assumeyes https://packages.microsoft.com/config/rhel/8/packages-microsoft-prod.rpm
+        dnf install --assumeyes azure-cli llvm-toolset-20.1.8 python38-pip python38-devel git jq tar gzip
+        alternatives --set python3 /usr/bin/python3.8
+        echo "extra_cmake_flags=-DCMAKE_ASM_COMPILER=clang -DCMAKE_CXX_FLAGS=-Wno-everything -DPython3_EXECUTABLE=/usr/bin/python3.8 -DPython_EXECUTABLE=/usr/bin/python3.8" >> "$GITHUB_ENV"
+
+    - name: Fetch LLVM Build Metadata
+      shell: bash
+      run: |
+        LLVM_COMMIT_HASH="$(jq -r '.llvm_hash' llvm-build/cmake/nvidia-llvm-build-info.json)"
+        echo "Found LLVM commit hash: ${LLVM_COMMIT_HASH}"
+        echo "llvm_commit_hash=${LLVM_COMMIT_HASH}" >> ${GITHUB_ENV}
+
+        LLVM_REPOSITORY="$(jq -r '.repository // "llvm/llvm-project"' llvm-build/cmake/nvidia-llvm-build-info.json)"
+        echo "Found LLVM repository: ${LLVM_REPOSITORY}"
+        echo "llvm_repository=${LLVM_REPOSITORY}" >> ${GITHUB_ENV}
+
+        LLVM_BUILD_NUMBER="$(jq -r '.build_number' llvm-build/cmake/nvidia-llvm-build-info.json)"
+        echo "Found LLVM build number: ${LLVM_BUILD_NUMBER}"
+        echo "llvm_build_number=${LLVM_BUILD_NUMBER}" >> ${GITHUB_ENV}
+
+        SHORT_LLVM_COMMIT_HASH="${LLVM_COMMIT_HASH:0:8}"
+        echo "Short LLVM commit hash: ${SHORT_LLVM_COMMIT_HASH}"
+        echo "short_llvm_commit_hash=${SHORT_LLVM_COMMIT_HASH}" >> ${GITHUB_ENV}
+
+        INSTALL_DIR="nvidia-codegen-${SHORT_LLVM_COMMIT_HASH}-${{ matrix.config.target-os }}-${{ matrix.config.arch }}-${LLVM_BUILD_NUMBER}"
+        echo "LLVM installation directory name: ${INSTALL_DIR}"
+        echo "llvm_install_dir=${INSTALL_DIR}" >> ${GITHUB_ENV}
+
+    - name: Check LLVM Build Does Not Exist
+      shell: bash
+      run: |
+        URL="https://oaitriton.blob.core.windows.net/public/llvm-builds/${{ env.llvm_install_dir }}.tar.gz"
+        HTTP_STATUS="$(curl --head --silent --show-error --output /dev/null --write-out "%{http_code}" "${URL}")"
+        if [ "${HTTP_STATUS}" != "404" ]; then
+          echo "LLVM build already exists or could not be checked: ${URL} returned ${HTTP_STATUS}"
+          exit 1
+        fi
+
+    - name: Checkout LLVM
+      uses: actions/checkout@v6
+      with:
+        repository: ${{ env.llvm_repository }}
+        path: llvm-project
+        ref: ${{ env.llvm_commit_hash }}
+
+    - name: Set up Python
+      if: matrix.config.target-os != 'almalinux'
+      uses: actions/setup-python@v7
+      with:
+        python-version: 3.11
+
+    - name: Set up MSVC
+      if: matrix.config.target-os == 'windows'
+      uses: ilammy/msvc-dev-cmd@v1.13.0
+      with:
+        arch: ${{ matrix.config.msvc_arch }}
+
+    - name: Install Prerequisites
+      shell: bash
+      run: |
+        python3 -m pip install cmake ninja sccache
+        mkdir -p ${{ env.SCCACHE_DIR }}
+        rm -rf ${{ env.SCCACHE_DIR }}/*
+
+    - name: Enable Cache
+      uses: actions/cache@v6
+      with:
+        path: ${{ env.SCCACHE_DIR }}
+        key: nvidia-codegen-${{ matrix.config.target-os }}-${{ matrix.config.arch }}-${{ env.short_llvm_commit_hash }}
+        restore-keys: nvidia-codegen-${{ matrix.config.target-os }}-${{ matrix.config.arch }}-
+
+    - name: Free disk space on Ubuntu
+      if: matrix.config.arch == 'x64' && matrix.config.target-os == 'ubuntu'
+      run: |
+        df -h
+        echo "Removing large packages"
+        sudo apt-get remove -y 'php.*'
+        sudo apt-get remove -y google-chrome-stable firefox powershell mono-devel
+        sudo apt-get autoremove -y
+        sudo apt-get clean
+        df -h
+
+    - name: Configure, Build, Test, and Install LLVM (Ubuntu, CentOS, and macOS)
+      if: matrix.config.target-os == 'ubuntu' || matrix.config.target-os == 'almalinux' || matrix.config.target-os == 'macos'
+      run: >
+        cmake -GNinja -Bllvm-project/build
+        -DCMAKE_BUILD_TYPE=Release
+        -DCMAKE_C_COMPILER=clang -DCMAKE_CXX_COMPILER=clang++
+        -DCMAKE_C_COMPILER_LAUNCHER=sccache -DCMAKE_CXX_COMPILER_LAUNCHER=sccache
+        -DCMAKE_INSTALL_PREFIX="${{ github.workspace }}/llvm-project/install"
+        -DCMAKE_LINKER=lld
+        -DLLVM_BUILD_UTILS=OFF
+        -DLLVM_BUILD_TOOLS=ON
+        -DLLVM_ENABLE_ASSERTIONS=ON
+        -DLLVM_INCLUDE_BENCHMARKS=OFF
+        -DLLVM_INCLUDE_TESTS=OFF
+        -DLLVM_ENABLE_PIC=ON
+        -DLLVM_DISTRIBUTION_COMPONENTS="${{ env.LLVM_DISTRIBUTION_COMPONENTS }}"
+        -DLLVM_TARGETS_TO_BUILD="NVPTX"
+        -DLLVM_ENABLE_ZSTD=OFF
+        $extra_cmake_flags
+        llvm-project/llvm
+
+        ninja -C llvm-project/build install-distribution
+
+        cmake -GNinja -B nvidia-codegen-build
+        -DCMAKE_BUILD_TYPE=Release
+        -DCMAKE_C_COMPILER=clang -DCMAKE_CXX_COMPILER=clang++
+        -DLLVM_DIR="${{ github.workspace }}/llvm-project/install/lib/cmake/llvm"
+        -DCMAKE_INSTALL_PREFIX="${{ github.workspace }}/${{ env.llvm_install_dir }}"
+        -DTRITON_NVIDIA_LLVM_REVISION="${{ env.llvm_commit_hash }}-${{ env.llvm_build_number }}"
+        llvm-build/third_party/nvidia/backend/codegen
+
+        ninja -C nvidia-codegen-build install
+
+        tar czf "${{ env.llvm_install_dir }}.tar.gz" "${{ env.llvm_install_dir }}"
+
+    - name: Configure, Build, Test, and Install LLVM (Windows)
+      if: matrix.config.target-os == 'windows'
+      run: >
+        cmake -GNinja -Bllvm-project/build
+        -DCMAKE_BUILD_TYPE=Release
+        -DCMAKE_C_COMPILER=cl -DCMAKE_CXX_COMPILER=cl
+        -DCMAKE_INSTALL_PREFIX="${{ github.workspace }}/llvm-project/install"
+        -DLLVM_BUILD_UTILS=OFF
+        -DLLVM_BUILD_TOOLS=ON
+        -DLLVM_ENABLE_ASSERTIONS=ON
+        -DLLVM_INCLUDE_BENCHMARKS=OFF
+        -DLLVM_INCLUDE_TESTS=OFF
+        -DLLVM_DISTRIBUTION_COMPONENTS="${{ env.LLVM_DISTRIBUTION_COMPONENTS }}"
+        -DLLVM_ENABLE_DIA_SDK=OFF
+        -DLLVM_TARGETS_TO_BUILD="NVPTX"
+        -DLLVM_ENABLE_ZSTD=OFF
+        llvm-project/llvm
+
+        ninja -C llvm-project/build install-distribution
+
+        cmake -GNinja -B nvidia-codegen-build
+        -DCMAKE_BUILD_TYPE=Release
+        -DCMAKE_C_COMPILER=cl -DCMAKE_CXX_COMPILER=cl
+        -DLLVM_DIR="${{ github.workspace }}/llvm-project/install/lib/cmake/llvm"
+        -DCMAKE_INSTALL_PREFIX="${{ github.workspace }}/${{ env.llvm_install_dir }}"
+        -DTRITON_NVIDIA_LLVM_REVISION="${{ env.llvm_commit_hash }}-${{ env.llvm_build_number }}"
+        llvm-build/third_party/nvidia/backend/codegen
+
+        ninja -C nvidia-codegen-build install
+
+        tar czf "${{ env.llvm_install_dir }}.tar.gz" "${{ env.llvm_install_dir }}"
+
+
+    - name: Upload Build Artifacts
+      uses: actions/upload-artifact@v7
+      with:
+        name: nvidia-codegen-${{ matrix.config.target-os }}-${{ matrix.config.arch }}
+        path: |
+          ${{ github.workspace }}/nvidia-codegen-*-${{ matrix.config.target-os }}-${{ matrix.config.arch }}-*.tar.gz
+
+    - name: Azure login
+      if: ${{ (github.repository == 'triton-lang/triton') && github.ref_name == 'main' }}
+      uses: azure/login@v2
+      with:
+        client-id: ${{ secrets.AZURE_CLIENT_ID_LLVM }}
+        tenant-id: ${{ secrets.AZURE_TENANT_ID_LLVM }}
+        subscription-id: ${{ secrets.AZURE_SUBSCRIPTION_ID_LLVM }}
+
+    - name: Upload LLVM Artifacts to Azure
+      if: ${{ (github.repository == 'triton-lang/triton') && github.ref_name == 'main' }}
+      shell: bash -el {0}
+      run: |
+        sha256sum "${{ env.llvm_install_dir }}.tar.gz"
+
+        az storage blob upload --account-name oaitriton --auth-mode login --container-name public --file "${{ env.llvm_install_dir }}.tar.gz" --name "llvm-builds/${{ env.llvm_install_dir }}.tar.gz"
+
+        URL=$(az storage blob url --account-name oaitriton --auth-mode login --container-name public --name "llvm-builds/${{ env.llvm_install_dir }}.tar.gz")
+        echo "Blob URL: ${URL}"
+
+    - name: Azure Logout
+      if: ${{ (github.repository == 'triton-lang/triton') && github.ref_name == 'main' }}
+      run: |
+        az logout
+        az cache purge
+        az account clear
+
+    - name: Dump Sccache Statistics
+      run: sccache --show-stats

--- a/.gitignore
+++ b/.gitignore
@@ -73,6 +73,9 @@ third_party/nvidia/backend/include
 third_party/nvidia/backend/lib/cupti
 third_party/nvidia/backend/lib/cupti-blackwell
 third_party/nvidia/backend/lib/gsan.ll
+third_party/nvidia/backend/lib/libtriton_nvidia_codegen.dylib
+third_party/nvidia/backend/lib/libtriton_nvidia_codegen.so
+third_party/nvidia/backend/lib/triton_nvidia_codegen.dll
 
 # Docs
 docs/_build/

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -399,6 +399,7 @@ if(TRITON_BUILD_PYTHON_MODULE)
     MLIRUBToLLVM
 
     # LLVM
+    LLVMBitWriter
     LLVMPasses
     LLVMNVPTXCodeGen
     LLVMAMDGPUCodeGen

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -31,6 +31,7 @@ set(TRITON_CACHE_PATH "" CACHE PATH "Path to triton cache")
 set(TRITON_LLVM_SYSTEM_SUFFIX "" CACHE STRING "Path to LLVM system suffix")
 set(LLVM_SYSPATH "" CACHE PATH "Path to system LLVM installation")
 set(JSON_SYSPATH "" CACHE PATH "Path to system nlohmann/json headers")
+set(TRITON_NVIDIA_CODEGEN_PATH "" CACHE FILEPATH "Path override for NVIDIA code-generation library")
 set(TRITON_PTXAS_PATH "" CACHE FILEPATH "Path override for ptxas")
 set(TRITON_PTXAS_BLACKWELL_PATH "" CACHE FILEPATH "Path override for ptxas-blackwell")
 set(TRITON_CUOBJDUMP_PATH "" CACHE FILEPATH "Path override for cuobjdump")
@@ -57,6 +58,9 @@ if(NOT "${LLVM_SYSPATH}" STREQUAL "")
 endif()
 if(NOT "${JSON_SYSPATH}" STREQUAL "")
   list(APPEND TRITON_BUILD_HELPER_COMMON_ARGS --json-syspath "${JSON_SYSPATH}")
+endif()
+if(NOT "${TRITON_NVIDIA_CODEGEN_PATH}" STREQUAL "")
+  list(APPEND TRITON_BUILD_HELPER_COMMON_ARGS --triton-nvidia-codegen-path "${TRITON_NVIDIA_CODEGEN_PATH}")
 endif()
 if(NOT "${TRITON_PTXAS_PATH}" STREQUAL "")
   list(APPEND TRITON_BUILD_HELPER_COMMON_ARGS --triton-ptxas-path "${TRITON_PTXAS_PATH}")
@@ -140,6 +144,9 @@ if(TRITON_BUILD_PYTHON_MODULE)
     APPEND
     PROPERTY CMAKE_CONFIGURE_DEPENDS
       "${CMAKE_CURRENT_SOURCE_DIR}/python/build_helpers.py"
+      "${CMAKE_CURRENT_SOURCE_DIR}/cmake/nvidia-llvm-info.json"
+      "${CMAKE_CURRENT_SOURCE_DIR}/third_party/nvidia/backend/codegen/CMakeLists.txt"
+      "${CMAKE_CURRENT_SOURCE_DIR}/third_party/nvidia/backend/codegen/nvptx_codegen.cc"
       "${CMAKE_CURRENT_SOURCE_DIR}/cmake/nvidia-toolchain-version.json"
   )
   find_package(Python3 REQUIRED COMPONENTS Interpreter)

--- a/cmake/nvidia-llvm-build-info.json
+++ b/cmake/nvidia-llvm-build-info.json
@@ -1,0 +1,5 @@
+{
+  "llvm_hash": "ce3529423abda3fc4ad0b542daa50af21e539a29",
+  "repository": "llvm/llvm-project",
+  "build_number": 1
+}

--- a/cmake/nvidia-llvm-info.json
+++ b/cmake/nvidia-llvm-info.json
@@ -1,0 +1,5 @@
+{
+  "llvm_hash": "ce3529423abda3fc4ad0b542daa50af21e539a29",
+  "build_number": 1,
+  "sha256sum": {}
+}

--- a/cmake/nvidia-llvm-info.json
+++ b/cmake/nvidia-llvm-info.json
@@ -1,5 +1,18 @@
 {
   "llvm_hash": "ce3529423abda3fc4ad0b542daa50af21e539a29",
   "build_number": 1,
-  "sha256sum": {}
+  "sha256sum": {},
+  "bootstrap_llvm": {
+    "build_number": 1,
+    "sha256sum": {
+      "almalinux-arm64": "b66134e232015cbdf443d5a2520714bc07c1546f30aa1a1f05b5571706debfc1",
+      "almalinux-x64": "8d2502f7647e393b580a10cbc3650467f84993d8be53db750706a437c349477e",
+      "macos-arm64": "4aaca94f931a4300c0041884a26149ef4bd9b5728b5d970d22f3440e75f8b034",
+      "macos-x64": "35a798de4116833ae7ecadf1fa6617e4546517d728ef69fc72603c76b2d70c70",
+      "ubuntu-arm64": "c0036e8bd18be160029dd9c24d2c87166fdd182ba6af8bf7ca4476cda4dbaa16",
+      "ubuntu-x64": "f20d30fdb2ea3c14ef032245214663ddb99c0ed0a9fdb46e1ebd47d3513d4ada",
+      "windows-arm64": "7260cc3e10bdddf690104d4e1ce14d6d7f942d4715e62471b3e0f9b1d8d9ca9f",
+      "windows-x64": "ac84a8d0e63db6b6d155c2ae9714d29aa3d9458d674a840f4684c5c02ce6401a"
+    }
+  }
 }

--- a/python/build_helpers.py
+++ b/python/build_helpers.py
@@ -46,6 +46,7 @@ class BuildHelperArgs:
     llvm_system_suffix: Optional[str]
     llvm_syspath: Optional[str]
     json_syspath: Optional[str]
+    nvidia_codegen_path: Optional[str]
     ptxas_path: Optional[str]
     ptxas_blackwell_path: Optional[str]
     cuobjdump_path: Optional[str]
@@ -407,6 +408,31 @@ def get_llvm_package_info(helper_args: BuildHelperArgs):
     )
 
 
+def get_nvidia_codegen_package_info(helper_args: BuildHelperArgs):
+    llvm_package = get_llvm_package_info(helper_args)
+    if llvm_package.sym_name is None:
+        raise RuntimeError("NVIDIA code generation is unavailable for this platform; set TRITON_NVIDIA_CODEGEN_PATH")
+
+    system_suffix = llvm_package.sym_name.removeprefix("llvm-")
+    nvidia_llvm_info_path = os.path.join(get_base_dir(), "cmake", "nvidia-llvm-info.json")
+    with open(nvidia_llvm_info_path, "r") as nvidia_llvm_info_file:
+        nvidia_llvm_info = json.load(nvidia_llvm_info_file)
+
+    revision = nvidia_llvm_info["llvm_hash"][:8]
+    build_number = nvidia_llvm_info["build_number"]
+    name = f"nvidia-codegen-{revision}-{system_suffix}-{build_number}"
+    url = f"https://oaitriton.blob.core.windows.net/public/llvm-builds/{name}.tar.gz"
+    return Package(
+        "nvidia",
+        name,
+        url,
+        "",
+        "",
+        "",
+        sha256sum=nvidia_llvm_info.get("sha256sum", {}).get(system_suffix),
+    )
+
+
 def _get_syspath_override(package_syspath_var_name: str, helper_args: BuildHelperArgs) -> Optional[str]:
     syspath_overrides = {
         "LLVM_SYSPATH": helper_args.llvm_syspath,
@@ -483,6 +509,110 @@ def write_thirdparty_cmake_vars(output: str, packages: list[str], helper_args: B
 # --- nvidia toolchain helpers -----
 
 
+def nvidia_codegen_library_name():
+    if sys.platform == "win32":
+        return "triton_nvidia_codegen.dll"
+    if sys.platform == "darwin":
+        return "libtriton_nvidia_codegen.dylib"
+    return "libtriton_nvidia_codegen.so"
+
+
+def build_nvidia_codegen(llvm_path: str, nvidia_llvm_info: dict, helper_args: BuildHelperArgs):
+    revision = f'{nvidia_llvm_info["llvm_hash"]}-{nvidia_llvm_info["build_number"]}'
+    system_suffix = get_llvm_package_info(helper_args).sym_name.removeprefix("llvm-")
+    build_path = os.path.join(helper_args.cache_path, "nvidia", f"codegen-bootstrap-{revision}-{system_suffix}")
+    install_path = os.path.join(build_path, "install")
+    source_path = os.path.join(get_base_dir(), "third_party", "nvidia", "backend", "codegen")
+    llvm_cmake_path = os.path.join(llvm_path, "lib", "cmake", "llvm")
+    command = [
+        "cmake",
+        "-G",
+        "Ninja",
+        "-S",
+        source_path,
+        "-B",
+        build_path,
+        f"-DLLVM_DIR={llvm_cmake_path}",
+        f"-DCMAKE_INSTALL_PREFIX={install_path}",
+        f"-DTRITON_NVIDIA_LLVM_REVISION={revision}",
+        "-DCMAKE_BUILD_TYPE=Release",
+    ]
+    if sys.platform != "win32":
+        clang = os.path.join(llvm_path, "bin", "clang")
+        clangxx = os.path.join(llvm_path, "bin", "clang++")
+        if os.path.isfile(clang) and os.path.isfile(clangxx):
+            command.extend([f"-DCMAKE_C_COMPILER={clang}", f"-DCMAKE_CXX_COMPILER={clangxx}"])
+    if sys.platform == "darwin":
+        sdk = os.environ.get("SDKROOT", "/Library/Developer/CommandLineTools/SDKs/MacOSX.sdk")
+        linker = "/Library/Developer/CommandLineTools/usr/bin/ld"
+        if os.path.isdir(sdk):
+            command.extend([
+                f"-DCMAKE_OSX_SYSROOT={sdk}",
+                f"-DCMAKE_CXX_FLAGS=-isystem{sdk}/usr/include/c++/v1",
+            ])
+        if os.path.isfile(linker):
+            linker_flag = f"-fuse-ld={linker}"
+            command.extend([
+                f"-DCMAKE_EXE_LINKER_FLAGS={linker_flag}",
+                f"-DCMAKE_SHARED_LINKER_FLAGS={linker_flag}",
+            ])
+    subprocess.check_call(command)
+    subprocess.check_call(["cmake", "--build", build_path, "--config", "Release", "--target", "triton_nvidia_codegen"])
+    subprocess.check_call(["cmake", "--install", build_path, "--config", "Release"])
+    return os.path.join(install_path, "lib", nvidia_codegen_library_name())
+
+
+def download_and_copy_nvidia_codegen(helper_args: BuildHelperArgs):
+    if helper_args.nvidia_codegen_path is not None:
+        return
+
+    library = nvidia_codegen_library_name()
+    llvm_info_path = os.path.join(get_base_dir(), "cmake", "llvm-info.json")
+    nvidia_llvm_info_path = os.path.join(get_base_dir(), "cmake", "nvidia-llvm-info.json")
+    with open(llvm_info_path, "r") as llvm_info_file:
+        llvm_info = json.load(llvm_info_file)
+    with open(nvidia_llvm_info_path, "r") as nvidia_llvm_info_file:
+        nvidia_llvm_info = json.load(nvidia_llvm_info_file)
+
+    same_llvm_revision = (nvidia_llvm_info["llvm_hash"] == llvm_info["llvm_hash"]
+                          and nvidia_llvm_info["build_number"] == llvm_info["build_number"])
+    package = get_nvidia_codegen_package_info(helper_args)
+    if same_llvm_revision and package.sha256sum is None:
+        # Bootstrap against Triton's existing LLVM only until an independently
+        # built NVIDIA code-generation artifact and checksum are published.
+        if helper_args.llvm_syspath is not None:
+            llvm_path = helper_args.llvm_syspath
+        else:
+            llvm_package = get_llvm_package_info(helper_args)
+            llvm_path = os.path.join(helper_args.cache_path, "llvm", llvm_package.name)
+        source_path = build_nvidia_codegen(llvm_path, nvidia_llvm_info, helper_args)
+    elif package.sha256sum is None:
+        raise RuntimeError(f"Missing SHA256 for NVIDIA code-generation package {package.name}")
+    else:
+        package_root = os.path.join(helper_args.cache_path, package.package)
+        source_path = os.path.join(package_root, package.name, "lib", library)
+        if not os.path.isfile(source_path):
+            if helper_args.offline_build:
+                raise RuntimeError(
+                    f"Requested an offline build but NVIDIA code generation is missing from {source_path}")
+            _download_and_extract(package.url, package_root, package.name, helper_args.archives_path, package.sha256sum)
+
+    if not os.path.isfile(source_path):
+        raise RuntimeError(f"Cannot find NVIDIA code generation at {source_path}; set TRITON_NVIDIA_CODEGEN_PATH")
+
+    destination_path = os.path.join(get_base_dir(), "third_party", "nvidia", "backend", "lib", library)
+    if os.path.isfile(destination_path):
+        source_stat = os.stat(source_path)
+        destination_stat = os.stat(destination_path)
+        if (source_stat.st_size == destination_stat.st_size
+                and source_stat.st_mtime_ns == destination_stat.st_mtime_ns):
+            return
+
+    os.makedirs(os.path.dirname(destination_path), exist_ok=True)
+    print(f"copy {source_path} to {destination_path} ...")
+    shutil.copy2(source_path, destination_path)
+
+
 def download_and_copy(name, src_func, dst_path, override_path, version, url_func, helper_args: BuildHelperArgs):
     if helper_args.offline_build:
         return
@@ -518,6 +648,8 @@ def download_and_copy(name, src_func, dst_path, override_path, version, url_func
 
 
 def download_and_copy_dependencies(helper_args: BuildHelperArgs):
+    download_and_copy_nvidia_codegen(helper_args)
+
     nvidia_version_path = os.path.join(get_base_dir(), "cmake", "nvidia-toolchain-version.json")
     with open(nvidia_version_path, "r") as nvidia_version_file:
         # parse this json file to get the version of the nvidia toolchain
@@ -627,6 +759,7 @@ def add_common_args(parser: argparse.ArgumentParser):
     parser.add_argument("--triton-llvm-system-suffix", default="", help="Override LLVM system suffix")
     parser.add_argument("--llvm-syspath", default="", help="Path override for LLVM_SYSPATH")
     parser.add_argument("--json-syspath", default="", help="Path override for JSON_SYSPATH")
+    parser.add_argument("--triton-nvidia-codegen-path", default="", help="Path override for TRITON_NVIDIA_CODEGEN_PATH")
     parser.add_argument("--triton-ptxas-path", default="", help="Path override for TRITON_PTXAS_PATH")
     parser.add_argument(
         "--triton-ptxas-blackwell-path",
@@ -654,6 +787,7 @@ def normalize_parsed_args(parsed_args) -> BuildHelperArgs:
         llvm_system_suffix=_normalize_optional(parsed_args.triton_llvm_system_suffix),
         llvm_syspath=_normalize_optional_path(parsed_args.llvm_syspath),
         json_syspath=_normalize_optional_path(parsed_args.json_syspath),
+        nvidia_codegen_path=_normalize_optional_path(parsed_args.triton_nvidia_codegen_path),
         ptxas_path=_normalize_optional_path(parsed_args.triton_ptxas_path),
         ptxas_blackwell_path=_normalize_optional_path(parsed_args.triton_ptxas_blackwell_path),
         cuobjdump_path=_normalize_optional_path(parsed_args.triton_cuobjdump_path),

--- a/python/build_helpers.py
+++ b/python/build_helpers.py
@@ -349,7 +349,7 @@ def is_linux_os(os_id):
     return False
 
 
-def get_llvm_package_info(helper_args: BuildHelperArgs):
+def get_llvm_system_suffix(helper_args: BuildHelperArgs):
     system = platform.system()
     try:
         arch = {"x86_64": "x64", "arm64": "arm64", "aarch64": "arm64"}[platform.machine()]
@@ -380,11 +380,18 @@ def get_llvm_package_info(helper_args: BuildHelperArgs):
             print(
                 f"LLVM pre-compiled image is not available for {system}-{arch}. Proceeding with user-configured LLVM from source build."
             )
-            return Package("llvm", "LLVM-C.lib", "", "LLVM_INCLUDE_DIRS", "LLVM_LIBRARY_DIR", "LLVM_SYSPATH")
+            return None
     else:
         print(
             f"LLVM pre-compiled image is not available for {system}-{arch}. Proceeding with user-configured LLVM from source build."
         )
+        return None
+    return system_suffix
+
+
+def get_llvm_package_info(helper_args: BuildHelperArgs):
+    system_suffix = get_llvm_system_suffix(helper_args)
+    if system_suffix is None:
         return Package("llvm", "LLVM-C.lib", "", "LLVM_INCLUDE_DIRS", "LLVM_LIBRARY_DIR", "LLVM_SYSPATH")
     llvm_info_path = os.path.join(get_base_dir(), "cmake", "llvm-info.json")
     with open(llvm_info_path, "r") as llvm_info_file:
@@ -409,11 +416,10 @@ def get_llvm_package_info(helper_args: BuildHelperArgs):
 
 
 def get_nvidia_codegen_package_info(helper_args: BuildHelperArgs):
-    llvm_package = get_llvm_package_info(helper_args)
-    if llvm_package.sym_name is None:
+    system_suffix = get_llvm_system_suffix(helper_args)
+    if system_suffix is None:
         raise RuntimeError("NVIDIA code generation is unavailable for this platform; set TRITON_NVIDIA_CODEGEN_PATH")
 
-    system_suffix = llvm_package.sym_name.removeprefix("llvm-")
     nvidia_llvm_info_path = os.path.join(get_base_dir(), "cmake", "nvidia-llvm-info.json")
     with open(nvidia_llvm_info_path, "r") as nvidia_llvm_info_file:
         nvidia_llvm_info = json.load(nvidia_llvm_info_file)
@@ -517,12 +523,39 @@ def nvidia_codegen_library_name():
     return "libtriton_nvidia_codegen.so"
 
 
-def build_nvidia_codegen(llvm_path: str, nvidia_llvm_info: dict, helper_args: BuildHelperArgs):
+def download_codegen_llvm(backend: str, llvm_info: dict, helper_args: BuildHelperArgs):
+    # This SDK has its own pin and cache. Never consult llvm-info.json or
+    # LLVM_SYSPATH, which configure Triton's core LLVM rather than this backend.
+    system_suffix = get_llvm_system_suffix(helper_args)
+    bootstrap = llvm_info.get("bootstrap_llvm", {})
+    checksum = bootstrap.get("sha256sum", {}).get(system_suffix)
+    if checksum is None:
+        raise RuntimeError(
+            f"Missing {backend} code-generation artifact and bootstrap LLVM checksum for {system_suffix}")
+    revision = llvm_info["llvm_hash"][:8]
+    name = f"llvm-{revision}-{system_suffix}-{bootstrap['build_number']}"
+    package_root = os.path.join(helper_args.cache_path, backend, "llvm")
+    llvm_path = os.path.join(package_root, name)
+    llvm_config = os.path.join(llvm_path, "lib", "cmake", "llvm", "LLVMConfig.cmake")
+    if not os.path.isfile(llvm_config):
+        if helper_args.offline_build:
+            raise RuntimeError(f"Requested an offline build but {backend} bootstrap LLVM is missing from {llvm_path}")
+        url = f"https://oaitriton.blob.core.windows.net/public/llvm-builds/{name}.tar.gz"
+        _download_and_extract(url, package_root, name, helper_args.archives_path, checksum)
+    if not os.path.isfile(llvm_config):
+        raise RuntimeError(f"Cannot find independently pinned {backend} LLVM configuration at {llvm_config}")
+    return llvm_path
+
+
+def build_nvidia_codegen(nvidia_llvm_info: dict, helper_args: BuildHelperArgs):
+    llvm_path = download_codegen_llvm("nvidia", nvidia_llvm_info, helper_args)
     revision = f'{nvidia_llvm_info["llvm_hash"]}-{nvidia_llvm_info["build_number"]}'
-    system_suffix = get_llvm_package_info(helper_args).sym_name.removeprefix("llvm-")
-    build_path = os.path.join(helper_args.cache_path, "nvidia", f"codegen-bootstrap-{revision}-{system_suffix}")
-    install_path = os.path.join(build_path, "install")
+    system_suffix = get_llvm_system_suffix(helper_args)
     source_path = os.path.join(get_base_dir(), "third_party", "nvidia", "backend", "codegen")
+    checkout_hash = hashlib.sha256(os.path.realpath(source_path).encode()).hexdigest()[:12]
+    build_path = os.path.join(helper_args.cache_path, "nvidia",
+                              f"codegen-bootstrap-{revision}-{system_suffix}-{checkout_hash}")
+    install_path = os.path.join(build_path, "install")
     llvm_cmake_path = os.path.join(llvm_path, "lib", "cmake", "llvm")
     command = [
         "cmake",
@@ -567,27 +600,15 @@ def download_and_copy_nvidia_codegen(helper_args: BuildHelperArgs):
         return
 
     library = nvidia_codegen_library_name()
-    llvm_info_path = os.path.join(get_base_dir(), "cmake", "llvm-info.json")
     nvidia_llvm_info_path = os.path.join(get_base_dir(), "cmake", "nvidia-llvm-info.json")
-    with open(llvm_info_path, "r") as llvm_info_file:
-        llvm_info = json.load(llvm_info_file)
     with open(nvidia_llvm_info_path, "r") as nvidia_llvm_info_file:
         nvidia_llvm_info = json.load(nvidia_llvm_info_file)
 
-    same_llvm_revision = (nvidia_llvm_info["llvm_hash"] == llvm_info["llvm_hash"]
-                          and nvidia_llvm_info["build_number"] == llvm_info["build_number"])
     package = get_nvidia_codegen_package_info(helper_args)
-    if same_llvm_revision and package.sha256sum is None:
-        # Bootstrap against Triton's existing LLVM only until an independently
-        # built NVIDIA code-generation artifact and checksum are published.
-        if helper_args.llvm_syspath is not None:
-            llvm_path = helper_args.llvm_syspath
-        else:
-            llvm_package = get_llvm_package_info(helper_args)
-            llvm_path = os.path.join(helper_args.cache_path, "llvm", llvm_package.name)
-        source_path = build_nvidia_codegen(llvm_path, nvidia_llvm_info, helper_args)
-    elif package.sha256sum is None:
-        raise RuntimeError(f"Missing SHA256 for NVIDIA code-generation package {package.name}")
+    if package.sha256sum is None:
+        # Until standalone artifacts are published, use the SDK pinned in this
+        # backend's manifest, regardless of Triton's core LLVM configuration.
+        source_path = build_nvidia_codegen(nvidia_llvm_info, helper_args)
     else:
         package_root = os.path.join(helper_args.cache_path, package.package)
         source_path = os.path.join(package_root, package.name, "lib", library)

--- a/python/src/llvm.cc
+++ b/python/src/llvm.cc
@@ -7,6 +7,7 @@
 #include "llvm/ADT/SmallVector.h"
 #include "llvm/Analysis/ScopedNoAliasAA.h"
 #include "llvm/Analysis/TargetTransformInfo.h"
+#include "llvm/Bitcode/BitcodeWriter.h"
 #include "llvm/CodeGen/MIRParser/MIRParser.h"
 #include "llvm/CodeGen/MachineModuleInfo.h"
 #include "llvm/CodeGen/MachineRegisterInfo.h"
@@ -703,6 +704,24 @@ void init_triton_llvm(py::module_ &m) {
         return llvmMod;
       },
       py::keep_alive<0, 2>(), py::call_guard<py::gil_scoped_release>());
+
+  m.def("to_bitcode", [](const std::string &llvmIR) {
+    std::string bitcode;
+    {
+      py::gil_scoped_release release;
+      llvm::LLVMContext context;
+      auto buffer = llvm::MemoryBuffer::getMemBuffer(llvmIR, "triton", false);
+      llvm::SMDiagnostic error;
+      auto module = llvm::parseIR(buffer->getMemBufferRef(), error, context);
+      if (!module)
+        throw std::runtime_error(
+            "failed to parse LLVM IR: " + error.getMessage().str() +
+            " at line " + std::to_string(error.getLineNo()));
+      llvm::raw_string_ostream stream(bitcode);
+      llvm::WriteBitcodeToFile(*module, stream);
+    }
+    return py::bytes(bitcode.data(), bitcode.size());
+  });
 
   // Add Triton and LLVM versions to the module.
   m.def("add_version_info", [](llvm::Module *mod) {

--- a/python/test/unit/runtime/test_bindings.py
+++ b/python/test/unit/runtime/test_bindings.py
@@ -8,6 +8,22 @@ import pytest
 _BLOCK_SIZE = 16
 
 
+def test_llvm_ir_to_bitcode():
+    from triton._C.libtriton import llvm
+
+    bitcode = llvm.to_bitcode("define void @kernel() { ret void }")
+    assert isinstance(bitcode, bytes)
+    assert bitcode.startswith(b"BC\xc0\xde")
+    assert b"\x00" in bitcode
+
+
+def test_llvm_ir_to_bitcode_reports_invalid_ir():
+    from triton._C.libtriton import llvm
+
+    with pytest.raises(RuntimeError, match="failed to parse LLVM IR.*expected top-level entity"):
+        llvm.to_bitcode("invalid LLVM IR")
+
+
 @triton.jit
 def add_helper(x, y):
     return x + y

--- a/python/test/unit/runtime/test_build.py
+++ b/python/test/unit/runtime/test_build.py
@@ -9,6 +9,118 @@ import triton
 
 from triton.runtime.build import compile_module_from_src
 
+
+@pytest.fixture
+def nvidia_codegen_build_setup(tmp_path, monkeypatch):
+    import argparse
+    import json
+
+    monkeypatch.syspath_prepend(str(Path(__file__).resolve().parents[3]))
+    import build_helpers
+
+    monkeypatch.setattr(build_helpers, "get_base_dir", lambda: str(tmp_path))
+    monkeypatch.setattr(build_helpers, "get_llvm_package_info",
+                        lambda *args: pytest.fail("backend consulted core LLVM"))
+    (tmp_path / "cmake").mkdir()
+    (tmp_path / "cmake/llvm-info.json").write_text("core LLVM metadata must not be read")
+    info = {
+        "llvm_hash": "a" * 40,
+        "build_number": 2,
+        "sha256sum": {},
+        "bootstrap_llvm": {
+            "build_number": 1,
+            "sha256sum": {"macos-arm64": "backend-sdk-checksum"},
+        },
+    }
+    manifest = tmp_path / "cmake/nvidia-llvm-info.json"
+    manifest.write_text(json.dumps(info))
+    parser = argparse.ArgumentParser()
+    build_helpers.add_common_args(parser)
+    args = build_helpers.normalize_parsed_args(
+        parser.parse_args([
+            "--triton-cache-path",
+            str(tmp_path / "cache"),
+            "--triton-llvm-system-suffix",
+            "macos-arm64",
+            "--llvm-syspath",
+            str(tmp_path / "unusable-core-llvm"),
+        ]))
+    return build_helpers, args, info, manifest
+
+
+@pytest.mark.parametrize("offline", [False, True])
+def test_nvidia_codegen_bootstrap_ignores_core_llvm(nvidia_codegen_build_setup, monkeypatch, offline):
+    from dataclasses import replace
+
+    helpers, args, info, _ = nvidia_codegen_build_setup
+    args = replace(args, offline_build=offline)
+    library = helpers.nvidia_codegen_library_name()
+    sdk = Path(args.cache_path) / "nvidia/llvm/llvm-aaaaaaaa-macos-arm64-1"
+    config = sdk / "lib/cmake/llvm/LLVMConfig.cmake"
+    downloads = []
+
+    def download(url, package_root, name, archives_path, checksum):
+        assert not offline
+        assert name == "llvm-aaaaaaaa-macos-arm64-1"
+        assert checksum == "backend-sdk-checksum"
+        assert Path(package_root) == sdk.parent
+        downloads.append(url)
+        config.parent.mkdir(parents=True)
+        config.touch()
+
+    if offline:
+        config.parent.mkdir(parents=True)
+        config.touch()
+    monkeypatch.setattr(helpers, "_download_and_extract", download)
+    commands = []
+
+    def cmake(command):
+        commands.append(command)
+        if "--install" in command:
+            prefix = next(flag.split("=", 1)[1] for flag in commands[0] if flag.startswith("-DCMAKE_INSTALL_PREFIX="))
+            output = Path(prefix) / "lib" / library
+            output.parent.mkdir(parents=True)
+            output.write_bytes(b"packaging fixture")
+
+    monkeypatch.setattr(helpers.subprocess, "check_call", cmake)
+    helpers.download_and_copy_nvidia_codegen(args)
+    assert len(downloads) == (0 if offline else 1)
+    assert f"-DLLVM_DIR={sdk / 'lib/cmake/llvm'}" in commands[0]
+    assert f"-DTRITON_NVIDIA_LLVM_REVISION={info['llvm_hash']}-2" in commands[0]
+    assert all(args.llvm_syspath not in flag for command in commands for flag in command)
+
+
+def test_nvidia_codegen_download_ignores_core_llvm(nvidia_codegen_build_setup, monkeypatch):
+    import json
+
+    helpers, args, info, manifest = nvidia_codegen_build_setup
+    info["sha256sum"]["macos-arm64"] = "backend-library-checksum"
+    manifest.write_text(json.dumps(info))
+    monkeypatch.setattr(helpers, "build_nvidia_codegen", lambda *args: pytest.fail("published backend was rebuilt"))
+    downloads = []
+
+    def download(url, package_root, name, archives_path, checksum):
+        assert name == "nvidia-codegen-aaaaaaaa-macos-arm64-2"
+        assert checksum == "backend-library-checksum"
+        downloads.append(url)
+        library = Path(package_root) / name / "lib" / helpers.nvidia_codegen_library_name()
+        library.parent.mkdir(parents=True)
+        library.write_bytes(b"published packaging fixture")
+
+    monkeypatch.setattr(helpers, "_download_and_extract", download)
+    helpers.download_and_copy_nvidia_codegen(args)
+    assert len(downloads) == 1
+
+
+def test_nvidia_codegen_bootstrap_requires_cached_llvm_offline(nvidia_codegen_build_setup, monkeypatch):
+    from dataclasses import replace
+
+    helpers, args, info, _ = nvidia_codegen_build_setup
+    monkeypatch.setattr(helpers, "_download_and_extract", lambda *args: pytest.fail("offline download attempted"))
+    with pytest.raises(RuntimeError, match="nvidia bootstrap LLVM is missing"):
+        helpers.download_codegen_llvm("nvidia", info, replace(args, offline_build=True))
+
+
 TEST_MODULE_C = """
 #include <Python.h>
 #include <string.h>

--- a/python/test/unit/test_knobs.py
+++ b/python/test/unit/test_knobs.py
@@ -139,7 +139,7 @@ def test_nvidia_codegen_revision_invalidates_backend_hash(fresh_knobs, monkeypat
 
 
 @pytest.mark.skipif(is_hip(), reason="NVPTX code generation is unavailable on AMD")
-def test_nvidia_codegen_inlines_functions(fresh_knobs):
+def test_nvidia_codegen_inlines_functions_from_bitcode(fresh_knobs, monkeypatch):
     from triton.backends.compiler import GPUTarget
     from triton.backends.nvidia import compiler
 
@@ -157,9 +157,22 @@ define ptx_kernel void @inline_kernel(ptr addrspace(1) %out, i32 %value) {
   ret void
 }
 '''
+    library = compiler._load_nvidia_codegen(compiler.get_nvidia_codegen_path())
+    compile_bitcode = library.triton_nvptx_compile
+    inputs = []
+
+    def check_bitcode(bitcode, size, *args):
+        inputs.append(bitcode)
+        assert bitcode.startswith(b"BC\xc0\xde")
+        assert b"\x00" in bitcode
+        assert size == len(bitcode)
+        return compile_bitcode(bitcode, size, *args)
+
+    monkeypatch.setattr(library, "triton_nvptx_compile", check_bitcode)
     backend = compiler.CUDABackend(GPUTarget("cuda", 90, 32))
     ptx = backend.make_ptx(source, {}, compiler.CUDAOptions(ptx_version=80), 90)
 
+    assert len(inputs) == 1
     assert ".visible .entry inline_kernel" in ptx
     assert "call.uni" not in ptx
     assert "helper(" not in ptx
@@ -171,7 +184,7 @@ def test_nvidia_codegen_reports_invalid_llvm_ir(fresh_knobs):
     from triton.backends.nvidia import compiler
 
     backend = compiler.CUDABackend(GPUTarget("cuda", 90, 32))
-    with pytest.raises(RuntimeError, match="NVIDIA LLVM .*expected top-level entity"):
+    with pytest.raises(RuntimeError, match="failed to parse LLVM IR.*expected top-level entity"):
         backend.make_ptx("invalid LLVM IR", {}, compiler.CUDAOptions(ptx_version=80), 90)
 
 

--- a/python/test/unit/test_knobs.py
+++ b/python/test/unit/test_knobs.py
@@ -68,6 +68,137 @@ def test_knobs_utils(fresh_knobs) -> None:
     }
 
 
+@pytest.mark.parametrize(("capability", "enable_fp_fusion", "disable_opt", "disable_optimization"), [
+    (80, True, None, False),
+    (90, False, "1", True),
+    (107, True, "disable-lsr", False),
+    (90, True, "0", False),
+])
+def test_nvidia_codegen_options(capability, enable_fp_fusion, disable_opt, disable_optimization, fresh_knobs,
+                                monkeypatch):
+    from triton.backends.compiler import GPUTarget
+    from triton.backends.nvidia import compiler
+
+    calls = []
+
+    def run_codegen(source, triple, processor, features, **kwargs):
+        calls.append((source, triple, processor, features, kwargs))
+        return ".version 9.0\n.target sm_90\n.visible .entry test_kernel() {}\n"
+
+    monkeypatch.setattr(compiler, "compile_nvptx", run_codegen)
+    if disable_opt is not None:
+        monkeypatch.setenv("DISABLE_LLVM_OPT", disable_opt)
+    else:
+        monkeypatch.delenv("DISABLE_LLVM_OPT", raising=False)
+
+    backend = compiler.CUDABackend(GPUTarget("cuda", capability, 32))
+    options = compiler.CUDAOptions(ptx_version=90, enable_fp_fusion=enable_fp_fusion)
+    metadata = {}
+    ptx = backend.make_ptx("test llvm ir", metadata, options, capability)
+
+    assert len(calls) == 1
+    source, triple, processor, features, arguments = calls[0]
+    llvm_capability = 100 if capability == 107 else capability
+    assert source == "test llvm ir"
+    assert triple == "nvptx64-nvidia-cuda"
+    assert processor == compiler.sm_arch_from_capability(llvm_capability)
+    assert features == "+ptx90"
+    assert arguments["enable_fp_fusion"] is enable_fp_fusion
+    assert arguments["disable_optimization"] is disable_optimization
+    assert arguments["disabled_passes"] == ("disable-lsr" if disable_opt == "disable-lsr" else "")
+    assert metadata["name"] == "test_kernel"
+    assert f".target sm_{capability}" in ptx
+
+
+def test_nvidia_codegen_path_override(fresh_knobs, monkeypatch):
+    from triton.backends.nvidia import compiler
+
+    monkeypatch.delenv("TRITON_NVIDIA_CODEGEN_PATH", raising=False)
+    library = Path(compiler.get_nvidia_codegen_path())
+    assert library.parent == Path(compiler.__file__).parent / "lib"
+    assert "triton_nvidia_codegen" in library.name
+
+    monkeypatch.setenv("TRITON_NVIDIA_CODEGEN_PATH", "/custom/nvidia/codegen.so")
+    assert compiler.get_nvidia_codegen_path() == "/custom/nvidia/codegen.so"
+
+
+def test_nvidia_codegen_revision_invalidates_backend_hash(fresh_knobs, monkeypatch):
+    from triton.backends.compiler import GPUTarget
+    from triton.backends.nvidia import compiler
+
+    monkeypatch.setattr(compiler, "get_ptxas_version", lambda arch: "ptxas version")
+    monkeypatch.setattr(compiler, "get_nvidia_codegen_revision", lambda: "first-revision-1")
+    backend = compiler.CUDABackend(GPUTarget("cuda", 90, 32))
+    first_hash = backend.hash()
+
+    monkeypatch.setattr(compiler, "get_nvidia_codegen_revision", lambda: "second-revision-1")
+    backend.hash.cache_clear()
+    second_hash = backend.hash()
+
+    assert first_hash != second_hash
+
+
+@pytest.mark.skipif(is_hip(), reason="NVPTX code generation is unavailable on AMD")
+def test_nvidia_codegen_inlines_functions(fresh_knobs):
+    from triton.backends.compiler import GPUTarget
+    from triton.backends.nvidia import compiler
+
+    source = '''
+target triple = "nvptx64-nvidia-cuda"
+
+define internal i32 @helper(i32 %value) {
+  %result = add i32 %value, 1
+  ret i32 %result
+}
+
+define ptx_kernel void @inline_kernel(ptr addrspace(1) %out, i32 %value) {
+  %result = call i32 @helper(i32 %value)
+  store i32 %result, ptr addrspace(1) %out, align 4
+  ret void
+}
+'''
+    backend = compiler.CUDABackend(GPUTarget("cuda", 90, 32))
+    ptx = backend.make_ptx(source, {}, compiler.CUDAOptions(ptx_version=80), 90)
+
+    assert ".visible .entry inline_kernel" in ptx
+    assert "call.uni" not in ptx
+    assert "helper(" not in ptx
+
+
+@pytest.mark.skipif(is_hip(), reason="NVPTX code generation is unavailable on AMD")
+def test_nvidia_codegen_reports_invalid_llvm_ir(fresh_knobs):
+    from triton.backends.compiler import GPUTarget
+    from triton.backends.nvidia import compiler
+
+    backend = compiler.CUDABackend(GPUTarget("cuda", 90, 32))
+    with pytest.raises(RuntimeError, match="NVIDIA LLVM .*expected top-level entity"):
+        backend.make_ptx("invalid LLVM IR", {}, compiler.CUDAOptions(ptx_version=80), 90)
+
+
+@pytest.mark.skipif(is_hip(), reason="NVPTX code generation is unavailable on AMD")
+def test_nvidia_codegen_uses_short_shared_memory_pointers(fresh_knobs):
+    from triton.backends.compiler import GPUTarget
+    from triton.backends.nvidia import compiler
+
+    source = '''
+target triple = "nvptx64-nvidia-cuda"
+
+@global_smem = external addrspace(3) global [0 x i8], align 1
+
+define ptx_kernel void @short_pointer_kernel(ptr addrspace(1) %out, i32 %offset) {
+  %shared = getelementptr [0 x i8], ptr addrspace(3) @global_smem, i32 0, i32 %offset
+  %value = load i8, ptr addrspace(3) %shared, align 1
+  store i8 %value, ptr addrspace(1) %out, align 1
+  ret void
+}
+'''
+    backend = compiler.CUDABackend(GPUTarget("cuda", 90, 32))
+    ptx = backend.make_ptx(source, {}, compiler.CUDAOptions(ptx_version=80), 90)
+
+    assert any(
+        line.startswith("mov.b32") and "global_smem" in line for line in (line.strip() for line in ptx.splitlines()))
+
+
 def test_knobs_scope(fresh_knobs, monkeypatch):
     fresh_knobs.amd.use_buffer_atomics = True
 

--- a/python/triton/knobs.py
+++ b/python/triton/knobs.py
@@ -499,6 +499,7 @@ class language_knobs(base_knobs):
 
 
 class nvidia_knobs(base_knobs):
+    codegen_path: env_opt_str = env_opt_str("TRITON_NVIDIA_CODEGEN_PATH")
     cuobjdump: env_nvidia_tool = env_nvidia_tool("cuobjdump")
     nvdisasm: env_nvidia_tool = env_nvidia_tool("nvdisasm")
     ptxas: env_nvidia_tool = env_nvidia_tool("ptxas")

--- a/setup.py
+++ b/setup.py
@@ -365,6 +365,7 @@ class CMakeBuild(build_ext):
             "TRITON_ROCPROFILER_SDK_INCLUDE_PATH",
             "TRITON_ROCPROFILER_SDK_LIB_PATH",
             "TRITON_NVDISASM_PATH",
+            "TRITON_NVIDIA_CODEGEN_PATH",
             "TRITON_PTXAS_PATH",
             "TRITON_PTXAS_BLACKWELL_PATH",
         ]

--- a/third_party/nvidia/backend/codegen/CMakeLists.txt
+++ b/third_party/nvidia/backend/codegen/CMakeLists.txt
@@ -31,6 +31,13 @@ llvm_map_components_to_libnames(TRITON_NVIDIA_LLVM_LIBRARIES
 target_link_libraries(triton_nvidia_codegen PRIVATE
                       ${TRITON_NVIDIA_LLVM_LIBRARIES})
 
+foreach(llvm_library IN LISTS TRITON_NVIDIA_LLVM_LIBRARIES)
+  get_target_property(llvm_library_type ${llvm_library} TYPE)
+  if(NOT llvm_library_type STREQUAL "STATIC_LIBRARY")
+    message(FATAL_ERROR "Standalone NVIDIA code generation requires static LLVM libraries: ${llvm_library}")
+  endif()
+endforeach()
+
 set_target_properties(triton_nvidia_codegen PROPERTIES
     CXX_VISIBILITY_PRESET hidden
     VISIBILITY_INLINES_HIDDEN YES
@@ -48,7 +55,8 @@ elseif(UNIX)
       "{\n  global:\n    triton_nvptx_compile;\n    triton_nvptx_free;\n    triton_nvptx_revision;\n  local:\n    *;\n};\n")
   target_link_options(triton_nvidia_codegen PRIVATE
       "LINKER:--version-script,${TRITON_NVIDIA_EXPORTS}"
-      "LINKER:--exclude-libs,ALL")
+      "LINKER:--exclude-libs,ALL"
+      "LINKER:-z,defs")
 endif()
 
 install(TARGETS triton_nvidia_codegen

--- a/third_party/nvidia/backend/codegen/CMakeLists.txt
+++ b/third_party/nvidia/backend/codegen/CMakeLists.txt
@@ -1,0 +1,56 @@
+cmake_minimum_required(VERSION 3.20)
+
+project(triton_nvidia_codegen LANGUAGES C CXX)
+
+find_package(LLVM REQUIRED CONFIG)
+
+set(TRITON_NVIDIA_LLVM_REVISION "unknown" CACHE STRING
+    "Independently pinned NVIDIA LLVM revision and build number")
+
+add_library(triton_nvidia_codegen SHARED nvptx_codegen.cc)
+target_compile_features(triton_nvidia_codegen PRIVATE cxx_std_17)
+target_include_directories(triton_nvidia_codegen SYSTEM PRIVATE
+                           ${LLVM_INCLUDE_DIRS})
+target_compile_definitions(triton_nvidia_codegen PRIVATE
+    TRITON_NVIDIA_LLVM_REVISION="${TRITON_NVIDIA_LLVM_REVISION}")
+
+if(NOT LLVM_ENABLE_EH)
+  target_compile_options(triton_nvidia_codegen PRIVATE
+      $<$<CXX_COMPILER_ID:MSVC>:/EHs-c->
+      $<$<NOT:$<CXX_COMPILER_ID:MSVC>>:-fno-exceptions>)
+endif()
+if(NOT LLVM_ENABLE_RTTI)
+  target_compile_options(triton_nvidia_codegen PRIVATE
+      $<$<CXX_COMPILER_ID:MSVC>:/GR->
+      $<$<NOT:$<CXX_COMPILER_ID:MSVC>>:-fno-rtti>)
+endif()
+
+llvm_map_components_to_libnames(TRITON_NVIDIA_LLVM_LIBRARIES
+    NVPTXCodeGen NVPTXDesc NVPTXInfo
+    IRReader IPO ScalarOpts TransformUtils Analysis CodeGen Target Support)
+target_link_libraries(triton_nvidia_codegen PRIVATE
+                      ${TRITON_NVIDIA_LLVM_LIBRARIES})
+
+set_target_properties(triton_nvidia_codegen PROPERTIES
+    CXX_VISIBILITY_PRESET hidden
+    VISIBILITY_INLINES_HIDDEN YES
+    POSITION_INDEPENDENT_CODE ON)
+
+if(APPLE)
+  set(TRITON_NVIDIA_EXPORTS "${CMAKE_CURRENT_BINARY_DIR}/nvidia-codegen.exports")
+  file(GENERATE OUTPUT "${TRITON_NVIDIA_EXPORTS}" CONTENT
+      "_triton_nvptx_compile\n_triton_nvptx_free\n_triton_nvptx_revision\n")
+  target_link_options(triton_nvidia_codegen PRIVATE
+      "LINKER:-exported_symbols_list,${TRITON_NVIDIA_EXPORTS}")
+elseif(UNIX)
+  set(TRITON_NVIDIA_EXPORTS "${CMAKE_CURRENT_BINARY_DIR}/nvidia-codegen.exports")
+  file(GENERATE OUTPUT "${TRITON_NVIDIA_EXPORTS}" CONTENT
+      "{\n  global:\n    triton_nvptx_compile;\n    triton_nvptx_free;\n    triton_nvptx_revision;\n  local:\n    *;\n};\n")
+  target_link_options(triton_nvidia_codegen PRIVATE
+      "LINKER:--version-script,${TRITON_NVIDIA_EXPORTS}"
+      "LINKER:--exclude-libs,ALL")
+endif()
+
+install(TARGETS triton_nvidia_codegen
+        LIBRARY DESTINATION lib
+        RUNTIME DESTINATION lib)

--- a/third_party/nvidia/backend/codegen/nvptx_codegen.cc
+++ b/third_party/nvidia/backend/codegen/nvptx_codegen.cc
@@ -1,0 +1,243 @@
+#include "llvm/ADT/SmallString.h"
+#include "llvm/ADT/SmallVector.h"
+#include "llvm/Analysis/TargetTransformInfo.h"
+#include "llvm/IR/Attributes.h"
+#include "llvm/IR/Function.h"
+#include "llvm/IR/LLVMContext.h"
+#include "llvm/IR/LegacyPassManager.h"
+#include "llvm/IR/Module.h"
+#include "llvm/IR/PassTimingInfo.h"
+#include "llvm/IR/Verifier.h"
+#include "llvm/IRReader/IRReader.h"
+#include "llvm/InitializePasses.h"
+#include "llvm/MC/TargetRegistry.h"
+#include "llvm/PassRegistry.h"
+#include "llvm/Support/CommandLine.h"
+#include "llvm/Support/MemoryBuffer.h"
+#include "llvm/Support/Parallel.h"
+#include "llvm/Support/SourceMgr.h"
+#include "llvm/Support/TargetSelect.h"
+#include "llvm/Support/Threading.h"
+#include "llvm/Support/Timer.h"
+#include "llvm/Support/raw_ostream.h"
+#include "llvm/Target/TargetMachine.h"
+#include "llvm/Transforms/IPO/AlwaysInliner.h"
+#include "llvm/Transforms/Scalar.h"
+
+#include <cstddef>
+#include <cstdint>
+#include <cstdlib>
+#include <cstring>
+#include <memory>
+#include <mutex>
+#include <optional>
+#include <string>
+
+#if defined(_WIN32)
+#define TRITON_NVIDIA_EXPORT __declspec(dllexport)
+#else
+#define TRITON_NVIDIA_EXPORT __attribute__((visibility("default")))
+#endif
+
+namespace {
+
+constexpr uint32_t codegenABIVersion = 1;
+
+struct CodegenOptions {
+  uint32_t abiVersion;
+  const char *triple;
+  const char *processor;
+  const char *features;
+  const char *abi;
+  const char *disabledPasses;
+  uint8_t enableFPFusion;
+  uint8_t disableOptimization;
+  uint8_t canonicalizeGEP;
+  uint8_t dumpIR;
+  uint8_t enableTiming;
+};
+
+std::once_flag targetInitialization;
+
+bool setLLVMOption(llvm::StringRef name, bool value) {
+  auto options = llvm::cl::getRegisteredOptions();
+  auto option = options.find(name);
+  if (option == options.end())
+    return false;
+
+  auto *typedOption = static_cast<llvm::cl::opt<bool> *>(option->second);
+  bool previous = typedOption->getValue();
+  option->second->addOccurrence(1, name, value ? "true" : "false");
+  return previous;
+}
+
+char *copyString(llvm::StringRef value) {
+  auto *result = static_cast<char *>(std::malloc(value.size() + 1));
+  if (!result)
+    return nullptr;
+  std::memcpy(result, value.data(), value.size());
+  result[value.size()] = '\0';
+  return result;
+}
+
+int fail(const std::string &message, char **error) {
+  if (error)
+    *error = copyString(message);
+  return 1;
+}
+
+void initializeTarget() {
+  LLVMInitializeNVPTXTargetInfo();
+  LLVMInitializeNVPTXTarget();
+  LLVMInitializeNVPTXTargetMC();
+  LLVMInitializeNVPTXAsmPrinter();
+
+  llvm::PassRegistry &registry = *llvm::PassRegistry::getPassRegistry();
+  llvm::initializeCore(registry);
+  llvm::initializeCodeGen(registry);
+  llvm::initializeLoopStrengthReducePass(registry);
+  llvm::initializePostInlineEntryExitInstrumenterPass(registry);
+  llvm::initializeUnreachableBlockElimLegacyPassPass(registry);
+  llvm::initializeConstantHoistingLegacyPassPass(registry);
+  llvm::initializeScalarOpts(registry);
+  llvm::initializeIPO(registry);
+  llvm::initializeVectorization(registry);
+  llvm::initializeScalarizeMaskedMemIntrinLegacyPassPass(registry);
+  llvm::initializeTransformUtils(registry);
+
+  llvm::parallel::strategy = llvm::hardware_concurrency(1);
+  // Older NVPTX backends select 32-bit shared/local pointers through an LLVM
+  // command-line option rather than the target ABI. This LLVM copy is private,
+  // so options configured by libtriton do not propagate into this library.
+  setLLVMOption("nvptx-short-ptr", true);
+  setLLVMOption("nvptx-mad-wide-opt", true);
+}
+
+} // namespace
+
+extern "C" TRITON_NVIDIA_EXPORT int
+triton_nvptx_compile(const char *llvmIR, size_t llvmIRSize,
+                     const CodegenOptions *options, char **ptx, size_t *ptxSize,
+                     char **error) {
+  if (error)
+    *error = nullptr;
+  if (ptx)
+    *ptx = nullptr;
+  if (ptxSize)
+    *ptxSize = 0;
+
+  if (!llvmIR || !options || !ptx || !ptxSize)
+    return fail("invalid NVIDIA code-generation arguments", error);
+  if (options->abiVersion != codegenABIVersion)
+    return fail("incompatible NVIDIA code-generation ABI", error);
+  if (!options->triple || !options->processor || !options->features ||
+      !options->abi)
+    return fail("incomplete NVIDIA code-generation target options", error);
+
+  std::call_once(targetInitialization, initializeTarget);
+
+  if (options->dumpIR)
+    setLLVMOption("print-after-all", true);
+
+  if (options->disabledPasses && options->disabledPasses[0]) {
+    llvm::SmallVector<llvm::StringRef, 4> disabledPasses;
+    llvm::StringRef(options->disabledPasses).split(disabledPasses, ',');
+    for (llvm::StringRef pass : disabledPasses)
+      if (!pass.empty())
+        setLLVMOption(pass, true);
+  }
+
+  llvm::LLVMContext context;
+  llvm::SMDiagnostic diagnostic;
+  auto buffer = llvm::MemoryBuffer::getMemBuffer(
+      llvm::StringRef(llvmIR, llvmIRSize), "triton-nvidia-codegen", false);
+  auto module = llvm::parseIR(buffer->getMemBufferRef(), diagnostic, context);
+  if (!module) {
+    std::string message;
+    llvm::raw_string_ostream stream(message);
+    diagnostic.print("triton-nvidia-codegen", stream);
+    return fail(message, error);
+  }
+
+  module->setTargetTriple(llvm::Triple(options->triple));
+  std::string targetError;
+  const llvm::Target *target = llvm::TargetRegistry::lookupTarget(
+      module->getTargetTriple(), targetError);
+  if (!target)
+    return fail(targetError, error);
+
+  llvm::TargetOptions targetOptions;
+  if (options->enableFPFusion)
+    targetOptions.AllowFPOpFusion = llvm::FPOpFusion::Fast;
+  targetOptions.TrapUnreachable = true;
+  targetOptions.MCOptions.AsmVerbose = true;
+  targetOptions.MCOptions.PreserveAsmComments = true;
+  targetOptions.MCOptions.ABIName = options->abi;
+
+  std::unique_ptr<llvm::TargetMachine> machine(target->createTargetMachine(
+      module->getTargetTriple(), options->processor, options->features,
+      targetOptions, llvm::Reloc::PIC_, std::nullopt,
+      options->disableOptimization ? llvm::CodeGenOptLevel::None
+                                   : llvm::CodeGenOptLevel::Aggressive));
+  if (!machine)
+    return fail("failed to create NVIDIA target machine", error);
+  module->setDataLayout(machine->createDataLayout());
+
+  for (llvm::Function &function : module->functions())
+    if (!function.hasFnAttribute(llvm::Attribute::NoInline))
+      function.addFnAttr(llvm::Attribute::AlwaysInline);
+
+  llvm::legacy::PassManager inlinePasses;
+  inlinePasses.add(llvm::createTargetTransformInfoWrapperPass(
+      machine->getTargetIRAnalysis()));
+  inlinePasses.add(llvm::createAlwaysInlinerLegacyPass());
+  inlinePasses.add(llvm::createVerifierPass());
+
+  if (options->enableTiming) {
+    llvm::TimePassesIsEnabled = true;
+    llvm::TimePassesPerRun = true;
+  }
+
+  inlinePasses.run(*module);
+
+  if (options->canonicalizeGEP && !options->disableOptimization) {
+    llvm::legacy::PassManager cleanup;
+    cleanup.add(llvm::createTargetTransformInfoWrapperPass(
+        machine->getTargetIRAnalysis()));
+    cleanup.add(llvm::createSeparateConstOffsetFromGEPPass());
+    cleanup.add(llvm::createEarlyCSEPass());
+    cleanup.run(*module);
+  }
+
+  std::string assembly;
+  {
+    llvm::raw_string_ostream output(assembly);
+    llvm::buffer_ostream bufferedOutput(output);
+    llvm::legacy::PassManager codegen;
+    if (machine->addPassesToEmitFile(codegen, bufferedOutput, nullptr,
+                                     llvm::CodeGenFileType::AssemblyFile))
+      return fail("NVIDIA target cannot emit PTX assembly", error);
+    codegen.run(*module);
+  }
+
+  if (options->enableTiming) {
+    llvm::SmallString<0> timings;
+    llvm::raw_svector_ostream stream(timings);
+    llvm::reportAndResetTimings(&stream);
+    llvm::dbgs() << stream.str();
+  }
+
+  *ptx = copyString(assembly);
+  if (!*ptx)
+    return fail("failed to allocate NVIDIA PTX result", error);
+  *ptxSize = assembly.size();
+  return 0;
+}
+
+extern "C" TRITON_NVIDIA_EXPORT void triton_nvptx_free(void *pointer) {
+  std::free(pointer);
+}
+
+extern "C" TRITON_NVIDIA_EXPORT const char *triton_nvptx_revision() {
+  return TRITON_NVIDIA_LLVM_REVISION;
+}

--- a/third_party/nvidia/backend/compiler.py
+++ b/third_party/nvidia/backend/compiler.py
@@ -97,7 +97,9 @@ def compile_nvptx(src: str, triple: str, processor: str, features: str, *, enabl
                   disable_optimization: bool, canonicalize_gep: bool, disabled_passes: str, dump_ir: bool,
                   enable_timing: bool) -> str:
     library = _load_nvidia_codegen(get_nvidia_codegen_path())
-    llvm_ir = src.encode("utf-8")
+    # Serialize with Triton's LLVM: newer backends support older bitcode,
+    # whereas textual IR has no backwards-compatibility guarantee.
+    llvm_bitcode = llvm.to_bitcode(src)
     options = _NVPTXCodegenOptions(
         1,
         triple.encode("utf-8"),
@@ -114,7 +116,7 @@ def compile_nvptx(src: str, triple: str, processor: str, features: str, *, enabl
     ptx = ctypes.c_void_p()
     ptx_size = ctypes.c_size_t()
     error = ctypes.c_void_p()
-    status = library.triton_nvptx_compile(llvm_ir, len(llvm_ir), ctypes.byref(options), ctypes.byref(ptx),
+    status = library.triton_nvptx_compile(llvm_bitcode, len(llvm_bitcode), ctypes.byref(options), ctypes.byref(ptx),
                                           ctypes.byref(ptx_size), ctypes.byref(error))
     if status:
         message = ctypes.string_at(error).decode("utf-8") if error.value else "unknown NVIDIA code-generation failure"

--- a/third_party/nvidia/backend/compiler.py
+++ b/third_party/nvidia/backend/compiler.py
@@ -4,6 +4,7 @@ from triton import knobs
 from triton.runtime.errors import PTXASError
 
 from dataclasses import dataclass
+import ctypes
 import functools
 from typing import Any, Dict, Tuple, Optional
 from types import ModuleType
@@ -13,6 +14,7 @@ import tempfile
 import signal
 import os
 import subprocess
+import sys
 from pathlib import Path
 
 
@@ -37,6 +39,93 @@ def min_dot_size(target: GPUTarget):
 
 def get_ptxas(arch: int) -> knobs.NvidiaTool:
     return knobs.nvidia.ptxas_blackwell if arch >= 100 else knobs.nvidia.ptxas
+
+
+def get_nvidia_codegen_path() -> str:
+    if knobs.nvidia.codegen_path is not None:
+        return knobs.nvidia.codegen_path
+    if os.name == "nt":
+        library = "triton_nvidia_codegen.dll"
+    elif sys.platform == "darwin":
+        library = "libtriton_nvidia_codegen.dylib"
+    else:
+        library = "libtriton_nvidia_codegen.so"
+    return str(Path(__file__).parent / "lib" / library)
+
+
+class _NVPTXCodegenOptions(ctypes.Structure):
+    _fields_ = [
+        ("abi_version", ctypes.c_uint32),
+        ("triple", ctypes.c_char_p),
+        ("processor", ctypes.c_char_p),
+        ("features", ctypes.c_char_p),
+        ("abi", ctypes.c_char_p),
+        ("disabled_passes", ctypes.c_char_p),
+        ("enable_fp_fusion", ctypes.c_uint8),
+        ("disable_optimization", ctypes.c_uint8),
+        ("canonicalize_gep", ctypes.c_uint8),
+        ("dump_ir", ctypes.c_uint8),
+        ("enable_timing", ctypes.c_uint8),
+    ]
+
+
+@functools.lru_cache()
+def _load_nvidia_codegen(path: str):
+    mode = getattr(os, "RTLD_LOCAL", 0) | getattr(os, "RTLD_NOW", 0)
+    library = ctypes.CDLL(path, mode=mode)
+    library.triton_nvptx_compile.argtypes = [
+        ctypes.c_char_p,
+        ctypes.c_size_t,
+        ctypes.POINTER(_NVPTXCodegenOptions),
+        ctypes.POINTER(ctypes.c_void_p),
+        ctypes.POINTER(ctypes.c_size_t),
+        ctypes.POINTER(ctypes.c_void_p),
+    ]
+    library.triton_nvptx_compile.restype = ctypes.c_int
+    library.triton_nvptx_free.argtypes = [ctypes.c_void_p]
+    library.triton_nvptx_free.restype = None
+    library.triton_nvptx_revision.argtypes = []
+    library.triton_nvptx_revision.restype = ctypes.c_char_p
+    return library
+
+
+def get_nvidia_codegen_revision() -> str:
+    return _load_nvidia_codegen(get_nvidia_codegen_path()).triton_nvptx_revision().decode("utf-8")
+
+
+def compile_nvptx(src: str, triple: str, processor: str, features: str, *, enable_fp_fusion: bool,
+                  disable_optimization: bool, canonicalize_gep: bool, disabled_passes: str, dump_ir: bool,
+                  enable_timing: bool) -> str:
+    library = _load_nvidia_codegen(get_nvidia_codegen_path())
+    llvm_ir = src.encode("utf-8")
+    options = _NVPTXCodegenOptions(
+        1,
+        triple.encode("utf-8"),
+        processor.encode("utf-8"),
+        features.encode("utf-8"),
+        b"shortptr",
+        disabled_passes.encode("utf-8"),
+        enable_fp_fusion,
+        disable_optimization,
+        canonicalize_gep,
+        dump_ir,
+        enable_timing,
+    )
+    ptx = ctypes.c_void_p()
+    ptx_size = ctypes.c_size_t()
+    error = ctypes.c_void_p()
+    status = library.triton_nvptx_compile(llvm_ir, len(llvm_ir), ctypes.byref(options), ctypes.byref(ptx),
+                                          ctypes.byref(ptx_size), ctypes.byref(error))
+    if status:
+        message = ctypes.string_at(error).decode("utf-8") if error.value else "unknown NVIDIA code-generation failure"
+        if error.value:
+            library.triton_nvptx_free(error)
+        revision = library.triton_nvptx_revision().decode("utf-8")
+        raise RuntimeError(f"NVIDIA LLVM {revision}: {message}")
+    try:
+        return ctypes.string_at(ptx, ptx_size.value).decode("utf-8")
+    finally:
+        library.triton_nvptx_free(ptx)
 
 
 @functools.lru_cache()
@@ -532,10 +621,26 @@ class CUDABackend(BaseBackend):
 
         proc = sm_arch_from_capability(cap_llvm)
         features = get_features(opt, cap_llvm)
-        flags = ["nvptx-mad-wide-opt"]
         canonicalize_gep = "fpsan" in opt.instrumentation_mode
-        ret = llvm.translate_to_asm(src, triple, proc, features, flags, opt.enable_fp_fusion, False, canonicalize_gep,
-                                    "shortptr")
+        disable_llvm_opt = knobs.getenv_bool("DISABLE_LLVM_OPT", False)
+        disabled_passes = ""
+        if not disable_llvm_opt:
+            requested_passes = os.environ.get("DISABLE_LLVM_OPT", "")
+            if requested_passes.lower() not in {"0", "false", "off"}:
+                disabled_passes = requested_passes
+
+        ret = compile_nvptx(
+            src,
+            triple,
+            proc,
+            features,
+            enable_fp_fusion=opt.enable_fp_fusion,
+            disable_optimization=disable_llvm_opt,
+            canonicalize_gep=canonicalize_gep,
+            disabled_passes=disabled_passes,
+            dump_ir=knobs.getenv_bool("LLVM_IR_ENABLE_DUMP", False),
+            enable_timing=knobs.getenv_bool("LLVM_ENABLE_TIMING", False),
+        )
         # Find kernel names (there should only be one)
         names = re.findall(r".visible .entry ([a-zA-Z_][a-zA-Z0-9_]*)", ret)
         assert len(names) == 1
@@ -655,4 +760,4 @@ please share the reproducer above with Triton project.
     @functools.lru_cache()
     def hash(self):
         version = get_ptxas_version(self.target.arch)
-        return f'{version}-{self.target.arch}'
+        return f'{version}-{self.target.arch}-{get_nvidia_codegen_revision()}'


### PR DESCRIPTION
NVPTX code generation currently shares Triton's core LLVM pin. This PR packages it in a shared library built with its own pinned LLVM, allowing backend updates without changing core LLVM or starting a subprocess.

Core LLVM passes serialized bitcode to the backend, which should use the same or a newer LLVM. The library links LLVM statically and exports only its C ABI. Bootstrap builds use the LLVM SDK pinned in the NVIDIA manifest and a separate cache; they do not read the core LLVM manifest or use LLVM_SYSPATH. Target options, short shared-memory pointers, readable LLVM IR dumps, and revision-based cache invalidation are preserved.

Verified an isolated build without core LLVM configuration, standalone loading, rejection of shared LLVM dependencies, and 30 focused tests. Nine kernels produce identical PTX with text and bitcode transport, including LLVM 23 bitcode read by LLVM 24. The bitcode update was checked locally through PTX; end-to-end NVIDIA timing including ptxas was not remeasured because the previous benchmark environment was unavailable.
