### PR TITLE
[KERNELS] Fuse forward FP4 layout conversion

### DIFF
--- a/python/triton_kernels/tests/test_tensor.py
+++ b/python/triton_kernels/tests/test_tensor.py
@@ -1,6 +1,5 @@
 import pytest
 import torch
-from torch._subclasses.fake_tensor import FakeTensorMode
 import triton
 import triton.language as tl
 from triton_kernels.fpsan import embed, unembed
@@ -274,25 +273,22 @@ def test_mxfp4_value_convert_layout_forward_fallback(layout, major_dim, dtype):
 
 @pytest.mark.parametrize("layout", _FP4_VALUE_LAYOUTS)
 @pytest.mark.parametrize("major_dim", [-2, -1])
-@pytest.mark.parametrize("device", ["meta", "cuda"])
 @pytest.mark.parametrize("inverse", [False, True])
-def test_mxfp4_value_convert_layout_fake(layout, major_dim, device, inverse):
+def test_mxfp4_value_convert_layout_meta(layout, major_dim, inverse):
     shape = [2, 130, 66]
-    source = empty(shape, dtype=FP4, device="meta", layout=StridedLayout(major_dim))
+    source = empty(shape, dtype=FP4, device="cpu", layout=StridedLayout(major_dim))
     source = convert_layout(source, layout) if inverse else source
     destination = StridedLayout(major_dim) if inverse else layout
     expected = convert_layout(source, destination)
 
-    with FakeTensorMode():
-        source = empty(shape, dtype=FP4, device=device, layout=StridedLayout(major_dim))
-        source = convert_layout(source, layout) if inverse else source
-        actual = convert_layout(source, destination)
+    source_meta = wrap_torch_tensor(source.data.to("meta"), dtype=FP4, shape=source.shape, layout=source.storage.layout)
+    actual = convert_layout(source_meta, destination)
 
     assert actual.shape == expected.shape
     assert actual.data.shape == expected.data.shape
     assert actual.data.stride() == expected.data.stride()
     assert actual.data.dtype == expected.data.dtype
-    assert actual.device.type == device
+    assert actual.device.type == "meta"
 
 
 @pytest.mark.parametrize("layout", _FP4_VALUE_LAYOUTS)

--- a/python/triton_kernels/tests/test_tensor.py
+++ b/python/triton_kernels/tests/test_tensor.py
@@ -1,5 +1,6 @@
 import pytest
 import torch
+from torch._subclasses.fake_tensor import FakeTensorMode
 import triton
 import triton.language as tl
 from triton_kernels.fpsan import embed, unembed
@@ -28,6 +29,13 @@ from triton_kernels.tensor_details.layout import (
     HopperMXValueLayout,
     StridedLayout,
 )
