### PR TITLE
[KERNELS] Keep scale layout shape calculations in integer arithmetic

### DIFF
--- a/python/triton_kernels/tests/test_tensor.py
+++ b/python/triton_kernels/tests/test_tensor.py
@@ -148,8 +148,6 @@ def test_fpsan_embed_unembed_torch_tensor(dtype, layout, fresh_knobs):
         ((0, 64), False, BlackwellActMXScaleLayout(None), [1, 0, 16, 2, 256]),
         ((3, 254, 60), False, CDNA4MXScaleLayout(), [3, 8192, 2]),
         ((0, 64), False, CDNA4MXScaleLayout(), [1, 0, 2]),
-        ((2**53 + 1, 1), False, CDNA4MXScaleLayout(), [1, (2**53 + 8) * 32, 1]),
-        ((8, 2**53 + 1), False, CDNA4MXScaleLayout(), [1, 256, 2**48 + 1]),
         ((3, 254, 60), False, GFX1250MXScaleLayout(), [3, 32768, 1]),
         ((0, 64), False, GFX1250MXScaleLayout(), [1, 0, 1]),
     ],
@@ -164,24 +162,11 @@ def test_layout_storage_shape_matches_conversion(logical_shape, is_fp4, layout, 
     assert list(converted.storage.data.shape) == storage_shape
 
 
-@pytest.mark.parametrize("layout", [
-    BlackwellMXScaleLayout(),
-    BlackwellActMXScaleLayout(None),
-    HopperMXScaleLayout(-1, 4),
-    HopperMXScaleLayout(-2, 4),
-    CDNA4MXScaleLayout(),
-])
-@pytest.mark.parametrize("rank", [2, 3])
-def test_scale_layout_symbolic_storage_shape(layout, rank):
-    symbols = sympy.symbols("batch rows cols", integer=True, nonnegative=True)
-    symbolic_shape = layout.storage_shape(list(symbols[-rank:]), False)
-
-    for shape in [(0, 129, 65), (2, 0, 0), (2, 0, 65), (2, 129, 0), (2, 8, 128), (2, 128, 64), (2, 129, 65)]:
-        tensor = empty(shape[-rank:], dtype=UINT8, device="meta")
-        converted = convert_layout(tensor, layout)
-        substitutions = dict(zip(symbols, shape))
-        result = [sympy.sympify(size).subs(substitutions) for size in symbolic_shape]
-        assert result == list(converted.storage.data.shape)
+def test_cdna4_scale_symbolic_storage_shape():
+    k, n = sympy.symbols("k n", integer=True, nonnegative=True)
+    shape = CDNA4MXScaleLayout().storage_shape([k, n], False)
+    assert shape[1].subs(k, 9) == 512
+    assert shape[2].subs(n, 33) == 2
 
 
 def test_ragged_layout_storage_shape():

--- a/python/triton_kernels/tests/test_tensor.py
+++ b/python/triton_kernels/tests/test_tensor.py
@@ -4,6 +4,7 @@ import sys
 from contextlib import nullcontext
 
 import pytest
+import sympy
 import torch
 from torch._subclasses.fake_tensor import FakeTensorMode
 import triton
@@ -147,6 +148,8 @@ def test_fpsan_embed_unembed_torch_tensor(dtype, layout, fresh_knobs):
         ((0, 64), False, BlackwellActMXScaleLayout(None), [1, 0, 16, 2, 256]),
         ((3, 254, 60), False, CDNA4MXScaleLayout(), [3, 8192, 2]),
         ((0, 64), False, CDNA4MXScaleLayout(), [1, 0, 2]),
+        ((2**53 + 1, 1), False, CDNA4MXScaleLayout(), [1, (2**53 + 8) * 32, 1]),
+        ((8, 2**53 + 1), False, CDNA4MXScaleLayout(), [1, 256, 2**48 + 1]),
         ((3, 254, 60), False, GFX1250MXScaleLayout(), [3, 32768, 1]),
         ((0, 64), False, GFX1250MXScaleLayout(), [1, 0, 1]),
     ],
