### PR TITLE
[interpreter] fix create_fma double rounding for float32

### DIFF
--- a/python/test/unit/language/test_core.py
+++ b/python/test/unit/language/test_core.py
@@ -1174,6 +1174,40 @@ def test_math_fma_op(dtype, device):
 
 
 @pytest.mark.interpreter
+def test_math_fma_op_float32_double_rounding(device):
+    # Regression test for: https://github.com/triton-lang/triton/issues/11610
+    # x=y=4097.0, z=2**-30: x*y == 16785409.0 sits exactly halfway between the
+    # two float32 neighbors 16785408.0 and 16785410.0 (float32 ulp is 2 here).
+    # z is below the float64 half-ulp threshold there, so rounding x*y+z to
+    # float64 first (as create_fma did before this fix) picks 16785409.0,
+    # which .astype(float32) then rounds-to-even down to 16785408.0. The
+    # exact (rational) value x*y+z is above the halfway point and must round
+    # up to 16785410.0 instead -- rounding through float64 double-rounds it.
+    check_type_supported('float32', device)
+
+    @triton.jit
+    def kernel(Z, X, Y, W, SIZE: tl.constexpr):
+        off = tl.arange(0, SIZE)
+        x = tl.load(X + off)
+        y = tl.load(Y + off)
+        w = tl.load(W + off)
+        z = tl.math.fma(x, y, w)
+        tl.store(Z + off, z)
+
+    x = np.array([4097.0], dtype=np.float32)
+    y = np.array([4097.0], dtype=np.float32)
+    w = np.array([2**-30], dtype=np.float32)
+
+    x_tri = to_triton(x, device=device, dst_type='float32')
+    y_tri = to_triton(y, device=device, dst_type='float32')
+    w_tri = to_triton(w, device=device, dst_type='float32')
+    z_tri = to_triton(np.zeros_like(x), device=device, dst_type='float32')
+    kernel[(1, )](z_tri, x_tri, y_tri, w_tri, SIZE=1)
+
+    np.testing.assert_equal(to_numpy(z_tri), np.array([16785410.0], dtype=np.float32))
+
+
+@pytest.mark.interpreter
 def test_math_fma_op_special_values(device):
     check_type_supported('float64', device)
 

--- a/python/triton/runtime/interpreter.py
+++ b/python/triton/runtime/interpreter.py
@@ -277,6 +277,47 @@ def _fma_fp64(a, b, c):
     return ret if ret != 0.0 else math.copysign(0.0, sign)
 
 
+def _fma_narrow(a, b, c, dtype):
+    # Rounding a*b and then a*b+c separately (each through float64) is double
+    # rounding: a value exactly halfway between two `dtype` steps can round to
+    # the wrong neighbor once the float64 intermediate has already rounded it
+    # once. Round the exact rational value directly against the two `dtype`
+    # candidates instead, so there is exactly one rounding step.
+    a64, b64, c64 = float(a), float(b), float(c)
+    if math.isnan(a64) or math.isnan(b64) or math.isnan(c64) or math.isinf(a64) or math.isinf(b64):
+        return dtype(a64 * b64 + c64)
+    if math.isinf(c64):
+        return dtype(c64)
+    exact = Fraction(a64) * Fraction(b64) + Fraction(c64)
+    if exact == 0:
+        # Only zero operands can make this a negative zero.
+        return dtype(a64 * b64 + c64) if a64 * b64 == 0.0 and c64 == 0.0 else dtype(0.0)
+    sign = 1.0 if exact > 0 else -1.0
+    approx = dtype(float(exact))
+    if not np.isfinite(approx):
+        return approx
+    # `approx` and its neighbor on the side of `exact` are the only two
+    # candidates a correctly-rounded result can be; pick whichever is closer,
+    # breaking an exact tie to the neighbor with an even mantissa bit
+    # (round-half-to-even, matching IEEE 754 default rounding).
+    # The neighbor must be taken towards `exact`, not away from zero: `approx`
+    # (itself already rounded once, through float64) can land on either side
+    # of `exact`, so the sign of the *value* is not the direction to search.
+    towards_exact = np.inf if Fraction(float(approx)) < exact else -np.inf
+    neighbor = dtype(np.nextafter(approx, towards_exact, dtype=dtype))
+    d_approx = abs(exact - Fraction(float(approx)))
+    d_neighbor = abs(exact - Fraction(float(neighbor)))
+    if d_neighbor < d_approx:
+        ret = neighbor
+    elif d_neighbor > d_approx:
+        ret = approx
+    else:
+        bit_view = np.uint16 if dtype is np.float16 else np.uint32
+        approx_is_even = (int(approx.view(bit_view)) & 1) == 0
+        ret = approx if approx_is_even else neighbor
+    return ret if ret != 0.0 else dtype(math.copysign(0.0, sign))
+
+
 def _e8m0_to_f32(scale):
     assert scale.dtype in (np.uint8, np.int8)
     scale = scale.astype(np.uint8)
