### PR TITLE
[NVIDIA] Flush pending TMEM accesses before CFG branches

### DIFF
--- a/lib/Dialect/TritonNvidiaGPU/Transforms/TMemBarrierInsertion.cpp
+++ b/lib/Dialect/TritonNvidiaGPU/Transforms/TMemBarrierInsertion.cpp
@@ -124,15 +124,16 @@ void TMemBarrierAnalysis::update(Operation *op, MembarInfo *membarInfo,
     membarInfo->sync();
 }
 
-// Ops before which we 100% need to flush reads and writes
+// Operations before which to flush pending TMEM accesses.
 bool isWaitBoundary(Operation *op) {
   // Defer waits at CTA barriers until a hazard or boundary requires them.
   if (isa<gpu::BarrierOp>(op))
     return false;
 
-  // Flush before starting or ending WS
-  if (isa<gpu::WarpSpecializeOp, gpu::WarpSpecializePartitionsOp,
-          gpu::WarpYieldOp, gpu::WarpReturnOp, CallOpInterface>(op))
+  // Flush before CFG branches, calls and warp specialization boundaries.
+  if (isa<BranchOpInterface, gpu::WarpSpecializeOp,
+          gpu::WarpSpecializePartitionsOp, gpu::WarpYieldOp, gpu::WarpReturnOp,
+          CallOpInterface>(op))
     return true;
   // A non-relaxed cluster barrier could be followed by a 2CTA MMA, in which
   // case we need to put the wait before the cluster barrier.
@@ -151,11 +152,6 @@ bool isWaitBoundary(Operation *op) {
     if (!barrier.getBarriers().empty())
       return true;
 
-  // Carry pending accesses through control-flow joins and backedges.
-  if (isa<BranchOpInterface, RegionBranchOpInterface>(op) ||
-      (isa<RegionBranchTerminatorOpInterface>(op) &&
-       isa<RegionBranchOpInterface>(op->getParentOp())))
-    return false;
   if (op->hasTrait<OpTrait::ReturnLike>())
     return true;
 
@@ -234,7 +230,6 @@ private:
 
   void finishBlock(BlockInfo &pending, OpBuilder *builder) {
     // Complete accesses preceding lastBarrier before forgetting it.
-    // Leave later accesses in pending for joins and backedges.
     for (TMEMWaitKind kind : {TMEMWaitKind::LOAD, TMEMWaitKind::STORE})
       waitBeforeBarrier(kind, pending, builder);
     lastBarrier = nullptr;
@@ -306,13 +301,11 @@ private:
       afterBarrier.join(effects);
     }
 
-    if (op->hasTrait<OpTrait::IsTerminator>() ||
-        isa<RegionBranchOpInterface>(op))
+    if (op->hasTrait<OpTrait::IsTerminator>())
       finishBlock(pending, builder);
   }
 
-  // These snapshots track accesses before and after lastBarrier within one
-  // virtual block. Only MembarInfo::pending flows through joins and backedges.
+  // Track accesses before and after lastBarrier within one block.
   Operation *lastBarrier = nullptr;
   BlockInfo beforeBarrier;
   BlockInfo afterBarrier;
@@ -350,8 +343,8 @@ struct TMemWaitInsertionPass
             })
              .wasInterrupted())
       return;
-    // Run after TMEM and shared-memory barrier insertion. Calls and returns
-    // complete pending accesses, so this pass needs no call summaries.
+    // Run after control-flow lowering and TMEM/shared-memory barrier insertion.
+    // Calls and returns complete pending accesses, so no summaries are needed.
     if (failed(runTMemAnalysis<TMemWaitAnalysis>(mod)))
       return signalPassFailure();
   }

--- a/test/TritonNvidiaGPU/tmem_barrier_insertion.mlir
+++ b/test/TritonNvidiaGPU/tmem_barrier_insertion.mlir
@@ -662,16 +662,47 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32} {
     tt.return
   }
 
