### PR TITLE
[triton_kernels] Enable CLC inner-loop warp specialization

### DIFF
--- a/python/triton_kernels/triton_kernels/matmul_details/_p_matmul.py
+++ b/python/triton_kernels/triton_kernels/matmul_details/_p_matmul.py
@@ -336,7 +336,12 @@ def _p_matmul(
         k_tiles = tl.cdiv(loop_k, BLOCK_K * SPLIT_K)
         loop_bound = tl.maximum(k_tiles, 1)
         tl.assume(loop_bound > 0)  # Currently necessary for the compiler to flatten the loop properly.
-        for ki in tl.range(loop_bound, disallow_acc_multi_buffer=DISALLOW_ACC_MULTI_BUFFER):
+        for ki in tl.range(
+            loop_bound,
+            disallow_acc_multi_buffer=DISALLOW_ACC_MULTI_BUFFER,
+            # CLC needs warp specialization enabled on the inner loop.
+            warp_specialize=CLC,
+        ):
             if RAGGED_DIMENSION == "K" and ki >= k_tiles:
                 # Tile #ki does not exist: use out-of-bound indices to mask all loads.
                 off_k_x = K


### PR DESCRIPTION
CLC replaces the outer persistent loop and disables its warp-specialization request. Request warp specialization on the inner K loop so CLC retains TMA/MMA producer-consumer overlap while leaving the CLC scheduler loop unchanged.

Tested on GB300 with the existing CLC matmul tests: 3 passed, 9 deselected. For the dense BF16 `[16384, 12288] @ [12288, 12288]` workload from the KI CLC thread, mean latency was 3.6103 ms for non-CLC with 118 SMs, 3.2535 ms for non-CLC with 152 SMs, and 3.3505 ms for CLC with 152 SMs.
