### PR TITLE
[KERNELS] Add broadcastable MX scale pointer helpers

### DIFF
--- a/python/triton_kernels/tests/test_tensor_details/test_layout_blackwell.py
+++ b/python/triton_kernels/tests/test_tensor_details/test_layout_blackwell.py
@@ -12,11 +12,7 @@ from triton_kernels.tensor_details.layout import (
     StridedLayout,
 )
 from triton_kernels.tensor_details.dtype import FP4
-from triton_kernels.tensor_details.layout_details.blackwell_scale import (
-    swizzle_act_mx_scale_bw_store_ptr,
-    swizzle_mx_scale_bw_ptr,
-    swizzle_mx_scale_bw_store_ptr,
-)
+from triton_kernels.tensor_details.layout_details import blackwell_scale
 from triton_kernels.tensor import make_ragged_tensor_metadata, make_ragged_tensor_metadata_torch, wrap_torch_tensor, convert_layout, empty
 
 # ------------------------------------------------------------
@@ -708,106 +704,25 @@ def test_scale_convert_layout_fake(layout, monkeypatch):
 
 
 @triton.jit
-def _pack_scale_with_store_ptr(X, S, OUTER: tl.constexpr, INNER: tl.constexpr, X_STRIDES: tl.constexpr,
-                               S_STRIDES: tl.constexpr, ACT: tl.constexpr, INDEX_TYPE: tl.constexpr,
-                               BATCHES: tl.constexpr):
-    batch = tl.program_id(0)
-    outer = tl.program_id(1) * 128 + tl.arange(0, 128)
-    inner = tl.program_id(2) * 8 + tl.arange(0, 8)
-    if ACT:
-        offsets = batch * X_STRIDES[0] + outer[:, None] * X_STRIDES[1] + inner[None, :] * X_STRIDES[2]
-        mask = (outer[:, None] < OUTER) & (inner[None, :] < INNER)
-        if BATCHES == 1:
-            origin = 0
-        else:
-            origin = batch * tl.cdiv(OUTER, 128)
-        pointers = swizzle_act_mx_scale_bw_store_ptr(S, outer, inner, origin, *S_STRIDES[1:], INDEX_TYPE=INDEX_TYPE)
-    else:
-        offsets = batch * X_STRIDES[0] + inner[:, None] * X_STRIDES[1] + outer[None, :] * X_STRIDES[2]
-        mask = (inner[:, None] < INNER) & (outer[None, :] < OUTER)
-        pointers = swizzle_mx_scale_bw_store_ptr(S, inner, outer, 0 if BATCHES == 1 else batch, OUTER, *S_STRIDES[1:],
-                                                 INDEX_TYPE=INDEX_TYPE)
-    tl.store(pointers, tl.load(X + offsets, mask, other=0), mask)
+def _gather_scale(S, Rows, Cols, Out, STRIDES: tl.constexpr):
+    i = tl.arange(0, 4)
+    rows = tl.load(Rows + i)
+    cols = tl.load(Cols + i)
+    ptrs = blackwell_scale.swizzle_mx_scale_bw_ptr(S, cols, rows, 0, *STRIDES)
+    tl.store(Out + i, tl.load(ptrs))
+    ptrs = blackwell_scale.swizzle_mx_scale_bw_ptr(S, 0, rows, 0, *STRIDES)
+    tl.store(Out + 4 + i, tl.load(ptrs))
+    ptrs = blackwell_scale.swizzle_mx_scale_bw_ptr(S, cols, 0, 0, *STRIDES)
+    tl.store(Out + 8 + i, tl.load(ptrs))
 
 
-@triton.jit
-def _gather_scale_with_ptr(S, Indices, Out, COUNT: tl.constexpr, OUTER: tl.constexpr, INNER: tl.constexpr,
-                           S_STRIDES: tl.constexpr, ACT: tl.constexpr, INDEX_TYPE: tl.constexpr):
-    positions = tl.program_id(0) * 256 + tl.arange(0, 256)
-    indices = tl.load(Indices + positions, positions < COUNT, other=0)
-    batch = indices // (OUTER * INNER)
-    if ACT:
-        outer, inner = indices // INNER % OUTER, indices % INNER
-    else:
-        outer, inner = indices % OUTER, indices // OUTER % INNER
-    for query in tl.static_range(3):
-        pointers = swizzle_mx_scale_bw_ptr(S, 0 if query == 1 else outer, 0 if query == 2 else inner,
-                                           batch * tl.cdiv(OUTER, 128), *S_STRIDES[1:], INDEX_TYPE=INDEX_TYPE)
-        tl.store(Out + query * COUNT + positions, tl.load(pointers, positions < COUNT, other=0), positions < COUNT)
+def test_scale_ptr_gather(device):
+    data = torch.arange(9 * 130, device=device).reshape(9, 130).to(torch.uint8)
+    packed = convert_layout(wrap_torch_tensor(data), BlackwellMXScaleLayout()).data
+    rows, cols = torch.tensor([[8, 0, 5, 2], [129, 31, 64, 0]], device=device)
+    gathered = torch.empty((3, 4), dtype=torch.uint8, device=device)
 
+    _gather_scale[(1, )](packed, rows, cols, gathered, packed.stride()[1:])
 
