### PR TITLE
[RUNTIME] Clear failed async compile futures

### DIFF
--- a/python/test/unit/runtime/test_cache.py
+++ b/python/test/unit/runtime/test_cache.py
@@ -1032,19 +1032,25 @@ def test_async_compile_error(fresh_triton_cache):
     def fn(x: tl.constexpr):
         tl.static_assert(x == 2)
 
-    with pytest.raises(triton.compiler.errors.CompileTimeAssertionFailure):
-        with (
-                ThreadPoolExecutor(2) as pool,
-                triton.AsyncCompileMode(pool),
-        ):
-            assert triton.runtime._async_compile.active_mode.get() is not None
-            fn.warmup(1, grid=(1, ))
+    with (
+            ThreadPoolExecutor(2) as pool,
+            triton.AsyncCompileMode(pool),
+    ):
+        assert triton.runtime._async_compile.active_mode.get() is not None
+        fn.warmup(1, grid=(1, ))
 
-            assert len(fn.device_caches[0][0]) == 1
+        assert len(fn.device_caches[0][0]) == 1
+        # Resolving the queued kernel reports the compilation failure. The
+        # mode must not resolve the failed FutureKernel again on exit.
+        with pytest.raises(triton.compiler.errors.CompileTimeAssertionFailure):
+            fn[(1, )](1)
 
     # After the AsyncCompileMode context manager exits, the active mode should
     # be set to None again, even if there was an error.
     assert triton.runtime._async_compile.active_mode.get() is None
+    # A failed Future would otherwise retain its exception traceback and the
+    # compiler objects reachable through it.
+    assert len(fn.device_caches[0][0]) == 0
 
 
 def test_higher_order_kernel(device, fresh_triton_cache, capsys):

--- a/python/triton/runtime/_async_compile.py
+++ b/python/triton/runtime/_async_compile.py
@@ -8,8 +8,9 @@ active_mode: ContextVar[Optional[AsyncCompileMode]] = ContextVar("async_compile_
 
 class FutureKernel:
 
-    def __init__(self, finalize_compile: Callable, future: Future):
+    def __init__(self, finalize_compile: Callable, cleanup_compile: Callable, future: Future):
         self.finalize_compile = finalize_compile
+        self.cleanup_compile = cleanup_compile
         self.kernel = None
         self.future = future
 
@@ -20,11 +21,14 @@ class FutureKernel:
         try:
             kernel = self.future.result()
         except Exception:
+            self.cleanup_compile(self)
+            self.future = None
             if ignore_errors:
                 return
             else:
                 raise
         self.finalize_compile(kernel)
+        self.future = None
         self.kernel = kernel
         return kernel
 
@@ -42,7 +46,7 @@ class AsyncCompileMode:
         self.raw_futures = []
         self.future_kernels = {}
 
-    def submit(self, key, compile_fn, finalize_fn):
+    def submit(self, key, compile_fn, finalize_fn, cleanup_fn):
         future = self.future_kernels.get(key)
         if future is not None:
             return future
@@ -50,7 +54,7 @@ class AsyncCompileMode:
         future = self.executor.submit(compile_fn)
         future._key = key
         self.raw_futures.append(future)
-        future_kernel = FutureKernel(finalize_fn, future)
+        future_kernel = FutureKernel(finalize_fn, cleanup_fn, future)
         self.future_kernels[key] = future_kernel
         return future_kernel
 
@@ -63,5 +67,13 @@ class AsyncCompileMode:
     def __exit__(self, exc_type, exc_value, traceback):
         active_mode.set(None)
         # Finalize any outstanding compiles
-        for future in as_completed(self.raw_futures):
-            self.future_kernels[future._key].result(self.ignore_errors)
+        try:
+            for future in as_completed(self.raw_futures):
+                future_kernel = self.future_kernels[future._key]
+                if future_kernel.future is not None:
+                    future_kernel.result(self.ignore_errors)
+        finally:
+            # Completed futures can still point back to compile frames so need
+            # to drop them to avoid resource leakage.
+            self.raw_futures = []
+            self.future_kernels = {}

--- a/python/triton/runtime/jit.py
+++ b/python/triton/runtime/jit.py
@@ -906,7 +906,12 @@ class JITFunction(JITCallable, KernelInterface[T]):
                 self._call_hook(knobs.runtime.jit_post_compile_hook, key, signature, target, device, constexprs,
                                 options, [attrs], warmup)
 
-            kernel = async_mode.submit(cache_key, async_compile, finalize_compile)
+            def cleanup_compile(future_kernel):
+                # On failure, remove the unresolved placeholder so its Future does not retain compiler locals.
+                if kernel_cache.get(key) is future_kernel:
+                    del kernel_cache[key]
+
+            kernel = async_mode.submit(cache_key, async_compile, finalize_compile, cleanup_compile)
             kernel_cache[key] = kernel
         else:
             kernel = self.compile(src, target=target, options=options.__dict__)


### PR DESCRIPTION
- remove failed async compile placeholders from JIT caches
- release completed futures and callbacks so exception tracebacks do not retain compiler objects

get rid of the following warnings in the CI

```
 nanobind: leaked 1 instances!
  - leaked instance 0x62867d30 of type "triton._C.libtriton.ir.context"
    nanobind: leaked 5 types!
  - leaked type "triton._C.libtriton.ir.builder"
  - leaked type "MEM_SEMANTIC"
  - leaked type "triton._C.libtriton.ir.type"
  - leaked type "triton._C.libtriton.ir.context"
  - leaked type "triton._C.libtriton.ir.value"
    nanobind: leaked 209 functions!
  - leaked function "get_insertion_point"
  - leaked function "create_minimumf"
  - leaked function "create_maximumf"
  - leaked function "create_xor"
  - leaked function "create_select"
  - leaked function "create_minnumf"
  - leaked function "is_integer"
  - leaked function "create_fcmpUGT"
  - leaked function "create_icmpEQ"
  - leaked function "extend_with"
 ```