### PR TITLE
[INTERPRETER] Convert bfloat16 operands of `tl.dot` before the matmul

### DIFF
--- a/python/test/unit/language/test_core.py
+++ b/python/test/unit/language/test_core.py
@@ -3932,8 +3932,6 @@ def get_test_small_dots_cases():
 def test_dot(M, N, K, num_warps, col_a, col_b, epilogue, input_precision, in_dtype, out_dtype, kpack, mma_nonk_size,
              num_ctas, device):
     if is_interpreter():
-        if in_dtype == 'bfloat16':
-            pytest.skip("bfloat16 is not supported in the interpreter")
         if input_precision == "bf16x3" or input_precision == "bf16x6":
             pytest.skip(f"input_precision {input_precision} is not supported in the interpreter")
     else:

--- a/python/triton/runtime/interpreter.py
+++ b/python/triton/runtime/interpreter.py
@@ -763,6 +763,11 @@ class InterpreterBuilder:
            (b.dtype.primitive_bitwidth == 8 and b.dtype.is_floating()):
             a_data = _convert_float(a_data, a.dtype, tl.float16, None).view(np.float16)
             b_data = _convert_float(b_data, b.dtype, tl.float16, None).view(np.float16)
+        # bfloat16 is stored as uint16 bit patterns; numpy has no bfloat16 type.
+        if a.dtype == tl.bfloat16:
+            a_data = _convert_float(a_data, tl.bfloat16, tl.float32, None).view(np.float32)
+        if b.dtype == tl.bfloat16:
+            b_data = _convert_float(b_data, tl.bfloat16, tl.float32, None).view(np.float32)
         return TensorHandle(np.matmul(a_data, b_data, dtype=d.data.dtype) + d.data, d.dtype.scalar)
 
     def create_make_range(self, ret_ty, start, stop):


### PR DESCRIPTION
The interpreter stores bfloat16 as uint16 and `create_dot` only converted 8-bit float operands, so a bfloat16 `tl.dot` multiplied the bit patterns (values around 1e10 for inputs in [-2, 2]). Convert bfloat16 operands to float32 through `_convert_float`, the way the cast path does, and stop skipping the bfloat16 cases of `test_dot` under the interpreter.

Fixes #11584.
