### PR TITLE
[AMD] Use hardware cvt instructions for OCP fp8 casts on gfx1170

### DIFF
--- a/test/Conversion/amd/ocp_fp8_cvt_lowering.mlir
+++ b/test/Conversion/amd/ocp_fp8_cvt_lowering.mlir
@@ -1,0 +1,285 @@
+// RUN: triton-opt %s --split-input-file --convert-triton-amdgpu-to-llvm=gfx-arch=gfx1170 | FileCheck --check-prefixes=COMMON,HWCVT %s
+// RUN: triton-opt %s --split-input-file --convert-triton-amdgpu-to-llvm=gfx-arch=gfx1100 | FileCheck --check-prefixes=COMMON,NOHW %s
+// RUN: triton-opt %s --split-input-file --convert-triton-amdgpu-to-llvm=gfx-arch=gfx1200 | FileCheck --check-prefixes=COMMON,NOHW %s
+
+// Whether OCP fp8 (f8E4M3FN / f8E5M2) casts lower to the hardware cvt
+// instructions or to the software bit-manipulation fallback, per target. COMMON
+// covers the fp16/bf16 <-> fp32 casts, which take the same scalar LLVM path
+// everywhere.
+//
+// HWCVT (gfx1170) has the *plain* v_cvt_pk_{f32_fp8,f32_bf8,fp8_f32,bf8_f32}
+// ops, which encode OCP on that target, but not the scaled ops CDNA4 and
+// gfx1250 use: expect rocdl.cvt.pk.*, not rocdl.cvt.scalef32.pk.*. There is no
+// plain 16-bit-source op, so f16/bf16 casts hop through f32; both hops are
+// lossless here, leaving the hardware op as the only rounding site.
+//
+// NOHW keeps the software fallback, so the hardware path cannot leak onto a
+// target that fails to run it. gfx1100/RDNA3 lacks the instructions outright;
+// gfx1200/RDNA4 has them, but its packed upcast prints without the .l/.h suffix
+// the assembler needs in gfx12's default real-true16 mode (LCOMPILER-2609).
+
+// COMMON-LABEL: f16_to_f32
+#blocked = #ttg.blocked<{sizePerThread = [1, 8], threadsPerWarp = [4, 8], warpsPerCTA = [4, 1], order = [1, 0]}>
+module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, "ttg.threads-per-warp" = 32 : i32} {
+  tt.func @f16_to_f32(%arg0: tensor<8x8xf16, #ttg.dot_op<{opIdx = 0, parent = #blocked}>>) {
+    // COMMON-COUNT-8: llvm.fpext %{{.+}} : f16 to f32
+    %0 = tt.fp_to_fp %arg0 : tensor<8x8xf16, #ttg.dot_op<{opIdx = 0, parent = #blocked}>> -> tensor<8x8xf32, #ttg.dot_op<{opIdx = 0, parent = #blocked}>>
+    tt.return
+  }
+}
+
+// -----
+
+// COMMON-LABEL: f32_to_f16
+#blocked = #ttg.blocked<{sizePerThread = [1, 8], threadsPerWarp = [4, 8], warpsPerCTA = [4, 1], order = [1, 0]}>
+module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, "ttg.threads-per-warp" = 32 : i32} {
+  tt.func @f32_to_f16(%arg0: tensor<8x8xf32, #ttg.dot_op<{opIdx = 0, parent = #blocked}>>) {
+    // rtne: scalar fptrunc.
+    // COMMON-COUNT-8: llvm.fptrunc %{{.+}} : f32 to f16
+    %0 = tt.fp_to_fp %arg0, rounding = rtne : tensor<8x8xf32, #ttg.dot_op<{opIdx = 0, parent = #blocked}>> -> tensor<8x8xf16, #ttg.dot_op<{opIdx = 0, parent = #blocked}>>
+    // rtz: packed round-to-zero conversion.
+    // COMMON-COUNT-4: rocdl.cvt.pkrtz
+    %1 = tt.fp_to_fp %arg0, rounding = rtz : tensor<8x8xf32, #ttg.dot_op<{opIdx = 0, parent = #blocked}>> -> tensor<8x8xf16, #ttg.dot_op<{opIdx = 0, parent = #blocked}>>
+    tt.return
+  }
+}
+
+// -----
+
+// f32 -> OCP fp8/bf8, RTNE. Each group of 4 elements becomes two packed
+// converts, chained through the `old` operand so the second call fills the
+// other half of the same dword. 8 elements per thread => 4 converts.
+
+// COMMON-LABEL: downcast_f32_to_ocp_f8
+#blocked = #ttg.blocked<{sizePerThread = [1, 8], threadsPerWarp = [4, 8], warpsPerCTA = [4, 1], order = [1, 0]}>
+module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, "ttg.threads-per-warp" = 32 : i32} {
+  tt.func @downcast_f32_to_ocp_f8(%arg0: tensor<8x8xf32, #ttg.dot_op<{opIdx = 0, parent = #blocked}>>) {
+    // HWCVT: %[[P0:.*]] = rocdl.cvt.pk.fp8.f32 %{{.*}}, %{{.*}} -> %{{.*}}[false]
+    // HWCVT: rocdl.cvt.pk.fp8.f32 %{{.*}}, %{{.*}} -> %[[P0]][true]
+    // HWCVT: %[[P1:.*]] = rocdl.cvt.pk.fp8.f32 %{{.*}}, %{{.*}} -> %{{.*}}[false]
+    // HWCVT: rocdl.cvt.pk.fp8.f32 %{{.*}}, %{{.*}} -> %[[P1]][true]
+    // NOHW-NOT: rocdl.cvt.pk.fp8.f32
+    %0 = tt.fp_to_fp %arg0, rounding = rtne : tensor<8x8xf32, #ttg.dot_op<{opIdx = 0, parent = #blocked}>> -> tensor<8x8xf8E4M3FN, #ttg.dot_op<{opIdx = 0, parent = #blocked}>>
+    tt.return
+  }
+}
+
+// -----
+
+// COMMON-LABEL: downcast_f32_to_ocp_bf8
+#blocked = #ttg.blocked<{sizePerThread = [1, 8], threadsPerWarp = [4, 8], warpsPerCTA = [4, 1], order = [1, 0]}>
+module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, "ttg.threads-per-warp" = 32 : i32} {
+  tt.func @downcast_f32_to_ocp_bf8(%arg0: tensor<8x8xf32, #ttg.dot_op<{opIdx = 0, parent = #blocked}>>) {
+    // HWCVT: %[[P0:.*]] = rocdl.cvt.pk.bf8.f32 %{{.*}}, %{{.*}} -> %{{.*}}[false]
+    // HWCVT: rocdl.cvt.pk.bf8.f32 %{{.*}}, %{{.*}} -> %[[P0]][true]
+    // HWCVT: %[[P1:.*]] = rocdl.cvt.pk.bf8.f32 %{{.*}}, %{{.*}} -> %{{.*}}[false]
+    // HWCVT: rocdl.cvt.pk.bf8.f32 %{{.*}}, %{{.*}} -> %[[P1]][true]
+    // NOHW-NOT: rocdl.cvt.pk.bf8.f32
+    %0 = tt.fp_to_fp %arg0, rounding = rtne : tensor<8x8xf32, #ttg.dot_op<{opIdx = 0, parent = #blocked}>> -> tensor<8x8xf8E5M2, #ttg.dot_op<{opIdx = 0, parent = #blocked}>>
+    tt.return
+  }
+}
+
+// -----
+
+// f16/bf16 -> OCP fp8/bf8, RTNE. No plain 16-bit-source op exists, so these
+// widen to f32 first and then use the same packed downcast.
+
+// COMMON-LABEL: downcast_16bit_to_ocp_f8
+#blocked = #ttg.blocked<{sizePerThread = [1, 8], threadsPerWarp = [4, 8], warpsPerCTA = [4, 1], order = [1, 0]}>
+module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, "ttg.threads-per-warp" = 32 : i32} {
+  tt.func @downcast_16bit_to_ocp_f8(%arg0: tensor<8x8xf16, #ttg.dot_op<{opIdx = 0, parent = #blocked}>>,
+                                  %arg1: tensor<8x8xbf16, #ttg.dot_op<{opIdx = 0, parent = #blocked}>>) {
+    // Converters run one group of 4 elements at a time, so the widening and the
+    // packed converts interleave per group rather than being hoisted.
+    // HWCVT-COUNT-4: llvm.fpext %{{.+}} : f16 to f32
+    // HWCVT-COUNT-2: rocdl.cvt.pk.fp8.f32
+    // HWCVT-COUNT-4: llvm.fpext %{{.+}} : f16 to f32
+    // HWCVT-COUNT-2: rocdl.cvt.pk.fp8.f32
+    // NOHW-NOT: rocdl.cvt.pk.fp8.f32
+    %0 = tt.fp_to_fp %arg0, rounding = rtne : tensor<8x8xf16, #ttg.dot_op<{opIdx = 0, parent = #blocked}>> -> tensor<8x8xf8E4M3FN, #ttg.dot_op<{opIdx = 0, parent = #blocked}>>
+
+    // HWCVT-COUNT-4: rocdl.cvt.pk.bf8.f32
+    // NOHW-NOT: rocdl.cvt.pk.bf8.f32
+    %1 = tt.fp_to_fp %arg0, rounding = rtne : tensor<8x8xf16, #ttg.dot_op<{opIdx = 0, parent = #blocked}>> -> tensor<8x8xf8E5M2, #ttg.dot_op<{opIdx = 0, parent = #blocked}>>
+
+    // HWCVT-COUNT-4: rocdl.cvt.pk.fp8.f32
+    // NOHW-NOT: rocdl.cvt.pk.fp8.f32
+    %2 = tt.fp_to_fp %arg1, rounding = rtne : tensor<8x8xbf16, #ttg.dot_op<{opIdx = 0, parent = #blocked}>> -> tensor<8x8xf8E4M3FN, #ttg.dot_op<{opIdx = 0, parent = #blocked}>>
+
+    // HWCVT-COUNT-4: rocdl.cvt.pk.bf8.f32
+    // NOHW-NOT: rocdl.cvt.pk.bf8.f32
+    %3 = tt.fp_to_fp %arg1, rounding = rtne : tensor<8x8xbf16, #ttg.dot_op<{opIdx = 0, parent = #blocked}>> -> tensor<8x8xf8E5M2, #ttg.dot_op<{opIdx = 0, parent = #blocked}>>
+    tt.return
+  }
+}
+
+// -----
+
+// OCP fp8/bf8 -> f32. Two packed upcasts per group of 4, both reading the same
+// source dword and selecting opposite halves via wordSel.
+
+// COMMON-LABEL: upcast_ocp_f8_to_f32
+#blocked = #ttg.blocked<{sizePerThread = [1, 8], threadsPerWarp = [4, 8], warpsPerCTA = [4, 1], order = [1, 0]}>
+module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, "ttg.threads-per-warp" = 32 : i32} {
+  tt.func @upcast_ocp_f8_to_f32(%arg0: tensor<8x8xf8E4M3FN, #ttg.dot_op<{opIdx = 0, parent = #blocked}>>) {
+    // HWCVT: rocdl.cvt.pk.f32.fp8 %[[V0:.*]][false]
+    // HWCVT: rocdl.cvt.pk.f32.fp8 %[[V0]][true]
+    // HWCVT: rocdl.cvt.pk.f32.fp8 %[[V1:.*]][false]
+    // HWCVT: rocdl.cvt.pk.f32.fp8 %[[V1]][true]
+    // NOHW-NOT: rocdl.cvt.pk.f32.fp8
+    %0 = tt.fp_to_fp %arg0 : tensor<8x8xf8E4M3FN, #ttg.dot_op<{opIdx = 0, parent = #blocked}>> -> tensor<8x8xf32, #ttg.dot_op<{opIdx = 0, parent = #blocked}>>
+    tt.return
+  }
+}
+
+// -----
+
+// COMMON-LABEL: upcast_ocp_bf8_to_f32
+#blocked = #ttg.blocked<{sizePerThread = [1, 8], threadsPerWarp = [4, 8], warpsPerCTA = [4, 1], order = [1, 0]}>
+module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, "ttg.threads-per-warp" = 32 : i32} {
+  tt.func @upcast_ocp_bf8_to_f32(%arg0: tensor<8x8xf8E5M2, #ttg.dot_op<{opIdx = 0, parent = #blocked}>>) {
+    // HWCVT: rocdl.cvt.pk.f32.bf8 %[[V0:.*]][false]
+    // HWCVT: rocdl.cvt.pk.f32.bf8 %[[V0]][true]
+    // HWCVT: rocdl.cvt.pk.f32.bf8 %[[V1:.*]][false]
+    // HWCVT: rocdl.cvt.pk.f32.bf8 %[[V1]][true]
+    // NOHW-NOT: rocdl.cvt.pk.f32.bf8
+    %0 = tt.fp_to_fp %arg0 : tensor<8x8xf8E5M2, #ttg.dot_op<{opIdx = 0, parent = #blocked}>> -> tensor<8x8xf32, #ttg.dot_op<{opIdx = 0, parent = #blocked}>>
+    tt.return
+  }
+}
+
+// -----
+
+// OCP fp8/bf8 -> f16/bf16. Packed upcast to f32, then narrow. Every OCP fp8
+// value is exactly representable in both f16 and bf16, so the narrowing step
+// cannot introduce error.
+
+// COMMON-LABEL: upcast_ocp_f8_to_16bit
+#blocked = #ttg.blocked<{sizePerThread = [1, 8], threadsPerWarp = [4, 8], warpsPerCTA = [4, 1], order = [1, 0]}>
+module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, "ttg.threads-per-warp" = 32 : i32} {
+  tt.func @upcast_ocp_f8_to_16bit(%arg0: tensor<8x8xf8E4M3FN, #ttg.dot_op<{opIdx = 0, parent = #blocked}>>,
+                                  %arg1: tensor<8x8xf8E5M2, #ttg.dot_op<{opIdx = 0, parent = #blocked}>>) {
+    // Per group of 4: two packed upcasts, then four narrowing truncs.
+    // HWCVT-COUNT-2: rocdl.cvt.pk.f32.fp8
+    // HWCVT-COUNT-4: llvm.fptrunc %{{.+}} : f32 to f16
+    // HWCVT-COUNT-2: rocdl.cvt.pk.f32.fp8
+    // HWCVT-COUNT-4: llvm.fptrunc %{{.+}} : f32 to f16
+    // NOHW-NOT: rocdl.cvt.pk.f32.fp8
+    %0 = tt.fp_to_fp %arg0 : tensor<8x8xf8E4M3FN, #ttg.dot_op<{opIdx = 0, parent = #blocked}>> -> tensor<8x8xf16, #ttg.dot_op<{opIdx = 0, parent = #blocked}>>
+
+    // HWCVT-COUNT-4: rocdl.cvt.pk.f32.bf8
+    // NOHW-NOT: rocdl.cvt.pk.f32.bf8
+    %1 = tt.fp_to_fp %arg1 : tensor<8x8xf8E5M2, #ttg.dot_op<{opIdx = 0, parent = #blocked}>> -> tensor<8x8xf16, #ttg.dot_op<{opIdx = 0, parent = #blocked}>>
+
+    // HWCVT-COUNT-4: rocdl.cvt.pk.f32.fp8
+    // NOHW-NOT: rocdl.cvt.pk.f32.fp8
+    %2 = tt.fp_to_fp %arg0 : tensor<8x8xf8E4M3FN, #ttg.dot_op<{opIdx = 0, parent = #blocked}>> -> tensor<8x8xbf16, #ttg.dot_op<{opIdx = 0, parent = #blocked}>>
+
+    // HWCVT-COUNT-4: rocdl.cvt.pk.f32.bf8
+    // NOHW-NOT: rocdl.cvt.pk.f32.bf8
+    %3 = tt.fp_to_fp %arg1 : tensor<8x8xf8E5M2, #ttg.dot_op<{opIdx = 0, parent = #blocked}>> -> tensor<8x8xbf16, #ttg.dot_op<{opIdx = 0, parent = #blocked}>>
+    tt.return
+  }
+}
+
+// -----
+
+// The plain hardware downcast is round-to-nearest-even only, so RTZ requests
+// must stay on the software path even on HWCVT targets. Guards against a future
+// change wiring RTZ to the RTNE instruction.
+
+// COMMON-LABEL: downcast_rtz_stays_software
+#blocked = #ttg.blocked<{sizePerThread = [1, 8], threadsPerWarp = [4, 8], warpsPerCTA = [4, 1], order = [1, 0]}>
+module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, "ttg.threads-per-warp" = 32 : i32} {
+  tt.func @downcast_rtz_stays_software(%arg0: tensor<8x8xf32, #ttg.dot_op<{opIdx = 0, parent = #blocked}>>,
+                                       %arg1: tensor<8x8xf16, #ttg.dot_op<{opIdx = 0, parent = #blocked}>>) {
+    // COMMON-NOT: rocdl.cvt.pk.bf8.f32
+    // COMMON-COUNT-4: rocdl.cvt.pkrtz
+    %0 = tt.fp_to_fp %arg0, rounding = rtz : tensor<8x8xf32, #ttg.dot_op<{opIdx = 0, parent = #blocked}>> -> tensor<8x8xf8E5M2, #ttg.dot_op<{opIdx = 0, parent = #blocked}>>
+    // COMMON-NOT: rocdl.cvt.pk.bf8.f32
+    %1 = tt.fp_to_fp %arg1, rounding = rtz : tensor<8x8xf16, #ttg.dot_op<{opIdx = 0, parent = #blocked}>> -> tensor<8x8xf8E5M2, #ttg.dot_op<{opIdx = 0, parent = #blocked}>>
+    tt.return
+  }
+}
+
+// -----
+
+// A layout that leaves a single fp8 value per thread upcasts with the scalar
+// converter rather than the packed one. The packed op would need the value
+// padded out with undef and would discard three quarters of its result.
+
+// COMMON-LABEL: single_element_upcast_is_scalar
+#blocked = #ttg.blocked<{sizePerThread = [1], threadsPerWarp = [32], warpsPerCTA = [4], order = [0]}>
+module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, "ttg.threads-per-warp" = 32 : i32} {
+  tt.func @single_element_upcast_is_scalar(%arg0: tensor<128xf8E4M3FN, #blocked>,
+                                           %arg1: tensor<128xf8E5M2, #blocked>) {
+    // HWCVT-COUNT-1: rocdl.cvt.f32.fp8
+    // HWCVT-NOT: rocdl.cvt.pk.f32.fp8
+    // NOHW-NOT: rocdl.cvt.f32.fp8
+    %0 = tt.fp_to_fp %arg0 : tensor<128xf8E4M3FN, #blocked> -> tensor<128xf32, #blocked>
+
+    // HWCVT-COUNT-1: rocdl.cvt.f32.bf8
+    // HWCVT-NOT: rocdl.cvt.pk.f32.bf8
+    // NOHW-NOT: rocdl.cvt.f32.bf8
+    %1 = tt.fp_to_fp %arg1 : tensor<128xf8E5M2, #blocked> -> tensor<128xf32, #blocked>
+    tt.return
+  }
+}
+
+// -----
+
+// Two values per thread still use the packed converter: only the single-value
+// case is special-cased, so this pins the boundary.
+
+// COMMON-LABEL: two_element_upcast_stays_packed
+#blocked = #ttg.blocked<{sizePerThread = [2], threadsPerWarp = [32], warpsPerCTA = [4], order = [0]}>
+module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, "ttg.threads-per-warp" = 32 : i32} {
+  tt.func @two_element_upcast_stays_packed(%arg0: tensor<256xf8E4M3FN, #blocked>) {
+    // HWCVT-NOT: rocdl.cvt.f32.fp8
+    // HWCVT-COUNT-2: rocdl.cvt.pk.f32.fp8
+    %0 = tt.fp_to_fp %arg0 : tensor<256xf8E4M3FN, #blocked> -> tensor<256xf32, #blocked>
+    tt.return
+  }
+}
+
+// -----
+
+// The scalar converter is used only for an f32 destination. A single fp8 value
+// headed for f16/bf16 keeps the packed upcast, which here still discards three
+// quarters of its result: there is no plain op landing directly in 16 bits, so
+// the f32 intermediate is needed either way.
+
+// COMMON-LABEL: single_element_upcast_to_16bit_stays_packed
+#blocked = #ttg.blocked<{sizePerThread = [1], threadsPerWarp = [32], warpsPerCTA = [4], order = [0]}>
+module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, "ttg.threads-per-warp" = 32 : i32} {
+  tt.func @single_element_upcast_to_16bit_stays_packed(%arg0: tensor<128xf8E4M3FN, #blocked>,
+                                                      %arg1: tensor<128xf8E5M2, #blocked>) {
+    // HWCVT-NOT: rocdl.cvt.f32.fp8
+    // HWCVT-COUNT-2: rocdl.cvt.pk.f32.fp8
+    %0 = tt.fp_to_fp %arg0 : tensor<128xf8E4M3FN, #blocked> -> tensor<128xf16, #blocked>
+
+    // HWCVT-NOT: rocdl.cvt.f32.bf8
+    // HWCVT-COUNT-2: rocdl.cvt.pk.f32.bf8
+    %1 = tt.fp_to_fp %arg1 : tensor<128xf8E5M2, #blocked> -> tensor<128xbf16, #blocked>
+    tt.return
+  }
+}
+
+// -----
+
+// FNUZ fp8 is the gfx942 encoding. These targets have no FNUZ hardware, so the
+// plain ops must not be selected for it even though the mnemonics match.
+
+// COMMON-LABEL: fnuz_stays_software
+#blocked = #ttg.blocked<{sizePerThread = [1, 8], threadsPerWarp = [4, 8], warpsPerCTA = [4, 1], order = [1, 0]}>
+module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, "ttg.threads-per-warp" = 32 : i32} {
+  tt.func @fnuz_stays_software(%arg0: tensor<8x8xf32, #ttg.dot_op<{opIdx = 0, parent = #blocked}>>,
+                               %arg1: tensor<8x8xf8E4M3FNUZ, #ttg.dot_op<{opIdx = 0, parent = #blocked}>>) {
+    // COMMON-NOT: rocdl.cvt.pk.fp8.f32
+    %0 = tt.fp_to_fp %arg0, rounding = rtne : tensor<8x8xf32, #ttg.dot_op<{opIdx = 0, parent = #blocked}>> -> tensor<8x8xf8E4M3FNUZ, #ttg.dot_op<{opIdx = 0, parent = #blocked}>>
+    // COMMON-NOT: rocdl.cvt.pk.f32.fp8
+    %1 = tt.fp_to_fp %arg1 : tensor<8x8xf8E4M3FNUZ, #ttg.dot_op<{opIdx = 0, parent = #blocked}>> -> tensor<8x8xf32, #ttg.dot_op<{opIdx = 0, parent = #blocked}>>
+    tt.return
+  }
+}

