### PR TITLE
[FPSan] Inline only calls required by instrumentation

### DIFF
--- a/include/triton/Dialect/TritonInstrument/Transforms/Passes.td
+++ b/include/triton/Dialect/TritonInstrument/Transforms/Passes.td
@@ -37,9 +37,10 @@ def TritonInstrumentFpSanitizer: Pass<"tritoninstrument-fp-sanitizer", "mlir::Mo
   let summary = "Replace floating-point ops with integer-payload equivalents";
 
   let description = [{
-    Remove dead symbols and diagnose calls that must be inlined to expose tensor
-    memory allocations or required kernel context. Then rewrite selected
-    floating-point operations to use integer payload semantics.
+    Diagnose calls that must be inlined to expose tensor memory allocations or
+    required kernel context. Then rewrite selected floating-point operations to
+    use integer payload semantics. Run symbol DCE before this pass to remove
+    unreachable private functions.
   }];
 
   let dependentDialects = ["mlir::arith::ArithDialect",

--- a/include/triton/Dialect/TritonInstrument/Transforms/Passes.td
+++ b/include/triton/Dialect/TritonInstrument/Transforms/Passes.td
@@ -33,6 +33,20 @@ def TritonInstrumentPrepareConSanCaptures: Pass<"tritoninstrument-prepare-consan
   ];
 }
 
+def TritonInstrumentPrepareFpSanitizer: Pass<"tritoninstrument-prepare-fp-sanitizer", "mlir::ModuleOp"> {
+  let summary = "Eliminate dead symbols and validate calls before FPSan";
+
+  let description = [{
+    Remove unreachable private functions and diagnose calls that hide tensor
+    memory allocations or kernel execution context required by FPSan.
+    Ordinary arithmetic helpers do not need to be inlined.
+  }];
+
+  let dependentDialects = ["mlir::triton::gpu::TritonGPUDialect",
+                           "mlir::triton::TritonDialect",
+                           "mlir::triton::nvidia_gpu::TritonNvidiaGPUDialect"];
+}
+
 def TritonInstrumentFpSanitizer: Pass<"tritoninstrument-fp-sanitizer", "mlir::ModuleOp"> {
   let summary = "Replace floating-point ops with integer-payload equivalents";
 

--- a/include/triton/Dialect/TritonInstrument/Transforms/Passes.td
+++ b/include/triton/Dialect/TritonInstrument/Transforms/Passes.td
@@ -37,10 +37,11 @@ def TritonInstrumentFpSanitizer: Pass<"tritoninstrument-fp-sanitizer", "mlir::Mo
   let summary = "Replace floating-point ops with integer-payload equivalents";
 
   let description = [{
-    Diagnose calls that must be inlined to expose tensor memory allocations or
-    required kernel context. Then rewrite selected floating-point operations to
-    use integer payload semantics. Run symbol DCE before this pass to remove
-    unreachable private functions.
+    Inline calls that hide tensor memory allocations or required kernel context.
+    Remove helpers made unreachable by inlining and diagnose required calls that
+    cannot be inlined. Then rewrite selected floating-point operations to use
+    integer payload semantics. Run symbol DCE before this pass to remove
+    existing unreachable private functions.
   }];
 
   let dependentDialects = ["mlir::arith::ArithDialect",

--- a/include/triton/Dialect/TritonInstrument/Transforms/Passes.td
+++ b/include/triton/Dialect/TritonInstrument/Transforms/Passes.td
@@ -33,24 +33,14 @@ def TritonInstrumentPrepareConSanCaptures: Pass<"tritoninstrument-prepare-consan
   ];
 }
 
