### PR TITLE
[KERNELS] Convert between Blackwell FP4 layouts directly

### DIFF
--- a/python/triton_kernels/tests/test_tensor.py
+++ b/python/triton_kernels/tests/test_tensor.py
@@ -540,19 +540,27 @@ def test_mxfp4_value_convert_layout_meta(layout, major_dim, inverse):
 @pytest.mark.parametrize("step", [1, 2])
 @pytest.mark.parametrize("with_out", [False, True])
 @pytest.mark.parametrize("device", ["cpu", "meta", "cuda"])
-def test_blackwell_fp4_shuffle_conversion(shape, tiles, step, with_out, device):
+@pytest.mark.parametrize("inverse", [False, True])
+def test_blackwell_fp4_shuffle_conversion(shape, tiles, step, with_out, device, inverse):
     data = torch.randint(0, 256, (*shape[:-1], shape[-1] // 2), dtype=torch.uint8,
                          generator=torch.Generator().manual_seed(0))
     canonical = wrap_torch_tensor(data, dtype=FP4)
-    source = convert_layout(canonical, BlackwellMXValueLayout())
-    destination = BlackwellMX4ValueShuffledLayout(*tiles)
+    plain, shuffled = BlackwellMXValueLayout(), BlackwellMX4ValueShuffledLayout(*tiles)
+    source_layout, destination = (shuffled, plain) if inverse else (plain, shuffled)
+    source = convert_layout(canonical, source_layout)
     expected = convert_layout(canonical, destination)
-    # Source padding is unspecified and must not leak into destination padding.
-    source.data[..., shape[-2] // 2:, :].fill_(0xAB)
+    # Padding bytes must not leak into logical values or shuffled destination padding.
+    if inverse:
+        _, tiles_k, tiles_n, tile_n, tile_k = source.data.shape
+        k = torch.arange(tiles_k * tile_k).reshape(1, tiles_k, 1, 1, tile_k)
+        n = torch.arange(tiles_n * tile_n).reshape(1, 1, tiles_n, tile_n, 1)
+        source.data.masked_fill_((k >= shape[-2] // 2) | (n >= shape[-1]), 0xAB)
+    else:
+        source.data[..., shape[-2] // 2:, :].fill_(0xAB)
     source_data = source.data.to(device)
     if step == 2:
         storage = torch.empty(tuple(2 * size for size in source_data.shape), dtype=torch.uint8, device=device)
-        source_view = storage[tuple(slice(None, None, 2) for _ in shape)]
+        source_view = storage[tuple(slice(None, None, 2) for _ in range(source_data.ndim))]
         source_view.copy_(source_data)
         source_data = source_view
     source = wrap_torch_tensor(source_data, dtype=FP4, shape=shape, layout=source.storage.layout)
@@ -570,7 +578,13 @@ def test_blackwell_fp4_shuffle_conversion(shape, tiles, step, with_out, device):
     if with_out:
         assert actual is out
     if device != "meta":
-        assert torch.equal(actual.data.cpu(), expected.data)
+        actual_data, expected_data = actual.data.cpu(), expected.data
+        if inverse:
+            actual_data = actual_data[..., :shape[-2] // 2, :]
+            expected_data = expected_data[..., :shape[-2] // 2, :]
+            if device == "cuda" and with_out:
+                assert torch.all(out.data[..., shape[-2] // 2:, :] == 0xCD)
+        assert torch.equal(actual_data, expected_data)
         assert torch.equal(convert_layout(actual, StridedLayout()).data.cpu(), data)
         if with_out:
             assert storage[0].item() == 0xCD
@@ -579,10 +593,12 @@ def test_blackwell_fp4_shuffle_conversion(shape, tiles, step, with_out, device):
 
 
 @pytest.mark.parametrize("with_out", [False, True])
-def test_blackwell_fp4_shuffle_peak_allocation(with_out):
+@pytest.mark.parametrize("inverse", [False, True])
+def test_blackwell_fp4_shuffle_peak_allocation(with_out, inverse):
     canonical = empty((8, 1024, 2048), dtype=FP4, device="cuda")
-    source = convert_layout(canonical, BlackwellMXValueLayout())
-    destination = BlackwellMX4ValueShuffledLayout()
+    plain, shuffled = BlackwellMXValueLayout(), BlackwellMX4ValueShuffledLayout()
+    source_layout, destination = (shuffled, plain) if inverse else (plain, shuffled)
+    source = convert_layout(canonical, source_layout)
     warm = convert_layout(source, destination)
     out = warm if with_out else None
     torch.cuda.synchronize()

--- a/python/triton_kernels/tests/test_tensor.py
+++ b/python/triton_kernels/tests/test_tensor.py
@@ -534,6 +534,69 @@ def test_mxfp4_value_convert_layout_meta(layout, major_dim, inverse):
     assert actual.device.type == "meta"
 
 
+@pytest.mark.parametrize("shape", [(256, 512), (130, 66), (2, 130, 66), (2, 3, 130, 66), (2, 1, 3, 130, 66),
+                                   (0, 130, 66)])
+@pytest.mark.parametrize("tiles", [(128, 256), (192, 48)])
+@pytest.mark.parametrize("step", [1, 2])
+@pytest.mark.parametrize("with_out", [False, True])
+@pytest.mark.parametrize("device", ["cpu", "meta", "cuda"])
+def test_blackwell_fp4_shuffle_conversion(shape, tiles, step, with_out, device):
+    data = torch.randint(0, 256, (*shape[:-1], shape[-1] // 2), dtype=torch.uint8,
+                         generator=torch.Generator().manual_seed(0))
+    canonical = wrap_torch_tensor(data, dtype=FP4)
+    source = convert_layout(canonical, BlackwellMXValueLayout())
+    destination = BlackwellMX4ValueShuffledLayout(*tiles)
+    expected = convert_layout(canonical, destination)
+    # Source padding is unspecified and must not leak into destination padding.
+    source.data[..., shape[-2] // 2:, :].fill_(0xAB)
+    source_data = source.data.to(device)
+    if step == 2:
+        storage = torch.empty(tuple(2 * size for size in source_data.shape), dtype=torch.uint8, device=device)
+        source_view = storage[tuple(slice(None, None, 2) for _ in shape)]
+        source_view.copy_(source_data)
+        source_data = source_view
+    source = wrap_torch_tensor(source_data, dtype=FP4, shape=shape, layout=source.storage.layout)
+    out = None
+    if with_out:
+        storage = torch.full((expected.data.numel() * step + 1, ), 0xCD, dtype=torch.uint8, device=device)
+        out_data = storage[1:].as_strided(expected.data.shape, tuple(step * s for s in expected.data.stride()))
+        out = wrap_torch_tensor(out_data, dtype=FP4, shape=shape, layout=destination)
+
+    actual = convert_layout(source, destination, out=out)
+
+    assert actual.shape == list(shape)
+    assert actual.data.shape == expected.data.shape
+    assert actual.data.dtype == expected.data.dtype
+    if with_out:
+        assert actual is out
+    if device != "meta":
+        assert torch.equal(actual.data.cpu(), expected.data)
+        assert torch.equal(convert_layout(actual, StridedLayout()).data.cpu(), data)
+        if with_out:
+            assert storage[0].item() == 0xCD
+            if step == 2:
+                assert torch.all(storage[2::2] == 0xCD)
+
+
+@pytest.mark.parametrize("with_out", [False, True])
+def test_blackwell_fp4_shuffle_peak_allocation(with_out):
+    canonical = empty((8, 1024, 2048), dtype=FP4, device="cuda")
+    source = convert_layout(canonical, BlackwellMXValueLayout())
+    destination = BlackwellMX4ValueShuffledLayout()
+    warm = convert_layout(source, destination)
+    out = warm if with_out else None
+    torch.cuda.synchronize()
+    del warm
+    baseline = torch.cuda.memory_allocated()
+    torch.cuda.reset_peak_memory_stats()
+
+    actual = convert_layout(source, destination, out=out)
+    torch.cuda.synchronize()
+    peak = torch.cuda.max_memory_allocated() - baseline
+
+    assert peak <= (0 if with_out else actual.data.nbytes) + 1024**2
+
+
 @pytest.mark.parametrize("layout", _FP4_VALUE_LAYOUTS)
 @pytest.mark.parametrize("inverse", [False, True])
 @pytest.mark.parametrize("major_dim", [-2, -1])

--- a/python/triton_kernels/triton_kernels/tensor_details/layout_details/blackwell_value_shuffled.py
+++ b/python/triton_kernels/triton_kernels/tensor_details/layout_details/blackwell_value_shuffled.py
@@ -7,7 +7,7 @@ import triton.language as tl
 
 from triton_kernels.tensor_details.layout_details import strided
 from .base import Layout, LayoutTransformation
-from .blackwell_value import BlackwellMXValueLayoutTransformation
+from .blackwell_value import BlackwellMXValueLayoutTransformation, strides_major_dim_m2
 from .torch_utils import repack
 
 
@@ -102,6 +102,14 @@ class BlackwellMX4ValueShuffledTransformation(LayoutTransformation):
         return self._convert_data(data, inverse=True, major_dim=-1)
 
     def convert_data(self, data, destination: LayoutTransformation, *, out=None):
+        if (isinstance(destination, BlackwellMXValueLayoutTransformation) and self.is_fp4 and data.device.type == "cuda"
+                and data.dtype == torch.uint8 and list(data.shape) == self.storage_shape):
+            if out is None:
+                out_shape = destination.storage_shape
+                out = torch.empty_strided(out_shape, strides_major_dim_m2(out_shape), device=data.device,
+                                          dtype=data.dtype)
+            # Only logical bytes are written; plain Blackwell padding is unspecified.
+            return self._convert_data(data, inverse=True, major_dim=len(self.shape) - 2, out=out)
         if (data.device.type != "cuda" or data.dtype != torch.uint8
                 or not isinstance(destination, strided.StridedLayoutTransformation)
                 or destination.order[0] < len(self.shape) - 2):

--- a/python/triton_kernels/triton_kernels/tensor_details/layout_details/blackwell_value_shuffled.py
+++ b/python/triton_kernels/triton_kernels/tensor_details/layout_details/blackwell_value_shuffled.py
@@ -7,6 +7,7 @@ import triton.language as tl
 
 from triton_kernels.tensor_details.layout_details import strided
 from .base import Layout, LayoutTransformation
+from .blackwell_value import BlackwellMXValueLayoutTransformation
 from .torch_utils import repack
 
 
@@ -108,6 +109,10 @@ class BlackwellMX4ValueShuffledTransformation(LayoutTransformation):
         return self._convert_data(data, inverse=True, major_dim=destination.order[0], out=out)
 
     def _convert_data_from(self, data, source: LayoutTransformation, *, out):
+        if (isinstance(source, BlackwellMXValueLayoutTransformation) and self.is_fp4 and data.device.type == "cuda"
+                and data.dtype == torch.uint8 and list(data.shape) == source.storage_shape):
+            # Blackwell values already pack K; only their physical tiling changes.
+            return self._convert_data(data, inverse=False, major_dim=len(self.shape) - 2, out=out)
         if (not isinstance(source, strided.StridedLayoutTransformation) or not self.is_fp4
                 or not source._can_convert_fp4(data)):
             return super()._convert_data_from(data, source, out=out)


### PR DESCRIPTION
## Summary

Converting packed 4-bit floating-point (FP4) values between `BlackwellMXValueLayout` and `BlackwellMX4ValueShuffledLayout` currently repacks bytes into canonical storage and then back into K-packed storage. Both layouts already pack the K dimension, so this intermediate adds memory traffic and a weight-sized allocation without changing the logical values.

Dispatch both directions through the shuffled layout's existing stride-aware conversion kernel with K packing enabled. The conversions copy packed bytes directly and support caller-provided `out` buffers and sliced storage. The forward direction ignores source padding and zeros shuffled destination padding. The direct reverse path writes only logical bytes; plain Blackwell padding remains unspecified, and padding in supplied output buffers is left untouched. Other inputs retain the existing fallback.

## Validation

Tested on NVIDIA GB300 GPUs on an aarch64 host with the installed Triton 3.8.0 compiler and this branch's `triton_kernels` sources.

```sh
PYTHONPATH=python/triton_kernels python -m pytest -s --tb=short python/triton_kernels/tests/test_tensor.py -k blackwell_fp4_shuffle
```

Regression coverage exercises both directions with ranks 2–5, aligned and padded shapes, alternate tile sizes, empty tensors, sliced input/output storage, CPU/meta/CUDA paths, byte equality over logical values, roundtrips, output-padding preservation, and peak allocation with and without `out`.

Additional standalone checks in both directions passed for 65,537 batches, input and output buffers larger than 2 GiB, a different current CUDA device, a nondefault stream, non-byte storage fallback, and fake CPU tensors. For an 8 MiB output, measured peak additional allocation fell from 16 MiB through canonical storage to 8 MiB through direct conversion in both directions.

Synthetic conversion benchmarks used `triton.testing.do_bench_cudagraph(rep=100)` on one GB300. Each baseline explicitly composes the source's `unswizzle_data` and destination's `swizzle_data` using the same compiler and source snapshot as its direct-conversion measurement. Logical output bytes matched the reference in every case. Improvement is canonical-path time divided by direct-conversion time.

### Plain → shuffled

| Logical shape `[batch, K, N]` | Canonical path | Direct conversion | Improvement |
| --- | ---: | ---: | ---: |
| `[4, 64, 64]` | 0.01775 ms | 0.00132 ms | 13.4x |
| `[8, 3072, 4096]` | 0.54885 ms | 0.01338 ms | 41.0x |
| `[16, 3072, 4096]` | 1.12805 ms | 0.03006 ms | 37.5x |
| `[64, 3072, 4096]` | 4.71011 ms | 0.11388 ms | 41.4x |
| `[256, 3072, 4096]` | 18.76957 ms | 0.44985 ms | 41.7x |
| `[2, 4096, 8192]` | 0.36042 ms | 0.00713 ms | 50.5x |
| `[16, 4096, 8192]` | 3.10246 ms | 0.07694 ms | 40.3x |
| `[64, 4096, 8192]` | 12.33963 ms | 0.30228 ms | 40.8x |
| `[256, 4096, 8192]` | 49.29435 ms | 1.20041 ms | 41.1x |

### Shuffled → plain

| Logical shape `[batch, K, N]` | Canonical path | Direct conversion | Improvement |
| --- | ---: | ---: | ---: |
| `[4, 64, 64]` | 0.01704 ms | 0.00114 ms | 14.9x |
| `[8, 3072, 4096]` | 0.53339 ms | 0.01195 ms | 44.6x |
| `[16, 3072, 4096]` | 1.09479 ms | 0.03044 ms | 36.0x |
| `[64, 3072, 4096]` | 4.56858 ms | 0.11555 ms | 39.5x |
| `[256, 3072, 4096]` | 18.18451 ms | 0.45454 ms | 40.0x |
| `[2, 4096, 8192]` | 0.36055 ms | 0.00710 ms | 50.8x |
| `[16, 4096, 8192]` | 3.05142 ms | 0.07799 ms | 39.1x |
| `[64, 4096, 8192]` | 12.13680 ms | 0.30443 ms | 39.9x |
| `[256, 4096, 8192]` | 48.43273 ms | 1.20905 ms | 40.1x |

These measure conversion GPU time; end-to-end model startup was not measured.

## Lines Changed

| Type | Added | Removed | Net |
| --- | ---: | ---: | ---: |
| Tests | 79 | 0 | 79 |
| Core Logic | 13 | 0 | 13 |
| AutoGenerated | 0 | 0 | 0 |
| Total | 92 | 0 | 92 |

## Reviewers Guide

- `python/triton_kernels/triton_kernels/tensor_details/layout_details/blackwell_value_shuffled.py`: direct conversion in both directions, reusing the existing kernel and allocating padded column-major storage for the reverse direction.
- `python/triton_kernels/tests/test_tensor.py`: conversion correctness, padding, and peak-allocation regression tests in both directions.
- No files are primarily movements.
