### PR TITLE
[KERNELS] Support ragged-M matmul with CLC

### DIFF
--- a/python/triton_kernels/tests/test_matmul_details/test_opt_flags_nvidia.py
+++ b/python/triton_kernels/tests/test_matmul_details/test_opt_flags_nvidia.py
@@ -13,7 +13,7 @@ from triton_kernels.tensor import FP4, UINT8, Storage, Tensor, convert_layout, w
 from triton_kernels.tensor_details import layout
 from triton_kernels.tensor_details.layout import BlackwellMX4ValueShuffledLayout
 from triton_kernels.tensor_details.layout_details.blackwell_scale import BlackwellMXScaleLayout
-from triton_kernels.tensor_details.ragged_tensor import make_ragged_tensor_metadata_torch
+from triton_kernels.tensor_details.ragged_tensor import make_ragged_tensor_metadata
 from triton_kernels.testing import assert_close
 
 
@@ -211,19 +211,111 @@ def test_matmul_clc(device, split_k):
     assert_close(ref_y, tri_y, maxtol=3e-2, rmstol=None)
 
 
-def test_matmul_clc_rejects_ragged_m_grid(device):
+def _assert_ragged_m_output(output, a, b, slice_sizes, sentinel):
+    offset = 0
+    for expert, size in enumerate(slice_sizes):
+        expected = (a[offset:offset + size].float() @ b[expert].float()).to(output.dtype)
+        torch.testing.assert_close(output[offset:offset + size], expected, rtol=0.02, atol=0.02)
+        offset += size
+    # Capacity-only tasks must not write output rows outside the useful range.
+    tail = output[offset:]
+    torch.testing.assert_close(tail, torch.full_like(tail, sentinel), rtol=0, atol=0)
+
+
+@pytest.mark.parametrize("slice_sizes,capacity,split_k", [
+    pytest.param((512, 256, 256, 0), 1024, 1, id="balanced-empty-expert"),
+    pytest.param((0, 0, 1024, 0), 1024, 1, id="one-hot-expert"),
+    pytest.param((1, 127, 129, 255), 1024, 1, id="partial-tiles-capacity-tail"),
+    pytest.param((0, 0, 0, 0), 1024, 1, id="zero-useful-tiles"),
+    pytest.param((16384, 8192, 4096, 0), 32768, 1, id="multiple-waves"),
+    pytest.param((1, 127, 129, 255), 512, 2, id="split-k-capacity-tail"),
+])
+@pytest.mark.parametrize("transpose_rhs", [False, True])
+@pytest.mark.parametrize("dtype", [torch.bfloat16, torch.float8_e4m3fn])
+def test_matmul_clc_ragged_m_capacity(device, slice_sizes, capacity, split_k, transpose_rhs, dtype):
     if device != "cuda" or not torch.cuda.is_available() or not is_cuda():
         pytest.skip("requires CUDA")
     if torch.cuda.get_device_capability()[0] < 10:
         pytest.skip("requires Blackwell or newer")
 
-    slice_sizes = torch.tensor([64, 0, 64], dtype=torch.int32, device=device)
-    metadata = make_ragged_tensor_metadata_torch(slice_sizes, 128)
-    a = torch.randn((128, 64), device=device, dtype=torch.bfloat16)
-    b = torch.randn((3, 64, 128), device=device, dtype=torch.bfloat16)
-    with scoped_opt_flags_constraints({"clc": True}):
-        with pytest.raises(InapplicableConstraint, match="host-known grid"):
-            matmul(a, b, None, a_ragged_metadata=metadata)
+    torch.manual_seed(0)
+    n, k = 512, 256
+    a = torch.randn((capacity, k), device=device, dtype=torch.bfloat16).to(dtype)
+    weight_shape = (len(slice_sizes), n, k) if transpose_rhs else (len(slice_sizes), k, n)
+    b = torch.randn(weight_shape, device=device, dtype=torch.bfloat16).to(dtype)
+    if transpose_rhs:
+        b = b.mT
+    sizes = torch.tensor(slice_sizes, device=device, dtype=torch.int32)
+    metadata = make_ragged_tensor_metadata(sizes, capacity)
+    sentinel = 123.0
+    precision = PrecisionConfig(out_dtype=torch.bfloat16)
+    constraints = {
+        "block_m": 128,
+        "block_n": 128,
+        "block_k": 64,
+        "is_persistent": True,
+        "split_k": split_k,
+        "idle_sms": 0,
+    }
+    outputs = []
+    for use_clc in (False, True):
+        output = torch.full((capacity, n), sentinel, device=device, dtype=torch.bfloat16)
+        with scoped_opt_flags_constraints({**constraints, "clc": use_clc}):
+            matmul(a, b, None, a_ragged_metadata=metadata, c=output, precision_config=precision)
+        outputs.append(output)
+
+    # Keep tile shape and reduction order fixed while changing the scheduler.
+    torch.testing.assert_close(outputs[1], outputs[0], rtol=0, atol=0)
+    _assert_ragged_m_output(outputs[1], a, b, slice_sizes, sentinel)
+
+
+@pytest.mark.parametrize("dtype", [torch.bfloat16, torch.float8_e4m3fn])
+def test_matmul_clc_ragged_m_graph_replay(device, dtype):
+    if device != "cuda" or not torch.cuda.is_available() or not is_cuda():
+        pytest.skip("requires CUDA")
+    if torch.cuda.get_device_capability()[0] < 10:
+        pytest.skip("requires Blackwell or newer")
+
+    torch.manual_seed(0)
+    capacity, n, k = 1024, 512, 256
+    a = torch.randn((capacity, k), device=device, dtype=torch.bfloat16).to(dtype)
+    b = torch.randn((4, k, n), device=device, dtype=torch.bfloat16).to(dtype)
+    sizes = torch.tensor((256, 256, 256, 256), device=device, dtype=torch.int32)
+    sentinel = 123.0
+    output = torch.full((capacity, n), sentinel, device=device, dtype=torch.bfloat16)
+    precision = PrecisionConfig(out_dtype=torch.bfloat16)
+    constraints = {
+        "block_m": 128,
+        "block_n": 128,
+        "block_k": 64,
+        "is_persistent": True,
+        "split_k": 1,
+        "idle_sms": 0,
+        "clc": True,
+    }
+
+    def run():
+        metadata = make_ragged_tensor_metadata(sizes, capacity)
+        matmul(a, b, None, a_ragged_metadata=metadata, c=output, precision_config=precision)
+
+    with scoped_opt_flags_constraints(constraints):
+        warmup = torch.cuda.Stream(device=device)
+        warmup.wait_stream(torch.cuda.current_stream(device))
+        with torch.cuda.stream(warmup):
+            for _ in range(3):
+                run()
+        torch.cuda.current_stream(device).wait_stream(warmup)
+        graph = torch.cuda.CUDAGraph()
+        with torch.cuda.graph(graph):
+            run()
+
+    # Reuse the same launch while the device-computed useful count changes.
+    for values in ((1, 127, 129, 255), (0, 0, 0, 0), (0, 0, 1024, 0)):
+        sizes.copy_(torch.tensor(values, device=device, dtype=torch.int32))
+        a.copy_(torch.randn(a.shape, device=device, dtype=torch.bfloat16).to(dtype))
+        output.fill_(sentinel)
+        graph.replay()
+        _assert_ragged_m_output(output, a, b, values, sentinel)
 
 
 def test_matmul_blackwell_shuffled_mxfp4_weight(device):