@@ -159,6 +162,26 @@ def test_layout_storage_shape_matches_conversion(logical_shape, is_fp4, layout, 
 
     assert layout.storage_shape(list(logical_shape), is_fp4) == storage_shape
     assert list(converted.storage.data.shape) == storage_shape
+
+
+@pytest.mark.parametrize("layout", [
+    BlackwellMXScaleLayout(),
+    BlackwellActMXScaleLayout(None),
+    HopperMXScaleLayout(-1, 4),
+    HopperMXScaleLayout(-2, 4),
+    CDNA4MXScaleLayout(),
+])
+@pytest.mark.parametrize("rank", [2, 3])
+def test_scale_layout_symbolic_storage_shape(layout, rank):
+    symbols = sympy.symbols("batch rows cols", integer=True, nonnegative=True)
+    symbolic_shape = layout.storage_shape(list(symbols[-rank:]), False)
+
+    for shape in [(0, 129, 65), (2, 0, 0), (2, 0, 65), (2, 129, 0), (2, 8, 128), (2, 128, 64), (2, 129, 65)]:
+        tensor = empty(shape[-rank:], dtype=UINT8, device="meta")
+        converted = convert_layout(tensor, layout)
+        substitutions = dict(zip(symbols, shape))
+        result = [sympy.sympify(size).subs(substitutions) for size in symbolic_shape]
+        assert result == list(converted.storage.data.shape)
 
 
 def test_ragged_layout_storage_shape():

--- a/python/triton_kernels/tests/test_tensor.py
+++ b/python/triton_kernels/tests/test_tensor.py
@@ -162,11 +162,17 @@ def test_layout_storage_shape_matches_conversion(logical_shape, is_fp4, layout, 
     assert list(converted.storage.data.shape) == storage_shape
 
 
-def test_cdna4_scale_symbolic_storage_shape():
-    k, n = sympy.symbols("k n", integer=True, nonnegative=True)
-    shape = CDNA4MXScaleLayout().storage_shape([k, n], False)
-    assert shape[1].subs(k, 9) == 512
-    assert shape[2].subs(n, 33) == 2
+@pytest.mark.parametrize(("layout", "expected"), [
+    (BlackwellMXScaleLayout(), [1, 1, 4, 2, 256]),
+    (BlackwellActMXScaleLayout(None), [1, 1, 10, 2, 256]),
+    (HopperMXScaleLayout(-1, 4), [4, 1088]),
+    (HopperMXScaleLayout(-2, 4), [320, 4]),
+    (CDNA4MXScaleLayout(), [1, 512, 2]),
+])
+def test_scale_layout_symbolic_storage_shape(layout, expected):
+    m, n = sympy.symbols("m n", integer=True, nonnegative=True)
+    shape = layout.storage_shape([m, n], False)
+    assert [sympy.sympify(dim).subs({m: 9, n: 33}) for dim in shape] == expected
 
 
 def test_ragged_layout_storage_shape():

--- a/python/triton_kernels/triton_kernels/tensor_details/layout_details/blackwell_scale.py
+++ b/python/triton_kernels/triton_kernels/tensor_details/layout_details/blackwell_scale.py
@@ -70,7 +70,7 @@ class BlackwellActMXScaleLayoutTransformation(ScaleLayoutTransformation):
             B, M, K = 1, *self.shape
             added_leading_batch_dim = True
             if self.ragged_metadata is None:
-                M_pad = (M + self.ALIGN_M - 1) // self.ALIGN_M * self.ALIGN_M
+                M_pad = (M + (self.ALIGN_M - 1)) // self.ALIGN_M * self.ALIGN_M
                 mode = "batched"
             else:
                 # In ragged mode, input often include padded tokens
@@ -84,9 +84,9 @@ class BlackwellActMXScaleLayoutTransformation(ScaleLayoutTransformation):
                 mode = "ragged"
         else:
             B, M, K = self.shape
-            M_pad = (M + self.ALIGN_M - 1) // self.ALIGN_M * self.ALIGN_M
+            M_pad = (M + (self.ALIGN_M - 1)) // self.ALIGN_M * self.ALIGN_M
             mode = "batched"
-        K_pad = (K + self.ALIGN_K - 1) // self.ALIGN_K * self.ALIGN_K  # min multiple of ALIGN_K
+        K_pad = (K + (self.ALIGN_K - 1)) // self.ALIGN_K * self.ALIGN_K  # min multiple of ALIGN_K
         # initialize attributes
         object.__setattr__(self, "B", B)
         object.__setattr__(self, "M", M)
@@ -169,8 +169,8 @@ class BlackwellMXScaleLayoutTransformation(ScaleLayoutTransformation):
         object.__setattr__(self, "ALIGN_K", 8)
         object.__setattr__(self, "ALIGN_N", 128)
         object.__setattr__(self, "SWIZZLE_K", 4)
-        object.__setattr__(self, "K_pad", (K + self.ALIGN_K - 1) // self.ALIGN_K * self.ALIGN_K)
-        object.__setattr__(self, "N_pad", (N + self.ALIGN_N - 1) // self.ALIGN_N * self.ALIGN_N)
+        object.__setattr__(self, "K_pad", (K + (self.ALIGN_K - 1)) // self.ALIGN_K * self.ALIGN_K)
+        object.__setattr__(self, "N_pad", (N + (self.ALIGN_N - 1)) // self.ALIGN_N * self.ALIGN_N)
 
     @property
     def storage_shape(self) -> list[int]:

--- a/python/triton_kernels/triton_kernels/tensor_details/layout_details/cdna4_scale.py
+++ b/python/triton_kernels/triton_kernels/tensor_details/layout_details/cdna4_scale.py
@@ -37,8 +37,8 @@ class CDNA4MXScaleLayoutTransformation(LayoutTransformation):
         B = math.prod(leading_shape)
         ALIGN_K_SCALE = 8
         ALIGN_N = 32
-        K_SCALE_pad = math.ceil(K_SCALE / ALIGN_K_SCALE) * ALIGN_K_SCALE
-        N_pad = math.ceil(N / ALIGN_N) * ALIGN_N
+        K_SCALE_pad = (K_SCALE + (ALIGN_K_SCALE - 1)) // ALIGN_K_SCALE * ALIGN_K_SCALE
+        N_pad = (N + (ALIGN_N - 1)) // ALIGN_N * ALIGN_N
         object.__setattr__(self, "leading_shape", leading_shape)
         object.__setattr__(self, "B", B)
         object.__setattr__(self, "ALIGN_K_SCALE", ALIGN_K_SCALE)

--- a/python/triton_kernels/triton_kernels/tensor_details/layout_details/hopper_scale.py
+++ b/python/triton_kernels/triton_kernels/tensor_details/layout_details/hopper_scale.py
@@ -59,7 +59,7 @@ class HopperMXScaleLayoutTransformation(ScaleLayoutTransformation):
         if self.mx_axis == len(leading_shape):
             M, K = K, M
         align_m = 32 * self.num_warps
-        M = (M + align_m - 1) // align_m * align_m
+        M = (M + (align_m - 1)) // align_m * align_m
         K = (K + 1) // 2 * 2
         return [*leading_shape, M, K]
 


### PR DESCRIPTION
Support symbolic integer dimensions when querying MX scale storage shapes on Blackwell, Hopper, and CDNA4.

- Blackwell weight and activation layouts, and Hopper layouts, evaluate `alignment - 1` before adding it to a dimension. Symbolic callers therefore need no subtraction operation.
- CDNA4 uses integer round-up instead of floating-point `math.ceil`, allowing unresolved symbolic dimensions and preserving integer precision.

For example, query the packed shapes before the logical dimensions are known:

```python
from sympy import symbols
from triton_kernels.tensor_details.layout import (
    BlackwellActMXScaleLayout, BlackwellMXScaleLayout,
    CDNA4MXScaleLayout, HopperMXScaleLayout,
)

m, n = symbols("m n", integer=True, nonnegative=True)
for layout in (
    BlackwellMXScaleLayout(), BlackwellActMXScaleLayout(None),
    HopperMXScaleLayout(-1, 4), CDNA4MXScaleLayout(),
):
    print(layout.storage_shape([m, n], False))
```

On `main`, the CDNA4 query raises `TypeError: Cannot convert expression to float`; here all queries return symbolic shapes. SymPy already supports subtraction, so the Blackwell/Hopper change specifically benefits symbolic integer types that lack it: `(m + 128) - 1` becomes `m + 127`.

| Files | Added | Removed | Net |
| --- | ---: | ---: | ---: |
| Tests | +14 | -0 | +14 |
| Non-tests | +8 | -8 | +0 |
| All | +22 | -8 | +14 |

## Reviewer's guide

- `python/triton_kernels/triton_kernels/tensor_details/layout_details`: keep CDNA4 padding exact and fold constant padding offsets in Blackwell and Hopper.
- `python/triton_kernels/tests`: query and resolve a small symbolic storage shape for every affected layout through the public API.

<!-- codex-thread: 01a0780a-af95-7c80-90ad-5ad47b8d9bb1 -->
