### PR TITLE
[RUNTIME] Tolerate EBUSY while cleaning published cache temp dirs

### DIFF
--- a/python/test/unit/runtime/test_cache.py
+++ b/python/test/unit/runtime/test_cache.py
@@ -1,4 +1,5 @@
 import expecttest
+import errno
 import importlib.util
 import itertools
 import multiprocessing
@@ -16,6 +17,32 @@ import triton
 import triton.language as tl
 from triton._internal_testing import is_hip
 from triton.runtime.cache import FileCacheManager, RemoteCacheManager
+
+
+def test_file_cache_manager_put_ignores_busy_temp_dir_cleanup(fresh_knobs, monkeypatch, tmp_path):
+    fresh_knobs.cache.dir = str(tmp_path)
+    manager = FileCacheManager("key")
+
+    def busy_rmdir(path):
+        raise OSError(errno.EBUSY, os.strerror(errno.EBUSY), path)
+
+    monkeypatch.setattr(os, "rmdir", busy_rmdir)
+    path = manager.put("published", "kernel.json", binary=False)
+
+    assert pathlib.Path(path).read_text() == "published"
+
+
+def test_file_cache_manager_put_propagates_unexpected_cleanup_error(fresh_knobs, monkeypatch, tmp_path):
+    fresh_knobs.cache.dir = str(tmp_path)
+    manager = FileCacheManager("key")
+
+    def denied_rmdir(path):
+        raise OSError(errno.EACCES, os.strerror(errno.EACCES), path)
+
+    monkeypatch.setattr(os, "rmdir", denied_rmdir)
+    with pytest.raises(OSError) as exc_info:
+        manager.put("published", "kernel.json", binary=False)
+    assert exc_info.value.errno == errno.EACCES
 
 
 def test_file_cache_manager_get_group_rejects_missing_child(fresh_knobs, tmp_path):

--- a/python/test/unit/runtime/test_cache.py
+++ b/python/test/unit/runtime/test_cache.py
@@ -19,30 +19,51 @@ from triton._internal_testing import is_hip
 from triton.runtime.cache import FileCacheManager, RemoteCacheManager
 
 
-def test_file_cache_manager_put_ignores_busy_temp_dir_cleanup(fresh_knobs, monkeypatch, tmp_path):
+def test_file_cache_manager_put_removes_only_temp_dir(fresh_knobs, monkeypatch, tmp_path):
     fresh_knobs.cache.dir = str(tmp_path)
     manager = FileCacheManager("key")
+    real_rmdir = os.rmdir
+    removed_paths = []
 
-    def busy_rmdir(path):
-        raise OSError(errno.EBUSY, os.strerror(errno.EBUSY), path)
+    def recording_rmdir(path, *args, **kwargs):
+        removed_paths.append(os.fspath(path))
+        return real_rmdir(path, *args, **kwargs)
 
-    monkeypatch.setattr(os, "rmdir", busy_rmdir)
+    monkeypatch.setattr(os, "rmdir", recording_rmdir)
     path = manager.put("published", "kernel.json", binary=False)
 
     assert pathlib.Path(path).read_text() == "published"
+    assert len(removed_paths) == 1
+    removed_path = pathlib.Path(removed_paths[0])
+    assert removed_path.parent == pathlib.Path(manager.cache_dir)
+    assert removed_path.name.startswith(f"tmp.pid_{os.getpid()}_")
 
 
-def test_file_cache_manager_put_propagates_unexpected_cleanup_error(fresh_knobs, monkeypatch, tmp_path):
+@pytest.mark.parametrize(
+    ("cleanup_errno", "should_raise"),
+    [
+        (errno.EBUSY, False),
+        (errno.EACCES, True),
+        (errno.ENOTEMPTY, True),
+        (errno.ENOENT, True),
+    ],
+)
+def test_file_cache_manager_put_handles_only_busy_temp_dir_cleanup(fresh_knobs, monkeypatch, tmp_path, cleanup_errno,
+                                                                   should_raise):
     fresh_knobs.cache.dir = str(tmp_path)
     manager = FileCacheManager("key")
 
-    def denied_rmdir(path):
-        raise OSError(errno.EACCES, os.strerror(errno.EACCES), path)
+    def failing_rmdir(path):
+        raise OSError(cleanup_errno, os.strerror(cleanup_errno), path)
 
