### PR TITLE
[KERNELS] Convert Blackwell FP4 directly to shuffled layout

### DIFF
--- a/python/triton_kernels/tests/test_tensor.py
+++ b/python/triton_kernels/tests/test_tensor.py
@@ -534,6 +534,69 @@ def test_mxfp4_value_convert_layout_meta(layout, major_dim, inverse):
     assert actual.device.type == "meta"
 
 
+@pytest.mark.parametrize("shape", [(256, 512), (130, 66), (2, 130, 66), (2, 3, 130, 66),
+                                  (2, 1, 3, 130, 66), (0, 130, 66)])
+@pytest.mark.parametrize("tiles", [(128, 256), (192, 48)])
+@pytest.mark.parametrize("step", [1, 2])
+@pytest.mark.parametrize("with_out", [False, True])
+@pytest.mark.parametrize("device", ["cpu", "meta", "cuda"])
+def test_blackwell_fp4_shuffle_conversion(shape, tiles, step, with_out, device):
+    data = torch.randint(0, 256, (*shape[:-1], shape[-1] // 2), dtype=torch.uint8,
+                         generator=torch.Generator().manual_seed(0))
+    canonical = wrap_torch_tensor(data, dtype=FP4)
+    source = convert_layout(canonical, BlackwellMXValueLayout())
+    destination = BlackwellMX4ValueShuffledLayout(*tiles)
+    expected = convert_layout(canonical, destination)
+    # Source padding is unspecified and must not leak into destination padding.
+    source.data[..., shape[-2] // 2:, :].fill_(0xAB)
+    source_data = source.data.to(device)
+    if step == 2:
+        storage = torch.empty(tuple(2 * size for size in source_data.shape), dtype=torch.uint8, device=device)
+        source_view = storage[tuple(slice(None, None, 2) for _ in shape)]
+        source_view.copy_(source_data)
+        source_data = source_view
+    source = wrap_torch_tensor(source_data, dtype=FP4, shape=shape, layout=source.storage.layout)
+    out = None
+    if with_out:
+        storage = torch.full((expected.data.numel() * step + 1,), 0xCD, dtype=torch.uint8, device=device)
+        out_data = storage[1:].as_strided(expected.data.shape, tuple(step * s for s in expected.data.stride()))
+        out = wrap_torch_tensor(out_data, dtype=FP4, shape=shape, layout=destination)
+
+    actual = convert_layout(source, destination, out=out)
+
+    assert actual.shape == list(shape)
+    assert actual.data.shape == expected.data.shape
+    assert actual.data.dtype == expected.data.dtype
+    if with_out:
+        assert actual is out
+    if device != "meta":
+        assert torch.equal(actual.data.cpu(), expected.data)
+        assert torch.equal(convert_layout(actual, StridedLayout()).data.cpu(), data)
+        if with_out:
+            assert storage[0].item() == 0xCD
+            if step == 2:
+                assert torch.all(storage[2::2] == 0xCD)
+
+
+@pytest.mark.parametrize("with_out", [False, True])
+def test_blackwell_fp4_shuffle_peak_allocation(with_out):
+    canonical = empty((8, 1024, 2048), dtype=FP4, device="cuda")
+    source = convert_layout(canonical, BlackwellMXValueLayout())
+    destination = BlackwellMX4ValueShuffledLayout()
+    warm = convert_layout(source, destination)
+    out = warm if with_out else None
+    torch.cuda.synchronize()
+    del warm
+    baseline = torch.cuda.memory_allocated()
+    torch.cuda.reset_peak_memory_stats()
+
+    actual = convert_layout(source, destination, out=out)
+    torch.cuda.synchronize()
+    peak = torch.cuda.max_memory_allocated() - baseline
+
+    assert peak <= (0 if with_out else actual.data.nbytes) + 1024**2
+
+
 @pytest.mark.parametrize("layout", _FP4_VALUE_LAYOUTS)
 @pytest.mark.parametrize("inverse", [False, True])
 @pytest.mark.parametrize("major_dim", [-2, -1])

--- a/python/triton_kernels/triton_kernels/tensor_details/layout_details/blackwell_value_shuffled.py
+++ b/python/triton_kernels/triton_kernels/tensor_details/layout_details/blackwell_value_shuffled.py
@@ -7,6 +7,7 @@ import triton.language as tl
 
 from triton_kernels.tensor_details.layout_details import strided
 from .base import Layout, LayoutTransformation
+from .blackwell_value import BlackwellMXValueLayoutTransformation
 from .torch_utils import repack
 
 
@@ -108,6 +109,11 @@ class BlackwellMX4ValueShuffledTransformation(LayoutTransformation):
         return self._convert_data(data, inverse=True, major_dim=destination.order[0], out=out)
 
     def _convert_data_from(self, data, source: LayoutTransformation, *, out):
+        if (isinstance(source, BlackwellMXValueLayoutTransformation) and self.is_fp4
+                and data.device.type == "cuda" and data.dtype == torch.uint8
+                and list(data.shape) == source.storage_shape):
+            # Blackwell values already pack K; only their physical tiling changes.
+            return self._convert_data(data, inverse=False, major_dim=len(self.shape) - 2, out=out)
         if (not isinstance(source, strided.StridedLayoutTransformation) or not self.is_fp4
                 or not source._can_convert_fp4(data)):
             return super()._convert_data_from(data, source, out=out)


### PR DESCRIPTION
## Summary

Converting packed 4-bit floating-point (FP4) values from `BlackwellMXValueLayout` to `BlackwellMX4ValueShuffledLayout` currently unpacks/repackages the values through canonical storage. Both layouts already pack the K dimension, so this intermediate adds memory traffic and a weight-sized allocation without changing the logical values.

Dispatch this layout pair through the shuffled layout's existing stride-aware conversion kernel with K packing enabled. The conversion copies packed bytes directly, ignores source padding, and zeros destination padding. It supports caller-provided `out` buffers and sliced storage while retaining the existing fallback for other inputs.

## Validation

Tested on NVIDIA GB300 GPUs on an aarch64 host with the installed Triton 3.8.0 compiler and this branch's `triton_kernels` sources.

```sh
PYTHONPATH=python/triton_kernels python -m pytest -s --tb=short \
    python/triton_kernels/tests/test_tensor.py -k blackwell_fp4_shuffle
```

Regression coverage includes ranks 2–5, aligned and padded shapes, alternate tile sizes, empty tensors, sliced input/output storage, CPU/meta/CUDA paths, byte equality, roundtrips, and peak allocation with and without `out`.

Additional standalone checks passed for 65,537 batches, input and output buffers larger than 2 GiB, a different current CUDA device, a nondefault stream, non-byte storage fallback, and fake CPU tensors. For an 8 MiB output, measured peak additional allocation fell from 16 MiB through canonical storage to 8 MiB through direct conversion.


Synthetic conversion benchmarks used `triton.testing.do_bench_cudagraph(rep=100)` on one GB300. The baseline explicitly composes the source's `unswizzle_data` and destination's `swizzle_data` using the same compiler and source revision. All outputs matched byte for byte.

| Logical shape `[batch, K, N]` | Canonical path | Direct conversion |
| --- | ---: | ---: |
| `[8, 3072, 4096]` | 0.5489 ms | 0.01338 ms |
| `[2, 4096, 8192]` | 0.3604 ms | 0.00713 ms |
| `[4, 64, 64]` | 0.01775 ms | 0.00132 ms |

These measure conversion GPU time; end-to-end model startup was not measured.

## Lines Changed

| Type | Added | Removed | Net |
| --- | ---: | ---: | ---: |
| Tests | 63 | 0 | 63 |
| Core Logic | 6 | 0 | 6 |
| AutoGenerated | 0 | 0 | 0 |
| Total | 69 | 0 | 69 |

## Reviewers Guide

- `python/triton_kernels/triton_kernels/tensor_details/layout_details/blackwell_value_shuffled.py`: the direct-conversion dispatch; reuses the existing kernel.
- `python/triton_kernels/tests/test_tensor.py`: conversion correctness and peak-allocation regression tests.
- No files are primarily movements.
