### PR TITLE
[ConSan] Disable operation-local scratch instrumentation

### DIFF
--- a/include/triton/Dialect/TritonInstrument/IR/TritonInstrument.md
+++ b/include/triton/Dialect/TritonInstrument/IR/TritonInstrument.md
@@ -349,11 +349,6 @@ The common hook implementation covers these TritonGPU operations:
   same destination. Equal-value duplicates and atomic scatter collisions remain
   valid.
 - `ttg.local_alloc` with a source: barrier-tracked shared-memory write.
-- Any operation with allocator-provided operation-local shared scratch: a
-  synchronous generic-proxy write over its allocated byte interval in its owning
-  CTA. Cross-CTA scratch reads follow intrinsic synchronization, and atomic
-  writes are issued only by producer CTAs. Forced warp-shuffle conversions
-  publish no scratch metadata because allocation reserves no scratch for them.
 - Function calls with allocator-provided virtual shared-memory frames: a
   synchronous generic-proxy write over the whole callee frame in the current
   CTA. This includes nested callees because each virtual frame is sized from
@@ -362,6 +357,11 @@ The common hook implementation covers these TritonGPU operations:
 
 These shared-memory effects are generic-proxy accesses for the proxy-ordering
 model.
+
+Operation-local compiler scratch is not instrumented. Races involving that
+scratch, including reuse while asynchronous accesses are pending, may therefore
+go undetected. Call-frame summaries and explicit shared-memory accesses remain
+instrumented.
 
 NVIDIA hooks additionally cover:
 

--- a/include/triton/Dialect/TritonInstrument/Transforms/ConSanTargetHooks.h
+++ b/include/triton/Dialect/TritonInstrument/Transforms/ConSanTargetHooks.h
@@ -216,7 +216,9 @@ inline std::optional<MemEffectsOpInfo>
 getConSanMemEffectsOpInfo(const ConSanTargetHooks &hooks, Operation *op) {
   std::optional<MemEffectsOpInfo> info = hooks.getMemEffectsOpInfo(op);
   auto sizeAttr = op->getAttrOfType<IntegerAttr>("allocation.size");
-  if (!sizeAttr)
+  // Keep frame summaries for retained callees, whose bodies are not
+  // instrumented, but omit operation-local compiler scratch.
+  if (!sizeAttr || !isa<CallOpInterface>(op))
     return info;
 
   uint32_t offset =
@@ -233,10 +235,9 @@ getConSanMemEffectsOpInfo(const ConSanTargetHooks &hooks, Operation *op) {
          "effect tracking");
   // A ConSan write performs both read- and write-conflict checks, so it is the
   // conservative read/write summary for compiler-owned scratch.
-  StringRef name = isa<CallOpInterface>(op) ? "Callee scratch" : "Scratch";
   info->operandEffects.emplace_back(
       RW::Write, MemEffectsOpInfo::Effects::StaticSharedBuffer{offset, size},
-      name.str());
+      "Callee scratch");
   return info;
 }
 

--- a/python/test/gluon/test_consan.py
+++ b/python/test/gluon/test_consan.py
@@ -1604,78 +1604,6 @@ def test_tma_store(FAILURE, device, run_wrapper, monkeypatch, num_ctas):
     kernel[(1, )](output_desc, FAILURE=FAILURE, num_warps=4, num_ctas=num_ctas)
 
 
