### PR TITLE
[Analysis] Account for masked load's `other` constancy

### DIFF
--- a/lib/Analysis/AxisInfo.cpp
+++ b/lib/Analysis/AxisInfo.cpp
@@ -771,13 +771,8 @@ public:
   AxisInfo
   getAxisInfo(triton::LoadOp op,
               ArrayRef<const dataflow::Lattice<AxisInfo> *> operands) override {
-    // If pointers and mask both have constancy properties, those properties
-    // will also extend to output.
+    // Repeated pointers, masks, and fallback values produce repeated results.
     AxisInfo ptrInfo = operands[0]->getValue();
-    std::optional<AxisInfo> maskInfo;
-    if (operands.size() > 1) {
-      maskInfo = operands[1]->getValue();
-    }
     AxisInfo::DimVectorT contiguity;
     AxisInfo::DimVectorT divisibility;
     AxisInfo::DimVectorT constancy;
@@ -785,9 +780,11 @@ public:
     for (int d = 0; d < ptrInfo.getRank(); ++d) {
       contiguity.push_back(1);
       divisibility.push_back(1);
-      constancy.push_back(
-          gcd(ptrInfo.getConstancy(d),
-              maskInfo.has_value() ? maskInfo->getConstancy(d) : 0));
+      int64_t resultConstancy = ptrInfo.getConstancy(d);
+      for (const auto *operand : operands.drop_front())
+        resultConstancy =
+            gcd(resultConstancy, operand->getValue().getConstancy(d));
+      constancy.push_back(resultConstancy);
     }
 
     return AxisInfo(contiguity, divisibility, constancy);

--- a/test/Analysis/test-alignment.mlir
+++ b/test/Analysis/test-alignment.mlir
@@ -1027,7 +1027,7 @@ tt.func @permute_2d(%arg0: !tt.ptr<f32> {tt.divisibility = 16 : i32}, %arg1: i32
 
 // -----
 
-tt.func @load_constancy(%arg0: !tt.ptr<f32> {tt.divisibility = 16 : i32}, %arg1: i32 {tt.divisibility = 1 : i32}) {
+tt.func @load_constancy(%arg0: !tt.ptr<i32> {tt.divisibility = 16 : i32}, %arg1: i32 {tt.divisibility = 1 : i32}) {
   // expected-remark @below {{divisibility = [16]}}
   %sixteen = arith.constant dense<16> : tensor<1024xi32>
   // expected-remark @below {{divisibility = [8]}}
@@ -1037,7 +1037,7 @@ tt.func @load_constancy(%arg0: !tt.ptr<f32> {tt.divisibility = 16 : i32}, %arg1:
   // expected-remark @below {{constancy = [16]}}
   %2 = arith.divsi %1, %sixteen : tensor<1024xi32>
   // expected-remark @below {{constancy = [1024]}}
-  %3 = tt.splat %arg0 : !tt.ptr<f32> -> tensor<1024x!tt.ptr<f32>>
+  %3 = tt.splat %arg0 : !tt.ptr<i32> -> tensor<1024x!tt.ptr<i32>>
   // expected-remark @below {{constancy = [1024]}}
   %4 = tt.splat %arg1 : i32 -> tensor<1024xi32>
   // expected-remark @below {{constancy = [8]}}
@@ -1045,11 +1045,15 @@ tt.func @load_constancy(%arg0: !tt.ptr<f32> {tt.divisibility = 16 : i32}, %arg1:
   // expected-remark @below {{constancy = [8]}}
   %6 = arith.cmpi slt, %5, %4 : tensor<1024xi32>
   // expected-remark @below {{constancy = [16]}}
-  %7 = tt.addptr %3, %2 : tensor<1024x!tt.ptr<f32>>, tensor<1024xi32>
+  %7 = tt.addptr %3, %2 : tensor<1024x!tt.ptr<i32>>, tensor<1024xi32>
   // expected-remark @below {{constancy = [16]}}
-  %8 = tt.load %7 : tensor<1024x!tt.ptr<f32>>
+  %8 = tt.load %7 : tensor<1024x!tt.ptr<i32>>
   // expected-remark @below {{constancy = [8]}}
-  %9 = tt.load %7, %6 : tensor<1024x!tt.ptr<f32>>
+  %9 = tt.load %7, %6 : tensor<1024x!tt.ptr<i32>>
+  // expected-remark @below {{constancy = [1]}}
+  %10 = tt.load %7, %6, %1 : tensor<1024x!tt.ptr<i32>>
+  // expected-remark @below {{constancy = [8]}}
+  %11 = tt.load %7, %6, %5 : tensor<1024x!tt.ptr<i32>>
   tt.return
 }
 


### PR DESCRIPTION
We were miscompiling when `other` is a non-constant tensor.
We were just considering the `mask` constancy.
