### PR TITLE
[BACKEND] Preserve requested floating-point behavior through lowering

### DIFF
--- a/include/triton/Conversion/TritonGPUToLLVM/ElementwiseOpToLLVMBase.h
+++ b/include/triton/Conversion/TritonGPUToLLVM/ElementwiseOpToLLVMBase.h
@@ -166,8 +166,10 @@ struct ElementwiseOpConversion
                                     ConversionPatternRewriter &rewriter,
                                     Type elemTy, MultipleOperandsRange operands,
                                     Location loc) const {
-    return {DestOp::create(rewriter, loc, elemTy, operands[0],
-                           adaptor.getAttributes().getValue())};
+    DestOp destOp = DestOp::create(rewriter, loc, elemTy, operands[0],
+                                   adaptor.getAttributes().getValue());
+    propagateFastMathFlags(op, destOp);
+    return {destOp};
   }
 };
 

--- a/include/triton/Conversion/TritonGPUToLLVM/Utility.h
+++ b/include/triton/Conversion/TritonGPUToLLVM/Utility.h
@@ -356,6 +356,23 @@ Value emitRedundantThreadPredicate(
 // Takes two values that may be boolean, or null to represent constant True.
 Value maybeAnd(OpBuilder &builder, Location loc, Value a, Value b);
 
+// Fast-math flags are dropped unless a lowering carries them over explicitly.
+// Prefer `getLLVMFastmathFlags` when the destination is built through a builder
+// that accepts a `LLVM::FastmathFlagsAttr`; use `propagateFastMathFlags` when
+// the destination comes back from a helper, or when a lowering emits several
+// floating-point ops that each need the flags. Destinations that cannot
+// represent them (ROCDL intrinsics, integer bit-manipulation sequences, inline
+// asm) necessarily drop them.
+
+// Returns the fast-math flags of `op` in the LLVM dialect spelling, or a null
+// attribute when it carries none.
+LLVM::FastmathFlagsAttr getLLVMFastmathFlags(Operation *op);
+
+// Carries the fast-math flags of `srcOp` over to `dstOp`, translating them when
+// the lowering crosses from the arith/math spelling to the LLVM spelling. Does
+// nothing if `srcOp` has no flags or `dstOp` cannot carry them.
+void propagateFastMathFlags(Operation *srcOp, Operation *dstOp);
+
 } // namespace gpu
 
 } // namespace triton

--- a/lib/Conversion/TritonGPUToLLVM/CMakeLists.txt
+++ b/lib/Conversion/TritonGPUToLLVM/CMakeLists.txt
@@ -29,6 +29,7 @@ add_triton_library(TritonGPUToLLVM
     TritonGPUConversionPassIncGen
 
     LINK_LIBS PUBLIC
+    MLIRArithAttrToLLVMConversion
     MLIRIR
     MLIRPass
     MLIRGPUDialect

--- a/lib/Conversion/TritonGPUToLLVM/ElementwiseOpToLLVM.cpp
+++ b/lib/Conversion/TritonGPUToLLVM/ElementwiseOpToLLVM.cpp
@@ -102,9 +102,11 @@ struct CmpFOpConversion
   createDestOps(arith::CmpFOp op, OpAdaptor adaptor,
                 ConversionPatternRewriter &rewriter, Type elemTy,
                 MultipleOperandsRange operands, Location loc) {
-    return {LLVM::FCmpOp::create(rewriter, loc, elemTy,
-                                 ArithCmpFPredicateToLLVM(op.getPredicate()),
-                                 operands[0][0], operands[0][1])};
+    auto dstOp = LLVM::FCmpOp::create(
+        rewriter, loc, elemTy, ArithCmpFPredicateToLLVM(op.getPredicate()),
+        operands[0][0], operands[0][1]);
+    propagateFastMathFlags(op, dstOp);
+    return {dstOp};
   }
 
   static LLVM::FCmpPredicate
@@ -408,7 +410,8 @@ struct AbsFOpConversion
                                    Location loc) const {
     auto b = TritonLLVMOpBuilder(loc, rewriter);
     if (llvm::isa<IntegerType>(elemTy)) {
-      // Mask out the sign bit
+      // Mask out the sign bit. This is implemented with integer bit
+      // operations, which cannot represent floating-point fast-math flags.
       auto num_bits =
           getElementTypeOrSelf(op.getType()).getIntOrFloatBitWidth();
       assert(num_bits <= 16);
@@ -418,7 +421,9 @@ struct AbsFOpConversion
       return {b.and_(operands[0][0], maskConst)};
     }
 
-    return {LLVM::FAbsOp::create(rewriter, loc, elemTy, operands[0][0])};
+    auto dstOp = LLVM::FAbsOp::create(rewriter, loc, elemTy, operands[0][0]);
+    propagateFastMathFlags(op, dstOp);
+    return {dstOp};
   }
 };
 
@@ -477,8 +482,10 @@ struct MinMaxFOpConversion
                                    Type elemTy, MultipleOperandsRange operands,
                                    Location loc) const {
     if (hwNanPropagationSupported) {
-      return {DestOpNanProp::create(rewriter, loc, elemTy, operands[0][0],
-                                    operands[0][1])};
+      auto dstOp = DestOpNanProp::create(rewriter, loc, elemTy, operands[0][0],
+                                         operands[0][1]);
+      propagateFastMathFlags(op, dstOp);
+      return {dstOp};
     }
     // Handle workaround for NaN propagation, i.e. software emulation of NaN
     // propagation. If any of the operands is NaN, return NaN.
@@ -486,15 +493,20 @@ struct MinMaxFOpConversion
     auto rhs = operands[0][1];
     auto lhsIsNan =
         LLVM::FCmpOp::create(rewriter, loc, LLVM::FCmpPredicate::une, lhs, lhs);
+    propagateFastMathFlags(op, lhsIsNan);
     auto rhsIsNan =
         LLVM::FCmpOp::create(rewriter, loc, LLVM::FCmpPredicate::une, rhs, rhs);
+    propagateFastMathFlags(op, rhsIsNan);
     auto isNan = LLVM::OrOp::create(rewriter, loc, lhsIsNan, rhsIsNan);
     auto nonNanRes = DestOpNoNanProp::create(rewriter, loc, elemTy, lhs, rhs);
+    propagateFastMathFlags(op, nonNanRes);
 
     auto nan = LLVM::createNaNConstant(loc, rewriter, elemTy);
 
     // Select the result based on the isNan flag.
-    return {LLVM::SelectOp::create(rewriter, loc, isNan, nan, nonNanRes)};
+    auto result = LLVM::SelectOp::create(rewriter, loc, isNan, nan, nonNanRes);
+    propagateFastMathFlags(op, result);
+    return {result};
   }
 
 private:

--- a/lib/Conversion/TritonGPUToLLVM/Utility.cpp
+++ b/lib/Conversion/TritonGPUToLLVM/Utility.cpp
@@ -1,4 +1,5 @@
 #include "triton/Conversion/TritonGPUToLLVM/Utility.h"
+#include "mlir/Conversion/ArithCommon/AttrToLLVMConverter.h"
 #include "mlir/Dialect/LLVMIR/LLVMDialect.h"
 #include "mlir/IR/Attributes.h"
 #include "mlir/Transforms/RegionUtils.h"
@@ -285,6 +286,46 @@ Value emitRedundantThreadPredicate(
     }
   }
   return pred;
+}
+
+// Returns the fast-math flags carried by `op`, or a null attribute when it has
+// none. Arith fast-math attributes are default-valued, so an operation without
+// flags still reports an explicit `none` attribute.
+static arith::FastMathFlagsAttr getArithFastmathFlags(Operation *op) {
+  auto fastmath = dyn_cast<arith::ArithFastMathInterface>(op);
+  if (!fastmath)
+    return {};
+
+  arith::FastMathFlagsAttr flags = fastmath.getFastMathFlagsAttr();
+  if (!flags || flags.getValue() == arith::FastMathFlags::none)
+    return {};
+  return flags;
+}
+
+LLVM::FastmathFlagsAttr getLLVMFastmathFlags(Operation *op) {
+  arith::FastMathFlagsAttr flags = getArithFastmathFlags(op);
+  if (!flags)
+    return {};
+  return arith::convertArithFastMathAttrToLLVM(flags);
+}
+
+void propagateFastMathFlags(Operation *srcOp, Operation *dstOp) {
+  arith::FastMathFlagsAttr flags = getArithFastmathFlags(srcOp);
+  if (!flags)
+    return;
+
+  // Neither fast-math interface exposes a setter, so the flags have to go in
+  // by name.
+  if (auto dstFastmath = dyn_cast<arith::ArithFastMathInterface>(dstOp)) {
+    dstOp->setAttr(dstFastmath.getFastMathAttrName(), flags);
+    return;
+  }
+
+  auto dstFastmath = dyn_cast<LLVM::FastmathFlagsInterface>(dstOp);
+  if (!dstFastmath)
+    return;
+  dstOp->setAttr(dstFastmath.getFastmathAttrName(),
+                 arith::convertArithFastMathAttrToLLVM(flags));
 }
 
 } // namespace triton::gpu

