### PR TITLE
[AUTOTUNER] Reject autotune name lists that are not kernel arguments

### DIFF
--- a/python/test/unit/runtime/test_autotuner.py
+++ b/python/test/unit/runtime/test_autotuner.py
@@ -309,6 +309,66 @@ def test_prune_configs_fractional_top_k_after_early_prune():
     assert benchmarked == [1, 2, 3]
 
 
+def test_unknown_key_name_is_rejected():
+    # `key` is documented as a list of argument names. An unknown name used to be
+    # dropped from the tuning key by run(), so the kernel tuned once and then reused
+    # that config no matter how the real argument changed.
+    class Kernel:
+
+        def __init__(self):
+            self.fn = lambda: None
+
+        def run(self, **kwargs):
+            pass
+
+    for param in ("key", "reset_to_zero", "restore_value"):
+        with pytest.raises(ValueError, match="not kernel arguments"):
+            triton.runtime.Autotuner(
+                Kernel(),
+                arg_names=["n"],
+                configs=[triton.Config(kwargs={"BLOCK_SIZE": 32})],
+                key=["N"] if param == "key" else [],
+                reset_to_zero=["N"] if param == "reset_to_zero" else None,
+                restore_value=["N"] if param == "restore_value" else None,
+            )
+
+
+def test_restore_value_with_user_pre_hook():
+    # A user-supplied pre_hook replaces the default one that populates restore_copies,
+    # but the default post_hook that reads it stays installed, so running the autotuner
+    # used to raise AttributeError instead of benchmarking.
+    launched = []
+
+    class Kernel:
+
+        def __init__(self):
+            self.fn = lambda: None
+
+        def run(self, **kwargs):
+            launched.append(kwargs["BLOCK_SIZE"])
+
+    def do_bench(kernel_call, quantiles):
+        kernel_call()
+        return [1.0, 1.0, 1.0]
+
+    tuner = triton.runtime.Autotuner(
+        Kernel(),
+        arg_names=["x"],
+        configs=[triton.Config(kwargs={"BLOCK_SIZE": 32}),
+                 triton.Config(kwargs={"BLOCK_SIZE": 64})],
+        key=[],
+        reset_to_zero=None,
+        restore_value=["x"],
+        pre_hook=lambda kwargs, reset_only=False: None,
+        do_bench=do_bench,
+    )
+
+    tuner.run(x=None)
+
+    # Both configs get benchmarked, then the winner is launched for real.
+    assert launched[:2] == [32, 64]
+
+
 def test_config_ir_override_changes_disk_cache_key():
     # Autotuner derives persisted result-cache keys from Config.__str__().
     first = triton.Config(kwargs={"BLOCK_SIZE": 32}, ir_override="first.ttir")
@@ -572,7 +632,7 @@ def test_exceed_tmem(device):
         if exception is not None:
             exception_out_of_resource = exception
 
-    @triton.autotune(configs=configs, key=['N'], do_bench=do_bench, pre_hook=None, post_hook=_post_hook)
+    @triton.autotune(configs=configs, key=[], do_bench=do_bench, pre_hook=None, post_hook=_post_hook)
     @triton.jit
     def dot_kernel(dst, BLOCK_SIZE: tl.constexpr):
         a = tl.full((BLOCK_SIZE, BLOCK_SIZE), 0.0, tl.float16)

--- a/python/triton/runtime/autotuner.py
+++ b/python/triton/runtime/autotuner.py
@@ -6,7 +6,7 @@ import inspect
 import hashlib
 import json
 from functools import cached_property
-from typing import Dict, Tuple, List, Optional
+from typing import Any, Dict, Tuple, List, Optional
 
 from .. import knobs
 from .jit import KernelInterface, JITFunction
@@ -45,6 +45,21 @@ class Autotuner(KernelInterface):
         self.restore_value = []
         if restore_value is not None:
             self.restore_value = list(restore_value)
+
+        # `key`, `reset_to_zero` and `restore_value` are all documented as lists of
+        # argument names. A name that is not one is silently dropped from the tuning
+        # key by `run()`, so a typo makes the kernel tune once and never re-tune.
+        for param, names in (("key", self.keys), ("reset_to_zero", self.reset_to_zero), ("restore_value",
+                                                                                         self.restore_value)):
+            unknown = [name for name in names if name not in self.arg_names]
+            if unknown:
+                raise ValueError(f"{param} contains names that are not kernel arguments: "
+                                 f"{', '.join(unknown)}. Valid argument names are: {', '.join(self.arg_names)}.")
+
+        # Populated by the default pre_hook when `restore_value` is set. Initialized here
+        # because a user-supplied pre_hook replaces that default while the default
+        # post_hook, which reads this, stays installed.
+        self.restore_copies: Dict[str, Any] = {}
 
         # Hook to reset or restore for required tensors
         self.pre_hook = lambda kwargs, reset_only=False: 0


### PR DESCRIPTION
# New contributor declaration
- [x] I am not making a trivial change, such as fixing a typo in a comment.

- [x] I have written a PR description following these
  [rules](https://cbea.ms/git-commit/#why-not-how).

- [x] I have run `pre-commit run --from-ref origin/main --to-ref HEAD`.

- Select one of the following.
  - [x] I have added tests.

## Silently ignored autotune key names

`key`, `reset_to_zero` and `restore_value` are documented as lists of argument names, but a name that is not one is silently dropped. `Autotuner.run()` builds the tuning key as:

```python
_args = {k: v for (k, v) in all_args.items() if k in self.arg_names}
key = [_args[key] for key in self.keys if key in _args]
```

so a stale or misspelled entry leaves the kernel tuning once and then reusing that config no matter how the real argument changes. There is no error and no warning; the only symptom is a kernel that quietly stopped re-tuning, which reads as a performance mystery rather than a bug.

This is easy to hit. `test_tmem_out_of_resource` in `python/test/unit/runtime/test_autotuner.py` passes `key=['N']` to a kernel whose arguments are `dst` and `BLOCK_SIZE`, so that test's tuning key has been empty since it was written. An AST scan over `python/` and `third_party/` found it to be the only such usage in the repository, and dropping the stale name is behaviour-preserving: the key already resolved to the empty tuple.

This PR validates the three name lists in `__init__` and raises `ValueError` naming the offending entries and the valid argument names, matching how the class already reports conflicting meta-parameters. Happy to downgrade it to a `warnings.warn` if you would rather not fail at decoration time.

## `restore_copies` is never initialized

Passing `pre_hook` together with `restore_value` replaces the default pre_hook that populates `restore_copies`, but the default post_hook that reads it stays installed, because it is selected independently:

```python
if post_hook:
    self.post_hook = post_hook
elif len(self.restore_value) > 0:
    def _post_hook(kwargs, exception):
        for name, value in self.restore_copies.items():   # never set
```

Autotuning such a kernel raised `AttributeError: 'Autotuner' object has no attribute 'restore_copies'` instead of benchmarking. Initializing it in `__init__` fixes that; the default pre_hook still overwrites it when it runs.

## Tests

Two tests added next to the existing `Autotuner`-constructed ones, both device-free:

- `test_unknown_key_name_is_rejected` — parametrised over the three arguments, asserts `ValueError`.
- `test_restore_value_with_user_pre_hook` — asserts both configs get benchmarked instead of raising `AttributeError`.

Both fail on `main` and pass with this change. `pre-commit` passes on the two touched files (ruff, yapf, mypy included).
