### PR TITLE
[Analysis] Gate the signed div/rem group rules on a non-negative dividend

### DIFF
--- a/include/triton/Analysis/AxisInfo.h
+++ b/include/triton/Analysis/AxisInfo.h
@@ -32,9 +32,12 @@ public:
       : AxisInfo(contiguity, divisibility, constancy, std::nullopt) {}
 
   AxisInfo(ArrayRef<int64_t> contiguity, ArrayRef<int64_t> divisibility,
-           ArrayRef<int64_t> constancy, std::optional<APInt> constantValue)
+           ArrayRef<int64_t> constancy, std::optional<APInt> constantValue,
+           bool nonNegative = false)
       : contiguity(contiguity), divisibility(divisibility),
-        constancy(constancy), constantValue(std::move(constantValue)) {
+        constancy(constancy), constantValue(std::move(constantValue)),
+        nonNegative(nonNegative || (this->constantValue &&
+                                    !this->constantValue->isNegative())) {
     assert(divisibility.size() == contiguity.size());
     assert(constancy.size() == contiguity.size());
     int64_t globalDivisibility = getGlobalDivisibility();
@@ -125,6 +128,14 @@ public:
 
   const std::optional<APInt> &getConstantValue() const { return constantValue; }
 
+  // Whether every element is known to be non-negative as a signed integer.
+  //
+  // Truncating division and remainder only respect the group structure that
+  // contiguity and divisibility describe when the dividend is non-negative:
+  // [-64, -63, ..., -33] / 32 is [-2, -1, ..., -1], not a constant group, and
+  // [-64, -63, ..., -33] % 32 is [0, -31, ..., -1], not a contiguous one.
+  bool isNonNegative() const { return nonNegative; }
+
   static void initPessimisticStateFromFunc(int argNumber,
                                            FunctionOpInterface funcOp,
                                            DimVectorT *contiguity,
@@ -140,7 +151,8 @@ public:
             (constantValue && other.constantValue &&
              constantValue->getBitWidth() ==
                  other.constantValue->getBitWidth() &&
-             *constantValue == *other.constantValue));
+             *constantValue == *other.constantValue)) &&
+           nonNegative == other.nonNegative;
   }
 
   static AxisInfo getPessimisticValueState(Value value);
@@ -163,6 +175,7 @@ public:
       os << *constantValue;
     else
       os << "<none>";
+    os << ", non_negative = " << (nonNegative ? "true" : "false");
   }
 
 private:
@@ -172,6 +185,9 @@ private:
 
   // Exact fixed-width integer scalar or splat bits, if known.
   std::optional<APInt> constantValue;
+
+  // Every element is >= 0 as a signed integer. Never set for pointers.
+  bool nonNegative = false;
 };
 
 class AxisInfoVisitor {
@@ -218,6 +234,13 @@ class AxisInfoAnalysis : public dataflow::SparseForwardDataFlowAnalysis<
 protected:
   AxisInfoVisitorList visitors;
 
+  // Values that an `llvm.intr.assume` in the entry block of their function
+  // proves non-negative. The entry block runs on every execution of the
+  // function, so the fact holds wherever the value is used.
+  DenseSet<Value> assumedNonNegative;
+
+  AxisInfo applyAssumptions(Value value, AxisInfo info) const;
+
   void setToEntryState(dataflow::Lattice<AxisInfo> *lattice) override;
 
   void visitNonControlFlowArguments(
@@ -233,6 +256,8 @@ public:
   AxisInfoAnalysis(DataFlowSolver &solver);
   using dataflow::SparseForwardDataFlowAnalysis<
       dataflow::Lattice<AxisInfo>>::getLatticeElement;
+
+  LogicalResult initialize(Operation *top) override;
 
   LogicalResult
   visitOperation(Operation *op,

--- a/lib/Analysis/AxisInfo.cpp
+++ b/lib/Analysis/AxisInfo.cpp
@@ -1,6 +1,7 @@
 #include "triton/Analysis/AxisInfo.h"
 #include "mlir/Analysis/DataFlowFramework.h"
 #include "mlir/Dialect/Arith/IR/Arith.h"
+#include "mlir/Dialect/LLVMIR/LLVMDialect.h"
 #include "mlir/Dialect/UB/IR/UBOps.h"
 #include "mlir/IR/Matchers.h"
 #include "triton/Dialect/Gluon/IR/Dialect.h"
@@ -311,6 +312,29 @@ int64_t getDivisibilityFromContiguity(const AxisInfo &lhs, const AxisInfo &rhs,
   }
 }
 
+// Whether `cmp` compares `subject` against a constant so that a true result
+// means `subject >= 0`: `x >= c` with `c >= 0`, `x > c` with `c >= -1`, and
+// the mirrored forms.
+bool provesNonNegative(arith::CmpIOp cmp, Value &subject) {
+  APInt bound;
+  bool boundOnRight = matchPattern(cmp.getRhs(), m_ConstantInt(&bound));
+  if (!boundOnRight && !matchPattern(cmp.getLhs(), m_ConstantInt(&bound)))
+    return false;
+  subject = boundOnRight ? cmp.getLhs() : cmp.getRhs();
+  switch (cmp.getPredicate()) {
+  case arith::CmpIPredicate::sge:
+    return boundOnRight && bound.isNonNegative();
+  case arith::CmpIPredicate::sgt:
+    return boundOnRight && (bound.isNonNegative() || bound.isAllOnes());
+  case arith::CmpIPredicate::sle:
+    return !boundOnRight && bound.isNonNegative();
+  case arith::CmpIPredicate::slt:
+    return !boundOnRight && (bound.isNonNegative() || bound.isAllOnes());
+  default:
+    return false;
+  }
+}
+
 // Base class for all operations
 template <typename OpTy> class AxisInfoVisitorImpl : public AxisInfoVisitor {
 public:
@@ -352,13 +376,19 @@ public:
       constancy.push_back(getConstancy(op, lhsInfo, rhsInfo, d));
       divisibility.push_back(getDivisibility(op, lhsInfo, rhsInfo, d));
     }
-    return AxisInfo(contiguity, divisibility, constancy);
+    return AxisInfo(contiguity, divisibility, constancy, std::nullopt,
+                    getNonNegative(op, lhsInfo, rhsInfo));
   }
 
 protected:
   virtual int64_t getContiguity(OpTy op, const AxisInfo &lhs,
                                 const AxisInfo &rhs, int dim) {
     return 1;
+  }
+
+  virtual bool getNonNegative(OpTy op, const AxisInfo &lhs,
+                              const AxisInfo &rhs) {
+    return false;
   }
 
   virtual int64_t getDivisibility(OpTy op, const AxisInfo &lhs,
@@ -383,8 +413,14 @@ public:
     const AxisInfo &info = operands[0]->getValue();
     // Exact casts are handled before the bound visitors. An unproven or poison
     // cast must not retain its operand's constant value.
+    bool nonNegative = info.isNonNegative();
+    // Zero extension clears the sign; truncation can set it.
+    if constexpr (std::is_same_v<OpTy, arith::ExtUIOp>)
+      nonNegative = true;
+    else if constexpr (std::is_same_v<OpTy, arith::TruncIOp>)
+      nonNegative = false;
     return AxisInfo(info.getContiguity(), info.getDivisibility(),
-                    info.getConstancy());
+                    info.getConstancy(), std::nullopt, nonNegative);
   }
 };
 
