### PR TITLE
[BAKCEND] Temporarily revert thread locality reduction changes

### DIFF
--- a/lib/Dialect/TritonGPU/Transforms/OptimizeThreadLocality.cpp
+++ b/lib/Dialect/TritonGPU/Transforms/OptimizeThreadLocality.cpp
@@ -239,58 +239,6 @@ struct OptimizeGatherLayoutPattern : public mlir::OpRewritePattern<GatherOp> {
 } // namespace
 
 namespace {
-// A reduction accumulated into an scf.for iter_arg:
-//
-//   %res = scf.for ... iter_args(.., %acc = %init, ..)  (forOp)
-//     %red = tt.reduce %src {axis}                      (reduce)
-//              [%a, %b] {return ⊕(%a, %b);}             (combiner)
-//     %upd = ⊕(%acc, %red)                              (update)
-//     scf.yield .., %upd, ..                            (slot argIdx)
-//
-struct AccumulatedReduce {
-  triton::ReduceOp reduce;
-  Operation *update;
-};
-
-std::optional<AccumulatedReduce> matchAccumulatedReduce(scf::ForOp forOp,
-                                                        unsigned argIdx) {
-  BlockArgument iterArg = forOp.getRegionIterArgs()[argIdx];
-  // The accumulator is only used at its own update in the loop
-  if (!iterArg.hasOneUse())
-    return std::nullopt;
-  Operation *update = forOp.getYieldedValues()[argIdx].getDefiningOp();
-  if (!update || !update->hasOneUse() ||
-      !update->hasTrait<OpTrait::IsCommutative>())
-    return std::nullopt;
-  // Match the reduce as the other operand of update
-  OpOperand &iterArgUse = llvm::getSingleElement(iterArg.getUses());
-  if (iterArgUse.getOwner() != update)
-    return std::nullopt;
-  auto reduce = update->getOperand(1 - iterArgUse.getOperandNumber())
-                    .getDefiningOp<triton::ReduceOp>();
-  if (!reduce || !reduce->hasOneUse() || reduce->getBlock() != forOp.getBody())
-    return std::nullopt;
-  Operation *combiner = reduce.getSingleCombiner();
-  // the combiner & the update needs to share the opcode, and it needs a neutral
-  // element to initialise the partial accumulator.
-  if (!combiner || update->getName() != combiner->getName() ||
-      !arith::getNeutralElement(combiner))
-    return std::nullopt;
-  auto srcType = cast<RankedTensorType>(reduce.getOperands()[0].getType());
-  unsigned axis = reduce.getAxis();
-  // TODO: relax this restriction
-  if (!isa<triton::gpu::BlockedEncodingAttr>(srcType.getEncoding()))
-    return std::nullopt;
-  // only profitable when there are inter-thread/warp/cta communication that
-  // can be deferred after the loop.
-  bool isThreadLocal = getThreadsPerWarp(srcType)[axis] == 1 &&
-                       getWarpsPerCTA(srcType)[axis] == 1 &&
-                       getCTASplitNum(srcType.getEncoding())[axis] == 1;
-  if (isThreadLocal)
-    return std::nullopt;
-  return AccumulatedReduce{reduce, update};
-}
-
 class TritonGPUOptimizeThreadLocalityPass
     : public impl::TritonGPUOptimizeThreadLocalityBase<
           TritonGPUOptimizeThreadLocalityPass> {
@@ -305,86 +253,156 @@ class TritonGPUOptimizeThreadLocalityPass
       signalPassFailure();
     }
 
-    // Collect the loops first: rewriting during the walk would invalidate it.
-    SmallVector<scf::ForOp> loops;
-    mod.walk([&](scf::ForOp forOp) -> void { loops.push_back(forOp); });
+    DenseSet<triton::ReduceOp> reduceOps;
+    mod.walk([&](triton::ReduceOp reduce) -> void {
+      auto srcType = cast<RankedTensorType>(reduce.getOperands()[0].getType());
+      auto rank = srcType.getShape().size();
+      auto srcEncoding = srcType.getEncoding();
+      auto reductionOp = getReductionOp(reduce);
+      if (!reductionOp ||
+          !isa<arith::AddFOp, arith::MulFOp, arith::MaximumFOp,
+               arith::MaxNumFOp, arith::MinimumFOp, arith::MinNumFOp>(
+              reductionOp.value()))
+        return;
+      // TODO: relax this restriction
+      if (!(isa<triton::gpu::BlockedEncodingAttr>(srcEncoding) && rank > 1))
+        return;
+      // The code currently assumes that the reduction is happening on the most
+      // inner dim.
+      if (reduce.getAxis() != rank - 1)
+        return;
+      for (auto operand : reduce->getOperands()) {
+        if (!operand.getDefiningOp<triton::LoadOp>())
+          return;
+      }
+      auto elemsPerThread =
+          triton::gpu::getElemsPerThread(srcType)[reduce.getAxis()];
+      // Not worth applying this optimization if there is only one element per
+      // thread on the reduction axis
+      if (elemsPerThread == 1)
+        return;
+      if (!reduce->hasOneUse())
+        return;
+      Operation *user = *(reduce->getUsers().begin());
+      if (!user->hasOneUse())
+        return;
+      OpOperand &yieldOpOperand = *(user->getUses().begin());
+      auto yieldOp = dyn_cast<scf::YieldOp>(yieldOpOperand.getOwner());
+      if (!yieldOp)
+        return;
+      // Get the parent forOp for the yield and ensure the reduce is inside the
+      // forOp block
+      auto forOp = dyn_cast<scf::ForOp>(yieldOp->getParentOp());
+      if (!forOp)
+        return;
+      if (reduce->getBlock() != forOp.getBody())
+        return;
+      auto argNum = yieldOpOperand.getOperandNumber();
+      auto oldAccum = forOp.getInitArgs()[argNum];
+      auto cstOp = oldAccum.getDefiningOp<arith::ConstantOp>();
+      if (!cstOp)
+        return;
+      reduceOps.insert(reduce);
+    });
 
     IRRewriter builder(&getContext());
-    for (scf::ForOp forOp : loops) {
-      // iterate over original iter args (each time forOp is rewritten, the
-      // new accumulator is appended to the arg list)
-      unsigned iterArgNum = forOp.getInitArgs().size();
-      for (unsigned argIdx = 0; argIdx != iterArgNum; ++argIdx) {
-        auto match = matchAccumulatedReduce(forOp, argIdx);
-        if (!match)
-          continue;
-        triton::ReduceOp reduce = match->reduce;
-        Operation *oldUpdate = match->update;
-        builder.setInsertionPoint(reduce);
-        auto srcType =
-            cast<RankedTensorType>(reduce.getOperands()[0].getType());
-        auto srcShape = srcType.getShape();
-        auto rank = srcShape.size();
-        // create new layouts
-        auto blocked3d = getThreadLocalityOptimizedEncoding(reduce);
-        auto viewOpTensorShape = getThreadLocalityOptimizedShape(reduce);
-        auto viewOpTensorType = RankedTensorType::get(
-            viewOpTensorShape, srcType.getElementType(), blocked3d);
-        auto slice2d = triton::gpu::SliceEncodingAttr::get(reduce.getContext(),
-                                                           rank, blocked3d);
-        auto blockArgNum = argIdx + forOp.getNumInductionVars();
-        // get oldAccum
-        auto oldAccum = forOp.getInitArgs()[argIdx];
-        // get old loop yield
-        auto oldYield = cast<scf::YieldOp>(forOp.getBody()->getTerminator());
-        // create newAccum initialization
-        auto newAccum =
-            createAccum(builder, reduce, forOp, viewOpTensorShape, slice2d);
-        // create new loop by copying the old for op signature and appending
-        // newAccum to the block arguments
-        auto newLoop = replaceForOpWithNewSignature(
-            builder, forOp, ValueRange{newAccum->getResult(0)});
-        // create thread local reduction (also adds viewOps)
-        auto newReduce = createReduce(builder, reduce, viewOpTensorType);
+    for (auto reduce : reduceOps) {
+      builder.setInsertionPoint(reduce);
+      auto srcType = cast<RankedTensorType>(reduce.getOperands()[0].getType());
+      auto srcShape = srcType.getShape();
+      auto srcEncoding = srcType.getEncoding();
+      assert(isa<triton::gpu::BlockedEncodingAttr>(srcEncoding) &&
+             "Thread locality optimization only supports blocked encoding");
+      auto rank = srcShape.size();
+      // create new layouts
+      auto blocked3d = getThreadLocalityOptimizedEncoding(reduce);
+      auto viewOpTensorShape = getThreadLocalityOptimizedShape(reduce);
+      auto viewOpTensorType = RankedTensorType::get(
+          viewOpTensorShape, srcType.getElementType(), blocked3d);
+      auto slice2d = triton::gpu::SliceEncodingAttr::get(mod.getContext(), rank,
+                                                         blocked3d);
+      // Get forOp
+      assert(reduce->hasOneUse());
+      OpOperand &use = *(reduce->getUses().begin());
+      auto operandNumber = use.getOperandNumber();
+      auto oldUpdate = use.getOwner();
+      assert(oldUpdate->getNumOperands() == 2);
+      auto accumOperandNumber = (operandNumber == 0) ? 1 : 0;
+      auto accumOperand = oldUpdate->getOperand(accumOperandNumber);
+      assert(isa<BlockArgument>(accumOperand));
+      auto blockArg = dyn_cast<BlockArgument>(accumOperand);
+      auto blockArgNum = blockArg.getArgNumber();
+      auto forOp = dyn_cast<scf::ForOp>(blockArg.getOwner()->getParentOp());
+      // get oldAccum
+      auto oldAccum =
+          forOp.getInitArgs()[blockArgNum - forOp.getNumInductionVars()];
+      // get old loop user
+      Value loopResult =
+          forOp.getResult(blockArgNum - forOp.getNumInductionVars());
+      assert(loopResult.hasOneUse());
+      OpOperand &loopUse = *(loopResult.getUses().begin());
+      Operation *loopUser = loopUse.getOwner();
+      // get old loop yield
+      auto oldYield = cast<scf::YieldOp>(forOp.getBody()->getTerminator());
+      // create newAccum initialization
+      auto newAccum =
+          createAccum(builder, reduce, oldAccum, viewOpTensorShape, slice2d);
+      // create new loop by copying the old for op signature and appending
+      // newAccum to the block arguments
+      auto newLoop = replaceForOpWithNewSignature(
+          builder, forOp, ValueRange{newAccum->getResult(0)});
+      // create thread local reduction (also adds viewOps)
+      auto newReduce = createReduce(builder, reduce, viewOpTensorType);
 
-        // create new accum update
-        auto newUpdate = createUpdate(builder, newLoop, newReduce, oldUpdate);
-        // create new yield
-        createYield(builder, newLoop, oldYield, newUpdate->getResult(0),
-                    blockArgNum);
-        // create post loop reduction on the original reduce axis
-        auto newReduce2 = createPostLoopReduce(builder, newLoop, reduce);
-        // add convert_layout to get back to original layout, the result layout
-        // should now match the layout of the old accumulator (%init); a
-        // rank-one reduce yields a scalar, which needs no conversion
-        Type destType = newLoop.getResult(argIdx).getType();
-        Operation *newResult = newReduce2;
-        if (isa<RankedTensorType>(destType))
-          newResult = createConvertLayout(builder, destType, newReduce2);
-        // incorporate the original accumulator value into the final result
-        auto finalOp = incorporateOriginalAccumulatorValue(builder, oldUpdate,
-                                                           newResult, oldAccum);
-        // Replace the old accumulator's uses with the final result
-        newLoop.getResult(argIdx).replaceAllUsesWith(finalOp->getResult(0));
+      // create new accum update
+      auto newUpdate = createUpdate(builder, newLoop, newReduce, oldUpdate);
+      // create new yield
+      createYield(builder, newLoop, oldYield, newUpdate->getResult(0),
+                  blockArgNum);
+      // create post loop reduction on the original reduce axis
+      auto newReduce2 = createPostLoopReduce(builder, newLoop, reduce);
+      // add convert_layout to get back to original layout, the result layout
+      // should now match the layout of the old accumulator (%cst)
+      Type destType = loopResult.getType();
+      auto cvtLayout = createConvertLayout(builder, destType, newReduce2);
+      // incorporate the original accumulator value into the final result
+      auto finalOp = incorporateOriginalAccumulatorValue(builder, oldUpdate,
+                                                         cvtLayout, oldAccum);
+      // Replace the old loop user with the final result
+      loopUser->setOperand(loopUse.getOperandNumber(), finalOp->getResult(0));
 
-        // cleanup
-        oldYield.erase();
-        forOp.erase();
-        // continue matching other args on the replaced loop
-        forOp = newLoop;
-      }
+      // cleanup
+      oldYield.erase();
+      forOp.erase();
     }
   };
 
 private:
+  std::optional<Operation *> getReductionOp(triton::ReduceOp reduce) const {
+    auto numRegions = reduce->getNumRegions();
+    if (numRegions != 1)
+      return std::nullopt;
+    Region &region = reduce->getRegion(0);
+    auto numBlocks = region.getBlocks().size();
+    if (numBlocks != 1)
+      return std::nullopt;
+    Block &block = region.front();
+    auto blockWithoutTerminator = block.without_terminator();
+    auto blockSizeWithoutTerminator = std::distance(
+        blockWithoutTerminator.begin(), blockWithoutTerminator.end());
+    if (blockSizeWithoutTerminator != 1)
+      return std::nullopt;
+    Operation *op = &block.front();
+    return std::optional<Operation *>(op);
+  }
   Operation *incorporateOriginalAccumulatorValue(OpBuilder &builder,
                                                  Operation *oldUpdate,
-                                                 Operation *newResult,
+                                                 Operation *cvtLayout,
                                                  Value oldAccum) const {
-    builder.setInsertionPointAfter(newResult);
+    builder.setInsertionPointAfter(cvtLayout);
     IRMapping mapping;
     mapping.map(oldUpdate->getOperand(0), oldAccum);
-    mapping.map(oldUpdate->getOperand(1), newResult->getResult(0));
+    mapping.map(oldUpdate->getOperand(1), cvtLayout->getResult(0));
     auto finalOp = cloneWithInferType(builder, &(*oldUpdate), mapping);
     return finalOp;
   }
@@ -403,7 +421,7 @@ private:
     auto newLoopResult = loop.getResult(resultIndex);
     builder.setInsertionPointAfter(loop);
     IRMapping mapping;
-    mapping.map(reduce.getOperands()[0], newLoopResult);
+    mapping.map(*(reduce.getOperands().begin()), newLoopResult);
     auto newReduce2 = cloneWithInferType(builder, &(*reduce), mapping);
     return newReduce2;
   }
