### PR TITLE
[RUNTIME] Serialize concurrent kernel handle initialization

### DIFF
--- a/python/test/unit/runtime/test_launch.py
+++ b/python/test/unit/runtime/test_launch.py
@@ -3,12 +3,16 @@ import tracemalloc
 import pytest
 import pathlib
 import os
+from concurrent.futures import ThreadPoolExecutor
+from threading import Event, Lock, get_ident
+from types import SimpleNamespace
 import numpy as np
 
 import torch
 import triton
 import triton.language as tl
 from triton._internal_testing import is_cuda, is_hip
+from triton.compiler import compiler
 
 
 def test_metadata() -> None:
@@ -100,6 +104,143 @@ def test_load_hook() -> None:
     assert start_hash == end_hash
     triton.knobs.runtime.kernel_load_start_hook.remove(hook_start)
     triton.knobs.runtime.kernel_load_end_hook.remove(hook_end)
+
+
+def test_concurrent_kernel_load(monkeypatch) -> None:
+    launcher_created = Event()
+    release_load = Event()
+    waiter_entered = Event()
+    end_hook_entered = Event()
+    release_end_hook = Event()
+    start_hook_reentered = Event()
+    module = object()
+    function = object()
+    launched_functions = []
+    load_calls = 0
+
+    def launcher(*args):
+        launched_functions.append(args[4])
+
+    class ObservableLock:
+
+        def __init__(self):
+            self.lock = Lock()
+            self.first_owner = None
+
+        def __enter__(self):
+            self.lock.acquire()
+            owner = get_ident()
+            if self.first_owner is None:
+                self.first_owner = owner
+            elif owner != self.first_owner:
+                waiter_entered.set()
+            return self
+
+        def __exit__(self, exc_type, exc_value, traceback):
+            self.lock.release()
+
+    def make_launcher(src, metadata):
+        launcher_created.set()
+        return launcher
+
+    def load_binary(name, kernel, shared, device):
+        nonlocal load_calls
+        load_calls += 1
+        assert release_load.wait(timeout=5)
+        return module, function, 32, 0, 1024
+
+    utils = SimpleNamespace(
+        get_device_properties=lambda _: {"max_shared_mem": 1},
+        load_binary=load_binary,
+        unload_module=lambda _: None,
+    )
+    fake_driver = SimpleNamespace(
+        get_current_device=lambda: 0,
+        get_current_stream=lambda _: 0,
+        get_current_target=lambda: SimpleNamespace(warp_size=32),
+        launcher_cls=make_launcher,
+        utils=utils,
+    )
+    monkeypatch.setattr(compiler.driver, "_active", fake_driver)
+    monkeypatch.setattr(compiler, "max_shared_mem", lambda _: 1)
+
+    compiled = object.__new__(compiler.CompiledKernel)
+    compiled.src = object()
+    compiled.metadata = SimpleNamespace(shared=0, num_warps=4, target=SimpleNamespace(arch=89))
+    compiled.metadata_group = {}
+    compiled.packed_metadata = ()
+    compiled.hash = "hash"
+    compiled.name = "kernel"
+    compiled.kernel = b""
+    compiled.module = None
+    compiled._module_pid = None
+    compiled.function = None
+    compiled._run = None
+    # Simulate a fork copying a lock held by a thread that does not survive in
+    # the child. The child must replace that lock before lazy initialization.
+    stale_lock = Lock()
+    stale_lock.acquire()
+    stale_state = SimpleNamespace(lock=stale_lock, event=Event(), owner=1, run=None, handles_ready=False)
+    current_state = SimpleNamespace(lock=ObservableLock(), event=Event(), owner=None, run=None, handles_ready=False)
+    compiled._init_states = {-1: stale_state}
+    compiled._handle_generation = getattr(compiler, "_handle_generation", 0)
+    if hasattr(compiler, "_HandleInitState"):
+        monkeypatch.setattr(compiler, "_HandleInitState", lambda: current_state)
+
+    def hook_start(module, function, name, metadata_group, hash):
+        assert compiled.run is launcher
+        start_hook_reentered.set()
+
+    def hook_end(module, function, name, metadata_group, hash):
+        end_hook_entered.set()
+        assert compiled.module is module
+        assert compiled.function is function
+        compiled[(1, 1, 1)]()
+        assert launched_functions[-1] is function
+        assert release_end_hook.wait(timeout=5)
+
+    triton.knobs.runtime.kernel_load_start_hook.add(hook_start)
+    triton.knobs.runtime.kernel_load_end_hook.add(hook_end)
+
+    try:
+        with ThreadPoolExecutor(max_workers=2) as pool:
+            first = pool.submit(lambda: compiled.run)
+            assert launcher_created.wait(timeout=5)
+            assert start_hook_reentered.wait(timeout=5)
+            second = pool.submit(lambda: compiled.run)
+            try:
+                assert waiter_entered.wait(timeout=5)
+                assert not second.done()
+                release_load.set()
+                assert end_hook_entered.wait(timeout=5)
+                assert not second.done()
+            finally:
+                release_load.set()
+                release_end_hook.set()
+            assert first.result(timeout=5) is launcher
+            assert second.result(timeout=5) is launcher
+        assert load_calls == 1
+        assert compiled.module is module
+        assert compiled.function is function
+
+        # A child must discard even fully published handles from its parent.
+        compiled.module = object()
+        compiled._module_pid = -1
+        compiled.function = object()
+        compiled._run = launcher
+        compiled._handle_generation = -1
+        assert compiled.run is launcher
+        assert load_calls == 2
+        assert compiled.module is module
+        assert compiled.function is function
+    finally:
+        release_load.set()
+        release_end_hook.set()
+        triton.knobs.runtime.kernel_load_start_hook.remove(hook_start)
+        triton.knobs.runtime.kernel_load_end_hook.remove(hook_end)
+        compiled.module = None
+        compiled._module_pid = None
+        stale_lock.release()
 
 
 def test_multiple_hooks() -> None:

--- a/python/triton/compiler/compiler.py
+++ b/python/triton/compiler/compiler.py
@@ -16,6 +16,7 @@ import functools
 import os
 import time
 import copy
+import threading
 
 # - ^\s*tt\.func\s+ : match the start of the string, any leading whitespace, the keyword func,
 #    and any following whitespace
@@ -404,6 +405,43 @@ def _raise_error(err, *args, **kwargs):
     raise copy.deepcopy(err)
 
 
+_handle_init_tls = threading.local()
+_handle_generation = 0
+
+
+def _after_fork():
+    global _handle_generation
+    _handle_generation += 1
+
+
+if hasattr(os, "register_at_fork"):
+    os.register_at_fork(after_in_child=_after_fork)
+
+
+def _run_kernel_load_hook(hook, state, *args):
+    hook_state = getattr(_handle_init_tls, "state", None)
+    _handle_init_tls.state = state
+    try:
+        hook(*args)
+    finally:
+        _handle_init_tls.state = hook_state
+
+
+def _ensure_same_process(pid, generation):
+    if os.getpid() != pid or _handle_generation != generation:
+        raise RuntimeError("process forked during kernel initialization; retry the launch")
+
+
+class _HandleInitState:
+
+    def __init__(self):
+        self.lock = threading.Lock()
+        self.event = threading.Event()
+        self.owner = None
+        self.run = None
+        self.handles_ready = False
+
+
 class CompiledKernel:
 
     def __init__(self, src, metadata_group, hash):
@@ -436,6 +474,8 @@ class CompiledKernel:
         self._module_pid = None
         self.function = None
         self._run = None
+        self._handle_generation = _handle_generation
+        self._init_states = {os.getpid(): _HandleInitState()}
 
     def __del__(self):
 
@@ -449,50 +489,162 @@ class CompiledKernel:
             self.module = None
             self._module_pid = None
 
-    def _init_handles(self):
-        if self.module is not None:
-            return
+    def _init_handles(self, allow_provisional=False):
+        if self._run is not None and self._handle_generation == _handle_generation:
+            return self._run
 