@@ -425,7 +461,8 @@ public:
       if (info.getContiguity(dim) > 1)
         divisibility[dim] = gcd(divisibility[dim], srcBytes);
     return AxisInfo(AxisInfo::DimVectorT(info.getRank(), 1), divisibility,
-                    info.getConstancy(), info.getConstantValue());
+                    info.getConstancy(), info.getConstantValue(),
+                    info.isNonNegative());
   }
 };
 
@@ -451,7 +488,7 @@ public:
     if (op.getOperand(0).getType() == op.getResult(0).getType())
       return info;
     return AxisInfo(info.getContiguity(), info.getDivisibility(),
-                    info.getConstancy());
+                    info.getConstancy(), std::nullopt, info.isNonNegative());
   }
 };
 
@@ -465,9 +502,25 @@ public:
               ArrayRef<const dataflow::Lattice<AxisInfo> *> operands) override {
     auto start = op.getStart();
     auto end = op.getEnd();
+    // The attribute is signless; read the sign from its signed value.
+    bool nonNegative = op.getStartAttr().getInt() >= 0;
     return AxisInfo(/*contiguity=*/{end - start},
                     /*divisibility=*/{highestPowOf2Divisor(start)},
-                    /*constancy=*/{1});
+                    /*constancy=*/{1}, std::nullopt, nonNegative);
+  }
+};
+
+// Program ids and grid sizes are non-negative scalars.
+template <typename OpTy>
+class ProgramIdOpAxisInfoVisitor final : public AxisInfoVisitorImpl<OpTy> {
+public:
+  using AxisInfoVisitorImpl<OpTy>::AxisInfoVisitorImpl;
+
+  AxisInfo
+  getAxisInfo(OpTy op,
+              ArrayRef<const dataflow::Lattice<AxisInfo> *> operands) override {
+    return AxisInfo(/*contiguity=*/{1}, /*divisibility=*/{1},
+                    /*constancy=*/{1}, std::nullopt, /*nonNegative=*/true);
   }
 };
 
@@ -586,6 +639,14 @@ private:
       }
     }
   }
+
+  bool getNonNegative(OpTy op, const AxisInfo &lhs,
+                      const AxisInfo &rhs) override {
+    // Like the rules above, this assumes the addition does not wrap.
+    if constexpr (std::is_same_v<OpTy, arith::AddIOp>)
+      return lhs.isNonNegative() && rhs.isNonNegative();
+    return false;
+  }
 };
 
 class MulIOpAxisInfoVisitor final : public BinaryOpVisitorImpl<arith::MulIOp> {
@@ -628,6 +689,11 @@ private:
     }
     return multiplyDivisor(lhsDivisibility, rhsDivisibility);
   }
+
+  bool getNonNegative(arith::MulIOp op, const AxisInfo &lhs,
+                      const AxisInfo &rhs) override {
+    return lhs.isNonNegative() && rhs.isNonNegative();
+  }
 };
 
 template <typename OpTy>