--- a/python/src/llvm.cc
+++ b/python/src/llvm.cc
@@ -3,6 +3,7 @@
 #include "mlir/Target/LLVMIR/ModuleTranslation.h"
 #include "triton/Tools/Sys/GetEnv.h"
 #include "triton/Version.h"
+#include "llvm/ADT/FloatingPointMode.h"
 #include "llvm/ADT/SmallVector.h"
 #include "llvm/Analysis/ScopedNoAliasAA.h"
 #include "llvm/Analysis/TargetTransformInfo.h"
@@ -12,6 +13,7 @@
 #include "llvm/CodeGen/SchedulerRegistry.h"
 #include "llvm/CodeGen/SelectionDAGISel.h"
 #include "llvm/Config/llvm-config.h"
+#include "llvm/IR/Attributes.h"
 #include "llvm/IR/DebugInfo.h"
 #include "llvm/IR/IRBuilder.h"
 #include "llvm/IR/IntrinsicInst.h"
@@ -679,6 +681,22 @@ void init_triton_llvm(py::module_ &m) {
               fn->addFnAttr(name, val);
           },
           py::arg("name"), py::arg("val") = "")
+      .def(
+          "add_denormal_fp_env_attr",
+          [](llvm::Function *fn, const std::string &defaultMode,
+             const std::string &f32Mode) {
+            auto parseMode = [](const std::string &mode) {
+              llvm::DenormalMode parsed = llvm::parseDenormalFPAttribute(mode);
+              if (!parsed.isValid())
+                throw std::invalid_argument("invalid denormal mode: " + mode);
+              return parsed;
+            };
+            llvm::AttrBuilder attrs(fn->getContext());
+            attrs.addDenormalFPEnvAttr(llvm::DenormalFPEnv(
+                parseMode(defaultMode), parseMode(f32Mode)));
+            fn->addFnAttrs(attrs);
+          },
+          py::arg("default_mode"), py::arg("f32_mode"))
       .def("remove_fn_attr", [](llvm::Function *fn,
                                 std::string &name) { fn->removeFnAttr(name); })
       .def("add_fn_asan_attr",

--- a/python/test/unit/language/test_compile_only.py
+++ b/python/test/unit/language/test_compile_only.py
@@ -72,6 +72,54 @@ def test_compile_only_sm100() -> None:
     assert k.asm["cubin"] != b""
 
 
+@pytest.mark.parametrize(
+    "allow_flush_denorm, llvm_fn_attrs, expected, expected_denorm_modes",
+    [
+        (False, (), "denormal_fpenv(ieee)", (3, 3)),
+        (True, (), "denormal_fpenv(float: preservesign)", (0, 3)),
+        (True, "denormal-fp-math-f32=ieee", "denormal_fpenv(ieee)", (3, 3)),
+        (
+            False,
+            "denormal-fp-math=preserve-sign",
+            "denormal_fpenv(preservesign, float: ieee)",
+            (3, 0),
+        ),
+    ],
+)
+def test_compile_only_denormal_fp_env(allow_flush_denorm, llvm_fn_attrs, expected, expected_denorm_modes) -> None:
+    """
+    Validate that the requested denormal mode reaches code generation.
+
+    The mode has to be carried by LLVM's `denormal_fpenv` attribute; the legacy
+    `denormal-fp-math` string attributes are accepted on the function but never
+    read, so requesting flush-to-zero through them has no effect on the
+    generated assembly.
+    """
+
+    @triton.jit
+    def kernel(out):
+        tl.store(out, 0.0)
+
+    src = ASTSource(fn=kernel, signature={"out": "*fp32"})
+    compiled = triton.compile(
+        src,
+        target=GPUTarget("hip", "gfx942", 64),
+        options={
+            "allow_flush_denorm": allow_flush_denorm,
+            "llvm_fn_attrs": llvm_fn_attrs,
+        },
+    )
+    llir = compiled.asm["llir"]
+    assert expected in llir
+    assert "denormal-fp-math" not in llir
+
+    # 3 selects IEEE denormals, 0 selects flush-to-zero.
+    f32_mode, f16_f64_mode = expected_denorm_modes
+    amdgcn = compiled.asm["amdgcn"]
+    assert f".amdhsa_float_denorm_mode_32 {f32_mode}" in amdgcn
+    assert f".amdhsa_float_denorm_mode_16_64 {f16_f64_mode}" in amdgcn
+
+
 @pytest.mark.parametrize("element_type", ["f32", "f16", "bf16"])
 def test_compile_only_packed_arith_chains(element_type, tmp_path) -> None:
     packed_type = f"{element_type}x2"

--- a/test/Conversion/amd/math-denorm-handling.mlir
+++ b/test/Conversion/amd/math-denorm-handling.mlir
@@ -29,9 +29,27 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 1 : i32, ttg.targ
 #blocked = #ttg.blocked<{sizePerThread = [1], threadsPerWarp = [64], warpsPerCTA = [1], order = [0]}>
 module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 1 : i32, ttg.target = "hip:gfx942", "ttg.threads-per-warp" = 64 : i32} {
   tt.func public @test_rsqrt(%arg0: tensor<64xf32, #blocked>) {
+    // ROCDL ops do not implement LLVM::FastmathFlagsInterface, so the FTZ path
+    // cannot record the flags. The non-FTZ path is handled by MathToROCDL.
+    // COMMON-LABEL: test_rsqrt
     // LLVM_FTZ: rocdl.rsq {{.*}} f32 -> f32
-    // LLVM_NO_FTZ: _ocml_rsqrt_f32
-    %0 = math.rsqrt %arg0 : tensor<64xf32, #blocked>
+    // LLVM_FTZ-NOT: fastmathFlags
+    // LLVM_NO_FTZ: llvm.call @__ocml_rsqrt_f32
+    %0 = math.rsqrt %arg0 fastmath<nnan,afn> : tensor<64xf32, #blocked>
+    tt.return
+  }
+}
+
+// -----
+
+#blocked = #ttg.blocked<{sizePerThread = [1], threadsPerWarp = [64], warpsPerCTA = [1], order = [0]}>
+module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 1 : i32, ttg.target = "hip:gfx942", "ttg.threads-per-warp" = 64 : i32} {
+  tt.func public @test_fastmath_intrinsics(%arg0: tensor<64xf32, #blocked>) {
+    // MathToROCDL leaves f32 log to MathToLLVM, which keeps the flags on the
+    // intrinsic. This is what lets the AMDGPU backend act on `afn`.
+    // COMMON-LABEL: test_fastmath_intrinsics
+    // COMMON: llvm.intr.log({{.*}}) {fastmathFlags = #llvm.fastmath<nnan, afn>} : (f32) -> f32
+    %log = math.log %arg0 fastmath<nnan,afn> : tensor<64xf32, #blocked>
     tt.return
   }
 }
@@ -48,13 +66,13 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 1 : i32, ttg.targ
     // LLVM_FTZ-NOT: llvm.select
     //
     // LLVM_NO_FTZ-LABEL: test_sqrt_f32
-    // LLVM_NO_FTZ: llvm.fcmp "ogt"
-    // LLVM_NO_FTZ: llvm.fmul
-    // LLVM_NO_FTZ-NEXT: llvm.select
+    // LLVM_NO_FTZ: llvm.fcmp "ogt" {{.*}} {fastmathFlags = #llvm.fastmath<nnan, nsz>}
+    // LLVM_NO_FTZ: llvm.fmul {{.*}} {fastmathFlags = #llvm.fastmath<nnan, nsz>}
+    // LLVM_NO_FTZ-NEXT: llvm.select {{.*}} {fastmathFlags = #llvm.fastmath<nnan, nsz>}
     // LLVM_NO_FTZ-NEXT: rocdl.sqrt
-    // LLVM_NO_FTZ: llvm.fmul
-    // LLVM_NO_FTZ-NEXT: llvm.select
-    %0 = math.sqrt %arg0 : tensor<64xf32, #blocked>
+    // LLVM_NO_FTZ: llvm.fmul {{.*}} {fastmathFlags = #llvm.fastmath<nnan, nsz>}
+    // LLVM_NO_FTZ-NEXT: llvm.select {{.*}} {fastmathFlags = #llvm.fastmath<nnan, nsz>}
+    %0 = math.sqrt %arg0 fastmath<nnan,nsz> : tensor<64xf32, #blocked>
     tt.return
   }
 }
@@ -91,6 +109,184 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 1 : i32, ttg.targ
     // COMMON-LABEL: test_divf_rn_f32
     // COMMON: llvm.fdiv
     %0 = tt.precise_divf %arg0, %arg1 : tensor<64xf32, #blocked>