-        def raise_(err):
-            # clone the exception object so that the one saved in the closure
-            # of the partial function below doesn't get assigned a stack trace
-            # after the subsequent raise. otherwise, the CompiledKernel instance
-            # saved in the (global) kernel cache will keep references to all the
-            # locals in the traceback via the exception instance in the closure.
-            cloned_err = copy.deepcopy(err)
-            self._run = functools.partial(_raise_error, cloned_err)
-            raise err
+        pid = os.getpid()
+        state = self._init_states.get(pid)
+        if state is None:
+            # setdefault makes concurrent first access in a forked child select
+            # one state without ever reusing the parent's possibly held lock.
+            state = self._init_states.setdefault(pid, _HandleInitState())
+        owner = threading.get_ident()
+        generation = _handle_generation
+        while True:
+            with state.lock:
+                if self._handle_generation != _handle_generation:
+                    self.module = None
+                    self._module_pid = None
+                    self.function = None
+                    self._run = None
+                    self._handle_generation = _handle_generation
+                if self._run is not None:
+                    return self._run
+                if state.owner is None:
+                    state.owner = owner
+                    state.handles_ready = False
+                    state.event.clear()
+                    break
+                hook_state = getattr(_handle_init_tls, "state", None)
+                if state.owner == owner and state.handles_ready:
+                    return state.run
+                if allow_provisional and state.run is not None and hook_state is state:
+                    return state.run
+                if state.owner == owner or hook_state is not None:
+                    raise RuntimeError("cannot initialize a kernel recursively from a kernel load hook")
+                event = state.event
+            event.wait()
+
+        try:
+            handles, error, cache_error = self._load_handles(state, pid, generation)
+            _ensure_same_process(pid, generation)
+        except BaseException:
+            with state.lock:
+                if self._module_pid is not None and self._module_pid != os.getpid():
+                    self.module = None
+                    self._module_pid = None
+                    self.function = None
+                state.owner = None
+                state.run = None
+                state.handles_ready = False
+                state.event.set()
+            raise
+
+        run = state.run
+        try:
+            if cache_error:
+                # Clone the exception so the one saved in the partial below
+                # does not retain this frame through its traceback.
+                run = functools.partial(_raise_error, copy.deepcopy(error))
+        except BaseException:
+            with state.lock:
+                state.owner = None
+                state.run = None
+                state.handles_ready = False
+                state.event.set()
+            raise
+
+        try:
+            with state.lock:
+                _ensure_same_process(pid, generation)
+                self._run = run
+                state.owner = None
+                state.run = None
+                state.handles_ready = False
+                state.event.set()
+        except BaseException:
+            with state.lock:
+                self._run = None
+                state.owner = None
+                state.run = None
+                state.handles_ready = False
+                state.event.set()
+            raise
+
+        if error is not None:
+            raise error
+        return run
+
+    def _load_handles(self, state, pid, generation):
 
         device = driver.active.get_current_device()
+        if self.module is not None and self._run is None:
+            if self._module_pid == os.getpid():
+                if knobs.runtime.kernel_unload_hook is not None:
+                    knobs.runtime.kernel_unload_hook(self.module, self.function, self.name, self.metadata_group,
+                                                     self.hash)
+                driver.active.utils.unload_module(self.module)
+            self.module = None
+            self._module_pid = None
+            self.function = None
         # create launcher
-        self._run = driver.active.launcher_cls(self.src, self.metadata)
+        run = driver.active.launcher_cls(self.src, self.metadata)
+        with state.lock:
+            state.run = run
         # not enough shared memory to run the kernel
         max_shared = max_shared_mem(device)
         if self.metadata.shared > max_shared:
-            raise_(OutOfResources(self.metadata.shared, max_shared, "shared memory"))
+            return None, OutOfResources(self.metadata.shared, max_shared, "shared memory"), True
         if hasattr(self.metadata, "tmem_size") and self.metadata.tmem_size is not None:
             # Use blackwell max tmem size for now, this should be moved in device properties
             max_tmem_size = 512  # tmem size in number of columns
             if self.metadata.target.arch == 107:
                 max_tmem_size = 576
             if self.metadata.tmem_size > max_tmem_size:
-                raise_(OutOfResources(self.metadata.tmem_size, max_tmem_size, "tensor memory"))
+                return None, OutOfResources(self.metadata.tmem_size, max_tmem_size, "tensor memory"), True
         if knobs.runtime.kernel_load_start_hook is not None:
-            knobs.runtime.kernel_load_start_hook(self.module, self.function, self.name, self.metadata_group, self.hash)
-        # TODO: n_regs, n_spills should be metadata generated when calling `ptxas`
-        self.module, self.function, self.n_regs, self.n_spills, self.n_max_threads = driver.active.utils.load_binary(
-            self.name, self.kernel, self.metadata.shared, device)
-        self._module_pid = os.getpid()
+            _run_kernel_load_hook(knobs.runtime.kernel_load_start_hook, state, self.module, self.function, self.name,
+                                  self.metadata_group, self.hash)
+        _ensure_same_process(pid, generation)
         warp_size = driver.active.get_current_target().warp_size
