### PR TITLE
[TUTORIALS] Fix fused attention backward arity

### DIFF
--- a/python/tutorials/06-fused-attention.py
+++ b/python/tutorials/06-fused-attention.py
@@ -615,7 +615,7 @@ class _attention(torch.autograd.Function):
             CAUSAL=ctx.causal,  #
         )
 
-        return dq, dk, dv, None, None, None, None
+        return dq, dk, dv, None, None, None
 
 
 attention = _attention.apply


### PR DESCRIPTION
## Why

`_attention.forward` has six differentiable or non-differentiable inputs after `ctx`, but `backward` returns seven entries. PyTorch requires one returned gradient per forward input. The extra trailing `None` is stale from an earlier forward signature and leaves the tutorial inconsistent with that contract.

This makes the return arity match the current forward signature and fixes #7666.

## Testing

- Parsed `python/tutorials/06-fused-attention.py` with Python AST.
- Verified that the forward input count and backward return count are both six.
- Ran `git diff --check`.

The GPU tutorial test was not run locally because PyTorch is not installed in this environment.

# New contributor declaration

- [x] I am not making a trivial comment-only change.
- [x] I have written a PR description following the project guidance.
- [ ] I have run `pre-commit run --from-ref origin/main --to-ref HEAD` (pre-commit is not installed locally).
- [x] This PR does not need a new test because the existing fused-attention integration test exercises the backward path; this change only removes a stale extra return entry that PyTorch currently tolerates.
- [x] I have not added any lit tests.