+    tt.return
+  }
+}
+
+// -----
+
+#blocked = #ttg.blocked<{sizePerThread = [1], threadsPerWarp = [64], warpsPerCTA = [1], order = [0]}>
+module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 1 : i32, ttg.target = "hip:gfx942", "ttg.threads-per-warp" = 64 : i32} {
+  tt.func public @test_fastmath_arith(
+      %arg0: tensor<64xf32, #blocked>,
+      %arg1: tensor<64xf32, #blocked>,
+      %arg2: tensor<64xf32, #blocked>) {
+    // COMMON-LABEL: test_fastmath_arith
+    // COMMON-DAG: llvm.fdiv {{.*}} {fastmathFlags = #llvm.fastmath<nsz, arcp, afn>} : f32
+    // COMMON-DAG: llvm.fadd {{.*}} {fastmathFlags = #llvm.fastmath<nsz, contract>} : f32
+    // COMMON-DAG: llvm.fsub {{.*}} {fastmathFlags = #llvm.fastmath<nsz, contract>} : f32
+    // COMMON-DAG: llvm.fmul {{.*}} {fastmathFlags = #llvm.fastmath<nsz, contract>} : f32
+    // COMMON-DAG: llvm.fneg {{.*}} {fastmathFlags = #llvm.fastmath<nnan>} : f32
+    // COMMON-DAG: llvm.frem {{.*}} {fastmathFlags = #llvm.fastmath<ninf>} : f32
+    // COMMON-DAG: llvm.intr.maxnum({{.*}}) {fastmathFlags = #llvm.fastmath<nnan, nsz>}
+    // COMMON-DAG: llvm.intr.maximum({{.*}}) {fastmathFlags = #llvm.fastmath<nnan>}
+    // COMMON-DAG: llvm.intr.minnum({{.*}}) {fastmathFlags = #llvm.fastmath<reassoc>}
+    // COMMON-DAG: llvm.intr.minimum({{.*}}) {fastmathFlags = #llvm.fastmath<ninf>}
+    // COMMON-DAG: llvm.fcmp "olt" {{.*}} {fastmathFlags = #llvm.fastmath<arcp>} : f32
+    // COMMON-DAG: llvm.intr.fabs({{.*}}) {fastmathFlags = #llvm.fastmath<nsz>} : (f32) -> f32
+    // COMMON-DAG: llvm.intr.fma({{.*}}) {fastmathFlags = #llvm.fastmath<nsz, contract>}
+    %div = arith.divf %arg0, %arg1 fastmath<nsz,arcp,afn> : tensor<64xf32, #blocked>
+    %add = arith.addf %div, %arg2 fastmath<nsz,contract> : tensor<64xf32, #blocked>
+    %sub = arith.subf %add, %arg2 fastmath<nsz,contract> : tensor<64xf32, #blocked>
+    %mul = arith.mulf %sub, %arg2 fastmath<nsz,contract> : tensor<64xf32, #blocked>
+    %neg = arith.negf %mul fastmath<nnan> : tensor<64xf32, #blocked>
+    %rem = arith.remf %neg, %arg2 fastmath<ninf> : tensor<64xf32, #blocked>
+    %maxnum = arith.maxnumf %rem, %arg2 fastmath<nnan,nsz> : tensor<64xf32, #blocked>
+    %maximum = arith.maximumf %maxnum, %arg2 fastmath<nnan> : tensor<64xf32, #blocked>
+    %minnum = arith.minnumf %rem, %arg2 fastmath<reassoc> : tensor<64xf32, #blocked>
+    %minimum = arith.minimumf %minnum, %arg2 fastmath<ninf> : tensor<64xf32, #blocked>
+    %cmp = arith.cmpf olt, %arg0, %arg1 fastmath<arcp> : tensor<64xf32, #blocked>
+    %abs = math.absf %arg0 fastmath<nsz> : tensor<64xf32, #blocked>
+    %fma = math.fma %maximum, %arg1, %arg2 fastmath<nsz,contract> : tensor<64xf32, #blocked>
+    tt.return
+  }
+}
+
+// -----
+
+#blocked = #ttg.blocked<{sizePerThread = [1], threadsPerWarp = [64], warpsPerCTA = [1], order = [0]}>
+module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 1 : i32, ttg.target = "hip:gfx942", "ttg.threads-per-warp" = 64 : i32} {
+  tt.func public @test_fastmath_libcalls(
+      %arg0: tensor<64xf32, #blocked>,
+      %arg1: tensor<64xf16, #blocked>,
+      %arg2: tensor<64xf64, #blocked>) {
+    // Transcendentals routed to OCML by MathToROCDL do not carry the flags:
+    // OpToFuncCallLowering drops them, and they would be inert on the callsite
+    // anyway because the inliner does not push callsite flags into the body.
+    // COMMON-LABEL: test_fastmath_libcalls
+    // COMMON-DAG: llvm.call @__ocml_floor_f32({{.*}}) : (f32) -> f32
+    // COMMON-DAG: llvm.call @__ocml_log2_f32({{.*}}) : (f32) -> f32
+    // COMMON-DAG: llvm.call @__ocml_cos_f32({{.*}}) : (f32) -> f32
+    // COMMON-DAG: llvm.call @__ocml_sin_f32({{.*}}) : (f32) -> f32
+    // COMMON-DAG: llvm.call @__ocml_erf_f32({{.*}}) : (f32) -> f32
+    // COMMON-DAG: llvm.call @__ocml_log_f16({{.*}}) : (f16) -> f16
+    // COMMON-DAG: llvm.call @__ocml_log_f64({{.*}}) : (f64) -> f64
+    %floor = math.floor %arg0 fastmath<afn> : tensor<64xf32, #blocked>
+    %log2 = math.log2 %arg0 fastmath<nnan,afn> : tensor<64xf32, #blocked>
+    %cos = math.cos %arg0 fastmath<ninf,afn> : tensor<64xf32, #blocked>
+    %sin = math.sin %arg0 fastmath<arcp,afn> : tensor<64xf32, #blocked>
+    %erf = math.erf %arg0 fastmath<nnan> : tensor<64xf32, #blocked>
+    %log16 = math.log %arg1 fastmath<nsz> : tensor<64xf16, #blocked>
+    %log64 = math.log %arg2 fastmath<ninf> : tensor<64xf64, #blocked>
+    tt.return
+  }
+}
+
+// -----
+
+#blocked = #ttg.blocked<{sizePerThread = [1], threadsPerWarp = [64], warpsPerCTA = [1], order = [0]}>
+module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 1 : i32, ttg.target = "hip:gfx942", "ttg.threads-per-warp" = 64 : i32} {
+  tt.func public @test_fastmath_none(%arg0: tensor<64xf32, #blocked>) {
+    // COMMON-LABEL: test_fastmath_none
+    // COMMON-NOT: fastmathFlags
+    // COMMON: llvm.return
+    %floor = math.floor %arg0 : tensor<64xf32, #blocked>
+    %log2 = math.log2 %arg0 : tensor<64xf32, #blocked>
+    tt.return
+  }
+}
+
+// -----
+
+#blocked = #ttg.blocked<{sizePerThread = [1], threadsPerWarp = [64], warpsPerCTA = [1], order = [0]}>
+module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 1 : i32, ttg.target = "hip:gfx942", "ttg.threads-per-warp" = 64 : i32} {
+  tt.func public @test_fastmath_bf16(
+      %arg0: tensor<64xbf16, #blocked>,
+      %arg1: tensor<64xbf16, #blocked>) {
+    // COMMON-LABEL: test_fastmath_bf16
+    // COMMON-DAG: llvm.fdiv {{.*}} {fastmathFlags = #llvm.fastmath<arcp>} : bf16
+    // COMMON-DAG: llvm.fadd {{.*}} {fastmathFlags = #llvm.fastmath<contract>} : f32
+    // COMMON-DAG: llvm.fsub {{.*}} {fastmathFlags = #llvm.fastmath<contract>} : f32
+    // COMMON-DAG: llvm.fmul {{.*}} {fastmathFlags = #llvm.fastmath<contract>} : f32
+    // COMMON-DAG: llvm.call @__ocml_exp2_f32({{.*}}) : (f32) -> f32
+    // COMMON-DAG: llvm.call @__ocml_rsqrt_f32({{.*}}) : (f32) -> f32
+    %div = arith.divf %arg0, %arg1 fastmath<arcp> : tensor<64xbf16, #blocked>
+    %add = arith.addf %div, %arg1 fastmath<contract> : tensor<64xbf16, #blocked>
+    %sub = arith.subf %add, %arg1 fastmath<contract> : tensor<64xbf16, #blocked>
+    %mul = arith.mulf %sub, %arg1 fastmath<contract> : tensor<64xbf16, #blocked>
+    %exp2 = math.exp2 %arg0 fastmath<afn> : tensor<64xbf16, #blocked>
+    %rsqrt = math.rsqrt %arg0 fastmath<afn> : tensor<64xbf16, #blocked>
+    tt.return
+  }
+}
+
+// -----
+
+#blocked = #ttg.blocked<{sizePerThread = [1], threadsPerWarp = [64], warpsPerCTA = [1], order = [0]}>
+module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 1 : i32, ttg.target = "hip:gfx942", "ttg.threads-per-warp" = 64 : i32} {
+  tt.func public @test_fastmath_exp(%arg0: tensor<64xf32, #blocked>) {
+    // COMMON-LABEL: test_fastmath_exp
+    // COMMON-DAG: llvm.fmul {{.*}} {fastmathFlags = #llvm.fastmath<nsz, contract, afn>} : f32
+    // COMMON-DAG: llvm.call @llvm.exp2.f32({{.*}}) {fastmathFlags = #llvm.fastmath<nsz, contract, afn>}
+    %0 = math.exp %arg0 fastmath<nsz,contract,afn> : tensor<64xf32, #blocked>
+    tt.return
+  }
+}
+
+// -----
+
+#blocked = #ttg.blocked<{sizePerThread = [1], threadsPerWarp = [64], warpsPerCTA = [1], order = [0]}>
+module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 1 : i32, ttg.target = "hip:gfx942", "ttg.threads-per-warp" = 64 : i32} {
+  tt.func public @test_fastmath_exp2(%arg0: tensor<64xf32, #blocked>) {
+    // COMMON-LABEL: test_fastmath_exp2
+    // LLVM_FTZ: rocdl.exp2
+    // LLVM_FTZ-NOT: fastmathFlags
+    // LLVM_NO_FTZ: llvm.intr.exp2({{.*}}) {fastmathFlags = #llvm.fastmath<afn>}
+    %0 = math.exp2 %arg0 fastmath<afn> : tensor<64xf32, #blocked>
+    tt.return
+  }
+}
+
+// -----
+
+#blocked = #ttg.blocked<{sizePerThread = [1], threadsPerWarp = [64], warpsPerCTA = [1], order = [0]}>
+module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 1 : i32, ttg.target = "hip:gfx942", "ttg.threads-per-warp" = 64 : i32} {
+  tt.func public @test_fastmath_casts(
+      %arg0: tensor<64xf16, #blocked>,
+      %arg1: tensor<64xf64, #blocked>,
+      %arg2: tensor<64xf32, #blocked>) {
+    // COMMON-LABEL: test_fastmath_casts
+    // COMMON-DAG: llvm.fpext {{.*}} fastmath<nnan> : f16 to f32
+    // COMMON-DAG: llvm.fptrunc {{.*}} fastmath<ninf> : f64 to f32
+    // COMMON-DAG: llvm.fptrunc {{.*}} fastmath<contract> : f32 to f16
+    // The f16 math ops are left to MathToROCDL, which drops the flags.
+    // COMMON-DAG: llvm.call @__ocml_exp_f16({{.*}}) : (f16) -> f16
+    // COMMON-DAG: llvm.call @__ocml_exp2_f16({{.*}}) : (f16) -> f16
+    // COMMON-DAG: llvm.call @__ocml_rsqrt_f16({{.*}}) : (f16) -> f16
+    %ext = arith.extf %arg0 fastmath<nnan> : tensor<64xf16, #blocked> to tensor<64xf32, #blocked>
+    %trunc = arith.truncf %arg1 fastmath<ninf> : tensor<64xf64, #blocked> to tensor<64xf32, #blocked>
+    %truncf16 = arith.truncf %arg2 fastmath<contract> : tensor<64xf32, #blocked> to tensor<64xf16, #blocked>
+    %exp = math.exp %arg0 fastmath<afn> : tensor<64xf16, #blocked>
+    %exp2 = math.exp2 %arg0 fastmath<afn> : tensor<64xf16, #blocked>
+    %rsqrt = math.rsqrt %arg0 fastmath<afn> : tensor<64xf16, #blocked>
+    tt.return
+  }
+}
+
+// -----
+
+#blocked = #ttg.blocked<{sizePerThread = [1], threadsPerWarp = [64], warpsPerCTA = [1], order = [0]}>
+module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 1 : i32, ttg.target = "hip:gfx942", "ttg.threads-per-warp" = 64 : i32} {
+  tt.func public @test_fastmath_bf16_casts(
+      %arg0: tensor<64xbf16, #blocked>,
+      %arg1: tensor<64xf32, #blocked>) {
+    // The bf16 conversions are software sequences of integer bit operations,
+    // which cannot represent fast-math flags.
+    // COMMON-LABEL: test_fastmath_bf16_casts
+    // COMMON-NOT: fastmath
+    // COMMON: llvm.return
+    %ext = arith.extf %arg0 fastmath<nnan> : tensor<64xbf16, #blocked> to tensor<64xf32, #blocked>
+    %trunc = arith.truncf %arg1 fastmath<ninf> : tensor<64xf32, #blocked> to tensor<64xbf16, #blocked>
     tt.return
   }
 }