--- a/third_party/amd/lib/TritonAMDGPUToLLVM/ConvertFpCastOpToLLVM.cpp
+++ b/third_party/amd/lib/TritonAMDGPUToLLVM/ConvertFpCastOpToLLVM.cpp
@@ -40,6 +40,14 @@ namespace {
 bool isCDNA4OrHigher(ISAFamily family) {
   return family == ISAFamily::CDNA4 || family == ISAFamily::GFX1250;
 }
+// List of architectures that have hardware support for OCP fp8 formats via the
+// *plain* cvt instructions, i.e. v_cvt_pk_{f32_fp8,f32_bf8,fp8_f32,bf8_f32},
+// rather than the scaled ops CDNA4 and gfx1250 use.
+// TODO(LCOMPILER-2609): add RDNA4 once the LLVM bug is fixed. RDNA4 has the
+// instructions, but v_cvt_pk_f32_fp8/bf8 is selected as its fake16 form and
+// printed without a .l/.h suffix, which the assembler rejects in the
+// real-true16 mode gfx12 defaults to.
+bool hasPlainOcpFp8HW(ISAFamily family) { return family == ISAFamily::RDNA4m; }
 // List of architectures that have hardware support for FNUZ fp8 formats. On
 // those architectures we will use the HW instructions to do the conversion
 // instead of the software fallback.
@@ -399,7 +407,8 @@ SmallVector<Value> scalePk8UpcastFromFp8(Location loc,
   return ret;
 }
 
-// Convert Bf8/Fp8 to Fp32 on CDNA3
+// Convert four packed 8-bit floating-point values to four Fp32 values
+// ConvertOp chooses Fp8 versus Bf8; target dispatch chooses OCP versus FNUZ.
 template <typename ConvertOp>
 SmallVector<Value> PkF4ToFp32(Location loc, ConversionPatternRewriter &rewriter,
                               const SmallVector<Value> &v) {
@@ -790,7 +799,8 @@ Value Fp16ToFp32OneValue(Location loc, ConversionPatternRewriter &rewriter,
   return b.fpext(f32_ty, v);
 }
 
-// Convert Fp32 to Bf8/Fp8 on CDNA3
+// Convert four Fp32 values to four packed 8-bit floating-point values
+// ConvertOp chooses Fp8 versus Bf8; target dispatch chooses OCP versus FNUZ.
 template <typename ConvertOp>
 SmallVector<Value> Pk4Fp32ToF8(Location loc,
                                ConversionPatternRewriter &rewriter,
@@ -811,6 +821,81 @@ SmallVector<Value> Pk4Fp32ToF8(Location loc,
     ret[i] = b.extract_element(i8_ty, fp8x4Vec, idx);
   }
   return ret;
+}
+
+// Convert a single Bf8/Fp8 value to Fp32
+// The packed converter would work too, but its second result would come from an
+// undefined byte.
+template <typename ConvertOp>
+SmallVector<Value> ScalarF8ToFp32(Location loc,
+                                  ConversionPatternRewriter &rewriter,
+                                  const SmallVector<Value> &v) {
+  assert(v.size() == 1);
+  auto b = TritonLLVMOpBuilder(loc, rewriter);
+  auto fp8x4VecTy = vec_ty(i8_ty, 4);
+  Value fp8x4Vec = b.undef(fp8x4VecTy);
+  fp8x4Vec = b.insert_element(fp8x4VecTy, fp8x4Vec, v[0], b.i32_val(0));
+  Value i32v = b.bitcast(fp8x4Vec, i32_ty);
+  return {ConvertOp::create(rewriter, loc, f32_ty, i32v, /*byteSel=*/0)};
+}
+
+// Convert OCP Fp8/Bf8 to Fp32/Fp16/Bf16 using the plain cvt instructions
+// The plain ops only land in Fp32, so Fp16/Bf16 narrow afterwards; Fp8 is exact
+// in Fp32, leaving that narrowing as the only rounding site.
+template <typename DstFPType, typename PackedConvertOp,
+          typename ScalarConvertOp = void>
+SmallVector<Value> plainHWUpcastFromFp8(Location loc,
+                                        ConversionPatternRewriter &rewriter,
+                                        const SmallVector<Value> &v) {
+  static_assert(std::is_same_v<DstFPType, Float32Type> ||
+                    std::is_same_v<DstFPType, Float16Type> ||
+                    std::is_same_v<DstFPType, BFloat16Type>,
+                "plain fp8 upcast only lands in f32, f16 or bf16");
+  if constexpr (std::is_same_v<DstFPType, Float32Type>) {
+    static_assert(!std::is_void_v<ScalarConvertOp>,
+                  "an f32 destination needs the scalar cvt op");
+    // A lone value has no partner to fill the other half of a packed result.
+    if (v.size() == 1)
+      return ScalarF8ToFp32<ScalarConvertOp>(loc, rewriter, v);
+  }
+  assert(v.size() == 4);
+  SmallVector<Value> ret = PkF4ToFp32<PackedConvertOp>(loc, rewriter, v);
+  if constexpr (std::is_same_v<DstFPType, Float16Type>) {
+    // The Fp32 values came from Fp8 and are exactly representable in Fp16,
+    // so this narrowing conversion is lossless.
+    for (Value &val : ret)
+      val = Fp32ToFp16rtneOneValue(loc, rewriter, val);
+  } else if constexpr (std::is_same_v<DstFPType, BFloat16Type>) {
+    for (Value &val : ret)
+      val = AMD::convertFp32ToBf16(loc, rewriter, val, RoundingMode::RTZ);
+  }
+  return ret;
+}
+
+// Convert Fp32/Fp16/Bf16 to OCP Fp8/Bf8 using the plain cvt instructions
+// The plain ops only read Fp32, so Fp16/Bf16 widen first; both widenings are
+// exact, which keeps the rounding to Fp8 in the hardware instruction.
+template <typename SrcFPType, typename PackedConvertOp>
+SmallVector<Value> plainHWDowncastToFp8(Location loc,
+                                        ConversionPatternRewriter &rewriter,
+                                        const SmallVector<Value> &v) {
+  static_assert(std::is_same_v<SrcFPType, Float32Type> ||
+                    std::is_same_v<SrcFPType, Float16Type> ||
+                    std::is_same_v<SrcFPType, BFloat16Type>,
+                "plain fp8 downcast only starts from f32, f16 or bf16");
+  assert(v.size() == 4);
+  if constexpr (std::is_same_v<SrcFPType, Float32Type>) {
+    return Pk4Fp32ToF8<PackedConvertOp>(loc, rewriter, v);
+  } else {
+    SmallVector<Value> f32Vec(4);
+    for (size_t i = 0; i < 4; i++) {
+      if constexpr (std::is_same_v<SrcFPType, Float16Type>)
+        f32Vec[i] = Fp16ToFp32OneValue(loc, rewriter, v[i]);
+      else
+        f32Vec[i] = AMD::convertBf16ToFp32(loc, rewriter, v[i]);
+    }
+    return Pk4Fp32ToF8<PackedConvertOp>(loc, rewriter, f32Vec);
+  }
 }
 
 // Fp32->Fp16/Bf16 (RTNE) in GFX950
@@ -891,6 +976,9 @@ public:
       } else if (isaFamily == ISAFamily::CDNA4) {
         return scalePk4UpcastFromFp8<ROCDL::CvtScaleF32PkF16Fp8Op>(loc,
                                                                    rewriter, v);
+      } else if (hasPlainOcpFp8HW(isaFamily)) {
+        return plainHWUpcastFromFp8<Float16Type, ROCDL::CvtPkF32Fp8Op>(
+            loc, rewriter, v);
       } else
         return Fp8E4M3fnToFp16SW(loc, rewriter, v);
     }
