### PR TITLE
[TRITONGPU] Guard loop-bound loads during flattening

### DIFF
--- a/lib/Dialect/TritonGPU/Transforms/FuseNestedLoops.cpp
+++ b/lib/Dialect/TritonGPU/Transforms/FuseNestedLoops.cpp
@@ -275,6 +275,33 @@ static bool canSliceBounds(mlir::DominanceInfo &domInfo, scf::ForOp outer,
       });
 }
 
+static void
+hoistLoopBoundComputations(scf::ForOp outer,
+                           const llvm::SetVector<Operation *> &toHoist,
+                           mlir::DominanceInfo &domInfo) {
+  if (llvm::any_of(toHoist,
+                   [](Operation *op) { return !isMemoryEffectFree(op); })) {
+    // A read-only bound computation may still fault when the outer loop is
+    // empty. Guard the loop and its bounds together, including computations
+    // that consume the loaded value (e.g. a divisor).
+    ImplicitLocOpBuilder b(outer.getLoc(), outer);
+    auto predicate = outer.getUnsignedCmp() ? arith::CmpIPredicate::ult
+                                            : arith::CmpIPredicate::slt;
+    Value nonEmpty = arith::CmpIOp::create(b, predicate, outer.getLowerBound(),
+                                           outer.getUpperBound());
+    auto guard = scf::IfOp::create(b, outer.getResultTypes(), nonEmpty);
+    outer.replaceAllUsesWith(guard.getResults());
+    b.createBlock(&guard.getThenRegion());
+    outer->remove();
+    b.insert(outer);
+    scf::YieldOp::create(b, outer.getResults());
+    b.createBlock(&guard.getElseRegion());
+    scf::YieldOp::create(b, outer.getInits());
+    domInfo.invalidate();
+  }
+  hoistOpsBefore(outer, toHoist);
+}
+
 // Pessimistically assume the internal storage bitwidth for index types.
 static unsigned getIntTypeWidth(Type type) {
   if (isa<IndexType>(type))
@@ -516,6 +543,10 @@ static void fuseOneLevel(LoopNestNode *parent, mlir::DominanceInfo &domInfo) {
   for (LoopNestNode *child : parent->children) {
     scf::ForOp inner = child->loop;
     assert(child->children.empty() && "fuseOneLevel runs leaf-to-root");
+    // A child fusion may have introduced an execution guard. Treat the
+    // guarded loop opaquely, just as loop-nest discovery treats scf.if.
+    if (inner->getBlock() != outer.getBody())
+      continue;
 
     // Check if the inner loop bounds are or can be made invariant to the outer
     // loop. Check them all at once to avoid adding ops to `toHoist` if not
@@ -553,7 +584,7 @@ static void fuseOneLevel(LoopNestNode *parent, mlir::DominanceInfo &domInfo) {
   // The transformation will definitely succeed on `childrenToFuse`. `toHoist`
   // only contains the operations that must be hoisted for `childrenToFuse` to
   // be fusible.
-  hoistOpsBefore(outer, toHoist);
+  hoistLoopBoundComputations(outer, toHoist, domInfo);
 
   // Determine the integer type to use for the length computations. Use an
   // integer bitwidth twice the size of the largest integer, up to 64 bits, to
@@ -1154,7 +1185,8 @@ static LogicalResult speculateInnerLoopLength(scf::ForOp outerLoop,
     return failure();
 
   // Hoist the inner loop bounds computations if necessary.
-  hoistOpsBefore(outerLoop, toHoist);
+  hoistLoopBoundComputations(outerLoop, toHoist, domInfo);
+  b.setInsertionPoint(outerLoop);
 
   // Mark the inner loop.
   innerLoop->setAttr(kMustExecuteAttrName, b.getUnitAttr());

--- a/python/test/unit/language/test_core.py
+++ b/python/test/unit/language/test_core.py
@@ -6886,6 +6886,38 @@ def test_tl_range_fuse(device):
     torch.testing.assert_close(out, ref, atol=0, rtol=0)
 
 
+@pytest.mark.parametrize("bounds", [(0, 0), (3, 1), (2, 5)])
+@pytest.mark.parametrize("inner_bound", [0, 3])
+@pytest.mark.parametrize("load_enabled", [False, True])
+def test_tl_range_fuse_loaded_bound_zero_trip(bounds, inner_bound, load_enabled, device):
+
+    @triton.jit
+    def kernel(x_ptr, bound_ptr, out_ptr, lower, upper, enabled, BLOCK: tl.constexpr):
+        offsets = tl.arange(0, BLOCK)
+        acc = tl.full((BLOCK, ), 7, tl.int32)
+        for i in tl.range(lower, upper, flatten=True):
+            n = tl.load(bound_ptr, mask=enabled, other=0)
+            for j in range(n):
+                acc += tl.load(x_ptr + j * BLOCK + offsets)
+        tl.store(out_ptr + offsets, acc)
+
+    lower, upper = bounds
+    # Empty outer loops must not dereference the bound, even when its load
+    # mask is true. An empty tensor supplies no readable elements.
+    bound_values = [inner_bound] if lower < upper else []
+    bound = torch.tensor(bound_values, dtype=torch.int32, device=device)
+    x = torch.arange(3 * 128, dtype=torch.int32, device=device).reshape(3, 128)
+    out = torch.empty((128, ), dtype=torch.int32, device=device)
+    compiled = kernel[(1, )](x, bound, out, lower, upper, load_enabled, BLOCK=128)
+
+    trips = max(upper - lower, 0)
+    expected = torch.full_like(out, 7)
+    if trips and load_enabled:
+        expected += trips * x[:inner_bound].sum(dim=0).to(torch.int32)
+    torch.testing.assert_close(out, expected, atol=0, rtol=0)
+    assert compiled.asm["ttgir"].count("scf.for") == 1
+
+
 def test_tl_range_fuse_dependent(device):
 
     @triton.jit

--- a/test/TritonGPU/fuse-nested-loops.mlir
+++ b/test/TritonGPU/fuse-nested-loops.mlir
@@ -596,3 +596,64 @@ tt.func @prologue_output(%ub: i32) {
 
   tt.return
 }
+
+// -----
+
+// The loaded divisor and the division must both stay under the outer trip
+// condition. Preserve the original load mask and the zero-trip result.
+// CHECK-LABEL: @speculate_loaded_bound
+// CHECK-SAME: [[PTR:%.*]]: !tt.ptr<i32>, [[MASK:%.*]]: i1, [[LB:%.*]]: i32, [[UB:%.*]]: i32, [[INIT:%.*]]: i32
+// CHECK-NOT: tt.load
+// CHECK: [[NONEMPTY:%.*]] = arith.cmpi slt, [[LB]], [[UB]]
+// CHECK-NEXT: [[RESULT:%.*]] = scf.if [[NONEMPTY]] -> (i32) {
+// CHECK-NEXT: [[DIVISOR:%.*]] = tt.load [[PTR]], [[MASK]], %c1_i32
+// CHECK-NEXT: arith.divsi %c6_i32, [[DIVISOR]]
+// CHECK: scf.for
+// CHECK: scf.yield [[INIT]] : i32
+// CHECK-NEXT: }
+// CHECK-NEXT: tt.return [[RESULT]] : i32
+tt.func @speculate_loaded_bound(%ptr: !tt.ptr<i32>, %mask: i1, %lb: i32, %ub: i32, %init: i32) -> i32 {
+  %c0 = arith.constant 0 : i32
+  %c1 = arith.constant 1 : i32
+  %c6 = arith.constant 6 : i32
+  %result = scf.for %i = %lb to %ub step %c1 iter_args(%acc = %init) -> i32 : i32 {
+    %divisor = tt.load %ptr, %mask, %c1 : !tt.ptr<i32>
+    %bound = arith.divsi %c6, %divisor : i32
+    %sum = scf.for %j = %c0 to %bound step %c1 iter_args(%value = %acc) -> i32 : i32 {
+      %next = arith.addi %value, %j : i32
+      scf.yield %next : i32
+    }
+    scf.yield %sum : i32
+  } {tt.flatten}
+  tt.return %result : i32
+}
+
+// -----
+
+// After fusing the inner pair, keep its execution guard inside the outer loop.
+// CHECK-LABEL: @fuse_guarded_child
+// CHECK-SAME: [[PTR:%.*]]: !tt.ptr<i32>, [[UB:%.*]]: i32, [[INIT:%.*]]: i32
+// CHECK-NOT: tt.load
+// CHECK: scf.for [[I:%.*]] = %c0_i32 to [[UB]]
+// CHECK: [[NONEMPTY:%.*]] = arith.cmpi sgt, [[I]], %c0_i32
+// CHECK-NEXT: {{.*}}scf.if [[NONEMPTY]]
+// CHECK-NEXT: tt.load [[PTR]]
+// CHECK: scf.for
+// CHECK-NOT: scf.for
+// CHECK: tt.return
+tt.func @fuse_guarded_child(%ptr: !tt.ptr<i32>, %ub: i32, %init: i32) -> i32 {
+  %c0 = arith.constant 0 : i32
+  %c1 = arith.constant 1 : i32
+  %result = scf.for %i = %c0 to %ub step %c1 iter_args(%a = %init) -> i32 : i32 {
+    %middle = scf.for %j = %c0 to %i step %c1 iter_args(%b = %a) -> i32 : i32 {
+      %bound = tt.load %ptr : !tt.ptr<i32>
+      %inner = scf.for %k = %c0 to %bound step %c1 iter_args(%c = %b) -> i32 : i32 {
+        %next = arith.addi %c, %k : i32
+        scf.yield %next : i32
+      }
+      scf.yield %inner : i32
+    }
+    scf.yield %middle : i32
+  } {"ttg.always-fuse"}
+  tt.return %result : i32
+}


### PR DESCRIPTION
#11601

keep loads inside the outer loop's execution guard so flattening doesn't add reads when the loop is empty