@@ -426,9 +444,10 @@ private:
     auto blockArgNum = loop.getBody()->getNumArguments() - 1;
     auto newArg = loop.getBody()->getArgument(blockArgNum);
     builder.setInsertionPointAfter(newReduce);
-    Operation *newUpdate = builder.clone(*oldUpdate);
-    newUpdate->setOperands({newArg, newReduce->getResult(0)});
-    newUpdate->getResult(0).setType(newArg.getType());
+    IRMapping mapping;
+    mapping.map(oldUpdate->getOperand(0), newArg);
+    mapping.map(oldUpdate->getOperand(1), newReduce->getResult(0));
+    auto newUpdate = cloneWithInferType(builder, oldUpdate, mapping);
     return newUpdate;
   }
 
@@ -443,42 +462,34 @@ private:
     int64_t sizePerThread = std::min<int64_t>(
         blocked.getSizePerThread()[reduce.getAxis()], elemsPerThread);
 
-    // [.., N, ..] -> [.., ctaSplit, R, H, S, ..] -> [.., ctaSplit, H, .., R, S]
-    //   -> [.., ctaSplit * H, .., R * S].
-    unsigned axis = reduce.getAxis();
-    int64_t ctaSplit =
-        std::min<int64_t>(getCTASplitNum(blocked)[axis], dstShape[axis]);
-    int64_t R = elemsPerThread / sizePerThread; // register wraparounds
-    int64_t H = dstShape[axis] / ctaSplit;      // warps & threads
+    // Group register-owned elements without permuting non-reduction axes:
+    // [..., N] -> [..., R, H, S] -> [..., H, R, S] -> [..., H, R * S].
     SmallVector<int64_t> factorShape(srcType.getShape().begin(),
                                      srcType.getShape().end());
-    // [.., ctaSplit, R, H, S, ..]
-    factorShape[axis] = ctaSplit;
-    factorShape.insert(factorShape.begin() + axis + 1, {R, H, sizePerThread});
-    SmallVector<int32_t> transposeOrder(rank + 3);
+    factorShape.back() = elemsPerThread / sizePerThread;
+    factorShape.push_back(dstShape[rank - 1]);
+    factorShape.push_back(sizePerThread);
+    SmallVector<int32_t> transposeOrder(rank + 2);
     std::iota(transposeOrder.begin(), transposeOrder.end(), 0);
-    // [.., ctaSplit, (R, H), S, ..] -> [.., ctaSplit, (H, R), S, ..]
-    std::swap(transposeOrder[axis + 1], transposeOrder[axis + 2]);
-    // [.., ctaSplit, H, (R, S), ..] -> [.., ctaSplit, H, .., (R, S)]
-    std::rotate(transposeOrder.begin() + axis + 2,
-                transposeOrder.begin() + axis + 4, transposeOrder.end());
+    std::swap(transposeOrder[rank - 1], transposeOrder[rank]);
 
     builder.setInsertionPointAfter(reduce);
-    Value operand = reduce.getOperands()[0];
-    auto factored = triton::ReshapeOp::create(builder, reduce.getLoc(),
-                                              factorShape, operand);
-    auto transposed = triton::TransOp::create(builder, reduce.getLoc(),
-                                              factored, transposeOrder);
-    auto viewOp = triton::ReshapeOp::create(builder, reduce.getLoc(), dstShape,
-                                            transposed);
-    viewOp.setEfficientLayout(true);
-    auto converted =
-        ConvertLayoutOp::create(builder, reduce.getLoc(), dstType, viewOp);
-    assert(cvtReordersRegisters(viewOp.getType(), converted.getType()) &&
-           "thread locality optimization requires a register-only layout "
-           "conversion");
     IRMapping mapping;
-    mapping.map(operand, converted);
+    for (auto operand : reduce.getOperands()) {
+      auto factored = triton::ReshapeOp::create(builder, reduce.getLoc(),
+                                                factorShape, operand);
+      auto transposed = triton::TransOp::create(builder, reduce.getLoc(),
+                                                factored, transposeOrder);
+      auto viewOp = triton::ReshapeOp::create(builder, reduce.getLoc(),
+                                              dstShape, transposed);
+      viewOp.setEfficientLayout(true);
+      auto converted =
+          ConvertLayoutOp::create(builder, reduce.getLoc(), dstType, viewOp);
+      assert(cvtReordersRegisters(viewOp.getType(), converted.getType()) &&
+             "thread locality optimization requires a register-only layout "
+             "conversion");
+      mapping.map(operand, converted);
+    }
 
     auto newReduce = cloneWithInferType(builder, &(*reduce), mapping);
     newReduce->setAttr("axis", builder.getI32IntegerAttr(rank));
@@ -489,27 +500,54 @@ private:
           newReduce->getContext(), newReduce->getLoc(),
           newReduce->getOperands(), newReduce->getAttrDictionary(),
           newReduce->getPropertiesStorage(), newReduce->getRegions(), newTypes);
-      if (succeeded(success))
-        newReduce->getResult(0).setType(newTypes[0]);
+      if (succeeded(success)) {
+        for (size_t i = 0; i < newTypes.size(); i++)
+          newReduce->getResult(i).setType(newTypes[i]);
+      }
     }
     return newReduce;
   }
 