@@ -660,8 +726,12 @@ private:
     // the minimal constancy is gcd(d_lhs, d_rhs).
     // Since gcd(d_lhs, d_rhs) maybe > len(lhs),
     // we need to use another gcd to get the actual constancy.
+    // Signed division truncates toward zero, so a negative group splits at
+    // its first element: [-64, -63, ..., -33] / 32 = [-2, -1, ..., -1]. The
+    // rule needs a non-negative dividend.
     if (AxisInfoVisitor::isContiguousDim(lhs, shape, dim) &&
-        AxisInfoVisitor::isConstantDim(rhs, shape, dim)) {
+        AxisInfoVisitor::isConstantDim(rhs, shape, dim) &&
+        (std::is_same_v<OpTy, arith::DivUIOp> || lhs.isNonNegative())) {
       constancy = std::max(constancy,
                            gcd(lhs.getContiguity(dim), lhs.getDivisibility(dim),
                                rhs.getDivisibility(dim)));
@@ -691,6 +761,11 @@ private:
     // otherwise: return 1
     return 1;
   }
+
+  bool getNonNegative(OpTy op, const AxisInfo &lhs,
+                      const AxisInfo &rhs) override {
+    return lhs.isNonNegative() && rhs.isNonNegative();
+  }
 };
 
 template <typename OpTy>
@@ -715,8 +790,12 @@ private:
     // The minimal contiguity is gcd(d_lhs, d_rhs).
     // Since gcd(d_lhs, d_rhs) maybe > len(lhs),
     // we need to use another gcd to get the actual contiguity.
+    // The signed remainder of a negative group is not contiguous:
+    // [-64, -63, ..., -33] % 32 = [0, -31, ..., -1]. The rule needs a
+    // non-negative dividend.
     if (AxisInfoVisitor::isContiguousDim(lhs, shape, dim) &&
-        AxisInfoVisitor::isConstantDim(rhs, shape, dim)) {
+        AxisInfoVisitor::isConstantDim(rhs, shape, dim) &&
+        (std::is_same_v<OpTy, arith::RemUIOp> || lhs.isNonNegative())) {
       contiguity = gcd(lhs.getContiguity(dim), lhs.getDivisibility(dim),
                        rhs.getDivisibility(dim));
     }
@@ -734,6 +813,12 @@ private:
       divisibility = gcd(divisibility, contiguity);
     return divisibility;
   };
+
+  bool getNonNegative(OpTy op, const AxisInfo &lhs,
+                      const AxisInfo &rhs) override {
+    // The remainder takes the sign of the dividend.
+    return lhs.isNonNegative();
+  }
 };
 
 class SplatOpAxisInfoVisitor final
@@ -756,7 +841,7 @@ public:
       constancy.push_back(retTy.getShape()[d]);
     }
     return AxisInfo(contiguity, divisibility, constancy,
-                    operands[0]->getValue().getConstantValue());
+                    opInfo.getConstantValue(), opInfo.isNonNegative());
   }
 };
 
@@ -818,7 +903,8 @@ public:
     contiguity.insert(contiguity.begin() + op.getAxis(), 1);
     divisibility.insert(divisibility.begin() + op.getAxis(), newDivisibility);
     constancy.insert(constancy.begin() + op.getAxis(), 1);
-    return AxisInfo(contiguity, divisibility, constancy);
+    return AxisInfo(contiguity, divisibility, constancy, std::nullopt,
+                    opInfo.isNonNegative());
   }
 };
 
@@ -847,7 +933,7 @@ public:
                                           : opInfo.getConstancy(d));
     }
     return AxisInfo(contiguity, divisibility, constancy,
-                    operands[0]->getValue().getConstantValue());
+                    opInfo.getConstantValue(), opInfo.isNonNegative());
   }
 };
 
@@ -964,7 +1050,8 @@ public:
       }
     }
 
-    return AxisInfo(contiguity, divisibility, constancy);
+    return AxisInfo(contiguity, divisibility, constancy, std::nullopt,
+                    srcInfo.isNonNegative());
   }
 };
 
@@ -1090,7 +1177,24 @@ public:
               contiguity.back()));
     }
 
-    return AxisInfo(contiguity, divisibility, constancy);
+    return AxisInfo(contiguity, divisibility, constancy, std::nullopt,
+                    lhsInfo.isNonNegative() && rhsInfo.isNonNegative());
+  }
+};
+
+template <typename OpTy>
+class LogicalOpAxisInfoVisitor final : public BinaryOpVisitorImpl<OpTy> {
+public:
+  using BinaryOpVisitorImpl<OpTy>::BinaryOpVisitorImpl;
+
+private:
+  bool getNonNegative(OpTy op, const AxisInfo &lhs,
+                      const AxisInfo &rhs) override {
+    // A clear sign bit survives `and` from either side, `or` and `xor` only
+    // from both.
+    if constexpr (std::is_same_v<OpTy, arith::AndIOp>)
+      return lhs.isNonNegative() || rhs.isNonNegative();
+    return lhs.isNonNegative() && rhs.isNonNegative();
   }
 };
 
