### PR TITLE
[OPTIMIZER] Respect disable_licm in Triton LICM

### DIFF
--- a/lib/Dialect/Triton/Transforms/LoopInvariantCodeMotion.cpp
+++ b/lib/Dialect/Triton/Transforms/LoopInvariantCodeMotion.cpp
@@ -1,3 +1,4 @@
+#include "mlir/Dialect/LLVMIR/LLVMAttrs.h"
 #include "mlir/Transforms/LoopInvariantCodeMotionUtils.h"
 #include "triton/Dialect/Triton/IR/Dialect.h"
 #include "triton/Dialect/Triton/IR/Utility.h"
@@ -19,6 +20,20 @@ class LoopInvariantCodeMotionPass
 
   DenseMap<LoopLikeOpInterface, bool> isLoopMemoryEffectFreeOrOnlyRead;
 
+  bool isLICMDisabled(LoopLikeOpInterface loopLike) {
+    auto loopMD = loopLike->getAttrOfType<LLVM::LoopAnnotationAttr>(
+        LLVM::LoopAnnotationAttr::name);
+    if (!loopMD)
+      return false;
+
+    auto licmMD = loopMD.getLicm();
+    if (!licmMD)
+      return false;
+
+    auto disable = licmMD.getDisable();
+    return disable && disable.getValue();
+  }
+
   bool isMemoryEffectFreeOrOnlyRead(Operation *op) {
     std::optional<SmallVector<MemoryEffects::EffectInstance>> effects =
         getEffectsRecursively(op);
@@ -35,6 +50,8 @@ class LoopInvariantCodeMotionPass
     // This way, we first LICM from the inner loop, and place the ops in the
     // outer loop, which in turn can be further LICM'ed.
     getOperation()->walk([&](LoopLikeOpInterface loopLike) {
+      if (isLICMDisabled(loopLike))
+        return;
       moveLoopInvariantCode(
           loopLike.getLoopRegions(),
           // isDefinedOutsideOfRegion

--- a/test/Triton/loop-invariant-code-motion.mlir
+++ b/test/Triton/loop-invariant-code-motion.mlir
@@ -167,3 +167,17 @@ tt.func @hoist_cond_no_hoist_load_from_scf_while(%ptr: tensor<1024x!tt.ptr<f32>>
   tt.store %ptr, %1 : tensor<1024x!tt.ptr<f32>>
   tt.return
 }
+
+// -----
+
+tt.func @do_not_hoist_from_for_with_licm_disabled(%lb: i32, %ub: i32, %step: i32, %a: i32, %b: i32) -> i32 {
+  // CHECK-LABEL: do_not_hoist_from_for_with_licm_disabled
+  // CHECK-NOT: arith.addi
+  // CHECK: scf.for
+  // CHECK: arith.addi
+  %result = scf.for %i = %lb to %ub step %step iter_args(%value = %a) -> i32 : i32 {
+    %sum = arith.addi %a, %b : i32
+    scf.yield %sum : i32
+  } {llvm.loop_annotation = #llvm.loop_annotation<licm = <disable = true>>}
+  tt.return %result : i32
+}


### PR DESCRIPTION
Triton LICM still occurs even through `tl.range(..., disable_licm=True)` is used. The frontend records this option in the loop's llvm.loop_annotation, but Triton's LICM pass previously ignored the setting and hoisted invariant operations out of the loop.

The issue can be reproduced with:
```
import triton
import triton.language as tl
from triton.runtime import MockTensor


@triton.jit
def kernel(output, n, a, b):
    product = 0
    for _ in tl.range(0, n, disable_licm=True):
        product += a * b
    tl.store(output, product)


compiled = kernel.warmup(MockTensor(tl.int32), 10, 3, 4, grid=(1, ))
print(compiled.asm["ttgir"])
```

Before this commit, a * b is hoisted outside the loop:
```
%invariant = arith.muli %a, %b
%result = scf.for ... {
  %next = arith.addi %acc, %invariant
}
```
After this commit, the multiplication remains inside the loop as requested:
```
%result = scf.for ... {
  %invariant = arith.muli %a, %b
  %next = arith.addi %acc, %invariant
}
```
Loops without disable_licm=True retain the existing LICM behavior. A minimal scf.for regression test is included.


<!---
The core Triton is a small number of people, and we receive many PRs (thank
you!).  To help us review your code more quickly, **if you are a new
contributor (less than 3 PRs merged) we ask that you complete the following
tasks and include the filled-out checklist in your PR description.**

Complete the following tasks before sending your PR, and replace `[ ]` with
`[x]` to indicate you have done them.
-->

# New contributor declaration
- [x] I am not making a trivial change, such as fixing a typo in a comment.

- [x] I have written a PR description following these
  [rules](https://cbea.ms/git-commit/#why-not-how).

- [x] I have run `pre-commit run --from-ref origin/main --to-ref HEAD`.

- Select one of the following.
  - [x] I have added tests.
    - `/test` for `lit` tests
    - `/unittest` for C++ tests
    - `/python/test` for end-to-end tests
  - [ ] This PR does not need a test because `FILL THIS IN`.

- Select one of the following.
  - [ ] I have not added any `lit` tests.
  - [x] The `lit` tests I have added follow these [best practices](https://mlir.llvm.org/getting_started/TestingGuide/#filecheck-best-practices),
    including the "tests should be minimal" section. (Usually running Python code
    and using the instructions it generates is not minimal.)
