### PR TITLE
[BACKEND] Fix  abstract signature to match its overrides

### DIFF
--- a/python/triton/backends/compiler.py
+++ b/python/triton/backends/compiler.py
@@ -54,6 +54,7 @@ class BaseBackend(metaclass=ABCMeta):
         Stages will be run sequentially (in inseriton order) and can communicate using `metadata`.
         All stages are expected to return a `str` object, except for the last stage which returns
         a `bytes` object for execution by the launcher.
+        `language` is the frontend that produced `src` (e.g. `Language.TRITON` or `Language.GLUON`).
         """
         raise NotImplementedError
 

--- a/python/triton/backends/compiler.py
+++ b/python/triton/backends/compiler.py
@@ -46,7 +46,7 @@ class BaseBackend(metaclass=ABCMeta):
         raise NotImplementedError
 
     @abstractmethod
-    def add_stages(self, stages: dict, options: object) -> None:
+    def add_stages(self, stages: dict, options: object, language: Language) -> None:
         """
         Populates `stages` dictionary with entries of the form:
         ir_name [str] => Function[(src: str, metadata: dict) -> str|bytes]


### PR DESCRIPTION
`BaseBackend.add_stages` was declared as `add_stages(self, stages, options)`,
missing the `language` parameter. Every concrete backend already overrides it
with `language` included, e.g.:
```
  third_party/amd/backend/compiler.py:
      def add_stages(self, stages, options, language):

  third_party/nvidia/backend/compiler.py:
      def add_stages(self, stages, options, language):
```
and the call site in `python/triton/compiler/compiler.py` passes it:
```
  backend.add_stages(stages, options, src.language)
```
so the abstract method's signature was simply stale. This causes static
type checkers (Pyright/Pylance) to flag every backend override as
"incompatible with base class" due to a positional parameter count
mismatch. Add the missing `language: Language` parameter to the abstract
declaration so it matches actual usage and all existing overrides.

# New contributor declaration
- [x] I am not making a trivial change, such as fixing a typo in a comment.

- [x] I have written a PR description following these
  [rules](https://cbea.ms/git-commit/#why-not-how).

- [x] I have run `pre-commit run --from-ref origin/main --to-ref HEAD`.

- Select one of the following.
  - [ ] I have added tests.
    - `/test` for `lit` tests
    - `/unittest` for C++ tests
    - `/python/test` for end-to-end tests
  - [x] This PR does not need a test because `it only corrects a stale type
    annotation on an abstract method to match its existing overrides
    (amd/nvidia/vulkan backends already implement it with the extra
    parameter); there is no runtime behavior change to test.`

- Select one of the following.
  - [x] I have not added any `lit` tests.
  - [ ] The `lit` tests I have added follow these [best practices](https://mlir.llvm.org/getting_started/TestingGuide/#filecheck-best-practices),
    including the "tests should be minimal" section. (Usually running Python code
    and using the instructions it generates is not minimal.)