### PR TITLE
[PROTON] Move Proton lowering before warp specialization

### DIFF
--- a/third_party/amd/backend/compiler.py
+++ b/third_party/amd/backend/compiler.py
@@ -384,6 +384,8 @@ class HIPBackend(BaseBackend):
         ##    For now it is used as a controller for developers only.
         __HIP_FTZ = True
         amd.passes.ttgpuir.add_to_llvmir(pm, options.arch, __HIP_FTZ)
+        # Lower Proton segment values before warp specialization captures partition operands.
+        instrument(pm, point="llvmir-to-llvm", context=mod.context)
         amd.passes.ttgpuir.add_warp_specialize_to_llvm(pm, options.arch)
         passes.common.add_canonicalizer(pm)
         passes.common.add_cse(pm)
@@ -393,9 +395,6 @@ class HIPBackend(BaseBackend):
         passes.common.add_canonicalizer(pm)
         passes.common.add_cse(pm)
         passes.common.add_symbol_dce(pm)
-
-        # This can not be moved below the di_scope pass
-        instrument(pm, point="llvmir-to-llvm", context=mod.context)
 
         if not knobs.compilation.disable_line_info and not knobs.compilation.dump_ir_extract_di_local_variables:
             passes.llvmir.add_di_scope(pm)

--- a/third_party/nvidia/backend/compiler.py
+++ b/third_party/nvidia/backend/compiler.py
@@ -436,6 +436,8 @@ class CUDABackend(BaseBackend):
             nvidia.passes.ttgpuir.add_set_minimum_shared_memory(pm, options.min_shared_mem)
         passes.ttgpuir.add_canonicalize_llvm_ir(pm)
         passes.common.add_cse(pm)
+        # Lower Proton segment values before warp specialization captures partition operands.
+        instrument(pm, point="llvmir-to-llvm", context=mod.context)
         nvidia.passes.ttnvgpuir.add_warp_specialize_to_llvm(pm)
         nvidia.passes.ttnvgpuir.add_nvgpu_to_llvm(pm)
         passes.common.add_canonicalizer(pm)
@@ -445,8 +447,6 @@ class CUDABackend(BaseBackend):
 
         if not knobs.compilation.disable_line_info and not knobs.compilation.dump_ir_extract_di_local_variables:
             passes.llvmir.add_di_scope(pm)
-
-        instrument(pm, point="llvmir-to-llvm", context=mod.context)
 
         pm.run(mod, 'make_llir')
 

--- a/third_party/proton/Dialect/lib/ProtonToProtonGPU/ProtonToProtonGPUPass.cpp
+++ b/third_party/proton/Dialect/lib/ProtonToProtonGPU/ProtonToProtonGPUPass.cpp
@@ -71,9 +71,10 @@ template <typename T> bool hasProtonEvent(T *o) {
 
 void instrumentWarpSpecializeOps(FuncOp func, Value buffer, Value profileMem) {
   for (auto wsOp : func.getOps<triton::gpu::WarpSpecializeOp>()) {
-    auto loc = wsOp.getLoc();
-    if (hasProtonEvent(wsOp.getOperation())) {
-      auto partOp = wsOp.getPartitionOp();
+    auto partOp = wsOp.getPartitionOp();
+    if (hasProtonEvent(partOp.getOperation())) {
+      auto loc = wsOp.getLoc();
+      // All worker partitions share the same explicit capture list.
       partOp->insertOperands(partOp->getNumOperands(), {buffer, profileMem});
       for (Region *region : wsOp.getPartitionRegions()) {
         region->addArgument(buffer.getType(), loc);

--- a/third_party/proton/test/test_instrumentation.py
+++ b/third_party/proton/test/test_instrumentation.py
@@ -348,6 +348,40 @@ def test_gluon_warp_specialized_event(tmp_path: pathlib.Path):
         assert start["ts"] <= end["ts"]
 
 
+@pytest.mark.skipif(not supports_ws(), reason="requires warp specialization")
+def test_gluon_warp_specialized_dynamic_event(tmp_path: pathlib.Path):
+
+    @gluon.jit
+    def default_partition(iterations):
+        event = pl.allocate_event("dynamic_warp_specialized")
+        # The dynamic loop makes Proton's segment part of warp specialization's CFG.
+        for _ in range(iterations):
+            pl.start_event(event)
+            pl.end_event(event)
+
+    @gluon.jit
+    def empty_partition():
+        pass
+
+    @gluon.jit(do_not_specialize=["iterations"])
+    def kernel(iterations):
+        gl.warp_specialize([
+            (default_partition, (iterations, )),
+            (empty_partition, ()),
+        ], [4], [24])
+
+    trace_path = tmp_path / "warp_specialized_dynamic_event.chrome_trace"
+    proton.start(str(trace_path.with_suffix("")), backend="instrumentation", data="trace")
+    kernel[(1, )](2, num_warps=4)
+    proton.finalize()
+
+    with trace_path.open("rb") as f:
+        events = json.load(f)["traceEvents"]
+    async_events = [event for event in events if event["name"] == "dynamic_warp_specialized"]
+    assert async_events
+    assert all(event["ph"] == "X" for event in async_events)
+
+
 def test_select_ids(tmp_path: pathlib.Path):
     from contextlib import contextmanager
 


### PR DESCRIPTION
warp specialization pass assumes loop arguments are already llvm values instead of proton, so we need to move it earlier