@@ -1065,6 +1153,9 @@ public:
       } else if (isaFamily == ISAFamily::CDNA4) {
         return scalePk4UpcastFromFp8<ROCDL::CvtScaleF32PkF16Bf8Op>(loc,
                                                                    rewriter, v);
+      } else if (hasPlainOcpFp8HW(isaFamily)) {
+        return plainHWUpcastFromFp8<Float16Type, ROCDL::CvtPkF32Bf8Op>(
+            loc, rewriter, v);
       } else
         return Fp8E5M2ToFp16SW(loc, rewriter, v);
     }
@@ -1204,6 +1295,9 @@ public:
       } else if (isaFamily == ISAFamily::CDNA4) {
         return scalePk4UpcastFromFp8<ROCDL::CvtScaleF32PkBf16Fp8Op>(
             loc, rewriter, v);
+      } else if (hasPlainOcpFp8HW(isaFamily)) {
+        return plainHWUpcastFromFp8<BFloat16Type, ROCDL::CvtPkF32Fp8Op>(
+            loc, rewriter, v);
       } else
         return OcpF8ToBf16SW<Float8E4M3FNType>(loc, rewriter, v);
     }
@@ -1316,6 +1410,9 @@ public:
       } else if (isaFamily == ISAFamily::CDNA4) {
         return scalePk4UpcastFromFp8<ROCDL::CvtScaleF32PkBf16Bf8Op>(
             loc, rewriter, v);
+      } else if (hasPlainOcpFp8HW(isaFamily)) {
+        return plainHWUpcastFromFp8<BFloat16Type, ROCDL::CvtPkF32Bf8Op>(
+            loc, rewriter, v);
       } else
         return OcpF8ToBf16SW<Float8E5M2Type>(loc, rewriter, v);
     }
