### PR TITLE
[TritonGPU] Broadcast reduced value to all lanes in cross-warp reduce epilogue

### DIFF
--- a/include/triton/Conversion/TritonGPUToLLVM/Utility.h
+++ b/include/triton/Conversion/TritonGPUToLLVM/Utility.h
@@ -353,6 +353,19 @@ Value emitRedundantThreadPredicate(
     ConversionPatternRewriter &rewriter, Location loc,
     const TargetInfoBase &targetInfo);
 
+// Return a predicate for a shared-memory store that lowers a layout conversion,
+// true only for a representative thread of each group of threads that hold the
+// same value AND write the same shared-memory address. A thread is redundant
+// only when the value it stores and the address it writes are both invariant
+// across the same thread-index bits, so the free-variable masks of the source
+// value layout are intersected with those of the store-address layout. The
+// predicate may be null to indicate no predication is required.
+Value emitRedundantSharedStorePredicate(const LinearLayout &srcLayout,
+                                        const LinearLayout &storeCvt,
+                                        ConversionPatternRewriter &rewriter,
+                                        Location loc,
+                                        const TargetInfoBase &targetInfo);
+
 // Takes two values that may be boolean, or null to represent constant True.
 Value maybeAnd(OpBuilder &builder, Location loc, Value a, Value b);
 

--- a/lib/Conversion/TritonGPUToLLVM/ConvertLayoutOpToLLVM.cpp
+++ b/lib/Conversion/TritonGPUToLLVM/ConvertLayoutOpToLLVM.cpp
@@ -216,6 +216,17 @@ struct ConvertLayoutOpConversion
     };
 
     auto [laneId, warpId] = getLaneAndWarpId(rewriter, loc);
+    // The source layout may broadcast a value across a group of threads (e.g.
+    // the partial held by every lane of a warp in the cross-warp epilogue of a
+    // `tt.reduce`). All redundant threads would then write the same shared
+    // memory address, which is a data race when the combine is not
+    // bitwise-exact. Predicate the store to a representative thread of each
+    // broadcast group.
+    Value storePred =
+        emitRedundantSharedStorePredicate(srcLayout, storeCvt, rewriter, loc,
+                                          targetInfo);
+    if (!storePred)
+      storePred = b.true_val();
     for (int i = 0; i < nReps; ++i) {
       if (i > 0)
         emitBarrier();
@@ -226,7 +237,7 @@ struct ConvertLayoutOpConversion
                 /*paddingShifts=*/{}, affineOffset, maskSpanAffineOffset,
                 /*affineBlockOffset=*/Value(), /*maskSpanAffineBlock=*/0,
                 laneId, warpId, rewriter, targetInfo, /*maybeMaxVecElems=*/{},
-                makeSharedStoreEmitter(targetInfo, b.true_val()));
+                makeSharedStoreEmitter(targetInfo, storePred));
       emitBarrier();
       // Load
       auto tileOutVals = lowerLdSt(

--- a/lib/Conversion/TritonGPUToLLVM/ReduceOpToLLVM.cpp
+++ b/lib/Conversion/TritonGPUToLLVM/ReduceOpToLLVM.cpp
@@ -380,6 +380,23 @@ private:
       }
       accumulate(op.getLoc(), rewriter, op.getCombineOp(), acc, shfl);
     }
+    // The butterfly above folds each group of lanes into a single value held
+    // by the group's base lane (e.g. lane 0 for a full-warp reduction).
+    // For a combine that is not bitwise-commutative (e.g. the Welford combine
+    // emitted for var/var_mean) the other lanes still hold values that differ
+    // in the low bits. The layout codegen treats the reduced lanes as
+    // redundant (the result is broadcast across them) and, when the result is
+    // staged through shared memory, emits a store where every lane of the
+    // group writes the same address. Divergent lane values would make that a
+    // data race with an undefined winner in the PTX memory model. Broadcast
+    // the group base lane's value to the whole group so every lane genuinely
+    // holds the same result and the layout's broadcast assertion holds.
+    auto b = TritonLLVMOpBuilder(op.getLoc(), rewriter);
+    Value laneId = getLaneId(rewriter, op.getLoc());
+    Value groupBase = b.and_(laneId, b.i32_val(~reduceLaneIdMask));
+    for (unsigned i = 0; i < op.getNumOperands(); ++i) {
+      acc[i] = targetInfo.shuffleIdx(rewriter, op.getLoc(), acc[i], groupBase);
+    }
   }
 
   // Pack the accumulator values and replace the reduce op with the result.