@@ -373,6 +414,7 @@ np_erf_fp32 = np.vectorize(_erf, otypes=[np.float32])
 np_erf_fp64 = np.vectorize(_erf, otypes=[np.float64])
 np_umulhi_u64 = np.vectorize(_umulhi_64, otypes=[np.uint64])
 np_fma_fp64 = np.vectorize(_fma_fp64, otypes=[np.float64])
+np_fma_fp32 = np.vectorize(lambda a, b, c: _fma_narrow(a, b, c, np.float32), otypes=[np.float32])
 
 
 class ExtraFunctions:
@@ -708,10 +750,18 @@ class InterpreterBuilder:
 
     def create_fma(self, x, y, z):
         # An fma rounds once, but multiplying and then adding rounds twice.
-        # float64 has the precision to round the narrower types correctly.
+        # A float64 intermediate has the precision to round float16 correctly
+        # (its full range fits in a float64 mantissa), but not float32: the
+        # product+sum can land exactly halfway between two float32 values, in
+        # which case rounding it to float64 first and then to float32 can pick
+        # the wrong neighbor (double rounding). float32 is routed through
+        # `_fma_narrow`, which rounds the exact value directly against the
+        # float32 grid.
         dtype = z.data.dtype
         if dtype == np.float64:
             ret = np_fma_fp64(x.data, y.data, z.data)
+        elif dtype == np.float32:
+            ret = np_fma_fp32(x.data, y.data, z.data)
         else:
             product = np.multiply(x.data, y.data, dtype=np.float64)
             ret = np.add(product, z.data, dtype=np.float64).astype(dtype)


### PR DESCRIPTION
## Summary

PR #11424 fixed FMA double rounding by routing float16/float32 through
a float64 intermediate, on the premise that "float64 has enough
precision to produce the correctly rounded target result." That
premise holds for float16 (its full dynamic range fits in a float64
mantissa, so the float64 sum is exact) but not for float32: the
product `a*b` is exact in float64, but `product+z` can land exactly on
the halfway point between two float32 values, and rounding that
halfway value to float64 first (round-to-nearest-even) can already
pick the wrong side before the subsequent float32 cast ever runs. That
is double rounding, the same defect class #11424 set out to fix,
surviving in the float32 path.

Repro: `x=y=4097.0, z=2**-30`. `4097**2 = 16785409` sits exactly
between the two float32 neighbors `16785408.0` and `16785410.0`
(float32 ulp is 2 in this range); `z` is below the float64 half-ulp
threshold there, so `np.add` rounds `product+z` to `16785409.0` and
`.astype(float32)` picks `16785408.0` (ties-to-even). The true fma is
`16785409 + 2**-30`, which is above the halfway point, so it rounds to
`16785410.0` instead — what compiled mode returns.

Fixes #11610.

## Fix

`create_fma` now routes float32 through `_fma_narrow`, which computes
the exact rational value (`Fraction`) and rounds it directly against
the float32 grid — comparing the two float32 candidates that bracket
it and breaking an exact tie to the even mantissa — so there is only
one rounding step. float16 keeps using the existing float64-intermediate
path (still correctly rounded for that dtype); float64 keeps using the
existing `_fma_fp64` path.

## Testing

Verified against:
- An independent brute-force correctly-rounded reference implementation
  over the reported case and a second independently-found case.
- A wide random sweep (200k cases: integer-mantissa products landing
  exactly on the float32 midpoint, paired with a sub-half-ulp `z`) —
  zero mismatches against the reference.
- NaN / Inf / zero / negative-zero / overflow-to-inf edge cases.
- GPU comparison against compiled `tl.math.fma` on both reported cases
  (Colab L4, upstream/main build `20e6ba86`) — compiled and fixed
  interpreter now agree exactly (`16785410.0` and `239825862656.0`),
  where the unfixed interpreter previously disagreed.
- Existing `test_math_fma_op[float16/float32/float64]` and
  `test_math_fma_op_special_values` — all pass under both compiled and
  interpreter modes.

## Note on a tempting-but-wrong alternative

Reusing `_fma_fp64` (the existing float64-exact-rounding helper) and
simply `.astype(float32)`-ing its result is **not** sufficient — it is
still double rounding (exact → float64 RN → float32 RN) and reproduces
the exact same bug on the reported case. The fix must round the exact
value directly against the float32 grid.