@@ -1361,6 +1458,12 @@ public:
         ConverterInterface(isaFamily, maxElementsPerThread, roundingMode) {}
 
   size_t getNumElements() override {
+    // A lone ocp fp8 value upcasts in one scalar hardware step. Asking for a
+    // packed group here would pad it with undef and throw away three quarters
+    // of the result.
+    if (maxElementsPerThread == 1 && hasPlainOcpFp8HW(isaFamily) &&
+        isa<Float8E4M3FNType>(srcTy))
+      return 1;
     return isa<Float8E4M3FNType>(srcTy) && isaFamily == ISAFamily::GFX1250 ? 8
                                                                            : 4;
   }
@@ -1386,6 +1489,9 @@ public:
       else if (isaFamily == ISAFamily::CDNA4)
         return scalePk4UpcastFromFp8<ROCDL::CvtScaleF32PkF32Fp8Op>(loc,
                                                                    rewriter, v);
+      else if (hasPlainOcpFp8HW(isaFamily))
+        return plainHWUpcastFromFp8<Float32Type, ROCDL::CvtPkF32Fp8Op,
+                                    ROCDL::CvtF32Fp8Op>(loc, rewriter, v);
       else
         useTwoStepConversion = true;
     }
@@ -1417,6 +1523,12 @@ public:
         ConverterInterface(isaFamily, maxElementsPerThread, roundingMode) {}
 
   size_t getNumElements() override {
+    // A lone ocp bf8 value upcasts in one scalar hardware step. Asking for a
+    // packed group here would pad it with undef and throw away three quarters
+    // of the result.
+    if (maxElementsPerThread == 1 && hasPlainOcpFp8HW(isaFamily) &&
+        isa<Float8E5M2Type>(srcTy))
+      return 1;
     return isa<Float8E5M2Type>(srcTy) && isaFamily == ISAFamily::GFX1250 ? 8
                                                                          : 4;
   }
