### PR TITLE
[NVIDIA] Add opt-in loader-gated CLC lookahead

### DIFF
--- a/include/triton/Dialect/TritonGPU/Transforms/Passes.td
+++ b/include/triton/Dialect/TritonGPU/Transforms/Passes.td
@@ -117,7 +117,9 @@ def TritonGPUAutomaticWarpSpecialization : Pass<"tritongpu-automatic-warp-specia
 
   let options = [
     Option<"numStages", "num-stages", "int32_t", /*default*/"3",
-           "number of pipeline stages">
+           "number of pipeline stages">,
+    Option<"clcThrottle", "clc-throttle", "std::string", /*default*/"\"none\"",
+           "limit CLC requests to one per loader tile admission: none or load">
   ];
 }
 

--- a/lib/Dialect/TritonGPU/Transforms/WarpSpecialization/AutomaticWarpSpecialization.cpp
+++ b/lib/Dialect/TritonGPU/Transforms/WarpSpecialization/AutomaticWarpSpecialization.cpp
@@ -1,6 +1,8 @@
 #include "PartitionAttrs.h"
 #include "mlir/Dialect/Arith/Transforms/Passes.h"
+#include "mlir/Dialect/SCF/IR/SCF.h"
 #include "mlir/IR/BuiltinOps.h"
+#include "mlir/IR/Matchers.h"
 #include "mlir/Pass/Pass.h"
 #include "mlir/Pass/PassManager.h"
 #include "mlir/Transforms/Passes.h"
@@ -9,10 +11,12 @@
 #include "triton/Dialect/TritonGPU/Transforms/PipeliningUtility.h"
 #include "triton/Dialect/TritonGPU/Transforms/Schedule.h"
 #include "triton/Dialect/TritonGPU/Transforms/Utility.h"
+#include "triton/Dialect/TritonNvidiaGPU/IR/Dialect.h"
 
 using namespace mlir;
 using namespace triton;
 using namespace triton::gpu;
+namespace ttng = mlir::triton::nvidia_gpu;
 
 //===----------------------------------------------------------------------===//
 // Pass Definition
@@ -86,6 +90,113 @@ void clearInternalWarpSpecializationAttrs(ModuleOp mod) {
   });
 }
 
