### PR TITLE
[Backend] Fix spurious iterator warning in softmax tests

### DIFF
--- a/python/src/llvm.cc
+++ b/python/src/llvm.cc
@@ -620,7 +620,8 @@ void init_triton_llvm(py::module_ &m) {
           "__iter__",
           [](llvm::Module::FunctionListType &s) {
             return py::make_iterator<py::rv_policy::reference>(
-                py::handle(), "iterator", s.begin(), s.end());
+                py::type<llvm::Module::FunctionListType>(), "iterator",
+                s.begin(), s.end());
           },
           py::keep_alive<0, 1>());
 


### PR DESCRIPTION
<!---
The core Triton is a small number of people, and we receive many PRs (thank
you!).  To help us review your code more quickly, **if you are a new
contributor (less than 3 PRs merged) we ask that you complete the following
tasks and include the filled-out checklist in your PR description.**

Complete the following tasks before sending your PR, and replace `[ ]` with
`[x]` to indicate you have done them.
-->

Fix a `DeprecationWarning` emitted while iterating over an LLVM module's function list:

  ```text
  DeprecationWarning: builtin type iterator has no __module__ attribute
  ```

  The warning was captured by test_softmax_keep_dims_deprecated, causing all six parameterizations to fail because the test expects either no warning or exactly one softmax deprecation warning.

  Pass the bound llvm::Module::FunctionListType as the scope when creating the iterator instead of using an empty handle. This gives the generated iterator a valid Python scope and prevents the unrelated warning.

  The iterator's reference policy and lifetime handling remain unchanged.

# New contributor declaration
- [x] I am not making a trivial change, such as fixing a typo in a comment.

- [x] I have written a PR description following these
  [rules](https://cbea.ms/git-commit/#why-not-how).

- [x] I have run `pre-commit run --from-ref origin/main --to-ref HEAD`.

- Select one of the following.
  - [ ] I have added tests.
    - `/test` for `lit` tests
    - `/unittest` for C++ tests
    - `/python/test` for end-to-end tests
  - [x] This PR does not need a test because `I fix a test`.

- Select one of the following.
  - [x] I have not added any `lit` tests.
  - [ ] The `lit` tests I have added follow these [best practices](https://mlir.llvm.org/getting_started/TestingGuide/#filecheck-best-practices),
    including the "tests should be minimal" section. (Usually running Python code
    and using the instructions it generates is not minimal.)
