### PR TITLE
[Analysis] Infer ranges through reducible control flow

### DIFF
--- a/include/triton/Dialect/Triton/IR/Utility.h
+++ b/include/triton/Dialect/Triton/IR/Utility.h
@@ -199,6 +199,12 @@ bool isKernel(FunctionOpInterface funcOp);
 
 unsigned getBitwidth(RankedTensorType ty);
 
+// Values that can satisfy the predicate with some value in `other`.
+// Return nullopt when the comparison cannot hold.
+std::optional<ConstantIntRanges>
+getBoundFromCmpPredicate(arith::CmpIPredicate predicate,
+                         const ConstantIntRanges &other, bool isLhs = true);
+
 // If the value "anchor" is compared against a statically-computed bound, return
 // inclusive lower and upper bounds lb <= anchor <= ub. Depending on the
 // comparison operator, one of the bounds is a computed one while the other is

--- a/lib/Dialect/Triton/IR/Utility.cpp
+++ b/lib/Dialect/Triton/IR/Utility.cpp
@@ -52,80 +52,81 @@ unsigned tt::getBitwidth(RankedTensorType ty) {
   return isPtr ? kPtrBitWidth : std::max(ty.getElementTypeBitWidth(), 8u);
 }
 
+std::optional<ConstantIntRanges>
+tt::getBoundFromCmpPredicate(arith::CmpIPredicate predicate,
+                             const ConstantIntRanges &other, bool isLhs) {
+  using P = arith::CmpIPredicate;
+  if (predicate == P::eq)
+    return other;
+
+  unsigned width = other.umin().getBitWidth();
+  if (predicate == P::ne) {
+    auto value = other.getConstantValue();
+    if (!value)
+      return ConstantIntRanges::maxRange(width);
+    APInt umin = APInt::getZero(width), umax = APInt::getMaxValue(width);
+    APInt smin = APInt::getSignedMinValue(width);
+    APInt smax = APInt::getSignedMaxValue(width);
+    if (*value == umin)
+      ++umin;
+    if (*value == umax)
+      --umax;
+    if (*value == smin)
+      ++smin;
+    if (*value == smax)
+      --smax;
+    return ConstantIntRanges(umin, umax, smin, smax);
+  }
+
+  bool isSigned = predicate == P::slt || predicate == P::sle ||
+                  predicate == P::sgt || predicate == P::sge;
+  bool less = predicate == P::slt || predicate == P::sle ||
+              predicate == P::ult || predicate == P::ule;
+  bool strict = predicate == P::slt || predicate == P::sgt ||
+                predicate == P::ult || predicate == P::ugt;
+  bool upperBound = less == isLhs;
+  APInt min =
+      isSigned ? APInt::getSignedMinValue(width) : APInt::getZero(width);
+  APInt max =
+      isSigned ? APInt::getSignedMaxValue(width) : APInt::getMaxValue(width);
+  if (upperBound) {
+    APInt bound = isSigned ? other.smax() : other.umax();
+    if (strict && bound == min)
+      return std::nullopt;
+    max = strict ? bound - 1 : bound;
+  } else {
+    APInt bound = isSigned ? other.smin() : other.umin();
+    if (strict && bound == max)
+      return std::nullopt;
+    min = strict ? bound + 1 : bound;
+  }
+  return ConstantIntRanges::range(min, max, isSigned);
+}
+
 std::optional<ConstantIntRanges> tt::getBoundFromCmpOp(arith::CmpIOp cmpOp,
                                                        Value anchor) {
-  bool isSigned = true;
-  switch (cmpOp.getPredicate()) {
-  case arith::CmpIPredicate::uge:
-  case arith::CmpIPredicate::ugt:
-  case arith::CmpIPredicate::ule:
-  case arith::CmpIPredicate::ult:
-    isSigned = false;
-  default:
-    break;
-  }
+  // Assumption ranges replace inferred ranges, so an unrepresentable hole
+  // must not introduce an otherwise uninformative assumption.
+  if (cmpOp.getPredicate() == arith::CmpIPredicate::ne)
+    return std::nullopt;
+  bool isLhs = cmpOp.getLhs() == anchor;
+  auto value = getConstantIntValue(
+      getAsOpFoldResult(isLhs ? cmpOp.getRhs() : cmpOp.getLhs()));
+  if (!value)
+    return std::nullopt;
 
-  bool anchorIsLhs = cmpOp.getLhs() == anchor;
-  auto maybeConstantIntValue = getConstantIntValue(
-      getAsOpFoldResult(anchorIsLhs ? cmpOp.getRhs() : cmpOp.getLhs()));
-  if (auto constValue = maybeConstantIntValue) {
-    unsigned bitWidth = ConstantIntRanges::getStorageBitwidth(anchor.getType());
-    assert(bitWidth > 0 && "expected non-zero bitwdith");
-    APInt apVal = {bitWidth, static_cast<uint64_t>(*constValue), isSigned};
-    APInt min, max;
-    if (isSigned) {
-      min = APInt::getSignedMinValue(bitWidth);
-      if (llvm::isa_and_nonnull<mlir::triton::GetProgramIdOp,
-                                mlir::triton::GetNumProgramsOp>(
-              anchor.getDefiningOp())) {
-        min = APInt::getZero(bitWidth);
-      } else
-        min = APInt::getSignedMinValue(bitWidth);
-      max = APInt::getSignedMaxValue(bitWidth);
-    } else {
-      min = APInt::getMinValue(bitWidth);
-      max = APInt::getMaxValue(bitWidth);
-    }
-
-    switch (cmpOp.getPredicate()) {
-    case arith::CmpIPredicate::eq:
-      return mlir::ConstantIntRanges::constant(apVal);
-    case arith::CmpIPredicate::uge:
-    case arith::CmpIPredicate::sge: {
-      // K >= apVal implies K ∈ [apVal, max]
-      if (anchorIsLhs)
-        return mlir::ConstantIntRanges::range(apVal, max, isSigned);
-      // apVal >= K implies K ∈ [min, apVal]
-      return mlir::ConstantIntRanges::range(min, apVal, isSigned);
-    }
-    case arith::CmpIPredicate::ugt:
-    case arith::CmpIPredicate::sgt: {
-      // K > apVal implies K >= apVal + 1 implies K ∈ [apVal + 1, max]
-      if (anchorIsLhs)
-        return mlir::ConstantIntRanges::range(apVal + 1, max, isSigned);
-      // apVal > K implies apVal - 1 >= K implies K ∈ [min, apVal - 1]
-      return mlir::ConstantIntRanges::range(min, apVal - 1, isSigned);
-    }
-    case arith::CmpIPredicate::ule:
-    case arith::CmpIPredicate::sle: {
-      // K <= apVal implies K ∈ [min, apVal]
-      if (anchorIsLhs)
-        return mlir::ConstantIntRanges::range(min, apVal, isSigned);
-      // apVal <= K implies K ∈ [apVal, max]
-      return mlir::ConstantIntRanges::range(apVal, max, isSigned);
-    }
-    case arith::CmpIPredicate::ult:
-    case arith::CmpIPredicate::slt: {
-      // K < apVal implies K <= apVal -1 implies K ∈ [min, apVal - 1]
-      if (anchorIsLhs)
-        return mlir::ConstantIntRanges::range(min, apVal - 1, isSigned);
-      // apVal < K implies apVal + 1 <= K implies K ∈ [apVal + 1, max]
-      return mlir::ConstantIntRanges::range(apVal + 1, max, isSigned);
-    }
-    default:
-      emitRemark(cmpOp.getLoc(), "unsupported cmp predicate for assumption");
-      return {};
-    }
-  }
-  return {};
+  unsigned width = ConstantIntRanges::getStorageBitwidth(anchor.getType());
+  APInt bound(width, static_cast<uint64_t>(*value), /*isSigned=*/true);
+  auto result = getBoundFromCmpPredicate(
+      cmpOp.getPredicate(), ConstantIntRanges::constant(bound), isLhs);
+  auto predicate = cmpOp.getPredicate();
+  bool isSigned = predicate == arith::CmpIPredicate::slt ||
+                  predicate == arith::CmpIPredicate::sle ||
+                  predicate == arith::CmpIPredicate::sgt ||
+                  predicate == arith::CmpIPredicate::sge;
+  if (result && isSigned && result->smin().isMinSignedValue() &&
+      isa_and_nonnull<GetProgramIdOp, GetNumProgramsOp>(anchor.getDefiningOp()))
+    result = result->intersection(ConstantIntRanges::fromSigned(
+        APInt::getZero(width), APInt::getSignedMaxValue(width)));
+  return result;
 }

--- a/test/TritonGPU/amd/amd-range-analysis.mlir
+++ b/test/TritonGPU/amd/amd-range-analysis.mlir
@@ -1,4 +1,5 @@
 // RUN: triton-opt %s -split-input-file -allow-unregistered-dialect -test-tritonamdgpu-range-analysis -verify-diagnostics=only-expected | FileCheck %s
+// RUN: sed 's/expected-remark/unused-remark/g' %s | triton-opt -split-input-file -allow-unregistered-dialect -convert-scf-to-cf -test-tritonamdgpu-range-analysis 2>&1 | FileCheck %s --check-prefix=LOWERED
 
 // CHECK-LABEL:   tt.func @conversion1
 module attributes {"ttg.num-warps" = 4 : i32} {
@@ -2010,4 +2011,501 @@ module attributes {"ttg.num-warps" = 4 : i32} {
     }
     tt.return %res : i32
   }