@@ -1442,6 +1554,9 @@ public:
       else if (isaFamily == ISAFamily::CDNA4)
         return scalePk4UpcastFromFp8<ROCDL::CvtScaleF32PkF32Bf8Op>(loc,
                                                                    rewriter, v);
+      else if (hasPlainOcpFp8HW(isaFamily))
+        return plainHWUpcastFromFp8<Float32Type, ROCDL::CvtPkF32Bf8Op,
+                                    ROCDL::CvtF32Bf8Op>(loc, rewriter, v);
       else
         useTwoStepConversion = true;
     }
@@ -1496,6 +1611,9 @@ public:
       } else if (isaFamily == ISAFamily::CDNA4) {
         return scalePk4DowncastToFp8<ROCDL::CvtScaleF32PkFp8F16Op>(loc,
                                                                    rewriter, v);
+      } else if (hasPlainOcpFp8HW(isaFamily)) {
+        return plainHWDowncastToFp8<Float16Type, ROCDL::CvtPkFp8F32Op>(
+            loc, rewriter, v);
       } else
         return Fp16ToFp8E4M3fnRtneSW(loc, rewriter, v);
     } else if (isa<Float8E4M3FNUZType>(dstTy)) {
@@ -1586,6 +1704,9 @@ public:
               loc, rewriter, v);
         } else if (isaFamily == ISAFamily::CDNA4) {
           return scalePk4DowncastToFp8<ROCDL::CvtScaleF32PkBf8F16Op>(
+              loc, rewriter, v);
+        } else if (hasPlainOcpFp8HW(isaFamily)) {
+          return plainHWDowncastToFp8<Float16Type, ROCDL::CvtPkBf8F32Op>(
               loc, rewriter, v);
         } else
           return Fp16ToFp8E5M2rtneSW(loc, rewriter, v);
