### PR TITLE
[AMD] Remove ISA family gate on `readfirstlane` in `warp_id` lowering

### DIFF
--- a/test/Conversion/amd/warp_id_to_llvm.mlir
+++ b/test/Conversion/amd/warp_id_to_llvm.mlir
@@ -1,21 +1,23 @@
-// RUN: triton-opt %s -split-input-file --convert-triton-amdgpu-to-llvm=gfx-arch=gfx942  | FileCheck %s --check-prefixes=CHECK,GFX9
-// RUN: triton-opt %s -split-input-file --convert-triton-amdgpu-to-llvm=gfx-arch=gfx950  | FileCheck %s --check-prefixes=CHECK,GFX9
-// RUN: triton-opt %s -split-input-file --convert-triton-amdgpu-to-llvm=gfx-arch=gfx1200 | FileCheck %s --check-prefixes=CHECK,GFX12
-// RUN: triton-opt %s -split-input-file --convert-triton-amdgpu-to-llvm=gfx-arch=gfx1250 | FileCheck %s --check-prefixes=CHECK,GFX12
+// RUN: triton-opt %s -split-input-file --convert-triton-amdgpu-to-llvm=gfx-arch=gfx90a  | FileCheck %s --check-prefixes=CHECK,ARITH
+// RUN: triton-opt %s -split-input-file --convert-triton-amdgpu-to-llvm=gfx-arch=gfx942  | FileCheck %s --check-prefixes=CHECK,ARITH
+// RUN: triton-opt %s -split-input-file --convert-triton-amdgpu-to-llvm=gfx-arch=gfx950  | FileCheck %s --check-prefixes=CHECK,ARITH
+// RUN: triton-opt %s -split-input-file --convert-triton-amdgpu-to-llvm=gfx-arch=gfx1100 | FileCheck %s --check-prefixes=CHECK,ARITH
+// RUN: triton-opt %s -split-input-file --convert-triton-amdgpu-to-llvm=gfx-arch=gfx1200 | FileCheck %s --check-prefixes=CHECK,WAVEID
+// RUN: triton-opt %s -split-input-file --convert-triton-amdgpu-to-llvm=gfx-arch=gfx1250 | FileCheck %s --check-prefixes=CHECK,WAVEID
 
 module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 1 : i32, ttg.shared = 0 : i32, "ttg.threads-per-warp" = 64 : i32} {
 
 // CHECK-LABEL: @wave_id
 tt.func public @wave_id() {
-  //       GFX9: %[[C64:.+]] = llvm.mlir.constant(64 : i32) : i32
-  //  GFX9-NEXT: %[[IDX:.+]] = rocdl.workitem.id.x : i32
-  //  GFX9-NEXT: %[[C63:.+]] = llvm.mlir.constant(63 : i32) : i32
-  //  GFX9-NEXT: %[[AND:.+]] = llvm.and %[[IDX]], %[[C63]] : i32
-  //  GFX9-NEXT: %[[DIV:.+]] = llvm.udiv %[[AND]], %[[C64]] : i32
-  //  GFX9-NEXT: %{{.+}} = rocdl.readfirstlane %[[DIV]] : i32
+  //       ARITH: %[[C64:.+]] = llvm.mlir.constant(64 : i32) : i32
+  //  ARITH-NEXT: %[[IDX:.+]] = rocdl.workitem.id.x : i32
+  //  ARITH-NEXT: %[[C63:.+]] = llvm.mlir.constant(63 : i32) : i32
+  //  ARITH-NEXT: %[[AND:.+]] = llvm.and %[[IDX]], %[[C63]] : i32
+  //  ARITH-NEXT: %[[DIV:.+]] = llvm.udiv %[[AND]], %[[C64]] : i32
+  //  ARITH-NEXT: %{{.+}} = rocdl.readfirstlane %[[DIV]] : i32
 
-  // GFX12-NEXT: rocdl.wave.id
-  //      CHECK: scf.for
+  // WAVEID-NEXT: rocdl.wave.id
+  //       CHECK: scf.for
 
   %c0 = arith.constant 0 : index
   %c1 = arith.constant 1 : index

--- a/third_party/amd/lib/TritonAMDGPUToLLVM/WarpIdOpToLLVM.cpp
+++ b/third_party/amd/lib/TritonAMDGPUToLLVM/WarpIdOpToLLVM.cpp
@@ -11,7 +11,6 @@
 using namespace mlir;
 using namespace mlir::triton;
 using namespace mlir::triton::gpu;
-using triton::amdgpu::ISAFamily;
 
 namespace {
 
@@ -48,21 +47,15 @@ public:
       Value warpSizeVal = b.i32_val(threadsPerWarp);
       Value tid = getThreadId(rewriter, loc);
       warpId = b.udiv(tid, warpSizeVal);
-      auto isaFamily = targetInfo.getISAFamily();
-      if (ISAFamily::CDNA3 == isaFamily || ISAFamily::CDNA4 == isaFamily) {
-        // On GFX9, there is no dedicated hardware instruction to read
-        // `wave_id`. The value is instead computed from `workitem.id.x`. Per
-        // the GFX9 ABI, `workitem.id.x` is initialized in a vector register,
-        // and vector instructions are generated for IR operations that depend
-        // on `wave_id`.
-        //
-        // A `v_readfirstlane` instruction is inserted at the end of these
-        // vector sequences to transfer the value from a vector register to a
-        // scalar register, initializing `$m0`.
-        auto call =
-            ROCDL::ReadfirstlaneOp::create(rewriter, loc, {i32_ty}, warpId);
-        warpId = call.getRes();
-      }
+
+      // `warpId` is derived from the thread id, so LLVM's uniformity analysis
+      // conservatively treats it as divergent even though every lane in a wave
+      // computes the same value. `v_readfirstlane` moves it into an SGPR and
+      // lets LLVM propagate uniformity to dependent ops, selecting SALU/SGPRs
+      // instead of VALU/VGPRs.
+      auto call =
+          ROCDL::ReadfirstlaneOp::create(rewriter, loc, {i32_ty}, warpId);
+      warpId = call.getRes();
     }
 
     if (startWarpId) {


### PR DESCRIPTION
Triton currently lowers `ttg.warp_id` in 3 different ways, depending on ISAFamily

1. With `rocdl.wave.id` instruction when supportsWaveId() (RDNA4/GFX1250) only
2. With `v_readfirstlane` wrapped around the udiv for CDNA3/CDNA4
3. With a plain `udiv` otherwise

The 2nd lowering allows LLVM's uniformity analysis to understand better when data is warp uniform, therefore generating more efficient code. However it's currently gated to CDNA3/CDNA4 for the wrong reason, missing performance optimization opportunities.

This ISAFamily gate was introduced in https://github.com/triton-lang/triton/pull/8601 where the `readfirstlane` was added inside `DirectToLdsLoadConversionBase::lowerDirectToLDSLoad`, and the original comment justified it as "initializing $m0" (a direct-to-LDS concern) with CDNA3/CDNA4 being exactly the direct-to-LDS-capable families at the time. Later, this check was moved in https://github.com/triton-lang/triton/pull/8659 from direct-to-LDS related code to WarpIdOpToLLVM.cpp, which is unrelated and where direct-to-LDS restriction does not apply, yet the gate was kept. This PR simply deletes this gate.

The `readfirstlane` instruction is supported in all archs since gfx6. Also note that `ROCDL::ReadfirstlaneOp` has no arch target predicate, so removing this gate is safe.

By removing this gate, we have seen solid performance improvements (~10%) in our end on archs that fall outside this ISAFamily gate

