### PR TITLE
[AMD] Scalarize masked f32 vec2 buffer stores on gfx1151

### DIFF
--- a/test/Conversion/amd/buffer_store_gfx1151.mlir
+++ b/test/Conversion/amd/buffer_store_gfx1151.mlir
@@ -1,0 +1,25 @@
+// RUN: triton-opt %s -split-input-file --convert-triton-amdgpu-to-llvm=gfx-arch=gfx1151 | FileCheck %s --check-prefix=GFX1151
+
+#blocked0 = #ttg.blocked<{sizePerThread = [2], threadsPerWarp = [32], warpsPerCTA = [1], order = [0]}>
+
+module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 1 : i32} {
+  // GFX1151-LABEL: masked_buffer_store_vec2_f32
+  // GFX1151-COUNT-2: rocdl.raw.ptr.buffer.store {{.*}} : f32
+  // GFX1151-NOT: rocdl.raw.ptr.buffer.store {{.*}} : vector<2xf32>
+  tt.func @masked_buffer_store_vec2_f32(%value: f32, %base: !tt.ptr<f32> {tt.divisibility = 8 : i32}, %pred: i1, %stride: i32) {
+    %vals = tt.splat %value : f32 -> tensor<64xf32, #blocked0>
+    %offs = tt.make_range {end = 64 : i32, start = 0 : i32} : tensor<64xi32, #blocked0>
+    %mask = tt.splat %pred : i1 -> tensor<64xi1, #blocked0>
+    amdg.buffer_store %vals, %base[%offs], %mask stride = %stride {contiguity = 2 : i32} : !tt.ptr<f32> -> tensor<64xf32, #blocked0>
+    tt.return
+  }
+
+  // GFX1151-LABEL: unmasked_buffer_store_vec2_f32
+  // GFX1151: rocdl.raw.ptr.buffer.store {{.*}} : vector<2xf32>
+  tt.func @unmasked_buffer_store_vec2_f32(%value: f32, %base: !tt.ptr<f32> {tt.divisibility = 8 : i32}, %stride: i32) {
+    %vals = tt.splat %value : f32 -> tensor<64xf32, #blocked0>
+    %offs = tt.make_range {end = 64 : i32, start = 0 : i32} : tensor<64xi32, #blocked0>
+    amdg.buffer_store %vals, %base[%offs] stride = %stride {contiguity = 2 : i32} : !tt.ptr<f32> -> tensor<64xf32, #blocked0>
+    tt.return
+  }
+}

