### PR TITLE
[TRITONGPU] FuseNestedLoops: only trust llvm.assume that dominates the loop

### DIFF
--- a/lib/Dialect/TritonGPU/Transforms/FuseNestedLoops.cpp
+++ b/lib/Dialect/TritonGPU/Transforms/FuseNestedLoops.cpp
@@ -1105,11 +1105,18 @@ static void optimizeEpilogueDependencies(scf::ForOp outerLoop,
 }
 
 // Crudely match llvm.assume(ub > lb) or llvm.assume(lb < ub).
-static LogicalResult matchPositiveTripCount(scf::ForOp loop) {
+static LogicalResult matchPositiveTripCount(scf::ForOp loop,
+                                            mlir::DominanceInfo &domInfo) {
   for (Operation *user : loop.getUpperBound().getUsers()) {
     if (auto cmp = dyn_cast<arith::CmpIOp>(user)) {
-      if (llvm::none_of(cmp->getUsers(),
-                        [](Operation *op) { return isa<LLVM::AssumeOp>(op); }))
+      // An llvm.assume only licenses its condition at program points that are
+      // reachable from the assume; only trust it if it properly dominates the
+      // loop. Otherwise an assume on a branch the loop is not reachable from
+      // would let us drop the zero-trip version split and miscompile.
+      if (llvm::none_of(cmp->getUsers(), [&](Operation *op) {
+            return isa<LLVM::AssumeOp>(op) &&
+                   domInfo.properlyDominates(op, loop);
+          }))
         continue;
       if (cmp.getPredicate() == (loop.getUnsignedCmp()
                                      ? arith::CmpIPredicate::ugt
@@ -1139,7 +1146,7 @@ static LogicalResult speculateInnerLoopLength(scf::ForOp outerLoop,
   ImplicitLocOpBuilder b(loc, outerLoop);
 
   // Check if the inner loop is known to execute at least once.
-  if (succeeded(matchPositiveTripCount(innerLoop))) {
+  if (succeeded(matchPositiveTripCount(innerLoop, domInfo))) {
     innerLoop->setAttr(kMustExecuteAttrName, b.getUnitAttr());
     return success();
   }

--- a/lib/Dialect/TritonGPU/Transforms/FuseNestedLoops.cpp
+++ b/lib/Dialect/TritonGPU/Transforms/FuseNestedLoops.cpp
@@ -1109,10 +1109,6 @@ static LogicalResult matchPositiveTripCount(scf::ForOp loop,
                                             mlir::DominanceInfo &domInfo) {
   for (Operation *user : loop.getUpperBound().getUsers()) {
     if (auto cmp = dyn_cast<arith::CmpIOp>(user)) {
-      // An llvm.assume only licenses its condition at program points that are
-      // reachable from the assume; only trust it if it properly dominates the
-      // loop. Otherwise an assume on a branch the loop is not reachable from
-      // would let us drop the zero-trip version split and miscompile.
       if (llvm::none_of(cmp->getUsers(), [&](Operation *op) {
             return isa<LLVM::AssumeOp>(op) &&
                    domInfo.properlyDominates(op, loop);

--- a/python/test/regression/test_functional_regressions.py
+++ b/python/test/regression/test_functional_regressions.py
@@ -343,37 +343,3 @@ def test_permutation_ptxas_bug(device):
     )
     ref = torch.matmul(X.float(), W.float()).to(dtype)
     torch.testing.assert_close(Out.to(torch.float32), ref.to(torch.float32), rtol=0.25, atol=0.0625)
-
-
-def test_fuse_nested_loops_assume_on_unreachable_branch(device):
-    # Regression test for https://github.com/triton-lang/triton/issues/11519:
-    # tritongpu-fuse-nested-loops trusted an llvm.assume(ub > lb) even when it
-    # did not dominate the loop nest (it sat on a branch the nest is not
-    # reachable from) and dropped the zero-trip version split. On the legal call
-    # m=4, n=0 the fused loop then ran max(n, 1) * m times, returned a value the
-    # source cannot produce, and stored into a buffer the source never writes.
-
-    @triton.jit
-    def assume_other_branch(p, out, sink, m, n, BLOCK: tl.constexpr, FLAT: tl.constexpr):
-        offs = tl.arange(0, BLOCK)
-        acc = tl.zeros([BLOCK], dtype=tl.float32)
-        if m == 0:
-            tl.assume(n > 0)  # in force only where m == 0
-            acc += tl.load(p + offs)
-        else:
-            for i in tl.range(0, m, flatten=FLAT):
-                for j in range(0, n):  # the nest, reachable only where m != 0
-                    acc += tl.load(p + j * BLOCK + offs)
-                    tl.store(sink + (i * 8 + j) * BLOCK + offs, acc)
-        tl.store(out + offs, acc)
-
-    BLOCK = 64
-    p = torch.arange(BLOCK, dtype=torch.float32, device=device) % 7.0 + 1.0
-    out = torch.full((BLOCK, ), -7777.0, dtype=torch.float32, device=device)
-    sink = torch.full((4 * 8 * BLOCK, ), -7777.0, dtype=torch.float32, device=device)
-    # m=4, n=0 is a legal call: the else-branch nest runs zero times, so the
-    # source leaves out at zero and never writes sink.
-    assume_other_branch[(1, )](p, out, sink, 4, 0, BLOCK=BLOCK, FLAT=True)
-    if not is_compile_warmup():
-        torch.testing.assert_close(out, torch.zeros(BLOCK, dtype=torch.float32, device=device))
-        assert torch.all(sink == -7777.0)

--- a/python/test/regression/test_functional_regressions.py
+++ b/python/test/regression/test_functional_regressions.py
@@ -343,3 +343,37 @@ def test_permutation_ptxas_bug(device):
     )
     ref = torch.matmul(X.float(), W.float()).to(dtype)
     torch.testing.assert_close(Out.to(torch.float32), ref.to(torch.float32), rtol=0.25, atol=0.0625)
+
+
+def test_fuse_nested_loops_assume_on_unreachable_branch(device):
+    # Regression test for https://github.com/triton-lang/triton/issues/11519:
+    # tritongpu-fuse-nested-loops trusted an llvm.assume(ub > lb) even when it
+    # did not dominate the loop nest (it sat on a branch the nest is not
+    # reachable from) and dropped the zero-trip version split. On the legal call
+    # m=4, n=0 the fused loop then ran max(n, 1) * m times, returned a value the
+    # source cannot produce, and stored into a buffer the source never writes.
+
+    @triton.jit
+    def assume_other_branch(p, out, sink, m, n, BLOCK: tl.constexpr, FLAT: tl.constexpr):
+        offs = tl.arange(0, BLOCK)
+        acc = tl.zeros([BLOCK], dtype=tl.float32)
+        if m == 0:
+            tl.assume(n > 0)  # in force only where m == 0
+            acc += tl.load(p + offs)
+        else:
+            for i in tl.range(0, m, flatten=FLAT):
+                for j in range(0, n):  # the nest, reachable only where m != 0
+                    acc += tl.load(p + j * BLOCK + offs)
+                    tl.store(sink + (i * 8 + j) * BLOCK + offs, acc)
+        tl.store(out + offs, acc)
+
+    BLOCK = 64
+    p = torch.arange(BLOCK, dtype=torch.float32, device=device) % 7.0 + 1.0
+    out = torch.full((BLOCK, ), -7777.0, dtype=torch.float32, device=device)
+    sink = torch.full((4 * 8 * BLOCK, ), -7777.0, dtype=torch.float32, device=device)
+    # m=4, n=0 is a legal call: the else-branch nest runs zero times, so the
+    # source leaves out at zero and never writes sink.
+    assume_other_branch[(1, )](p, out, sink, 4, 0, BLOCK=BLOCK, FLAT=True)
+    if not is_compile_warmup():
+        torch.testing.assert_close(out, torch.zeros(BLOCK, dtype=torch.float32, device=device))
+        assert torch.all(sink == -7777.0)

--- a/test/TritonGPU/fuse-nested-loops.mlir
+++ b/test/TritonGPU/fuse-nested-loops.mlir
@@ -596,3 +596,43 @@ tt.func @prologue_output(%ub: i32) {
 
   tt.return
 }
+
+// -----
+
+// CHECK-LABEL: @assume_not_dominating_loop
+// An llvm.assume(ub > lb) that does not dominate the inner loop (it sits on
+// another branch of an scf.if) must not license dropping the zero-trip version
+// split of the fused loop: the nest is not reachable from the assume, so the
+// fast path must be declined and the runtime zero-trip guard kept.
+// CHECK-SAME: [[LB:%.*]]: i32, [[UB:%.*]]: i32, [[FLAG:%.*]]: i1
+tt.func @assume_not_dominating_loop(%lb: i32, %ub: i32, %flag: i1) {
+  %c0_i32 = arith.constant 0 : i32
+  %c1_i32 = arith.constant 1 : i32
+
+  // The inner loop goes from 0 to %ub, so its zero-trip test is %ub == 0, and
+  // it must still be emitted (the assume on the other branch is not in force
+  // here). The buggy pass instead replaced this guard with `arith.constant
+  // true` because it matched the assume without a dominance check.
+  // CHECK: [[IS_ZERO:%.*]] = arith.cmpi eq, [[UB]], %c0_i32
+  // CHECK: scf.if [[IS_ZERO]]
+  // CHECK-NEXT: scf.for %{{.*}} = %c0_i32 to [[UB]] step %c1_i32
+  // CHECK-NEXT:   "prologue"
+  // CHECK-NOT: arith.constant true
+  scf.if %flag {
+    // The assume is in force only where %flag holds; the loop nest below is
+    // only reachable where %flag does not hold.
+    %cmp = arith.cmpi sgt, %ub, %lb : i32
+    llvm.intr.assume %cmp : i1
+    scf.yield
+  } else {
+    scf.for %i = %c0_i32 to %ub step %c1_i32 : i32 {
+      "prologue"(%i) : (i32) -> ()
+      scf.for %j = %c0_i32 to %ub step %c1_i32 : i32 {
+        "body"(%i, %j) : (i32, i32) -> ()
+        scf.yield
+      }
+    } {tt.flatten}
+    scf.yield
+  }
+  tt.return
+}


### PR DESCRIPTION
# [TRITONGPU] FuseNestedLoops: only trust `llvm.assume` that dominates the loop

Fixes #11519.

## Problem

`tritongpu-fuse-nested-loops` proves an inner loop's trip count positive by
matching an `llvm.assume(ub > lb)` **anywhere in the function** — no dominance
or reachability query. When the assume sits on a branch the loop nest is not
reachable from (e.g. a shape-specialization branch that asserts something
about another parameter), the pass marks the inner loop as must-execute and
drops the zero-trip version split it would otherwise emit.

On a fully legal call (`m=4, n=0` in the reproducer) the fused loop then runs
`max(n, 1) * m` times: the kernel returns a value the source program cannot
produce, and stores into a buffer the source program never writes (silent
memory corruption, no diagnostic).

The assumption is not being weighed and found probable: it is being read from
a program point the code under transformation cannot reach, which no
assumption-consuming analysis in LLVM or MLIR would consider valid
(`llvm::isValidAssumeForContext` is dominance-gated).

## Fix

Thread `DominanceInfo` (already held by the pass and used two functions above
in the same file) into `matchPositiveTripCount` and require the matched
`llvm.assume` to **properly dominate the loop**. Otherwise fall through to the
existing version-split path, which is what every kernel without an in-scope
assume gets today. The in-tree `_p_matmul` idiom (`tl.assume(loop_bound > 0)`
immediately before the loop) keeps the fast path — nothing is lost there.

## Verification

- Reproduced on NVIDIA H200 (sm_90) with the reproducer from #11519: before
  the fix `out[:4] = [4.0, 8.0, 12.0, 16.0]` and 256 spurious `sink` writes;
  after the fix `out` stays `[0.0, 0.0, 0.0, 0.0]` and `sink` is untouched.
- The structural half (no GPU): before the fix the emitted LLVM IR for the
  assume kernel contains no zero-trip test (`icmp eq i32 %4, 0` absent); after
  the fix it is present, matching the assume-free control kernel.
- Lit test `test/TritonGPU/fuse-nested-loops.mlir`: new `@assume_not_dominating_loop`
  case asserts the zero-trip guard (`scf.if (ub == 0)`) is still emitted and no
  `arith.constant true` must-execute guard appears.

## Tests

- [x] `/test` for `lit` tests
- [ ] `/python/test` for end-to-end tests

## New contributor declaration

- [x] I am not making a trivial change, such as fixing a typo in a comment.
- [x] I have written a PR description following these
  [rules](https://cbea.ms/git-commit/#why-not-how).
- [x] I have run `pre-commit run --from-ref origin/main --to-ref HEAD`
  (the `expand-yaml-anchors` hook was skipped: it only applies to
  `.github/workflows/integration-tests.yml` and needs a network fetch of `yq`).