@@ -1731,6 +1852,9 @@ public:
       } else if (isaFamily == ISAFamily::CDNA4) {
         return scalePk4DowncastToFp8<ROCDL::CvtScaleF32PkFp8Bf16Op>(
             loc, rewriter, v);
+      } else if (hasPlainOcpFp8HW(isaFamily)) {
+        return plainHWDowncastToFp8<BFloat16Type, ROCDL::CvtPkFp8F32Op>(
+            loc, rewriter, v);
       } else
         return Bf16ToFp8E4M3fnRtneSW(loc, rewriter, v);
     } else if (isa<Float8E4M3FNUZType>(dstTy)) {
@@ -1812,6 +1936,9 @@ public:
             loc, rewriter, v);
       } else if (isaFamily == ISAFamily::CDNA4) {
         return scalePk4DowncastToFp8<ROCDL::CvtScaleF32PkBf8Bf16Op>(
+            loc, rewriter, v);
+      } else if (hasPlainOcpFp8HW(isaFamily)) {
+        return plainHWDowncastToFp8<BFloat16Type, ROCDL::CvtPkBf8F32Op>(
             loc, rewriter, v);
       } else
         return Bf16ToFp8E5M2SW(loc, rewriter, v);
@@ -2097,6 +2224,9 @@ public:
       } else if (isaFamily == ISAFamily::CDNA4) {
         return scalePk4DowncastToFp8<ROCDL::CvtScaleF32PkFp8F32Op>(
             loc, rewriter, inVals);
+      } else if (hasPlainOcpFp8HW(isaFamily)) {
+        return plainHWDowncastToFp8<Float32Type, ROCDL::CvtPkFp8F32Op>(
+            loc, rewriter, inVals);
       } else
         return Fp32ToFp8E4M3fnRtneSW(loc, rewriter, inVals);
     }