-    monkeypatch.setattr(os, "rmdir", denied_rmdir)
-    with pytest.raises(OSError) as exc_info:
+    monkeypatch.setattr(os, "rmdir", failing_rmdir)
+    if not should_raise:
         manager.put("published", "kernel.json", binary=False)
-    assert exc_info.value.errno == errno.EACCES
+    else:
+        with pytest.raises(OSError) as exc_info:
+            manager.put("published", "kernel.json", binary=False)
+        assert exc_info.value.errno == cleanup_errno
+    assert (pathlib.Path(manager.cache_dir) / "kernel.json").read_text() == "published"
 
 
 def test_file_cache_manager_get_group_rejects_missing_child(fresh_knobs, tmp_path):

--- a/python/triton/runtime/cache.py
+++ b/python/triton/runtime/cache.py
@@ -1,4 +1,5 @@
 import json
+import errno
 import os
 import uuid
 from abc import ABC, abstractmethod
@@ -123,7 +124,13 @@ class FileCacheManager(CacheManager):
         # Replace is guaranteed to be atomic on POSIX systems if it succeeds
         # so filepath cannot see a partial write
         os.replace(temp_path, filepath)
-        os.removedirs(temp_dir)
+        try:
+            os.rmdir(temp_dir)
+        except OSError as e:
+            # Publishing has already succeeded. Some network filesystems can
+            # transiently report EBUSY while removing this private directory.
+            if e.errno != errno.EBUSY:
+                raise
         return filepath
 
 

--- a/python/triton/runtime/cache.py
+++ b/python/triton/runtime/cache.py
@@ -127,8 +127,9 @@ class FileCacheManager(CacheManager):
         try:
             os.rmdir(temp_dir)
         except OSError as e:
-            # Publishing has already succeeded. Some network filesystems can
-            # transiently report EBUSY while removing this private directory.
+            # Linux's NFSv4 client can surface NFS4ERR_FILE_OPEN as EBUSY after
+            # retrying REMOVE. The cache file is already atomically published,
+            # so leave the empty private temp dir rather than fail the write.
             if e.errno != errno.EBUSY:
                 raise
         return filepath


### PR DESCRIPTION
# New contributor declaration

- [x] I am not making a trivial change, such as fixing a typo in a comment.

- [x] I have written a PR description following these
  [rules](https://cbea.ms/git-commit/#why-not-how).

- [x] I have run `pre-commit run --from-ref origin/main --to-ref HEAD`.
  The workflow-only `expand-yaml-anchors` hook was explicitly skipped because
  this PR does not change workflow files and its Go dependency setup timed out;
  every applicable hook passed.

- Select one of the following.
  - [x] I have added tests.
    - `/test` for `lit` tests
    - `/unittest` for C++ tests
    - `/python/test` for end-to-end tests
  - [ ] This PR does not need a test because `FILL THIS IN`.

- Select one of the following.
  - [x] I have not added any `lit` tests.
  - [ ] The `lit` tests I have added follow these [best practices](https://mlir.llvm.org/getting_started/TestingGuide/#filecheck-best-practices),
    including the "tests should be minimal" section. (Usually running Python code
    and using the instructions it generates is not minimal.)

## Summary

`FileCacheManager.put` publishes its staged artifact with an atomic
`os.replace` and then cleans up the writer-private temporary directory.
On some distributed filesystems, removing that already-empty directory can
transiently fail with `EBUSY`. The artifact is already available at its final
path, but the cleanup error currently turns the successful publish into a
failed compilation.

Use leaf-only `os.rmdir` instead of `os.removedirs`, which also avoids trying
to prune the shared cache-key directory and its parents. Ignore only `EBUSY`
after publication; preserve all other cleanup errors.

This intentionally addresses only the `EBUSY` cleanup signature in #11512.
It does not change the separate read-back `FileNotFoundError` path.

## Tests

- Add a regression test that injects `EBUSY`, verifies `put` succeeds, and
  verifies the published contents.
- Add a guard test that injects `EACCES` and verifies unexpected cleanup
  errors still propagate.
- `python -m pytest -s --tb=short python/test/unit/runtime/test_cache.py`
  (`46 passed, 1 skipped` on Linux with an RTX 4090)
- Exact-source native build and an SM89 JIT/launch smoke test passed.

## A/B evidence

With deterministic `EBUSY` injection at the temp-dir cleanup boundary:

- exact base: 1,000/1,000 `put` calls raised after all 1,000 artifacts had
  already been published;
- patch: 0/1,000 calls raised and all 1,000 artifacts were published.

Fixes the cleanup portion of #11512.
