### PR TITLE
[Triton] Add triton-narrow-redundant-loads pass

### DIFF
--- a/include/triton/Dialect/Triton/Transforms/Passes.td
+++ b/include/triton/Dialect/Triton/Transforms/Passes.td
@@ -35,6 +35,25 @@ def TritonReorderBroadcast : Pass</*cli-arg*/"triton-reorder-broadcast", /*Op*/"
   let dependentDialects = ["mlir::triton::TritonDialect"];
 }
 
+def TritonNarrowRedundantLoads : Pass</*cli-arg*/"triton-narrow-redundant-loads", /*Op*/"mlir::ModuleOp"> {
+  let summary = "Narrow loads that read the same value along a dimension";
+  let description = [{
+    The purpose of this pass is to transform:
+      - `load(ptrs) => broadcast(load(ptrs[0:1]))`
+    along every dimension the axis info analysis proves the loaded values
+    constant across, which leaves fewer redundant copies for layout assignment
+    and the pipeliner to route through shared memory.
+
+    The address computation is re-materialized at the narrower shape, so a load
+    whose address the pass cannot re-materialize is left unchanged. This pass
+    expects to run after `triton-combine`.
+  }];
+
+  let dependentDialects = ["mlir::triton::TritonDialect",
+                           "mlir::arith::ArithDialect",
+                           "mlir::math::MathDialect"];
+}
+
 def TritonRewriteTensorDescriptorToPointer : Pass</*cli-arg*/"triton-rewrite-tensor-descriptor-to-pointer", /*Op*/"mlir::ModuleOp"> {
   let summary = "Rewrite load/stores of tensor descriptors into pointer load/stores";
   let description = [{

--- a/lib/Dialect/Triton/Transforms/CMakeLists.txt
+++ b/lib/Dialect/Triton/Transforms/CMakeLists.txt
@@ -8,6 +8,7 @@ add_triton_library(TritonTransforms
   LoopInvariantCodeMotion.cpp
   LoopPeeling.cpp
   LoopUnroll.cpp
+  NarrowRedundantLoads.cpp
   ReorderBroadcast.cpp
   RewriteTensorDescriptorToPointer.cpp
   ArithTypeConversion.cpp
@@ -22,5 +23,6 @@ add_triton_library(TritonTransforms
   MLIRTransformUtils
   MLIRTransforms
   MLIRSCFToControlFlow
+  TritonAnalysis
   TritonIR
 )

--- a/lib/Dialect/Triton/Transforms/NarrowRedundantLoads.cpp
+++ b/lib/Dialect/Triton/Transforms/NarrowRedundantLoads.cpp
@@ -1,0 +1,280 @@
+#include "mlir/Dialect/Arith/IR/Arith.h"
+#include "mlir/Dialect/Math/IR/Math.h"
+#include "mlir/IR/Builders.h"
+#include "mlir/IR/BuiltinAttributes.h"
+#include "mlir/IR/PatternMatch.h"
+#include "mlir/Interfaces/SideEffectInterfaces.h"
+#include "mlir/Pass/Pass.h"
+#include "triton/Analysis/AxisInfo.h"
+#include "triton/Dialect/Triton/IR/Dialect.h"
+#include "triton/Dialect/Triton/Transforms/Passes.h"
+#include "llvm/Support/Debug.h"
+
+#define DEBUG_TYPE "triton-narrow-redundant-loads"
+
+namespace mlir::triton {
+
+#define GEN_PASS_DEF_TRITONNARROWREDUNDANTLOADS
+#include "triton/Dialect/Triton/Transforms/Passes.h.inc"
+
+namespace {
+
+// A load worth rewriting, together with the shape it should be narrowed to.
+struct NarrowingCandidate {
+  LoadOp load;
+  SmallVector<int64_t> narrowShape;
+};
+
+// Re-materializes values at a reduced shape, which amounts to taking their
+// slice at index 0 along every narrowed dimension. Only valid where the value
+// is invariant along those dimensions, since any other slice would have done
+// equally well.
+class SliceMaterializer {
+public:
+  SliceMaterializer(OpBuilder &builder) : builder(builder) {}
+
+  // Returns `v` restricted to `shape`, or failure if some operation in its
+  // definition cannot be re-materialized at a narrower shape.
+  FailureOr<Value> slice(Value v, ArrayRef<int64_t> shape);
+
+  // Erases everything re-materialized so far. A narrowing that gives up
+  // partway leaves behind an address computation nothing reads.
+  void rollback() {
+    for (Operation *op : llvm::reverse(created))
+      op->erase();
+    created.clear();
+    cache.clear();
+  }
+
+private:
+  static RankedTensorType narrowType(RankedTensorType type,
+                                     ArrayRef<int64_t> shape) {
+    return RankedTensorType::get(shape, type.getElementType(),
+                                 type.getEncoding());
+  }
+
+  // Clones a single-result elementwise op with narrowed operands.
+  FailureOr<Value> sliceElementwise(Operation *op, ArrayRef<int64_t> shape);
+
+  // Records `op` so that `rollback` can undo it, and returns its result.
+  Value track(Operation *op) {
+    created.push_back(op);
+    return op->getResult(0);
+  }
+
+  OpBuilder &builder;
+  DenseMap<Value, Value> cache;
+  SmallVector<Operation *> created;
+};
+
+// Returns true if `op` computes its result elementwise from operands of the
+// same shape, so cloning it at a narrower shape computes the same slice.
+// Constants are excluded because their value attribute is shaped, and so has
+// to be rebuilt rather than carried over.
+bool isNarrowableElementwise(Operation *op) {
+  if (op->getNumResults() != 1 || op->getNumRegions() != 0)
+    return false;
+  if (isa<arith::ConstantOp>(op) || !isMemoryEffectFree(op))
+    return false;
+  if (!isa<arith::ArithDialect, math::MathDialect>(op->getDialect()))
+    return false;
+
+  auto resultType = dyn_cast<RankedTensorType>(op->getResult(0).getType());
+  if (!resultType)
+    return false;
+  // A scalar operand contributes the same value to every lane, so only the
+  // tensor operands have to line up with the result.
+  return llvm::all_of(op->getOperands(), [&](Value operand) {
+    auto type = dyn_cast<RankedTensorType>(operand.getType());
+    return !type || type.getShape() == resultType.getShape();
+  });
+}
+
+// Returns true if `v` holds the same element in every lane.
+bool isSplatLike(Value v) {
+  Operation *defOp = v.getDefiningOp();
+  if (!defOp)
+    return false;
+  if (isa<SplatOp>(defOp))
+    return true;
+  auto constant = dyn_cast<arith::ConstantOp>(defOp);
+  return constant && isa<SplatElementsAttr>(constant.getValue());
+}
+
+FailureOr<Value> SliceMaterializer::slice(Value v, ArrayRef<int64_t> shape) {
+  auto type = dyn_cast<RankedTensorType>(v.getType());
+  if (!type || type.getShape() == shape)
+    return v;
+
+  RankedTensorType resultType = narrowType(type, shape);
+  if (Value cached = cache.lookup(v); cached && cached.getType() == resultType)
+    return cached;
+
+  Operation *defOp = v.getDefiningOp();
+  if (!defOp)
+    return failure();
+
+  Location loc = defOp->getLoc();
+  FailureOr<Value> result = failure();
+
+  if (auto splat = dyn_cast<SplatOp>(defOp)) {
+    result = track(SplatOp::create(builder, loc, resultType, splat.getSrc()));
+  } else if (auto constant = dyn_cast<arith::ConstantOp>(defOp)) {
+    if (auto splatAttr = dyn_cast<SplatElementsAttr>(constant.getValue())) {
+      Value scalar = track(arith::ConstantOp::create(
+          builder, loc, cast<TypedAttr>(splatAttr.getSplatValue<Attribute>())));
+      result = track(SplatOp::create(builder, loc, resultType, scalar));
+    }
+  } else if (auto range = dyn_cast<MakeRangeOp>(defOp)) {
+    // Keeping only the first element of a range collapses it to its start.
+    if (shape.size() == 1 && shape[0] == 1) {
+      Value start = track(arith::ConstantOp::create(
+          builder, loc, builder.getI32IntegerAttr(range.getStart())));
+      result = track(SplatOp::create(builder, loc, resultType, start));
+    }
+  } else if (auto broadcast = dyn_cast<BroadcastOp>(defOp)) {
+    // The source is already unit-sized along the dimensions it broadcasts, so
+    // narrowing it to the same shape leaves those dimensions alone.
+    auto srcType = cast<RankedTensorType>(broadcast.getSrc().getType());
+    SmallVector<int64_t> srcShape;
+    for (auto [srcDim, dim] : llvm::zip(srcType.getShape(), shape))
+      srcShape.push_back(std::min(srcDim, dim));
+    FailureOr<Value> src = slice(broadcast.getSrc(), srcShape);
+    if (succeeded(src)) {
+      result = src->getType() == resultType
+                   ? *src
+                   : track(BroadcastOp::create(builder, loc, resultType, *src));
+    }
+  } else if (auto expand = dyn_cast<ExpandDimsOp>(defOp)) {
+    // The expanded dimension is unit-sized in the result, hence unit-sized in
+    // any narrowing of it, so it can be dropped and re-inserted unchanged.
+    uint32_t axis = expand.getAxis();
+    SmallVector<int64_t> srcShape(shape);
+    srcShape.erase(srcShape.begin() + axis);
+    FailureOr<Value> src = slice(expand.getSrc(), srcShape);
+    if (succeeded(src))
+      result =
+          track(ExpandDimsOp::create(builder, loc, resultType, *src, axis));
+  } else if (auto addPtr = dyn_cast<AddPtrOp>(defOp)) {
+    FailureOr<Value> ptr = slice(addPtr.getPtr(), shape);
+    FailureOr<Value> offset = slice(addPtr.getOffset(), shape);
+    if (succeeded(ptr) && succeeded(offset))
+      result = track(AddPtrOp::create(builder, loc, resultType, *ptr, *offset));
+  } else if (isNarrowableElementwise(defOp)) {
+    result = sliceElementwise(defOp, shape);
+  }
+
+  if (succeeded(result))
+    cache[v] = *result;
+  return result;
+}
+
+FailureOr<Value> SliceMaterializer::sliceElementwise(Operation *op,
+                                                     ArrayRef<int64_t> shape) {
+  SmallVector<Value> operands;
+  for (Value operand : op->getOperands()) {
+    FailureOr<Value> narrowed = slice(operand, shape);
+    if (failed(narrowed))
+      return failure();
+    operands.push_back(*narrowed);
+  }
+
+  OperationState state(op->getLoc(), op->getName());
+  state.addOperands(operands);
+  state.addTypes(
+      narrowType(cast<RankedTensorType>(op->getResult(0).getType()), shape));
+  state.addAttributes(op->getAttrs());
+  return track(builder.create(state));
+}
+
+// Returns the shape `load` can be narrowed to, if any. A dimension qualifies
+// when the analysis proves the loaded values repeat across its whole extent.
+// That constancy is the gcd of the address and mask constancies; `other` is
+// checked separately because it is not part of it.
+std::optional<SmallVector<int64_t>>
+getNarrowShape(LoadOp load, ModuleAxisInfoAnalysis &axisInfo) {
+  auto type = dyn_cast<RankedTensorType>(load.getType());
+  if (!type || !type.hasStaticShape())
+    return std::nullopt;
+  // Dropping reads of a volatile load would change how many times it is issued.
+  if (load.getIsVolatile())
+    return std::nullopt;
+  if (load.getOther() && !isSplatLike(load.getOther()))
+    return std::nullopt;
+
+  AxisInfo *info = axisInfo.getAxisInfo(load.getResult());
+  if (!info || info->getRank() != type.getRank())
+    return std::nullopt;
+
+  ArrayRef<int64_t> shape = type.getShape();
+  SmallVector<int64_t> narrowShape(shape);
+  bool narrowed = false;
+  for (auto [dim, extent] : llvm::enumerate(shape)) {
+    if (extent > 1 && info->getConstancy(dim) == extent) {
+      narrowShape[dim] = 1;
+      narrowed = true;
+    }
+  }
+  return narrowed ? std::optional(narrowShape) : std::nullopt;
+}
+
+LogicalResult narrowLoad(const NarrowingCandidate &candidate) {
+  LoadOp load = candidate.load;
+  IRRewriter rewriter(load);
+  SliceMaterializer materializer(rewriter);
+
+  // Narrow every operand before building the load, so that giving up on one of
+  // them leaves the original load in place.
+  SmallVector<Value> operands;
+  for (Value operand : {load.getPtr(), load.getMask(), load.getOther()}) {
+    if (!operand) {
+      operands.push_back(nullptr);
+      continue;
+    }
+    FailureOr<Value> narrowed =
+        materializer.slice(operand, candidate.narrowShape);
+    if (failed(narrowed)) {
+      materializer.rollback();
+      return failure();
+    }
+    operands.push_back(*narrowed);
+  }
+
+  auto type = cast<RankedTensorType>(load.getType());
+  auto narrowedType = RankedTensorType::get(
+      candidate.narrowShape, type.getElementType(), type.getEncoding());
+  Value narrowedLoad =
+      LoadOp::create(rewriter, load.getLoc(), narrowedType, operands[0],
+                     operands[1], operands[2], load.getCacheAttr(),
+                     load.getEvictAttr(), load.getIsVolatileAttr());
+  rewriter.replaceOpWithNewOp<BroadcastOp>(load, type, narrowedLoad);
+  return success();
+}
+
+} // namespace
+
+class NarrowRedundantLoadsPass
+    : public impl::TritonNarrowRedundantLoadsBase<NarrowRedundantLoadsPass> {
+public:
+  void runOnOperation() override {
+    ModuleOp m = getOperation();
+    ModuleAxisInfoAnalysis axisInfo(m);
+
+    // Collect first: rewriting the loads invalidates the analysis.
+    SmallVector<NarrowingCandidate> candidates;
+    m.walk([&](LoadOp load) {
+      if (std::optional<SmallVector<int64_t>> narrowShape =
+              getNarrowShape(load, axisInfo))
+        candidates.push_back({load, std::move(*narrowShape)});
+    });
+
+    for (const NarrowingCandidate &candidate : candidates) {
+      // Logged before the rewrite, which erases the load.
+      LLVM_DEBUG(llvm::dbgs() << "narrowing " << candidate.load << "\n");
+      if (failed(narrowLoad(candidate)))
+        LLVM_DEBUG(llvm::dbgs() << "declined: address not re-materializable\n");
+    }
+  }
+};
+
+} // namespace mlir::triton

--- a/python/src/passes.cc
+++ b/python/src/passes.cc
@@ -46,6 +46,8 @@ void init_triton_passes_ttir(py::module_ &m) {
   using namespace mlir::triton;
   ADD_PASS_WRAPPER_0("add_combine", createTritonCombineOps);
   ADD_PASS_WRAPPER_0("add_reorder_broadcast", createTritonReorderBroadcast);
+  ADD_PASS_WRAPPER_0("add_narrow_redundant_loads",
+                     createTritonNarrowRedundantLoads);
   ADD_PASS_WRAPPER_0("add_rewrite_tensor_descriptor_to_pointer",
                      createTritonRewriteTensorDescriptorToPointer);
   ADD_PASS_WRAPPER_0("add_loop_unroll", createTritonLoopUnroll);

--- a/python/test/unit/language/test_core.py
+++ b/python/test/unit/language/test_core.py
@@ -4908,6 +4908,38 @@ def test_masked_load_scalar(num_ctas, mask_val, other_val, device):
     torch.testing.assert_close(output, reference_out)
 
 
+@pytest.mark.parametrize("masked", [False, True])
+def test_load_uniform_along_dim(masked, device):
+    # A group-quantized scale read: with one group per tile the scale address
+    # does not depend on the row, so triton-narrow-redundant-loads rewrites the
+    # load into a single-row load plus a broadcast. Check that the values the
+    # narrowed load produces still match a full-tile read.
+    K, N = 32, 128
+
+    @triton.jit
+    def kernel(x_ptr, scale_ptr, out_ptr, K: tl.constexpr, N: tl.constexpr, GROUP: tl.constexpr,
+               MASKED: tl.constexpr):
+        k = tl.arange(0, K)[:, None]
+        n = tl.arange(0, N)[None, :]
+        x = tl.load(x_ptr + k * N + n)
+        scale_ptrs = scale_ptr + (k // GROUP) * N + n
+        if MASKED:
+            scale = tl.load(scale_ptrs, mask=n < N // 2, other=1.0)
+        else:
+            scale = tl.load(scale_ptrs)
+        tl.store(out_ptr + k * N + n, x * scale)
+
+    x = torch.randn((K, N), device=device, dtype=torch.float32)
+    scale = torch.randn((1, N), device=device, dtype=torch.float32)
+    out = torch.empty_like(x)
+    kernel[(1, )](x, scale, out, K, N, K, masked)
+
+    expected_scale = scale.clone()
+    if masked:
+        expected_scale[:, N // 2:] = 1.0
+    torch.testing.assert_close(out, x * expected_scale)
+
+
 # Testing masked loads with a copy to shared memory.
 # FIXME: Shape too small for ldmatrix when num_ctas=4
 @pytest.mark.interpreter

--- a/test/Triton/narrow-redundant-loads.mlir
+++ b/test/Triton/narrow-redundant-loads.mlir
@@ -1,0 +1,256 @@
+// RUN: triton-opt %s -triton-narrow-redundant-loads | FileCheck %s
+
+// A group-quantized GEMM scale: the scale index divides the K coordinate by the
+// group size, so a K tile inside one group reads the same scale for all of its K
+// positions. Dim 1 still picks a different scale per lane.
+// CHECK-LABEL: @narrow_group_quant_scale
+tt.func @narrow_group_quant_scale(%base: !tt.ptr<f16>, %kBlock: i32) -> tensor<32x128xf16> {
+  %kPerBlock = arith.constant 32 : i32
+  %groupSize = arith.constant dense<128> : tensor<32x1xi32>
+  %kRange = tt.make_range {end = 32 : i32, start = 0 : i32} : tensor<32xi32>
+  %kCol = tt.expand_dims %kRange {axis = 1 : i32} : tensor<32xi32> -> tensor<32x1xi32>
+  %kBase = arith.muli %kBlock, %kPerBlock : i32
+  %kBaseT = tt.splat %kBase : i32 -> tensor<32x1xi32>
+  %k = arith.addi %kBaseT, %kCol : tensor<32x1xi32>
+  %group = arith.divui %k, %groupSize : tensor<32x1xi32>
+  %nRange = tt.make_range {end = 128 : i32, start = 0 : i32} : tensor<128xi32>
+  %nRow = tt.expand_dims %nRange {axis = 0 : i32} : tensor<128xi32> -> tensor<1x128xi32>
+  %groupB = tt.broadcast %group : tensor<32x1xi32> -> tensor<32x128xi32>
+  %nB = tt.broadcast %nRow : tensor<1x128xi32> -> tensor<32x128xi32>
+  %off = arith.addi %nB, %groupB : tensor<32x128xi32>
+  %ptrs = tt.splat %base : !tt.ptr<f16> -> tensor<32x128x!tt.ptr<f16>>
+  %addr = tt.addptr %ptrs, %off : tensor<32x128x!tt.ptr<f16>>, tensor<32x128xi32>
+  // CHECK: %[[VAL:.*]] = tt.load %{{.*}} : tensor<1x128x!tt.ptr<f16>>
+  // CHECK-NEXT: tt.broadcast %[[VAL]] : tensor<1x128xf16> -> tensor<32x128xf16>
+  %val = tt.load %addr : tensor<32x128x!tt.ptr<f16>>
+  tt.return %val : tensor<32x128xf16>
+}
+
+// The same kernel with a K tile four times the group size. The tile spans four
+// groups, so the scale is not constant along the whole dimension.
+// CHECK-LABEL: @no_narrow_k_tile_straddles_groups
+tt.func @no_narrow_k_tile_straddles_groups(%base: !tt.ptr<f16>, %kBlock: i32) -> tensor<512x128xf16> {
+  %kPerBlock = arith.constant 512 : i32
+  %groupSize = arith.constant dense<128> : tensor<512x1xi32>
+  %kRange = tt.make_range {end = 512 : i32, start = 0 : i32} : tensor<512xi32>
+  %kCol = tt.expand_dims %kRange {axis = 1 : i32} : tensor<512xi32> -> tensor<512x1xi32>
+  %kBase = arith.muli %kBlock, %kPerBlock : i32
+  %kBaseT = tt.splat %kBase : i32 -> tensor<512x1xi32>
+  %k = arith.addi %kBaseT, %kCol : tensor<512x1xi32>
+  %group = arith.divui %k, %groupSize : tensor<512x1xi32>
+  %nRange = tt.make_range {end = 128 : i32, start = 0 : i32} : tensor<128xi32>
+  %nRow = tt.expand_dims %nRange {axis = 0 : i32} : tensor<128xi32> -> tensor<1x128xi32>
+  %groupB = tt.broadcast %group : tensor<512x1xi32> -> tensor<512x128xi32>
+  %nB = tt.broadcast %nRow : tensor<1x128xi32> -> tensor<512x128xi32>
+  %off = arith.addi %nB, %groupB : tensor<512x128xi32>
+  %ptrs = tt.splat %base : !tt.ptr<f16> -> tensor<512x128x!tt.ptr<f16>>
+  %addr = tt.addptr %ptrs, %off : tensor<512x128x!tt.ptr<f16>>, tensor<512x128xi32>
+  // CHECK: tt.load %{{.*}} : tensor<512x128x!tt.ptr<f16>>
+  %val = tt.load %addr : tensor<512x128x!tt.ptr<f16>>
+  tt.return %val : tensor<512x128xf16>
+}
+
+// Which dimension is redundant follows the address, not its position.
+// CHECK-LABEL: @narrow_uniform_along_dim_one
+tt.func @narrow_uniform_along_dim_one(%base: !tt.ptr<f16>) -> tensor<32x128xf16> {
+  %mRange = tt.make_range {end = 32 : i32, start = 0 : i32} : tensor<32xi32>
+  %mCol = tt.expand_dims %mRange {axis = 1 : i32} : tensor<32xi32> -> tensor<32x1xi32>
+  %off = tt.broadcast %mCol : tensor<32x1xi32> -> tensor<32x128xi32>
+  %ptrs = tt.splat %base : !tt.ptr<f16> -> tensor<32x128x!tt.ptr<f16>>
+  %addr = tt.addptr %ptrs, %off : tensor<32x128x!tt.ptr<f16>>, tensor<32x128xi32>
+  // CHECK: %[[VAL:.*]] = tt.load %{{.*}} : tensor<32x1x!tt.ptr<f16>>
+  // CHECK-NEXT: tt.broadcast %[[VAL]] : tensor<32x1xf16> -> tensor<32x128xf16>
+  %val = tt.load %addr : tensor<32x128x!tt.ptr<f16>>
+  tt.return %val : tensor<32x128xf16>
+}
+
+// A dequantizing GEMM reads both a scale and a zero point per group.
+// CHECK-LABEL: @narrow_two_loads
+tt.func @narrow_two_loads(%scaleBase: !tt.ptr<f16>, %zeroBase: !tt.ptr<f16>) -> tensor<32x128xf16> {
+  %nRange = tt.make_range {end = 128 : i32, start = 0 : i32} : tensor<128xi32>
+  %nRow = tt.expand_dims %nRange {axis = 0 : i32} : tensor<128xi32> -> tensor<1x128xi32>
+  %off = tt.broadcast %nRow : tensor<1x128xi32> -> tensor<32x128xi32>
+  %scalePtrs = tt.splat %scaleBase : !tt.ptr<f16> -> tensor<32x128x!tt.ptr<f16>>
+  %scaleAddr = tt.addptr %scalePtrs, %off : tensor<32x128x!tt.ptr<f16>>, tensor<32x128xi32>
+  // CHECK: %[[SCALE:.*]] = tt.load %{{.*}} : tensor<1x128x!tt.ptr<f16>>
+  // CHECK-NEXT: %[[SCALE_FULL:.*]] = tt.broadcast %[[SCALE]] : tensor<1x128xf16> -> tensor<32x128xf16>
+  %scale = tt.load %scaleAddr : tensor<32x128x!tt.ptr<f16>>
+  %zeroPtrs = tt.splat %zeroBase : !tt.ptr<f16> -> tensor<32x128x!tt.ptr<f16>>
+  %zeroAddr = tt.addptr %zeroPtrs, %off : tensor<32x128x!tt.ptr<f16>>, tensor<32x128xi32>
+  // CHECK: %[[ZERO:.*]] = tt.load %{{.*}} : tensor<1x128x!tt.ptr<f16>>
+  // CHECK-NEXT: %[[ZERO_FULL:.*]] = tt.broadcast %[[ZERO]] : tensor<1x128xf16> -> tensor<32x128xf16>
+  %zero = tt.load %zeroAddr : tensor<32x128x!tt.ptr<f16>>
+  // CHECK: arith.subf %[[SCALE_FULL]], %[[ZERO_FULL]]
+  %res = arith.subf %scale, %zero : tensor<32x128xf16>
+  tt.return %res : tensor<32x128xf16>
+}
+
+// Only the address is narrowed; uses of the loaded values stay on the full tile.
+// CHECK-LABEL: @narrow_integer_load
+tt.func @narrow_integer_load(%base: !tt.ptr<i8>) -> tensor<32x128xf16> {
+  %nRange = tt.make_range {end = 128 : i32, start = 0 : i32} : tensor<128xi32>
+  %nRow = tt.expand_dims %nRange {axis = 0 : i32} : tensor<128xi32> -> tensor<1x128xi32>
+  %off = tt.broadcast %nRow : tensor<1x128xi32> -> tensor<32x128xi32>
+  %ptrs = tt.splat %base : !tt.ptr<i8> -> tensor<32x128x!tt.ptr<i8>>
+  %addr = tt.addptr %ptrs, %off : tensor<32x128x!tt.ptr<i8>>, tensor<32x128xi32>
+  // CHECK: %[[VAL:.*]] = tt.load %{{.*}} : tensor<1x128x!tt.ptr<i8>>
+  // CHECK-NEXT: %[[FULL:.*]] = tt.broadcast %[[VAL]] : tensor<1x128xi8> -> tensor<32x128xi8>
+  %val = tt.load %addr : tensor<32x128x!tt.ptr<i8>>
+  // CHECK: arith.sitofp %[[FULL]]
+  %res = arith.sitofp %val : tensor<32x128xi8> to tensor<32x128xf16>
+  tt.return %res : tensor<32x128xf16>
+}
+
+// Elementwise arithmetic in the address is re-materialized by cloning it over
+// narrowed operands.
+// CHECK-LABEL: @narrow_address_through_arithmetic
+tt.func @narrow_address_through_arithmetic(%base: !tt.ptr<f16>, %packed: i32) -> tensor<32x128xf16> {
+  %maskBits = arith.constant dense<255> : tensor<1x128xi32>
+  %shift = arith.constant dense<8> : tensor<1x128xi32>
+  %nRange = tt.make_range {end = 128 : i32, start = 0 : i32} : tensor<128xi32>
+  %nRow = tt.expand_dims %nRange {axis = 0 : i32} : tensor<128xi32> -> tensor<1x128xi32>
+  %packedT = tt.splat %packed : i32 -> tensor<1x128xi32>
+  %biased = arith.addi %packedT, %nRow : tensor<1x128xi32>
+  %shifted = arith.shrui %biased, %shift : tensor<1x128xi32>
+  %group = arith.andi %shifted, %maskBits : tensor<1x128xi32>
+  %off = tt.broadcast %group : tensor<1x128xi32> -> tensor<32x128xi32>
+  %ptrs = tt.splat %base : !tt.ptr<f16> -> tensor<32x128x!tt.ptr<f16>>
+  %addr = tt.addptr %ptrs, %off : tensor<32x128x!tt.ptr<f16>>, tensor<32x128xi32>
+  // CHECK: %[[VAL:.*]] = tt.load %{{.*}} : tensor<1x128x!tt.ptr<f16>>
+  // CHECK-NEXT: tt.broadcast %[[VAL]] : tensor<1x128xf16> -> tensor<32x128xf16>
+  %val = tt.load %addr : tensor<32x128x!tt.ptr<f16>>
+  tt.return %val : tensor<32x128xf16>
+}
+
+// Narrowing a volatile load would change how many times it is issued.
+// CHECK-LABEL: @no_narrow_volatile_load
+tt.func @no_narrow_volatile_load(%base: !tt.ptr<f16>) -> tensor<16x64xf16> {
+  %ptrs = tt.splat %base : !tt.ptr<f16> -> tensor<16x64x!tt.ptr<f16>>
+  // CHECK: tt.load %{{.*}} {isVolatile = true} : tensor<16x64x!tt.ptr<f16>>
+  %val = tt.load %ptrs {isVolatile = true} : tensor<16x64x!tt.ptr<f16>>
+  tt.return %val : tensor<16x64xf16>
+}
+
+// A load off a bare splat reads one address for the whole tile.
+// CHECK-LABEL: @narrow_fully_uniform
+tt.func @narrow_fully_uniform(%base: !tt.ptr<f16>) -> tensor<16x64xf16> {
+  %ptrs = tt.splat %base : !tt.ptr<f16> -> tensor<16x64x!tt.ptr<f16>>
+  // CHECK: %[[VAL:.*]] = tt.load %{{.*}} : tensor<1x1x!tt.ptr<f16>>
+  // CHECK-NEXT: tt.broadcast %[[VAL]] : tensor<1x1xf16> -> tensor<16x64xf16>
+  %val = tt.load %ptrs : tensor<16x64x!tt.ptr<f16>>
+  tt.return %val : tensor<16x64xf16>
+}
+
+// Narrowing both dimensions at once makes tt.expand_dims drop its axis while
+// the dimension it expands is itself collapsing.
+// CHECK-LABEL: @narrow_uniform_along_both_dims
+tt.func @narrow_uniform_along_both_dims(%base: !tt.ptr<f16>) -> tensor<32x128xf16> {
+  %groupSize = arith.constant dense<32> : tensor<32x1xi32>
+  %kRange = tt.make_range {end = 32 : i32, start = 0 : i32} : tensor<32xi32>
+  %kCol = tt.expand_dims %kRange {axis = 1 : i32} : tensor<32xi32> -> tensor<32x1xi32>
+  %group = arith.divui %kCol, %groupSize : tensor<32x1xi32>
+  %off = tt.broadcast %group : tensor<32x1xi32> -> tensor<32x128xi32>
+  %ptrs = tt.splat %base : !tt.ptr<f16> -> tensor<32x128x!tt.ptr<f16>>
+  %addr = tt.addptr %ptrs, %off : tensor<32x128x!tt.ptr<f16>>, tensor<32x128xi32>
+  // CHECK: %[[VAL:.*]] = tt.load %{{.*}} : tensor<1x1x!tt.ptr<f16>>
+  // CHECK-NEXT: tt.broadcast %[[VAL]] : tensor<1x1xf16> -> tensor<32x128xf16>
+  %val = tt.load %addr : tensor<32x128x!tt.ptr<f16>>
+  tt.return %val : tensor<32x128xf16>
+}
+
+// An ordinary tiled load reads a distinct element per lane along both dims.
+// CHECK-LABEL: @no_narrow_contiguous_tile
+tt.func @no_narrow_contiguous_tile(%base: !tt.ptr<f16>) -> tensor<32x128xf16> {
+  %stride = arith.constant dense<128> : tensor<32x1xi32>
+  %mRange = tt.make_range {end = 32 : i32, start = 0 : i32} : tensor<32xi32>
+  %mCol = tt.expand_dims %mRange {axis = 1 : i32} : tensor<32xi32> -> tensor<32x1xi32>
+  %row = arith.muli %mCol, %stride : tensor<32x1xi32>
+  %nRange = tt.make_range {end = 128 : i32, start = 0 : i32} : tensor<128xi32>
+  %nRow = tt.expand_dims %nRange {axis = 0 : i32} : tensor<128xi32> -> tensor<1x128xi32>
+  %rowB = tt.broadcast %row : tensor<32x1xi32> -> tensor<32x128xi32>
+  %nB = tt.broadcast %nRow : tensor<1x128xi32> -> tensor<32x128xi32>
+  %off = arith.addi %rowB, %nB : tensor<32x128xi32>
+  %ptrs = tt.splat %base : !tt.ptr<f16> -> tensor<32x128x!tt.ptr<f16>>
+  %addr = tt.addptr %ptrs, %off : tensor<32x128x!tt.ptr<f16>>, tensor<32x128xi32>
+  // CHECK: tt.load %{{.*}} : tensor<32x128x!tt.ptr<f16>>
+  %val = tt.load %addr : tensor<32x128x!tt.ptr<f16>>
+  tt.return %val : tensor<32x128xf16>
+}
+
+// A mask uniform along the redundant dim narrows with the address, and its zero
+// fill narrows as a splat.
+// CHECK-LABEL: @narrow_masked_uniform_along_dim
+tt.func @narrow_masked_uniform_along_dim(%base: !tt.ptr<f16>, %n: i32) -> tensor<32x128xf16> {
+  %zero = arith.constant dense<0.0> : tensor<32x128xf16>
+  %nRange = tt.make_range {end = 128 : i32, start = 0 : i32} : tensor<128xi32>
+  %nRow = tt.expand_dims %nRange {axis = 0 : i32} : tensor<128xi32> -> tensor<1x128xi32>
+  %limit = tt.splat %n : i32 -> tensor<1x128xi32>
+  %nMask = arith.cmpi slt, %nRow, %limit : tensor<1x128xi32>
+  %mask = tt.broadcast %nMask : tensor<1x128xi1> -> tensor<32x128xi1>
+  %nB = tt.broadcast %nRow : tensor<1x128xi32> -> tensor<32x128xi32>
+  %ptrs = tt.splat %base : !tt.ptr<f16> -> tensor<32x128x!tt.ptr<f16>>
+  %addr = tt.addptr %ptrs, %nB : tensor<32x128x!tt.ptr<f16>>, tensor<32x128xi32>
+  // CHECK: %[[VAL:.*]] = tt.load %{{.*}}, %{{.*}}, %{{.*}} : tensor<1x128x!tt.ptr<f16>>
+  // CHECK-NEXT: tt.broadcast %[[VAL]] : tensor<1x128xf16> -> tensor<32x128xf16>
+  %val = tt.load %addr, %mask, %zero : tensor<32x128x!tt.ptr<f16>>
+  tt.return %val : tensor<32x128xf16>
+}
+
+// The address is uniform along dim 0 but the mask is not, so which lane a value
+// comes from decides whether it is the loaded value or the fill.
+// CHECK-LABEL: @no_narrow_mask_varies_along_dim
+tt.func @no_narrow_mask_varies_along_dim(%base: !tt.ptr<f16>, %k: i32) -> tensor<32x128xf16> {
+  %zero = arith.constant dense<0.0> : tensor<32x128xf16>
+  %kRange = tt.make_range {end = 32 : i32, start = 0 : i32} : tensor<32xi32>
+  %kCol = tt.expand_dims %kRange {axis = 1 : i32} : tensor<32xi32> -> tensor<32x1xi32>
+  %limit = tt.splat %k : i32 -> tensor<32x1xi32>
+  %kMask = arith.cmpi slt, %kCol, %limit : tensor<32x1xi32>
+  %mask = tt.broadcast %kMask : tensor<32x1xi1> -> tensor<32x128xi1>
+  %nRange = tt.make_range {end = 128 : i32, start = 0 : i32} : tensor<128xi32>
+  %nRow = tt.expand_dims %nRange {axis = 0 : i32} : tensor<128xi32> -> tensor<1x128xi32>
+  %nB = tt.broadcast %nRow : tensor<1x128xi32> -> tensor<32x128xi32>
+  %ptrs = tt.splat %base : !tt.ptr<f16> -> tensor<32x128x!tt.ptr<f16>>
+  %addr = tt.addptr %ptrs, %nB : tensor<32x128x!tt.ptr<f16>>, tensor<32x128xi32>
+  // CHECK: tt.load %{{.*}}, %{{.*}}, %{{.*}} : tensor<32x128x!tt.ptr<f16>>
+  %val = tt.load %addr, %mask, %zero : tensor<32x128x!tt.ptr<f16>>
+  tt.return %val : tensor<32x128xf16>
+}
+
+// The analysis sees through a transpose, but the rewrite has no rule for one.
+// Nothing of the half-built narrow address is left behind.
+// CHECK-LABEL: @no_narrow_address_not_rematerializable
+tt.func @no_narrow_address_not_rematerializable(%base: !tt.ptr<f16>) -> tensor<32x128xf16> {
+  %nRange = tt.make_range {end = 128 : i32, start = 0 : i32} : tensor<128xi32>
+  %nCol = tt.expand_dims %nRange {axis = 1 : i32} : tensor<128xi32> -> tensor<128x1xi32>
+  %wide = tt.broadcast %nCol : tensor<128x1xi32> -> tensor<128x32xi32>
+  %off = tt.trans %wide {order = array<i32: 1, 0>} : tensor<128x32xi32> -> tensor<32x128xi32>
+  %ptrs = tt.splat %base : !tt.ptr<f16> -> tensor<32x128x!tt.ptr<f16>>
+  %addr = tt.addptr %ptrs, %off : tensor<32x128x!tt.ptr<f16>>, tensor<32x128xi32>
+  // The CHECK-NOT covers the rolled-back address, which would otherwise be
+  // emitted ahead of the load and left dead.
+  // CHECK-NOT: tensor<1x128x!tt.ptr<f16>>
+  // CHECK: tt.load %{{.*}} : tensor<32x128x!tt.ptr<f16>>
+  %val = tt.load %addr : tensor<32x128x!tt.ptr<f16>>
+  tt.return %val : tensor<32x128xf16>
+}
+
+// Address and mask are uniform along dim 0 but the fill is not, and the analysis
+// does not account for it.
+// CHECK-LABEL: @no_narrow_fill_varies_along_dim
+tt.func @no_narrow_fill_varies_along_dim(%base: !tt.ptr<f16>, %n: i32) -> tensor<32x128xf16> {
+  %kRange = tt.make_range {end = 32 : i32, start = 0 : i32} : tensor<32xi32>
+  %kCol = tt.expand_dims %kRange {axis = 1 : i32} : tensor<32xi32> -> tensor<32x1xi32>
+  %kB = tt.broadcast %kCol : tensor<32x1xi32> -> tensor<32x128xi32>
+  %fill = arith.sitofp %kB : tensor<32x128xi32> to tensor<32x128xf16>
+  %nRange = tt.make_range {end = 128 : i32, start = 0 : i32} : tensor<128xi32>
+  %nRow = tt.expand_dims %nRange {axis = 0 : i32} : tensor<128xi32> -> tensor<1x128xi32>
+  %limit = tt.splat %n : i32 -> tensor<1x128xi32>
+  %nMask = arith.cmpi slt, %nRow, %limit : tensor<1x128xi32>
+  %mask = tt.broadcast %nMask : tensor<1x128xi1> -> tensor<32x128xi1>
+  %nB = tt.broadcast %nRow : tensor<1x128xi32> -> tensor<32x128xi32>
+  %ptrs = tt.splat %base : !tt.ptr<f16> -> tensor<32x128x!tt.ptr<f16>>
+  %addr = tt.addptr %ptrs, %nB : tensor<32x128x!tt.ptr<f16>>, tensor<32x128xi32>
+  // CHECK: tt.load %{{.*}}, %{{.*}}, %{{.*}} : tensor<32x128x!tt.ptr<f16>>
+  %val = tt.load %addr, %mask, %fill : tensor<32x128x!tt.ptr<f16>>
+  tt.return %val : tensor<32x128xf16>
+}

--- a/third_party/amd/backend/compiler.py
+++ b/third_party/amd/backend/compiler.py
@@ -248,6 +248,7 @@ class HIPBackend(BaseBackend):
             passes.ttir.add_rewrite_tensor_descriptor_to_pointer(pm)
         passes.common.add_canonicalizer(pm)
         passes.ttir.add_combine(pm)
+        passes.ttir.add_narrow_redundant_loads(pm)
         passes.ttir.add_reorder_broadcast(pm)
         passes.common.add_cse(pm)
         passes.ttir.add_triton_licm(pm)

--- a/third_party/nvidia/backend/compiler.py
+++ b/third_party/nvidia/backend/compiler.py
@@ -282,6 +282,7 @@ class CUDABackend(BaseBackend):
             passes.ttir.add_rewrite_tensor_descriptor_to_pointer(pm)
         passes.common.add_canonicalizer(pm)
         passes.ttir.add_combine(pm)
+        passes.ttir.add_narrow_redundant_loads(pm)
         passes.ttir.add_reorder_broadcast(pm)
         passes.common.add_cse(pm)
         passes.common.add_symbol_dce(pm)


### PR DESCRIPTION
A `tt.load` whose address is invariant along a tensor dimension reads the same value once per position along that dimension. Nothing removes those redundant copies before layout assignment, so they survive into TTGIR, where a layout conversion or a pipeliner stage can route the whole tile through shared memory. The tiles this affects are small ones, for example: a group-quantized GEMM's per-group scale, whose blocked layout holds one element per thread, so that shared memory traffic cannot be vectorized and costs a scalar write/read pair per redundant copy.

This pass rewrites such a load into a load of the index-0 slice plus a `tt.broadcast` back to the original shape, taking the invariant dimensions from the axis info analysis, whose load-result constancy is already the gcd of the address and mask constancies. `other` is checked separately because the analysis does not account for it.

The rewrite re-materializes the address computation at the narrower shape rather than reasoning about what the address means, so it is value-preserving; a load whose address it cannot re-materialize is left unchanged. It is self-limiting under tuning: a K tile spanning several quantization groups is no longer constant along that dimension and is not rewritten.

Enabled in the AMD and NVIDIA make_ttir pipelines after triton-combine, which folds chained tt.addptrs into the single offset the pass re-materializes and turns select plus load into a masked load.


<!---
The core Triton is a small number of people, and we receive many PRs (thank
you!).  To help us review your code more quickly, **if you are a new
contributor (less than 3 PRs merged) we ask that you complete the following
tasks and include the filled-out checklist in your PR description.**

Complete the following tasks before sending your PR, and replace `[ ]` with
`[x]` to indicate you have done them.
-->

# New contributor declaration
- [x] I am not making a trivial change, such as fixing a typo in a comment.

- [x] I have written a PR description following these
  [rules](https://cbea.ms/git-commit/#why-not-how).

- [ ] I have run `pre-commit run --from-ref origin/main --to-ref HEAD`.

- Select one of the following.
  - [x] I have added tests.
    - `/test` for `lit` tests
    - `/unittest` for C++ tests
    - `/python/test` for end-to-end tests
  - [ ] This PR does not need a test because `FILL THIS IN`.

- Select one of the following.
  - [ ] I have not added any `lit` tests.
  - [x] The `lit` tests I have added follow these [best practices](https://mlir.llvm.org/getting_started/TestingGuide/#filecheck-best-practices),
    including the "tests should be minimal" section. (Usually running Python code
    and using the instructions it generates is not minimal.)
