### PR TITLE
[BACKEND] Preserve NVPTX scheduler across HIP linking

### DIFF
--- a/python/src/llvm.cc
+++ b/python/src/llvm.cc
@@ -203,15 +203,17 @@ ScheduleDAGSDNodes *createTritonDAGScheduler(SelectionDAGISel *selector,
 }
 
 void installTritonDAGScheduler() {
-  static RegisterScheduler scheduler("triton-nvptx",
-                                     "Triton compilation-local NVPTX scheduler",
-                                     createTritonDAGScheduler);
   auto options = llvm::cl::getRegisteredOptions();
   auto option = options.find("pre-RA-sched");
   if (option == options.end())
     throw std::runtime_error("LLVM SelectionDAG scheduler option is missing");
-  if (option->second->addOccurrence(1, "pre-RA-sched", "triton-nvptx"))
-    throw std::runtime_error("failed to install Triton's LLVM scheduler");
+  using SchedulerOption =
+      llvm::cl::opt<RegisterScheduler::FunctionPassCtor, false,
+                    RegisterPassParser<RegisterScheduler>>;
+  // LLD resets LLVM options when linking HSACO. Make the dispatcher the default
+  // so subsequent NVIDIA compilations retain their per-compilation policy.
+  static_cast<SchedulerOption *>(option->second)
+      ->setInitialValue(createTritonDAGScheduler);
 }
 
 std::unique_ptr<TargetMachine>

--- a/python/test/unit/test_knobs.py
+++ b/python/test/unit/test_knobs.py
@@ -97,8 +97,19 @@ def _register_pressure_scheduler_kernel():
 
 
 @pytest.mark.skipif(is_hip(), reason="NVPTX code generation is unavailable on AMD")
-def test_nvidia_register_pressure_scheduler_hook():
+@pytest.mark.parametrize("link_hip_first", [False, True])
+def test_nvidia_register_pressure_scheduler_hook(link_hip_first, fresh_triton_cache):
     backend, source = _register_pressure_scheduler_kernel()
+    if link_hip_first:
+        from triton.backends.compiler import GPUTarget
+
+        @triton.jit
+        def empty_kernel():
+            return
+
+        # HIP linking resets LLVM command-line options.
+        triton.compile(triton.compiler.ASTSource(empty_kernel, {}), target=GPUTarget("hip", "gfx942", 64))
+
     default_options = backend.parse_options({"ptx_version": 80, "sched4reg": False})
     pressure_options = backend.parse_options({"ptx_version": 80, "sched4reg": True})
 


### PR DESCRIPTION
Compiling a HIP kernel invokes LLD, which calls `ResetAllOptionOccurrences()` and resets `pre-RA-sched`. Triton installs its scheduler dispatcher only once, so subsequent NVIDIA compilations silently ignore `sched4reg`, making the CI failure depend on test order.

Use `setInitialValue()` to make Triton’s dispatcher the option’s default, preserving the requested scheduling policy after LLVM options are reset.
