### PR TITLE
[WS] Don't data-partition tiles fed by host-side tensor descriptors

### DIFF
--- a/python/test/unit/language/test_compile_only.py
+++ b/python/test/unit/language/test_compile_only.py
@@ -407,3 +407,32 @@ def test_fp8_compiles_for_multiple_architectures_cuda():
     src = ASTSource(fn=fp8_convert, signature={"src": "*fp32", "dst": "*fp8e5"}, constexprs={})
     triton.compile(src, target=GPUTarget("cuda", 90, 32))
     triton.compile(src, target=GPUTarget("cuda", 80, 32))
+
+
+def test_compile_only_warp_specialize_host_descriptor() -> None:
+    # Host-side descriptors have fixed TMA box dimensions, so the warp
+    # specialization pass must not split their tile across consumer groups.
+    # See https://github.com/triton-lang/triton/issues/11587.
+
+    @triton.jit
+    def matmul(out_desc, a_desc, b_desc, K, BLOCK_M: tl.constexpr, BLOCK_N: tl.constexpr, BLOCK_K: tl.constexpr):
+        off_m = tl.program_id(0) * BLOCK_M
+        off_n = tl.program_id(1) * BLOCK_N
+        acc = tl.zeros((BLOCK_M, BLOCK_N), dtype=tl.float32)
+        for k in tl.range(0, tl.cdiv(K, BLOCK_K), warp_specialize=True, num_stages=2):
+            a = a_desc.load([off_m, k * BLOCK_K])
+            b = b_desc.load([k * BLOCK_K, off_n])
+            acc = tl.dot(a, b, acc)
+        out_desc.store([off_m, off_n], acc)
+
+    src = triton.compiler.ASTSource(
+        fn=matmul, signature={
+            "out_desc": "tensordesc<fp32[128,128]>",
+            "a_desc": "tensordesc<fp16[128,64]>",
+            "b_desc": "tensordesc<fp16[64,128]>",
+            "K": "i32",
+            "BLOCK_M": "constexpr",
+            "BLOCK_N": "constexpr",
+            "BLOCK_K": "constexpr",
+        }, constexprs={"BLOCK_M": 128, "BLOCK_N": 128, "BLOCK_K": 64})
+    triton.compile(src, target=GPUTarget("cuda", 90, 32), options={"num_warps": 4})

--- a/third_party/nvidia/hopper/lib/Transforms/WarpSpecialization/WSDataPartition.cpp
+++ b/third_party/nvidia/hopper/lib/Transforms/WarpSpecialization/WSDataPartition.cpp
@@ -342,6 +342,14 @@ static bool getBackwardSliceToPartition(Value v,
       auto yieldArg = forOp.getYieldedValues()[bbArg.getArgNumber() - 1];
       if (!getBackwardSliceToPartition(yieldArg, partitionScheme, currentDim))
         return false;
+    } else if (isa<TensorDescType>(v.getType())) {
+      // A descriptor passed in as a function argument is built on the host,
+      // which fixes its TMA box dimensions. Unlike a MakeTensorDescOp result,
+      // it cannot be re-blocked to match a partitioned tile, so partitioning
+      // here would leave the copy's destination and the descriptor block
+      // disagreeing on shape.
+      LDBG("cannot partition a host side tensor descriptor");
+      return false;
     }
   }
 


### PR DESCRIPTION
Fixes #11587

A warp-specialized loop whose TMA descriptors are built on the host fails to compile once the tile is large enough to be split across consumer warp groups:

    'ttng.async_tma_copy_global_to_local' op descriptor block and tensor must have the same
    number of elements, but got descriptor block with 8192 elements tensor with 4096 elements

8192 is the descriptor's `[128, 64]` box, 4096 the `[64, 64]` destination left after the split.

A host-side descriptor reaches the kernel as a `tt.func` block argument. In `getBackwardSliceToPartition` the block-argument branch only handles `scf::ForOp` owners, so a function argument falls through to `return true` and the tile is reported as partitionable. `sliceOp` then halves the copy's destination, but the descriptor's box dimensions were fixed when it was built on the host and can't be re-derived the way a `tt.make_tensor_descriptor` result can. Plain pointer arguments never get here — `getShape` returns `{}` for them, so `needToSlice` exits early.

Changes:

- `WSDataPartition.cpp`: bail out of the partition when the block argument is a `TensorDescType`. `computePartitionScheme` then fails for two consumer groups and the existing retry drops to one, which warp specializes without splitting the tile — the fallback the pass already anticipates with its `// FIXME: skip data partitioning with on-host TMA`. Descriptors built in the kernel are unaffected and still partition, their block shape halving to `64x64` as before.
- `test_compile_only.py`: regression test for the failing kernel. Compile-only, so it needs no Hopper hardware.

Verified red before the fix. All fp16 host-descriptor block shapes named in the issue now compile (`128x128x64`, `128x64x64`, `128x64x32`, `128x128x128`, `64x16x128`), warp specialization is retained rather than disabled, and the descriptor blocks stay at `128x64` / `64x128` / `128x128`. `check-triton-lit-tests` 299 passed / 2 unsupported; `test_compile_only.py` 26 passed.

Notes:

- Verified at compile time only. The failure is in the MLIR pipeline so it reproduces without Hopper hardware, but I haven't run the resulting kernels on an H100. The fix declines a transformation rather than emitting new IR, so the resulting path is the same single-consumer-group one that host descriptors with `BLOCK_M=64` already take today.
- This trades a consumer warp group for compiling at all. Happy to rework it to keep both consumers and split somewhere the descriptor permits, if you'd rather.