@@ -1151,6 +1255,18 @@ private:
     unsigned shift = amount->getLimitedValue(kMaxDivisorLog2);
     return std::max<int64_t>(1, lhsDivisibility >> shift);
   }
+
+  bool getNonNegative(OpTy op, const AxisInfo &lhs,
+                      const AxisInfo &rhs) override {
+    if constexpr (std::is_same_v<OpTy, arith::ShRUIOp>) {
+      // A logical shift by at least one bit clears the sign.
+      const auto &amount = rhs.getConstantValue();
+      if (amount && !amount->isZero() &&
+          amount->ult(getIntegerBitWidth(op.getType())))
+        return true;
+    }
+    return lhs.isNonNegative();
+  }
 };
 
 template <typename OpTy>
@@ -1161,7 +1277,19 @@ public:
   AxisInfo
   getAxisInfo(OpTy op,
               ArrayRef<const dataflow::Lattice<AxisInfo> *> operands) override {
-    return AxisInfo::join(operands[0]->getValue(), operands[1]->getValue());
+    const AxisInfo &lhs = operands[0]->getValue();
+    const AxisInfo &rhs = operands[1]->getValue();
+    AxisInfo info = AxisInfo::join(lhs, rhs);
+    // A signed maximum or an unsigned minimum is non-negative as soon as one
+    // operand is; a signed minimum or an unsigned maximum needs both.
+    bool nonNegative;
+    if constexpr (std::is_same_v<OpTy, arith::MaxSIOp> ||
+                  std::is_same_v<OpTy, arith::MinUIOp>)
+      nonNegative = lhs.isNonNegative() || rhs.isNonNegative();
+    else
+      nonNegative = lhs.isNonNegative() && rhs.isNonNegative();
+    return AxisInfo(info.getContiguity(), info.getDivisibility(),
+                    info.getConstancy(), info.getConstantValue(), nonNegative);
   }
 };
 
@@ -1190,7 +1318,7 @@ public:
     }
 
     return AxisInfo(contiguity, divisibility, constancy,
-                    srcInfo.getConstantValue());
+                    srcInfo.getConstantValue(), srcInfo.isNonNegative());
   }
 };
 
@@ -1215,6 +1343,8 @@ AxisInfoAnalysis::AxisInfoAnalysis(DataFlowSolver &solver)
                   BitcastOpAxisInfoVisitor,
                   IdentityOpAxisInfoVisitor<triton::gluon::SetAutoLayoutOp>>();
   visitors.append<MakeRangeOpAxisInfoVisitor>();
+  visitors.append<ProgramIdOpAxisInfoVisitor<triton::GetProgramIdOp>,
+                  ProgramIdOpAxisInfoVisitor<triton::GetNumProgramsOp>>();
   visitors.append<PoisonOpAxisInfoVisitor>();
   visitors.append<AddSubOpAxisInfoVisitor<triton::AddPtrOp>,
                   AddSubOpAxisInfoVisitor<arith::AddIOp>,
@@ -1229,9 +1359,9 @@ AxisInfoAnalysis::AxisInfoAnalysis(DataFlowSolver &solver)
   visitors.append<ExpandDimsOpAxisInfoVisitor>();
   visitors.append<ReshapeOpAxisInfoVisitor>();
   visitors.append<CmpOpAxisInfoVisitor<arith::CmpIOp>>();
-  visitors.append<BinaryOpVisitorImpl<arith::AndIOp>,
-                  BinaryOpVisitorImpl<arith::OrIOp>,
-                  BinaryOpVisitorImpl<arith::XOrIOp>>();
+  visitors.append<LogicalOpAxisInfoVisitor<arith::AndIOp>,
+                  LogicalOpAxisInfoVisitor<arith::OrIOp>,
+                  LogicalOpAxisInfoVisitor<arith::XOrIOp>>();
   visitors.append<SelectOpAxisInfoVisitor<mlir::arith::SelectOp>>();
   visitors.append<ShLIOpAxisInfoVisitor, ShROpAxisInfoVisitor<arith::ShRUIOp>,
                   ShROpAxisInfoVisitor<arith::ShRSIOp>>();
@@ -1243,9 +1373,34 @@ AxisInfoAnalysis::AxisInfoAnalysis(DataFlowSolver &solver)
   visitors.append<TransOpAxisInfoVisitor>();
 }
 