-@pytest.mark.parametrize("shape", [(2, 9, 130), (1, 8, 256)])
-@pytest.mark.parametrize("act", [False, True])
-@pytest.mark.parametrize("step", [1, 2])
-@pytest.mark.parametrize("index_type", [tl.int32, tl.int64])
-def test_scale_addressing_pack_and_gather(shape, act, step, index_type, device):
-    data = torch.randint(0, 256, shape, dtype=torch.uint8, generator=torch.Generator().manual_seed(0))
-    if act:
-        data = data.mT
-    layout = BlackwellActMXScaleLayout(None) if act else BlackwellMXScaleLayout()
-    expected = layout.make_transformation(list(data.shape), False).swizzle_data(data)
-    storage = torch.full((expected.numel() * step + 2, ), 0xAB, dtype=torch.uint8, device=device)
-    packed = storage[1:-1].as_strided(expected.shape, tuple(s * step for s in expected.stride()))
-    packed.zero_()
-    source = data.to(device)
-    batch, inner, outer = shape
-
-    pack_grid = (batch, triton.cdiv(outer, 128), triton.cdiv(inner, 8))
-    _pack_scale_with_store_ptr[pack_grid](source, packed, outer, inner, source.stride(), packed.stride(), act,
-                                          index_type, batch)
-
-    assert torch.equal(packed.cpu(), expected)
-    assert storage[0].item() == storage[-1].item() == 0xAB
-    if step == 2:
-        assert torch.all(storage[2:-1:2] == 0xAB)
-
-    indices = torch.randperm(data.numel(), generator=torch.Generator().manual_seed(1))
-    gathered = torch.empty((3, indices.numel()), dtype=torch.uint8, device=device)
-    gather_grid = (triton.cdiv(indices.numel(), 256), )
-    _gather_scale_with_ptr[gather_grid](packed, indices.to(device), gathered, indices.numel(), outer, inner,
-                                        packed.stride(), act, index_type)
-
-    b, i, j = torch.unravel_index(indices, data.shape)
-    first_outer = data[b, 0, j] if act else data[b, i, 0]
-    first_inner = data[b, i, 0] if act else data[b, 0, j]
-    assert torch.equal(gathered.cpu(), torch.stack((data.reshape(-1)[indices], first_outer, first_inner)))
-
-
-@triton.jit
-def _scale_store_addresses(Base, Origins, Out, ACT: tl.constexpr, INDEX_TYPE: tl.constexpr):
-    outer = tl.arange(0, 4)
-    inner = 4 + tl.arange(0, 4)
-    origins = tl.load(Origins + outer)
-    if ACT:
-        pointers = swizzle_act_mx_scale_bw_store_ptr(Base, outer, inner, origins, 2**31 - 512, 512, 256, 1,
-                                                     INDEX_TYPE=INDEX_TYPE)
-    else:
-        pointers = swizzle_mx_scale_bw_store_ptr(Base, inner, outer, origins, 128, 2**31 - 512, 512, 256, 1,
-                                                 INDEX_TYPE=INDEX_TYPE)
-    # Inspect addresses without dereferencing the sparsely strided storage.
-    addresses = pointers.to(tl.int64) - Base.to(tl.int64)
-    tl.store(Out + tl.arange(0, 4)[:, None] * 4 + tl.arange(0, 4)[None, :], addresses)
-
-
-@pytest.mark.parametrize("act", [False, True])
-@pytest.mark.parametrize("index_type", [tl.int32, tl.int64])
-def test_scale_store_ptr_large_offset(act, index_type, device):
-    base = torch.empty(1, dtype=torch.uint8, device=device)
-    origins = torch.tensor([0, 1, 1, 0], dtype=torch.int32, device=device)
-    addresses = torch.empty((4, 4), dtype=torch.int64, device=device)
-
-    _scale_store_addresses[(1, )](base, origins, addresses, act, index_type)
-
-    outer = origins.cpu().long() * (2**31 - 512) + torch.arange(4) * 16
-    expected = outer[:, None] + 512 + torch.arange(4)[None, :]
-    assert torch.equal(addresses.cpu(), expected if act else expected.mT)
+    expected = torch.stack((data[rows, cols], data[rows, 0], data[0, cols]))
+    assert torch.equal(gathered, expected)

--- a/python/triton_kernels/tests/test_tensor_details/test_layout_blackwell.py
+++ b/python/triton_kernels/tests/test_tensor_details/test_layout_blackwell.py
@@ -722,7 +722,8 @@ def test_scale_ptr_gather_column(device):
     assert torch.equal(gathered, data[rows, 0])
 
 
-@triton.jit
+# The one-byte base stands in for a large allocation; do not specialize its pointer range.
+@triton.jit(do_not_specialize=["S"])
 def _scale_ptr_offset(S, Out, outer, inner):
     # Two int32 stride products sum to 2**31; inspect the pointer without loading it.
     ptr = blackwell_scale.swizzle_mx_scale_bw_ptr(S, outer, inner, 0, 2**31 - 1024, 512, 256, 1, INDEX_TYPE=tl.int32)

--- a/python/triton_kernels/tests/test_tensor_details/test_layout_blackwell.py
+++ b/python/triton_kernels/tests/test_tensor_details/test_layout_blackwell.py
@@ -2,6 +2,7 @@ import math
 import pytest
 import torch
 import triton