--- a/test/Conversion/amd/tritongpu_to_llvm_gfx1250.mlir
+++ b/test/Conversion/amd/tritongpu_to_llvm_gfx1250.mlir
@@ -15,6 +15,26 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 2 : i32, "ttg.thr
 
 // -----
 
+#blocked = #ttg.blocked<{sizePerThread = [2], threadsPerWarp = [32], warpsPerCTA = [1], order = [0]}>
+module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 1 : i32, "ttg.threads-per-warp" = 32 : i32} {
+  tt.func public @packed_fastmath(
+      %arg0: tensor<64xf32, #blocked>,
+      %arg1: tensor<64xf32, #blocked>) {
+    // GFX1250-LABEL: packed_fastmath
+    // GFX1250-DAG: llvm.fadd {{.*}} {fastmathFlags = #llvm.fastmath<contract>} : vector<2xf32>
+    // GFX1250-DAG: llvm.fsub {{.*}} {fastmathFlags = #llvm.fastmath<contract>} : vector<2xf32>
+    // GFX1250-DAG: llvm.fmul {{.*}} {fastmathFlags = #llvm.fastmath<contract>} : vector<2xf32>
+    // GFX1250-DAG: llvm.fptrunc {{.*}} fastmath<ninf> : vector<2xf32> to vector<2xf16>
+    %add = arith.addf %arg0, %arg1 fastmath<contract> : tensor<64xf32, #blocked>
+    %sub = arith.subf %add, %arg1 fastmath<contract> : tensor<64xf32, #blocked>
+    %mul = arith.mulf %sub, %arg1 fastmath<contract> : tensor<64xf32, #blocked>
+    %trunc = arith.truncf %mul fastmath<ninf> : tensor<64xf32, #blocked> to tensor<64xf16, #blocked>
+    tt.return
+  }
+}
+
+// -----
+
 #mma = #ttg.amd_wmma<{version = 3, ctaLayout = {warp = [[1, 0], [2, 0]]}, isTranspose = true, instrShape = [16, 16, 32]}>
 module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, "ttg.threads-per-warp" = 32 : i32} {
   // GFX1250-LABEL: reduce_16x16

--- a/test/Conversion/tritongpu_to_llvm.mlir
+++ b/test/Conversion/tritongpu_to_llvm.mlir
@@ -3263,3 +3263,121 @@ module attributes {"ttg.num-ctas" = 4 : i32, "ttg.num-warps" = 4 : i32, ttg.prof
     tt.return
   }
 }