--- a/test/TritonGPU/amd/amd-convert-buffer-ops-mask-alignment.mlir
+++ b/test/TritonGPU/amd/amd-convert-buffer-ops-mask-alignment.mlir
@@ -1,0 +1,62 @@
+// RUN: triton-opt %s -split-input-file --tritonamdgpu-convert-buffer-ops="gfx-arch=gfx942 analyze-small-tensor-ofst=true" | FileCheck %s --check-prefix=COMMON
+// RUN: triton-opt %s -split-input-file --tritonamdgpu-convert-buffer-ops="gfx-arch=gfx950 analyze-small-tensor-ofst=true" | FileCheck %s --check-prefix=COMMON
+// RUN: triton-opt %s -split-input-file --tritonamdgpu-convert-buffer-ops="gfx-arch=gfx1151 analyze-small-tensor-ofst=true" | FileCheck %s --check-prefix=COMMON
+// RUN: triton-opt %s -split-input-file --tritonamdgpu-convert-buffer-ops="gfx-arch=gfx1250 analyze-small-tensor-ofst=true" | FileCheck %s --check-prefix=COMMON
+
+#blocked0 = #ttg.blocked<{sizePerThread = [2], threadsPerWarp = [32], warpsPerCTA = [1], order = [0]}>
+
+module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 1 : i32} {
+  // COMMON-LABEL: unmasked_store_vec2
+  // COMMON: amdg.buffer_store %{{.*}}, %arg0[%[[RANGE:.*]]] {contiguity = 2 : i32} : !tt.ptr<f32> -> tensor<64xf32, #{{.*}}>
+  tt.func @unmasked_store_vec2(%base: !tt.ptr<f32> {tt.divisibility = 8 : i32, tt.pointer_range = 32 : i32}, %value: f32) {
+    %offs = tt.make_range {end = 64 : i32, start = 0 : i32} : tensor<64xi32, #blocked0>
+    %ptrs = tt.splat %base : !tt.ptr<f32> -> tensor<64x!tt.ptr<f32>, #blocked0>
+    %addrs = tt.addptr %ptrs, %offs : tensor<64x!tt.ptr<f32>, #blocked0>, tensor<64xi32, #blocked0>
+    %vals = tt.splat %value : f32 -> tensor<64xf32, #blocked0>
+    tt.store %addrs, %vals : tensor<64x!tt.ptr<f32>, #blocked0>
+    tt.return
+  }
+
+  // COMMON-LABEL: masked_store_even_boundary
+  // COMMON: amdg.buffer_store %{{.*}}, %arg0[%[[RANGE:.*]]], %[[MASK:.*]] {contiguity = 2 : i32} : !tt.ptr<f32> -> tensor<64xf32, #{{.*}}>
+  tt.func @masked_store_even_boundary(%base: !tt.ptr<f32> {tt.divisibility = 8 : i32, tt.pointer_range = 32 : i32}, %value: f32) {
+    %offs = tt.make_range {end = 64 : i32, start = 0 : i32} : tensor<64xi32, #blocked0>
+    %ptrs = tt.splat %base : !tt.ptr<f32> -> tensor<64x!tt.ptr<f32>, #blocked0>
+    %addrs = tt.addptr %ptrs, %offs : tensor<64x!tt.ptr<f32>, #blocked0>, tensor<64xi32, #blocked0>
+    %vals = tt.splat %value : f32 -> tensor<64xf32, #blocked0>
+    %limit = arith.constant 62 : i32
+    %limits = tt.splat %limit : i32 -> tensor<64xi32, #blocked0>
+    %mask = arith.cmpi slt, %offs, %limits : tensor<64xi32, #blocked0>
+    tt.store %addrs, %vals, %mask : tensor<64x!tt.ptr<f32>, #blocked0>
+    tt.return
+  }
+
+  // COMMON-LABEL: masked_store_odd_boundary
+  // COMMON: amdg.buffer_store %{{.*}}, %arg0[%[[RANGE:.*]]], %[[MASK:.*]] : !tt.ptr<f32> -> tensor<64xf32, #{{.*}}>
+  // COMMON-NOT: amdg.buffer_store {{.*}} {contiguity = 2 : i32}
+  tt.func @masked_store_odd_boundary(%base: !tt.ptr<f32> {tt.divisibility = 8 : i32, tt.pointer_range = 32 : i32}, %value: f32) {
+    %offs = tt.make_range {end = 64 : i32, start = 0 : i32} : tensor<64xi32, #blocked0>
+    %ptrs = tt.splat %base : !tt.ptr<f32> -> tensor<64x!tt.ptr<f32>, #blocked0>
+    %addrs = tt.addptr %ptrs, %offs : tensor<64x!tt.ptr<f32>, #blocked0>, tensor<64xi32, #blocked0>
+    %vals = tt.splat %value : f32 -> tensor<64xf32, #blocked0>
+    %limit = arith.constant 63 : i32
+    %limits = tt.splat %limit : i32 -> tensor<64xi32, #blocked0>
+    %mask = arith.cmpi slt, %offs, %limits : tensor<64xi32, #blocked0>
+    tt.store %addrs, %vals, %mask : tensor<64x!tt.ptr<f32>, #blocked0>
+    tt.return
+  }
+
+  // COMMON-LABEL: masked_store_runtime_boundary
+  // COMMON: amdg.buffer_store %{{.*}}, %arg0[%[[RANGE:.*]]], %[[MASK:.*]] : !tt.ptr<f32> -> tensor<64xf32, #{{.*}}>
+  // COMMON-NOT: amdg.buffer_store {{.*}} {contiguity = 2 : i32}
+  tt.func @masked_store_runtime_boundary(%base: !tt.ptr<f32> {tt.divisibility = 8 : i32, tt.pointer_range = 32 : i32}, %value: f32, %limit: i32) {
+    %offs = tt.make_range {end = 64 : i32, start = 0 : i32} : tensor<64xi32, #blocked0>
+    %ptrs = tt.splat %base : !tt.ptr<f32> -> tensor<64x!tt.ptr<f32>, #blocked0>
+    %addrs = tt.addptr %ptrs, %offs : tensor<64x!tt.ptr<f32>, #blocked0>, tensor<64xi32, #blocked0>
+    %vals = tt.splat %value : f32 -> tensor<64xf32, #blocked0>
+    %limits = tt.splat %limit : i32 -> tensor<64xi32, #blocked0>
+    %mask = arith.cmpi slt, %offs, %limits : tensor<64xi32, #blocked0>
+    tt.store %addrs, %vals, %mask : tensor<64x!tt.ptr<f32>, #blocked0>
+    tt.return
+  }
+}

--- a/third_party/amd/lib/TritonAMDGPUToLLVM/LoadStoreOpToLLVM.cpp
+++ b/third_party/amd/lib/TritonAMDGPUToLLVM/LoadStoreOpToLLVM.cpp
@@ -2053,6 +2053,12 @@ struct BufferStoreOpConversion
     SmallVector<Value> maskElems =
         getMaskElemsAndUpdateVeclen(rewriter, loc, llMask, mask, vec);
 
+    // Work around gfx1151 faults from masked v2f32 buffer stores.
+    if (targetInfo.getArch() == "gfx1151" && valueElemTy.isF32() && llMask &&
+        vec == 2) {
+      vec = 1u;
+    }
+
     Value rsrcDesc = bufferEmitter.createResourceDescriptor(llPtr, llStride);
     MLIRContext *ctx = rewriter.getContext();
     auto freeVarMasks = getFreeVariableMasks(valueTy);


### PR DESCRIPTION
<!---
The core Triton is a small number of people, and we receive many PRs (thank
you!).  To help us review your code more quickly, **if you are a new
contributor (less than 3 PRs merged) we ask that you complete the following
tasks and include the filled-out checklist in your PR description.**

Complete the following tasks before sending your PR, and replace `[ ]` with
`[x]` to indicate you have done them.
-->

# New contributor declaration
- [ ] I am not making a trivial change, such as fixing a typo in a comment.

- [ ] I have written a PR description following these
  [rules](https://cbea.ms/git-commit/#why-not-how).

- [ ] I have run `pre-commit run --from-ref origin/main --to-ref HEAD`.

- Select one of the following.
  - [ ] I have added tests.
    - `/test` for `lit` tests
    - `/unittest` for C++ tests
    - `/python/test` for end-to-end tests
  - [ ] This PR does not need a test because `FILL THIS IN`.

- Select one of the following.
  - [ ] I have not added any `lit` tests.
  - [ ] The `lit` tests I have added follow these [best practices](https://mlir.llvm.org/getting_started/TestingGuide/#filecheck-best-practices),
    including the "tests should be minimal" section. (Usually running Python code
    and using the instructions it generates is not minimal.)