+// Resolve a response-ring view through the explicit partition capture list.
+Value getCLCResponseAllocation(Value value, WarpSpecializeOp ws) {
+  while (auto index = value.getDefiningOp<MemDescIndexOp>())
+    value = index.getSrc();
+  auto arg = dyn_cast<BlockArgument>(value);
+  if (arg && arg.getOwner()->getParentOp() == ws.getPartitionOp())
+    return ws.getPartitionOp().getExplicitCaptures()[arg.getArgNumber()];
+  return value;
+}
+
+// Match a worker whose first tile is unconditional and whose subsequent
+// iterations are controlled solely by the response from this CLC queue.
+Value getCLCContinuationAllocation(scf::WhileOp loop, WarpSpecializeOp ws) {
+  if (!loop.getBefore().hasOneBlock() || !loop.getAfter().hasOneBlock() ||
+      !llvm::hasSingleElement(loop.getBefore().front()) ||
+      !llvm::equal(loop.getConditionOp().getArgs(), loop.getBeforeArguments()))
+    return {};
+  auto condition =
+      dyn_cast<BlockArgument>(loop.getConditionOp().getCondition());
+  if (!condition || condition.getOwner() != &loop.getBefore().front() ||
+      !matchPattern(loop.getInits()[condition.getArgNumber()], m_One()))
+    return {};
+  auto canceled = loop.getYieldOp()
+                      .getOperand(condition.getArgNumber())
+                      .getDefiningOp<ttng::CLCIsCanceledOp>();
+  if (!canceled || canceled->getBlock() != &loop.getAfter().front())
+    return {};
+  auto response =
+      canceled.getClcResult().getDefiningOp<ttng::CLCLoadResultOp>();
+  if (!response || response->getBlock() != &loop.getAfter().front())
+    return {};
+  return getCLCResponseAllocation(response.getSrc(), ws);
+}
+
+void throttleCLC(WarpSpecializeOp ws) {
+  // The automatic CLC pipeline currently supports single-CTA workers. Leave
+  // other warp-specialized kernels and unmatched control flow unchanged.
+  if (lookupNumCTAs(ws) != 1)
+    return;
+  SmallVector<ttng::CLCTryCancelOp> requests;
+  ws.walk([&](ttng::CLCTryCancelOp op) { requests.push_back(op); });
+  if (requests.size() != 1)
+    return;
+  auto request = requests.front();
+  auto scheduler = request->getParentOfType<scf::WhileOp>();
+  if (!scheduler ||
+      scheduler->getBlock()->getParentOp() != ws.getPartitionOp() ||
+      request->getBlock() != &scheduler.getAfter().front())
+    return;
+  Value response = getCLCContinuationAllocation(scheduler, ws);
+  if (!response ||
+      response != getCLCResponseAllocation(request.getResult(), ws))
+    return;
+
+  scf::WhileOp loaderLoop;
+  bool unsupported = false;
+  ws.walk([&](ttng::AsyncTMACopyGlobalToLocalOp op) {
+    auto loop = op->getParentOfType<scf::WhileOp>();
+    if (!loop || loop->getBlock()->getParentOp() != ws.getPartitionOp() ||
+        loop == scheduler || (loaderLoop && loaderLoop != loop)) {
+      unsupported = true;
+      return;
+    }
+    loaderLoop = loop;
+  });
+  if (unsupported || !loaderLoop ||
+      getCLCContinuationAllocation(loaderLoop, ws) != response)
+    return;
+
+  // Authorize one request at the start of each loader tile, before waiting
+  // for input buffers. Loader admission allows input prefetch to
+  // run ahead of MMA. Keep response and accumulator buffering independent.
+  OpBuilder builder(ws);
+  Location loc = request.getLoc();
+  auto barrierType = cast<MemDescType>(request.getMbarrier().getType());
+  Value credit = LocalAllocOp::create(builder, loc, barrierType);
+  ttng::InitBarrierOp::create(builder, loc, credit, 1);
+  ws.getPartitionOp().getExplicitCapturesMutable().append(credit);
+  for (Region *region : ws.getPartitionRegions())
+    region->front().addArgument(barrierType, loc);
+
+  builder.setInsertionPointToStart(&loaderLoop.getAfter().front());
+  Value loaderCredit = loaderLoop->getBlock()->getArguments().back();
+  ttng::ArriveBarrierOp::create(builder, loc, loaderCredit, 1);
+
+  builder.setInsertionPoint(scheduler);
+  Value zero = arith::ConstantIntOp::create(builder, loc, 0, 32);
+  Value one = arith::ConstantIntOp::create(builder, loc, 1, 32);
+  Value schedulerCredit = scheduler->getBlock()->getArguments().back();
+  scheduler = addIterArgsToLoop(builder, scheduler, ValueRange{zero});
+  Value phase = scheduler.getAfterArguments().back();
+  builder.setInsertionPointToStart(&scheduler.getAfter().front());
+  ttng::WaitBarrierOp::create(builder, loc, schedulerCredit, phase);
+  builder.setInsertionPoint(scheduler.getYieldOp());
+  Value nextPhase = arith::XOrIOp::create(builder, loc, phase, one);
+  scheduler.getYieldOp().getResultsMutable().append(nextPhase);
+
+  // The loader cannot admit its next tile without the current CLC response.
+  // This dependency prevents two arrivals before the scheduler consumes a
+  // credit, so a single phase-tracked barrier suffices. The failed terminal
+  // request consumes the final tile's credit and requires no additional
+  // arrival.
+  builder.setInsertionPointAfter(ws);
+  ttng::InvalBarrierOp::create(builder, loc, credit);
+  LocalDeallocOp::create(builder, loc, credit);
+}
+
 std::unique_ptr<Pass> createVerifyWarpSpecializationPartitionsPass() {
   return std::make_unique<VerifyWarpSpecializationPartitions>();
 }