+
+// -----
+
+#blocked = #ttg.blocked<{sizePerThread = [1], threadsPerWarp = [32], warpsPerCTA = [1], order = [0]}>
+module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 1 : i32, ttg.target = "cuda:90", "ttg.threads-per-warp" = 32 : i32} {
+  // CHECK-LABEL: @fastmath_elementwise
+  // CHECK-DAG: llvm.fadd {{.*}} {fastmathFlags = #llvm.fastmath<contract>} : f32
+  // CHECK-DAG: llvm.call_intrinsic "llvm.nvvm.div.full"({{.*}}) {fastmathFlags = #llvm.fastmath<arcp>}
+  // CHECK-DAG: llvm.fsub {{.*}} {fastmathFlags = #llvm.fastmath<reassoc>} : f32
+  // CHECK-DAG: llvm.fmul {{.*}} {fastmathFlags = #llvm.fastmath<ninf>} : f32
+  // CHECK-DAG: llvm.fneg {{.*}} {fastmathFlags = #llvm.fastmath<nnan>} : f32
+  // CHECK-DAG: llvm.frem {{.*}} {fastmathFlags = #llvm.fastmath<nsz>} : f32
+  // CHECK-DAG: llvm.intr.minnum({{.*}}) {fastmathFlags = #llvm.fastmath<reassoc>} : (f32, f32) -> f32
+  // CHECK-DAG: llvm.intr.minimum({{.*}}) {fastmathFlags = #llvm.fastmath<ninf>} : (f32, f32) -> f32
+  // CHECK-DAG: llvm.intr.fma({{.*}}) {fastmathFlags = #llvm.fastmath<contract>} : (f32, f32, f32) -> f32
+  // CHECK-DAG: llvm.fmul {{.*}} {fastmathFlags = #llvm.fastmath<afn>} : f32
+  // CHECK-DAG: llvm.call_intrinsic "llvm.nvvm.ex2.approx.f32"({{.*}}) {fastmathFlags = #llvm.fastmath<afn>}
+  // CHECK-DAG: llvm.fcmp "olt" {{.*}} {fastmathFlags = #llvm.fastmath<ninf>} : f32
+  // CHECK-DAG: llvm.intr.fabs({{.*}}) {fastmathFlags = #llvm.fastmath<nsz>} : (f32) -> f32
+  // CHECK-DAG: llvm.intr.maximum({{.*}}) {fastmathFlags = #llvm.fastmath<nnan>} : (f32, f32) -> f32
+  // CHECK-DAG: llvm.fpext {{.*}} fastmath<nnan> : f16 to f32
+  // CHECK-DAG: llvm.fptrunc {{.*}} fastmath<ninf> : f64 to f32
+  //
+  // Transcendentals reach MLIR's libdevice lowering as scalar math ops that
+  // still carry their flags, so `afn` selects the approximate entry points.
+  // CHECK-DAG: llvm.call @__nv_fast_logf({{.*}}) : (f32) -> f32
+  // CHECK-DAG: llvm.call @__nv_fast_log2f({{.*}}) : (f32) -> f32
+  // CHECK-DAG: llvm.call @__nv_fast_cosf({{.*}}) : (f32) -> f32
+  // CHECK-DAG: llvm.call @__nv_fast_sinf({{.*}}) : (f32) -> f32
+  // CHECK-DAG: llvm.call @__nv_fast_expf({{.*}}) : (f32) -> f32
+  // Without `afn` the precise entry points are kept.
+  // CHECK-DAG: llvm.call @__nv_expf({{.*}}) : (f32) -> f32
+  // CHECK-DAG: llvm.call @__nv_ceilf({{.*}}) : (f32) -> f32
+  // CHECK-DAG: llvm.call @__nv_sqrtf({{.*}}) : (f32) -> f32
+  // CHECK-DAG: llvm.call @__nv_erff({{.*}}) : (f32) -> f32
+  // CHECK-DAG: llvm.call @__nv_exp2f({{.*}}) : (f32) -> f32
+  // CHECK-DAG: llvm.call @__nv_rsqrtf({{.*}}) : (f32) -> f32
+  // CHECK-DAG: llvm.call @__nv_floorf({{.*}}) : (f32) -> f32
+  // CHECK-DAG: llvm.call @__nv_exp({{.*}}) : (f64) -> f64
+  // CHECK-DAG: llvm.call @__nv_exp2({{.*}}) : (f64) -> f64
+  // CHECK-DAG: llvm.call @__nv_rsqrt({{.*}}) : (f64) -> f64
+  tt.func @fastmath_elementwise(
+      %arg0: tensor<32xf32, #blocked>,
+      %arg1: tensor<32xf32, #blocked>,
+      %arg2: tensor<32xf16, #blocked>,
+      %arg3: tensor<32xf64, #blocked>,
+      %arg4: tensor<32xbf16, #blocked>) {
+    %add = arith.addf %arg0, %arg1 fastmath<contract> : tensor<32xf32, #blocked>
+    %div = arith.divf %add, %arg1 fastmath<arcp> : tensor<32xf32, #blocked>
+    %sub = arith.subf %div, %arg1 fastmath<reassoc> : tensor<32xf32, #blocked>
+    %mul = arith.mulf %sub, %arg1 fastmath<ninf> : tensor<32xf32, #blocked>
+    %neg = arith.negf %mul fastmath<nnan> : tensor<32xf32, #blocked>
+    %rem = arith.remf %neg, %arg1 fastmath<nsz> : tensor<32xf32, #blocked>
+    %minnum = arith.minnumf %rem, %arg1 fastmath<reassoc> : tensor<32xf32, #blocked>
+    %minimum = arith.minimumf %minnum, %arg1 fastmath<ninf> : tensor<32xf32, #blocked>
+    %fma = math.fma %minimum, %arg0, %arg1 fastmath<contract> : tensor<32xf32, #blocked>
+    %exp = math.exp %div fastmath<afn> : tensor<32xf32, #blocked>
+    %exp2f = math.exp2 %div fastmath<afn> : tensor<32xf32, #blocked>
+    %rsqrtf = math.rsqrt %div fastmath<afn> : tensor<32xf32, #blocked>
+    %floor = math.floor %arg0 fastmath<afn> : tensor<32xf32, #blocked>
+    %ceil = math.ceil %arg0 fastmath<nnan> : tensor<32xf32, #blocked>
+    %log = math.log %arg0 fastmath<nnan,afn> : tensor<32xf32, #blocked>
+    %log2 = math.log2 %arg0 fastmath<ninf,afn> : tensor<32xf32, #blocked>
+    %cos = math.cos %arg0 fastmath<nsz,afn> : tensor<32xf32, #blocked>
+    %sin = math.sin %arg0 fastmath<arcp,afn> : tensor<32xf32, #blocked>
+    %sqrt = math.sqrt %arg0 fastmath<nnan,afn> : tensor<32xf32, #blocked>
+    %erf = math.erf %arg0 fastmath<ninf> : tensor<32xf32, #blocked>
+    %cmp = arith.cmpf olt, %arg0, %arg1 fastmath<ninf> : tensor<32xf32, #blocked>
+    %abs = math.absf %arg0 fastmath<nsz> : tensor<32xf32, #blocked>
+    %maximum = arith.maximumf %abs, %arg1 fastmath<nnan> : tensor<32xf32, #blocked>
+    %ext = arith.extf %arg2 fastmath<nnan> : tensor<32xf16, #blocked> to tensor<32xf32, #blocked>
+    %trunc = arith.truncf %arg3 fastmath<ninf> : tensor<32xf64, #blocked> to tensor<32xf32, #blocked>
+    %exp64 = math.exp %arg3 fastmath<nnan,afn> : tensor<32xf64, #blocked>
+    %exp2 = math.exp2 %exp64 fastmath<nnan,afn> : tensor<32xf64, #blocked>
+    %rsqrt = math.rsqrt %exp2 fastmath<nnan,afn> : tensor<32xf64, #blocked>
+    %exp16 = math.exp %arg2 fastmath<afn> : tensor<32xf16, #blocked>
+    %exp16Strict = math.exp %arg2 fastmath<nnan> : tensor<32xf16, #blocked>
+    %exp2bf16 = math.exp2 %arg4 fastmath<afn> : tensor<32xbf16, #blocked>
+    %rsqrt16 = math.rsqrt %arg2 fastmath<afn> : tensor<32xf16, #blocked>
+    %floor16 = math.floor %arg2 fastmath<nsz> : tensor<32xf16, #blocked>
+    tt.return
+  }
+}
+
+// -----
+
+#blocked = #ttg.blocked<{sizePerThread = [1], threadsPerWarp = [32], warpsPerCTA = [1], order = [0]}>
+module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 1 : i32, ttg.target = "cuda:90", "ttg.threads-per-warp" = 32 : i32} {
+  // CHECK-LABEL: @fastmath_none
+  // CHECK-NOT: fastmathFlags
+  // CHECK: llvm.call @__nv_logf
+  // CHECK: llvm.return
+  tt.func @fastmath_none(
+      %arg0: tensor<32xf32, #blocked>,
+      %arg1: tensor<32xf32, #blocked>) {
+    %add = arith.addf %arg0, %arg1 : tensor<32xf32, #blocked>
+    %div = arith.divf %add, %arg1 : tensor<32xf32, #blocked>
+    %log = math.log %arg0 : tensor<32xf32, #blocked>
+    tt.return
+  }
+}
+
+// -----
+
+#blocked = #ttg.blocked<{sizePerThread = [1], threadsPerWarp = [32], warpsPerCTA = [1], order = [0]}>
+module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 1 : i32, ttg.target = "cuda:90", "ttg.threads-per-warp" = 32 : i32} {
+  // Sub-byte floats are converted to integers, so `absf` becomes a sign-bit
+  // mask that cannot represent fast-math flags.
+  // CHECK-LABEL: @fastmath_absf_masked
+  // CHECK-NOT: fastmath
+  // CHECK: llvm.and
+  // CHECK-NOT: fastmath
+  // CHECK: llvm.return
+  tt.func @fastmath_absf_masked(%arg0: tensor<32xf8E4M3FN, #blocked>) {
+    %abs = math.absf %arg0 fastmath<nsz> : tensor<32xf8E4M3FN, #blocked>
+    tt.return
+  }
+}

--- a/test/Conversion/tritongpu_to_llvm_volta.mlir
+++ b/test/Conversion/tritongpu_to_llvm_volta.mlir
@@ -29,3 +29,19 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32} {
     tt.return
   }
 }