+}
+
+// -----
+
+// Lowered scf.for values are visible in the body and exit by dominance.
+// CHECK-LABEL: tt.func @cf_counted_loop
+tt.func @cf_counted_loop() -> i32 {
+  %c0 = arith.constant 0 : i32
+  %c1 = arith.constant 1 : i32
+  %c2 = arith.constant 2 : i32
+  %c3 = arith.constant 3 : i32
+  %c8 = arith.constant 8 : i32
+  cf.br ^header(%c0, %c3 : i32, i32)
+^header(%iv: i32, %q: i32):
+  // The header also executes for the final failed condition.
+  // expected-remark@+1 {{unsigned : [0, 8] signed : [0, 8]}}
+  %header_iv = arith.addi %iv, %c0 : i32
+  %condition = arith.cmpi slt, %iv, %c8 : i32
+  cf.cond_br %condition, ^body, ^exit
+^body:
+  // expected-remark@+1 {{unsigned : [0, 7] signed : [0, 7]}}
+  %body_iv = arith.addi %iv, %c0 : i32
+  // expected-remark@+1 {{unsigned : [3, 17] signed : [3, 17]}}
+  %body_q = arith.addi %q, %c0 : i32
+  %next_q = arith.addi %q, %c2 : i32
+  %next_iv = arith.addi %iv, %c1 : i32
+  cf.br ^header(%next_iv, %next_q : i32, i32)
+^exit:
+  // expected-remark@+1 {{unsigned : [8, 8] signed : [8, 8]}}
+  %exit_iv = arith.addi %iv, %c0 : i32
+  // expected-remark@+1 {{unsigned : [19, 19] signed : [19, 19]}}
+  %exit_q = arith.addi %q, %c0 : i32
+  tt.return %exit_q : i32
+}
+
+// -----
+
+// CHECK-LABEL: tt.func @cf_nonunit_step
+tt.func @cf_nonunit_step() -> i32 {
+  %c0 = arith.constant 0 : i32
+  %c1 = arith.constant 1 : i32
+  %c3 = arith.constant 3 : i32
+  %c8 = arith.constant 8 : i32
+  cf.br ^header(%c1 : i32)
+^header(%iv: i32):
+  %condition = arith.cmpi slt, %iv, %c8 : i32
+  cf.cond_br %condition, ^body, ^exit
+^body:
+  // expected-remark@+1 {{unsigned : [1, 7] signed : [1, 7]}}
+  %body_iv = arith.addi %iv, %c0 : i32
+  %next_iv = arith.addi %iv, %c3 : i32
+  cf.br ^header(%next_iv : i32)
+^exit:
+  // expected-remark@+1 {{unsigned : [10, 10] signed : [10, 10]}}
+  %exit_iv = arith.addi %iv, %c0 : i32
+  tt.return %exit_iv : i32
+}
+
+// -----
+
+// CHECK-LABEL: tt.func @cf_zero_trip
+tt.func @cf_zero_trip() -> i32 {
+  %c0 = arith.constant 0 : i32
+  %c1 = arith.constant 1 : i32
+  %c3 = arith.constant 3 : i32
+  %c4 = arith.constant 4 : i32
+  %c8 = arith.constant 8 : i32
+  cf.br ^header(%c8, %c3 : i32, i32)
+^header(%iv: i32, %q: i32):
+  %condition = arith.cmpi slt, %iv, %c4 : i32
+  cf.cond_br %condition, ^body, ^exit
+^body:
+  %next_q = arith.addi %q, %c1 : i32
+  %next_iv = arith.addi %iv, %c1 : i32
+  cf.br ^header(%next_iv, %next_q : i32, i32)
+^exit:
+  // expected-remark@+1 {{unsigned : [8, 8] signed : [8, 8]}}
+  %exit_iv = arith.addi %iv, %c0 : i32
+  // expected-remark@+1 {{unsigned : [3, 3] signed : [3, 3]}}
+  %exit_q = arith.addi %q, %c0 : i32
+  tt.return %exit_q : i32
+}
+
+// -----
+
+// CHECK-LABEL: tt.func @cf_descending_while
+tt.func @cf_descending_while() -> i32 {
+  %c0 = arith.constant 0 : i32
+  %c2 = arith.constant 2 : i32
+  %c8 = arith.constant 8 : i32
+  cf.br ^header(%c8 : i32)
+^header(%iv: i32):
+  %condition = arith.cmpi sgt, %iv, %c0 : i32
+  cf.cond_br %condition, ^body(%iv : i32), ^exit
+^body(%body_arg: i32):
+  // expected-remark@+1 {{unsigned : [2, 8] signed : [2, 8]}}
+  %body_iv = arith.addi %body_arg, %c0 : i32
+  %next_iv = arith.subi %body_arg, %c2 : i32
+  cf.br ^header(%next_iv : i32)
+^exit:
+  // expected-remark@+1 {{unsigned : [0, 0] signed : [0, 0]}}
+  %exit_iv = arith.addi %iv, %c0 : i32
+  tt.return %exit_iv : i32
+}
+
+// -----
+
+// CHECK-LABEL: tt.func @cf_dynamic_bound
+module attributes {"ttg.num-warps" = 4 : i32, "test.pid-bound-x" = 7 : i64} {
+  tt.func @cf_dynamic_bound() -> i32 {
+    %c0 = arith.constant 0 : i32
+    %c1 = arith.constant 1 : i32
+    %pid = tt.get_program_id x : i32
+    %bound = arith.addi %pid, %c1 : i32
+    cf.br ^header(%c0 : i32)
+  ^header(%iv: i32):
+    %condition = arith.cmpi slt, %iv, %bound : i32
+    cf.cond_br %condition, ^body, ^exit
+  ^body:
+    // expected-remark@+1 {{unsigned : [0, 7] signed : [0, 7]}}
+    %body_iv = arith.addi %iv, %c0 : i32
+    %next_iv = arith.addi %iv, %c1 : i32
+    cf.br ^header(%next_iv : i32)
+  ^exit:
+    // expected-remark@+1 {{unsigned : [1, 8] signed : [1, 8]}}
+    %exit_iv = arith.addi %iv, %c0 : i32
+    tt.return %exit_iv : i32
+  }
+}
+
+// -----
+
+// The outer body's guard narrows both the inner initial value and bound.
+// CHECK-LABEL: tt.func @cf_nested_loops
+tt.func @cf_nested_loops() -> i32 {
+  %c0 = arith.constant 0 : i32
+  %c1 = arith.constant 1 : i32
+  %c2 = arith.constant 2 : i32
+  %c4 = arith.constant 4 : i32
+  cf.br ^outer_header(%c0 : i32)
+^outer_header(%i: i32):
+  %outer_condition = arith.cmpi slt, %i, %c4 : i32
+  cf.cond_br %outer_condition, ^outer_body, ^exit
+^outer_body:
+  // expected-remark@+1 {{unsigned : [2, 5] signed : [2, 5]}}
+  %inner_bound = arith.addi %i, %c2 : i32
+  cf.br ^inner_header(%i : i32)
+^inner_header(%j: i32):
+  %inner_condition = arith.cmpi slt, %j, %inner_bound : i32
+  cf.cond_br %inner_condition, ^inner_body, ^outer_latch
+^inner_body:
+  // expected-remark@+1 {{unsigned : [0, 4] signed : [0, 4]}}
+  %body_j = arith.addi %j, %c0 : i32
+  %next_j = arith.addi %j, %c1 : i32
+  cf.br ^inner_header(%next_j : i32)
+^outer_latch:
+  // expected-remark@+1 {{unsigned : [2, 5] signed : [2, 5]}}
+  %exit_j = arith.addi %j, %c0 : i32
+  %next_i = arith.addi %i, %c1 : i32
+  cf.br ^outer_header(%next_i : i32)
+^exit:
+  // expected-remark@+1 {{unsigned : [4, 4] signed : [4, 4]}}
+  %exit_i = arith.addi %i, %c0 : i32
+  tt.return %exit_i : i32
+}
+
+// -----
+
+// The apparent final value 130 overflows i8; this is not a bounded recurrence.
+// CHECK-LABEL: tt.func @cf_overflowing_sentinel
+tt.func @cf_overflowing_sentinel() {
+  %c0 = arith.constant 0 : i8
+  %c10 = arith.constant 10 : i8
+  %c120 = arith.constant 120 : i8
+  %c127 = arith.constant 127 : i8
+  cf.br ^header(%c120 : i8)
+^header(%iv: i8):
+  // Repeated wrapping visits every even i8 value, including -128.
+  // expected-remark@+1 {{signed : [-128,}}
+  %header_iv = arith.addi %iv, %c0 : i8
+  %condition = arith.cmpi slt, %iv, %c127 : i8
+  cf.cond_br %condition, ^body, ^exit
+^body:
+  %next_iv = arith.addi %iv, %c10 : i8
+  cf.br ^header(%next_iv : i8)
+^exit:
+  tt.return
+}
+
+// -----
+
+// Both cycle blocks have an entry edge, so neither is a natural-loop header.
+// CHECK-LABEL: tt.func @cf_irreducible_cycle
+tt.func @cf_irreducible_cycle(%choose: i1, %leave: i1) {
+  %c0 = arith.constant 0 : i32
+  %c1 = arith.constant 1 : i32
+  cf.cond_br %choose, ^left(%c0 : i32), ^right(%c0 : i32)
+^left(%x: i32):
+  // expected-remark@+1 {{unsigned : [0, 4294967295] signed : [-2147483648, 2147483647]}}
+  %observed = arith.addi %x, %c0 : i32
+  %next_x = arith.addi %x, %c1 : i32
+  cf.cond_br %leave, ^exit, ^right(%next_x : i32)
+^right(%y: i32):
+  %next_y = arith.addi %y, %c1 : i32
+  cf.br ^left(%next_y : i32)
+^exit:
+  tt.return
+}
+
+// -----
+
+// CHECK-LABEL: tt.func @cf_guard_scope
+module attributes {"ttg.num-warps" = 4 : i32, "test.pid-bound-x" = 15 : i64} {
+  tt.func @cf_guard_scope() -> i32 {
+    %c0 = arith.constant 0 : i32
+    %c8 = arith.constant 8 : i32
+    %pid = tt.get_program_id x : i32
+    %condition = arith.cmpi slt, %pid, %c8 : i32
+    cf.cond_br %condition, ^then, ^else
+  ^then:
+    // expected-remark@+1 {{unsigned : [0, 7] signed : [0, 7]}}
+    %then_value = arith.addi %pid, %c0 : i32
+    cf.br ^merge
+  ^else:
+    // expected-remark@+1 {{unsigned : [8, 15] signed : [8, 15]}}
+    %else_value = arith.addi %pid, %c0 : i32
+    cf.br ^merge
+  ^merge:
+    // expected-remark@+1 {{unsigned : [0, 15] signed : [0, 15]}}
+    %merged_value = arith.addi %pid, %c0 : i32
+    tt.return %merged_value : i32
+  }
+}
+
+// -----
+
+// Neither condition holds throughout a block reached by both branch edges.
+// CHECK-LABEL: tt.func @cf_duplicate_successors
+module attributes {"ttg.num-warps" = 4 : i32, "test.pid-bound-x" = 15 : i64} {
+  tt.func @cf_duplicate_successors() -> i32 {
+    %c0 = arith.constant 0 : i32
+    %c8 = arith.constant 8 : i32
+    %pid = tt.get_program_id x : i32
+    %condition = arith.cmpi slt, %pid, %c8 : i32
+    cf.cond_br %condition, ^merge(%pid : i32), ^merge(%pid : i32)
+  ^merge(%value: i32):
+    // expected-remark@+1 {{unsigned : [0, 15] signed : [0, 15]}}
+    %argument = arith.addi %value, %c0 : i32
+    // expected-remark@+1 {{unsigned : [0, 15] signed : [0, 15]}}
+    %direct = arith.addi %pid, %c0 : i32
+    tt.return %argument : i32
+  }
+}
+
+// -----
+
+// scf.for also lowers to an unsigned comparison when unsignedCmp is present.
+// CHECK-LABEL: tt.func @cf_unsigned_loop
+tt.func @cf_unsigned_loop() -> i32 {
+  %c0 = arith.constant 0 : i32
+  %c1 = arith.constant 1 : i32
+  %start = arith.constant -2147483648 : i32
+  %bound = arith.constant -2147483640 : i32
+  cf.br ^header(%start : i32)
+^header(%iv: i32):
+  %condition = arith.cmpi ult, %iv, %bound : i32
+  cf.cond_br %condition, ^body, ^exit
+^body:
+  // expected-remark@+1 {{unsigned : [2147483648, 2147483655] signed : [-2147483648, -2147483641]}}
+  %body_iv = arith.addi %iv, %c0 : i32
+  %next_iv = arith.addi %iv, %c1 : i32
+  cf.br ^header(%next_iv : i32)
+^exit:
+  // expected-remark@+1 {{unsigned : [2147483656, 2147483656] signed : [-2147483640, -2147483640]}}
+  %exit_iv = arith.addi %iv, %c0 : i32
+  tt.return %exit_iv : i32
+}
+
+// -----
+
+// An inner comparison also benefits from the enclosing branch's bounds.
+// CHECK-LABEL: tt.func @cf_nested_guards
+module attributes {"ttg.num-warps" = 4 : i32, "test.pid-bound-x" = 127 : i64, "test.pid-bound-y" = 127 : i64} {
+  tt.func @cf_nested_guards() {
+    %c0 = arith.constant 0 : i32
+    %c16 = arith.constant 16 : i32
+    %x = tt.get_program_id x : i32
+    %y = tt.get_program_id y : i32
+    %outer = arith.cmpi slt, %y, %c16 : i32
+    cf.cond_br %outer, ^small, ^exit
+  ^small:
+    %inner = arith.cmpi slt, %x, %y : i32
+    cf.cond_br %inner, ^ordered, ^exit
+  ^ordered:
+    // expected-remark@+1 {{unsigned : [0, 14] signed : [0, 14]}}
+    %bounded = arith.addi %x, %c0 : i32
+    cf.br ^exit
+  ^exit:
+    tt.return
+  }
+}
+
+// -----
+
+// The assume's block determines its scope, even when the comparison is hoisted.
+// CHECK-LABEL: tt.func @cf_assume_scope
+tt.func @cf_assume_scope(%x: i32, %choose: i1) {
+  %c0 = arith.constant 0 : i32
+  %nonnegative = arith.cmpi sge, %x, %c0 : i32
+  cf.cond_br %choose, ^then, ^else
+^then:
+  llvm.intr.assume %nonnegative : i1
+  // expected-remark@+1 {{unsigned : [0, 2147483647] signed : [0, 2147483647]}}
+  %positive = arith.addi %x, %c0 : i32
+  tt.return
+^else:
+  // expected-remark@+1 {{unsigned : [0, 4294967295] signed : [-2147483648, 2147483647]}}
+  %unconstrained = arith.addi %x, %c0 : i32
+  tt.return
+}
+
+// -----
+
+// The inner loop's final accumulator is one update of the outer recurrence.
+// CHECK-LABEL: tt.func @cf_nested_accumulator
+tt.func @cf_nested_accumulator() -> i32 {
+  %c0 = arith.constant 0 : i32
+  %c1 = arith.constant 1 : i32
+  %c3 = arith.constant 3 : i32
+  %c4 = arith.constant 4 : i32
+  cf.br ^outer_header(%c0, %c0 : i32, i32)
+^outer_header(%i: i32, %outer_acc: i32):
+  %outer_condition = arith.cmpi slt, %i, %c4 : i32
+  cf.cond_br %outer_condition, ^outer_body, ^exit
+^outer_body:
+  // expected-remark@+1 {{unsigned : [0, 9] signed : [0, 9]}}
+  %outer_value = arith.addi %outer_acc, %c0 : i32
+  cf.br ^inner_header(%c0, %outer_acc : i32, i32)
+^inner_header(%j: i32, %inner_acc: i32):
+  %inner_condition = arith.cmpi slt, %j, %c3 : i32
+  cf.cond_br %inner_condition, ^inner_body, ^outer_latch
+^inner_body:
+  // expected-remark@+1 {{unsigned : [0, 11] signed : [0, 11]}}
+  %inner_value = arith.addi %inner_acc, %c0 : i32
+  %next_acc = arith.addi %inner_acc, %c1 : i32
+  %next_j = arith.addi %j, %c1 : i32
+  cf.br ^inner_header(%next_j, %next_acc : i32, i32)
+^outer_latch:
+  %next_i = arith.addi %i, %c1 : i32
+  cf.br ^outer_header(%next_i, %inner_acc : i32, i32)
+^exit:
+  // expected-remark@+1 {{unsigned : [12, 12] signed : [12, 12]}}
+  %result = arith.addi %outer_acc, %c0 : i32
+  tt.return %result : i32
+}
+
+// -----
+
+// Each diamond arm contributes to every iteration, regardless of visit order.
+// CHECK-LABEL: tt.func @cf_diamond_accumulator
+tt.func @cf_diamond_accumulator(%choose: i1) -> i32 {
+  %c0 = arith.constant 0 : i32
+  %c1 = arith.constant 1 : i32
+  %c2 = arith.constant 2 : i32
+  %c100 = arith.constant 100 : i32
+  cf.br ^header(%c0, %c0 : i32, i32)
+^header(%iv: i32, %acc: i32):
+  %condition = arith.cmpi slt, %iv, %c2 : i32
+  cf.cond_br %condition, ^body, ^exit
+^body:
+  // expected-remark@+1 {{unsigned : [0, 100] signed : [0, 100]}}
+  %body_acc = arith.addi %acc, %c0 : i32
+  cf.cond_br %choose, ^then, ^else
+^then:
+  %small = arith.addi %acc, %c1 : i32
+  cf.br ^latch(%small : i32)
+^else:
+  %large = arith.addi %acc, %c100 : i32
+  cf.br ^latch(%large : i32)
+^latch(%next_acc: i32):
+  %next_iv = arith.addi %iv, %c1 : i32
+  cf.br ^header(%next_iv, %next_acc : i32, i32)
+^exit:
+  // expected-remark@+1 {{unsigned : [2, 200] signed : [2, 200]}}
+  %result = arith.addi %acc, %c0 : i32
+  tt.return %result : i32
+}
+
+// -----
+
+// The child's bound and an enclosing guard must not recursively query each other.
+// CHECK-LABEL: tt.func @cf_guarded_nested_accumulator
+tt.func @cf_guarded_nested_accumulator() -> i32 {
+  %c0 = arith.constant 0 : i32
+  %c1 = arith.constant 1 : i32
+  %c4 = arith.constant 4 : i32
+  %c10 = arith.constant 10 : i32
+  cf.br ^outer_header(%c0, %c10 : i32, i32)
+^outer_header(%i: i32, %q: i32):
+  %condition = arith.cmpi slt, %i, %c4 : i32
+  cf.cond_br %condition, ^outer_body, ^exit
+^outer_body:
+  %guard = arith.cmpi slt, %i, %q : i32
+  cf.cond_br %guard, ^inner_entry, ^outer_latch(%q : i32)
+^inner_entry:
+  cf.br ^inner_header(%c0, %q : i32, i32)
+^inner_header(%j: i32, %inner_q: i32):
+  %inner_condition = arith.cmpi slt, %j, %i : i32
+  cf.cond_br %inner_condition, ^inner_body, ^inner_exit
+^inner_body:
+  %next_j = arith.addi %j, %c1 : i32
+  %next_q = arith.addi %inner_q, %c1 : i32
+  cf.br ^inner_header(%next_j, %next_q : i32, i32)
+^inner_exit:
+  cf.br ^outer_latch(%inner_q : i32)
+^outer_latch(%next_outer_q: i32):
+  %next_i = arith.addi %i, %c1 : i32
+  cf.br ^outer_header(%next_i, %next_outer_q : i32, i32)
+^exit:
+  // expected-remark@+1 {{unsigned : [10, 22] signed : [10, 22]}}
+  %result = arith.addi %q, %c0 : i32
+  tt.return %result : i32
+}
+
+// -----
+
+// Visit shared boolean subexpressions once when recovering branch constraints.
+// CHECK-LABEL: tt.func @cf_shared_condition
+module attributes {"ttg.num-warps" = 4 : i32, "test.pid-bound-x" = 15 : i64} {
+  tt.func @cf_shared_condition() {
+    %c0 = arith.constant 0 : i32
+    %c8 = arith.constant 8 : i32
+    %x = tt.get_program_id x : i32
+    %cmp = arith.cmpi slt, %x, %c8 : i32
+    %cnd0 = arith.andi %cmp, %cmp : i1
+    %cnd1 = arith.andi %cnd0, %cnd0 : i1
+    %cnd2 = arith.andi %cnd1, %cnd1 : i1
+    %cnd3 = arith.andi %cnd2, %cnd2 : i1
+    %cnd4 = arith.andi %cnd3, %cnd3 : i1
+    %cnd5 = arith.andi %cnd4, %cnd4 : i1
+    %cnd6 = arith.andi %cnd5, %cnd5 : i1
+    %cnd7 = arith.andi %cnd6, %cnd6 : i1
+    %cnd8 = arith.andi %cnd7, %cnd7 : i1
+    %cnd9 = arith.andi %cnd8, %cnd8 : i1
+    %cnd10 = arith.andi %cnd9, %cnd9 : i1
+    %cnd11 = arith.andi %cnd10, %cnd10 : i1
+    %cnd12 = arith.andi %cnd11, %cnd11 : i1
+    %cnd13 = arith.andi %cnd12, %cnd12 : i1
+    %cnd14 = arith.andi %cnd13, %cnd13 : i1
+    %cnd15 = arith.andi %cnd14, %cnd14 : i1
+    %cnd16 = arith.andi %cnd15, %cnd15 : i1
+    %cnd17 = arith.andi %cnd16, %cnd16 : i1
+    %cnd18 = arith.andi %cnd17, %cnd17 : i1
+    %cnd19 = arith.andi %cnd18, %cnd18 : i1
+    %cnd20 = arith.andi %cnd19, %cnd19 : i1
+    %cnd21 = arith.andi %cnd20, %cnd20 : i1
+    %cnd22 = arith.andi %cnd21, %cnd21 : i1
+    %cnd23 = arith.andi %cnd22, %cnd22 : i1
+    %cnd24 = arith.andi %cnd23, %cnd23 : i1
+    %cnd25 = arith.andi %cnd24, %cnd24 : i1
+    %cnd26 = arith.andi %cnd25, %cnd25 : i1
+    %cnd27 = arith.andi %cnd26, %cnd26 : i1
+    %cnd28 = arith.andi %cnd27, %cnd27 : i1
+    %cnd29 = arith.andi %cnd28, %cnd28 : i1
+    %cnd30 = arith.andi %cnd29, %cnd29 : i1
+    %cnd31 = arith.andi %cnd30, %cnd30 : i1
+    cf.cond_br %cnd31, ^then, ^exit
+  ^then:
+    // expected-remark@+1 {{unsigned : [0, 7] signed : [0, 7]}}
+    %bounded = arith.addi %x, %c0 : i32
+    cf.br ^exit
+  ^exit:
+    tt.return
+  }
+}
+
+// -----
+
+// Check the actual lowering, including its final header value at the loop exit.
+// CHECK-LABEL: tt.func @scf_to_cf_counted_loop
+tt.func @scf_to_cf_counted_loop() -> i32 {
+  %c0 = arith.constant 0 : i32
+  %c1 = arith.constant 1 : i32
+  %c2 = arith.constant 2 : i32
+  %c3 = arith.constant 3 : i32
+  %c8 = arith.constant 8 : i32
+  %q = scf.for %iv = %c0 to %c8 step %c1 iter_args(%acc = %c3) -> (i32) : i32 {
+    // LOWERED: :[[@LINE+2]]:{{[0-9]+}}: remark: unsigned : [0, 7] signed : [0, 7]
+    // expected-remark@+1 {{unsigned : [0, 7] signed : [0, 7]}}
+    %body_iv = arith.addi %iv, %c0 : i32
+    %next_q = arith.addi %acc, %c2 : i32
+    scf.yield %next_q : i32
+  }
+  // LOWERED: :[[@LINE+2]]:{{[0-9]+}}: remark: unsigned : [19, 19] signed : [19, 19]
+  // expected-remark@+1 {{unsigned : [5, 19] signed : [5, 19]}}
+  %exit_q = arith.addi %q, %c0 : i32
+  tt.return %exit_q : i32
 }