@@ -93,6 +204,10 @@ std::unique_ptr<Pass> createVerifyWarpSpecializationPartitionsPass() {
 } // namespace
 
 void AutomaticWarpSpecialization::runOnOperation() {
+  if (clcThrottle != "none" && clcThrottle != "load") {
+    getOperation().emitError("clc-throttle must be 'none' or 'load'");
+    return signalPassFailure();
+  }
   OpPassManager pm;
   auto addPassWithPartitionVerifier = [&](std::unique_ptr<Pass> pass) {
     pm.addPass(std::move(pass));
@@ -120,4 +235,6 @@ void AutomaticWarpSpecialization::runOnOperation() {
   // desc updates in nested loops.
   multiBufferTMADescriptors(getOperation(), numStages);
   clearInternalWarpSpecializationAttrs(getOperation());
+  if (clcThrottle != "none")
+    getOperation().walk(throttleCLC);
 }

--- a/python/src/passes.cc
+++ b/python/src/passes.cc
@@ -71,6 +71,9 @@ void init_triton_passes_ttgpuir(py::module_ &m) {
   ADD_PASS_OPTION_WRAPPER_2("add_pipeline", createTritonGPUPipeline, int, bool);
   ADD_PASS_OPTION_WRAPPER_1("add_warp_specialize",
                             createTritonGPUAutomaticWarpSpecialization, int);
+  ADD_PASS_OPTION_WRAPPER_2("add_warp_specialize",
+                            createTritonGPUAutomaticWarpSpecialization, int,
+                            std::string);
   ADD_PASS_WRAPPER_0("add_prefetch", createTritonGPUPrefetch);
   ADD_PASS_WRAPPER_0("add_accelerate_matmul", createTritonGPUAccelerateMatmul);
   ADD_PASS_WRAPPER_0("add_reorder_instructions",

--- a/python/test/unit/language/test_clc.py
+++ b/python/test/unit/language/test_clc.py
@@ -290,11 +290,11 @@ def _clc_ws_tma_matmul_kernel(
     tl.atomic_add(counts + tile_id, 1)
 
 
-def _run_clc_ws_tma_matmul(M, N, K, device, num_ctas):
+def _run_clc_ws_tma_matmul(M, N, K, device, num_ctas, clc_throttle, dtype=torch.float16):
     block_m, block_n, block_k = 128, 64, 64
     torch.manual_seed(42)
-    a = torch.randn((M, K), dtype=torch.float16, device=device)
-    b = torch.randn((K, N), dtype=torch.float16, device=device)
+    a = torch.randn((M, K), dtype=torch.float16, device=device).to(dtype)
+    b = torch.randn((K, N), dtype=torch.float16, device=device).to(dtype)
     c = torch.empty((M, N), dtype=torch.float16, device=device)
     num_tiles = triton.cdiv(M, block_m) * triton.cdiv(N, block_n)
     counts = torch.zeros((num_tiles, ), dtype=torch.int32, device=device)
@@ -302,39 +302,76 @@ def _run_clc_ws_tma_matmul(M, N, K, device, num_ctas):
     b_desc = TensorDescriptor.from_tensor(b, [block_k, block_n])
     c_desc = TensorDescriptor.from_tensor(c, [block_m, block_n])
 
-    compiled = _clc_ws_tma_matmul_kernel[(num_tiles, )](
-        a_desc,
-        b_desc,
-        c_desc,
-        counts,
-        M,
-        N,
-        K,
-        block_m,
-        block_n,
-        block_k,
-        num_warps=4,
-        num_stages=2,
-        num_ctas=num_ctas,
-        clc=True,
-    )
+    def launch():
+        return _clc_ws_tma_matmul_kernel[(num_tiles, )](
+            a_desc,
+            b_desc,
+            c_desc,
+            counts,
+            M,
+            N,
+            K,
+            block_m,
+            block_n,
+            block_k,
+            num_warps=4,
+            num_stages=2,
+            num_ctas=num_ctas,
+            clc=True,
+            clc_throttle=clc_throttle,
+        )
+
+    compiled = launch()
     _assert_clc_ws_ir(compiled)
     expected = torch.matmul(a.float(), b.float()).half()
     torch.testing.assert_close(c, expected, atol=3e-2, rtol=3e-2)
-    return counts
-
-
-@requires_clc
-@pytest.mark.parametrize("M,N,K", [(512, 512, 192), (4096, 2048, 512), (2048, 2048, 128)])
-def test_clc_ws_tma_matmul_1cta(M, N, K, device):
-    counts = _run_clc_ws_tma_matmul(M, N, K, device, 1)
     assert torch.all(counts == 1)
+    graph = torch.cuda.CUDAGraph()
+    with torch.cuda.graph(graph):
+        launch()
+    for _ in range(2):
+        a.copy_(torch.randn(a.shape, dtype=torch.float16, device=device).to(dtype))
+        c.fill_(float("nan"))
+        counts.zero_()
+        graph.replay()
+        expected = torch.matmul(a.float(), b.float()).half()
+        torch.testing.assert_close(c, expected, atol=3e-2, rtol=3e-2)
+        assert torch.all(counts == 1)
 
 
 @requires_clc
-def test_clc_ws_consan_1cta(device, fresh_knobs):
+@pytest.mark.parametrize("M,N,K", [
+    pytest.param(128, 64, 128, id="no-pending-work"),
+    pytest.param(513, 576, 192, id="partial-tiles"),
+    (512, 512, 192),
+    (4096, 2048, 512),
+    pytest.param(2048, 2048, 128, id="many-tiles"),
+    pytest.param(2176, 1088, 4096, id="long-k-tail"),
+])
+@pytest.mark.parametrize("clc_throttle", ["none", "load"])
+@pytest.mark.parametrize("dtype", [torch.float16, torch.float8_e4m3fn])
+def test_clc_ws_tma_matmul_1cta(M, N, K, device, clc_throttle, dtype):
+    _run_clc_ws_tma_matmul(M, N, K, device, 1, clc_throttle, dtype)
+
+
+@requires_clc
+@pytest.mark.parametrize("single_tile", [True, False], ids=["no-pending-work", "phase-reuse"])
+@pytest.mark.parametrize("clc_throttle", ["none", "load"])
+@pytest.mark.parametrize("dtype", [torch.float16, torch.float8_e4m3fn])
+def test_clc_ws_consan_1cta(device, fresh_knobs, single_tile, clc_throttle, dtype):
     triton.knobs.compilation.instrumentation_mode = "consan"
     num_sms = torch.cuda.get_device_properties(device).multi_processor_count
-    num_tiles = max(64, num_sms * 32)
-    counts = _run_clc_ws_tma_matmul(128, num_tiles * 64, 128, device, 1)
-    assert torch.all(counts == 1)
+    num_tiles = 1 if single_tile else max(64, num_sms * 32)
+    _run_clc_ws_tma_matmul(128, num_tiles * 64, 128, device, 1, clc_throttle, dtype)
+
+
+@requires_clc
+@pytest.mark.parametrize("options,match", [
+    ({"clc": True, "clc_throttle": "mma"}, "clc_throttle must be"),
+    ({"clc": True, "clc_throttle": "invalid"}, "clc_throttle must be"),
+    ({"clc_throttle": "load"}, "clc_throttle requires clc=True"),
+])
+def test_clc_throttle_invalid_options(options, match):
+    from triton.backends.nvidia.compiler import CUDAOptions
+    with pytest.raises(ValueError, match=match):
+        CUDAOptions(**options)

--- a/test/TritonGPU/automatic-warp-specialization.mlir
+++ b/test/TritonGPU/automatic-warp-specialization.mlir
@@ -1,6 +1,7 @@
-// RUN: triton-opt %s -split-input-file -allow-unregistered-dialect -tritongpu-hoist-tmem-alloc -tritongpu-assign-latencies -tritongpu-schedule-loops -tritongpu-automatic-warp-specialization=num-stages=2 | FileCheck %s --check-prefix=CHECK --check-prefix=BASE --check-prefix=CLEAN
-// RUN: triton-opt %s -split-input-file -allow-unregistered-dialect -tritongpu-hoist-tmem-alloc -tritongpu-assign-latencies -tritongpu-schedule-loops -tritongpu-automatic-warp-specialization=num-stages=2 -tritongpu-pipeline | FileCheck %s --check-prefix=CHECK --check-prefix=PIPELINE --check-prefix=CLEAN
-// RUN: triton-opt %s -split-input-file -allow-unregistered-dialect -tritongpu-hoist-tmem-alloc -tritongpu-assign-latencies -tritongpu-schedule-loops -tritongpu-automatic-warp-specialization=num-stages=2 -tritongpu-pipeline -tritongpu-optimize-partition-warps | FileCheck %s --check-prefix=OPT --check-prefix=CLEAN
+// RUN: triton-opt %s -split-input-file -allow-unregistered-dialect -tritongpu-hoist-tmem-alloc -tritongpu-assign-latencies -tritongpu-schedule-loops -tritongpu-automatic-warp-specialization=num-stages=2 | FileCheck %s --check-prefix=STOCK
+// RUN: triton-opt %s -split-input-file -allow-unregistered-dialect -tritongpu-hoist-tmem-alloc -tritongpu-assign-latencies -tritongpu-schedule-loops -tritongpu-automatic-warp-specialization='num-stages=2 clc-throttle=load' | FileCheck %s --check-prefix=CHECK --check-prefix=BASE --check-prefix=CLEAN
+// RUN: triton-opt %s -split-input-file -allow-unregistered-dialect -tritongpu-hoist-tmem-alloc -tritongpu-assign-latencies -tritongpu-schedule-loops -tritongpu-automatic-warp-specialization='num-stages=2 clc-throttle=load' -tritongpu-pipeline | FileCheck %s --check-prefix=CHECK --check-prefix=PIPELINE --check-prefix=CLEAN
+// RUN: triton-opt %s -split-input-file -allow-unregistered-dialect -tritongpu-hoist-tmem-alloc -tritongpu-assign-latencies -tritongpu-schedule-loops -tritongpu-automatic-warp-specialization='num-stages=2 clc-throttle=load' -tritongpu-pipeline -tritongpu-optimize-partition-warps | FileCheck %s --check-prefix=OPT --check-prefix=CLEAN
 
 // CLEAN: module
 // CLEAN-NOT: ttg.partition
@@ -395,7 +396,8 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.targ
 
 // -----
 
-// AutomaticWS partitions one CLC While and emits a single physical CLC issue.
+// AutomaticWS partitions one CLC While. One credit per loader tile admission
+// limits the scheduler to one future tile without shrinking either ring.
 #clc_aws_oper = #ttg.blocked<{sizePerThread = [1, 1], threadsPerWarp = [1, 32], warpsPerCTA = [2, 2], order = [1, 0]}>
 #clc_aws_acc = #ttg.blocked<{sizePerThread = [1, 128], threadsPerWarp = [32, 1], warpsPerCTA = [4, 1], order = [0, 1]}>
 #clc_aws_shared = #ttg.nvmma_shared<{swizzlingByteWidth = 128, transposed = false, elementBitWidth = 16}>
@@ -406,6 +408,9 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.targ
 #clc_aws_response_shared = #ttg.swizzled_shared<{vec = 1, perPhase = 1, maxPhase = 1, order = [0]}>
 
 module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.target = "cuda:100"} {
+  // STOCK-LABEL: @clc_while_aws
+  // STOCK-NOT: ttg.local_alloc : () -> !ttg.memdesc<1xi64,
+  // STOCK: tt.return
   // BASE-LABEL: @clc_while_aws
   tt.func @clc_while_aws(
       %a_desc: !tt.tensordesc<128x64xf16, #clc_aws_shared>,
@@ -417,25 +422,108 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.targ
     %true = arith.constant true
     %false = arith.constant false
     %pid0 = tt.get_program_id x : i32
-    // BASE: ttg.warp_specialize
+    // BASE: %[[CREDIT:.*]] = ttg.local_alloc : () -> !ttg.memdesc<1xi64,
+    // BASE-NEXT: ttng.init_barrier %[[CREDIT]], 1
+    // BASE-NEXT: ttg.warp_specialize({{.*}}, %[[CREDIT]])
     // BASE: default
     // BASE: ttng.clc_load_result
     // BASE: ttng.clc_get_program_id
     // BASE-NOT: ttng.clc_try_cancel
-    // BASE: partition0
+    // BASE: partition0({{.*}}, %[[MMA_CREDIT:[^: ]+]]: !ttg.memdesc<1xi64,
+    // BASE-NOT: ttng.arrive_barrier %[[MMA_CREDIT]], 1
+    // BASE: scf.for
+    // BASE: ttng.tc_gen5_mma
     // BASE: ttng.clc_load_result
     // BASE: ttng.clc_get_program_id
     // BASE-NOT: ttng.clc_try_cancel
-    // BASE: partition1
+    // BASE: partition1({{.*}}, %[[LOAD_CREDIT:[^: ]+]]: !ttg.memdesc<1xi64,
+    // BASE: scf.while
+    // BASE: ^bb0
+    // BASE-NEXT: ttng.arrive_barrier %[[LOAD_CREDIT]], 1
+    // BASE: scf.for
+    // BASE: ttng.async_tma_copy_global_to_local
     // BASE: ttng.clc_load_result
     // BASE: ttng.clc_get_program_id
     // BASE-NOT: ttng.clc_try_cancel
-    // BASE: partition2
+    // BASE: partition2({{.*}}, %[[SCHED_CREDIT:[^: ]+]]: !ttg.memdesc<1xi64,
+    // BASE: arith.constant 0 : i32
+    // BASE-NEXT: %[[ZERO:.*]] = arith.constant 0 : i32
+    // BASE-NEXT: %[[ONE:.*]] = arith.constant 1 : i32
+    // BASE: scf.while ({{.*}}, %{{[^ ]+}} = %[[ZERO]])
+    // BASE: ^bb0({{.*}}, %[[PHASE:[^: ]+]]: i32):
+    // BASE-NEXT: ttng.wait_barrier %[[SCHED_CREDIT]], %[[PHASE]]
     // BASE: ttng.clc_try_cancel
     // BASE-NOT: ttng.clc_try_cancel
     // BASE: ttng.clc_load_result
     // BASE: ttng.clc_get_program_id
+    // BASE: %[[NEXT_PHASE:.*]] = arith.xori %[[PHASE]], %[[ONE]] : i32
+    // BASE-NEXT: scf.yield {{.*}}, %[[NEXT_PHASE]] :
+    // BASE: ttg.warp_return
+    // BASE: ttng.inval_barrier %[[CREDIT]]
+    // BASE-NEXT: ttg.local_dealloc %[[CREDIT]]
     scf.while (%pid = %pid0, %has_work = %true) : (i32, i1) -> (i32, i1) {
+      scf.condition(%has_work) %pid, %has_work : i32, i1
+    } do {
+    ^bb0(%pid: i32, %has_work: i1):
+      %response = ttng.clc_try_cancel_sync : tensor<2xi64, #clc_aws_response>
+      %response_smem = ttg.local_alloc %response {alignment = 16 : i32} : (tensor<2xi64, #clc_aws_response>) -> !ttg.memdesc<2xi64, #clc_aws_response_shared, #clc_aws_smem, mutable>
+      scf.for %k = %c0 to %c6 step %c1 : i32 {
+        %a = tt.descriptor_load %a_desc[%pid, %k] : !tt.tensordesc<128x64xf16, #clc_aws_shared> -> tensor<128x64xf16, #clc_aws_oper>
+        %b = tt.descriptor_load %b_desc[%pid, %k] : !tt.tensordesc<128x64xf16, #clc_aws_shared> -> tensor<128x64xf16, #clc_aws_oper>
+        %a_s = ttg.local_alloc %a : (tensor<128x64xf16, #clc_aws_oper>) -> !ttg.memdesc<128x64xf16, #clc_aws_shared, #clc_aws_smem>
+        %b_s0 = ttg.local_alloc %b : (tensor<128x64xf16, #clc_aws_oper>) -> !ttg.memdesc<128x64xf16, #clc_aws_shared, #clc_aws_smem>
+        %b_s = ttg.memdesc_trans %b_s0 {order = array<i32: 1, 0>} : !ttg.memdesc<128x64xf16, #clc_aws_shared, #clc_aws_smem> -> !ttg.memdesc<64x128xf16, #clc_aws_shared_t, #clc_aws_smem>
+        %acc_mem, %acc_tok = ttng.tmem_alloc : () -> (!ttg.memdesc<128x128xf32, #clc_aws_tmem, #ttng.tensor_memory, mutable>, !ttg.async.token)
+        %mma = ttng.tc_gen5_mma %a_s, %b_s, %acc_mem[%acc_tok], %false, %true : !ttg.memdesc<128x64xf16, #clc_aws_shared, #clc_aws_smem>, !ttg.memdesc<64x128xf16, #clc_aws_shared_t, #clc_aws_smem>, !ttg.memdesc<128x128xf32, #clc_aws_tmem, #ttng.tensor_memory, mutable>
+        %value, %load_tok = ttng.tmem_load %acc_mem[%mma] : !ttg.memdesc<128x128xf32, #clc_aws_tmem, #ttng.tensor_memory, mutable> -> tensor<128x128xf32, #clc_aws_acc>
+        "consume"(%value) : (tensor<128x128xf32, #clc_aws_acc>) -> ()
+      } {tt.warp_specialize, tt.num_stages = 2 : i32}
+      %out_ptr = tt.addptr %out, %pid : !tt.ptr<i32>, i32
+      tt.store %out_ptr, %pid : !tt.ptr<i32>
+      %raw = ttng.clc_load_result %response_smem : !ttg.memdesc<2xi64, #clc_aws_response_shared, #clc_aws_smem, mutable> -> i128
+      %next_has_work = ttng.clc_is_canceled %raw : i128 -> i1
+      %next_pid = scf.if %next_has_work -> i32 {
+        %stolen = ttng.clc_get_program_id %raw, x : i128 -> i32
+        scf.yield %stolen : i32
+      } else {
+        scf.yield %pid : i32
+      }
+      scf.yield %next_pid, %next_has_work : i32, i1
+    }
+    tt.return
+  }
+}
+
+// -----
+
+// Conditional entry is outside the one-credit transformation contract.
+#clc_aws_oper = #ttg.blocked<{sizePerThread = [1, 1], threadsPerWarp = [1, 32], warpsPerCTA = [2, 2], order = [1, 0]}>
+#clc_aws_acc = #ttg.blocked<{sizePerThread = [1, 128], threadsPerWarp = [32, 1], warpsPerCTA = [4, 1], order = [0, 1]}>
+#clc_aws_shared = #ttg.nvmma_shared<{swizzlingByteWidth = 128, transposed = false, elementBitWidth = 16}>
+#clc_aws_shared_t = #ttg.nvmma_shared<{swizzlingByteWidth = 128, transposed = true, elementBitWidth = 16}>
+#clc_aws_smem = #ttg.shared_memory
+#clc_aws_tmem = #ttng.tensor_memory_encoding<blockM = 128, blockN = 128, colStride = 1>
+#clc_aws_response = #ttg.linear<{register = [[1]], lane = [[0], [0], [0], [0], [0]], warp = [[0], [0]], block = []}>
+#clc_aws_response_shared = #ttg.swizzled_shared<{vec = 1, perPhase = 1, maxPhase = 1, order = [0]}>
+
+module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.target = "cuda:100"} {
+  // BASE-LABEL: @clc_while_conditional_entry
+  // BASE-NOT: ttg.local_alloc : () -> !ttg.memdesc<1xi64,
+  // BASE: ttg.warp_specialize
+  // BASE: ttng.tc_gen5_mma
+  // BASE: ttng.clc_try_cancel
+  // BASE: tt.return
+  tt.func @clc_while_conditional_entry(
+      %a_desc: !tt.tensordesc<128x64xf16, #clc_aws_shared>,
+      %b_desc: !tt.tensordesc<128x64xf16, #clc_aws_shared>,
+      %out: !tt.ptr<i32>, %run: i1) {
+    %c0 = arith.constant 0 : i32
+    %c1 = arith.constant 1 : i32
+    %c6 = arith.constant 6 : i32
+    %true = arith.constant true
+    %false = arith.constant false
+    %pid0 = tt.get_program_id x : i32
+    scf.while (%pid = %pid0, %has_work = %run) : (i32, i1) -> (i32, i1) {
       scf.condition(%has_work) %pid, %has_work : i32, i1
     } do {
     ^bb0(%pid: i32, %has_work: i1):

--- a/third_party/nvidia/backend/compiler.py
+++ b/third_party/nvidia/backend/compiler.py
@@ -123,6 +123,8 @@ class CUDAOptions:
     launch_cooperative_grid: bool = False
     launch_pdl: bool = False
     clc: bool = False
+    # Loader-gated one-tile CLC lookahead; "none" retains stock scheduling.
+    clc_throttle: str = "none"
     supported_fp8_dtypes: Tuple[str] = ("fp8e5", "fp8e4b15")
     deprecated_fp8_dot_operand_dtypes: Tuple[str] = ()
     default_dot_input_precision: str = "tf32"
@@ -138,6 +140,10 @@ class CUDAOptions:
     min_shared_mem: Optional[int] = None
 
     def __post_init__(self):
+        if self.clc_throttle not in ("none", "load"):
+            raise ValueError("clc_throttle must be 'none' or 'load'")
+        if self.clc_throttle != "none" and not self.clc:
+            raise ValueError("clc_throttle requires clc=True")
         default_libdir = Path(__file__).parent / 'lib'
         extern_libs = {} if self.extern_libs is None else dict(self.extern_libs)
         if not extern_libs.get('libdevice', None):
@@ -333,7 +339,7 @@ class CUDABackend(BaseBackend):
             nvidia.passes.ttnvgpuir.add_promote_lhs_to_tmem(pm)
             passes.ttgpuir.add_assign_latencies(pm, opt.num_stages)
             passes.ttgpuir.add_schedule_loops(pm)
-            passes.ttgpuir.add_warp_specialize(pm, opt.num_stages)
+            passes.ttgpuir.add_warp_specialize(pm, opt.num_stages, opt.clc_throttle)
             passes.ttgpuir.add_pipeline(pm, opt.num_stages, dump_enabled)
             passes.ttgpuir.add_optimize_partition_warps(pm)
             passes.ttgpuir.add_combine_tensor_select_and_if(pm)


### PR DESCRIPTION
## Motivation

The compiler-generated CLC scheduler can claim future tiles before the
loader starts them. Bounding that lookahead may improve tail balance by
leaving more unstarted tiles available to other workers. The bound should
follow loader progress without waiting for MMA to accept the current tile.

## Changes

- Add the opt-in CUDA option `clc_throttle="load"`, requiring `clc=True`.
  The default, `"none"`, preserves existing scheduling.
- Insert a one-credit barrier after automatic warp specialization. The
  loader releases credit at the start of each output-tile iteration,
  before input-buffer waits and TMA loads; the CLC scheduler consumes it
  before requesting the next tile.
- Restrict the transformation to single-CTA workers with one CLC request
  and a loader controlled by the same response queue. Unmatched kernels
  remain unchanged.
- Keep initial `blockIdx` work assignment, response/accumulator buffering,
  and warp allocation unchanged. Add one 8-byte barrier per worker.
- Extend existing MLIR and GPU tests for barrier placement and phase
  reuse, unsupported conditional entry, FP16/FP8 correctness, exactly-once
  tile execution, changed-input CUDA graph replay, ConSan, and invalid
  options.

```python
kernel[grid](..., clc=True, clc_throttle="load")
```

No matmul kernel source changes are needed to opt in.

## Validation

- Passed: `pre-commit run --from-ref origin/main --to-ref HEAD`.
- Passed: `git diff --check origin/main...HEAD`.
- Pending for this rebased commit: native compiler rebuild, lit tests,
  and GPU/ConSan regression tests. This PR is a draft for review, not a
  claim that the rebased compiler has passed runtime validation.

## New contributor declaration

- [x] I am not making a trivial change, such as fixing a typo in a comment.
- [x] I have written a PR description following these
  [rules](https://cbea.ms/git-commit/#why-not-how).
- [x] I have run `pre-commit run --from-ref origin/main --to-ref HEAD`.
- [x] I have added tests in `/test` and `/python/test`.
- [x] The lit tests I have added follow the
  [MLIR testing best practices](https://mlir.llvm.org/getting_started/TestingGuide/#filecheck-best-practices),
  including the requirement for minimal tests.
