### PR TITLE
[Proton][AMD] Increase ROCProfiler dispatch flush retries

### DIFF
--- a/third_party/proton/csrc/lib/Profiler/RocprofSDK/RocprofSDKProfiler.cpp
+++ b/third_party/proton/csrc/lib/Profiler/RocprofSDK/RocprofSDKProfiler.cpp
@@ -1403,7 +1403,7 @@ void RocprofSDKProfiler::RocprofSDKProfilerPimpl::doFlush() {
   // Flush kernel dispatch records first so PC samples can be attached to the
   // Proton scopes that launched each dispatch.
   profiler.correlation.flush(
-      /*maxRetries=*/100, /*sleepUs=*/10,
+      /*maxRetries=*/250, /*sleepUs=*/10,
       [&state]() { rocprofiler::flushBuffer<true>(state.kernelBuffer); });
   profiler.pendingGraphPool->flushAll();
   if (pcSamplingModeEnabled) {


### PR DESCRIPTION
Give asynchronous ROCProfiler dispatch records more time to arrive before Proton clears correlation state during finalization.

CI has been flaky on `third_party/proton/test/test_profile.py:952: in test_hook_multiple_threads`, probably due to costs of PC sampling optimistic initialization. We should turn off optimistic initialization once we can rely on the newer (yet-unreleased) rocprofiler-sdk feature for any-time initialization. But for now I think the best fix is to just bump the timeout.

<!---
The core Triton is a small number of people, and we receive many PRs (thank
you!).  To help us review your code more quickly, **if you are a new
contributor (less than 3 PRs merged) we ask that you complete the following
tasks and include the filled-out checklist in your PR description.**

Complete the following tasks before sending your PR, and replace `[ ]` with
`[x]` to indicate you have done them.
-->

# New contributor declaration
- [x] I am not making a trivial change, such as fixing a typo in a comment.

- [x] I have written a PR description following these
  [rules](https://cbea.ms/git-commit/#why-not-how).

- [x] I have run `pre-commit run --from-ref origin/main --to-ref HEAD`.

- Select one of the following.
  - [ ] I have added tests.
    - `/test` for `lit` tests
    - `/unittest` for C++ tests
    - `/python/test` for end-to-end tests
  - [x] This PR does not need a test because it is fixing a flaky test.

- Select one of the following.
  - [x] I have not added any `lit` tests.
  - [ ] The `lit` tests I have added follow these [best practices](https://mlir.llvm.org/getting_started/TestingGuide/#filecheck-best-practices),
    including the "tests should be minimal" section. (Usually running Python code
    and using the instructions it generates is not minimal.)
