### PR TITLE
[OptimizeThreadLocality] Support rank-one, non-innermost-axis, and cross CTA reduce

### DIFF
--- a/lib/Dialect/TritonGPU/Transforms/OptimizeThreadLocality.cpp
+++ b/lib/Dialect/TritonGPU/Transforms/OptimizeThreadLocality.cpp
@@ -242,7 +242,7 @@ namespace {
 // A reduction accumulated into an scf.for iter_arg:
 //
 //   %res = scf.for ... iter_args(.., %acc = %init, ..)  (forOp)
-//     %red = tt.reduce %src {axis = rank-1}             (reduce)
+//     %red = tt.reduce %src {axis}                      (reduce)
 //              [%a, %b] {return ⊕(%a, %b);}             (combiner)
 //     %upd = ⊕(%acc, %red)                              (update)
 //     scf.yield .., %upd, ..                            (slot argIdx)
@@ -277,15 +277,9 @@ std::optional<AccumulatedReduce> matchAccumulatedReduce(scf::ForOp forOp,
       !arith::getNeutralElement(combiner))
     return std::nullopt;
   auto srcType = cast<RankedTensorType>(reduce.getOperands()[0].getType());
-  auto rank = srcType.getShape().size();
   unsigned axis = reduce.getAxis();
   // TODO: relax this restriction
-  if (!(isa<triton::gpu::BlockedEncodingAttr>(srcType.getEncoding()) &&
-        rank > 1))
-    return std::nullopt;
-  // The code currently assumes that the reduction is happening on the most
-  // inner dim.
-  if (axis != rank - 1)
+  if (!isa<triton::gpu::BlockedEncodingAttr>(srcType.getEncoding()))
     return std::nullopt;
   // only profitable when there are inter-thread/warp/cta communication that
   // can be deferred after the loop.
@@ -361,12 +355,15 @@ class TritonGPUOptimizeThreadLocalityPass
         // create post loop reduction on the original reduce axis
         auto newReduce2 = createPostLoopReduce(builder, newLoop, reduce);
         // add convert_layout to get back to original layout, the result layout
-        // should now match the layout of the old accumulator (%init)
+        // should now match the layout of the old accumulator (%init); a
+        // rank-one reduce yields a scalar, which needs no conversion
         Type destType = newLoop.getResult(argIdx).getType();
-        auto cvtLayout = createConvertLayout(builder, destType, newReduce2);
+        Operation *newResult = newReduce2;
+        if (isa<RankedTensorType>(destType))
+          newResult = createConvertLayout(builder, destType, newReduce2);
         // incorporate the original accumulator value into the final result
         auto finalOp = incorporateOriginalAccumulatorValue(builder, oldUpdate,
-                                                           cvtLayout, oldAccum);
+                                                           newResult, oldAccum);
         // Replace the old accumulator's uses with the final result
         newLoop.getResult(argIdx).replaceAllUsesWith(finalOp->getResult(0));
 
@@ -382,12 +379,12 @@ class TritonGPUOptimizeThreadLocalityPass
 private:
   Operation *incorporateOriginalAccumulatorValue(OpBuilder &builder,
                                                  Operation *oldUpdate,
-                                                 Operation *cvtLayout,
+                                                 Operation *newResult,
                                                  Value oldAccum) const {
-    builder.setInsertionPointAfter(cvtLayout);
+    builder.setInsertionPointAfter(newResult);
     IRMapping mapping;
     mapping.map(oldUpdate->getOperand(0), oldAccum);
-    mapping.map(oldUpdate->getOperand(1), cvtLayout->getResult(0));
+    mapping.map(oldUpdate->getOperand(1), newResult->getResult(0));
     auto finalOp = cloneWithInferType(builder, &(*oldUpdate), mapping);
     return finalOp;
   }
@@ -429,10 +426,9 @@ private:
     auto blockArgNum = loop.getBody()->getNumArguments() - 1;
     auto newArg = loop.getBody()->getArgument(blockArgNum);
     builder.setInsertionPointAfter(newReduce);
