### PR TITLE
[ConSan] Track async-copy completion through mbarriers

### DIFF
--- a/include/triton/Dialect/TritonInstrument/IR/FunctionBuilder.h
+++ b/include/triton/Dialect/TritonInstrument/IR/FunctionBuilder.h
@@ -184,6 +184,10 @@ public:
                                             Operation *insertPoint,
                                             Value barrierCTAs,
                                             Value effectCTAs);
+  void createTrackAsyncCopiesForBarrierCall(ImplicitLocOpBuilder &b, Value mbar,
+                                            int thread, Value pred,
+                                            Operation *insertPoint,
+                                            Value barrierCTAs);
   // transferVisibleAccesses: transfer the requested barrier phase's
   // independently tracked write and read visibility to all threads in
   // threadMask.

--- a/include/triton/Dialect/TritonInstrument/IR/Utility.h
+++ b/include/triton/Dialect/TritonInstrument/IR/Utility.h
@@ -236,9 +236,12 @@ struct AuxDataMap {
   // Per-commit-kind outstanding commit counters for shared-memory buffers.
   // Entries are 0 for none, -1 for staged but uncommitted, and positive for a
   // committed access with an outstanding-group distance.
+  // With async-copy mbarriers, -2 retains a completed copy's issuer for later
+  // barrier arrivals. Visibility distinguishes completed from pending copies.
   // Just one C dimension as ampere async_copy, WGMMA and TMA store are
   // intra-CTA.
   RegionToValueMap commits[CommitKind::NumCommitKinds];
+  bool hasAsyncCopyMbarriers = false;
 
   // State-lane plans and analysis-derived runtime-base, state-mask, and CTA
   // cases for each memdesc. bufferRegions preserves the ordered region list

--- a/include/triton/Dialect/TritonInstrument/Transforms/ConSanTargetHooks.h
+++ b/include/triton/Dialect/TritonInstrument/Transforms/ConSanTargetHooks.h
@@ -31,6 +31,7 @@ struct MemEffectsOpInfo {
   enum class BarrierTrackingMode {
     Frontier,
     EffectWrites,
+    AsyncCopies,
   };
   struct Effects {
     struct StaticSharedBuffer {

--- a/lib/Dialect/TritonInstrument/IR/FunctionBuilder.cpp
+++ b/lib/Dialect/TritonInstrument/IR/FunctionBuilder.cpp
@@ -1669,6 +1669,10 @@ void FunctionBuilder::createPublishWriteVisibilityCall(
   const bool clearWrites = !auxData.writeTracking[(int)memType].empty();
   const bool clearReads = !auxData.readVisibility[(int)memType].empty();
   const bool clearReadTracking = !auxData.readTracking[(int)memType].empty();
+  const bool clearCopies = memType == MemType::SHARED_MEM &&
+                           auxData.hasAsyncCopyMbarriers &&
+                           !auxData.commits[CommitKind::AsyncCp].empty();
+  const bool unpublishedWrite = threadMask == 0;
   if (!publishWrite && !clearWrites && !clearReads && !clearReadTracking)
     return;
 
@@ -1681,6 +1685,8 @@ void FunctionBuilder::createPublishWriteVisibilityCall(
   specializationArgs.append(static_cast<uint64_t>(clearWrites));
   specializationArgs.append(static_cast<uint64_t>(clearReads));
   specializationArgs.append(static_cast<uint64_t>(clearReadTracking));
+  specializationArgs.append(static_cast<uint64_t>(clearCopies));
+  specializationArgs.append(static_cast<uint64_t>(unpublishedWrite));
 
   RankedTensorType writeVisibilityType;
   if (publishWrite) {
@@ -1715,11 +1721,20 @@ void FunctionBuilder::createPublishWriteVisibilityCall(
     specializationArgs.append(readTrackingType);
   }
 
+  RankedTensorType copiesType;
+  if (clearCopies) {
+    ValueType copies = auxData.commits[CommitKind::AsyncCp].at(insertPoint);
+    copiesType = cast<RankedTensorType>(copies.type);
+    args.push_back(copies.value);
+    specializationArgs.append(copiesType);
+  }
+
   createCallToCachedFunction(
       b, "publish_write_visibility", args, /*assertInfo=*/std::nullopt,
       specializationArgs,
-      [publishWrite, clearWrites, clearReads, clearReadTracking,
-       writeVisibilityType, writeTrackingType, readVisibilityType,
+      [publishWrite, clearWrites, clearReads, clearReadTracking, clearCopies,
+       unpublishedWrite, copiesType, writeVisibilityType, writeTrackingType,
+       readVisibilityType,
        readTrackingType](ImplicitLocOpBuilder &fb, Block *entryBlock) {
         Value bufferMask = entryBlock->getArgument(0);
         Value pred = entryBlock->getArgument(1);
@@ -1737,7 +1752,10 @@ void FunctionBuilder::createPublishWriteVisibilityCall(
           Value visibilityMask =
               convertAndBroadcast(fb, bufferMask, {1}, writeVisibilityType);
           Value relationMask =
-              createLeadCTAEffectMask(fb, writeVisibilityType, effectCTAs);
+              unpublishedWrite
+                  ? createCTASetMask(fb, writeVisibilityType, 0, effectCTAs)
+                  : createLeadCTAEffectMask(fb, writeVisibilityType,
+                                            effectCTAs);
           visibilityMask =
               arith::AndIOp::create(fb, visibilityMask, relationMask);
           auto elemType =
@@ -1773,6 +1791,8 @@ void FunctionBuilder::createPublishWriteVisibilityCall(
           clearTable(readVisibilityType);
         if (clearReadTracking)
           clearTable(readTrackingType);
+        if (clearCopies)
+          clearTable(copiesType);
 
         fb.setInsertionPointToEnd(thenBlock);
         triton::ReturnOp::create(fb);
@@ -2127,6 +2147,30 @@ void FunctionBuilder::createTrackVisibleAccessesCall(
       });
 }
 
+void FunctionBuilder::createTrackAsyncCopiesForBarrierCall(
+    ImplicitLocOpBuilder &b, Value mbar, int thread, Value pred,
+    Operation *insertPoint, Value barrierCTAs) {
+  if (auxData.commits[CommitKind::AsyncCp].empty())
+    return;
+  ValueType copies = auxData.commits[CommitKind::AsyncCp].at(insertPoint);
+  auto copiesType = cast<RankedTensorType>(copies.type);
+  Value pending =
+      tti::createLoadScratchMemory(b, b.getLoc(), copies.value, copiesType);
+  Value mask = arith::CmpIOp::create(
+      b, arith::CmpIPredicate::ne, pending,
+      tti::createConstIntTensor(b, b.getLoc(), 0, copiesType));
+  Value issuer = createDimMask(b, arith::ConstantIntOp::create(b, thread, 32),
+                               copiesType, 2);
+  mask = arith::AndIOp::create(b, mask, issuer);
+  Value currentCTA = createCurrentCTAMask(b);
+  mask = arith::AndIOp::create(b, mask,
+                               createCTASetMask(b, copiesType, 0, currentCTA));
+  Value bufferMask = reduce<arith::OrIOp>(b, mask, {0, 2});
+  createTrackBarrierWriteForBufferCall(b, mbar, bufferMask, pred,
+                                       MemType::SHARED_MEM, insertPoint,
+                                       barrierCTAs, currentCTA);
+}
+
 void FunctionBuilder::createTrackBarrierWriteForBufferCall(
     ImplicitLocOpBuilder &b, Value mbar, Value bufferMask, Value pred,
     MemType memType, Operation *insertPoint, Value barrierCTAs,
@@ -2153,10 +2197,13 @@ void FunctionBuilder::createTrackBarrierWriteForBufferCall(
   SmallVector<Value> args = {mbarOffset,       mbarLengthVal, pred,
                              bufferMask,       barriersVal,   writeTrackingVal,
                              barrierStatesVal, barrierCTAs,   effectCTAs};
+  auto maskEncoding =
+      cast<RankedTensorType>(bufferMask.getType()).getEncoding();
   createCallToCachedFunction(
       b, "track_barrier_write_for_buffer", args,
       /*assertInfo=*/std::nullopt,
-      {barriersType, writeTrackingType, barrierStatesType},
+      {barriersType, writeTrackingType, barrierStatesType,
+       llvm::xxh3_64bits(mlir::debugString(maskEncoding))},
       [writeTrackingType, barrierStatesType](ImplicitLocOpBuilder &fb,
                                              Block *entryBlock) {
         Value mbarOffset = entryBlock->getArgument(0);
@@ -3646,11 +3693,13 @@ void FunctionBuilder::createCommitAccessesCall(ImplicitLocOpBuilder &b,
   ValueType outstandingCommits = auxData.commits[commitKind].at(insertPoint);
   auto commitsType = cast<RankedTensorType>(outstandingCommits.type);
   Value threadVal = arith::ConstantIntOp::create(b, thread, 32);
+  bool retainCopies =
+      auxData.hasAsyncCopyMbarriers && commitKind == CommitKind::AsyncCp;
   SmallVector<Value> args = {threadVal, pred, outstandingCommits.value};
   createCallToCachedFunction(
       b, "commit_accesses", args,
-      /*assertInfo=*/std::nullopt, {commitsType},
-      [commitsType](ImplicitLocOpBuilder &fb, Block *entryBlock) {
+      /*assertInfo=*/std::nullopt, {commitsType, uint64_t(retainCopies)},
+      [commitsType, retainCopies](ImplicitLocOpBuilder &fb, Block *entryBlock) {
         Value threadVal = entryBlock->getArgument(0);
         Value pred = entryBlock->getArgument(1);
         Value outstandingCommitsPtr = entryBlock->getArgument(2);
@@ -3675,6 +3724,14 @@ void FunctionBuilder::createCommitAccessesCall(ImplicitLocOpBuilder &b,
             fb, commits, zero, arith::CmpIPredicate::sgt);
         commitsGtZero = arith::AndIOp::create(fb, commitsGtZero, threadMask);
         Value commitsPlusOne = arith::AddIOp::create(fb, commits, ones);
+        if (retainCopies) {
+          Value maximum =
+              tti::createConstIntTensor(fb, fb.getLoc(), 127, commitsType);
+          Value saturated = arith::CmpIOp::create(fb, arith::CmpIPredicate::eq,
+                                                  commits, maximum);
+          commitsPlusOne =
+              arith::SelectOp::create(fb, saturated, commits, commitsPlusOne);
+        }
         commits =
             arith::SelectOp::create(fb, commitsGtZero, commitsPlusOne, commits);
 
@@ -3730,6 +3787,8 @@ void FunctionBuilder::createClearOutstandingCommitsTransferCall(
       transferWrites && !auxData.writeVisibility[(int)memType].empty();
   bool hasReadVisibility =
       transferReads && !auxData.readVisibility[(int)memType].empty();
+  bool retainCopies =
+      auxData.hasAsyncCopyMbarriers && commitKind == CommitKind::AsyncCp;
   if (!hasWriteVisibility && !hasReadVisibility)
     return;
   if (!pred)
@@ -3743,7 +3802,7 @@ void FunctionBuilder::createClearOutstandingCommitsTransferCall(
   Value outstandingNumVal = arith::ConstantIntOp::create(b, outstandingNum, 32);
   SmallVector<Value> args = {threadVal, transferMaskVal, outstandingNumVal,
                              pred, outstandingCommits.value};
-  ManglingArgs specializationArgs{commitsType};
+  ManglingArgs specializationArgs{commitsType, uint64_t(retainCopies)};
 
   RankedTensorType writeVisibilityType;
   if (hasWriteVisibility) {
@@ -3770,7 +3829,8 @@ void FunctionBuilder::createClearOutstandingCommitsTransferCall(
   createCallToCachedFunction(
       b, functionName, args, /*assertInfo=*/std::nullopt, specializationArgs,
       [commitsType, writeVisibilityType, readVisibilityType, hasWriteVisibility,
-       hasReadVisibility](ImplicitLocOpBuilder &fb, Block *entryBlock) {
+       hasReadVisibility,
+       retainCopies](ImplicitLocOpBuilder &fb, Block *entryBlock) {
         Value threadVal = entryBlock->getArgument(0);
         Value transferMaskVal = entryBlock->getArgument(1);
         Value outstandingNumVal = entryBlock->getArgument(2);
@@ -3851,9 +3911,12 @@ void FunctionBuilder::createClearOutstandingCommitsTransferCall(
                                          updated, readVisibilityType, readMask);
         }
 
-        Value zero = tti::createConstIntTensor(fb, fb.getLoc(), 0, commitsType);
-        outstandingCommits = arith::SelectOp::create(
-            fb, outstandingCommitsGtOutstandingNum, zero, outstandingCommits);
+        Value completed = tti::createConstIntTensor(
+            fb, fb.getLoc(), retainCopies ? -2 : 0, commitsType,
+            /*isSigned=*/true);
+        outstandingCommits =
+            arith::SelectOp::create(fb, outstandingCommitsGtOutstandingNum,
+                                    completed, outstandingCommits);
         createMaskedStoreScratchMemory(fb, fb.getLoc(), outstandingCommitsPtr,
                                        outstandingCommits, commitsType,
                                        commitCTAMask);
@@ -3884,11 +3947,24 @@ void FunctionBuilder::createCheckOutstandingCommitsCall(
   AssertInfo assertInfo{message, b.getI1Type()};
   SmallVector<Value> args = {bufferMask, pred, threadVal,
                              outstandingCommits.value, effectCTAs};
+  bool retainCopies =
+      auxData.hasAsyncCopyMbarriers && commitKind == CommitKind::AsyncCp;
+  RankedTensorType visibilityType;
+  ManglingArgs specializationArgs{commitsType, uint64_t(thread),
+                                  uint64_t(retainCopies)};
+  if (retainCopies) {
+    ValueType visibility =
+        auxData.writeVisibility[(int)MemType::SHARED_MEM].at(insertPoint);
+    visibilityType = cast<RankedTensorType>(visibility.type);
+    args.push_back(visibility.value);
+    specializationArgs.append(visibilityType);
+  }
   std::string funcName = excludeSelf ? "check_outstanding_commits_excl_self"
                                      : "check_outstanding_commits";
   createCallToCachedFunction(
-      b, funcName, args, assertInfo, {commitsType, (uint64_t)thread},
-      [commitsType, excludeSelf](ImplicitLocOpBuilder &fb, Block *entryBlock) {
+      b, funcName, args, assertInfo, specializationArgs,
+      [commitsType, excludeSelf, retainCopies,
+       visibilityType](ImplicitLocOpBuilder &fb, Block *entryBlock) {
         Value checkMask = entryBlock->getArgument(0);
         Value pred = entryBlock->getArgument(1);
         Value threadVal = entryBlock->getArgument(2);
@@ -3913,6 +3989,26 @@ void FunctionBuilder::createCheckOutstandingCommitsCall(
         }
         Value selectedEqZero = arith::CmpIOp::create(
             fb, arith::CmpIPredicate::eq, selectedRows, zeroTensor);
+        if (retainCopies) {
+          Value visibility = tti::createLoadScratchMemory(
+              fb, fb.getLoc(), entryBlock->getArgument(5), visibilityType);
+          Value threadBit = arith::ShLIOp::create(
+              fb, arith::ConstantIntOp::create(fb, 1, 64),
+              arith::ExtUIOp::create(fb, fb.getI64Type(), threadVal));
+          Value threadMask =
+              triton::SplatOp::create(fb, visibilityType, threadBit);
+          Value visible = arith::CmpIOp::create(
+              fb, arith::CmpIPredicate::ne,
+              arith::AndIOp::create(fb, visibility, threadMask),
+              tti::createConstIntTensor(fb, fb.getLoc(), 0, visibilityType));
+          visible =
+              arith::AndIOp::create(fb, visible,
+                                    createCTASetMask(fb, visibilityType, 2,
+                                                     createCurrentCTAMask(fb)));
+          Value completed = reduceLastDim<arith::OrIOp>(fb, visible);
+          completed = convertAndBroadcast(fb, completed, {0, 1}, commitsType);
+          selectedEqZero = arith::OrIOp::create(fb, selectedEqZero, completed);
+        }
         Value allSelectedEqZero = reduceAll<arith::AndIOp>(fb, selectedEqZero);
         Value vTrue =
             arith::ConstantOp::create(fb, allSelectedEqZero.getType(),

--- a/lib/Dialect/TritonInstrument/IR/Utility.cpp
+++ b/lib/Dialect/TritonInstrument/IR/Utility.cpp
@@ -418,7 +418,7 @@ AuxDataMap::ThreadLayout getThreadLayout(FuncOp entryPoint,
     if (auto wsOp = dyn_cast<WarpSpecializePartitionsOp>(op))
       layout.numBaseThreads = std::max<int>(
           layout.numBaseThreads, wsOp.getPartitionRegions().size() + 1);
-    hasTMA |= hooks.isTMAOp(op);
+    hasTMA |= hooks.isTMAOp(op) || isa<AsyncCopyMbarrierArriveOp>(op);
     hasTC |= isa<MMAv5OpInterface, TCGen5CommitOp, TMEMCopyOp>(op);
     hasCLC |= hooks.isCLCOp(op);
   });
@@ -493,6 +493,8 @@ AuxDataMap::populateAndPassToWarpSpecialize(ModuleOp module, FuncOp entryPoint,
     return failure();
   int numCTAs = lookupNumCTAs(module);
   threadLayout = getThreadLayout(entryPoint, hooks);
+  entryPoint.walk(
+      [&](AsyncCopyMbarrierArriveOp) { hasAsyncCopyMbarriers = true; });
   hasAsyncProxyFenceTracking =
       hooks.needsAsyncProxyFenceTracking(module) &&
       bufferStatePlans[(int)MemType::SHARED_MEM].numLanes != 0;

--- a/lib/Dialect/TritonInstrument/Transforms/ConcurrencySanitizer.cpp
+++ b/lib/Dialect/TritonInstrument/Transforms/ConcurrencySanitizer.cpp
@@ -96,7 +96,7 @@ int getCurrentThread(Operation *op, const ConSanTargetHooks &hooks,
                      const AuxDataMap::ThreadLayout &threadLayout) {
   // Default partition is 0, other partitions are idx + 1
   int thread = maybeGetPartitionIdx(op).value_or(-1) + 1;
-  if (hooks.isTMAOp(op)) {
+  if (hooks.isTMAOp(op) || isa<ttng::AsyncCopyMbarrierArriveOp>(op)) {
     assert(threadLayout.hasTMAThreads() &&
            "TMA thread class must exist when instrumenting a TMA op");
     thread += threadLayout.tmaThreadOffset;
@@ -1425,6 +1425,10 @@ private:
         if (opInfo->trackingKind ==
             MemEffectsOpInfo::TrackingKind::CommitCount) {
           assert(memType == MemType::SHARED_MEM);
+          if (auxData.hasAsyncCopyMbarriers &&
+              opInfo->commitKind == CommitKind::AsyncCp)
+            funcBuilder.createPublishWriteVisibilityCall(
+                b, bufferMask, 0, pred, memType, op, effectCTAs);
           funcBuilder.createStageAccessForCommitCall(
               b, bufferMask, baseThread, pred, memType, opInfo->commitKind, op);
         }
@@ -1488,6 +1492,13 @@ private:
           funcBuilder.createTrackVisibleAccessesCall(
               b, barrier, thread, combinedPred, MemType::SHARED_MEM, op,
               recipientCTAs, completionBufferMask);
+      } else if (barrierInfo.trackingMode ==
+                 MemEffectsOpInfo::BarrierTrackingMode::AsyncCopies) {
+        funcBuilder.createTrackAsyncCopiesForBarrierCall(
+            b, barrier, baseThread, combinedPred, op, recipientCTAs);
+        funcBuilder.createTrackVisibleAccessesCall(
+            b, barrier, thread, combinedPred, MemType::SHARED_MEM, op,
+            recipientCTAs, completionBufferMask);
       }
       if (barrierInfo.count > 0 || barrierInfo.txCount != 0) {
         funcBuilder.createVerifyAndUpdateBarrierStateCall(

--- a/lib/Dialect/TritonNvidiaGPU/Transforms/ConSanNVIDIA.cpp
+++ b/lib/Dialect/TritonNvidiaGPU/Transforms/ConSanNVIDIA.cpp
@@ -163,7 +163,7 @@ public:
         ConSanTargetHooks::getMemEffectsOpInfo(op);
     if (!info) {
       if (!isa<ttng::BarrierExpectOp, ttng::TCGen5CommitOp,
-               ttng::ArriveBarrierOp>(op))
+               ttng::ArriveBarrierOp, ttng::AsyncCopyMbarrierArriveOp>(op))
         return std::nullopt;
       info.emplace();
       info->trackingKind = MemEffectsOpInfo::TrackingKind::Barrier;
@@ -248,6 +248,12 @@ public:
       info->pred = arriveOp.getPred();
       info->barriers.push_back(
           {arriveOp.getBarrier(), nullptr, (int)arriveOp.getCount()});
+    }
+    if (auto arriveOp = dyn_cast<ttng::AsyncCopyMbarrierArriveOp>(op)) {
+      int count = arriveOp.getNoIncrement() ? ttg::lookupNumWarps(op) * 32 : 0;
+      info->barriers.push_back(
+          {arriveOp.getBarrier(), nullptr, count,
+           MemEffectsOpInfo::BarrierTrackingMode::AsyncCopies});
     }
 
     if (!namedOperands.empty()) {

--- a/python/test/gluon/test_consan.py
+++ b/python/test/gluon/test_consan.py
@@ -1561,6 +1561,167 @@ def test_async_copy(FAILURE, device, run_wrapper, monkeypatch, num_ctas):
     kernel[(1, )](input, FAILURE=FAILURE, num_warps=4, num_ctas=num_ctas)
 
 
+@pytest.mark.skipif(not is_cuda() or torch.cuda.get_device_capability()[0] < 9, reason="Requires hopper or newer")
+@pytest.mark.parametrize("num_ctas", [1, 2], ids=["1cta", "2ctas"])
+@pytest.mark.parametrize("CASE", [
+    "wait", "noinc", "committed", "missing_wait", "wrong_barrier", "after_arrive", "reused_buffer", "peer_read",
+    "peer_read_synced"
+])
+def test_async_copy_mbarrier_completion(CASE, num_ctas, device, run_wrapper, monkeypatch):
+    if CASE in ("peer_read", "peer_read_synced") and num_ctas == 1:
+        pytest.skip("Peer reads require two CTAs")
+    failure = CASE in ("missing_wait", "wrong_barrier", "after_arrive", "reused_buffer", "peer_read")
+    if run_wrapper:
+        result = run_in_process(test_async_copy_mbarrier_completion, (CASE, num_ctas, device, False, monkeypatch))
+        if failure:
+            assert_expected_cuda_failure(result.exc)
+            assert any(message in result.driver_stderr_output for message in (
+                "Buffer being accessed has outstanding writes",
+                "Accessing buffer with pending access. Pending access type: async_copy_global_to_shared",
+            ))
+        else:
+            assert result.exc is None
+            assert result.driver_stderr_output == ""
+        return
+
+    monkeypatch.setenv("TRITON_INSTRUMENTATION_MODE", "consan")
+    monkeypatch.setenv("CUDA_LAUNCH_BLOCKING", "1")
+    knobs.refresh_knobs()
+
+    @gluon.jit
+    def kernel(source, output, CASE: ttgl.constexpr):
+        block_x: ttgl.constexpr = XBLOCK * ttgl.num_ctas()
+        cga: ttgl.constexpr = default_cga_layout(ttgl.num_ctas(), 1)
+        layout: ttgl.constexpr = ttgl.BlockedLayout([1], [32], [4], [0], cga_layout=cga)
+        shared: ttgl.constexpr = ttgl.SwizzledSharedLayout(1, 1, 1, [0], cga_layout=cga)
+        offsets = ttgl.arange(0, block_x, layout)
+        smem = ttgl.allocate_shared_memory(ttgl.int32, [2, block_x], shared)
+        bars = mbarrier.allocate_mbarrier(batch=2)
+        mbarrier.init(bars.index(0), count=128 if CASE == "noinc" else 1)
+        mbarrier.init(bars.index(1), count=1)
+        ampere.async_copy.async_load(smem.index(0), source + offsets)
+        if CASE == "committed":
+            ampere.async_copy.commit_group()
+        ampere.async_copy.mbarrier_arrive(bars.index(0), increment_count=CASE != "noinc")
+        if CASE != "noinc":
+            mbarrier.arrive(bars.index(0), count=1)
+        mbarrier.arrive(bars.index(1), count=1)
+
+        if CASE == "after_arrive":
+            ampere.async_copy.async_load(smem.index(1), source + offsets)
+        elif CASE == "reused_buffer":
+            mbarrier.wait(bars.index(0), 0, deps=[smem.index(0)])
+            ampere.async_copy.async_load(smem.index(0), source + offsets)
+        if CASE != "missing_wait":
+            mbarrier.wait(bars.index(1 if CASE == "wrong_barrier" else 0), 0, deps=[smem])
+        if CASE == "peer_read" or CASE == "peer_read_synced":
+            if CASE == "peer_read_synced":
+                ttgl.barrier(cluster=True)
+            else:
+                # Both local waits finish, without granting visibility to peer CTAs.
+                hopper.cluster.barrier(relaxed=True)
+            value = smem.index(0).gather(offsets ^ XBLOCK, axis=0)
+            ttgl.barrier(cluster=True)
+        else:
+            value = smem.index(1 if CASE == "after_arrive" else 0).load(layout)
+        ttgl.store(output + offsets, value)
+
+        ampere.async_copy.commit_group()
+        ampere.async_copy.wait_group(0)
+        for i in ttgl.static_range(2):
+            mbarrier.wait(bars.index(i), 0)
+            mbarrier.invalidate(bars.index(i))
+
+    source = torch.arange(XBLOCK.value * num_ctas, device=device, dtype=torch.int32)
+    output = torch.empty_like(source)
+    kernel[(1, )](source, output, CASE, num_warps=4, num_ctas=num_ctas)
+    if not failure:
+        expected = source.reshape(2, XBLOCK.value).flip(0).reshape(-1) if CASE == "peer_read_synced" else source
+        torch.testing.assert_close(output, expected)
+
+
+@pytest.mark.skipif(not is_cuda() or torch.cuda.get_device_capability()[0] < 9, reason="Requires hopper or newer")
+@pytest.mark.parametrize("MODE", ["group_before", "group_after", "non_acquiring", "mixed_tma"])
+def test_ws_async_copy_mbarrier_visibility(MODE, device, run_wrapper, monkeypatch):
+    if run_wrapper:
+        result = run_in_process(test_ws_async_copy_mbarrier_visibility, (MODE, device, False, monkeypatch))
+        if MODE == "non_acquiring":
+            assert_expected_cuda_failure(result.exc)
+            assert "Buffer being accessed has outstanding writes" in result.driver_stderr_output
+        else:
+            assert result.exc is None
+            assert result.driver_stderr_output == ""
+        return
+
+    monkeypatch.setenv("TRITON_INSTRUMENTATION_MODE", "consan")
+    monkeypatch.setenv("CUDA_LAUNCH_BLOCKING", "1")
+    knobs.refresh_knobs()
+
+    @gluon.jit
+    def producer(source, output, smem, bars, input_desc, tma_smem, layout: ttgl.constexpr, MODE: ttgl.constexpr):
+        offsets = ttgl.arange(0, XBLOCK, layout)
+        if MODE == "mixed_tma":
+            mbarrier.expect(bars.index(0), input_desc.nbytes_per_cta)
+            tma.async_load(input_desc, [0, 0], bars.index(0), tma_smem)
+        ampere.async_copy.async_load(smem, source + offsets)
+        ampere.async_copy.commit_group()
+        if MODE == "group_before" or MODE == "mixed_tma":
+            ampere.async_copy.wait_group(0)
+        ampere.async_copy.mbarrier_arrive(bars.index(0), increment_count=False)
+        mbarrier.wait(bars.index(1), 0)
+        if MODE == "group_after":
+            # Empty groups must not overflow the retained age of the completed copy.
+            for _ in range(130):
+                ampere.async_copy.commit_group()
+            ampere.async_copy.wait_group(0)
+        ttgl.store(output + XBLOCK + offsets, smem.load(layout))
+        mbarrier.wait(bars.index(0), 0, deps=[smem])
+
+    @gluon.jit
+    def consumer(output, smem, bars, tma_smem, layout: ttgl.constexpr, MODE: ttgl.constexpr):
+        offsets = ttgl.arange(0, XBLOCK, layout)
+        mbarrier.wait(bars.index(0), 0, deps=[smem, tma_smem] if MODE == "mixed_tma" else [smem])
+        value = smem.load(layout)
+        if MODE == "mixed_tma":
+            rows: ttgl.constexpr = ttgl.BlockedLayout([1, 1], [1, 32], [1, 4], [1, 0])
+            for i in ttgl.static_range(32):
+                value += ttgl.convert_layout(ttgl.sum(tma_smem.slice(i, 1).load(rows), 0), layout)
+        ttgl.store(output + offsets, value)
+        # This partition issued no copies; its completion does not release the payload.
+        ampere.async_copy.mbarrier_arrive(bars.index(1), increment_count=False)
+
+    @gluon.jit
+    def kernel(source, output, input_desc, MODE: ttgl.constexpr):
+        layout: ttgl.constexpr = ttgl.BlockedLayout([1], [32], [4], [0])
+        smem = ttgl.allocate_shared_memory(ttgl.int32, [XBLOCK], ttgl.SwizzledSharedLayout(1, 1, 1, [0]))
+        tma_smem = ttgl.allocate_shared_memory(ttgl.int32, [32, XBLOCK],
+                                               input_desc.layout) if MODE == "mixed_tma" else 0
+        bars = mbarrier.allocate_mbarrier(batch=2)
+        for i in ttgl.static_range(2):
+            # noinc emits one arrival for each of the partition's 128 threads.
+            mbarrier.init(bars.index(i), count=128 + (MODE == "mixed_tma" and i == 0))
+        ttgl.warp_specialize([
+            (producer, (source, output, smem, bars, input_desc, tma_smem, layout, MODE)),
+            (consumer, (output, smem, bars, tma_smem, layout, MODE)),
+        ], [4], [32])
+        for i in ttgl.static_range(2):
+            mbarrier.wait(bars.index(i), 0)
+            mbarrier.invalidate(bars.index(i))
+
+    source = torch.arange(XBLOCK.value, device=device, dtype=torch.int32)
+    output = torch.empty((2, XBLOCK.value), device=device, dtype=torch.int32)
+    input_desc = None
+    if MODE == "mixed_tma":
+        input_desc = gluon.nvidia.hopper.TensorDescriptor.from_tensor(source.repeat(32, 1), [32, XBLOCK.value],
+                                                                      ttgl.NVMMASharedLayout(0, 32, rank=2))
+    kernel[(1, )](source, output, input_desc, MODE, num_warps=4, num_ctas=1)
+    if MODE != "non_acquiring":
+        expected = source.expand(2, -1).clone()
+        if MODE == "mixed_tma":
+            expected[0] *= 33
+        torch.testing.assert_close(output, expected)
+
+
 @pytest.mark.skipif(not is_cuda() or torch.cuda.get_device_capability()[0] < 9, reason="Requires ampere or newer")
 @pytest.mark.parametrize("FAILURE", [True, False])
 def test_tma_store(FAILURE, device, run_wrapper, monkeypatch, num_ctas):
@@ -3998,17 +4159,22 @@ def test_async_copy_mbarrier_arrive_requires_init(INITIALIZE, device, run_wrappe
     def kernel(INITIALIZE: ttgl.constexpr):
         barrier = mbarrier.allocate_mbarrier()
         if INITIALIZE:
-            mbarrier.init(barrier, count=1)
+            mbarrier.init(barrier, count=128)
         ampere.async_copy.mbarrier_arrive(barrier, increment_count=False)
+        if INITIALIZE:
+            mbarrier.wait(barrier, 0)
+            mbarrier.invalidate(barrier)
 
     kernel[(1, )](INITIALIZE=INITIALIZE, num_warps=4, num_ctas=1)
 
 
 @pytest.mark.skipif(not is_cuda() or torch.cuda.get_device_capability()[0] < 9, reason="Requires hopper")
+@pytest.mark.parametrize("COPY_KIND", ["tma", "cp_async"])
 @pytest.mark.parametrize("WAIT", [False, True], ids=["outstanding-completion", "waited-completion"])
-def test_barrier_invalidate_requires_completion_wait(WAIT, device, run_wrapper, monkeypatch):
+def test_barrier_invalidate_requires_completion_wait(WAIT, COPY_KIND, device, run_wrapper, monkeypatch):
     if run_wrapper and not WAIT:
-        result = run_in_process(test_barrier_invalidate_requires_completion_wait, (WAIT, device, False, monkeypatch))
+        result = run_in_process(test_barrier_invalidate_requires_completion_wait,
+                                (WAIT, COPY_KIND, device, False, monkeypatch))
         assert_expected_cuda_failure(result.exc)
         assert "Buffer being accessed has outstanding reads" in result.driver_stderr_output
         return
@@ -4018,12 +4184,20 @@ def test_barrier_invalidate_requires_completion_wait(WAIT, device, run_wrapper, 
     knobs.refresh_knobs()
 
     @gluon.jit
-    def kernel(input_desc, WAIT: ttgl.constexpr):
+    def kernel(input_desc, source, WAIT: ttgl.constexpr, COPY_KIND: ttgl.constexpr):
         smem = ttgl.allocate_shared_memory(ttgl.float16, [XBLOCK, XBLOCK], input_desc.layout)
         barrier = mbarrier.allocate_mbarrier()
         mbarrier.init(barrier, count=1)
-        mbarrier.expect(barrier, input_desc.nbytes_per_cta)
-        tma.async_load(input_desc, [0, 0], barrier, smem)
+        if COPY_KIND == "tma":
+            mbarrier.expect(barrier, input_desc.nbytes_per_cta)
+            tma.async_load(input_desc, [0, 0], barrier, smem)
+        else:
+            layout: ttgl.constexpr = ttgl.BlockedLayout([1, 4], [4, 8], [4, 1], [1, 0])
+            rows = ttgl.arange(0, XBLOCK, ttgl.SliceLayout(1, layout))[:, None]
+            cols = ttgl.arange(0, XBLOCK, ttgl.SliceLayout(0, layout))[None, :]
+            ampere.async_copy.async_load(smem, source + rows * XBLOCK + cols)
+            ampere.async_copy.mbarrier_arrive(barrier)
+            mbarrier.arrive(barrier, count=1)
         if WAIT:
             mbarrier.wait(barrier, 0, deps=[smem])
         mbarrier.invalidate(barrier)
@@ -4031,7 +4205,7 @@ def test_barrier_invalidate_requires_completion_wait(WAIT, device, run_wrapper, 
     source = torch.randn((XBLOCK.value, XBLOCK.value), device=device, dtype=torch.float16)
     smem_layout = ttgl.NVMMASharedLayout(128, 16, rank=2, cga_layout=[])
     input_desc = gluon.nvidia.hopper.TensorDescriptor.from_tensor(source, [XBLOCK.value, XBLOCK.value], smem_layout)
-    kernel[(1, )](input_desc, WAIT=WAIT, num_warps=4, num_ctas=1)
+    kernel[(1, )](input_desc, source, WAIT=WAIT, COPY_KIND=COPY_KIND, num_warps=4, num_ctas=1)
 
 
 @pytest.mark.skipif(not is_cuda() or torch.cuda.get_device_capability()[0] < 9, reason="Requires hopper or newer")


### PR DESCRIPTION
ConSan leaves `cp.async` writes pending when they complete through `cp.async.mbarrier.arrive` and `mbarrier.wait`. Valid kernels then fail with `Pending access type: async_copy_global_to_shared`.

Track the copies associated with each barrier phase using the existing write-tracking state. Preserve the copy issuer when mixing `wait_group` with barrier completion, transfer visibility only to the acquiring thread/CTA, and protect the barrier while its asynchronous completion is outstanding. New writes clear stale copy and barrier associations. Existing wait-group-only kernels keep their current bookkeeping.

The regressions cover valid waits, missing or wrong waits, copies issued after arrival, buffer reuse, cross-CTA visibility, barrier invalidation, mixed TMA/copy completion, and mixed wait-group/barrier synchronization. The shared helper cache distinguishes mask layouts without introducing shared-memory conversions after allocation.

Validation at `2c01e5879ae65d1d00e99a0aafa26162b1726caf`, based on upstream `20e6ba864830b88f56b907fef85cab5097cf3892`:

- Fresh AArch64 GCC 13.3 build with assertions and the pinned LLVM `b010a18d2b648cab83c83967ff26b8fde11acdc6` passed.
- Both existing NVIDIA and AMD ConSan lit regression files passed.
- On NVIDIA GB300 with a `ptxas` 13.3.69 override: 55 GPU cases passed, 6 skipped, and 492 deselected in 60.74 seconds. The negative cases still reject invalid synchronization.

GPU regression command:

```sh
TRITON_PTXAS_BLACKWELL_PATH=/path/to/ptxas-13.3.69 python -m pytest \
  python/test/gluon/test_consan.py -s -q --tb=short \
  -k 'async_copy or barrier_invalidate_requires_completion_wait or tma_multicast'
```