+  // Work around the lack of support for MaxNumFOp and MinNumFOp in
+  // arith::getNeutralElement.
+  std::optional<TypedAttr> getNeutralElement(Operation *op) const {
+    if (isa<arith::MaxNumFOp, arith::MinNumFOp>(op)) {
+      OpBuilder builder(op->getContext());
+
+      Type resultType = op->getResult(0).getType();
+      const llvm::fltSemantics &semantic =
+          llvm::cast<FloatType>(resultType).getFloatSemantics();
+      if (isa<arith::MaxNumFOp>(op)) {
+        return builder.getFloatAttr(
+            resultType, APFloat::getInf(semantic, /*Negative=*/true));
+      }
+      if (isa<arith::MinNumFOp>(op)) {
+        return builder.getFloatAttr(
+            resultType, APFloat::getInf(semantic, /*Negative=*/false));
+      }
+    } else {
+      return mlir::arith::getNeutralElement(op);
+    }
+    llvm_unreachable("Unhandled reduction op");
+    return std::nullopt;
+  }
+
   Operation *createAccum(OpBuilder &builder, triton::ReduceOp reduce,
-                         scf::ForOp forOp, SmallVector<int64_t> &shape,
+                         Value &oldAccum, SmallVector<int64_t> &shape,
                          Attribute &slice2d) const {
     // Drop the last dimension (thread locality dimension)
     SmallVector<int64_t> accumShape(shape.begin(), shape.end() - 1);
-    auto elemType = cast<RankedTensorType>(reduce.getOperands()[0].getType())
-                        .getElementType();
+    auto elemType = cast<RankedTensorType>(oldAccum.getType()).getElementType();
     // Create tensor type for the new accumulator
     auto accumType = RankedTensorType::get(accumShape, elemType, slice2d);
     // Create new accumulator
-    builder.setInsertionPoint(forOp);
-    Operation *reductionOp = reduce.getSingleCombiner();
-    auto neutralVal = arith::getNeutralElement(reductionOp);
+    builder.setInsertionPointAfter(oldAccum.getDefiningOp());
+    auto reductionOp = getReductionOp(reduce);
+    assert(reductionOp && "Processing a reduce that is not supported!");
+    auto neutralVal = getNeutralElement(reductionOp.value());
+    assert(neutralVal && "Could not find neutral value for reduction op!");
     auto denseAttr = DenseElementsAttr::get(accumType, neutralVal.value());
-    auto newAccum = arith::ConstantOp::create(builder, forOp.getLoc(),
+    auto newAccum = arith::ConstantOp::create(builder, oldAccum.getLoc(),
                                               accumType, denseAttr);
     return newAccum;
   }

--- a/test/TritonGPU/optimize-locality.mlir
+++ b/test/TritonGPU/optimize-locality.mlir
@@ -4,8 +4,8 @@
 // CHECK: %[[INIT_ARG:.*]] = arith.constant dense<0.000000e+00>
 // CHECK: %[[LOOP_OUTPUT:.*]] = scf.for {{.*}} iter_args(%[[FOR_ARG:.*]] = %[[INIT_ARG]]) -> {{.*}}
 // CHECK: %[[LOAD:.*]] = tt.load
-// CHECK: %[[FACTORED:.*]] = tt.reshape %[[LOAD]] : {{.*}} -> tensor<{{32x1x2x32x2xf32.*}}>
-// CHECK-NEXT: %[[TRANSPOSED:.*]] = tt.trans %[[FACTORED]] {order = array<i32: 0, 1, 3, 2, 4>}
+// CHECK: %[[FACTORED:.*]] = tt.reshape %[[LOAD]] : {{.*}} -> tensor<{{32x2x32x2xf32.*}}>
+// CHECK-NEXT: %[[TRANSPOSED:.*]] = tt.trans %[[FACTORED]] {order = array<i32: 0, 2, 1, 3>}
 // CHECK-NEXT: tt.reshape %[[TRANSPOSED]] efficient_layout : {{.*}} -> tensor<{{32x32x4xf32.*}}>
 // CHECK: %[[REDUCE:.*]] = "tt.reduce"({{%.*}}) <{axis = 2 : i32}>
 // CHECK: arith.addf
@@ -55,8 +55,8 @@ module attributes {"ttg.target" = "cuda:80", "ttg.num-ctas" = 1 : i32, "ttg.num-
 // -----
 
 // CHECK-LABEL: positive_zero_accumulator
-// CHECK-DAG: %[[CST:.*]] = arith.constant dense<0.000000e+00> : tensor<32xf32
-// CHECK-DAG: %[[CST1:.*]] = arith.constant dense<0.000000e+00> : tensor<32x32xf32
+// CHECK: %[[CST:.*]] = arith.constant dense<0.000000e+00>
+// CHECK-NEXT: %[[CST1:.*]] = arith.constant dense<0.000000e+00>
 // CHECK: %[[LOOP_OUTPUT:.*]] = scf.for {{.*}} iter_args(%[[FOR_ARG:.*]] = %[[CST1]]) -> {{.*}}
 // CHECK: tt.load
 // CHECK: tt.reshape
@@ -109,8 +109,8 @@ module attributes {"ttg.target" = "cuda:80", "ttg.num-ctas" = 1 : i32, "ttg.num-
 
 // CHECK-LABEL: @row_major_register_grouping
 // CHECK: %[[LOAD:.*]] = tt.load
-// CHECK-NEXT: %[[FACTORED:.*]] = tt.reshape %[[LOAD]] : {{.*}} -> tensor<{{8x1x2x32x4xf32.*}}>
-// CHECK-NEXT: %[[TRANSPOSED:.*]] = tt.trans %[[FACTORED]] {order = array<i32: 0, 1, 3, 2, 4>}
+// CHECK-NEXT: %[[FACTORED:.*]] = tt.reshape %[[LOAD]] : {{.*}} -> tensor<{{8x2x32x4xf32.*}}>
+// CHECK-NEXT: %[[TRANSPOSED:.*]] = tt.trans %[[FACTORED]] {order = array<i32: 0, 2, 1, 3>}
 // CHECK-NEXT: %[[RESHAPED:.*]] = tt.reshape %[[TRANSPOSED]] efficient_layout : {{.*}} -> tensor<{{8x32x8xf32.*}}>
 // CHECK: %[[REDUCED:.*]] = "tt.reduce"({{%.*}}) <{axis = 2 : i32}>
 // CHECK: scf.yield
@@ -139,128 +139,27 @@ module attributes {"ttg.target" = "cuda:80", "ttg.num-ctas" = 1 : i32, "ttg.num-
 
 // -----
 
-// The accumulator init is a function argument rather than a constant.
-// CHECK-LABEL: @non_constant_accumulator_init
-// CHECK-SAME: %[[INIT:[a-z0-9]+]]: tensor<8xf32
-// CHECK: %[[NEW_INIT:.*]] = arith.constant dense<0.000000e+00> : tensor<8x32xf32
-// CHECK: %[[LOOP_OUTPUT:.*]] = scf.for {{.*}} iter_args(%[[FOR_ARG:.*]] = %[[NEW_INIT]])
-// CHECK: "tt.reduce"({{%.*}}) <{axis = 2 : i32}>
-// CHECK: scf.yield
-// CHECK: %[[FINAL_REDUCE:.*]] = "tt.reduce"(%[[LOOP_OUTPUT]]) <{axis = 1 : i32}>
-// CHECK: %[[CVT:.*]] = ttg.convert_layout %[[FINAL_REDUCE]]
-// CHECK: %[[RESULT:.*]] = arith.addf %[[INIT]], %[[CVT]]
-// CHECK: tt.store {{.*}}, %[[RESULT]]
-#blocked = #ttg.blocked<{sizePerThread = [1, 4], threadsPerWarp = [1, 32], warpsPerCTA = [1, 1], order = [1, 0]}>
-#slice = #ttg.slice<{dim = 1, parent = #blocked}>
-module attributes {"ttg.target" = "cuda:80", "ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 1 : i32, "ttg.threads-per-warp" = 32 : i32} {
-  tt.func public @non_constant_accumulator_init(%init: tensor<8xf32, #slice>, %input: tensor<8x256x!tt.ptr<f32>, #blocked>, %output: tensor<8x!tt.ptr<f32>, #slice>, %count: i32) {
-    %start = arith.constant 0 : i32
-    %step = arith.constant 1 : i32
-    %result = scf.for %index = %start to %count step %step iter_args(%accumulator = %init) -> (tensor<8xf32, #slice>) : i32 {
-      %values = tt.load %input : tensor<8x256x!tt.ptr<f32>, #blocked>
-      %reduced = "tt.reduce"(%values) <{axis = 1 : i32}> ({
-      ^bb0(%left: f32, %right: f32):
-        %sum = arith.addf %left, %right : f32
-        tt.reduce.return %sum : f32
-      }) : (tensor<8x256xf32, #blocked>) -> tensor<8xf32, #slice>
-      %updated = arith.addf %accumulator, %reduced : tensor<8xf32, #slice>
-      scf.yield %updated : tensor<8xf32, #slice>
-    }
-    tt.store %output, %result : tensor<8x!tt.ptr<f32>, #slice>
-    tt.return
-  }
-}
-
-// -----
-
-// The max/minnumf accumulator is seeded with quiet NaN, not -/+inf
-// CHECK-LABEL: @maxnum_accumulator
-// CHECK: %[[SEED:.*]] = arith.constant dense<0xFFC00000>
-// CHECK: %[[LOOP_OUTPUT:.*]] = scf.for {{.*}} iter_args(%[[FOR_ARG:.*]] = %[[SEED]]) -> {{.*}}
-// CHECK: %[[REDUCE:.*]] = "tt.reduce"({{%.*}}) <{axis = 2 : i32}>
-// CHECK: arith.maxnumf
-// CHECK: arith.maxnumf %[[FOR_ARG]], %[[REDUCE]]
-// CHECK-NEXT: scf.yield
-// CHECK: "tt.reduce"(%[[LOOP_OUTPUT]]) <{axis = 1 : i32}>
-#blocked = #ttg.blocked<{sizePerThread = [1, 4], threadsPerWarp = [1, 32], warpsPerCTA = [1, 1], order = [1, 0]}>
-#slice = #ttg.slice<{dim = 1, parent = #blocked}>
-module attributes {"ttg.target" = "cuda:80", "ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 1 : i32, "ttg.threads-per-warp" = 32 : i32} {
-  tt.func public @maxnum_accumulator(%input: tensor<8x256x!tt.ptr<f32>, #blocked>, %output: tensor<8x!tt.ptr<f32>, #slice>, %count: i32) {
-    %init = arith.constant dense<0xFF800000> : tensor<8xf32, #slice>
-    %start = arith.constant 0 : i32
-    %step = arith.constant 1 : i32
-    %result = scf.for %index = %start to %count step %step iter_args(%accumulator = %init) -> (tensor<8xf32, #slice>) : i32 {
-      %values = tt.load %input : tensor<8x256x!tt.ptr<f32>, #blocked>
-      %reduced = "tt.reduce"(%values) <{axis = 1 : i32}> ({
-      ^bb0(%left: f32, %right: f32):
-        %max = arith.maxnumf %left, %right : f32
-        tt.reduce.return %max : f32
-      }) : (tensor<8x256xf32, #blocked>) -> tensor<8xf32, #slice>
-      %updated = arith.maxnumf %accumulator, %reduced : tensor<8xf32, #slice>
-      scf.yield %updated : tensor<8xf32, #slice>
-    }
-    tt.store %output, %result : tensor<8x!tt.ptr<f32>, #slice>
-    tt.return
-  }
-}
-
-// -----
-
-// CHECK-LABEL: @integer_accumulator
-// CHECK: %[[SEED:.*]] = arith.constant dense<0> : tensor<8x32xi32
-// CHECK: %[[LOOP_OUTPUT:.*]] = scf.for {{.*}} iter_args(%[[FOR_ARG:.*]] = %[[SEED]]) -> {{.*}}
-// CHECK: %[[REDUCE:.*]] = "tt.reduce"({{%.*}}) <{axis = 2 : i32}>
-// CHECK: arith.addi
-// CHECK: arith.addi %[[FOR_ARG]], %[[REDUCE]]
-// CHECK-NEXT: scf.yield
-// CHECK: %[[FINAL_REDUCE:.*]] = "tt.reduce"(%[[LOOP_OUTPUT]]) <{axis = 1 : i32}>
-// CHECK: %[[CVT:.*]] = ttg.convert_layout %[[FINAL_REDUCE]]
-// CHECK: tt.store {{.*}}, %[[CVT]]
-#blocked = #ttg.blocked<{sizePerThread = [1, 4], threadsPerWarp = [1, 32], warpsPerCTA = [1, 1], order = [1, 0]}>
-#slice = #ttg.slice<{dim = 1, parent = #blocked}>
-module attributes {"ttg.target" = "cuda:80", "ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 1 : i32, "ttg.threads-per-warp" = 32 : i32} {
-  tt.func public @integer_accumulator(%input: tensor<8x256x!tt.ptr<i32>, #blocked>, %output: tensor<8x!tt.ptr<i32>, #slice>, %count: i32) {
-    %zero = arith.constant dense<0> : tensor<8xi32, #slice>
-    %start = arith.constant 0 : i32
-    %step = arith.constant 1 : i32
-    %result = scf.for %index = %start to %count step %step iter_args(%accumulator = %zero) -> (tensor<8xi32, #slice>) : i32 {
-      %values = tt.load %input : tensor<8x256x!tt.ptr<i32>, #blocked>
-      %reduced = "tt.reduce"(%values) <{axis = 1 : i32}> ({
-      ^bb0(%left: i32, %right: i32):
-        %sum = arith.addi %left, %right : i32
-        tt.reduce.return %sum : i32
-      }) : (tensor<8x256xi32, #blocked>) -> tensor<8xi32, #slice>
-      %updated = arith.addi %accumulator, %reduced : tensor<8xi32, #slice>
-      scf.yield %updated : tensor<8xi32, #slice>
-    }
-    tt.store %output, %result : tensor<8x!tt.ptr<i32>, #slice>
-    tt.return
-  }
-}
-
-// -----
-
 // CHECK-LABEL: @preserve_rows_when_reordering_registers
 // CHECK: %[[LOAD:.*]] = tt.load
-// CHECK-NEXT: %[[FACTORED:.*]] = tt.reshape %[[LOAD]] : {{.*}} -> tensor<{{256x1x2x2x1xf32.*}}>
-// CHECK-NEXT: %[[TRANSPOSED:.*]] = tt.trans %[[FACTORED]] {order = array<i32: 0, 1, 3, 2, 4>}
-// CHECK-NEXT: %[[RESHAPED:.*]] = tt.reshape %[[TRANSPOSED]] efficient_layout : {{.*}} -> tensor<{{256x2x2xf32.*}}>
-// CHECK-NEXT: %[[REORDERED:.*]] = ttg.convert_layout %[[RESHAPED]] : tensor<{{256x2x2xf32.*}}> -> tensor<{{256x2x2xf32.*}}>
+// CHECK-NEXT: %[[FACTORED:.*]] = tt.reshape %[[LOAD]] : {{.*}} -> tensor<{{256x2x1x1xf32.*}}>
+// CHECK-NEXT: %[[TRANSPOSED:.*]] = tt.trans %[[FACTORED]] {order = array<i32: 0, 2, 1, 3>}
+// CHECK-NEXT: %[[RESHAPED:.*]] = tt.reshape %[[TRANSPOSED]] efficient_layout : {{.*}} -> tensor<{{256x1x2xf32.*}}>
+// CHECK-NEXT: %[[REORDERED:.*]] = ttg.convert_layout %[[RESHAPED]] : tensor<{{256x1x2xf32.*}}> -> tensor<{{256x1x2xf32.*}}>
 // CHECK-NEXT: "tt.reduce"(%[[REORDERED]]) <{axis = 2 : i32}>
-#blocked = #ttg.blocked<{sizePerThread = [4, 1], threadsPerWarp = [16, 2], warpsPerCTA = [1, 1], order = [0, 1]}>
+#blocked = #ttg.blocked<{sizePerThread = [4, 1], threadsPerWarp = [32, 1], warpsPerCTA = [1, 1], order = [0, 1]}>
 #slice = #ttg.slice<{dim = 1, parent = #blocked}>
 module attributes {"ttg.target" = "cuda:80", "ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 1 : i32, "ttg.threads-per-warp" = 32 : i32} {
-  tt.func public @preserve_rows_when_reordering_registers(%input: tensor<256x4x!tt.ptr<f32>, #blocked>, %output: tensor<256x!tt.ptr<f32>, #slice>, %count: i32) {
+  tt.func public @preserve_rows_when_reordering_registers(%input: tensor<256x2x!tt.ptr<f32>, #blocked>, %output: tensor<256x!tt.ptr<f32>, #slice>, %count: i32) {
     %zero = arith.constant dense<0.000000e+00> : tensor<256xf32, #slice>
     %start = arith.constant 0 : i32
     %step = arith.constant 1 : i32
     %result = scf.for %index = %start to %count step %step iter_args(%accumulator = %zero) -> (tensor<256xf32, #slice>) : i32 {
-      %values = tt.load %input : tensor<256x4x!tt.ptr<f32>, #blocked>
+      %values = tt.load %input : tensor<256x2x!tt.ptr<f32>, #blocked>
       %reduced = "tt.reduce"(%values) <{axis = 1 : i32}> ({
       ^bb0(%left: f32, %right: f32):
         %sum = arith.addf %left, %right : f32
         tt.reduce.return %sum : f32
-      }) : (tensor<256x4xf32, #blocked>) -> tensor<256xf32, #slice>
+      }) : (tensor<256x2xf32, #blocked>) -> tensor<256xf32, #slice>
       %updated = arith.addf %accumulator, %reduced : tensor<256xf32, #slice>
       scf.yield %updated : tensor<256xf32, #slice>
     }
@@ -273,22 +172,21 @@ module attributes {"ttg.target" = "cuda:80", "ttg.num-ctas" = 1 : i32, "ttg.num-
 
 // The yielded accumulator belongs to a different loop than the one enclosing the reduce.
 // CHECK-LABEL: @reduce_outside_accumulator_loop
-// CHECK-NOT: tt.reshape
 // CHECK: "tt.reduce"({{.*}}) <{axis = 1 : i32}>
-#blocked = #ttg.blocked<{sizePerThread = [1, 2], threadsPerWarp = [16, 2], warpsPerCTA = [1, 1], order = [1, 0]}>
+#blocked = #ttg.blocked<{sizePerThread = [1, 2], threadsPerWarp = [32, 1], warpsPerCTA = [1, 1], order = [1, 0]}>
 #slice = #ttg.slice<{dim = 1, parent = #blocked}>
 module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 1 : i32, "ttg.threads-per-warp" = 32 : i32} {
-  tt.func public @reduce_outside_accumulator_loop(%input: tensor<32x4x!tt.ptr<f32>, #blocked>, %output: tensor<32x!tt.ptr<f32>, #slice>, %count: i32) {
+  tt.func public @reduce_outside_accumulator_loop(%input: tensor<32x2x!tt.ptr<f32>, #blocked>, %output: tensor<32x!tt.ptr<f32>, #slice>, %count: i32) {
     %zero = arith.constant dense<0.000000e+00> : tensor<32xf32, #slice>
     %start = arith.constant 0 : i32
     %step = arith.constant 1 : i32
     scf.for %index = %start to %count step %step : i32 {
-      %values = tt.load %input : tensor<32x4x!tt.ptr<f32>, #blocked>
+      %values = tt.load %input : tensor<32x2x!tt.ptr<f32>, #blocked>
       %reduced = "tt.reduce"(%values) <{axis = 1 : i32}> ({
       ^bb0(%left: f32, %right: f32):
         %sum = arith.addf %left, %right : f32
         tt.reduce.return %sum : f32
-      }) : (tensor<32x4xf32, #blocked>) -> tensor<32xf32, #slice>
+      }) : (tensor<32x2xf32, #blocked>) -> tensor<32xf32, #slice>
       %result = scf.for %inner = %start to %count step %step iter_args(%accumulator = %zero) -> (tensor<32xf32, #slice>) : i32 {
         %updated = arith.addf %accumulator, %reduced : tensor<32xf32, #slice>
         scf.yield %updated : tensor<32xf32, #slice>
@@ -403,7 +301,7 @@ module attributes {"ttg.target" = "cuda:80", "ttg.num-ctas" = 1 : i32, "ttg.num-
 // CHECK: %[[INIT_ARG:.*]] = arith.constant dense<0xFF800000>
 // CHECK: %[[LOOP_OUTPUT:.*]] = scf.for {{.*}} iter_args(%[[FOR_ARG:.*]] = %[[INIT_ARG]]) -> {{.*}}
 // CHECK: %[[LOAD:.*]] = tt.load
-// CHECK: tt.reshape %[[LOAD]] : {{.*}} -> tensor<{{32x1x2x32x2xf32.*}}>
+// CHECK: tt.reshape %[[LOAD]] : {{.*}} -> tensor<{{32x2x32x2xf32.*}}>
 // CHECK: tt.reshape {{%.*}} efficient_layout : {{.*}} -> tensor<{{32x32x4xf32.*}}>
 // CHECK: %[[REDUCE:.*]] = "tt.reduce"({{%.*}}) <{axis = 2 : i32}>
 // CHECK: arith.maximumf
@@ -454,8 +352,8 @@ module attributes {"ttg.target" = "cuda:80", "ttg.num-ctas" = 1 : i32, "ttg.num-
 // -----
 
 // CHECK-LABEL: max_reduce_zero_int_accumulator
-// CHECK-DAG: %[[CST:.*]] = arith.constant dense<0.000000e+00>
-// CHECK-DAG: %[[CST1:.*]] = arith.constant dense<0xFF800000>
+// CHECK: %[[CST:.*]] = arith.constant dense<0.000000e+00>
+// CHECK-NEXT: %[[CST1:.*]] = arith.constant dense<0xFF800000>
 // CHECK: %[[LOOP_OUTPUT:.*]] = scf.for {{.*}} iter_args(%[[FOR_ARG:.*]] = %[[CST1]]) -> {{.*}}
 // CHECK: tt.load
 // CHECK: tt.reshape
@@ -511,7 +409,7 @@ module attributes {"ttg.target" = "cuda:80", "ttg.num-ctas" = 1 : i32, "ttg.num-
 // CHECK: %[[CST:.*]] = arith.constant dense<0x7F800000>
 // CHECK: %[[LOOP_OUTPUT:.*]] = scf.for {{.*}} iter_args(%[[FOR_ARG:.*]] = %[[CST]]) -> {{.*}}
 // CHECK: %[[LOAD:.*]] = tt.load
-// CHECK: tt.reshape %[[LOAD]] : {{.*}} -> tensor<{{32x1x2x32x2xf32.*}}>
+// CHECK: tt.reshape %[[LOAD]] : {{.*}} -> tensor<{{32x2x32x2xf32.*}}>
 // CHECK: tt.reshape {{%.*}} efficient_layout : {{.*}} -> tensor<{{32x32x4xf32.*}}>
 // CHECK: %[[REDUCE:.*]] = "tt.reduce"({{%.*}}) <{axis = 2 : i32}>
 // CHECK: arith.minimumf
@@ -562,8 +460,8 @@ module attributes {"ttg.target" = "cuda:80", "ttg.num-ctas" = 1 : i32, "ttg.num-
 // -----
 
 // CHECK-LABEL: min_reduce_zero_int_accumulator
-// CHECK-DAG: %[[CST:.*]] = arith.constant dense<0.000000e+00>
-// CHECK-DAG: %[[CST1:.*]] = arith.constant dense<0x7F800000>
+// CHECK: %[[CST:.*]] = arith.constant dense<0.000000e+00>
+// CHECK-NEXT: %[[CST1:.*]] = arith.constant dense<0x7F800000>
 // CHECK: %[[LOOP_OUTPUT:.*]] = scf.for {{.*}} iter_args(%[[FOR_ARG:.*]] = %[[CST1]]) -> {{.*}}
 // CHECK: tt.load
 // CHECK: tt.reshape
@@ -619,7 +517,7 @@ module attributes {"ttg.target" = "cuda:80", "ttg.num-ctas" = 1 : i32, "ttg.num-
 // CHECK: %[[CST:.*]] = arith.constant dense<1.000000e+00>
 // CHECK: %[[LOOP_OUTPUT:.*]] = scf.for {{.*}} iter_args(%[[FOR_ARG:.*]] = %[[CST]]) -> {{.*}}
 // CHECK: %[[LOAD:.*]] = tt.load
-// CHECK: tt.reshape %[[LOAD]] : {{.*}} -> tensor<{{32x1x2x32x2xf32.*}}>
+// CHECK: tt.reshape %[[LOAD]] : {{.*}} -> tensor<{{32x2x32x2xf32.*}}>
 // CHECK: tt.reshape {{%.*}} efficient_layout : {{.*}} -> tensor<{{32x32x4xf32.*}}>
 // CHECK: %[[REDUCE:.*]] = "tt.reduce"({{%.*}}) <{axis = 2 : i32}>
 // CHECK: arith.mulf
@@ -670,8 +568,8 @@ module attributes {"ttg.target" = "cuda:80", "ttg.num-ctas" = 1 : i32, "ttg.num-
 // -----
 
 // CHECK-LABEL: mul_reduce_zero_int_accumulator
-// CHECK-DAG: %[[CST:.*]] = arith.constant dense<0.000000e+00>
-// CHECK-DAG: %[[CST1:.*]] = arith.constant dense<1.000000e+00>
+// CHECK: %[[CST:.*]] = arith.constant dense
+// CHECK-NEXT: %[[CST1:.*]] = arith.constant dense<1.000000e+00>
 // CHECK: %[[LOOP_OUTPUT:.*]] = scf.for {{.*}} iter_args(%[[FOR_ARG:.*]] = %[[CST1]]) -> {{.*}}
 // CHECK: tt.load
 // CHECK: tt.reshape
@@ -724,29 +622,19 @@ module attributes {"ttg.target" = "cuda:80", "ttg.num-ctas" = 1 : i32, "ttg.num-
 
 // -----
 
-// The reduce operand comes from an elementwise op rather than a load
-// CHECK-LABEL: elementwise_operand
-// CHECK-DAG: %[[ORIG_INIT:.*]] = arith.constant dense<0.000000e+00>
-// CHECK-DAG: %[[INIT_ARG:.*]] = arith.constant dense<0xFF800000>
-// CHECK: %[[LOOP_OUTPUT:.*]] = scf.for {{.*}} iter_args(%[[FOR_ARG:.*]] = %[[INIT_ARG]]) -> {{.*}}
+// CHECK-LABEL: remains_unchanged
+// CHECK: %[[CST:.*]] = arith.constant dense
+// CHECK: %[[LOOP_OUTPUT:.*]] = scf.for {{.*}} iter_args(%[[FOR_ARG:.*]] = %[[CST]]) -> {{.*}}
 // CHECK: %[[LOAD:.*]] = tt.load
 // CHECK: %[[MULF:.*]] = arith.mulf %[[LOAD]], %[[LOAD]]
-// CHECK: tt.reshape %[[MULF]] : {{.*}} -> tensor<{{32x1x2x32x2xf32.*}}>
-// CHECK: tt.reshape {{%.*}} efficient_layout : {{.*}} -> tensor<{{32x32x4xf32.*}}>
-// CHECK: %[[REDUCE:.*]] = "tt.reduce"({{%.*}}) <{axis = 2 : i32}>
+// CHECK-NEXT: %[[REDUCE:.*]] = "tt.reduce"(%[[MULF]]) <{axis = 1 : i32}>
 // CHECK: arith.maximumf
 // CHECK: arith.maximumf %[[FOR_ARG]], %[[REDUCE]]
 // CHECK-NEXT: scf.yield
-// CHECK: %[[FINAL_REDUCE:.*]] = "tt.reduce"(%[[LOOP_OUTPUT]]) <{axis = 1 : i32}>
-// CHECK: arith.maximumf
-// CHECK: %[[CVT:.*]] = ttg.convert_layout %[[FINAL_REDUCE]]
-// CHECK: %[[WITH_INIT:.*]] = arith.maximumf %[[CVT]], %[[ORIG_INIT]]
-// CHECK: %[[OUTPUT:.*]] = ttg.convert_layout %[[WITH_INIT]]
-// CHECK: tt.store {{%.*}}, %[[OUTPUT]]
 #blocked = #ttg.blocked<{sizePerThread = [1, 2], threadsPerWarp = [1, 32], warpsPerCTA = [4, 1], order = [1, 0]}>
 #blocked1 = #ttg.blocked<{sizePerThread = [1], threadsPerWarp = [32], warpsPerCTA = [4], order = [0]}>
 module attributes {"ttg.target" = "cuda:80", "ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, "ttg.threads-per-warp" = 32 : i32} {
-  tt.func public @elementwise_operand(
+  tt.func public @remains_unchanged(
     %arg0: !tt.ptr<f32> {tt.divisibility = 16 : i32},
     %arg1: !tt.ptr<f32> {tt.divisibility = 16 : i32},
     %arg2: i32 {tt.divisibility = 16 : i32, tt.max_divisibility = 8 : i32},
@@ -995,538 +883,4 @@ tt.func @skip_optimize_on_1d_tensor(%arg0: tensor<256xf32, #blocked>, %arg1: ten
   tt.return %0 : tensor<8xf32, #blocked>
 }
 
-}
-
-// -----
-
-// A multi-operand reduce must be left untouched
-// CHECK-LABEL: @two_operand_reduce
-// CHECK-NOT: tt.reshape
-// CHECK: "tt.reduce"({{.*}}, {{.*}}) <{axis = 1 : i32}>
-#blocked = #ttg.blocked<{sizePerThread = [1, 2], threadsPerWarp = [16, 2], warpsPerCTA = [1, 1], order = [1, 0]}>
-#slice = #ttg.slice<{dim = 1, parent = #blocked}>
-module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 1 : i32, "ttg.threads-per-warp" = 32 : i32} {
-  tt.func public @two_operand_reduce(%values: tensor<32x4x!tt.ptr<f32>, #blocked>, %tags: tensor<32x4x!tt.ptr<f32>, #blocked>, %output: tensor<32x!tt.ptr<f32>, #slice>, %count: i32) {
-    %zero = arith.constant dense<0.000000e+00> : tensor<32xf32, #slice>
-    %start = arith.constant 0 : i32
-    %step = arith.constant 1 : i32
-    %result = scf.for %index = %start to %count step %step iter_args(%accumulator = %zero) -> (tensor<32xf32, #slice>) : i32 {
-      %v = tt.load %values : tensor<32x4x!tt.ptr<f32>, #blocked>
-      %t = tt.load %tags : tensor<32x4x!tt.ptr<f32>, #blocked>
-      %reduced:2 = "tt.reduce"(%v, %t) <{axis = 1 : i32}> ({
-      ^bb0(%a0: f32, %a1: f32, %b0: f32, %b1: f32):
-        %sum = arith.addf %a0, %b0 : f32
-        tt.reduce.return %sum, %a1 : f32, f32
-      }) : (tensor<32x4xf32, #blocked>, tensor<32x4xf32, #blocked>) -> (tensor<32xf32, #slice>, tensor<32xf32, #slice>)
-      %updated = arith.addf %accumulator, %reduced#0 : tensor<32xf32, #slice>
-      scf.yield %updated : tensor<32xf32, #slice>
-    }
-    tt.store %output, %result : tensor<32x!tt.ptr<f32>, #slice>
-    tt.return
-  }
-}
-
-// -----
-
-// A degenerate combiner that could change the result if the optimization is applied
-// CHECK-LABEL: @self_add_combiner
-// CHECK-NOT: tt.reshape
-// CHECK: "tt.reduce"({{.*}}) <{axis = 1 : i32}>
-#blocked = #ttg.blocked<{sizePerThread = [1, 2], threadsPerWarp = [16, 2], warpsPerCTA = [1, 1], order = [1, 0]}>
-#slice = #ttg.slice<{dim = 1, parent = #blocked}>
-module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 1 : i32, "ttg.threads-per-warp" = 32 : i32} {
-  tt.func public @self_add_combiner(%values: tensor<32x4x!tt.ptr<f32>, #blocked>, %output: tensor<32x!tt.ptr<f32>, #slice>, %count: i32) {
-    %zero = arith.constant dense<0.000000e+00> : tensor<32xf32, #slice>
-    %start = arith.constant 0 : i32
-    %step = arith.constant 1 : i32
-    %result = scf.for %index = %start to %count step %step iter_args(%accumulator = %zero) -> (tensor<32xf32, #slice>) : i32 {
-      %v = tt.load %values : tensor<32x4x!tt.ptr<f32>, #blocked>
-      %reduced = "tt.reduce"(%v) <{axis = 1 : i32}> ({
-      ^bb0(%a: f32, %b: f32):
-        %sum = arith.addf %a, %a : f32
-        tt.reduce.return %sum : f32
-      }) : (tensor<32x4xf32, #blocked>) -> tensor<32xf32, #slice>
-      %updated = arith.addf %accumulator, %reduced : tensor<32xf32, #slice>
-      scf.yield %updated : tensor<32xf32, #slice>
-    }
-    tt.store %output, %result : tensor<32x!tt.ptr<f32>, #slice>
-    tt.return
-  }
-}
-
-// -----
-
-// The accumulator update op does not match the reduce's combiner
-// CHECK-LABEL: @update_combiner_mismatch
-// CHECK-NOT: tt.reshape
-// CHECK: "tt.reduce"({{.*}}) <{axis = 1 : i32}>
-#blocked = #ttg.blocked<{sizePerThread = [1, 2], threadsPerWarp = [16, 2], warpsPerCTA = [1, 1], order = [1, 0]}>
-#slice = #ttg.slice<{dim = 1, parent = #blocked}>
-module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 1 : i32, "ttg.threads-per-warp" = 32 : i32} {
-  tt.func public @update_combiner_mismatch(%values: tensor<32x4x!tt.ptr<f32>, #blocked>, %output: tensor<32x!tt.ptr<f32>, #slice>, %count: i32) {
-    %zero = arith.constant dense<0xFF800000> : tensor<32xf32, #slice>
-    %start = arith.constant 0 : i32
-    %step = arith.constant 1 : i32
-    %result = scf.for %index = %start to %count step %step iter_args(%accumulator = %zero) -> (tensor<32xf32, #slice>) : i32 {
-      %v = tt.load %values : tensor<32x4x!tt.ptr<f32>, #blocked>
-      %reduced = "tt.reduce"(%v) <{axis = 1 : i32}> ({
-      ^bb0(%a: f32, %b: f32):
-        %sum = arith.addf %a, %b : f32
-        tt.reduce.return %sum : f32
-      }) : (tensor<32x4xf32, #blocked>) -> tensor<32xf32, #slice>
-      %updated = arith.maximumf %accumulator, %reduced : tensor<32xf32, #slice>
-      scf.yield %updated : tensor<32xf32, #slice>
-    }
-    tt.store %output, %result : tensor<32x!tt.ptr<f32>, #slice>
-    tt.return
-  }
-}
-
-// -----
-
-// The accumulator's final value is consumed in two places; both uses receive
-// the post-loop result
-// CHECK-LABEL: @loop_result_two_uses
-// CHECK: %[[LOOP_OUTPUT:.*]] = scf.for
-// CHECK: "tt.reduce"({{.*}}) <{axis = 2 : i32}>
-// CHECK: scf.yield
-// CHECK: %[[FINAL_REDUCE:.*]] = "tt.reduce"(%[[LOOP_OUTPUT]]) <{axis = 1 : i32}>
-// CHECK: %[[CVT:.*]] = ttg.convert_layout %[[FINAL_REDUCE]]
-// CHECK: %[[RES:.*]] = arith.addf %[[CVT]], %{{.*}}
-// CHECK: tt.store {{.*}}, %[[RES]]
-// CHECK: tt.store {{.*}}, %[[RES]]
-#blocked = #ttg.blocked<{sizePerThread = [1, 2], threadsPerWarp = [16, 2], warpsPerCTA = [1, 1], order = [1, 0]}>
-#slice = #ttg.slice<{dim = 1, parent = #blocked}>
-module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 1 : i32, "ttg.threads-per-warp" = 32 : i32} {
-  tt.func public @loop_result_two_uses(%values: tensor<32x4x!tt.ptr<f32>, #blocked>, %out1: tensor<32x!tt.ptr<f32>, #slice>, %out2: tensor<32x!tt.ptr<f32>, #slice>, %count: i32) {
-    %zero = arith.constant dense<0.000000e+00> : tensor<32xf32, #slice>
-    %start = arith.constant 0 : i32
-    %step = arith.constant 1 : i32
-    %result = scf.for %index = %start to %count step %step iter_args(%accumulator = %zero) -> (tensor<32xf32, #slice>) : i32 {
-      %v = tt.load %values : tensor<32x4x!tt.ptr<f32>, #blocked>
-      %reduced = "tt.reduce"(%v) <{axis = 1 : i32}> ({
-      ^bb0(%a: f32, %b: f32):
-        %sum = arith.addf %a, %b : f32
-        tt.reduce.return %sum : f32
-      }) : (tensor<32x4xf32, #blocked>) -> tensor<32xf32, #slice>
-      %updated = arith.addf %accumulator, %reduced : tensor<32xf32, #slice>
-      scf.yield %updated : tensor<32xf32, #slice>
-    }
-    tt.store %out1, %result : tensor<32x!tt.ptr<f32>, #slice>
-    tt.store %out2, %result : tensor<32x!tt.ptr<f32>, #slice>
-    tt.return
-  }
-}
-
-// -----
-
-// The accumulator has a second use inside the loop
-// CHECK-LABEL: @accumulator_second_use
-// CHECK-NOT: tt.reshape
-// CHECK: "tt.reduce"({{.*}}) <{axis = 1 : i32}>
-#blocked = #ttg.blocked<{sizePerThread = [1, 2], threadsPerWarp = [16, 2], warpsPerCTA = [1, 1], order = [1, 0]}>
-#slice = #ttg.slice<{dim = 1, parent = #blocked}>
-module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 1 : i32, "ttg.threads-per-warp" = 32 : i32} {
-  tt.func public @accumulator_second_use(%values: tensor<32x4x!tt.ptr<f32>, #blocked>, %trace: tensor<32x!tt.ptr<f32>, #slice>, %output: tensor<32x!tt.ptr<f32>, #slice>, %count: i32) {
-    %zero = arith.constant dense<0.000000e+00> : tensor<32xf32, #slice>
-    %start = arith.constant 0 : i32
-    %step = arith.constant 1 : i32
-    %result = scf.for %index = %start to %count step %step iter_args(%accumulator = %zero) -> (tensor<32xf32, #slice>) : i32 {
-      tt.store %trace, %accumulator : tensor<32x!tt.ptr<f32>, #slice>
-      %v = tt.load %values : tensor<32x4x!tt.ptr<f32>, #blocked>
-      %reduced = "tt.reduce"(%v) <{axis = 1 : i32}> ({
-      ^bb0(%a: f32, %b: f32):
-        %sum = arith.addf %a, %b : f32
-        tt.reduce.return %sum : f32
-      }) : (tensor<32x4xf32, #blocked>) -> tensor<32xf32, #slice>
-      %updated = arith.addf %accumulator, %reduced : tensor<32xf32, #slice>
-      scf.yield %updated : tensor<32xf32, #slice>
-    }
-    tt.store %output, %result : tensor<32x!tt.ptr<f32>, #slice>
-    tt.return
-  }
-}
-
-// -----
-
-// The update's other operand is a rescaled accumulator rather than the iter_arg
-// CHECK-LABEL: @rescaled_accumulator
-// CHECK-NOT: tt.reshape
-// CHECK: "tt.reduce"({{.*}}) <{axis = 1 : i32}>
-#blocked = #ttg.blocked<{sizePerThread = [1, 2], threadsPerWarp = [16, 2], warpsPerCTA = [1, 1], order = [1, 0]}>
-#slice = #ttg.slice<{dim = 1, parent = #blocked}>
-module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 1 : i32, "ttg.threads-per-warp" = 32 : i32} {
-  tt.func public @rescaled_accumulator(%values: tensor<32x4x!tt.ptr<f32>, #blocked>, %output: tensor<32x!tt.ptr<f32>, #slice>, %count: i32) {
-    %zero = arith.constant dense<0.000000e+00> : tensor<32xf32, #slice>
-    %alpha = arith.constant dense<5.000000e-01> : tensor<32xf32, #slice>
-    %start = arith.constant 0 : i32
-    %step = arith.constant 1 : i32
-    %result = scf.for %index = %start to %count step %step iter_args(%accumulator = %zero) -> (tensor<32xf32, #slice>) : i32 {
-      %v = tt.load %values : tensor<32x4x!tt.ptr<f32>, #blocked>
-      %reduced = "tt.reduce"(%v) <{axis = 1 : i32}> ({
-      ^bb0(%a: f32, %b: f32):
-        %sum = arith.addf %a, %b : f32
-        tt.reduce.return %sum : f32
-      }) : (tensor<32x4xf32, #blocked>) -> tensor<32xf32, #slice>
-      %scaled = arith.mulf %accumulator, %alpha : tensor<32xf32, #slice>
-      %updated = arith.addf %scaled, %reduced : tensor<32xf32, #slice>
-      scf.yield %updated : tensor<32xf32, #slice>
-    }
-    tt.store %output, %result : tensor<32x!tt.ptr<f32>, #slice>
-    tt.return
-  }
-}
-
-// -----
-
-// Two independent accumulators in the same loop are both optimized
-// CHECK-LABEL: @two_independent_accumulators
-// CHECK: %[[RES:.*]]:2 = scf.for {{.*}} iter_args(%[[SUM:.*]] = %{{.*}}, %[[MAX:.*]] = %{{.*}})
-// CHECK: %[[A_RED:.*]] = "tt.reduce"({{.*}}) <{axis = 2 : i32}>
-// CHECK: %[[SUM_UPD:.*]] = arith.addf %[[SUM]], %[[A_RED]]
-// CHECK: %[[B_RED:.*]] = "tt.reduce"({{.*}}) <{axis = 2 : i32}>
-// CHECK: %[[MAX_UPD:.*]] = arith.maximumf %[[MAX]], %[[B_RED]]
-// CHECK: scf.yield %[[SUM_UPD]], %[[MAX_UPD]]
-// CHECK: %[[MAX_RED:.*]] = "tt.reduce"(%[[RES]]#1) <{axis = 1 : i32}>
-// CHECK: %[[MAX_OUT:.*]] = ttg.convert_layout %[[MAX_RED]]
-// CHECK: %[[SUM_RED:.*]] = "tt.reduce"(%[[RES]]#0) <{axis = 1 : i32}>
-// CHECK: %[[SUM_CVT:.*]] = ttg.convert_layout %[[SUM_RED]]
-// CHECK: %[[SUM_OUT:.*]] = arith.addf %[[SUM_CVT]], %{{.*}}
-// CHECK: tt.store %{{.*}}, %[[SUM_OUT]]
-// CHECK: tt.store %{{.*}}, %[[MAX_OUT]]
-#blocked = #ttg.blocked<{sizePerThread = [1, 2], threadsPerWarp = [16, 2], warpsPerCTA = [1, 1], order = [1, 0]}>
-#slice = #ttg.slice<{dim = 1, parent = #blocked}>
-module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 1 : i32, "ttg.threads-per-warp" = 32 : i32} {
-  tt.func public @two_independent_accumulators(%a_ptr: tensor<32x4x!tt.ptr<f32>, #blocked>, %b_ptr: tensor<32x4x!tt.ptr<f32>, #blocked>, %sum_out: tensor<32x!tt.ptr<f32>, #slice>, %max_out: tensor<32x!tt.ptr<f32>, #slice>, %count: i32) {
-    %zero = arith.constant dense<0.000000e+00> : tensor<32xf32, #slice>
-    %ninf = arith.constant dense<0xFF800000> : tensor<32xf32, #slice>
-    %start = arith.constant 0 : i32
-    %step = arith.constant 1 : i32
-    %result:2 = scf.for %i = %start to %count step %step iter_args(%sum_acc = %zero, %max_acc = %ninf) -> (tensor<32xf32, #slice>, tensor<32xf32, #slice>) : i32 {
-      %a = tt.load %a_ptr : tensor<32x4x!tt.ptr<f32>, #blocked>
-      %a_red = "tt.reduce"(%a) <{axis = 1 : i32}> ({
-      ^bb0(%l: f32, %r: f32):
-        %s = arith.addf %l, %r : f32
-        tt.reduce.return %s : f32
-      }) : (tensor<32x4xf32, #blocked>) -> tensor<32xf32, #slice>
-      %sum_upd = arith.addf %sum_acc, %a_red : tensor<32xf32, #slice>
-      %b = tt.load %b_ptr : tensor<32x4x!tt.ptr<f32>, #blocked>
-      %b_red = "tt.reduce"(%b) <{axis = 1 : i32}> ({
-      ^bb0(%l: f32, %r: f32):
-        %m = arith.maximumf %l, %r : f32
-        tt.reduce.return %m : f32
-      }) : (tensor<32x4xf32, #blocked>) -> tensor<32xf32, #slice>
-      %max_upd = arith.maximumf %max_acc, %b_red : tensor<32xf32, #slice>
-      scf.yield %sum_upd, %max_upd : tensor<32xf32, #slice>, tensor<32xf32, #slice>
-    }
-    tt.store %sum_out, %result#0 : tensor<32x!tt.ptr<f32>, #slice>
-    tt.store %max_out, %result#1 : tensor<32x!tt.ptr<f32>, #slice>
-    tt.return
-  }
-}
-
-// -----
-
-// Two reductions in a loop, each accumulator's running value feeds the other reduce's load mask
-// CHECK-LABEL: @mutually_dependent_accumulators
-// CHECK: scf.for {{.*}} iter_args(%[[SUM:.*]] = %{{.*}}, %[[MAX:.*]] = %{{.*}})
-// CHECK: tt.expand_dims %[[MAX]]
-// CHECK: "tt.reduce"({{.*}}) <{axis = 1 : i32}>
-// CHECK: arith.addf %[[SUM]],
-// CHECK: tt.expand_dims %[[SUM]]
-// CHECK: "tt.reduce"({{.*}}) <{axis = 1 : i32}>
-// CHECK: arith.maximumf %[[MAX]],
-#blocked = #ttg.blocked<{sizePerThread = [1, 2], threadsPerWarp = [16, 2], warpsPerCTA = [1, 1], order = [1, 0]}>
-#slice = #ttg.slice<{dim = 1, parent = #blocked}>
-module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 1 : i32, "ttg.threads-per-warp" = 32 : i32} {
-  tt.func public @mutually_dependent_accumulators(%a_ptr: tensor<32x4x!tt.ptr<f32>, #blocked>, %b_ptr: tensor<32x4x!tt.ptr<f32>, #blocked>, %sum_out: tensor<32x!tt.ptr<f32>, #slice>, %max_out: tensor<32x!tt.ptr<f32>, #slice>, %count: i32) {
-    %zero = arith.constant dense<0.000000e+00> : tensor<32xf32, #slice>
-    %ninf = arith.constant dense<0xFF800000> : tensor<32xf32, #slice>
-    %thresh = arith.constant dense<0.000000e+00> : tensor<32x1xf32, #blocked>
-    %start = arith.constant 0 : i32
-    %step = arith.constant 1 : i32
-    %result:2 = scf.for %i = %start to %count step %step iter_args(%sum_acc = %zero, %max_acc = %ninf) -> (tensor<32xf32, #slice>, tensor<32xf32, #slice>) : i32 {
-      %max_col = tt.expand_dims %max_acc {axis = 1 : i32} : tensor<32xf32, #slice> -> tensor<32x1xf32, #blocked>
-      %a_cmp = arith.cmpf ogt, %max_col, %thresh : tensor<32x1xf32, #blocked>
-      %a_mask = tt.broadcast %a_cmp : tensor<32x1xi1, #blocked> -> tensor<32x4xi1, #blocked>
-      %a = tt.load %a_ptr, %a_mask : tensor<32x4x!tt.ptr<f32>, #blocked>
-      %a_red = "tt.reduce"(%a) <{axis = 1 : i32}> ({
-      ^bb0(%l: f32, %r: f32):
-        %s = arith.addf %l, %r : f32
-        tt.reduce.return %s : f32
-      }) : (tensor<32x4xf32, #blocked>) -> tensor<32xf32, #slice>
-      %sum_upd = arith.addf %sum_acc, %a_red : tensor<32xf32, #slice>
-      %sum_col = tt.expand_dims %sum_acc {axis = 1 : i32} : tensor<32xf32, #slice> -> tensor<32x1xf32, #blocked>
-      %b_cmp = arith.cmpf ogt, %sum_col, %thresh : tensor<32x1xf32, #blocked>
-      %b_mask = tt.broadcast %b_cmp : tensor<32x1xi1, #blocked> -> tensor<32x4xi1, #blocked>
-      %b = tt.load %b_ptr, %b_mask : tensor<32x4x!tt.ptr<f32>, #blocked>
-      %b_red = "tt.reduce"(%b) <{axis = 1 : i32}> ({
-      ^bb0(%l: f32, %r: f32):
-        %m = arith.maximumf %l, %r : f32
-        tt.reduce.return %m : f32
-      }) : (tensor<32x4xf32, #blocked>) -> tensor<32xf32, #slice>
-      %max_upd = arith.maximumf %max_acc, %b_red : tensor<32xf32, #slice>
-      scf.yield %sum_upd, %max_upd : tensor<32xf32, #slice>, tensor<32xf32, #slice>
-    }
-    tt.store %sum_out, %result#0 : tensor<32x!tt.ptr<f32>, #slice>
-    tt.store %max_out, %result#1 : tensor<32x!tt.ptr<f32>, #slice>
-    tt.return
-  }
-}
-
-// -----
-
-// The reduction axis is entirely in the registers of one thread
-// CHECK-LABEL: @thread_local_axis
-// CHECK-NOT: tt.reshape
-// CHECK: "tt.reduce"({{.*}}) <{axis = 1 : i32}>
-#blocked = #ttg.blocked<{sizePerThread = [1, 32], threadsPerWarp = [32, 1], warpsPerCTA = [4, 1], order = [1, 0]}>
-#slice = #ttg.slice<{dim = 1, parent = #blocked}>
-module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, "ttg.threads-per-warp" = 32 : i32} {
-  tt.func public @thread_local_axis(%values: tensor<32x32x!tt.ptr<f32>, #blocked>, %output: tensor<32x!tt.ptr<f32>, #slice>, %count: i32) {
-    %zero = arith.constant dense<0.000000e+00> : tensor<32xf32, #slice>
-    %start = arith.constant 0 : i32
-    %step = arith.constant 1 : i32
-    %result = scf.for %index = %start to %count step %step iter_args(%accumulator = %zero) -> (tensor<32xf32, #slice>) : i32 {
-      %v = tt.load %values : tensor<32x32x!tt.ptr<f32>, #blocked>
-      %reduced = "tt.reduce"(%v) <{axis = 1 : i32}> ({
-      ^bb0(%a: f32, %b: f32):
-        %sum = arith.addf %a, %b : f32
-        tt.reduce.return %sum : f32
-      }) : (tensor<32x32xf32, #blocked>) -> tensor<32xf32, #slice>
-      %updated = arith.addf %accumulator, %reduced : tensor<32xf32, #slice>
-      scf.yield %updated : tensor<32xf32, #slice>
-    }
-    tt.store %output, %result : tensor<32x!tt.ptr<f32>, #slice>
-    tt.return
-  }
-}
-
-// -----
-
-// The reduction axis has one element per thread, but distributed across multiple threads in a warp
-// CHECK-LABEL: @lane_spread_axis
-// CHECK: %[[RES:.*]] = scf.for {{.*}} iter_args(%[[ACC:.*]] = %{{.*}}) -> (tensor<32x32xf32
-// CHECK: "tt.reduce"({{.*}}) <{axis = 2 : i32}>
-// CHECK: arith.addf %[[ACC]], %{{.*}}
-// CHECK: scf.yield
-// CHECK: "tt.reduce"(%[[RES]]) <{axis = 1 : i32}>
-#blocked = #ttg.blocked<{sizePerThread = [1, 1], threadsPerWarp = [1, 32], warpsPerCTA = [4, 1], order = [1, 0]}>
-#slice = #ttg.slice<{dim = 1, parent = #blocked}>
-module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, "ttg.threads-per-warp" = 32 : i32} {
-  tt.func public @lane_spread_axis(%values: tensor<32x32x!tt.ptr<f32>, #blocked>, %output: tensor<32x!tt.ptr<f32>, #slice>, %count: i32) {
-    %zero = arith.constant dense<0.000000e+00> : tensor<32xf32, #slice>
-    %start = arith.constant 0 : i32
-    %step = arith.constant 1 : i32
-    %result = scf.for %index = %start to %count step %step iter_args(%accumulator = %zero) -> (tensor<32xf32, #slice>) : i32 {
-      %v = tt.load %values : tensor<32x32x!tt.ptr<f32>, #blocked>
-      %reduced = "tt.reduce"(%v) <{axis = 1 : i32}> ({
-      ^bb0(%a: f32, %b: f32):
-        %sum = arith.addf %a, %b : f32
-        tt.reduce.return %sum : f32
-      }) : (tensor<32x32xf32, #blocked>) -> tensor<32xf32, #slice>
-      %updated = arith.addf %accumulator, %reduced : tensor<32xf32, #slice>
-      scf.yield %updated : tensor<32xf32, #slice>
-    }
-    tt.store %output, %result : tensor<32x!tt.ptr<f32>, #slice>
-    tt.return
-  }
-}
-
-// -----
-
-// The reduction axis has one element per thread, but distributed across multiple warps
-// CHECK-LABEL: @warp_spread_axis
-// CHECK: %[[RES:.*]] = scf.for {{.*}} iter_args(%[[ACC:.*]] = %{{.*}}) -> (tensor<32x4xf32
-// CHECK: "tt.reduce"({{.*}}) <{axis = 2 : i32}>
-// CHECK: arith.addf %[[ACC]], %{{.*}}
-// CHECK: scf.yield
-// CHECK: "tt.reduce"(%[[RES]]) <{axis = 1 : i32}>
-#blocked = #ttg.blocked<{sizePerThread = [1, 1], threadsPerWarp = [32, 1], warpsPerCTA = [1, 4], order = [1, 0]}>
-#slice = #ttg.slice<{dim = 1, parent = #blocked}>
-module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, "ttg.threads-per-warp" = 32 : i32} {
-  tt.func public @warp_spread_axis(%values: tensor<32x4x!tt.ptr<f32>, #blocked>, %output: tensor<32x!tt.ptr<f32>, #slice>, %count: i32) {
-    %zero = arith.constant dense<0.000000e+00> : tensor<32xf32, #slice>
-    %start = arith.constant 0 : i32
-    %step = arith.constant 1 : i32
-    %result = scf.for %index = %start to %count step %step iter_args(%accumulator = %zero) -> (tensor<32xf32, #slice>) : i32 {
-      %v = tt.load %values : tensor<32x4x!tt.ptr<f32>, #blocked>
-      %reduced = "tt.reduce"(%v) <{axis = 1 : i32}> ({
-      ^bb0(%a: f32, %b: f32):
-        %sum = arith.addf %a, %b : f32
-        tt.reduce.return %sum : f32
-      }) : (tensor<32x4xf32, #blocked>) -> tensor<32xf32, #slice>
-      %updated = arith.addf %accumulator, %reduced : tensor<32xf32, #slice>
-      scf.yield %updated : tensor<32xf32, #slice>
-    }
-    tt.store %output, %result : tensor<32x!tt.ptr<f32>, #slice>
-    tt.return
-  }
-}
-
-// -----
-
-// The reduction axis has one element per thread, but distributed across multiple CTAs
-// CHECK-LABEL: @cta_split_axis
-// CHECK: %[[RES:.*]] = scf.for {{.*}} iter_args(%[[ACC:.*]] = %{{.*}}) -> (tensor<32x2xf32
-// CHECK: "tt.reduce"({{.*}}) <{axis = 2 : i32}>
-// CHECK: arith.addf %[[ACC]], %{{.*}}
-// CHECK: scf.yield
-// CHECK: "tt.reduce"(%[[RES]]) <{axis = 1 : i32}>
-#blocked = #ttg.blocked<{sizePerThread = [1, 32], threadsPerWarp = [32, 1], warpsPerCTA = [4, 1], order = [1, 0], CGALayout = [[0, 1]]}>
-#slice = #ttg.slice<{dim = 1, parent = #blocked}>
-module attributes {"ttg.target" = "cuda:90", "ttg.num-ctas" = 2 : i32, "ttg.num-warps" = 4 : i32, "ttg.threads-per-warp" = 32 : i32} {
-  tt.func public @cta_split_axis(%values: tensor<32x64x!tt.ptr<f32>, #blocked>, %output: tensor<32x!tt.ptr<f32>, #slice>, %count: i32) {
-    %zero = arith.constant dense<0.000000e+00> : tensor<32xf32, #slice>
-    %start = arith.constant 0 : i32
-    %step = arith.constant 1 : i32
-    %result = scf.for %index = %start to %count step %step iter_args(%accumulator = %zero) -> (tensor<32xf32, #slice>) : i32 {
-      %v = tt.load %values : tensor<32x64x!tt.ptr<f32>, #blocked>
-      %reduced = "tt.reduce"(%v) <{axis = 1 : i32}> ({
-      ^bb0(%a: f32, %b: f32):
-        %sum = arith.addf %a, %b : f32
-        tt.reduce.return %sum : f32
-      }) : (tensor<32x64xf32, #blocked>) -> tensor<32xf32, #slice>
-      %updated = arith.addf %accumulator, %reduced : tensor<32xf32, #slice>
-      scf.yield %updated : tensor<32xf32, #slice>
-    }
-    tt.store %output, %result : tensor<32x!tt.ptr<f32>, #slice>
-    tt.return
-  }
-}
-
-// -----
-
-// Reduce along a non-innermost axis
-// CHECK-LABEL: @reduce_axis_zero
-// CHECK: %[[INIT_ARG:.*]] = arith.constant dense<0.000000e+00> : tensor<4x8xf32
-// CHECK: %[[LOOP_OUTPUT:.*]] = scf.for {{.*}} iter_args(%[[FOR_ARG:.*]] = %[[INIT_ARG]]) -> {{.*}}
-// CHECK: tt.reshape {{.*}} -> tensor<{{1x1x4x2x8xf32.*}}>
-// CHECK: tt.trans {{.*}} {order = array<i32: 0, 2, 4, 1, 3>}
-// CHECK: %[[REDUCE:.*]] = "tt.reduce"({{%.*}}) <{axis = 2 : i32}>
-// CHECK: arith.addf %[[FOR_ARG]], %[[REDUCE]]
-// CHECK: %[[FINAL_REDUCE:.*]] = "tt.reduce"(%[[LOOP_OUTPUT]]) <{axis = 0 : i32}>
-// CHECK: %[[CVT_OUTPUT:.*]] = ttg.convert_layout %[[FINAL_REDUCE]]
-// CHECK: arith.addf %[[CVT_OUTPUT]], {{.*}}
-#blocked = #ttg.blocked<{sizePerThread = [2, 2], threadsPerWarp = [2, 2], warpsPerCTA = [2, 2], order = [1, 0]}>
-#slice = #ttg.slice<{dim = 0, parent = #blocked}>
-module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, "ttg.threads-per-warp" = 4 : i32} {
-  tt.func public @reduce_axis_zero(%values: tensor<8x8x!tt.ptr<f32>, #blocked>, %output: tensor<8x!tt.ptr<f32>, #slice>, %count: i32) {
-    %zero = arith.constant dense<0.000000e+00> : tensor<8xf32, #slice>
-    %start = arith.constant 0 : i32
-    %step = arith.constant 1 : i32
-    %result = scf.for %index = %start to %count step %step iter_args(%accumulator = %zero) -> (tensor<8xf32, #slice>) : i32 {
-      %v = tt.load %values : tensor<8x8x!tt.ptr<f32>, #blocked>
-      %reduced = "tt.reduce"(%v) <{axis = 0 : i32}> ({
-      ^bb0(%a: f32, %b: f32):
-        %sum = arith.addf %a, %b : f32
-        tt.reduce.return %sum : f32
-      }) : (tensor<8x8xf32, #blocked>) -> tensor<8xf32, #slice>
-      %updated = arith.addf %accumulator, %reduced : tensor<8xf32, #slice>
-      scf.yield %updated : tensor<8xf32, #slice>
-    }
-    tt.store %output, %result : tensor<8x!tt.ptr<f32>, #slice>
-    tt.return
-  }
-}
-
-// -----
-
-// Rank-3 reduce along the middle axis
-// CHECK-LABEL: @reduce_middle_axis
-// CHECK: %[[INIT_ARG:.*]] = arith.constant dense<0.000000e+00> : tensor<2x4x2xf32
-// CHECK: %[[LOOP_OUTPUT:.*]] = scf.for {{.*}} iter_args(%[[FOR_ARG:.*]] = %[[INIT_ARG]]) -> {{.*}}
-// CHECK: tt.reshape {{.*}} -> tensor<{{2x1x2x4x2x2xf32.*}}>
-// CHECK: tt.trans {{.*}} {order = array<i32: 0, 1, 3, 5, 2, 4>}
-// CHECK: %[[REDUCE:.*]] = "tt.reduce"({{%.*}}) <{axis = 3 : i32}>
-// CHECK: arith.addf %[[FOR_ARG]], %[[REDUCE]]
-// CHECK: %[[FINAL_REDUCE:.*]] = "tt.reduce"(%[[LOOP_OUTPUT]]) <{axis = 1 : i32}>
-// CHECK: %[[CVT_OUTPUT:.*]] = ttg.convert_layout %[[FINAL_REDUCE]]
-// CHECK: arith.addf %[[CVT_OUTPUT]], {{.*}}
-#blocked = #ttg.blocked<{sizePerThread = [1, 2, 1], threadsPerWarp = [1, 4, 1], warpsPerCTA = [2, 1, 2], order = [2, 1, 0]}>
-#slice = #ttg.slice<{dim = 1, parent = #blocked}>
-module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, "ttg.threads-per-warp" = 4 : i32} {
-  tt.func public @reduce_middle_axis(%values: tensor<2x16x2x!tt.ptr<f32>, #blocked>, %output: tensor<2x2x!tt.ptr<f32>, #slice>, %count: i32) {
-    %zero = arith.constant dense<0.000000e+00> : tensor<2x2xf32, #slice>
-    %start = arith.constant 0 : i32
-    %step = arith.constant 1 : i32
-    %result = scf.for %index = %start to %count step %step iter_args(%accumulator = %zero) -> (tensor<2x2xf32, #slice>) : i32 {
-      %v = tt.load %values : tensor<2x16x2x!tt.ptr<f32>, #blocked>
-      %reduced = "tt.reduce"(%v) <{axis = 1 : i32}> ({
-      ^bb0(%a: f32, %b: f32):
-        %sum = arith.addf %a, %b : f32
-        tt.reduce.return %sum : f32
-      }) : (tensor<2x16x2xf32, #blocked>) -> tensor<2x2xf32, #slice>
-      %updated = arith.addf %accumulator, %reduced : tensor<2x2xf32, #slice>
-      scf.yield %updated : tensor<2x2xf32, #slice>
-    }
-    tt.store %output, %result : tensor<2x2x!tt.ptr<f32>, #slice>
-    tt.return
-  }
-}
-
-// -----
-
-// Rank-1 reduce accumulated into a scalar
-// CHECK-LABEL: @rank_one_reduce
-// CHECK: %[[INIT_ARG:.*]] = arith.constant dense<0.000000e+00> : tensor<4xf32
-// CHECK: %[[LOOP_OUTPUT:.*]] = scf.for {{.*}} iter_args(%[[FOR_ARG:.*]] = %[[INIT_ARG]]) -> {{.*}}
-// CHECK: tt.reshape {{.*}} -> tensor<{{1x1x4x2xf32.*}}>
-// CHECK: tt.trans {{.*}} {order = array<i32: 0, 2, 1, 3>}
-// CHECK: %[[REDUCE:.*]] = "tt.reduce"({{%.*}}) <{axis = 1 : i32}>
-// CHECK: arith.addf %[[FOR_ARG]], %[[REDUCE]]
-// CHECK: %[[FINAL_REDUCE:.*]] = "tt.reduce"(%[[LOOP_OUTPUT]]) <{axis = 0 : i32}>
-// CHECK: %[[FINAL:.*]] = arith.addf %[[FINAL_REDUCE]], {{.*}} : f32
-// CHECK: tt.return %[[FINAL]] : f32
-#blocked = #ttg.blocked<{sizePerThread = [2], threadsPerWarp = [2], warpsPerCTA = [2], order = [0]}>
-module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 2 : i32, "ttg.threads-per-warp" = 2 : i32} {
-  tt.func public @rank_one_reduce(%values: tensor<8x!tt.ptr<f32>, #blocked>, %count: i32) -> f32 {
-    %zero = arith.constant 0.0 : f32
-    %start = arith.constant 0 : i32
-    %step = arith.constant 1 : i32
-    %result = scf.for %index = %start to %count step %step iter_args(%accumulator = %zero) -> (f32) : i32 {
-      %v = tt.load %values : tensor<8x!tt.ptr<f32>, #blocked>
-      %reduced = "tt.reduce"(%v) <{axis = 0 : i32}> ({
-      ^bb0(%a: f32, %b: f32):
-        %sum = arith.addf %a, %b : f32
-        tt.reduce.return %sum : f32
-      }) : (tensor<8xf32, #blocked>) -> f32
-      %updated = arith.addf %accumulator, %reduced : f32
-      scf.yield %updated : f32
-    }
-    tt.return %result : f32
-  }
-}
-
-// -----
-
-// Rank-1 reduce with the CGA split on the reduced axis and non-trivial register wraparound
-// CHECK-LABEL: @rank_one_reduce_cta_split
-// CHECK: %[[INIT_ARG:.*]] = arith.constant dense<0.000000e+00> : tensor<8xf32
-// CHECK: %[[LOOP_OUTPUT:.*]] = scf.for {{.*}} iter_args(%[[FOR_ARG:.*]] = %[[INIT_ARG]]) -> {{.*}}
-// CHECK: tt.reshape {{.*}} -> tensor<{{2x2x4x2xf32.*}}>
-// CHECK: tt.trans {{.*}} {order = array<i32: 0, 2, 1, 3>}
-// CHECK: %[[REDUCE:.*]] = "tt.reduce"({{%.*}}) <{axis = 1 : i32}>
-// CHECK: arith.addf %[[FOR_ARG]], %[[REDUCE]]
-// CHECK: %[[FINAL_REDUCE:.*]] = "tt.reduce"(%[[LOOP_OUTPUT]]) <{axis = 0 : i32}>
-// CHECK: %[[FINAL:.*]] = arith.addf %[[FINAL_REDUCE]], {{.*}} : f32
-// CHECK: tt.return %[[FINAL]] : f32
-#blocked = #ttg.blocked<{sizePerThread = [2], threadsPerWarp = [2], warpsPerCTA = [2], order = [0], CGALayout = [[1]]}>
-module attributes {"ttg.num-ctas" = 2 : i32, "ttg.num-warps" = 2 : i32, "ttg.threads-per-warp" = 2 : i32} {
-  tt.func public @rank_one_reduce_cta_split(%values: tensor<32x!tt.ptr<f32>, #blocked>, %count: i32) -> f32 {
-    %zero = arith.constant 0.0 : f32
-    %start = arith.constant 0 : i32
-    %step = arith.constant 1 : i32
-    %result = scf.for %index = %start to %count step %step iter_args(%accumulator = %zero) -> (f32) : i32 {
-      %v = tt.load %values : tensor<32x!tt.ptr<f32>, #blocked>
-      %reduced = "tt.reduce"(%v) <{axis = 0 : i32}> ({
-      ^bb0(%a: f32, %b: f32):
-        %sum = arith.addf %a, %b : f32
-        tt.reduce.return %sum : f32
-      }) : (tensor<32xf32, #blocked>) -> f32
-      %updated = arith.addf %accumulator, %reduced : f32
-      scf.yield %updated : f32
-    }
-    tt.return %result : f32
-  }
 }


### PR DESCRIPTION
This temporarily reverts e3674d2b8a86c9e4dd859e1710abedcb8d8d54fd and 657a12b0d708dc654005c05420ab7b3b05f3dd2f while we track regressions.
