### PR TITLE
[TRITONGPU] Fix loop fusion with duplicate epilogue outputs

### DIFF
--- a/lib/Dialect/TritonGPU/Transforms/FuseNestedLoops.cpp
+++ b/lib/Dialect/TritonGPU/Transforms/FuseNestedLoops.cpp
@@ -883,33 +883,36 @@ static void fuseOneLevel(LoopNestNode *parent, mlir::DominanceInfo &domInfo) {
   //   epilogue(i)
   Logue &epilogue = logues.back();
 
-  // The only possible use of an epilogue output is the yield.
+  // The only external uses of epilogue outputs are in the outer yield.
+  auto epilogueOutputs = epilogue.getOutputs();
   auto outerYield = cast<scf::YieldOp>(outer.getBody()->getTerminator());
-  SmallVector<Value> usedIterArgs;
-  for (Value output : epilogue.getOutputs()) {
-    for (OpOperand &use : output.getUses()) {
-      if (use.getOwner() == outerYield) {
-        usedIterArgs.push_back(fused.getRegionIterArgs().drop_front(
-            outerArgsStartIdx)[use.getOperandNumber()]);
-      }
-    }
+
+  SmallVector<unsigned> positions;
+  SmallVector<Value> thenValues, elseValues;
+  for (auto [pos, value] : llvm::enumerate(outerYield.getOperands())) {
+    if (!llvm::is_contained(epilogueOutputs, value))
+      continue;
+    positions.push_back(pos);
+    thenValues.push_back(value);
+    elseValues.push_back(fused.getRegionIterArg(outerArgsStartIdx + pos));
   }
 
   auto epilogueCond =
       arith::CmpIOp::create(b, arith::CmpIPredicate::eq, T,
                             arith::SubIOp::create(b, innerLen, intTyCst(1)));
   auto epilogueIf =
-      scf::IfOp::create(b, epilogue.getOutputTypes(), epilogueCond);
+      scf::IfOp::create(b, ValueRange(thenValues).getTypes(), epilogueCond);
 
   Block *thenBlock = b.createBlock(&epilogueIf.getThenRegion());
   epilogue.moveBefore(thenBlock, thenBlock->end());
 
   b.setInsertionPointToEnd(thenBlock);
-  scf::YieldOp::create(b, epilogue.getOutputs());
+  scf::YieldOp::create(b, thenValues);
   b.createBlock(&epilogueIf.getElseRegion());
-  scf::YieldOp::create(b, usedIterArgs);
-  epilogue.replaceAllUsesWith(epilogueIf.getResults(),
-                              epilogueIf.getThenRegion());
+  scf::YieldOp::create(b, elseValues);
+  for (auto [result, position] :
+       llvm::zip_equal(epilogueIf.getResults(), positions))
+    outerYield->setOperand(position, result);
 
   // T = 0 if T == (inner_len - 1) else T + 1
   b.setInsertionPointToEnd(fused.getBody());

--- a/test/TritonGPU/fuse-nested-loops.mlir
+++ b/test/TritonGPU/fuse-nested-loops.mlir
@@ -5,6 +5,25 @@ tt.func @empty_function() {
   tt.return
 }
 
+// CHECK-LABEL: @duplicate_epilogue_outputs
+tt.func @duplicate_epilogue_outputs(%lb: i32, %ub: i32, %step: i32) {
+  %r:2 = scf.for %i = %lb to %ub step %step
+      iter_args(%a = %lb, %b = %ub) -> (i32, i32) : i32 {
+    scf.for %j = %lb to %ub step %step : i32 {
+      "body"() : () -> ()
+    }
+    // CHECK: [[RESULTS:%.*]]:2 = scf.if {{.*}} -> (i32, i32) {
+    // CHECK-NEXT: [[NEXT:%.*]] = "epilogue"([[A:%.*]], [[B:%.*]]) :
+    // CHECK-NEXT: scf.yield [[NEXT]], [[NEXT]] : i32, i32
+    // CHECK-NEXT: } else {
+    // CHECK-NEXT: scf.yield [[A]], [[B]] : i32, i32
+    %next = "epilogue"(%a, %b) : (i32, i32) -> i32
+    // CHECK: scf.yield {{.*}}[[RESULTS]]#0, [[RESULTS]]#1
+    scf.yield %next, %next : i32, i32
+  } {"ttg.always-fuse"}
+  tt.return
+}
+
 // CHECK-LABEL: @no_fusion
 tt.func @no_fusion(%lb: index, %ub: index, %step: index) -> index {
   %c0 = arith.constant 0 : index


### PR DESCRIPTION
<!---
The core Triton is a small number of people, and we receive many PRs (thank
you!).  To help us review your code more quickly, **if you are a new
contributor (less than 3 PRs merged) we ask that you complete the following
tasks and include the filled-out checklist in your PR description.**

Complete the following tasks before sending your PR, and replace `[ ]` with
`[x]` to indicate you have done them.
-->

The old code created an `scf.if` result per distinct epilogue output, but added an `else` operand for every loop-carried user of that of that output. When there are two loop-carried users of the same value, it generated two `else` operands for one result, producing invalid ir.

I updated the code to track the yielded/loop-carried operand positions and create one conditional result for each affected position.

Fixes #11620

<details>
<summary>New contributor declaration</summary>

- [x] I am not making a trivial change, such as fixing a typo in a comment.

- [x] I have written a PR description following these
  [rules](https://cbea.ms/git-commit/#why-not-how).

- [x] I have run `pre-commit run --from-ref origin/main --to-ref HEAD`.

- Select one of the following.
  - [x] I have added tests.
    - `/test` for `lit` tests
    - `/unittest` for C++ tests
    - `/python/test` for end-to-end tests
  - [ ] This PR does not need a test because `FILL THIS IN`.

- Select one of the following.
  - [ ] I have not added any `lit` tests.
  - [x] The `lit` tests I have added follow these [best practices](https://mlir.llvm.org/getting_started/TestingGuide/#filecheck-best-practices),
    including the "tests should be minimal" section. (Usually running Python code
    and using the instructions it generates is not minimal.)