+LogicalResult AxisInfoAnalysis::initialize(Operation *top) {
+  top->walk([&](LLVM::AssumeOp assume) {
+    auto func = assume->getParentOfType<FunctionOpInterface>();
+    if (!func || func.getFunctionBody().empty() ||
+        assume->getBlock() != &func.getFunctionBody().front())
+      return;
+    auto cmp = assume.getCond().getDefiningOp<arith::CmpIOp>();
+    Value subject;
+    if (cmp && provesNonNegative(cmp, subject))
+      assumedNonNegative.insert(subject);
+  });
+  return dataflow::SparseForwardDataFlowAnalysis<
+      dataflow::Lattice<AxisInfo>>::initialize(top);
+}
+
+AxisInfo AxisInfoAnalysis::applyAssumptions(Value value, AxisInfo info) const {
+  if (info.isNonNegative() || !assumedNonNegative.contains(value))
+    return info;
+  return AxisInfo(info.getContiguity(), info.getDivisibility(),
+                  info.getConstancy(), info.getConstantValue(),
+                  /*nonNegative=*/true);
+}
+
 void AxisInfoAnalysis::setToEntryState(dataflow::Lattice<AxisInfo> *lattice) {
-  propagateIfChanged(lattice, lattice->join(AxisInfo::getPessimisticValueState(
-                                  lattice->getAnchor())));
+  Value value = lattice->getAnchor();
+  propagateIfChanged(lattice,
+                     lattice->join(applyAssumptions(
+                         value, AxisInfo::getPessimisticValueState(value))));
 }
 
 void AxisInfoAnalysis::visitNonControlFlowArguments(
@@ -1283,8 +1438,9 @@ LogicalResult AxisInfoAnalysis::visitOperation(
         curr = AxisInfo::getConstantValueState(op->getResult(0).getType(),
                                                *constant);
       } else {
-        curr = AxisInfo(curr.getContiguity(), curr.getDivisibility(),
-                        curr.getConstancy());
+        curr =
+            AxisInfo(curr.getContiguity(), curr.getDivisibility(),
+                     curr.getConstancy(), std::nullopt, curr.isNonNegative());
       }
     }
   }
@@ -1303,10 +1459,11 @@ LogicalResult AxisInfoAnalysis::visitOperation(
   AxisInfo::initDimVectorFromHint(op->getDiscardableAttr("tt.constancy"),
                                   &newConstancy);
   curr = AxisInfo(newContiguity, newDivisibility, newConstancy,
-                  curr.getConstantValue());
+                  curr.getConstantValue(), curr.isNonNegative());
   // join all lattice elements
   for (auto *result : results)
-    propagateIfChanged(result, result->join(curr));
+    propagateIfChanged(
+        result, result->join(applyAssumptions(result->getAnchor(), curr)));
   return success();
 }
 
@@ -1326,8 +1483,10 @@ void AxisInfoAnalysis::visitForOpInductionVar(
   AxisInfo::DimVectorT knownConstancy(1, 1);
   knownDivisibility[0] = gcd(lbLattice->getValue().getDivisibility(0),
                              stepLattice->getValue().getDivisibility(0));
-  auto inductionVar =
-      AxisInfo(knownContiguity, knownDivisibility, knownConstancy);
+  bool nonNegative = lbLattice->getValue().isNonNegative() &&
+                     stepLattice->getValue().isNonNegative();
+  auto inductionVar = AxisInfo(knownContiguity, knownDivisibility,
+                               knownConstancy, std::nullopt, nonNegative);
   (void)argLattices[0]->join(inductionVar);
 }
 
@@ -1430,8 +1589,8 @@ void AxisInfo::initDimVectorFromHint(Attribute attr, DimVectorT *vec) {
       lhsConstant->getBitWidth() == rhsConstant->getBitWidth() &&
       *lhsConstant == *rhsConstant)
     constantValue = lhsConstant;
-  return AxisInfo(contiguity, divisibility, constancy,
-                  std::move(constantValue));
+  return AxisInfo(contiguity, divisibility, constancy, std::move(constantValue),
+                  lhs.isNonNegative() && rhs.isNonNegative());
 }
 
 AxisInfoAnalysis *

--- a/python/test/unit/language/test_core.py
+++ b/python/test/unit/language/test_core.py
@@ -552,6 +552,36 @@ def test_floordiv(dtype_x, dtype_y, num_ctas, device):
     _test_binary(dtype_x, dtype_y, expr, numpy_expr, filter_y=filter_y, device=device, num_ctas=num_ctas)
 
 
+@pytest.mark.interpreter
+@pytest.mark.parametrize("op", ["//", "%"])
+def test_signed_div_rem_negative_run(op, device):
+    # The alignment analysis used to keep the group structure of a contiguous
+    # run through a signed division or remainder without knowing the sign of
+    # the run. On `offs - 64` the lowering then deduplicated `//` results and
+    # vectorized loads at `x + r` across elements the source never grouped.
+    N = 128
+    SHIFT = 64
+    DIV = 32
+
+    @triton.jit
+    def kernel(x_ptr, out_ptr, N: tl.constexpr, SHIFT: tl.constexpr, DIV: tl.constexpr, op: tl.constexpr):
+        offs = tl.arange(0, N)
+        x = offs - SHIFT
+        if op == "//":
+            v = x // DIV
+        else:
+            v = tl.load(x_ptr + (x % DIV))
+        tl.store(out_ptr + offs, v)
+
+    # x[SHIFT + i] == i, so x_ptr + r reads back r for -SHIFT <= r < N.
+    x = torch.arange(-SHIFT, N, dtype=torch.int32, device=device)
+    out = torch.full((N, ), 12345, dtype=torch.int32, device=device)
+    kernel[(1, )](x[SHIFT:], out, N=N, SHIFT=SHIFT, DIV=DIV, op=op, num_warps=1)
+    offs = np.arange(N, dtype=np.int64) - SHIFT
+    ref = np.trunc(offs / DIV) if op == "//" else np.fmod(offs, DIV)
+    np.testing.assert_equal(to_numpy(out), ref.astype(np.int32))
+
+
 def test_unsigned_name_mangling(device):
     # Test that uint32 and int32 are mangled differently by the compiler
     SIZE = 128

