### PR TITLE
[Backend] Add another SLPVectorizer workaround :(

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -12,7 +12,8 @@
 
 ## Build and Testing Guidelines
 - Before running tests for native/compiler changes, run `make` in the triton directory to rebuild triton. DO NOT RUN `make` if you only changed Python code or code in `python/triton_kernels`.
-- For compiler changes, add tests in `python/test/` (pytest) or test (lit). Keep GPU-only tests in `python/test/unit/` or `python/test/gluon/`, name them `test_<feature>_<condition>`, and avoid creating new test files unless requested.
+- For compiler changes, add tests in `python/test/` (pytest) or test (lit). Keep GPU-only tests in `python/test/unit/` or `python/test/gluon/`, name them `test_<feature>_<condition>`.
+- Avoid creating new test files, except when requested or when adding lit tests for a new compiler pass.
 - Run pytest with `-s --tb=short`. Run a single test with `pytest file.py::test_name`.
 - The build dir is given by `BUILD_DIR := $(shell PYTHONPATH="./python" python3 -c 'from build_helpers import get_cmake_dir; print(get_cmake_dir())')`
 - Run lit from the build dir:  `cd BUILD_DIR; ninja triton-opt; lit -v test/<path>.mlir` (example: `lit -v test/TritonNvidiaGPU/tmem_layouts.mlir`).

--- a/bin/triton-llvm-opt.cpp
+++ b/bin/triton-llvm-opt.cpp
@@ -43,6 +43,11 @@ static cl::opt<bool>
                         llvm::cl::desc("run pass to break phi struct"),
                         cl::init(false));
 
