### PR TITLE
[NVIDIA] Use non-aligned barrier before TMEM deallocation

### DIFF
--- a/test/Conversion/nvgpu_to_llvm.mlir
+++ b/test/Conversion/nvgpu_to_llvm.mlir
@@ -84,7 +84,8 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.shar
   //      CHECK:    nvvm.barrier
   //      CHECK:    "@$0 tcgen05.relinquish_alloc_permit.cta_group::1.sync.aligned;", "b" %[[PRED]]  : (i1) -> !llvm.void
   //      CHECK:    nvvm.barrier
-  //      CHECK:    llvm.inline_asm has_side_effects asm_dialect = att operand_attrs = [] "@$0 tcgen05.dealloc.cta_group::1.sync.aligned.b32 $1, 128;", "b,r" %[[PRED]], %{{.+}} : (i1, !llvm.ptr<6>) -> !llvm.void
+  // CHECK-SAME:    aligned = false
+  // CHECK-NEXT:    llvm.inline_asm has_side_effects asm_dialect = att operand_attrs = [] "@$0 tcgen05.dealloc.cta_group::1.sync.aligned.b32 $1, 128;", "b,r" %[[PRED]], %{{.+}} : (i1, !llvm.ptr<6>) -> !llvm.void
   llvm.mlir.global external @global_smem() {addr_space = 3 : i32, alignment = 16 : i64} : !llvm.array<0 x i8>
   llvm.func @tensor_memory_base_lowering() -> i32 attributes {nvvm.kernel = 1 : ui1, nvvm.maxntid = array<i32: 128>} {
     %263 = nvg.tensor_memory_base
@@ -133,7 +134,8 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.shar
   //      CHECK:    nvvm.barrier
   //      CHECK:    "@$0 tcgen05.relinquish_alloc_permit.cta_group::1.sync.aligned;", "b" %[[PRED]]  : (i1) -> !llvm.void
   //      CHECK:    nvvm.barrier
-  //      CHECK:    llvm.inline_asm has_side_effects asm_dialect = att operand_attrs = [] "@$0 tcgen05.dealloc.exclusive.cta_group::1.sync.aligned.b32 $1, 576;", "b,r" %[[PRED]], %{{.+}} : (i1, !llvm.ptr<6>) -> !llvm.void
+  // CHECK-SAME:    aligned = false
+  // CHECK-NEXT:    llvm.inline_asm has_side_effects asm_dialect = att operand_attrs = [] "@$0 tcgen05.dealloc.exclusive.cta_group::1.sync.aligned.b32 $1, 576;", "b,r" %[[PRED]], %{{.+}} : (i1, !llvm.ptr<6>) -> !llvm.void
   llvm.mlir.global external @global_smem() {addr_space = 3 : i32, alignment = 16 : i64} : !llvm.array<0 x i8>
   llvm.func @tensor_memory_exclusive_rubin() -> i32 attributes {nvvm.kernel = 1 : ui1, nvvm.maxntid = array<i32: 128>} {
     %263 = nvg.tensor_memory_base
@@ -157,7 +159,8 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.shar
   //      CHECK:    nvvm.barrier
   //      CHECK:    "@$0 tcgen05.relinquish_alloc_permit.cta_group::1.sync.aligned;", "b" %[[PRED]]  : (i1) -> !llvm.void
   //      CHECK:    nvvm.barrier
-  //      CHECK:    llvm.inline_asm has_side_effects asm_dialect = att operand_attrs = [] "@$0 tcgen05.dealloc.cta_group::1.sync.aligned.b32 $1, 512;", "b,r" %[[PRED]], %{{.+}} : (i1, !llvm.ptr<6>) -> !llvm.void
+  // CHECK-SAME:    aligned = false
+  // CHECK-NEXT:    llvm.inline_asm has_side_effects asm_dialect = att operand_attrs = [] "@$0 tcgen05.dealloc.cta_group::1.sync.aligned.b32 $1, 512;", "b,r" %[[PRED]], %{{.+}} : (i1, !llvm.ptr<6>) -> !llvm.void
   //      CHECK-NOT:  .exclusive
   llvm.mlir.global external @global_smem() {addr_space = 3 : i32, alignment = 16 : i64} : !llvm.array<0 x i8>
   llvm.func @tensor_memory_no_exclusive_rubin() -> i32 attributes {nvvm.kernel = 1 : ui1, nvvm.maxntid = array<i32: 128>} {

--- a/third_party/nvidia/lib/NVGPUToLLVM/NVGPUToLLVMPass.cpp
+++ b/third_party/nvidia/lib/NVGPUToLLVM/NVGPUToLLVMPass.cpp
@@ -565,8 +565,10 @@ void freeTMAlloc(LLVM::LLVMFuncOp func, Value alloc, std::string exclusive,
     auto ctx = ret->getContext();
     auto loc = ret.getLoc();
     // Multi-CTA kernels already synchronize the cluster before every return.
-    if (!twoCTAs)
-      NVVM::BarrierOp::create(b, loc);
+    if (!twoCTAs) {
+      // Warp-specialized groups may reach different copies of this barrier.
+      NVVM::BarrierOp::create(b, loc, Value{}, Value{}, /*aligned=*/false);
+    }
     PTXBuilder ptxBuilder;
     // Calculate the predicate in the inline asm to avoid creating long
     // liveranges.


### PR DESCRIPTION
PR description written by Codex

Warp-specialized groups can reach different return blocks, so an aligned barrier before TMEM deallocation violates the same-instruction requirement. The production change sets this single-CTA barrier to `aligned = false`; allocation barriers and multi-CTA handling are unchanged.

The test-only change updates the existing TMEM lowering checks to require a non-aligned barrier immediately before deallocation.

Rebuilt with `make`; `nvgpu_to_llvm.mlir` and `warp_specialize_to_llvm.mlir` passed. A compile-only warp-specialized TMEM probe emits `barrier.sync 0` before both deallocation paths. No GPU execution was performed.