-    IRMapping mapping;
-    mapping.map(oldUpdate->getOperand(0), newArg);
-    mapping.map(oldUpdate->getOperand(1), newReduce->getResult(0));
-    auto newUpdate = cloneWithInferType(builder, oldUpdate, mapping);
+    Operation *newUpdate = builder.clone(*oldUpdate);
+    newUpdate->setOperands({newArg, newReduce->getResult(0)});
+    newUpdate->getResult(0).setType(newArg.getType());
     return newUpdate;
   }
 
@@ -447,16 +443,25 @@ private:
     int64_t sizePerThread = std::min<int64_t>(
         blocked.getSizePerThread()[reduce.getAxis()], elemsPerThread);
 
-    // Group register-owned elements without permuting non-reduction axes:
-    // [..., N] -> [..., R, H, S] -> [..., H, R, S] -> [..., H, R * S].
+    // [.., N, ..] -> [.., ctaSplit, R, H, S, ..] -> [.., ctaSplit, H, .., R, S]
+    //   -> [.., ctaSplit * H, .., R * S].
+    unsigned axis = reduce.getAxis();
+    int64_t ctaSplit =
+        std::min<int64_t>(getCTASplitNum(blocked)[axis], dstShape[axis]);
+    int64_t R = elemsPerThread / sizePerThread; // register wraparounds
+    int64_t H = dstShape[axis] / ctaSplit;      // warps & threads
     SmallVector<int64_t> factorShape(srcType.getShape().begin(),
                                      srcType.getShape().end());
-    factorShape.back() = elemsPerThread / sizePerThread;
-    factorShape.push_back(dstShape[rank - 1]);
-    factorShape.push_back(sizePerThread);
-    SmallVector<int32_t> transposeOrder(rank + 2);
+    // [.., ctaSplit, R, H, S, ..]
+    factorShape[axis] = ctaSplit;
+    factorShape.insert(factorShape.begin() + axis + 1, {R, H, sizePerThread});
+    SmallVector<int32_t> transposeOrder(rank + 3);
     std::iota(transposeOrder.begin(), transposeOrder.end(), 0);
-    std::swap(transposeOrder[rank - 1], transposeOrder[rank]);
+    // [.., ctaSplit, (R, H), S, ..] -> [.., ctaSplit, (H, R), S, ..]
+    std::swap(transposeOrder[axis + 1], transposeOrder[axis + 2]);
+    // [.., ctaSplit, H, (R, S), ..] -> [.., ctaSplit, H, .., (R, S)]
+    std::rotate(transposeOrder.begin() + axis + 2,
+                transposeOrder.begin() + axis + 4, transposeOrder.end());
 
     builder.setInsertionPointAfter(reduce);
     Value operand = reduce.getOperands()[0];

--- a/test/TritonGPU/optimize-locality.mlir
+++ b/test/TritonGPU/optimize-locality.mlir
@@ -4,8 +4,8 @@
 // CHECK: %[[INIT_ARG:.*]] = arith.constant dense<0.000000e+00>
 // CHECK: %[[LOOP_OUTPUT:.*]] = scf.for {{.*}} iter_args(%[[FOR_ARG:.*]] = %[[INIT_ARG]]) -> {{.*}}
 // CHECK: %[[LOAD:.*]] = tt.load
-// CHECK: %[[FACTORED:.*]] = tt.reshape %[[LOAD]] : {{.*}} -> tensor<{{32x2x32x2xf32.*}}>
-// CHECK-NEXT: %[[TRANSPOSED:.*]] = tt.trans %[[FACTORED]] {order = array<i32: 0, 2, 1, 3>}
+// CHECK: %[[FACTORED:.*]] = tt.reshape %[[LOAD]] : {{.*}} -> tensor<{{32x1x2x32x2xf32.*}}>
+// CHECK-NEXT: %[[TRANSPOSED:.*]] = tt.trans %[[FACTORED]] {order = array<i32: 0, 1, 3, 2, 4>}
 // CHECK-NEXT: tt.reshape %[[TRANSPOSED]] efficient_layout : {{.*}} -> tensor<{{32x32x4xf32.*}}>
 // CHECK: %[[REDUCE:.*]] = "tt.reduce"({{%.*}}) <{axis = 2 : i32}>
 // CHECK: arith.addf