-def TritonInstrumentPrepareFpSanitizer: Pass<"tritoninstrument-prepare-fp-sanitizer", "mlir::ModuleOp"> {
-  let summary = "Eliminate dead symbols and validate calls before FPSan";
-
-  let description = [{
-    Remove unreachable private functions and diagnose calls that hide tensor
-    memory allocations or kernel execution context required by FPSan.
-    Ordinary arithmetic helpers do not need to be inlined.
-  }];
-
-  let dependentDialects = ["mlir::triton::gpu::TritonGPUDialect",
-                           "mlir::triton::TritonDialect",
-                           "mlir::triton::nvidia_gpu::TritonNvidiaGPUDialect"];
-}
-
 def TritonInstrumentFpSanitizer: Pass<"tritoninstrument-fp-sanitizer", "mlir::ModuleOp"> {
   let summary = "Replace floating-point ops with integer-payload equivalents";
 
-  let description = "Rewrite selected floating-point operations to use integer payload semantics for fpsan.";
+  let description = [{
+    Remove dead symbols and diagnose calls that must be inlined to expose tensor
+    memory allocations or required kernel context. Then rewrite selected
+    floating-point operations to use integer payload semantics.
+  }];
 
   let dependentDialects = ["mlir::arith::ArithDialect",
                            "mlir::math::MathDialect",

--- a/lib/Dialect/TritonInstrument/Transforms/FpSanitizer.cpp
+++ b/lib/Dialect/TritonInstrument/Transforms/FpSanitizer.cpp
@@ -1,9 +1,7 @@
 #include "mlir/IR/Diagnostics.h"
 #include "mlir/IR/PatternMatch.h"
 #include "mlir/IR/Types.h"
-#include "mlir/Pass/PassManager.h"
 #include "mlir/Transforms/GreedyPatternRewriteDriver.h"
-#include "mlir/Transforms/Passes.h"
 #include "mlir/Transforms/RegionUtils.h"
 #include "triton/Dialect/Triton/IR/Dialect.h"
 #include "triton/Dialect/TritonGPU/IR/Dialect.h"
@@ -3339,11 +3337,6 @@ static FpSanRequiredCalls getFpSanRequiredCalls(ModuleOp module) {
 class FpSanitizerPass
     : public impl::TritonInstrumentFpSanitizerBase<FpSanitizerPass> {
   LogicalResult prepareForFpSan() {
-    OpPassManager cleanup;
-    cleanup.addPass(createSymbolDCEPass());
-    if (failed(runPipeline(cleanup, getOperation())))
-      return failure();
-
     auto calls = getFpSanRequiredCalls(getOperation());
     for (auto [call, requirement] : calls) {
       auto diagnostic = call.emitOpError("must be inlined before FPSan");

--- a/lib/Dialect/TritonInstrument/Transforms/FpSanitizer.cpp
+++ b/lib/Dialect/TritonInstrument/Transforms/FpSanitizer.cpp
@@ -28,7 +28,6 @@ namespace ttg = mlir::triton::gpu;
 namespace ttng = mlir::triton::nvidia_gpu;
 
 #define GEN_PASS_DEF_TRITONINSTRUMENTFPSANITIZER
-#define GEN_PASS_DEF_TRITONINSTRUMENTPREPAREFPSANITIZER
 #include "triton/Dialect/TritonInstrument/Transforms/Passes.h.inc"
 
 namespace {
@@ -233,6 +232,49 @@ Operation *storeFpSanScratchMemory(PatternRewriter &rewriter, Location loc,
   return createStoreScratchMemory(rewriter, loc, alloc, stored, storageTy);
 }
 
+// Return one forwarding step, preserving view operations for scratch emission.
+static Value getFpSanTmemSource(Value value) {
+  if (auto arg = dyn_cast<BlockArgument>(value)) {
+    Operation *parent = arg.getOwner()->getParentOp();
+    if (auto partitions = dyn_cast<ttg::WarpSpecializePartitionsOp>(parent))
+      return partitions.getExplicitCaptures()[arg.getArgNumber()];
+    if (auto loop = dyn_cast<scf::ForOp>(parent)) {
+      if (arg.getArgNumber() != 0)
+        return loop.getInitArgs()[arg.getArgNumber() - 1];
+    }
+  }
+  if (auto view = value.getDefiningOp<ttng::TMEMSubSliceOp>())
+    return view.getSrc();
+  if (auto view = value.getDefiningOp<ttg::MemDescIndexOp>())
+    return view.getSrc();
+  if (auto view = value.getDefiningOp<ttg::MemDescReinterpretOp>())
+    return view.getSrc();
+  return {};
+}
+
+static bool hasTwoCTAMma(ModuleOp module) {
+  bool twoCTAs = false;
+  module.walk([&](ttng::MMAv5OpInterface mma) { twoCTAs |= mma.getTwoCtas(); });
+  return twoCTAs;
+}
+
+enum class FpSanMmaKind { Integer, Floating, Mixed };
+
+static FpSanMmaKind getFpSanMmaKind(ttng::TCGen5MMAOp mma) {
+  auto isFloatMemdesc = [](Value value) {
+    return isa<FloatType>(
+        cast<ttg::MemDescType>(value.getType()).getElementType());
+  };
+  bool aIsFloat = isFloatMemdesc(mma.getA());
+  bool bIsFloat = isFloatMemdesc(mma.getB());
+  bool dIsFloat = isFloatMemdesc(mma.getD());
+  if (aIsFloat && bIsFloat && dIsFloat)
+    return FpSanMmaKind::Floating;
+  if (!aIsFloat && !bIsFloat && !dIsFloat)
+    return FpSanMmaKind::Integer;
+  return FpSanMmaKind::Mixed;
+}
+
 class TmemScratchManager {
 public:
   explicit TmemScratchManager(bool sharedClusterState)
@@ -290,19 +332,9 @@ public:
 
   std::optional<ScratchInfo>
   getOrCreate(Value memdesc, PatternRewriter &rewriter, Region *scope) {
-    if (auto arg = dyn_cast<BlockArgument>(memdesc)) {
-      if (auto wsPartitions = dyn_cast<ttg::WarpSpecializePartitionsOp>(
-              arg.getOwner()->getParentOp())) {
-        auto capture = wsPartitions.getExplicitCaptures()[arg.getArgNumber()];
-        return getOrCreate(capture, rewriter, scope);
-      }
-      if (auto forOp = dyn_cast<scf::ForOp>(arg.getOwner()->getParentOp())) {
-        unsigned argNum = arg.getArgNumber();
-        if (argNum == 0)
-          return std::nullopt;
-        Value init = forOp.getInitArgs()[argNum - 1];
-        return getOrCreate(init, rewriter, scope);
-      }
+    if (isa<BlockArgument>(memdesc)) {
+      if (Value source = getFpSanTmemSource(memdesc))
+        return getOrCreate(source, rewriter, scope);
       return std::nullopt;
     }
 
@@ -358,12 +390,13 @@ public:
       return info;
     }
 
+    Value source = getFpSanTmemSource(memdesc);
     if (auto subslice = memdesc.getDefiningOp<ttng::TMEMSubSliceOp>()) {
-      auto baseInfo = getOrCreate(subslice.getSrc(), rewriter, scope);
+      auto baseInfo = getOrCreate(source, rewriter, scope);
       if (!baseInfo || baseInfo->scaleSourceType)
         return std::nullopt;
 
-      auto baseTy = cast<ttg::MemDescType>(subslice.getSrc().getType());
+      auto baseTy = cast<ttg::MemDescType>(source.getType());
       if (baseTy.getRank() != memTy.getRank() ||
           baseTy.getRank() != baseInfo->tensorType.getRank())
         return std::nullopt;
@@ -394,11 +427,11 @@ public:
     }
 
     if (auto view = memdesc.getDefiningOp<ttg::MemDescIndexOp>()) {
-      auto baseInfo = getOrCreate(view.getSrc(), rewriter, scope);
+      auto baseInfo = getOrCreate(source, rewriter, scope);
       if (!baseInfo || baseInfo->scaleSourceType)
         return std::nullopt;
 
-      auto baseTy = cast<ttg::MemDescType>(view.getSrc().getType());
+      auto baseTy = cast<ttg::MemDescType>(source.getType());
       if (baseTy.getRank() < 2)
         return std::nullopt;
 
@@ -424,11 +457,11 @@ public:
     }
 
     if (auto view = memdesc.getDefiningOp<ttg::MemDescReinterpretOp>()) {
-      auto baseInfo = getOrCreate(view.getSrc(), rewriter, scope);
+      auto baseInfo = getOrCreate(source, rewriter, scope);
       if (!baseInfo)
         return std::nullopt;
 
-      auto baseTy = cast<ttg::MemDescType>(view.getSrc().getType());
+      auto baseTy = cast<ttg::MemDescType>(source.getType());
       if (isa<ttng::TensorMemoryScalesEncodingAttr>(baseTy.getEncoding()) &&
           !isa<ttng::TensorMemoryScalesEncodingAttr>(memTy.getEncoding()))
         return ScratchInfo{baseInfo->ptr, baseInfo->tensorType, baseTy};
@@ -2782,12 +2815,10 @@ struct TCGen5MMAPattern : public OpRewritePattern<ttng::TCGen5MMAOp> {
     auto bMemTy = cast<ttg::MemDescType>(op.getB().getType());
     auto dMemTy = cast<ttg::MemDescType>(op.getD().getType());
 
-    bool aIsFloat = isa<FloatType>(aMemTy.getElementType());
-    bool bIsFloat = isa<FloatType>(bMemTy.getElementType());
-    bool dIsFloat = isa<FloatType>(dMemTy.getElementType());
-    if (!aIsFloat && !bIsFloat && !dIsFloat)
+    auto kind = getFpSanMmaKind(op);
+    if (kind == FpSanMmaKind::Integer)
       return failure();
-    if (!aIsFloat || !bIsFloat || !dIsFloat)
+    if (kind == FpSanMmaKind::Mixed)
       return emitFpSanUnsupported(op.getOperation());
 
     auto scope = getScratchScopeRegion(op);
@@ -3228,51 +3259,13 @@ static SmallVector<Value> getFpSanTmemOperands(Operation *op) {
   if (auto copy = dyn_cast<ttng::TMEMCopyOp>(op))
     return {copy.getDst()};
   if (auto mma = dyn_cast<ttng::TCGen5MMAOp>(op)) {
-    auto isFloatMemdesc = [](Value value) {
-      return isa<FloatType>(
-          cast<ttg::MemDescType>(value.getType()).getElementType());
-    };
-    // Integer MMA is not emulated, and mixed types are diagnosed by its
-    // pattern.
-    if (isFloatMemdesc(mma.getA()) && isFloatMemdesc(mma.getB()) &&
-        isFloatMemdesc(mma.getD()))
+    if (getFpSanMmaKind(mma) == FpSanMmaKind::Floating)
       return {mma.getA(), mma.getB(), mma.getD()};
   }
   if (auto mma = dyn_cast<ttng::TCGen5MMAScaledOp>(op))
     return {mma.getA(), mma.getB(), mma.getD(), mma.getAScale(),
             mma.getBScale()};
   return {};
-}
-
-// Follow the same forwarding operations as TmemScratchManager. An unsupported
-// producer within a function is not necessarily something inlining can repair.
-static Value getFpSanTmemOrigin(Value value) {
-  while (true) {
-    if (auto arg = dyn_cast<BlockArgument>(value)) {
-      Operation *parent = arg.getOwner()->getParentOp();
-      if (auto partitions = dyn_cast<ttg::WarpSpecializePartitionsOp>(parent)) {
-        value = partitions.getExplicitCaptures()[arg.getArgNumber()];
-        continue;
-      }
-      if (auto loop = dyn_cast<scf::ForOp>(parent)) {
-        value = loop.getInitArgs()[arg.getArgNumber() - 1];
-        continue;
-      }
-    }
-    if (auto view = value.getDefiningOp<ttng::TMEMSubSliceOp>()) {
-      value = view.getSrc();
-      continue;
-    }
-    if (auto view = value.getDefiningOp<ttg::MemDescIndexOp>()) {
-      value = view.getSrc();
-      continue;
-    }
-    if (auto view = value.getDefiningOp<ttg::MemDescReinterpretOp>()) {
-      value = view.getSrc();
-      continue;
-    }
-    return value;
-  }
 }
 
 struct FpSanInliningRequirement {
@@ -3286,8 +3279,7 @@ using FpSanRequiredCalls =
 static FpSanRequiredCalls getFpSanRequiredCalls(ModuleOp module) {
   DenseMap<Operation *, FpSanInliningRequirement> functions;
   DenseMap<Operation *, FpSanInliningRequirement> producers;
-  bool twoCTAs = false;
-  module.walk([&](ttng::MMAv5OpInterface mma) { twoCTAs |= mma.getTwoCtas(); });
+  bool twoCTAs = hasTwoCTAMma(module);
 
   module.walk([&](Operation *op) {
     auto operands = getFpSanTmemOperands(op);
@@ -3295,7 +3287,9 @@ static FpSanRequiredCalls getFpSanRequiredCalls(ModuleOp module) {
       auto type = cast<ttg::MemDescType>(operand.getType());
       if (!isa<ttng::TensorMemorySpaceAttr>(type.getMemorySpace()))
         continue;
-      Value origin = getFpSanTmemOrigin(operand);
+      Value origin = operand;
+      while (Value source = getFpSanTmemSource(origin))
+        origin = source;
       if (auto arg = dyn_cast<BlockArgument>(origin)) {
         if (auto function = dyn_cast<tt::FuncOp>(arg.getOwner()->getParentOp());
             function && arg.getOwner()->isEntryBlock())
@@ -3342,39 +3336,28 @@ static FpSanRequiredCalls getFpSanRequiredCalls(ModuleOp module) {
   return calls;
 }
 
-class PrepareFpSanitizerPass
-    : public impl::TritonInstrumentPrepareFpSanitizerBase<
-          PrepareFpSanitizerPass> {
-public:
-  void runOnOperation() override {
+class FpSanitizerPass
+    : public impl::TritonInstrumentFpSanitizerBase<FpSanitizerPass> {
+  LogicalResult prepareForFpSan() {
     OpPassManager cleanup;
     cleanup.addPass(createSymbolDCEPass());
-    if (failed(runPipeline(cleanup, getOperation()))) {
-      signalPassFailure();
-      return;
-    }
+    if (failed(runPipeline(cleanup, getOperation())))
+      return failure();
 
     auto calls = getFpSanRequiredCalls(getOperation());
     for (auto [call, requirement] : calls) {
       auto diagnostic = call.emitOpError("must be inlined before FPSan");
       diagnostic.attachNote(requirement.cause->getLoc()) << requirement.reason;
     }
-    if (!calls.empty())
-      signalPassFailure();
+    return success(calls.empty());
   }
-};
 
-class FpSanitizerPass
-    : public impl::TritonInstrumentFpSanitizerBase<FpSanitizerPass> {
 public:
   using impl::TritonInstrumentFpSanitizerBase<
       FpSanitizerPass>::TritonInstrumentFpSanitizerBase;
 
   void runOnOperation() override {
-    // Keep direct pass invocations safe as well as prepared backend pipelines.
-    OpPassManager preparation;
-    preparation.addPass(createTritonInstrumentPrepareFpSanitizer());
-    if (failed(runPipeline(preparation, getOperation()))) {
+    if (failed(prepareForFpSan())) {
       signalPassFailure();
       return;
     }
@@ -3387,9 +3370,7 @@ public:
           return failure();
         });
 
-    bool twoCTAs = false;
-    getOperation().walk(
-        [&](ttng::MMAv5OpInterface op) { twoCTAs |= op.getTwoCtas(); });
+    bool twoCTAs = hasTwoCTAMma(getOperation());
 
     getOperation()->setAttr(ttng::AttrTwoCTAsName,
                             BoolAttr::get(&getContext(), twoCTAs));

--- a/lib/Dialect/TritonInstrument/Transforms/FpSanitizer.cpp
+++ b/lib/Dialect/TritonInstrument/Transforms/FpSanitizer.cpp
@@ -1,7 +1,9 @@
 #include "mlir/IR/Diagnostics.h"
 #include "mlir/IR/PatternMatch.h"
 #include "mlir/IR/Types.h"
+#include "mlir/Pass/PassManager.h"
 #include "mlir/Transforms/GreedyPatternRewriteDriver.h"
+#include "mlir/Transforms/Passes.h"
 #include "mlir/Transforms/RegionUtils.h"
 #include "triton/Dialect/Triton/IR/Dialect.h"
 #include "triton/Dialect/TritonGPU/IR/Dialect.h"
@@ -26,6 +28,7 @@ namespace ttg = mlir::triton::gpu;
 namespace ttng = mlir::triton::nvidia_gpu;
 
 #define GEN_PASS_DEF_TRITONINSTRUMENTFPSANITIZER
+#define GEN_PASS_DEF_TRITONINSTRUMENTPREPAREFPSANITIZER
 #include "triton/Dialect/TritonInstrument/Transforms/Passes.h.inc"
 
 namespace {
@@ -3216,6 +3219,151 @@ struct ElementwiseInlineAsmPattern
   }
 };
 
+// These are the operands whose scratch storage the FPSan patterns resolve.
+static SmallVector<Value> getFpSanTmemOperands(Operation *op) {
+  if (auto load = dyn_cast<ttng::TMEMLoadOp>(op))
+    return {load.getSrc()};
+  if (auto store = dyn_cast<ttng::TMEMStoreOp>(op))
+    return {store.getDst()};
+  if (auto copy = dyn_cast<ttng::TMEMCopyOp>(op))
+    return {copy.getDst()};
+  if (auto mma = dyn_cast<ttng::TCGen5MMAOp>(op)) {
+    auto isFloatMemdesc = [](Value value) {
+      return isa<FloatType>(
+          cast<ttg::MemDescType>(value.getType()).getElementType());
+    };
+    // Integer MMA is not emulated, and mixed types are diagnosed by its
+    // pattern.
+    if (isFloatMemdesc(mma.getA()) && isFloatMemdesc(mma.getB()) &&
+        isFloatMemdesc(mma.getD()))
+      return {mma.getA(), mma.getB(), mma.getD()};
+  }
+  if (auto mma = dyn_cast<ttng::TCGen5MMAScaledOp>(op))
+    return {mma.getA(), mma.getB(), mma.getD(), mma.getAScale(),
+            mma.getBScale()};
+  return {};
+}
+
+// Follow the same forwarding operations as TmemScratchManager. An unsupported
+// producer within a function is not necessarily something inlining can repair.
+static Value getFpSanTmemOrigin(Value value) {
+  while (true) {
+    if (auto arg = dyn_cast<BlockArgument>(value)) {
+      Operation *parent = arg.getOwner()->getParentOp();
+      if (auto partitions = dyn_cast<ttg::WarpSpecializePartitionsOp>(parent)) {
+        value = partitions.getExplicitCaptures()[arg.getArgNumber()];
+        continue;
+      }
+      if (auto loop = dyn_cast<scf::ForOp>(parent)) {
+        value = loop.getInitArgs()[arg.getArgNumber() - 1];
+        continue;
+      }
+    }
+    if (auto view = value.getDefiningOp<ttng::TMEMSubSliceOp>()) {
+      value = view.getSrc();
+      continue;
+    }
+    if (auto view = value.getDefiningOp<ttg::MemDescIndexOp>()) {
+      value = view.getSrc();
+      continue;
+    }
+    if (auto view = value.getDefiningOp<ttg::MemDescReinterpretOp>()) {
+      value = view.getSrc();
+      continue;
+    }
+    return value;
+  }
+}
+
+struct FpSanInliningRequirement {
+  Operation *cause;
+  StringRef reason;
+};
+
+using FpSanRequiredCalls =
+    SmallVector<std::pair<tt::CallOp, FpSanInliningRequirement>>;
+
+static FpSanRequiredCalls getFpSanRequiredCalls(ModuleOp module) {
+  DenseMap<Operation *, FpSanInliningRequirement> functions;
+  DenseMap<Operation *, FpSanInliningRequirement> producers;
+  bool twoCTAs = false;
+  module.walk([&](ttng::MMAv5OpInterface mma) { twoCTAs |= mma.getTwoCtas(); });
+
+  module.walk([&](Operation *op) {
+    auto operands = getFpSanTmemOperands(op);
+    for (Value operand : operands) {
+      auto type = cast<ttg::MemDescType>(operand.getType());
+      if (!isa<ttng::TensorMemorySpaceAttr>(type.getMemorySpace()))
+        continue;
+      Value origin = getFpSanTmemOrigin(operand);
+      if (auto arg = dyn_cast<BlockArgument>(origin)) {
+        if (auto function = dyn_cast<tt::FuncOp>(arg.getOwner()->getParentOp());
+            function && arg.getOwner()->isEntryBlock())
+          functions.try_emplace(
+              function, FpSanInliningRequirement{
+                            op, "FPSan needs the allocation behind this tensor "
+                                "memory argument"});
+      } else if (auto call = origin.getDefiningOp<tt::CallOp>()) {
+        producers.try_emplace(
+            call,
+            FpSanInliningRequirement{
+                op, "FPSan needs the allocation behind this tensor memory "
+                    "call result"});
+      }
+    }
+
+    auto function = op->getParentOfType<tt::FuncOp>();
+    if (!function || function.isPublic())
+      return;
+    if (isa<ttg::WarpSpecializeOp>(op))
+      functions.try_emplace(
+          function, FpSanInliningRequirement{
+                        op, "warp specialization requires kernel context"});
+    // A callee receives a per-CTA scratch base, not the cluster base needed by
+    // TMEM emulation. Its generated cluster barriers also need kernel context.
+    if (twoCTAs && (!operands.empty() || isa<ttng::TCGen5CommitOp>(op)))
+      functions.try_emplace(
+          function, FpSanInliningRequirement{
+                        op, "FPSan cluster scratch and barriers require kernel "
+                            "context"});
+  });
+
+  FpSanRequiredCalls calls;
+  module.walk([&](tt::CallOp call) {
+    auto producer = producers.find(call);
+    if (producer != producers.end()) {
+      calls.emplace_back(call, producer->second);
+      return;
+    }
+    auto function = functions.find(call.resolveCallable());
+    if (function != functions.end())
+      calls.emplace_back(call, function->second);
+  });
+  return calls;
+}
+
+class PrepareFpSanitizerPass
+    : public impl::TritonInstrumentPrepareFpSanitizerBase<
+          PrepareFpSanitizerPass> {
+public:
+  void runOnOperation() override {
+    OpPassManager cleanup;
+    cleanup.addPass(createSymbolDCEPass());
+    if (failed(runPipeline(cleanup, getOperation()))) {
+      signalPassFailure();
+      return;
+    }
+
+    auto calls = getFpSanRequiredCalls(getOperation());
+    for (auto [call, requirement] : calls) {
+      auto diagnostic = call.emitOpError("must be inlined before FPSan");
+      diagnostic.attachNote(requirement.cause->getLoc()) << requirement.reason;
+    }
+    if (!calls.empty())
+      signalPassFailure();
+  }
+};
+
 class FpSanitizerPass
     : public impl::TritonInstrumentFpSanitizerBase<FpSanitizerPass> {
 public:
@@ -3223,6 +3371,14 @@ public:
       FpSanitizerPass>::TritonInstrumentFpSanitizerBase;
 
   void runOnOperation() override {
+    // Keep direct pass invocations safe as well as prepared backend pipelines.
+    OpPassManager preparation;
+    preparation.addPass(createTritonInstrumentPrepareFpSanitizer());
+    if (failed(runPipeline(preparation, getOperation()))) {
+      signalPassFailure();
+      return;
+    }
+
     bool fpSanErrorEmitted = false;
     ScopedDiagnosticHandler diagnosticHandler(
         &getContext(), [&](Diagnostic &diagnostic) {

--- a/lib/Dialect/TritonInstrument/Transforms/FpSanitizer.cpp
+++ b/lib/Dialect/TritonInstrument/Transforms/FpSanitizer.cpp
@@ -259,13 +259,9 @@ static bool hasTwoCTAMma(ModuleOp module) {
 enum class FpSanMmaKind { Integer, Floating, Mixed };
 
 static FpSanMmaKind getFpSanMmaKind(ttng::TCGen5MMAOp mma) {
-  auto isFloatMemdesc = [](Value value) {
-    return isa<FloatType>(
-        cast<ttg::MemDescType>(value.getType()).getElementType());
-  };
-  bool aIsFloat = isFloatMemdesc(mma.getA());
-  bool bIsFloat = isFloatMemdesc(mma.getB());
-  bool dIsFloat = isFloatMemdesc(mma.getD());
+  bool aIsFloat = isa<FloatType>(mma.getA().getType().getElementType());
+  bool bIsFloat = isa<FloatType>(mma.getB().getType().getElementType());
+  bool dIsFloat = isa<FloatType>(mma.getD().getType().getElementType());
   if (aIsFloat && bIsFloat && dIsFloat)
     return FpSanMmaKind::Floating;
   if (!aIsFloat && !bIsFloat && !dIsFloat)
@@ -3271,10 +3267,11 @@ struct FpSanInliningRequirement {
   StringRef reason;
 };
 
-using FpSanRequiredCalls =
+using FpSanCallsRequiringInlining =
     SmallVector<std::pair<tt::CallOp, FpSanInliningRequirement>>;
 
-static FpSanRequiredCalls getFpSanRequiredCalls(ModuleOp module) {
+static FpSanCallsRequiringInlining
+getFpSanCallsRequiringInlining(ModuleOp module) {
   DenseMap<Operation *, FpSanInliningRequirement> functions;
   DenseMap<Operation *, FpSanInliningRequirement> producers;
   bool twoCTAs = hasTwoCTAMma(module);
@@ -3320,7 +3317,7 @@ static FpSanRequiredCalls getFpSanRequiredCalls(ModuleOp module) {
                             "context"});
   });
 
-  FpSanRequiredCalls calls;
+  FpSanCallsRequiringInlining calls;
   module.walk([&](tt::CallOp call) {
     auto producer = producers.find(call);
     if (producer != producers.end()) {
@@ -3336,21 +3333,17 @@ static FpSanRequiredCalls getFpSanRequiredCalls(ModuleOp module) {
 
 class FpSanitizerPass
     : public impl::TritonInstrumentFpSanitizerBase<FpSanitizerPass> {
-  LogicalResult prepareForFpSan() {
-    auto calls = getFpSanRequiredCalls(getOperation());
-    for (auto [call, requirement] : calls) {
-      auto diagnostic = call.emitOpError("must be inlined before FPSan");
-      diagnostic.attachNote(requirement.cause->getLoc()) << requirement.reason;
-    }
-    return success(calls.empty());
-  }
-
 public:
   using impl::TritonInstrumentFpSanitizerBase<
       FpSanitizerPass>::TritonInstrumentFpSanitizerBase;
 
   void runOnOperation() override {
-    if (failed(prepareForFpSan())) {
+    auto calls = getFpSanCallsRequiringInlining(getOperation());
+    for (auto [call, requirement] : calls) {
+      auto diagnostic = call.emitOpError("must be inlined before FPSan");
+      diagnostic.attachNote(requirement.cause->getLoc()) << requirement.reason;
+    }
+    if (!calls.empty()) {
       signalPassFailure();
       return;
     }

--- a/lib/Dialect/TritonInstrument/Transforms/FpSanitizer.cpp
+++ b/lib/Dialect/TritonInstrument/Transforms/FpSanitizer.cpp
@@ -1,7 +1,12 @@
+#include "mlir/Analysis/CallGraph.h"
 #include "mlir/IR/Diagnostics.h"
 #include "mlir/IR/PatternMatch.h"
 #include "mlir/IR/Types.h"
+#include "mlir/Pass/PassManager.h"
 #include "mlir/Transforms/GreedyPatternRewriteDriver.h"
+#include "mlir/Transforms/Inliner.h"
+#include "mlir/Transforms/InliningUtils.h"
+#include "mlir/Transforms/Passes.h"
 #include "mlir/Transforms/RegionUtils.h"
 #include "triton/Dialect/Triton/IR/Dialect.h"
 #include "triton/Dialect/TritonGPU/IR/Dialect.h"
@@ -12,7 +17,9 @@
 #include "triton/Dialect/TritonNvidiaGPU/IR/Dialect.h"
 #include "triton/Dialect/TritonNvidiaGPU/IR/TensorMemoryUtils.h"
 #include "triton/Tools/LayoutUtils.h"
+#include "llvm/ADT/SCCIterator.h"
 #include "llvm/ADT/STLExtras.h"
+#include "llvm/ADT/ScopeExit.h"
 #include "llvm/ADT/StringSwitch.h"
 #include <cassert>
 #include <functional>
@@ -3331,6 +3338,59 @@ getFpSanCallsRequiringInlining(ModuleOp module) {
   return calls;
 }
 
+static void inlineFpSanRequiredCalls(ModuleOp module) {
+  auto calls = getFpSanCallsRequiringInlining(module);
+  if (calls.empty())
+    return;
+
+  // Only acyclic callees may be expanded. Keep the function definitions until
+  // the final DCE, so this set remains valid as requirements are rediscovered.
+  DenseSet<Operation *> recursiveFunctions;
+  const CallGraph callGraph(module);
+  for (auto scc = llvm::scc_begin(&callGraph); !scc.isAtEnd(); ++scc) {
+    if (!scc.hasCycle())
+      continue;
+    for (CallGraphNode *node : *scc)
+      if (!node->isExternal())
+        recursiveFunctions.insert(node->getCallableRegion()->getParentOp());
+  }
+
+  InlinerInterface interface(module.getContext());
+  InlinerConfig config;
+  while (!calls.empty()) {
+    bool inlined = false;
+    for (auto [call, requirement] : calls) {
+      auto callee = cast<tt::FuncOp>(call.resolveCallable());
+      if (recursiveFunctions.contains(callee))
+        continue;
+      // Do not inline a multi-block callee into a single-block region.
+      if (!llvm::hasSingleElement(callee.getBody()) &&
+          call->getParentOp()->hasTrait<OpTrait::SingleBlock>())
+        continue;
+
+      // Override noinline for this invocation only, retaining all other dialect
+      // legality checks and leaving unrelated calls and arithmetic unchanged.
+      Attribute noinline = callee->removeAttr("noinline");
+      auto restore = llvm::scope_exit([&] {
+        if (noinline)
+          callee->setAttr("noinline", noinline);
+      });
+      if (succeeded(inlineCall(interface, config.getCloneCallback(),
+                               cast<CallOpInterface>(call.getOperation()),
+                               cast<CallableOpInterface>(callee.getOperation()),
+                               &callee.getBody(),
+                               /*shouldCloneInlinedRegion=*/true))) {
+        call.erase();
+        inlined = true;
+        break;
+      }
+    }
+    if (!inlined)
+      break;
+    calls = getFpSanCallsRequiringInlining(module);
+  }
+}
+
 class FpSanitizerPass
     : public impl::TritonInstrumentFpSanitizerBase<FpSanitizerPass> {
 public:
@@ -3338,6 +3398,15 @@ public:
       FpSanitizerPass>::TritonInstrumentFpSanitizerBase;
 
   void runOnOperation() override {
+    inlineFpSanRequiredCalls(getOperation());
+
+    OpPassManager cleanup;
+    cleanup.addPass(createSymbolDCEPass());
+    if (failed(runPipeline(cleanup, getOperation()))) {
+      signalPassFailure();
+      return;
+    }
+
     auto calls = getFpSanCallsRequiringInlining(getOperation());
     for (auto [call, requirement] : calls) {
       auto diagnostic = call.emitOpError("must be inlined before FPSan");

--- a/python/src/passes.cc
+++ b/python/src/passes.cc
@@ -108,8 +108,6 @@ void init_triton_passes_ttgpuir(py::module_ &m) {
         });
   ADD_PASS_WRAPPER_0("add_concurrency_sanitizer",
                      createTritonInstrumentConcurrencySanitizer);
-  ADD_PASS_WRAPPER_0("add_prepare_fp_sanitizer",
-                     createTritonInstrumentPrepareFpSanitizer);
   ADD_PASS_OPTION_WRAPPER_1("add_fp_sanitizer",
                             createTritonInstrumentFpSanitizer, bool);
   ADD_PASS_WRAPPER_0("add_optimize_partition_warps",

--- a/python/src/passes.cc
+++ b/python/src/passes.cc
@@ -108,6 +108,8 @@ void init_triton_passes_ttgpuir(py::module_ &m) {
         });
   ADD_PASS_WRAPPER_0("add_concurrency_sanitizer",
                      createTritonInstrumentConcurrencySanitizer);
+  ADD_PASS_WRAPPER_0("add_prepare_fp_sanitizer",
+                     createTritonInstrumentPrepareFpSanitizer);
   ADD_PASS_OPTION_WRAPPER_1("add_fp_sanitizer",
                             createTritonInstrumentFpSanitizer, bool);
   ADD_PASS_WRAPPER_0("add_optimize_partition_warps",

--- a/python/test/gluon/test_fpsan.py
+++ b/python/test/gluon/test_fpsan.py
@@ -2838,6 +2838,46 @@ def test_tcgen05_mma_scaled_two_ctas(device, fresh_knobs):
 
 
 @pytest.mark.skipif(not is_blackwell(), reason="Requires Blackwell")
+@pytest.mark.parametrize("nested", [False, True], ids=["direct", "nested"])
+def test_tmem_noinline_consumer(device, nested, fresh_knobs):
+    _require_cuda_backend(device)
+    fresh_knobs.compilation.instrumentation_mode = "fpsan"
+
+    @gluon.jit(noinline=True)
+    def read_tmem(tmem, out_ptr):
+        layout: gl.constexpr = tmem.get_reg_layout()
+        rows = gl.arange(0, 128, layout=gl.SliceLayout(1, layout))[:, None]
+        cols = gl.arange(0, 128, layout=gl.SliceLayout(0, layout))[None, :]
+        gl.store(out_ptr + rows * 128 + cols, tmem.load())
+
+    @gluon.jit(noinline=True)
+    def forward_tmem(tmem, out_ptr):
+        read_tmem(tmem, out_ptr)
+
+    @gluon.jit
+    def kernel(x_ptr, out_ptr, NESTED: gl.constexpr):
+        tmem = allocate_tensor_memory(gl.float32, [128, 128], TensorMemoryLayout((128, 128), col_stride=1))
+        layout: gl.constexpr = tmem.get_reg_layout()
+        rows = gl.arange(0, 128, layout=gl.SliceLayout(1, layout))[:, None]
+        cols = gl.arange(0, 128, layout=gl.SliceLayout(0, layout))[None, :]
+        tmem.store(gl.load(x_ptr + rows * 128 + cols))
+        if NESTED:
+            forward_tmem(tmem, out_ptr)
+        else:
+            read_tmem(tmem, out_ptr)
+
+    rs = np.random.RandomState(0)
+    x_bits = rs.randint(-(2**31), 2**31 - 1, size=(128, 128), dtype=np.int32)
+    x = torch.tensor(x_bits, device=device, dtype=torch.int32)
+    out = torch.empty_like(x)
+    compiled = kernel[(1, )](triton.TensorWrapper(x, dtype=torch.float32),
+                             triton.TensorWrapper(out, dtype=torch.float32), nested, num_warps=4)
+
+    assert "tt.call" not in compiled.asm["ttgir"]
+    _assert_payload_equal(out, x_bits)
+
+
+@pytest.mark.skipif(not is_blackwell(), reason="Requires Blackwell")
 def test_tmem_index_subslice(device, fresh_knobs):
     _require_cuda_backend(device)
 

--- a/test/TritonGPU/amd/amd-fpsan.mlir
+++ b/test/TritonGPU/amd/amd-fpsan.mlir
@@ -1,4 +1,4 @@
-// RUN: triton-opt %s -split-input-file -tritoninstrument-prepare-fp-sanitizer -tritonamdgpu-fp-sanitizer | FileCheck %s
+// RUN: triton-opt %s -split-input-file -symbol-dce -tritonamdgpu-fp-sanitizer | FileCheck %s
 
 #blocked = #ttg.blocked<{sizePerThread = [1, 4], threadsPerWarp = [64, 1], warpsPerCTA = [4, 1], order = [1, 0]}>
 module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.target = "hip:gfx950", "ttg.threads-per-warp" = 64 : i32} {
@@ -18,7 +18,7 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.targ
 #unpacked = #ttg.blocked<{sizePerThread = [1, 64], threadsPerWarp = [8, 8], warpsPerCTA = [1, 1], order = [1, 0]}>
 #scale = #ttg.blocked<{sizePerThread = [1, 2], threadsPerWarp = [8, 8], warpsPerCTA = [1, 1], order = [1, 0]}>
 module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 1 : i32, ttg.target = "hip:gfx950", "ttg.threads-per-warp" = 64 : i32} {
-  // Preparation removes dead functions before AMD-specific rewrites inspect them.
+  // Symbol DCE removes dead functions before AMD-specific rewrites inspect them.
   // CHECK-LABEL: @dead_scaled_upcast_kernel
   tt.func public @dead_scaled_upcast_kernel() {
     // CHECK: tt.return

--- a/test/TritonGPU/amd/amd-fpsan.mlir
+++ b/test/TritonGPU/amd/amd-fpsan.mlir
@@ -1,4 +1,4 @@
-// RUN: triton-opt %s -split-input-file -tritonamdgpu-fp-sanitizer | FileCheck %s
+// RUN: triton-opt %s -split-input-file -tritoninstrument-prepare-fp-sanitizer -tritonamdgpu-fp-sanitizer | FileCheck %s
 
 #blocked = #ttg.blocked<{sizePerThread = [1, 4], threadsPerWarp = [64, 1], warpsPerCTA = [4, 1], order = [1, 0]}>
 module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.target = "hip:gfx950", "ttg.threads-per-warp" = 64 : i32} {
@@ -9,6 +9,25 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.targ
     // CHECK-NOT: amdg.scaled_upcast_fp8
     %0 = amdg.scaled_upcast_fp8 %src scale %scale : tensor<32x128xf8E4M3FN, #blocked>, tensor<32x128xbf16, #blocked> -> tensor<32x128xbf16, #blocked>
     tt.return %0 : tensor<32x128xbf16, #blocked>
+  }
+}
+
+// -----
+
+#packed = #ttg.blocked<{sizePerThread = [1, 32], threadsPerWarp = [8, 8], warpsPerCTA = [1, 1], order = [1, 0]}>
+#unpacked = #ttg.blocked<{sizePerThread = [1, 64], threadsPerWarp = [8, 8], warpsPerCTA = [1, 1], order = [1, 0]}>
+#scale = #ttg.blocked<{sizePerThread = [1, 2], threadsPerWarp = [8, 8], warpsPerCTA = [1, 1], order = [1, 0]}>
+module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 1 : i32, ttg.target = "hip:gfx950", "ttg.threads-per-warp" = 64 : i32} {
+  // Preparation removes dead functions before AMD-specific rewrites inspect them.
+  // CHECK-LABEL: @dead_scaled_upcast_kernel
+  tt.func public @dead_scaled_upcast_kernel() {
+    // CHECK: tt.return
+    tt.return
+  }
+  // CHECK-NOT: @dead_compact_scaled_upcast
+  tt.func private @dead_compact_scaled_upcast(%src: tensor<8x256xi8, #packed>, %scale: tensor<8x16xi8, #scale>) -> tensor<8x512xbf16, #unpacked> {
+    %0 = amdg.scaled_upcast_fp4 %src scale %scale {axis = 1 : i32} : tensor<8x256xi8, #packed>, tensor<8x16xi8, #scale> -> tensor<8x512xbf16, #unpacked>
+    tt.return %0 : tensor<8x512xbf16, #unpacked>
   }
 }
 

--- a/test/TritonGPU/fpsan.mlir
+++ b/test/TritonGPU/fpsan.mlir
@@ -5,6 +5,26 @@
 
 //--- success.mlir
 
+module {
+  // CHECK-LABEL: @call_arithmetic
+  tt.func public @call_arithmetic(%x: f32, %y: f32) -> f32 {
+    // CHECK: tt.call @arithmetic
+    %result = tt.call @arithmetic(%x, %y) : (f32, f32) -> f32
+    tt.return %result : f32
+  }
+  // CHECK-LABEL: tt.func private @arithmetic
+  // CHECK-SAME: noinline = true
+  tt.func private @arithmetic(%x: f32, %y: f32) -> f32 attributes {noinline = true} {
+    // CHECK: tti.experimental_fpsan_embed
+    // CHECK: arith.addi
+    // CHECK: tti.experimental_fpsan_unembed
+    %result = arith.addf %x, %y : f32
+    tt.return %result : f32
+  }
+}
+
+// -----
+
 #blocked = #ttg.blocked<{sizePerThread = [1, 4], threadsPerWarp = [64, 1], warpsPerCTA = [4, 1], order = [1, 0]}>
 #dot_operand_a = #ttg.dot_op<{opIdx = 0, parent = #blocked}>
 #dot_operand_b = #ttg.dot_op<{opIdx = 1, parent = #blocked}>

--- a/test/TritonGPU/fpsan.mlir
+++ b/test/TritonGPU/fpsan.mlir
@@ -1,5 +1,5 @@
 // RUN: split-file %s %t
-// RUN: triton-opt %t/success.mlir -split-input-file -tritoninstrument-fp-sanitizer | FileCheck %t/success.mlir
+// RUN: triton-opt %t/success.mlir -split-input-file -symbol-dce -tritoninstrument-fp-sanitizer | FileCheck %t/success.mlir
 // RUN: triton-opt %t/canonicalize.mlir -canonicalize | FileCheck %t/canonicalize.mlir
 // RUN: not triton-opt %t/unsupported.mlir -tritoninstrument-fp-sanitizer 2>&1 | FileCheck %t/unsupported.mlir --check-prefix=FPSANERR
 

--- a/test/TritonGPU/nvidia-fpsan.mlir
+++ b/test/TritonGPU/nvidia-fpsan.mlir
@@ -1,5 +1,5 @@
 // RUN: split-file %s %t
-// RUN: triton-opt %t/success.mlir -split-input-file -allow-unregistered-dialect -tritoninstrument-fp-sanitizer -triton-nvidia-check-matmul-two-cta | FileCheck %t/success.mlir
+// RUN: triton-opt %t/success.mlir -split-input-file -allow-unregistered-dialect -symbol-dce -tritoninstrument-fp-sanitizer -triton-nvidia-check-matmul-two-cta | FileCheck %t/success.mlir
 // RUN: triton-opt %t/preserve-calls.mlir -tritoninstrument-fp-sanitizer | FileCheck %t/preserve-calls.mlir
 // RUN: triton-opt %t/required-calls.mlir -split-input-file -tritoninstrument-fp-sanitizer -verify-diagnostics
 // RUN: triton-opt %t/blocked-call.mlir -inline -tritoninstrument-fp-sanitizer -verify-diagnostics

--- a/test/TritonGPU/nvidia-fpsan.mlir
+++ b/test/TritonGPU/nvidia-fpsan.mlir
@@ -1,9 +1,8 @@
 // RUN: split-file %s %t
 // RUN: triton-opt %t/success.mlir -split-input-file -allow-unregistered-dialect -tritoninstrument-fp-sanitizer -triton-nvidia-check-matmul-two-cta | FileCheck %t/success.mlir
-// RUN: triton-opt %t/preserve-calls.mlir -tritoninstrument-prepare-fp-sanitizer | FileCheck %t/preserve-calls.mlir
-// RUN: triton-opt %t/required-calls.mlir -split-input-file -tritoninstrument-prepare-fp-sanitizer -verify-diagnostics
+// RUN: triton-opt %t/preserve-calls.mlir -tritoninstrument-fp-sanitizer | FileCheck %t/preserve-calls.mlir
 // RUN: triton-opt %t/required-calls.mlir -split-input-file -tritoninstrument-fp-sanitizer -verify-diagnostics
-// RUN: triton-opt %t/blocked-call.mlir -inline -tritoninstrument-prepare-fp-sanitizer -verify-diagnostics
+// RUN: triton-opt %t/blocked-call.mlir -inline -tritoninstrument-fp-sanitizer -verify-diagnostics
 
 //--- success.mlir
 

--- a/test/TritonGPU/nvidia-fpsan.mlir
+++ b/test/TritonGPU/nvidia-fpsan.mlir
@@ -670,7 +670,7 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32} {
     %memory = ttng.tmem_alloc : () -> !ttg.memdesc<128x128xf32, #tmem, #ttng.tensor_memory, mutable>
     %result = scf.if %pred -> tensor<128x128xf32, #blocked> {
       // A multi-block callee cannot be inlined into a single-block SCF region,
-      // even without noinline. Preparation must identify the remaining call.
+      // even without noinline. FPSan must diagnose the remaining call.
       // expected-error @below {{must be inlined before FPSan}}
       %value = tt.call @early_return(%memory, %pred) : (!ttg.memdesc<128x128xf32, #tmem, #ttng.tensor_memory, mutable>, i1) -> tensor<128x128xf32, #blocked>
       scf.yield %value : tensor<128x128xf32, #blocked>

--- a/test/TritonGPU/nvidia-fpsan.mlir
+++ b/test/TritonGPU/nvidia-fpsan.mlir
@@ -1,8 +1,9 @@
 // RUN: split-file %s %t
 // RUN: triton-opt %t/success.mlir -split-input-file -allow-unregistered-dialect -symbol-dce -tritoninstrument-fp-sanitizer -triton-nvidia-check-matmul-two-cta | FileCheck %t/success.mlir
-// RUN: triton-opt %t/preserve-calls.mlir -tritoninstrument-fp-sanitizer | FileCheck %t/preserve-calls.mlir
-// RUN: triton-opt %t/required-calls.mlir -split-input-file -tritoninstrument-fp-sanitizer -verify-diagnostics
+// RUN: triton-opt %t/preserve-calls.mlir -split-input-file -tritoninstrument-fp-sanitizer | FileCheck %t/preserve-calls.mlir
+// RUN: triton-opt %t/inlined-calls.mlir -split-input-file -tritoninstrument-fp-sanitizer | FileCheck %t/inlined-calls.mlir --implicit-check-not="tt.call" --implicit-check-not="tt.func private"
 // RUN: triton-opt %t/blocked-call.mlir -inline -tritoninstrument-fp-sanitizer -verify-diagnostics
+// RUN: triton-opt %t/recursive-call.mlir -tritoninstrument-fp-sanitizer -verify-diagnostics
 
 //--- success.mlir
 
@@ -548,19 +549,60 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32} {
   }
 }
 
-//--- required-calls.mlir
+// -----
 
 #blocked = #ttg.blocked<{sizePerThread = [1, 4], threadsPerWarp = [32, 1], warpsPerCTA = [4, 1], order = [0, 1]}>
 #tmem = #ttng.tensor_memory_encoding<blockM = 128, blockN = 128, colStride = 1>
 module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32} {
+  // CHECK-LABEL: @call_allocating_wrapper
+  tt.func public @call_allocating_wrapper(%x: f32) -> tensor<128x128xf32, #blocked> {
+    // CHECK: tt.call @ordinary
+    %input = tt.call @ordinary(%x) : (f32) -> f32
+    // CHECK: tt.call @allocating_wrapper
+    %value = tt.call @allocating_wrapper(%input) : (f32) -> tensor<128x128xf32, #blocked>
+    tt.return %value : tensor<128x128xf32, #blocked>
+  }
+  // CHECK-LABEL: tt.func private @ordinary
+  // CHECK-SAME: noinline = false
+  tt.func private @ordinary(%x: f32) -> f32 attributes {noinline = false} {
+    // CHECK: arith.addi
+    %one = arith.constant 1.0 : f32
+    %value = arith.addf %x, %one : f32
+    tt.return %value : f32
+  }
+  // Inlining the consumer resolves its argument without requiring the wrapper
+  // to be inlined, since the wrapper owns the allocation.
+  // CHECK-LABEL: tt.func private @allocating_wrapper
+  // CHECK-SAME: noinline = true
+  tt.func private @allocating_wrapper(%x: f32) -> tensor<128x128xf32, #blocked> attributes {noinline = true} {
+    // CHECK: ttg.global_scratch_alloc
+    // CHECK-NOT: tt.call
+    // CHECK: tt.load
+    // CHECK: tt.return
+    %input = tt.splat %x : f32 -> tensor<128x128xf32, #blocked>
+    %memory = ttng.tmem_alloc %input : (tensor<128x128xf32, #blocked>) -> !ttg.memdesc<128x128xf32, #tmem, #ttng.tensor_memory, mutable>
+    %value = tt.call @consumer(%memory) : (!ttg.memdesc<128x128xf32, #tmem, #ttng.tensor_memory, mutable>) -> tensor<128x128xf32, #blocked>
+    tt.return %value : tensor<128x128xf32, #blocked>
+  }
+  // CHECK-NOT: @consumer
+  tt.func private @consumer(%memory: !ttg.memdesc<128x128xf32, #tmem, #ttng.tensor_memory, mutable>) -> tensor<128x128xf32, #blocked> attributes {noinline = true} {
+    %value = ttng.tmem_load %memory : !ttg.memdesc<128x128xf32, #tmem, #ttng.tensor_memory, mutable> -> tensor<128x128xf32, #blocked>
+    tt.return %value : tensor<128x128xf32, #blocked>
+  }
+}
+
+//--- inlined-calls.mlir
+
+#blocked = #ttg.blocked<{sizePerThread = [1, 4], threadsPerWarp = [32, 1], warpsPerCTA = [4, 1], order = [0, 1]}>
+#tmem = #ttng.tensor_memory_encoding<blockM = 128, blockN = 128, colStride = 1>
+module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32} {
+  // CHECK-LABEL: @call_tmem
   tt.func public @call_tmem() -> tensor<128x128xf32, #blocked> {
     %memory = ttng.tmem_alloc : () -> !ttg.memdesc<128x128xf32, #tmem, #ttng.tensor_memory, mutable>
-    // expected-error @below {{must be inlined before FPSan}}
     %value = tt.call @read_tmem(%memory) : (!ttg.memdesc<128x128xf32, #tmem, #ttng.tensor_memory, mutable>) -> tensor<128x128xf32, #blocked>
     tt.return %value : tensor<128x128xf32, #blocked>
   }
   tt.func private @read_tmem(%memory: !ttg.memdesc<128x128xf32, #tmem, #ttng.tensor_memory, mutable>) -> tensor<128x128xf32, #blocked> attributes {noinline = true} {
-    // expected-note @below {{FPSan needs the allocation behind this tensor memory argument}}
     %value = ttng.tmem_load %memory : !ttg.memdesc<128x128xf32, #tmem, #ttng.tensor_memory, mutable> -> tensor<128x128xf32, #blocked>
     tt.return %value : tensor<128x128xf32, #blocked>
   }
@@ -571,12 +613,11 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32} {
 #blocked = #ttg.blocked<{sizePerThread = [1, 4], threadsPerWarp = [32, 1], warpsPerCTA = [4, 1], order = [0, 1]}>
 #tmem = #ttng.tensor_memory_encoding<blockM = 128, blockN = 128, colStride = 1>
 module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32} {
+  // CHECK-LABEL: @call_tmem_result
   tt.func public @call_tmem_result() -> tensor<128x128xf32, #blocked> {
     %memory = ttng.tmem_alloc : () -> !ttg.memdesc<128x128xf32, #tmem, #ttng.tensor_memory, mutable>
     // A producer can hide provenance without doing any TMEM arithmetic itself.
-    // expected-error @below {{must be inlined before FPSan}}
     %alias = tt.call @identity(%memory) : (!ttg.memdesc<128x128xf32, #tmem, #ttng.tensor_memory, mutable>) -> !ttg.memdesc<128x128xf32, #tmem, #ttng.tensor_memory, mutable>
-    // expected-note @below {{FPSan needs the allocation behind this tensor memory call result}}
     %value = ttng.tmem_load %alias : !ttg.memdesc<128x128xf32, #tmem, #ttng.tensor_memory, mutable> -> tensor<128x128xf32, #blocked>
     tt.return %value : tensor<128x128xf32, #blocked>
   }
@@ -590,18 +631,17 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32} {
 #blocked = #ttg.blocked<{sizePerThread = [1, 4], threadsPerWarp = [32, 1], warpsPerCTA = [4, 1], order = [0, 1]}>
 #tmem = #ttng.tensor_memory_encoding<blockM = 128, blockN = 128, colStride = 1>
 module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32} {
+  // CHECK-LABEL: @call_forwarder
   tt.func public @call_forwarder() -> tensor<128x128xf32, #blocked> {
     %memory = ttng.tmem_alloc : () -> !ttg.memdesc<128x128xf32, #tmem, #ttng.tensor_memory, mutable>
     %value = tt.call @forward(%memory) : (!ttg.memdesc<128x128xf32, #tmem, #ttng.tensor_memory, mutable>) -> tensor<128x128xf32, #blocked>
     tt.return %value : tensor<128x128xf32, #blocked>
   }
   tt.func private @forward(%memory: !ttg.memdesc<128x128xf32, #tmem, #ttng.tensor_memory, mutable>) -> tensor<128x128xf32, #blocked> attributes {noinline = true} {
-    // expected-error @below {{must be inlined before FPSan}}
     %value = tt.call @read_tmem(%memory) : (!ttg.memdesc<128x128xf32, #tmem, #ttng.tensor_memory, mutable>) -> tensor<128x128xf32, #blocked>
     tt.return %value : tensor<128x128xf32, #blocked>
   }
   tt.func private @read_tmem(%memory: !ttg.memdesc<128x128xf32, #tmem, #ttng.tensor_memory, mutable>) -> tensor<128x128xf32, #blocked> attributes {noinline = true} {
-    // expected-note @below {{FPSan needs the allocation behind this tensor memory argument}}
     %value = ttng.tmem_load %memory : !ttg.memdesc<128x128xf32, #tmem, #ttng.tensor_memory, mutable> -> tensor<128x128xf32, #blocked>
     tt.return %value : tensor<128x128xf32, #blocked>
   }
@@ -610,13 +650,12 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32} {
 // -----
 
 module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32} {
+  // CHECK-LABEL: @call_warp_specialized_helper
   tt.func public @call_warp_specialized_helper() {
-    // expected-error @below {{must be inlined before FPSan}}
     tt.call @warp_specialized_helper() : () -> ()
     tt.return
   }
   tt.func private @warp_specialized_helper() attributes {noinline = true} {
-    // expected-note @below {{warp specialization requires kernel context}}
     ttg.warp_specialize()
     default {
       ttg.warp_yield
@@ -635,6 +674,7 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32} {
 #barrier = #ttg.swizzled_shared<{vec = 1, perPhase = 1, maxPhase = 1, order = [0], CGALayout = [[1]]}>
 #tmem = #ttng.tensor_memory_encoding<blockM = 128, blockN = 128, colStride = 1, CGALayout = [[1, 0]], twoCTAs = true>
 module attributes {"ttg.num-ctas" = 2 : i32, "ttg.num-warps" = 4 : i32} {
+  // CHECK-LABEL: @call_commit_from_partition
   tt.func public @call_commit_from_partition() {
     %true = arith.constant true
     %a = ttg.local_alloc : () -> !ttg.memdesc<256x128xf16, #shared_a, #ttg.shared_memory, mutable>
@@ -647,7 +687,6 @@ module attributes {"ttg.num-ctas" = 2 : i32, "ttg.num-warps" = 4 : i32} {
       ttg.warp_yield
     }
     partition0(%part_bar: !ttg.memdesc<1xi64, #barrier, #ttg.shared_memory, mutable>) num_warps(4) {
-      // expected-error @below {{must be inlined before FPSan}}
       tt.call @commit(%part_bar) : (!ttg.memdesc<1xi64, #barrier, #ttg.shared_memory, mutable>) -> ()
       ttg.warp_return
     } : (!ttg.memdesc<1xi64, #barrier, #ttg.shared_memory, mutable>) -> ()
@@ -655,9 +694,30 @@ module attributes {"ttg.num-ctas" = 2 : i32, "ttg.num-warps" = 4 : i32} {
   }
   tt.func private @commit(%bar: !ttg.memdesc<1xi64, #barrier, #ttg.shared_memory, mutable>) attributes {noinline = true} {
     %true = arith.constant true
-    // expected-note @below {{FPSan cluster scratch and barriers require kernel context}}
     ttng.tc_gen5_commit %bar, %true : !ttg.memdesc<1xi64, #barrier, #ttg.shared_memory, mutable>
     tt.return
+  }
+}
+
+// -----
+
+#blocked = #ttg.blocked<{sizePerThread = [1, 4], threadsPerWarp = [32, 1], warpsPerCTA = [4, 1], order = [0, 1]}>
+#tmem = #ttng.tensor_memory_encoding<blockM = 128, blockN = 128, colStride = 1>
+module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32} {
+  // CHECK-LABEL: @call_cfg_in_function
+  tt.func public @call_cfg_in_function(%pred: i1) -> tensor<128x128xf32, #blocked> {
+    %memory = ttng.tmem_alloc : () -> !ttg.memdesc<128x128xf32, #tmem, #ttng.tensor_memory, mutable>
+    %value = tt.call @early_return(%memory, %pred) : (!ttg.memdesc<128x128xf32, #tmem, #ttng.tensor_memory, mutable>, i1) -> tensor<128x128xf32, #blocked>
+    tt.return %value : tensor<128x128xf32, #blocked>
+  }
+  tt.func private @early_return(%memory: !ttg.memdesc<128x128xf32, #tmem, #ttng.tensor_memory, mutable>, %pred: i1) -> tensor<128x128xf32, #blocked> attributes {noinline = true} {
+    cf.cond_br %pred, ^load, ^zero
+  ^load:
+    %value = ttng.tmem_load %memory : !ttg.memdesc<128x128xf32, #tmem, #ttng.tensor_memory, mutable> -> tensor<128x128xf32, #blocked>
+    tt.return %value : tensor<128x128xf32, #blocked>
+  ^zero:
+    %zero = arith.constant dense<0.0> : tensor<128x128xf32, #blocked>
+    tt.return %zero : tensor<128x128xf32, #blocked>
   }
 }
 
@@ -689,5 +749,26 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32} {
   ^zero:
     %zero = arith.constant dense<0.0> : tensor<128x128xf32, #blocked>
     tt.return %zero : tensor<128x128xf32, #blocked>
+  }
+}
+
+//--- recursive-call.mlir
+
+#blocked = #ttg.blocked<{sizePerThread = [1, 4], threadsPerWarp = [32, 1], warpsPerCTA = [4, 1], order = [0, 1]}>
+#tmem = #ttng.tensor_memory_encoding<blockM = 128, blockN = 128, colStride = 1>
+module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32} {
+  tt.func public @call_recursive_producer() -> tensor<128x128xf32, #blocked> {
+    %memory = ttng.tmem_alloc : () -> !ttg.memdesc<128x128xf32, #tmem, #ttng.tensor_memory, mutable>
+    // Only this invocation initially requires inlining. The unselected
+    // recursive invocation must not cause unbounded expansion.
+    // expected-error @below {{must be inlined before FPSan}}
+    %alias = tt.call @recursive_identity(%memory) : (!ttg.memdesc<128x128xf32, #tmem, #ttng.tensor_memory, mutable>) -> !ttg.memdesc<128x128xf32, #tmem, #ttng.tensor_memory, mutable>
+    // expected-note @below {{FPSan needs the allocation behind this tensor memory call result}}
+    %value = ttng.tmem_load %alias : !ttg.memdesc<128x128xf32, #tmem, #ttng.tensor_memory, mutable> -> tensor<128x128xf32, #blocked>
+    tt.return %value : tensor<128x128xf32, #blocked>
+  }
+  tt.func private @recursive_identity(%memory: !ttg.memdesc<128x128xf32, #tmem, #ttng.tensor_memory, mutable>) -> !ttg.memdesc<128x128xf32, #tmem, #ttng.tensor_memory, mutable> attributes {noinline = true} {
+    %alias = tt.call @recursive_identity(%memory) : (!ttg.memdesc<128x128xf32, #tmem, #ttng.tensor_memory, mutable>) -> !ttg.memdesc<128x128xf32, #tmem, #ttng.tensor_memory, mutable>
+    tt.return %alias : !ttg.memdesc<128x128xf32, #tmem, #ttng.tensor_memory, mutable>
   }
 }

--- a/test/TritonGPU/nvidia-fpsan.mlir
+++ b/test/TritonGPU/nvidia-fpsan.mlir
@@ -1,7 +1,55 @@
 // RUN: split-file %s %t
 // RUN: triton-opt %t/success.mlir -split-input-file -allow-unregistered-dialect -tritoninstrument-fp-sanitizer -triton-nvidia-check-matmul-two-cta | FileCheck %t/success.mlir
+// RUN: triton-opt %t/preserve-calls.mlir -tritoninstrument-prepare-fp-sanitizer | FileCheck %t/preserve-calls.mlir
+// RUN: triton-opt %t/required-calls.mlir -split-input-file -tritoninstrument-prepare-fp-sanitizer -verify-diagnostics
+// RUN: triton-opt %t/required-calls.mlir -split-input-file -tritoninstrument-fp-sanitizer -verify-diagnostics
+// RUN: triton-opt %t/blocked-call.mlir -inline -tritoninstrument-prepare-fp-sanitizer -verify-diagnostics
 
 //--- success.mlir
+
+#blocked = #ttg.blocked<{sizePerThread = [1, 4], threadsPerWarp = [32, 1], warpsPerCTA = [4, 1], order = [0, 1]}>
+#tmem = #ttng.tensor_memory_encoding<blockM = 128, blockN = 128, colStride = 1>
+module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32} {
+  // CHECK-LABEL: @empty_kernel
+  tt.func public @empty_kernel() {
+    // CHECK: tt.return
+    tt.return
+  }
+  // The dead helper must disappear before FPSan resolves its TMEM argument.
+  // CHECK-NOT: @unused_tmem
+  // CHECK-NOT: ttng.tmem_load
+  tt.func private @unused_tmem(%memory: !ttg.memdesc<128x128xf32, #tmem, #ttng.tensor_memory, mutable>) -> tensor<128x128xf32, #blocked> {
+    %value = ttng.tmem_load %memory : !ttg.memdesc<128x128xf32, #tmem, #ttng.tensor_memory, mutable> -> tensor<128x128xf32, #blocked>
+    tt.return %value : tensor<128x128xf32, #blocked>
+  }
+}
+
+// -----
+
+#blocked = #ttg.blocked<{sizePerThread = [1, 4], threadsPerWarp = [32, 1], warpsPerCTA = [4, 1], order = [0, 1]}>
+#tmem = #ttng.tensor_memory_encoding<blockM = 128, blockN = 128, colStride = 1>
+module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32} {
+  // CHECK-LABEL: @call_local_tmem
+  tt.func public @call_local_tmem() -> tensor<128x128xf32, #blocked> {
+    // CHECK: tt.call @local_tmem
+    %result = tt.call @local_tmem() : () -> tensor<128x128xf32, #blocked>
+    tt.return %result : tensor<128x128xf32, #blocked>
+  }
+  // A helper with its own allocation does not hide TMEM provenance.
+  // CHECK-LABEL: tt.func private @local_tmem
+  // CHECK-SAME: noinline = true
+  tt.func private @local_tmem() -> tensor<128x128xf32, #blocked> attributes {noinline = true} {
+    // CHECK: ttg.global_scratch_alloc
+    // CHECK: tt.load
+    // CHECK-NOT: ttng.tmem_load
+    %zero = arith.constant dense<0.0> : tensor<128x128xf32, #blocked>
+    %memory = ttng.tmem_alloc %zero : (tensor<128x128xf32, #blocked>) -> !ttg.memdesc<128x128xf32, #tmem, #ttng.tensor_memory, mutable>
+    %value = ttng.tmem_load %memory : !ttg.memdesc<128x128xf32, #tmem, #ttng.tensor_memory, mutable> -> tensor<128x128xf32, #blocked>
+    tt.return %value : tensor<128x128xf32, #blocked>
+  }
+}
+
+// -----
 
 #blocked = #ttg.blocked<{sizePerThread = [1, 64], threadsPerWarp = [32, 1], warpsPerCTA = [4, 1], order = [0, 1]}>
 #blocked_reduce = #ttg.blocked<{sizePerThread = [1, 128], threadsPerWarp = [32, 1], warpsPerCTA = [4, 1], order = [0, 1]}>
@@ -469,5 +517,178 @@ module attributes {"ttg.num-ctas" = 2 : i32, "ttg.num-warps" = 4 : i32, ttg.shar
     %bar = ttg.local_alloc {allocation.offset = 8192 : i32} : () -> !ttg.memdesc<1xi64, #shared1, #smem, mutable>
     ttng.tc_gen5_mma_scaled %a, %b, %d, %a_scale, %b_scale, %true, %true lhs = e2m1 rhs = e2m1, %bar[%true] {is_async, two_ctas} : !ttg.memdesc<256x256xi8, #shared_a, #smem, mutable>, !ttg.memdesc<256x128xi8, #shared_b, #smem, mutable>, !ttg.memdesc<256x128xf32, #tmem, #ttng.tensor_memory, mutable>, !ttg.memdesc<256x8xf8E4M3FN, #tmem_scale_a, #ttng.tensor_memory, mutable>, !ttg.memdesc<128x8xf8E4M3FN, #tmem_scale_b, #ttng.tensor_memory, mutable>, !ttg.memdesc<1xi64, #shared1, #smem, mutable>
     tt.return
+  }
+}
+
+//--- preserve-calls.mlir
+
+#blocked = #ttg.blocked<{sizePerThread = [1, 4], threadsPerWarp = [32, 1], warpsPerCTA = [4, 1], order = [0, 1]}>
+#shared = #ttg.swizzled_shared<{vec = 1, perPhase = 1, maxPhase = 1, order = [0, 1]}>
+#tmem = #ttng.tensor_memory_encoding<blockM = 128, blockN = 128, colStride = 1>
+module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32} {
+  // CHECK-LABEL: @preserve_calls
+  tt.func public @preserve_calls() -> tensor<128x128xf32, #blocked> {
+    %memory = ttng.tmem_alloc : () -> !ttg.memdesc<128x128xf32, #tmem, #ttng.tensor_memory, mutable>
+    // CHECK: tt.call @unused_argument
+    tt.call @unused_argument(%memory) : (!ttg.memdesc<128x128xf32, #tmem, #ttng.tensor_memory, mutable>) -> ()
+    %shared = ttg.local_alloc : () -> !ttg.memdesc<128x128xf32, #shared, #ttg.shared_memory, mutable>
+    // CHECK: tt.call @shared_load
+    %value = tt.call @shared_load(%shared) : (!ttg.memdesc<128x128xf32, #shared, #ttg.shared_memory, mutable>) -> tensor<128x128xf32, #blocked>
+    tt.return %value : tensor<128x128xf32, #blocked>
+  }
+  // CHECK-LABEL: tt.func private @unused_argument
+  // CHECK-SAME: noinline = true
+  tt.func private @unused_argument(%memory: !ttg.memdesc<128x128xf32, #tmem, #ttng.tensor_memory, mutable>) attributes {noinline = true} {
+    tt.return
+  }
+  // CHECK-LABEL: tt.func private @shared_load
+  // CHECK-SAME: noinline = true
+  tt.func private @shared_load(%memory: !ttg.memdesc<128x128xf32, #shared, #ttg.shared_memory, mutable>) -> tensor<128x128xf32, #blocked> attributes {noinline = true} {
+    %value = ttg.local_load %memory : !ttg.memdesc<128x128xf32, #shared, #ttg.shared_memory, mutable> -> tensor<128x128xf32, #blocked>
+    tt.return %value : tensor<128x128xf32, #blocked>
+  }
+}
+
+//--- required-calls.mlir
+
+#blocked = #ttg.blocked<{sizePerThread = [1, 4], threadsPerWarp = [32, 1], warpsPerCTA = [4, 1], order = [0, 1]}>
+#tmem = #ttng.tensor_memory_encoding<blockM = 128, blockN = 128, colStride = 1>
+module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32} {
+  tt.func public @call_tmem() -> tensor<128x128xf32, #blocked> {
+    %memory = ttng.tmem_alloc : () -> !ttg.memdesc<128x128xf32, #tmem, #ttng.tensor_memory, mutable>
+    // expected-error @below {{must be inlined before FPSan}}
+    %value = tt.call @read_tmem(%memory) : (!ttg.memdesc<128x128xf32, #tmem, #ttng.tensor_memory, mutable>) -> tensor<128x128xf32, #blocked>
+    tt.return %value : tensor<128x128xf32, #blocked>
+  }
+  tt.func private @read_tmem(%memory: !ttg.memdesc<128x128xf32, #tmem, #ttng.tensor_memory, mutable>) -> tensor<128x128xf32, #blocked> attributes {noinline = true} {
+    // expected-note @below {{FPSan needs the allocation behind this tensor memory argument}}
+    %value = ttng.tmem_load %memory : !ttg.memdesc<128x128xf32, #tmem, #ttng.tensor_memory, mutable> -> tensor<128x128xf32, #blocked>
+    tt.return %value : tensor<128x128xf32, #blocked>
+  }
+}
+
+// -----
+
+#blocked = #ttg.blocked<{sizePerThread = [1, 4], threadsPerWarp = [32, 1], warpsPerCTA = [4, 1], order = [0, 1]}>
+#tmem = #ttng.tensor_memory_encoding<blockM = 128, blockN = 128, colStride = 1>
+module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32} {
+  tt.func public @call_tmem_result() -> tensor<128x128xf32, #blocked> {
+    %memory = ttng.tmem_alloc : () -> !ttg.memdesc<128x128xf32, #tmem, #ttng.tensor_memory, mutable>
+    // A producer can hide provenance without doing any TMEM arithmetic itself.
+    // expected-error @below {{must be inlined before FPSan}}
+    %alias = tt.call @identity(%memory) : (!ttg.memdesc<128x128xf32, #tmem, #ttng.tensor_memory, mutable>) -> !ttg.memdesc<128x128xf32, #tmem, #ttng.tensor_memory, mutable>
+    // expected-note @below {{FPSan needs the allocation behind this tensor memory call result}}
+    %value = ttng.tmem_load %alias : !ttg.memdesc<128x128xf32, #tmem, #ttng.tensor_memory, mutable> -> tensor<128x128xf32, #blocked>
+    tt.return %value : tensor<128x128xf32, #blocked>
+  }
+  tt.func private @identity(%memory: !ttg.memdesc<128x128xf32, #tmem, #ttng.tensor_memory, mutable>) -> !ttg.memdesc<128x128xf32, #tmem, #ttng.tensor_memory, mutable> attributes {noinline = true} {
+    tt.return %memory : !ttg.memdesc<128x128xf32, #tmem, #ttng.tensor_memory, mutable>
+  }
+}
+
+// -----
+
+#blocked = #ttg.blocked<{sizePerThread = [1, 4], threadsPerWarp = [32, 1], warpsPerCTA = [4, 1], order = [0, 1]}>
+#tmem = #ttng.tensor_memory_encoding<blockM = 128, blockN = 128, colStride = 1>
+module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32} {
+  tt.func public @call_forwarder() -> tensor<128x128xf32, #blocked> {
+    %memory = ttng.tmem_alloc : () -> !ttg.memdesc<128x128xf32, #tmem, #ttng.tensor_memory, mutable>
+    %value = tt.call @forward(%memory) : (!ttg.memdesc<128x128xf32, #tmem, #ttng.tensor_memory, mutable>) -> tensor<128x128xf32, #blocked>
+    tt.return %value : tensor<128x128xf32, #blocked>
+  }
+  tt.func private @forward(%memory: !ttg.memdesc<128x128xf32, #tmem, #ttng.tensor_memory, mutable>) -> tensor<128x128xf32, #blocked> attributes {noinline = true} {
+    // expected-error @below {{must be inlined before FPSan}}
+    %value = tt.call @read_tmem(%memory) : (!ttg.memdesc<128x128xf32, #tmem, #ttng.tensor_memory, mutable>) -> tensor<128x128xf32, #blocked>
+    tt.return %value : tensor<128x128xf32, #blocked>
+  }
+  tt.func private @read_tmem(%memory: !ttg.memdesc<128x128xf32, #tmem, #ttng.tensor_memory, mutable>) -> tensor<128x128xf32, #blocked> attributes {noinline = true} {
+    // expected-note @below {{FPSan needs the allocation behind this tensor memory argument}}
+    %value = ttng.tmem_load %memory : !ttg.memdesc<128x128xf32, #tmem, #ttng.tensor_memory, mutable> -> tensor<128x128xf32, #blocked>
+    tt.return %value : tensor<128x128xf32, #blocked>
+  }
+}
+
+// -----
+
+module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32} {
+  tt.func public @call_warp_specialized_helper() {
+    // expected-error @below {{must be inlined before FPSan}}
+    tt.call @warp_specialized_helper() : () -> ()
+    tt.return
+  }
+  tt.func private @warp_specialized_helper() attributes {noinline = true} {
+    // expected-note @below {{warp specialization requires kernel context}}
+    ttg.warp_specialize()
+    default {
+      ttg.warp_yield
+    }
+    partition0() num_warps(4) {
+      ttg.warp_return
+    } : () -> ()
+    tt.return
+  }
+}
+
+// -----
+
+#shared_a = #ttg.nvmma_shared<{swizzlingByteWidth = 128, transposed = false, elementBitWidth = 16, CGALayout = [[1, 0]]}>
+#shared_b = #ttg.nvmma_shared<{swizzlingByteWidth = 128, transposed = false, elementBitWidth = 16, CGALayout = [[0, 1]]}>
+#barrier = #ttg.swizzled_shared<{vec = 1, perPhase = 1, maxPhase = 1, order = [0], CGALayout = [[1]]}>
+#tmem = #ttng.tensor_memory_encoding<blockM = 128, blockN = 128, colStride = 1, CGALayout = [[1, 0]], twoCTAs = true>
+module attributes {"ttg.num-ctas" = 2 : i32, "ttg.num-warps" = 4 : i32} {
+  tt.func public @call_commit_from_partition() {
+    %true = arith.constant true
+    %a = ttg.local_alloc : () -> !ttg.memdesc<256x128xf16, #shared_a, #ttg.shared_memory, mutable>
+    %b = ttg.local_alloc : () -> !ttg.memdesc<128x128xf16, #shared_b, #ttg.shared_memory, mutable>
+    %d = ttng.tmem_alloc : () -> !ttg.memdesc<256x128xf32, #tmem, #ttng.tensor_memory, mutable>
+    %bar = ttg.local_alloc : () -> !ttg.memdesc<1xi64, #barrier, #ttg.shared_memory, mutable>
+    ttg.warp_specialize(%bar)
+    default {
+      ttng.tc_gen5_mma %a, %b, %d, %true, %true {two_ctas} : !ttg.memdesc<256x128xf16, #shared_a, #ttg.shared_memory, mutable>, !ttg.memdesc<128x128xf16, #shared_b, #ttg.shared_memory, mutable>, !ttg.memdesc<256x128xf32, #tmem, #ttng.tensor_memory, mutable>
+      ttg.warp_yield
+    }
+    partition0(%part_bar: !ttg.memdesc<1xi64, #barrier, #ttg.shared_memory, mutable>) num_warps(4) {
+      // expected-error @below {{must be inlined before FPSan}}
+      tt.call @commit(%part_bar) : (!ttg.memdesc<1xi64, #barrier, #ttg.shared_memory, mutable>) -> ()
+      ttg.warp_return
+    } : (!ttg.memdesc<1xi64, #barrier, #ttg.shared_memory, mutable>) -> ()
+    tt.return
+  }
+  tt.func private @commit(%bar: !ttg.memdesc<1xi64, #barrier, #ttg.shared_memory, mutable>) attributes {noinline = true} {
+    %true = arith.constant true
+    // expected-note @below {{FPSan cluster scratch and barriers require kernel context}}
+    ttng.tc_gen5_commit %bar, %true : !ttg.memdesc<1xi64, #barrier, #ttg.shared_memory, mutable>
+    tt.return
+  }
+}
+
+//--- blocked-call.mlir
+
+#blocked = #ttg.blocked<{sizePerThread = [1, 4], threadsPerWarp = [32, 1], warpsPerCTA = [4, 1], order = [0, 1]}>
+#tmem = #ttng.tensor_memory_encoding<blockM = 128, blockN = 128, colStride = 1>
+module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32} {
+  tt.func public @call_in_if(%pred: i1) -> tensor<128x128xf32, #blocked> {
+    %memory = ttng.tmem_alloc : () -> !ttg.memdesc<128x128xf32, #tmem, #ttng.tensor_memory, mutable>
+    %result = scf.if %pred -> tensor<128x128xf32, #blocked> {
+      // A multi-block callee cannot be inlined into a single-block SCF region,
+      // even without noinline. Preparation must identify the remaining call.
+      // expected-error @below {{must be inlined before FPSan}}
+      %value = tt.call @early_return(%memory, %pred) : (!ttg.memdesc<128x128xf32, #tmem, #ttng.tensor_memory, mutable>, i1) -> tensor<128x128xf32, #blocked>
+      scf.yield %value : tensor<128x128xf32, #blocked>
+    } else {
+      %zero = arith.constant dense<0.0> : tensor<128x128xf32, #blocked>
+      scf.yield %zero : tensor<128x128xf32, #blocked>
+    }
+    tt.return %result : tensor<128x128xf32, #blocked>
+  }
+  tt.func private @early_return(%memory: !ttg.memdesc<128x128xf32, #tmem, #ttng.tensor_memory, mutable>, %pred: i1) -> tensor<128x128xf32, #blocked> attributes {noinline = false} {
+    cf.cond_br %pred, ^load, ^zero
+  ^load:
+    // expected-note @below {{FPSan needs the allocation behind this tensor memory argument}}
+    %value = ttng.tmem_load %memory : !ttg.memdesc<128x128xf32, #tmem, #ttng.tensor_memory, mutable> -> tensor<128x128xf32, #blocked>
+    tt.return %value : tensor<128x128xf32, #blocked>
+  ^zero:
+    %zero = arith.constant dense<0.0> : tensor<128x128xf32, #blocked>
+    tt.return %zero : tensor<128x128xf32, #blocked>
   }
 }

--- a/third_party/amd/backend/compiler.py
+++ b/third_party/amd/backend/compiler.py
@@ -317,6 +317,7 @@ class HIPBackend(BaseBackend):
         passes.common.add_cse(pm)
         passes.common.add_symbol_dce(pm)
         if options.instrumentation_mode == "fpsan" and is_fpsan_supported(options.arch):
+            passes.ttgpuir.add_prepare_fp_sanitizer(pm)
             amd.passes.ttgpuir.add_fp_sanitizer(pm)
             passes.ttgpuir.add_fp_sanitizer(pm, options.fpsan_homomorphic_casts)
         pm.run(mod, 'make_ttgir')
@@ -336,6 +337,8 @@ class HIPBackend(BaseBackend):
         passes.gluon.add_canonicalizer(pm)
         passes.ttir.add_loop_unroll(pm)
         passes.ttgpuir.add_combine_tensor_select_and_if(pm)
+        if options.instrumentation_mode == "fpsan" and is_fpsan_supported(options.arch):
+            passes.ttgpuir.add_prepare_fp_sanitizer(pm)
         amd.passes.ttgpuir.add_warp_pipeline(pm)
         passes.ttgpuir.add_allocate_warp_groups(pm)
 

--- a/third_party/amd/backend/compiler.py
+++ b/third_party/amd/backend/compiler.py
@@ -317,7 +317,6 @@ class HIPBackend(BaseBackend):
         passes.common.add_cse(pm)
         passes.common.add_symbol_dce(pm)
         if options.instrumentation_mode == "fpsan" and is_fpsan_supported(options.arch):
-            passes.ttgpuir.add_prepare_fp_sanitizer(pm)
             amd.passes.ttgpuir.add_fp_sanitizer(pm)
             passes.ttgpuir.add_fp_sanitizer(pm, options.fpsan_homomorphic_casts)
         pm.run(mod, 'make_ttgir')
@@ -338,7 +337,7 @@ class HIPBackend(BaseBackend):
         passes.ttir.add_loop_unroll(pm)
         passes.ttgpuir.add_combine_tensor_select_and_if(pm)
         if options.instrumentation_mode == "fpsan" and is_fpsan_supported(options.arch):
-            passes.ttgpuir.add_prepare_fp_sanitizer(pm)
+            passes.common.add_symbol_dce(pm)
         amd.passes.ttgpuir.add_warp_pipeline(pm)
         passes.ttgpuir.add_allocate_warp_groups(pm)
 

--- a/third_party/nvidia/backend/compiler.py
+++ b/third_party/nvidia/backend/compiler.py
@@ -389,6 +389,8 @@ class CUDABackend(BaseBackend):
         passes.ttir.add_loop_aware_cse(pm)
         passes.gluon.add_canonicalizer(pm)
         passes.ttgpuir.add_combine_tensor_select_and_if(pm)
+        if "fpsan" in options.instrumentation_mode:
+            passes.ttgpuir.add_prepare_fp_sanitizer(pm)
         nvidia.passes.ttnvgpuir.add_check_matmul_two_cta(pm)
 
         if "fpsan" in options.instrumentation_mode:

--- a/third_party/nvidia/backend/compiler.py
+++ b/third_party/nvidia/backend/compiler.py
@@ -389,8 +389,7 @@ class CUDABackend(BaseBackend):
         passes.ttir.add_loop_aware_cse(pm)
         passes.gluon.add_canonicalizer(pm)
         passes.ttgpuir.add_combine_tensor_select_and_if(pm)
-        if "fpsan" in options.instrumentation_mode:
-            passes.common.add_symbol_dce(pm)
+        passes.common.add_symbol_dce(pm)
         nvidia.passes.ttnvgpuir.add_check_matmul_two_cta(pm)
 
         if "fpsan" in options.instrumentation_mode:

--- a/third_party/nvidia/backend/compiler.py
+++ b/third_party/nvidia/backend/compiler.py
@@ -390,7 +390,7 @@ class CUDABackend(BaseBackend):
         passes.gluon.add_canonicalizer(pm)
         passes.ttgpuir.add_combine_tensor_select_and_if(pm)
         if "fpsan" in options.instrumentation_mode:
-            passes.ttgpuir.add_prepare_fp_sanitizer(pm)
+            passes.common.add_symbol_dce(pm)
         nvidia.passes.ttnvgpuir.add_check_matmul_two_cta(pm)
 
         if "fpsan" in options.instrumentation_mode:


### PR DESCRIPTION
Stacked on #11489.

With initial symbol DCE supplied by the compiler pipeline, FPSan inlines only calls that hide required TMEM allocation identity or kernel context. Override `noinline` only for selected invocations and retain MLIR's legality checks. Re-evaluate after each successful inline, then remove newly unreachable helpers before instrumentation.

Use MLIR's direct inlining API without a general optimization pipeline. Unrelated helpers remain callable; recursive callees and multi-block callees inside single-block regions retain the diagnostic explaining why inlining is required.
