### PR TITLE
[TRITONGPU] Preserve empty inner loops during flattening

### DIFF
--- a/lib/Dialect/TritonGPU/Transforms/FuseNestedLoops.cpp
+++ b/lib/Dialect/TritonGPU/Transforms/FuseNestedLoops.cpp
@@ -1159,12 +1159,11 @@ static LogicalResult speculateInnerLoopLength(scf::ForOp outerLoop,
   // Mark the inner loop.
   innerLoop->setAttr(kMustExecuteAttrName, b.getUnitAttr());
 
-  // Speculate on whether the length of the inner loop is zero.
-  Value lenInner = computeNumIters(b, innerLoop);
-  auto zeroAttr = IntegerAttr::get(lenInner.getType(), 0);
-  Value innerLoopEmpty =
-      arith::CmpIOp::create(b, arith::CmpIPredicate::eq, lenInner,
-                            arith::ConstantOp::create(b, zeroAttr));
+  // SCF for loops have positive steps, so inverted bounds are empty too.
+  auto predicate = innerLoop.getUnsignedCmp() ? arith::CmpIPredicate::uge
+                                              : arith::CmpIPredicate::sge;
+  Value innerLoopEmpty = arith::CmpIOp::create(
+      b, predicate, innerLoop.getLowerBound(), innerLoop.getUpperBound());
   auto ifOp = scf::IfOp::create(b, outerLoop.getResultTypes(), innerLoopEmpty);
 
   // In the `then` branch, the inner loop does not execute. Clone the loop nest

--- a/python/test/unit/language/test_core.py
+++ b/python/test/unit/language/test_core.py
@@ -6886,6 +6886,29 @@ def test_tl_range_fuse(device):
     torch.testing.assert_close(out, ref, atol=0, rtol=0)
 
 
+@pytest.mark.parametrize("bounds", [(2, 5, 1), (5, 5, 1), (5, 2, 1), (5, 2, 2), (5, 4, 2), (2, 5, 2)])
+@pytest.mark.parametrize("flatten", [False, True])
+def test_tl_range_fuse_empty_inner_bounds(bounds, flatten, device):
+
+    @triton.jit
+    def kernel(x_ptr, out_ptr, lower, upper, step, FLATTEN: tl.constexpr):
+        acc = 7
+        for i in tl.range(3, flatten=FLATTEN):
+            acc += 10
+            for j in range(lower, upper, step):
+                acc += tl.load(x_ptr + j)
+            acc += 100
+        tl.store(out_ptr, acc)
+
+    lower, upper, step = bounds
+    x = torch.arange(32, dtype=torch.int32, device=device)
+    out = torch.empty((), dtype=torch.int32, device=device)
+    kernel[(1, )](x, out, lower, upper, step, flatten)
+    # Empty inner loops must still preserve the outer prologue and epilogue.
+    expected = 7 + 3 * (110 + sum(range(lower, upper, step)))
+    assert out.item() == expected
+
+
 def test_tl_range_fuse_dependent(device):
 
     @triton.jit

--- a/test/TritonGPU/fuse-nested-loops.mlir
+++ b/test/TritonGPU/fuse-nested-loops.mlir
@@ -492,10 +492,9 @@ tt.func @preserve_explicit_stage_one(%lb: i32, %ub: i32) {
 tt.func @fuse_attr_speculate(%lb: i32, %ub: i32) {
   %c1_i32 = arith.constant 1 : i32
 
-  // CHECK: [[LEN:%.*]] = arith.subi [[UB]], [[LB]]
-  // CHECK: [[IS_ZERO:%.*]] = arith.cmpi eq, [[LEN]], %c0_i32
+  // CHECK: [[IS_EMPTY:%.*]] = arith.cmpi sge, [[LB]], [[UB]]
 
-  // CHECK: scf.if [[IS_ZERO]]
+  // CHECK: scf.if [[IS_EMPTY]]
   // CHECK-NEXT: scf.for %{{.*}} = [[LB]] to [[UB]] step %c1_i32
   // CHECK-NEXT:   "prologue"
   // CHECK-NXET: } {tt.flatten}
@@ -525,9 +524,10 @@ tt.func @fuse_attr_speculate(%lb: i32, %ub: i32) {
 tt.func @speculate_hoist(%lb: i32, %ub: i32) {
   %c1_i32 = arith.constant 1 : i32
 
-  // CHECK: [[IS_ZERO:%.*]] = arith.cmpi eq, [[UB]], %c0_i32
+  // CHECK: [[INNER_UB:%.*]] = arith.addi [[LB]], [[UB]]
+  // CHECK: [[IS_EMPTY:%.*]] = arith.cmpi sge, [[LB]], [[INNER_UB]]
 
-  // CHECK: scf.if [[IS_ZERO]]
+  // CHECK: scf.if [[IS_EMPTY]]
   scf.for %i = %lb to %ub step %c1_i32 : i32 {
     "prologue"(%i) : (i32) -> ()
     %ubj = arith.addi %lb, %ub : i32
@@ -535,6 +535,31 @@ tt.func @speculate_hoist(%lb: i32, %ub: i32) {
       "body"(%i, %j) : (i32, i32) -> ()
       scf.yield
     }
+  } {tt.flatten}
+  tt.return
+}
+
+// The empty-loop check must use the inner loop's comparison signedness.
+// CHECK-LABEL: @speculate_unsigned_inner_bounds
+// CHECK-SAME: [[M:%.*]]: i32, [[LB:%.*]]: i32, [[UB:%.*]]: i32
+tt.func @speculate_unsigned_inner_bounds(%m: i32, %lb: i32, %ub: i32) {
+  %c0 = arith.constant 0 : i32
+  %c1 = arith.constant 1 : i32
+  // CHECK: [[EMPTY:%.*]] = arith.cmpi uge, [[LB]], [[UB]]
+  // CHECK-NEXT: scf.if [[EMPTY]] {
+  // CHECK-NEXT: scf.for
+  // CHECK-NEXT: "prologue"
+  // CHECK-NEXT: "epilogue"
+  // CHECK-NEXT: }
+  // CHECK-NEXT: } else {
+  // CHECK: scf.for
+  // CHECK: "body"
+  scf.for %i = %c0 to %m step %c1 : i32 {
+    "prologue"(%i) : (i32) -> ()
+    scf.for unsigned %j = %lb to %ub step %c1 : i32 {
+      "body"(%j) : (i32) -> ()
+    }
+    "epilogue"(%i) : (i32) -> ()
   } {tt.flatten}
   tt.return
 }


### PR DESCRIPTION
An inner range with lower > upper is empty, but flattening treated it as nonempty and ran its body once per outer iteration.
