### PR TITLE
[BACKEND] Avoid duplicated side effects in inline assembly

### DIFF
--- a/include/triton/Analysis/Allocation.h
+++ b/include/triton/Analysis/Allocation.h
@@ -29,7 +29,7 @@ bool hasCrossCTAScratch(Operation *op);
 /// broadcast from each group leader. Physical scratch owners have these bits
 /// clear. Scalar results are broadcast from CTA0 across all CTAs. Callers check
 /// whether scratch has been allocated.
-std::optional<uint16_t> getAtomicScratchBroadcastMask(Operation *op);
+std::optional<uint16_t> getScratchBroadcastMask(Operation *op);
 
 unsigned getNumScratchElemsSwizzledCvt(const LinearLayout &srcLayout,
                                        const LinearLayout &dstLayout,

--- a/include/triton/Analysis/Allocation.h
+++ b/include/triton/Analysis/Allocation.h
@@ -25,10 +25,10 @@ unsigned defaultAllocationAnalysisScratchSizeFn(Operation *op);
 /// Returns whether an operation uses scratch memory across CTAs.
 bool hasCrossCTAScratch(Operation *op);
 
-/// For atomic-result scratch, returns the CTA bits broadcast from
-/// each group leader. Physical scratch owners have these bits clear.
-/// Scalar results are broadcast from CTA0 across all CTAs.
-/// Callers check whether scratch has been allocated.
+/// For atomic or impure inline-asm result scratch, returns the CTA bits
+/// broadcast from each group leader. Physical scratch owners have these bits
+/// clear. Scalar results are broadcast from CTA0 across all CTAs. Callers check
+/// whether scratch has been allocated.
 std::optional<uint16_t> getAtomicScratchBroadcastMask(Operation *op);
 
 unsigned getNumScratchElemsSwizzledCvt(const LinearLayout &srcLayout,

--- a/include/triton/Conversion/TritonGPUToLLVM/Utility.h
+++ b/include/triton/Conversion/TritonGPUToLLVM/Utility.h
@@ -788,7 +788,7 @@ createIfBlock(RewriterBase &b, Location loc, Value cnd);
 SmallVector<Value>
 broadcastTensorResult(Operation *op, RankedTensorType tensorTy,
                       ConversionPatternRewriter &rewriter,
-                      SmallVector<Value> uniqueResultVals, Type valueElemTy,
+                      ArrayRef<Value> uniqueResultVals, Type valueElemTy,
                       TritonLLVMOpBuilder &b, Value threadPred,
                       const TargetInfoBase &targetInfo);
 

--- a/include/triton/Conversion/TritonGPUToLLVM/Utility.h
+++ b/include/triton/Conversion/TritonGPUToLLVM/Utility.h
@@ -783,6 +783,15 @@ SmallVector<Value> inlineRegion(RewriterBase &rewriter, Region &region,
 std::tuple</*prevBlock=*/Block *, /*ifBlock=*/Block *, /*thenBlock=*/Block *>
 createIfBlock(RewriterBase &b, Location loc, Value cnd);
 
+// Broadcast canonical owners' results to redundant threads and CTAs. Both the
+// input and returned values contain only unique registers.
+SmallVector<Value>
+broadcastTensorResult(Operation *op, RankedTensorType tensorTy,
+                      ConversionPatternRewriter &rewriter,
+                      SmallVector<Value> uniqueResultVals, Type valueElemTy,
+                      TritonLLVMOpBuilder &b, Value threadPred,
+                      const TargetInfoBase &targetInfo);
+
 void finalizeTensorAtomicResults(Operation *op, RankedTensorType tensorTy,
                                  ConversionPatternRewriter &rewriter,
                                  SmallVector<Value> &resultVals,

--- a/include/triton/Dialect/Triton/IR/TritonOps.td
+++ b/include/triton/Dialect/Triton/IR/TritonOps.td
@@ -907,6 +907,12 @@ def TT_ElementwiseInlineAsmOp : TT_Op<"elementwise_inline_asm", [
 
     The asm block is given `packed_element` elements at a time.  Exactly which
     elems it receives is unspecified.
+    Incomplete groups are padded with undefined inputs, and the corresponding
+    padded outputs are discarded.
+
+    When `pure` is false, each logical group of packed elements executes the
+    asm block once, even if the tensor layout replicates those elements across
+    physical threads.
   }];
 
   let arguments = (ins StrAttr:$asm_string, StrAttr:$constraints, BoolAttr:$pure, I32Attr:$packed_element, Variadic<AnyTypeOf<[TT_Type]>>:$args);

--- a/lib/Analysis/Allocation.cpp
+++ b/lib/Analysis/Allocation.cpp
@@ -92,6 +92,32 @@ static SmallVector<unsigned> getRepShapeForAtomic(Value result) {
   return smemShape;
 }
 
+static unsigned getInlineAsmResultScratchSize(Value result) {
+  if (result.use_empty())
+    return 0;
+
+  SmallVector<unsigned> smemShape;
+  if (auto tensorTy = dyn_cast<RankedTensorType>(result.getType())) {
+    auto freeVariableMasks =
+        gpu::toLinearLayout(tensorTy).getFreeVariableMasks();
+    auto *ctx = tensorTy.getContext();
+    bool hasThreadReplication =
+        freeVariableMasks.lookup(StringAttr::get(ctx, "lane")) != 0 ||
+        freeVariableMasks.lookup(StringAttr::get(ctx, "warp")) != 0 ||
+        freeVariableMasks.lookup(StringAttr::get(ctx, "block")) != 0;
+    if (!hasThreadReplication)
+      return 0;
+    smemShape = convertType<unsigned>(gpu::getShapePerCTA(tensorTy));
+  } else {
+    smemShape.push_back(1);
+  }
+
+  unsigned elems = getNumScratchElements(smemShape);
+  Type elemTy = getElementTypeOrSelf(result.getType());
+  unsigned bitWidth = getIntOrFloatOrPtrBitWidth(elemTy);
+  return elems * std::max(8u, bitWidth) / 8;
+}
+
 unsigned defaultAllocationAnalysisScratchSizeFn(Operation *op) {
   if (auto reduceOp = dyn_cast<ReduceOp>(op)) {
     return ReduceOpHelper(reduceOp).getScratchSizeInBytes();
@@ -126,6 +152,14 @@ unsigned defaultAllocationAnalysisScratchSizeFn(Operation *op) {
     if (!poll.getTimeout())
       return 0;
   }
+  if (auto inlineAsm = dyn_cast<ElementwiseInlineAsmOp>(op)) {
+    if (inlineAsm.getPure())
+      return 0;
+    unsigned bytes = 0;
+    for (Value result : inlineAsm.getResults())
+      bytes = std::max(bytes, getInlineAsmResultScratchSize(result));
+    return bytes;
+  }
   if (isa<gpu::LocalAtomicScatterRMWOp, AtomicPollOp>(op) ||
       isa<AtomicOpInterface>(op)) {
     auto value = op->getOperand(0);
@@ -147,7 +181,9 @@ unsigned defaultAllocationAnalysisScratchSizeFn(Operation *op) {
 }
 
 std::optional<uint16_t> getAtomicScratchBroadcastMask(Operation *op) {
-  if (!isa<AtomicOpInterface, AtomicPollOp, gpu::LocalAtomicScatterRMWOp>(op))
+  auto inlineAsm = dyn_cast<ElementwiseInlineAsmOp>(op);
+  if (!isa<AtomicOpInterface, AtomicPollOp, gpu::LocalAtomicScatterRMWOp>(op) &&
+      !(inlineAsm && !inlineAsm.getPure()))
     return std::nullopt;
 
   Type resultTy = op->getResult(0).getType();
@@ -170,6 +206,10 @@ bool hasCrossCTAScratch(Operation *op) {
     return !ReduceOpHelper(reduce).isReduceWithinCTA();
   if (auto poll = dyn_cast<AtomicPollOp>(op))
     return poll.getTimeout() && !poll.getResult().use_empty();
+  if (auto inlineAsm = dyn_cast<ElementwiseInlineAsmOp>(op)) {
+    return !inlineAsm.getPure() && !inlineAsm->use_empty() &&
+           getAtomicScratchBroadcastMask(op).value_or(0) != 0;
+  }
   if (isa<AtomicOpInterface, gpu::LocalAtomicScatterRMWOp>(op)) {
     Value result = op->getResult(0);
     if (result.use_empty())

--- a/lib/Analysis/Allocation.cpp
+++ b/lib/Analysis/Allocation.cpp
@@ -180,7 +180,7 @@ unsigned defaultAllocationAnalysisScratchSizeFn(Operation *op) {
   return 0;
 }
 
-std::optional<uint16_t> getAtomicScratchBroadcastMask(Operation *op) {
+std::optional<uint16_t> getScratchBroadcastMask(Operation *op) {
   auto inlineAsm = dyn_cast<ElementwiseInlineAsmOp>(op);
   if (!isa<AtomicOpInterface, AtomicPollOp, gpu::LocalAtomicScatterRMWOp>(op) &&
       !(inlineAsm && !inlineAsm.getPure()))
@@ -208,7 +208,7 @@ bool hasCrossCTAScratch(Operation *op) {
     return poll.getTimeout() && !poll.getResult().use_empty();
   if (auto inlineAsm = dyn_cast<ElementwiseInlineAsmOp>(op)) {
     return !inlineAsm.getPure() && !inlineAsm->use_empty() &&
-           getAtomicScratchBroadcastMask(op).value_or(0) != 0;
+           getScratchBroadcastMask(op).value_or(0) != 0;
   }
   if (isa<AtomicOpInterface, gpu::LocalAtomicScatterRMWOp>(op)) {
     Value result = op->getResult(0);

--- a/lib/Analysis/BufferRegion.cpp
+++ b/lib/Analysis/BufferRegion.cpp
@@ -616,7 +616,7 @@ BufferRegionAnalysis::getScratchFootprint(Operation *op) {
       getOperationId(op->getParentOfType<FunctionOpInterface>());
   AddressSet addresses = AddressSet::fromRange(base, length);
   unsigned numCTAs = ttg::lookupNumCTAs(op);
-  uint32_t broadcastMask = getAtomicScratchBroadcastMask(op).value_or(0);
+  uint32_t broadcastMask = getScratchBroadcastMask(op).value_or(0);
   for (unsigned cta = 0; cta < numCTAs; ++cta)
     if (!(cta & broadcastMask))
       view.region.ctaAddresses.emplace_back(cta, addresses);

--- a/lib/Analysis/Utility.cpp
+++ b/lib/Analysis/Utility.cpp
@@ -1314,6 +1314,8 @@ static bool atomicNeedsClusterBarrier(Operation *op) {
 bool needsClusterBarrier(Operation *op) {
   if (isa<ClusterBarrierOp>(op))
     return true;
+  if (isa<ElementwiseInlineAsmOp>(op))
+    return hasCrossCTAScratch(op);
   if (auto cvt = dyn_cast<gpu::ConvertLayoutOp>(op)) {
     auto kBlock = StringAttr::get(op->getContext(), "block");
     return !isCvtDimSync(gpu::toLinearLayout(cvt.getSrc().getType()),

--- a/lib/Conversion/TritonGPUToLLVM/ElementwiseOpToLLVM.cpp
+++ b/lib/Conversion/TritonGPUToLLVM/ElementwiseOpToLLVM.cpp
@@ -369,8 +369,7 @@ struct ElementwiseInlineAsmOpConversion
       results.resize(numElemsPerThread);
     }
 
-    if (failed(broadcastResults(op, unpackedResults, threadPred, rewriter)))
-      return failure();
+    broadcastResults(op, unpackedResults, threadPred, rewriter);
 
     // Reorder and pack the results.
     SmallVector<Value> outs;
@@ -429,16 +428,14 @@ private:
     return mergedResult;
   }
 
-  LogicalResult
-  broadcastResults(ElementwiseInlineAsmOp op,
-                   SmallVector<SmallVector<Value>> &unpackedResults,
-                   Value threadPred,
-                   ConversionPatternRewriter &rewriter) const {
+  void broadcastResults(ElementwiseInlineAsmOp op,
+                        SmallVector<SmallVector<Value>> &unpackedResults,
+                        Value threadPred,
+                        ConversionPatternRewriter &rewriter) const {
     if (!threadPred || op->use_empty())
-      return success();
-    if (!op->hasAttr("allocation.offset"))
-      return op.emitError(
-          "missing shared-memory allocation for replicated inline asm result");
+      return;
+    assert(op->hasAttr("allocation.offset") &&
+           "missing shared-memory allocation for replicated inline asm result");
 
     Location loc = op.getLoc();
     auto b = TritonLLVMOpBuilder(loc, rewriter);
@@ -474,8 +471,6 @@ private:
           targetInfo.barrier(loc, rewriter, AddrSpace::Local);
       }
     }
-
-    return success();
   }
 
   const TargetInfoBase &targetInfo;

--- a/lib/Conversion/TritonGPUToLLVM/ElementwiseOpToLLVM.cpp
+++ b/lib/Conversion/TritonGPUToLLVM/ElementwiseOpToLLVM.cpp
@@ -274,46 +274,8 @@ struct ElementwiseInlineAsmOpConversion
     Type asmRetType =
         asmRetTypes.size() > 1 ? struct_ty(asmRetTypes) : asmRetTypes[0];
 
-    auto emitInlineAsm = [&]() -> Value {
-      return LLVM::InlineAsmOp::create(
-                 rewriter, loc, asmRetType,
-                 /*operands=*/packedOperands,
-                 /*asm_string=*/op.getAsmString(),
-                 /*constraints=*/op.getConstraints(),
-                 /*has_side_effects=*/!op.getPure(),
-                 /*is_align_stack=*/false, LLVM::TailCallKind::None,
-                 /*asm_dialect=*/
-                 LLVM::AsmDialectAttr::get(rewriter.getContext(),
-                                           LLVM::AsmDialect::AD_ATT),
-                 /*operand_attrs=*/ArrayAttr())
-          ->getResult(0);
-    };
-
-    Value asmResults;
-    if (!threadPred) {
-      asmResults = emitInlineAsm();
-    } else {
-      Block *currentBlock = rewriter.getInsertionBlock();
-      Block *continuation =
-          currentBlock->splitBlock(rewriter.getInsertionPoint());
-      Region *region = currentBlock->getParent();
-      Block *asmBlock =
-          rewriter.createBlock(region, Region::iterator(continuation));
-      BlockArgument mergedResult = continuation->addArgument(asmRetType, loc);
-
-      rewriter.setInsertionPointToEnd(currentBlock);
-      Value undef = b.undef(asmRetType);
-      LLVM::CondBrOp::create(rewriter, loc, threadPred, asmBlock, ValueRange{},
-                             continuation, ValueRange{undef});
-
-      rewriter.setInsertionPointToEnd(asmBlock);
-      Value executedResult = emitInlineAsm();
-      LLVM::BrOp::create(rewriter, loc, ValueRange{executedResult},
-                         continuation);
-
-      rewriter.setInsertionPointToStart(continuation);
-      asmResults = mergedResult;
-    }
+    Value asmResults =
+        createInlineAsm(op, asmRetType, packedOperands, threadPred, rewriter);
 
     // asmResults is a flat struct; pack its values into
     // [return_value][op.getPackedElement()].
@@ -407,18 +369,83 @@ struct ElementwiseInlineAsmOpConversion
       results.resize(numElemsPerThread);
     }
 
-    SmallVector<unsigned> usedResultIndices;
-    if (threadPred) {
-      for (auto [index, result] : llvm::enumerate(op->getResults())) {
-        if (!result.use_empty())
-          usedResultIndices.push_back(index);
-      }
-      if (!usedResultIndices.empty() && !op->hasAttr("allocation.offset")) {
-        return op.emitError(
-            "missing shared-memory allocation for replicated inline asm "
-            "result");
-      }
+    if (failed(broadcastResults(op, unpackedResults, threadPred, rewriter)))
+      return failure();
+
+    // Reorder and pack the results.
+    SmallVector<Value> outs;
+    for (int i = 0; i < unpackedResults.size(); i++) {
+      outs.push_back(packUniqueTensorElements(loc, getTypeConverter(),
+                                              unpackedResults[i], rewriter,
+                                              op->getResult(i).getType()));
     }
+
+    rewriter.replaceOp(op, outs);
+    return success();
+  }
+
+private:
+  Value createInlineAsm(ElementwiseInlineAsmOp op, Type asmRetType,
+                        ValueRange packedOperands, Value threadPred,
+                        ConversionPatternRewriter &rewriter) const {
+    Location loc = op.getLoc();
+    auto b = TritonLLVMOpBuilder(loc, rewriter);
+    auto emitInlineAsm = [&]() -> Value {
+      return LLVM::InlineAsmOp::create(
+                 rewriter, loc, asmRetType,
+                 /*operands=*/packedOperands,
+                 /*asm_string=*/op.getAsmString(),
+                 /*constraints=*/op.getConstraints(),
+                 /*has_side_effects=*/!op.getPure(),
+                 /*is_align_stack=*/false, LLVM::TailCallKind::None,
+                 /*asm_dialect=*/
+                 LLVM::AsmDialectAttr::get(rewriter.getContext(),
+                                           LLVM::AsmDialect::AD_ATT),
+                 /*operand_attrs=*/ArrayAttr())
+          ->getResult(0);
+    };
+
+    if (!threadPred)
+      return emitInlineAsm();
+
+    Block *currentBlock = rewriter.getInsertionBlock();
+    Block *continuation =
+        currentBlock->splitBlock(rewriter.getInsertionPoint());
+    Region *region = currentBlock->getParent();
+    Block *asmBlock =
+        rewriter.createBlock(region, Region::iterator(continuation));
+    BlockArgument mergedResult = continuation->addArgument(asmRetType, loc);
+
+    rewriter.setInsertionPointToEnd(currentBlock);
+    Value undef = b.undef(asmRetType);
+    LLVM::CondBrOp::create(rewriter, loc, threadPred, asmBlock, ValueRange{},
+                           continuation, ValueRange{undef});
+
+    rewriter.setInsertionPointToEnd(asmBlock);
+    Value executedResult = emitInlineAsm();
+    LLVM::BrOp::create(rewriter, loc, ValueRange{executedResult}, continuation);
+
+    rewriter.setInsertionPointToStart(continuation);
+    return mergedResult;
+  }
+
+  LogicalResult
+  broadcastResults(ElementwiseInlineAsmOp op,
+                   SmallVector<SmallVector<Value>> &unpackedResults,
+                   Value threadPred,
+                   ConversionPatternRewriter &rewriter) const {
+    if (!threadPred || op->use_empty())
+      return success();
+    if (!op->hasAttr("allocation.offset"))
+      return op.emitError(
+          "missing shared-memory allocation for replicated inline asm result");
+
+    Location loc = op.getLoc();
+    auto b = TritonLLVMOpBuilder(loc, rewriter);
+    SmallVector<unsigned> usedResultIndices;
+    for (auto [index, result] : llvm::enumerate(op->getResults()))
+      if (!result.use_empty())
+        usedResultIndices.push_back(index);
 
     for (auto [broadcastIndex, resultIndex] :
          llvm::enumerate(usedResultIndices)) {
@@ -448,19 +475,9 @@ struct ElementwiseInlineAsmOpConversion
       }
     }
 
-    // Reorder and pack the results.
-    SmallVector<Value> outs;
-    for (int i = 0; i < unpackedResults.size(); i++) {
-      outs.push_back(packUniqueTensorElements(loc, getTypeConverter(),
-                                              unpackedResults[i], rewriter,
-                                              op->getResult(i).getType()));
-    }
-
-    rewriter.replaceOp(op, outs);
     return success();
   }
 
-private:
   const TargetInfoBase &targetInfo;
 };
 

--- a/lib/Conversion/TritonGPUToLLVM/ElementwiseOpToLLVM.cpp
+++ b/lib/Conversion/TritonGPUToLLVM/ElementwiseOpToLLVM.cpp
@@ -449,16 +449,33 @@ private:
       Type originalResultTy = op->getResult(resultIndex).getType();
       Type valueElemTy = getTypeConverter()->convertType(
           getElementTypeOrSelf(originalResultTy));
+      auto &resultVals = unpackedResults[resultIndex];
+      bool isPointer = isa<LLVM::LLVMPointerType>(valueElemTy);
+      Type storageTy = valueElemTy;
+      if (isPointer)
+        storageTy = i64_ty;
+      else if (valueElemTy.isInteger(1))
+        storageTy = i8_ty;
+      // Broadcast pointers as integers and widen booleans to whole bytes.
+      if (storageTy != valueElemTy)
+        for (Value &value : resultVals)
+          value = isPointer ? Value(b.ptrtoint(storageTy, value))
+                            : Value(b.zext(storageTy, value));
+
       if (auto tensorTy = dyn_cast<RankedTensorType>(originalResultTy)) {
-        unpackedResults[resultIndex] = broadcastTensorResult(
-            op, tensorTy, rewriter, unpackedResults[resultIndex], valueElemTy,
-            b, threadPred, targetInfo);
+        resultVals =
+            broadcastTensorResult(op, tensorTy, rewriter, resultVals, storageTy,
+                                  b, threadPred, targetInfo);
       } else {
-        assert(unpackedResults[resultIndex].size() == 1);
-        unpackedResults[resultIndex][0] = broadcastScalarAtomicResult(
-            op, valueElemTy, unpackedResults[resultIndex][0], rewriter, b,
-            threadPred, targetInfo);
+        assert(resultVals.size() == 1);
+        resultVals[0] = broadcastScalarAtomicResult(
+            op, storageTy, resultVals[0], rewriter, b, threadPred, targetInfo);
       }
+
+      if (storageTy != valueElemTy)
+        for (Value &value : resultVals)
+          value = isPointer ? Value(b.inttoptr(valueElemTy, value))
+                            : Value(b.trunc(valueElemTy, value));
 
       if (broadcastIndex + 1 != usedResultIndices.size()) {
         // Each result reuses the same scratch. Finish all readers before the

--- a/lib/Conversion/TritonGPUToLLVM/ElementwiseOpToLLVM.cpp
+++ b/lib/Conversion/TritonGPUToLLVM/ElementwiseOpToLLVM.cpp
@@ -198,9 +198,13 @@ struct ElementwiseInlineAsmOpConversion
     : public ConvertOpToLLVMPattern<ElementwiseInlineAsmOp> {
   using Base = ConvertOpToLLVMPattern<ElementwiseInlineAsmOp>;
 
-  using Base::Base;
   using Adaptor = typename Base::OpAdaptor;
   typedef typename Base::OpAdaptor OpAdaptor;
+
+  explicit ElementwiseInlineAsmOpConversion(LLVMTypeConverter &typeConverter,
+                                            const TargetInfoBase &targetInfo,
+                                            PatternBenefit benefit = 1)
+      : Base(typeConverter, benefit), targetInfo(targetInfo) {}
 
   // If operand size is smaller than 32 bits, pack in groups of 32 bits.
   SmallVector<Value> packOperands(ElementwiseInlineAsmOp op,
@@ -236,7 +240,8 @@ struct ElementwiseInlineAsmOpConversion
   SmallVector<SmallVector<Value>>
   createDestOps(ElementwiseInlineAsmOp op, OpAdaptor adaptor,
                 ConversionPatternRewriter &rewriter,
-                MultipleOperandsRange operands, Location loc) const {
+                MultipleOperandsRange operands, Location loc,
+                Value threadPred) const {
     auto ctx = op->getContext();
     auto b = TritonLLVMOpBuilder(loc, rewriter);
 
@@ -269,18 +274,46 @@ struct ElementwiseInlineAsmOpConversion
     Type asmRetType =
         asmRetTypes.size() > 1 ? struct_ty(asmRetTypes) : asmRetTypes[0];
 
-    Value asmResults = LLVM::InlineAsmOp::create(
-                           rewriter, loc, asmRetType,
-                           /*operands=*/packedOperands,
-                           /*asm_string=*/op.getAsmString(),
-                           /*constraints=*/op.getConstraints(),
-                           /*has_side_effects=*/!op.getPure(),
-                           /*is_align_stack=*/false, LLVM::TailCallKind::None,
-                           /*asm_dialect=*/
-                           LLVM::AsmDialectAttr::get(rewriter.getContext(),
-                                                     LLVM::AsmDialect::AD_ATT),
-                           /*operand_attrs=*/ArrayAttr())
-                           ->getResult(0);
+    auto emitInlineAsm = [&]() -> Value {
+      return LLVM::InlineAsmOp::create(
+                 rewriter, loc, asmRetType,
+                 /*operands=*/packedOperands,
+                 /*asm_string=*/op.getAsmString(),
+                 /*constraints=*/op.getConstraints(),
+                 /*has_side_effects=*/!op.getPure(),
+                 /*is_align_stack=*/false, LLVM::TailCallKind::None,
+                 /*asm_dialect=*/
+                 LLVM::AsmDialectAttr::get(rewriter.getContext(),
+                                           LLVM::AsmDialect::AD_ATT),
+                 /*operand_attrs=*/ArrayAttr())
+          ->getResult(0);
+    };
+
+    Value asmResults;
+    if (!threadPred) {
+      asmResults = emitInlineAsm();
+    } else {
+      Block *currentBlock = rewriter.getInsertionBlock();
+      Block *continuation =
+          currentBlock->splitBlock(rewriter.getInsertionPoint());
+      Region *region = currentBlock->getParent();
+      Block *asmBlock =
+          rewriter.createBlock(region, Region::iterator(continuation));
+      BlockArgument mergedResult = continuation->addArgument(asmRetType, loc);
+
+      rewriter.setInsertionPointToEnd(currentBlock);
+      Value undef = b.undef(asmRetType);
+      LLVM::CondBrOp::create(rewriter, loc, threadPred, asmBlock, ValueRange{},
+                             continuation, ValueRange{undef});
+
+      rewriter.setInsertionPointToEnd(asmBlock);
+      Value executedResult = emitInlineAsm();
+      LLVM::BrOp::create(rewriter, loc, ValueRange{executedResult},
+                         continuation);
+
+      rewriter.setInsertionPointToStart(continuation);
+      asmResults = mergedResult;
+    }
 
     // asmResults is a flat struct; pack its values into
     // [return_value][op.getPackedElement()].
@@ -341,6 +374,11 @@ struct ElementwiseInlineAsmOpConversion
       }
     }
 
+    Value threadPred;
+    if (!op.getPure())
+      threadPred = emitRedundantThreadPredicate(getFreeVariableMasks(resultTy),
+                                                rewriter, loc, targetInfo);
+
     // Run the inline asm op on each block of elements.
     //
     // Layout is unpackedResults[result_idx][elem].
@@ -358,7 +396,7 @@ struct ElementwiseInlineAsmOpConversion
           block[j].push_back(os[i + j]);
         }
       }
-      auto cur = createDestOps(op, adaptor, rewriter, block, loc);
+      auto cur = createDestOps(op, adaptor, rewriter, block, loc, threadPred);
       assert(cur.size() == unpackedResults.size());
       for (unsigned j = 0; j < cur.size(); j++) {
         unpackedResults[j].insert(unpackedResults[j].end(), cur[j].begin(),
@@ -368,6 +406,48 @@ struct ElementwiseInlineAsmOpConversion
     for (auto &results : unpackedResults) {
       results.resize(numElemsPerThread);
     }
+
+    SmallVector<unsigned> usedResultIndices;
+    if (threadPred) {
+      for (auto [index, result] : llvm::enumerate(op->getResults())) {
+        if (!result.use_empty())
+          usedResultIndices.push_back(index);
+      }
+      if (!usedResultIndices.empty() && !op->hasAttr("allocation.offset")) {
+        return op.emitError(
+            "missing shared-memory allocation for replicated inline asm "
+            "result");
+      }
+    }
+
+    for (auto [broadcastIndex, resultIndex] :
+         llvm::enumerate(usedResultIndices)) {
+      Type originalResultTy = op->getResult(resultIndex).getType();
+      Type valueElemTy = getTypeConverter()->convertType(
+          getElementTypeOrSelf(originalResultTy));
+      if (auto tensorTy = dyn_cast<RankedTensorType>(originalResultTy)) {
+        unpackedResults[resultIndex] = broadcastTensorResult(
+            op, tensorTy, rewriter, unpackedResults[resultIndex], valueElemTy,
+            b, threadPred, targetInfo);
+      } else {
+        assert(unpackedResults[resultIndex].size() == 1);
+        unpackedResults[resultIndex][0] = broadcastScalarAtomicResult(
+            op, valueElemTy, unpackedResults[resultIndex][0], rewriter, b,
+            threadPred, targetInfo);
+      }
+
+      if (broadcastIndex + 1 != usedResultIndices.size()) {
+        // Each result reuses the same scratch. Finish all readers before the
+        // next result overwrites it; membar handles reuse after this operation.
+        if (getFreeVariableMasks(originalResultTy)
+                    .lookup(StringAttr::get(op->getContext(), "block")) != 0 &&
+            lookupNumCTAs(op) > 1)
+          targetInfo.clusterBarrier(loc, rewriter, op);
+        else
+          targetInfo.barrier(loc, rewriter, AddrSpace::Local);
+      }
+    }
+
     // Reorder and pack the results.
     SmallVector<Value> outs;
     for (int i = 0; i < unpackedResults.size(); i++) {
@@ -379,6 +459,9 @@ struct ElementwiseInlineAsmOpConversion
     rewriter.replaceOp(op, outs);
     return success();
   }
+
+private:
+  const TargetInfoBase &targetInfo;
 };
 
 struct AbsIOpConversion
@@ -706,7 +789,8 @@ void mlir::triton::populateElementwiseOpToLLVMPatterns(
                                     benefit);
   patterns.add<ExternElementwiseOpConversion>(typeConverter, axisInfoAnalysis,
                                               benefit);
-  patterns.add<ElementwiseInlineAsmOpConversion>(typeConverter, benefit);
+  patterns.add<ElementwiseInlineAsmOpConversion>(typeConverter, targetInfo,
+                                                 benefit);
   patterns.add<AbsIOpConversion>(typeConverter, axisInfoAnalysis, benefit);
   patterns.add<AbsFOpConversion>(typeConverter, axisInfoAnalysis, benefit);
   patterns.add<SelectOpConversion>(typeConverter, axisInfoAnalysis, benefit);

--- a/lib/Conversion/TritonGPUToLLVM/Utility.cpp
+++ b/lib/Conversion/TritonGPUToLLVM/Utility.cpp
@@ -2115,7 +2115,7 @@ std::tuple<Block *, Block *, Block *> createIfBlock(RewriterBase &b,
 SmallVector<Value>
 broadcastTensorResult(Operation *op, RankedTensorType tensorTy,
                       ConversionPatternRewriter &rewriter,
-                      SmallVector<Value> uniqueResultVals, Type valueElemTy,
+                      ArrayRef<Value> uniqueResultVals, Type valueElemTy,
                       TritonLLVMOpBuilder &b, Value threadPred,
                       const TargetInfoBase &targetInfo) {
   assert(op->hasAttr("allocation.offset"));

--- a/lib/Conversion/TritonGPUToLLVM/Utility.cpp
+++ b/lib/Conversion/TritonGPUToLLVM/Utility.cpp
@@ -2112,22 +2112,15 @@ std::tuple<Block *, Block *, Block *> createIfBlock(RewriterBase &b,
   return {prevBlock, ifBlock, thenBlock};
 }
 
-void finalizeTensorAtomicResults(Operation *op, RankedTensorType tensorTy,
-                                 ConversionPatternRewriter &rewriter,
-                                 SmallVector<Value> &resultVals,
-                                 Type valueElemTy, TritonLLVMOpBuilder &b,
-                                 Value threadPred,
-                                 const TargetInfoBase &targetInfo,
-                                 const LLVMTypeConverter *typeConverter) {
+SmallVector<Value>
+broadcastTensorResult(Operation *op, RankedTensorType tensorTy,
+                      ConversionPatternRewriter &rewriter,
+                      SmallVector<Value> uniqueResultVals, Type valueElemTy,
+                      TritonLLVMOpBuilder &b, Value threadPred,
+                      const TargetInfoBase &targetInfo) {
+  assert(op->hasAttr("allocation.offset"));
   auto *ctx = rewriter.getContext();
   auto loc = op->getLoc();
-  if (!op->hasAttr("allocation.offset")) {
-    // No broadcasting, just pack the values into a struct
-    Value resultStruct =
-        packTensorElements(loc, typeConverter, resultVals, rewriter, tensorTy);
-    rewriter.replaceOp(op, {resultStruct});
-    return;
-  }
 
   auto kOffset = str_attr("offset");
   auto kBlock = str_attr("block");
@@ -2135,7 +2128,6 @@ void finalizeTensorAtomicResults(Operation *op, RankedTensorType tensorTy,
   auto regLayout = triton::gpu::toLinearLayout(tensorTy);
   auto removeRegBroadcast = actionRemoveBroadcastedRegs(regLayout);
   auto uniqueRegLayout = removeRegBroadcast.apply(regLayout);
-  auto uniqueResultVals = removeRegBroadcast.apply(resultVals);
 
   auto shapePerCTA =
       convertType<unsigned>(triton::gpu::getShapePerCTA(tensorTy));
@@ -2172,12 +2164,33 @@ void finalizeTensorAtomicResults(Operation *op, RankedTensorType tensorTy,
   else
     targetInfo.barrier(loc, rewriter, triton::gpu::AddrSpace::Local);
 
-  resultVals =
-      lowerLdSt(loc, ctx, loadCvt, /*valsArray=*/{}, valueElemTy, smemBases,
-                /*paddingShifts=*/{}, /*affineOffset=*/b.i32_val(0),
-                /*maskSpanAffineOffset=*/0, /*affineBlockOffset=*/Value(),
-                /*maskSpanAffineBlock=*/0, laneId, warpId, rewriter, targetInfo,
-                /*maybeMaxVecElems=*/{}, makeSharedLoadEmitter(targetInfo));
+  return lowerLdSt(loc, ctx, loadCvt, /*valsArray=*/{}, valueElemTy, smemBases,
+                   /*paddingShifts=*/{}, /*affineOffset=*/b.i32_val(0),
+                   /*maskSpanAffineOffset=*/0, /*affineBlockOffset=*/Value(),
+                   /*maskSpanAffineBlock=*/0, laneId, warpId, rewriter,
+                   targetInfo,
+                   /*maybeMaxVecElems=*/{}, makeSharedLoadEmitter(targetInfo));
+}
+
+void finalizeTensorAtomicResults(Operation *op, RankedTensorType tensorTy,
+                                 ConversionPatternRewriter &rewriter,
+                                 SmallVector<Value> &resultVals,
+                                 Type valueElemTy, TritonLLVMOpBuilder &b,
+                                 Value threadPred,
+                                 const TargetInfoBase &targetInfo,
+                                 const LLVMTypeConverter *typeConverter) {
+  auto loc = op->getLoc();
+  if (!op->hasAttr("allocation.offset")) {
+    Value resultStruct =
+        packTensorElements(loc, typeConverter, resultVals, rewriter, tensorTy);
+    rewriter.replaceOp(op, {resultStruct});
+    return;
+  }
+  auto removeRegBroadcast =
+      actionRemoveBroadcastedRegs(triton::gpu::toLinearLayout(tensorTy));
+  resultVals = broadcastTensorResult(op, tensorTy, rewriter,
+                                     removeRegBroadcast.apply(resultVals),
+                                     valueElemTy, b, threadPred, targetInfo);
   // Create the result struct and replace the operation
   Value resultStruct = packUniqueTensorElements(loc, typeConverter, resultVals,
                                                 rewriter, tensorTy);

--- a/lib/Dialect/TritonGPU/Transforms/RemoveLayoutConversions.cpp
+++ b/lib/Dialect/TritonGPU/Transforms/RemoveLayoutConversions.cpp
@@ -680,7 +680,7 @@ bool canBeRemat(Operation *op) {
   if (isa<scf::WhileOp, scf::ConditionOp>(op))
     return false;
 
-  return true;
+  return !hasEffect<MemoryEffects::Write>(op);
 }
 
 void LayoutRematerialization::updateRematMapping(

--- a/lib/Dialect/TritonNvidiaGPU/Transforms/ConSanNVIDIA.cpp
+++ b/lib/Dialect/TritonNvidiaGPU/Transforms/ConSanNVIDIA.cpp
@@ -126,7 +126,7 @@ public:
     if (auto storeOp = dyn_cast<ttng::TMAStoreLikeOpInterface>(op))
       mask = getBlockBroadcastMask(storeOp.getSrc().getType());
     if (op->hasAttr("allocation.size"))
-      if (auto scratchMask = getAtomicScratchBroadcastMask(op))
+      if (auto scratchMask = getScratchBroadcastMask(op))
         mask = *scratchMask;
     if (isa<ttng::CLCTryCancelOp>(op) && ttg::lookupNumCTAs(op) > 1) {
       Value ctaId = tti::ExperimentalClusterCTAIdOp::create(b, b.getLoc());
@@ -154,7 +154,7 @@ public:
     if (isa<ClusterBarrierOp>(op))
       return true;
     return op->hasAttr("allocation.size") &&
-           getAtomicScratchBroadcastMask(op).value_or(0) != 0;
+           getScratchBroadcastMask(op).value_or(0) != 0;
   }
 
   std::optional<MemEffectsOpInfo>

--- a/python/test/gluon/test_core.py
+++ b/python/test/gluon/test_core.py
@@ -54,29 +54,38 @@ THREADS_PER_WARP = triton.runtime.driver.active.get_current_target().warp_size
 
 @pytest.mark.parametrize("num_ctas", [1, 2])
 @pytest.mark.parametrize("use_result", [False, True])
-def test_inline_asm_replicated_results(num_ctas, use_result):
+@pytest.mark.parametrize("scalar", [False, True])
+def test_inline_asm_replicated_results(num_ctas, use_result, scalar):
     if not is_cuda() or (num_ctas > 1 and not is_hopper_or_newer()):
         pytest.skip("requires CUDA and Hopper for thread block clusters")
 
     @gluon.jit
-    def kernel(Cells, Out, WideOut, Layout: ttgl.constexpr, NumCTAs: ttgl.constexpr, UseResult: ttgl.constexpr):
+    def kernel(Cells, Out, WideOut, Layout: ttgl.constexpr, NumCTAs: ttgl.constexpr, UseResult: ttgl.constexpr,
+               Scalar: ttgl.constexpr):
         rows = ttgl.arange(0, 8, layout=ttgl.SliceLayout(1, Layout))
         cols = ttgl.arange(0, 32 * NumCTAs, layout=ttgl.SliceLayout(0, Layout))
         for i in range(3):
-            result, wide = ttgl.inline_asm_elementwise("atom.global.add.u32 $0, [$2], 1; cvt.u64.u32 $1, $0;",
-                                                       "=r,=l,l", [Cells + rows], dtype=(ttgl.int32, ttgl.int64),
-                                                       is_pure=False, pack=1)
+            if Scalar:
+                # Only the first pointer is real; padded inputs are ignored.
+                result, wide = ttgl.inline_asm_elementwise(
+                    "atom.global.add.u32 $0, [$4], 1; mov.u32 $1, $0; "
+                    "cvt.u64.u32 $2, $0; mov.u64 $3, $2;", "=r,=r,=l,=l,l,l", [Cells], dtype=(ttgl.int32, ttgl.int64),
+                    is_pure=False, pack=2)
+            else:
+                result, wide = ttgl.inline_asm_elementwise("atom.global.add.u32 $0, [$2], 1; cvt.u64.u32 $1, $0;",
+                                                           "=r,=l,l", [Cells + rows], dtype=(ttgl.int32, ttgl.int64),
+                                                           is_pure=False, pack=1)
             if UseResult:
                 # Expanding the sliced dimension observes every replicated result.
                 offsets = (i * 8 + rows[:, None]) * 32 * NumCTAs + cols[None, :]
-                ttgl.store(Out + offsets, result[:, None])
-                ttgl.store(WideOut + offsets, wide[:, None])
+                ttgl.store(Out + offsets, result if Scalar else result[:, None])
+                ttgl.store(WideOut + offsets, wide if Scalar else wide[:, None])
 
     layout = ttgl.BlockedLayout([1, 2], [8, 4], [1, 4], [0, 1], [[0, 1]] if num_ctas == 2 else [])
-    cells = torch.zeros(8, dtype=torch.int32, device="cuda")
+    cells = torch.zeros(1 if scalar else 8, dtype=torch.int32, device="cuda")
     output = torch.empty((3, 8, 32 * num_ctas), dtype=torch.int32, device="cuda")
     wide_output = torch.empty_like(output, dtype=torch.int64)
-    compiled = kernel[(1, )](cells, output, wide_output, layout, num_ctas, use_result, num_ctas=num_ctas)
+    compiled = kernel[(1, )](cells, output, wide_output, layout, num_ctas, use_result, scalar, num_ctas=num_ctas)
     torch.testing.assert_close(cells, torch.full_like(cells, 3))
     if use_result:
         expected = torch.arange(3, dtype=torch.int32, device="cuda")[:, None, None].expand_as(output)

--- a/python/test/gluon/test_core.py
+++ b/python/test/gluon/test_core.py
@@ -52,50 +52,31 @@ from triton._C.libtriton.gluon_ir import make_cga_layout
 THREADS_PER_WARP = triton.runtime.driver.active.get_current_target().warp_size
 
 
-@pytest.mark.parametrize("size_per_thread,threads_per_warp,warps_per_cta,N", [
-    ([2, 1], [32, 1], [4, 1], 32),
-    ([2, 2], [8, 4], [2, 2], 32),
-    ([2, 2], [1, 32], [1, 4], 32),
-    ([2, 1], [8, 4], [4, 1], 256),
-    ([2, 1], [32, 1], [4, 1], 256),
-])
-@pytest.mark.parametrize("cga_layout", [[], [[0, 1]], [[1, 0]], [[1, 0], [0, 1]]])
-@pytest.mark.parametrize("pack", [1, 2])
+@pytest.mark.parametrize("num_ctas", [1, 2])
 @pytest.mark.parametrize("use_result", [False, True])
-def test_inline_asm_replicated_results(size_per_thread, threads_per_warp, warps_per_cta, N, cga_layout, pack,
-                                       use_result):
-    if not is_cuda():
-        pytest.skip("requires PTX inline assembly")
-    if cga_layout and not is_hopper_or_newer():
-        pytest.skip("requires thread block clusters")
+def test_inline_asm_replicated_results(num_ctas, use_result):
+    if not is_cuda() or (num_ctas > 1 and not is_hopper_or_newer()):
+        pytest.skip("requires CUDA and Hopper for thread block clusters")
 
     @gluon.jit
-    def kernel(Cells, Out, WideOut, N: ttgl.constexpr, Layout: ttgl.constexpr, Pack: ttgl.constexpr,
-               UseResult: ttgl.constexpr):
-        rows = ttgl.arange(0, N, layout=ttgl.SliceLayout(1, Layout))
-        cols = ttgl.arange(0, 128, layout=ttgl.SliceLayout(0, Layout))
+    def kernel(Cells, Out, WideOut, Layout: ttgl.constexpr, NumCTAs: ttgl.constexpr, UseResult: ttgl.constexpr):
+        rows = ttgl.arange(0, 8, layout=ttgl.SliceLayout(1, Layout))
+        cols = ttgl.arange(0, 32 * NumCTAs, layout=ttgl.SliceLayout(0, Layout))
         for i in range(3):
-            if Pack == 1:
-                result, wide = ttgl.inline_asm_elementwise("atom.global.add.u32 $0, [$2], 1; cvt.u64.u32 $1, $0;",
-                                                           "=r,=l,l", [Cells + rows], dtype=(ttgl.int32, ttgl.int64),
-                                                           is_pure=False, pack=1)
-            else:
-                result, wide = ttgl.inline_asm_elementwise(
-                    "atom.global.add.u32 $0, [$4], 1; atom.global.add.u32 $1, [$5], 1; "
-                    "cvt.u64.u32 $2, $0; cvt.u64.u32 $3, $1;", "=r,=r,=l,=l,l,l", [Cells + rows],
-                    dtype=(ttgl.int32, ttgl.int64), is_pure=False, pack=2)
+            result, wide = ttgl.inline_asm_elementwise("atom.global.add.u32 $0, [$2], 1; cvt.u64.u32 $1, $0;",
+                                                       "=r,=l,l", [Cells + rows], dtype=(ttgl.int32, ttgl.int64),
+                                                       is_pure=False, pack=1)
             if UseResult:
-                # Expanding the sliced dimension makes replicas observable:
-                # every lane, warp, register and CTA must see the same ticket.
-                offsets = (i * N + rows[:, None]) * 128 + cols[None, :]
+                # Expanding the sliced dimension observes every replicated result.
+                offsets = (i * 8 + rows[:, None]) * 32 * NumCTAs + cols[None, :]
                 ttgl.store(Out + offsets, result[:, None])
                 ttgl.store(WideOut + offsets, wide[:, None])
 
-    layout = ttgl.BlockedLayout(size_per_thread, threads_per_warp, warps_per_cta, [0, 1], cga_layout)
-    cells = torch.zeros(N, dtype=torch.int32, device="cuda")
-    output = torch.empty((3, N, 128), dtype=torch.int32, device="cuda")
+    layout = ttgl.BlockedLayout([1, 2], [8, 4], [1, 4], [0, 1], [[0, 1]] if num_ctas == 2 else [])
+    cells = torch.zeros(8, dtype=torch.int32, device="cuda")
+    output = torch.empty((3, 8, 32 * num_ctas), dtype=torch.int32, device="cuda")
     wide_output = torch.empty_like(output, dtype=torch.int64)
-    compiled = kernel[(1, )](cells, output, wide_output, N, layout, pack, use_result, num_ctas=2**len(cga_layout))
+    compiled = kernel[(1, )](cells, output, wide_output, layout, num_ctas, use_result, num_ctas=num_ctas)
     torch.testing.assert_close(cells, torch.full_like(cells, 3))
     if use_result:
         expected = torch.arange(3, dtype=torch.int32, device="cuda")[:, None, None].expand_as(output)
@@ -103,91 +84,6 @@ def test_inline_asm_replicated_results(size_per_thread, threads_per_warp, warps_
         torch.testing.assert_close(wide_output, expected.to(torch.int64))
     else:
         assert compiled.metadata.shared == 0
-
-
-@pytest.mark.parametrize("num_ctas", [1, 2, 4])
-@pytest.mark.parametrize("pack", [2, 4])
-@pytest.mark.parametrize("use_result", [False, True])
-def test_inline_asm_replicated_padded_pack(num_ctas, pack, use_result):
-    if not is_cuda():
-        pytest.skip("requires PTX inline assembly")
-    if num_ctas > 1 and not is_hopper_or_newer():
-        pytest.skip("requires thread block clusters")
-
-    @gluon.jit
-    def kernel(Cells, Out, Layout: ttgl.constexpr, NumCTAs: ttgl.constexpr, Pack: ttgl.constexpr, Asm: ttgl.constexpr,
-               Constraints: ttgl.constexpr, UseResult: ttgl.constexpr):
-        rows = ttgl.arange(0, 8, layout=ttgl.SliceLayout(1, Layout))
-        cols = ttgl.arange(0, 16 * NumCTAs, layout=ttgl.SliceLayout(0, Layout))
-        for i in range(3):
-            # This layout has one unique element per thread. The asm ignores
-            # padded pointers and returns extra values that must be discarded.
-            result = ttgl.inline_asm_elementwise(Asm, Constraints, [Cells + rows], dtype=ttgl.int32, is_pure=False,
-                                                 pack=Pack)
-            if UseResult:
-                offsets = (i * 8 + rows[:, None]) * 16 * NumCTAs + cols[None, :]
-                ttgl.store(Out + offsets, result[:, None])
-
-    asm = f"atom.global.add.u32 $0, [${pack}], 1; "
-    asm += " ".join(f"mov.u32 ${i}, $0;" for i in range(1, pack))
-    constraints = ",".join(["=r"] * pack + ["l"] * pack)
-    cga_layout = [[0, 1 << i] for i in range(num_ctas.bit_length() - 1)]
-    layout = ttgl.BlockedLayout([1, 1], [8, 4], [1, 4], [0, 1], cga_layout)
-    cells = torch.zeros(8, dtype=torch.int32, device="cuda")
-    output = torch.empty((3, 8, 16 * num_ctas), dtype=torch.int32, device="cuda")
-    compiled = kernel[(1, )](cells, output, layout, num_ctas, pack, asm, constraints, use_result, num_ctas=num_ctas)
-    torch.testing.assert_close(cells, torch.full_like(cells, 3))
-    if use_result:
-        expected = torch.arange(3, dtype=torch.int32, device="cuda")[:, None, None].expand_as(output)
-        torch.testing.assert_close(output, expected)
-    else:
-        assert compiled.metadata.shared == 0
-
-
-@pytest.mark.parametrize("num_ctas", [1, 2, 4])
-@pytest.mark.parametrize("use_result", [False, True])
-@pytest.mark.parametrize("partition", [None, 0, 1])
-def test_inline_asm_scalar_results(num_ctas, use_result, partition):
-    if not is_cuda():
-        pytest.skip("requires PTX inline assembly")
-    if num_ctas > 1 and not is_hopper_or_newer():
-        pytest.skip("requires thread block clusters")
-    if partition is not None and not is_hopper_or_newer():
-        pytest.skip("requires warp specialization")
-
-    @gluon.jit
-    def asm_partition(Cells, Out, UseResult: ttgl.constexpr, NumCTAs: ttgl.constexpr, Layout: ttgl.constexpr):
-        offsets = ttgl.arange(0, 128 * NumCTAs, layout=Layout)
-        for i in range(3):
-            result = ttgl.inline_asm_elementwise("atom.global.add.u32 $0, [$1], 1;", "=r,l", [Cells], dtype=ttgl.int32,
-                                                 is_pure=False, pack=1)
-            if UseResult:
-                ttgl.store(Out + i * 128 * NumCTAs + offsets, result)
-
-    @gluon.jit
-    def empty_partition():
-        pass
-
-    @gluon.jit
-    def kernel(Cells, Out, UseResult: ttgl.constexpr, NumCTAs: ttgl.constexpr, Layout: ttgl.constexpr,
-               Partition: ttgl.constexpr):
-        if Partition is None:
-            asm_partition(Cells, Out, UseResult, NumCTAs, Layout)
-        elif Partition == 0:
-            ttgl.warp_specialize([(asm_partition, (Cells, Out, UseResult, NumCTAs, Layout)), (empty_partition, ())],
-                                 [4])
-        else:
-            ttgl.warp_specialize([(empty_partition, ()), (asm_partition, (Cells, Out, UseResult, NumCTAs, Layout))],
-                                 [4])
-
-    cells = torch.zeros((), dtype=torch.int32, device="cuda")
-    output = torch.empty((3, 128 * num_ctas), dtype=torch.int32, device="cuda")
-    layout = ttgl.BlockedLayout([1], [32], [4], [0], [[1 << i] for i in range(num_ctas.bit_length() - 1)])
-    kernel[(1, )](cells, output, use_result, num_ctas, layout, partition, num_ctas=num_ctas)
-    torch.testing.assert_close(cells, torch.full_like(cells, 3))
-    if use_result:
-        expected = torch.arange(3, dtype=torch.int32, device="cuda")[:, None].expand_as(output)
-        torch.testing.assert_close(output, expected)
 
 
 @gluon.jit

--- a/python/test/gluon/test_core.py
+++ b/python/test/gluon/test_core.py
@@ -52,6 +52,144 @@ from triton._C.libtriton.gluon_ir import make_cga_layout
 THREADS_PER_WARP = triton.runtime.driver.active.get_current_target().warp_size
 
 
+@pytest.mark.parametrize("size_per_thread,threads_per_warp,warps_per_cta,N", [
+    ([2, 1], [32, 1], [4, 1], 32),
+    ([2, 2], [8, 4], [2, 2], 32),
+    ([2, 2], [1, 32], [1, 4], 32),
+    ([2, 1], [8, 4], [4, 1], 256),
+    ([2, 1], [32, 1], [4, 1], 256),
+])
+@pytest.mark.parametrize("cga_layout", [[], [[0, 1]], [[1, 0]], [[1, 0], [0, 1]]])
+@pytest.mark.parametrize("pack", [1, 2])
+@pytest.mark.parametrize("use_result", [False, True])
+def test_inline_asm_replicated_results(size_per_thread, threads_per_warp, warps_per_cta, N, cga_layout, pack,
+                                       use_result):
+    if not is_cuda():
+        pytest.skip("requires PTX inline assembly")
+    if cga_layout and not is_hopper_or_newer():
+        pytest.skip("requires thread block clusters")
+
+    @gluon.jit
+    def kernel(Cells, Out, WideOut, N: ttgl.constexpr, Layout: ttgl.constexpr, Pack: ttgl.constexpr,
+               UseResult: ttgl.constexpr):
+        rows = ttgl.arange(0, N, layout=ttgl.SliceLayout(1, Layout))
+        cols = ttgl.arange(0, 128, layout=ttgl.SliceLayout(0, Layout))
+        for i in range(3):
+            if Pack == 1:
+                result, wide = ttgl.inline_asm_elementwise("atom.global.add.u32 $0, [$2], 1; cvt.u64.u32 $1, $0;",
+                                                           "=r,=l,l", [Cells + rows], dtype=(ttgl.int32, ttgl.int64),
+                                                           is_pure=False, pack=1)
+            else:
+                result, wide = ttgl.inline_asm_elementwise(
+                    "atom.global.add.u32 $0, [$4], 1; atom.global.add.u32 $1, [$5], 1; "
+                    "cvt.u64.u32 $2, $0; cvt.u64.u32 $3, $1;", "=r,=r,=l,=l,l,l", [Cells + rows],
+                    dtype=(ttgl.int32, ttgl.int64), is_pure=False, pack=2)
+            if UseResult:
+                # Expanding the sliced dimension makes replicas observable:
+                # every lane, warp, register and CTA must see the same ticket.
+                offsets = (i * N + rows[:, None]) * 128 + cols[None, :]
+                ttgl.store(Out + offsets, result[:, None])
+                ttgl.store(WideOut + offsets, wide[:, None])
+
+    layout = ttgl.BlockedLayout(size_per_thread, threads_per_warp, warps_per_cta, [0, 1], cga_layout)
+    cells = torch.zeros(N, dtype=torch.int32, device="cuda")
+    output = torch.empty((3, N, 128), dtype=torch.int32, device="cuda")
+    wide_output = torch.empty_like(output, dtype=torch.int64)
+    compiled = kernel[(1, )](cells, output, wide_output, N, layout, pack, use_result, num_ctas=2**len(cga_layout))
+    torch.testing.assert_close(cells, torch.full_like(cells, 3))
+    if use_result:
+        expected = torch.arange(3, dtype=torch.int32, device="cuda")[:, None, None].expand_as(output)
+        torch.testing.assert_close(output, expected)
+        torch.testing.assert_close(wide_output, expected.to(torch.int64))
+    else:
+        assert compiled.metadata.shared == 0
+
+
+@pytest.mark.parametrize("num_ctas", [1, 2, 4])
+@pytest.mark.parametrize("pack", [2, 4])
+@pytest.mark.parametrize("use_result", [False, True])
+def test_inline_asm_replicated_padded_pack(num_ctas, pack, use_result):
+    if not is_cuda():
+        pytest.skip("requires PTX inline assembly")
+    if num_ctas > 1 and not is_hopper_or_newer():
+        pytest.skip("requires thread block clusters")
+
+    @gluon.jit
+    def kernel(Cells, Out, Layout: ttgl.constexpr, NumCTAs: ttgl.constexpr, Pack: ttgl.constexpr, Asm: ttgl.constexpr,
+               Constraints: ttgl.constexpr, UseResult: ttgl.constexpr):
+        rows = ttgl.arange(0, 8, layout=ttgl.SliceLayout(1, Layout))
+        cols = ttgl.arange(0, 16 * NumCTAs, layout=ttgl.SliceLayout(0, Layout))
+        for i in range(3):
+            # This layout has one unique element per thread. The asm ignores
+            # padded pointers and returns extra values that must be discarded.
+            result = ttgl.inline_asm_elementwise(Asm, Constraints, [Cells + rows], dtype=ttgl.int32, is_pure=False,
+                                                 pack=Pack)
+            if UseResult:
+                offsets = (i * 8 + rows[:, None]) * 16 * NumCTAs + cols[None, :]
+                ttgl.store(Out + offsets, result[:, None])
+
+    asm = f"atom.global.add.u32 $0, [${pack}], 1; "
+    asm += " ".join(f"mov.u32 ${i}, $0;" for i in range(1, pack))
+    constraints = ",".join(["=r"] * pack + ["l"] * pack)
+    cga_layout = [[0, 1 << i] for i in range(num_ctas.bit_length() - 1)]
+    layout = ttgl.BlockedLayout([1, 1], [8, 4], [1, 4], [0, 1], cga_layout)
+    cells = torch.zeros(8, dtype=torch.int32, device="cuda")
+    output = torch.empty((3, 8, 16 * num_ctas), dtype=torch.int32, device="cuda")
+    compiled = kernel[(1, )](cells, output, layout, num_ctas, pack, asm, constraints, use_result, num_ctas=num_ctas)
+    torch.testing.assert_close(cells, torch.full_like(cells, 3))
+    if use_result:
+        expected = torch.arange(3, dtype=torch.int32, device="cuda")[:, None, None].expand_as(output)
+        torch.testing.assert_close(output, expected)
+    else:
+        assert compiled.metadata.shared == 0
+
+
+@pytest.mark.parametrize("num_ctas", [1, 2, 4])
+@pytest.mark.parametrize("use_result", [False, True])
+@pytest.mark.parametrize("partition", [None, 0, 1])
+def test_inline_asm_scalar_results(num_ctas, use_result, partition):
+    if not is_cuda():
+        pytest.skip("requires PTX inline assembly")
+    if num_ctas > 1 and not is_hopper_or_newer():
+        pytest.skip("requires thread block clusters")
+    if partition is not None and not is_hopper_or_newer():
+        pytest.skip("requires warp specialization")
+
+    @gluon.jit
+    def asm_partition(Cells, Out, UseResult: ttgl.constexpr, NumCTAs: ttgl.constexpr, Layout: ttgl.constexpr):
+        offsets = ttgl.arange(0, 128 * NumCTAs, layout=Layout)
+        for i in range(3):
+            result = ttgl.inline_asm_elementwise("atom.global.add.u32 $0, [$1], 1;", "=r,l", [Cells], dtype=ttgl.int32,
+                                                 is_pure=False, pack=1)
+            if UseResult:
+                ttgl.store(Out + i * 128 * NumCTAs + offsets, result)
+
+    @gluon.jit
+    def empty_partition():
+        pass
+
+    @gluon.jit
+    def kernel(Cells, Out, UseResult: ttgl.constexpr, NumCTAs: ttgl.constexpr, Layout: ttgl.constexpr,
+               Partition: ttgl.constexpr):
+        if Partition is None:
+            asm_partition(Cells, Out, UseResult, NumCTAs, Layout)
+        elif Partition == 0:
+            ttgl.warp_specialize([(asm_partition, (Cells, Out, UseResult, NumCTAs, Layout)), (empty_partition, ())],
+                                 [4])
+        else:
+            ttgl.warp_specialize([(empty_partition, ()), (asm_partition, (Cells, Out, UseResult, NumCTAs, Layout))],
+                                 [4])
+
+    cells = torch.zeros((), dtype=torch.int32, device="cuda")
+    output = torch.empty((3, 128 * num_ctas), dtype=torch.int32, device="cuda")
+    layout = ttgl.BlockedLayout([1], [32], [4], [0], [[1 << i] for i in range(num_ctas.bit_length() - 1)])
+    kernel[(1, )](cells, output, use_result, num_ctas, layout, partition, num_ctas=num_ctas)
+    torch.testing.assert_close(cells, torch.full_like(cells, 3))
+    if use_result:
+        expected = torch.arange(3, dtype=torch.int32, device="cuda")[:, None].expand_as(output)
+        torch.testing.assert_close(output, expected)
+
+
 @gluon.jit
 def copy_kernel(Out, In, numel, XBLOCK: ttgl.constexpr, layout: ttgl.constexpr):
     xbase = ttgl.program_id(0) * XBLOCK

--- a/python/test/unit/language/test_core.py
+++ b/python/test/unit/language/test_core.py
@@ -5727,52 +5727,30 @@ def test_inline_asm_with_pointers(num_ctas, device):
     np.testing.assert_equal(y_ref, to_numpy(y_tri))
 
 
-def test_inline_asm_replicated_side_effects(device):
+@pytest.mark.parametrize("pack", [1, 2])
+@pytest.mark.parametrize("use_result", [False, True])
+def test_inline_asm_side_effects(device, pack, use_result):
     if not is_cuda():
-        pytest.skip('test_inline_asm is only supported in CUDA')
+        pytest.skip("requires PTX inline assembly")
 
     @triton.jit
-    def kernel(cells, output, N: tl.constexpr):
-        offsets = tl.arange(0, N)
-        result = tl.inline_asm_elementwise(
-            "red.global.add.u32 [$1], 1; mov.u32 $0, 7;",
-            "=r,l",
-            [cells + offsets],
-            dtype=tl.int32,
-            is_pure=False,
-            pack=1,
-        )
-        tl.store(output + offsets, result)
+    def kernel(Cells, Out, Asm: tl.constexpr, Constraints: tl.constexpr, Pack: tl.constexpr, UseResult: tl.constexpr):
+        result = tl.inline_asm_elementwise(Asm, Constraints, [Cells], dtype=tl.int32, is_pure=False, pack=Pack)
+        if UseResult:
+            tl.store(Out + tl.arange(0, 128), result)
 
-    N = 32
-    cells = torch.zeros(N, dtype=torch.int32, device=device)
-    output = torch.empty_like(cells)
-    kernel[(1, )](cells, output, N=N, num_warps=4)
-
-    torch.testing.assert_close(cells, torch.ones_like(cells))
-    torch.testing.assert_close(output, torch.full_like(output, 7))
-
-
-@pytest.mark.parametrize("pack", [2, 4])
-def test_inline_asm_side_effect_padded_pack(device, pack):
-    if not is_cuda():
-        pytest.skip('test_inline_asm is only supported in CUDA')
-
-    @triton.jit
-    def kernel(cells, output, ASM: tl.constexpr, CONSTRAINTS: tl.constexpr, PACK: tl.constexpr):
-        # A scalar provides one real input; the other packed pointers are
-        # undefined and must not be dereferenced by the assembly.
-        result = tl.inline_asm_elementwise(ASM, CONSTRAINTS, [cells], dtype=tl.int32, is_pure=False, pack=PACK)
-        tl.store(output + tl.arange(0, 128), result)
-
+    # Only the first pointer is real; ignore padded inputs and discard extra outputs.
     asm = f"atom.global.add.u32 $0, [${pack}], 1; "
     asm += " ".join(f"mov.u32 ${i}, $0;" for i in range(1, pack))
     constraints = ",".join(["=r"] * pack + ["l"] * pack)
     cells = torch.full((), 17, dtype=torch.int32, device=device)
     output = torch.empty(128, dtype=torch.int32, device=device)
-    kernel[(1, )](cells, output, asm, constraints, pack, num_warps=4)
+    compiled = kernel[(1, )](cells, output, asm, constraints, pack, use_result, num_warps=4)
     torch.testing.assert_close(cells, torch.full_like(cells, 18))
-    torch.testing.assert_close(output, torch.full_like(output, 17))
+    if use_result:
+        torch.testing.assert_close(output, torch.full_like(output, 17))
+    else:
+        assert compiled.metadata.shared == 0
 
 
 def test_inline_asm_multiple_outputs(device):

--- a/python/test/unit/language/test_core.py
+++ b/python/test/unit/language/test_core.py
@@ -5727,6 +5727,54 @@ def test_inline_asm_with_pointers(num_ctas, device):
     np.testing.assert_equal(y_ref, to_numpy(y_tri))
 
 
+def test_inline_asm_replicated_side_effects(device):
+    if not is_cuda():
+        pytest.skip('test_inline_asm is only supported in CUDA')
+
+    @triton.jit
+    def kernel(cells, output, N: tl.constexpr):
+        offsets = tl.arange(0, N)
+        result = tl.inline_asm_elementwise(
+            "red.global.add.u32 [$1], 1; mov.u32 $0, 7;",
+            "=r,l",
+            [cells + offsets],
+            dtype=tl.int32,
+            is_pure=False,
+            pack=1,
+        )
+        tl.store(output + offsets, result)
+
+    N = 32
+    cells = torch.zeros(N, dtype=torch.int32, device=device)
+    output = torch.empty_like(cells)
+    kernel[(1, )](cells, output, N=N, num_warps=4)
+
+    torch.testing.assert_close(cells, torch.ones_like(cells))
+    torch.testing.assert_close(output, torch.full_like(output, 7))
+
+
+@pytest.mark.parametrize("pack", [2, 4])
+def test_inline_asm_side_effect_padded_pack(device, pack):
+    if not is_cuda():
+        pytest.skip('test_inline_asm is only supported in CUDA')
+
+    @triton.jit
+    def kernel(cells, output, ASM: tl.constexpr, CONSTRAINTS: tl.constexpr, PACK: tl.constexpr):
+        # A scalar provides one real input; the other packed pointers are
+        # undefined and must not be dereferenced by the assembly.
+        result = tl.inline_asm_elementwise(ASM, CONSTRAINTS, [cells], dtype=tl.int32, is_pure=False, pack=PACK)
+        tl.store(output + tl.arange(0, 128), result)
+
+    asm = f"atom.global.add.u32 $0, [${pack}], 1; "
+    asm += " ".join(f"mov.u32 ${i}, $0;" for i in range(1, pack))
+    constraints = ",".join(["=r"] * pack + ["l"] * pack)
+    cells = torch.full((), 17, dtype=torch.int32, device=device)
+    output = torch.empty(128, dtype=torch.int32, device=device)
+    kernel[(1, )](cells, output, asm, constraints, pack, num_warps=4)
+    torch.testing.assert_close(cells, torch.full_like(cells, 18))
+    torch.testing.assert_close(output, torch.full_like(output, 17))
+
+
 def test_inline_asm_multiple_outputs(device):
     if not is_cuda():
         pytest.skip('test_inline_asm is only supported in CUDA')

--- a/python/test/unit/language/test_core.py
+++ b/python/test/unit/language/test_core.py
@@ -5727,32 +5727,6 @@ def test_inline_asm_with_pointers(num_ctas, device):
     np.testing.assert_equal(y_ref, to_numpy(y_tri))
 
 
-@pytest.mark.parametrize("pack", [1, 2])
-@pytest.mark.parametrize("use_result", [False, True])
-def test_inline_asm_side_effects(device, pack, use_result):
-    if not is_cuda():
-        pytest.skip("requires PTX inline assembly")
-
-    @triton.jit
-    def kernel(Cells, Out, Asm: tl.constexpr, Constraints: tl.constexpr, Pack: tl.constexpr, UseResult: tl.constexpr):
-        result = tl.inline_asm_elementwise(Asm, Constraints, [Cells], dtype=tl.int32, is_pure=False, pack=Pack)
-        if UseResult:
-            tl.store(Out + tl.arange(0, 128), result)
-
-    # Only the first pointer is real; ignore padded inputs and discard extra outputs.
-    asm = f"atom.global.add.u32 $0, [${pack}], 1; "
-    asm += " ".join(f"mov.u32 ${i}, $0;" for i in range(1, pack))
-    constraints = ",".join(["=r"] * pack + ["l"] * pack)
-    cells = torch.full((), 17, dtype=torch.int32, device=device)
-    output = torch.empty(128, dtype=torch.int32, device=device)
-    compiled = kernel[(1, )](cells, output, asm, constraints, pack, use_result, num_warps=4)
-    torch.testing.assert_close(cells, torch.full_like(cells, 18))
-    if use_result:
-        torch.testing.assert_close(output, torch.full_like(output, 17))
-    else:
-        assert compiled.metadata.shared == 0
-
-
 def test_inline_asm_multiple_outputs(device):
     if not is_cuda():
         pytest.skip('test_inline_asm is only supported in CUDA')

--- a/python/triton/language/core.py
+++ b/python/triton/language/core.py
@@ -3402,6 +3402,12 @@ def inline_asm_elementwise(asm: str, constraints: str, args: Sequence, dtype: Un
         time.  Exactly which set of inputs a block receives is unspecified.
         Input elements of size less than 4 bytes are packed into 4-byte
         registers.
+        Incomplete groups are padded with undefined inputs, and the corresponding
+        padded outputs are discarded.
+
+        When :code:`is_pure` is false, each logical group of packed elements
+        executes once, even if its tensor layout replicates those elements
+        across physical threads.
 
         This op does not support empty :code:`dtype` -- the inline asm must
         return at least one tensor, even if you don't need it.  You can work

--- a/test/Conversion/tritongpu_to_llvm.mlir
+++ b/test/Conversion/tritongpu_to_llvm.mlir
@@ -2291,6 +2291,83 @@ module attributes {"ttg.target" = "cuda:80", "ttg.num-ctas" = 1 : i32, "ttg.num-
 
 // -----
 
+#replicated = #ttg.blocked<{sizePerThread = [1], threadsPerWarp = [32], warpsPerCTA = [4], order = [0]}>
+module attributes {"ttg.target" = "cuda:80", "ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, "ttg.threads-per-warp" = 32 : i32} {
+  // CHECK-LABEL: inline_asm_replicated_side_effect_dead_result
+  // CHECK: llvm.cond_br
+  // CHECK: llvm.inline_asm has_side_effects
+  // CHECK-SAME: "red.global.add.u32 [$1], 1; mov.u32 $0, 0;"
+  // CHECK-NOT: st.shared
+  // CHECK-NOT: nvvm.barrier
+  // CHECK: llvm.return
+  tt.func public @inline_asm_replicated_side_effect_dead_result(%ptrs: tensor<32x!tt.ptr<i32>, #replicated>) {
+    %unused = tt.elementwise_inline_asm "red.global.add.u32 [$1], 1; mov.u32 $0, 0;" {constraints = "=r,l", packed_element = 1 : i32, pure = false} %ptrs : tensor<32x!tt.ptr<i32>, #replicated> -> tensor<32xi32, #replicated>
+    tt.return
+  }
+
+  // CHECK-LABEL: inline_asm_replicated_side_effect_live_result
+  // CHECK: llvm.cond_br
+  // CHECK: llvm.inline_asm has_side_effects
+  // CHECK-SAME: "red.global.add.u32 [$1], 1; mov.u32 $0, 7;"
+  // CHECK: st.shared
+  // CHECK: nvvm.barrier
+  // CHECK: llvm.load
+  // CHECK: llvm.return
+  tt.func public @inline_asm_replicated_side_effect_live_result(%ptrs: tensor<32x!tt.ptr<i32>, #replicated>, %out: tensor<32x!tt.ptr<i32>, #replicated>) {
+    %result = tt.elementwise_inline_asm "red.global.add.u32 [$1], 1; mov.u32 $0, 7;" {constraints = "=r,l", packed_element = 1 : i32, pure = false} %ptrs : tensor<32x!tt.ptr<i32>, #replicated> -> tensor<32xi32, #replicated>
+    tt.store %out, %result : tensor<32x!tt.ptr<i32>, #replicated>
+    tt.return
+  }
+
+  // CHECK-LABEL: inline_asm_scalar_unused_first_result
+  // CHECK: llvm.cond_br
+  // CHECK: llvm.inline_asm has_side_effects
+  // CHECK-SAME: "atom.global.add.u32 $0, [$2], 1; mov.u32 $1, $0;"
+  // CHECK: st.shared::cta.b8
+  // CHECK: nvvm.barrier
+  // CHECK: llvm.load
+  // CHECK: llvm.return
+  tt.func public @inline_asm_scalar_unused_first_result(%ptr: !tt.ptr<i32>, %out: !tt.ptr<i8>) {
+    %result:2 = tt.elementwise_inline_asm "atom.global.add.u32 $0, [$2], 1; mov.u32 $1, $0;" {constraints = "=r,=r,l", packed_element = 1 : i32, pure = false} %ptr : !tt.ptr<i32> -> i32, i8
+    tt.store %out, %result#1 : !tt.ptr<i8>
+    tt.return
+  }
+
+  // CHECK-LABEL: inline_asm_scalar_without_operands
+  // CHECK: llvm.cond_br
+  // CHECK: llvm.inline_asm has_side_effects
+  // CHECK-SAME: "mov.u32 $0, 7;"
+  // CHECK: st.shared::cta.b32
+  // CHECK: nvvm.barrier
+  // CHECK: llvm.load
+  // CHECK: llvm.return
+  tt.func public @inline_asm_scalar_without_operands(%out: !tt.ptr<i32>) {
+    %result = tt.elementwise_inline_asm "mov.u32 $0, 7;" {constraints = "=r", packed_element = 1 : i32, pure = false} -> i32
+    tt.store %out, %result : !tt.ptr<i32>
+    tt.return
+  }
+
+  // An impure asm may ignore padded inputs. Preserve padding and discard the
+  // extra result while still executing only on the canonical owner.
+  // CHECK-LABEL: inline_asm_side_effect_padded_pack
+  // CHECK: %[[PAD:.*]] = llvm.mlir.undef : !llvm.ptr<1>
+  // CHECK: llvm.cond_br
+  // CHECK: llvm.inline_asm has_side_effects
+  // CHECK-SAME: "atom.global.add.u32 $0, [$2], 1; mov.u32 $1, $0;"
+  // CHECK-SAME: %{{.*}}, %[[PAD]] : (!llvm.ptr<1>, !llvm.ptr<1>) -> !llvm.struct<(i32, i32)>
+  // CHECK: st.shared::cta.b32
+  // CHECK: nvvm.barrier
+  // CHECK: llvm.load
+  // CHECK: llvm.return
+  tt.func public @inline_asm_side_effect_padded_pack(%ptr: !tt.ptr<i32>, %out: !tt.ptr<i32>) {
+    %result = tt.elementwise_inline_asm "atom.global.add.u32 $0, [$2], 1; mov.u32 $1, $0;" {constraints = "=r,=r,l,l", packed_element = 2 : i32, pure = false} %ptr : !tt.ptr<i32> -> i32
+    tt.store %out, %result : !tt.ptr<i32>
+    tt.return
+  }
+}
+
+// -----
+
 //  CHECK-LABEL: reduce_slice
 //  CHECK-NOT: st.shared
 //  CHECK-NOT: ld.shared

--- a/test/Conversion/tritongpu_to_llvm.mlir
+++ b/test/Conversion/tritongpu_to_llvm.mlir
@@ -2319,6 +2319,21 @@ module attributes {"ttg.target" = "cuda:80", "ttg.num-ctas" = 1 : i32, "ttg.num-
     tt.return
   }
 
+  // CHECK-LABEL: inline_asm_scalar_pointer_result
+  // CHECK: llvm.inline_asm has_side_effects
+  // CHECK: llvm.ptrtoint {{.*}} : !llvm.ptr<1> to i64
+  // CHECK: st.shared::cta.b64
+  // CHECK: nvvm.barrier
+  // CHECK: llvm.load {{.*}} -> i64
+  // CHECK: llvm.inttoptr {{.*}} : i64 to !llvm.ptr<1>
+  // CHECK: llvm.return
+  tt.func public @inline_asm_scalar_pointer_result(%ptr: !tt.ptr<i32>, %out: !tt.ptr<i32>) {
+    %result = tt.elementwise_inline_asm "mov.u64 $0, $1;" {constraints = "=l,l", packed_element = 1 : i32, pure = false} %ptr : !tt.ptr<i32> -> !tt.ptr<i32>
+    %value = tt.load %result : !tt.ptr<i32>
+    tt.store %out, %value : !tt.ptr<i32>
+    tt.return
+  }
+
   // CHECK-LABEL: inline_asm_scalar_unused_first_result
   // CHECK: llvm.cond_br
   // CHECK: llvm.inline_asm has_side_effects
@@ -2362,6 +2377,29 @@ module attributes {"ttg.target" = "cuda:80", "ttg.num-ctas" = 1 : i32, "ttg.num-
   tt.func public @inline_asm_side_effect_padded_pack(%ptr: !tt.ptr<i32>, %out: !tt.ptr<i32>) {
     %result = tt.elementwise_inline_asm "atom.global.add.u32 $0, [$2], 1; mov.u32 $1, $0;" {constraints = "=r,=r,l,l", packed_element = 2 : i32, pure = false} %ptr : !tt.ptr<i32> -> i32
     tt.store %out, %result : !tt.ptr<i32>
+    tt.return
+  }
+}
+
+// -----
+
+#replicated = #ttg.blocked<{sizePerThread = [4], threadsPerWarp = [32], warpsPerCTA = [4], order = [0], CGALayout = [[0]]}>
+module attributes {"ttg.target" = "cuda:90", "ttg.num-ctas" = 2 : i32, "ttg.num-warps" = 4 : i32, "ttg.threads-per-warp" = 32 : i32} {
+  // CHECK-LABEL: inline_asm_replicated_bool_result
+  // CHECK: llvm.inline_asm has_side_effects
+  // CHECK: llvm.zext {{.*}} : i1 to i8
+  // CHECK: vector<4xi8>
+  // CHECK: st.shared::cta.v4.b8
+  // CHECK: nvvm.cluster.arrive
+  // CHECK: nvvm.cluster.wait
+  // CHECK: llvm.load {{.*}} -> vector<4xi8>
+  // CHECK: llvm.trunc {{.*}} : i8 to i1
+  // CHECK: llvm.return
+  tt.func public @inline_asm_replicated_bool_result(%out: tensor<128x!tt.ptr<i32>, #replicated>) {
+    %x = tt.make_range {start = 0 : i32, end = 128 : i32} : tensor<128xi32, #replicated>
+    %result = tt.elementwise_inline_asm "setp.eq.u32 $0, $1, 0;" {constraints = "=b,r", packed_element = 1 : i32, pure = false} %x : tensor<128xi32, #replicated> -> tensor<128xi1, #replicated>
+    %value = arith.extui %result : tensor<128xi1, #replicated> to tensor<128xi32, #replicated>
+    tt.store %out, %value : tensor<128x!tt.ptr<i32>, #replicated>
     tt.return
   }
 }

--- a/test/TritonGPU/combine.mlir
+++ b/test/TritonGPU/combine.mlir
@@ -4267,6 +4267,17 @@ module attributes {"ttg.num-warps" = 1 : i32, "ttg.num-ctas" = 1 : i32} {
     // CHECK: tt.return
     tt.return %cvt, %exp : tensor<1x32xf32, #blocked1>, tensor<1x32xf32, #blocked>
   }
+
+  // CHECK-LABEL: @side_effecting_inline_asm
+  tt.func @side_effecting_inline_asm() -> (tensor<1x32xi32, #blocked1>, tensor<1x32xi32, #blocked>) {
+    %cst = arith.constant dense<0> : tensor<1x32xi32, #blocked>
+    // CHECK: %[[ASM:.+]] = tt.elementwise_inline_asm {{.*}}pure = false
+    %asm = tt.elementwise_inline_asm "mov.u32 $0, %clock;" {constraints = "=r,r", packed_element = 1 : i32, pure = false} %cst : tensor<1x32xi32, #blocked> -> tensor<1x32xi32, #blocked>
+    // CHECK-NEXT: %[[CONVERT:.+]] = ttg.convert_layout %[[ASM]]
+    %converted = ttg.convert_layout %asm : tensor<1x32xi32, #blocked> -> tensor<1x32xi32, #blocked1>
+    // CHECK-NEXT: tt.return %[[CONVERT]], %[[ASM]]
+    tt.return %converted, %asm : tensor<1x32xi32, #blocked1>, tensor<1x32xi32, #blocked>
+  }
 }
 
 // -----

--- a/test/TritonNvidiaGPU/cluster-barrier-mbar-allocator.mlir
+++ b/test/TritonNvidiaGPU/cluster-barrier-mbar-allocator.mlir
@@ -45,6 +45,15 @@ module attributes {"ttg.num-ctas" = 2 : i32, "ttg.num-warps" = 4 : i32, ttg.shar
       // CHECK: tt.atomic_cas {{.*}}ttg.mbar_offset = 8 : i32
       %tensor_cas = tt.atomic_cas acq_rel, gpu, %ptrs, %zeros, %ones {allocation.offset = 0 : i32} : (tensor<128x!tt.ptr<i32>, #blockedBroadcast>, tensor<128xi32, #blockedBroadcast>, tensor<128xi32, #blockedBroadcast>) -> tensor<128xi32, #blockedBroadcast>
       tt.store %ptrs, %tensor_cas : tensor<128x!tt.ptr<i32>, #blockedBroadcast>
+      // Only live impure results need a cluster broadcast. An unused first
+      // result must not hide the live second result from the allocator.
+      // CHECK: tt.elementwise_inline_asm {{.*}}ttg.mbar_offset = 8 : i32
+      %asm:2 = tt.elementwise_inline_asm "mov.u32 $0, 0; atom.global.add.u32 $1, [$2], 1;" {constraints = "=r,=r,l", packed_element = 1 : i32, pure = false} %ptr : !tt.ptr<i32> -> i32, i32
+      tt.store %ptr, %asm#1 : !tt.ptr<i32>
+      // CHECK: tt.elementwise_inline_asm
+      // CHECK-NOT: ttg.mbar_offset
+      // CHECK: ttg.warp_yield
+      %unused = tt.elementwise_inline_asm "mov.u32 $0, 0;" {constraints = "=r", packed_element = 1 : i32, pure = false} -> i32
       ttg.warp_yield
     }
     partition0() num_warps(4) {

--- a/test/TritonNvidiaGPU/membar-cluster.mlir
+++ b/test/TritonNvidiaGPU/membar-cluster.mlir
@@ -637,6 +637,22 @@ module attributes {"ttg.num-ctas" = 2 : i32, "ttg.num-warps" = 4 : i32, "ttng.tw
     tt.return %result, %reduced : i32, tensor<128xf16, #sliceScratch0>
   }
 
+  // Impure inline asm also broadcasts its result through cross-CTA scratch.
+  // The following reduction must wait before overwriting that allocation.
+  // CHECK-LABEL: @cross_cta_inline_asm_then_local_reduce
+  // CHECK: tt.elementwise_inline_asm
+  // CHECK-NEXT: ttng.cluster_barrier
+  // CHECK-NEXT: "tt.reduce"{{.*}}axis = 0
+  tt.func @cross_cta_inline_asm_then_local_reduce(%ptr: !tt.ptr<i32>, %input: tensor<256x128xf16, #blockedScratch>) -> (i32, tensor<128xf16, #sliceScratch0>) {
+    %result = tt.elementwise_inline_asm "atom.global.add.u32 $0, [$1], 1;" {constraints = "=r,l", packed_element = 1 : i32, pure = false} %ptr : !tt.ptr<i32> -> i32
+    %reduced = "tt.reduce"(%input) ({
+    ^bb0(%lhs: f16, %rhs: f16):
+      %sum = arith.addf %lhs, %rhs : f16
+      tt.reduce.return %sum : f16
+    }) {axis = 0 : i32} : (tensor<256x128xf16, #blockedScratch>) -> tensor<128xf16, #sliceScratch0>
+    tt.return %result, %reduced : i32, tensor<128xf16, #sliceScratch0>
+  }
+
   // A scalar atomic RMW has the same scratch broadcast sequence as atomic CAS.
   // Its internal barrier also leaves only a read before the following
   // read-only reuse.


### PR DESCRIPTION
Impure elementwise inline assembly can be duplicated during layout rematerialization or executed by redundant threads and CTAs, repeating side effects for the same logical input.

Prevent rematerialization of operations with write effects, execute impure asm on the unique owners, and broadcast live results through shared memory. This handles cross-CTA and warp-specialized execution while avoiding scratch allocation for unused results. Pointer and boolean results are converted to integer storage types for broadcasting. Partial packs continue to round up with undefined inputs and discarded padded outputs.

Builds on #11001 and #11089. Validation passed: 248 lit tests and 8 Gluon-to-PTX compilation cases. One assertion-dependent lit test was excluded from the Release build. The 13 inline-asm GPU tests passed before the review follow-ups.