+static cl::opt<bool> VectorizeExtractedAdds(
+    "vectorize-extracted-adds",
+    cl::desc("re-form full-lane vector adds extracted from vector multiplies"),
+    cl::init(false));
+
 static cl::opt<bool> ScalarizePackedFOps(
     "scalarize-packed-fops",
     cl::desc("scalarize FP32 arithmetic pairs with only one used lane"),
@@ -68,6 +73,8 @@ static std::function<Error(Module *)> makeOptimizingPipeline() {
     llvm::FunctionPassManager fpm;
     if (BreakStructPhiNodes)
       fpm.addPass(BreakStructPhiNodesPass());
+    if (VectorizeExtractedAdds)
+      fpm.addPass(VectorizeExtractedAddsPass());
     if (ScalarizePackedFOps) {
       fpm.addPass(ScalarizePackedFOpsPass());
       fpm.addPass(InstSimplifyPass());

--- a/lib/Target/LLVMIR/CMakeLists.txt
+++ b/lib/Target/LLVMIR/CMakeLists.txt
@@ -3,6 +3,7 @@ add_triton_library(TritonLLVMIR
         LLVMDILocalVariable.cpp
         LLVMIRBreakPhiStruct.cpp
         LLVMIRScalarizePackedFOps.cpp
+        LLVMIRVectorizeExtractedAdds.cpp
         LLVMDIUtils.cpp
 
         DEPENDS

--- a/lib/Target/LLVMIR/LLVMIRVectorizeExtractedAdds.cpp
+++ b/lib/Target/LLVMIR/LLVMIRVectorizeExtractedAdds.cpp
@@ -1,0 +1,92 @@
+//===----------------------------------------------------------------------===//
+// Re-form full-lane vector additions before NVPTX code generation.
+//===----------------------------------------------------------------------===//
+#include "LLVMPasses.h"
+#include "llvm/ADT/SmallVector.h"
+#include "llvm/IR/Constants.h"
+#include "llvm/IR/IRBuilder.h"
+#include "llvm/IR/InstIterator.h"
+#include "llvm/IR/Instructions.h"
+
+using namespace llvm;
+
+static bool vectorizeExtractedAdds(BinaryOperator &Mul) {
+  auto *Ty = dyn_cast<FixedVectorType>(Mul.getType());
+  if (Mul.getOpcode() != Instruction::FMul || !Ty ||
+      !Ty->getElementType()->isFloatTy() || Ty->getNumElements() < 2 ||
+      Ty->getNumElements() > 16)
+    return false;
+
+  unsigned Width = Ty->getNumElements();
+  SmallVector<BinaryOperator *, 16> Adds(Width, nullptr);
+  SmallVector<ExtractElementInst *, 16> Extracts;
+  ConstantFP *CommonAddend = nullptr;
+  BinaryOperator *FirstAdd = nullptr;
+  for (User *U : Mul.users()) {
+    auto *Extract = dyn_cast<ExtractElementInst>(U);
+    if (!Extract || !Extract->hasOneUse() ||
+        Extract->getParent() != Mul.getParent())
+      return false;
+
+    auto *Index = dyn_cast<ConstantInt>(Extract->getIndexOperand());
+    if (!Index || Index->getValue().uge(Width))
+      return false;
+    unsigned Lane = Index->getZExtValue();
+
+    auto *Add = dyn_cast<BinaryOperator>(*Extract->user_begin());
+    if (!Add || Add->getOpcode() != Instruction::FAdd ||
+        Add->getParent() != Mul.getParent() || Adds[Lane])
+      return false;
+
+    Value *Other = Add->getOperand(Add->getOperand(0) == Extract ? 1 : 0);
+    auto *Addend = dyn_cast<ConstantFP>(Other);
+    if (!Addend || (CommonAddend && Addend != CommonAddend) ||
+        (FirstAdd && Add->getFastMathFlags() != FirstAdd->getFastMathFlags()))
+      return false;
+
+    CommonAddend = Addend;
+    if (!FirstAdd || Add->comesBefore(FirstAdd))
+      FirstAdd = Add;
+    Adds[Lane] = Add;
+    Extracts.push_back(Extract);
+  }
+  if (Extracts.size() != Width)
+    return false;
+
+  IRBuilder<> Builder(FirstAdd);
+  Builder.setFastMathFlags(FirstAdd->getFastMathFlags());
+  Builder.SetCurrentDebugLocation(FirstAdd->getDebugLoc());
+  Value *Splat =
+      ConstantVector::getSplat(ElementCount::getFixed(Width), CommonAddend);
+  Value *PackedAdd = Builder.CreateFAdd(&Mul, Splat, "repacked.add");
+  for (unsigned Lane = 0; Lane != Width; ++Lane) {
+    IRBuilder<> LaneBuilder(Adds[Lane]);
+    LaneBuilder.SetCurrentDebugLocation(Adds[Lane]->getDebugLoc());
+    Value *Result = LaneBuilder.CreateExtractElement(PackedAdd, Lane);
+    Adds[Lane]->replaceAllUsesWith(Result);
+  }
+  for (BinaryOperator *Add : Adds)
+    Add->eraseFromParent();
+  for (ExtractElementInst *Extract : Extracts)
+    Extract->eraseFromParent();
+  return true;
+}
+
+PreservedAnalyses VectorizeExtractedAddsPass::run(Function &F,
+                                                  FunctionAnalysisManager &AM) {
+  // Do not change evaluation or contraction in strict floating-point code.
+  if (F.hasFnAttribute(Attribute::StrictFP))
+    return PreservedAnalyses::all();
+
+  SmallVector<BinaryOperator *> Multiplies;
+  for (Instruction &I : instructions(F))
+    if (auto *Mul = dyn_cast<BinaryOperator>(&I);
+        Mul && Mul->getOpcode() == Instruction::FMul &&
+        Mul->getType()->isVectorTy())
+      Multiplies.push_back(Mul);
+
+  bool Changed = false;
+  for (BinaryOperator *Mul : Multiplies)
+    Changed |= vectorizeExtractedAdds(*Mul);
+  return Changed ? PreservedAnalyses::none() : PreservedAnalyses::all();
+}

--- a/lib/Target/LLVMIR/LLVMPasses.h
+++ b/lib/Target/LLVMIR/LLVMPasses.h
@@ -14,6 +14,16 @@ struct BreakStructPhiNodesPass
   static StringRef name() { return "BreakStructPhiNodesPass"; }
 };
 
+// Re-form vector additions when every lane of a vector multiply is extracted
+// and added to the same scalar constant. Run after vectorization so NVPTX can
+// lower the multiply-add pairs to packed operations.
+struct VectorizeExtractedAddsPass
+    : OptionalPassInfoMixin<VectorizeExtractedAddsPass> {
+  PreservedAnalyses run(Function &F, FunctionAnalysisManager &AM);
+
+  static StringRef name() { return "VectorizeExtractedAddsPass"; }
+};
+
 // Split FP32 arithmetic pairs with only one demanded lane on NVPTX. Run after
 // vectorization, followed by InstSimplify to clean up extracts and repacking.
 struct ScalarizePackedFOpsPass

--- a/python/src/llvm.cc
+++ b/python/src/llvm.cc
@@ -746,7 +746,7 @@ void init_triton_llvm(py::module_ &m) {
          std::string arch, std::string features, std::vector<std::string> flags,
          bool enable_fp_fusion, bool disable_slp_vectorizer,
          bool disable_vector_combine, bool expand_masked_div_rem,
-         bool scalarize_packed_fops) {
+         bool scalarize_packed_fops, bool vectorize_extracted_adds) {
         if (mlir::triton::tools::getBoolEnv("DISABLE_LLVM_OPT"))
           return;
         // Check to see if we are passing a list of flags to disable
@@ -863,10 +863,14 @@ void init_triton_llvm(py::module_ &m) {
           mpm.addPass(AddressSanitizerPass(Opts));
         }
         mpm.addPass(pb.buildPerModuleDefaultPipeline(opt));
-        if (scalarize_packed_fops) {
+        if (vectorize_extracted_adds || scalarize_packed_fops) {
           FunctionPassManager fpm;
-          fpm.addPass(ScalarizePackedFOpsPass());
-          fpm.addPass(InstSimplifyPass());
+          if (vectorize_extracted_adds)
+            fpm.addPass(VectorizeExtractedAddsPass());
+          if (scalarize_packed_fops) {
+            fpm.addPass(ScalarizePackedFOpsPass());
+            fpm.addPass(InstSimplifyPass());
+          }
           mpm.addPass(createModuleToFunctionPassAdaptor(std::move(fpm)));
         }
         if (expand_masked_div_rem)
@@ -884,6 +888,7 @@ void init_triton_llvm(py::module_ &m) {
       py::arg("disable_vector_combine") = false,
       py::arg("expand_masked_div_rem") = false,
       py::arg("scalarize_packed_fops") = false,
+      py::arg("vectorize_extracted_adds") = false,
       py::call_guard<py::gil_scoped_release>());
 
   m.def("translate_to_asm",

--- a/python/test/unit/runtime/test_bindings.py
+++ b/python/test/unit/runtime/test_bindings.py
@@ -149,3 +149,35 @@ module {
     llvm.optimize_module(llvm_module, llvm.OPTIMIZE_O3, **options)
     expected = "call float @llvm.fma.f32" if scalarize else "call <2 x float> @llvm.fma.v2f32"
     assert expected in str(llvm_module)
+
+
+@pytest.mark.parametrize("vectorize", [False, True])
+def test_vectorize_extracted_adds_llvm_pipeline(tmp_path, vectorize):
+    from triton._C.libtriton import ir, llvm
+
+    source = tmp_path / "extracted_adds.mlir"
+    source.write_text("""
+module {
+  llvm.func @extracted_adds(%a: vector<2xf32>, %b: vector<2xf32>) -> f32 {
+    %mul = llvm.fmul %a, %b : vector<2xf32>
+    %i0 = llvm.mlir.constant(0 : i32) : i32
+    %i1 = llvm.mlir.constant(1 : i32) : i32
+    %zero = llvm.mlir.constant(0.0 : f32) : f32
+    %x0 = llvm.extractelement %mul[%i0 : i32] : vector<2xf32>
+    %a0 = llvm.fadd %x0, %zero : f32
+    %x1 = llvm.extractelement %mul[%i1 : i32] : vector<2xf32>
+    %a1 = llvm.fadd %x1, %zero : f32
+    %r = llvm.fadd %a0, %a1 : f32
+    llvm.return %r : f32
+  }
+}
+""")
+    context = ir.context()
+    ir.load_dialects(context)
+    module = ir.parse_mlir_module(str(source), context)
+    llvm_context = llvm.context()
+    llvm_module = llvm.to_module(module, llvm_context)
+    options = {"vectorize_extracted_adds": True} if vectorize else {}
+    llvm.optimize_module(llvm_module, llvm.OPTIMIZE_O0, **options)
+    expected = "fadd <2 x float>" if vectorize else "fadd float"
+    assert expected in str(llvm_module)

--- a/test/LLVMIR/vectorize-extracted-adds.ll
+++ b/test/LLVMIR/vectorize-extracted-adds.ll
@@ -1,0 +1,139 @@
+; RUN: triton-llvm-opt -vectorize-extracted-adds %s | FileCheck %s
+; RUN: triton-llvm-opt -vectorize-extracted-adds %s | llc -mtriple=nvptx64 -mcpu=sm_100 -fp-contract=fast | FileCheck %s --check-prefix=PTX
+
+; Re-form the full-lane scalar adds so NVPTX sees packed FMA candidates.
+define void @full2(<2 x float> %a, <2 x float> %b, ptr %out) {
+; PTX-LABEL: full2(
+; PTX:       fma.rn.f32x2
+; PTX:       ret;
+; CHECK-LABEL: define void @full2(
+; CHECK:         [[MUL:%.*]] = fmul <2 x float> %a, %b
+; CHECK-NEXT:    [[ADD:%.*]] = fadd <2 x float> [[MUL]], splat (float 1.000000e+00)
+; CHECK-NEXT:    [[LO:%.*]] = extractelement <2 x float> [[ADD]], i64 0
+; CHECK-NEXT:    [[HI:%.*]] = extractelement <2 x float> [[ADD]], i64 1
+; CHECK-NEXT:    store float [[LO]], ptr %out, align 4
+; CHECK:         store float [[HI]], ptr
+  %mul = fmul <2 x float> %a, %b
+  %lo = extractelement <2 x float> %mul, i64 0
+  %lo.add = fadd float %lo, 1.0
+  %hi = extractelement <2 x float> %mul, i64 1
+  %hi.add = fadd float 1.0, %hi
+  store float %lo.add, ptr %out
+  %next = getelementptr float, ptr %out, i64 1
+  store float %hi.add, ptr %next
+  ret void
+}
+
+define void @full8(<8 x float> %a, <8 x float> %b) {
+; CHECK-LABEL: define void @full8(
+; CHECK:         [[MUL:%.*]] = fmul <8 x float> %a, %b
+; CHECK-NEXT:    [[ADD:%.*]] = fadd <8 x float> [[MUL]], zeroinitializer
+; CHECK-COUNT-8: extractelement <8 x float> [[ADD]]
+; CHECK-NEXT:    ret void
+  %mul = fmul <8 x float> %a, %b
+  %x0 = extractelement <8 x float> %mul, i64 0
+  %a0 = fadd float %x0, 0.0
+  %x1 = extractelement <8 x float> %mul, i64 1
+  %a1 = fadd float %x1, 0.0
+  %x2 = extractelement <8 x float> %mul, i64 2
+  %a2 = fadd float %x2, 0.0
+  %x3 = extractelement <8 x float> %mul, i64 3
+  %a3 = fadd float %x3, 0.0
+  %x4 = extractelement <8 x float> %mul, i64 4
+  %a4 = fadd float %x4, 0.0
+  %x5 = extractelement <8 x float> %mul, i64 5
+  %a5 = fadd float %x5, 0.0
+  %x6 = extractelement <8 x float> %mul, i64 6
+  %a6 = fadd float %x6, 0.0
+  %x7 = extractelement <8 x float> %mul, i64 7
+  %a7 = fadd float %x7, 0.0
+  ret void
+}
+
+; Keep partial, ambiguous, or non-uniform groups scalar.
+define float @missing_lane(<2 x float> %a, <2 x float> %b) {
+; CHECK-LABEL: define float @missing_lane(
+; CHECK-NOT:     fadd <2 x float>
+; CHECK:         fadd float
+  %mul = fmul <2 x float> %a, %b
+  %lo = extractelement <2 x float> %mul, i64 0
+  %r = fadd float %lo, 0.0
+  ret float %r
+}
+
+define void @duplicate_lane(<2 x float> %a, <2 x float> %b) {
+; CHECK-LABEL: define void @duplicate_lane(
+; CHECK-NOT:     fadd <2 x float>
+; CHECK-COUNT-2: fadd float
+  %mul = fmul <2 x float> %a, %b
+  %x0 = extractelement <2 x float> %mul, i64 0
+  %a0 = fadd float %x0, 0.0
+  %x1 = extractelement <2 x float> %mul, i64 0
+  %a1 = fadd float %x1, 0.0
+  ret void
+}
+
+define void @vector_user(<2 x float> %a, <2 x float> %b, ptr %out) {
+; CHECK-LABEL: define void @vector_user(
+; CHECK-NOT:     fadd <2 x float>
+; CHECK-COUNT-2: fadd float
+  %mul = fmul <2 x float> %a, %b
+  store <2 x float> %mul, ptr %out
+  %x0 = extractelement <2 x float> %mul, i64 0
+  %a0 = fadd float %x0, 0.0
+  %x1 = extractelement <2 x float> %mul, i64 1
+  %a1 = fadd float %x1, 0.0
+  ret void
+}
+
+define void @different_addends(<2 x float> %a, <2 x float> %b) {
+; CHECK-LABEL: define void @different_addends(
+; CHECK-NOT:     fadd <2 x float>
+; CHECK-COUNT-2: fadd float
+  %mul = fmul <2 x float> %a, %b
+  %x0 = extractelement <2 x float> %mul, i64 0
+  %a0 = fadd float %x0, 0.0
+  %x1 = extractelement <2 x float> %mul, i64 1
+  %a1 = fadd float %x1, 1.0
+  ret void
+}
+
+define void @different_flags(<2 x float> %a, <2 x float> %b) {
+; CHECK-LABEL: define void @different_flags(
+; CHECK-NOT:     fadd <2 x float>
+; CHECK:         fadd float
+; CHECK:         fadd fast float
+  %mul = fmul <2 x float> %a, %b
+  %x0 = extractelement <2 x float> %mul, i64 0
+  %a0 = fadd float %x0, 0.0
+  %x1 = extractelement <2 x float> %mul, i64 1
+  %a1 = fadd fast float %x1, 0.0
+  ret void
+}
+
+define void @strict(<2 x float> %a, <2 x float> %b) strictfp {
+; CHECK-LABEL: define void @strict(
+; CHECK-NOT:     fadd <2 x float>
+; CHECK-COUNT-2: fadd float
+  %mul = fmul <2 x float> %a, %b
+  %x0 = extractelement <2 x float> %mul, i64 0
+  %a0 = fadd float %x0, 0.0
+  %x1 = extractelement <2 x float> %mul, i64 1
+  %a1 = fadd float %x1, 0.0
+  ret void
+}
+
+define void @different_blocks(<2 x float> %a, <2 x float> %b) {
+; CHECK-LABEL: define void @different_blocks(
+; CHECK-NOT:     fadd <2 x float>
+; CHECK-COUNT-2: fadd float
+entry:
+  %mul = fmul <2 x float> %a, %b
+  %x0 = extractelement <2 x float> %mul, i64 0
+  %a0 = fadd float %x0, 0.0
+  br label %next
+next:
+  %x1 = extractelement <2 x float> %mul, i64 1
+  %a1 = fadd float %x1, 0.0
+  ret void
+}

--- a/third_party/nvidia/backend/compiler.py
+++ b/third_party/nvidia/backend/compiler.py
@@ -497,6 +497,7 @@ class CUDABackend(BaseBackend):
             llvm.OPTIMIZE_O3,
             disable_slp_vectorizer=capability == 80,
             expand_masked_div_rem=True,
+            vectorize_extracted_adds=True,
             scalarize_packed_fops=True,
         )
 


### PR DESCRIPTION
This is kind of dumb, but for some reason SLPVectorizer can generate code like:
```llvm
  %mul = fmul <2 x float> %a, %b
  %lo = extractelement <2 x float> %mul, i64 0
  %lo.add = fadd float %lo, 1.0
  %hi = extractelement <2 x float> %mul, i64 1
  %hi.add = fadd float %hi, 1.0
```

So I add a tiny pass to turn this into:
```llvm
  %mul = fmul <2 x float> %a, %b
  %add = fadd <2 x float> %mul, splat (float 1.000000e+00)
  %lo.add = extractelement <2 x float> %add, i64 0
  %hi.add = extractelement <2 x float> %add, i64 1
```
which in turn becomes a vector fma.f32x2 in ptx.