### PR TITLE
[KERNELS] Allow layout conversion into existing storage

### DIFF
--- a/python/triton_kernels/tests/test_tensor.py
+++ b/python/triton_kernels/tests/test_tensor.py
@@ -1,7 +1,9 @@
 import math
+from contextlib import nullcontext
 
 import pytest
 import torch
+from torch._subclasses.fake_tensor import FakeTensorMode
 import triton
 import triton.language as tl
 from triton_kernels.fpsan import embed, unembed
@@ -259,21 +261,25 @@ def test_convert_layout_out_requires_byte_fp4_storage():
 
 @pytest.mark.parametrize("offset", [0, 1, 32])
 @pytest.mark.parametrize("major_dim", [-2, -1])
-def test_convert_layout_out_shared_storage(offset, major_dim):
-    data = torch.arange(64, dtype=torch.uint8)
-    source = wrap_torch_tensor(data[:32].view(4, 8), dtype=FP4)
-    layout = StridedLayout(major_dim)
-    shape = layout.storage_shape(source.shape, True)
-    out = wrap_torch_tensor(data[offset:offset + 32].view(shape), dtype=FP4, shape=source.shape, layout=layout)
-    expected = convert_layout(source, layout)
+@pytest.mark.parametrize("mode", ["cpu", "meta", "fake"])
+def test_convert_layout_out_shared_storage(offset, major_dim, mode):
+    with FakeTensorMode() if mode == "fake" else nullcontext():
+        data = torch.arange(64, dtype=torch.uint8, device="meta" if mode == "meta" else "cpu")
+        source = wrap_torch_tensor(data[:32].view(4, 8), dtype=FP4)
+        layout = StridedLayout(major_dim)
+        shape = layout.storage_shape(source.shape, True)
+        out = wrap_torch_tensor(data[offset:offset + 32].view(shape), dtype=FP4, shape=source.shape, layout=layout)
+        expected = convert_layout(source, layout)
 