--- a/test/Analysis/test-alignment.mlir
+++ b/test/Analysis/test-alignment.mlir
@@ -1544,3 +1544,155 @@ tt.func @negative_constants() {
   %sum = arith.addi %neg8_dense, %sixteen : tensor<128xi32>
   tt.return
 }
+
+// -----
+
+// Signed division and remainder only keep the group structure of a
+// non-negative dividend (#7749).
+tt.func @signed_div_rem_negative_run() {
+  // expected-remark @below {{contiguity = [128], divisibility = [1073741824], constancy = [1], constant_value = <none>, non_negative = true}}
+  %0 = tt.make_range {end = 128 : i32, start = 0 : i32} : tensor<128xi32>
+  // expected-remark @below {{contiguity = [1], divisibility = [64], constancy = [128], constant_value = 64, non_negative = true}}
+  %c64 = arith.constant dense<64> : tensor<128xi32>
+  // expected-remark @below {{contiguity = [1], divisibility = [32], constancy = [128], constant_value = 32, non_negative = true}}
+  %c32 = arith.constant dense<32> : tensor<128xi32>
+  // expected-remark @below {{contiguity = [128], divisibility = [64], constancy = [1], constant_value = <none>, non_negative = false}}
+  %1 = arith.subi %0, %c64 : tensor<128xi32>
+  // [-64, -63, ..., 63] / 32 = [-2, -1, ..., -1, -1, 0, ..., 0, 1, ..., 1]
+  // expected-remark @below {{contiguity = [1], divisibility = [1], constancy = [1], constant_value = <none>, non_negative = false}}
+  %2 = arith.divsi %1, %c32 : tensor<128xi32>
+  // [-64, -63, ..., 63] % 32 = [0, -31, ..., -1, 0, -31, ..., -1, 0, 1, ..., 31]
+  // expected-remark @below {{contiguity = [1], divisibility = [1], constancy = [1], constant_value = <none>, non_negative = false}}
+  %3 = arith.remsi %1, %c32 : tensor<128xi32>
+  // expected-remark @below {{contiguity = [128], divisibility = [64], constancy = [1], constant_value = <none>, non_negative = true}}
+  %4 = arith.addi %0, %c64 : tensor<128xi32>
+  // expected-remark @below {{contiguity = [1], divisibility = [1], constancy = [32], constant_value = <none>, non_negative = true}}
+  %5 = arith.divsi %4, %c32 : tensor<128xi32>
+  // expected-remark @below {{contiguity = [32], divisibility = [32], constancy = [1], constant_value = <none>, non_negative = true}}
+  %6 = arith.remsi %4, %c32 : tensor<128xi32>
+  // The unsigned operations never split a group.
+  // expected-remark @below {{contiguity = [1], divisibility = [1], constancy = [32], constant_value = <none>, non_negative = false}}
+  %7 = arith.divui %1, %c32 : tensor<128xi32>
+  // expected-remark @below {{contiguity = [32], divisibility = [32], constancy = [1], constant_value = <none>, non_negative = false}}
+  %8 = arith.remui %1, %c32 : tensor<128xi32>
+  // A range that starts below zero is the same negative run.
+  // expected-remark @below {{contiguity = [128], divisibility = [64], constancy = [1], constant_value = <none>, non_negative = false}}
+  %9 = tt.make_range {end = 64 : i32, start = -64 : i32} : tensor<128xi32>
+  // expected-remark @below {{contiguity = [1], divisibility = [1], constancy = [1], constant_value = <none>, non_negative = false}}
+  %10 = arith.divsi %9, %c32 : tensor<128xi32>
+  tt.return
+}
+
+// -----
+
+tt.func @program_id_offsets() {
+  // expected-remark @below {{contiguity = [1], divisibility = [1], constancy = [1], constant_value = <none>, non_negative = true}}
+  %pid = tt.get_program_id x : i32
+  // expected-remark @below {{contiguity = [1], divisibility = [128], constancy = [1], constant_value = 128, non_negative = true}}
+  %c128 = arith.constant 128 : i32
+  // expected-remark @below {{contiguity = [1], divisibility = [128], constancy = [1], constant_value = <none>, non_negative = true}}
+  %start = arith.muli %pid, %c128 : i32
+  // expected-remark @below {{contiguity = [1], divisibility = [128], constancy = [128], constant_value = <none>, non_negative = true}}
+  %splat = tt.splat %start : i32 -> tensor<128xi32>
+  %range = tt.make_range {end = 128 : i32, start = 0 : i32} : tensor<128xi32>
+  // expected-remark @below {{contiguity = [128], divisibility = [128], constancy = [1], constant_value = <none>, non_negative = true}}
+  %offs = arith.addi %splat, %range : tensor<128xi32>
+  %c4 = arith.constant dense<4> : tensor<128xi32>
+  // expected-remark @below {{contiguity = [1], divisibility = [1], constancy = [4], constant_value = <none>, non_negative = true}}
+  %q = arith.divsi %offs, %c4 : tensor<128xi32>
+  // expected-remark @below {{contiguity = [4], divisibility = [4], constancy = [1], constant_value = <none>, non_negative = true}}
+  %r = arith.remsi %offs, %c4 : tensor<128xi32>
+  tt.return
+}
+
+// -----
+
+tt.func @loop_offsets(%n: i32) {
+  %c0 = arith.constant 0 : i32
+  %c4 = arith.constant 4 : i32
+  %range = tt.make_range {end = 128 : i32, start = 0 : i32} : tensor<128xi32>
+  %c4_tensor = arith.constant dense<4> : tensor<128xi32>
+  scf.for %i = %c0 to %n step %c4 : i32 {
+    // expected-remark @below {{contiguity = [1], divisibility = [4], constancy = [128], constant_value = <none>, non_negative = true}}
+    %s = tt.splat %i : i32 -> tensor<128xi32>
+    // expected-remark @below {{contiguity = [128], divisibility = [4], constancy = [1], constant_value = <none>, non_negative = true}}
+    %offs = arith.addi %s, %range : tensor<128xi32>
+    // expected-remark @below {{contiguity = [1], divisibility = [1], constancy = [4], constant_value = <none>, non_negative = true}}
+    %q = arith.divsi %offs, %c4_tensor : tensor<128xi32>
+  }
+  tt.return
+}
+
+// -----
+
+tt.func @sign_through_casts_and_bits(%arg0: i32) {
+  %range = tt.make_range {end = 128 : i32, start = 0 : i32} : tensor<128xi32>
+  %c0 = arith.constant dense<0> : tensor<128xi32>
+  %splat = tt.splat %arg0 : i32 -> tensor<128xi32>
+  // expected-remark @below {{contiguity = [1], divisibility = [1], constancy = [128], constant_value = <none>, non_negative = false}}
+  %arg_tensor = arith.addi %splat, %c0 : tensor<128xi32>
+  // expected-remark @below {{contiguity = [1], divisibility = [1], constancy = [1], constant_value = <none>, non_negative = true}}
+  %and = arith.andi %arg_tensor, %range : tensor<128xi32>
+  // expected-remark @below {{contiguity = [1], divisibility = [1], constancy = [1], constant_value = <none>, non_negative = false}}
+  %or = arith.ori %arg_tensor, %range : tensor<128xi32>
+  // expected-remark @below {{contiguity = [1], divisibility = [1], constancy = [1], constant_value = <none>, non_negative = true}}
+  %max = arith.maxsi %arg_tensor, %range : tensor<128xi32>
+  // expected-remark @below {{contiguity = [1], divisibility = [1], constancy = [1], constant_value = <none>, non_negative = false}}
+  %min = arith.minsi %arg_tensor, %range : tensor<128xi32>
+  // expected-remark @below {{contiguity = [128], divisibility = [1073741824], constancy = [1], constant_value = <none>, non_negative = true}}
+  %ext = arith.extsi %range : tensor<128xi32> to tensor<128xi64>
+  // expected-remark @below {{contiguity = [1], divisibility = [1], constancy = [128], constant_value = <none>, non_negative = true}}
+  %zext = arith.extui %arg_tensor : tensor<128xi32> to tensor<128xi64>
+  // expected-remark @below {{contiguity = [128], divisibility = [1073741824], constancy = [1], constant_value = <none>, non_negative = false}}
+  %trunc = arith.trunci %range : tensor<128xi32> to tensor<128xi8>
+  tt.return
+}
+
+// -----
+
+// An `llvm.intr.assume` in the entry block holds on every execution of the
+// function, so its non-negativity facts apply wherever the value is used.
+tt.func @assume_non_negative(%n: i32 {tt.divisibility = 16 : i32}, %m: i32 {tt.divisibility = 16 : i32}, %k: i32 {tt.divisibility = 16 : i32}) {
+  %c0 = arith.constant 0 : i32
+  %n_nonneg = arith.cmpi sge, %n, %c0 : i32
+  llvm.intr.assume %n_nonneg : i1
+  %m_pos = arith.cmpi slt, %c0, %m : i32
+  llvm.intr.assume %m_pos : i1
+  %range = tt.make_range {end = 128 : i32, start = 0 : i32} : tensor<128xi32>
+  // expected-remark @below {{contiguity = [1], divisibility = [16], constancy = [128], constant_value = <none>, non_negative = true}}
+  %n_splat = tt.splat %n : i32 -> tensor<128xi32>
+  // expected-remark @below {{contiguity = [128], divisibility = [16], constancy = [1], constant_value = <none>, non_negative = true}}
+  %n_offs = arith.addi %n_splat, %range : tensor<128xi32>
+  // expected-remark @below {{contiguity = [1], divisibility = [16], constancy = [128], constant_value = <none>, non_negative = true}}
+  %m_splat = tt.splat %m : i32 -> tensor<128xi32>
+  // expected-remark @below {{contiguity = [16], divisibility = [16], constancy = [1], constant_value = <none>, non_negative = true}}
+  %n_rem = arith.remsi %n_offs, %m_splat : tensor<128xi32>
+  // Without the assumption the same shape keeps nothing.
+  // expected-remark @below {{contiguity = [1], divisibility = [16], constancy = [128], constant_value = <none>, non_negative = false}}
+  %k_splat = tt.splat %k : i32 -> tensor<128xi32>
+  // expected-remark @below {{contiguity = [128], divisibility = [16], constancy = [1], constant_value = <none>, non_negative = false}}
+  %k_offs = arith.addi %k_splat, %range : tensor<128xi32>
+  // expected-remark @below {{contiguity = [1], divisibility = [1], constancy = [1], constant_value = <none>, non_negative = false}}
+  %k_rem = arith.remsi %k_offs, %m_splat : tensor<128xi32>
+  // The assumption can also be about a value the function computes.
+  %pid = tt.get_program_id x : i32
+  // expected-remark @below {{contiguity = [1], divisibility = [1], constancy = [1], constant_value = <none>, non_negative = true}}
+  %pid_n = arith.divsi %pid, %k : i32
+  %pid_n_nonneg = arith.cmpi sge, %pid_n, %c0 : i32
+  llvm.intr.assume %pid_n_nonneg : i1
+  tt.return
+}
+
+// -----
+
+// Assumptions outside the entry block are not used.
+tt.func @assume_in_branch(%n: i32, %flag: i1) {
+  %c0 = arith.constant 0 : i32
+  scf.if %flag {
+    %n_nonneg = arith.cmpi sge, %n, %c0 : i32
+    llvm.intr.assume %n_nonneg : i1
+  }
+  // expected-remark @below {{contiguity = [1], divisibility = [1], constancy = [128], constant_value = <none>, non_negative = false}}
+  %n_splat = tt.splat %n : i32 -> tensor<128xi32>
+  tt.return
+}

