### PR TITLE
[FIX] Fence mbarrier initialization from its elected issuer

### DIFF
--- a/test/Conversion/tritonnvidiagpu_to_llvm.mlir
+++ b/test/Conversion/tritonnvidiagpu_to_llvm.mlir
@@ -670,7 +670,9 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.targ
 // CHECK-LABEL: mbarrier_sync_cluster_init
 module attributes {"ttg.num-ctas" = 2 : i32, "ttg.num-warps" = 4 : i32, ttg.target = "cuda:90", "ttg.threads-per-warp" = 32 : i32} {
   tt.func public @mbarrier_sync_cluster_init() {
-    // CHECK: fence.mbarrier_init.release.cluster
+    // CHECK: [[ELECT:%.*]] = nvvm.elect.sync
+    // CHECK: [[ISSUER:%.*]] = llvm.and %{{.*}}, [[ELECT]] : i1
+    // CHECK: fence.mbarrier_init.release.cluster {{.*}}"b" [[ISSUER]]
     // CHECK: nvvm.cluster.arrive.relaxed
     // CHECK-NEXT: nvvm.cluster.wait
     ttng.fence_mbarrier_init_release_cluster

--- a/third_party/nvidia/lib/TritonNVIDIAGPUToLLVM/BarrierOpToLLVM.cpp
+++ b/third_party/nvidia/lib/TritonNVIDIAGPUToLLVM/BarrierOpToLLVM.cpp
@@ -148,11 +148,9 @@ struct FenceMBarrierInitReleaseClusterOpConversion
                   OpAdaptor adaptor,
                   ConversionPatternRewriter &rewriter) const override {
     Location loc = op.getLoc();
-    auto b = TritonLLVMOpBuilder(loc, rewriter);
 
-    // Only one thread needs to issue the fence, just like mbarrier.init.
-    Value tid = getThreadId(rewriter, loc);
-    Value pred = b.icmp_eq(tid, b.i32_val(0));
+    // The fence only orders initializations issued by the same thread.
+    Value pred = LLVM::NVIDIA::createElectPredicateWarp0(loc, rewriter);
 
     NVIDIA::createFenceMBarrierInitReleaseCluster(rewriter, loc, pred);
 


### PR DESCRIPTION
Use elect for init fence as mbarrier.init also uses elect and the fence has to be emitted by the same thread as the init!