+
+// -----
+
+#blocked1 = #ttg.blocked<{sizePerThread = [1], threadsPerWarp = [32], warpsPerCTA = [1], order = [0]}>
+module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 1 : i32, ttg.target = "cuda:70", "ttg.threads-per-warp" = 32 : i32} {
+  // CHECK-LABEL: fastmath_minmax_emulated
+  // CHECK-COUNT-2: llvm.fcmp "une" {{.*}} {fastmathFlags = #llvm.fastmath<nnan>} : f32
+  // CHECK: llvm.intr.maxnum({{.*}}) {fastmathFlags = #llvm.fastmath<nnan>} : (f32, f32) -> f32
+  // CHECK: llvm.select {{.*}} {fastmathFlags = #llvm.fastmath<nnan>} : i1, f32
+  tt.func @fastmath_minmax_emulated(
+      %arg0: tensor<32xf32, #blocked1>,
+      %arg1: tensor<32xf32, #blocked1>) {
+    %maximum = arith.maximumf %arg0, %arg1 fastmath<nnan> : tensor<32xf32, #blocked1>
+    tt.return
+  }
+}

--- a/test/Conversion/tritongpu_to_ptx.mlir
+++ b/test/Conversion/tritongpu_to_ptx.mlir
@@ -4,6 +4,7 @@
 // RUN: triton-opt %s --convert-triton-gpu-to-llvm='compute-capability=80 ptx-version=83' -cse | FileCheck --check-prefix=VEC80 --dump-input-context=20 %s
 // RUN: triton-opt %s --convert-triton-gpu-to-llvm='compute-capability=90 ptx-version=83' -cse | FileCheck --check-prefix=VEC90 --dump-input-context=20 %s
 // RUN: triton-opt %s --convert-triton-gpu-to-llvm='compute-capability=100 ptx-version=87' -cse | FileCheck --check-prefix=VEC100 --dump-input-context=20 %s
+// RUN: triton-opt %s --allocate-shared-memory-nv='compute-capability=90 ptx-version=83' --convert-triton-gpu-to-llvm='compute-capability=90 ptx-version=83' --convert-nv-gpu-to-llvm | mlir-translate --mlir-to-llvmir | FileCheck --check-prefix=LLVMIR-FMF %s
 
 
 #blocked = #ttg.blocked<{sizePerThread = [8], threadsPerWarp = [32], warpsPerCTA = [2], order = [0]}>
@@ -171,6 +172,37 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 2 : i32, "ttg.thr
     }) {allocation.offset = 0 : i32} : (tensor<1x256xf32, #blocked_reduce>) -> tensor<1xf32, #ttg.slice<{dim = 1, parent = #blocked_reduce}>>
     %ptr = tt.splat %out : !tt.ptr<f32> -> tensor<1x!tt.ptr<f32>, #ttg.slice<{dim = 1, parent = #blocked_reduce}>>
     tt.store %ptr, %r : tensor<1x!tt.ptr<f32>, #ttg.slice<{dim = 1, parent = #blocked_reduce}>>
+    tt.return
+  }
+
+  // LLVMIR-FMF-LABEL: define{{.*}} @fastmath_llvm_ir
+  // LLVMIR-FMF: fadd contract float
+  // LLVMIR-FMF: call arcp float @llvm.nvvm.div.full
+  // LLVMIR-FMF: fmul afn float
+  // LLVMIR-FMF: call afn float @llvm.nvvm.ex2.approx
+  // LLVMIR-FMF: call double @__nv_exp
+  // LLVMIR-FMF: call double @__nv_exp2
+  // LLVMIR-FMF: call double @__nv_rsqrt
+  // `afn` survives to the scalar math op, so libdevice lowering picks the
+  // approximate variant of log.
+  // LLVMIR-FMF: call float @__nv_fast_logf
+  // LLVMIR-FMF: call float @__nv_floorf
+  tt.func public @fastmath_llvm_ir(
+      %out: !tt.ptr<f32>,
+      %out64: !tt.ptr<f64>,
+      %arg0: f32,
+      %arg1: f32,
+      %arg2: f64) {
+    %add = arith.addf %arg0, %arg1 fastmath<contract> : f32
+    %div = arith.divf %add, %arg1 fastmath<arcp> : f32
+    %exp = math.exp %div fastmath<afn> : f32
+    %exp64 = math.exp %arg2 fastmath<nnan,afn> : f64
+    %exp2 = math.exp2 %exp64 fastmath<nnan,afn> : f64
+    %rsqrt = math.rsqrt %exp2 fastmath<nnan,afn> : f64
+    %log = math.log %arg0 fastmath<nnan,afn> : f32
+    %floor = math.floor %arg1 fastmath<ninf> : f32
+    tt.store %out, %exp : !tt.ptr<f32>
+    tt.store %out64, %rsqrt : !tt.ptr<f64>
     tt.return
   }
 }

--- a/third_party/amd/backend/compiler.py
+++ b/third_party/amd/backend/compiler.py
@@ -472,13 +472,24 @@ class HIPBackend(BaseBackend):
         if is_coexec_scheduler_enabled(options.arch) and options.num_warps <= 4:
             kernel_fn.add_fn_attr("amdgpu-sched-strategy", "coexec")
 
-        denormal_mode = "preserve-sign" if options.allow_flush_denorm else "ieee"
-        kernel_fn.add_fn_attr("denormal-fp-math-f32", denormal_mode)
+        denormal_default_mode = "ieee"
+        denormal_f32_mode = "preserve-sign" if options.allow_flush_denorm else "ieee"
+        llvm_fn_attrs = []
+        for name, value in options.llvm_fn_attrs:
+            # Preserve the override behavior of the legacy denormal attributes,
+            # but materialize them through LLVM's first-class attribute API.
+            if name == "denormal-fp-math":
+                denormal_default_mode = value
+            elif name == "denormal-fp-math-f32":
+                denormal_f32_mode = value
+            else:
+                llvm_fn_attrs.append((name, value))
+        kernel_fn.add_denormal_fp_env_attr(denormal_default_mode, denormal_f32_mode)
 
         if knobs.compilation.enable_asan:
             kernel_fn.add_fn_target_feature("+xnack")
             kernel_fn.add_fn_asan_attr()
-        for name, value in options.llvm_fn_attrs:
+        for name, value in llvm_fn_attrs:
             kernel_fn.remove_fn_attr(name)
             kernel_fn.add_fn_attr(name, value)
 