-        if self.metadata.num_warps * warp_size > self.n_max_threads:
-            raise_(OutOfResources(self.metadata.num_warps * warp_size, self.n_max_threads, "threads"))
+        # TODO: n_regs, n_spills should be metadata generated when calling `ptxas`
+        module, function, n_regs, n_spills, n_max_threads = driver.active.utils.load_binary(
+            self.name, self.kernel, self.metadata.shared, device)
+        _ensure_same_process(pid, generation)
+        handles = (module, function, n_regs, n_spills, n_max_threads)
+        with state.lock:
+            # End hooks have historically observed usable handles. Publish the
+            # generation first so a fork during these assignments discards the
+            # parent's partial state, while normal waiters still gate on _run.
+            self._handle_generation = _handle_generation
+            self._module_pid = os.getpid()
+            self.module = module
+            self.function = function
+            self.n_regs = n_regs
+            self.n_spills = n_spills
+            self.n_max_threads = n_max_threads
+            state.handles_ready = True
+        if self.metadata.num_warps * warp_size > n_max_threads:
+            error = OutOfResources(self.metadata.num_warps * warp_size, n_max_threads, "threads")
+            return handles, error, True
         if knobs.runtime.kernel_load_end_hook is not None:
-            knobs.runtime.kernel_load_end_hook(self.module, self.function, self.name, self.metadata_group, self.hash)
+            try:
+                _run_kernel_load_hook(knobs.runtime.kernel_load_end_hook, state, module, function, self.name,
+                                      self.metadata_group, self.hash)
+            except BaseException as error:
+                # The handles are usable even if an observer hook fails. Match
+                # the existing behavior by publishing them before re-raising.
+                return handles, error, False
+        _ensure_same_process(pid, generation)
+        return handles, None, False
 
     @property
     def run(self):
-        if self._run is None:
-            self._init_handles()
+        if self._run is None or self._handle_generation != _handle_generation:
+            run = self._init_handles(allow_provisional=True)
+            if run is not None:
+                return run
         return self._run
 
     def launch_metadata(self, grid, stream, *args):


### PR DESCRIPTION
## Why

`CompiledKernel._init_handles()` currently publishes `_run` as soon as it creates the launcher, before `load_binary()` has published `module` and `function` or the kernel-load hooks have completed. A concurrent first access can therefore observe `_run`, skip initialization, and return a launcher for a partially initialized kernel.

## What changed

- Coordinate lazy handle initialization so one thread owns the load and other callers wait for final publication.
- Keep the launcher provisionally visible to the owning load hook, publish loaded handles before the end hook as before, and publish `_run` to ordinary callers only after the end hook finishes.
- Preserve cached internal `OutOfResources` failures and retry non-resource hook/driver failures without losing a loaded module handle.
- Invalidate inherited handle state after `fork()` and reject recursive cross-kernel initialization from load hooks instead of exposing a partial launcher or deadlocking.

## Validation

- Exact-base regression at `c349ce522e996cf0662249caa47b5d97a1748330`: `test_concurrent_kernel_load` fails because the second caller never enters the initialization wait path.
- Patched regression: `1 passed`.
- `python/test/unit/runtime/test_launch.py`: `10 passed`.
- `test_concurrent_kernel_load` plus `test_module_load_unload`: `2 passed` (with Python 3.12's existing multi-threaded `fork()` deprecation warning).
- RTX 4090 / SM89 smoke test: eight concurrent cold accesses observed one start hook, one end hook, the same launcher in every worker, and a correct real CUDA launch.
- Applicable pre-commit hooks passed individually: generic file checks, Ruff, YAPF, and mypy; `py_compile` and `git diff --check` also passed. The aggregate template command was run but stopped while installing the unrelated local Go `expand-yaml-anchors` hook because `proxy.golang.org` timed out.
- Hot getter microbenchmark (500,000 warmup, 9 x 2,000,000 accesses): base median 55.70 ns, patch median 71.57 ns. This measures only Python `CompiledKernel.run` property access, not CUDA dispatch or end-to-end execution.

# New contributor declaration

- [x] I am not making a trivial change, such as fixing a typo in a comment.

- [x] I have written a PR description following these
  [rules](https://cbea.ms/git-commit/#why-not-how).

- [x] I have run `pre-commit run --from-ref origin/main --to-ref HEAD`.

- Select one of the following.
  - [x] I have added tests.
    - `/test` for `lit` tests
    - `/unittest` for C++ tests
    - `/python/test` for end-to-end tests
  - [ ] This PR does not need a test because `FILL THIS IN`.

- Select one of the following.
  - [x] I have not added any `lit` tests.
  - [ ] The `lit` tests I have added follow these [best practices](https://mlir.llvm.org/getting_started/TestingGuide/#filecheck-best-practices),
    including the "tests should be minimal" section. (Usually running Python code
    and using the instructions it generates is not minimal.)