--- a/third_party/amd/include/Analysis/RangeAnalysis.h
+++ b/third_party/amd/include/Analysis/RangeAnalysis.h
@@ -6,16 +6,20 @@
 #include "mlir/Dialect/Arith/IR/Arith.h"
 #include "mlir/IR/Dominance.h"
 #include "mlir/Interfaces/LoopLikeInterface.h"
+#include <memory>
 
 namespace mlir::triton {
 class FuncOp;
+namespace AMD::detail {
+class ControlFlowRangeAnalysis;
 }
+} // namespace mlir::triton
 
 namespace mlir::triton::AMD {
 
 /// This struct (analysis) adapt's upstream's IntegerRangeAnalysis (inferring
 /// lower/upperbounds on integer constants) to our needs.
-/// Specifically there are 2 points of extension:
+/// Specifically there are 3 points of extension:
 ///
 /// 1. Support for GetProgramIdOp, MakeRangeOp, SplatOp, ExpandDimsOp. *Note*,
 /// upstream already supports range inference for shaped types such as tensors
@@ -31,6 +35,11 @@ namespace mlir::triton::AMD {
 /// body values). Here we attempt to do better by analysis the loop bounds and
 /// "abstractly interpreting" the loop when loop bounds are statically known.
 /// See visitRegionSuccessors.
+///
+/// 3. Natural loops in CF graphs use affine recurrence summaries, with
+/// arithmetic overflow checked through the final failed condition. Branch
+/// conditions and loop body/exit bounds refine ranges at each use. Unsupported
+/// recurrences retain MLIR's bounded merge-site widening.
 struct TritonIntegerRangeAnalysis : dataflow::IntegerRangeAnalysis {
   using dataflow::IntegerRangeAnalysis::IntegerRangeAnalysis;
   using Base = dataflow::IntegerRangeAnalysis;
@@ -50,6 +59,13 @@ struct TritonIntegerRangeAnalysis : dataflow::IntegerRangeAnalysis {
   void initializeFuncOp(triton::FuncOp funcOp);
 
   LogicalResult initialize(Operation *top) override;
+
+  LogicalResult visit(ProgramPoint *point) override;
+
+  /// Range at a use, including dominating branch conditions and the body or
+  /// exit range of a natural loop. The global lattice also includes values at
+  /// the loop header's final, failing condition.
+  IntegerValueRange getRangeAt(Value value, Operation *use);
 
   LogicalResult visitOperation(
       Operation *op,
@@ -139,8 +155,8 @@ struct TritonIntegerRangeAnalysis : dataflow::IntegerRangeAnalysis {
   ///   llvm.intr.assume %assumesltlhs : i1
   ///   %assumesltlhs = arith.cmpi slt, %K, %c128 : i32
   ///   llvm.intr.assume %assumesltlhs : i1
-  /// If one uses collectAssumptions below then `assumptions` will look like
-  /// %K -> {arith.cmpi slt..., arith.cmpi sge}.
+  /// Entries retain the llvm.intr.assume operations so their blocks determine
+  /// where the comparison bounds are valid.
   llvm::DenseMap<Value, SetVector<Operation *>> assumptions;
 
   /// The defaultTransferFunc is the default transfer function for this dataflow
@@ -148,19 +164,36 @@ struct TritonIntegerRangeAnalysis : dataflow::IntegerRangeAnalysis {
   /// @param[in] op: the Operation in question
   /// @param[in] result: a particular value defined by this op. Note that op
   ///            may define multiple values.
-  /// @param[in] srcLattices: lattices of all source operands
   /// @param[in] destLattices: lattices all all result values
   /// @param[in] incomingRange: the value-range inffered for result
   void defaultTransferFunc(
       Operation *op, Value result,
-      ArrayRef<const dataflow::IntegerValueRangeLattice *> srcLattices,
       ArrayRef<dataflow::IntegerValueRangeLattice *> destLattices,
       const IntegerValueRange &incomingRange);
 
 private:
+  void visitControlFlowBlock(Block *block);
+  IntegerValueRange getRangeAt(Value value, Block *block, ProgramPoint *point);
+  IntegerValueRange refineWithCondition(Value value, IntegerValueRange range,
+                                        Value condition, bool isTrue,
+                                        ProgramPoint *point);
+
+  struct BranchConstraint {
+    Value condition;
+    bool isTrue;
+    BranchConstraint *parent = nullptr;
+  };
+  BranchConstraint *getConstraintScope(Block *block);
+  DenseMap<Block *, BranchConstraint> branchConstraints;
+  DenseMap<Block *, BranchConstraint *> blockConstraints;
+  using RangeQuery = std::pair<Value, Block *>;
+  DenseSet<RangeQuery> activeRangeQueries;
+  DenseMap<RangeQuery, IntegerValueRange> rangeQueryCache;
+  std::shared_ptr<detail::ControlFlowRangeAnalysis> controlFlow;
+  std::unique_ptr<DominanceInfo> ownedDomInfo;
+
   LogicalResult visitOperationHelper(
-      Operation *op,
-      ArrayRef<const dataflow::IntegerValueRangeLattice *> operands,
+      Operation *op, ArrayRef<IntegerValueRange> operands,
       ArrayRef<dataflow::IntegerValueRangeLattice *> resultsLattices);
 
   DenseSet<Value> signedIntValues;

--- a/third_party/amd/include/Dialect/TritonAMDGPU/IR/Dialect.h
+++ b/third_party/amd/include/Dialect/TritonAMDGPU/IR/Dialect.h
@@ -29,6 +29,7 @@
 #include "mlir/IR/BuiltinOps.h"
 #include "mlir/IR/Dialect.h"
 #include "mlir/IR/PatternMatch.h"
+#include "mlir/Interfaces/InferIntRangeInterface.h"
 #include "triton/Dialect/Triton/IR/Dialect.h"
 #include "triton/Dialect/Triton/IR/Traits.h"
 #include "triton/Dialect/TritonGPU/IR/Dialect.h"

--- a/third_party/amd/include/Dialect/TritonAMDGPU/IR/TritonAMDGPUOps.td
+++ b/third_party/amd/include/Dialect/TritonAMDGPU/IR/TritonAMDGPUOps.td
@@ -39,6 +39,7 @@ include "triton/Dialect/TritonGPU/IR/TritonGPUMemoryEffects.td"
 include "mlir/IR/EnumAttr.td"
 include "mlir/Dialect/LLVMIR/LLVMOpBase.td"
 include "mlir/Interfaces/InferTypeOpInterface.td"
+include "mlir/Interfaces/InferIntRangeInterface.td"
 include "mlir/Interfaces/SideEffectInterfaces.td" // Pure
 include "TritonAMDGPUDialect.td"
 include "TritonAMDGPUAttrDefs.td"
@@ -58,7 +59,8 @@ def L2Cache : Resource<"::mlir::triton::amd::L2Cache">;
 // ExtractSliceOp
 //===----------------------------------------------------------------------===//
 
-def ExtractSliceOp : TT_AMDGPU_Op<"extract_slice", [Pure]> {
+def ExtractSliceOp : TT_AMDGPU_Op<"extract_slice", [Pure,
+    DeclareOpInterfaceMethods<InferIntRangeInterface, ["inferResultRanges"]>]> {
   let summary = "extract slice operation";
   let description = [{
     The "extract_slice" operation enables extracting a slice of a tensor in

--- a/third_party/amd/lib/Analysis/CMakeLists.txt
+++ b/third_party/amd/lib/Analysis/CMakeLists.txt
@@ -1,5 +1,6 @@
 add_triton_library(TritonAMDAnalysis
   RangeAnalysis.cpp
+  ControlFlowRangeAnalysis.cpp
   AxisInfoExt.cpp
   AMDGPUAllocation.cpp
 
@@ -9,6 +10,7 @@ add_triton_library(TritonAMDAnalysis
 
   LINK_LIBS PUBLIC
   MLIRAnalysis
+  MLIRControlFlowDialect
   MLIRLLVMDialect
   TritonIR
   TritonGPUIR

--- a/third_party/amd/lib/Analysis/ControlFlowRangeAnalysis.cpp
+++ b/third_party/amd/lib/Analysis/ControlFlowRangeAnalysis.cpp
@@ -1,0 +1,668 @@
+#include "ControlFlowRangeAnalysis.h"
+
+#include "mlir/Analysis/CFGLoopInfo.h"
+#include "mlir/Dialect/Arith/IR/Arith.h"
+#include "mlir/Dialect/ControlFlow/IR/ControlFlowOps.h"
+#include "mlir/IR/Matchers.h"
+#include "mlir/Interfaces/ControlFlowInterfaces.h"
+#include "mlir/Interfaces/SideEffectInterfaces.h"
+#include "llvm/ADT/DenseMap.h"
+#include "llvm/ADT/STLExtras.h"
+#include "llvm/ADT/SmallVector.h"
+#include <algorithm>
+#include <tuple>
+
+using namespace mlir;
+using namespace mlir::triton::AMD::detail;
+
+namespace {
+
+using GetRangeFn = ControlFlowRangeAnalysis::GetRangeFn;
+
+// All arithmetic below uses signed, widened APInts. This also represents the
+// unsigned input domain and the sentinel past an inclusive loop bound.
+struct Interval {
+  APInt min;
+  APInt max;
+};
+
+template <typename T> struct Evaluation {
+  std::optional<T> value;
+  bool pending = false;
+};
+
+APInt min(const APInt &a, const APInt &b) { return a.slt(b) ? a : b; }
+APInt max(const APInt &a, const APInt &b) { return a.sgt(b) ? a : b; }
+
+std::optional<APInt> addProduct(const APInt &initial, const APInt &count,
+                                const APInt &delta) {
+  bool overflow;
+  APInt product = count.smul_ov(delta, overflow);
+  if (overflow)
+    return std::nullopt;
+  APInt result = initial.sadd_ov(product, overflow);
+  if (overflow)
+    return std::nullopt;
+  return result;
+}
+
+APInt ceilPositive(const APInt &numerator, const APInt &denominator) {
+  if (numerator.isNonPositive())
+    return APInt(numerator.getBitWidth(), 0);
+  return numerator.udiv(denominator) +
+         APInt(numerator.getBitWidth(), !numerator.urem(denominator).isZero());
+}
+
+Interval widen(const ConstantIntRanges &range, unsigned width, bool isSigned) {
+  if (isSigned)
+    return {range.smin().sext(width), range.smax().sext(width)};
+  return {range.umin().zext(width), range.umax().zext(width)};
+}
+
+Interval domain(unsigned valueWidth, unsigned width, bool isSigned) {
+  if (isSigned)
+    return {APInt::getSignedMinValue(valueWidth).sext(width),
+            APInt::getSignedMaxValue(valueWidth).sext(width)};
+  return {APInt(width, 0), APInt::getMaxValue(valueWidth).zext(width)};
+}
+
+bool contains(Interval outer, Interval inner) {
+  return outer.min.sle(inner.min) && outer.max.sge(inner.max);
+}
+
+ConstantIntRanges narrow(Interval range, unsigned width, bool isSigned) {
+  return ConstantIntRanges::range(range.min.trunc(width),
+                                  range.max.trunc(width), isSigned);
+}
+
+Block *getAncestorBlock(Block *block, Region *region) {
+  while (block && block->getParent() != region)
+    block = block->getParentOp()->getBlock();
+  return block;
+}
+
+// Structural dependencies are independent of lattice updates. The optional
+// allowed value is the enclosing IV when checking a nested recurrence.
+struct Dependencies {
+  using Key = std::tuple<Value, Block *, Value, Value>;
+  DenseMap<Key, bool> known;
+  unsigned depth = 0;
+
+  bool check(Value value, const CFGLoop &loop, Value allowed = {},
+             Value excluded = {}) {
+    if (value == excluded)
+      return false;
+    if (value == allowed)
+      return true;
+    Block *block =
+        getAncestorBlock(value.getParentBlock(), loop.getHeader()->getParent());
+    if (!block || !loop.contains(block))
+      return true;
+    Key key{value, loop.getHeader(), allowed, excluded};
+    if (auto it = known.find(key); it != known.end())
+      return it->second;
+    auto *op = value.getDefiningOp();
+    if (!op || op->getNumRegions() || !isPure(op) ||
+        !isa<InferIntRangeInterface>(op) || depth >= 64)
+      return false;
+    known.try_emplace(key, false);
+    ++depth;
+    bool result = llvm::all_of(op->getOperands(), [&](Value operand) {
+      return check(operand, loop, allowed, excluded);
+    });
+    --depth;
+    // A depth-limit failure may succeed when reached through a shorter path.
+    if (result)
+      known[key] = true;
+    else
+      known.erase(key);
+    return result;
+  }
+};
+
+Value getIncoming(Block::pred_iterator edge, BlockArgument argument) {
+  auto branch = dyn_cast<BranchOpInterface>((*edge)->getTerminator());
+  if (!branch)
+    return {};
+  return branch.getSuccessorOperands(
+      edge.getSuccessorIndex())[argument.getArgNumber()];
+}
+
+struct LoopDescription {
+  CFGLoop *loop;
+  Block *entry;
+  Block *exit;
+  BlockArgument induction;
+  Value bound;
+  bool isSigned;
+  bool increasing;
+  bool inclusive;
+};
+
+std::optional<LoopDescription> describeLoop(CFGLoop *loop,
+                                            Dependencies &dependencies) {
+  Block *header = loop->getHeader();
+  auto branch = dyn_cast<cf::CondBranchOp>(header->getTerminator());
+  if (!branch || loop->getExitingBlock() != header)
+    return std::nullopt;
+  bool trueContinues = loop->contains(branch.getTrueDest());
+  if (trueContinues == loop->contains(branch.getFalseDest()))
+    return std::nullopt;
+  // Self-edges are post-test loops; their header and exit counts differ.
+  if (branch.getTrueDest() == header || branch.getFalseDest() == header)
+    return std::nullopt;
+  Block *entry = loop->getLoopPredecessor();
+  if (!entry)
+    return std::nullopt;
+  auto cmp = branch.getCondition().getDefiningOp<arith::CmpIOp>();
+  if (!cmp || cmp->getBlock() != header)
+    return std::nullopt;
+  arith::CmpIPredicate predicate = cmp.getPredicate();
+  if (!trueContinues)
+    predicate = arith::invertPredicate(predicate);
+  using P = arith::CmpIPredicate;
+  if (predicate == P::eq || predicate == P::ne)
+    return std::nullopt;
+  bool isLhs = true;
+  if (auto argument = dyn_cast<BlockArgument>(cmp.getRhs());
+      argument && argument.getOwner() == header &&
+      dependencies.check(cmp.getLhs(), *loop))
+    isLhs = false;
+  Value iv = isLhs ? cmp.getLhs() : cmp.getRhs();
+  Value bound = isLhs ? cmp.getRhs() : cmp.getLhs();
+  auto induction = dyn_cast<BlockArgument>(iv);
+  if (!induction || induction.getOwner() != header ||
+      !isa<IntegerType>(induction.getType()) ||
+      !dependencies.check(bound, *loop))
+    return std::nullopt;
+  bool isSigned = predicate == P::slt || predicate == P::sle ||
+                  predicate == P::sgt || predicate == P::sge;
+  bool less = predicate == P::slt || predicate == P::sle ||
+              predicate == P::ult || predicate == P::ule;
+  bool inclusive = predicate == P::sle || predicate == P::sge ||
+                   predicate == P::ule || predicate == P::uge;
+  return LoopDescription{loop,
+                         entry,
+                         trueContinues ? branch.getFalseDest()
+                                       : branch.getTrueDest(),
+                         induction,
+                         bound,
+                         isSigned,
+                         less == isLhs,
+                         inclusive};
+}
+
+IntegerValueRange readRangeImpl(Value value, Block *block, GetRangeFn getRange,
+                                DenseMap<Value, IntegerValueRange> &known,
+                                unsigned depth) {
+  if (auto it = known.find(value); it != known.end())
+    return it->second;
+  // Constants inside an unvisited diamond arm need not wait for its liveness.
+  APInt constant;
+  if (matchPattern(value, m_ConstantInt(&constant)))
+    return IntegerValueRange(ConstantIntRanges::constant(constant));
+  IntegerValueRange range = getRange(value, block);
+  if (!range.isUninitialized() || depth >= 64)
+    return range;
+  auto *op = value.getDefiningOp();
+  auto infer = dyn_cast_or_null<InferIntRangeInterface>(op);
+  if (!infer || !isPure(op) || op->getNumRegions())
+    return range;
+  SmallVector<IntegerValueRange> operands;
+  for (Value operand : op->getOperands())
+    operands.push_back(
+        readRangeImpl(operand, block, getRange, known, depth + 1));
+  infer.inferResultRangesFromOptional(
+      operands, [&](Value result, const IntegerValueRange &inferred) {
+        if (result == value)
+          range = inferred;
+      });
+  known.try_emplace(value, range);
+  return range;
+}
+
+IntegerValueRange readRange(Value value, Block *block, GetRangeFn getRange) {
+  DenseMap<Value, IntegerValueRange> known;
+  return readRangeImpl(value, block, getRange, known, 0);
+}
+
+IntegerValueRange getInitialRange(BlockArgument argument,
+                                  const LoopDescription &loop,
+                                  GetRangeFn getRange) {
+  IntegerValueRange initial;
+  for (auto edge = argument.getOwner()->pred_begin(),
+            end = argument.getOwner()->pred_end();
+       edge != end; ++edge) {
+    if (*edge != loop.entry)
+      continue;
+    Value incoming = getIncoming(edge, argument);
+    if (!incoming)
+      return IntegerValueRange::getMaxRange(argument);
+    IntegerValueRange range = readRange(incoming, loop.entry, getRange);
+    if (range.isUninitialized())
+      return range;
+    initial = IntegerValueRange::join(initial, range);
+  }
+  return initial;
+}
+
+struct LoopBounds {
+  APInt minTrips;
+  APInt maxTrips;
+  Interval header;
+  Interval body;
+  Interval exit;
+};
+
+std::optional<LoopBounds> getLoopBounds(const LoopDescription &loop,
+                                        Interval initial, Interval bound,
+                                        Interval delta, unsigned valueWidth) {
+  unsigned width = initial.min.getBitWidth();
+  APInt one(width, 1);
+  // Reflect descending loops so both directions advance toward an upper bound.
+  auto orient = [&](Interval range) {
+    return loop.increasing ? range : Interval{-range.max, -range.min};
+  };
+  initial = orient(initial);
+  bound = orient(bound);
+  delta = orient(delta);
+  if (!delta.min.isStrictlyPositive() || !delta.max.isStrictlyPositive())
+    return std::nullopt;
+  if (loop.inclusive) {
+    bound.min += one;
+    bound.max += one;
+  }
+  APInt minTrips = ceilPositive(bound.min - initial.max, delta.max);
+  APInt maxTrips = ceilPositive(bound.max - initial.min, delta.min);
+  if (maxTrips.isZero()) {
+    initial = orient(initial);
+    return LoopBounds{minTrips, maxTrips, initial, initial, initial};
+  }
+
+  auto last = addProduct(initial.max, maxTrips - one, delta.max);
+  auto firstExit = addProduct(initial.min, minTrips, delta.min);
+  if (!last || !firstExit)
+    return std::nullopt;
+  Interval body{initial.min, min(bound.max - one, *last)};
+  auto sentinel = addProduct(body.max, one, delta.max);
+  if (!sentinel)
+    return std::nullopt;
+  Interval header{initial.min, max(initial.max, *sentinel)};
+  Interval exit{max(max(initial.min, bound.min), *firstExit), header.max};
+  header = orient(header);
+  // In particular, the update that first fails the condition must not wrap.
+  if (!contains(domain(valueWidth, width, loop.isSigned), header))
+    return std::nullopt;
+  return LoopBounds{minTrips, maxTrips, header, orient(body), orient(exit)};
+}
+
+enum class UseKind { Header, Body, Exit };
+
+UseKind getUseKind(const LoopDescription &loop, Block *useBlock,
+                   DominanceInfo &domInfo) {
+  Block *header = loop.loop->getHeader();
+  Block *block = getAncestorBlock(useBlock, header->getParent());
+  if (!block || block == header)
+    return UseKind::Header;
+  if (loop.loop->contains(block))
+    return UseKind::Body;
+  if (loop.exit->getSinglePredecessor() == header &&
+      domInfo.dominates(loop.exit, block))
+    return UseKind::Exit;
+  return UseKind::Header;
+}
+
+std::optional<Interval> getRecurrenceBounds(Interval initial, Interval delta,
+                                            const APInt &minTrips,
+                                            const APInt &maxTrips) {
+  auto lower = addProduct(
+      initial.min, delta.min.isNegative() ? maxTrips : minTrips, delta.min);
+  auto upper = addProduct(
+      initial.max, delta.max.isNegative() ? minTrips : maxTrips, delta.max);
+  if (!lower || !upper)
+    return std::nullopt;
+  return Interval{*lower, *upper};
+}
+
+} // namespace
+
+struct ControlFlowRangeAnalysis::Impl {
+  DominanceInfo &domInfo;
+  SmallVector<std::unique_ptr<CFGLoopInfo>> loopInfos;
+  DenseMap<Block *, LoopDescription> loops;
+  mutable Dependencies dependencies;
+  unsigned maxIVWidth = 1;
+
+  Impl(Operation *top, DominanceInfo &domInfo) : domInfo(domInfo) {
+    top->walk([&](Operation *op) {
+      for (Region &region : op->getRegions()) {
+        if (region.empty() || region.hasOneBlock() ||
+            !domInfo.hasSSADominance(&region))
+          continue;
+        auto info = std::make_unique<CFGLoopInfo>(domInfo.getDomTree(&region));
+        for (CFGLoop *loop : info->getLoopsInPreorder())
+          if (auto description = describeLoop(loop, dependencies)) {
+            maxIVWidth =
+                std::max(maxIVWidth, ConstantIntRanges::getStorageBitwidth(
+                                         description->induction.getType()));
+            loops.try_emplace(loop->getHeader(), std::move(*description));
+          }
+        loopInfos.push_back(std::move(info));
+      }
+    });
+  }
+
+  struct Query {
+    const Impl &analysis;
+    GetRangeFn getRange;
+    unsigned width;
+    unsigned depth = 0;
+    using Result = Evaluation<Interval>;
+    using ExpressionKey = std::tuple<Value, Value, Block *, Value, unsigned>;
+    using DeltaKey = std::tuple<Value, Value, unsigned>;
+    DenseMap<ExpressionKey, Result> expressions;
+    DenseMap<DeltaKey, Result> deltas;
+    DenseMap<std::pair<Block *, Value>, Evaluation<LoopBounds>> loopBounds;
+
+    Query(const Impl &analysis, GetRangeFn getRange, unsigned width)
+        : analysis(analysis), getRange(getRange), width(width) {}
+
+    template <typename Key, typename T, typename Fn>
+    Evaluation<T> memo(DenseMap<Key, Evaluation<T>> &cache, Key key,
+                       Fn compute) {
+      if (auto it = cache.find(key); it != cache.end())
+        return it->second;
+      if (depth >= 64)
+        return {};
+      // Re-entering an unfinished expression is an unsupported cycle.
+      cache.try_emplace(key);
+      ++depth;
+      auto result = compute();
+      --depth;
+      cache[key] = result;
+      return result;
+    }
+
+    static bool unsupported(const Result &result) {
+      return !result.value && !result.pending;
+    }
+
+    template <typename Fn>
+    static Result combine(Result lhs, Result rhs, Fn fn) {
+      if (unsupported(lhs) || unsupported(rhs))
+        return {};
+      if (lhs.pending || rhs.pending)
+        return {std::nullopt, true};
+      return {fn(*lhs.value, *rhs.value), false};
+    }
+
+    static Result add(Result lhs, Result rhs, bool subtract = false) {
+      return combine(lhs, rhs,
+                     [&](Interval a, Interval b) -> std::optional<Interval> {
+                       bool loOverflow, hiOverflow;
+                       APInt lo = subtract ? a.min.ssub_ov(b.max, loOverflow)
+                                           : a.min.sadd_ov(b.min, loOverflow);
+                       APInt hi = subtract ? a.max.ssub_ov(b.min, hiOverflow)
+                                           : a.max.sadd_ov(b.max, hiOverflow);
+                       if (loOverflow || hiOverflow)
+                         return std::nullopt;
+                       return Interval{lo, hi};
+                     });
+    }
+
+    template <typename Include, typename Read>
+    Result incoming(BlockArgument argument, Include include, Read read) {
+      std::optional<Result> result;
+      for (auto edge = argument.getOwner()->pred_begin(),
+                end = argument.getOwner()->pred_end();
+           edge != end; ++edge) {
+        if (!include(*edge))
+          continue;
+        Value value = getIncoming(edge, argument);
+        Result next = value ? read(value, *edge) : Result{};
+        // Pending information never hides an unsupported structural arm.
+        result = result ? combine(*result, next,
+                                  [](Interval a, Interval b) {
+                                    return Interval{min(a.min, b.min),
+                                                    max(a.max, b.max)};
+                                  })
+                        : next;
+      }
+      return result.value_or(Result{});
+    }
+
+    bool independent(Value value, Value excluded) {
+      if (!excluded)
+        return true;
+      const auto &outer =
+          analysis.loops.find(excluded.getParentBlock())->second;
+      return analysis.dependencies.check(value, *outer.loop, outer.induction,
+                                         excluded);
+    }
+
+    Result invariant(Value value, const LoopDescription &loop, Value excluded,
+                     bool isSigned) {
+      if (!analysis.dependencies.check(value, *loop.loop) ||
+          !independent(value, excluded))
+        return {};
+      auto range = readRange(value, loop.loop->getHeader(), getRange);
+      return range.isUninitialized()
+                 ? Result{std::nullopt, true}
+                 : Result{widen(range.getValue(), width, isSigned), false};
+    }
+
+    Result loopExit(BlockArgument argument, BlockArgument base,
+                    const LoopDescription &child, Value excluded,
+                    bool isSigned) {
+      auto initial = incoming(
+          argument, [&](Block *p) { return p == child.entry; },
+          [&](Value v, Block *p) {
+            return expression(v, base, p, excluded, isSigned);
+          });
+      Value outer = excluded ? excluded : base;
+      auto change = delta(argument, outer, isSigned);
+      if (unsupported(initial))
+        return {};
+      // An unchanged child needs no finite trip count to describe its exit.
+      if (change.value && change.value->min.isZero() &&
+          change.value->max.isZero())
+        return initial;
+      auto count = bounds(child, outer);
+      if (!count.value)
+        return {std::nullopt, count.pending || change.pending};
+      if (count.value->maxTrips.isZero())
+        return initial;
+      if (!change.value)
+        return change;
+      Interval zero{APInt(width, 0), APInt(width, 0)};
+      return add(initial, {getRecurrenceBounds(zero, *change.value,
+                                               count.value->minTrips,
+                                               count.value->maxTrips),
+                           false});
+    }
+
+    Result expression(Value value, BlockArgument base, Block *useBlock,
+                      Value excluded, bool isSigned) {
+      if (value == base)
+        return {Interval{APInt(width, 0), APInt(width, 0)}, false};
+      if (auto *op = value.getDefiningOp())
+        useBlock = op->getBlock();
+      return memo(
+          expressions, ExpressionKey{value, base, useBlock, excluded, isSigned},
+          [&]() -> Result {
+            const auto &loop = analysis.loops.find(base.getOwner())->second;
+            Value previous, increment;
+            bool subtract = false;
+            if (auto op = value.getDefiningOp<arith::AddIOp>()) {
+              previous = op.getLhs();
+              increment = op.getRhs();
+              if (!analysis.dependencies.check(increment, *loop.loop))
+                std::swap(previous, increment);
+            } else if (auto op = value.getDefiningOp<arith::SubIOp>()) {
+              previous = op.getLhs();
+              increment = op.getRhs();
+              subtract = true;
+            }
+            if (increment) {
+              auto operand =
+                  expression(previous, base, useBlock, excluded, isSigned);
+              auto change = invariant(increment, loop, excluded, isSigned);
+              return add(operand, change, subtract);
+            }
+            auto argument = dyn_cast<BlockArgument>(value);
+            if (!argument || argument.getOwner() == base.getOwner() ||
+                !loop.loop->contains(argument.getOwner()))
+              return {};
+            auto nested = analysis.loops.find(argument.getOwner());
+            // Keep the controlling IV's update independent of nested loops.
+            if (base != loop.induction && nested != analysis.loops.end() &&
+                getUseKind(nested->second, useBlock, analysis.domInfo) ==
+                    UseKind::Exit) {
+              auto result =
+                  loopExit(argument, base, nested->second, excluded, isSigned);
+              if (!unsupported(result))
+                return result;
+            }
+            return incoming(
+                argument, [](Block *) { return true; },
+                [&](Value v, Block *p) {
+                  return loop.loop->contains(p)
+                             ? expression(v, base, p, excluded, isSigned)
+                             : Result{};
+                });
+          });
+    }
+
+    Result delta(BlockArgument argument, Value excluded, bool isSigned) {
+      return memo(deltas, DeltaKey{argument, excluded, isSigned}, [&] {
+        const auto &loop = analysis.loops.find(argument.getOwner())->second;
+        return incoming(
+            argument, [&](Block *p) { return loop.loop->contains(p); },
+            [&](Value v, Block *p) {
+              return expression(v, argument, p, excluded, isSigned);
+            });
+      });
+    }
+
+    Evaluation<LoopBounds> bounds(const LoopDescription &loop,
+                                  Value excluded = {}) {
+      return memo(
+          loopBounds,
+          std::pair<Block *, Value>{loop.loop->getHeader(), excluded},
+          [&]() -> Evaluation<LoopBounds> {
+            if (!independent(loop.bound, excluded))
+              return {};
+            for (auto edge = loop.loop->getHeader()->pred_begin(),
+                      end = loop.loop->getHeader()->pred_end();
+                 edge != end; ++edge) {
+              if (*edge != loop.entry)
+                continue;
+              Value initial = getIncoming(edge, loop.induction);
+              if (!initial || !independent(initial, excluded))
+                return {};
+            }
+            auto initial = getInitialRange(loop.induction, loop, getRange);
+            auto limit =
+                readRange(loop.bound, loop.loop->getHeader(), getRange);
+            bool pending = false;
+            for (bool isSigned : {true, false}) {
+              auto step = delta(loop.induction, excluded, isSigned);
+              if (unsupported(step))
+                continue;
+              if (step.pending || initial.isUninitialized() ||
+                  limit.isUninitialized()) {
+                pending = true;
+                continue;
+              }
+              auto result = getLoopBounds(
+                  loop, widen(initial.getValue(), width, loop.isSigned),
+                  widen(limit.getValue(), width, loop.isSigned), *step.value,
+                  ConstantIntRanges::getStorageBitwidth(
+                      loop.induction.getType()));
+              if (result)
+                return {result, false};
+            }
+            return {std::nullopt, pending};
+          });
+    }
+  };
+
+  std::optional<IntegerValueRange>
+  getRange(BlockArgument argument, Block *useBlock, GetRangeFn getRange) const {
+    auto it = loops.find(argument.getOwner());
+    unsigned valueWidth =
+        ConstantIntRanges::getStorageBitwidth(argument.getType());
+    if (it == loops.end() || !valueWidth)
+      return std::nullopt;
+    const auto &loop = it->second;
+    // All products are checked, including products across nested loops.
+    unsigned width = 2 * std::max(valueWidth, maxIVWidth) + 16;
+    Query query{*this, getRange, width};
+    SmallVector<Interval, 2> deltas;
+    bool pending = false;
+    for (bool isSigned : {true, false}) {
+      auto delta = query.delta(argument, {}, isSigned);
+      if (delta.value && delta.value->min.isZero() && delta.value->max.isZero())
+        return getInitialRange(argument, loop, getRange);
+      pending |= delta.pending;
+      if (delta.value)
+        deltas.push_back(*delta.value);
+    }
+    auto count = query.bounds(loop);
+    if (count.value && count.value->maxTrips.isZero())
+      return getInitialRange(argument, loop, getRange);
+    if (!count.value)
+      return (count.pending || pending)
+                 ? std::optional<IntegerValueRange>(IntegerValueRange())
+                 : std::nullopt;
+    if (deltas.empty())
+      return pending ? std::optional<IntegerValueRange>(IntegerValueRange())
+                     : std::nullopt;
+    UseKind use = getUseKind(loop, useBlock, domInfo);
+    if (argument == loop.induction) {
+      Interval range = use == UseKind::Body   ? count.value->body
+                       : use == UseKind::Exit ? count.value->exit
+                                              : count.value->header;
+      return IntegerValueRange(narrow(range, valueWidth, loop.isSigned));
+    }
+    auto initial = getInitialRange(argument, loop, getRange);
+    if (initial.isUninitialized())
+      return initial;
+    APInt zero(width, 0), one(width, 1);
+    APInt minTrips = use == UseKind::Exit ? count.value->minTrips : zero;
+    APInt maxTrips = use == UseKind::Body
+                         ? max(zero, count.value->maxTrips - one)
+                         : count.value->maxTrips;
+    std::optional<ConstantIntRanges> result;
+    for (bool isSigned : {true, false}) {
+      Interval init = widen(initial.getValue(), width, isSigned);
+      for (const Interval &delta : deltas) {
+        auto all =
+            getRecurrenceBounds(init, delta, zero, count.value->maxTrips);
+        if (!all || !contains(domain(valueWidth, width, isSigned), *all))
+          continue;
+        auto refined = getRecurrenceBounds(init, delta, minTrips, maxTrips);
+        if (!refined)
+          continue;
+        auto range = narrow(*refined, valueWidth, isSigned);
+        result = result ? result->intersection(range) : range;
+      }
+    }
+    if (result)
+      return IntegerValueRange(*result);
+    return pending ? std::optional<IntegerValueRange>(IntegerValueRange())
+                   : std::nullopt;
+  }
+};
+
+ControlFlowRangeAnalysis::ControlFlowRangeAnalysis(Operation *top,
+                                                   DominanceInfo &domInfo)
+    : impl(std::make_unique<Impl>(top, domInfo)) {}
+
+ControlFlowRangeAnalysis::~ControlFlowRangeAnalysis() = default;
+
+std::optional<IntegerValueRange>
+ControlFlowRangeAnalysis::getRange(BlockArgument argument, Block *useBlock,
+                                   GetRangeFn getRange) const {
+  return impl->getRange(argument, useBlock, getRange);
+}

--- a/third_party/amd/lib/Analysis/ControlFlowRangeAnalysis.h
+++ b/third_party/amd/lib/Analysis/ControlFlowRangeAnalysis.h
@@ -1,0 +1,38 @@
+#ifndef TRITONAMD_ANALYSIS_CONTROL_FLOW_RANGE_ANALYSIS_H
+#define TRITONAMD_ANALYSIS_CONTROL_FLOW_RANGE_ANALYSIS_H
+
+#include "mlir/Interfaces/InferIntRangeInterface.h"
+#include "llvm/ADT/STLFunctionalExtras.h"
+#include <memory>
+#include <optional>
+
+namespace mlir {
+class DominanceInfo;
+
+namespace triton::AMD::detail {
+
+/// Range summaries for natural loops formed by lowering structured control
+/// flow. A header argument includes the final, failing condition evaluation;
+/// its uses in the body and after the loop can have narrower ranges.
+class ControlFlowRangeAnalysis {
+public:
+  using GetRangeFn = llvm::function_ref<IntegerValueRange(Value, Block *)>;
+
+  ControlFlowRangeAnalysis(Operation *top, DominanceInfo &domInfo);
+  ~ControlFlowRangeAnalysis();
+
+  /// A missing result means the recurrence is unsupported. An uninitialized
+  /// result means an input range is pending. A null useBlock requests the
+  /// range of the header argument across all condition evaluations.
+  std::optional<IntegerValueRange>
+  getRange(BlockArgument argument, Block *useBlock, GetRangeFn getRange) const;
+
+private:
+  struct Impl;
+  std::unique_ptr<Impl> impl;
+};
+
+} // namespace triton::AMD::detail
+} // namespace mlir
+
+#endif

--- a/third_party/amd/lib/Analysis/RangeAnalysis.cpp
+++ b/third_party/amd/lib/Analysis/RangeAnalysis.cpp
@@ -1,15 +1,17 @@
-#include "third_party/amd/include/Analysis/RangeAnalysis.h"
+#include "Analysis/RangeAnalysis.h"
+#include "ControlFlowRangeAnalysis.h"
 #include "mlir/Analysis/DataFlow/DeadCodeAnalysis.h"
 #include "mlir/Analysis/DataFlow/IntegerRangeAnalysis.h"
 #include "mlir/Dialect/Arith/IR/Arith.h"
+#include "mlir/Dialect/ControlFlow/IR/ControlFlowOps.h"
 #include "mlir/Dialect/LLVMIR/LLVMDialect.h"
 #include "mlir/Dialect/SCF/IR/SCF.h"
 #include "mlir/IR/Iterators.h"
 #include "mlir/Interfaces/Utils/InferIntRangeCommon.h"
-#include "third_party/amd/include/Dialect/TritonAMDGPU/IR/Dialect.h"
 #include "triton/Dialect/Triton/IR/Dialect.h"
 #include "triton/Dialect/Triton/IR/Utility.h"
 #include "triton/Dialect/TritonGPU/IR/Dialect.h"
+#include "llvm/ADT/ScopeExit.h"
 #include "llvm/ADT/TypeSwitch.h"
 #include "llvm/Support/Debug.h"
 
@@ -78,26 +80,16 @@ void getEnclosingLoops(Operation &op, SmallVector<LoopLikeOpInterface> &ops) {
   }
 }
 
-tt::FuncOp getEnclosingFunction(Value v) {
-  tt::FuncOp funcOp = nullptr;
-
-  auto definingOp = v.getDefiningOp();
-  if (!definingOp)
-    if (auto blk = v.getParentBlock())
-      definingOp = blk->getParentOp();
-
-  if (definingOp) {
-    if (auto selfIsFunc = dyn_cast<tt::FuncOp>(definingOp))
-      funcOp = selfIsFunc;
-    else
-      funcOp = definingOp->getParentOfType<tt::FuncOp>();
-  }
-
-  assert(funcOp && "No enclosing tt::FuncOp");
-  return funcOp;
+FunctionOpInterface getEnclosingFunction(Value v) {
+  Region *region = v.getParentRegion();
+  return region ? region->getParentOfType<FunctionOpInterface>() : nullptr;
 }
 
-Block *getFuncEntryBlock(tt::FuncOp func) { return &func.getRegion().front(); }
+Block *getFuncEntryBlock(FunctionOpInterface func) {
+  if (!func || func.isExternal())
+    return nullptr;
+  return &func.getFunctionBody().front();
+}
 
 void inferResultRangesPID(Operation *op, uint64_t max,
                           SetIntRangeFn setResultRange) {
@@ -200,7 +192,8 @@ std::optional<ConstantIntRanges>
 maybeGetAssumedRangeHelper(Operation *assumption, Value anchor, Block *useBlock,
                            DominanceInfo *domInfo) {
 
-  arith::CmpIOp cmpOp = llvm::dyn_cast<arith::CmpIOp>(assumption);
+  auto assumeOp = cast<LLVM::AssumeOp>(assumption);
+  auto cmpOp = assumeOp.getCond().getDefiningOp<arith::CmpIOp>();
   if (!cmpOp) {
     emitRemark(assumption->getLoc(), "unsupported assumption operation");
     return {};
@@ -208,7 +201,7 @@ maybeGetAssumedRangeHelper(Operation *assumption, Value anchor, Block *useBlock,
 
   // The block where tl.assume resides must dominate the block where the value
   // is referenced!
-  if (!useBlock || !domInfo->dominates(cmpOp->getBlock(), useBlock))
+  if (!useBlock || !domInfo->dominates(assumeOp->getBlock(), useBlock))
     return {};
 
   return triton::getBoundFromCmpOp(cmpOp, anchor);
@@ -327,7 +320,7 @@ bool isEmptyInitializedRange(ConstantIntRanges rv) {
   if (!rv.umin().getBitWidth() || !rv.umax().getBitWidth() ||
       !rv.smin().getBitWidth() || !rv.smax().getBitWidth())
     return true;
-  return false;
+  return rv.umin().ugt(rv.umax()) || rv.smin().sgt(rv.smax());
 }
 
 std::optional<SmallVector<std::optional<ConstantIntRanges>>>
@@ -367,7 +360,256 @@ std::optional<bool> evaluateCmpI(const DataFlowSolver &solver,
 
 LogicalResult TritonIntegerRangeAnalysis::initialize(Operation *top) {
   signedIntValues.clear();
-  return Base::initialize(top);
+  controlFlow.reset();
+  branchConstraints.clear();
+  blockConstraints.clear();
+  activeRangeQueries.clear();
+  rangeQueryCache.clear();
+  bool hasControlFlow = false;
+  top->walk([&](Operation *op) {
+    for (Region &region : op->getRegions())
+      hasControlFlow |= !region.empty() && !llvm::hasSingleElement(region);
+  });
+  if (!hasControlFlow)
+    return Base::initialize(top);
+
+  if (!domInfo) {
+    ownedDomInfo = std::make_unique<DominanceInfo>(top);
+    domInfo = ownedDomInfo.get();
+  }
+  controlFlow =
+      std::make_shared<detail::ControlFlowRangeAnalysis>(top, *domInfo);
+  top->walk([&](cf::CondBranchOp branch) {
+    if (branch.getTrueDest() == branch.getFalseDest())
+      return;
+    for (auto [index, successor] : llvm::enumerate(branch->getSuccessors())) {
+      // A unique incoming edge makes successor dominance edge dominance.
+      if (successor->getSinglePredecessor() == branch->getBlock())
+        branchConstraints.try_emplace(
+            successor, BranchConstraint{branch.getCondition(), index == 0});
+    }
+  });
+
+  // The base initializer calls its non-virtual CFG transfer directly. Keep its
+  // traversal and subscriptions, routing block starts through our transfer.
+  for (Region &region : top->getRegions())
+    if (!region.empty())
+      for (BlockArgument arg : region.front().getArguments())
+        setToEntryState(getLatticeElement(arg));
+  WalkResult result = top->walk<WalkOrder::PreOrder>([&](Operation *op) {
+    if (failed(Base::visit(getProgramPointAfter(op))))
+      return WalkResult::interrupt();
+    for (Region &region : op->getRegions()) {
+      for (Block &block : region) {
+        auto *point = getProgramPointBefore(&block);
+        getOrCreate<dataflow::Executable>(point)->blockContentSubscribe(this);
+        if (failed(visit(point)))
+          return WalkResult::interrupt();
+      }
+    }
+    return WalkResult::advance();
+  });
+  return failure(result.wasInterrupted());
+}
+
+LogicalResult TritonIntegerRangeAnalysis::visit(ProgramPoint *point) {
+  if (!point->isBlockStart() || point->getBlock()->isEntryBlock())
+    return Base::visit(point);
+  visitControlFlowBlock(point->getBlock());
+  return success();
+}
+
+static IntegerValueRange intersectRanges(const ConstantIntRanges &lhs,
+                                         const ConstantIntRanges &rhs) {
+  ConstantIntRanges range = lhs.intersection(rhs);
+  if (isEmptyInitializedRange(range))
+    return IntegerValueRange();
+  // Reflect a newly established sign in both interval representations.
+  range = ConstantIntRanges::fromSigned(range.smin(), range.smax())
+              .intersection(
+                  ConstantIntRanges::fromUnsigned(range.umin(), range.umax()));
+  return isEmptyInitializedRange(range) ? IntegerValueRange()
+                                        : IntegerValueRange(range);
+}
+
+IntegerValueRange TritonIntegerRangeAnalysis::refineWithCondition(
+    Value value, IntegerValueRange range, Value condition, bool isTrue,
+    ProgramPoint *point) {
+  if (range.isUninitialized())
+    return range;
+  SmallVector<Value> worklist{condition};
+  DenseSet<Value> visited;
+  while (!worklist.empty()) {
+    Value current = worklist.pop_back_val();
+    if (!visited.insert(current).second)
+      continue;
+    if (auto andOp = current.getDefiningOp<arith::AndIOp>(); andOp && isTrue) {
+      llvm::append_range(worklist, andOp->getOperands());
+      continue;
+    }
+    if (auto orOp = current.getDefiningOp<arith::OrIOp>(); orOp && !isTrue) {
+      llvm::append_range(worklist, orOp->getOperands());
+      continue;
+    }
+    auto cmp = current.getDefiningOp<arith::CmpIOp>();
+    if (!cmp || (value != cmp.getLhs() && value != cmp.getRhs()))
+      continue;
+    bool isLhs = value == cmp.getLhs();
+    Value other = isLhs ? cmp.getRhs() : cmp.getLhs();
+    // The comparison's block includes enclosing guards, but not its own branch.
+    auto otherRange = getRangeAt(other, cmp->getBlock(), point);
+    if (otherRange.isUninitialized())
+      return IntegerValueRange();
+    auto predicate = isTrue ? cmp.getPredicate()
+                            : arith::invertPredicate(cmp.getPredicate());
+    auto bound =
+        getBoundFromCmpPredicate(predicate, otherRange.getValue(), isLhs);
+    if (!bound)
+      return IntegerValueRange();
+    range = intersectRanges(range.getValue(), *bound);
+    if (range.isUninitialized())
+      return range;
+  }
+  return range;
+}
+
+IntegerValueRange TritonIntegerRangeAnalysis::getRangeAt(Value value,
+                                                         Operation *use) {
+  return getRangeAt(value, use->getBlock(), nullptr);
+}
+
+TritonIntegerRangeAnalysis::BranchConstraint *
+TritonIntegerRangeAnalysis::getConstraintScope(Block *block) {
+  // Cache the nearest dominating branch. Following each block's immediate
+  // dominator once avoids scanning every branch for every queried block.
+  SmallVector<Block *> path;
+  while (block && !blockConstraints.contains(block)) {
+    path.push_back(block);
+    Region *region = block->getParent();
+    auto *node = !region->hasOneBlock() && domInfo->hasSSADominance(region)
+                     ? domInfo->getNode(block)
+                     : nullptr;
+    block = node && node->getIDom() ? node->getIDom()->getBlock()
+                                    : region->getParentOp()->getBlock();
+  }
+  BranchConstraint *scope = blockConstraints.lookup(block);
+  for (Block *entry : llvm::reverse(path)) {
+    if (auto it = branchConstraints.find(entry);
+        it != branchConstraints.end()) {
+      it->second.parent = scope;
+      scope = &it->second;
+    }
+    blockConstraints.try_emplace(entry, scope);
+  }
+  return scope;
+}
+
+IntegerValueRange TritonIntegerRangeAnalysis::getRangeAt(Value value,
+                                                         Block *block,
+                                                         ProgramPoint *point) {
+  const auto *lattice =
+      point ? getLatticeElementFor(point, value) : getLatticeElement(value);
+  if (activeRangeQueries.empty())
+    rangeQueryCache.clear();
+  RangeQuery query{value, block};
+  if (auto it = rangeQueryCache.find(query); it != rangeQueryCache.end())
+    return it->second;
+  // A nested loop bound can depend on a guard involving this same recurrence.
+  // Break that optional refinement cycle without publishing a temporary top.
+  if (activeRangeQueries.size() >= 64 ||
+      !activeRangeQueries.insert(query).second)
+    return lattice->getValue().isUninitialized()
+               ? IntegerValueRange::getMaxRange(value)
+               : lattice->getValue();
+  llvm::scope_exit cleanup([&] { activeRangeQueries.erase(query); });
+  auto finish = [&](IntegerValueRange range) {
+    rangeQueryCache.try_emplace(query, range);
+    return range;
+  };
+  IntegerValueRange range = lattice->getValue();
+  if (controlFlow) {
+    if (auto arg = dyn_cast<BlockArgument>(value)) {
+      auto summary =
+          controlFlow->getRange(arg, block, [&](Value bound, Block *useBlock) {
+            return getRangeAt(bound, useBlock, point);
+          });
+      if (summary)
+        range = *summary;
+    }
+  }
+  if (auto assumed = maybeGetAssumedRange(value, block))
+    range = controlFlow && !range.isUninitialized()
+                ? intersectRanges(range.getValue(), *assumed)
+                : IntegerValueRange(*assumed);
+  if (!block || range.isUninitialized() || !controlFlow)
+    return finish(range);
+
+  for (auto *scope = getConstraintScope(block); scope; scope = scope->parent)
+    range = refineWithCondition(value, range, scope->condition, scope->isTrue,
+                                point);
+  return finish(range);
+}
+
+void TritonIntegerRangeAnalysis::visitControlFlowBlock(Block *block) {
+  auto *point = getProgramPointBefore(block);
+  if (!getOrCreate<dataflow::Executable>(point)->isLive())
+    return;
+  for (BlockArgument arg : block->getArguments()) {
+    auto *lattice = getLatticeElement(arg);
+    if (controlFlow) {
+      auto summary = controlFlow->getRange(
+          arg, nullptr, [&](Value bound, Block *useBlock) {
+            return getRangeAt(bound, useBlock, point);
+          });
+      if (summary) {
+        propagateIfChanged(lattice, lattice->join(*summary));
+        continue;
+      }
+    }
+
+    for (auto it = block->pred_begin(), end = block->pred_end(); it != end;
+         ++it) {
+      Block *predecessor = *it;
+      auto *edge = getOrCreateFor<dataflow::Executable>(
+          point, getLatticeAnchor<dataflow::CFGEdge>(predecessor, block));
+      if (!edge->isLive())
+        continue;
+      auto branch = dyn_cast<BranchOpInterface>(predecessor->getTerminator());
+      if (!branch) {
+        setToEntryState(lattice);
+        continue;
+      }
+      unsigned successor = it.getSuccessorIndex();
+      Value operand =
+          branch.getSuccessorOperands(successor)[arg.getArgNumber()];
+      if (!operand) {
+        setToEntryState(lattice);
+        continue;
+      }
+      IntegerValueRange incoming = getRangeAt(operand, predecessor, point);
+      if (auto condBranch = dyn_cast<cf::CondBranchOp>(branch.getOperation())) {
+        if (auto sourceArg = dyn_cast<BlockArgument>(operand);
+            sourceArg && sourceArg.getOwner() == predecessor)
+          incoming = getRangeAt(operand, block, point);
+        auto condition =
+            getRangeAt(condBranch.getCondition(), predecessor, point);
+        if (!condition.isUninitialized()) {
+          auto constant = condition.getValue().getConstantValue();
+          if (constant && (!constant->isZero() != (successor == 0)))
+            continue;
+        }
+        incoming =
+            refineWithCondition(operand, incoming, condBranch.getCondition(),
+                                successor == 0, point);
+      }
+      if (incoming.isUninitialized())
+        continue;
+      // Keep MLIR's merge-site widening for unsupported and irreducible loops.
+      dataflow::IntegerValueRangeLattice source(operand);
+      (void)source.join(incoming);
+      propagateIfChanged(lattice, lattice->join(source));
+    }
+  }
 }
 
 std::optional<ConstantIntRanges>
@@ -414,10 +656,10 @@ void TritonIntegerRangeAnalysis::setToEntryState(
       !llvm::isa<IntegerType>(getElementTypeOrSelf(anchor)))
     return;
 
-  Block *entryBlock = getFuncEntryBlock(getEnclosingFunction(anchor));
   IntegerValueRange range = IntegerValueRange::getMaxRange(anchor);
-  if (auto maybeRange = maybeGetAssumedRange(anchor, entryBlock))
-    range = *maybeRange;
+  if (Block *entryBlock = getFuncEntryBlock(getEnclosingFunction(anchor)))
+    if (auto maybeRange = maybeGetAssumedRange(anchor, entryBlock))
+      range = *maybeRange;
   auto changed = lattice->join(range);
   LLVM_DEBUG({
     if (changed == ChangeResult::Change) {
@@ -431,7 +673,6 @@ void TritonIntegerRangeAnalysis::setToEntryState(
 
 void TritonIntegerRangeAnalysis::defaultTransferFunc(
     Operation *op, Value resultVal,
-    ArrayRef<const dataflow::IntegerValueRangeLattice *> srcLattices,
     ArrayRef<dataflow::IntegerValueRangeLattice *> resultsLattices,
     const IntegerValueRange &incomingRange) {
 
@@ -492,32 +733,27 @@ LogicalResult TritonIntegerRangeAnalysis::visitOperation(
       opResultAssumption.insert(std::pair(result, *assumedRange));
   }
 
-  llvm::SmallVector<const dataflow::IntegerValueRangeLattice *, 4>
-      opndValueRanges;
-
-  llvm::SmallVector<std::unique_ptr<dataflow::IntegerValueRangeLattice>, 4>
-      newSrcLattices;
-
+  SmallVector<IntegerValueRange> operandRanges;
   for (auto [index, opnd] : llvm::enumerate(op->getOperands())) {
-    auto assumedRange = maybeGetAssumedRange(opnd, op->getBlock());
-    if (!assumedRange.has_value()) {
-      opndValueRanges.push_back(operands[index]);
-      continue;
+    auto range = operands[index]->getValue();
+    if (controlFlow) {
+      range = getRangeAt(opnd, op->getBlock(), getProgramPointAfter(op));
+      // A guard or loop bound may not have arrived yet. Publishing top here
+      // would permanently lose the precision from that pending dependency.
+      if (range.isUninitialized() &&
+          ConstantIntRanges::getStorageBitwidth(opnd.getType()))
+        return success();
+    } else if (auto assumed = maybeGetAssumedRange(opnd, op->getBlock())) {
+      range = IntegerValueRange(*assumed);
     }
-
-    auto newLattice =
-        std::make_unique<dataflow::IntegerValueRangeLattice>(opnd);
-    (void)newLattice->join(IntegerValueRange(*assumedRange));
-    opndValueRanges.push_back(newLattice.get());
-    newSrcLattices.push_back(std::move(newLattice));
+    operandRanges.push_back(range);
   }
-  assert(opndValueRanges.size() == operands.size() && "size disagree");
 
   // step 2: call helper function inferring the value range. If assumed value-
   // range is present, the transfer-function will intersect the assumed value-
   // value with the inferred value range.
   LogicalResult visitResult =
-      visitOperationHelper(op, opndValueRanges, resultsLattices);
+      visitOperationHelper(op, operandRanges, resultsLattices);
 
   // step 3: If previous step failed to infer value-range, apply assumed
   //  value-range is present.
@@ -528,7 +764,7 @@ LogicalResult TritonIntegerRangeAnalysis::visitOperation(
       continue;
 
     const mlir::IntegerValueRange &vr = lattice->getValue();
-    if (!vr.isUninitialized() && !AMD::isEmptyInitializedRange(vr.getValue()))
+    if (!vr.isUninitialized() && !isEmptyInitializedRange(vr.getValue()))
       continue;
 
     const ConstantIntRanges &assumedVr = assumedIter->second;
@@ -549,8 +785,7 @@ LogicalResult TritonIntegerRangeAnalysis::visitOperation(
 }
 
 LogicalResult TritonIntegerRangeAnalysis::visitOperationHelper(
-    Operation *op,
-    ArrayRef<const dataflow::IntegerValueRangeLattice *> operands,
+    Operation *op, ArrayRef<IntegerValueRange> operands,
     ArrayRef<dataflow::IntegerValueRangeLattice *> resultsLattices) {
   LDBG("Inferring ranges for " << *op);
 
@@ -558,9 +793,8 @@ LogicalResult TritonIntegerRangeAnalysis::visitOperationHelper(
   // IntegerRangeAnalysis::visitOperation except we do not "short-cicruit" the
   // analysis by inferring a maximum range for loop results (instead we
   // perform a check based on visit counts in visitRegionSuccessors).
-  auto joinCallback = [&op, &operands, &resultsLattices,
-                       this](Value v, const IntegerValueRange &incomingRange) {
-    this->defaultTransferFunc(op, v, operands, resultsLattices, incomingRange);
+  auto joinCallback = [&](Value v, const IntegerValueRange &incomingRange) {
+    defaultTransferFunc(op, v, resultsLattices, incomingRange);
   };
 
   // Ops with fixed/constant ranges.
@@ -587,21 +821,11 @@ LogicalResult TritonIntegerRangeAnalysis::visitOperationHelper(
     return success();
   }
 
-  SmallVector<IntegerValueRange> argIntValueRanges = llvm::map_to_vector(
-      operands, [](const dataflow::IntegerValueRangeLattice *lattice) {
-        return lattice->getValue();
-      });
-
-  if (auto sliceOp = dyn_cast<triton::amdgpu::ExtractSliceOp>(op)) {
-    joinCallback(sliceOp->getResult(0), argIntValueRanges[0]);
-    return success();
-  }
-
   // Ops with actually changing/variable input/output ranges.
   if (llvm::isa<TransOp, SplitOp, BroadcastOp, ReshapeOp, gpu::ConvertLayoutOp,
                 SplatOp, ExpandDimsOp, JoinOp, GatherOp>(op)) {
     SmallVector<ConstantIntRanges> argConstIntRanges;
-    for (const auto &r : argIntValueRanges) {
+    for (const auto &r : operands) {
       if (r.isUninitialized()) {
         setAllToEntryStates(resultsLattices);
         return success();
@@ -630,7 +854,7 @@ LogicalResult TritonIntegerRangeAnalysis::visitOperationHelper(
   //   - arith.shrui, e.g. arith.shrui %arg3, %c5_i32
   //
   if (auto inferrable = dyn_cast<InferIntRangeInterface>(op)) {
-    inferrable.inferResultRangesFromOptional(argIntValueRanges, joinCallback);
+    inferrable.inferResultRangesFromOptional(operands, joinCallback);
     return success();
   }
 
@@ -826,11 +1050,13 @@ TritonIntegerRangeAnalysis::collectAssumptions(Operation *rootOp,
                                                bool filterConstants) {
   DenseMap<Value, SetVector<Operation *>> assumptions;
   rootOp->walk([&](LLVM::AssumeOp op) {
-    auto assump = op.getCond().getDefiningOp();
-    for (auto operand : assump->getOperands()) {
+    auto cmp = op.getCond().getDefiningOp<arith::CmpIOp>();
+    if (!cmp)
+      return;
+    for (auto operand : cmp->getOperands()) {
       if (filterConstants && getConstantIntValue(operand))
         continue;
-      assumptions[operand].insert(assump);
+      assumptions[operand].insert(op);
     }
   });
   return assumptions;
@@ -863,7 +1089,7 @@ void populateFoldTrueCmpIOpPatterns(RewritePatternSet &patterns,
 }
 
 void initializeFuncOps(Operation *op,
-                       AMD::TritonIntegerRangeAnalysis *rangeAnalysis) {
+                       TritonIntegerRangeAnalysis *rangeAnalysis) {
   op->walk<WalkOrder::PreOrder>([&rangeAnalysis](FuncOp funcOp) {
     rangeAnalysis->initializeFuncOp(funcOp);
   });

--- a/third_party/amd/lib/Dialect/TritonAMDGPU/IR/Dialect.cpp
+++ b/third_party/amd/lib/Dialect/TritonAMDGPU/IR/Dialect.cpp
@@ -474,6 +474,11 @@ std::optional<LinearLayout> ScaledDowncastFp8Op::computeScaleLayout(
   return computeScaledCastScaleLayout(outputLayout, axis, elementsPerScale);
 }
 
+void ExtractSliceOp::inferResultRanges(ArrayRef<ConstantIntRanges> argRanges,
+                                       SetIntRangeFn setResultRange) {
+  setResultRange(getResult(), argRanges.front());
+}
+
 LogicalResult ExtractSliceOp::verify() {
   // Basic type/rank checks.
   auto srcTypeVal = getSource().getType();


### PR DESCRIPTION
Infer integer ranges through reducible control flow. Summarize affine loop-carried values, keep header/body/exit ranges separate, and refine uses with dominating branch conditions.

Base for #11590.