--- a/test/TritonGPU/loop-pipeline-hip.mlir
+++ b/test/TritonGPU/loop-pipeline-hip.mlir
@@ -485,6 +485,10 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 8 : i32, ttg.targ
     %c1_i32 = arith.constant 1 : i32
     %c0_i32 = arith.constant 0 : i32
     %cst_1 = arith.constant dense<0.000000e+00> : tensor<64x64xf32, #mma>
+    // The block index is non-negative, as tl.assume states it in the tutorial;
+    // the signed remainder below keeps its contiguity only with that fact.
+    %arg1_nonneg = arith.cmpi sge, %arg1, %c0_i32 : i32
+    llvm.intr.assume %arg1_nonneg : i1
     %0 = tt.make_range {end = 64 : i32, start = 0 : i32} : tensor<64xi32, #ttg.slice<{dim = 0, parent = #blocked1}>>
     %1 = arith.muli %arg1, %c64_i32 : i32
     %2 = tt.splat %1 : i32 -> tensor<64xi32, #ttg.slice<{dim = 0, parent = #blocked1}>>

--- a/third_party/amd/lib/Analysis/AxisInfoExt.cpp
+++ b/third_party/amd/lib/Analysis/AxisInfoExt.cpp
@@ -51,7 +51,8 @@ public:
       newConst = std::min(newConst, outputShape[dim]);
       newConstancy.push_back(newConst);
     }
