### PR TITLE
[BACKEND] Generalize atomic_poll to tensor pointers

### DIFF
--- a/include/triton/Dialect/Triton/IR/TritonOps.td
+++ b/include/triton/Dialect/Triton/IR/TritonOps.td
@@ -341,11 +341,12 @@ def TT_AtomicPollOp : TT_Op<"atomic_poll", [
 
     let description = [{
         Repeatedly load each logical element of $ptr with relaxed semantics
-        until it equals $expected or its timeout expires. One thread polls
+        until it equals $expected or the operation's timeout expires. One thread polls
         each element; threads replicating that element wait for its result.
         For acquire semantics, issue an acquire fence after each successful
         poll. The block waits for all elements to finish. The result has the
-        same shape and encoding as $ptr.
+        same shape and encoding as $ptr. All elements share one timeout budget,
+        and each element is loaded at least once, even with a zero timeout.
     }];
 
     let arguments = (ins

--- a/include/triton/Dialect/Triton/IR/TritonOps.td
+++ b/include/triton/Dialect/Triton/IR/TritonOps.td
@@ -331,27 +331,32 @@ def TT_GridDependencyLaunchDependentsOp
 }
 
 def TT_AtomicPollOp : TT_Op<"atomic_poll", [
+  SameOperandsAndResultEncoding,
   TypesMatchWith<"ptr type matches expected type", "expected", "ptr",
-                 "getPointerTypeSameShape($_self)">
+                 "getPointerTypeSameShape($_self)">,
+  TypesMatchWith<"result type matches expected shape", "expected", "result",
+                 "getI1SameShape($_self)">
 ]> {
     let summary = "poll an atomic value";
 
     let description = [{
-        Repeatedly load from $ptr with relaxed semantics on a single thread
-        until the loaded value equals $expected. For acquire semantics, issue
-        an acquire fence only after a successful poll. Other threads wait for
-        the polling thread to finish.
+        Repeatedly load each logical element of $ptr with relaxed semantics
+        until it equals $expected or its timeout expires. One thread polls
+        each element; threads replicating that element wait for its result.
+        For acquire semantics, issue an acquire fence after each successful
+        poll. The block waits for all elements to finish. The result has the
+        same shape and encoding as $ptr.
     }];
 
     let arguments = (ins
-      Arg<TT_Ptr, "", [MemRead<GlobalMemory>, MemWrite<GlobalMemory>]>:$ptr,
-      TT_Int:$expected,
+      Arg<TT_PtrLike, "", [MemRead<GlobalMemory>, MemWrite<GlobalMemory>]>:$ptr,
+      TT_IntLike:$expected,
       Optional<I64>:$timeout,
       TT_MemSemanticAttr:$sem,
       TT_MemSyncScopeAttr:$scope
     );
 
-    let results = (outs I1:$result);
+    let results = (outs TT_BoolLike:$result);
 
     let assemblyFormat = [{
       $sem `,` $scope `,` $ptr `,` $expected (`timeout` $timeout^)?

--- a/include/triton/Dialect/TritonInstrument/IR/TritonInstrumentOps.td
+++ b/include/triton/Dialect/TritonInstrument/IR/TritonInstrumentOps.td
@@ -303,15 +303,19 @@ def TTI_ExperimentalGSanTensorAccessOp
 }
 
 def TTI_ExperimentalGSanAtomicPollOp
-    : TTI_Op<"experimental_gsan_atomic_poll"> {
+    : TTI_Op<"experimental_gsan_atomic_poll", [
+        SameOperandsEncoding,
+        TypesMatchWith<"matched type matches pointer shape", "ptr", "matched",
+                       "getI1SameShape($_self)">
+      ]> {
   let summary = "Instrument a completed atomic poll for GSan";
   let description = [{
     Records the successful read performed by an atomic poll after the hardware
     polling loop has completed.
   }];
   let arguments = (ins
-    Arg<TT_Ptr, "", [MemRead<GlobalMemory>, MemWrite<GlobalMemory>]>:$ptr,
-    I1:$matched,
+    Arg<TT_PtrLike, "", [MemRead<GlobalMemory>, MemWrite<GlobalMemory>]>:$ptr,
+    TT_BoolLike:$matched,
     TT_MemSemanticAttr:$sem,
     TT_MemSyncScopeAttr:$scope
   );

--- a/lib/Analysis/Allocation.cpp
+++ b/lib/Analysis/Allocation.cpp
@@ -92,7 +92,7 @@ static SmallVector<unsigned> getRepShapeForAtomic(Value result) {
   return smemShape;
 }
 
-static unsigned getInlineAsmResultScratchSize(Value result) {
+static unsigned getResultBroadcastScratchSize(Value result) {
   if (result.use_empty())
     return 0;
 
@@ -151,17 +151,17 @@ unsigned defaultAllocationAnalysisScratchSizeFn(Operation *op) {
     // need to be broadcast through shared memory.
     if (!poll.getTimeout())
       return 0;
+    return getResultBroadcastScratchSize(poll.getResult());
   }
   if (auto inlineAsm = dyn_cast<ElementwiseInlineAsmOp>(op)) {
     if (inlineAsm.getPure())
       return 0;
     unsigned bytes = 0;
     for (Value result : inlineAsm.getResults())
-      bytes = std::max(bytes, getInlineAsmResultScratchSize(result));
+      bytes = std::max(bytes, getResultBroadcastScratchSize(result));
     return bytes;
   }
-  if (isa<gpu::LocalAtomicScatterRMWOp, AtomicPollOp>(op) ||
-      isa<AtomicOpInterface>(op)) {
+  if (isa<gpu::LocalAtomicScatterRMWOp>(op) || isa<AtomicOpInterface>(op)) {
     auto value = op->getOperand(0);
     auto smemShape = getRepShapeForAtomic(op->getResult(0));
     auto elems = getNumScratchElements(smemShape);
@@ -205,7 +205,8 @@ bool hasCrossCTAScratch(Operation *op) {
   if (auto reduce = dyn_cast<ReduceOp>(op))
     return !ReduceOpHelper(reduce).isReduceWithinCTA();
   if (auto poll = dyn_cast<AtomicPollOp>(op))
-    return poll.getTimeout() && !poll.getResult().use_empty();
+    return poll.getTimeout() && !poll.getResult().use_empty() &&
+           getScratchBroadcastMask(op).value_or(0) != 0;
   if (auto inlineAsm = dyn_cast<ElementwiseInlineAsmOp>(op)) {
     return !inlineAsm.getPure() && !inlineAsm->use_empty() &&
            getScratchBroadcastMask(op).value_or(0) != 0;

--- a/lib/Conversion/TritonGPUToLLVM/MemoryOpToLLVM.cpp
+++ b/lib/Conversion/TritonGPUToLLVM/MemoryOpToLLVM.cpp
@@ -2,6 +2,7 @@
 #include "mlir/Conversion/LLVMCommon/TypeConverter.h"
 #include "mlir/Dialect/GPU/IR/GPUDialect.h"
 #include "mlir/IR/PatternMatch.h"
+#include "triton/Analysis/Utility.h"
 #include "triton/Conversion/TritonGPUToLLVM/PatternTritonGPUOpToLLVM.h"
 #include "triton/Conversion/TritonGPUToLLVM/TargetInfoBase.h"
 #include "triton/Conversion/TritonGPUToLLVM/Utility.h"
@@ -372,27 +373,84 @@ struct AtomicPollOpConversion
                   ConversionPatternRewriter &rewriter) const override {
     auto loc = op.getLoc();
     auto b = TritonLLVMOpBuilder(loc, rewriter);
-    auto moduleOp = op->getParentOfType<ModuleOp>();
-    assert(moduleOp && "Parent ModuleOp not found for AtomicPollOp");
-    int numCTAs = TritonGPUDialect::getNumCTAs(moduleOp);
+    int numCTAs = lookupNumCTAs(op);
     if (numCTAs != 1 && !targetInfo.isCuda())
       return rewriter.notifyMatchFailure(
           op, "multi-CTA atomic_poll requires cross-CTA shared memory");
 
-    // Every lowering path emits a rendezvous barrier after the poll, so use it
-    // as the post-atomic ordering barrier instead of emitting a duplicate.
-    insertAtomicOrderingBarriers(op, op.getSem(),
-                                 /*emitBarrierAfter=*/false, rewriter,
-                                 targetInfo);
-
+    auto ptrs = unpackUniqueTensorElements(loc, adaptor.getPtr(), rewriter);
+    auto expected =
+        unpackUniqueTensorElements(loc, adaptor.getExpected(), rewriter);
     auto freeVarMasks = getFreeVariableMasks(op.getPtr().getType());
     Value threadPred =
         emitRedundantThreadPredicate(freeVarMasks, rewriter, loc, targetInfo);
-    StringRef syncScope = targetInfo.getAtomicSyncScope(op.getScope());
-    unsigned bitWidth = adaptor.getExpected().getType().getIntOrFloatBitWidth();
+    if (!threadPred)
+      threadPred = b.true_val();
 
-    // Split the block at the poll and branch only the elected thread into the
-    // polling loop. All other threads skip directly to the rendezvous block.
+    // Scalars are one logical element replicated across the execution region.
+    // The layout elects owners in exactly the same way for every input shape.
+    SmallVector<Value> results;
+    for (auto [ptr, value] : llvm::zip_equal(ptrs, expected))
+      results.push_back(
+          emitPoll(op, ptr, value, adaptor.getTimeout(), threadPred, rewriter));
+
+    auto rendezvous = [&] {
+      if (numCTAs == 1)
+        targetInfo.barrier(loc, rewriter, AddrSpace::Local);
+      else
+        targetInfo.clusterBarrier(loc, rewriter, op);
+    };
+
+    // All elements have completed before the block continues, even when the
+    // result is unused. Without a timeout every element's result is known.
+    if (!adaptor.getTimeout() || op.getResult().use_empty()) {
+      rendezvous();
+      results.assign(ptrs.size(), b.true_val());
+    } else if (op->hasAttr("allocation.offset")) {
+      // Reuse the existing atomic result transport for physical replicas.
+      if (auto tensorTy = dyn_cast<RankedTensorType>(op.getType())) {
+        SmallVector<Value> bytes;
+        for (Value result : results)
+          bytes.push_back(b.zext(i8_ty, result));
+        bytes = broadcastTensorResult(op, tensorTy, rewriter, bytes, i8_ty, b,
+                                      threadPred, targetInfo);
+        for (auto [result, byte] : llvm::zip_equal(results, bytes))
+          result = b.trunc(i1_ty, byte);
+        if (numCTAs != 1 && !atomicResultHasCTABroadcast(op))
+          rendezvous();
+      } else {
+        Value scratch =
+            LLVM::getSharedMemoryBase(loc, rewriter, targetInfo, op);
+        targetInfo.storeShared(rewriter, loc, scratch, results.front(),
+                               threadPred);
+        rendezvous();
+        results.front() =
+            numCTAs == 1
+                ? b.load(i1_ty, scratch)
+                : targetInfo.loadDShared(rewriter, loc, scratch, b.i32_val(0),
+                                         i1_ty, b.true_val());
+      }
+    } else {
+      rendezvous();
+    }
+
+    rewriter.replaceOp(op, packUniqueTensorElements(loc, getTypeConverter(),
+                                                    results, rewriter,
+                                                    op.getType()));
+    return success();
+  }
+
+private:
+  // Emit the polling state machine for one logical element. Both successful
+  // and timed-out polls use this path regardless of the input's shape.
+  Value emitPoll(triton::AtomicPollOp op, Value ptr, Value expected,
+                 Value timeout, Value threadPred,
+                 ConversionPatternRewriter &rewriter) const {
+    auto loc = op.getLoc();
+    auto b = TritonLLVMOpBuilder(loc, rewriter);
+    StringRef syncScope = targetInfo.getAtomicSyncScope(op.getScope());
+    unsigned bitWidth = expected.getType().getIntOrFloatBitWidth();
+
     Block *currentBlock = rewriter.getInsertionBlock();
     Block *doneBlock = currentBlock->splitBlock(rewriter.getInsertionPoint());
     Region *region = currentBlock->getParent();
@@ -403,9 +461,8 @@ struct AtomicPollOpConversion
     Block *pollSuccessBlock =
         rewriter.createBlock(region, Region::iterator(doneBlock));
     Block *timeoutCheckBlock =
-        adaptor.getTimeout()
-            ? rewriter.createBlock(region, Region::iterator(doneBlock))
-            : nullptr;
+        timeout ? rewriter.createBlock(region, Region::iterator(doneBlock))
+                : nullptr;
     BlockArgument matched = doneBlock->addArgument(i1_ty, loc);
 
     rewriter.setInsertionPointToEnd(currentBlock);
@@ -414,24 +471,24 @@ struct AtomicPollOpConversion
 
     rewriter.setInsertionPointToEnd(pollInitBlock);
     Value start;
-    if (adaptor.getTimeout())
+    if (timeout)
       start = targetInfo.getGlobalTimer(rewriter, loc);
     LLVM::BrOp::create(rewriter, loc, pollLoopBlock);
 
     rewriter.setInsertionPointToEnd(pollLoopBlock);
     Value loaded = LLVM::LoadOp::create(
-        rewriter, loc, adaptor.getExpected().getType(), adaptor.getPtr(),
-        bitWidth / 8, /*isVolatile=*/false, /*isNonTemporal=*/false,
+        rewriter, loc, expected.getType(), ptr, bitWidth / 8,
+        /*isVolatile=*/false, /*isNonTemporal=*/false,
         /*isInvariant=*/false, /*isInvariantGroup=*/false,
         LLVM::AtomicOrdering::monotonic, syncScope);
-    Value pollMatched = b.icmp_eq(loaded, adaptor.getExpected());
-    if (adaptor.getTimeout()) {
+    Value pollMatched = b.icmp_eq(loaded, expected);
+    if (timeout) {
       LLVM::CondBrOp::create(rewriter, loc, pollMatched, pollSuccessBlock,
                              timeoutCheckBlock);
 
       rewriter.setInsertionPointToEnd(timeoutCheckBlock);
       Value elapsed = b.sub(targetInfo.getGlobalTimer(rewriter, loc), start);
-      Value timedOut = b.icmp_uge(elapsed, adaptor.getTimeout());
+      Value timedOut = b.icmp_uge(elapsed, timeout);
       LLVM::CondBrOp::create(rewriter, loc, timedOut, doneBlock,
                              ValueRange{b.false_val()}, pollLoopBlock,
                              ValueRange{});
@@ -445,53 +502,10 @@ struct AtomicPollOpConversion
       LLVM::FenceOp::create(rewriter, loc, LLVM::AtomicOrdering::acquire,
                             syncScope);
     LLVM::BrOp::create(rewriter, loc, ValueRange{b.true_val()}, doneBlock);
-
     rewriter.setInsertionPointToStart(doneBlock);
-    if (!adaptor.getTimeout()) {
-      // Successful completion is the only possible result without a timeout,
-      // so rendezvous and return true without a shared-memory broadcast.
-      if (numCTAs == 1)
-        targetInfo.barrier(loc, rewriter, AddrSpace::Local);
-      else
-        targetInfo.clusterBarrier(loc, rewriter, op);
-      rewriter.replaceOp(op, b.true_val());
-      return success();
-    }
-
-    // Broadcast the elected thread's result after every thread has left the
-    // loop, preserving the scalar result convention used by Triton atomics.
-    if (op.getResult().use_empty()) {
-      if (numCTAs == 1)
-        targetInfo.barrier(loc, rewriter, AddrSpace::Local);
-      else
-        targetInfo.clusterBarrier(loc, rewriter, op);
-      rewriter.eraseOp(op);
-      return success();
-    }
-
-    Value atomPtr =
-        LLVM::getSharedMemoryBase(loc, rewriter, targetInfo, op.getOperation());
-    atomPtr = b.bitcast(atomPtr, ptr_ty(rewriter.getContext(),
-                                        targetInfo.getSharedAddressSpace()));
-    targetInfo.storeShared(rewriter, loc, atomPtr, matched, threadPred);
-    if (numCTAs == 1)
-      targetInfo.barrier(loc, rewriter, AddrSpace::Local);
-    else
-      targetInfo.clusterBarrier(loc, rewriter, op);
-
-    Value result;
-    if (numCTAs == 1) {
-      result = b.load(i1_ty, atomPtr);
-    } else {
-      // Scalar operations are issued by CTA 0, so read CTA 0's scratch.
-      result = targetInfo.loadDShared(rewriter, loc, atomPtr, b.i32_val(0),
-                                      i1_ty, b.true_val());
-    }
-    rewriter.replaceOp(op, result);
-    return success();
+    return matched;
   }
 
-private:
   const TargetInfoBase &targetInfo;
 };
 

--- a/lib/Conversion/TritonGPUToLLVM/MemoryOpToLLVM.cpp
+++ b/lib/Conversion/TritonGPUToLLVM/MemoryOpToLLVM.cpp
@@ -387,12 +387,13 @@ struct AtomicPollOpConversion
     if (!threadPred)
       threadPred = b.true_val();
 
-    // Scalars are one logical element replicated across the execution region.
-    // The layout elects owners in exactly the same way for every input shape.
+    Value start;
+    if (adaptor.getTimeout())
+      start = targetInfo.getGlobalTimer(rewriter, loc);
     SmallVector<Value> results;
     for (auto [ptr, value] : llvm::zip_equal(ptrs, expected))
-      results.push_back(
-          emitPoll(op, ptr, value, adaptor.getTimeout(), threadPred, rewriter));
+      results.push_back(emitPoll(op, ptr, value, start, adaptor.getTimeout(),
+                                 threadPred, rewriter));
 
     auto rendezvous = [&] {
       if (numCTAs == 1)
@@ -444,7 +445,7 @@ private:
   // Emit the polling state machine for one logical element. Both successful
   // and timed-out polls use this path regardless of the input's shape.
   Value emitPoll(triton::AtomicPollOp op, Value ptr, Value expected,
-                 Value timeout, Value threadPred,
+                 Value start, Value timeout, Value threadPred,
                  ConversionPatternRewriter &rewriter) const {
     auto loc = op.getLoc();
     auto b = TritonLLVMOpBuilder(loc, rewriter);
@@ -454,8 +455,6 @@ private:
     Block *currentBlock = rewriter.getInsertionBlock();
     Block *doneBlock = currentBlock->splitBlock(rewriter.getInsertionPoint());
     Region *region = currentBlock->getParent();
-    Block *pollInitBlock =
-        rewriter.createBlock(region, Region::iterator(doneBlock));
     Block *pollLoopBlock =
         rewriter.createBlock(region, Region::iterator(doneBlock));
     Block *pollSuccessBlock =
@@ -466,14 +465,8 @@ private:
     BlockArgument matched = doneBlock->addArgument(i1_ty, loc);
 
     rewriter.setInsertionPointToEnd(currentBlock);
-    LLVM::CondBrOp::create(rewriter, loc, threadPred, pollInitBlock,
+    LLVM::CondBrOp::create(rewriter, loc, threadPred, pollLoopBlock,
                            ValueRange{}, doneBlock, ValueRange{b.false_val()});
-
-    rewriter.setInsertionPointToEnd(pollInitBlock);
-    Value start;
-    if (timeout)
-      start = targetInfo.getGlobalTimer(rewriter, loc);
-    LLVM::BrOp::create(rewriter, loc, pollLoopBlock);
 
     rewriter.setInsertionPointToEnd(pollLoopBlock);
     Value loaded = LLVM::LoadOp::create(

--- a/lib/Conversion/TritonInstrumentToLLVM/GSanToLLVM.cpp
+++ b/lib/Conversion/TritonInstrumentToLLVM/GSanToLLVM.cpp
@@ -653,12 +653,13 @@ public:
     if (failed(gsanGlobalStatePtr))
       return failure();
 
-    Value pollPtr = unpackLLElements(loc, adaptor.getPtr(), rewriter).front();
+    auto ptrs = unpackUniqueTensorElements(loc, adaptor.getPtr(), rewriter);
+    auto matched =
+        unpackUniqueTensorElements(loc, adaptor.getMatched(), rewriter);
     int32_t bytesPerElem = tt::getPointeeBitWidth(op.getPtr().getType()) / 8;
     auto freeVarMasks = getFreeVariableMasks(op.getPtr().getType());
     Value threadPred = ttg::emitRedundantThreadPredicate(freeVarMasks, rewriter,
                                                          loc, *targetInfo);
-    threadPred = ttg::maybeAnd(rewriter, loc, threadPred, adaptor.getMatched());
     auto sourceLoc = materializeSourceLocation(rewriter, loc);
 
     TritonLLVMOpBuilder b(loc, rewriter);
@@ -666,13 +667,16 @@ public:
     Value eventState = LLVM::AllocaOp::create(rewriter, loc, ptr_ty(ctx),
                                               eventStateTy, b.i32_val(1),
                                               /*alignment=*/0);
-    emitGSanAtomicBeginCall(rewriter, loc, *gsanGlobalStatePtr, eventState,
-                            threadPred, pollPtr, bytesPerElem,
+    for (auto [ptr, success] : llvm::zip_equal(ptrs, matched)) {
+      Value pred = ttg::maybeAnd(rewriter, loc, threadPred, success);
+      emitGSanAtomicBeginCall(rewriter, loc, *gsanGlobalStatePtr, eventState,
+                              pred, ptr, bytesPerElem,
+                              static_cast<int32_t>(op.getSem()),
+                              static_cast<int32_t>(op.getScope()), sourceLoc);
+      emitGSanAtomicEndCall(rewriter, loc, eventState, pred, b.false_val(),
                             static_cast<int32_t>(op.getSem()),
                             static_cast<int32_t>(op.getScope()), sourceLoc);
-    emitGSanAtomicEndCall(rewriter, loc, eventState, threadPred, b.false_val(),
-                          static_cast<int32_t>(op.getSem()),
-                          static_cast<int32_t>(op.getScope()), sourceLoc);
+    }
 
     rewriter.eraseOp(op);
     return success();

--- a/lib/Dialect/Triton/IR/Ops.cpp
+++ b/lib/Dialect/Triton/IR/Ops.cpp
@@ -160,7 +160,8 @@ LogicalResult AtomicPollOp::verify() {
   if (getSem() != MemSemantic::ACQUIRE && getSem() != MemSemantic::RELAXED)
     return emitOpError("only supports acquire and relaxed semantics");
 
-  unsigned bitWidth = getExpected().getType().getIntOrFloatBitWidth();
+  unsigned bitWidth =
+      getElementTypeOrSelf(getExpected().getType()).getIntOrFloatBitWidth();
   if (bitWidth != 16 && bitWidth != 32 && bitWidth != 64)
     return emitOpError(
         "only supports integer elements with width {16, 32, 64}");

--- a/python/test/gluon/test_core.py
+++ b/python/test/gluon/test_core.py
@@ -52,6 +52,53 @@ from triton._C.libtriton.gluon_ir import make_cga_layout
 THREADS_PER_WARP = triton.runtime.driver.active.get_current_target().warp_size
 
 
+@pytest.mark.parametrize("block_size", [1, 16, 128, 512])
+@pytest.mark.parametrize("num_warps", [4, 8])
+@pytest.mark.parametrize("timeout", [None, 0])
+def test_atomic_poll_tensor_results(block_size, num_warps, timeout, device):
+
+    @gluon.jit
+    def kernel(Flags, Out, BLOCK: ttgl.constexpr, TIMEOUT: ttgl.constexpr, Layout: ttgl.constexpr):
+        offsets = ttgl.arange(0, BLOCK, layout=Layout)
+        matched = ttgl.atomic_poll(Flags + offsets, offsets + 1, timeout_ns=TIMEOUT)
+        ttgl.store(Out + offsets, matched)
+
+    expected = torch.arange(1, block_size + 1, dtype=torch.int32, device=device)
+    flags = expected.clone()
+    if timeout is not None:
+        flags[::2] = 0
+    out = torch.empty(block_size, dtype=torch.bool, device=device)
+    layout = ttgl.BlockedLayout([1], [THREADS_PER_WARP], [num_warps], [0])
+    kernel[(1, )](flags, out, block_size, timeout, layout, num_warps=num_warps)
+    assert torch.equal(out, flags == expected)
+
+
+@pytest.mark.parametrize("block_size", [16, 128, 512])
+@pytest.mark.parametrize("use_result", [False, True])
+def test_atomic_poll_tensor_acquire(block_size, use_result, device):
+    if not is_cuda():
+        pytest.skip("requires concurrent CUDA CTAs")
+
+    @gluon.jit
+    def kernel(Flags, Payload, Out, BLOCK: ttgl.constexpr, UseResult: ttgl.constexpr):
+        offsets = ttgl.arange(0, BLOCK, layout=ttgl.BlockedLayout([1], [32], [4], [0]))
+        if ttgl.program_id(0) == 0:
+            matched = ttgl.atomic_poll(Flags + offsets, 1, scope="gpu")
+            values = ttgl.load(Payload + offsets)
+            if UseResult:
+                values = ttgl.where(matched, values, -1)
+            ttgl.store(Out + offsets, values)
+        else:
+            ttgl.store(Payload + offsets, offsets + 1)
+            ttgl.atomic_xchg(Flags + offsets, 1, sem="release", scope="gpu")
+
+    flags = torch.zeros(block_size, dtype=torch.int32, device=device)
+    payload = torch.zeros_like(flags)
+    out = torch.zeros_like(flags)
+    kernel[(2, )](flags, payload, out, block_size, use_result, num_warps=4)
+    torch.testing.assert_close(out, torch.arange(1, block_size + 1, dtype=torch.int32, device=device))
+
+
 @pytest.mark.parametrize("num_ctas", [1, 2])
 @pytest.mark.parametrize("use_result", [False, True])
 @pytest.mark.parametrize("scalar", [False, True])

--- a/python/test/gluon/test_frontend.py
+++ b/python/test/gluon/test_frontend.py
@@ -30,6 +30,20 @@ from triton.runtime.jit import MockTensor
 import triton.language as tl
 from triton.compiler.errors import CompilationError, CompileTimeAssertionFailure
 
+
+@filecheck_test
+@gluon.jit
+def test_atomic_poll_tensor():
+    # CHECK-LABEL: test_atomic_poll_tensor
+    layout: ttgl.constexpr = ttgl.BlockedLayout([1], [32], [4], [0])
+    offsets = ttgl.arange(0, 128, layout=layout)
+    ptrs = offsets.to(ttgl.int64).to(ttgl.pointer_type(ttgl.int32), bitcast=True)
+    # CHECK: tt.atomic_poll acquire, gpu, {{.*}} : tensor<128x!tt.ptr<i32>, #blocked>, tensor<128xi32, #blocked> -> tensor<128xi1, #blocked>
+    result = ttgl.atomic_poll(ptrs, 1)
+    ttgl.static_assert(result.type.layout == layout)
+    # CHECK: tt.atomic_poll acquire, gpu, {{.*}} timeout {{.*}} : tensor<128x!tt.ptr<i32>, #blocked>, tensor<128xi32, #blocked> -> tensor<128xi1, #blocked>
+    ttgl.atomic_poll(ptrs, offsets, timeout_ns=0)
+
 TARGET_PAT = re.compile('ttg.target = "[^"]*"')
 # HIP backend can add this attribute to function parameters
 PTRRANGE_PAT = re.compile('(, )?tt.pointer_range = 32 : i32')

--- a/python/test/gluon/test_frontend.py
+++ b/python/test/gluon/test_frontend.py
@@ -44,6 +44,7 @@ def test_atomic_poll_tensor():
     # CHECK: tt.atomic_poll acquire, gpu, {{.*}} timeout {{.*}} : tensor<128x!tt.ptr<i32>, #blocked>, tensor<128xi32, #blocked> -> tensor<128xi1, #blocked>
     ttgl.atomic_poll(ptrs, offsets, timeout_ns=0)
 
+
 TARGET_PAT = re.compile('ttg.target = "[^"]*"')
 # HIP backend can add this attribute to function parameters
 PTRRANGE_PAT = re.compile('(, )?tt.pointer_range = 32 : i32')

--- a/python/test/gsan/test_gsan.py
+++ b/python/test/gsan/test_gsan.py
@@ -765,6 +765,29 @@ def atomic_poll_timeout_kernel(ptr, out_ptr):
     tl.store(out_ptr, matched)
 
 
+@gluon.jit
+def _atomic_poll_tensor_kernel(ptr, out_ptr, BLOCK: gl.constexpr, STRIDE: gl.constexpr, sem: gl.constexpr,
+                               scope: gl.constexpr, TIMEOUT: gl.constexpr):
+    offsets = gl.arange(0, BLOCK, layout=gl.BlockedLayout([1], [32], [4], [0]))
+    matched = gl.atomic_poll(ptr + offsets * STRIDE, offsets + 1, sem=sem, scope=scope, timeout_ns=TIMEOUT)
+    gl.store(out_ptr + offsets, matched)
+
+
+@gluon.jit
+def _atomic_poll_tensor_sync_kernel(payload_ptr, flag_ptr, out_ptr, BLOCK: gl.constexpr, STRIDE: gl.constexpr,
+                                    scope: gl.constexpr):
+    offsets = gl.arange(0, BLOCK, layout=gl.BlockedLayout([1], [32], [4], [0]))
+    pid = gl.program_id(0)
+    if pid < 2:
+        mask = offsets % 2 == pid
+        gl.store(payload_ptr + offsets * STRIDE, offsets + 1000, mask)
+        gl.atomic_xchg(flag_ptr + offsets * STRIDE, 1, mask=mask, sem="release", scope=scope)
+    else:
+        gl.atomic_poll(flag_ptr + offsets * STRIDE, 1, sem="acquire", scope=scope)
+        result = gl.load(payload_ptr + offsets * STRIDE)
+        gl.store(out_ptr + offsets, result)
+
+
 @triton.jit
 def _cross_sm_atomic_sync_kernel(payload_ptr, flag_ptr, out_ptr, producer_sem: tl.constexpr, consumer_sem: tl.constexpr,
                                  scope: tl.constexpr):
@@ -856,6 +879,55 @@ def test_atomic_poll_timeout_does_not_record_read(with_gsan):
     cell = shadow_cell_from_address(target.data_ptr())
     assert cell.write_clock == ScalarClock(0, 0, AtomicScope.NON_ATOMIC)
     assert cell.num_reads == 0
+
+
+@pytest.mark.skipif(not is_cuda(), reason="GSan requires CUDA")
+@pytest.mark.parametrize("block_size", [16, 256])
+@pytest.mark.parametrize("dtype", [torch.int16, torch.int32, torch.int64])
+@pytest.mark.parametrize("sem", ["relaxed", "acquire"])
+@pytest.mark.parametrize("scope, expected_scope", ATOMIC_SCOPE_CASES)
+@pytest.mark.parametrize("timeout", [None, 0])
+def test_atomic_poll_tensor_only_records_matched_reads(with_gsan, block_size, dtype, sem, scope, expected_scope,
+                                                       timeout):
+    # Separate shadow cells let us check successful and timed-out elements independently.
+    stride = max(1, SHADOW_GRANULARITY_BYTES // torch.empty((), dtype=dtype).element_size())
+    target = torch.zeros(block_size * stride, dtype=dtype, device="cuda")
+    expected = torch.arange(1, block_size + 1, dtype=dtype, device="cuda")
+    target[::stride] = expected
+    if timeout is not None:
+        target[::2 * stride] = 0
+    out = torch.empty(block_size, dtype=torch.bool, device="cuda")
+
+    _atomic_poll_tensor_kernel[(1, )](target, out, block_size, stride, sem, scope, timeout, num_warps=4)
+    torch.testing.assert_close(out, target[::stride] == expected)
+
+    for index in range(block_size):
+        for byte_offset in range(0, target.element_size(), SHADOW_GRANULARITY_BYTES):
+            address = target.data_ptr() + index * stride * target.element_size() + byte_offset
+            if timeout is None or index % 2:
+                _assert_atomic_read_only_shadow(address, expected_scope)
+            else:
+                cell = shadow_cell_from_address(address)
+                assert cell.write_clock == ScalarClock(0, 0, AtomicScope.NON_ATOMIC)
+                assert cell.num_reads == 0
+
+
+@pytest.mark.skipif(not is_cuda(), reason="GSan requires CUDA")
+@pytest.mark.parametrize("block_size", [16, 256])
+@pytest.mark.parametrize("scope, expected_scope", ATOMIC_SCOPE_CASES[1:])
+def test_atomic_poll_tensor_acquires_all_producers(with_gsan, capfd, block_size, scope, expected_scope):
+    stride = SHADOW_GRANULARITY_BYTES // 4
+    payload = torch.zeros(block_size * stride, dtype=torch.int32, device="cuda")
+    flags = torch.zeros_like(payload)
+    out = torch.full((block_size, ), -1, dtype=torch.int32, device="cuda")
+
+    _atomic_poll_tensor_sync_kernel[(3, )](payload, flags, out, block_size, stride, scope, num_warps=4)
+    torch.cuda.synchronize()
+
+    torch.testing.assert_close(out, torch.arange(1000, 1000 + block_size, dtype=torch.int32, device="cuda"))
+    for index in range(block_size):
+        _assert_cross_sm_sync(payload[index * stride:], flags[index * stride:], expected_scope)
+    _assert_no_gsan_runtime_output(capfd)
 
 
 @pytest.mark.skipif(not is_cuda(), reason="GSan requires CUDA")

--- a/python/test/unit/language/test_core.py
+++ b/python/test/unit/language/test_core.py
@@ -1604,6 +1604,26 @@ def test_atomic_poll(dtype, bit_width, sem, scope, device):
         assert "%globaltimer" not in ptx
 
 
+@pytest.mark.interpreter
+@pytest.mark.parametrize("block_size", [1, 16, 128, 512])
+@pytest.mark.parametrize("timeout", [None, 0])
+def test_atomic_poll_tensor_results(block_size, timeout, device):
+
+    @triton.jit
+    def kernel(flags, out, BLOCK: tl.constexpr, TIMEOUT: tl.constexpr):
+        offsets = tl.arange(0, BLOCK)
+        matched = tl.atomic_poll(flags + offsets, offsets + 1, timeout_ns=TIMEOUT)
+        tl.store(out + offsets, matched)
+
+    expected = torch.arange(1, block_size + 1, dtype=torch.int32, device=device)
+    flags = expected.clone()
+    if timeout is not None:
+        flags[::2] = 0
+    out = torch.empty(block_size, dtype=torch.bool, device=device)
+    kernel[(1, )](flags, out, block_size, timeout, num_warps=4)
+    assert torch.equal(out, flags == expected)
+
+
 def test_atomic_poll_no_timeout_uses_no_shared_memory(device):
 
     @triton.jit

--- a/python/test/unit/language/test_frontend.py
+++ b/python/test/unit/language/test_frontend.py
@@ -915,11 +915,31 @@ def test_atomic_poll_timeout():
     tl.atomic_poll(ptr, 1, timeout_ns=1000)
 
 
+@filecheck_test
+@triton.jit
+def test_atomic_poll_tensor_pointer():
+    # CHECK-LABEL: test_atomic_poll_tensor_pointer
+    ptrs = tl.full((1, ), 0, tl.int64).to(tl.pointer_type(tl.int32), bitcast=True)
+    # CHECK: tt.atomic_poll acquire, gpu, {{.*}} : tensor<1x!tt.ptr<i32>>, tensor<1xi32> -> tensor<1xi1>
+    tl.atomic_poll(ptrs, 1)
+
+
+@filecheck_test
+@triton.jit
+def test_atomic_poll_tensor_timeout():
+    # CHECK-LABEL: test_atomic_poll_tensor_timeout
+    ptrs = tl.full((128, ), 0, tl.int64).to(tl.pointer_type(tl.int32), bitcast=True)
+    expected = tl.arange(0, 128)
+    # CHECK: tt.atomic_poll acquire, gpu, {{.*}} timeout {{.*}} : tensor<128x!tt.ptr<i32>>, tensor<128xi32> -> tensor<128xi1>
+    result = tl.atomic_poll(ptrs, expected, timeout_ns=0)
+    tl.static_assert(result.shape == expected.shape)
+
+
 @doesnt_compile
 @triton.jit
-def test_atomic_poll_rejects_tensor_pointer():
-    ptrs = tl.full((1, ), 0, tl.int64).to(tl.pointer_type(tl.int32), bitcast=True)
-    tl.atomic_poll(ptrs, 1)
+def test_atomic_poll_rejects_mismatched_shape():
+    ptrs = tl.full((32, ), 0, tl.int64).to(tl.pointer_type(tl.int32), bitcast=True)
+    tl.atomic_poll(ptrs, tl.arange(0, 64))
 
 
 @doesnt_compile

--- a/python/test/unit/runtime/test_interpreter.py
+++ b/python/test/unit/runtime/test_interpreter.py
@@ -1,12 +1,39 @@
 import numpy as np
+import itertools
 
 from triton._C.libtriton import interpreter as _interpreter
+import triton.language as tl
+from triton.runtime import interpreter
 
 
 def _element_ptrs(array: np.ndarray) -> np.ndarray:
     base = np.uint64(array.ctypes.data)
     offsets = np.arange(array.size, dtype=np.uint64) * np.uint64(array.itemsize)
     return (base + offsets).reshape(array.shape)
+
+
+def test_atomic_poll_tensor_shares_timeout(monkeypatch) -> None:
+    builder = interpreter.InterpreterBuilder()
+    data = np.array([0, 0, 1], dtype=np.int32)
+    addresses = _element_ptrs(data)
+    ptr = interpreter.TensorHandle(addresses, tl.pointer_type(tl.int32))
+    expected = interpreter.TensorHandle(np.ones(3, dtype=np.int32), tl.int32)
+    timeout = interpreter.TensorHandle(np.array(2, dtype=np.uint64), tl.uint64)
+    clock = itertools.count()
+    monkeypatch.setattr(interpreter.time, "perf_counter_ns", lambda: next(clock))
+    loads = []
+    original_load = builder.create_load
+
+    def load(element_ptr, *args):
+        loads.append(element_ptr.data.item())
+        return original_load(element_ptr, *args)
+
+    monkeypatch.setattr(builder, "create_load", load)
+    result = builder.create_atomic_poll(ptr, expected, timeout, None, None)
+
+    np.testing.assert_array_equal(result.data, [False, False, True])
+    # The first element exhausts the budget; later elements still get one load.
+    assert loads == [addresses[0], addresses[0], addresses[1], addresses[2]]
 
 
 def test_load_accepts_non_contiguous_ndarray_views() -> None:

--- a/python/triton/language/core.py
+++ b/python/triton/language/core.py
@@ -2581,13 +2581,14 @@ def atomic_poll(pointer, expected_value, sem=None, scope=None, timeout_ns=None, 
     """
     Wait until the value at :code:`pointer` equals :code:`expected_value`.
 
-    This will spin-wait on the specified pointer until either the value equals
-    the expected value, or the operation times out. In the event of a timeout,
-    the operation returns false and no results may be acquired.
+    This will spin-wait on each specified pointer until either its value equals
+    the expected value, or its poll times out. The block waits for all polls to
+    finish. Timed-out elements return false and acquire no results.
 
-    :param pointer: A pointer to a scalar 16-, 32-, or 64-bit integer.
+    :param pointer: A pointer, or block of pointers, to 16-, 32-, or 64-bit integers.
     :type pointer: triton.PointerDType
-    :param expected_value: The value that ends the polling loop.
+    :param expected_value: The value that ends each polling loop, broadcast to
+        the shape of :code:`pointer`.
     :type expected_value: pointer.dtype.element_ty
     :param sem: Specifies whether a successful poll has acquire semantics.
         Acceptable values are "acquire" (default) and "relaxed".
@@ -2596,12 +2597,12 @@ def atomic_poll(pointer, expected_value, sem=None, scope=None, timeout_ns=None, 
         effect of the poll. Acceptable values are "gpu" (default), "cta"
         (cooperative thread array, thread block), and "sys" (system).
     :type scope: str, optional
-    :param timeout_ns: Maximum wall time to poll, measured in nanoseconds by
+    :param timeout_ns: Maximum wall time to poll each element, measured in nanoseconds by
         the GPU global timer. If omitted, polling has no timeout. A timeout of
         zero still performs one load.
     :type timeout_ns: int, optional
-    :return: True if the expected value was observed, or False if the timeout
-        expired first.
+    :return: A boolean with the shape of :code:`pointer`, true for each element
+        whose expected value was observed and false if its timeout expired first.
     :rtype: triton.language.tensor
     """
     expected_value = _semantic.to_tensor(expected_value)

--- a/python/triton/language/core.py
+++ b/python/triton/language/core.py
@@ -2582,7 +2582,7 @@ def atomic_poll(pointer, expected_value, sem=None, scope=None, timeout_ns=None, 
     Wait until the value at :code:`pointer` equals :code:`expected_value`.
 
     This will spin-wait on each specified pointer until either its value equals
-    the expected value, or its poll times out. The block waits for all polls to
+    the expected value, or the operation times out. The block waits for all polls to
     finish. Timed-out elements return false and acquire no results.
 
     :param pointer: A pointer, or block of pointers, to 16-, 32-, or 64-bit integers.
@@ -2597,9 +2597,9 @@ def atomic_poll(pointer, expected_value, sem=None, scope=None, timeout_ns=None, 
         effect of the poll. Acceptable values are "gpu" (default), "cta"
         (cooperative thread array, thread block), and "sys" (system).
     :type scope: str, optional
-    :param timeout_ns: Maximum wall time to poll each element, measured in nanoseconds by
-        the GPU global timer. If omitted, polling has no timeout. A timeout of
-        zero still performs one load.
+    :param timeout_ns: Shared polling time budget for the entire operation, measured
+        in nanoseconds by the GPU global timer. If omitted, polling has no timeout.
+        Each element is loaded at least once, even with a zero timeout.
     :type timeout_ns: int, optional
     :return: A boolean with the shape of :code:`pointer`, true for each element
         whose expected value was observed and false if its timeout expired first.

--- a/python/triton/language/semantic.py
+++ b/python/triton/language/semantic.py
@@ -1245,17 +1245,14 @@ class TritonSemantic(Generic[TensorTy]):
             raise ValueError("atomic_poll timeout_ns must be non-negative")
         if timeout_ns is not None:
             timeout_ns = self.to_tensor(timeout_ns)
-        if ptr.type.is_block():
-            raise ValueError("atomic_poll only supports a pointer to a scalar")
-        if not ptr.type.is_ptr():
+        if not ptr.type.scalar.is_ptr():
             raise ValueError(f"Unsupported ptr type {ptr.type.__repr__()} in `tl.atomic_poll`")
-        if expected.type.is_block():
-            raise ValueError("Expected value argument cannot be block type")
 
-        element_ty = ptr.type.element_ty
+        element_ty = ptr.type.scalar.element_ty
         if not element_ty.is_int() or element_ty.primitive_bitwidth not in [16, 32, 64]:
             raise ValueError("atomic_poll only supports integer elements with width {16, 32, 64}")
         expected = self.cast(expected, element_ty)
+        ptr, expected, _ = self._broadcast_ptr_val_mask(ptr, expected, None)
 
         sem = self._str_to_sem(sem, default=ir.MEM_SEMANTIC.ACQUIRE)
         if sem not in [ir.MEM_SEMANTIC.ACQUIRE, ir.MEM_SEMANTIC.RELAXED]:
@@ -1272,7 +1269,7 @@ class TritonSemantic(Generic[TensorTy]):
             sem,
             scope,
         )
-        return self.tensor(handle, tl.int1)
+        return self.tensor(handle, expected.type.with_element_ty(tl.int1))
 
     def atomic_cas(self, ptr: TensorTy, cmp: TensorTy, val: TensorTy, sem: str, scope: str) -> TensorTy:
         sem = self._str_to_sem(sem)

--- a/python/triton/runtime/interpreter.py
+++ b/python/triton/runtime/interpreter.py
@@ -834,13 +834,18 @@ class InterpreterBuilder:
         return TensorHandle(_interpreter.atomic_cas(ptr.data, cmp.data, val.data, sem), cmp.dtype.scalar)
 
     def create_atomic_poll(self, ptr, expected, timeout_ns, sem, scope):
-        start_ns = time.perf_counter_ns()
-        while True:
-            value = self.create_load(ptr, None, None, True)
-            if np.array_equal(value.data, expected.data):
-                return TensorHandle(np.array(True, dtype=np.bool_), tl.int1)
-            if timeout_ns is not None and time.perf_counter_ns() - start_ns >= timeout_ns.data.item():
-                return TensorHandle(np.array(False, dtype=np.bool_), tl.int1)
+        matched = np.zeros(ptr.data.shape, dtype=np.bool_)
+        for index in np.ndindex(ptr.data.shape):
+            element_ptr = TensorHandle(np.asarray(ptr.data[index]), ptr.dtype)
+            start_ns = time.perf_counter_ns()
+            while True:
+                value = self.create_load(element_ptr, None, None, True)
+                if value.data.item() == expected.data[index]:
+                    matched[index] = True
+                    break
+                if timeout_ns is not None and time.perf_counter_ns() - start_ns >= timeout_ns.data.item():
+                    break
+        return TensorHandle(matched, tl.int1)
 
     def create_atomic_rmw(self, rmwOp, ptr, val, mask, sem, scope):
         if rmwOp not in self.ir_rmw_op_to_interpreter_rmw_op:

--- a/python/triton/runtime/interpreter.py
+++ b/python/triton/runtime/interpreter.py
@@ -835,9 +835,9 @@ class InterpreterBuilder:
 
     def create_atomic_poll(self, ptr, expected, timeout_ns, sem, scope):
         matched = np.zeros(ptr.data.shape, dtype=np.bool_)
+        start_ns = time.perf_counter_ns() if timeout_ns is not None else None
         for index in np.ndindex(ptr.data.shape):
             element_ptr = TensorHandle(np.asarray(ptr.data[index]), ptr.dtype)
-            start_ns = time.perf_counter_ns()
             while True:
                 value = self.create_load(element_ptr, None, None, True)
                 if value.data.item() == expected.data[index]:

--- a/test/Conversion/amd/atomic_cas.mlir
+++ b/test/Conversion/amd/atomic_cas.mlir
@@ -72,13 +72,11 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.targ
     // CHECK-LABEL: @atomic_poll
     // CHECK: %[[WARP_ELECTED:.*]] = llvm.and %{{.*}}, %{{.*}} : i1
     // CHECK: %[[ELECTED:.*]] = llvm.and %[[WARP_ELECTED]], %{{.*}} : i1
-    // CHECK: %[[FALSE:.*]] = llvm.mlir.constant(false) : i1
-    // CHECK: llvm.cond_br %[[ELECTED]], ^[[INIT:bb[0-9]+]], ^[[DONE:bb[0-9]+]](%[[FALSE]] : i1)
-    // CHECK: ^[[INIT]]:
     // CHECK: %[[START_RAW:.*]] = llvm.call_intrinsic "llvm.amdgcn.s.memrealtime"() : () -> i64
     // CHECK: %[[TEN:.*]] = llvm.mlir.constant(10 : i64) : i64
     // CHECK: %[[START:.*]] = llvm.mul %[[START_RAW]], %[[TEN]] : i64
-    // CHECK: llvm.br ^[[LOOP:bb[0-9]+]]
+    // CHECK: %[[FALSE:.*]] = llvm.mlir.constant(false) : i1
+    // CHECK: llvm.cond_br %[[ELECTED]], ^[[LOOP:bb[0-9]+]], ^[[DONE:bb[0-9]+]](%[[FALSE]] : i1)
     // CHECK: ^[[LOOP]]:
     // CHECK: %[[LOADED:.*]] = llvm.load %{{.*}} atomic syncscope("agent") monotonic
     // CHECK: %[[MATCHED:.*]] = llvm.icmp "eq" %[[LOADED]], %{{.*}} : i32

--- a/test/Conversion/amd/atomic_cas.mlir
+++ b/test/Conversion/amd/atomic_cas.mlir
@@ -113,6 +113,23 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.targ
 
 // -----
 
+#poll = #ttg.blocked<{sizePerThread = [1], threadsPerWarp = [64], warpsPerCTA = [4], order = [0]}>
+module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.target = "hip:gfx942", "ttg.threads-per-warp" = 64 : i32} {
+  // CHECK-LABEL: @atomic_poll_tensor
+  // CHECK: llvm.load %{{.*}} atomic syncscope("agent") monotonic
+  // CHECK: llvm.fence syncscope("agent") acquire
+  // CHECK: llvm.load %{{.*}} atomic syncscope("agent") monotonic
+  // CHECK: llvm.fence syncscope("agent") acquire
+  // CHECK: rocdl.s.barrier
+  // CHECK: llvm.return
+  tt.func public @atomic_poll_tensor(%ptr: tensor<512x!tt.ptr<i32>, #poll>, %expected: tensor<512xi32, #poll>) {
+    %matched = tt.atomic_poll acquire, gpu, %ptr, %expected : tensor<512x!tt.ptr<i32>, #poll>, tensor<512xi32, #poll> -> tensor<512xi1, #poll>
+    tt.return
+  }
+}
+
+// -----
+
 module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.target = "hip:gfx942", "ttg.threads-per-warp" = 64 : i32} {
   tt.func public @atomic_cas_f32(%arg3: !tt.ptr<f32> {tt.divisibility = 16 : i32}) attributes {noinline = false} {
     // CHECK-LABEL: @atomic_cas_f32

--- a/test/Conversion/atomic_ldst.mlir
+++ b/test/Conversion/atomic_ldst.mlir
@@ -29,10 +29,8 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, "ttg.thr
 
   // CHECK-POLL-LABEL: @atomic_poll
   // CHECK-POLL: nvvm.read.ptx.sreg.tid.x
-  // CHECK-POLL: llvm.cond_br %[[ELECTED:.*]], ^[[INIT:bb[0-9]+]], ^[[DONE:bb[0-9]+]](%{{.*}} : i1)
-  // CHECK-POLL: ^[[INIT]]:
   // CHECK-POLL: %[[START:.*]] = llvm.call_intrinsic "llvm.nvvm.read.ptx.sreg.globaltimer"() : () -> i64
-  // CHECK-POLL: llvm.br ^[[LOOP:bb[0-9]+]]
+  // CHECK-POLL: llvm.cond_br %[[ELECTED:.*]], ^[[LOOP:bb[0-9]+]], ^[[DONE:bb[0-9]+]](%{{.*}} : i1)
   // CHECK-POLL: ^[[LOOP]]:
   // CHECK-POLL: %[[LOADED:.*]] = llvm.load %{{.*}} atomic monotonic
   // CHECK-POLL: %[[MATCHED:.*]] = llvm.icmp "eq" %[[LOADED]], %{{.*}} : i32
@@ -112,6 +110,22 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, "ttg.thr
     %matched = tt.atomic_poll acquire, gpu, %ptr, %expected timeout %timeout : tensor<128x!tt.ptr<i32>, #poll>, tensor<128xi32, #poll> -> tensor<128xi1, #poll>
     %result = arith.extui %matched : tensor<128xi1, #poll> to tensor<128xi32, #poll>
     tt.store %out, %result : tensor<128x!tt.ptr<i32>, #poll>
+    tt.return
+  }
+
+  // CHECK-POLL-LABEL: @atomic_poll_shared_timeout
+  // CHECK-POLL: %[[START:.*]] = llvm.call_intrinsic "llvm.nvvm.read.ptx.sreg.globaltimer"() : () -> i64
+  // CHECK-POLL: llvm.load %{{.*}} atomic syncscope("device") monotonic
+  // CHECK-POLL: %[[NOW0:.*]] = llvm.call_intrinsic "llvm.nvvm.read.ptx.sreg.globaltimer"() : () -> i64
+  // CHECK-POLL: llvm.sub %[[NOW0]], %[[START]] : i64
+  // CHECK-POLL-NOT: llvm.call_intrinsic "llvm.nvvm.read.ptx.sreg.globaltimer"
+  // CHECK-POLL: llvm.load %{{.*}} atomic syncscope("device") monotonic
+  // CHECK-POLL: %[[NOW1:.*]] = llvm.call_intrinsic "llvm.nvvm.read.ptx.sreg.globaltimer"() : () -> i64
+  // CHECK-POLL: llvm.sub %[[NOW1]], %[[START]] : i64
+  // CHECK-POLL: nvvm.barrier
+  // CHECK-POLL: llvm.return
+  tt.func public @atomic_poll_shared_timeout(%ptr: tensor<256x!tt.ptr<i32>, #poll>, %expected: tensor<256xi32, #poll>, %timeout: i64) {
+    %matched = tt.atomic_poll acquire, gpu, %ptr, %expected timeout %timeout : tensor<256x!tt.ptr<i32>, #poll>, tensor<256xi32, #poll> -> tensor<256xi1, #poll>
     tt.return
   }
 

--- a/test/Conversion/atomic_ldst.mlir
+++ b/test/Conversion/atomic_ldst.mlir
@@ -1,5 +1,5 @@
-// RUN: triton-opt %s --allocate-shared-memory-nv=compute-capability=90 --convert-triton-gpu-to-llvm=compute-capability=90 2>&1 | FileCheck %s --check-prefixes=CHECK-TTG2NVGPU,CHECK-POLL
-// RUN: triton-opt %s --allocate-shared-memory-nv=compute-capability=90 --convert-triton-gpu-to-llvm=compute-capability=90 --convert-nv-gpu-to-llvm 2>&1 | FileCheck %s --check-prefixes=CHECK-NVGPU2LLVM,CHECK-POLL
+// RUN: triton-opt %s -split-input-file --allocate-shared-memory-nv=compute-capability=90 --convert-triton-gpu-to-llvm=compute-capability=90 2>&1 | FileCheck %s --check-prefixes=CHECK-TTG2NVGPU,CHECK-POLL
+// RUN: triton-opt %s -split-input-file --allocate-shared-memory-nv=compute-capability=90 --convert-triton-gpu-to-llvm=compute-capability=90 --convert-nv-gpu-to-llvm 2>&1 | FileCheck %s --check-prefixes=CHECK-NVGPU2LLVM,CHECK-POLL
 module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, "ttg.threads-per-warp" = 32 : i32} {
   tt.func public @kernel_r(%arg0: !tt.ptr<f32> {tt.divisibility = 16 : i32}) {
     %cst = arith.constant 0.000000e+00 : f32
@@ -78,6 +78,74 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, "ttg.thr
   // CHECK-NVGPU2LLVM-NOT: llvm.fence
   tt.func public @atomic_poll_relaxed(%ptr: !tt.ptr<i32>, %expected: i32) {
     %matched = tt.atomic_poll relaxed, gpu, %ptr, %expected : !tt.ptr<i32>, i32 -> i1
+    tt.return
+  }
+}
+
+// -----
+
+#poll = #ttg.blocked<{sizePerThread = [1], threadsPerWarp = [32], warpsPerCTA = [4], order = [0]}>
+module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, "ttg.threads-per-warp" = 32 : i32} {
+  // CHECK-POLL-LABEL: @atomic_poll_tensor
+  // CHECK-POLL: llvm.load %{{.*}} atomic syncscope("device") monotonic
+  // CHECK-POLL: llvm.fence syncscope("device") acquire
+  // CHECK-POLL: llvm.load %{{.*}} atomic syncscope("device") monotonic
+  // CHECK-POLL: llvm.fence syncscope("device") acquire
+  // CHECK-POLL: nvvm.barrier
+  // CHECK-POLL-NOT: llvm.load
+  // CHECK-POLL: llvm.return
+  tt.func public @atomic_poll_tensor(%ptr: tensor<256x!tt.ptr<i32>, #poll>, %expected: tensor<256xi32, #poll>) {
+    %matched = tt.atomic_poll acquire, gpu, %ptr, %expected : tensor<256x!tt.ptr<i32>, #poll>, tensor<256xi32, #poll> -> tensor<256xi1, #poll>
+    tt.return
+  }
+
+  // CHECK-POLL-LABEL: @atomic_poll_tensor_timeout
+  // CHECK-POLL: llvm.call_intrinsic "llvm.nvvm.read.ptx.sreg.globaltimer"
+  // CHECK-POLL: llvm.load %{{.*}} atomic syncscope("device") monotonic
+  // CHECK-POLL: llvm.fence syncscope("device") acquire
+  // CHECK-POLL: llvm.call_intrinsic "llvm.nvvm.read.ptx.sreg.globaltimer"
+  // CHECK-POLL: llvm.icmp "uge"
+  // CHECK-POLL: nvvm.barrier
+  // CHECK-POLL-NOT: !llvm.ptr<3>
+  // CHECK-POLL: llvm.return
+  tt.func public @atomic_poll_tensor_timeout(%ptr: tensor<128x!tt.ptr<i32>, #poll>, %expected: tensor<128xi32, #poll>, %timeout: i64, %out: tensor<128x!tt.ptr<i32>, #poll>) {
+    %matched = tt.atomic_poll acquire, gpu, %ptr, %expected timeout %timeout : tensor<128x!tt.ptr<i32>, #poll>, tensor<128xi32, #poll> -> tensor<128xi1, #poll>
+    %result = arith.extui %matched : tensor<128xi1, #poll> to tensor<128xi32, #poll>
+    tt.store %out, %result : tensor<128x!tt.ptr<i32>, #poll>
+    tt.return
+  }
+
+  // CHECK-POLL-LABEL: @atomic_poll_replicated_tensor
+  // CHECK-POLL: llvm.cond_br
+  // CHECK-POLL: llvm.load %{{.*}} atomic syncscope("device") monotonic
+  // CHECK-POLL: llvm.fence syncscope("device") acquire
+  // CHECK-POLL: nvvm.barrier
+  // CHECK-POLL: llvm.return
+  tt.func public @atomic_poll_replicated_tensor(%ptr: tensor<16x!tt.ptr<i32>, #poll>, %expected: tensor<16xi32, #poll>, %timeout: i64, %out: tensor<16x!tt.ptr<i32>, #poll>) {
+    %matched = tt.atomic_poll acquire, gpu, %ptr, %expected timeout %timeout : tensor<16x!tt.ptr<i32>, #poll>, tensor<16xi32, #poll> -> tensor<16xi1, #poll>
+    %result = arith.extui %matched : tensor<16xi1, #poll> to tensor<16xi32, #poll>
+    tt.store %out, %result : tensor<16x!tt.ptr<i32>, #poll>
+    tt.return
+  }
+}
+
+// -----
+
+#poll = #ttg.blocked<{sizePerThread = [1], threadsPerWarp = [32], warpsPerCTA = [4], order = [0], CGALayout = [[0]]}>
+module attributes {"ttg.num-ctas" = 2 : i32, "ttg.num-warps" = 4 : i32, "ttg.threads-per-warp" = 32 : i32} {
+  // CHECK-POLL-LABEL: @atomic_poll_cluster_replicas
+  // CHECK-POLL: llvm.load %{{.*}} atomic syncscope("device") monotonic
+  // CHECK-POLL: llvm.fence syncscope("device") acquire
+  // CHECK-POLL: nvvm.cluster.arrive
+  // CHECK-POLL: nvvm.cluster.wait
+  // CHECK-POLL: nvvm.mapa
+  // CHECK-POLL: llvm.load %{{.*}} {{.*}} : !llvm.ptr<7> -> i8
+  // CHECK-POLL: llvm.trunc %{{.*}} : i8 to i1
+  // CHECK-POLL: llvm.return
+  tt.func public @atomic_poll_cluster_replicas(%ptr: tensor<128x!tt.ptr<i32>, #poll>, %expected: tensor<128xi32, #poll>, %timeout: i64, %out: tensor<128x!tt.ptr<i32>, #poll>) {
+    %matched = tt.atomic_poll acquire, gpu, %ptr, %expected timeout %timeout : tensor<128x!tt.ptr<i32>, #poll>, tensor<128xi32, #poll> -> tensor<128xi1, #poll>
+    %result = arith.extui %matched : tensor<128xi1, #poll> to tensor<128xi32, #poll>
+    tt.store %out, %result : tensor<128x!tt.ptr<i32>, #poll>
     tt.return
   }
 }

--- a/test/Conversion/tritongpu_to_llvm_gsan.mlir
+++ b/test/Conversion/tritongpu_to_llvm_gsan.mlir
@@ -51,6 +51,20 @@ module attributes {"ttg.instrumentation_mode" = "gsan", "ttg.num-ctas" = 1 : i32
     tt.return
   }
 
+  // CHECK-LABEL: llvm.func @atomic_poll_tensor
+  // CHECK: llvm.load %{{.*}} atomic monotonic
+  // CHECK: llvm.load %{{.*}} atomic monotonic
+  // CHECK: nvvm.barrier
+  // CHECK: llvm.call @__triton_gsan_atomic_begin_scalar
+  // CHECK: llvm.call @__triton_gsan_atomic_end_scalar
+  // CHECK: llvm.call @__triton_gsan_atomic_begin_scalar
+  // CHECK: llvm.call @__triton_gsan_atomic_end_scalar
+  // CHECK: nvvm.barrier
+  tt.func @atomic_poll_tensor(%ptr: tensor<256x!tt.ptr<i32>, #blocked>, %expected: tensor<256xi32, #blocked>) {
+    %matched = tt.atomic_poll acquire, sys, %ptr, %expected : tensor<256x!tt.ptr<i32>, #blocked>, tensor<256xi32, #blocked> -> tensor<256xi1, #blocked>
+    tt.return
+  }
+
   // CHECK-LABEL: llvm.func @atomic_tensor_desc
   // CHECK: llvm.alloca %{{.*}} x !llvm.array<2 x i32>
   // CHECK: llvm.alloca %{{.*}} x !llvm.array<2 x i16>

--- a/test/Triton/invalid.mlir
+++ b/test/Triton/invalid.mlir
@@ -1,5 +1,21 @@
 // RUN: triton-opt --split-input-file %s --verify-diagnostics
 
+tt.func @atomic_poll_mismatched_result(%ptr: tensor<32x!tt.ptr<i32>>, %expected: tensor<32xi32>) {
+  // expected-error @+1 {{result type matches expected shape}}
+  %matched = tt.atomic_poll acquire, gpu, %ptr, %expected : tensor<32x!tt.ptr<i32>>, tensor<32xi32> -> i1
+  tt.return
+}
+
+// -----
+
+tt.func @atomic_poll_invalid_width(%ptr: tensor<32x!tt.ptr<i8>>, %expected: tensor<32xi8>) {
+  // expected-error @+1 {{only supports integer elements with width {16, 32, 64}}}
+  %matched = tt.atomic_poll acquire, gpu, %ptr, %expected : tensor<32x!tt.ptr<i8>>, tensor<32xi8> -> tensor<32xi1>
+  tt.return
+}
+
+// -----
+
 tt.func @fn(%v: i32) {
   %b = tt.splat %v : i32 -> tensor<128xi32>
   // expected-error @+1 {{rank of source must be same as rank of result}}


### PR DESCRIPTION
Allow `atomic_poll` to accept tensor pointers and return a boolean with the same shape and layout. Scalar and tensor inputs share one polling state machine, including per-element timeouts, layout-based owner election, and an acquire fence after successful polls. The block waits for all polls to finish; timeout results are shared with replicated threads and CTAs. Update the frontend, verifier, interpreter, scratch allocation, and GSan instrumentation accordingly.