+import triton.language as tl
 from torch._subclasses.fake_tensor import FakeTensorMode
 from triton_kernels.tensor_details.layout import (
     BlackwellActMXScaleLayout,
@@ -11,6 +12,11 @@ from triton_kernels.tensor_details.layout import (
     StridedLayout,
 )
 from triton_kernels.tensor_details.dtype import FP4
+from triton_kernels.tensor_details.layout_details.blackwell_scale import (
+    swizzle_act_mx_scale_bw_store_ptr,
+    swizzle_mx_scale_bw_ptr,
+    swizzle_mx_scale_bw_store_ptr,
+)
 from triton_kernels.tensor import make_ragged_tensor_metadata, make_ragged_tensor_metadata_torch, wrap_torch_tensor, convert_layout, empty
 
 # ------------------------------------------------------------
@@ -699,3 +705,109 @@ def test_scale_convert_layout_fake(layout, monkeypatch):
         restored = convert_layout(out, StridedLayout())
         assert list(restored.data.shape) == list(shape)
         assert convert_layout(out, StridedLayout(), out=restored) is restored
+
+
+@triton.jit
+def _pack_scale_with_store_ptr(X, S, OUTER: tl.constexpr, INNER: tl.constexpr, X_STRIDES: tl.constexpr,
+                               S_STRIDES: tl.constexpr, ACT: tl.constexpr, INDEX_TYPE: tl.constexpr,
+                               BATCHES: tl.constexpr):
+    batch = tl.program_id(0)
+    outer = tl.program_id(1) * 128 + tl.arange(0, 128)
+    inner = tl.program_id(2) * 8 + tl.arange(0, 8)
+    if ACT:
+        offsets = batch * X_STRIDES[0] + outer[:, None] * X_STRIDES[1] + inner[None, :] * X_STRIDES[2]
+        mask = (outer[:, None] < OUTER) & (inner[None, :] < INNER)
+        if BATCHES == 1:
+            origin = 0
+        else:
+            origin = batch * tl.cdiv(OUTER, 128)
+        pointers = swizzle_act_mx_scale_bw_store_ptr(S, outer, inner, origin, *S_STRIDES[1:], INDEX_TYPE=INDEX_TYPE)
+    else:
+        offsets = batch * X_STRIDES[0] + inner[:, None] * X_STRIDES[1] + outer[None, :] * X_STRIDES[2]
+        mask = (inner[:, None] < INNER) & (outer[None, :] < OUTER)
+        pointers = swizzle_mx_scale_bw_store_ptr(S, inner, outer, 0 if BATCHES == 1 else batch, OUTER, *S_STRIDES[1:],
+                                                 INDEX_TYPE=INDEX_TYPE)
+    tl.store(pointers, tl.load(X + offsets, mask, other=0), mask)
+
+
+@triton.jit
+def _gather_scale_with_ptr(S, Indices, Out, COUNT: tl.constexpr, OUTER: tl.constexpr, INNER: tl.constexpr,
+                           S_STRIDES: tl.constexpr, ACT: tl.constexpr, INDEX_TYPE: tl.constexpr):
+    positions = tl.program_id(0) * 256 + tl.arange(0, 256)
+    indices = tl.load(Indices + positions, positions < COUNT, other=0)
+    batch = indices // (OUTER * INNER)
+    if ACT:
+        outer, inner = indices // INNER % OUTER, indices % INNER
+    else:
+        outer, inner = indices % OUTER, indices // OUTER % INNER
+    for query in tl.static_range(3):
+        pointers = swizzle_mx_scale_bw_ptr(S, 0 if query == 1 else outer, 0 if query == 2 else inner,
+                                           batch * tl.cdiv(OUTER, 128), *S_STRIDES[1:], INDEX_TYPE=INDEX_TYPE)
+        tl.store(Out + query * COUNT + positions, tl.load(pointers, positions < COUNT, other=0), positions < COUNT)
+
+
+@pytest.mark.parametrize("shape", [(2, 9, 130), (1, 8, 256)])
+@pytest.mark.parametrize("act", [False, True])
+@pytest.mark.parametrize("step", [1, 2])
+@pytest.mark.parametrize("index_type", [tl.int32, tl.int64])
+def test_scale_addressing_pack_and_gather(shape, act, step, index_type, device):
+    data = torch.randint(0, 256, shape, dtype=torch.uint8, generator=torch.Generator().manual_seed(0))
+    if act:
+        data = data.mT
+    layout = BlackwellActMXScaleLayout(None) if act else BlackwellMXScaleLayout()
+    expected = layout.make_transformation(list(data.shape), False).swizzle_data(data)
+    storage = torch.full((expected.numel() * step + 2, ), 0xAB, dtype=torch.uint8, device=device)
+    packed = storage[1:-1].as_strided(expected.shape, tuple(s * step for s in expected.stride()))
+    packed.zero_()
+    source = data.to(device)
+    batch, inner, outer = shape
+
+    pack_grid = (batch, triton.cdiv(outer, 128), triton.cdiv(inner, 8))
+    _pack_scale_with_store_ptr[pack_grid](source, packed, outer, inner, source.stride(), packed.stride(), act,
+                                          index_type, batch)
+
+    assert torch.equal(packed.cpu(), expected)
+    assert storage[0].item() == storage[-1].item() == 0xAB
+    if step == 2:
+        assert torch.all(storage[2:-1:2] == 0xAB)
+
+    indices = torch.randperm(data.numel(), generator=torch.Generator().manual_seed(1))
+    gathered = torch.empty((3, indices.numel()), dtype=torch.uint8, device=device)
+    gather_grid = (triton.cdiv(indices.numel(), 256), )
+    _gather_scale_with_ptr[gather_grid](packed, indices.to(device), gathered, indices.numel(), outer, inner,
+                                        packed.stride(), act, index_type)
+
+    b, i, j = torch.unravel_index(indices, data.shape)
+    first_outer = data[b, 0, j] if act else data[b, i, 0]
+    first_inner = data[b, i, 0] if act else data[b, 0, j]
+    assert torch.equal(gathered.cpu(), torch.stack((data.reshape(-1)[indices], first_outer, first_inner)))
+
+
+@triton.jit
+def _scale_store_addresses(Base, Origins, Out, ACT: tl.constexpr, INDEX_TYPE: tl.constexpr):
+    outer = tl.arange(0, 4)
+    inner = 4 + tl.arange(0, 4)
+    origins = tl.load(Origins + outer)
+    if ACT:
+        pointers = swizzle_act_mx_scale_bw_store_ptr(Base, outer, inner, origins, 2**31 - 512, 512, 256, 1,
+                                                     INDEX_TYPE=INDEX_TYPE)
+    else:
+        pointers = swizzle_mx_scale_bw_store_ptr(Base, inner, outer, origins, 128, 2**31 - 512, 512, 256, 1,
+                                                 INDEX_TYPE=INDEX_TYPE)
+    # Inspect addresses without dereferencing the sparsely strided storage.
+    addresses = pointers.to(tl.int64) - Base.to(tl.int64)
+    tl.store(Out + tl.arange(0, 4)[:, None] * 4 + tl.arange(0, 4)[None, :], addresses)
+
+
+@pytest.mark.parametrize("act", [False, True])
+@pytest.mark.parametrize("index_type", [tl.int32, tl.int64])
+def test_scale_store_ptr_large_offset(act, index_type, device):
+    base = torch.empty(1, dtype=torch.uint8, device=device)
+    origins = torch.tensor([0, 1, 1, 0], dtype=torch.int32, device=device)
+    addresses = torch.empty((4, 4), dtype=torch.int64, device=device)
+
+    _scale_store_addresses[(1, )](base, origins, addresses, act, index_type)
+
+    outer = origins.cpu().long() * (2**31 - 512) + torch.arange(4) * 16
+    expected = outer[:, None] + 512 + torch.arange(4)[None, :]
+    assert torch.equal(addresses.cpu(), expected if act else expected.mT)

--- a/python/triton_kernels/tests/test_tensor_details/test_layout_blackwell.py
+++ b/python/triton_kernels/tests/test_tensor_details/test_layout_blackwell.py
@@ -720,3 +720,17 @@ def test_scale_ptr_gather_column(device):
     _gather_scale_column[(1, )](packed, rows, gathered, packed.stride()[1:])
 
     assert torch.equal(gathered, data[rows, 0])
+
+
+@triton.jit
+def _scale_ptr_offset(S, Out, outer, inner):
+    # Two int32 stride products sum to 2**31; inspect the pointer without loading it.
+    ptr = blackwell_scale.swizzle_mx_scale_bw_ptr(S, outer, inner, 0, 2**31 - 1024, 512, 256, 1, INDEX_TYPE=tl.int32)
+    tl.store(Out, ptr.to(tl.int64) - S.to(tl.int64))
+
+
+def test_scale_ptr_large_offset(device):
+    base = torch.empty(1, dtype=torch.uint8, device=device)
+    offset = torch.empty((), dtype=torch.int64, device=device)
+    _scale_ptr_offset[(1, )](base, offset, 128, 8)
+    assert offset.item() == 2**31

--- a/python/triton_kernels/tests/test_tensor_details/test_layout_blackwell.py
+++ b/python/triton_kernels/tests/test_tensor_details/test_layout_blackwell.py
@@ -704,25 +704,19 @@ def test_scale_convert_layout_fake(layout, monkeypatch):
 
 
 @triton.jit
-def _gather_scale(S, Rows, Cols, Out, STRIDES: tl.constexpr):
+def _gather_scale_column(S, Rows, Out, STRIDES: tl.constexpr):
     i = tl.arange(0, 4)
     rows = tl.load(Rows + i)
-    cols = tl.load(Cols + i)
-    ptrs = blackwell_scale.swizzle_mx_scale_bw_ptr(S, cols, rows, 0, *STRIDES)
-    tl.store(Out + i, tl.load(ptrs))
     ptrs = blackwell_scale.swizzle_mx_scale_bw_ptr(S, 0, rows, 0, *STRIDES)
-    tl.store(Out + 4 + i, tl.load(ptrs))
-    ptrs = blackwell_scale.swizzle_mx_scale_bw_ptr(S, cols, 0, 0, *STRIDES)
-    tl.store(Out + 8 + i, tl.load(ptrs))
+    tl.store(Out + i, tl.load(ptrs))
 
 
-def test_scale_ptr_gather(device):
-    data = torch.arange(9 * 130, device=device).reshape(9, 130).to(torch.uint8)
+def test_scale_ptr_gather_column(device):
+    data = torch.arange(9 * 8, device=device).reshape(9, 8).to(torch.uint8)
     packed = convert_layout(wrap_torch_tensor(data), BlackwellMXScaleLayout()).data
-    rows, cols = torch.tensor([[8, 0, 5, 2], [129, 31, 64, 0]], device=device)
-    gathered = torch.empty((3, 4), dtype=torch.uint8, device=device)
+    rows = torch.tensor([8, 0, 5, 2], device=device)
+    gathered = torch.empty(4, dtype=torch.uint8, device=device)
 
-    _gather_scale[(1, )](packed, rows, cols, gathered, packed.stride()[1:])
+    _gather_scale_column[(1, )](packed, rows, gathered, packed.stride()[1:])
 
-    expected = torch.stack((data[rows, cols], data[rows, 0], data[0, cols]))
-    assert torch.equal(gathered, expected)
+    assert torch.equal(gathered, data[rows, 0])

--- a/python/triton_kernels/tests/test_tensor_details/test_layout_hopper.py
+++ b/python/triton_kernels/tests/test_tensor_details/test_layout_hopper.py
@@ -4,7 +4,8 @@ from triton_kernels.tensor import wrap_torch_tensor, convert_layout, empty, FP4
 from triton_kernels.tensor_details.layout import HopperMXScaleLayout, HopperMXValueLayout, StridedLayout
 from triton_kernels.numerics_details.mxfp import downcast_to_mxfp, upcast_from_mxfp
 from triton_kernels.tensor_details.layout_details.hopper_value import mxfp4_to_bf16_triton
-from triton_kernels.tensor_details.layout_details.hopper_scale import swizzle_mx_scale_hopper_ptr, unswizzle_mxfp4_scale_hopper
+from triton_kernels.tensor_details.layout_details import hopper_scale
+from triton_kernels.tensor_details.layout_details.hopper_scale import unswizzle_mxfp4_scale_hopper
 from triton_kernels.target_info import cuda_capability_geq
 import triton.language as tl
 import triton
@@ -352,63 +353,28 @@ def test_mxfp4_scale_zero_sized_roundtrip(shape, mx_axis, num_warps, device):
 
 
 @triton.jit
-def _pack_scale_with_ptr(X, S, OUTER: tl.constexpr, INNER: tl.constexpr, S_STRIDES: tl.constexpr,
-                         LAYOUT_WARPS: tl.constexpr, INDEX_TYPE: tl.constexpr):
-    batch = tl.program_id(0)
-    outer = tl.program_id(1) * (32 * LAYOUT_WARPS) + tl.arange(0, 32 * LAYOUT_WARPS)
-    inner = tl.program_id(2) * 8 + tl.arange(0, 8)
-    mask = (outer[:, None] < OUTER) & (inner[None, :] < INNER)
-    values = tl.load(X + (batch * OUTER + outer[:, None]) * INNER + inner[None, :], mask, other=0)
-    pointers = swizzle_mx_scale_hopper_ptr(S + batch * S_STRIDES[0], outer[:, None], inner[None, :], *S_STRIDES[1:],
-                                           LAYOUT_WARPS, INDEX_TYPE)
-    tl.store(pointers, values, mask)
+def _gather_scale(S, Rows, Cols, Out, STRIDES: tl.constexpr):
+    i = tl.arange(0, 4)
+    rows = tl.load(Rows + i)
+    cols = tl.load(Cols + i)
+    ptrs = hopper_scale.swizzle_mx_scale_hopper_ptr(S, rows, cols, *STRIDES, 4)
+    tl.store(Out + i, tl.load(ptrs))
+    ptrs = hopper_scale.swizzle_mx_scale_hopper_ptr(S, 0, cols, *STRIDES, 4)
+    tl.store(Out + 4 + i, tl.load(ptrs))
+    ptrs = hopper_scale.swizzle_mx_scale_hopper_ptr(S, rows, 0, *STRIDES, 4)
+    tl.store(Out + 8 + i, tl.load(ptrs))
 
 
-@triton.jit
-def _gather_scale_with_ptr(S, Indices, Out, COUNT: tl.constexpr, OUTER: tl.constexpr, INNER: tl.constexpr,
-                           S_STRIDES: tl.constexpr, LAYOUT_WARPS: tl.constexpr, INDEX_TYPE: tl.constexpr):
-    positions = tl.program_id(0) * 256 + tl.arange(0, 256)
-    indices = tl.load(Indices + positions, positions < COUNT, other=0)
-    batch = indices // (OUTER * INNER)
-    outer, inner = indices // INNER % OUTER, indices % INNER
-    for query in tl.static_range(3):
-        pointers = swizzle_mx_scale_hopper_ptr(S + batch * S_STRIDES[0], 0 if query == 1 else outer,
-                                               0 if query == 2 else inner, *S_STRIDES[1:], LAYOUT_WARPS, INDEX_TYPE)
-        values = tl.load(pointers, positions < COUNT, other=0)
-        tl.store(Out + query * COUNT + positions, values, positions < COUNT)
+def test_scale_ptr_gather(device):
+    data = torch.arange(131 * 9, device=device).reshape(131, 9).to(torch.uint8)
+    packed = convert_layout(wrap_torch_tensor(data), HopperMXScaleLayout(-1, 4)).data
+    rows, cols = torch.tensor([[130, 0, 65, 31], [8, 1, 5, 0]], device=device)
+    gathered = torch.empty((3, 4), dtype=torch.uint8, device=device)
 
+    _gather_scale[(1, )](packed, rows, cols, gathered, packed.stride())
 
-@pytest.mark.parametrize("mx_axis", [-2, -1])
-@pytest.mark.parametrize("num_warps", [4, 8])
-@pytest.mark.parametrize("step", [1, 2])
-@pytest.mark.parametrize("index_type", [tl.int32, tl.int64])
-def test_scale_addressing_pack_and_gather(mx_axis, num_warps, step, index_type, device):
-    batch, outer, inner = 2, 32 * num_warps + 3, 9
-    data = torch.randint(0, 256, (batch, outer, inner), dtype=torch.uint8, generator=torch.Generator().manual_seed(0))
-    logical = data.mT if mx_axis == -2 else data
-    layout = HopperMXScaleLayout(mx_axis, num_warps)
-    expected = layout.make_transformation(list(logical.shape), False).swizzle_data(logical)
-    storage = torch.full((expected.numel() * step + 2, ), 0xAB, dtype=torch.uint8, device=device)
-    packed = storage[1:-1].as_strided(expected.shape, tuple(s * step for s in expected.stride()))
-    packed.zero_()
-    strides = (packed.mT if mx_axis == -2 else packed).stride()
-
-    pack_grid = (batch, triton.cdiv(outer, 32 * num_warps), triton.cdiv(inner, 8))
-    _pack_scale_with_ptr[pack_grid](data.to(device), packed, outer, inner, strides, num_warps, index_type)
-
-    assert torch.equal(packed.cpu(), expected)
-    assert storage[0].item() == storage[-1].item() == 0xAB
-    if step == 2:
-        assert torch.all(storage[2:-1:2] == 0xAB)
-
-    indices = torch.randperm(data.numel(), generator=torch.Generator().manual_seed(1))
-    gathered = torch.empty((3, indices.numel()), dtype=torch.uint8, device=device)
-    gather_grid = (triton.cdiv(indices.numel(), 256), )
-    _gather_scale_with_ptr[gather_grid](packed, indices.to(device), gathered, indices.numel(), outer, inner, strides,
-                                        num_warps, index_type)
-
-    b, i, j = torch.unravel_index(indices, data.shape)
-    assert torch.equal(gathered.cpu(), torch.stack((data.reshape(-1)[indices], data[b, 0, j], data[b, i, 0])))
+    expected = torch.stack((data[rows, cols], data[0, cols], data[rows, 0]))
+    assert torch.equal(gathered, expected)
 
 
 # ------------------ upcast mxfp4 to bf16 --------------------

--- a/python/triton_kernels/tests/test_tensor_details/test_layout_hopper.py
+++ b/python/triton_kernels/tests/test_tensor_details/test_layout_hopper.py
@@ -4,7 +4,7 @@ from triton_kernels.tensor import wrap_torch_tensor, convert_layout, empty, FP4
 from triton_kernels.tensor_details.layout import HopperMXScaleLayout, HopperMXValueLayout, StridedLayout
 from triton_kernels.numerics_details.mxfp import downcast_to_mxfp, upcast_from_mxfp
 from triton_kernels.tensor_details.layout_details.hopper_value import mxfp4_to_bf16_triton
-from triton_kernels.tensor_details.layout_details.hopper_scale import unswizzle_mxfp4_scale_hopper
+from triton_kernels.tensor_details.layout_details.hopper_scale import swizzle_mx_scale_hopper_ptr, unswizzle_mxfp4_scale_hopper
 from triton_kernels.target_info import cuda_capability_geq
 import triton.language as tl
 import triton
@@ -349,6 +349,67 @@ def test_mxfp4_scale_zero_sized_roundtrip(shape, mx_axis, num_warps, device):
 # ------------------------------------------------------------
 # Triton tests
 # ------------------------------------------------------------
+
+
+@triton.jit
+def _pack_scale_with_ptr(X, S, OUTER: tl.constexpr, INNER: tl.constexpr, S_STRIDES: tl.constexpr,
+                         LAYOUT_WARPS: tl.constexpr, INDEX_TYPE: tl.constexpr):
+    batch = tl.program_id(0)
+    outer = tl.program_id(1) * (32 * LAYOUT_WARPS) + tl.arange(0, 32 * LAYOUT_WARPS)
+    inner = tl.program_id(2) * 8 + tl.arange(0, 8)
+    mask = (outer[:, None] < OUTER) & (inner[None, :] < INNER)
+    values = tl.load(X + (batch * OUTER + outer[:, None]) * INNER + inner[None, :], mask, other=0)
+    pointers = swizzle_mx_scale_hopper_ptr(S + batch * S_STRIDES[0], outer[:, None], inner[None, :], *S_STRIDES[1:],
+                                           LAYOUT_WARPS, INDEX_TYPE)
+    tl.store(pointers, values, mask)
+
+
+@triton.jit
+def _gather_scale_with_ptr(S, Indices, Out, COUNT: tl.constexpr, OUTER: tl.constexpr, INNER: tl.constexpr,
+                           S_STRIDES: tl.constexpr, LAYOUT_WARPS: tl.constexpr, INDEX_TYPE: tl.constexpr):
+    positions = tl.program_id(0) * 256 + tl.arange(0, 256)
+    indices = tl.load(Indices + positions, positions < COUNT, other=0)
+    batch = indices // (OUTER * INNER)
+    outer, inner = indices // INNER % OUTER, indices % INNER
+    for query in tl.static_range(3):
+        pointers = swizzle_mx_scale_hopper_ptr(S + batch * S_STRIDES[0], 0 if query == 1 else outer,
+                                               0 if query == 2 else inner, *S_STRIDES[1:], LAYOUT_WARPS, INDEX_TYPE)
+        values = tl.load(pointers, positions < COUNT, other=0)
+        tl.store(Out + query * COUNT + positions, values, positions < COUNT)
+
+
+@pytest.mark.parametrize("mx_axis", [-2, -1])
+@pytest.mark.parametrize("num_warps", [4, 8])
+@pytest.mark.parametrize("step", [1, 2])
+@pytest.mark.parametrize("index_type", [tl.int32, tl.int64])
+def test_scale_addressing_pack_and_gather(mx_axis, num_warps, step, index_type, device):
+    batch, outer, inner = 2, 32 * num_warps + 3, 9
+    data = torch.randint(0, 256, (batch, outer, inner), dtype=torch.uint8, generator=torch.Generator().manual_seed(0))
+    logical = data.mT if mx_axis == -2 else data
+    layout = HopperMXScaleLayout(mx_axis, num_warps)
+    expected = layout.make_transformation(list(logical.shape), False).swizzle_data(logical)
+    storage = torch.full((expected.numel() * step + 2, ), 0xAB, dtype=torch.uint8, device=device)
+    packed = storage[1:-1].as_strided(expected.shape, tuple(s * step for s in expected.stride()))
+    packed.zero_()
+    strides = (packed.mT if mx_axis == -2 else packed).stride()
+
+    pack_grid = (batch, triton.cdiv(outer, 32 * num_warps), triton.cdiv(inner, 8))
+    _pack_scale_with_ptr[pack_grid](data.to(device), packed, outer, inner, strides, num_warps, index_type)
+
+    assert torch.equal(packed.cpu(), expected)
+    assert storage[0].item() == storage[-1].item() == 0xAB
+    if step == 2:
+        assert torch.all(storage[2:-1:2] == 0xAB)
+
+    indices = torch.randperm(data.numel(), generator=torch.Generator().manual_seed(1))
+    gathered = torch.empty((3, indices.numel()), dtype=torch.uint8, device=device)
+    gather_grid = (triton.cdiv(indices.numel(), 256), )
+    _gather_scale_with_ptr[gather_grid](packed, indices.to(device), gathered, indices.numel(), outer, inner, strides,
+                                        num_warps, index_type)
+
+    b, i, j = torch.unravel_index(indices, data.shape)
+    assert torch.equal(gathered.cpu(), torch.stack((data.reshape(-1)[indices], data[b, 0, j], data[b, i, 0])))
+
 
 # ------------------ upcast mxfp4 to bf16 --------------------
 

--- a/python/triton_kernels/tests/test_tensor_details/test_layout_hopper.py
+++ b/python/triton_kernels/tests/test_tensor_details/test_layout_hopper.py
@@ -359,22 +359,17 @@ def _gather_scale(S, Rows, Cols, Out, STRIDES: tl.constexpr):
     cols = tl.load(Cols + i)
     ptrs = hopper_scale.swizzle_mx_scale_hopper_ptr(S, rows, cols, *STRIDES, 4)
     tl.store(Out + i, tl.load(ptrs))
-    ptrs = hopper_scale.swizzle_mx_scale_hopper_ptr(S, 0, cols, *STRIDES, 4)
-    tl.store(Out + 4 + i, tl.load(ptrs))
-    ptrs = hopper_scale.swizzle_mx_scale_hopper_ptr(S, rows, 0, *STRIDES, 4)
-    tl.store(Out + 8 + i, tl.load(ptrs))
 
 
 def test_scale_ptr_gather(device):
     data = torch.arange(131 * 9, device=device).reshape(131, 9).to(torch.uint8)
     packed = convert_layout(wrap_torch_tensor(data), HopperMXScaleLayout(-1, 4)).data
     rows, cols = torch.tensor([[130, 0, 65, 31], [8, 1, 5, 0]], device=device)
-    gathered = torch.empty((3, 4), dtype=torch.uint8, device=device)
+    gathered = torch.empty(4, dtype=torch.uint8, device=device)
 
     _gather_scale[(1, )](packed, rows, cols, gathered, packed.stride())
 
-    expected = torch.stack((data[rows, cols], data[0, cols], data[rows, 0]))
-    assert torch.equal(gathered, expected)
+    assert torch.equal(gathered, data[rows, cols])
 
 
 # ------------------ upcast mxfp4 to bf16 --------------------

--- a/python/triton_kernels/triton_kernels/tensor_details/layout_details/blackwell_scale.py
+++ b/python/triton_kernels/triton_kernels/tensor_details/layout_details/blackwell_scale.py
@@ -543,6 +543,8 @@ def swizzle_mx_scale_bw_ptr(base, outer, inner, leading_block, stride_outer, str
     Strides are in elements. Each stride product uses ``INDEX_TYPE`` before
     being added to the pointer.
     """
+    outer = tl.to_tensor(outer)
+    inner = tl.to_tensor(inner)
     outer_block = leading_block + outer // SIZE_OUTER
     inner_group = inner // SIZE_INNER
     outer_lane = outer % SIZE_OUTER

--- a/python/triton_kernels/triton_kernels/tensor_details/layout_details/blackwell_scale.py
+++ b/python/triton_kernels/triton_kernels/tensor_details/layout_details/blackwell_scale.py
@@ -532,24 +532,37 @@ def unswizzle_act_mx_scale_bw(
 
 
 @triton.jit
+def swizzle_mx_scale_bw_ptr(base, outer, inner, leading_block, stride_outer, stride_inner, stride_half, stride_lane,
+                            SIZE_OUTER: tl.constexpr = SWIZZLE_SIZE_OUTER,
+                            SIZE_INNER: tl.constexpr = SWIZZLE_SIZE_INNER, SIZE_LANE: tl.constexpr = SWIZZLE_SIZE_LANE,
+                            SIZE_HALF: tl.constexpr = SWIZZLE_SIZE_HALF, INDEX_TYPE: tl.constexpr = tl.int64):
+    """Pointers for broadcastable scale coordinates, without bounds masking.
+
+    ``outer`` indexes the non-MX axis; ``inner`` indexes scales along the MX axis.
+    ``leading_block`` is the batch or segment origin in outer storage tiles.
+    Strides are in elements. Each stride product uses ``INDEX_TYPE`` before
+    being added to the pointer.
+    """
+    outer_block = leading_block + outer // SIZE_OUTER
+    inner_group = inner // SIZE_INNER
+    outer_lane = outer % SIZE_OUTER
+    inner_linear = ((outer_lane % SIZE_LANE * (SIZE_OUTER // SIZE_LANE) + outer_lane // SIZE_LANE) * SIZE_INNER +
+                    inner % SIZE_INNER)
+    half = inner_linear // SIZE_HALF
+    lane = inner_linear % SIZE_HALF
+    return (base + tl.cast(outer_block, INDEX_TYPE) * stride_outer + tl.cast(inner_group, INDEX_TYPE) * stride_inner +
+            tl.cast(half, INDEX_TYPE) * stride_half + tl.cast(lane, INDEX_TYPE) * stride_lane)
+
+
+@triton.jit
 def swizzle_mx_scale_bw_store_ptr(base, rows, cols, leading_idx, n_cols, stride_outer, stride_inner, stride_half,
                                   stride_lane, SIZE_OUTER: tl.constexpr = SWIZZLE_SIZE_OUTER,
                                   SIZE_INNER: tl.constexpr = SWIZZLE_SIZE_INNER,
                                   SIZE_LANE: tl.constexpr = SWIZZLE_SIZE_LANE,
                                   SIZE_HALF: tl.constexpr = SWIZZLE_SIZE_HALF, INDEX_TYPE: tl.constexpr = tl.int64):
-    col_block = cols // SIZE_OUTER
-    outer = leading_idx * tl.cdiv(n_cols, SIZE_OUTER) + col_block
-    inner_group = rows // SIZE_INNER
-    col_lane = cols - col_block * SIZE_OUTER
-    col_quad = col_lane // SIZE_LANE
-    col_lane_inner = col_lane - col_quad * SIZE_LANE
-    row_lane = rows - inner_group * SIZE_INNER
-    inner_linear = ((col_lane_inner[None, :] * (SIZE_OUTER // SIZE_LANE) + col_quad[None, :]) * SIZE_INNER +
-                    row_lane[:, None])
-    half = inner_linear // SIZE_HALF
-    inner = inner_linear - half * SIZE_HALF
-    return (base + outer.to(INDEX_TYPE)[None, :] * stride_outer + inner_group.to(INDEX_TYPE)[:, None] * stride_inner +
-            half.to(INDEX_TYPE) * stride_half + inner.to(INDEX_TYPE) * stride_lane)
+    return swizzle_mx_scale_bw_ptr(base, cols[None, :], rows[:, None], leading_idx * tl.cdiv(n_cols, SIZE_OUTER),
+                                   stride_outer, stride_inner, stride_half, stride_lane, SIZE_OUTER, SIZE_INNER,
+                                   SIZE_LANE, SIZE_HALF, INDEX_TYPE)
 
 
 @triton.jit
@@ -639,16 +652,7 @@ def swizzle_act_mx_scale_bw_store_ptr(base, rows, cols, leading_m_block, stride_
                                       SIZE_INNER: tl.constexpr = SWIZZLE_SIZE_INNER,
                                       SIZE_LANE: tl.constexpr = SWIZZLE_SIZE_LANE,
                                       SIZE_HALF: tl.constexpr = SWIZZLE_SIZE_HALF, INDEX_TYPE: tl.constexpr = tl.int64):
-    row_block = rows // SIZE_OUTER
-    outer = leading_m_block + row_block
-    inner_group = cols // SIZE_INNER
-    col_lane = cols - inner_group * SIZE_INNER
-    row_lane = rows - row_block * SIZE_OUTER
-    row_quad = row_lane // SIZE_LANE
-    row_lane_inner = row_lane - row_quad * SIZE_LANE
-    inner_linear = ((row_lane_inner[:, None] * (SIZE_OUTER // SIZE_LANE) + row_quad[:, None]) * SIZE_INNER +
-                    col_lane[None, :])
-    half = inner_linear // SIZE_HALF
-    inner = inner_linear - half * SIZE_HALF
-    return (base + outer.to(INDEX_TYPE)[:, None] * stride_outer + inner_group.to(INDEX_TYPE)[None, :] * stride_inner +
-            half.to(INDEX_TYPE) * stride_half + inner.to(INDEX_TYPE) * stride_lane)
+    leading_m_block = tl.broadcast_to(tl.to_tensor(leading_m_block), rows.shape)
+    return swizzle_mx_scale_bw_ptr(base, rows[:, None], cols[None, :], leading_m_block[:, None], stride_outer,
+                                   stride_inner, stride_half, stride_lane, SIZE_OUTER, SIZE_INNER, SIZE_LANE, SIZE_HALF,
+                                   INDEX_TYPE)

--- a/python/triton_kernels/triton_kernels/tensor_details/layout_details/hopper_scale.py
+++ b/python/triton_kernels/triton_kernels/tensor_details/layout_details/hopper_scale.py
@@ -148,6 +148,21 @@ class HopperMXScaleLayoutTransformation(ScaleLayoutTransformation):
 
 
 @triton.jit
+def swizzle_mx_scale_hopper_ptr(base, outer, inner, stride_outer, stride_inner, num_warps: tl.constexpr,
+                                INDEX_TYPE: tl.constexpr = tl.int64):
+    """Pointers for broadcastable scale coordinates, without bounds masking.
+
+    ``outer`` indexes the non-MX axis; ``inner`` indexes scales along the MX axis.
+    Strides are in elements, in physical outer/inner order. ``base`` points to
+    the batch origin. Each stride product uses ``INDEX_TYPE`` before being
+    added to the pointer.
+    """
+    outer_block = outer // (32 * num_warps) * num_warps + outer // 16 % num_warps
+    inner_lane = (inner // 2 * 64 + outer // (16 * num_warps) % 2 * 32 + outer % 8 * 4 + inner % 2 * 2 + outer // 8 % 2)
+    return base + tl.cast(outer_block, INDEX_TYPE) * stride_outer + tl.cast(inner_lane, INDEX_TYPE) * stride_inner
+
+
+@triton.jit
 def unswizzle_mxfp4_scale_hopper(x, mx_axis: tl.constexpr, num_warps: tl.constexpr):
     """
     Triton inverse of swizzle_mxfp4_scale_hopper


### PR DESCRIPTION
Let Triton kernels load or store selected MX scales directly in packed Blackwell and Hopper storage. The new pointer helpers accept scalar, paired, or broadcast coordinates, so callers can express operations like `scales[rows, cols]` without duplicating the packing arithmetic. Existing Blackwell tile helpers reuse the same address calculation.

Returning pointers preserves 64-bit accumulation when individual index terms fit in `int32` but their sum does not.

Import the layout helpers, then use them inside a `@triton.jit` kernel to read a column from Blackwell scales or paired coordinates from Hopper scales:

```python
import triton.language as tl
from triton_kernels.tensor_details.layout_details import blackwell_scale, hopper_scale

# Inside the kernel:
# Blackwell: logical scales[rows, 0].
ptrs = blackwell_scale.swizzle_mx_scale_bw_ptr(BWScales, 0, rows, 0, *bw_strides)
column = tl.load(ptrs)

# Hopper: logical scales[rows, cols], with the four-warp scale layout.
ptrs = hopper_scale.swizzle_mx_scale_hopper_ptr(HopperScales, rows, cols, *hopper_strides, 4)
selected = tl.load(ptrs)
```

The inputs are already packed with `convert_layout`. For `BlackwellMXScaleLayout`, `bw_strides` is `packed.stride()[1:]`; for `HopperMXScaleLayout(-1, 4)`, `hopper_strides` is `packed.stride()`. Each result has the broadcast shape of its coordinates. These helper names are absent on `main`. Literal coordinates also work in the interpreter.

| Files | Added | Removed | Net |
| --- | ---: | ---: | ---: |
| Tests | +58 | -0 | +58 |
| Non-tests | +47 | -26 | +21 |
| All | +105 | -26 | +79 |

## Reviewer's guide

- `python/triton_kernels/triton_kernels/tensor_details/layout_details`: add the coordinate-based pointer primitives and share Blackwell address calculation with the existing tile helpers.
- `python/triton_kernels/tests/test_tensor_details`: demonstrate paired and literal-coordinate gathers, and preserve large pointer offsets with 32-bit index terms.

<!-- codex-thread: 01a0780a-af95-7c80-90ad-5ad47b8d9bb1 -->