+
+_FP4_VALUE_LAYOUTS = [
+    HopperMXValueLayout(-2, 3),
+    HopperMXValueLayout(-1, 3),
+    BlackwellMXValueLayout(),
+    BlackwellMX4ValueShuffledLayout(),
+]
 
 
 @pytest.mark.parametrize("dtype", [
@@ -213,23 +221,20 @@ def test_convert_layout_converts_different_parameterized_layout(storage_shape, l
     assert convert_layout(converted, different_layout) is not converted
 
 
-@pytest.mark.parametrize("layout", [
-    HopperMXValueLayout(-2, 3),
-    HopperMXValueLayout(-1, 3),
-    BlackwellMXValueLayout(),
-    BlackwellMX4ValueShuffledLayout(),
-])
+@pytest.mark.parametrize("layout", _FP4_VALUE_LAYOUTS)
 @pytest.mark.parametrize("major_dim", [-2, -1])
 @pytest.mark.parametrize("step", [1, 2])
-def test_mxfp4_value_convert_layout_to_strided_peak_allocation(layout, major_dim, step):
+@pytest.mark.parametrize("inverse", [False, True])
+def test_mxfp4_value_convert_layout_peak_allocation(layout, major_dim, step, inverse):
     data = torch.empty((2048, 2048), dtype=torch.uint8, device="cuda")
-    source = convert_layout(wrap_torch_tensor(data, dtype=FP4), layout)
+    strided = convert_layout(wrap_torch_tensor(data, dtype=FP4), StridedLayout(major_dim))
+    source = convert_layout(strided, layout) if inverse else strided
+    destination = strided.storage.layout if inverse else layout
     if step == 2:
         contiguous_dim = source.data.stride().index(1)
         storage = source.data.movedim(contiguous_dim, -1)
         storage = torch.stack((storage, storage), dim=-2)[..., 1, :].movedim(-1, contiguous_dim)
-        source = wrap_torch_tensor(storage, dtype=FP4, shape=source.shape, layout=layout)
-    destination = StridedLayout(major_dim)
+        source = wrap_torch_tensor(storage, dtype=FP4, shape=source.shape, layout=source.storage.layout)
     warm = convert_layout(source, destination)
     torch.cuda.synchronize(source.device)
     del warm
@@ -244,10 +249,53 @@ def test_mxfp4_value_convert_layout_to_strided_peak_allocation(layout, major_dim
     assert peak <= actual.data.nbytes + 1024**2
 
 
-@pytest.mark.parametrize(
-    "layout",
-    [HopperMXValueLayout(-2, 3),
-     BlackwellMXValueLayout(), BlackwellMX4ValueShuffledLayout()])
+@pytest.mark.parametrize("layout", _FP4_VALUE_LAYOUTS)
+@pytest.mark.parametrize("major_dim", [-3, -2, -1])
+@pytest.mark.parametrize("dtype", [torch.uint8, torch.int32])
+def test_mxfp4_value_convert_layout_forward_fallback(layout, major_dim, dtype):
+    data = torch.randint(0, 256, (4, 66, 66), dtype=torch.uint8, generator=torch.Generator().manual_seed(0))
+    source = convert_layout(wrap_torch_tensor(data, dtype=FP4), StridedLayout(major_dim))
+    source = wrap_torch_tensor(source.data.to(dtype), dtype=FP4, shape=source.shape, layout=source.storage.layout)
+    expected = convert_layout(source, layout)
+    source_cuda = wrap_torch_tensor(source.data.cuda(), dtype=FP4, shape=source.shape, layout=source.storage.layout)
+
+    actual = convert_layout(source_cuda, layout)
+
+    assert actual.shape == expected.shape
+    assert actual.data.shape == expected.data.shape
+    assert actual.data.stride() == expected.data.stride()
+    assert actual.data.dtype == expected.data.dtype
+    if isinstance(layout, BlackwellMXValueLayout):
+        assert torch.equal(actual.data[..., :source.shape[-2] // 2, :].cpu(),
+                           expected.data[..., :source.shape[-2] // 2, :])
+    else:
+        assert torch.equal(actual.data.cpu(), expected.data)
+
+
+@pytest.mark.parametrize("layout", _FP4_VALUE_LAYOUTS)
+@pytest.mark.parametrize("major_dim", [-2, -1])
+@pytest.mark.parametrize("device", ["meta", "cuda"])
+@pytest.mark.parametrize("inverse", [False, True])
+def test_mxfp4_value_convert_layout_fake(layout, major_dim, device, inverse):
+    shape = [2, 130, 66]
+    source = empty(shape, dtype=FP4, device="meta", layout=StridedLayout(major_dim))
+    source = convert_layout(source, layout) if inverse else source
+    destination = StridedLayout(major_dim) if inverse else layout
+    expected = convert_layout(source, destination)
+
+    with FakeTensorMode():
+        source = empty(shape, dtype=FP4, device=device, layout=StridedLayout(major_dim))
+        source = convert_layout(source, layout) if inverse else source
+        actual = convert_layout(source, destination)
+
+    assert actual.shape == expected.shape
+    assert actual.data.shape == expected.data.shape
+    assert actual.data.stride() == expected.data.stride()
+    assert actual.data.dtype == expected.data.dtype
+    assert actual.device.type == device
+
+
+@pytest.mark.parametrize("layout", _FP4_VALUE_LAYOUTS)
 @pytest.mark.parametrize("inverse", [False, True])
 @pytest.mark.parametrize("major_dim", [-2, -1])
 def test_convert_layout_uses_input_device(layout, inverse, major_dim):

--- a/python/triton_kernels/tests/test_tensor_details/test_layout_blackwell.py
+++ b/python/triton_kernels/tests/test_tensor_details/test_layout_blackwell.py
@@ -124,6 +124,7 @@ def test_mxfp4_value_shuffled_matches_torch(shape, block_k, block_n, step):
 ])
 @pytest.mark.parametrize("trans", [False, True])
 @pytest.mark.parametrize("step", [1, 2])
+@pytest.mark.enable_warmup
 def test_mxfp4_value_convert_layout_matches_torch(shape, layout, trans, step):
     input_shape = tuple(step * size for size in shape[:-1]) + shape[-1:]
     data_cpu = torch.randint(0, 256, (math.prod(input_shape) + 1, ), dtype=torch.uint8)

--- a/python/triton_kernels/tests/test_tensor_details/test_layout_blackwell.py
+++ b/python/triton_kernels/tests/test_tensor_details/test_layout_blackwell.py
@@ -1,3 +1,4 @@
+import math
 import pytest
 import torch
 from triton_kernels.tensor_details.layout import (
@@ -115,21 +116,39 @@ def test_mxfp4_value_shuffled_matches_torch(shape, block_k, block_n, step):
     assert torch.equal(restored_cpu, data_cpu)
 
 
-@pytest.mark.parametrize("shape", [(256, 128), (2, 258, 65)])
-def test_mxfp4_value_shuffled_convert_layout_matches_torch(shape):
-    data_cpu = torch.randint(0, 256, shape, dtype=torch.uint8)
+@pytest.mark.parametrize("shape", [(256, 128), (2, 258, 65), (2, 3, 130, 66)])
+@pytest.mark.parametrize("layout", [
+    BlackwellMXValueLayout(),
+    BlackwellMX4ValueShuffledLayout(),
+    BlackwellMX4ValueShuffledLayout(block_k=256, block_n=128),
+])
+@pytest.mark.parametrize("trans", [False, True])
+@pytest.mark.parametrize("step", [1, 2])
+def test_mxfp4_value_convert_layout_matches_torch(shape, layout, trans, step):
+    input_shape = tuple(step * size for size in shape[:-1]) + shape[-1:]
+    data_cpu = torch.randint(0, 256, (math.prod(input_shape) + 1, ), dtype=torch.uint8)
     data_cuda = data_cpu.cuda()
-    data_cpu, data_cuda = data_cpu.mT, data_cuda.mT
+    data_cpu, data_cuda = data_cpu[1:].view(input_shape), data_cuda[1:].view(input_shape)
+    index = (slice(step - 1, None, step), ) * (len(shape) - 1) + (slice(None), )
+    data_cpu, data_cuda = data_cpu[index], data_cuda[index]
+    if trans:
+        data_cpu, data_cuda = data_cpu.mT, data_cuda.mT
     src_cpu = wrap_torch_tensor(data_cpu, dtype=FP4)
     src_cuda = wrap_torch_tensor(data_cuda, dtype=FP4)
-    layout = BlackwellMX4ValueShuffledLayout()
 
     expected = convert_layout(src_cpu, layout)
     actual = convert_layout(src_cuda, layout)
     roundtrip = convert_layout(actual, src_cuda.storage.layout)
 
-    assert actual.storage.data.is_contiguous()
-    assert torch.equal(actual.storage.data.cpu(), expected.storage.data)
+    assert actual.storage.data.shape == expected.storage.data.shape
+    if isinstance(layout, BlackwellMXValueLayout):
+        # Default Blackwell padding is unspecified; compare its logical bytes.
+        assert actual.storage.data.stride() == expected.storage.data.stride()
+        assert torch.equal(actual.data[..., :src_cpu.shape[-2] // 2, :].cpu(),
+                           expected.data[..., :src_cpu.shape[-2] // 2, :])
+    else:
+        assert actual.storage.data.is_contiguous()
+        assert torch.equal(actual.storage.data.cpu(), expected.storage.data)
     assert torch.equal(roundtrip.storage.data, data_cuda)
 
 

--- a/python/triton_kernels/tests/test_tensor_details/test_layout_hopper.py
+++ b/python/triton_kernels/tests/test_tensor_details/test_layout_hopper.py
@@ -1,3 +1,4 @@
+import math
 import pytest
 from triton_kernels.tensor import wrap_torch_tensor, convert_layout, empty, FP4
 from triton_kernels.tensor_details.layout import HopperMXScaleLayout, HopperMXValueLayout, StridedLayout
@@ -107,13 +108,18 @@ def test_mxfp4_value_convert_layout_roundtrip(mx_axis):
     assert torch.equal(roundtrip.storage.data, x)
 
 
-@pytest.mark.parametrize("shape", [(64, 64), (2, 34, 18)])
+@pytest.mark.parametrize("shape", [(64, 64), (130, 66), (2, 34, 18), (2, 3, 66, 34)])
+@pytest.mark.parametrize("step", [1, 2])
 @pytest.mark.parametrize("trans", [False, True])
 @pytest.mark.parametrize("mx_axis", [-2, -1])
 @pytest.mark.parametrize("mma_version", [2, 3])
-def test_mxfp4_value_convert_layout_matches_torch(shape, trans, mx_axis, mma_version):
-    data_cpu = torch.randint(0, 256, shape, dtype=torch.uint8)
+def test_mxfp4_value_convert_layout_matches_torch(shape, step, trans, mx_axis, mma_version):
+    input_shape = tuple(step * size for size in shape[:-1]) + shape[-1:]
+    data_cpu = torch.randint(0, 256, (math.prod(input_shape) + 1, ), dtype=torch.uint8)
     data_cuda = data_cpu.cuda()
+    data_cpu, data_cuda = data_cpu[1:].view(input_shape), data_cuda[1:].view(input_shape)
+    index = (slice(step - 1, None, step), ) * (len(shape) - 1) + (slice(None), )
+    data_cpu, data_cuda = data_cpu[index], data_cuda[index]
     if trans:
         data_cpu, data_cuda = data_cpu.mT, data_cuda.mT
     src_cpu = wrap_torch_tensor(data_cpu, dtype=FP4)
@@ -222,8 +228,7 @@ def test_mxfp4_value_swizzle_peak_allocation(mx_axis):
     torch.cuda.synchronize(data.device)
     peak = torch.cuda.max_memory_allocated(data.device) - baseline
 
-    # Allow overlapping byte buffers, but not whole-tensor int32 intermediates.
-    assert peak <= 2 * swizzled.nbytes + 1024**2
+    assert peak <= swizzled.nbytes + 1024**2
 
 
 @pytest.mark.parametrize("mx_axis", [0, 1])

--- a/python/triton_kernels/tests/test_tensor_details/test_layout_hopper.py
+++ b/python/triton_kernels/tests/test_tensor_details/test_layout_hopper.py
@@ -113,6 +113,7 @@ def test_mxfp4_value_convert_layout_roundtrip(mx_axis):
 @pytest.mark.parametrize("trans", [False, True])
 @pytest.mark.parametrize("mx_axis", [-2, -1])
 @pytest.mark.parametrize("mma_version", [2, 3])
+@pytest.mark.enable_warmup
 def test_mxfp4_value_convert_layout_matches_torch(shape, step, trans, mx_axis, mma_version):
     input_shape = tuple(step * size for size in shape[:-1]) + shape[-1:]
     data_cpu = torch.randint(0, 256, (math.prod(input_shape) + 1, ), dtype=torch.uint8)

--- a/python/triton_kernels/triton_kernels/tensor_details/layout_details/base.py
+++ b/python/triton_kernels/triton_kernels/tensor_details/layout_details/base.py
@@ -19,7 +19,10 @@ class LayoutTransformation(ABC):
 
     def convert_data(self, data, destination: "LayoutTransformation"):
         """Convert to another layout, using canonical storage by default."""
-        return destination.swizzle_data(self.unswizzle_data(data))
+        return destination._convert_data_from(data, self)
+
+    def _convert_data_from(self, data, source: "LayoutTransformation"):
+        return self.swizzle_data(source.unswizzle_data(data))
 
     @abstractmethod
     def swizzle_data(self, data):

--- a/python/triton_kernels/triton_kernels/tensor_details/layout_details/blackwell_value.py
+++ b/python/triton_kernels/triton_kernels/tensor_details/layout_details/blackwell_value.py
@@ -58,6 +58,15 @@ class BlackwellMXValueLayoutTransformation(LayoutTransformation):
         repack(data, -2, destination.order[0], True, out=out)
         return out
 
+    def _convert_data_from(self, data, source: LayoutTransformation):
+        if (not isinstance(source, strided.StridedLayoutTransformation) or not self.is_fp4 or self.shape[-1] % 2
+                or self.shape[-2] % 2 or not source._can_convert_fp4(data)):
+            return super()._convert_data_from(data, source)
+        out = torch.empty_strided(self.storage_shape, strides_major_dim_m2(self.storage_shape), device=data.device,
+                                  dtype=data.dtype)
+        repack(data, source.order[0], -2, True, out=out[..., :self.shape[-2] // 2, :])
+        return out
+
     def swizzle_data(self, data):
         assert data.stride(-1) == 1
         # re-pack as column-major

--- a/python/triton_kernels/triton_kernels/tensor_details/layout_details/blackwell_value_shuffled.py
+++ b/python/triton_kernels/triton_kernels/tensor_details/layout_details/blackwell_value_shuffled.py
@@ -2,7 +2,6 @@ import math
 from dataclasses import dataclass
 
 import torch
-from torch._subclasses.fake_tensor import is_fake
 import triton
 import triton.language as tl
 
@@ -103,7 +102,7 @@ class BlackwellMX4ValueShuffledTransformation(LayoutTransformation):
         return self._convert_data(data, inverse=True, major_dim=-1)
 
     def convert_data(self, data, destination: LayoutTransformation):
-        if (data.device.type != "cuda" or data.dtype != torch.uint8 or is_fake(data)
+        if (data.device.type != "cuda" or data.dtype != torch.uint8
                 or not isinstance(destination, strided.StridedLayoutTransformation)
                 or destination.order[0] < len(self.shape) - 2):
             return super().convert_data(data, destination)
@@ -120,7 +119,7 @@ class BlackwellMX4ValueShuffledTransformation(LayoutTransformation):
         # Preserve the canonical path's even-N packing requirement.
         if self.shape[-1] % 2:
             raise ValueError(f"FP4 packing dimension -1 must have an even size, got {self.shape[-1]}")
-        if data.device.type != "cuda" or data.dtype != torch.uint8 or is_fake(data):
+        if data.device.type != "cuda" or data.dtype != torch.uint8:
             return self._unswizzle_data_torch(data) if inverse else self._swizzle_data_torch(data)
 
         if inverse:

--- a/python/triton_kernels/triton_kernels/tensor_details/layout_details/blackwell_value_shuffled.py
+++ b/python/triton_kernels/triton_kernels/tensor_details/layout_details/blackwell_value_shuffled.py
@@ -2,6 +2,7 @@ import math
 from dataclasses import dataclass
 
 import torch
+from torch._subclasses.fake_tensor import is_fake
 import triton
 import triton.language as tl
 
@@ -102,18 +103,24 @@ class BlackwellMX4ValueShuffledTransformation(LayoutTransformation):
         return self._convert_data(data, inverse=True, major_dim=-1)
 
     def convert_data(self, data, destination: LayoutTransformation):
-        if (data.device.type != "cuda" or data.dtype != torch.uint8
+        if (data.device.type != "cuda" or data.dtype != torch.uint8 or is_fake(data)
                 or not isinstance(destination, strided.StridedLayoutTransformation)
                 or destination.order[0] < len(self.shape) - 2):
             return super().convert_data(data, destination)
         return self._convert_data(data, inverse=True, major_dim=destination.order[0])
+
+    def _convert_data_from(self, data, source: LayoutTransformation):
+        if (not isinstance(source, strided.StridedLayoutTransformation) or not self.is_fp4
+                or not source._can_convert_fp4(data)):
+            return super()._convert_data_from(data, source)
+        return self._convert_data(data, inverse=False, major_dim=source.order[0])
 
     def _convert_data(self, data: torch.Tensor, inverse: bool, major_dim: int) -> torch.Tensor:
         storage_shape = self.storage_shape
         # Preserve the canonical path's even-N packing requirement.
         if self.shape[-1] % 2:
             raise ValueError(f"FP4 packing dimension -1 must have an even size, got {self.shape[-1]}")
-        if data.device.type != "cuda" or data.dtype != torch.uint8:
+        if data.device.type != "cuda" or data.dtype != torch.uint8 or is_fake(data):
             return self._unswizzle_data_torch(data) if inverse else self._swizzle_data_torch(data)
 
         if inverse:

--- a/python/triton_kernels/triton_kernels/tensor_details/layout_details/hopper_value.py
+++ b/python/triton_kernels/triton_kernels/tensor_details/layout_details/hopper_value.py
@@ -1,5 +1,6 @@
 import math
 import torch
+from torch._subclasses.fake_tensor import is_fake
 import triton
 import triton.language as tl
 from dataclasses import dataclass
@@ -87,7 +88,7 @@ class HopperMXValueLayoutTransformation(LayoutTransformation):
         # The tiled path needs the full padded encoding and even packing extents.
         # Keep compact or otherwise unsupported sources on the reference path.
         if (not self.is_fp4 or self.N % 2 or self.shape[self.mx_axis] % 2 or data.device.type != "cuda"
-                or data.dtype != torch.uint8 or list(data.shape) != self.storage_shape
+                or data.dtype != torch.uint8 or is_fake(data) or list(data.shape) != self.storage_shape
                 or not isinstance(destination, strided.StridedLayoutTransformation)
                 or destination.order[0] < len(self.shape) - 2):
             return super().convert_data(data, destination)
@@ -106,6 +107,30 @@ class HopperMXValueLayoutTransformation(LayoutTransformation):
                                                    PACK_M=destination.order[0] != self.mx_axis, BLOCK_M=block_m,
                                                    BLOCK_K=block_k)
         return out
+
+    def _convert_data_from(self, data, source: LayoutTransformation):
+        if (not isinstance(source, strided.StridedLayoutTransformation) or not self.is_fp4 or self.N % 2
+                or self.shape[self.mx_axis] % 2 or not source._can_convert_fp4(data)):
+            return super()._convert_data_from(data, source)
+        return self._swizzle_from_strided(data, source.order[0])
+
+    def _swizzle_from_strided(self, data, major_dim):
+        shape = self.storage_shape
+        if self.mx_axis == len(self.leading_shape):
+            shape[-2:] = reversed(shape[-2:])
+        out = torch.empty((*shape[:-1], shape[-1] // 4), dtype=torch.int32, device=data.device)
+        source = self._maybe_mT(data)
+        m, k = (self.N, self.K) if self.mx_axis == len(self.leading_shape) else (self.K, self.N)
+        block_m, block_k = 16, 256
+        grid_m, grid_k = shape[-2] // block_m, shape[-1] // block_k
+        grid = (math.prod(self.leading_shape) * grid_m * grid_k, )
+        if grid[0] > 0:
+            with torch.cuda.device(data.device):
+                _swizzle_from_strided_kernel[grid](source, out, tuple(self.leading_shape), source.stride(),
+                                                   out.stride(), m, k, GRID_M=grid_m, GRID_K=grid_k,
+                                                   MMA_VERSION=self.mma_version, PACK_M=major_dim != self.mx_axis,
+                                                   BLOCK_M=block_m, BLOCK_K=block_k)
+        return self._maybe_mT(out.view(torch.uint8))
 
     def swizzle_data(self, data):
         """
@@ -127,6 +152,10 @@ class HopperMXValueLayoutTransformation(LayoutTransformation):
         WARNING: Assumes that the matmul will be done in bf16 or fp16!
         Implementing it for fp8 is as easy as making the tile size (8, 8)
         """
+        if (self.is_fp4 and self.N % 2 == 0 and self.shape[self.mx_axis] % 2 == 0 and data.device.type == "cuda"
+                and data.dtype == torch.uint8 and not is_fake(data)
+                and list(data.shape) == [*self.shape[:-1], self.N // 2]):
+            return self._swizzle_from_strided(data, len(self.shape) - 1)
         # re-pack as column-major
         data = repack(data, -1, self.mx_axis, self.is_fp4)
         batch = data.ndim - 2
@@ -327,7 +356,7 @@ def _convert_bits_kernel(X, Y, N, INVERSE: tl.constexpr, BLOCK_SIZE: tl.constexp
 
 def _convert_bits(x: torch.Tensor, inverse: bool) -> torch.Tensor:
     """Avoid full-size integer temporaries when re-encoding CUDA values."""
-    if x.device.type != "cuda" or x.dtype != torch.uint8:
+    if x.device.type != "cuda" or x.dtype != torch.uint8 or is_fake(x):
         return _unpack_bits(x) if inverse else _pack_bits(x)
     x = x.contiguous()
     shape = (*x.shape[:-1], x.shape[-1] // 4)
@@ -341,6 +370,49 @@ def _convert_bits(x: torch.Tensor, inverse: bool) -> torch.Tensor:
 
 
 # -----------------------------------------------------------------------
+
+
+@triton.jit
+def _swizzle_from_strided_kernel(X, Y, LEADING_SHAPE: tl.constexpr, X_STRIDES: tl.constexpr, Y_STRIDES: tl.constexpr,
+                                 M: tl.constexpr, K: tl.constexpr, GRID_M: tl.constexpr, GRID_K: tl.constexpr,
+                                 MMA_VERSION: tl.constexpr, PACK_M: tl.constexpr, BLOCK_M: tl.constexpr,
+                                 BLOCK_K: tl.constexpr):
+    pid = tl.program_id(0).to(tl.int64)
+    batch = pid // (GRID_M * GRID_K)
+    tile_m, tile_k = pid // GRID_K % GRID_M, pid % GRID_K
+    for dim in tl.static_range(len(LEADING_SHAPE) - 1, -1, -1):
+        index = batch % LEADING_SHAPE[dim]
+        batch //= LEADING_SHAPE[dim]
+        X += index * X_STRIDES[dim]
+        Y += index * Y_STRIDES[dim]
+
+    if PACK_M:
+        rows = tile_m * (2 * BLOCK_M) + tl.arange(0, 2 * BLOCK_M)
+        cols = tile_k * (BLOCK_K // 2) + tl.arange(0, BLOCK_K // 2)
+        mask = (rows[:, None] < M // 2) & (cols[None, :] < K)
+        x = tl.load(X + rows[:, None] * X_STRIDES[-2] + cols[None, :] * X_STRIDES[-1], mask, other=0)
+        even, odd = tl.split(x.reshape(2 * BLOCK_M, BLOCK_K // 4, 2))
+        x = tl.join((even & 0xF) | (odd << 4), (even >> 4) | (odd & 0xF0))
+        x = x.trans(0, 2, 1).reshape(4 * BLOCK_M, BLOCK_K // 4)
+    else:
+        rows = tile_m * (4 * BLOCK_M) + tl.arange(0, 4 * BLOCK_M)
+        cols = tile_k * (BLOCK_K // 4) + tl.arange(0, BLOCK_K // 4)
+        mask = (rows[:, None] < M) & (cols[None, :] < K // 2)
+        x = tl.load(X + rows[:, None] * X_STRIDES[-2] + cols[None, :] * X_STRIDES[-1], mask, other=0)
+
+    # Invert the MMA tile permutation used by _unshuffle_triton, then encode
+    # each group of four packed bytes directly into its final word.
+    u8_kwidth: tl.constexpr = 4 if MMA_VERSION == 2 else 1
+    x = x.reshape(BLOCK_M // 4, 2, 4, 2, BLOCK_K // 128, 8 // u8_kwidth, 4, u8_kwidth)
+    x = x.trans(0, 2, 4, 3, 6, 5, 1, 7).reshape(BLOCK_M, BLOCK_K // 4, 2, 2).to(tl.uint32)
+    even, odd = tl.split(x)
+    a, c = tl.split(even)
+    b, d = tl.split(odd)
+    encoded = (_compress_fp4x2_triton(a, False) | (_compress_fp4x2_triton(b, False) >> 3)
+               | (_compress_fp4x2_triton(c, False) >> 6) | _compress_fp4x2_triton(d, True))
+    rows = tile_m * BLOCK_M + tl.arange(0, BLOCK_M)
+    words = tile_k * (BLOCK_K // 4) + tl.arange(0, BLOCK_K // 4)
+    tl.store(Y + rows[:, None] * Y_STRIDES[-2] + words[None, :] * Y_STRIDES[-1], encoded)
 
 
 @triton.jit

--- a/python/triton_kernels/triton_kernels/tensor_details/layout_details/hopper_value.py
+++ b/python/triton_kernels/triton_kernels/tensor_details/layout_details/hopper_value.py
@@ -1,6 +1,5 @@
 import math
 import torch
-from torch._subclasses.fake_tensor import is_fake
 import triton
 import triton.language as tl
 from dataclasses import dataclass
@@ -88,7 +87,7 @@ class HopperMXValueLayoutTransformation(LayoutTransformation):
         # The tiled path needs the full padded encoding and even packing extents.
         # Keep compact or otherwise unsupported sources on the reference path.
         if (not self.is_fp4 or self.N % 2 or self.shape[self.mx_axis] % 2 or data.device.type != "cuda"
-                or data.dtype != torch.uint8 or is_fake(data) or list(data.shape) != self.storage_shape
+                or data.dtype != torch.uint8 or list(data.shape) != self.storage_shape
                 or not isinstance(destination, strided.StridedLayoutTransformation)
                 or destination.order[0] < len(self.shape) - 2):
             return super().convert_data(data, destination)
@@ -153,8 +152,7 @@ class HopperMXValueLayoutTransformation(LayoutTransformation):
         Implementing it for fp8 is as easy as making the tile size (8, 8)
         """
         if (self.is_fp4 and self.N % 2 == 0 and self.shape[self.mx_axis] % 2 == 0 and data.device.type == "cuda"
-                and data.dtype == torch.uint8 and not is_fake(data)
-                and list(data.shape) == [*self.shape[:-1], self.N // 2]):
+                and data.dtype == torch.uint8 and list(data.shape) == [*self.shape[:-1], self.N // 2]):
             return self._swizzle_from_strided(data, len(self.shape) - 1)
         # re-pack as column-major
         data = repack(data, -1, self.mx_axis, self.is_fp4)
@@ -356,7 +354,7 @@ def _convert_bits_kernel(X, Y, N, INVERSE: tl.constexpr, BLOCK_SIZE: tl.constexp
 
 def _convert_bits(x: torch.Tensor, inverse: bool) -> torch.Tensor:
     """Avoid full-size integer temporaries when re-encoding CUDA values."""
-    if x.device.type != "cuda" or x.dtype != torch.uint8 or is_fake(x):
+    if x.device.type != "cuda" or x.dtype != torch.uint8:
         return _unpack_bits(x) if inverse else _pack_bits(x)
     x = x.contiguous()
     shape = (*x.shape[:-1], x.shape[-1] // 4)

--- a/python/triton_kernels/triton_kernels/tensor_details/layout_details/strided.py
+++ b/python/triton_kernels/triton_kernels/tensor_details/layout_details/strided.py
@@ -2,7 +2,6 @@ from dataclasses import dataclass
 from .base import Layout, LayoutTransformation
 from .torch_utils import repack
 import torch
-from torch._subclasses.fake_tensor import is_fake
 
 
 # ------------------- Layout Definition -------------------
@@ -66,8 +65,8 @@ class StridedLayoutTransformation(LayoutTransformation):
     def _can_convert_fp4(self, data):
         """Whether direct kernels can read this strided FP4 storage."""
         return (self.is_fp4 and len(self.shape) >= 2 and self.order[0] >= len(self.shape) - 2
-                and data.device.type == "cuda" and data.dtype == torch.uint8 and not is_fake(data)
-                and list(data.shape) == self.storage_shape and data.stride(self.order[0]) == 1)
+                and data.device.type == "cuda" and data.dtype == torch.uint8 and list(data.shape) == self.storage_shape
+                and data.stride(self.order[0]) == 1)
 
     @property
     def storage_shape(self) -> list[int]:

--- a/python/triton_kernels/triton_kernels/tensor_details/layout_details/strided.py
+++ b/python/triton_kernels/triton_kernels/tensor_details/layout_details/strided.py
@@ -2,6 +2,7 @@ from dataclasses import dataclass
 from .base import Layout, LayoutTransformation
 from .torch_utils import repack
 import torch
+from torch._subclasses.fake_tensor import is_fake
 
 
 # ------------------- Layout Definition -------------------
@@ -61,6 +62,12 @@ class StridedLayout(Layout):
 class StridedLayoutTransformation(LayoutTransformation):
 
     order: list[int]
+
+    def _can_convert_fp4(self, data):
+        """Whether direct kernels can read this strided FP4 storage."""
+        return (self.is_fp4 and len(self.shape) >= 2 and self.order[0] >= len(self.shape) - 2
+                and data.device.type == "cuda" and data.dtype == torch.uint8 and not is_fake(data)
+                and list(data.shape) == self.storage_shape and data.stride(self.order[0]) == 1)
 
     @property
     def storage_shape(self) -> list[int]:


### PR DESCRIPTION
Strided-to-device FP4 layout conversion currently allocates canonical storage before producing the final encoding. This adds a full-sized buffer and extra copies.

Add destination dispatch for direct conversion from strided FP4 storage. Hopper combines repacking, padding, permutation and bit encoding in one kernel. Blackwell writes the final allocation through the existing repacking/shuffle code. Other conversions keep their existing paths; CPU/meta tensors and unsupported forward packing use the reference implementation.

## Benchmarks

Synthetic FP4 data uses uniform random `uint8` bytes with seed 0 and logical shape `(16, 4096, 4096)`; the output is 128 MiB. Packing is the `StridedLayout` major dimension; Hopper uses `mma_version=3`, and shuffled Blackwell uses `block_k=128, block_n=256`. Build the source on CPU, then copy only that storage to CUDA.

| GPU / layout | MX axis | Packing | Base (ms) | PR (ms) | Speedup | Peak MiB, base → PR |
|---|---:|---:|---:|---:|---:|---:|
| H100 / Hopper | -1 | -1 | 0.830 | 0.132 | 6.29× | 256.0 → 128.0 |
| H100 / Hopper | -1 | -2 | 3.350 | 0.164 | 20.45× | 256.0 → 128.0 |
| H100 / Hopper | -2 | -1 | 2.338 | 0.166 | 14.06× | 256.0 → 128.0 |
| H100 / Hopper | -2 | -2 | 4.862 | 0.135 | 36.07× | 256.0 → 128.0 |
| GB300 / Blackwell | — | -1 | 1.564 | 1.545 | 1.01× | 256.0 → 128.0 |
| GB300 / Blackwell | — | -2 | 3.006 | 0.073 | 41.37× | 256.0 → 128.0 |
| GB300 / Blackwell shuffled | — | -1 | 0.132 | 0.102 | 1.30× | 256.0 → 128.0 |
| GB300 / Blackwell shuffled | — | -2 | 1.600 | 0.080 | 19.93× | 256.0 → 128.0 |

The default Blackwell row-packed case is essentially unchanged in latency; it still halves peak allocation. Smaller controls at `(4, 1024, 1024)` and `(2, 130, 66)` change latency by -85.5% to -12.6% (two balanced rounds each).

With the CUDA allocator capped at 192 MiB above the resident input, all eight baseline cases OOM and all eight PR cases succeed. After warmup and `empty_cache()`, set `set_per_process_memory_fraction((resident_allocated + 192 * 2**20) / total_memory)`; restore the limit after each probe.

Times measure the warm public `convert_layout(source, destination)` call, including allocation and synchronization but excluding output destruction. Each main-table value is the median of four fresh-process medians: 25 calls after five warmups, alternating baseline/PR order. For peak allocation, release prior outputs, synchronize, empty the cache, record `memory_allocated()` and reset peak stats; report `max_memory_allocated() - resident_allocated`. This includes the output and intermediates, not the input. Byte equality against CPU references and output metadata are checked outside timing; unspecified Blackwell padding is excluded. These are conversion measurements, not matmul or cold-compilation results.

Measured against [[AMD][LAYOUTS] Refine segment computation to support DS_READ_B128](https://github.com/triton-lang/triton/commit/0699c93421aaa077667280f69c5dfef68ac629bd), using Python 3.12, a build based on PyTorch 2.11, and CUDA 13.0. Both revisions use the same compiler from [[NVIDIA] Snapshot synthetic cluster-barrier counters before rendezvous](https://github.com/triton-lang/triton/commit/b3762cc612ff2925d9a81308513b91ff89bac636). Measured PR head: [[KERNELS] Preserve FP4 conversion compile warmup](https://github.com/triton-lang/triton/commit/4bd15e987e393e6e589a6b627c011734e03c13b3).

Validation on H100 and GB300: 1,097 tests passed per GPU setup, plus 180 cases under Compute Sanitizer memcheck with no errors. Coverage includes both packing axes, Hopper MMA versions, batches, tails, stepped inputs, nonzero storage offsets, empty shapes, CPU/meta tensors and a non-current CUDA device. Separate large-address checks cover source offsets above 4 GiB and outputs above 2 GiB. All 18 forward allocation checks fail on the baseline and pass with this change. Compile warmup captures and executes all 100 conversion cases with zero misses on both GPU families.

| LoC | Added | Removed | Net |
|---|---:|---:|---:|
| Tests | +96 | -26 | +70 |
| Non-tests | +95 | -1 | +94 |
| All | +191 | -27 | +164 |

## Reviewer's guide

- `python/triton_kernels/triton_kernels/tensor_details/layout_details/`: destination dispatch, strided eligibility checks and direct Hopper/Blackwell conversion paths.
- `python/triton_kernels/tests/`: extend the existing conversion matrices and peak-allocation checks, including reference/meta fallbacks.
