### PR TITLE
[TritonGPU] Skip Gluon placeholder encodings in tritongpu-coalesce

### DIFF
--- a/lib/Dialect/TritonGPU/Transforms/CMakeLists.txt
+++ b/lib/Dialect/TritonGPU/Transforms/CMakeLists.txt
@@ -50,6 +50,7 @@ add_triton_library(TritonGPUTransforms
   TritonTransforms
   TritonGPUIR
   TritonNvidiaGPUIR
+  GluonIR
   NVWSIR
   NVWSTransforms
   TritonToTritonGPU

--- a/lib/Dialect/TritonGPU/Transforms/Coalesce.cpp
+++ b/lib/Dialect/TritonGPU/Transforms/Coalesce.cpp
@@ -4,6 +4,7 @@
 #include "mlir/Analysis/SliceAnalysis.h"
 #include "mlir/Support/LLVM.h"
 #include "triton/Analysis/AxisInfo.h"
+#include "triton/Dialect/Gluon/IR/Dialect.h"
 #include "triton/Dialect/Triton/IR/Utility.h"
 #include "triton/Dialect/TritonGPU/IR/Dialect.h"
 #include "triton/Dialect/TritonGPU/Transforms/CoalesceUtils.h"
@@ -22,6 +23,15 @@ namespace gpu {
 
 #define GEN_PASS_DEF_TRITONGPUCOALESCE
 #include "triton/Dialect/TritonGPU/Transforms/Passes.h.inc"
+
+// Gluon placeholder encodings (AutoEncodingAttr, CoalescedEncodingAttr) are not
+// LayoutEncodingTrait and are resolved by their own pipeline
+// (gluon-infer-coalesced-encodings, gluon-resolve-auto-encodings).
+// tritongpu-coalesce must skip them.
+static bool isGluonEncoding(Attribute encoding) {
+  return isa<mlir::triton::gluon::AutoEncodingAttr,
+             mlir::triton::gluon::CoalescedEncodingAttr>(encoding);
+}
 
 // Descriptor load/stores don't need to consider L1 coalescing but the
 // destination layout will affect the shared memory load/store generated. So we
@@ -56,14 +66,18 @@ static void pickDescriptorLoadStoreLayout(
   moduleOp.walk([&](Operation *op) {
     int numWarps = lookupNumWarps(op);
     if (auto load = dyn_cast<DescriptorOpInterface>(op)) {
-      if (load->getNumResults() == 1)
-        layoutMap[op] = pickDescriptorLoadStoreLayout(
-            numWarps, threadsPerWarp,
-            cast<RankedTensorType>(load->getResult(0).getType()));
+      if (load->getNumResults() == 1) {
+        auto resultType = cast<RankedTensorType>(load->getResult(0).getType());
+        if (!isGluonEncoding(resultType.getEncoding()))
+          layoutMap[op] = pickDescriptorLoadStoreLayout(numWarps, threadsPerWarp,
+                                                        resultType);
+      }
     }
     if (auto store = dyn_cast<DescriptorStoreLikeOpInterface>(op)) {
-      layoutMap[op] = pickDescriptorLoadStoreLayout(numWarps, threadsPerWarp,
-                                                    store.getSrc().getType());
+      auto srcType = store.getSrc().getType();
+      if (!isGluonEncoding(srcType.getEncoding()))
+        layoutMap[op] = pickDescriptorLoadStoreLayout(numWarps, threadsPerWarp,
+                                                      srcType);
     }
   });
 }
@@ -96,6 +110,10 @@ struct CoalescePass : public impl::TritonGPUCoalesceBase<CoalescePass> {
       int numWarps = lookupNumWarps(curr);
 
       auto tensorType = cast<RankedTensorType>(ptr.getType());
+      // Skip Gluon placeholder encodings; they are resolved by the Gluon
+      // pipeline (gluon-infer-coalesced-encodings) instead.
+      if (isGluonEncoding(tensorType.getEncoding()))
+        return;
       CGAEncodingAttr cgaLayout = getCGALayout(tensorType.getEncoding());
       SmallVector<int64_t> shapePerCTA = getShapePerCTA(tensorType);
       auto layout =

--- a/test/TritonGPU/coalesce.mlir
+++ b/test/TritonGPU/coalesce.mlir
@@ -312,3 +312,20 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.targ
     tt.return
   }
 }
+
+// -----
+
+// Gluon placeholder encodings (gluon.auto_encoding / gluon.coalesced_encoding)
+// do not implement LayoutEncodingTrait. tritongpu-coalesce must skip them
+// (they are resolved by the Gluon pipeline), not crash in getCGALayout.
+// CHECK-LABEL: @gluon_coalesced_encoding
+module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.target = "cuda:90", "ttg.threads-per-warp" = 32 : i32} {
+  tt.func public @gluon_coalesced_encoding(%arg0: !tt.ptr<f32>, %arg1: !tt.ptr<f32>) {
+    %mask = arith.constant dense<0> : tensor<128x256xi1, #gluon.auto_encoding>
+    %0 = tt.splat %arg0 : !tt.ptr<f32> -> tensor<128x256x!tt.ptr<f32>, #gluon.auto_encoding>
+    %1 = gluon.set_auto_layout %0 : tensor<128x256x!tt.ptr<f32>, #gluon.auto_encoding> -> tensor<128x256x!tt.ptr<f32>, #gluon.coalesced_encoding>
+    %2 = gluon.set_auto_layout %mask : tensor<128x256xi1, #gluon.auto_encoding> -> tensor<128x256xi1, #gluon.coalesced_encoding>
+    %3 = tt.load %1, %2 : tensor<128x256x!tt.ptr<f32>, #gluon.coalesced_encoding>
+    tt.return
+  }
+}


### PR DESCRIPTION
Fixes #11543

## Summary
`tritongpu-coalesce` crashes with `UNREACHABLE executed at .../Dialect.cpp:374`
(a `getCGALayout` call on an unsupported layout) when run on a module that uses
Gluon placeholder encodings produced by `gluon.set_auto_layout`.

The Gluon placeholder encodings (`#gluon.auto_encoding`,
`#gluon.coalesced_encoding`) do not implement `LayoutEncodingTrait`; they are
resolved later by the Gluon pipeline (`gluon-infer-coalesced-encodings` /
`gluon-resolve-auto-encodings`). The `Triton` default backend pipeline runs
`tritongpu-coalesce` before those placeholders are resolved, so the pass must
skip them instead of consulting `getCGALayout`.

## Changes
- `lib/Dialect/TritonGPU/Transforms/Coalesce.cpp`: skip Gluon placeholder
  encodings in `CoalescePass::runOnOperation` and in
  `pickDescriptorLoadStoreLayout` (both `tt.load`/`tt.store` pointer tensors
  and descriptor load/store ops).
- `lib/Dialect/TritonGPU/Transforms/CMakeLists.txt`: link `GluonIR` into
  `TritonGPUTransforms`.
- `test/TritonGPU/coalesce.mlir`: regression test mirroring the issue
  reproducer.

## Verification
Built `triton-opt` locally (macOS, prebuilt LLVM archive) and ran the lit test:
- With the fix: `TritonGPU/coalesce.mlir` passes.
- Without the fix: the same test crashes inside
  `CoalescePass::runOnOperation`, matching the reported stack trace.
- Full `TritonGPU` lit directory: 136/137 pass; the single failure
  (`pipeline-split-cluster-unscheduled-op.mlir`) fails identically on the
  unmodified tree and is unrelated to this change.