@@ -109,8 +109,8 @@ module attributes {"ttg.target" = "cuda:80", "ttg.num-ctas" = 1 : i32, "ttg.num-
 
 // CHECK-LABEL: @row_major_register_grouping
 // CHECK: %[[LOAD:.*]] = tt.load
-// CHECK-NEXT: %[[FACTORED:.*]] = tt.reshape %[[LOAD]] : {{.*}} -> tensor<{{8x2x32x4xf32.*}}>
-// CHECK-NEXT: %[[TRANSPOSED:.*]] = tt.trans %[[FACTORED]] {order = array<i32: 0, 2, 1, 3>}
+// CHECK-NEXT: %[[FACTORED:.*]] = tt.reshape %[[LOAD]] : {{.*}} -> tensor<{{8x1x2x32x4xf32.*}}>
+// CHECK-NEXT: %[[TRANSPOSED:.*]] = tt.trans %[[FACTORED]] {order = array<i32: 0, 1, 3, 2, 4>}
 // CHECK-NEXT: %[[RESHAPED:.*]] = tt.reshape %[[TRANSPOSED]] efficient_layout : {{.*}} -> tensor<{{8x32x8xf32.*}}>
 // CHECK: %[[REDUCED:.*]] = "tt.reduce"({{%.*}}) <{axis = 2 : i32}>
 // CHECK: scf.yield
@@ -242,8 +242,8 @@ module attributes {"ttg.target" = "cuda:80", "ttg.num-ctas" = 1 : i32, "ttg.num-
 
 // CHECK-LABEL: @preserve_rows_when_reordering_registers
 // CHECK: %[[LOAD:.*]] = tt.load
-// CHECK-NEXT: %[[FACTORED:.*]] = tt.reshape %[[LOAD]] : {{.*}} -> tensor<{{256x2x2x1xf32.*}}>
-// CHECK-NEXT: %[[TRANSPOSED:.*]] = tt.trans %[[FACTORED]] {order = array<i32: 0, 2, 1, 3>}
+// CHECK-NEXT: %[[FACTORED:.*]] = tt.reshape %[[LOAD]] : {{.*}} -> tensor<{{256x1x2x2x1xf32.*}}>
+// CHECK-NEXT: %[[TRANSPOSED:.*]] = tt.trans %[[FACTORED]] {order = array<i32: 0, 1, 3, 2, 4>}
 // CHECK-NEXT: %[[RESHAPED:.*]] = tt.reshape %[[TRANSPOSED]] efficient_layout : {{.*}} -> tensor<{{256x2x2xf32.*}}>
 // CHECK-NEXT: %[[REORDERED:.*]] = ttg.convert_layout %[[RESHAPED]] : tensor<{{256x2x2xf32.*}}> -> tensor<{{256x2x2xf32.*}}>
 // CHECK-NEXT: "tt.reduce"(%[[REORDERED]]) <{axis = 2 : i32}>
@@ -403,7 +403,7 @@ module attributes {"ttg.target" = "cuda:80", "ttg.num-ctas" = 1 : i32, "ttg.num-
 // CHECK: %[[INIT_ARG:.*]] = arith.constant dense<0xFF800000>
 // CHECK: %[[LOOP_OUTPUT:.*]] = scf.for {{.*}} iter_args(%[[FOR_ARG:.*]] = %[[INIT_ARG]]) -> {{.*}}
 // CHECK: %[[LOAD:.*]] = tt.load
-// CHECK: tt.reshape %[[LOAD]] : {{.*}} -> tensor<{{32x2x32x2xf32.*}}>
+// CHECK: tt.reshape %[[LOAD]] : {{.*}} -> tensor<{{32x1x2x32x2xf32.*}}>
 // CHECK: tt.reshape {{%.*}} efficient_layout : {{.*}} -> tensor<{{32x32x4xf32.*}}>
 // CHECK: %[[REDUCE:.*]] = "tt.reduce"({{%.*}}) <{axis = 2 : i32}>
 // CHECK: arith.maximumf
@@ -511,7 +511,7 @@ module attributes {"ttg.target" = "cuda:80", "ttg.num-ctas" = 1 : i32, "ttg.num-
 // CHECK: %[[CST:.*]] = arith.constant dense<0x7F800000>
 // CHECK: %[[LOOP_OUTPUT:.*]] = scf.for {{.*}} iter_args(%[[FOR_ARG:.*]] = %[[CST]]) -> {{.*}}
 // CHECK: %[[LOAD:.*]] = tt.load
-// CHECK: tt.reshape %[[LOAD]] : {{.*}} -> tensor<{{32x2x32x2xf32.*}}>
+// CHECK: tt.reshape %[[LOAD]] : {{.*}} -> tensor<{{32x1x2x32x2xf32.*}}>
 // CHECK: tt.reshape {{%.*}} efficient_layout : {{.*}} -> tensor<{{32x32x4xf32.*}}>
 // CHECK: %[[REDUCE:.*]] = "tt.reduce"({{%.*}}) <{axis = 2 : i32}>
 // CHECK: arith.minimumf
@@ -619,7 +619,7 @@ module attributes {"ttg.target" = "cuda:80", "ttg.num-ctas" = 1 : i32, "ttg.num-
 // CHECK: %[[CST:.*]] = arith.constant dense<1.000000e+00>
 // CHECK: %[[LOOP_OUTPUT:.*]] = scf.for {{.*}} iter_args(%[[FOR_ARG:.*]] = %[[CST]]) -> {{.*}}
 // CHECK: %[[LOAD:.*]] = tt.load
-// CHECK: tt.reshape %[[LOAD]] : {{.*}} -> tensor<{{32x2x32x2xf32.*}}>
+// CHECK: tt.reshape %[[LOAD]] : {{.*}} -> tensor<{{32x1x2x32x2xf32.*}}>
 // CHECK: tt.reshape {{%.*}} efficient_layout : {{.*}} -> tensor<{{32x32x4xf32.*}}>
 // CHECK: %[[REDUCE:.*]] = "tt.reduce"({{%.*}}) <{axis = 2 : i32}>
 // CHECK: arith.mulf
@@ -731,7 +731,7 @@ module attributes {"ttg.target" = "cuda:80", "ttg.num-ctas" = 1 : i32, "ttg.num-
 // CHECK: %[[LOOP_OUTPUT:.*]] = scf.for {{.*}} iter_args(%[[FOR_ARG:.*]] = %[[INIT_ARG]]) -> {{.*}}
 // CHECK: %[[LOAD:.*]] = tt.load
 // CHECK: %[[MULF:.*]] = arith.mulf %[[LOAD]], %[[LOAD]]
-// CHECK: tt.reshape %[[MULF]] : {{.*}} -> tensor<{{32x2x32x2xf32.*}}>
+// CHECK: tt.reshape %[[MULF]] : {{.*}} -> tensor<{{32x1x2x32x2xf32.*}}>
 // CHECK: tt.reshape {{%.*}} efficient_layout : {{.*}} -> tensor<{{32x32x4xf32.*}}>
 // CHECK: %[[REDUCE:.*]] = "tt.reduce"({{%.*}}) <{axis = 2 : i32}>
 // CHECK: arith.maximumf
@@ -1392,5 +1392,141 @@ module attributes {"ttg.target" = "cuda:90", "ttg.num-ctas" = 2 : i32, "ttg.num-
     }
     tt.store %output, %result : tensor<32x!tt.ptr<f32>, #slice>
     tt.return
+  }
+}
+
+// -----
+
+// Reduce along a non-innermost axis
+// CHECK-LABEL: @reduce_axis_zero
+// CHECK: %[[INIT_ARG:.*]] = arith.constant dense<0.000000e+00> : tensor<4x8xf32
+// CHECK: %[[LOOP_OUTPUT:.*]] = scf.for {{.*}} iter_args(%[[FOR_ARG:.*]] = %[[INIT_ARG]]) -> {{.*}}
+// CHECK: tt.reshape {{.*}} -> tensor<{{1x1x4x2x8xf32.*}}>
+// CHECK: tt.trans {{.*}} {order = array<i32: 0, 2, 4, 1, 3>}
+// CHECK: %[[REDUCE:.*]] = "tt.reduce"({{%.*}}) <{axis = 2 : i32}>
+// CHECK: arith.addf %[[FOR_ARG]], %[[REDUCE]]
+// CHECK: %[[FINAL_REDUCE:.*]] = "tt.reduce"(%[[LOOP_OUTPUT]]) <{axis = 0 : i32}>
+// CHECK: %[[CVT_OUTPUT:.*]] = ttg.convert_layout %[[FINAL_REDUCE]]
+// CHECK: arith.addf %[[CVT_OUTPUT]], {{.*}}
+#blocked = #ttg.blocked<{sizePerThread = [2, 2], threadsPerWarp = [2, 2], warpsPerCTA = [2, 2], order = [1, 0]}>
+#slice = #ttg.slice<{dim = 0, parent = #blocked}>
+module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, "ttg.threads-per-warp" = 4 : i32} {
+  tt.func public @reduce_axis_zero(%values: tensor<8x8x!tt.ptr<f32>, #blocked>, %output: tensor<8x!tt.ptr<f32>, #slice>, %count: i32) {
+    %zero = arith.constant dense<0.000000e+00> : tensor<8xf32, #slice>
+    %start = arith.constant 0 : i32
+    %step = arith.constant 1 : i32
+    %result = scf.for %index = %start to %count step %step iter_args(%accumulator = %zero) -> (tensor<8xf32, #slice>) : i32 {
+      %v = tt.load %values : tensor<8x8x!tt.ptr<f32>, #blocked>
+      %reduced = "tt.reduce"(%v) <{axis = 0 : i32}> ({
+      ^bb0(%a: f32, %b: f32):
+        %sum = arith.addf %a, %b : f32
+        tt.reduce.return %sum : f32
+      }) : (tensor<8x8xf32, #blocked>) -> tensor<8xf32, #slice>
+      %updated = arith.addf %accumulator, %reduced : tensor<8xf32, #slice>
+      scf.yield %updated : tensor<8xf32, #slice>
+    }
+    tt.store %output, %result : tensor<8x!tt.ptr<f32>, #slice>
+    tt.return
+  }
+}
+
+// -----
+
+// Rank-3 reduce along the middle axis
+// CHECK-LABEL: @reduce_middle_axis
+// CHECK: %[[INIT_ARG:.*]] = arith.constant dense<0.000000e+00> : tensor<2x4x2xf32
+// CHECK: %[[LOOP_OUTPUT:.*]] = scf.for {{.*}} iter_args(%[[FOR_ARG:.*]] = %[[INIT_ARG]]) -> {{.*}}
+// CHECK: tt.reshape {{.*}} -> tensor<{{2x1x2x4x2x2xf32.*}}>
+// CHECK: tt.trans {{.*}} {order = array<i32: 0, 1, 3, 5, 2, 4>}
+// CHECK: %[[REDUCE:.*]] = "tt.reduce"({{%.*}}) <{axis = 3 : i32}>
+// CHECK: arith.addf %[[FOR_ARG]], %[[REDUCE]]
+// CHECK: %[[FINAL_REDUCE:.*]] = "tt.reduce"(%[[LOOP_OUTPUT]]) <{axis = 1 : i32}>
+// CHECK: %[[CVT_OUTPUT:.*]] = ttg.convert_layout %[[FINAL_REDUCE]]
+// CHECK: arith.addf %[[CVT_OUTPUT]], {{.*}}
+#blocked = #ttg.blocked<{sizePerThread = [1, 2, 1], threadsPerWarp = [1, 4, 1], warpsPerCTA = [2, 1, 2], order = [2, 1, 0]}>
+#slice = #ttg.slice<{dim = 1, parent = #blocked}>
+module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, "ttg.threads-per-warp" = 4 : i32} {
+  tt.func public @reduce_middle_axis(%values: tensor<2x16x2x!tt.ptr<f32>, #blocked>, %output: tensor<2x2x!tt.ptr<f32>, #slice>, %count: i32) {
+    %zero = arith.constant dense<0.000000e+00> : tensor<2x2xf32, #slice>
+    %start = arith.constant 0 : i32
+    %step = arith.constant 1 : i32
+    %result = scf.for %index = %start to %count step %step iter_args(%accumulator = %zero) -> (tensor<2x2xf32, #slice>) : i32 {
+      %v = tt.load %values : tensor<2x16x2x!tt.ptr<f32>, #blocked>
+      %reduced = "tt.reduce"(%v) <{axis = 1 : i32}> ({
+      ^bb0(%a: f32, %b: f32):
+        %sum = arith.addf %a, %b : f32
+        tt.reduce.return %sum : f32
+      }) : (tensor<2x16x2xf32, #blocked>) -> tensor<2x2xf32, #slice>
+      %updated = arith.addf %accumulator, %reduced : tensor<2x2xf32, #slice>
+      scf.yield %updated : tensor<2x2xf32, #slice>
+    }
+    tt.store %output, %result : tensor<2x2x!tt.ptr<f32>, #slice>
+    tt.return
+  }
+}
+
+// -----
+
+// Rank-1 reduce accumulated into a scalar
+// CHECK-LABEL: @rank_one_reduce
+// CHECK: %[[INIT_ARG:.*]] = arith.constant dense<0.000000e+00> : tensor<4xf32
+// CHECK: %[[LOOP_OUTPUT:.*]] = scf.for {{.*}} iter_args(%[[FOR_ARG:.*]] = %[[INIT_ARG]]) -> {{.*}}
+// CHECK: tt.reshape {{.*}} -> tensor<{{1x1x4x2xf32.*}}>
+// CHECK: tt.trans {{.*}} {order = array<i32: 0, 2, 1, 3>}
+// CHECK: %[[REDUCE:.*]] = "tt.reduce"({{%.*}}) <{axis = 1 : i32}>
+// CHECK: arith.addf %[[FOR_ARG]], %[[REDUCE]]
+// CHECK: %[[FINAL_REDUCE:.*]] = "tt.reduce"(%[[LOOP_OUTPUT]]) <{axis = 0 : i32}>
+// CHECK: %[[FINAL:.*]] = arith.addf %[[FINAL_REDUCE]], {{.*}} : f32
+// CHECK: tt.return %[[FINAL]] : f32
+#blocked = #ttg.blocked<{sizePerThread = [2], threadsPerWarp = [2], warpsPerCTA = [2], order = [0]}>
+module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 2 : i32, "ttg.threads-per-warp" = 2 : i32} {
+  tt.func public @rank_one_reduce(%values: tensor<8x!tt.ptr<f32>, #blocked>, %count: i32) -> f32 {
+    %zero = arith.constant 0.0 : f32
+    %start = arith.constant 0 : i32
+    %step = arith.constant 1 : i32
+    %result = scf.for %index = %start to %count step %step iter_args(%accumulator = %zero) -> (f32) : i32 {
+      %v = tt.load %values : tensor<8x!tt.ptr<f32>, #blocked>
+      %reduced = "tt.reduce"(%v) <{axis = 0 : i32}> ({
+      ^bb0(%a: f32, %b: f32):
+        %sum = arith.addf %a, %b : f32
+        tt.reduce.return %sum : f32
+      }) : (tensor<8xf32, #blocked>) -> f32
+      %updated = arith.addf %accumulator, %reduced : f32
+      scf.yield %updated : f32
+    }
+    tt.return %result : f32
+  }
+}
+
+// -----
+
+// Rank-1 reduce with the CGA split on the reduced axis and non-trivial register wraparound
+// CHECK-LABEL: @rank_one_reduce_cta_split
+// CHECK: %[[INIT_ARG:.*]] = arith.constant dense<0.000000e+00> : tensor<8xf32
+// CHECK: %[[LOOP_OUTPUT:.*]] = scf.for {{.*}} iter_args(%[[FOR_ARG:.*]] = %[[INIT_ARG]]) -> {{.*}}
+// CHECK: tt.reshape {{.*}} -> tensor<{{2x2x4x2xf32.*}}>
+// CHECK: tt.trans {{.*}} {order = array<i32: 0, 2, 1, 3>}
+// CHECK: %[[REDUCE:.*]] = "tt.reduce"({{%.*}}) <{axis = 1 : i32}>
+// CHECK: arith.addf %[[FOR_ARG]], %[[REDUCE]]
+// CHECK: %[[FINAL_REDUCE:.*]] = "tt.reduce"(%[[LOOP_OUTPUT]]) <{axis = 0 : i32}>
+// CHECK: %[[FINAL:.*]] = arith.addf %[[FINAL_REDUCE]], {{.*}} : f32
+// CHECK: tt.return %[[FINAL]] : f32
+#blocked = #ttg.blocked<{sizePerThread = [2], threadsPerWarp = [2], warpsPerCTA = [2], order = [0], CGALayout = [[1]]}>
+module attributes {"ttg.num-ctas" = 2 : i32, "ttg.num-warps" = 2 : i32, "ttg.threads-per-warp" = 2 : i32} {
+  tt.func public @rank_one_reduce_cta_split(%values: tensor<32x!tt.ptr<f32>, #blocked>, %count: i32) -> f32 {
+    %zero = arith.constant 0.0 : f32
+    %start = arith.constant 0 : i32
+    %step = arith.constant 1 : i32
+    %result = scf.for %index = %start to %count step %step iter_args(%accumulator = %zero) -> (f32) : i32 {
+      %v = tt.load %values : tensor<32x!tt.ptr<f32>, #blocked>
+      %reduced = "tt.reduce"(%v) <{axis = 0 : i32}> ({
+      ^bb0(%a: f32, %b: f32):
+        %sum = arith.addf %a, %b : f32
+        tt.reduce.return %sum : f32
+      }) : (tensor<32xf32, #blocked>) -> f32
+      %updated = arith.addf %accumulator, %reduced : f32
+      scf.yield %updated : f32
+    }
+    tt.return %result : f32
   }
 }


### PR DESCRIPTION
Follow up on #11370. Relax more gates that were limited by rewriter implementation rather than actual correctness or profitability.

1. rank = 1: (arguably the more common case than everything already handled)
    
    In this case the accumulator in the original pattern, and the result of the post-loop reduction in the transformed pattern are now scalars. this requires 2 changes:
    
    - skip the last `convert_layout`  after the post-loop reduction
    - In `createUpdate` , replace the `cloneWithInferType` utility , which only support tensor types
2. axis ≠ rank - 1:
    
    Handling this only requires changing the way axes are permuted when writing the reshape - transpose - reshape pattern in `createReduce` . 
    
3. Multi-CTA:
    
    (this is a general pre-existing issue, but mostly made reachable by enabling rank = 1, as otherwise the nvidia `PlanCTA` pass would avoid splitting CTA across the reduce axis.)
    
    For an axis in the blocked encoding layout, the CTA split is the slowest varying dimension, but the current code in `createReduce` assumes the register-wraparound as the slowest dimension. When both ctaSplit and register-wraparound are non-trivial, it trips the `cvtReordersRegisters` assert.


Considering both CTA split and axis ≠ rank - 1, the general form of axes regrouping in `createReduce` should be:

```
R := register wraparound
H := warps & lanes
S := size per thread

[.., N, ..] 
-> [.., ctaSplit, R, H, S, ..] (reshape)
-> [.., ctaSplit, H, .., R, S] (transpose)
-> [.., ctaSplit * H, .., R * S] (reshape)
```