### PR TITLE
[Release][Cherry-Pick] [AMD] Fix empty range inference for HistogramOp in RangeAnalysis (#11246)

### DIFF
--- a/python/test/unit/language/test_core.py
+++ b/python/test/unit/language/test_core.py
@@ -3068,6 +3068,27 @@ def test_histogram_mask(M, N, device):
     assert (z_torch == z).all()
 
 
+@pytest.mark.interpreter
+@pytest.mark.parametrize("M, N", [[1024, 64], [4096, 128]])
+def test_histogram_compare_mask(M, N, device):
+
+    @triton.jit
+    def histogram_kernel(x_ptr, out_ptr, M: tl.constexpr, N: tl.constexpr):
+        offsets = tl.arange(0, M)
+        x = tl.load(x_ptr + offsets)
+        hist = tl.histogram(x, N)
+        bins = tl.arange(0, N)
+        mask = hist > 0
+        tl.store(out_ptr + bins, hist, mask=mask)
+
+    torch.manual_seed(17)
+    x = torch.randint(0, N, (M, ), device=device, dtype=torch.int32)
+    out = torch.zeros(N, dtype=torch.int32, device=device)
+    ref = torch.histc(x.float(), bins=N, min=0, max=N - 1).to(torch.int32)
+    histogram_kernel[(1, )](x, out, M=M, N=N)
+    assert (out == ref).all(), f"expected {ref}, got {out}"
+
+
 @pytest.mark.parametrize("M, N", [(1, 64), (2, 32), (4, 16), (8, 8), (16, 4), (32, 2), (64, 1)])
 def test_scan_1d(M, N, device):
 

--- a/test/TritonGPU/amd/amd-fold-true-cmpi.mlir
+++ b/test/TritonGPU/amd/amd-fold-true-cmpi.mlir
@@ -248,3 +248,23 @@ module attributes {"ttg.num-warps" = 4 : i32} {
 // CHECK:           %[[TRUE:.*]] = arith.constant dense<true> : tensor<32xi1>
 // CHECK:           tt.return %[[TRUE]] : tensor<32xi1>
 // CHECK:         }
+
+// -----
+
+// Comparison on tt.histogram result should NOT be folded.
+// histogram returns [0, INT_MAX], so sgt against 0 is indeterminate.
+module attributes {"ttg.num-warps" = 4 : i32} {
+  tt.func @dontfoldhistogramcmpi(%arg0: tensor<1024xi32>) -> tensor<64xi1> {
+    %c0 = arith.constant dense<0> : tensor<64xi32>
+    %hist = tt.histogram %arg0 : tensor<1024xi32> -> tensor<64xi32>
+    %cmp = arith.cmpi sgt, %hist, %c0 : tensor<64xi32>
+    tt.return %cmp : tensor<64xi1>
+  }
+}
+
+// CHECK-LABEL:   tt.func @dontfoldhistogramcmpi
+// CHECK-NOT:       arith.constant dense<true>
+// CHECK-NOT:       arith.constant dense<false>
+// CHECK:           tt.histogram
+// CHECK:           arith.cmpi sgt
+// CHECK:         }

--- a/test/TritonGPU/amd/amd-range-analysis.mlir
+++ b/test/TritonGPU/amd/amd-range-analysis.mlir
@@ -1291,7 +1291,7 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32} {
 module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32} {
   // expected-remark@+1 {{arg 2: unsigned : [0, 4294967295] signed : [-2147483648, 2147483647]}}
   tt.func @histo_nonneg(%arg0: !tt.ptr<bf16>, %arg1: !tt.ptr<bf16>, %arg2 : tensor<256xi32>) {
-    // expected-remark@+2 {{unsigned : [0, 4294967295] signed : [0, -1]}}
+    // expected-remark@+2 {{unsigned : [0, 2147483647] signed : [0, 2147483647]}}
     // expected-remark@+1 {{non-neg}}
     %0 = tt.histogram %arg2 : tensor<256xi32> -> tensor<8xi32>
     %1 = tt.make_range {end = 8 : i32, start = 0 : i32} : tensor<8xi32>

--- a/third_party/amd/lib/Analysis/RangeAnalysis.cpp
+++ b/third_party/amd/lib/Analysis/RangeAnalysis.cpp
@@ -160,8 +160,8 @@ void inferResultRangesMaxNonNegSigned(Operation *op,
     auto bitWidth =
         mlir::ConstantIntRanges::getStorageBitwidth(result.getType());
     setResultRange(result, ConstantIntRanges::fromSigned(
-                               APInt::getZero(bitWidth).sext(bitWidth),
-                               APInt::getMaxValue(bitWidth).sext(bitWidth)));
+                               APInt::getZero(bitWidth),
+                               APInt::getSignedMaxValue(bitWidth)));
   }
 }
 


### PR DESCRIPTION
Link to landed trunk PR: https://github.com/triton-lang/triton/pull/11246
Link to release branch PR: this one (there is no open 3.8.1 tracker to file against)
Criteria Category: Critical fix (silent incorrectness), regression against 3.7.1

#11246 merged on 2026-08-20, after the release/3.8.x cut, so v3.8.0 shipped without
it.

On v3.8.0 the AMD backend gives `tt.histogram` a signed range of `[0, -1]`, an empty
set, so signed ordered comparisons against a histogram result fold to a constant and
get deleted. `h > 0` comes back all false. Nothing raises an error, the kernel just
returns wrong values. The bad range comes from `RangeAnalysis.cpp` and the fold from
`TritonAMDFoldTrueCmpI`, so this is not specific to one target. 3.7.1 is unaffected
because tensor-typed `cmpi` was not folded at all before #9805.

I built release/3.8.x with and without this commit and ran them on gfx1101
(RX 7800 XT, ROCm 10.0.0, torch 2.11.0+rocm10.0.0). The `test_histogram_compare_mask`
case that comes with this commit fails on both parameter sets before the fix and
passes on both after, so the test doubles as the reproducer.

Cherry-pick note: the source change applied cleanly. `amd-fold-true-cmpi.mlir`
conflicted only because #11313's loop tests sit above the new test on main; those are
being backported separately in #11429, so whichever of the two lands second needs a
trivial rebase in that one file.

Is a 3.8.1 planned that this could go into?

# New contributor declaration

- [x] I am not making a trivial change, such as fixing a typo in a comment.

- [x] I have written a PR description following these
  [rules](https://cbea.ms/git-commit/#why-not-how).

- [x] I have run `pre-commit run --from-ref origin/release/3.8.x --to-ref HEAD`.

- Select one of the following.
  - [x] I have added tests.
    - `/test` for `lit` tests
    - `/python/test` for end-to-end tests
    - (both carried over unmodified from the trunk PR)

- Select one of the following.
  - [x] The `lit` tests I have added follow these [best practices](https://mlir.llvm.org/getting_started/TestingGuide/#filecheck-best-practices),
    including the "tests should be minimal" section.
