### PR TITLE
[AMD] Fix additive strides for overlapping register bases

### DIFF
--- a/lib/Tools/LayoutUtils.cpp
+++ b/lib/Tools/LayoutUtils.cpp
@@ -424,12 +424,32 @@ actionAdditiveStrides(const LinearLayout &layout, const LinearLayout addrLayout,
   blockBits |= getOutputBasisMask(addrLayout, addrInDims, addrOutDims[1]);
   SmallVector<size_t> front, back;
   auto layoutNamedBases = layout.getBases();
-  assert(layoutNamedBases.lookup(kReg).size() >= regBasisPerVec &&
+  const auto &regBases = layoutNamedBases.lookup(kReg);
+  assert(regBases.size() >= regBasisPerVec &&
          "layout must have at least log2(regsPerInst) register bases");
-  for (auto [idx, basis] : llvm::enumerate(layoutNamedBases.lookup(kReg))) {
-    bool isAdditive =
-        (basis[0] & offsetBits) == 0 && (basis[1] & blockBits) == 0;
-    if (idx < regBasisPerVec || isAdditive) {
+
+  // If a register basis overlaps the dynamic address, it must remain in the
+  // outer xor offset. Any other register basis that overlaps it must remain
+  // there as well; otherwise the inner loop would add two non-disjoint values.
+  // Compute this transitive closure before partitioning the register bases.
+  SmallVector<bool> isAdditive(regBases.size(), true);
+  bool changed = true;
+  while (changed) {
+    changed = false;
+    for (auto [idx, basis] : llvm::enumerate(regBases)) {
+      if (idx < regBasisPerVec || !isAdditive[idx])
+        continue;
+      if ((basis[0] & offsetBits) == 0 && (basis[1] & blockBits) == 0)
+        continue;
+      isAdditive[idx] = false;
+      offsetBits |= basis[0];
+      blockBits |= basis[1];
+      changed = true;
+    }
+  }
+
+  for (size_t idx = 0; idx < regBases.size(); ++idx) {
+    if (idx < regBasisPerVec || isAdditive[idx]) {
       front.push_back(idx);
     } else {
       back.push_back(idx);

--- a/unittest/Dialect/TritonGPU/SwizzleTest.cpp
+++ b/unittest/Dialect/TritonGPU/SwizzleTest.cpp
@@ -18,6 +18,7 @@
 using namespace mlir;
 using namespace mlir::triton;
 
+using mlir::triton::actionAdditiveStrides;
 using mlir::triton::gpu::bankConflictsLdSt;
 using mlir::triton::gpu::getVecBitwidthLdSt;
 using mlir::triton::gpu::LocalMemOpTile;
@@ -302,6 +303,58 @@ protected:
 };
 
 // ——— Tests ———
+
+TEST_F(SwizzleTest, AdditiveStridesRejectsTransitiveOverlap) {
+  auto kRegister = S("register");
+  auto kLane = S("lane");
+  auto kWarp = S("warp");
+  auto kBlock = S("block");
+  auto kOffset = S("offset");
+  SmallVector<std::pair<StringAttr, int32_t>> outDims = {{kOffset, 2048},
+                                                         {kBlock, 1}};
+
+  // The 0x510 basis overlaps the lane address at 0x10, so it must remain in
+  // the outer xor offset. The 0x100 basis must remain there too because it
+  // overlaps 0x510; moving it into the additive inner loop would incorrectly
+  // turn (base ^ 0x510) ^ 0x100 into (base ^ 0x510) + 0x100.
+  LinearLayout reps(
+      {{kRegister, {{1, 0}, {2, 0}, {4, 0}, {0x100, 0}, {0x510, 0}}},
+       {kLane, {{0x10, 0}}},
+       {kWarp, {}},
+       {kBlock, {}}},
+      outDims, /*requireSurjective=*/false);
+  LinearLayout addrLayout({{kLane, {{0x10, 0}}}, {kWarp, {}}, {kBlock, {}}},
+                          outDims, /*requireSurjective=*/false);
+
+  auto result = actionAdditiveStrides(reps, addrLayout, /*maskSpanOffsets=*/0,
+                                      /*maskSpanBlocks=*/0,
+                                      /*regsPerInst=*/8);
+  EXPECT_EQ(result.first, 8);
+}
+
+TEST_F(SwizzleTest, AdditiveStridesKeepsIndependentRegisterBases) {
+  auto kRegister = S("register");
+  auto kLane = S("lane");
+  auto kWarp = S("warp");
+  auto kBlock = S("block");
+  auto kOffset = S("offset");
+  SmallVector<std::pair<StringAttr, int32_t>> outDims = {{kOffset, 2048},
+                                                         {kBlock, 1}};
+
+  LinearLayout reps(
+      {{kRegister, {{1, 0}, {2, 0}, {4, 0}, {0x100, 0}, {0x500, 0}}},
+       {kLane, {{0x10, 0}}},
+       {kWarp, {}},
+       {kBlock, {}}},
+      outDims, /*requireSurjective=*/false);
+  LinearLayout addrLayout({{kLane, {{0x10, 0}}}, {kWarp, {}}, {kBlock, {}}},
+                          outDims, /*requireSurjective=*/false);
+
+  auto result = actionAdditiveStrides(reps, addrLayout, /*maskSpanOffsets=*/0,
+                                      /*maskSpanBlocks=*/0,
+                                      /*regsPerInst=*/8);
+  EXPECT_EQ(result.first, 32);
+}
 
 TEST_F(SwizzleTest, Test128x128Float8Transpose) {
   // 128x128 float8 matrix transpose


### PR DESCRIPTION
<!---
The core Triton is a small number of people, and we receive many PRs (thank
you!).  To help us review your code more quickly, **if you are a new
contributor (less than 3 PRs merged) we ask that you complete the following
tasks and include the filled-out checklist in your PR description.**

Complete the following tasks before sending your PR, and replace `[ ]` with
`[x]` to indicate you have done them.
-->

 Fix shared-memory address generation when a register basis classified as additive overlaps another register basis retained in the outer XOR offset.

  This issue was exposed by the following RDNA3 and RDNA3.5 Gluon failures:

  test_lowerings.py::test_convert_warp_local_layouts[dst_layout11-src_layout4-float16-32-32]
  test_lowerings.py::test_convert_warp_local_layouts[dst_layout11-src_layout4-float16-64-64]
  test_lowerings.py::test_convert_warp_local_layouts[dst_layout12-src_layout7-float16-32-32]
  test_lowerings.py::test_convert_warp_local_layouts[dst_layout11-src_layout7-float16-64-64]
  test_lowerings.py::test_convert_warp_local_layouts[dst_layout12-src_layout7-float16-64-64]

  actionAdditiveStrides previously checked register bases only against address bits contributed by lanes, warps, blocks, and affine offsets.

  A register basis could initially appear safe for addition but overlap another basis subsequently classified as part of the outer XOR offset. For the failing RDNA3 layout, the relevant register bases were 0x510 and 0x100:

  0x510 & 0x100 = 0x100

  The old classification could therefore transform:

  (base XOR 0x510) XOR 0x100

  into:

  (base XOR 0x510) + 0x100

  These expressions are not equivalent because the operands overlap:
  
  0x510 XOR 0x100 = 0x410
  0x510 +   0x100 = 0x610

  This produced incorrect LDS addresses.

In this fix I compute the transitive closure of non-additive register bases before partitioning them, starting with bits contributed by lanes, warps, blocks, and affine offsets and mark any overlapping register basis as non-additive then add all bits from that basis to the outer-address masks and repeat until no additional bases become non-additive.

  This keeps overlapping register contributions in the outer XOR calculation while preserving the additive optimization for disjoint bases.
# New contributor declaration
- [x] I am not making a trivial change, such as fixing a typo in a comment.

- [x] I have written a PR description following these
  [rules](https://cbea.ms/git-commit/#why-not-how).

- [x] I have run `pre-commit run --from-ref origin/main --to-ref HEAD`.

- Select one of the following.
  - [x] I have added tests.
    - `/test` for `lit` tests
    - `/unittest` for C++ tests
    - `/python/test` for end-to-end tests
  - [ ] This PR does not need a test because `FILL THIS IN`.

- Select one of the following.
  - [x] I have not added any `lit` tests.
  - [ ] The `lit` tests I have added follow these [best practices](https://mlir.llvm.org/getting_started/TestingGuide/#filecheck-best-practices),
    including the "tests should be minimal" section. (Usually running Python code
    and using the instructions it generates is not minimal.)
