### PR TITLE
[BACKEND] Disable packed FP scalarization on NVIDIA

### DIFF
--- a/third_party/nvidia/backend/compiler.py
+++ b/third_party/nvidia/backend/compiler.py
@@ -500,7 +500,7 @@ class CUDABackend(BaseBackend):
             disable_slp_vectorizer=capability == 80,
             expand_masked_div_rem=True,
             vectorize_extracted_adds=True,
-            scalarize_packed_fops=True,
+            scalarize_packed_fops=False,
         )
 
         # Get some metadata


### PR DESCRIPTION
Disable `scalarize_packed_fops` on NVIDIA. After the LLVM rollback in #11506, it prevents packed FMA contraction in softmax backward and breaks bitwise parity. Keep `vectorize_extracted_adds` enabled.

Validated on GB300: all three previously failing parity tests pass with fresh kernel caches. Pre-commit checks pass. No test changes.
