### PR TITLE
[interpreter] fix tl.sum NaN loss for bfloat16/float8 dtypes

### DIFF
--- a/python/triton/runtime/interpreter.py
+++ b/python/triton/runtime/interpreter.py
@@ -1139,6 +1139,16 @@ class ReduceOps(ReduceScanOpInterface):
             raise ValueError("val_reduce_op and idx_reduce_op are both None")
 
     def sum(self, input):
+        # bfloat16/float8 are stored as raw uint bits (numpy has no native
+        # support for them), so np.sum on input.handle.data directly would
+        # perform integer addition on the bit patterns instead of float
+        # addition -- silently corrupting the result and losing NaN
+        # propagation. Compute in float32 for these dtypes, then cast back.
+        if input.dtype.is_floating() and np.issubdtype(_get_np_dtype(input.dtype), np.integer):
+            data = _convert_float(input.handle.data, input.dtype, tl.float32, None).view(np.float32)
+            result = np.sum(data, axis=self.axis, keepdims=self.keep_dims)
+            cast_back = _convert_float(result, tl.float32, input.dtype, None).view(_get_np_dtype(input.dtype))
+            return self.to_tensor(cast_back, input.dtype)
         return self.to_tensor(np.sum(input.handle.data, axis=self.axis, keepdims=self.keep_dims), input.dtype)
 
     def apply_impl(self, input):


### PR DESCRIPTION
## Summary

`bfloat16`/`float8` tensors are stored as raw uint bits in the
interpreter (numpy has no native support for them). `ReduceOps.sum()`
called `np.sum` directly on this raw integer data, performing integer
addition on the bit patterns instead of float addition — silently
corrupting results and losing NaN propagation.

Example: `sum([nan, 2, 3, 4, 5, 6, 7, 8])` in bfloat16 returned
`384.0` instead of `nan`, because the NaN bit pattern (`0x7fc0`) was
summed as a plain integer with the other bit patterns and wrapped.

Fixes #11604.

## Fix

For dtypes whose numpy representation is an integer type despite
being logically floating-point, convert to float32 via the existing
`_convert_float()` helper before calling `np.sum`, then cast the
result back to the original dtype. `float16` is unaffected (numpy
supports it natively) and takes the existing fast path unchanged.

```diff
     def sum(self, input):
+        # bfloat16/float8 are stored as raw uint bits (numpy has no native
+        # support for them), so np.sum on input.handle.data directly would
+        # perform integer addition on the bit patterns instead of float
+        # addition -- silently corrupting the result and losing NaN
+        # propagation. Compute in float32 for these dtypes, then cast back.
+        if input.dtype.is_floating() and np.issubdtype(_get_np_dtype(input.dtype), np.integer):
+            data = _convert_float(input.handle.data, input.dtype, tl.float32, None).view(np.float32)
+            result = np.sum(data, axis=self.axis, keepdims=self.keep_dims)
+            cast_back = _convert_float(result, tl.float32, input.dtype, None).view(_get_np_dtype(input.dtype))
+            return self.to_tensor(cast_back, input.dtype)
         return self.to_tensor(np.sum(input.handle.data, axis=self.axis, keepdims=self.keep_dims), input.dtype)
```

Note: this is unrelated to #11531 (integer overflow in scalar `tl.sum`
narrowing, a different code path in `ReduceScanOpInterface.to_tensor`)
— confirmed no overlap by rebasing this branch onto current main.

## Test plan

- Found via a differential (jit vs interpreter) fuzzing harness
  sweeping NaN x reduction-op x dtype combinations (140 cases).
- Manually verified on Colab against installed pip triton (3.6.0,
  same `sum()` code structure as this patch's base):
  - Bug case: `sum([nan, 2..8])` in bfloat16 — before: `384.0`,
    after: `nan`.
  - Regression check: bfloat16/float32 sums with no NaN still
    produce correct totals (e.g. `36.0`); float32/float16 NaN cases
    (already correct before this patch) remain correct.
- No existing interpreter test covers NaN reduction across dtypes —
  open question for reviewer: where is the right place to add one —
  `test/unit/language/test_reduce.py` or an interpreter-specific test
  file?