-@pytest.mark.skipif(not is_cuda() or torch.cuda.get_device_capability()[0] < 9, reason="Requires Hopper or newer")
-@pytest.mark.parametrize("FAILURE", [
-    pytest.param(True, id="reused-pending-source"),
-    pytest.param(False, id="stable-source"),
-])
-def test_tma_store_convert_layout_scratch(FAILURE, device, run_wrapper, monkeypatch):
-    if run_wrapper:
-        result = run_in_process(test_tma_store_convert_layout_scratch, (FAILURE, device, False, monkeypatch))
-        if FAILURE:
-            assert_expected_cuda_failure(result.exc)
-            expected_error = "Accessing buffer with pending access. Pending access type: async_copy_shared_to_global"
-            assert expected_error in result.driver_stderr_output
-        else:
-            assert result.exc is None
-            assert result.driver_stderr_output == ""
-        return
-
-    monkeypatch.setenv("TRITON_INSTRUMENTATION_MODE", "consan")
-    monkeypatch.setenv("CUDA_LAUNCH_BLOCKING", "1")
-    knobs.refresh_knobs()
-
-    @gluon.jit
-    def kernel(output_desc, input, sink, iterations, FAILURE: ttgl.constexpr):
-        src_layout: ttgl.constexpr = ttgl.BlockedLayout([1], [32], [4], [0])
-        dst_layout: ttgl.constexpr = ttgl.SliceLayout(1, ttgl.BlockedLayout([1, 1], [1, 32], [1, 4], [1, 0]))
-        src_offsets = ttgl.arange(0, 128, layout=src_layout)
-        dst_offsets = ttgl.arange(0, 128, layout=dst_layout)
-        persistent_page = ttgl.allocate_shared_memory(ttgl.int32, [128], output_desc.layout)
-        if not FAILURE:
-            stable_source_page = ttgl.allocate_shared_memory(ttgl.int32, [128], output_desc.layout)
-
-        for iteration in range(iterations):
-            base = iteration * 128
-
-            # On iteration 1, scratch aliases iteration 0's deallocated source
-            # while its asynchronous TMA read can still be pending.
-            value = ttgl.load(input + base + src_offsets)
-            converted = ttgl.convert_layout(value, dst_layout)
-            ttgl.store(sink + base + dst_offsets, converted)
-
-            # Keep an unrelated store pending so wait(1) does not complete the
-            # source transfer below.
-            tma.store_wait(1)
-            persistent_page.store(value)
-            hopper.fence_async_shared()
-            tma.async_store(output_desc, [2 * base], persistent_page)
-
-            tma.store_wait(1)
-            if FAILURE:
-                source_page = ttgl.allocate_shared_memory(ttgl.int32, [128], output_desc.layout, value)
-            else:
-                stable_source_page.store(value)
-                source_page = stable_source_page
-            hopper.fence_async_shared()
-            tma.async_store(output_desc, [2 * base + 128], source_page)
-            if FAILURE:
-                source_page._keep_alive()
-
-        tma.store_wait(0)
-        persistent_page._keep_alive()
-        if not FAILURE:
-            stable_source_page._keep_alive()
-
-    iterations = 2
-    output = torch.empty(iterations * 2 * 128, dtype=torch.int32, device=device)
-    input = torch.arange(iterations * 128, dtype=torch.int32, device=device)
-    sink = torch.empty_like(input)
-    shared_layout = ttgl.NVMMASharedLayout.get_default_for([128], ttgl.int32)
-    output_desc = gluon.nvidia.hopper.TensorDescriptor.from_tensor(output, [128], shared_layout)
-    kernel[(1, )](output_desc, input, sink, iterations, FAILURE=FAILURE, num_warps=4)
-
-
 @pytest.mark.skipif(not is_cuda() or torch.cuda.get_device_capability()[0] < 10, reason="Requires blackwell or newer")
 @pytest.mark.parametrize("FAILURE", [True, False])
 @pytest.mark.parametrize("MEM_ACCESS_KIND", ["tma_cp", "local_store", "tmem_load", "tmem_store"])
@@ -3975,7 +3903,7 @@ def test_barrier_underflow(device, run_wrapper, monkeypatch, num_ctas):
 
 
 @pytest.mark.skipif(not is_cuda() or torch.cuda.get_device_capability()[0] < 9, reason="Requires hopper")
-@pytest.mark.parametrize("ACCESS", ["generic", "async-copy", "convert-layout"])
+@pytest.mark.parametrize("ACCESS", ["generic", "async-copy"])
 @pytest.mark.parametrize("INVALIDATE", [False, True], ids=["live", "invalidated"])
 def test_payload_reuse_requires_barrier_invalidation(ACCESS, INVALIDATE, device, run_wrapper, monkeypatch):
     if run_wrapper and not INVALIDATE:
@@ -4004,16 +3932,10 @@ def test_payload_reuse_requires_barrier_invalidation(ACCESS, INVALIDATE, device,
             ampere.async_copy.async_load(smem, source + offsets)
             ampere.async_copy.commit_group()
             ampere.async_copy.wait_group(0)
-        elif ACCESS == "convert-layout":
-            dst_layout: ttgl.constexpr = ttgl.SliceLayout(1, ttgl.BlockedLayout([1, 1], [1, 32], [1, 4], [1, 0]))
-            dst_offsets = ttgl.arange(0, XBLOCK, layout=dst_layout)
-            values = ttgl.load(source + offsets)
-            ttgl.store(output + dst_offsets, ttgl.convert_layout(values, dst_layout))
         else:
             values = ttgl.full([XBLOCK], 7, ttgl.int32, layout)
             smem = ttgl.allocate_shared_memory(ttgl.int32, [XBLOCK], smem_layout, values)
-        if ACCESS != "convert-layout":
-            ttgl.store(output + offsets, smem.load(layout))
+        ttgl.store(output + offsets, smem.load(layout))
 
     source = torch.arange(XBLOCK.value, device=device, dtype=torch.int32)
     output = torch.empty_like(source)

--- a/test/TritonGPU/amd/amd-consan.mlir
+++ b/test/TritonGPU/amd/amd-consan.mlir
@@ -1378,11 +1378,9 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, "ttg.thr
     // CHECK: ttg.local_dealloc
     ttg.local_dealloc %barrier
         : !ttg.memdesc<1xi64, #amd_convert_barrier, #ttg.shared_memory, mutable>
-    // CHECK-NOT: tt.call @__triton_consan_verify_barrier_can_init
-    // CHECK: tt.call @__triton_consan_verify_write_visibility
-    // CHECK: tt.call @__triton_consan_verify_read_visibility
-    // CHECK: tt.call @__triton_consan_invalidate_barrier_storage
-    // CHECK: tt.call @__triton_consan_publish_write_visibility
+    // Operation-local scratch does not update memory or barrier state.
+    // CHECK-NOT: tt.call @__triton_consan
+    // CHECK-NOT: tti.experimental_lock_acquire
     // CHECK: ttg.convert_layout
     %converted = ttg.convert_layout %value
         {allocation.offset = 0 : i32, allocation.size = 512 : i32}
@@ -1405,11 +1403,22 @@ module attributes {"ttg.num-ctas" = 2 : i32, "ttg.num-warps" = 1 : i32, "ttg.thr
     tt.return %old : i32
   }
 
-  // CHECK-LABEL: @amd_scalar_atomic_scratch_stays_cta_local
-  tt.func public @amd_scalar_atomic_scratch_stays_cta_local(
+  // CHECK-LABEL: @amd_scalar_atomic_keeps_callee_scratch_checks
+  tt.func public @amd_scalar_atomic_keeps_callee_scratch_checks(
       %ptr: !tt.ptr<i32>, %out: !tt.ptr<i32>) {
     %one = arith.constant 1 : i32
-    // Skip cluster-state initialization and the unrelated default effect mask.
+    // Skip the sanitizer's initialization helpers and rendezvous.
+    // CHECK: amdg.cluster_barrier_arrive
+    // CHECK-NEXT: amdg.cluster_barrier_wait
+    // Inline atomic scratch is not instrumented.
+    // CHECK-NOT: tt.call @__triton_consan
+    // CHECK-NOT: tti.experimental_lock_acquire
+    // CHECK: tt.atomic_rmw
+    %old = tt.atomic_rmw add, relaxed, gpu, %ptr, %one
+        {allocation.offset = 0 : i32, allocation.size = 4 : i32}
+        : (!tt.ptr<i32>, i32) -> i32
+    tt.store %out, %old : !tt.ptr<i32>
+    // Retained callees still have a CTA-local frame summary.
     // CHECK: tti.experimental_lock_acquire
     // CHECK-NOT: arith.cmpi eq
     // CHECK: tti.experimental_cluster_cta_id
@@ -1420,11 +1429,6 @@ module attributes {"ttg.num-ctas" = 2 : i32, "ttg.num-warps" = 1 : i32, "ttg.thr
     // CHECK: tt.call @__triton_consan_verify_write_visibility{{.*}}%[[AMD_SCALAR_RECIPIENT]]
     // CHECK: tt.call @__triton_consan_verify_read_visibility{{.*}}%[[AMD_SCALAR_RECIPIENT]]
     // CHECK: tt.call @__triton_consan_publish_write_visibility{{.*}}%[[AMD_SCALAR_RECIPIENT]]
-    // CHECK: tt.atomic_rmw
-    %old = tt.atomic_rmw add, relaxed, gpu, %ptr, %one
-        {allocation.offset = 0 : i32, allocation.size = 4 : i32}
-        : (!tt.ptr<i32>, i32) -> i32
-    tt.store %out, %old : !tt.ptr<i32>
     // CHECK: tt.call @amd_scalar_atomic_callee
     %callee = tt.call @amd_scalar_atomic_callee(%ptr)
         {allocation.offset = 0 : i32, allocation.size = 4 : i32}

--- a/test/TritonGPU/consan.mlir
+++ b/test/TritonGPU/consan.mlir
@@ -425,19 +425,14 @@ module attributes {"ttg.num-ctas" = 2 : i32, "ttg.num-warps" = 8 : i32, ttg.shar
 
     // Runtime indices along the sharded axis can target either CTA row.
     // CHECK: %[[ATOMIC_CTAS:.*]] = arith.constant 3 : i32
-    // CHECK: arith.constant dense<[true, false, false, false]> : tensor<4xi1
+    // CHECK: arith.constant dense<[true, false]> : tensor<2xi1
     // CHECK: tt.call @__triton_consan_set_proxy_access{{.*}}({{.*}}%[[ATOMIC_CTAS]])
     // CHECK: tt.call @__triton_consan_verify_write_visibility{{.*}}({{.*}}%[[ATOMIC_CTAS]]{{.*}})
     // CHECK: tt.call @__triton_consan_verify_read_visibility{{.*}}({{.*}}%[[ATOMIC_CTAS]]{{.*}})
     // CHECK: tt.call @__triton_consan_publish_write_visibility{{.*}}({{.*}}%[[ATOMIC_CTAS]]{{.*}})
-    // The existing destination reaches both CTAs, while independent result
-    // staging remains private to the issuer's shared-memory frame.
-    // CHECK: arith.constant dense<[false, false, true, false]> : tensor<4xi1
-    // CHECK: %[[ATOMIC_SCRATCH_CTA_ID:.*]] = tti.experimental_cluster_cta_id
-    // CHECK: %[[ATOMIC_SCRATCH_CTA:.*]] = arith.shli {{.*}}, %[[ATOMIC_SCRATCH_CTA_ID]] : i32
-    // CHECK: tt.call @__triton_consan_verify_write_visibility{{.*}}%[[ATOMIC_SCRATCH_CTA]]
-    // CHECK: tt.call @__triton_consan_verify_read_visibility{{.*}}%[[ATOMIC_SCRATCH_CTA]]
-    // CHECK: tt.call @__triton_consan_publish_write_visibility{{.*}}%[[ATOMIC_SCRATCH_CTA]]
+    // The explicit destination remains checked, but result-staging scratch
+    // adds no further checks to the same operation.
+    // CHECK-NOT: tt.call @__triton_consan
     // CHECK: ttg.local_atomic_scatter_rmw
     %old = ttg.local_atomic_scatter_rmw add, %dst[%indices], %values {allocation.offset = 1024 : i32, allocation.size = 512 : i32, axis = 1 : i32} : (!ttg.memdesc<8x32xi32, #local_atomic_shared, #local_atomic_smem, mutable>, tensor<8x32xi32, #local_atomic_blocked>, tensor<8x32xi32, #local_atomic_blocked>) -> tensor<8x32xi32, #local_atomic_blocked>
     tt.store %result, %old : tensor<8x32x!tt.ptr<i32>, #local_atomic_blocked>
@@ -2581,8 +2576,8 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, "ttg.thr
 #direct_reduce = #ttg.blocked<{sizePerThread = [1, 2], threadsPerWarp = [1, 32], warpsPerCTA = [1, 4], order = [1, 0]}>
 
 module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, "ttg.threads-per-warp" = 32 : i32, "ttg.total-num-warps" = 4 : i32, ttg.shared = 1024 : i32, ttg.target = "cuda:90", ttg.tensor_memory_size = 0 : i32} {
-  // CHECK-LABEL: @conversion_and_reduction_detect_outstanding_tma
-  tt.func public @conversion_and_reduction_detect_outstanding_tma(
+  // CHECK-LABEL: @conversion_and_reduction_omit_scratch_checks
+  tt.func public @conversion_and_reduction_omit_scratch_checks(
       %desc: !tt.tensordesc<256xi32, #direct_shared>,
       %value: tensor<128xi32, #direct_src>,
       %reduce: tensor<1x256xf32, #direct_reduce>) {
@@ -2592,19 +2587,19 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, "ttg.thr
     ttng.async_tma_copy_local_to_global %desc[%zero] %buffer
         : !tt.tensordesc<256xi32, #direct_shared>,
           !ttg.memdesc<256xi32, #direct_shared, #direct_smem, mutable>
+    // CHECK: ttg.local_dealloc
     ttg.local_dealloc %buffer
         : !ttg.memdesc<256xi32, #direct_shared, #direct_smem, mutable>
 
-    // CHECK: tt.call @__triton_consan_verify_read_visibility
-    // CHECK: tt.call @__triton_consan_check_outstanding_commits
-    // CHECK: tt.call @__triton_consan_publish_write_visibility
+    // Operation-local scratch does not check the pending TMA read.
+    // CHECK-NOT: tt.call @__triton_consan
+    // CHECK-NOT: tti.experimental_lock_acquire
     // CHECK: ttg.convert_layout
     %converted = ttg.convert_layout %value {allocation.offset = 0 : i32, allocation.size = 512 : i32}
         : tensor<128xi32, #direct_src> -> tensor<128xi32, #direct_dst>
 
-    // CHECK: tt.call @__triton_consan_verify_read_visibility
-    // CHECK: tt.call @__triton_consan_check_outstanding_commits
-    // CHECK: tt.call @__triton_consan_publish_write_visibility
+    // CHECK-NOT: tt.call @__triton_consan
+    // CHECK-NOT: tti.experimental_lock_acquire
     // CHECK: "tt.reduce"
     %reduced = "tt.reduce"(%reduce) <{axis = 1 : i32}> ({
     ^bb0(%lhs: f32, %rhs: f32):
@@ -2623,25 +2618,13 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, "ttg.thr
 #reduce_groups = #ttg.blocked<{sizePerThread = [1, 2], threadsPerWarp = [1, 32], warpsPerCTA = [1, 4], order = [1, 0], CGALayout = [[1, 0], [0, 1]]}>
 
 module attributes {"ttg.num-ctas" = 4 : i32, "ttg.num-warps" = 4 : i32, "ttg.threads-per-warp" = 32 : i32, "ttg.total-num-warps" = 4 : i32, ttg.shared = 32 : i32, ttg.target = "cuda:90", ttg.tensor_memory_size = 0 : i32} {
-  // CHECK-LABEL: @reduce_cross_cta_scratch_is_cta_local
-  tt.func public @reduce_cross_cta_scratch_is_cta_local(
+  // CHECK-LABEL: @reduce_cross_cta_omits_scratch_checks
+  tt.func public @reduce_cross_cta_omits_scratch_checks(
       %value: tensor<8x256xf32, #reduce_groups>) {
-    // Reduction groups {0,2} and {1,3} read peers only after their intrinsic
-    // cluster barrier; scratch writes touch the current CTA alone.
-    // CHECK: tti.experimental_lock_acquire
-    // CHECK: arith.constant dense<true> : tensor<1xi1
-    // CHECK: %[[REDUCE_CTA:.*]] = tti.experimental_cluster_cta_id
-    // CHECK: %[[REDUCE_ONE:.*]] = arith.constant 1 : i32
-    // CHECK: %[[REDUCE_OWNER:.*]] = arith.shli %[[REDUCE_ONE]], %[[REDUCE_CTA]] : i32
-    // CHECK: %[[REDUCE_GROUP_CTA:.*]] = tti.experimental_cluster_cta_id
-    // CHECK: %[[REDUCE_GROUP_FIXED:.*]] = arith.constant 1 : i32
-    // CHECK: %[[REDUCE_GROUP_BASE:.*]] = arith.andi %[[REDUCE_GROUP_CTA]], %[[REDUCE_GROUP_FIXED]] : i32
-    // CHECK: %[[REDUCE_GROUP_PATTERN:.*]] = arith.constant 5 : i32
-    // CHECK: %[[REDUCE_GROUP_SHIFT:.*]] = arith.shli %[[REDUCE_GROUP_PATTERN]], %[[REDUCE_GROUP_BASE]] : i32
-    // CHECK: %[[REDUCE_READERS:.*]] = arith.ori {{.*}}, %[[REDUCE_GROUP_SHIFT]] : i32
-    // CHECK: tt.call @__triton_consan_verify_write_visibility{{.*}}%[[REDUCE_READERS]]
-    // CHECK: tt.call @__triton_consan_verify_read_visibility{{.*}}%[[REDUCE_OWNER]]
-    // CHECK: tt.call @__triton_consan_publish_write_visibility{{.*}}%[[REDUCE_OWNER]]
+    // Scratch-only reductions do not acquire the instrumentation lock.
+    // CHECK: ttng.cluster_barrier
+    // CHECK-NOT: tt.call @__triton_consan
+    // CHECK-NOT: tti.experimental_lock_acquire
     // CHECK: "tt.reduce"
     %reduced = "tt.reduce"(%value) <{axis = 1 : i32}> ({
     ^bb0(%lhs: f32, %rhs: f32):
@@ -2675,18 +2658,9 @@ module attributes {"ttg.num-ctas" = 2 : i32, "ttg.num-warps" = 4 : i32, "ttg.thr
     ttg.local_dealloc %buffer : !ttg.memdesc<8x32xi32, #cross_shared, #cross_smem, mutable>
     // CHECK: ttng.cluster_barrier {relaxed = true}
     ttng.cluster_barrier {relaxed = true}
-    // Peer reads follow the conversion's intrinsic cluster barrier; the
-    // compiler-owned scratch write belongs only to its issuing CTA.
-    // CHECK: tti.experimental_lock_acquire
-    // CHECK: arith.constant dense<true> : tensor<1xi1
-    // CHECK: %[[CONVERT_CTA:.*]] = tti.experimental_cluster_cta_id
-    // CHECK: %[[CONVERT_ONE:.*]] = arith.constant 1 : i32
-    // CHECK: %[[CONVERT_OWNER:.*]] = arith.shli %[[CONVERT_ONE]], %[[CONVERT_CTA]] : i32
-    // CHECK: %[[CONVERT_PEERS:.*]] = arith.constant 3 : i32
-    // CHECK: %[[CONVERT_READERS:.*]] = arith.ori {{.*}}, %[[CONVERT_PEERS]] : i32
-    // CHECK: tt.call @__triton_consan_verify_write_visibility{{.*}}%[[CONVERT_READERS]]
-    // CHECK: tt.call @__triton_consan_verify_read_visibility{{.*}}%[[CONVERT_OWNER]]
-    // CHECK: tt.call @__triton_consan_publish_write_visibility{{.*}}%[[CONVERT_OWNER]]
+    // Cross-CTA scratch is omitted along with CTA-local scratch.
+    // CHECK-NOT: tt.call @__triton_consan
+    // CHECK-NOT: tti.experimental_lock_acquire
     // CHECK: ttg.convert_layout
     %converted = ttg.convert_layout %loaded {allocation.offset = 0 : i32, allocation.size = 512 : i32}
         : tensor<8x32xi32, #cross_src> -> tensor<8x32xi32, #cross_dst>
@@ -2714,17 +2688,9 @@ module attributes {"ttg.num-ctas" = 2 : i32, "ttg.num-warps" = 1 : i32, "ttg.thr
     }
     // CHECK: ttng.cluster_barrier {relaxed = true}
     ttng.cluster_barrier {relaxed = true}
-    // Both CTAs consume the result, but only CTA zero owns the scratch. The
-    // live barrier in CTA one does not overlap the atomic's physical storage.
-    // CHECK: tti.experimental_lock_acquire
-    // CHECK: %[[SCALAR_PRODUCER:.*]] = arith.cmpi eq, {{.*}} : i32
-    // CHECK: arith.constant dense<[true, false]> : tensor<2xi1
-    // CHECK: %[[SCALAR_CTA:.*]] = tti.experimental_cluster_cta_id
-    // CHECK: %[[SCALAR_ONE:.*]] = arith.constant 1 : i32
-    // CHECK: %[[SCALAR_OWNER:.*]] = arith.shli %[[SCALAR_ONE]], %[[SCALAR_CTA]] : i32
-    // CHECK: tt.call @__triton_consan_verify_write_visibility{{.*}}%[[SCALAR_PRODUCER]]{{.*}}%[[SCALAR_OWNER]]
-    // CHECK: tt.call @__triton_consan_verify_read_visibility{{.*}}%[[SCALAR_PRODUCER]]{{.*}}%[[SCALAR_OWNER]]
-    // CHECK: tt.call @__triton_consan_publish_write_visibility{{.*}}%[[SCALAR_PRODUCER]]{{.*}}%[[SCALAR_OWNER]]
+    // Result-broadcast scratch does not add shared-memory checks.
+    // CHECK-NOT: tt.call @__triton_consan
+    // CHECK-NOT: tti.experimental_lock_acquire
     // CHECK: tt.atomic_rmw
     %old = tt.atomic_rmw add, relaxed, gpu, %ptr, %one
         {allocation.offset = 0 : i32, allocation.size = 4 : i32}
@@ -2759,19 +2725,9 @@ module attributes {"ttg.num-ctas" = 2 : i32, "ttg.num-warps" = 4 : i32, "ttg.thr
     ttng.async_tma_copy_global_to_local %desc[%zero, %zero] %remote, %bar, %lead : !tt.tensordesc<8x32xi32, #tma_shared>, !ttg.memdesc<2xi64, #tma_barrier, #tma_smem, mutable> -> !ttg.memdesc<8x32xi32, #tma_shared, #tma_smem, mutable, 16x32>
     // CHECK: ttg.local_dealloc
     ttg.local_dealloc %parent : !ttg.memdesc<16x32xi32, #tma_shared, #tma_smem, mutable>
-    // CTA zero's pending async write targets CTA one. Conversion must check
-    // that remote owner but publish its own CTA-local scratch write only.
-    // CHECK: tti.experimental_lock_acquire
-    // CHECK: arith.constant dense<[true, false]> : tensor<2xi1
-    // CHECK: %[[TMA_OWNER_CTA:.*]] = tti.experimental_cluster_cta_id
-    // CHECK: %[[TMA_OWNER_ONE:.*]] = arith.constant 1 : i32
-    // CHECK: %[[TMA_OWNER:.*]] = arith.shli %[[TMA_OWNER_ONE]], %[[TMA_OWNER_CTA]] : i32
-    // CHECK: %[[TMA_PEERS:.*]] = arith.constant 3 : i32
-    // CHECK: %[[TMA_READERS:.*]] = arith.ori {{.*}}, %[[TMA_PEERS]] : i32
-    // CHECK: tt.call @__triton_consan_set_proxy_access{{.*}}%[[TMA_READERS]]
-    // CHECK: tt.call @__triton_consan_verify_write_visibility{{.*}}%[[TMA_READERS]]
-    // CHECK: tt.call @__triton_consan_verify_read_visibility{{.*}}%[[TMA_OWNER]]
-    // CHECK: tt.call @__triton_consan_publish_write_visibility{{.*}}%[[TMA_OWNER]]
+    // The TMA write remains tracked, but conversion scratch does not check it.
+    // CHECK-NOT: tt.call @__triton_consan
+    // CHECK-NOT: tti.experimental_lock_acquire
     // CHECK: ttg.convert_layout
     %converted = ttg.convert_layout %value {allocation.offset = 0 : i32, allocation.size = 1024 : i32} : tensor<16x32xi32, #tma_src> -> tensor<16x32xi32, #tma_dst>
     tt.return


### PR DESCRIPTION
Operation-local scratch instrumentation causes hangs in internal workloads. Disable these checks while the root cause of the hang is under investigation.

Keep callee-frame summaries and explicit shared-memory/TMEM instrumentation enabled. Races involving operation-local compiler scratch may go undetected while these checks are disabled.