--- a/lib/Conversion/TritonGPUToLLVM/Utility.cpp
+++ b/lib/Conversion/TritonGPUToLLVM/Utility.cpp
@@ -287,6 +287,20 @@ Value emitRedundantThreadPredicate(
   return pred;
 }
 
+Value emitRedundantSharedStorePredicate(const LinearLayout &srcLayout,
+                                        const LinearLayout &storeCvt,
+                                        ConversionPatternRewriter &rewriter,
+                                        Location loc,
+                                        const TargetInfoBase &targetInfo) {
+  auto valueMasks = srcLayout.getFreeVariableMasks();
+  auto addrMasks = storeCvt.getFreeVariableMasks();
+  llvm::MapVector<StringAttr, int32_t> redundantMasks;
+  for (auto &[dim, mask] : valueMasks)
+    redundantMasks[dim] = mask & addrMasks.lookup(dim);
+  return emitRedundantThreadPredicate(redundantMasks, rewriter, loc,
+                                      targetInfo);
+}
+
 } // namespace triton::gpu
 
 SmallVector<std::pair<StringAttr, Value>>

--- a/test/Conversion/amd/tritongpu_to_llvm_rdna.mlir
+++ b/test/Conversion/amd/tritongpu_to_llvm_rdna.mlir
@@ -47,10 +47,18 @@ tt.func private @reduce_linear_layout(%arg0: tensor<32x2xi32, #linear>) -> tenso
   // CHECK-DAG: [[reg1:%.*]] = llvm.extractvalue %arg0[1]
   // CHECK: [[permlane0:%.*]] = rocdl.permlanex16 [[reg0]], [[reg0]], [[select_lo]], [[select_hi]], true, false
   // CHECK: [[sum0:%.*]] = llvm.add [[reg0]], [[permlane0]]
+  // The 16-lane butterfly folds each lane pair into the group's base lane.
+  // Broadcast the base lane's value back to the whole group so all lanes of
+  // the group hold the same reduced result (needed when the result is staged
+  // through shared memory by redundant threads).
+  // CHECK: rocdl.workitem.id.x
+  // CHECK: [[brd0:%.*]] = rocdl.ds_bpermute {{.*}}, [[sum0]]
   // CHECK: [[permlane1:%.*]] = rocdl.permlanex16 [[reg1]], [[reg1]], [[select_lo]], [[select_hi]], true, false
   // CHECK: [[sum1:%.*]] = llvm.add [[reg1]], [[permlane1]]
-  // CHECK: [[result1:%.*]] = llvm.insertvalue [[sum0]], [[result0]][0]
-  // CHECK: [[result2:%.*]] = llvm.insertvalue [[sum1]], [[result1]][1]
+  // CHECK: rocdl.workitem.id.x
+  // CHECK: [[brd1:%.*]] = rocdl.ds_bpermute {{.*}}, [[sum1]]
+  // CHECK: [[result1:%.*]] = llvm.insertvalue [[brd0]], [[result0]][0]
+  // CHECK: [[result2:%.*]] = llvm.insertvalue [[brd1]], [[result1]][1]
 
   %0 = "tt.reduce"(%arg0) ({
   ^bb0(%arg1: i32, %arg2: i32):

--- a/test/Conversion/reduce_cross_warp_predicate.mlir
+++ b/test/Conversion/reduce_cross_warp_predicate.mlir
@@ -1,0 +1,21 @@
+// RUN: triton-opt %s --allocate-shared-memory --convert-triton-gpu-to-llvm | FileCheck %s
+// Cross-warp tt.reduce: axis 0 spans 8 warps (256 rows over 8 warps x 32 lanes),
+// so the reduce epilogue goes through shared memory. Each warp's partial is
+// broadcast across all 32 lanes; the shared store must be predicated on the
+// representative lane (regression #11614, restored on 3.7.1).
+
+#blocked = #ttg.blocked<{sizePerThread = [1, 4], threadsPerWarp = [32, 1], warpsPerCTA = [8, 1], order = [1, 0]}>
+module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 8 : i32, "ttg.threads-per-warp" = 32 : i32, ttg.target = "cuda:90"} {
+  tt.func public @reduce_cross_warp(%ptr: !tt.ptr<i32>, %arg0: tensor<256x4xi32, #blocked>) {
+    %0 = "tt.reduce"(%arg0) <{axis = 0 : i32}> ({
+    ^bb0(%arg1: i32, %arg2: i32):
+      %1 = arith.addi %arg1, %arg2 : i32
+      tt.reduce.return %1 : i32
+    }) : (tensor<256x4xi32, #blocked>) -> tensor<4xi32, #ttg.slice<{dim = 0, parent = #blocked}>>
+    // CHECK: llvm.inline_asm{{.*}}st.shared::cta.v4.b32
+    // CHECK: llvm.icmp "eq"
+    %2 = tt.splat %ptr : !tt.ptr<i32> -> tensor<4x!tt.ptr<i32>, #ttg.slice<{dim = 0, parent = #blocked}>>
+    tt.store %2, %0 : tensor<4x!tt.ptr<i32>, #ttg.slice<{dim = 0, parent = #blocked}>>
+    tt.return
+  }
+}

--- a/test/Conversion/reduce_to_llvm.mlir
+++ b/test/Conversion/reduce_to_llvm.mlir
@@ -41,6 +41,13 @@ tt.func private @reduce_linear_layout(%arg0: tensor<32x16xi32, #linear>) -> tens
   // CHECK-NEXT: [[W3:%.*]] = tail call i32 @llvm.nvvm.shfl.sync.bfly.i32(i32 -1, i32 [[WSUM2]], i32 2, i32 31)
   // CHECK-NEXT: [[WSUM3:%.*]] = add i32 [[WSUM2]], [[W3]]
 
+  // The reduction along lane bit 0 (mask 0x1) folds each {lane, lane^1} pair
+  // into the group's base lane. Broadcast that base lane's value to the whole
+  // group so every lane of the group holds the same reduced result.
+  // CHECK-NEXT: [[TID:%.*]] = tail call i32 @llvm.nvvm.read.ptx.sreg.tid.x()
+  // CHECK-NEXT: [[BASE:%.*]] = and i32 [[TID]], 1
+  // CHECK-NEXT: [[BRD0:%.*]] = tail call i32 @llvm.nvvm.shfl.sync.idx.i32(i32 -1, i32 [[WSUM3]], i32 [[BASE]], i32 31)
+
   // CHECK-NEXT: [[W4:%.*]] = tail call i32 @llvm.nvvm.shfl.sync.bfly.i32(i32 -1, i32 [[SUM1]], i32 16, i32 31)
   // CHECK-NEXT: [[WSUM4:%.*]] = add i32 [[W4]], [[SUM1]]
   // CHECK-NEXT: [[W5:%.*]] = tail call i32 @llvm.nvvm.shfl.sync.bfly.i32(i32 -1, i32 [[WSUM4]], i32 8, i32 31)
@@ -49,9 +56,10 @@ tt.func private @reduce_linear_layout(%arg0: tensor<32x16xi32, #linear>) -> tens
   // CHECK-NEXT: [[WSUM6:%.*]] = add i32 [[WSUM5]], [[W6]]
   // CHECK-NEXT: [[W7:%.*]] = tail call i32 @llvm.nvvm.shfl.sync.bfly.i32(i32 -1, i32 [[WSUM6]], i32 2, i32 31)
   // CHECK-NEXT: [[WSUM7:%.*]] = add i32 [[WSUM6]], [[W7]]
+  // CHECK-NEXT: [[BRD1:%.*]] = tail call i32 @llvm.nvvm.shfl.sync.idx.i32(i32 -1, i32 [[WSUM7]], i32 [[BASE]], i32 31)
 
-  // CHECK-NEXT: [[DST0:%.*]] = insertvalue { i32, i32 } undef, i32 [[WSUM3]], 0
-  // CHECK-NEXT: [[DST1:%.*]] = insertvalue { i32, i32 } [[DST0]], i32 [[WSUM7]], 1
+  // CHECK-NEXT: [[DST0:%.*]] = insertvalue { i32, i32 } undef, i32 [[BRD0]], 0
+  // CHECK-NEXT: [[DST1:%.*]] = insertvalue { i32, i32 } [[DST0]], i32 [[BRD1]], 1
 
   %0 = "tt.reduce"(%arg0) ({
   ^bb0(%arg1: i32, %arg2: i32):

--- a/test/Conversion/tritongpu_to_llvm.mlir
+++ b/test/Conversion/tritongpu_to_llvm.mlir
@@ -1586,7 +1586,7 @@ module attributes {"ttg.num-ctas" = 2 : i32, "ttg.num-warps" = 1 : i32} {
 #dst = #ttg.linear<{register = [], lane = [[0], [0], [0], [0], [0]], warp = [], block = [[1]]}>
 module attributes {"ttg.num-ctas" = 2 : i32, "ttg.num-warps" = 1 : i32, ttg.target = "cuda:90", "ttg.threads-per-warp" = 32 : i32} {
   // CHECK-LABEL: convert_layout_loads_local_replica
-  // CHECK: llvm.store
+  // CHECK: st.shared::cta
   // CHECK: nvg.cluster_id
   // CHECK-NOT: nvvm.mapa
   // CHECK: llvm.load
@@ -1607,7 +1607,7 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 8 : i32} {
   // CHECK-LABEL: linear_layout_with_multiple_iterations
   tt.func @linear_layout_with_multiple_iterations(%src: tensor<8x4xbf16, #linear>) {
     %cvt = ttg.convert_layout %src : tensor<8x4xbf16, #linear> -> tensor<8x4xbf16, #linear1>
-    // CHECK-COUNT-1: llvm.store {{.*}} : vector<4xi16>
+    // CHECK-COUNT-1: st.shared::cta.v4.b16
     // CHECK: nvvm.barrier
     // CHECK-COUNT: llvm.load{{.*}}->vector<2xi16>
     tt.return
@@ -2353,7 +2353,7 @@ module attributes {"ttg.target" = "cuda:80", "ttg.num-ctas" = 1 : i32, "ttg.num-
 // -----
 
 //  CHECK-LABEL: reduce_md_slice
-//  CHECK: llvm.store {{.*}} vector<2xi32>
+//  CHECK: llvm.inline_asm{{.*}} st.shared::cta.v2.b32
 //  CHECK: llvm.load {{.*}} vector<2xi32>
 #blocked = #ttg.blocked<{sizePerThread = [1, 1, 1], threadsPerWarp = [1, 1, 32], warpsPerCTA = [1, 2, 2], order = [2, 1, 0]}>
 #sliced = #ttg.slice<{dim = 2, parent = #blocked}>

--- a/third_party/nvidia/lib/TritonNVIDIAGPUToLLVM/ConvertLayoutOpToLLVM.cpp
+++ b/third_party/nvidia/lib/TritonNVIDIAGPUToLLVM/ConvertLayoutOpToLLVM.cpp
@@ -171,6 +171,19 @@ struct ConvertLayoutOpSwizzlingConversion
       SmallVector<StringAttr> outDims = {kOffset};
       return cvt.sublayout(inDims, outDims);
     };
+    // When the source layout broadcasts a value across a group of threads
+    // (e.g. the partial held by every lane of a warp in the cross-warp
+    // epilogue of a `tt.reduce`), all redundant threads write the same shared
+    // memory address. Unpredicated, this is a data race when the combine is not
+    // bitwise-exact (e.g. a Welford combine where the lanes differ in the low
+    // bits), making the result non-deterministic. Predicate the store to the
+    // representative thread of each broadcast group.
+    Value storePred =
+        emitRedundantSharedStorePredicate(srcLayout, storeCvt, rewriter, loc,
+                                          targetInfo);
+    if (!storePred)
+      storePred = b.true_val();
+
     auto [laneId, warpId] = getLaneAndWarpId(rewriter, loc);
     for (int i = 0; i < nReps; ++i) {
       if (i > 0)
@@ -185,7 +198,7 @@ struct ConvertLayoutOpSwizzlingConversion
                   /*affineBlockOffset=*/Value(), /*maskSpanAffineBlock=*/0,
                   laneId, warpId, rewriter, targetInfo,
                   /*maybeMaxVecElems=*/{},
-                  makeSharedStoreEmitter(targetInfo, b.true_val()));
+                  makeSharedStoreEmitter(targetInfo, storePred));
       } else {
         assert(idxSrc == 1 || idxSrc == 2);
         bool transpose = idxSrc == 2;


### PR DESCRIPTION
Fixes #11614.

## Problem

The epilogue of a cross-warp `tt.reduce` broadcasts each warp's partial to every lane of the warp, then lowers a `convert_layout` whose shared-memory store writes the same address from all 32 lanes. The current layout-codegen path marks that store with a constant-true predicate, dropping the lane-0 guard that was present before #6530 (3.7.1).

When the reduce combine is not bitwise-exact — e.g. the Welford combine emitted by `torch._inductor.runtime.triton_helpers` for `var` / `var_mean` — the 32 lanes write values that differ in the low bits, and the PTX memory model leaves the winning value undefined. This makes results non-deterministic and is reachable from plain `torch.compile(torch.var_mean(x, dim=1))`.

## Fix

Add `emitRedundantSharedStorePredicate`, which:

1. Computes the free-variable masks of the **source value layout** (which bits of the thread index do not affect the stored value) and the **store address layout** (which bits do not affect the shared address).
2. Intersects them per thread dimension, so a thread is predicated away only when it is *redundant*: it stores the same value to the same address as another thread.
3. Emits the representative-thread predicate via the existing `emitRedundantThreadPredicate` (already used by `finalizeTensorAtomicResults`).

The predicate is threaded into `makeSharedStoreEmitter` at both shared-store sites:
- generic `transferSwizzlingLocalMemImpl` (`Conversion/TritonGPUToLLVM/ConvertLayoutOpToLLVM.cpp`)
- the NVIDIA swizzling path (`TritonNVIDIAGPUToLLVM/ConvertLayoutOpToLLVM.cpp`)

When no thread group is redundant the predicate is null and the store is emitted exactly as before (`llvm.store` / `st.shared`), so ordinary fan-out layout conversions are not affected.

## Evidence (no GPU required)

Generated LLVM IR for a cross-warp reduce (256×4 over 8 warps):

| | cross-warp partial store |
|---|---|
| before | `llvm.store vector<4xi32>, !llvm.ptr<3>` (unpredicated, racing) |
| after | `@$5 st.shared::cta.v4.b32 [ ... ], { ... }` predicated on `(tid & 31) == 0` (lane 0) |

## Testing

- New lit test `test/Conversion/reduce_cross_warp_predicate.mlir` reproduces the missing predicate and passes with the fix.
- Three CHECK groups in `test/Conversion/tritongpu_to_llvm.mlir` encoded the old unpredicated codegen (`llvm.store`); updated to expect the predicated `st.shared::cta.*` inline asm. Loads are unchanged.
- Full lit suite: 299/302 pass; only failure is the pre-existing unrelated `TritonGPU/pipeline-split-cluster-unscheduled-op.mlir`.