### PR TITLE
[KERNELS] Fuse compact Hopper FP4 inverse layout conversion

### DIFF
--- a/python/triton_kernels/tests/test_tensor_details/test_layout_hopper.py
+++ b/python/triton_kernels/tests/test_tensor_details/test_layout_hopper.py
@@ -8,6 +8,7 @@ from triton_kernels.target_info import cuda_capability_geq
 import triton.language as tl
 import triton
 import torch
+from torch._subclasses.fake_tensor import FakeTensorMode
 
 # ------------------------------------------------------------
 # Torch tests
@@ -187,24 +188,102 @@ def test_mxfp4_value_convert_layout_odd_source_packing(shape, mx_axis, major_dim
     assert str(actual.value) == str(expected.value)
 
 
+@pytest.mark.parametrize("shape", [(2, 2), (18, 34), (64, 32), (2, 3, 66, 34)])
+@pytest.mark.parametrize("mx_axis", [-2, -1])
 @pytest.mark.parametrize("mma_version", [2, 3])
 @pytest.mark.parametrize("major_dim", [-2, -1])
-@pytest.mark.parametrize("device", ["cpu", "cuda"])
-def test_mxfp4_value_convert_layout_compact_source(mma_version, major_dim, device):
-    data = torch.randint(0, 256, (64, 32), dtype=torch.uint8, generator=torch.Generator().manual_seed(0))
+@pytest.mark.parametrize(("device", "step"), [("cpu", 1), ("meta", 1), ("cuda", 1), ("cuda", 2)])
+def test_mxfp4_value_convert_layout_compact_source(shape, mx_axis, mma_version, major_dim, device, step):
+    data = torch.randint(0, 256, shape, dtype=torch.uint8, generator=torch.Generator().manual_seed(0))
     canonical = wrap_torch_tensor(data, dtype=FP4)
-    layout = HopperMXValueLayout(-1, mma_version)
+    layout = HopperMXValueLayout(mx_axis, mma_version)
     full = convert_layout(canonical, layout)
-    compact = full.data[:16, :128].contiguous()
-    source = wrap_torch_tensor(compact.to(device), dtype=FP4, shape=canonical.shape, layout=layout)
+    m, k = (canonical.shape[-1], canonical.shape[-2]) if mx_axis == -2 else canonical.shape[-2:]
+    encoded = full.data.mT if mx_axis == -2 else full.data
+    compact = encoded[..., :triton.cdiv(m, 16) * 4, :triton.cdiv(k, 64) * 128].contiguous().to(device)
+    if step == 2:
+        compact = torch.stack((torch.zeros_like(compact), compact), dim=-1)[..., 1]
+    if mx_axis == -2:
+        compact = compact.mT
+    source = wrap_torch_tensor(compact, dtype=FP4, shape=canonical.shape, layout=layout)
     destination = StridedLayout(major_dim)
     expected = convert_layout(canonical, destination)
 
     actual = convert_layout(source, destination)
 
     assert actual.shape == expected.shape
+    assert actual.data.shape == expected.data.shape
     assert actual.data.stride() == expected.data.stride()
-    assert torch.equal(actual.data.cpu(), expected.data)
+    if device != "meta":
+        assert torch.equal(actual.data.cpu(), expected.data)
+
+
+@pytest.mark.parametrize("mx_axis", [-2, -1])
+@pytest.mark.parametrize("mma_version", [2, 3])
+@pytest.mark.parametrize("major_dim", [-2, -1])
+def test_mxfp4_value_convert_layout_compact_source_fake(mx_axis, mma_version, major_dim):
+    data = torch.empty((2, 3, 4, 128), dtype=torch.uint8)
+    shape = (2, 3, 64, 16) if mx_axis == -2 else (2, 3, 16, 64)
+    if mx_axis == -2:
+        data = data.mT
+    layout = HopperMXValueLayout(mx_axis, mma_version)
+    destination = StridedLayout(major_dim)
+    expected = convert_layout(wrap_torch_tensor(data, dtype=FP4, shape=shape, layout=layout), destination)
+
+    with FakeTensorMode():
+        data = torch.empty_strided(data.shape, data.stride(), dtype=data.dtype, device="cuda")
+        source = wrap_torch_tensor(data, dtype=FP4, shape=shape, layout=layout)
+        actual = convert_layout(source, destination)
+
+    assert actual.shape == expected.shape
+    assert actual.data.shape == expected.data.shape
+    assert actual.data.stride() == expected.data.stride()
+    assert actual.data.device.type == "cuda"
+
+
+@pytest.mark.parametrize("encoded_shape", [(3, 128), (4, 124), (4, 128), (8, 256)])
+@pytest.mark.parametrize("mx_axis", [-2, -1])
+@pytest.mark.parametrize("mma_version", [2, 3])
+@pytest.mark.parametrize("major_dim", [-2, -1])
+def test_mxfp4_value_convert_layout_invalid_source_storage(encoded_shape, mx_axis, mma_version, major_dim):
+    data = torch.empty(encoded_shape, dtype=torch.uint8)
+    shape = (130, 66) if mx_axis == -2 else (66, 130)
+    if mx_axis == -2:
+        data = data.mT
+    layout = HopperMXValueLayout(mx_axis, mma_version)
+    destination = StridedLayout(major_dim)
+    source_cpu = wrap_torch_tensor(data, dtype=FP4, shape=shape, layout=layout)
+    with pytest.raises((AssertionError, RuntimeError)) as expected:
+        convert_layout(source_cpu, destination)
+
+    source_cuda = wrap_torch_tensor(data.cuda(), dtype=FP4, shape=shape, layout=layout)
+    with pytest.raises(type(expected.value)) as actual:
+        convert_layout(source_cuda, destination)
+    assert str(actual.value) == str(expected.value)
+
+
+@pytest.mark.parametrize("mx_axis", [-2, -1])
+@pytest.mark.parametrize("mma_version", [2, 3])
+@pytest.mark.parametrize("major_dim", [-2, -1])
+def test_mxfp4_value_convert_layout_compact_source_peak_allocation(mx_axis, mma_version, major_dim):
+    data = torch.empty((1028, 8320), dtype=torch.uint8, device="cuda")
+    shape = (4160, 4112) if mx_axis == -2 else (4112, 4160)
+    if mx_axis == -2:
+        data = data.mT
+    layout = HopperMXValueLayout(mx_axis, mma_version)
+    source = wrap_torch_tensor(data, dtype=FP4, shape=shape, layout=layout)
+    destination = StridedLayout(major_dim)
+    warm = convert_layout(source, destination)
+    torch.cuda.synchronize(data.device)
+    del warm
+    baseline = torch.cuda.memory_allocated(data.device)
+    torch.cuda.reset_peak_memory_stats(data.device)
+
+    actual = convert_layout(source, destination)
+    torch.cuda.synchronize(data.device)
+    peak = torch.cuda.max_memory_allocated(data.device) - baseline
+
+    assert peak <= actual.data.nbytes + 1024**2
 
 
 @pytest.mark.parametrize("mx_axis", [-2, -1])

--- a/python/triton_kernels/tests/test_tensor_details/test_layout_hopper.py
+++ b/python/triton_kernels/tests/test_tensor_details/test_layout_hopper.py
@@ -8,7 +8,6 @@ from triton_kernels.target_info import cuda_capability_geq
 import triton.language as tl
 import triton
 import torch
-from torch._subclasses.fake_tensor import FakeTensorMode
 
 # ------------------------------------------------------------
 # Torch tests
@@ -188,6 +187,7 @@ def test_mxfp4_value_convert_layout_odd_source_packing(shape, mx_axis, major_dim
     assert str(actual.value) == str(expected.value)
 
 
+@pytest.mark.enable_warmup
 @pytest.mark.parametrize("shape", [(2, 2), (18, 34), (64, 32), (2, 3, 66, 34)])
 @pytest.mark.parametrize("mx_axis", [-2, -1])
 @pytest.mark.parametrize("mma_version", [2, 3])
@@ -218,30 +218,7 @@ def test_mxfp4_value_convert_layout_compact_source(shape, mx_axis, mma_version, 
         assert torch.equal(actual.data.cpu(), expected.data)
 
 
-@pytest.mark.parametrize("mx_axis", [-2, -1])
-@pytest.mark.parametrize("mma_version", [2, 3])
-@pytest.mark.parametrize("major_dim", [-2, -1])
-def test_mxfp4_value_convert_layout_compact_source_fake(mx_axis, mma_version, major_dim):
-    data = torch.empty((2, 3, 4, 128), dtype=torch.uint8)
-    shape = (2, 3, 64, 16) if mx_axis == -2 else (2, 3, 16, 64)
-    if mx_axis == -2:
-        data = data.mT
-    layout = HopperMXValueLayout(mx_axis, mma_version)
-    destination = StridedLayout(major_dim)
-    expected = convert_layout(wrap_torch_tensor(data, dtype=FP4, shape=shape, layout=layout), destination)
-
-    with FakeTensorMode():
-        data = torch.empty_strided(data.shape, data.stride(), dtype=data.dtype, device="cuda")
-        source = wrap_torch_tensor(data, dtype=FP4, shape=shape, layout=layout)
-        actual = convert_layout(source, destination)
-
-    assert actual.shape == expected.shape
-    assert actual.data.shape == expected.data.shape
-    assert actual.data.stride() == expected.data.stride()
-    assert actual.data.device.type == "cuda"
-
-
-@pytest.mark.parametrize("encoded_shape", [(3, 128), (4, 124), (4, 128), (8, 256)])
+@pytest.mark.parametrize("encoded_shape", [(3, 128), (4, 124), (16, 384), (20, 256)])
 @pytest.mark.parametrize("mx_axis", [-2, -1])
 @pytest.mark.parametrize("mma_version", [2, 3])
 @pytest.mark.parametrize("major_dim", [-2, -1])

--- a/python/triton_kernels/triton_kernels/tensor_details/layout_details/hopper_value.py
+++ b/python/triton_kernels/triton_kernels/tensor_details/layout_details/hopper_value.py
@@ -1,5 +1,6 @@
 import math
 import torch
+from torch._subclasses.fake_tensor import is_fake
 import triton
 import triton.language as tl
 from dataclasses import dataclass
@@ -84,24 +85,28 @@ class HopperMXValueLayoutTransformation(LayoutTransformation):
         return data
 
     def convert_data(self, data, destination: LayoutTransformation):
-        # The tiled path needs the full padded encoding and even packing extents.
-        # Keep compact or otherwise unsupported sources on the reference path.
         if (not self.is_fp4 or self.N % 2 or self.shape[self.mx_axis] % 2 or data.device.type != "cuda"
-                or data.dtype != torch.uint8 or list(data.shape) != self.storage_shape
+                or data.dtype != torch.uint8 or data.ndim != len(self.shape) or is_fake(data)
                 or not isinstance(destination, strided.StridedLayoutTransformation)
                 or destination.order[0] < len(self.shape) - 2):
             return super().convert_data(data, destination)
 
+        source = self._maybe_mT(data)
+        m, k = (self.N, self.K) if self.mx_axis == len(self.leading_shape) else (self.K, self.N)
+        # Each 4x128 encoded tile covers 16x64 logical FP4 values. Compact
+        # encodings must contain complete tiles covering the logical shape.
+        if (list(source.shape[:-2]) != self.leading_shape or source.shape[-2] % 4 or source.shape[-1] % 128
+                or 4 * source.shape[-2] < m or source.shape[-1] // 2 < k):
+            return super().convert_data(data, destination)
+
         out = torch.empty_strided(destination.storage_shape, destination.storage_strides, dtype=data.dtype,
                                   device=data.device)
-        source = self._maybe_mT(data)
         target = self._maybe_mT(out)
-        m, k = (self.N, self.K) if self.mx_axis == len(self.leading_shape) else (self.K, self.N)
         block_m, block_k = 16, 256
         grid = (math.prod(self.leading_shape) * triton.cdiv(m, 4 * block_m) * triton.cdiv(k, block_k // 2), )
         if grid[0] > 0:
             with torch.cuda.device(data.device):
-                _unswizzle_to_strided_kernel[grid](source, target, tuple(self.leading_shape), source.stride(),
+                _unswizzle_to_strided_kernel[grid](source, target, tuple(source.shape), source.stride(),
                                                    target.stride(), m, k, MMA_VERSION=self.mma_version,
                                                    PACK_M=destination.order[0] != self.mx_axis, BLOCK_M=block_m,
                                                    BLOCK_K=block_k)
@@ -327,7 +332,7 @@ def _convert_bits_kernel(X, Y, N, INVERSE: tl.constexpr, BLOCK_SIZE: tl.constexp
 
 def _convert_bits(x: torch.Tensor, inverse: bool) -> torch.Tensor:
     """Avoid full-size integer temporaries when re-encoding CUDA values."""
-    if x.device.type != "cuda" or x.dtype != torch.uint8:
+    if x.device.type != "cuda" or x.dtype != torch.uint8 or is_fake(x):
         return _unpack_bits(x) if inverse else _pack_bits(x)
     x = x.contiguous()
     shape = (*x.shape[:-1], x.shape[-1] // 4)
@@ -371,7 +376,7 @@ def _unshuffle_triton(x, mma_version: tl.constexpr):
 
 
 @triton.jit
-def _unswizzle_to_strided_kernel(X, Y, LEADING_SHAPE: tl.constexpr, X_STRIDES: tl.constexpr, Y_STRIDES: tl.constexpr,
+def _unswizzle_to_strided_kernel(X, Y, X_SHAPE: tl.constexpr, X_STRIDES: tl.constexpr, Y_STRIDES: tl.constexpr,
                                  M: tl.constexpr, K: tl.constexpr, MMA_VERSION: tl.constexpr, PACK_M: tl.constexpr,
                                  BLOCK_M: tl.constexpr, BLOCK_K: tl.constexpr):
     tiles_m: tl.constexpr = triton.cdiv(M, 4 * BLOCK_M)
@@ -383,9 +388,9 @@ def _unswizzle_to_strided_kernel(X, Y, LEADING_SHAPE: tl.constexpr, X_STRIDES: t
         tile_m, tile_k = tile % tiles_m, tile // tiles_m
     else:
         tile_m, tile_k = tile // tiles_k, tile % tiles_k
-    for dim in tl.static_range(len(LEADING_SHAPE) - 1, -1, -1):
-        index = batch % LEADING_SHAPE[dim]
-        batch //= LEADING_SHAPE[dim]
+    for dim in tl.static_range(len(X_SHAPE) - 3, -1, -1):
+        index = batch % X_SHAPE[dim]
+        batch //= X_SHAPE[dim]
         X += index * X_STRIDES[dim]
         Y += index * Y_STRIDES[dim]
 
@@ -394,10 +399,11 @@ def _unswizzle_to_strided_kernel(X, Y, LEADING_SHAPE: tl.constexpr, X_STRIDES: t
     rows = tile_m * BLOCK_M + tl.arange(0, BLOCK_M)
     words = tile_k * (BLOCK_K // 4) + tl.arange(0, BLOCK_K // 4)
     offsets = rows[:, None] * X_STRIDES[-2] + 4 * words[None, :] * X_STRIDES[-1]
-    a = tl.load(X + offsets).to(tl.uint32)
-    b = tl.load(X + offsets + X_STRIDES[-1]).to(tl.uint32)
-    c = tl.load(X + offsets + 2 * X_STRIDES[-1]).to(tl.uint32)
-    d = tl.load(X + offsets + 3 * X_STRIDES[-1]).to(tl.uint32)
+    mask = (rows[:, None] < X_SHAPE[-2]) & (4 * words[None, :] < X_SHAPE[-1])
+    a = tl.load(X + offsets, mask, other=0).to(tl.uint32)
+    b = tl.load(X + offsets + X_STRIDES[-1], mask, other=0).to(tl.uint32)
+    c = tl.load(X + offsets + 2 * X_STRIDES[-1], mask, other=0).to(tl.uint32)
+    d = tl.load(X + offsets + 3 * X_STRIDES[-1], mask, other=0).to(tl.uint32)
     x = _unpack_bits_triton(a | (b << 8) | (c << 16) | (d << 24))
     shifts = 8 * tl.arange(0, 4)
     x = (x[:, :, None] >> shifts[None, None, :]).to(tl.uint8)

--- a/python/triton_kernels/triton_kernels/tensor_details/layout_details/hopper_value.py
+++ b/python/triton_kernels/triton_kernels/tensor_details/layout_details/hopper_value.py
@@ -92,11 +92,12 @@ class HopperMXValueLayoutTransformation(LayoutTransformation):
             return super().convert_data(data, destination)
 
         source = self._maybe_mT(data)
+        source_shape = tuple(source.shape)
         m, k = (self.N, self.K) if self.mx_axis == len(self.leading_shape) else (self.K, self.N)
         # Each 4x128 encoded tile covers 16x64 logical FP4 values. Compact
         # encodings must contain complete tiles covering the logical shape.
-        if (list(source.shape[:-2]) != self.leading_shape or source.shape[-2] % 4 or source.shape[-1] % 128
-                or 4 * source.shape[-2] < m or source.shape[-1] // 2 < k):
+        if (list(source_shape[:-2]) != self.leading_shape or source_shape[-2] % 4 or source_shape[-1] % 128
+                or 4 * source_shape[-2] < m or source_shape[-1] // 2 < k):
             return super().convert_data(data, destination)
 
         out = torch.empty_strided(destination.storage_shape, destination.storage_strides, dtype=data.dtype,
@@ -106,10 +107,9 @@ class HopperMXValueLayoutTransformation(LayoutTransformation):
         grid = (math.prod(self.leading_shape) * triton.cdiv(m, 4 * block_m) * triton.cdiv(k, block_k // 2), )
         if grid[0] > 0:
             with torch.cuda.device(data.device):
-                _unswizzle_to_strided_kernel[grid](source, target, tuple(source.shape), source.stride(),
-                                                   target.stride(), m, k, MMA_VERSION=self.mma_version,
-                                                   PACK_M=destination.order[0] != self.mx_axis, BLOCK_M=block_m,
-                                                   BLOCK_K=block_k)
+                _unswizzle_to_strided_kernel[grid](source, target, source_shape, source.stride(), target.stride(), m, k,
+                                                   PACK_M=destination.order[0] != self.mx_axis,
+                                                   MMA_VERSION=self.mma_version, BLOCK_M=block_m, BLOCK_K=block_k)
         return out
 
     def swizzle_data(self, data):
@@ -399,7 +399,10 @@ def _unswizzle_to_strided_kernel(X, Y, X_SHAPE: tl.constexpr, X_STRIDES: tl.cons
     rows = tile_m * BLOCK_M + tl.arange(0, BLOCK_M)
     words = tile_k * (BLOCK_K // 4) + tl.arange(0, BLOCK_K // 4)
     offsets = rows[:, None] * X_STRIDES[-2] + 4 * words[None, :] * X_STRIDES[-1]
-    mask = (rows[:, None] < X_SHAPE[-2]) & (4 * words[None, :] < X_SHAPE[-1])
+    if X_SHAPE[-2] % BLOCK_M or X_SHAPE[-1] % BLOCK_K:
+        mask = (rows[:, None] < X_SHAPE[-2]) & (4 * words[None, :] < X_SHAPE[-1])
+    else:
+        mask = True
     a = tl.load(X + offsets, mask, other=0).to(tl.uint32)
     b = tl.load(X + offsets + X_STRIDES[-1], mask, other=0).to(tl.uint32)
     c = tl.load(X + offsets + 2 * X_STRIDES[-1], mask, other=0).to(tl.uint32)

--- a/python/triton_kernels/triton_kernels/tensor_details/layout_details/hopper_value.py
+++ b/python/triton_kernels/triton_kernels/tensor_details/layout_details/hopper_value.py
@@ -1,6 +1,5 @@
 import math
 import torch
-from torch._subclasses.fake_tensor import is_fake
 import triton
 import triton.language as tl
 from dataclasses import dataclass
@@ -86,7 +85,7 @@ class HopperMXValueLayoutTransformation(LayoutTransformation):
 
     def convert_data(self, data, destination: LayoutTransformation):
         if (not self.is_fp4 or self.N % 2 or self.shape[self.mx_axis] % 2 or data.device.type != "cuda"
-                or data.dtype != torch.uint8 or data.ndim != len(self.shape) or is_fake(data)
+                or data.dtype != torch.uint8 or data.ndim != len(self.shape)
                 or not isinstance(destination, strided.StridedLayoutTransformation)
                 or destination.order[0] < len(self.shape) - 2):
             return super().convert_data(data, destination)
@@ -332,7 +331,7 @@ def _convert_bits_kernel(X, Y, N, INVERSE: tl.constexpr, BLOCK_SIZE: tl.constexp
 
 def _convert_bits(x: torch.Tensor, inverse: bool) -> torch.Tensor:
     """Avoid full-size integer temporaries when re-encoding CUDA values."""
-    if x.device.type != "cuda" or x.dtype != torch.uint8 or is_fake(x):
+    if x.device.type != "cuda" or x.dtype != torch.uint8:
         return _unpack_bits(x) if inverse else _pack_bits(x)
     x = x.contiguous()
     shape = (*x.shape[:-1], x.shape[-1] // 4)


### PR DESCRIPTION
Hopper's fused FP4 inverse conversion currently requires the full nominal padding shape. A compact encoding with complete tiles therefore falls back to full-sized intermediate tensors.

Accept physical encodings made of complete 4×128-byte tiles that cover the logical tensor. Skip source masks only when the physical shape is a multiple of the 16×256-byte kernel tile. The conversion writes directly into the requested strided packing. Unsupported geometry and CPU/meta tensors keep the reference path.

The complementary forward path is covered by [[KERNELS] Fuse forward FP4 layout conversion](https://github.com/triton-lang/triton/pull/11495).

## Benchmarks

Synthetic FP4 data uses uniform random `uint8` bytes with seed 0 and logical shape `(16, 4112, 4160)`. Build the Hopper encoding on CPU. With the MX axis oriented last and logical tail shape `(M, K)`, crop encoded storage to `(..., 4*cdiv(M,16), 128*cdiv(K,64))`, make it contiguous, and transpose back for MX axis `-2`. Copy only this source to CUDA. The dense output is 130.5 MiB; packing is the destination `StridedLayout` major dimension, and `mma_version=3`.

| GPU / layout | MX axis | Packing | Base (ms) | PR (ms) | Speedup | Peak MiB, base → PR |
|---|---:|---:|---:|---:|---:|---:|
| H100 / Hopper | -1 | -1 | 0.778 | 0.162 | 4.80× | 261.0 → 130.5 |
| H100 / Hopper | -1 | -2 | 3.757 | 0.194 | 19.38× | 261.0 → 130.5 |
| H100 / Hopper | -2 | -1 | 4.270 | 0.189 | 22.60× | 264.1 → 130.5 |
| H100 / Hopper | -2 | -2 | 7.229 | 0.170 | 42.40× | 264.1 → 130.5 |
| GB300 / Hopper | -1 | -1 | 0.588 | 0.133 | 4.43× | 261.0 → 130.5 |
| GB300 / Hopper | -1 | -2 | 2.027 | 0.162 | 12.51× | 261.0 → 130.5 |
| GB300 / Hopper | -2 | -1 | 2.338 | 0.162 | 14.47× | 264.1 → 130.5 |
| GB300 / Hopper | -2 | -2 | 3.755 | 0.149 | 25.28× | 264.1 → 130.5 |

Fully padded controls at the same large shape change latency by -1.8% to +1.0% and keep the same output-only peak allocation. For `(64, 64)`, compact sources improve 2.10–6.73×; fully padded controls change by -1.7 to +6.4 µs (two balanced rounds each, with visible variation between processes).

With the CUDA allocator capped at 192 MiB above the resident input, all eight baseline compact cases OOM and all eight PR cases succeed. After warmup and `empty_cache()`, set `set_per_process_memory_fraction((resident_allocated + 192 * 2**20) / total_memory)`; restore the limit after each probe.

Times measure the warm public `convert_layout(source, destination)` call, including allocation and synchronization but excluding output destruction. Each main-table value is the median of four fresh-process medians: 25 calls after five warmups, alternating baseline/PR order. For peak allocation, release prior outputs, synchronize, empty the cache, record `memory_allocated()` and reset peak stats; report `max_memory_allocated() - resident_allocated`. This includes the output and intermediates, not the input. Cached baseline CPU references check exact bytes, shape and strides outside timing. These are conversion measurements, not matmul or cold-compilation results.

Measured against [[AMD][LAYOUTS] Refine segment computation to support DS_READ_B128](https://github.com/triton-lang/triton/commit/0699c93421aaa077667280f69c5dfef68ac629bd), using Python 3.12, a build based on PyTorch 2.11, and CUDA 13.0. Both revisions use the same compiler from [[NVIDIA] Snapshot synthetic cluster-barrier counters before rendezvous](https://github.com/triton-lang/triton/commit/b3762cc612ff2925d9a81308513b91ff89bac636). Measured PR head: [[KERNELS] Preserve compact FP4 conversion compile warmup](https://github.com/triton-lang/triton/commit/3c5f3d9be4aaf9797e37044e4ae30225277a759c).

Validation on H100 and GB300: 595 Hopper tests passed per GPU setup, plus 144 cases under Compute Sanitizer memcheck with no errors. Coverage includes both MX/packing axes and MMA versions, compact tails, batches, stepped storage, empty shapes, malformed encodings and CPU/meta tensors. Separate large-address checks cover source offsets above 4 GiB and outputs above 2 GiB. All eight compact peak-allocation checks fail on the baseline and pass with this change. Compile warmup captures and executes all 128 conversion cases with zero misses on both GPU families.

| LoC | Added | Removed | Net |
|---|---:|---:|---:|
| Tests | +63 | -7 | +56 |
| Non-tests | +25 | -17 | +8 |
| All | +88 | -24 | +64 |

## Reviewer's guide

- `python/triton_kernels/triton_kernels/tensor_details/layout_details/hopper_value.py`: validate physical tile coverage and bound the inverse kernel's source loads.
- `python/triton_kernels/tests/test_tensor_details/test_layout_hopper.py`: extend the compact-source matrix and verify output-only peak allocation and fallback behavior.
