### PR TITLE
[AMD] Register gluon-infer-coalesced-encodings in the HIP pipeline

### DIFF
--- a/python/test/gluon/test_core.py
+++ b/python/test/gluon/test_core.py
@@ -14,6 +14,7 @@ from triton._internal_testing import (
     is_blackwell,
     is_blackwell_ultra,
     is_rubin,
+    is_hip,
     is_hip_rdna,
     is_hip_rdna3,
     is_hip_rdna4,
@@ -3565,7 +3566,7 @@ def test_tcgen05_mma_scaled_lhs_tmem(a_format, a_torch_dtype, b_format, b_torch_
     torch.testing.assert_close(out, ref, atol=atol, rtol=rtol)
 
 
-@pytest.mark.skipif(not is_ampere_or_newer(), reason="Requires Ampere or newer")
+@pytest.mark.skipif(not (is_ampere_or_newer() or is_hip()), reason="Requires Ampere or newer, or AMD")
 def test_coalesced_layout():
 
     @gluon.jit
@@ -3610,7 +3611,7 @@ def test_coalesced_layout():
     torch.testing.assert_close(output, ref)
 
 
-@pytest.mark.skipif(not is_ampere_or_newer(), reason="Requires Ampere or newer")
+@pytest.mark.skipif(not (is_ampere_or_newer() or is_hip()), reason="Requires Ampere or newer, or AMD")
 def test_convert_auto_layout_to_coalesced_layout():
 
     @gluon.jit

--- a/third_party/amd/backend/compiler.py
+++ b/third_party/amd/backend/compiler.py
@@ -331,6 +331,7 @@ class HIPBackend(BaseBackend):
         pm.enable_debug()
 
         passes.gluon.add_inliner(pm)
+        passes.gluon.add_infer_coalesced_encodings(pm)
         passes.gluon.add_resolve_auto_encodings(pm)
         passes.common.add_sccp(pm)
         passes.ttir.add_loop_aware_cse(pm)


### PR DESCRIPTION
`ttgl.CoalescedLayout()` crashes the compiler on the AMD backend:

```
python: lib/Dialect/TritonGPU/IR/LinearLayoutConversions.cpp:
  TritonGPUDialect::toLinearLayout(...): Assertion `0 && "unknown layout"' failed.
```

#8604 added the layout along with `gluon-infer-coalesced-encodings`, the pass that resolves `#gluon.coalesced_encoding`, but registered it only in the NVIDIA `gluon_to_ttgir`. On AMD the encoding survives into `gluon-resolve-auto-encodings` and reaches TritonGPU code that can't handle it.

### The layout it picks

`CoalescedLayout` is defined as the layout the coalesce pass would have chosen, and `buildCoalescedEncoding` is shared with `Coalesce.cpp`.

I compiled the same access pattern twice, once as a Triton kernel and once as a Gluon one. The encoding came out the same in all four cases I tried (1-D and 2-D, `cuda:90` and `hip:gfx942`). On gfx942 that is `sizePerThread = [1, 4], threadsPerWarp = [1, 64], warpsPerCTA = [4, 1], order = [1, 0]`.

### Tests

I ran the 239 distinct Gluon modules that `test_frontend.py` produces through the AMD `gluon_to_ttgir`, with and without this line.

The generated IR is unchanged if the code is not related to `CoalescedLayout`. Only 5 modules are changed. However they are also changed in NVIDIA pipeline without `gluon-infer-coalesced-encodings`. So this is behaviour AMD was missing.

What I am worried is that compile time does go up. The pass builds `ModuleAxisInfoAnalysis`, so it runs even when there is no coalesced encoding to resolve. That cost is already being paid on NVIDIA. An early return before the analysis would remove it, but that also changes the NVIDIA path, so I left it out of this PR.

Both tests that use `CoalescedLayout` are gated on `is_ampere_or_newer()`, which is false on AMD, so both were skipped there. That is why this never showed up. They now run on HIP as well. I have no AMD hardware, so I only checked that the two kernels compile for `gfx942`; the numerics are for CI to confirm.

repro:

```python
import triton
import triton.language as tl
from triton.backends.compiler import GPUTarget
from triton.compiler import make_backend
from triton.experimental import gluon
from triton.experimental.gluon import language as ttgl
from triton.experimental.gluon._runtime import GluonASTSource
from triton.runtime.jit import create_function_from_signature, MockTensor

TARGET = GPUTarget("hip", "gfx942", 64)


@gluon.jit
def kernel(in_ptr, out_ptr, XBLOCK: ttgl.constexpr):
    idx = ttgl.arange(0, XBLOCK, ttgl.AutoLayout())
    in_ptrs = ttgl.set_auto_layout(in_ptr + idx, ttgl.CoalescedLayout())
    out_ptrs = ttgl.set_auto_layout(out_ptr + idx, ttgl.CoalescedLayout())
    ttgl.store(out_ptrs, ttgl.load(in_ptrs))


args = (MockTensor(tl.float32), MockTensor(tl.float32), 128)
kwargs = dict(num_warps=4, sanitize_overflow=False)

backend = make_backend(TARGET)
binder = create_function_from_signature(kernel.signature, kernel.params, backend)
bound, spec, opts = binder(*args, **kwargs)
opts, sig, constexprs, attrs = kernel._pack_args(backend, kwargs, bound, spec, opts)

triton.compile(GluonASTSource(kernel, sig, constexprs, attrs), target=TARGET)  # boom
```

# New contributor declaration
- [x] I am not making a trivial change, such as fixing a typo in a comment.

- [x] I have written a PR description following these
  [rules](https://cbea.ms/git-commit/#why-not-how).

- [x] I have run `pre-commit run --from-ref origin/main --to-ref HEAD`.

- Select one of the following.
  - [ ] I have added tests.
    - `/test` for `lit` tests
    - `/unittest` for C++ tests
    - `/python/test` for end-to-end tests
  - [x] This PR does not need a test because `the two existing tests for CoalescedLayout now run on AMD, which covers this path`.

- Select one of the following.
  - [x] I have not added any `lit` tests.
  - [ ] The `lit` tests I have added follow these [best practices](https://mlir.llvm.org/getting_started/TestingGuide/#filecheck-best-practices),
    including the "tests should be minimal" section.