--- a/python/triton_kernels/triton_kernels/matmul.py
+++ b/python/triton_kernels/triton_kernels/matmul.py
@@ -434,8 +434,6 @@ def matmul(a, b, bias,
         rhs_layout=b.storage.layout,
         epilogue_reduction_n=fused_activation.specs.reduction_n,
     )
-    if opt_flags.clc and ragged_dimension == "M":
-        raise InapplicableConstraint("CLC requires a host-known grid and does not support ragged-M matmul")
     if opt_flags.clc and opt_flags.idle_sms:
         raise InapplicableConstraint("CLC does not support leaving SMs idle")
     if b_is_shuffled:

--- a/python/triton_kernels/triton_kernels/matmul_details/_p_matmul.py
+++ b/python/triton_kernels/triton_kernels/matmul_details/_p_matmul.py
@@ -249,6 +249,11 @@ def _p_matmul(
     loop_start = 0 if CLC else tl.program_id(0)
     loop_end = 1 if CLC else num_blocks
     loop_step = 1 if CLC else NUM_SMS
+    if CLC and RAGGED_DIMENSION == "M":
+        # The launch covers schedule capacity; num_blocks is the useful count.
+        # Skip capacity-only IDs before computing coordinates or reading the
+        # expert schedule, but keep the compiler's CLC loop running to drain them.
+        loop_end = (tl.program_id(0) < num_blocks).to(tl.int32)
     for block_id in tl.range(
         loop_start, loop_end, loop_step,
         flatten=FLATTEN_LOOPS and not CLC,


### PR DESCRIPTION
## Summary

Ragged-M matmul already launches from a host-known schedule capacity, but its useful tile count is computed on the device. Guarding the capacity-only tail lets CLC use that existing launch without copying the routed sizes back to the host.

This enables ragged-M CLC using the existing compiler-generated cancellation loop:

- Remove the ragged-M CLC rejection in `matmul.py`; retain the existing capacity-based grid calculation and other eligibility checks.
- Guard the GEMM tile loop in `_p_matmul.py` with the device-computed useful tile count. Capacity-only IDs skip coordinate calculations, expert schedule reads, and GEMM work, while the surrounding CLC loop continues to drain work. This also handles zero useful tiles without computing invalid coordinates.
- Replace the rejection test with BF16/FP8 correctness and graph-replay regressions in `test_opt_flags_nvidia.py`.

The tests cover empty experts, one-hot routing, partial tiles, excess capacity, zero useful tiles, multiple worker waves, split-K, and both RHS layouts. They compare CLC with static persistent scheduling at a fixed tile configuration, check a per-expert reference, and verify untouched capacity-only output rows. Graph replay changes the device routing metadata without changing the launch.

## Scope

Only these three kernel/test files change. No compiler changes, new drain protocol, fused-communication batching, wheel/pin updates, or default-scheduling changes. The existing inner-K warp specialization is unchanged. This is independent of the loader-gated lookahead proposal in #11529 and makes no new performance claim.

## Validation

- Pre-commit and `git diff --check` passed.
- On NVIDIA GB300, `test_opt_flags_nvidia.py -k matmul_clc`: **28 passed** normally and **28 passed** with ConSan, without skips. This includes 26 ragged-M cases and the two existing dense CLC cases.
- Generated IR inspection confirmed that the cancellation request and response query surround the guarded tile loop and that ragged-M variants retain inner-K warp specialization.

GPU validation used the exact kernel/test sources in this PR with an existing CLC-capable Triton 3.8.0 compiler runtime, not a fresh compiler build of the current `main`. No compiler rebuild is needed for this Python/kernel-only change; upstream CI validation is still pending.

## New contributor declaration

- [x] I am not making a trivial change, such as fixing a typo in a comment.
- [x] I have written a PR description following these [rules](https://cbea.ms/git-commit/#why-not-how).
- [x] I have run `pre-commit run --from-ref origin/main --to-ref HEAD`.
- [x] I have added tests in `python/triton_kernels/tests/`.
- [x] I have not added any `lit` tests.
