### PR TITLE
[AMD] Register gluon-infer-coalesced-encodings in the HIP pipeline

### DIFF
--- a/python/test/gluon/test_core.py
+++ b/python/test/gluon/test_core.py
@@ -14,6 +14,7 @@ from triton._internal_testing import (
     is_blackwell,
     is_blackwell_ultra,
     is_rubin,
+    is_hip,
     is_hip_rdna,
     is_hip_rdna3,
     is_hip_rdna4,
@@ -3565,7 +3566,7 @@ def test_tcgen05_mma_scaled_lhs_tmem(a_format, a_torch_dtype, b_format, b_torch_
     torch.testing.assert_close(out, ref, atol=atol, rtol=rtol)
 
 
-@pytest.mark.skipif(not is_ampere_or_newer(), reason="Requires Ampere or newer")
+@pytest.mark.skipif(not (is_ampere_or_newer() or is_hip()), reason="Requires Ampere or newer, or AMD")
 def test_coalesced_layout():
 
     @gluon.jit
@@ -3610,7 +3611,7 @@ def test_coalesced_layout():
     torch.testing.assert_close(output, ref)
 
 
-@pytest.mark.skipif(not is_ampere_or_newer(), reason="Requires Ampere or newer")
+@pytest.mark.skipif(not (is_ampere_or_newer() or is_hip()), reason="Requires Ampere or newer, or AMD")
 def test_convert_auto_layout_to_coalesced_layout():
 
     @gluon.jit

--- a/third_party/amd/backend/compiler.py
+++ b/third_party/amd/backend/compiler.py
@@ -331,6 +331,7 @@ class HIPBackend(BaseBackend):
         pm.enable_debug()
 
         passes.gluon.add_inliner(pm)
+        passes.gluon.add_infer_coalesced_encodings(pm)
         passes.gluon.add_resolve_auto_encodings(pm)
         passes.common.add_sccp(pm)
         passes.ttir.add_loop_aware_cse(pm)


### PR DESCRIPTION
`ttgl.CoalescedLayout()` crashes the compiler on the AMD backend:

```
python: lib/Dialect/TritonGPU/IR/LinearLayoutConversions.cpp:
  TritonGPUDialect::toLinearLayout(...): Assertion `0 && "unknown layout"' failed.
```

#8604 added the layout along with `gluon-infer-coalesced-encodings`, the pass that resolves
`#gluon.coalesced_encoding`, but registered it only in the NVIDIA `gluon_to_ttgir`. On AMD
the encoding survives into `gluon-resolve-auto-encodings` and reaches TritonGPU code that
can't handle it. The pass is backend agnostic, so registering it is the whole fix.

Repro (compile-only, no AMD hardware needed) — compile this for
`GPUTarget("hip", "gfx942", 64)`:

```python
@gluon.jit
def kernel(in_ptr, out_ptr, XBLOCK: ttgl.constexpr):
    idx = ttgl.arange(0, XBLOCK, ttgl.AutoLayout())
    in_ptrs = ttgl.set_auto_layout(in_ptr + idx, ttgl.CoalescedLayout())
    out_ptrs = ttgl.set_auto_layout(out_ptr + idx, ttgl.CoalescedLayout())
    ttgl.store(out_ptrs, ttgl.load(in_ptrs))
```

Also reproduces on the released `triton==3.8.0` wheel.

### The layout it picks

`CoalescedLayout` is defined as the layout the coalesce pass would have chosen, and
`buildCoalescedEncoding` is shared with `Coalesce.cpp`. Compiling the same access pattern
as a Triton kernel (which goes through `-tritongpu-coalesce`) and as a Gluon kernel gives
the same encoding on all four combinations I checked — 1-D and 2-D, `cuda:90` and
`hip:gfx942`. On gfx942 that is e.g. `sizePerThread = [1, 4], threadsPerWarp = [1, 64],
warpsPerCTA = [4, 1], order = [1, 0]`.

### What else changes

For code that doesn't use `CoalescedLayout`, the generated IR is almost unchanged. Over the
239 distinct Gluon modules `test_frontend.py` produces, 234 are byte-identical; the other 5
(the ones with `noinline` functions) pick up `tt.contiguity`/`tt.divisibility`/
`tt.constancy` on the non-inlined arguments, written by the `ModuleAxisInfoAnalysis` the
pass constructs. Removing the same line from the NVIDIA pipeline changes exactly those 5
modules in exactly the same way, so this is behaviour AMD was missing rather than behaviour
this adds. Those attributes can only raise the callee's axis info, never lower it: an entry
argument starts at `1/1/1` and the attribute is a `gcd` across call sites, so 1 is its
floor. On these 5 it is exactly `1/1/1`.

Compile time does go up, though: the pass builds `ModuleAxisInfoAnalysis` unconditionally,
so it runs even when there is no coalesced encoding to resolve. Over those 60 of the
modules that don't use `CoalescedLayout`, `gluon_to_ttgir` goes from 0.233s to 0.283s
(+21%, ~0.8ms per kernel). That cost is already being paid on NVIDIA. If you'd like it
gone, I'm happy to follow up with an early return before the analysis is constructed — that
touches the shared pass and so changes NVIDIA too, which is why it isn't in this PR.

### Tests

Both tests using `CoalescedLayout` were gated on `is_ampere_or_newer()`, which is why AMD
never hit this; they now run on HIP too. I have no AMD hardware, so I only checked that
they compile for `gfx942` — if CI turns them red, drop the guard change and land the
registration alone.