--- a/third_party/amd/lib/TritonAMDGPUToLLVM/ConvertFpCastOpToLLVM.cpp
+++ b/third_party/amd/lib/TritonAMDGPUToLLVM/ConvertFpCastOpToLLVM.cpp
@@ -49,7 +49,8 @@ Value Fp16ToFp32OneValue(Location loc, ConversionPatternRewriter &rewriter,
                          const Value &v);
 SmallVector<Value> convertFp32ToFp16rtne(Location loc,
                                          ConversionPatternRewriter &rewriter,
-                                         ArrayRef<Value> v, Type outElemTy);
+                                         ArrayRef<Value> v, Type outElemTy,
+                                         LLVM::FastmathFlagsAttr fastmathFlags);
 } // namespace
 
 namespace mlir::triton::AMD {
@@ -98,7 +99,8 @@ SmallVector<Value> convertFp32ToF16rtne(Location loc,
                                         ConversionPatternRewriter &rewriter,
                                         Type inElemTy, Type outElemTy,
                                         MultipleOperandsRange operands,
-                                        ISAFamily isaFamily) {
+                                        ISAFamily isaFamily,
+                                        LLVM::FastmathFlagsAttr fastmathFlags) {
   // For CDNA4 we can potentially use packed v_cvt_pk_[b]f16_f32 instructions.
   if (isCDNA4OrHigher(isaFamily)) {
     SmallVector<Value> inVals;
@@ -107,7 +109,8 @@ SmallVector<Value> convertFp32ToF16rtne(Location loc,
     for (unsigned i = 0; i < numElem; i++) {
       inVals.push_back(operands[i][0]);
     }
-    return convertFp32ToFp16rtne(loc, rewriter, inVals, outElemTy);
+    return convertFp32ToFp16rtne(loc, rewriter, inVals, outElemTy,
+                                 fastmathFlags);
   }
 
   if (outElemTy.isBF16()) {
@@ -115,7 +118,11 @@ SmallVector<Value> convertFp32ToF16rtne(Location loc,
     return {AMD::convertFp32ToBf16(loc, rewriter, operands[0][0],
                                    RoundingMode::RTNE)};
   }
-  return {LLVM::FPTruncOp::create(rewriter, loc, outElemTy, operands[0][0])};
+  auto result =
+      LLVM::FPTruncOp::create(rewriter, loc, outElemTy, operands[0][0]);
+  if (fastmathFlags)
+    result.setFastmathFlagsAttr(fastmathFlags);
+  return {result};
 }
 } // namespace mlir::triton::AMD
 
@@ -813,13 +820,18 @@ SmallVector<Value> Pk4Fp32ToF8(Location loc,
   return ret;
 }
 
-// Fp32->Fp16/Bf16 (RTNE) in GFX950
-SmallVector<Value> convertFp32ToFp16rtne(Location loc,
-                                         ConversionPatternRewriter &rewriter,
-                                         ArrayRef<Value> v, Type outElemTy) {
+// Fp32->Fp16/Bf16 (RTNE) on CDNA4 and GFX1250
+SmallVector<Value>
+convertFp32ToFp16rtne(Location loc, ConversionPatternRewriter &rewriter,
+                      ArrayRef<Value> v, Type outElemTy,
+                      LLVM::FastmathFlagsAttr fastmathFlags) {
   auto b = TritonLLVMOpBuilder(loc, rewriter);
-  if (v.size() == 1)
-    return {b.fptrunc(outElemTy, v.front())};
+  if (v.size() == 1) {
+    auto result = b.fptrunc(outElemTy, v.front());
+    if (fastmathFlags)
+      result.setFastmathFlagsAttr(fastmathFlags);
+    return {result};
+  }
 
   assert(v.size() == 2);
   auto inVecTy = vec_ty(f32_ty, 2);
@@ -829,7 +841,9 @@ SmallVector<Value> convertFp32ToFp16rtne(Location loc,
   auto idx1 = b.i32_val(1);
   inVec = b.insert_element(inVecTy, inVec, v[0], idx0);
   inVec = b.insert_element(inVecTy, inVec, v[1], idx1);
-  Value retVec = b.fptrunc(retVecTy, inVec);
+  auto retVec = b.fptrunc(retVecTy, inVec);
+  if (fastmathFlags)
+    retVec.setFastmathFlagsAttr(fastmathFlags);
   SmallVector<Value> ret(2);
   ret[0] = b.extract_element(outElemTy, retVec, idx0);
   ret[1] = b.extract_element(outElemTy, retVec, idx1);
@@ -1971,7 +1985,8 @@ public:
     Type dstTy = Float16Type::get(rewriter.getContext());
     if (roundingMode == RoundingMode::RTNE) {
       if (isCDNA4OrHigher(isaFamily))
-        return convertFp32ToFp16rtne(loc, rewriter, inVals, dstTy);
+        return convertFp32ToFp16rtne(loc, rewriter, inVals, dstTy,
+                                     /*fastmathFlags=*/{});
       else {
         SmallVector<Value> outVals;
         for (const Value &v : inVals) {
@@ -2025,7 +2040,8 @@ public:
 
     if (roundingMode == RoundingMode::RTNE) {
       if (isCDNA4OrHigher(isaFamily))
-        return convertFp32ToFp16rtne(loc, rewriter, v, dstTy);
+        return convertFp32ToFp16rtne(loc, rewriter, v, dstTy,
+                                     /*fastmathFlags=*/{});
       else {
         auto result =
             AMD::convertFp32ToBf16(loc, rewriter, v[0], RoundingMode::RTNE);

--- a/third_party/amd/lib/TritonAMDGPUToLLVM/ConvertFpCastOpToLLVM.h
+++ b/third_party/amd/lib/TritonAMDGPUToLLVM/ConvertFpCastOpToLLVM.h
@@ -14,7 +14,8 @@ SmallVector<Value> convertFp32ToF16rtne(Location loc,
                                         ConversionPatternRewriter &rewriter,
                                         Type inElemTy, Type outElemTy,
                                         gpu::MultipleOperandsRange operands,
-                                        amdgpu::ISAFamily isaFamily);
+                                        amdgpu::ISAFamily isaFamily,
+                                        LLVM::FastmathFlagsAttr fastmathFlags);
 } // namespace mlir::triton::AMD
 
 #endif // TRITON_THIRD_PARTY_AMD_LIB_CONVERTFPCASTOPTOLLVM_H_

--- a/third_party/amd/lib/TritonAMDGPUToLLVM/ElementwiseOpToLLVM.cpp
+++ b/third_party/amd/lib/TritonAMDGPUToLLVM/ElementwiseOpToLLVM.cpp
@@ -20,7 +20,9 @@ using mlir::triton::gpu::appendOrGetExternFuncOp;
 using mlir::triton::gpu::ElementwiseOpConversion;
 using mlir::triton::gpu::ElementwiseOpConversionBase;
 using mlir::triton::gpu::getFunctionType;
+using mlir::triton::gpu::getLLVMFastmathFlags;
 using mlir::triton::gpu::MultipleOperandsRange;
+using mlir::triton::gpu::propagateFastMathFlags;
 using triton::amdgpu::ISAFamily;
 
 namespace {
@@ -28,10 +30,11 @@ namespace {
 template <typename OP>
 Value EmitDualBF16ElementwiseOp(Location loc,
                                 ConversionPatternRewriter &rewriter,
-                                MultipleOperandsRange operands) {
+                                MultipleOperandsRange operands,
+                                LLVM::FastmathFlagsAttr fastmathFlags) {
   auto v0 = AMD::convertBf16ToFp32(loc, rewriter, operands[0][0]);
   auto v1 = AMD::convertBf16ToFp32(loc, rewriter, operands[0][1]);
-  auto result = OP::create(rewriter, loc, f32_ty, v0, v1);
+  auto result = OP::create(rewriter, loc, f32_ty, v0, v1, fastmathFlags);
   return AMD::convertFp32ToBf16(loc, rewriter, result, RoundingMode::RTNE);
 }
 
@@ -57,7 +60,8 @@ struct PackedArithOpConversion
 
     Value va = packLLVector(loc, {operands[0][0], operands[1][0]}, rewriter);
     Value vb = packLLVector(loc, {operands[0][1], operands[1][1]}, rewriter);
-    Value vr = LLVMOp::create(rewriter, loc, va.getType(), va, vb);
+    Value vr = LLVMOp::create(rewriter, loc, va.getType(), va, vb,
+                              getLLVMFastmathFlags(op));
     return unpackLLVector(loc, vr, rewriter);
   }
 };
@@ -72,7 +76,7 @@ struct FDivOpConversion
                                    Location loc) const {
 
     return {LLVM::FDivOp::create(rewriter, loc, elemTy, operands[0][0],
-                                 operands[0][1])};
+                                 operands[0][1], getLLVMFastmathFlags(op))};
   }
 };
 
@@ -87,10 +91,11 @@ struct FMulOpConversion
     auto lhsElemTy = getElementTypeOrSelf(op.getLhs());
     auto rhsElemTy = getElementTypeOrSelf(op.getRhs());
     if (lhsElemTy.isBF16() && rhsElemTy.isBF16()) {
-      return {EmitDualBF16ElementwiseOp<LLVM::FMulOp>(loc, rewriter, operands)};
+      return {EmitDualBF16ElementwiseOp<LLVM::FMulOp>(
+          loc, rewriter, operands, getLLVMFastmathFlags(op))};
     } else {
       return {LLVM::FMulOp::create(rewriter, loc, elemTy, operands[0][0],
-                                   operands[0][1])};
+                                   operands[0][1], getLLVMFastmathFlags(op))};
     }
   }
 };
@@ -106,10 +111,11 @@ struct FAddOpConversion
     auto lhsElemTy = getElementTypeOrSelf(op.getLhs());
     auto rhsElemTy = getElementTypeOrSelf(op.getRhs());
     if (lhsElemTy.isBF16() && rhsElemTy.isBF16()) {
-      return {EmitDualBF16ElementwiseOp<LLVM::FAddOp>(loc, rewriter, operands)};
+      return {EmitDualBF16ElementwiseOp<LLVM::FAddOp>(
+          loc, rewriter, operands, getLLVMFastmathFlags(op))};
     } else {
       return {LLVM::FAddOp::create(rewriter, loc, elemTy, operands[0][0],
-                                   operands[0][1])};
+                                   operands[0][1], getLLVMFastmathFlags(op))};
     }
   }
 };
@@ -125,10 +131,11 @@ struct FSubOpConversion
     auto lhsElemTy = getElementTypeOrSelf(op.getLhs());
     auto rhsElemTy = getElementTypeOrSelf(op.getRhs());
     if (lhsElemTy.isBF16() && rhsElemTy.isBF16()) {
-      return {EmitDualBF16ElementwiseOp<LLVM::FSubOp>(loc, rewriter, operands)};
+      return {EmitDualBF16ElementwiseOp<LLVM::FSubOp>(
+          loc, rewriter, operands, getLLVMFastmathFlags(op))};
     } else {
       return {LLVM::FSubOp::create(rewriter, loc, elemTy, operands[0][0],
-                                   operands[0][1])};
+                                   operands[0][1], getLLVMFastmathFlags(op))};
     }
   }
 };