-    return AxisInfo(newContiguity, newDivisibility, newConstancy, constant);
+    return AxisInfo(newContiguity, newDivisibility, newConstancy, constant,
+                    srcInfo.isNonNegative());
   }
 
   virtual bool match(Operation *op) final {


### PR DESCRIPTION
`arith.divsi` and `arith.remsi` of a contiguous run are given the group structure of a non-negative run: `(arange(0, 128) - 64) // 32` gets constancy 32 and `(arange(0, 128) - 64) % 32` contiguity 32, but truncation splits every negative group at its first element (`[-64, ..., -33] / 32 = [-2, -1, ..., -1]`). The lowering consumes both, `maybeDeduplicate` on the quotient and `ld.global.v4` on `x_ptr + r`: six wrong elements each on an H100, from kernels with no hints and no overflow.

This adds a `nonNegative` bit to `AxisInfo`, set by `make_range`, `get_program_id` and constants, kept by the arithmetic that preserves it and by the induction variable of a loop whose bound and step have it, joined with `and`. The signed div/rem rules require it on the dividend; `divui`/`remui` are unchanged.

The pattern that needs the sign and cannot prove it is `pid_n = pid // num_pid_n` with `num_pid_n` from a runtime argument, then `(pid_n * BLOCK + arange) % N`. The matmul tutorial already states `tl.assume(pid_n >= 0)`, so the analysis reads `llvm.intr.assume` in the entry block (`x >= c` with `c >= 0`, and the mirrored forms) as a fact about `x`; `loop-pipeline-hip.mlir` gets the same assumption on its block index. Same IR through both builds: no claim moves on the 18,473 kernels of `test_core.py` (376,880 values); on the 297 lit files, 26 values move, all in that HIP test, downstream of its three remainders.

The gated rules went through the sweep that found #11544 (sampled abstract inputs at n <= 32 and i8/i16/i32, plus an exact z3 tier at i8) with no counterexample left. The two kernels are a regression test in `test_core.py` and pass on H100.

A range analysis is the longer-term answer, as said on #11546. The bit is the part of one these two rules need; if the AMD `TritonIntegerRangeAnalysis` moves out of `third_party`, it can become the source of the bit and the gates stay.

Fixes #7749.
