### PR TITLE
[AMD] Avoid false HIP runtime mismatch with TheRock

### DIFF
--- a/third_party/amd/backend/driver.py
+++ b/third_party/amd/backend/driver.py
@@ -87,7 +87,7 @@ def _get_path_to_hip_runtime_dylib():
         therock_libhip_path = None
     if therock_libhip_path is not None:
         mmapped_path = _find_already_mmapped_dylib_on_linux(lib_name)
-        if mmapped_path and os.path.realpath(mmapped_path) != os.path.realpath(therock_libhip_path):
+        if mmapped_path and not os.path.samefile(mmapped_path, therock_libhip_path):
             raise RuntimeError(f"TheRock provides '{therock_libhip_path}', but a different HIP runtime "
                                f"'{mmapped_path}' is already loaded; refusing to mix ROCm installations")
         return therock_libhip_path


### PR DESCRIPTION
# Problem

The AMD jobs on PyTorch PR https://github.com/pytorch/pytorch/pull/190440 fail when TorchInductor initializes Triton. One example is https://github.com/pytorch/pytorch/actions/runs/33027829505/job/98404275210.

Triton reports that TheRock provides `.../_rocm_sdk_core/lib/libamdhip64.so.7` while `.../_rocm_sdk_devel/lib/libamdhip64.so.7` is already loaded, then refuses to continue.

# Root Cause

Triton PR https://github.com/triton-lang/triton/pull/11028 compares the two real paths and treats them as different ROCm installations. TheRock gives the same HIP runtime two hard-link names: one under `_rocm_sdk_core` and one under `_rocm_sdk_devel`. `realpath` does not recognize that hard links identify the same file.

# This Diff

Before: `realpath(core) != realpath(devel)`, so Triton rejects the runtime.

After: `samefile(core, devel)` is true because both paths have the same device and inode, so Triton accepts the runtime. Different files are still rejected.

# Test Plan

- `pre-commit run --files third_party/amd/backend/driver.py`
- `HIP_VISIBLE_DEVICES=0 python tools/dynamo/verify_dynamo.py`

Reproduced on MI300X with PyTorch `01c0ad24e4c6e0bcae4847351630ff641968926e` and TheRock ROCm 7.14. The `core` and `devel` paths have the same device and inode, and `os.path.samefile` returns true.

Authored with assistance from Codex.
