### PR TITLE
[Analysis] Fix membar Python binding in debug builds

### DIFF
--- a/include/triton/Analysis/Membar.h
+++ b/include/triton/Analysis/Membar.h
@@ -358,7 +358,9 @@ public:
                        MembarFilterFn filter = nullptr)
       : moduleAllocation(moduleAllocation), filter(std::move(filter)) {}
 
-  template <typename AnalysisT = MembarAnalysis> void run() {
+  void run();
+
+  template <typename AnalysisT> void run() {
     // Geometry and interval slices use the same completed allocation, including
     // backend scratch sizes and shared-memory partition offsets.
     auto solver = createDataFlowSolver();

--- a/lib/Analysis/Membar.cpp
+++ b/lib/Analysis/Membar.cpp
@@ -435,4 +435,6 @@ void MembarAnalysis::updateMemoryEffects(Operation *op, MembarInfo *membarInfo,
   }
 }
 
+void ModuleMembarAnalysis::run() { run<MembarAnalysis>(); }
+
 } // namespace mlir

--- a/python/src/passes.cc
+++ b/python/src/passes.cc
@@ -28,7 +28,7 @@ void init_triton_analysis(py::module_ &m) {
       .def(py::init<mlir::ModuleOp>());
   py::class_<mlir::ModuleMembarAnalysis>(m, "membar")
       .def(py::init<mlir::ModuleAllocation &>())
-      .def("run", &mlir::ModuleMembarAnalysis::run<>);
+      .def("run", [](mlir::ModuleMembarAnalysis &analysis) { analysis.run(); });
 }
 
 void init_triton_passes_common(py::module_ &m) {


### PR DESCRIPTION
[PR #11468](https://github.com/triton-lang/triton/pull/11468) moved `ModuleMembarAnalysis::run<>` instantiation into the RTTI-enabled Python binding. Debug builds then reference RTTI unavailable from MLIR, which is built with `-fno-rtti`.
 
Explicitly instantiate the default specialization in the RTTI-disabled analysis library. This fixes import triton in Debug builds.