@@ -202,9 +209,13 @@ struct ExtFOpConversion
     if (inElemTy.isBF16()) {
       auto outElemTy = getElementTypeOrSelf(op.getOut());
       assert(outElemTy.isF32() && "unsupported conversion");
+      // This conversion is implemented with integer bit operations, which
+      // cannot represent floating-point fast-math flags.
       return {AMD::convertBf16ToFp32(loc, rewriter, operands[0][0])};
     } else {
-      return {LLVM::FPExtOp::create(rewriter, loc, elemTy, operands[0][0])};
+      auto dstOp = LLVM::FPExtOp::create(rewriter, loc, elemTy, operands[0][0]);
+      propagateFastMathFlags(op, dstOp);
+      return {dstOp};
     }
   }
 };
@@ -227,10 +238,15 @@ struct TruncFOpConversion
     auto outElemTy = getElementTypeOrSelf(op.getOut());
     auto inElemTy = getElementTypeOrSelf(op.getIn());
     if (inElemTy.isF32() && (outElemTy.isBF16() || outElemTy.isF16())) {
+      // Hardware-backed FPTrunc operations can carry fast-math flags; the
+      // software BF16 bit-manipulation fallback cannot represent them.
       return AMD::convertFp32ToF16rtne(loc, rewriter, inElemTy, outElemTy,
-                                       operands, isaFamily);
+                                       operands, isaFamily,
+                                       getLLVMFastmathFlags(op));
     }
-    return {LLVM::FPTruncOp::create(rewriter, loc, elemTy, operands[0][0])};
+    auto dstOp = LLVM::FPTruncOp::create(rewriter, loc, elemTy, operands[0][0]);
+    propagateFastMathFlags(op, dstOp);
+    return {dstOp};
   }
 
 private:
@@ -251,7 +267,9 @@ struct ExpOpConversionApprox
       return {};
 
     const double log2e = 1.4426950408889634;
-    Value prod = b.fmul(f32_ty, operands[0][0], b.f32_val(log2e));
+    LLVM::FastmathFlagsAttr fastmathFlags = getLLVMFastmathFlags(op);
+    Value prod =
+        b.fmul(f32_ty, operands[0][0], b.f32_val(log2e), fastmathFlags);
 
     // Here we use llvm.exp2.f32 instead of math::Exp2Op. The latter
     // flushes denorms by default, but we want to preserve denorms by default
@@ -261,7 +279,10 @@ struct ExpOpConversionApprox
     LLVM::LLVMFuncOp funcOp =
         appendOrGetExternFuncOp(rewriter, op, funcName, funcType);
 
-    return {LLVM::createLLVMCallOp(rewriter, loc, funcOp, prod).getResult()};
+    auto callOp = LLVM::createLLVMCallOp(rewriter, loc, funcOp, prod);
+    if (fastmathFlags)
+      callOp.setFastmathFlagsAttr(fastmathFlags);
+    return {callOp.getResult()};
   }
 };
 
@@ -285,10 +306,16 @@ struct Exp2OpConversion
     // which flushes input and output denorms. `llvm.amdgcn.exp2.f32` provides
     // direct access to v_exp_f32. For `llvm.exp2.f32`, the LLVM backend inserts
     // instructions to handle denorms iff `allow_flush_denorm` is False.
+    //
+    // ROCDL ops map directly to AMDGPU intrinsics and do not implement
+    // LLVM::FastmathFlagsInterface, so the FTZ path cannot record the source
+    // fast-math flags.
     if (ftz)
       return {ROCDL::ROCDLExp2::create(rewriter, loc, elemTy, operands[0])};
 
-    return {LLVM::Exp2Op::create(rewriter, loc, elemTy, operands[0])};
+    auto dstOp = LLVM::Exp2Op::create(rewriter, loc, elemTy, operands[0]);
+    propagateFastMathFlags(op, dstOp);
+    return {dstOp};
   }
 
 private:
@@ -328,20 +355,28 @@ private:
 
 static inline std::pair<Value, Value>
 scaleUpIfDenorm(ConversionPatternRewriter &rewriter, Location loc,
-                const Value &src, float scaleThreshold, float scaleFactor) {
+                const Value &src, float scaleThreshold, float scaleFactor,
+                Operation *srcOp) {
   auto b = TritonLLVMOpBuilder(loc, rewriter);
-  Value needScale = b.fcmp_ogt(b.f32_val(scaleThreshold), src);
-  Value scaledSrc = b.fmul(f32_ty, src, b.f32_val(scaleFactor));
-  Value selectedSrc = b.select(needScale, scaledSrc, src);
+  auto needScale = b.fcmp_ogt(b.f32_val(scaleThreshold), src);
+  propagateFastMathFlags(srcOp, needScale);
+  auto scaledSrc = b.fmul(f32_ty, src, b.f32_val(scaleFactor));
+  propagateFastMathFlags(srcOp, scaledSrc);
+  auto selectedSrc = b.select(needScale, scaledSrc, src);
+  propagateFastMathFlags(srcOp, selectedSrc);
   return {needScale, selectedSrc};
 }
 
 static inline Value scaleDownIfDenorm(ConversionPatternRewriter &rewriter,
                                       Location loc, const Value &src,
-                                      Value needScale, float scaleFactor) {
+                                      Value needScale, float scaleFactor,
+                                      Operation *srcOp) {
   auto b = TritonLLVMOpBuilder(loc, rewriter);
-  Value scaledSrc = b.fmul(f32_ty, src, b.f32_val(scaleFactor));
-  return b.select(needScale, scaledSrc, src);
+  auto scaledSrc = b.fmul(f32_ty, src, b.f32_val(scaleFactor));
+  propagateFastMathFlags(srcOp, scaledSrc);
+  auto result = b.select(needScale, scaledSrc, src);
+  propagateFastMathFlags(srcOp, result);
+  return result;
 }
 
 struct SqrtOpConversion
@@ -384,7 +419,7 @@ struct SqrtOpConversion
       // Reference:
       // https://github.com/llvm/llvm-project/blob/0876c11c/llvm/lib/Target/AMDGPU/AMDGPULegalizerInfo.cpp#L5235-L5314.
       std::tie(needScale, scaledSrc) = scaleUpIfDenorm(
-          rewriter, loc, operands[0][0], 0x1.0p-96f, 0x1.0p+32f);
+          rewriter, loc, operands[0][0], 0x1.0p-96f, 0x1.0p+32f, op);
     }
 
     // llvm.amdgcn.sqrt.f32 provides direct access to v_sqrt_f32, which provides
@@ -396,7 +431,7 @@ struct SqrtOpConversion
       // In case of non-ftz, we need to calibrate the results by scaling down by
       // a factor of 2^{-16}.
       return {scaleDownIfDenorm(rewriter, loc, intrinsicsOutput, needScale,
-                                0x1.0p-16f)};
+                                0x1.0p-16f, op)};
     } else {
       return {intrinsicsOutput};
     }

--- a/third_party/nvidia/lib/TritonNVIDIAGPUToLLVM/ElementwiseOpToLLVM.cpp
+++ b/third_party/nvidia/lib/TritonNVIDIAGPUToLLVM/ElementwiseOpToLLVM.cpp
@@ -589,6 +589,7 @@ struct FDivOpConversion
     Value args[] = {operands[0][0], operands[0][1]};
     auto callOp =
         LLVM::createLLVMIntrinsicCallOp(rewriter, loc, name, resultTy, args);
+    propagateFastMathFlags(op, callOp);
     return {callOp.getResult(0)};
   }
 };
@@ -661,12 +662,15 @@ struct ExpOpConversionApprox
       return {};
 
     const double log2e = 1.4426950408889634;
-    Value prod = b.fmul(f32_ty, operands[0][0], b.f32_val(log2e));
+    LLVM::FastmathFlagsAttr fastmathFlags = getLLVMFastmathFlags(op);
+    Value prod =
+        b.fmul(f32_ty, operands[0][0], b.f32_val(log2e), fastmathFlags);
 
     Type resultTy = operands[0][0].getType();
     StringRef name = "llvm.nvvm.ex2.approx.f32";
     auto callOp =
         LLVM::createLLVMIntrinsicCallOp(rewriter, loc, name, resultTy, {prod});
+    propagateFastMathFlags(op, callOp);
     return {callOp.getResult(0)};
   }
 };


### PR DESCRIPTION
TritonGPU-to-LLVM accepts legal arith and math operations implementing ArithFastMathInterface. The elementwise lowering recreated these operations per element without forwarding their fast-math attributes.

The Python DSL does not currently expose arbitrary per-operation fast-math flags, so this cannot be reproduced from normal Python reproducers today. However, dropping attributes during lowering prevents compiler transformations, direct IR users, and future frontends from relying on them.

Additionally, in Triton’s AMD compilation path, `allow_flush_denorm=True` has no effect on generated code. Triton records the request using the legacy "denormal-fp-math-f32" string function attribute, while AMDGPU code generation queries the first-class denormal_fpenv attribute. Because the in-memory module does not pass through LLVM’s auto-upgrader after adding the string attribute, it remains syntactically valid but is not interpreted by code generation.
