### PR TITLE
[Proton][AMD] Finalize the ROCprofiler client before process teardown

### DIFF
--- a/third_party/proton/csrc/lib/Profiler/RocprofSDK/RocprofSDKProfiler.cpp
+++ b/third_party/proton/csrc/lib/Profiler/RocprofSDK/RocprofSDKProfiler.cpp
@@ -151,6 +151,14 @@ struct RocprofilerRuntimeState {
   std::atomic<bool> profilingActive{false};
   std::atomic<bool> nvtxEnabled{false};
   std::atomic<RocprofSDKProfiler::RocprofSDKProfilerPimpl *> pimpl{nullptr};
+  // rocprofiler-sdk provides a terminal client-finalization callback during
+  // tool initialization. Invoking it before Proton static destruction drains
+  // SDK callbacks and prevents the SDK atexit handler from finalizing this
+  // client again.
+  rocprofiler_client_finalize_t clientFinalize{};
+  std::optional<rocprofiler_client_id_t> clientId;
+  std::once_flag registerShutdownFlag;
+  bool clientFinalized{false};
 };
 
 RocprofilerRuntimeState &getRuntimeState() {
@@ -165,6 +173,26 @@ using RoctxRegisterTracerCallbackFn = void (*)(RoctxTracerCallbackFn);
 // registerRoctxCallback is defined after the Pimpl class (needs access to
 // the static roctxCallback member).
 void registerRoctxCallback(bool enable);
+
+void finalizeRocprofilerClient() {
+  auto &state = getRuntimeState();
+  rocprofiler_client_finalize_t finalize = nullptr;
+  std::optional<rocprofiler_client_id_t> clientId;
+  {
+    std::lock_guard<std::mutex> lock(state.mutex);
+    if (state.clientFinalized)
+      return;
+    state.clientFinalized = true;
+    state.profilingActive.store(false, std::memory_order_relaxed);
+    state.nvtxEnabled.store(false, std::memory_order_relaxed);
+    finalize = state.clientFinalize;
+    if (state.clientId)
+      clientId.emplace(*state.clientId);
+  }
+  registerRoctxCallback(false);
+  if (finalize && clientId)
+    finalize(*clientId);
+}
 
 // ---- Agent (GPU) ID mapping ----
 
@@ -1202,8 +1230,9 @@ void RocprofSDKProfiler::RocprofSDKProfilerPimpl::pcSamplingBufferCallback(
 
 namespace {
 
-int protonToolInit(rocprofiler_client_finalize_t, void *toolData) {
+int protonToolInit(rocprofiler_client_finalize_t finalize, void *toolData) {
   auto *state = static_cast<RocprofilerRuntimeState *>(toolData);
+  state->clientFinalize = finalize;
   auto *impl = state->pimpl.load();
 
   // Context 1: always-active context for code object tracking. Kernel symbol
@@ -1364,6 +1393,7 @@ protonConfigure(uint32_t version, const char *runtimeVersion, uint32_t priority,
                 rocprofiler_client_id_t *id) {
   auto &state = getRuntimeState();
   id->name = "ProtonRocprofSDK";
+  state.clientId.emplace(*id);
   static rocprofiler_tool_configure_result_t config{
       sizeof(rocprofiler_tool_configure_result_t), &protonToolInit,
       &protonToolFini, static_cast<void *>(&state)};
@@ -1377,6 +1407,15 @@ protonConfigure(uint32_t version, const char *runtimeVersion, uint32_t priority,
 void RocprofSDKProfiler::RocprofSDKProfilerPimpl::doStart() {
   {
     auto &state = getRuntimeState();
+    // SessionManager has been constructed before a profiler can start.
+    // Registering here makes this handler run before SessionManager and
+    // RocprofSDKProfiler static destruction, while callback destinations are
+    // still alive.
+    std::call_once(state.registerShutdownFlag, []() {
+      if (std::atexit(&finalizeRocprofilerClient) != 0)
+        throw std::runtime_error(
+            "[PROTON] Failed to register ROCprofiler shutdown handler");
+    });
     std::lock_guard<std::mutex> lock(state.mutex);
     if (!state.profilingStarted) {
       rocprofiler::startContext<true>(state.profilingContext);

--- a/third_party/proton/csrc/lib/Profiler/RocprofSDK/RocprofSDKProfiler.cpp
+++ b/third_party/proton/csrc/lib/Profiler/RocprofSDK/RocprofSDKProfiler.cpp
@@ -1413,8 +1413,8 @@ void RocprofSDKProfiler::RocprofSDKProfilerPimpl::doStart() {
     // still alive.
     std::call_once(state.registerShutdownFlag, []() {
       if (std::atexit(&finalizeRocprofilerClient) != 0)
-        throw std::runtime_error(
-            "[PROTON] Failed to register ROCprofiler shutdown handler");
+        throw makeRuntimeError(
+            "Failed to register ROCprofiler shutdown handler");
     });
     std::lock_guard<std::mutex> lock(state.mutex);
     if (!state.profilingStarted) {

--- a/third_party/proton/test/test_profile.py
+++ b/third_party/proton/test/test_profile.py
@@ -6,6 +6,8 @@ Each test should invoke one or more GPU kernels and check the validity of their 
 import inspect
 import os
 import pathlib
+import subprocess
+import sys
 
 import triton
 import triton.profiler as proton
@@ -39,6 +41,43 @@ _skip_cudagraph_test = pytest.mark.skipif(
     os.environ.get("PROTON_SKIP_CUDAGRAPH_TEST", "0") == "1",
     reason="CUDAGraph test skipped due to environment constraints",
 )
+
+
+@pytest.mark.skipif(not is_hip(), reason="ROCprofiler is only available on HIP")
+def test_rocprofiler_process_exit_without_finalize(tmp_path: pathlib.Path):
+    # Run in a subprocess so normal process teardown exercises the ordering
+    # between Proton static destruction and rocprofiler-sdk's atexit handler.
+    script = tmp_path / "unfinalized_rocprofiler.py"
+    output = tmp_path / "unfinalized_rocprofiler"
+    script.write_text(f"""
+import triton.profiler as proton
+import triton
+import triton.language as tl
+import torch
+
+
+@triton.jit
+def copy(x, y, n: tl.constexpr):
+    offsets = tl.arange(0, n)
+    tl.store(y + offsets, tl.load(x + offsets))
+
+
+x = torch.ones((1024,), device="cuda")
+y = torch.zeros_like(x)
+proton.start({str(output)!r}, hook="triton", backend="rocprofiler")
+for _ in range(100):
+    copy[(1,)](x, y, x.numel())
+# Intentionally omit synchronization and proton.finalize(). The SDK must
+# finish queued work and drain its pending callbacks before Proton destroys
+# the callback targets.
+""")
+
+    # Poison freed heap allocations so stale Proton state is not likely to
+    # remain accidentally usable until rocprofiler-sdk's atexit handler runs.
+    env = os.environ.copy()
+    env["MALLOC_PERTURB_"] = "165"
+    result = subprocess.run([sys.executable, str(script)], capture_output=True, text=True, timeout=20, env=env)
+    assert result.returncode == 0, result.stderr
 
 
 @pytest.mark.parametrize("context", ["shadow", "python"])


### PR DESCRIPTION
This reduces flakiness for Proton's rocprofiler-sdk shutdown.

ROCprofiler-SDK can deliver buffered profiling records during process shutdown. Proton previously allowed its profiler state to be destroyed before that delivery was complete, so late callbacks could access freed state.

The resulting failures were timing- and allocator-dependent: affected processes could exit successfully, hang during teardown, report heap corruption, or terminate with `SIGSEGV`/`SIGABRT` after profiling had otherwise completed successfully. Explicit `proton.finalize()` often hid the issue by draining pending records earlier, but process exit without explicit finalization remained unsafe.

This change makes Proton’s lifetime agree with the ROCprofiler-SDK client lifecycle: all callbacks required during terminal SDK shutdown complete while their Proton destinations remain valid. It also adds subprocess coverage for SDK-driven shutdown, using heap perturbation to reliably expose stale- state access that would otherwise depend on allocator reuse and timing.

The included regression test runs profiling in a subprocess, queues GPU work, and deliberately exits without synchronizing the device or calling `proton.finalize()`. This leaves rocprofiler-sdk responsible for completing outstanding work and delivering pending callbacks during its process-exit shutdown sequence, which is where the lifetime bug occurs.

The test also enables glibc’s `MALLOC_PERTURB_` debugging behavior. Without it, freed Proton storage often retains enough of its previous contents for the invalid callback to appear to work, making the bug highly sensitive to allocator reuse and timing. I initially used a simpler test that reproduced the original `SIGSEGV`, but only once across many runs, so it was not reliable enough to demonstrate that the fix changed the behavior rather than merely getting lucky.

With heap perturbation, freed allocations are overwritten with a recognizable byte pattern, making callbacks into destroyed Proton state consistently fail instead of accidentally succeeding. Running the test for 10 subprocesses without the fix in this PR resulted in 10 failures (non-termination during teardown, at least not within a generous timeout). With the fix, 60 out of 60 runs exited successfully (well under timeout).