@@ -2178,6 +2308,9 @@ public:
               loc, rewriter, inVals);
         } else if (isaFamily == ISAFamily::CDNA4) {
           return scalePk4DowncastToFp8<ROCDL::CvtScaleF32PkBf8F32Op>(
+              loc, rewriter, inVals);
+        } else if (hasPlainOcpFp8HW(isaFamily)) {
+          return plainHWDowncastToFp8<Float32Type, ROCDL::CvtPkBf8F32Op>(
               loc, rewriter, inVals);
         } else
           return Fp32ToFp8E5M2rtneSW(loc, rewriter, inVals);


### PR DESCRIPTION
gfx1170 has `FeatureFP8ConversionInsts`, the `v_cvt_`, and  `v_cvt_pk_' instructions, and on that target they encode OCP fp8. Until now every OCP fp8 cast on gfx1170 fell back to the software bit-manipulation path anyway, because neither existing hardware path fit: CDNA4 and gfx1250 use the *scaled* ops (`v_cvt_scalef32_pk_*`), which gfx1170 does not have, and the plain ops were wired only into the CDNA3 FNUZ converters, the wrong fp8 flavor for gfx1170's E4M3FN/E5M2.

This PR routes `f8E4M3FN`/`f8E5M2` <-> `f32`/`f16`/`bf16` casts on gfx1170 to the plain instructions, gated on a new `hasPlainOcpFp8HW()` capability so the other RDNA targets are unaffected.


# New contributor declaration
- [x] I am not making a trivial change, such as fixing a typo in a comment.

- [x] I have written a PR description following these
  [rules](https://cbea.ms/git-commit/#why-not-how).

- [x] I have run `pre-commit run --from-ref origin/main --to-ref HEAD`.

- Select one of the following.
  - [x] I have added tests.
    - `/test` for `lit` tests
    - `/unittest` for C++ tests
    - `/python/test` for end-to-end tests

- Select one of the following.
  - [x] The `lit` tests I have added follow these [best practices](https://mlir.llvm.org/getting_started/TestingGuide/#filecheck-best-practices),
    including the "tests should be minimal" section. (Usually running Python code
    and using the instructions it generates is not minimal.)

CC: @zhanglx13 @antiagainst @AlexAUT