### PR TITLE
Fix multithreading race condition in Autotuner nargs

### DIFF
--- a/python/triton/runtime/autotuner.py
+++ b/python/triton/runtime/autotuner.py
@@ -5,6 +5,7 @@ import time
 import inspect
 import hashlib
 import json
+import threading
 from functools import cached_property
 from typing import Dict, Tuple, List, Optional
 
@@ -123,6 +124,27 @@ class Autotuner(KernelInterface):
                 quantiles=quantiles,
             )
             return
+
+    @property
+    def nargs(self):
+        tls = getattr(self, '_tls', None)
+        return getattr(tls, 'nargs', None) if tls is not None else None
+
+    @nargs.setter
+    def nargs(self, value):
+        if not hasattr(self, '_tls'):
+            self._tls = threading.local()
+        self._tls.nargs = value
+
+    def __getstate__(self):
+        # Strip the unpicklable threading.local object during serialization
+        state = self.__dict__.copy()
+        state.pop('_tls', None)
+        return state
+
+    def __setstate__(self, state):
+        # Restore state; _tls will be lazily recreated on next access
+        self.__dict__.update(state)
 
     @cached_property
     def do_bench(self):


### PR DESCRIPTION
Isolates execution state to thread-local storage to prevent cache-miss benchmarks from nullifying nargs for concurrent threads, as observed in #11494. Implements custom __getstate__/__setstate__ to preserve multiprocessing serialization.

<!---
The core Triton is a small number of people, and we receive many PRs (thank
you!).  To help us review your code more quickly, **if you are a new
contributor (less than 3 PRs merged) we ask that you complete the following
tasks and include the filled-out checklist in your PR description.**

Complete the following tasks before sending your PR, and replace `[ ]` with
`[x]` to indicate you have done them.
-->

# New contributor declaration
- [x] I am not making a trivial change, such as fixing a typo in a comment.

- [x] I have written a PR description following these
  [rules](https://cbea.ms/git-commit/#why-not-how).

- [x] I have run `pre-commit run --from-ref origin/main --to-ref HEAD`.

- Select one of the following.
  - [ ] I have added tests.
    - `/test` for `lit` tests
    - `/unittest` for C++ tests
    - `/python/test` for end-to-end tests
  - [x] This PR does not need a test because `the bug requires multi-threaded concurrent execution and cold-cache synchronization which cannot be reliably reproduced in standard single-node test runners without introducing environment-dependent flakiness.`

- Select one of the following.
  - [x] I have not added any `lit` tests.
  - [ ] The `lit` tests I have added follow these [best practices](https://mlir.llvm.org/getting_started/TestingGuide/#filecheck-best-practices),
    including the "tests should be minimal" section. (Usually running Python code
    and using the instructions it generates is not minimal.)

### Description
`Autotuner.run()` stores the call's arguments as `self.nargs` on the shared kernel object, reads it throughout the benchmarking loop (`{**self.nargs, ...}`), and sets `self.nargs = None` on exit.

This is inconsequential in single-threaded or multiprocess workloads, but when two threads call the same autotuned kernel while the tuning cache is cold, the first thread to finish nulls `nargs` while the other is still inside its (potentially seconds-long) benchmark loop. This results in a `TypeError: 'NoneType' object is not a mapping`. 

This is frequently observed in quantization pipelines and multi-GPU setups where multiple threads dispatch kernels concurrently.

### Solution
This PR binds `Autotuner.nargs` to per-instance thread-local storage using Python's descriptor protocol (`@property`) with lazy initialization and custom `__getstate__`/`__setstate__` methods to preserve multiprocessing serialization.
- It completely eliminates the race condition.
- It requires zero changes to the internal `run()` logic.
- It remains fully backward-compatible for any custom `pre_hook` or `post_hook` functions inspecting `autotuner.nargs`.

### Minimal Repro
```python
import os, threading, torch, triton, triton.language as tl

os.environ["TRITON_CACHE_DIR"] = "/tmp/triton_race_cache_123"

@triton.autotune(
    configs=[triton.Config({"BLOCK": b}, num_warps=w) for b in (64, 128) for w in (1, 2)],
    key=["n"]
)
@triton.jit
def add_kernel(x, y, z, n, BLOCK: tl.constexpr):
    offs = tl.program_id(0) * BLOCK + tl.arange(0, BLOCK)
    mask = offs < n
    tl.store(z + offs, tl.load(x + offs, mask=mask) + tl.load(y + offs, mask=mask), mask=mask)

def worker():
    n = 65536
    x = torch.randn(n, device="cuda")
    y = torch.randn(n, device="cuda")
    z = torch.empty_like(x)
    add_kernel[lambda META: (triton.cdiv(n, META["BLOCK"]),)](x, y, z, n)

threads = [threading.Thread(target=worker) for _ in range(4)]
for t in threads: t.start()
for t in threads: t.join()