### PR TITLE
[BAKCEND] Fuse abs min/max reductions on Blackwell

### DIFF
--- a/include/triton/Conversion/TritonGPUToLLVM/TargetInfoBase.h
+++ b/include/triton/Conversion/TritonGPUToLLVM/TargetInfoBase.h
@@ -4,6 +4,7 @@
 #include "triton/Conversion/MLIRTypes.h"
 #include "triton/Tools/GenericSwizzling.h"
 #include "llvm/ADT/ArrayRef.h"
+#include <optional>
 
 namespace mlir::triton {
 enum class ProgramIDDim : uint32_t;
@@ -76,6 +77,16 @@ public:
   virtual bool warpReduce(RewriterBase &rewriter, Location loc,
                           SmallVector<Value> &acc, triton::ReduceOp op,
                           unsigned reduceLaneIdMask) const = 0;
+
+  // Try to combine a group of absolute values as part of an in-thread
+  // reduction. The values are the results of LLVM fabs operations and a
+  // successful result replaces them in the reduction tree. Targets without a
+  // fused instruction should leave this unhandled.
+  virtual std::optional<Value>
+  tryReduceAbs(RewriterBase &rewriter, Location loc, triton::ReduceOp op,
+               ValueRange values) const {
+    return std::nullopt;
+  }
 
   virtual std::string getMulhiFuncName(Type resultElementTy) const = 0;
   // Emits LLVM code with |rewriter| to print a message following the given

--- a/lib/Conversion/TritonGPUToLLVM/ReduceOpToLLVM.cpp
+++ b/lib/Conversion/TritonGPUToLLVM/ReduceOpToLLVM.cpp
@@ -112,7 +112,7 @@ private:
   // instructions (e.g. v_maximum3_f32 on AMD).
   SmallVector<Value> treeReduce(Location loc,
                                 ConversionPatternRewriter &rewriter,
-                                Region &combineOp,
+                                triton::ReduceOp op, Region &combineOp,
                                 SmallVector<SmallVector<Value>> values,
                                 unsigned arity) const {
     assert(!values.empty() && arity >= 2);
@@ -124,6 +124,21 @@ private:
         if (groupSize == 1) {
           next.push_back(std::move(values[i]));
         } else {
+          SmallVector<Value> group;
+          ArrayRef<SmallVector<Value>> groupValues(values.data() + i,
+                                                    groupSize);
+          if (llvm::all_of(groupValues, [](const SmallVector<Value> &values) {
+                             return values.size() == 1;
+                           })) {
+            group.reserve(groupSize);
+            for (const auto &values : groupValues)
+              group.push_back(values.front());
+            if (auto result =
+                    targetInfo.tryReduceAbs(rewriter, loc, op, group)) {
+              next.push_back({*result});
+              continue;
+            }
+          }
           SmallVector<Value> acc = std::move(values[i]);
           for (size_t j = 1; j < groupSize; ++j)
             accumulate(loc, rewriter, combineOp, acc, values[i + j]);
@@ -293,8 +308,8 @@ private:
         }
         vals.push_back(std::move(cur));
       }
-      auto acc =
-          treeReduce(loc, rewriter, combineRegion, std::move(vals), arity);
+      auto acc = treeReduce(loc, rewriter, op, combineRegion, std::move(vals),
+                            arity);
       for (unsigned opIdx = 0; opIdx < numOperands; ++opIdx) {
         reduced[opIdx].push_back(acc[opIdx]);
       }

--- a/python/test/unit/language/test_core.py
+++ b/python/test/unit/language/test_core.py
@@ -6712,6 +6712,24 @@ def test_propagate_nan(dtype, propagate_nan, func, device):
             assert not torch.isnan(C[0])
 
 
+@pytest.mark.interpreter
+@pytest.mark.parametrize("func", ["min", "max"])
+@pytest.mark.parametrize("propagate_nan", ["NONE", "ALL"])
+def test_reduce_propagate_nan(func, propagate_nan, device):
+
+    @triton.jit
+    def kernel(x_ptr, out_ptr, propagate_nan: tl.constexpr, func: tl.constexpr):
+        x = tl.load(x_ptr + tl.arange(0, 2))
+        result = getattr(tl, func)(x, axis=0, propagate_nan=getattr(tl.PropagateNan, propagate_nan))
+        tl.store(out_ptr, result)
+
+    x = torch.tensor([torch.nan, 1.0], device=device)
+    out = torch.empty((), device=device)
+    kernel[(1, )](x, out, propagate_nan, func)
+
+    assert torch.isnan(out) == (propagate_nan == "ALL")
+
+
 # -----------------------
 # test clamp
 # -----------------------

--- a/python/triton/language/core.py
+++ b/python/triton/language/core.py
@@ -1267,13 +1267,15 @@ class tensor(base_value):
     def ravel(self) -> tensor:
         ...
 
-    def max(self, axis=None, return_indices=False, return_indices_tie_break_left=True, keep_dims=False) -> tensor:
+    def max(self, axis=None, return_indices=False, return_indices_tie_break_left=True, keep_dims=False,
+            propagate_nan: constexpr = PropagateNan.NONE) -> tensor:
         ...
 
     def argmax(self, axis, tie_break_left=True, keep_dims=False) -> tensor:
         ...
 
-    def min(self, axis=None, return_indices=False, return_indices_tie_break_left=True, keep_dims=False) -> tensor:
+    def min(self, axis=None, return_indices=False, return_indices_tie_break_left=True, keep_dims=False,
+            propagate_nan: constexpr = PropagateNan.NONE) -> tensor:
         ...
 
     def argmin(self, axis, tie_break_left=True, keep_dims=False) -> tensor:
@@ -2873,7 +2875,7 @@ def clamp(x, min, max, propagate_nan: constexpr = PropagateNan.NONE, _semantic=N
 
 
 def _add_reduction_docstr(name: str, return_indices_arg: str = None, tie_break_arg: str = None,
-                          dtype_arg: str = None) -> Callable[[T], T]:
+                          dtype_arg: str = None, propagate_nan_arg: bool = False) -> Callable[[T], T]:
 
     def _decorator(func: T) -> T:
         docstr = """
@@ -2899,6 +2901,11 @@ def _add_reduction_docstr(name: str, return_indices_arg: str = None, tie_break_a
             docstr += f"""
     :param {dtype_arg}: the desired data type of the returned tensor. If specified, the input tensor is casted to :code:`{dtype_arg}` before the operation is performed. This is useful for preventing data overflows. If not specified, signed integer dtypes narrower than 32 bits are upcasted to :code:`tl.int32`, while unsigned integer and bool dtypes narrower than 32 bits are upcasted to :code:`tl.uint32`. Other dtypes are kept as-is.
     :type {dtype_arg}: tl.dtype"""
+
+        if propagate_nan_arg:
+            docstr += """
+    :param propagate_nan: whether to propagate NaN values.
+    :type propagate_nan: tl.PropagateNan"""
 
         func.__doc__ = docstr.format(name=name)
         return func

--- a/python/triton/language/standard.py
+++ b/python/triton/language/standard.py
@@ -196,13 +196,24 @@ def _elementwise_max(a, b):
     return core.maximum(a, b)
 
 
+@jit
+def _elementwise_max_nan(a, b):
+    return core.maximum(a, b, propagate_nan=core.PropagateNan.ALL)
+
+
 @core._tensor_member_fn
 @jit
 @core._add_reduction_docstr("maximum", return_indices_arg="return_indices",
-                            tie_break_arg="return_indices_tie_break_left")
-def max(input, axis=None, return_indices=False, return_indices_tie_break_left=True, keep_dims=False):
+                            tie_break_arg="return_indices_tie_break_left", propagate_nan_arg=True)
+def max(input, axis=None, return_indices=False, return_indices_tie_break_left=True, keep_dims=False,
+        propagate_nan=core.PropagateNan.NONE):
     input = core._promote_bfloat16_to_float32(input)
+    propagate_nan = core._unwrap_if_constexpr(propagate_nan)
+    assert propagate_nan in (core.PropagateNan.NONE, core.PropagateNan.ALL), \
+        "propagate_nan must be tl.PropagateNan.NONE or tl.PropagateNan.ALL"
     if return_indices:
+        assert propagate_nan == core.PropagateNan.NONE, \
+            "propagate_nan is not supported when return_indices is true"
         if return_indices_tie_break_left:
             return core._reduce_with_indices(input, axis, _argmax_combine_tie_break_left, keep_dims=keep_dims)
         else:
@@ -214,7 +225,8 @@ def max(input, axis=None, return_indices=False, return_indices_tie_break_left=Tr
             else:
                 assert input.dtype.is_int(), "Expecting input to be integer type"
                 input = input.to(core.int32)
-        return core.reduce(input, axis, _elementwise_max, keep_dims=keep_dims)
+        combine_fn = _elementwise_max_nan if propagate_nan == core.PropagateNan.ALL else _elementwise_max
+        return core.reduce(input, axis, combine_fn, keep_dims=keep_dims)
 
 
 @core._tensor_member_fn
@@ -255,13 +267,24 @@ def _elementwise_min(a, b):
     return core.minimum(a, b)
 
 
+@jit
+def _elementwise_min_nan(a, b):
+    return core.minimum(a, b, propagate_nan=core.PropagateNan.ALL)
+
+
 @core._tensor_member_fn
 @jit
 @core._add_reduction_docstr("minimum", return_indices_arg="return_indices",
-                            tie_break_arg="return_indices_tie_break_left")
-def min(input, axis=None, return_indices=False, return_indices_tie_break_left=True, keep_dims=False):
+                            tie_break_arg="return_indices_tie_break_left", propagate_nan_arg=True)
+def min(input, axis=None, return_indices=False, return_indices_tie_break_left=True, keep_dims=False,
+        propagate_nan=core.PropagateNan.NONE):
     input = core._promote_bfloat16_to_float32(input)
+    propagate_nan = core._unwrap_if_constexpr(propagate_nan)
+    assert propagate_nan in (core.PropagateNan.NONE, core.PropagateNan.ALL), \
+        "propagate_nan must be tl.PropagateNan.NONE or tl.PropagateNan.ALL"
     if return_indices:
+        assert propagate_nan == core.PropagateNan.NONE, \
+            "propagate_nan is not supported when return_indices is true"
         if return_indices_tie_break_left:
             return core._reduce_with_indices(input, axis, _argmin_combine_tie_break_left, keep_dims=keep_dims)
         else:
@@ -273,7 +296,8 @@ def min(input, axis=None, return_indices=False, return_indices_tie_break_left=Tr
             else:
                 assert input.dtype.is_int(), "Expecting input to be integer type"
                 input = input.to(core.int32)
-        return core.reduce(input, axis, _elementwise_min, keep_dims=keep_dims)
+        combine_fn = _elementwise_min_nan if propagate_nan == core.PropagateNan.ALL else _elementwise_min
+        return core.reduce(input, axis, combine_fn, keep_dims=keep_dims)
 
 
 @core._tensor_member_fn

--- a/test/Conversion/tritongpu_to_llvm_blackwell.mlir
+++ b/test/Conversion/tritongpu_to_llvm_blackwell.mlir
@@ -1024,6 +1024,40 @@ module attributes {"ttg.target" = "cuda:100", "ttg.num-ctas" = 1 : i32, "ttg.num
 
 // -----
 
+// CHECK-LABEL: @max_abs_within_thread
+// CHECK-COUNT-2: llvm.inline_asm "max.abs.f32
+#blocked = #ttg.blocked<{sizePerThread = [1, 4], threadsPerWarp = [1, 32], warpsPerCTA = [1, 1], order = [1, 0]}>
+module attributes {"ttg.target" = "cuda:100", "ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 1 : i32, "ttg.threads-per-warp" = 32 : i32} {
+  tt.func public @max_abs_within_thread(%arg0: tensor<1x128xf32, #blocked>) {
+    %0 = math.absf %arg0 : tensor<1x128xf32, #blocked>
+    %1 = "tt.reduce"(%0) <{axis = 1 : i32}> ({
+    ^bb0(%lhs: f32, %rhs: f32):
+      %2 = arith.maxnumf %lhs, %rhs : f32
+      tt.reduce.return %2 : f32
+    }) {allocation.offset = 0 : i32} : (tensor<1x128xf32, #blocked>) -> tensor<1xf32, #ttg.slice<{dim = 1, parent = #blocked}>>
+    tt.return
+  }
+}
+
+// -----
+
+// CHECK-LABEL: @max_abs_across_threads
+// CHECK: nvvm.redux.sync fmax {{.*}} abs = true : f32 -> f32
+#blocked = #ttg.blocked<{sizePerThread = [1, 1], threadsPerWarp = [1, 32], warpsPerCTA = [1, 1], order = [1, 0]}>
+module attributes {"ttg.target" = "cuda:100", "ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 1 : i32, "ttg.threads-per-warp" = 32 : i32} {
+  tt.func public @max_abs_across_threads(%arg0: tensor<1x32xf32, #blocked>) {
+    %0 = math.absf %arg0 : tensor<1x32xf32, #blocked>
+    %1 = "tt.reduce"(%0) <{axis = 1 : i32}> ({
+    ^bb0(%lhs: f32, %rhs: f32):
+      %2 = arith.maxnumf %lhs, %rhs : f32
+      tt.reduce.return %2 : f32
+    }) {allocation.offset = 0 : i32} : (tensor<1x32xf32, #blocked>) -> tensor<1xf32, #ttg.slice<{dim = 1, parent = #blocked}>>
+    tt.return
+  }
+}
+
+// -----
+
 // CHECK-LABEL: maxnum_reduction
 //       CHECK:  %[[M:.+]] = llvm.mlir.constant(-1 : i32) : i32
 //       CHECK:   nvvm.redux.sync  fmax %{{.*}}, %[[M]] : f32 -> f32

--- a/third_party/nvidia/lib/TritonNVIDIAGPUToLLVM/TargetInfo.cpp
+++ b/third_party/nvidia/lib/TritonNVIDIAGPUToLLVM/TargetInfo.cpp
@@ -521,6 +521,20 @@ bool TargetInfo::warpReduce(RewriterBase &rewriter, Location loc,
   if (auto kind = matchReduxKind(op, targetFeatures.getComputeCapability(),
                                  useNanQualifier)) {
     assert(acc.size() == 1);
+    bool useAbs = false;
+    Value reduxInput = acc.front();
+    // redux.sync.{min,max}.abs.f32 is available on Blackwell. Only absorb a
+    // direct fabs when each thread contributes one value to this reduction;
+    // otherwise the in-thread reduction has already consumed the fabs.
+    if (targetFeatures.getComputeCapability() >= 100 &&
+        (ptxVersion == 0 || ptxVersion >= 88) && reduxInput.getType().isF32() &&
+        (*kind == NVVM::ReductionKind::FMIN ||
+         *kind == NVVM::ReductionKind::FMAX)) {
+      if (auto abs = reduxInput.getDefiningOp<LLVM::FAbsOp>()) {
+        reduxInput = abs.getOperand();
+        useAbs = true;
+      }
+    }
     Value mask = b.i32_val(0xFFFFFFFF);
     // Even though we currently don't use redux for partitioned reduction
     // the code below supports it in case we want to tweak the heuristic.
@@ -542,8 +556,8 @@ bool TargetInfo::warpReduce(RewriterBase &rewriter, Location loc,
             acc[i] = b.zext(i32_ty, acc[i]);
         }
       }
-      acc[i] = NVVM::ReduxOp::create(rewriter, loc, acc[i].getType(), acc[0],
-                                     *kind, mask, /*abs=*/false,
+      acc[i] = NVVM::ReduxOp::create(rewriter, loc, acc[i].getType(),
+                                     reduxInput, *kind, mask, useAbs,
                                      /*nan=*/useNanQualifier);
       if (acc[i].getType().isInteger()) {
         if (bitwidth < 32)
@@ -553,6 +567,50 @@ bool TargetInfo::warpReduce(RewriterBase &rewriter, Location loc,
     return true;
   }
   return false;
+}
+
+std::optional<Value>
+TargetInfo::tryReduceAbs(RewriterBase &rewriter, Location loc,
+                         triton::ReduceOp op, ValueRange values) const {
+  // max.abs.f32 and min.abs.f32 take two or three input values on Blackwell.
+  // PTX 8.8 introduced the ternary form used for three-element reduction
+  // groups; use zero as the identity for the two-element case.
+  if (targetFeatures.getComputeCapability() < 100 ||
+      (ptxVersion != 0 && ptxVersion < 88) || values.size() < 2 ||
+      values.size() > 3 || !llvm::all_of(values, [](Value value) {
+        return value.getType().isF32() && value.getDefiningOp<LLVM::FAbsOp>();
+      })) {
+    return std::nullopt;
+  }
+
+  Operation *combiner = op.getSingleCombiner();
+  bool isMax = isa<arith::MaxNumFOp, arith::MaximumFOp>(combiner);
+  bool isMin = isa<arith::MinNumFOp, arith::MinimumFOp>(combiner);
+  if (!isMax && !isMin)
+    return std::nullopt;
+
+  bool propagateNan =
+      isa<arith::MaximumFOp, arith::MinimumFOp>(combiner);
+  PTXBuilder builder;
+  TritonLLVMOpBuilder llvmBuilder(loc, rewriter);
+  auto *dst = builder.newOperand("=r");
+  auto toRegister = [&](Value value) {
+    return llvmBuilder.bitcast(i32_ty, value);
+  };
+  auto *lhs = builder.newOperand(
+      toRegister(values[0].getDefiningOp<LLVM::FAbsOp>().getOperand()), "r");
+  auto *rhs = builder.newOperand(
+      toRegister(values[1].getDefiningOp<LLVM::FAbsOp>().getOperand()), "r");
+  auto *third = builder.newOperand(
+      values.size() == 3
+          ? toRegister(values[2].getDefiningOp<LLVM::FAbsOp>().getOperand())
+          : llvmBuilder.i32_val(0),
+      "r");
+  auto &minmax = *builder.create(isMax ? "max" : "min");
+  minmax.o("NaN", propagateNan).o("abs").o("f32");
+  minmax(dst, lhs, rhs, third);
+  Value result = builder.launch(rewriter, loc, i32_ty, /*hasSideEffect=*/false);
+  return llvmBuilder.bitcast(values.front().getType(), result);
 }
 
 unsigned TargetInfo::getReductionTreeArity(Operation *combinerOp) const {

--- a/third_party/nvidia/lib/TritonNVIDIAGPUToLLVM/TargetInfo.h
+++ b/third_party/nvidia/lib/TritonNVIDIAGPUToLLVM/TargetInfo.h
@@ -73,6 +73,9 @@ public:
   bool warpReduce(RewriterBase &rewriter, Location loc, SmallVector<Value> &acc,
                   triton::ReduceOp op,
                   unsigned reduceLaneIdMask) const override;
+  std::optional<Value> tryReduceAbs(RewriterBase &rewriter, Location loc,
+                                    triton::ReduceOp op,
+                                    ValueRange values) const override;
   unsigned getReductionTreeArity(Operation *combinerOp) const override;
 
   std::string getMulhiFuncName(Type resultElementTy) const override;


### PR DESCRIPTION
Fuses absolute-value min/max reductions into Blackwell instructions when the reduction inputs are direct absolute values. Adds NaN-propagation support to reduction min and max, with regression coverage for the frontend behavior and LLVM lowering.