### PR TITLE
[NVIDIA] row reductions in MMAv2 warp distribution

### DIFF
--- a/lib/Dialect/TritonGPU/Transforms/AccelerateMatmul.cpp
+++ b/lib/Dialect/TritonGPU/Transforms/AccelerateMatmul.cpp
@@ -97,7 +97,28 @@ SmallVector<unsigned> warpsPerTileV2(DotOpInterface dotOp,
   };
   auto slices = mlir::getSlice(dotOp, {filter}, {filter});
   bool hasChainedDot = false;
+  bool hasRowReduction = false;
+  bool hasOtherReduction = false;
+  bool canDistributeRows = shape[0] >= 16 * numWarps;
   for (Operation *op : slices) {
+    if (auto reduce = dyn_cast<ReduceOp>(op)) {
+      SetVector<Operation *> backward, forward;
+      if (failed(getBackwardSlice(op, &backward, {filter}))) {
+        hasOtherReduction = true;
+        continue;
+      }
+      getForwardSlice(op, &forward, {filter});
+      auto isDot = [](Operation *op) { return isa<DotOp, DotScaledOp>(op); };
+      // Only consider reductions on a path between dots, not reductions of
+      // their inputs or reductions used solely by an epilogue.
+      if (llvm::any_of(backward, isDot) && llvm::any_of(forward, isDot)) {
+        auto srcTy = cast<RankedTensorType>(reduce.getSrcs()[0].getType());
+        if (srcTy.getRank() == 2 && reduce.getAxis() == 1)
+          hasRowReduction = true;
+        else
+          hasOtherReduction = true;
+      }
+    }
     if (isa<DotOp, DotScaledOp>(op) && (op != dotOp)) {
       auto resTy = cast<RankedTensorType>(op->getResult(0).getType());
       if (resTy.getRank() != rank) {
@@ -108,9 +129,16 @@ SmallVector<unsigned> warpsPerTileV2(DotOpInterface dotOp,
         return to_vector(mmaEncoding.getWarpsPerCTA());
       }
       hasChainedDot = true;
+      canDistributeRows &= resTy.getShape()[0] >= 16 * numWarps;
     }
   }
   if (hasChainedDot) {
+    // Keep row reductions, such as the softmax between attention's dots,
+    // within a warp. Each MMA v2 warp covers 16 rows, so only do this when
+    // all dots have enough rows to avoid replicating work across warps.
+    // Reusing an existing MMA encoding above keeps the whole chain consistent.
+    if (hasRowReduction && !hasOtherReduction && canDistributeRows)
+      return {(unsigned)numWarps, 1};
     if (shape[0] >= shape[1]) {
       return {(unsigned)numWarps, 1};
     } else {

--- a/python/test/unit/language/test_core.py
+++ b/python/test/unit/language/test_core.py
@@ -4640,6 +4640,35 @@ def test_dot3d(B, num_warps, M, N, K, BLOCK_M, BLOCK_N, in_dtype_str, out_dtype_
     np.testing.assert_allclose(out_ref, to_numpy(out_tri), rtol=0.01, atol=1e-2)
 
 
+@pytest.mark.parametrize("rows, head_dim, num_warps", [(64, 128, 4), (64, 128, 8), (128, 256, 8), (64, 256, 4)])
+def test_dot_row_reduction_chained(rows, head_dim, num_warps, device):
+
+    @triton.jit
+    def kernel(Q, K, V, O, M: tl.constexpr, D: tl.constexpr):
+        m = tl.arange(0, M)
+        n = tl.arange(0, 64)
+        d = tl.arange(0, D)
+        q = tl.load(Q + m[:, None] * D + d[None, :])
+        k = tl.load(K + n[None, :] * D + d[:, None])
+        scores = tl.dot(q, k) * (D**-0.5)
+        p = tl.exp(scores - tl.max(scores, 1)[:, None])
+        p = p / tl.sum(p, 1)[:, None]
+        v = tl.load(V + n[:, None] * D + d[None, :])
+        out = tl.dot(p.to(v.dtype), v)
+        tl.store(O + m[:, None] * D + d[None, :], out)
+
+    torch.manual_seed(0)
+    q = torch.randn((rows, head_dim), device=device, dtype=torch.float16)
+    k, v = [torch.randn((64, head_dim), device=device, dtype=torch.float16) for _ in range(2)]
+    out = torch.empty_like(q)
+    kernel[(1, )](q, k, v, out, rows, head_dim, num_warps=num_warps)
+    if is_compile_warmup():
+        return
+    scores = (q.float() @ k.float().T) * (head_dim**-0.5)
+    expected = (scores.softmax(-1) @ v.float()).half()
+    torch.testing.assert_close(out, expected, atol=2e-3, rtol=2e-3)
+
+
 @pytest.mark.parametrize('in_dtype', ['float32'])
 def test_dot_mulbroadcasted(in_dtype, device):
     if is_cuda():

--- a/test/TritonGPU/accelerate-matmul.mlir
+++ b/test/TritonGPU/accelerate-matmul.mlir
@@ -1168,3 +1168,65 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.targ
     tt.return %0 : tensor<128x256xf32, #blocked>
   }
 }
+
+// -----
+
+// Distribute rows only when every warp gets distinct MMA rows.
+// CHECK: #[[$MMA:.+]] = #ttg.nvidia_mma<{versionMajor = 2, versionMinor = 0, warpsPerCTA = [4, 1], instrShape = [16, 8]}>
+#blocked = #ttg.blocked<{sizePerThread = [1, 4], threadsPerWarp = [4, 8], warpsPerCTA = [4, 1], order = [1, 0]}>
+module attributes {"ttg.target" = "cuda:120", "ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, "ttg.threads-per-warp" = 32 : i32} {
+  // CHECK-LABEL: @chained_dot_row_reduction
+  tt.func @chained_dot_row_reduction(
+      %a: tensor<64x32xf16, #ttg.dot_op<{opIdx = 0, parent = #blocked}>>,
+      %b: tensor<32x64xf16, #ttg.dot_op<{opIdx = 1, parent = #blocked}>>,
+      %v: tensor<64x128xf16, #ttg.dot_op<{opIdx = 1, parent = #blocked}>>) -> tensor<64x128xf32, #blocked> {
+    %zero_qk = arith.constant dense<0.0> : tensor<64x64xf32, #blocked>
+    %zero_pv = arith.constant dense<0.0> : tensor<64x128xf32, #blocked>
+    // CHECK: tt.dot {{.*}} -> tensor<64x64xf32, #[[$MMA]]>
+    %d = tt.dot %a, %b, %zero_qk : tensor<64x32xf16, #ttg.dot_op<{opIdx = 0, parent = #blocked}>> * tensor<32x64xf16, #ttg.dot_op<{opIdx = 1, parent = #blocked}>> -> tensor<64x64xf32, #blocked>
+    %row = "tt.reduce"(%d) ({
+    ^bb0(%lhs: f32, %rhs: f32):
+      %sum = arith.addf %lhs, %rhs : f32
+      tt.reduce.return %sum : f32
+    }) {axis = 1 : i32} : (tensor<64x64xf32, #blocked>) -> tensor<64xf32, #ttg.slice<{dim = 1, parent = #blocked}>>
+    %row_expand = tt.expand_dims %row {axis = 1 : i32} : tensor<64xf32, #ttg.slice<{dim = 1, parent = #blocked}>> -> tensor<64x1xf32, #blocked>
+    %row_broadcast = tt.broadcast %row_expand : tensor<64x1xf32, #blocked> -> tensor<64x64xf32, #blocked>
+    %normalized = arith.subf %d, %row_broadcast : tensor<64x64xf32, #blocked>
+    %half = arith.truncf %normalized : tensor<64x64xf32, #blocked> to tensor<64x64xf16, #blocked>
+    %p = ttg.convert_layout %half : tensor<64x64xf16, #blocked> -> tensor<64x64xf16, #ttg.dot_op<{opIdx = 0, parent = #blocked}>>
+    // CHECK: tt.dot {{.*}} -> tensor<64x128xf32, #[[$MMA]]>
+    %out = tt.dot %p, %v, %zero_pv : tensor<64x64xf16, #ttg.dot_op<{opIdx = 0, parent = #blocked}>> * tensor<64x128xf16, #ttg.dot_op<{opIdx = 1, parent = #blocked}>> -> tensor<64x128xf32, #blocked>
+    tt.return %out : tensor<64x128xf32, #blocked>
+  }
+}
+
+// -----
+
+// Distribute rows only when every warp gets distinct MMA rows.
+// CHECK: #[[$MMA:.+]] = #ttg.nvidia_mma<{versionMajor = 2, versionMinor = 0, warpsPerCTA = [1, 8], instrShape = [16, 8]}>
+#blocked = #ttg.blocked<{sizePerThread = [1, 4], threadsPerWarp = [4, 8], warpsPerCTA = [8, 1], order = [1, 0]}>
+module attributes {"ttg.target" = "cuda:120", "ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 8 : i32, "ttg.threads-per-warp" = 32 : i32} {
+  // CHECK-LABEL: @chained_dot_row_reduction_replicated_warps
+  tt.func @chained_dot_row_reduction_replicated_warps(
+      %a: tensor<64x32xf16, #ttg.dot_op<{opIdx = 0, parent = #blocked}>>,
+      %b: tensor<32x64xf16, #ttg.dot_op<{opIdx = 1, parent = #blocked}>>,
+      %v: tensor<64x128xf16, #ttg.dot_op<{opIdx = 1, parent = #blocked}>>) -> tensor<64x128xf32, #blocked> {
+    %zero_qk = arith.constant dense<0.0> : tensor<64x64xf32, #blocked>
+    %zero_pv = arith.constant dense<0.0> : tensor<64x128xf32, #blocked>
+    // CHECK: tt.dot {{.*}} -> tensor<64x64xf32, #[[$MMA]]>
+    %d = tt.dot %a, %b, %zero_qk : tensor<64x32xf16, #ttg.dot_op<{opIdx = 0, parent = #blocked}>> * tensor<32x64xf16, #ttg.dot_op<{opIdx = 1, parent = #blocked}>> -> tensor<64x64xf32, #blocked>
+    %row = "tt.reduce"(%d) ({
+    ^bb0(%lhs: f32, %rhs: f32):
+      %sum = arith.addf %lhs, %rhs : f32
+      tt.reduce.return %sum : f32
+    }) {axis = 1 : i32} : (tensor<64x64xf32, #blocked>) -> tensor<64xf32, #ttg.slice<{dim = 1, parent = #blocked}>>
+    %row_expand = tt.expand_dims %row {axis = 1 : i32} : tensor<64xf32, #ttg.slice<{dim = 1, parent = #blocked}>> -> tensor<64x1xf32, #blocked>
+    %row_broadcast = tt.broadcast %row_expand : tensor<64x1xf32, #blocked> -> tensor<64x64xf32, #blocked>
+    %normalized = arith.subf %d, %row_broadcast : tensor<64x64xf32, #blocked>
+    %half = arith.truncf %normalized : tensor<64x64xf32, #blocked> to tensor<64x64xf16, #blocked>
+    %p = ttg.convert_layout %half : tensor<64x64xf16, #blocked> -> tensor<64x64xf16, #ttg.dot_op<{opIdx = 0, parent = #blocked}>>
+    // CHECK: tt.dot {{.*}} -> tensor<64x128xf32, #[[$MMA]]>
+    %out = tt.dot %p, %v, %zero_pv : tensor<64x64xf16, #ttg.dot_op<{opIdx = 0, parent = #blocked}>> * tensor<64x128xf16, #ttg.dot_op<{opIdx = 1, parent = #blocked}>> -> tensor<64x128xf32, #blocked>
+    tt.return %out : tensor<64x128xf32, #blocked>
+  }
+}


### PR DESCRIPTION
Use row-distributed MMAv2 layouts when a row reduction connects two dots and there are enough rows for all warps. 

Results on python/tutorials/06-fused-attention.py:

| Sequence | Before (us) | After (us) | Speedup |
|---|---:|---:|---:|
| 512 | 22.12 | 18.39 | 1.20x |
| 2048 | 115.03 | 91.44 | 1.26x |
| 4096 | 317.94 | 272.21 | 1.17x |
