### PR TITLE
[INTERPRETER] Fix integer overflow in tl.sum

### DIFF
--- a/python/test/unit/language/test_core.py
+++ b/python/test/unit/language/test_core.py
@@ -2862,10 +2862,7 @@ def get_reduced_dtype(dtype_str, op):
 
 
 def get_reduce_input(dtype_str, shape):
-    # limit the range of integers so that reduce ops do not overflow
-    low = 0 if dtype_str in uint_dtypes else -10 if dtype_str in integral_dtypes else None
-    high = 10 if dtype_str in integral_dtypes else None
-    return numpy_random(shape, dtype_str=dtype_str, low=low, high=high)
+    return numpy_random(shape, dtype_str=dtype_str)
 
 
 @pytest.mark.interpreter
@@ -2927,7 +2924,10 @@ def test_reduce1d(op, dtype_str, shape, num_ctas, device):
     kernel[(1, )](x_tri, z_tri, BLOCK=shape, num_ctas=num_ctas)
     z_tri = to_numpy(z_tri)
     # compare
-    if op == 'sum':
+    if op == 'sum' and dtype_str in integral_dtypes:
+        # Integer sums wrap around, so a relative tolerance is meaningless.
+        np.testing.assert_equal(z_ref, z_tri)
+    elif op == 'sum':
         np.testing.assert_allclose(z_ref, z_tri, rtol=0.01)
     else:
         if 'tie-break-left' in op:
@@ -3061,7 +3061,10 @@ def test_reduce(op, dtype_str, shape, axis, keep_dims, num_ctas, device):
     z_tri = to_numpy(z_tri)
 
     # compare
-    if op == 'sum':
+    if op == 'sum' and dtype_str in integral_dtypes:
+        # Integer sums wrap around, so a relative tolerance is meaningless.
+        np.testing.assert_equal(z_ref, z_tri)
+    elif op == 'sum':
         np.testing.assert_allclose(z_ref, z_tri, rtol=0.01)
     else:
         if op in ('argmin', 'argmax'):

--- a/python/triton/runtime/interpreter.py
+++ b/python/triton/runtime/interpreter.py
@@ -1039,7 +1039,9 @@ class ReduceScanOpInterface:
             ret = ret.astype(np_dtype)
             ret_type = tl.block_type(dtype, list(ret.shape))
         else:
-            ret = np.array([ret], dtype=np_dtype)
+            # Match the shaped path above. NumPy 2 rejects out-of-range Python
+            # integers in array(..., dtype=...), while astype narrows instead.
+            ret = np.array([ret]).astype(np_dtype)
             ret_type = dtype
         return tl.core.tensor(TensorHandle(ret, dtype.scalar), ret_type)
 


### PR DESCRIPTION
Under `TRITON_INTERPRET=1`, a scalar integer reduction can raise `OverflowError` when its result exceeds the target dtype, while the compiled kernel wraps around.

```python
@triton.jit
def kernel(X, Z, SIZE: tl.constexpr):
    x = tl.load(X + tl.arange(0, SIZE))
    tl.store(Z, tl.sum(x))

x = torch.full((128,), 2**30, dtype=torch.int32, device="cuda")
z = torch.zeros(1, dtype=torch.int32, device="cuda")
kernel[(1, )](x, z, SIZE=128)
```

produces:

```text
compiled:            0
TRITON_INTERPRET=1:  InterpreterError("OverflowError('Python integer 137438953472 out of bounds for int32')")
```

NumPy promotes the int32 accumulator to int64. In `ReduceScanOpInterface.to_tensor`, shaped results are narrowed separately with `astype`, which performs the expected fixed-width integer conversion. The scalar path instead passed the target dtype directly to `np.array`, which NumPy 2 rejects for an out-of-range scalar.

Infer the intermediate dtype first and then narrow it with `astype`, matching the shaped-result path. The NumPy deprecation warning that preceded this NumPy 2 behavior recommended the same two-step conversion: `np.array(value).astype(dtype)`.

#7470 worked around the same failure by limiting the integer inputs in the reduce tests. Remove that restriction and compare integer sums exactly, since a relative tolerance is inappropriate for wrapped integer results. Reverting only the interpreter change makes the `test_reduce1d[sum-int32-*]` cases fail again.
