### PR TITLE
[GSan] Add optional halfword shadow precision

### DIFF
--- a/lib/Conversion/TritonInstrumentToLLVM/GSanToLLVM.cpp
+++ b/lib/Conversion/TritonInstrumentToLLVM/GSanToLLVM.cpp
@@ -21,8 +21,6 @@ namespace ttg = mlir::triton::gpu;
 
 namespace {
 
-static constexpr unsigned kGSanShadowGranularityBytes = 4;
-
 struct GSanSourceLocation {
   Value file;
   Value line;
@@ -136,7 +134,7 @@ LLVM::LLVMStructType
 getGSanAtomicEventStateType(ConversionPatternRewriter &rewriter) {
   auto *ctx = rewriter.getContext();
   return LLVM::LLVMStructType::getLiteral(
-      ctx, {ptr_ty(ctx), array_ty(ptr_ty(ctx), 3), i8_ty});
+      ctx, {ptr_ty(ctx), array_ty(ptr_ty(ctx), 5), i8_ty});
 }
 
 FileLineColLoc extractSourceLocation(Location loc) {
@@ -290,33 +288,20 @@ void emitGSanAtomicEndCall(ConversionPatternRewriter &rewriter, Location loc,
 
 template <typename OpT>
 unsigned getTensorAccessVecSize(OpT op,
-                                ModuleAxisInfoAnalysis &axisInfoAnalysis,
-                                bool keepWithinSingleShadowCell) {
-  auto ptrTy = op.getPtr().getType();
-  auto bytesPerElem = std::max(8u, tt::getPointeeBitWidth(ptrTy)) / 8;
+                                ModuleAxisInfoAnalysis &axisInfoAnalysis) {
   auto contiguity = axisInfoAnalysis.getContiguity(op.getPtr());
-
-  if (keepWithinSingleShadowCell) {
-    if (bytesPerElem >= kGSanShadowGranularityBytes)
-      return 1;
-    contiguity =
-        std::min(contiguity, kGSanShadowGranularityBytes / bytesPerElem);
-  }
 
   if (!op.getMask())
     return contiguity;
 
+  // Preserve subword masks; shadow precision is selected by the allocator.
   auto maskAlign = axisInfoAnalysis.getMaskAlignment(op.getMask());
-  if (bytesPerElem < kGSanShadowGranularityBytes) {
-    maskAlign = std::max(maskAlign, kGSanShadowGranularityBytes / bytesPerElem);
-  }
   return std::min(contiguity, maskAlign);
 }
 
-void mergeTensorAccessElements(ConversionPatternRewriter &rewriter,
-                               Location loc, SmallVector<Value> &ptrElems,
+void mergeTensorAccessElements(SmallVector<Value> &ptrElems,
                                SmallVector<Value> &maskElems, unsigned mergeVec,
-                               unsigned maskAlign, int32_t &bytesPerElem) {
+                               int32_t &bytesPerElem) {
   if (mergeVec <= 1)
     return;
 
@@ -328,14 +313,9 @@ void mergeTensorAccessElements(ConversionPatternRewriter &rewriter,
 
   for (unsigned i = 0; i < ptrElems.size(); i += mergeVec) {
     mergedPtrElems.push_back(ptrElems[i]);
-    if (maskElems.empty())
-      continue;
-    Value mergedMask = maskElems[i];
-    for (unsigned j = maskAlign; j < mergeVec; j += maskAlign) {
-      mergedMask =
-          arith::OrIOp::create(rewriter, loc, mergedMask, maskElems[i + j]);
-    }
-    mergedMaskElems.push_back(mergedMask);
+    // getTensorAccessVecSize only merges groups with identical masks.
+    if (!maskElems.empty())
+      mergedMaskElems.push_back(maskElems[i]);
   }
 
   ptrElems = std::move(mergedPtrElems);
@@ -419,8 +399,7 @@ public:
         axisInfoAnalysis(&axisInfoAnalysis) {}
 
   unsigned getVecSize(tti::ExperimentalGSanTensorAccessOp op) const {
-    return getTensorAccessVecSize(op, *axisInfoAnalysis,
-                                  /*keepWithinSingleShadowCell=*/false);
+    return getTensorAccessVecSize(op, *axisInfoAnalysis);
   }
 
   LogicalResult
@@ -438,10 +417,7 @@ public:
     }
 
     unsigned mergeVec = getVecSize(op);
-    auto maskAlign =
-        op.getMask() ? axisInfoAnalysis->getMaskAlignment(op.getMask()) : 1;
-    mergeTensorAccessElements(rewriter, loc, ptrElems, maskElems, mergeVec,
-                              maskAlign, bytesPerElem);
+    mergeTensorAccessElements(ptrElems, maskElems, mergeVec, bytesPerElem);
 
     auto ctx = op.getContext();
     auto kReg = str_attr("register");

--- a/python/test/gsan/test_allocator.py
+++ b/python/test/gsan/test_allocator.py
@@ -18,13 +18,16 @@ from triton.experimental.gsan._allocator import (
     get_global_state_pointer,
     get_reserve_pointer,
     get_reserve_size,
+    get_runtime_state_layout,
+    get_shadow_granularity_bytes,
     gsan_free,
     gsan_malloc,
     import_allocation_handles,
     import_runtime_state_handle,
 )
-from triton.experimental.gsan._testing_utils import (global_state, shadow_cell_from_address, shadow_tensor_for,
-                                                     store_one_i32, thread_state_from_smid)
+from triton.experimental.gsan._testing_utils import (SHADOW_CELL_SIZE_BYTES, global_state, shadow_cell_from_address,
+                                                     shadow_cell_tensor_from_address, shadow_tensor_for, store_one_i32,
+                                                     thread_state_from_smid)
 from triton.experimental.gsan._utils import uint8_cuda_tensor_from_ptr
 
 # With 2 MiB pages, this rounds to a 6 MiB allocation inside an 8 MiB tree node.
@@ -49,6 +52,71 @@ def _run_configure_runtime_fields_check() -> None:
         assert state.clock_buffer_size == 17
     finally:
         gsan_free(ptr, device, 0, 0)
+
+
+def _run_shadow_precision_configuration_check() -> None:
+    assert get_shadow_granularity_bytes() == 4
+    for invalid in (0, 1, 3, 8, -2, True):
+        with pytest.raises(ValueError, match="shadow_granularity_bytes"):
+            configure(shadow_granularity_bytes=invalid)
+    with pytest.raises(TypeError):
+        configure(shadow_granularity_bytes=2.0)
+    for precision in (2, 4, 2):
+        configure(shadow_granularity_bytes=precision)
+        configure(rng_seed=12345)
+        assert get_shadow_granularity_bytes() == precision
+
+
+def _run_shadow_precision_reservation_check(query: str) -> None:
+    configure(shadow_granularity_bytes=2)
+    reserve = get_reserve_pointer if query == "reserve" else get_global_state_pointer
+    assert reserve() != 0
+    for precision in (2, 4):
+        with pytest.raises(RuntimeError, match="memory is reserved"):
+            configure(shadow_granularity_bytes=precision)
+    # Other settings retain their existing pre-allocation behavior.
+    configure(rng_seed=12345)
+    assert get_shadow_granularity_bytes() == 2
+
+
+def _run_shadow_precision_mapping_check(precision: int | None) -> None:
+    configure(shadow_granularity_bytes=precision)
+    expected = 4 if precision is None else precision
+    device = torch.cuda.current_device()
+    ptr = gsan_malloc(_ODD_LARGE_ALLOCATION_SIZE, device)
+    assert ptr != 0
+    try:
+        real = uint8_cuda_tensor_from_ptr(ptr, _ODD_LARGE_ALLOCATION_SIZE, device)
+        shadow = shadow_tensor_for(real)
+        assert shadow.numel() == triton.cdiv(_ODD_LARGE_ALLOCATION_SIZE, expected) * SHADOW_CELL_SIZE_BYTES
+        neighbor = shadow_cell_tensor_from_address(ptr + 2, device_index=device)
+        assert neighbor.data_ptr() - shadow.data_ptr() == (2 // expected) * SHADOW_CELL_SIZE_BYTES
+        assert global_state(device_index=device).shadow_granularity_bytes == expected
+        assert get_runtime_state_layout(get_device_rank(device))["shadow_granularity_bytes"] == expected
+        # Exercise the whole mapped range, including beyond the default 4-byte shadow size.
+        shadow.fill_(17)
+        assert torch.all(shadow == 17).item()
+        del neighbor, shadow, real
+    finally:
+        gsan_free(ptr, device)
+
+
+def _run_shadow_precision_ipc_check(handle_type: ShareableHandleType) -> None:
+    configure(shadow_granularity_bytes=2)
+    handle = 0 if handle_type == ShareableHandleType.POSIX_FILE_DESCRIPTOR else bytes(64)
+    calls = (
+        (export_allocation_handles, (1, handle_type)),
+        (export_allocation_memhandle_regions, (1, )),
+        (export_runtime_state_handle, (0, handle_type)),
+        (import_allocation_handles, (handle, handle, 4096, 0, handle_type)),
+        (import_runtime_state_handle, (handle, 4096, 0, 0, handle_type)),
+    )
+    for function, args in calls:
+        with pytest.raises(RuntimeError, match="IPC requires shadow_granularity_bytes=4"):
+            function(*args)
+    assert not has_live_allocations()
+    # Rejected IPC must not reserve addresses or freeze the configuration.
+    configure(shadow_granularity_bytes=4)
 
 
 def _run_freeze_config_check() -> None:
@@ -146,9 +214,9 @@ def _run_reset_collects_unreachable_allocations_check() -> None:
     reset()
 
 
-def _run_reset_reinitializes_runtime_state_check() -> None:
+def _run_reset_reinitializes_runtime_state_check(precision: int | None) -> None:
     device = torch.cuda.current_device()
-    configure(rng_seed=12345, clock_buffer_size=17)
+    configure(rng_seed=12345, clock_buffer_size=17, shadow_granularity_bytes=precision)
     original_state_pointer = get_global_state_pointer()
 
     ptr = gsan_malloc(4, device)
@@ -176,6 +244,7 @@ def _run_reset_reinitializes_runtime_state_check() -> None:
     state = global_state(device_index=device)
     assert state.rng_seed == 12345
     assert state.clock_buffer_size == 17
+    assert state.shadow_granularity_bytes == (4 if precision is None else precision)
     with pytest.raises(RuntimeError, match="configuration is already frozen"):
         configure(rng_seed=12345)
 
@@ -354,6 +423,33 @@ def test_configure_exposes_runtime_fields():
 
 
 @pytest.mark.skipif(not is_cuda(), reason="requires CUDA backend")
+def test_shadow_precision_configuration():
+    result = run_in_process(_run_shadow_precision_configuration_check)
+    assert result.exc is None
+
+
+@pytest.mark.skipif(not is_cuda(), reason="requires CUDA backend")
+@pytest.mark.parametrize("query", ["reserve", "global_state"])
+def test_shadow_precision_freezes_at_reservation(query):
+    result = run_in_process(_run_shadow_precision_reservation_check, args=(query, ))
+    assert result.exc is None
+
+
+@pytest.mark.skipif(not is_cuda(), reason="requires CUDA backend")
+@pytest.mark.parametrize("precision", [None, 2], ids=["default", "halfword"])
+def test_shadow_precision_maps_full_shadow(precision):
+    result = run_in_process(_run_shadow_precision_mapping_check, args=(precision, ))
+    assert result.exc is None
+
+
+@pytest.mark.skipif(not is_cuda(), reason="requires CUDA backend")
+@pytest.mark.parametrize("handle_type", list(ShareableHandleType))
+def test_halfword_precision_rejects_ipc(handle_type):
+    result = run_in_process(_run_shadow_precision_ipc_check, args=(handle_type, ))
+    assert result.exc is None
+
+
+@pytest.mark.skipif(not is_cuda(), reason="requires CUDA backend")
 def test_freeze_config_rejects_later_changes():
     result = run_in_process(_run_freeze_config_check)
     assert result.exc is None
@@ -384,8 +480,9 @@ def test_reset_collects_unreachable_allocations():
 
 
 @pytest.mark.skipif(not is_cuda(), reason="requires CUDA backend")
-def test_reset_reinitializes_runtime_state():
-    result = run_in_process(_run_reset_reinitializes_runtime_state_check)
+@pytest.mark.parametrize("precision", [None, 2], ids=["default", "halfword"])
+def test_reset_reinitializes_runtime_state(precision):
+    result = run_in_process(_run_reset_reinitializes_runtime_state_check, args=(precision, ))
     assert result.exc is None
 
 

--- a/python/test/gsan/test_gsan.py
+++ b/python/test/gsan/test_gsan.py
@@ -10,8 +10,8 @@ from triton.experimental.gluon.language.nvidia.ampere import async_copy
 from triton.experimental.gluon.language.nvidia import hopper
 from triton.tools.tensor_descriptor import TensorDescriptor
 
-from triton._internal_testing import is_blackwell, is_cuda, is_ampere_or_newer, is_hopper_or_newer, is_sm12x
-from triton.experimental.gsan import create_mem_pool
+from triton._internal_testing import default_alloc_fn, is_blackwell, is_cuda, is_ampere_or_newer, is_hopper_or_newer, is_sm12x, run_in_process
+from triton.experimental.gsan import configure, create_mem_pool
 from triton._C.libtriton.gsan_testing import AtomicScope, SHADOW_GRANULARITY_BYTES, ScalarClock
 from triton.experimental.gsan._testing_utils import (atomic_poll, load_one_i32, shadow_cell_from_address, store_one_i32,
                                                      thread_state_from_smid)
@@ -102,6 +102,89 @@ def _assert_cross_sm_sync(payload_ptr: torch.Tensor, flag_ptr: torch.Tensor, exp
 def _assert_no_gsan_runtime_output(capfd) -> None:
     captured = capfd.readouterr()
     assert "GSanLibrary.cu" not in captured.out + captured.err
+
+
+@triton.jit
+def _subword_rows_kernel(output, COLS: tl.constexpr):
+    row = tl.program_id(0)
+    columns = tl.arange(0, 4)
+    tl.store(output + row * COLS + columns, row + columns, columns < COLS)
+
+
+def _run_subword_rows(granularity, cols):
+    configure(shadow_granularity_bytes=granularity)
+    triton.knobs.compilation.instrumentation_mode = "gsan"
+    pool = create_mem_pool()
+    with torch.cuda.use_mem_pool(pool):
+        output = torch.empty((64, cols), dtype=torch.bfloat16, device="cuda")
+        _subword_rows_kernel[(64, )](output, cols)
+        torch.cuda.synchronize()
+        expected = torch.arange(64, device="cuda")[:, None] + torch.arange(cols, device="cuda")
+        torch.testing.assert_close(output, expected.to(torch.bfloat16), rtol=0, atol=0)
+
+
+@pytest.mark.skipif(not is_cuda(), reason="GSan requires CUDA")
+@pytest.mark.parametrize("granularity, cols", [(2, 3), (2, 4), (4, 4)])
+def test_subword_rows(granularity, cols):
+    result = run_in_process(_run_subword_rows, (granularity, cols))
+    assert result.exc is None, result
+
+
+@gluon.jit
+def _subword_mask_kernel(source, output):
+    offsets = gl.arange(0, 128, layout=gl.BlockedLayout([4], [32], [1], [0]))
+    mask = offsets % 2 == 0
+    values = gl.load(source + offsets, mask, other=0)
+    gl.store(output + offsets, values, mask)
+
+
+def _run_subword_masks():
+    configure(shadow_granularity_bytes=2)
+    triton.knobs.compilation.instrumentation_mode = "gsan"
+    pool = create_mem_pool()
+    with torch.cuda.use_mem_pool(pool):
+        source = torch.ones(128, dtype=torch.bfloat16, device="cuda")
+        output = torch.zeros_like(source)
+        _subword_mask_kernel[(1, )](source, output, num_warps=1)
+        torch.cuda.synchronize()
+        assert torch.all(output[::2] == 1)
+        assert torch.all(output[1::2] == 0)
+        for index in range(4):
+            read_cell = shadow_cell_from_address(source.data_ptr() + index * 2)
+            write_cell = shadow_cell_from_address(output.data_ptr() + index * 2)
+            assert (read_cell.num_reads > 0) == (index % 2 == 0)
+            assert (write_cell.write_clock.epoch > 0) == (index % 2 == 0)
+
+
+@pytest.mark.skipif(not is_cuda(), reason="GSan requires CUDA")
+def test_subword_masks_preserve_untouched_halfwords():
+    result = run_in_process(_run_subword_masks)
+    assert result.exc is None, result
+
+
+def _run_subword_atomic_cells():
+    configure(shadow_granularity_bytes=2)
+    triton.knobs.compilation.instrumentation_mode = "gsan"
+    pool = create_mem_pool()
+    with torch.cuda.use_mem_pool(pool):
+        target = torch.zeros(2, dtype=torch.int64, device="cuda")
+        atomic_add_kernel[(1, )](target, sem="acq_rel", scope="gpu", num_warps=1)
+        assert target[0].item() == 1
+        for offset in range(0, 8, 2):
+            _assert_atomic_rmw_shadow(target.data_ptr() + offset, AtomicScope.GPU, is_release=True)
+        assert shadow_cell_from_address(target.data_ptr() + 8).write_clock.epoch == 0
+
+        atomic_poll_kernel[(1, )](target, 1, sem="acquire", scope="gpu", num_warps=1)
+        torch.cuda.synchronize()
+        for offset in range(0, 8, 2):
+            assert shadow_cell_from_address(target.data_ptr() + offset).num_reads == 2
+        assert shadow_cell_from_address(target.data_ptr() + 8).num_reads == 0
+
+
+@pytest.mark.skipif(not is_cuda(), reason="GSan requires CUDA")
+def test_subword_eight_byte_atomics_cover_all_cells():
+    result = run_in_process(_run_subword_atomic_cells)
+    assert result.exc is None, result
 
 
 @pytest.mark.skipif(not is_cuda(), reason="GSan requires CUDA")
@@ -1170,7 +1253,7 @@ def _gluon_async_copy_masked_kernel(out_ptr, in_ptr, n_elements, start_idx, BLOC
 @triton.jit
 def _device_tma_masked_store_kernel(ptr, m_size, n_size, row_idx, col_idx, stride_0, BLOCK: tl.constexpr):
     desc = tl.make_tensor_descriptor(ptr, [m_size, n_size], [stride_0, 1], [BLOCK, BLOCK])
-    values = tl.full((BLOCK, BLOCK), 1, dtype=tl.int32)
+    values = tl.full((BLOCK, BLOCK), 1, dtype=ptr.dtype.element_ty)
     desc.store([row_idx, col_idx], values)
 
 
@@ -1209,6 +1292,79 @@ def _host_tma_reduce_add_kernel(desc, src_ptr, src_stride_0, src_stride_1, BLOCK
     indices_y = tl.arange(0, BLOCK_Y)[None, :] * src_stride_1
     src = tl.load(src_ptr + indices_x + indices_y)
     desc.atomic_add([0, 0], src)
+
+
+def _run_subword_tma_masks(indexed, cols):
+    configure(shadow_granularity_bytes=2)
+    triton.knobs.compilation.instrumentation_mode = "gsan"
+    triton.set_allocator(default_alloc_fn)
+    pool = create_mem_pool()
+    with torch.cuda.use_mem_pool(pool):
+        storage = torch.zeros((16, 16), dtype=torch.bfloat16, device="cuda")
+        output = torch.empty_like(storage)
+        if indexed:
+            desc = TensorDescriptor.from_tensor(storage[:8, :cols], [1, 16])
+            rows = torch.arange(8, dtype=torch.int32, device="cuda")
+            source = torch.ones((8, 16), dtype=torch.bfloat16, device="cuda")
+            _host_tma_scatter_kernel[(1, )](desc, rows, 0, source, 16, 1, BLOCK_X=8)
+            _host_tma_gather_kernel[(1, )](output, 16, 1, desc, rows, 0, BLOCK_X=8)
+        else:
+            _device_tma_masked_store_kernel[(1, )](storage, 8, cols, 0, 0, 16, BLOCK=16)
+            _device_tma_masked_load_kernel[(1, )](output, storage, 8, cols, 0, 0, 16, BLOCK=16)
+        torch.cuda.synchronize()
+        # Stores write whole 16-byte sectors; loads only read logical elements.
+        written_cols = triton.cdiv(cols * storage.element_size(), 16) * 16 // storage.element_size()
+        assert torch.all(storage[:8, :written_cols] == 1)
+        assert torch.all(storage[:8, written_cols:] == 0)
+        assert torch.all(storage[8:] == 0)
+        assert torch.all(output[:8, :cols] == 1)
+        assert torch.all(output[:8, cols:] == 0)
+        for col in (cols - 1, cols, 15):
+            cell = shadow_cell_from_address(storage[0, col].data_ptr())
+            assert (cell.write_clock.epoch > 0) == (col < written_cols)
+            assert (cell.num_reads > 0) == (col < cols)
+        untouched_row = shadow_cell_from_address(storage[8, 0].data_ptr())
+        assert untouched_row.write_clock.epoch == untouched_row.num_reads == 0
+
+
+@pytest.mark.skipif(not is_hopper_or_newer(), reason="TMA requires Hopper or newer")
+@pytest.mark.parametrize(
+    "indexed",
+    [False,
+     pytest.param(True, marks=pytest.mark.skipif(not is_blackwell(), reason="Indexed TMA requires Blackwell"))])
+@pytest.mark.parametrize("cols", [8, 9])
+def test_subword_tma_tracks_store_and_load_bounds(indexed, cols):
+    result = run_in_process(_run_subword_tma_masks, (indexed, cols))
+    assert result.exc is None, result
+
+
+def _run_subword_tma_atomic_cells(dtype, cols):
+    configure(shadow_granularity_bytes=2)
+    triton.knobs.compilation.instrumentation_mode = "gsan"
+    pool = create_mem_pool()
+    with torch.cuda.use_mem_pool(pool):
+        target = torch.zeros((1, 16), dtype=dtype, device="cuda")
+        source = torch.ones_like(target)
+        desc = TensorDescriptor.from_tensor(target[:, :cols], [1, 16])
+        _host_tma_reduce_add_kernel[(1, )](desc, source, 16, 1, BLOCK_X=1)
+        torch.cuda.synchronize()
+        written_bytes = triton.cdiv(cols * target.element_size(), 16) * 16
+        written_cols = written_bytes // target.element_size()
+        assert torch.all(target[:, :written_cols] == 1)
+        assert torch.all(target[:, written_cols:] == 0)
+        for offset in range(0, written_bytes, 2):
+            _assert_atomic_rmw_shadow(target.data_ptr() + offset, AtomicScope.GPU, is_release=False)
+        if written_cols < target.numel():
+            untouched = shadow_cell_from_address(target.data_ptr() + written_bytes)
+            assert untouched.write_clock.epoch == untouched.num_reads == 0
+
+
+@pytest.mark.skipif(not is_hopper_or_newer(), reason="TMA requires Hopper or newer")
+@pytest.mark.parametrize("dtype", [torch.bfloat16, torch.uint64])
+@pytest.mark.parametrize("cols", [9, 16])
+def test_subword_tma_atomics_cover_all_cells(dtype, cols):
+    result = run_in_process(_run_subword_tma_atomic_cells, (dtype, cols))
+    assert result.exc is None, result
 
 
 def _shadow_cells_for_tensor(tensor: torch.Tensor):
@@ -1377,16 +1533,17 @@ def test_tma_masked_store_updates_shadow(with_gsan, with_allocator, row_idx, col
     valid_cols = max(last_col - first_col, 0)
     target_storage = torch.zeros((padded_m, padded_n), dtype=torch.int32, device="cuda")
     target = target_storage[:m_size, :n_size]
+    write_n_size = triton.cdiv(n_size * target.element_size(), 16) * 16 // target.element_size()
     shadow0 = _shadow_cells_for_tensor(target_storage)
-    changed_mask = _masked_tma_change_mask(target_storage, m_size, n_size, row_idx, col_idx, block)
+    changed_mask = _masked_tma_change_mask(target_storage, m_size, write_n_size, row_idx, col_idx, block)
 
     _device_tma_masked_store_kernel[(1, )](target, m_size, n_size, row_idx, col_idx, target.stride(0), BLOCK=block,
                                            num_ctas=num_ctas)
     torch.cuda.synchronize()
 
-    expected = torch.zeros_like(target)
-    expected[first_row:last_row, first_col:last_col] = 1
-    torch.testing.assert_close(target, expected)
+    expected = torch.zeros_like(target_storage)
+    expected[first_row:last_row, first_col:min(col_idx + block, write_n_size)] = 1
+    torch.testing.assert_close(target_storage, expected)
 
     shadow1 = _shadow_cells_for_tensor(target_storage)
     _assert_shadow_mask(shadow0, shadow1, changed_mask, access_kind="write")
@@ -1437,15 +1594,19 @@ def test_host_tma_scatter_updates_shadow(with_gsan):
     target = target_storage[:m_size, :n_size]
     target_desc = TensorDescriptor.from_tensor(target, [1, block_y])
     src = torch.arange(1, block_x * block_y + 1, dtype=torch.int32, device="cuda").reshape(block_x, block_y)
+    write_n_size = triton.cdiv(n_size * target.element_size(), 16) * 16 // target.element_size()
     shadow0 = _shadow_cells_for_tensor(target_storage)
-    changed_mask = _gather_scatter_change_mask(target_storage, x_offsets, y_offset, m_size, n_size, block_y)
+    changed_mask = _gather_scatter_change_mask(target_storage, x_offsets, y_offset, m_size, write_n_size, block_y)
 
     compiled = _host_tma_scatter_kernel[(1, )](target_desc, x_offsets, y_offset, src, src.stride(0), src.stride(1),
                                                BLOCK_X=block_x)
     assert "ttng.async_tma_scatter" in compiled.asm["ttgir"]
     torch.cuda.synchronize()
 
-    torch.testing.assert_close(target, _scatter_reference(target, src, x_offsets, y_offset))
+    expected = torch.zeros_like(target_storage)
+    expected[:m_size, :write_n_size] = _scatter_reference(target_storage[:m_size, :write_n_size], src, x_offsets,
+                                                          y_offset)
+    torch.testing.assert_close(target_storage, expected)
 
     shadow1 = _shadow_cells_for_tensor(target_storage)
     _assert_shadow_mask(shadow0, shadow1, changed_mask, access_kind="write")

--- a/python/test/gsan/test_gsan.py
+++ b/python/test/gsan/test_gsan.py
@@ -1533,7 +1533,10 @@ def test_tma_masked_store_updates_shadow(with_gsan, with_allocator, row_idx, col
     valid_cols = max(last_col - first_col, 0)
     target_storage = torch.zeros((padded_m, padded_n), dtype=torch.int32, device="cuda")
     target = target_storage[:m_size, :n_size]
-    write_n_size = triton.cdiv(n_size * target.element_size(), 16) * 16 // target.element_size()
+    # Hardware TMA writes full 16-byte sectors; the pre-Hopper fallback masks to the logical shape.
+    write_n_size = n_size
+    if is_hopper_or_newer():
+        write_n_size = triton.cdiv(n_size * target.element_size(), 16) * 16 // target.element_size()
     shadow0 = _shadow_cells_for_tensor(target_storage)
     changed_mask = _masked_tma_change_mask(target_storage, m_size, write_n_size, row_idx, col_idx, block)
 

--- a/python/test/gsan/test_gsan_failures.py
+++ b/python/test/gsan/test_gsan_failures.py
@@ -19,7 +19,7 @@ from triton.experimental.gluon.language.nvidia.blackwell import (
 )
 
 from triton._internal_testing import is_blackwell, is_cuda, is_hopper_or_newer, run_in_process
-from triton.experimental.gsan import create_mem_pool
+from triton.experimental.gsan import configure, create_mem_pool
 from triton.experimental.gsan._testing_utils import atomic_poll, shadow_cell_from_address
 from triton.tools.tensor_descriptor import TensorDescriptor
 
@@ -80,6 +80,38 @@ def _waw_kernel(ptr, scratch_ptr, counter_ptr):
     else:
         atomic_poll(counter_ptr, 1)
         tl.store(ptr, 2)
+
+
+@triton.jit
+def _subword_race_kernel(ptr, scratch_ptr, counter_ptr, KIND: tl.constexpr):
+    if tl.program_id(0) == 0:
+        if KIND == "war":
+            value = tl.load(ptr)
+            tl.store(scratch_ptr, value)
+        else:
+            tl.store(ptr, 1)
+        tl.atomic_xchg(counter_ptr, 1, sem="relaxed")
+    else:
+        atomic_poll(counter_ptr, 1)
+        # A disjoint halfword write must not replace the first halfword's history.
+        tl.store(ptr + 1, 7)
+        if KIND == "raw":
+            conflicting_read = tl.load(ptr)
+            tl.store(scratch_ptr, conflicting_read)
+        else:
+            tl.store(ptr, 2)  # conflicting write
+
+
+def _run_subword_race(kind):
+    configure(shadow_granularity_bytes=2)
+    triton.knobs.compilation.instrumentation_mode = "gsan"
+    pool = create_mem_pool()
+    with torch.cuda.use_mem_pool(pool):
+        target = torch.zeros(2, dtype=torch.bfloat16, device="cuda")
+        scratch = torch.zeros(1, dtype=torch.float32, device="cuda")
+        counter = torch.zeros(1, dtype=torch.int32, device="cuda")
+        _subword_race_kernel[(2, )](target, scratch, counter, kind, num_warps=1)
+        torch.cuda.synchronize()
 
 
 @triton.jit
@@ -185,6 +217,37 @@ def _tma_raw_kernel(ptr, scratch_ptr, counter_ptr, m_size, n_size, row_idx, col_
         atomic_poll(counter_ptr, 1)
         value = tl.load(ptr + row_idx * stride_0 + col_idx)
         tl.store(scratch_ptr, value)
+
+
+@triton.jit
+def _tma_padding_raw_kernel(ptr, desc, scratch_ptr, counter_ptr, KIND: tl.constexpr):
+    if tl.program_id(0) == 0:
+        values = tl.full((8, 16), 1, dtype=ptr.dtype.element_ty)
+        if KIND == "scatter":
+            desc.scatter(values, tl.arange(0, 8), 0)
+        elif KIND == "reduce":
+            desc.atomic_add([0, 0], values)
+        else:
+            desc.store([0, 0], values)
+        tl.atomic_xchg(counter_ptr, 1, sem="relaxed")
+    else:
+        atomic_poll(counter_ptr, 1)
+        padding_read = tl.load(ptr + 15)
+        tl.store(scratch_ptr, padding_read)
+
+
+def _run_tma_padding_race(kind, granularity):
+    configure(shadow_granularity_bytes=granularity)
+    triton.knobs.compilation.instrumentation_mode = "gsan"
+    pool = create_mem_pool()
+    with torch.cuda.use_mem_pool(pool):
+        target = torch.zeros((8, 16), dtype=torch.bfloat16, device="cuda")
+        scratch = torch.zeros(1, dtype=torch.bfloat16, device="cuda")
+        counter = torch.zeros(1, dtype=torch.int32, device="cuda")
+        block_shape = [1, 16] if kind == "scatter" else [8, 16]
+        desc = TensorDescriptor.from_tensor(target[:, :9], block_shape)
+        _tma_padding_raw_kernel[(2, )](target, desc, scratch, counter, kind)
+        torch.cuda.synchronize()
 
 
 @triton.jit
@@ -650,6 +713,28 @@ def test_write_after_read():
 def test_write_after_write():
     _run_failure_case("waw", runner=_run_waw_case, source_function=_waw_kernel.fn, marker="tl.store(ptr, 2)",
                       error="Write after write race detected")
+
+
+@pytest.mark.parametrize("kind, marker, error", [
+    ("raw", "conflicting_read =", "Read after write race detected"),
+    ("war", "# conflicting write", "Write after read race detected"),
+    ("waw", "# conflicting write", "Write after write race detected"),
+])
+def test_subword_access_preserves_neighbor_history(kind, marker, error):
+    _run_failure_case(kind, runner=_run_subword_race, runner_args=(kind, ), source_function=_subword_race_kernel.fn,
+                      marker=marker, error=error)
+
+
+@pytest.mark.skipif(not is_hopper_or_newer(), reason="TMA requires Hopper or newer")
+@pytest.mark.parametrize("kind", [
+    "store", "reduce",
+    pytest.param("scatter", marks=pytest.mark.skipif(not is_blackwell(), reason="Indexed TMA requires Blackwell"))
+])
+@pytest.mark.parametrize("granularity", [2, 4])
+def test_subword_tma_padding_reports_race(kind, granularity):
+    _run_failure_case(kind, runner=_run_tma_padding_race, runner_args=(kind, granularity),
+                      source_function=_tma_padding_raw_kernel.fn, marker="padding_read =",
+                      error="Read after write race detected")
 
 
 @pytest.mark.skipif(not is_hopper_or_newer(), reason="PDL requires SM90 or newer")

--- a/python/triton/experimental/gsan/README.md
+++ b/python/triton/experimental/gsan/README.md
@@ -86,6 +86,25 @@ These limitations can be mitigated by increasing the number of read samples, or 
 
 ## **3\. Shadow Memory Details**
 
+GSan tracks one access history per four-byte cell by default. Independent writes to
+adjacent FP16 or BF16 values can therefore report a race when they share a cell.
+For local workloads that need halfword precision, configure the process before
+creating a memory pool or reserving any GSan addresses:
+
+```python
+from triton.experimental import gsan
+
+gsan.configure(shadow_granularity_bytes=2)
+pool = gsan.create_mem_pool()
+```
+
+Each cell occupies 24 bytes. Two-byte precision increases shadow storage from
+six to twelve bytes per application byte, excluding allocation rounding and
+the shared vector-clock state. It does not distinguish independent single-byte
+accesses. The choice is fixed after the first address reservation; IPC currently
+requires the default four-byte precision. Kernel instrumentation supports both
+choices without changing the kernel's compilation options.
+
 So far we’ve assumed that we can quickly and easily map between a given pointer and its corresponding shadow memory. To do this, we can take advantage of the CUDA driver API which has a number of primitives to control virtual memory addressing. `cuMemAddressReserve` allows us to reserve a large chunk of virtual address space, and `cuMemMap` allows us to map newly allocated memory pages anywhere we want within the reserved address space.
 
 This gives us the tools we need to  implement a custom allocator that maps all tensor allocations into the higher address range with `cuMemMap`; and also creates a corresponding shadow allocation that gets mapped into the lower address range.

--- a/python/triton/experimental/gsan/_allocator.py
+++ b/python/triton/experimental/gsan/_allocator.py
@@ -55,6 +55,7 @@ def configure(
     rng_seed: int | None = None,
     clock_buffer_size: int | None = None,
     handle_type: ShareableHandleType | None = None,
+    shadow_granularity_bytes: int | None = None,
 ) -> None:
     """Configures the process-local GSan state.
 
@@ -82,8 +83,13 @@ def configure(
         handle_type (ShareableHandleType, optional): Type of shareable handle requested for GSan
             allocations. If omitted, GSan uses fabric handles when ``PYTORCH_CUDA_ALLOC_CONF``
             contains ``fabric_handles:True`` and otherwise uses POSIX file descriptors.
+        shadow_granularity_bytes (int, optional): Bytes tracked by each shadow cell, either
+            2 or 4 (default). Two-byte precision distinguishes adjacent halfwords and doubles
+            shadow memory use. Set this before any address reservation, including calls to
+            get_reserve_pointer or get_global_state_pointer. IPC requires four-byte precision.
     """
-    _load_gsan_module().configure(device_ranks, num_devices, rng_seed, clock_buffer_size, handle_type)
+    _load_gsan_module().configure(device_ranks, num_devices, rng_seed, clock_buffer_size, handle_type,
+                                  shadow_granularity_bytes)
 
 
 def freeze_config() -> None:
@@ -136,6 +142,11 @@ def get_reserve_pointer() -> int:
 
 def get_reserve_size() -> int:
     return _load_gsan_module().get_reserve_size()
+
+
+def get_shadow_granularity_bytes() -> int:
+    """Return configured precision without reserving or mapping memory."""
+    return _load_gsan_module().get_shadow_granularity_bytes()
 
 
 def get_global_state_pointer() -> int:

--- a/python/triton/experimental/gsan/_testing_utils.py
+++ b/python/triton/experimental/gsan/_testing_utils.py
@@ -4,8 +4,8 @@ import torch
 import triton
 import triton.language as tl
 
-from ._allocator import get_global_state_pointer
-from triton._C.libtriton.gsan_testing import thread_state_address, SHADOW_GRANULARITY_BYTES, PER_DEVICE_STATE_STRIDE_BYTES, GLOBAL_STATE_SIZE_BYTES, shadow_cell_address, thread_state_stride_bytes, SHADOW_CELL_SIZE_BYTES
+from ._allocator import get_global_state_pointer, get_shadow_granularity_bytes
+from triton._C.libtriton.gsan_testing import thread_state_address, SHADOW_GRANULARITY_BYTES as SHADOW_GRANULARITY_BYTES, PER_DEVICE_STATE_STRIDE_BYTES, GLOBAL_STATE_SIZE_BYTES, shadow_cell_address, thread_state_stride_bytes, SHADOW_CELL_SIZE_BYTES
 from ._testing import (decode_global_state_tensor, decode_shadow_cell_tensor, decode_thread_state_tensor)
 from ._utils import uint8_cuda_tensor_from_ptr
 
@@ -25,7 +25,7 @@ def atomic_poll(ptr, expect, sem: tl.constexpr = "relaxed", scope: tl.constexpr 
 def shadow_cell_tensor_from_address(real_address: int, *, device_index: int | None = None) -> torch.Tensor:
     if device_index is None:
         device_index = torch.cuda.current_device()
-    shadow_ptr = shadow_cell_address(real_address)
+    shadow_ptr = shadow_cell_address(real_address, get_shadow_granularity_bytes())
     return uint8_cuda_tensor_from_ptr(shadow_ptr, SHADOW_CELL_SIZE_BYTES, device_index)
 
 
@@ -70,9 +70,10 @@ def thread_state_from_smid(smid: int, *, device_index: int | None = None):
 
 
 def shadow_tensor_for(real: torch.Tensor) -> torch.Tensor:
-    shadow_ptr = shadow_cell_address(real.data_ptr())
+    granularity = get_shadow_granularity_bytes()
+    shadow_ptr = shadow_cell_address(real.data_ptr(), granularity)
     nbytes = real.untyped_storage().nbytes()
-    num_cells = triton.cdiv(nbytes, SHADOW_GRANULARITY_BYTES)
+    num_cells = triton.cdiv(nbytes, granularity)
     shadow_size = num_cells * SHADOW_CELL_SIZE_BYTES
     return uint8_cuda_tensor_from_ptr(shadow_ptr, shadow_size, real.device.index)
 

--- a/python/triton/experimental/gsan/src/GSan.h
+++ b/python/triton/experimental/gsan/src/GSan.h
@@ -24,6 +24,7 @@ using uintptr_t = __UINTPTR_TYPE__;
 // Reserve 1 PiB, should be big enough for a while :)
 static constexpr size_t kReserveSize = 1ull << 40;
 static constexpr int kShadowMemGranularityBytes = 4;
+static constexpr int kMinShadowMemGranularityBytes = 2;
 static_assert((kReserveSize & (kReserveSize - 1)) == 0,
               "kReserveSize must be a power of 2");
 
@@ -75,6 +76,7 @@ struct GlobalState {
   thread_id_t numThreads;
 
   uint16_t clockBufferSize;
+  uint32_t shadowGranularityBytes;
 };
 
 struct ThreadState {
@@ -101,7 +103,9 @@ struct ThreadState {
   epoch_t vectorClock[];
 };
 
-static constexpr int kMaxAtomicShadowCells = 3;
+// An eight-byte atomic can intersect five two-byte shadow cells.
+static constexpr int kMaxAtomicShadowCells =
+    8 / kMinShadowMemGranularityBytes + 1;
 
 struct AtomicEventState {
   ThreadState *threadState;
@@ -181,11 +185,14 @@ inline GSAN_HOST_DEVICE uintptr_t getReserveBaseFromAddress(uintptr_t addr) {
 }
 
 // Assumes address is in gsan-managed memory
-inline GSAN_HOST_DEVICE uintptr_t getShadowAddress(uintptr_t virtualAddress) {
+inline GSAN_HOST_DEVICE uintptr_t getShadowAddress(
+    uintptr_t virtualAddress, int granularity = kShadowMemGranularityBytes) {
   auto reserveBase = getReserveBaseFromAddress(virtualAddress);
   auto realBase = getRealBaseAddress(reserveBase);
   auto byteOffset = virtualAddress - realBase;
-  auto wordOffset = byteOffset / kShadowMemGranularityBytes;
+  // Configuration accepts only two- or four-byte cells. Avoid a device-side
+  // integer division when the precision comes from runtime state.
+  auto wordOffset = byteOffset >> (granularity == 2 ? 1 : 2);
   return reserveBase + sizeof(ShadowCell) * wordOffset;
 }
 

--- a/python/triton/experimental/gsan/src/GSanAllocator.cc
+++ b/python/triton/experimental/gsan/src/GSanAllocator.cc
@@ -93,6 +93,7 @@ struct GSanConfig {
   int numThreads = 0;
   int clockBufferSize = 0;
   uint32_t rngSeed = 0;
+  int shadowGranularityBytes = gsan::kShadowMemGranularityBytes;
   CUmemAllocationHandleType shareableHandleType =
       CU_MEM_HANDLE_TYPE_POSIX_FILE_DESCRIPTOR;
   bool clockBufferSizeConfigured = false;
@@ -124,6 +125,16 @@ void printCUDAError(CUresult err) {
 static AllocatorState *alloc = nullptr;
 static GSanConfig config;
 static std::mutex mut;
+
+// IPC handles do not encode their shadow precision. Keep the existing format
+// restricted to its original mapping until peers can negotiate precision.
+bool requireDefaultShadowGranularityForIPC() {
+  if (config.shadowGranularityBytes == gsan::kShadowMemGranularityBytes)
+    return true;
+  PyErr_SetString(PyExc_RuntimeError,
+                  "GSan IPC requires shadow_granularity_bytes=4");
+  return false;
+}
 
 bool hasLiveAllocations() {
   return alloc != nullptr &&
@@ -193,7 +204,7 @@ size_t roundDownToPowerOfTwo(size_t x) {
 }
 
 size_t getShadowSize(size_t realMemSize) {
-  auto wordSize = cdiv(realMemSize, gsan::kShadowMemGranularityBytes);
+  auto wordSize = cdiv(realMemSize, config.shadowGranularityBytes);
   return wordSize * sizeof(gsan::ShadowCell);
 }
 
@@ -363,8 +374,8 @@ int gsanEnsureInit() {
   // Choose size so that both shadow memory and real memory definitely fit in
   // the address reservation
   auto shadowSize = gsan::kReserveSize / 2;
-  auto realSize = gsan::kShadowMemGranularityBytes *
-                  (shadowSize / sizeof(gsan::ShadowCell));
+  auto realSize =
+      config.shadowGranularityBytes * (shadowSize / sizeof(gsan::ShadowCell));
   realSize = std::min(gsan::kReserveSize / 2, realSize);
   realSize = roundDownToPowerOfTwo(realSize);
   root->size = realSize;
@@ -478,6 +489,7 @@ CUresult initializeRuntimeState(CUdeviceptr deviceAddr, size_t allocSize) {
   globals.numDevices = static_cast<gsan::thread_id_t>(config.numGPUs);
   globals.numThreads = static_cast<gsan::thread_id_t>(config.numThreads);
   globals.clockBufferSize = config.clockBufferSize;
+  globals.shadowGranularityBytes = config.shadowGranularityBytes;
   return cuMemcpyHtoD(deviceAddr, &globals, sizeof(globals));
 }
 
@@ -568,7 +580,8 @@ CUresult mapNodeHandles(AllocNode *node,
   assert(realMapped != nullptr);
   assert(shadowMapped != nullptr);
 
-  const auto shadowAddress = gsan::getShadowAddress(node->virtualAddress);
+  const auto shadowAddress = gsan::getShadowAddress(
+      node->virtualAddress, config.shadowGranularityBytes);
   const auto shadowSize = getShadowSize(allocSize);
 
   CUresult err = cuMemMap(node->virtualAddress, allocSize, /*offset*/ 0,
@@ -604,7 +617,8 @@ CUresult mapNodeHandles(AllocNode *node,
 
 void unmapNodeHandles(AllocNode *node, bool realMapped, bool shadowMapped) {
   assert(node != nullptr);
-  const auto shadowAddress = gsan::getShadowAddress(node->virtualAddress);
+  const auto shadowAddress = gsan::getShadowAddress(
+      node->virtualAddress, config.shadowGranularityBytes);
   const auto shadowSize = getShadowSize(node->allocSize);
   if (shadowMapped)
     cuMemUnmap(shadowAddress, shadowSize);
@@ -658,7 +672,8 @@ extern "C" void *gsanMalloc(ssize_t size, int device,
   bool realMapped = false;
   bool shadowMapped = false;
   auto cuStream = reinterpret_cast<CUstream>(stream);
-  auto shadowAddress = gsan::getShadowAddress(node->virtualAddress);
+  auto shadowAddress = gsan::getShadowAddress(node->virtualAddress,
+                                              config.shadowGranularityBytes);
   auto shadowSize = getShadowSize(allocSize);
   err = cuMemCreate(&realHandle, allocSize, &prop, 0);
   if (err != CUDA_SUCCESS)
@@ -718,7 +733,8 @@ extern "C" void gsanFree(void *void_ptr, [[maybe_unused]] ssize_t size,
   if (err != CUDA_SUCCESS)
     printCUDAError(err);
 
-  const auto shadowAddress = gsan::getShadowAddress(node->virtualAddress);
+  const auto shadowAddress = gsan::getShadowAddress(
+      node->virtualAddress, config.shadowGranularityBytes);
   const auto shadowSize = getShadowSize(node->allocSize);
 
   err = cuMemUnmap(node->virtualAddress, node->allocSize);
@@ -765,6 +781,8 @@ int gsanExportAllocationHandles(void *void_ptr,
     return -1;
 
   std::lock_guard lg(mut);
+  if (!requireDefaultShadowGranularityForIPC())
+    return -1;
   if (alloc == nullptr)
     return -1;
 
@@ -816,6 +834,8 @@ int gsanExportAllocationMemhandleRegions(void *void_ptr, uintptr_t *realPtr,
     return -1;
 
   std::lock_guard lg(mut);
+  if (!requireDefaultShadowGranularityForIPC())
+    return -1;
   if (alloc == nullptr)
     return -1;
 
@@ -831,8 +851,8 @@ int gsanExportAllocationMemhandleRegions(void *void_ptr, uintptr_t *realPtr,
 
   *realPtr = static_cast<uintptr_t>(node->virtualAddress);
   *realSize = node->allocSize;
-  *shadowPtr =
-      static_cast<uintptr_t>(gsan::getShadowAddress(node->virtualAddress));
+  *shadowPtr = static_cast<uintptr_t>(gsan::getShadowAddress(
+      node->virtualAddress, config.shadowGranularityBytes));
   *shadowSize = getShadowSize(node->allocSize);
   return 0;
 }
@@ -852,6 +872,8 @@ int gsanExportRuntimeStateHandle(int device,
     return -1;
 
   std::lock_guard lg(mut);
+  if (!requireDefaultShadowGranularityForIPC())
+    return -1;
   if (gsanEnsureInit() != 0)
     return -1;
   CUresult err = ensureContext(device);
@@ -897,6 +919,8 @@ gsanImportAllocationHandles(const GSanShareableHandle *realShareableHandle,
   }
 
   std::lock_guard lg(mut);
+  if (!requireDefaultShadowGranularityForIPC())
+    return nullptr;
   if (gsanEnsureInit() != 0)
     return nullptr;
   CUresult err = ensureContext(device);
@@ -963,6 +987,8 @@ int gsanImportRuntimeStateHandle(const GSanShareableHandle *shareableHandle,
     return -1;
 
   std::lock_guard lg(mut);
+  if (!requireDefaultShadowGranularityForIPC())
+    return -1;
   if (gsanEnsureInit() != 0)
     return -1;
   CUresult err = ensureContext(device);
@@ -1156,9 +1182,9 @@ PyObject *pyFree([[maybe_unused]] PyObject *self, PyObject *const *args,
 
 PyObject *pyConfigure([[maybe_unused]] PyObject *self, PyObject *const *args,
                       Py_ssize_t nargs) {
-  if (nargs != 5) {
+  if (nargs != 6) {
     PyErr_Format(PyExc_TypeError,
-                 "%s.configure expected 5 positional arguments, got %zd",
+                 "%s.configure expected 6 positional arguments, got %zd",
                  kModuleName, nargs);
     return nullptr;
   }
@@ -1259,11 +1285,31 @@ PyObject *pyConfigure([[maybe_unused]] PyObject *self, PyObject *const *args,
     return nullptr;
   }
 
+  const bool shadowGranularityRequested = args[5] != Py_None;
+  int requestedShadowGranularity = 0;
+  if (shadowGranularityRequested) {
+    if (!parseIntArg(args[5], "shadow_granularity_bytes",
+                     &requestedShadowGranularity))
+      return nullptr;
+    if (requestedShadowGranularity != gsan::kMinShadowMemGranularityBytes &&
+        requestedShadowGranularity != gsan::kShadowMemGranularityBytes) {
+      PyErr_SetString(PyExc_ValueError,
+                      "shadow_granularity_bytes must be 2 or 4");
+      return nullptr;
+    }
+  }
+
   std::lock_guard lg(mut);
   if (config.topologyFrozen) {
     PyErr_SetString(PyExc_RuntimeError,
                     "GSan allocator configuration is already frozen and "
                     "cannot be changed");
+    return nullptr;
+  }
+  if (shadowGranularityRequested && alloc != nullptr) {
+    PyErr_SetString(PyExc_RuntimeError,
+                    "GSan shadow precision cannot be changed after memory "
+                    "is reserved");
     return nullptr;
   }
 
@@ -1287,6 +1333,8 @@ PyObject *pyConfigure([[maybe_unused]] PyObject *self, PyObject *const *args,
     config.shareableHandleType = requestedShareableHandleType;
     config.shareableHandleTypeConfigured = true;
   }
+  if (shadowGranularityRequested)
+    config.shadowGranularityBytes = requestedShadowGranularity;
   Py_RETURN_NONE;
 }
 
@@ -1405,6 +1453,11 @@ PyObject *pyGetShadowSizeBytes(PyObject *self, PyObject *args) {
   return PyLong_FromLong(sizeof(gsan::ShadowCell));
 }
 
+PyObject *pyGetShadowGranularityBytes(PyObject *self, PyObject *args) {
+  std::lock_guard lg(mut);
+  return PyLong_FromLong(config.shadowGranularityBytes);
+}
+
 PyObject *pyGetGlobalStatePointer([[maybe_unused]] PyObject *self,
                                   PyObject *args) {
   std::lock_guard lg(mut);
@@ -1488,7 +1541,7 @@ PyObject *pyGetRuntimeStateLayout([[maybe_unused]] PyObject *self,
   threadStateStride = roundUp(threadStateStride, alignof(gsan::ThreadState));
 
   return Py_BuildValue(
-      "{s:K,s:K,s:K,s:K,s:i,s:i,s:i}", "global_state_ptr",
+      "{s:K,s:K,s:K,s:K,s:i,s:i,s:i,s:i}", "global_state_ptr",
       static_cast<unsigned long long>(globalStateAddress),
       "thread_state_base_ptr", static_cast<unsigned long long>(threadStateBase),
       "thread_state_stride_bytes",
@@ -1496,7 +1549,8 @@ PyObject *pyGetRuntimeStateLayout([[maybe_unused]] PyObject *self,
       "thread_state_header_size_bytes",
       static_cast<unsigned long long>(kThreadStateHeaderSize), "num_sms",
       config.numSMs, "num_threads", config.numThreads, "clock_buffer_size",
-      config.clockBufferSize);
+      config.clockBufferSize, "shadow_granularity_bytes",
+      config.shadowGranularityBytes);
 }
 
 PyObject *pyExportAllocationHandles(PyObject *self, PyObject *const *args,
@@ -1524,7 +1578,9 @@ PyObject *pyExportAllocationHandles(PyObject *self, PyObject *const *args,
                                        &shadowShareableHandle, &allocSize,
                                        handleType);
   if (rc != 0) {
-    PyErr_SetString(PyExc_RuntimeError, "gsanExportAllocationHandles failed.");
+    if (!PyErr_Occurred())
+      PyErr_SetString(PyExc_RuntimeError,
+                      "gsanExportAllocationHandles failed.");
     return nullptr;
   }
 
@@ -1557,8 +1613,9 @@ PyObject *pyExportAllocationMemhandleRegions(PyObject *self,
   int rc = gsanExportAllocationMemhandleRegions(ptr, &realPtr, &realSize,
                                                 &shadowPtr, &shadowSize);
   if (rc != 0) {
-    PyErr_SetString(PyExc_RuntimeError,
-                    "gsanExportAllocationMemhandleRegions failed.");
+    if (!PyErr_Occurred())
+      PyErr_SetString(PyExc_RuntimeError,
+                      "gsanExportAllocationMemhandleRegions failed.");
     return nullptr;
   }
 
@@ -1601,7 +1658,9 @@ PyObject *pyImportAllocationHandles(PyObject *self, PyObject *const *args,
       gsanImportAllocationHandles(&realShareableHandle, &shadowShareableHandle,
                                   handleType, allocSize, device);
   if (ptr == nullptr) {
-    PyErr_SetString(PyExc_RuntimeError, "gsanImportAllocationHandles failed.");
+    if (!PyErr_Occurred())
+      PyErr_SetString(PyExc_RuntimeError,
+                      "gsanImportAllocationHandles failed.");
     return nullptr;
   }
 
@@ -1631,7 +1690,9 @@ PyObject *pyExportRuntimeStateHandle(PyObject *self, PyObject *const *args,
   int rc = gsanExportRuntimeStateHandle(device, &shareableHandle, &allocSize,
                                         handleType);
   if (rc != 0) {
-    PyErr_SetString(PyExc_RuntimeError, "gsanExportRuntimeStateHandle failed.");
+    if (!PyErr_Occurred())
+      PyErr_SetString(PyExc_RuntimeError,
+                      "gsanExportRuntimeStateHandle failed.");
     return nullptr;
   }
 
@@ -1671,7 +1732,9 @@ PyObject *pyImportRuntimeStateHandle(PyObject *self, PyObject *const *args,
   int rc = gsanImportRuntimeStateHandle(&shareableHandle, handleType, allocSize,
                                         peerDevice, device);
   if (rc != 0) {
-    PyErr_SetString(PyExc_RuntimeError, "gsanImportRuntimeStateHandle failed.");
+    if (!PyErr_Occurred())
+      PyErr_SetString(PyExc_RuntimeError,
+                      "gsanImportRuntimeStateHandle failed.");
     return nullptr;
   }
 
@@ -1699,6 +1762,9 @@ PyMethodDef kGSanAllocatorMethods[] = {
     {"get_shadow_size_bytes",
      reinterpret_cast<PyCFunction>(pyGetShadowSizeBytes), METH_NOARGS,
      "Return the shadow cell size in bytes."},
+    {"get_shadow_granularity_bytes",
+     reinterpret_cast<PyCFunction>(pyGetShadowGranularityBytes), METH_NOARGS,
+     "Return configured bytes per shadow cell without initializing memory."},
     {"get_global_state_pointer",
      reinterpret_cast<PyCFunction>(pyGetGlobalStatePointer), METH_NOARGS,
      "Return the pointer to the GSan global state region."},

--- a/python/triton/experimental/gsan/src/GSanLibrary.cu
+++ b/python/triton/experimental/gsan/src/GSanLibrary.cu
@@ -357,12 +357,10 @@ struct Range {
   uintptr_t end;
 };
 
-GSAN_DEVICE Range roundRange(Range x) {
-  // Round start down to shadow granularity
-  x.start = x.start - (x.start % kShadowMemGranularityBytes);
-  // Round end up to shadow granularity
-  auto mod = x.end % kShadowMemGranularityBytes;
-  x.end = x.end + (mod == 0 ? 0 : kShadowMemGranularityBytes - mod);
+GSAN_DEVICE Range roundRange(Range x, int granularity) {
+  uintptr_t mask = granularity - 1;
+  x.start &= ~mask;
+  x.end = (x.end + mask) & ~mask;
   return x;
 }
 
@@ -819,15 +817,15 @@ GSAN_DEVICE void doWrite(ThreadState *state, ShadowCell *cell, Location loc) {
 
 GSAN_DEVICE void writeRange(ThreadState *state, uintptr_t write_addr,
                             int nBytes, Location loc) {
-  auto range = roundRange(Range{write_addr, write_addr + nBytes});
+  auto granularity = getGlobalState(state)->shadowGranularityBytes;
+  auto range = roundRange(Range{write_addr, write_addr + nBytes}, granularity);
 
   auto reserveBase = state->reserveBase;
 
-  for (uintptr_t addr = range.start; addr < range.end;
-       addr += kShadowMemGranularityBytes) {
+  for (uintptr_t addr = range.start; addr < range.end; addr += granularity) {
     if (!isGsanManaged(addr, reserveBase))
       continue;
-    auto shadowAddr = getShadowAddress(addr);
+    auto shadowAddr = getShadowAddress(addr, granularity);
     auto cell = acquireShadow(shadowAddr);
     doWrite(state, cell, loc);
     releaseShadow(cell);
@@ -863,17 +861,17 @@ GSAN_DEVICE void doRead(ThreadState *state, ShadowCell *cell, Location loc) {
 
 GSAN_DEVICE void readRange(ThreadState *state, uintptr_t read_addr, int nBytes,
                            Location loc) {
-  auto range = roundRange(Range{read_addr, read_addr + nBytes});
+  auto granularity = getGlobalState(state)->shadowGranularityBytes;
+  auto range = roundRange(Range{read_addr, read_addr + nBytes}, granularity);
 
   auto reserveBase = state->reserveBase;
   if (range.start >= reserveBase + kReserveSize || reserveBase >= range.end)
     return;
 
-  for (uintptr_t addr = range.start; addr < range.end;
-       addr += kShadowMemGranularityBytes) {
+  for (uintptr_t addr = range.start; addr < range.end; addr += granularity) {
     if (!isGsanManaged(addr, reserveBase))
       continue;
-    auto shadowAddr = getShadowAddress(addr);
+    auto shadowAddr = getShadowAddress(addr, granularity);
     auto cell = acquireShadow(shadowAddr);
     doRead(state, cell, loc);
     releaseShadow(cell);
@@ -933,7 +931,11 @@ template <typename ElementHandler>
 GSAN_DEVICE void tensorAccessRow(uintptr_t rowPtr, int rowBytes,
                                  int elementGranularity,
                                  ElementHandler &handleElement) {
-  auto range = roundRange(Range{rowPtr, rowPtr + rowBytes});
+  // TMA stores and reductions write whole 16-byte sectors at a partial row
+  // boundary. Loads clip to the logical tensor bounds instead.
+  int alignment =
+      ElementHandler::kIsWrite ? 16 : handleElement.shadowGranularityBytes;
+  auto range = roundRange(Range{rowPtr, rowPtr + rowBytes}, alignment);
   uintptr_t reserveBase = handleElement.reserveBase;
   uintptr_t reserveEnd = reserveBase + kReserveSize;
   range.start = range.start < reserveBase ? reserveBase : range.start;
@@ -1033,12 +1035,14 @@ GSAN_DEVICE void tensorAccessIndexedDesc(const void *descriptor,
 
     uintptr_t rowPtr =
         desc.base + static_cast<uintptr_t>(index) * rowStride + colOffset;
-    tensorAccessRow(rowPtr, rowBytes, kShadowMemGranularityBytes,
+    tensorAccessRow(rowPtr, rowBytes, handleElement.shadowGranularityBytes,
                     handleElement);
   }
 }
 
 struct ReadShadowCellHandler {
+  static constexpr bool kIsWrite = false;
+
   GSAN_DEVICE void operator()(ThreadState *state, ShadowCell *cell,
                               Location loc) const {
     doRead(state, cell, loc);
@@ -1046,6 +1050,8 @@ struct ReadShadowCellHandler {
 };
 
 struct WriteShadowCellHandler {
+  static constexpr bool kIsWrite = true;
+
   GSAN_DEVICE void operator()(ThreadState *state, ShadowCell *cell,
                               Location loc) const {
     doWrite(state, cell, loc);
@@ -1053,8 +1059,11 @@ struct WriteShadowCellHandler {
 };
 
 template <typename ShadowCellHandler> struct NonAtomicElementHandler {
+  static constexpr bool kIsWrite = ShadowCellHandler::kIsWrite;
+
   ThreadState *state;
   uintptr_t reserveBase;
+  int shadowGranularityBytes;
   Location loc;
   ShadowCellHandler handleShadowCell;
   bool acquired = false;
@@ -1064,7 +1073,8 @@ template <typename ShadowCellHandler> struct NonAtomicElementHandler {
       rwLockAcquireRead(state->lock);
       acquired = true;
     }
-    auto cell = acquireShadow(getShadowAddress(address));
+    auto cell =
+        acquireShadow(getShadowAddress(address, shadowGranularityBytes));
     handleShadowCell(state, cell, loc);
     releaseShadow(cell);
   }
@@ -1077,9 +1087,12 @@ tensorNonAtomicDesc(ThreadState *state, const void *descriptor,
                     int bytesPerElem, int warpId, int numWarps, Location loc,
                     ShadowCellHandler handleShadowCell) {
   NonAtomicElementHandler<ShadowCellHandler> handleElement{
-      state, state->reserveBase, loc, handleShadowCell};
+      state, state->reserveBase,
+      static_cast<int>(getGlobalState(state)->shadowGranularityBytes), loc,
+      handleShadowCell};
   tensorAccessDesc(descriptor, coords, rank, blockShape, bytesPerElem,
-                   kShadowMemGranularityBytes, warpId, numWarps, handleElement);
+                   handleElement.shadowGranularityBytes, warpId, numWarps,
+                   handleElement);
   if (handleElement.acquired)
     rwLockReleaseRead(state->lock);
 }
@@ -1091,7 +1104,9 @@ tensorNonAtomicIndexedDesc(ThreadState *state, const void *descriptor,
                            int numCols, int bytesPerElem, int pred,
                            Location loc, ShadowCellHandler handleShadowCell) {
   NonAtomicElementHandler<ShadowCellHandler> handleElement{
-      state, state->reserveBase, loc, handleShadowCell};
+      state, state->reserveBase,
+      static_cast<int>(getGlobalState(state)->shadowGranularityBytes), loc,
+      handleShadowCell};
   tensorAccessIndexedDesc(descriptor, indices, numIndices, yOffset, numCols,
                           bytesPerElem, pred, handleElement);
   if (handleElement.acquired)
@@ -1109,11 +1124,11 @@ GSAN_DEVICE void acquireAtomicShadowRange(ThreadState *state,
                                           AtomicEventState *event,
                                           uintptr_t address, int nBytes,
                                           Location loc) {
-  auto range = roundRange(Range{address, address + nBytes});
+  auto granularity = getGlobalState(state)->shadowGranularityBytes;
+  auto range = roundRange(Range{address, address + nBytes}, granularity);
   auto reserveBase = state->reserveBase;
   uint8_t numCells = 0;
-  for (uintptr_t addr = range.start; addr < range.end;
-       addr += kShadowMemGranularityBytes) {
+  for (uintptr_t addr = range.start; addr < range.end; addr += granularity) {
     if (isGsanManaged(addr, reserveBase))
       ++numCells;
   }
@@ -1128,11 +1143,11 @@ GSAN_DEVICE void acquireAtomicShadowRange(ThreadState *state,
   rwLockAcquireWrite(state->lock);
   event->threadState = state;
   event->numCells = 0;
-  for (uintptr_t addr = range.start; addr < range.end;
-       addr += kShadowMemGranularityBytes) {
+  for (uintptr_t addr = range.start; addr < range.end; addr += granularity) {
     if (!isGsanManaged(addr, reserveBase))
       continue;
-    event->cells[event->numCells++] = acquireShadow(getShadowAddress(addr));
+    event->cells[event->numCells++] =
+        acquireShadow(getShadowAddress(addr, granularity));
   }
 }
 
@@ -1235,12 +1250,15 @@ GSAN_DEVICE void endAtomicAccess(AtomicEventState *event, bool pred,
 }
 
 struct AtomicElementHandler {
+  static constexpr bool kIsWrite = true;
+
   GlobalState *globals;
   uintptr_t reserveBase;
   int bytesPerElem;
   int sem;
   int scope;
   Location loc;
+  int shadowGranularityBytes;
 
   GSAN_DEVICE void operator()(uintptr_t address) const {
     AtomicEventState event;
@@ -1255,10 +1273,15 @@ GSAN_DEVICE void tensorAtomicDesc(GlobalState *globals, const void *descriptor,
                                   const int16_t *blockShape, int bytesPerElem,
                                   int sem, int scope, int warpId, int numWarps,
                                   Location loc) {
-  int granularity =
-      roundUp(bytesPerElem, static_cast<uintptr_t>(kShadowMemGranularityBytes));
+  int granularity = roundUp(bytesPerElem, globals->shadowGranularityBytes);
   AtomicElementHandler handleElement{
-      globals, globals->reserveBase, granularity, sem, scope, loc};
+      globals,
+      globals->reserveBase,
+      granularity,
+      sem,
+      scope,
+      loc,
+      static_cast<int>(globals->shadowGranularityBytes)};
   tensorAccessDesc(descriptor, coords, rank, blockShape, bytesPerElem,
                    granularity, warpId, numWarps, handleElement);
 }

--- a/python/triton/experimental/gsan/src/gsan_testing.cc
+++ b/python/triton/experimental/gsan/src/gsan_testing.cc
@@ -50,6 +50,7 @@ struct PyGlobalState {
   uintptr_t reserveBase = 0;
   uintptr_t globalsBase = 0;
   uint32_t rngSeed = 0;
+  uint32_t shadowGranularityBytes = 0;
   uint32_t numSms = 0;
   uint32_t numDevices = 0;
   uint32_t numThreads = 0;
@@ -144,6 +145,7 @@ std::string globalStateStr(const PyGlobalState &s) {
   std::ostringstream oss;
   oss << "GlobalState(reserve_base=" << s.reserveBase
       << ", globals_base=" << s.globalsBase << ", rng_seed=" << s.rngSeed
+      << ", shadow_granularity_bytes=" << s.shadowGranularityBytes
       << ", num_sms=" << s.numSms << ", num_devices=" << s.numDevices
       << ", num_threads=" << s.numThreads
       << ", clock_buffer_size=" << s.clockBufferSize << ")";
@@ -190,6 +192,7 @@ PyGlobalState toPyGlobalState(const gsan::GlobalState &state) {
   out.reserveBase = static_cast<uintptr_t>(state.reserveBase);
   out.globalsBase = static_cast<uintptr_t>(state.globalsBase);
   out.rngSeed = state.rngSeed;
+  out.shadowGranularityBytes = state.shadowGranularityBytes;
   out.numSms = state.numSms;
   out.numDevices = state.numDevices;
   out.numThreads = state.numThreads;
@@ -325,6 +328,9 @@ void init_gsan_testing(py::module_ &m) {
       .def_prop_ro("globals_base",
                    [](const PyGlobalState &s) { return s.globalsBase; })
       .def_prop_ro("rng_seed", [](const PyGlobalState &s) { return s.rngSeed; })
+      .def_prop_ro(
+          "shadow_granularity_bytes",
+          [](const PyGlobalState &s) { return s.shadowGranularityBytes; })
       .def_prop_ro("num_sms", [](const PyGlobalState &s) { return s.numSms; })
       .def_prop_ro("num_devices",
                    [](const PyGlobalState &s) { return s.numDevices; })
@@ -365,6 +371,7 @@ void init_gsan_testing(py::module_ &m) {
 
   m.def(
       "shadow_cell_address", gsan::getShadowAddress, py::arg("real_address"),
+      py::arg("granularity_bytes") = gsan::kShadowMemGranularityBytes,
       "Return the address of the ShadowCell corresponding to a real address.");
 
   m.attr("SHADOW_CELL_SIZE_BYTES") = sizeof(gsan::ShadowCell);

--- a/test/Conversion/tritongpu_to_llvm_gsan.mlir
+++ b/test/Conversion/tritongpu_to_llvm_gsan.mlir
@@ -39,6 +39,16 @@ module attributes {"ttg.instrumentation_mode" = "gsan", "ttg.num-ctas" = 1 : i32
     tt.return
   }
 
+  // CHECK-LABEL: llvm.func @unmasked_atomic_add_i64
+  // CHECK: llvm.alloca %{{.*}} x !llvm.struct<(ptr, array<5 x ptr>, i8)>
+  // CHECK: %[[ATOMIC_BYTES:.*]] = llvm.mlir.constant(8 : i32)
+  // CHECK: llvm.call @__triton_gsan_atomic_begin_scalar(%{{.*}}, %{{.*}}, %{{.*}}, %{{.*}}, %[[ATOMIC_BYTES]],
+  // CHECK: llvm.call @__triton_gsan_atomic_end_scalar
+  tt.func @unmasked_atomic_add_i64(%ptr: !tt.ptr<i64>, %val: i64) {
+    %0 = tt.atomic_rmw add, relaxed, gpu, %ptr, %val : (!tt.ptr<i64>, i64) -> i64
+    tt.return
+  }
+
   // CHECK-LABEL: llvm.func @atomic_poll
   // CHECK: llvm.load %{{.*}} atomic monotonic
   // CHECK: llvm.fence acquire
@@ -83,6 +93,27 @@ module attributes {"ttg.instrumentation_mode" = "gsan", "ttg.num-ctas" = 1 : i32
     %c0_i32 = arith.constant 0 : i32
     %buf = ttg.local_alloc {allocation.offset = 0 : i32} : () -> !ttg.memdesc<8x16xi64, #shared_i64, #smem, mutable>
     ttng.async_tma_reduce add, %desc[%c0_i32, %c0_i32] %buf : !tt.tensordesc<8x16xi64, #shared_i64>, !ttg.memdesc<8x16xi64, #shared_i64, #smem, mutable>
+    tt.return
+  }
+}
+
+// -----
+
+#subword = #ttg.blocked<{sizePerThread = [4], threadsPerWarp = [32], warpsPerCTA = [1], order = [0]}>
+module attributes {"ttg.instrumentation_mode" = "gsan", "ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 1 : i32} {
+  // Each halfword retains its own mask, even when neighboring pointers are contiguous.
+  // CHECK-LABEL: llvm.func @subword_masks
+  // CHECK: llvm.alloca %{{.*}} x !llvm.struct<(array<4 x i64>, array<4 x i8>)>
+  // CHECK: llvm.call @__triton_gsan_load_tensor
+  // CHECK: llvm.alloca %{{.*}} x !llvm.struct<(array<4 x i64>, array<4 x i8>)>
+  // CHECK: llvm.call @__triton_gsan_store_tensor
+  tt.func @subword_masks(%ptr: !tt.ptr<bf16> {tt.divisibility = 16 : i32},
+                        %mask: tensor<128xi1, #subword>) {
+    %offsets = tt.make_range {start = 0 : i32, end = 128 : i32} : tensor<128xi32, #subword>
+    %base = tt.splat %ptr : !tt.ptr<bf16> -> tensor<128x!tt.ptr<bf16>, #subword>
+    %ptrs = tt.addptr %base, %offsets : tensor<128x!tt.ptr<bf16>, #subword>, tensor<128xi32, #subword>
+    %values = tt.load %ptrs, %mask : tensor<128x!tt.ptr<bf16>, #subword>
+    tt.store %ptrs, %values, %mask : tensor<128x!tt.ptr<bf16>, #subword>
     tt.return
   }
 }


### PR DESCRIPTION
GSan assigns one access history to each four-byte cell, so independent FP16/BF16 writes can report a race when they share a cell—for example, adjacent CTAs writing odd-width BF16 rows. Add optional `gsan.configure(shadow_granularity_bytes=2)` before the first address reservation. Preserve exact subword masks during lowering and track every touched cell, including eight-byte atomic operations.

The default remains four-byte precision. Halfword precision doubles shadow storage from six to twelve bytes per application byte; the choice freezes at reservation, and unsupported IPC with nondefault precision fails explicitly.

Track the physical trailing 16-byte sectors written by hardware TMA stores, scatters, and reductions. Loads and gathers retain logical bounds. Tests check actual stored values and shadow histories, including real races on overlapping halfwords and TMA padding.

On pre-Hopper GPUs, descriptors lower to ordinary masked pointer operations. The follow-up fix makes `test_tma_masked_store_updates_shadow` expect logical bounds on that path, while retaining hardware-TMA expectations on Hopper and newer. This fixes the three A100 failures at column 37 without dropping their value or shadow-history checks.

## Validation

- Python syntax, Ruff 0.9.1, YAPF 0.43.0, and `git diff --check` pass for the follow-up.
- A fresh native build at the follow-up commit passed. On NVIDIA GB300 (sm103), 35 focused value/shadow tests and nine race-detection tests passed, including all masked TMA cases and padding races at both shadow precisions.
- Twelve uninstrumented store/scatter/reduction controls passed. With nine logical columns, BF16 writes reached column 15, uint64 store/reduction writes reached column 9, and int32 scatter writes reached column 11; later storage remained untouched. These are measured GB300 results.
- Both GSan lit files passed: `test/TritonGPU/gsan.mlir` and `test/Conversion/tritongpu_to_llvm_gsan.mlir`.
- The original A100 run had three failures in `test_tma_masked_store_updates_shadow`, 224 passing GSan tests, and 68 skips. H100 and GB200 jobs were cancelled after that failure. A100/H100 CI must rerun after this update.
- Earlier validation on base `5198bceaf9939c6e1d266d0bc0dc47cface0d2c3` passed the native build, both GSan lit tests, and 85 GPU tests. Those historical results are separate from the follow-up validation above.

Follow-up commit: `a3c3fd9fb2cb18439108e2213b144c5a27f335aa`, on the existing PR head `0cbb8cc94366aa3da254fae351dd3bccc0e5cb0c`. The PR base remains `20e6ba864830b88f56b907fef85cab5097cf3892`; this update does not rebase the branch.