-  // Stores remain pending across branches. At the merge, wait before
+  // Complete the initializer before branching without repeating its store wait.
+  // Each path keeps its rendezvous, and loads complete before leaving the block.
+  // WAIT-LABEL: @wait_initializer_before_fork
+  // WAIT: ttng.tmem_alloc
+  // WAIT-NEXT: ttng.tmem_wait store
+  // WAIT-NEXT: cf.cond_br
+  // WAIT-NOT: ttng.tmem_wait store
+  // CHECK: ttg.barrier local
+  // WAIT: ttng.tmem_load
+  // WAIT-NEXT: tt.store
+  // WAIT-NEXT: ttng.tmem_wait load
+  // WAIT-NEXT: cf.br
+  // WAIT-NOT: ttng.tmem_wait store
+  // CHECK: ttg.barrier local
+  // WAIT: ttng.tmem_load
+  // WAIT-NEXT: ttng.tmem_wait load
+  // WAIT-NEXT: tt.return
+  tt.func @wait_initializer_before_fork(%condition: i1, %data: tensor<128x64xf32, #blocked>, %out: tensor<128x64x!tt.ptr<f32>, #blocked>) -> tensor<128x64xf32, #blocked> {
+    %mem = ttng.tmem_alloc %data {tensor_memory_col_offset = 0 : i32, tensor_memory_row_offset = 0 : i32} : (tensor<128x64xf32, #blocked>) -> !ttg.memdesc<128x64xf32, #tmem128, #ttng.tensor_memory, mutable>
+    cf.cond_br %condition, ^body, ^merge
+  ^body:
+    %value = ttng.tmem_load %mem : !ttg.memdesc<128x64xf32, #tmem128, #ttng.tensor_memory, mutable> -> tensor<128x64xf32, #blocked>
+    tt.store %out, %value : tensor<128x64x!tt.ptr<f32>, #blocked>
+    cf.br ^merge
+  ^merge:
+    %result = ttng.tmem_load %mem : !ttg.memdesc<128x64xf32, #tmem128, #ttng.tensor_memory, mutable> -> tensor<128x64xf32, #blocked>
+    tt.return %result : tensor<128x64xf32, #blocked>
+  }
+
+  // Complete stores before branching. The merge keeps its rendezvous before
   // overwriting %low, which may have been written by the left branch.
   // CHECK-LABEL: @wait_cfg_join
   // CHECK: cf.cond_br
   // CHECK: ttng.tmem_store
+  // CHECK-NEXT: ttng.tmem_wait store
   // CHECK-NEXT: cf.br
   // CHECK: ttng.tmem_store
+  // CHECK-NEXT: ttng.tmem_wait store
   // CHECK-NEXT: cf.br
-  // CHECK: ttng.tmem_wait store
-  // CHECK-NEXT: ttg.barrier local
+  // CHECK-NOT: ttng.tmem_wait store
+  // CHECK: ttg.barrier local
   // CHECK-NEXT: ttng.tmem_store
   // CHECK-NEXT: ttng.tmem_wait store
   // CHECK-NEXT: tt.return
@@ -715,18 +746,20 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32} {
     tt.return
   }
 
-  // Carry pending stores across the backedge; the next iteration must wait
-  // before writing the same descriptor again.
+  // Complete stores before the backedge; the next iteration keeps its
+  // rendezvous before writing the same descriptor again.
   // CHECK-LABEL: @wait_cfg_backedge
   // CHECK: cf.br
-  // CHECK: cf.cond_br
-  // CHECK: ttng.tmem_wait store
-  // CHECK-NEXT: ttg.barrier local
-  // CHECK-NEXT: ttng.tmem_store
   // CHECK-NOT: ttng.tmem_wait
-  // CHECK: cf.br
-  // CHECK: ttng.tmem_wait store
-  // CHECK-NEXT: tt.return
+  // CHECK: cf.cond_br
+  // CHECK-NOT: ttng.tmem_wait
+  // CHECK: ttg.barrier local
+  // CHECK-NEXT: ttng.tmem_store
+  // CHECK-NEXT: %{{.*}} = arith.subi
+  // CHECK-NEXT: ttng.tmem_wait store
+  // CHECK-NEXT: cf.br
+  // CHECK-NOT: ttng.tmem_wait
+  // CHECK: tt.return
   tt.func @wait_cfg_backedge(%iterations: i32, %data: tensor<128x128xf32, #blocked>) {
     %true = arith.constant true
     %zero = arith.constant 0 : i32


### PR DESCRIPTION
Complete outstanding TMEM loads and stores before CFG branches so incomplete accesses do not cross control-flow edges.

Stacked on #11693.
