### PR TITLE
Clamp fp64 kWidth to 1.

### DIFF
--- a/lib/Dialect/TritonGPU/Transforms/AccelerateMatmul.cpp
+++ b/lib/Dialect/TritonGPU/Transforms/AccelerateMatmul.cpp
@@ -561,6 +561,13 @@ public:
     } else {
       int minBitwidth =
           std::min(computeOrigBitWidth(a), computeOrigBitWidth(b));
+      // F64 MMAv2 does not support largeK (kWidth > 1). Keep minBitwidth at 64
+      // for F64 dots to ensure kWidth = 1.
+      if (oldRetType.getElementType().isF64() ||
+          oldAType.getElementType().isF64() ||
+          oldBType.getElementType().isF64()) {
+        minBitwidth = 64;
+      }
       a = convertDotOperandForMMA(a, 0, minBitwidth, mmaResult.newRetType,
                                   rewriter);
       b = convertDotOperandForMMA(b, 1, minBitwidth, mmaResult.newRetType,

--- a/python/test/unit/language/test_core.py
+++ b/python/test/unit/language/test_core.py
@@ -4287,8 +4287,7 @@ def test_dot(M, N, K, num_warps, col_a, col_b, epilogue, input_precision, in_dty
 
 
 @pytest.mark.parametrize("in_dtype", ["int16", "float16", "int8"])
-@pytest.mark.parametrize("shape", [(16, 16, 16), (32, 32, 32)])
-def test_dot_upcast_to_fp64(in_dtype, shape, device):
+def test_dot_upcast_to_fp64(in_dtype, device):
     if is_interpreter():
         pytest.skip("Interpreter does not support FP64 dot")
     if not is_cuda():
@@ -4296,7 +4295,7 @@ def test_dot_upcast_to_fp64(in_dtype, shape, device):
     if torch.cuda.get_device_capability()[0] < 8:
         pytest.skip("FP64 MMA requires CUDA sm >= 80")
 
-    M, N, K = shape
+    M, N, K = 32, 32, 32
 
     @triton.jit
     def kernel(X, Y, Z, stride_xm, stride_xk, stride_yk, stride_yn, stride_zm, stride_zn, BLOCK_M: tl.constexpr,

--- a/python/test/unit/language/test_core.py
+++ b/python/test/unit/language/test_core.py
@@ -4286,6 +4286,45 @@ def test_dot(M, N, K, num_warps, col_a, col_b, epilogue, input_precision, in_dty
         assert re.search(pattern, ptx, flags=re.DOTALL)
 
 
+@pytest.mark.parametrize("in_dtype", ["int16", "float16", "int8"])
+@pytest.mark.parametrize("shape", [(16, 16, 16), (32, 32, 32)])
+def test_dot_upcast_to_fp64(in_dtype, shape, device):
+    if is_interpreter():
+        pytest.skip("Interpreter does not support FP64 dot")
+    if not is_cuda():
+        pytest.skip("Only test on CUDA")
+    if torch.cuda.get_device_capability()[0] < 8:
+        pytest.skip("FP64 MMA requires CUDA sm >= 80")
+
+    M, N, K = shape
+
+    @triton.jit
+    def kernel(X, Y, Z, stride_xm, stride_xk, stride_yk, stride_yn, stride_zm, stride_zn, BLOCK_M: tl.constexpr,
+               BLOCK_N: tl.constexpr, BLOCK_K: tl.constexpr):
+        off_m = tl.arange(0, BLOCK_M)
+        off_n = tl.arange(0, BLOCK_N)
+        off_k = tl.arange(0, BLOCK_K)
+        x = tl.load(X + off_m[:, None] * stride_xm + off_k[None, :] * stride_xk)
+        y = tl.load(Y + off_k[:, None] * stride_yk + off_n[None, :] * stride_yn)
+        z = tl.dot(x.to(tl.float64), y.to(tl.float64))
+        tl.store(Z + off_m[:, None] * stride_zm + off_n[None, :] * stride_zn, z)
+
+    torch_dtype = getattr(torch, in_dtype)
+    if "int" in in_dtype:
+        x = torch.randint(-10, 10, (M, K), device=device, dtype=torch_dtype)
+        y = torch.randint(-10, 10, (K, N), device=device, dtype=torch_dtype)
+    else:
+        x = torch.randn((M, K), device=device, dtype=torch_dtype)
+        y = torch.randn((K, N), device=device, dtype=torch_dtype)
+
+    z_triton = torch.empty((M, N), device=device, dtype=torch.float64)
+    kernel[(1, 1)](x, y, z_triton, x.stride(0), x.stride(1), y.stride(0), y.stride(1), z_triton.stride(0),
+                   z_triton.stride(1), BLOCK_M=M, BLOCK_N=N, BLOCK_K=K)
+
+    z_ref = torch.matmul(x.to(torch.float64), y.to(torch.float64))
+    torch.testing.assert_close(z_triton, z_ref)
+
+
 @pytest.mark.interpreter
 @pytest.mark.parametrize("M, N, K, col_a, col_b, rhs_scale, mxfp_type, normal_type, num_warps, mma, kpack",
                          [(M, N, K, col_a, col_b, rhs_scale, mxfp_type, normal_type, 4, mma, kpack)

--- a/test/TritonGPU/accelerate-matmul.mlir
+++ b/test/TritonGPU/accelerate-matmul.mlir
@@ -1187,3 +1187,22 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.targ
     tt.return %0 : tensor<128x256xf32, #blocked>
   }
 }
+
+// -----
+
+// CHECK: #mma = #ttg.nvidia_mma<{versionMajor = 2, versionMinor = 0, warpsPerCTA = [2, 4], instrShape = [8, 8]}>
+#blocked = #ttg.blocked<{sizePerThread = [4, 4], threadsPerWarp = [1, 32], warpsPerCTA = [8, 1], order = [1, 0]}>
+module attributes {"ttg.target" = "cuda:80", "ttg.num-warps" = 8 : i32} {
+  // CHECK-LABEL: fp64_dot_with_i16_upcast
+  tt.func public @fp64_dot_with_i16_upcast(
+    %ptr_a: tensor<128x32x!tt.ptr<i16>, #blocked>,
+    %b: tensor<32x128xf64, #ttg.dot_op<{opIdx = 1, parent = #blocked}>>,
+    %c: tensor<128x128xf64, #blocked>) -> tensor<128x128xf64, #blocked> {
+    %a_i16 = tt.load %ptr_a : tensor<128x32x!tt.ptr<i16>, #blocked>
+    %a_f64 = arith.sitofp %a_i16 : tensor<128x32xi16, #blocked> to tensor<128x32xf64, #blocked>
+    %a = ttg.convert_layout %a_f64 : tensor<128x32xf64, #blocked> -> tensor<128x32xf64, #ttg.dot_op<{opIdx = 0, parent = #blocked}>>
+    // CHECK: tt.dot {{.*}} : tensor<128x32xf64, #ttg.dot_op<{opIdx = 0, parent = #mma, kWidth = 1}>> * tensor<32x128xf64, #ttg.dot_op<{opIdx = 1, parent = #mma, kWidth = 1}>> -> tensor<128x128xf64, #mma>
+    %d = tt.dot %a, %b, %c : tensor<128x32xf64, #ttg.dot_op<{opIdx = 0, parent = #blocked}>> * tensor<32x128xf64, #ttg.dot_op<{opIdx = 1, parent = #blocked}>> -> tensor<128x128xf64, #blocked>
+    tt.return %d : tensor<128x128xf64, #blocked>
+  }
+}


### PR DESCRIPTION
At the moment, upcasting from something below 32 bits to f64 causes us to hit the "Currently fp64 don't support largeK MMA" assert in MMAv2 (or simply gives incorrect results without asserts). Clamp the min_bit_width to 64 in order to create correct lowering.

Added lit & e2e test showcasing the failure before & fix.