-    if offset == 1 or (offset == 0 and major_dim == -2):
-        with pytest.raises(ValueError, match="must not overlap"):
-            convert_layout(source, layout, out=out)
-        assert torch.equal(data, torch.arange(64, dtype=torch.uint8))
-    else:
-        assert convert_layout(source, layout, out=out) is out
-        assert torch.equal(out.data, expected.data)
+        if offset == 1 or (offset == 0 and major_dim == -2):
+            with pytest.raises(ValueError, match="must not overlap"):
+                convert_layout(source, layout, out=out)
+            if mode == "cpu":
+                assert torch.equal(data, torch.arange(64, dtype=torch.uint8))
+        else:
+            assert convert_layout(source, layout, out=out) is out
+            if mode == "cpu":
+                assert torch.equal(out.data, expected.data)
 
 
 @pytest.mark.parametrize(

--- a/python/triton_kernels/tests/test_tensor.py
+++ b/python/triton_kernels/tests/test_tensor.py
@@ -218,34 +218,34 @@ def test_convert_layout_noop_for_equivalent_layout(storage_shape, logical_shape,
     assert torch.equal(out.data, converted.data)
 
 
-@pytest.mark.parametrize("shape,layout,dtype", [
-    ([2, 16], StridedLayout(-2), FP4),
-    ([4, 8], StridedLayout(-1), FP4),
-    ([4, 8], StridedLayout(-2), UINT8),
+@pytest.mark.parametrize("shape,layout,dtype,message", [
+    ([2, 16], StridedLayout(-2), FP4, "out must have the same logical shape as the input"),
+    ([4, 8], StridedLayout(-1), FP4, "out must have the requested layout"),
+    ([4, 8], StridedLayout(-2), UINT8, "out must have the same logical and storage dtypes as the input"),
 ])
-def test_convert_layout_out_rejects_incompatible_metadata(shape, layout, dtype):
+def test_convert_layout_out_rejects_incompatible_metadata(shape, layout, dtype, message):
     source = wrap_torch_tensor(torch.zeros((4, 4), dtype=torch.uint8), dtype=FP4)
-    data = torch.full((2, 8), 0xAB, dtype=torch.uint8)
-    out = wrap_torch_tensor(data, dtype=dtype, shape=shape, layout=layout)
+    out = empty(shape, dtype=dtype, device="cpu", layout=layout)
+    out.data.fill_(0xAB)
 
-    with pytest.raises(ValueError, match="out must have"):
+    with pytest.raises(ValueError, match=message):
         convert_layout(source, StridedLayout(-2), out=out)
-    assert torch.all(data == 0xAB)
+    assert torch.all(out.data == 0xAB)
 
 
-@pytest.mark.parametrize("shape,strides,dtype,device", [
-    ((2, 8), (1, 2), torch.int16, "cpu"),
-    ((2, 7), (1, 2), torch.uint8, "cpu"),
-    ((2, 8), (0, 1), torch.uint8, "cpu"),
-    ((2, 8), (1, 2), torch.uint8, "meta"),
+@pytest.mark.parametrize("shape,strides,dtype,device,message", [
+    ((2, 8), (1, 2), torch.int16, "cpu", "out must have the same logical and storage dtypes as the input"),
+    ((2, 7), (1, 2), torch.uint8, "cpu", "out has an incorrect physical storage shape"),
+    ((2, 8), (0, 1), torch.uint8, "cpu", "out must have nonoverlapping physical strides"),
+    ((2, 8), (1, 2), torch.uint8, "meta", "out must be on the input device"),
 ])
-def test_convert_layout_out_rejects_incompatible_storage(shape, strides, dtype, device):
+def test_convert_layout_out_rejects_incompatible_storage(shape, strides, dtype, device, message):
     source = wrap_torch_tensor(torch.zeros((4, 4), dtype=torch.uint8), dtype=FP4)
     layout = StridedLayout(-2)
     data = torch.empty_strided(shape, strides, dtype=dtype, device=device).fill_(0xAB)
     out = wrap_torch_tensor(data, dtype=FP4, shape=source.shape, layout=layout)
 
-    with pytest.raises(ValueError, match="out"):
+    with pytest.raises(ValueError, match=message):
         convert_layout(source, layout, out=out)
     if device != "meta":
         assert torch.all(data == 0xAB)
@@ -305,17 +305,22 @@ def test_convert_layout_converts_different_parameterized_layout(storage_shape, l
 @pytest.mark.parametrize("inverse", [False, True])
 @pytest.mark.parametrize("with_out", [False, True])
 def test_mxfp4_value_convert_layout_peak_allocation(layout, major_dim, step, inverse, with_out):
-    data = torch.empty((2048, 2048), dtype=torch.uint8, device="cuda")
+    data = torch.randint(0, 256, (2048, 2048), dtype=torch.uint8, generator=torch.Generator().manual_seed(0))
     strided = convert_layout(wrap_torch_tensor(data, dtype=FP4), StridedLayout(major_dim))
     source = convert_layout(strided, layout) if inverse else strided
     destination = strided.storage.layout if inverse else layout
+    expected = convert_layout(source, destination)
+    source = wrap_torch_tensor(source.data.cuda(), dtype=FP4, shape=source.shape, layout=source.storage.layout)
     if step == 2:
         contiguous_dim = source.data.stride().index(1)
         storage = source.data.movedim(contiguous_dim, -1)
         storage = torch.stack((storage, storage), dim=-2)[..., 1, :].movedim(-1, contiguous_dim)
         source = wrap_torch_tensor(storage, dtype=FP4, shape=source.shape, layout=source.storage.layout)
-    out = convert_layout(source, destination) if with_out else None
+    out = wrap_torch_tensor(torch.empty_like(expected.data, device="cuda"), dtype=FP4, shape=source.shape,
+                            layout=destination) if with_out else None
     warm = convert_layout(source, destination, out=out)
+    if with_out:
+        out.data.fill_(0xAB)
     torch.cuda.synchronize(source.device)
     del warm
     baseline = torch.cuda.memory_allocated(source.device)
@@ -329,13 +334,13 @@ def test_mxfp4_value_convert_layout_peak_allocation(layout, major_dim, step, inv
     if with_out:
         assert actual is out
     assert peak <= (0 if with_out else actual.data.nbytes) + 1024**2
+    assert torch.equal(actual.data.cpu(), expected.data)
 
 
 @pytest.mark.parametrize("layout", _FP4_VALUE_LAYOUTS + [HopperMXValueLayout(-2, 2), HopperMXValueLayout(-1, 2)])
-@pytest.mark.parametrize("shape", [(2, 130, 66), (0, 130, 66)])
+@pytest.mark.parametrize("shape,step", [((2, 130, 66), 1), ((2, 130, 66), 2), ((0, 130, 66), 1)])
 @pytest.mark.parametrize("major_dim", [-2, -1])
 @pytest.mark.parametrize("inverse", [False, True])
-@pytest.mark.parametrize("step", [1, 2])
 @pytest.mark.parametrize("device", ["cpu", "meta", "cuda"])
 def test_mxfp4_value_convert_layout_out(layout, shape, major_dim, inverse, step, device):
     strided = StridedLayout(major_dim)
@@ -344,9 +349,9 @@ def test_mxfp4_value_convert_layout_out(layout, shape, major_dim, inverse, step,
                          generator=torch.Generator().manual_seed(0))
     # Packing is explicit: C-order physical bytes may pack logical dimension -2.
     source = wrap_torch_tensor(data[1:].view(storage_shape), dtype=FP4, shape=shape, layout=strided)
+    expected = source if inverse else convert_layout(source, layout)
     source = convert_layout(source, layout) if inverse else source
     destination = strided if inverse else layout
-    expected = convert_layout(source, destination)
     source_data = source.data.to(device) if inverse else data.to(device)[1:].view(storage_shape)
     source = wrap_torch_tensor(source_data, dtype=FP4, shape=shape, layout=source.storage.layout)
 
@@ -433,7 +438,7 @@ def test_convert_layout_uses_input_device(layout, inverse, major_dim, with_out):
     with torch.cuda.stream(stream), torch.cuda.device(0):
         source_cuda = wrap_torch_tensor(source.storage.data.to("cuda:1"), dtype=FP4, shape=source.shape,
                                         layout=source.storage.layout)
-        out = wrap_torch_tensor(torch.empty_like(expected.data, device="cuda:1"), dtype=FP4, shape=source.shape,
+        out = wrap_torch_tensor(torch.full_like(expected.data, 0xAB, device="cuda:1"), dtype=FP4, shape=source.shape,
                                 layout=destination) if with_out else None
         actual = convert_layout(source_cuda, destination, out=out)
 

--- a/python/triton_kernels/tests/test_tensor.py
+++ b/python/triton_kernels/tests/test_tensor.py
@@ -239,7 +239,7 @@ def test_convert_layout_scalar(mode):
 
 
 @pytest.mark.parametrize("dtype", _STRIDED_DTYPES)
-@pytest.mark.parametrize("shape,source_dim,destination_dim", [((4, 6, 16), 2, 1), ((2, 4, 3), 0, 1), ((0, 4, 6), 2, 1)])
+@pytest.mark.parametrize("shape,source_dim,destination_dim", [((4, 6, 16), 2, 1), ((2, 4, 3), 0, 1), ((2, 0, 4), 2, 1)])
 @pytest.mark.parametrize("with_out", [False, True])
 @pytest.mark.parametrize("mode", ["cpu", "meta", "fake", "cuda"])
 def test_convert_layout_between_strided_layouts(dtype, shape, source_dim, destination_dim, with_out, mode):
@@ -313,7 +313,9 @@ def test_convert_layout_between_strided_layouts_peak_allocation(dtype, with_out)
         ((70, 65), None, UINT8, HopperMXScaleLayout(-2, 4), HopperMXScaleLayout(-2, 4)),
         ((64, 64), (64, 128), FP4, HopperMXValueLayout(-2, 3), HopperMXValueLayout(-2, 3)),
         ((10, 254, 60), None, UINT8, CDNA4MXScaleLayout(), CDNA4MXScaleLayout()),
+        ((8, 1), None, UINT8, CDNA4MXScaleLayout(), CDNA4MXScaleLayout()),
         ((10, 254, 60), None, UINT8, GFX1250MXScaleLayout(), GFX1250MXScaleLayout()),
+        ((4, 1), None, UINT8, GFX1250MXScaleLayout(), GFX1250MXScaleLayout()),
     ],
 )
 def test_convert_layout_noop_for_equivalent_layout(storage_shape, logical_shape, dtype, layout, equivalent_layout):
@@ -327,6 +329,8 @@ def test_convert_layout_noop_for_equivalent_layout(storage_shape, logical_shape,
                             layout=equivalent_layout)
     assert convert_layout(tensor, layout, out=out) is out
     assert torch.equal(out.data, converted.data)
+    restored = convert_layout(out, tensor.storage.layout)
+    assert torch.equal(restored.data, tensor.data)
 
 
 @pytest.mark.parametrize("shape,layout,dtype,message", [

--- a/python/triton_kernels/tests/test_tensor.py
+++ b/python/triton_kernels/tests/test_tensor.py
@@ -11,6 +11,7 @@ from triton_kernels.tensor_details.bitmatrix import _keyed_add
 from triton_kernels.tensor_details.dtype import BIT, FP4, UINT8
 from triton_kernels.tensor import (
     convert_layout,
+    dtype_to_torch_dtype,
     empty,
     make_ragged_tensor_metadata,
     make_ragged_tensor_metadata_torch,
@@ -39,6 +40,35 @@ _FP4_VALUE_LAYOUTS = [
     BlackwellMXValueLayout(),
     BlackwellMX4ValueShuffledLayout(),
 ]
+
+_STRIDED_DTYPES = [
+    FP4,
+    torch.float8_e4m3fn,
+    torch.float8_e4m3fnuz,
+    torch.float8_e5m2,
+    torch.bfloat16,
+    torch.float16,
+    torch.uint8,
+    torch.int32,
+]
+
+
+def _tensor_bytes(data):
+    return data.contiguous().reshape(-1).view(torch.uint8).cpu()
+
+
+def _strided_conversion_data(shape, dtype, source_dim, destination_dim):
+    if dtype == FP4:
+        nibbles = torch.randint(0, 16, shape, dtype=torch.uint8, generator=torch.Generator().manual_seed(0))
+        packed = []
+        for dim in (source_dim, destination_dim):
+            values = nibbles.movedim(dim, -1)
+            packed.append((values[..., ::2] | (values[..., 1::2] << 4)).movedim(-1, dim))
+        return packed
+    nbytes = math.prod(shape) * dtype.itemsize
+    bits = torch.arange(256, dtype=torch.uint8).repeat(triton.cdiv(nbytes, 256))[:nbytes]
+    values = bits.view(dtype).reshape(shape)
+    return values, values
 
 
 @pytest.mark.parametrize("dtype", [
@@ -190,6 +220,87 @@ def test_convert_layout_noop_does_not_ignore_transformation_kwargs():
 
     with pytest.raises(TypeError):
         convert_layout(tensor, tensor.storage.layout, unsupported=True)
+
+
+@pytest.mark.parametrize("mode", ["cpu", "meta", "fake", "cuda"])
+def test_convert_layout_scalar(mode):
+    with FakeTensorMode() if mode == "fake" else nullcontext():
+        device = "cpu" if mode == "fake" else mode
+        data = torch.tensor(17, dtype=torch.int32, device=device)
+        source = wrap_torch_tensor(data)
+        layout = StridedLayout(0)
+        assert convert_layout(source, layout) is source
+        alias = wrap_torch_tensor(data.view_as(data), layout=layout)
+        assert convert_layout(source, layout, out=alias) is alias
+        out = wrap_torch_tensor(torch.empty_like(data), layout=layout)
+        assert convert_layout(source, layout, out=out) is out
+        if mode in ("cpu", "cuda"):
+            assert torch.equal(out.data, data)
+
+
+@pytest.mark.parametrize("dtype", _STRIDED_DTYPES)
+@pytest.mark.parametrize("shape,source_dim,destination_dim", [((4, 6, 16), 2, 1), ((2, 4, 3), 0, 1), ((0, 4, 6), 2, 1)])
+@pytest.mark.parametrize("with_out", [False, True])
+@pytest.mark.parametrize("mode", ["cpu", "meta", "fake", "cuda"])
+def test_convert_layout_between_strided_layouts(dtype, shape, source_dim, destination_dim, with_out, mode):
+    with FakeTensorMode() if mode == "fake" else nullcontext():
+        device = "cpu" if mode == "fake" else mode
+        source_values, expected = _strided_conversion_data(shape, dtype, source_dim, destination_dim)
+        source_storage = torch.stack((source_values, source_values), dim=-1).to(device)
+        source_layout = StridedLayout(source_dim)
+        source = wrap_torch_tensor(source_storage[..., 1], dtype=dtype, shape=shape, layout=source_layout)
+        destination = StridedLayout(destination_dim)
+        if with_out:
+            out_storage = torch.empty((*expected.shape, 2), dtype=dtype_to_torch_dtype(dtype), device=device)
+            out_storage.view(torch.uint8).fill_(0xAB)
+            out = wrap_torch_tensor(out_storage[..., 1], dtype=dtype, shape=shape, layout=destination)
+        else:
+            out = None
+
+        actual = convert_layout(source, destination, out=out)
+        assert actual.shape == list(shape)
+        assert actual.data.shape == expected.shape
+        assert actual.data.dtype == expected.dtype
+        assert actual.device == source.device
+        if with_out:
+            assert actual is out
+        else:
+            assert actual.stride(destination_dim) == 1
+        restored = convert_layout(actual, source_layout)
+        if mode in ("cpu", "cuda"):
+            source_bits = _tensor_bytes(source_values)
+            assert torch.equal(_tensor_bytes(actual.data), _tensor_bytes(expected))
+            assert torch.equal(_tensor_bytes(restored.data), source_bits)
+            assert torch.equal(_tensor_bytes(source.data), source_bits)
+            assert torch.equal(_tensor_bytes(source_storage[..., 0]), source_bits)
+            if with_out:
+                assert torch.all(_tensor_bytes(out_storage[..., 0]) == 0xAB)
+
+
+@pytest.mark.parametrize("dtype", _STRIDED_DTYPES)
+@pytest.mark.parametrize("with_out", [False, True])
+def test_convert_layout_between_strided_layouts_peak_allocation(dtype, with_out):
+    shape = (2, 1024, 4096)
+    source_values, expected = _strided_conversion_data(shape, dtype, 0, 1)
+    source = wrap_torch_tensor(source_values.cuda(), dtype=dtype, shape=shape, layout=StridedLayout(0))
+    destination = StridedLayout(1)
+    out = empty(shape, dtype=dtype, device=source.device, layout=destination) if with_out else None
+    warm = convert_layout(source, destination, out=out)
+    if with_out:
+        out.data.fill_(0xAB)
+    torch.cuda.synchronize(source.device)
+    del warm
+    baseline = torch.cuda.memory_allocated(source.device)
+    torch.cuda.reset_peak_memory_stats(source.device)
+
+    actual = convert_layout(source, destination, out=out)
+    torch.cuda.synchronize(source.device)
+    peak = torch.cuda.max_memory_allocated(source.device) - baseline
+
+    if with_out:
+        assert actual is out
+    assert peak <= (0 if with_out else actual.data.nbytes) + 1024**2
+    assert torch.equal(_tensor_bytes(actual.data), _tensor_bytes(expected))
 
 
 @pytest.mark.parametrize(

--- a/python/triton_kernels/tests/test_tensor.py
+++ b/python/triton_kernels/tests/test_tensor.py
@@ -1,3 +1,5 @@
+import math
+
 import pytest
 import torch
 import triton
@@ -151,13 +153,20 @@ def test_strided_layout_rejects_odd_fp4_packing_dim(major_dim, other_size):
         (True, StridedLayout(0)),
     ],
 )
-def test_convert_layout_noop(transpose, layout):
-    data = torch.randn((7, 11))
+@pytest.mark.parametrize("device", ["cpu", "meta"])
+def test_convert_layout_noop(transpose, layout, device):
+    data = torch.randn((7, 11), device=device)
     if transpose:
         data = data.T
     tensor = wrap_torch_tensor(data)
 
     assert convert_layout(tensor, layout) is tensor
+    alias = wrap_torch_tensor(data.view_as(data), layout=layout)
+    assert convert_layout(tensor, layout, out=alias) is alias
+    out = wrap_torch_tensor(torch.empty_like(data), layout=layout)
+    assert convert_layout(tensor, layout, out=out) is out
+    if device != "meta":
+        assert torch.equal(out.data, data)
 
 
 def test_convert_layout_noop_preserves_strided_view():
@@ -201,6 +210,70 @@ def test_convert_layout_noop_for_equivalent_layout(storage_shape, logical_shape,
 
     assert converted is not tensor
     assert convert_layout(converted, equivalent_layout) is converted
+    out = wrap_torch_tensor(torch.empty_like(converted.data), dtype=dtype, shape=converted.shape,
+                            layout=equivalent_layout)
+    assert convert_layout(tensor, layout, out=out) is out
+    assert torch.equal(out.data, converted.data)
+
+
+@pytest.mark.parametrize("shape,layout,dtype", [
+    ([2, 16], StridedLayout(-2), FP4),
+    ([4, 8], StridedLayout(-1), FP4),
+    ([4, 8], StridedLayout(-2), UINT8),
+])
+def test_convert_layout_out_rejects_incompatible_metadata(shape, layout, dtype):
+    source = wrap_torch_tensor(torch.zeros((4, 4), dtype=torch.uint8), dtype=FP4)
+    data = torch.full((2, 8), 0xAB, dtype=torch.uint8)
+    out = wrap_torch_tensor(data, dtype=dtype, shape=shape, layout=layout)
+
+    with pytest.raises(ValueError, match="out must have"):
+        convert_layout(source, StridedLayout(-2), out=out)
+    assert torch.all(data == 0xAB)
+
+
+@pytest.mark.parametrize("shape,strides,dtype,device", [
+    ((2, 8), (1, 2), torch.int16, "cpu"),
+    ((2, 7), (1, 2), torch.uint8, "cpu"),
+    ((2, 8), (0, 1), torch.uint8, "cpu"),
+    ((2, 8), (1, 2), torch.uint8, "meta"),
+])
+def test_convert_layout_out_rejects_incompatible_storage(shape, strides, dtype, device):
+    source = wrap_torch_tensor(torch.zeros((4, 4), dtype=torch.uint8), dtype=FP4)
+    layout = StridedLayout(-2)
+    data = torch.empty_strided(shape, strides, dtype=dtype, device=device).fill_(0xAB)
+    out = wrap_torch_tensor(data, dtype=FP4, shape=source.shape, layout=layout)
+
+    with pytest.raises(ValueError, match="out"):
+        convert_layout(source, layout, out=out)
+    if device != "meta":
+        assert torch.all(data == 0xAB)
+
+
+def test_convert_layout_out_requires_byte_fp4_storage():
+    source = wrap_torch_tensor(torch.zeros((4, 4), dtype=torch.int32), dtype=FP4, shape=[4, 8])
+    out = wrap_torch_tensor(torch.empty_like(source.data), dtype=FP4, shape=source.shape)
+
+    with pytest.raises(ValueError, match="requires uint8 storage"):
+        convert_layout(source, source.storage.layout, out=out)
+
+
+@pytest.mark.parametrize("offset", [0, 1, 32])
+@pytest.mark.parametrize("major_dim", [-2, -1])
+def test_convert_layout_out_shared_storage(offset, major_dim):
+    data = torch.arange(64, dtype=torch.uint8)
+    source = wrap_torch_tensor(data[:32].view(4, 8), dtype=FP4)
+    layout = StridedLayout(major_dim)
+    shape = layout.storage_shape(source.shape, True)
+    out = wrap_torch_tensor(data[offset:offset + 32].view(shape), dtype=FP4, shape=source.shape, layout=layout)
+    expected = convert_layout(source, layout)
+
+    if offset == 1 or (offset == 0 and major_dim == -2):
+        with pytest.raises(ValueError, match="must not overlap"):
+            convert_layout(source, layout, out=out)
+        assert torch.equal(data, torch.arange(64, dtype=torch.uint8))
+    else:
+        assert convert_layout(source, layout, out=out) is out
+        assert torch.equal(out.data, expected.data)
 
 
 @pytest.mark.parametrize(
@@ -224,7 +297,8 @@ def test_convert_layout_converts_different_parameterized_layout(storage_shape, l
 @pytest.mark.parametrize("major_dim", [-2, -1])
 @pytest.mark.parametrize("step", [1, 2])
 @pytest.mark.parametrize("inverse", [False, True])
-def test_mxfp4_value_convert_layout_peak_allocation(layout, major_dim, step, inverse):
+@pytest.mark.parametrize("with_out", [False, True])
+def test_mxfp4_value_convert_layout_peak_allocation(layout, major_dim, step, inverse, with_out):
     data = torch.empty((2048, 2048), dtype=torch.uint8, device="cuda")
     strided = convert_layout(wrap_torch_tensor(data, dtype=FP4), StridedLayout(major_dim))
     source = convert_layout(strided, layout) if inverse else strided
@@ -234,18 +308,61 @@ def test_mxfp4_value_convert_layout_peak_allocation(layout, major_dim, step, inv
         storage = source.data.movedim(contiguous_dim, -1)
         storage = torch.stack((storage, storage), dim=-2)[..., 1, :].movedim(-1, contiguous_dim)
         source = wrap_torch_tensor(storage, dtype=FP4, shape=source.shape, layout=source.storage.layout)
-    warm = convert_layout(source, destination)
+    out = convert_layout(source, destination) if with_out else None
+    warm = convert_layout(source, destination, out=out)
     torch.cuda.synchronize(source.device)
     del warm
     baseline = torch.cuda.memory_allocated(source.device)
     torch.cuda.reset_peak_memory_stats(source.device)
 
-    actual = convert_layout(source, destination)
+    actual = convert_layout(source, destination, out=out)
     torch.cuda.synchronize(source.device)
     peak = torch.cuda.max_memory_allocated(source.device) - baseline
 
-    # Public conversion should allocate only its final packed storage.
-    assert peak <= actual.data.nbytes + 1024**2
+    # Supplied output storage needs no additional weight-sized allocation.
+    if with_out:
+        assert actual is out
+    assert peak <= (0 if with_out else actual.data.nbytes) + 1024**2
+
+
+@pytest.mark.parametrize("layout", _FP4_VALUE_LAYOUTS + [HopperMXValueLayout(-2, 2), HopperMXValueLayout(-1, 2)])
+@pytest.mark.parametrize("shape", [(2, 130, 66), (0, 130, 66)])
+@pytest.mark.parametrize("major_dim", [-2, -1])
+@pytest.mark.parametrize("inverse", [False, True])
+@pytest.mark.parametrize("step", [1, 2])
+@pytest.mark.parametrize("device", ["cpu", "meta", "cuda"])
+def test_mxfp4_value_convert_layout_out(layout, shape, major_dim, inverse, step, device):
+    strided = StridedLayout(major_dim)
+    storage_shape = strided.storage_shape(shape, True)
+    data = torch.randint(0, 256, (math.prod(storage_shape) + 1, ), dtype=torch.uint8,
+                         generator=torch.Generator().manual_seed(0))
+    # Packing is explicit: C-order physical bytes may pack logical dimension -2.
+    source = wrap_torch_tensor(data[1:].view(storage_shape), dtype=FP4, shape=shape, layout=strided)
+    source = convert_layout(source, layout) if inverse else source
+    destination = strided if inverse else layout
+    expected = convert_layout(source, destination)
+    source_data = source.data.to(device) if inverse else data.to(device)[1:].view(storage_shape)
+    source = wrap_torch_tensor(source_data, dtype=FP4, shape=shape, layout=source.storage.layout)
+
+    storage = torch.full((expected.data.numel() * step + 1, ), 0xAB, dtype=torch.uint8, device=device)
+    out_data = storage[1:].as_strided(expected.data.shape, tuple(stride * step for stride in expected.data.stride()))
+    out = wrap_torch_tensor(out_data, dtype=FP4, shape=shape, layout=destination)
+
+    assert convert_layout(source, destination, out=out) is out
+    assert out.data is out_data
+    if device != "meta":
+        actual = out.data
+        reference = expected.data
+        if not inverse and isinstance(layout, BlackwellMXValueLayout):
+            actual = actual[..., :shape[-2] // 2, :]
+            reference = reference[..., :shape[-2] // 2, :]
+        assert torch.equal(actual.cpu(), reference)
+        assert storage[0].item() == 0xAB
+        if step == 2:
+            assert torch.all(storage[2::2] == 0xAB)
+        if not inverse:
+            restored = convert_layout(out, strided)
+            assert torch.equal(restored.data.cpu(), data[1:].view(storage_shape))
 
 
 @pytest.mark.parametrize("layout", _FP4_VALUE_LAYOUTS)
@@ -294,7 +411,8 @@ def test_mxfp4_value_convert_layout_meta(layout, major_dim, inverse):
 @pytest.mark.parametrize("layout", _FP4_VALUE_LAYOUTS)
 @pytest.mark.parametrize("inverse", [False, True])
 @pytest.mark.parametrize("major_dim", [-2, -1])
-def test_convert_layout_uses_input_device(layout, inverse, major_dim):
+@pytest.mark.parametrize("with_out", [False, True])
+def test_convert_layout_uses_input_device(layout, inverse, major_dim, with_out):
     if torch.cuda.device_count() < 2:
         pytest.skip("requires two CUDA devices")
 
@@ -309,8 +427,12 @@ def test_convert_layout_uses_input_device(layout, inverse, major_dim):
     with torch.cuda.stream(stream), torch.cuda.device(0):
         source_cuda = wrap_torch_tensor(source.storage.data.to("cuda:1"), dtype=FP4, shape=source.shape,
                                         layout=source.storage.layout)
-        actual = convert_layout(source_cuda, destination)
+        out = wrap_torch_tensor(torch.empty_like(expected.data, device="cuda:1"), dtype=FP4, shape=source.shape,
+                                layout=destination) if with_out else None
+        actual = convert_layout(source_cuda, destination, out=out)
 
+        if with_out:
+            assert actual is out
         assert torch.cuda.current_device() == 0
         assert torch.cuda.current_stream(1) == stream
         assert actual.device == torch.device("cuda:1")

--- a/python/triton_kernels/tests/test_tensor_details/test_layout_blackwell.py
+++ b/python/triton_kernels/tests/test_tensor_details/test_layout_blackwell.py
@@ -91,10 +91,10 @@ def test_mxfp4_value_shuffled_rejects_odd_n(k, destination):
 @pytest.mark.parametrize("block_n", [128, 256])
 @pytest.mark.parametrize("step", [1, 2])
 def test_mxfp4_value_shuffled_matches_torch(shape, block_k, block_n, step):
-    input_shape = tuple(step * size for size in shape[:-1]) + shape[-1:]
+    input_shape = tuple(step * size for size in shape)
     data_cpu = torch.randint(0, 256, input_shape, dtype=torch.uint8, generator=torch.Generator().manual_seed(0))
     data_cuda = data_cpu.cuda()
-    index = (slice(step - 1, None, step), ) * (len(shape) - 1) + (slice(None), )
+    index = (slice(step - 1, None, step), ) * len(shape)
     data_cpu, data_cuda = data_cpu[index], data_cuda[index]
     logical_shape = list(data_cpu.shape)
     logical_shape[-1] *= 2

--- a/python/triton_kernels/tests/test_tensor_details/test_layout_hopper.py
+++ b/python/triton_kernels/tests/test_tensor_details/test_layout_hopper.py
@@ -200,7 +200,8 @@ def test_mxfp4_value_convert_layout_odd_source_packing(shape, mx_axis, major_dim
 @pytest.mark.parametrize("mma_version", [2, 3])
 @pytest.mark.parametrize("major_dim", [-2, -1])
 @pytest.mark.parametrize(("device", "step"), [("cpu", 1), ("meta", 1), ("cuda", 1), ("cuda", 2)])
-def test_mxfp4_value_convert_layout_compact_source(shape, mx_axis, mma_version, major_dim, device, step):
+@pytest.mark.parametrize("with_out", [False, True])
+def test_mxfp4_value_convert_layout_compact_source(shape, mx_axis, mma_version, major_dim, device, step, with_out):
     data = torch.randint(0, 256, shape, dtype=torch.uint8, generator=torch.Generator().manual_seed(0))
     canonical = wrap_torch_tensor(data, dtype=FP4)
     layout = HopperMXValueLayout(mx_axis, mma_version)
@@ -216,8 +217,12 @@ def test_mxfp4_value_convert_layout_compact_source(shape, mx_axis, mma_version, 
     destination = StridedLayout(major_dim)
     expected = convert_layout(canonical, destination)
 
-    actual = convert_layout(source, destination)
+    out = wrap_torch_tensor(torch.empty_like(expected.data, device=device), dtype=FP4, shape=source.shape,
+                            layout=destination) if with_out else None
+    actual = convert_layout(source, destination, out=out)
 
+    if with_out:
+        assert actual is out
     assert actual.shape == expected.shape
     assert actual.data.shape == expected.data.shape
     assert actual.data.stride() == expected.data.stride()
@@ -249,7 +254,8 @@ def test_mxfp4_value_convert_layout_invalid_source_storage(encoded_shape, mx_axi
 @pytest.mark.parametrize("mx_axis", [-2, -1])
 @pytest.mark.parametrize("mma_version", [2, 3])
 @pytest.mark.parametrize("major_dim", [-2, -1])
-def test_mxfp4_value_convert_layout_compact_source_peak_allocation(mx_axis, mma_version, major_dim):
+@pytest.mark.parametrize("with_out", [False, True])
+def test_mxfp4_value_convert_layout_compact_source_peak_allocation(mx_axis, mma_version, major_dim, with_out):
     data = torch.empty((1028, 8320), dtype=torch.uint8, device="cuda")
     shape = (4160, 4112) if mx_axis == -2 else (4112, 4160)
     if mx_axis == -2:
@@ -257,17 +263,20 @@ def test_mxfp4_value_convert_layout_compact_source_peak_allocation(mx_axis, mma_
     layout = HopperMXValueLayout(mx_axis, mma_version)
     source = wrap_torch_tensor(data, dtype=FP4, shape=shape, layout=layout)
     destination = StridedLayout(major_dim)
-    warm = convert_layout(source, destination)
+    out = convert_layout(source, destination) if with_out else None
+    warm = convert_layout(source, destination, out=out)
     torch.cuda.synchronize(data.device)
     del warm
     baseline = torch.cuda.memory_allocated(data.device)
     torch.cuda.reset_peak_memory_stats(data.device)
 
-    actual = convert_layout(source, destination)
+    actual = convert_layout(source, destination, out=out)
     torch.cuda.synchronize(data.device)
     peak = torch.cuda.max_memory_allocated(data.device) - baseline
 
-    assert peak <= actual.data.nbytes + 1024**2
+    if with_out:
+        assert actual is out
+    assert peak <= (0 if with_out else actual.data.nbytes) + 1024**2
 
 
 @pytest.mark.parametrize("mx_axis", [-2, -1])

--- a/python/triton_kernels/tests/test_tensor_details/test_layout_hopper.py
+++ b/python/triton_kernels/tests/test_tensor_details/test_layout_hopper.py
@@ -86,7 +86,8 @@ def test_mxfp4_value_zero_sized_roundtrip(shape, major_dim, mx_axis, mma_version
     transformation = layout.make_transformation(list(shape), True)
 
     swizzled = convert_layout(src, layout)
-    canonical = transformation.unswizzle_data(swizzled.data)
+    # Cloning empty storage may give outer strides that are not word-aligned.
+    canonical = transformation.unswizzle_data(swizzled.data.clone())
     roundtrip = convert_layout(swizzled, src_layout)
 
     assert src.shape == swizzled.shape == roundtrip.shape == list(shape)
@@ -98,21 +99,19 @@ def test_mxfp4_value_zero_sized_roundtrip(shape, major_dim, mx_axis, mma_version
 
 @pytest.mark.parametrize("mx_axis", [-2, -1])
 @pytest.mark.parametrize("mma_version", [2, 3])
-@pytest.mark.parametrize("shape", [(64, 64), (0, 64), (64, 0)])
 @pytest.mark.parametrize("step", [(1, 1), (2, 1), (1, 2)])
 @pytest.mark.parametrize("transpose", [False, True])
-@pytest.mark.parametrize("offset", [0, 1])
-def test_mxfp4_value_convert_layout_roundtrip(mx_axis, mma_version, shape, step, transpose, offset):
-    x = torch.randint(0, 256, shape, dtype=torch.uint8)
-    src = wrap_torch_tensor(x, dtype=FP4, shape=[shape[0], 2 * shape[1]], layout=StridedLayout(-1))
+def test_mxfp4_value_convert_layout_roundtrip(mx_axis, mma_version, step, transpose):
+    x = torch.randint(0, 256, (64, 64), dtype=torch.uint8)
+    src = wrap_torch_tensor(x, dtype=FP4)
     layout = HopperMXValueLayout(mx_axis=mx_axis, mma_version=mma_version)
 
     swizzled = convert_layout(src, layout)
     encoded = swizzled.data.mT if mx_axis == -2 else swizzled.data
-    strides = ((step[0], encoded.shape[0] * math.prod(step)) if transpose else
-               (encoded.shape[1] * math.prod(step), step[1]))
-    storage = torch.empty((encoded.numel() * math.prod(step) + offset, ), dtype=torch.uint8)
-    data = storage[offset:].as_strided(encoded.shape, strides)
+    storage_shape = [size * spacing for size, spacing in zip(encoded.shape, step)]
+    storage = torch.empty(storage_shape[::-1] if transpose else storage_shape, dtype=torch.uint8)
+    data = storage.mT if transpose else storage
+    data = data[::step[0], ::step[1]]
     data.copy_(encoded)
     data = data.mT if mx_axis == -2 else data
     swizzled = wrap_torch_tensor(data, dtype=FP4, shape=src.shape, layout=layout)
@@ -270,15 +269,23 @@ def test_mxfp4_value_convert_layout_invalid_source_storage(encoded_shape, mx_axi
 @pytest.mark.parametrize("major_dim", [-2, -1])
 @pytest.mark.parametrize("with_out", [False, True])
 def test_mxfp4_value_convert_layout_compact_source_peak_allocation(mx_axis, mma_version, major_dim, with_out):
-    data = torch.empty((1028, 8320), dtype=torch.uint8, device="cuda")
     shape = (4160, 4112) if mx_axis == -2 else (4112, 4160)
+    data = torch.randint(0, 256, (shape[0], shape[1] // 2), dtype=torch.uint8,
+                         generator=torch.Generator().manual_seed(0))
+    canonical = wrap_torch_tensor(data, dtype=FP4)
+    layout = HopperMXValueLayout(mx_axis, mma_version)
+    source = convert_layout(canonical, layout)
+    data = source.data.mT if mx_axis == -2 else source.data
+    data = data[:1028, :8320].contiguous().cuda()
     if mx_axis == -2:
         data = data.mT
-    layout = HopperMXValueLayout(mx_axis, mma_version)
     source = wrap_torch_tensor(data, dtype=FP4, shape=shape, layout=layout)
     destination = StridedLayout(major_dim)
-    out = convert_layout(source, destination) if with_out else None
+    expected = convert_layout(canonical, destination)
+    out = empty(shape, dtype=FP4, device=data.device, layout=destination) if with_out else None
     warm = convert_layout(source, destination, out=out)
+    if with_out:
+        out.data.fill_(0xAB)
     torch.cuda.synchronize(data.device)
     del warm
     baseline = torch.cuda.memory_allocated(data.device)
@@ -291,6 +298,7 @@ def test_mxfp4_value_convert_layout_compact_source_peak_allocation(mx_axis, mma_
     if with_out:
         assert actual is out
     assert peak <= (0 if with_out else actual.data.nbytes) + 1024**2
+    assert torch.equal(actual.data.cpu(), expected.data)
 
 
 @pytest.mark.parametrize("mx_axis", [-2, -1])

--- a/python/triton_kernels/tests/test_tensor_details/test_layout_hopper.py
+++ b/python/triton_kernels/tests/test_tensor_details/test_layout_hopper.py
@@ -97,12 +97,25 @@ def test_mxfp4_value_zero_sized_roundtrip(shape, major_dim, mx_axis, mma_version
 
 
 @pytest.mark.parametrize("mx_axis", [-2, -1])
-def test_mxfp4_value_convert_layout_roundtrip(mx_axis):
-    x = torch.randint(0, 256, (64, 64), dtype=torch.uint8)
-    src = wrap_torch_tensor(x, dtype=FP4)
-    layout = HopperMXValueLayout(mx_axis=mx_axis, mma_version=3)
+@pytest.mark.parametrize("mma_version", [2, 3])
+@pytest.mark.parametrize("shape", [(64, 64), (0, 64), (64, 0)])
+@pytest.mark.parametrize("step", [(1, 1), (2, 1), (1, 2)])
+@pytest.mark.parametrize("transpose", [False, True])
+@pytest.mark.parametrize("offset", [0, 1])
+def test_mxfp4_value_convert_layout_roundtrip(mx_axis, mma_version, shape, step, transpose, offset):
+    x = torch.randint(0, 256, shape, dtype=torch.uint8)
+    src = wrap_torch_tensor(x, dtype=FP4, shape=[shape[0], 2 * shape[1]], layout=StridedLayout(-1))
+    layout = HopperMXValueLayout(mx_axis=mx_axis, mma_version=mma_version)
 
     swizzled = convert_layout(src, layout)
+    encoded = swizzled.data.mT if mx_axis == -2 else swizzled.data
+    strides = ((step[0], encoded.shape[0] * math.prod(step)) if transpose else
+               (encoded.shape[1] * math.prod(step), step[1]))
+    storage = torch.empty((encoded.numel() * math.prod(step) + offset, ), dtype=torch.uint8)
+    data = storage[offset:].as_strided(encoded.shape, strides)
+    data.copy_(encoded)
+    data = data.mT if mx_axis == -2 else data
+    swizzled = wrap_torch_tensor(data, dtype=FP4, shape=src.shape, layout=layout)
     roundtrip = convert_layout(swizzled, src.storage.layout)
 
     assert torch.equal(roundtrip.storage.data, x)

--- a/python/triton_kernels/tests/test_tensor_details/test_layout_hopper.py
+++ b/python/triton_kernels/tests/test_tensor_details/test_layout_hopper.py
@@ -217,8 +217,9 @@ def test_mxfp4_value_convert_layout_compact_source(shape, mx_axis, mma_version, 
     destination = StridedLayout(major_dim)
     expected = convert_layout(canonical, destination)
 
-    out = wrap_torch_tensor(torch.empty_like(expected.data, device=device), dtype=FP4, shape=source.shape,
-                            layout=destination) if with_out else None
+    out = wrap_torch_tensor(
+        torch.empty_strided(expected.data.shape, expected.data.stride(), dtype=expected.data.dtype, device=device),
+        dtype=FP4, shape=source.shape, layout=destination) if with_out else None
     actual = convert_layout(source, destination, out=out)
 
     if with_out:

--- a/python/triton_kernels/triton_kernels/tensor.py
+++ b/python/triton_kernels/triton_kernels/tensor.py
@@ -1,6 +1,7 @@
 from dataclasses import dataclass
 
 import torch
+from torch._subclasses.fake_tensor import is_fake
 from triton.tools.ragged_tma import create_ragged_descriptor
 from triton.tools.tensor_descriptor import TensorDescriptor
 
@@ -231,18 +232,78 @@ def wrap_torch_tensor(torch_tensor, dtype=None, shape=None, shape_max=None, layo
     return Tensor(Storage(torch_tensor, layout), dtype=dtype, shape=shape, shape_max=shape_max)
 
 
-def convert_layout(tensor: Tensor, layout: Layout, **layout_transformation_kwargs):
+def _validate_conversion_out(tensor, out, layout, destination, same_encoding):
+    if out.shape != tensor.shape:
+        raise ValueError("out must have the same logical shape as the input")
+    if not out.storage.layout.can_preserve_storage_as(layout, len(tensor.shape)):
+        raise ValueError("out must have the requested layout")
+    if out.dtype != tensor.dtype or out.data.dtype != tensor.data.dtype:
+        raise ValueError("out must have the same logical and storage dtypes as the input")
+    if out.device != tensor.device:
+        raise ValueError("out must be on the input device")
+    if tensor.dtype == FP4 and tensor.data.dtype != torch.uint8:
+        raise ValueError("FP4 conversion with out requires uint8 storage")
+    if (same_encoding and torch._C._overlaps(tensor.data, out.data)
+            and out.data.storage_offset() == tensor.data.storage_offset() and out.data.shape == tensor.data.shape
+            and out.data.stride() == tensor.data.stride()):
+        return True
+    if list(out.data.shape) != destination.storage_shape:
+        raise ValueError("out has an incorrect physical storage shape")
+    if not out.data.numel():
+        return False
+
+    # Increasing strides must separate the spans of the faster dimensions.
+    # This permits sliced storage without permitting overlapping writes.
+    span = 1
+    for size, stride in sorted(zip(out.data.shape, out.data.stride()), key=lambda item: item[1]):
+        if size > 1:
+            if stride < span:
+                raise ValueError("out must have nonoverlapping physical strides")
+            span += (size - 1) * stride
+
+    if tensor.device.type == "meta" or is_fake(tensor.data):
+        overlaps = torch._C._overlaps(tensor.data, out.data)
+    elif tensor.data.numel():
+        source_start = tensor.data.data_ptr()
+        source_end = source_start + tensor.data.element_size() * (1 + sum(
+            (size - 1) * stride for size, stride in zip(tensor.data.shape, tensor.data.stride())))
+        out_start = out.data.data_ptr()
+        out_end = out_start + out.data.element_size() * span
+        overlaps = source_start < out_end and out_start < source_end
+    else:
+        overlaps = False
+    if overlaps:
+        raise ValueError("input and out storage must not overlap")
+    return False
+
+
+def convert_layout(tensor: Tensor, layout: Layout, *, out: Tensor | None = None, **layout_transformation_kwargs):
     """Convert `tensor` storage encoding to `layout`.
 
-    Returns `tensor` unchanged when its existing storage is already valid for
-    `layout`. This operation does not clone, densify, or canonicalize physical
-    strides of a tensor that is already in the requested encoding.
+    Without `out`, returns `tensor` unchanged when its storage is already valid
+    for `layout`, without cloning or canonicalizing its physical strides.
+
+    With `out`, writes into and returns that tensor. Its storage must have the
+    destination shape, matching input dtype/device, and nonoverlapping strides.
+    Slices with gaps are supported; interleaved strides are not. Input and output
+    spans must be disjoint unless they are identical views in the same encoding.
+    FP4 storage must be uint8. Reference paths may still allocate intermediates.
     """
     shape = list(tensor.shape)
-    if not layout_transformation_kwargs and tensor.storage.layout.can_preserve_storage_as(layout, len(shape)):
+    same_encoding = not layout_transformation_kwargs and tensor.storage.layout.can_preserve_storage_as(
+        layout, len(shape))
+    if out is None and same_encoding:
         return tensor
     source = tensor.storage.layout.make_transformation(shape, tensor.dtype == FP4)
     destination = layout.make_transformation(shape, tensor.dtype == FP4, **layout_transformation_kwargs)
+    if out is not None:
+        if _validate_conversion_out(tensor, out, layout, destination, same_encoding):
+            return out
+        if same_encoding and tensor.data.shape == out.data.shape:
+            out.data.copy_(tensor.data)
+        else:
+            source.convert_data(tensor.data, destination, out=out.data)
+        return out
     new_data = source.convert_data(tensor.storage.data, destination)
     return Tensor(Storage(new_data, layout), shape=list(tensor.shape), dtype=tensor.dtype)
 

--- a/python/triton_kernels/triton_kernels/tensor.py
+++ b/python/triton_kernels/triton_kernels/tensor.py
@@ -261,8 +261,6 @@ def _validate_conversion_out(tensor, out, layout, destination, same_encoding):
                 raise ValueError("out must have nonoverlapping physical strides")
             span += (size - 1) * stride
 
-    if not data.numel():
-        return False
     if data.device.type == "meta" or is_fake(data):
         if not torch._C._overlaps(data, out_data):
             return False

--- a/python/triton_kernels/triton_kernels/tensor.py
+++ b/python/triton_kernels/triton_kernels/tensor.py
@@ -249,6 +249,7 @@ def _validate_conversion_out(tensor, out, layout, destination, same_encoding):
         return True
     if list(out_data.shape) != destination.storage_shape:
         raise ValueError("out has an incorrect physical storage shape")
+    # Empty tensors have no spans to validate, regardless of strides or pointers.
     if not out_data.numel():
         return False
 

--- a/python/triton_kernels/triton_kernels/tensor.py
+++ b/python/triton_kernels/triton_kernels/tensor.py
@@ -233,46 +233,48 @@ def wrap_torch_tensor(torch_tensor, dtype=None, shape=None, shape_max=None, layo
 
 
 def _validate_conversion_out(tensor, out, layout, destination, same_encoding):
+    data, out_data = tensor.data, out.data
     if out.shape != tensor.shape:
         raise ValueError("out must have the same logical shape as the input")
     if not out.storage.layout.can_preserve_storage_as(layout, len(tensor.shape)):
         raise ValueError("out must have the requested layout")
-    if out.dtype != tensor.dtype or out.data.dtype != tensor.data.dtype:
+    if out.dtype != tensor.dtype or out_data.dtype != data.dtype:
         raise ValueError("out must have the same logical and storage dtypes as the input")
-    if out.device != tensor.device:
+    if out_data.device != data.device:
         raise ValueError("out must be on the input device")
-    if tensor.dtype == FP4 and tensor.data.dtype != torch.uint8:
+    if tensor.dtype == FP4 and data.dtype != torch.uint8:
         raise ValueError("FP4 conversion with out requires uint8 storage")
-    if (same_encoding and torch._C._overlaps(tensor.data, out.data)
-            and out.data.storage_offset() == tensor.data.storage_offset() and out.data.shape == tensor.data.shape
-            and out.data.stride() == tensor.data.stride()):
+    if (same_encoding and torch._C._overlaps(data, out_data) and out_data.storage_offset() == data.storage_offset()
+            and out_data.shape == data.shape and out_data.stride() == data.stride()):
         return True
-    if list(out.data.shape) != destination.storage_shape:
+    if list(out_data.shape) != destination.storage_shape:
         raise ValueError("out has an incorrect physical storage shape")
-    if not out.data.numel():
+    if not out_data.numel():
         return False
 
     # Increasing strides must separate the spans of the faster dimensions.
     # This permits sliced storage without permitting overlapping writes.
     span = 1
-    for size, stride in sorted(zip(out.data.shape, out.data.stride()), key=lambda item: item[1]):
+    for size, stride in sorted(zip(out_data.shape, out_data.stride()), key=lambda item: item[1]):
         if size > 1:
             if stride < span:
                 raise ValueError("out must have nonoverlapping physical strides")
             span += (size - 1) * stride
 
-    if tensor.device.type == "meta" or is_fake(tensor.data):
-        overlaps = torch._C._overlaps(tensor.data, out.data)
-    elif tensor.data.numel():
-        source_start = tensor.data.data_ptr()
-        source_end = source_start + tensor.data.element_size() * (1 + sum(
-            (size - 1) * stride for size, stride in zip(tensor.data.shape, tensor.data.stride())))
-        out_start = out.data.data_ptr()
-        out_end = out_start + out.data.element_size() * span
-        overlaps = source_start < out_end and out_start < source_end
+    if not data.numel():
+        return False
+    if data.device.type == "meta" or is_fake(data):
+        if not torch._C._overlaps(data, out_data):
+            return False
+        source_start = data.storage_offset() * data.element_size()
+        out_start = out_data.storage_offset() * out_data.element_size()
     else:
-        overlaps = False
-    if overlaps:
+        source_start = data.data_ptr()
+        out_start = out_data.data_ptr()
+    source_end = source_start + data.element_size() * (1 + sum(
+        (size - 1) * stride for size, stride in zip(data.shape, data.stride())))
+    out_end = out_start + out_data.element_size() * span
+    if source_start < out_end and out_start < source_end:
         raise ValueError("input and out storage must not overlap")
     return False
 

--- a/python/triton_kernels/triton_kernels/tensor_details/layout_details/base.py
+++ b/python/triton_kernels/triton_kernels/tensor_details/layout_details/base.py
@@ -21,7 +21,7 @@ class LayoutTransformation(ABC):
         """Convert to another layout, using canonical storage by default."""
         return destination._convert_data_from(data, self, out=out)
 
-    def _convert_data_from(self, data, source: "LayoutTransformation", *, out=None):
+    def _convert_data_from(self, data, source: "LayoutTransformation", *, out):
         result = self.swizzle_data(source.unswizzle_data(data))
         return result if out is None else out.copy_(result)
 

--- a/python/triton_kernels/triton_kernels/tensor_details/layout_details/base.py
+++ b/python/triton_kernels/triton_kernels/tensor_details/layout_details/base.py
@@ -17,12 +17,13 @@ class LayoutTransformation(ABC):
         assert list(data.shape) == self.storage_shape
         return data
 
-    def convert_data(self, data, destination: "LayoutTransformation"):
+    def convert_data(self, data, destination: "LayoutTransformation", *, out=None):
         """Convert to another layout, using canonical storage by default."""
-        return destination._convert_data_from(data, self)
+        return destination._convert_data_from(data, self, out=out)
 
-    def _convert_data_from(self, data, source: "LayoutTransformation"):
-        return self.swizzle_data(source.unswizzle_data(data))
+    def _convert_data_from(self, data, source: "LayoutTransformation", *, out=None):
+        result = self.swizzle_data(source.unswizzle_data(data))
+        return result if out is None else out.copy_(result)
 
     @abstractmethod
     def swizzle_data(self, data):

--- a/python/triton_kernels/triton_kernels/tensor_details/layout_details/blackwell_value.py
+++ b/python/triton_kernels/triton_kernels/tensor_details/layout_details/blackwell_value.py
@@ -59,7 +59,7 @@ class BlackwellMXValueLayoutTransformation(LayoutTransformation):
         repack(data, -2, destination.order[0], True, out=out)
         return out
 
-    def _convert_data_from(self, data, source: LayoutTransformation, *, out=None):
+    def _convert_data_from(self, data, source: LayoutTransformation, *, out):
         if (not isinstance(source, strided.StridedLayoutTransformation) or not self.is_fp4 or self.shape[-1] % 2
                 or self.shape[-2] % 2 or not source._can_convert_fp4(data)):
             return super()._convert_data_from(data, source, out=out)

--- a/python/triton_kernels/triton_kernels/tensor_details/layout_details/blackwell_value.py
+++ b/python/triton_kernels/triton_kernels/tensor_details/layout_details/blackwell_value.py
@@ -46,24 +46,26 @@ class BlackwellMXValueLayoutTransformation(LayoutTransformation):
         M += -M % 128
         return [*leading_shape, M, K]
 
-    def convert_data(self, data, destination: LayoutTransformation):
+    def convert_data(self, data, destination: LayoutTransformation, *, out=None):
         if (not self.is_fp4 or data.device.type != "cuda" or data.dtype != torch.uint8 or self.shape[-2] % 2
                 or self.shape[-1] % 2 or not isinstance(destination, strided.StridedLayoutTransformation)
                 or destination.order[0] < len(self.shape) - 2):
-            return super().convert_data(data, destination)
+            return super().convert_data(data, destination, out=out)
 
         data = self._unpad_data(data)
-        out = torch.empty_strided(destination.storage_shape, destination.storage_strides, device=data.device,
-                                  dtype=data.dtype)
+        if out is None:
+            out = torch.empty_strided(destination.storage_shape, destination.storage_strides, device=data.device,
+                                      dtype=data.dtype)
         repack(data, -2, destination.order[0], True, out=out)
         return out
 
-    def _convert_data_from(self, data, source: LayoutTransformation):
+    def _convert_data_from(self, data, source: LayoutTransformation, *, out=None):
         if (not isinstance(source, strided.StridedLayoutTransformation) or not self.is_fp4 or self.shape[-1] % 2
                 or self.shape[-2] % 2 or not source._can_convert_fp4(data)):
-            return super()._convert_data_from(data, source)
-        out = torch.empty_strided(self.storage_shape, strides_major_dim_m2(self.storage_shape), device=data.device,
-                                  dtype=data.dtype)
+            return super()._convert_data_from(data, source, out=out)
+        if out is None:
+            out = torch.empty_strided(self.storage_shape, strides_major_dim_m2(self.storage_shape), device=data.device,
+                                      dtype=data.dtype)
         repack(data, source.order[0], -2, True, out=out[..., :self.shape[-2] // 2, :])
         return out
 
@@ -79,7 +81,6 @@ class BlackwellMXValueLayoutTransformation(LayoutTransformation):
         return self._validate_storage_shape(ret)
 
     def _unpad_data(self, data: torch.Tensor):
-        assert data.stride(-2) == 1
         sizes = [self.shape[i] for i in range(data.ndim)]
         sizes[-2] //= 2
         return data[tuple(slice(0, s) for s in sizes)]

--- a/python/triton_kernels/triton_kernels/tensor_details/layout_details/blackwell_value.py
+++ b/python/triton_kernels/triton_kernels/tensor_details/layout_details/blackwell_value.py
@@ -70,7 +70,6 @@ class BlackwellMXValueLayoutTransformation(LayoutTransformation):
         return out
 
     def swizzle_data(self, data):
-        assert data.stride(-1) == 1
         # re-pack as column-major
         ret = torch.empty_strided(self.storage_shape, strides_major_dim_m2(self.storage_shape), device=data.device,
                                   dtype=data.dtype)

--- a/python/triton_kernels/triton_kernels/tensor_details/layout_details/blackwell_value_shuffled.py
+++ b/python/triton_kernels/triton_kernels/tensor_details/layout_details/blackwell_value_shuffled.py
@@ -94,7 +94,6 @@ class BlackwellMX4ValueShuffledTransformation(LayoutTransformation):
 
     def swizzle_data(self, data: torch.Tensor) -> torch.Tensor:
         """Convert canonical [..., K, N_packed] bytes to shuffled 5D storage."""
-        assert data.stride(-1) == 1
         return self._convert_data(data, inverse=False, major_dim=-1)
 
     def unswizzle_data(self, data: torch.Tensor) -> torch.Tensor:

--- a/python/triton_kernels/triton_kernels/tensor_details/layout_details/blackwell_value_shuffled.py
+++ b/python/triton_kernels/triton_kernels/tensor_details/layout_details/blackwell_value_shuffled.py
@@ -108,7 +108,7 @@ class BlackwellMX4ValueShuffledTransformation(LayoutTransformation):
             return super().convert_data(data, destination, out=out)
         return self._convert_data(data, inverse=True, major_dim=destination.order[0], out=out)
 
-    def _convert_data_from(self, data, source: LayoutTransformation, *, out=None):
+    def _convert_data_from(self, data, source: LayoutTransformation, *, out):
         if (not isinstance(source, strided.StridedLayoutTransformation) or not self.is_fp4
                 or not source._can_convert_fp4(data)):
             return super()._convert_data_from(data, source, out=out)

--- a/python/triton_kernels/triton_kernels/tensor_details/layout_details/blackwell_value_shuffled.py
+++ b/python/triton_kernels/triton_kernels/tensor_details/layout_details/blackwell_value_shuffled.py
@@ -101,20 +101,20 @@ class BlackwellMX4ValueShuffledTransformation(LayoutTransformation):
         """Convert shuffled 5D storage back to canonical packed bytes."""
         return self._convert_data(data, inverse=True, major_dim=-1)
 
-    def convert_data(self, data, destination: LayoutTransformation):
+    def convert_data(self, data, destination: LayoutTransformation, *, out=None):
         if (data.device.type != "cuda" or data.dtype != torch.uint8
                 or not isinstance(destination, strided.StridedLayoutTransformation)
                 or destination.order[0] < len(self.shape) - 2):
-            return super().convert_data(data, destination)
-        return self._convert_data(data, inverse=True, major_dim=destination.order[0])
+            return super().convert_data(data, destination, out=out)
+        return self._convert_data(data, inverse=True, major_dim=destination.order[0], out=out)
 
-    def _convert_data_from(self, data, source: LayoutTransformation):
+    def _convert_data_from(self, data, source: LayoutTransformation, *, out=None):
         if (not isinstance(source, strided.StridedLayoutTransformation) or not self.is_fp4
                 or not source._can_convert_fp4(data)):
-            return super()._convert_data_from(data, source)
-        return self._convert_data(data, inverse=False, major_dim=source.order[0])
+            return super()._convert_data_from(data, source, out=out)
+        return self._convert_data(data, inverse=False, major_dim=source.order[0], out=out)
 
-    def _convert_data(self, data: torch.Tensor, inverse: bool, major_dim: int) -> torch.Tensor:
+    def _convert_data(self, data: torch.Tensor, inverse: bool, major_dim: int, out=None) -> torch.Tensor:
         storage_shape = self.storage_shape
         # Preserve the canonical path's even-N packing requirement.
         if self.shape[-1] % 2:
@@ -122,12 +122,13 @@ class BlackwellMX4ValueShuffledTransformation(LayoutTransformation):
         if data.device.type != "cuda" or data.dtype != torch.uint8:
             return self._unswizzle_data_torch(data) if inverse else self._swizzle_data_torch(data)
 
-        if inverse:
-            destination = strided.StridedLayout(major_dim).make_transformation(self.shape, True)
-            out = torch.empty_strided(destination.storage_shape, destination.storage_strides, dtype=data.dtype,
-                                      device=data.device)
-        else:
-            out = torch.empty(storage_shape, dtype=data.dtype, device=data.device)
+        if out is None:
+            if inverse:
+                destination = strided.StridedLayout(major_dim).make_transformation(self.shape, True)
+                out = torch.empty_strided(destination.storage_shape, destination.storage_strides, dtype=data.dtype,
+                                          device=data.device)
+            else:
+                out = torch.empty(storage_shape, dtype=data.dtype, device=data.device)
         strided_data, shuffled = (out, data) if inverse else (data, out)
         E, num_tiles_k, num_tiles_n, tile_n, tile_k = storage_shape
         K_packed, N_packed = self.shape[-2] // 2, self.shape[-1] // 2

--- a/python/triton_kernels/triton_kernels/tensor_details/layout_details/hopper_value.py
+++ b/python/triton_kernels/triton_kernels/tensor_details/layout_details/hopper_value.py
@@ -313,10 +313,12 @@ def _bf16x2_to_fp4e2m1x2(x):
 
 def _unpack_bits(x):
     shape = (*x.shape[:-1], x.shape[-1] * x.element_size() // torch.int32.itemsize)
-    # Flatten before reinterpreting: empty tensors may have arbitrary outer strides.
-    x = x.reshape(-1)
-    if x.stride(0) != 1 or x.storage_offset() * x.element_size() % torch.int32.itemsize:
-        x = x.clone(memory_format=torch.contiguous_format)
+    # Reinterpret aligned row gaps directly; flatten unsupported byte layouts.
+    if (x.stride(-1) != 1 or x.storage_offset() * x.element_size() % torch.int32.itemsize
+            or any(stride * x.element_size() % torch.int32.itemsize for stride in x.stride()[:-1])):
+        x = x.reshape(-1)
+        if x.stride(0) != 1 or x.storage_offset() * x.element_size() % torch.int32.itemsize:
+            x = x.clone(memory_format=torch.contiguous_format)
     x = x.view(torch.int32).reshape(shape)
     m = 0b10000001110000001000000111000000
     a = (x << 1) & 0b10000000000000001000000000000000

--- a/python/triton_kernels/triton_kernels/tensor_details/layout_details/hopper_value.py
+++ b/python/triton_kernels/triton_kernels/tensor_details/layout_details/hopper_value.py
@@ -112,7 +112,7 @@ class HopperMXValueLayoutTransformation(LayoutTransformation):
                                                    MMA_VERSION=self.mma_version, BLOCK_M=block_m, BLOCK_K=block_k)
         return out
 
-    def _convert_data_from(self, data, source: LayoutTransformation, *, out=None):
+    def _convert_data_from(self, data, source: LayoutTransformation, *, out):
         if (not isinstance(source, strided.StridedLayoutTransformation) or not self.is_fp4 or self.N % 2
                 or self.shape[self.mx_axis] % 2 or not source._can_convert_fp4(data)):
             return super()._convert_data_from(data, source, out=out)

--- a/python/triton_kernels/triton_kernels/tensor_details/layout_details/hopper_value.py
+++ b/python/triton_kernels/triton_kernels/tensor_details/layout_details/hopper_value.py
@@ -83,12 +83,12 @@ class HopperMXValueLayoutTransformation(LayoutTransformation):
             return data.mT
         return data
 
-    def convert_data(self, data, destination: LayoutTransformation):
+    def convert_data(self, data, destination: LayoutTransformation, *, out=None):
         if (not self.is_fp4 or self.N % 2 or self.shape[self.mx_axis] % 2 or data.device.type != "cuda"
                 or data.dtype != torch.uint8 or data.ndim != len(self.shape)
                 or not isinstance(destination, strided.StridedLayoutTransformation)
                 or destination.order[0] < len(self.shape) - 2):
-            return super().convert_data(data, destination)
+            return super().convert_data(data, destination, out=out)
 
         source = self._maybe_mT(data)
         source_shape = tuple(source.shape)
@@ -97,10 +97,11 @@ class HopperMXValueLayoutTransformation(LayoutTransformation):
         # encodings must contain complete tiles covering the logical shape.
         if (list(source_shape[:-2]) != self.leading_shape or source_shape[-2] % 4 or source_shape[-1] % 128
                 or 4 * source_shape[-2] < m or source_shape[-1] // 2 < k):
-            return super().convert_data(data, destination)
+            return super().convert_data(data, destination, out=out)
 
-        out = torch.empty_strided(destination.storage_shape, destination.storage_strides, dtype=data.dtype,
-                                  device=data.device)
+        if out is None:
+            out = torch.empty_strided(destination.storage_shape, destination.storage_strides, dtype=data.dtype,
+                                      device=data.device)
         target = self._maybe_mT(out)
         block_m, block_k = 16, 256
         grid = (math.prod(self.leading_shape) * triton.cdiv(m, 4 * block_m) * triton.cdiv(k, block_k // 2), )
@@ -111,17 +112,24 @@ class HopperMXValueLayoutTransformation(LayoutTransformation):
                                                    MMA_VERSION=self.mma_version, BLOCK_M=block_m, BLOCK_K=block_k)
         return out
 
-    def _convert_data_from(self, data, source: LayoutTransformation):
+    def _convert_data_from(self, data, source: LayoutTransformation, *, out=None):
         if (not isinstance(source, strided.StridedLayoutTransformation) or not self.is_fp4 or self.N % 2
                 or self.shape[self.mx_axis] % 2 or not source._can_convert_fp4(data)):
-            return super()._convert_data_from(data, source)
-        return self._swizzle_from_strided(data, source.order[0])
+            return super()._convert_data_from(data, source, out=out)
+        return self._swizzle_from_strided(data, source.order[0], out=out)
 
-    def _swizzle_from_strided(self, data, major_dim):
+    def _swizzle_from_strided(self, data, major_dim, out=None):
         shape = self.storage_shape
         if self.mx_axis == len(self.leading_shape):
             shape[-2:] = reversed(shape[-2:])
-        out = torch.empty((*shape[:-1], shape[-1] // 4), dtype=torch.int32, device=data.device)
+        if out is None:
+            target = torch.empty((*shape[:-1], shape[-1] // 4), dtype=torch.int32, device=data.device)
+            out = self._maybe_mT(target.view(torch.uint8))
+        else:
+            target = self._maybe_mT(out)
+            if (target.stride(-1) == 1 and target.storage_offset() % 4 == 0 and target.data_ptr() % 4 == 0
+                    and all(stride % 4 == 0 for stride in target.stride()[:-1])):
+                target = target.view(torch.int32)
         source = self._maybe_mT(data)
         m, k = (self.N, self.K) if self.mx_axis == len(self.leading_shape) else (self.K, self.N)
         block_m, block_k = 16, 256
@@ -129,11 +137,11 @@ class HopperMXValueLayoutTransformation(LayoutTransformation):
         grid = (math.prod(self.leading_shape) * grid_m * grid_k, )
         if grid[0] > 0:
             with torch.cuda.device(data.device):
-                _swizzle_from_strided_kernel[grid](source, out, tuple(self.leading_shape), source.stride(),
-                                                   out.stride(), m, k, GRID_M=grid_m, GRID_K=grid_k,
+                _swizzle_from_strided_kernel[grid](source, target, tuple(self.leading_shape), source.stride(),
+                                                   target.stride(), m, k, GRID_M=grid_m, GRID_K=grid_k,
                                                    MMA_VERSION=self.mma_version, PACK_M=major_dim != self.mx_axis,
                                                    BLOCK_M=block_m, BLOCK_K=block_k)
-        return self._maybe_mT(out.view(torch.uint8))
+        return out
 
     def swizzle_data(self, data):
         """
@@ -304,7 +312,12 @@ def _bf16x2_to_fp4e2m1x2(x):
 
 
 def _unpack_bits(x):
-    x = x.view(torch.int32)
+    shape = (*x.shape[:-1], x.shape[-1] * x.element_size() // torch.int32.itemsize)
+    # Flatten before reinterpreting: empty tensors may have arbitrary outer strides.
+    x = x.reshape(-1)
+    if x.stride(0) != 1 or x.storage_offset() * x.element_size() % torch.int32.itemsize:
+        x = x.clone(memory_format=torch.contiguous_format)
+    x = x.view(torch.int32).reshape(shape)
     m = 0b10000001110000001000000111000000
     a = (x << 1) & 0b10000000000000001000000000000000
     b = right_shift_unsigned(x, 3) & 0b00000001100000000000000110000000
@@ -414,7 +427,12 @@ def _swizzle_from_strided_kernel(X, Y, LEADING_SHAPE: tl.constexpr, X_STRIDES: t
                | (_compress_fp4x2_triton(c, False) >> 6) | _compress_fp4x2_triton(d, True))
     rows = tile_m * BLOCK_M + tl.arange(0, BLOCK_M)
     words = tile_k * (BLOCK_K // 4) + tl.arange(0, BLOCK_K // 4)
-    tl.store(Y + rows[:, None] * Y_STRIDES[-2] + words[None, :] * Y_STRIDES[-1], encoded)
+    if Y.dtype.element_ty == tl.uint8:
+        offsets = rows[:, None] * Y_STRIDES[-2] + 4 * words[None, :] * Y_STRIDES[-1]
+        for byte in tl.static_range(4):
+            tl.store(Y + offsets + byte * Y_STRIDES[-1], encoded >> (8 * byte))
+    else:
+        tl.store(Y + rows[:, None] * Y_STRIDES[-2] + words[None, :] * Y_STRIDES[-1], encoded)
 
 
 @triton.jit

--- a/python/triton_kernels/triton_kernels/tensor_details/layout_details/strided.py
+++ b/python/triton_kernels/triton_kernels/tensor_details/layout_details/strided.py
@@ -63,10 +63,9 @@ class StridedLayoutTransformation(LayoutTransformation):
     order: list[int]
 
     def _can_convert_fp4(self, data):
-        """Whether direct kernels can read this strided FP4 storage."""
+        """Packed shape identifies nibble pairs; readers use actual strides."""
         return (self.is_fp4 and len(self.shape) >= 2 and self.order[0] >= len(self.shape) - 2
-                and data.device.type == "cuda" and data.dtype == torch.uint8 and list(data.shape) == self.storage_shape
-                and data.stride(self.order[0]) == 1)
+                and data.device.type == "cuda" and data.dtype == torch.uint8 and list(data.shape) == self.storage_shape)
 
     @property
     def storage_shape(self) -> list[int]:
@@ -98,7 +97,6 @@ class StridedLayoutTransformation(LayoutTransformation):
         return self._validate_storage_shape(out)
 
     def unswizzle_data(self, data):
-        assert data.stride(self.order[0]) == 1
         out_shape = list(self.shape)
         if self.is_fp4:
             out_shape[-1] //= 2

--- a/python/triton_kernels/triton_kernels/tensor_details/layout_details/strided.py
+++ b/python/triton_kernels/triton_kernels/tensor_details/layout_details/strided.py
@@ -94,7 +94,6 @@ class StridedLayoutTransformation(LayoutTransformation):
         return strides
 
     def swizzle_data(self, data):
-        assert data.numel() == 0 or data.stride(-1) == 1
         r = len(self.shape)
         if r == 0:
             return self._validate_storage_shape(data)

--- a/python/triton_kernels/triton_kernels/tensor_details/layout_details/strided.py
+++ b/python/triton_kernels/triton_kernels/tensor_details/layout_details/strided.py
@@ -62,6 +62,13 @@ class StridedLayoutTransformation(LayoutTransformation):
 
     order: list[int]
 
+    def _convert_data_from(self, data, source: LayoutTransformation, *, out):
+        if (not isinstance(source, StridedLayoutTransformation) or (self.is_fp4 and data.dtype != torch.uint8)):
+            return super()._convert_data_from(data, source, out=out)
+        if out is None:
+            out = torch.empty_strided(self.storage_shape, self.storage_strides, dtype=data.dtype, device=data.device)
+        return repack(data, source.order[0], self.order[0], self.is_fp4, out=out)
+
     def _can_convert_fp4(self, data):
         """Packed shape identifies nibble pairs; readers use actual strides."""
         return (self.is_fp4 and len(self.shape) >= 2 and self.order[0] >= len(self.shape) - 2


### PR DESCRIPTION
Add `convert_layout(..., out=destination)` to write conversions into existing storage, avoiding a converted-result allocation and final copy. Strided reorders reuse the copy/repacking helper directly, also removing the canonical intermediate; CUDA Hopper/Blackwell FP4 value kernels write into the supplied buffer, including shuffled Blackwell layouts. Destination identity, dtype, and strides are preserved, with metadata/overlap checks guarding unsafe writes.

Timings and peak extra GPU allocation when filling an existing 128 MiB destination on GB300:

| Conversion and logical shape | Allocate + copy: ms / extra MiB | `out`: ms / extra MiB |
|---|---:|---:|
| Hopper FP4, 8192×32768 | 0.192 / 128 | 0.157 / 0 |
| Strided FP4, 16384×16384 | 1.595 / 128 | 1.563 / 0 |
| Strided BF16, 8192×8192 | 0.332 / 128 | 0.296 / 0 |

For these strided cases, the previous route needed 256 MiB extra; direct dispatch needs only the returned result (128 MiB), or zero with `out`. Median paired timings show **33–35 µs saved when filling a destination**, but **8–11 µs overhead for conversion alone**.

Measurements use warm, resident buffers and GPU-local CPU/memory placement, with three processes × 31 randomized ABBA blocks. Timings include host dispatch and completion, excluding transfers/loader work; no H100 timings. Hopper uses C-order bytes packed on axis −2; strided cases reorder column-major to row-major.

Direct strided conversion covers FP4, FP8, FP16/BF16, and integers. FP4 `out` requires uint8 storage; other routes, including scale conversions, may still allocate intermediates.

**1,619 CPU/CUDA/meta/fake tests passed.** All 16 new strided allocation checks fail on the previous route and pass with direct dispatch.

| Files | Added | Removed | Net |
|---|---:|---:|---:|
| Test | +302 | -23 | +279 |
| Non-test | +140 | -53 | +87 |
| All | +442 | -76 | +366 |

## Reviewer's guide

- `python/triton_kernels/triton_kernels`: output validation and direct dispatch/kernels; CPU Hopper decoding also avoids copying aligned row gaps.
- `python/triton_kernels/tests`: byte-preservation and allocation tests, including NaN payloads, aliases, empty/scalar tensors, singleton dimensions, and device/stream coverage.
