### PR TITLE
[TRITONGPU] Narrow wide gather indices before layout conversion

### DIFF
--- a/lib/Dialect/TritonGPU/Transforms/OptimizeThreadLocality.cpp
+++ b/lib/Dialect/TritonGPU/Transforms/OptimizeThreadLocality.cpp
@@ -199,11 +199,20 @@ static LogicalResult setOptimizedGatherLayout(GatherOp op, RewriterBase &b) {
   auto newLayout = BlockedEncodingAttr::get(ctx, sizePerThread, threadsPerWarp,
                                             warpsPerCTA, order, cgaLayout);
 
+  // Gather indices are converted to i32 during lowering. Do this before the
+  // layout conversion to avoid moving unnecessarily wide indices through
+  // shared memory.
+  Value indices = op.getIndices();
+  if (idxType.getElementTypeBitWidth() > 32) {
+    idxType = idxType.clone(b.getI32Type());
+    indices = arith::TruncIOp::create(b, op.getLoc(), idxType, indices);
+  }
+
   // Update the layout on the gather op and insert conversions.
   auto cvtSrc = ConvertLayoutOp::create(
       b, op.getLoc(), srcType.cloneWithEncoding(newLayout), op.getSrc());
   auto cvtIdx = ConvertLayoutOp::create(
-      b, op.getLoc(), idxType.cloneWithEncoding(newLayout), op.getIndices());
+      b, op.getLoc(), idxType.cloneWithEncoding(newLayout), indices);
 
   b.setInsertionPointAfter(op);
   auto cvtOut =

--- a/test/TritonGPU/optimize-locality.mlir
+++ b/test/TritonGPU/optimize-locality.mlir
@@ -878,6 +878,28 @@ tt.func @set_warp_shuffle_layout_square_axis_0(%arg0: tensor<64x64xf32, #blocked
 
 // -----
 
+#blocked = #ttg.blocked<{sizePerThread = [1, 4], threadsPerWarp = [2, 16], warpsPerCTA = [4, 1], order = [1, 0]}>
+
+// CHECK: [[LAYOUT:#.*]] = #ttg.blocked<{sizePerThread = [8, 1], threadsPerWarp = [32, 1], warpsPerCTA = [1, 4], order = [0, 1]}>
+
+module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32} {
+
+// CHECK: narrow_wide_gather_indices
+tt.func @narrow_wide_gather_indices(%arg0: tensor<128x64xf32, #blocked>, %arg1: tensor<256x64xi64, #blocked>) -> tensor<256x64xf32, #blocked> {
+  // CHECK-NEXT: [[IDX32:%.*]] = arith.trunci %arg1 : tensor<256x64xi64, #blocked> to tensor<256x64xi32, #blocked>
+  // CHECK-NEXT: [[SRC:%.*]] = ttg.convert_layout %arg0
+  // CHECK-NEXT: [[IDX:%.*]] = ttg.convert_layout [[IDX32]]
+  // CHECK-NEXT: [[OUT:%.*]] = tt.gather [[SRC]][[[IDX]]] {axis = 0 : i32, efficient_layout} : (tensor<128x64xf32, [[LAYOUT]]>, tensor<256x64xi32, [[LAYOUT]]>) -> tensor<256x64xf32, [[LAYOUT]]>
+  %0 = tt.gather %arg0[%arg1] {axis = 0 : i32} : (tensor<128x64xf32, #blocked>, tensor<256x64xi64, #blocked>) -> tensor<256x64xf32, #blocked>
+  // CHECK-NEXT: [[RES:%.*]] = ttg.convert_layout [[OUT]]
+  // CHECK-NEXT: return [[RES]]
+  tt.return %0 : tensor<256x64xf32, #blocked>
+}
+
+}
+
+// -----
+
 #blocked = #ttg.blocked<{sizePerThread = [2, 2], threadsPerWarp = [16, 2], warpsPerCTA = [2, 2], order = [1, 0]}>
 
 // CHECK: [[LAYOUT:#.*]] = #ttg.blocked<{sizePerThread = [1, 2], threadsPerWarp = [1, 32], warpsPerCTA = [4, 1], order = [1, 0]}>


### PR DESCRIPTION
## Summary

- truncate gather indices wider than 32 bits before applying the optimized layout conversion
- avoid carrying index bits that the gather lowering already discards through shared memory
- leave 8-, 16-, and 32-bit index paths unchanged

## Problem

The existing `test_gather` case with a `[128, 64]` source and `[256, 64]` int64 indices fails on an RTX 5090 before launch:

```text
OutOfResources: shared memory, Required: 131072, Hardware limit: 101376
```

`OptimizeThreadLocality` converts the full `256 x 64 x i64` index tile to its warp-local layout, which requires 131072 bytes. Both gather lowering paths later convert each index to i32 for address computation, so the upper 32 bits are carried through the expensive conversion only to be discarded.

## Fix

When assigning an optimized gather layout, truncate indices wider than 32 bits while they still have their original encoding, then convert the narrower tensor to the selected layout. The existing lowering-side conversion remains as a defensive fallback.

This is intentionally not a general gather cost model: it only removes storage for bits that current lowering does not use.

## Testing

- `make`
- `lit -v test/TritonGPU/optimize-locality.mlir`
- `TRITON_ALWAYS_COMPILE=1 python3 -m pytest -s --tb=short python/test/unit/language/test_core.py::test_gather` — 5 passed
- RTX 5090 regression case now runs and matches `torch.gather`
- compiled shared-memory metadata for the failing case: `131072 -> 65536` bytes
